### PR TITLE
add API endpoint to get the AWS availability zones in a region

### DIFF
--- a/api/cmd/kubermatic-api/swagger.json
+++ b/api/cmd/kubermatic-api/swagger.json
@@ -1679,6 +1679,55 @@
         }
       }
     },
+    "/api/v1/projects/{project_id}/dc/{dc}/clusters/{cluster_id}/providers/aws/zones": {
+      "get": {
+        "description": "Lists available AWS zones",
+        "produces": [
+          "application/json"
+        ],
+        "tags": [
+          "aws"
+        ],
+        "operationId": "listAWSZonesNoCredentials",
+        "parameters": [
+          {
+            "type": "string",
+            "x-go-name": "ProjectID",
+            "name": "project_id",
+            "in": "path",
+            "required": true
+          },
+          {
+            "type": "string",
+            "x-go-name": "DC",
+            "name": "dc",
+            "in": "path",
+            "required": true
+          },
+          {
+            "type": "string",
+            "x-go-name": "ClusterID",
+            "name": "cluster_id",
+            "in": "path",
+            "required": true
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "AWSZoneList",
+            "schema": {
+              "$ref": "#/definitions/AWSZoneList"
+            }
+          },
+          "default": {
+            "description": "errorResponse",
+            "schema": {
+              "$ref": "#/definitions/errorResponse"
+            }
+          }
+        }
+      }
+    },
     "/api/v1/projects/{project_id}/dc/{dc}/clusters/{cluster_id}/providers/azure/sizes": {
       "get": {
         "description": "Lists available VM sizes in an Azure region",
@@ -3362,6 +3411,56 @@
         }
       }
     },
+    "/api/v1/providers/aws/{dc}/zones": {
+      "get": {
+        "description": "Lists available AWS zones",
+        "produces": [
+          "application/json"
+        ],
+        "tags": [
+          "aws"
+        ],
+        "operationId": "listAWSZones",
+        "parameters": [
+          {
+            "type": "string",
+            "name": "AccessKeyID",
+            "in": "header"
+          },
+          {
+            "type": "string",
+            "name": "SecretAccessKey",
+            "in": "header"
+          },
+          {
+            "type": "string",
+            "name": "Credential",
+            "in": "header"
+          },
+          {
+            "type": "string",
+            "x-go-name": "DC",
+            "name": "dc",
+            "in": "path",
+            "required": true
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "AWSZoneList",
+            "schema": {
+              "$ref": "#/definitions/AWSZoneList"
+            }
+          },
+          "default": {
+            "description": "errorResponse",
+            "schema": {
+              "$ref": "#/definitions/errorResponse"
+            }
+          }
+        }
+      }
+    },
     "/api/v1/providers/azure/sizes": {
       "get": {
         "description": "Lists available VM sizes in an Azure region",
@@ -4061,6 +4160,25 @@
           "x-go-name": "VolumeType",
           "example": "gp2, io1, st1, sc1, standard"
         }
+      },
+      "x-go-package": "github.com/kubermatic/kubermatic/api/pkg/api/v1"
+    },
+    "AWSZone": {
+      "type": "object",
+      "title": "AWSZone represents a object of AWS availability zone.",
+      "properties": {
+        "name": {
+          "type": "string",
+          "x-go-name": "Name"
+        }
+      },
+      "x-go-package": "github.com/kubermatic/kubermatic/api/pkg/api/v1"
+    },
+    "AWSZoneList": {
+      "type": "array",
+      "title": "AWSZoneList represents an array of AWS availability zones.",
+      "items": {
+        "$ref": "#/definitions/AWSZone"
       },
       "x-go-package": "github.com/kubermatic/kubermatic/api/pkg/api/v1"
     },

--- a/api/pkg/api/v1/types.go
+++ b/api/pkg/api/v1/types.go
@@ -127,6 +127,16 @@ type Datacenter struct {
 	Seed     bool             `json:"seed,omitempty"`
 }
 
