### PR TITLE
move credentials to presets

### DIFF
--- a/api/cmd/kubermatic-api/options.go
+++ b/api/cmd/kubermatic-api/options.go
@@ -22,7 +22,7 @@ type serverRunOptions struct {
 	workerName      string
 	versionsFile    string
 	updatesFile     string
-	credentialFile  string
+	presetsFile     string
 	domain          string
 	exposeStrategy  corev1.ServiceType
 	log             kubermaticlog.Options
@@ -58,7 +58,7 @@ func newServerRunOptions() (serverRunOptions, error) {
 	flag.StringVar(&s.workerName, "worker-name", "", "Create clusters only processed by worker-name cluster controller")
 	flag.StringVar(&s.versionsFile, "versions", "versions.yaml", "The versions.yaml file path")
 	flag.StringVar(&s.updatesFile, "updates", "updates.yaml", "The updates.yaml file path")
-	flag.StringVar(&s.credentialFile, "credentials", "", "The optional credential file path")
+	flag.StringVar(&s.presetsFile, "presets", "", "The optional file path for a file containing presets")
 	flag.StringVar(&s.oidcURL, "oidc-url", "", "URL of the OpenID token issuer. Example: http://auth.int.kubermatic.io")
 	flag.BoolVar(&s.oidcSkipTLSVerify, "oidc-skip-tls-verify", false, "Skip TLS verification for the token issuer")
 	flag.StringVar(&s.oidcAuthenticatorClientID, "oidc-authenticator-client-id", "", "Authenticator client ID")

--- a/api/cmd/kubermatic-api/swagger.json
+++ b/api/cmd/kubermatic-api/swagger.json
@@ -3155,7 +3155,7 @@
         }
       }
     },
