### PR TITLE
Perform vault login during offline deployment

### DIFF
--- a/api/hack/ci/ci-deploy-offline.sh
+++ b/api/hack/ci/ci-deploy-offline.sh
@@ -5,6 +5,13 @@ set -euo pipefail
 # receives a SIGINT
 set -o monitor
 
+echodate "Getting secrets from Vault"
+export VAULT_ADDR=https://vault.loodse.com/
+export VAULT_TOKEN=$(vault write \
+  --format=json auth/approle/login \
+  role_id=${VAULT_ROLE_ID} secret_id=${VAULT_SECRET_ID} \
+  | jq .auth.client_token -r)
+
 export GIT_HEAD_HASH="$(git rev-parse HEAD|tr -d '\n')"
 
 cd "$(dirname "$0")/"


### PR DESCRIPTION
**What this PR does / why we need it**:
Perform vault login during offline deployment in CI script.

**Does this PR introduce a user-facing change?**:
```release-note
NONE
```
