### PR TITLE
Use opt-in rather than opt-out mechanism to determine if initial nd creation error is unrecoverable

### DIFF
--- a/api/pkg/handler/v1/cluster/cluster.go
+++ b/api/pkg/handler/v1/cluster/cluster.go
@@ -7,6 +7,7 @@ import (
 	"io/ioutil"
 	"net/http"
 	"strconv"
+	"strings"
 	"time"
 
 	jsonpatch "github.com/evanphx/json-patch"
@@ -167,24 +168,18 @@ func createInitialNodeDeploymentWithRetries(nodeDeployment *apiv1.NodeDeployment
 	clusterProvider provider.ClusterProvider, userInfo *provider.UserInfo, eventRecorder record.EventRecorder) error {
 	return wait.Poll(5*time.Second, 30*time.Minute, func() (bool, error) {
 		err := createInitialNodeDeployment(nodeDeployment, cluster, project, sshKeyProvider, seeds, clusterProvider, userInfo)
-		switch {
-		case err == nil:
-			return true, nil
-		case kerrors.IsInternalError(err):
-			// An internal error can be:
-			//
-			//  Internal error occurred: failed calling webhook "machine-controller.kubermatic.io-machinedeployments"
-			//  Post REDACTED: net/http: request canceled while waiting for connection (Client.Timeout exceeded while awaiting headers)
-			fallthrough
-		case kerrors.IsServiceUnavailable(err):
-			fallthrough
-		case kerrors.IsServerTimeout(err):
+		if err != nil {
+			// unrecoverable
+			if strings.Contains(err.Error(), `admission webhook "machine-controller.kubermatic.io-machinedeployments" denied the request`) {
+				glog.V(4).Infof("giving up creating initial Node Deployments for cluster %s (%s) due to an unrecoverabl err %#v", cluster.Name, cluster.Spec.HumanReadableName, err)
+				return false, err
+			}
+			// Likely recoverable
 			eventRecorder.Eventf(cluster, corev1.EventTypeNormal, string(nodeDeploymentCreationRetry), "retrying creating initial Node Deployments%s for cluster %s (%s) due to %v", getNodeDeploymentDisplayName(nodeDeployment), cluster.Name, cluster.Spec.HumanReadableName, err)
 			glog.V(4).Infof("retrying creating initial Node Deployments for cluster %s (%s) due to %v", cluster.Name, cluster.Spec.HumanReadableName, err)
 			return false, nil
 		}
-		glog.V(4).Infof("giving up creating initial Node Deployments for cluster %s (%s) due to an unknown err %#v", cluster.Name, cluster.Spec.HumanReadableName, err)
-		return false, err
+		return true, nil
 	})
 }
 


### PR DESCRIPTION

**What this PR does / why we need it**:

Currently we instanly stop retrying to create the inital nodedeploymen when we hit an unknown error. This PR changes that behaviour to instead retry unless we get an error that contains an admission webhook response, as this is the only case where we know for sure retrying wont help.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Documentation**:
<!-- Add links to the related documentation changes related to this pull request. E.g. the link to the kubermatic/docs pullrequest. -->

**Does this PR introduce a user-facing change?**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If  no release note is required, just write "NONE".
-->
```release-note
A bug that sometimes resulted in the creation of the initial NodeDeployment failing was fixed
```
