### PR TITLE
 [release/v2.11] Update UI to v1.3.3

### DIFF
--- a/config/kubermatic/values.yaml
+++ b/config/kubermatic/values.yaml
@@ -166,7 +166,7 @@ kubermatic:
     replicas: 2
     image:
       repository: "quay.io/kubermatic/ui-v2"
-      tag: "v1.3.2"
+      tag: "v1.3.3"
       pullPolicy: "IfNotPresent"
     config: |
       {


### PR DESCRIPTION
**What this PR does / why we need it**:
Related to https://github.com/kubermatic/dashboard-v2/pull/1426. Updates UI to version where this issue is fixed.

**Documentation**:
<!-- Add links to the related documentation changes related to this pull request. E.g. the link to the kubermatic/docs pullrequest. -->
N/A

**Does this PR introduce a user-facing change?**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If  no release note is required, just write "NONE".
-->
```release-note
Update UI to version v1.3.3 to re-enable the option to manually enter the Openstack project
```
