### PR TITLE
fix resources-per-namespace-and-node dashboard

### DIFF
--- a/config/monitoring/grafana/Chart.yaml
+++ b/config/monitoring/grafana/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: grafana
-version: 1.0.7
+version: 1.0.8
 appVersion: 6.2.1
 description: Grafana for Kubermatic
 keywords:

--- a/config/monitoring/grafana/dashboards/kubernetes/node-namespaces.json
+++ b/config/monitoring/grafana/dashboards/kubernetes/node-namespaces.json
@@ -76,7 +76,7 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "sum by (namespace) (container_memory_rss{kubernetes_io_hostname=\"$hostname\",namespace!=\"\",namespace!~\"^$exclude.*\"})",
+          "expr": "sum by (namespace) (container_memory_rss{kubernetes_io_hostname=\"$hostname\",container_name!=\"\",namespace!=\"\",namespace!~\"^$exclude.*\"})",
           "format": "time_series",
           "intervalFactor": 1,
           "legendFormat": "{{ namespace }}",

--- a/config/monitoring/grafana/dashboards/kubernetes/node-namespaces.json
+++ b/config/monitoring/grafana/dashboards/kubernetes/node-namespaces.json
@@ -76,7 +76,7 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "sum by (namespace) (container_memory_rss{kubernetes_io_hostname=\"$hostname\",container_name!=\"\",namespace!=\"\",namespace!~\"^$exclude.*\"})",
+          "expr": "sum by (namespace) (container_memory_rss{kubernetes_io_hostname=\"$hostname\",job=\"cadvisor\",container_name!=\"\",namespace!=\"\",namespace!~\"^$exclude.*\"})",
           "format": "time_series",
           "intervalFactor": 1,
           "legendFormat": "{{ namespace }}",
@@ -190,7 +190,7 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "sum by (kubernetes_io_hostname, namespace) (rate(container_cpu_usage_seconds_total{kubernetes_io_hostname=\"$hostname\",namespace!=\"\",namespace!~\"$exclude\",namespace!~\"^$exclude.*\"}[5m]))",
+          "expr": "sum by (kubernetes_io_hostname, namespace) (rate(container_cpu_usage_seconds_total{kubernetes_io_hostname=\"$hostname\",job=\"cadvisor\",namespace!=\"\",namespace!~\"$exclude\",namespace!~\"^$exclude.*\"}[5m]))",
           "format": "time_series",
           "intervalFactor": 1,
           "legendFormat": "{{ namespace }}",
@@ -250,14 +250,14 @@
         "allValue": null,
         "current": {},
         "datasource": "prometheus",
-        "definition": "label_values(container_memory_rss, kubernetes_io_hostname)",
+        "definition": "label_values(container_memory_rss{job=\"cadvisor\"}, kubernetes_io_hostname)",
         "hide": 0,
         "includeAll": true,
         "label": "Hostname",
         "multi": true,
         "name": "hostname",
         "options": [],
-        "query": "label_values(container_memory_rss, kubernetes_io_hostname)",
+        "query": "label_values(container_memory_rss{job=\"cadvisor\"}, kubernetes_io_hostname)",
         "refresh": 2,
         "regex": "",
         "skipUrlSync": false,

--- a/config/monitoring/grafana/dashboards/kubernetes/pods.json
+++ b/config/monitoring/grafana/dashboards/kubernetes/pods.json
@@ -50,7 +50,7 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "sum (container_memory_usage_bytes{job=\"cadvisor\", namespace=\"$namespace\", pod_name=\"$pod\", container_name!=\"POD\"})",
+          "expr": "sum (container_memory_usage_bytes{job=\"cadvisor\", namespace=\"$namespace\", pod_name=\"$pod\", container_name!=\"POD\", image!=\"\"})",
           "format": "time_series",
           "intervalFactor": 2,
           "legendFormat": "Current Usage",
@@ -347,7 +347,7 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "rate(container_network_receive_bytes_total{job=\"cadvisor\", pod_name=\"$pod\"}[1m])",
+          "expr": "rate(container_network_receive_bytes_total{job=\"cadvisor\", namespace=\"$namespace\", pod_name=\"$pod\"}[1m])",
           "format": "time_series",
           "intervalFactor": 2,
           "legendFormat": "bytes",

--- a/config/monitoring/grafana/dashboards/kubernetes/resources-cluster.json
+++ b/config/monitoring/grafana/dashboards/kubernetes/resources-cluster.json
@@ -1267,7 +1267,7 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "sum(container_memory_rss{container_name!=\"\"}) by (namespace)",
+          "expr": "sum(container_memory_rss{job=\"cadvisor\",container_name!=\"\"}) by (namespace)",
           "format": "time_series",
           "intervalFactor": 2,
           "legendFormat": "{{namespace}}",
