### PR TITLE
Add no credential endpoints for GCP

### DIFF
--- a/api/cmd/kubermatic-api/swagger.json
+++ b/api/cmd/kubermatic-api/swagger.json
@@ -1626,6 +1626,154 @@
         }
       }
     },
+    "/api/v1/projects/{project_id}/dc/{dc}/clusters/{cluster_id}/providers/gcp/disktypes": {
+      "get": {
+        "description": "Lists disk types from GCP",
+        "produces": [
+          "application/json"
+        ],
+        "tags": [
+          "gcp"
+        ],
+        "operationId": "listGCPDiskTypesNoCredentials",
+        "parameters": [
+          {
+            "type": "string",
+            "x-go-name": "ProjectID",
+            "name": "project_id",
+            "in": "path",
+            "required": true
+          },
+          {
+            "type": "string",
+            "x-go-name": "DC",
+            "name": "dc",
+            "in": "path",
+            "required": true
+          },
+          {
+            "type": "string",
+            "x-go-name": "ClusterID",
+            "name": "cluster_id",
+            "in": "path",
+            "required": true
+          },
+          {
+            "type": "string",
+            "name": "Zone",
+            "in": "header"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "GCPDiskTypeList",
+            "schema": {
+              "$ref": "#/definitions/GCPDiskTypeList"
+            }
+          },
+          "default": {
+            "$ref": "#/responses/errorResponse"
+          }
+        }
+      }
+    },
+    "/api/v1/projects/{project_id}/dc/{dc}/clusters/{cluster_id}/providers/gcp/sizes": {
+      "get": {
+        "description": "Lists machine sizes from GCP",
+        "produces": [
+          "application/json"
+        ],
+        "tags": [
+          "gcp"
+        ],
+        "operationId": "listGCPSizesNoCredentials",
+        "parameters": [
+          {
+            "type": "string",
+            "x-go-name": "ProjectID",
+            "name": "project_id",
+            "in": "path",
+            "required": true
+          },
+          {
+            "type": "string",
+            "x-go-name": "DC",
+            "name": "dc",
+            "in": "path",
+            "required": true
+          },
+          {
+            "type": "string",
+            "x-go-name": "ClusterID",
+            "name": "cluster_id",
+            "in": "path",
+            "required": true
+          },
+          {
+            "type": "string",
+            "name": "Zone",
+            "in": "header"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "GCPMachineSizeList",
+            "schema": {
+              "$ref": "#/definitions/GCPMachineSizeList"
+            }
+          },
+          "default": {
+            "$ref": "#/responses/errorResponse"
+          }
+        }
+      }
+    },
+    "/api/v1/projects/{project_id}/dc/{dc}/clusters/{cluster_id}/providers/gcp/{dc}/zones": {
+      "get": {
+        "description": "Lists available GCP zones",
+        "produces": [
+          "application/json"
+        ],
+        "tags": [
+          "gcp"
+        ],
+        "operationId": "listGCPZonesNoCredentials",
+        "parameters": [
+          {
+            "type": "string",
+            "x-go-name": "ProjectID",
+            "name": "project_id",
+            "in": "path",
+            "required": true
+          },
+          {
+            "type": "string",
+            "x-go-name": "DC",
+            "name": "dc",
+            "in": "path",
+            "required": true
+          },
+          {
+            "type": "string",
+            "x-go-name": "ClusterID",
+            "name": "cluster_id",
+            "in": "path",
+            "required": true
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "GCPZoneList",
+            "schema": {
+              "$ref": "#/definitions/GCPZoneList"
+            }
+          },
+          "default": {
+            "$ref": "#/responses/errorResponse"
+          }
+        }
+      }
+    },
     "/api/v1/projects/{project_id}/dc/{dc}/clusters/{cluster_id}/providers/openstack/networks": {
       "get": {
         "description": "Lists networks from openstack",
@@ -3061,7 +3209,7 @@
     },
     "/api/v1/providers/gcp/sizes": {
       "get": {
-        "description": "Lists machine types from GCP",
+        "description": "Lists machine sizes from GCP",
         "produces": [
           "application/json"
         ],

--- a/api/cmd/kubermatic-api/swagger.json
+++ b/api/cmd/kubermatic-api/swagger.json
@@ -1728,7 +1728,7 @@
         }
       }
     },
