### PR TITLE
Fix setting of CloudMigrationRevision on cluster create

### DIFF
--- a/api/pkg/handler/v1/cluster/cluster.go
+++ b/api/pkg/handler/v1/cluster/cluster.go
@@ -20,7 +20,6 @@ import (
 	"k8s.io/client-go/tools/record"
 
 	apiv1 "github.com/kubermatic/kubermatic/api/pkg/api/v1"
-	"github.com/kubermatic/kubermatic/api/pkg/controller/cloud"
 	kubermaticapiv1 "github.com/kubermatic/kubermatic/api/pkg/crd/kubermatic/v1"
 	"github.com/kubermatic/kubermatic/api/pkg/handler/middleware"
 	"github.com/kubermatic/kubermatic/api/pkg/handler/v1/common"
@@ -107,7 +106,6 @@ func CreateEndpoint(sshKeyProvider provider.SSHKeyProvider, cloudProviders map[s
 				"kubermatic.io/openshift": "true",
 			}
 		}
-		partialCluster.Status.CloudMigrationRevision = cloud.CurrentMigrationRevision
 
 		newCluster, err := clusterProvider.New(project, userInfo, partialCluster)
 		if err != nil {

--- a/api/pkg/provider/kubernetes/cluster.go
+++ b/api/pkg/provider/kubernetes/cluster.go
@@ -5,6 +5,7 @@ import (
 	"strings"
 
 	k8cuserclusterclient "github.com/kubermatic/kubermatic/api/pkg/cluster/client"
+	"github.com/kubermatic/kubermatic/api/pkg/controller/cloud"
 	kubermaticv1lister "github.com/kubermatic/kubermatic/api/pkg/crd/client/listers/kubermatic/v1"
 	kubermaticv1 "github.com/kubermatic/kubermatic/api/pkg/crd/kubermatic/v1"
 	"github.com/kubermatic/kubermatic/api/pkg/provider"
@@ -94,8 +95,9 @@ func (p *ClusterProvider) New(project *kubermaticv1.Project, userInfo *provider.
 		},
 		Spec: cluster.Spec,
 		Status: kubermaticv1.ClusterStatus{
-			UserEmail:     userInfo.Email,
-			NamespaceName: NamespaceName(name),
+			UserEmail:              userInfo.Email,
+			NamespaceName:          NamespaceName(name),
+			CloudMigrationRevision: cloud.CurrentMigrationRevision,
 		},
 		Address: kubermaticv1.ClusterAddress{},
 	}

--- a/api/pkg/provider/kubernetes/util_test.go
+++ b/api/pkg/provider/kubernetes/util_test.go
@@ -12,6 +12,7 @@ import (
 	"github.com/kubermatic/kubermatic/api/pkg/provider/kubernetes"
 	"k8s.io/apimachinery/pkg/types"
 
+	"github.com/kubermatic/kubermatic/api/pkg/controller/cloud"
 	kubermaticfakeclentset "github.com/kubermatic/kubermatic/api/pkg/crd/client/clientset/versioned/fake"
 	kubermaticclientv1 "github.com/kubermatic/kubermatic/api/pkg/crd/client/clientset/versioned/typed/kubermatic/v1"
 	kubermaticapiv1 "github.com/kubermatic/kubermatic/api/pkg/crd/kubermatic/v1"
@@ -289,8 +290,9 @@ func genCluster(name, clusterType, projectID, workerName, userEmail string) *kub
 	cluster.Labels = labels
 	cluster.Name = name
 	cluster.Status = kubermaticapiv1.ClusterStatus{
-		UserEmail:     userEmail,
-		NamespaceName: fmt.Sprintf("cluster-%s", name),
+		UserEmail:              userEmail,
+		NamespaceName:          fmt.Sprintf("cluster-%s", name),
+		CloudMigrationRevision: cloud.CurrentMigrationRevision,
 	}
 	cluster.Address = kubermaticapiv1.ClusterAddress{}
 


### PR DESCRIPTION
**What this PR does / why we need it**:

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Documentation**:
<!-- Add links to the related documentation changes related to this pull request. E.g. the link to the kubermatic/docs pullrequest. -->

**Does this PR introduce a user-facing change?**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If  no release note is required, just write "NONE".
-->
```release-note
none
```

/assign @zreigz 

We _really_ should change the e2e tester to actually use the api.  E2E tests would have failed if we had used the API, instead we discovered the issue because ppls clusters didnt come up