### PR TITLE
fix Kibana index setup code

### DIFF
--- a/config/logging/kibana/config/ensure-index-pattern.sh
+++ b/config/logging/kibana/config/ensure-index-pattern.sh
@@ -11,8 +11,14 @@ kibana() {
 }
 
 ensure_index_pattern() {
-   if [[ "$(kibana --show-error --connect-timeout 1 "${KIBANA_URL}/api/status" | jq -r '.status.overall.state')" != "green" ]]; then
-      echo "Kibana is not yet available or unhealthy."
+   output=$(kibana --show-error --connect-timeout 1 "${KIBANA_URL}/api/status")
+   if [ $? -ne 0 ] || [ "${output:0:1}" != "{" ]; then
+      echo "Kibana is not yet available."
+      return 1
+   fi
+
+   if [[ "$(echo "$output" | jq -r '.status.overall.state')" != "green" ]]; then
+      echo "Kibana is still unhealthy."
       return 1
    fi
 
@@ -40,11 +46,11 @@ ensure_index_pattern() {
    fi
 
    echo "Setting pattern as default..."
-   config=$(curl --silent "${ELASTICSEARCH_URL}/.kibana/doc/config:${KIBANA_VERSION}" | jq '._source // {"type": "config","config":{}}')
+   config=$(curl --silent "${ELASTICSEARCH_HOSTS}/.kibana/doc/config:${KIBANA_VERSION}" | jq '._source // {"type": "config","config":{}}')
 
    echo "$config" | \
       jq ".config.defaultIndex = \"${id}\"" | \
-      curl --silent -XPUT -H 'Content-Type:application/json' "${ELASTICSEARCH_URL}/.kibana/doc/config:$KIBANA_VERSION" -d @- > /dev/null
+      curl --silent -XPUT -H 'Content-Type:application/json' "${ELASTICSEARCH_HOSTS}/.kibana/doc/config:$KIBANA_VERSION" -d @- > /dev/null
 
    echo "Kibana successfully configured."
 }


### PR DESCRIPTION
**What this PR does / why we need it**:
Since the botched Elasticsearch 7.0 upgrade we're using the new, shiny `ELASTICSEARCH_HOSTS` variable, which broke the setup index-pattern container. This PR fixes that and also explicitly checks the API response *before* attempting to pipe it into jq, so that when Kibana responds with "Kibana server is not ready yet" jq will not report a parse error.

**Does this PR introduce a user-facing change?**:
```release-note
NONE
```