+// AWSZone represents a object of AWS availability zone.
+// swagger:model AWSZone
+type AWSZone struct {
+	Name string `json:"name"`
+}
+
+// AWSZoneList represents an array of AWS availability zones.
+// swagger:model AWSZoneList
+type AWSZoneList []AWSZone
+
 // GCPDiskTypeList represents an array of GCP disk types.
 // swagger:model GCPDiskTypeList
 type GCPDiskTypeList []GCPDiskType

--- a/api/pkg/handler/routes_v1.go
+++ b/api/pkg/handler/routes_v1.go
@@ -9,7 +9,7 @@ import (
 	"github.com/prometheus/client_golang/prometheus"
 
 	"github.com/kubermatic/kubermatic/api/pkg/handler/middleware"
-	"github.com/kubermatic/kubermatic/api/pkg/handler/v1"
+	v1 "github.com/kubermatic/kubermatic/api/pkg/handler/v1"
 	"github.com/kubermatic/kubermatic/api/pkg/handler/v1/cluster"
 	"github.com/kubermatic/kubermatic/api/pkg/handler/v1/common"
 	"github.com/kubermatic/kubermatic/api/pkg/handler/v1/dc"
@@ -43,6 +43,10 @@ func (r Routing) RegisterV1(mux *mux.Router, metrics common.ServerMetrics) {
 	//
 	// Defines a set of HTTP endpoint for interacting with
 	// various cloud providers
+	mux.Methods(http.MethodGet).
+		Path("/providers/aws/{dc}/zones").
+		Handler(r.listAWSZones())
+
 	mux.Methods(http.MethodGet).
 		Path("/providers/gcp/disktypes").
 		Handler(r.listGCPDiskTypes())
@@ -232,6 +236,10 @@ func (r Routing) RegisterV1(mux *mux.Router, metrics common.ServerMetrics) {
 	//
 	// Defines a set of HTTP endpoints for various cloud providers
 	// Note that these endpoints don't require credentials as opposed to the ones defined under /providers/*
+	mux.Methods(http.MethodGet).
+		Path("/projects/{project_id}/dc/{dc}/clusters/{cluster_id}/providers/aws/zones").
+		Handler(r.listAWSZonesNoCredentials())
+
 	mux.Methods(http.MethodGet).
 		Path("/projects/{project_id}/dc/{dc}/clusters/{cluster_id}/providers/gcp/disktypes").
 		Handler(r.listGCPDiskTypesNoCredentials())
@@ -443,6 +451,28 @@ func (r Routing) listCredentials() http.Handler {
 			middleware.UserSaver(r.userProvider),
 		)(presets.CredentialEndpoint(r.presetsManager)),
 		presets.DecodeProviderReq,
+		encodeJSON,
+		r.defaultServerOptions()...,
+	)
+}
+
+// swagger:route GET /api/v1/providers/aws/{dc}/zones aws listAWSZones
+//
+// Lists available AWS zones
+//
+//     Produces:
+//     - application/json
+//
+//     Responses:
+//       default: errorResponse
+//       200: AWSZoneList
+func (r Routing) listAWSZones() http.Handler {
+	return httptransport.NewServer(
+		endpoint.Chain(
+			middleware.TokenVerifier(r.tokenVerifiers),
+			middleware.UserSaver(r.userProvider),
+		)(provider.AWSZoneEndpoint(r.presetsManager, r.seeds)),
+		provider.DecodeAWSZoneReq,
 		encodeJSON,
 		r.defaultServerOptions()...,
 	)
@@ -1739,6 +1769,30 @@ func (r Routing) deleteServiceAccountToken() http.Handler {
 			middleware.UserInfoExtractor(r.userProjectMapper),
 		)(serviceaccount.DeleteTokenEndpoint(r.projectProvider, r.serviceAccountProvider, r.serviceAccountTokenProvider)),
 		serviceaccount.DecodeDeleteTokenReq,
+		encodeJSON,
+		r.defaultServerOptions()...,
+	)
+}
+
+// swagger:route GET /api/v1/projects/{project_id}/dc/{dc}/clusters/{cluster_id}/providers/aws/zones aws listAWSZonesNoCredentials
+//
+// Lists available AWS zones
+//
+//     Produces:
+//     - application/json
+//
+//     Responses:
+//       default: errorResponse
+//       200: AWSZoneList
+func (r Routing) listAWSZonesNoCredentials() http.Handler {
+	return httptransport.NewServer(
+		endpoint.Chain(
+			middleware.TokenVerifier(r.tokenVerifiers),
+			middleware.UserSaver(r.userProvider),
+			middleware.SetClusterProvider(r.clusterProviders, r.seeds),
+			middleware.UserInfoExtractor(r.userProjectMapper),
+		)(provider.AWSZoneNoCredentialsEndpoint(r.projectProvider, r.seeds)),
+		common.DecodeGetClusterReq,
 		encodeJSON,
 		r.defaultServerOptions()...,
 	)

--- a/api/pkg/handler/v1/common/request.go
+++ b/api/pkg/handler/v1/common/request.go
@@ -71,7 +71,7 @@ func DecodeDcReq(c context.Context, r *http.Request) (interface{}, error) {
 }
 
 // GetClusterReq defines HTTP request for deleteCluster and getClusterKubeconfig endpoints
-// swagger:parameters getCluster deleteCluster getClusterKubeconfig getOidcClusterKubeconfig getClusterHealth getClusterUpgrades getClusterMetrics getClusterNodeUpgrades listGCPZonesNoCredentials
+// swagger:parameters getCluster deleteCluster getClusterKubeconfig getOidcClusterKubeconfig getClusterHealth getClusterUpgrades getClusterMetrics getClusterNodeUpgrades listGCPZonesNoCredentials listAWSZonesNoCredentials
 type GetClusterReq struct {
 	DCReq
 	// in: path

--- a/api/pkg/handler/v1/provider/aws.go
+++ b/api/pkg/handler/v1/provider/aws.go
@@ -1,0 +1,150 @@
+package provider
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+
+	"github.com/go-kit/kit/endpoint"
+	"github.com/gorilla/mux"
+
+	apiv1 "github.com/kubermatic/kubermatic/api/pkg/api/v1"
+	kubermaticv1 "github.com/kubermatic/kubermatic/api/pkg/crd/kubermatic/v1"
+	"github.com/kubermatic/kubermatic/api/pkg/handler/middleware"
+	"github.com/kubermatic/kubermatic/api/pkg/handler/v1/common"
+	"github.com/kubermatic/kubermatic/api/pkg/provider"
+	awsProvider "github.com/kubermatic/kubermatic/api/pkg/provider/cloud/aws"
+	"github.com/kubermatic/kubermatic/api/pkg/util/errors"
+)
+
+// AWSCommonReq represent a request with common parameters for GCP.
+type AWSCommonReq struct {
+	// in: header
+	// name: AccessKeyID
+	AccessKeyID string
+	// in: header
+	// name: SecretAccessKey
+	SecretAccessKey string
+	// in: header
+	// name: Credential
+	Credential string
+}
+
+// AWSZoneReq represent a request for AWS zones.
+// swagger:parameters listAWSZones
+type AWSZoneReq struct {
+	AWSCommonReq
+	// in: path
+	// required: true
+	DC string `json:"dc"`
+}
+
+// DecodeAWSCommonReq decodes the base type for a AWS special endpoint request
+func DecodeAWSCommonReq(c context.Context, r *http.Request) (interface{}, error) {
+	var req AWSCommonReq
+
+	req.AccessKeyID = r.Header.Get("AccessKeyID")
+	req.SecretAccessKey = r.Header.Get("SecretAccessKey")
+
+	return req, nil
+}
+
+// DecodeAWSZoneReq decodes a request for a list of AWS zones
+func DecodeAWSZoneReq(c context.Context, r *http.Request) (interface{}, error) {
+	var req AWSZoneReq
+
+	commonReq, err := DecodeAWSCommonReq(c, r)
+	if err != nil {
+		return nil, err
+	}
+	req.AWSCommonReq = commonReq.(AWSCommonReq)
+
+	dc, ok := mux.Vars(r)["dc"]
+	if !ok {
+		return req, fmt.Errorf("'dc' parameter is required")
+	}
+	req.DC = dc
+
+	return req, nil
+}
+
+// AWSZoneEndpoint handles the request to list AWS availability zones in a given region, using provided credentials
+func AWSZoneEndpoint(credentialManager common.PresetsManager, seeds map[string]*kubermaticv1.Seed) endpoint.Endpoint {
+	return func(ctx context.Context, request interface{}) (interface{}, error) {
+		req := request.(AWSZoneReq)
+
+		keyID := req.AccessKeyID
+		keySecret := req.SecretAccessKey
+
+		if len(req.Credential) > 0 && credentialManager.GetPresets().AWS.Credentials != nil {
+			for _, credential := range credentialManager.GetPresets().AWS.Credentials {
+				if credential.Name == req.Credential {
+					keyID = credential.AccessKeyID
+					keySecret = credential.SecretAccessKey
+					break
+				}
+			}
+		}
+
+		return listAWSZones(ctx, keyID, keySecret, req.DC, seeds)
+	}
+}
+
+// AWSZoneNoCredentialsEndpoint handles the request to list AWS availability zones in a given region, using credentials from a given datacenter
+func AWSZoneNoCredentialsEndpoint(projectProvider provider.ProjectProvider, seeds map[string]*kubermaticv1.Seed) endpoint.Endpoint {
+	return func(ctx context.Context, request interface{}) (interface{}, error) {
+		req := request.(common.GetClusterReq)
+		clusterProvider := ctx.Value(middleware.ClusterProviderContextKey).(provider.ClusterProvider)
+		userInfo := ctx.Value(middleware.UserInfoContextKey).(*provider.UserInfo)
+		_, err := projectProvider.Get(userInfo, req.ProjectID, &provider.ProjectGetOptions{})
+		if err != nil {
+			return nil, common.KubernetesErrorToHTTPError(err)
+		}
+		cluster, err := clusterProvider.Get(userInfo, req.ClusterID, &provider.ClusterGetOptions{})
+		if err != nil {
+			return nil, common.KubernetesErrorToHTTPError(err)
+		}
+		if cluster.Spec.Cloud.AWS == nil {
+			return nil, errors.NewNotFound("cloud spec for ", req.ClusterID)
+		}
+
+		keyID := cluster.Spec.Cloud.AWS.AccessKeyID
+		keySecret := cluster.Spec.Cloud.AWS.SecretAccessKey
+		return listAWSZones(ctx, keyID, keySecret, cluster.Spec.Cloud.DatacenterName, seeds)
+	}
+}
+
+func listAWSZones(ctx context.Context, keyID, keySecret, datacenterName string, seeds map[string]*kubermaticv1.Seed) (apiv1.AWSZoneList, error) {
+	zones := apiv1.AWSZoneList{}
+
+	datacenter, err := provider.DatacenterFromSeedMap(seeds, datacenterName)
+	if err != nil {
+		return nil, errors.NewBadRequest("%v", err)
+	}
+
+	if datacenter.Spec.AWS == nil {
+		return nil, errors.NewBadRequest("the %s is not AWS datacenter", datacenterName)
+	}
+
+	ec2, err := awsProvider.NewCloudProvider(datacenter)
+	if err != nil {
+		return nil, err
+	}
+
+	zoneResults, err := ec2.GetAvailabilityZonesInRegion(kubermaticv1.CloudSpec{
+		DatacenterName: datacenterName,
+		AWS: &kubermaticv1.AWSCloudSpec{
+			AccessKeyID:     keyID,
+			SecretAccessKey: keySecret,
+		},
+	}, datacenter.Spec.AWS.Region)
+	if err != nil {
+		return nil, err
+	}
+
+	for _, z := range zoneResults {
+		zones = append(zones, apiv1.AWSZone{Name: *z.ZoneName})
+	}
+
+	return zones, err
+}


### PR DESCRIPTION
**What this PR does / why we need it**:
Second-to-last step towards #3456 

**Does this PR introduce a user-facing change?**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If  no release note is required, just write "NONE".
-->
```release-note
AWS: MachineDeployments can now be created in any availability zone of the cluster's region
```
