### PR TITLE
change the node_dc/seed_dc label in InitNodeDeploymentFailures metric to `datacenter`

### DIFF
--- a/api/cmd/kubermatic-api/metrics.go
+++ b/api/cmd/kubermatic-api/metrics.go
@@ -28,7 +28,7 @@ var metrics = common.ServerMetrics{
 			Name: "kubermatic_api_init_node_deployment_failures",
 			Help: "The number of times initial node deployment couldn't be created within the timeout",
 		},
-		[]string{"cluster", "seed_dc"},
+		[]string{"cluster", "datacenter"},
 	),
 }
 

--- a/api/pkg/handler/test/hack/hack.go
+++ b/api/pkg/handler/test/hack/hack.go
@@ -98,7 +98,7 @@ func generateDefaultMetrics() common.ServerMetrics {
 				Name: "kubermatic_api_init_node_deployment_failures",
 				Help: "The number of times initial node deployment couldn't be created within the timeout",
 			},
-			[]string{"cluster", "seed_dc"},
+			[]string{"cluster", "datacenter"},
 		),
 	}
 }

--- a/api/pkg/handler/v1/cluster/cluster.go
+++ b/api/pkg/handler/v1/cluster/cluster.go
@@ -133,7 +133,7 @@ func CreateEndpoint(sshKeyProvider provider.SSHKeyProvider, cloudProviders map[s
 				if err != nil {
 					eventRecorderProvider.ClusterRecorderFor(k8sClient).Eventf(newCluster, corev1.EventTypeWarning, string(nodeDeploymentCreationFail), "failed to create initial node deployment%s: %v", ndName, err)
 					glog.Errorf("failed to create initial node deployment for cluster %s: %v", newCluster.Name, err)
-					initNodeDeploymentFailures.With(prometheus.Labels{"cluster": newCluster.Name, "node_dc": req.Body.Cluster.Spec.Cloud.DatacenterName}).Add(1)
+					initNodeDeploymentFailures.With(prometheus.Labels{"cluster": newCluster.Name, "datacenter": req.Body.Cluster.Spec.Cloud.DatacenterName}).Add(1)
 				} else {
 					eventRecorderProvider.ClusterRecorderFor(k8sClient).Eventf(newCluster, corev1.EventTypeNormal, string(nodeDeploymentCreationSuccess), "created initial node deployment%s", ndName)
 					glog.V(5).Infof("created initial node deployment for cluster %s", newCluster.Name)


### PR DESCRIPTION
**What this PR does / why we need it**:
Inconsistency between the metric's definition and actually applied label leads to a panic.

```release-note
NONE
```

/assign @alvaroaleman 