-    "/api/v1/projects/{project_id}/dc/{dc}/clusters/{cluster_id}/providers/gcp/{dc}/zones": {
+    "/api/v1/projects/{project_id}/dc/{dc}/clusters/{cluster_id}/providers/gcp/zones": {
       "get": {
         "description": "Lists available GCP zones",
         "produces": [

--- a/api/pkg/handler/routes_v1.go
+++ b/api/pkg/handler/routes_v1.go
@@ -237,7 +237,7 @@ func (r Routing) RegisterV1(mux *mux.Router, metrics common.ServerMetrics) {
 		Handler(r.listGCPSizesNoCredentials())
 
 	mux.Methods(http.MethodGet).
-		Path("/projects/{project_id}/dc/{dc}/clusters/{cluster_id}/providers/gcp/{dc}/zones").
+		Path("/projects/{project_id}/dc/{dc}/clusters/{cluster_id}/providers/gcp/zones").
 		Handler(r.listGCPZonesNoCredentials())
 
 	mux.Methods(http.MethodGet).
@@ -1760,7 +1760,7 @@ func (r Routing) listGCPDiskTypesNoCredentials() http.Handler {
 	)
 }
 
-// swagger:route GET /api/v1/projects/{project_id}/dc/{dc}/clusters/{cluster_id}/providers/gcp/{dc}/zones gcp listGCPZonesNoCredentials
+// swagger:route GET /api/v1/projects/{project_id}/dc/{dc}/clusters/{cluster_id}/providers/gcp/zones gcp listGCPZonesNoCredentials
 //
 // Lists available GCP zones
 //

--- a/api/pkg/handler/routes_v1.go
+++ b/api/pkg/handler/routes_v1.go
@@ -229,6 +229,18 @@ func (r Routing) RegisterV1(mux *mux.Router, metrics common.ServerMetrics) {
 	// Defines a set of HTTP endpoints for various cloud providers
 	// Note that these endpoints don't require credentials as opposed to the ones defined under /providers/*
 	mux.Methods(http.MethodGet).
+		Path("/projects/{project_id}/dc/{dc}/clusters/{cluster_id}/providers/gcp/disktypes").
+		Handler(r.listGCPDiskTypesNoCredentials())
+
+	mux.Methods(http.MethodGet).
+		Path("/projects/{project_id}/dc/{dc}/clusters/{cluster_id}/providers/gcp/sizes").
+		Handler(r.listGCPSizesNoCredentials())
+
+	mux.Methods(http.MethodGet).
+		Path("/projects/{project_id}/dc/{dc}/clusters/{cluster_id}/providers/gcp/{dc}/zones").
+		Handler(r.listGCPZonesNoCredentials())
+
+	mux.Methods(http.MethodGet).
 		Path("/projects/{project_id}/dc/{dc}/clusters/{cluster_id}/providers/digitalocean/sizes").
 		Handler(r.listDigitaloceanSizesNoCredentials())
 
@@ -456,7 +468,7 @@ func (r Routing) listGCPDiskTypes() http.Handler {
 
 // swagger:route GET /api/v1/providers/gcp/sizes gcp listGCPSizes
 //
-// Lists machine types from GCP
+// Lists machine sizes from GCP
 //
 //     Produces:
 //     - application/json
@@ -1695,6 +1707,78 @@ func (r Routing) deleteServiceAccountToken() http.Handler {
 			middleware.UserInfoExtractor(r.userProjectMapper),
 		)(serviceaccount.DeleteTokenEndpoint(r.projectProvider, r.serviceAccountProvider, r.serviceAccountTokenProvider)),
 		serviceaccount.DecodeDeleteTokenReq,
+		encodeJSON,
+		r.defaultServerOptions()...,
+	)
+}
+
+// swagger:route GET /api/v1/projects/{project_id}/dc/{dc}/clusters/{cluster_id}/providers/gcp/sizes gcp listGCPSizesNoCredentials
+//
+// Lists machine sizes from GCP
+//
+//     Produces:
+//     - application/json
+//
+//     Responses:
+//       default: errorResponse
+//       200: GCPMachineSizeList
+func (r Routing) listGCPSizesNoCredentials() http.Handler {
+	return httptransport.NewServer(
+		endpoint.Chain(
+			middleware.TokenVerifier(r.tokenVerifiers),
+			middleware.UserSaver(r.userProvider),
+			middleware.SetClusterProvider(r.clusterProviders, r.datacenters),
+			middleware.UserInfoExtractor(r.userProjectMapper),
+		)(provider.GCPSizeNoCredentialsEndpoint(r.projectProvider)),
+		provider.DecodeGCPTypesNoCredentialReq,
+		encodeJSON,
+		r.defaultServerOptions()...,
+	)
+}
+
+// swagger:route GET /api/v1/projects/{project_id}/dc/{dc}/clusters/{cluster_id}/providers/gcp/disktypes gcp listGCPDiskTypesNoCredentials
+//
+// Lists disk types from GCP
+//
+//     Produces:
+//     - application/json
+//
+//     Responses:
+//       default: errorResponse
+//       200: GCPDiskTypeList
+func (r Routing) listGCPDiskTypesNoCredentials() http.Handler {
+	return httptransport.NewServer(
+		endpoint.Chain(
+			middleware.TokenVerifier(r.tokenVerifiers),
+			middleware.UserSaver(r.userProvider),
+			middleware.SetClusterProvider(r.clusterProviders, r.datacenters),
+			middleware.UserInfoExtractor(r.userProjectMapper),
+		)(provider.GCPDiskTypesNoCredentialsEndpoint(r.projectProvider)),
+		provider.DecodeGCPTypesNoCredentialReq,
+		encodeJSON,
+		r.defaultServerOptions()...,
+	)
+}
+
+// swagger:route GET /api/v1/projects/{project_id}/dc/{dc}/clusters/{cluster_id}/providers/gcp/{dc}/zones gcp listGCPZonesNoCredentials
+//
+// Lists available GCP zones
+//
+//     Produces:
+//     - application/json
+//
+//     Responses:
+//       default: errorResponse
+//       200: GCPZoneList
+func (r Routing) listGCPZonesNoCredentials() http.Handler {
+	return httptransport.NewServer(
+		endpoint.Chain(
+			middleware.TokenVerifier(r.tokenVerifiers),
+			middleware.UserSaver(r.userProvider),
+			middleware.SetClusterProvider(r.clusterProviders, r.datacenters),
+			middleware.UserInfoExtractor(r.userProjectMapper),
+		)(provider.GCPZoneNoCredentialsEndpoint(r.projectProvider, r.datacenters)),
+		common.DecodeGetClusterReq,
 		encodeJSON,
 		r.defaultServerOptions()...,
 	)

--- a/api/pkg/handler/v1/common/request.go
+++ b/api/pkg/handler/v1/common/request.go
@@ -71,7 +71,7 @@ func DecodeDcReq(c context.Context, r *http.Request) (interface{}, error) {
 }
 
 // GetClusterReq defines HTTP request for deleteCluster and getClusterKubeconfig endpoints
-// swagger:parameters getCluster deleteCluster getClusterKubeconfig getClusterHealth getClusterUpgrades getClusterMetrics getClusterNodeUpgrades
+// swagger:parameters getCluster deleteCluster getClusterKubeconfig getClusterHealth getClusterUpgrades getClusterMetrics getClusterNodeUpgrades listGCPZonesNoCredentials
 type GetClusterReq struct {
 	DCReq
 	// in: path

--- a/api/pkg/handler/v1/provider/gcp.go
+++ b/api/pkg/handler/v1/provider/gcp.go
@@ -48,7 +48,7 @@ type GCPCommonReq struct {
 }
 
 // GCPTypesNoCredentialReq represent a request for GCP machine or disk types.
-// swagger:parameters listGCPSizesNoCredentials
+// swagger:parameters listGCPSizesNoCredentials listGCPDiskTypesNoCredentials
 type GCPTypesNoCredentialReq struct {
 	common.GetClusterReq
 	// in: header

--- a/api/pkg/handler/v1/provider/gcp.go
+++ b/api/pkg/handler/v1/provider/gcp.go
@@ -270,7 +270,7 @@ func GCPZoneEndpoint(credentialManager common.PresetsManager, dcs map[string]pro
 
 func GCPZoneNoCredentialsEndpoint(projectProvider provider.ProjectProvider, dcs map[string]provider.DatacenterMeta) endpoint.Endpoint {
 	return func(ctx context.Context, request interface{}) (interface{}, error) {
-		req := request.(GCPTypesNoCredentialReq)
+		req := request.(common.GetClusterReq)
 		clusterProvider := ctx.Value(middleware.ClusterProviderContextKey).(provider.ClusterProvider)
 		userInfo := ctx.Value(middleware.UserInfoContextKey).(*provider.UserInfo)
 		_, err := projectProvider.Get(userInfo, req.ProjectID, &provider.ProjectGetOptions{})
@@ -286,7 +286,7 @@ func GCPZoneNoCredentialsEndpoint(projectProvider provider.ProjectProvider, dcs 
 		}
 
 		sa := cluster.Spec.Cloud.GCP.ServiceAccount
-		return listGCPZones(ctx, sa, req.DC, dcs)
+		return listGCPZones(ctx, sa, cluster.Spec.Cloud.DatacenterName, dcs)
 	}
 }
 

--- a/api/pkg/handler/v1/provider/gcp.go
+++ b/api/pkg/handler/v1/provider/gcp.go
@@ -3,7 +3,6 @@ package provider
 import (
 	"context"
 	"fmt"
-	"github.com/kubermatic/kubermatic/api/pkg/handler/middleware"
 	"net/http"
 	"strings"
 
@@ -12,6 +11,7 @@ import (
 	"google.golang.org/api/compute/v1"
 
 	apiv1 "github.com/kubermatic/kubermatic/api/pkg/api/v1"
+	"github.com/kubermatic/kubermatic/api/pkg/handler/middleware"
 	"github.com/kubermatic/kubermatic/api/pkg/handler/v1/common"
 	"github.com/kubermatic/kubermatic/api/pkg/handler/v1/dc"
 	"github.com/kubermatic/kubermatic/api/pkg/provider"


### PR DESCRIPTION
**What this PR does / why we need it**: We need it to download data from GCP not only in the wizard but also from the cluster details page.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:

**Special notes for your reviewer**: Contuation of https://github.com/kubermatic/kubermatic/pull/3708.

Tested locally:
- [x] sizes
- [x] disk types
- [x] zones

**Documentation**:
<!-- Add links to the related documentation changes related to this pull request. E.g. the link to the kubermatic/docs pullrequest. -->

**Does this PR introduce a user-facing change?**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If  no release note is required, just write "NONE".
-->
```release-note
NONE
```
