### PR TITLE
Update Prometheus to 2.11

### DIFF
--- a/config/monitoring/prometheus/Chart.yaml
+++ b/config/monitoring/prometheus/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 name: prometheus
-version: 2.1.3
-appVersion: v2.10.0
+version: 2.1.4
+appVersion: v2.11.0
 description: Prometheus Monitoring for Kubernetes
 keywords:
 - kubermatic

--- a/config/monitoring/prometheus/templates/statefulset.yaml
+++ b/config/monitoring/prometheus/templates/statefulset.yaml
@@ -65,6 +65,7 @@ spec:
             --storage.tsdb.retention.time={{ .Values.prometheus.tsdb.retentionTime | default "24h" }} \
             --storage.tsdb.min-block-duration=2h \
             --storage.tsdb.max-block-duration=2h \
+            --storage.tsdb.wal-compression={{ .Values.prometheus.tsdb.compressWAL }} \
             --web.enable-lifecycle \
             --web.external-url=https://{{ .Values.prometheus.host | trim }} \
             --web.enable-admin-api
@@ -75,6 +76,7 @@ spec:
             --storage.tsdb.no-lockfile \
             --storage.tsdb.path=/var/prometheus/data \
             --storage.tsdb.retention.time={{ .Values.prometheus.tsdb.retentionTime | default "24h" }} \
+            --storage.tsdb.wal-compression={{ .Values.prometheus.tsdb.compressWAL }} \
             --web.enable-lifecycle \
             {{- if .Values.prometheus.backup.enabled }}
             --web.enable-admin-api \

--- a/config/monitoring/prometheus/templates/statefulset.yaml
+++ b/config/monitoring/prometheus/templates/statefulset.yaml
@@ -65,7 +65,9 @@ spec:
             --storage.tsdb.retention.time={{ .Values.prometheus.tsdb.retentionTime | default "24h" }} \
             --storage.tsdb.min-block-duration=2h \
             --storage.tsdb.max-block-duration=2h \
-            --storage.tsdb.wal-compression={{ .Values.prometheus.tsdb.compressWAL }} \
+            {{- if .Values.prometheus.tsdb.compressWAL }}
+            --storage.tsdb.wal-compression \
+            {{- end }}
             --web.enable-lifecycle \
             --web.external-url=https://{{ .Values.prometheus.host | trim }} \
             --web.enable-admin-api
@@ -76,7 +78,9 @@ spec:
             --storage.tsdb.no-lockfile \
             --storage.tsdb.path=/var/prometheus/data \
             --storage.tsdb.retention.time={{ .Values.prometheus.tsdb.retentionTime | default "24h" }} \
-            --storage.tsdb.wal-compression={{ .Values.prometheus.tsdb.compressWAL }} \
+            {{- if .Values.prometheus.tsdb.compressWAL }}
+            --storage.tsdb.wal-compression \
+            {{- end }}
             --web.enable-lifecycle \
             {{- if .Values.prometheus.backup.enabled }}
             --web.enable-admin-api \

--- a/config/monitoring/prometheus/values.yaml
+++ b/config/monitoring/prometheus/values.yaml
@@ -1,7 +1,7 @@
 prometheus:
   image:
     repository: quay.io/prometheus/prometheus
-    tag: v2.10.0
+    tag: v2.11.0
     pullPolicy: IfNotPresent
 
   host: ''
@@ -10,6 +10,11 @@ prometheus:
 
   tsdb:
     retentionTime: 15d
+
+    # This is not yet considered a truly stable
+    # feature by the Prometheus developers, see
+    # https://github.com/prometheus/tsdb/pull/609
+    compressWAL: false
 
   configReloaderImage:
     repository: docker.io/jimmidyson/configmap-reload


### PR DESCRIPTION
**What this PR does / why we need it**:
This updates Prometheus to the latest stable. The new version supports compressing the WAL, which for us saves roughly 40-50% of disk space :-) As disabling compression is not supported without also wiping the WAL, we keep the compression disabled by default for now, but will disable it on our clusters later.

**Does this PR introduce a user-facing change?**:
```release-note
update Prometheus to 2.11.0
```
