### PR TITLE
Use yaml.UnmarshalStrict everywhere

### DIFF
--- a/api/pkg/presets/manager.go
+++ b/api/pkg/presets/manager.go
@@ -6,7 +6,7 @@ import (
 	"io/ioutil"
 	"os"
 
-	"github.com/ghodss/yaml"
+	"sigs.k8s.io/yaml"
 
 	"github.com/kubermatic/kubermatic/api/pkg/crd/kubermatic/v1"
 	"github.com/kubermatic/kubermatic/api/pkg/provider"
@@ -163,7 +163,7 @@ func loadPresets(path string) (*Presets, error) {
 		Presets *Presets `json:"presets"`
 	}{}
 
-	err = yaml.Unmarshal(bytes, &s)
+	err = yaml.UnmarshalStrict(bytes, &s)
 	if err != nil {
 		return nil, err
 	}

--- a/api/pkg/provider/datacenter.go
+++ b/api/pkg/provider/datacenter.go
@@ -42,7 +42,7 @@ func LoadDatacentersMeta(path string) (map[string]DatacenterMeta, error) {
 	}
 
 	dcs := datacentersMeta{}
-	if err := yaml.Unmarshal(bytes, &dcs); err != nil {
+	if err := yaml.UnmarshalStrict(bytes, &dcs); err != nil {
 		return nil, err
 	}
 

--- a/api/pkg/provider/datacenter_test.go
+++ b/api/pkg/provider/datacenter_test.go
@@ -22,13 +22,9 @@ datacenters:
   europe-west3-c: #Master
     location: Frankfurt
     country: DE
-    provider: Loodse
     is_seed: true
     spec:
-      bringyourown:
-        region: DE
-      seed:
-        bringyourown:
+      bringyourown: {}
 #==================================
 #===========Digitalocean===========
 #==================================
@@ -46,7 +42,6 @@ datacenters:
     location: Australia
     seed: sydney-1
     country: AU
-    provider: openstack
     spec:
       openstack:
         availability_zone: au1

--- a/api/pkg/version/load.go
+++ b/api/pkg/version/load.go
@@ -5,7 +5,7 @@ import (
 	"io/ioutil"
 	"os"
 
-	"github.com/ghodss/yaml"
+	"sigs.k8s.io/yaml"
 )
 
 // LoadUpdates loads the update definition file and returns the defined MasterUpdate
@@ -24,7 +24,7 @@ func LoadUpdates(path string) ([]*MasterUpdate, error) {
 		Updates []*MasterUpdate `json:"updates"`
 	}{}
 
-	err = yaml.Unmarshal(bytes, &s)
+	err = yaml.UnmarshalStrict(bytes, &s)
 	if err != nil {
 		return nil, err
 	}
@@ -48,7 +48,7 @@ func LoadVersions(path string) ([]*MasterVersion, error) {
 		Versions []*MasterVersion `json:"versions"`
 	}{}
 
-	err = yaml.Unmarshal(bytes, &s)
+	err = yaml.UnmarshalStrict(bytes, &s)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
**What this PR does / why we need it**:

This PR makes us use `yaml.UnmarshalStrict` everywhere. This has the advantage that unknown fields cause an error instead of being silently dropped.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Documentation**:
<!-- Add links to the related documentation changes related to this pull request. E.g. the link to the kubermatic/docs pullrequest. -->

**Does this PR introduce a user-facing change?**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If  no release note is required, just write "NONE".
-->
```release-note
[ACTION REQUIRED] Kubermatic now doesn't accept unknown keys in its config files anymore and will crash if an unknown key is present
[ACTION REQUIRED] BYO datacenters now need to be specific in the `datacenters.yaml` with a value of `{}`, e.G `bringyourown: {}`
```

/assign @zreigz 
/assign @nikhita 