### PR TITLE
cluster cleanup: don't disable updates on PV, PVC and PDBs

### DIFF
--- a/api/pkg/clusterdeletion/deletion.go
+++ b/api/pkg/clusterdeletion/deletion.go
@@ -479,7 +479,7 @@ func terminatingAdmissionWebhook() (string, *admissionregistrationv1beta1.Valida
 				},
 				Rules: []admissionregistrationv1beta1.RuleWithOperations{
 					{
-						Operations: []admissionregistrationv1beta1.OperationType{admissionregistrationv1beta1.Create, admissionregistrationv1beta1.Update},
+						Operations: []admissionregistrationv1beta1.OperationType{admissionregistrationv1beta1.Create},
 						Rule: admissionregistrationv1beta1.Rule{
 							APIGroups:   []string{""},
 							APIVersions: []string{"*"},
@@ -487,7 +487,7 @@ func terminatingAdmissionWebhook() (string, *admissionregistrationv1beta1.Valida
 						},
 					},
 					{
-						Operations: []admissionregistrationv1beta1.OperationType{admissionregistrationv1beta1.Create, admissionregistrationv1beta1.Update},
+						Operations: []admissionregistrationv1beta1.OperationType{admissionregistrationv1beta1.Create},
 						Rule: admissionregistrationv1beta1.Rule{
 							APIGroups:   []string{"policy"},
 							APIVersions: []string{"*"},


### PR DESCRIPTION
This prevents cluster deletion since we use finalizers.

Ref: https://github.com/kubermatic/kubermatic/pull/3863

**Documentation**:
<!-- Add links to the related documentation changes related to this pull request. E.g. the link to the kubermatic/docs pullrequest. -->

**Does this PR introduce a user-facing change?**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If  no release note is required, just write "NONE".
-->
```release-note
NONE
```
