### PR TITLE
PV cleanup: Delete Pods only

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -30,7 +30,7 @@ issues:
   - cyclomatic complexity 33 of func `ValidateCloudSpec` is high
   - cyclomatic complexity 38 of func `migrateToProject` is high
   - cyclomatic complexity [0-9]+ of func `TestDatacenterMetasToSeedDatacenterSpecs` is high
-  - cyclomatic complexity 33 of func `\(\*Deletion\)\.cleanupInClusterResources` is high
+  - cyclomatic complexity 32 of func `\(\*Deletion\)\.cleanupInClusterResources` is high
   - 'CleanUpCloudProvider` is high'
   - string `get` has 6 occurrences, make it a constant
   - struct of size 536 bytes could be of size 520 bytes


### PR DESCRIPTION
The former approach of traversing up to the owner was needlessly complex
and only needed for statefulsets, as those re-create PVCs. Now that we
prevent that, its not needed at all.

Not trying the traversal has the advantage that we don't hang on
unknown owner types.

When I tried this out in #3863 it didn't result in any deletions of PVs/PVCs,  most likely because the webhook wrongly prevented UPDATE on PVs/PVCs. Tested it again now, works fine.

**What this PR does / why we need it**:

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #3696

**Special notes for your reviewer**:

**Documentation**:
<!-- Add links to the related documentation changes related to this pull request. E.g. the link to the kubermatic/docs pullrequest. -->

**Does this PR introduce a user-facing change?**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If  no release note is required, just write "NONE".
-->
```release-note
none
```

/assign @nikhita 