### PR TITLE
Update versions.yaml to Kubernetes 1.14.3 as default

### DIFF
--- a/config/kubermatic/static/master/versions.yaml
+++ b/config/kubermatic/static/master/versions.yaml
@@ -37,10 +37,11 @@ versions:
 - version: "1.13.4"
   default: false
 - version: "1.13.5"
-  default: true
+  default: false
 # Insecure https://github.com/kubernetes/kubernetes/issues/78308
 #- version: "1.13.6"
 #  default: false
+# Kubernetes 1.14
 - version: "v1.14.0"
   default: false
 - version: "v1.14.1"
@@ -48,8 +49,10 @@ versions:
 # Insecure https://github.com/kubernetes/kubernetes/issues/78308
 #- version: "v1.14.2"
 #  default: false
-# TODO: Remove once there is an actual release
-- version: v1.15.0-rc.1
+- version: "v1.14.3"
+  default: true
+# Kubernetes 1.15
+- version: "v1.15.0"
   default: false
 # OpenShift 3.11
 - version: "v3.11"


### PR DESCRIPTION
Signed-off-by: Frank Mueller <mail@themue.dev>

**What this PR does / why we need it**:

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

Beside moving the default to the actual K8S 1.14.3 the 1.15 is no rc.1 anymore.

**Documentation**:
<!-- Add links to the related documentation changes related to this pull request. E.g. the link to the kubermatic/docs pullrequest. -->

**Does this PR introduce a user-facing change?**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If  no release note is required, just write "NONE".
-->
```release-note
NONE
```
