### PR TITLE
Prometheus alert inhibitions

### DIFF
--- a/api/pkg/resources/dns/dns.go
+++ b/api/pkg/resources/dns/dns.go
@@ -82,17 +82,18 @@ func DeploymentCreator(data deploymentCreatorData) reconciling.NamedDeploymentCr
 			volumes := getVolumes()
 			podLabels, err := data.GetPodTemplateLabels(resources.DNSResolverDeploymentName, volumes, nil)
 			if err != nil {
-				return nil, fmt.Errorf("failed to get podlabels: %v", err)
+				return nil, fmt.Errorf("failed to get pod labels: %v", err)
 			}
 
-			dep.Spec.Template.ObjectMeta = metav1.ObjectMeta{
-				Labels: podLabels,
-				Annotations: map[string]string{
-					"prometheus.io/scrape": "true",
-					"prometheus.io/path":   "/metrics",
-					"prometheus.io/port":   "9253",
-				},
+			dep.Spec.Template.ObjectMeta.Labels = podLabels
+
+			if dep.Spec.Template.ObjectMeta.Annotations == nil {
+				dep.Spec.Template.ObjectMeta.Annotations = make(map[string]string)
 			}
+
+			dep.Spec.Template.ObjectMeta.Annotations["prometheus.io/scrape"] = "true"
+			dep.Spec.Template.ObjectMeta.Annotations["prometheus.io/path"] = "/metrics"
+			dep.Spec.Template.ObjectMeta.Annotations["prometheus.io/port"] = "9253"
 
 			openvpnSidecar, err := vpnsidecar.OpenVPNSidecarContainer(data, "openvpn-client")
 			if err != nil {

--- a/api/pkg/resources/dns/dns.go
+++ b/api/pkg/resources/dns/dns.go
@@ -85,7 +85,15 @@ func DeploymentCreator(data deploymentCreatorData) reconciling.NamedDeploymentCr
 				return nil, fmt.Errorf("failed to get podlabels: %v", err)
 			}
 
-			dep.Spec.Template.ObjectMeta = metav1.ObjectMeta{Labels: podLabels}
+			dep.Spec.Template.ObjectMeta = metav1.ObjectMeta{
+				Labels: podLabels,
+				Annotations: map[string]string{
+					"prometheus.io/scrape": "true",
+					"prometheus.io/path":   "/metrics",
+					"prometheus.io/port":   "9253",
+				},
+			}
+
 			openvpnSidecar, err := vpnsidecar.OpenVPNSidecarContainer(data, "openvpn-client")
 			if err != nil {
 				return nil, fmt.Errorf("failed to get openvpn sidecar for dns resolver: %v", err)
@@ -202,6 +210,7 @@ func ConfigMapCreator(data configMapCreatorData) reconciling.NamedConfigMapCreat
   forward . /etc/resolv.conf
   errors
   health
+  prometheus 0.0.0.0:9253
 }
 `, seedClusterNamespaceDNS, data.Cluster().Spec.ClusterNetwork.DNSDomain, dnsIP)
 

--- a/api/pkg/resources/prometheus/configmap-rules.go
+++ b/api/pkg/resources/prometheus/configmap-rules.go
@@ -351,6 +351,27 @@ groups:
     labels:
       severity: critical
 
+  # This is triggered if the cluster does have nodes, but the cadvisor could
+  # not successfully be scraped for whatever reason. An absent() on cadvisor
+  # metrics is not a good alert because clusters could simply have no nodes
+  # and hence no cadvisors.
+  - alert: CAdvisorDown
+    annotations:
+      message: cAdvisor on {{ $labels.kubernetes_io_hostname }} could not be scraped.
+    expr: up{job="cadvisor"} == 0
+    for: 15m
+    labels:
+      severity: warning
+
+  # This functions similarly to the cadvisor alert above.
+  - alert: KubernetesNodeDown
+    annotations:
+      message: The kubelet on {{ $labels.kubernetes_io_hostname }} could not be scraped.
+    expr: up{job="kubernetes-nodes"} == 0
+    for: 15m
+    labels:
+      severity: warning
+
   - alert: DNSResolverDown
     annotations:
       message: DNS resolver has disappeared from Prometheus target discovery.

--- a/api/pkg/resources/prometheus/configmap-rules.go
+++ b/api/pkg/resources/prometheus/configmap-rules.go
@@ -323,13 +323,21 @@ groups:
     labels:
       severity: critical
 
+  - alert: UserClusterControllerDown
+    annotations:
+      message: User Cluster Controller has disappeared from Prometheus target discovery.
+    expr: absent(up{job="usercluster-controller"} == 1)
+    for: 15m
+    labels:
+      severity: critical
+
   - alert: KubeStateMetricsDown
     annotations:
       message: Kube-state-metrics has disappeared from Prometheus target discovery.
     expr: absent(up{job="kube-state-metrics"} == 1)
     for: 15m
     labels:
-      severity: critical
+      severity: warning
 
   - alert: EtcdDown
     annotations:

--- a/api/pkg/resources/prometheus/configmap-rules.go
+++ b/api/pkg/resources/prometheus/configmap-rules.go
@@ -1,5 +1,9 @@
 package prometheus
 
+// prometheusRules contains the prerecoding and alerting rules for
+// Prometheus. Be careful when changing alert names, as some of them
+// are used for alert inhibitions and configured inside the
+// seed-cluster's Alertmanager.
 const prometheusRules = `
 groups:
 - name: kubermatic.goprocess

--- a/api/pkg/resources/prometheus/configmap-rules.go
+++ b/api/pkg/resources/prometheus/configmap-rules.go
@@ -351,6 +351,14 @@ groups:
     labels:
       severity: critical
 
+  - alert: DNSResolverDown
+    annotations:
+      message: DNS resolver has disappeared from Prometheus target discovery.
+    expr: absent(up{job="dns-resolver"} == 1)
+    for: 15m
+    labels:
+      severity: warning
+
 - name: kubernetes-nodes
   rules:
   - alert: KubernetesNodeNotReady

--- a/api/pkg/resources/prometheus/configmap-rules.go
+++ b/api/pkg/resources/prometheus/configmap-rules.go
@@ -286,7 +286,7 @@ groups:
 
   - alert: FdExhaustionClose
     annotations:
-      description: '{{ $labels.job }} instance {{ $labels.instance }} will exhaust its file descriptors soon'
+      message: '{{ $labels.job }} instance {{ $labels.instance }} will exhaust its file descriptors soon'
     expr: |
       predict_linear(instance:fd_utilization[10m], 3600) > 1
     for: 10m

--- a/api/pkg/resources/test/fixtures/configmap-aws-1.10.0-dns-resolver.yaml
+++ b/api/pkg/resources/test/fixtures/configmap-aws-1.10.0-dns-resolver.yaml
@@ -13,6 +13,7 @@ data:
       forward . /etc/resolv.conf
       errors
       health
+      prometheus 0.0.0.0:9253
     }
 metadata:
   creationTimestamp: null

--- a/api/pkg/resources/test/fixtures/configmap-aws-1.10.0-prometheus.yaml
+++ b/api/pkg/resources/test/fixtures/configmap-aws-1.10.0-prometheus.yaml
@@ -519,7 +519,7 @@ data:
 
       - alert: FdExhaustionClose
         annotations:
-          description: '{{ $labels.job }} instance {{ $labels.instance }} will exhaust its file descriptors soon'
+          message: '{{ $labels.job }} instance {{ $labels.instance }} will exhaust its file descriptors soon'
         expr: |
           predict_linear(instance:fd_utilization[10m], 3600) > 1
         for: 10m
@@ -560,13 +560,21 @@ data:
         labels:
           severity: critical
 
+      - alert: UserClusterControllerDown
+        annotations:
+          message: User Cluster Controller has disappeared from Prometheus target discovery.
+        expr: absent(up{job="usercluster-controller"} == 1)
+        for: 15m
+        labels:
+          severity: critical
+
       - alert: KubeStateMetricsDown
         annotations:
           message: Kube-state-metrics has disappeared from Prometheus target discovery.
         expr: absent(up{job="kube-state-metrics"} == 1)
         for: 15m
         labels:
-          severity: critical
+          severity: warning
 
       - alert: EtcdDown
         annotations:
@@ -575,6 +583,35 @@ data:
         for: 15m
         labels:
           severity: critical
+
+      # This is triggered if the cluster does have nodes, but the cadvisor could
+      # not successfully be scraped for whatever reason. An absent() on cadvisor
+      # metrics is not a good alert because clusters could simply have no nodes
+      # and hence no cadvisors.
+      - alert: CAdvisorDown
+        annotations:
+          message: cAdvisor on {{ $labels.kubernetes_io_hostname }} could not be scraped.
+        expr: up{job="cadvisor"} == 0
+        for: 15m
+        labels:
+          severity: warning
+
+      # This functions similarly to the cadvisor alert above.
+      - alert: KubernetesNodeDown
+        annotations:
+          message: The kubelet on {{ $labels.kubernetes_io_hostname }} could not be scraped.
+        expr: up{job="kubernetes-nodes"} == 0
+        for: 15m
+        labels:
+          severity: warning
+
+      - alert: DNSResolverDown
+        annotations:
+          message: DNS resolver has disappeared from Prometheus target discovery.
+        expr: absent(up{job="dns-resolver"} == 1)
+        for: 15m
+        labels:
+          severity: warning
 
     - name: kubernetes-nodes
       rules:

--- a/api/pkg/resources/test/fixtures/configmap-aws-1.10.6-dns-resolver.yaml
+++ b/api/pkg/resources/test/fixtures/configmap-aws-1.10.6-dns-resolver.yaml
@@ -13,6 +13,7 @@ data:
       forward . /etc/resolv.conf
       errors
       health
+      prometheus 0.0.0.0:9253
     }
 metadata:
   creationTimestamp: null

--- a/api/pkg/resources/test/fixtures/configmap-aws-1.10.6-prometheus.yaml
+++ b/api/pkg/resources/test/fixtures/configmap-aws-1.10.6-prometheus.yaml
@@ -519,7 +519,7 @@ data:
 
       - alert: FdExhaustionClose
         annotations:
-          description: '{{ $labels.job }} instance {{ $labels.instance }} will exhaust its file descriptors soon'
+          message: '{{ $labels.job }} instance {{ $labels.instance }} will exhaust its file descriptors soon'
         expr: |
           predict_linear(instance:fd_utilization[10m], 3600) > 1
         for: 10m
@@ -560,13 +560,21 @@ data:
         labels:
           severity: critical
 
+      - alert: UserClusterControllerDown
+        annotations:
+          message: User Cluster Controller has disappeared from Prometheus target discovery.
+        expr: absent(up{job="usercluster-controller"} == 1)
+        for: 15m
+        labels:
+          severity: critical
+
       - alert: KubeStateMetricsDown
         annotations:
           message: Kube-state-metrics has disappeared from Prometheus target discovery.
         expr: absent(up{job="kube-state-metrics"} == 1)
         for: 15m
         labels:
-          severity: critical
+          severity: warning
 
       - alert: EtcdDown
         annotations:
@@ -575,6 +583,35 @@ data:
         for: 15m
         labels:
           severity: critical
+
+      # This is triggered if the cluster does have nodes, but the cadvisor could
+      # not successfully be scraped for whatever reason. An absent() on cadvisor
+      # metrics is not a good alert because clusters could simply have no nodes
+      # and hence no cadvisors.
+      - alert: CAdvisorDown
+        annotations:
+          message: cAdvisor on {{ $labels.kubernetes_io_hostname }} could not be scraped.
+        expr: up{job="cadvisor"} == 0
+        for: 15m
+        labels:
+          severity: warning
+
+      # This functions similarly to the cadvisor alert above.
+      - alert: KubernetesNodeDown
+        annotations:
+          message: The kubelet on {{ $labels.kubernetes_io_hostname }} could not be scraped.
+        expr: up{job="kubernetes-nodes"} == 0
+        for: 15m
+        labels:
+          severity: warning
+
+      - alert: DNSResolverDown
+        annotations:
+          message: DNS resolver has disappeared from Prometheus target discovery.
+        expr: absent(up{job="dns-resolver"} == 1)
+        for: 15m
+        labels:
+          severity: warning
 
     - name: kubernetes-nodes
       rules:

--- a/api/pkg/resources/test/fixtures/configmap-aws-1.11.0-dns-resolver.yaml
+++ b/api/pkg/resources/test/fixtures/configmap-aws-1.11.0-dns-resolver.yaml
@@ -13,6 +13,7 @@ data:
       forward . /etc/resolv.conf
       errors
       health
+      prometheus 0.0.0.0:9253
     }
 metadata:
   creationTimestamp: null

--- a/api/pkg/resources/test/fixtures/configmap-aws-1.11.0-prometheus.yaml
+++ b/api/pkg/resources/test/fixtures/configmap-aws-1.11.0-prometheus.yaml
@@ -523,7 +523,7 @@ data:
 
       - alert: FdExhaustionClose
         annotations:
-          description: '{{ $labels.job }} instance {{ $labels.instance }} will exhaust its file descriptors soon'
+          message: '{{ $labels.job }} instance {{ $labels.instance }} will exhaust its file descriptors soon'
         expr: |
           predict_linear(instance:fd_utilization[10m], 3600) > 1
         for: 10m
@@ -564,13 +564,21 @@ data:
         labels:
           severity: critical
 
+      - alert: UserClusterControllerDown
+        annotations:
+          message: User Cluster Controller has disappeared from Prometheus target discovery.
+        expr: absent(up{job="usercluster-controller"} == 1)
+        for: 15m
+        labels:
+          severity: critical
+
       - alert: KubeStateMetricsDown
         annotations:
           message: Kube-state-metrics has disappeared from Prometheus target discovery.
         expr: absent(up{job="kube-state-metrics"} == 1)
         for: 15m
         labels:
-          severity: critical
+          severity: warning
 
       - alert: EtcdDown
         annotations:
@@ -579,6 +587,35 @@ data:
         for: 15m
         labels:
           severity: critical
+
+      # This is triggered if the cluster does have nodes, but the cadvisor could
+      # not successfully be scraped for whatever reason. An absent() on cadvisor
+      # metrics is not a good alert because clusters could simply have no nodes
+      # and hence no cadvisors.
+      - alert: CAdvisorDown
+        annotations:
+          message: cAdvisor on {{ $labels.kubernetes_io_hostname }} could not be scraped.
+        expr: up{job="cadvisor"} == 0
+        for: 15m
+        labels:
+          severity: warning
+
+      # This functions similarly to the cadvisor alert above.
+      - alert: KubernetesNodeDown
+        annotations:
+          message: The kubelet on {{ $labels.kubernetes_io_hostname }} could not be scraped.
+        expr: up{job="kubernetes-nodes"} == 0
+        for: 15m
+        labels:
+          severity: warning
+
+      - alert: DNSResolverDown
+        annotations:
+          message: DNS resolver has disappeared from Prometheus target discovery.
+        expr: absent(up{job="dns-resolver"} == 1)
+        for: 15m
+        labels:
+          severity: warning
 
     - name: kubernetes-nodes
       rules:

--- a/api/pkg/resources/test/fixtures/configmap-aws-1.11.1-dns-resolver.yaml
+++ b/api/pkg/resources/test/fixtures/configmap-aws-1.11.1-dns-resolver.yaml
@@ -13,6 +13,7 @@ data:
       forward . /etc/resolv.conf
       errors
       health
+      prometheus 0.0.0.0:9253
     }
 metadata:
   creationTimestamp: null

--- a/api/pkg/resources/test/fixtures/configmap-aws-1.11.1-prometheus.yaml
+++ b/api/pkg/resources/test/fixtures/configmap-aws-1.11.1-prometheus.yaml
@@ -523,7 +523,7 @@ data:
 
       - alert: FdExhaustionClose
         annotations:
-          description: '{{ $labels.job }} instance {{ $labels.instance }} will exhaust its file descriptors soon'
+          message: '{{ $labels.job }} instance {{ $labels.instance }} will exhaust its file descriptors soon'
         expr: |
           predict_linear(instance:fd_utilization[10m], 3600) > 1
         for: 10m
@@ -564,13 +564,21 @@ data:
         labels:
           severity: critical
 
+      - alert: UserClusterControllerDown
+        annotations:
+          message: User Cluster Controller has disappeared from Prometheus target discovery.
+        expr: absent(up{job="usercluster-controller"} == 1)
+        for: 15m
+        labels:
+          severity: critical
+
       - alert: KubeStateMetricsDown
         annotations:
           message: Kube-state-metrics has disappeared from Prometheus target discovery.
         expr: absent(up{job="kube-state-metrics"} == 1)
         for: 15m
         labels:
-          severity: critical
+          severity: warning
 
       - alert: EtcdDown
         annotations:
