### PR TITLE
Drop metrics from kube-state-metrics initContainer

### DIFF
--- a/api/pkg/resources/prometheus/configmap.go
+++ b/api/pkg/resources/prometheus/configmap.go
@@ -285,6 +285,9 @@ scrape_configs:
 {{- end }}
 
   relabel_configs:
+  - source_labels: [__meta_kubernetes_pod_label_app, __meta_kubernetes_pod_container_init]
+    regex: "kube-state-metrics;true"
+    action: drop
   - source_labels: [__meta_kubernetes_pod_annotation_prometheus_io_scrape]
     action: keep
     regex: true

--- a/api/pkg/resources/test/fixtures/configmap-aws-1.10.0-prometheus.yaml
+++ b/api/pkg/resources/test/fixtures/configmap-aws-1.10.0-prometheus.yaml
@@ -204,6 +204,9 @@ data:
           - "cluster-de-test-01"
 
       relabel_configs:
+      - source_labels: [__meta_kubernetes_pod_label_app, __meta_kubernetes_pod_container_init]
+        regex: "kube-state-metrics;true"
+        action: drop
       - source_labels: [__meta_kubernetes_pod_annotation_prometheus_io_scrape]
         action: keep
         regex: true

--- a/api/pkg/resources/test/fixtures/configmap-aws-1.10.6-prometheus.yaml
+++ b/api/pkg/resources/test/fixtures/configmap-aws-1.10.6-prometheus.yaml
@@ -204,6 +204,9 @@ data:
           - "cluster-de-test-01"
 
       relabel_configs:
+      - source_labels: [__meta_kubernetes_pod_label_app, __meta_kubernetes_pod_container_init]
+        regex: "kube-state-metrics;true"
+        action: drop
       - source_labels: [__meta_kubernetes_pod_annotation_prometheus_io_scrape]
         action: keep
         regex: true

--- a/api/pkg/resources/test/fixtures/configmap-aws-1.11.0-prometheus.yaml
+++ b/api/pkg/resources/test/fixtures/configmap-aws-1.11.0-prometheus.yaml
@@ -208,6 +208,9 @@ data:
         action: drop
 
       relabel_configs:
+      - source_labels: [__meta_kubernetes_pod_label_app, __meta_kubernetes_pod_container_init]
+        regex: "kube-state-metrics;true"
+        action: drop
       - source_labels: [__meta_kubernetes_pod_annotation_prometheus_io_scrape]
         action: keep
         regex: true

--- a/api/pkg/resources/test/fixtures/configmap-aws-1.11.1-prometheus.yaml
+++ b/api/pkg/resources/test/fixtures/configmap-aws-1.11.1-prometheus.yaml
@@ -208,6 +208,9 @@ data:
         action: drop
 
       relabel_configs:
+      - source_labels: [__meta_kubernetes_pod_label_app, __meta_kubernetes_pod_container_init]
+        regex: "kube-state-metrics;true"
+        action: drop
       - source_labels: [__meta_kubernetes_pod_annotation_prometheus_io_scrape]
         action: keep
         regex: true

--- a/api/pkg/resources/test/fixtures/configmap-aws-1.12.0-prometheus.yaml
+++ b/api/pkg/resources/test/fixtures/configmap-aws-1.12.0-prometheus.yaml
@@ -204,6 +204,9 @@ data:
           - "cluster-de-test-01"
 
       relabel_configs:
+      - source_labels: [__meta_kubernetes_pod_label_app, __meta_kubernetes_pod_container_init]
+        regex: "kube-state-metrics;true"
+        action: drop
       - source_labels: [__meta_kubernetes_pod_annotation_prometheus_io_scrape]
         action: keep
         regex: true

--- a/api/pkg/resources/test/fixtures/configmap-aws-1.13.0-prometheus.yaml
+++ b/api/pkg/resources/test/fixtures/configmap-aws-1.13.0-prometheus.yaml
@@ -204,6 +204,9 @@ data:
           - "cluster-de-test-01"
 
       relabel_configs:
