### PR TITLE
add shellcheck binary to the kubernetes-test-binaries image

### DIFF
--- a/containers/conformance-tests/Dockerfile
+++ b/containers/conformance-tests/Dockerfile
@@ -12,7 +12,7 @@ FROM golang:1.11.4-stretch
 
 COPY --from=0 /opt/kube-test /opt/kube-test
 COPY start-docker.sh /usr/local/bin/start-docker.sh
-RUN apt update && apt install -y git-crypt curl apt-transport-https software-properties-common unzip jq && \
+RUN apt update && apt install -y git-crypt curl apt-transport-https software-properties-common unzip jq shellcheck && \
   curl -fsSL https://download.docker.com/linux/debian/gpg | apt-key add - && \
   curl -fsSL https://download.docker.com/linux/$(. /etc/os-release; echo "$ID")/gpg \
     | apt-key add - && \

--- a/containers/conformance-tests/release.sh
+++ b/containers/conformance-tests/release.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 
-TAG=v0.9.2
+TAG=v0.10.0
 
 set -euox pipefail
 


### PR DESCRIPTION
**What this PR does / why we need it**:
A step towards #3538 

```release-note
NONE
```
