### PR TITLE
API: Dynamically create clusterprovider

### DIFF
--- a/api/cmd/kubermatic-api/main.go
+++ b/api/cmd/kubermatic-api/main.go
@@ -111,12 +111,6 @@ func main() {
 }
 
 func createInitProviders(options serverRunOptions) (providers, error) {
-	// create cluster providers - one foreach context
-	clientcmdConfig, err := clientcmd.LoadFromFile(options.kubeconfig)
-	if err != nil {
-		return providers{}, fmt.Errorf("unable to create client config for due to %v", err)
-	}
-
 	masterCfg, err := clientcmd.BuildConfigFromFlags("", options.kubeconfig)
 	if err != nil {
 		return providers{}, fmt.Errorf("unable to build client configuration from kubeconfig due to %v", err)

--- a/api/cmd/kubermatic-api/main.go
+++ b/api/cmd/kubermatic-api/main.go
@@ -112,45 +112,9 @@ func main() {
 
 func createInitProviders(options serverRunOptions) (providers, error) {
 	// create cluster providers - one foreach context
-	clusterProviders := map[string]provider.ClusterProvider{}
 	clientcmdConfig, err := clientcmd.LoadFromFile(options.kubeconfig)
 	if err != nil {
 		return providers{}, fmt.Errorf("unable to create client config for due to %v", err)
-	}
-
-	for ctx := range clientcmdConfig.Contexts {
-		clientConfig := clientcmd.NewNonInteractiveClientConfig(
-			*clientcmdConfig,
-			ctx,
-			&clientcmd.ConfigOverrides{CurrentContext: ctx},
-			nil,
-		)
-		cfg, err := clientConfig.ClientConfig()
-		if err != nil {
-			return providers{}, fmt.Errorf("unable to create client config for %s due to %v", ctx, err)
-		}
-		kubermaticlog.Logger.Infow("adding seed", "seed", ctx)
-		kubeClient := kubernetes.NewForConfigOrDie(cfg)
-		defaultImpersonationClientForSeed := kubernetesprovider.NewKubermaticImpersonationClient(cfg)
-		seedCtrlruntimeClient, err := ctrlruntimeclient.New(cfg, ctrlruntimeclient.Options{})
-		if err != nil {
-			return providers{}, fmt.Errorf("failed to create dynamic seed client: %v", err)
-		}
-
-		userClusterConnectionProvider, err := client.NewExternal(seedCtrlruntimeClient)
-		if err != nil {
-			return providers{}, fmt.Errorf("failed to get userClusterConnectionProvider: %v", err)
-		}
-
-		clusterProviders[ctx] = kubernetesprovider.NewClusterProvider(
-			defaultImpersonationClientForSeed.CreateImpersonatedKubermaticClientSet,
-			userClusterConnectionProvider,
-			options.workerName,
-			rbac.ExtractGroupPrefix,
-			seedCtrlruntimeClient,
-			kubeClient,
-			options.featureGates.Enabled(OIDCKubeCfgEndpoint),
-		)
 	}
 
 	masterCfg, err := clientcmd.BuildConfigFromFlags("", options.kubeconfig)
@@ -176,6 +140,11 @@ func createInitProviders(options serverRunOptions) (providers, error) {
 	if err != nil {
 		return providers{}, err
 	}
+	seedKubeconfigGetter, err := provider.SeedKubeconfigGetterFactory(context.Background(), mgr.GetClient(), options.kubeconfig, options.dynamicDatacenters)
+	if err != nil {
+		return providers{}, err
+	}
+	clusterProviderGetter := clusterProviderFactory(seedKubeconfigGetter, options.workerName, options.featureGates.Enabled(OIDCKubeCfgEndpoint))
 
 	userMasterLister := kubermaticMasterInformerFactory.Kubermatic().V1().Users().Lister()
 	sshKeyProvider := kubernetesprovider.NewSSHKeyProvider(defaultKubermaticImpersonationClient.CreateImpersonatedKubermaticClientSet, kubermaticMasterInformerFactory.Kubermatic().V1().UserSSHKeys().Lister())
@@ -221,7 +190,7 @@ func createInitProviders(options serverRunOptions) (providers, error) {
 		projectMember:                         projectMemberProvider,
 		memberMapper:                          projectMemberProvider,
 		eventRecorderProvider:                 eventRecorderProvider,
-		clusters:                              clusterProviders,
+		clusterProviderGetter:                 clusterProviderGetter,
 		seedsGetter:                           seedsGetter,
 		credentialsProvider:                   credentialsProvider}, nil
 }
@@ -287,7 +256,7 @@ func createAPIHandler(options serverRunOptions, prov providers, oidcIssuerVerifi
 
 	r := handler.NewRouting(
 		prov.seedsGetter,
-		prov.clusters,
+		prov.clusterProviderGetter,
 		prov.sshKey,
 		prov.user,
 		prov.serviceAccountProvider,
@@ -356,4 +325,37 @@ func createAPIHandler(options serverRunOptions, prov providers, oidcIssuerVerifi
 	}
 
 	return instrumentHandler(mainRouter, lookupRoute), nil
+}
+
+func clusterProviderFactory(seedKubeconfigGetter provider.SeedKubeconfigGetter, workerName string, oidcKubeCfgEndpointEnabled bool) provider.ClusterProviderGetter {
+	return func(seedName string) (provider.ClusterProvider, error) {
+		cfg, err := seedKubeconfigGetter(seedName)
+		if err != nil {
+			return nil, err
+		}
+		kubeClient, err := kubernetes.NewForConfig(cfg)
+		if err != nil {
+			return nil, fmt.Errorf("faild to create kubeClient: %v", err)
+		}
+		defaultImpersonationClientForSeed := kubernetesprovider.NewKubermaticImpersonationClient(cfg)
+		seedCtrlruntimeClient, err := ctrlruntimeclient.New(cfg, ctrlruntimeclient.Options{})
+		if err != nil {
+			return nil, fmt.Errorf("failed to create dynamic seed client: %v", err)
+		}
+
+		userClusterConnectionProvider, err := client.NewExternal(seedCtrlruntimeClient)
+		if err != nil {
+			return nil, fmt.Errorf("failed to get userClusterConnectionProvider: %v", err)
+		}
+
+		return kubernetesprovider.NewClusterProvider(
+			defaultImpersonationClientForSeed.CreateImpersonatedKubermaticClientSet,
+			userClusterConnectionProvider,
+			workerName,
+			rbac.ExtractGroupPrefix,
+			seedCtrlruntimeClient,
+			kubeClient,
+			oidcKubeCfgEndpointEnabled,
+		), nil
+	}
 }

--- a/api/cmd/kubermatic-api/options.go
+++ b/api/cmd/kubermatic-api/options.go
@@ -137,6 +137,6 @@ type providers struct {
 	projectMember                         provider.ProjectMemberProvider
 	memberMapper                          provider.ProjectMemberMapper
 	eventRecorderProvider                 provider.EventRecorderProvider
-	clusters                              map[string]provider.ClusterProvider
+	clusterProviderGetter                 provider.ClusterProviderGetter
 	seedsGetter                           provider.SeedsGetter
 }

--- a/api/pkg/handler/middleware/middleware.go
+++ b/api/pkg/handler/middleware/middleware.go
@@ -55,10 +55,10 @@ type dCGetter interface {
 }
 
 // SetClusterProvider is a middleware that injects the current ClusterProvider into the ctx
-func SetClusterProvider(clusterProviders map[string]provider.ClusterProvider, seedsGetter provider.SeedsGetter) endpoint.Middleware {
+func SetClusterProvider(clusterProviderGetter provider.ClusterProviderGetter, seedsGetter provider.SeedsGetter) endpoint.Middleware {
 	return func(next endpoint.Endpoint) endpoint.Endpoint {
 		return func(ctx context.Context, request interface{}) (response interface{}, err error) {
-			clusterProvider, ctx, err := getClusterProvider(ctx, request, seedsGetter, clusterProviders)
+			clusterProvider, ctx, err := getClusterProvider(ctx, request, seedsGetter, clusterProviderGetter)
 			if err != nil {
 				return nil, err
 			}
@@ -70,10 +70,10 @@ func SetClusterProvider(clusterProviders map[string]provider.ClusterProvider, se
 }
 
 // SetPrivilegedClusterProvider is a middleware that injects the current ClusterProvider into the ctx
-func SetPrivilegedClusterProvider(clusterProviders map[string]provider.ClusterProvider, seedsGetter provider.SeedsGetter) endpoint.Middleware {
+func SetPrivilegedClusterProvider(clusterProviderGetter provider.ClusterProviderGetter, seedsGetter provider.SeedsGetter) endpoint.Middleware {
 	return func(next endpoint.Endpoint) endpoint.Endpoint {
 		return func(ctx context.Context, request interface{}) (response interface{}, err error) {
-			clusterProvider, ctx, err := getClusterProvider(ctx, request, seedsGetter, clusterProviders)
+			clusterProvider, ctx, err := getClusterProvider(ctx, request, seedsGetter, clusterProviderGetter)
 			if err != nil {
 				return nil, err
 			}
@@ -247,7 +247,7 @@ func createUserInfo(user *kubermaticapiv1.User, projectID string, userProjectMap
 	return &provider.UserInfo{Email: user.Spec.Email, Group: group}, nil
 }
 
-func getClusterProvider(ctx context.Context, request interface{}, seedsGetter provider.SeedsGetter, clusterProviders map[string]provider.ClusterProvider) (provider.ClusterProvider, context.Context, error) {
+func getClusterProvider(ctx context.Context, request interface{}, seedsGetter provider.SeedsGetter, clusterProviderGetter provider.ClusterProviderGetter) (provider.ClusterProvider, context.Context, error) {
 	getter := request.(dCGetter)
 	seeds, err := seedsGetter()
 	if err != nil {
@@ -259,8 +259,8 @@ func getClusterProvider(ctx context.Context, request interface{}, seedsGetter pr
 	}
 	ctx = context.WithValue(ctx, datacenterContextKey, seed)
 
-	clusterProvider, exists := clusterProviders[getter.GetDC()]
-	if !exists {
+	clusterProvider, err := clusterProviderGetter(getter.GetDC())
+	if err != nil {
 		return nil, ctx, errors.NewNotFound("cluster-provider", getter.GetDC())
 	}
 

--- a/api/pkg/handler/routes_v1.go
+++ b/api/pkg/handler/routes_v1.go
@@ -959,7 +959,7 @@ func (r Routing) createCluster(initNodeDeploymentFailures *prometheus.CounterVec
 		endpoint.Chain(
 			middleware.TokenVerifier(r.tokenVerifiers),
 			middleware.UserSaver(r.userProvider),
-			middleware.SetClusterProvider(r.clusterProviders, r.seedsGetter),
+			middleware.SetClusterProvider(r.clusterProviderGetter, r.seedsGetter),
 			middleware.SetPrivilegedClusterProvider(r.clusterProviders, r.seedsGetter),
 			middleware.UserInfoExtractor(r.userProjectMapper),
 		)(cluster.CreateEndpoint(r.sshKeyProvider, r.projectProvider, r.credentialsProvider, r.seedsGetter, initNodeDeploymentFailures, r.eventRecorderProvider, r.presetsManager, r.exposeStrategy)),

--- a/api/pkg/handler/routes_v1_alpha.go
+++ b/api/pkg/handler/routes_v1_alpha.go
@@ -37,7 +37,7 @@ func (r Routing) getClusterMetrics() http.Handler {
 		endpoint.Chain(
 			middleware.TokenVerifier(r.tokenVerifiers),
 			middleware.UserSaver(r.userProvider),
-			middleware.SetClusterProvider(r.clusterProviders, r.seedsGetter),
+			middleware.SetClusterProvider(r.clusterProviderGetter, r.seedsGetter),
 			middleware.UserInfoExtractor(r.userProjectMapper),
 		)(cluster.GetMetricsEndpoint(r.projectProvider, r.prometheusClient)),
 		common.DecodeGetClusterReq,

--- a/api/pkg/handler/routes_v1_legacy.go
+++ b/api/pkg/handler/routes_v1_legacy.go
@@ -56,7 +56,7 @@ func (r Routing) getNodeForClusterLegacy() http.Handler {
 		endpoint.Chain(
 			middleware.TokenVerifier(r.tokenVerifiers),
 			middleware.UserSaver(r.userProvider),
-			middleware.SetClusterProvider(r.clusterProviders, r.seedsGetter),
+			middleware.SetClusterProvider(r.clusterProviderGetter, r.seedsGetter),
 			middleware.UserInfoExtractor(r.userProjectMapper),
 		)(node.GetNodeForClusterLegacyEndpoint(r.projectProvider)),
 		node.DecodeGetNodeForClusterLegacy,
@@ -89,7 +89,7 @@ func (r Routing) createNodeForClusterLegacy() http.Handler {
 		endpoint.Chain(
 			middleware.TokenVerifier(r.tokenVerifiers),
 			middleware.UserSaver(r.userProvider),
-			middleware.SetClusterProvider(r.clusterProviders, r.seedsGetter),
+			middleware.SetClusterProvider(r.clusterProviderGetter, r.seedsGetter),
 			middleware.UserInfoExtractor(r.userProjectMapper),
 		)(node.CreateNodeForClusterLegacyEndpoint()),
 		node.DecodeCreateNodeForClusterLegacy,
@@ -118,7 +118,7 @@ func (r Routing) listNodesForClusterLegacy() http.Handler {
 		endpoint.Chain(
 			middleware.TokenVerifier(r.tokenVerifiers),
 			middleware.UserSaver(r.userProvider),
-			middleware.SetClusterProvider(r.clusterProviders, r.seedsGetter),
+			middleware.SetClusterProvider(r.clusterProviderGetter, r.seedsGetter),
 			middleware.UserInfoExtractor(r.userProjectMapper),
 		)(node.ListNodesForClusterLegacyEndpoint(r.projectProvider)),
 		node.DecodeListNodesForClusterLegacy,
@@ -147,7 +147,7 @@ func (r Routing) deleteNodeForClusterLegacy() http.Handler {
 		endpoint.Chain(
 			middleware.TokenVerifier(r.tokenVerifiers),
 			middleware.UserSaver(r.userProvider),
-			middleware.SetClusterProvider(r.clusterProviders, r.seedsGetter),
+			middleware.SetClusterProvider(r.clusterProviderGetter, r.seedsGetter),
 			middleware.UserInfoExtractor(r.userProjectMapper),
 		)(node.DeleteNodeForClusterLegacyEndpoint(r.projectProvider)),
 		node.DecodeDeleteNodeForClusterLegacy,

--- a/api/pkg/handler/routes_v1_optional.go
+++ b/api/pkg/handler/routes_v1_optional.go
@@ -36,7 +36,7 @@ func (r Routing) RegisterV1Optional(mux *mux.Router, oidcKubeConfEndpoint bool, 
 func (r Routing) createOIDCKubeconfig(oidcCfg common.OIDCConfiguration) http.Handler {
 	return httptransport.NewServer(
 		endpoint.Chain(
-			middleware.SetClusterProvider(r.clusterProviders, r.seedsGetter),
+			middleware.SetClusterProvider(r.clusterProviderGetter, r.seedsGetter),
 			middleware.UserInfoUnauthorized(r.userProjectMapper, r.userProvider),
 		)(cluster.CreateOIDCKubeconfigEndpoint(r.projectProvider, r.oidcIssuerVerifier, oidcCfg)),
 		cluster.DecodeCreateOIDCKubeconfig,

--- a/api/pkg/handler/routing.go
+++ b/api/pkg/handler/routing.go
@@ -41,7 +41,7 @@ type Routing struct {
 	oidcIssuerVerifier          auth.OIDCIssuerVerifier
 	tokenVerifiers              auth.TokenVerifier
 	tokenExtractors             auth.TokenExtractor
-	clusterProviders            map[string]provider.ClusterProvider
+	clusterProviderGetter       provider.ClusterProviderGetter
 	updateManager               common.UpdateManager
 	prometheusClient            prometheusapi.Client
 	projectMemberProvider       provider.ProjectMemberProvider
@@ -56,7 +56,7 @@ type Routing struct {
 // NewRouting creates a new Routing.
 func NewRouting(
 	seedsGetter provider.SeedsGetter,
-	newClusterProviders map[string]provider.ClusterProvider,
+	clusterProviderGetter provider.ClusterProviderGetter,
 	newSSHKeyProvider provider.SSHKeyProvider,
 	userProvider provider.UserProvider,
 	serviceAccountProvider provider.ServiceAccountProvider,
@@ -79,7 +79,7 @@ func NewRouting(
 ) Routing {
 	return Routing{
 		seedsGetter:                 seedsGetter,
-		clusterProviders:            newClusterProviders,
+		clusterProviderGetter:       clusterProviderGetter,
 		sshKeyProvider:              newSSHKeyProvider,
 		userProvider:                userProvider,
 		serviceAccountProvider:      serviceAccountProvider,

--- a/api/pkg/handler/test/hack/hack.go
+++ b/api/pkg/handler/test/hack/hack.go
@@ -24,7 +24,7 @@ import (
 // for example handler package uses v1/dc and v1/dc needs handler for testing
 func NewTestRouting(
 	seedsGetter provider.SeedsGetter,
-	clusterProviders map[string]provider.ClusterProvider,
+	clusterProvidersGetter provider.ClusterProviderGetter,
 	sshKeyProvider provider.SSHKeyProvider,
 	userProvider provider.UserProvider,
 	serviceAccountProvider provider.ServiceAccountProvider,
@@ -47,7 +47,7 @@ func NewTestRouting(
 	updateManager := version.New(versions, updates)
 	r := handler.NewRouting(
 		seedsGetter,
-		clusterProviders,
+		clusterProvidersGetter,
 		sshKeyProvider,
 		userProvider,
 		serviceAccountProvider,

--- a/api/pkg/handler/test/helper.go
+++ b/api/pkg/handler/test/helper.go
@@ -116,7 +116,7 @@ func GetUser(email, id, name string, admin bool) apiv1.User {
 // it is meant to be used by legacy handler.createTestEndpointAndGetClients function
 type newRoutingFunc func(
 	seedsGetter provider.SeedsGetter,
-	newClusterProviders map[string]provider.ClusterProvider,
+	clusterProviderGetter provider.ClusterProviderGetter,
 	newSSHKeyProvider provider.SSHKeyProvider,
 	userProvider provider.UserProvider,
 	serviceAccountProvider provider.ServiceAccountProvider,
@@ -222,6 +222,12 @@ func initTestEndpoint(user apiv1.User, seedsGetter provider.SeedsGetter, kubeObj
 		false,
 	)
 	clusterProviders := map[string]provider.ClusterProvider{"us-central1": clusterProvider}
+	clusterProviderGetter := func(seedName string) (provider.ClusterProvider, error) {
+		if clusterProvider, exists := clusterProviders[seedName]; exists {
+			return clusterProvider, nil
+		}
+		return nil, fmt.Errorf("can not find clusterprovider for cluster %q", seedName)
+	}
 
 	kubernetesInformerFactory.Start(wait.NeverStop)
 	kubernetesInformerFactory.WaitForCacheSync(wait.NeverStop)
@@ -235,7 +241,7 @@ func initTestEndpoint(user apiv1.User, seedsGetter provider.SeedsGetter, kubeObj
 
 	mainRouter := routingFunc(
 		seedsGetter,
-		clusterProviders,
+		clusterProviderGetter,
 		sshKeyProvider,
 		userProvider,
 		serviceAccountProvider,

--- a/api/pkg/handler/v1/cluster/cluster.go
+++ b/api/pkg/handler/v1/cluster/cluster.go
@@ -346,19 +346,29 @@ func ListEndpoint(projectProvider provider.ProjectProvider) endpoint.Endpoint {
 }
 
 // ListAllEndpoint list clusters for the given project in all datacenters
-func ListAllEndpoint(projectProvider provider.ProjectProvider, clusterProviders map[string]provider.ClusterProvider) endpoint.Endpoint {
+func ListAllEndpoint(projectProvider provider.ProjectProvider, seedsGetter provider.SeedsGetter, clusterProviderGetter provider.ClusterProviderGetter) endpoint.Endpoint {
 	return func(ctx context.Context, request interface{}) (interface{}, error) {
 		req := request.(common.GetProjectRq)
 		allClusters := make([]*apiv1.Cluster, 0)
 		userInfo := ctx.Value(middleware.UserInfoContextKey).(*provider.UserInfo)
 
-		for _, clusterProvider := range clusterProviders {
+		seeds, err := seedsGetter()
+		if err != nil {
+			return nil, common.KubernetesErrorToHTTPError(err)
+		}
+
+		for seedName := range seeds {
+			clusterProvider, err := clusterProviderGetter(seedName)
+			if err != nil {
+				return nil, common.KubernetesErrorToHTTPError(err)
+			}
 			apiClusters, err := getClusters(clusterProvider, userInfo, projectProvider, req.ProjectID)
 			if err != nil {
 				return nil, common.KubernetesErrorToHTTPError(err)
 			}
 			allClusters = append(allClusters, apiClusters...)
 		}
+
 		return allClusters, nil
 	}
 }

--- a/api/pkg/provider/datacenter.go
+++ b/api/pkg/provider/datacenter.go
@@ -39,6 +39,9 @@ type SeedsGetter = func() (map[string]*kubermaticv1.Seed, error)
 // SeedKubeconfigGetter is used to fetch the kubeconfig for a given seed
 type SeedKubeconfigGetter = func(seedName string) (*rest.Config, error)
 
+// ClusterProviderGetter is used to get a clusterProvider
+type ClusterProviderGetter = func(seedName string) (ClusterProvider, error)
+
 // DatacenterMeta describes a Kubermatic datacenter.
 type DatacenterMeta struct {
 	Location         string                      `json:"location"`


### PR DESCRIPTION
**What this PR does / why we need it**:

Changes the api to dynamically create the cluster providers during runtime instead of startup to be able to react in changes to the seeds. Towards #2113 

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Documentation**:
<!-- Add links to the related documentation changes related to this pull request. E.g. the link to the kubermatic/docs pullrequest. -->

**Does this PR introduce a user-facing change?**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If  no release note is required, just write "NONE".
-->
```release-note
none
```

/assign @maciaszczykm 
