### PR TITLE
Re-Build the nodeport proxy

### DIFF
--- a/api/cmd/nodeport-proxy/release.sh
+++ b/api/cmd/nodeport-proxy/release.sh
@@ -2,7 +2,7 @@
 
 set -euo pipefail
 
-TAG=v2.2.0
+TAG=v2.2.1
 export TAG
 make docker
 docker push quay.io/kubermatic/nodeport-proxy:${TAG}

--- a/config/nodeport-proxy/Chart.yaml
+++ b/config/nodeport-proxy/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: nodeport-proxy
-version: 1.2.0
+version: 1.2.1
 appVersion: v2.2.1
 description: Kubermatic nodeport-proxy
 keywords:

--- a/config/nodeport-proxy/Chart.yaml
+++ b/config/nodeport-proxy/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 name: nodeport-proxy
 version: 1.2.0
-appVersion: v2.1.1
+appVersion: v2.2.1
 description: Kubermatic nodeport-proxy
 keywords:
 - kubermatic

--- a/config/nodeport-proxy/values.yaml
+++ b/config/nodeport-proxy/values.yaml
@@ -2,7 +2,7 @@ nodePortProxy:
   replicas: 3
   image:
     repository: "quay.io/kubermatic/nodeport-proxy"
-    tag: v2.2.0
+    tag: v2.2.1
   envoy:
     image:
       repository: "docker.io/envoyproxy/envoy-alpine"


### PR DESCRIPTION
**What this PR does / why we need it**:
The current version of the envoy-manager is outputting **a lot** of

```
time="2019-07-15T11:28:13Z" level=error annotation=nodeport-proxy.k8s.io/expose
```

log lines for no apparent reason. To make sure the binary inside the Docker image is fresh and actually based on the code in the repo, this PR deploys a new, pristine version.

**Does this PR introduce a user-facing change?**:
```release-note
none
```

/assign @xrstf 