### PR TITLE
Azure Kube 1.15+: Support multiple clusters in the same resoruce group

### DIFF
--- a/api/pkg/resources/controllermanager/deployment.go
+++ b/api/pkg/resources/controllermanager/deployment.go
@@ -242,6 +242,11 @@ func getFlags(cluster *kubermaticv1.Cluster) ([]string, error) {
 		flags = append(flags, "--cloud-provider", "azure")
 		flags = append(flags, "--cloud-config", "/etc/kubernetes/cloud/config")
 		flags = append(flags, "--configure-cloud-routes=false")
+		if cluster.Spec.Version.Semver().Minor() >= 15 {
+			// Required so multiple clusters using the same resource group can
+			// allocate public IPs. Ref: https://github.com/kubernetes/kubernetes/pull/77630
+			flags = append(flags, "--cluster-name", cluster.Name)
+		}
 	}
 	if cluster.Spec.Cloud.GCP != nil {
 		flags = append(flags, "--cloud-provider", "gce")


### PR DESCRIPTION
**What this PR does / why we need it**:

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Documentation**:
<!-- Add links to the related documentation changes related to this pull request. E.g. the link to the kubermatic/docs pullrequest. -->

**Does this PR introduce a user-facing change?**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If  no release note is required, just write "NONE".
-->
```release-note
none
```

/assign  @mrIncompetent 

/hold

I want  https://github.com/kubermatic/infra/pull/460 to merge first and use the presubmits added there to test this
