### PR TITLE
Define new KubermaticClusterPaused alert

### DIFF
--- a/config/monitoring/alertmanager/values.yaml
+++ b/config/monitoring/alertmanager/values.yaml
@@ -11,17 +11,38 @@ alertmanager:
   replicas: 3
   storageSize: 100Mi
   storageClass: kubermatic-fast
+
   config:
     global:
       slack_api_url: https://hooks.slack.com/services/YOUR_KEYS_HERE
     route:
       receiver: default
       repeat_interval: 1h
+      routes:
+      - receiver: blackhole
+        match:
+          severity: none
     receivers:
+    - name: blackhole
     - name: default
       slack_configs:
       - channel: '#alerting'
         send_resolved: true
+    inhibit_rules:
+    # do not alert about anything going wrong inside paused clusters
+    - source_match: { alertname: KubermaticClusterPaused }
+      equal: [seed_cluster, cluster]
+    # if etcd is down, it brings down everything else as well
+    - source_match_re: { alertname: EtcdDown, cluster: .+ }
+      equal: [seed_cluster, cluster]
+    # if a user-cluster apiserver is down, ignore other components failing
+    - source_match_re: { alertname: KubernetesApiserverDown, cluster: .+ }
+      equal: [seed_cluster, cluster]
+    # if a user-cluster OpenVPN server is dead, we cannot connect to the nodes anymore
+    - source_match_re: { alertname: OpenVPNServerDown, cluster: .+ }
+      target_match_re: { alertname: (CAdvisorDown|KubernetesNodeDown) }
+      equal: [seed_cluster, cluster]
+
   resources:
     alertmanager:
       requests:

--- a/config/monitoring/prometheus/rules/kubermatic-seed-kubermatic.yaml
+++ b/config/monitoring/prometheus/rules/kubermatic-seed-kubermatic.yaml
@@ -29,3 +29,11 @@ groups:
     for: 15m
     labels:
       severity: critical
+  - alert: KubermaticClusterPaused
+    annotations:
+      message: Cluster {{ $labels.name }} has been paused and will not be reconciled
+        until the pause flag is reset.
+    expr: label_replace(kubermatic_cluster_info{pause="true"}, "cluster", "$0", "name",
+      ".+")
+    labels:
+      severity: none

--- a/config/monitoring/prometheus/rules/src/kubermatic-seed/kubermatic.yaml
+++ b/config/monitoring/prometheus/rules/src/kubermatic-seed/kubermatic.yaml
@@ -48,6 +48,5 @@ groups:
     annotations:
       message: Cluster {{ $labels.name }} has been paused and will not be reconciled until the pause flag is reset.
     expr: label_replace(kubermatic_cluster_info{pause="true"}, "cluster", "$0", "name", ".+")
-    for: 5m
     labels:
       severity: none

--- a/config/monitoring/prometheus/rules/src/kubermatic-seed/kubermatic.yaml
+++ b/config/monitoring/prometheus/rules/src/kubermatic-seed/kubermatic.yaml
@@ -41,3 +41,13 @@ groups:
       steps:
       - Check the Prometheus Service Discovery page to find out why the target is unreachable.
       - Ensure that the controller-manager pod's logs and that it is not crashlooping.
+
+  # This is a dummy alert that is triggered for paused clusters to inhibit all other alerts from such clusters.
+  # The label_replace() is used to create a new "cluster" label that will be used for the inhibitions as well.
+  - alert: KubermaticClusterPaused
+    annotations:
+      message: Cluster {{ $labels.name }} has been paused and will not be reconciled until the pause flag is reset.
+    expr: label_replace(kubermatic_cluster_info{pause="true"}, "cluster", "$0", "name", ".+")
+    for: 5m
+    labels:
+      severity: none


### PR DESCRIPTION
**What this PR does / why we need it**:
This alert is triggered immediately when a cluster is paused. It's being used to inhibit all other alerts from within the cluster, assuming an operator or developer is investigating/developing.

The alert has severity=none because it's not actually an issue. Alertmanager needs to be configured to ignore these alerts accordingly.

**Does this PR introduce a user-facing change?**:
```release-note
add new KubermaticClusterPaused alert with "none" severity for inhibiting alerts from paused clusters
```
