### PR TITLE
Add new endpoint to get GCP zones for the datacenter

### DIFF
--- a/api/cmd/kubermatic-api/swagger.json
+++ b/api/cmd/kubermatic-api/swagger.json
@@ -3065,6 +3065,48 @@
         }
       }
     },
+    "/api/v1/providers/gcp/{dc}/zones": {
+      "get": {
+        "description": "Lists available GCP zones",
+        "produces": [
+          "application/json"
+        ],
+        "tags": [
+          "gcp"
+        ],
+        "operationId": "listGCPZones",
+        "parameters": [
+          {
+            "type": "string",
+            "name": "ServiceAccount",
+            "in": "query"
+          },
+          {
+            "type": "string",
+            "name": "Credential",
+            "in": "query"
+          },
+          {
+            "type": "string",
+            "x-go-name": "DC",
+            "name": "dc",
+            "in": "path",
+            "required": true
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "GCPZoneList",
+            "schema": {
+              "$ref": "#/definitions/GCPZoneList"
+            }
+          },
+          "default": {
+            "$ref": "#/responses/errorResponse"
+          }
+        }
+      }
+    },
     "/api/v1/providers/openstack/networks": {
       "get": {
         "description": "Lists networks from openstack",
@@ -4544,6 +4586,25 @@
           "type": "string",
           "x-go-name": "Zone"
         }
+      },
+      "x-go-package": "github.com/kubermatic/kubermatic/api/pkg/api/v1"
+    },
+    "GCPZone": {
+      "type": "object",
+      "title": "GCPZone represents a object of GCP zone.",
+      "properties": {
+        "name": {
+          "type": "string",
+          "x-go-name": "Name"
+        }
+      },
+      "x-go-package": "github.com/kubermatic/kubermatic/api/pkg/api/v1"
+    },
+    "GCPZoneList": {
+      "type": "array",
+      "title": "GCPZoneList represents an array of GCP zones.",
+      "items": {
+        "$ref": "#/definitions/GCPZone"
       },
       "x-go-package": "github.com/kubermatic/kubermatic/api/pkg/api/v1"
     },

--- a/api/pkg/api/v1/types.go
+++ b/api/pkg/api/v1/types.go
@@ -151,6 +151,16 @@ type GCPMachineSize struct {
 	VCPUs       int64  `json:"vcpus"`
 }
 