-    "/api/v1/providers/{provider_name}/credentials": {
+    "/api/v1/providers/{provider_name}/presets/credentials": {
       "get": {
         "description": "Lists credential names for the provider",
         "produces": [

--- a/api/pkg/handler/routing.go
+++ b/api/pkg/handler/routing.go
@@ -48,7 +48,7 @@ type Routing struct {
 	saTokenAuthenticator        serviceaccount.TokenAuthenticator
 	saTokenGenerator            serviceaccount.TokenGenerator
 	eventRecorderProvider       provider.EventRecorderProvider
-	credentialManager           common.CredentialManager
+	presetsManager              common.PresetsManager
 	exposeStrategy              corev1.ServiceType
 }
 
@@ -73,7 +73,7 @@ func NewRouting(
 	saTokenAuthenticator serviceaccount.TokenAuthenticator,
 	saTokenGenerator serviceaccount.TokenGenerator,
 	eventRecorderProvider provider.EventRecorderProvider,
-	credentialManager common.CredentialManager,
+	presetsManager common.PresetsManager,
 	exposeStrategy corev1.ServiceType,
 ) Routing {
 	return Routing{
@@ -97,7 +97,7 @@ func NewRouting(
 		saTokenAuthenticator:        saTokenAuthenticator,
 		saTokenGenerator:            saTokenGenerator,
 		eventRecorderProvider:       eventRecorderProvider,
-		credentialManager:           credentialManager,
+		presetsManager:              presetsManager,
 		exposeStrategy:              exposeStrategy,
 	}
 }

--- a/api/pkg/handler/test/hack/hack.go
+++ b/api/pkg/handler/test/hack/hack.go
@@ -41,7 +41,7 @@ func NewTestRouting(
 	saTokenAuthenticator serviceaccount.TokenAuthenticator,
 	saTokenGenerator serviceaccount.TokenGenerator,
 	eventRecorderProvider provider.EventRecorderProvider,
-	credentialManager common.CredentialManager) http.Handler {
+	credentialManager common.PresetsManager) http.Handler {
 
 	updateManager := version.New(versions, updates)
 	r := handler.NewRouting(

--- a/api/pkg/handler/test/helper.go
+++ b/api/pkg/handler/test/helper.go
@@ -13,7 +13,7 @@ import (
 	"testing"
 	"time"
 
-	"github.com/kubermatic/kubermatic/api/pkg/credentials"
+	"github.com/kubermatic/kubermatic/api/pkg/presets"
 
 	"github.com/kubermatic/kubermatic/api/pkg/handler/v1/common"
 
@@ -130,9 +130,9 @@ type newRoutingFunc func(
 	saTokenAuthenticator serviceaccount.TokenAuthenticator,
 	saTokenGenerator serviceaccount.TokenGenerator,
 	eventRecorderProvider provider.EventRecorderProvider,
-	credentialManager common.CredentialManager) http.Handler
+	credentialManager common.PresetsManager) http.Handler
 
-func initTestEndpoint(user apiv1.User, dc map[string]provider.DatacenterMeta, kubeObjects, machineObjects, kubermaticObjects []runtime.Object, versions []*version.MasterVersion, updates []*version.MasterUpdate, credentialsManager common.CredentialManager, routingFunc newRoutingFunc) (http.Handler, *ClientsSets, error) {
+func initTestEndpoint(user apiv1.User, dc map[string]provider.DatacenterMeta, kubeObjects, machineObjects, kubermaticObjects []runtime.Object, versions []*version.MasterVersion, updates []*version.MasterUpdate, credentialsManager common.PresetsManager, routingFunc newRoutingFunc) (http.Handler, *ClientsSets, error) {
 	datacenters := dc
 	if datacenters == nil {
 		datacenters = buildDatacenterMeta()
@@ -252,17 +252,17 @@ func initTestEndpoint(user apiv1.User, dc map[string]provider.DatacenterMeta, ku
 
 // CreateTestEndpointAndGetClients is a convenience function that instantiates fake providers and sets up routes  for the tests
 func CreateTestEndpointAndGetClients(user apiv1.User, dc map[string]provider.DatacenterMeta, kubeObjects, machineObjects, kubermaticObjects []runtime.Object, versions []*version.MasterVersion, updates []*version.MasterUpdate, routingFunc newRoutingFunc) (http.Handler, *ClientsSets, error) {
-	credentialManager := credentials.New()
-	credentialManager.GetCredentials().Fake = []credentials.FakeCredentials{
+	credentialManager := presets.New()
+	credentialManager.GetPresets().Fake = presets.Fake{Credentials: []presets.FakeCredentials{
 		{Name: TestFakeCredential, Token: "dummy_pluton_token"},
-	}
-	credentialManager.GetCredentials().Openstack = []credentials.OpenstackCredentials{
+	}}
+	credentialManager.GetPresets().Openstack = presets.Openstack{Credentials: []presets.OpenstackCredentials{
 		{Name: TestOSCredential, Username: TestOSuserName, Password: TestOSuserPass, Domain: TestOSdomain},
-	}
+	}}
 	return initTestEndpoint(user, dc, kubeObjects, machineObjects, kubermaticObjects, versions, updates, credentialManager, routingFunc)
 }
 
-func CreateCredentialTestEndpoint(credentialsManager common.CredentialManager, routingFunc newRoutingFunc) (http.Handler, error) {
+func CreateCredentialTestEndpoint(credentialsManager common.PresetsManager, routingFunc newRoutingFunc) (http.Handler, error) {
 	apiUser := GenDefaultAPIUser()
 	router, _, err := initTestEndpoint(*apiUser, nil, nil, nil, nil, nil, nil, credentialsManager, routingFunc)
 	return router, err

--- a/api/pkg/handler/v1/cluster/cluster.go
+++ b/api/pkg/handler/v1/cluster/cluster.go
@@ -54,7 +54,7 @@ var clusterTypes = []string{
 }
 
 func CreateEndpoint(sshKeyProvider provider.SSHKeyProvider, cloudProviders map[string]provider.CloudProvider, projectProvider provider.ProjectProvider,
-	dcs map[string]provider.DatacenterMeta, initNodeDeploymentFailures *prometheus.CounterVec, eventRecorderProvider provider.EventRecorderProvider, credentialManager common.CredentialManager, exposeStrategy corev1.ServiceType) endpoint.Endpoint {
+	dcs map[string]provider.DatacenterMeta, initNodeDeploymentFailures *prometheus.CounterVec, eventRecorderProvider provider.EventRecorderProvider, credentialManager common.PresetsManager, exposeStrategy corev1.ServiceType) endpoint.Endpoint {
 	return func(ctx context.Context, request interface{}) (interface{}, error) {
 		req := request.(CreateReq)
 		err := req.Validate()

--- a/api/pkg/handler/v1/common/common.go
+++ b/api/pkg/handler/v1/common/common.go
@@ -4,7 +4,7 @@ import (
 	"github.com/prometheus/client_golang/prometheus"
 
 	"github.com/kubermatic/kubermatic/api/pkg/crd/kubermatic/v1"
-	"github.com/kubermatic/kubermatic/api/pkg/credentials"
+	"github.com/kubermatic/kubermatic/api/pkg/presets"
 	"github.com/kubermatic/kubermatic/api/pkg/provider"
 	"github.com/kubermatic/kubermatic/api/pkg/version"
 )
@@ -37,9 +37,9 @@ type UpdateManager interface {
 	GetPossibleUpdates(from, clusterType string) ([]*version.MasterVersion, error)
 }
 
-// UpdateManager specifies a set of methods to handle credentials for specific provider
-type CredentialManager interface {
-	GetCredentials() *credentials.Credentials
+// PresetsManager specifies a set of methods to handle presets for specific provider
+type PresetsManager interface {
+	GetPresets() *presets.Presets
 	SetCloudCredentials(credentialName string, cloud v1.CloudSpec) (*v1.CloudSpec, error)
 }
 

--- a/api/pkg/handler/v1/presets/credentials.go
+++ b/api/pkg/handler/v1/presets/credentials.go
@@ -1,4 +1,4 @@
-package credentials
+package presets
 
 import (
 	"context"
@@ -34,7 +34,7 @@ type providerReq struct {
 }
 
 // CredentialEndpoint returns custom credential list name for the provider
-func CredentialEndpoint(credentialManager common.CredentialManager) endpoint.Endpoint {
+func CredentialEndpoint(credentialManager common.PresetsManager) endpoint.Endpoint {
 	return func(ctx context.Context, request interface{}) (interface{}, error) {
 		req, ok := request.(providerReq)
 		if !ok {
@@ -49,11 +49,12 @@ func CredentialEndpoint(credentialManager common.CredentialManager) endpoint.End
 		names := make([]string, 0)
 
 		providerN := parseProvider(req.ProviderName)
-		providers := reflect.ValueOf(credentialManager.GetCredentials()).Elem()
+		providers := reflect.ValueOf(credentialManager.GetPresets()).Elem()
 		providerItems := providers.Field(providerN)
-		if providerItems.Kind() == reflect.Slice {
-			for i := 0; i < providerItems.Len(); i++ {
-				item := providerItems.Index(i)
+		credentialItems := providerItems.FieldByName("Credentials")
+		if credentialItems.Kind() == reflect.Slice {
+			for i := 0; i < credentialItems.Len(); i++ {
+				item := credentialItems.Index(i)
 				if item.Kind() == reflect.Struct {
 					v := reflect.Indirect(item)
 					if _, ok := v.Type().FieldByName("Name"); ok {

--- a/api/pkg/handler/v1/presets/credentials_test.go
+++ b/api/pkg/handler/v1/presets/credentials_test.go
@@ -1,4 +1,4 @@
-package credentials_test
+package presets_test
 
 import (
 	"encoding/json"
@@ -13,9 +13,9 @@ import (
 	"k8s.io/apimachinery/pkg/api/equality"
 	"k8s.io/apimachinery/pkg/util/diff"
 
-	"github.com/kubermatic/kubermatic/api/pkg/credentials"
 	"github.com/kubermatic/kubermatic/api/pkg/handler/test"
 	"github.com/kubermatic/kubermatic/api/pkg/handler/test/hack"
+	"github.com/kubermatic/kubermatic/api/pkg/presets"
 )
 
 func TestCredentialEndpoint(t *testing.T) {
@@ -23,7 +23,7 @@ func TestCredentialEndpoint(t *testing.T) {
 	testcases := []struct {
 		name             string
 		provider         string
-		credentials      *credentials.Credentials
+		credentials      *presets.Presets
 		httpStatus       int
 		expectedResponse string
 	}{
@@ -36,10 +36,10 @@ func TestCredentialEndpoint(t *testing.T) {
 		{
 			name:     "test list of credential names for AWS",
 			provider: "aws",
-			credentials: &credentials.Credentials{AWS: []credentials.AWSCredentials{
+			credentials: &presets.Presets{AWS: presets.AWS{Credentials: []presets.AWSCredentials{
 				{Name: "first"},
 				{Name: "second"},
-			}},
+			}}},
 			httpStatus:       http.StatusOK,
 			expectedResponse: `{"names":["first","second"]}`,
 		},
@@ -52,10 +52,10 @@ func TestCredentialEndpoint(t *testing.T) {
 		{
 			name:     "test list of credential names for Azure",
 			provider: "azure",
-			credentials: &credentials.Credentials{Azure: []credentials.AzureCredentials{
+			credentials: &presets.Presets{Azure: presets.Azure{Credentials: []presets.AzureCredentials{
 				{Name: "first", ClientID: "test-first", ClientSecret: "secret-first", SubscriptionID: "subscription-first", TenantID: "tenant-first"},
 				{Name: "second", ClientID: "test-second", ClientSecret: "secret-second", SubscriptionID: "subscription-second", TenantID: "tenant-second"},
-			}},
+			}}},
 			httpStatus:       http.StatusOK,
 			expectedResponse: `{"names":["first","second"]}`,
 		},
@@ -68,10 +68,10 @@ func TestCredentialEndpoint(t *testing.T) {
 		{
 			name:     "test list of credential names for DigitalOcean",
 			provider: "digitalocean",
-			credentials: &credentials.Credentials{Digitalocean: []credentials.DigitaloceanCredentials{
+			credentials: &presets.Presets{Digitalocean: presets.Digitalocean{Credentials: []presets.DigitaloceanCredentials{
 				{Name: "digitalocean-first"},
 				{Name: "digitalocean-second"},
-			}},
+			}}},
 			httpStatus:       http.StatusOK,
 			expectedResponse: `{"names":["digitalocean-first","digitalocean-second"]}`,
 		},
@@ -84,10 +84,10 @@ func TestCredentialEndpoint(t *testing.T) {
 		{
 			name:     "test list of credential names for GCP",
 			provider: "gcp",
-			credentials: &credentials.Credentials{GCP: []credentials.GCPCredentials{
+			credentials: &presets.Presets{GCP: presets.GCP{Credentials: []presets.GCPCredentials{
 				{Name: "first"},
 				{Name: "second"},
-			}},
+			}}},
 			httpStatus:       http.StatusOK,
 			expectedResponse: `{"names":["first","second"]}`,
 		},
@@ -100,10 +100,10 @@ func TestCredentialEndpoint(t *testing.T) {
 		{
 			name:     "test list of credential names for Hetzner",
 			provider: "hetzner",
-			credentials: &credentials.Credentials{Hetzner: []credentials.HetznerCredentials{
+			credentials: &presets.Presets{Hetzner: presets.Hetzner{Credentials: []presets.HetznerCredentials{
 				{Name: "first"},
 				{Name: "second"},
-			}},
+			}}},
 			httpStatus:       http.StatusOK,
 			expectedResponse: `{"names":["first","second"]}`,
 		},
@@ -116,10 +116,10 @@ func TestCredentialEndpoint(t *testing.T) {
 		{
 			name:     "test list of credential names for OpenStack",
 			provider: "openstack",
-			credentials: &credentials.Credentials{Openstack: []credentials.OpenstackCredentials{
+			credentials: &presets.Presets{Openstack: presets.Openstack{Credentials: []presets.OpenstackCredentials{
 				{Name: "first"},
 				{Name: "second"},
-			}},
+			}}},
 			httpStatus:       http.StatusOK,
 			expectedResponse: `{"names":["first","second"]}`,
 		},
@@ -132,10 +132,10 @@ func TestCredentialEndpoint(t *testing.T) {
 		{
 			name:     "test list of credential names for Packet",
 			provider: "packet",
-			credentials: &credentials.Credentials{Packet: []credentials.PacketCredentials{
+			credentials: &presets.Presets{Packet: presets.Packet{Credentials: []presets.PacketCredentials{
 				{Name: "first"},
 				{Name: "second"},
-			}},
+			}}},
 			httpStatus:       http.StatusOK,
 			expectedResponse: `{"names":["first","second"]}`,
 		},
@@ -148,10 +148,10 @@ func TestCredentialEndpoint(t *testing.T) {
 		{
 			name:     "test list of credential names for Vsphere",
 			provider: "vsphere",
-			credentials: &credentials.Credentials{VSphere: []credentials.VSphereCredentials{
+			credentials: &presets.Presets{VSphere: presets.VSphere{Credentials: []presets.VSphereCredentials{
 				{Name: "first"},
 				{Name: "second"},
-			}},
+			}}},
 			httpStatus:       http.StatusOK,
 			expectedResponse: `{"names":["first","second"]}`,
 		},
@@ -165,11 +165,11 @@ func TestCredentialEndpoint(t *testing.T) {
 	for _, tc := range testcases {
 		t.Run(tc.name, func(t *testing.T) {
 
-			req := httptest.NewRequest("GET", fmt.Sprintf("/api/v1/providers/%s/credentials", tc.provider), strings.NewReader(""))
+			req := httptest.NewRequest("GET", fmt.Sprintf("/api/v1/providers/%s/presets/credentials", tc.provider), strings.NewReader(""))
 
-			credentialsManager := credentials.New()
+			credentialsManager := presets.New()
 			if tc.credentials != nil {
-				credentialsManager = credentials.NewWithCredentials(tc.credentials)
+				credentialsManager = presets.NewWithPresets(tc.credentials)
 			}
 
 			res := httptest.NewRecorder()

--- a/api/pkg/handler/v1/provider/azure.go
+++ b/api/pkg/handler/v1/provider/azure.go
@@ -146,7 +146,7 @@ func AzureSizeNoCredentialsEndpoint(projectProvider provider.ProjectProvider, dc
 	}
 }
 
-func AzureSizeEndpoint(credentialManager common.CredentialManager) endpoint.Endpoint {
+func AzureSizeEndpoint(credentialManager common.PresetsManager) endpoint.Endpoint {
 	return func(ctx context.Context, request interface{}) (interface{}, error) {
 		req := request.(AzureSizeReq)
 
@@ -155,8 +155,8 @@ func AzureSizeEndpoint(credentialManager common.CredentialManager) endpoint.Endp
 		clientSecret := req.ClientSecret
 		tenantID := req.TenantID
 
-		if len(req.Credential) > 0 && credentialManager.GetCredentials().Azure != nil {
-			for _, credential := range credentialManager.GetCredentials().Azure {
+		if len(req.Credential) > 0 && credentialManager.GetPresets().Azure.Credentials != nil {
+			for _, credential := range credentialManager.GetPresets().Azure.Credentials {
 				if credential.Name == req.Credential {
 					subscriptionID = credential.SubscriptionID
 					clientID = credential.ClientID

--- a/api/pkg/handler/v1/provider/digitalocean.go
+++ b/api/pkg/handler/v1/provider/digitalocean.go
@@ -42,12 +42,12 @@ func DigitaloceanSizeNoCredentialsEndpoint(projectProvider provider.ProjectProvi
 	}
 }
 
-func DigitaloceanSizeEndpoint(credentialManager common.CredentialManager) endpoint.Endpoint {
+func DigitaloceanSizeEndpoint(credentialManager common.PresetsManager) endpoint.Endpoint {
 	return func(ctx context.Context, request interface{}) (interface{}, error) {
 		req := request.(DoSizesReq)
 		token := req.DoToken
-		if len(req.Credential) > 0 && credentialManager.GetCredentials().Digitalocean != nil {
-			for _, credential := range credentialManager.GetCredentials().Digitalocean {
+		if len(req.Credential) > 0 && credentialManager.GetPresets().Digitalocean.Credentials != nil {
+			for _, credential := range credentialManager.GetPresets().Digitalocean.Credentials {
 				if credential.Name == req.Credential {
 					token = credential.Token
 					break

--- a/api/pkg/handler/v1/provider/openstack.go
+++ b/api/pkg/handler/v1/provider/openstack.go
@@ -16,7 +16,7 @@ import (
 	"github.com/kubermatic/kubermatic/api/pkg/util/errors"
 )
 
-func OpenstackSizeEndpoint(providers provider.CloudRegistry, datacenters map[string]provider.DatacenterMeta, credentialManager common.CredentialManager) endpoint.Endpoint {
+func OpenstackSizeEndpoint(providers provider.CloudRegistry, datacenters map[string]provider.DatacenterMeta, credentialManager common.PresetsManager) endpoint.Endpoint {
 	return func(ctx context.Context, request interface{}) (interface{}, error) {
 		req, ok := request.(OpenstackReq)
 		if !ok {
@@ -108,7 +108,7 @@ func MeetsOpenstackNodeSizeRequirement(apiSize apiv1.OpenstackSize, requirements
 	return true
 }
 
-func OpenstackTenantEndpoint(providers provider.CloudRegistry, credentialManager common.CredentialManager) endpoint.Endpoint {
+func OpenstackTenantEndpoint(providers provider.CloudRegistry, credentialManager common.PresetsManager) endpoint.Endpoint {
 	return func(ctx context.Context, request interface{}) (interface{}, error) {
 		req, ok := request.(OpenstackTenantReq)
 		if !ok {
@@ -171,7 +171,7 @@ func getOpenstackTenants(providers provider.CloudRegistry, username, password, d
 	return apiTenants, nil
 }
 
-func OpenstackNetworkEndpoint(providers provider.CloudRegistry, credentialManager common.CredentialManager) endpoint.Endpoint {
+func OpenstackNetworkEndpoint(providers provider.CloudRegistry, credentialManager common.PresetsManager) endpoint.Endpoint {
 	return func(ctx context.Context, request interface{}) (interface{}, error) {
 		req, ok := request.(OpenstackReq)
 		if !ok {
@@ -236,7 +236,7 @@ func getOpenstackNetworks(providers provider.CloudRegistry, username, password, 
 	return apiNetworks, nil
 }
 
-func OpenstackSecurityGroupEndpoint(providers provider.CloudRegistry, credentialManager common.CredentialManager) endpoint.Endpoint {
+func OpenstackSecurityGroupEndpoint(providers provider.CloudRegistry, credentialManager common.PresetsManager) endpoint.Endpoint {
 	return func(ctx context.Context, request interface{}) (interface{}, error) {
 		req, ok := request.(OpenstackReq)
 		if !ok {
@@ -300,7 +300,7 @@ func getOpenstackSecurityGroups(providers provider.CloudRegistry, username, pass
 	return apiSecurityGroups, nil
 }
 
-func OpenstackSubnetsEndpoint(providers provider.CloudRegistry, credentialManager common.CredentialManager) endpoint.Endpoint {
+func OpenstackSubnetsEndpoint(providers provider.CloudRegistry, credentialManager common.PresetsManager) endpoint.Endpoint {
 	return func(ctx context.Context, request interface{}) (interface{}, error) {
 		req, ok := request.(OpenstackSubnetReq)
 		if !ok {
@@ -487,10 +487,10 @@ func DecodeOpenstackTenantReq(c context.Context, r *http.Request) (interface{}, 
 	return req, nil
 }
 
-func getOpenstackCredentials(credentialName, username, password, domain, tenant string, credentialManager common.CredentialManager) (string, string, string, string) {
+func getOpenstackCredentials(credentialName, username, password, domain, tenant string, credentialManager common.PresetsManager) (string, string, string, string) {
 
-	if len(credentialName) > 0 && credentialManager.GetCredentials().Openstack != nil {
-		for _, credential := range credentialManager.GetCredentials().Openstack {
+	if len(credentialName) > 0 && credentialManager.GetPresets().Openstack.Credentials != nil {
+		for _, credential := range credentialManager.GetPresets().Openstack.Credentials {
 			if credential.Name == credentialName {
 				username = credential.Username
 				password = credential.Password

--- a/api/pkg/handler/v1/provider/vsphere.go
+++ b/api/pkg/handler/v1/provider/vsphere.go
@@ -16,7 +16,7 @@ import (
 	"github.com/kubermatic/kubermatic/api/pkg/util/errors"
 )
 
-func VsphereNetworksEndpoint(providers provider.CloudRegistry, credentialManager common.CredentialManager) endpoint.Endpoint {
+func VsphereNetworksEndpoint(providers provider.CloudRegistry, credentialManager common.PresetsManager) endpoint.Endpoint {
 	return func(ctx context.Context, request interface{}) (interface{}, error) {
 		req, ok := request.(VSphereNetworksReq)
 		if !ok {
@@ -26,8 +26,8 @@ func VsphereNetworksEndpoint(providers provider.CloudRegistry, credentialManager
 		username := req.Username
 		password := req.Password
 
-		if len(req.Credential) > 0 && credentialManager.GetCredentials().VSphere != nil {
-			for _, credential := range credentialManager.GetCredentials().VSphere {
+		if len(req.Credential) > 0 && credentialManager.GetPresets().VSphere.Credentials != nil {
+			for _, credential := range credentialManager.GetPresets().VSphere.Credentials {
 				if credential.Name == req.Credential {
 					username = credential.Username
 					password = credential.Password

--- a/api/pkg/presets/manager_test.go
+++ b/api/pkg/presets/manager_test.go
@@ -1,4 +1,4 @@
-package credentials_test
+package presets_test
 
 import (
 	"testing"
@@ -6,7 +6,7 @@ import (
 	"k8s.io/apimachinery/pkg/api/equality"
 
 	"github.com/kubermatic/kubermatic/api/pkg/crd/kubermatic/v1"
-	"github.com/kubermatic/kubermatic/api/pkg/credentials"
+	"github.com/kubermatic/kubermatic/api/pkg/presets"
 )
 
 func TestAWSCredentialEndpoint(t *testing.T) {
@@ -17,14 +17,14 @@ func TestAWSCredentialEndpoint(t *testing.T) {
 		expectedError     string
 		cloudSpec         v1.CloudSpec
 		expectedCloudSpec *v1.CloudSpec
-		manager           *credentials.Manager
+		manager           *presets.Manager
 	}{
 		{
 			name:           "test 1: set credentials for Fake provider",
 			credentialName: "test",
-			manager: func() *credentials.Manager {
-				manager := credentials.New()
-				manager.GetCredentials().Fake = []credentials.FakeCredentials{
+			manager: func() *presets.Manager {
+				manager := presets.New()
+				manager.GetPresets().Fake.Credentials = []presets.FakeCredentials{
 					{Name: "test", Token: "abc"},
 					{Name: "pluto", Token: "def"},
 				}
@@ -36,9 +36,9 @@ func TestAWSCredentialEndpoint(t *testing.T) {
 		{
 			name:           "test 2: set credentials for GCP provider",
 			credentialName: "test",
-			manager: func() *credentials.Manager {
-				manager := credentials.New()
-				manager.GetCredentials().GCP = []credentials.GCPCredentials{
+			manager: func() *presets.Manager {
+				manager := presets.New()
+				manager.GetPresets().GCP.Credentials = []presets.GCPCredentials{
 					{Name: "test", ServiceAccount: "test_service_accouont"},
 				}
 				return manager
@@ -49,9 +49,9 @@ func TestAWSCredentialEndpoint(t *testing.T) {
 		{
 			name:           "test 3: set credentials for AWS provider",
 			credentialName: "test",
-			manager: func() *credentials.Manager {
-				manager := credentials.New()
-				manager.GetCredentials().AWS = []credentials.AWSCredentials{
+			manager: func() *presets.Manager {
+				manager := presets.New()
+				manager.GetPresets().AWS.Credentials = []presets.AWSCredentials{
 					{Name: "test", SecretAccessKey: "secret", AccessKeyID: "key"},
 				}
 				return manager
@@ -62,9 +62,9 @@ func TestAWSCredentialEndpoint(t *testing.T) {
 		{
 			name:           "test 4: set credentials for Hetzner provider",
 			credentialName: "test",
-			manager: func() *credentials.Manager {
-				manager := credentials.New()
-				manager.GetCredentials().Hetzner = []credentials.HetznerCredentials{
+			manager: func() *presets.Manager {
+				manager := presets.New()
+				manager.GetPresets().Hetzner.Credentials = []presets.HetznerCredentials{
 					{Name: "test", Token: "secret"},
 				}
 				return manager
@@ -75,9 +75,9 @@ func TestAWSCredentialEndpoint(t *testing.T) {
 		{
 			name:           "test 5: set credentials for Packet provider",
 			credentialName: "test",
-			manager: func() *credentials.Manager {
-				manager := credentials.New()
-				manager.GetCredentials().Packet = []credentials.PacketCredentials{
+			manager: func() *presets.Manager {
+				manager := presets.New()
+				manager.GetPresets().Packet.Credentials = []presets.PacketCredentials{
 					{Name: "test", APIKey: "secret", ProjectID: "project"},
 				}
 				return manager
@@ -88,9 +88,9 @@ func TestAWSCredentialEndpoint(t *testing.T) {
 		{
 			name:           "test 6: set credentials for DigitalOcean provider",
 			credentialName: "test",
-			manager: func() *credentials.Manager {
-				manager := credentials.New()
-				manager.GetCredentials().Digitalocean = []credentials.DigitaloceanCredentials{
+			manager: func() *presets.Manager {
+				manager := presets.New()
+				manager.GetPresets().Digitalocean.Credentials = []presets.DigitaloceanCredentials{
 					{Name: "test", Token: "abcd"},
 				}
 				return manager
@@ -101,9 +101,9 @@ func TestAWSCredentialEndpoint(t *testing.T) {
 		{
 			name:           "test 7: set credentials for OpenStack provider",
 			credentialName: "test",
-			manager: func() *credentials.Manager {
-				manager := credentials.New()
-				manager.GetCredentials().Openstack = []credentials.OpenstackCredentials{
+			manager: func() *presets.Manager {
+				manager := presets.New()
+				manager.GetPresets().Openstack.Credentials = []presets.OpenstackCredentials{
 					{Name: "test", Tenant: "a", Domain: "b", Password: "c", Username: "d"},
 				}
 				return manager
@@ -114,9 +114,9 @@ func TestAWSCredentialEndpoint(t *testing.T) {
 		{
 			name:           "test 8: set credentials for Vsphere provider",
 			credentialName: "test",
-			manager: func() *credentials.Manager {
-				manager := credentials.New()
-				manager.GetCredentials().VSphere = []credentials.VSphereCredentials{
+			manager: func() *presets.Manager {
+				manager := presets.New()
+				manager.GetPresets().VSphere.Credentials = []presets.VSphereCredentials{
 					{Name: "test", Username: "bob", Password: "secret"},
 				}
 				return manager
@@ -127,9 +127,9 @@ func TestAWSCredentialEndpoint(t *testing.T) {
 		{
 			name:           "test 9: set credentials for Azure provider",
 			credentialName: "test",
-			manager: func() *credentials.Manager {
-				manager := credentials.New()
-				manager.GetCredentials().Azure = []credentials.AzureCredentials{
+			manager: func() *presets.Manager {
+				manager := presets.New()
+				manager.GetPresets().Azure.Credentials = []presets.AzureCredentials{
 					{Name: "test", SubscriptionID: "a", ClientID: "b", ClientSecret: "c", TenantID: "d"},
 				}
 				return manager
@@ -140,8 +140,8 @@ func TestAWSCredentialEndpoint(t *testing.T) {
 		{
 			name:           "test 10: no credentials for Azure provider",
 			credentialName: "test",
-			manager: func() *credentials.Manager {
-				manager := credentials.New()
+			manager: func() *presets.Manager {
+				manager := presets.New()
 				return manager
 			}(),
 			cloudSpec:     v1.CloudSpec{Azure: &v1.AzureCloudSpec{}},
@@ -150,9 +150,9 @@ func TestAWSCredentialEndpoint(t *testing.T) {
 		{
 			name:           "test 11: cloud provider spec is empty",
 			credentialName: "test",
-			manager: func() *credentials.Manager {
-				manager := credentials.New()
-				manager.GetCredentials().Openstack = []credentials.OpenstackCredentials{
+			manager: func() *presets.Manager {
+				manager := presets.New()
+				manager.GetPresets().Openstack.Credentials = []presets.OpenstackCredentials{
 					{Name: "test", Tenant: "a", Domain: "b", Password: "c", Username: "d"},
 				}
 				return manager


### PR DESCRIPTION
**What this PR does / why we need it**: move custom credentials to presets

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #3699

```release-note
credential endpoint changed from /api/v1/providers/{provider_name}/credentials to /api/v1/providers/{provider_name}/presets/credentials
[Action required] `credential` flag changed to `presets`
[Action required] to get credentials for the given provider the configuration file must be set in the kubermatic API server: `-presets=/path/to/presets/file`
The presets file example:
presets:
  digitalocean:
    credentials:
      - name: digitalocean
        token: 
  azure:
    credentials:
      - name: azure
        tenantId: 
        subscriptionId: 
        clientId: 
        clientSecret: 
  aws:
    credentials:
      - name: aws
        accessKeyId: 
        secretAccessKey: 
  openstack:
    credentials:
      - name: openstack
        username: 
        password: 
        tenant: 
        domain: DEFAULT
  hetzner:
    credentials:
      - name: default
        token:
  vsphere:
    credentials:
      - name: default
        username: 
        password: 
  packet:
    credentials:
      - name: default
        apiKey:
        projectId:
  gcp:
    credentials:
      - name: default
        serviceAccount:
```
