### PR TITLE
disable unused seed-proxy controller

### DIFF
--- a/api/cmd/master-controller-manager/controllers.go
+++ b/api/cmd/master-controller-manager/controllers.go
@@ -9,8 +9,8 @@ import (
 
 	"github.com/kubermatic/kubermatic/api/pkg/controller/rbac"
 	seedproxy "github.com/kubermatic/kubermatic/api/pkg/controller/seed-proxy"
-	"github.com/kubermatic/kubermatic/api/pkg/controller/service-account"
-	"github.com/kubermatic/kubermatic/api/pkg/controller/user-project-binding"
+	serviceaccount "github.com/kubermatic/kubermatic/api/pkg/controller/service-account"
+	userprojectbinding "github.com/kubermatic/kubermatic/api/pkg/controller/user-project-binding"
 	kubermaticclientset "github.com/kubermatic/kubermatic/api/pkg/crd/client/clientset/versioned"
 	"github.com/kubermatic/kubermatic/api/pkg/crd/client/informers/externalversions"
 	"github.com/kubermatic/kubermatic/api/pkg/log"
@@ -33,7 +33,7 @@ var allControllers = map[string]controllerCreator{
 	"RBAC":               createRBACContoller,
 	"UserProjectBinding": createUserProjectBindingController,
 	"ServiceAccounts":    createServiceAccountsController,
-	"SeedProxy":          createSeedProxyController,
+	// "SeedProxy":          createSeedProxyController,
 }
 
 func createAllControllers(ctrlCtx *controllerContext) (map[string]runnerFn, error) {

--- a/api/cmd/master-controller-manager/controllers.go
+++ b/api/cmd/master-controller-manager/controllers.go
@@ -8,7 +8,6 @@ import (
 	"github.com/oklog/run"
 
 	"github.com/kubermatic/kubermatic/api/pkg/controller/rbac"
-	seedproxy "github.com/kubermatic/kubermatic/api/pkg/controller/seed-proxy"
 	serviceaccount "github.com/kubermatic/kubermatic/api/pkg/controller/service-account"
 	userprojectbinding "github.com/kubermatic/kubermatic/api/pkg/controller/user-project-binding"
 	kubermaticclientset "github.com/kubermatic/kubermatic/api/pkg/crd/client/clientset/versioned"
@@ -33,7 +32,7 @@ var allControllers = map[string]controllerCreator{
 	"RBAC":               createRBACContoller,
 	"UserProjectBinding": createUserProjectBindingController,
 	"ServiceAccounts":    createServiceAccountsController,
-	// "SeedProxy":          createSeedProxyController,
+	"SeedProxy":          createSeedProxyController,
 }
 
 func createAllControllers(ctrlCtx *controllerContext) (map[string]runnerFn, error) {
@@ -173,8 +172,8 @@ func createServiceAccountsController(ctrlCtx *controllerContext) (runnerFn, erro
 }
 
 func createSeedProxyController(ctrlCtx *controllerContext) (runnerFn, error) {
-	if err := seedproxy.Add(ctrlCtx.mgr, 1, ctrlCtx.kubeconfig, ctrlCtx.datacenters); err != nil {
-		return nil, err
-	}
+	// if err := seedproxy.Add(ctrlCtx.mgr, 1, ctrlCtx.kubeconfig, ctrlCtx.datacenters); err != nil {
+	// 	return nil, err
+	// }
 	return noop, nil
 }


### PR DESCRIPTION
**What this PR does / why we need it**:
The seed-proxy controller is responsible for opening a communication channel from the master cluster to each channel. This is nice, but not tested well and not yet used for Prometheus/Alertmanager. This PR therefore disables the controller entirely in 2.11 so that we do not create resources that are not used at all.

**Does this PR introduce a user-facing change?**:
```release-note
NONE
```
