### PR TITLE
remove explicit TerminationMessage and ImagePullPolicy fields

### DIFF
--- a/api/codegen/reconcile/main.go
+++ b/api/codegen/reconcile/main.go
@@ -42,6 +42,7 @@ func main() {
 				ResourceName:       "StatefulSet",
 				ImportAlias:        "appsv1",
 				ResourceImportPath: "k8s.io/api/apps/v1",
+				DefaultingFunc:     "DefaultStatefulSet",
 			},
 			{
 				ResourceName: "Deployment",
@@ -53,6 +54,7 @@ func main() {
 				ResourceName: "DaemonSet",
 				ImportAlias:  "appsv1",
 				// Don't specify ResourceImportPath so this block does not create a new import line in the generated code
+				DefaultingFunc: "DefaultDaemonSet",
 			},
 			{
 				ResourceName:       "PodDisruptionBudget",
@@ -94,6 +96,7 @@ func main() {
 				ResourceName:       "CronJob",
 				ImportAlias:        "batchv1beta1",
 				ResourceImportPath: "k8s.io/api/batch/v1beta1",
+				DefaultingFunc:     "DefaultCronJob",
 			},
 			{
 				ResourceName:       "MutatingWebhookConfiguration",

--- a/api/pkg/controller/backup/backup_controller.go
+++ b/api/pkg/controller/backup/backup_controller.go
@@ -389,9 +389,6 @@ func (r *Reconciler) cronjob(cluster *kubermaticv1.Cluster) (string, reconciling
 					"--key", "/etc/etcd/client/backup-etcd-client.key",
 					"snapshot", "save", "/backup/snapshot.db",
 				},
-				ImagePullPolicy:          corev1.PullIfNotPresent,
-				TerminationMessagePath:   corev1.TerminationMessagePathDefault,
-				TerminationMessagePolicy: corev1.TerminationMessageReadFile,
 				VolumeMounts: []corev1.VolumeMount{
 					{
 						Name:      SharedVolumeName,
@@ -410,9 +407,6 @@ func (r *Reconciler) cronjob(cluster *kubermaticv1.Cluster) (string, reconciling
 			Name:  clusterEnvVarKey,
 			Value: cluster.Name,
 		})
-		storeContainer.ImagePullPolicy = corev1.PullIfNotPresent
-		storeContainer.TerminationMessagePath = corev1.TerminationMessagePathDefault
-		storeContainer.TerminationMessagePolicy = corev1.TerminationMessageReadFile
 
 		cronJob.Spec.JobTemplate.Spec.Template.Spec.RestartPolicy = corev1.RestartPolicyOnFailure
 		cronJob.Spec.JobTemplate.Spec.Template.Spec.Containers = []corev1.Container{*storeContainer}

--- a/api/pkg/controller/container-linux/resources/daemonset.go
+++ b/api/pkg/controller/container-linux/resources/daemonset.go
@@ -40,10 +40,9 @@ func DaemonSetCreator(getRegistry GetImageRegistry) reconciling.NamedDaemonSetCr
 
 			ds.Spec.Template.Spec.Containers = []corev1.Container{
 				{
-					Name:            "update-agent",
-					Image:           getRegistry(resources.RegistryQuay) + "/coreos/container-linux-update-operator:v0.7.0",
-					ImagePullPolicy: corev1.PullIfNotPresent,
-					Command:         []string{"/bin/update-agent"},
+					Name:    "update-agent",
+					Image:   getRegistry(resources.RegistryQuay) + "/coreos/container-linux-update-operator:v0.7.0",
+					Command: []string{"/bin/update-agent"},
 					Env: []corev1.EnvVar{
 						{
 							Name: "UPDATE_AGENT_NODE",
@@ -64,8 +63,6 @@ func DaemonSetCreator(getRegistry GetImageRegistry) reconciling.NamedDaemonSetCr
 							},
 						},
 					},
-					TerminationMessagePath:   corev1.TerminationMessagePathDefault,
-					TerminationMessagePolicy: corev1.TerminationMessageReadFile,
 					VolumeMounts: []corev1.VolumeMount{
 						{
 							Name:      "var-run-dbus",

--- a/api/pkg/controller/container-linux/resources/deployment.go
+++ b/api/pkg/controller/container-linux/resources/deployment.go
@@ -49,10 +49,9 @@ func DeploymentCreator(getRegistry GetImageRegistry) reconciling.NamedDeployment
 
 			dep.Spec.Template.Spec.Containers = []corev1.Container{
 				{
-					Name:            "update-operator",
-					Image:           getRegistry(resources.RegistryQuay) + "/coreos/container-linux-update-operator:v0.7.0",
-					ImagePullPolicy: corev1.PullIfNotPresent,
-					Command:         []string{"/bin/update-operator"},
+					Name:    "update-operator",
+					Image:   getRegistry(resources.RegistryQuay) + "/coreos/container-linux-update-operator:v0.7.0",
+					Command: []string{"/bin/update-operator"},
 					Env: []corev1.EnvVar{
 						{
 							Name: "POD_NAMESPACE",
@@ -64,8 +63,6 @@ func DeploymentCreator(getRegistry GetImageRegistry) reconciling.NamedDeployment
 							},
 						},
 					},
-					TerminationMessagePath:   corev1.TerminationMessagePathDefault,
-					TerminationMessagePolicy: corev1.TerminationMessageReadFile,
 				},
 			}
 

--- a/api/pkg/controller/openshift/resources/controller_manager_deployment.go
+++ b/api/pkg/controller/openshift/resources/controller_manager_deployment.go
@@ -147,15 +147,12 @@ func ControllerManagerDeploymentCreator(ctx context.Context, data openshiftData)
 			dep.Spec.Template.Spec.Containers = []corev1.Container{
 				*openvpnSidecar,
 				{
-					Name:                     ControllerManagerDeploymentName,
-					Image:                    data.ImageRegistry(resources.RegistryDocker) + "/openshift/origin-control-plane:v3.11",
-					ImagePullPolicy:          corev1.PullIfNotPresent,
-					Command:                  []string{"/usr/bin/openshift", "start", "master", "controllers"},
-					Args:                     []string{"--config=/etc/origin/master/master-config.yaml", "--listen=https://0.0.0.0:8444"},
-					Env:                      getControllerManagerEnvVars(data.Cluster()),
-					TerminationMessagePath:   corev1.TerminationMessagePathDefault,
-					TerminationMessagePolicy: corev1.TerminationMessageReadFile,
-					Resources:                resourceRequirements,
+					Name:      ControllerManagerDeploymentName,
+					Image:     data.ImageRegistry(resources.RegistryDocker) + "/openshift/origin-control-plane:v3.11",
+					Command:   []string{"/usr/bin/openshift", "start", "master", "controllers"},
+					Args:      []string{"--config=/etc/origin/master/master-config.yaml", "--listen=https://0.0.0.0:8444"},
+					Env:       getControllerManagerEnvVars(data.Cluster()),
+					Resources: resourceRequirements,
 					ReadinessProbe: &corev1.Probe{
 						Handler: corev1.Handler{
 							HTTPGet: getHealthGetAction(),

--- a/api/pkg/controller/seed-proxy/resources.go
+++ b/api/pkg/controller/seed-proxy/resources.go
@@ -173,11 +173,10 @@ func masterDeploymentCreator(contextName string, secret *corev1.Secret) reconcil
 
 			d.Spec.Template.Spec.Containers = []corev1.Container{
 				{
-					Name:            "proxy",
-					Image:           "quay.io/kubermatic/util:1.0.0-5",
-					ImagePullPolicy: corev1.PullIfNotPresent,
-					Command:         []string{"/bin/bash"},
-					Args:            []string{"-c", strings.TrimSpace(proxyScript)},
+					Name:    "proxy",
+					Image:   "quay.io/kubermatic/util:1.0.0-5",
+					Command: []string{"/bin/bash"},
+					Args:    []string{"-c", strings.TrimSpace(proxyScript)},
 					Env: []corev1.EnvVar{
 						{
 							Name:  "KUBERNETES_CONTEXT",
@@ -212,9 +211,7 @@ func masterDeploymentCreator(contextName string, secret *corev1.Secret) reconcil
 							corev1.ResourceMemory: resource.MustParse("32Mi"),
 						},
 					},
-					TerminationMessagePolicy: corev1.TerminationMessageReadFile,
-					TerminationMessagePath:   "/dev/termination-log",
-					ReadinessProbe:           &probe,
+					ReadinessProbe: &probe,
 				},
 			}
 

--- a/api/pkg/resources/etcd/cronjob.go
+++ b/api/pkg/resources/etcd/cronjob.go
@@ -41,12 +41,9 @@ func CronJobCreator(data cronJobCreatorData) reconciling.NamedCronJobCreatorGett
 			job.Spec.JobTemplate.Spec.Template.Spec.ImagePullSecrets = []corev1.LocalObjectReference{{Name: resources.ImagePullSecretName}}
 			job.Spec.JobTemplate.Spec.Template.Spec.Containers = []corev1.Container{
 				{
-					Name:                     "defragger",
-					Image:                    data.ImageRegistry(resources.RegistryGCR) + "/etcd-development/etcd:" + ImageTag,
-					ImagePullPolicy:          corev1.PullIfNotPresent,
-					Command:                  command,
-					TerminationMessagePath:   corev1.TerminationMessagePathDefault,
-					TerminationMessagePolicy: corev1.TerminationMessageReadFile,
+					Name:    "defragger",
+					Image:   data.ImageRegistry(resources.RegistryGCR) + "/etcd-development/etcd:" + ImageTag,
+					Command: command,
 					VolumeMounts: []corev1.VolumeMount{
 						{
 							Name:      resources.ApiserverEtcdClientCertificateSecretName,

--- a/api/pkg/resources/etcd/statefulset.go
+++ b/api/pkg/resources/etcd/statefulset.go
@@ -91,12 +91,9 @@ func StatefulSetCreator(data etcdStatefulSetCreatorData, enableDataCorruptionChe
 			}
 			set.Spec.Template.Spec.Containers = []corev1.Container{
 				{
-					Name:                     name,
-					Image:                    data.ImageRegistry(resources.RegistryGCR) + "/etcd-development/etcd:" + ImageTag,
-					ImagePullPolicy:          corev1.PullIfNotPresent,
-					Command:                  etcdStartCmd,
-					TerminationMessagePath:   corev1.TerminationMessagePathDefault,
-					TerminationMessagePolicy: corev1.TerminationMessageReadFile,
+					Name:    name,
+					Image:   data.ImageRegistry(resources.RegistryGCR) + "/etcd-development/etcd:" + ImageTag,
+					Command: etcdStartCmd,
 					Env: []corev1.EnvVar{
 						{
 							Name: "POD_NAME",

--- a/api/pkg/resources/prometheus/statefulset.go
+++ b/api/pkg/resources/prometheus/statefulset.go
@@ -84,11 +84,8 @@ func StatefulSetCreator(data *resources.TemplateData) reconciling.NamedStatefulS
 
 			set.Spec.Template.Spec.Containers = []corev1.Container{
 				{
-					Name:                     name,
-					Image:                    data.ImageRegistry(resources.RegistryQuay) + "/prometheus/prometheus:" + tag,
-					ImagePullPolicy:          corev1.PullIfNotPresent,
-					TerminationMessagePath:   corev1.TerminationMessagePathDefault,
-					TerminationMessagePolicy: corev1.TerminationMessageReadFile,
+					Name:  name,
+					Image: data.ImageRegistry(resources.RegistryQuay) + "/prometheus/prometheus:" + tag,
 					Args: []string{
 						"--config.file=/etc/prometheus/config/prometheus.yaml",
 						"--storage.tsdb.path=/var/prometheus/data",

--- a/api/pkg/resources/reconciling/ensure_test.go
+++ b/api/pkg/resources/reconciling/ensure_test.go
@@ -145,7 +145,7 @@ func TestEnsureObjectByAnnotation(t *testing.T) {
 
 			gotConfigMap := &corev1.ConfigMap{}
 			if err := client.Get(context.Background(), key, gotConfigMap); err != nil {
-				t.Fatalf("Failed to get the ServiceAccount from the client: %v", err)
+				t.Fatalf("Failed to get the ConfigMap from the client: %v", err)
 			}
 
 			if diff := deep.Equal(gotConfigMap, test.expectedObject); diff != nil {

--- a/api/pkg/resources/reconciling/wrapper.go
+++ b/api/pkg/resources/reconciling/wrapper.go
@@ -66,21 +66,11 @@ func DefaultPodSpec(old, new corev1.PodSpec) (corev1.PodSpec, error) {
 	}
 
 	for idx, container := range new.InitContainers {
-		t := corev1.DefaultProcMount
-		if tt, ok := initContainerProcMountType[container.Name]; ok && tt != nil {
-			t = *tt
-		}
-
-		DefaultContainer(&new.InitContainers[idx], &t)
+		DefaultContainer(&new.InitContainers[idx], initContainerProcMountType[container.Name])
 	}
 
 	for idx, container := range new.Containers {
-		t := corev1.DefaultProcMount
-		if tt, ok := containerProcMountType[container.Name]; ok && tt != nil {
-			t = *tt
-		}
-
-		DefaultContainer(&new.Containers[idx], &t)
+		DefaultContainer(&new.Containers[idx], containerProcMountType[container.Name])
 	}
 
 	return new, nil

--- a/api/pkg/resources/reconciling/wrapper_test.go
+++ b/api/pkg/resources/reconciling/wrapper_test.go
@@ -43,54 +43,64 @@ func TestDefaultPodSpec(t *testing.T) {
 			},
 		},
 		{
-			name: "Default values for security contexts are added",
+			name: "The new version of objects is prioritized",
+			oldObject: corev1.PodSpec{
+				Containers: []corev1.Container{
+					{
+						ImagePullPolicy:          corev1.PullAlways,
+						TerminationMessagePath:   "/dev/old",
+						TerminationMessagePolicy: corev1.TerminationMessageReadFile,
+					},
+				},
+			},
 			newObject: corev1.PodSpec{
 				Containers: []corev1.Container{
 					{
-						SecurityContext: &corev1.SecurityContext{},
+						ImagePullPolicy:          corev1.PullNever,
+						TerminationMessagePath:   "/dev/new",
+						TerminationMessagePolicy: corev1.TerminationMessageFallbackToLogsOnError,
 					},
 				},
 			},
 			expectedObject: corev1.PodSpec{
 				Containers: []corev1.Container{
 					{
-						ImagePullPolicy:          corev1.PullIfNotPresent,
-						TerminationMessagePath:   corev1.TerminationMessagePathDefault,
-						TerminationMessagePolicy: corev1.TerminationMessageReadFile,
+						ImagePullPolicy:          corev1.PullNever,
+						TerminationMessagePath:   "/dev/new",
+						TerminationMessagePolicy: corev1.TerminationMessageFallbackToLogsOnError,
+					},
+				},
+			},
+		},
+		{
+			name: "The procMountType is always retained and cannot be overwritten",
+			oldObject: corev1.PodSpec{
+				Containers: []corev1.Container{
+					{
 						SecurityContext: &corev1.SecurityContext{
 							ProcMount: &defaultProcMountType,
 						},
 					},
 				},
 			},
-		},
-		{
-			name: "Explicit values for security contexts are retained",
-			oldObject: corev1.PodSpec{
+			newObject: corev1.PodSpec{
 				Containers: []corev1.Container{
 					{
 						SecurityContext: &corev1.SecurityContext{
 							ProcMount: &otherProcMountType,
 						},
-					},
-				},
-			},
-			newObject: corev1.PodSpec{
-				Containers: []corev1.Container{
-					{
-						SecurityContext: &corev1.SecurityContext{},
 					},
 				},
 			},
 			expectedObject: corev1.PodSpec{
 				Containers: []corev1.Container{
 					{
+						SecurityContext: &corev1.SecurityContext{
+							ProcMount: &defaultProcMountType,
+						},
 						ImagePullPolicy:          corev1.PullIfNotPresent,
 						TerminationMessagePath:   corev1.TerminationMessagePathDefault,
 						TerminationMessagePolicy: corev1.TerminationMessageReadFile,
-						SecurityContext: &corev1.SecurityContext{
-							ProcMount: &otherProcMountType,
-						},
 					},
 				},
 			},
@@ -225,9 +235,7 @@ func TestDefaultPodSpec(t *testing.T) {
 						ImagePullPolicy:          corev1.PullIfNotPresent,
 						TerminationMessagePath:   corev1.TerminationMessagePathDefault,
 						TerminationMessagePolicy: corev1.TerminationMessageReadFile,
-						SecurityContext: &corev1.SecurityContext{
-							ProcMount: &defaultProcMountType,
-						},
+						SecurityContext:          &corev1.SecurityContext{},
 					},
 				},
 			},

--- a/api/pkg/resources/reconciling/wrapper_test.go
+++ b/api/pkg/resources/reconciling/wrapper_test.go
@@ -1,0 +1,525 @@
+package reconciling
+
+import (
+	"context"
+	"testing"
+
+	"github.com/go-test/deep"
+	controllerruntimeclient "sigs.k8s.io/controller-runtime/pkg/client"
+	controllerruntimefake "sigs.k8s.io/controller-runtime/pkg/client/fake"
+
+	appsv1 "k8s.io/api/apps/v1"
+	batchv1 "k8s.io/api/batch/v1"
+	batchv1beta1 "k8s.io/api/batch/v1beta1"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+func TestDefaultPodSpec(t *testing.T) {
+	defaultProcMountType := corev1.DefaultProcMount
+	otherProcMountType := corev1.UnmaskedProcMount
+
+	tests := []struct {
+		name           string
+		oldObject      corev1.PodSpec
+		newObject      corev1.PodSpec
+		expectedObject corev1.PodSpec
+	}{
+		{
+			name: "Default values for termination message and pull policies are added",
+			newObject: corev1.PodSpec{
+				Containers: []corev1.Container{
+					{},
+				},
+			},
+			expectedObject: corev1.PodSpec{
+				Containers: []corev1.Container{
+					{
+						ImagePullPolicy:          corev1.PullIfNotPresent,
+						TerminationMessagePath:   corev1.TerminationMessagePathDefault,
+						TerminationMessagePolicy: corev1.TerminationMessageReadFile,
+					},
+				},
+			},
+		},
+		{
+			name: "Default values for security contexts are added",
+			newObject: corev1.PodSpec{
+				Containers: []corev1.Container{
+					{
+						SecurityContext: &corev1.SecurityContext{},
+					},
+				},
+			},
+			expectedObject: corev1.PodSpec{
+				Containers: []corev1.Container{
+					{
+						ImagePullPolicy:          corev1.PullIfNotPresent,
+						TerminationMessagePath:   corev1.TerminationMessagePathDefault,
+						TerminationMessagePolicy: corev1.TerminationMessageReadFile,
+						SecurityContext: &corev1.SecurityContext{
+							ProcMount: &defaultProcMountType,
+						},
+					},
+				},
+			},
+		},
+		{
+			name: "Explicit values for security contexts are retained",
+			oldObject: corev1.PodSpec{
+				Containers: []corev1.Container{
+					{
+						SecurityContext: &corev1.SecurityContext{
+							ProcMount: &otherProcMountType,
+						},
+					},
+				},
+			},
+			newObject: corev1.PodSpec{
+				Containers: []corev1.Container{
+					{
+						SecurityContext: &corev1.SecurityContext{},
+					},
+				},
+			},
+			expectedObject: corev1.PodSpec{
+				Containers: []corev1.Container{
+					{
+						ImagePullPolicy:          corev1.PullIfNotPresent,
+						TerminationMessagePath:   corev1.TerminationMessagePathDefault,
+						TerminationMessagePolicy: corev1.TerminationMessageReadFile,
+						SecurityContext: &corev1.SecurityContext{
+							ProcMount: &otherProcMountType,
+						},
+					},
+				},
+			},
+		},
+		{
+			name: "Values are assigned based on container names, not ordering",
+			oldObject: corev1.PodSpec{
+				Containers: []corev1.Container{
+					{
+						Name: "a",
+						SecurityContext: &corev1.SecurityContext{
+							ProcMount: &defaultProcMountType,
+						},
+					},
+					{
+						Name: "b",
+						SecurityContext: &corev1.SecurityContext{
+							ProcMount: &otherProcMountType,
+						},
+					},
+				},
+			},
+			newObject: corev1.PodSpec{
+				Containers: []corev1.Container{
+					{
+						Name:            "b",
+						SecurityContext: &corev1.SecurityContext{},
+					},
+				},
+			},
+			expectedObject: corev1.PodSpec{
+				Containers: []corev1.Container{
+					{
+						Name:                     "b",
+						ImagePullPolicy:          corev1.PullIfNotPresent,
+						TerminationMessagePath:   corev1.TerminationMessagePathDefault,
+						TerminationMessagePolicy: corev1.TerminationMessageReadFile,
+						SecurityContext: &corev1.SecurityContext{
+							ProcMount: &otherProcMountType,
+						},
+					},
+				},
+			},
+		},
+		{
+			name: "InitContainers are updated as well",
+			oldObject: corev1.PodSpec{
+				InitContainers: []corev1.Container{
+					{
+						Name: "a",
+						SecurityContext: &corev1.SecurityContext{
+							ProcMount: &defaultProcMountType,
+						},
+					},
+					{
+						Name: "b",
+						SecurityContext: &corev1.SecurityContext{
+							ProcMount: &otherProcMountType,
+						},
+					},
+				},
+			},
+			newObject: corev1.PodSpec{
+				InitContainers: []corev1.Container{
+					{
+						Name:            "b",
+						SecurityContext: &corev1.SecurityContext{},
+					},
+				},
+			},
+			expectedObject: corev1.PodSpec{
+				InitContainers: []corev1.Container{
+					{
+						Name:                     "b",
+						ImagePullPolicy:          corev1.PullIfNotPresent,
+						TerminationMessagePath:   corev1.TerminationMessagePathDefault,
+						TerminationMessagePolicy: corev1.TerminationMessageReadFile,
+						SecurityContext: &corev1.SecurityContext{
+							ProcMount: &otherProcMountType,
+						},
+					},
+				},
+			},
+		},
+		{
+			name: "InitContainers and Containers are not mixed up",
+			oldObject: corev1.PodSpec{
+				InitContainers: []corev1.Container{
+					{
+						Name: "a",
+						SecurityContext: &corev1.SecurityContext{
+							ProcMount: &otherProcMountType,
+						},
+					},
+				},
+				Containers: []corev1.Container{
+					{
+						Name:            "a",
+						SecurityContext: &corev1.SecurityContext{},
+					},
+				},
+			},
+			newObject: corev1.PodSpec{
+				InitContainers: []corev1.Container{
+					{
+						Name:            "a",
+						SecurityContext: &corev1.SecurityContext{},
+					},
+				},
+				Containers: []corev1.Container{
+					{
+						Name:            "a",
+						SecurityContext: &corev1.SecurityContext{},
+					},
+				},
+			},
+			expectedObject: corev1.PodSpec{
+				InitContainers: []corev1.Container{
+					{
+						Name:                     "a",
+						ImagePullPolicy:          corev1.PullIfNotPresent,
+						TerminationMessagePath:   corev1.TerminationMessagePathDefault,
+						TerminationMessagePolicy: corev1.TerminationMessageReadFile,
+						SecurityContext: &corev1.SecurityContext{
+							ProcMount: &otherProcMountType,
+						},
+					},
+				},
+				Containers: []corev1.Container{
+					{
+						Name:                     "a",
+						ImagePullPolicy:          corev1.PullIfNotPresent,
+						TerminationMessagePath:   corev1.TerminationMessagePathDefault,
+						TerminationMessagePolicy: corev1.TerminationMessageReadFile,
+						SecurityContext: &corev1.SecurityContext{
+							ProcMount: &defaultProcMountType,
+						},
+					},
+				},
+			},
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			result, err := DefaultPodSpec(test.oldObject, test.newObject)
+			if err != nil {
+				t.Errorf("DefaultPodSpec returned an unexpected error: %v", err)
+			}
+
+			if diff := deep.Equal(result, test.expectedObject); diff != nil {
+				t.Errorf("The PodSpec from the client does not match the expected PodSpec. Diff: \n%v", diff)
+			}
+		})
+	}
+}
+
+func TestDefaultDeployment(t *testing.T) {
+	const (
+		testNamespace    = "default"
+		testResourceName = "test"
+	)
+
+	creators := []NamedDeploymentCreatorGetter{
+		func() (string, DeploymentCreator) {
+			return testResourceName, func(d *appsv1.Deployment) (*appsv1.Deployment, error) {
+				return d, nil
+			}
+		},
+	}
+
+	existingObject := &appsv1.Deployment{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      testResourceName,
+			Namespace: testNamespace,
+		},
+		Spec: appsv1.DeploymentSpec{
+			Template: corev1.PodTemplateSpec{
+				Spec: corev1.PodSpec{
+					Containers: []corev1.Container{
+						{},
+					},
+				},
+			},
+		},
+	}
+
+	expectedObject := &appsv1.Deployment{
+		ObjectMeta: existingObject.ObjectMeta,
+		Spec: appsv1.DeploymentSpec{
+			Template: corev1.PodTemplateSpec{
+				Spec: corev1.PodSpec{
+					Containers: []corev1.Container{
+						{
+							ImagePullPolicy:          corev1.PullIfNotPresent,
+							TerminationMessagePath:   corev1.TerminationMessagePathDefault,
+							TerminationMessagePolicy: corev1.TerminationMessageReadFile,
+						},
+					},
+				},
+			},
+		},
+	}
+
+	client := controllerruntimefake.NewFakeClient(existingObject)
+	if err := ReconcileDeployments(context.Background(), creators, testNamespace, client); err != nil {
+		t.Errorf("EnsureObject returned an error while none was expected: %v", err)
+	}
+
+	key, err := controllerruntimeclient.ObjectKeyFromObject(expectedObject)
+	if err != nil {
+		t.Fatalf("Failed to generate a ObjectKey for the expected object: %v", err)
+	}
+
+	actualDeployment := &appsv1.Deployment{}
+	if err := client.Get(context.Background(), key, actualDeployment); err != nil {
+		t.Fatalf("Failed to get the Deployment from the client: %v", err)
+	}
+
+	if diff := deep.Equal(actualDeployment, expectedObject); diff != nil {
+		t.Errorf("The Deployment from the client does not match the expected Deployment. Diff: \n%v", diff)
+	}
+}
+
+func TestDefaultStatefulSet(t *testing.T) {
+	const (
+		testNamespace    = "default"
+		testResourceName = "test"
+	)
+
+	creators := []NamedStatefulSetCreatorGetter{
+		func() (string, StatefulSetCreator) {
+			return testResourceName, func(d *appsv1.StatefulSet) (*appsv1.StatefulSet, error) {
+				return d, nil
+			}
+		},
+	}
+
+	existingObject := &appsv1.StatefulSet{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      testResourceName,
+			Namespace: testNamespace,
+		},
+		Spec: appsv1.StatefulSetSpec{
+			Template: corev1.PodTemplateSpec{
+				Spec: corev1.PodSpec{
+					Containers: []corev1.Container{
+						{},
+					},
+				},
+			},
+		},
+	}
+
+	expectedObject := &appsv1.StatefulSet{
+		ObjectMeta: existingObject.ObjectMeta,
+		Spec: appsv1.StatefulSetSpec{
+			Template: corev1.PodTemplateSpec{
+				Spec: corev1.PodSpec{
+					Containers: []corev1.Container{
+						{
+							ImagePullPolicy:          corev1.PullIfNotPresent,
+							TerminationMessagePath:   corev1.TerminationMessagePathDefault,
+							TerminationMessagePolicy: corev1.TerminationMessageReadFile,
+						},
+					},
+				},
+			},
+		},
+	}
+
+	client := controllerruntimefake.NewFakeClient(existingObject)
+	if err := ReconcileStatefulSets(context.Background(), creators, testNamespace, client); err != nil {
+		t.Errorf("EnsureObject returned an error while none was expected: %v", err)
+	}
+
+	key, err := controllerruntimeclient.ObjectKeyFromObject(expectedObject)
+	if err != nil {
+		t.Fatalf("Failed to generate a ObjectKey for the expected object: %v", err)
+	}
+
+	actualStatefulSet := &appsv1.StatefulSet{}
+	if err := client.Get(context.Background(), key, actualStatefulSet); err != nil {
+		t.Fatalf("Failed to get the StatefulSet from the client: %v", err)
+	}
+
+	if diff := deep.Equal(actualStatefulSet, expectedObject); diff != nil {
+		t.Errorf("The StatefulSet from the client does not match the expected StatefulSet. Diff: \n%v", diff)
+	}
+}
+
+func TestDefaultDaemonSet(t *testing.T) {
+	const (
+		testNamespace    = "default"
+		testResourceName = "test"
+	)
+
+	creators := []NamedDaemonSetCreatorGetter{
+		func() (string, DaemonSetCreator) {
+			return testResourceName, func(d *appsv1.DaemonSet) (*appsv1.DaemonSet, error) {
+				return d, nil
+			}
+		},
+	}
+
+	existingObject := &appsv1.DaemonSet{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      testResourceName,
+			Namespace: testNamespace,
+		},
+		Spec: appsv1.DaemonSetSpec{
+			Template: corev1.PodTemplateSpec{
+				Spec: corev1.PodSpec{
+					Containers: []corev1.Container{
+						{},
+					},
+				},
+			},
+		},
+	}
+
+	expectedObject := &appsv1.DaemonSet{
+		ObjectMeta: existingObject.ObjectMeta,
+		Spec: appsv1.DaemonSetSpec{
+			Template: corev1.PodTemplateSpec{
+				Spec: corev1.PodSpec{
+					Containers: []corev1.Container{
+						{
+							ImagePullPolicy:          corev1.PullIfNotPresent,
+							TerminationMessagePath:   corev1.TerminationMessagePathDefault,
+							TerminationMessagePolicy: corev1.TerminationMessageReadFile,
+						},
+					},
+				},
+			},
+		},
+	}
+
+	client := controllerruntimefake.NewFakeClient(existingObject)
+	if err := ReconcileDaemonSets(context.Background(), creators, testNamespace, client); err != nil {
+		t.Errorf("EnsureObject returned an error while none was expected: %v", err)
+	}
+
+	key, err := controllerruntimeclient.ObjectKeyFromObject(expectedObject)
+	if err != nil {
+		t.Fatalf("Failed to generate a ObjectKey for the expected object: %v", err)
+	}
+
+	actualDaemonSet := &appsv1.DaemonSet{}
+	if err := client.Get(context.Background(), key, actualDaemonSet); err != nil {
+		t.Fatalf("Failed to get the DaemonSet from the client: %v", err)
+	}
+
+	if diff := deep.Equal(actualDaemonSet, expectedObject); diff != nil {
+		t.Errorf("The DaemonSet from the client does not match the expected DaemonSet. Diff: \n%v", diff)
+	}
+}
+
+func TestDefaultCronJob(t *testing.T) {
+	const (
+		testNamespace    = "default"
+		testResourceName = "test"
+	)
+
+	creators := []NamedCronJobCreatorGetter{
+		func() (string, CronJobCreator) {
+			return testResourceName, func(d *batchv1beta1.CronJob) (*batchv1beta1.CronJob, error) {
+				return d, nil
+			}
+		},
+	}
+
+	existingObject := &batchv1beta1.CronJob{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      testResourceName,
+			Namespace: testNamespace,
+		},
+		Spec: batchv1beta1.CronJobSpec{
+			JobTemplate: batchv1beta1.JobTemplateSpec{
+				Spec: batchv1.JobSpec{
+					Template: corev1.PodTemplateSpec{
+						Spec: corev1.PodSpec{
+							Containers: []corev1.Container{
+								{},
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+
+	expectedObject := &batchv1beta1.CronJob{
+		ObjectMeta: existingObject.ObjectMeta,
+		Spec: batchv1beta1.CronJobSpec{
+			JobTemplate: batchv1beta1.JobTemplateSpec{
+				Spec: batchv1.JobSpec{
+					Template: corev1.PodTemplateSpec{
+						Spec: corev1.PodSpec{
+							Containers: []corev1.Container{
+								{
+									ImagePullPolicy:          corev1.PullIfNotPresent,
+									TerminationMessagePath:   corev1.TerminationMessagePathDefault,
+									TerminationMessagePolicy: corev1.TerminationMessageReadFile,
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+
+	client := controllerruntimefake.NewFakeClient(existingObject)
+	if err := ReconcileCronJobs(context.Background(), creators, testNamespace, client); err != nil {
+		t.Errorf("EnsureObject returned an error while none was expected: %v", err)
+	}
+
+	key, err := controllerruntimeclient.ObjectKeyFromObject(expectedObject)
+	if err != nil {
+		t.Fatalf("Failed to generate a ObjectKey for the expected object: %v", err)
+	}
+
+	actualCronJob := &batchv1beta1.CronJob{}
+	if err := client.Get(context.Background(), key, actualCronJob); err != nil {
+		t.Fatalf("Failed to get the CronJob from the client: %v", err)
+	}
+
+	if diff := deep.Equal(actualCronJob, expectedObject); diff != nil {
+		t.Errorf("The CronJob from the client does not match the expected CronJob. Diff: \n%v", diff)
+	}
+}

--- a/api/pkg/resources/reconciling/zz_generated_reconcile.go
+++ b/api/pkg/resources/reconciling/zz_generated_reconcile.go
@@ -177,6 +177,7 @@ func StatefulSetObjectWrapper(create StatefulSetCreator) ObjectCreator {
 func ReconcileStatefulSets(ctx context.Context, namedGetters []NamedStatefulSetCreatorGetter, namespace string, client ctrlruntimeclient.Client, objectModifiers ...ObjectModifier) error {
 	for _, get := range namedGetters {
 		name, create := get()
+		create = DefaultStatefulSet(create)
 		createObject := StatefulSetObjectWrapper(create)
 		for _, objectModifier := range objectModifiers {
 			createObject = objectModifier(createObject)
@@ -246,6 +247,7 @@ func DaemonSetObjectWrapper(create DaemonSetCreator) ObjectCreator {
 func ReconcileDaemonSets(ctx context.Context, namedGetters []NamedDaemonSetCreatorGetter, namespace string, client ctrlruntimeclient.Client, objectModifiers ...ObjectModifier) error {
 	for _, get := range namedGetters {
 		name, create := get()
+		create = DefaultDaemonSet(create)
 		createObject := DaemonSetObjectWrapper(create)
 		for _, objectModifier := range objectModifiers {
 			createObject = objectModifier(createObject)
@@ -518,6 +520,7 @@ func CronJobObjectWrapper(create CronJobCreator) ObjectCreator {
 func ReconcileCronJobs(ctx context.Context, namedGetters []NamedCronJobCreatorGetter, namespace string, client ctrlruntimeclient.Client, objectModifiers ...ObjectModifier) error {
 	for _, get := range namedGetters {
 		name, create := get()
+		create = DefaultCronJob(create)
 		createObject := CronJobObjectWrapper(create)
 		for _, objectModifier := range objectModifiers {
 			createObject = objectModifier(createObject)

--- a/api/pkg/resources/test/fixtures/cronjob-aws-1.10.0-etcd-defragger.yaml
+++ b/api/pkg/resources/test/fixtures/cronjob-aws-1.10.0-etcd-defragger.yaml
@@ -45,11 +45,8 @@ spec:
                 fi
               done
             image: gcr.io/etcd-development/etcd:v3.3.12
-            imagePullPolicy: IfNotPresent
             name: defragger
             resources: {}
-            terminationMessagePath: /dev/termination-log
-            terminationMessagePolicy: File
             volumeMounts:
             - mountPath: /etc/etcd/pki/client
               name: apiserver-etcd-client-certificate

--- a/api/pkg/resources/test/fixtures/cronjob-aws-1.10.6-etcd-defragger.yaml
+++ b/api/pkg/resources/test/fixtures/cronjob-aws-1.10.6-etcd-defragger.yaml
@@ -45,11 +45,8 @@ spec:
                 fi
               done
             image: gcr.io/etcd-development/etcd:v3.3.12
-            imagePullPolicy: IfNotPresent
             name: defragger
             resources: {}
-            terminationMessagePath: /dev/termination-log
-            terminationMessagePolicy: File
             volumeMounts:
             - mountPath: /etc/etcd/pki/client
               name: apiserver-etcd-client-certificate

--- a/api/pkg/resources/test/fixtures/cronjob-aws-1.11.0-etcd-defragger.yaml
+++ b/api/pkg/resources/test/fixtures/cronjob-aws-1.11.0-etcd-defragger.yaml
@@ -45,11 +45,8 @@ spec:
                 fi
               done
             image: gcr.io/etcd-development/etcd:v3.3.12
-            imagePullPolicy: IfNotPresent
             name: defragger
             resources: {}
-            terminationMessagePath: /dev/termination-log
-            terminationMessagePolicy: File
             volumeMounts:
             - mountPath: /etc/etcd/pki/client
               name: apiserver-etcd-client-certificate

--- a/api/pkg/resources/test/fixtures/cronjob-aws-1.11.1-etcd-defragger.yaml
+++ b/api/pkg/resources/test/fixtures/cronjob-aws-1.11.1-etcd-defragger.yaml
@@ -45,11 +45,8 @@ spec:
                 fi
               done
             image: gcr.io/etcd-development/etcd:v3.3.12
-            imagePullPolicy: IfNotPresent
             name: defragger
             resources: {}
-            terminationMessagePath: /dev/termination-log
-            terminationMessagePolicy: File
             volumeMounts:
             - mountPath: /etc/etcd/pki/client
               name: apiserver-etcd-client-certificate

--- a/api/pkg/resources/test/fixtures/cronjob-aws-1.12.0-etcd-defragger.yaml
+++ b/api/pkg/resources/test/fixtures/cronjob-aws-1.12.0-etcd-defragger.yaml
@@ -45,11 +45,8 @@ spec:
                 fi
               done
             image: gcr.io/etcd-development/etcd:v3.3.12
-            imagePullPolicy: IfNotPresent
             name: defragger
             resources: {}
-            terminationMessagePath: /dev/termination-log
-            terminationMessagePolicy: File
             volumeMounts:
             - mountPath: /etc/etcd/pki/client
               name: apiserver-etcd-client-certificate

--- a/api/pkg/resources/test/fixtures/cronjob-aws-1.13.0-etcd-defragger.yaml
+++ b/api/pkg/resources/test/fixtures/cronjob-aws-1.13.0-etcd-defragger.yaml
@@ -45,11 +45,8 @@ spec:
                 fi
               done
             image: gcr.io/etcd-development/etcd:v3.3.12
-            imagePullPolicy: IfNotPresent
             name: defragger
             resources: {}
-            terminationMessagePath: /dev/termination-log
-            terminationMessagePolicy: File
             volumeMounts:
             - mountPath: /etc/etcd/pki/client
               name: apiserver-etcd-client-certificate

--- a/api/pkg/resources/test/fixtures/cronjob-azure-1.10.0-etcd-defragger.yaml
+++ b/api/pkg/resources/test/fixtures/cronjob-azure-1.10.0-etcd-defragger.yaml
@@ -45,11 +45,8 @@ spec:
                 fi
               done
             image: gcr.io/etcd-development/etcd:v3.3.12
-            imagePullPolicy: IfNotPresent
             name: defragger
             resources: {}
-            terminationMessagePath: /dev/termination-log
-            terminationMessagePolicy: File
             volumeMounts:
             - mountPath: /etc/etcd/pki/client
               name: apiserver-etcd-client-certificate

--- a/api/pkg/resources/test/fixtures/cronjob-azure-1.10.6-etcd-defragger.yaml
+++ b/api/pkg/resources/test/fixtures/cronjob-azure-1.10.6-etcd-defragger.yaml
@@ -45,11 +45,8 @@ spec:
                 fi
               done
             image: gcr.io/etcd-development/etcd:v3.3.12
-            imagePullPolicy: IfNotPresent
             name: defragger
             resources: {}
-            terminationMessagePath: /dev/termination-log
-            terminationMessagePolicy: File
             volumeMounts:
             - mountPath: /etc/etcd/pki/client
               name: apiserver-etcd-client-certificate

--- a/api/pkg/resources/test/fixtures/cronjob-azure-1.11.0-etcd-defragger.yaml
+++ b/api/pkg/resources/test/fixtures/cronjob-azure-1.11.0-etcd-defragger.yaml
@@ -45,11 +45,8 @@ spec:
                 fi
               done
             image: gcr.io/etcd-development/etcd:v3.3.12
-            imagePullPolicy: IfNotPresent
             name: defragger
             resources: {}
-            terminationMessagePath: /dev/termination-log
-            terminationMessagePolicy: File
             volumeMounts:
             - mountPath: /etc/etcd/pki/client
               name: apiserver-etcd-client-certificate

--- a/api/pkg/resources/test/fixtures/cronjob-azure-1.11.1-etcd-defragger.yaml
+++ b/api/pkg/resources/test/fixtures/cronjob-azure-1.11.1-etcd-defragger.yaml
@@ -45,11 +45,8 @@ spec:
                 fi
               done
             image: gcr.io/etcd-development/etcd:v3.3.12
-            imagePullPolicy: IfNotPresent
             name: defragger
             resources: {}
-            terminationMessagePath: /dev/termination-log
-            terminationMessagePolicy: File
             volumeMounts:
             - mountPath: /etc/etcd/pki/client
               name: apiserver-etcd-client-certificate

--- a/api/pkg/resources/test/fixtures/cronjob-azure-1.12.0-etcd-defragger.yaml
+++ b/api/pkg/resources/test/fixtures/cronjob-azure-1.12.0-etcd-defragger.yaml
@@ -45,11 +45,8 @@ spec:
                 fi
               done
             image: gcr.io/etcd-development/etcd:v3.3.12
-            imagePullPolicy: IfNotPresent
             name: defragger
             resources: {}
-            terminationMessagePath: /dev/termination-log
-            terminationMessagePolicy: File
             volumeMounts:
             - mountPath: /etc/etcd/pki/client
               name: apiserver-etcd-client-certificate

--- a/api/pkg/resources/test/fixtures/cronjob-azure-1.13.0-etcd-defragger.yaml
+++ b/api/pkg/resources/test/fixtures/cronjob-azure-1.13.0-etcd-defragger.yaml
@@ -45,11 +45,8 @@ spec:
                 fi
               done
             image: gcr.io/etcd-development/etcd:v3.3.12
-            imagePullPolicy: IfNotPresent
             name: defragger
             resources: {}
-            terminationMessagePath: /dev/termination-log
-            terminationMessagePolicy: File
             volumeMounts:
             - mountPath: /etc/etcd/pki/client
               name: apiserver-etcd-client-certificate

--- a/api/pkg/resources/test/fixtures/cronjob-bringyourown-1.10.0-etcd-defragger.yaml
+++ b/api/pkg/resources/test/fixtures/cronjob-bringyourown-1.10.0-etcd-defragger.yaml
@@ -45,11 +45,8 @@ spec:
                 fi
               done
             image: gcr.io/etcd-development/etcd:v3.3.12
-            imagePullPolicy: IfNotPresent
             name: defragger
             resources: {}
-            terminationMessagePath: /dev/termination-log
-            terminationMessagePolicy: File
             volumeMounts:
             - mountPath: /etc/etcd/pki/client
               name: apiserver-etcd-client-certificate

--- a/api/pkg/resources/test/fixtures/cronjob-bringyourown-1.10.6-etcd-defragger.yaml
+++ b/api/pkg/resources/test/fixtures/cronjob-bringyourown-1.10.6-etcd-defragger.yaml
@@ -45,11 +45,8 @@ spec:
                 fi
               done
             image: gcr.io/etcd-development/etcd:v3.3.12
-            imagePullPolicy: IfNotPresent
             name: defragger
             resources: {}
-            terminationMessagePath: /dev/termination-log
-            terminationMessagePolicy: File
             volumeMounts:
             - mountPath: /etc/etcd/pki/client
               name: apiserver-etcd-client-certificate

--- a/api/pkg/resources/test/fixtures/cronjob-bringyourown-1.11.0-etcd-defragger.yaml
+++ b/api/pkg/resources/test/fixtures/cronjob-bringyourown-1.11.0-etcd-defragger.yaml
@@ -45,11 +45,8 @@ spec:
                 fi
               done
             image: gcr.io/etcd-development/etcd:v3.3.12
-            imagePullPolicy: IfNotPresent
             name: defragger
             resources: {}
-            terminationMessagePath: /dev/termination-log
-            terminationMessagePolicy: File
             volumeMounts:
             - mountPath: /etc/etcd/pki/client
               name: apiserver-etcd-client-certificate

--- a/api/pkg/resources/test/fixtures/cronjob-bringyourown-1.11.1-etcd-defragger.yaml
+++ b/api/pkg/resources/test/fixtures/cronjob-bringyourown-1.11.1-etcd-defragger.yaml
@@ -45,11 +45,8 @@ spec:
                 fi
               done
             image: gcr.io/etcd-development/etcd:v3.3.12
-            imagePullPolicy: IfNotPresent
             name: defragger
             resources: {}
-            terminationMessagePath: /dev/termination-log
-            terminationMessagePolicy: File
             volumeMounts:
             - mountPath: /etc/etcd/pki/client
               name: apiserver-etcd-client-certificate

--- a/api/pkg/resources/test/fixtures/cronjob-bringyourown-1.12.0-etcd-defragger.yaml
+++ b/api/pkg/resources/test/fixtures/cronjob-bringyourown-1.12.0-etcd-defragger.yaml
@@ -45,11 +45,8 @@ spec:
                 fi
               done
             image: gcr.io/etcd-development/etcd:v3.3.12
-            imagePullPolicy: IfNotPresent
             name: defragger
             resources: {}
-            terminationMessagePath: /dev/termination-log
-            terminationMessagePolicy: File
             volumeMounts:
             - mountPath: /etc/etcd/pki/client
               name: apiserver-etcd-client-certificate

--- a/api/pkg/resources/test/fixtures/cronjob-bringyourown-1.13.0-etcd-defragger.yaml
+++ b/api/pkg/resources/test/fixtures/cronjob-bringyourown-1.13.0-etcd-defragger.yaml
@@ -45,11 +45,8 @@ spec:
                 fi
               done
             image: gcr.io/etcd-development/etcd:v3.3.12
-            imagePullPolicy: IfNotPresent
             name: defragger
             resources: {}
-            terminationMessagePath: /dev/termination-log
-            terminationMessagePolicy: File
             volumeMounts:
             - mountPath: /etc/etcd/pki/client
               name: apiserver-etcd-client-certificate

--- a/api/pkg/resources/test/fixtures/cronjob-digitalocean-1.10.0-etcd-defragger.yaml
+++ b/api/pkg/resources/test/fixtures/cronjob-digitalocean-1.10.0-etcd-defragger.yaml
@@ -45,11 +45,8 @@ spec:
                 fi
               done
             image: gcr.io/etcd-development/etcd:v3.3.12
-            imagePullPolicy: IfNotPresent
             name: defragger
             resources: {}
-            terminationMessagePath: /dev/termination-log
-            terminationMessagePolicy: File
             volumeMounts:
             - mountPath: /etc/etcd/pki/client
               name: apiserver-etcd-client-certificate

--- a/api/pkg/resources/test/fixtures/cronjob-digitalocean-1.10.6-etcd-defragger.yaml
+++ b/api/pkg/resources/test/fixtures/cronjob-digitalocean-1.10.6-etcd-defragger.yaml
@@ -45,11 +45,8 @@ spec:
                 fi
               done
             image: gcr.io/etcd-development/etcd:v3.3.12
-            imagePullPolicy: IfNotPresent
             name: defragger
             resources: {}
-            terminationMessagePath: /dev/termination-log
-            terminationMessagePolicy: File
             volumeMounts:
             - mountPath: /etc/etcd/pki/client
               name: apiserver-etcd-client-certificate

--- a/api/pkg/resources/test/fixtures/cronjob-digitalocean-1.11.0-etcd-defragger.yaml
+++ b/api/pkg/resources/test/fixtures/cronjob-digitalocean-1.11.0-etcd-defragger.yaml
@@ -45,11 +45,8 @@ spec:
                 fi
               done
             image: gcr.io/etcd-development/etcd:v3.3.12
-            imagePullPolicy: IfNotPresent
             name: defragger
             resources: {}
-            terminationMessagePath: /dev/termination-log
-            terminationMessagePolicy: File
             volumeMounts:
             - mountPath: /etc/etcd/pki/client
               name: apiserver-etcd-client-certificate

--- a/api/pkg/resources/test/fixtures/cronjob-digitalocean-1.11.1-etcd-defragger.yaml
+++ b/api/pkg/resources/test/fixtures/cronjob-digitalocean-1.11.1-etcd-defragger.yaml
@@ -45,11 +45,8 @@ spec:
                 fi
               done
             image: gcr.io/etcd-development/etcd:v3.3.12
-            imagePullPolicy: IfNotPresent
             name: defragger
             resources: {}
-            terminationMessagePath: /dev/termination-log
-            terminationMessagePolicy: File
             volumeMounts:
             - mountPath: /etc/etcd/pki/client
               name: apiserver-etcd-client-certificate

--- a/api/pkg/resources/test/fixtures/cronjob-digitalocean-1.12.0-etcd-defragger.yaml
+++ b/api/pkg/resources/test/fixtures/cronjob-digitalocean-1.12.0-etcd-defragger.yaml
@@ -45,11 +45,8 @@ spec:
                 fi
               done
             image: gcr.io/etcd-development/etcd:v3.3.12
-            imagePullPolicy: IfNotPresent
             name: defragger
             resources: {}
-            terminationMessagePath: /dev/termination-log
-            terminationMessagePolicy: File
             volumeMounts:
             - mountPath: /etc/etcd/pki/client
               name: apiserver-etcd-client-certificate

--- a/api/pkg/resources/test/fixtures/cronjob-digitalocean-1.13.0-etcd-defragger.yaml
+++ b/api/pkg/resources/test/fixtures/cronjob-digitalocean-1.13.0-etcd-defragger.yaml
@@ -45,11 +45,8 @@ spec:
                 fi
               done
             image: gcr.io/etcd-development/etcd:v3.3.12
-            imagePullPolicy: IfNotPresent
             name: defragger
             resources: {}
-            terminationMessagePath: /dev/termination-log
-            terminationMessagePolicy: File
             volumeMounts:
             - mountPath: /etc/etcd/pki/client
               name: apiserver-etcd-client-certificate

--- a/api/pkg/resources/test/fixtures/cronjob-openstack-1.10.0-etcd-defragger.yaml
+++ b/api/pkg/resources/test/fixtures/cronjob-openstack-1.10.0-etcd-defragger.yaml
@@ -45,11 +45,8 @@ spec:
                 fi
               done
             image: gcr.io/etcd-development/etcd:v3.3.12
-            imagePullPolicy: IfNotPresent
             name: defragger
             resources: {}
-            terminationMessagePath: /dev/termination-log
-            terminationMessagePolicy: File
             volumeMounts:
             - mountPath: /etc/etcd/pki/client
               name: apiserver-etcd-client-certificate

--- a/api/pkg/resources/test/fixtures/cronjob-openstack-1.10.6-etcd-defragger.yaml
+++ b/api/pkg/resources/test/fixtures/cronjob-openstack-1.10.6-etcd-defragger.yaml
@@ -45,11 +45,8 @@ spec:
                 fi
               done
             image: gcr.io/etcd-development/etcd:v3.3.12
-            imagePullPolicy: IfNotPresent
             name: defragger
             resources: {}
-            terminationMessagePath: /dev/termination-log
-            terminationMessagePolicy: File
             volumeMounts:
             - mountPath: /etc/etcd/pki/client
               name: apiserver-etcd-client-certificate

--- a/api/pkg/resources/test/fixtures/cronjob-openstack-1.11.0-etcd-defragger.yaml
+++ b/api/pkg/resources/test/fixtures/cronjob-openstack-1.11.0-etcd-defragger.yaml
@@ -45,11 +45,8 @@ spec:
                 fi
               done
             image: gcr.io/etcd-development/etcd:v3.3.12
-            imagePullPolicy: IfNotPresent
             name: defragger
             resources: {}
-            terminationMessagePath: /dev/termination-log
-            terminationMessagePolicy: File
             volumeMounts:
             - mountPath: /etc/etcd/pki/client
               name: apiserver-etcd-client-certificate

--- a/api/pkg/resources/test/fixtures/cronjob-openstack-1.11.1-etcd-defragger.yaml
+++ b/api/pkg/resources/test/fixtures/cronjob-openstack-1.11.1-etcd-defragger.yaml
@@ -45,11 +45,8 @@ spec:
                 fi
               done
             image: gcr.io/etcd-development/etcd:v3.3.12
-            imagePullPolicy: IfNotPresent
             name: defragger
             resources: {}
-            terminationMessagePath: /dev/termination-log
-            terminationMessagePolicy: File
             volumeMounts:
             - mountPath: /etc/etcd/pki/client
               name: apiserver-etcd-client-certificate

--- a/api/pkg/resources/test/fixtures/cronjob-openstack-1.12.0-etcd-defragger.yaml
+++ b/api/pkg/resources/test/fixtures/cronjob-openstack-1.12.0-etcd-defragger.yaml
@@ -45,11 +45,8 @@ spec:
                 fi
               done
             image: gcr.io/etcd-development/etcd:v3.3.12
-            imagePullPolicy: IfNotPresent
             name: defragger
             resources: {}
-            terminationMessagePath: /dev/termination-log
-            terminationMessagePolicy: File
             volumeMounts:
             - mountPath: /etc/etcd/pki/client
               name: apiserver-etcd-client-certificate

--- a/api/pkg/resources/test/fixtures/cronjob-openstack-1.13.0-etcd-defragger.yaml
+++ b/api/pkg/resources/test/fixtures/cronjob-openstack-1.13.0-etcd-defragger.yaml
@@ -45,11 +45,8 @@ spec:
                 fi
               done
             image: gcr.io/etcd-development/etcd:v3.3.12
-            imagePullPolicy: IfNotPresent
             name: defragger
             resources: {}
-            terminationMessagePath: /dev/termination-log
-            terminationMessagePolicy: File
             volumeMounts:
             - mountPath: /etc/etcd/pki/client
               name: apiserver-etcd-client-certificate

--- a/api/pkg/resources/test/fixtures/cronjob-vsphere-1.10.0-etcd-defragger.yaml
+++ b/api/pkg/resources/test/fixtures/cronjob-vsphere-1.10.0-etcd-defragger.yaml
@@ -45,11 +45,8 @@ spec:
                 fi
               done
             image: gcr.io/etcd-development/etcd:v3.3.12
-            imagePullPolicy: IfNotPresent
             name: defragger
             resources: {}
-            terminationMessagePath: /dev/termination-log
-            terminationMessagePolicy: File
             volumeMounts:
             - mountPath: /etc/etcd/pki/client
               name: apiserver-etcd-client-certificate

--- a/api/pkg/resources/test/fixtures/cronjob-vsphere-1.10.6-etcd-defragger.yaml
+++ b/api/pkg/resources/test/fixtures/cronjob-vsphere-1.10.6-etcd-defragger.yaml
@@ -45,11 +45,8 @@ spec:
                 fi
               done
             image: gcr.io/etcd-development/etcd:v3.3.12
-            imagePullPolicy: IfNotPresent
             name: defragger
             resources: {}
-            terminationMessagePath: /dev/termination-log
-            terminationMessagePolicy: File
             volumeMounts:
             - mountPath: /etc/etcd/pki/client
               name: apiserver-etcd-client-certificate

--- a/api/pkg/resources/test/fixtures/cronjob-vsphere-1.11.0-etcd-defragger.yaml
+++ b/api/pkg/resources/test/fixtures/cronjob-vsphere-1.11.0-etcd-defragger.yaml
@@ -45,11 +45,8 @@ spec:
                 fi
               done
             image: gcr.io/etcd-development/etcd:v3.3.12
-            imagePullPolicy: IfNotPresent
             name: defragger
             resources: {}
-            terminationMessagePath: /dev/termination-log
-            terminationMessagePolicy: File
             volumeMounts:
             - mountPath: /etc/etcd/pki/client
               name: apiserver-etcd-client-certificate

--- a/api/pkg/resources/test/fixtures/cronjob-vsphere-1.11.1-etcd-defragger.yaml
+++ b/api/pkg/resources/test/fixtures/cronjob-vsphere-1.11.1-etcd-defragger.yaml
@@ -45,11 +45,8 @@ spec:
                 fi
               done
             image: gcr.io/etcd-development/etcd:v3.3.12
-            imagePullPolicy: IfNotPresent
             name: defragger
             resources: {}
-            terminationMessagePath: /dev/termination-log
-            terminationMessagePolicy: File
             volumeMounts:
             - mountPath: /etc/etcd/pki/client
               name: apiserver-etcd-client-certificate

--- a/api/pkg/resources/test/fixtures/cronjob-vsphere-1.12.0-etcd-defragger.yaml
+++ b/api/pkg/resources/test/fixtures/cronjob-vsphere-1.12.0-etcd-defragger.yaml
@@ -45,11 +45,8 @@ spec:
                 fi
               done
             image: gcr.io/etcd-development/etcd:v3.3.12
-            imagePullPolicy: IfNotPresent
             name: defragger
             resources: {}
-            terminationMessagePath: /dev/termination-log
-            terminationMessagePolicy: File
             volumeMounts:
             - mountPath: /etc/etcd/pki/client
               name: apiserver-etcd-client-certificate

--- a/api/pkg/resources/test/fixtures/cronjob-vsphere-1.13.0-etcd-defragger.yaml
+++ b/api/pkg/resources/test/fixtures/cronjob-vsphere-1.13.0-etcd-defragger.yaml
@@ -45,11 +45,8 @@ spec:
                 fi
               done
             image: gcr.io/etcd-development/etcd:v3.3.12
-            imagePullPolicy: IfNotPresent
             name: defragger
             resources: {}
-            terminationMessagePath: /dev/termination-log
-            terminationMessagePolicy: File
             volumeMounts:
             - mountPath: /etc/etcd/pki/client
               name: apiserver-etcd-client-certificate

--- a/api/pkg/resources/test/fixtures/deployment-aws-1.10.0-apiserver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-aws-1.10.0-apiserver.yaml
@@ -103,7 +103,6 @@ spec:
             memory: 5Mi
         securityContext:
           privileged: true
-          procMount: Default
         volumeMounts:
         - mountPath: /etc/openvpn/pki/client
           name: openvpn-client-certificates
@@ -121,7 +120,6 @@ spec:
         command:
         - /usr/local/bin/kubeletdnat-controller
         image: 'quay.io/kubermatic/api:'
-        imagePullPolicy: IfNotPresent
         name: dnat-controller
         resources:
           limits:

--- a/api/pkg/resources/test/fixtures/deployment-aws-1.10.0-controller-manager.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-aws-1.10.0-controller-manager.yaml
@@ -96,7 +96,6 @@ spec:
             memory: 5Mi
         securityContext:
           privileged: true
-          procMount: Default
         volumeMounts:
         - mountPath: /etc/openvpn/pki/client
           name: openvpn-client-certificates

--- a/api/pkg/resources/test/fixtures/deployment-aws-1.10.0-dns-resolver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-aws-1.10.0-dns-resolver.yaml
@@ -90,7 +90,6 @@ spec:
             memory: 5Mi
         securityContext:
           privileged: true
-          procMount: Default
         volumeMounts:
         - mountPath: /etc/openvpn/pki/client
           name: openvpn-client-certificates

--- a/api/pkg/resources/test/fixtures/deployment-aws-1.10.0-metrics-server.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-aws-1.10.0-metrics-server.yaml
@@ -119,7 +119,6 @@ spec:
             memory: 5Mi
         securityContext:
           privileged: true
-          procMount: Default
         volumeMounts:
         - mountPath: /etc/openvpn/pki/client
           name: openvpn-client-certificates
@@ -135,7 +134,6 @@ spec:
         command:
         - /usr/local/bin/kubeletdnat-controller
         image: 'quay.io/kubermatic/api:'
-        imagePullPolicy: IfNotPresent
         name: dnat-controller
         resources:
           limits:

--- a/api/pkg/resources/test/fixtures/deployment-aws-1.10.0-scheduler.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-aws-1.10.0-scheduler.yaml
@@ -94,7 +94,6 @@ spec:
             memory: 5Mi
         securityContext:
           privileged: true
-          procMount: Default
         volumeMounts:
         - mountPath: /etc/openvpn/pki/client
           name: openvpn-client-certificates

--- a/api/pkg/resources/test/fixtures/deployment-aws-1.10.6-apiserver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-aws-1.10.6-apiserver.yaml
@@ -103,7 +103,6 @@ spec:
             memory: 5Mi
         securityContext:
           privileged: true
-          procMount: Default
         volumeMounts:
         - mountPath: /etc/openvpn/pki/client
           name: openvpn-client-certificates
@@ -121,7 +120,6 @@ spec:
         command:
         - /usr/local/bin/kubeletdnat-controller
         image: 'quay.io/kubermatic/api:'
-        imagePullPolicy: IfNotPresent
         name: dnat-controller
         resources:
           limits:

--- a/api/pkg/resources/test/fixtures/deployment-aws-1.10.6-controller-manager.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-aws-1.10.6-controller-manager.yaml
@@ -96,7 +96,6 @@ spec:
             memory: 5Mi
         securityContext:
           privileged: true
-          procMount: Default
         volumeMounts:
         - mountPath: /etc/openvpn/pki/client
           name: openvpn-client-certificates

--- a/api/pkg/resources/test/fixtures/deployment-aws-1.10.6-dns-resolver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-aws-1.10.6-dns-resolver.yaml
@@ -90,7 +90,6 @@ spec:
             memory: 5Mi
         securityContext:
           privileged: true
-          procMount: Default
         volumeMounts:
         - mountPath: /etc/openvpn/pki/client
           name: openvpn-client-certificates

--- a/api/pkg/resources/test/fixtures/deployment-aws-1.10.6-metrics-server.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-aws-1.10.6-metrics-server.yaml
@@ -119,7 +119,6 @@ spec:
             memory: 5Mi
         securityContext:
           privileged: true
-          procMount: Default
         volumeMounts:
         - mountPath: /etc/openvpn/pki/client
           name: openvpn-client-certificates
@@ -135,7 +134,6 @@ spec:
         command:
         - /usr/local/bin/kubeletdnat-controller
         image: 'quay.io/kubermatic/api:'
-        imagePullPolicy: IfNotPresent
         name: dnat-controller
         resources:
           limits:

--- a/api/pkg/resources/test/fixtures/deployment-aws-1.10.6-scheduler.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-aws-1.10.6-scheduler.yaml
@@ -94,7 +94,6 @@ spec:
             memory: 5Mi
         securityContext:
           privileged: true
-          procMount: Default
         volumeMounts:
         - mountPath: /etc/openvpn/pki/client
           name: openvpn-client-certificates

--- a/api/pkg/resources/test/fixtures/deployment-aws-1.11.0-apiserver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-aws-1.11.0-apiserver.yaml
@@ -103,7 +103,6 @@ spec:
             memory: 5Mi
         securityContext:
           privileged: true
-          procMount: Default
         volumeMounts:
         - mountPath: /etc/openvpn/pki/client
           name: openvpn-client-certificates
@@ -121,7 +120,6 @@ spec:
         command:
         - /usr/local/bin/kubeletdnat-controller
         image: 'quay.io/kubermatic/api:'
-        imagePullPolicy: IfNotPresent
         name: dnat-controller
         resources:
           limits:

--- a/api/pkg/resources/test/fixtures/deployment-aws-1.11.0-controller-manager.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-aws-1.11.0-controller-manager.yaml
@@ -96,7 +96,6 @@ spec:
             memory: 5Mi
         securityContext:
           privileged: true
-          procMount: Default
         volumeMounts:
         - mountPath: /etc/openvpn/pki/client
           name: openvpn-client-certificates

--- a/api/pkg/resources/test/fixtures/deployment-aws-1.11.0-dns-resolver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-aws-1.11.0-dns-resolver.yaml
@@ -90,7 +90,6 @@ spec:
             memory: 5Mi
         securityContext:
           privileged: true
-          procMount: Default
         volumeMounts:
         - mountPath: /etc/openvpn/pki/client
           name: openvpn-client-certificates

--- a/api/pkg/resources/test/fixtures/deployment-aws-1.11.0-metrics-server.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-aws-1.11.0-metrics-server.yaml
@@ -119,7 +119,6 @@ spec:
             memory: 5Mi
         securityContext:
           privileged: true
-          procMount: Default
         volumeMounts:
         - mountPath: /etc/openvpn/pki/client
           name: openvpn-client-certificates
@@ -135,7 +134,6 @@ spec:
         command:
         - /usr/local/bin/kubeletdnat-controller
         image: 'quay.io/kubermatic/api:'
-        imagePullPolicy: IfNotPresent
         name: dnat-controller
         resources:
           limits:

--- a/api/pkg/resources/test/fixtures/deployment-aws-1.11.0-scheduler.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-aws-1.11.0-scheduler.yaml
@@ -94,7 +94,6 @@ spec:
             memory: 5Mi
         securityContext:
           privileged: true
-          procMount: Default
         volumeMounts:
         - mountPath: /etc/openvpn/pki/client
           name: openvpn-client-certificates

--- a/api/pkg/resources/test/fixtures/deployment-aws-1.11.1-apiserver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-aws-1.11.1-apiserver.yaml
@@ -103,7 +103,6 @@ spec:
             memory: 5Mi
         securityContext:
           privileged: true
-          procMount: Default
         volumeMounts:
         - mountPath: /etc/openvpn/pki/client
           name: openvpn-client-certificates
@@ -121,7 +120,6 @@ spec:
         command:
         - /usr/local/bin/kubeletdnat-controller
         image: 'quay.io/kubermatic/api:'
-        imagePullPolicy: IfNotPresent
         name: dnat-controller
         resources:
           limits:

--- a/api/pkg/resources/test/fixtures/deployment-aws-1.11.1-controller-manager.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-aws-1.11.1-controller-manager.yaml
@@ -96,7 +96,6 @@ spec:
             memory: 5Mi
         securityContext:
           privileged: true
-          procMount: Default
         volumeMounts:
         - mountPath: /etc/openvpn/pki/client
           name: openvpn-client-certificates

--- a/api/pkg/resources/test/fixtures/deployment-aws-1.11.1-dns-resolver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-aws-1.11.1-dns-resolver.yaml
@@ -90,7 +90,6 @@ spec:
             memory: 5Mi
         securityContext:
           privileged: true
-          procMount: Default
         volumeMounts:
         - mountPath: /etc/openvpn/pki/client
           name: openvpn-client-certificates

--- a/api/pkg/resources/test/fixtures/deployment-aws-1.11.1-metrics-server.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-aws-1.11.1-metrics-server.yaml
@@ -119,7 +119,6 @@ spec:
             memory: 5Mi
         securityContext:
           privileged: true
-          procMount: Default
         volumeMounts:
         - mountPath: /etc/openvpn/pki/client
           name: openvpn-client-certificates
@@ -135,7 +134,6 @@ spec:
         command:
         - /usr/local/bin/kubeletdnat-controller
         image: 'quay.io/kubermatic/api:'
-        imagePullPolicy: IfNotPresent
         name: dnat-controller
         resources:
           limits:

--- a/api/pkg/resources/test/fixtures/deployment-aws-1.11.1-scheduler.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-aws-1.11.1-scheduler.yaml
@@ -94,7 +94,6 @@ spec:
             memory: 5Mi
         securityContext:
           privileged: true
-          procMount: Default
         volumeMounts:
         - mountPath: /etc/openvpn/pki/client
           name: openvpn-client-certificates

--- a/api/pkg/resources/test/fixtures/deployment-aws-1.12.0-apiserver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-aws-1.12.0-apiserver.yaml
@@ -103,7 +103,6 @@ spec:
             memory: 5Mi
         securityContext:
           privileged: true
-          procMount: Default
         volumeMounts:
         - mountPath: /etc/openvpn/pki/client
           name: openvpn-client-certificates
@@ -121,7 +120,6 @@ spec:
         command:
         - /usr/local/bin/kubeletdnat-controller
         image: 'quay.io/kubermatic/api:'
-        imagePullPolicy: IfNotPresent
         name: dnat-controller
         resources:
           limits:

--- a/api/pkg/resources/test/fixtures/deployment-aws-1.12.0-controller-manager.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-aws-1.12.0-controller-manager.yaml
@@ -96,7 +96,6 @@ spec:
             memory: 5Mi
         securityContext:
           privileged: true
-          procMount: Default
         volumeMounts:
         - mountPath: /etc/openvpn/pki/client
           name: openvpn-client-certificates

--- a/api/pkg/resources/test/fixtures/deployment-aws-1.12.0-dns-resolver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-aws-1.12.0-dns-resolver.yaml
@@ -90,7 +90,6 @@ spec:
             memory: 5Mi
         securityContext:
           privileged: true
-          procMount: Default
         volumeMounts:
         - mountPath: /etc/openvpn/pki/client
           name: openvpn-client-certificates

--- a/api/pkg/resources/test/fixtures/deployment-aws-1.12.0-metrics-server.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-aws-1.12.0-metrics-server.yaml
@@ -119,7 +119,6 @@ spec:
             memory: 5Mi
         securityContext:
           privileged: true
-          procMount: Default
         volumeMounts:
         - mountPath: /etc/openvpn/pki/client
           name: openvpn-client-certificates
@@ -135,7 +134,6 @@ spec:
         command:
         - /usr/local/bin/kubeletdnat-controller
         image: 'quay.io/kubermatic/api:'
-        imagePullPolicy: IfNotPresent
         name: dnat-controller
         resources:
           limits:

--- a/api/pkg/resources/test/fixtures/deployment-aws-1.12.0-scheduler.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-aws-1.12.0-scheduler.yaml
@@ -94,7 +94,6 @@ spec:
             memory: 5Mi
         securityContext:
           privileged: true
-          procMount: Default
         volumeMounts:
         - mountPath: /etc/openvpn/pki/client
           name: openvpn-client-certificates

--- a/api/pkg/resources/test/fixtures/deployment-aws-1.13.0-apiserver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-aws-1.13.0-apiserver.yaml
@@ -103,7 +103,6 @@ spec:
             memory: 5Mi
         securityContext:
           privileged: true
-          procMount: Default
         volumeMounts:
         - mountPath: /etc/openvpn/pki/client
           name: openvpn-client-certificates
@@ -121,7 +120,6 @@ spec:
         command:
         - /usr/local/bin/kubeletdnat-controller
         image: 'quay.io/kubermatic/api:'
-        imagePullPolicy: IfNotPresent
         name: dnat-controller
         resources:
           limits:

--- a/api/pkg/resources/test/fixtures/deployment-aws-1.13.0-controller-manager.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-aws-1.13.0-controller-manager.yaml
@@ -96,7 +96,6 @@ spec:
             memory: 5Mi
         securityContext:
           privileged: true
-          procMount: Default
         volumeMounts:
         - mountPath: /etc/openvpn/pki/client
           name: openvpn-client-certificates

--- a/api/pkg/resources/test/fixtures/deployment-aws-1.13.0-dns-resolver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-aws-1.13.0-dns-resolver.yaml
@@ -90,7 +90,6 @@ spec:
             memory: 5Mi
         securityContext:
           privileged: true
-          procMount: Default
         volumeMounts:
         - mountPath: /etc/openvpn/pki/client
           name: openvpn-client-certificates

--- a/api/pkg/resources/test/fixtures/deployment-aws-1.13.0-metrics-server.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-aws-1.13.0-metrics-server.yaml
@@ -119,7 +119,6 @@ spec:
             memory: 5Mi
         securityContext:
           privileged: true
-          procMount: Default
         volumeMounts:
         - mountPath: /etc/openvpn/pki/client
           name: openvpn-client-certificates
@@ -135,7 +134,6 @@ spec:
         command:
         - /usr/local/bin/kubeletdnat-controller
         image: 'quay.io/kubermatic/api:'
-        imagePullPolicy: IfNotPresent
         name: dnat-controller
         resources:
           limits:

--- a/api/pkg/resources/test/fixtures/deployment-aws-1.13.0-scheduler.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-aws-1.13.0-scheduler.yaml
@@ -94,7 +94,6 @@ spec:
             memory: 5Mi
         securityContext:
           privileged: true
-          procMount: Default
         volumeMounts:
         - mountPath: /etc/openvpn/pki/client
           name: openvpn-client-certificates

--- a/api/pkg/resources/test/fixtures/deployment-azure-1.10.0-apiserver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-azure-1.10.0-apiserver.yaml
@@ -103,7 +103,6 @@ spec:
             memory: 5Mi
         securityContext:
           privileged: true
-          procMount: Default
         volumeMounts:
         - mountPath: /etc/openvpn/pki/client
           name: openvpn-client-certificates
@@ -121,7 +120,6 @@ spec:
         command:
         - /usr/local/bin/kubeletdnat-controller
         image: 'quay.io/kubermatic/api:'
-        imagePullPolicy: IfNotPresent
         name: dnat-controller
         resources:
           limits:

--- a/api/pkg/resources/test/fixtures/deployment-azure-1.10.0-controller-manager.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-azure-1.10.0-controller-manager.yaml
@@ -96,7 +96,6 @@ spec:
             memory: 5Mi
         securityContext:
           privileged: true
-          procMount: Default
         volumeMounts:
         - mountPath: /etc/openvpn/pki/client
           name: openvpn-client-certificates

--- a/api/pkg/resources/test/fixtures/deployment-azure-1.10.0-dns-resolver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-azure-1.10.0-dns-resolver.yaml
@@ -90,7 +90,6 @@ spec:
             memory: 5Mi
         securityContext:
           privileged: true
-          procMount: Default
         volumeMounts:
         - mountPath: /etc/openvpn/pki/client
           name: openvpn-client-certificates

--- a/api/pkg/resources/test/fixtures/deployment-azure-1.10.0-metrics-server.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-azure-1.10.0-metrics-server.yaml
@@ -119,7 +119,6 @@ spec:
             memory: 5Mi
         securityContext:
           privileged: true
-          procMount: Default
         volumeMounts:
         - mountPath: /etc/openvpn/pki/client
           name: openvpn-client-certificates
@@ -135,7 +134,6 @@ spec:
         command:
         - /usr/local/bin/kubeletdnat-controller
         image: 'quay.io/kubermatic/api:'
-        imagePullPolicy: IfNotPresent
         name: dnat-controller
         resources:
           limits:

--- a/api/pkg/resources/test/fixtures/deployment-azure-1.10.0-scheduler.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-azure-1.10.0-scheduler.yaml
@@ -94,7 +94,6 @@ spec:
             memory: 5Mi
         securityContext:
           privileged: true
-          procMount: Default
         volumeMounts:
         - mountPath: /etc/openvpn/pki/client
           name: openvpn-client-certificates

--- a/api/pkg/resources/test/fixtures/deployment-azure-1.10.6-apiserver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-azure-1.10.6-apiserver.yaml
@@ -103,7 +103,6 @@ spec:
             memory: 5Mi
         securityContext:
           privileged: true
-          procMount: Default
         volumeMounts:
         - mountPath: /etc/openvpn/pki/client
           name: openvpn-client-certificates
@@ -121,7 +120,6 @@ spec:
         command:
         - /usr/local/bin/kubeletdnat-controller
         image: 'quay.io/kubermatic/api:'
-        imagePullPolicy: IfNotPresent
         name: dnat-controller
         resources:
           limits:

--- a/api/pkg/resources/test/fixtures/deployment-azure-1.10.6-controller-manager.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-azure-1.10.6-controller-manager.yaml
@@ -96,7 +96,6 @@ spec:
             memory: 5Mi
         securityContext:
           privileged: true
-          procMount: Default
         volumeMounts:
         - mountPath: /etc/openvpn/pki/client
           name: openvpn-client-certificates

--- a/api/pkg/resources/test/fixtures/deployment-azure-1.10.6-dns-resolver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-azure-1.10.6-dns-resolver.yaml
@@ -90,7 +90,6 @@ spec:
             memory: 5Mi
         securityContext:
           privileged: true
-          procMount: Default
         volumeMounts:
         - mountPath: /etc/openvpn/pki/client
           name: openvpn-client-certificates

--- a/api/pkg/resources/test/fixtures/deployment-azure-1.10.6-metrics-server.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-azure-1.10.6-metrics-server.yaml
@@ -119,7 +119,6 @@ spec:
             memory: 5Mi
         securityContext:
           privileged: true
-          procMount: Default
         volumeMounts:
         - mountPath: /etc/openvpn/pki/client
           name: openvpn-client-certificates
@@ -135,7 +134,6 @@ spec:
         command:
         - /usr/local/bin/kubeletdnat-controller
         image: 'quay.io/kubermatic/api:'
-        imagePullPolicy: IfNotPresent
         name: dnat-controller
         resources:
           limits:

--- a/api/pkg/resources/test/fixtures/deployment-azure-1.10.6-scheduler.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-azure-1.10.6-scheduler.yaml
@@ -94,7 +94,6 @@ spec:
             memory: 5Mi
         securityContext:
           privileged: true
-          procMount: Default
         volumeMounts:
         - mountPath: /etc/openvpn/pki/client
           name: openvpn-client-certificates

--- a/api/pkg/resources/test/fixtures/deployment-azure-1.11.0-apiserver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-azure-1.11.0-apiserver.yaml
@@ -103,7 +103,6 @@ spec:
             memory: 5Mi
         securityContext:
           privileged: true
-          procMount: Default
         volumeMounts:
         - mountPath: /etc/openvpn/pki/client
           name: openvpn-client-certificates
@@ -121,7 +120,6 @@ spec:
         command:
         - /usr/local/bin/kubeletdnat-controller
         image: 'quay.io/kubermatic/api:'
-        imagePullPolicy: IfNotPresent
         name: dnat-controller
         resources:
           limits:

--- a/api/pkg/resources/test/fixtures/deployment-azure-1.11.0-controller-manager.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-azure-1.11.0-controller-manager.yaml
@@ -96,7 +96,6 @@ spec:
             memory: 5Mi
         securityContext:
           privileged: true
-          procMount: Default
         volumeMounts:
         - mountPath: /etc/openvpn/pki/client
           name: openvpn-client-certificates

--- a/api/pkg/resources/test/fixtures/deployment-azure-1.11.0-dns-resolver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-azure-1.11.0-dns-resolver.yaml
@@ -90,7 +90,6 @@ spec:
             memory: 5Mi
         securityContext:
           privileged: true
-          procMount: Default
         volumeMounts:
         - mountPath: /etc/openvpn/pki/client
           name: openvpn-client-certificates

--- a/api/pkg/resources/test/fixtures/deployment-azure-1.11.0-metrics-server.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-azure-1.11.0-metrics-server.yaml
@@ -119,7 +119,6 @@ spec:
             memory: 5Mi
         securityContext:
           privileged: true
-          procMount: Default
         volumeMounts:
         - mountPath: /etc/openvpn/pki/client
           name: openvpn-client-certificates
@@ -135,7 +134,6 @@ spec:
         command:
         - /usr/local/bin/kubeletdnat-controller
         image: 'quay.io/kubermatic/api:'
-        imagePullPolicy: IfNotPresent
         name: dnat-controller
         resources:
           limits:

--- a/api/pkg/resources/test/fixtures/deployment-azure-1.11.0-scheduler.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-azure-1.11.0-scheduler.yaml
@@ -94,7 +94,6 @@ spec:
             memory: 5Mi
         securityContext:
           privileged: true
-          procMount: Default
         volumeMounts:
         - mountPath: /etc/openvpn/pki/client
           name: openvpn-client-certificates

--- a/api/pkg/resources/test/fixtures/deployment-azure-1.11.1-apiserver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-azure-1.11.1-apiserver.yaml
@@ -103,7 +103,6 @@ spec:
             memory: 5Mi
         securityContext:
           privileged: true
-          procMount: Default
         volumeMounts:
         - mountPath: /etc/openvpn/pki/client
           name: openvpn-client-certificates
@@ -121,7 +120,6 @@ spec:
         command:
         - /usr/local/bin/kubeletdnat-controller
         image: 'quay.io/kubermatic/api:'
-        imagePullPolicy: IfNotPresent
         name: dnat-controller
         resources:
           limits:

--- a/api/pkg/resources/test/fixtures/deployment-azure-1.11.1-controller-manager.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-azure-1.11.1-controller-manager.yaml
@@ -96,7 +96,6 @@ spec:
             memory: 5Mi
         securityContext:
           privileged: true
-          procMount: Default
         volumeMounts:
         - mountPath: /etc/openvpn/pki/client
           name: openvpn-client-certificates

--- a/api/pkg/resources/test/fixtures/deployment-azure-1.11.1-dns-resolver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-azure-1.11.1-dns-resolver.yaml
@@ -90,7 +90,6 @@ spec:
             memory: 5Mi
         securityContext:
           privileged: true
-          procMount: Default
         volumeMounts:
         - mountPath: /etc/openvpn/pki/client
           name: openvpn-client-certificates

--- a/api/pkg/resources/test/fixtures/deployment-azure-1.11.1-metrics-server.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-azure-1.11.1-metrics-server.yaml
@@ -119,7 +119,6 @@ spec:
             memory: 5Mi
         securityContext:
           privileged: true
-          procMount: Default
         volumeMounts:
         - mountPath: /etc/openvpn/pki/client
           name: openvpn-client-certificates
@@ -135,7 +134,6 @@ spec:
         command:
         - /usr/local/bin/kubeletdnat-controller
         image: 'quay.io/kubermatic/api:'
-        imagePullPolicy: IfNotPresent
         name: dnat-controller
         resources:
           limits:

--- a/api/pkg/resources/test/fixtures/deployment-azure-1.11.1-scheduler.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-azure-1.11.1-scheduler.yaml
@@ -94,7 +94,6 @@ spec:
             memory: 5Mi
         securityContext:
           privileged: true
-          procMount: Default
         volumeMounts:
         - mountPath: /etc/openvpn/pki/client
           name: openvpn-client-certificates

--- a/api/pkg/resources/test/fixtures/deployment-azure-1.12.0-apiserver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-azure-1.12.0-apiserver.yaml
@@ -103,7 +103,6 @@ spec:
             memory: 5Mi
         securityContext:
           privileged: true
-          procMount: Default
         volumeMounts:
         - mountPath: /etc/openvpn/pki/client
           name: openvpn-client-certificates
@@ -121,7 +120,6 @@ spec:
         command:
         - /usr/local/bin/kubeletdnat-controller
         image: 'quay.io/kubermatic/api:'
-        imagePullPolicy: IfNotPresent
         name: dnat-controller
         resources:
           limits:

--- a/api/pkg/resources/test/fixtures/deployment-azure-1.12.0-controller-manager.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-azure-1.12.0-controller-manager.yaml
@@ -96,7 +96,6 @@ spec:
             memory: 5Mi
         securityContext:
           privileged: true
-          procMount: Default
         volumeMounts:
         - mountPath: /etc/openvpn/pki/client
           name: openvpn-client-certificates

--- a/api/pkg/resources/test/fixtures/deployment-azure-1.12.0-dns-resolver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-azure-1.12.0-dns-resolver.yaml
@@ -90,7 +90,6 @@ spec:
             memory: 5Mi
         securityContext:
           privileged: true
-          procMount: Default
         volumeMounts:
         - mountPath: /etc/openvpn/pki/client
           name: openvpn-client-certificates

--- a/api/pkg/resources/test/fixtures/deployment-azure-1.12.0-metrics-server.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-azure-1.12.0-metrics-server.yaml
@@ -119,7 +119,6 @@ spec:
             memory: 5Mi
         securityContext:
           privileged: true
-          procMount: Default
         volumeMounts:
         - mountPath: /etc/openvpn/pki/client
           name: openvpn-client-certificates
@@ -135,7 +134,6 @@ spec:
         command:
         - /usr/local/bin/kubeletdnat-controller
         image: 'quay.io/kubermatic/api:'
-        imagePullPolicy: IfNotPresent
         name: dnat-controller
         resources:
           limits:

--- a/api/pkg/resources/test/fixtures/deployment-azure-1.12.0-scheduler.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-azure-1.12.0-scheduler.yaml
@@ -94,7 +94,6 @@ spec:
             memory: 5Mi
         securityContext:
           privileged: true
-          procMount: Default
         volumeMounts:
         - mountPath: /etc/openvpn/pki/client
           name: openvpn-client-certificates

--- a/api/pkg/resources/test/fixtures/deployment-azure-1.13.0-apiserver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-azure-1.13.0-apiserver.yaml
@@ -103,7 +103,6 @@ spec:
             memory: 5Mi
         securityContext:
           privileged: true
-          procMount: Default
         volumeMounts:
         - mountPath: /etc/openvpn/pki/client
           name: openvpn-client-certificates
@@ -121,7 +120,6 @@ spec:
         command:
         - /usr/local/bin/kubeletdnat-controller
         image: 'quay.io/kubermatic/api:'
-        imagePullPolicy: IfNotPresent
         name: dnat-controller
         resources:
           limits:

--- a/api/pkg/resources/test/fixtures/deployment-azure-1.13.0-controller-manager.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-azure-1.13.0-controller-manager.yaml
@@ -96,7 +96,6 @@ spec:
             memory: 5Mi
         securityContext:
           privileged: true
-          procMount: Default
         volumeMounts:
         - mountPath: /etc/openvpn/pki/client
           name: openvpn-client-certificates

--- a/api/pkg/resources/test/fixtures/deployment-azure-1.13.0-dns-resolver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-azure-1.13.0-dns-resolver.yaml
@@ -90,7 +90,6 @@ spec:
             memory: 5Mi
         securityContext:
           privileged: true
-          procMount: Default
         volumeMounts:
         - mountPath: /etc/openvpn/pki/client
           name: openvpn-client-certificates

--- a/api/pkg/resources/test/fixtures/deployment-azure-1.13.0-metrics-server.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-azure-1.13.0-metrics-server.yaml
@@ -119,7 +119,6 @@ spec:
             memory: 5Mi
         securityContext:
           privileged: true
-          procMount: Default
         volumeMounts:
         - mountPath: /etc/openvpn/pki/client
           name: openvpn-client-certificates
@@ -135,7 +134,6 @@ spec:
         command:
         - /usr/local/bin/kubeletdnat-controller
         image: 'quay.io/kubermatic/api:'
-        imagePullPolicy: IfNotPresent
         name: dnat-controller
         resources:
           limits:

--- a/api/pkg/resources/test/fixtures/deployment-azure-1.13.0-scheduler.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-azure-1.13.0-scheduler.yaml
@@ -94,7 +94,6 @@ spec:
             memory: 5Mi
         securityContext:
           privileged: true
-          procMount: Default
         volumeMounts:
         - mountPath: /etc/openvpn/pki/client
           name: openvpn-client-certificates

--- a/api/pkg/resources/test/fixtures/deployment-bringyourown-1.10.0-apiserver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-bringyourown-1.10.0-apiserver.yaml
@@ -103,7 +103,6 @@ spec:
             memory: 5Mi
         securityContext:
           privileged: true
-          procMount: Default
         volumeMounts:
         - mountPath: /etc/openvpn/pki/client
           name: openvpn-client-certificates
@@ -121,7 +120,6 @@ spec:
         command:
         - /usr/local/bin/kubeletdnat-controller
         image: 'quay.io/kubermatic/api:'
-        imagePullPolicy: IfNotPresent
         name: dnat-controller
         resources:
           limits:

--- a/api/pkg/resources/test/fixtures/deployment-bringyourown-1.10.0-controller-manager.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-bringyourown-1.10.0-controller-manager.yaml
@@ -96,7 +96,6 @@ spec:
             memory: 5Mi
         securityContext:
           privileged: true
-          procMount: Default
         volumeMounts:
         - mountPath: /etc/openvpn/pki/client
           name: openvpn-client-certificates

--- a/api/pkg/resources/test/fixtures/deployment-bringyourown-1.10.0-dns-resolver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-bringyourown-1.10.0-dns-resolver.yaml
@@ -90,7 +90,6 @@ spec:
             memory: 5Mi
         securityContext:
           privileged: true
-          procMount: Default
         volumeMounts:
         - mountPath: /etc/openvpn/pki/client
           name: openvpn-client-certificates

--- a/api/pkg/resources/test/fixtures/deployment-bringyourown-1.10.0-metrics-server.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-bringyourown-1.10.0-metrics-server.yaml
@@ -119,7 +119,6 @@ spec:
             memory: 5Mi
         securityContext:
           privileged: true
-          procMount: Default
         volumeMounts:
         - mountPath: /etc/openvpn/pki/client
           name: openvpn-client-certificates
@@ -135,7 +134,6 @@ spec:
         command:
         - /usr/local/bin/kubeletdnat-controller
         image: 'quay.io/kubermatic/api:'
-        imagePullPolicy: IfNotPresent
         name: dnat-controller
         resources:
           limits:

--- a/api/pkg/resources/test/fixtures/deployment-bringyourown-1.10.0-scheduler.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-bringyourown-1.10.0-scheduler.yaml
@@ -94,7 +94,6 @@ spec:
             memory: 5Mi
         securityContext:
           privileged: true
-          procMount: Default
         volumeMounts:
         - mountPath: /etc/openvpn/pki/client
           name: openvpn-client-certificates

--- a/api/pkg/resources/test/fixtures/deployment-bringyourown-1.10.6-apiserver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-bringyourown-1.10.6-apiserver.yaml
@@ -103,7 +103,6 @@ spec:
             memory: 5Mi
         securityContext:
           privileged: true
-          procMount: Default
         volumeMounts:
         - mountPath: /etc/openvpn/pki/client
           name: openvpn-client-certificates
@@ -121,7 +120,6 @@ spec:
         command:
         - /usr/local/bin/kubeletdnat-controller
         image: 'quay.io/kubermatic/api:'
-        imagePullPolicy: IfNotPresent
         name: dnat-controller
         resources:
           limits:

--- a/api/pkg/resources/test/fixtures/deployment-bringyourown-1.10.6-controller-manager.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-bringyourown-1.10.6-controller-manager.yaml
@@ -96,7 +96,6 @@ spec:
             memory: 5Mi
         securityContext:
           privileged: true
-          procMount: Default
         volumeMounts:
         - mountPath: /etc/openvpn/pki/client
           name: openvpn-client-certificates

--- a/api/pkg/resources/test/fixtures/deployment-bringyourown-1.10.6-dns-resolver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-bringyourown-1.10.6-dns-resolver.yaml
@@ -90,7 +90,6 @@ spec:
             memory: 5Mi
         securityContext:
           privileged: true
-          procMount: Default
         volumeMounts:
         - mountPath: /etc/openvpn/pki/client
           name: openvpn-client-certificates

--- a/api/pkg/resources/test/fixtures/deployment-bringyourown-1.10.6-metrics-server.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-bringyourown-1.10.6-metrics-server.yaml
@@ -119,7 +119,6 @@ spec:
             memory: 5Mi
         securityContext:
           privileged: true
-          procMount: Default
         volumeMounts:
         - mountPath: /etc/openvpn/pki/client
           name: openvpn-client-certificates
@@ -135,7 +134,6 @@ spec:
         command:
         - /usr/local/bin/kubeletdnat-controller
         image: 'quay.io/kubermatic/api:'
-        imagePullPolicy: IfNotPresent
         name: dnat-controller
         resources:
           limits:

--- a/api/pkg/resources/test/fixtures/deployment-bringyourown-1.10.6-scheduler.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-bringyourown-1.10.6-scheduler.yaml
@@ -94,7 +94,6 @@ spec:
             memory: 5Mi
         securityContext:
           privileged: true
-          procMount: Default
         volumeMounts:
         - mountPath: /etc/openvpn/pki/client
           name: openvpn-client-certificates

--- a/api/pkg/resources/test/fixtures/deployment-bringyourown-1.11.0-apiserver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-bringyourown-1.11.0-apiserver.yaml
@@ -103,7 +103,6 @@ spec:
             memory: 5Mi
         securityContext:
           privileged: true
-          procMount: Default
         volumeMounts:
         - mountPath: /etc/openvpn/pki/client
           name: openvpn-client-certificates
@@ -121,7 +120,6 @@ spec:
         command:
         - /usr/local/bin/kubeletdnat-controller
         image: 'quay.io/kubermatic/api:'
-        imagePullPolicy: IfNotPresent
         name: dnat-controller
         resources:
           limits:

--- a/api/pkg/resources/test/fixtures/deployment-bringyourown-1.11.0-controller-manager.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-bringyourown-1.11.0-controller-manager.yaml
@@ -96,7 +96,6 @@ spec:
             memory: 5Mi
         securityContext:
           privileged: true
-          procMount: Default
         volumeMounts:
         - mountPath: /etc/openvpn/pki/client
           name: openvpn-client-certificates

--- a/api/pkg/resources/test/fixtures/deployment-bringyourown-1.11.0-dns-resolver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-bringyourown-1.11.0-dns-resolver.yaml
@@ -90,7 +90,6 @@ spec:
             memory: 5Mi
         securityContext:
           privileged: true
-          procMount: Default
         volumeMounts:
         - mountPath: /etc/openvpn/pki/client
           name: openvpn-client-certificates

--- a/api/pkg/resources/test/fixtures/deployment-bringyourown-1.11.0-metrics-server.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-bringyourown-1.11.0-metrics-server.yaml
@@ -119,7 +119,6 @@ spec:
             memory: 5Mi
         securityContext:
           privileged: true
-          procMount: Default
         volumeMounts:
         - mountPath: /etc/openvpn/pki/client
           name: openvpn-client-certificates
@@ -135,7 +134,6 @@ spec:
         command:
         - /usr/local/bin/kubeletdnat-controller
         image: 'quay.io/kubermatic/api:'
-        imagePullPolicy: IfNotPresent
         name: dnat-controller
         resources:
           limits:

--- a/api/pkg/resources/test/fixtures/deployment-bringyourown-1.11.0-scheduler.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-bringyourown-1.11.0-scheduler.yaml
@@ -94,7 +94,6 @@ spec:
             memory: 5Mi
         securityContext:
           privileged: true
-          procMount: Default
         volumeMounts:
         - mountPath: /etc/openvpn/pki/client
           name: openvpn-client-certificates

--- a/api/pkg/resources/test/fixtures/deployment-bringyourown-1.11.1-apiserver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-bringyourown-1.11.1-apiserver.yaml
@@ -103,7 +103,6 @@ spec:
             memory: 5Mi
         securityContext:
           privileged: true
-          procMount: Default
         volumeMounts:
         - mountPath: /etc/openvpn/pki/client
           name: openvpn-client-certificates
@@ -121,7 +120,6 @@ spec:
         command:
         - /usr/local/bin/kubeletdnat-controller
         image: 'quay.io/kubermatic/api:'
-        imagePullPolicy: IfNotPresent
         name: dnat-controller
         resources:
           limits:

--- a/api/pkg/resources/test/fixtures/deployment-bringyourown-1.11.1-controller-manager.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-bringyourown-1.11.1-controller-manager.yaml
@@ -96,7 +96,6 @@ spec:
             memory: 5Mi
         securityContext:
           privileged: true
-          procMount: Default
         volumeMounts:
         - mountPath: /etc/openvpn/pki/client
           name: openvpn-client-certificates

--- a/api/pkg/resources/test/fixtures/deployment-bringyourown-1.11.1-dns-resolver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-bringyourown-1.11.1-dns-resolver.yaml
@@ -90,7 +90,6 @@ spec:
             memory: 5Mi
         securityContext:
           privileged: true
-          procMount: Default
         volumeMounts:
         - mountPath: /etc/openvpn/pki/client
           name: openvpn-client-certificates

--- a/api/pkg/resources/test/fixtures/deployment-bringyourown-1.11.1-metrics-server.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-bringyourown-1.11.1-metrics-server.yaml
@@ -119,7 +119,6 @@ spec:
             memory: 5Mi
         securityContext:
           privileged: true
-          procMount: Default
         volumeMounts:
         - mountPath: /etc/openvpn/pki/client
           name: openvpn-client-certificates
@@ -135,7 +134,6 @@ spec:
         command:
         - /usr/local/bin/kubeletdnat-controller
         image: 'quay.io/kubermatic/api:'
-        imagePullPolicy: IfNotPresent
         name: dnat-controller
         resources:
           limits:

--- a/api/pkg/resources/test/fixtures/deployment-bringyourown-1.11.1-scheduler.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-bringyourown-1.11.1-scheduler.yaml
@@ -94,7 +94,6 @@ spec:
             memory: 5Mi
         securityContext:
           privileged: true
-          procMount: Default
         volumeMounts:
         - mountPath: /etc/openvpn/pki/client
           name: openvpn-client-certificates

--- a/api/pkg/resources/test/fixtures/deployment-bringyourown-1.12.0-apiserver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-bringyourown-1.12.0-apiserver.yaml
@@ -103,7 +103,6 @@ spec:
             memory: 5Mi
         securityContext:
           privileged: true
-          procMount: Default
         volumeMounts:
         - mountPath: /etc/openvpn/pki/client
           name: openvpn-client-certificates
@@ -121,7 +120,6 @@ spec:
         command:
         - /usr/local/bin/kubeletdnat-controller
         image: 'quay.io/kubermatic/api:'
-        imagePullPolicy: IfNotPresent
         name: dnat-controller
         resources:
           limits:

--- a/api/pkg/resources/test/fixtures/deployment-bringyourown-1.12.0-controller-manager.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-bringyourown-1.12.0-controller-manager.yaml
@@ -96,7 +96,6 @@ spec:
             memory: 5Mi
         securityContext:
           privileged: true
-          procMount: Default
         volumeMounts:
         - mountPath: /etc/openvpn/pki/client
           name: openvpn-client-certificates

--- a/api/pkg/resources/test/fixtures/deployment-bringyourown-1.12.0-dns-resolver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-bringyourown-1.12.0-dns-resolver.yaml
@@ -90,7 +90,6 @@ spec:
             memory: 5Mi
         securityContext:
           privileged: true
-          procMount: Default
         volumeMounts:
         - mountPath: /etc/openvpn/pki/client
           name: openvpn-client-certificates

--- a/api/pkg/resources/test/fixtures/deployment-bringyourown-1.12.0-metrics-server.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-bringyourown-1.12.0-metrics-server.yaml
@@ -119,7 +119,6 @@ spec:
             memory: 5Mi
         securityContext:
           privileged: true
-          procMount: Default
         volumeMounts:
         - mountPath: /etc/openvpn/pki/client
           name: openvpn-client-certificates
@@ -135,7 +134,6 @@ spec:
         command:
         - /usr/local/bin/kubeletdnat-controller
         image: 'quay.io/kubermatic/api:'
-        imagePullPolicy: IfNotPresent
         name: dnat-controller
         resources:
           limits:

--- a/api/pkg/resources/test/fixtures/deployment-bringyourown-1.12.0-scheduler.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-bringyourown-1.12.0-scheduler.yaml
@@ -94,7 +94,6 @@ spec:
             memory: 5Mi
         securityContext:
           privileged: true
-          procMount: Default
         volumeMounts:
         - mountPath: /etc/openvpn/pki/client
           name: openvpn-client-certificates

--- a/api/pkg/resources/test/fixtures/deployment-bringyourown-1.13.0-apiserver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-bringyourown-1.13.0-apiserver.yaml
@@ -103,7 +103,6 @@ spec:
             memory: 5Mi
         securityContext:
           privileged: true
-          procMount: Default
         volumeMounts:
         - mountPath: /etc/openvpn/pki/client
           name: openvpn-client-certificates
@@ -121,7 +120,6 @@ spec:
         command:
         - /usr/local/bin/kubeletdnat-controller
         image: 'quay.io/kubermatic/api:'
-        imagePullPolicy: IfNotPresent
         name: dnat-controller
         resources:
           limits:

--- a/api/pkg/resources/test/fixtures/deployment-bringyourown-1.13.0-controller-manager.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-bringyourown-1.13.0-controller-manager.yaml
@@ -96,7 +96,6 @@ spec:
             memory: 5Mi
         securityContext:
           privileged: true
-          procMount: Default
         volumeMounts:
         - mountPath: /etc/openvpn/pki/client
           name: openvpn-client-certificates

--- a/api/pkg/resources/test/fixtures/deployment-bringyourown-1.13.0-dns-resolver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-bringyourown-1.13.0-dns-resolver.yaml
@@ -90,7 +90,6 @@ spec:
             memory: 5Mi
         securityContext:
           privileged: true
-          procMount: Default
         volumeMounts:
         - mountPath: /etc/openvpn/pki/client
           name: openvpn-client-certificates

--- a/api/pkg/resources/test/fixtures/deployment-bringyourown-1.13.0-metrics-server.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-bringyourown-1.13.0-metrics-server.yaml
@@ -119,7 +119,6 @@ spec:
             memory: 5Mi
         securityContext:
           privileged: true
-          procMount: Default
         volumeMounts:
         - mountPath: /etc/openvpn/pki/client
           name: openvpn-client-certificates
@@ -135,7 +134,6 @@ spec:
         command:
         - /usr/local/bin/kubeletdnat-controller
         image: 'quay.io/kubermatic/api:'
-        imagePullPolicy: IfNotPresent
         name: dnat-controller
         resources:
           limits:

--- a/api/pkg/resources/test/fixtures/deployment-bringyourown-1.13.0-scheduler.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-bringyourown-1.13.0-scheduler.yaml
@@ -94,7 +94,6 @@ spec:
             memory: 5Mi
         securityContext:
           privileged: true
-          procMount: Default
         volumeMounts:
         - mountPath: /etc/openvpn/pki/client
           name: openvpn-client-certificates

--- a/api/pkg/resources/test/fixtures/deployment-digitalocean-1.10.0-apiserver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-digitalocean-1.10.0-apiserver.yaml
@@ -103,7 +103,6 @@ spec:
             memory: 5Mi
         securityContext:
           privileged: true
-          procMount: Default
         volumeMounts:
         - mountPath: /etc/openvpn/pki/client
           name: openvpn-client-certificates
@@ -121,7 +120,6 @@ spec:
         command:
         - /usr/local/bin/kubeletdnat-controller
         image: 'quay.io/kubermatic/api:'
-        imagePullPolicy: IfNotPresent
         name: dnat-controller
         resources:
           limits:

--- a/api/pkg/resources/test/fixtures/deployment-digitalocean-1.10.0-controller-manager.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-digitalocean-1.10.0-controller-manager.yaml
@@ -96,7 +96,6 @@ spec:
             memory: 5Mi
         securityContext:
           privileged: true
-          procMount: Default
         volumeMounts:
         - mountPath: /etc/openvpn/pki/client
           name: openvpn-client-certificates

--- a/api/pkg/resources/test/fixtures/deployment-digitalocean-1.10.0-dns-resolver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-digitalocean-1.10.0-dns-resolver.yaml
@@ -90,7 +90,6 @@ spec:
             memory: 5Mi
         securityContext:
           privileged: true
-          procMount: Default
         volumeMounts:
         - mountPath: /etc/openvpn/pki/client
           name: openvpn-client-certificates

--- a/api/pkg/resources/test/fixtures/deployment-digitalocean-1.10.0-metrics-server.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-digitalocean-1.10.0-metrics-server.yaml
@@ -119,7 +119,6 @@ spec:
             memory: 5Mi
         securityContext:
           privileged: true
-          procMount: Default
         volumeMounts:
         - mountPath: /etc/openvpn/pki/client
           name: openvpn-client-certificates
@@ -135,7 +134,6 @@ spec:
         command:
         - /usr/local/bin/kubeletdnat-controller
         image: 'quay.io/kubermatic/api:'
-        imagePullPolicy: IfNotPresent
         name: dnat-controller
         resources:
           limits:

--- a/api/pkg/resources/test/fixtures/deployment-digitalocean-1.10.0-scheduler.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-digitalocean-1.10.0-scheduler.yaml
@@ -94,7 +94,6 @@ spec:
             memory: 5Mi
         securityContext:
           privileged: true
-          procMount: Default
         volumeMounts:
         - mountPath: /etc/openvpn/pki/client
           name: openvpn-client-certificates

--- a/api/pkg/resources/test/fixtures/deployment-digitalocean-1.10.6-apiserver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-digitalocean-1.10.6-apiserver.yaml
@@ -103,7 +103,6 @@ spec:
             memory: 5Mi
         securityContext:
           privileged: true
-          procMount: Default
         volumeMounts:
         - mountPath: /etc/openvpn/pki/client
           name: openvpn-client-certificates
@@ -121,7 +120,6 @@ spec:
         command:
         - /usr/local/bin/kubeletdnat-controller
         image: 'quay.io/kubermatic/api:'
-        imagePullPolicy: IfNotPresent
         name: dnat-controller
         resources:
           limits:

--- a/api/pkg/resources/test/fixtures/deployment-digitalocean-1.10.6-controller-manager.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-digitalocean-1.10.6-controller-manager.yaml
@@ -96,7 +96,6 @@ spec:
             memory: 5Mi
         securityContext:
           privileged: true
-          procMount: Default
         volumeMounts:
         - mountPath: /etc/openvpn/pki/client
           name: openvpn-client-certificates

--- a/api/pkg/resources/test/fixtures/deployment-digitalocean-1.10.6-dns-resolver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-digitalocean-1.10.6-dns-resolver.yaml
@@ -90,7 +90,6 @@ spec:
             memory: 5Mi
         securityContext:
           privileged: true
-          procMount: Default
         volumeMounts:
         - mountPath: /etc/openvpn/pki/client
           name: openvpn-client-certificates

--- a/api/pkg/resources/test/fixtures/deployment-digitalocean-1.10.6-metrics-server.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-digitalocean-1.10.6-metrics-server.yaml
@@ -119,7 +119,6 @@ spec:
             memory: 5Mi
         securityContext:
           privileged: true
-          procMount: Default
         volumeMounts:
         - mountPath: /etc/openvpn/pki/client
           name: openvpn-client-certificates
@@ -135,7 +134,6 @@ spec:
         command:
         - /usr/local/bin/kubeletdnat-controller
         image: 'quay.io/kubermatic/api:'
-        imagePullPolicy: IfNotPresent
         name: dnat-controller
         resources:
           limits:

--- a/api/pkg/resources/test/fixtures/deployment-digitalocean-1.10.6-scheduler.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-digitalocean-1.10.6-scheduler.yaml
@@ -94,7 +94,6 @@ spec:
             memory: 5Mi
         securityContext:
           privileged: true
-          procMount: Default
         volumeMounts:
         - mountPath: /etc/openvpn/pki/client
           name: openvpn-client-certificates

--- a/api/pkg/resources/test/fixtures/deployment-digitalocean-1.11.0-apiserver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-digitalocean-1.11.0-apiserver.yaml
@@ -103,7 +103,6 @@ spec:
             memory: 5Mi
         securityContext:
           privileged: true
-          procMount: Default
         volumeMounts:
         - mountPath: /etc/openvpn/pki/client
           name: openvpn-client-certificates
@@ -121,7 +120,6 @@ spec:
         command:
         - /usr/local/bin/kubeletdnat-controller
         image: 'quay.io/kubermatic/api:'
-        imagePullPolicy: IfNotPresent
         name: dnat-controller
         resources:
           limits:

--- a/api/pkg/resources/test/fixtures/deployment-digitalocean-1.11.0-controller-manager.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-digitalocean-1.11.0-controller-manager.yaml
@@ -96,7 +96,6 @@ spec:
             memory: 5Mi
         securityContext:
           privileged: true
-          procMount: Default
         volumeMounts:
         - mountPath: /etc/openvpn/pki/client
           name: openvpn-client-certificates

--- a/api/pkg/resources/test/fixtures/deployment-digitalocean-1.11.0-dns-resolver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-digitalocean-1.11.0-dns-resolver.yaml
@@ -90,7 +90,6 @@ spec:
             memory: 5Mi
         securityContext:
           privileged: true
-          procMount: Default
         volumeMounts:
         - mountPath: /etc/openvpn/pki/client
           name: openvpn-client-certificates

--- a/api/pkg/resources/test/fixtures/deployment-digitalocean-1.11.0-metrics-server.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-digitalocean-1.11.0-metrics-server.yaml
@@ -119,7 +119,6 @@ spec:
             memory: 5Mi
         securityContext:
           privileged: true
-          procMount: Default
         volumeMounts:
         - mountPath: /etc/openvpn/pki/client
           name: openvpn-client-certificates
@@ -135,7 +134,6 @@ spec:
         command:
         - /usr/local/bin/kubeletdnat-controller
         image: 'quay.io/kubermatic/api:'
-        imagePullPolicy: IfNotPresent
         name: dnat-controller
         resources:
           limits:

--- a/api/pkg/resources/test/fixtures/deployment-digitalocean-1.11.0-scheduler.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-digitalocean-1.11.0-scheduler.yaml
@@ -94,7 +94,6 @@ spec:
             memory: 5Mi
         securityContext:
           privileged: true
-          procMount: Default
         volumeMounts:
         - mountPath: /etc/openvpn/pki/client
           name: openvpn-client-certificates

--- a/api/pkg/resources/test/fixtures/deployment-digitalocean-1.11.1-apiserver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-digitalocean-1.11.1-apiserver.yaml
@@ -103,7 +103,6 @@ spec:
             memory: 5Mi
         securityContext:
           privileged: true
-          procMount: Default
         volumeMounts:
         - mountPath: /etc/openvpn/pki/client
           name: openvpn-client-certificates
@@ -121,7 +120,6 @@ spec:
         command:
         - /usr/local/bin/kubeletdnat-controller
         image: 'quay.io/kubermatic/api:'
-        imagePullPolicy: IfNotPresent
         name: dnat-controller
         resources:
           limits:

--- a/api/pkg/resources/test/fixtures/deployment-digitalocean-1.11.1-controller-manager.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-digitalocean-1.11.1-controller-manager.yaml
@@ -96,7 +96,6 @@ spec:
             memory: 5Mi
         securityContext:
           privileged: true
-          procMount: Default
         volumeMounts:
         - mountPath: /etc/openvpn/pki/client
           name: openvpn-client-certificates

--- a/api/pkg/resources/test/fixtures/deployment-digitalocean-1.11.1-dns-resolver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-digitalocean-1.11.1-dns-resolver.yaml
@@ -90,7 +90,6 @@ spec:
             memory: 5Mi
         securityContext:
           privileged: true
-          procMount: Default
         volumeMounts:
         - mountPath: /etc/openvpn/pki/client
           name: openvpn-client-certificates

--- a/api/pkg/resources/test/fixtures/deployment-digitalocean-1.11.1-metrics-server.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-digitalocean-1.11.1-metrics-server.yaml
@@ -119,7 +119,6 @@ spec:
             memory: 5Mi
         securityContext:
           privileged: true
-          procMount: Default
         volumeMounts:
         - mountPath: /etc/openvpn/pki/client
           name: openvpn-client-certificates
@@ -135,7 +134,6 @@ spec:
         command:
         - /usr/local/bin/kubeletdnat-controller
         image: 'quay.io/kubermatic/api:'
-        imagePullPolicy: IfNotPresent
         name: dnat-controller
         resources:
           limits:

--- a/api/pkg/resources/test/fixtures/deployment-digitalocean-1.11.1-scheduler.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-digitalocean-1.11.1-scheduler.yaml
@@ -94,7 +94,6 @@ spec:
             memory: 5Mi
         securityContext:
           privileged: true
-          procMount: Default
         volumeMounts:
         - mountPath: /etc/openvpn/pki/client
           name: openvpn-client-certificates

--- a/api/pkg/resources/test/fixtures/deployment-digitalocean-1.12.0-apiserver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-digitalocean-1.12.0-apiserver.yaml
@@ -103,7 +103,6 @@ spec:
             memory: 5Mi
         securityContext:
           privileged: true
-          procMount: Default
         volumeMounts:
         - mountPath: /etc/openvpn/pki/client
           name: openvpn-client-certificates
@@ -121,7 +120,6 @@ spec:
         command:
         - /usr/local/bin/kubeletdnat-controller
         image: 'quay.io/kubermatic/api:'
-        imagePullPolicy: IfNotPresent
         name: dnat-controller
         resources:
           limits:

--- a/api/pkg/resources/test/fixtures/deployment-digitalocean-1.12.0-controller-manager.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-digitalocean-1.12.0-controller-manager.yaml
@@ -96,7 +96,6 @@ spec:
             memory: 5Mi
         securityContext:
           privileged: true
-          procMount: Default
         volumeMounts:
         - mountPath: /etc/openvpn/pki/client
           name: openvpn-client-certificates

--- a/api/pkg/resources/test/fixtures/deployment-digitalocean-1.12.0-dns-resolver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-digitalocean-1.12.0-dns-resolver.yaml
@@ -90,7 +90,6 @@ spec:
             memory: 5Mi
         securityContext:
           privileged: true
-          procMount: Default
         volumeMounts:
         - mountPath: /etc/openvpn/pki/client
           name: openvpn-client-certificates

--- a/api/pkg/resources/test/fixtures/deployment-digitalocean-1.12.0-metrics-server.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-digitalocean-1.12.0-metrics-server.yaml
@@ -119,7 +119,6 @@ spec:
             memory: 5Mi
         securityContext:
           privileged: true
-          procMount: Default
         volumeMounts:
         - mountPath: /etc/openvpn/pki/client
           name: openvpn-client-certificates
@@ -135,7 +134,6 @@ spec:
         command:
         - /usr/local/bin/kubeletdnat-controller
         image: 'quay.io/kubermatic/api:'
-        imagePullPolicy: IfNotPresent
         name: dnat-controller
         resources:
           limits:

--- a/api/pkg/resources/test/fixtures/deployment-digitalocean-1.12.0-scheduler.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-digitalocean-1.12.0-scheduler.yaml
@@ -94,7 +94,6 @@ spec:
             memory: 5Mi
         securityContext:
           privileged: true
-          procMount: Default
         volumeMounts:
         - mountPath: /etc/openvpn/pki/client
           name: openvpn-client-certificates

--- a/api/pkg/resources/test/fixtures/deployment-digitalocean-1.13.0-apiserver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-digitalocean-1.13.0-apiserver.yaml
@@ -103,7 +103,6 @@ spec:
             memory: 5Mi
         securityContext:
           privileged: true
-          procMount: Default
         volumeMounts:
         - mountPath: /etc/openvpn/pki/client
           name: openvpn-client-certificates
@@ -121,7 +120,6 @@ spec:
         command:
         - /usr/local/bin/kubeletdnat-controller
         image: 'quay.io/kubermatic/api:'
-        imagePullPolicy: IfNotPresent
         name: dnat-controller
         resources:
           limits:

--- a/api/pkg/resources/test/fixtures/deployment-digitalocean-1.13.0-controller-manager.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-digitalocean-1.13.0-controller-manager.yaml
@@ -96,7 +96,6 @@ spec:
             memory: 5Mi
         securityContext:
           privileged: true
-          procMount: Default
         volumeMounts:
         - mountPath: /etc/openvpn/pki/client
           name: openvpn-client-certificates

--- a/api/pkg/resources/test/fixtures/deployment-digitalocean-1.13.0-dns-resolver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-digitalocean-1.13.0-dns-resolver.yaml
@@ -90,7 +90,6 @@ spec:
             memory: 5Mi
         securityContext:
           privileged: true
-          procMount: Default
         volumeMounts:
         - mountPath: /etc/openvpn/pki/client
           name: openvpn-client-certificates

--- a/api/pkg/resources/test/fixtures/deployment-digitalocean-1.13.0-metrics-server.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-digitalocean-1.13.0-metrics-server.yaml
@@ -119,7 +119,6 @@ spec:
             memory: 5Mi
         securityContext:
           privileged: true
-          procMount: Default
         volumeMounts:
         - mountPath: /etc/openvpn/pki/client
           name: openvpn-client-certificates
@@ -135,7 +134,6 @@ spec:
         command:
         - /usr/local/bin/kubeletdnat-controller
         image: 'quay.io/kubermatic/api:'
-        imagePullPolicy: IfNotPresent
         name: dnat-controller
         resources:
           limits:

--- a/api/pkg/resources/test/fixtures/deployment-digitalocean-1.13.0-scheduler.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-digitalocean-1.13.0-scheduler.yaml
@@ -94,7 +94,6 @@ spec:
             memory: 5Mi
         securityContext:
           privileged: true
-          procMount: Default
         volumeMounts:
         - mountPath: /etc/openvpn/pki/client
           name: openvpn-client-certificates

--- a/api/pkg/resources/test/fixtures/deployment-openstack-1.10.0-apiserver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-openstack-1.10.0-apiserver.yaml
@@ -103,7 +103,6 @@ spec:
             memory: 5Mi
         securityContext:
           privileged: true
-          procMount: Default
         volumeMounts:
         - mountPath: /etc/openvpn/pki/client
           name: openvpn-client-certificates
@@ -121,7 +120,6 @@ spec:
         command:
         - /usr/local/bin/kubeletdnat-controller
         image: 'quay.io/kubermatic/api:'
-        imagePullPolicy: IfNotPresent
         name: dnat-controller
         resources:
           limits:

--- a/api/pkg/resources/test/fixtures/deployment-openstack-1.10.0-controller-manager.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-openstack-1.10.0-controller-manager.yaml
@@ -96,7 +96,6 @@ spec:
             memory: 5Mi
         securityContext:
           privileged: true
-          procMount: Default
         volumeMounts:
         - mountPath: /etc/openvpn/pki/client
           name: openvpn-client-certificates

--- a/api/pkg/resources/test/fixtures/deployment-openstack-1.10.0-dns-resolver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-openstack-1.10.0-dns-resolver.yaml
@@ -90,7 +90,6 @@ spec:
             memory: 5Mi
         securityContext:
           privileged: true
-          procMount: Default
         volumeMounts:
         - mountPath: /etc/openvpn/pki/client
           name: openvpn-client-certificates

--- a/api/pkg/resources/test/fixtures/deployment-openstack-1.10.0-metrics-server.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-openstack-1.10.0-metrics-server.yaml
@@ -119,7 +119,6 @@ spec:
             memory: 5Mi
         securityContext:
           privileged: true
-          procMount: Default
         volumeMounts:
         - mountPath: /etc/openvpn/pki/client
           name: openvpn-client-certificates
@@ -135,7 +134,6 @@ spec:
         command:
         - /usr/local/bin/kubeletdnat-controller
         image: 'quay.io/kubermatic/api:'
-        imagePullPolicy: IfNotPresent
         name: dnat-controller
         resources:
           limits:

--- a/api/pkg/resources/test/fixtures/deployment-openstack-1.10.0-scheduler.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-openstack-1.10.0-scheduler.yaml
@@ -94,7 +94,6 @@ spec:
             memory: 5Mi
         securityContext:
           privileged: true
-          procMount: Default
         volumeMounts:
         - mountPath: /etc/openvpn/pki/client
           name: openvpn-client-certificates

--- a/api/pkg/resources/test/fixtures/deployment-openstack-1.10.6-apiserver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-openstack-1.10.6-apiserver.yaml
@@ -103,7 +103,6 @@ spec:
             memory: 5Mi
         securityContext:
           privileged: true
-          procMount: Default
         volumeMounts:
         - mountPath: /etc/openvpn/pki/client
           name: openvpn-client-certificates
@@ -121,7 +120,6 @@ spec:
         command:
         - /usr/local/bin/kubeletdnat-controller
         image: 'quay.io/kubermatic/api:'
-        imagePullPolicy: IfNotPresent
         name: dnat-controller
         resources:
           limits:

--- a/api/pkg/resources/test/fixtures/deployment-openstack-1.10.6-controller-manager.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-openstack-1.10.6-controller-manager.yaml
@@ -96,7 +96,6 @@ spec:
             memory: 5Mi
         securityContext:
           privileged: true
-          procMount: Default
         volumeMounts:
         - mountPath: /etc/openvpn/pki/client
           name: openvpn-client-certificates

--- a/api/pkg/resources/test/fixtures/deployment-openstack-1.10.6-dns-resolver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-openstack-1.10.6-dns-resolver.yaml
@@ -90,7 +90,6 @@ spec:
             memory: 5Mi
         securityContext:
           privileged: true
-          procMount: Default
         volumeMounts:
         - mountPath: /etc/openvpn/pki/client
           name: openvpn-client-certificates

--- a/api/pkg/resources/test/fixtures/deployment-openstack-1.10.6-metrics-server.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-openstack-1.10.6-metrics-server.yaml
@@ -119,7 +119,6 @@ spec:
             memory: 5Mi
         securityContext:
           privileged: true
-          procMount: Default
         volumeMounts:
         - mountPath: /etc/openvpn/pki/client
           name: openvpn-client-certificates
@@ -135,7 +134,6 @@ spec:
         command:
         - /usr/local/bin/kubeletdnat-controller
         image: 'quay.io/kubermatic/api:'
-        imagePullPolicy: IfNotPresent
         name: dnat-controller
         resources:
           limits:

--- a/api/pkg/resources/test/fixtures/deployment-openstack-1.10.6-scheduler.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-openstack-1.10.6-scheduler.yaml
@@ -94,7 +94,6 @@ spec:
             memory: 5Mi
         securityContext:
           privileged: true
-          procMount: Default
         volumeMounts:
         - mountPath: /etc/openvpn/pki/client
           name: openvpn-client-certificates

--- a/api/pkg/resources/test/fixtures/deployment-openstack-1.11.0-apiserver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-openstack-1.11.0-apiserver.yaml
@@ -103,7 +103,6 @@ spec:
             memory: 5Mi
         securityContext:
           privileged: true
-          procMount: Default
         volumeMounts:
         - mountPath: /etc/openvpn/pki/client
           name: openvpn-client-certificates
@@ -121,7 +120,6 @@ spec:
         command:
         - /usr/local/bin/kubeletdnat-controller
         image: 'quay.io/kubermatic/api:'
-        imagePullPolicy: IfNotPresent
         name: dnat-controller
         resources:
           limits:

--- a/api/pkg/resources/test/fixtures/deployment-openstack-1.11.0-controller-manager.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-openstack-1.11.0-controller-manager.yaml
@@ -96,7 +96,6 @@ spec:
             memory: 5Mi
         securityContext:
           privileged: true
-          procMount: Default
         volumeMounts:
         - mountPath: /etc/openvpn/pki/client
           name: openvpn-client-certificates

--- a/api/pkg/resources/test/fixtures/deployment-openstack-1.11.0-dns-resolver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-openstack-1.11.0-dns-resolver.yaml
@@ -90,7 +90,6 @@ spec:
             memory: 5Mi
         securityContext:
           privileged: true
-          procMount: Default
         volumeMounts:
         - mountPath: /etc/openvpn/pki/client
           name: openvpn-client-certificates

--- a/api/pkg/resources/test/fixtures/deployment-openstack-1.11.0-metrics-server.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-openstack-1.11.0-metrics-server.yaml
@@ -119,7 +119,6 @@ spec:
             memory: 5Mi
         securityContext:
           privileged: true
-          procMount: Default
         volumeMounts:
         - mountPath: /etc/openvpn/pki/client
           name: openvpn-client-certificates
@@ -135,7 +134,6 @@ spec:
         command:
         - /usr/local/bin/kubeletdnat-controller
         image: 'quay.io/kubermatic/api:'
-        imagePullPolicy: IfNotPresent
         name: dnat-controller
         resources:
           limits:

--- a/api/pkg/resources/test/fixtures/deployment-openstack-1.11.0-scheduler.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-openstack-1.11.0-scheduler.yaml
@@ -94,7 +94,6 @@ spec:
             memory: 5Mi
         securityContext:
           privileged: true
-          procMount: Default
         volumeMounts:
         - mountPath: /etc/openvpn/pki/client
           name: openvpn-client-certificates

--- a/api/pkg/resources/test/fixtures/deployment-openstack-1.11.1-apiserver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-openstack-1.11.1-apiserver.yaml
@@ -103,7 +103,6 @@ spec:
             memory: 5Mi
         securityContext:
           privileged: true
-          procMount: Default
         volumeMounts:
         - mountPath: /etc/openvpn/pki/client
           name: openvpn-client-certificates
@@ -121,7 +120,6 @@ spec:
         command:
         - /usr/local/bin/kubeletdnat-controller
         image: 'quay.io/kubermatic/api:'
-        imagePullPolicy: IfNotPresent
         name: dnat-controller
         resources:
           limits:

--- a/api/pkg/resources/test/fixtures/deployment-openstack-1.11.1-controller-manager.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-openstack-1.11.1-controller-manager.yaml
@@ -96,7 +96,6 @@ spec:
             memory: 5Mi
         securityContext:
           privileged: true
-          procMount: Default
         volumeMounts:
         - mountPath: /etc/openvpn/pki/client
           name: openvpn-client-certificates

--- a/api/pkg/resources/test/fixtures/deployment-openstack-1.11.1-dns-resolver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-openstack-1.11.1-dns-resolver.yaml
@@ -90,7 +90,6 @@ spec:
             memory: 5Mi
         securityContext:
           privileged: true
-          procMount: Default
         volumeMounts:
         - mountPath: /etc/openvpn/pki/client
           name: openvpn-client-certificates

--- a/api/pkg/resources/test/fixtures/deployment-openstack-1.11.1-metrics-server.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-openstack-1.11.1-metrics-server.yaml
@@ -119,7 +119,6 @@ spec:
             memory: 5Mi
         securityContext:
           privileged: true
-          procMount: Default
         volumeMounts:
         - mountPath: /etc/openvpn/pki/client
           name: openvpn-client-certificates
@@ -135,7 +134,6 @@ spec:
         command:
         - /usr/local/bin/kubeletdnat-controller
         image: 'quay.io/kubermatic/api:'
-        imagePullPolicy: IfNotPresent
         name: dnat-controller
         resources:
           limits:

--- a/api/pkg/resources/test/fixtures/deployment-openstack-1.11.1-scheduler.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-openstack-1.11.1-scheduler.yaml
@@ -94,7 +94,6 @@ spec:
             memory: 5Mi
         securityContext:
           privileged: true
-          procMount: Default
         volumeMounts:
         - mountPath: /etc/openvpn/pki/client
           name: openvpn-client-certificates

--- a/api/pkg/resources/test/fixtures/deployment-openstack-1.12.0-apiserver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-openstack-1.12.0-apiserver.yaml
@@ -103,7 +103,6 @@ spec:
             memory: 5Mi
         securityContext:
           privileged: true
-          procMount: Default
         volumeMounts:
         - mountPath: /etc/openvpn/pki/client
           name: openvpn-client-certificates
@@ -121,7 +120,6 @@ spec:
         command:
         - /usr/local/bin/kubeletdnat-controller
         image: 'quay.io/kubermatic/api:'
-        imagePullPolicy: IfNotPresent
         name: dnat-controller
         resources:
           limits:

--- a/api/pkg/resources/test/fixtures/deployment-openstack-1.12.0-controller-manager.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-openstack-1.12.0-controller-manager.yaml
@@ -96,7 +96,6 @@ spec:
             memory: 5Mi
         securityContext:
           privileged: true
-          procMount: Default
         volumeMounts:
         - mountPath: /etc/openvpn/pki/client
           name: openvpn-client-certificates

--- a/api/pkg/resources/test/fixtures/deployment-openstack-1.12.0-dns-resolver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-openstack-1.12.0-dns-resolver.yaml
@@ -90,7 +90,6 @@ spec:
             memory: 5Mi
         securityContext:
           privileged: true
-          procMount: Default
         volumeMounts:
         - mountPath: /etc/openvpn/pki/client
           name: openvpn-client-certificates

--- a/api/pkg/resources/test/fixtures/deployment-openstack-1.12.0-metrics-server.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-openstack-1.12.0-metrics-server.yaml
@@ -119,7 +119,6 @@ spec:
             memory: 5Mi
         securityContext:
           privileged: true
-          procMount: Default
         volumeMounts:
         - mountPath: /etc/openvpn/pki/client
           name: openvpn-client-certificates
@@ -135,7 +134,6 @@ spec:
         command:
         - /usr/local/bin/kubeletdnat-controller
         image: 'quay.io/kubermatic/api:'
-        imagePullPolicy: IfNotPresent
         name: dnat-controller
         resources:
           limits:

--- a/api/pkg/resources/test/fixtures/deployment-openstack-1.12.0-scheduler.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-openstack-1.12.0-scheduler.yaml
@@ -94,7 +94,6 @@ spec:
             memory: 5Mi
         securityContext:
           privileged: true
-          procMount: Default
         volumeMounts:
         - mountPath: /etc/openvpn/pki/client
           name: openvpn-client-certificates

--- a/api/pkg/resources/test/fixtures/deployment-openstack-1.13.0-apiserver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-openstack-1.13.0-apiserver.yaml
@@ -103,7 +103,6 @@ spec:
             memory: 5Mi
         securityContext:
           privileged: true
-          procMount: Default
         volumeMounts:
         - mountPath: /etc/openvpn/pki/client
           name: openvpn-client-certificates
@@ -121,7 +120,6 @@ spec:
         command:
         - /usr/local/bin/kubeletdnat-controller
         image: 'quay.io/kubermatic/api:'
-        imagePullPolicy: IfNotPresent
         name: dnat-controller
         resources:
           limits:

--- a/api/pkg/resources/test/fixtures/deployment-openstack-1.13.0-controller-manager.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-openstack-1.13.0-controller-manager.yaml
@@ -96,7 +96,6 @@ spec:
             memory: 5Mi
         securityContext:
           privileged: true
-          procMount: Default
         volumeMounts:
         - mountPath: /etc/openvpn/pki/client
           name: openvpn-client-certificates

--- a/api/pkg/resources/test/fixtures/deployment-openstack-1.13.0-dns-resolver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-openstack-1.13.0-dns-resolver.yaml
@@ -90,7 +90,6 @@ spec:
             memory: 5Mi
         securityContext:
           privileged: true
-          procMount: Default
         volumeMounts:
         - mountPath: /etc/openvpn/pki/client
           name: openvpn-client-certificates

--- a/api/pkg/resources/test/fixtures/deployment-openstack-1.13.0-metrics-server.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-openstack-1.13.0-metrics-server.yaml
@@ -119,7 +119,6 @@ spec:
             memory: 5Mi
         securityContext:
           privileged: true
-          procMount: Default
         volumeMounts:
         - mountPath: /etc/openvpn/pki/client
           name: openvpn-client-certificates
@@ -135,7 +134,6 @@ spec:
         command:
         - /usr/local/bin/kubeletdnat-controller
         image: 'quay.io/kubermatic/api:'
-        imagePullPolicy: IfNotPresent
         name: dnat-controller
         resources:
           limits:

--- a/api/pkg/resources/test/fixtures/deployment-openstack-1.13.0-scheduler.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-openstack-1.13.0-scheduler.yaml
@@ -94,7 +94,6 @@ spec:
             memory: 5Mi
         securityContext:
           privileged: true
-          procMount: Default
         volumeMounts:
         - mountPath: /etc/openvpn/pki/client
           name: openvpn-client-certificates

--- a/api/pkg/resources/test/fixtures/deployment-vsphere-1.10.0-apiserver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-vsphere-1.10.0-apiserver.yaml
@@ -103,7 +103,6 @@ spec:
             memory: 5Mi
         securityContext:
           privileged: true
-          procMount: Default
         volumeMounts:
         - mountPath: /etc/openvpn/pki/client
           name: openvpn-client-certificates
@@ -121,7 +120,6 @@ spec:
         command:
         - /usr/local/bin/kubeletdnat-controller
         image: 'quay.io/kubermatic/api:'
-        imagePullPolicy: IfNotPresent
         name: dnat-controller
         resources:
           limits:

--- a/api/pkg/resources/test/fixtures/deployment-vsphere-1.10.0-controller-manager.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-vsphere-1.10.0-controller-manager.yaml
@@ -96,7 +96,6 @@ spec:
             memory: 5Mi
         securityContext:
           privileged: true
-          procMount: Default
         volumeMounts:
         - mountPath: /etc/openvpn/pki/client
           name: openvpn-client-certificates

--- a/api/pkg/resources/test/fixtures/deployment-vsphere-1.10.0-dns-resolver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-vsphere-1.10.0-dns-resolver.yaml
@@ -90,7 +90,6 @@ spec:
             memory: 5Mi
         securityContext:
           privileged: true
-          procMount: Default
         volumeMounts:
         - mountPath: /etc/openvpn/pki/client
           name: openvpn-client-certificates

--- a/api/pkg/resources/test/fixtures/deployment-vsphere-1.10.0-metrics-server.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-vsphere-1.10.0-metrics-server.yaml
@@ -119,7 +119,6 @@ spec:
             memory: 5Mi
         securityContext:
           privileged: true
-          procMount: Default
         volumeMounts:
         - mountPath: /etc/openvpn/pki/client
           name: openvpn-client-certificates
@@ -135,7 +134,6 @@ spec:
         command:
         - /usr/local/bin/kubeletdnat-controller
         image: 'quay.io/kubermatic/api:'
-        imagePullPolicy: IfNotPresent
         name: dnat-controller
         resources:
           limits:

--- a/api/pkg/resources/test/fixtures/deployment-vsphere-1.10.0-scheduler.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-vsphere-1.10.0-scheduler.yaml
@@ -94,7 +94,6 @@ spec:
             memory: 5Mi
         securityContext:
           privileged: true
-          procMount: Default
         volumeMounts:
         - mountPath: /etc/openvpn/pki/client
           name: openvpn-client-certificates

--- a/api/pkg/resources/test/fixtures/deployment-vsphere-1.10.6-apiserver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-vsphere-1.10.6-apiserver.yaml
@@ -103,7 +103,6 @@ spec:
             memory: 5Mi
         securityContext:
           privileged: true
-          procMount: Default
         volumeMounts:
         - mountPath: /etc/openvpn/pki/client
           name: openvpn-client-certificates
@@ -121,7 +120,6 @@ spec:
         command:
         - /usr/local/bin/kubeletdnat-controller
         image: 'quay.io/kubermatic/api:'
-        imagePullPolicy: IfNotPresent
         name: dnat-controller
         resources:
           limits:

--- a/api/pkg/resources/test/fixtures/deployment-vsphere-1.10.6-controller-manager.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-vsphere-1.10.6-controller-manager.yaml
@@ -96,7 +96,6 @@ spec:
             memory: 5Mi
         securityContext:
           privileged: true
-          procMount: Default
         volumeMounts:
         - mountPath: /etc/openvpn/pki/client
           name: openvpn-client-certificates

--- a/api/pkg/resources/test/fixtures/deployment-vsphere-1.10.6-dns-resolver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-vsphere-1.10.6-dns-resolver.yaml
@@ -90,7 +90,6 @@ spec:
             memory: 5Mi
         securityContext:
           privileged: true
-          procMount: Default
         volumeMounts:
         - mountPath: /etc/openvpn/pki/client
           name: openvpn-client-certificates

--- a/api/pkg/resources/test/fixtures/deployment-vsphere-1.10.6-metrics-server.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-vsphere-1.10.6-metrics-server.yaml
@@ -119,7 +119,6 @@ spec:
             memory: 5Mi
         securityContext:
           privileged: true
-          procMount: Default
         volumeMounts:
         - mountPath: /etc/openvpn/pki/client
           name: openvpn-client-certificates
@@ -135,7 +134,6 @@ spec:
         command:
         - /usr/local/bin/kubeletdnat-controller
         image: 'quay.io/kubermatic/api:'
-        imagePullPolicy: IfNotPresent
         name: dnat-controller
         resources:
           limits:

--- a/api/pkg/resources/test/fixtures/deployment-vsphere-1.10.6-scheduler.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-vsphere-1.10.6-scheduler.yaml
@@ -94,7 +94,6 @@ spec:
             memory: 5Mi
         securityContext:
           privileged: true
-          procMount: Default
         volumeMounts:
         - mountPath: /etc/openvpn/pki/client
           name: openvpn-client-certificates

--- a/api/pkg/resources/test/fixtures/deployment-vsphere-1.11.0-apiserver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-vsphere-1.11.0-apiserver.yaml
@@ -103,7 +103,6 @@ spec:
             memory: 5Mi
         securityContext:
           privileged: true
-          procMount: Default
         volumeMounts:
         - mountPath: /etc/openvpn/pki/client
           name: openvpn-client-certificates
@@ -121,7 +120,6 @@ spec:
         command:
         - /usr/local/bin/kubeletdnat-controller
         image: 'quay.io/kubermatic/api:'
-        imagePullPolicy: IfNotPresent
         name: dnat-controller
         resources:
           limits:

--- a/api/pkg/resources/test/fixtures/deployment-vsphere-1.11.0-controller-manager.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-vsphere-1.11.0-controller-manager.yaml
@@ -96,7 +96,6 @@ spec:
             memory: 5Mi
         securityContext:
           privileged: true
-          procMount: Default
         volumeMounts:
         - mountPath: /etc/openvpn/pki/client
           name: openvpn-client-certificates

--- a/api/pkg/resources/test/fixtures/deployment-vsphere-1.11.0-dns-resolver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-vsphere-1.11.0-dns-resolver.yaml
@@ -90,7 +90,6 @@ spec:
             memory: 5Mi
         securityContext:
           privileged: true
-          procMount: Default
         volumeMounts:
         - mountPath: /etc/openvpn/pki/client
           name: openvpn-client-certificates

--- a/api/pkg/resources/test/fixtures/deployment-vsphere-1.11.0-metrics-server.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-vsphere-1.11.0-metrics-server.yaml
@@ -119,7 +119,6 @@ spec:
             memory: 5Mi
         securityContext:
           privileged: true
-          procMount: Default
         volumeMounts:
         - mountPath: /etc/openvpn/pki/client
           name: openvpn-client-certificates
@@ -135,7 +134,6 @@ spec:
         command:
         - /usr/local/bin/kubeletdnat-controller
         image: 'quay.io/kubermatic/api:'
-        imagePullPolicy: IfNotPresent
         name: dnat-controller
         resources:
           limits:

--- a/api/pkg/resources/test/fixtures/deployment-vsphere-1.11.0-scheduler.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-vsphere-1.11.0-scheduler.yaml
@@ -94,7 +94,6 @@ spec:
             memory: 5Mi
         securityContext:
           privileged: true
-          procMount: Default
         volumeMounts:
         - mountPath: /etc/openvpn/pki/client
           name: openvpn-client-certificates

--- a/api/pkg/resources/test/fixtures/deployment-vsphere-1.11.1-apiserver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-vsphere-1.11.1-apiserver.yaml
@@ -103,7 +103,6 @@ spec:
             memory: 5Mi
         securityContext:
           privileged: true
-          procMount: Default
         volumeMounts:
         - mountPath: /etc/openvpn/pki/client
           name: openvpn-client-certificates
@@ -121,7 +120,6 @@ spec:
         command:
         - /usr/local/bin/kubeletdnat-controller
         image: 'quay.io/kubermatic/api:'
-        imagePullPolicy: IfNotPresent
         name: dnat-controller
         resources:
           limits:

--- a/api/pkg/resources/test/fixtures/deployment-vsphere-1.11.1-controller-manager.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-vsphere-1.11.1-controller-manager.yaml
@@ -96,7 +96,6 @@ spec:
             memory: 5Mi
         securityContext:
           privileged: true
-          procMount: Default
         volumeMounts:
         - mountPath: /etc/openvpn/pki/client
           name: openvpn-client-certificates

--- a/api/pkg/resources/test/fixtures/deployment-vsphere-1.11.1-dns-resolver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-vsphere-1.11.1-dns-resolver.yaml
@@ -90,7 +90,6 @@ spec:
             memory: 5Mi
         securityContext:
           privileged: true
-          procMount: Default
         volumeMounts:
         - mountPath: /etc/openvpn/pki/client
           name: openvpn-client-certificates

--- a/api/pkg/resources/test/fixtures/deployment-vsphere-1.11.1-metrics-server.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-vsphere-1.11.1-metrics-server.yaml
@@ -119,7 +119,6 @@ spec:
             memory: 5Mi
         securityContext:
           privileged: true
-          procMount: Default
         volumeMounts:
         - mountPath: /etc/openvpn/pki/client
           name: openvpn-client-certificates
@@ -135,7 +134,6 @@ spec:
         command:
         - /usr/local/bin/kubeletdnat-controller
         image: 'quay.io/kubermatic/api:'
-        imagePullPolicy: IfNotPresent
         name: dnat-controller
         resources:
           limits:

--- a/api/pkg/resources/test/fixtures/deployment-vsphere-1.11.1-scheduler.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-vsphere-1.11.1-scheduler.yaml
@@ -94,7 +94,6 @@ spec:
             memory: 5Mi
         securityContext:
           privileged: true
-          procMount: Default
         volumeMounts:
         - mountPath: /etc/openvpn/pki/client
           name: openvpn-client-certificates

--- a/api/pkg/resources/test/fixtures/deployment-vsphere-1.12.0-apiserver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-vsphere-1.12.0-apiserver.yaml
@@ -103,7 +103,6 @@ spec:
             memory: 5Mi
         securityContext:
           privileged: true
-          procMount: Default
         volumeMounts:
         - mountPath: /etc/openvpn/pki/client
           name: openvpn-client-certificates
@@ -121,7 +120,6 @@ spec:
         command:
         - /usr/local/bin/kubeletdnat-controller
         image: 'quay.io/kubermatic/api:'
-        imagePullPolicy: IfNotPresent
         name: dnat-controller
         resources:
           limits:

--- a/api/pkg/resources/test/fixtures/deployment-vsphere-1.12.0-controller-manager.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-vsphere-1.12.0-controller-manager.yaml
@@ -96,7 +96,6 @@ spec:
             memory: 5Mi
         securityContext:
           privileged: true
-          procMount: Default
         volumeMounts:
         - mountPath: /etc/openvpn/pki/client
           name: openvpn-client-certificates

--- a/api/pkg/resources/test/fixtures/deployment-vsphere-1.12.0-dns-resolver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-vsphere-1.12.0-dns-resolver.yaml
@@ -90,7 +90,6 @@ spec:
             memory: 5Mi
         securityContext:
           privileged: true
-          procMount: Default
         volumeMounts:
         - mountPath: /etc/openvpn/pki/client
           name: openvpn-client-certificates

--- a/api/pkg/resources/test/fixtures/deployment-vsphere-1.12.0-metrics-server.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-vsphere-1.12.0-metrics-server.yaml
@@ -119,7 +119,6 @@ spec:
             memory: 5Mi
         securityContext:
           privileged: true
-          procMount: Default
         volumeMounts:
         - mountPath: /etc/openvpn/pki/client
           name: openvpn-client-certificates
@@ -135,7 +134,6 @@ spec:
         command:
         - /usr/local/bin/kubeletdnat-controller
         image: 'quay.io/kubermatic/api:'
-        imagePullPolicy: IfNotPresent
         name: dnat-controller
         resources:
           limits:

--- a/api/pkg/resources/test/fixtures/deployment-vsphere-1.12.0-scheduler.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-vsphere-1.12.0-scheduler.yaml
@@ -94,7 +94,6 @@ spec:
             memory: 5Mi
         securityContext:
           privileged: true
-          procMount: Default
         volumeMounts:
         - mountPath: /etc/openvpn/pki/client
           name: openvpn-client-certificates

--- a/api/pkg/resources/test/fixtures/deployment-vsphere-1.13.0-apiserver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-vsphere-1.13.0-apiserver.yaml
@@ -103,7 +103,6 @@ spec:
             memory: 5Mi
         securityContext:
           privileged: true
-          procMount: Default
         volumeMounts:
         - mountPath: /etc/openvpn/pki/client
           name: openvpn-client-certificates
@@ -121,7 +120,6 @@ spec:
         command:
         - /usr/local/bin/kubeletdnat-controller
         image: 'quay.io/kubermatic/api:'
-        imagePullPolicy: IfNotPresent
         name: dnat-controller
         resources:
           limits:

--- a/api/pkg/resources/test/fixtures/deployment-vsphere-1.13.0-controller-manager.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-vsphere-1.13.0-controller-manager.yaml
@@ -96,7 +96,6 @@ spec:
             memory: 5Mi
         securityContext:
           privileged: true
-          procMount: Default
         volumeMounts:
         - mountPath: /etc/openvpn/pki/client
           name: openvpn-client-certificates

--- a/api/pkg/resources/test/fixtures/deployment-vsphere-1.13.0-dns-resolver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-vsphere-1.13.0-dns-resolver.yaml
@@ -90,7 +90,6 @@ spec:
             memory: 5Mi
         securityContext:
           privileged: true
-          procMount: Default
         volumeMounts:
         - mountPath: /etc/openvpn/pki/client
           name: openvpn-client-certificates

--- a/api/pkg/resources/test/fixtures/deployment-vsphere-1.13.0-metrics-server.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-vsphere-1.13.0-metrics-server.yaml
@@ -119,7 +119,6 @@ spec:
             memory: 5Mi
         securityContext:
           privileged: true
-          procMount: Default
         volumeMounts:
         - mountPath: /etc/openvpn/pki/client
           name: openvpn-client-certificates
@@ -135,7 +134,6 @@ spec:
         command:
         - /usr/local/bin/kubeletdnat-controller
         image: 'quay.io/kubermatic/api:'
-        imagePullPolicy: IfNotPresent
         name: dnat-controller
         resources:
           limits:

--- a/api/pkg/resources/test/fixtures/deployment-vsphere-1.13.0-scheduler.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-vsphere-1.13.0-scheduler.yaml
@@ -94,7 +94,6 @@ spec:
             memory: 5Mi
         securityContext:
           privileged: true
-          procMount: Default
         volumeMounts:
         - mountPath: /etc/openvpn/pki/client
           name: openvpn-client-certificates

--- a/api/pkg/resources/test/fixtures/statefulset-aws-1.10.0-etcd.yaml
+++ b/api/pkg/resources/test/fixtures/statefulset-aws-1.10.0-etcd.yaml
@@ -80,7 +80,6 @@ spec:
         - name: ETCDCTL_API
           value: "3"
         image: gcr.io/etcd-development/etcd:v3.3.12
-        imagePullPolicy: IfNotPresent
         name: etcd
         ports:
         - containerPort: 2379
@@ -117,8 +116,6 @@ spec:
           requests:
             cpu: 50m
             memory: 256Mi
-        terminationMessagePath: /dev/termination-log
-        terminationMessagePolicy: File
         volumeMounts:
         - mountPath: /var/run/etcd
           name: data

--- a/api/pkg/resources/test/fixtures/statefulset-aws-1.10.0-prometheus.yaml
+++ b/api/pkg/resources/test/fixtures/statefulset-aws-1.10.0-prometheus.yaml
@@ -39,7 +39,6 @@ spec:
         - --storage.tsdb.no-lockfile
         - --web.route-prefix=/
         image: quay.io/prometheus/prometheus:v2.9.2
-        imagePullPolicy: IfNotPresent
         livenessProbe:
           failureThreshold: 10
           httpGet:
@@ -72,8 +71,6 @@ spec:
           requests:
             cpu: 50m
             memory: 256Mi
-        terminationMessagePath: /dev/termination-log
-        terminationMessagePolicy: File
         volumeMounts:
         - mountPath: /etc/prometheus/config
           name: config

--- a/api/pkg/resources/test/fixtures/statefulset-aws-1.10.6-etcd.yaml
+++ b/api/pkg/resources/test/fixtures/statefulset-aws-1.10.6-etcd.yaml
@@ -80,7 +80,6 @@ spec:
         - name: ETCDCTL_API
           value: "3"
         image: gcr.io/etcd-development/etcd:v3.3.12
-        imagePullPolicy: IfNotPresent
         name: etcd
         ports:
         - containerPort: 2379
@@ -117,8 +116,6 @@ spec:
           requests:
             cpu: 50m
             memory: 256Mi
-        terminationMessagePath: /dev/termination-log
-        terminationMessagePolicy: File
         volumeMounts:
         - mountPath: /var/run/etcd
           name: data

--- a/api/pkg/resources/test/fixtures/statefulset-aws-1.10.6-prometheus.yaml
+++ b/api/pkg/resources/test/fixtures/statefulset-aws-1.10.6-prometheus.yaml
@@ -39,7 +39,6 @@ spec:
         - --storage.tsdb.no-lockfile
         - --web.route-prefix=/
         image: quay.io/prometheus/prometheus:v2.9.2
-        imagePullPolicy: IfNotPresent
         livenessProbe:
           failureThreshold: 10
           httpGet:
@@ -72,8 +71,6 @@ spec:
           requests:
             cpu: 50m
             memory: 256Mi
-        terminationMessagePath: /dev/termination-log
-        terminationMessagePolicy: File
         volumeMounts:
         - mountPath: /etc/prometheus/config
           name: config

--- a/api/pkg/resources/test/fixtures/statefulset-aws-1.11.0-etcd.yaml
+++ b/api/pkg/resources/test/fixtures/statefulset-aws-1.11.0-etcd.yaml
@@ -80,7 +80,6 @@ spec:
         - name: ETCDCTL_API
           value: "3"
         image: gcr.io/etcd-development/etcd:v3.3.12
-        imagePullPolicy: IfNotPresent
         name: etcd
         ports:
         - containerPort: 2379
@@ -117,8 +116,6 @@ spec:
           requests:
             cpu: 50m
             memory: 256Mi
-        terminationMessagePath: /dev/termination-log
-        terminationMessagePolicy: File
         volumeMounts:
         - mountPath: /var/run/etcd
           name: data

--- a/api/pkg/resources/test/fixtures/statefulset-aws-1.11.0-prometheus.yaml
+++ b/api/pkg/resources/test/fixtures/statefulset-aws-1.11.0-prometheus.yaml
@@ -39,7 +39,6 @@ spec:
         - --storage.tsdb.no-lockfile
         - --web.route-prefix=/
         image: quay.io/prometheus/prometheus:v2.9.2
-        imagePullPolicy: IfNotPresent
         livenessProbe:
           failureThreshold: 10
           httpGet:
@@ -72,8 +71,6 @@ spec:
           requests:
             cpu: 50m
             memory: 256Mi
-        terminationMessagePath: /dev/termination-log
-        terminationMessagePolicy: File
         volumeMounts:
         - mountPath: /etc/prometheus/config
           name: config

--- a/api/pkg/resources/test/fixtures/statefulset-aws-1.11.1-etcd.yaml
+++ b/api/pkg/resources/test/fixtures/statefulset-aws-1.11.1-etcd.yaml
@@ -80,7 +80,6 @@ spec:
         - name: ETCDCTL_API
           value: "3"
         image: gcr.io/etcd-development/etcd:v3.3.12
-        imagePullPolicy: IfNotPresent
         name: etcd
         ports:
         - containerPort: 2379
@@ -117,8 +116,6 @@ spec:
           requests:
             cpu: 50m
             memory: 256Mi
-        terminationMessagePath: /dev/termination-log
-        terminationMessagePolicy: File
         volumeMounts:
         - mountPath: /var/run/etcd
           name: data

--- a/api/pkg/resources/test/fixtures/statefulset-aws-1.11.1-prometheus.yaml
+++ b/api/pkg/resources/test/fixtures/statefulset-aws-1.11.1-prometheus.yaml
@@ -39,7 +39,6 @@ spec:
         - --storage.tsdb.no-lockfile
         - --web.route-prefix=/
         image: quay.io/prometheus/prometheus:v2.9.2
-        imagePullPolicy: IfNotPresent
         livenessProbe:
           failureThreshold: 10
           httpGet:
@@ -72,8 +71,6 @@ spec:
           requests:
             cpu: 50m
             memory: 256Mi
-        terminationMessagePath: /dev/termination-log
-        terminationMessagePolicy: File
         volumeMounts:
         - mountPath: /etc/prometheus/config
           name: config

--- a/api/pkg/resources/test/fixtures/statefulset-aws-1.12.0-etcd.yaml
+++ b/api/pkg/resources/test/fixtures/statefulset-aws-1.12.0-etcd.yaml
@@ -80,7 +80,6 @@ spec:
         - name: ETCDCTL_API
           value: "3"
         image: gcr.io/etcd-development/etcd:v3.3.12
-        imagePullPolicy: IfNotPresent
         name: etcd
         ports:
         - containerPort: 2379
@@ -117,8 +116,6 @@ spec:
           requests:
             cpu: 50m
             memory: 256Mi
-        terminationMessagePath: /dev/termination-log
-        terminationMessagePolicy: File
         volumeMounts:
         - mountPath: /var/run/etcd
           name: data

--- a/api/pkg/resources/test/fixtures/statefulset-aws-1.12.0-prometheus.yaml
+++ b/api/pkg/resources/test/fixtures/statefulset-aws-1.12.0-prometheus.yaml
@@ -39,7 +39,6 @@ spec:
         - --storage.tsdb.no-lockfile
         - --web.route-prefix=/
         image: quay.io/prometheus/prometheus:v2.9.2
-        imagePullPolicy: IfNotPresent
         livenessProbe:
           failureThreshold: 10
           httpGet:
@@ -72,8 +71,6 @@ spec:
           requests:
             cpu: 50m
             memory: 256Mi
-        terminationMessagePath: /dev/termination-log
-        terminationMessagePolicy: File
         volumeMounts:
         - mountPath: /etc/prometheus/config
           name: config

--- a/api/pkg/resources/test/fixtures/statefulset-aws-1.13.0-etcd.yaml
+++ b/api/pkg/resources/test/fixtures/statefulset-aws-1.13.0-etcd.yaml
@@ -80,7 +80,6 @@ spec:
         - name: ETCDCTL_API
           value: "3"
         image: gcr.io/etcd-development/etcd:v3.3.12
-        imagePullPolicy: IfNotPresent
         name: etcd
         ports:
         - containerPort: 2379
@@ -117,8 +116,6 @@ spec:
           requests:
             cpu: 50m
             memory: 256Mi
-        terminationMessagePath: /dev/termination-log
-        terminationMessagePolicy: File
         volumeMounts:
         - mountPath: /var/run/etcd
           name: data

--- a/api/pkg/resources/test/fixtures/statefulset-aws-1.13.0-prometheus.yaml
+++ b/api/pkg/resources/test/fixtures/statefulset-aws-1.13.0-prometheus.yaml
@@ -39,7 +39,6 @@ spec:
         - --storage.tsdb.no-lockfile
         - --web.route-prefix=/
         image: quay.io/prometheus/prometheus:v2.9.2
-        imagePullPolicy: IfNotPresent
         livenessProbe:
           failureThreshold: 10
           httpGet:
@@ -72,8 +71,6 @@ spec:
           requests:
             cpu: 50m
             memory: 256Mi
-        terminationMessagePath: /dev/termination-log
-        terminationMessagePolicy: File
         volumeMounts:
         - mountPath: /etc/prometheus/config
           name: config

--- a/api/pkg/resources/test/fixtures/statefulset-azure-1.10.0-etcd.yaml
+++ b/api/pkg/resources/test/fixtures/statefulset-azure-1.10.0-etcd.yaml
@@ -80,7 +80,6 @@ spec:
         - name: ETCDCTL_API
           value: "3"
         image: gcr.io/etcd-development/etcd:v3.3.12
-        imagePullPolicy: IfNotPresent
         name: etcd
         ports:
         - containerPort: 2379
@@ -117,8 +116,6 @@ spec:
           requests:
             cpu: 50m
             memory: 256Mi
-        terminationMessagePath: /dev/termination-log
-        terminationMessagePolicy: File
         volumeMounts:
         - mountPath: /var/run/etcd
           name: data

--- a/api/pkg/resources/test/fixtures/statefulset-azure-1.10.0-prometheus.yaml
+++ b/api/pkg/resources/test/fixtures/statefulset-azure-1.10.0-prometheus.yaml
@@ -39,7 +39,6 @@ spec:
         - --storage.tsdb.no-lockfile
         - --web.route-prefix=/
         image: quay.io/prometheus/prometheus:v2.9.2
-        imagePullPolicy: IfNotPresent
         livenessProbe:
           failureThreshold: 10
           httpGet:
@@ -72,8 +71,6 @@ spec:
           requests:
             cpu: 50m
             memory: 256Mi
-        terminationMessagePath: /dev/termination-log
-        terminationMessagePolicy: File
         volumeMounts:
         - mountPath: /etc/prometheus/config
           name: config

--- a/api/pkg/resources/test/fixtures/statefulset-azure-1.10.6-etcd.yaml
+++ b/api/pkg/resources/test/fixtures/statefulset-azure-1.10.6-etcd.yaml
@@ -80,7 +80,6 @@ spec:
         - name: ETCDCTL_API
           value: "3"
         image: gcr.io/etcd-development/etcd:v3.3.12
-        imagePullPolicy: IfNotPresent
         name: etcd
         ports:
         - containerPort: 2379
@@ -117,8 +116,6 @@ spec:
           requests:
             cpu: 50m
             memory: 256Mi
-        terminationMessagePath: /dev/termination-log
-        terminationMessagePolicy: File
         volumeMounts:
         - mountPath: /var/run/etcd
           name: data

--- a/api/pkg/resources/test/fixtures/statefulset-azure-1.10.6-prometheus.yaml
+++ b/api/pkg/resources/test/fixtures/statefulset-azure-1.10.6-prometheus.yaml
@@ -39,7 +39,6 @@ spec:
         - --storage.tsdb.no-lockfile
         - --web.route-prefix=/
         image: quay.io/prometheus/prometheus:v2.9.2
-        imagePullPolicy: IfNotPresent
         livenessProbe:
           failureThreshold: 10
           httpGet:
@@ -72,8 +71,6 @@ spec:
           requests:
             cpu: 50m
             memory: 256Mi
-        terminationMessagePath: /dev/termination-log
-        terminationMessagePolicy: File
         volumeMounts:
         - mountPath: /etc/prometheus/config
           name: config

--- a/api/pkg/resources/test/fixtures/statefulset-azure-1.11.0-etcd.yaml
+++ b/api/pkg/resources/test/fixtures/statefulset-azure-1.11.0-etcd.yaml
@@ -80,7 +80,6 @@ spec:
         - name: ETCDCTL_API
           value: "3"
         image: gcr.io/etcd-development/etcd:v3.3.12
-        imagePullPolicy: IfNotPresent
         name: etcd
         ports:
         - containerPort: 2379
@@ -117,8 +116,6 @@ spec:
           requests:
             cpu: 50m
             memory: 256Mi
-        terminationMessagePath: /dev/termination-log
-        terminationMessagePolicy: File
         volumeMounts:
         - mountPath: /var/run/etcd
           name: data

--- a/api/pkg/resources/test/fixtures/statefulset-azure-1.11.0-prometheus.yaml
+++ b/api/pkg/resources/test/fixtures/statefulset-azure-1.11.0-prometheus.yaml
@@ -39,7 +39,6 @@ spec:
         - --storage.tsdb.no-lockfile
         - --web.route-prefix=/
         image: quay.io/prometheus/prometheus:v2.9.2
-        imagePullPolicy: IfNotPresent
         livenessProbe:
           failureThreshold: 10
           httpGet:
@@ -72,8 +71,6 @@ spec:
           requests:
             cpu: 50m
             memory: 256Mi
-        terminationMessagePath: /dev/termination-log
-        terminationMessagePolicy: File
         volumeMounts:
         - mountPath: /etc/prometheus/config
           name: config

--- a/api/pkg/resources/test/fixtures/statefulset-azure-1.11.1-etcd.yaml
+++ b/api/pkg/resources/test/fixtures/statefulset-azure-1.11.1-etcd.yaml
@@ -80,7 +80,6 @@ spec:
         - name: ETCDCTL_API
           value: "3"
         image: gcr.io/etcd-development/etcd:v3.3.12
-        imagePullPolicy: IfNotPresent
         name: etcd
         ports:
         - containerPort: 2379
@@ -117,8 +116,6 @@ spec:
           requests:
             cpu: 50m
             memory: 256Mi
-        terminationMessagePath: /dev/termination-log
-        terminationMessagePolicy: File
         volumeMounts:
         - mountPath: /var/run/etcd
           name: data

--- a/api/pkg/resources/test/fixtures/statefulset-azure-1.11.1-prometheus.yaml
+++ b/api/pkg/resources/test/fixtures/statefulset-azure-1.11.1-prometheus.yaml
@@ -39,7 +39,6 @@ spec:
         - --storage.tsdb.no-lockfile
         - --web.route-prefix=/
         image: quay.io/prometheus/prometheus:v2.9.2
-        imagePullPolicy: IfNotPresent
         livenessProbe:
           failureThreshold: 10
           httpGet:
@@ -72,8 +71,6 @@ spec:
           requests:
             cpu: 50m
             memory: 256Mi
-        terminationMessagePath: /dev/termination-log
-        terminationMessagePolicy: File
         volumeMounts:
         - mountPath: /etc/prometheus/config
           name: config

--- a/api/pkg/resources/test/fixtures/statefulset-azure-1.12.0-etcd.yaml
+++ b/api/pkg/resources/test/fixtures/statefulset-azure-1.12.0-etcd.yaml
@@ -80,7 +80,6 @@ spec:
         - name: ETCDCTL_API
           value: "3"
         image: gcr.io/etcd-development/etcd:v3.3.12
-        imagePullPolicy: IfNotPresent
         name: etcd
         ports:
         - containerPort: 2379
@@ -117,8 +116,6 @@ spec:
           requests:
             cpu: 50m
             memory: 256Mi
-        terminationMessagePath: /dev/termination-log
-        terminationMessagePolicy: File
         volumeMounts:
         - mountPath: /var/run/etcd
           name: data

--- a/api/pkg/resources/test/fixtures/statefulset-azure-1.12.0-prometheus.yaml
+++ b/api/pkg/resources/test/fixtures/statefulset-azure-1.12.0-prometheus.yaml
@@ -39,7 +39,6 @@ spec:
         - --storage.tsdb.no-lockfile
         - --web.route-prefix=/
         image: quay.io/prometheus/prometheus:v2.9.2
-        imagePullPolicy: IfNotPresent
         livenessProbe:
           failureThreshold: 10
           httpGet:
@@ -72,8 +71,6 @@ spec:
           requests:
             cpu: 50m
             memory: 256Mi
-        terminationMessagePath: /dev/termination-log
-        terminationMessagePolicy: File
         volumeMounts:
         - mountPath: /etc/prometheus/config
           name: config

--- a/api/pkg/resources/test/fixtures/statefulset-azure-1.13.0-etcd.yaml
+++ b/api/pkg/resources/test/fixtures/statefulset-azure-1.13.0-etcd.yaml
@@ -80,7 +80,6 @@ spec:
         - name: ETCDCTL_API
           value: "3"
         image: gcr.io/etcd-development/etcd:v3.3.12
-        imagePullPolicy: IfNotPresent
         name: etcd
         ports:
         - containerPort: 2379
@@ -117,8 +116,6 @@ spec:
           requests:
             cpu: 50m
             memory: 256Mi
-        terminationMessagePath: /dev/termination-log
-        terminationMessagePolicy: File
         volumeMounts:
         - mountPath: /var/run/etcd
           name: data

--- a/api/pkg/resources/test/fixtures/statefulset-azure-1.13.0-prometheus.yaml
+++ b/api/pkg/resources/test/fixtures/statefulset-azure-1.13.0-prometheus.yaml
@@ -39,7 +39,6 @@ spec:
         - --storage.tsdb.no-lockfile
         - --web.route-prefix=/
         image: quay.io/prometheus/prometheus:v2.9.2
-        imagePullPolicy: IfNotPresent
         livenessProbe:
           failureThreshold: 10
           httpGet:
@@ -72,8 +71,6 @@ spec:
           requests:
             cpu: 50m
             memory: 256Mi
-        terminationMessagePath: /dev/termination-log
-        terminationMessagePolicy: File
         volumeMounts:
         - mountPath: /etc/prometheus/config
           name: config

--- a/api/pkg/resources/test/fixtures/statefulset-bringyourown-1.10.0-etcd.yaml
+++ b/api/pkg/resources/test/fixtures/statefulset-bringyourown-1.10.0-etcd.yaml
@@ -80,7 +80,6 @@ spec:
         - name: ETCDCTL_API
           value: "3"
         image: gcr.io/etcd-development/etcd:v3.3.12
-        imagePullPolicy: IfNotPresent
         name: etcd
         ports:
         - containerPort: 2379
@@ -117,8 +116,6 @@ spec:
           requests:
             cpu: 50m
             memory: 256Mi
-        terminationMessagePath: /dev/termination-log
-        terminationMessagePolicy: File
         volumeMounts:
         - mountPath: /var/run/etcd
           name: data

--- a/api/pkg/resources/test/fixtures/statefulset-bringyourown-1.10.0-prometheus.yaml
+++ b/api/pkg/resources/test/fixtures/statefulset-bringyourown-1.10.0-prometheus.yaml
@@ -39,7 +39,6 @@ spec:
         - --storage.tsdb.no-lockfile
         - --web.route-prefix=/
         image: quay.io/prometheus/prometheus:v2.9.2
-        imagePullPolicy: IfNotPresent
         livenessProbe:
           failureThreshold: 10
           httpGet:
@@ -72,8 +71,6 @@ spec:
           requests:
             cpu: 50m
             memory: 256Mi
-        terminationMessagePath: /dev/termination-log
-        terminationMessagePolicy: File
         volumeMounts:
         - mountPath: /etc/prometheus/config
           name: config

--- a/api/pkg/resources/test/fixtures/statefulset-bringyourown-1.10.6-etcd.yaml
+++ b/api/pkg/resources/test/fixtures/statefulset-bringyourown-1.10.6-etcd.yaml
@@ -80,7 +80,6 @@ spec:
         - name: ETCDCTL_API
           value: "3"
         image: gcr.io/etcd-development/etcd:v3.3.12
-        imagePullPolicy: IfNotPresent
         name: etcd
         ports:
         - containerPort: 2379
@@ -117,8 +116,6 @@ spec:
           requests:
             cpu: 50m
             memory: 256Mi
-        terminationMessagePath: /dev/termination-log
-        terminationMessagePolicy: File
         volumeMounts:
         - mountPath: /var/run/etcd
           name: data

--- a/api/pkg/resources/test/fixtures/statefulset-bringyourown-1.10.6-prometheus.yaml
+++ b/api/pkg/resources/test/fixtures/statefulset-bringyourown-1.10.6-prometheus.yaml
@@ -39,7 +39,6 @@ spec:
         - --storage.tsdb.no-lockfile
         - --web.route-prefix=/
         image: quay.io/prometheus/prometheus:v2.9.2
-        imagePullPolicy: IfNotPresent
         livenessProbe:
           failureThreshold: 10
           httpGet:
@@ -72,8 +71,6 @@ spec:
           requests:
             cpu: 50m
             memory: 256Mi
-        terminationMessagePath: /dev/termination-log
-        terminationMessagePolicy: File
         volumeMounts:
         - mountPath: /etc/prometheus/config
           name: config

--- a/api/pkg/resources/test/fixtures/statefulset-bringyourown-1.11.0-etcd.yaml
+++ b/api/pkg/resources/test/fixtures/statefulset-bringyourown-1.11.0-etcd.yaml
@@ -80,7 +80,6 @@ spec:
         - name: ETCDCTL_API
           value: "3"
         image: gcr.io/etcd-development/etcd:v3.3.12
-        imagePullPolicy: IfNotPresent
         name: etcd
         ports:
         - containerPort: 2379
@@ -117,8 +116,6 @@ spec:
           requests:
             cpu: 50m
             memory: 256Mi
-        terminationMessagePath: /dev/termination-log
-        terminationMessagePolicy: File
         volumeMounts:
         - mountPath: /var/run/etcd
           name: data

--- a/api/pkg/resources/test/fixtures/statefulset-bringyourown-1.11.0-prometheus.yaml
+++ b/api/pkg/resources/test/fixtures/statefulset-bringyourown-1.11.0-prometheus.yaml
@@ -39,7 +39,6 @@ spec:
         - --storage.tsdb.no-lockfile
         - --web.route-prefix=/
         image: quay.io/prometheus/prometheus:v2.9.2
-        imagePullPolicy: IfNotPresent
         livenessProbe:
           failureThreshold: 10
           httpGet:
@@ -72,8 +71,6 @@ spec:
           requests:
             cpu: 50m
             memory: 256Mi
-        terminationMessagePath: /dev/termination-log
-        terminationMessagePolicy: File
         volumeMounts:
         - mountPath: /etc/prometheus/config
           name: config

--- a/api/pkg/resources/test/fixtures/statefulset-bringyourown-1.11.1-etcd.yaml
+++ b/api/pkg/resources/test/fixtures/statefulset-bringyourown-1.11.1-etcd.yaml
@@ -80,7 +80,6 @@ spec:
         - name: ETCDCTL_API
           value: "3"
         image: gcr.io/etcd-development/etcd:v3.3.12
-        imagePullPolicy: IfNotPresent
         name: etcd
         ports:
         - containerPort: 2379
@@ -117,8 +116,6 @@ spec:
           requests:
             cpu: 50m
             memory: 256Mi
-        terminationMessagePath: /dev/termination-log
-        terminationMessagePolicy: File
         volumeMounts:
         - mountPath: /var/run/etcd
           name: data

--- a/api/pkg/resources/test/fixtures/statefulset-bringyourown-1.11.1-prometheus.yaml
+++ b/api/pkg/resources/test/fixtures/statefulset-bringyourown-1.11.1-prometheus.yaml
@@ -39,7 +39,6 @@ spec:
         - --storage.tsdb.no-lockfile
         - --web.route-prefix=/
         image: quay.io/prometheus/prometheus:v2.9.2
-        imagePullPolicy: IfNotPresent
         livenessProbe:
           failureThreshold: 10
           httpGet:
@@ -72,8 +71,6 @@ spec:
           requests:
             cpu: 50m
             memory: 256Mi
-        terminationMessagePath: /dev/termination-log
-        terminationMessagePolicy: File
         volumeMounts:
         - mountPath: /etc/prometheus/config
           name: config

--- a/api/pkg/resources/test/fixtures/statefulset-bringyourown-1.12.0-etcd.yaml
+++ b/api/pkg/resources/test/fixtures/statefulset-bringyourown-1.12.0-etcd.yaml
@@ -80,7 +80,6 @@ spec:
         - name: ETCDCTL_API
           value: "3"
         image: gcr.io/etcd-development/etcd:v3.3.12
-        imagePullPolicy: IfNotPresent
         name: etcd
         ports:
         - containerPort: 2379
@@ -117,8 +116,6 @@ spec:
           requests:
             cpu: 50m
             memory: 256Mi
-        terminationMessagePath: /dev/termination-log
-        terminationMessagePolicy: File
         volumeMounts:
         - mountPath: /var/run/etcd
           name: data

--- a/api/pkg/resources/test/fixtures/statefulset-bringyourown-1.12.0-prometheus.yaml
+++ b/api/pkg/resources/test/fixtures/statefulset-bringyourown-1.12.0-prometheus.yaml
@@ -39,7 +39,6 @@ spec:
         - --storage.tsdb.no-lockfile
         - --web.route-prefix=/
         image: quay.io/prometheus/prometheus:v2.9.2
-        imagePullPolicy: IfNotPresent
         livenessProbe:
           failureThreshold: 10
           httpGet:
@@ -72,8 +71,6 @@ spec:
           requests:
             cpu: 50m
             memory: 256Mi
-        terminationMessagePath: /dev/termination-log
-        terminationMessagePolicy: File
         volumeMounts:
         - mountPath: /etc/prometheus/config
           name: config

--- a/api/pkg/resources/test/fixtures/statefulset-bringyourown-1.13.0-etcd.yaml
+++ b/api/pkg/resources/test/fixtures/statefulset-bringyourown-1.13.0-etcd.yaml
@@ -80,7 +80,6 @@ spec:
         - name: ETCDCTL_API
           value: "3"
         image: gcr.io/etcd-development/etcd:v3.3.12
-        imagePullPolicy: IfNotPresent
         name: etcd
         ports:
         - containerPort: 2379
@@ -117,8 +116,6 @@ spec:
           requests:
             cpu: 50m
             memory: 256Mi
-        terminationMessagePath: /dev/termination-log
-        terminationMessagePolicy: File
         volumeMounts:
         - mountPath: /var/run/etcd
           name: data

--- a/api/pkg/resources/test/fixtures/statefulset-bringyourown-1.13.0-prometheus.yaml
+++ b/api/pkg/resources/test/fixtures/statefulset-bringyourown-1.13.0-prometheus.yaml
@@ -39,7 +39,6 @@ spec:
         - --storage.tsdb.no-lockfile
         - --web.route-prefix=/
         image: quay.io/prometheus/prometheus:v2.9.2
-        imagePullPolicy: IfNotPresent
         livenessProbe:
           failureThreshold: 10
           httpGet:
@@ -72,8 +71,6 @@ spec:
           requests:
             cpu: 50m
             memory: 256Mi
-        terminationMessagePath: /dev/termination-log
-        terminationMessagePolicy: File
         volumeMounts:
         - mountPath: /etc/prometheus/config
           name: config

--- a/api/pkg/resources/test/fixtures/statefulset-digitalocean-1.10.0-etcd.yaml
+++ b/api/pkg/resources/test/fixtures/statefulset-digitalocean-1.10.0-etcd.yaml
@@ -80,7 +80,6 @@ spec:
         - name: ETCDCTL_API
           value: "3"
         image: gcr.io/etcd-development/etcd:v3.3.12
-        imagePullPolicy: IfNotPresent
         name: etcd
         ports:
         - containerPort: 2379
@@ -117,8 +116,6 @@ spec:
           requests:
             cpu: 50m
             memory: 256Mi
-        terminationMessagePath: /dev/termination-log
-        terminationMessagePolicy: File
         volumeMounts:
         - mountPath: /var/run/etcd
           name: data

--- a/api/pkg/resources/test/fixtures/statefulset-digitalocean-1.10.0-prometheus.yaml
+++ b/api/pkg/resources/test/fixtures/statefulset-digitalocean-1.10.0-prometheus.yaml
@@ -39,7 +39,6 @@ spec:
         - --storage.tsdb.no-lockfile
         - --web.route-prefix=/
         image: quay.io/prometheus/prometheus:v2.9.2
-        imagePullPolicy: IfNotPresent
         livenessProbe:
           failureThreshold: 10
           httpGet:
@@ -72,8 +71,6 @@ spec:
           requests:
             cpu: 50m
             memory: 256Mi
-        terminationMessagePath: /dev/termination-log
-        terminationMessagePolicy: File
         volumeMounts:
         - mountPath: /etc/prometheus/config
           name: config

--- a/api/pkg/resources/test/fixtures/statefulset-digitalocean-1.10.6-etcd.yaml
+++ b/api/pkg/resources/test/fixtures/statefulset-digitalocean-1.10.6-etcd.yaml
@@ -80,7 +80,6 @@ spec:
         - name: ETCDCTL_API
           value: "3"
         image: gcr.io/etcd-development/etcd:v3.3.12
-        imagePullPolicy: IfNotPresent
         name: etcd
         ports:
         - containerPort: 2379
@@ -117,8 +116,6 @@ spec:
           requests:
             cpu: 50m
             memory: 256Mi
-        terminationMessagePath: /dev/termination-log
-        terminationMessagePolicy: File
         volumeMounts:
         - mountPath: /var/run/etcd
           name: data

--- a/api/pkg/resources/test/fixtures/statefulset-digitalocean-1.10.6-prometheus.yaml
+++ b/api/pkg/resources/test/fixtures/statefulset-digitalocean-1.10.6-prometheus.yaml
@@ -39,7 +39,6 @@ spec:
         - --storage.tsdb.no-lockfile
         - --web.route-prefix=/
         image: quay.io/prometheus/prometheus:v2.9.2
-        imagePullPolicy: IfNotPresent
         livenessProbe:
           failureThreshold: 10
           httpGet:
@@ -72,8 +71,6 @@ spec:
           requests:
             cpu: 50m
             memory: 256Mi
-        terminationMessagePath: /dev/termination-log
-        terminationMessagePolicy: File
         volumeMounts:
         - mountPath: /etc/prometheus/config
           name: config

--- a/api/pkg/resources/test/fixtures/statefulset-digitalocean-1.11.0-etcd.yaml
+++ b/api/pkg/resources/test/fixtures/statefulset-digitalocean-1.11.0-etcd.yaml
@@ -80,7 +80,6 @@ spec:
         - name: ETCDCTL_API
           value: "3"
         image: gcr.io/etcd-development/etcd:v3.3.12
-        imagePullPolicy: IfNotPresent
         name: etcd
         ports:
         - containerPort: 2379
@@ -117,8 +116,6 @@ spec:
           requests:
             cpu: 50m
             memory: 256Mi
-        terminationMessagePath: /dev/termination-log
-        terminationMessagePolicy: File
         volumeMounts:
         - mountPath: /var/run/etcd
           name: data

--- a/api/pkg/resources/test/fixtures/statefulset-digitalocean-1.11.0-prometheus.yaml
+++ b/api/pkg/resources/test/fixtures/statefulset-digitalocean-1.11.0-prometheus.yaml
@@ -39,7 +39,6 @@ spec:
         - --storage.tsdb.no-lockfile
         - --web.route-prefix=/
         image: quay.io/prometheus/prometheus:v2.9.2
-        imagePullPolicy: IfNotPresent
         livenessProbe:
           failureThreshold: 10
           httpGet:
@@ -72,8 +71,6 @@ spec:
           requests:
             cpu: 50m
             memory: 256Mi
-        terminationMessagePath: /dev/termination-log
-        terminationMessagePolicy: File
         volumeMounts:
         - mountPath: /etc/prometheus/config
           name: config

--- a/api/pkg/resources/test/fixtures/statefulset-digitalocean-1.11.1-etcd.yaml
+++ b/api/pkg/resources/test/fixtures/statefulset-digitalocean-1.11.1-etcd.yaml
@@ -80,7 +80,6 @@ spec:
         - name: ETCDCTL_API
           value: "3"
         image: gcr.io/etcd-development/etcd:v3.3.12
-        imagePullPolicy: IfNotPresent
         name: etcd
         ports:
         - containerPort: 2379
@@ -117,8 +116,6 @@ spec:
           requests:
             cpu: 50m
             memory: 256Mi
-        terminationMessagePath: /dev/termination-log
-        terminationMessagePolicy: File
         volumeMounts:
         - mountPath: /var/run/etcd
           name: data

--- a/api/pkg/resources/test/fixtures/statefulset-digitalocean-1.11.1-prometheus.yaml
+++ b/api/pkg/resources/test/fixtures/statefulset-digitalocean-1.11.1-prometheus.yaml
@@ -39,7 +39,6 @@ spec:
         - --storage.tsdb.no-lockfile
         - --web.route-prefix=/
         image: quay.io/prometheus/prometheus:v2.9.2
-        imagePullPolicy: IfNotPresent
         livenessProbe:
           failureThreshold: 10
           httpGet:
@@ -72,8 +71,6 @@ spec:
           requests:
             cpu: 50m
             memory: 256Mi
-        terminationMessagePath: /dev/termination-log
-        terminationMessagePolicy: File
         volumeMounts:
         - mountPath: /etc/prometheus/config
           name: config

--- a/api/pkg/resources/test/fixtures/statefulset-digitalocean-1.12.0-etcd.yaml
+++ b/api/pkg/resources/test/fixtures/statefulset-digitalocean-1.12.0-etcd.yaml
@@ -80,7 +80,6 @@ spec:
         - name: ETCDCTL_API
           value: "3"
         image: gcr.io/etcd-development/etcd:v3.3.12
-        imagePullPolicy: IfNotPresent
         name: etcd
         ports:
         - containerPort: 2379
@@ -117,8 +116,6 @@ spec:
           requests:
             cpu: 50m
             memory: 256Mi
-        terminationMessagePath: /dev/termination-log
-        terminationMessagePolicy: File
         volumeMounts:
         - mountPath: /var/run/etcd
           name: data

--- a/api/pkg/resources/test/fixtures/statefulset-digitalocean-1.12.0-prometheus.yaml
+++ b/api/pkg/resources/test/fixtures/statefulset-digitalocean-1.12.0-prometheus.yaml
@@ -39,7 +39,6 @@ spec:
         - --storage.tsdb.no-lockfile
         - --web.route-prefix=/
         image: quay.io/prometheus/prometheus:v2.9.2
-        imagePullPolicy: IfNotPresent
         livenessProbe:
           failureThreshold: 10
           httpGet:
@@ -72,8 +71,6 @@ spec:
           requests:
             cpu: 50m
             memory: 256Mi
-        terminationMessagePath: /dev/termination-log
-        terminationMessagePolicy: File
         volumeMounts:
         - mountPath: /etc/prometheus/config
           name: config

--- a/api/pkg/resources/test/fixtures/statefulset-digitalocean-1.13.0-etcd.yaml
+++ b/api/pkg/resources/test/fixtures/statefulset-digitalocean-1.13.0-etcd.yaml
@@ -80,7 +80,6 @@ spec:
         - name: ETCDCTL_API
           value: "3"
         image: gcr.io/etcd-development/etcd:v3.3.12
-        imagePullPolicy: IfNotPresent
         name: etcd
         ports:
         - containerPort: 2379
@@ -117,8 +116,6 @@ spec:
           requests:
             cpu: 50m
             memory: 256Mi
-        terminationMessagePath: /dev/termination-log
-        terminationMessagePolicy: File
         volumeMounts:
         - mountPath: /var/run/etcd
           name: data

--- a/api/pkg/resources/test/fixtures/statefulset-digitalocean-1.13.0-prometheus.yaml
+++ b/api/pkg/resources/test/fixtures/statefulset-digitalocean-1.13.0-prometheus.yaml
@@ -39,7 +39,6 @@ spec:
         - --storage.tsdb.no-lockfile
         - --web.route-prefix=/
         image: quay.io/prometheus/prometheus:v2.9.2
-        imagePullPolicy: IfNotPresent
         livenessProbe:
           failureThreshold: 10
           httpGet:
@@ -72,8 +71,6 @@ spec:
           requests:
             cpu: 50m
             memory: 256Mi
-        terminationMessagePath: /dev/termination-log
-        terminationMessagePolicy: File
         volumeMounts:
         - mountPath: /etc/prometheus/config
           name: config

--- a/api/pkg/resources/test/fixtures/statefulset-openstack-1.10.0-etcd.yaml
+++ b/api/pkg/resources/test/fixtures/statefulset-openstack-1.10.0-etcd.yaml
@@ -80,7 +80,6 @@ spec:
         - name: ETCDCTL_API
           value: "3"
         image: gcr.io/etcd-development/etcd:v3.3.12
-        imagePullPolicy: IfNotPresent
         name: etcd
         ports:
         - containerPort: 2379
@@ -117,8 +116,6 @@ spec:
           requests:
             cpu: 50m
             memory: 256Mi
-        terminationMessagePath: /dev/termination-log
-        terminationMessagePolicy: File
         volumeMounts:
         - mountPath: /var/run/etcd
           name: data

--- a/api/pkg/resources/test/fixtures/statefulset-openstack-1.10.0-prometheus.yaml
+++ b/api/pkg/resources/test/fixtures/statefulset-openstack-1.10.0-prometheus.yaml
@@ -39,7 +39,6 @@ spec:
         - --storage.tsdb.no-lockfile
         - --web.route-prefix=/
         image: quay.io/prometheus/prometheus:v2.9.2
-        imagePullPolicy: IfNotPresent
         livenessProbe:
           failureThreshold: 10
           httpGet:
@@ -72,8 +71,6 @@ spec:
           requests:
             cpu: 50m
             memory: 256Mi
-        terminationMessagePath: /dev/termination-log
-        terminationMessagePolicy: File
         volumeMounts:
         - mountPath: /etc/prometheus/config
           name: config

--- a/api/pkg/resources/test/fixtures/statefulset-openstack-1.10.6-etcd.yaml
+++ b/api/pkg/resources/test/fixtures/statefulset-openstack-1.10.6-etcd.yaml
@@ -80,7 +80,6 @@ spec:
         - name: ETCDCTL_API
           value: "3"
         image: gcr.io/etcd-development/etcd:v3.3.12
-        imagePullPolicy: IfNotPresent
         name: etcd
         ports:
         - containerPort: 2379
@@ -117,8 +116,6 @@ spec:
           requests:
             cpu: 50m
             memory: 256Mi
-        terminationMessagePath: /dev/termination-log
-        terminationMessagePolicy: File
         volumeMounts:
         - mountPath: /var/run/etcd
           name: data

--- a/api/pkg/resources/test/fixtures/statefulset-openstack-1.10.6-prometheus.yaml
+++ b/api/pkg/resources/test/fixtures/statefulset-openstack-1.10.6-prometheus.yaml
@@ -39,7 +39,6 @@ spec:
         - --storage.tsdb.no-lockfile
         - --web.route-prefix=/
         image: quay.io/prometheus/prometheus:v2.9.2
-        imagePullPolicy: IfNotPresent
         livenessProbe:
           failureThreshold: 10
           httpGet:
@@ -72,8 +71,6 @@ spec:
           requests:
             cpu: 50m
             memory: 256Mi
-        terminationMessagePath: /dev/termination-log
-        terminationMessagePolicy: File
         volumeMounts:
         - mountPath: /etc/prometheus/config
           name: config

--- a/api/pkg/resources/test/fixtures/statefulset-openstack-1.11.0-etcd.yaml
+++ b/api/pkg/resources/test/fixtures/statefulset-openstack-1.11.0-etcd.yaml
@@ -80,7 +80,6 @@ spec:
         - name: ETCDCTL_API
           value: "3"
         image: gcr.io/etcd-development/etcd:v3.3.12
-        imagePullPolicy: IfNotPresent
         name: etcd
         ports:
         - containerPort: 2379
@@ -117,8 +116,6 @@ spec:
           requests:
             cpu: 50m
             memory: 256Mi
-        terminationMessagePath: /dev/termination-log
-        terminationMessagePolicy: File
         volumeMounts:
         - mountPath: /var/run/etcd
           name: data

--- a/api/pkg/resources/test/fixtures/statefulset-openstack-1.11.0-prometheus.yaml
+++ b/api/pkg/resources/test/fixtures/statefulset-openstack-1.11.0-prometheus.yaml
@@ -39,7 +39,6 @@ spec:
         - --storage.tsdb.no-lockfile
         - --web.route-prefix=/
         image: quay.io/prometheus/prometheus:v2.9.2
-        imagePullPolicy: IfNotPresent
         livenessProbe:
           failureThreshold: 10
           httpGet:
@@ -72,8 +71,6 @@ spec:
           requests:
             cpu: 50m
             memory: 256Mi
-        terminationMessagePath: /dev/termination-log
-        terminationMessagePolicy: File
         volumeMounts:
         - mountPath: /etc/prometheus/config
           name: config

--- a/api/pkg/resources/test/fixtures/statefulset-openstack-1.11.1-etcd.yaml
+++ b/api/pkg/resources/test/fixtures/statefulset-openstack-1.11.1-etcd.yaml
@@ -80,7 +80,6 @@ spec:
         - name: ETCDCTL_API
           value: "3"
         image: gcr.io/etcd-development/etcd:v3.3.12
-        imagePullPolicy: IfNotPresent
         name: etcd
         ports:
         - containerPort: 2379
@@ -117,8 +116,6 @@ spec:
           requests:
             cpu: 50m
             memory: 256Mi
-        terminationMessagePath: /dev/termination-log
-        terminationMessagePolicy: File
         volumeMounts:
         - mountPath: /var/run/etcd
           name: data

--- a/api/pkg/resources/test/fixtures/statefulset-openstack-1.11.1-prometheus.yaml
+++ b/api/pkg/resources/test/fixtures/statefulset-openstack-1.11.1-prometheus.yaml
@@ -39,7 +39,6 @@ spec:
         - --storage.tsdb.no-lockfile
         - --web.route-prefix=/
         image: quay.io/prometheus/prometheus:v2.9.2
-        imagePullPolicy: IfNotPresent
         livenessProbe:
           failureThreshold: 10
           httpGet:
@@ -72,8 +71,6 @@ spec:
           requests:
             cpu: 50m
             memory: 256Mi
-        terminationMessagePath: /dev/termination-log
-        terminationMessagePolicy: File
         volumeMounts:
         - mountPath: /etc/prometheus/config
           name: config

--- a/api/pkg/resources/test/fixtures/statefulset-openstack-1.12.0-etcd.yaml
+++ b/api/pkg/resources/test/fixtures/statefulset-openstack-1.12.0-etcd.yaml
@@ -80,7 +80,6 @@ spec:
         - name: ETCDCTL_API
           value: "3"
         image: gcr.io/etcd-development/etcd:v3.3.12
-        imagePullPolicy: IfNotPresent
         name: etcd
         ports:
         - containerPort: 2379
@@ -117,8 +116,6 @@ spec:
           requests:
             cpu: 50m
             memory: 256Mi
-        terminationMessagePath: /dev/termination-log
-        terminationMessagePolicy: File
         volumeMounts:
         - mountPath: /var/run/etcd
           name: data

--- a/api/pkg/resources/test/fixtures/statefulset-openstack-1.12.0-prometheus.yaml
+++ b/api/pkg/resources/test/fixtures/statefulset-openstack-1.12.0-prometheus.yaml
@@ -39,7 +39,6 @@ spec:
         - --storage.tsdb.no-lockfile
         - --web.route-prefix=/
         image: quay.io/prometheus/prometheus:v2.9.2
-        imagePullPolicy: IfNotPresent
         livenessProbe:
           failureThreshold: 10
           httpGet:
@@ -72,8 +71,6 @@ spec:
           requests:
             cpu: 50m
             memory: 256Mi
-        terminationMessagePath: /dev/termination-log
-        terminationMessagePolicy: File
         volumeMounts:
         - mountPath: /etc/prometheus/config
           name: config

--- a/api/pkg/resources/test/fixtures/statefulset-openstack-1.13.0-etcd.yaml
+++ b/api/pkg/resources/test/fixtures/statefulset-openstack-1.13.0-etcd.yaml
@@ -80,7 +80,6 @@ spec:
         - name: ETCDCTL_API
           value: "3"
         image: gcr.io/etcd-development/etcd:v3.3.12
-        imagePullPolicy: IfNotPresent
         name: etcd
         ports:
         - containerPort: 2379
@@ -117,8 +116,6 @@ spec:
           requests:
             cpu: 50m
             memory: 256Mi
-        terminationMessagePath: /dev/termination-log
-        terminationMessagePolicy: File
         volumeMounts:
         - mountPath: /var/run/etcd
           name: data

--- a/api/pkg/resources/test/fixtures/statefulset-openstack-1.13.0-prometheus.yaml
+++ b/api/pkg/resources/test/fixtures/statefulset-openstack-1.13.0-prometheus.yaml
@@ -39,7 +39,6 @@ spec:
         - --storage.tsdb.no-lockfile
         - --web.route-prefix=/
         image: quay.io/prometheus/prometheus:v2.9.2
-        imagePullPolicy: IfNotPresent
         livenessProbe:
           failureThreshold: 10
           httpGet:
@@ -72,8 +71,6 @@ spec:
           requests:
             cpu: 50m
             memory: 256Mi
-        terminationMessagePath: /dev/termination-log
-        terminationMessagePolicy: File
         volumeMounts:
         - mountPath: /etc/prometheus/config
           name: config

--- a/api/pkg/resources/test/fixtures/statefulset-vsphere-1.10.0-etcd.yaml
+++ b/api/pkg/resources/test/fixtures/statefulset-vsphere-1.10.0-etcd.yaml
@@ -80,7 +80,6 @@ spec:
         - name: ETCDCTL_API
           value: "3"
         image: gcr.io/etcd-development/etcd:v3.3.12
-        imagePullPolicy: IfNotPresent
         name: etcd
         ports:
         - containerPort: 2379
@@ -117,8 +116,6 @@ spec:
           requests:
             cpu: 50m
             memory: 256Mi
-        terminationMessagePath: /dev/termination-log
-        terminationMessagePolicy: File
         volumeMounts:
         - mountPath: /var/run/etcd
           name: data

--- a/api/pkg/resources/test/fixtures/statefulset-vsphere-1.10.0-prometheus.yaml
+++ b/api/pkg/resources/test/fixtures/statefulset-vsphere-1.10.0-prometheus.yaml
@@ -39,7 +39,6 @@ spec:
         - --storage.tsdb.no-lockfile
         - --web.route-prefix=/
         image: quay.io/prometheus/prometheus:v2.9.2
-        imagePullPolicy: IfNotPresent
         livenessProbe:
           failureThreshold: 10
           httpGet:
@@ -72,8 +71,6 @@ spec:
           requests:
             cpu: 50m
             memory: 256Mi
-        terminationMessagePath: /dev/termination-log
-        terminationMessagePolicy: File
         volumeMounts:
         - mountPath: /etc/prometheus/config
           name: config

--- a/api/pkg/resources/test/fixtures/statefulset-vsphere-1.10.6-etcd.yaml
+++ b/api/pkg/resources/test/fixtures/statefulset-vsphere-1.10.6-etcd.yaml
@@ -80,7 +80,6 @@ spec:
         - name: ETCDCTL_API
           value: "3"
         image: gcr.io/etcd-development/etcd:v3.3.12
-        imagePullPolicy: IfNotPresent
         name: etcd
         ports:
         - containerPort: 2379
@@ -117,8 +116,6 @@ spec:
           requests:
             cpu: 50m
             memory: 256Mi
-        terminationMessagePath: /dev/termination-log
-        terminationMessagePolicy: File
         volumeMounts:
         - mountPath: /var/run/etcd
           name: data

--- a/api/pkg/resources/test/fixtures/statefulset-vsphere-1.10.6-prometheus.yaml
+++ b/api/pkg/resources/test/fixtures/statefulset-vsphere-1.10.6-prometheus.yaml
@@ -39,7 +39,6 @@ spec:
         - --storage.tsdb.no-lockfile
         - --web.route-prefix=/
         image: quay.io/prometheus/prometheus:v2.9.2
-        imagePullPolicy: IfNotPresent
         livenessProbe:
           failureThreshold: 10
           httpGet:
@@ -72,8 +71,6 @@ spec:
           requests:
             cpu: 50m
             memory: 256Mi
-        terminationMessagePath: /dev/termination-log
-        terminationMessagePolicy: File
         volumeMounts:
         - mountPath: /etc/prometheus/config
           name: config

--- a/api/pkg/resources/test/fixtures/statefulset-vsphere-1.11.0-etcd.yaml
+++ b/api/pkg/resources/test/fixtures/statefulset-vsphere-1.11.0-etcd.yaml
@@ -80,7 +80,6 @@ spec:
         - name: ETCDCTL_API
           value: "3"
         image: gcr.io/etcd-development/etcd:v3.3.12
-        imagePullPolicy: IfNotPresent
         name: etcd
         ports:
         - containerPort: 2379
@@ -117,8 +116,6 @@ spec:
           requests:
             cpu: 50m
             memory: 256Mi
-        terminationMessagePath: /dev/termination-log
-        terminationMessagePolicy: File
         volumeMounts:
         - mountPath: /var/run/etcd
           name: data

--- a/api/pkg/resources/test/fixtures/statefulset-vsphere-1.11.0-prometheus.yaml
+++ b/api/pkg/resources/test/fixtures/statefulset-vsphere-1.11.0-prometheus.yaml
@@ -39,7 +39,6 @@ spec:
         - --storage.tsdb.no-lockfile
         - --web.route-prefix=/
         image: quay.io/prometheus/prometheus:v2.9.2
-        imagePullPolicy: IfNotPresent
         livenessProbe:
           failureThreshold: 10
           httpGet:
@@ -72,8 +71,6 @@ spec:
           requests:
             cpu: 50m
             memory: 256Mi
-        terminationMessagePath: /dev/termination-log
-        terminationMessagePolicy: File
         volumeMounts:
         - mountPath: /etc/prometheus/config
           name: config

--- a/api/pkg/resources/test/fixtures/statefulset-vsphere-1.11.1-etcd.yaml
+++ b/api/pkg/resources/test/fixtures/statefulset-vsphere-1.11.1-etcd.yaml
@@ -80,7 +80,6 @@ spec:
         - name: ETCDCTL_API
           value: "3"
         image: gcr.io/etcd-development/etcd:v3.3.12
-        imagePullPolicy: IfNotPresent
         name: etcd
         ports:
         - containerPort: 2379
@@ -117,8 +116,6 @@ spec:
           requests:
             cpu: 50m
             memory: 256Mi
-        terminationMessagePath: /dev/termination-log
-        terminationMessagePolicy: File
         volumeMounts:
         - mountPath: /var/run/etcd
           name: data

--- a/api/pkg/resources/test/fixtures/statefulset-vsphere-1.11.1-prometheus.yaml
+++ b/api/pkg/resources/test/fixtures/statefulset-vsphere-1.11.1-prometheus.yaml
@@ -39,7 +39,6 @@ spec:
         - --storage.tsdb.no-lockfile
         - --web.route-prefix=/
         image: quay.io/prometheus/prometheus:v2.9.2
-        imagePullPolicy: IfNotPresent
         livenessProbe:
           failureThreshold: 10
           httpGet:
@@ -72,8 +71,6 @@ spec:
           requests:
             cpu: 50m
             memory: 256Mi
-        terminationMessagePath: /dev/termination-log
-        terminationMessagePolicy: File
         volumeMounts:
         - mountPath: /etc/prometheus/config
           name: config

--- a/api/pkg/resources/test/fixtures/statefulset-vsphere-1.12.0-etcd.yaml
+++ b/api/pkg/resources/test/fixtures/statefulset-vsphere-1.12.0-etcd.yaml
@@ -80,7 +80,6 @@ spec:
         - name: ETCDCTL_API
           value: "3"
         image: gcr.io/etcd-development/etcd:v3.3.12
-        imagePullPolicy: IfNotPresent
         name: etcd
         ports:
         - containerPort: 2379
@@ -117,8 +116,6 @@ spec:
           requests:
             cpu: 50m
             memory: 256Mi
-        terminationMessagePath: /dev/termination-log
-        terminationMessagePolicy: File
         volumeMounts:
         - mountPath: /var/run/etcd
           name: data

--- a/api/pkg/resources/test/fixtures/statefulset-vsphere-1.12.0-prometheus.yaml
+++ b/api/pkg/resources/test/fixtures/statefulset-vsphere-1.12.0-prometheus.yaml
@@ -39,7 +39,6 @@ spec:
         - --storage.tsdb.no-lockfile
         - --web.route-prefix=/
         image: quay.io/prometheus/prometheus:v2.9.2
-        imagePullPolicy: IfNotPresent
         livenessProbe:
           failureThreshold: 10
           httpGet:
@@ -72,8 +71,6 @@ spec:
           requests:
             cpu: 50m
             memory: 256Mi
-        terminationMessagePath: /dev/termination-log
-        terminationMessagePolicy: File
         volumeMounts:
         - mountPath: /etc/prometheus/config
           name: config

--- a/api/pkg/resources/test/fixtures/statefulset-vsphere-1.13.0-etcd.yaml
+++ b/api/pkg/resources/test/fixtures/statefulset-vsphere-1.13.0-etcd.yaml
@@ -80,7 +80,6 @@ spec:
         - name: ETCDCTL_API
           value: "3"
         image: gcr.io/etcd-development/etcd:v3.3.12
-        imagePullPolicy: IfNotPresent
         name: etcd
         ports:
         - containerPort: 2379
@@ -117,8 +116,6 @@ spec:
           requests:
             cpu: 50m
             memory: 256Mi
-        terminationMessagePath: /dev/termination-log
-        terminationMessagePolicy: File
         volumeMounts:
         - mountPath: /var/run/etcd
           name: data

--- a/api/pkg/resources/test/fixtures/statefulset-vsphere-1.13.0-prometheus.yaml
+++ b/api/pkg/resources/test/fixtures/statefulset-vsphere-1.13.0-prometheus.yaml
@@ -39,7 +39,6 @@ spec:
         - --storage.tsdb.no-lockfile
         - --web.route-prefix=/
         image: quay.io/prometheus/prometheus:v2.9.2
-        imagePullPolicy: IfNotPresent
         livenessProbe:
           failureThreshold: 10
           httpGet:
@@ -72,8 +71,6 @@ spec:
           requests:
             cpu: 50m
             memory: 256Mi
-        terminationMessagePath: /dev/termination-log
-        terminationMessagePolicy: File
         volumeMounts:
         - mountPath: /etc/prometheus/config
           name: config

--- a/api/pkg/resources/vpnsidecar/dnatController.go
+++ b/api/pkg/resources/vpnsidecar/dnatController.go
@@ -40,11 +40,10 @@ func DnatControllerContainer(data dnatControllerData, name, apiserverAddress str
 	}
 
 	return &corev1.Container{
-		Name:            name,
-		Image:           data.KubermaticAPIImage() + ":" + resources.KUBERMATICCOMMIT,
-		ImagePullPolicy: corev1.PullIfNotPresent,
-		Command:         []string{"/usr/local/bin/kubeletdnat-controller"},
-		Args:            args,
+		Name:    name,
+		Image:   data.KubermaticAPIImage() + ":" + resources.KUBERMATICCOMMIT,
+		Command: []string{"/usr/local/bin/kubeletdnat-controller"},
+		Args:    args,
 		SecurityContext: &corev1.SecurityContext{
 			Capabilities: &corev1.Capabilities{
 				Add: []corev1.Capability{"NET_ADMIN"},

--- a/api/pkg/resources/vpnsidecar/openvpnClient.go
+++ b/api/pkg/resources/vpnsidecar/openvpnClient.go
@@ -32,7 +32,6 @@ type openvpnData interface {
 // Also required but not provided by this func:
 // * volumes: resources.OpenVPNClientCertificatesSecretName, resources.CACertSecretName
 func OpenVPNSidecarContainer(data openvpnData, name string) (*corev1.Container, error) {
-	procMountType := corev1.DefaultProcMount
 	return &corev1.Container{
 		Name:    name,
 		Image:   data.ImageRegistry(resources.RegistryQuay) + "/kubermatic/openvpn:v0.5",
@@ -60,7 +59,6 @@ func OpenVPNSidecarContainer(data openvpnData, name string) (*corev1.Container, 
 		},
 		SecurityContext: &corev1.SecurityContext{
 			Privileged: resources.Bool(true),
-			ProcMount:  &procMountType,
 		},
 		Resources: vpnClientResourceRequirements,
 		VolumeMounts: []corev1.VolumeMount{


### PR DESCRIPTION
**What this PR does / why we need it**:
We have defaulting functions that take care of applying the default ImagePullPolicy and TerminationMessage stuff, so we do not need to set these explicitly everywhere. A few tests have been added to ensure the defaulting works.

**Does this PR introduce a user-facing change?**:
```release-note
NONE
```