+      - source_labels: [__meta_kubernetes_pod_label_app, __meta_kubernetes_pod_container_init]
+        regex: "kube-state-metrics;true"
+        action: drop
       - source_labels: [__meta_kubernetes_pod_annotation_prometheus_io_scrape]
         action: keep
         regex: true

--- a/api/pkg/resources/test/fixtures/configmap-azure-1.10.0-prometheus.yaml
+++ b/api/pkg/resources/test/fixtures/configmap-azure-1.10.0-prometheus.yaml
@@ -204,6 +204,9 @@ data:
           - "cluster-de-test-01"
 
       relabel_configs:
+      - source_labels: [__meta_kubernetes_pod_label_app, __meta_kubernetes_pod_container_init]
+        regex: "kube-state-metrics;true"
+        action: drop
       - source_labels: [__meta_kubernetes_pod_annotation_prometheus_io_scrape]
         action: keep
         regex: true

--- a/api/pkg/resources/test/fixtures/configmap-azure-1.10.6-prometheus.yaml
+++ b/api/pkg/resources/test/fixtures/configmap-azure-1.10.6-prometheus.yaml
@@ -204,6 +204,9 @@ data:
           - "cluster-de-test-01"
 
       relabel_configs:
+      - source_labels: [__meta_kubernetes_pod_label_app, __meta_kubernetes_pod_container_init]
+        regex: "kube-state-metrics;true"
+        action: drop
       - source_labels: [__meta_kubernetes_pod_annotation_prometheus_io_scrape]
         action: keep
         regex: true

--- a/api/pkg/resources/test/fixtures/configmap-azure-1.11.0-prometheus.yaml
+++ b/api/pkg/resources/test/fixtures/configmap-azure-1.11.0-prometheus.yaml
@@ -208,6 +208,9 @@ data:
         action: drop
 
       relabel_configs:
+      - source_labels: [__meta_kubernetes_pod_label_app, __meta_kubernetes_pod_container_init]
+        regex: "kube-state-metrics;true"
+        action: drop
       - source_labels: [__meta_kubernetes_pod_annotation_prometheus_io_scrape]
         action: keep
         regex: true

--- a/api/pkg/resources/test/fixtures/configmap-azure-1.11.1-prometheus.yaml
+++ b/api/pkg/resources/test/fixtures/configmap-azure-1.11.1-prometheus.yaml
@@ -208,6 +208,9 @@ data:
         action: drop
 
       relabel_configs:
+      - source_labels: [__meta_kubernetes_pod_label_app, __meta_kubernetes_pod_container_init]
+        regex: "kube-state-metrics;true"
+        action: drop
       - source_labels: [__meta_kubernetes_pod_annotation_prometheus_io_scrape]
         action: keep
         regex: true

--- a/api/pkg/resources/test/fixtures/configmap-azure-1.12.0-prometheus.yaml
+++ b/api/pkg/resources/test/fixtures/configmap-azure-1.12.0-prometheus.yaml
@@ -204,6 +204,9 @@ data:
           - "cluster-de-test-01"
 
       relabel_configs:
+      - source_labels: [__meta_kubernetes_pod_label_app, __meta_kubernetes_pod_container_init]
+        regex: "kube-state-metrics;true"
+        action: drop
       - source_labels: [__meta_kubernetes_pod_annotation_prometheus_io_scrape]
         action: keep
         regex: true

--- a/api/pkg/resources/test/fixtures/configmap-azure-1.13.0-prometheus.yaml
+++ b/api/pkg/resources/test/fixtures/configmap-azure-1.13.0-prometheus.yaml
@@ -204,6 +204,9 @@ data:
           - "cluster-de-test-01"
 
       relabel_configs:
+      - source_labels: [__meta_kubernetes_pod_label_app, __meta_kubernetes_pod_container_init]
+        regex: "kube-state-metrics;true"
+        action: drop
       - source_labels: [__meta_kubernetes_pod_annotation_prometheus_io_scrape]
         action: keep
         regex: true

