### PR TITLE
Kubermatic Noperator

### DIFF
--- a/api/cmd/kubermatic-operator/README.md
+++ b/api/cmd/kubermatic-operator/README.md
@@ -1,0 +1,3 @@
+# Kubermatic Operator
+
+This implements the operator for deploying and maintaining Kubermatic.

--- a/api/cmd/kubermatic-operator/main.go
+++ b/api/cmd/kubermatic-operator/main.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"context"
 	"flag"
 	"fmt"
 
@@ -77,7 +78,10 @@ func main() {
 		log.Fatalw("Failed to register types in Scheme", "error", err)
 	}
 
-	if err := operatormaster.Add(mgr, 1, clientConfig, log, opt.workerName); err != nil {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	if err := operatormaster.Add(ctx, mgr, 1, clientConfig, log, opt.workerName); err != nil {
 		log.Fatalw("Failed to add operator-master controller", "error", err)
 	}
 

--- a/api/cmd/kubermatic-operator/main.go
+++ b/api/cmd/kubermatic-operator/main.go
@@ -1,0 +1,87 @@
+package main
+
+import (
+	"flag"
+	"fmt"
+
+	"github.com/go-logr/zapr"
+	"go.uber.org/zap"
+
+	operatormaster "github.com/kubermatic/kubermatic/api/pkg/controller/operator-master"
+	operatorv1alpha1 "github.com/kubermatic/kubermatic/api/pkg/crd/operator/v1alpha1"
+	kubermaticlog "github.com/kubermatic/kubermatic/api/pkg/log"
+	"github.com/kubermatic/kubermatic/api/pkg/signals"
+
+	"k8s.io/client-go/tools/clientcmd"
+	"sigs.k8s.io/controller-runtime/pkg/manager"
+	ctrllog "sigs.k8s.io/controller-runtime/pkg/runtime/log"
+	// Do not import "sigs.k8s.io/controller-runtime/pkg" to prevent
+	// duplicate kubeconfig flags being defined.
+)
+
+type controllerRunOptions struct {
+	kubeconfig   string
+	internalAddr string
+	log          kubermaticlog.Options
+	workerCount  int
+	workerName   string
+}
+
+func main() {
+	opt := &controllerRunOptions{}
+	flag.StringVar(&opt.kubeconfig, "kubeconfig", "", "Path to a kubeconfig.")
+	flag.IntVar(&opt.workerCount, "worker-count", 4, "Number of workers which process the clusters in parallel.")
+	flag.StringVar(&opt.internalAddr, "internal-address", "127.0.0.1:8085", "The address on which the /metrics endpoint will be served")
+	flag.BoolVar(&opt.log.Debug, "log-debug", false, "Enables debug logging")
+	flag.StringVar(&opt.log.Format, "log-format", string(kubermaticlog.FormatJSON), "Log format, one of "+kubermaticlog.AvailableFormats.String())
+	flag.StringVar(&opt.workerName, "worker-name", "", "The name of the worker that will only processes resources with label=worker-name.")
+	flag.Parse()
+
+	rawLog := kubermaticlog.New(opt.log.Debug, kubermaticlog.Format(opt.log.Format)).Named(opt.workerName)
+	log := rawLog.Sugar()
+	defer func() {
+		if err := log.Sync(); err != nil {
+			fmt.Println(err)
+		}
+	}()
+
+	// update global logger instance
+	kubermaticlog.Logger = log
+
+	// set the logger used by sigs.k8s.io/controller-runtime
+	ctrllog.SetLogger(zapr.NewLogger(rawLog.WithOptions(zap.AddCallerSkip(1))))
+
+	clientConfig, err := clientcmd.LoadFromFile(opt.kubeconfig)
+	if err != nil {
+		log.Fatalw("Failed to read the kubeconfig", "error", err)
+	}
+
+	config := clientcmd.NewNonInteractiveClientConfig(
+		*clientConfig,
+		clientConfig.CurrentContext,
+		&clientcmd.ConfigOverrides{CurrentContext: clientConfig.CurrentContext},
+		nil,
+	)
+
+	cfg, err := config.ClientConfig()
+	if err != nil {
+		log.Fatalw("Failed to create client", "error", err)
+	}
+
+	mgr, err := manager.New(cfg, manager.Options{MetricsBindAddress: opt.internalAddr})
+	if err != nil {
+		log.Fatalw("Failed to create Controller Manager instance: %v", err)
+	}
+
+	if err := operatorv1alpha1.AddToScheme(mgr.GetScheme()); err != nil {
+		log.Fatalw("Failed to register types in Scheme", "error", err)
+	}
+
+	if err := operatormaster.Add(mgr, 1, clientConfig, log, opt.workerName); err != nil {
+		log.Fatalw("Failed to add operator-master controller", "error", err)
+	}
+
+	if err := mgr.Start(signals.SetupSignalHandler()); err != nil {
+		log.Fatalw("Cannot start manager", "error", err)
+	}
+}

--- a/api/pkg/controller/operator-master/controller.go
+++ b/api/pkg/controller/operator-master/controller.go
@@ -7,15 +7,10 @@ import (
 
 	operatorv1alpha1 "github.com/kubermatic/kubermatic/api/pkg/crd/operator/v1alpha1"
 
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/apimachinery/pkg/types"
 	clientcmdapi "k8s.io/client-go/tools/clientcmd/api"
 	"sigs.k8s.io/controller-runtime/pkg/controller"
-	"sigs.k8s.io/controller-runtime/pkg/event"
 	"sigs.k8s.io/controller-runtime/pkg/handler"
 	"sigs.k8s.io/controller-runtime/pkg/manager"
-	"sigs.k8s.io/controller-runtime/pkg/predicate"
-	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 	"sigs.k8s.io/controller-runtime/pkg/source"
 )
 
@@ -50,58 +45,10 @@ func Add(
 		return err
 	}
 
-	// reconcile for every KubermaticConfiguration labelled with the current worker name
-	predicate := newPredicateFuncs(func(meta metav1.Object) bool {
-		return meta.GetLabels()[WorkerNameLabel] == workerName
-	})
-
-	// put the config's identifier on the queue
-	eventHandler := newEventHandler(func(a handler.MapObject) []reconcile.Request {
-		return []reconcile.Request{
-			{
-				NamespacedName: types.NamespacedName{
-					Namespace: a.Meta.GetNamespace(),
-					Name:      a.Meta.GetName(),
-				},
-			},
-		}
-	})
-
 	obj := &operatorv1alpha1.KubermaticConfiguration{}
-	if err := c.Watch(&source.Kind{Type: obj}, eventHandler, predicate); err != nil {
+	if err := c.Watch(&source.Kind{Type: obj}, &handler.EnqueueRequestForObject{}); err != nil {
 		return fmt.Errorf("failed to create watcher for %T: %v", obj, err)
 	}
 
 	return nil
-}
-
-// newEventHandler takes a obj->request mapper function and wraps it into an
-// handler.EnqueueRequestsFromMapFunc.
-func newEventHandler(rf handler.ToRequestsFunc) *handler.EnqueueRequestsFromMapFunc {
-	return &handler.EnqueueRequestsFromMapFunc{
-		ToRequests: rf,
-	}
-}
-
-// newPredicateFuncs takes a predicate and returns a struct appliying the
-// function for Create, Update, Delete and Generic events. For Update events,
-// only the new version is considered.
-func newPredicateFuncs(pred func(metav1.Object) bool) predicate.Funcs {
-	return predicate.Funcs{
-		CreateFunc: func(e event.CreateEvent) bool {
-			return pred(e.Meta)
-		},
-
-		UpdateFunc: func(e event.UpdateEvent) bool {
-			return pred(e.MetaNew)
-		},
-
-		DeleteFunc: func(e event.DeleteEvent) bool {
-			return pred(e.Meta)
-		},
-
-		GenericFunc: func(e event.GenericEvent) bool {
-			return pred(e.Meta)
-		},
-	}
 }

--- a/api/pkg/controller/operator-master/controller.go
+++ b/api/pkg/controller/operator-master/controller.go
@@ -1,0 +1,107 @@
+package operatormaster
+
+import (
+	"fmt"
+
+	"go.uber.org/zap"
+
+	operatorv1alpha1 "github.com/kubermatic/kubermatic/api/pkg/crd/operator/v1alpha1"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+	clientcmdapi "k8s.io/client-go/tools/clientcmd/api"
+	"sigs.k8s.io/controller-runtime/pkg/controller"
+	"sigs.k8s.io/controller-runtime/pkg/event"
+	"sigs.k8s.io/controller-runtime/pkg/handler"
+	"sigs.k8s.io/controller-runtime/pkg/manager"
+	"sigs.k8s.io/controller-runtime/pkg/predicate"
+	"sigs.k8s.io/controller-runtime/pkg/reconcile"
+	"sigs.k8s.io/controller-runtime/pkg/source"
+)
+
+const (
+	// ControllerName is the name of this very controller.
+	ControllerName = "kubermatic-master-operator"
+
+	// WorkerNameLabel is the label containing the worker-name,
+	// restricting the operator that is willing to work on a given
+	// resource.
+	WorkerNameLabel = "operator.kubermatic.io/worker"
+)
+
+func Add(
+	mgr manager.Manager,
+	numWorkers int,
+	clientConfig *clientcmdapi.Config,
+	log *zap.SugaredLogger,
+	workerName string,
+) error {
+	reconciler := &Reconciler{
+		Client:       mgr.GetClient(),
+		recorder:     mgr.GetRecorder(ControllerName),
+		clientConfig: clientConfig,
+		log:          log.Named(ControllerName),
+		workerName:   workerName,
+	}
+
+	ctrlOptions := controller.Options{Reconciler: reconciler, MaxConcurrentReconciles: numWorkers}
+	c, err := controller.New(ControllerName, mgr, ctrlOptions)
+	if err != nil {
+		return err
+	}
+
+	// reconcile for every KubermaticConfiguration labelled with the current worker name
+	predicate := newPredicateFuncs(func(meta metav1.Object) bool {
+		return meta.GetLabels()[WorkerNameLabel] == workerName
+	})
+
+	// put the config's identifier on the queue
+	eventHandler := newEventHandler(func(a handler.MapObject) []reconcile.Request {
+		return []reconcile.Request{
+			{
+				NamespacedName: types.NamespacedName{
+					Namespace: a.Meta.GetNamespace(),
+					Name:      a.Meta.GetName(),
+				},
+			},
+		}
+	})
+
+	obj := &operatorv1alpha1.KubermaticConfiguration{}
+	if err := c.Watch(&source.Kind{Type: obj}, eventHandler, predicate); err != nil {
+		return fmt.Errorf("failed to create watcher for %T: %v", obj, err)
+	}
+
+	return nil
+}
+
+// newEventHandler takes a obj->request mapper function and wraps it into an
+// handler.EnqueueRequestsFromMapFunc.
+func newEventHandler(rf handler.ToRequestsFunc) *handler.EnqueueRequestsFromMapFunc {
+	return &handler.EnqueueRequestsFromMapFunc{
+		ToRequests: rf,
+	}
+}
+
+// newPredicateFuncs takes a predicate and returns a struct appliying the
+// function for Create, Update, Delete and Generic events. For Update events,
+// only the new version is considered.
+func newPredicateFuncs(pred func(metav1.Object) bool) predicate.Funcs {
+	return predicate.Funcs{
+		CreateFunc: func(e event.CreateEvent) bool {
+			return pred(e.Meta)
+		},
+
+		UpdateFunc: func(e event.UpdateEvent) bool {
+			return pred(e.MetaNew)
+		},
+
+		DeleteFunc: func(e event.DeleteEvent) bool {
+			return pred(e.Meta)
+		},
+
+		GenericFunc: func(e event.GenericEvent) bool {
+			return pred(e.Meta)
+		},
+	}
+}

--- a/api/pkg/controller/operator-master/controller.go
+++ b/api/pkg/controller/operator-master/controller.go
@@ -1,6 +1,7 @@
 package operatormaster
 
 import (
+	"context"
 	"fmt"
 
 	"go.uber.org/zap"
@@ -25,6 +26,7 @@ const (
 )
 
 func Add(
+	ctx context.Context,
 	mgr manager.Manager,
 	numWorkers int,
 	clientConfig *clientcmdapi.Config,
@@ -37,6 +39,7 @@ func Add(
 		clientConfig: clientConfig,
 		log:          log.Named(ControllerName),
 		workerName:   workerName,
+		ctx:          ctx,
 	}
 
 	ctrlOptions := controller.Options{Reconciler: reconciler, MaxConcurrentReconciles: numWorkers}

--- a/api/pkg/controller/operator-master/reconciler.go
+++ b/api/pkg/controller/operator-master/reconciler.go
@@ -39,7 +39,7 @@ func (r *Reconciler) Reconcile(request reconcile.Request) (reconcile.Result, err
 	}
 
 	// silently ignore other worker names
-	if labels := config.GetLabels(); labels[WorkerNameLabel] != r.workerName {
+	if config.Labels[WorkerNameLabel] != r.workerName {
 		return reconcile.Result{}, nil
 	}
 

--- a/api/pkg/controller/operator-master/reconciler.go
+++ b/api/pkg/controller/operator-master/reconciler.go
@@ -35,7 +35,7 @@ func (r *Reconciler) Reconcile(request reconcile.Request) (reconcile.Result, err
 	// find the requested configuration
 	config := &operatorv1alpha1.KubermaticConfiguration{}
 	if err := r.Get(ctx, request.NamespacedName, config); err != nil {
-		return reconcile.Result{}, fmt.Errorf("could not find KubermaticConfiguration %q", request)
+		return reconcile.Result{}, fmt.Errorf("could not get KubermaticConfiguration %q: %v", request, err)
 	}
 
 	// silently ignore other worker names

--- a/api/pkg/controller/operator-master/reconciler.go
+++ b/api/pkg/controller/operator-master/reconciler.go
@@ -29,11 +29,6 @@ type Reconciler struct {
 // for the given namespace. Will return an error if any API operation
 // failed, otherwise will return an empty dummy Result struct.
 func (r *Reconciler) Reconcile(request reconcile.Request) (reconcile.Result, error) {
-	var cancel context.CancelFunc
-
-	r.ctx, cancel = context.WithCancel(context.Background())
-	defer cancel()
-
 	// find the requested configuration
 	config := &operatorv1alpha1.KubermaticConfiguration{}
 	if err := r.Get(r.ctx, request.NamespacedName, config); err != nil {

--- a/api/pkg/controller/operator-master/reconciler.go
+++ b/api/pkg/controller/operator-master/reconciler.go
@@ -1,0 +1,59 @@
+package operatormaster
+
+import (
+	"context"
+	"fmt"
+
+	operatorv1alpha1 "github.com/kubermatic/kubermatic/api/pkg/crd/operator/v1alpha1"
+	"go.uber.org/zap"
+	"k8s.io/client-go/tools/cache"
+	clientcmdapi "k8s.io/client-go/tools/clientcmd/api"
+	"k8s.io/client-go/tools/record"
+	ctrlruntimeclient "sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/reconcile"
+)
+
+// Reconciler (re)stores all components required for proxying requests to
+// seed clusters. It also takes care of creating a nice ConfigMap for
+// Grafana's provisioning mechanism.
+type Reconciler struct {
+	ctrlruntimeclient.Client
+
+	clientConfig *clientcmdapi.Config
+	log          *zap.SugaredLogger
+	recorder     record.EventRecorder
+	workerName   string
+}
+
+// Reconcile acts upon requests and will restore the state of resources
+// for the given namespace. Will return an error if any API operation
+// failed, otherwise will return an empty dummy Result struct.
+func (r *Reconciler) Reconcile(request reconcile.Request) (reconcile.Result, error) {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	// find the requested configuration
+	config := &operatorv1alpha1.KubermaticConfiguration{}
+	if err := r.Get(ctx, request.NamespacedName, config); err != nil {
+		return reconcile.Result{}, fmt.Errorf("could not find KubermaticConfiguration %q", request)
+	}
+
+	// silently ignore other worker names
+	if labels := config.GetLabels(); labels[WorkerNameLabel] != r.workerName {
+		return reconcile.Result{}, nil
+	}
+
+	identifier, err := cache.MetaNamespaceKeyFunc(config)
+	if err != nil {
+		return reconcile.Result{}, fmt.Errorf("failed to determine string key for KubermaticConfiguration: %v", err)
+	}
+
+	logger := r.log.With("config", identifier)
+
+	return reconcile.Result{}, r.reconcile(ctx, config, logger)
+}
+
+func (r *Reconciler) reconcile(ctx context.Context, config *operatorv1alpha1.KubermaticConfiguration, logger *zap.SugaredLogger) error {
+	logger.Debug("Reconciling Kubermatic configuration now.")
+	return nil
+}

--- a/api/pkg/controller/operator-master/reconciler.go
+++ b/api/pkg/controller/operator-master/reconciler.go
@@ -13,9 +13,8 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 )
 
-// Reconciler (re)stores all components required for proxying requests to
-// seed clusters. It also takes care of creating a nice ConfigMap for
-// Grafana's provisioning mechanism.
+// Reconciler (re)stores all components required for running a Kubermatic
+// master cluster.
 type Reconciler struct {
 	ctrlruntimeclient.Client
 

--- a/api/pkg/resources/reconciling/compare.go
+++ b/api/pkg/resources/reconciling/compare.go
@@ -27,6 +27,6 @@ func DeepEqual(a, b metav1.Object) bool {
 		diff = deep.Equal(b, a)
 	}
 
-	glog.V(4).Infof("Object %T %s/%s differs from the one, generated: %v", a, a.GetNamespace(), a.GetName(), diff)
+	glog.V(4).Infof("Object %T %s/%s differs from the generated one: %v", a, a.GetNamespace(), a.GetName(), diff)
 	return false
 }

--- a/config/kubermatic/crd/crd-kubermatic-configuration.yaml
+++ b/config/kubermatic/crd/crd-kubermatic-configuration.yaml
@@ -1,0 +1,13 @@
+apiVersion: apiextensions.k8s.io/v1beta1
+kind: CustomResourceDefinition
+metadata:
+  name: kubermaticconfigurations.operator.kubermatic.io
+spec:
+  group: operator.kubermatic.io
+  names:
+    kind: KubermaticConfiguration
+    listKind: KubermaticConfigurationList
+    plural: kubermaticconfigurations
+    singular: kubermaticconfiguration
+  scope: Namespaced
+  version: v1alpha1


### PR DESCRIPTION
**What this PR does / why we need it**:
This is a bare bones operator that does nothing except watching KubermaticConfiguration objects.

**Which issue(s) this PR fixes**:
Relates to #3626 

**Does this PR introduce a user-facing change?**:
```release-note
NONE
```
