### PR TITLE
mark Thanos support as experimental for upcoming 2.11 release

### DIFF
--- a/config/monitoring/prometheus/values.yaml
+++ b/config/monitoring/prometheus/values.yaml
@@ -102,7 +102,9 @@ prometheus:
   #  secretName: initech-recording-rules-secret
 
   # Thanos can be used to handle long-term storage of metrics by
-  # shipping the data blocks into an object storage like Minio.
+  # shipping the data blocks into an object storage like Minio. Note that
+  # this is considered EXPERIMENTAL and can be removed or significantly
+  # altered in future Kubermatic releases.
   # When enabling Thanos it's advised to disable backups, as blocks
   # are already backed up, and to lower the retentionTime to something
   # short like 24 hours.


### PR DESCRIPTION
**What this PR does / why we need it**:
Considering we're not 100% sure that Thanos is our way to go and since VictoriaMetrics is a strong contender, we should not make Kubermatic customers jump on the Thanos bandwaggon just now. *If* we decide VM is better than Thanos, a migration would probably be not easy/impossible.

**Does this PR introduce a user-facing change?**:
```release-note
NONE
```
