### PR TITLE
Use a NLB for the NodePortProxy when running on AWS

### DIFF
--- a/config/nodeport-proxy/Chart.yaml
+++ b/config/nodeport-proxy/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: nodeport-proxy
-version: 1.3.0
+version: 1.4.0
 appVersion: v2.2.2
 description: Kubermatic nodeport-proxy
 keywords:

--- a/config/nodeport-proxy/templates/lb.yaml
+++ b/config/nodeport-proxy/templates/lb.yaml
@@ -4,6 +4,9 @@ metadata:
   name: nodeport-lb
   annotations:
     "helm.sh/resource-policy": keep
+    # If we're running on AWS, use an NLB. It has a fixed IP & we can use VPC endpoints
+    # https://docs.aws.amazon.com/de_de/eks/latest/userguide/load-balancing.html
+    "service.beta.kubernetes.io/aws-load-balancer-type": nlb
     "service.beta.kubernetes.io/aws-load-balancer-connection-idle-timeout": "3600"  # On AWS default timeout is 60s, which means: kubectl logs -f will recieve EOF after 60s.
 spec:
   selector:


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR will change the LB type for the NodePortProxy from a classic ELB to a NLB.
The NLB has 2 advantages:
- It has a static IP (We currently need logic to handle the changing IP's of a classic ELB)
- I is supported by VPC endpoints (We require this for a customer project)

**Does this PR introduce a user-facing change?**:
```release-note
ACTION REQUIRED: On AWS, the nodeport-proxy will be recreated as NLB. DNS entries must be updated to point to the new LB.
```

/assign @xrstf 