### PR TITLE
Add addon: component-override-controller hack.

### DIFF
--- a/addons/component-override-controller/coc-config.yaml
+++ b/addons/component-override-controller/coc-config.yaml
@@ -1,0 +1,9 @@
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: component-override-controller-config
+  namespace: kubermatic
+data:
+  PROJECT_LIST: ""
+  DESIRED_REPLICAS: "3"

--- a/addons/component-override-controller/coc-deployment.yaml
+++ b/addons/component-override-controller/coc-deployment.yaml
@@ -1,0 +1,58 @@
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  labels:
+    app: component-override-controller
+  name: component-override-controller
+  namespace: kubermatic
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: component-override-controller
+  strategy: {}
+  template:
+    metadata:
+      labels:
+        app: component-override-controller
+    spec:
+      serviceAccountName: kubermatic
+      containers:
+      - image: quay.io/kubermatic/util:1.0.0-2
+        name: util
+        command:
+        - bash
+        - -c
+        - |
+          ltmp=$(mktemp -d) ; trap "rm -rv $ltmp" EXIT
+
+          # syncrun INSTANCE_PROFILE_NAME [PROJECT_LIST]
+          syncrun() {
+            count="$1"; shift
+            projects="$1"; shift
+            [ -n "$projects" ] && label_selector="project-id in ( $projects )"
+            kubectl get -o json clusters -l "$label_selector" \
+              | jq -r '.items[]|select(.spec.componentsOverride.apiserver.replicas==null) .metadata.name' \
+              > $ltmp/clusters
+
+            for cluster in $(< $ltmp/clusters ); do
+              echo "Found cluster $cluster without empty apiserver replicas spec. Setting $count replicas."
+
+              kubectl patch cluster $cluster \
+                --type=json \
+                -p='[{"op": "replace", "path": "/spec/componentsOverride/apiserver/replicas", "value":"'"$count"'"}]'
+            done
+          }
+
+          while true; do
+            syncrun "${DESIRED_REPLICAS:-3}" "$PROJECT_LIST"
+            sleep 5
+          done
+        envFrom:
+          - configMapRef:
+              name: component-override-controller-config
+        resources:
+          requests:
+            cpu: 10m
+            memory: 200M

--- a/addons/component-override-controller/coc-deployment.yaml
+++ b/addons/component-override-controller/coc-deployment.yaml
@@ -37,7 +37,7 @@ spec:
               > $ltmp/clusters
 
             for cluster in $(< $ltmp/clusters ); do
-              echo "Found cluster $cluster without empty apiserver replicas spec. Setting $count replicas."
+              echo "Found cluster $cluster with empty apiserver replicas spec. Setting $count replicas."
 
               kubectl patch cluster $cluster \
                 --type=json \


### PR DESCRIPTION
**What this PR does / why we need it**:

This PR adds a tiny controller which patches the spec.componentOverride.apiserver.replicas for clusters which do not have it set. Filtering by a label selector is support (e.g. for project-id).

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:


**Documentation**:
<!-- Add links to the related documentation changes related to this pull request. E.g. the link to the kubermatic/docs pullrequest. -->

**Does this PR introduce a user-facing change?**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If  no release note is required, just write "NONE".
-->
```release-note
NONE
```
