### PR TITLE
define a readiness probe for the kubermatic API server

### DIFF
--- a/config/kubermatic/Chart.yaml
+++ b/config/kubermatic/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: kubermatic
-version: 1.0.1
+version: 1.0.2
 appVersion: '__KUBERMATIC_TAG__'
 description: Kubermatic chart for master and/or seed clusters.
 keywords:

--- a/config/kubermatic/templates/kubermatic-api-dep.yaml
+++ b/config/kubermatic/templates/kubermatic-api-dep.yaml
@@ -62,7 +62,11 @@ spec:
           containerPort: 8085
         - name: http
           containerPort: 8080
-          protocol: TCP
+        readinessProbe:
+          httpGet:
+            port: 8080
+            path: /api/v1/healthz
+            scheme: HTTP
         volumeMounts:
         - name: kubeconfig
           mountPath: "/opt/.kube/"


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR adds a readiness probe to the Kubermatic API server pod.

**Does this PR introduce a user-facing change?**:
```release-note
NONE
```