@@ -579,6 +587,35 @@ data:
         for: 15m
         labels:
           severity: critical
+
+      # This is triggered if the cluster does have nodes, but the cadvisor could
+      # not successfully be scraped for whatever reason. An absent() on cadvisor
+      # metrics is not a good alert because clusters could simply have no nodes
+      # and hence no cadvisors.
+      - alert: CAdvisorDown
+        annotations:
+          message: cAdvisor on {{ $labels.kubernetes_io_hostname }} could not be scraped.
+        expr: up{job="cadvisor"} == 0
+        for: 15m
+        labels:
+          severity: warning
+
+      # This functions similarly to the cadvisor alert above.
+      - alert: KubernetesNodeDown
+        annotations:
+          message: The kubelet on {{ $labels.kubernetes_io_hostname }} could not be scraped.
+        expr: up{job="kubernetes-nodes"} == 0
+        for: 15m
+        labels:
+          severity: warning
+
+      - alert: DNSResolverDown
+        annotations:
+          message: DNS resolver has disappeared from Prometheus target discovery.
+        expr: absent(up{job="dns-resolver"} == 1)
+        for: 15m
+        labels:
+          severity: warning
 
     - name: kubernetes-nodes
       rules:

--- a/api/pkg/resources/test/fixtures/configmap-aws-1.12.0-dns-resolver.yaml
+++ b/api/pkg/resources/test/fixtures/configmap-aws-1.12.0-dns-resolver.yaml
@@ -13,6 +13,7 @@ data:
       forward . /etc/resolv.conf
       errors
       health
+      prometheus 0.0.0.0:9253
     }
 metadata:
   creationTimestamp: null

--- a/api/pkg/resources/test/fixtures/configmap-aws-1.12.0-prometheus.yaml
+++ b/api/pkg/resources/test/fixtures/configmap-aws-1.12.0-prometheus.yaml
@@ -519,7 +519,7 @@ data:
 
       - alert: FdExhaustionClose
         annotations:
-          description: '{{ $labels.job }} instance {{ $labels.instance }} will exhaust its file descriptors soon'
+          message: '{{ $labels.job }} instance {{ $labels.instance }} will exhaust its file descriptors soon'
         expr: |
           predict_linear(instance:fd_utilization[10m], 3600) > 1
         for: 10m
@@ -560,13 +560,21 @@ data:
         labels:
           severity: critical
 
+      - alert: UserClusterControllerDown
+        annotations:
+          message: User Cluster Controller has disappeared from Prometheus target discovery.
+        expr: absent(up{job="usercluster-controller"} == 1)
+        for: 15m
+        labels:
+          severity: critical
+
       - alert: KubeStateMetricsDown
         annotations:
           message: Kube-state-metrics has disappeared from Prometheus target discovery.
         expr: absent(up{job="kube-state-metrics"} == 1)
         for: 15m
         labels:
-          severity: critical
+          severity: warning
 
       - alert: EtcdDown
         annotations:
@@ -575,6 +583,35 @@ data:
         for: 15m
         labels:
           severity: critical
+
+      # This is triggered if the cluster does have nodes, but the cadvisor could
+      # not successfully be scraped for whatever reason. An absent() on cadvisor
+      # metrics is not a good alert because clusters could simply have no nodes
+      # and hence no cadvisors.
+      - alert: CAdvisorDown
+        annotations:
+          message: cAdvisor on {{ $labels.kubernetes_io_hostname }} could not be scraped.
+        expr: up{job="cadvisor"} == 0
+        for: 15m
+        labels:
+          severity: warning
+
+      # This functions similarly to the cadvisor alert above.
+      - alert: KubernetesNodeDown
+        annotations:
+          message: The kubelet on {{ $labels.kubernetes_io_hostname }} could not be scraped.
+        expr: up{job="kubernetes-nodes"} == 0
+        for: 15m
+        labels:
+          severity: warning
+
+      - alert: DNSResolverDown
+        annotations:
+          message: DNS resolver has disappeared from Prometheus target discovery.
+        expr: absent(up{job="dns-resolver"} == 1)
+        for: 15m
+        labels:
+          severity: warning
 
     - name: kubernetes-nodes
       rules:

--- a/api/pkg/resources/test/fixtures/configmap-aws-1.13.0-dns-resolver.yaml
+++ b/api/pkg/resources/test/fixtures/configmap-aws-1.13.0-dns-resolver.yaml
@@ -13,6 +13,7 @@ data:
       forward . /etc/resolv.conf
       errors
       health
+      prometheus 0.0.0.0:9253
     }
 metadata:
   creationTimestamp: null

--- a/api/pkg/resources/test/fixtures/configmap-aws-1.13.0-prometheus.yaml
+++ b/api/pkg/resources/test/fixtures/configmap-aws-1.13.0-prometheus.yaml
@@ -519,7 +519,7 @@ data:
 
       - alert: FdExhaustionClose
         annotations:
-          description: '{{ $labels.job }} instance {{ $labels.instance }} will exhaust its file descriptors soon'
+          message: '{{ $labels.job }} instance {{ $labels.instance }} will exhaust its file descriptors soon'
         expr: |
           predict_linear(instance:fd_utilization[10m], 3600) > 1
         for: 10m
@@ -560,13 +560,21 @@ data:
         labels:
           severity: critical
 
+      - alert: UserClusterControllerDown
+        annotations:
+          message: User Cluster Controller has disappeared from Prometheus target discovery.
+        expr: absent(up{job="usercluster-controller"} == 1)
+        for: 15m
+        labels:
+          severity: critical
+
       - alert: KubeStateMetricsDown
         annotations:
           message: Kube-state-metrics has disappeared from Prometheus target discovery.
         expr: absent(up{job="kube-state-metrics"} == 1)
         for: 15m
         labels:
-          severity: critical
+          severity: warning
 
       - alert: EtcdDown
         annotations:
@@ -575,6 +583,35 @@ data:
         for: 15m
         labels:
           severity: critical
+
+      # This is triggered if the cluster does have nodes, but the cadvisor could
+      # not successfully be scraped for whatever reason. An absent() on cadvisor
+      # metrics is not a good alert because clusters could simply have no nodes
+      # and hence no cadvisors.
+      - alert: CAdvisorDown
+        annotations:
+          message: cAdvisor on {{ $labels.kubernetes_io_hostname }} could not be scraped.
+        expr: up{job="cadvisor"} == 0
+        for: 15m
+        labels:
+          severity: warning
+
+      # This functions similarly to the cadvisor alert above.
+      - alert: KubernetesNodeDown
+        annotations:
+          message: The kubelet on {{ $labels.kubernetes_io_hostname }} could not be scraped.
+        expr: up{job="kubernetes-nodes"} == 0
+        for: 15m
+        labels:
+          severity: warning
+
+      - alert: DNSResolverDown
+        annotations:
+          message: DNS resolver has disappeared from Prometheus target discovery.
+        expr: absent(up{job="dns-resolver"} == 1)
+        for: 15m
+        labels:
+          severity: warning
 
     - name: kubernetes-nodes
       rules:

--- a/api/pkg/resources/test/fixtures/configmap-azure-1.10.0-dns-resolver.yaml
+++ b/api/pkg/resources/test/fixtures/configmap-azure-1.10.0-dns-resolver.yaml
@@ -13,6 +13,7 @@ data:
       forward . /etc/resolv.conf
       errors
       health
+      prometheus 0.0.0.0:9253
     }
 metadata:
   creationTimestamp: null

--- a/api/pkg/resources/test/fixtures/configmap-azure-1.10.0-prometheus.yaml
+++ b/api/pkg/resources/test/fixtures/configmap-azure-1.10.0-prometheus.yaml
@@ -519,7 +519,7 @@ data:
 
       - alert: FdExhaustionClose
         annotations:
-          description: '{{ $labels.job }} instance {{ $labels.instance }} will exhaust its file descriptors soon'
+          message: '{{ $labels.job }} instance {{ $labels.instance }} will exhaust its file descriptors soon'
         expr: |
           predict_linear(instance:fd_utilization[10m], 3600) > 1
         for: 10m
@@ -560,13 +560,21 @@ data:
         labels:
           severity: critical
 
+      - alert: UserClusterControllerDown
+        annotations:
+          message: User Cluster Controller has disappeared from Prometheus target discovery.
+        expr: absent(up{job="usercluster-controller"} == 1)
+        for: 15m
+        labels:
+          severity: critical
+
       - alert: KubeStateMetricsDown
         annotations:
           message: Kube-state-metrics has disappeared from Prometheus target discovery.
         expr: absent(up{job="kube-state-metrics"} == 1)
         for: 15m
         labels:
-          severity: critical
+          severity: warning
 
       - alert: EtcdDown
         annotations:
@@ -575,6 +583,35 @@ data:
         for: 15m
         labels:
           severity: critical
+
+      # This is triggered if the cluster does have nodes, but the cadvisor could
+      # not successfully be scraped for whatever reason. An absent() on cadvisor
+      # metrics is not a good alert because clusters could simply have no nodes
+      # and hence no cadvisors.
+      - alert: CAdvisorDown
+        annotations:
+          message: cAdvisor on {{ $labels.kubernetes_io_hostname }} could not be scraped.
+        expr: up{job="cadvisor"} == 0
+        for: 15m
+        labels:
+          severity: warning
+
+      # This functions similarly to the cadvisor alert above.
+      - alert: KubernetesNodeDown
+        annotations:
+          message: The kubelet on {{ $labels.kubernetes_io_hostname }} could not be scraped.
+        expr: up{job="kubernetes-nodes"} == 0
+        for: 15m
+        labels:
+          severity: warning
+
+      - alert: DNSResolverDown
+        annotations:
+          message: DNS resolver has disappeared from Prometheus target discovery.
+        expr: absent(up{job="dns-resolver"} == 1)
+        for: 15m
+        labels:
+          severity: warning
 
     - name: kubernetes-nodes
       rules:

--- a/api/pkg/resources/test/fixtures/configmap-azure-1.10.6-dns-resolver.yaml
+++ b/api/pkg/resources/test/fixtures/configmap-azure-1.10.6-dns-resolver.yaml
@@ -13,6 +13,7 @@ data:
       forward . /etc/resolv.conf
       errors
       health
+      prometheus 0.0.0.0:9253
     }
 metadata:
   creationTimestamp: null

--- a/api/pkg/resources/test/fixtures/configmap-azure-1.10.6-prometheus.yaml
+++ b/api/pkg/resources/test/fixtures/configmap-azure-1.10.6-prometheus.yaml
@@ -519,7 +519,7 @@ data:
 
       - alert: FdExhaustionClose
         annotations:
-          description: '{{ $labels.job }} instance {{ $labels.instance }} will exhaust its file descriptors soon'
+          message: '{{ $labels.job }} instance {{ $labels.instance }} will exhaust its file descriptors soon'
         expr: |
           predict_linear(instance:fd_utilization[10m], 3600) > 1
         for: 10m
@@ -560,13 +560,21 @@ data:
         labels:
           severity: critical
 
+      - alert: UserClusterControllerDown
+        annotations:
+          message: User Cluster Controller has disappeared from Prometheus target discovery.
+        expr: absent(up{job="usercluster-controller"} == 1)
+        for: 15m
+        labels:
+          severity: critical
+
       - alert: KubeStateMetricsDown
         annotations:
           message: Kube-state-metrics has disappeared from Prometheus target discovery.
         expr: absent(up{job="kube-state-metrics"} == 1)
         for: 15m
         labels:
-          severity: critical
+          severity: warning
 
       - alert: EtcdDown
         annotations:
@@ -575,6 +583,35 @@ data:
         for: 15m
         labels:
           severity: critical
+
+      # This is triggered if the cluster does have nodes, but the cadvisor could
+      # not successfully be scraped for whatever reason. An absent() on cadvisor
+      # metrics is not a good alert because clusters could simply have no nodes
+      # and hence no cadvisors.
+      - alert: CAdvisorDown
+        annotations:
+          message: cAdvisor on {{ $labels.kubernetes_io_hostname }} could not be scraped.
+        expr: up{job="cadvisor"} == 0
+        for: 15m
+        labels:
+          severity: warning
+
+      # This functions similarly to the cadvisor alert above.
+      - alert: KubernetesNodeDown
+        annotations:
+          message: The kubelet on {{ $labels.kubernetes_io_hostname }} could not be scraped.
+        expr: up{job="kubernetes-nodes"} == 0
+        for: 15m
+        labels:
+          severity: warning
+
+      - alert: DNSResolverDown
+        annotations:
+          message: DNS resolver has disappeared from Prometheus target discovery.
+        expr: absent(up{job="dns-resolver"} == 1)
+        for: 15m
+        labels:
+          severity: warning
 
     - name: kubernetes-nodes
       rules:

--- a/api/pkg/resources/test/fixtures/configmap-azure-1.11.0-dns-resolver.yaml
+++ b/api/pkg/resources/test/fixtures/configmap-azure-1.11.0-dns-resolver.yaml
@@ -13,6 +13,7 @@ data:
       forward . /etc/resolv.conf
       errors
       health
+      prometheus 0.0.0.0:9253
     }
 metadata:
   creationTimestamp: null

--- a/api/pkg/resources/test/fixtures/configmap-azure-1.11.0-prometheus.yaml
+++ b/api/pkg/resources/test/fixtures/configmap-azure-1.11.0-prometheus.yaml
@@ -523,7 +523,7 @@ data:
 
       - alert: FdExhaustionClose
         annotations:
-          description: '{{ $labels.job }} instance {{ $labels.instance }} will exhaust its file descriptors soon'
+          message: '{{ $labels.job }} instance {{ $labels.instance }} will exhaust its file descriptors soon'
         expr: |
           predict_linear(instance:fd_utilization[10m], 3600) > 1
         for: 10m
@@ -564,13 +564,21 @@ data:
         labels:
           severity: critical
 
+      - alert: UserClusterControllerDown
+        annotations:
+          message: User Cluster Controller has disappeared from Prometheus target discovery.
+        expr: absent(up{job="usercluster-controller"} == 1)
+        for: 15m
+        labels:
+          severity: critical
+
       - alert: KubeStateMetricsDown
         annotations:
           message: Kube-state-metrics has disappeared from Prometheus target discovery.
         expr: absent(up{job="kube-state-metrics"} == 1)
         for: 15m
         labels:
-          severity: critical
+          severity: warning
 
       - alert: EtcdDown
         annotations:
@@ -579,6 +587,35 @@ data:
         for: 15m
         labels:
           severity: critical
+
+      # This is triggered if the cluster does have nodes, but the cadvisor could
+      # not successfully be scraped for whatever reason. An absent() on cadvisor
+      # metrics is not a good alert because clusters could simply have no nodes
+      # and hence no cadvisors.
+      - alert: CAdvisorDown
+        annotations:
+          message: cAdvisor on {{ $labels.kubernetes_io_hostname }} could not be scraped.
+        expr: up{job="cadvisor"} == 0
+        for: 15m
+        labels:
+          severity: warning
+
+      # This functions similarly to the cadvisor alert above.
+      - alert: KubernetesNodeDown
+        annotations:
+          message: The kubelet on {{ $labels.kubernetes_io_hostname }} could not be scraped.
+        expr: up{job="kubernetes-nodes"} == 0
+        for: 15m
+        labels:
+          severity: warning
+
+      - alert: DNSResolverDown
+        annotations:
+          message: DNS resolver has disappeared from Prometheus target discovery.
+        expr: absent(up{job="dns-resolver"} == 1)
+        for: 15m
+        labels:
+          severity: warning
 
     - name: kubernetes-nodes
       rules:

--- a/api/pkg/resources/test/fixtures/configmap-azure-1.11.1-dns-resolver.yaml
+++ b/api/pkg/resources/test/fixtures/configmap-azure-1.11.1-dns-resolver.yaml
@@ -13,6 +13,7 @@ data:
       forward . /etc/resolv.conf
       errors
       health
+      prometheus 0.0.0.0:9253
     }
 metadata:
   creationTimestamp: null

--- a/api/pkg/resources/test/fixtures/configmap-azure-1.11.1-prometheus.yaml
+++ b/api/pkg/resources/test/fixtures/configmap-azure-1.11.1-prometheus.yaml
@@ -523,7 +523,7 @@ data:
 
       - alert: FdExhaustionClose
         annotations:
-          description: '{{ $labels.job }} instance {{ $labels.instance }} will exhaust its file descriptors soon'
+          message: '{{ $labels.job }} instance {{ $labels.instance }} will exhaust its file descriptors soon'
         expr: |
           predict_linear(instance:fd_utilization[10m], 3600) > 1
         for: 10m
@@ -564,13 +564,21 @@ data:
         labels:
           severity: critical
 
