### PR TITLE
CRUD API for addons 

### DIFF
--- a/api/cmd/kubermatic-api/main.go
+++ b/api/cmd/kubermatic-api/main.go
@@ -196,6 +196,8 @@ func createInitProviders(options serverRunOptions) (providers, error) {
 
 	eventRecorderProvider := kubernetesprovider.NewEventRecorder()
 
+	addonProviderGetter := kubernetesprovider.AddonProviderFactory(seedKubeconfigGetter, options.accessibleAddons)
+
 	return providers{
 		sshKey:                                sshKeyProvider,
 		user:                                  userProvider,
@@ -209,7 +211,8 @@ func createInitProviders(options serverRunOptions) (providers, error) {
 		eventRecorderProvider:                 eventRecorderProvider,
 		clusterProviderGetter:                 clusterProviderGetter,
 		seedsGetter:                           seedsGetter,
-		credentialsProvider:                   credentialsProvider}, nil
+		credentialsProvider:                   credentialsProvider,
+		addons:                                addonProviderGetter}, nil
 }
 
 func createOIDCClients(options serverRunOptions) (auth.OIDCIssuerVerifier, error) {
@@ -274,6 +277,7 @@ func createAPIHandler(options serverRunOptions, prov providers, oidcIssuerVerifi
 	r := handler.NewRouting(
 		prov.seedsGetter,
 		prov.clusterProviderGetter,
+		prov.addons,
 		prov.sshKey,
 		prov.user,
 		prov.serviceAccountProvider,

--- a/api/cmd/kubermatic-api/swagger.json
+++ b/api/cmd/kubermatic-api/swagger.json
@@ -677,6 +677,316 @@
         }
       }
     },
