### PR TITLE
Allow setting the default number of replicas for controlplane components

### DIFF
--- a/api/cmd/kubermatic-controller-manager/options.go
+++ b/api/cmd/kubermatic-controller-manager/options.go
@@ -58,6 +58,9 @@ type controllerRunOptions struct {
 	log                                              kubermaticlog.Options
 	kubermaticImage                                  string
 	dynamicDatacenters                               bool
+	apiServerDefaultReplicas                         int
+	controllerManagerDefaultReplicas                 int
+	schedulerDefaultReplicas                         int
 
 	// OIDC configuration
 	oidcCAFile             string
@@ -111,6 +114,9 @@ func newControllerRunOptions() (controllerRunOptions, error) {
 	flag.StringVar(&c.log.Format, "log-format", string(kubermaticlog.FormatJSON), "Log format. Available are: "+kubermaticlog.AvailableFormats.String())
 	flag.StringVar(&c.kubermaticImage, "kubermatic-image", resources.DefaultKubermaticImage, "The location from which to pull the Kubermatic image")
 	flag.BoolVar(&c.dynamicDatacenters, "dynamic-datacenters", false, "Whether to enable dynamic datacenters")
+	flag.IntVar(&c.apiServerDefaultReplicas, "apiserver-default-replicas", 2, "The default number of replicas for usercluster api servers")
+	flag.IntVar(&c.controllerManagerDefaultReplicas, "controller-manager-default-replicas", 1, "The default number of replicas for usercluster controller managers")
+	flag.IntVar(&c.schedulerDefaultReplicas, "scheduler-default-replicas", 1, "The default number of replicas for usercluster schedulers")
 	flag.Parse()
 
 	featureGates, err := features.NewFeatures(rawFeatureGates)
@@ -174,6 +180,16 @@ func (o controllerRunOptions) validate() error {
 
 	if o.monitoringScrapeAnnotationPrefix == "" {
 		return fmt.Errorf("moniotring-scrape-annotation-prefix is undefined")
+	}
+
+	if o.apiServerDefaultReplicas < 1 {
+		return fmt.Errorf("--apiserver-default-replicas must be > 0 (was %d)", o.apiServerDefaultReplicas)
+	}
+	if o.controllerManagerDefaultReplicas < 1 {
+		return fmt.Errorf("--controller-manager-default-replicas must be > 0 (was %d)", o.controllerManagerDefaultReplicas)
+	}
+	if o.schedulerDefaultReplicas < 1 {
+		return fmt.Errorf("--scheduler-default-replicas must be > 0 (was %d)", o.schedulerDefaultReplicas)
 	}
 
 	// Validate OIDC CA file

--- a/api/pkg/controller/cloud/cloud_controller.go
+++ b/api/pkg/controller/cloud/cloud_controller.go
@@ -196,19 +196,13 @@ func (r *Reconciler) migrateAWSMultiAZ(ctx context.Context, cluster *kubermaticv
 	return nil
 }
 
-func (r *Reconciler) updateCluster(name string, modify func(*kubermaticv1.Cluster)) (updatedCluster *kubermaticv1.Cluster, err error) {
-	err = retry.RetryOnConflict(retry.DefaultBackoff, func() error {
-		cluster := &kubermaticv1.Cluster{}
+func (r *Reconciler) updateCluster(name string, modify func(*kubermaticv1.Cluster)) (*kubermaticv1.Cluster, error) {
+	cluster := &kubermaticv1.Cluster{}
+	return cluster, retry.RetryOnConflict(retry.DefaultBackoff, func() error {
 		if err := r.Get(context.Background(), types.NamespacedName{Name: name}, cluster); err != nil {
 			return err
 		}
 		modify(cluster)
-		err := r.Update(context.Background(), cluster)
-		if err == nil {
-			updatedCluster = cluster
-		}
-		return err
+		return r.Update(context.Background(), cluster)
 	})
-
-	return updatedCluster, err
 }

--- a/api/pkg/controller/clustercomponentdefaulter/clustercomponentdefaulter.go
+++ b/api/pkg/controller/clustercomponentdefaulter/clustercomponentdefaulter.go
@@ -1,0 +1,137 @@
+package clustercomponentdefaulter
+
+import (
+	"context"
+	"fmt"
+
+	kubermaticv1 "github.com/kubermatic/kubermatic/api/pkg/crd/kubermatic/v1"
+
+	"go.uber.org/zap"
+
+	corev1 "k8s.io/api/core/v1"
+	apiequality "k8s.io/apimachinery/pkg/api/equality"
+	kerrors "k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/client-go/tools/record"
+	"k8s.io/client-go/util/retry"
+	ctrlruntimeclient "sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/controller"
+	"sigs.k8s.io/controller-runtime/pkg/handler"
+	"sigs.k8s.io/controller-runtime/pkg/manager"
+	"sigs.k8s.io/controller-runtime/pkg/predicate"
+	"sigs.k8s.io/controller-runtime/pkg/reconcile"
+	"sigs.k8s.io/controller-runtime/pkg/source"
+)
+
+const ControllerName = "clustercomponent_defaulter"
+
+type Reconciler struct {
+	ctx      context.Context
+	log      *zap.SugaredLogger
+	client   ctrlruntimeclient.Client
+	recorder record.EventRecorder
+	defaults kubermaticv1.ComponentSettings
+}
+
+func Add(
+	ctx context.Context,
+	log *zap.SugaredLogger,
+	mgr manager.Manager,
+	numWorkers int,
+	defaults kubermaticv1.ComponentSettings,
+	clusterPredicates predicate.Predicate) error {
+
+	reconciler := &Reconciler{
+		ctx:      ctx,
+		log:      log.Named(ControllerName),
+		client:   mgr.GetClient(),
+		recorder: mgr.GetRecorder(ControllerName),
+		defaults: defaults,
+	}
+
+	c, err := controller.New(ControllerName, mgr,
+		controller.Options{Reconciler: reconciler, MaxConcurrentReconciles: numWorkers})
+	if err != nil {
+		return err
+	}
+	return c.Watch(&source.Kind{Type: &kubermaticv1.Cluster{}}, &handler.EnqueueRequestForObject{}, clusterPredicates)
+}
+
+func (r *Reconciler) Reconcile(request reconcile.Request) (reconcile.Result, error) {
+	cluster := &kubermaticv1.Cluster{}
+	if err := r.client.Get(r.ctx, request.NamespacedName, cluster); err != nil {
+		if kerrors.IsNotFound(err) {
+			return reconcile.Result{}, nil
+		}
+		return reconcile.Result{}, err
+	}
+
+	// Add a wrapping here so we can emit an event on error
+	err := r.reconcile(cluster)
+	if err != nil {
+		r.recorder.Eventf(cluster, corev1.EventTypeWarning, "ReconcilingError", "%v", err)
+		r.log.With("error", err).With("cluster", request.NamespacedName.Name).Error("failed to reconcile cluster")
+	}
+	return reconcile.Result{}, err
+}
+
+func (r *Reconciler) reconcile(cluster *kubermaticv1.Cluster) error {
+
+	log := r.log.With("cluster", cluster.Name)
+	if cluster.Spec.Pause {
+		log.Info("Skipping paused cluster")
+		return nil
+	}
+	log.Info("syncing cluster")
+
+	originalComponentsOverride := cluster.Spec.ComponentsOverride.DeepCopy()
+	targetComponentsOverride := cluster.Spec.ComponentsOverride
+
+	if targetComponentsOverride.Apiserver.Replicas == nil {
+		targetComponentsOverride.Apiserver.Replicas = r.defaults.Apiserver.Replicas
+	}
+	if targetComponentsOverride.Apiserver.Resources == nil {
+		targetComponentsOverride.Apiserver.Resources = r.defaults.Apiserver.Resources
+	}
+	if targetComponentsOverride.ControllerManager.Replicas == nil {
+		targetComponentsOverride.ControllerManager.Replicas = r.defaults.ControllerManager.Replicas
+	}
+	if targetComponentsOverride.ControllerManager.Resources == nil {
+		targetComponentsOverride.ControllerManager.Resources = r.defaults.ControllerManager.Resources
+	}
+	if targetComponentsOverride.Scheduler.Replicas == nil {
+		targetComponentsOverride.Scheduler.Replicas = r.defaults.Scheduler.Replicas
+	}
+	if targetComponentsOverride.Scheduler.Resources == nil {
+		targetComponentsOverride.Scheduler.Resources = r.defaults.Scheduler.Resources
+	}
+	if targetComponentsOverride.Etcd.Resources == nil {
+		targetComponentsOverride.Etcd.Resources = r.defaults.Etcd.Resources
+	}
+	if targetComponentsOverride.Prometheus.Resources == nil {
+		targetComponentsOverride.Prometheus.Resources = r.defaults.Prometheus.Resources
+	}
+
+	if apiequality.Semantic.DeepEqual(originalComponentsOverride, targetComponentsOverride) {
+		return nil
+	}
+
+	if _, err := r.updateCluster(cluster.Name, func(c *kubermaticv1.Cluster) {
+		c.Spec.ComponentsOverride = targetComponentsOverride
+	}); err != nil {
+		return fmt.Errorf("failed to update componentsOverride: %v", err)
+	}
+	log.Info("Successfully updated componentsOverride")
+	return nil
+}
+
+func (r *Reconciler) updateCluster(name string, modify func(*kubermaticv1.Cluster)) (*kubermaticv1.Cluster, error) {
+	cluster := &kubermaticv1.Cluster{}
+	return cluster, retry.RetryOnConflict(retry.DefaultBackoff, func() error {
+		if err := r.client.Get(r.ctx, types.NamespacedName{Name: name}, cluster); err != nil {
+			return err
+		}
+		modify(cluster)
+		return r.client.Update(r.ctx, cluster)
+	})
+}

--- a/config/kubermatic/templates/kubermatic-controller-manager-dep.yaml
+++ b/config/kubermatic/templates/kubermatic-controller-manager-dep.yaml
@@ -99,6 +99,9 @@ spec:
         {{- if .Values.kubermatic.kubermaticImage }}
         - -kubermatic-image={{ .Values.kubermatic.kubermaticImage }}
         {{- end }}
+        - -apiserver-default-replicas={{ .Values.kubermatic.apiserverDefaultReplicas }}
+        - -controller-manager-default-replicas={{ .Values.kubermatic.controllerManagerDefaultReplicas}}
+        - -scheduler-default-replicas={{ .Values.kubermatic.schedulerDefaultReplicas}}
         image: '{{ .Values.kubermatic.controller.image.repository }}:{{ .Values.kubermatic.controller.image.tag }}'
         imagePullPolicy: {{ .Values.kubermatic.controller.image.pullPolicy }}
         ports:

--- a/config/kubermatic/values.yaml
+++ b/config/kubermatic/values.yaml
@@ -30,6 +30,12 @@ kubermatic:
   # base64 encoded presets.yaml. Predefined presets for all supported providers.
   presets: ""
 
+  # The default number of replicas for controlplane components. Can be overriden on
+  # a per-cluster basis by setting .Spec.ComponentsOverride.$COMPONENT.Replicas
+  apiserverDefaultReplicas: "2"
+  controllerManagerDefaultReplicas: "1"
+  schedulerDefaultReplicas: "1"
+
   # helm hooks/checks
   checks:
     # Checks if the last release contains the kubermatic CRD's.


### PR DESCRIPTION
**What this PR does / why we need it**:

Allows setting the default number of replicas for controlplane components. Defaults the number of apiserver replicas to two, as requested by the sebastian.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Documentation**:
<!-- Add links to the related documentation changes related to this pull request. E.g. the link to the kubermatic/docs pullrequest. -->

**Does this PR introduce a user-facing change?**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If  no release note is required, just write "NONE".
-->
```release-note
[BREAKING] The default number of apiserver replicas was increased to 2. You can revert to the old behavior by setting `.Kubermatic.apiserverDefaultReplicas` in the `values.yaml`
```