+      - alert: UserClusterControllerDown
+        annotations:
+          message: User Cluster Controller has disappeared from Prometheus target discovery.
+        expr: absent(up{job="usercluster-controller"} == 1)
+        for: 15m
+        labels:
+          severity: critical
+
       - alert: KubeStateMetricsDown
         annotations:
           message: Kube-state-metrics has disappeared from Prometheus target discovery.
         expr: absent(up{job="kube-state-metrics"} == 1)
         for: 15m
         labels:
-          severity: critical
+          severity: warning
 
       - alert: EtcdDown
         annotations:
@@ -579,6 +587,35 @@ data:
         for: 15m
         labels:
           severity: critical
+
+      # This is triggered if the cluster does have nodes, but the cadvisor could
+      # not successfully be scraped for whatever reason. An absent() on cadvisor
+      # metrics is not a good alert because clusters could simply have no nodes
+      # and hence no cadvisors.
+      - alert: CAdvisorDown
+        annotations:
+          message: cAdvisor on {{ $labels.kubernetes_io_hostname }} could not be scraped.
+        expr: up{job="cadvisor"} == 0
+        for: 15m
+        labels:
+          severity: warning
+
+      # This functions similarly to the cadvisor alert above.
+      - alert: KubernetesNodeDown
+        annotations:
+          message: The kubelet on {{ $labels.kubernetes_io_hostname }} could not be scraped.
+        expr: up{job="kubernetes-nodes"} == 0
+        for: 15m
+        labels:
+          severity: warning
+
+      - alert: DNSResolverDown
+        annotations:
+          message: DNS resolver has disappeared from Prometheus target discovery.
+        expr: absent(up{job="dns-resolver"} == 1)
+        for: 15m
+        labels:
+          severity: warning
 
     - name: kubernetes-nodes
       rules:

--- a/api/pkg/resources/test/fixtures/configmap-azure-1.12.0-dns-resolver.yaml
+++ b/api/pkg/resources/test/fixtures/configmap-azure-1.12.0-dns-resolver.yaml
@@ -13,6 +13,7 @@ data:
       forward . /etc/resolv.conf
       errors
       health
+      prometheus 0.0.0.0:9253
     }
 metadata:
   creationTimestamp: null

--- a/api/pkg/resources/test/fixtures/configmap-azure-1.12.0-prometheus.yaml
+++ b/api/pkg/resources/test/fixtures/configmap-azure-1.12.0-prometheus.yaml
@@ -519,7 +519,7 @@ data:
 
       - alert: FdExhaustionClose
         annotations:
-          description: '{{ $labels.job }} instance {{ $labels.instance }} will exhaust its file descriptors soon'
+          message: '{{ $labels.job }} instance {{ $labels.instance }} will exhaust its file descriptors soon'
         expr: |
           predict_linear(instance:fd_utilization[10m], 3600) > 1
         for: 10m
@@ -560,13 +560,21 @@ data:
         labels:
           severity: critical
 
+      - alert: UserClusterControllerDown
+        annotations:
+          message: User Cluster Controller has disappeared from Prometheus target discovery.
+        expr: absent(up{job="usercluster-controller"} == 1)
+        for: 15m
+        labels:
+          severity: critical
+
       - alert: KubeStateMetricsDown
         annotations:
           message: Kube-state-metrics has disappeared from Prometheus target discovery.
         expr: absent(up{job="kube-state-metrics"} == 1)
         for: 15m
         labels:
-          severity: critical
+          severity: warning
 
       - alert: EtcdDown
         annotations:
@@ -575,6 +583,35 @@ data:
         for: 15m
         labels:
           severity: critical
+
+      # This is triggered if the cluster does have nodes, but the cadvisor could
+      # not successfully be scraped for whatever reason. An absent() on cadvisor
+      # metrics is not a good alert because clusters could simply have no nodes
+      # and hence no cadvisors.
+      - alert: CAdvisorDown
+        annotations:
+          message: cAdvisor on {{ $labels.kubernetes_io_hostname }} could not be scraped.
+        expr: up{job="cadvisor"} == 0
+        for: 15m
+        labels:
+          severity: warning
+
+      # This functions similarly to the cadvisor alert above.
+      - alert: KubernetesNodeDown
+        annotations:
+          message: The kubelet on {{ $labels.kubernetes_io_hostname }} could not be scraped.
+        expr: up{job="kubernetes-nodes"} == 0
+        for: 15m
+        labels:
+          severity: warning
+
+      - alert: DNSResolverDown
+        annotations:
+          message: DNS resolver has disappeared from Prometheus target discovery.
+        expr: absent(up{job="dns-resolver"} == 1)
+        for: 15m
+        labels:
+          severity: warning
 
     - name: kubernetes-nodes
       rules:

--- a/api/pkg/resources/test/fixtures/configmap-azure-1.13.0-dns-resolver.yaml
+++ b/api/pkg/resources/test/fixtures/configmap-azure-1.13.0-dns-resolver.yaml
@@ -13,6 +13,7 @@ data:
       forward . /etc/resolv.conf
       errors
       health
+      prometheus 0.0.0.0:9253
     }
 metadata:
   creationTimestamp: null

--- a/api/pkg/resources/test/fixtures/configmap-azure-1.13.0-prometheus.yaml
+++ b/api/pkg/resources/test/fixtures/configmap-azure-1.13.0-prometheus.yaml
@@ -519,7 +519,7 @@ data:
 
       - alert: FdExhaustionClose
         annotations:
-          description: '{{ $labels.job }} instance {{ $labels.instance }} will exhaust its file descriptors soon'
+          message: '{{ $labels.job }} instance {{ $labels.instance }} will exhaust its file descriptors soon'
         expr: |
           predict_linear(instance:fd_utilization[10m], 3600) > 1
         for: 10m
@@ -560,13 +560,21 @@ data:
         labels:
           severity: critical
 
+      - alert: UserClusterControllerDown
+        annotations:
+          message: User Cluster Controller has disappeared from Prometheus target discovery.
+        expr: absent(up{job="usercluster-controller"} == 1)
+        for: 15m
+        labels:
+          severity: critical
+
       - alert: KubeStateMetricsDown
         annotations:
           message: Kube-state-metrics has disappeared from Prometheus target discovery.
         expr: absent(up{job="kube-state-metrics"} == 1)
         for: 15m
         labels:
-          severity: critical
+          severity: warning
 
       - alert: EtcdDown
         annotations:
@@ -575,6 +583,35 @@ data:
         for: 15m
         labels:
           severity: critical
+
+      # This is triggered if the cluster does have nodes, but the cadvisor could
+      # not successfully be scraped for whatever reason. An absent() on cadvisor
+      # metrics is not a good alert because clusters could simply have no nodes
+      # and hence no cadvisors.
+      - alert: CAdvisorDown
+        annotations:
+          message: cAdvisor on {{ $labels.kubernetes_io_hostname }} could not be scraped.
+        expr: up{job="cadvisor"} == 0
+        for: 15m
+        labels:
+          severity: warning
+
+      # This functions similarly to the cadvisor alert above.
+      - alert: KubernetesNodeDown
+        annotations:
+          message: The kubelet on {{ $labels.kubernetes_io_hostname }} could not be scraped.
+        expr: up{job="kubernetes-nodes"} == 0
+        for: 15m
+        labels:
+          severity: warning
+
+      - alert: DNSResolverDown
+        annotations:
+          message: DNS resolver has disappeared from Prometheus target discovery.
+        expr: absent(up{job="dns-resolver"} == 1)
+        for: 15m
+        labels:
+          severity: warning
 
     - name: kubernetes-nodes
       rules:

--- a/api/pkg/resources/test/fixtures/configmap-bringyourown-1.10.0-dns-resolver.yaml
+++ b/api/pkg/resources/test/fixtures/configmap-bringyourown-1.10.0-dns-resolver.yaml
@@ -13,6 +13,7 @@ data:
       forward . /etc/resolv.conf
       errors
       health
+      prometheus 0.0.0.0:9253
     }
 metadata:
   creationTimestamp: null

--- a/api/pkg/resources/test/fixtures/configmap-bringyourown-1.10.0-prometheus.yaml
+++ b/api/pkg/resources/test/fixtures/configmap-bringyourown-1.10.0-prometheus.yaml
@@ -519,7 +519,7 @@ data:
 
       - alert: FdExhaustionClose
         annotations:
-          description: '{{ $labels.job }} instance {{ $labels.instance }} will exhaust its file descriptors soon'
+          message: '{{ $labels.job }} instance {{ $labels.instance }} will exhaust its file descriptors soon'
         expr: |
           predict_linear(instance:fd_utilization[10m], 3600) > 1
         for: 10m
@@ -560,13 +560,21 @@ data:
         labels:
           severity: critical
 
+      - alert: UserClusterControllerDown
+        annotations:
+          message: User Cluster Controller has disappeared from Prometheus target discovery.
+        expr: absent(up{job="usercluster-controller"} == 1)
+        for: 15m
+        labels:
+          severity: critical
+
       - alert: KubeStateMetricsDown
         annotations:
           message: Kube-state-metrics has disappeared from Prometheus target discovery.
         expr: absent(up{job="kube-state-metrics"} == 1)
         for: 15m
         labels:
-          severity: critical
+          severity: warning
 
       - alert: EtcdDown
         annotations:
@@ -575,6 +583,35 @@ data:
         for: 15m
         labels:
           severity: critical
+
+      # This is triggered if the cluster does have nodes, but the cadvisor could
+      # not successfully be scraped for whatever reason. An absent() on cadvisor
+      # metrics is not a good alert because clusters could simply have no nodes
+      # and hence no cadvisors.
+      - alert: CAdvisorDown
+        annotations:
+          message: cAdvisor on {{ $labels.kubernetes_io_hostname }} could not be scraped.
+        expr: up{job="cadvisor"} == 0
+        for: 15m
+        labels:
+          severity: warning
+
+      # This functions similarly to the cadvisor alert above.
+      - alert: KubernetesNodeDown
+        annotations:
+          message: The kubelet on {{ $labels.kubernetes_io_hostname }} could not be scraped.
+        expr: up{job="kubernetes-nodes"} == 0
+        for: 15m
+        labels:
+          severity: warning
+
+      - alert: DNSResolverDown
+        annotations:
+          message: DNS resolver has disappeared from Prometheus target discovery.
+        expr: absent(up{job="dns-resolver"} == 1)
+        for: 15m
+        labels:
+          severity: warning
 
     - name: kubernetes-nodes
       rules:

--- a/api/pkg/resources/test/fixtures/configmap-bringyourown-1.10.6-dns-resolver.yaml
+++ b/api/pkg/resources/test/fixtures/configmap-bringyourown-1.10.6-dns-resolver.yaml
@@ -13,6 +13,7 @@ data:
       forward . /etc/resolv.conf
       errors
       health
+      prometheus 0.0.0.0:9253
     }
 metadata:
   creationTimestamp: null

--- a/api/pkg/resources/test/fixtures/configmap-bringyourown-1.10.6-prometheus.yaml
+++ b/api/pkg/resources/test/fixtures/configmap-bringyourown-1.10.6-prometheus.yaml
@@ -519,7 +519,7 @@ data:
 
       - alert: FdExhaustionClose
         annotations:
-          description: '{{ $labels.job }} instance {{ $labels.instance }} will exhaust its file descriptors soon'
+          message: '{{ $labels.job }} instance {{ $labels.instance }} will exhaust its file descriptors soon'
         expr: |
           predict_linear(instance:fd_utilization[10m], 3600) > 1
         for: 10m
@@ -560,13 +560,21 @@ data:
         labels:
           severity: critical
 
+      - alert: UserClusterControllerDown
+        annotations:
+          message: User Cluster Controller has disappeared from Prometheus target discovery.
+        expr: absent(up{job="usercluster-controller"} == 1)
+        for: 15m
+        labels:
+          severity: critical
+
       - alert: KubeStateMetricsDown
         annotations:
           message: Kube-state-metrics has disappeared from Prometheus target discovery.
         expr: absent(up{job="kube-state-metrics"} == 1)
         for: 15m
         labels:
-          severity: critical
+          severity: warning
 
       - alert: EtcdDown
         annotations:
@@ -575,6 +583,35 @@ data:
         for: 15m
         labels:
           severity: critical
+
+      # This is triggered if the cluster does have nodes, but the cadvisor could
+      # not successfully be scraped for whatever reason. An absent() on cadvisor
+      # metrics is not a good alert because clusters could simply have no nodes
+      # and hence no cadvisors.
+      - alert: CAdvisorDown
+        annotations:
+          message: cAdvisor on {{ $labels.kubernetes_io_hostname }} could not be scraped.
+        expr: up{job="cadvisor"} == 0
+        for: 15m
+        labels:
+          severity: warning
+
+      # This functions similarly to the cadvisor alert above.
+      - alert: KubernetesNodeDown
+        annotations:
+          message: The kubelet on {{ $labels.kubernetes_io_hostname }} could not be scraped.
+        expr: up{job="kubernetes-nodes"} == 0
+        for: 15m
+        labels:
+          severity: warning
+
+      - alert: DNSResolverDown
+        annotations:
+          message: DNS resolver has disappeared from Prometheus target discovery.
+        expr: absent(up{job="dns-resolver"} == 1)
+        for: 15m
+        labels:
+          severity: warning
 
     - name: kubernetes-nodes
       rules:

--- a/api/pkg/resources/test/fixtures/configmap-bringyourown-1.11.0-dns-resolver.yaml
+++ b/api/pkg/resources/test/fixtures/configmap-bringyourown-1.11.0-dns-resolver.yaml
@@ -13,6 +13,7 @@ data:
       forward . /etc/resolv.conf
       errors
       health
+      prometheus 0.0.0.0:9253
     }
 metadata:
   creationTimestamp: null

--- a/api/pkg/resources/test/fixtures/configmap-bringyourown-1.11.0-prometheus.yaml
+++ b/api/pkg/resources/test/fixtures/configmap-bringyourown-1.11.0-prometheus.yaml
@@ -523,7 +523,7 @@ data:
 
       - alert: FdExhaustionClose
         annotations:
-          description: '{{ $labels.job }} instance {{ $labels.instance }} will exhaust its file descriptors soon'
+          message: '{{ $labels.job }} instance {{ $labels.instance }} will exhaust its file descriptors soon'
         expr: |
           predict_linear(instance:fd_utilization[10m], 3600) > 1
         for: 10m
@@ -564,13 +564,21 @@ data:
         labels:
           severity: critical
 
+      - alert: UserClusterControllerDown
+        annotations:
+          message: User Cluster Controller has disappeared from Prometheus target discovery.
+        expr: absent(up{job="usercluster-controller"} == 1)
+        for: 15m
+        labels:
+          severity: critical
+
       - alert: KubeStateMetricsDown
         annotations:
           message: Kube-state-metrics has disappeared from Prometheus target discovery.
         expr: absent(up{job="kube-state-metrics"} == 1)
         for: 15m
         labels:
-          severity: critical
+          severity: warning
 
       - alert: EtcdDown
         annotations:
@@ -579,6 +587,35 @@ data:
         for: 15m
         labels:
           severity: critical
+
+      # This is triggered if the cluster does have nodes, but the cadvisor could
+      # not successfully be scraped for whatever reason. An absent() on cadvisor
+      # metrics is not a good alert because clusters could simply have no nodes
+      # and hence no cadvisors.
+      - alert: CAdvisorDown
+        annotations:
+          message: cAdvisor on {{ $labels.kubernetes_io_hostname }} could not be scraped.
+        expr: up{job="cadvisor"} == 0
+        for: 15m
+        labels:
+          severity: warning
+
+      # This functions similarly to the cadvisor alert above.
+      - alert: KubernetesNodeDown
+        annotations:
+          message: The kubelet on {{ $labels.kubernetes_io_hostname }} could not be scraped.
+        expr: up{job="kubernetes-nodes"} == 0
+        for: 15m
+        labels:
+          severity: warning
+
+      - alert: DNSResolverDown
+        annotations:
+          message: DNS resolver has disappeared from Prometheus target discovery.
+        expr: absent(up{job="dns-resolver"} == 1)
+        for: 15m
+        labels:
+          severity: warning
 
     - name: kubernetes-nodes
       rules:

--- a/api/pkg/resources/test/fixtures/configmap-bringyourown-1.11.1-dns-resolver.yaml
+++ b/api/pkg/resources/test/fixtures/configmap-bringyourown-1.11.1-dns-resolver.yaml
@@ -13,6 +13,7 @@ data:
       forward . /etc/resolv.conf
       errors
       health
+      prometheus 0.0.0.0:9253
     }
 metadata:
   creationTimestamp: null