+// GCPZone represents a object of GCP zone.
+// swagger:model GCPZone
+type GCPZone struct {
+	Name string `json:"name"`
+}
+
+// GCPZoneList represents an array of GCP zones.
+// swagger:model GCPZoneList
+type GCPZoneList []GCPZone
+
 // DigitaloceanSizeList represents a object of digitalocean sizes.
 // swagger:model DigitaloceanSizeList
 type DigitaloceanSizeList struct {

--- a/api/pkg/handler/routes_v1.go
+++ b/api/pkg/handler/routes_v1.go
@@ -52,6 +52,10 @@ func (r Routing) RegisterV1(mux *mux.Router, metrics common.ServerMetrics) {
 		Handler(r.listGCPSizes())
 
 	mux.Methods(http.MethodGet).
+		Path("/providers/gcp/{dc}/zones").
+		Handler(r.listGCPZones())
+
+	mux.Methods(http.MethodGet).
 		Path("/providers/digitalocean/sizes").
 		Handler(r.listDigitaloceanSizes())
 
@@ -467,6 +471,28 @@ func (r Routing) listGCPSizes() http.Handler {
 			middleware.UserSaver(r.userProvider),
 		)(provider.GCPSizeEndpoint(r.presetsManager)),
 		provider.DecodeGCPTypesReq,
+		encodeJSON,
+		r.defaultServerOptions()...,
+	)
+}
+
+// swagger:route GET /api/v1/providers/gcp/{dc}/zones gcp listGCPZones
+//
+// Lists available GCP zones
+//
+//     Produces:
+//     - application/json
+//
+//     Responses:
+//       default: errorResponse
+//       200: GCPZoneList
+func (r Routing) listGCPZones() http.Handler {
+	return httptransport.NewServer(
+		endpoint.Chain(
+			middleware.TokenVerifier(r.tokenVerifiers),
+			middleware.UserSaver(r.userProvider),
+		)(provider.GCPZoneEndpoint(r.presetsManager, r.datacenters)),
+		provider.DecodeGCPZoneReq,
 		encodeJSON,
 		r.defaultServerOptions()...,
 	)

--- a/api/pkg/handler/v1/provider/gcp.go
+++ b/api/pkg/handler/v1/provider/gcp.go
@@ -2,28 +2,77 @@ package provider
 
 import (
 	"context"
+	"fmt"
 	"net/http"
 
 	"github.com/go-kit/kit/endpoint"
+	"github.com/gorilla/mux"
 	"google.golang.org/api/compute/v1"
 
 	apiv1 "github.com/kubermatic/kubermatic/api/pkg/api/v1"
 	"github.com/kubermatic/kubermatic/api/pkg/handler/v1/common"
+	"github.com/kubermatic/kubermatic/api/pkg/handler/v1/dc"
+	"github.com/kubermatic/kubermatic/api/pkg/provider"
 	"github.com/kubermatic/kubermatic/api/pkg/provider/cloud/gcp"
+	"github.com/kubermatic/kubermatic/api/pkg/util/errors"
 )
+
+// GCPZoneReq represent a request for GCP zones.
+// swagger:parameters listGCPZones
+type GCPZoneReq struct {
+	GCPCommonReq
+	// in: path
+	// required: true
+	DC string `json:"dc"`
+}
 
 // GCPTypesReq represent a request for GCP machine or disk types.
 type GCPTypesReq struct {
+	GCPCommonReq
+	Zone string
+}
+
+// GCPCommonReq represent a request with common parameters for GCP.
+type GCPCommonReq struct {
 	ServiceAccount string
-	Zone           string
 	Credential     string
 }
 
 func DecodeGCPTypesReq(c context.Context, r *http.Request) (interface{}, error) {
 	var req GCPTypesReq
 
-	req.ServiceAccount = r.Header.Get("ServiceAccount")
+	commonReq, err := DecodeGCPCommonReq(c, r)
+	if err != nil {
+		return nil, err
+	}
+	req.GCPCommonReq = commonReq.(GCPCommonReq)
 	req.Zone = r.Header.Get("Zone")
+
+	return req, nil
+}
+
+func DecodeGCPZoneReq(c context.Context, r *http.Request) (interface{}, error) {
+	var req GCPZoneReq
+
+	commonReq, err := DecodeGCPCommonReq(c, r)
+	if err != nil {
+		return nil, err
+	}
+	req.GCPCommonReq = commonReq.(GCPCommonReq)
+
+	dc, ok := mux.Vars(r)["dc"]
+	if !ok {
+		return req, fmt.Errorf("'dc' parameter is required")
+	}
+	req.DC = dc
+
+	return req, nil
+}
+
+func DecodeGCPCommonReq(c context.Context, r *http.Request) (interface{}, error) {
+	var req GCPCommonReq
+
+	req.ServiceAccount = r.Header.Get("ServiceAccount")
 	req.Credential = r.Header.Get("Credential")
 
 	return req, nil
@@ -123,4 +172,61 @@ func listGCPSizes(ctx context.Context, sa string, zone string) (apiv1.GCPMachine
 	})
 
 	return sizes, err
+}
+
+func GCPZoneEndpoint(credentialManager common.PresetsManager, dcs map[string]provider.DatacenterMeta) endpoint.Endpoint {
+	return func(ctx context.Context, request interface{}) (interface{}, error) {
+		req := request.(GCPZoneReq)
+
+		sa := req.ServiceAccount
+
+		if len(req.Credential) > 0 && credentialManager.GetPresets().GCP.Credentials != nil {
+			for _, credential := range credentialManager.GetPresets().GCP.Credentials {
+				if credential.Name == req.Credential {
+					sa = credential.ServiceAccount
+					break
+				}
+			}
+		}
+
+		return listGCPZones(ctx, sa, req.DC, dcs)
+	}
+}
+
+func listGCPZones(ctx context.Context, sa, datacenterName string, dcs map[string]provider.DatacenterMeta) (apiv1.GCPZoneList, error) {
+	supportedZones := make(map[string]struct{})
+	zones := apiv1.GCPZoneList{}
+
+	datacenter, err := dc.GetDatacenter(dcs, datacenterName)
+	if err != nil {
+		return nil, errors.NewBadRequest("%v", err)
+	}
+
+	if datacenter.Spec.GCP == nil {
+		return nil, errors.NewBadRequest("the %s is not GCP datacenter", datacenterName)
+	}
+
+	for _, suffix := range datacenter.Spec.GCP.ZoneSuffixes {
+		supportedZones[fmt.Sprintf("%s-%s", datacenter.Spec.GCP.Region, suffix)] = struct{}{}
+	}
+
+	computeService, project, err := gcp.ConnectToComputeService(sa)
+	if err != nil {
+		return nil, err
+	}
+
+	req := computeService.Zones.List(project)
+	err = req.Pages(ctx, func(page *compute.ZoneList) error {
+		for _, zone := range page.Items {
+
+			_, ok := supportedZones[zone.Name]
+			if ok {
+				apiZone := apiv1.GCPZone{Name: zone.Name}
+				zones = append(zones, apiZone)
+			}
+		}
+		return nil
+	})
+
+	return zones, err
 }


### PR DESCRIPTION
**What this PR does / why we need it**: Add new endpoint to get GCP zones for the datacenter

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #3737 

```release-note
new endpoint for GCP zones:
GET /api/v1/providers/gcp/{dc}/zones
```