--- a/api/pkg/resources/test/fixtures/configmap-bringyourown-1.10.0-prometheus.yaml
+++ b/api/pkg/resources/test/fixtures/configmap-bringyourown-1.10.0-prometheus.yaml
@@ -204,6 +204,9 @@ data:
           - "cluster-de-test-01"
 
       relabel_configs:
+      - source_labels: [__meta_kubernetes_pod_label_app, __meta_kubernetes_pod_container_init]
+        regex: "kube-state-metrics;true"
+        action: drop
       - source_labels: [__meta_kubernetes_pod_annotation_prometheus_io_scrape]
         action: keep
         regex: true

--- a/api/pkg/resources/test/fixtures/configmap-bringyourown-1.10.6-prometheus.yaml
+++ b/api/pkg/resources/test/fixtures/configmap-bringyourown-1.10.6-prometheus.yaml
@@ -204,6 +204,9 @@ data:
           - "cluster-de-test-01"
 
       relabel_configs:
+      - source_labels: [__meta_kubernetes_pod_label_app, __meta_kubernetes_pod_container_init]
+        regex: "kube-state-metrics;true"
+        action: drop
       - source_labels: [__meta_kubernetes_pod_annotation_prometheus_io_scrape]
         action: keep
         regex: true

--- a/api/pkg/resources/test/fixtures/configmap-bringyourown-1.11.0-prometheus.yaml
+++ b/api/pkg/resources/test/fixtures/configmap-bringyourown-1.11.0-prometheus.yaml
@@ -208,6 +208,9 @@ data:
         action: drop
 
       relabel_configs:
+      - source_labels: [__meta_kubernetes_pod_label_app, __meta_kubernetes_pod_container_init]
+        regex: "kube-state-metrics;true"
+        action: drop
       - source_labels: [__meta_kubernetes_pod_annotation_prometheus_io_scrape]
         action: keep
         regex: true

--- a/api/pkg/resources/test/fixtures/configmap-bringyourown-1.11.1-prometheus.yaml
+++ b/api/pkg/resources/test/fixtures/configmap-bringyourown-1.11.1-prometheus.yaml
@@ -208,6 +208,9 @@ data:
         action: drop
 
       relabel_configs:
+      - source_labels: [__meta_kubernetes_pod_label_app, __meta_kubernetes_pod_container_init]
+        regex: "kube-state-metrics;true"
+        action: drop
       - source_labels: [__meta_kubernetes_pod_annotation_prometheus_io_scrape]
         action: keep
         regex: true

--- a/api/pkg/resources/test/fixtures/configmap-bringyourown-1.12.0-prometheus.yaml
+++ b/api/pkg/resources/test/fixtures/configmap-bringyourown-1.12.0-prometheus.yaml
@@ -204,6 +204,9 @@ data:
           - "cluster-de-test-01"
 
       relabel_configs:
+      - source_labels: [__meta_kubernetes_pod_label_app, __meta_kubernetes_pod_container_init]
+        regex: "kube-state-metrics;true"
+        action: drop
       - source_labels: [__meta_kubernetes_pod_annotation_prometheus_io_scrape]
         action: keep
         regex: true

--- a/api/pkg/resources/test/fixtures/configmap-bringyourown-1.13.0-prometheus.yaml
+++ b/api/pkg/resources/test/fixtures/configmap-bringyourown-1.13.0-prometheus.yaml
@@ -204,6 +204,9 @@ data:
           - "cluster-de-test-01"
 
       relabel_configs:
+      - source_labels: [__meta_kubernetes_pod_label_app, __meta_kubernetes_pod_container_init]
+        regex: "kube-state-metrics;true"
+        action: drop
       - source_labels: [__meta_kubernetes_pod_annotation_prometheus_io_scrape]
         action: keep
         regex: true