--- a/api/pkg/resources/test/fixtures/configmap-bringyourown-1.11.1-prometheus.yaml
+++ b/api/pkg/resources/test/fixtures/configmap-bringyourown-1.11.1-prometheus.yaml
@@ -523,7 +523,7 @@ data:
 
       - alert: FdExhaustionClose
         annotations:
-          description: '{{ $labels.job }} instance {{ $labels.instance }} will exhaust its file descriptors soon'
+          message: '{{ $labels.job }} instance {{ $labels.instance }} will exhaust its file descriptors soon'
         expr: |
           predict_linear(instance:fd_utilization[10m], 3600) > 1
         for: 10m
@@ -564,13 +564,21 @@ data:
         labels:
           severity: critical
 
+      - alert: UserClusterControllerDown
+        annotations:
+          message: User Cluster Controller has disappeared from Prometheus target discovery.
+        expr: absent(up{job="usercluster-controller"} == 1)
+        for: 15m
+        labels:
+          severity: critical
+
       - alert: KubeStateMetricsDown
         annotations:
           message: Kube-state-metrics has disappeared from Prometheus target discovery.
         expr: absent(up{job="kube-state-metrics"} == 1)
         for: 15m
         labels:
-          severity: critical
+          severity: warning
 
       - alert: EtcdDown
         annotations:
@@ -579,6 +587,35 @@ data:
         for: 15m
         labels:
           severity: critical
+
+      # This is triggered if the cluster does have nodes, but the cadvisor could
+      # not successfully be scraped for whatever reason. An absent() on cadvisor
+      # metrics is not a good alert because clusters could simply have no nodes
+      # and hence no cadvisors.
+      - alert: CAdvisorDown
+        annotations:
+          message: cAdvisor on {{ $labels.kubernetes_io_hostname }} could not be scraped.
+        expr: up{job="cadvisor"} == 0
+        for: 15m
+        labels:
+          severity: warning
+
+      # This functions similarly to the cadvisor alert above.
+      - alert: KubernetesNodeDown
+        annotations:
+          message: The kubelet on {{ $labels.kubernetes_io_hostname }} could not be scraped.
+        expr: up{job="kubernetes-nodes"} == 0
+        for: 15m
+        labels:
+          severity: warning
+
+      - alert: DNSResolverDown
+        annotations:
+          message: DNS resolver has disappeared from Prometheus target discovery.
+        expr: absent(up{job="dns-resolver"} == 1)
+        for: 15m
+        labels:
+          severity: warning
 
     - name: kubernetes-nodes
       rules:

--- a/api/pkg/resources/test/fixtures/configmap-bringyourown-1.12.0-dns-resolver.yaml
+++ b/api/pkg/resources/test/fixtures/configmap-bringyourown-1.12.0-dns-resolver.yaml
@@ -13,6 +13,7 @@ data:
       forward . /etc/resolv.conf
       errors
       health
+      prometheus 0.0.0.0:9253
     }
 metadata:
   creationTimestamp: null

--- a/api/pkg/resources/test/fixtures/configmap-bringyourown-1.12.0-prometheus.yaml
+++ b/api/pkg/resources/test/fixtures/configmap-bringyourown-1.12.0-prometheus.yaml
@@ -519,7 +519,7 @@ data:
 
       - alert: FdExhaustionClose
         annotations:
-          description: '{{ $labels.job }} instance {{ $labels.instance }} will exhaust its file descriptors soon'
+          message: '{{ $labels.job }} instance {{ $labels.instance }} will exhaust its file descriptors soon'
         expr: |
           predict_linear(instance:fd_utilization[10m], 3600) > 1
         for: 10m
@@ -560,13 +560,21 @@ data:
         labels:
           severity: critical
 
+      - alert: UserClusterControllerDown
+        annotations:
+          message: User Cluster Controller has disappeared from Prometheus target discovery.
+        expr: absent(up{job="usercluster-controller"} == 1)
+        for: 15m
+        labels:
+          severity: critical
+
       - alert: KubeStateMetricsDown
         annotations:
           message: Kube-state-metrics has disappeared from Prometheus target discovery.
         expr: absent(up{job="kube-state-metrics"} == 1)
         for: 15m
         labels:
-          severity: critical
+          severity: warning
 
       - alert: EtcdDown
         annotations:
@@ -575,6 +583,35 @@ data:
         for: 15m
         labels:
           severity: critical
+
+      # This is triggered if the cluster does have nodes, but the cadvisor could
+      # not successfully be scraped for whatever reason. An absent() on cadvisor
+      # metrics is not a good alert because clusters could simply have no nodes
+      # and hence no cadvisors.
+      - alert: CAdvisorDown
+        annotations:
+          message: cAdvisor on {{ $labels.kubernetes_io_hostname }} could not be scraped.
+        expr: up{job="cadvisor"} == 0
+        for: 15m
+        labels:
+          severity: warning
+
+      # This functions similarly to the cadvisor alert above.
+      - alert: KubernetesNodeDown
+        annotations:
+          message: The kubelet on {{ $labels.kubernetes_io_hostname }} could not be scraped.
+        expr: up{job="kubernetes-nodes"} == 0
+        for: 15m
+        labels:
+          severity: warning
+
+      - alert: DNSResolverDown
+        annotations:
+          message: DNS resolver has disappeared from Prometheus target discovery.
+        expr: absent(up{job="dns-resolver"} == 1)
+        for: 15m
+        labels:
+          severity: warning
 
     - name: kubernetes-nodes
       rules:

--- a/api/pkg/resources/test/fixtures/configmap-bringyourown-1.13.0-dns-resolver.yaml
+++ b/api/pkg/resources/test/fixtures/configmap-bringyourown-1.13.0-dns-resolver.yaml
@@ -13,6 +13,7 @@ data:
       forward . /etc/resolv.conf
       errors
       health
+      prometheus 0.0.0.0:9253
     }
 metadata:
   creationTimestamp: null

--- a/api/pkg/resources/test/fixtures/configmap-bringyourown-1.13.0-prometheus.yaml
+++ b/api/pkg/resources/test/fixtures/configmap-bringyourown-1.13.0-prometheus.yaml
@@ -519,7 +519,7 @@ data:
 
       - alert: FdExhaustionClose
         annotations:
-          description: '{{ $labels.job }} instance {{ $labels.instance }} will exhaust its file descriptors soon'
+          message: '{{ $labels.job }} instance {{ $labels.instance }} will exhaust its file descriptors soon'
         expr: |
           predict_linear(instance:fd_utilization[10m], 3600) > 1
         for: 10m
@@ -560,13 +560,21 @@ data:
         labels:
           severity: critical
 
+      - alert: UserClusterControllerDown
+        annotations:
+          message: User Cluster Controller has disappeared from Prometheus target discovery.
+        expr: absent(up{job="usercluster-controller"} == 1)
+        for: 15m
+        labels:
+          severity: critical
+
       - alert: KubeStateMetricsDown
         annotations:
           message: Kube-state-metrics has disappeared from Prometheus target discovery.
         expr: absent(up{job="kube-state-metrics"} == 1)
         for: 15m
         labels:
-          severity: critical
+          severity: warning
 
       - alert: EtcdDown
         annotations:
@@ -575,6 +583,35 @@ data:
         for: 15m
         labels:
           severity: critical
+
+      # This is triggered if the cluster does have nodes, but the cadvisor could
+      # not successfully be scraped for whatever reason. An absent() on cadvisor
+      # metrics is not a good alert because clusters could simply have no nodes
+      # and hence no cadvisors.
+      - alert: CAdvisorDown
+        annotations:
+          message: cAdvisor on {{ $labels.kubernetes_io_hostname }} could not be scraped.
+        expr: up{job="cadvisor"} == 0
+        for: 15m
+        labels:
+          severity: warning
+
+      # This functions similarly to the cadvisor alert above.
+      - alert: KubernetesNodeDown
+        annotations:
+          message: The kubelet on {{ $labels.kubernetes_io_hostname }} could not be scraped.
+        expr: up{job="kubernetes-nodes"} == 0
+        for: 15m
+        labels:
+          severity: warning
+
+      - alert: DNSResolverDown
+        annotations:
+          message: DNS resolver has disappeared from Prometheus target discovery.
+        expr: absent(up{job="dns-resolver"} == 1)
+        for: 15m
+        labels:
+          severity: warning
 
     - name: kubernetes-nodes
       rules:

--- a/api/pkg/resources/test/fixtures/configmap-digitalocean-1.10.0-dns-resolver.yaml
+++ b/api/pkg/resources/test/fixtures/configmap-digitalocean-1.10.0-dns-resolver.yaml
@@ -13,6 +13,7 @@ data:
       forward . /etc/resolv.conf
       errors
       health
+      prometheus 0.0.0.0:9253
     }
 metadata:
   creationTimestamp: null

--- a/api/pkg/resources/test/fixtures/configmap-digitalocean-1.10.0-prometheus.yaml
+++ b/api/pkg/resources/test/fixtures/configmap-digitalocean-1.10.0-prometheus.yaml
@@ -519,7 +519,7 @@ data:
 
       - alert: FdExhaustionClose
         annotations:
-          description: '{{ $labels.job }} instance {{ $labels.instance }} will exhaust its file descriptors soon'
+          message: '{{ $labels.job }} instance {{ $labels.instance }} will exhaust its file descriptors soon'
         expr: |
           predict_linear(instance:fd_utilization[10m], 3600) > 1
         for: 10m
@@ -560,13 +560,21 @@ data:
         labels:
           severity: critical
 
+      - alert: UserClusterControllerDown
+        annotations:
+          message: User Cluster Controller has disappeared from Prometheus target discovery.
+        expr: absent(up{job="usercluster-controller"} == 1)
+        for: 15m
+        labels:
+          severity: critical
+
       - alert: KubeStateMetricsDown
         annotations:
           message: Kube-state-metrics has disappeared from Prometheus target discovery.
         expr: absent(up{job="kube-state-metrics"} == 1)
         for: 15m
         labels:
-          severity: critical
+          severity: warning
 
       - alert: EtcdDown
         annotations:
@@ -575,6 +583,35 @@ data:
         for: 15m
         labels:
           severity: critical
+
+      # This is triggered if the cluster does have nodes, but the cadvisor could
+      # not successfully be scraped for whatever reason. An absent() on cadvisor
+      # metrics is not a good alert because clusters could simply have no nodes
+      # and hence no cadvisors.
+      - alert: CAdvisorDown
+        annotations:
+          message: cAdvisor on {{ $labels.kubernetes_io_hostname }} could not be scraped.
+        expr: up{job="cadvisor"} == 0
+        for: 15m
+        labels:
+          severity: warning
+
+      # This functions similarly to the cadvisor alert above.
+      - alert: KubernetesNodeDown
+        annotations:
+          message: The kubelet on {{ $labels.kubernetes_io_hostname }} could not be scraped.
+        expr: up{job="kubernetes-nodes"} == 0
+        for: 15m
+        labels:
+          severity: warning
+
+      - alert: DNSResolverDown
+        annotations:
+          message: DNS resolver has disappeared from Prometheus target discovery.
+        expr: absent(up{job="dns-resolver"} == 1)
+        for: 15m
+        labels:
+          severity: warning
 
     - name: kubernetes-nodes
       rules:

--- a/api/pkg/resources/test/fixtures/configmap-digitalocean-1.10.6-dns-resolver.yaml
+++ b/api/pkg/resources/test/fixtures/configmap-digitalocean-1.10.6-dns-resolver.yaml
@@ -13,6 +13,7 @@ data:
       forward . /etc/resolv.conf
       errors
       health
+      prometheus 0.0.0.0:9253
     }
 metadata:
   creationTimestamp: null

--- a/api/pkg/resources/test/fixtures/configmap-digitalocean-1.10.6-prometheus.yaml
+++ b/api/pkg/resources/test/fixtures/configmap-digitalocean-1.10.6-prometheus.yaml
@@ -519,7 +519,7 @@ data:
 
       - alert: FdExhaustionClose
         annotations:
-          description: '{{ $labels.job }} instance {{ $labels.instance }} will exhaust its file descriptors soon'
+          message: '{{ $labels.job }} instance {{ $labels.instance }} will exhaust its file descriptors soon'
         expr: |
           predict_linear(instance:fd_utilization[10m], 3600) > 1
         for: 10m
@@ -560,13 +560,21 @@ data:
         labels:
           severity: critical
 
+      - alert: UserClusterControllerDown
+        annotations:
+          message: User Cluster Controller has disappeared from Prometheus target discovery.
+        expr: absent(up{job="usercluster-controller"} == 1)
+        for: 15m
+        labels:
+          severity: critical
+
       - alert: KubeStateMetricsDown
         annotations:
           message: Kube-state-metrics has disappeared from Prometheus target discovery.
         expr: absent(up{job="kube-state-metrics"} == 1)
         for: 15m
         labels:
-          severity: critical
+          severity: warning
 
       - alert: EtcdDown
         annotations:
@@ -575,6 +583,35 @@ data:
         for: 15m
         labels:
           severity: critical
+
+      # This is triggered if the cluster does have nodes, but the cadvisor could
+      # not successfully be scraped for whatever reason. An absent() on cadvisor
+      # metrics is not a good alert because clusters could simply have no nodes
+      # and hence no cadvisors.
+      - alert: CAdvisorDown
+        annotations:
+          message: cAdvisor on {{ $labels.kubernetes_io_hostname }} could not be scraped.
+        expr: up{job="cadvisor"} == 0
+        for: 15m
+        labels:
+          severity: warning
+
+      # This functions similarly to the cadvisor alert above.
+      - alert: KubernetesNodeDown
+        annotations:
+          message: The kubelet on {{ $labels.kubernetes_io_hostname }} could not be scraped.
+        expr: up{job="kubernetes-nodes"} == 0
+        for: 15m
+        labels:
+          severity: warning
+
+      - alert: DNSResolverDown
+        annotations:
+          message: DNS resolver has disappeared from Prometheus target discovery.
+        expr: absent(up{job="dns-resolver"} == 1)
+        for: 15m
+        labels:
+          severity: warning
 
     - name: kubernetes-nodes
       rules:

--- a/api/pkg/resources/test/fixtures/configmap-digitalocean-1.11.0-dns-resolver.yaml
+++ b/api/pkg/resources/test/fixtures/configmap-digitalocean-1.11.0-dns-resolver.yaml
@@ -13,6 +13,7 @@ data:
       forward . /etc/resolv.conf
       errors
       health
+      prometheus 0.0.0.0:9253
     }
 metadata:
   creationTimestamp: null

--- a/api/pkg/resources/test/fixtures/configmap-digitalocean-1.11.0-prometheus.yaml
+++ b/api/pkg/resources/test/fixtures/configmap-digitalocean-1.11.0-prometheus.yaml
@@ -523,7 +523,7 @@ data:
 
       - alert: FdExhaustionClose
         annotations:
-          description: '{{ $labels.job }} instance {{ $labels.instance }} will exhaust its file descriptors soon'
+          message: '{{ $labels.job }} instance {{ $labels.instance }} will exhaust its file descriptors soon'
         expr: |
           predict_linear(instance:fd_utilization[10m], 3600) > 1
         for: 10m
@@ -564,13 +564,21 @@ data:
         labels:
           severity: critical
 
+      - alert: UserClusterControllerDown
+        annotations:
+          message: User Cluster Controller has disappeared from Prometheus target discovery.
+        expr: absent(up{job="usercluster-controller"} == 1)
+        for: 15m
+        labels:
+          severity: critical
+
       - alert: KubeStateMetricsDown
         annotations:
           message: Kube-state-metrics has disappeared from Prometheus target discovery.
         expr: absent(up{job="kube-state-metrics"} == 1)
         for: 15m
         labels:
-          severity: critical
+          severity: warning
 
       - alert: EtcdDown
         annotations:
@@ -579,6 +587,35 @@ data:
         for: 15m
         labels:
           severity: critical
+
+      # This is triggered if the cluster does have nodes, but the cadvisor could
+      # not successfully be scraped for whatever reason. An absent() on cadvisor
+      # metrics is not a good alert because clusters could simply have no nodes
+      # and hence no cadvisors.
+      - alert: CAdvisorDown
+        annotations:
+          message: cAdvisor on {{ $labels.kubernetes_io_hostname }} could not be scraped.
+        expr: up{job="cadvisor"} == 0
+        for: 15m
+        labels:
+          severity: warning
+
+      # This functions similarly to the cadvisor alert above.
+      - alert: KubernetesNodeDown
+        annotations:
+          message: The kubelet on {{ $labels.kubernetes_io_hostname }} could not be scraped.
+        expr: up{job="kubernetes-nodes"} == 0
+        for: 15m
+        labels:
+          severity: warning
+
+      - alert: DNSResolverDown
+        annotations:
+          message: DNS resolver has disappeared from Prometheus target discovery.
+        expr: absent(up{job="dns-resolver"} == 1)
+        for: 15m
+        labels:
+          severity: warning
 
     - name: kubernetes-nodes
       rules:

--- a/api/pkg/resources/test/fixtures/configmap-digitalocean-1.11.1-dns-resolver.yaml
+++ b/api/pkg/resources/test/fixtures/configmap-digitalocean-1.11.1-dns-resolver.yaml
@@ -13,6 +13,7 @@ data:
       forward . /etc/resolv.conf
       errors
       health
+      prometheus 0.0.0.0:9253
     }
 metadata:
   creationTimestamp: null

--- a/api/pkg/resources/test/fixtures/configmap-digitalocean-1.11.1-prometheus.yaml
+++ b/api/pkg/resources/test/fixtures/configmap-digitalocean-1.11.1-prometheus.yaml
@@ -523,7 +523,7 @@ data:
 
       - alert: FdExhaustionClose
         annotations:
-          description: '{{ $labels.job }} instance {{ $labels.instance }} will exhaust its file descriptors soon'
+          message: '{{ $labels.job }} instance {{ $labels.instance }} will exhaust its file descriptors soon'
         expr: |
           predict_linear(instance:fd_utilization[10m], 3600) > 1
         for: 10m
@@ -564,13 +564,21 @@ data:
         labels:
           severity: critical
 
+      - alert: UserClusterControllerDown
+        annotations:
+          message: User Cluster Controller has disappeared from Prometheus target discovery.
+        expr: absent(up{job="usercluster-controller"} == 1)
+        for: 15m
+        labels:
+          severity: critical
+
       - alert: KubeStateMetricsDown
         annotations:
           message: Kube-state-metrics has disappeared from Prometheus target discovery.
         expr: absent(up{job="kube-state-metrics"} == 1)
         for: 15m
         labels:
-          severity: critical
+          severity: warning
 
       - alert: EtcdDown
         annotations:
@@ -579,6 +587,35 @@ data:
         for: 15m
         labels:
           severity: critical
+
+      # This is triggered if the cluster does have nodes, but the cadvisor could
+      # not successfully be scraped for whatever reason. An absent() on cadvisor
+      # metrics is not a good alert because clusters could simply have no nodes
+      # and hence no cadvisors.
+      - alert: CAdvisorDown
+        annotations:
+          message: cAdvisor on {{ $labels.kubernetes_io_hostname }} could not be scraped.
+        expr: up{job="cadvisor"} == 0
+        for: 15m
+        labels:
+          severity: warning
+
+      # This functions similarly to the cadvisor alert above.
+      - alert: KubernetesNodeDown
+        annotations:
+          message: The kubelet on {{ $labels.kubernetes_io_hostname }} could not be scraped.
+        expr: up{job="kubernetes-nodes"} == 0
+        for: 15m
+        labels:
+          severity: warning
+
+      - alert: DNSResolverDown
+        annotations:
+          message: DNS resolver has disappeared from Prometheus target discovery.
+        expr: absent(up{job="dns-resolver"} == 1)
+        for: 15m
+        labels:
+          severity: warning
 
     - name: kubernetes-nodes
       rules:

--- a/api/pkg/resources/test/fixtures/configmap-digitalocean-1.12.0-dns-resolver.yaml
+++ b/api/pkg/resources/test/fixtures/configmap-digitalocean-1.12.0-dns-resolver.yaml
@@ -13,6 +13,7 @@ data:
       forward . /etc/resolv.conf
       errors
       health
+      prometheus 0.0.0.0:9253
     }
 metadata:
   creationTimestamp: null

--- a/api/pkg/resources/test/fixtures/configmap-digitalocean-1.12.0-prometheus.yaml
+++ b/api/pkg/resources/test/fixtures/configmap-digitalocean-1.12.0-prometheus.yaml
@@ -519,7 +519,7 @@ data:
 
       - alert: FdExhaustionClose
         annotations:
-          description: '{{ $labels.job }} instance {{ $labels.instance }} will exhaust its file descriptors soon'
+          message: '{{ $labels.job }} instance {{ $labels.instance }} will exhaust its file descriptors soon'
         expr: |
           predict_linear(instance:fd_utilization[10m], 3600) > 1
         for: 10m
@@ -560,13 +560,21 @@ data:
         labels:
           severity: critical
 
+      - alert: UserClusterControllerDown
+        annotations:
+          message: User Cluster Controller has disappeared from Prometheus target discovery.
+        expr: absent(up{job="usercluster-controller"} == 1)
+        for: 15m
+        labels:
+          severity: critical
+
       - alert: KubeStateMetricsDown
         annotations:
           message: Kube-state-metrics has disappeared from Prometheus target discovery.
         expr: absent(up{job="kube-state-metrics"} == 1)
         for: 15m
         labels:
-          severity: critical
+          severity: warning
 
       - alert: EtcdDown
         annotations:
@@ -575,6 +583,35 @@ data:
         for: 15m
         labels:
           severity: critical
+
+      # This is triggered if the cluster does have nodes, but the cadvisor could
+      # not successfully be scraped for whatever reason. An absent() on cadvisor
+      # metrics is not a good alert because clusters could simply have no nodes
+      # and hence no cadvisors.
+      - alert: CAdvisorDown
+        annotations:
+          message: cAdvisor on {{ $labels.kubernetes_io_hostname }} could not be scraped.
+        expr: up{job="cadvisor"} == 0
+        for: 15m
+        labels:
+          severity: warning
+
+      # This functions similarly to the cadvisor alert above.
+      - alert: KubernetesNodeDown
+        annotations:
+          message: The kubelet on {{ $labels.kubernetes_io_hostname }} could not be scraped.
+        expr: up{job="kubernetes-nodes"} == 0
+        for: 15m
+        labels:
+          severity: warning
+
+      - alert: DNSResolverDown
+        annotations:
+          message: DNS resolver has disappeared from Prometheus target discovery.
+        expr: absent(up{job="dns-resolver"} == 1)
+        for: 15m
+        labels:
+          severity: warning
 
     - name: kubernetes-nodes
       rules:

--- a/api/pkg/resources/test/fixtures/configmap-digitalocean-1.13.0-dns-resolver.yaml
+++ b/api/pkg/resources/test/fixtures/configmap-digitalocean-1.13.0-dns-resolver.yaml
@@ -13,6 +13,7 @@ data:
       forward . /etc/resolv.conf
       errors
       health
+      prometheus 0.0.0.0:9253
     }
 metadata:
   creationTimestamp: null

--- a/api/pkg/resources/test/fixtures/configmap-digitalocean-1.13.0-prometheus.yaml
+++ b/api/pkg/resources/test/fixtures/configmap-digitalocean-1.13.0-prometheus.yaml
@@ -519,7 +519,7 @@ data:
 
       - alert: FdExhaustionClose
         annotations:
-          description: '{{ $labels.job }} instance {{ $labels.instance }} will exhaust its file descriptors soon'
+          message: '{{ $labels.job }} instance {{ $labels.instance }} will exhaust its file descriptors soon'
         expr: |
           predict_linear(instance:fd_utilization[10m], 3600) > 1
         for: 10m
@@ -560,13 +560,21 @@ data:
         labels:
           severity: critical
 
+      - alert: UserClusterControllerDown
+        annotations:
+          message: User Cluster Controller has disappeared from Prometheus target discovery.
+        expr: absent(up{job="usercluster-controller"} == 1)
+        for: 15m
+        labels:
+          severity: critical
+
       - alert: KubeStateMetricsDown
         annotations:
           message: Kube-state-metrics has disappeared from Prometheus target discovery.
         expr: absent(up{job="kube-state-metrics"} == 1)
         for: 15m
         labels:
-          severity: critical
+          severity: warning
 
       - alert: EtcdDown
         annotations:
@@ -575,6 +583,35 @@ data:
         for: 15m
         labels:
           severity: critical
+
+      # This is triggered if the cluster does have nodes, but the cadvisor could
+      # not successfully be scraped for whatever reason. An absent() on cadvisor
+      # metrics is not a good alert because clusters could simply have no nodes
+      # and hence no cadvisors.
+      - alert: CAdvisorDown
+        annotations:
+          message: cAdvisor on {{ $labels.kubernetes_io_hostname }} could not be scraped.
+        expr: up{job="cadvisor"} == 0
+        for: 15m
+        labels:
+          severity: warning
+
+      # This functions similarly to the cadvisor alert above.
+      - alert: KubernetesNodeDown
+        annotations:
+          message: The kubelet on {{ $labels.kubernetes_io_hostname }} could not be scraped.
+        expr: up{job="kubernetes-nodes"} == 0
+        for: 15m
+        labels:
+          severity: warning
+
+      - alert: DNSResolverDown
+        annotations:
+          message: DNS resolver has disappeared from Prometheus target discovery.
+        expr: absent(up{job="dns-resolver"} == 1)
+        for: 15m
+        labels:
+          severity: warning
 
     - name: kubernetes-nodes
       rules:

--- a/api/pkg/resources/test/fixtures/configmap-openstack-1.10.0-dns-resolver.yaml
+++ b/api/pkg/resources/test/fixtures/configmap-openstack-1.10.0-dns-resolver.yaml
@@ -13,6 +13,7 @@ data:
       forward . /etc/resolv.conf
       errors
       health
+      prometheus 0.0.0.0:9253
     }
 metadata:
   creationTimestamp: null

--- a/api/pkg/resources/test/fixtures/configmap-openstack-1.10.0-prometheus.yaml
+++ b/api/pkg/resources/test/fixtures/configmap-openstack-1.10.0-prometheus.yaml
@@ -519,7 +519,7 @@ data:
 
       - alert: FdExhaustionClose
         annotations:
-          description: '{{ $labels.job }} instance {{ $labels.instance }} will exhaust its file descriptors soon'
+          message: '{{ $labels.job }} instance {{ $labels.instance }} will exhaust its file descriptors soon'
         expr: |
           predict_linear(instance:fd_utilization[10m], 3600) > 1
         for: 10m
@@ -560,13 +560,21 @@ data:
         labels:
           severity: critical
 
+      - alert: UserClusterControllerDown
+        annotations:
+          message: User Cluster Controller has disappeared from Prometheus target discovery.
+        expr: absent(up{job="usercluster-controller"} == 1)
+        for: 15m
+        labels:
+          severity: critical
+
       - alert: KubeStateMetricsDown
         annotations:
           message: Kube-state-metrics has disappeared from Prometheus target discovery.
         expr: absent(up{job="kube-state-metrics"} == 1)
         for: 15m
         labels:
-          severity: critical
+          severity: warning
 
       - alert: EtcdDown
         annotations:
@@ -575,6 +583,35 @@ data:
         for: 15m
         labels:
           severity: critical
+
+      # This is triggered if the cluster does have nodes, but the cadvisor could
+      # not successfully be scraped for whatever reason. An absent() on cadvisor
+      # metrics is not a good alert because clusters could simply have no nodes
+      # and hence no cadvisors.
+      - alert: CAdvisorDown
+        annotations:
+          message: cAdvisor on {{ $labels.kubernetes_io_hostname }} could not be scraped.
+        expr: up{job="cadvisor"} == 0
+        for: 15m
+        labels:
+          severity: warning
+
+      # This functions similarly to the cadvisor alert above.
+      - alert: KubernetesNodeDown
+        annotations:
+          message: The kubelet on {{ $labels.kubernetes_io_hostname }} could not be scraped.
+        expr: up{job="kubernetes-nodes"} == 0
+        for: 15m
+        labels:
+          severity: warning
+
+      - alert: DNSResolverDown
+        annotations:
+          message: DNS resolver has disappeared from Prometheus target discovery.
+        expr: absent(up{job="dns-resolver"} == 1)
+        for: 15m
+        labels:
+          severity: warning
 
     - name: kubernetes-nodes
       rules:

--- a/api/pkg/resources/test/fixtures/configmap-openstack-1.10.6-dns-resolver.yaml
+++ b/api/pkg/resources/test/fixtures/configmap-openstack-1.10.6-dns-resolver.yaml
@@ -13,6 +13,7 @@ data:
       forward . /etc/resolv.conf
       errors
       health
+      prometheus 0.0.0.0:9253
     }
 metadata:
   creationTimestamp: null

--- a/api/pkg/resources/test/fixtures/configmap-openstack-1.10.6-prometheus.yaml
+++ b/api/pkg/resources/test/fixtures/configmap-openstack-1.10.6-prometheus.yaml
@@ -519,7 +519,7 @@ data:
 
       - alert: FdExhaustionClose
         annotations:
-          description: '{{ $labels.job }} instance {{ $labels.instance }} will exhaust its file descriptors soon'
+          message: '{{ $labels.job }} instance {{ $labels.instance }} will exhaust its file descriptors soon'
         expr: |
           predict_linear(instance:fd_utilization[10m], 3600) > 1
         for: 10m
@@ -560,13 +560,21 @@ data:
         labels:
           severity: critical
 
+      - alert: UserClusterControllerDown
+        annotations:
+          message: User Cluster Controller has disappeared from Prometheus target discovery.
+        expr: absent(up{job="usercluster-controller"} == 1)
+        for: 15m
+        labels:
+          severity: critical
+
       - alert: KubeStateMetricsDown
         annotations:
           message: Kube-state-metrics has disappeared from Prometheus target discovery.
         expr: absent(up{job="kube-state-metrics"} == 1)
         for: 15m
         labels:
-          severity: critical
+          severity: warning
 
       - alert: EtcdDown
         annotations:
@@ -575,6 +583,35 @@ data:
         for: 15m
         labels:
           severity: critical
+
+      # This is triggered if the cluster does have nodes, but the cadvisor could
+      # not successfully be scraped for whatever reason. An absent() on cadvisor
+      # metrics is not a good alert because clusters could simply have no nodes
+      # and hence no cadvisors.
+      - alert: CAdvisorDown
+        annotations:
+          message: cAdvisor on {{ $labels.kubernetes_io_hostname }} could not be scraped.
+        expr: up{job="cadvisor"} == 0
+        for: 15m
+        labels:
+          severity: warning
+
+      # This functions similarly to the cadvisor alert above.
+      - alert: KubernetesNodeDown
+        annotations:
+          message: The kubelet on {{ $labels.kubernetes_io_hostname }} could not be scraped.
+        expr: up{job="kubernetes-nodes"} == 0
+        for: 15m
+        labels:
+          severity: warning
+
+      - alert: DNSResolverDown
+        annotations:
+          message: DNS resolver has disappeared from Prometheus target discovery.
+        expr: absent(up{job="dns-resolver"} == 1)
+        for: 15m
+        labels:
+          severity: warning
 
     - name: kubernetes-nodes
       rules:

--- a/api/pkg/resources/test/fixtures/configmap-openstack-1.11.0-dns-resolver.yaml
+++ b/api/pkg/resources/test/fixtures/configmap-openstack-1.11.0-dns-resolver.yaml
@@ -13,6 +13,7 @@ data:
       forward . /etc/resolv.conf
       errors
       health
+      prometheus 0.0.0.0:9253
     }
 metadata:
   creationTimestamp: null

--- a/api/pkg/resources/test/fixtures/configmap-openstack-1.11.0-prometheus.yaml
+++ b/api/pkg/resources/test/fixtures/configmap-openstack-1.11.0-prometheus.yaml
@@ -523,7 +523,7 @@ data:
 
       - alert: FdExhaustionClose
         annotations:
-          description: '{{ $labels.job }} instance {{ $labels.instance }} will exhaust its file descriptors soon'
+          message: '{{ $labels.job }} instance {{ $labels.instance }} will exhaust its file descriptors soon'
         expr: |
           predict_linear(instance:fd_utilization[10m], 3600) > 1
         for: 10m
@@ -564,13 +564,21 @@ data:
         labels:
           severity: critical
 
+      - alert: UserClusterControllerDown
+        annotations:
+          message: User Cluster Controller has disappeared from Prometheus target discovery.
+        expr: absent(up{job="usercluster-controller"} == 1)
+        for: 15m
+        labels:
+          severity: critical
+
       - alert: KubeStateMetricsDown
         annotations:
           message: Kube-state-metrics has disappeared from Prometheus target discovery.
         expr: absent(up{job="kube-state-metrics"} == 1)
         for: 15m
         labels:
-          severity: critical
+          severity: warning
 
       - alert: EtcdDown
         annotations:
@@ -579,6 +587,35 @@ data:
         for: 15m
         labels:
           severity: critical
