### PR TITLE
Restore pushing latest tag to kubermatic/api quay image

### DIFF
--- a/api/hack/ci/ci-push-images.sh
+++ b/api/hack/ci/ci-push-images.sh
@@ -16,5 +16,5 @@ time make -C api build
 echodate "Successfully finished building binaries"
 
 echodate "Building and pushing quay images"
-retry 5 ./api/hack/push_image.sh $GIT_HEAD_HASH $(git tag -l --points-at HEAD)
+retry 5 ./api/hack/push_image.sh $GIT_HEAD_HASH $(git tag -l --points-at HEAD) "latest"
 echodate "Sucessfully finished building and pushing quay images"


### PR DESCRIPTION
**What this PR does / why we need it**:
Restores the latest image for `kubermatic/api` image on quay

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #3738

**Does this PR introduce a user-facing change?**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If  no release note is required, just write "NONE".
-->
```release-note
NONE
```
