### PR TITLE
Fix nginx permissions

### DIFF
--- a/config/nginx-ingress-controller/templates/cluster-role.yaml
+++ b/config/nginx-ingress-controller/templates/cluster-role.yaml
@@ -30,6 +30,7 @@ rules:
   - watch
 - apiGroups:
   - extensions
+  - networking.k8s.io
   resources:
   - ingresses
   verbs:
@@ -45,6 +46,7 @@ rules:
   - patch
 - apiGroups:
   - extensions
+  - networking.k8s.io
   resources:
   - ingresses/status
   verbs:


### PR DESCRIPTION
**What this PR does / why we need it**:
Ingresses got moved from the `extensions` apigroup to `networking.k8s.io`.
Thus the ClusterRole must be updated.

**Does this PR introduce a user-facing change?**:
```release-note
NONE
```
