### PR TITLE
Add missing docker start

### DIFF
--- a/api/hack/ci/ci-deploy-offline.sh
+++ b/api/hack/ci/ci-deploy-offline.sh
@@ -8,6 +8,9 @@ set -o monitor
 cd "$(dirname "$0")/"
 source ./../lib.sh
 
+# Start docker if its not running yet
+docker ps &>/dev/null || start-docker.sh
+
 echodate "Getting secrets from Vault"
 export VAULT_ADDR=https://vault.loodse.com/
 export VAULT_TOKEN=$(vault write \


### PR DESCRIPTION
**What this PR does / why we need it**:
This will add the required start of docker so docker can actually be used...

A failed build: https://prow.loodse.com/view/gcs/prow-data/logs/post-kubermatic-deploy-offline/1149328343380791297

**Does this PR introduce a user-facing change?**:
```release-note
NONE
```
