### PR TITLE
E2E tests: Print ginkgo logs on failures (#3510)

### DIFF
--- a/api/cmd/conformance-tests/main.go
+++ b/api/cmd/conformance-tests/main.go
@@ -71,6 +71,7 @@ type Opts struct {
 	excludeSelector              excludeSelector
 	excludeSelectorRaw           string
 	existingClusterLabel         string
+	printGinkoLogs               bool
 
 	secrets secrets
 }
@@ -156,6 +157,7 @@ func main() {
 	flag.StringVar(&opts.excludeSelectorRaw, "exclude-distributions", "", "a comma-separated list of distributions that will get excluded from the tests")
 	_ = flag.Bool("run-kubermatic-controller-manager", false, "Unused, but kept for compatibility reasons")
 
+	flag.BoolVar(&opts.printGinkoLogs, "print-ginkgo-logs", false, "Whether to print ginkgo logs when ginkgo encountered failures")
 	flag.StringVar(&opts.secrets.AWS.AccessKeyID, "aws-access-key-id", "", "AWS: AccessKeyID")
 	flag.StringVar(&opts.secrets.AWS.SecretAccessKey, "aws-secret-access-key", "", "AWS: SecretAccessKey")
 	flag.StringVar(&opts.secrets.Digitalocean.Token, "digitalocean-token", "", "Digitalocean: API Token")


### PR DESCRIPTION
**What this PR does / why we need it**:
Cherry picking flag change to fix parameter incompatibility between `conformance-tests` on different branches.

```release-note
NONE
```