+    "/api/v1/projects/{project_id}/dc/{dc}/clusters/{cluster_id}/addons": {
+      "get": {
+        "description": "Lists addons that belong to the given cluster",
+        "produces": [
+          "application/json"
+        ],
+        "tags": [
+          "addon"
+        ],
+        "operationId": "listAddons",
+        "parameters": [
+          {
+            "type": "string",
+            "x-go-name": "ProjectID",
+            "name": "project_id",
+            "in": "path",
+            "required": true
+          },
+          {
+            "type": "string",
+            "x-go-name": "DC",
+            "name": "dc",
+            "in": "path",
+            "required": true
+          },
+          {
+            "type": "string",
+            "x-go-name": "ClusterID",
+            "name": "cluster_id",
+            "in": "path",
+            "required": true
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Addon",
+            "schema": {
+              "type": "array",
+              "items": {
+                "$ref": "#/definitions/Addon"
+              }
+            }
+          },
+          "401": {
+            "$ref": "#/responses/empty"
+          },
+          "403": {
+            "$ref": "#/responses/empty"
+          },
+          "default": {
+            "description": "errorResponse",
+            "schema": {
+              "$ref": "#/definitions/errorResponse"
+            }
+          }
+        }
+      },
+      "post": {
+        "description": "Creates an addon that will belong to the given cluster",
+        "consumes": [
+          "application/json"
+        ],
+        "produces": [
+          "application/json"
+        ],
+        "tags": [
+          "addon"
+        ],
+        "operationId": "createAddon",
+        "parameters": [
+          {
+            "type": "string",
+            "x-go-name": "ProjectID",
+            "name": "project_id",
+            "in": "path",
+            "required": true
+          },
+          {
+            "type": "string",
+            "x-go-name": "DC",
+            "name": "dc",
+            "in": "path",
+            "required": true
+          },
+          {
+            "type": "string",
+            "x-go-name": "ClusterID",
+            "name": "cluster_id",
+            "in": "path",
+            "required": true
+          },
+          {
+            "name": "Body",
+            "in": "body",
+            "schema": {
+              "$ref": "#/definitions/Addon"
+            }
+          }
+        ],
+        "responses": {
+          "201": {
+            "description": "Addon",
+            "schema": {
+              "$ref": "#/definitions/Addon"
+            }
+          },
+          "401": {
+            "$ref": "#/responses/empty"
+          },
+          "403": {
+            "$ref": "#/responses/empty"
+          },
+          "default": {
+            "description": "errorResponse",
+            "schema": {
+              "$ref": "#/definitions/errorResponse"
+            }
+          }
+        }
+      }
+    },
+    "/api/v1/projects/{project_id}/dc/{dc}/clusters/{cluster_id}/addons/{addon_id}": {
+      "get": {
+        "produces": [
+          "application/json"
+        ],
+        "tags": [
+          "addon"
+        ],
+        "summary": "Gets an addon that is assigned to the given cluster.",
+        "operationId": "getAddon",
+        "parameters": [
+          {
+            "type": "string",
+            "x-go-name": "ProjectID",
+            "name": "project_id",
+            "in": "path",
+            "required": true
+          },
+          {
+            "type": "string",
+            "x-go-name": "DC",
+            "name": "dc",
+            "in": "path",
+            "required": true
+          },
+          {
+            "type": "string",
+            "x-go-name": "ClusterID",
+            "name": "cluster_id",
+            "in": "path",
+            "required": true
+          },
+          {
+            "type": "string",
+            "x-go-name": "AddonID",
+            "name": "addon_id",
+            "in": "path",
+            "required": true
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Addon",
+            "schema": {
+              "$ref": "#/definitions/Addon"
+            }
+          },
+          "401": {
+            "$ref": "#/responses/empty"
+          },
+          "403": {
+            "$ref": "#/responses/empty"
+          },
+          "default": {
+            "description": "errorResponse",
+            "schema": {
+              "$ref": "#/definitions/errorResponse"
+            }
+          }
+        }
+      },
+      "delete": {
+        "produces": [
+          "application/json"
+        ],
+        "tags": [
+          "addon"
+        ],
+        "summary": "Deletes the given addon that belongs to the cluster.",
+        "operationId": "deleteAddon",
+        "parameters": [
+          {
+            "type": "string",
+            "x-go-name": "ProjectID",
+            "name": "project_id",
+            "in": "path",
+            "required": true
+          },
+          {
+            "type": "string",
+            "x-go-name": "DC",
+            "name": "dc",
+            "in": "path",
+            "required": true
+          },
+          {
+            "type": "string",
+            "x-go-name": "ClusterID",
+            "name": "cluster_id",
+            "in": "path",
+            "required": true
+          },
+          {
+            "type": "string",
+            "x-go-name": "AddonID",
+            "name": "addon_id",
+            "in": "path",
+            "required": true
+          }
+        ],
+        "responses": {
+          "200": {
+            "$ref": "#/responses/empty"
+          },
+          "401": {
+            "$ref": "#/responses/empty"
+          },
+          "403": {
+            "$ref": "#/responses/empty"
+          },
+          "default": {
+            "description": "errorResponse",
+            "schema": {
+              "$ref": "#/definitions/errorResponse"
+            }
+          }
+        }
+      },
+      "patch": {
+        "consumes": [
+          "application/json"
+        ],
+        "produces": [
+          "application/json"
+        ],
+        "tags": [
+          "addon"
+        ],
+        "summary": "Patches an addon that is assigned to the given cluster.",
+        "operationId": "patchAddon",
+        "parameters": [
+          {
+            "type": "string",
+            "x-go-name": "ProjectID",
+            "name": "project_id",
+            "in": "path",
+            "required": true
+          },
+          {
+            "type": "string",
+            "x-go-name": "DC",
+            "name": "dc",
+            "in": "path",
+            "required": true
+          },
+          {
+            "type": "string",
+            "x-go-name": "ClusterID",
+            "name": "cluster_id",
+            "in": "path",
+            "required": true
+          },
+          {
+            "type": "string",
+            "x-go-name": "AddonID",
+            "name": "addon_id",
+            "in": "path",
+            "required": true
+          },
+          {
+            "name": "Body",
+            "in": "body",
+            "schema": {
+              "$ref": "#/definitions/Addon"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Addon",
+            "schema": {
+              "$ref": "#/definitions/Addon"
+            }
+          },
+          "401": {
+            "$ref": "#/responses/empty"
+          },
+          "403": {
+            "$ref": "#/responses/empty"
+          },
+          "default": {
+            "description": "errorResponse",
+            "schema": {
+              "$ref": "#/definitions/errorResponse"
+            }
+          }
+        }
+      }
+    },
     "/api/v1/projects/{project_id}/dc/{dc}/clusters/{cluster_id}/events": {
       "get": {
         "produces": [
@@ -4179,6 +4489,53 @@
       "title": "AWSZoneList represents an array of AWS availability zones.",
       "items": {
         "$ref": "#/definitions/AWSZone"
+      },
+      "x-go-package": "github.com/kubermatic/kubermatic/api/pkg/api/v1"
+    },
+    "Addon": {
+      "description": "Addon represents a predefined addon that users may install into their cluster",
+      "type": "object",
+      "properties": {
+        "creationTimestamp": {
+          "description": "CreationTimestamp is a timestamp representing the server time when this object was created.",
+          "type": "string",
+          "format": "date-time",
+          "x-go-name": "CreationTimestamp"
+        },
+        "deletionTimestamp": {
+          "description": "DeletionTimestamp is a timestamp representing the server time when this object was deleted.",
+          "type": "string",
+          "format": "date-time",
+          "x-go-name": "DeletionTimestamp"
+        },
+        "id": {
+          "description": "ID unique value that identifies the resource generated by the server. Read-Only.",
+          "type": "string",
+          "x-go-name": "ID"
+        },
+        "name": {
+          "description": "Name represents human readable name for the resource",
+          "type": "string",
+          "x-go-name": "Name"
+        },
+        "spec": {
+          "$ref": "#/definitions/AddonSpec"
+        }
+      },
+      "x-go-package": "github.com/kubermatic/kubermatic/api/pkg/api/v1"
+    },
+    "AddonSpec": {
+      "description": "AddonSpec addon specification",
+      "type": "object",
+      "properties": {
+        "variables": {
+          "description": "Variables is free form data to use for parsing the manifest templates",
+          "type": "object",
+          "additionalProperties": {
+            "type": "object"
+          },
+          "x-go-name": "Variables"
+        }
       },
       "x-go-package": "github.com/kubermatic/kubermatic/api/pkg/api/v1"
     },

--- a/api/pkg/api/v1/types.go
+++ b/api/pkg/api/v1/types.go
@@ -2,7 +2,6 @@ package v1
 
 import (
 	"encoding/json"
-
 	"github.com/Masterminds/semver"
 
 	kubermaticv1 "github.com/kubermatic/kubermatic/api/pkg/crd/kubermatic/v1"
@@ -597,6 +596,22 @@ type ClusterHealth struct {
 	Etcd                         kubermaticv1.HealthStatus `json:"etcd"`
 	CloudProviderInfrastructure  kubermaticv1.HealthStatus `json:"cloudProviderInfrastructure"`
 	UserClusterControllerManager kubermaticv1.HealthStatus `json:"userClusterControllerManager"`
+}
+
+// Addon represents a predefined addon that users may install into their cluster
+// swagger:model Addon
+type Addon struct {
+	ObjectMeta `json:",inline"`
+
+	Spec AddonSpec `json:"spec"`
+}
+
+// AddonSpec addon specification
+// swagger:model AddonSpec
+type AddonSpec struct {
+
+	// Variables is free form data to use for parsing the manifest templates
+	Variables map[string]interface{} `json:"variables,omitempty"`
 }
 
 // ClusterList represents a list of clusters

--- a/api/pkg/controller/rbac/sync_resource_test.go
+++ b/api/pkg/controller/rbac/sync_resource_test.go
@@ -36,7 +36,7 @@ func TestSyncProjectResourcesClusterWide(t *testing.T) {
 		// scenario 1
 		{
 			name:            "scenario 1: a proper set of RBAC Role/Binding is generated for a cluster",
-			expectedActions: []string{"create", "create", "create", "create", "create", "create"},
+			expectedActions: []string{"create", "create", "create", "create", "create", "create", "get", "create", "get", "create", "get", "create", "get", "create", "get", "create", "get", "create"},
 
 			dependantToSync: &resourceToProcess{
 				gvr: schema.GroupVersionResource{
@@ -576,7 +576,7 @@ func TestSyncProjectResourcesClusterWide(t *testing.T) {
 				}
 			}
 
-			clusterRoleBindingActions := allActions[offset:]
+			clusterRoleBindingActions := allActions[offset:(2 * offset)]
 			for index, action := range clusterRoleBindingActions {
 				if !action.Matches(test.expectedActions[index+offset], "clusterrolebindings") {
 					t.Fatalf("unexpected action %#v", action)

--- a/api/pkg/handler/routing.go
+++ b/api/pkg/handler/routing.go
@@ -42,6 +42,7 @@ type Routing struct {
 	tokenVerifiers              auth.TokenVerifier
 	tokenExtractors             auth.TokenExtractor
 	clusterProviderGetter       provider.ClusterProviderGetter
+	addonProviderGetter         provider.AddonProviderGetter
 	updateManager               common.UpdateManager
 	prometheusClient            prometheusapi.Client
 	projectMemberProvider       provider.ProjectMemberProvider
@@ -57,6 +58,7 @@ type Routing struct {
 func NewRouting(
 	seedsGetter provider.SeedsGetter,
 	clusterProviderGetter provider.ClusterProviderGetter,
+	addonProviderGetter provider.AddonProviderGetter,
 	newSSHKeyProvider provider.SSHKeyProvider,
 	userProvider provider.UserProvider,
 	serviceAccountProvider provider.ServiceAccountProvider,
@@ -80,6 +82,7 @@ func NewRouting(
 	return Routing{
 		seedsGetter:                 seedsGetter,
 		clusterProviderGetter:       clusterProviderGetter,
+		addonProviderGetter:         addonProviderGetter,
 		sshKeyProvider:              newSSHKeyProvider,
 		userProvider:                userProvider,
 		serviceAccountProvider:      serviceAccountProvider,

--- a/api/pkg/handler/test/fake_wrapper.go
+++ b/api/pkg/handler/test/fake_wrapper.go
@@ -224,3 +224,33 @@ func (k NewServiceAccountTokenV1SliceWrapper) EqualOrDie(expected NewServiceAcco
 		t.Errorf("actual slice is different that the expected one. Diff: %v", diff)
 	}
 }
+
+// NewAddonSliceWrapper wraps []apiv1.Addon
+// to provide convenient methods for tests
+type NewAddonSliceWrapper []apiv1.Addon
+
+// Sort sorts the collection by CreationTimestamp
+func (k NewAddonSliceWrapper) Sort() {
+	sort.Slice(k, func(i, j int) bool {
+		return k[i].CreationTimestamp.Before(k[j].CreationTimestamp)
+	})
+}
+
+// DecodeOrDie reads and decodes json data from the reader
+func (k *NewAddonSliceWrapper) DecodeOrDie(r io.Reader, t *testing.T) *NewAddonSliceWrapper {
+	t.Helper()
+	dec := json.NewDecoder(r)
+	err := dec.Decode(k)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return k
+}
+
+// EqualOrDie compares whether expected collection is equal to the actual one
+func (k NewAddonSliceWrapper) EqualOrDie(expected NewAddonSliceWrapper, t *testing.T) {
+	t.Helper()
+	if diff := deep.Equal(k, expected); diff != nil {
+		t.Errorf("actual slice is different that the expected one. Diff: %v", diff)
+	}
+}

--- a/api/pkg/handler/test/hack/hack.go
+++ b/api/pkg/handler/test/hack/hack.go
@@ -25,6 +25,7 @@ import (
 func NewTestRouting(
 	seedsGetter provider.SeedsGetter,
 	clusterProvidersGetter provider.ClusterProviderGetter,
+	addonProviderGetter provider.AddonProviderGetter,
 	sshKeyProvider provider.SSHKeyProvider,
 	userProvider provider.UserProvider,
 	serviceAccountProvider provider.ServiceAccountProvider,
@@ -48,6 +49,7 @@ func NewTestRouting(
 	r := handler.NewRouting(
 		seedsGetter,
 		clusterProvidersGetter,
+		addonProviderGetter,
 		sshKeyProvider,
 		userProvider,
 		serviceAccountProvider,

--- a/api/pkg/handler/v1/addon/addon.go
+++ b/api/pkg/handler/v1/addon/addon.go
@@ -1,0 +1,317 @@
+package addon
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"k8s.io/apimachinery/pkg/runtime"
+	"net/http"
+
+	"github.com/go-kit/kit/endpoint"
+	"github.com/gorilla/mux"
+
+	apiv1 "github.com/kubermatic/kubermatic/api/pkg/api/v1"
+	kubermaticapiv1 "github.com/kubermatic/kubermatic/api/pkg/crd/kubermatic/v1"
+	"github.com/kubermatic/kubermatic/api/pkg/handler/middleware"
+	"github.com/kubermatic/kubermatic/api/pkg/handler/v1/common"
+	"github.com/kubermatic/kubermatic/api/pkg/provider"
+	k8sjson "k8s.io/apimachinery/pkg/util/json"
+)
+
+// addonReq defines HTTP request for getAddon and deleteAddon
+// swagger:parameters getAddon deleteAddon
+type addonReq struct {
+	common.GetClusterReq
+	// in: path
+	AddonID string `json:"addon_id"`
+}
+
+// listReq defines HTTP request for listAddons endpoint
+// swagger:parameters listAddons
+type listReq struct {
+	common.GetClusterReq
+}
+
+// createReq defines HTTP request for createAddon endpoint
+// swagger:parameters createAddon
+type createReq struct {
+	common.GetClusterReq
+	// in: body
+	Body apiv1.Addon
+}
+
+// patchReq defines HTTP request for patchAddon endpoint
+// swagger:parameters patchAddon
+type patchReq struct {
+	addonReq
+	// in: body
+	Body apiv1.Addon
+}
+
+func DecodeGetAddon(c context.Context, r *http.Request) (interface{}, error) {
+	var req addonReq
+
+	cr, err := common.DecodeGetClusterReq(c, r)
+	if err != nil {
+		return nil, err
+	}
+
+	addonID, err := decodeAddonID(c, r)
+	if err != nil {
+		return nil, err
+	}
+
+	req.GetClusterReq = cr.(common.GetClusterReq)
+	req.AddonID = addonID
+
+	return req, nil
+}
+
+func DecodeListAddons(c context.Context, r *http.Request) (interface{}, error) {
+	var req listReq
+
+	cr, err := common.DecodeGetClusterReq(c, r)
+	if err != nil {
+		return nil, err
+	}
+
+	req.GetClusterReq = cr.(common.GetClusterReq)
+
+	return req, nil
+}
+
+func DecodeCreateAddon(c context.Context, r *http.Request) (interface{}, error) {
+	var req createReq
+
+	cr, err := common.DecodeGetClusterReq(c, r)
+	if err != nil {
+		return nil, err
+	}
+
+	req.GetClusterReq = cr.(common.GetClusterReq)
+
+	if err := json.NewDecoder(r.Body).Decode(&req.Body); err != nil {
+		return nil, err
+	}
+
+	return req, nil
+}
+
+func DecodePatchAddon(c context.Context, r *http.Request) (interface{}, error) {
+	var req patchReq
+
+	gr, err := DecodeGetAddon(c, r)
+	if err != nil {
+		return nil, err
+	}
+
+	req.addonReq = gr.(addonReq)
+	if err := json.NewDecoder(r.Body).Decode(&req.Body); err != nil {
+		return nil, err
+	}
+
+	return req, nil
+}
+
+func decodeAddonID(c context.Context, r *http.Request) (string, error) {
+	addonID := mux.Vars(r)["addon_id"]
+	if addonID == "" {
+		return "", fmt.Errorf("'addon_id' parameter is required but was not provided")
+	}
+
+	return addonID, nil
+}
+
+func GetAddonEndpoint(projectProvider provider.ProjectProvider) endpoint.Endpoint {
+	return func(ctx context.Context, request interface{}) (interface{}, error) {
+		req := request.(addonReq)
+		clusterProvider := ctx.Value(middleware.ClusterProviderContextKey).(provider.ClusterProvider)
+		userInfo := ctx.Value(middleware.UserInfoContextKey).(*provider.UserInfo)
+		_, err := projectProvider.Get(userInfo, req.ProjectID, &provider.ProjectGetOptions{})
+		if err != nil {
+			return nil, common.KubernetesErrorToHTTPError(err)
+		}
+		cluster, err := clusterProvider.Get(userInfo, req.ClusterID, &provider.ClusterGetOptions{})
+		if err != nil {
+			return nil, common.KubernetesErrorToHTTPError(err)
+		}
+
+		addonProvider := ctx.Value(middleware.AddonProviderContextKey).(provider.AddonProvider)
+		addon, err := addonProvider.Get(userInfo, cluster, req.AddonID)
+		if err != nil {
+			return nil, common.KubernetesErrorToHTTPError(err)
+		}
+
+		result, err := convertInternalAddonToExternal(addon)
+		if err != nil {
+			return nil, common.KubernetesErrorToHTTPError(err)
+		}
+		return result, nil
+	}
+}
+
+func ListAddonEndpoint(projectProvider provider.ProjectProvider) endpoint.Endpoint {
+	return func(ctx context.Context, request interface{}) (interface{}, error) {
+		req := request.(listReq)
+		clusterProvider := ctx.Value(middleware.ClusterProviderContextKey).(provider.ClusterProvider)
+		userInfo := ctx.Value(middleware.UserInfoContextKey).(*provider.UserInfo)
+		_, err := projectProvider.Get(userInfo, req.ProjectID, &provider.ProjectGetOptions{})
+		if err != nil {
+			return nil, common.KubernetesErrorToHTTPError(err)
+		}
+		cluster, err := clusterProvider.Get(userInfo, req.ClusterID, &provider.ClusterGetOptions{})
+		if err != nil {
+			return nil, common.KubernetesErrorToHTTPError(err)
+		}
+
+		addonProvider := ctx.Value(middleware.AddonProviderContextKey).(provider.AddonProvider)
+		addons, err := addonProvider.List(userInfo, cluster)
+		if err != nil {
+			return nil, common.KubernetesErrorToHTTPError(err)
+		}
+
+		result, err := convertInternalAddonsToExternal(addons)
+		if err != nil {
+			return nil, common.KubernetesErrorToHTTPError(err)
+		}
+		return result, nil
+	}
+}
+
+func CreateAddonEndpoint(projectProvider provider.ProjectProvider) endpoint.Endpoint {
+	return func(ctx context.Context, request interface{}) (interface{}, error) {
+		req := request.(createReq)
+		clusterProvider := ctx.Value(middleware.ClusterProviderContextKey).(provider.ClusterProvider)
+		userInfo := ctx.Value(middleware.UserInfoContextKey).(*provider.UserInfo)
+		_, err := projectProvider.Get(userInfo, req.ProjectID, &provider.ProjectGetOptions{})
+		if err != nil {
+			return nil, common.KubernetesErrorToHTTPError(err)
+		}
+		cluster, err := clusterProvider.Get(userInfo, req.ClusterID, &provider.ClusterGetOptions{})
+		if err != nil {
+			return nil, common.KubernetesErrorToHTTPError(err)
+		}
+
+		addonProvider := ctx.Value(middleware.AddonProviderContextKey).(provider.AddonProvider)
+		rawVars, err := convertExternalVariablesToInternal(req.Body.Spec.Variables)
+		if err != nil {
+			return nil, common.KubernetesErrorToHTTPError(err)
+		}
+
+		addon, err := addonProvider.New(userInfo, cluster, req.Body.Name, rawVars)
+		if err != nil {
+			return nil, common.KubernetesErrorToHTTPError(err)
+		}
+
+		result, err := convertInternalAddonToExternal(addon)
+		if err != nil {
+			return nil, common.KubernetesErrorToHTTPError(err)
+		}
+		return result, nil
+	}
+}
+
+func PatchAddonEndpoint(projectProvider provider.ProjectProvider) endpoint.Endpoint {
+	return func(ctx context.Context, request interface{}) (interface{}, error) {
+		req := request.(patchReq)
+		clusterProvider := ctx.Value(middleware.ClusterProviderContextKey).(provider.ClusterProvider)
+		userInfo := ctx.Value(middleware.UserInfoContextKey).(*provider.UserInfo)
+		_, err := projectProvider.Get(userInfo, req.ProjectID, &provider.ProjectGetOptions{})
+		if err != nil {
+			return nil, common.KubernetesErrorToHTTPError(err)
+		}
+		cluster, err := clusterProvider.Get(userInfo, req.ClusterID, &provider.ClusterGetOptions{})
+		if err != nil {
+			return nil, common.KubernetesErrorToHTTPError(err)
+		}
+
+		addonProvider := ctx.Value(middleware.AddonProviderContextKey).(provider.AddonProvider)
+		addon, err := addonProvider.Get(userInfo, cluster, req.AddonID)
+		if err != nil {
+			return nil, common.KubernetesErrorToHTTPError(err)
+		}
+		rawVars, err := convertExternalVariablesToInternal(req.Body.Spec.Variables)
+		if err != nil {
+			return nil, common.KubernetesErrorToHTTPError(err)
+		}
+		addon.Spec.Variables = *rawVars
+
+		addon, err = addonProvider.Update(userInfo, cluster, addon)
+		if err != nil {
+			return nil, common.KubernetesErrorToHTTPError(err)
+		}
+
+		result, err := convertInternalAddonToExternal(addon)
+		if err != nil {
+			return nil, common.KubernetesErrorToHTTPError(err)
+		}
+		return result, nil
+	}
+}
+
+func DeleteAddonEndpoint(projectProvider provider.ProjectProvider) endpoint.Endpoint {
+	return func(ctx context.Context, request interface{}) (interface{}, error) {
+		req := request.(addonReq)
+		clusterProvider := ctx.Value(middleware.ClusterProviderContextKey).(provider.ClusterProvider)
+		userInfo := ctx.Value(middleware.UserInfoContextKey).(*provider.UserInfo)
+		_, err := projectProvider.Get(userInfo, req.ProjectID, &provider.ProjectGetOptions{})
+		if err != nil {
+			return nil, common.KubernetesErrorToHTTPError(err)
+		}
+		cluster, err := clusterProvider.Get(userInfo, req.ClusterID, &provider.ClusterGetOptions{})
+		if err != nil {
+			return nil, common.KubernetesErrorToHTTPError(err)
+		}
+
+		addonProvider := ctx.Value(middleware.AddonProviderContextKey).(provider.AddonProvider)
+
+		return nil, common.KubernetesErrorToHTTPError(addonProvider.Delete(userInfo, cluster, req.AddonID))
+	}
+}
+
+func convertInternalAddonToExternal(internalAddon *kubermaticapiv1.Addon) (*apiv1.Addon, error) {
+	result := &apiv1.Addon{
+		ObjectMeta: apiv1.ObjectMeta{
+			ID:                internalAddon.Name,
+			Name:              internalAddon.Name,
+			CreationTimestamp: apiv1.NewTime(internalAddon.CreationTimestamp.Time),
+			DeletionTimestamp: func() *apiv1.Time {
+				if internalAddon.DeletionTimestamp != nil {
+					deletionTimestamp := apiv1.NewTime(internalAddon.DeletionTimestamp.Time)
+					return &deletionTimestamp
+				}
+				return nil
+			}(),
+		},
+	}
+	if len(internalAddon.Spec.Variables.Raw) > 0 {
+		if err := k8sjson.Unmarshal(internalAddon.Spec.Variables.Raw, &result.Spec.Variables); err != nil {
+			return nil, err
+		}
+	}
+	return result, nil
+}
+
+func convertInternalAddonsToExternal(internalAddons []*kubermaticapiv1.Addon) ([]*apiv1.Addon, error) {
+	result := []*apiv1.Addon{}
+
+	for _, addon := range internalAddons {
+		converted, err := convertInternalAddonToExternal(addon)
+		if err != nil {
+			return nil, err
+		}
+		result = append(result, converted)
+	}
+
+	return result, nil
+}
+
+func convertExternalVariablesToInternal(external map[string]interface{}) (*runtime.RawExtension, error) {
+	result := &runtime.RawExtension{}
+	raw, err := k8sjson.Marshal(external)
+	if err != nil {
+		return nil, err
+	}
+	result.Raw = raw
+	return result, nil
+}

--- a/api/pkg/handler/v1/addon/addon_test.go
+++ b/api/pkg/handler/v1/addon/addon_test.go
@@ -1,0 +1,468 @@
+package addon_test
+
+import (
+	"encoding/json"
+	"fmt"
+	apiv1 "github.com/kubermatic/kubermatic/api/pkg/api/v1"
+	kubermaticv1 "github.com/kubermatic/kubermatic/api/pkg/crd/kubermatic/v1"
+	"github.com/kubermatic/kubermatic/api/pkg/handler/test"
+	"github.com/kubermatic/kubermatic/api/pkg/handler/test/hack"
+	"k8s.io/apimachinery/pkg/runtime"
+	k8sjson "k8s.io/apimachinery/pkg/util/json"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+)
+
+func TestGetAddon(t *testing.T) {
+	t.Parallel()
+	creationTime := test.DefaultCreationTimestamp()
+	testVariables := map[string]interface{}{"foo": "bar", "hello": "world"}
+
+	testcases := []struct {
+		Name                   string
+		ProjectIDToSync        string
+		ClusterIDToSync        string
+		ExistingProject        *kubermaticv1.Project
+		ExistingKubermaticUser *kubermaticv1.User
+		ExistingAPIUser        *apiv1.User
+		ExistingCluster        *kubermaticv1.Cluster
+		ExistingAddons         []*kubermaticv1.Addon
+		AddonToGet             string
+		ExistingKubermaticObjs []runtime.Object
+		ExpectedHTTPStatus     int
+		ExpectedResponse       apiv1.Addon
+	}{
+		// scenario 1
+		{
+			Name:                   "scenario 1: get addon that belongs to the given cluster",
+			ClusterIDToSync:        test.GenDefaultCluster().Name,
+			ProjectIDToSync:        test.GenDefaultProject().Name,
+			ExistingKubermaticObjs: test.GenDefaultKubermaticObjects(test.GenDefaultCluster()),
+			ExistingAPIUser:        test.GenDefaultAPIUser(),
+			ExistingAddons: []*kubermaticv1.Addon{
+				test.GenTestAddon("addon1", nil, test.GenDefaultCluster(), creationTime),
+			},
+			AddonToGet:         "addon1",
+			ExpectedHTTPStatus: http.StatusOK,
+			ExpectedResponse: apiv1.Addon{
+				ObjectMeta: apiv1.ObjectMeta{
+					ID:                "addon1",
+					Name:              "addon1",
+					CreationTimestamp: apiv1.NewTime(creationTime),
+				},
+			},
+		},
+		// scenario 2
+		{
+			Name:                   "scenario 2: get addon with variables that belongs to the given cluster",
+			ClusterIDToSync:        test.GenDefaultCluster().Name,
+			ProjectIDToSync:        test.GenDefaultProject().Name,
+			ExistingKubermaticObjs: test.GenDefaultKubermaticObjects(test.GenDefaultCluster()),
+			ExistingAPIUser:        test.GenDefaultAPIUser(),
+			ExistingAddons: []*kubermaticv1.Addon{
+				test.GenTestAddon("addon1", createRawVariables(t, testVariables), test.GenDefaultCluster(), creationTime),
+			},
+			AddonToGet:         "addon1",
+			ExpectedHTTPStatus: http.StatusOK,
+			ExpectedResponse: apiv1.Addon{
+				ObjectMeta: apiv1.ObjectMeta{
+					ID:                "addon1",
+					Name:              "addon1",
+					CreationTimestamp: apiv1.NewTime(creationTime),
+				},
+				Spec: apiv1.AddonSpec{
+					Variables: testVariables,
+				},
+			},
+		},
+		// scenario 3
+		{
+			Name:                   "scenario 3: try to get addon that belongs to the given cluster but isn't accessible",
+			ClusterIDToSync:        test.GenDefaultCluster().Name,
+			ProjectIDToSync:        test.GenDefaultProject().Name,
+			ExistingKubermaticObjs: test.GenDefaultKubermaticObjects(test.GenDefaultCluster()),
+			ExistingAPIUser:        test.GenDefaultAPIUser(),
+			ExistingAddons: []*kubermaticv1.Addon{
+				test.GenTestAddon("addon1", nil, test.GenDefaultCluster(), creationTime),
+				test.GenTestAddon("addon2", nil, test.GenDefaultCluster(), creationTime),
+				test.GenTestAddon("addon3", nil, test.GenDefaultCluster(), creationTime),
+			},
+			AddonToGet:         "addon3",
+			ExpectedHTTPStatus: http.StatusUnauthorized,
+			ExpectedResponse:   apiv1.Addon{},
+		},
+	}
+
+	for _, tc := range testcases {
+		t.Run(tc.Name, func(t *testing.T) {
+			req := httptest.NewRequest("GET", fmt.Sprintf("/api/v1/projects/%s/dc/us-central1/clusters/%s/addons/%s", tc.ProjectIDToSync, tc.ClusterIDToSync, tc.AddonToGet), strings.NewReader(""))
+			res := httptest.NewRecorder()
+			kubermaticObj := []runtime.Object{}
+			machineObj := []runtime.Object{}
+			kubernetesObj := []runtime.Object{}
+			kubermaticObj = append(kubermaticObj, tc.ExistingKubermaticObjs...)
+			for _, existingAddon := range tc.ExistingAddons {
+				kubermaticObj = append(kubermaticObj, existingAddon)
+			}
+			ep, _, err := test.CreateTestEndpointAndGetClients(*tc.ExistingAPIUser, nil, kubernetesObj, machineObj, kubermaticObj, nil, nil, hack.NewTestRouting)
+			if err != nil {
+				t.Fatalf("failed to create test endpoint due to %v", err)
+			}
+
+			ep.ServeHTTP(res, req)
+
+			if res.Code != tc.ExpectedHTTPStatus {
+				t.Fatalf("Expected HTTP status code %d, got %d: %s", tc.ExpectedHTTPStatus, res.Code, res.Body.String())
+			}
+
+			if res.Code == http.StatusOK {
+				bytes, err := json.Marshal(tc.ExpectedResponse)
+				if err != nil {
+					t.Fatalf("failed to marshall expected response %v", err)
+				}
+
+				test.CompareWithResult(t, res, string(bytes))
+			}
+		})
+	}
+}
+
+func TestListAddons(t *testing.T) {
+	t.Parallel()
+	creationTime := test.DefaultCreationTimestamp()
+	cluster := test.GenDefaultCluster()
+	cluster.Status.NamespaceName = fmt.Sprintf("cluster-%s", cluster.Name)
+	testVariables := map[string]interface{}{"foo": "bar", "hello": "world"}
+
+	testcases := []struct {
+		Name                   string
+		ExpectedResponse       []apiv1.Addon
+		ExpectedHTTPStatus     int
+		ExistingKubermaticObjs []runtime.Object
+		ExistingAPIUser        *apiv1.User
+	}{
+		// scenario 1
+		{
+			Name: "scenario 1: gets a list of addons added to cluster",
+			ExpectedResponse: []apiv1.Addon{
+				{
+					ObjectMeta: apiv1.ObjectMeta{
+						ID:                "addon1",
+						Name:              "addon1",
+						CreationTimestamp: apiv1.NewTime(creationTime),
+					},
+				},
+				{
+					ObjectMeta: apiv1.ObjectMeta{
+						ID:                "addon2",
+						Name:              "addon2",
+						CreationTimestamp: apiv1.NewTime(creationTime),
+					},
+					Spec: apiv1.AddonSpec{
+						Variables: testVariables,
+					},
+				},
+			},
+			ExpectedHTTPStatus: http.StatusOK,
+			ExistingKubermaticObjs: []runtime.Object{
+				/*add projects*/
+				test.GenProject("my-first-project", kubermaticv1.ProjectActive, test.DefaultCreationTimestamp()),
+				/*add bindings*/
+				test.GenBinding("my-first-project-ID", "john@acme.com", "owners"),
+				/*add users*/
+				test.GenUser("", "john", "john@acme.com"),
+				/*add cluster*/
+				cluster,
+				test.GenTestAddon("addon1", nil, cluster, creationTime),
+				test.GenTestAddon("addon2", createRawVariables(t, testVariables), cluster, creationTime),
+			},
+			ExistingAPIUser: test.GenAPIUser("john", "john@acme.com"),
+		},
+		// scenario 2
+		{
+			Name: "scenario 2: gets a list of addons added to cluster except those that are not accessible",
+			ExpectedResponse: []apiv1.Addon{
+				{
+					ObjectMeta: apiv1.ObjectMeta{
+						ID:                "addon1",
+						Name:              "addon1",
+						CreationTimestamp: apiv1.NewTime(creationTime),
+					},
+				},
+				{
+					ObjectMeta: apiv1.ObjectMeta{
+						ID:                "addon2",
+						Name:              "addon2",
+						CreationTimestamp: apiv1.NewTime(creationTime),
+					},
+				},
+			},
+			ExpectedHTTPStatus: http.StatusOK,
+			ExistingKubermaticObjs: []runtime.Object{
+				/*add projects*/
+				test.GenProject("my-first-project", kubermaticv1.ProjectActive, test.DefaultCreationTimestamp()),
+				/*add bindings*/
+				test.GenBinding("my-first-project-ID", "john@acme.com", "owners"),
+				/*add users*/
+				test.GenUser("", "john", "john@acme.com"),
+				/*add cluster*/
+				cluster,
+				test.GenTestAddon("addon0", nil, cluster, creationTime),
+				test.GenTestAddon("addon1", nil, cluster, creationTime),
+				test.GenTestAddon("addon2", nil, cluster, creationTime),
+				test.GenTestAddon("addon3", nil, cluster, creationTime),
+				test.GenTestAddon("addon4", nil, cluster, creationTime),
+			},
+			ExistingAPIUser: test.GenAPIUser("john", "john@acme.com"),
+		},
+	}
+
+	for _, tc := range testcases {
+		t.Run(tc.Name, func(t *testing.T) {
+			req := httptest.NewRequest("GET", fmt.Sprintf("/api/v1/projects/%s/dc/us-central1/clusters/%s/addons", "my-first-project-ID", cluster.Name), strings.NewReader(""))
+			res := httptest.NewRecorder()
+			kubermaticObj := []runtime.Object{}
+			kubermaticObj = append(kubermaticObj, tc.ExistingKubermaticObjs...)
+			ep, err := test.CreateTestEndpoint(*tc.ExistingAPIUser, []runtime.Object{}, kubermaticObj, nil, nil, hack.NewTestRouting)
+			if err != nil {
+				t.Fatalf("failed to create test endpoint due to %v", err)
+			}
+
+			ep.ServeHTTP(res, req)
+
+			if res.Code != tc.ExpectedHTTPStatus {
+				t.Fatalf("Expected HTTP status code %d, got %d: %s", tc.ExpectedHTTPStatus, res.Code, res.Body.String())
+			}
+
+			actualAddons := test.NewAddonSliceWrapper{}
+			actualAddons.DecodeOrDie(res.Body, t).Sort()
+
+			wrappedExpectedAddons := test.NewAddonSliceWrapper(tc.ExpectedResponse)
+			wrappedExpectedAddons.Sort()
+			actualAddons.EqualOrDie(wrappedExpectedAddons, t)
+		})
+	}
+}
+
+func TestCreateAddon(t *testing.T) {
+	t.Parallel()
+	cluster := test.GenDefaultCluster()
+	cluster.Status.NamespaceName = fmt.Sprintf("cluster-%s", cluster.Name)
+
+	testcases := []struct {
+		Name                   string
+		Body                   string
+		ExpectedResponse       apiv1.Addon
+		ExpectedHTTPStatus     int
+		ExistingKubermaticObjs []runtime.Object
+		ExistingAPIUser        *apiv1.User
+	}{
+		// scenario 1
+		{
+			Name: "scenario 1: create an addon",
+			Body: `{
+				"name": "addon1",
+				"spec": {
+					"variables": null
+				}
+			}`,
+			ExpectedResponse: apiv1.Addon{
+				ObjectMeta: apiv1.ObjectMeta{
+					ID:   "addon1",
+					Name: "addon1",
+				},
+			},
+			ExpectedHTTPStatus: http.StatusCreated,
+			ExistingKubermaticObjs: []runtime.Object{
+				/*add projects*/
+				test.GenProject("my-first-project", kubermaticv1.ProjectActive, test.DefaultCreationTimestamp()),
+				/*add bindings*/
+				test.GenBinding("my-first-project-ID", "john@acme.com", "owners"),
+				/*add users*/
+				test.GenUser("", "john", "john@acme.com"),
+				/*add cluster*/
+				cluster,
+			},
+			ExistingAPIUser: test.GenAPIUser("john", "john@acme.com"),
+		},
+		// scenario 2
+		{
+			Name: "scenario 2: try to create an addon that wouldn't be accessible",
+			Body: `{
+				"name": "inaccessible",
+				"spec": {
+					"variables": null
+				}
+			}`,
+			ExpectedHTTPStatus: http.StatusUnauthorized,
+			ExistingKubermaticObjs: []runtime.Object{
+				/*add projects*/
+				test.GenProject("my-first-project", kubermaticv1.ProjectActive, test.DefaultCreationTimestamp()),
+				/*add bindings*/
+				test.GenBinding("my-first-project-ID", "john@acme.com", "owners"),
+				/*add users*/
+				test.GenUser("", "john", "john@acme.com"),
+				/*add cluster*/
+				cluster,
+			},
+			ExistingAPIUser: test.GenAPIUser("john", "john@acme.com"),
+		},
+	}
+
+	for _, tc := range testcases {
+		t.Run(tc.Name, func(t *testing.T) {
+			req := httptest.NewRequest("POST", fmt.Sprintf("/api/v1/projects/%s/dc/us-central1/clusters/%s/addons", "my-first-project-ID", cluster.Name), strings.NewReader(tc.Body))
+			res := httptest.NewRecorder()
+			kubermaticObj := []runtime.Object{}
+			kubermaticObj = append(kubermaticObj, tc.ExistingKubermaticObjs...)
+			ep, err := test.CreateTestEndpoint(*tc.ExistingAPIUser, []runtime.Object{}, kubermaticObj, nil, nil, hack.NewTestRouting)
+			if err != nil {
+				t.Fatalf("failed to create test endpoint due to %v", err)
+			}
+
+			ep.ServeHTTP(res, req)
+
+			if res.Code != tc.ExpectedHTTPStatus {
+				t.Fatalf("Expected HTTP status code %d, got %d: %s", tc.ExpectedHTTPStatus, res.Code, res.Body.String())
+			}
+
+			if res.Code == http.StatusCreated {
+				bytes, err := json.Marshal(tc.ExpectedResponse)
+				if err != nil {
+					t.Fatalf("failed to marshall expected response %v", err)
+				}
+
+				test.CompareWithResult(t, res, string(bytes))
+			}
+		})
+	}
+}
+
+func TestCreatePatchGetAddon(t *testing.T) {
+	t.Parallel()
+	cluster := test.GenDefaultCluster()
+	cluster.Status.NamespaceName = fmt.Sprintf("cluster-%s", cluster.Name)
+
+	testcases := []struct {
+		Name                     string
+		CreateBody               string
+		PatchBody                string
+		ExpectedGetResponse      apiv1.Addon
+		ExpectedCreateHTTPStatus int
+		AddonToPatch             string
+		ExpectedPatchHTTPStatus  int
+		AddonToGet               string
+		ExpectedGetHTTPStatus    int
+		ExistingKubermaticObjs   []runtime.Object
+		ExistingAPIUser          *apiv1.User
+	}{
+		// scenario 1
+		{
+			Name: "scenario 1: create, patch, get an addon",
+			CreateBody: `{
+				"name": "addon1",
+				"spec": {
+					"variables": null
+				}
+			}`,
+			ExpectedCreateHTTPStatus: http.StatusCreated,
+			AddonToPatch:             "addon1",
+			PatchBody: `{
+				"name": "addon1",
+				"spec": {
+					"variables": {"foo": "bar"}
+				}
+			}`,
+			ExpectedPatchHTTPStatus: http.StatusOK,
+			AddonToGet:              "addon1",
+			ExpectedGetHTTPStatus:   http.StatusOK,
+			ExpectedGetResponse: apiv1.Addon{
+				ObjectMeta: apiv1.ObjectMeta{
+					ID:   "addon1",
+					Name: "addon1",
+				},
+				Spec: apiv1.AddonSpec{
+					Variables: map[string]interface{}{"foo": "bar"},
+				},
+			},
+			ExistingKubermaticObjs: []runtime.Object{
+				/*add projects*/
+				test.GenProject("my-first-project", kubermaticv1.ProjectActive, test.DefaultCreationTimestamp()),
+				/*add bindings*/
+				test.GenBinding("my-first-project-ID", "john@acme.com", "owners"),
+				/*add users*/
+				test.GenUser("", "john", "john@acme.com"),
+				/*add cluster*/
+				cluster,
+			},
+			ExistingAPIUser: test.GenAPIUser("john", "john@acme.com"),
+		},
+	}
+
+	for _, tc := range testcases {
+		t.Run(tc.Name, func(t *testing.T) {
+			req := httptest.NewRequest("POST", fmt.Sprintf("/api/v1/projects/%s/dc/us-central1/clusters/%s/addons", "my-first-project-ID", cluster.Name), strings.NewReader(tc.CreateBody))
+			res := httptest.NewRecorder()
+			kubermaticObj := []runtime.Object{}
+			kubermaticObj = append(kubermaticObj, tc.ExistingKubermaticObjs...)
+			ep, err := test.CreateTestEndpoint(*tc.ExistingAPIUser, []runtime.Object{}, kubermaticObj, nil, nil, hack.NewTestRouting)
+			if err != nil {
+				t.Fatalf("failed to create test endpoint due to %v", err)
+			}
+
+			ep.ServeHTTP(res, req)
+
+			if res.Code != tc.ExpectedCreateHTTPStatus {
+				t.Fatalf("Expected CREATE HTTP status code %d, got %d: %s", tc.ExpectedCreateHTTPStatus, res.Code, res.Body.String())
+			}
+
+			if res.Code != http.StatusCreated {
+				return
+			}
+
+			req = httptest.NewRequest("PATCH", fmt.Sprintf("/api/v1/projects/%s/dc/us-central1/clusters/%s/addons/%s", "my-first-project-ID", cluster.Name, tc.AddonToPatch), strings.NewReader(tc.PatchBody))
+			res = httptest.NewRecorder()
+
+			ep.ServeHTTP(res, req)
+
+			if res.Code != tc.ExpectedPatchHTTPStatus {
+				t.Fatalf("Expected PATCH HTTP status code %d, got %d: %s", tc.ExpectedPatchHTTPStatus, res.Code, res.Body.String())
+			}
+
+			if res.Code != http.StatusOK {
+				return
+			}
+
+			req = httptest.NewRequest("GET", fmt.Sprintf("/api/v1/projects/%s/dc/us-central1/clusters/%s/addons/%s", "my-first-project-ID", cluster.Name, tc.AddonToGet), strings.NewReader(""))
+			res = httptest.NewRecorder()
+
+			if res.Code != tc.ExpectedGetHTTPStatus {
+				t.Fatalf("Expected GET HTTP status code %d, got %d: %s", tc.ExpectedGetHTTPStatus, res.Code, res.Body.String())
+			}
+
+			ep.ServeHTTP(res, req)
+
+			if res.Code != http.StatusOK {
+				return
+			}
+
+			bytes, err := json.Marshal(tc.ExpectedGetResponse)
+			if err != nil {
+				t.Fatalf("failed to marshall expected response %v", err)
+			}
+			test.CompareWithResult(t, res, string(bytes))
+		})
+	}
+}
+
+func createRawVariables(t *testing.T, in map[string]interface{}) *runtime.RawExtension {
+	result := &runtime.RawExtension{}
+	raw, err := k8sjson.Marshal(in)
+	if err != nil {
+		t.Fatalf("failed to marshal external Variables: %v", err)
+	}
+	result.Raw = raw
+	return result
+}

--- a/api/pkg/provider/datacenter.go
+++ b/api/pkg/provider/datacenter.go
@@ -42,6 +42,9 @@ type SeedKubeconfigGetter = func(seedName string) (*rest.Config, error)
 // ClusterProviderGetter is used to get a clusterProvider
 type ClusterProviderGetter = func(seedName string) (ClusterProvider, error)
 
+// AddonProviderGetterr is used to get an AddonProvider
+type AddonProviderGetter = func(seedName string) (AddonProvider, error)
+
 // DatacenterMeta describes a Kubermatic datacenter.
 type DatacenterMeta struct {
 	Location         string                      `json:"location"`

--- a/api/pkg/provider/types.go
+++ b/api/pkg/provider/types.go
@@ -3,6 +3,7 @@ package provider
 import (
 	"errors"
 	"fmt"
+	"k8s.io/apimachinery/pkg/runtime"
 
 	kubermaticv1 "github.com/kubermatic/kubermatic/api/pkg/crd/kubermatic/v1"
 
@@ -409,4 +410,23 @@ type EventRecorderProvider interface {
 	// ClusterRecorderFor returns a event recorder that will be able to record event for objects in the cluster
 	// referred by provided cluster config.
 	ClusterRecorderFor(client kubernetes.Interface) record.EventRecorder
+}
+
+// AddonProvider declares the set of methods for interacting with addons
+type AddonProvider interface {
+	// New creates a new addon in the given cluster
+	New(userInfo *UserInfo, cluster *kubermaticv1.Cluster, addonName string, variables *runtime.RawExtension) (*kubermaticv1.Addon, error)
+
+	// List gets all addons that belong to the given cluster
+	// If you want to filter the result please take a look at ClusterListOptions
+	List(userInfo *UserInfo, cluster *kubermaticv1.Cluster) ([]*kubermaticv1.Addon, error)
+
+	// Get returns the given addon
+	Get(userInfo *UserInfo, cluster *kubermaticv1.Cluster, addonName string) (*kubermaticv1.Addon, error)
+
+	// Update updates an addon
+	Update(userInfo *UserInfo, cluster *kubermaticv1.Cluster, newAddon *kubermaticv1.Addon) (*kubermaticv1.Addon, error)
+
+	// Delete deletes the given addon
+	Delete(userInfo *UserInfo, cluster *kubermaticv1.Cluster, addonName string) error
 }

--- a/config/kubermatic/templates/kubermatic-api-dep.yaml
+++ b/config/kubermatic/templates/kubermatic-api-dep.yaml
@@ -38,6 +38,7 @@ spec:
         - -kubeconfig=/opt/.kube/kubeconfig
         - -master-resources=/opt/master-files
         - -service-account-signing-key={{ .Values.kubermatic.auth.serviceAccountKey }}
+        - -accessible-addons={{ join "," .Values.kubermatic.api.accessibleAddons }}
         # the following flags enable oidc kubeconfig feature/endpoint
         - -feature-gates={{ .Values.kubermatic.api.featureGates }}
         {{- if regexMatch ".*OIDCKubeCfgEndpoint=true.*" (default "" .Values.kubermatic.api.featureGates) }}

--- a/config/kubermatic/values.yaml
+++ b/config/kubermatic/values.yaml
@@ -135,6 +135,7 @@ kubermatic:
 
   api:
     replicas: 2
+    accessibleAddons: []
     image:
       repository: "quay.io/kubermatic/api"
       tag: "__KUBERMATIC_TAG__"


### PR DESCRIPTION
**What this PR does / why we need it**:

This adds endpoints to the API so users can C/R/U/D addons in their own clusters. We also added an option for passing a whitelist of the actually accessible addons to the apiserver, so you can prevent users from uninstalling canal or other vital addons.

**Special notes for your reviewer**:

Open issues:

- unit tests

- using runtime.RawExtension in the AddonSpec API type -- is this OK?

```release-note
added API endpoints for user to create/read/update/delete addons in the clusters
```