@@ -1482,7 +1482,7 @@
       ],
       "targets": [
         {
-          "expr": "sum(container_memory_rss{container_name!=\"\"}) by (namespace)",
+          "expr": "sum(container_memory_rss{job=\"cadvisor\",container_name!=\"\"}) by (namespace)",
           "format": "table",
           "instant": true,
           "intervalFactor": 2,
@@ -1500,7 +1500,7 @@
           "step": 10
         },
         {
-          "expr": "sum(container_memory_rss{container_name!=\"\"}) by (namespace) / sum(kube_pod_container_resource_requests_memory_bytes) by (namespace)",
+          "expr": "sum(container_memory_rss{job=\"cadvisor\",container_name!=\"\"}) by (namespace) / sum(kube_pod_container_resource_requests_memory_bytes) by (namespace)",
           "format": "table",
           "instant": true,
           "intervalFactor": 2,
@@ -1518,7 +1518,7 @@
           "step": 10
         },
         {
-          "expr": "sum(container_memory_rss{container_name!=\"\"}) by (namespace) / sum(kube_pod_container_resource_limits_memory_bytes) by (namespace)",
+          "expr": "sum(container_memory_rss{job=\"cadvisor\",container_name!=\"\"}) by (namespace) / sum(kube_pod_container_resource_limits_memory_bytes) by (namespace)",
           "format": "table",
           "instant": true,
           "intervalFactor": 2,

--- a/config/monitoring/grafana/dashboards/kubernetes/resources-namespace.json
+++ b/config/monitoring/grafana/dashboards/kubernetes/resources-namespace.json
@@ -411,7 +411,7 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "sum(container_memory_usage_bytes{namespace=\"$namespace\", container_name!=\"\"}) by (pod_name)",
+          "expr": "sum(container_memory_usage_bytes{job=\"cadvisor\",namespace=\"$namespace\", container_name!=\"\"}) by (pod_name)",
           "format": "time_series",
           "intervalFactor": 2,
           "legendFormat": "{{pod_name}}",
@@ -668,7 +668,7 @@
       ],
       "targets": [
         {
-          "expr": "sum(label_replace(container_memory_usage_bytes{namespace=\"$namespace\",container_name!=\"\"}, \"pod\", \"$1\", \"pod_name\", \"(.*)\")) by (pod)",
+          "expr": "sum(label_replace(container_memory_usage_bytes{job=\"cadvisor\",namespace=\"$namespace\",container_name!=\"\"}, \"pod\", \"$1\", \"pod_name\", \"(.*)\")) by (pod)",
           "format": "table",
           "instant": true,
           "intervalFactor": 2,
@@ -686,7 +686,7 @@
           "step": 10
         },
         {
-          "expr": "sum(label_replace(container_memory_usage_bytes{namespace=\"$namespace\",container_name!=\"\"}, \"pod\", \"$1\", \"pod_name\", \"(.*)\")) by (pod) / sum(kube_pod_container_resource_requests_memory_bytes{namespace=\"$namespace\"}) by (pod)",
+          "expr": "sum(label_replace(container_memory_usage_bytes{job=\"cadvisor\",namespace=\"$namespace\",container_name!=\"\"}, \"pod\", \"$1\", \"pod_name\", \"(.*)\")) by (pod) / sum(kube_pod_container_resource_requests_memory_bytes{namespace=\"$namespace\"}) by (pod)",
           "format": "table",
           "instant": true,
           "intervalFactor": 2,
@@ -704,7 +704,7 @@
           "step": 10
         },
         {
-          "expr": "sum(label_replace(container_memory_usage_bytes{namespace=\"$namespace\",container_name!=\"\"}, \"pod\", \"$1\", \"pod_name\", \"(.*)\")) by (pod) / sum(kube_pod_container_resource_limits_memory_bytes{namespace=\"$namespace\"}) by (pod)",
+          "expr": "sum(label_replace(container_memory_usage_bytes{job=\"cadvisor\",namespace=\"$namespace\",container_name!=\"\"}, \"pod\", \"$1\", \"pod_name\", \"(.*)\")) by (pod) / sum(kube_pod_container_resource_limits_memory_bytes{namespace=\"$namespace\"}) by (pod)",
           "format": "table",
           "instant": true,
           "intervalFactor": 2,
@@ -713,7 +713,7 @@
           "step": 10
         },
         {
-          "expr": "sum(label_replace(container_memory_rss{namespace=\"$namespace\",container_name!=\"\"}, \"pod\", \"$1\", \"pod_name\", \"(.*)\")) by (pod)",
+          "expr": "sum(label_replace(container_memory_rss{job=\"cadvisor\",namespace=\"$namespace\",container_name!=\"\"}, \"pod\", \"$1\", \"pod_name\", \"(.*)\")) by (pod)",
           "format": "table",
           "instant": true,
           "intervalFactor": 2,
@@ -722,7 +722,7 @@
           "step": 10
         },
         {
-          "expr": "sum(label_replace(container_memory_cache{namespace=\"$namespace\",container_name!=\"\"}, \"pod\", \"$1\", \"pod_name\", \"(.*)\")) by (pod)",
+          "expr": "sum(label_replace(container_memory_cache{job=\"cadvisor\",namespace=\"$namespace\",container_name!=\"\"}, \"pod\", \"$1\", \"pod_name\", \"(.*)\")) by (pod)",
           "format": "table",
           "instant": true,
           "intervalFactor": 2,
@@ -731,7 +731,7 @@
           "step": 10
         },
         {
-          "expr": "sum(label_replace(container_memory_swap{namespace=\"$namespace\",container_name!=\"\"}, \"pod\", \"$1\", \"pod_name\", \"(.*)\")) by (pod)",
+          "expr": "sum(label_replace(container_memory_swap{job=\"cadvisor\",namespace=\"$namespace\",container_name!=\"\"}, \"pod\", \"$1\", \"pod_name\", \"(.*)\")) by (pod)",
           "format": "table",
           "instant": true,
           "intervalFactor": 2,

--- a/config/monitoring/grafana/dashboards/kubernetes/statefulset.json
+++ b/config/monitoring/grafana/dashboards/kubernetes/statefulset.json
@@ -69,7 +69,7 @@
       "tableColumn": "",
       "targets": [
         {
-          "expr": "sum(rate(container_cpu_usage_seconds_total{job=\"cadvisor\", namespace=\"$namespace\", pod_name=~\"$statefulset.*\"}[3m]))",
+          "expr": "sum(rate(container_cpu_usage_seconds_total{job=\"cadvisor\", namespace=\"$namespace\", pod_name=~\"$statefulset.*\", container_name!=\"\"}[3m]))",
           "format": "time_series",
           "intervalFactor": 2,
           "legendFormat": "",
@@ -152,7 +152,7 @@
       "tableColumn": "",
       "targets": [
         {
-          "expr": "sum(container_memory_usage_bytes{job=\"cadvisor\", namespace=\"$namespace\", pod_name=~\"$statefulset.*\"}) / 1024^3",
+          "expr": "sum(container_memory_usage_bytes{job=\"cadvisor\", namespace=\"$namespace\", pod_name=~\"$statefulset.*\", container_name!=\"\"}) / 1024^3",
           "format": "time_series",
           "intervalFactor": 2,
           "legendFormat": "",
@@ -235,7 +235,7 @@
       "tableColumn": "",
       "targets": [
         {
-          "expr": "sum(rate(container_network_transmit_bytes_total{job=\"cadvisor\", namespace=\"$namespace\", pod_name=~\"$statefulset.*\"}[3m])) + sum(rate(container_network_receive_bytes_total{namespace=\"$namespace\",pod_name=~\"$statefulset.*\"}[3m]))",
+          "expr": "sum(rate(container_network_transmit_bytes_total{job=\"cadvisor\", namespace=\"$namespace\", pod_name=~\"$statefulset.*\", container_name!=\"\"}[3m])) + sum(rate(container_network_receive_bytes_total{namespace=\"$namespace\",pod_name=~\"$statefulset.*\"}[3m]))",
           "format": "time_series",
           "intervalFactor": 2,
           "legendFormat": "",


### PR DESCRIPTION
**What this PR does / why we need it**:
cAdvisor publishes metrics for each container *and then once per pod*. This leads to metrics like these:

![screenshot-2019-07-02-115516](https://user-images.githubusercontent.com/127499/60503565-47934b00-9cc0-11e9-931e-6760333d7110.png)

It's obvious that the non-container'ed metric is the sum of all containers. Without excluding these cumulative metrics, we would count everything twice.

Also, it turns out that we have other cadvisors in our cluster and this can interfere with the CPU metrics. This is why the PR now also explicitly restricts the queries to *our* cadvisor.

The same fixes are applied to a couple of dashboards. Finally some of the weird, broken charts begin to make sense :-)

**Does this PR introduce a user-facing change?**:
```release-note
NONE
```