+
+      # This is triggered if the cluster does have nodes, but the cadvisor could
+      # not successfully be scraped for whatever reason. An absent() on cadvisor
+      # metrics is not a good alert because clusters could simply have no nodes
+      # and hence no cadvisors.
+      - alert: CAdvisorDown
+        annotations:
+          message: cAdvisor on {{ $labels.kubernetes_io_hostname }} could not be scraped.
+        expr: up{job="cadvisor"} == 0
+        for: 15m
+        labels:
+          severity: warning
+
+      # This functions similarly to the cadvisor alert above.
+      - alert: KubernetesNodeDown
+        annotations:
+          message: The kubelet on {{ $labels.kubernetes_io_hostname }} could not be scraped.
+        expr: up{job="kubernetes-nodes"} == 0
+        for: 15m
+        labels:
+          severity: warning
+
+      - alert: DNSResolverDown
+        annotations:
+          message: DNS resolver has disappeared from Prometheus target discovery.
+        expr: absent(up{job="dns-resolver"} == 1)
+        for: 15m
+        labels:
+          severity: warning
 
     - name: kubernetes-nodes
       rules:

--- a/api/pkg/resources/test/fixtures/configmap-openstack-1.11.1-dns-resolver.yaml
+++ b/api/pkg/resources/test/fixtures/configmap-openstack-1.11.1-dns-resolver.yaml
@@ -13,6 +13,7 @@ data:
       forward . /etc/resolv.conf
       errors
       health
+      prometheus 0.0.0.0:9253
     }
 metadata:
   creationTimestamp: null

--- a/api/pkg/resources/test/fixtures/configmap-openstack-1.11.1-prometheus.yaml
+++ b/api/pkg/resources/test/fixtures/configmap-openstack-1.11.1-prometheus.yaml
@@ -523,7 +523,7 @@ data:
 
       - alert: FdExhaustionClose
         annotations:
-          description: '{{ $labels.job }} instance {{ $labels.instance }} will exhaust its file descriptors soon'
+          message: '{{ $labels.job }} instance {{ $labels.instance }} will exhaust its file descriptors soon'
         expr: |
           predict_linear(instance:fd_utilization[10m], 3600) > 1
         for: 10m
@@ -564,13 +564,21 @@ data:
         labels:
           severity: critical
 
+      - alert: UserClusterControllerDown
+        annotations:
+          message: User Cluster Controller has disappeared from Prometheus target discovery.
+        expr: absent(up{job="usercluster-controller"} == 1)
+        for: 15m
+        labels:
+          severity: critical
+
       - alert: KubeStateMetricsDown
         annotations:
           message: Kube-state-metrics has disappeared from Prometheus target discovery.
         expr: absent(up{job="kube-state-metrics"} == 1)
         for: 15m
         labels:
-          severity: critical
+          severity: warning
 
       - alert: EtcdDown
         annotations:
@@ -579,6 +587,35 @@ data:
         for: 15m
         labels:
           severity: critical
+
+      # This is triggered if the cluster does have nodes, but the cadvisor could
+      # not successfully be scraped for whatever reason. An absent() on cadvisor
+      # metrics is not a good alert because clusters could simply have no nodes
+      # and hence no cadvisors.
+      - alert: CAdvisorDown
+        annotations:
+          message: cAdvisor on {{ $labels.kubernetes_io_hostname }} could not be scraped.
+        expr: up{job="cadvisor"} == 0
+        for: 15m
+        labels:
+          severity: warning
+
+      # This functions similarly to the cadvisor alert above.
+      - alert: KubernetesNodeDown
+        annotations:
+          message: The kubelet on {{ $labels.kubernetes_io_hostname }} could not be scraped.
+        expr: up{job="kubernetes-nodes"} == 0
+        for: 15m
+        labels:
+          severity: warning
+
+      - alert: DNSResolverDown
+        annotations:
+          message: DNS resolver has disappeared from Prometheus target discovery.
+        expr: absent(up{job="dns-resolver"} == 1)
+        for: 15m
+        labels:
+          severity: warning
 
     - name: kubernetes-nodes
       rules:

--- a/api/pkg/resources/test/fixtures/configmap-openstack-1.12.0-dns-resolver.yaml
+++ b/api/pkg/resources/test/fixtures/configmap-openstack-1.12.0-dns-resolver.yaml
@@ -13,6 +13,7 @@ data:
       forward . /etc/resolv.conf
       errors
       health
+      prometheus 0.0.0.0:9253
     }
 metadata:
   creationTimestamp: null

--- a/api/pkg/resources/test/fixtures/configmap-openstack-1.12.0-prometheus.yaml
+++ b/api/pkg/resources/test/fixtures/configmap-openstack-1.12.0-prometheus.yaml
@@ -519,7 +519,7 @@ data:
 
       - alert: FdExhaustionClose
         annotations:
-          description: '{{ $labels.job }} instance {{ $labels.instance }} will exhaust its file descriptors soon'
+          message: '{{ $labels.job }} instance {{ $labels.instance }} will exhaust its file descriptors soon'
         expr: |
           predict_linear(instance:fd_utilization[10m], 3600) > 1
         for: 10m
@@ -560,13 +560,21 @@ data:
         labels:
           severity: critical
 
+      - alert: UserClusterControllerDown
+        annotations:
+          message: User Cluster Controller has disappeared from Prometheus target discovery.
+        expr: absent(up{job="usercluster-controller"} == 1)
+        for: 15m
+        labels:
+          severity: critical
+
       - alert: KubeStateMetricsDown
         annotations:
           message: Kube-state-metrics has disappeared from Prometheus target discovery.
         expr: absent(up{job="kube-state-metrics"} == 1)
         for: 15m
         labels:
-          severity: critical
+          severity: warning
 
       - alert: EtcdDown
         annotations:
@@ -575,6 +583,35 @@ data:
         for: 15m
         labels:
           severity: critical
+
+      # This is triggered if the cluster does have nodes, but the cadvisor could
+      # not successfully be scraped for whatever reason. An absent() on cadvisor
+      # metrics is not a good alert because clusters could simply have no nodes
+      # and hence no cadvisors.
+      - alert: CAdvisorDown
+        annotations:
+          message: cAdvisor on {{ $labels.kubernetes_io_hostname }} could not be scraped.
+        expr: up{job="cadvisor"} == 0
+        for: 15m
+        labels:
+          severity: warning
+
+      # This functions similarly to the cadvisor alert above.
+      - alert: KubernetesNodeDown
+        annotations:
+          message: The kubelet on {{ $labels.kubernetes_io_hostname }} could not be scraped.
+        expr: up{job="kubernetes-nodes"} == 0
+        for: 15m
+        labels:
+          severity: warning
+
+      - alert: DNSResolverDown
+        annotations:
+          message: DNS resolver has disappeared from Prometheus target discovery.
+        expr: absent(up{job="dns-resolver"} == 1)
+        for: 15m
+        labels:
+          severity: warning
 
     - name: kubernetes-nodes
       rules:

--- a/api/pkg/resources/test/fixtures/configmap-openstack-1.13.0-dns-resolver.yaml
+++ b/api/pkg/resources/test/fixtures/configmap-openstack-1.13.0-dns-resolver.yaml
@@ -13,6 +13,7 @@ data:
       forward . /etc/resolv.conf
       errors
       health
+      prometheus 0.0.0.0:9253
     }
 metadata:
   creationTimestamp: null

--- a/api/pkg/resources/test/fixtures/configmap-openstack-1.13.0-prometheus.yaml
+++ b/api/pkg/resources/test/fixtures/configmap-openstack-1.13.0-prometheus.yaml
@@ -519,7 +519,7 @@ data:
 
       - alert: FdExhaustionClose
         annotations:
-          description: '{{ $labels.job }} instance {{ $labels.instance }} will exhaust its file descriptors soon'
+          message: '{{ $labels.job }} instance {{ $labels.instance }} will exhaust its file descriptors soon'
         expr: |
           predict_linear(instance:fd_utilization[10m], 3600) > 1
         for: 10m
@@ -560,13 +560,21 @@ data:
         labels:
           severity: critical
 
+      - alert: UserClusterControllerDown
+        annotations:
+          message: User Cluster Controller has disappeared from Prometheus target discovery.
+        expr: absent(up{job="usercluster-controller"} == 1)
+        for: 15m
+        labels:
+          severity: critical
+
       - alert: KubeStateMetricsDown
         annotations:
           message: Kube-state-metrics has disappeared from Prometheus target discovery.
         expr: absent(up{job="kube-state-metrics"} == 1)
         for: 15m
         labels:
-          severity: critical
+          severity: warning
 
       - alert: EtcdDown
         annotations:
@@ -575,6 +583,35 @@ data:
         for: 15m
         labels:
           severity: critical
+
+      # This is triggered if the cluster does have nodes, but the cadvisor could
+      # not successfully be scraped for whatever reason. An absent() on cadvisor
+      # metrics is not a good alert because clusters could simply have no nodes
+      # and hence no cadvisors.
+      - alert: CAdvisorDown
+        annotations:
+          message: cAdvisor on {{ $labels.kubernetes_io_hostname }} could not be scraped.
+        expr: up{job="cadvisor"} == 0
+        for: 15m
+        labels:
+          severity: warning
+
+      # This functions similarly to the cadvisor alert above.
+      - alert: KubernetesNodeDown
+        annotations:
+          message: The kubelet on {{ $labels.kubernetes_io_hostname }} could not be scraped.
+        expr: up{job="kubernetes-nodes"} == 0
+        for: 15m
+        labels:
+          severity: warning
+
+      - alert: DNSResolverDown
+        annotations:
+          message: DNS resolver has disappeared from Prometheus target discovery.
+        expr: absent(up{job="dns-resolver"} == 1)
+        for: 15m
+        labels:
+          severity: warning
 
     - name: kubernetes-nodes
       rules:

--- a/api/pkg/resources/test/fixtures/configmap-vsphere-1.10.0-dns-resolver.yaml
+++ b/api/pkg/resources/test/fixtures/configmap-vsphere-1.10.0-dns-resolver.yaml
@@ -13,6 +13,7 @@ data:
       forward . /etc/resolv.conf
       errors
       health
+      prometheus 0.0.0.0:9253
     }
 metadata:
   creationTimestamp: null

--- a/api/pkg/resources/test/fixtures/configmap-vsphere-1.10.0-prometheus.yaml
+++ b/api/pkg/resources/test/fixtures/configmap-vsphere-1.10.0-prometheus.yaml
@@ -519,7 +519,7 @@ data:
 
       - alert: FdExhaustionClose
         annotations:
-          description: '{{ $labels.job }} instance {{ $labels.instance }} will exhaust its file descriptors soon'
+          message: '{{ $labels.job }} instance {{ $labels.instance }} will exhaust its file descriptors soon'
         expr: |
           predict_linear(instance:fd_utilization[10m], 3600) > 1
         for: 10m
@@ -560,13 +560,21 @@ data:
         labels:
           severity: critical
 
+      - alert: UserClusterControllerDown
+        annotations:
+          message: User Cluster Controller has disappeared from Prometheus target discovery.
+        expr: absent(up{job="usercluster-controller"} == 1)
+        for: 15m
+        labels:
+          severity: critical
+
       - alert: KubeStateMetricsDown
         annotations:
           message: Kube-state-metrics has disappeared from Prometheus target discovery.
         expr: absent(up{job="kube-state-metrics"} == 1)
         for: 15m
         labels:
-          severity: critical
+          severity: warning
 
       - alert: EtcdDown
         annotations:
@@ -575,6 +583,35 @@ data:
         for: 15m
         labels:
           severity: critical
+
+      # This is triggered if the cluster does have nodes, but the cadvisor could
+      # not successfully be scraped for whatever reason. An absent() on cadvisor
+      # metrics is not a good alert because clusters could simply have no nodes
+      # and hence no cadvisors.
+      - alert: CAdvisorDown
+        annotations:
+          message: cAdvisor on {{ $labels.kubernetes_io_hostname }} could not be scraped.
+        expr: up{job="cadvisor"} == 0
+        for: 15m
+        labels:
+          severity: warning
+
+      # This functions similarly to the cadvisor alert above.
+      - alert: KubernetesNodeDown
+        annotations:
+          message: The kubelet on {{ $labels.kubernetes_io_hostname }} could not be scraped.
+        expr: up{job="kubernetes-nodes"} == 0
+        for: 15m
+        labels:
+          severity: warning
+
+      - alert: DNSResolverDown
+        annotations:
+          message: DNS resolver has disappeared from Prometheus target discovery.
+        expr: absent(up{job="dns-resolver"} == 1)
+        for: 15m
+        labels:
+          severity: warning
 
     - name: kubernetes-nodes
       rules:

--- a/api/pkg/resources/test/fixtures/configmap-vsphere-1.10.6-dns-resolver.yaml
+++ b/api/pkg/resources/test/fixtures/configmap-vsphere-1.10.6-dns-resolver.yaml
@@ -13,6 +13,7 @@ data:
       forward . /etc/resolv.conf
       errors
       health
+      prometheus 0.0.0.0:9253
     }
 metadata:
   creationTimestamp: null

--- a/api/pkg/resources/test/fixtures/configmap-vsphere-1.10.6-prometheus.yaml
+++ b/api/pkg/resources/test/fixtures/configmap-vsphere-1.10.6-prometheus.yaml
@@ -519,7 +519,7 @@ data:
 
       - alert: FdExhaustionClose
         annotations:
-          description: '{{ $labels.job }} instance {{ $labels.instance }} will exhaust its file descriptors soon'
+          message: '{{ $labels.job }} instance {{ $labels.instance }} will exhaust its file descriptors soon'
         expr: |
           predict_linear(instance:fd_utilization[10m], 3600) > 1
         for: 10m
@@ -560,13 +560,21 @@ data:
         labels:
           severity: critical
 
+      - alert: UserClusterControllerDown
+        annotations:
+          message: User Cluster Controller has disappeared from Prometheus target discovery.
+        expr: absent(up{job="usercluster-controller"} == 1)
+        for: 15m
+        labels:
+          severity: critical
+
       - alert: KubeStateMetricsDown
         annotations:
           message: Kube-state-metrics has disappeared from Prometheus target discovery.
         expr: absent(up{job="kube-state-metrics"} == 1)
         for: 15m
         labels:
-          severity: critical
+          severity: warning
 
       - alert: EtcdDown
         annotations:
@@ -575,6 +583,35 @@ data:
         for: 15m
         labels:
           severity: critical
+
+      # This is triggered if the cluster does have nodes, but the cadvisor could
+      # not successfully be scraped for whatever reason. An absent() on cadvisor
+      # metrics is not a good alert because clusters could simply have no nodes
+      # and hence no cadvisors.
+      - alert: CAdvisorDown
+        annotations:
+          message: cAdvisor on {{ $labels.kubernetes_io_hostname }} could not be scraped.
+        expr: up{job="cadvisor"} == 0
+        for: 15m
+        labels:
+          severity: warning
+
+      # This functions similarly to the cadvisor alert above.
+      - alert: KubernetesNodeDown
+        annotations:
+          message: The kubelet on {{ $labels.kubernetes_io_hostname }} could not be scraped.
+        expr: up{job="kubernetes-nodes"} == 0
+        for: 15m
+        labels:
+          severity: warning
+
+      - alert: DNSResolverDown
+        annotations:
+          message: DNS resolver has disappeared from Prometheus target discovery.
+        expr: absent(up{job="dns-resolver"} == 1)
+        for: 15m
+        labels:
+          severity: warning
 
     - name: kubernetes-nodes
       rules:

--- a/api/pkg/resources/test/fixtures/configmap-vsphere-1.11.0-dns-resolver.yaml
+++ b/api/pkg/resources/test/fixtures/configmap-vsphere-1.11.0-dns-resolver.yaml
@@ -13,6 +13,7 @@ data:
       forward . /etc/resolv.conf
       errors
       health
+      prometheus 0.0.0.0:9253
     }
 metadata:
   creationTimestamp: null

--- a/api/pkg/resources/test/fixtures/configmap-vsphere-1.11.0-prometheus.yaml
+++ b/api/pkg/resources/test/fixtures/configmap-vsphere-1.11.0-prometheus.yaml
@@ -523,7 +523,7 @@ data:
 
       - alert: FdExhaustionClose
         annotations:
-          description: '{{ $labels.job }} instance {{ $labels.instance }} will exhaust its file descriptors soon'
+          message: '{{ $labels.job }} instance {{ $labels.instance }} will exhaust its file descriptors soon'
         expr: |
           predict_linear(instance:fd_utilization[10m], 3600) > 1
         for: 10m
@@ -564,13 +564,21 @@ data:
         labels:
           severity: critical
 
+      - alert: UserClusterControllerDown
+        annotations:
+          message: User Cluster Controller has disappeared from Prometheus target discovery.
+        expr: absent(up{job="usercluster-controller"} == 1)
+        for: 15m
+        labels:
+          severity: critical
+
       - alert: KubeStateMetricsDown
         annotations:
           message: Kube-state-metrics has disappeared from Prometheus target discovery.
         expr: absent(up{job="kube-state-metrics"} == 1)
         for: 15m
         labels:
