### PR TITLE
Adjust CPU resources

### DIFF
--- a/config/backup/velero/values.yaml
+++ b/config/backup/velero/values.yaml
@@ -19,10 +19,10 @@ velero:
     deploy: true
     resources:
       requests:
-        cpu: 10m
+        cpu: 100m
         memory: 30Mi
       limits:
-        cpu: 200m
+        cpu: 300m
         # during backups memory usage can spike, see https://github.com/restic/restic/issues/979
         memory: 1Gi
 
@@ -88,10 +88,10 @@ velero:
 
   resources:
     requests:
-      cpu: 10m
+      cpu: 100m
       memory: 50Mi
     limits:
-      cpu: 100m
+      cpu: 200m
       memory: 100Mi
 
   affinity:

--- a/config/cert-manager/values.yaml
+++ b/config/cert-manager/values.yaml
@@ -10,10 +10,10 @@ certManager:
 
     resources:
       requests:
-        cpu: 10m
+        cpu: 100m
         memory: 30Mi
       limits:
-        cpu: 30m
+        cpu: 300m
         memory: 50Mi
 
     affinity: {}
@@ -29,10 +29,10 @@ certManager:
 
     resources:
       requests:
-        cpu: 10m
+        cpu: 100m
         memory: 30Mi
       limits:
-        cpu: 30m
+        cpu: 250m
         memory: 30Mi
 
     affinity: {}

--- a/config/iap/values.yaml
+++ b/config/iap/values.yaml
@@ -84,10 +84,10 @@ iap:
 
   resources:
     requests:
-      cpu: 10m
+      cpu: 50m
       memory: 25Mi
     limits:
-      cpu: 100m
+      cpu: 200m
       memory: 50Mi
 
   # You can use Go templating inside affinities and access

--- a/config/minio/values.yaml
+++ b/config/minio/values.yaml
@@ -30,10 +30,10 @@ minio:
   resources:
     minio:
       requests:
-        cpu: 10m
+        cpu: 100m
         memory: 32Mi
       limits:
-        cpu: 100m
+        cpu: 300m
         memory: 512Mi
     backup:
       requests:

--- a/config/monitoring/alertmanager/values.yaml
+++ b/config/monitoring/alertmanager/values.yaml
@@ -25,17 +25,17 @@ alertmanager:
   resources:
     alertmanager:
       requests:
-        cpu: 20m
+        cpu: 100m
         memory: 32Mi
       limits:
-        cpu: 100m
+        cpu: 200m
         memory: 48Mi
     reloader:
       requests:
-        cpu: 5m
+        cpu: 50m
         memory: 24Mi
       limits:
-        cpu: 5m
+        cpu: 150m
         memory: 32Mi
     migration:
       resources:

--- a/config/monitoring/blackbox-exporter/values.yaml
+++ b/config/monitoring/blackbox-exporter/values.yaml
@@ -8,10 +8,10 @@ blackboxExporter:
     blackboxExporter:
       resources:
         requests:
-          cpu: 20m
+          cpu: 100m
           memory: 24Mi
         limits:
-          cpu: 100m
+          cpu: 250m
           memory: 32Mi
 
   nodeSelector: {}

--- a/config/monitoring/helm-exporter/values.yaml
+++ b/config/monitoring/helm-exporter/values.yaml
@@ -7,7 +7,13 @@ helmExporter:
     pullPolicy: IfNotPresent
   nameOverride: ''
 
-  resources: {}
+  resources:
+    requests:
+      cpu: 50m
+      memory: 32Mi
+    limits:
+      cpu: 250m
+      memory: 64Mi
   nodeSelector: {}
   tolerations: []
   affinity: {}

--- a/config/monitoring/kube-state-metrics/values.yaml
+++ b/config/monitoring/kube-state-metrics/values.yaml
@@ -7,7 +7,7 @@ kubeStateMetrics:
       cpu: 50m
       memory: 32Mi
     limits:
-      cpu: 200m
+      cpu: 250m
       memory: 128Mi
 
   resizer:

--- a/config/monitoring/node-exporter/values.yaml
+++ b/config/monitoring/node-exporter/values.yaml
@@ -4,10 +4,10 @@ nodeExporter:
     tag: v0.18.1
   resources:
     requests:
