### PR TITLE
update Dex to 2.17.0

### DIFF
--- a/config/oauth/Chart.yaml
+++ b/config/oauth/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 name: oauth
-version: 1.0.3
-appVersion: v2.16.0
+version: 1.0.4
+appVersion: v2.17.0
 description: Dex
 keywords:
 - kubermatic

--- a/config/oauth/values.yaml
+++ b/config/oauth/values.yaml
@@ -1,7 +1,7 @@
 dex:
   image:
     repository: "quay.io/dexidp/dex"
-    tag: "v2.16.0"
+    tag: "v2.17.0"
   replicas: 2
   ingress:
     host: ""


### PR DESCRIPTION
**What this PR does / why we need it**:
This updates Dex to the latest stable version. See https://github.com/dexidp/dex/releases/tag/v2.17.0

**Does this PR introduce a user-facing change?**:
```release-note
update Dex to 2.17.0
```
