### PR TITLE
Kubermatic Operator deployment

### DIFF
--- a/api/cmd/kubermatic-operator/main.go
+++ b/api/cmd/kubermatic-operator/main.go
@@ -30,7 +30,7 @@ type controllerRunOptions struct {
 
 func main() {
 	opt := &controllerRunOptions{}
-	flag.StringVar(&opt.kubeconfig, "kubeconfig", "", "Path to a kubeconfig. Only required out-of-cluster.")
+	flag.StringVar(&opt.kubeconfig, "kubeconfig", "", "Path to a kubeconfig. Only required if outside of cluster.")
 	flag.IntVar(&opt.workerCount, "worker-count", 4, "Number of workers which process the clusters in parallel.")
 	flag.StringVar(&opt.internalAddr, "internal-address", "127.0.0.1:8085", "The address on which the /metrics endpoint will be served")
 	flag.BoolVar(&opt.log.Debug, "log-debug", false, "Enables debug logging")

--- a/api/cmd/kubermatic-operator/main.go
+++ b/api/cmd/kubermatic-operator/main.go
@@ -30,7 +30,7 @@ type controllerRunOptions struct {
 
 func main() {
 	opt := &controllerRunOptions{}
-	flag.StringVar(&opt.kubeconfig, "kubeconfig", "", "Path to a kubeconfig.")
+	flag.StringVar(&opt.kubeconfig, "kubeconfig", "", "Path to a kubeconfig. Only required out-of-cluster.")
 	flag.IntVar(&opt.workerCount, "worker-count", 4, "Number of workers which process the clusters in parallel.")
 	flag.StringVar(&opt.internalAddr, "internal-address", "127.0.0.1:8085", "The address on which the /metrics endpoint will be served")
 	flag.BoolVar(&opt.log.Debug, "log-debug", false, "Enables debug logging")
@@ -52,24 +52,12 @@ func main() {
 	// set the logger used by sigs.k8s.io/controller-runtime
 	ctrllog.SetLogger(zapr.NewLogger(rawLog.WithOptions(zap.AddCallerSkip(1))))
 
-	clientConfig, err := clientcmd.LoadFromFile(opt.kubeconfig)
+	config, err := clientcmd.BuildConfigFromFlags("", opt.kubeconfig)
 	if err != nil {
-		log.Fatalw("Failed to read the kubeconfig", "error", err)
+		log.Fatalw("Failed to build config", "error", err)
 	}
 
-	config := clientcmd.NewNonInteractiveClientConfig(
-		*clientConfig,
-		clientConfig.CurrentContext,
-		&clientcmd.ConfigOverrides{CurrentContext: clientConfig.CurrentContext},
-		nil,
-	)
-
-	cfg, err := config.ClientConfig()
-	if err != nil {
-		log.Fatalw("Failed to create client", "error", err)
-	}
-
-	mgr, err := manager.New(cfg, manager.Options{MetricsBindAddress: opt.internalAddr})
+	mgr, err := manager.New(config, manager.Options{MetricsBindAddress: opt.internalAddr})
 	if err != nil {
 		log.Fatalw("Failed to create Controller Manager instance: %v", err)
 	}
@@ -81,7 +69,7 @@ func main() {
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 
-	if err := operatormaster.Add(ctx, mgr, 1, clientConfig, log, opt.workerName); err != nil {
+	if err := operatormaster.Add(ctx, mgr, 1, log, opt.workerName); err != nil {
 		log.Fatalw("Failed to add operator-master controller", "error", err)
 	}
 

--- a/api/pkg/controller/operator-master/controller.go
+++ b/api/pkg/controller/operator-master/controller.go
@@ -8,7 +8,6 @@ import (
 
 	operatorv1alpha1 "github.com/kubermatic/kubermatic/api/pkg/crd/operator/v1alpha1"
 
-	clientcmdapi "k8s.io/client-go/tools/clientcmd/api"
 	"sigs.k8s.io/controller-runtime/pkg/controller"
 	"sigs.k8s.io/controller-runtime/pkg/handler"
 	"sigs.k8s.io/controller-runtime/pkg/manager"
@@ -29,17 +28,15 @@ func Add(
 	ctx context.Context,
 	mgr manager.Manager,
 	numWorkers int,
-	clientConfig *clientcmdapi.Config,
 	log *zap.SugaredLogger,
 	workerName string,
 ) error {
 	reconciler := &Reconciler{
-		Client:       mgr.GetClient(),
-		recorder:     mgr.GetRecorder(ControllerName),
-		clientConfig: clientConfig,
-		log:          log.Named(ControllerName),
-		workerName:   workerName,
-		ctx:          ctx,
+		Client:     mgr.GetClient(),
+		recorder:   mgr.GetRecorder(ControllerName),
+		log:        log.Named(ControllerName),
+		workerName: workerName,
+		ctx:        ctx,
 	}
 
 	ctrlOptions := controller.Options{Reconciler: reconciler, MaxConcurrentReconciles: numWorkers}

--- a/api/pkg/controller/operator-master/reconciler.go
+++ b/api/pkg/controller/operator-master/reconciler.go
@@ -7,7 +7,6 @@ import (
 	operatorv1alpha1 "github.com/kubermatic/kubermatic/api/pkg/crd/operator/v1alpha1"
 	"go.uber.org/zap"
 	"k8s.io/client-go/tools/cache"
-	clientcmdapi "k8s.io/client-go/tools/clientcmd/api"
 	"k8s.io/client-go/tools/record"
 	ctrlruntimeclient "sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
@@ -18,11 +17,10 @@ import (
 type Reconciler struct {
 	ctrlruntimeclient.Client
 
-	clientConfig *clientcmdapi.Config
-	log          *zap.SugaredLogger
-	recorder     record.EventRecorder
-	workerName   string
-	ctx          context.Context
+	log        *zap.SugaredLogger
+	recorder   record.EventRecorder
+	workerName string
+	ctx        context.Context
 }
 
 // Reconcile acts upon requests and will restore the state of resources

--- a/config/kubermatic-operator/deployment.yaml
+++ b/config/kubermatic-operator/deployment.yaml
@@ -1,0 +1,40 @@
+apiVersion: extensions/v1beta1
+kind: Deployment
+metadata:
+  name: kubermatic-operator
+  namespace: kubermatic-operator
+  labels:
+    app.kubernetes.io/name: kubermatic-operator
+    app.kubernetes.io/version: '__KUBERMATIC_TAG__'
+spec:
+  replicas: 1
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: kubermatic-operator
+      annotations:
+        prometheus.io/scrape: 'true'
+        prometheus.io/scrape_port: '8085'
+        fluentbit.io/parser: glog
+    spec:
+      serviceAccountName: kubermatic-operator
+      containers:
+      - name: operator
+        image: 'quay.io/kubermatic/api:__KUBERMATIC_TAG__'
+        imagePullPolicy: IfNotPresent
+        command:
+        - kubermatic-operator
+        args:
+        - -internal-address=0.0.0.0:8085
+        - -log-format=json
+        ports:
+        - name: metrics
+          containerPort: 8085
+          protocol: TCP
+        resources:
+          requests:
+            cpu: 200m
+            memory: 256Mi
+          limits:
+            cpu: 500m
+            memory: 512Mi

--- a/config/kubermatic-operator/rbac.yaml
+++ b/config/kubermatic-operator/rbac.yaml
@@ -1,0 +1,14 @@
+kind: ClusterRoleBinding
+apiVersion: rbac.authorization.k8s.io/v1beta1
+metadata:
+  name: kubermatic-operator
+  labels:
+    app.kubernetes.io/name: kubermatic-operator
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: cluster-admin
+subjects:
+- kind: ServiceAccount
+  name: kubermatic-operator
+  namespace: kubermatic-operator

--- a/config/kubermatic-operator/serviceaccount.yaml
+++ b/config/kubermatic-operator/serviceaccount.yaml
@@ -1,0 +1,7 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: kubermatic-operator
+  namespace: kubermatic-operator
+  labels:
+    app.kubernetes.io/name: kubermatic-operator


### PR DESCRIPTION
**What this PR does / why we need it**:
This first and foremost removes the need to load a kubeconfig into the Kubermatic Operator. In the new world, Datacenters and Seeds will be linking to their kubeconfigs, which already exist as secrets. The operator therefore can easily find all the kubeconfigs it could ever need.

Apart from this, this PR adds static manifests and a new stack, `kubermatic-operator`, to the `deploy.sh` script. Unfortunately in this setup, the deployment will go into an ImagePull backoff until the `kubermatic` stack is done building and pushing the Docker images. We can solve this by simply doing the operator deployment as part of the `kubermatic` stack (I separated it because I wanted to be able to send prow errors to a custom Slack channel).

**Which issue(s) this PR fixes**:
Relates to #3626 

**Does this PR introduce a user-facing change?**:
```release-note
NONE
```
