### PR TITLE
Azure: Assign securityGroup to machines

### DIFF
--- a/api/Gopkg.lock
+++ b/api/Gopkg.lock
@@ -824,7 +824,7 @@
   version = "v0.1.0"
 
 [[projects]]
-  digest = "1:61d44fb0a79e4a90b568630a6b8565eefc2afc3dee02aaa9251789f60f52e01d"
+  digest = "1:e6f1ef7da43b73786c0f909ad8e9d27bfcfbaadb4532fd38a638376838d14e81"
   name = "github.com/kubermatic/machine-controller"
   packages = [
     "pkg/apis/plugin",
@@ -852,8 +852,8 @@
     "pkg/userdata/ubuntu",
   ]
   pruneopts = "NUT"
-  revision = "623acc8e9a15ad07c88af7b45f7fca9f9cce0164"
-  version = "v1.4.1"
+  revision = "33957631a6492cba7b205b7bbe0ec0e8ed9414a4"
+  version = "v1.4.2"
 
 [[projects]]
   digest = "1:0dbba7d4d4f3eeb01acd81af338ff4a3c4b0bb814d87368ea536e616f383240d"

--- a/api/Gopkg.toml
+++ b/api/Gopkg.toml
@@ -121,7 +121,7 @@ required = [
 
 [[override]]
   name = "github.com/kubermatic/machine-controller"
-  version = "v1.4.1"
+  version = "v1.4.2"
 
 [[override]]
   name = "sigs.k8s.io/controller-runtime"

--- a/api/pkg/resources/machine/common.go
+++ b/api/pkg/resources/machine/common.go
@@ -104,13 +104,14 @@ func getAzureProviderSpec(c *kubermaticv1.Cluster, nodeSpec apiv1.NodeSpec, dc p
 		ClientID:       providerconfig.ConfigVarString{Value: c.Spec.Cloud.Azure.ClientID},
 		ClientSecret:   providerconfig.ConfigVarString{Value: c.Spec.Cloud.Azure.ClientSecret},
 
-		Location:        providerconfig.ConfigVarString{Value: dc.Spec.Azure.Location},
-		ResourceGroup:   providerconfig.ConfigVarString{Value: c.Spec.Cloud.Azure.ResourceGroup},
-		VMSize:          providerconfig.ConfigVarString{Value: nodeSpec.Cloud.Azure.Size},
-		VNetName:        providerconfig.ConfigVarString{Value: c.Spec.Cloud.Azure.VNetName},
-		SubnetName:      providerconfig.ConfigVarString{Value: c.Spec.Cloud.Azure.SubnetName},
-		RouteTableName:  providerconfig.ConfigVarString{Value: c.Spec.Cloud.Azure.RouteTableName},
-		AvailabilitySet: providerconfig.ConfigVarString{Value: c.Spec.Cloud.Azure.AvailabilitySet},
+		Location:          providerconfig.ConfigVarString{Value: dc.Spec.Azure.Location},
+		ResourceGroup:     providerconfig.ConfigVarString{Value: c.Spec.Cloud.Azure.ResourceGroup},
+		VMSize:            providerconfig.ConfigVarString{Value: nodeSpec.Cloud.Azure.Size},
+		VNetName:          providerconfig.ConfigVarString{Value: c.Spec.Cloud.Azure.VNetName},
+		SubnetName:        providerconfig.ConfigVarString{Value: c.Spec.Cloud.Azure.SubnetName},
+		RouteTableName:    providerconfig.ConfigVarString{Value: c.Spec.Cloud.Azure.RouteTableName},
+		AvailabilitySet:   providerconfig.ConfigVarString{Value: c.Spec.Cloud.Azure.AvailabilitySet},
+		SecurityGroupName: providerconfig.ConfigVarString{Value: c.Spec.Cloud.Azure.SecurityGroup},
 
 		// Revisit when we have the DNAT topic complete and we can use private machines. Then we can use: node.Spec.Cloud.Azure.AssignPublicIP
 		AssignPublicIP: providerconfig.ConfigVarBool{Value: true},

--- a/api/pkg/resources/machinecontroller/deployment.go
+++ b/api/pkg/resources/machinecontroller/deployment.go
@@ -33,7 +33,7 @@ var (
 const (
 	Name = "machine-controller"
 
-	tag = "33957631a6492cba7b205b7bbe0ec0e8ed9414a4"
+	tag = "v1.4.2"
 
 	nodeLocalDNSCacheAddress = "169.254.20.10"
 )

--- a/api/pkg/resources/machinecontroller/deployment.go
+++ b/api/pkg/resources/machinecontroller/deployment.go
@@ -33,7 +33,7 @@ var (
 const (
 	Name = "machine-controller"
 
-	tag = "v1.4.1"
+	tag = "33957631a6492cba7b205b7bbe0ec0e8ed9414a4"
 
 	nodeLocalDNSCacheAddress = "169.254.20.10"
 )

--- a/api/pkg/resources/test/fixtures/deployment-aws-1.10.0-machine-controller-webhook.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-aws-1.10.0-machine-controller-webhook.yaml
@@ -38,7 +38,7 @@ spec:
           value: aws-access-key-id
         - name: AWS_SECRET_ACCESS_KEY
           value: aws-secret-access-key
-        image: docker.io/kubermatic/machine-controller:v1.4.1
+        image: docker.io/kubermatic/machine-controller:v1.4.2
         livenessProbe:
           failureThreshold: 8
           httpGet:

--- a/api/pkg/resources/test/fixtures/deployment-aws-1.10.0-machine-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-aws-1.10.0-machine-controller.yaml
@@ -43,7 +43,7 @@ spec:
           value: aws-access-key-id
         - name: AWS_SECRET_ACCESS_KEY
           value: aws-secret-access-key
-        image: docker.io/kubermatic/machine-controller:v1.4.1
+        image: docker.io/kubermatic/machine-controller:v1.4.2
         livenessProbe:
           failureThreshold: 3
           httpGet:

--- a/api/pkg/resources/test/fixtures/deployment-aws-1.10.6-machine-controller-webhook.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-aws-1.10.6-machine-controller-webhook.yaml
@@ -38,7 +38,7 @@ spec:
           value: aws-access-key-id
         - name: AWS_SECRET_ACCESS_KEY
           value: aws-secret-access-key
-        image: docker.io/kubermatic/machine-controller:v1.4.1
+        image: docker.io/kubermatic/machine-controller:v1.4.2
         livenessProbe:
           failureThreshold: 8
           httpGet:

--- a/api/pkg/resources/test/fixtures/deployment-aws-1.10.6-machine-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-aws-1.10.6-machine-controller.yaml
@@ -43,7 +43,7 @@ spec:
           value: aws-access-key-id
         - name: AWS_SECRET_ACCESS_KEY
           value: aws-secret-access-key
-        image: docker.io/kubermatic/machine-controller:v1.4.1
+        image: docker.io/kubermatic/machine-controller:v1.4.2
         livenessProbe:
           failureThreshold: 3
           httpGet:

--- a/api/pkg/resources/test/fixtures/deployment-aws-1.11.0-machine-controller-webhook.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-aws-1.11.0-machine-controller-webhook.yaml
@@ -38,7 +38,7 @@ spec:
           value: aws-access-key-id
         - name: AWS_SECRET_ACCESS_KEY
           value: aws-secret-access-key
-        image: docker.io/kubermatic/machine-controller:v1.4.1
+        image: docker.io/kubermatic/machine-controller:v1.4.2
         livenessProbe:
           failureThreshold: 8
           httpGet:

--- a/api/pkg/resources/test/fixtures/deployment-aws-1.11.0-machine-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-aws-1.11.0-machine-controller.yaml
@@ -43,7 +43,7 @@ spec:
           value: aws-access-key-id
         - name: AWS_SECRET_ACCESS_KEY
           value: aws-secret-access-key
-        image: docker.io/kubermatic/machine-controller:v1.4.1
+        image: docker.io/kubermatic/machine-controller:v1.4.2
         livenessProbe:
           failureThreshold: 3
           httpGet:

--- a/api/pkg/resources/test/fixtures/deployment-aws-1.11.1-machine-controller-webhook.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-aws-1.11.1-machine-controller-webhook.yaml
@@ -38,7 +38,7 @@ spec:
           value: aws-access-key-id
         - name: AWS_SECRET_ACCESS_KEY
           value: aws-secret-access-key
-        image: docker.io/kubermatic/machine-controller:v1.4.1
+        image: docker.io/kubermatic/machine-controller:v1.4.2
         livenessProbe:
           failureThreshold: 8
           httpGet:

--- a/api/pkg/resources/test/fixtures/deployment-aws-1.11.1-machine-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-aws-1.11.1-machine-controller.yaml
@@ -43,7 +43,7 @@ spec:
           value: aws-access-key-id
         - name: AWS_SECRET_ACCESS_KEY
           value: aws-secret-access-key
-        image: docker.io/kubermatic/machine-controller:v1.4.1
+        image: docker.io/kubermatic/machine-controller:v1.4.2
         livenessProbe:
           failureThreshold: 3
           httpGet:

--- a/api/pkg/resources/test/fixtures/deployment-aws-1.12.0-machine-controller-webhook.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-aws-1.12.0-machine-controller-webhook.yaml
@@ -38,7 +38,7 @@ spec:
           value: aws-access-key-id
         - name: AWS_SECRET_ACCESS_KEY
           value: aws-secret-access-key
-        image: docker.io/kubermatic/machine-controller:v1.4.1
+        image: docker.io/kubermatic/machine-controller:v1.4.2
         livenessProbe:
           failureThreshold: 8
           httpGet:

--- a/api/pkg/resources/test/fixtures/deployment-aws-1.12.0-machine-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-aws-1.12.0-machine-controller.yaml
@@ -43,7 +43,7 @@ spec:
           value: aws-access-key-id
         - name: AWS_SECRET_ACCESS_KEY
           value: aws-secret-access-key
-        image: docker.io/kubermatic/machine-controller:v1.4.1
+        image: docker.io/kubermatic/machine-controller:v1.4.2
         livenessProbe:
           failureThreshold: 3
           httpGet:

--- a/api/pkg/resources/test/fixtures/deployment-aws-1.13.0-machine-controller-webhook.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-aws-1.13.0-machine-controller-webhook.yaml
@@ -38,7 +38,7 @@ spec:
           value: aws-access-key-id
         - name: AWS_SECRET_ACCESS_KEY
           value: aws-secret-access-key
-        image: docker.io/kubermatic/machine-controller:v1.4.1
+        image: docker.io/kubermatic/machine-controller:v1.4.2
         livenessProbe:
           failureThreshold: 8
           httpGet:

--- a/api/pkg/resources/test/fixtures/deployment-aws-1.13.0-machine-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-aws-1.13.0-machine-controller.yaml
@@ -43,7 +43,7 @@ spec:
           value: aws-access-key-id
         - name: AWS_SECRET_ACCESS_KEY
           value: aws-secret-access-key
-        image: docker.io/kubermatic/machine-controller:v1.4.1
+        image: docker.io/kubermatic/machine-controller:v1.4.2
         livenessProbe:
           failureThreshold: 3
           httpGet:

--- a/api/pkg/resources/test/fixtures/deployment-azure-1.10.0-machine-controller-webhook.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-azure-1.10.0-machine-controller-webhook.yaml
@@ -33,7 +33,7 @@ spec:
         - 0.0.0.0:9876
         command:
         - /usr/local/bin/webhook
-        image: docker.io/kubermatic/machine-controller:v1.4.1
+        image: docker.io/kubermatic/machine-controller:v1.4.2
         livenessProbe:
           failureThreshold: 8
           httpGet:

--- a/api/pkg/resources/test/fixtures/deployment-azure-1.10.0-machine-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-azure-1.10.0-machine-controller.yaml
@@ -38,7 +38,7 @@ spec:
         - 0.0.0.0:8085
         command:
         - /usr/local/bin/machine-controller
-        image: docker.io/kubermatic/machine-controller:v1.4.1
+        image: docker.io/kubermatic/machine-controller:v1.4.2
         livenessProbe:
           failureThreshold: 3
           httpGet:

--- a/api/pkg/resources/test/fixtures/deployment-azure-1.10.6-machine-controller-webhook.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-azure-1.10.6-machine-controller-webhook.yaml
@@ -33,7 +33,7 @@ spec:
         - 0.0.0.0:9876
         command:
         - /usr/local/bin/webhook
-        image: docker.io/kubermatic/machine-controller:v1.4.1
+        image: docker.io/kubermatic/machine-controller:v1.4.2
         livenessProbe:
           failureThreshold: 8
           httpGet:

--- a/api/pkg/resources/test/fixtures/deployment-azure-1.10.6-machine-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-azure-1.10.6-machine-controller.yaml
@@ -38,7 +38,7 @@ spec:
         - 0.0.0.0:8085
         command:
         - /usr/local/bin/machine-controller
-        image: docker.io/kubermatic/machine-controller:v1.4.1
+        image: docker.io/kubermatic/machine-controller:v1.4.2
         livenessProbe:
           failureThreshold: 3
           httpGet:

--- a/api/pkg/resources/test/fixtures/deployment-azure-1.11.0-machine-controller-webhook.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-azure-1.11.0-machine-controller-webhook.yaml
@@ -33,7 +33,7 @@ spec:
         - 0.0.0.0:9876
         command:
         - /usr/local/bin/webhook
-        image: docker.io/kubermatic/machine-controller:v1.4.1
+        image: docker.io/kubermatic/machine-controller:v1.4.2
         livenessProbe:
           failureThreshold: 8
           httpGet:

--- a/api/pkg/resources/test/fixtures/deployment-azure-1.11.0-machine-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-azure-1.11.0-machine-controller.yaml
@@ -38,7 +38,7 @@ spec:
         - 0.0.0.0:8085
         command:
         - /usr/local/bin/machine-controller
-        image: docker.io/kubermatic/machine-controller:v1.4.1
+        image: docker.io/kubermatic/machine-controller:v1.4.2
         livenessProbe:
           failureThreshold: 3
           httpGet:

--- a/api/pkg/resources/test/fixtures/deployment-azure-1.11.1-machine-controller-webhook.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-azure-1.11.1-machine-controller-webhook.yaml
@@ -33,7 +33,7 @@ spec:
         - 0.0.0.0:9876
         command:
         - /usr/local/bin/webhook
-        image: docker.io/kubermatic/machine-controller:v1.4.1
+        image: docker.io/kubermatic/machine-controller:v1.4.2
         livenessProbe:
           failureThreshold: 8
           httpGet:

--- a/api/pkg/resources/test/fixtures/deployment-azure-1.11.1-machine-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-azure-1.11.1-machine-controller.yaml
@@ -38,7 +38,7 @@ spec:
         - 0.0.0.0:8085
         command:
         - /usr/local/bin/machine-controller
-        image: docker.io/kubermatic/machine-controller:v1.4.1
+        image: docker.io/kubermatic/machine-controller:v1.4.2
         livenessProbe:
           failureThreshold: 3
           httpGet:

--- a/api/pkg/resources/test/fixtures/deployment-azure-1.12.0-machine-controller-webhook.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-azure-1.12.0-machine-controller-webhook.yaml
@@ -33,7 +33,7 @@ spec:
         - 0.0.0.0:9876
         command:
         - /usr/local/bin/webhook
-        image: docker.io/kubermatic/machine-controller:v1.4.1
+        image: docker.io/kubermatic/machine-controller:v1.4.2
         livenessProbe:
           failureThreshold: 8
           httpGet:

--- a/api/pkg/resources/test/fixtures/deployment-azure-1.12.0-machine-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-azure-1.12.0-machine-controller.yaml
@@ -38,7 +38,7 @@ spec:
         - 0.0.0.0:8085
         command:
         - /usr/local/bin/machine-controller
-        image: docker.io/kubermatic/machine-controller:v1.4.1
+        image: docker.io/kubermatic/machine-controller:v1.4.2
         livenessProbe:
           failureThreshold: 3
           httpGet:

--- a/api/pkg/resources/test/fixtures/deployment-azure-1.13.0-machine-controller-webhook.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-azure-1.13.0-machine-controller-webhook.yaml
@@ -33,7 +33,7 @@ spec:
         - 0.0.0.0:9876
         command:
         - /usr/local/bin/webhook
-        image: docker.io/kubermatic/machine-controller:v1.4.1
+        image: docker.io/kubermatic/machine-controller:v1.4.2
         livenessProbe:
           failureThreshold: 8
           httpGet:

--- a/api/pkg/resources/test/fixtures/deployment-azure-1.13.0-machine-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-azure-1.13.0-machine-controller.yaml
@@ -38,7 +38,7 @@ spec:
         - 0.0.0.0:8085
         command:
         - /usr/local/bin/machine-controller
-        image: docker.io/kubermatic/machine-controller:v1.4.1
+        image: docker.io/kubermatic/machine-controller:v1.4.2
         livenessProbe:
           failureThreshold: 3
           httpGet:

--- a/api/pkg/resources/test/fixtures/deployment-bringyourown-1.10.0-machine-controller-webhook.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-bringyourown-1.10.0-machine-controller-webhook.yaml
@@ -33,7 +33,7 @@ spec:
         - 0.0.0.0:9876
         command:
         - /usr/local/bin/webhook
-        image: docker.io/kubermatic/machine-controller:v1.4.1
+        image: docker.io/kubermatic/machine-controller:v1.4.2
         livenessProbe:
           failureThreshold: 8
           httpGet:

--- a/api/pkg/resources/test/fixtures/deployment-bringyourown-1.10.0-machine-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-bringyourown-1.10.0-machine-controller.yaml
@@ -38,7 +38,7 @@ spec:
         - 0.0.0.0:8085
         command:
         - /usr/local/bin/machine-controller
-        image: docker.io/kubermatic/machine-controller:v1.4.1
+        image: docker.io/kubermatic/machine-controller:v1.4.2
         livenessProbe:
           failureThreshold: 3
           httpGet:

--- a/api/pkg/resources/test/fixtures/deployment-bringyourown-1.10.6-machine-controller-webhook.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-bringyourown-1.10.6-machine-controller-webhook.yaml
@@ -33,7 +33,7 @@ spec:
         - 0.0.0.0:9876
         command:
         - /usr/local/bin/webhook
-        image: docker.io/kubermatic/machine-controller:v1.4.1
+        image: docker.io/kubermatic/machine-controller:v1.4.2
         livenessProbe:
           failureThreshold: 8
           httpGet:

--- a/api/pkg/resources/test/fixtures/deployment-bringyourown-1.10.6-machine-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-bringyourown-1.10.6-machine-controller.yaml
@@ -38,7 +38,7 @@ spec:
         - 0.0.0.0:8085
         command:
         - /usr/local/bin/machine-controller
-        image: docker.io/kubermatic/machine-controller:v1.4.1
+        image: docker.io/kubermatic/machine-controller:v1.4.2
         livenessProbe:
           failureThreshold: 3
           httpGet:

--- a/api/pkg/resources/test/fixtures/deployment-bringyourown-1.11.0-machine-controller-webhook.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-bringyourown-1.11.0-machine-controller-webhook.yaml
@@ -33,7 +33,7 @@ spec:
         - 0.0.0.0:9876
         command:
         - /usr/local/bin/webhook
-        image: docker.io/kubermatic/machine-controller:v1.4.1
+        image: docker.io/kubermatic/machine-controller:v1.4.2
         livenessProbe:
           failureThreshold: 8
           httpGet:

--- a/api/pkg/resources/test/fixtures/deployment-bringyourown-1.11.0-machine-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-bringyourown-1.11.0-machine-controller.yaml
@@ -38,7 +38,7 @@ spec:
         - 0.0.0.0:8085
         command:
         - /usr/local/bin/machine-controller
-        image: docker.io/kubermatic/machine-controller:v1.4.1
+        image: docker.io/kubermatic/machine-controller:v1.4.2
         livenessProbe:
           failureThreshold: 3
           httpGet:

--- a/api/pkg/resources/test/fixtures/deployment-bringyourown-1.11.1-machine-controller-webhook.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-bringyourown-1.11.1-machine-controller-webhook.yaml
@@ -33,7 +33,7 @@ spec:
         - 0.0.0.0:9876
         command:
         - /usr/local/bin/webhook
-        image: docker.io/kubermatic/machine-controller:v1.4.1
+        image: docker.io/kubermatic/machine-controller:v1.4.2
         livenessProbe:
           failureThreshold: 8
           httpGet:

--- a/api/pkg/resources/test/fixtures/deployment-bringyourown-1.11.1-machine-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-bringyourown-1.11.1-machine-controller.yaml
@@ -38,7 +38,7 @@ spec:
         - 0.0.0.0:8085
         command:
         - /usr/local/bin/machine-controller
-        image: docker.io/kubermatic/machine-controller:v1.4.1
+        image: docker.io/kubermatic/machine-controller:v1.4.2
         livenessProbe:
           failureThreshold: 3
           httpGet:

--- a/api/pkg/resources/test/fixtures/deployment-bringyourown-1.12.0-machine-controller-webhook.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-bringyourown-1.12.0-machine-controller-webhook.yaml
@@ -33,7 +33,7 @@ spec:
         - 0.0.0.0:9876
         command:
         - /usr/local/bin/webhook
-        image: docker.io/kubermatic/machine-controller:v1.4.1
+        image: docker.io/kubermatic/machine-controller:v1.4.2
         livenessProbe:
           failureThreshold: 8
           httpGet:

--- a/api/pkg/resources/test/fixtures/deployment-bringyourown-1.12.0-machine-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-bringyourown-1.12.0-machine-controller.yaml
@@ -38,7 +38,7 @@ spec:
         - 0.0.0.0:8085
         command:
         - /usr/local/bin/machine-controller
-        image: docker.io/kubermatic/machine-controller:v1.4.1
+        image: docker.io/kubermatic/machine-controller:v1.4.2
         livenessProbe:
           failureThreshold: 3
           httpGet:

--- a/api/pkg/resources/test/fixtures/deployment-bringyourown-1.13.0-machine-controller-webhook.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-bringyourown-1.13.0-machine-controller-webhook.yaml
@@ -33,7 +33,7 @@ spec:
         - 0.0.0.0:9876
         command:
         - /usr/local/bin/webhook
-        image: docker.io/kubermatic/machine-controller:v1.4.1
+        image: docker.io/kubermatic/machine-controller:v1.4.2
         livenessProbe:
           failureThreshold: 8
           httpGet:

--- a/api/pkg/resources/test/fixtures/deployment-bringyourown-1.13.0-machine-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-bringyourown-1.13.0-machine-controller.yaml
@@ -38,7 +38,7 @@ spec:
         - 0.0.0.0:8085
         command:
         - /usr/local/bin/machine-controller
-        image: docker.io/kubermatic/machine-controller:v1.4.1
+        image: docker.io/kubermatic/machine-controller:v1.4.2
         livenessProbe:
           failureThreshold: 3
           httpGet:

--- a/api/pkg/resources/test/fixtures/deployment-digitalocean-1.10.0-machine-controller-webhook.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-digitalocean-1.10.0-machine-controller-webhook.yaml
@@ -36,7 +36,7 @@ spec:
         env:
         - name: DO_TOKEN
           value: do-token
-        image: docker.io/kubermatic/machine-controller:v1.4.1
+        image: docker.io/kubermatic/machine-controller:v1.4.2
         livenessProbe:
           failureThreshold: 8
           httpGet:

--- a/api/pkg/resources/test/fixtures/deployment-digitalocean-1.10.0-machine-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-digitalocean-1.10.0-machine-controller.yaml
@@ -41,7 +41,7 @@ spec:
         env:
         - name: DO_TOKEN
           value: do-token
-        image: docker.io/kubermatic/machine-controller:v1.4.1
+        image: docker.io/kubermatic/machine-controller:v1.4.2
         livenessProbe:
           failureThreshold: 3
           httpGet:

--- a/api/pkg/resources/test/fixtures/deployment-digitalocean-1.10.6-machine-controller-webhook.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-digitalocean-1.10.6-machine-controller-webhook.yaml
@@ -36,7 +36,7 @@ spec:
         env:
         - name: DO_TOKEN
           value: do-token
-        image: docker.io/kubermatic/machine-controller:v1.4.1
+        image: docker.io/kubermatic/machine-controller:v1.4.2
         livenessProbe:
           failureThreshold: 8
           httpGet:

--- a/api/pkg/resources/test/fixtures/deployment-digitalocean-1.10.6-machine-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-digitalocean-1.10.6-machine-controller.yaml
@@ -41,7 +41,7 @@ spec:
         env:
         - name: DO_TOKEN
           value: do-token
-        image: docker.io/kubermatic/machine-controller:v1.4.1
+        image: docker.io/kubermatic/machine-controller:v1.4.2
         livenessProbe:
           failureThreshold: 3
           httpGet:

--- a/api/pkg/resources/test/fixtures/deployment-digitalocean-1.11.0-machine-controller-webhook.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-digitalocean-1.11.0-machine-controller-webhook.yaml
@@ -36,7 +36,7 @@ spec:
         env:
         - name: DO_TOKEN
           value: do-token
-        image: docker.io/kubermatic/machine-controller:v1.4.1
+        image: docker.io/kubermatic/machine-controller:v1.4.2
         livenessProbe:
           failureThreshold: 8
           httpGet:

--- a/api/pkg/resources/test/fixtures/deployment-digitalocean-1.11.0-machine-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-digitalocean-1.11.0-machine-controller.yaml
@@ -41,7 +41,7 @@ spec:
         env:
         - name: DO_TOKEN
           value: do-token
-        image: docker.io/kubermatic/machine-controller:v1.4.1
+        image: docker.io/kubermatic/machine-controller:v1.4.2
         livenessProbe:
           failureThreshold: 3
           httpGet:

--- a/api/pkg/resources/test/fixtures/deployment-digitalocean-1.11.1-machine-controller-webhook.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-digitalocean-1.11.1-machine-controller-webhook.yaml
@@ -36,7 +36,7 @@ spec:
         env:
         - name: DO_TOKEN
           value: do-token
-        image: docker.io/kubermatic/machine-controller:v1.4.1
+        image: docker.io/kubermatic/machine-controller:v1.4.2
         livenessProbe:
           failureThreshold: 8
           httpGet:

--- a/api/pkg/resources/test/fixtures/deployment-digitalocean-1.11.1-machine-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-digitalocean-1.11.1-machine-controller.yaml
@@ -41,7 +41,7 @@ spec:
         env:
         - name: DO_TOKEN
           value: do-token
-        image: docker.io/kubermatic/machine-controller:v1.4.1
+        image: docker.io/kubermatic/machine-controller:v1.4.2
         livenessProbe:
           failureThreshold: 3
           httpGet:

--- a/api/pkg/resources/test/fixtures/deployment-digitalocean-1.12.0-machine-controller-webhook.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-digitalocean-1.12.0-machine-controller-webhook.yaml
@@ -36,7 +36,7 @@ spec:
         env:
         - name: DO_TOKEN
           value: do-token
-        image: docker.io/kubermatic/machine-controller:v1.4.1
+        image: docker.io/kubermatic/machine-controller:v1.4.2
         livenessProbe:
           failureThreshold: 8
           httpGet:

--- a/api/pkg/resources/test/fixtures/deployment-digitalocean-1.12.0-machine-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-digitalocean-1.12.0-machine-controller.yaml
@@ -41,7 +41,7 @@ spec:
         env:
         - name: DO_TOKEN
           value: do-token
-        image: docker.io/kubermatic/machine-controller:v1.4.1
+        image: docker.io/kubermatic/machine-controller:v1.4.2
         livenessProbe:
           failureThreshold: 3
           httpGet:

--- a/api/pkg/resources/test/fixtures/deployment-digitalocean-1.13.0-machine-controller-webhook.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-digitalocean-1.13.0-machine-controller-webhook.yaml
@@ -36,7 +36,7 @@ spec:
         env:
         - name: DO_TOKEN
           value: do-token
-        image: docker.io/kubermatic/machine-controller:v1.4.1
+        image: docker.io/kubermatic/machine-controller:v1.4.2
         livenessProbe:
           failureThreshold: 8
           httpGet:

--- a/api/pkg/resources/test/fixtures/deployment-digitalocean-1.13.0-machine-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-digitalocean-1.13.0-machine-controller.yaml
@@ -41,7 +41,7 @@ spec:
         env:
         - name: DO_TOKEN
           value: do-token
-        image: docker.io/kubermatic/machine-controller:v1.4.1
+        image: docker.io/kubermatic/machine-controller:v1.4.2
         livenessProbe:
           failureThreshold: 3
           httpGet:

--- a/api/pkg/resources/test/fixtures/deployment-openstack-1.10.0-machine-controller-webhook.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-openstack-1.10.0-machine-controller-webhook.yaml
@@ -45,7 +45,7 @@ spec:
         - name: OS_TENANT_NAME
           value: openstack-tenant
         - name: OS_TENANT_ID
-        image: docker.io/kubermatic/machine-controller:v1.4.1
+        image: docker.io/kubermatic/machine-controller:v1.4.2
         livenessProbe:
           failureThreshold: 8
           httpGet:

--- a/api/pkg/resources/test/fixtures/deployment-openstack-1.10.0-machine-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-openstack-1.10.0-machine-controller.yaml
@@ -50,7 +50,7 @@ spec:
         - name: OS_TENANT_NAME
           value: openstack-tenant
         - name: OS_TENANT_ID
-        image: docker.io/kubermatic/machine-controller:v1.4.1
+        image: docker.io/kubermatic/machine-controller:v1.4.2
         livenessProbe:
           failureThreshold: 3
           httpGet:

--- a/api/pkg/resources/test/fixtures/deployment-openstack-1.10.6-machine-controller-webhook.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-openstack-1.10.6-machine-controller-webhook.yaml
@@ -45,7 +45,7 @@ spec:
         - name: OS_TENANT_NAME
           value: openstack-tenant
         - name: OS_TENANT_ID
-        image: docker.io/kubermatic/machine-controller:v1.4.1
+        image: docker.io/kubermatic/machine-controller:v1.4.2
         livenessProbe:
           failureThreshold: 8
           httpGet:

--- a/api/pkg/resources/test/fixtures/deployment-openstack-1.10.6-machine-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-openstack-1.10.6-machine-controller.yaml
@@ -50,7 +50,7 @@ spec:
         - name: OS_TENANT_NAME
           value: openstack-tenant
         - name: OS_TENANT_ID
-        image: docker.io/kubermatic/machine-controller:v1.4.1
+        image: docker.io/kubermatic/machine-controller:v1.4.2
         livenessProbe:
           failureThreshold: 3
           httpGet:

--- a/api/pkg/resources/test/fixtures/deployment-openstack-1.11.0-machine-controller-webhook.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-openstack-1.11.0-machine-controller-webhook.yaml
@@ -45,7 +45,7 @@ spec:
         - name: OS_TENANT_NAME
           value: openstack-tenant
         - name: OS_TENANT_ID
-        image: docker.io/kubermatic/machine-controller:v1.4.1
+        image: docker.io/kubermatic/machine-controller:v1.4.2
         livenessProbe:
           failureThreshold: 8
           httpGet:

--- a/api/pkg/resources/test/fixtures/deployment-openstack-1.11.0-machine-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-openstack-1.11.0-machine-controller.yaml
@@ -50,7 +50,7 @@ spec:
         - name: OS_TENANT_NAME
           value: openstack-tenant
         - name: OS_TENANT_ID
-        image: docker.io/kubermatic/machine-controller:v1.4.1
+        image: docker.io/kubermatic/machine-controller:v1.4.2
         livenessProbe:
           failureThreshold: 3
           httpGet:

--- a/api/pkg/resources/test/fixtures/deployment-openstack-1.11.1-machine-controller-webhook.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-openstack-1.11.1-machine-controller-webhook.yaml
@@ -45,7 +45,7 @@ spec:
         - name: OS_TENANT_NAME
           value: openstack-tenant
         - name: OS_TENANT_ID
-        image: docker.io/kubermatic/machine-controller:v1.4.1
+        image: docker.io/kubermatic/machine-controller:v1.4.2
         livenessProbe:
           failureThreshold: 8
           httpGet:

--- a/api/pkg/resources/test/fixtures/deployment-openstack-1.11.1-machine-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-openstack-1.11.1-machine-controller.yaml
@@ -50,7 +50,7 @@ spec:
         - name: OS_TENANT_NAME
           value: openstack-tenant
         - name: OS_TENANT_ID
-        image: docker.io/kubermatic/machine-controller:v1.4.1
+        image: docker.io/kubermatic/machine-controller:v1.4.2
         livenessProbe:
           failureThreshold: 3
           httpGet:

--- a/api/pkg/resources/test/fixtures/deployment-openstack-1.12.0-machine-controller-webhook.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-openstack-1.12.0-machine-controller-webhook.yaml
@@ -45,7 +45,7 @@ spec:
         - name: OS_TENANT_NAME
           value: openstack-tenant
         - name: OS_TENANT_ID
-        image: docker.io/kubermatic/machine-controller:v1.4.1
+        image: docker.io/kubermatic/machine-controller:v1.4.2
         livenessProbe:
           failureThreshold: 8
           httpGet:

--- a/api/pkg/resources/test/fixtures/deployment-openstack-1.12.0-machine-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-openstack-1.12.0-machine-controller.yaml
@@ -50,7 +50,7 @@ spec:
         - name: OS_TENANT_NAME
           value: openstack-tenant
         - name: OS_TENANT_ID
-        image: docker.io/kubermatic/machine-controller:v1.4.1
+        image: docker.io/kubermatic/machine-controller:v1.4.2
         livenessProbe:
           failureThreshold: 3
           httpGet:

--- a/api/pkg/resources/test/fixtures/deployment-openstack-1.13.0-machine-controller-webhook.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-openstack-1.13.0-machine-controller-webhook.yaml
@@ -45,7 +45,7 @@ spec:
         - name: OS_TENANT_NAME
           value: openstack-tenant
         - name: OS_TENANT_ID
-        image: docker.io/kubermatic/machine-controller:v1.4.1
+        image: docker.io/kubermatic/machine-controller:v1.4.2
         livenessProbe:
           failureThreshold: 8
           httpGet:

--- a/api/pkg/resources/test/fixtures/deployment-openstack-1.13.0-machine-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-openstack-1.13.0-machine-controller.yaml
@@ -50,7 +50,7 @@ spec:
         - name: OS_TENANT_NAME
           value: openstack-tenant
         - name: OS_TENANT_ID
-        image: docker.io/kubermatic/machine-controller:v1.4.1
+        image: docker.io/kubermatic/machine-controller:v1.4.2
         livenessProbe:
           failureThreshold: 3
           httpGet:

--- a/api/pkg/resources/test/fixtures/deployment-vsphere-1.10.0-machine-controller-webhook.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-vsphere-1.10.0-machine-controller-webhook.yaml
@@ -38,7 +38,7 @@ spec:
           value: https://vs-endpoint.io
         - name: VSPHERE_USERNAME
         - name: VSPHERE_PASSWORD
-        image: docker.io/kubermatic/machine-controller:v1.4.1
+        image: docker.io/kubermatic/machine-controller:v1.4.2
         livenessProbe:
           failureThreshold: 8
           httpGet:

--- a/api/pkg/resources/test/fixtures/deployment-vsphere-1.10.0-machine-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-vsphere-1.10.0-machine-controller.yaml
@@ -43,7 +43,7 @@ spec:
           value: https://vs-endpoint.io
         - name: VSPHERE_USERNAME
         - name: VSPHERE_PASSWORD
-        image: docker.io/kubermatic/machine-controller:v1.4.1
+        image: docker.io/kubermatic/machine-controller:v1.4.2
         livenessProbe:
           failureThreshold: 3
           httpGet:

--- a/api/pkg/resources/test/fixtures/deployment-vsphere-1.10.6-machine-controller-webhook.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-vsphere-1.10.6-machine-controller-webhook.yaml
@@ -38,7 +38,7 @@ spec:
           value: https://vs-endpoint.io
         - name: VSPHERE_USERNAME
         - name: VSPHERE_PASSWORD
-        image: docker.io/kubermatic/machine-controller:v1.4.1
+        image: docker.io/kubermatic/machine-controller:v1.4.2
         livenessProbe:
           failureThreshold: 8
           httpGet:

--- a/api/pkg/resources/test/fixtures/deployment-vsphere-1.10.6-machine-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-vsphere-1.10.6-machine-controller.yaml
@@ -43,7 +43,7 @@ spec:
           value: https://vs-endpoint.io
         - name: VSPHERE_USERNAME
         - name: VSPHERE_PASSWORD
-        image: docker.io/kubermatic/machine-controller:v1.4.1
+        image: docker.io/kubermatic/machine-controller:v1.4.2
         livenessProbe:
           failureThreshold: 3
           httpGet:

--- a/api/pkg/resources/test/fixtures/deployment-vsphere-1.11.0-machine-controller-webhook.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-vsphere-1.11.0-machine-controller-webhook.yaml
@@ -38,7 +38,7 @@ spec:
           value: https://vs-endpoint.io
         - name: VSPHERE_USERNAME
         - name: VSPHERE_PASSWORD
-        image: docker.io/kubermatic/machine-controller:v1.4.1
+        image: docker.io/kubermatic/machine-controller:v1.4.2
         livenessProbe:
           failureThreshold: 8
           httpGet:

--- a/api/pkg/resources/test/fixtures/deployment-vsphere-1.11.0-machine-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-vsphere-1.11.0-machine-controller.yaml
@@ -43,7 +43,7 @@ spec:
           value: https://vs-endpoint.io
         - name: VSPHERE_USERNAME
         - name: VSPHERE_PASSWORD
-        image: docker.io/kubermatic/machine-controller:v1.4.1
+        image: docker.io/kubermatic/machine-controller:v1.4.2
         livenessProbe:
           failureThreshold: 3
           httpGet:

--- a/api/pkg/resources/test/fixtures/deployment-vsphere-1.11.1-machine-controller-webhook.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-vsphere-1.11.1-machine-controller-webhook.yaml
@@ -38,7 +38,7 @@ spec:
           value: https://vs-endpoint.io
         - name: VSPHERE_USERNAME
         - name: VSPHERE_PASSWORD
-        image: docker.io/kubermatic/machine-controller:v1.4.1
+        image: docker.io/kubermatic/machine-controller:v1.4.2
         livenessProbe:
           failureThreshold: 8
           httpGet:

--- a/api/pkg/resources/test/fixtures/deployment-vsphere-1.11.1-machine-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-vsphere-1.11.1-machine-controller.yaml
@@ -43,7 +43,7 @@ spec:
           value: https://vs-endpoint.io
         - name: VSPHERE_USERNAME
         - name: VSPHERE_PASSWORD
-        image: docker.io/kubermatic/machine-controller:v1.4.1
+        image: docker.io/kubermatic/machine-controller:v1.4.2
         livenessProbe:
           failureThreshold: 3
           httpGet:

--- a/api/pkg/resources/test/fixtures/deployment-vsphere-1.12.0-machine-controller-webhook.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-vsphere-1.12.0-machine-controller-webhook.yaml
@@ -38,7 +38,7 @@ spec:
           value: https://vs-endpoint.io
         - name: VSPHERE_USERNAME
         - name: VSPHERE_PASSWORD
-        image: docker.io/kubermatic/machine-controller:v1.4.1
+        image: docker.io/kubermatic/machine-controller:v1.4.2
         livenessProbe:
           failureThreshold: 8
           httpGet:

--- a/api/pkg/resources/test/fixtures/deployment-vsphere-1.12.0-machine-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-vsphere-1.12.0-machine-controller.yaml
@@ -43,7 +43,7 @@ spec:
           value: https://vs-endpoint.io
         - name: VSPHERE_USERNAME
         - name: VSPHERE_PASSWORD
-        image: docker.io/kubermatic/machine-controller:v1.4.1
+        image: docker.io/kubermatic/machine-controller:v1.4.2
         livenessProbe:
           failureThreshold: 3
           httpGet:

--- a/api/pkg/resources/test/fixtures/deployment-vsphere-1.13.0-machine-controller-webhook.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-vsphere-1.13.0-machine-controller-webhook.yaml
@@ -38,7 +38,7 @@ spec:
           value: https://vs-endpoint.io
         - name: VSPHERE_USERNAME
         - name: VSPHERE_PASSWORD
-        image: docker.io/kubermatic/machine-controller:v1.4.1
+        image: docker.io/kubermatic/machine-controller:v1.4.2
         livenessProbe:
           failureThreshold: 8
           httpGet:

--- a/api/pkg/resources/test/fixtures/deployment-vsphere-1.13.0-machine-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-vsphere-1.13.0-machine-controller.yaml
@@ -43,7 +43,7 @@ spec:
           value: https://vs-endpoint.io
         - name: VSPHERE_USERNAME
         - name: VSPHERE_PASSWORD
-        image: docker.io/kubermatic/machine-controller:v1.4.1
+        image: docker.io/kubermatic/machine-controller:v1.4.2
         livenessProbe:
           failureThreshold: 3
           httpGet:

--- a/api/pkg/resources/test/fixtures/machine-openstack.yaml
+++ b/api/pkg/resources/test/fixtures/machine-openstack.yaml
@@ -16,6 +16,7 @@ spec:
         identityEndpoint: os-auth-url
         image: os-image
         network: os-network
+        nodeVolumeAttachLimit: null
         password: ""
         region: os-region
         rootDiskSizeGB: null

--- a/api/vendor/github.com/kubermatic/machine-controller/pkg/cloudprovider/provider/openstack/cloudconfig.go
+++ b/api/vendor/github.com/kubermatic/machine-controller/pkg/cloudprovider/provider/openstack/cloudconfig.go
@@ -59,6 +59,9 @@ ignore-volume-az  = {{ .BlockStorage.IgnoreVolumeAZ }}
 {{- end }}
 trust-device-path = {{ .BlockStorage.TrustDevicePath }}
 bs-version        = {{ default "auto" .BlockStorage.BSVersion | iniEscape }}
+{{- if .BlockStorage.NodeVolumeAttachLimit }}
+node-volume-attach-limit = {{ .BlockStorage.NodeVolumeAttachLimit }}
+{{- end }}
 `
 )
 
@@ -76,9 +79,10 @@ type LoadBalancerOpts struct {
 }
 
 type BlockStorageOpts struct {
-	BSVersion       string `gcfg:"bs-version"`
-	TrustDevicePath bool   `gcfg:"trust-device-path"`
-	IgnoreVolumeAZ  bool   `gcfg:"ignore-volume-az"`
+	BSVersion             string `gcfg:"bs-version"`
+	TrustDevicePath       bool   `gcfg:"trust-device-path"`
+	IgnoreVolumeAZ        bool   `gcfg:"ignore-volume-az"`
+	NodeVolumeAttachLimit uint   `gcfg:"node-volume-attach-limit"`
 }
 
 type GlobalOpts struct {

--- a/api/vendor/github.com/kubermatic/machine-controller/pkg/cloudprovider/provider/openstack/provider.go
+++ b/api/vendor/github.com/kubermatic/machine-controller/pkg/cloudprovider/provider/openstack/provider.go
@@ -76,15 +76,16 @@ type RawConfig struct {
 	Region           providerconfig.ConfigVarString `json:"region,omitempty"`
 
 	// Machine details
-	Image            providerconfig.ConfigVarString   `json:"image"`
-	Flavor           providerconfig.ConfigVarString   `json:"flavor"`
-	SecurityGroups   []providerconfig.ConfigVarString `json:"securityGroups,omitempty"`
-	Network          providerconfig.ConfigVarString   `json:"network,omitempty"`
-	Subnet           providerconfig.ConfigVarString   `json:"subnet,omitempty"`
-	FloatingIPPool   providerconfig.ConfigVarString   `json:"floatingIpPool,omitempty"`
-	AvailabilityZone providerconfig.ConfigVarString   `json:"availabilityZone,omitempty"`
-	TrustDevicePath  providerconfig.ConfigVarBool     `json:"trustDevicePath"`
-	RootDiskSizeGB   *int                             `json:"rootDiskSizeGB"`
+	Image                 providerconfig.ConfigVarString   `json:"image"`
+	Flavor                providerconfig.ConfigVarString   `json:"flavor"`
+	SecurityGroups        []providerconfig.ConfigVarString `json:"securityGroups,omitempty"`
+	Network               providerconfig.ConfigVarString   `json:"network,omitempty"`
+	Subnet                providerconfig.ConfigVarString   `json:"subnet,omitempty"`
+	FloatingIPPool        providerconfig.ConfigVarString   `json:"floatingIpPool,omitempty"`
+	AvailabilityZone      providerconfig.ConfigVarString   `json:"availabilityZone,omitempty"`
+	TrustDevicePath       providerconfig.ConfigVarBool     `json:"trustDevicePath"`
+	RootDiskSizeGB        *int                             `json:"rootDiskSizeGB"`
+	NodeVolumeAttachLimit *uint                            `json:"nodeVolumeAttachLimit"`
 	// This tag is related to server metadata, not compute server's tag
 	Tags map[string]string `json:"tags,omitempty"`
 }
@@ -100,15 +101,16 @@ type Config struct {
 	Region           string
 
 	// Machine details
-	Image            string
-	Flavor           string
-	SecurityGroups   []string
-	Network          string
-	Subnet           string
-	FloatingIPPool   string
-	AvailabilityZone string
-	TrustDevicePath  bool
-	RootDiskSizeGB   *int
+	Image                 string
+	Flavor                string
+	SecurityGroups        []string
+	Network               string
+	Subnet                string
+	FloatingIPPool        string
+	AvailabilityZone      string
+	TrustDevicePath       bool
+	RootDiskSizeGB        *int
+	NodeVolumeAttachLimit *uint
 
 	Tags map[string]string
 }
@@ -207,6 +209,7 @@ func (p *provider) getConfig(s v1alpha1.ProviderSpec) (*Config, *providerconfig.
 		return nil, nil, nil, err
 	}
 	c.RootDiskSizeGB = rawConfig.RootDiskSizeGB
+	c.NodeVolumeAttachLimit = rawConfig.NodeVolumeAttachLimit
 	c.Tags = rawConfig.Tags
 	if c.Tags == nil {
 		c.Tags = map[string]string{}
@@ -727,6 +730,9 @@ func (p *provider) GetCloudConfig(spec v1alpha1.MachineSpec) (config string, nam
 			IgnoreVolumeAZ:  true,
 		},
 		Version: spec.Versions.Kubelet,
+	}
+	if c.NodeVolumeAttachLimit != nil {
+		cc.BlockStorage.NodeVolumeAttachLimit = *c.NodeVolumeAttachLimit
 	}
 
 	s, err := CloudConfigToString(cc)

--- a/api/vendor/github.com/kubermatic/machine-controller/pkg/userdata/centos/provider.go
+++ b/api/vendor/github.com/kubermatic/machine-controller/pkg/userdata/centos/provider.go
@@ -220,11 +220,6 @@ write_files:
   content: |
 {{ kubeletSystemdUnit .KubeletVersion .CloudProviderName .MachineSpec.Name .DNSIPs .ExternalCloudProvider .PauseImage | indent 4 }}
 
-- path: "/etc/systemd/system/kubelet.service.d/extras.conf"
-  content: |
-    [Service]
-    Environment="KUBELET_EXTRA_ARGS=--cgroup-driver=systemd"
-
 - path: "/etc/kubernetes/cloud-config"
   content: |
 {{ .CloudConfig | indent 4 }}

--- a/api/vendor/github.com/kubermatic/machine-controller/pkg/userdata/helper/helper.go
+++ b/api/vendor/github.com/kubermatic/machine-controller/pkg/userdata/helper/helper.go
@@ -93,6 +93,7 @@ SystemMaxUse=5G
 }
 
 type dockerConfig struct {
+	ExecOpts           []string `json:"exec-opts"`
 	StorageDriver      string   `json:"storage-driver"`
 	InsecureRegistries []string `json:"insecure-registries"`
 	RegistryMirrors    []string `json:"registry-mirrors"`
@@ -101,6 +102,7 @@ type dockerConfig struct {
 // DockerConfig returns the docker daemon.json.
 func DockerConfig(insecureRegistries, registryMirrors []string) (string, error) {
 	cfg := dockerConfig{
+		ExecOpts:           []string{"native.cgroupdriver=systemd"},
 		StorageDriver:      "overlay2",
 		InsecureRegistries: insecureRegistries,
 		RegistryMirrors:    registryMirrors,

--- a/api/vendor/github.com/kubermatic/machine-controller/pkg/userdata/helper/kubelet.go
+++ b/api/vendor/github.com/kubermatic/machine-controller/pkg/userdata/helper/kubelet.go
@@ -58,7 +58,8 @@ const (
 --pod-infra-container-image={{ .PauseImage }} \
 {{- end }}
 --kube-reserved=cpu=100m,memory=100Mi,ephemeral-storage=1Gi \
---system-reserved=cpu=100m,memory=100Mi,ephemeral-storage=1Gi`
+--system-reserved=cpu=100m,memory=100Mi,ephemeral-storage=1Gi \
+--cgroup-driver=systemd`
 
 	kubeletSystemdUnitTpl = `[Unit]
 After=docker.service

--- a/api/vendor/github.com/kubermatic/machine-controller/pkg/userdata/ubuntu/provider.go
+++ b/api/vendor/github.com/kubermatic/machine-controller/pkg/userdata/ubuntu/provider.go
@@ -218,6 +218,8 @@ write_files:
   content: |
     #!/bin/bash
     set -xeuo pipefail
+    if systemctl is-active ufw; then systemctl stop ufw; fi
+    systemctl mask ufw
 
 {{- /* As we added some modules and don't want to reboot, restart the service */}}
     systemctl restart systemd-modules-load.service


### PR DESCRIPTION
**What this PR does / why we need it**:

Fixes Azure to actually put the security group we create onto the machines. Also updates the machine-controller to realize the attechment of the security group onto the instances network interface.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Documentation**:
<!-- Add links to the related documentation changes related to this pull request. E.g. the link to the kubermatic/docs pullrequest. -->

**Does this PR introduce a user-facing change?**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If  no release note is required, just write "NONE".
-->
```release-note
Updated `machine-controller` to `v1.4.2`.
```