-      cpu: 10m
+      cpu: 50m
       memory: 24Mi
     limits:
-      cpu: 25m
+      cpu: 250m
       memory: 48Mi
 
   rbacProxy:
@@ -16,10 +16,10 @@ nodeExporter:
       tag: v0.4.1
     resources:
       requests:
-        cpu: 10m
+        cpu: 50m
         memory: 24Mi
       limits:
-        cpu: 20m
+        cpu: 100m
         memory: 48Mi
 
   nodeSelector: {}

--- a/config/monitoring/prometheus/values.yaml
+++ b/config/monitoring/prometheus/values.yaml
@@ -231,7 +231,7 @@ prometheus:
     thanosQuery:
       resources:
         requests:
-          cpu: 500m
+          cpu: 50m
           memory: 64Mi
         limits:
           cpu: 1

--- a/config/monitoring/prometheus/values.yaml
+++ b/config/monitoring/prometheus/values.yaml
@@ -213,13 +213,37 @@ prometheus:
           cpu: 5m
           memory: 32Mi
     thanosSidecar:
-      resources: {}
+      resources:
+        requests:
+          cpu: 100m
+          memory: 32Mi
+        limits:
+          cpu: 300m
+          memory: 1Gi
     thanosStore:
-      resources: {}
+      resources:
+        requests:
+          cpu: 100m
+          memory: 1536Mi
+        limits:
+          cpu: 250m
+          memory: 3Gi
     thanosQuery:
-      resources: {}
+      resources:
+        requests:
+          cpu: 500m
+          memory: 64Mi
+        limits:
+          cpu: 1
+          memory: 1Gi
     thanosCompact:
-      resources: {}
+      resources:
+        requests:
+          cpu: 250m
+          memory: 1Gi
+        limits:
+          cpu: 1
+          memory: 4Gi
 
   nodeSelector: {}
   affinity:

--- a/config/nodeport-proxy/values.yaml
+++ b/config/nodeport-proxy/values.yaml
@@ -29,24 +29,24 @@ nodePortProxy:
   resources:
     envoy:
       requests:
-        cpu: 10m
+        cpu: 50m
         memory: 32Mi
       limits:
-        cpu: 20m
+        cpu: 200m
         memory: 64Mi
     envoyManager:
       requests:
-        cpu: 10m
+        cpu: 50m
         memory: 32Mi
       limits:
-        cpu: 20m
+        cpu: 150m
         memory: 48Mi
     lbUpdater:
       requests:
-        cpu: 10m
+        cpu: 50m
         memory: 32Mi
       limits:
-        cpu: 10m
+        cpu: 150m
         memory: 32Mi
 
   lbUpdater:

--- a/config/oauth/values.yaml
+++ b/config/oauth/values.yaml
@@ -38,10 +38,10 @@ dex:
 #    userID: "08a8684b-db88-4b73-90a9-3cd1661f5466"
   resources:
     requests:
-      cpu: 10m
+      cpu: 200m
       memory: 32Mi
     limits:
-      cpu: 50m
+      cpu: 300m
       memory: 128Mi
 
   nodeSelector: {}

--- a/config/s3-exporter/values.yaml
+++ b/config/s3-exporter/values.yaml
@@ -6,10 +6,10 @@ s3Exporter:
   bucket: kubermatic-etcd-backups
   resources:
     requests:
-      cpu: 10m
+      cpu: 50m
       memory: 24Mi
     limits:
-      cpu: 30m
+      cpu: 150m
       memory: 32Mi
   nodeSelector: {}
   affinity: {}


### PR DESCRIPTION
**What this PR does / why we need it**:
We are experiencing timeouts for things that should normally not time out. Like TLS handshakes and node-exporter scrapes. It turns out that very low CPU limits actually work and really limit the CPU time we can spend. Who could have expected that?!

This PR increases the CPU shares for most components and allows more bursting. Likewise, this PR adds resource constraints for Thanos based on our current cloud-eu cluster.

**Does this PR introduce a user-facing change?**:
```release-note
NONE
```