--- a/api/pkg/resources/test/fixtures/configmap-digitalocean-1.10.0-prometheus.yaml
+++ b/api/pkg/resources/test/fixtures/configmap-digitalocean-1.10.0-prometheus.yaml
@@ -204,6 +204,9 @@ data:
           - "cluster-de-test-01"
 
       relabel_configs:
+      - source_labels: [__meta_kubernetes_pod_label_app, __meta_kubernetes_pod_container_init]
+        regex: "kube-state-metrics;true"
+        action: drop
       - source_labels: [__meta_kubernetes_pod_annotation_prometheus_io_scrape]
         action: keep
         regex: true

--- a/api/pkg/resources/test/fixtures/configmap-digitalocean-1.10.6-prometheus.yaml
+++ b/api/pkg/resources/test/fixtures/configmap-digitalocean-1.10.6-prometheus.yaml
@@ -204,6 +204,9 @@ data:
           - "cluster-de-test-01"
 
       relabel_configs:
+      - source_labels: [__meta_kubernetes_pod_label_app, __meta_kubernetes_pod_container_init]
+        regex: "kube-state-metrics;true"
+        action: drop
       - source_labels: [__meta_kubernetes_pod_annotation_prometheus_io_scrape]
         action: keep
         regex: true

--- a/api/pkg/resources/test/fixtures/configmap-digitalocean-1.11.0-prometheus.yaml
+++ b/api/pkg/resources/test/fixtures/configmap-digitalocean-1.11.0-prometheus.yaml
@@ -208,6 +208,9 @@ data:
         action: drop
 
       relabel_configs:
+      - source_labels: [__meta_kubernetes_pod_label_app, __meta_kubernetes_pod_container_init]
+        regex: "kube-state-metrics;true"
+        action: drop
       - source_labels: [__meta_kubernetes_pod_annotation_prometheus_io_scrape]
         action: keep
         regex: true

--- a/api/pkg/resources/test/fixtures/configmap-digitalocean-1.11.1-prometheus.yaml
+++ b/api/pkg/resources/test/fixtures/configmap-digitalocean-1.11.1-prometheus.yaml
@@ -208,6 +208,9 @@ data:
         action: drop
 
       relabel_configs:
+      - source_labels: [__meta_kubernetes_pod_label_app, __meta_kubernetes_pod_container_init]
+        regex: "kube-state-metrics;true"
+        action: drop
       - source_labels: [__meta_kubernetes_pod_annotation_prometheus_io_scrape]
         action: keep
         regex: true

--- a/api/pkg/resources/test/fixtures/configmap-digitalocean-1.12.0-prometheus.yaml
+++ b/api/pkg/resources/test/fixtures/configmap-digitalocean-1.12.0-prometheus.yaml
@@ -204,6 +204,9 @@ data:
           - "cluster-de-test-01"
 
       relabel_configs:
+      - source_labels: [__meta_kubernetes_pod_label_app, __meta_kubernetes_pod_container_init]
+        regex: "kube-state-metrics;true"
+        action: drop
       - source_labels: [__meta_kubernetes_pod_annotation_prometheus_io_scrape]
         action: keep
         regex: true

--- a/api/pkg/resources/test/fixtures/configmap-digitalocean-1.13.0-prometheus.yaml
+++ b/api/pkg/resources/test/fixtures/configmap-digitalocean-1.13.0-prometheus.yaml
@@ -204,6 +204,9 @@ data:
           - "cluster-de-test-01"
 
       relabel_configs:
+      - source_labels: [__meta_kubernetes_pod_label_app, __meta_kubernetes_pod_container_init]
+        regex: "kube-state-metrics;true"
+        action: drop
       - source_labels: [__meta_kubernetes_pod_annotation_prometheus_io_scrape]
         action: keep
         regex: true

--- a/api/pkg/resources/test/fixtures/configmap-openstack-1.10.0-prometheus.yaml
+++ b/api/pkg/resources/test/fixtures/configmap-openstack-1.10.0-prometheus.yaml
@@ -204,6 +204,9 @@ data:
           - "cluster-de-test-01"
 
       relabel_configs:
