### PR TITLE
Clusterprovider: Stop using a lister

### DIFF
--- a/api/cmd/kubermatic-api/main.go
+++ b/api/cmd/kubermatic-api/main.go
@@ -35,6 +35,7 @@ import (
 	"github.com/kubermatic/kubermatic/api/pkg/controller/rbac"
 	kubermaticclientset "github.com/kubermatic/kubermatic/api/pkg/crd/client/clientset/versioned"
 	kubermaticinformers "github.com/kubermatic/kubermatic/api/pkg/crd/client/informers/externalversions"
+	kubermaticv1 "github.com/kubermatic/kubermatic/api/pkg/crd/kubermatic/v1"
 	"github.com/kubermatic/kubermatic/api/pkg/handler"
 	"github.com/kubermatic/kubermatic/api/pkg/handler/auth"
 	"github.com/kubermatic/kubermatic/api/pkg/handler/v1/common"
@@ -50,6 +51,7 @@ import (
 	"k8s.io/apimachinery/pkg/util/wait"
 	"k8s.io/client-go/informers"
 	"k8s.io/client-go/kubernetes"
+	"k8s.io/client-go/kubernetes/scheme"
 	"k8s.io/client-go/tools/clientcmd"
 	ctrlruntimeclient "sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/manager"
@@ -73,6 +75,10 @@ func main() {
 		}
 	}()
 	kubermaticlog.Logger = log
+
+	if err := kubermaticv1.SchemeBuilder.AddToScheme(scheme.Scheme); err != nil {
+		kubermaticlog.Logger.Fatalw("failed to add kubermaticv1 scheme to scheme.Scheme", "error", err)
+	}
 
 	providers, err := createInitProviders(options)
 	if err != nil {
@@ -125,9 +131,6 @@ func createInitProviders(options serverRunOptions) (providers, error) {
 		}
 		kubermaticlog.Logger.Infow("adding seed", "seed", ctx)
 		kubeClient := kubernetes.NewForConfigOrDie(cfg)
-		kubeInformerFactory := informers.NewSharedInformerFactory(kubeClient, informer.DefaultInformerResyncPeriod)
-		kubermaticSeedClient := kubermaticclientset.NewForConfigOrDie(cfg)
-		kubermaticSeedInformerFactory := kubermaticinformers.NewSharedInformerFactory(kubermaticSeedClient, informer.DefaultInformerResyncPeriod)
 		defaultImpersonationClientForSeed := kubernetesprovider.NewKubermaticImpersonationClient(cfg)
 		seedCtrlruntimeClient, err := ctrlruntimeclient.New(cfg, ctrlruntimeclient.Options{})
 		if err != nil {
@@ -142,18 +145,12 @@ func createInitProviders(options serverRunOptions) (providers, error) {
 		clusterProviders[ctx] = kubernetesprovider.NewClusterProvider(
 			defaultImpersonationClientForSeed.CreateImpersonatedKubermaticClientSet,
 			userClusterConnectionProvider,
-			kubermaticSeedInformerFactory.Kubermatic().V1().Clusters().Lister(),
 			options.workerName,
 			rbac.ExtractGroupPrefix,
 			seedCtrlruntimeClient,
 			kubeClient,
 			options.featureGates.Enabled(OIDCKubeCfgEndpoint),
 		)
-
-		kubeInformerFactory.Start(wait.NeverStop)
-		kubeInformerFactory.WaitForCacheSync(wait.NeverStop)
-		kubermaticSeedInformerFactory.Start(wait.NeverStop)
-		kubermaticSeedInformerFactory.WaitForCacheSync(wait.NeverStop)
 	}
 
 	masterCfg, err := clientcmd.BuildConfigFromFlags("", options.kubeconfig)

--- a/api/pkg/handler/v1/cluster/cluster.go
+++ b/api/pkg/handler/v1/cluster/cluster.go
@@ -107,7 +107,7 @@ func CreateEndpoint(sshKeyProvider provider.SSHKeyProvider, projectProvider prov
 			return nil, common.KubernetesErrorToHTTPError(err)
 		}
 
-		if len(existingClusters) > 0 {
+		if len(existingClusters.Items) > 0 {
 			return nil, errors.NewAlreadyExists("cluster", spec.HumanReadableName)
 		}
 
@@ -588,10 +588,10 @@ func convertInternalClusterToExternal(internalCluster *kubermaticv1.Cluster) *ap
 	return cluster
 }
 
-func convertInternalClustersToExternal(internalClusters []*kubermaticv1.Cluster) []*apiv1.Cluster {
+func convertInternalClustersToExternal(internalClusters []kubermaticv1.Cluster) []*apiv1.Cluster {
 	apiClusters := make([]*apiv1.Cluster, len(internalClusters))
 	for index, cluster := range internalClusters {
-		apiClusters[index] = convertInternalClusterToExternal(cluster)
+		apiClusters[index] = convertInternalClusterToExternal(cluster.DeepCopy())
 	}
 	return apiClusters
 }
@@ -1026,7 +1026,7 @@ func getClusters(clusterProvider provider.ClusterProvider, userInfo *provider.Us
 		return nil, err
 	}
 
-	apiClusters := convertInternalClustersToExternal(clusters)
+	apiClusters := convertInternalClustersToExternal(clusters.Items)
 	return apiClusters, nil
 }
 

--- a/api/pkg/provider/kubernetes/cluster_test.go
+++ b/api/pkg/provider/kubernetes/cluster_test.go
@@ -3,7 +3,6 @@ package kubernetes_test
 import (
 	"testing"
 
-	kubermaticv1lister "github.com/kubermatic/kubermatic/api/pkg/crd/client/listers/kubermatic/v1"
 	kubermaticv1 "github.com/kubermatic/kubermatic/api/pkg/crd/kubermatic/v1"
 	"github.com/kubermatic/kubermatic/api/pkg/provider"
 	"github.com/kubermatic/kubermatic/api/pkg/provider/kubernetes"
@@ -80,15 +79,13 @@ func TestCreateCluster(t *testing.T) {
 	for _, tc := range testcases {
 		t.Run(tc.name, func(t *testing.T) {
 
-			impersonationClient, _, indexer, err := createFakeKubermaticClients(tc.existingKubermaticObjects)
+			impersonationClient, _, _, err := createFakeKubermaticClients(tc.existingKubermaticObjects)
 			if err != nil {
 				t.Fatalf("unable to create fake clients, err = %v", err)
 			}
 
-			clusterLister := kubermaticv1lister.NewClusterLister(indexer)
-
 			// act
-			target := kubernetes.NewClusterProvider(impersonationClient.CreateFakeImpersonatedClientSet, nil, clusterLister, tc.workerName, nil, nil, nil, tc.shareKubeconfig)
+			target := kubernetes.NewClusterProvider(impersonationClient.CreateFakeImpersonatedClientSet, nil, tc.workerName, nil, nil, nil, tc.shareKubeconfig)
 			partialCluster := &kubermaticv1.Cluster{}
 			partialCluster.Spec = *tc.spec
 			if tc.clusterType == "openshift" {

--- a/api/pkg/provider/types.go
+++ b/api/pkg/provider/types.go
@@ -91,7 +91,7 @@ type ClusterProvider interface {
 	// Note:
 	// After we get the list of clusters we could try to get each cluster individually using unprivileged account to see if the user have read access,
 	// We don't do this because we assume that if the user was able to get the project (argument) it has to have at least read access.
-	List(project *kubermaticv1.Project, options *ClusterListOptions) ([]*kubermaticv1.Cluster, error)
+	List(project *kubermaticv1.Project, options *ClusterListOptions) (*kubermaticv1.ClusterList, error)
 
 	// Get returns the given cluster, it uses the projectInternalName to determine the group the user belongs to
 	Get(userInfo *UserInfo, clusterName string, options *ClusterGetOptions) (*kubermaticv1.Cluster, error)


### PR DESCRIPTION
**What this PR does / why we need it**:

This PR changes the clusterprovider to not use a lister anymore. We can't use a lister because we want to be able to dynamically initialize clusterproviders, #2113 

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Documentation**:
<!-- Add links to the related documentation changes related to this pull request. E.g. the link to the kubermatic/docs pullrequest. -->

**Does this PR introduce a user-facing change?**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If  no release note is required, just write "NONE".
-->
```release-note
none
```

/assign @maciaszczykm 