-          severity: critical
+          severity: warning
 
       - alert: EtcdDown
         annotations:
@@ -579,6 +587,35 @@ data:
         for: 15m
         labels:
           severity: critical
+
+      # This is triggered if the cluster does have nodes, but the cadvisor could
+      # not successfully be scraped for whatever reason. An absent() on cadvisor
+      # metrics is not a good alert because clusters could simply have no nodes
+      # and hence no cadvisors.
+      - alert: CAdvisorDown
+        annotations:
+          message: cAdvisor on {{ $labels.kubernetes_io_hostname }} could not be scraped.
+        expr: up{job="cadvisor"} == 0
+        for: 15m
+        labels:
+          severity: warning
+
+      # This functions similarly to the cadvisor alert above.
+      - alert: KubernetesNodeDown
+        annotations:
+          message: The kubelet on {{ $labels.kubernetes_io_hostname }} could not be scraped.
+        expr: up{job="kubernetes-nodes"} == 0
+        for: 15m
+        labels:
+          severity: warning
+
+      - alert: DNSResolverDown
+        annotations:
+          message: DNS resolver has disappeared from Prometheus target discovery.
+        expr: absent(up{job="dns-resolver"} == 1)
+        for: 15m
+        labels:
+          severity: warning
 
     - name: kubernetes-nodes
       rules:

--- a/api/pkg/resources/test/fixtures/configmap-vsphere-1.11.1-dns-resolver.yaml
+++ b/api/pkg/resources/test/fixtures/configmap-vsphere-1.11.1-dns-resolver.yaml
@@ -13,6 +13,7 @@ data:
       forward . /etc/resolv.conf
       errors
       health
+      prometheus 0.0.0.0:9253
     }
 metadata:
   creationTimestamp: null

--- a/api/pkg/resources/test/fixtures/configmap-vsphere-1.11.1-prometheus.yaml
+++ b/api/pkg/resources/test/fixtures/configmap-vsphere-1.11.1-prometheus.yaml
@@ -523,7 +523,7 @@ data:
 
       - alert: FdExhaustionClose
         annotations:
-          description: '{{ $labels.job }} instance {{ $labels.instance }} will exhaust its file descriptors soon'
+          message: '{{ $labels.job }} instance {{ $labels.instance }} will exhaust its file descriptors soon'
         expr: |
           predict_linear(instance:fd_utilization[10m], 3600) > 1
         for: 10m
@@ -564,13 +564,21 @@ data:
         labels:
           severity: critical
 
+      - alert: UserClusterControllerDown
+        annotations:
+          message: User Cluster Controller has disappeared from Prometheus target discovery.
+        expr: absent(up{job="usercluster-controller"} == 1)
+        for: 15m
+        labels:
+          severity: critical
+
       - alert: KubeStateMetricsDown
         annotations:
           message: Kube-state-metrics has disappeared from Prometheus target discovery.
         expr: absent(up{job="kube-state-metrics"} == 1)
         for: 15m
         labels:
-          severity: critical
+          severity: warning
 
       - alert: EtcdDown
         annotations:
@@ -579,6 +587,35 @@ data:
         for: 15m
         labels:
           severity: critical
+
+      # This is triggered if the cluster does have nodes, but the cadvisor could
+      # not successfully be scraped for whatever reason. An absent() on cadvisor
+      # metrics is not a good alert because clusters could simply have no nodes
+      # and hence no cadvisors.
+      - alert: CAdvisorDown
+        annotations:
+          message: cAdvisor on {{ $labels.kubernetes_io_hostname }} could not be scraped.
+        expr: up{job="cadvisor"} == 0
+        for: 15m
+        labels:
+          severity: warning
+
+      # This functions similarly to the cadvisor alert above.
+      - alert: KubernetesNodeDown
+        annotations:
+          message: The kubelet on {{ $labels.kubernetes_io_hostname }} could not be scraped.
+        expr: up{job="kubernetes-nodes"} == 0
+        for: 15m
+        labels:
+          severity: warning
+
+      - alert: DNSResolverDown
+        annotations:
+          message: DNS resolver has disappeared from Prometheus target discovery.
+        expr: absent(up{job="dns-resolver"} == 1)
+        for: 15m
+        labels:
+          severity: warning
 
     - name: kubernetes-nodes
       rules:

--- a/api/pkg/resources/test/fixtures/configmap-vsphere-1.12.0-dns-resolver.yaml
+++ b/api/pkg/resources/test/fixtures/configmap-vsphere-1.12.0-dns-resolver.yaml
@@ -13,6 +13,7 @@ data:
       forward . /etc/resolv.conf
       errors
       health
+      prometheus 0.0.0.0:9253
     }
 metadata:
   creationTimestamp: null

--- a/api/pkg/resources/test/fixtures/configmap-vsphere-1.12.0-prometheus.yaml
+++ b/api/pkg/resources/test/fixtures/configmap-vsphere-1.12.0-prometheus.yaml
@@ -519,7 +519,7 @@ data:
 
       - alert: FdExhaustionClose
         annotations:
-          description: '{{ $labels.job }} instance {{ $labels.instance }} will exhaust its file descriptors soon'
+          message: '{{ $labels.job }} instance {{ $labels.instance }} will exhaust its file descriptors soon'
         expr: |
           predict_linear(instance:fd_utilization[10m], 3600) > 1
         for: 10m
@@ -560,13 +560,21 @@ data:
         labels:
           severity: critical
 
+      - alert: UserClusterControllerDown
+        annotations:
+          message: User Cluster Controller has disappeared from Prometheus target discovery.
+        expr: absent(up{job="usercluster-controller"} == 1)
+        for: 15m
+        labels:
+          severity: critical
+
       - alert: KubeStateMetricsDown
         annotations:
           message: Kube-state-metrics has disappeared from Prometheus target discovery.
         expr: absent(up{job="kube-state-metrics"} == 1)
         for: 15m
         labels:
-          severity: critical
+          severity: warning
 
       - alert: EtcdDown
         annotations:
@@ -575,6 +583,35 @@ data:
         for: 15m
         labels:
           severity: critical
+
+      # This is triggered if the cluster does have nodes, but the cadvisor could
+      # not successfully be scraped for whatever reason. An absent() on cadvisor
+      # metrics is not a good alert because clusters could simply have no nodes
+      # and hence no cadvisors.
+      - alert: CAdvisorDown
+        annotations:
+          message: cAdvisor on {{ $labels.kubernetes_io_hostname }} could not be scraped.
+        expr: up{job="cadvisor"} == 0
+        for: 15m
+        labels:
+          severity: warning
+
+      # This functions similarly to the cadvisor alert above.
+      - alert: KubernetesNodeDown
+        annotations:
+          message: The kubelet on {{ $labels.kubernetes_io_hostname }} could not be scraped.
+        expr: up{job="kubernetes-nodes"} == 0
+        for: 15m
+        labels:
+          severity: warning
+
+      - alert: DNSResolverDown
+        annotations:
+          message: DNS resolver has disappeared from Prometheus target discovery.
+        expr: absent(up{job="dns-resolver"} == 1)
+        for: 15m
+        labels:
+          severity: warning
 
     - name: kubernetes-nodes
       rules:

--- a/api/pkg/resources/test/fixtures/configmap-vsphere-1.13.0-dns-resolver.yaml
+++ b/api/pkg/resources/test/fixtures/configmap-vsphere-1.13.0-dns-resolver.yaml
@@ -13,6 +13,7 @@ data:
       forward . /etc/resolv.conf
       errors
       health
+      prometheus 0.0.0.0:9253
     }
 metadata:
   creationTimestamp: null

--- a/api/pkg/resources/test/fixtures/configmap-vsphere-1.13.0-prometheus.yaml
+++ b/api/pkg/resources/test/fixtures/configmap-vsphere-1.13.0-prometheus.yaml
@@ -519,7 +519,7 @@ data:
 
       - alert: FdExhaustionClose
         annotations:
-          description: '{{ $labels.job }} instance {{ $labels.instance }} will exhaust its file descriptors soon'
+          message: '{{ $labels.job }} instance {{ $labels.instance }} will exhaust its file descriptors soon'
         expr: |
           predict_linear(instance:fd_utilization[10m], 3600) > 1
         for: 10m
@@ -560,13 +560,21 @@ data:
         labels:
           severity: critical
 
+      - alert: UserClusterControllerDown
+        annotations:
+          message: User Cluster Controller has disappeared from Prometheus target discovery.
+        expr: absent(up{job="usercluster-controller"} == 1)
+        for: 15m
+        labels:
+          severity: critical
+
       - alert: KubeStateMetricsDown
         annotations:
           message: Kube-state-metrics has disappeared from Prometheus target discovery.
         expr: absent(up{job="kube-state-metrics"} == 1)
         for: 15m
         labels:
-          severity: critical
+          severity: warning
 
       - alert: EtcdDown
         annotations:
@@ -575,6 +583,35 @@ data:
         for: 15m
         labels:
           severity: critical
+
+      # This is triggered if the cluster does have nodes, but the cadvisor could
+      # not successfully be scraped for whatever reason. An absent() on cadvisor
+      # metrics is not a good alert because clusters could simply have no nodes
+      # and hence no cadvisors.
+      - alert: CAdvisorDown
+        annotations:
+          message: cAdvisor on {{ $labels.kubernetes_io_hostname }} could not be scraped.
+        expr: up{job="cadvisor"} == 0
+        for: 15m
+        labels:
+          severity: warning
+
+      # This functions similarly to the cadvisor alert above.
+      - alert: KubernetesNodeDown
+        annotations:
+          message: The kubelet on {{ $labels.kubernetes_io_hostname }} could not be scraped.
+        expr: up{job="kubernetes-nodes"} == 0
+        for: 15m
+        labels:
+          severity: warning
+
+      - alert: DNSResolverDown
+        annotations:
+          message: DNS resolver has disappeared from Prometheus target discovery.
+        expr: absent(up{job="dns-resolver"} == 1)
+        for: 15m
+        labels:
+          severity: warning
 
     - name: kubernetes-nodes
       rules:

--- a/api/pkg/resources/test/fixtures/deployment-aws-1.10.0-dns-resolver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-aws-1.10.0-dns-resolver.yaml
@@ -15,6 +15,10 @@ spec:
     type: RollingUpdate
   template:
     metadata:
+      annotations:
+        prometheus.io/path: /metrics
+        prometheus.io/port: "9253"
+        prometheus.io/scrape: "true"
       creationTimestamp: null
       labels:
         app: dns-resolver

--- a/api/pkg/resources/test/fixtures/deployment-aws-1.10.6-dns-resolver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-aws-1.10.6-dns-resolver.yaml
@@ -15,6 +15,10 @@ spec:
     type: RollingUpdate
   template:
     metadata:
+      annotations:
+        prometheus.io/path: /metrics
+        prometheus.io/port: "9253"
+        prometheus.io/scrape: "true"
       creationTimestamp: null
       labels:
         app: dns-resolver

--- a/api/pkg/resources/test/fixtures/deployment-aws-1.11.0-dns-resolver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-aws-1.11.0-dns-resolver.yaml
@@ -15,6 +15,10 @@ spec:
     type: RollingUpdate
   template:
     metadata:
+      annotations:
+        prometheus.io/path: /metrics
+        prometheus.io/port: "9253"
+        prometheus.io/scrape: "true"
       creationTimestamp: null
       labels:
         app: dns-resolver

--- a/api/pkg/resources/test/fixtures/deployment-aws-1.11.1-dns-resolver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-aws-1.11.1-dns-resolver.yaml
@@ -15,6 +15,10 @@ spec:
     type: RollingUpdate
   template:
     metadata:
+      annotations:
+        prometheus.io/path: /metrics
+        prometheus.io/port: "9253"
+        prometheus.io/scrape: "true"
       creationTimestamp: null
       labels:
         app: dns-resolver

--- a/api/pkg/resources/test/fixtures/deployment-aws-1.12.0-dns-resolver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-aws-1.12.0-dns-resolver.yaml
@@ -15,6 +15,10 @@ spec:
     type: RollingUpdate
   template:
     metadata:
+      annotations:
+        prometheus.io/path: /metrics
+        prometheus.io/port: "9253"
+        prometheus.io/scrape: "true"
       creationTimestamp: null
       labels:
         app: dns-resolver

--- a/api/pkg/resources/test/fixtures/deployment-aws-1.13.0-dns-resolver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-aws-1.13.0-dns-resolver.yaml
@@ -15,6 +15,10 @@ spec:
     type: RollingUpdate
   template:
     metadata:
+      annotations:
+        prometheus.io/path: /metrics
+        prometheus.io/port: "9253"
+        prometheus.io/scrape: "true"
       creationTimestamp: null
       labels:
         app: dns-resolver

--- a/api/pkg/resources/test/fixtures/deployment-azure-1.10.0-dns-resolver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-azure-1.10.0-dns-resolver.yaml
@@ -15,6 +15,10 @@ spec:
     type: RollingUpdate
   template:
     metadata:
+      annotations:
+        prometheus.io/path: /metrics
+        prometheus.io/port: "9253"
+        prometheus.io/scrape: "true"
       creationTimestamp: null
       labels:
         app: dns-resolver

--- a/api/pkg/resources/test/fixtures/deployment-azure-1.10.6-dns-resolver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-azure-1.10.6-dns-resolver.yaml
@@ -15,6 +15,10 @@ spec:
     type: RollingUpdate
   template:
     metadata:
+      annotations:
+        prometheus.io/path: /metrics
+        prometheus.io/port: "9253"
+        prometheus.io/scrape: "true"
       creationTimestamp: null
       labels:
         app: dns-resolver

--- a/api/pkg/resources/test/fixtures/deployment-azure-1.11.0-dns-resolver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-azure-1.11.0-dns-resolver.yaml
@@ -15,6 +15,10 @@ spec:
     type: RollingUpdate
   template:
     metadata:
+      annotations:
+        prometheus.io/path: /metrics
+        prometheus.io/port: "9253"
+        prometheus.io/scrape: "true"
       creationTimestamp: null
       labels:
         app: dns-resolver

--- a/api/pkg/resources/test/fixtures/deployment-azure-1.11.1-dns-resolver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-azure-1.11.1-dns-resolver.yaml
@@ -15,6 +15,10 @@ spec:
     type: RollingUpdate
   template:
     metadata:
+      annotations:
+        prometheus.io/path: /metrics
+        prometheus.io/port: "9253"
+        prometheus.io/scrape: "true"
       creationTimestamp: null
       labels:
         app: dns-resolver

--- a/api/pkg/resources/test/fixtures/deployment-azure-1.12.0-dns-resolver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-azure-1.12.0-dns-resolver.yaml
@@ -15,6 +15,10 @@ spec:
     type: RollingUpdate
   template:
     metadata:
+      annotations:
+        prometheus.io/path: /metrics
+        prometheus.io/port: "9253"
+        prometheus.io/scrape: "true"
       creationTimestamp: null
       labels:
         app: dns-resolver

--- a/api/pkg/resources/test/fixtures/deployment-azure-1.13.0-dns-resolver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-azure-1.13.0-dns-resolver.yaml
@@ -15,6 +15,10 @@ spec:
     type: RollingUpdate
   template:
     metadata:
+      annotations:
+        prometheus.io/path: /metrics
+        prometheus.io/port: "9253"
+        prometheus.io/scrape: "true"
       creationTimestamp: null
       labels:
         app: dns-resolver

--- a/api/pkg/resources/test/fixtures/deployment-bringyourown-1.10.0-dns-resolver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-bringyourown-1.10.0-dns-resolver.yaml
@@ -15,6 +15,10 @@ spec:
     type: RollingUpdate
   template:
     metadata:
+      annotations:
+        prometheus.io/path: /metrics
+        prometheus.io/port: "9253"
+        prometheus.io/scrape: "true"
       creationTimestamp: null
       labels:
         app: dns-resolver

--- a/api/pkg/resources/test/fixtures/deployment-bringyourown-1.10.6-dns-resolver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-bringyourown-1.10.6-dns-resolver.yaml
@@ -15,6 +15,10 @@ spec:
     type: RollingUpdate
   template:
     metadata:
+      annotations:
+        prometheus.io/path: /metrics
+        prometheus.io/port: "9253"
+        prometheus.io/scrape: "true"
       creationTimestamp: null
       labels:
         app: dns-resolver

--- a/api/pkg/resources/test/fixtures/deployment-bringyourown-1.11.0-dns-resolver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-bringyourown-1.11.0-dns-resolver.yaml
@@ -15,6 +15,10 @@ spec:
     type: RollingUpdate
   template:
     metadata:
+      annotations:
+        prometheus.io/path: /metrics
+        prometheus.io/port: "9253"
+        prometheus.io/scrape: "true"
       creationTimestamp: null
       labels:
         app: dns-resolver

--- a/api/pkg/resources/test/fixtures/deployment-bringyourown-1.11.1-dns-resolver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-bringyourown-1.11.1-dns-resolver.yaml
@@ -15,6 +15,10 @@ spec:
     type: RollingUpdate
   template:
     metadata:
+      annotations:
+        prometheus.io/path: /metrics
+        prometheus.io/port: "9253"
+        prometheus.io/scrape: "true"
       creationTimestamp: null
       labels:
         app: dns-resolver

--- a/api/pkg/resources/test/fixtures/deployment-bringyourown-1.12.0-dns-resolver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-bringyourown-1.12.0-dns-resolver.yaml
@@ -15,6 +15,10 @@ spec:
     type: RollingUpdate
   template:
     metadata:
+      annotations:
+        prometheus.io/path: /metrics
+        prometheus.io/port: "9253"
+        prometheus.io/scrape: "true"
       creationTimestamp: null
       labels:
         app: dns-resolver

--- a/api/pkg/resources/test/fixtures/deployment-bringyourown-1.13.0-dns-resolver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-bringyourown-1.13.0-dns-resolver.yaml
@@ -15,6 +15,10 @@ spec:
     type: RollingUpdate
   template:
     metadata:
+      annotations:
+        prometheus.io/path: /metrics
+        prometheus.io/port: "9253"
+        prometheus.io/scrape: "true"
       creationTimestamp: null
       labels:
         app: dns-resolver

--- a/api/pkg/resources/test/fixtures/deployment-digitalocean-1.10.0-dns-resolver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-digitalocean-1.10.0-dns-resolver.yaml
@@ -15,6 +15,10 @@ spec:
     type: RollingUpdate
   template:
     metadata:
+      annotations:
+        prometheus.io/path: /metrics
+        prometheus.io/port: "9253"
+        prometheus.io/scrape: "true"
       creationTimestamp: null
       labels:
         app: dns-resolver

--- a/api/pkg/resources/test/fixtures/deployment-digitalocean-1.10.6-dns-resolver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-digitalocean-1.10.6-dns-resolver.yaml
@@ -15,6 +15,10 @@ spec:
     type: RollingUpdate
   template:
     metadata:
+      annotations:
+        prometheus.io/path: /metrics
+        prometheus.io/port: "9253"
+        prometheus.io/scrape: "true"
       creationTimestamp: null
       labels:
         app: dns-resolver

--- a/api/pkg/resources/test/fixtures/deployment-digitalocean-1.11.0-dns-resolver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-digitalocean-1.11.0-dns-resolver.yaml
@@ -15,6 +15,10 @@ spec:
     type: RollingUpdate
   template:
     metadata:
+      annotations:
+        prometheus.io/path: /metrics
+        prometheus.io/port: "9253"
+        prometheus.io/scrape: "true"
       creationTimestamp: null
       labels:
         app: dns-resolver

--- a/api/pkg/resources/test/fixtures/deployment-digitalocean-1.11.1-dns-resolver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-digitalocean-1.11.1-dns-resolver.yaml
@@ -15,6 +15,10 @@ spec:
     type: RollingUpdate
   template:
     metadata:
+      annotations:
+        prometheus.io/path: /metrics
+        prometheus.io/port: "9253"
+        prometheus.io/scrape: "true"
       creationTimestamp: null
       labels:
         app: dns-resolver

--- a/api/pkg/resources/test/fixtures/deployment-digitalocean-1.12.0-dns-resolver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-digitalocean-1.12.0-dns-resolver.yaml
@@ -15,6 +15,10 @@ spec:
     type: RollingUpdate
   template:
     metadata:
+      annotations:
+        prometheus.io/path: /metrics
+        prometheus.io/port: "9253"
+        prometheus.io/scrape: "true"
       creationTimestamp: null
       labels:
         app: dns-resolver

--- a/api/pkg/resources/test/fixtures/deployment-digitalocean-1.13.0-dns-resolver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-digitalocean-1.13.0-dns-resolver.yaml
@@ -15,6 +15,10 @@ spec:
     type: RollingUpdate
   template:
     metadata:
+      annotations:
+        prometheus.io/path: /metrics
+        prometheus.io/port: "9253"
+        prometheus.io/scrape: "true"
       creationTimestamp: null
       labels:
         app: dns-resolver

--- a/api/pkg/resources/test/fixtures/deployment-openstack-1.10.0-dns-resolver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-openstack-1.10.0-dns-resolver.yaml
@@ -15,6 +15,10 @@ spec:
     type: RollingUpdate
   template:
     metadata:
+      annotations:
+        prometheus.io/path: /metrics
+        prometheus.io/port: "9253"
+        prometheus.io/scrape: "true"
       creationTimestamp: null
       labels:
         app: dns-resolver

--- a/api/pkg/resources/test/fixtures/deployment-openstack-1.10.6-dns-resolver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-openstack-1.10.6-dns-resolver.yaml
@@ -15,6 +15,10 @@ spec:
     type: RollingUpdate
   template:
     metadata:
+      annotations:
+        prometheus.io/path: /metrics
+        prometheus.io/port: "9253"
+        prometheus.io/scrape: "true"
       creationTimestamp: null
       labels:
         app: dns-resolver

--- a/api/pkg/resources/test/fixtures/deployment-openstack-1.11.0-dns-resolver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-openstack-1.11.0-dns-resolver.yaml
@@ -15,6 +15,10 @@ spec:
     type: RollingUpdate
   template:
     metadata:
+      annotations:
+        prometheus.io/path: /metrics
+        prometheus.io/port: "9253"
+        prometheus.io/scrape: "true"
       creationTimestamp: null
       labels:
         app: dns-resolver

--- a/api/pkg/resources/test/fixtures/deployment-openstack-1.11.1-dns-resolver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-openstack-1.11.1-dns-resolver.yaml
@@ -15,6 +15,10 @@ spec:
     type: RollingUpdate
   template:
     metadata:
+      annotations:
+        prometheus.io/path: /metrics
+        prometheus.io/port: "9253"
+        prometheus.io/scrape: "true"
       creationTimestamp: null
       labels:
         app: dns-resolver

--- a/api/pkg/resources/test/fixtures/deployment-openstack-1.12.0-dns-resolver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-openstack-1.12.0-dns-resolver.yaml
@@ -15,6 +15,10 @@ spec:
     type: RollingUpdate
   template:
     metadata:
+      annotations:
+        prometheus.io/path: /metrics
+        prometheus.io/port: "9253"
+        prometheus.io/scrape: "true"
       creationTimestamp: null
       labels:
         app: dns-resolver

--- a/api/pkg/resources/test/fixtures/deployment-openstack-1.13.0-dns-resolver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-openstack-1.13.0-dns-resolver.yaml
@@ -15,6 +15,10 @@ spec:
     type: RollingUpdate
   template:
     metadata:
+      annotations:
+        prometheus.io/path: /metrics
+        prometheus.io/port: "9253"
+        prometheus.io/scrape: "true"
       creationTimestamp: null
       labels:
         app: dns-resolver

--- a/api/pkg/resources/test/fixtures/deployment-vsphere-1.10.0-dns-resolver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-vsphere-1.10.0-dns-resolver.yaml
@@ -15,6 +15,10 @@ spec:
     type: RollingUpdate
   template:
     metadata:
+      annotations:
+        prometheus.io/path: /metrics
+        prometheus.io/port: "9253"
+        prometheus.io/scrape: "true"
       creationTimestamp: null
       labels:
         app: dns-resolver

--- a/api/pkg/resources/test/fixtures/deployment-vsphere-1.10.6-dns-resolver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-vsphere-1.10.6-dns-resolver.yaml
@@ -15,6 +15,10 @@ spec:
     type: RollingUpdate
   template:
     metadata:
+      annotations:
+        prometheus.io/path: /metrics
+        prometheus.io/port: "9253"
+        prometheus.io/scrape: "true"
       creationTimestamp: null
       labels:
         app: dns-resolver

--- a/api/pkg/resources/test/fixtures/deployment-vsphere-1.11.0-dns-resolver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-vsphere-1.11.0-dns-resolver.yaml
@@ -15,6 +15,10 @@ spec:
     type: RollingUpdate
   template:
     metadata:
+      annotations:
+        prometheus.io/path: /metrics
+        prometheus.io/port: "9253"
+        prometheus.io/scrape: "true"
       creationTimestamp: null
       labels:
         app: dns-resolver

--- a/api/pkg/resources/test/fixtures/deployment-vsphere-1.11.1-dns-resolver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-vsphere-1.11.1-dns-resolver.yaml
@@ -15,6 +15,10 @@ spec:
     type: RollingUpdate
   template:
     metadata:
+      annotations:
+        prometheus.io/path: /metrics
+        prometheus.io/port: "9253"
+        prometheus.io/scrape: "true"
       creationTimestamp: null
       labels:
         app: dns-resolver

--- a/api/pkg/resources/test/fixtures/deployment-vsphere-1.12.0-dns-resolver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-vsphere-1.12.0-dns-resolver.yaml
@@ -15,6 +15,10 @@ spec:
     type: RollingUpdate
   template:
     metadata:
+      annotations:
+        prometheus.io/path: /metrics
+        prometheus.io/port: "9253"
+        prometheus.io/scrape: "true"
       creationTimestamp: null
       labels:
         app: dns-resolver

--- a/api/pkg/resources/test/fixtures/deployment-vsphere-1.13.0-dns-resolver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-vsphere-1.13.0-dns-resolver.yaml
@@ -15,6 +15,10 @@ spec:
     type: RollingUpdate
   template:
     metadata:
+      annotations:
+        prometheus.io/path: /metrics
+        prometheus.io/port: "9253"
+        prometheus.io/scrape: "true"
       creationTimestamp: null
       labels:
         app: dns-resolver

--- a/config/monitoring/prometheus/Chart.yaml
+++ b/config/monitoring/prometheus/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: prometheus
-version: 2.1.5
+version: 2.1.6
 appVersion: v2.11.0
 description: Prometheus Monitoring for Kubernetes
 keywords:

--- a/config/monitoring/prometheus/config/scraping/kube-state-metrics.yaml
+++ b/config/monitoring/prometheus/config/scraping/kube-state-metrics.yaml
@@ -59,3 +59,8 @@ metric_relabel_configs:
 - source_labels: [namespace]
   regex: .*prow-(e2e|kubermatic)-.*
   action: drop
+- source_labels: [namespace]
+  regex: cluster-([a-z0-9]+)
+  target_label: cluster
+  replacement: $1
+  action: replace

--- a/config/monitoring/prometheus/config/scraping/pods.yaml
+++ b/config/monitoring/prometheus/config/scraping/pods.yaml
@@ -34,3 +34,9 @@ relabel_configs:
   target_label: pod
   replacement: $1
   action: replace
+metric_relabel_configs:
+- source_labels: [namespace]
+  regex: cluster-([a-z0-9]+)
+  target_label: cluster
+  replacement: $1
+  action: replace

--- a/config/monitoring/prometheus/rules/kubermatic-master-kubermatic.yaml
+++ b/config/monitoring/prometheus/rules/kubermatic-master-kubermatic.yaml
@@ -21,7 +21,7 @@ groups:
       severity: warning
   - alert: KubermaticAPITooManyInitNodeDeloymentFailures
     annotations:
-      message: Kubermatic API is failing to create initial node deployments.
+      message: Kubermatic API is failing to create too many initial node deployments.
     expr: sum(rate(kubermatic_api_init_node_deployment_failures[5m])) > 0.01
     for: 15m
     labels:

--- a/config/monitoring/prometheus/rules/kubermatic-seed-kubermatic.yaml
+++ b/config/monitoring/prometheus/rules/kubermatic-seed-kubermatic.yaml
@@ -29,6 +29,29 @@ groups:
     for: 15m
     labels:
       severity: critical
+  - alert: OpenVPNServerDown
+    annotations:
+      message: There is no healthy OpenVPN server in cluster {{ $labels.cluster }}.
+      runbook_url: https://docs.kubermatic.io/monitoring/runbook/#alert-openvpnserverdown
+    expr: absent(kube_deployment_status_replicas_available{deployment="openvpn-server",cluster!=""}
+      > 0)
+    for: 15m
+    labels:
+      severity: critical
+  - alert: UserClusterPrometheusAbsent
+    annotations:
+      message: There is no Prometheus in cluster {{ $labels.name }}.
+      runbook_url: https://docs.kubermatic.io/monitoring/runbook/#alert-userclusterprometheusdisappeared
+    expr: |
+      (
+        kubermatic_cluster_info * on (name) group_left
+        label_replace(up{job="clusters"}, "name", "$1", "namespace", "cluster-(.+)")
+        or
+        kubermatic_cluster_info * 0
+      ) == 0
+    for: 15m
+    labels:
+      severity: critical
   - alert: KubermaticClusterPaused
     annotations:
       message: Cluster {{ $labels.name }} has been paused and will not be reconciled

--- a/config/monitoring/prometheus/rules/src/kubermatic-seed/kubermatic.yaml
+++ b/config/monitoring/prometheus/rules/src/kubermatic-seed/kubermatic.yaml
@@ -46,7 +46,22 @@ groups:
     annotations:
       message: There is no healthy OpenVPN server in cluster {{ $labels.cluster }}.
       runbook_url: https://docs.kubermatic.io/monitoring/runbook/#alert-openvpnserverdown
-    expr: absent(kube_deployment_status_replicas_available{deployment="openvpn-client",cluster!=""} > 0)
+    expr: absent(kube_deployment_status_replicas_available{deployment="openvpn-server",cluster!=""} > 0)
+    for: 15m
+    labels:
+      severity: critical
+
+  - alert: UserClusterPrometheusAbsent
+    annotations:
+      message: There is no Prometheus in cluster {{ $labels.name }}.
+      runbook_url: https://docs.kubermatic.io/monitoring/runbook/#alert-userclusterprometheusdisappeared
+    expr: |
+      (
+        kubermatic_cluster_info * on (name) group_left
+        label_replace(up{job="clusters"}, "name", "$1", "namespace", "cluster-(.+)")
+        or
+        kubermatic_cluster_info * 0
+      ) == 0
     for: 15m
     labels:
       severity: critical

--- a/config/monitoring/prometheus/rules/src/kubermatic-seed/kubermatic.yaml
+++ b/config/monitoring/prometheus/rules/src/kubermatic-seed/kubermatic.yaml
@@ -42,6 +42,15 @@ groups:
       - Check the Prometheus Service Discovery page to find out why the target is unreachable.
       - Ensure that the controller-manager pod's logs and that it is not crashlooping.
 
+  - alert: OpenVPNServerDown
+    annotations:
+      message: There is no healthy OpenVPN server in cluster {{ $labels.cluster }}.
+      runbook_url: https://docs.kubermatic.io/monitoring/runbook/#alert-openvpnserverdown
+    expr: absent(kube_deployment_status_replicas_available{deployment="openvpn-client",cluster!=""} > 0)
+    for: 15m
+    labels:
+      severity: critical
+
   # This is a dummy alert that is triggered for paused clusters to inhibit all other alerts from such clusters.
   # The label_replace() is used to create a new "cluster" label that will be used for the inhibitions as well.
   - alert: KubermaticClusterPaused


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR starts to make use of the "Alert Inhibitions" for the Prometheus Alertmanager. This allows us to not send alerts for consequential alerts, e.g. we do not want to alert about broken kube-state-metrics when at the same time the apiserver pod is already dead (causing kube-state-metrics to explode).

For now, most of the inhibitions are centered around user clusters, but I suspect we will expand this in the future. The workflow for figuring out the inhibition rules was as follows:

1. Nuke/remove/break a component inside the user cluster namespace.
2. Wait a few minutes.
3. Observe the alerts and inhibit all alerts that follow the alert for the component you nuked.
4. Goto 1.

So why is this PR so large? It needs to adjust a few things to make inhibitions easy/easier to define and add new alerts that we can use to inhibit others.

* The DNS resolver is now being scraped by Prometheus. A new alert for it has been defined (`DNSResolverDown`) to inhibit the other alerts.
* New alerts for missing cAdvisors, unscraped kubelets and usercluster-controllers have been defined.
* `KubeStateMetricsDown` has been reduced from critical to warning, as the user cluster itself should not be affected immediately.
* The *seed* Prometheus scraping rules have been extended to put a `cluster` label on each metric originating from a user-cluster namespace pod. This makes it much, much easier to define inhibitions.

**Does this PR introduce a user-facing change?**:
```release-note
Alertmanager's inhibition feature is now used to hide consequential alerts.
```