+      - source_labels: [__meta_kubernetes_pod_label_app, __meta_kubernetes_pod_container_init]
+        regex: "kube-state-metrics;true"
+        action: drop
       - source_labels: [__meta_kubernetes_pod_annotation_prometheus_io_scrape]
         action: keep
         regex: true

--- a/api/pkg/resources/test/fixtures/configmap-openstack-1.10.6-prometheus.yaml
+++ b/api/pkg/resources/test/fixtures/configmap-openstack-1.10.6-prometheus.yaml
@@ -204,6 +204,9 @@ data:
           - "cluster-de-test-01"
 
       relabel_configs:
+      - source_labels: [__meta_kubernetes_pod_label_app, __meta_kubernetes_pod_container_init]
+        regex: "kube-state-metrics;true"
+        action: drop
       - source_labels: [__meta_kubernetes_pod_annotation_prometheus_io_scrape]
         action: keep
         regex: true

--- a/api/pkg/resources/test/fixtures/configmap-openstack-1.11.0-prometheus.yaml
+++ b/api/pkg/resources/test/fixtures/configmap-openstack-1.11.0-prometheus.yaml
@@ -208,6 +208,9 @@ data:
         action: drop
 
       relabel_configs:
+      - source_labels: [__meta_kubernetes_pod_label_app, __meta_kubernetes_pod_container_init]
+        regex: "kube-state-metrics;true"
+        action: drop
       - source_labels: [__meta_kubernetes_pod_annotation_prometheus_io_scrape]
         action: keep
         regex: true

--- a/api/pkg/resources/test/fixtures/configmap-openstack-1.11.1-prometheus.yaml
+++ b/api/pkg/resources/test/fixtures/configmap-openstack-1.11.1-prometheus.yaml
@@ -208,6 +208,9 @@ data:
         action: drop
 
       relabel_configs:
+      - source_labels: [__meta_kubernetes_pod_label_app, __meta_kubernetes_pod_container_init]
+        regex: "kube-state-metrics;true"
+        action: drop
       - source_labels: [__meta_kubernetes_pod_annotation_prometheus_io_scrape]
         action: keep
         regex: true

--- a/api/pkg/resources/test/fixtures/configmap-openstack-1.12.0-prometheus.yaml
+++ b/api/pkg/resources/test/fixtures/configmap-openstack-1.12.0-prometheus.yaml
@@ -204,6 +204,9 @@ data:
           - "cluster-de-test-01"
 
       relabel_configs:
+      - source_labels: [__meta_kubernetes_pod_label_app, __meta_kubernetes_pod_container_init]
+        regex: "kube-state-metrics;true"
+        action: drop
       - source_labels: [__meta_kubernetes_pod_annotation_prometheus_io_scrape]
         action: keep
         regex: true

--- a/api/pkg/resources/test/fixtures/configmap-openstack-1.13.0-prometheus.yaml
+++ b/api/pkg/resources/test/fixtures/configmap-openstack-1.13.0-prometheus.yaml
@@ -204,6 +204,9 @@ data:
           - "cluster-de-test-01"
 
       relabel_configs:
+      - source_labels: [__meta_kubernetes_pod_label_app, __meta_kubernetes_pod_container_init]
+        regex: "kube-state-metrics;true"
+        action: drop
       - source_labels: [__meta_kubernetes_pod_annotation_prometheus_io_scrape]
         action: keep
         regex: true

--- a/api/pkg/resources/test/fixtures/configmap-vsphere-1.10.0-prometheus.yaml
+++ b/api/pkg/resources/test/fixtures/configmap-vsphere-1.10.0-prometheus.yaml
@@ -204,6 +204,9 @@ data:
           - "cluster-de-test-01"
 
       relabel_configs:
