### PR TITLE
Expose swagger.json spec over the API

### DIFF
--- a/api/Dockerfile
+++ b/api/Dockerfile
@@ -11,5 +11,6 @@ RUN chmod +x /usr/local/bin/kubectl && \
   mv openshift-origin-client-tools-v3.11.0-0cbc58b-linux-64bit/oc /usr/local/bin
 
 COPY ./_build/* /usr/local/bin/
+COPY ./cmd/kubermatic-api/swagger.json /opt/swagger.json
 
 USER nobody

--- a/api/cmd/kubermatic-api/main.go
+++ b/api/cmd/kubermatic-api/main.go
@@ -10,7 +10,7 @@
 //
 //     Schemes: https
 //     Host: cloud.kubermatic.io
-//     Version: 2.8
+//     Version: 2.11
 //
 //     Consumes:
 //     - application/json
@@ -333,6 +333,12 @@ func createAPIHandler(options serverRunOptions, prov providers, oidcIssuerVerifi
 		},
 		mainRouter)
 	r.RegisterV1Alpha(v1AlphaRouter)
+
+	mainRouter.Methods(http.MethodGet).
+		Path("/api/swagger.json").
+		HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			http.ServeFile(w, r, options.swaggerFile)
+		})
 
 	lookupRoute := func(r *http.Request) string {
 		var match mux.RouteMatch

--- a/api/cmd/kubermatic-api/options.go
+++ b/api/cmd/kubermatic-api/options.go
@@ -24,7 +24,7 @@ type serverRunOptions struct {
 	versionsFile       string
 	updatesFile        string
 	presetsFile        string
-	swaggerFile     string
+	swaggerFile        string
 	domain             string
 	exposeStrategy     corev1.ServiceType
 	dynamicDatacenters bool

--- a/api/cmd/kubermatic-api/options.go
+++ b/api/cmd/kubermatic-api/options.go
@@ -24,6 +24,7 @@ type serverRunOptions struct {
 	versionsFile       string
 	updatesFile        string
 	presetsFile        string
+	swaggerFile     string
 	domain             string
 	exposeStrategy     corev1.ServiceType
 	dynamicDatacenters bool
@@ -61,6 +62,7 @@ func newServerRunOptions() (serverRunOptions, error) {
 	flag.StringVar(&s.versionsFile, "versions", "versions.yaml", "The versions.yaml file path")
 	flag.StringVar(&s.updatesFile, "updates", "updates.yaml", "The updates.yaml file path")
 	flag.StringVar(&s.presetsFile, "presets", "", "The optional file path for a file containing presets")
+	flag.StringVar(&s.swaggerFile, "swagger", "./cmd/kubermatic-api/swagger.json", "The swagger.json file path")
 	flag.StringVar(&s.oidcURL, "oidc-url", "", "URL of the OpenID token issuer. Example: http://auth.int.kubermatic.io")
 	flag.BoolVar(&s.oidcSkipTLSVerify, "oidc-skip-tls-verify", false, "Skip TLS verification for the token issuer")
 	flag.StringVar(&s.oidcAuthenticatorClientID, "oidc-authenticator-client-id", "", "Authenticator client ID")

--- a/api/cmd/kubermatic-api/swagger.json
+++ b/api/cmd/kubermatic-api/swagger.json
@@ -13,7 +13,7 @@
     "description": "Kubermatic API\n\nThis describes possible operations which can be made against the Kubermatic API.",
     "title": "Kubermatic API.",
     "termsOfService": "there are no TOS at this moment, use at your own risk we take no responsibility",
-    "version": "2.8"
+    "version": "2.11"
   },
   "host": "cloud.kubermatic.io",
   "paths": {

--- a/config/kubermatic/templates/kubermatic-api-dep.yaml
+++ b/config/kubermatic/templates/kubermatic-api-dep.yaml
@@ -52,6 +52,7 @@ spec:
         {{- if .Values.kubermatic.presets }}
         - -presets=/opt/presets/presets.yaml
         {{- end }}
+        - -swagger=/opt/swagger.json
         {{- if .Values.kubermatic.exposeStrategy }}
         - -expose-strategy={{ .Values.kubermatic.exposeStrategy }}
         {{- end }}


### PR DESCRIPTION
**What this PR does / why we need it**:
This allows to add the Swagger UI to the dashboard or to use the spec in libraries or API clients

**Does this PR introduce a user-facing change?**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If  no release note is required, just write "NONE".
-->
```release-note
Kubermatic Swagger API Spec is now exposed over its API server
```
