### PR TITLE
remove user name (unused anyway) and email from cluster_info metrics

### DIFF
--- a/api/pkg/collectors/cluster.go
+++ b/api/pkg/collectors/cluster.go
@@ -51,8 +51,6 @@ func MustRegisterClusterCollector(registry prometheus.Registerer, client ctrlrun
 				"master_version",
 				"cloud_provider",
 				"datacenter",
-				"user_name",
-				"user_email",
 				"pause",
 			},
 			nil,
@@ -130,8 +128,6 @@ func (cc *ClusterCollector) clusterLabels(cluster *kubermaticv1.Cluster) ([]stri
 		cluster.Spec.Version.String(),
 		provider,
 		cluster.Spec.Cloud.DatacenterName,
-		cluster.Status.UserName,
-		cluster.Status.UserEmail,
 		pause,
 	}, nil
 }


### PR DESCRIPTION
**What this PR does / why we need it**:
To make sure we don't spread personal information throughout many systems I removed the user name and email from the cluster info metrics. As far as I can tell, the user name is never set inside the cluster status anyway (so the label is always missing on our metrics), but the email was indeed used.

**Does this PR introduce a user-facing change?**:
```release-note
removed cluster owner name and email labels from kubermatic_cluster_info metric to prevent leaking PII
```