+      - source_labels: [__meta_kubernetes_pod_label_app, __meta_kubernetes_pod_container_init]
+        regex: "kube-state-metrics;true"
+        action: drop
       - source_labels: [__meta_kubernetes_pod_annotation_prometheus_io_scrape]
         action: keep
         regex: true

--- a/api/pkg/resources/test/fixtures/configmap-vsphere-1.10.6-prometheus.yaml
+++ b/api/pkg/resources/test/fixtures/configmap-vsphere-1.10.6-prometheus.yaml
@@ -204,6 +204,9 @@ data:
           - "cluster-de-test-01"
 
       relabel_configs:
+      - source_labels: [__meta_kubernetes_pod_label_app, __meta_kubernetes_pod_container_init]
+        regex: "kube-state-metrics;true"
+        action: drop
       - source_labels: [__meta_kubernetes_pod_annotation_prometheus_io_scrape]
         action: keep
         regex: true

--- a/api/pkg/resources/test/fixtures/configmap-vsphere-1.11.0-prometheus.yaml
+++ b/api/pkg/resources/test/fixtures/configmap-vsphere-1.11.0-prometheus.yaml
@@ -208,6 +208,9 @@ data:
         action: drop
 
       relabel_configs:
+      - source_labels: [__meta_kubernetes_pod_label_app, __meta_kubernetes_pod_container_init]
+        regex: "kube-state-metrics;true"
+        action: drop
       - source_labels: [__meta_kubernetes_pod_annotation_prometheus_io_scrape]
         action: keep
         regex: true

--- a/api/pkg/resources/test/fixtures/configmap-vsphere-1.11.1-prometheus.yaml
+++ b/api/pkg/resources/test/fixtures/configmap-vsphere-1.11.1-prometheus.yaml
@@ -208,6 +208,9 @@ data:
         action: drop
 
       relabel_configs:
+      - source_labels: [__meta_kubernetes_pod_label_app, __meta_kubernetes_pod_container_init]
+        regex: "kube-state-metrics;true"
+        action: drop
       - source_labels: [__meta_kubernetes_pod_annotation_prometheus_io_scrape]
         action: keep
         regex: true

--- a/api/pkg/resources/test/fixtures/configmap-vsphere-1.12.0-prometheus.yaml
+++ b/api/pkg/resources/test/fixtures/configmap-vsphere-1.12.0-prometheus.yaml
@@ -204,6 +204,9 @@ data:
           - "cluster-de-test-01"
 
       relabel_configs:
+      - source_labels: [__meta_kubernetes_pod_label_app, __meta_kubernetes_pod_container_init]
+        regex: "kube-state-metrics;true"
+        action: drop
       - source_labels: [__meta_kubernetes_pod_annotation_prometheus_io_scrape]
         action: keep
         regex: true

--- a/api/pkg/resources/test/fixtures/configmap-vsphere-1.13.0-prometheus.yaml
+++ b/api/pkg/resources/test/fixtures/configmap-vsphere-1.13.0-prometheus.yaml
@@ -204,6 +204,9 @@ data:
           - "cluster-de-test-01"
 
       relabel_configs:
+      - source_labels: [__meta_kubernetes_pod_label_app, __meta_kubernetes_pod_container_init]
+        regex: "kube-state-metrics;true"
+        action: drop
       - source_labels: [__meta_kubernetes_pod_annotation_prometheus_io_scrape]
         action: keep
         regex: true


### PR DESCRIPTION
**What this PR does / why we need it**:

#3427 added a scrape annotation for the kube-state-metrics server scraping all pods. Since prometheus 2.11 this includes initContainers, breaking the upness alerts on the kube-state-metrics server

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:

**Special notes for your reviewer**:
This might be resolvable in many ways, but since the scrape label is very restricted (one or all), it seemed for me the most elegant version to drop the labels in relabelling

**Documentation**:
<!-- Add links to the related documentation changes related to this pull request. E.g. the link to the kubermatic/docs pullrequest. -->

**Does this PR introduce a user-facing change?**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If  no release note is required, just write "NONE".
-->
```release-note
NONE
```
