### PR TITLE
add extended fields for credential presets

### DIFF
--- a/api/pkg/handler/v1/cluster/cluster.go
+++ b/api/pkg/handler/v1/cluster/cluster.go
@@ -72,7 +72,11 @@ func CreateEndpoint(sshKeyProvider provider.SSHKeyProvider, cloudProviders map[s
 
 		credentialName := req.Body.Cluster.Credential
 		if len(credentialName) > 0 {
-			cloudSpec, err := credentialManager.SetCloudCredentials(credentialName, req.Body.Cluster.Spec.Cloud)
+			dc, found := dcs[req.Body.Cluster.Spec.Cloud.DatacenterName]
+			if !found {
+				return nil, errors.NewBadRequest("unknown cluster datacenter %s", req.Body.Cluster.Spec.Cloud.DatacenterName)
+			}
+			cloudSpec, err := credentialManager.SetCloudCredentials(credentialName, req.Body.Cluster.Spec.Cloud, dc)
 			if err != nil {
 				return nil, errors.NewBadRequest("invalid credentials: %v", err)
 			}

--- a/api/pkg/handler/v1/common/common.go
+++ b/api/pkg/handler/v1/common/common.go
@@ -40,7 +40,7 @@ type UpdateManager interface {
 // PresetsManager specifies a set of methods to handle presets for specific provider
 type PresetsManager interface {
 	GetPresets() *presets.Presets
-	SetCloudCredentials(credentialName string, cloud v1.CloudSpec) (*v1.CloudSpec, error)
+	SetCloudCredentials(credentialName string, cloud v1.CloudSpec, dc provider.DatacenterMeta) (*v1.CloudSpec, error)
 }
 
 // ServerMetrics defines metrics used by the API.

--- a/api/pkg/presets/manager_test.go
+++ b/api/pkg/presets/manager_test.go
@@ -7,9 +7,10 @@ import (
 
 	"github.com/kubermatic/kubermatic/api/pkg/crd/kubermatic/v1"
 	"github.com/kubermatic/kubermatic/api/pkg/presets"
+	"github.com/kubermatic/kubermatic/api/pkg/provider"
 )
 
-func TestAWSCredentialEndpoint(t *testing.T) {
+func TestCredentialEndpoint(t *testing.T) {
 	t.Parallel()
 	testcases := []struct {
 		name              string
@@ -17,6 +18,7 @@ func TestAWSCredentialEndpoint(t *testing.T) {
 		expectedError     string
 		cloudSpec         v1.CloudSpec
 		expectedCloudSpec *v1.CloudSpec
+		dc                provider.DatacenterMeta
 		manager           *presets.Manager
 	}{
 		{
@@ -83,7 +85,7 @@ func TestAWSCredentialEndpoint(t *testing.T) {
 				return manager
 			}(),
 			cloudSpec:         v1.CloudSpec{Packet: &v1.PacketCloudSpec{}},
-			expectedCloudSpec: &v1.CloudSpec{Packet: &v1.PacketCloudSpec{APIKey: "secret", ProjectID: "project"}},
+			expectedCloudSpec: &v1.CloudSpec{Packet: &v1.PacketCloudSpec{APIKey: "secret", ProjectID: "project", BillingCycle: "hourly"}},
 		},
 		{
 			name:           "test 6: set credentials for DigitalOcean provider",
@@ -108,6 +110,7 @@ func TestAWSCredentialEndpoint(t *testing.T) {
 				}
 				return manager
 			}(),
+			dc:                provider.DatacenterMeta{Spec: provider.DatacenterSpec{Openstack: &provider.OpenstackSpec{EnforceFloatingIP: false}}},
 			cloudSpec:         v1.CloudSpec{Openstack: &v1.OpenstackCloudSpec{}},
 			expectedCloudSpec: &v1.CloudSpec{Openstack: &v1.OpenstackCloudSpec{Tenant: "a", Domain: "b", Password: "c", Username: "d"}},
 		},
@@ -165,7 +168,7 @@ func TestAWSCredentialEndpoint(t *testing.T) {
 	for _, tc := range testcases {
 		t.Run(tc.name, func(t *testing.T) {
 
-			cloudResult, err := tc.manager.SetCloudCredentials(tc.credentialName, tc.cloudSpec)
+			cloudResult, err := tc.manager.SetCloudCredentials(tc.credentialName, tc.cloudSpec, tc.dc)
 
 			if len(tc.expectedError) > 0 {
 				if err == nil {


### PR DESCRIPTION
**What this PR does / why we need it**: extends credentials for extra parameters like network configuration

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #3705

```release-note
preset.yaml example:
presets:
  digitalocean:
    credentials:
      - name: digitalocean
        token:
  azure:
    credentials:
      - name: azure
        tenantId:
        subscriptionId:
        clientId:
        clientSecret:
        resourceGroup:
        vnet:
        subnet:
        routeTable:
        securityGroup:
  aws:
    credentials:
      - name: aws
        accessKeyId:
        secretAccessKey:
        vpcId:
        subnetId:
        routeTableId:
        instanceProfileName:
        securityGroupID:
  openstack:
    credentials:
      - name: openstack
        username:
        password:
        tenant:
        domain: DEFAULT
        network:
        securityGroups:
        floatingIpPool:
        routerID:
        subnetID:
  hetzner:
    credentials:
      - name: default
        token:
  vsphere:
    credentials:
      - name: default
        username:
        password:
        vmNetName:
  packet:
    credentials:
      - name: default
        apiKey:
        projectId:
        billingCycle:
  gcp:
    credentials:
      - name: default
        serviceAccount:
        network:
        subnetwork:
```
