### PR TITLE
Use the canonical image name for busybox inside the elasticsearch chart

### DIFF
--- a/config/logging/elasticsearch/values.yaml
+++ b/config/logging/elasticsearch/values.yaml
@@ -83,7 +83,7 @@ logging:
 
     init:
       image:
-        repository: docker.io/busybox
+        repository: docker.io/library/busybox
         tag: "1.30.1"
         pullPolicy: IfNotPresent
 


### PR DESCRIPTION
**What this PR does / why we need it**:
We have scripts in place which parse our helm charts & retag the images.
To have a reliable way of retagging, the scripts require all images to use the canonical name.

**Does this PR introduce a user-facing change?**:
```release-note
NONE
```
