### PR TITLE
Dont create a zero replica initial nodedeployment

### DIFF
--- a/api/pkg/handler/v1/cluster/cluster.go
+++ b/api/pkg/handler/v1/cluster/cluster.go
@@ -114,7 +114,7 @@ func CreateEndpoint(sshKeyProvider provider.SSHKeyProvider, projectProvider prov
 		}
 
 		// Create the initial node deployment in the background.
-		if req.Body.NodeDeployment != nil {
+		if req.Body.NodeDeployment != nil && req.Body.NodeDeployment.Spec.Replicas > 0 {
 			// for BringYourOwn provider we don't create ND
 			isBYO, err := common.IsBringYourOwnProvider(spec.Cloud)
 			if err != nil {


### PR DESCRIPTION
**What this PR does / why we need it**:

Currently, the UI seems to always create a nodedeployment, even if setting the replica count to 0. This PR fixes that by checking in the API if the replicaCount of the initial nodeDeployment is > 0
**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Documentation**:
<!-- Add links to the related documentation changes related to this pull request. E.g. the link to the kubermatic/docs pullrequest. -->

**Does this PR introduce a user-facing change?**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If  no release note is required, just write "NONE".
-->
```release-note
none
```

/assign @maciaszczykm 
