### PR TITLE
add 'pause' label to cluster_info metric

### DIFF
--- a/api/pkg/collectors/cluster.go
+++ b/api/pkg/collectors/cluster.go
@@ -53,6 +53,7 @@ func MustRegisterClusterCollector(registry prometheus.Registerer, client ctrlrun
 				"datacenter",
 				"user_name",
 				"user_email",
+				"pause",
 			},
 			nil,
 		),
@@ -117,6 +118,11 @@ func (cc *ClusterCollector) clusterLabels(cluster *kubermaticv1.Cluster) ([]stri
 		return nil, err
 	}
 
+	pause := "false"
+	if cluster.Spec.Pause {
+		pause = "true"
+	}
+
 	return []string{
 		cluster.Name,
 		cluster.Spec.HumanReadableName,
@@ -126,5 +132,6 @@ func (cc *ClusterCollector) clusterLabels(cluster *kubermaticv1.Cluster) ([]stri
 		cluster.Spec.Cloud.DatacenterName,
 		cluster.Status.UserName,
 		cluster.Status.UserEmail,
+		pause,
 	}, nil
 }


### PR DESCRIPTION
**What this PR does / why we need it**:
This adds a new `pause` label to our existing `cluster_info` metrics. I want to use this metric to trigger a permanent silent alert that we can then use to inhibit all other alerts from any paused alert.

**Does this PR introduce a user-facing change?**:
```release-note
NONE
```
