### PR TITLE
Fixup and simplify healthchecking

### DIFF
--- a/api/pkg/resources/health.go
+++ b/api/pkg/resources/health.go
@@ -25,13 +25,10 @@ func HealthyDeployment(ctx context.Context, client client.Client, nn types.Names
 		return kubermaticv1.HealthStatusDown, nil
 	}
 	// update scenario
-	if deployment.Status.UpdatedReplicas != *deployment.Spec.Replicas || deployment.Status.Replicas != *deployment.Spec.Replicas {
+	if deployment.Status.UpdatedReplicas != *deployment.Spec.Replicas || deployment.Status.ReadyReplicas != *deployment.Spec.Replicas || deployment.Status.Replicas != *deployment.Spec.Replicas {
 		return kubermaticv1.HealthStatusProvisioning, nil
 	}
-	if deployment.Status.UpdatedReplicas == *deployment.Spec.Replicas && deployment.Status.Replicas == *deployment.Spec.Replicas {
-		return kubermaticv1.HealthStatusUp, nil
-	}
-	return kubermaticv1.HealthStatusDown, nil
+	return kubermaticv1.HealthStatusUp, nil
 }
 
 // HealthyStatefulSe tells if the deployment has a minimum of minReady replicas in Ready status
@@ -41,17 +38,14 @@ func HealthyStatefulSet(ctx context.Context, client client.Client, nn types.Name
 		if kerrors.IsNotFound(err) {
 			return kubermaticv1.HealthStatusDown, nil
 		}
-		return kubermaticv1.HealthStatusDown, nil
+		return kubermaticv1.HealthStatusDown, err
 	}
 
 	if statefulSet.Status.ReadyReplicas < minReady {
 		return kubermaticv1.HealthStatusDown, nil
 	}
-	if statefulSet.Status.UpdatedReplicas != *statefulSet.Spec.Replicas || statefulSet.Status.Replicas != *statefulSet.Spec.Replicas {
+	if statefulSet.Status.UpdatedReplicas != *statefulSet.Spec.Replicas || statefulSet.Status.ReadyReplicas != *statefulSet.Spec.Replicas || statefulSet.Status.Replicas != *statefulSet.Spec.Replicas {
 		return kubermaticv1.HealthStatusProvisioning, nil
 	}
-	if statefulSet.Status.UpdatedReplicas == *statefulSet.Spec.Replicas && statefulSet.Status.Replicas == *statefulSet.Spec.Replicas {
-		return kubermaticv1.HealthStatusUp, nil
-	}
-	return kubermaticv1.HealthStatusDown, nil
+	return kubermaticv1.HealthStatusUp, nil
 }


### PR DESCRIPTION
**What this PR does / why we need it**:

* We currently don't do any checking for number of `readyReplicas` except in the first check if we are down
* The third condition is an invert of the second condition, if we didn't go into the second condition we must go in the third, so why make it conditional at all?
* Returning "DOWN" at the end doesn't make any sense at all because we start off with a check if we are down. In practise this is unreachable code, but its confusing nonetheless 

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Documentation**:
<!-- Add links to the related documentation changes related to this pull request. E.g. the link to the kubermatic/docs pullrequest. -->

**Does this PR introduce a user-facing change?**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If  no release note is required, just write "NONE".
-->
```release-note
none
```

CC @bashofmann 
/assign @mrIncompetent 
