### PR TITLE
Use seedKubeconfigGetter for seed-proxy-controller

### DIFF
--- a/api/cmd/master-controller-manager/controllers.go
+++ b/api/cmd/master-controller-manager/controllers.go
@@ -173,7 +173,7 @@ func createServiceAccountsController(ctrlCtx *controllerContext) (runnerFn, erro
 }
 
 func createSeedProxyController(ctrlCtx *controllerContext) (runnerFn, error) {
-	if err := seedproxy.Add(ctrlCtx.mgr, 1, ctrlCtx.kubeconfig, ctrlCtx.seedsGetter); err != nil {
+	if err := seedproxy.Add(ctrlCtx.mgr, 1, ctrlCtx.seedsGetter, ctrlCtx.seedKubeconfigGetter); err != nil {
 		return nil, err
 	}
 	return noop, nil

--- a/api/cmd/master-controller-manager/main.go
+++ b/api/cmd/master-controller-manager/main.go
@@ -48,10 +48,11 @@ type controllerContext struct {
 	kubermaticMasterInformerFactory externalversions.SharedInformerFactory
 	kubeMasterInformerFactory       kuberinformers.SharedInformerFactory
 
-	mgr               manager.Manager
-	kubeconfig        *clientcmdapi.Config
-	seedsGetter       provider.SeedsGetter
-	labelSelectorFunc func(*metav1.ListOptions)
+	mgr                  manager.Manager
+	kubeconfig           *clientcmdapi.Config
+	seedsGetter          provider.SeedsGetter
+	seedKubeconfigGetter provider.SeedKubeconfigGetter
+	labelSelectorFunc    func(*metav1.ListOptions)
 }
 
 func main() {
@@ -132,6 +133,11 @@ func main() {
 	ctrlCtx.seedsGetter, err = provider.SeedsGetterFactory(ctx, ctrlCtx.mgr.GetClient(), ctrlCtx.runOptions.dcFile, ctrlCtx.runOptions.workerName, ctrlCtx.runOptions.dynamicDatacenters)
 	if err != nil {
 		sugarLog.Fatalw("failed to get construct seedsGetter", "error", err)
+	}
+	ctrlCtx.seedKubeconfigGetter, err = provider.SeedKubeconfigGetterFactory(
+		ctx, mgr.GetClient(), ctrlCtx.runOptions.kubeconfig, ctrlCtx.runOptions.dynamicDatacenters)
+	if err != nil {
+		sugarLog.Fatalf("failed to construct seedKubeconfigGetter", "error", err)
 	}
 
 	controllers, err := createAllControllers(ctrlCtx)

--- a/api/cmd/master-controller-manager/main.go
+++ b/api/cmd/master-controller-manager/main.go
@@ -132,12 +132,12 @@ func main() {
 	ctrlCtx.mgr = mgr
 	ctrlCtx.seedsGetter, err = provider.SeedsGetterFactory(ctx, ctrlCtx.mgr.GetClient(), ctrlCtx.runOptions.dcFile, ctrlCtx.runOptions.workerName, ctrlCtx.runOptions.dynamicDatacenters)
 	if err != nil {
-		sugarLog.Fatalw("failed to get construct seedsGetter", "error", err)
+		sugarLog.Fatalw("failed to construct seedsGetter", "error", err)
 	}
 	ctrlCtx.seedKubeconfigGetter, err = provider.SeedKubeconfigGetterFactory(
 		ctx, mgr.GetClient(), ctrlCtx.runOptions.kubeconfig, ctrlCtx.runOptions.dynamicDatacenters)
 	if err != nil {
-		sugarLog.Fatalf("failed to construct seedKubeconfigGetter", "error", err)
+		sugarLog.Fatalw("failed to construct seedKubeconfigGetter", "error", err)
 	}
 
 	controllers, err := createAllControllers(ctrlCtx)

--- a/api/pkg/controller/seed-proxy/controller.go
+++ b/api/pkg/controller/seed-proxy/controller.go
@@ -3,9 +3,7 @@ package seedproxy
 import (
 	"fmt"
 
-	"sigs.k8s.io/controller-runtime/pkg/event"
-	"sigs.k8s.io/controller-runtime/pkg/predicate"
-	"sigs.k8s.io/controller-runtime/pkg/reconcile"
+	"github.com/golang/glog"
 
 	"github.com/kubermatic/kubermatic/api/pkg/provider"
 
@@ -14,10 +12,12 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
-	clientcmdapi "k8s.io/client-go/tools/clientcmd/api"
 	"sigs.k8s.io/controller-runtime/pkg/controller"
+	"sigs.k8s.io/controller-runtime/pkg/event"
 	"sigs.k8s.io/controller-runtime/pkg/handler"
 	"sigs.k8s.io/controller-runtime/pkg/manager"
+	"sigs.k8s.io/controller-runtime/pkg/predicate"
+	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 	"sigs.k8s.io/controller-runtime/pkg/source"
 )
 
@@ -99,14 +99,14 @@ const (
 func Add(
 	mgr manager.Manager,
 	numWorkers int,
-	kubeconfig *clientcmdapi.Config,
 	seedsGetter provider.SeedsGetter,
+	seedKubeconfigGetter provider.SeedKubeconfigGetter,
 ) error {
 	reconciler := &Reconciler{
-		Client:      mgr.GetClient(),
-		recorder:    mgr.GetRecorder(ControllerName),
-		kubeconfig:  kubeconfig,
-		seedsGetter: seedsGetter,
+		Client:               mgr.GetClient(),
+		recorder:             mgr.GetRecorder(ControllerName),
+		seedsGetter:          seedsGetter,
+		seedKubeconfigGetter: seedKubeconfigGetter,
 	}
 
 	ctrlOptions := controller.Options{Reconciler: reconciler, MaxConcurrentReconciles: numWorkers}
@@ -116,13 +116,16 @@ func Add(
 	}
 
 	eventHandler := &handler.EnqueueRequestsFromMapFunc{ToRequests: handler.ToRequestsFunc(func(a handler.MapObject) []reconcile.Request {
-		requests := make([]reconcile.Request, 0)
+		seeds, err := seedsGetter()
+		if err != nil {
+			glog.Errorf("failed to get seeds: %v", err)
+			return nil
+		}
 
-		for name := range kubeconfig.Contexts {
+		var requests []reconcile.Request
+		for seedName := range seeds {
 			requests = append(requests, reconcile.Request{
-				NamespacedName: types.NamespacedName{
-					Name: name,
-				},
+				NamespacedName: types.NamespacedName{Name: seedName},
 			})
 		}
 

--- a/api/pkg/controller/seed-proxy/controller.go
+++ b/api/pkg/controller/seed-proxy/controller.go
@@ -118,7 +118,7 @@ func Add(
 	eventHandler := &handler.EnqueueRequestsFromMapFunc{ToRequests: handler.ToRequestsFunc(func(a handler.MapObject) []reconcile.Request {
 		seeds, err := seedsGetter()
 		if err != nil {
-			glog.Errorf("failed to get seeds: %v", err)
+			glog.Errorf("Failed to get seeds: %v", err)
 			return nil
 		}
 

--- a/api/pkg/controller/seed-proxy/reconciler.go
+++ b/api/pkg/controller/seed-proxy/reconciler.go
@@ -101,7 +101,7 @@ func (r *Reconciler) reconcileSeed(name string) error {
 		return fmt.Errorf("failed to create client for seed: %v", err)
 	}
 
-	glog.V(4).Info("Reconciling seed cluster %q", name)
+	glog.V(4).Infof("Reconciling seed cluster %q", name)
 
 	glog.V(4).Info("Reconciling service accounts...")
 	if err := r.ensureSeedServiceAccounts(client); err != nil {

--- a/api/pkg/controller/seed-proxy/reconciler.go
+++ b/api/pkg/controller/seed-proxy/reconciler.go
@@ -57,6 +57,7 @@ func (r *Reconciler) Reconcile(request reconcile.Request) (reconcile.Result, err
 		return reconcile.Result{}, fmt.Errorf("failed to reconcile Grafana: %v", err)
 	}
 
+	glog.V(4).Infof("Successfully reconciled seed %q", request.Name)
 	return reconcile.Result{}, nil
 }
 

--- a/api/pkg/provider/datacenter.go
+++ b/api/pkg/provider/datacenter.go
@@ -255,7 +255,7 @@ func SeedKubeconfigGetterFactory(
 		if _, exists := kubeconfig.Contexts[seedName]; !exists {
 			return nil, fmt.Errorf("found no context with name %q in kubeconfig", seedName)
 		}
-		cfg, err := clientcmd.NewNonInteractiveClientConfig(*kubeconfig, seedName, nil, nil).ClientConfig()
+		cfg, err := clientcmd.NewNonInteractiveClientConfig(*kubeconfig, seedName, &clientcmd.ConfigOverrides{}, nil).ClientConfig()
 		if err != nil {
 			return nil, fmt.Errorf("failed to get restConfig for seed %q: %v", seedName, err)
 		}

--- a/api/pkg/provider/datacenter.go
+++ b/api/pkg/provider/datacenter.go
@@ -15,6 +15,7 @@ import (
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/apimachinery/pkg/util/sets"
 	"k8s.io/apimachinery/pkg/util/validation"
+	"k8s.io/client-go/rest"
 	ctrlruntimeclient "sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/yaml"
 )
@@ -29,6 +30,9 @@ type SeedGetter = func() (*kubermaticv1.Seed, error)
 
 // SeedsGetter is a function to retrieve a list of seeds
 type SeedsGetter = func() (map[string]*kubermaticv1.Seed, error)
+
+// SeedKubeconfigGetter is used to fetch the kubeconfig for a given seed
+type SeedKubeconfigGetter = func(seedName string) (*rest.Config, error)
 
 // DatacenterMeta describes a Kubermatic datacenter.
 type DatacenterMeta struct {


### PR DESCRIPTION
**What this PR does / why we need it**:

This PR changes the seed-proxy-controller to use a `seedKubeconfigGetter` to dynamically resolve the kubecofig for a given seed at runtime. This is required for for #2113

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

What should be mentioned is that the `seed-proxy-controller` doesn't work for unrelated reasons, namely it has a predicate that makes it only react to resources it created. However initially there will be no such resources, hence the controller never does anything. I tested the whole change by temporarily removing the predicate.
**Documentation**:
<!-- Add links to the related documentation changes related to this pull request. E.g. the link to the kubermatic/docs pullrequest. -->

**Does this PR introduce a user-facing change?**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If  no release note is required, just write "NONE".
-->
```release-note
none
```

/assign @xrstf 