### PR TITLE
[release/v2.11] Cherrypick http prober as wrapper instead of initContainer

### DIFF
--- a/api/cmd/http-prober/Dockerfile
+++ b/api/cmd/http-prober/Dockerfile
@@ -1,4 +1,4 @@
-FROM alpine:3.7
+FROM alpine:3.9
 LABEL maintainer "henrik@loodse.com"
 
 COPY ./http-prober /usr/local/bin/

--- a/api/cmd/http-prober/api/httpprober.go
+++ b/api/cmd/http-prober/api/httpprober.go
@@ -1,0 +1,6 @@
+package api
+
+type Command struct {
+	Command string   `json:"command"`
+	Args    []string `json:"args"`
+}

--- a/api/cmd/http-prober/main.go
+++ b/api/cmd/http-prober/main.go
@@ -2,21 +2,18 @@ package main
 
 import (
 	"crypto/tls"
+	"encoding/json"
 	"flag"
 	"log"
 	"net/http"
 	"net/http/httptrace"
 	"net/url"
 	"os"
+	"os/exec"
+	"syscall"
 	"time"
-)
 
-var (
-	endpoint  string
-	insecure  bool
-	retries   int
-	retryWait int
-	timeout   int
+	httpproberapi "github.com/kubermatic/kubermatic/api/cmd/http-prober/api"
 )
 
 const (
@@ -24,12 +21,29 @@ const (
 )
 
 func main() {
+	var (
+		endpoint   string
+		insecure   bool
+		retries    int
+		retryWait  int
+		timeout    int
+		commandRaw string
+	)
 	flag.StringVar(&endpoint, "endpoint", "", "The endpoint which should be waited for")
 	flag.BoolVar(&insecure, "insecure", false, "Disable certificate validation")
 	flag.IntVar(&retries, "retries", 10, "Number of retries")
 	flag.IntVar(&retryWait, "retry-wait", 1, "Wait interval in seconds between retries")
 	flag.IntVar(&timeout, "timeout", 30, "Timeout in seconds")
+	flag.StringVar(&commandRaw, "command", "", "If passed, the http prober will exec this command. Must be json encoded")
 	flag.Parse()
+
+	var command *httpproberapi.Command
+	if commandRaw != "" {
+		command = &httpproberapi.Command{}
+		if err := json.Unmarshal([]byte(commandRaw), command); err != nil {
+			log.Fatalf("failed to deserialize command: %v", err)
+		}
+	}
 
 	tr := &http.Transport{
 		TLSClientConfig: &tls.Config{
@@ -78,6 +92,19 @@ func main() {
 		}
 
 		log.Println("Endpoint is available!")
+		if command != nil {
+			commandFullPath, err := exec.LookPath(command.Command)
+			if err != nil {
+				log.Fatalf("failed to look up full path for command %q: %v", command.Command, err)
+			}
+			// First arg should be the filename of the command being executed, quote from execve(2):
+			// `By convention, the first of these strings (i.e., argv[0]) should contain the filename associated with the file being executed`
+			args := append([]string{command.Command}, command.Args...)
+			if err := syscall.Exec(commandFullPath, args, os.Environ()); err != nil {
+				log.Fatalf("failed to execute command: %v", err)
+			}
+
+		}
 		os.Exit(0)
 	}
 

--- a/api/cmd/http-prober/release.sh
+++ b/api/cmd/http-prober/release.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 
-ver=v0.1
+ver=v0.2-dev0
 
 set -euox pipefail
 

--- a/api/cmd/http-prober/release.sh
+++ b/api/cmd/http-prober/release.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 
-ver=v0.2-dev0
+ver=v0.2
 
 set -euox pipefail
 

--- a/api/pkg/controller/openshift/openshift_controller_test.go
+++ b/api/pkg/controller/openshift/openshift_controller_test.go
@@ -5,6 +5,7 @@ import (
 	"flag"
 	"fmt"
 	"io/ioutil"
+	"strings"
 	"testing"
 
 	kubermaticv1 "github.com/kubermatic/kubermatic/api/pkg/crd/kubermatic/v1"
@@ -159,7 +160,7 @@ func TestResources(t *testing.T) {
 				t.Fatalf("failed to serialize object %q: %v", metav1object.GetName(), err)
 			}
 
-			testhelper.CompareOutput(t, fmt.Sprintf("%s-%s", tc.name, metav1object.GetName()), string(serializedObject), *update, ".yaml")
+			testhelper.CompareOutput(t, fmt.Sprintf("%s-%s", strings.Replace(tc.name, " ", "_", -1), metav1object.GetName()), string(serializedObject), *update, ".yaml")
 		})
 	}
 

--- a/api/pkg/controller/openshift/testdata/Kubermatic API image is overwritten-usercluster-controller.golden.yaml
+++ b/api/pkg/controller/openshift/testdata/Kubermatic API image is overwritten-usercluster-controller.golden.yaml
@@ -30,30 +30,19 @@ spec:
     spec:
       containers:
       - args:
-        - -kubeconfig
-        - /etc/kubernetes/kubeconfig/kubeconfig
-        - -metrics-listen-address
-        - 0.0.0.0:8085
-        - -health-listen-address
-        - 0.0.0.0:8086
-        - -namespace
-        - $(NAMESPACE)
-        - -ca-cert
-        - /etc/kubernetes/pki/ca/ca.crt
-        - -cluster-url
-        - https://test-cluster.alias-europe-west3-c.dev.kubermatic.io:0
-        - -openvpn-server-port
-        - "0"
-        - -overwrite-registry
-        - ""
-        - -openshift=true
-        - -openvpn-ca-cert-file=/etc/kubernetes/pki/openvpn/ca.crt
-        - -openvpn-ca-key-file=/etc/kubernetes/pki/openvpn/ca.key
-        - -logtostderr
-        - -v
+        - -endpoint
+        - https://apiserver-external.test-cluster-ns.svc.cluster.local.:0/healthz
+        - -insecure
+        - -retries
+        - "100"
+        - -retry-wait
         - "2"
+        - -timeout
+        - "1"
+        - -command
+        - '{"command":"/usr/local/bin/user-cluster-controller-manager","args":["-kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","-metrics-listen-address","0.0.0.0:8085","-health-listen-address","0.0.0.0:8086","-namespace","$(NAMESPACE)","-ca-cert","/etc/kubernetes/pki/ca/ca.crt","-cluster-url","https://test-cluster.alias-europe-west3-c.dev.kubermatic.io:0","-openvpn-server-port","0","-overwrite-registry","","-openshift=true","-openvpn-ca-cert-file=/etc/kubernetes/pki/openvpn/ca.crt","-openvpn-ca-key-file=/etc/kubernetes/pki/openvpn/ca.key","-logtostderr","-v","2"]}'
         command:
-        - /usr/local/bin/user-cluster-controller-manager
+        - /http-prober-bin/http-prober
         env:
         - name: NAMESPACE
           valueFrom:
@@ -91,27 +80,24 @@ spec:
         - mountPath: /etc/kubernetes/pki/openvpn
           name: openvpn-ca
           readOnly: true
+        - mountPath: /http-prober-bin
+          name: http-prober-bin
       imagePullSecrets:
       - name: dockercfg
       initContainers:
-      - args:
-        - -endpoint
-        - https://apiserver-external.test-cluster-ns.svc.cluster.local.:0/healthz
-        - -insecure
-        - -retries
-        - "100"
-        - -retry-wait
-        - "2"
-        - -timeout
-        - "1"
-        command:
+      - command:
+        - /bin/cp
         - /usr/local/bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.1
+        - /http-prober-bin/http-prober
+        image: quay.io/kubermatic/http-prober:v0.2-dev0
         imagePullPolicy: IfNotPresent
-        name: apiserver-running
+        name: copy-http-prober
         resources: {}
         terminationMessagePath: /dev/termination-log
         terminationMessagePolicy: File
+        volumeMounts:
+        - mountPath: /http-prober-bin
+          name: http-prober-bin
       volumes:
       - name: internal-admin-kubeconfig
         secret:
@@ -128,4 +114,6 @@ spec:
         secret:
           defaultMode: 292
           secretName: openvpn-ca
+      - emptyDir: {}
+        name: http-prober-bin
 status: {}

--- a/api/pkg/controller/openshift/testdata/Kubermatic_API_image_is_overwritten-usercluster-controller.golden.yaml
+++ b/api/pkg/controller/openshift/testdata/Kubermatic_API_image_is_overwritten-usercluster-controller.golden.yaml
@@ -89,7 +89,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.2-dev0
+        image: quay.io/kubermatic/http-prober:v0.2
         imagePullPolicy: IfNotPresent
         name: copy-http-prober
         resources: {}

--- a/api/pkg/resources/apiserver/is-running.go
+++ b/api/pkg/resources/apiserver/is-running.go
@@ -1,12 +1,22 @@
 package apiserver
 
 import (
+	"encoding/json"
+	"errors"
 	"fmt"
 
+	httpproberapi "github.com/kubermatic/kubermatic/api/cmd/http-prober/api"
 	kubermaticv1 "github.com/kubermatic/kubermatic/api/pkg/crd/kubermatic/v1"
 	"github.com/kubermatic/kubermatic/api/pkg/resources"
 
 	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/util/sets"
+)
+
+const (
+	tag                = "v0.2-dev0"
+	emptyDirVolumeName = "http-prober-bin"
+	initContainerName  = "copy-http-prober"
 )
 
 // IsRunningInitContainer returns a init container which will wait until the apiserver is reachable via its ClusterIP
@@ -15,21 +25,117 @@ type isRunningInitContainerData interface {
 	Cluster() *kubermaticv1.Cluster
 }
 
-func IsRunningInitContainer(data isRunningInitContainerData) (*corev1.Container, error) {
-	// get clusterIP of apiserver
-	return &corev1.Container{
-		Name:            "apiserver-running",
-		Image:           data.ImageRegistry(resources.RegistryQuay) + "/kubermatic/http-prober:v0.1",
-		ImagePullPolicy: corev1.PullIfNotPresent,
-		Command:         []string{"/usr/local/bin/http-prober"},
-		Args: []string{
-			"-endpoint", fmt.Sprintf("https://%s:%d/healthz", data.Cluster().Address.InternalName, data.Cluster().Address.Port),
-			"-insecure",
-			"-retries", "100",
-			"-retry-wait", "2",
-			"-timeout", "1",
+// IsRunningWrapper wraps the named containers in the pod with a check if the API server is reachable.
+// This is achieved by copying a `http-prober` binary via an init container into an emptyDir volume,
+// then mounting that volume onto all named containers and replacing the command with a call to
+// the `http-prober` binary. The http prober binary gets the original command as serialized string
+// and does an syscall.Exec onto it once the apiserver became reachable
+func IsRunningWrapper(data isRunningInitContainerData, spec corev1.PodSpec, containersToWrap sets.String) (*corev1.PodSpec, error) {
+	if containersToWrap.Len() == 0 {
+		return nil, errors.New("no containers to wrap passed")
+	}
+
+	for _, containerToWrap := range containersToWrap.List() {
+		if !hasContainerNamed(spec, containerToWrap) {
+			return nil, fmt.Errorf("pod has no container named %q", containerToWrap)
+		}
+	}
+
+	var newVoumes []corev1.Volume
+	for _, volume := range spec.Volumes {
+		if volume.Name == emptyDirVolumeName {
+			continue
+		}
+		newVoumes = append(newVoumes, volume)
+	}
+	spec.Volumes = append(newVoumes, corev1.Volume{
+		Name: emptyDirVolumeName,
+		VolumeSource: corev1.VolumeSource{
+			EmptyDir: &corev1.EmptyDirVolumeSource{},
 		},
-		TerminationMessagePath:   corev1.TerminationMessagePathDefault,
-		TerminationMessagePolicy: corev1.TerminationMessageReadFile,
-	}, nil
+	})
+
+	var newInitContainers []corev1.Container
+	for _, container := range spec.InitContainers {
+		if container.Name == initContainerName {
+			continue
+		}
+		newInitContainers = append(newInitContainers, container)
+	}
+	copyContainer := corev1.Container{
+		Name:    initContainerName,
+		Image:   data.ImageRegistry(resources.RegistryQuay) + "/kubermatic/http-prober:" + tag,
+		Command: []string{"/bin/cp", "/usr/local/bin/http-prober", "/http-prober-bin/http-prober"},
+		VolumeMounts: []corev1.VolumeMount{{
+			Name:      emptyDirVolumeName,
+			MountPath: "/http-prober-bin",
+		}},
+	}
+	// We must come first in case an initContainer gets wrapped
+	spec.InitContainers = append([]corev1.Container{copyContainer}, newInitContainers...)
+
+	for idx := range spec.InitContainers {
+		if !containersToWrap.Has(spec.InitContainers[idx].Name) {
+			continue
+		}
+		wrappedContainer, err := wrapContainer(data, spec.InitContainers[idx])
+		if err != nil {
+			return nil, fmt.Errorf("failed to wrap initContainer %q: %v", spec.InitContainers[idx].Name, err)
+		}
+		spec.InitContainers[idx] = *wrappedContainer
+	}
+	for idx := range spec.Containers {
+		if !containersToWrap.Has(spec.Containers[idx].Name) {
+			continue
+		}
+		wrappedContainer, err := wrapContainer(data, spec.Containers[idx])
+		if err != nil {
+			return nil, fmt.Errorf("failed to wrap container %q: %v", spec.Containers[idx].Name, err)
+		}
+		spec.Containers[idx] = *wrappedContainer
+	}
+
+	return &spec, nil
+}
+
+func hasContainerNamed(spec corev1.PodSpec, name string) bool {
+	for _, container := range append(spec.InitContainers, spec.Containers...) {
+		if container.Name == name {
+			return true
+		}
+	}
+	return false
+}
+
+func wrapContainer(data isRunningInitContainerData, container corev1.Container) (*corev1.Container, error) {
+	commandWithArgs := append(container.Command, container.Args...)
+	if len(commandWithArgs) == 0 {
+		return nil, fmt.Errorf("container %q has no command or args set", container.Name)
+	}
+	command := httpproberapi.Command{
+		Command: commandWithArgs[0],
+	}
+	if len(commandWithArgs) > 1 {
+		command.Args = commandWithArgs[1:]
+	}
+	serializedCommand, err := json.Marshal(command)
+	if err != nil {
+		return nil, fmt.Errorf("failed to serialize command: %v", err)
+	}
+
+	container.VolumeMounts = append(container.VolumeMounts, corev1.VolumeMount{
+		Name:      emptyDirVolumeName,
+		MountPath: "/http-prober-bin",
+	})
+	container.Command = []string{"/http-prober-bin/http-prober"}
+	container.Args = []string{
+		"-endpoint", fmt.Sprintf("https://%s:%d/healthz", data.Cluster().Address.InternalName, data.Cluster().Address.Port),
+		"-insecure",
+		"-retries", "100",
+		"-retry-wait", "2",
+		"-timeout", "1",
+		"-command", string(serializedCommand),
+	}
+
+	return &container, nil
 }

--- a/api/pkg/resources/apiserver/is-running.go
+++ b/api/pkg/resources/apiserver/is-running.go
@@ -14,7 +14,7 @@ import (
 )
 
 const (
-	tag                = "v0.2-dev0"
+	tag                = "v0.2"
 	emptyDirVolumeName = "http-prober-bin"
 	initContainerName  = "copy-http-prober"
 )

--- a/api/pkg/resources/clusterautoscaler/clusterautoscaler.go
+++ b/api/pkg/resources/clusterautoscaler/clusterautoscaler.go
@@ -13,6 +13,7 @@ import (
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/intstr"
+	"k8s.io/apimachinery/pkg/util/sets"
 )
 
 type clusterautoscalerData interface {
@@ -79,12 +80,6 @@ func DeploymentCreator(data clusterautoscalerData) reconciling.NamedDeploymentCr
 
 			dep.Spec.Template.Spec.Volumes = volumes
 
-			apiserverIsRunningContainer, err := apiserver.IsRunningInitContainer(data)
-			if err != nil {
-				return nil, err
-			}
-			dep.Spec.Template.Spec.InitContainers = []corev1.Container{*apiserverIsRunningContainer}
-
 			dep.Spec.Template.Spec.Containers = []corev1.Container{
 				{
 					Name:    resources.ClusterAutoscalerDeploymentName,
@@ -136,6 +131,12 @@ func DeploymentCreator(data clusterautoscalerData) reconciling.NamedDeploymentCr
 					},
 				},
 			}
+
+			wrappedPodSpec, err := apiserver.IsRunningWrapper(data, dep.Spec.Template.Spec, sets.NewString(resources.ClusterAutoscalerDeploymentName))
+			if err != nil {
+				return nil, fmt.Errorf("failed to add apiserver.IsRunningWrapper: %v", err)
+			}
+			dep.Spec.Template.Spec = *wrappedPodSpec
 
 			return dep, nil
 		}

--- a/api/pkg/resources/controllermanager/deployment.go
+++ b/api/pkg/resources/controllermanager/deployment.go
@@ -16,6 +16,7 @@ import (
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/intstr"
+	"k8s.io/apimachinery/pkg/util/sets"
 )
 
 var (
@@ -100,12 +101,6 @@ func DeploymentCreator(data *resources.TemplateData) reconciling.NamedDeployment
 
 			dep.Spec.Template.Spec.Volumes = volumes
 
-			apiserverIsRunningContainer, err := apiserver.IsRunningInitContainer(data)
-			if err != nil {
-				return nil, err
-			}
-			dep.Spec.Template.Spec.InitContainers = []corev1.Container{*apiserverIsRunningContainer}
-
 			openvpnSidecar, err := vpnsidecar.OpenVPNSidecarContainer(data, "openvpn-client")
 			if err != nil {
 				return nil, fmt.Errorf("failed to get openvpn sidecar: %v", err)
@@ -189,6 +184,12 @@ func DeploymentCreator(data *resources.TemplateData) reconciling.NamedDeployment
 			}
 
 			dep.Spec.Template.Spec.Affinity = resources.HostnameAntiAffinity(name, data.Cluster().Name)
+
+			wrappedPodSpec, err := apiserver.IsRunningWrapper(data, dep.Spec.Template.Spec, sets.NewString(name))
+			if err != nil {
+				return nil, fmt.Errorf("failed to add apiserver.IsRunningWrapper: %v", err)
+			}
+			dep.Spec.Template.Spec = *wrappedPodSpec
 
 			return dep, nil
 		}

--- a/api/pkg/resources/machinecontroller/webhook.go
+++ b/api/pkg/resources/machinecontroller/webhook.go
@@ -54,11 +54,6 @@ func WebhookDeploymentCreator(data machinecontrollerData) reconciling.NamedDeplo
 			}
 			dep.Spec.Template.Spec.ImagePullSecrets = []corev1.LocalObjectReference{{Name: resources.ImagePullSecretName}}
 
-			envVars, err := getEnvVars(data)
-			if err != nil {
-				return nil, err
-			}
-
 			volumes := []corev1.Volume{getKubeconfigVolume(), getServingCertVolume()}
 			dep.Spec.Template.Spec.Volumes = volumes
 			podLabels, err := data.GetPodTemplateLabels(resources.MachineControllerWebhookDeploymentName, volumes, nil)

--- a/api/pkg/resources/metrics-server/deployment.go
+++ b/api/pkg/resources/metrics-server/deployment.go
@@ -13,6 +13,7 @@ import (
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/intstr"
+	"k8s.io/apimachinery/pkg/util/sets"
 )
 
 var (
@@ -70,12 +71,6 @@ func DeploymentCreator(data *resources.TemplateData) reconciling.NamedDeployment
 
 			dep.Spec.Template.Spec.Volumes = volumes
 
-			apiserverIsRunningContainer, err := apiserver.IsRunningInitContainer(data)
-			if err != nil {
-				return nil, err
-			}
-			dep.Spec.Template.Spec.InitContainers = []corev1.Container{*apiserverIsRunningContainer}
-
 			openvpnSidecar, err := vpnsidecar.OpenVPNSidecarContainer(data, "openvpn-client")
 			if err != nil {
 				return nil, fmt.Errorf("failed to get openvpn-client sidecar: %v", err)
@@ -116,6 +111,12 @@ func DeploymentCreator(data *resources.TemplateData) reconciling.NamedDeployment
 			}
 
 			dep.Spec.Template.Spec.Affinity = resources.HostnameAntiAffinity(name, data.Cluster().Name)
+
+			wrappedPodSpec, err := apiserver.IsRunningWrapper(data, dep.Spec.Template.Spec, sets.NewString(name))
+			if err != nil {
+				return nil, fmt.Errorf("failed to add apiserver.IsRunningWrapper: %v", err)
+			}
+			dep.Spec.Template.Spec = *wrappedPodSpec
 
 			return dep, nil
 		}

--- a/api/pkg/resources/test/fixtures/deployment-aws-1.10.0-controller-manager.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-aws-1.10.0-controller-manager.yaml
@@ -185,7 +185,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.2-dev0
+        image: quay.io/kubermatic/http-prober:v0.2
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/api/pkg/resources/test/fixtures/deployment-aws-1.10.0-controller-manager.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-aws-1.10.0-controller-manager.yaml
@@ -102,32 +102,19 @@ spec:
           name: openvpn-client-certificates
           readOnly: true
       - args:
-        - --kubeconfig
-        - /etc/kubernetes/kubeconfig/kubeconfig
-        - --service-account-private-key-file
-        - /etc/kubernetes/service-account-key/sa.key
-        - --root-ca-file
-        - /etc/kubernetes/pki/ca/ca.crt
-        - --cluster-signing-cert-file
-        - /etc/kubernetes/pki/ca/ca.crt
-        - --cluster-signing-key-file
-        - /etc/kubernetes/pki/ca/ca.key
-        - --cluster-cidr
-        - 172.25.0.0/16
-        - --allocate-node-cidrs=true
-        - --controllers
-        - '*,bootstrapsigner,tokencleaner'
-        - --use-service-account-credentials=true
-        - --feature-gates
-        - RotateKubeletClientCertificate=true,RotateKubeletServerCertificate=true
-        - --cloud-provider
-        - aws
-        - --cloud-config
-        - /etc/kubernetes/cloud/config
-        - --configure-cloud-routes=false
+        - -endpoint
+        - https://apiserver-external.cluster-de-test-01.svc.cluster.local.:30000/healthz
+        - -insecure
+        - -retries
+        - "100"
+        - -retry-wait
+        - "2"
+        - -timeout
+        - "1"
+        - -command
+        - '{"command":"/hyperkube","args":["kube-controller-manager","--kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","--service-account-private-key-file","/etc/kubernetes/service-account-key/sa.key","--root-ca-file","/etc/kubernetes/pki/ca/ca.crt","--cluster-signing-cert-file","/etc/kubernetes/pki/ca/ca.crt","--cluster-signing-key-file","/etc/kubernetes/pki/ca/ca.key","--cluster-cidr","172.25.0.0/16","--allocate-node-cidrs=true","--controllers","*,bootstrapsigner,tokencleaner","--use-service-account-credentials=true","--feature-gates","RotateKubeletClientCertificate=true,RotateKubeletServerCertificate=true","--cloud-provider","aws","--cloud-config","/etc/kubernetes/cloud/config","--configure-cloud-routes=false"]}'
         command:
-        - /hyperkube
-        - kube-controller-manager
+        - /http-prober-bin/http-prober
         env:
         - name: AWS_ACCESS_KEY_ID
           value: aws-access-key-id
@@ -178,6 +165,8 @@ spec:
         - mountPath: /etc/kubernetes/kubeconfig
           name: controllermanager-kubeconfig
           readOnly: true
+        - mountPath: /http-prober-bin
+          name: http-prober-bin
       dnsConfig:
         nameservers:
         - 192.0.2.14
@@ -192,24 +181,16 @@ spec:
       imagePullSecrets:
       - name: dockercfg
       initContainers:
-      - args:
-        - -endpoint
-        - https://apiserver-external.cluster-de-test-01.svc.cluster.local.:30000/healthz
-        - -insecure
-        - -retries
-        - "100"
-        - -retry-wait
-        - "2"
-        - -timeout
-        - "1"
-        command:
+      - command:
+        - /bin/cp
         - /usr/local/bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.1
-        imagePullPolicy: IfNotPresent
-        name: apiserver-running
+        - /http-prober-bin/http-prober
+        image: quay.io/kubermatic/http-prober:v0.2-dev0
+        name: copy-http-prober
         resources: {}
-        terminationMessagePath: /dev/termination-log
-        terminationMessagePolicy: File
+        volumeMounts:
+        - mountPath: /http-prober-bin
+          name: http-prober-bin
       volumes:
       - name: ca
         secret:
@@ -231,4 +212,6 @@ spec:
         secret:
           defaultMode: 256
           secretName: controllermanager-kubeconfig
+      - emptyDir: {}
+        name: http-prober-bin
 status: {}

--- a/api/pkg/resources/test/fixtures/deployment-aws-1.10.0-kube-state-metrics.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-aws-1.10.0-kube-state-metrics.yaml
@@ -21,14 +21,19 @@ spec:
     spec:
       containers:
       - args:
-        - --kubeconfig
-        - /etc/kubernetes/kubeconfig/kubeconfig
-        - --port
-        - "8080"
-        - --telemetry-port
-        - "8081"
+        - -endpoint
+        - https://apiserver-external.cluster-de-test-01.svc.cluster.local.:30000/healthz
+        - -insecure
+        - -retries
+        - "100"
+        - -retry-wait
+        - "2"
+        - -timeout
+        - "1"
+        - -command
+        - '{"command":"/kube-state-metrics","args":["--kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","--port","8080","--telemetry-port","8081"]}'
         command:
-        - /kube-state-metrics
+        - /http-prober-bin/http-prober
         image: quay.io/coreos/kube-state-metrics:v1.6.0
         name: kube-state-metrics
         ports:
@@ -58,30 +63,26 @@ spec:
         - mountPath: /etc/kubernetes/kubeconfig
           name: kube-state-metrics-kubeconfig
           readOnly: true
+        - mountPath: /http-prober-bin
+          name: http-prober-bin
       imagePullSecrets:
       - name: dockercfg
       initContainers:
-      - args:
-        - -endpoint
-        - https://apiserver-external.cluster-de-test-01.svc.cluster.local.:30000/healthz
-        - -insecure
-        - -retries
-        - "100"
-        - -retry-wait
-        - "2"
-        - -timeout
-        - "1"
-        command:
+      - command:
+        - /bin/cp
         - /usr/local/bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.1
-        imagePullPolicy: IfNotPresent
-        name: apiserver-running
+        - /http-prober-bin/http-prober
+        image: quay.io/kubermatic/http-prober:v0.2-dev0
+        name: copy-http-prober
         resources: {}
-        terminationMessagePath: /dev/termination-log
-        terminationMessagePolicy: File
+        volumeMounts:
+        - mountPath: /http-prober-bin
+          name: http-prober-bin
       volumes:
       - name: kube-state-metrics-kubeconfig
         secret:
           defaultMode: 256
           secretName: kube-state-metrics-kubeconfig
+      - emptyDir: {}
+        name: http-prober-bin
 status: {}

--- a/api/pkg/resources/test/fixtures/deployment-aws-1.10.0-kube-state-metrics.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-aws-1.10.0-kube-state-metrics.yaml
@@ -72,7 +72,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.2-dev0
+        image: quay.io/kubermatic/http-prober:v0.2
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/api/pkg/resources/test/fixtures/deployment-aws-1.10.0-machine-controller-webhook.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-aws-1.10.0-machine-controller-webhook.yaml
@@ -86,7 +86,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.2-dev0
+        image: quay.io/kubermatic/http-prober:v0.2
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/api/pkg/resources/test/fixtures/deployment-aws-1.10.0-machine-controller-webhook.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-aws-1.10.0-machine-controller-webhook.yaml
@@ -24,15 +24,19 @@ spec:
     spec:
       containers:
       - args:
-        - -kubeconfig
-        - /etc/kubernetes/kubeconfig/kubeconfig
-        - -logtostderr
-        - -v
-        - "4"
-        - -listen-address
-        - 0.0.0.0:9876
+        - -endpoint
+        - https://apiserver-external.cluster-de-test-01.svc.cluster.local.:30000/healthz
+        - -insecure
+        - -retries
+        - "100"
+        - -retry-wait
+        - "2"
+        - -timeout
+        - "1"
+        - -command
+        - '{"command":"/usr/local/bin/webhook","args":["-kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","-logtostderr","-v","4","-listen-address","0.0.0.0:9876"]}'
         command:
-        - /usr/local/bin/webhook
+        - /http-prober-bin/http-prober
         env:
         - name: AWS_ACCESS_KEY_ID
           value: aws-access-key-id
@@ -73,27 +77,21 @@ spec:
         - mountPath: /tmp/cert
           name: machinecontroller-webhook-serving-cert
           readOnly: true
+        - mountPath: /http-prober-bin
+          name: http-prober-bin
       imagePullSecrets:
       - name: dockercfg
       initContainers:
-      - args:
-        - -endpoint
-        - https://apiserver-external.cluster-de-test-01.svc.cluster.local.:30000/healthz
-        - -insecure
-        - -retries
-        - "100"
-        - -retry-wait
-        - "2"
-        - -timeout
-        - "1"
-        command:
+      - command:
+        - /bin/cp
         - /usr/local/bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.1
-        imagePullPolicy: IfNotPresent
-        name: apiserver-running
+        - /http-prober-bin/http-prober
+        image: quay.io/kubermatic/http-prober:v0.2-dev0
+        name: copy-http-prober
         resources: {}
-        terminationMessagePath: /dev/termination-log
-        terminationMessagePolicy: File
+        volumeMounts:
+        - mountPath: /http-prober-bin
+          name: http-prober-bin
       volumes:
       - name: machinecontroller-kubeconfig
         secret:
@@ -103,4 +101,6 @@ spec:
         secret:
           defaultMode: 292
           secretName: machinecontroller-webhook-serving-cert
+      - emptyDir: {}
+        name: http-prober-bin
 status: {}

--- a/api/pkg/resources/test/fixtures/deployment-aws-1.10.0-machine-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-aws-1.10.0-machine-controller.yaml
@@ -27,17 +27,19 @@ spec:
     spec:
       containers:
       - args:
-        - -kubeconfig
-        - /etc/kubernetes/kubeconfig/kubeconfig
-        - -logtostderr
-        - -v
-        - "4"
-        - -cluster-dns
-        - 169.254.20.10
-        - -internal-listen-address
-        - 0.0.0.0:8085
+        - -endpoint
+        - https://apiserver-external.cluster-de-test-01.svc.cluster.local.:30000/healthz
+        - -insecure
+        - -retries
+        - "100"
+        - -retry-wait
+        - "2"
+        - -timeout
+        - "1"
+        - -command
+        - '{"command":"/usr/local/bin/machine-controller","args":["-kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","-logtostderr","-v","4","-cluster-dns","169.254.20.10","-internal-listen-address","0.0.0.0:8085"]}'
         command:
-        - /usr/local/bin/machine-controller
+        - /http-prober-bin/http-prober
         env:
         - name: AWS_ACCESS_KEY_ID
           value: aws-access-key-id
@@ -66,30 +68,26 @@ spec:
         - mountPath: /etc/kubernetes/kubeconfig
           name: machinecontroller-kubeconfig
           readOnly: true
+        - mountPath: /http-prober-bin
+          name: http-prober-bin
       imagePullSecrets:
       - name: dockercfg
       initContainers:
-      - args:
-        - -endpoint
-        - https://apiserver-external.cluster-de-test-01.svc.cluster.local.:30000/healthz
-        - -insecure
-        - -retries
-        - "100"
-        - -retry-wait
-        - "2"
-        - -timeout
-        - "1"
-        command:
+      - command:
+        - /bin/cp
         - /usr/local/bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.1
-        imagePullPolicy: IfNotPresent
-        name: apiserver-running
+        - /http-prober-bin/http-prober
+        image: quay.io/kubermatic/http-prober:v0.2-dev0
+        name: copy-http-prober
         resources: {}
-        terminationMessagePath: /dev/termination-log
-        terminationMessagePolicy: File
+        volumeMounts:
+        - mountPath: /http-prober-bin
+          name: http-prober-bin
       volumes:
       - name: machinecontroller-kubeconfig
         secret:
           defaultMode: 292
           secretName: machinecontroller-kubeconfig
+      - emptyDir: {}
+        name: http-prober-bin
 status: {}

--- a/api/pkg/resources/test/fixtures/deployment-aws-1.10.0-machine-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-aws-1.10.0-machine-controller.yaml
@@ -77,7 +77,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.2-dev0
+        image: quay.io/kubermatic/http-prober:v0.2
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/api/pkg/resources/test/fixtures/deployment-aws-1.10.0-metrics-server.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-aws-1.10.0-metrics-server.yaml
@@ -41,22 +41,19 @@ spec:
             weight: 10
       containers:
       - args:
-        - --kubeconfig
-        - /etc/kubernetes/kubeconfig/kubeconfig
-        - --authentication-kubeconfig
-        - /etc/kubernetes/kubeconfig/kubeconfig
-        - --authorization-kubeconfig
-        - /etc/kubernetes/kubeconfig/kubeconfig
-        - --kubelet-port
-        - "10250"
-        - --kubelet-insecure-tls
-        - --kubelet-preferred-address-types
-        - ExternalIP,InternalIP
-        - --v
+        - -endpoint
+        - https://apiserver-external.cluster-de-test-01.svc.cluster.local.:30000/healthz
+        - -insecure
+        - -retries
+        - "100"
+        - -retry-wait
+        - "2"
+        - -timeout
         - "1"
-        - --logtostderr
+        - -command
+        - '{"command":"/metrics-server","args":["--kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","--authentication-kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","--authorization-kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","--kubelet-port","10250","--kubelet-insecure-tls","--kubelet-preferred-address-types","ExternalIP,InternalIP","--v","1","--logtostderr"]}'
         command:
-        - /metrics-server
+        - /http-prober-bin/http-prober
         image: gcr.io/google_containers/metrics-server-amd64:v0.3.2
         name: metrics-server
         resources:
@@ -70,6 +67,8 @@ spec:
         - mountPath: /etc/kubernetes/kubeconfig
           name: metrics-server
           readOnly: true
+        - mountPath: /http-prober-bin
+          name: http-prober-bin
       - args:
         - --client
         - --proto
@@ -158,24 +157,16 @@ spec:
       imagePullSecrets:
       - name: dockercfg
       initContainers:
-      - args:
-        - -endpoint
-        - https://apiserver-external.cluster-de-test-01.svc.cluster.local.:30000/healthz
-        - -insecure
-        - -retries
-        - "100"
-        - -retry-wait
-        - "2"
-        - -timeout
-        - "1"
-        command:
+      - command:
+        - /bin/cp
         - /usr/local/bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.1
-        imagePullPolicy: IfNotPresent
-        name: apiserver-running
+        - /http-prober-bin/http-prober
+        image: quay.io/kubermatic/http-prober:v0.2-dev0
+        name: copy-http-prober
         resources: {}
-        terminationMessagePath: /dev/termination-log
-        terminationMessagePolicy: File
+        volumeMounts:
+        - mountPath: /http-prober-bin
+          name: http-prober-bin
       volumes:
       - name: metrics-server
         secret:
@@ -189,4 +180,6 @@ spec:
         secret:
           defaultMode: 292
           secretName: kubeletdnatcontroller-kubeconfig
+      - emptyDir: {}
+        name: http-prober-bin
 status: {}

--- a/api/pkg/resources/test/fixtures/deployment-aws-1.10.0-metrics-server.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-aws-1.10.0-metrics-server.yaml
@@ -161,7 +161,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.2-dev0
+        image: quay.io/kubermatic/http-prober:v0.2
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/api/pkg/resources/test/fixtures/deployment-aws-1.10.0-scheduler.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-aws-1.10.0-scheduler.yaml
@@ -100,11 +100,19 @@ spec:
           name: openvpn-client-certificates
           readOnly: true
       - args:
-        - --kubeconfig
-        - /etc/kubernetes/kubeconfig/kubeconfig
+        - -endpoint
+        - https://apiserver-external.cluster-de-test-01.svc.cluster.local.:30000/healthz
+        - -insecure
+        - -retries
+        - "100"
+        - -retry-wait
+        - "2"
+        - -timeout
+        - "1"
+        - -command
+        - '{"command":"/hyperkube","args":["kube-scheduler","--kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig"]}'
         command:
-        - /hyperkube
-        - kube-scheduler
+        - /http-prober-bin/http-prober
         image: gcr.io/google_containers/hyperkube-amd64:v1.10.0
         livenessProbe:
           failureThreshold: 8
@@ -140,6 +148,8 @@ spec:
         - mountPath: /etc/kubernetes/pki/ca
           name: ca
           readOnly: true
+        - mountPath: /http-prober-bin
+          name: http-prober-bin
       dnsConfig:
         nameservers:
         - 192.0.2.14
@@ -154,24 +164,16 @@ spec:
       imagePullSecrets:
       - name: dockercfg
       initContainers:
-      - args:
-        - -endpoint
-        - https://apiserver-external.cluster-de-test-01.svc.cluster.local.:30000/healthz
-        - -insecure
-        - -retries
-        - "100"
-        - -retry-wait
-        - "2"
-        - -timeout
-        - "1"
-        command:
+      - command:
+        - /bin/cp
         - /usr/local/bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.1
-        imagePullPolicy: IfNotPresent
-        name: apiserver-running
+        - /http-prober-bin/http-prober
+        image: quay.io/kubermatic/http-prober:v0.2-dev0
+        name: copy-http-prober
         resources: {}
-        terminationMessagePath: /dev/termination-log
-        terminationMessagePolicy: File
+        volumeMounts:
+        - mountPath: /http-prober-bin
+          name: http-prober-bin
       volumes:
       - name: openvpn-client-certificates
         secret:
@@ -188,4 +190,6 @@ spec:
         secret:
           defaultMode: 256
           secretName: scheduler-kubeconfig
+      - emptyDir: {}
+        name: http-prober-bin
 status: {}

--- a/api/pkg/resources/test/fixtures/deployment-aws-1.10.0-scheduler.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-aws-1.10.0-scheduler.yaml
@@ -168,7 +168,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.2-dev0
+        image: quay.io/kubermatic/http-prober:v0.2
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/api/pkg/resources/test/fixtures/deployment-aws-1.10.0-usercluster-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-aws-1.10.0-usercluster-controller.yaml
@@ -85,7 +85,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.2-dev0
+        image: quay.io/kubermatic/http-prober:v0.2
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/api/pkg/resources/test/fixtures/deployment-aws-1.10.0-usercluster-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-aws-1.10.0-usercluster-controller.yaml
@@ -29,32 +29,19 @@ spec:
     spec:
       containers:
       - args:
-        - -kubeconfig
-        - /etc/kubernetes/kubeconfig/kubeconfig
-        - -metrics-listen-address
-        - 0.0.0.0:8085
-        - -health-listen-address
-        - 0.0.0.0:8086
-        - -namespace
-        - $(NAMESPACE)
-        - -ca-cert
-        - /etc/kubernetes/pki/ca/ca.crt
-        - -cluster-url
-        - ""
-        - -openvpn-server-port
-        - "30003"
-        - -overwrite-registry
-        - ""
-        - -openshift=false
-        - -openvpn-ca-cert-file=/etc/kubernetes/pki/openvpn/ca.crt
-        - -openvpn-ca-key-file=/etc/kubernetes/pki/openvpn/ca.key
-        - -logtostderr
-        - -v
+        - -endpoint
+        - https://apiserver-external.cluster-de-test-01.svc.cluster.local.:30000/healthz
+        - -insecure
+        - -retries
+        - "100"
+        - -retry-wait
         - "2"
-        - --ipam-controller-network
-        - 192.168.1.1/24,192.168.1.1,8.8.8.8
+        - -timeout
+        - "1"
+        - -command
+        - '{"command":"/usr/local/bin/user-cluster-controller-manager","args":["-kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","-metrics-listen-address","0.0.0.0:8085","-health-listen-address","0.0.0.0:8086","-namespace","$(NAMESPACE)","-ca-cert","/etc/kubernetes/pki/ca/ca.crt","-cluster-url","","-openvpn-server-port","30003","-overwrite-registry","","-openshift=false","-openvpn-ca-cert-file=/etc/kubernetes/pki/openvpn/ca.crt","-openvpn-ca-key-file=/etc/kubernetes/pki/openvpn/ca.key","-logtostderr","-v","2","--ipam-controller-network","192.168.1.1/24,192.168.1.1,8.8.8.8"]}'
         command:
-        - /usr/local/bin/user-cluster-controller-manager
+        - /http-prober-bin/http-prober
         env:
         - name: NAMESPACE
           valueFrom:
@@ -89,27 +76,21 @@ spec:
         - mountPath: /etc/kubernetes/pki/openvpn
           name: openvpn-ca
           readOnly: true
+        - mountPath: /http-prober-bin
+          name: http-prober-bin
       imagePullSecrets:
       - name: dockercfg
       initContainers:
-      - args:
-        - -endpoint
-        - https://apiserver-external.cluster-de-test-01.svc.cluster.local.:30000/healthz
-        - -insecure
-        - -retries
-        - "100"
-        - -retry-wait
-        - "2"
-        - -timeout
-        - "1"
-        command:
+      - command:
+        - /bin/cp
         - /usr/local/bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.1
-        imagePullPolicy: IfNotPresent
-        name: apiserver-running
+        - /http-prober-bin/http-prober
+        image: quay.io/kubermatic/http-prober:v0.2-dev0
+        name: copy-http-prober
         resources: {}
-        terminationMessagePath: /dev/termination-log
-        terminationMessagePolicy: File
+        volumeMounts:
+        - mountPath: /http-prober-bin
+          name: http-prober-bin
       volumes:
       - name: internal-admin-kubeconfig
         secret:
@@ -126,4 +107,6 @@ spec:
         secret:
           defaultMode: 292
           secretName: openvpn-ca
+      - emptyDir: {}
+        name: http-prober-bin
 status: {}

--- a/api/pkg/resources/test/fixtures/deployment-aws-1.10.6-controller-manager.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-aws-1.10.6-controller-manager.yaml
@@ -185,7 +185,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.2-dev0
+        image: quay.io/kubermatic/http-prober:v0.2
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/api/pkg/resources/test/fixtures/deployment-aws-1.10.6-controller-manager.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-aws-1.10.6-controller-manager.yaml
@@ -102,32 +102,19 @@ spec:
           name: openvpn-client-certificates
           readOnly: true
       - args:
-        - --kubeconfig
-        - /etc/kubernetes/kubeconfig/kubeconfig
-        - --service-account-private-key-file
-        - /etc/kubernetes/service-account-key/sa.key
-        - --root-ca-file
-        - /etc/kubernetes/pki/ca/ca.crt
-        - --cluster-signing-cert-file
-        - /etc/kubernetes/pki/ca/ca.crt
-        - --cluster-signing-key-file
-        - /etc/kubernetes/pki/ca/ca.key
-        - --cluster-cidr
-        - 172.25.0.0/16
-        - --allocate-node-cidrs=true
-        - --controllers
-        - '*,bootstrapsigner,tokencleaner'
-        - --use-service-account-credentials=true
-        - --feature-gates
-        - RotateKubeletClientCertificate=true,RotateKubeletServerCertificate=true
-        - --cloud-provider
-        - aws
-        - --cloud-config
-        - /etc/kubernetes/cloud/config
-        - --configure-cloud-routes=false
+        - -endpoint
+        - https://apiserver-external.cluster-de-test-01.svc.cluster.local.:30000/healthz
+        - -insecure
+        - -retries
+        - "100"
+        - -retry-wait
+        - "2"
+        - -timeout
+        - "1"
+        - -command
+        - '{"command":"/hyperkube","args":["kube-controller-manager","--kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","--service-account-private-key-file","/etc/kubernetes/service-account-key/sa.key","--root-ca-file","/etc/kubernetes/pki/ca/ca.crt","--cluster-signing-cert-file","/etc/kubernetes/pki/ca/ca.crt","--cluster-signing-key-file","/etc/kubernetes/pki/ca/ca.key","--cluster-cidr","172.25.0.0/16","--allocate-node-cidrs=true","--controllers","*,bootstrapsigner,tokencleaner","--use-service-account-credentials=true","--feature-gates","RotateKubeletClientCertificate=true,RotateKubeletServerCertificate=true","--cloud-provider","aws","--cloud-config","/etc/kubernetes/cloud/config","--configure-cloud-routes=false"]}'
         command:
-        - /hyperkube
-        - kube-controller-manager
+        - /http-prober-bin/http-prober
         env:
         - name: AWS_ACCESS_KEY_ID
           value: aws-access-key-id
@@ -178,6 +165,8 @@ spec:
         - mountPath: /etc/kubernetes/kubeconfig
           name: controllermanager-kubeconfig
           readOnly: true
+        - mountPath: /http-prober-bin
+          name: http-prober-bin
       dnsConfig:
         nameservers:
         - 192.0.2.14
@@ -192,24 +181,16 @@ spec:
       imagePullSecrets:
       - name: dockercfg
       initContainers:
-      - args:
-        - -endpoint
-        - https://apiserver-external.cluster-de-test-01.svc.cluster.local.:30000/healthz
-        - -insecure
-        - -retries
-        - "100"
-        - -retry-wait
-        - "2"
-        - -timeout
-        - "1"
-        command:
+      - command:
+        - /bin/cp
         - /usr/local/bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.1
-        imagePullPolicy: IfNotPresent
-        name: apiserver-running
+        - /http-prober-bin/http-prober
+        image: quay.io/kubermatic/http-prober:v0.2-dev0
+        name: copy-http-prober
         resources: {}
-        terminationMessagePath: /dev/termination-log
-        terminationMessagePolicy: File
+        volumeMounts:
+        - mountPath: /http-prober-bin
+          name: http-prober-bin
       volumes:
       - name: ca
         secret:
@@ -231,4 +212,6 @@ spec:
         secret:
           defaultMode: 256
           secretName: controllermanager-kubeconfig
+      - emptyDir: {}
+        name: http-prober-bin
 status: {}

--- a/api/pkg/resources/test/fixtures/deployment-aws-1.10.6-kube-state-metrics.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-aws-1.10.6-kube-state-metrics.yaml
@@ -21,14 +21,19 @@ spec:
     spec:
       containers:
       - args:
-        - --kubeconfig
-        - /etc/kubernetes/kubeconfig/kubeconfig
-        - --port
-        - "8080"
-        - --telemetry-port
-        - "8081"
+        - -endpoint
+        - https://apiserver-external.cluster-de-test-01.svc.cluster.local.:30000/healthz
+        - -insecure
+        - -retries
+        - "100"
+        - -retry-wait
+        - "2"
+        - -timeout
+        - "1"
+        - -command
+        - '{"command":"/kube-state-metrics","args":["--kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","--port","8080","--telemetry-port","8081"]}'
         command:
-        - /kube-state-metrics
+        - /http-prober-bin/http-prober
         image: quay.io/coreos/kube-state-metrics:v1.6.0
         name: kube-state-metrics
         ports:
@@ -58,30 +63,26 @@ spec:
         - mountPath: /etc/kubernetes/kubeconfig
           name: kube-state-metrics-kubeconfig
           readOnly: true
+        - mountPath: /http-prober-bin
+          name: http-prober-bin
       imagePullSecrets:
       - name: dockercfg
       initContainers:
-      - args:
-        - -endpoint
-        - https://apiserver-external.cluster-de-test-01.svc.cluster.local.:30000/healthz
-        - -insecure
-        - -retries
-        - "100"
-        - -retry-wait
-        - "2"
-        - -timeout
-        - "1"
-        command:
+      - command:
+        - /bin/cp
         - /usr/local/bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.1
-        imagePullPolicy: IfNotPresent
-        name: apiserver-running
+        - /http-prober-bin/http-prober
+        image: quay.io/kubermatic/http-prober:v0.2-dev0
+        name: copy-http-prober
         resources: {}
-        terminationMessagePath: /dev/termination-log
-        terminationMessagePolicy: File
+        volumeMounts:
+        - mountPath: /http-prober-bin
+          name: http-prober-bin
       volumes:
       - name: kube-state-metrics-kubeconfig
         secret:
           defaultMode: 256
           secretName: kube-state-metrics-kubeconfig
+      - emptyDir: {}
+        name: http-prober-bin
 status: {}

--- a/api/pkg/resources/test/fixtures/deployment-aws-1.10.6-kube-state-metrics.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-aws-1.10.6-kube-state-metrics.yaml
@@ -72,7 +72,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.2-dev0
+        image: quay.io/kubermatic/http-prober:v0.2
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/api/pkg/resources/test/fixtures/deployment-aws-1.10.6-machine-controller-webhook.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-aws-1.10.6-machine-controller-webhook.yaml
@@ -86,7 +86,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.2-dev0
+        image: quay.io/kubermatic/http-prober:v0.2
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/api/pkg/resources/test/fixtures/deployment-aws-1.10.6-machine-controller-webhook.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-aws-1.10.6-machine-controller-webhook.yaml
@@ -24,15 +24,19 @@ spec:
     spec:
       containers:
       - args:
-        - -kubeconfig
-        - /etc/kubernetes/kubeconfig/kubeconfig
-        - -logtostderr
-        - -v
-        - "4"
-        - -listen-address
-        - 0.0.0.0:9876
+        - -endpoint
+        - https://apiserver-external.cluster-de-test-01.svc.cluster.local.:30000/healthz
+        - -insecure
+        - -retries
+        - "100"
+        - -retry-wait
+        - "2"
+        - -timeout
+        - "1"
+        - -command
+        - '{"command":"/usr/local/bin/webhook","args":["-kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","-logtostderr","-v","4","-listen-address","0.0.0.0:9876"]}'
         command:
-        - /usr/local/bin/webhook
+        - /http-prober-bin/http-prober
         env:
         - name: AWS_ACCESS_KEY_ID
           value: aws-access-key-id
@@ -73,27 +77,21 @@ spec:
         - mountPath: /tmp/cert
           name: machinecontroller-webhook-serving-cert
           readOnly: true
+        - mountPath: /http-prober-bin
+          name: http-prober-bin
       imagePullSecrets:
       - name: dockercfg
       initContainers:
-      - args:
-        - -endpoint
-        - https://apiserver-external.cluster-de-test-01.svc.cluster.local.:30000/healthz
-        - -insecure
-        - -retries
-        - "100"
-        - -retry-wait
-        - "2"
-        - -timeout
-        - "1"
-        command:
+      - command:
+        - /bin/cp
         - /usr/local/bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.1
-        imagePullPolicy: IfNotPresent
-        name: apiserver-running
+        - /http-prober-bin/http-prober
+        image: quay.io/kubermatic/http-prober:v0.2-dev0
+        name: copy-http-prober
         resources: {}
-        terminationMessagePath: /dev/termination-log
-        terminationMessagePolicy: File
+        volumeMounts:
+        - mountPath: /http-prober-bin
+          name: http-prober-bin
       volumes:
       - name: machinecontroller-kubeconfig
         secret:
@@ -103,4 +101,6 @@ spec:
         secret:
           defaultMode: 292
           secretName: machinecontroller-webhook-serving-cert
+      - emptyDir: {}
+        name: http-prober-bin
 status: {}

--- a/api/pkg/resources/test/fixtures/deployment-aws-1.10.6-machine-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-aws-1.10.6-machine-controller.yaml
@@ -27,17 +27,19 @@ spec:
     spec:
       containers:
       - args:
-        - -kubeconfig
-        - /etc/kubernetes/kubeconfig/kubeconfig
-        - -logtostderr
-        - -v
-        - "4"
-        - -cluster-dns
-        - 169.254.20.10
-        - -internal-listen-address
-        - 0.0.0.0:8085
+        - -endpoint
+        - https://apiserver-external.cluster-de-test-01.svc.cluster.local.:30000/healthz
+        - -insecure
+        - -retries
+        - "100"
+        - -retry-wait
+        - "2"
+        - -timeout
+        - "1"
+        - -command
+        - '{"command":"/usr/local/bin/machine-controller","args":["-kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","-logtostderr","-v","4","-cluster-dns","169.254.20.10","-internal-listen-address","0.0.0.0:8085"]}'
         command:
-        - /usr/local/bin/machine-controller
+        - /http-prober-bin/http-prober
         env:
         - name: AWS_ACCESS_KEY_ID
           value: aws-access-key-id
@@ -66,30 +68,26 @@ spec:
         - mountPath: /etc/kubernetes/kubeconfig
           name: machinecontroller-kubeconfig
           readOnly: true
+        - mountPath: /http-prober-bin
+          name: http-prober-bin
       imagePullSecrets:
       - name: dockercfg
       initContainers:
-      - args:
-        - -endpoint
-        - https://apiserver-external.cluster-de-test-01.svc.cluster.local.:30000/healthz
-        - -insecure
-        - -retries
-        - "100"
-        - -retry-wait
-        - "2"
-        - -timeout
-        - "1"
-        command:
+      - command:
+        - /bin/cp
         - /usr/local/bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.1
-        imagePullPolicy: IfNotPresent
-        name: apiserver-running
+        - /http-prober-bin/http-prober
+        image: quay.io/kubermatic/http-prober:v0.2-dev0
+        name: copy-http-prober
         resources: {}
-        terminationMessagePath: /dev/termination-log
-        terminationMessagePolicy: File
+        volumeMounts:
+        - mountPath: /http-prober-bin
+          name: http-prober-bin
       volumes:
       - name: machinecontroller-kubeconfig
         secret:
           defaultMode: 292
           secretName: machinecontroller-kubeconfig
+      - emptyDir: {}
+        name: http-prober-bin
 status: {}

--- a/api/pkg/resources/test/fixtures/deployment-aws-1.10.6-machine-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-aws-1.10.6-machine-controller.yaml
@@ -77,7 +77,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.2-dev0
+        image: quay.io/kubermatic/http-prober:v0.2
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/api/pkg/resources/test/fixtures/deployment-aws-1.10.6-metrics-server.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-aws-1.10.6-metrics-server.yaml
@@ -41,22 +41,19 @@ spec:
             weight: 10
       containers:
       - args:
-        - --kubeconfig
-        - /etc/kubernetes/kubeconfig/kubeconfig
-        - --authentication-kubeconfig
-        - /etc/kubernetes/kubeconfig/kubeconfig
-        - --authorization-kubeconfig
-        - /etc/kubernetes/kubeconfig/kubeconfig
-        - --kubelet-port
-        - "10250"
-        - --kubelet-insecure-tls
-        - --kubelet-preferred-address-types
-        - ExternalIP,InternalIP
-        - --v
+        - -endpoint
+        - https://apiserver-external.cluster-de-test-01.svc.cluster.local.:30000/healthz
+        - -insecure
+        - -retries
+        - "100"
+        - -retry-wait
+        - "2"
+        - -timeout
         - "1"
-        - --logtostderr
+        - -command
+        - '{"command":"/metrics-server","args":["--kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","--authentication-kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","--authorization-kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","--kubelet-port","10250","--kubelet-insecure-tls","--kubelet-preferred-address-types","ExternalIP,InternalIP","--v","1","--logtostderr"]}'
         command:
-        - /metrics-server
+        - /http-prober-bin/http-prober
         image: gcr.io/google_containers/metrics-server-amd64:v0.3.2
         name: metrics-server
         resources:
@@ -70,6 +67,8 @@ spec:
         - mountPath: /etc/kubernetes/kubeconfig
           name: metrics-server
           readOnly: true
+        - mountPath: /http-prober-bin
+          name: http-prober-bin
       - args:
         - --client
         - --proto
@@ -158,24 +157,16 @@ spec:
       imagePullSecrets:
       - name: dockercfg
       initContainers:
-      - args:
-        - -endpoint
-        - https://apiserver-external.cluster-de-test-01.svc.cluster.local.:30000/healthz
-        - -insecure
-        - -retries
-        - "100"
-        - -retry-wait
-        - "2"
-        - -timeout
-        - "1"
-        command:
+      - command:
+        - /bin/cp
         - /usr/local/bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.1
-        imagePullPolicy: IfNotPresent
-        name: apiserver-running
+        - /http-prober-bin/http-prober
+        image: quay.io/kubermatic/http-prober:v0.2-dev0
+        name: copy-http-prober
         resources: {}
-        terminationMessagePath: /dev/termination-log
-        terminationMessagePolicy: File
+        volumeMounts:
+        - mountPath: /http-prober-bin
+          name: http-prober-bin
       volumes:
       - name: metrics-server
         secret:
@@ -189,4 +180,6 @@ spec:
         secret:
           defaultMode: 292
           secretName: kubeletdnatcontroller-kubeconfig
+      - emptyDir: {}
+        name: http-prober-bin
 status: {}

--- a/api/pkg/resources/test/fixtures/deployment-aws-1.10.6-metrics-server.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-aws-1.10.6-metrics-server.yaml
@@ -161,7 +161,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.2-dev0
+        image: quay.io/kubermatic/http-prober:v0.2
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/api/pkg/resources/test/fixtures/deployment-aws-1.10.6-scheduler.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-aws-1.10.6-scheduler.yaml
@@ -100,11 +100,19 @@ spec:
           name: openvpn-client-certificates
           readOnly: true
       - args:
-        - --kubeconfig
-        - /etc/kubernetes/kubeconfig/kubeconfig
+        - -endpoint
+        - https://apiserver-external.cluster-de-test-01.svc.cluster.local.:30000/healthz
+        - -insecure
+        - -retries
+        - "100"
+        - -retry-wait
+        - "2"
+        - -timeout
+        - "1"
+        - -command
+        - '{"command":"/hyperkube","args":["kube-scheduler","--kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig"]}'
         command:
-        - /hyperkube
-        - kube-scheduler
+        - /http-prober-bin/http-prober
         image: gcr.io/google_containers/hyperkube-amd64:v1.10.6
         livenessProbe:
           failureThreshold: 8
@@ -140,6 +148,8 @@ spec:
         - mountPath: /etc/kubernetes/pki/ca
           name: ca
           readOnly: true
+        - mountPath: /http-prober-bin
+          name: http-prober-bin
       dnsConfig:
         nameservers:
         - 192.0.2.14
@@ -154,24 +164,16 @@ spec:
       imagePullSecrets:
       - name: dockercfg
       initContainers:
-      - args:
-        - -endpoint
-        - https://apiserver-external.cluster-de-test-01.svc.cluster.local.:30000/healthz
-        - -insecure
-        - -retries
-        - "100"
-        - -retry-wait
-        - "2"
-        - -timeout
-        - "1"
-        command:
+      - command:
+        - /bin/cp
         - /usr/local/bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.1
-        imagePullPolicy: IfNotPresent
-        name: apiserver-running
+        - /http-prober-bin/http-prober
+        image: quay.io/kubermatic/http-prober:v0.2-dev0
+        name: copy-http-prober
         resources: {}
-        terminationMessagePath: /dev/termination-log
-        terminationMessagePolicy: File
+        volumeMounts:
+        - mountPath: /http-prober-bin
+          name: http-prober-bin
       volumes:
       - name: openvpn-client-certificates
         secret:
@@ -188,4 +190,6 @@ spec:
         secret:
           defaultMode: 256
           secretName: scheduler-kubeconfig
+      - emptyDir: {}
+        name: http-prober-bin
 status: {}

--- a/api/pkg/resources/test/fixtures/deployment-aws-1.10.6-scheduler.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-aws-1.10.6-scheduler.yaml
@@ -168,7 +168,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.2-dev0
+        image: quay.io/kubermatic/http-prober:v0.2
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/api/pkg/resources/test/fixtures/deployment-aws-1.10.6-usercluster-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-aws-1.10.6-usercluster-controller.yaml
@@ -85,7 +85,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.2-dev0
+        image: quay.io/kubermatic/http-prober:v0.2
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/api/pkg/resources/test/fixtures/deployment-aws-1.10.6-usercluster-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-aws-1.10.6-usercluster-controller.yaml
@@ -29,32 +29,19 @@ spec:
     spec:
       containers:
       - args:
-        - -kubeconfig
-        - /etc/kubernetes/kubeconfig/kubeconfig
-        - -metrics-listen-address
-        - 0.0.0.0:8085
-        - -health-listen-address
-        - 0.0.0.0:8086
-        - -namespace
-        - $(NAMESPACE)
-        - -ca-cert
-        - /etc/kubernetes/pki/ca/ca.crt
-        - -cluster-url
-        - ""
-        - -openvpn-server-port
-        - "30003"
-        - -overwrite-registry
-        - ""
-        - -openshift=false
-        - -openvpn-ca-cert-file=/etc/kubernetes/pki/openvpn/ca.crt
-        - -openvpn-ca-key-file=/etc/kubernetes/pki/openvpn/ca.key
-        - -logtostderr
-        - -v
+        - -endpoint
+        - https://apiserver-external.cluster-de-test-01.svc.cluster.local.:30000/healthz
+        - -insecure
+        - -retries
+        - "100"
+        - -retry-wait
         - "2"
-        - --ipam-controller-network
-        - 192.168.1.1/24,192.168.1.1,8.8.8.8
+        - -timeout
+        - "1"
+        - -command
+        - '{"command":"/usr/local/bin/user-cluster-controller-manager","args":["-kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","-metrics-listen-address","0.0.0.0:8085","-health-listen-address","0.0.0.0:8086","-namespace","$(NAMESPACE)","-ca-cert","/etc/kubernetes/pki/ca/ca.crt","-cluster-url","","-openvpn-server-port","30003","-overwrite-registry","","-openshift=false","-openvpn-ca-cert-file=/etc/kubernetes/pki/openvpn/ca.crt","-openvpn-ca-key-file=/etc/kubernetes/pki/openvpn/ca.key","-logtostderr","-v","2","--ipam-controller-network","192.168.1.1/24,192.168.1.1,8.8.8.8"]}'
         command:
-        - /usr/local/bin/user-cluster-controller-manager
+        - /http-prober-bin/http-prober
         env:
         - name: NAMESPACE
           valueFrom:
@@ -89,27 +76,21 @@ spec:
         - mountPath: /etc/kubernetes/pki/openvpn
           name: openvpn-ca
           readOnly: true
+        - mountPath: /http-prober-bin
+          name: http-prober-bin
       imagePullSecrets:
       - name: dockercfg
       initContainers:
-      - args:
-        - -endpoint
-        - https://apiserver-external.cluster-de-test-01.svc.cluster.local.:30000/healthz
-        - -insecure
-        - -retries
-        - "100"
-        - -retry-wait
-        - "2"
-        - -timeout
-        - "1"
-        command:
+      - command:
+        - /bin/cp
         - /usr/local/bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.1
-        imagePullPolicy: IfNotPresent
-        name: apiserver-running
+        - /http-prober-bin/http-prober
+        image: quay.io/kubermatic/http-prober:v0.2-dev0
+        name: copy-http-prober
         resources: {}
-        terminationMessagePath: /dev/termination-log
-        terminationMessagePolicy: File
+        volumeMounts:
+        - mountPath: /http-prober-bin
+          name: http-prober-bin
       volumes:
       - name: internal-admin-kubeconfig
         secret:
@@ -126,4 +107,6 @@ spec:
         secret:
           defaultMode: 292
           secretName: openvpn-ca
+      - emptyDir: {}
+        name: http-prober-bin
 status: {}

--- a/api/pkg/resources/test/fixtures/deployment-aws-1.11.0-controller-manager.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-aws-1.11.0-controller-manager.yaml
@@ -185,7 +185,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.2-dev0
+        image: quay.io/kubermatic/http-prober:v0.2
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/api/pkg/resources/test/fixtures/deployment-aws-1.11.0-controller-manager.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-aws-1.11.0-controller-manager.yaml
@@ -102,32 +102,19 @@ spec:
           name: openvpn-client-certificates
           readOnly: true
       - args:
-        - --kubeconfig
-        - /etc/kubernetes/kubeconfig/kubeconfig
-        - --service-account-private-key-file
-        - /etc/kubernetes/service-account-key/sa.key
-        - --root-ca-file
-        - /etc/kubernetes/pki/ca/ca.crt
-        - --cluster-signing-cert-file
-        - /etc/kubernetes/pki/ca/ca.crt
-        - --cluster-signing-key-file
-        - /etc/kubernetes/pki/ca/ca.key
-        - --cluster-cidr
-        - 172.25.0.0/16
-        - --allocate-node-cidrs=true
-        - --controllers
-        - '*,bootstrapsigner,tokencleaner'
-        - --use-service-account-credentials=true
-        - --feature-gates
-        - RotateKubeletClientCertificate=true,RotateKubeletServerCertificate=true
-        - --cloud-provider
-        - aws
-        - --cloud-config
-        - /etc/kubernetes/cloud/config
-        - --configure-cloud-routes=false
+        - -endpoint
+        - https://apiserver-external.cluster-de-test-01.svc.cluster.local.:30000/healthz
+        - -insecure
+        - -retries
+        - "100"
+        - -retry-wait
+        - "2"
+        - -timeout
+        - "1"
+        - -command
+        - '{"command":"/hyperkube","args":["kube-controller-manager","--kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","--service-account-private-key-file","/etc/kubernetes/service-account-key/sa.key","--root-ca-file","/etc/kubernetes/pki/ca/ca.crt","--cluster-signing-cert-file","/etc/kubernetes/pki/ca/ca.crt","--cluster-signing-key-file","/etc/kubernetes/pki/ca/ca.key","--cluster-cidr","172.25.0.0/16","--allocate-node-cidrs=true","--controllers","*,bootstrapsigner,tokencleaner","--use-service-account-credentials=true","--feature-gates","RotateKubeletClientCertificate=true,RotateKubeletServerCertificate=true","--cloud-provider","aws","--cloud-config","/etc/kubernetes/cloud/config","--configure-cloud-routes=false"]}'
         command:
-        - /hyperkube
-        - kube-controller-manager
+        - /http-prober-bin/http-prober
         env:
         - name: AWS_ACCESS_KEY_ID
           value: aws-access-key-id
@@ -178,6 +165,8 @@ spec:
         - mountPath: /etc/kubernetes/kubeconfig
           name: controllermanager-kubeconfig
           readOnly: true
+        - mountPath: /http-prober-bin
+          name: http-prober-bin
       dnsConfig:
         nameservers:
         - 192.0.2.14
@@ -192,24 +181,16 @@ spec:
       imagePullSecrets:
       - name: dockercfg
       initContainers:
-      - args:
-        - -endpoint
-        - https://apiserver-external.cluster-de-test-01.svc.cluster.local.:30000/healthz
-        - -insecure
-        - -retries
-        - "100"
-        - -retry-wait
-        - "2"
-        - -timeout
-        - "1"
-        command:
+      - command:
+        - /bin/cp
         - /usr/local/bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.1
-        imagePullPolicy: IfNotPresent
-        name: apiserver-running
+        - /http-prober-bin/http-prober
+        image: quay.io/kubermatic/http-prober:v0.2-dev0
+        name: copy-http-prober
         resources: {}
-        terminationMessagePath: /dev/termination-log
-        terminationMessagePolicy: File
+        volumeMounts:
+        - mountPath: /http-prober-bin
+          name: http-prober-bin
       volumes:
       - name: ca
         secret:
@@ -231,4 +212,6 @@ spec:
         secret:
           defaultMode: 256
           secretName: controllermanager-kubeconfig
+      - emptyDir: {}
+        name: http-prober-bin
 status: {}

--- a/api/pkg/resources/test/fixtures/deployment-aws-1.11.0-kube-state-metrics.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-aws-1.11.0-kube-state-metrics.yaml
@@ -21,14 +21,19 @@ spec:
     spec:
       containers:
       - args:
-        - --kubeconfig
-        - /etc/kubernetes/kubeconfig/kubeconfig
-        - --port
-        - "8080"
-        - --telemetry-port
-        - "8081"
+        - -endpoint
+        - https://apiserver-external.cluster-de-test-01.svc.cluster.local.:30000/healthz
+        - -insecure
+        - -retries
+        - "100"
+        - -retry-wait
+        - "2"
+        - -timeout
+        - "1"
+        - -command
+        - '{"command":"/kube-state-metrics","args":["--kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","--port","8080","--telemetry-port","8081"]}'
         command:
-        - /kube-state-metrics
+        - /http-prober-bin/http-prober
         image: quay.io/coreos/kube-state-metrics:v1.6.0
         name: kube-state-metrics
         ports:
@@ -58,30 +63,26 @@ spec:
         - mountPath: /etc/kubernetes/kubeconfig
           name: kube-state-metrics-kubeconfig
           readOnly: true
+        - mountPath: /http-prober-bin
+          name: http-prober-bin
       imagePullSecrets:
       - name: dockercfg
       initContainers:
-      - args:
-        - -endpoint
-        - https://apiserver-external.cluster-de-test-01.svc.cluster.local.:30000/healthz
-        - -insecure
-        - -retries
-        - "100"
-        - -retry-wait
-        - "2"
-        - -timeout
-        - "1"
-        command:
+      - command:
+        - /bin/cp
         - /usr/local/bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.1
-        imagePullPolicy: IfNotPresent
-        name: apiserver-running
+        - /http-prober-bin/http-prober
+        image: quay.io/kubermatic/http-prober:v0.2-dev0
+        name: copy-http-prober
         resources: {}
-        terminationMessagePath: /dev/termination-log
-        terminationMessagePolicy: File
+        volumeMounts:
+        - mountPath: /http-prober-bin
+          name: http-prober-bin
       volumes:
       - name: kube-state-metrics-kubeconfig
         secret:
           defaultMode: 256
           secretName: kube-state-metrics-kubeconfig
+      - emptyDir: {}
+        name: http-prober-bin
 status: {}

--- a/api/pkg/resources/test/fixtures/deployment-aws-1.11.0-kube-state-metrics.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-aws-1.11.0-kube-state-metrics.yaml
@@ -72,7 +72,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.2-dev0
+        image: quay.io/kubermatic/http-prober:v0.2
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/api/pkg/resources/test/fixtures/deployment-aws-1.11.0-machine-controller-webhook.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-aws-1.11.0-machine-controller-webhook.yaml
@@ -86,7 +86,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.2-dev0
+        image: quay.io/kubermatic/http-prober:v0.2
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/api/pkg/resources/test/fixtures/deployment-aws-1.11.0-machine-controller-webhook.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-aws-1.11.0-machine-controller-webhook.yaml
@@ -24,15 +24,19 @@ spec:
     spec:
       containers:
       - args:
-        - -kubeconfig
-        - /etc/kubernetes/kubeconfig/kubeconfig
-        - -logtostderr
-        - -v
-        - "4"
-        - -listen-address
-        - 0.0.0.0:9876
+        - -endpoint
+        - https://apiserver-external.cluster-de-test-01.svc.cluster.local.:30000/healthz
+        - -insecure
+        - -retries
+        - "100"
+        - -retry-wait
+        - "2"
+        - -timeout
+        - "1"
+        - -command
+        - '{"command":"/usr/local/bin/webhook","args":["-kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","-logtostderr","-v","4","-listen-address","0.0.0.0:9876"]}'
         command:
-        - /usr/local/bin/webhook
+        - /http-prober-bin/http-prober
         env:
         - name: AWS_ACCESS_KEY_ID
           value: aws-access-key-id
@@ -73,27 +77,21 @@ spec:
         - mountPath: /tmp/cert
           name: machinecontroller-webhook-serving-cert
           readOnly: true
+        - mountPath: /http-prober-bin
+          name: http-prober-bin
       imagePullSecrets:
       - name: dockercfg
       initContainers:
-      - args:
-        - -endpoint
-        - https://apiserver-external.cluster-de-test-01.svc.cluster.local.:30000/healthz
-        - -insecure
-        - -retries
-        - "100"
-        - -retry-wait
-        - "2"
-        - -timeout
-        - "1"
-        command:
+      - command:
+        - /bin/cp
         - /usr/local/bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.1
-        imagePullPolicy: IfNotPresent
-        name: apiserver-running
+        - /http-prober-bin/http-prober
+        image: quay.io/kubermatic/http-prober:v0.2-dev0
+        name: copy-http-prober
         resources: {}
-        terminationMessagePath: /dev/termination-log
-        terminationMessagePolicy: File
+        volumeMounts:
+        - mountPath: /http-prober-bin
+          name: http-prober-bin
       volumes:
       - name: machinecontroller-kubeconfig
         secret:
@@ -103,4 +101,6 @@ spec:
         secret:
           defaultMode: 292
           secretName: machinecontroller-webhook-serving-cert
+      - emptyDir: {}
+        name: http-prober-bin
 status: {}

--- a/api/pkg/resources/test/fixtures/deployment-aws-1.11.0-machine-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-aws-1.11.0-machine-controller.yaml
@@ -27,17 +27,19 @@ spec:
     spec:
       containers:
       - args:
-        - -kubeconfig
-        - /etc/kubernetes/kubeconfig/kubeconfig
-        - -logtostderr
-        - -v
-        - "4"
-        - -cluster-dns
-        - 169.254.20.10
-        - -internal-listen-address
-        - 0.0.0.0:8085
+        - -endpoint
+        - https://apiserver-external.cluster-de-test-01.svc.cluster.local.:30000/healthz
+        - -insecure
+        - -retries
+        - "100"
+        - -retry-wait
+        - "2"
+        - -timeout
+        - "1"
+        - -command
+        - '{"command":"/usr/local/bin/machine-controller","args":["-kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","-logtostderr","-v","4","-cluster-dns","169.254.20.10","-internal-listen-address","0.0.0.0:8085"]}'
         command:
-        - /usr/local/bin/machine-controller
+        - /http-prober-bin/http-prober
         env:
         - name: AWS_ACCESS_KEY_ID
           value: aws-access-key-id
@@ -66,30 +68,26 @@ spec:
         - mountPath: /etc/kubernetes/kubeconfig
           name: machinecontroller-kubeconfig
           readOnly: true
+        - mountPath: /http-prober-bin
+          name: http-prober-bin
       imagePullSecrets:
       - name: dockercfg
       initContainers:
-      - args:
-        - -endpoint
-        - https://apiserver-external.cluster-de-test-01.svc.cluster.local.:30000/healthz
-        - -insecure
-        - -retries
-        - "100"
-        - -retry-wait
-        - "2"
-        - -timeout
-        - "1"
-        command:
+      - command:
+        - /bin/cp
         - /usr/local/bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.1
-        imagePullPolicy: IfNotPresent
-        name: apiserver-running
+        - /http-prober-bin/http-prober
+        image: quay.io/kubermatic/http-prober:v0.2-dev0
+        name: copy-http-prober
         resources: {}
-        terminationMessagePath: /dev/termination-log
-        terminationMessagePolicy: File
+        volumeMounts:
+        - mountPath: /http-prober-bin
+          name: http-prober-bin
       volumes:
       - name: machinecontroller-kubeconfig
         secret:
           defaultMode: 292
           secretName: machinecontroller-kubeconfig
+      - emptyDir: {}
+        name: http-prober-bin
 status: {}

--- a/api/pkg/resources/test/fixtures/deployment-aws-1.11.0-machine-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-aws-1.11.0-machine-controller.yaml
@@ -77,7 +77,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.2-dev0
+        image: quay.io/kubermatic/http-prober:v0.2
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/api/pkg/resources/test/fixtures/deployment-aws-1.11.0-metrics-server.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-aws-1.11.0-metrics-server.yaml
@@ -41,22 +41,19 @@ spec:
             weight: 10
       containers:
       - args:
-        - --kubeconfig
-        - /etc/kubernetes/kubeconfig/kubeconfig
-        - --authentication-kubeconfig
-        - /etc/kubernetes/kubeconfig/kubeconfig
-        - --authorization-kubeconfig
-        - /etc/kubernetes/kubeconfig/kubeconfig
-        - --kubelet-port
-        - "10250"
-        - --kubelet-insecure-tls
-        - --kubelet-preferred-address-types
-        - ExternalIP,InternalIP
-        - --v
+        - -endpoint
+        - https://apiserver-external.cluster-de-test-01.svc.cluster.local.:30000/healthz
+        - -insecure
+        - -retries
+        - "100"
+        - -retry-wait
+        - "2"
+        - -timeout
         - "1"
-        - --logtostderr
+        - -command
+        - '{"command":"/metrics-server","args":["--kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","--authentication-kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","--authorization-kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","--kubelet-port","10250","--kubelet-insecure-tls","--kubelet-preferred-address-types","ExternalIP,InternalIP","--v","1","--logtostderr"]}'
         command:
-        - /metrics-server
+        - /http-prober-bin/http-prober
         image: gcr.io/google_containers/metrics-server-amd64:v0.3.2
         name: metrics-server
         resources:
@@ -70,6 +67,8 @@ spec:
         - mountPath: /etc/kubernetes/kubeconfig
           name: metrics-server
           readOnly: true
+        - mountPath: /http-prober-bin
+          name: http-prober-bin
       - args:
         - --client
         - --proto
@@ -158,24 +157,16 @@ spec:
       imagePullSecrets:
       - name: dockercfg
       initContainers:
-      - args:
-        - -endpoint
-        - https://apiserver-external.cluster-de-test-01.svc.cluster.local.:30000/healthz
-        - -insecure
-        - -retries
-        - "100"
-        - -retry-wait
-        - "2"
-        - -timeout
-        - "1"
-        command:
+      - command:
+        - /bin/cp
         - /usr/local/bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.1
-        imagePullPolicy: IfNotPresent
-        name: apiserver-running
+        - /http-prober-bin/http-prober
+        image: quay.io/kubermatic/http-prober:v0.2-dev0
+        name: copy-http-prober
         resources: {}
-        terminationMessagePath: /dev/termination-log
-        terminationMessagePolicy: File
+        volumeMounts:
+        - mountPath: /http-prober-bin
+          name: http-prober-bin
       volumes:
       - name: metrics-server
         secret:
@@ -189,4 +180,6 @@ spec:
         secret:
           defaultMode: 292
           secretName: kubeletdnatcontroller-kubeconfig
+      - emptyDir: {}
+        name: http-prober-bin
 status: {}

--- a/api/pkg/resources/test/fixtures/deployment-aws-1.11.0-metrics-server.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-aws-1.11.0-metrics-server.yaml
@@ -161,7 +161,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.2-dev0
+        image: quay.io/kubermatic/http-prober:v0.2
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/api/pkg/resources/test/fixtures/deployment-aws-1.11.0-scheduler.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-aws-1.11.0-scheduler.yaml
@@ -100,11 +100,19 @@ spec:
           name: openvpn-client-certificates
           readOnly: true
       - args:
-        - --kubeconfig
-        - /etc/kubernetes/kubeconfig/kubeconfig
+        - -endpoint
+        - https://apiserver-external.cluster-de-test-01.svc.cluster.local.:30000/healthz
+        - -insecure
+        - -retries
+        - "100"
+        - -retry-wait
+        - "2"
+        - -timeout
+        - "1"
+        - -command
+        - '{"command":"/hyperkube","args":["kube-scheduler","--kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig"]}'
         command:
-        - /hyperkube
-        - kube-scheduler
+        - /http-prober-bin/http-prober
         image: gcr.io/google_containers/hyperkube-amd64:v1.11.0
         livenessProbe:
           failureThreshold: 8
@@ -140,6 +148,8 @@ spec:
         - mountPath: /etc/kubernetes/pki/ca
           name: ca
           readOnly: true
+        - mountPath: /http-prober-bin
+          name: http-prober-bin
       dnsConfig:
         nameservers:
         - 192.0.2.14
@@ -154,24 +164,16 @@ spec:
       imagePullSecrets:
       - name: dockercfg
       initContainers:
-      - args:
-        - -endpoint
-        - https://apiserver-external.cluster-de-test-01.svc.cluster.local.:30000/healthz
-        - -insecure
-        - -retries
-        - "100"
-        - -retry-wait
-        - "2"
-        - -timeout
-        - "1"
-        command:
+      - command:
+        - /bin/cp
         - /usr/local/bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.1
-        imagePullPolicy: IfNotPresent
-        name: apiserver-running
+        - /http-prober-bin/http-prober
+        image: quay.io/kubermatic/http-prober:v0.2-dev0
+        name: copy-http-prober
         resources: {}
-        terminationMessagePath: /dev/termination-log
-        terminationMessagePolicy: File
+        volumeMounts:
+        - mountPath: /http-prober-bin
+          name: http-prober-bin
       volumes:
       - name: openvpn-client-certificates
         secret:
@@ -188,4 +190,6 @@ spec:
         secret:
           defaultMode: 256
           secretName: scheduler-kubeconfig
+      - emptyDir: {}
+        name: http-prober-bin
 status: {}

--- a/api/pkg/resources/test/fixtures/deployment-aws-1.11.0-scheduler.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-aws-1.11.0-scheduler.yaml
@@ -168,7 +168,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.2-dev0
+        image: quay.io/kubermatic/http-prober:v0.2
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/api/pkg/resources/test/fixtures/deployment-aws-1.11.0-usercluster-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-aws-1.11.0-usercluster-controller.yaml
@@ -85,7 +85,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.2-dev0
+        image: quay.io/kubermatic/http-prober:v0.2
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/api/pkg/resources/test/fixtures/deployment-aws-1.11.0-usercluster-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-aws-1.11.0-usercluster-controller.yaml
@@ -29,32 +29,19 @@ spec:
     spec:
       containers:
       - args:
-        - -kubeconfig
-        - /etc/kubernetes/kubeconfig/kubeconfig
-        - -metrics-listen-address
-        - 0.0.0.0:8085
-        - -health-listen-address
-        - 0.0.0.0:8086
-        - -namespace
-        - $(NAMESPACE)
-        - -ca-cert
-        - /etc/kubernetes/pki/ca/ca.crt
-        - -cluster-url
-        - ""
-        - -openvpn-server-port
-        - "30003"
-        - -overwrite-registry
-        - ""
-        - -openshift=false
-        - -openvpn-ca-cert-file=/etc/kubernetes/pki/openvpn/ca.crt
-        - -openvpn-ca-key-file=/etc/kubernetes/pki/openvpn/ca.key
-        - -logtostderr
-        - -v
+        - -endpoint
+        - https://apiserver-external.cluster-de-test-01.svc.cluster.local.:30000/healthz
+        - -insecure
+        - -retries
+        - "100"
+        - -retry-wait
         - "2"
-        - --ipam-controller-network
-        - 192.168.1.1/24,192.168.1.1,8.8.8.8
+        - -timeout
+        - "1"
+        - -command
+        - '{"command":"/usr/local/bin/user-cluster-controller-manager","args":["-kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","-metrics-listen-address","0.0.0.0:8085","-health-listen-address","0.0.0.0:8086","-namespace","$(NAMESPACE)","-ca-cert","/etc/kubernetes/pki/ca/ca.crt","-cluster-url","","-openvpn-server-port","30003","-overwrite-registry","","-openshift=false","-openvpn-ca-cert-file=/etc/kubernetes/pki/openvpn/ca.crt","-openvpn-ca-key-file=/etc/kubernetes/pki/openvpn/ca.key","-logtostderr","-v","2","--ipam-controller-network","192.168.1.1/24,192.168.1.1,8.8.8.8"]}'
         command:
-        - /usr/local/bin/user-cluster-controller-manager
+        - /http-prober-bin/http-prober
         env:
         - name: NAMESPACE
           valueFrom:
@@ -89,27 +76,21 @@ spec:
         - mountPath: /etc/kubernetes/pki/openvpn
           name: openvpn-ca
           readOnly: true
+        - mountPath: /http-prober-bin
+          name: http-prober-bin
       imagePullSecrets:
       - name: dockercfg
       initContainers:
-      - args:
-        - -endpoint
-        - https://apiserver-external.cluster-de-test-01.svc.cluster.local.:30000/healthz
-        - -insecure
-        - -retries
-        - "100"
-        - -retry-wait
-        - "2"
-        - -timeout
-        - "1"
-        command:
+      - command:
+        - /bin/cp
         - /usr/local/bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.1
-        imagePullPolicy: IfNotPresent
-        name: apiserver-running
+        - /http-prober-bin/http-prober
+        image: quay.io/kubermatic/http-prober:v0.2-dev0
+        name: copy-http-prober
         resources: {}
-        terminationMessagePath: /dev/termination-log
-        terminationMessagePolicy: File
+        volumeMounts:
+        - mountPath: /http-prober-bin
+          name: http-prober-bin
       volumes:
       - name: internal-admin-kubeconfig
         secret:
@@ -126,4 +107,6 @@ spec:
         secret:
           defaultMode: 292
           secretName: openvpn-ca
+      - emptyDir: {}
+        name: http-prober-bin
 status: {}

--- a/api/pkg/resources/test/fixtures/deployment-aws-1.11.1-controller-manager.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-aws-1.11.1-controller-manager.yaml
@@ -185,7 +185,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.2-dev0
+        image: quay.io/kubermatic/http-prober:v0.2
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/api/pkg/resources/test/fixtures/deployment-aws-1.11.1-controller-manager.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-aws-1.11.1-controller-manager.yaml
@@ -102,32 +102,19 @@ spec:
           name: openvpn-client-certificates
           readOnly: true
       - args:
-        - --kubeconfig
-        - /etc/kubernetes/kubeconfig/kubeconfig
-        - --service-account-private-key-file
-        - /etc/kubernetes/service-account-key/sa.key
-        - --root-ca-file
-        - /etc/kubernetes/pki/ca/ca.crt
-        - --cluster-signing-cert-file
-        - /etc/kubernetes/pki/ca/ca.crt
-        - --cluster-signing-key-file
-        - /etc/kubernetes/pki/ca/ca.key
-        - --cluster-cidr
-        - 172.25.0.0/16
-        - --allocate-node-cidrs=true
-        - --controllers
-        - '*,bootstrapsigner,tokencleaner'
-        - --use-service-account-credentials=true
-        - --feature-gates
-        - RotateKubeletClientCertificate=true,RotateKubeletServerCertificate=true
-        - --cloud-provider
-        - aws
-        - --cloud-config
-        - /etc/kubernetes/cloud/config
-        - --configure-cloud-routes=false
+        - -endpoint
+        - https://apiserver-external.cluster-de-test-01.svc.cluster.local.:30000/healthz
+        - -insecure
+        - -retries
+        - "100"
+        - -retry-wait
+        - "2"
+        - -timeout
+        - "1"
+        - -command
+        - '{"command":"/hyperkube","args":["kube-controller-manager","--kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","--service-account-private-key-file","/etc/kubernetes/service-account-key/sa.key","--root-ca-file","/etc/kubernetes/pki/ca/ca.crt","--cluster-signing-cert-file","/etc/kubernetes/pki/ca/ca.crt","--cluster-signing-key-file","/etc/kubernetes/pki/ca/ca.key","--cluster-cidr","172.25.0.0/16","--allocate-node-cidrs=true","--controllers","*,bootstrapsigner,tokencleaner","--use-service-account-credentials=true","--feature-gates","RotateKubeletClientCertificate=true,RotateKubeletServerCertificate=true","--cloud-provider","aws","--cloud-config","/etc/kubernetes/cloud/config","--configure-cloud-routes=false"]}'
         command:
-        - /hyperkube
-        - kube-controller-manager
+        - /http-prober-bin/http-prober
         env:
         - name: AWS_ACCESS_KEY_ID
           value: aws-access-key-id
@@ -178,6 +165,8 @@ spec:
         - mountPath: /etc/kubernetes/kubeconfig
           name: controllermanager-kubeconfig
           readOnly: true
+        - mountPath: /http-prober-bin
+          name: http-prober-bin
       dnsConfig:
         nameservers:
         - 192.0.2.14
@@ -192,24 +181,16 @@ spec:
       imagePullSecrets:
       - name: dockercfg
       initContainers:
-      - args:
-        - -endpoint
-        - https://apiserver-external.cluster-de-test-01.svc.cluster.local.:30000/healthz
-        - -insecure
-        - -retries
-        - "100"
-        - -retry-wait
-        - "2"
-        - -timeout
-        - "1"
-        command:
+      - command:
+        - /bin/cp
         - /usr/local/bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.1
-        imagePullPolicy: IfNotPresent
-        name: apiserver-running
+        - /http-prober-bin/http-prober
+        image: quay.io/kubermatic/http-prober:v0.2-dev0
+        name: copy-http-prober
         resources: {}
-        terminationMessagePath: /dev/termination-log
-        terminationMessagePolicy: File
+        volumeMounts:
+        - mountPath: /http-prober-bin
+          name: http-prober-bin
       volumes:
       - name: ca
         secret:
@@ -231,4 +212,6 @@ spec:
         secret:
           defaultMode: 256
           secretName: controllermanager-kubeconfig
+      - emptyDir: {}
+        name: http-prober-bin
 status: {}

--- a/api/pkg/resources/test/fixtures/deployment-aws-1.11.1-kube-state-metrics.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-aws-1.11.1-kube-state-metrics.yaml
@@ -21,14 +21,19 @@ spec:
     spec:
       containers:
       - args:
-        - --kubeconfig
-        - /etc/kubernetes/kubeconfig/kubeconfig
-        - --port
-        - "8080"
-        - --telemetry-port
-        - "8081"
+        - -endpoint
+        - https://apiserver-external.cluster-de-test-01.svc.cluster.local.:30000/healthz
+        - -insecure
+        - -retries
+        - "100"
+        - -retry-wait
+        - "2"
+        - -timeout
+        - "1"
+        - -command
+        - '{"command":"/kube-state-metrics","args":["--kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","--port","8080","--telemetry-port","8081"]}'
         command:
-        - /kube-state-metrics
+        - /http-prober-bin/http-prober
         image: quay.io/coreos/kube-state-metrics:v1.6.0
         name: kube-state-metrics
         ports:
@@ -58,30 +63,26 @@ spec:
         - mountPath: /etc/kubernetes/kubeconfig
           name: kube-state-metrics-kubeconfig
           readOnly: true
+        - mountPath: /http-prober-bin
+          name: http-prober-bin
       imagePullSecrets:
       - name: dockercfg
       initContainers:
-      - args:
-        - -endpoint
-        - https://apiserver-external.cluster-de-test-01.svc.cluster.local.:30000/healthz
-        - -insecure
-        - -retries
-        - "100"
-        - -retry-wait
-        - "2"
-        - -timeout
-        - "1"
-        command:
+      - command:
+        - /bin/cp
         - /usr/local/bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.1
-        imagePullPolicy: IfNotPresent
-        name: apiserver-running
+        - /http-prober-bin/http-prober
+        image: quay.io/kubermatic/http-prober:v0.2-dev0
+        name: copy-http-prober
         resources: {}
-        terminationMessagePath: /dev/termination-log
-        terminationMessagePolicy: File
+        volumeMounts:
+        - mountPath: /http-prober-bin
+          name: http-prober-bin
       volumes:
       - name: kube-state-metrics-kubeconfig
         secret:
           defaultMode: 256
           secretName: kube-state-metrics-kubeconfig
+      - emptyDir: {}
+        name: http-prober-bin
 status: {}

--- a/api/pkg/resources/test/fixtures/deployment-aws-1.11.1-kube-state-metrics.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-aws-1.11.1-kube-state-metrics.yaml
@@ -72,7 +72,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.2-dev0
+        image: quay.io/kubermatic/http-prober:v0.2
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/api/pkg/resources/test/fixtures/deployment-aws-1.11.1-machine-controller-webhook.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-aws-1.11.1-machine-controller-webhook.yaml
@@ -86,7 +86,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.2-dev0
+        image: quay.io/kubermatic/http-prober:v0.2
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/api/pkg/resources/test/fixtures/deployment-aws-1.11.1-machine-controller-webhook.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-aws-1.11.1-machine-controller-webhook.yaml
@@ -24,15 +24,19 @@ spec:
     spec:
       containers:
       - args:
-        - -kubeconfig
-        - /etc/kubernetes/kubeconfig/kubeconfig
-        - -logtostderr
-        - -v
-        - "4"
-        - -listen-address
-        - 0.0.0.0:9876
+        - -endpoint
+        - https://apiserver-external.cluster-de-test-01.svc.cluster.local.:30000/healthz
+        - -insecure
+        - -retries
+        - "100"
+        - -retry-wait
+        - "2"
+        - -timeout
+        - "1"
+        - -command
+        - '{"command":"/usr/local/bin/webhook","args":["-kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","-logtostderr","-v","4","-listen-address","0.0.0.0:9876"]}'
         command:
-        - /usr/local/bin/webhook
+        - /http-prober-bin/http-prober
         env:
         - name: AWS_ACCESS_KEY_ID
           value: aws-access-key-id
@@ -73,27 +77,21 @@ spec:
         - mountPath: /tmp/cert
           name: machinecontroller-webhook-serving-cert
           readOnly: true
+        - mountPath: /http-prober-bin
+          name: http-prober-bin
       imagePullSecrets:
       - name: dockercfg
       initContainers:
-      - args:
-        - -endpoint
-        - https://apiserver-external.cluster-de-test-01.svc.cluster.local.:30000/healthz
-        - -insecure
-        - -retries
-        - "100"
-        - -retry-wait
-        - "2"
-        - -timeout
-        - "1"
-        command:
+      - command:
+        - /bin/cp
         - /usr/local/bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.1
-        imagePullPolicy: IfNotPresent
-        name: apiserver-running
+        - /http-prober-bin/http-prober
+        image: quay.io/kubermatic/http-prober:v0.2-dev0
+        name: copy-http-prober
         resources: {}
-        terminationMessagePath: /dev/termination-log
-        terminationMessagePolicy: File
+        volumeMounts:
+        - mountPath: /http-prober-bin
+          name: http-prober-bin
       volumes:
       - name: machinecontroller-kubeconfig
         secret:
@@ -103,4 +101,6 @@ spec:
         secret:
           defaultMode: 292
           secretName: machinecontroller-webhook-serving-cert
+      - emptyDir: {}
+        name: http-prober-bin
 status: {}

--- a/api/pkg/resources/test/fixtures/deployment-aws-1.11.1-machine-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-aws-1.11.1-machine-controller.yaml
@@ -27,17 +27,19 @@ spec:
     spec:
       containers:
       - args:
-        - -kubeconfig
-        - /etc/kubernetes/kubeconfig/kubeconfig
-        - -logtostderr
-        - -v
-        - "4"
-        - -cluster-dns
-        - 169.254.20.10
-        - -internal-listen-address
-        - 0.0.0.0:8085
+        - -endpoint
+        - https://apiserver-external.cluster-de-test-01.svc.cluster.local.:30000/healthz
+        - -insecure
+        - -retries
+        - "100"
+        - -retry-wait
+        - "2"
+        - -timeout
+        - "1"
+        - -command
+        - '{"command":"/usr/local/bin/machine-controller","args":["-kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","-logtostderr","-v","4","-cluster-dns","169.254.20.10","-internal-listen-address","0.0.0.0:8085"]}'
         command:
-        - /usr/local/bin/machine-controller
+        - /http-prober-bin/http-prober
         env:
         - name: AWS_ACCESS_KEY_ID
           value: aws-access-key-id
@@ -66,30 +68,26 @@ spec:
         - mountPath: /etc/kubernetes/kubeconfig
           name: machinecontroller-kubeconfig
           readOnly: true
+        - mountPath: /http-prober-bin
+          name: http-prober-bin
       imagePullSecrets:
       - name: dockercfg
       initContainers:
-      - args:
-        - -endpoint
-        - https://apiserver-external.cluster-de-test-01.svc.cluster.local.:30000/healthz
-        - -insecure
-        - -retries
-        - "100"
-        - -retry-wait
-        - "2"
-        - -timeout
-        - "1"
-        command:
+      - command:
+        - /bin/cp
         - /usr/local/bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.1
-        imagePullPolicy: IfNotPresent
-        name: apiserver-running
+        - /http-prober-bin/http-prober
+        image: quay.io/kubermatic/http-prober:v0.2-dev0
+        name: copy-http-prober
         resources: {}
-        terminationMessagePath: /dev/termination-log
-        terminationMessagePolicy: File
+        volumeMounts:
+        - mountPath: /http-prober-bin
+          name: http-prober-bin
       volumes:
       - name: machinecontroller-kubeconfig
         secret:
           defaultMode: 292
           secretName: machinecontroller-kubeconfig
+      - emptyDir: {}
+        name: http-prober-bin
 status: {}

--- a/api/pkg/resources/test/fixtures/deployment-aws-1.11.1-machine-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-aws-1.11.1-machine-controller.yaml
@@ -77,7 +77,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.2-dev0
+        image: quay.io/kubermatic/http-prober:v0.2
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/api/pkg/resources/test/fixtures/deployment-aws-1.11.1-metrics-server.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-aws-1.11.1-metrics-server.yaml
@@ -41,22 +41,19 @@ spec:
             weight: 10
       containers:
       - args:
-        - --kubeconfig
-        - /etc/kubernetes/kubeconfig/kubeconfig
-        - --authentication-kubeconfig
-        - /etc/kubernetes/kubeconfig/kubeconfig
-        - --authorization-kubeconfig
-        - /etc/kubernetes/kubeconfig/kubeconfig
-        - --kubelet-port
-        - "10250"
-        - --kubelet-insecure-tls
-        - --kubelet-preferred-address-types
-        - ExternalIP,InternalIP
-        - --v
+        - -endpoint
+        - https://apiserver-external.cluster-de-test-01.svc.cluster.local.:30000/healthz
+        - -insecure
+        - -retries
+        - "100"
+        - -retry-wait
+        - "2"
+        - -timeout
         - "1"
-        - --logtostderr
+        - -command
+        - '{"command":"/metrics-server","args":["--kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","--authentication-kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","--authorization-kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","--kubelet-port","10250","--kubelet-insecure-tls","--kubelet-preferred-address-types","ExternalIP,InternalIP","--v","1","--logtostderr"]}'
         command:
-        - /metrics-server
+        - /http-prober-bin/http-prober
         image: gcr.io/google_containers/metrics-server-amd64:v0.3.2
         name: metrics-server
         resources:
@@ -70,6 +67,8 @@ spec:
         - mountPath: /etc/kubernetes/kubeconfig
           name: metrics-server
           readOnly: true
+        - mountPath: /http-prober-bin
+          name: http-prober-bin
       - args:
         - --client
         - --proto
@@ -158,24 +157,16 @@ spec:
       imagePullSecrets:
       - name: dockercfg
       initContainers:
-      - args:
-        - -endpoint
-        - https://apiserver-external.cluster-de-test-01.svc.cluster.local.:30000/healthz
-        - -insecure
-        - -retries
-        - "100"
-        - -retry-wait
-        - "2"
-        - -timeout
-        - "1"
-        command:
+      - command:
+        - /bin/cp
         - /usr/local/bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.1
-        imagePullPolicy: IfNotPresent
-        name: apiserver-running
+        - /http-prober-bin/http-prober
+        image: quay.io/kubermatic/http-prober:v0.2-dev0
+        name: copy-http-prober
         resources: {}
-        terminationMessagePath: /dev/termination-log
-        terminationMessagePolicy: File
+        volumeMounts:
+        - mountPath: /http-prober-bin
+          name: http-prober-bin
       volumes:
       - name: metrics-server
         secret:
@@ -189,4 +180,6 @@ spec:
         secret:
           defaultMode: 292
           secretName: kubeletdnatcontroller-kubeconfig
+      - emptyDir: {}
+        name: http-prober-bin
 status: {}

--- a/api/pkg/resources/test/fixtures/deployment-aws-1.11.1-metrics-server.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-aws-1.11.1-metrics-server.yaml
@@ -161,7 +161,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.2-dev0
+        image: quay.io/kubermatic/http-prober:v0.2
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/api/pkg/resources/test/fixtures/deployment-aws-1.11.1-scheduler.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-aws-1.11.1-scheduler.yaml
@@ -100,11 +100,19 @@ spec:
           name: openvpn-client-certificates
           readOnly: true
       - args:
-        - --kubeconfig
-        - /etc/kubernetes/kubeconfig/kubeconfig
+        - -endpoint
+        - https://apiserver-external.cluster-de-test-01.svc.cluster.local.:30000/healthz
+        - -insecure
+        - -retries
+        - "100"
+        - -retry-wait
+        - "2"
+        - -timeout
+        - "1"
+        - -command
+        - '{"command":"/hyperkube","args":["kube-scheduler","--kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig"]}'
         command:
-        - /hyperkube
-        - kube-scheduler
+        - /http-prober-bin/http-prober
         image: gcr.io/google_containers/hyperkube-amd64:v1.11.1
         livenessProbe:
           failureThreshold: 8
@@ -140,6 +148,8 @@ spec:
         - mountPath: /etc/kubernetes/pki/ca
           name: ca
           readOnly: true
+        - mountPath: /http-prober-bin
+          name: http-prober-bin
       dnsConfig:
         nameservers:
         - 192.0.2.14
@@ -154,24 +164,16 @@ spec:
       imagePullSecrets:
       - name: dockercfg
       initContainers:
-      - args:
-        - -endpoint
-        - https://apiserver-external.cluster-de-test-01.svc.cluster.local.:30000/healthz
-        - -insecure
-        - -retries
-        - "100"
-        - -retry-wait
-        - "2"
-        - -timeout
-        - "1"
-        command:
+      - command:
+        - /bin/cp
         - /usr/local/bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.1
-        imagePullPolicy: IfNotPresent
-        name: apiserver-running
+        - /http-prober-bin/http-prober
+        image: quay.io/kubermatic/http-prober:v0.2-dev0
+        name: copy-http-prober
         resources: {}
-        terminationMessagePath: /dev/termination-log
-        terminationMessagePolicy: File
+        volumeMounts:
+        - mountPath: /http-prober-bin
+          name: http-prober-bin
       volumes:
       - name: openvpn-client-certificates
         secret:
@@ -188,4 +190,6 @@ spec:
         secret:
           defaultMode: 256
           secretName: scheduler-kubeconfig
+      - emptyDir: {}
+        name: http-prober-bin
 status: {}

--- a/api/pkg/resources/test/fixtures/deployment-aws-1.11.1-scheduler.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-aws-1.11.1-scheduler.yaml
@@ -168,7 +168,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.2-dev0
+        image: quay.io/kubermatic/http-prober:v0.2
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/api/pkg/resources/test/fixtures/deployment-aws-1.11.1-usercluster-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-aws-1.11.1-usercluster-controller.yaml
@@ -85,7 +85,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.2-dev0
+        image: quay.io/kubermatic/http-prober:v0.2
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/api/pkg/resources/test/fixtures/deployment-aws-1.11.1-usercluster-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-aws-1.11.1-usercluster-controller.yaml
@@ -29,32 +29,19 @@ spec:
     spec:
       containers:
       - args:
-        - -kubeconfig
-        - /etc/kubernetes/kubeconfig/kubeconfig
-        - -metrics-listen-address
-        - 0.0.0.0:8085
-        - -health-listen-address
-        - 0.0.0.0:8086
-        - -namespace
-        - $(NAMESPACE)
-        - -ca-cert
-        - /etc/kubernetes/pki/ca/ca.crt
-        - -cluster-url
-        - ""
-        - -openvpn-server-port
-        - "30003"
-        - -overwrite-registry
-        - ""
-        - -openshift=false
-        - -openvpn-ca-cert-file=/etc/kubernetes/pki/openvpn/ca.crt
-        - -openvpn-ca-key-file=/etc/kubernetes/pki/openvpn/ca.key
-        - -logtostderr
-        - -v
+        - -endpoint
+        - https://apiserver-external.cluster-de-test-01.svc.cluster.local.:30000/healthz
+        - -insecure
+        - -retries
+        - "100"
+        - -retry-wait
         - "2"
-        - --ipam-controller-network
-        - 192.168.1.1/24,192.168.1.1,8.8.8.8
+        - -timeout
+        - "1"
+        - -command
+        - '{"command":"/usr/local/bin/user-cluster-controller-manager","args":["-kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","-metrics-listen-address","0.0.0.0:8085","-health-listen-address","0.0.0.0:8086","-namespace","$(NAMESPACE)","-ca-cert","/etc/kubernetes/pki/ca/ca.crt","-cluster-url","","-openvpn-server-port","30003","-overwrite-registry","","-openshift=false","-openvpn-ca-cert-file=/etc/kubernetes/pki/openvpn/ca.crt","-openvpn-ca-key-file=/etc/kubernetes/pki/openvpn/ca.key","-logtostderr","-v","2","--ipam-controller-network","192.168.1.1/24,192.168.1.1,8.8.8.8"]}'
         command:
-        - /usr/local/bin/user-cluster-controller-manager
+        - /http-prober-bin/http-prober
         env:
         - name: NAMESPACE
           valueFrom:
@@ -89,27 +76,21 @@ spec:
         - mountPath: /etc/kubernetes/pki/openvpn
           name: openvpn-ca
           readOnly: true
+        - mountPath: /http-prober-bin
+          name: http-prober-bin
       imagePullSecrets:
       - name: dockercfg
       initContainers:
-      - args:
-        - -endpoint
-        - https://apiserver-external.cluster-de-test-01.svc.cluster.local.:30000/healthz
-        - -insecure
-        - -retries
-        - "100"
-        - -retry-wait
-        - "2"
-        - -timeout
-        - "1"
-        command:
+      - command:
+        - /bin/cp
         - /usr/local/bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.1
-        imagePullPolicy: IfNotPresent
-        name: apiserver-running
+        - /http-prober-bin/http-prober
+        image: quay.io/kubermatic/http-prober:v0.2-dev0
+        name: copy-http-prober
         resources: {}
-        terminationMessagePath: /dev/termination-log
-        terminationMessagePolicy: File
+        volumeMounts:
+        - mountPath: /http-prober-bin
+          name: http-prober-bin
       volumes:
       - name: internal-admin-kubeconfig
         secret:
@@ -126,4 +107,6 @@ spec:
         secret:
           defaultMode: 292
           secretName: openvpn-ca
+      - emptyDir: {}
+        name: http-prober-bin
 status: {}

--- a/api/pkg/resources/test/fixtures/deployment-aws-1.12.0-controller-manager.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-aws-1.12.0-controller-manager.yaml
@@ -102,37 +102,19 @@ spec:
           name: openvpn-client-certificates
           readOnly: true
       - args:
-        - --kubeconfig
-        - /etc/kubernetes/kubeconfig/kubeconfig
-        - --service-account-private-key-file
-        - /etc/kubernetes/service-account-key/sa.key
-        - --root-ca-file
-        - /etc/kubernetes/pki/ca/ca.crt
-        - --cluster-signing-cert-file
-        - /etc/kubernetes/pki/ca/ca.crt
-        - --cluster-signing-key-file
-        - /etc/kubernetes/pki/ca/ca.key
-        - --cluster-cidr
-        - 172.25.0.0/16
-        - --allocate-node-cidrs=true
-        - --controllers
-        - '*,bootstrapsigner,tokencleaner'
-        - --use-service-account-credentials=true
-        - --feature-gates
-        - RotateKubeletClientCertificate=true,RotateKubeletServerCertificate=true,ScheduleDaemonSetPods=false
-        - --cloud-provider
-        - aws
-        - --cloud-config
-        - /etc/kubernetes/cloud/config
-        - --configure-cloud-routes=false
-        - --authentication-kubeconfig
-        - /etc/kubernetes/kubeconfig/kubeconfig
-        - --client-ca-file
-        - /etc/kubernetes/pki/ca/ca.crt
-        - --authentication-skip-lookup=true
+        - -endpoint
+        - https://apiserver-external.cluster-de-test-01.svc.cluster.local.:30000/healthz
+        - -insecure
+        - -retries
+        - "100"
+        - -retry-wait
+        - "2"
+        - -timeout
+        - "1"
+        - -command
+        - '{"command":"/hyperkube","args":["kube-controller-manager","--kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","--service-account-private-key-file","/etc/kubernetes/service-account-key/sa.key","--root-ca-file","/etc/kubernetes/pki/ca/ca.crt","--cluster-signing-cert-file","/etc/kubernetes/pki/ca/ca.crt","--cluster-signing-key-file","/etc/kubernetes/pki/ca/ca.key","--cluster-cidr","172.25.0.0/16","--allocate-node-cidrs=true","--controllers","*,bootstrapsigner,tokencleaner","--use-service-account-credentials=true","--feature-gates","RotateKubeletClientCertificate=true,RotateKubeletServerCertificate=true,ScheduleDaemonSetPods=false","--cloud-provider","aws","--cloud-config","/etc/kubernetes/cloud/config","--configure-cloud-routes=false","--authentication-kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","--client-ca-file","/etc/kubernetes/pki/ca/ca.crt","--authentication-skip-lookup=true"]}'
         command:
-        - /hyperkube
-        - kube-controller-manager
+        - /http-prober-bin/http-prober
         env:
         - name: AWS_ACCESS_KEY_ID
           value: aws-access-key-id
@@ -183,6 +165,8 @@ spec:
         - mountPath: /etc/kubernetes/kubeconfig
           name: controllermanager-kubeconfig
           readOnly: true
+        - mountPath: /http-prober-bin
+          name: http-prober-bin
       dnsConfig:
         nameservers:
         - 192.0.2.14
@@ -197,24 +181,16 @@ spec:
       imagePullSecrets:
       - name: dockercfg
       initContainers:
-      - args:
-        - -endpoint
-        - https://apiserver-external.cluster-de-test-01.svc.cluster.local.:30000/healthz
-        - -insecure
-        - -retries
-        - "100"
-        - -retry-wait
-        - "2"
-        - -timeout
-        - "1"
-        command:
+      - command:
+        - /bin/cp
         - /usr/local/bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.1
-        imagePullPolicy: IfNotPresent
-        name: apiserver-running
+        - /http-prober-bin/http-prober
+        image: quay.io/kubermatic/http-prober:v0.2-dev0
+        name: copy-http-prober
         resources: {}
-        terminationMessagePath: /dev/termination-log
-        terminationMessagePolicy: File
+        volumeMounts:
+        - mountPath: /http-prober-bin
+          name: http-prober-bin
       volumes:
       - name: ca
         secret:
@@ -236,4 +212,6 @@ spec:
         secret:
           defaultMode: 256
           secretName: controllermanager-kubeconfig
+      - emptyDir: {}
+        name: http-prober-bin
 status: {}

--- a/api/pkg/resources/test/fixtures/deployment-aws-1.12.0-controller-manager.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-aws-1.12.0-controller-manager.yaml
@@ -185,7 +185,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.2-dev0
+        image: quay.io/kubermatic/http-prober:v0.2
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/api/pkg/resources/test/fixtures/deployment-aws-1.12.0-kube-state-metrics.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-aws-1.12.0-kube-state-metrics.yaml
@@ -21,14 +21,19 @@ spec:
     spec:
       containers:
       - args:
-        - --kubeconfig
-        - /etc/kubernetes/kubeconfig/kubeconfig
-        - --port
-        - "8080"
-        - --telemetry-port
-        - "8081"
+        - -endpoint
+        - https://apiserver-external.cluster-de-test-01.svc.cluster.local.:30000/healthz
+        - -insecure
+        - -retries
+        - "100"
+        - -retry-wait
+        - "2"
+        - -timeout
+        - "1"
+        - -command
+        - '{"command":"/kube-state-metrics","args":["--kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","--port","8080","--telemetry-port","8081"]}'
         command:
-        - /kube-state-metrics
+        - /http-prober-bin/http-prober
         image: quay.io/coreos/kube-state-metrics:v1.6.0
         name: kube-state-metrics
         ports:
@@ -58,30 +63,26 @@ spec:
         - mountPath: /etc/kubernetes/kubeconfig
           name: kube-state-metrics-kubeconfig
           readOnly: true
+        - mountPath: /http-prober-bin
+          name: http-prober-bin
       imagePullSecrets:
       - name: dockercfg
       initContainers:
-      - args:
-        - -endpoint
-        - https://apiserver-external.cluster-de-test-01.svc.cluster.local.:30000/healthz
-        - -insecure
-        - -retries
-        - "100"
-        - -retry-wait
-        - "2"
-        - -timeout
-        - "1"
-        command:
+      - command:
+        - /bin/cp
         - /usr/local/bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.1
-        imagePullPolicy: IfNotPresent
-        name: apiserver-running
+        - /http-prober-bin/http-prober
+        image: quay.io/kubermatic/http-prober:v0.2-dev0
+        name: copy-http-prober
         resources: {}
-        terminationMessagePath: /dev/termination-log
-        terminationMessagePolicy: File
+        volumeMounts:
+        - mountPath: /http-prober-bin
+          name: http-prober-bin
       volumes:
       - name: kube-state-metrics-kubeconfig
         secret:
           defaultMode: 256
           secretName: kube-state-metrics-kubeconfig
+      - emptyDir: {}
+        name: http-prober-bin
 status: {}

--- a/api/pkg/resources/test/fixtures/deployment-aws-1.12.0-kube-state-metrics.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-aws-1.12.0-kube-state-metrics.yaml
@@ -72,7 +72,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.2-dev0
+        image: quay.io/kubermatic/http-prober:v0.2
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/api/pkg/resources/test/fixtures/deployment-aws-1.12.0-machine-controller-webhook.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-aws-1.12.0-machine-controller-webhook.yaml
@@ -86,7 +86,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.2-dev0
+        image: quay.io/kubermatic/http-prober:v0.2
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/api/pkg/resources/test/fixtures/deployment-aws-1.12.0-machine-controller-webhook.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-aws-1.12.0-machine-controller-webhook.yaml
@@ -24,15 +24,19 @@ spec:
     spec:
       containers:
       - args:
-        - -kubeconfig
-        - /etc/kubernetes/kubeconfig/kubeconfig
-        - -logtostderr
-        - -v
-        - "4"
-        - -listen-address
-        - 0.0.0.0:9876
+        - -endpoint
+        - https://apiserver-external.cluster-de-test-01.svc.cluster.local.:30000/healthz
+        - -insecure
+        - -retries
+        - "100"
+        - -retry-wait
+        - "2"
+        - -timeout
+        - "1"
+        - -command
+        - '{"command":"/usr/local/bin/webhook","args":["-kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","-logtostderr","-v","4","-listen-address","0.0.0.0:9876"]}'
         command:
-        - /usr/local/bin/webhook
+        - /http-prober-bin/http-prober
         env:
         - name: AWS_ACCESS_KEY_ID
           value: aws-access-key-id
@@ -73,27 +77,21 @@ spec:
         - mountPath: /tmp/cert
           name: machinecontroller-webhook-serving-cert
           readOnly: true
+        - mountPath: /http-prober-bin
+          name: http-prober-bin
       imagePullSecrets:
       - name: dockercfg
       initContainers:
-      - args:
-        - -endpoint
-        - https://apiserver-external.cluster-de-test-01.svc.cluster.local.:30000/healthz
-        - -insecure
-        - -retries
-        - "100"
-        - -retry-wait
-        - "2"
-        - -timeout
-        - "1"
-        command:
+      - command:
+        - /bin/cp
         - /usr/local/bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.1
-        imagePullPolicy: IfNotPresent
-        name: apiserver-running
+        - /http-prober-bin/http-prober
+        image: quay.io/kubermatic/http-prober:v0.2-dev0
+        name: copy-http-prober
         resources: {}
-        terminationMessagePath: /dev/termination-log
-        terminationMessagePolicy: File
+        volumeMounts:
+        - mountPath: /http-prober-bin
+          name: http-prober-bin
       volumes:
       - name: machinecontroller-kubeconfig
         secret:
@@ -103,4 +101,6 @@ spec:
         secret:
           defaultMode: 292
           secretName: machinecontroller-webhook-serving-cert
+      - emptyDir: {}
+        name: http-prober-bin
 status: {}

--- a/api/pkg/resources/test/fixtures/deployment-aws-1.12.0-machine-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-aws-1.12.0-machine-controller.yaml
@@ -27,17 +27,19 @@ spec:
     spec:
       containers:
       - args:
-        - -kubeconfig
-        - /etc/kubernetes/kubeconfig/kubeconfig
-        - -logtostderr
-        - -v
-        - "4"
-        - -cluster-dns
-        - 169.254.20.10
-        - -internal-listen-address
-        - 0.0.0.0:8085
+        - -endpoint
+        - https://apiserver-external.cluster-de-test-01.svc.cluster.local.:30000/healthz
+        - -insecure
+        - -retries
+        - "100"
+        - -retry-wait
+        - "2"
+        - -timeout
+        - "1"
+        - -command
+        - '{"command":"/usr/local/bin/machine-controller","args":["-kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","-logtostderr","-v","4","-cluster-dns","169.254.20.10","-internal-listen-address","0.0.0.0:8085"]}'
         command:
-        - /usr/local/bin/machine-controller
+        - /http-prober-bin/http-prober
         env:
         - name: AWS_ACCESS_KEY_ID
           value: aws-access-key-id
@@ -66,30 +68,26 @@ spec:
         - mountPath: /etc/kubernetes/kubeconfig
           name: machinecontroller-kubeconfig
           readOnly: true
+        - mountPath: /http-prober-bin
+          name: http-prober-bin
       imagePullSecrets:
       - name: dockercfg
       initContainers:
-      - args:
-        - -endpoint
-        - https://apiserver-external.cluster-de-test-01.svc.cluster.local.:30000/healthz
-        - -insecure
-        - -retries
-        - "100"
-        - -retry-wait
-        - "2"
-        - -timeout
-        - "1"
-        command:
+      - command:
+        - /bin/cp
         - /usr/local/bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.1
-        imagePullPolicy: IfNotPresent
-        name: apiserver-running
+        - /http-prober-bin/http-prober
+        image: quay.io/kubermatic/http-prober:v0.2-dev0
+        name: copy-http-prober
         resources: {}
-        terminationMessagePath: /dev/termination-log
-        terminationMessagePolicy: File
+        volumeMounts:
+        - mountPath: /http-prober-bin
+          name: http-prober-bin
       volumes:
       - name: machinecontroller-kubeconfig
         secret:
           defaultMode: 292
           secretName: machinecontroller-kubeconfig
+      - emptyDir: {}
+        name: http-prober-bin
 status: {}

--- a/api/pkg/resources/test/fixtures/deployment-aws-1.12.0-machine-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-aws-1.12.0-machine-controller.yaml
@@ -77,7 +77,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.2-dev0
+        image: quay.io/kubermatic/http-prober:v0.2
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/api/pkg/resources/test/fixtures/deployment-aws-1.12.0-metrics-server.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-aws-1.12.0-metrics-server.yaml
@@ -41,22 +41,19 @@ spec:
             weight: 10
       containers:
       - args:
-        - --kubeconfig
-        - /etc/kubernetes/kubeconfig/kubeconfig
-        - --authentication-kubeconfig
-        - /etc/kubernetes/kubeconfig/kubeconfig
-        - --authorization-kubeconfig
-        - /etc/kubernetes/kubeconfig/kubeconfig
-        - --kubelet-port
-        - "10250"
-        - --kubelet-insecure-tls
-        - --kubelet-preferred-address-types
-        - ExternalIP,InternalIP
-        - --v
+        - -endpoint
+        - https://apiserver-external.cluster-de-test-01.svc.cluster.local.:30000/healthz
+        - -insecure
+        - -retries
+        - "100"
+        - -retry-wait
+        - "2"
+        - -timeout
         - "1"
-        - --logtostderr
+        - -command
+        - '{"command":"/metrics-server","args":["--kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","--authentication-kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","--authorization-kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","--kubelet-port","10250","--kubelet-insecure-tls","--kubelet-preferred-address-types","ExternalIP,InternalIP","--v","1","--logtostderr"]}'
         command:
-        - /metrics-server
+        - /http-prober-bin/http-prober
         image: gcr.io/google_containers/metrics-server-amd64:v0.3.2
         name: metrics-server
         resources:
@@ -70,6 +67,8 @@ spec:
         - mountPath: /etc/kubernetes/kubeconfig
           name: metrics-server
           readOnly: true
+        - mountPath: /http-prober-bin
+          name: http-prober-bin
       - args:
         - --client
         - --proto
@@ -158,24 +157,16 @@ spec:
       imagePullSecrets:
       - name: dockercfg
       initContainers:
-      - args:
-        - -endpoint
-        - https://apiserver-external.cluster-de-test-01.svc.cluster.local.:30000/healthz
-        - -insecure
-        - -retries
-        - "100"
-        - -retry-wait
-        - "2"
-        - -timeout
-        - "1"
-        command:
+      - command:
+        - /bin/cp
         - /usr/local/bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.1
-        imagePullPolicy: IfNotPresent
-        name: apiserver-running
+        - /http-prober-bin/http-prober
+        image: quay.io/kubermatic/http-prober:v0.2-dev0
+        name: copy-http-prober
         resources: {}
-        terminationMessagePath: /dev/termination-log
-        terminationMessagePolicy: File
+        volumeMounts:
+        - mountPath: /http-prober-bin
+          name: http-prober-bin
       volumes:
       - name: metrics-server
         secret:
@@ -189,4 +180,6 @@ spec:
         secret:
           defaultMode: 292
           secretName: kubeletdnatcontroller-kubeconfig
+      - emptyDir: {}
+        name: http-prober-bin
 status: {}

--- a/api/pkg/resources/test/fixtures/deployment-aws-1.12.0-metrics-server.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-aws-1.12.0-metrics-server.yaml
@@ -161,7 +161,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.2-dev0
+        image: quay.io/kubermatic/http-prober:v0.2
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/api/pkg/resources/test/fixtures/deployment-aws-1.12.0-scheduler.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-aws-1.12.0-scheduler.yaml
@@ -168,7 +168,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.2-dev0
+        image: quay.io/kubermatic/http-prober:v0.2
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/api/pkg/resources/test/fixtures/deployment-aws-1.12.0-scheduler.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-aws-1.12.0-scheduler.yaml
@@ -100,13 +100,19 @@ spec:
           name: openvpn-client-certificates
           readOnly: true
       - args:
-        - --kubeconfig
-        - /etc/kubernetes/kubeconfig/kubeconfig
-        - --feature-gates
-        - ScheduleDaemonSetPods=false
+        - -endpoint
+        - https://apiserver-external.cluster-de-test-01.svc.cluster.local.:30000/healthz
+        - -insecure
+        - -retries
+        - "100"
+        - -retry-wait
+        - "2"
+        - -timeout
+        - "1"
+        - -command
+        - '{"command":"/hyperkube","args":["kube-scheduler","--kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","--feature-gates","ScheduleDaemonSetPods=false"]}'
         command:
-        - /hyperkube
-        - kube-scheduler
+        - /http-prober-bin/http-prober
         image: gcr.io/google_containers/hyperkube-amd64:v1.12.0
         livenessProbe:
           failureThreshold: 8
@@ -142,6 +148,8 @@ spec:
         - mountPath: /etc/kubernetes/pki/ca
           name: ca
           readOnly: true
+        - mountPath: /http-prober-bin
+          name: http-prober-bin
       dnsConfig:
         nameservers:
         - 192.0.2.14
@@ -156,24 +164,16 @@ spec:
       imagePullSecrets:
       - name: dockercfg
       initContainers:
-      - args:
-        - -endpoint
-        - https://apiserver-external.cluster-de-test-01.svc.cluster.local.:30000/healthz
-        - -insecure
-        - -retries
-        - "100"
-        - -retry-wait
-        - "2"
-        - -timeout
-        - "1"
-        command:
+      - command:
+        - /bin/cp
         - /usr/local/bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.1
-        imagePullPolicy: IfNotPresent
-        name: apiserver-running
+        - /http-prober-bin/http-prober
+        image: quay.io/kubermatic/http-prober:v0.2-dev0
+        name: copy-http-prober
         resources: {}
-        terminationMessagePath: /dev/termination-log
-        terminationMessagePolicy: File
+        volumeMounts:
+        - mountPath: /http-prober-bin
+          name: http-prober-bin
       volumes:
       - name: openvpn-client-certificates
         secret:
@@ -190,4 +190,6 @@ spec:
         secret:
           defaultMode: 256
           secretName: scheduler-kubeconfig
+      - emptyDir: {}
+        name: http-prober-bin
 status: {}

--- a/api/pkg/resources/test/fixtures/deployment-aws-1.12.0-usercluster-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-aws-1.12.0-usercluster-controller.yaml
@@ -85,7 +85,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.2-dev0
+        image: quay.io/kubermatic/http-prober:v0.2
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/api/pkg/resources/test/fixtures/deployment-aws-1.12.0-usercluster-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-aws-1.12.0-usercluster-controller.yaml
@@ -29,32 +29,19 @@ spec:
     spec:
       containers:
       - args:
-        - -kubeconfig
-        - /etc/kubernetes/kubeconfig/kubeconfig
-        - -metrics-listen-address
-        - 0.0.0.0:8085
-        - -health-listen-address
-        - 0.0.0.0:8086
-        - -namespace
-        - $(NAMESPACE)
-        - -ca-cert
-        - /etc/kubernetes/pki/ca/ca.crt
-        - -cluster-url
-        - ""
-        - -openvpn-server-port
-        - "30003"
-        - -overwrite-registry
-        - ""
-        - -openshift=false
-        - -openvpn-ca-cert-file=/etc/kubernetes/pki/openvpn/ca.crt
-        - -openvpn-ca-key-file=/etc/kubernetes/pki/openvpn/ca.key
-        - -logtostderr
-        - -v
+        - -endpoint
+        - https://apiserver-external.cluster-de-test-01.svc.cluster.local.:30000/healthz
+        - -insecure
+        - -retries
+        - "100"
+        - -retry-wait
         - "2"
-        - --ipam-controller-network
-        - 192.168.1.1/24,192.168.1.1,8.8.8.8
+        - -timeout
+        - "1"
+        - -command
+        - '{"command":"/usr/local/bin/user-cluster-controller-manager","args":["-kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","-metrics-listen-address","0.0.0.0:8085","-health-listen-address","0.0.0.0:8086","-namespace","$(NAMESPACE)","-ca-cert","/etc/kubernetes/pki/ca/ca.crt","-cluster-url","","-openvpn-server-port","30003","-overwrite-registry","","-openshift=false","-openvpn-ca-cert-file=/etc/kubernetes/pki/openvpn/ca.crt","-openvpn-ca-key-file=/etc/kubernetes/pki/openvpn/ca.key","-logtostderr","-v","2","--ipam-controller-network","192.168.1.1/24,192.168.1.1,8.8.8.8"]}'
         command:
-        - /usr/local/bin/user-cluster-controller-manager
+        - /http-prober-bin/http-prober
         env:
         - name: NAMESPACE
           valueFrom:
@@ -89,27 +76,21 @@ spec:
         - mountPath: /etc/kubernetes/pki/openvpn
           name: openvpn-ca
           readOnly: true
+        - mountPath: /http-prober-bin
+          name: http-prober-bin
       imagePullSecrets:
       - name: dockercfg
       initContainers:
-      - args:
-        - -endpoint
-        - https://apiserver-external.cluster-de-test-01.svc.cluster.local.:30000/healthz
-        - -insecure
-        - -retries
-        - "100"
-        - -retry-wait
-        - "2"
-        - -timeout
-        - "1"
-        command:
+      - command:
+        - /bin/cp
         - /usr/local/bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.1
-        imagePullPolicy: IfNotPresent
-        name: apiserver-running
+        - /http-prober-bin/http-prober
+        image: quay.io/kubermatic/http-prober:v0.2-dev0
+        name: copy-http-prober
         resources: {}
-        terminationMessagePath: /dev/termination-log
-        terminationMessagePolicy: File
+        volumeMounts:
+        - mountPath: /http-prober-bin
+          name: http-prober-bin
       volumes:
       - name: internal-admin-kubeconfig
         secret:
@@ -126,4 +107,6 @@ spec:
         secret:
           defaultMode: 292
           secretName: openvpn-ca
+      - emptyDir: {}
+        name: http-prober-bin
 status: {}

--- a/api/pkg/resources/test/fixtures/deployment-aws-1.13.0-controller-manager.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-aws-1.13.0-controller-manager.yaml
@@ -185,7 +185,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.2-dev0
+        image: quay.io/kubermatic/http-prober:v0.2
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/api/pkg/resources/test/fixtures/deployment-aws-1.13.0-controller-manager.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-aws-1.13.0-controller-manager.yaml
@@ -102,42 +102,19 @@ spec:
           name: openvpn-client-certificates
           readOnly: true
       - args:
-        - --kubeconfig
-        - /etc/kubernetes/kubeconfig/kubeconfig
-        - --service-account-private-key-file
-        - /etc/kubernetes/service-account-key/sa.key
-        - --root-ca-file
-        - /etc/kubernetes/pki/ca/ca.crt
-        - --cluster-signing-cert-file
-        - /etc/kubernetes/pki/ca/ca.crt
-        - --cluster-signing-key-file
-        - /etc/kubernetes/pki/ca/ca.key
-        - --cluster-cidr
-        - 172.25.0.0/16
-        - --allocate-node-cidrs=true
-        - --controllers
-        - '*,bootstrapsigner,tokencleaner'
-        - --use-service-account-credentials=true
-        - --feature-gates
-        - RotateKubeletClientCertificate=true,RotateKubeletServerCertificate=true,ScheduleDaemonSetPods=false
-        - --cloud-provider
-        - aws
-        - --cloud-config
-        - /etc/kubernetes/cloud/config
-        - --configure-cloud-routes=false
-        - --authentication-kubeconfig
-        - /etc/kubernetes/kubeconfig/kubeconfig
-        - --client-ca-file
-        - /etc/kubernetes/pki/ca/ca.crt
-        - --authentication-kubeconfig
-        - /etc/kubernetes/kubeconfig/kubeconfig
-        - --authorization-kubeconfig
-        - /etc/kubernetes/kubeconfig/kubeconfig
-        - --port
-        - "0"
+        - -endpoint
+        - https://apiserver-external.cluster-de-test-01.svc.cluster.local.:30000/healthz
+        - -insecure
+        - -retries
+        - "100"
+        - -retry-wait
+        - "2"
+        - -timeout
+        - "1"
+        - -command
+        - '{"command":"/hyperkube","args":["kube-controller-manager","--kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","--service-account-private-key-file","/etc/kubernetes/service-account-key/sa.key","--root-ca-file","/etc/kubernetes/pki/ca/ca.crt","--cluster-signing-cert-file","/etc/kubernetes/pki/ca/ca.crt","--cluster-signing-key-file","/etc/kubernetes/pki/ca/ca.key","--cluster-cidr","172.25.0.0/16","--allocate-node-cidrs=true","--controllers","*,bootstrapsigner,tokencleaner","--use-service-account-credentials=true","--feature-gates","RotateKubeletClientCertificate=true,RotateKubeletServerCertificate=true,ScheduleDaemonSetPods=false","--cloud-provider","aws","--cloud-config","/etc/kubernetes/cloud/config","--configure-cloud-routes=false","--authentication-kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","--client-ca-file","/etc/kubernetes/pki/ca/ca.crt","--authentication-kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","--authorization-kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","--port","0"]}'
         command:
-        - /hyperkube
-        - kube-controller-manager
+        - /http-prober-bin/http-prober
         env:
         - name: AWS_ACCESS_KEY_ID
           value: aws-access-key-id
@@ -188,6 +165,8 @@ spec:
         - mountPath: /etc/kubernetes/kubeconfig
           name: controllermanager-kubeconfig
           readOnly: true
+        - mountPath: /http-prober-bin
+          name: http-prober-bin
       dnsConfig:
         nameservers:
         - 192.0.2.14
@@ -202,24 +181,16 @@ spec:
       imagePullSecrets:
       - name: dockercfg
       initContainers:
-      - args:
-        - -endpoint
-        - https://apiserver-external.cluster-de-test-01.svc.cluster.local.:30000/healthz
-        - -insecure
-        - -retries
-        - "100"
-        - -retry-wait
-        - "2"
-        - -timeout
-        - "1"
-        command:
+      - command:
+        - /bin/cp
         - /usr/local/bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.1
-        imagePullPolicy: IfNotPresent
-        name: apiserver-running
+        - /http-prober-bin/http-prober
+        image: quay.io/kubermatic/http-prober:v0.2-dev0
+        name: copy-http-prober
         resources: {}
-        terminationMessagePath: /dev/termination-log
-        terminationMessagePolicy: File
+        volumeMounts:
+        - mountPath: /http-prober-bin
+          name: http-prober-bin
       volumes:
       - name: ca
         secret:
@@ -241,4 +212,6 @@ spec:
         secret:
           defaultMode: 256
           secretName: controllermanager-kubeconfig
+      - emptyDir: {}
+        name: http-prober-bin
 status: {}

--- a/api/pkg/resources/test/fixtures/deployment-aws-1.13.0-kube-state-metrics.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-aws-1.13.0-kube-state-metrics.yaml
@@ -21,14 +21,19 @@ spec:
     spec:
       containers:
       - args:
-        - --kubeconfig
-        - /etc/kubernetes/kubeconfig/kubeconfig
-        - --port
-        - "8080"
-        - --telemetry-port
-        - "8081"
+        - -endpoint
+        - https://apiserver-external.cluster-de-test-01.svc.cluster.local.:30000/healthz
+        - -insecure
+        - -retries
+        - "100"
+        - -retry-wait
+        - "2"
+        - -timeout
+        - "1"
+        - -command
+        - '{"command":"/kube-state-metrics","args":["--kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","--port","8080","--telemetry-port","8081"]}'
         command:
-        - /kube-state-metrics
+        - /http-prober-bin/http-prober
         image: quay.io/coreos/kube-state-metrics:v1.6.0
         name: kube-state-metrics
         ports:
@@ -58,30 +63,26 @@ spec:
         - mountPath: /etc/kubernetes/kubeconfig
           name: kube-state-metrics-kubeconfig
           readOnly: true
+        - mountPath: /http-prober-bin
+          name: http-prober-bin
       imagePullSecrets:
       - name: dockercfg
       initContainers:
-      - args:
-        - -endpoint
-        - https://apiserver-external.cluster-de-test-01.svc.cluster.local.:30000/healthz
-        - -insecure
-        - -retries
-        - "100"
-        - -retry-wait
-        - "2"
-        - -timeout
-        - "1"
-        command:
+      - command:
+        - /bin/cp
         - /usr/local/bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.1
-        imagePullPolicy: IfNotPresent
-        name: apiserver-running
+        - /http-prober-bin/http-prober
+        image: quay.io/kubermatic/http-prober:v0.2-dev0
+        name: copy-http-prober
         resources: {}
-        terminationMessagePath: /dev/termination-log
-        terminationMessagePolicy: File
+        volumeMounts:
+        - mountPath: /http-prober-bin
+          name: http-prober-bin
       volumes:
       - name: kube-state-metrics-kubeconfig
         secret:
           defaultMode: 256
           secretName: kube-state-metrics-kubeconfig
+      - emptyDir: {}
+        name: http-prober-bin
 status: {}

--- a/api/pkg/resources/test/fixtures/deployment-aws-1.13.0-kube-state-metrics.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-aws-1.13.0-kube-state-metrics.yaml
@@ -72,7 +72,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.2-dev0
+        image: quay.io/kubermatic/http-prober:v0.2
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/api/pkg/resources/test/fixtures/deployment-aws-1.13.0-machine-controller-webhook.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-aws-1.13.0-machine-controller-webhook.yaml
@@ -86,7 +86,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.2-dev0
+        image: quay.io/kubermatic/http-prober:v0.2
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/api/pkg/resources/test/fixtures/deployment-aws-1.13.0-machine-controller-webhook.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-aws-1.13.0-machine-controller-webhook.yaml
@@ -24,15 +24,19 @@ spec:
     spec:
       containers:
       - args:
-        - -kubeconfig
-        - /etc/kubernetes/kubeconfig/kubeconfig
-        - -logtostderr
-        - -v
-        - "4"
-        - -listen-address
-        - 0.0.0.0:9876
+        - -endpoint
+        - https://apiserver-external.cluster-de-test-01.svc.cluster.local.:30000/healthz
+        - -insecure
+        - -retries
+        - "100"
+        - -retry-wait
+        - "2"
+        - -timeout
+        - "1"
+        - -command
+        - '{"command":"/usr/local/bin/webhook","args":["-kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","-logtostderr","-v","4","-listen-address","0.0.0.0:9876"]}'
         command:
-        - /usr/local/bin/webhook
+        - /http-prober-bin/http-prober
         env:
         - name: AWS_ACCESS_KEY_ID
           value: aws-access-key-id
@@ -73,27 +77,21 @@ spec:
         - mountPath: /tmp/cert
           name: machinecontroller-webhook-serving-cert
           readOnly: true
+        - mountPath: /http-prober-bin
+          name: http-prober-bin
       imagePullSecrets:
       - name: dockercfg
       initContainers:
-      - args:
-        - -endpoint
-        - https://apiserver-external.cluster-de-test-01.svc.cluster.local.:30000/healthz
-        - -insecure
-        - -retries
-        - "100"
-        - -retry-wait
-        - "2"
-        - -timeout
-        - "1"
-        command:
+      - command:
+        - /bin/cp
         - /usr/local/bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.1
-        imagePullPolicy: IfNotPresent
-        name: apiserver-running
+        - /http-prober-bin/http-prober
+        image: quay.io/kubermatic/http-prober:v0.2-dev0
+        name: copy-http-prober
         resources: {}
-        terminationMessagePath: /dev/termination-log
-        terminationMessagePolicy: File
+        volumeMounts:
+        - mountPath: /http-prober-bin
+          name: http-prober-bin
       volumes:
       - name: machinecontroller-kubeconfig
         secret:
@@ -103,4 +101,6 @@ spec:
         secret:
           defaultMode: 292
           secretName: machinecontroller-webhook-serving-cert
+      - emptyDir: {}
+        name: http-prober-bin
 status: {}

--- a/api/pkg/resources/test/fixtures/deployment-aws-1.13.0-machine-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-aws-1.13.0-machine-controller.yaml
@@ -27,17 +27,19 @@ spec:
     spec:
       containers:
       - args:
-        - -kubeconfig
-        - /etc/kubernetes/kubeconfig/kubeconfig
-        - -logtostderr
-        - -v
-        - "4"
-        - -cluster-dns
-        - 169.254.20.10
-        - -internal-listen-address
-        - 0.0.0.0:8085
+        - -endpoint
+        - https://apiserver-external.cluster-de-test-01.svc.cluster.local.:30000/healthz
+        - -insecure
+        - -retries
+        - "100"
+        - -retry-wait
+        - "2"
+        - -timeout
+        - "1"
+        - -command
+        - '{"command":"/usr/local/bin/machine-controller","args":["-kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","-logtostderr","-v","4","-cluster-dns","169.254.20.10","-internal-listen-address","0.0.0.0:8085"]}'
         command:
-        - /usr/local/bin/machine-controller
+        - /http-prober-bin/http-prober
         env:
         - name: AWS_ACCESS_KEY_ID
           value: aws-access-key-id
@@ -66,30 +68,26 @@ spec:
         - mountPath: /etc/kubernetes/kubeconfig
           name: machinecontroller-kubeconfig
           readOnly: true
+        - mountPath: /http-prober-bin
+          name: http-prober-bin
       imagePullSecrets:
       - name: dockercfg
       initContainers:
-      - args:
-        - -endpoint
-        - https://apiserver-external.cluster-de-test-01.svc.cluster.local.:30000/healthz
-        - -insecure
-        - -retries
-        - "100"
-        - -retry-wait
-        - "2"
-        - -timeout
-        - "1"
-        command:
+      - command:
+        - /bin/cp
         - /usr/local/bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.1
-        imagePullPolicy: IfNotPresent
-        name: apiserver-running
+        - /http-prober-bin/http-prober
+        image: quay.io/kubermatic/http-prober:v0.2-dev0
+        name: copy-http-prober
         resources: {}
-        terminationMessagePath: /dev/termination-log
-        terminationMessagePolicy: File
+        volumeMounts:
+        - mountPath: /http-prober-bin
+          name: http-prober-bin
       volumes:
       - name: machinecontroller-kubeconfig
         secret:
           defaultMode: 292
           secretName: machinecontroller-kubeconfig
+      - emptyDir: {}
+        name: http-prober-bin
 status: {}

--- a/api/pkg/resources/test/fixtures/deployment-aws-1.13.0-machine-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-aws-1.13.0-machine-controller.yaml
@@ -77,7 +77,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.2-dev0
+        image: quay.io/kubermatic/http-prober:v0.2
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/api/pkg/resources/test/fixtures/deployment-aws-1.13.0-metrics-server.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-aws-1.13.0-metrics-server.yaml
@@ -41,22 +41,19 @@ spec:
             weight: 10
       containers:
       - args:
-        - --kubeconfig
-        - /etc/kubernetes/kubeconfig/kubeconfig
-        - --authentication-kubeconfig
-        - /etc/kubernetes/kubeconfig/kubeconfig
-        - --authorization-kubeconfig
-        - /etc/kubernetes/kubeconfig/kubeconfig
-        - --kubelet-port
-        - "10250"
-        - --kubelet-insecure-tls
-        - --kubelet-preferred-address-types
-        - ExternalIP,InternalIP
-        - --v
+        - -endpoint
+        - https://apiserver-external.cluster-de-test-01.svc.cluster.local.:30000/healthz
+        - -insecure
+        - -retries
+        - "100"
+        - -retry-wait
+        - "2"
+        - -timeout
         - "1"
-        - --logtostderr
+        - -command
+        - '{"command":"/metrics-server","args":["--kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","--authentication-kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","--authorization-kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","--kubelet-port","10250","--kubelet-insecure-tls","--kubelet-preferred-address-types","ExternalIP,InternalIP","--v","1","--logtostderr"]}'
         command:
-        - /metrics-server
+        - /http-prober-bin/http-prober
         image: gcr.io/google_containers/metrics-server-amd64:v0.3.2
         name: metrics-server
         resources:
@@ -70,6 +67,8 @@ spec:
         - mountPath: /etc/kubernetes/kubeconfig
           name: metrics-server
           readOnly: true
+        - mountPath: /http-prober-bin
+          name: http-prober-bin
       - args:
         - --client
         - --proto
@@ -158,24 +157,16 @@ spec:
       imagePullSecrets:
       - name: dockercfg
       initContainers:
-      - args:
-        - -endpoint
-        - https://apiserver-external.cluster-de-test-01.svc.cluster.local.:30000/healthz
-        - -insecure
-        - -retries
-        - "100"
-        - -retry-wait
-        - "2"
-        - -timeout
-        - "1"
-        command:
+      - command:
+        - /bin/cp
         - /usr/local/bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.1
-        imagePullPolicy: IfNotPresent
-        name: apiserver-running
+        - /http-prober-bin/http-prober
+        image: quay.io/kubermatic/http-prober:v0.2-dev0
+        name: copy-http-prober
         resources: {}
-        terminationMessagePath: /dev/termination-log
-        terminationMessagePolicy: File
+        volumeMounts:
+        - mountPath: /http-prober-bin
+          name: http-prober-bin
       volumes:
       - name: metrics-server
         secret:
@@ -189,4 +180,6 @@ spec:
         secret:
           defaultMode: 292
           secretName: kubeletdnatcontroller-kubeconfig
+      - emptyDir: {}
+        name: http-prober-bin
 status: {}

--- a/api/pkg/resources/test/fixtures/deployment-aws-1.13.0-metrics-server.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-aws-1.13.0-metrics-server.yaml
@@ -161,7 +161,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.2-dev0
+        image: quay.io/kubermatic/http-prober:v0.2
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/api/pkg/resources/test/fixtures/deployment-aws-1.13.0-scheduler.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-aws-1.13.0-scheduler.yaml
@@ -100,21 +100,19 @@ spec:
           name: openvpn-client-certificates
           readOnly: true
       - args:
-        - --kubeconfig
-        - /etc/kubernetes/kubeconfig/kubeconfig
-        - --authentication-kubeconfig
-        - /etc/kubernetes/kubeconfig/kubeconfig
-        - --authorization-kubeconfig
-        - /etc/kubernetes/kubeconfig/kubeconfig
-        - --client-ca-file
-        - /etc/kubernetes/pki/ca/ca.crt
-        - --port
-        - "0"
-        - --feature-gates
-        - ScheduleDaemonSetPods=false
+        - -endpoint
+        - https://apiserver-external.cluster-de-test-01.svc.cluster.local.:30000/healthz
+        - -insecure
+        - -retries
+        - "100"
+        - -retry-wait
+        - "2"
+        - -timeout
+        - "1"
+        - -command
+        - '{"command":"/hyperkube","args":["kube-scheduler","--kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","--authentication-kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","--authorization-kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","--client-ca-file","/etc/kubernetes/pki/ca/ca.crt","--port","0","--feature-gates","ScheduleDaemonSetPods=false"]}'
         command:
-        - /hyperkube
-        - kube-scheduler
+        - /http-prober-bin/http-prober
         image: gcr.io/google_containers/hyperkube-amd64:v1.13.0
         livenessProbe:
           failureThreshold: 8
@@ -150,6 +148,8 @@ spec:
         - mountPath: /etc/kubernetes/pki/ca
           name: ca
           readOnly: true
+        - mountPath: /http-prober-bin
+          name: http-prober-bin
       dnsConfig:
         nameservers:
         - 192.0.2.14
@@ -164,24 +164,16 @@ spec:
       imagePullSecrets:
       - name: dockercfg
       initContainers:
-      - args:
-        - -endpoint
-        - https://apiserver-external.cluster-de-test-01.svc.cluster.local.:30000/healthz
-        - -insecure
-        - -retries
-        - "100"
-        - -retry-wait
-        - "2"
-        - -timeout
-        - "1"
-        command:
+      - command:
+        - /bin/cp
         - /usr/local/bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.1
-        imagePullPolicy: IfNotPresent
-        name: apiserver-running
+        - /http-prober-bin/http-prober
+        image: quay.io/kubermatic/http-prober:v0.2-dev0
+        name: copy-http-prober
         resources: {}
-        terminationMessagePath: /dev/termination-log
-        terminationMessagePolicy: File
+        volumeMounts:
+        - mountPath: /http-prober-bin
+          name: http-prober-bin
       volumes:
       - name: openvpn-client-certificates
         secret:
@@ -198,4 +190,6 @@ spec:
         secret:
           defaultMode: 256
           secretName: scheduler-kubeconfig
+      - emptyDir: {}
+        name: http-prober-bin
 status: {}

--- a/api/pkg/resources/test/fixtures/deployment-aws-1.13.0-scheduler.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-aws-1.13.0-scheduler.yaml
@@ -168,7 +168,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.2-dev0
+        image: quay.io/kubermatic/http-prober:v0.2
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/api/pkg/resources/test/fixtures/deployment-aws-1.13.0-usercluster-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-aws-1.13.0-usercluster-controller.yaml
@@ -85,7 +85,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.2-dev0
+        image: quay.io/kubermatic/http-prober:v0.2
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/api/pkg/resources/test/fixtures/deployment-aws-1.13.0-usercluster-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-aws-1.13.0-usercluster-controller.yaml
@@ -29,32 +29,19 @@ spec:
     spec:
       containers:
       - args:
-        - -kubeconfig
-        - /etc/kubernetes/kubeconfig/kubeconfig
-        - -metrics-listen-address
-        - 0.0.0.0:8085
-        - -health-listen-address
-        - 0.0.0.0:8086
-        - -namespace
-        - $(NAMESPACE)
-        - -ca-cert
-        - /etc/kubernetes/pki/ca/ca.crt
-        - -cluster-url
-        - ""
-        - -openvpn-server-port
-        - "30003"
-        - -overwrite-registry
-        - ""
-        - -openshift=false
-        - -openvpn-ca-cert-file=/etc/kubernetes/pki/openvpn/ca.crt
-        - -openvpn-ca-key-file=/etc/kubernetes/pki/openvpn/ca.key
-        - -logtostderr
-        - -v
+        - -endpoint
+        - https://apiserver-external.cluster-de-test-01.svc.cluster.local.:30000/healthz
+        - -insecure
+        - -retries
+        - "100"
+        - -retry-wait
         - "2"
-        - --ipam-controller-network
-        - 192.168.1.1/24,192.168.1.1,8.8.8.8
+        - -timeout
+        - "1"
+        - -command
+        - '{"command":"/usr/local/bin/user-cluster-controller-manager","args":["-kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","-metrics-listen-address","0.0.0.0:8085","-health-listen-address","0.0.0.0:8086","-namespace","$(NAMESPACE)","-ca-cert","/etc/kubernetes/pki/ca/ca.crt","-cluster-url","","-openvpn-server-port","30003","-overwrite-registry","","-openshift=false","-openvpn-ca-cert-file=/etc/kubernetes/pki/openvpn/ca.crt","-openvpn-ca-key-file=/etc/kubernetes/pki/openvpn/ca.key","-logtostderr","-v","2","--ipam-controller-network","192.168.1.1/24,192.168.1.1,8.8.8.8"]}'
         command:
-        - /usr/local/bin/user-cluster-controller-manager
+        - /http-prober-bin/http-prober
         env:
         - name: NAMESPACE
           valueFrom:
@@ -89,27 +76,21 @@ spec:
         - mountPath: /etc/kubernetes/pki/openvpn
           name: openvpn-ca
           readOnly: true
+        - mountPath: /http-prober-bin
+          name: http-prober-bin
       imagePullSecrets:
       - name: dockercfg
       initContainers:
-      - args:
-        - -endpoint
-        - https://apiserver-external.cluster-de-test-01.svc.cluster.local.:30000/healthz
-        - -insecure
-        - -retries
-        - "100"
-        - -retry-wait
-        - "2"
-        - -timeout
-        - "1"
-        command:
+      - command:
+        - /bin/cp
         - /usr/local/bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.1
-        imagePullPolicy: IfNotPresent
-        name: apiserver-running
+        - /http-prober-bin/http-prober
+        image: quay.io/kubermatic/http-prober:v0.2-dev0
+        name: copy-http-prober
         resources: {}
-        terminationMessagePath: /dev/termination-log
-        terminationMessagePolicy: File
+        volumeMounts:
+        - mountPath: /http-prober-bin
+          name: http-prober-bin
       volumes:
       - name: internal-admin-kubeconfig
         secret:
@@ -126,4 +107,6 @@ spec:
         secret:
           defaultMode: 292
           secretName: openvpn-ca
+      - emptyDir: {}
+        name: http-prober-bin
 status: {}

--- a/api/pkg/resources/test/fixtures/deployment-azure-1.10.0-controller-manager.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-azure-1.10.0-controller-manager.yaml
@@ -176,7 +176,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.2-dev0
+        image: quay.io/kubermatic/http-prober:v0.2
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/api/pkg/resources/test/fixtures/deployment-azure-1.10.0-controller-manager.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-azure-1.10.0-controller-manager.yaml
@@ -102,32 +102,19 @@ spec:
           name: openvpn-client-certificates
           readOnly: true
       - args:
-        - --kubeconfig
-        - /etc/kubernetes/kubeconfig/kubeconfig
-        - --service-account-private-key-file
-        - /etc/kubernetes/service-account-key/sa.key
-        - --root-ca-file
-        - /etc/kubernetes/pki/ca/ca.crt
-        - --cluster-signing-cert-file
-        - /etc/kubernetes/pki/ca/ca.crt
-        - --cluster-signing-key-file
-        - /etc/kubernetes/pki/ca/ca.key
-        - --cluster-cidr
-        - 172.25.0.0/16
-        - --allocate-node-cidrs=true
-        - --controllers
-        - '*,bootstrapsigner,tokencleaner'
-        - --use-service-account-credentials=true
-        - --feature-gates
-        - RotateKubeletClientCertificate=true,RotateKubeletServerCertificate=true
-        - --cloud-provider
-        - azure
-        - --cloud-config
-        - /etc/kubernetes/cloud/config
-        - --configure-cloud-routes=false
+        - -endpoint
+        - https://apiserver-external.cluster-de-test-01.svc.cluster.local.:30000/healthz
+        - -insecure
+        - -retries
+        - "100"
+        - -retry-wait
+        - "2"
+        - -timeout
+        - "1"
+        - -command
+        - '{"command":"/hyperkube","args":["kube-controller-manager","--kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","--service-account-private-key-file","/etc/kubernetes/service-account-key/sa.key","--root-ca-file","/etc/kubernetes/pki/ca/ca.crt","--cluster-signing-cert-file","/etc/kubernetes/pki/ca/ca.crt","--cluster-signing-key-file","/etc/kubernetes/pki/ca/ca.key","--cluster-cidr","172.25.0.0/16","--allocate-node-cidrs=true","--controllers","*,bootstrapsigner,tokencleaner","--use-service-account-credentials=true","--feature-gates","RotateKubeletClientCertificate=true,RotateKubeletServerCertificate=true","--cloud-provider","azure","--cloud-config","/etc/kubernetes/cloud/config","--configure-cloud-routes=false"]}'
         command:
-        - /hyperkube
-        - kube-controller-manager
+        - /http-prober-bin/http-prober
         image: gcr.io/google_containers/hyperkube-amd64:v1.10.0
         livenessProbe:
           failureThreshold: 8
@@ -169,6 +156,8 @@ spec:
         - mountPath: /etc/kubernetes/kubeconfig
           name: controllermanager-kubeconfig
           readOnly: true
+        - mountPath: /http-prober-bin
+          name: http-prober-bin
       dnsConfig:
         nameservers:
         - 192.0.2.14
@@ -183,24 +172,16 @@ spec:
       imagePullSecrets:
       - name: dockercfg
       initContainers:
-      - args:
-        - -endpoint
-        - https://apiserver-external.cluster-de-test-01.svc.cluster.local.:30000/healthz
-        - -insecure
-        - -retries
-        - "100"
-        - -retry-wait
-        - "2"
-        - -timeout
-        - "1"
-        command:
+      - command:
+        - /bin/cp
         - /usr/local/bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.1
-        imagePullPolicy: IfNotPresent
-        name: apiserver-running
+        - /http-prober-bin/http-prober
+        image: quay.io/kubermatic/http-prober:v0.2-dev0
+        name: copy-http-prober
         resources: {}
-        terminationMessagePath: /dev/termination-log
-        terminationMessagePolicy: File
+        volumeMounts:
+        - mountPath: /http-prober-bin
+          name: http-prober-bin
       volumes:
       - name: ca
         secret:
@@ -222,4 +203,6 @@ spec:
         secret:
           defaultMode: 256
           secretName: controllermanager-kubeconfig
+      - emptyDir: {}
+        name: http-prober-bin
 status: {}

--- a/api/pkg/resources/test/fixtures/deployment-azure-1.10.0-kube-state-metrics.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-azure-1.10.0-kube-state-metrics.yaml
@@ -21,14 +21,19 @@ spec:
     spec:
       containers:
       - args:
-        - --kubeconfig
-        - /etc/kubernetes/kubeconfig/kubeconfig
-        - --port
-        - "8080"
-        - --telemetry-port
-        - "8081"
+        - -endpoint
+        - https://apiserver-external.cluster-de-test-01.svc.cluster.local.:30000/healthz
+        - -insecure
+        - -retries
+        - "100"
+        - -retry-wait
+        - "2"
+        - -timeout
+        - "1"
+        - -command
+        - '{"command":"/kube-state-metrics","args":["--kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","--port","8080","--telemetry-port","8081"]}'
         command:
-        - /kube-state-metrics
+        - /http-prober-bin/http-prober
         image: quay.io/coreos/kube-state-metrics:v1.6.0
         name: kube-state-metrics
         ports:
@@ -58,30 +63,26 @@ spec:
         - mountPath: /etc/kubernetes/kubeconfig
           name: kube-state-metrics-kubeconfig
           readOnly: true
+        - mountPath: /http-prober-bin
+          name: http-prober-bin
       imagePullSecrets:
       - name: dockercfg
       initContainers:
-      - args:
-        - -endpoint
-        - https://apiserver-external.cluster-de-test-01.svc.cluster.local.:30000/healthz
-        - -insecure
-        - -retries
-        - "100"
-        - -retry-wait
-        - "2"
-        - -timeout
-        - "1"
-        command:
+      - command:
+        - /bin/cp
         - /usr/local/bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.1
-        imagePullPolicy: IfNotPresent
-        name: apiserver-running
+        - /http-prober-bin/http-prober
+        image: quay.io/kubermatic/http-prober:v0.2-dev0
+        name: copy-http-prober
         resources: {}
-        terminationMessagePath: /dev/termination-log
-        terminationMessagePolicy: File
+        volumeMounts:
+        - mountPath: /http-prober-bin
+          name: http-prober-bin
       volumes:
       - name: kube-state-metrics-kubeconfig
         secret:
           defaultMode: 256
           secretName: kube-state-metrics-kubeconfig
+      - emptyDir: {}
+        name: http-prober-bin
 status: {}

--- a/api/pkg/resources/test/fixtures/deployment-azure-1.10.0-kube-state-metrics.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-azure-1.10.0-kube-state-metrics.yaml
@@ -72,7 +72,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.2-dev0
+        image: quay.io/kubermatic/http-prober:v0.2
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/api/pkg/resources/test/fixtures/deployment-azure-1.10.0-machine-controller-webhook.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-azure-1.10.0-machine-controller-webhook.yaml
@@ -36,13 +36,8 @@ spec:
         - -command
         - '{"command":"/usr/local/bin/webhook","args":["-kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","-logtostderr","-v","4","-listen-address","0.0.0.0:9876"]}'
         command:
-<<<<<<< HEAD
-        - /usr/local/bin/webhook
-        image: docker.io/kubermatic/machine-controller:v1.4.3
-=======
         - /http-prober-bin/http-prober
-        image: docker.io/kubermatic/machine-controller:v1.4.2
->>>>>>> Use wrapper instead of initContainer to check if apiserver is reachable (#3857)
+        image: docker.io/kubermatic/machine-controller:v1.4.3
         livenessProbe:
           failureThreshold: 8
           httpGet:

--- a/api/pkg/resources/test/fixtures/deployment-azure-1.10.0-machine-controller-webhook.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-azure-1.10.0-machine-controller-webhook.yaml
@@ -86,7 +86,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.2-dev0
+        image: quay.io/kubermatic/http-prober:v0.2
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/api/pkg/resources/test/fixtures/deployment-azure-1.10.0-machine-controller-webhook.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-azure-1.10.0-machine-controller-webhook.yaml
@@ -24,16 +24,25 @@ spec:
     spec:
       containers:
       - args:
-        - -kubeconfig
-        - /etc/kubernetes/kubeconfig/kubeconfig
-        - -logtostderr
-        - -v
-        - "4"
-        - -listen-address
-        - 0.0.0.0:9876
+        - -endpoint
+        - https://apiserver-external.cluster-de-test-01.svc.cluster.local.:30000/healthz
+        - -insecure
+        - -retries
+        - "100"
+        - -retry-wait
+        - "2"
+        - -timeout
+        - "1"
+        - -command
+        - '{"command":"/usr/local/bin/webhook","args":["-kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","-logtostderr","-v","4","-listen-address","0.0.0.0:9876"]}'
         command:
+<<<<<<< HEAD
         - /usr/local/bin/webhook
         image: docker.io/kubermatic/machine-controller:v1.4.3
+=======
+        - /http-prober-bin/http-prober
+        image: docker.io/kubermatic/machine-controller:v1.4.2
+>>>>>>> Use wrapper instead of initContainer to check if apiserver is reachable (#3857)
         livenessProbe:
           failureThreshold: 8
           httpGet:
@@ -68,27 +77,21 @@ spec:
         - mountPath: /tmp/cert
           name: machinecontroller-webhook-serving-cert
           readOnly: true
+        - mountPath: /http-prober-bin
+          name: http-prober-bin
       imagePullSecrets:
       - name: dockercfg
       initContainers:
-      - args:
-        - -endpoint
-        - https://apiserver-external.cluster-de-test-01.svc.cluster.local.:30000/healthz
-        - -insecure
-        - -retries
-        - "100"
-        - -retry-wait
-        - "2"
-        - -timeout
-        - "1"
-        command:
+      - command:
+        - /bin/cp
         - /usr/local/bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.1
-        imagePullPolicy: IfNotPresent
-        name: apiserver-running
+        - /http-prober-bin/http-prober
+        image: quay.io/kubermatic/http-prober:v0.2-dev0
+        name: copy-http-prober
         resources: {}
-        terminationMessagePath: /dev/termination-log
-        terminationMessagePolicy: File
+        volumeMounts:
+        - mountPath: /http-prober-bin
+          name: http-prober-bin
       volumes:
       - name: machinecontroller-kubeconfig
         secret:
@@ -98,4 +101,6 @@ spec:
         secret:
           defaultMode: 292
           secretName: machinecontroller-webhook-serving-cert
+      - emptyDir: {}
+        name: http-prober-bin
 status: {}

--- a/api/pkg/resources/test/fixtures/deployment-azure-1.10.0-machine-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-azure-1.10.0-machine-controller.yaml
@@ -77,7 +77,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.2-dev0
+        image: quay.io/kubermatic/http-prober:v0.2
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/api/pkg/resources/test/fixtures/deployment-azure-1.10.0-machine-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-azure-1.10.0-machine-controller.yaml
@@ -39,13 +39,8 @@ spec:
         - -command
         - '{"command":"/usr/local/bin/machine-controller","args":["-kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","-logtostderr","-v","4","-cluster-dns","169.254.20.10","-internal-listen-address","0.0.0.0:8085"]}'
         command:
-<<<<<<< HEAD
-        - /usr/local/bin/machine-controller
-        image: docker.io/kubermatic/machine-controller:v1.4.3
-=======
         - /http-prober-bin/http-prober
-        image: docker.io/kubermatic/machine-controller:v1.4.2
->>>>>>> Use wrapper instead of initContainer to check if apiserver is reachable (#3857)
+        image: docker.io/kubermatic/machine-controller:v1.4.3
         livenessProbe:
           failureThreshold: 3
           httpGet:

--- a/api/pkg/resources/test/fixtures/deployment-azure-1.10.0-machine-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-azure-1.10.0-machine-controller.yaml
@@ -27,18 +27,25 @@ spec:
     spec:
       containers:
       - args:
-        - -kubeconfig
-        - /etc/kubernetes/kubeconfig/kubeconfig
-        - -logtostderr
-        - -v
-        - "4"
-        - -cluster-dns
-        - 169.254.20.10
-        - -internal-listen-address
-        - 0.0.0.0:8085
+        - -endpoint
+        - https://apiserver-external.cluster-de-test-01.svc.cluster.local.:30000/healthz
+        - -insecure
+        - -retries
+        - "100"
+        - -retry-wait
+        - "2"
+        - -timeout
+        - "1"
+        - -command
+        - '{"command":"/usr/local/bin/machine-controller","args":["-kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","-logtostderr","-v","4","-cluster-dns","169.254.20.10","-internal-listen-address","0.0.0.0:8085"]}'
         command:
+<<<<<<< HEAD
         - /usr/local/bin/machine-controller
         image: docker.io/kubermatic/machine-controller:v1.4.3
+=======
+        - /http-prober-bin/http-prober
+        image: docker.io/kubermatic/machine-controller:v1.4.2
+>>>>>>> Use wrapper instead of initContainer to check if apiserver is reachable (#3857)
         livenessProbe:
           failureThreshold: 3
           httpGet:
@@ -61,30 +68,26 @@ spec:
         - mountPath: /etc/kubernetes/kubeconfig
           name: machinecontroller-kubeconfig
           readOnly: true
+        - mountPath: /http-prober-bin
+          name: http-prober-bin
       imagePullSecrets:
       - name: dockercfg
       initContainers:
-      - args:
-        - -endpoint
-        - https://apiserver-external.cluster-de-test-01.svc.cluster.local.:30000/healthz
-        - -insecure
-        - -retries
-        - "100"
-        - -retry-wait
-        - "2"
-        - -timeout
-        - "1"
-        command:
+      - command:
+        - /bin/cp
         - /usr/local/bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.1
-        imagePullPolicy: IfNotPresent
-        name: apiserver-running
+        - /http-prober-bin/http-prober
+        image: quay.io/kubermatic/http-prober:v0.2-dev0
+        name: copy-http-prober
         resources: {}
-        terminationMessagePath: /dev/termination-log
-        terminationMessagePolicy: File
+        volumeMounts:
+        - mountPath: /http-prober-bin
+          name: http-prober-bin
       volumes:
       - name: machinecontroller-kubeconfig
         secret:
           defaultMode: 292
           secretName: machinecontroller-kubeconfig
+      - emptyDir: {}
+        name: http-prober-bin
 status: {}

--- a/api/pkg/resources/test/fixtures/deployment-azure-1.10.0-metrics-server.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-azure-1.10.0-metrics-server.yaml
@@ -41,22 +41,19 @@ spec:
             weight: 10
       containers:
       - args:
-        - --kubeconfig
-        - /etc/kubernetes/kubeconfig/kubeconfig
-        - --authentication-kubeconfig
-        - /etc/kubernetes/kubeconfig/kubeconfig
-        - --authorization-kubeconfig
-        - /etc/kubernetes/kubeconfig/kubeconfig
-        - --kubelet-port
-        - "10250"
-        - --kubelet-insecure-tls
-        - --kubelet-preferred-address-types
-        - ExternalIP,InternalIP
-        - --v
+        - -endpoint
+        - https://apiserver-external.cluster-de-test-01.svc.cluster.local.:30000/healthz
+        - -insecure
+        - -retries
+        - "100"
+        - -retry-wait
+        - "2"
+        - -timeout
         - "1"
-        - --logtostderr
+        - -command
+        - '{"command":"/metrics-server","args":["--kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","--authentication-kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","--authorization-kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","--kubelet-port","10250","--kubelet-insecure-tls","--kubelet-preferred-address-types","ExternalIP,InternalIP","--v","1","--logtostderr"]}'
         command:
-        - /metrics-server
+        - /http-prober-bin/http-prober
         image: gcr.io/google_containers/metrics-server-amd64:v0.3.2
         name: metrics-server
         resources:
@@ -70,6 +67,8 @@ spec:
         - mountPath: /etc/kubernetes/kubeconfig
           name: metrics-server
           readOnly: true
+        - mountPath: /http-prober-bin
+          name: http-prober-bin
       - args:
         - --client
         - --proto
@@ -158,24 +157,16 @@ spec:
       imagePullSecrets:
       - name: dockercfg
       initContainers:
-      - args:
-        - -endpoint
-        - https://apiserver-external.cluster-de-test-01.svc.cluster.local.:30000/healthz
-        - -insecure
-        - -retries
-        - "100"
-        - -retry-wait
-        - "2"
-        - -timeout
-        - "1"
-        command:
+      - command:
+        - /bin/cp
         - /usr/local/bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.1
-        imagePullPolicy: IfNotPresent
-        name: apiserver-running
+        - /http-prober-bin/http-prober
+        image: quay.io/kubermatic/http-prober:v0.2-dev0
+        name: copy-http-prober
         resources: {}
-        terminationMessagePath: /dev/termination-log
-        terminationMessagePolicy: File
+        volumeMounts:
+        - mountPath: /http-prober-bin
+          name: http-prober-bin
       volumes:
       - name: metrics-server
         secret:
@@ -189,4 +180,6 @@ spec:
         secret:
           defaultMode: 292
           secretName: kubeletdnatcontroller-kubeconfig
+      - emptyDir: {}
+        name: http-prober-bin
 status: {}

--- a/api/pkg/resources/test/fixtures/deployment-azure-1.10.0-metrics-server.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-azure-1.10.0-metrics-server.yaml
@@ -161,7 +161,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.2-dev0
+        image: quay.io/kubermatic/http-prober:v0.2
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/api/pkg/resources/test/fixtures/deployment-azure-1.10.0-scheduler.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-azure-1.10.0-scheduler.yaml
@@ -100,11 +100,19 @@ spec:
           name: openvpn-client-certificates
           readOnly: true
       - args:
-        - --kubeconfig
-        - /etc/kubernetes/kubeconfig/kubeconfig
+        - -endpoint
+        - https://apiserver-external.cluster-de-test-01.svc.cluster.local.:30000/healthz
+        - -insecure
+        - -retries
+        - "100"
+        - -retry-wait
+        - "2"
+        - -timeout
+        - "1"
+        - -command
+        - '{"command":"/hyperkube","args":["kube-scheduler","--kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig"]}'
         command:
-        - /hyperkube
-        - kube-scheduler
+        - /http-prober-bin/http-prober
         image: gcr.io/google_containers/hyperkube-amd64:v1.10.0
         livenessProbe:
           failureThreshold: 8
@@ -140,6 +148,8 @@ spec:
         - mountPath: /etc/kubernetes/pki/ca
           name: ca
           readOnly: true
+        - mountPath: /http-prober-bin
+          name: http-prober-bin
       dnsConfig:
         nameservers:
         - 192.0.2.14
@@ -154,24 +164,16 @@ spec:
       imagePullSecrets:
       - name: dockercfg
       initContainers:
-      - args:
-        - -endpoint
-        - https://apiserver-external.cluster-de-test-01.svc.cluster.local.:30000/healthz
-        - -insecure
-        - -retries
-        - "100"
-        - -retry-wait
-        - "2"
-        - -timeout
-        - "1"
-        command:
+      - command:
+        - /bin/cp
         - /usr/local/bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.1
-        imagePullPolicy: IfNotPresent
-        name: apiserver-running
+        - /http-prober-bin/http-prober
+        image: quay.io/kubermatic/http-prober:v0.2-dev0
+        name: copy-http-prober
         resources: {}
-        terminationMessagePath: /dev/termination-log
-        terminationMessagePolicy: File
+        volumeMounts:
+        - mountPath: /http-prober-bin
+          name: http-prober-bin
       volumes:
       - name: openvpn-client-certificates
         secret:
@@ -188,4 +190,6 @@ spec:
         secret:
           defaultMode: 256
           secretName: scheduler-kubeconfig
+      - emptyDir: {}
+        name: http-prober-bin
 status: {}

--- a/api/pkg/resources/test/fixtures/deployment-azure-1.10.0-scheduler.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-azure-1.10.0-scheduler.yaml
@@ -168,7 +168,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.2-dev0
+        image: quay.io/kubermatic/http-prober:v0.2
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/api/pkg/resources/test/fixtures/deployment-azure-1.10.0-usercluster-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-azure-1.10.0-usercluster-controller.yaml
@@ -85,7 +85,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.2-dev0
+        image: quay.io/kubermatic/http-prober:v0.2
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/api/pkg/resources/test/fixtures/deployment-azure-1.10.0-usercluster-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-azure-1.10.0-usercluster-controller.yaml
@@ -29,32 +29,19 @@ spec:
     spec:
       containers:
       - args:
-        - -kubeconfig
-        - /etc/kubernetes/kubeconfig/kubeconfig
-        - -metrics-listen-address
-        - 0.0.0.0:8085
-        - -health-listen-address
-        - 0.0.0.0:8086
-        - -namespace
-        - $(NAMESPACE)
-        - -ca-cert
-        - /etc/kubernetes/pki/ca/ca.crt
-        - -cluster-url
-        - ""
-        - -openvpn-server-port
-        - "30003"
-        - -overwrite-registry
-        - ""
-        - -openshift=false
-        - -openvpn-ca-cert-file=/etc/kubernetes/pki/openvpn/ca.crt
-        - -openvpn-ca-key-file=/etc/kubernetes/pki/openvpn/ca.key
-        - -logtostderr
-        - -v
+        - -endpoint
+        - https://apiserver-external.cluster-de-test-01.svc.cluster.local.:30000/healthz
+        - -insecure
+        - -retries
+        - "100"
+        - -retry-wait
         - "2"
-        - --ipam-controller-network
-        - 192.168.1.1/24,192.168.1.1,8.8.8.8
+        - -timeout
+        - "1"
+        - -command
+        - '{"command":"/usr/local/bin/user-cluster-controller-manager","args":["-kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","-metrics-listen-address","0.0.0.0:8085","-health-listen-address","0.0.0.0:8086","-namespace","$(NAMESPACE)","-ca-cert","/etc/kubernetes/pki/ca/ca.crt","-cluster-url","","-openvpn-server-port","30003","-overwrite-registry","","-openshift=false","-openvpn-ca-cert-file=/etc/kubernetes/pki/openvpn/ca.crt","-openvpn-ca-key-file=/etc/kubernetes/pki/openvpn/ca.key","-logtostderr","-v","2","--ipam-controller-network","192.168.1.1/24,192.168.1.1,8.8.8.8"]}'
         command:
-        - /usr/local/bin/user-cluster-controller-manager
+        - /http-prober-bin/http-prober
         env:
         - name: NAMESPACE
           valueFrom:
@@ -89,27 +76,21 @@ spec:
         - mountPath: /etc/kubernetes/pki/openvpn
           name: openvpn-ca
           readOnly: true
+        - mountPath: /http-prober-bin
+          name: http-prober-bin
       imagePullSecrets:
       - name: dockercfg
       initContainers:
-      - args:
-        - -endpoint
-        - https://apiserver-external.cluster-de-test-01.svc.cluster.local.:30000/healthz
-        - -insecure
-        - -retries
-        - "100"
-        - -retry-wait
-        - "2"
-        - -timeout
-        - "1"
-        command:
+      - command:
+        - /bin/cp
         - /usr/local/bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.1
-        imagePullPolicy: IfNotPresent
-        name: apiserver-running
+        - /http-prober-bin/http-prober
+        image: quay.io/kubermatic/http-prober:v0.2-dev0
+        name: copy-http-prober
         resources: {}
-        terminationMessagePath: /dev/termination-log
-        terminationMessagePolicy: File
+        volumeMounts:
+        - mountPath: /http-prober-bin
+          name: http-prober-bin
       volumes:
       - name: internal-admin-kubeconfig
         secret:
@@ -126,4 +107,6 @@ spec:
         secret:
           defaultMode: 292
           secretName: openvpn-ca
+      - emptyDir: {}
+        name: http-prober-bin
 status: {}

--- a/api/pkg/resources/test/fixtures/deployment-azure-1.10.6-controller-manager.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-azure-1.10.6-controller-manager.yaml
@@ -176,7 +176,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.2-dev0
+        image: quay.io/kubermatic/http-prober:v0.2
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/api/pkg/resources/test/fixtures/deployment-azure-1.10.6-controller-manager.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-azure-1.10.6-controller-manager.yaml
@@ -102,32 +102,19 @@ spec:
           name: openvpn-client-certificates
           readOnly: true
       - args:
-        - --kubeconfig
-        - /etc/kubernetes/kubeconfig/kubeconfig
-        - --service-account-private-key-file
-        - /etc/kubernetes/service-account-key/sa.key
-        - --root-ca-file
-        - /etc/kubernetes/pki/ca/ca.crt
-        - --cluster-signing-cert-file
-        - /etc/kubernetes/pki/ca/ca.crt
-        - --cluster-signing-key-file
-        - /etc/kubernetes/pki/ca/ca.key
-        - --cluster-cidr
-        - 172.25.0.0/16
-        - --allocate-node-cidrs=true
-        - --controllers
-        - '*,bootstrapsigner,tokencleaner'
-        - --use-service-account-credentials=true
-        - --feature-gates
-        - RotateKubeletClientCertificate=true,RotateKubeletServerCertificate=true
-        - --cloud-provider
-        - azure
-        - --cloud-config
-        - /etc/kubernetes/cloud/config
-        - --configure-cloud-routes=false
+        - -endpoint
+        - https://apiserver-external.cluster-de-test-01.svc.cluster.local.:30000/healthz
+        - -insecure
+        - -retries
+        - "100"
+        - -retry-wait
+        - "2"
+        - -timeout
+        - "1"
+        - -command
+        - '{"command":"/hyperkube","args":["kube-controller-manager","--kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","--service-account-private-key-file","/etc/kubernetes/service-account-key/sa.key","--root-ca-file","/etc/kubernetes/pki/ca/ca.crt","--cluster-signing-cert-file","/etc/kubernetes/pki/ca/ca.crt","--cluster-signing-key-file","/etc/kubernetes/pki/ca/ca.key","--cluster-cidr","172.25.0.0/16","--allocate-node-cidrs=true","--controllers","*,bootstrapsigner,tokencleaner","--use-service-account-credentials=true","--feature-gates","RotateKubeletClientCertificate=true,RotateKubeletServerCertificate=true","--cloud-provider","azure","--cloud-config","/etc/kubernetes/cloud/config","--configure-cloud-routes=false"]}'
         command:
-        - /hyperkube
-        - kube-controller-manager
+        - /http-prober-bin/http-prober
         image: gcr.io/google_containers/hyperkube-amd64:v1.10.6
         livenessProbe:
           failureThreshold: 8
@@ -169,6 +156,8 @@ spec:
         - mountPath: /etc/kubernetes/kubeconfig
           name: controllermanager-kubeconfig
           readOnly: true
+        - mountPath: /http-prober-bin
+          name: http-prober-bin
       dnsConfig:
         nameservers:
         - 192.0.2.14
@@ -183,24 +172,16 @@ spec:
       imagePullSecrets:
       - name: dockercfg
       initContainers:
-      - args:
-        - -endpoint
-        - https://apiserver-external.cluster-de-test-01.svc.cluster.local.:30000/healthz
-        - -insecure
-        - -retries
-        - "100"
-        - -retry-wait
-        - "2"
-        - -timeout
-        - "1"
-        command:
+      - command:
+        - /bin/cp
         - /usr/local/bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.1
-        imagePullPolicy: IfNotPresent
-        name: apiserver-running
+        - /http-prober-bin/http-prober
+        image: quay.io/kubermatic/http-prober:v0.2-dev0
+        name: copy-http-prober
         resources: {}
-        terminationMessagePath: /dev/termination-log
-        terminationMessagePolicy: File
+        volumeMounts:
+        - mountPath: /http-prober-bin
+          name: http-prober-bin
       volumes:
       - name: ca
         secret:
@@ -222,4 +203,6 @@ spec:
         secret:
           defaultMode: 256
           secretName: controllermanager-kubeconfig
+      - emptyDir: {}
+        name: http-prober-bin
 status: {}

--- a/api/pkg/resources/test/fixtures/deployment-azure-1.10.6-kube-state-metrics.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-azure-1.10.6-kube-state-metrics.yaml
@@ -21,14 +21,19 @@ spec:
     spec:
       containers:
       - args:
-        - --kubeconfig
-        - /etc/kubernetes/kubeconfig/kubeconfig
-        - --port
-        - "8080"
-        - --telemetry-port
-        - "8081"
+        - -endpoint
+        - https://apiserver-external.cluster-de-test-01.svc.cluster.local.:30000/healthz
+        - -insecure
+        - -retries
+        - "100"
+        - -retry-wait
+        - "2"
+        - -timeout
+        - "1"
+        - -command
+        - '{"command":"/kube-state-metrics","args":["--kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","--port","8080","--telemetry-port","8081"]}'
         command:
-        - /kube-state-metrics
+        - /http-prober-bin/http-prober
         image: quay.io/coreos/kube-state-metrics:v1.6.0
         name: kube-state-metrics
         ports:
@@ -58,30 +63,26 @@ spec:
         - mountPath: /etc/kubernetes/kubeconfig
           name: kube-state-metrics-kubeconfig
           readOnly: true
+        - mountPath: /http-prober-bin
+          name: http-prober-bin
       imagePullSecrets:
       - name: dockercfg
       initContainers:
-      - args:
-        - -endpoint
-        - https://apiserver-external.cluster-de-test-01.svc.cluster.local.:30000/healthz
-        - -insecure
-        - -retries
-        - "100"
-        - -retry-wait
-        - "2"
-        - -timeout
-        - "1"
-        command:
+      - command:
+        - /bin/cp
         - /usr/local/bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.1
-        imagePullPolicy: IfNotPresent
-        name: apiserver-running
+        - /http-prober-bin/http-prober
+        image: quay.io/kubermatic/http-prober:v0.2-dev0
+        name: copy-http-prober
         resources: {}
-        terminationMessagePath: /dev/termination-log
-        terminationMessagePolicy: File
+        volumeMounts:
+        - mountPath: /http-prober-bin
+          name: http-prober-bin
       volumes:
       - name: kube-state-metrics-kubeconfig
         secret:
           defaultMode: 256
           secretName: kube-state-metrics-kubeconfig
+      - emptyDir: {}
+        name: http-prober-bin
 status: {}

--- a/api/pkg/resources/test/fixtures/deployment-azure-1.10.6-kube-state-metrics.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-azure-1.10.6-kube-state-metrics.yaml
@@ -72,7 +72,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.2-dev0
+        image: quay.io/kubermatic/http-prober:v0.2
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/api/pkg/resources/test/fixtures/deployment-azure-1.10.6-machine-controller-webhook.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-azure-1.10.6-machine-controller-webhook.yaml
@@ -36,13 +36,8 @@ spec:
         - -command
         - '{"command":"/usr/local/bin/webhook","args":["-kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","-logtostderr","-v","4","-listen-address","0.0.0.0:9876"]}'
         command:
-<<<<<<< HEAD
-        - /usr/local/bin/webhook
-        image: docker.io/kubermatic/machine-controller:v1.4.3
-=======
         - /http-prober-bin/http-prober
-        image: docker.io/kubermatic/machine-controller:v1.4.2
->>>>>>> Use wrapper instead of initContainer to check if apiserver is reachable (#3857)
+        image: docker.io/kubermatic/machine-controller:v1.4.3
         livenessProbe:
           failureThreshold: 8
           httpGet:

--- a/api/pkg/resources/test/fixtures/deployment-azure-1.10.6-machine-controller-webhook.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-azure-1.10.6-machine-controller-webhook.yaml
@@ -86,7 +86,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.2-dev0
+        image: quay.io/kubermatic/http-prober:v0.2
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/api/pkg/resources/test/fixtures/deployment-azure-1.10.6-machine-controller-webhook.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-azure-1.10.6-machine-controller-webhook.yaml
@@ -24,16 +24,25 @@ spec:
     spec:
       containers:
       - args:
-        - -kubeconfig
-        - /etc/kubernetes/kubeconfig/kubeconfig
-        - -logtostderr
-        - -v
-        - "4"
-        - -listen-address
-        - 0.0.0.0:9876
+        - -endpoint
+        - https://apiserver-external.cluster-de-test-01.svc.cluster.local.:30000/healthz
+        - -insecure
+        - -retries
+        - "100"
+        - -retry-wait
+        - "2"
+        - -timeout
+        - "1"
+        - -command
+        - '{"command":"/usr/local/bin/webhook","args":["-kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","-logtostderr","-v","4","-listen-address","0.0.0.0:9876"]}'
         command:
+<<<<<<< HEAD
         - /usr/local/bin/webhook
         image: docker.io/kubermatic/machine-controller:v1.4.3
+=======
+        - /http-prober-bin/http-prober
+        image: docker.io/kubermatic/machine-controller:v1.4.2
+>>>>>>> Use wrapper instead of initContainer to check if apiserver is reachable (#3857)
         livenessProbe:
           failureThreshold: 8
           httpGet:
@@ -68,27 +77,21 @@ spec:
         - mountPath: /tmp/cert
           name: machinecontroller-webhook-serving-cert
           readOnly: true
+        - mountPath: /http-prober-bin
+          name: http-prober-bin
       imagePullSecrets:
       - name: dockercfg
       initContainers:
-      - args:
-        - -endpoint
-        - https://apiserver-external.cluster-de-test-01.svc.cluster.local.:30000/healthz
-        - -insecure
-        - -retries
-        - "100"
-        - -retry-wait
-        - "2"
-        - -timeout
-        - "1"
-        command:
+      - command:
+        - /bin/cp
         - /usr/local/bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.1
-        imagePullPolicy: IfNotPresent
-        name: apiserver-running
+        - /http-prober-bin/http-prober
+        image: quay.io/kubermatic/http-prober:v0.2-dev0
+        name: copy-http-prober
         resources: {}
-        terminationMessagePath: /dev/termination-log
-        terminationMessagePolicy: File
+        volumeMounts:
+        - mountPath: /http-prober-bin
+          name: http-prober-bin
       volumes:
       - name: machinecontroller-kubeconfig
         secret:
@@ -98,4 +101,6 @@ spec:
         secret:
           defaultMode: 292
           secretName: machinecontroller-webhook-serving-cert
+      - emptyDir: {}
+        name: http-prober-bin
 status: {}

--- a/api/pkg/resources/test/fixtures/deployment-azure-1.10.6-machine-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-azure-1.10.6-machine-controller.yaml
@@ -77,7 +77,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.2-dev0
+        image: quay.io/kubermatic/http-prober:v0.2
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/api/pkg/resources/test/fixtures/deployment-azure-1.10.6-machine-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-azure-1.10.6-machine-controller.yaml
@@ -39,13 +39,8 @@ spec:
         - -command
         - '{"command":"/usr/local/bin/machine-controller","args":["-kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","-logtostderr","-v","4","-cluster-dns","169.254.20.10","-internal-listen-address","0.0.0.0:8085"]}'
         command:
-<<<<<<< HEAD
-        - /usr/local/bin/machine-controller
-        image: docker.io/kubermatic/machine-controller:v1.4.3
-=======
         - /http-prober-bin/http-prober
-        image: docker.io/kubermatic/machine-controller:v1.4.2
->>>>>>> Use wrapper instead of initContainer to check if apiserver is reachable (#3857)
+        image: docker.io/kubermatic/machine-controller:v1.4.3
         livenessProbe:
           failureThreshold: 3
           httpGet:

--- a/api/pkg/resources/test/fixtures/deployment-azure-1.10.6-machine-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-azure-1.10.6-machine-controller.yaml
@@ -27,18 +27,25 @@ spec:
     spec:
       containers:
       - args:
-        - -kubeconfig
-        - /etc/kubernetes/kubeconfig/kubeconfig
-        - -logtostderr
-        - -v
-        - "4"
-        - -cluster-dns
-        - 169.254.20.10
-        - -internal-listen-address
-        - 0.0.0.0:8085
+        - -endpoint
+        - https://apiserver-external.cluster-de-test-01.svc.cluster.local.:30000/healthz
+        - -insecure
+        - -retries
+        - "100"
+        - -retry-wait
+        - "2"
+        - -timeout
+        - "1"
+        - -command
+        - '{"command":"/usr/local/bin/machine-controller","args":["-kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","-logtostderr","-v","4","-cluster-dns","169.254.20.10","-internal-listen-address","0.0.0.0:8085"]}'
         command:
+<<<<<<< HEAD
         - /usr/local/bin/machine-controller
         image: docker.io/kubermatic/machine-controller:v1.4.3
+=======
+        - /http-prober-bin/http-prober
+        image: docker.io/kubermatic/machine-controller:v1.4.2
+>>>>>>> Use wrapper instead of initContainer to check if apiserver is reachable (#3857)
         livenessProbe:
           failureThreshold: 3
           httpGet:
@@ -61,30 +68,26 @@ spec:
         - mountPath: /etc/kubernetes/kubeconfig
           name: machinecontroller-kubeconfig
           readOnly: true
+        - mountPath: /http-prober-bin
+          name: http-prober-bin
       imagePullSecrets:
       - name: dockercfg
       initContainers:
-      - args:
-        - -endpoint
-        - https://apiserver-external.cluster-de-test-01.svc.cluster.local.:30000/healthz
-        - -insecure
-        - -retries
-        - "100"
-        - -retry-wait
-        - "2"
-        - -timeout
-        - "1"
-        command:
+      - command:
+        - /bin/cp
         - /usr/local/bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.1
-        imagePullPolicy: IfNotPresent
-        name: apiserver-running
+        - /http-prober-bin/http-prober
+        image: quay.io/kubermatic/http-prober:v0.2-dev0
+        name: copy-http-prober
         resources: {}
-        terminationMessagePath: /dev/termination-log
-        terminationMessagePolicy: File
+        volumeMounts:
+        - mountPath: /http-prober-bin
+          name: http-prober-bin
       volumes:
       - name: machinecontroller-kubeconfig
         secret:
           defaultMode: 292
           secretName: machinecontroller-kubeconfig
+      - emptyDir: {}
+        name: http-prober-bin
 status: {}

--- a/api/pkg/resources/test/fixtures/deployment-azure-1.10.6-metrics-server.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-azure-1.10.6-metrics-server.yaml
@@ -41,22 +41,19 @@ spec:
             weight: 10
       containers:
       - args:
-        - --kubeconfig
-        - /etc/kubernetes/kubeconfig/kubeconfig
-        - --authentication-kubeconfig
-        - /etc/kubernetes/kubeconfig/kubeconfig
-        - --authorization-kubeconfig
-        - /etc/kubernetes/kubeconfig/kubeconfig
-        - --kubelet-port
-        - "10250"
-        - --kubelet-insecure-tls
-        - --kubelet-preferred-address-types
-        - ExternalIP,InternalIP
-        - --v
+        - -endpoint
+        - https://apiserver-external.cluster-de-test-01.svc.cluster.local.:30000/healthz
+        - -insecure
+        - -retries
+        - "100"
+        - -retry-wait
+        - "2"
+        - -timeout
         - "1"
-        - --logtostderr
+        - -command
+        - '{"command":"/metrics-server","args":["--kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","--authentication-kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","--authorization-kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","--kubelet-port","10250","--kubelet-insecure-tls","--kubelet-preferred-address-types","ExternalIP,InternalIP","--v","1","--logtostderr"]}'
         command:
-        - /metrics-server
+        - /http-prober-bin/http-prober
         image: gcr.io/google_containers/metrics-server-amd64:v0.3.2
         name: metrics-server
         resources:
@@ -70,6 +67,8 @@ spec:
         - mountPath: /etc/kubernetes/kubeconfig
           name: metrics-server
           readOnly: true
+        - mountPath: /http-prober-bin
+          name: http-prober-bin
       - args:
         - --client
         - --proto
@@ -158,24 +157,16 @@ spec:
       imagePullSecrets:
       - name: dockercfg
       initContainers:
-      - args:
-        - -endpoint
-        - https://apiserver-external.cluster-de-test-01.svc.cluster.local.:30000/healthz
-        - -insecure
-        - -retries
-        - "100"
-        - -retry-wait
-        - "2"
-        - -timeout
-        - "1"
-        command:
+      - command:
+        - /bin/cp
         - /usr/local/bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.1
-        imagePullPolicy: IfNotPresent
-        name: apiserver-running
+        - /http-prober-bin/http-prober
+        image: quay.io/kubermatic/http-prober:v0.2-dev0
+        name: copy-http-prober
         resources: {}
-        terminationMessagePath: /dev/termination-log
-        terminationMessagePolicy: File
+        volumeMounts:
+        - mountPath: /http-prober-bin
+          name: http-prober-bin
       volumes:
       - name: metrics-server
         secret:
@@ -189,4 +180,6 @@ spec:
         secret:
           defaultMode: 292
           secretName: kubeletdnatcontroller-kubeconfig
+      - emptyDir: {}
+        name: http-prober-bin
 status: {}

--- a/api/pkg/resources/test/fixtures/deployment-azure-1.10.6-metrics-server.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-azure-1.10.6-metrics-server.yaml
@@ -161,7 +161,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.2-dev0
+        image: quay.io/kubermatic/http-prober:v0.2
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/api/pkg/resources/test/fixtures/deployment-azure-1.10.6-scheduler.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-azure-1.10.6-scheduler.yaml
@@ -100,11 +100,19 @@ spec:
           name: openvpn-client-certificates
           readOnly: true
       - args:
-        - --kubeconfig
-        - /etc/kubernetes/kubeconfig/kubeconfig
+        - -endpoint
+        - https://apiserver-external.cluster-de-test-01.svc.cluster.local.:30000/healthz
+        - -insecure
+        - -retries
+        - "100"
+        - -retry-wait
+        - "2"
+        - -timeout
+        - "1"
+        - -command
+        - '{"command":"/hyperkube","args":["kube-scheduler","--kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig"]}'
         command:
-        - /hyperkube
-        - kube-scheduler
+        - /http-prober-bin/http-prober
         image: gcr.io/google_containers/hyperkube-amd64:v1.10.6
         livenessProbe:
           failureThreshold: 8
@@ -140,6 +148,8 @@ spec:
         - mountPath: /etc/kubernetes/pki/ca
           name: ca
           readOnly: true
+        - mountPath: /http-prober-bin
+          name: http-prober-bin
       dnsConfig:
         nameservers:
         - 192.0.2.14
@@ -154,24 +164,16 @@ spec:
       imagePullSecrets:
       - name: dockercfg
       initContainers:
-      - args:
-        - -endpoint
-        - https://apiserver-external.cluster-de-test-01.svc.cluster.local.:30000/healthz
-        - -insecure
-        - -retries
-        - "100"
-        - -retry-wait
-        - "2"
-        - -timeout
-        - "1"
-        command:
+      - command:
+        - /bin/cp
         - /usr/local/bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.1
-        imagePullPolicy: IfNotPresent
-        name: apiserver-running
+        - /http-prober-bin/http-prober
+        image: quay.io/kubermatic/http-prober:v0.2-dev0
+        name: copy-http-prober
         resources: {}
-        terminationMessagePath: /dev/termination-log
-        terminationMessagePolicy: File
+        volumeMounts:
+        - mountPath: /http-prober-bin
+          name: http-prober-bin
       volumes:
       - name: openvpn-client-certificates
         secret:
@@ -188,4 +190,6 @@ spec:
         secret:
           defaultMode: 256
           secretName: scheduler-kubeconfig
+      - emptyDir: {}
+        name: http-prober-bin
 status: {}

--- a/api/pkg/resources/test/fixtures/deployment-azure-1.10.6-scheduler.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-azure-1.10.6-scheduler.yaml
@@ -168,7 +168,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.2-dev0
+        image: quay.io/kubermatic/http-prober:v0.2
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/api/pkg/resources/test/fixtures/deployment-azure-1.10.6-usercluster-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-azure-1.10.6-usercluster-controller.yaml
@@ -85,7 +85,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.2-dev0
+        image: quay.io/kubermatic/http-prober:v0.2
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/api/pkg/resources/test/fixtures/deployment-azure-1.10.6-usercluster-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-azure-1.10.6-usercluster-controller.yaml
@@ -29,32 +29,19 @@ spec:
     spec:
       containers:
       - args:
-        - -kubeconfig
-        - /etc/kubernetes/kubeconfig/kubeconfig
-        - -metrics-listen-address
-        - 0.0.0.0:8085
-        - -health-listen-address
-        - 0.0.0.0:8086
-        - -namespace
-        - $(NAMESPACE)
-        - -ca-cert
-        - /etc/kubernetes/pki/ca/ca.crt
-        - -cluster-url
-        - ""
-        - -openvpn-server-port
-        - "30003"
-        - -overwrite-registry
-        - ""
-        - -openshift=false
-        - -openvpn-ca-cert-file=/etc/kubernetes/pki/openvpn/ca.crt
-        - -openvpn-ca-key-file=/etc/kubernetes/pki/openvpn/ca.key
-        - -logtostderr
-        - -v
+        - -endpoint
+        - https://apiserver-external.cluster-de-test-01.svc.cluster.local.:30000/healthz
+        - -insecure
+        - -retries
+        - "100"
+        - -retry-wait
         - "2"
-        - --ipam-controller-network
-        - 192.168.1.1/24,192.168.1.1,8.8.8.8
+        - -timeout
+        - "1"
+        - -command
+        - '{"command":"/usr/local/bin/user-cluster-controller-manager","args":["-kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","-metrics-listen-address","0.0.0.0:8085","-health-listen-address","0.0.0.0:8086","-namespace","$(NAMESPACE)","-ca-cert","/etc/kubernetes/pki/ca/ca.crt","-cluster-url","","-openvpn-server-port","30003","-overwrite-registry","","-openshift=false","-openvpn-ca-cert-file=/etc/kubernetes/pki/openvpn/ca.crt","-openvpn-ca-key-file=/etc/kubernetes/pki/openvpn/ca.key","-logtostderr","-v","2","--ipam-controller-network","192.168.1.1/24,192.168.1.1,8.8.8.8"]}'
         command:
-        - /usr/local/bin/user-cluster-controller-manager
+        - /http-prober-bin/http-prober
         env:
         - name: NAMESPACE
           valueFrom:
@@ -89,27 +76,21 @@ spec:
         - mountPath: /etc/kubernetes/pki/openvpn
           name: openvpn-ca
           readOnly: true
+        - mountPath: /http-prober-bin
+          name: http-prober-bin
       imagePullSecrets:
       - name: dockercfg
       initContainers:
-      - args:
-        - -endpoint
-        - https://apiserver-external.cluster-de-test-01.svc.cluster.local.:30000/healthz
-        - -insecure
-        - -retries
-        - "100"
-        - -retry-wait
-        - "2"
-        - -timeout
-        - "1"
-        command:
+      - command:
+        - /bin/cp
         - /usr/local/bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.1
-        imagePullPolicy: IfNotPresent
-        name: apiserver-running
+        - /http-prober-bin/http-prober
+        image: quay.io/kubermatic/http-prober:v0.2-dev0
+        name: copy-http-prober
         resources: {}
-        terminationMessagePath: /dev/termination-log
-        terminationMessagePolicy: File
+        volumeMounts:
+        - mountPath: /http-prober-bin
+          name: http-prober-bin
       volumes:
       - name: internal-admin-kubeconfig
         secret:
@@ -126,4 +107,6 @@ spec:
         secret:
           defaultMode: 292
           secretName: openvpn-ca
+      - emptyDir: {}
+        name: http-prober-bin
 status: {}

--- a/api/pkg/resources/test/fixtures/deployment-azure-1.11.0-controller-manager.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-azure-1.11.0-controller-manager.yaml
@@ -176,7 +176,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.2-dev0
+        image: quay.io/kubermatic/http-prober:v0.2
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/api/pkg/resources/test/fixtures/deployment-azure-1.11.0-controller-manager.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-azure-1.11.0-controller-manager.yaml
@@ -102,32 +102,19 @@ spec:
           name: openvpn-client-certificates
           readOnly: true
       - args:
-        - --kubeconfig
-        - /etc/kubernetes/kubeconfig/kubeconfig
-        - --service-account-private-key-file
-        - /etc/kubernetes/service-account-key/sa.key
-        - --root-ca-file
-        - /etc/kubernetes/pki/ca/ca.crt
-        - --cluster-signing-cert-file
-        - /etc/kubernetes/pki/ca/ca.crt
-        - --cluster-signing-key-file
-        - /etc/kubernetes/pki/ca/ca.key
-        - --cluster-cidr
-        - 172.25.0.0/16
-        - --allocate-node-cidrs=true
-        - --controllers
-        - '*,bootstrapsigner,tokencleaner'
-        - --use-service-account-credentials=true
-        - --feature-gates
-        - RotateKubeletClientCertificate=true,RotateKubeletServerCertificate=true
-        - --cloud-provider
-        - azure
-        - --cloud-config
-        - /etc/kubernetes/cloud/config
-        - --configure-cloud-routes=false
+        - -endpoint
+        - https://apiserver-external.cluster-de-test-01.svc.cluster.local.:30000/healthz
+        - -insecure
+        - -retries
+        - "100"
+        - -retry-wait
+        - "2"
+        - -timeout
+        - "1"
+        - -command
+        - '{"command":"/hyperkube","args":["kube-controller-manager","--kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","--service-account-private-key-file","/etc/kubernetes/service-account-key/sa.key","--root-ca-file","/etc/kubernetes/pki/ca/ca.crt","--cluster-signing-cert-file","/etc/kubernetes/pki/ca/ca.crt","--cluster-signing-key-file","/etc/kubernetes/pki/ca/ca.key","--cluster-cidr","172.25.0.0/16","--allocate-node-cidrs=true","--controllers","*,bootstrapsigner,tokencleaner","--use-service-account-credentials=true","--feature-gates","RotateKubeletClientCertificate=true,RotateKubeletServerCertificate=true","--cloud-provider","azure","--cloud-config","/etc/kubernetes/cloud/config","--configure-cloud-routes=false"]}'
         command:
-        - /hyperkube
-        - kube-controller-manager
+        - /http-prober-bin/http-prober
         image: gcr.io/google_containers/hyperkube-amd64:v1.11.0
         livenessProbe:
           failureThreshold: 8
@@ -169,6 +156,8 @@ spec:
         - mountPath: /etc/kubernetes/kubeconfig
           name: controllermanager-kubeconfig
           readOnly: true
+        - mountPath: /http-prober-bin
+          name: http-prober-bin
       dnsConfig:
         nameservers:
         - 192.0.2.14
@@ -183,24 +172,16 @@ spec:
       imagePullSecrets:
       - name: dockercfg
       initContainers:
-      - args:
-        - -endpoint
-        - https://apiserver-external.cluster-de-test-01.svc.cluster.local.:30000/healthz
-        - -insecure
-        - -retries
-        - "100"
-        - -retry-wait
-        - "2"
-        - -timeout
-        - "1"
-        command:
+      - command:
+        - /bin/cp
         - /usr/local/bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.1
-        imagePullPolicy: IfNotPresent
-        name: apiserver-running
+        - /http-prober-bin/http-prober
+        image: quay.io/kubermatic/http-prober:v0.2-dev0
+        name: copy-http-prober
         resources: {}
-        terminationMessagePath: /dev/termination-log
-        terminationMessagePolicy: File
+        volumeMounts:
+        - mountPath: /http-prober-bin
+          name: http-prober-bin
       volumes:
       - name: ca
         secret:
@@ -222,4 +203,6 @@ spec:
         secret:
           defaultMode: 256
           secretName: controllermanager-kubeconfig
+      - emptyDir: {}
+        name: http-prober-bin
 status: {}

--- a/api/pkg/resources/test/fixtures/deployment-azure-1.11.0-kube-state-metrics.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-azure-1.11.0-kube-state-metrics.yaml
@@ -21,14 +21,19 @@ spec:
     spec:
       containers:
       - args:
-        - --kubeconfig
-        - /etc/kubernetes/kubeconfig/kubeconfig
-        - --port
-        - "8080"
-        - --telemetry-port
-        - "8081"
+        - -endpoint
+        - https://apiserver-external.cluster-de-test-01.svc.cluster.local.:30000/healthz
+        - -insecure
+        - -retries
+        - "100"
+        - -retry-wait
+        - "2"
+        - -timeout
+        - "1"
+        - -command
+        - '{"command":"/kube-state-metrics","args":["--kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","--port","8080","--telemetry-port","8081"]}'
         command:
-        - /kube-state-metrics
+        - /http-prober-bin/http-prober
         image: quay.io/coreos/kube-state-metrics:v1.6.0
         name: kube-state-metrics
         ports:
@@ -58,30 +63,26 @@ spec:
         - mountPath: /etc/kubernetes/kubeconfig
           name: kube-state-metrics-kubeconfig
           readOnly: true
+        - mountPath: /http-prober-bin
+          name: http-prober-bin
       imagePullSecrets:
       - name: dockercfg
       initContainers:
-      - args:
-        - -endpoint
-        - https://apiserver-external.cluster-de-test-01.svc.cluster.local.:30000/healthz
-        - -insecure
-        - -retries
-        - "100"
-        - -retry-wait
-        - "2"
-        - -timeout
-        - "1"
-        command:
+      - command:
+        - /bin/cp
         - /usr/local/bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.1
-        imagePullPolicy: IfNotPresent
-        name: apiserver-running
+        - /http-prober-bin/http-prober
+        image: quay.io/kubermatic/http-prober:v0.2-dev0
+        name: copy-http-prober
         resources: {}
-        terminationMessagePath: /dev/termination-log
-        terminationMessagePolicy: File
+        volumeMounts:
+        - mountPath: /http-prober-bin
+          name: http-prober-bin
       volumes:
       - name: kube-state-metrics-kubeconfig
         secret:
           defaultMode: 256
           secretName: kube-state-metrics-kubeconfig
+      - emptyDir: {}
+        name: http-prober-bin
 status: {}

--- a/api/pkg/resources/test/fixtures/deployment-azure-1.11.0-kube-state-metrics.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-azure-1.11.0-kube-state-metrics.yaml
@@ -72,7 +72,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.2-dev0
+        image: quay.io/kubermatic/http-prober:v0.2
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/api/pkg/resources/test/fixtures/deployment-azure-1.11.0-machine-controller-webhook.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-azure-1.11.0-machine-controller-webhook.yaml
@@ -36,13 +36,8 @@ spec:
         - -command
         - '{"command":"/usr/local/bin/webhook","args":["-kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","-logtostderr","-v","4","-listen-address","0.0.0.0:9876"]}'
         command:
-<<<<<<< HEAD
-        - /usr/local/bin/webhook
-        image: docker.io/kubermatic/machine-controller:v1.4.3
-=======
         - /http-prober-bin/http-prober
-        image: docker.io/kubermatic/machine-controller:v1.4.2
->>>>>>> Use wrapper instead of initContainer to check if apiserver is reachable (#3857)
+        image: docker.io/kubermatic/machine-controller:v1.4.3
         livenessProbe:
           failureThreshold: 8
           httpGet:

--- a/api/pkg/resources/test/fixtures/deployment-azure-1.11.0-machine-controller-webhook.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-azure-1.11.0-machine-controller-webhook.yaml
@@ -86,7 +86,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.2-dev0
+        image: quay.io/kubermatic/http-prober:v0.2
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/api/pkg/resources/test/fixtures/deployment-azure-1.11.0-machine-controller-webhook.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-azure-1.11.0-machine-controller-webhook.yaml
@@ -24,16 +24,25 @@ spec:
     spec:
       containers:
       - args:
-        - -kubeconfig
-        - /etc/kubernetes/kubeconfig/kubeconfig
-        - -logtostderr
-        - -v
-        - "4"
-        - -listen-address
-        - 0.0.0.0:9876
+        - -endpoint
+        - https://apiserver-external.cluster-de-test-01.svc.cluster.local.:30000/healthz
+        - -insecure
+        - -retries
+        - "100"
+        - -retry-wait
+        - "2"
+        - -timeout
+        - "1"
+        - -command
+        - '{"command":"/usr/local/bin/webhook","args":["-kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","-logtostderr","-v","4","-listen-address","0.0.0.0:9876"]}'
         command:
+<<<<<<< HEAD
         - /usr/local/bin/webhook
         image: docker.io/kubermatic/machine-controller:v1.4.3
+=======
+        - /http-prober-bin/http-prober
+        image: docker.io/kubermatic/machine-controller:v1.4.2
+>>>>>>> Use wrapper instead of initContainer to check if apiserver is reachable (#3857)
         livenessProbe:
           failureThreshold: 8
           httpGet:
@@ -68,27 +77,21 @@ spec:
         - mountPath: /tmp/cert
           name: machinecontroller-webhook-serving-cert
           readOnly: true
+        - mountPath: /http-prober-bin
+          name: http-prober-bin
       imagePullSecrets:
       - name: dockercfg
       initContainers:
-      - args:
-        - -endpoint
-        - https://apiserver-external.cluster-de-test-01.svc.cluster.local.:30000/healthz
-        - -insecure
-        - -retries
-        - "100"
-        - -retry-wait
-        - "2"
-        - -timeout
-        - "1"
-        command:
+      - command:
+        - /bin/cp
         - /usr/local/bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.1
-        imagePullPolicy: IfNotPresent
-        name: apiserver-running
+        - /http-prober-bin/http-prober
+        image: quay.io/kubermatic/http-prober:v0.2-dev0
+        name: copy-http-prober
         resources: {}
-        terminationMessagePath: /dev/termination-log
-        terminationMessagePolicy: File
+        volumeMounts:
+        - mountPath: /http-prober-bin
+          name: http-prober-bin
       volumes:
       - name: machinecontroller-kubeconfig
         secret:
@@ -98,4 +101,6 @@ spec:
         secret:
           defaultMode: 292
           secretName: machinecontroller-webhook-serving-cert
+      - emptyDir: {}
+        name: http-prober-bin
 status: {}

--- a/api/pkg/resources/test/fixtures/deployment-azure-1.11.0-machine-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-azure-1.11.0-machine-controller.yaml
@@ -77,7 +77,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.2-dev0
+        image: quay.io/kubermatic/http-prober:v0.2
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/api/pkg/resources/test/fixtures/deployment-azure-1.11.0-machine-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-azure-1.11.0-machine-controller.yaml
@@ -39,13 +39,8 @@ spec:
         - -command
         - '{"command":"/usr/local/bin/machine-controller","args":["-kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","-logtostderr","-v","4","-cluster-dns","169.254.20.10","-internal-listen-address","0.0.0.0:8085"]}'
         command:
-<<<<<<< HEAD
-        - /usr/local/bin/machine-controller
-        image: docker.io/kubermatic/machine-controller:v1.4.3
-=======
         - /http-prober-bin/http-prober
-        image: docker.io/kubermatic/machine-controller:v1.4.2
->>>>>>> Use wrapper instead of initContainer to check if apiserver is reachable (#3857)
+        image: docker.io/kubermatic/machine-controller:v1.4.3
         livenessProbe:
           failureThreshold: 3
           httpGet:

--- a/api/pkg/resources/test/fixtures/deployment-azure-1.11.0-machine-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-azure-1.11.0-machine-controller.yaml
@@ -27,18 +27,25 @@ spec:
     spec:
       containers:
       - args:
-        - -kubeconfig
-        - /etc/kubernetes/kubeconfig/kubeconfig
-        - -logtostderr
-        - -v
-        - "4"
-        - -cluster-dns
-        - 169.254.20.10
-        - -internal-listen-address
-        - 0.0.0.0:8085
+        - -endpoint
+        - https://apiserver-external.cluster-de-test-01.svc.cluster.local.:30000/healthz
+        - -insecure
+        - -retries
+        - "100"
+        - -retry-wait
+        - "2"
+        - -timeout
+        - "1"
+        - -command
+        - '{"command":"/usr/local/bin/machine-controller","args":["-kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","-logtostderr","-v","4","-cluster-dns","169.254.20.10","-internal-listen-address","0.0.0.0:8085"]}'
         command:
+<<<<<<< HEAD
         - /usr/local/bin/machine-controller
         image: docker.io/kubermatic/machine-controller:v1.4.3
+=======
+        - /http-prober-bin/http-prober
+        image: docker.io/kubermatic/machine-controller:v1.4.2
+>>>>>>> Use wrapper instead of initContainer to check if apiserver is reachable (#3857)
         livenessProbe:
           failureThreshold: 3
           httpGet:
@@ -61,30 +68,26 @@ spec:
         - mountPath: /etc/kubernetes/kubeconfig
           name: machinecontroller-kubeconfig
           readOnly: true
+        - mountPath: /http-prober-bin
+          name: http-prober-bin
       imagePullSecrets:
       - name: dockercfg
       initContainers:
-      - args:
-        - -endpoint
-        - https://apiserver-external.cluster-de-test-01.svc.cluster.local.:30000/healthz
-        - -insecure
-        - -retries
-        - "100"
-        - -retry-wait
-        - "2"
-        - -timeout
-        - "1"
-        command:
+      - command:
+        - /bin/cp
         - /usr/local/bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.1
-        imagePullPolicy: IfNotPresent
-        name: apiserver-running
+        - /http-prober-bin/http-prober
+        image: quay.io/kubermatic/http-prober:v0.2-dev0
+        name: copy-http-prober
         resources: {}
-        terminationMessagePath: /dev/termination-log
-        terminationMessagePolicy: File
+        volumeMounts:
+        - mountPath: /http-prober-bin
+          name: http-prober-bin
       volumes:
       - name: machinecontroller-kubeconfig
         secret:
           defaultMode: 292
           secretName: machinecontroller-kubeconfig
+      - emptyDir: {}
+        name: http-prober-bin
 status: {}

--- a/api/pkg/resources/test/fixtures/deployment-azure-1.11.0-metrics-server.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-azure-1.11.0-metrics-server.yaml
@@ -41,22 +41,19 @@ spec:
             weight: 10
       containers:
       - args:
-        - --kubeconfig
-        - /etc/kubernetes/kubeconfig/kubeconfig
-        - --authentication-kubeconfig
-        - /etc/kubernetes/kubeconfig/kubeconfig
-        - --authorization-kubeconfig
-        - /etc/kubernetes/kubeconfig/kubeconfig
-        - --kubelet-port
-        - "10250"
-        - --kubelet-insecure-tls
-        - --kubelet-preferred-address-types
-        - ExternalIP,InternalIP
-        - --v
+        - -endpoint
+        - https://apiserver-external.cluster-de-test-01.svc.cluster.local.:30000/healthz
+        - -insecure
+        - -retries
+        - "100"
+        - -retry-wait
+        - "2"
+        - -timeout
         - "1"
-        - --logtostderr
+        - -command
+        - '{"command":"/metrics-server","args":["--kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","--authentication-kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","--authorization-kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","--kubelet-port","10250","--kubelet-insecure-tls","--kubelet-preferred-address-types","ExternalIP,InternalIP","--v","1","--logtostderr"]}'
         command:
-        - /metrics-server
+        - /http-prober-bin/http-prober
         image: gcr.io/google_containers/metrics-server-amd64:v0.3.2
         name: metrics-server
         resources:
@@ -70,6 +67,8 @@ spec:
         - mountPath: /etc/kubernetes/kubeconfig
           name: metrics-server
           readOnly: true
+        - mountPath: /http-prober-bin
+          name: http-prober-bin
       - args:
         - --client
         - --proto
@@ -158,24 +157,16 @@ spec:
       imagePullSecrets:
       - name: dockercfg
       initContainers:
-      - args:
-        - -endpoint
-        - https://apiserver-external.cluster-de-test-01.svc.cluster.local.:30000/healthz
-        - -insecure
-        - -retries
-        - "100"
-        - -retry-wait
-        - "2"
-        - -timeout
-        - "1"
-        command:
+      - command:
+        - /bin/cp
         - /usr/local/bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.1
-        imagePullPolicy: IfNotPresent
-        name: apiserver-running
+        - /http-prober-bin/http-prober
+        image: quay.io/kubermatic/http-prober:v0.2-dev0
+        name: copy-http-prober
         resources: {}
-        terminationMessagePath: /dev/termination-log
-        terminationMessagePolicy: File
+        volumeMounts:
+        - mountPath: /http-prober-bin
+          name: http-prober-bin
       volumes:
       - name: metrics-server
         secret:
@@ -189,4 +180,6 @@ spec:
         secret:
           defaultMode: 292
           secretName: kubeletdnatcontroller-kubeconfig
+      - emptyDir: {}
+        name: http-prober-bin
 status: {}

--- a/api/pkg/resources/test/fixtures/deployment-azure-1.11.0-metrics-server.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-azure-1.11.0-metrics-server.yaml
@@ -161,7 +161,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.2-dev0
+        image: quay.io/kubermatic/http-prober:v0.2
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/api/pkg/resources/test/fixtures/deployment-azure-1.11.0-scheduler.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-azure-1.11.0-scheduler.yaml
@@ -100,11 +100,19 @@ spec:
           name: openvpn-client-certificates
           readOnly: true
       - args:
-        - --kubeconfig
-        - /etc/kubernetes/kubeconfig/kubeconfig
+        - -endpoint
+        - https://apiserver-external.cluster-de-test-01.svc.cluster.local.:30000/healthz
+        - -insecure
+        - -retries
+        - "100"
+        - -retry-wait
+        - "2"
+        - -timeout
+        - "1"
+        - -command
+        - '{"command":"/hyperkube","args":["kube-scheduler","--kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig"]}'
         command:
-        - /hyperkube
-        - kube-scheduler
+        - /http-prober-bin/http-prober
         image: gcr.io/google_containers/hyperkube-amd64:v1.11.0
         livenessProbe:
           failureThreshold: 8
@@ -140,6 +148,8 @@ spec:
         - mountPath: /etc/kubernetes/pki/ca
           name: ca
           readOnly: true
+        - mountPath: /http-prober-bin
+          name: http-prober-bin
       dnsConfig:
         nameservers:
         - 192.0.2.14
@@ -154,24 +164,16 @@ spec:
       imagePullSecrets:
       - name: dockercfg
       initContainers:
-      - args:
-        - -endpoint
-        - https://apiserver-external.cluster-de-test-01.svc.cluster.local.:30000/healthz
-        - -insecure
-        - -retries
-        - "100"
-        - -retry-wait
-        - "2"
-        - -timeout
-        - "1"
-        command:
+      - command:
+        - /bin/cp
         - /usr/local/bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.1
-        imagePullPolicy: IfNotPresent
-        name: apiserver-running
+        - /http-prober-bin/http-prober
+        image: quay.io/kubermatic/http-prober:v0.2-dev0
+        name: copy-http-prober
         resources: {}
-        terminationMessagePath: /dev/termination-log
-        terminationMessagePolicy: File
+        volumeMounts:
+        - mountPath: /http-prober-bin
+          name: http-prober-bin
       volumes:
       - name: openvpn-client-certificates
         secret:
@@ -188,4 +190,6 @@ spec:
         secret:
           defaultMode: 256
           secretName: scheduler-kubeconfig
+      - emptyDir: {}
+        name: http-prober-bin
 status: {}

--- a/api/pkg/resources/test/fixtures/deployment-azure-1.11.0-scheduler.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-azure-1.11.0-scheduler.yaml
@@ -168,7 +168,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.2-dev0
+        image: quay.io/kubermatic/http-prober:v0.2
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/api/pkg/resources/test/fixtures/deployment-azure-1.11.0-usercluster-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-azure-1.11.0-usercluster-controller.yaml
@@ -85,7 +85,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.2-dev0
+        image: quay.io/kubermatic/http-prober:v0.2
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/api/pkg/resources/test/fixtures/deployment-azure-1.11.0-usercluster-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-azure-1.11.0-usercluster-controller.yaml
@@ -29,32 +29,19 @@ spec:
     spec:
       containers:
       - args:
-        - -kubeconfig
-        - /etc/kubernetes/kubeconfig/kubeconfig
-        - -metrics-listen-address
-        - 0.0.0.0:8085
-        - -health-listen-address
-        - 0.0.0.0:8086
-        - -namespace
-        - $(NAMESPACE)
-        - -ca-cert
-        - /etc/kubernetes/pki/ca/ca.crt
-        - -cluster-url
-        - ""
-        - -openvpn-server-port
-        - "30003"
-        - -overwrite-registry
-        - ""
-        - -openshift=false
-        - -openvpn-ca-cert-file=/etc/kubernetes/pki/openvpn/ca.crt
-        - -openvpn-ca-key-file=/etc/kubernetes/pki/openvpn/ca.key
-        - -logtostderr
-        - -v
+        - -endpoint
+        - https://apiserver-external.cluster-de-test-01.svc.cluster.local.:30000/healthz
+        - -insecure
+        - -retries
+        - "100"
+        - -retry-wait
         - "2"
-        - --ipam-controller-network
-        - 192.168.1.1/24,192.168.1.1,8.8.8.8
+        - -timeout
+        - "1"
+        - -command
+        - '{"command":"/usr/local/bin/user-cluster-controller-manager","args":["-kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","-metrics-listen-address","0.0.0.0:8085","-health-listen-address","0.0.0.0:8086","-namespace","$(NAMESPACE)","-ca-cert","/etc/kubernetes/pki/ca/ca.crt","-cluster-url","","-openvpn-server-port","30003","-overwrite-registry","","-openshift=false","-openvpn-ca-cert-file=/etc/kubernetes/pki/openvpn/ca.crt","-openvpn-ca-key-file=/etc/kubernetes/pki/openvpn/ca.key","-logtostderr","-v","2","--ipam-controller-network","192.168.1.1/24,192.168.1.1,8.8.8.8"]}'
         command:
-        - /usr/local/bin/user-cluster-controller-manager
+        - /http-prober-bin/http-prober
         env:
         - name: NAMESPACE
           valueFrom:
@@ -89,27 +76,21 @@ spec:
         - mountPath: /etc/kubernetes/pki/openvpn
           name: openvpn-ca
           readOnly: true
+        - mountPath: /http-prober-bin
+          name: http-prober-bin
       imagePullSecrets:
       - name: dockercfg
       initContainers:
-      - args:
-        - -endpoint
-        - https://apiserver-external.cluster-de-test-01.svc.cluster.local.:30000/healthz
-        - -insecure
-        - -retries
-        - "100"
-        - -retry-wait
-        - "2"
-        - -timeout
-        - "1"
-        command:
+      - command:
+        - /bin/cp
         - /usr/local/bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.1
-        imagePullPolicy: IfNotPresent
-        name: apiserver-running
+        - /http-prober-bin/http-prober
+        image: quay.io/kubermatic/http-prober:v0.2-dev0
+        name: copy-http-prober
         resources: {}
-        terminationMessagePath: /dev/termination-log
-        terminationMessagePolicy: File
+        volumeMounts:
+        - mountPath: /http-prober-bin
+          name: http-prober-bin
       volumes:
       - name: internal-admin-kubeconfig
         secret:
@@ -126,4 +107,6 @@ spec:
         secret:
           defaultMode: 292
           secretName: openvpn-ca
+      - emptyDir: {}
+        name: http-prober-bin
 status: {}

--- a/api/pkg/resources/test/fixtures/deployment-azure-1.11.1-controller-manager.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-azure-1.11.1-controller-manager.yaml
@@ -176,7 +176,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.2-dev0
+        image: quay.io/kubermatic/http-prober:v0.2
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/api/pkg/resources/test/fixtures/deployment-azure-1.11.1-controller-manager.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-azure-1.11.1-controller-manager.yaml
@@ -102,32 +102,19 @@ spec:
           name: openvpn-client-certificates
           readOnly: true
       - args:
-        - --kubeconfig
-        - /etc/kubernetes/kubeconfig/kubeconfig
-        - --service-account-private-key-file
-        - /etc/kubernetes/service-account-key/sa.key
-        - --root-ca-file
-        - /etc/kubernetes/pki/ca/ca.crt
-        - --cluster-signing-cert-file
-        - /etc/kubernetes/pki/ca/ca.crt
-        - --cluster-signing-key-file
-        - /etc/kubernetes/pki/ca/ca.key
-        - --cluster-cidr
-        - 172.25.0.0/16
-        - --allocate-node-cidrs=true
-        - --controllers
-        - '*,bootstrapsigner,tokencleaner'
-        - --use-service-account-credentials=true
-        - --feature-gates
-        - RotateKubeletClientCertificate=true,RotateKubeletServerCertificate=true
-        - --cloud-provider
-        - azure
-        - --cloud-config
-        - /etc/kubernetes/cloud/config
-        - --configure-cloud-routes=false
+        - -endpoint
+        - https://apiserver-external.cluster-de-test-01.svc.cluster.local.:30000/healthz
+        - -insecure
+        - -retries
+        - "100"
+        - -retry-wait
+        - "2"
+        - -timeout
+        - "1"
+        - -command
+        - '{"command":"/hyperkube","args":["kube-controller-manager","--kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","--service-account-private-key-file","/etc/kubernetes/service-account-key/sa.key","--root-ca-file","/etc/kubernetes/pki/ca/ca.crt","--cluster-signing-cert-file","/etc/kubernetes/pki/ca/ca.crt","--cluster-signing-key-file","/etc/kubernetes/pki/ca/ca.key","--cluster-cidr","172.25.0.0/16","--allocate-node-cidrs=true","--controllers","*,bootstrapsigner,tokencleaner","--use-service-account-credentials=true","--feature-gates","RotateKubeletClientCertificate=true,RotateKubeletServerCertificate=true","--cloud-provider","azure","--cloud-config","/etc/kubernetes/cloud/config","--configure-cloud-routes=false"]}'
         command:
-        - /hyperkube
-        - kube-controller-manager
+        - /http-prober-bin/http-prober
         image: gcr.io/google_containers/hyperkube-amd64:v1.11.1
         livenessProbe:
           failureThreshold: 8
@@ -169,6 +156,8 @@ spec:
         - mountPath: /etc/kubernetes/kubeconfig
           name: controllermanager-kubeconfig
           readOnly: true
+        - mountPath: /http-prober-bin
+          name: http-prober-bin
       dnsConfig:
         nameservers:
         - 192.0.2.14
@@ -183,24 +172,16 @@ spec:
       imagePullSecrets:
       - name: dockercfg
       initContainers:
-      - args:
-        - -endpoint
-        - https://apiserver-external.cluster-de-test-01.svc.cluster.local.:30000/healthz
-        - -insecure
-        - -retries
-        - "100"
-        - -retry-wait
-        - "2"
-        - -timeout
-        - "1"
-        command:
+      - command:
+        - /bin/cp
         - /usr/local/bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.1
-        imagePullPolicy: IfNotPresent
-        name: apiserver-running
+        - /http-prober-bin/http-prober
+        image: quay.io/kubermatic/http-prober:v0.2-dev0
+        name: copy-http-prober
         resources: {}
-        terminationMessagePath: /dev/termination-log
-        terminationMessagePolicy: File
+        volumeMounts:
+        - mountPath: /http-prober-bin
+          name: http-prober-bin
       volumes:
       - name: ca
         secret:
@@ -222,4 +203,6 @@ spec:
         secret:
           defaultMode: 256
           secretName: controllermanager-kubeconfig
+      - emptyDir: {}
+        name: http-prober-bin
 status: {}

--- a/api/pkg/resources/test/fixtures/deployment-azure-1.11.1-kube-state-metrics.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-azure-1.11.1-kube-state-metrics.yaml
@@ -21,14 +21,19 @@ spec:
     spec:
       containers:
       - args:
-        - --kubeconfig
-        - /etc/kubernetes/kubeconfig/kubeconfig
-        - --port
-        - "8080"
-        - --telemetry-port
-        - "8081"
+        - -endpoint
+        - https://apiserver-external.cluster-de-test-01.svc.cluster.local.:30000/healthz
+        - -insecure
+        - -retries
+        - "100"
+        - -retry-wait
+        - "2"
+        - -timeout
+        - "1"
+        - -command
+        - '{"command":"/kube-state-metrics","args":["--kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","--port","8080","--telemetry-port","8081"]}'
         command:
-        - /kube-state-metrics
+        - /http-prober-bin/http-prober
         image: quay.io/coreos/kube-state-metrics:v1.6.0
         name: kube-state-metrics
         ports:
@@ -58,30 +63,26 @@ spec:
         - mountPath: /etc/kubernetes/kubeconfig
           name: kube-state-metrics-kubeconfig
           readOnly: true
+        - mountPath: /http-prober-bin
+          name: http-prober-bin
       imagePullSecrets:
       - name: dockercfg
       initContainers:
-      - args:
-        - -endpoint
-        - https://apiserver-external.cluster-de-test-01.svc.cluster.local.:30000/healthz
-        - -insecure
-        - -retries
-        - "100"
-        - -retry-wait
-        - "2"
-        - -timeout
-        - "1"
-        command:
+      - command:
+        - /bin/cp
         - /usr/local/bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.1
-        imagePullPolicy: IfNotPresent
-        name: apiserver-running
+        - /http-prober-bin/http-prober
+        image: quay.io/kubermatic/http-prober:v0.2-dev0
+        name: copy-http-prober
         resources: {}
-        terminationMessagePath: /dev/termination-log
-        terminationMessagePolicy: File
+        volumeMounts:
+        - mountPath: /http-prober-bin
+          name: http-prober-bin
       volumes:
       - name: kube-state-metrics-kubeconfig
         secret:
           defaultMode: 256
           secretName: kube-state-metrics-kubeconfig
+      - emptyDir: {}
+        name: http-prober-bin
 status: {}

--- a/api/pkg/resources/test/fixtures/deployment-azure-1.11.1-kube-state-metrics.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-azure-1.11.1-kube-state-metrics.yaml
@@ -72,7 +72,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.2-dev0
+        image: quay.io/kubermatic/http-prober:v0.2
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/api/pkg/resources/test/fixtures/deployment-azure-1.11.1-machine-controller-webhook.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-azure-1.11.1-machine-controller-webhook.yaml
@@ -36,13 +36,8 @@ spec:
         - -command
         - '{"command":"/usr/local/bin/webhook","args":["-kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","-logtostderr","-v","4","-listen-address","0.0.0.0:9876"]}'
         command:
-<<<<<<< HEAD
-        - /usr/local/bin/webhook
-        image: docker.io/kubermatic/machine-controller:v1.4.3
-=======
         - /http-prober-bin/http-prober
-        image: docker.io/kubermatic/machine-controller:v1.4.2
->>>>>>> Use wrapper instead of initContainer to check if apiserver is reachable (#3857)
+        image: docker.io/kubermatic/machine-controller:v1.4.3
         livenessProbe:
           failureThreshold: 8
           httpGet:

--- a/api/pkg/resources/test/fixtures/deployment-azure-1.11.1-machine-controller-webhook.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-azure-1.11.1-machine-controller-webhook.yaml
@@ -86,7 +86,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.2-dev0
+        image: quay.io/kubermatic/http-prober:v0.2
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/api/pkg/resources/test/fixtures/deployment-azure-1.11.1-machine-controller-webhook.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-azure-1.11.1-machine-controller-webhook.yaml
@@ -24,16 +24,25 @@ spec:
     spec:
       containers:
       - args:
-        - -kubeconfig
-        - /etc/kubernetes/kubeconfig/kubeconfig
-        - -logtostderr
-        - -v
-        - "4"
-        - -listen-address
-        - 0.0.0.0:9876
+        - -endpoint
+        - https://apiserver-external.cluster-de-test-01.svc.cluster.local.:30000/healthz
+        - -insecure
+        - -retries
+        - "100"
+        - -retry-wait
+        - "2"
+        - -timeout
+        - "1"
+        - -command
+        - '{"command":"/usr/local/bin/webhook","args":["-kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","-logtostderr","-v","4","-listen-address","0.0.0.0:9876"]}'
         command:
+<<<<<<< HEAD
         - /usr/local/bin/webhook
         image: docker.io/kubermatic/machine-controller:v1.4.3
+=======
+        - /http-prober-bin/http-prober
+        image: docker.io/kubermatic/machine-controller:v1.4.2
+>>>>>>> Use wrapper instead of initContainer to check if apiserver is reachable (#3857)
         livenessProbe:
           failureThreshold: 8
           httpGet:
@@ -68,27 +77,21 @@ spec:
         - mountPath: /tmp/cert
           name: machinecontroller-webhook-serving-cert
           readOnly: true
+        - mountPath: /http-prober-bin
+          name: http-prober-bin
       imagePullSecrets:
       - name: dockercfg
       initContainers:
-      - args:
-        - -endpoint
-        - https://apiserver-external.cluster-de-test-01.svc.cluster.local.:30000/healthz
-        - -insecure
-        - -retries
-        - "100"
-        - -retry-wait
-        - "2"
-        - -timeout
-        - "1"
-        command:
+      - command:
+        - /bin/cp
         - /usr/local/bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.1
-        imagePullPolicy: IfNotPresent
-        name: apiserver-running
+        - /http-prober-bin/http-prober
+        image: quay.io/kubermatic/http-prober:v0.2-dev0
+        name: copy-http-prober
         resources: {}
-        terminationMessagePath: /dev/termination-log
-        terminationMessagePolicy: File
+        volumeMounts:
+        - mountPath: /http-prober-bin
+          name: http-prober-bin
       volumes:
       - name: machinecontroller-kubeconfig
         secret:
@@ -98,4 +101,6 @@ spec:
         secret:
           defaultMode: 292
           secretName: machinecontroller-webhook-serving-cert
+      - emptyDir: {}
+        name: http-prober-bin
 status: {}

--- a/api/pkg/resources/test/fixtures/deployment-azure-1.11.1-machine-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-azure-1.11.1-machine-controller.yaml
@@ -77,7 +77,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.2-dev0
+        image: quay.io/kubermatic/http-prober:v0.2
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/api/pkg/resources/test/fixtures/deployment-azure-1.11.1-machine-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-azure-1.11.1-machine-controller.yaml
@@ -39,13 +39,8 @@ spec:
         - -command
         - '{"command":"/usr/local/bin/machine-controller","args":["-kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","-logtostderr","-v","4","-cluster-dns","169.254.20.10","-internal-listen-address","0.0.0.0:8085"]}'
         command:
-<<<<<<< HEAD
-        - /usr/local/bin/machine-controller
-        image: docker.io/kubermatic/machine-controller:v1.4.3
-=======
         - /http-prober-bin/http-prober
-        image: docker.io/kubermatic/machine-controller:v1.4.2
->>>>>>> Use wrapper instead of initContainer to check if apiserver is reachable (#3857)
+        image: docker.io/kubermatic/machine-controller:v1.4.3
         livenessProbe:
           failureThreshold: 3
           httpGet:

--- a/api/pkg/resources/test/fixtures/deployment-azure-1.11.1-machine-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-azure-1.11.1-machine-controller.yaml
@@ -27,18 +27,25 @@ spec:
     spec:
       containers:
       - args:
-        - -kubeconfig
-        - /etc/kubernetes/kubeconfig/kubeconfig
-        - -logtostderr
-        - -v
-        - "4"
-        - -cluster-dns
-        - 169.254.20.10
-        - -internal-listen-address
-        - 0.0.0.0:8085
+        - -endpoint
+        - https://apiserver-external.cluster-de-test-01.svc.cluster.local.:30000/healthz
+        - -insecure
+        - -retries
+        - "100"
+        - -retry-wait
+        - "2"
+        - -timeout
+        - "1"
+        - -command
+        - '{"command":"/usr/local/bin/machine-controller","args":["-kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","-logtostderr","-v","4","-cluster-dns","169.254.20.10","-internal-listen-address","0.0.0.0:8085"]}'
         command:
+<<<<<<< HEAD
         - /usr/local/bin/machine-controller
         image: docker.io/kubermatic/machine-controller:v1.4.3
+=======
+        - /http-prober-bin/http-prober
+        image: docker.io/kubermatic/machine-controller:v1.4.2
+>>>>>>> Use wrapper instead of initContainer to check if apiserver is reachable (#3857)
         livenessProbe:
           failureThreshold: 3
           httpGet:
@@ -61,30 +68,26 @@ spec:
         - mountPath: /etc/kubernetes/kubeconfig
           name: machinecontroller-kubeconfig
           readOnly: true
+        - mountPath: /http-prober-bin
+          name: http-prober-bin
       imagePullSecrets:
       - name: dockercfg
       initContainers:
-      - args:
-        - -endpoint
-        - https://apiserver-external.cluster-de-test-01.svc.cluster.local.:30000/healthz
-        - -insecure
-        - -retries
-        - "100"
-        - -retry-wait
-        - "2"
-        - -timeout
-        - "1"
-        command:
+      - command:
+        - /bin/cp
         - /usr/local/bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.1
-        imagePullPolicy: IfNotPresent
-        name: apiserver-running
+        - /http-prober-bin/http-prober
+        image: quay.io/kubermatic/http-prober:v0.2-dev0
+        name: copy-http-prober
         resources: {}
-        terminationMessagePath: /dev/termination-log
-        terminationMessagePolicy: File
+        volumeMounts:
+        - mountPath: /http-prober-bin
+          name: http-prober-bin
       volumes:
       - name: machinecontroller-kubeconfig
         secret:
           defaultMode: 292
           secretName: machinecontroller-kubeconfig
+      - emptyDir: {}
+        name: http-prober-bin
 status: {}

--- a/api/pkg/resources/test/fixtures/deployment-azure-1.11.1-metrics-server.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-azure-1.11.1-metrics-server.yaml
@@ -41,22 +41,19 @@ spec:
             weight: 10
       containers:
       - args:
-        - --kubeconfig
-        - /etc/kubernetes/kubeconfig/kubeconfig
-        - --authentication-kubeconfig
-        - /etc/kubernetes/kubeconfig/kubeconfig
-        - --authorization-kubeconfig
-        - /etc/kubernetes/kubeconfig/kubeconfig
-        - --kubelet-port
-        - "10250"
-        - --kubelet-insecure-tls
-        - --kubelet-preferred-address-types
-        - ExternalIP,InternalIP
-        - --v
+        - -endpoint
+        - https://apiserver-external.cluster-de-test-01.svc.cluster.local.:30000/healthz
+        - -insecure
+        - -retries
+        - "100"
+        - -retry-wait
+        - "2"
+        - -timeout
         - "1"
-        - --logtostderr
+        - -command
+        - '{"command":"/metrics-server","args":["--kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","--authentication-kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","--authorization-kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","--kubelet-port","10250","--kubelet-insecure-tls","--kubelet-preferred-address-types","ExternalIP,InternalIP","--v","1","--logtostderr"]}'
         command:
-        - /metrics-server
+        - /http-prober-bin/http-prober
         image: gcr.io/google_containers/metrics-server-amd64:v0.3.2
         name: metrics-server
         resources:
@@ -70,6 +67,8 @@ spec:
         - mountPath: /etc/kubernetes/kubeconfig
           name: metrics-server
           readOnly: true
+        - mountPath: /http-prober-bin
+          name: http-prober-bin
       - args:
         - --client
         - --proto
@@ -158,24 +157,16 @@ spec:
       imagePullSecrets:
       - name: dockercfg
       initContainers:
-      - args:
-        - -endpoint
-        - https://apiserver-external.cluster-de-test-01.svc.cluster.local.:30000/healthz
-        - -insecure
-        - -retries
-        - "100"
-        - -retry-wait
-        - "2"
-        - -timeout
-        - "1"
-        command:
+      - command:
+        - /bin/cp
         - /usr/local/bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.1
-        imagePullPolicy: IfNotPresent
-        name: apiserver-running
+        - /http-prober-bin/http-prober
+        image: quay.io/kubermatic/http-prober:v0.2-dev0
+        name: copy-http-prober
         resources: {}
-        terminationMessagePath: /dev/termination-log
-        terminationMessagePolicy: File
+        volumeMounts:
+        - mountPath: /http-prober-bin
+          name: http-prober-bin
       volumes:
       - name: metrics-server
         secret:
@@ -189,4 +180,6 @@ spec:
         secret:
           defaultMode: 292
           secretName: kubeletdnatcontroller-kubeconfig
+      - emptyDir: {}
+        name: http-prober-bin
 status: {}

--- a/api/pkg/resources/test/fixtures/deployment-azure-1.11.1-metrics-server.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-azure-1.11.1-metrics-server.yaml
@@ -161,7 +161,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.2-dev0
+        image: quay.io/kubermatic/http-prober:v0.2
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/api/pkg/resources/test/fixtures/deployment-azure-1.11.1-scheduler.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-azure-1.11.1-scheduler.yaml
@@ -100,11 +100,19 @@ spec:
           name: openvpn-client-certificates
           readOnly: true
       - args:
-        - --kubeconfig
-        - /etc/kubernetes/kubeconfig/kubeconfig
+        - -endpoint
+        - https://apiserver-external.cluster-de-test-01.svc.cluster.local.:30000/healthz
+        - -insecure
+        - -retries
+        - "100"
+        - -retry-wait
+        - "2"
+        - -timeout
+        - "1"
+        - -command
+        - '{"command":"/hyperkube","args":["kube-scheduler","--kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig"]}'
         command:
-        - /hyperkube
-        - kube-scheduler
+        - /http-prober-bin/http-prober
         image: gcr.io/google_containers/hyperkube-amd64:v1.11.1
         livenessProbe:
           failureThreshold: 8
@@ -140,6 +148,8 @@ spec:
         - mountPath: /etc/kubernetes/pki/ca
           name: ca
           readOnly: true
+        - mountPath: /http-prober-bin
+          name: http-prober-bin
       dnsConfig:
         nameservers:
         - 192.0.2.14
@@ -154,24 +164,16 @@ spec:
       imagePullSecrets:
       - name: dockercfg
       initContainers:
-      - args:
-        - -endpoint
-        - https://apiserver-external.cluster-de-test-01.svc.cluster.local.:30000/healthz
-        - -insecure
-        - -retries
-        - "100"
-        - -retry-wait
-        - "2"
-        - -timeout
-        - "1"
-        command:
+      - command:
+        - /bin/cp
         - /usr/local/bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.1
-        imagePullPolicy: IfNotPresent
-        name: apiserver-running
+        - /http-prober-bin/http-prober
+        image: quay.io/kubermatic/http-prober:v0.2-dev0
+        name: copy-http-prober
         resources: {}
-        terminationMessagePath: /dev/termination-log
-        terminationMessagePolicy: File
+        volumeMounts:
+        - mountPath: /http-prober-bin
+          name: http-prober-bin
       volumes:
       - name: openvpn-client-certificates
         secret:
@@ -188,4 +190,6 @@ spec:
         secret:
           defaultMode: 256
           secretName: scheduler-kubeconfig
+      - emptyDir: {}
+        name: http-prober-bin
 status: {}

--- a/api/pkg/resources/test/fixtures/deployment-azure-1.11.1-scheduler.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-azure-1.11.1-scheduler.yaml
@@ -168,7 +168,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.2-dev0
+        image: quay.io/kubermatic/http-prober:v0.2
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/api/pkg/resources/test/fixtures/deployment-azure-1.11.1-usercluster-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-azure-1.11.1-usercluster-controller.yaml
@@ -85,7 +85,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.2-dev0
+        image: quay.io/kubermatic/http-prober:v0.2
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/api/pkg/resources/test/fixtures/deployment-azure-1.11.1-usercluster-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-azure-1.11.1-usercluster-controller.yaml
@@ -29,32 +29,19 @@ spec:
     spec:
       containers:
       - args:
-        - -kubeconfig
-        - /etc/kubernetes/kubeconfig/kubeconfig
-        - -metrics-listen-address
-        - 0.0.0.0:8085
-        - -health-listen-address
-        - 0.0.0.0:8086
-        - -namespace
-        - $(NAMESPACE)
-        - -ca-cert
-        - /etc/kubernetes/pki/ca/ca.crt
-        - -cluster-url
-        - ""
-        - -openvpn-server-port
-        - "30003"
-        - -overwrite-registry
-        - ""
-        - -openshift=false
-        - -openvpn-ca-cert-file=/etc/kubernetes/pki/openvpn/ca.crt
-        - -openvpn-ca-key-file=/etc/kubernetes/pki/openvpn/ca.key
-        - -logtostderr
-        - -v
+        - -endpoint
+        - https://apiserver-external.cluster-de-test-01.svc.cluster.local.:30000/healthz
+        - -insecure
+        - -retries
+        - "100"
+        - -retry-wait
         - "2"
-        - --ipam-controller-network
-        - 192.168.1.1/24,192.168.1.1,8.8.8.8
+        - -timeout
+        - "1"
+        - -command
+        - '{"command":"/usr/local/bin/user-cluster-controller-manager","args":["-kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","-metrics-listen-address","0.0.0.0:8085","-health-listen-address","0.0.0.0:8086","-namespace","$(NAMESPACE)","-ca-cert","/etc/kubernetes/pki/ca/ca.crt","-cluster-url","","-openvpn-server-port","30003","-overwrite-registry","","-openshift=false","-openvpn-ca-cert-file=/etc/kubernetes/pki/openvpn/ca.crt","-openvpn-ca-key-file=/etc/kubernetes/pki/openvpn/ca.key","-logtostderr","-v","2","--ipam-controller-network","192.168.1.1/24,192.168.1.1,8.8.8.8"]}'
         command:
-        - /usr/local/bin/user-cluster-controller-manager
+        - /http-prober-bin/http-prober
         env:
         - name: NAMESPACE
           valueFrom:
@@ -89,27 +76,21 @@ spec:
         - mountPath: /etc/kubernetes/pki/openvpn
           name: openvpn-ca
           readOnly: true
+        - mountPath: /http-prober-bin
+          name: http-prober-bin
       imagePullSecrets:
       - name: dockercfg
       initContainers:
-      - args:
-        - -endpoint
-        - https://apiserver-external.cluster-de-test-01.svc.cluster.local.:30000/healthz
-        - -insecure
-        - -retries
-        - "100"
-        - -retry-wait
-        - "2"
-        - -timeout
-        - "1"
-        command:
+      - command:
+        - /bin/cp
         - /usr/local/bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.1
-        imagePullPolicy: IfNotPresent
-        name: apiserver-running
+        - /http-prober-bin/http-prober
+        image: quay.io/kubermatic/http-prober:v0.2-dev0
+        name: copy-http-prober
         resources: {}
-        terminationMessagePath: /dev/termination-log
-        terminationMessagePolicy: File
+        volumeMounts:
+        - mountPath: /http-prober-bin
+          name: http-prober-bin
       volumes:
       - name: internal-admin-kubeconfig
         secret:
@@ -126,4 +107,6 @@ spec:
         secret:
           defaultMode: 292
           secretName: openvpn-ca
+      - emptyDir: {}
+        name: http-prober-bin
 status: {}

--- a/api/pkg/resources/test/fixtures/deployment-azure-1.12.0-controller-manager.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-azure-1.12.0-controller-manager.yaml
@@ -176,7 +176,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.2-dev0
+        image: quay.io/kubermatic/http-prober:v0.2
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/api/pkg/resources/test/fixtures/deployment-azure-1.12.0-controller-manager.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-azure-1.12.0-controller-manager.yaml
@@ -102,37 +102,19 @@ spec:
           name: openvpn-client-certificates
           readOnly: true
       - args:
-        - --kubeconfig
-        - /etc/kubernetes/kubeconfig/kubeconfig
-        - --service-account-private-key-file
-        - /etc/kubernetes/service-account-key/sa.key
-        - --root-ca-file
-        - /etc/kubernetes/pki/ca/ca.crt
-        - --cluster-signing-cert-file
-        - /etc/kubernetes/pki/ca/ca.crt
-        - --cluster-signing-key-file
-        - /etc/kubernetes/pki/ca/ca.key
-        - --cluster-cidr
-        - 172.25.0.0/16
-        - --allocate-node-cidrs=true
-        - --controllers
-        - '*,bootstrapsigner,tokencleaner'
-        - --use-service-account-credentials=true
-        - --feature-gates
-        - RotateKubeletClientCertificate=true,RotateKubeletServerCertificate=true,ScheduleDaemonSetPods=false
-        - --cloud-provider
-        - azure
-        - --cloud-config
-        - /etc/kubernetes/cloud/config
-        - --configure-cloud-routes=false
-        - --authentication-kubeconfig
-        - /etc/kubernetes/kubeconfig/kubeconfig
-        - --client-ca-file
-        - /etc/kubernetes/pki/ca/ca.crt
-        - --authentication-skip-lookup=true
+        - -endpoint
+        - https://apiserver-external.cluster-de-test-01.svc.cluster.local.:30000/healthz
+        - -insecure
+        - -retries
+        - "100"
+        - -retry-wait
+        - "2"
+        - -timeout
+        - "1"
+        - -command
+        - '{"command":"/hyperkube","args":["kube-controller-manager","--kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","--service-account-private-key-file","/etc/kubernetes/service-account-key/sa.key","--root-ca-file","/etc/kubernetes/pki/ca/ca.crt","--cluster-signing-cert-file","/etc/kubernetes/pki/ca/ca.crt","--cluster-signing-key-file","/etc/kubernetes/pki/ca/ca.key","--cluster-cidr","172.25.0.0/16","--allocate-node-cidrs=true","--controllers","*,bootstrapsigner,tokencleaner","--use-service-account-credentials=true","--feature-gates","RotateKubeletClientCertificate=true,RotateKubeletServerCertificate=true,ScheduleDaemonSetPods=false","--cloud-provider","azure","--cloud-config","/etc/kubernetes/cloud/config","--configure-cloud-routes=false","--authentication-kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","--client-ca-file","/etc/kubernetes/pki/ca/ca.crt","--authentication-skip-lookup=true"]}'
         command:
-        - /hyperkube
-        - kube-controller-manager
+        - /http-prober-bin/http-prober
         image: gcr.io/google_containers/hyperkube-amd64:v1.12.0
         livenessProbe:
           failureThreshold: 8
@@ -174,6 +156,8 @@ spec:
         - mountPath: /etc/kubernetes/kubeconfig
           name: controllermanager-kubeconfig
           readOnly: true
+        - mountPath: /http-prober-bin
+          name: http-prober-bin
       dnsConfig:
         nameservers:
         - 192.0.2.14
@@ -188,24 +172,16 @@ spec:
       imagePullSecrets:
       - name: dockercfg
       initContainers:
-      - args:
-        - -endpoint
-        - https://apiserver-external.cluster-de-test-01.svc.cluster.local.:30000/healthz
-        - -insecure
-        - -retries
-        - "100"
-        - -retry-wait
-        - "2"
-        - -timeout
-        - "1"
-        command:
+      - command:
+        - /bin/cp
         - /usr/local/bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.1
-        imagePullPolicy: IfNotPresent
-        name: apiserver-running
+        - /http-prober-bin/http-prober
+        image: quay.io/kubermatic/http-prober:v0.2-dev0
+        name: copy-http-prober
         resources: {}
-        terminationMessagePath: /dev/termination-log
-        terminationMessagePolicy: File
+        volumeMounts:
+        - mountPath: /http-prober-bin
+          name: http-prober-bin
       volumes:
       - name: ca
         secret:
@@ -227,4 +203,6 @@ spec:
         secret:
           defaultMode: 256
           secretName: controllermanager-kubeconfig
+      - emptyDir: {}
+        name: http-prober-bin
 status: {}

--- a/api/pkg/resources/test/fixtures/deployment-azure-1.12.0-kube-state-metrics.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-azure-1.12.0-kube-state-metrics.yaml
@@ -21,14 +21,19 @@ spec:
     spec:
       containers:
       - args:
-        - --kubeconfig
-        - /etc/kubernetes/kubeconfig/kubeconfig
-        - --port
-        - "8080"
-        - --telemetry-port
-        - "8081"
+        - -endpoint
+        - https://apiserver-external.cluster-de-test-01.svc.cluster.local.:30000/healthz
+        - -insecure
+        - -retries
+        - "100"
+        - -retry-wait
+        - "2"
+        - -timeout
+        - "1"
+        - -command
+        - '{"command":"/kube-state-metrics","args":["--kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","--port","8080","--telemetry-port","8081"]}'
         command:
-        - /kube-state-metrics
+        - /http-prober-bin/http-prober
         image: quay.io/coreos/kube-state-metrics:v1.6.0
         name: kube-state-metrics
         ports:
@@ -58,30 +63,26 @@ spec:
         - mountPath: /etc/kubernetes/kubeconfig
           name: kube-state-metrics-kubeconfig
           readOnly: true
+        - mountPath: /http-prober-bin
+          name: http-prober-bin
       imagePullSecrets:
       - name: dockercfg
       initContainers:
-      - args:
-        - -endpoint
-        - https://apiserver-external.cluster-de-test-01.svc.cluster.local.:30000/healthz
-        - -insecure
-        - -retries
-        - "100"
-        - -retry-wait
-        - "2"
-        - -timeout
-        - "1"
-        command:
+      - command:
+        - /bin/cp
         - /usr/local/bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.1
-        imagePullPolicy: IfNotPresent
-        name: apiserver-running
+        - /http-prober-bin/http-prober
+        image: quay.io/kubermatic/http-prober:v0.2-dev0
+        name: copy-http-prober
         resources: {}
-        terminationMessagePath: /dev/termination-log
-        terminationMessagePolicy: File
+        volumeMounts:
+        - mountPath: /http-prober-bin
+          name: http-prober-bin
       volumes:
       - name: kube-state-metrics-kubeconfig
         secret:
           defaultMode: 256
           secretName: kube-state-metrics-kubeconfig
+      - emptyDir: {}
+        name: http-prober-bin
 status: {}

--- a/api/pkg/resources/test/fixtures/deployment-azure-1.12.0-kube-state-metrics.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-azure-1.12.0-kube-state-metrics.yaml
@@ -72,7 +72,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.2-dev0
+        image: quay.io/kubermatic/http-prober:v0.2
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/api/pkg/resources/test/fixtures/deployment-azure-1.12.0-machine-controller-webhook.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-azure-1.12.0-machine-controller-webhook.yaml
@@ -36,13 +36,8 @@ spec:
         - -command
         - '{"command":"/usr/local/bin/webhook","args":["-kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","-logtostderr","-v","4","-listen-address","0.0.0.0:9876"]}'
         command:
-<<<<<<< HEAD
-        - /usr/local/bin/webhook
-        image: docker.io/kubermatic/machine-controller:v1.4.3
-=======
         - /http-prober-bin/http-prober
-        image: docker.io/kubermatic/machine-controller:v1.4.2
->>>>>>> Use wrapper instead of initContainer to check if apiserver is reachable (#3857)
+        image: docker.io/kubermatic/machine-controller:v1.4.3
         livenessProbe:
           failureThreshold: 8
           httpGet:

--- a/api/pkg/resources/test/fixtures/deployment-azure-1.12.0-machine-controller-webhook.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-azure-1.12.0-machine-controller-webhook.yaml
@@ -86,7 +86,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.2-dev0
+        image: quay.io/kubermatic/http-prober:v0.2
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/api/pkg/resources/test/fixtures/deployment-azure-1.12.0-machine-controller-webhook.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-azure-1.12.0-machine-controller-webhook.yaml
@@ -24,16 +24,25 @@ spec:
     spec:
       containers:
       - args:
-        - -kubeconfig
-        - /etc/kubernetes/kubeconfig/kubeconfig
-        - -logtostderr
-        - -v
-        - "4"
-        - -listen-address
-        - 0.0.0.0:9876
+        - -endpoint
+        - https://apiserver-external.cluster-de-test-01.svc.cluster.local.:30000/healthz
+        - -insecure
+        - -retries
+        - "100"
+        - -retry-wait
+        - "2"
+        - -timeout
+        - "1"
+        - -command
+        - '{"command":"/usr/local/bin/webhook","args":["-kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","-logtostderr","-v","4","-listen-address","0.0.0.0:9876"]}'
         command:
+<<<<<<< HEAD
         - /usr/local/bin/webhook
         image: docker.io/kubermatic/machine-controller:v1.4.3
+=======
+        - /http-prober-bin/http-prober
+        image: docker.io/kubermatic/machine-controller:v1.4.2
+>>>>>>> Use wrapper instead of initContainer to check if apiserver is reachable (#3857)
         livenessProbe:
           failureThreshold: 8
           httpGet:
@@ -68,27 +77,21 @@ spec:
         - mountPath: /tmp/cert
           name: machinecontroller-webhook-serving-cert
           readOnly: true
+        - mountPath: /http-prober-bin
+          name: http-prober-bin
       imagePullSecrets:
       - name: dockercfg
       initContainers:
-      - args:
-        - -endpoint
-        - https://apiserver-external.cluster-de-test-01.svc.cluster.local.:30000/healthz
-        - -insecure
-        - -retries
-        - "100"
-        - -retry-wait
-        - "2"
-        - -timeout
-        - "1"
-        command:
+      - command:
+        - /bin/cp
         - /usr/local/bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.1
-        imagePullPolicy: IfNotPresent
-        name: apiserver-running
+        - /http-prober-bin/http-prober
+        image: quay.io/kubermatic/http-prober:v0.2-dev0
+        name: copy-http-prober
         resources: {}
-        terminationMessagePath: /dev/termination-log
-        terminationMessagePolicy: File
+        volumeMounts:
+        - mountPath: /http-prober-bin
+          name: http-prober-bin
       volumes:
       - name: machinecontroller-kubeconfig
         secret:
@@ -98,4 +101,6 @@ spec:
         secret:
           defaultMode: 292
           secretName: machinecontroller-webhook-serving-cert
+      - emptyDir: {}
+        name: http-prober-bin
 status: {}

--- a/api/pkg/resources/test/fixtures/deployment-azure-1.12.0-machine-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-azure-1.12.0-machine-controller.yaml
@@ -77,7 +77,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.2-dev0
+        image: quay.io/kubermatic/http-prober:v0.2
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/api/pkg/resources/test/fixtures/deployment-azure-1.12.0-machine-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-azure-1.12.0-machine-controller.yaml
@@ -39,13 +39,8 @@ spec:
         - -command
         - '{"command":"/usr/local/bin/machine-controller","args":["-kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","-logtostderr","-v","4","-cluster-dns","169.254.20.10","-internal-listen-address","0.0.0.0:8085"]}'
         command:
-<<<<<<< HEAD
-        - /usr/local/bin/machine-controller
-        image: docker.io/kubermatic/machine-controller:v1.4.3
-=======
         - /http-prober-bin/http-prober
-        image: docker.io/kubermatic/machine-controller:v1.4.2
->>>>>>> Use wrapper instead of initContainer to check if apiserver is reachable (#3857)
+        image: docker.io/kubermatic/machine-controller:v1.4.3
         livenessProbe:
           failureThreshold: 3
           httpGet:

--- a/api/pkg/resources/test/fixtures/deployment-azure-1.12.0-machine-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-azure-1.12.0-machine-controller.yaml
@@ -27,18 +27,25 @@ spec:
     spec:
       containers:
       - args:
-        - -kubeconfig
-        - /etc/kubernetes/kubeconfig/kubeconfig
-        - -logtostderr
-        - -v
-        - "4"
-        - -cluster-dns
-        - 169.254.20.10
-        - -internal-listen-address
-        - 0.0.0.0:8085
+        - -endpoint
+        - https://apiserver-external.cluster-de-test-01.svc.cluster.local.:30000/healthz
+        - -insecure
+        - -retries
+        - "100"
+        - -retry-wait
+        - "2"
+        - -timeout
+        - "1"
+        - -command
+        - '{"command":"/usr/local/bin/machine-controller","args":["-kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","-logtostderr","-v","4","-cluster-dns","169.254.20.10","-internal-listen-address","0.0.0.0:8085"]}'
         command:
+<<<<<<< HEAD
         - /usr/local/bin/machine-controller
         image: docker.io/kubermatic/machine-controller:v1.4.3
+=======
+        - /http-prober-bin/http-prober
+        image: docker.io/kubermatic/machine-controller:v1.4.2
+>>>>>>> Use wrapper instead of initContainer to check if apiserver is reachable (#3857)
         livenessProbe:
           failureThreshold: 3
           httpGet:
@@ -61,30 +68,26 @@ spec:
         - mountPath: /etc/kubernetes/kubeconfig
           name: machinecontroller-kubeconfig
           readOnly: true
+        - mountPath: /http-prober-bin
+          name: http-prober-bin
       imagePullSecrets:
       - name: dockercfg
       initContainers:
-      - args:
-        - -endpoint
-        - https://apiserver-external.cluster-de-test-01.svc.cluster.local.:30000/healthz
-        - -insecure
-        - -retries
-        - "100"
-        - -retry-wait
-        - "2"
-        - -timeout
-        - "1"
-        command:
+      - command:
+        - /bin/cp
         - /usr/local/bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.1
-        imagePullPolicy: IfNotPresent
-        name: apiserver-running
+        - /http-prober-bin/http-prober
+        image: quay.io/kubermatic/http-prober:v0.2-dev0
+        name: copy-http-prober
         resources: {}
-        terminationMessagePath: /dev/termination-log
-        terminationMessagePolicy: File
+        volumeMounts:
+        - mountPath: /http-prober-bin
+          name: http-prober-bin
       volumes:
       - name: machinecontroller-kubeconfig
         secret:
           defaultMode: 292
           secretName: machinecontroller-kubeconfig
+      - emptyDir: {}
+        name: http-prober-bin
 status: {}

--- a/api/pkg/resources/test/fixtures/deployment-azure-1.12.0-metrics-server.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-azure-1.12.0-metrics-server.yaml
@@ -41,22 +41,19 @@ spec:
             weight: 10
       containers:
       - args:
-        - --kubeconfig
-        - /etc/kubernetes/kubeconfig/kubeconfig
-        - --authentication-kubeconfig
-        - /etc/kubernetes/kubeconfig/kubeconfig
-        - --authorization-kubeconfig
-        - /etc/kubernetes/kubeconfig/kubeconfig
-        - --kubelet-port
-        - "10250"
-        - --kubelet-insecure-tls
-        - --kubelet-preferred-address-types
-        - ExternalIP,InternalIP
-        - --v
+        - -endpoint
+        - https://apiserver-external.cluster-de-test-01.svc.cluster.local.:30000/healthz
+        - -insecure
+        - -retries
+        - "100"
+        - -retry-wait
+        - "2"
+        - -timeout
         - "1"
-        - --logtostderr
+        - -command
+        - '{"command":"/metrics-server","args":["--kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","--authentication-kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","--authorization-kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","--kubelet-port","10250","--kubelet-insecure-tls","--kubelet-preferred-address-types","ExternalIP,InternalIP","--v","1","--logtostderr"]}'
         command:
-        - /metrics-server
+        - /http-prober-bin/http-prober
         image: gcr.io/google_containers/metrics-server-amd64:v0.3.2
         name: metrics-server
         resources:
@@ -70,6 +67,8 @@ spec:
         - mountPath: /etc/kubernetes/kubeconfig
           name: metrics-server
           readOnly: true
+        - mountPath: /http-prober-bin
+          name: http-prober-bin
       - args:
         - --client
         - --proto
@@ -158,24 +157,16 @@ spec:
       imagePullSecrets:
       - name: dockercfg
       initContainers:
-      - args:
-        - -endpoint
-        - https://apiserver-external.cluster-de-test-01.svc.cluster.local.:30000/healthz
-        - -insecure
-        - -retries
-        - "100"
-        - -retry-wait
-        - "2"
-        - -timeout
-        - "1"
-        command:
+      - command:
+        - /bin/cp
         - /usr/local/bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.1
-        imagePullPolicy: IfNotPresent
-        name: apiserver-running
+        - /http-prober-bin/http-prober
+        image: quay.io/kubermatic/http-prober:v0.2-dev0
+        name: copy-http-prober
         resources: {}
-        terminationMessagePath: /dev/termination-log
-        terminationMessagePolicy: File
+        volumeMounts:
+        - mountPath: /http-prober-bin
+          name: http-prober-bin
       volumes:
       - name: metrics-server
         secret:
@@ -189,4 +180,6 @@ spec:
         secret:
           defaultMode: 292
           secretName: kubeletdnatcontroller-kubeconfig
+      - emptyDir: {}
+        name: http-prober-bin
 status: {}

--- a/api/pkg/resources/test/fixtures/deployment-azure-1.12.0-metrics-server.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-azure-1.12.0-metrics-server.yaml
@@ -161,7 +161,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.2-dev0
+        image: quay.io/kubermatic/http-prober:v0.2
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/api/pkg/resources/test/fixtures/deployment-azure-1.12.0-scheduler.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-azure-1.12.0-scheduler.yaml
@@ -168,7 +168,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.2-dev0
+        image: quay.io/kubermatic/http-prober:v0.2
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/api/pkg/resources/test/fixtures/deployment-azure-1.12.0-scheduler.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-azure-1.12.0-scheduler.yaml
@@ -100,13 +100,19 @@ spec:
           name: openvpn-client-certificates
           readOnly: true
       - args:
-        - --kubeconfig
-        - /etc/kubernetes/kubeconfig/kubeconfig
-        - --feature-gates
-        - ScheduleDaemonSetPods=false
+        - -endpoint
+        - https://apiserver-external.cluster-de-test-01.svc.cluster.local.:30000/healthz
+        - -insecure
+        - -retries
+        - "100"
+        - -retry-wait
+        - "2"
+        - -timeout
+        - "1"
+        - -command
+        - '{"command":"/hyperkube","args":["kube-scheduler","--kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","--feature-gates","ScheduleDaemonSetPods=false"]}'
         command:
-        - /hyperkube
-        - kube-scheduler
+        - /http-prober-bin/http-prober
         image: gcr.io/google_containers/hyperkube-amd64:v1.12.0
         livenessProbe:
           failureThreshold: 8
@@ -142,6 +148,8 @@ spec:
         - mountPath: /etc/kubernetes/pki/ca
           name: ca
           readOnly: true
+        - mountPath: /http-prober-bin
+          name: http-prober-bin
       dnsConfig:
         nameservers:
         - 192.0.2.14
@@ -156,24 +164,16 @@ spec:
       imagePullSecrets:
       - name: dockercfg
       initContainers:
-      - args:
-        - -endpoint
-        - https://apiserver-external.cluster-de-test-01.svc.cluster.local.:30000/healthz
-        - -insecure
-        - -retries
-        - "100"
-        - -retry-wait
-        - "2"
-        - -timeout
-        - "1"
-        command:
+      - command:
+        - /bin/cp
         - /usr/local/bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.1
-        imagePullPolicy: IfNotPresent
-        name: apiserver-running
+        - /http-prober-bin/http-prober
+        image: quay.io/kubermatic/http-prober:v0.2-dev0
+        name: copy-http-prober
         resources: {}
-        terminationMessagePath: /dev/termination-log
-        terminationMessagePolicy: File
+        volumeMounts:
+        - mountPath: /http-prober-bin
+          name: http-prober-bin
       volumes:
       - name: openvpn-client-certificates
         secret:
@@ -190,4 +190,6 @@ spec:
         secret:
           defaultMode: 256
           secretName: scheduler-kubeconfig
+      - emptyDir: {}
+        name: http-prober-bin
 status: {}

--- a/api/pkg/resources/test/fixtures/deployment-azure-1.12.0-usercluster-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-azure-1.12.0-usercluster-controller.yaml
@@ -85,7 +85,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.2-dev0
+        image: quay.io/kubermatic/http-prober:v0.2
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/api/pkg/resources/test/fixtures/deployment-azure-1.12.0-usercluster-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-azure-1.12.0-usercluster-controller.yaml
@@ -29,32 +29,19 @@ spec:
     spec:
       containers:
       - args:
-        - -kubeconfig
-        - /etc/kubernetes/kubeconfig/kubeconfig
-        - -metrics-listen-address
-        - 0.0.0.0:8085
-        - -health-listen-address
-        - 0.0.0.0:8086
-        - -namespace
-        - $(NAMESPACE)
-        - -ca-cert
-        - /etc/kubernetes/pki/ca/ca.crt
-        - -cluster-url
-        - ""
-        - -openvpn-server-port
-        - "30003"
-        - -overwrite-registry
-        - ""
-        - -openshift=false
-        - -openvpn-ca-cert-file=/etc/kubernetes/pki/openvpn/ca.crt
-        - -openvpn-ca-key-file=/etc/kubernetes/pki/openvpn/ca.key
-        - -logtostderr
-        - -v
+        - -endpoint
+        - https://apiserver-external.cluster-de-test-01.svc.cluster.local.:30000/healthz
+        - -insecure
+        - -retries
+        - "100"
+        - -retry-wait
         - "2"
-        - --ipam-controller-network
-        - 192.168.1.1/24,192.168.1.1,8.8.8.8
+        - -timeout
+        - "1"
+        - -command
+        - '{"command":"/usr/local/bin/user-cluster-controller-manager","args":["-kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","-metrics-listen-address","0.0.0.0:8085","-health-listen-address","0.0.0.0:8086","-namespace","$(NAMESPACE)","-ca-cert","/etc/kubernetes/pki/ca/ca.crt","-cluster-url","","-openvpn-server-port","30003","-overwrite-registry","","-openshift=false","-openvpn-ca-cert-file=/etc/kubernetes/pki/openvpn/ca.crt","-openvpn-ca-key-file=/etc/kubernetes/pki/openvpn/ca.key","-logtostderr","-v","2","--ipam-controller-network","192.168.1.1/24,192.168.1.1,8.8.8.8"]}'
         command:
-        - /usr/local/bin/user-cluster-controller-manager
+        - /http-prober-bin/http-prober
         env:
         - name: NAMESPACE
           valueFrom:
@@ -89,27 +76,21 @@ spec:
         - mountPath: /etc/kubernetes/pki/openvpn
           name: openvpn-ca
           readOnly: true
+        - mountPath: /http-prober-bin
+          name: http-prober-bin
       imagePullSecrets:
       - name: dockercfg
       initContainers:
-      - args:
-        - -endpoint
-        - https://apiserver-external.cluster-de-test-01.svc.cluster.local.:30000/healthz
-        - -insecure
-        - -retries
-        - "100"
-        - -retry-wait
-        - "2"
-        - -timeout
-        - "1"
-        command:
+      - command:
+        - /bin/cp
         - /usr/local/bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.1
-        imagePullPolicy: IfNotPresent
-        name: apiserver-running
+        - /http-prober-bin/http-prober
+        image: quay.io/kubermatic/http-prober:v0.2-dev0
+        name: copy-http-prober
         resources: {}
-        terminationMessagePath: /dev/termination-log
-        terminationMessagePolicy: File
+        volumeMounts:
+        - mountPath: /http-prober-bin
+          name: http-prober-bin
       volumes:
       - name: internal-admin-kubeconfig
         secret:
@@ -126,4 +107,6 @@ spec:
         secret:
           defaultMode: 292
           secretName: openvpn-ca
+      - emptyDir: {}
+        name: http-prober-bin
 status: {}

--- a/api/pkg/resources/test/fixtures/deployment-azure-1.13.0-controller-manager.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-azure-1.13.0-controller-manager.yaml
@@ -176,7 +176,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.2-dev0
+        image: quay.io/kubermatic/http-prober:v0.2
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/api/pkg/resources/test/fixtures/deployment-azure-1.13.0-controller-manager.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-azure-1.13.0-controller-manager.yaml
@@ -102,42 +102,19 @@ spec:
           name: openvpn-client-certificates
           readOnly: true
       - args:
-        - --kubeconfig
-        - /etc/kubernetes/kubeconfig/kubeconfig
-        - --service-account-private-key-file
-        - /etc/kubernetes/service-account-key/sa.key
-        - --root-ca-file
-        - /etc/kubernetes/pki/ca/ca.crt
-        - --cluster-signing-cert-file
-        - /etc/kubernetes/pki/ca/ca.crt
-        - --cluster-signing-key-file
-        - /etc/kubernetes/pki/ca/ca.key
-        - --cluster-cidr
-        - 172.25.0.0/16
-        - --allocate-node-cidrs=true
-        - --controllers
-        - '*,bootstrapsigner,tokencleaner'
-        - --use-service-account-credentials=true
-        - --feature-gates
-        - RotateKubeletClientCertificate=true,RotateKubeletServerCertificate=true,ScheduleDaemonSetPods=false
-        - --cloud-provider
-        - azure
-        - --cloud-config
-        - /etc/kubernetes/cloud/config
-        - --configure-cloud-routes=false
-        - --authentication-kubeconfig
-        - /etc/kubernetes/kubeconfig/kubeconfig
-        - --client-ca-file
-        - /etc/kubernetes/pki/ca/ca.crt
-        - --authentication-kubeconfig
-        - /etc/kubernetes/kubeconfig/kubeconfig
-        - --authorization-kubeconfig
-        - /etc/kubernetes/kubeconfig/kubeconfig
-        - --port
-        - "0"
+        - -endpoint
+        - https://apiserver-external.cluster-de-test-01.svc.cluster.local.:30000/healthz
+        - -insecure
+        - -retries
+        - "100"
+        - -retry-wait
+        - "2"
+        - -timeout
+        - "1"
+        - -command
+        - '{"command":"/hyperkube","args":["kube-controller-manager","--kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","--service-account-private-key-file","/etc/kubernetes/service-account-key/sa.key","--root-ca-file","/etc/kubernetes/pki/ca/ca.crt","--cluster-signing-cert-file","/etc/kubernetes/pki/ca/ca.crt","--cluster-signing-key-file","/etc/kubernetes/pki/ca/ca.key","--cluster-cidr","172.25.0.0/16","--allocate-node-cidrs=true","--controllers","*,bootstrapsigner,tokencleaner","--use-service-account-credentials=true","--feature-gates","RotateKubeletClientCertificate=true,RotateKubeletServerCertificate=true,ScheduleDaemonSetPods=false","--cloud-provider","azure","--cloud-config","/etc/kubernetes/cloud/config","--configure-cloud-routes=false","--authentication-kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","--client-ca-file","/etc/kubernetes/pki/ca/ca.crt","--authentication-kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","--authorization-kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","--port","0"]}'
         command:
-        - /hyperkube
-        - kube-controller-manager
+        - /http-prober-bin/http-prober
         image: gcr.io/google_containers/hyperkube-amd64:v1.13.0
         livenessProbe:
           failureThreshold: 8
@@ -179,6 +156,8 @@ spec:
         - mountPath: /etc/kubernetes/kubeconfig
           name: controllermanager-kubeconfig
           readOnly: true
+        - mountPath: /http-prober-bin
+          name: http-prober-bin
       dnsConfig:
         nameservers:
         - 192.0.2.14
@@ -193,24 +172,16 @@ spec:
       imagePullSecrets:
       - name: dockercfg
       initContainers:
-      - args:
-        - -endpoint
-        - https://apiserver-external.cluster-de-test-01.svc.cluster.local.:30000/healthz
-        - -insecure
-        - -retries
-        - "100"
-        - -retry-wait
-        - "2"
-        - -timeout
-        - "1"
-        command:
+      - command:
+        - /bin/cp
         - /usr/local/bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.1
-        imagePullPolicy: IfNotPresent
-        name: apiserver-running
+        - /http-prober-bin/http-prober
+        image: quay.io/kubermatic/http-prober:v0.2-dev0
+        name: copy-http-prober
         resources: {}
-        terminationMessagePath: /dev/termination-log
-        terminationMessagePolicy: File
+        volumeMounts:
+        - mountPath: /http-prober-bin
+          name: http-prober-bin
       volumes:
       - name: ca
         secret:
@@ -232,4 +203,6 @@ spec:
         secret:
           defaultMode: 256
           secretName: controllermanager-kubeconfig
+      - emptyDir: {}
+        name: http-prober-bin
 status: {}

--- a/api/pkg/resources/test/fixtures/deployment-azure-1.13.0-kube-state-metrics.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-azure-1.13.0-kube-state-metrics.yaml
@@ -21,14 +21,19 @@ spec:
     spec:
       containers:
       - args:
-        - --kubeconfig
-        - /etc/kubernetes/kubeconfig/kubeconfig
-        - --port
-        - "8080"
-        - --telemetry-port
-        - "8081"
+        - -endpoint
+        - https://apiserver-external.cluster-de-test-01.svc.cluster.local.:30000/healthz
+        - -insecure
+        - -retries
+        - "100"
+        - -retry-wait
+        - "2"
+        - -timeout
+        - "1"
+        - -command
+        - '{"command":"/kube-state-metrics","args":["--kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","--port","8080","--telemetry-port","8081"]}'
         command:
-        - /kube-state-metrics
+        - /http-prober-bin/http-prober
         image: quay.io/coreos/kube-state-metrics:v1.6.0
         name: kube-state-metrics
         ports:
@@ -58,30 +63,26 @@ spec:
         - mountPath: /etc/kubernetes/kubeconfig
           name: kube-state-metrics-kubeconfig
           readOnly: true
+        - mountPath: /http-prober-bin
+          name: http-prober-bin
       imagePullSecrets:
       - name: dockercfg
       initContainers:
-      - args:
-        - -endpoint
-        - https://apiserver-external.cluster-de-test-01.svc.cluster.local.:30000/healthz
-        - -insecure
-        - -retries
-        - "100"
-        - -retry-wait
-        - "2"
-        - -timeout
-        - "1"
-        command:
+      - command:
+        - /bin/cp
         - /usr/local/bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.1
-        imagePullPolicy: IfNotPresent
-        name: apiserver-running
+        - /http-prober-bin/http-prober
+        image: quay.io/kubermatic/http-prober:v0.2-dev0
+        name: copy-http-prober
         resources: {}
-        terminationMessagePath: /dev/termination-log
-        terminationMessagePolicy: File
+        volumeMounts:
+        - mountPath: /http-prober-bin
+          name: http-prober-bin
       volumes:
       - name: kube-state-metrics-kubeconfig
         secret:
           defaultMode: 256
           secretName: kube-state-metrics-kubeconfig
+      - emptyDir: {}
+        name: http-prober-bin
 status: {}

--- a/api/pkg/resources/test/fixtures/deployment-azure-1.13.0-kube-state-metrics.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-azure-1.13.0-kube-state-metrics.yaml
@@ -72,7 +72,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.2-dev0
+        image: quay.io/kubermatic/http-prober:v0.2
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/api/pkg/resources/test/fixtures/deployment-azure-1.13.0-machine-controller-webhook.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-azure-1.13.0-machine-controller-webhook.yaml
@@ -36,13 +36,8 @@ spec:
         - -command
         - '{"command":"/usr/local/bin/webhook","args":["-kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","-logtostderr","-v","4","-listen-address","0.0.0.0:9876"]}'
         command:
-<<<<<<< HEAD
-        - /usr/local/bin/webhook
-        image: docker.io/kubermatic/machine-controller:v1.4.3
-=======
         - /http-prober-bin/http-prober
-        image: docker.io/kubermatic/machine-controller:v1.4.2
->>>>>>> Use wrapper instead of initContainer to check if apiserver is reachable (#3857)
+        image: docker.io/kubermatic/machine-controller:v1.4.3
         livenessProbe:
           failureThreshold: 8
           httpGet:

--- a/api/pkg/resources/test/fixtures/deployment-azure-1.13.0-machine-controller-webhook.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-azure-1.13.0-machine-controller-webhook.yaml
@@ -86,7 +86,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.2-dev0
+        image: quay.io/kubermatic/http-prober:v0.2
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/api/pkg/resources/test/fixtures/deployment-azure-1.13.0-machine-controller-webhook.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-azure-1.13.0-machine-controller-webhook.yaml
@@ -24,16 +24,25 @@ spec:
     spec:
       containers:
       - args:
-        - -kubeconfig
-        - /etc/kubernetes/kubeconfig/kubeconfig
-        - -logtostderr
-        - -v
-        - "4"
-        - -listen-address
-        - 0.0.0.0:9876
+        - -endpoint
+        - https://apiserver-external.cluster-de-test-01.svc.cluster.local.:30000/healthz
+        - -insecure
+        - -retries
+        - "100"
+        - -retry-wait
+        - "2"
+        - -timeout
+        - "1"
+        - -command
+        - '{"command":"/usr/local/bin/webhook","args":["-kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","-logtostderr","-v","4","-listen-address","0.0.0.0:9876"]}'
         command:
+<<<<<<< HEAD
         - /usr/local/bin/webhook
         image: docker.io/kubermatic/machine-controller:v1.4.3
+=======
+        - /http-prober-bin/http-prober
+        image: docker.io/kubermatic/machine-controller:v1.4.2
+>>>>>>> Use wrapper instead of initContainer to check if apiserver is reachable (#3857)
         livenessProbe:
           failureThreshold: 8
           httpGet:
@@ -68,27 +77,21 @@ spec:
         - mountPath: /tmp/cert
           name: machinecontroller-webhook-serving-cert
           readOnly: true
+        - mountPath: /http-prober-bin
+          name: http-prober-bin
       imagePullSecrets:
       - name: dockercfg
       initContainers:
-      - args:
-        - -endpoint
-        - https://apiserver-external.cluster-de-test-01.svc.cluster.local.:30000/healthz
-        - -insecure
-        - -retries
-        - "100"
-        - -retry-wait
-        - "2"
-        - -timeout
-        - "1"
-        command:
+      - command:
+        - /bin/cp
         - /usr/local/bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.1
-        imagePullPolicy: IfNotPresent
-        name: apiserver-running
+        - /http-prober-bin/http-prober
+        image: quay.io/kubermatic/http-prober:v0.2-dev0
+        name: copy-http-prober
         resources: {}
-        terminationMessagePath: /dev/termination-log
-        terminationMessagePolicy: File
+        volumeMounts:
+        - mountPath: /http-prober-bin
+          name: http-prober-bin
       volumes:
       - name: machinecontroller-kubeconfig
         secret:
@@ -98,4 +101,6 @@ spec:
         secret:
           defaultMode: 292
           secretName: machinecontroller-webhook-serving-cert
+      - emptyDir: {}
+        name: http-prober-bin
 status: {}

--- a/api/pkg/resources/test/fixtures/deployment-azure-1.13.0-machine-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-azure-1.13.0-machine-controller.yaml
@@ -77,7 +77,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.2-dev0
+        image: quay.io/kubermatic/http-prober:v0.2
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/api/pkg/resources/test/fixtures/deployment-azure-1.13.0-machine-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-azure-1.13.0-machine-controller.yaml
@@ -39,13 +39,8 @@ spec:
         - -command
         - '{"command":"/usr/local/bin/machine-controller","args":["-kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","-logtostderr","-v","4","-cluster-dns","169.254.20.10","-internal-listen-address","0.0.0.0:8085"]}'
         command:
-<<<<<<< HEAD
-        - /usr/local/bin/machine-controller
-        image: docker.io/kubermatic/machine-controller:v1.4.3
-=======
         - /http-prober-bin/http-prober
-        image: docker.io/kubermatic/machine-controller:v1.4.2
->>>>>>> Use wrapper instead of initContainer to check if apiserver is reachable (#3857)
+        image: docker.io/kubermatic/machine-controller:v1.4.3
         livenessProbe:
           failureThreshold: 3
           httpGet:

--- a/api/pkg/resources/test/fixtures/deployment-azure-1.13.0-machine-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-azure-1.13.0-machine-controller.yaml
@@ -27,18 +27,25 @@ spec:
     spec:
       containers:
       - args:
-        - -kubeconfig
-        - /etc/kubernetes/kubeconfig/kubeconfig
-        - -logtostderr
-        - -v
-        - "4"
-        - -cluster-dns
-        - 169.254.20.10
-        - -internal-listen-address
-        - 0.0.0.0:8085
+        - -endpoint
+        - https://apiserver-external.cluster-de-test-01.svc.cluster.local.:30000/healthz
+        - -insecure
+        - -retries
+        - "100"
+        - -retry-wait
+        - "2"
+        - -timeout
+        - "1"
+        - -command
+        - '{"command":"/usr/local/bin/machine-controller","args":["-kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","-logtostderr","-v","4","-cluster-dns","169.254.20.10","-internal-listen-address","0.0.0.0:8085"]}'
         command:
+<<<<<<< HEAD
         - /usr/local/bin/machine-controller
         image: docker.io/kubermatic/machine-controller:v1.4.3
+=======
+        - /http-prober-bin/http-prober
+        image: docker.io/kubermatic/machine-controller:v1.4.2
+>>>>>>> Use wrapper instead of initContainer to check if apiserver is reachable (#3857)
         livenessProbe:
           failureThreshold: 3
           httpGet:
@@ -61,30 +68,26 @@ spec:
         - mountPath: /etc/kubernetes/kubeconfig
           name: machinecontroller-kubeconfig
           readOnly: true
+        - mountPath: /http-prober-bin
+          name: http-prober-bin
       imagePullSecrets:
       - name: dockercfg
       initContainers:
-      - args:
-        - -endpoint
-        - https://apiserver-external.cluster-de-test-01.svc.cluster.local.:30000/healthz
-        - -insecure
-        - -retries
-        - "100"
-        - -retry-wait
-        - "2"
-        - -timeout
-        - "1"
-        command:
+      - command:
+        - /bin/cp
         - /usr/local/bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.1
-        imagePullPolicy: IfNotPresent
-        name: apiserver-running
+        - /http-prober-bin/http-prober
+        image: quay.io/kubermatic/http-prober:v0.2-dev0
+        name: copy-http-prober
         resources: {}
-        terminationMessagePath: /dev/termination-log
-        terminationMessagePolicy: File
+        volumeMounts:
+        - mountPath: /http-prober-bin
+          name: http-prober-bin
       volumes:
       - name: machinecontroller-kubeconfig
         secret:
           defaultMode: 292
           secretName: machinecontroller-kubeconfig
+      - emptyDir: {}
+        name: http-prober-bin
 status: {}

--- a/api/pkg/resources/test/fixtures/deployment-azure-1.13.0-metrics-server.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-azure-1.13.0-metrics-server.yaml
@@ -41,22 +41,19 @@ spec:
             weight: 10
       containers:
       - args:
-        - --kubeconfig
-        - /etc/kubernetes/kubeconfig/kubeconfig
-        - --authentication-kubeconfig
-        - /etc/kubernetes/kubeconfig/kubeconfig
-        - --authorization-kubeconfig
-        - /etc/kubernetes/kubeconfig/kubeconfig
-        - --kubelet-port
-        - "10250"
-        - --kubelet-insecure-tls
-        - --kubelet-preferred-address-types
-        - ExternalIP,InternalIP
-        - --v
+        - -endpoint
+        - https://apiserver-external.cluster-de-test-01.svc.cluster.local.:30000/healthz
+        - -insecure
+        - -retries
+        - "100"
+        - -retry-wait
+        - "2"
+        - -timeout
         - "1"
-        - --logtostderr
+        - -command
+        - '{"command":"/metrics-server","args":["--kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","--authentication-kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","--authorization-kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","--kubelet-port","10250","--kubelet-insecure-tls","--kubelet-preferred-address-types","ExternalIP,InternalIP","--v","1","--logtostderr"]}'
         command:
-        - /metrics-server
+        - /http-prober-bin/http-prober
         image: gcr.io/google_containers/metrics-server-amd64:v0.3.2
         name: metrics-server
         resources:
@@ -70,6 +67,8 @@ spec:
         - mountPath: /etc/kubernetes/kubeconfig
           name: metrics-server
           readOnly: true
+        - mountPath: /http-prober-bin
+          name: http-prober-bin
       - args:
         - --client
         - --proto
@@ -158,24 +157,16 @@ spec:
       imagePullSecrets:
       - name: dockercfg
       initContainers:
-      - args:
-        - -endpoint
-        - https://apiserver-external.cluster-de-test-01.svc.cluster.local.:30000/healthz
-        - -insecure
-        - -retries
-        - "100"
-        - -retry-wait
-        - "2"
-        - -timeout
-        - "1"
-        command:
+      - command:
+        - /bin/cp
         - /usr/local/bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.1
-        imagePullPolicy: IfNotPresent
-        name: apiserver-running
+        - /http-prober-bin/http-prober
+        image: quay.io/kubermatic/http-prober:v0.2-dev0
+        name: copy-http-prober
         resources: {}
-        terminationMessagePath: /dev/termination-log
-        terminationMessagePolicy: File
+        volumeMounts:
+        - mountPath: /http-prober-bin
+          name: http-prober-bin
       volumes:
       - name: metrics-server
         secret:
@@ -189,4 +180,6 @@ spec:
         secret:
           defaultMode: 292
           secretName: kubeletdnatcontroller-kubeconfig
+      - emptyDir: {}
+        name: http-prober-bin
 status: {}

--- a/api/pkg/resources/test/fixtures/deployment-azure-1.13.0-metrics-server.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-azure-1.13.0-metrics-server.yaml
@@ -161,7 +161,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.2-dev0
+        image: quay.io/kubermatic/http-prober:v0.2
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/api/pkg/resources/test/fixtures/deployment-azure-1.13.0-scheduler.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-azure-1.13.0-scheduler.yaml
@@ -100,21 +100,19 @@ spec:
           name: openvpn-client-certificates
           readOnly: true
       - args:
-        - --kubeconfig
-        - /etc/kubernetes/kubeconfig/kubeconfig
-        - --authentication-kubeconfig
-        - /etc/kubernetes/kubeconfig/kubeconfig
-        - --authorization-kubeconfig
-        - /etc/kubernetes/kubeconfig/kubeconfig
-        - --client-ca-file
-        - /etc/kubernetes/pki/ca/ca.crt
-        - --port
-        - "0"
-        - --feature-gates
-        - ScheduleDaemonSetPods=false
+        - -endpoint
+        - https://apiserver-external.cluster-de-test-01.svc.cluster.local.:30000/healthz
+        - -insecure
+        - -retries
+        - "100"
+        - -retry-wait
+        - "2"
+        - -timeout
+        - "1"
+        - -command
+        - '{"command":"/hyperkube","args":["kube-scheduler","--kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","--authentication-kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","--authorization-kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","--client-ca-file","/etc/kubernetes/pki/ca/ca.crt","--port","0","--feature-gates","ScheduleDaemonSetPods=false"]}'
         command:
-        - /hyperkube
-        - kube-scheduler
+        - /http-prober-bin/http-prober
         image: gcr.io/google_containers/hyperkube-amd64:v1.13.0
         livenessProbe:
           failureThreshold: 8
@@ -150,6 +148,8 @@ spec:
         - mountPath: /etc/kubernetes/pki/ca
           name: ca
           readOnly: true
+        - mountPath: /http-prober-bin
+          name: http-prober-bin
       dnsConfig:
         nameservers:
         - 192.0.2.14
@@ -164,24 +164,16 @@ spec:
       imagePullSecrets:
       - name: dockercfg
       initContainers:
-      - args:
-        - -endpoint
-        - https://apiserver-external.cluster-de-test-01.svc.cluster.local.:30000/healthz
-        - -insecure
-        - -retries
-        - "100"
-        - -retry-wait
-        - "2"
-        - -timeout
-        - "1"
-        command:
+      - command:
+        - /bin/cp
         - /usr/local/bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.1
-        imagePullPolicy: IfNotPresent
-        name: apiserver-running
+        - /http-prober-bin/http-prober
+        image: quay.io/kubermatic/http-prober:v0.2-dev0
+        name: copy-http-prober
         resources: {}
-        terminationMessagePath: /dev/termination-log
-        terminationMessagePolicy: File
+        volumeMounts:
+        - mountPath: /http-prober-bin
+          name: http-prober-bin
       volumes:
       - name: openvpn-client-certificates
         secret:
@@ -198,4 +190,6 @@ spec:
         secret:
           defaultMode: 256
           secretName: scheduler-kubeconfig
+      - emptyDir: {}
+        name: http-prober-bin
 status: {}

--- a/api/pkg/resources/test/fixtures/deployment-azure-1.13.0-scheduler.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-azure-1.13.0-scheduler.yaml
@@ -168,7 +168,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.2-dev0
+        image: quay.io/kubermatic/http-prober:v0.2
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/api/pkg/resources/test/fixtures/deployment-azure-1.13.0-usercluster-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-azure-1.13.0-usercluster-controller.yaml
@@ -85,7 +85,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.2-dev0
+        image: quay.io/kubermatic/http-prober:v0.2
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/api/pkg/resources/test/fixtures/deployment-azure-1.13.0-usercluster-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-azure-1.13.0-usercluster-controller.yaml
@@ -29,32 +29,19 @@ spec:
     spec:
       containers:
       - args:
-        - -kubeconfig
-        - /etc/kubernetes/kubeconfig/kubeconfig
-        - -metrics-listen-address
-        - 0.0.0.0:8085
-        - -health-listen-address
-        - 0.0.0.0:8086
-        - -namespace
-        - $(NAMESPACE)
-        - -ca-cert
-        - /etc/kubernetes/pki/ca/ca.crt
-        - -cluster-url
-        - ""
-        - -openvpn-server-port
-        - "30003"
-        - -overwrite-registry
-        - ""
-        - -openshift=false
-        - -openvpn-ca-cert-file=/etc/kubernetes/pki/openvpn/ca.crt
-        - -openvpn-ca-key-file=/etc/kubernetes/pki/openvpn/ca.key
-        - -logtostderr
-        - -v
+        - -endpoint
+        - https://apiserver-external.cluster-de-test-01.svc.cluster.local.:30000/healthz
+        - -insecure
+        - -retries
+        - "100"
+        - -retry-wait
         - "2"
-        - --ipam-controller-network
-        - 192.168.1.1/24,192.168.1.1,8.8.8.8
+        - -timeout
+        - "1"
+        - -command
+        - '{"command":"/usr/local/bin/user-cluster-controller-manager","args":["-kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","-metrics-listen-address","0.0.0.0:8085","-health-listen-address","0.0.0.0:8086","-namespace","$(NAMESPACE)","-ca-cert","/etc/kubernetes/pki/ca/ca.crt","-cluster-url","","-openvpn-server-port","30003","-overwrite-registry","","-openshift=false","-openvpn-ca-cert-file=/etc/kubernetes/pki/openvpn/ca.crt","-openvpn-ca-key-file=/etc/kubernetes/pki/openvpn/ca.key","-logtostderr","-v","2","--ipam-controller-network","192.168.1.1/24,192.168.1.1,8.8.8.8"]}'
         command:
-        - /usr/local/bin/user-cluster-controller-manager
+        - /http-prober-bin/http-prober
         env:
         - name: NAMESPACE
           valueFrom:
@@ -89,27 +76,21 @@ spec:
         - mountPath: /etc/kubernetes/pki/openvpn
           name: openvpn-ca
           readOnly: true
+        - mountPath: /http-prober-bin
+          name: http-prober-bin
       imagePullSecrets:
       - name: dockercfg
       initContainers:
-      - args:
-        - -endpoint
-        - https://apiserver-external.cluster-de-test-01.svc.cluster.local.:30000/healthz
-        - -insecure
-        - -retries
-        - "100"
-        - -retry-wait
-        - "2"
-        - -timeout
-        - "1"
-        command:
+      - command:
+        - /bin/cp
         - /usr/local/bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.1
-        imagePullPolicy: IfNotPresent
-        name: apiserver-running
+        - /http-prober-bin/http-prober
+        image: quay.io/kubermatic/http-prober:v0.2-dev0
+        name: copy-http-prober
         resources: {}
-        terminationMessagePath: /dev/termination-log
-        terminationMessagePolicy: File
+        volumeMounts:
+        - mountPath: /http-prober-bin
+          name: http-prober-bin
       volumes:
       - name: internal-admin-kubeconfig
         secret:
@@ -126,4 +107,6 @@ spec:
         secret:
           defaultMode: 292
           secretName: openvpn-ca
+      - emptyDir: {}
+        name: http-prober-bin
 status: {}

--- a/api/pkg/resources/test/fixtures/deployment-bringyourown-1.10.0-controller-manager.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-bringyourown-1.10.0-controller-manager.yaml
@@ -176,7 +176,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.2-dev0
+        image: quay.io/kubermatic/http-prober:v0.2
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/api/pkg/resources/test/fixtures/deployment-bringyourown-1.10.0-controller-manager.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-bringyourown-1.10.0-controller-manager.yaml
@@ -102,27 +102,19 @@ spec:
           name: openvpn-client-certificates
           readOnly: true
       - args:
-        - --kubeconfig
-        - /etc/kubernetes/kubeconfig/kubeconfig
-        - --service-account-private-key-file
-        - /etc/kubernetes/service-account-key/sa.key
-        - --root-ca-file
-        - /etc/kubernetes/pki/ca/ca.crt
-        - --cluster-signing-cert-file
-        - /etc/kubernetes/pki/ca/ca.crt
-        - --cluster-signing-key-file
-        - /etc/kubernetes/pki/ca/ca.key
-        - --cluster-cidr
-        - 172.25.0.0/16
-        - --allocate-node-cidrs=true
-        - --controllers
-        - '*,bootstrapsigner,tokencleaner'
-        - --use-service-account-credentials=true
-        - --feature-gates
-        - RotateKubeletClientCertificate=true,RotateKubeletServerCertificate=true
+        - -endpoint
+        - https://apiserver-external.cluster-de-test-01.svc.cluster.local.:30000/healthz
+        - -insecure
+        - -retries
+        - "100"
+        - -retry-wait
+        - "2"
+        - -timeout
+        - "1"
+        - -command
+        - '{"command":"/hyperkube","args":["kube-controller-manager","--kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","--service-account-private-key-file","/etc/kubernetes/service-account-key/sa.key","--root-ca-file","/etc/kubernetes/pki/ca/ca.crt","--cluster-signing-cert-file","/etc/kubernetes/pki/ca/ca.crt","--cluster-signing-key-file","/etc/kubernetes/pki/ca/ca.key","--cluster-cidr","172.25.0.0/16","--allocate-node-cidrs=true","--controllers","*,bootstrapsigner,tokencleaner","--use-service-account-credentials=true","--feature-gates","RotateKubeletClientCertificate=true,RotateKubeletServerCertificate=true"]}'
         command:
-        - /hyperkube
-        - kube-controller-manager
+        - /http-prober-bin/http-prober
         image: gcr.io/google_containers/hyperkube-amd64:v1.10.0
         livenessProbe:
           failureThreshold: 8
@@ -164,6 +156,8 @@ spec:
         - mountPath: /etc/kubernetes/kubeconfig
           name: controllermanager-kubeconfig
           readOnly: true
+        - mountPath: /http-prober-bin
+          name: http-prober-bin
       dnsConfig:
         nameservers:
         - 192.0.2.14
@@ -178,24 +172,16 @@ spec:
       imagePullSecrets:
       - name: dockercfg
       initContainers:
-      - args:
-        - -endpoint
-        - https://apiserver-external.cluster-de-test-01.svc.cluster.local.:30000/healthz
-        - -insecure
-        - -retries
-        - "100"
-        - -retry-wait
-        - "2"
-        - -timeout
-        - "1"
-        command:
+      - command:
+        - /bin/cp
         - /usr/local/bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.1
-        imagePullPolicy: IfNotPresent
-        name: apiserver-running
+        - /http-prober-bin/http-prober
+        image: quay.io/kubermatic/http-prober:v0.2-dev0
+        name: copy-http-prober
         resources: {}
-        terminationMessagePath: /dev/termination-log
-        terminationMessagePolicy: File
+        volumeMounts:
+        - mountPath: /http-prober-bin
+          name: http-prober-bin
       volumes:
       - name: ca
         secret:
@@ -217,4 +203,6 @@ spec:
         secret:
           defaultMode: 256
           secretName: controllermanager-kubeconfig
+      - emptyDir: {}
+        name: http-prober-bin
 status: {}

--- a/api/pkg/resources/test/fixtures/deployment-bringyourown-1.10.0-kube-state-metrics.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-bringyourown-1.10.0-kube-state-metrics.yaml
@@ -21,14 +21,19 @@ spec:
     spec:
       containers:
       - args:
-        - --kubeconfig
-        - /etc/kubernetes/kubeconfig/kubeconfig
-        - --port
-        - "8080"
-        - --telemetry-port
-        - "8081"
+        - -endpoint
+        - https://apiserver-external.cluster-de-test-01.svc.cluster.local.:30000/healthz
+        - -insecure
+        - -retries
+        - "100"
+        - -retry-wait
+        - "2"
+        - -timeout
+        - "1"
+        - -command
+        - '{"command":"/kube-state-metrics","args":["--kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","--port","8080","--telemetry-port","8081"]}'
         command:
-        - /kube-state-metrics
+        - /http-prober-bin/http-prober
         image: quay.io/coreos/kube-state-metrics:v1.6.0
         name: kube-state-metrics
         ports:
@@ -58,30 +63,26 @@ spec:
         - mountPath: /etc/kubernetes/kubeconfig
           name: kube-state-metrics-kubeconfig
           readOnly: true
+        - mountPath: /http-prober-bin
+          name: http-prober-bin
       imagePullSecrets:
       - name: dockercfg
       initContainers:
-      - args:
-        - -endpoint
-        - https://apiserver-external.cluster-de-test-01.svc.cluster.local.:30000/healthz
-        - -insecure
-        - -retries
-        - "100"
-        - -retry-wait
-        - "2"
-        - -timeout
-        - "1"
-        command:
+      - command:
+        - /bin/cp
         - /usr/local/bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.1
-        imagePullPolicy: IfNotPresent
-        name: apiserver-running
+        - /http-prober-bin/http-prober
+        image: quay.io/kubermatic/http-prober:v0.2-dev0
+        name: copy-http-prober
         resources: {}
-        terminationMessagePath: /dev/termination-log
-        terminationMessagePolicy: File
+        volumeMounts:
+        - mountPath: /http-prober-bin
+          name: http-prober-bin
       volumes:
       - name: kube-state-metrics-kubeconfig
         secret:
           defaultMode: 256
           secretName: kube-state-metrics-kubeconfig
+      - emptyDir: {}
+        name: http-prober-bin
 status: {}

--- a/api/pkg/resources/test/fixtures/deployment-bringyourown-1.10.0-kube-state-metrics.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-bringyourown-1.10.0-kube-state-metrics.yaml
@@ -72,7 +72,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.2-dev0
+        image: quay.io/kubermatic/http-prober:v0.2
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/api/pkg/resources/test/fixtures/deployment-bringyourown-1.10.0-machine-controller-webhook.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-bringyourown-1.10.0-machine-controller-webhook.yaml
@@ -36,13 +36,8 @@ spec:
         - -command
         - '{"command":"/usr/local/bin/webhook","args":["-kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","-logtostderr","-v","4","-listen-address","0.0.0.0:9876"]}'
         command:
-<<<<<<< HEAD
-        - /usr/local/bin/webhook
-        image: docker.io/kubermatic/machine-controller:v1.4.3
-=======
         - /http-prober-bin/http-prober
-        image: docker.io/kubermatic/machine-controller:v1.4.2
->>>>>>> Use wrapper instead of initContainer to check if apiserver is reachable (#3857)
+        image: docker.io/kubermatic/machine-controller:v1.4.3
         livenessProbe:
           failureThreshold: 8
           httpGet:

--- a/api/pkg/resources/test/fixtures/deployment-bringyourown-1.10.0-machine-controller-webhook.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-bringyourown-1.10.0-machine-controller-webhook.yaml
@@ -86,7 +86,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.2-dev0
+        image: quay.io/kubermatic/http-prober:v0.2
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/api/pkg/resources/test/fixtures/deployment-bringyourown-1.10.0-machine-controller-webhook.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-bringyourown-1.10.0-machine-controller-webhook.yaml
@@ -24,16 +24,25 @@ spec:
     spec:
       containers:
       - args:
-        - -kubeconfig
-        - /etc/kubernetes/kubeconfig/kubeconfig
-        - -logtostderr
-        - -v
-        - "4"
-        - -listen-address
-        - 0.0.0.0:9876
+        - -endpoint
+        - https://apiserver-external.cluster-de-test-01.svc.cluster.local.:30000/healthz
+        - -insecure
+        - -retries
+        - "100"
+        - -retry-wait
+        - "2"
+        - -timeout
+        - "1"
+        - -command
+        - '{"command":"/usr/local/bin/webhook","args":["-kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","-logtostderr","-v","4","-listen-address","0.0.0.0:9876"]}'
         command:
+<<<<<<< HEAD
         - /usr/local/bin/webhook
         image: docker.io/kubermatic/machine-controller:v1.4.3
+=======
+        - /http-prober-bin/http-prober
+        image: docker.io/kubermatic/machine-controller:v1.4.2
+>>>>>>> Use wrapper instead of initContainer to check if apiserver is reachable (#3857)
         livenessProbe:
           failureThreshold: 8
           httpGet:
@@ -68,27 +77,21 @@ spec:
         - mountPath: /tmp/cert
           name: machinecontroller-webhook-serving-cert
           readOnly: true
+        - mountPath: /http-prober-bin
+          name: http-prober-bin
       imagePullSecrets:
       - name: dockercfg
       initContainers:
-      - args:
-        - -endpoint
-        - https://apiserver-external.cluster-de-test-01.svc.cluster.local.:30000/healthz
-        - -insecure
-        - -retries
-        - "100"
-        - -retry-wait
-        - "2"
-        - -timeout
-        - "1"
-        command:
+      - command:
+        - /bin/cp
         - /usr/local/bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.1
-        imagePullPolicy: IfNotPresent
-        name: apiserver-running
+        - /http-prober-bin/http-prober
+        image: quay.io/kubermatic/http-prober:v0.2-dev0
+        name: copy-http-prober
         resources: {}
-        terminationMessagePath: /dev/termination-log
-        terminationMessagePolicy: File
+        volumeMounts:
+        - mountPath: /http-prober-bin
+          name: http-prober-bin
       volumes:
       - name: machinecontroller-kubeconfig
         secret:
@@ -98,4 +101,6 @@ spec:
         secret:
           defaultMode: 292
           secretName: machinecontroller-webhook-serving-cert
+      - emptyDir: {}
+        name: http-prober-bin
 status: {}

--- a/api/pkg/resources/test/fixtures/deployment-bringyourown-1.10.0-machine-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-bringyourown-1.10.0-machine-controller.yaml
@@ -77,7 +77,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.2-dev0
+        image: quay.io/kubermatic/http-prober:v0.2
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/api/pkg/resources/test/fixtures/deployment-bringyourown-1.10.0-machine-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-bringyourown-1.10.0-machine-controller.yaml
@@ -39,13 +39,8 @@ spec:
         - -command
         - '{"command":"/usr/local/bin/machine-controller","args":["-kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","-logtostderr","-v","4","-cluster-dns","169.254.20.10","-internal-listen-address","0.0.0.0:8085"]}'
         command:
-<<<<<<< HEAD
-        - /usr/local/bin/machine-controller
-        image: docker.io/kubermatic/machine-controller:v1.4.3
-=======
         - /http-prober-bin/http-prober
-        image: docker.io/kubermatic/machine-controller:v1.4.2
->>>>>>> Use wrapper instead of initContainer to check if apiserver is reachable (#3857)
+        image: docker.io/kubermatic/machine-controller:v1.4.3
         livenessProbe:
           failureThreshold: 3
           httpGet:

--- a/api/pkg/resources/test/fixtures/deployment-bringyourown-1.10.0-machine-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-bringyourown-1.10.0-machine-controller.yaml
@@ -27,18 +27,25 @@ spec:
     spec:
       containers:
       - args:
-        - -kubeconfig
-        - /etc/kubernetes/kubeconfig/kubeconfig
-        - -logtostderr
-        - -v
-        - "4"
-        - -cluster-dns
-        - 169.254.20.10
-        - -internal-listen-address
-        - 0.0.0.0:8085
+        - -endpoint
+        - https://apiserver-external.cluster-de-test-01.svc.cluster.local.:30000/healthz
+        - -insecure
+        - -retries
+        - "100"
+        - -retry-wait
+        - "2"
+        - -timeout
+        - "1"
+        - -command
+        - '{"command":"/usr/local/bin/machine-controller","args":["-kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","-logtostderr","-v","4","-cluster-dns","169.254.20.10","-internal-listen-address","0.0.0.0:8085"]}'
         command:
+<<<<<<< HEAD
         - /usr/local/bin/machine-controller
         image: docker.io/kubermatic/machine-controller:v1.4.3
+=======
+        - /http-prober-bin/http-prober
+        image: docker.io/kubermatic/machine-controller:v1.4.2
+>>>>>>> Use wrapper instead of initContainer to check if apiserver is reachable (#3857)
         livenessProbe:
           failureThreshold: 3
           httpGet:
@@ -61,30 +68,26 @@ spec:
         - mountPath: /etc/kubernetes/kubeconfig
           name: machinecontroller-kubeconfig
           readOnly: true
+        - mountPath: /http-prober-bin
+          name: http-prober-bin
       imagePullSecrets:
       - name: dockercfg
       initContainers:
-      - args:
-        - -endpoint
-        - https://apiserver-external.cluster-de-test-01.svc.cluster.local.:30000/healthz
-        - -insecure
-        - -retries
-        - "100"
-        - -retry-wait
-        - "2"
-        - -timeout
-        - "1"
-        command:
+      - command:
+        - /bin/cp
         - /usr/local/bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.1
-        imagePullPolicy: IfNotPresent
-        name: apiserver-running
+        - /http-prober-bin/http-prober
+        image: quay.io/kubermatic/http-prober:v0.2-dev0
+        name: copy-http-prober
         resources: {}
-        terminationMessagePath: /dev/termination-log
-        terminationMessagePolicy: File
+        volumeMounts:
+        - mountPath: /http-prober-bin
+          name: http-prober-bin
       volumes:
       - name: machinecontroller-kubeconfig
         secret:
           defaultMode: 292
           secretName: machinecontroller-kubeconfig
+      - emptyDir: {}
+        name: http-prober-bin
 status: {}

--- a/api/pkg/resources/test/fixtures/deployment-bringyourown-1.10.0-metrics-server.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-bringyourown-1.10.0-metrics-server.yaml
@@ -41,22 +41,19 @@ spec:
             weight: 10
       containers:
       - args:
-        - --kubeconfig
-        - /etc/kubernetes/kubeconfig/kubeconfig
-        - --authentication-kubeconfig
-        - /etc/kubernetes/kubeconfig/kubeconfig
-        - --authorization-kubeconfig
-        - /etc/kubernetes/kubeconfig/kubeconfig
-        - --kubelet-port
-        - "10250"
-        - --kubelet-insecure-tls
-        - --kubelet-preferred-address-types
-        - ExternalIP,InternalIP
-        - --v
+        - -endpoint
+        - https://apiserver-external.cluster-de-test-01.svc.cluster.local.:30000/healthz
+        - -insecure
+        - -retries
+        - "100"
+        - -retry-wait
+        - "2"
+        - -timeout
         - "1"
-        - --logtostderr
+        - -command
+        - '{"command":"/metrics-server","args":["--kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","--authentication-kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","--authorization-kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","--kubelet-port","10250","--kubelet-insecure-tls","--kubelet-preferred-address-types","ExternalIP,InternalIP","--v","1","--logtostderr"]}'
         command:
-        - /metrics-server
+        - /http-prober-bin/http-prober
         image: gcr.io/google_containers/metrics-server-amd64:v0.3.2
         name: metrics-server
         resources:
@@ -70,6 +67,8 @@ spec:
         - mountPath: /etc/kubernetes/kubeconfig
           name: metrics-server
           readOnly: true
+        - mountPath: /http-prober-bin
+          name: http-prober-bin
       - args:
         - --client
         - --proto
@@ -158,24 +157,16 @@ spec:
       imagePullSecrets:
       - name: dockercfg
       initContainers:
-      - args:
-        - -endpoint
-        - https://apiserver-external.cluster-de-test-01.svc.cluster.local.:30000/healthz
-        - -insecure
-        - -retries
-        - "100"
-        - -retry-wait
-        - "2"
-        - -timeout
-        - "1"
-        command:
+      - command:
+        - /bin/cp
         - /usr/local/bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.1
-        imagePullPolicy: IfNotPresent
-        name: apiserver-running
+        - /http-prober-bin/http-prober
+        image: quay.io/kubermatic/http-prober:v0.2-dev0
+        name: copy-http-prober
         resources: {}
-        terminationMessagePath: /dev/termination-log
-        terminationMessagePolicy: File
+        volumeMounts:
+        - mountPath: /http-prober-bin
+          name: http-prober-bin
       volumes:
       - name: metrics-server
         secret:
@@ -189,4 +180,6 @@ spec:
         secret:
           defaultMode: 292
           secretName: kubeletdnatcontroller-kubeconfig
+      - emptyDir: {}
+        name: http-prober-bin
 status: {}

--- a/api/pkg/resources/test/fixtures/deployment-bringyourown-1.10.0-metrics-server.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-bringyourown-1.10.0-metrics-server.yaml
@@ -161,7 +161,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.2-dev0
+        image: quay.io/kubermatic/http-prober:v0.2
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/api/pkg/resources/test/fixtures/deployment-bringyourown-1.10.0-scheduler.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-bringyourown-1.10.0-scheduler.yaml
@@ -100,11 +100,19 @@ spec:
           name: openvpn-client-certificates
           readOnly: true
       - args:
-        - --kubeconfig
-        - /etc/kubernetes/kubeconfig/kubeconfig
+        - -endpoint
+        - https://apiserver-external.cluster-de-test-01.svc.cluster.local.:30000/healthz
+        - -insecure
+        - -retries
+        - "100"
+        - -retry-wait
+        - "2"
+        - -timeout
+        - "1"
+        - -command
+        - '{"command":"/hyperkube","args":["kube-scheduler","--kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig"]}'
         command:
-        - /hyperkube
-        - kube-scheduler
+        - /http-prober-bin/http-prober
         image: gcr.io/google_containers/hyperkube-amd64:v1.10.0
         livenessProbe:
           failureThreshold: 8
@@ -140,6 +148,8 @@ spec:
         - mountPath: /etc/kubernetes/pki/ca
           name: ca
           readOnly: true
+        - mountPath: /http-prober-bin
+          name: http-prober-bin
       dnsConfig:
         nameservers:
         - 192.0.2.14
@@ -154,24 +164,16 @@ spec:
       imagePullSecrets:
       - name: dockercfg
       initContainers:
-      - args:
-        - -endpoint
-        - https://apiserver-external.cluster-de-test-01.svc.cluster.local.:30000/healthz
-        - -insecure
-        - -retries
-        - "100"
-        - -retry-wait
-        - "2"
-        - -timeout
-        - "1"
-        command:
+      - command:
+        - /bin/cp
         - /usr/local/bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.1
-        imagePullPolicy: IfNotPresent
-        name: apiserver-running
+        - /http-prober-bin/http-prober
+        image: quay.io/kubermatic/http-prober:v0.2-dev0
+        name: copy-http-prober
         resources: {}
-        terminationMessagePath: /dev/termination-log
-        terminationMessagePolicy: File
+        volumeMounts:
+        - mountPath: /http-prober-bin
+          name: http-prober-bin
       volumes:
       - name: openvpn-client-certificates
         secret:
@@ -188,4 +190,6 @@ spec:
         secret:
           defaultMode: 256
           secretName: scheduler-kubeconfig
+      - emptyDir: {}
+        name: http-prober-bin
 status: {}

--- a/api/pkg/resources/test/fixtures/deployment-bringyourown-1.10.0-scheduler.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-bringyourown-1.10.0-scheduler.yaml
@@ -168,7 +168,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.2-dev0
+        image: quay.io/kubermatic/http-prober:v0.2
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/api/pkg/resources/test/fixtures/deployment-bringyourown-1.10.0-usercluster-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-bringyourown-1.10.0-usercluster-controller.yaml
@@ -85,7 +85,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.2-dev0
+        image: quay.io/kubermatic/http-prober:v0.2
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/api/pkg/resources/test/fixtures/deployment-bringyourown-1.10.0-usercluster-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-bringyourown-1.10.0-usercluster-controller.yaml
@@ -29,32 +29,19 @@ spec:
     spec:
       containers:
       - args:
-        - -kubeconfig
-        - /etc/kubernetes/kubeconfig/kubeconfig
-        - -metrics-listen-address
-        - 0.0.0.0:8085
-        - -health-listen-address
-        - 0.0.0.0:8086
-        - -namespace
-        - $(NAMESPACE)
-        - -ca-cert
-        - /etc/kubernetes/pki/ca/ca.crt
-        - -cluster-url
-        - ""
-        - -openvpn-server-port
-        - "30003"
-        - -overwrite-registry
-        - ""
-        - -openshift=false
-        - -openvpn-ca-cert-file=/etc/kubernetes/pki/openvpn/ca.crt
-        - -openvpn-ca-key-file=/etc/kubernetes/pki/openvpn/ca.key
-        - -logtostderr
-        - -v
+        - -endpoint
+        - https://apiserver-external.cluster-de-test-01.svc.cluster.local.:30000/healthz
+        - -insecure
+        - -retries
+        - "100"
+        - -retry-wait
         - "2"
-        - --ipam-controller-network
-        - 192.168.1.1/24,192.168.1.1,8.8.8.8
+        - -timeout
+        - "1"
+        - -command
+        - '{"command":"/usr/local/bin/user-cluster-controller-manager","args":["-kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","-metrics-listen-address","0.0.0.0:8085","-health-listen-address","0.0.0.0:8086","-namespace","$(NAMESPACE)","-ca-cert","/etc/kubernetes/pki/ca/ca.crt","-cluster-url","","-openvpn-server-port","30003","-overwrite-registry","","-openshift=false","-openvpn-ca-cert-file=/etc/kubernetes/pki/openvpn/ca.crt","-openvpn-ca-key-file=/etc/kubernetes/pki/openvpn/ca.key","-logtostderr","-v","2","--ipam-controller-network","192.168.1.1/24,192.168.1.1,8.8.8.8"]}'
         command:
-        - /usr/local/bin/user-cluster-controller-manager
+        - /http-prober-bin/http-prober
         env:
         - name: NAMESPACE
           valueFrom:
@@ -89,27 +76,21 @@ spec:
         - mountPath: /etc/kubernetes/pki/openvpn
           name: openvpn-ca
           readOnly: true
+        - mountPath: /http-prober-bin
+          name: http-prober-bin
       imagePullSecrets:
       - name: dockercfg
       initContainers:
-      - args:
-        - -endpoint
-        - https://apiserver-external.cluster-de-test-01.svc.cluster.local.:30000/healthz
-        - -insecure
-        - -retries
-        - "100"
-        - -retry-wait
-        - "2"
-        - -timeout
-        - "1"
-        command:
+      - command:
+        - /bin/cp
         - /usr/local/bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.1
-        imagePullPolicy: IfNotPresent
-        name: apiserver-running
+        - /http-prober-bin/http-prober
+        image: quay.io/kubermatic/http-prober:v0.2-dev0
+        name: copy-http-prober
         resources: {}
-        terminationMessagePath: /dev/termination-log
-        terminationMessagePolicy: File
+        volumeMounts:
+        - mountPath: /http-prober-bin
+          name: http-prober-bin
       volumes:
       - name: internal-admin-kubeconfig
         secret:
@@ -126,4 +107,6 @@ spec:
         secret:
           defaultMode: 292
           secretName: openvpn-ca
+      - emptyDir: {}
+        name: http-prober-bin
 status: {}

--- a/api/pkg/resources/test/fixtures/deployment-bringyourown-1.10.6-controller-manager.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-bringyourown-1.10.6-controller-manager.yaml
@@ -102,27 +102,19 @@ spec:
           name: openvpn-client-certificates
           readOnly: true
       - args:
-        - --kubeconfig
-        - /etc/kubernetes/kubeconfig/kubeconfig
-        - --service-account-private-key-file
-        - /etc/kubernetes/service-account-key/sa.key
-        - --root-ca-file
-        - /etc/kubernetes/pki/ca/ca.crt
-        - --cluster-signing-cert-file
-        - /etc/kubernetes/pki/ca/ca.crt
-        - --cluster-signing-key-file
-        - /etc/kubernetes/pki/ca/ca.key
-        - --cluster-cidr
-        - 172.25.0.0/16
-        - --allocate-node-cidrs=true
-        - --controllers
-        - '*,bootstrapsigner,tokencleaner'
-        - --use-service-account-credentials=true
-        - --feature-gates
-        - RotateKubeletClientCertificate=true,RotateKubeletServerCertificate=true
+        - -endpoint
+        - https://apiserver-external.cluster-de-test-01.svc.cluster.local.:30000/healthz
+        - -insecure
+        - -retries
+        - "100"
+        - -retry-wait
+        - "2"
+        - -timeout
+        - "1"
+        - -command
+        - '{"command":"/hyperkube","args":["kube-controller-manager","--kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","--service-account-private-key-file","/etc/kubernetes/service-account-key/sa.key","--root-ca-file","/etc/kubernetes/pki/ca/ca.crt","--cluster-signing-cert-file","/etc/kubernetes/pki/ca/ca.crt","--cluster-signing-key-file","/etc/kubernetes/pki/ca/ca.key","--cluster-cidr","172.25.0.0/16","--allocate-node-cidrs=true","--controllers","*,bootstrapsigner,tokencleaner","--use-service-account-credentials=true","--feature-gates","RotateKubeletClientCertificate=true,RotateKubeletServerCertificate=true"]}'
         command:
-        - /hyperkube
-        - kube-controller-manager
+        - /http-prober-bin/http-prober
         image: gcr.io/google_containers/hyperkube-amd64:v1.10.6
         livenessProbe:
           failureThreshold: 8
@@ -164,6 +156,8 @@ spec:
         - mountPath: /etc/kubernetes/kubeconfig
           name: controllermanager-kubeconfig
           readOnly: true
+        - mountPath: /http-prober-bin
+          name: http-prober-bin
       dnsConfig:
         nameservers:
         - 192.0.2.14
@@ -178,24 +172,16 @@ spec:
       imagePullSecrets:
       - name: dockercfg
       initContainers:
-      - args:
-        - -endpoint
-        - https://apiserver-external.cluster-de-test-01.svc.cluster.local.:30000/healthz
-        - -insecure
-        - -retries
-        - "100"
-        - -retry-wait
-        - "2"
-        - -timeout
-        - "1"
-        command:
+      - command:
+        - /bin/cp
         - /usr/local/bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.1
-        imagePullPolicy: IfNotPresent
-        name: apiserver-running
+        - /http-prober-bin/http-prober
+        image: quay.io/kubermatic/http-prober:v0.2-dev0
+        name: copy-http-prober
         resources: {}
-        terminationMessagePath: /dev/termination-log
-        terminationMessagePolicy: File
+        volumeMounts:
+        - mountPath: /http-prober-bin
+          name: http-prober-bin
       volumes:
       - name: ca
         secret:
@@ -217,4 +203,6 @@ spec:
         secret:
           defaultMode: 256
           secretName: controllermanager-kubeconfig
+      - emptyDir: {}
+        name: http-prober-bin
 status: {}

--- a/api/pkg/resources/test/fixtures/deployment-bringyourown-1.10.6-controller-manager.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-bringyourown-1.10.6-controller-manager.yaml
@@ -176,7 +176,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.2-dev0
+        image: quay.io/kubermatic/http-prober:v0.2
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/api/pkg/resources/test/fixtures/deployment-bringyourown-1.10.6-kube-state-metrics.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-bringyourown-1.10.6-kube-state-metrics.yaml
@@ -21,14 +21,19 @@ spec:
     spec:
       containers:
       - args:
-        - --kubeconfig
-        - /etc/kubernetes/kubeconfig/kubeconfig
-        - --port
-        - "8080"
-        - --telemetry-port
-        - "8081"
+        - -endpoint
+        - https://apiserver-external.cluster-de-test-01.svc.cluster.local.:30000/healthz
+        - -insecure
+        - -retries
+        - "100"
+        - -retry-wait
+        - "2"
+        - -timeout
+        - "1"
+        - -command
+        - '{"command":"/kube-state-metrics","args":["--kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","--port","8080","--telemetry-port","8081"]}'
         command:
-        - /kube-state-metrics
+        - /http-prober-bin/http-prober
         image: quay.io/coreos/kube-state-metrics:v1.6.0
         name: kube-state-metrics
         ports:
@@ -58,30 +63,26 @@ spec:
         - mountPath: /etc/kubernetes/kubeconfig
           name: kube-state-metrics-kubeconfig
           readOnly: true
+        - mountPath: /http-prober-bin
+          name: http-prober-bin
       imagePullSecrets:
       - name: dockercfg
       initContainers:
-      - args:
-        - -endpoint
-        - https://apiserver-external.cluster-de-test-01.svc.cluster.local.:30000/healthz
-        - -insecure
-        - -retries
-        - "100"
-        - -retry-wait
-        - "2"
-        - -timeout
-        - "1"
-        command:
+      - command:
+        - /bin/cp
         - /usr/local/bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.1
-        imagePullPolicy: IfNotPresent
-        name: apiserver-running
+        - /http-prober-bin/http-prober
+        image: quay.io/kubermatic/http-prober:v0.2-dev0
+        name: copy-http-prober
         resources: {}
-        terminationMessagePath: /dev/termination-log
-        terminationMessagePolicy: File
+        volumeMounts:
+        - mountPath: /http-prober-bin
+          name: http-prober-bin
       volumes:
       - name: kube-state-metrics-kubeconfig
         secret:
           defaultMode: 256
           secretName: kube-state-metrics-kubeconfig
+      - emptyDir: {}
+        name: http-prober-bin
 status: {}

--- a/api/pkg/resources/test/fixtures/deployment-bringyourown-1.10.6-kube-state-metrics.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-bringyourown-1.10.6-kube-state-metrics.yaml
@@ -72,7 +72,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.2-dev0
+        image: quay.io/kubermatic/http-prober:v0.2
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/api/pkg/resources/test/fixtures/deployment-bringyourown-1.10.6-machine-controller-webhook.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-bringyourown-1.10.6-machine-controller-webhook.yaml
@@ -36,13 +36,8 @@ spec:
         - -command
         - '{"command":"/usr/local/bin/webhook","args":["-kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","-logtostderr","-v","4","-listen-address","0.0.0.0:9876"]}'
         command:
-<<<<<<< HEAD
-        - /usr/local/bin/webhook
-        image: docker.io/kubermatic/machine-controller:v1.4.3
-=======
         - /http-prober-bin/http-prober
-        image: docker.io/kubermatic/machine-controller:v1.4.2
->>>>>>> Use wrapper instead of initContainer to check if apiserver is reachable (#3857)
+        image: docker.io/kubermatic/machine-controller:v1.4.3
         livenessProbe:
           failureThreshold: 8
           httpGet:

--- a/api/pkg/resources/test/fixtures/deployment-bringyourown-1.10.6-machine-controller-webhook.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-bringyourown-1.10.6-machine-controller-webhook.yaml
@@ -86,7 +86,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.2-dev0
+        image: quay.io/kubermatic/http-prober:v0.2
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/api/pkg/resources/test/fixtures/deployment-bringyourown-1.10.6-machine-controller-webhook.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-bringyourown-1.10.6-machine-controller-webhook.yaml
@@ -24,16 +24,25 @@ spec:
     spec:
       containers:
       - args:
-        - -kubeconfig
-        - /etc/kubernetes/kubeconfig/kubeconfig
-        - -logtostderr
-        - -v
-        - "4"
-        - -listen-address
-        - 0.0.0.0:9876
+        - -endpoint
+        - https://apiserver-external.cluster-de-test-01.svc.cluster.local.:30000/healthz
+        - -insecure
+        - -retries
+        - "100"
+        - -retry-wait
+        - "2"
+        - -timeout
+        - "1"
+        - -command
+        - '{"command":"/usr/local/bin/webhook","args":["-kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","-logtostderr","-v","4","-listen-address","0.0.0.0:9876"]}'
         command:
+<<<<<<< HEAD
         - /usr/local/bin/webhook
         image: docker.io/kubermatic/machine-controller:v1.4.3
+=======
+        - /http-prober-bin/http-prober
+        image: docker.io/kubermatic/machine-controller:v1.4.2
+>>>>>>> Use wrapper instead of initContainer to check if apiserver is reachable (#3857)
         livenessProbe:
           failureThreshold: 8
           httpGet:
@@ -68,27 +77,21 @@ spec:
         - mountPath: /tmp/cert
           name: machinecontroller-webhook-serving-cert
           readOnly: true
+        - mountPath: /http-prober-bin
+          name: http-prober-bin
       imagePullSecrets:
       - name: dockercfg
       initContainers:
-      - args:
-        - -endpoint
-        - https://apiserver-external.cluster-de-test-01.svc.cluster.local.:30000/healthz
-        - -insecure
-        - -retries
-        - "100"
-        - -retry-wait
-        - "2"
-        - -timeout
-        - "1"
-        command:
+      - command:
+        - /bin/cp
         - /usr/local/bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.1
-        imagePullPolicy: IfNotPresent
-        name: apiserver-running
+        - /http-prober-bin/http-prober
+        image: quay.io/kubermatic/http-prober:v0.2-dev0
+        name: copy-http-prober
         resources: {}
-        terminationMessagePath: /dev/termination-log
-        terminationMessagePolicy: File
+        volumeMounts:
+        - mountPath: /http-prober-bin
+          name: http-prober-bin
       volumes:
       - name: machinecontroller-kubeconfig
         secret:
@@ -98,4 +101,6 @@ spec:
         secret:
           defaultMode: 292
           secretName: machinecontroller-webhook-serving-cert
+      - emptyDir: {}
+        name: http-prober-bin
 status: {}

--- a/api/pkg/resources/test/fixtures/deployment-bringyourown-1.10.6-machine-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-bringyourown-1.10.6-machine-controller.yaml
@@ -77,7 +77,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.2-dev0
+        image: quay.io/kubermatic/http-prober:v0.2
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/api/pkg/resources/test/fixtures/deployment-bringyourown-1.10.6-machine-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-bringyourown-1.10.6-machine-controller.yaml
@@ -39,13 +39,8 @@ spec:
         - -command
         - '{"command":"/usr/local/bin/machine-controller","args":["-kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","-logtostderr","-v","4","-cluster-dns","169.254.20.10","-internal-listen-address","0.0.0.0:8085"]}'
         command:
-<<<<<<< HEAD
-        - /usr/local/bin/machine-controller
-        image: docker.io/kubermatic/machine-controller:v1.4.3
-=======
         - /http-prober-bin/http-prober
-        image: docker.io/kubermatic/machine-controller:v1.4.2
->>>>>>> Use wrapper instead of initContainer to check if apiserver is reachable (#3857)
+        image: docker.io/kubermatic/machine-controller:v1.4.3
         livenessProbe:
           failureThreshold: 3
           httpGet:

--- a/api/pkg/resources/test/fixtures/deployment-bringyourown-1.10.6-machine-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-bringyourown-1.10.6-machine-controller.yaml
@@ -27,18 +27,25 @@ spec:
     spec:
       containers:
       - args:
-        - -kubeconfig
-        - /etc/kubernetes/kubeconfig/kubeconfig
-        - -logtostderr
-        - -v
-        - "4"
-        - -cluster-dns
-        - 169.254.20.10
-        - -internal-listen-address
-        - 0.0.0.0:8085
+        - -endpoint
+        - https://apiserver-external.cluster-de-test-01.svc.cluster.local.:30000/healthz
+        - -insecure
+        - -retries
+        - "100"
+        - -retry-wait
+        - "2"
+        - -timeout
+        - "1"
+        - -command
+        - '{"command":"/usr/local/bin/machine-controller","args":["-kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","-logtostderr","-v","4","-cluster-dns","169.254.20.10","-internal-listen-address","0.0.0.0:8085"]}'
         command:
+<<<<<<< HEAD
         - /usr/local/bin/machine-controller
         image: docker.io/kubermatic/machine-controller:v1.4.3
+=======
+        - /http-prober-bin/http-prober
+        image: docker.io/kubermatic/machine-controller:v1.4.2
+>>>>>>> Use wrapper instead of initContainer to check if apiserver is reachable (#3857)
         livenessProbe:
           failureThreshold: 3
           httpGet:
@@ -61,30 +68,26 @@ spec:
         - mountPath: /etc/kubernetes/kubeconfig
           name: machinecontroller-kubeconfig
           readOnly: true
+        - mountPath: /http-prober-bin
+          name: http-prober-bin
       imagePullSecrets:
       - name: dockercfg
       initContainers:
-      - args:
-        - -endpoint
-        - https://apiserver-external.cluster-de-test-01.svc.cluster.local.:30000/healthz
-        - -insecure
-        - -retries
-        - "100"
-        - -retry-wait
-        - "2"
-        - -timeout
-        - "1"
-        command:
+      - command:
+        - /bin/cp
         - /usr/local/bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.1
-        imagePullPolicy: IfNotPresent
-        name: apiserver-running
+        - /http-prober-bin/http-prober
+        image: quay.io/kubermatic/http-prober:v0.2-dev0
+        name: copy-http-prober
         resources: {}
-        terminationMessagePath: /dev/termination-log
-        terminationMessagePolicy: File
+        volumeMounts:
+        - mountPath: /http-prober-bin
+          name: http-prober-bin
       volumes:
       - name: machinecontroller-kubeconfig
         secret:
           defaultMode: 292
           secretName: machinecontroller-kubeconfig
+      - emptyDir: {}
+        name: http-prober-bin
 status: {}

--- a/api/pkg/resources/test/fixtures/deployment-bringyourown-1.10.6-metrics-server.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-bringyourown-1.10.6-metrics-server.yaml
@@ -41,22 +41,19 @@ spec:
             weight: 10
       containers:
       - args:
-        - --kubeconfig
-        - /etc/kubernetes/kubeconfig/kubeconfig
-        - --authentication-kubeconfig
-        - /etc/kubernetes/kubeconfig/kubeconfig
-        - --authorization-kubeconfig
-        - /etc/kubernetes/kubeconfig/kubeconfig
-        - --kubelet-port
-        - "10250"
-        - --kubelet-insecure-tls
-        - --kubelet-preferred-address-types
-        - ExternalIP,InternalIP
-        - --v
+        - -endpoint
+        - https://apiserver-external.cluster-de-test-01.svc.cluster.local.:30000/healthz
+        - -insecure
+        - -retries
+        - "100"
+        - -retry-wait
+        - "2"
+        - -timeout
         - "1"
-        - --logtostderr
+        - -command
+        - '{"command":"/metrics-server","args":["--kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","--authentication-kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","--authorization-kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","--kubelet-port","10250","--kubelet-insecure-tls","--kubelet-preferred-address-types","ExternalIP,InternalIP","--v","1","--logtostderr"]}'
         command:
-        - /metrics-server
+        - /http-prober-bin/http-prober
         image: gcr.io/google_containers/metrics-server-amd64:v0.3.2
         name: metrics-server
         resources:
@@ -70,6 +67,8 @@ spec:
         - mountPath: /etc/kubernetes/kubeconfig
           name: metrics-server
           readOnly: true
+        - mountPath: /http-prober-bin
+          name: http-prober-bin
       - args:
         - --client
         - --proto
@@ -158,24 +157,16 @@ spec:
       imagePullSecrets:
       - name: dockercfg
       initContainers:
-      - args:
-        - -endpoint
-        - https://apiserver-external.cluster-de-test-01.svc.cluster.local.:30000/healthz
-        - -insecure
-        - -retries
-        - "100"
-        - -retry-wait
-        - "2"
-        - -timeout
-        - "1"
-        command:
+      - command:
+        - /bin/cp
         - /usr/local/bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.1
-        imagePullPolicy: IfNotPresent
-        name: apiserver-running
+        - /http-prober-bin/http-prober
+        image: quay.io/kubermatic/http-prober:v0.2-dev0
+        name: copy-http-prober
         resources: {}
-        terminationMessagePath: /dev/termination-log
-        terminationMessagePolicy: File
+        volumeMounts:
+        - mountPath: /http-prober-bin
+          name: http-prober-bin
       volumes:
       - name: metrics-server
         secret:
@@ -189,4 +180,6 @@ spec:
         secret:
           defaultMode: 292
           secretName: kubeletdnatcontroller-kubeconfig
+      - emptyDir: {}
+        name: http-prober-bin
 status: {}

--- a/api/pkg/resources/test/fixtures/deployment-bringyourown-1.10.6-metrics-server.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-bringyourown-1.10.6-metrics-server.yaml
@@ -161,7 +161,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.2-dev0
+        image: quay.io/kubermatic/http-prober:v0.2
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/api/pkg/resources/test/fixtures/deployment-bringyourown-1.10.6-scheduler.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-bringyourown-1.10.6-scheduler.yaml
@@ -100,11 +100,19 @@ spec:
           name: openvpn-client-certificates
           readOnly: true
       - args:
-        - --kubeconfig
-        - /etc/kubernetes/kubeconfig/kubeconfig
+        - -endpoint
+        - https://apiserver-external.cluster-de-test-01.svc.cluster.local.:30000/healthz
+        - -insecure
+        - -retries
+        - "100"
+        - -retry-wait
+        - "2"
+        - -timeout
+        - "1"
+        - -command
+        - '{"command":"/hyperkube","args":["kube-scheduler","--kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig"]}'
         command:
-        - /hyperkube
-        - kube-scheduler
+        - /http-prober-bin/http-prober
         image: gcr.io/google_containers/hyperkube-amd64:v1.10.6
         livenessProbe:
           failureThreshold: 8
@@ -140,6 +148,8 @@ spec:
         - mountPath: /etc/kubernetes/pki/ca
           name: ca
           readOnly: true
+        - mountPath: /http-prober-bin
+          name: http-prober-bin
       dnsConfig:
         nameservers:
         - 192.0.2.14
@@ -154,24 +164,16 @@ spec:
       imagePullSecrets:
       - name: dockercfg
       initContainers:
-      - args:
-        - -endpoint
-        - https://apiserver-external.cluster-de-test-01.svc.cluster.local.:30000/healthz
-        - -insecure
-        - -retries
-        - "100"
-        - -retry-wait
-        - "2"
-        - -timeout
-        - "1"
-        command:
+      - command:
+        - /bin/cp
         - /usr/local/bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.1
-        imagePullPolicy: IfNotPresent
-        name: apiserver-running
+        - /http-prober-bin/http-prober
+        image: quay.io/kubermatic/http-prober:v0.2-dev0
+        name: copy-http-prober
         resources: {}
-        terminationMessagePath: /dev/termination-log
-        terminationMessagePolicy: File
+        volumeMounts:
+        - mountPath: /http-prober-bin
+          name: http-prober-bin
       volumes:
       - name: openvpn-client-certificates
         secret:
@@ -188,4 +190,6 @@ spec:
         secret:
           defaultMode: 256
           secretName: scheduler-kubeconfig
+      - emptyDir: {}
+        name: http-prober-bin
 status: {}

--- a/api/pkg/resources/test/fixtures/deployment-bringyourown-1.10.6-scheduler.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-bringyourown-1.10.6-scheduler.yaml
@@ -168,7 +168,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.2-dev0
+        image: quay.io/kubermatic/http-prober:v0.2
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/api/pkg/resources/test/fixtures/deployment-bringyourown-1.10.6-usercluster-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-bringyourown-1.10.6-usercluster-controller.yaml
@@ -85,7 +85,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.2-dev0
+        image: quay.io/kubermatic/http-prober:v0.2
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/api/pkg/resources/test/fixtures/deployment-bringyourown-1.10.6-usercluster-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-bringyourown-1.10.6-usercluster-controller.yaml
@@ -29,32 +29,19 @@ spec:
     spec:
       containers:
       - args:
-        - -kubeconfig
-        - /etc/kubernetes/kubeconfig/kubeconfig
-        - -metrics-listen-address
-        - 0.0.0.0:8085
-        - -health-listen-address
-        - 0.0.0.0:8086
-        - -namespace
-        - $(NAMESPACE)
-        - -ca-cert
-        - /etc/kubernetes/pki/ca/ca.crt
-        - -cluster-url
-        - ""
-        - -openvpn-server-port
-        - "30003"
-        - -overwrite-registry
-        - ""
-        - -openshift=false
-        - -openvpn-ca-cert-file=/etc/kubernetes/pki/openvpn/ca.crt
-        - -openvpn-ca-key-file=/etc/kubernetes/pki/openvpn/ca.key
-        - -logtostderr
-        - -v
+        - -endpoint
+        - https://apiserver-external.cluster-de-test-01.svc.cluster.local.:30000/healthz
+        - -insecure
+        - -retries
+        - "100"
+        - -retry-wait
         - "2"
-        - --ipam-controller-network
-        - 192.168.1.1/24,192.168.1.1,8.8.8.8
+        - -timeout
+        - "1"
+        - -command
+        - '{"command":"/usr/local/bin/user-cluster-controller-manager","args":["-kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","-metrics-listen-address","0.0.0.0:8085","-health-listen-address","0.0.0.0:8086","-namespace","$(NAMESPACE)","-ca-cert","/etc/kubernetes/pki/ca/ca.crt","-cluster-url","","-openvpn-server-port","30003","-overwrite-registry","","-openshift=false","-openvpn-ca-cert-file=/etc/kubernetes/pki/openvpn/ca.crt","-openvpn-ca-key-file=/etc/kubernetes/pki/openvpn/ca.key","-logtostderr","-v","2","--ipam-controller-network","192.168.1.1/24,192.168.1.1,8.8.8.8"]}'
         command:
-        - /usr/local/bin/user-cluster-controller-manager
+        - /http-prober-bin/http-prober
         env:
         - name: NAMESPACE
           valueFrom:
@@ -89,27 +76,21 @@ spec:
         - mountPath: /etc/kubernetes/pki/openvpn
           name: openvpn-ca
           readOnly: true
+        - mountPath: /http-prober-bin
+          name: http-prober-bin
       imagePullSecrets:
       - name: dockercfg
       initContainers:
-      - args:
-        - -endpoint
-        - https://apiserver-external.cluster-de-test-01.svc.cluster.local.:30000/healthz
-        - -insecure
-        - -retries
-        - "100"
-        - -retry-wait
-        - "2"
-        - -timeout
-        - "1"
-        command:
+      - command:
+        - /bin/cp
         - /usr/local/bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.1
-        imagePullPolicy: IfNotPresent
-        name: apiserver-running
+        - /http-prober-bin/http-prober
+        image: quay.io/kubermatic/http-prober:v0.2-dev0
+        name: copy-http-prober
         resources: {}
-        terminationMessagePath: /dev/termination-log
-        terminationMessagePolicy: File
+        volumeMounts:
+        - mountPath: /http-prober-bin
+          name: http-prober-bin
       volumes:
       - name: internal-admin-kubeconfig
         secret:
@@ -126,4 +107,6 @@ spec:
         secret:
           defaultMode: 292
           secretName: openvpn-ca
+      - emptyDir: {}
+        name: http-prober-bin
 status: {}

--- a/api/pkg/resources/test/fixtures/deployment-bringyourown-1.11.0-controller-manager.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-bringyourown-1.11.0-controller-manager.yaml
@@ -176,7 +176,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.2-dev0
+        image: quay.io/kubermatic/http-prober:v0.2
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/api/pkg/resources/test/fixtures/deployment-bringyourown-1.11.0-controller-manager.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-bringyourown-1.11.0-controller-manager.yaml
@@ -102,27 +102,19 @@ spec:
           name: openvpn-client-certificates
           readOnly: true
       - args:
-        - --kubeconfig
-        - /etc/kubernetes/kubeconfig/kubeconfig
-        - --service-account-private-key-file
-        - /etc/kubernetes/service-account-key/sa.key
-        - --root-ca-file
-        - /etc/kubernetes/pki/ca/ca.crt
-        - --cluster-signing-cert-file
-        - /etc/kubernetes/pki/ca/ca.crt
-        - --cluster-signing-key-file
-        - /etc/kubernetes/pki/ca/ca.key
-        - --cluster-cidr
-        - 172.25.0.0/16
-        - --allocate-node-cidrs=true
-        - --controllers
-        - '*,bootstrapsigner,tokencleaner'
-        - --use-service-account-credentials=true
-        - --feature-gates
-        - RotateKubeletClientCertificate=true,RotateKubeletServerCertificate=true
+        - -endpoint
+        - https://apiserver-external.cluster-de-test-01.svc.cluster.local.:30000/healthz
+        - -insecure
+        - -retries
+        - "100"
+        - -retry-wait
+        - "2"
+        - -timeout
+        - "1"
+        - -command
+        - '{"command":"/hyperkube","args":["kube-controller-manager","--kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","--service-account-private-key-file","/etc/kubernetes/service-account-key/sa.key","--root-ca-file","/etc/kubernetes/pki/ca/ca.crt","--cluster-signing-cert-file","/etc/kubernetes/pki/ca/ca.crt","--cluster-signing-key-file","/etc/kubernetes/pki/ca/ca.key","--cluster-cidr","172.25.0.0/16","--allocate-node-cidrs=true","--controllers","*,bootstrapsigner,tokencleaner","--use-service-account-credentials=true","--feature-gates","RotateKubeletClientCertificate=true,RotateKubeletServerCertificate=true"]}'
         command:
-        - /hyperkube
-        - kube-controller-manager
+        - /http-prober-bin/http-prober
         image: gcr.io/google_containers/hyperkube-amd64:v1.11.0
         livenessProbe:
           failureThreshold: 8
@@ -164,6 +156,8 @@ spec:
         - mountPath: /etc/kubernetes/kubeconfig
           name: controllermanager-kubeconfig
           readOnly: true
+        - mountPath: /http-prober-bin
+          name: http-prober-bin
       dnsConfig:
         nameservers:
         - 192.0.2.14
@@ -178,24 +172,16 @@ spec:
       imagePullSecrets:
       - name: dockercfg
       initContainers:
-      - args:
-        - -endpoint
-        - https://apiserver-external.cluster-de-test-01.svc.cluster.local.:30000/healthz
-        - -insecure
-        - -retries
-        - "100"
-        - -retry-wait
-        - "2"
-        - -timeout
-        - "1"
-        command:
+      - command:
+        - /bin/cp
         - /usr/local/bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.1
-        imagePullPolicy: IfNotPresent
-        name: apiserver-running
+        - /http-prober-bin/http-prober
+        image: quay.io/kubermatic/http-prober:v0.2-dev0
+        name: copy-http-prober
         resources: {}
-        terminationMessagePath: /dev/termination-log
-        terminationMessagePolicy: File
+        volumeMounts:
+        - mountPath: /http-prober-bin
+          name: http-prober-bin
       volumes:
       - name: ca
         secret:
@@ -217,4 +203,6 @@ spec:
         secret:
           defaultMode: 256
           secretName: controllermanager-kubeconfig
+      - emptyDir: {}
+        name: http-prober-bin
 status: {}

--- a/api/pkg/resources/test/fixtures/deployment-bringyourown-1.11.0-kube-state-metrics.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-bringyourown-1.11.0-kube-state-metrics.yaml
@@ -21,14 +21,19 @@ spec:
     spec:
       containers:
       - args:
-        - --kubeconfig
-        - /etc/kubernetes/kubeconfig/kubeconfig
-        - --port
-        - "8080"
-        - --telemetry-port
-        - "8081"
+        - -endpoint
+        - https://apiserver-external.cluster-de-test-01.svc.cluster.local.:30000/healthz
+        - -insecure
+        - -retries
+        - "100"
+        - -retry-wait
+        - "2"
+        - -timeout
+        - "1"
+        - -command
+        - '{"command":"/kube-state-metrics","args":["--kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","--port","8080","--telemetry-port","8081"]}'
         command:
-        - /kube-state-metrics
+        - /http-prober-bin/http-prober
         image: quay.io/coreos/kube-state-metrics:v1.6.0
         name: kube-state-metrics
         ports:
@@ -58,30 +63,26 @@ spec:
         - mountPath: /etc/kubernetes/kubeconfig
           name: kube-state-metrics-kubeconfig
           readOnly: true
+        - mountPath: /http-prober-bin
+          name: http-prober-bin
       imagePullSecrets:
       - name: dockercfg
       initContainers:
-      - args:
-        - -endpoint
-        - https://apiserver-external.cluster-de-test-01.svc.cluster.local.:30000/healthz
-        - -insecure
-        - -retries
-        - "100"
-        - -retry-wait
-        - "2"
-        - -timeout
-        - "1"
-        command:
+      - command:
+        - /bin/cp
         - /usr/local/bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.1
-        imagePullPolicy: IfNotPresent
-        name: apiserver-running
+        - /http-prober-bin/http-prober
+        image: quay.io/kubermatic/http-prober:v0.2-dev0
+        name: copy-http-prober
         resources: {}
-        terminationMessagePath: /dev/termination-log
-        terminationMessagePolicy: File
+        volumeMounts:
+        - mountPath: /http-prober-bin
+          name: http-prober-bin
       volumes:
       - name: kube-state-metrics-kubeconfig
         secret:
           defaultMode: 256
           secretName: kube-state-metrics-kubeconfig
+      - emptyDir: {}
+        name: http-prober-bin
 status: {}

--- a/api/pkg/resources/test/fixtures/deployment-bringyourown-1.11.0-kube-state-metrics.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-bringyourown-1.11.0-kube-state-metrics.yaml
@@ -72,7 +72,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.2-dev0
+        image: quay.io/kubermatic/http-prober:v0.2
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/api/pkg/resources/test/fixtures/deployment-bringyourown-1.11.0-machine-controller-webhook.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-bringyourown-1.11.0-machine-controller-webhook.yaml
@@ -36,13 +36,8 @@ spec:
         - -command
         - '{"command":"/usr/local/bin/webhook","args":["-kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","-logtostderr","-v","4","-listen-address","0.0.0.0:9876"]}'
         command:
-<<<<<<< HEAD
-        - /usr/local/bin/webhook
-        image: docker.io/kubermatic/machine-controller:v1.4.3
-=======
         - /http-prober-bin/http-prober
-        image: docker.io/kubermatic/machine-controller:v1.4.2
->>>>>>> Use wrapper instead of initContainer to check if apiserver is reachable (#3857)
+        image: docker.io/kubermatic/machine-controller:v1.4.3
         livenessProbe:
           failureThreshold: 8
           httpGet:

--- a/api/pkg/resources/test/fixtures/deployment-bringyourown-1.11.0-machine-controller-webhook.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-bringyourown-1.11.0-machine-controller-webhook.yaml
@@ -86,7 +86,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.2-dev0
+        image: quay.io/kubermatic/http-prober:v0.2
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/api/pkg/resources/test/fixtures/deployment-bringyourown-1.11.0-machine-controller-webhook.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-bringyourown-1.11.0-machine-controller-webhook.yaml
@@ -24,16 +24,25 @@ spec:
     spec:
       containers:
       - args:
-        - -kubeconfig
-        - /etc/kubernetes/kubeconfig/kubeconfig
-        - -logtostderr
-        - -v
-        - "4"
-        - -listen-address
-        - 0.0.0.0:9876
+        - -endpoint
+        - https://apiserver-external.cluster-de-test-01.svc.cluster.local.:30000/healthz
+        - -insecure
+        - -retries
+        - "100"
+        - -retry-wait
+        - "2"
+        - -timeout
+        - "1"
+        - -command
+        - '{"command":"/usr/local/bin/webhook","args":["-kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","-logtostderr","-v","4","-listen-address","0.0.0.0:9876"]}'
         command:
+<<<<<<< HEAD
         - /usr/local/bin/webhook
         image: docker.io/kubermatic/machine-controller:v1.4.3
+=======
+        - /http-prober-bin/http-prober
+        image: docker.io/kubermatic/machine-controller:v1.4.2
+>>>>>>> Use wrapper instead of initContainer to check if apiserver is reachable (#3857)
         livenessProbe:
           failureThreshold: 8
           httpGet:
@@ -68,27 +77,21 @@ spec:
         - mountPath: /tmp/cert
           name: machinecontroller-webhook-serving-cert
           readOnly: true
+        - mountPath: /http-prober-bin
+          name: http-prober-bin
       imagePullSecrets:
       - name: dockercfg
       initContainers:
-      - args:
-        - -endpoint
-        - https://apiserver-external.cluster-de-test-01.svc.cluster.local.:30000/healthz
-        - -insecure
-        - -retries
-        - "100"
-        - -retry-wait
-        - "2"
-        - -timeout
-        - "1"
-        command:
+      - command:
+        - /bin/cp
         - /usr/local/bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.1
-        imagePullPolicy: IfNotPresent
-        name: apiserver-running
+        - /http-prober-bin/http-prober
+        image: quay.io/kubermatic/http-prober:v0.2-dev0
+        name: copy-http-prober
         resources: {}
-        terminationMessagePath: /dev/termination-log
-        terminationMessagePolicy: File
+        volumeMounts:
+        - mountPath: /http-prober-bin
+          name: http-prober-bin
       volumes:
       - name: machinecontroller-kubeconfig
         secret:
@@ -98,4 +101,6 @@ spec:
         secret:
           defaultMode: 292
           secretName: machinecontroller-webhook-serving-cert
+      - emptyDir: {}
+        name: http-prober-bin
 status: {}

--- a/api/pkg/resources/test/fixtures/deployment-bringyourown-1.11.0-machine-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-bringyourown-1.11.0-machine-controller.yaml
@@ -77,7 +77,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.2-dev0
+        image: quay.io/kubermatic/http-prober:v0.2
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/api/pkg/resources/test/fixtures/deployment-bringyourown-1.11.0-machine-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-bringyourown-1.11.0-machine-controller.yaml
@@ -39,13 +39,8 @@ spec:
         - -command
         - '{"command":"/usr/local/bin/machine-controller","args":["-kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","-logtostderr","-v","4","-cluster-dns","169.254.20.10","-internal-listen-address","0.0.0.0:8085"]}'
         command:
-<<<<<<< HEAD
-        - /usr/local/bin/machine-controller
-        image: docker.io/kubermatic/machine-controller:v1.4.3
-=======
         - /http-prober-bin/http-prober
-        image: docker.io/kubermatic/machine-controller:v1.4.2
->>>>>>> Use wrapper instead of initContainer to check if apiserver is reachable (#3857)
+        image: docker.io/kubermatic/machine-controller:v1.4.3
         livenessProbe:
           failureThreshold: 3
           httpGet:

--- a/api/pkg/resources/test/fixtures/deployment-bringyourown-1.11.0-machine-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-bringyourown-1.11.0-machine-controller.yaml
@@ -27,18 +27,25 @@ spec:
     spec:
       containers:
       - args:
-        - -kubeconfig
-        - /etc/kubernetes/kubeconfig/kubeconfig
-        - -logtostderr
-        - -v
-        - "4"
-        - -cluster-dns
-        - 169.254.20.10
-        - -internal-listen-address
-        - 0.0.0.0:8085
+        - -endpoint
+        - https://apiserver-external.cluster-de-test-01.svc.cluster.local.:30000/healthz
+        - -insecure
+        - -retries
+        - "100"
+        - -retry-wait
+        - "2"
+        - -timeout
+        - "1"
+        - -command
+        - '{"command":"/usr/local/bin/machine-controller","args":["-kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","-logtostderr","-v","4","-cluster-dns","169.254.20.10","-internal-listen-address","0.0.0.0:8085"]}'
         command:
+<<<<<<< HEAD
         - /usr/local/bin/machine-controller
         image: docker.io/kubermatic/machine-controller:v1.4.3
+=======
+        - /http-prober-bin/http-prober
+        image: docker.io/kubermatic/machine-controller:v1.4.2
+>>>>>>> Use wrapper instead of initContainer to check if apiserver is reachable (#3857)
         livenessProbe:
           failureThreshold: 3
           httpGet:
@@ -61,30 +68,26 @@ spec:
         - mountPath: /etc/kubernetes/kubeconfig
           name: machinecontroller-kubeconfig
           readOnly: true
+        - mountPath: /http-prober-bin
+          name: http-prober-bin
       imagePullSecrets:
       - name: dockercfg
       initContainers:
-      - args:
-        - -endpoint
-        - https://apiserver-external.cluster-de-test-01.svc.cluster.local.:30000/healthz
-        - -insecure
-        - -retries
-        - "100"
-        - -retry-wait
-        - "2"
-        - -timeout
-        - "1"
-        command:
+      - command:
+        - /bin/cp
         - /usr/local/bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.1
-        imagePullPolicy: IfNotPresent
-        name: apiserver-running
+        - /http-prober-bin/http-prober
+        image: quay.io/kubermatic/http-prober:v0.2-dev0
+        name: copy-http-prober
         resources: {}
-        terminationMessagePath: /dev/termination-log
-        terminationMessagePolicy: File
+        volumeMounts:
+        - mountPath: /http-prober-bin
+          name: http-prober-bin
       volumes:
       - name: machinecontroller-kubeconfig
         secret:
           defaultMode: 292
           secretName: machinecontroller-kubeconfig
+      - emptyDir: {}
+        name: http-prober-bin
 status: {}

--- a/api/pkg/resources/test/fixtures/deployment-bringyourown-1.11.0-metrics-server.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-bringyourown-1.11.0-metrics-server.yaml
@@ -41,22 +41,19 @@ spec:
             weight: 10
       containers:
       - args:
-        - --kubeconfig
-        - /etc/kubernetes/kubeconfig/kubeconfig
-        - --authentication-kubeconfig
-        - /etc/kubernetes/kubeconfig/kubeconfig
-        - --authorization-kubeconfig
-        - /etc/kubernetes/kubeconfig/kubeconfig
-        - --kubelet-port
-        - "10250"
-        - --kubelet-insecure-tls
-        - --kubelet-preferred-address-types
-        - ExternalIP,InternalIP
-        - --v
+        - -endpoint
+        - https://apiserver-external.cluster-de-test-01.svc.cluster.local.:30000/healthz
+        - -insecure
+        - -retries
+        - "100"
+        - -retry-wait
+        - "2"
+        - -timeout
         - "1"
-        - --logtostderr
+        - -command
+        - '{"command":"/metrics-server","args":["--kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","--authentication-kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","--authorization-kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","--kubelet-port","10250","--kubelet-insecure-tls","--kubelet-preferred-address-types","ExternalIP,InternalIP","--v","1","--logtostderr"]}'
         command:
-        - /metrics-server
+        - /http-prober-bin/http-prober
         image: gcr.io/google_containers/metrics-server-amd64:v0.3.2
         name: metrics-server
         resources:
@@ -70,6 +67,8 @@ spec:
         - mountPath: /etc/kubernetes/kubeconfig
           name: metrics-server
           readOnly: true
+        - mountPath: /http-prober-bin
+          name: http-prober-bin
       - args:
         - --client
         - --proto
@@ -158,24 +157,16 @@ spec:
       imagePullSecrets:
       - name: dockercfg
       initContainers:
-      - args:
-        - -endpoint
-        - https://apiserver-external.cluster-de-test-01.svc.cluster.local.:30000/healthz
-        - -insecure
-        - -retries
-        - "100"
-        - -retry-wait
-        - "2"
-        - -timeout
-        - "1"
-        command:
+      - command:
+        - /bin/cp
         - /usr/local/bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.1
-        imagePullPolicy: IfNotPresent
-        name: apiserver-running
+        - /http-prober-bin/http-prober
+        image: quay.io/kubermatic/http-prober:v0.2-dev0
+        name: copy-http-prober
         resources: {}
-        terminationMessagePath: /dev/termination-log
-        terminationMessagePolicy: File
+        volumeMounts:
+        - mountPath: /http-prober-bin
+          name: http-prober-bin
       volumes:
       - name: metrics-server
         secret:
@@ -189,4 +180,6 @@ spec:
         secret:
           defaultMode: 292
           secretName: kubeletdnatcontroller-kubeconfig
+      - emptyDir: {}
+        name: http-prober-bin
 status: {}

--- a/api/pkg/resources/test/fixtures/deployment-bringyourown-1.11.0-metrics-server.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-bringyourown-1.11.0-metrics-server.yaml
@@ -161,7 +161,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.2-dev0
+        image: quay.io/kubermatic/http-prober:v0.2
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/api/pkg/resources/test/fixtures/deployment-bringyourown-1.11.0-scheduler.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-bringyourown-1.11.0-scheduler.yaml
@@ -100,11 +100,19 @@ spec:
           name: openvpn-client-certificates
           readOnly: true
       - args:
-        - --kubeconfig
-        - /etc/kubernetes/kubeconfig/kubeconfig
+        - -endpoint
+        - https://apiserver-external.cluster-de-test-01.svc.cluster.local.:30000/healthz
+        - -insecure
+        - -retries
+        - "100"
+        - -retry-wait
+        - "2"
+        - -timeout
+        - "1"
+        - -command
+        - '{"command":"/hyperkube","args":["kube-scheduler","--kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig"]}'
         command:
-        - /hyperkube
-        - kube-scheduler
+        - /http-prober-bin/http-prober
         image: gcr.io/google_containers/hyperkube-amd64:v1.11.0
         livenessProbe:
           failureThreshold: 8
@@ -140,6 +148,8 @@ spec:
         - mountPath: /etc/kubernetes/pki/ca
           name: ca
           readOnly: true
+        - mountPath: /http-prober-bin
+          name: http-prober-bin
       dnsConfig:
         nameservers:
         - 192.0.2.14
@@ -154,24 +164,16 @@ spec:
       imagePullSecrets:
       - name: dockercfg
       initContainers:
-      - args:
-        - -endpoint
-        - https://apiserver-external.cluster-de-test-01.svc.cluster.local.:30000/healthz
-        - -insecure
-        - -retries
-        - "100"
-        - -retry-wait
-        - "2"
-        - -timeout
-        - "1"
-        command:
+      - command:
+        - /bin/cp
         - /usr/local/bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.1
-        imagePullPolicy: IfNotPresent
-        name: apiserver-running
+        - /http-prober-bin/http-prober
+        image: quay.io/kubermatic/http-prober:v0.2-dev0
+        name: copy-http-prober
         resources: {}
-        terminationMessagePath: /dev/termination-log
-        terminationMessagePolicy: File
+        volumeMounts:
+        - mountPath: /http-prober-bin
+          name: http-prober-bin
       volumes:
       - name: openvpn-client-certificates
         secret:
@@ -188,4 +190,6 @@ spec:
         secret:
           defaultMode: 256
           secretName: scheduler-kubeconfig
+      - emptyDir: {}
+        name: http-prober-bin
 status: {}

--- a/api/pkg/resources/test/fixtures/deployment-bringyourown-1.11.0-scheduler.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-bringyourown-1.11.0-scheduler.yaml
@@ -168,7 +168,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.2-dev0
+        image: quay.io/kubermatic/http-prober:v0.2
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/api/pkg/resources/test/fixtures/deployment-bringyourown-1.11.0-usercluster-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-bringyourown-1.11.0-usercluster-controller.yaml
@@ -85,7 +85,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.2-dev0
+        image: quay.io/kubermatic/http-prober:v0.2
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/api/pkg/resources/test/fixtures/deployment-bringyourown-1.11.0-usercluster-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-bringyourown-1.11.0-usercluster-controller.yaml
@@ -29,32 +29,19 @@ spec:
     spec:
       containers:
       - args:
-        - -kubeconfig
-        - /etc/kubernetes/kubeconfig/kubeconfig
-        - -metrics-listen-address
-        - 0.0.0.0:8085
-        - -health-listen-address
-        - 0.0.0.0:8086
-        - -namespace
-        - $(NAMESPACE)
-        - -ca-cert
-        - /etc/kubernetes/pki/ca/ca.crt
-        - -cluster-url
-        - ""
-        - -openvpn-server-port
-        - "30003"
-        - -overwrite-registry
-        - ""
-        - -openshift=false
-        - -openvpn-ca-cert-file=/etc/kubernetes/pki/openvpn/ca.crt
-        - -openvpn-ca-key-file=/etc/kubernetes/pki/openvpn/ca.key
-        - -logtostderr
-        - -v
+        - -endpoint
+        - https://apiserver-external.cluster-de-test-01.svc.cluster.local.:30000/healthz
+        - -insecure
+        - -retries
+        - "100"
+        - -retry-wait
         - "2"
-        - --ipam-controller-network
-        - 192.168.1.1/24,192.168.1.1,8.8.8.8
+        - -timeout
+        - "1"
+        - -command
+        - '{"command":"/usr/local/bin/user-cluster-controller-manager","args":["-kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","-metrics-listen-address","0.0.0.0:8085","-health-listen-address","0.0.0.0:8086","-namespace","$(NAMESPACE)","-ca-cert","/etc/kubernetes/pki/ca/ca.crt","-cluster-url","","-openvpn-server-port","30003","-overwrite-registry","","-openshift=false","-openvpn-ca-cert-file=/etc/kubernetes/pki/openvpn/ca.crt","-openvpn-ca-key-file=/etc/kubernetes/pki/openvpn/ca.key","-logtostderr","-v","2","--ipam-controller-network","192.168.1.1/24,192.168.1.1,8.8.8.8"]}'
         command:
-        - /usr/local/bin/user-cluster-controller-manager
+        - /http-prober-bin/http-prober
         env:
         - name: NAMESPACE
           valueFrom:
@@ -89,27 +76,21 @@ spec:
         - mountPath: /etc/kubernetes/pki/openvpn
           name: openvpn-ca
           readOnly: true
+        - mountPath: /http-prober-bin
+          name: http-prober-bin
       imagePullSecrets:
       - name: dockercfg
       initContainers:
-      - args:
-        - -endpoint
-        - https://apiserver-external.cluster-de-test-01.svc.cluster.local.:30000/healthz
-        - -insecure
-        - -retries
-        - "100"
-        - -retry-wait
-        - "2"
-        - -timeout
-        - "1"
-        command:
+      - command:
+        - /bin/cp
         - /usr/local/bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.1
-        imagePullPolicy: IfNotPresent
-        name: apiserver-running
+        - /http-prober-bin/http-prober
+        image: quay.io/kubermatic/http-prober:v0.2-dev0
+        name: copy-http-prober
         resources: {}
-        terminationMessagePath: /dev/termination-log
-        terminationMessagePolicy: File
+        volumeMounts:
+        - mountPath: /http-prober-bin
+          name: http-prober-bin
       volumes:
       - name: internal-admin-kubeconfig
         secret:
@@ -126,4 +107,6 @@ spec:
         secret:
           defaultMode: 292
           secretName: openvpn-ca
+      - emptyDir: {}
+        name: http-prober-bin
 status: {}

--- a/api/pkg/resources/test/fixtures/deployment-bringyourown-1.11.1-controller-manager.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-bringyourown-1.11.1-controller-manager.yaml
@@ -176,7 +176,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.2-dev0
+        image: quay.io/kubermatic/http-prober:v0.2
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/api/pkg/resources/test/fixtures/deployment-bringyourown-1.11.1-controller-manager.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-bringyourown-1.11.1-controller-manager.yaml
@@ -102,27 +102,19 @@ spec:
           name: openvpn-client-certificates
           readOnly: true
       - args:
-        - --kubeconfig
-        - /etc/kubernetes/kubeconfig/kubeconfig
-        - --service-account-private-key-file
-        - /etc/kubernetes/service-account-key/sa.key
-        - --root-ca-file
-        - /etc/kubernetes/pki/ca/ca.crt
-        - --cluster-signing-cert-file
-        - /etc/kubernetes/pki/ca/ca.crt
-        - --cluster-signing-key-file
-        - /etc/kubernetes/pki/ca/ca.key
-        - --cluster-cidr
-        - 172.25.0.0/16
-        - --allocate-node-cidrs=true
-        - --controllers
-        - '*,bootstrapsigner,tokencleaner'
-        - --use-service-account-credentials=true
-        - --feature-gates
-        - RotateKubeletClientCertificate=true,RotateKubeletServerCertificate=true
+        - -endpoint
+        - https://apiserver-external.cluster-de-test-01.svc.cluster.local.:30000/healthz
+        - -insecure
+        - -retries
+        - "100"
+        - -retry-wait
+        - "2"
+        - -timeout
+        - "1"
+        - -command
+        - '{"command":"/hyperkube","args":["kube-controller-manager","--kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","--service-account-private-key-file","/etc/kubernetes/service-account-key/sa.key","--root-ca-file","/etc/kubernetes/pki/ca/ca.crt","--cluster-signing-cert-file","/etc/kubernetes/pki/ca/ca.crt","--cluster-signing-key-file","/etc/kubernetes/pki/ca/ca.key","--cluster-cidr","172.25.0.0/16","--allocate-node-cidrs=true","--controllers","*,bootstrapsigner,tokencleaner","--use-service-account-credentials=true","--feature-gates","RotateKubeletClientCertificate=true,RotateKubeletServerCertificate=true"]}'
         command:
-        - /hyperkube
-        - kube-controller-manager
+        - /http-prober-bin/http-prober
         image: gcr.io/google_containers/hyperkube-amd64:v1.11.1
         livenessProbe:
           failureThreshold: 8
@@ -164,6 +156,8 @@ spec:
         - mountPath: /etc/kubernetes/kubeconfig
           name: controllermanager-kubeconfig
           readOnly: true
+        - mountPath: /http-prober-bin
+          name: http-prober-bin
       dnsConfig:
         nameservers:
         - 192.0.2.14
@@ -178,24 +172,16 @@ spec:
       imagePullSecrets:
       - name: dockercfg
       initContainers:
-      - args:
-        - -endpoint
-        - https://apiserver-external.cluster-de-test-01.svc.cluster.local.:30000/healthz
-        - -insecure
-        - -retries
-        - "100"
-        - -retry-wait
-        - "2"
-        - -timeout
-        - "1"
-        command:
+      - command:
+        - /bin/cp
         - /usr/local/bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.1
-        imagePullPolicy: IfNotPresent
-        name: apiserver-running
+        - /http-prober-bin/http-prober
+        image: quay.io/kubermatic/http-prober:v0.2-dev0
+        name: copy-http-prober
         resources: {}
-        terminationMessagePath: /dev/termination-log
-        terminationMessagePolicy: File
+        volumeMounts:
+        - mountPath: /http-prober-bin
+          name: http-prober-bin
       volumes:
       - name: ca
         secret:
@@ -217,4 +203,6 @@ spec:
         secret:
           defaultMode: 256
           secretName: controllermanager-kubeconfig
+      - emptyDir: {}
+        name: http-prober-bin
 status: {}

--- a/api/pkg/resources/test/fixtures/deployment-bringyourown-1.11.1-kube-state-metrics.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-bringyourown-1.11.1-kube-state-metrics.yaml
@@ -21,14 +21,19 @@ spec:
     spec:
       containers:
       - args:
-        - --kubeconfig
-        - /etc/kubernetes/kubeconfig/kubeconfig
-        - --port
-        - "8080"
-        - --telemetry-port
-        - "8081"
+        - -endpoint
+        - https://apiserver-external.cluster-de-test-01.svc.cluster.local.:30000/healthz
+        - -insecure
+        - -retries
+        - "100"
+        - -retry-wait
+        - "2"
+        - -timeout
+        - "1"
+        - -command
+        - '{"command":"/kube-state-metrics","args":["--kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","--port","8080","--telemetry-port","8081"]}'
         command:
-        - /kube-state-metrics
+        - /http-prober-bin/http-prober
         image: quay.io/coreos/kube-state-metrics:v1.6.0
         name: kube-state-metrics
         ports:
@@ -58,30 +63,26 @@ spec:
         - mountPath: /etc/kubernetes/kubeconfig
           name: kube-state-metrics-kubeconfig
           readOnly: true
+        - mountPath: /http-prober-bin
+          name: http-prober-bin
       imagePullSecrets:
       - name: dockercfg
       initContainers:
-      - args:
-        - -endpoint
-        - https://apiserver-external.cluster-de-test-01.svc.cluster.local.:30000/healthz
-        - -insecure
-        - -retries
-        - "100"
-        - -retry-wait
-        - "2"
-        - -timeout
-        - "1"
-        command:
+      - command:
+        - /bin/cp
         - /usr/local/bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.1
-        imagePullPolicy: IfNotPresent
-        name: apiserver-running
+        - /http-prober-bin/http-prober
+        image: quay.io/kubermatic/http-prober:v0.2-dev0
+        name: copy-http-prober
         resources: {}
-        terminationMessagePath: /dev/termination-log
-        terminationMessagePolicy: File
+        volumeMounts:
+        - mountPath: /http-prober-bin
+          name: http-prober-bin
       volumes:
       - name: kube-state-metrics-kubeconfig
         secret:
           defaultMode: 256
           secretName: kube-state-metrics-kubeconfig
+      - emptyDir: {}
+        name: http-prober-bin
 status: {}

--- a/api/pkg/resources/test/fixtures/deployment-bringyourown-1.11.1-kube-state-metrics.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-bringyourown-1.11.1-kube-state-metrics.yaml
@@ -72,7 +72,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.2-dev0
+        image: quay.io/kubermatic/http-prober:v0.2
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/api/pkg/resources/test/fixtures/deployment-bringyourown-1.11.1-machine-controller-webhook.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-bringyourown-1.11.1-machine-controller-webhook.yaml
@@ -36,13 +36,8 @@ spec:
         - -command
         - '{"command":"/usr/local/bin/webhook","args":["-kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","-logtostderr","-v","4","-listen-address","0.0.0.0:9876"]}'
         command:
-<<<<<<< HEAD
-        - /usr/local/bin/webhook
-        image: docker.io/kubermatic/machine-controller:v1.4.3
-=======
         - /http-prober-bin/http-prober
-        image: docker.io/kubermatic/machine-controller:v1.4.2
->>>>>>> Use wrapper instead of initContainer to check if apiserver is reachable (#3857)
+        image: docker.io/kubermatic/machine-controller:v1.4.3
         livenessProbe:
           failureThreshold: 8
           httpGet:

--- a/api/pkg/resources/test/fixtures/deployment-bringyourown-1.11.1-machine-controller-webhook.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-bringyourown-1.11.1-machine-controller-webhook.yaml
@@ -86,7 +86,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.2-dev0
+        image: quay.io/kubermatic/http-prober:v0.2
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/api/pkg/resources/test/fixtures/deployment-bringyourown-1.11.1-machine-controller-webhook.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-bringyourown-1.11.1-machine-controller-webhook.yaml
@@ -24,16 +24,25 @@ spec:
     spec:
       containers:
       - args:
-        - -kubeconfig
-        - /etc/kubernetes/kubeconfig/kubeconfig
-        - -logtostderr
-        - -v
-        - "4"
-        - -listen-address
-        - 0.0.0.0:9876
+        - -endpoint
+        - https://apiserver-external.cluster-de-test-01.svc.cluster.local.:30000/healthz
+        - -insecure
+        - -retries
+        - "100"
+        - -retry-wait
+        - "2"
+        - -timeout
+        - "1"
+        - -command
+        - '{"command":"/usr/local/bin/webhook","args":["-kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","-logtostderr","-v","4","-listen-address","0.0.0.0:9876"]}'
         command:
+<<<<<<< HEAD
         - /usr/local/bin/webhook
         image: docker.io/kubermatic/machine-controller:v1.4.3
+=======
+        - /http-prober-bin/http-prober
+        image: docker.io/kubermatic/machine-controller:v1.4.2
+>>>>>>> Use wrapper instead of initContainer to check if apiserver is reachable (#3857)
         livenessProbe:
           failureThreshold: 8
           httpGet:
@@ -68,27 +77,21 @@ spec:
         - mountPath: /tmp/cert
           name: machinecontroller-webhook-serving-cert
           readOnly: true
+        - mountPath: /http-prober-bin
+          name: http-prober-bin
       imagePullSecrets:
       - name: dockercfg
       initContainers:
-      - args:
-        - -endpoint
-        - https://apiserver-external.cluster-de-test-01.svc.cluster.local.:30000/healthz
-        - -insecure
-        - -retries
-        - "100"
-        - -retry-wait
-        - "2"
-        - -timeout
-        - "1"
-        command:
+      - command:
+        - /bin/cp
         - /usr/local/bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.1
-        imagePullPolicy: IfNotPresent
-        name: apiserver-running
+        - /http-prober-bin/http-prober
+        image: quay.io/kubermatic/http-prober:v0.2-dev0
+        name: copy-http-prober
         resources: {}
-        terminationMessagePath: /dev/termination-log
-        terminationMessagePolicy: File
+        volumeMounts:
+        - mountPath: /http-prober-bin
+          name: http-prober-bin
       volumes:
       - name: machinecontroller-kubeconfig
         secret:
@@ -98,4 +101,6 @@ spec:
         secret:
           defaultMode: 292
           secretName: machinecontroller-webhook-serving-cert
+      - emptyDir: {}
+        name: http-prober-bin
 status: {}

--- a/api/pkg/resources/test/fixtures/deployment-bringyourown-1.11.1-machine-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-bringyourown-1.11.1-machine-controller.yaml
@@ -77,7 +77,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.2-dev0
+        image: quay.io/kubermatic/http-prober:v0.2
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/api/pkg/resources/test/fixtures/deployment-bringyourown-1.11.1-machine-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-bringyourown-1.11.1-machine-controller.yaml
@@ -39,13 +39,8 @@ spec:
         - -command
         - '{"command":"/usr/local/bin/machine-controller","args":["-kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","-logtostderr","-v","4","-cluster-dns","169.254.20.10","-internal-listen-address","0.0.0.0:8085"]}'
         command:
-<<<<<<< HEAD
-        - /usr/local/bin/machine-controller
-        image: docker.io/kubermatic/machine-controller:v1.4.3
-=======
         - /http-prober-bin/http-prober
-        image: docker.io/kubermatic/machine-controller:v1.4.2
->>>>>>> Use wrapper instead of initContainer to check if apiserver is reachable (#3857)
+        image: docker.io/kubermatic/machine-controller:v1.4.3
         livenessProbe:
           failureThreshold: 3
           httpGet:

--- a/api/pkg/resources/test/fixtures/deployment-bringyourown-1.11.1-machine-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-bringyourown-1.11.1-machine-controller.yaml
@@ -27,18 +27,25 @@ spec:
     spec:
       containers:
       - args:
-        - -kubeconfig
-        - /etc/kubernetes/kubeconfig/kubeconfig
-        - -logtostderr
-        - -v
-        - "4"
-        - -cluster-dns
-        - 169.254.20.10
-        - -internal-listen-address
-        - 0.0.0.0:8085
+        - -endpoint
+        - https://apiserver-external.cluster-de-test-01.svc.cluster.local.:30000/healthz
+        - -insecure
+        - -retries
+        - "100"
+        - -retry-wait
+        - "2"
+        - -timeout
+        - "1"
+        - -command
+        - '{"command":"/usr/local/bin/machine-controller","args":["-kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","-logtostderr","-v","4","-cluster-dns","169.254.20.10","-internal-listen-address","0.0.0.0:8085"]}'
         command:
+<<<<<<< HEAD
         - /usr/local/bin/machine-controller
         image: docker.io/kubermatic/machine-controller:v1.4.3
+=======
+        - /http-prober-bin/http-prober
+        image: docker.io/kubermatic/machine-controller:v1.4.2
+>>>>>>> Use wrapper instead of initContainer to check if apiserver is reachable (#3857)
         livenessProbe:
           failureThreshold: 3
           httpGet:
@@ -61,30 +68,26 @@ spec:
         - mountPath: /etc/kubernetes/kubeconfig
           name: machinecontroller-kubeconfig
           readOnly: true
+        - mountPath: /http-prober-bin
+          name: http-prober-bin
       imagePullSecrets:
       - name: dockercfg
       initContainers:
-      - args:
-        - -endpoint
-        - https://apiserver-external.cluster-de-test-01.svc.cluster.local.:30000/healthz
-        - -insecure
-        - -retries
-        - "100"
-        - -retry-wait
-        - "2"
-        - -timeout
-        - "1"
-        command:
+      - command:
+        - /bin/cp
         - /usr/local/bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.1
-        imagePullPolicy: IfNotPresent
-        name: apiserver-running
+        - /http-prober-bin/http-prober
+        image: quay.io/kubermatic/http-prober:v0.2-dev0
+        name: copy-http-prober
         resources: {}
-        terminationMessagePath: /dev/termination-log
-        terminationMessagePolicy: File
+        volumeMounts:
+        - mountPath: /http-prober-bin
+          name: http-prober-bin
       volumes:
       - name: machinecontroller-kubeconfig
         secret:
           defaultMode: 292
           secretName: machinecontroller-kubeconfig
+      - emptyDir: {}
+        name: http-prober-bin
 status: {}

--- a/api/pkg/resources/test/fixtures/deployment-bringyourown-1.11.1-metrics-server.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-bringyourown-1.11.1-metrics-server.yaml
@@ -41,22 +41,19 @@ spec:
             weight: 10
       containers:
       - args:
-        - --kubeconfig
-        - /etc/kubernetes/kubeconfig/kubeconfig
-        - --authentication-kubeconfig
-        - /etc/kubernetes/kubeconfig/kubeconfig
-        - --authorization-kubeconfig
-        - /etc/kubernetes/kubeconfig/kubeconfig
-        - --kubelet-port
-        - "10250"
-        - --kubelet-insecure-tls
-        - --kubelet-preferred-address-types
-        - ExternalIP,InternalIP
-        - --v
+        - -endpoint
+        - https://apiserver-external.cluster-de-test-01.svc.cluster.local.:30000/healthz
+        - -insecure
+        - -retries
+        - "100"
+        - -retry-wait
+        - "2"
+        - -timeout
         - "1"
-        - --logtostderr
+        - -command
+        - '{"command":"/metrics-server","args":["--kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","--authentication-kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","--authorization-kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","--kubelet-port","10250","--kubelet-insecure-tls","--kubelet-preferred-address-types","ExternalIP,InternalIP","--v","1","--logtostderr"]}'
         command:
-        - /metrics-server
+        - /http-prober-bin/http-prober
         image: gcr.io/google_containers/metrics-server-amd64:v0.3.2
         name: metrics-server
         resources:
@@ -70,6 +67,8 @@ spec:
         - mountPath: /etc/kubernetes/kubeconfig
           name: metrics-server
           readOnly: true
+        - mountPath: /http-prober-bin
+          name: http-prober-bin
       - args:
         - --client
         - --proto
@@ -158,24 +157,16 @@ spec:
       imagePullSecrets:
       - name: dockercfg
       initContainers:
-      - args:
-        - -endpoint
-        - https://apiserver-external.cluster-de-test-01.svc.cluster.local.:30000/healthz
-        - -insecure
-        - -retries
-        - "100"
-        - -retry-wait
-        - "2"
-        - -timeout
-        - "1"
-        command:
+      - command:
+        - /bin/cp
         - /usr/local/bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.1
-        imagePullPolicy: IfNotPresent
-        name: apiserver-running
+        - /http-prober-bin/http-prober
+        image: quay.io/kubermatic/http-prober:v0.2-dev0
+        name: copy-http-prober
         resources: {}
-        terminationMessagePath: /dev/termination-log
-        terminationMessagePolicy: File
+        volumeMounts:
+        - mountPath: /http-prober-bin
+          name: http-prober-bin
       volumes:
       - name: metrics-server
         secret:
@@ -189,4 +180,6 @@ spec:
         secret:
           defaultMode: 292
           secretName: kubeletdnatcontroller-kubeconfig
+      - emptyDir: {}
+        name: http-prober-bin
 status: {}

--- a/api/pkg/resources/test/fixtures/deployment-bringyourown-1.11.1-metrics-server.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-bringyourown-1.11.1-metrics-server.yaml
@@ -161,7 +161,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.2-dev0
+        image: quay.io/kubermatic/http-prober:v0.2
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/api/pkg/resources/test/fixtures/deployment-bringyourown-1.11.1-scheduler.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-bringyourown-1.11.1-scheduler.yaml
@@ -100,11 +100,19 @@ spec:
           name: openvpn-client-certificates
           readOnly: true
       - args:
-        - --kubeconfig
-        - /etc/kubernetes/kubeconfig/kubeconfig
+        - -endpoint
+        - https://apiserver-external.cluster-de-test-01.svc.cluster.local.:30000/healthz
+        - -insecure
+        - -retries
+        - "100"
+        - -retry-wait
+        - "2"
+        - -timeout
+        - "1"
+        - -command
+        - '{"command":"/hyperkube","args":["kube-scheduler","--kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig"]}'
         command:
-        - /hyperkube
-        - kube-scheduler
+        - /http-prober-bin/http-prober
         image: gcr.io/google_containers/hyperkube-amd64:v1.11.1
         livenessProbe:
           failureThreshold: 8
@@ -140,6 +148,8 @@ spec:
         - mountPath: /etc/kubernetes/pki/ca
           name: ca
           readOnly: true
+        - mountPath: /http-prober-bin
+          name: http-prober-bin
       dnsConfig:
         nameservers:
         - 192.0.2.14
@@ -154,24 +164,16 @@ spec:
       imagePullSecrets:
       - name: dockercfg
       initContainers:
-      - args:
-        - -endpoint
-        - https://apiserver-external.cluster-de-test-01.svc.cluster.local.:30000/healthz
-        - -insecure
-        - -retries
-        - "100"
-        - -retry-wait
-        - "2"
-        - -timeout
-        - "1"
-        command:
+      - command:
+        - /bin/cp
         - /usr/local/bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.1
-        imagePullPolicy: IfNotPresent
-        name: apiserver-running
+        - /http-prober-bin/http-prober
+        image: quay.io/kubermatic/http-prober:v0.2-dev0
+        name: copy-http-prober
         resources: {}
-        terminationMessagePath: /dev/termination-log
-        terminationMessagePolicy: File
+        volumeMounts:
+        - mountPath: /http-prober-bin
+          name: http-prober-bin
       volumes:
       - name: openvpn-client-certificates
         secret:
@@ -188,4 +190,6 @@ spec:
         secret:
           defaultMode: 256
           secretName: scheduler-kubeconfig
+      - emptyDir: {}
+        name: http-prober-bin
 status: {}

--- a/api/pkg/resources/test/fixtures/deployment-bringyourown-1.11.1-scheduler.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-bringyourown-1.11.1-scheduler.yaml
@@ -168,7 +168,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.2-dev0
+        image: quay.io/kubermatic/http-prober:v0.2
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/api/pkg/resources/test/fixtures/deployment-bringyourown-1.11.1-usercluster-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-bringyourown-1.11.1-usercluster-controller.yaml
@@ -85,7 +85,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.2-dev0
+        image: quay.io/kubermatic/http-prober:v0.2
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/api/pkg/resources/test/fixtures/deployment-bringyourown-1.11.1-usercluster-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-bringyourown-1.11.1-usercluster-controller.yaml
@@ -29,32 +29,19 @@ spec:
     spec:
       containers:
       - args:
-        - -kubeconfig
-        - /etc/kubernetes/kubeconfig/kubeconfig
-        - -metrics-listen-address
-        - 0.0.0.0:8085
-        - -health-listen-address
-        - 0.0.0.0:8086
-        - -namespace
-        - $(NAMESPACE)
-        - -ca-cert
-        - /etc/kubernetes/pki/ca/ca.crt
-        - -cluster-url
-        - ""
-        - -openvpn-server-port
-        - "30003"
-        - -overwrite-registry
-        - ""
-        - -openshift=false
-        - -openvpn-ca-cert-file=/etc/kubernetes/pki/openvpn/ca.crt
-        - -openvpn-ca-key-file=/etc/kubernetes/pki/openvpn/ca.key
-        - -logtostderr
-        - -v
+        - -endpoint
+        - https://apiserver-external.cluster-de-test-01.svc.cluster.local.:30000/healthz
+        - -insecure
+        - -retries
+        - "100"
+        - -retry-wait
         - "2"
-        - --ipam-controller-network
-        - 192.168.1.1/24,192.168.1.1,8.8.8.8
+        - -timeout
+        - "1"
+        - -command
+        - '{"command":"/usr/local/bin/user-cluster-controller-manager","args":["-kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","-metrics-listen-address","0.0.0.0:8085","-health-listen-address","0.0.0.0:8086","-namespace","$(NAMESPACE)","-ca-cert","/etc/kubernetes/pki/ca/ca.crt","-cluster-url","","-openvpn-server-port","30003","-overwrite-registry","","-openshift=false","-openvpn-ca-cert-file=/etc/kubernetes/pki/openvpn/ca.crt","-openvpn-ca-key-file=/etc/kubernetes/pki/openvpn/ca.key","-logtostderr","-v","2","--ipam-controller-network","192.168.1.1/24,192.168.1.1,8.8.8.8"]}'
         command:
-        - /usr/local/bin/user-cluster-controller-manager
+        - /http-prober-bin/http-prober
         env:
         - name: NAMESPACE
           valueFrom:
@@ -89,27 +76,21 @@ spec:
         - mountPath: /etc/kubernetes/pki/openvpn
           name: openvpn-ca
           readOnly: true
+        - mountPath: /http-prober-bin
+          name: http-prober-bin
       imagePullSecrets:
       - name: dockercfg
       initContainers:
-      - args:
-        - -endpoint
-        - https://apiserver-external.cluster-de-test-01.svc.cluster.local.:30000/healthz
-        - -insecure
-        - -retries
-        - "100"
-        - -retry-wait
-        - "2"
-        - -timeout
-        - "1"
-        command:
+      - command:
+        - /bin/cp
         - /usr/local/bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.1
-        imagePullPolicy: IfNotPresent
-        name: apiserver-running
+        - /http-prober-bin/http-prober
+        image: quay.io/kubermatic/http-prober:v0.2-dev0
+        name: copy-http-prober
         resources: {}
-        terminationMessagePath: /dev/termination-log
-        terminationMessagePolicy: File
+        volumeMounts:
+        - mountPath: /http-prober-bin
+          name: http-prober-bin
       volumes:
       - name: internal-admin-kubeconfig
         secret:
@@ -126,4 +107,6 @@ spec:
         secret:
           defaultMode: 292
           secretName: openvpn-ca
+      - emptyDir: {}
+        name: http-prober-bin
 status: {}

--- a/api/pkg/resources/test/fixtures/deployment-bringyourown-1.12.0-controller-manager.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-bringyourown-1.12.0-controller-manager.yaml
@@ -176,7 +176,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.2-dev0
+        image: quay.io/kubermatic/http-prober:v0.2
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/api/pkg/resources/test/fixtures/deployment-bringyourown-1.12.0-controller-manager.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-bringyourown-1.12.0-controller-manager.yaml
@@ -102,32 +102,19 @@ spec:
           name: openvpn-client-certificates
           readOnly: true
       - args:
-        - --kubeconfig
-        - /etc/kubernetes/kubeconfig/kubeconfig
-        - --service-account-private-key-file
-        - /etc/kubernetes/service-account-key/sa.key
-        - --root-ca-file
-        - /etc/kubernetes/pki/ca/ca.crt
-        - --cluster-signing-cert-file
-        - /etc/kubernetes/pki/ca/ca.crt
-        - --cluster-signing-key-file
-        - /etc/kubernetes/pki/ca/ca.key
-        - --cluster-cidr
-        - 172.25.0.0/16
-        - --allocate-node-cidrs=true
-        - --controllers
-        - '*,bootstrapsigner,tokencleaner'
-        - --use-service-account-credentials=true
-        - --feature-gates
-        - RotateKubeletClientCertificate=true,RotateKubeletServerCertificate=true,ScheduleDaemonSetPods=false
-        - --authentication-kubeconfig
-        - /etc/kubernetes/kubeconfig/kubeconfig
-        - --client-ca-file
-        - /etc/kubernetes/pki/ca/ca.crt
-        - --authentication-skip-lookup=true
+        - -endpoint
+        - https://apiserver-external.cluster-de-test-01.svc.cluster.local.:30000/healthz
+        - -insecure
+        - -retries
+        - "100"
+        - -retry-wait
+        - "2"
+        - -timeout
+        - "1"
+        - -command
+        - '{"command":"/hyperkube","args":["kube-controller-manager","--kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","--service-account-private-key-file","/etc/kubernetes/service-account-key/sa.key","--root-ca-file","/etc/kubernetes/pki/ca/ca.crt","--cluster-signing-cert-file","/etc/kubernetes/pki/ca/ca.crt","--cluster-signing-key-file","/etc/kubernetes/pki/ca/ca.key","--cluster-cidr","172.25.0.0/16","--allocate-node-cidrs=true","--controllers","*,bootstrapsigner,tokencleaner","--use-service-account-credentials=true","--feature-gates","RotateKubeletClientCertificate=true,RotateKubeletServerCertificate=true,ScheduleDaemonSetPods=false","--authentication-kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","--client-ca-file","/etc/kubernetes/pki/ca/ca.crt","--authentication-skip-lookup=true"]}'
         command:
-        - /hyperkube
-        - kube-controller-manager
+        - /http-prober-bin/http-prober
         image: gcr.io/google_containers/hyperkube-amd64:v1.12.0
         livenessProbe:
           failureThreshold: 8
@@ -169,6 +156,8 @@ spec:
         - mountPath: /etc/kubernetes/kubeconfig
           name: controllermanager-kubeconfig
           readOnly: true
+        - mountPath: /http-prober-bin
+          name: http-prober-bin
       dnsConfig:
         nameservers:
         - 192.0.2.14
@@ -183,24 +172,16 @@ spec:
       imagePullSecrets:
       - name: dockercfg
       initContainers:
-      - args:
-        - -endpoint
-        - https://apiserver-external.cluster-de-test-01.svc.cluster.local.:30000/healthz
-        - -insecure
-        - -retries
-        - "100"
-        - -retry-wait
-        - "2"
-        - -timeout
-        - "1"
-        command:
+      - command:
+        - /bin/cp
         - /usr/local/bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.1
-        imagePullPolicy: IfNotPresent
-        name: apiserver-running
+        - /http-prober-bin/http-prober
+        image: quay.io/kubermatic/http-prober:v0.2-dev0
+        name: copy-http-prober
         resources: {}
-        terminationMessagePath: /dev/termination-log
-        terminationMessagePolicy: File
+        volumeMounts:
+        - mountPath: /http-prober-bin
+          name: http-prober-bin
       volumes:
       - name: ca
         secret:
@@ -222,4 +203,6 @@ spec:
         secret:
           defaultMode: 256
           secretName: controllermanager-kubeconfig
+      - emptyDir: {}
+        name: http-prober-bin
 status: {}

--- a/api/pkg/resources/test/fixtures/deployment-bringyourown-1.12.0-kube-state-metrics.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-bringyourown-1.12.0-kube-state-metrics.yaml
@@ -21,14 +21,19 @@ spec:
     spec:
       containers:
       - args:
-        - --kubeconfig
-        - /etc/kubernetes/kubeconfig/kubeconfig
-        - --port
-        - "8080"
-        - --telemetry-port
-        - "8081"
+        - -endpoint
+        - https://apiserver-external.cluster-de-test-01.svc.cluster.local.:30000/healthz
+        - -insecure
+        - -retries
+        - "100"
+        - -retry-wait
+        - "2"
+        - -timeout
+        - "1"
+        - -command
+        - '{"command":"/kube-state-metrics","args":["--kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","--port","8080","--telemetry-port","8081"]}'
         command:
-        - /kube-state-metrics
+        - /http-prober-bin/http-prober
         image: quay.io/coreos/kube-state-metrics:v1.6.0
         name: kube-state-metrics
         ports:
@@ -58,30 +63,26 @@ spec:
         - mountPath: /etc/kubernetes/kubeconfig
           name: kube-state-metrics-kubeconfig
           readOnly: true
+        - mountPath: /http-prober-bin
+          name: http-prober-bin
       imagePullSecrets:
       - name: dockercfg
       initContainers:
-      - args:
-        - -endpoint
-        - https://apiserver-external.cluster-de-test-01.svc.cluster.local.:30000/healthz
-        - -insecure
-        - -retries
-        - "100"
-        - -retry-wait
-        - "2"
-        - -timeout
-        - "1"
-        command:
+      - command:
+        - /bin/cp
         - /usr/local/bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.1
-        imagePullPolicy: IfNotPresent
-        name: apiserver-running
+        - /http-prober-bin/http-prober
+        image: quay.io/kubermatic/http-prober:v0.2-dev0
+        name: copy-http-prober
         resources: {}
-        terminationMessagePath: /dev/termination-log
-        terminationMessagePolicy: File
+        volumeMounts:
+        - mountPath: /http-prober-bin
+          name: http-prober-bin
       volumes:
       - name: kube-state-metrics-kubeconfig
         secret:
           defaultMode: 256
           secretName: kube-state-metrics-kubeconfig
+      - emptyDir: {}
+        name: http-prober-bin
 status: {}

--- a/api/pkg/resources/test/fixtures/deployment-bringyourown-1.12.0-kube-state-metrics.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-bringyourown-1.12.0-kube-state-metrics.yaml
@@ -72,7 +72,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.2-dev0
+        image: quay.io/kubermatic/http-prober:v0.2
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/api/pkg/resources/test/fixtures/deployment-bringyourown-1.12.0-machine-controller-webhook.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-bringyourown-1.12.0-machine-controller-webhook.yaml
@@ -36,13 +36,8 @@ spec:
         - -command
         - '{"command":"/usr/local/bin/webhook","args":["-kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","-logtostderr","-v","4","-listen-address","0.0.0.0:9876"]}'
         command:
-<<<<<<< HEAD
-        - /usr/local/bin/webhook
-        image: docker.io/kubermatic/machine-controller:v1.4.3
-=======
         - /http-prober-bin/http-prober
-        image: docker.io/kubermatic/machine-controller:v1.4.2
->>>>>>> Use wrapper instead of initContainer to check if apiserver is reachable (#3857)
+        image: docker.io/kubermatic/machine-controller:v1.4.3
         livenessProbe:
           failureThreshold: 8
           httpGet:

--- a/api/pkg/resources/test/fixtures/deployment-bringyourown-1.12.0-machine-controller-webhook.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-bringyourown-1.12.0-machine-controller-webhook.yaml
@@ -86,7 +86,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.2-dev0
+        image: quay.io/kubermatic/http-prober:v0.2
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/api/pkg/resources/test/fixtures/deployment-bringyourown-1.12.0-machine-controller-webhook.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-bringyourown-1.12.0-machine-controller-webhook.yaml
@@ -24,16 +24,25 @@ spec:
     spec:
       containers:
       - args:
-        - -kubeconfig
-        - /etc/kubernetes/kubeconfig/kubeconfig
-        - -logtostderr
-        - -v
-        - "4"
-        - -listen-address
-        - 0.0.0.0:9876
+        - -endpoint
+        - https://apiserver-external.cluster-de-test-01.svc.cluster.local.:30000/healthz
+        - -insecure
+        - -retries
+        - "100"
+        - -retry-wait
+        - "2"
+        - -timeout
+        - "1"
+        - -command
+        - '{"command":"/usr/local/bin/webhook","args":["-kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","-logtostderr","-v","4","-listen-address","0.0.0.0:9876"]}'
         command:
+<<<<<<< HEAD
         - /usr/local/bin/webhook
         image: docker.io/kubermatic/machine-controller:v1.4.3
+=======
+        - /http-prober-bin/http-prober
+        image: docker.io/kubermatic/machine-controller:v1.4.2
+>>>>>>> Use wrapper instead of initContainer to check if apiserver is reachable (#3857)
         livenessProbe:
           failureThreshold: 8
           httpGet:
@@ -68,27 +77,21 @@ spec:
         - mountPath: /tmp/cert
           name: machinecontroller-webhook-serving-cert
           readOnly: true
+        - mountPath: /http-prober-bin
+          name: http-prober-bin
       imagePullSecrets:
       - name: dockercfg
       initContainers:
-      - args:
-        - -endpoint
-        - https://apiserver-external.cluster-de-test-01.svc.cluster.local.:30000/healthz
-        - -insecure
-        - -retries
-        - "100"
-        - -retry-wait
-        - "2"
-        - -timeout
-        - "1"
-        command:
+      - command:
+        - /bin/cp
         - /usr/local/bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.1
-        imagePullPolicy: IfNotPresent
-        name: apiserver-running
+        - /http-prober-bin/http-prober
+        image: quay.io/kubermatic/http-prober:v0.2-dev0
+        name: copy-http-prober
         resources: {}
-        terminationMessagePath: /dev/termination-log
-        terminationMessagePolicy: File
+        volumeMounts:
+        - mountPath: /http-prober-bin
+          name: http-prober-bin
       volumes:
       - name: machinecontroller-kubeconfig
         secret:
@@ -98,4 +101,6 @@ spec:
         secret:
           defaultMode: 292
           secretName: machinecontroller-webhook-serving-cert
+      - emptyDir: {}
+        name: http-prober-bin
 status: {}

--- a/api/pkg/resources/test/fixtures/deployment-bringyourown-1.12.0-machine-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-bringyourown-1.12.0-machine-controller.yaml
@@ -77,7 +77,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.2-dev0
+        image: quay.io/kubermatic/http-prober:v0.2
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/api/pkg/resources/test/fixtures/deployment-bringyourown-1.12.0-machine-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-bringyourown-1.12.0-machine-controller.yaml
@@ -39,13 +39,8 @@ spec:
         - -command
         - '{"command":"/usr/local/bin/machine-controller","args":["-kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","-logtostderr","-v","4","-cluster-dns","169.254.20.10","-internal-listen-address","0.0.0.0:8085"]}'
         command:
-<<<<<<< HEAD
-        - /usr/local/bin/machine-controller
-        image: docker.io/kubermatic/machine-controller:v1.4.3
-=======
         - /http-prober-bin/http-prober
-        image: docker.io/kubermatic/machine-controller:v1.4.2
->>>>>>> Use wrapper instead of initContainer to check if apiserver is reachable (#3857)
+        image: docker.io/kubermatic/machine-controller:v1.4.3
         livenessProbe:
           failureThreshold: 3
           httpGet:

--- a/api/pkg/resources/test/fixtures/deployment-bringyourown-1.12.0-machine-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-bringyourown-1.12.0-machine-controller.yaml
@@ -27,18 +27,25 @@ spec:
     spec:
       containers:
       - args:
-        - -kubeconfig
-        - /etc/kubernetes/kubeconfig/kubeconfig
-        - -logtostderr
-        - -v
-        - "4"
-        - -cluster-dns
-        - 169.254.20.10
-        - -internal-listen-address
-        - 0.0.0.0:8085
+        - -endpoint
+        - https://apiserver-external.cluster-de-test-01.svc.cluster.local.:30000/healthz
+        - -insecure
+        - -retries
+        - "100"
+        - -retry-wait
+        - "2"
+        - -timeout
+        - "1"
+        - -command
+        - '{"command":"/usr/local/bin/machine-controller","args":["-kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","-logtostderr","-v","4","-cluster-dns","169.254.20.10","-internal-listen-address","0.0.0.0:8085"]}'
         command:
+<<<<<<< HEAD
         - /usr/local/bin/machine-controller
         image: docker.io/kubermatic/machine-controller:v1.4.3
+=======
+        - /http-prober-bin/http-prober
+        image: docker.io/kubermatic/machine-controller:v1.4.2
+>>>>>>> Use wrapper instead of initContainer to check if apiserver is reachable (#3857)
         livenessProbe:
           failureThreshold: 3
           httpGet:
@@ -61,30 +68,26 @@ spec:
         - mountPath: /etc/kubernetes/kubeconfig
           name: machinecontroller-kubeconfig
           readOnly: true
+        - mountPath: /http-prober-bin
+          name: http-prober-bin
       imagePullSecrets:
       - name: dockercfg
       initContainers:
-      - args:
-        - -endpoint
-        - https://apiserver-external.cluster-de-test-01.svc.cluster.local.:30000/healthz
-        - -insecure
-        - -retries
-        - "100"
-        - -retry-wait
-        - "2"
-        - -timeout
-        - "1"
-        command:
+      - command:
+        - /bin/cp
         - /usr/local/bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.1
-        imagePullPolicy: IfNotPresent
-        name: apiserver-running
+        - /http-prober-bin/http-prober
+        image: quay.io/kubermatic/http-prober:v0.2-dev0
+        name: copy-http-prober
         resources: {}
-        terminationMessagePath: /dev/termination-log
-        terminationMessagePolicy: File
+        volumeMounts:
+        - mountPath: /http-prober-bin
+          name: http-prober-bin
       volumes:
       - name: machinecontroller-kubeconfig
         secret:
           defaultMode: 292
           secretName: machinecontroller-kubeconfig
+      - emptyDir: {}
+        name: http-prober-bin
 status: {}

--- a/api/pkg/resources/test/fixtures/deployment-bringyourown-1.12.0-metrics-server.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-bringyourown-1.12.0-metrics-server.yaml
@@ -41,22 +41,19 @@ spec:
             weight: 10
       containers:
       - args:
-        - --kubeconfig
-        - /etc/kubernetes/kubeconfig/kubeconfig
-        - --authentication-kubeconfig
-        - /etc/kubernetes/kubeconfig/kubeconfig
-        - --authorization-kubeconfig
-        - /etc/kubernetes/kubeconfig/kubeconfig
-        - --kubelet-port
-        - "10250"
-        - --kubelet-insecure-tls
-        - --kubelet-preferred-address-types
-        - ExternalIP,InternalIP
-        - --v
+        - -endpoint
+        - https://apiserver-external.cluster-de-test-01.svc.cluster.local.:30000/healthz
+        - -insecure
+        - -retries
+        - "100"
+        - -retry-wait
+        - "2"
+        - -timeout
         - "1"
-        - --logtostderr
+        - -command
+        - '{"command":"/metrics-server","args":["--kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","--authentication-kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","--authorization-kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","--kubelet-port","10250","--kubelet-insecure-tls","--kubelet-preferred-address-types","ExternalIP,InternalIP","--v","1","--logtostderr"]}'
         command:
-        - /metrics-server
+        - /http-prober-bin/http-prober
         image: gcr.io/google_containers/metrics-server-amd64:v0.3.2
         name: metrics-server
         resources:
@@ -70,6 +67,8 @@ spec:
         - mountPath: /etc/kubernetes/kubeconfig
           name: metrics-server
           readOnly: true
+        - mountPath: /http-prober-bin
+          name: http-prober-bin
       - args:
         - --client
         - --proto
@@ -158,24 +157,16 @@ spec:
       imagePullSecrets:
       - name: dockercfg
       initContainers:
-      - args:
-        - -endpoint
-        - https://apiserver-external.cluster-de-test-01.svc.cluster.local.:30000/healthz
-        - -insecure
-        - -retries
-        - "100"
-        - -retry-wait
-        - "2"
-        - -timeout
-        - "1"
-        command:
+      - command:
+        - /bin/cp
         - /usr/local/bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.1
-        imagePullPolicy: IfNotPresent
-        name: apiserver-running
+        - /http-prober-bin/http-prober
+        image: quay.io/kubermatic/http-prober:v0.2-dev0
+        name: copy-http-prober
         resources: {}
-        terminationMessagePath: /dev/termination-log
-        terminationMessagePolicy: File
+        volumeMounts:
+        - mountPath: /http-prober-bin
+          name: http-prober-bin
       volumes:
       - name: metrics-server
         secret:
@@ -189,4 +180,6 @@ spec:
         secret:
           defaultMode: 292
           secretName: kubeletdnatcontroller-kubeconfig
+      - emptyDir: {}
+        name: http-prober-bin
 status: {}

--- a/api/pkg/resources/test/fixtures/deployment-bringyourown-1.12.0-metrics-server.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-bringyourown-1.12.0-metrics-server.yaml
@@ -161,7 +161,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.2-dev0
+        image: quay.io/kubermatic/http-prober:v0.2
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/api/pkg/resources/test/fixtures/deployment-bringyourown-1.12.0-scheduler.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-bringyourown-1.12.0-scheduler.yaml
@@ -168,7 +168,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.2-dev0
+        image: quay.io/kubermatic/http-prober:v0.2
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/api/pkg/resources/test/fixtures/deployment-bringyourown-1.12.0-scheduler.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-bringyourown-1.12.0-scheduler.yaml
@@ -100,13 +100,19 @@ spec:
           name: openvpn-client-certificates
           readOnly: true
       - args:
-        - --kubeconfig
-        - /etc/kubernetes/kubeconfig/kubeconfig
-        - --feature-gates
-        - ScheduleDaemonSetPods=false
+        - -endpoint
+        - https://apiserver-external.cluster-de-test-01.svc.cluster.local.:30000/healthz
+        - -insecure
+        - -retries
+        - "100"
+        - -retry-wait
+        - "2"
+        - -timeout
+        - "1"
+        - -command
+        - '{"command":"/hyperkube","args":["kube-scheduler","--kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","--feature-gates","ScheduleDaemonSetPods=false"]}'
         command:
-        - /hyperkube
-        - kube-scheduler
+        - /http-prober-bin/http-prober
         image: gcr.io/google_containers/hyperkube-amd64:v1.12.0
         livenessProbe:
           failureThreshold: 8
@@ -142,6 +148,8 @@ spec:
         - mountPath: /etc/kubernetes/pki/ca
           name: ca
           readOnly: true
+        - mountPath: /http-prober-bin
+          name: http-prober-bin
       dnsConfig:
         nameservers:
         - 192.0.2.14
@@ -156,24 +164,16 @@ spec:
       imagePullSecrets:
       - name: dockercfg
       initContainers:
-      - args:
-        - -endpoint
-        - https://apiserver-external.cluster-de-test-01.svc.cluster.local.:30000/healthz
-        - -insecure
-        - -retries
-        - "100"
-        - -retry-wait
-        - "2"
-        - -timeout
-        - "1"
-        command:
+      - command:
+        - /bin/cp
         - /usr/local/bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.1
-        imagePullPolicy: IfNotPresent
-        name: apiserver-running
+        - /http-prober-bin/http-prober
+        image: quay.io/kubermatic/http-prober:v0.2-dev0
+        name: copy-http-prober
         resources: {}
-        terminationMessagePath: /dev/termination-log
-        terminationMessagePolicy: File
+        volumeMounts:
+        - mountPath: /http-prober-bin
+          name: http-prober-bin
       volumes:
       - name: openvpn-client-certificates
         secret:
@@ -190,4 +190,6 @@ spec:
         secret:
           defaultMode: 256
           secretName: scheduler-kubeconfig
+      - emptyDir: {}
+        name: http-prober-bin
 status: {}

--- a/api/pkg/resources/test/fixtures/deployment-bringyourown-1.12.0-usercluster-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-bringyourown-1.12.0-usercluster-controller.yaml
@@ -85,7 +85,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.2-dev0
+        image: quay.io/kubermatic/http-prober:v0.2
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/api/pkg/resources/test/fixtures/deployment-bringyourown-1.12.0-usercluster-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-bringyourown-1.12.0-usercluster-controller.yaml
@@ -29,32 +29,19 @@ spec:
     spec:
       containers:
       - args:
-        - -kubeconfig
-        - /etc/kubernetes/kubeconfig/kubeconfig
-        - -metrics-listen-address
-        - 0.0.0.0:8085
-        - -health-listen-address
-        - 0.0.0.0:8086
-        - -namespace
-        - $(NAMESPACE)
-        - -ca-cert
-        - /etc/kubernetes/pki/ca/ca.crt
-        - -cluster-url
-        - ""
-        - -openvpn-server-port
-        - "30003"
-        - -overwrite-registry
-        - ""
-        - -openshift=false
-        - -openvpn-ca-cert-file=/etc/kubernetes/pki/openvpn/ca.crt
-        - -openvpn-ca-key-file=/etc/kubernetes/pki/openvpn/ca.key
-        - -logtostderr
-        - -v
+        - -endpoint
+        - https://apiserver-external.cluster-de-test-01.svc.cluster.local.:30000/healthz
+        - -insecure
+        - -retries
+        - "100"
+        - -retry-wait
         - "2"
-        - --ipam-controller-network
-        - 192.168.1.1/24,192.168.1.1,8.8.8.8
+        - -timeout
+        - "1"
+        - -command
+        - '{"command":"/usr/local/bin/user-cluster-controller-manager","args":["-kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","-metrics-listen-address","0.0.0.0:8085","-health-listen-address","0.0.0.0:8086","-namespace","$(NAMESPACE)","-ca-cert","/etc/kubernetes/pki/ca/ca.crt","-cluster-url","","-openvpn-server-port","30003","-overwrite-registry","","-openshift=false","-openvpn-ca-cert-file=/etc/kubernetes/pki/openvpn/ca.crt","-openvpn-ca-key-file=/etc/kubernetes/pki/openvpn/ca.key","-logtostderr","-v","2","--ipam-controller-network","192.168.1.1/24,192.168.1.1,8.8.8.8"]}'
         command:
-        - /usr/local/bin/user-cluster-controller-manager
+        - /http-prober-bin/http-prober
         env:
         - name: NAMESPACE
           valueFrom:
@@ -89,27 +76,21 @@ spec:
         - mountPath: /etc/kubernetes/pki/openvpn
           name: openvpn-ca
           readOnly: true
+        - mountPath: /http-prober-bin
+          name: http-prober-bin
       imagePullSecrets:
       - name: dockercfg
       initContainers:
-      - args:
-        - -endpoint
-        - https://apiserver-external.cluster-de-test-01.svc.cluster.local.:30000/healthz
-        - -insecure
-        - -retries
-        - "100"
-        - -retry-wait
-        - "2"
-        - -timeout
-        - "1"
-        command:
+      - command:
+        - /bin/cp
         - /usr/local/bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.1
-        imagePullPolicy: IfNotPresent
-        name: apiserver-running
+        - /http-prober-bin/http-prober
+        image: quay.io/kubermatic/http-prober:v0.2-dev0
+        name: copy-http-prober
         resources: {}
-        terminationMessagePath: /dev/termination-log
-        terminationMessagePolicy: File
+        volumeMounts:
+        - mountPath: /http-prober-bin
+          name: http-prober-bin
       volumes:
       - name: internal-admin-kubeconfig
         secret:
@@ -126,4 +107,6 @@ spec:
         secret:
           defaultMode: 292
           secretName: openvpn-ca
+      - emptyDir: {}
+        name: http-prober-bin
 status: {}

--- a/api/pkg/resources/test/fixtures/deployment-bringyourown-1.13.0-controller-manager.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-bringyourown-1.13.0-controller-manager.yaml
@@ -176,7 +176,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.2-dev0
+        image: quay.io/kubermatic/http-prober:v0.2
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/api/pkg/resources/test/fixtures/deployment-bringyourown-1.13.0-controller-manager.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-bringyourown-1.13.0-controller-manager.yaml
@@ -102,37 +102,19 @@ spec:
           name: openvpn-client-certificates
           readOnly: true
       - args:
-        - --kubeconfig
-        - /etc/kubernetes/kubeconfig/kubeconfig
-        - --service-account-private-key-file
-        - /etc/kubernetes/service-account-key/sa.key
-        - --root-ca-file
-        - /etc/kubernetes/pki/ca/ca.crt
-        - --cluster-signing-cert-file
-        - /etc/kubernetes/pki/ca/ca.crt
-        - --cluster-signing-key-file
-        - /etc/kubernetes/pki/ca/ca.key
-        - --cluster-cidr
-        - 172.25.0.0/16
-        - --allocate-node-cidrs=true
-        - --controllers
-        - '*,bootstrapsigner,tokencleaner'
-        - --use-service-account-credentials=true
-        - --feature-gates
-        - RotateKubeletClientCertificate=true,RotateKubeletServerCertificate=true,ScheduleDaemonSetPods=false
-        - --authentication-kubeconfig
-        - /etc/kubernetes/kubeconfig/kubeconfig
-        - --client-ca-file
-        - /etc/kubernetes/pki/ca/ca.crt
-        - --authentication-kubeconfig
-        - /etc/kubernetes/kubeconfig/kubeconfig
-        - --authorization-kubeconfig
-        - /etc/kubernetes/kubeconfig/kubeconfig
-        - --port
-        - "0"
+        - -endpoint
+        - https://apiserver-external.cluster-de-test-01.svc.cluster.local.:30000/healthz
+        - -insecure
+        - -retries
+        - "100"
+        - -retry-wait
+        - "2"
+        - -timeout
+        - "1"
+        - -command
+        - '{"command":"/hyperkube","args":["kube-controller-manager","--kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","--service-account-private-key-file","/etc/kubernetes/service-account-key/sa.key","--root-ca-file","/etc/kubernetes/pki/ca/ca.crt","--cluster-signing-cert-file","/etc/kubernetes/pki/ca/ca.crt","--cluster-signing-key-file","/etc/kubernetes/pki/ca/ca.key","--cluster-cidr","172.25.0.0/16","--allocate-node-cidrs=true","--controllers","*,bootstrapsigner,tokencleaner","--use-service-account-credentials=true","--feature-gates","RotateKubeletClientCertificate=true,RotateKubeletServerCertificate=true,ScheduleDaemonSetPods=false","--authentication-kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","--client-ca-file","/etc/kubernetes/pki/ca/ca.crt","--authentication-kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","--authorization-kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","--port","0"]}'
         command:
-        - /hyperkube
-        - kube-controller-manager
+        - /http-prober-bin/http-prober
         image: gcr.io/google_containers/hyperkube-amd64:v1.13.0
         livenessProbe:
           failureThreshold: 8
@@ -174,6 +156,8 @@ spec:
         - mountPath: /etc/kubernetes/kubeconfig
           name: controllermanager-kubeconfig
           readOnly: true
+        - mountPath: /http-prober-bin
+          name: http-prober-bin
       dnsConfig:
         nameservers:
         - 192.0.2.14
@@ -188,24 +172,16 @@ spec:
       imagePullSecrets:
       - name: dockercfg
       initContainers:
-      - args:
-        - -endpoint
-        - https://apiserver-external.cluster-de-test-01.svc.cluster.local.:30000/healthz
-        - -insecure
-        - -retries
-        - "100"
-        - -retry-wait
-        - "2"
-        - -timeout
-        - "1"
-        command:
+      - command:
+        - /bin/cp
         - /usr/local/bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.1
-        imagePullPolicy: IfNotPresent
-        name: apiserver-running
+        - /http-prober-bin/http-prober
+        image: quay.io/kubermatic/http-prober:v0.2-dev0
+        name: copy-http-prober
         resources: {}
-        terminationMessagePath: /dev/termination-log
-        terminationMessagePolicy: File
+        volumeMounts:
+        - mountPath: /http-prober-bin
+          name: http-prober-bin
       volumes:
       - name: ca
         secret:
@@ -227,4 +203,6 @@ spec:
         secret:
           defaultMode: 256
           secretName: controllermanager-kubeconfig
+      - emptyDir: {}
+        name: http-prober-bin
 status: {}

--- a/api/pkg/resources/test/fixtures/deployment-bringyourown-1.13.0-kube-state-metrics.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-bringyourown-1.13.0-kube-state-metrics.yaml
@@ -21,14 +21,19 @@ spec:
     spec:
       containers:
       - args:
-        - --kubeconfig
-        - /etc/kubernetes/kubeconfig/kubeconfig
-        - --port
-        - "8080"
-        - --telemetry-port
-        - "8081"
+        - -endpoint
+        - https://apiserver-external.cluster-de-test-01.svc.cluster.local.:30000/healthz
+        - -insecure
+        - -retries
+        - "100"
+        - -retry-wait
+        - "2"
+        - -timeout
+        - "1"
+        - -command
+        - '{"command":"/kube-state-metrics","args":["--kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","--port","8080","--telemetry-port","8081"]}'
         command:
-        - /kube-state-metrics
+        - /http-prober-bin/http-prober
         image: quay.io/coreos/kube-state-metrics:v1.6.0
         name: kube-state-metrics
         ports:
@@ -58,30 +63,26 @@ spec:
         - mountPath: /etc/kubernetes/kubeconfig
           name: kube-state-metrics-kubeconfig
           readOnly: true
+        - mountPath: /http-prober-bin
+          name: http-prober-bin
       imagePullSecrets:
       - name: dockercfg
       initContainers:
-      - args:
-        - -endpoint
-        - https://apiserver-external.cluster-de-test-01.svc.cluster.local.:30000/healthz
-        - -insecure
-        - -retries
-        - "100"
-        - -retry-wait
-        - "2"
-        - -timeout
-        - "1"
-        command:
+      - command:
+        - /bin/cp
         - /usr/local/bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.1
-        imagePullPolicy: IfNotPresent
-        name: apiserver-running
+        - /http-prober-bin/http-prober
+        image: quay.io/kubermatic/http-prober:v0.2-dev0
+        name: copy-http-prober
         resources: {}
-        terminationMessagePath: /dev/termination-log
-        terminationMessagePolicy: File
+        volumeMounts:
+        - mountPath: /http-prober-bin
+          name: http-prober-bin
       volumes:
       - name: kube-state-metrics-kubeconfig
         secret:
           defaultMode: 256
           secretName: kube-state-metrics-kubeconfig
+      - emptyDir: {}
+        name: http-prober-bin
 status: {}

--- a/api/pkg/resources/test/fixtures/deployment-bringyourown-1.13.0-kube-state-metrics.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-bringyourown-1.13.0-kube-state-metrics.yaml
@@ -72,7 +72,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.2-dev0
+        image: quay.io/kubermatic/http-prober:v0.2
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/api/pkg/resources/test/fixtures/deployment-bringyourown-1.13.0-machine-controller-webhook.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-bringyourown-1.13.0-machine-controller-webhook.yaml
@@ -36,13 +36,8 @@ spec:
         - -command
         - '{"command":"/usr/local/bin/webhook","args":["-kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","-logtostderr","-v","4","-listen-address","0.0.0.0:9876"]}'
         command:
-<<<<<<< HEAD
-        - /usr/local/bin/webhook
-        image: docker.io/kubermatic/machine-controller:v1.4.3
-=======
         - /http-prober-bin/http-prober
-        image: docker.io/kubermatic/machine-controller:v1.4.2
->>>>>>> Use wrapper instead of initContainer to check if apiserver is reachable (#3857)
+        image: docker.io/kubermatic/machine-controller:v1.4.3
         livenessProbe:
           failureThreshold: 8
           httpGet:

--- a/api/pkg/resources/test/fixtures/deployment-bringyourown-1.13.0-machine-controller-webhook.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-bringyourown-1.13.0-machine-controller-webhook.yaml
@@ -86,7 +86,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.2-dev0
+        image: quay.io/kubermatic/http-prober:v0.2
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/api/pkg/resources/test/fixtures/deployment-bringyourown-1.13.0-machine-controller-webhook.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-bringyourown-1.13.0-machine-controller-webhook.yaml
@@ -24,16 +24,25 @@ spec:
     spec:
       containers:
       - args:
-        - -kubeconfig
-        - /etc/kubernetes/kubeconfig/kubeconfig
-        - -logtostderr
-        - -v
-        - "4"
-        - -listen-address
-        - 0.0.0.0:9876
+        - -endpoint
+        - https://apiserver-external.cluster-de-test-01.svc.cluster.local.:30000/healthz
+        - -insecure
+        - -retries
+        - "100"
+        - -retry-wait
+        - "2"
+        - -timeout
+        - "1"
+        - -command
+        - '{"command":"/usr/local/bin/webhook","args":["-kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","-logtostderr","-v","4","-listen-address","0.0.0.0:9876"]}'
         command:
+<<<<<<< HEAD
         - /usr/local/bin/webhook
         image: docker.io/kubermatic/machine-controller:v1.4.3
+=======
+        - /http-prober-bin/http-prober
+        image: docker.io/kubermatic/machine-controller:v1.4.2
+>>>>>>> Use wrapper instead of initContainer to check if apiserver is reachable (#3857)
         livenessProbe:
           failureThreshold: 8
           httpGet:
@@ -68,27 +77,21 @@ spec:
         - mountPath: /tmp/cert
           name: machinecontroller-webhook-serving-cert
           readOnly: true
+        - mountPath: /http-prober-bin
+          name: http-prober-bin
       imagePullSecrets:
       - name: dockercfg
       initContainers:
-      - args:
-        - -endpoint
-        - https://apiserver-external.cluster-de-test-01.svc.cluster.local.:30000/healthz
-        - -insecure
-        - -retries
-        - "100"
-        - -retry-wait
-        - "2"
-        - -timeout
-        - "1"
-        command:
+      - command:
+        - /bin/cp
         - /usr/local/bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.1
-        imagePullPolicy: IfNotPresent
-        name: apiserver-running
+        - /http-prober-bin/http-prober
+        image: quay.io/kubermatic/http-prober:v0.2-dev0
+        name: copy-http-prober
         resources: {}
-        terminationMessagePath: /dev/termination-log
-        terminationMessagePolicy: File
+        volumeMounts:
+        - mountPath: /http-prober-bin
+          name: http-prober-bin
       volumes:
       - name: machinecontroller-kubeconfig
         secret:
@@ -98,4 +101,6 @@ spec:
         secret:
           defaultMode: 292
           secretName: machinecontroller-webhook-serving-cert
+      - emptyDir: {}
+        name: http-prober-bin
 status: {}

--- a/api/pkg/resources/test/fixtures/deployment-bringyourown-1.13.0-machine-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-bringyourown-1.13.0-machine-controller.yaml
@@ -77,7 +77,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.2-dev0
+        image: quay.io/kubermatic/http-prober:v0.2
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/api/pkg/resources/test/fixtures/deployment-bringyourown-1.13.0-machine-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-bringyourown-1.13.0-machine-controller.yaml
@@ -39,13 +39,8 @@ spec:
         - -command
         - '{"command":"/usr/local/bin/machine-controller","args":["-kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","-logtostderr","-v","4","-cluster-dns","169.254.20.10","-internal-listen-address","0.0.0.0:8085"]}'
         command:
-<<<<<<< HEAD
-        - /usr/local/bin/machine-controller
-        image: docker.io/kubermatic/machine-controller:v1.4.3
-=======
         - /http-prober-bin/http-prober
-        image: docker.io/kubermatic/machine-controller:v1.4.2
->>>>>>> Use wrapper instead of initContainer to check if apiserver is reachable (#3857)
+        image: docker.io/kubermatic/machine-controller:v1.4.3
         livenessProbe:
           failureThreshold: 3
           httpGet:

--- a/api/pkg/resources/test/fixtures/deployment-bringyourown-1.13.0-machine-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-bringyourown-1.13.0-machine-controller.yaml
@@ -27,18 +27,25 @@ spec:
     spec:
       containers:
       - args:
-        - -kubeconfig
-        - /etc/kubernetes/kubeconfig/kubeconfig
-        - -logtostderr
-        - -v
-        - "4"
-        - -cluster-dns
-        - 169.254.20.10
-        - -internal-listen-address
-        - 0.0.0.0:8085
+        - -endpoint
+        - https://apiserver-external.cluster-de-test-01.svc.cluster.local.:30000/healthz
+        - -insecure
+        - -retries
+        - "100"
+        - -retry-wait
+        - "2"
+        - -timeout
+        - "1"
+        - -command
+        - '{"command":"/usr/local/bin/machine-controller","args":["-kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","-logtostderr","-v","4","-cluster-dns","169.254.20.10","-internal-listen-address","0.0.0.0:8085"]}'
         command:
+<<<<<<< HEAD
         - /usr/local/bin/machine-controller
         image: docker.io/kubermatic/machine-controller:v1.4.3
+=======
+        - /http-prober-bin/http-prober
+        image: docker.io/kubermatic/machine-controller:v1.4.2
+>>>>>>> Use wrapper instead of initContainer to check if apiserver is reachable (#3857)
         livenessProbe:
           failureThreshold: 3
           httpGet:
@@ -61,30 +68,26 @@ spec:
         - mountPath: /etc/kubernetes/kubeconfig
           name: machinecontroller-kubeconfig
           readOnly: true
+        - mountPath: /http-prober-bin
+          name: http-prober-bin
       imagePullSecrets:
       - name: dockercfg
       initContainers:
-      - args:
-        - -endpoint
-        - https://apiserver-external.cluster-de-test-01.svc.cluster.local.:30000/healthz
-        - -insecure
-        - -retries
-        - "100"
-        - -retry-wait
-        - "2"
-        - -timeout
-        - "1"
-        command:
+      - command:
+        - /bin/cp
         - /usr/local/bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.1
-        imagePullPolicy: IfNotPresent
-        name: apiserver-running
+        - /http-prober-bin/http-prober
+        image: quay.io/kubermatic/http-prober:v0.2-dev0
+        name: copy-http-prober
         resources: {}
-        terminationMessagePath: /dev/termination-log
-        terminationMessagePolicy: File
+        volumeMounts:
+        - mountPath: /http-prober-bin
+          name: http-prober-bin
       volumes:
       - name: machinecontroller-kubeconfig
         secret:
           defaultMode: 292
           secretName: machinecontroller-kubeconfig
+      - emptyDir: {}
+        name: http-prober-bin
 status: {}

--- a/api/pkg/resources/test/fixtures/deployment-bringyourown-1.13.0-metrics-server.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-bringyourown-1.13.0-metrics-server.yaml
@@ -41,22 +41,19 @@ spec:
             weight: 10
       containers:
       - args:
-        - --kubeconfig
-        - /etc/kubernetes/kubeconfig/kubeconfig
-        - --authentication-kubeconfig
-        - /etc/kubernetes/kubeconfig/kubeconfig
-        - --authorization-kubeconfig
-        - /etc/kubernetes/kubeconfig/kubeconfig
-        - --kubelet-port
-        - "10250"
-        - --kubelet-insecure-tls
-        - --kubelet-preferred-address-types
-        - ExternalIP,InternalIP
-        - --v
+        - -endpoint
+        - https://apiserver-external.cluster-de-test-01.svc.cluster.local.:30000/healthz
+        - -insecure
+        - -retries
+        - "100"
+        - -retry-wait
+        - "2"
+        - -timeout
         - "1"
-        - --logtostderr
+        - -command
+        - '{"command":"/metrics-server","args":["--kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","--authentication-kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","--authorization-kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","--kubelet-port","10250","--kubelet-insecure-tls","--kubelet-preferred-address-types","ExternalIP,InternalIP","--v","1","--logtostderr"]}'
         command:
-        - /metrics-server
+        - /http-prober-bin/http-prober
         image: gcr.io/google_containers/metrics-server-amd64:v0.3.2
         name: metrics-server
         resources:
@@ -70,6 +67,8 @@ spec:
         - mountPath: /etc/kubernetes/kubeconfig
           name: metrics-server
           readOnly: true
+        - mountPath: /http-prober-bin
+          name: http-prober-bin
       - args:
         - --client
         - --proto
@@ -158,24 +157,16 @@ spec:
       imagePullSecrets:
       - name: dockercfg
       initContainers:
-      - args:
-        - -endpoint
-        - https://apiserver-external.cluster-de-test-01.svc.cluster.local.:30000/healthz
-        - -insecure
-        - -retries
-        - "100"
-        - -retry-wait
-        - "2"
-        - -timeout
-        - "1"
-        command:
+      - command:
+        - /bin/cp
         - /usr/local/bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.1
-        imagePullPolicy: IfNotPresent
-        name: apiserver-running
+        - /http-prober-bin/http-prober
+        image: quay.io/kubermatic/http-prober:v0.2-dev0
+        name: copy-http-prober
         resources: {}
-        terminationMessagePath: /dev/termination-log
-        terminationMessagePolicy: File
+        volumeMounts:
+        - mountPath: /http-prober-bin
+          name: http-prober-bin
       volumes:
       - name: metrics-server
         secret:
@@ -189,4 +180,6 @@ spec:
         secret:
           defaultMode: 292
           secretName: kubeletdnatcontroller-kubeconfig
+      - emptyDir: {}
+        name: http-prober-bin
 status: {}

--- a/api/pkg/resources/test/fixtures/deployment-bringyourown-1.13.0-metrics-server.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-bringyourown-1.13.0-metrics-server.yaml
@@ -161,7 +161,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.2-dev0
+        image: quay.io/kubermatic/http-prober:v0.2
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/api/pkg/resources/test/fixtures/deployment-bringyourown-1.13.0-scheduler.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-bringyourown-1.13.0-scheduler.yaml
@@ -100,21 +100,19 @@ spec:
           name: openvpn-client-certificates
           readOnly: true
       - args:
-        - --kubeconfig
-        - /etc/kubernetes/kubeconfig/kubeconfig
-        - --authentication-kubeconfig
-        - /etc/kubernetes/kubeconfig/kubeconfig
-        - --authorization-kubeconfig
-        - /etc/kubernetes/kubeconfig/kubeconfig
-        - --client-ca-file
-        - /etc/kubernetes/pki/ca/ca.crt
-        - --port
-        - "0"
-        - --feature-gates
-        - ScheduleDaemonSetPods=false
+        - -endpoint
+        - https://apiserver-external.cluster-de-test-01.svc.cluster.local.:30000/healthz
+        - -insecure
+        - -retries
+        - "100"
+        - -retry-wait
+        - "2"
+        - -timeout
+        - "1"
+        - -command
+        - '{"command":"/hyperkube","args":["kube-scheduler","--kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","--authentication-kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","--authorization-kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","--client-ca-file","/etc/kubernetes/pki/ca/ca.crt","--port","0","--feature-gates","ScheduleDaemonSetPods=false"]}'
         command:
-        - /hyperkube
-        - kube-scheduler
+        - /http-prober-bin/http-prober
         image: gcr.io/google_containers/hyperkube-amd64:v1.13.0
         livenessProbe:
           failureThreshold: 8
@@ -150,6 +148,8 @@ spec:
         - mountPath: /etc/kubernetes/pki/ca
           name: ca
           readOnly: true
+        - mountPath: /http-prober-bin
+          name: http-prober-bin
       dnsConfig:
         nameservers:
         - 192.0.2.14
@@ -164,24 +164,16 @@ spec:
       imagePullSecrets:
       - name: dockercfg
       initContainers:
-      - args:
-        - -endpoint
-        - https://apiserver-external.cluster-de-test-01.svc.cluster.local.:30000/healthz
-        - -insecure
-        - -retries
-        - "100"
-        - -retry-wait
-        - "2"
-        - -timeout
-        - "1"
-        command:
+      - command:
+        - /bin/cp
         - /usr/local/bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.1
-        imagePullPolicy: IfNotPresent
-        name: apiserver-running
+        - /http-prober-bin/http-prober
+        image: quay.io/kubermatic/http-prober:v0.2-dev0
+        name: copy-http-prober
         resources: {}
-        terminationMessagePath: /dev/termination-log
-        terminationMessagePolicy: File
+        volumeMounts:
+        - mountPath: /http-prober-bin
+          name: http-prober-bin
       volumes:
       - name: openvpn-client-certificates
         secret:
@@ -198,4 +190,6 @@ spec:
         secret:
           defaultMode: 256
           secretName: scheduler-kubeconfig
+      - emptyDir: {}
+        name: http-prober-bin
 status: {}

--- a/api/pkg/resources/test/fixtures/deployment-bringyourown-1.13.0-scheduler.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-bringyourown-1.13.0-scheduler.yaml
@@ -168,7 +168,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.2-dev0
+        image: quay.io/kubermatic/http-prober:v0.2
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/api/pkg/resources/test/fixtures/deployment-bringyourown-1.13.0-usercluster-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-bringyourown-1.13.0-usercluster-controller.yaml
@@ -85,7 +85,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.2-dev0
+        image: quay.io/kubermatic/http-prober:v0.2
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/api/pkg/resources/test/fixtures/deployment-bringyourown-1.13.0-usercluster-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-bringyourown-1.13.0-usercluster-controller.yaml
@@ -29,32 +29,19 @@ spec:
     spec:
       containers:
       - args:
-        - -kubeconfig
-        - /etc/kubernetes/kubeconfig/kubeconfig
-        - -metrics-listen-address
-        - 0.0.0.0:8085
-        - -health-listen-address
-        - 0.0.0.0:8086
-        - -namespace
-        - $(NAMESPACE)
-        - -ca-cert
-        - /etc/kubernetes/pki/ca/ca.crt
-        - -cluster-url
-        - ""
-        - -openvpn-server-port
-        - "30003"
-        - -overwrite-registry
-        - ""
-        - -openshift=false
-        - -openvpn-ca-cert-file=/etc/kubernetes/pki/openvpn/ca.crt
-        - -openvpn-ca-key-file=/etc/kubernetes/pki/openvpn/ca.key
-        - -logtostderr
-        - -v
+        - -endpoint
+        - https://apiserver-external.cluster-de-test-01.svc.cluster.local.:30000/healthz
+        - -insecure
+        - -retries
+        - "100"
+        - -retry-wait
         - "2"
-        - --ipam-controller-network
-        - 192.168.1.1/24,192.168.1.1,8.8.8.8
+        - -timeout
+        - "1"
+        - -command
+        - '{"command":"/usr/local/bin/user-cluster-controller-manager","args":["-kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","-metrics-listen-address","0.0.0.0:8085","-health-listen-address","0.0.0.0:8086","-namespace","$(NAMESPACE)","-ca-cert","/etc/kubernetes/pki/ca/ca.crt","-cluster-url","","-openvpn-server-port","30003","-overwrite-registry","","-openshift=false","-openvpn-ca-cert-file=/etc/kubernetes/pki/openvpn/ca.crt","-openvpn-ca-key-file=/etc/kubernetes/pki/openvpn/ca.key","-logtostderr","-v","2","--ipam-controller-network","192.168.1.1/24,192.168.1.1,8.8.8.8"]}'
         command:
-        - /usr/local/bin/user-cluster-controller-manager
+        - /http-prober-bin/http-prober
         env:
         - name: NAMESPACE
           valueFrom:
@@ -89,27 +76,21 @@ spec:
         - mountPath: /etc/kubernetes/pki/openvpn
           name: openvpn-ca
           readOnly: true
+        - mountPath: /http-prober-bin
+          name: http-prober-bin
       imagePullSecrets:
       - name: dockercfg
       initContainers:
-      - args:
-        - -endpoint
-        - https://apiserver-external.cluster-de-test-01.svc.cluster.local.:30000/healthz
-        - -insecure
-        - -retries
-        - "100"
-        - -retry-wait
-        - "2"
-        - -timeout
-        - "1"
-        command:
+      - command:
+        - /bin/cp
         - /usr/local/bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.1
-        imagePullPolicy: IfNotPresent
-        name: apiserver-running
+        - /http-prober-bin/http-prober
+        image: quay.io/kubermatic/http-prober:v0.2-dev0
+        name: copy-http-prober
         resources: {}
-        terminationMessagePath: /dev/termination-log
-        terminationMessagePolicy: File
+        volumeMounts:
+        - mountPath: /http-prober-bin
+          name: http-prober-bin
       volumes:
       - name: internal-admin-kubeconfig
         secret:
@@ -126,4 +107,6 @@ spec:
         secret:
           defaultMode: 292
           secretName: openvpn-ca
+      - emptyDir: {}
+        name: http-prober-bin
 status: {}

--- a/api/pkg/resources/test/fixtures/deployment-digitalocean-1.10.0-controller-manager.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-digitalocean-1.10.0-controller-manager.yaml
@@ -176,7 +176,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.2-dev0
+        image: quay.io/kubermatic/http-prober:v0.2
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/api/pkg/resources/test/fixtures/deployment-digitalocean-1.10.0-controller-manager.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-digitalocean-1.10.0-controller-manager.yaml
@@ -102,27 +102,19 @@ spec:
           name: openvpn-client-certificates
           readOnly: true
       - args:
-        - --kubeconfig
-        - /etc/kubernetes/kubeconfig/kubeconfig
-        - --service-account-private-key-file
-        - /etc/kubernetes/service-account-key/sa.key
-        - --root-ca-file
-        - /etc/kubernetes/pki/ca/ca.crt
-        - --cluster-signing-cert-file
-        - /etc/kubernetes/pki/ca/ca.crt
-        - --cluster-signing-key-file
-        - /etc/kubernetes/pki/ca/ca.key
-        - --cluster-cidr
-        - 172.25.0.0/16
-        - --allocate-node-cidrs=true
-        - --controllers
-        - '*,bootstrapsigner,tokencleaner'
-        - --use-service-account-credentials=true
-        - --feature-gates
-        - RotateKubeletClientCertificate=true,RotateKubeletServerCertificate=true
+        - -endpoint
+        - https://apiserver-external.cluster-de-test-01.svc.cluster.local.:30000/healthz
+        - -insecure
+        - -retries
+        - "100"
+        - -retry-wait
+        - "2"
+        - -timeout
+        - "1"
+        - -command
+        - '{"command":"/hyperkube","args":["kube-controller-manager","--kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","--service-account-private-key-file","/etc/kubernetes/service-account-key/sa.key","--root-ca-file","/etc/kubernetes/pki/ca/ca.crt","--cluster-signing-cert-file","/etc/kubernetes/pki/ca/ca.crt","--cluster-signing-key-file","/etc/kubernetes/pki/ca/ca.key","--cluster-cidr","172.25.0.0/16","--allocate-node-cidrs=true","--controllers","*,bootstrapsigner,tokencleaner","--use-service-account-credentials=true","--feature-gates","RotateKubeletClientCertificate=true,RotateKubeletServerCertificate=true"]}'
         command:
-        - /hyperkube
-        - kube-controller-manager
+        - /http-prober-bin/http-prober
         image: gcr.io/google_containers/hyperkube-amd64:v1.10.0
         livenessProbe:
           failureThreshold: 8
@@ -164,6 +156,8 @@ spec:
         - mountPath: /etc/kubernetes/kubeconfig
           name: controllermanager-kubeconfig
           readOnly: true
+        - mountPath: /http-prober-bin
+          name: http-prober-bin
       dnsConfig:
         nameservers:
         - 192.0.2.14
@@ -178,24 +172,16 @@ spec:
       imagePullSecrets:
       - name: dockercfg
       initContainers:
-      - args:
-        - -endpoint
-        - https://apiserver-external.cluster-de-test-01.svc.cluster.local.:30000/healthz
-        - -insecure
-        - -retries
-        - "100"
-        - -retry-wait
-        - "2"
-        - -timeout
-        - "1"
-        command:
+      - command:
+        - /bin/cp
         - /usr/local/bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.1
-        imagePullPolicy: IfNotPresent
-        name: apiserver-running
+        - /http-prober-bin/http-prober
+        image: quay.io/kubermatic/http-prober:v0.2-dev0
+        name: copy-http-prober
         resources: {}
-        terminationMessagePath: /dev/termination-log
-        terminationMessagePolicy: File
+        volumeMounts:
+        - mountPath: /http-prober-bin
+          name: http-prober-bin
       volumes:
       - name: ca
         secret:
@@ -217,4 +203,6 @@ spec:
         secret:
           defaultMode: 256
           secretName: controllermanager-kubeconfig
+      - emptyDir: {}
+        name: http-prober-bin
 status: {}

--- a/api/pkg/resources/test/fixtures/deployment-digitalocean-1.10.0-kube-state-metrics.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-digitalocean-1.10.0-kube-state-metrics.yaml
@@ -21,14 +21,19 @@ spec:
     spec:
       containers:
       - args:
-        - --kubeconfig
-        - /etc/kubernetes/kubeconfig/kubeconfig
-        - --port
-        - "8080"
-        - --telemetry-port
-        - "8081"
+        - -endpoint
+        - https://apiserver-external.cluster-de-test-01.svc.cluster.local.:30000/healthz
+        - -insecure
+        - -retries
+        - "100"
+        - -retry-wait
+        - "2"
+        - -timeout
+        - "1"
+        - -command
+        - '{"command":"/kube-state-metrics","args":["--kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","--port","8080","--telemetry-port","8081"]}'
         command:
-        - /kube-state-metrics
+        - /http-prober-bin/http-prober
         image: quay.io/coreos/kube-state-metrics:v1.6.0
         name: kube-state-metrics
         ports:
@@ -58,30 +63,26 @@ spec:
         - mountPath: /etc/kubernetes/kubeconfig
           name: kube-state-metrics-kubeconfig
           readOnly: true
+        - mountPath: /http-prober-bin
+          name: http-prober-bin
       imagePullSecrets:
       - name: dockercfg
       initContainers:
-      - args:
-        - -endpoint
-        - https://apiserver-external.cluster-de-test-01.svc.cluster.local.:30000/healthz
-        - -insecure
-        - -retries
-        - "100"
-        - -retry-wait
-        - "2"
-        - -timeout
-        - "1"
-        command:
+      - command:
+        - /bin/cp
         - /usr/local/bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.1
-        imagePullPolicy: IfNotPresent
-        name: apiserver-running
+        - /http-prober-bin/http-prober
+        image: quay.io/kubermatic/http-prober:v0.2-dev0
+        name: copy-http-prober
         resources: {}
-        terminationMessagePath: /dev/termination-log
-        terminationMessagePolicy: File
+        volumeMounts:
+        - mountPath: /http-prober-bin
+          name: http-prober-bin
       volumes:
       - name: kube-state-metrics-kubeconfig
         secret:
           defaultMode: 256
           secretName: kube-state-metrics-kubeconfig
+      - emptyDir: {}
+        name: http-prober-bin
 status: {}

--- a/api/pkg/resources/test/fixtures/deployment-digitalocean-1.10.0-kube-state-metrics.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-digitalocean-1.10.0-kube-state-metrics.yaml
@@ -72,7 +72,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.2-dev0
+        image: quay.io/kubermatic/http-prober:v0.2
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/api/pkg/resources/test/fixtures/deployment-digitalocean-1.10.0-machine-controller-webhook.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-digitalocean-1.10.0-machine-controller-webhook.yaml
@@ -84,7 +84,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.2-dev0
+        image: quay.io/kubermatic/http-prober:v0.2
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/api/pkg/resources/test/fixtures/deployment-digitalocean-1.10.0-machine-controller-webhook.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-digitalocean-1.10.0-machine-controller-webhook.yaml
@@ -24,15 +24,19 @@ spec:
     spec:
       containers:
       - args:
-        - -kubeconfig
-        - /etc/kubernetes/kubeconfig/kubeconfig
-        - -logtostderr
-        - -v
-        - "4"
-        - -listen-address
-        - 0.0.0.0:9876
+        - -endpoint
+        - https://apiserver-external.cluster-de-test-01.svc.cluster.local.:30000/healthz
+        - -insecure
+        - -retries
+        - "100"
+        - -retry-wait
+        - "2"
+        - -timeout
+        - "1"
+        - -command
+        - '{"command":"/usr/local/bin/webhook","args":["-kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","-logtostderr","-v","4","-listen-address","0.0.0.0:9876"]}'
         command:
-        - /usr/local/bin/webhook
+        - /http-prober-bin/http-prober
         env:
         - name: DO_TOKEN
           value: do-token
@@ -71,27 +75,21 @@ spec:
         - mountPath: /tmp/cert
           name: machinecontroller-webhook-serving-cert
           readOnly: true
+        - mountPath: /http-prober-bin
+          name: http-prober-bin
       imagePullSecrets:
       - name: dockercfg
       initContainers:
-      - args:
-        - -endpoint
-        - https://apiserver-external.cluster-de-test-01.svc.cluster.local.:30000/healthz
-        - -insecure
-        - -retries
-        - "100"
-        - -retry-wait
-        - "2"
-        - -timeout
-        - "1"
-        command:
+      - command:
+        - /bin/cp
         - /usr/local/bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.1
-        imagePullPolicy: IfNotPresent
-        name: apiserver-running
+        - /http-prober-bin/http-prober
+        image: quay.io/kubermatic/http-prober:v0.2-dev0
+        name: copy-http-prober
         resources: {}
-        terminationMessagePath: /dev/termination-log
-        terminationMessagePolicy: File
+        volumeMounts:
+        - mountPath: /http-prober-bin
+          name: http-prober-bin
       volumes:
       - name: machinecontroller-kubeconfig
         secret:
@@ -101,4 +99,6 @@ spec:
         secret:
           defaultMode: 292
           secretName: machinecontroller-webhook-serving-cert
+      - emptyDir: {}
+        name: http-prober-bin
 status: {}

--- a/api/pkg/resources/test/fixtures/deployment-digitalocean-1.10.0-machine-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-digitalocean-1.10.0-machine-controller.yaml
@@ -27,17 +27,19 @@ spec:
     spec:
       containers:
       - args:
-        - -kubeconfig
-        - /etc/kubernetes/kubeconfig/kubeconfig
-        - -logtostderr
-        - -v
-        - "4"
-        - -cluster-dns
-        - 169.254.20.10
-        - -internal-listen-address
-        - 0.0.0.0:8085
+        - -endpoint
+        - https://apiserver-external.cluster-de-test-01.svc.cluster.local.:30000/healthz
+        - -insecure
+        - -retries
+        - "100"
+        - -retry-wait
+        - "2"
+        - -timeout
+        - "1"
+        - -command
+        - '{"command":"/usr/local/bin/machine-controller","args":["-kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","-logtostderr","-v","4","-cluster-dns","169.254.20.10","-internal-listen-address","0.0.0.0:8085"]}'
         command:
-        - /usr/local/bin/machine-controller
+        - /http-prober-bin/http-prober
         env:
         - name: DO_TOKEN
           value: do-token
@@ -64,30 +66,26 @@ spec:
         - mountPath: /etc/kubernetes/kubeconfig
           name: machinecontroller-kubeconfig
           readOnly: true
+        - mountPath: /http-prober-bin
+          name: http-prober-bin
       imagePullSecrets:
       - name: dockercfg
       initContainers:
-      - args:
-        - -endpoint
-        - https://apiserver-external.cluster-de-test-01.svc.cluster.local.:30000/healthz
-        - -insecure
-        - -retries
-        - "100"
-        - -retry-wait
-        - "2"
-        - -timeout
-        - "1"
-        command:
+      - command:
+        - /bin/cp
         - /usr/local/bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.1
-        imagePullPolicy: IfNotPresent
-        name: apiserver-running
+        - /http-prober-bin/http-prober
+        image: quay.io/kubermatic/http-prober:v0.2-dev0
+        name: copy-http-prober
         resources: {}
-        terminationMessagePath: /dev/termination-log
-        terminationMessagePolicy: File
+        volumeMounts:
+        - mountPath: /http-prober-bin
+          name: http-prober-bin
       volumes:
       - name: machinecontroller-kubeconfig
         secret:
           defaultMode: 292
           secretName: machinecontroller-kubeconfig
+      - emptyDir: {}
+        name: http-prober-bin
 status: {}

--- a/api/pkg/resources/test/fixtures/deployment-digitalocean-1.10.0-machine-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-digitalocean-1.10.0-machine-controller.yaml
@@ -75,7 +75,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.2-dev0
+        image: quay.io/kubermatic/http-prober:v0.2
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/api/pkg/resources/test/fixtures/deployment-digitalocean-1.10.0-metrics-server.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-digitalocean-1.10.0-metrics-server.yaml
@@ -41,22 +41,19 @@ spec:
             weight: 10
       containers:
       - args:
-        - --kubeconfig
-        - /etc/kubernetes/kubeconfig/kubeconfig
-        - --authentication-kubeconfig
-        - /etc/kubernetes/kubeconfig/kubeconfig
-        - --authorization-kubeconfig
-        - /etc/kubernetes/kubeconfig/kubeconfig
-        - --kubelet-port
-        - "10250"
-        - --kubelet-insecure-tls
-        - --kubelet-preferred-address-types
-        - ExternalIP,InternalIP
-        - --v
+        - -endpoint
+        - https://apiserver-external.cluster-de-test-01.svc.cluster.local.:30000/healthz
+        - -insecure
+        - -retries
+        - "100"
+        - -retry-wait
+        - "2"
+        - -timeout
         - "1"
-        - --logtostderr
+        - -command
+        - '{"command":"/metrics-server","args":["--kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","--authentication-kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","--authorization-kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","--kubelet-port","10250","--kubelet-insecure-tls","--kubelet-preferred-address-types","ExternalIP,InternalIP","--v","1","--logtostderr"]}'
         command:
-        - /metrics-server
+        - /http-prober-bin/http-prober
         image: gcr.io/google_containers/metrics-server-amd64:v0.3.2
         name: metrics-server
         resources:
@@ -70,6 +67,8 @@ spec:
         - mountPath: /etc/kubernetes/kubeconfig
           name: metrics-server
           readOnly: true
+        - mountPath: /http-prober-bin
+          name: http-prober-bin
       - args:
         - --client
         - --proto
@@ -158,24 +157,16 @@ spec:
       imagePullSecrets:
       - name: dockercfg
       initContainers:
-      - args:
-        - -endpoint
-        - https://apiserver-external.cluster-de-test-01.svc.cluster.local.:30000/healthz
-        - -insecure
-        - -retries
-        - "100"
-        - -retry-wait
-        - "2"
-        - -timeout
-        - "1"
-        command:
+      - command:
+        - /bin/cp
         - /usr/local/bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.1
-        imagePullPolicy: IfNotPresent
-        name: apiserver-running
+        - /http-prober-bin/http-prober
+        image: quay.io/kubermatic/http-prober:v0.2-dev0
+        name: copy-http-prober
         resources: {}
-        terminationMessagePath: /dev/termination-log
-        terminationMessagePolicy: File
+        volumeMounts:
+        - mountPath: /http-prober-bin
+          name: http-prober-bin
       volumes:
       - name: metrics-server
         secret:
@@ -189,4 +180,6 @@ spec:
         secret:
           defaultMode: 292
           secretName: kubeletdnatcontroller-kubeconfig
+      - emptyDir: {}
+        name: http-prober-bin
 status: {}

--- a/api/pkg/resources/test/fixtures/deployment-digitalocean-1.10.0-metrics-server.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-digitalocean-1.10.0-metrics-server.yaml
@@ -161,7 +161,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.2-dev0
+        image: quay.io/kubermatic/http-prober:v0.2
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/api/pkg/resources/test/fixtures/deployment-digitalocean-1.10.0-scheduler.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-digitalocean-1.10.0-scheduler.yaml
@@ -100,11 +100,19 @@ spec:
           name: openvpn-client-certificates
           readOnly: true
       - args:
-        - --kubeconfig
-        - /etc/kubernetes/kubeconfig/kubeconfig
+        - -endpoint
+        - https://apiserver-external.cluster-de-test-01.svc.cluster.local.:30000/healthz
+        - -insecure
+        - -retries
+        - "100"
+        - -retry-wait
+        - "2"
+        - -timeout
+        - "1"
+        - -command
+        - '{"command":"/hyperkube","args":["kube-scheduler","--kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig"]}'
         command:
-        - /hyperkube
-        - kube-scheduler
+        - /http-prober-bin/http-prober
         image: gcr.io/google_containers/hyperkube-amd64:v1.10.0
         livenessProbe:
           failureThreshold: 8
@@ -140,6 +148,8 @@ spec:
         - mountPath: /etc/kubernetes/pki/ca
           name: ca
           readOnly: true
+        - mountPath: /http-prober-bin
+          name: http-prober-bin
       dnsConfig:
         nameservers:
         - 192.0.2.14
@@ -154,24 +164,16 @@ spec:
       imagePullSecrets:
       - name: dockercfg
       initContainers:
-      - args:
-        - -endpoint
-        - https://apiserver-external.cluster-de-test-01.svc.cluster.local.:30000/healthz
-        - -insecure
-        - -retries
-        - "100"
-        - -retry-wait
-        - "2"
-        - -timeout
-        - "1"
-        command:
+      - command:
+        - /bin/cp
         - /usr/local/bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.1
-        imagePullPolicy: IfNotPresent
-        name: apiserver-running
+        - /http-prober-bin/http-prober
+        image: quay.io/kubermatic/http-prober:v0.2-dev0
+        name: copy-http-prober
         resources: {}
-        terminationMessagePath: /dev/termination-log
-        terminationMessagePolicy: File
+        volumeMounts:
+        - mountPath: /http-prober-bin
+          name: http-prober-bin
       volumes:
       - name: openvpn-client-certificates
         secret:
@@ -188,4 +190,6 @@ spec:
         secret:
           defaultMode: 256
           secretName: scheduler-kubeconfig
+      - emptyDir: {}
+        name: http-prober-bin
 status: {}

--- a/api/pkg/resources/test/fixtures/deployment-digitalocean-1.10.0-scheduler.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-digitalocean-1.10.0-scheduler.yaml
@@ -168,7 +168,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.2-dev0
+        image: quay.io/kubermatic/http-prober:v0.2
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/api/pkg/resources/test/fixtures/deployment-digitalocean-1.10.0-usercluster-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-digitalocean-1.10.0-usercluster-controller.yaml
@@ -85,7 +85,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.2-dev0
+        image: quay.io/kubermatic/http-prober:v0.2
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/api/pkg/resources/test/fixtures/deployment-digitalocean-1.10.0-usercluster-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-digitalocean-1.10.0-usercluster-controller.yaml
@@ -29,32 +29,19 @@ spec:
     spec:
       containers:
       - args:
-        - -kubeconfig
-        - /etc/kubernetes/kubeconfig/kubeconfig
-        - -metrics-listen-address
-        - 0.0.0.0:8085
-        - -health-listen-address
-        - 0.0.0.0:8086
-        - -namespace
-        - $(NAMESPACE)
-        - -ca-cert
-        - /etc/kubernetes/pki/ca/ca.crt
-        - -cluster-url
-        - ""
-        - -openvpn-server-port
-        - "30003"
-        - -overwrite-registry
-        - ""
-        - -openshift=false
-        - -openvpn-ca-cert-file=/etc/kubernetes/pki/openvpn/ca.crt
-        - -openvpn-ca-key-file=/etc/kubernetes/pki/openvpn/ca.key
-        - -logtostderr
-        - -v
+        - -endpoint
+        - https://apiserver-external.cluster-de-test-01.svc.cluster.local.:30000/healthz
+        - -insecure
+        - -retries
+        - "100"
+        - -retry-wait
         - "2"
-        - --ipam-controller-network
-        - 192.168.1.1/24,192.168.1.1,8.8.8.8
+        - -timeout
+        - "1"
+        - -command
+        - '{"command":"/usr/local/bin/user-cluster-controller-manager","args":["-kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","-metrics-listen-address","0.0.0.0:8085","-health-listen-address","0.0.0.0:8086","-namespace","$(NAMESPACE)","-ca-cert","/etc/kubernetes/pki/ca/ca.crt","-cluster-url","","-openvpn-server-port","30003","-overwrite-registry","","-openshift=false","-openvpn-ca-cert-file=/etc/kubernetes/pki/openvpn/ca.crt","-openvpn-ca-key-file=/etc/kubernetes/pki/openvpn/ca.key","-logtostderr","-v","2","--ipam-controller-network","192.168.1.1/24,192.168.1.1,8.8.8.8"]}'
         command:
-        - /usr/local/bin/user-cluster-controller-manager
+        - /http-prober-bin/http-prober
         env:
         - name: NAMESPACE
           valueFrom:
@@ -89,27 +76,21 @@ spec:
         - mountPath: /etc/kubernetes/pki/openvpn
           name: openvpn-ca
           readOnly: true
+        - mountPath: /http-prober-bin
+          name: http-prober-bin
       imagePullSecrets:
       - name: dockercfg
       initContainers:
-      - args:
-        - -endpoint
-        - https://apiserver-external.cluster-de-test-01.svc.cluster.local.:30000/healthz
-        - -insecure
-        - -retries
-        - "100"
-        - -retry-wait
-        - "2"
-        - -timeout
-        - "1"
-        command:
+      - command:
+        - /bin/cp
         - /usr/local/bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.1
-        imagePullPolicy: IfNotPresent
-        name: apiserver-running
+        - /http-prober-bin/http-prober
+        image: quay.io/kubermatic/http-prober:v0.2-dev0
+        name: copy-http-prober
         resources: {}
-        terminationMessagePath: /dev/termination-log
-        terminationMessagePolicy: File
+        volumeMounts:
+        - mountPath: /http-prober-bin
+          name: http-prober-bin
       volumes:
       - name: internal-admin-kubeconfig
         secret:
@@ -126,4 +107,6 @@ spec:
         secret:
           defaultMode: 292
           secretName: openvpn-ca
+      - emptyDir: {}
+        name: http-prober-bin
 status: {}

--- a/api/pkg/resources/test/fixtures/deployment-digitalocean-1.10.6-controller-manager.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-digitalocean-1.10.6-controller-manager.yaml
@@ -102,27 +102,19 @@ spec:
           name: openvpn-client-certificates
           readOnly: true
       - args:
-        - --kubeconfig
-        - /etc/kubernetes/kubeconfig/kubeconfig
-        - --service-account-private-key-file
-        - /etc/kubernetes/service-account-key/sa.key
-        - --root-ca-file
-        - /etc/kubernetes/pki/ca/ca.crt
-        - --cluster-signing-cert-file
-        - /etc/kubernetes/pki/ca/ca.crt
-        - --cluster-signing-key-file
-        - /etc/kubernetes/pki/ca/ca.key
-        - --cluster-cidr
-        - 172.25.0.0/16
-        - --allocate-node-cidrs=true
-        - --controllers
-        - '*,bootstrapsigner,tokencleaner'
-        - --use-service-account-credentials=true
-        - --feature-gates
-        - RotateKubeletClientCertificate=true,RotateKubeletServerCertificate=true
+        - -endpoint
+        - https://apiserver-external.cluster-de-test-01.svc.cluster.local.:30000/healthz
+        - -insecure
+        - -retries
+        - "100"
+        - -retry-wait
+        - "2"
+        - -timeout
+        - "1"
+        - -command
+        - '{"command":"/hyperkube","args":["kube-controller-manager","--kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","--service-account-private-key-file","/etc/kubernetes/service-account-key/sa.key","--root-ca-file","/etc/kubernetes/pki/ca/ca.crt","--cluster-signing-cert-file","/etc/kubernetes/pki/ca/ca.crt","--cluster-signing-key-file","/etc/kubernetes/pki/ca/ca.key","--cluster-cidr","172.25.0.0/16","--allocate-node-cidrs=true","--controllers","*,bootstrapsigner,tokencleaner","--use-service-account-credentials=true","--feature-gates","RotateKubeletClientCertificate=true,RotateKubeletServerCertificate=true"]}'
         command:
-        - /hyperkube
-        - kube-controller-manager
+        - /http-prober-bin/http-prober
         image: gcr.io/google_containers/hyperkube-amd64:v1.10.6
         livenessProbe:
           failureThreshold: 8
@@ -164,6 +156,8 @@ spec:
         - mountPath: /etc/kubernetes/kubeconfig
           name: controllermanager-kubeconfig
           readOnly: true
+        - mountPath: /http-prober-bin
+          name: http-prober-bin
       dnsConfig:
         nameservers:
         - 192.0.2.14
@@ -178,24 +172,16 @@ spec:
       imagePullSecrets:
       - name: dockercfg
       initContainers:
-      - args:
-        - -endpoint
-        - https://apiserver-external.cluster-de-test-01.svc.cluster.local.:30000/healthz
-        - -insecure
-        - -retries
-        - "100"
-        - -retry-wait
-        - "2"
-        - -timeout
-        - "1"
-        command:
+      - command:
+        - /bin/cp
         - /usr/local/bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.1
-        imagePullPolicy: IfNotPresent
-        name: apiserver-running
+        - /http-prober-bin/http-prober
+        image: quay.io/kubermatic/http-prober:v0.2-dev0
+        name: copy-http-prober
         resources: {}
-        terminationMessagePath: /dev/termination-log
-        terminationMessagePolicy: File
+        volumeMounts:
+        - mountPath: /http-prober-bin
+          name: http-prober-bin
       volumes:
       - name: ca
         secret:
@@ -217,4 +203,6 @@ spec:
         secret:
           defaultMode: 256
           secretName: controllermanager-kubeconfig
+      - emptyDir: {}
+        name: http-prober-bin
 status: {}

--- a/api/pkg/resources/test/fixtures/deployment-digitalocean-1.10.6-controller-manager.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-digitalocean-1.10.6-controller-manager.yaml
@@ -176,7 +176,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.2-dev0
+        image: quay.io/kubermatic/http-prober:v0.2
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/api/pkg/resources/test/fixtures/deployment-digitalocean-1.10.6-kube-state-metrics.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-digitalocean-1.10.6-kube-state-metrics.yaml
@@ -21,14 +21,19 @@ spec:
     spec:
       containers:
       - args:
-        - --kubeconfig
-        - /etc/kubernetes/kubeconfig/kubeconfig
-        - --port
-        - "8080"
-        - --telemetry-port
-        - "8081"
+        - -endpoint
+        - https://apiserver-external.cluster-de-test-01.svc.cluster.local.:30000/healthz
+        - -insecure
+        - -retries
+        - "100"
+        - -retry-wait
+        - "2"
+        - -timeout
+        - "1"
+        - -command
+        - '{"command":"/kube-state-metrics","args":["--kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","--port","8080","--telemetry-port","8081"]}'
         command:
-        - /kube-state-metrics
+        - /http-prober-bin/http-prober
         image: quay.io/coreos/kube-state-metrics:v1.6.0
         name: kube-state-metrics
         ports:
@@ -58,30 +63,26 @@ spec:
         - mountPath: /etc/kubernetes/kubeconfig
           name: kube-state-metrics-kubeconfig
           readOnly: true
+        - mountPath: /http-prober-bin
+          name: http-prober-bin
       imagePullSecrets:
       - name: dockercfg
       initContainers:
-      - args:
-        - -endpoint
-        - https://apiserver-external.cluster-de-test-01.svc.cluster.local.:30000/healthz
-        - -insecure
-        - -retries
-        - "100"
-        - -retry-wait
-        - "2"
-        - -timeout
-        - "1"
-        command:
+      - command:
+        - /bin/cp
         - /usr/local/bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.1
-        imagePullPolicy: IfNotPresent
-        name: apiserver-running
+        - /http-prober-bin/http-prober
+        image: quay.io/kubermatic/http-prober:v0.2-dev0
+        name: copy-http-prober
         resources: {}
-        terminationMessagePath: /dev/termination-log
-        terminationMessagePolicy: File
+        volumeMounts:
+        - mountPath: /http-prober-bin
+          name: http-prober-bin
       volumes:
       - name: kube-state-metrics-kubeconfig
         secret:
           defaultMode: 256
           secretName: kube-state-metrics-kubeconfig
+      - emptyDir: {}
+        name: http-prober-bin
 status: {}

--- a/api/pkg/resources/test/fixtures/deployment-digitalocean-1.10.6-kube-state-metrics.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-digitalocean-1.10.6-kube-state-metrics.yaml
@@ -72,7 +72,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.2-dev0
+        image: quay.io/kubermatic/http-prober:v0.2
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/api/pkg/resources/test/fixtures/deployment-digitalocean-1.10.6-machine-controller-webhook.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-digitalocean-1.10.6-machine-controller-webhook.yaml
@@ -84,7 +84,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.2-dev0
+        image: quay.io/kubermatic/http-prober:v0.2
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/api/pkg/resources/test/fixtures/deployment-digitalocean-1.10.6-machine-controller-webhook.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-digitalocean-1.10.6-machine-controller-webhook.yaml
@@ -24,15 +24,19 @@ spec:
     spec:
       containers:
       - args:
-        - -kubeconfig
-        - /etc/kubernetes/kubeconfig/kubeconfig
-        - -logtostderr
-        - -v
-        - "4"
-        - -listen-address
-        - 0.0.0.0:9876
+        - -endpoint
+        - https://apiserver-external.cluster-de-test-01.svc.cluster.local.:30000/healthz
+        - -insecure
+        - -retries
+        - "100"
+        - -retry-wait
+        - "2"
+        - -timeout
+        - "1"
+        - -command
+        - '{"command":"/usr/local/bin/webhook","args":["-kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","-logtostderr","-v","4","-listen-address","0.0.0.0:9876"]}'
         command:
-        - /usr/local/bin/webhook
+        - /http-prober-bin/http-prober
         env:
         - name: DO_TOKEN
           value: do-token
@@ -71,27 +75,21 @@ spec:
         - mountPath: /tmp/cert
           name: machinecontroller-webhook-serving-cert
           readOnly: true
+        - mountPath: /http-prober-bin
+          name: http-prober-bin
       imagePullSecrets:
       - name: dockercfg
       initContainers:
-      - args:
-        - -endpoint
-        - https://apiserver-external.cluster-de-test-01.svc.cluster.local.:30000/healthz
-        - -insecure
-        - -retries
-        - "100"
-        - -retry-wait
-        - "2"
-        - -timeout
-        - "1"
-        command:
+      - command:
+        - /bin/cp
         - /usr/local/bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.1
-        imagePullPolicy: IfNotPresent
-        name: apiserver-running
+        - /http-prober-bin/http-prober
+        image: quay.io/kubermatic/http-prober:v0.2-dev0
+        name: copy-http-prober
         resources: {}
-        terminationMessagePath: /dev/termination-log
-        terminationMessagePolicy: File
+        volumeMounts:
+        - mountPath: /http-prober-bin
+          name: http-prober-bin
       volumes:
       - name: machinecontroller-kubeconfig
         secret:
@@ -101,4 +99,6 @@ spec:
         secret:
           defaultMode: 292
           secretName: machinecontroller-webhook-serving-cert
+      - emptyDir: {}
+        name: http-prober-bin
 status: {}

--- a/api/pkg/resources/test/fixtures/deployment-digitalocean-1.10.6-machine-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-digitalocean-1.10.6-machine-controller.yaml
@@ -27,17 +27,19 @@ spec:
     spec:
       containers:
       - args:
-        - -kubeconfig
-        - /etc/kubernetes/kubeconfig/kubeconfig
-        - -logtostderr
-        - -v
-        - "4"
-        - -cluster-dns
-        - 169.254.20.10
-        - -internal-listen-address
-        - 0.0.0.0:8085
+        - -endpoint
+        - https://apiserver-external.cluster-de-test-01.svc.cluster.local.:30000/healthz
+        - -insecure
+        - -retries
+        - "100"
+        - -retry-wait
+        - "2"
+        - -timeout
+        - "1"
+        - -command
+        - '{"command":"/usr/local/bin/machine-controller","args":["-kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","-logtostderr","-v","4","-cluster-dns","169.254.20.10","-internal-listen-address","0.0.0.0:8085"]}'
         command:
-        - /usr/local/bin/machine-controller
+        - /http-prober-bin/http-prober
         env:
         - name: DO_TOKEN
           value: do-token
@@ -64,30 +66,26 @@ spec:
         - mountPath: /etc/kubernetes/kubeconfig
           name: machinecontroller-kubeconfig
           readOnly: true
+        - mountPath: /http-prober-bin
+          name: http-prober-bin
       imagePullSecrets:
       - name: dockercfg
       initContainers:
-      - args:
-        - -endpoint
-        - https://apiserver-external.cluster-de-test-01.svc.cluster.local.:30000/healthz
-        - -insecure
-        - -retries
-        - "100"
-        - -retry-wait
-        - "2"
-        - -timeout
-        - "1"
-        command:
+      - command:
+        - /bin/cp
         - /usr/local/bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.1
-        imagePullPolicy: IfNotPresent
-        name: apiserver-running
+        - /http-prober-bin/http-prober
+        image: quay.io/kubermatic/http-prober:v0.2-dev0
+        name: copy-http-prober
         resources: {}
-        terminationMessagePath: /dev/termination-log
-        terminationMessagePolicy: File
+        volumeMounts:
+        - mountPath: /http-prober-bin
+          name: http-prober-bin
       volumes:
       - name: machinecontroller-kubeconfig
         secret:
           defaultMode: 292
           secretName: machinecontroller-kubeconfig
+      - emptyDir: {}
+        name: http-prober-bin
 status: {}

--- a/api/pkg/resources/test/fixtures/deployment-digitalocean-1.10.6-machine-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-digitalocean-1.10.6-machine-controller.yaml
@@ -75,7 +75,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.2-dev0
+        image: quay.io/kubermatic/http-prober:v0.2
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/api/pkg/resources/test/fixtures/deployment-digitalocean-1.10.6-metrics-server.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-digitalocean-1.10.6-metrics-server.yaml
@@ -41,22 +41,19 @@ spec:
             weight: 10
       containers:
       - args:
-        - --kubeconfig
-        - /etc/kubernetes/kubeconfig/kubeconfig
-        - --authentication-kubeconfig
-        - /etc/kubernetes/kubeconfig/kubeconfig
-        - --authorization-kubeconfig
-        - /etc/kubernetes/kubeconfig/kubeconfig
-        - --kubelet-port
-        - "10250"
-        - --kubelet-insecure-tls
-        - --kubelet-preferred-address-types
-        - ExternalIP,InternalIP
-        - --v
+        - -endpoint
+        - https://apiserver-external.cluster-de-test-01.svc.cluster.local.:30000/healthz
+        - -insecure
+        - -retries
+        - "100"
+        - -retry-wait
+        - "2"
+        - -timeout
         - "1"
-        - --logtostderr
+        - -command
+        - '{"command":"/metrics-server","args":["--kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","--authentication-kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","--authorization-kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","--kubelet-port","10250","--kubelet-insecure-tls","--kubelet-preferred-address-types","ExternalIP,InternalIP","--v","1","--logtostderr"]}'
         command:
-        - /metrics-server
+        - /http-prober-bin/http-prober
         image: gcr.io/google_containers/metrics-server-amd64:v0.3.2
         name: metrics-server
         resources:
@@ -70,6 +67,8 @@ spec:
         - mountPath: /etc/kubernetes/kubeconfig
           name: metrics-server
           readOnly: true
+        - mountPath: /http-prober-bin
+          name: http-prober-bin
       - args:
         - --client
         - --proto
@@ -158,24 +157,16 @@ spec:
       imagePullSecrets:
       - name: dockercfg
       initContainers:
-      - args:
-        - -endpoint
-        - https://apiserver-external.cluster-de-test-01.svc.cluster.local.:30000/healthz
-        - -insecure
-        - -retries
-        - "100"
-        - -retry-wait
-        - "2"
-        - -timeout
-        - "1"
-        command:
+      - command:
+        - /bin/cp
         - /usr/local/bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.1
-        imagePullPolicy: IfNotPresent
-        name: apiserver-running
+        - /http-prober-bin/http-prober
+        image: quay.io/kubermatic/http-prober:v0.2-dev0
+        name: copy-http-prober
         resources: {}
-        terminationMessagePath: /dev/termination-log
-        terminationMessagePolicy: File
+        volumeMounts:
+        - mountPath: /http-prober-bin
+          name: http-prober-bin
       volumes:
       - name: metrics-server
         secret:
@@ -189,4 +180,6 @@ spec:
         secret:
           defaultMode: 292
           secretName: kubeletdnatcontroller-kubeconfig
+      - emptyDir: {}
+        name: http-prober-bin
 status: {}

--- a/api/pkg/resources/test/fixtures/deployment-digitalocean-1.10.6-metrics-server.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-digitalocean-1.10.6-metrics-server.yaml
@@ -161,7 +161,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.2-dev0
+        image: quay.io/kubermatic/http-prober:v0.2
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/api/pkg/resources/test/fixtures/deployment-digitalocean-1.10.6-scheduler.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-digitalocean-1.10.6-scheduler.yaml
@@ -100,11 +100,19 @@ spec:
           name: openvpn-client-certificates
           readOnly: true
       - args:
-        - --kubeconfig
-        - /etc/kubernetes/kubeconfig/kubeconfig
+        - -endpoint
+        - https://apiserver-external.cluster-de-test-01.svc.cluster.local.:30000/healthz
+        - -insecure
+        - -retries
+        - "100"
+        - -retry-wait
+        - "2"
+        - -timeout
+        - "1"
+        - -command
+        - '{"command":"/hyperkube","args":["kube-scheduler","--kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig"]}'
         command:
-        - /hyperkube
-        - kube-scheduler
+        - /http-prober-bin/http-prober
         image: gcr.io/google_containers/hyperkube-amd64:v1.10.6
         livenessProbe:
           failureThreshold: 8
@@ -140,6 +148,8 @@ spec:
         - mountPath: /etc/kubernetes/pki/ca
           name: ca
           readOnly: true
+        - mountPath: /http-prober-bin
+          name: http-prober-bin
       dnsConfig:
         nameservers:
         - 192.0.2.14
@@ -154,24 +164,16 @@ spec:
       imagePullSecrets:
       - name: dockercfg
       initContainers:
-      - args:
-        - -endpoint
-        - https://apiserver-external.cluster-de-test-01.svc.cluster.local.:30000/healthz
-        - -insecure
-        - -retries
-        - "100"
-        - -retry-wait
-        - "2"
-        - -timeout
-        - "1"
-        command:
+      - command:
+        - /bin/cp
         - /usr/local/bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.1
-        imagePullPolicy: IfNotPresent
-        name: apiserver-running
+        - /http-prober-bin/http-prober
+        image: quay.io/kubermatic/http-prober:v0.2-dev0
+        name: copy-http-prober
         resources: {}
-        terminationMessagePath: /dev/termination-log
-        terminationMessagePolicy: File
+        volumeMounts:
+        - mountPath: /http-prober-bin
+          name: http-prober-bin
       volumes:
       - name: openvpn-client-certificates
         secret:
@@ -188,4 +190,6 @@ spec:
         secret:
           defaultMode: 256
           secretName: scheduler-kubeconfig
+      - emptyDir: {}
+        name: http-prober-bin
 status: {}

--- a/api/pkg/resources/test/fixtures/deployment-digitalocean-1.10.6-scheduler.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-digitalocean-1.10.6-scheduler.yaml
@@ -168,7 +168,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.2-dev0
+        image: quay.io/kubermatic/http-prober:v0.2
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/api/pkg/resources/test/fixtures/deployment-digitalocean-1.10.6-usercluster-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-digitalocean-1.10.6-usercluster-controller.yaml
@@ -85,7 +85,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.2-dev0
+        image: quay.io/kubermatic/http-prober:v0.2
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/api/pkg/resources/test/fixtures/deployment-digitalocean-1.10.6-usercluster-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-digitalocean-1.10.6-usercluster-controller.yaml
@@ -29,32 +29,19 @@ spec:
     spec:
       containers:
       - args:
-        - -kubeconfig
-        - /etc/kubernetes/kubeconfig/kubeconfig
-        - -metrics-listen-address
-        - 0.0.0.0:8085
-        - -health-listen-address
-        - 0.0.0.0:8086
-        - -namespace
-        - $(NAMESPACE)
-        - -ca-cert
-        - /etc/kubernetes/pki/ca/ca.crt
-        - -cluster-url
-        - ""
-        - -openvpn-server-port
-        - "30003"
-        - -overwrite-registry
-        - ""
-        - -openshift=false
-        - -openvpn-ca-cert-file=/etc/kubernetes/pki/openvpn/ca.crt
-        - -openvpn-ca-key-file=/etc/kubernetes/pki/openvpn/ca.key
-        - -logtostderr
-        - -v
+        - -endpoint
+        - https://apiserver-external.cluster-de-test-01.svc.cluster.local.:30000/healthz
+        - -insecure
+        - -retries
+        - "100"
+        - -retry-wait
         - "2"
-        - --ipam-controller-network
-        - 192.168.1.1/24,192.168.1.1,8.8.8.8
+        - -timeout
+        - "1"
+        - -command
+        - '{"command":"/usr/local/bin/user-cluster-controller-manager","args":["-kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","-metrics-listen-address","0.0.0.0:8085","-health-listen-address","0.0.0.0:8086","-namespace","$(NAMESPACE)","-ca-cert","/etc/kubernetes/pki/ca/ca.crt","-cluster-url","","-openvpn-server-port","30003","-overwrite-registry","","-openshift=false","-openvpn-ca-cert-file=/etc/kubernetes/pki/openvpn/ca.crt","-openvpn-ca-key-file=/etc/kubernetes/pki/openvpn/ca.key","-logtostderr","-v","2","--ipam-controller-network","192.168.1.1/24,192.168.1.1,8.8.8.8"]}'
         command:
-        - /usr/local/bin/user-cluster-controller-manager
+        - /http-prober-bin/http-prober
         env:
         - name: NAMESPACE
           valueFrom:
@@ -89,27 +76,21 @@ spec:
         - mountPath: /etc/kubernetes/pki/openvpn
           name: openvpn-ca
           readOnly: true
+        - mountPath: /http-prober-bin
+          name: http-prober-bin
       imagePullSecrets:
       - name: dockercfg
       initContainers:
-      - args:
-        - -endpoint
-        - https://apiserver-external.cluster-de-test-01.svc.cluster.local.:30000/healthz
-        - -insecure
-        - -retries
-        - "100"
-        - -retry-wait
-        - "2"
-        - -timeout
-        - "1"
-        command:
+      - command:
+        - /bin/cp
         - /usr/local/bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.1
-        imagePullPolicy: IfNotPresent
-        name: apiserver-running
+        - /http-prober-bin/http-prober
+        image: quay.io/kubermatic/http-prober:v0.2-dev0
+        name: copy-http-prober
         resources: {}
-        terminationMessagePath: /dev/termination-log
-        terminationMessagePolicy: File
+        volumeMounts:
+        - mountPath: /http-prober-bin
+          name: http-prober-bin
       volumes:
       - name: internal-admin-kubeconfig
         secret:
@@ -126,4 +107,6 @@ spec:
         secret:
           defaultMode: 292
           secretName: openvpn-ca
+      - emptyDir: {}
+        name: http-prober-bin
 status: {}

--- a/api/pkg/resources/test/fixtures/deployment-digitalocean-1.11.0-controller-manager.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-digitalocean-1.11.0-controller-manager.yaml
@@ -176,7 +176,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.2-dev0
+        image: quay.io/kubermatic/http-prober:v0.2
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/api/pkg/resources/test/fixtures/deployment-digitalocean-1.11.0-controller-manager.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-digitalocean-1.11.0-controller-manager.yaml
@@ -102,27 +102,19 @@ spec:
           name: openvpn-client-certificates
           readOnly: true
       - args:
-        - --kubeconfig
-        - /etc/kubernetes/kubeconfig/kubeconfig
-        - --service-account-private-key-file
-        - /etc/kubernetes/service-account-key/sa.key
-        - --root-ca-file
-        - /etc/kubernetes/pki/ca/ca.crt
-        - --cluster-signing-cert-file
-        - /etc/kubernetes/pki/ca/ca.crt
-        - --cluster-signing-key-file
-        - /etc/kubernetes/pki/ca/ca.key
-        - --cluster-cidr
-        - 172.25.0.0/16
-        - --allocate-node-cidrs=true
-        - --controllers
-        - '*,bootstrapsigner,tokencleaner'
-        - --use-service-account-credentials=true
-        - --feature-gates
-        - RotateKubeletClientCertificate=true,RotateKubeletServerCertificate=true
+        - -endpoint
+        - https://apiserver-external.cluster-de-test-01.svc.cluster.local.:30000/healthz
+        - -insecure
+        - -retries
+        - "100"
+        - -retry-wait
+        - "2"
+        - -timeout
+        - "1"
+        - -command
+        - '{"command":"/hyperkube","args":["kube-controller-manager","--kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","--service-account-private-key-file","/etc/kubernetes/service-account-key/sa.key","--root-ca-file","/etc/kubernetes/pki/ca/ca.crt","--cluster-signing-cert-file","/etc/kubernetes/pki/ca/ca.crt","--cluster-signing-key-file","/etc/kubernetes/pki/ca/ca.key","--cluster-cidr","172.25.0.0/16","--allocate-node-cidrs=true","--controllers","*,bootstrapsigner,tokencleaner","--use-service-account-credentials=true","--feature-gates","RotateKubeletClientCertificate=true,RotateKubeletServerCertificate=true"]}'
         command:
-        - /hyperkube
-        - kube-controller-manager
+        - /http-prober-bin/http-prober
         image: gcr.io/google_containers/hyperkube-amd64:v1.11.0
         livenessProbe:
           failureThreshold: 8
@@ -164,6 +156,8 @@ spec:
         - mountPath: /etc/kubernetes/kubeconfig
           name: controllermanager-kubeconfig
           readOnly: true
+        - mountPath: /http-prober-bin
+          name: http-prober-bin
       dnsConfig:
         nameservers:
         - 192.0.2.14
@@ -178,24 +172,16 @@ spec:
       imagePullSecrets:
       - name: dockercfg
       initContainers:
-      - args:
-        - -endpoint
-        - https://apiserver-external.cluster-de-test-01.svc.cluster.local.:30000/healthz
-        - -insecure
-        - -retries
-        - "100"
-        - -retry-wait
-        - "2"
-        - -timeout
-        - "1"
-        command:
+      - command:
+        - /bin/cp
         - /usr/local/bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.1
-        imagePullPolicy: IfNotPresent
-        name: apiserver-running
+        - /http-prober-bin/http-prober
+        image: quay.io/kubermatic/http-prober:v0.2-dev0
+        name: copy-http-prober
         resources: {}
-        terminationMessagePath: /dev/termination-log
-        terminationMessagePolicy: File
+        volumeMounts:
+        - mountPath: /http-prober-bin
+          name: http-prober-bin
       volumes:
       - name: ca
         secret:
@@ -217,4 +203,6 @@ spec:
         secret:
           defaultMode: 256
           secretName: controllermanager-kubeconfig
+      - emptyDir: {}
+        name: http-prober-bin
 status: {}

--- a/api/pkg/resources/test/fixtures/deployment-digitalocean-1.11.0-kube-state-metrics.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-digitalocean-1.11.0-kube-state-metrics.yaml
@@ -21,14 +21,19 @@ spec:
     spec:
       containers:
       - args:
-        - --kubeconfig
-        - /etc/kubernetes/kubeconfig/kubeconfig
-        - --port
-        - "8080"
-        - --telemetry-port
-        - "8081"
+        - -endpoint
+        - https://apiserver-external.cluster-de-test-01.svc.cluster.local.:30000/healthz
+        - -insecure
+        - -retries
+        - "100"
+        - -retry-wait
+        - "2"
+        - -timeout
+        - "1"
+        - -command
+        - '{"command":"/kube-state-metrics","args":["--kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","--port","8080","--telemetry-port","8081"]}'
         command:
-        - /kube-state-metrics
+        - /http-prober-bin/http-prober
         image: quay.io/coreos/kube-state-metrics:v1.6.0
         name: kube-state-metrics
         ports:
@@ -58,30 +63,26 @@ spec:
         - mountPath: /etc/kubernetes/kubeconfig
           name: kube-state-metrics-kubeconfig
           readOnly: true
+        - mountPath: /http-prober-bin
+          name: http-prober-bin
       imagePullSecrets:
       - name: dockercfg
       initContainers:
-      - args:
-        - -endpoint
-        - https://apiserver-external.cluster-de-test-01.svc.cluster.local.:30000/healthz
-        - -insecure
-        - -retries
-        - "100"
-        - -retry-wait
-        - "2"
-        - -timeout
-        - "1"
-        command:
+      - command:
+        - /bin/cp
         - /usr/local/bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.1
-        imagePullPolicy: IfNotPresent
-        name: apiserver-running
+        - /http-prober-bin/http-prober
+        image: quay.io/kubermatic/http-prober:v0.2-dev0
+        name: copy-http-prober
         resources: {}
-        terminationMessagePath: /dev/termination-log
-        terminationMessagePolicy: File
+        volumeMounts:
+        - mountPath: /http-prober-bin
+          name: http-prober-bin
       volumes:
       - name: kube-state-metrics-kubeconfig
         secret:
           defaultMode: 256
           secretName: kube-state-metrics-kubeconfig
+      - emptyDir: {}
+        name: http-prober-bin
 status: {}

--- a/api/pkg/resources/test/fixtures/deployment-digitalocean-1.11.0-kube-state-metrics.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-digitalocean-1.11.0-kube-state-metrics.yaml
@@ -72,7 +72,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.2-dev0
+        image: quay.io/kubermatic/http-prober:v0.2
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/api/pkg/resources/test/fixtures/deployment-digitalocean-1.11.0-machine-controller-webhook.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-digitalocean-1.11.0-machine-controller-webhook.yaml
@@ -84,7 +84,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.2-dev0
+        image: quay.io/kubermatic/http-prober:v0.2
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/api/pkg/resources/test/fixtures/deployment-digitalocean-1.11.0-machine-controller-webhook.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-digitalocean-1.11.0-machine-controller-webhook.yaml
@@ -24,15 +24,19 @@ spec:
     spec:
       containers:
       - args:
-        - -kubeconfig
-        - /etc/kubernetes/kubeconfig/kubeconfig
-        - -logtostderr
-        - -v
-        - "4"
-        - -listen-address
-        - 0.0.0.0:9876
+        - -endpoint
+        - https://apiserver-external.cluster-de-test-01.svc.cluster.local.:30000/healthz
+        - -insecure
+        - -retries
+        - "100"
+        - -retry-wait
+        - "2"
+        - -timeout
+        - "1"
+        - -command
+        - '{"command":"/usr/local/bin/webhook","args":["-kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","-logtostderr","-v","4","-listen-address","0.0.0.0:9876"]}'
         command:
-        - /usr/local/bin/webhook
+        - /http-prober-bin/http-prober
         env:
         - name: DO_TOKEN
           value: do-token
@@ -71,27 +75,21 @@ spec:
         - mountPath: /tmp/cert
           name: machinecontroller-webhook-serving-cert
           readOnly: true
+        - mountPath: /http-prober-bin
+          name: http-prober-bin
       imagePullSecrets:
       - name: dockercfg
       initContainers:
-      - args:
-        - -endpoint
-        - https://apiserver-external.cluster-de-test-01.svc.cluster.local.:30000/healthz
-        - -insecure
-        - -retries
-        - "100"
-        - -retry-wait
-        - "2"
-        - -timeout
-        - "1"
-        command:
+      - command:
+        - /bin/cp
         - /usr/local/bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.1
-        imagePullPolicy: IfNotPresent
-        name: apiserver-running
+        - /http-prober-bin/http-prober
+        image: quay.io/kubermatic/http-prober:v0.2-dev0
+        name: copy-http-prober
         resources: {}
-        terminationMessagePath: /dev/termination-log
-        terminationMessagePolicy: File
+        volumeMounts:
+        - mountPath: /http-prober-bin
+          name: http-prober-bin
       volumes:
       - name: machinecontroller-kubeconfig
         secret:
@@ -101,4 +99,6 @@ spec:
         secret:
           defaultMode: 292
           secretName: machinecontroller-webhook-serving-cert
+      - emptyDir: {}
+        name: http-prober-bin
 status: {}

--- a/api/pkg/resources/test/fixtures/deployment-digitalocean-1.11.0-machine-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-digitalocean-1.11.0-machine-controller.yaml
@@ -27,17 +27,19 @@ spec:
     spec:
       containers:
       - args:
-        - -kubeconfig
-        - /etc/kubernetes/kubeconfig/kubeconfig
-        - -logtostderr
-        - -v
-        - "4"
-        - -cluster-dns
-        - 169.254.20.10
-        - -internal-listen-address
-        - 0.0.0.0:8085
+        - -endpoint
+        - https://apiserver-external.cluster-de-test-01.svc.cluster.local.:30000/healthz
+        - -insecure
+        - -retries
+        - "100"
+        - -retry-wait
+        - "2"
+        - -timeout
+        - "1"
+        - -command
+        - '{"command":"/usr/local/bin/machine-controller","args":["-kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","-logtostderr","-v","4","-cluster-dns","169.254.20.10","-internal-listen-address","0.0.0.0:8085"]}'
         command:
-        - /usr/local/bin/machine-controller
+        - /http-prober-bin/http-prober
         env:
         - name: DO_TOKEN
           value: do-token
@@ -64,30 +66,26 @@ spec:
         - mountPath: /etc/kubernetes/kubeconfig
           name: machinecontroller-kubeconfig
           readOnly: true
+        - mountPath: /http-prober-bin
+          name: http-prober-bin
       imagePullSecrets:
       - name: dockercfg
       initContainers:
-      - args:
-        - -endpoint
-        - https://apiserver-external.cluster-de-test-01.svc.cluster.local.:30000/healthz
-        - -insecure
-        - -retries
-        - "100"
-        - -retry-wait
-        - "2"
-        - -timeout
-        - "1"
-        command:
+      - command:
+        - /bin/cp
         - /usr/local/bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.1
-        imagePullPolicy: IfNotPresent
-        name: apiserver-running
+        - /http-prober-bin/http-prober
+        image: quay.io/kubermatic/http-prober:v0.2-dev0
+        name: copy-http-prober
         resources: {}
-        terminationMessagePath: /dev/termination-log
-        terminationMessagePolicy: File
+        volumeMounts:
+        - mountPath: /http-prober-bin
+          name: http-prober-bin
       volumes:
       - name: machinecontroller-kubeconfig
         secret:
           defaultMode: 292
           secretName: machinecontroller-kubeconfig
+      - emptyDir: {}
+        name: http-prober-bin
 status: {}

--- a/api/pkg/resources/test/fixtures/deployment-digitalocean-1.11.0-machine-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-digitalocean-1.11.0-machine-controller.yaml
@@ -75,7 +75,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.2-dev0
+        image: quay.io/kubermatic/http-prober:v0.2
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/api/pkg/resources/test/fixtures/deployment-digitalocean-1.11.0-metrics-server.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-digitalocean-1.11.0-metrics-server.yaml
@@ -41,22 +41,19 @@ spec:
             weight: 10
       containers:
       - args:
-        - --kubeconfig
-        - /etc/kubernetes/kubeconfig/kubeconfig
-        - --authentication-kubeconfig
-        - /etc/kubernetes/kubeconfig/kubeconfig
-        - --authorization-kubeconfig
-        - /etc/kubernetes/kubeconfig/kubeconfig
-        - --kubelet-port
-        - "10250"
-        - --kubelet-insecure-tls
-        - --kubelet-preferred-address-types
-        - ExternalIP,InternalIP
-        - --v
+        - -endpoint
+        - https://apiserver-external.cluster-de-test-01.svc.cluster.local.:30000/healthz
+        - -insecure
+        - -retries
+        - "100"
+        - -retry-wait
+        - "2"
+        - -timeout
         - "1"
-        - --logtostderr
+        - -command
+        - '{"command":"/metrics-server","args":["--kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","--authentication-kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","--authorization-kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","--kubelet-port","10250","--kubelet-insecure-tls","--kubelet-preferred-address-types","ExternalIP,InternalIP","--v","1","--logtostderr"]}'
         command:
-        - /metrics-server
+        - /http-prober-bin/http-prober
         image: gcr.io/google_containers/metrics-server-amd64:v0.3.2
         name: metrics-server
         resources:
@@ -70,6 +67,8 @@ spec:
         - mountPath: /etc/kubernetes/kubeconfig
           name: metrics-server
           readOnly: true
+        - mountPath: /http-prober-bin
+          name: http-prober-bin
       - args:
         - --client
         - --proto
@@ -158,24 +157,16 @@ spec:
       imagePullSecrets:
       - name: dockercfg
       initContainers:
-      - args:
-        - -endpoint
-        - https://apiserver-external.cluster-de-test-01.svc.cluster.local.:30000/healthz
-        - -insecure
-        - -retries
-        - "100"
-        - -retry-wait
-        - "2"
-        - -timeout
-        - "1"
-        command:
+      - command:
+        - /bin/cp
         - /usr/local/bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.1
-        imagePullPolicy: IfNotPresent
-        name: apiserver-running
+        - /http-prober-bin/http-prober
+        image: quay.io/kubermatic/http-prober:v0.2-dev0
+        name: copy-http-prober
         resources: {}
-        terminationMessagePath: /dev/termination-log
-        terminationMessagePolicy: File
+        volumeMounts:
+        - mountPath: /http-prober-bin
+          name: http-prober-bin
       volumes:
       - name: metrics-server
         secret:
@@ -189,4 +180,6 @@ spec:
         secret:
           defaultMode: 292
           secretName: kubeletdnatcontroller-kubeconfig
+      - emptyDir: {}
+        name: http-prober-bin
 status: {}

--- a/api/pkg/resources/test/fixtures/deployment-digitalocean-1.11.0-metrics-server.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-digitalocean-1.11.0-metrics-server.yaml
@@ -161,7 +161,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.2-dev0
+        image: quay.io/kubermatic/http-prober:v0.2
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/api/pkg/resources/test/fixtures/deployment-digitalocean-1.11.0-scheduler.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-digitalocean-1.11.0-scheduler.yaml
@@ -100,11 +100,19 @@ spec:
           name: openvpn-client-certificates
           readOnly: true
       - args:
-        - --kubeconfig
-        - /etc/kubernetes/kubeconfig/kubeconfig
+        - -endpoint
+        - https://apiserver-external.cluster-de-test-01.svc.cluster.local.:30000/healthz
+        - -insecure
+        - -retries
+        - "100"
+        - -retry-wait
+        - "2"
+        - -timeout
+        - "1"
+        - -command
+        - '{"command":"/hyperkube","args":["kube-scheduler","--kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig"]}'
         command:
-        - /hyperkube
-        - kube-scheduler
+        - /http-prober-bin/http-prober
         image: gcr.io/google_containers/hyperkube-amd64:v1.11.0
         livenessProbe:
           failureThreshold: 8
@@ -140,6 +148,8 @@ spec:
         - mountPath: /etc/kubernetes/pki/ca
           name: ca
           readOnly: true
+        - mountPath: /http-prober-bin
+          name: http-prober-bin
       dnsConfig:
         nameservers:
         - 192.0.2.14
@@ -154,24 +164,16 @@ spec:
       imagePullSecrets:
       - name: dockercfg
       initContainers:
-      - args:
-        - -endpoint
-        - https://apiserver-external.cluster-de-test-01.svc.cluster.local.:30000/healthz
-        - -insecure
-        - -retries
-        - "100"
-        - -retry-wait
-        - "2"
-        - -timeout
-        - "1"
-        command:
+      - command:
+        - /bin/cp
         - /usr/local/bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.1
-        imagePullPolicy: IfNotPresent
-        name: apiserver-running
+        - /http-prober-bin/http-prober
+        image: quay.io/kubermatic/http-prober:v0.2-dev0
+        name: copy-http-prober
         resources: {}
-        terminationMessagePath: /dev/termination-log
-        terminationMessagePolicy: File
+        volumeMounts:
+        - mountPath: /http-prober-bin
+          name: http-prober-bin
       volumes:
       - name: openvpn-client-certificates
         secret:
@@ -188,4 +190,6 @@ spec:
         secret:
           defaultMode: 256
           secretName: scheduler-kubeconfig
+      - emptyDir: {}
+        name: http-prober-bin
 status: {}

--- a/api/pkg/resources/test/fixtures/deployment-digitalocean-1.11.0-scheduler.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-digitalocean-1.11.0-scheduler.yaml
@@ -168,7 +168,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.2-dev0
+        image: quay.io/kubermatic/http-prober:v0.2
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/api/pkg/resources/test/fixtures/deployment-digitalocean-1.11.0-usercluster-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-digitalocean-1.11.0-usercluster-controller.yaml
@@ -85,7 +85,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.2-dev0
+        image: quay.io/kubermatic/http-prober:v0.2
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/api/pkg/resources/test/fixtures/deployment-digitalocean-1.11.0-usercluster-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-digitalocean-1.11.0-usercluster-controller.yaml
@@ -29,32 +29,19 @@ spec:
     spec:
       containers:
       - args:
-        - -kubeconfig
-        - /etc/kubernetes/kubeconfig/kubeconfig
-        - -metrics-listen-address
-        - 0.0.0.0:8085
-        - -health-listen-address
-        - 0.0.0.0:8086
-        - -namespace
-        - $(NAMESPACE)
-        - -ca-cert
-        - /etc/kubernetes/pki/ca/ca.crt
-        - -cluster-url
-        - ""
-        - -openvpn-server-port
-        - "30003"
-        - -overwrite-registry
-        - ""
-        - -openshift=false
-        - -openvpn-ca-cert-file=/etc/kubernetes/pki/openvpn/ca.crt
-        - -openvpn-ca-key-file=/etc/kubernetes/pki/openvpn/ca.key
-        - -logtostderr
-        - -v
+        - -endpoint
+        - https://apiserver-external.cluster-de-test-01.svc.cluster.local.:30000/healthz
+        - -insecure
+        - -retries
+        - "100"
+        - -retry-wait
         - "2"
-        - --ipam-controller-network
-        - 192.168.1.1/24,192.168.1.1,8.8.8.8
+        - -timeout
+        - "1"
+        - -command
+        - '{"command":"/usr/local/bin/user-cluster-controller-manager","args":["-kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","-metrics-listen-address","0.0.0.0:8085","-health-listen-address","0.0.0.0:8086","-namespace","$(NAMESPACE)","-ca-cert","/etc/kubernetes/pki/ca/ca.crt","-cluster-url","","-openvpn-server-port","30003","-overwrite-registry","","-openshift=false","-openvpn-ca-cert-file=/etc/kubernetes/pki/openvpn/ca.crt","-openvpn-ca-key-file=/etc/kubernetes/pki/openvpn/ca.key","-logtostderr","-v","2","--ipam-controller-network","192.168.1.1/24,192.168.1.1,8.8.8.8"]}'
         command:
-        - /usr/local/bin/user-cluster-controller-manager
+        - /http-prober-bin/http-prober
         env:
         - name: NAMESPACE
           valueFrom:
@@ -89,27 +76,21 @@ spec:
         - mountPath: /etc/kubernetes/pki/openvpn
           name: openvpn-ca
           readOnly: true
+        - mountPath: /http-prober-bin
+          name: http-prober-bin
       imagePullSecrets:
       - name: dockercfg
       initContainers:
-      - args:
-        - -endpoint
-        - https://apiserver-external.cluster-de-test-01.svc.cluster.local.:30000/healthz
-        - -insecure
-        - -retries
-        - "100"
-        - -retry-wait
-        - "2"
-        - -timeout
-        - "1"
-        command:
+      - command:
+        - /bin/cp
         - /usr/local/bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.1
-        imagePullPolicy: IfNotPresent
-        name: apiserver-running
+        - /http-prober-bin/http-prober
+        image: quay.io/kubermatic/http-prober:v0.2-dev0
+        name: copy-http-prober
         resources: {}
-        terminationMessagePath: /dev/termination-log
-        terminationMessagePolicy: File
+        volumeMounts:
+        - mountPath: /http-prober-bin
+          name: http-prober-bin
       volumes:
       - name: internal-admin-kubeconfig
         secret:
@@ -126,4 +107,6 @@ spec:
         secret:
           defaultMode: 292
           secretName: openvpn-ca
+      - emptyDir: {}
+        name: http-prober-bin
 status: {}

--- a/api/pkg/resources/test/fixtures/deployment-digitalocean-1.11.1-controller-manager.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-digitalocean-1.11.1-controller-manager.yaml
@@ -176,7 +176,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.2-dev0
+        image: quay.io/kubermatic/http-prober:v0.2
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/api/pkg/resources/test/fixtures/deployment-digitalocean-1.11.1-controller-manager.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-digitalocean-1.11.1-controller-manager.yaml
@@ -102,27 +102,19 @@ spec:
           name: openvpn-client-certificates
           readOnly: true
       - args:
-        - --kubeconfig
-        - /etc/kubernetes/kubeconfig/kubeconfig
-        - --service-account-private-key-file
-        - /etc/kubernetes/service-account-key/sa.key
-        - --root-ca-file
-        - /etc/kubernetes/pki/ca/ca.crt
-        - --cluster-signing-cert-file
-        - /etc/kubernetes/pki/ca/ca.crt
-        - --cluster-signing-key-file
-        - /etc/kubernetes/pki/ca/ca.key
-        - --cluster-cidr
-        - 172.25.0.0/16
-        - --allocate-node-cidrs=true
-        - --controllers
-        - '*,bootstrapsigner,tokencleaner'
-        - --use-service-account-credentials=true
-        - --feature-gates
-        - RotateKubeletClientCertificate=true,RotateKubeletServerCertificate=true
+        - -endpoint
+        - https://apiserver-external.cluster-de-test-01.svc.cluster.local.:30000/healthz
+        - -insecure
+        - -retries
+        - "100"
+        - -retry-wait
+        - "2"
+        - -timeout
+        - "1"
+        - -command
+        - '{"command":"/hyperkube","args":["kube-controller-manager","--kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","--service-account-private-key-file","/etc/kubernetes/service-account-key/sa.key","--root-ca-file","/etc/kubernetes/pki/ca/ca.crt","--cluster-signing-cert-file","/etc/kubernetes/pki/ca/ca.crt","--cluster-signing-key-file","/etc/kubernetes/pki/ca/ca.key","--cluster-cidr","172.25.0.0/16","--allocate-node-cidrs=true","--controllers","*,bootstrapsigner,tokencleaner","--use-service-account-credentials=true","--feature-gates","RotateKubeletClientCertificate=true,RotateKubeletServerCertificate=true"]}'
         command:
-        - /hyperkube
-        - kube-controller-manager
+        - /http-prober-bin/http-prober
         image: gcr.io/google_containers/hyperkube-amd64:v1.11.1
         livenessProbe:
           failureThreshold: 8
@@ -164,6 +156,8 @@ spec:
         - mountPath: /etc/kubernetes/kubeconfig
           name: controllermanager-kubeconfig
           readOnly: true
+        - mountPath: /http-prober-bin
+          name: http-prober-bin
       dnsConfig:
         nameservers:
         - 192.0.2.14
@@ -178,24 +172,16 @@ spec:
       imagePullSecrets:
       - name: dockercfg
       initContainers:
-      - args:
-        - -endpoint
-        - https://apiserver-external.cluster-de-test-01.svc.cluster.local.:30000/healthz
-        - -insecure
-        - -retries
-        - "100"
-        - -retry-wait
-        - "2"
-        - -timeout
-        - "1"
-        command:
+      - command:
+        - /bin/cp
         - /usr/local/bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.1
-        imagePullPolicy: IfNotPresent
-        name: apiserver-running
+        - /http-prober-bin/http-prober
+        image: quay.io/kubermatic/http-prober:v0.2-dev0
+        name: copy-http-prober
         resources: {}
-        terminationMessagePath: /dev/termination-log
-        terminationMessagePolicy: File
+        volumeMounts:
+        - mountPath: /http-prober-bin
+          name: http-prober-bin
       volumes:
       - name: ca
         secret:
@@ -217,4 +203,6 @@ spec:
         secret:
           defaultMode: 256
           secretName: controllermanager-kubeconfig
+      - emptyDir: {}
+        name: http-prober-bin
 status: {}

--- a/api/pkg/resources/test/fixtures/deployment-digitalocean-1.11.1-kube-state-metrics.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-digitalocean-1.11.1-kube-state-metrics.yaml
@@ -21,14 +21,19 @@ spec:
     spec:
       containers:
       - args:
-        - --kubeconfig
-        - /etc/kubernetes/kubeconfig/kubeconfig
-        - --port
-        - "8080"
-        - --telemetry-port
-        - "8081"
+        - -endpoint
+        - https://apiserver-external.cluster-de-test-01.svc.cluster.local.:30000/healthz
+        - -insecure
+        - -retries
+        - "100"
+        - -retry-wait
+        - "2"
+        - -timeout
+        - "1"
+        - -command
+        - '{"command":"/kube-state-metrics","args":["--kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","--port","8080","--telemetry-port","8081"]}'
         command:
-        - /kube-state-metrics
+        - /http-prober-bin/http-prober
         image: quay.io/coreos/kube-state-metrics:v1.6.0
         name: kube-state-metrics
         ports:
@@ -58,30 +63,26 @@ spec:
         - mountPath: /etc/kubernetes/kubeconfig
           name: kube-state-metrics-kubeconfig
           readOnly: true
+        - mountPath: /http-prober-bin
+          name: http-prober-bin
       imagePullSecrets:
       - name: dockercfg
       initContainers:
-      - args:
-        - -endpoint
-        - https://apiserver-external.cluster-de-test-01.svc.cluster.local.:30000/healthz
-        - -insecure
-        - -retries
-        - "100"
-        - -retry-wait
-        - "2"
-        - -timeout
-        - "1"
-        command:
+      - command:
+        - /bin/cp
         - /usr/local/bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.1
-        imagePullPolicy: IfNotPresent
-        name: apiserver-running
+        - /http-prober-bin/http-prober
+        image: quay.io/kubermatic/http-prober:v0.2-dev0
+        name: copy-http-prober
         resources: {}
-        terminationMessagePath: /dev/termination-log
-        terminationMessagePolicy: File
+        volumeMounts:
+        - mountPath: /http-prober-bin
+          name: http-prober-bin
       volumes:
       - name: kube-state-metrics-kubeconfig
         secret:
           defaultMode: 256
           secretName: kube-state-metrics-kubeconfig
+      - emptyDir: {}
+        name: http-prober-bin
 status: {}

--- a/api/pkg/resources/test/fixtures/deployment-digitalocean-1.11.1-kube-state-metrics.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-digitalocean-1.11.1-kube-state-metrics.yaml
@@ -72,7 +72,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.2-dev0
+        image: quay.io/kubermatic/http-prober:v0.2
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/api/pkg/resources/test/fixtures/deployment-digitalocean-1.11.1-machine-controller-webhook.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-digitalocean-1.11.1-machine-controller-webhook.yaml
@@ -84,7 +84,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.2-dev0
+        image: quay.io/kubermatic/http-prober:v0.2
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/api/pkg/resources/test/fixtures/deployment-digitalocean-1.11.1-machine-controller-webhook.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-digitalocean-1.11.1-machine-controller-webhook.yaml
@@ -24,15 +24,19 @@ spec:
     spec:
       containers:
       - args:
-        - -kubeconfig
-        - /etc/kubernetes/kubeconfig/kubeconfig
-        - -logtostderr
-        - -v
-        - "4"
-        - -listen-address
-        - 0.0.0.0:9876
+        - -endpoint
+        - https://apiserver-external.cluster-de-test-01.svc.cluster.local.:30000/healthz
+        - -insecure
+        - -retries
+        - "100"
+        - -retry-wait
+        - "2"
+        - -timeout
+        - "1"
+        - -command
+        - '{"command":"/usr/local/bin/webhook","args":["-kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","-logtostderr","-v","4","-listen-address","0.0.0.0:9876"]}'
         command:
-        - /usr/local/bin/webhook
+        - /http-prober-bin/http-prober
         env:
         - name: DO_TOKEN
           value: do-token
@@ -71,27 +75,21 @@ spec:
         - mountPath: /tmp/cert
           name: machinecontroller-webhook-serving-cert
           readOnly: true
+        - mountPath: /http-prober-bin
+          name: http-prober-bin
       imagePullSecrets:
       - name: dockercfg
       initContainers:
-      - args:
-        - -endpoint
-        - https://apiserver-external.cluster-de-test-01.svc.cluster.local.:30000/healthz
-        - -insecure
-        - -retries
-        - "100"
-        - -retry-wait
-        - "2"
-        - -timeout
-        - "1"
-        command:
+      - command:
+        - /bin/cp
         - /usr/local/bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.1
-        imagePullPolicy: IfNotPresent
-        name: apiserver-running
+        - /http-prober-bin/http-prober
+        image: quay.io/kubermatic/http-prober:v0.2-dev0
+        name: copy-http-prober
         resources: {}
-        terminationMessagePath: /dev/termination-log
-        terminationMessagePolicy: File
+        volumeMounts:
+        - mountPath: /http-prober-bin
+          name: http-prober-bin
       volumes:
       - name: machinecontroller-kubeconfig
         secret:
@@ -101,4 +99,6 @@ spec:
         secret:
           defaultMode: 292
           secretName: machinecontroller-webhook-serving-cert
+      - emptyDir: {}
+        name: http-prober-bin
 status: {}

--- a/api/pkg/resources/test/fixtures/deployment-digitalocean-1.11.1-machine-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-digitalocean-1.11.1-machine-controller.yaml
@@ -27,17 +27,19 @@ spec:
     spec:
       containers:
       - args:
-        - -kubeconfig
-        - /etc/kubernetes/kubeconfig/kubeconfig
-        - -logtostderr
-        - -v
-        - "4"
-        - -cluster-dns
-        - 169.254.20.10
-        - -internal-listen-address
-        - 0.0.0.0:8085
+        - -endpoint
+        - https://apiserver-external.cluster-de-test-01.svc.cluster.local.:30000/healthz
+        - -insecure
+        - -retries
+        - "100"
+        - -retry-wait
+        - "2"
+        - -timeout
+        - "1"
+        - -command
+        - '{"command":"/usr/local/bin/machine-controller","args":["-kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","-logtostderr","-v","4","-cluster-dns","169.254.20.10","-internal-listen-address","0.0.0.0:8085"]}'
         command:
-        - /usr/local/bin/machine-controller
+        - /http-prober-bin/http-prober
         env:
         - name: DO_TOKEN
           value: do-token
@@ -64,30 +66,26 @@ spec:
         - mountPath: /etc/kubernetes/kubeconfig
           name: machinecontroller-kubeconfig
           readOnly: true
+        - mountPath: /http-prober-bin
+          name: http-prober-bin
       imagePullSecrets:
       - name: dockercfg
       initContainers:
-      - args:
-        - -endpoint
-        - https://apiserver-external.cluster-de-test-01.svc.cluster.local.:30000/healthz
-        - -insecure
-        - -retries
-        - "100"
-        - -retry-wait
-        - "2"
-        - -timeout
-        - "1"
-        command:
+      - command:
+        - /bin/cp
         - /usr/local/bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.1
-        imagePullPolicy: IfNotPresent
-        name: apiserver-running
+        - /http-prober-bin/http-prober
+        image: quay.io/kubermatic/http-prober:v0.2-dev0
+        name: copy-http-prober
         resources: {}
-        terminationMessagePath: /dev/termination-log
-        terminationMessagePolicy: File
+        volumeMounts:
+        - mountPath: /http-prober-bin
+          name: http-prober-bin
       volumes:
       - name: machinecontroller-kubeconfig
         secret:
           defaultMode: 292
           secretName: machinecontroller-kubeconfig
+      - emptyDir: {}
+        name: http-prober-bin
 status: {}

--- a/api/pkg/resources/test/fixtures/deployment-digitalocean-1.11.1-machine-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-digitalocean-1.11.1-machine-controller.yaml
@@ -75,7 +75,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.2-dev0
+        image: quay.io/kubermatic/http-prober:v0.2
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/api/pkg/resources/test/fixtures/deployment-digitalocean-1.11.1-metrics-server.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-digitalocean-1.11.1-metrics-server.yaml
@@ -41,22 +41,19 @@ spec:
             weight: 10
       containers:
       - args:
-        - --kubeconfig
-        - /etc/kubernetes/kubeconfig/kubeconfig
-        - --authentication-kubeconfig
-        - /etc/kubernetes/kubeconfig/kubeconfig
-        - --authorization-kubeconfig
-        - /etc/kubernetes/kubeconfig/kubeconfig
-        - --kubelet-port
-        - "10250"
-        - --kubelet-insecure-tls
-        - --kubelet-preferred-address-types
-        - ExternalIP,InternalIP
-        - --v
+        - -endpoint
+        - https://apiserver-external.cluster-de-test-01.svc.cluster.local.:30000/healthz
+        - -insecure
+        - -retries
+        - "100"
+        - -retry-wait
+        - "2"
+        - -timeout
         - "1"
-        - --logtostderr
+        - -command
+        - '{"command":"/metrics-server","args":["--kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","--authentication-kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","--authorization-kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","--kubelet-port","10250","--kubelet-insecure-tls","--kubelet-preferred-address-types","ExternalIP,InternalIP","--v","1","--logtostderr"]}'
         command:
-        - /metrics-server
+        - /http-prober-bin/http-prober
         image: gcr.io/google_containers/metrics-server-amd64:v0.3.2
         name: metrics-server
         resources:
@@ -70,6 +67,8 @@ spec:
         - mountPath: /etc/kubernetes/kubeconfig
           name: metrics-server
           readOnly: true
+        - mountPath: /http-prober-bin
+          name: http-prober-bin
       - args:
         - --client
         - --proto
@@ -158,24 +157,16 @@ spec:
       imagePullSecrets:
       - name: dockercfg
       initContainers:
-      - args:
-        - -endpoint
-        - https://apiserver-external.cluster-de-test-01.svc.cluster.local.:30000/healthz
-        - -insecure
-        - -retries
-        - "100"
-        - -retry-wait
-        - "2"
-        - -timeout
-        - "1"
-        command:
+      - command:
+        - /bin/cp
         - /usr/local/bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.1
-        imagePullPolicy: IfNotPresent
-        name: apiserver-running
+        - /http-prober-bin/http-prober
+        image: quay.io/kubermatic/http-prober:v0.2-dev0
+        name: copy-http-prober
         resources: {}
-        terminationMessagePath: /dev/termination-log
-        terminationMessagePolicy: File
+        volumeMounts:
+        - mountPath: /http-prober-bin
+          name: http-prober-bin
       volumes:
       - name: metrics-server
         secret:
@@ -189,4 +180,6 @@ spec:
         secret:
           defaultMode: 292
           secretName: kubeletdnatcontroller-kubeconfig
+      - emptyDir: {}
+        name: http-prober-bin
 status: {}

--- a/api/pkg/resources/test/fixtures/deployment-digitalocean-1.11.1-metrics-server.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-digitalocean-1.11.1-metrics-server.yaml
@@ -161,7 +161,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.2-dev0
+        image: quay.io/kubermatic/http-prober:v0.2
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/api/pkg/resources/test/fixtures/deployment-digitalocean-1.11.1-scheduler.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-digitalocean-1.11.1-scheduler.yaml
@@ -100,11 +100,19 @@ spec:
           name: openvpn-client-certificates
           readOnly: true
       - args:
-        - --kubeconfig
-        - /etc/kubernetes/kubeconfig/kubeconfig
+        - -endpoint
+        - https://apiserver-external.cluster-de-test-01.svc.cluster.local.:30000/healthz
+        - -insecure
+        - -retries
+        - "100"
+        - -retry-wait
+        - "2"
+        - -timeout
+        - "1"
+        - -command
+        - '{"command":"/hyperkube","args":["kube-scheduler","--kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig"]}'
         command:
-        - /hyperkube
-        - kube-scheduler
+        - /http-prober-bin/http-prober
         image: gcr.io/google_containers/hyperkube-amd64:v1.11.1
         livenessProbe:
           failureThreshold: 8
@@ -140,6 +148,8 @@ spec:
         - mountPath: /etc/kubernetes/pki/ca
           name: ca
           readOnly: true
+        - mountPath: /http-prober-bin
+          name: http-prober-bin
       dnsConfig:
         nameservers:
         - 192.0.2.14
@@ -154,24 +164,16 @@ spec:
       imagePullSecrets:
       - name: dockercfg
       initContainers:
-      - args:
-        - -endpoint
-        - https://apiserver-external.cluster-de-test-01.svc.cluster.local.:30000/healthz
-        - -insecure
-        - -retries
-        - "100"
-        - -retry-wait
-        - "2"
-        - -timeout
-        - "1"
-        command:
+      - command:
+        - /bin/cp
         - /usr/local/bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.1
-        imagePullPolicy: IfNotPresent
-        name: apiserver-running
+        - /http-prober-bin/http-prober
+        image: quay.io/kubermatic/http-prober:v0.2-dev0
+        name: copy-http-prober
         resources: {}
-        terminationMessagePath: /dev/termination-log
-        terminationMessagePolicy: File
+        volumeMounts:
+        - mountPath: /http-prober-bin
+          name: http-prober-bin
       volumes:
       - name: openvpn-client-certificates
         secret:
@@ -188,4 +190,6 @@ spec:
         secret:
           defaultMode: 256
           secretName: scheduler-kubeconfig
+      - emptyDir: {}
+        name: http-prober-bin
 status: {}

--- a/api/pkg/resources/test/fixtures/deployment-digitalocean-1.11.1-scheduler.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-digitalocean-1.11.1-scheduler.yaml
@@ -168,7 +168,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.2-dev0
+        image: quay.io/kubermatic/http-prober:v0.2
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/api/pkg/resources/test/fixtures/deployment-digitalocean-1.11.1-usercluster-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-digitalocean-1.11.1-usercluster-controller.yaml
@@ -85,7 +85,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.2-dev0
+        image: quay.io/kubermatic/http-prober:v0.2
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/api/pkg/resources/test/fixtures/deployment-digitalocean-1.11.1-usercluster-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-digitalocean-1.11.1-usercluster-controller.yaml
@@ -29,32 +29,19 @@ spec:
     spec:
       containers:
       - args:
-        - -kubeconfig
-        - /etc/kubernetes/kubeconfig/kubeconfig
-        - -metrics-listen-address
-        - 0.0.0.0:8085
-        - -health-listen-address
-        - 0.0.0.0:8086
-        - -namespace
-        - $(NAMESPACE)
-        - -ca-cert
-        - /etc/kubernetes/pki/ca/ca.crt
-        - -cluster-url
-        - ""
-        - -openvpn-server-port
-        - "30003"
-        - -overwrite-registry
-        - ""
-        - -openshift=false
-        - -openvpn-ca-cert-file=/etc/kubernetes/pki/openvpn/ca.crt
-        - -openvpn-ca-key-file=/etc/kubernetes/pki/openvpn/ca.key
-        - -logtostderr
-        - -v
+        - -endpoint
+        - https://apiserver-external.cluster-de-test-01.svc.cluster.local.:30000/healthz
+        - -insecure
+        - -retries
+        - "100"
+        - -retry-wait
         - "2"
-        - --ipam-controller-network
-        - 192.168.1.1/24,192.168.1.1,8.8.8.8
+        - -timeout
+        - "1"
+        - -command
+        - '{"command":"/usr/local/bin/user-cluster-controller-manager","args":["-kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","-metrics-listen-address","0.0.0.0:8085","-health-listen-address","0.0.0.0:8086","-namespace","$(NAMESPACE)","-ca-cert","/etc/kubernetes/pki/ca/ca.crt","-cluster-url","","-openvpn-server-port","30003","-overwrite-registry","","-openshift=false","-openvpn-ca-cert-file=/etc/kubernetes/pki/openvpn/ca.crt","-openvpn-ca-key-file=/etc/kubernetes/pki/openvpn/ca.key","-logtostderr","-v","2","--ipam-controller-network","192.168.1.1/24,192.168.1.1,8.8.8.8"]}'
         command:
-        - /usr/local/bin/user-cluster-controller-manager
+        - /http-prober-bin/http-prober
         env:
         - name: NAMESPACE
           valueFrom:
@@ -89,27 +76,21 @@ spec:
         - mountPath: /etc/kubernetes/pki/openvpn
           name: openvpn-ca
           readOnly: true
+        - mountPath: /http-prober-bin
+          name: http-prober-bin
       imagePullSecrets:
       - name: dockercfg
       initContainers:
-      - args:
-        - -endpoint
-        - https://apiserver-external.cluster-de-test-01.svc.cluster.local.:30000/healthz
-        - -insecure
-        - -retries
-        - "100"
-        - -retry-wait
-        - "2"
-        - -timeout
-        - "1"
-        command:
+      - command:
+        - /bin/cp
         - /usr/local/bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.1
-        imagePullPolicy: IfNotPresent
-        name: apiserver-running
+        - /http-prober-bin/http-prober
+        image: quay.io/kubermatic/http-prober:v0.2-dev0
+        name: copy-http-prober
         resources: {}
-        terminationMessagePath: /dev/termination-log
-        terminationMessagePolicy: File
+        volumeMounts:
+        - mountPath: /http-prober-bin
+          name: http-prober-bin
       volumes:
       - name: internal-admin-kubeconfig
         secret:
@@ -126,4 +107,6 @@ spec:
         secret:
           defaultMode: 292
           secretName: openvpn-ca
+      - emptyDir: {}
+        name: http-prober-bin
 status: {}

--- a/api/pkg/resources/test/fixtures/deployment-digitalocean-1.12.0-controller-manager.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-digitalocean-1.12.0-controller-manager.yaml
@@ -176,7 +176,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.2-dev0
+        image: quay.io/kubermatic/http-prober:v0.2
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/api/pkg/resources/test/fixtures/deployment-digitalocean-1.12.0-controller-manager.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-digitalocean-1.12.0-controller-manager.yaml
@@ -102,32 +102,19 @@ spec:
           name: openvpn-client-certificates
           readOnly: true
       - args:
-        - --kubeconfig
-        - /etc/kubernetes/kubeconfig/kubeconfig
-        - --service-account-private-key-file
-        - /etc/kubernetes/service-account-key/sa.key
-        - --root-ca-file
-        - /etc/kubernetes/pki/ca/ca.crt
-        - --cluster-signing-cert-file
-        - /etc/kubernetes/pki/ca/ca.crt
-        - --cluster-signing-key-file
-        - /etc/kubernetes/pki/ca/ca.key
-        - --cluster-cidr
-        - 172.25.0.0/16
-        - --allocate-node-cidrs=true
-        - --controllers
-        - '*,bootstrapsigner,tokencleaner'
-        - --use-service-account-credentials=true
-        - --feature-gates
-        - RotateKubeletClientCertificate=true,RotateKubeletServerCertificate=true,ScheduleDaemonSetPods=false
-        - --authentication-kubeconfig
-        - /etc/kubernetes/kubeconfig/kubeconfig
-        - --client-ca-file
-        - /etc/kubernetes/pki/ca/ca.crt
-        - --authentication-skip-lookup=true
+        - -endpoint
+        - https://apiserver-external.cluster-de-test-01.svc.cluster.local.:30000/healthz
+        - -insecure
+        - -retries
+        - "100"
+        - -retry-wait
+        - "2"
+        - -timeout
+        - "1"
+        - -command
+        - '{"command":"/hyperkube","args":["kube-controller-manager","--kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","--service-account-private-key-file","/etc/kubernetes/service-account-key/sa.key","--root-ca-file","/etc/kubernetes/pki/ca/ca.crt","--cluster-signing-cert-file","/etc/kubernetes/pki/ca/ca.crt","--cluster-signing-key-file","/etc/kubernetes/pki/ca/ca.key","--cluster-cidr","172.25.0.0/16","--allocate-node-cidrs=true","--controllers","*,bootstrapsigner,tokencleaner","--use-service-account-credentials=true","--feature-gates","RotateKubeletClientCertificate=true,RotateKubeletServerCertificate=true,ScheduleDaemonSetPods=false","--authentication-kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","--client-ca-file","/etc/kubernetes/pki/ca/ca.crt","--authentication-skip-lookup=true"]}'
         command:
-        - /hyperkube
-        - kube-controller-manager
+        - /http-prober-bin/http-prober
         image: gcr.io/google_containers/hyperkube-amd64:v1.12.0
         livenessProbe:
           failureThreshold: 8
@@ -169,6 +156,8 @@ spec:
         - mountPath: /etc/kubernetes/kubeconfig
           name: controllermanager-kubeconfig
           readOnly: true
+        - mountPath: /http-prober-bin
+          name: http-prober-bin
       dnsConfig:
         nameservers:
         - 192.0.2.14
@@ -183,24 +172,16 @@ spec:
       imagePullSecrets:
       - name: dockercfg
       initContainers:
-      - args:
-        - -endpoint
-        - https://apiserver-external.cluster-de-test-01.svc.cluster.local.:30000/healthz
-        - -insecure
-        - -retries
-        - "100"
-        - -retry-wait
-        - "2"
-        - -timeout
-        - "1"
-        command:
+      - command:
+        - /bin/cp
         - /usr/local/bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.1
-        imagePullPolicy: IfNotPresent
-        name: apiserver-running
+        - /http-prober-bin/http-prober
+        image: quay.io/kubermatic/http-prober:v0.2-dev0
+        name: copy-http-prober
         resources: {}
-        terminationMessagePath: /dev/termination-log
-        terminationMessagePolicy: File
+        volumeMounts:
+        - mountPath: /http-prober-bin
+          name: http-prober-bin
       volumes:
       - name: ca
         secret:
@@ -222,4 +203,6 @@ spec:
         secret:
           defaultMode: 256
           secretName: controllermanager-kubeconfig
+      - emptyDir: {}
+        name: http-prober-bin
 status: {}

--- a/api/pkg/resources/test/fixtures/deployment-digitalocean-1.12.0-kube-state-metrics.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-digitalocean-1.12.0-kube-state-metrics.yaml
@@ -21,14 +21,19 @@ spec:
     spec:
       containers:
       - args:
-        - --kubeconfig
-        - /etc/kubernetes/kubeconfig/kubeconfig
-        - --port
-        - "8080"
-        - --telemetry-port
-        - "8081"
+        - -endpoint
+        - https://apiserver-external.cluster-de-test-01.svc.cluster.local.:30000/healthz
+        - -insecure
+        - -retries
+        - "100"
+        - -retry-wait
+        - "2"
+        - -timeout
+        - "1"
+        - -command
+        - '{"command":"/kube-state-metrics","args":["--kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","--port","8080","--telemetry-port","8081"]}'
         command:
-        - /kube-state-metrics
+        - /http-prober-bin/http-prober
         image: quay.io/coreos/kube-state-metrics:v1.6.0
         name: kube-state-metrics
         ports:
@@ -58,30 +63,26 @@ spec:
         - mountPath: /etc/kubernetes/kubeconfig
           name: kube-state-metrics-kubeconfig
           readOnly: true
+        - mountPath: /http-prober-bin
+          name: http-prober-bin
       imagePullSecrets:
       - name: dockercfg
       initContainers:
-      - args:
-        - -endpoint
-        - https://apiserver-external.cluster-de-test-01.svc.cluster.local.:30000/healthz
-        - -insecure
-        - -retries
-        - "100"
-        - -retry-wait
-        - "2"
-        - -timeout
-        - "1"
-        command:
+      - command:
+        - /bin/cp
         - /usr/local/bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.1
-        imagePullPolicy: IfNotPresent
-        name: apiserver-running
+        - /http-prober-bin/http-prober
+        image: quay.io/kubermatic/http-prober:v0.2-dev0
+        name: copy-http-prober
         resources: {}
-        terminationMessagePath: /dev/termination-log
-        terminationMessagePolicy: File
+        volumeMounts:
+        - mountPath: /http-prober-bin
+          name: http-prober-bin
       volumes:
       - name: kube-state-metrics-kubeconfig
         secret:
           defaultMode: 256
           secretName: kube-state-metrics-kubeconfig
+      - emptyDir: {}
+        name: http-prober-bin
 status: {}

--- a/api/pkg/resources/test/fixtures/deployment-digitalocean-1.12.0-kube-state-metrics.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-digitalocean-1.12.0-kube-state-metrics.yaml
@@ -72,7 +72,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.2-dev0
+        image: quay.io/kubermatic/http-prober:v0.2
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/api/pkg/resources/test/fixtures/deployment-digitalocean-1.12.0-machine-controller-webhook.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-digitalocean-1.12.0-machine-controller-webhook.yaml
@@ -84,7 +84,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.2-dev0
+        image: quay.io/kubermatic/http-prober:v0.2
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/api/pkg/resources/test/fixtures/deployment-digitalocean-1.12.0-machine-controller-webhook.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-digitalocean-1.12.0-machine-controller-webhook.yaml
@@ -24,15 +24,19 @@ spec:
     spec:
       containers:
       - args:
-        - -kubeconfig
-        - /etc/kubernetes/kubeconfig/kubeconfig
-        - -logtostderr
-        - -v
-        - "4"
-        - -listen-address
-        - 0.0.0.0:9876
+        - -endpoint
+        - https://apiserver-external.cluster-de-test-01.svc.cluster.local.:30000/healthz
+        - -insecure
+        - -retries
+        - "100"
+        - -retry-wait
+        - "2"
+        - -timeout
+        - "1"
+        - -command
+        - '{"command":"/usr/local/bin/webhook","args":["-kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","-logtostderr","-v","4","-listen-address","0.0.0.0:9876"]}'
         command:
-        - /usr/local/bin/webhook
+        - /http-prober-bin/http-prober
         env:
         - name: DO_TOKEN
           value: do-token
@@ -71,27 +75,21 @@ spec:
         - mountPath: /tmp/cert
           name: machinecontroller-webhook-serving-cert
           readOnly: true
+        - mountPath: /http-prober-bin
+          name: http-prober-bin
       imagePullSecrets:
       - name: dockercfg
       initContainers:
-      - args:
-        - -endpoint
-        - https://apiserver-external.cluster-de-test-01.svc.cluster.local.:30000/healthz
-        - -insecure
-        - -retries
-        - "100"
-        - -retry-wait
-        - "2"
-        - -timeout
-        - "1"
-        command:
+      - command:
+        - /bin/cp
         - /usr/local/bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.1
-        imagePullPolicy: IfNotPresent
-        name: apiserver-running
+        - /http-prober-bin/http-prober
+        image: quay.io/kubermatic/http-prober:v0.2-dev0
+        name: copy-http-prober
         resources: {}
-        terminationMessagePath: /dev/termination-log
-        terminationMessagePolicy: File
+        volumeMounts:
+        - mountPath: /http-prober-bin
+          name: http-prober-bin
       volumes:
       - name: machinecontroller-kubeconfig
         secret:
@@ -101,4 +99,6 @@ spec:
         secret:
           defaultMode: 292
           secretName: machinecontroller-webhook-serving-cert
+      - emptyDir: {}
+        name: http-prober-bin
 status: {}

--- a/api/pkg/resources/test/fixtures/deployment-digitalocean-1.12.0-machine-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-digitalocean-1.12.0-machine-controller.yaml
@@ -27,17 +27,19 @@ spec:
     spec:
       containers:
       - args:
-        - -kubeconfig
-        - /etc/kubernetes/kubeconfig/kubeconfig
-        - -logtostderr
-        - -v
-        - "4"
-        - -cluster-dns
-        - 169.254.20.10
-        - -internal-listen-address
-        - 0.0.0.0:8085
+        - -endpoint
+        - https://apiserver-external.cluster-de-test-01.svc.cluster.local.:30000/healthz
+        - -insecure
+        - -retries
+        - "100"
+        - -retry-wait
+        - "2"
+        - -timeout
+        - "1"
+        - -command
+        - '{"command":"/usr/local/bin/machine-controller","args":["-kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","-logtostderr","-v","4","-cluster-dns","169.254.20.10","-internal-listen-address","0.0.0.0:8085"]}'
         command:
-        - /usr/local/bin/machine-controller
+        - /http-prober-bin/http-prober
         env:
         - name: DO_TOKEN
           value: do-token
@@ -64,30 +66,26 @@ spec:
         - mountPath: /etc/kubernetes/kubeconfig
           name: machinecontroller-kubeconfig
           readOnly: true
+        - mountPath: /http-prober-bin
+          name: http-prober-bin
       imagePullSecrets:
       - name: dockercfg
       initContainers:
-      - args:
-        - -endpoint
-        - https://apiserver-external.cluster-de-test-01.svc.cluster.local.:30000/healthz
-        - -insecure
-        - -retries
-        - "100"
-        - -retry-wait
-        - "2"
-        - -timeout
-        - "1"
-        command:
+      - command:
+        - /bin/cp
         - /usr/local/bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.1
-        imagePullPolicy: IfNotPresent
-        name: apiserver-running
+        - /http-prober-bin/http-prober
+        image: quay.io/kubermatic/http-prober:v0.2-dev0
+        name: copy-http-prober
         resources: {}
-        terminationMessagePath: /dev/termination-log
-        terminationMessagePolicy: File
+        volumeMounts:
+        - mountPath: /http-prober-bin
+          name: http-prober-bin
       volumes:
       - name: machinecontroller-kubeconfig
         secret:
           defaultMode: 292
           secretName: machinecontroller-kubeconfig
+      - emptyDir: {}
+        name: http-prober-bin
 status: {}

--- a/api/pkg/resources/test/fixtures/deployment-digitalocean-1.12.0-machine-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-digitalocean-1.12.0-machine-controller.yaml
@@ -75,7 +75,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.2-dev0
+        image: quay.io/kubermatic/http-prober:v0.2
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/api/pkg/resources/test/fixtures/deployment-digitalocean-1.12.0-metrics-server.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-digitalocean-1.12.0-metrics-server.yaml
@@ -41,22 +41,19 @@ spec:
             weight: 10
       containers:
       - args:
-        - --kubeconfig
-        - /etc/kubernetes/kubeconfig/kubeconfig
-        - --authentication-kubeconfig
-        - /etc/kubernetes/kubeconfig/kubeconfig
-        - --authorization-kubeconfig
-        - /etc/kubernetes/kubeconfig/kubeconfig
-        - --kubelet-port
-        - "10250"
-        - --kubelet-insecure-tls
-        - --kubelet-preferred-address-types
-        - ExternalIP,InternalIP
-        - --v
+        - -endpoint
+        - https://apiserver-external.cluster-de-test-01.svc.cluster.local.:30000/healthz
+        - -insecure
+        - -retries
+        - "100"
+        - -retry-wait
+        - "2"
+        - -timeout
         - "1"
-        - --logtostderr
+        - -command
+        - '{"command":"/metrics-server","args":["--kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","--authentication-kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","--authorization-kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","--kubelet-port","10250","--kubelet-insecure-tls","--kubelet-preferred-address-types","ExternalIP,InternalIP","--v","1","--logtostderr"]}'
         command:
-        - /metrics-server
+        - /http-prober-bin/http-prober
         image: gcr.io/google_containers/metrics-server-amd64:v0.3.2
         name: metrics-server
         resources:
@@ -70,6 +67,8 @@ spec:
         - mountPath: /etc/kubernetes/kubeconfig
           name: metrics-server
           readOnly: true
+        - mountPath: /http-prober-bin
+          name: http-prober-bin
       - args:
         - --client
         - --proto
@@ -158,24 +157,16 @@ spec:
       imagePullSecrets:
       - name: dockercfg
       initContainers:
-      - args:
-        - -endpoint
-        - https://apiserver-external.cluster-de-test-01.svc.cluster.local.:30000/healthz
-        - -insecure
-        - -retries
-        - "100"
-        - -retry-wait
-        - "2"
-        - -timeout
-        - "1"
-        command:
+      - command:
+        - /bin/cp
         - /usr/local/bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.1
-        imagePullPolicy: IfNotPresent
-        name: apiserver-running
+        - /http-prober-bin/http-prober
+        image: quay.io/kubermatic/http-prober:v0.2-dev0
+        name: copy-http-prober
         resources: {}
-        terminationMessagePath: /dev/termination-log
-        terminationMessagePolicy: File
+        volumeMounts:
+        - mountPath: /http-prober-bin
+          name: http-prober-bin
       volumes:
       - name: metrics-server
         secret:
@@ -189,4 +180,6 @@ spec:
         secret:
           defaultMode: 292
           secretName: kubeletdnatcontroller-kubeconfig
+      - emptyDir: {}
+        name: http-prober-bin
 status: {}

--- a/api/pkg/resources/test/fixtures/deployment-digitalocean-1.12.0-metrics-server.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-digitalocean-1.12.0-metrics-server.yaml
@@ -161,7 +161,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.2-dev0
+        image: quay.io/kubermatic/http-prober:v0.2
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/api/pkg/resources/test/fixtures/deployment-digitalocean-1.12.0-scheduler.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-digitalocean-1.12.0-scheduler.yaml
@@ -168,7 +168,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.2-dev0
+        image: quay.io/kubermatic/http-prober:v0.2
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/api/pkg/resources/test/fixtures/deployment-digitalocean-1.12.0-scheduler.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-digitalocean-1.12.0-scheduler.yaml
@@ -100,13 +100,19 @@ spec:
           name: openvpn-client-certificates
           readOnly: true
       - args:
-        - --kubeconfig
-        - /etc/kubernetes/kubeconfig/kubeconfig
-        - --feature-gates
-        - ScheduleDaemonSetPods=false
+        - -endpoint
+        - https://apiserver-external.cluster-de-test-01.svc.cluster.local.:30000/healthz
+        - -insecure
+        - -retries
+        - "100"
+        - -retry-wait
+        - "2"
+        - -timeout
+        - "1"
+        - -command
+        - '{"command":"/hyperkube","args":["kube-scheduler","--kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","--feature-gates","ScheduleDaemonSetPods=false"]}'
         command:
-        - /hyperkube
-        - kube-scheduler
+        - /http-prober-bin/http-prober
         image: gcr.io/google_containers/hyperkube-amd64:v1.12.0
         livenessProbe:
           failureThreshold: 8
@@ -142,6 +148,8 @@ spec:
         - mountPath: /etc/kubernetes/pki/ca
           name: ca
           readOnly: true
+        - mountPath: /http-prober-bin
+          name: http-prober-bin
       dnsConfig:
         nameservers:
         - 192.0.2.14
@@ -156,24 +164,16 @@ spec:
       imagePullSecrets:
       - name: dockercfg
       initContainers:
-      - args:
-        - -endpoint
-        - https://apiserver-external.cluster-de-test-01.svc.cluster.local.:30000/healthz
-        - -insecure
-        - -retries
-        - "100"
-        - -retry-wait
-        - "2"
-        - -timeout
-        - "1"
-        command:
+      - command:
+        - /bin/cp
         - /usr/local/bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.1
-        imagePullPolicy: IfNotPresent
-        name: apiserver-running
+        - /http-prober-bin/http-prober
+        image: quay.io/kubermatic/http-prober:v0.2-dev0
+        name: copy-http-prober
         resources: {}
-        terminationMessagePath: /dev/termination-log
-        terminationMessagePolicy: File
+        volumeMounts:
+        - mountPath: /http-prober-bin
+          name: http-prober-bin
       volumes:
       - name: openvpn-client-certificates
         secret:
@@ -190,4 +190,6 @@ spec:
         secret:
           defaultMode: 256
           secretName: scheduler-kubeconfig
+      - emptyDir: {}
+        name: http-prober-bin
 status: {}

--- a/api/pkg/resources/test/fixtures/deployment-digitalocean-1.12.0-usercluster-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-digitalocean-1.12.0-usercluster-controller.yaml
@@ -85,7 +85,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.2-dev0
+        image: quay.io/kubermatic/http-prober:v0.2
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/api/pkg/resources/test/fixtures/deployment-digitalocean-1.12.0-usercluster-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-digitalocean-1.12.0-usercluster-controller.yaml
@@ -29,32 +29,19 @@ spec:
     spec:
       containers:
       - args:
-        - -kubeconfig
-        - /etc/kubernetes/kubeconfig/kubeconfig
-        - -metrics-listen-address
-        - 0.0.0.0:8085
-        - -health-listen-address
-        - 0.0.0.0:8086
-        - -namespace
-        - $(NAMESPACE)
-        - -ca-cert
-        - /etc/kubernetes/pki/ca/ca.crt
-        - -cluster-url
-        - ""
-        - -openvpn-server-port
-        - "30003"
-        - -overwrite-registry
-        - ""
-        - -openshift=false
-        - -openvpn-ca-cert-file=/etc/kubernetes/pki/openvpn/ca.crt
-        - -openvpn-ca-key-file=/etc/kubernetes/pki/openvpn/ca.key
-        - -logtostderr
-        - -v
+        - -endpoint
+        - https://apiserver-external.cluster-de-test-01.svc.cluster.local.:30000/healthz
+        - -insecure
+        - -retries
+        - "100"
+        - -retry-wait
         - "2"
-        - --ipam-controller-network
-        - 192.168.1.1/24,192.168.1.1,8.8.8.8
+        - -timeout
+        - "1"
+        - -command
+        - '{"command":"/usr/local/bin/user-cluster-controller-manager","args":["-kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","-metrics-listen-address","0.0.0.0:8085","-health-listen-address","0.0.0.0:8086","-namespace","$(NAMESPACE)","-ca-cert","/etc/kubernetes/pki/ca/ca.crt","-cluster-url","","-openvpn-server-port","30003","-overwrite-registry","","-openshift=false","-openvpn-ca-cert-file=/etc/kubernetes/pki/openvpn/ca.crt","-openvpn-ca-key-file=/etc/kubernetes/pki/openvpn/ca.key","-logtostderr","-v","2","--ipam-controller-network","192.168.1.1/24,192.168.1.1,8.8.8.8"]}'
         command:
-        - /usr/local/bin/user-cluster-controller-manager
+        - /http-prober-bin/http-prober
         env:
         - name: NAMESPACE
           valueFrom:
@@ -89,27 +76,21 @@ spec:
         - mountPath: /etc/kubernetes/pki/openvpn
           name: openvpn-ca
           readOnly: true
+        - mountPath: /http-prober-bin
+          name: http-prober-bin
       imagePullSecrets:
       - name: dockercfg
       initContainers:
-      - args:
-        - -endpoint
-        - https://apiserver-external.cluster-de-test-01.svc.cluster.local.:30000/healthz
-        - -insecure
-        - -retries
-        - "100"
-        - -retry-wait
-        - "2"
-        - -timeout
-        - "1"
-        command:
+      - command:
+        - /bin/cp
         - /usr/local/bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.1
-        imagePullPolicy: IfNotPresent
-        name: apiserver-running
+        - /http-prober-bin/http-prober
+        image: quay.io/kubermatic/http-prober:v0.2-dev0
+        name: copy-http-prober
         resources: {}
-        terminationMessagePath: /dev/termination-log
-        terminationMessagePolicy: File
+        volumeMounts:
+        - mountPath: /http-prober-bin
+          name: http-prober-bin
       volumes:
       - name: internal-admin-kubeconfig
         secret:
@@ -126,4 +107,6 @@ spec:
         secret:
           defaultMode: 292
           secretName: openvpn-ca
+      - emptyDir: {}
+        name: http-prober-bin
 status: {}

--- a/api/pkg/resources/test/fixtures/deployment-digitalocean-1.13.0-controller-manager.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-digitalocean-1.13.0-controller-manager.yaml
@@ -176,7 +176,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.2-dev0
+        image: quay.io/kubermatic/http-prober:v0.2
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/api/pkg/resources/test/fixtures/deployment-digitalocean-1.13.0-controller-manager.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-digitalocean-1.13.0-controller-manager.yaml
@@ -102,37 +102,19 @@ spec:
           name: openvpn-client-certificates
           readOnly: true
       - args:
-        - --kubeconfig
-        - /etc/kubernetes/kubeconfig/kubeconfig
-        - --service-account-private-key-file
-        - /etc/kubernetes/service-account-key/sa.key
-        - --root-ca-file
-        - /etc/kubernetes/pki/ca/ca.crt
-        - --cluster-signing-cert-file
-        - /etc/kubernetes/pki/ca/ca.crt
-        - --cluster-signing-key-file
-        - /etc/kubernetes/pki/ca/ca.key
-        - --cluster-cidr
-        - 172.25.0.0/16
-        - --allocate-node-cidrs=true
-        - --controllers
-        - '*,bootstrapsigner,tokencleaner'
-        - --use-service-account-credentials=true
-        - --feature-gates
-        - RotateKubeletClientCertificate=true,RotateKubeletServerCertificate=true,ScheduleDaemonSetPods=false
-        - --authentication-kubeconfig
-        - /etc/kubernetes/kubeconfig/kubeconfig
-        - --client-ca-file
-        - /etc/kubernetes/pki/ca/ca.crt
-        - --authentication-kubeconfig
-        - /etc/kubernetes/kubeconfig/kubeconfig
-        - --authorization-kubeconfig
-        - /etc/kubernetes/kubeconfig/kubeconfig
-        - --port
-        - "0"
+        - -endpoint
+        - https://apiserver-external.cluster-de-test-01.svc.cluster.local.:30000/healthz
+        - -insecure
+        - -retries
+        - "100"
+        - -retry-wait
+        - "2"
+        - -timeout
+        - "1"
+        - -command
+        - '{"command":"/hyperkube","args":["kube-controller-manager","--kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","--service-account-private-key-file","/etc/kubernetes/service-account-key/sa.key","--root-ca-file","/etc/kubernetes/pki/ca/ca.crt","--cluster-signing-cert-file","/etc/kubernetes/pki/ca/ca.crt","--cluster-signing-key-file","/etc/kubernetes/pki/ca/ca.key","--cluster-cidr","172.25.0.0/16","--allocate-node-cidrs=true","--controllers","*,bootstrapsigner,tokencleaner","--use-service-account-credentials=true","--feature-gates","RotateKubeletClientCertificate=true,RotateKubeletServerCertificate=true,ScheduleDaemonSetPods=false","--authentication-kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","--client-ca-file","/etc/kubernetes/pki/ca/ca.crt","--authentication-kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","--authorization-kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","--port","0"]}'
         command:
-        - /hyperkube
-        - kube-controller-manager
+        - /http-prober-bin/http-prober
         image: gcr.io/google_containers/hyperkube-amd64:v1.13.0
         livenessProbe:
           failureThreshold: 8
@@ -174,6 +156,8 @@ spec:
         - mountPath: /etc/kubernetes/kubeconfig
           name: controllermanager-kubeconfig
           readOnly: true
+        - mountPath: /http-prober-bin
+          name: http-prober-bin
       dnsConfig:
         nameservers:
         - 192.0.2.14
@@ -188,24 +172,16 @@ spec:
       imagePullSecrets:
       - name: dockercfg
       initContainers:
-      - args:
-        - -endpoint
-        - https://apiserver-external.cluster-de-test-01.svc.cluster.local.:30000/healthz
-        - -insecure
-        - -retries
-        - "100"
-        - -retry-wait
-        - "2"
-        - -timeout
-        - "1"
-        command:
+      - command:
+        - /bin/cp
         - /usr/local/bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.1
-        imagePullPolicy: IfNotPresent
-        name: apiserver-running
+        - /http-prober-bin/http-prober
+        image: quay.io/kubermatic/http-prober:v0.2-dev0
+        name: copy-http-prober
         resources: {}
-        terminationMessagePath: /dev/termination-log
-        terminationMessagePolicy: File
+        volumeMounts:
+        - mountPath: /http-prober-bin
+          name: http-prober-bin
       volumes:
       - name: ca
         secret:
@@ -227,4 +203,6 @@ spec:
         secret:
           defaultMode: 256
           secretName: controllermanager-kubeconfig
+      - emptyDir: {}
+        name: http-prober-bin
 status: {}

--- a/api/pkg/resources/test/fixtures/deployment-digitalocean-1.13.0-kube-state-metrics.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-digitalocean-1.13.0-kube-state-metrics.yaml
@@ -21,14 +21,19 @@ spec:
     spec:
       containers:
       - args:
-        - --kubeconfig
-        - /etc/kubernetes/kubeconfig/kubeconfig
-        - --port
-        - "8080"
-        - --telemetry-port
-        - "8081"
+        - -endpoint
+        - https://apiserver-external.cluster-de-test-01.svc.cluster.local.:30000/healthz
+        - -insecure
+        - -retries
+        - "100"
+        - -retry-wait
+        - "2"
+        - -timeout
+        - "1"
+        - -command
+        - '{"command":"/kube-state-metrics","args":["--kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","--port","8080","--telemetry-port","8081"]}'
         command:
-        - /kube-state-metrics
+        - /http-prober-bin/http-prober
         image: quay.io/coreos/kube-state-metrics:v1.6.0
         name: kube-state-metrics
         ports:
@@ -58,30 +63,26 @@ spec:
         - mountPath: /etc/kubernetes/kubeconfig
           name: kube-state-metrics-kubeconfig
           readOnly: true
+        - mountPath: /http-prober-bin
+          name: http-prober-bin
       imagePullSecrets:
       - name: dockercfg
       initContainers:
-      - args:
-        - -endpoint
-        - https://apiserver-external.cluster-de-test-01.svc.cluster.local.:30000/healthz
-        - -insecure
-        - -retries
-        - "100"
-        - -retry-wait
-        - "2"
-        - -timeout
-        - "1"
-        command:
+      - command:
+        - /bin/cp
         - /usr/local/bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.1
-        imagePullPolicy: IfNotPresent
-        name: apiserver-running
+        - /http-prober-bin/http-prober
+        image: quay.io/kubermatic/http-prober:v0.2-dev0
+        name: copy-http-prober
         resources: {}
-        terminationMessagePath: /dev/termination-log
-        terminationMessagePolicy: File
+        volumeMounts:
+        - mountPath: /http-prober-bin
+          name: http-prober-bin
       volumes:
       - name: kube-state-metrics-kubeconfig
         secret:
           defaultMode: 256
           secretName: kube-state-metrics-kubeconfig
+      - emptyDir: {}
+        name: http-prober-bin
 status: {}

--- a/api/pkg/resources/test/fixtures/deployment-digitalocean-1.13.0-kube-state-metrics.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-digitalocean-1.13.0-kube-state-metrics.yaml
@@ -72,7 +72,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.2-dev0
+        image: quay.io/kubermatic/http-prober:v0.2
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/api/pkg/resources/test/fixtures/deployment-digitalocean-1.13.0-machine-controller-webhook.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-digitalocean-1.13.0-machine-controller-webhook.yaml
@@ -84,7 +84,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.2-dev0
+        image: quay.io/kubermatic/http-prober:v0.2
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/api/pkg/resources/test/fixtures/deployment-digitalocean-1.13.0-machine-controller-webhook.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-digitalocean-1.13.0-machine-controller-webhook.yaml
@@ -24,15 +24,19 @@ spec:
     spec:
       containers:
       - args:
-        - -kubeconfig
-        - /etc/kubernetes/kubeconfig/kubeconfig
-        - -logtostderr
-        - -v
-        - "4"
-        - -listen-address
-        - 0.0.0.0:9876
+        - -endpoint
+        - https://apiserver-external.cluster-de-test-01.svc.cluster.local.:30000/healthz
+        - -insecure
+        - -retries
+        - "100"
+        - -retry-wait
+        - "2"
+        - -timeout
+        - "1"
+        - -command
+        - '{"command":"/usr/local/bin/webhook","args":["-kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","-logtostderr","-v","4","-listen-address","0.0.0.0:9876"]}'
         command:
-        - /usr/local/bin/webhook
+        - /http-prober-bin/http-prober
         env:
         - name: DO_TOKEN
           value: do-token
@@ -71,27 +75,21 @@ spec:
         - mountPath: /tmp/cert
           name: machinecontroller-webhook-serving-cert
           readOnly: true
+        - mountPath: /http-prober-bin
+          name: http-prober-bin
       imagePullSecrets:
       - name: dockercfg
       initContainers:
-      - args:
-        - -endpoint
-        - https://apiserver-external.cluster-de-test-01.svc.cluster.local.:30000/healthz
-        - -insecure
-        - -retries
-        - "100"
-        - -retry-wait
-        - "2"
-        - -timeout
-        - "1"
-        command:
+      - command:
+        - /bin/cp
         - /usr/local/bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.1
-        imagePullPolicy: IfNotPresent
-        name: apiserver-running
+        - /http-prober-bin/http-prober
+        image: quay.io/kubermatic/http-prober:v0.2-dev0
+        name: copy-http-prober
         resources: {}
-        terminationMessagePath: /dev/termination-log
-        terminationMessagePolicy: File
+        volumeMounts:
+        - mountPath: /http-prober-bin
+          name: http-prober-bin
       volumes:
       - name: machinecontroller-kubeconfig
         secret:
@@ -101,4 +99,6 @@ spec:
         secret:
           defaultMode: 292
           secretName: machinecontroller-webhook-serving-cert
+      - emptyDir: {}
+        name: http-prober-bin
 status: {}

--- a/api/pkg/resources/test/fixtures/deployment-digitalocean-1.13.0-machine-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-digitalocean-1.13.0-machine-controller.yaml
@@ -27,17 +27,19 @@ spec:
     spec:
       containers:
       - args:
-        - -kubeconfig
-        - /etc/kubernetes/kubeconfig/kubeconfig
-        - -logtostderr
-        - -v
-        - "4"
-        - -cluster-dns
-        - 169.254.20.10
-        - -internal-listen-address
-        - 0.0.0.0:8085
+        - -endpoint
+        - https://apiserver-external.cluster-de-test-01.svc.cluster.local.:30000/healthz
+        - -insecure
+        - -retries
+        - "100"
+        - -retry-wait
+        - "2"
+        - -timeout
+        - "1"
+        - -command
+        - '{"command":"/usr/local/bin/machine-controller","args":["-kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","-logtostderr","-v","4","-cluster-dns","169.254.20.10","-internal-listen-address","0.0.0.0:8085"]}'
         command:
-        - /usr/local/bin/machine-controller
+        - /http-prober-bin/http-prober
         env:
         - name: DO_TOKEN
           value: do-token
@@ -64,30 +66,26 @@ spec:
         - mountPath: /etc/kubernetes/kubeconfig
           name: machinecontroller-kubeconfig
           readOnly: true
+        - mountPath: /http-prober-bin
+          name: http-prober-bin
       imagePullSecrets:
       - name: dockercfg
       initContainers:
-      - args:
-        - -endpoint
-        - https://apiserver-external.cluster-de-test-01.svc.cluster.local.:30000/healthz
-        - -insecure
-        - -retries
-        - "100"
-        - -retry-wait
-        - "2"
-        - -timeout
-        - "1"
-        command:
+      - command:
+        - /bin/cp
         - /usr/local/bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.1
-        imagePullPolicy: IfNotPresent
-        name: apiserver-running
+        - /http-prober-bin/http-prober
+        image: quay.io/kubermatic/http-prober:v0.2-dev0
+        name: copy-http-prober
         resources: {}
-        terminationMessagePath: /dev/termination-log
-        terminationMessagePolicy: File
+        volumeMounts:
+        - mountPath: /http-prober-bin
+          name: http-prober-bin
       volumes:
       - name: machinecontroller-kubeconfig
         secret:
           defaultMode: 292
           secretName: machinecontroller-kubeconfig
+      - emptyDir: {}
+        name: http-prober-bin
 status: {}

--- a/api/pkg/resources/test/fixtures/deployment-digitalocean-1.13.0-machine-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-digitalocean-1.13.0-machine-controller.yaml
@@ -75,7 +75,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.2-dev0
+        image: quay.io/kubermatic/http-prober:v0.2
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/api/pkg/resources/test/fixtures/deployment-digitalocean-1.13.0-metrics-server.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-digitalocean-1.13.0-metrics-server.yaml
@@ -41,22 +41,19 @@ spec:
             weight: 10
       containers:
       - args:
-        - --kubeconfig
-        - /etc/kubernetes/kubeconfig/kubeconfig
-        - --authentication-kubeconfig
-        - /etc/kubernetes/kubeconfig/kubeconfig
-        - --authorization-kubeconfig
-        - /etc/kubernetes/kubeconfig/kubeconfig
-        - --kubelet-port
-        - "10250"
-        - --kubelet-insecure-tls
-        - --kubelet-preferred-address-types
-        - ExternalIP,InternalIP
-        - --v
+        - -endpoint
+        - https://apiserver-external.cluster-de-test-01.svc.cluster.local.:30000/healthz
+        - -insecure
+        - -retries
+        - "100"
+        - -retry-wait
+        - "2"
+        - -timeout
         - "1"
-        - --logtostderr
+        - -command
+        - '{"command":"/metrics-server","args":["--kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","--authentication-kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","--authorization-kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","--kubelet-port","10250","--kubelet-insecure-tls","--kubelet-preferred-address-types","ExternalIP,InternalIP","--v","1","--logtostderr"]}'
         command:
-        - /metrics-server
+        - /http-prober-bin/http-prober
         image: gcr.io/google_containers/metrics-server-amd64:v0.3.2
         name: metrics-server
         resources:
@@ -70,6 +67,8 @@ spec:
         - mountPath: /etc/kubernetes/kubeconfig
           name: metrics-server
           readOnly: true
+        - mountPath: /http-prober-bin
+          name: http-prober-bin
       - args:
         - --client
         - --proto
@@ -158,24 +157,16 @@ spec:
       imagePullSecrets:
       - name: dockercfg
       initContainers:
-      - args:
-        - -endpoint
-        - https://apiserver-external.cluster-de-test-01.svc.cluster.local.:30000/healthz
-        - -insecure
-        - -retries
-        - "100"
-        - -retry-wait
-        - "2"
-        - -timeout
-        - "1"
-        command:
+      - command:
+        - /bin/cp
         - /usr/local/bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.1
-        imagePullPolicy: IfNotPresent
-        name: apiserver-running
+        - /http-prober-bin/http-prober
+        image: quay.io/kubermatic/http-prober:v0.2-dev0
+        name: copy-http-prober
         resources: {}
-        terminationMessagePath: /dev/termination-log
-        terminationMessagePolicy: File
+        volumeMounts:
+        - mountPath: /http-prober-bin
+          name: http-prober-bin
       volumes:
       - name: metrics-server
         secret:
@@ -189,4 +180,6 @@ spec:
         secret:
           defaultMode: 292
           secretName: kubeletdnatcontroller-kubeconfig
+      - emptyDir: {}
+        name: http-prober-bin
 status: {}

--- a/api/pkg/resources/test/fixtures/deployment-digitalocean-1.13.0-metrics-server.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-digitalocean-1.13.0-metrics-server.yaml
@@ -161,7 +161,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.2-dev0
+        image: quay.io/kubermatic/http-prober:v0.2
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/api/pkg/resources/test/fixtures/deployment-digitalocean-1.13.0-scheduler.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-digitalocean-1.13.0-scheduler.yaml
@@ -100,21 +100,19 @@ spec:
           name: openvpn-client-certificates
           readOnly: true
       - args:
-        - --kubeconfig
-        - /etc/kubernetes/kubeconfig/kubeconfig
-        - --authentication-kubeconfig
-        - /etc/kubernetes/kubeconfig/kubeconfig
-        - --authorization-kubeconfig
-        - /etc/kubernetes/kubeconfig/kubeconfig
-        - --client-ca-file
-        - /etc/kubernetes/pki/ca/ca.crt
-        - --port
-        - "0"
-        - --feature-gates
-        - ScheduleDaemonSetPods=false
+        - -endpoint
+        - https://apiserver-external.cluster-de-test-01.svc.cluster.local.:30000/healthz
+        - -insecure
+        - -retries
+        - "100"
+        - -retry-wait
+        - "2"
+        - -timeout
+        - "1"
+        - -command
+        - '{"command":"/hyperkube","args":["kube-scheduler","--kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","--authentication-kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","--authorization-kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","--client-ca-file","/etc/kubernetes/pki/ca/ca.crt","--port","0","--feature-gates","ScheduleDaemonSetPods=false"]}'
         command:
-        - /hyperkube
-        - kube-scheduler
+        - /http-prober-bin/http-prober
         image: gcr.io/google_containers/hyperkube-amd64:v1.13.0
         livenessProbe:
           failureThreshold: 8
@@ -150,6 +148,8 @@ spec:
         - mountPath: /etc/kubernetes/pki/ca
           name: ca
           readOnly: true
+        - mountPath: /http-prober-bin
+          name: http-prober-bin
       dnsConfig:
         nameservers:
         - 192.0.2.14
@@ -164,24 +164,16 @@ spec:
       imagePullSecrets:
       - name: dockercfg
       initContainers:
-      - args:
-        - -endpoint
-        - https://apiserver-external.cluster-de-test-01.svc.cluster.local.:30000/healthz
-        - -insecure
-        - -retries
-        - "100"
-        - -retry-wait
-        - "2"
-        - -timeout
-        - "1"
-        command:
+      - command:
+        - /bin/cp
         - /usr/local/bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.1
-        imagePullPolicy: IfNotPresent
-        name: apiserver-running
+        - /http-prober-bin/http-prober
+        image: quay.io/kubermatic/http-prober:v0.2-dev0
+        name: copy-http-prober
         resources: {}
-        terminationMessagePath: /dev/termination-log
-        terminationMessagePolicy: File
+        volumeMounts:
+        - mountPath: /http-prober-bin
+          name: http-prober-bin
       volumes:
       - name: openvpn-client-certificates
         secret:
@@ -198,4 +190,6 @@ spec:
         secret:
           defaultMode: 256
           secretName: scheduler-kubeconfig
+      - emptyDir: {}
+        name: http-prober-bin
 status: {}

--- a/api/pkg/resources/test/fixtures/deployment-digitalocean-1.13.0-scheduler.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-digitalocean-1.13.0-scheduler.yaml
@@ -168,7 +168,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.2-dev0
+        image: quay.io/kubermatic/http-prober:v0.2
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/api/pkg/resources/test/fixtures/deployment-digitalocean-1.13.0-usercluster-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-digitalocean-1.13.0-usercluster-controller.yaml
@@ -85,7 +85,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.2-dev0
+        image: quay.io/kubermatic/http-prober:v0.2
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/api/pkg/resources/test/fixtures/deployment-digitalocean-1.13.0-usercluster-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-digitalocean-1.13.0-usercluster-controller.yaml
@@ -29,32 +29,19 @@ spec:
     spec:
       containers:
       - args:
-        - -kubeconfig
-        - /etc/kubernetes/kubeconfig/kubeconfig
-        - -metrics-listen-address
-        - 0.0.0.0:8085
-        - -health-listen-address
-        - 0.0.0.0:8086
-        - -namespace
-        - $(NAMESPACE)
-        - -ca-cert
-        - /etc/kubernetes/pki/ca/ca.crt
-        - -cluster-url
-        - ""
-        - -openvpn-server-port
-        - "30003"
-        - -overwrite-registry
-        - ""
-        - -openshift=false
-        - -openvpn-ca-cert-file=/etc/kubernetes/pki/openvpn/ca.crt
-        - -openvpn-ca-key-file=/etc/kubernetes/pki/openvpn/ca.key
-        - -logtostderr
-        - -v
+        - -endpoint
+        - https://apiserver-external.cluster-de-test-01.svc.cluster.local.:30000/healthz
+        - -insecure
+        - -retries
+        - "100"
+        - -retry-wait
         - "2"
-        - --ipam-controller-network
-        - 192.168.1.1/24,192.168.1.1,8.8.8.8
+        - -timeout
+        - "1"
+        - -command
+        - '{"command":"/usr/local/bin/user-cluster-controller-manager","args":["-kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","-metrics-listen-address","0.0.0.0:8085","-health-listen-address","0.0.0.0:8086","-namespace","$(NAMESPACE)","-ca-cert","/etc/kubernetes/pki/ca/ca.crt","-cluster-url","","-openvpn-server-port","30003","-overwrite-registry","","-openshift=false","-openvpn-ca-cert-file=/etc/kubernetes/pki/openvpn/ca.crt","-openvpn-ca-key-file=/etc/kubernetes/pki/openvpn/ca.key","-logtostderr","-v","2","--ipam-controller-network","192.168.1.1/24,192.168.1.1,8.8.8.8"]}'
         command:
-        - /usr/local/bin/user-cluster-controller-manager
+        - /http-prober-bin/http-prober
         env:
         - name: NAMESPACE
           valueFrom:
@@ -89,27 +76,21 @@ spec:
         - mountPath: /etc/kubernetes/pki/openvpn
           name: openvpn-ca
           readOnly: true
+        - mountPath: /http-prober-bin
+          name: http-prober-bin
       imagePullSecrets:
       - name: dockercfg
       initContainers:
-      - args:
-        - -endpoint
-        - https://apiserver-external.cluster-de-test-01.svc.cluster.local.:30000/healthz
-        - -insecure
-        - -retries
-        - "100"
-        - -retry-wait
-        - "2"
-        - -timeout
-        - "1"
-        command:
+      - command:
+        - /bin/cp
         - /usr/local/bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.1
-        imagePullPolicy: IfNotPresent
-        name: apiserver-running
+        - /http-prober-bin/http-prober
+        image: quay.io/kubermatic/http-prober:v0.2-dev0
+        name: copy-http-prober
         resources: {}
-        terminationMessagePath: /dev/termination-log
-        terminationMessagePolicy: File
+        volumeMounts:
+        - mountPath: /http-prober-bin
+          name: http-prober-bin
       volumes:
       - name: internal-admin-kubeconfig
         secret:
@@ -126,4 +107,6 @@ spec:
         secret:
           defaultMode: 292
           secretName: openvpn-ca
+      - emptyDir: {}
+        name: http-prober-bin
 status: {}

--- a/api/pkg/resources/test/fixtures/deployment-openstack-1.10.0-controller-manager.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-openstack-1.10.0-controller-manager.yaml
@@ -176,7 +176,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.2-dev0
+        image: quay.io/kubermatic/http-prober:v0.2
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/api/pkg/resources/test/fixtures/deployment-openstack-1.10.0-controller-manager.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-openstack-1.10.0-controller-manager.yaml
@@ -102,32 +102,19 @@ spec:
           name: openvpn-client-certificates
           readOnly: true
       - args:
-        - --kubeconfig
-        - /etc/kubernetes/kubeconfig/kubeconfig
-        - --service-account-private-key-file
-        - /etc/kubernetes/service-account-key/sa.key
-        - --root-ca-file
-        - /etc/kubernetes/pki/ca/ca.crt
-        - --cluster-signing-cert-file
-        - /etc/kubernetes/pki/ca/ca.crt
-        - --cluster-signing-key-file
-        - /etc/kubernetes/pki/ca/ca.key
-        - --cluster-cidr
-        - 172.25.0.0/16
-        - --allocate-node-cidrs=true
-        - --controllers
-        - '*,bootstrapsigner,tokencleaner'
-        - --use-service-account-credentials=true
-        - --feature-gates
-        - RotateKubeletClientCertificate=true,RotateKubeletServerCertificate=true
-        - --cloud-provider
-        - openstack
-        - --cloud-config
-        - /etc/kubernetes/cloud/config
-        - --configure-cloud-routes=false
+        - -endpoint
+        - https://apiserver-external.cluster-de-test-01.svc.cluster.local.:30000/healthz
+        - -insecure
+        - -retries
+        - "100"
+        - -retry-wait
+        - "2"
+        - -timeout
+        - "1"
+        - -command
+        - '{"command":"/hyperkube","args":["kube-controller-manager","--kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","--service-account-private-key-file","/etc/kubernetes/service-account-key/sa.key","--root-ca-file","/etc/kubernetes/pki/ca/ca.crt","--cluster-signing-cert-file","/etc/kubernetes/pki/ca/ca.crt","--cluster-signing-key-file","/etc/kubernetes/pki/ca/ca.key","--cluster-cidr","172.25.0.0/16","--allocate-node-cidrs=true","--controllers","*,bootstrapsigner,tokencleaner","--use-service-account-credentials=true","--feature-gates","RotateKubeletClientCertificate=true,RotateKubeletServerCertificate=true","--cloud-provider","openstack","--cloud-config","/etc/kubernetes/cloud/config","--configure-cloud-routes=false"]}'
         command:
-        - /hyperkube
-        - kube-controller-manager
+        - /http-prober-bin/http-prober
         image: gcr.io/google_containers/hyperkube-amd64:v1.10.0
         livenessProbe:
           failureThreshold: 8
@@ -169,6 +156,8 @@ spec:
         - mountPath: /etc/kubernetes/kubeconfig
           name: controllermanager-kubeconfig
           readOnly: true
+        - mountPath: /http-prober-bin
+          name: http-prober-bin
       dnsConfig:
         nameservers:
         - 192.0.2.14
@@ -183,24 +172,16 @@ spec:
       imagePullSecrets:
       - name: dockercfg
       initContainers:
-      - args:
-        - -endpoint
-        - https://apiserver-external.cluster-de-test-01.svc.cluster.local.:30000/healthz
-        - -insecure
-        - -retries
-        - "100"
-        - -retry-wait
-        - "2"
-        - -timeout
-        - "1"
-        command:
+      - command:
+        - /bin/cp
         - /usr/local/bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.1
-        imagePullPolicy: IfNotPresent
-        name: apiserver-running
+        - /http-prober-bin/http-prober
+        image: quay.io/kubermatic/http-prober:v0.2-dev0
+        name: copy-http-prober
         resources: {}
-        terminationMessagePath: /dev/termination-log
-        terminationMessagePolicy: File
+        volumeMounts:
+        - mountPath: /http-prober-bin
+          name: http-prober-bin
       volumes:
       - name: ca
         secret:
@@ -222,4 +203,6 @@ spec:
         secret:
           defaultMode: 256
           secretName: controllermanager-kubeconfig
+      - emptyDir: {}
+        name: http-prober-bin
 status: {}

--- a/api/pkg/resources/test/fixtures/deployment-openstack-1.10.0-kube-state-metrics.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-openstack-1.10.0-kube-state-metrics.yaml
@@ -21,14 +21,19 @@ spec:
     spec:
       containers:
       - args:
-        - --kubeconfig
-        - /etc/kubernetes/kubeconfig/kubeconfig
-        - --port
-        - "8080"
-        - --telemetry-port
-        - "8081"
+        - -endpoint
+        - https://apiserver-external.cluster-de-test-01.svc.cluster.local.:30000/healthz
+        - -insecure
+        - -retries
+        - "100"
+        - -retry-wait
+        - "2"
+        - -timeout
+        - "1"
+        - -command
+        - '{"command":"/kube-state-metrics","args":["--kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","--port","8080","--telemetry-port","8081"]}'
         command:
-        - /kube-state-metrics
+        - /http-prober-bin/http-prober
         image: quay.io/coreos/kube-state-metrics:v1.6.0
         name: kube-state-metrics
         ports:
@@ -58,30 +63,26 @@ spec:
         - mountPath: /etc/kubernetes/kubeconfig
           name: kube-state-metrics-kubeconfig
           readOnly: true
+        - mountPath: /http-prober-bin
+          name: http-prober-bin
       imagePullSecrets:
       - name: dockercfg
       initContainers:
-      - args:
-        - -endpoint
-        - https://apiserver-external.cluster-de-test-01.svc.cluster.local.:30000/healthz
-        - -insecure
-        - -retries
-        - "100"
-        - -retry-wait
-        - "2"
-        - -timeout
-        - "1"
-        command:
+      - command:
+        - /bin/cp
         - /usr/local/bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.1
-        imagePullPolicy: IfNotPresent
-        name: apiserver-running
+        - /http-prober-bin/http-prober
+        image: quay.io/kubermatic/http-prober:v0.2-dev0
+        name: copy-http-prober
         resources: {}
-        terminationMessagePath: /dev/termination-log
-        terminationMessagePolicy: File
+        volumeMounts:
+        - mountPath: /http-prober-bin
+          name: http-prober-bin
       volumes:
       - name: kube-state-metrics-kubeconfig
         secret:
           defaultMode: 256
           secretName: kube-state-metrics-kubeconfig
+      - emptyDir: {}
+        name: http-prober-bin
 status: {}

--- a/api/pkg/resources/test/fixtures/deployment-openstack-1.10.0-kube-state-metrics.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-openstack-1.10.0-kube-state-metrics.yaml
@@ -72,7 +72,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.2-dev0
+        image: quay.io/kubermatic/http-prober:v0.2
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/api/pkg/resources/test/fixtures/deployment-openstack-1.10.0-machine-controller-webhook.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-openstack-1.10.0-machine-controller-webhook.yaml
@@ -24,15 +24,19 @@ spec:
     spec:
       containers:
       - args:
-        - -kubeconfig
-        - /etc/kubernetes/kubeconfig/kubeconfig
-        - -logtostderr
-        - -v
-        - "4"
-        - -listen-address
-        - 0.0.0.0:9876
+        - -endpoint
+        - https://apiserver-external.cluster-de-test-01.svc.cluster.local.:30000/healthz
+        - -insecure
+        - -retries
+        - "100"
+        - -retry-wait
+        - "2"
+        - -timeout
+        - "1"
+        - -command
+        - '{"command":"/usr/local/bin/webhook","args":["-kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","-logtostderr","-v","4","-listen-address","0.0.0.0:9876"]}'
         command:
-        - /usr/local/bin/webhook
+        - /http-prober-bin/http-prober
         env:
         - name: OS_AUTH_URL
           value: https://example.com:8000/v3
@@ -79,27 +83,21 @@ spec:
         - mountPath: /tmp/cert
           name: machinecontroller-webhook-serving-cert
           readOnly: true
+        - mountPath: /http-prober-bin
+          name: http-prober-bin
       imagePullSecrets:
       - name: dockercfg
       initContainers:
-      - args:
-        - -endpoint
-        - https://apiserver-external.cluster-de-test-01.svc.cluster.local.:30000/healthz
-        - -insecure
-        - -retries
-        - "100"
-        - -retry-wait
-        - "2"
-        - -timeout
-        - "1"
-        command:
+      - command:
+        - /bin/cp
         - /usr/local/bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.1
-        imagePullPolicy: IfNotPresent
-        name: apiserver-running
+        - /http-prober-bin/http-prober
+        image: quay.io/kubermatic/http-prober:v0.2-dev0
+        name: copy-http-prober
         resources: {}
-        terminationMessagePath: /dev/termination-log
-        terminationMessagePolicy: File
+        volumeMounts:
+        - mountPath: /http-prober-bin
+          name: http-prober-bin
       volumes:
       - name: machinecontroller-kubeconfig
         secret:
@@ -109,4 +107,6 @@ spec:
         secret:
           defaultMode: 292
           secretName: machinecontroller-webhook-serving-cert
+      - emptyDir: {}
+        name: http-prober-bin
 status: {}

--- a/api/pkg/resources/test/fixtures/deployment-openstack-1.10.0-machine-controller-webhook.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-openstack-1.10.0-machine-controller-webhook.yaml
@@ -92,7 +92,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.2-dev0
+        image: quay.io/kubermatic/http-prober:v0.2
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/api/pkg/resources/test/fixtures/deployment-openstack-1.10.0-machine-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-openstack-1.10.0-machine-controller.yaml
@@ -27,17 +27,19 @@ spec:
     spec:
       containers:
       - args:
-        - -kubeconfig
-        - /etc/kubernetes/kubeconfig/kubeconfig
-        - -logtostderr
-        - -v
-        - "4"
-        - -cluster-dns
-        - 169.254.20.10
-        - -internal-listen-address
-        - 0.0.0.0:8085
+        - -endpoint
+        - https://apiserver-external.cluster-de-test-01.svc.cluster.local.:30000/healthz
+        - -insecure
+        - -retries
+        - "100"
+        - -retry-wait
+        - "2"
+        - -timeout
+        - "1"
+        - -command
+        - '{"command":"/usr/local/bin/machine-controller","args":["-kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","-logtostderr","-v","4","-cluster-dns","169.254.20.10","-internal-listen-address","0.0.0.0:8085"]}'
         command:
-        - /usr/local/bin/machine-controller
+        - /http-prober-bin/http-prober
         env:
         - name: OS_AUTH_URL
           value: https://example.com:8000/v3
@@ -72,30 +74,26 @@ spec:
         - mountPath: /etc/kubernetes/kubeconfig
           name: machinecontroller-kubeconfig
           readOnly: true
+        - mountPath: /http-prober-bin
+          name: http-prober-bin
       imagePullSecrets:
       - name: dockercfg
       initContainers:
-      - args:
-        - -endpoint
-        - https://apiserver-external.cluster-de-test-01.svc.cluster.local.:30000/healthz
-        - -insecure
-        - -retries
-        - "100"
-        - -retry-wait
-        - "2"
-        - -timeout
-        - "1"
-        command:
+      - command:
+        - /bin/cp
         - /usr/local/bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.1
-        imagePullPolicy: IfNotPresent
-        name: apiserver-running
+        - /http-prober-bin/http-prober
+        image: quay.io/kubermatic/http-prober:v0.2-dev0
+        name: copy-http-prober
         resources: {}
-        terminationMessagePath: /dev/termination-log
-        terminationMessagePolicy: File
+        volumeMounts:
+        - mountPath: /http-prober-bin
+          name: http-prober-bin
       volumes:
       - name: machinecontroller-kubeconfig
         secret:
           defaultMode: 292
           secretName: machinecontroller-kubeconfig
+      - emptyDir: {}
+        name: http-prober-bin
 status: {}

--- a/api/pkg/resources/test/fixtures/deployment-openstack-1.10.0-machine-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-openstack-1.10.0-machine-controller.yaml
@@ -83,7 +83,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.2-dev0
+        image: quay.io/kubermatic/http-prober:v0.2
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/api/pkg/resources/test/fixtures/deployment-openstack-1.10.0-metrics-server.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-openstack-1.10.0-metrics-server.yaml
@@ -41,22 +41,19 @@ spec:
             weight: 10
       containers:
       - args:
-        - --kubeconfig
-        - /etc/kubernetes/kubeconfig/kubeconfig
-        - --authentication-kubeconfig
-        - /etc/kubernetes/kubeconfig/kubeconfig
-        - --authorization-kubeconfig
-        - /etc/kubernetes/kubeconfig/kubeconfig
-        - --kubelet-port
-        - "10250"
-        - --kubelet-insecure-tls
-        - --kubelet-preferred-address-types
-        - ExternalIP,InternalIP
-        - --v
+        - -endpoint
+        - https://apiserver-external.cluster-de-test-01.svc.cluster.local.:30000/healthz
+        - -insecure
+        - -retries
+        - "100"
+        - -retry-wait
+        - "2"
+        - -timeout
         - "1"
-        - --logtostderr
+        - -command
+        - '{"command":"/metrics-server","args":["--kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","--authentication-kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","--authorization-kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","--kubelet-port","10250","--kubelet-insecure-tls","--kubelet-preferred-address-types","ExternalIP,InternalIP","--v","1","--logtostderr"]}'
         command:
-        - /metrics-server
+        - /http-prober-bin/http-prober
         image: gcr.io/google_containers/metrics-server-amd64:v0.3.2
         name: metrics-server
         resources:
@@ -70,6 +67,8 @@ spec:
         - mountPath: /etc/kubernetes/kubeconfig
           name: metrics-server
           readOnly: true
+        - mountPath: /http-prober-bin
+          name: http-prober-bin
       - args:
         - --client
         - --proto
@@ -158,24 +157,16 @@ spec:
       imagePullSecrets:
       - name: dockercfg
       initContainers:
-      - args:
-        - -endpoint
-        - https://apiserver-external.cluster-de-test-01.svc.cluster.local.:30000/healthz
-        - -insecure
-        - -retries
-        - "100"
-        - -retry-wait
-        - "2"
-        - -timeout
-        - "1"
-        command:
+      - command:
+        - /bin/cp
         - /usr/local/bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.1
-        imagePullPolicy: IfNotPresent
-        name: apiserver-running
+        - /http-prober-bin/http-prober
+        image: quay.io/kubermatic/http-prober:v0.2-dev0
+        name: copy-http-prober
         resources: {}
-        terminationMessagePath: /dev/termination-log
-        terminationMessagePolicy: File
+        volumeMounts:
+        - mountPath: /http-prober-bin
+          name: http-prober-bin
       volumes:
       - name: metrics-server
         secret:
@@ -189,4 +180,6 @@ spec:
         secret:
           defaultMode: 292
           secretName: kubeletdnatcontroller-kubeconfig
+      - emptyDir: {}
+        name: http-prober-bin
 status: {}

--- a/api/pkg/resources/test/fixtures/deployment-openstack-1.10.0-metrics-server.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-openstack-1.10.0-metrics-server.yaml
@@ -161,7 +161,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.2-dev0
+        image: quay.io/kubermatic/http-prober:v0.2
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/api/pkg/resources/test/fixtures/deployment-openstack-1.10.0-scheduler.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-openstack-1.10.0-scheduler.yaml
@@ -100,11 +100,19 @@ spec:
           name: openvpn-client-certificates
           readOnly: true
       - args:
-        - --kubeconfig
-        - /etc/kubernetes/kubeconfig/kubeconfig
+        - -endpoint
+        - https://apiserver-external.cluster-de-test-01.svc.cluster.local.:30000/healthz
+        - -insecure
+        - -retries
+        - "100"
+        - -retry-wait
+        - "2"
+        - -timeout
+        - "1"
+        - -command
+        - '{"command":"/hyperkube","args":["kube-scheduler","--kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig"]}'
         command:
-        - /hyperkube
-        - kube-scheduler
+        - /http-prober-bin/http-prober
         image: gcr.io/google_containers/hyperkube-amd64:v1.10.0
         livenessProbe:
           failureThreshold: 8
@@ -140,6 +148,8 @@ spec:
         - mountPath: /etc/kubernetes/pki/ca
           name: ca
           readOnly: true
+        - mountPath: /http-prober-bin
+          name: http-prober-bin
       dnsConfig:
         nameservers:
         - 192.0.2.14
@@ -154,24 +164,16 @@ spec:
       imagePullSecrets:
       - name: dockercfg
       initContainers:
-      - args:
-        - -endpoint
-        - https://apiserver-external.cluster-de-test-01.svc.cluster.local.:30000/healthz
-        - -insecure
-        - -retries
-        - "100"
-        - -retry-wait
-        - "2"
-        - -timeout
-        - "1"
-        command:
+      - command:
+        - /bin/cp
         - /usr/local/bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.1
-        imagePullPolicy: IfNotPresent
-        name: apiserver-running
+        - /http-prober-bin/http-prober
+        image: quay.io/kubermatic/http-prober:v0.2-dev0
+        name: copy-http-prober
         resources: {}
-        terminationMessagePath: /dev/termination-log
-        terminationMessagePolicy: File
+        volumeMounts:
+        - mountPath: /http-prober-bin
+          name: http-prober-bin
       volumes:
       - name: openvpn-client-certificates
         secret:
@@ -188,4 +190,6 @@ spec:
         secret:
           defaultMode: 256
           secretName: scheduler-kubeconfig
+      - emptyDir: {}
+        name: http-prober-bin
 status: {}

--- a/api/pkg/resources/test/fixtures/deployment-openstack-1.10.0-scheduler.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-openstack-1.10.0-scheduler.yaml
@@ -168,7 +168,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.2-dev0
+        image: quay.io/kubermatic/http-prober:v0.2
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/api/pkg/resources/test/fixtures/deployment-openstack-1.10.0-usercluster-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-openstack-1.10.0-usercluster-controller.yaml
@@ -85,7 +85,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.2-dev0
+        image: quay.io/kubermatic/http-prober:v0.2
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/api/pkg/resources/test/fixtures/deployment-openstack-1.10.0-usercluster-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-openstack-1.10.0-usercluster-controller.yaml
@@ -29,32 +29,19 @@ spec:
     spec:
       containers:
       - args:
-        - -kubeconfig
-        - /etc/kubernetes/kubeconfig/kubeconfig
-        - -metrics-listen-address
-        - 0.0.0.0:8085
-        - -health-listen-address
-        - 0.0.0.0:8086
-        - -namespace
-        - $(NAMESPACE)
-        - -ca-cert
-        - /etc/kubernetes/pki/ca/ca.crt
-        - -cluster-url
-        - ""
-        - -openvpn-server-port
-        - "30003"
-        - -overwrite-registry
-        - ""
-        - -openshift=false
-        - -openvpn-ca-cert-file=/etc/kubernetes/pki/openvpn/ca.crt
-        - -openvpn-ca-key-file=/etc/kubernetes/pki/openvpn/ca.key
-        - -logtostderr
-        - -v
+        - -endpoint
+        - https://apiserver-external.cluster-de-test-01.svc.cluster.local.:30000/healthz
+        - -insecure
+        - -retries
+        - "100"
+        - -retry-wait
         - "2"
-        - --ipam-controller-network
-        - 192.168.1.1/24,192.168.1.1,8.8.8.8
+        - -timeout
+        - "1"
+        - -command
+        - '{"command":"/usr/local/bin/user-cluster-controller-manager","args":["-kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","-metrics-listen-address","0.0.0.0:8085","-health-listen-address","0.0.0.0:8086","-namespace","$(NAMESPACE)","-ca-cert","/etc/kubernetes/pki/ca/ca.crt","-cluster-url","","-openvpn-server-port","30003","-overwrite-registry","","-openshift=false","-openvpn-ca-cert-file=/etc/kubernetes/pki/openvpn/ca.crt","-openvpn-ca-key-file=/etc/kubernetes/pki/openvpn/ca.key","-logtostderr","-v","2","--ipam-controller-network","192.168.1.1/24,192.168.1.1,8.8.8.8"]}'
         command:
-        - /usr/local/bin/user-cluster-controller-manager
+        - /http-prober-bin/http-prober
         env:
         - name: NAMESPACE
           valueFrom:
@@ -89,27 +76,21 @@ spec:
         - mountPath: /etc/kubernetes/pki/openvpn
           name: openvpn-ca
           readOnly: true
+        - mountPath: /http-prober-bin
+          name: http-prober-bin
       imagePullSecrets:
       - name: dockercfg
       initContainers:
-      - args:
-        - -endpoint
-        - https://apiserver-external.cluster-de-test-01.svc.cluster.local.:30000/healthz
-        - -insecure
-        - -retries
-        - "100"
-        - -retry-wait
-        - "2"
-        - -timeout
-        - "1"
-        command:
+      - command:
+        - /bin/cp
         - /usr/local/bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.1
-        imagePullPolicy: IfNotPresent
-        name: apiserver-running
+        - /http-prober-bin/http-prober
+        image: quay.io/kubermatic/http-prober:v0.2-dev0
+        name: copy-http-prober
         resources: {}
-        terminationMessagePath: /dev/termination-log
-        terminationMessagePolicy: File
+        volumeMounts:
+        - mountPath: /http-prober-bin
+          name: http-prober-bin
       volumes:
       - name: internal-admin-kubeconfig
         secret:
@@ -126,4 +107,6 @@ spec:
         secret:
           defaultMode: 292
           secretName: openvpn-ca
+      - emptyDir: {}
+        name: http-prober-bin
 status: {}

--- a/api/pkg/resources/test/fixtures/deployment-openstack-1.10.6-controller-manager.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-openstack-1.10.6-controller-manager.yaml
@@ -176,7 +176,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.2-dev0
+        image: quay.io/kubermatic/http-prober:v0.2
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/api/pkg/resources/test/fixtures/deployment-openstack-1.10.6-controller-manager.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-openstack-1.10.6-controller-manager.yaml
@@ -102,32 +102,19 @@ spec:
           name: openvpn-client-certificates
           readOnly: true
       - args:
-        - --kubeconfig
-        - /etc/kubernetes/kubeconfig/kubeconfig
-        - --service-account-private-key-file
-        - /etc/kubernetes/service-account-key/sa.key
-        - --root-ca-file
-        - /etc/kubernetes/pki/ca/ca.crt
-        - --cluster-signing-cert-file
-        - /etc/kubernetes/pki/ca/ca.crt
-        - --cluster-signing-key-file
-        - /etc/kubernetes/pki/ca/ca.key
-        - --cluster-cidr
-        - 172.25.0.0/16
-        - --allocate-node-cidrs=true
-        - --controllers
-        - '*,bootstrapsigner,tokencleaner'
-        - --use-service-account-credentials=true
-        - --feature-gates
-        - RotateKubeletClientCertificate=true,RotateKubeletServerCertificate=true
-        - --cloud-provider
-        - openstack
-        - --cloud-config
-        - /etc/kubernetes/cloud/config
-        - --configure-cloud-routes=false
+        - -endpoint
+        - https://apiserver-external.cluster-de-test-01.svc.cluster.local.:30000/healthz
+        - -insecure
+        - -retries
+        - "100"
+        - -retry-wait
+        - "2"
+        - -timeout
+        - "1"
+        - -command
+        - '{"command":"/hyperkube","args":["kube-controller-manager","--kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","--service-account-private-key-file","/etc/kubernetes/service-account-key/sa.key","--root-ca-file","/etc/kubernetes/pki/ca/ca.crt","--cluster-signing-cert-file","/etc/kubernetes/pki/ca/ca.crt","--cluster-signing-key-file","/etc/kubernetes/pki/ca/ca.key","--cluster-cidr","172.25.0.0/16","--allocate-node-cidrs=true","--controllers","*,bootstrapsigner,tokencleaner","--use-service-account-credentials=true","--feature-gates","RotateKubeletClientCertificate=true,RotateKubeletServerCertificate=true","--cloud-provider","openstack","--cloud-config","/etc/kubernetes/cloud/config","--configure-cloud-routes=false"]}'
         command:
-        - /hyperkube
-        - kube-controller-manager
+        - /http-prober-bin/http-prober
         image: gcr.io/google_containers/hyperkube-amd64:v1.10.6
         livenessProbe:
           failureThreshold: 8
@@ -169,6 +156,8 @@ spec:
         - mountPath: /etc/kubernetes/kubeconfig
           name: controllermanager-kubeconfig
           readOnly: true
+        - mountPath: /http-prober-bin
+          name: http-prober-bin
       dnsConfig:
         nameservers:
         - 192.0.2.14
@@ -183,24 +172,16 @@ spec:
       imagePullSecrets:
       - name: dockercfg
       initContainers:
-      - args:
-        - -endpoint
-        - https://apiserver-external.cluster-de-test-01.svc.cluster.local.:30000/healthz
-        - -insecure
-        - -retries
-        - "100"
-        - -retry-wait
-        - "2"
-        - -timeout
-        - "1"
-        command:
+      - command:
+        - /bin/cp
         - /usr/local/bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.1
-        imagePullPolicy: IfNotPresent
-        name: apiserver-running
+        - /http-prober-bin/http-prober
+        image: quay.io/kubermatic/http-prober:v0.2-dev0
+        name: copy-http-prober
         resources: {}
-        terminationMessagePath: /dev/termination-log
-        terminationMessagePolicy: File
+        volumeMounts:
+        - mountPath: /http-prober-bin
+          name: http-prober-bin
       volumes:
       - name: ca
         secret:
@@ -222,4 +203,6 @@ spec:
         secret:
           defaultMode: 256
           secretName: controllermanager-kubeconfig
+      - emptyDir: {}
+        name: http-prober-bin
 status: {}

--- a/api/pkg/resources/test/fixtures/deployment-openstack-1.10.6-kube-state-metrics.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-openstack-1.10.6-kube-state-metrics.yaml
@@ -21,14 +21,19 @@ spec:
     spec:
       containers:
       - args:
-        - --kubeconfig
-        - /etc/kubernetes/kubeconfig/kubeconfig
-        - --port
-        - "8080"
-        - --telemetry-port
-        - "8081"
+        - -endpoint
+        - https://apiserver-external.cluster-de-test-01.svc.cluster.local.:30000/healthz
+        - -insecure
+        - -retries
+        - "100"
+        - -retry-wait
+        - "2"
+        - -timeout
+        - "1"
+        - -command
+        - '{"command":"/kube-state-metrics","args":["--kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","--port","8080","--telemetry-port","8081"]}'
         command:
-        - /kube-state-metrics
+        - /http-prober-bin/http-prober
         image: quay.io/coreos/kube-state-metrics:v1.6.0
         name: kube-state-metrics
         ports:
@@ -58,30 +63,26 @@ spec:
         - mountPath: /etc/kubernetes/kubeconfig
           name: kube-state-metrics-kubeconfig
           readOnly: true
+        - mountPath: /http-prober-bin
+          name: http-prober-bin
       imagePullSecrets:
       - name: dockercfg
       initContainers:
-      - args:
-        - -endpoint
-        - https://apiserver-external.cluster-de-test-01.svc.cluster.local.:30000/healthz
-        - -insecure
-        - -retries
-        - "100"
-        - -retry-wait
-        - "2"
-        - -timeout
-        - "1"
-        command:
+      - command:
+        - /bin/cp
         - /usr/local/bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.1
-        imagePullPolicy: IfNotPresent
-        name: apiserver-running
+        - /http-prober-bin/http-prober
+        image: quay.io/kubermatic/http-prober:v0.2-dev0
+        name: copy-http-prober
         resources: {}
-        terminationMessagePath: /dev/termination-log
-        terminationMessagePolicy: File
+        volumeMounts:
+        - mountPath: /http-prober-bin
+          name: http-prober-bin
       volumes:
       - name: kube-state-metrics-kubeconfig
         secret:
           defaultMode: 256
           secretName: kube-state-metrics-kubeconfig
+      - emptyDir: {}
+        name: http-prober-bin
 status: {}

--- a/api/pkg/resources/test/fixtures/deployment-openstack-1.10.6-kube-state-metrics.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-openstack-1.10.6-kube-state-metrics.yaml
@@ -72,7 +72,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.2-dev0
+        image: quay.io/kubermatic/http-prober:v0.2
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/api/pkg/resources/test/fixtures/deployment-openstack-1.10.6-machine-controller-webhook.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-openstack-1.10.6-machine-controller-webhook.yaml
@@ -24,15 +24,19 @@ spec:
     spec:
       containers:
       - args:
-        - -kubeconfig
-        - /etc/kubernetes/kubeconfig/kubeconfig
-        - -logtostderr
-        - -v
-        - "4"
-        - -listen-address
-        - 0.0.0.0:9876
+        - -endpoint
+        - https://apiserver-external.cluster-de-test-01.svc.cluster.local.:30000/healthz
+        - -insecure
+        - -retries
+        - "100"
+        - -retry-wait
+        - "2"
+        - -timeout
+        - "1"
+        - -command
+        - '{"command":"/usr/local/bin/webhook","args":["-kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","-logtostderr","-v","4","-listen-address","0.0.0.0:9876"]}'
         command:
-        - /usr/local/bin/webhook
+        - /http-prober-bin/http-prober
         env:
         - name: OS_AUTH_URL
           value: https://example.com:8000/v3
@@ -79,27 +83,21 @@ spec:
         - mountPath: /tmp/cert
           name: machinecontroller-webhook-serving-cert
           readOnly: true
+        - mountPath: /http-prober-bin
+          name: http-prober-bin
       imagePullSecrets:
       - name: dockercfg
       initContainers:
-      - args:
-        - -endpoint
-        - https://apiserver-external.cluster-de-test-01.svc.cluster.local.:30000/healthz
-        - -insecure
-        - -retries
-        - "100"
-        - -retry-wait
-        - "2"
-        - -timeout
-        - "1"
-        command:
+      - command:
+        - /bin/cp
         - /usr/local/bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.1
-        imagePullPolicy: IfNotPresent
-        name: apiserver-running
+        - /http-prober-bin/http-prober
+        image: quay.io/kubermatic/http-prober:v0.2-dev0
+        name: copy-http-prober
         resources: {}
-        terminationMessagePath: /dev/termination-log
-        terminationMessagePolicy: File
+        volumeMounts:
+        - mountPath: /http-prober-bin
+          name: http-prober-bin
       volumes:
       - name: machinecontroller-kubeconfig
         secret:
@@ -109,4 +107,6 @@ spec:
         secret:
           defaultMode: 292
           secretName: machinecontroller-webhook-serving-cert
+      - emptyDir: {}
+        name: http-prober-bin
 status: {}

--- a/api/pkg/resources/test/fixtures/deployment-openstack-1.10.6-machine-controller-webhook.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-openstack-1.10.6-machine-controller-webhook.yaml
@@ -92,7 +92,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.2-dev0
+        image: quay.io/kubermatic/http-prober:v0.2
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/api/pkg/resources/test/fixtures/deployment-openstack-1.10.6-machine-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-openstack-1.10.6-machine-controller.yaml
@@ -27,17 +27,19 @@ spec:
     spec:
       containers:
       - args:
-        - -kubeconfig
-        - /etc/kubernetes/kubeconfig/kubeconfig
-        - -logtostderr
-        - -v
-        - "4"
-        - -cluster-dns
-        - 169.254.20.10
-        - -internal-listen-address
-        - 0.0.0.0:8085
+        - -endpoint
+        - https://apiserver-external.cluster-de-test-01.svc.cluster.local.:30000/healthz
+        - -insecure
+        - -retries
+        - "100"
+        - -retry-wait
+        - "2"
+        - -timeout
+        - "1"
+        - -command
+        - '{"command":"/usr/local/bin/machine-controller","args":["-kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","-logtostderr","-v","4","-cluster-dns","169.254.20.10","-internal-listen-address","0.0.0.0:8085"]}'
         command:
-        - /usr/local/bin/machine-controller
+        - /http-prober-bin/http-prober
         env:
         - name: OS_AUTH_URL
           value: https://example.com:8000/v3
@@ -72,30 +74,26 @@ spec:
         - mountPath: /etc/kubernetes/kubeconfig
           name: machinecontroller-kubeconfig
           readOnly: true
+        - mountPath: /http-prober-bin
+          name: http-prober-bin
       imagePullSecrets:
       - name: dockercfg
       initContainers:
-      - args:
-        - -endpoint
-        - https://apiserver-external.cluster-de-test-01.svc.cluster.local.:30000/healthz
-        - -insecure
-        - -retries
-        - "100"
-        - -retry-wait
-        - "2"
-        - -timeout
-        - "1"
-        command:
+      - command:
+        - /bin/cp
         - /usr/local/bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.1
-        imagePullPolicy: IfNotPresent
-        name: apiserver-running
+        - /http-prober-bin/http-prober
+        image: quay.io/kubermatic/http-prober:v0.2-dev0
+        name: copy-http-prober
         resources: {}
-        terminationMessagePath: /dev/termination-log
-        terminationMessagePolicy: File
+        volumeMounts:
+        - mountPath: /http-prober-bin
+          name: http-prober-bin
       volumes:
       - name: machinecontroller-kubeconfig
         secret:
           defaultMode: 292
           secretName: machinecontroller-kubeconfig
+      - emptyDir: {}
+        name: http-prober-bin
 status: {}

--- a/api/pkg/resources/test/fixtures/deployment-openstack-1.10.6-machine-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-openstack-1.10.6-machine-controller.yaml
@@ -83,7 +83,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.2-dev0
+        image: quay.io/kubermatic/http-prober:v0.2
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/api/pkg/resources/test/fixtures/deployment-openstack-1.10.6-metrics-server.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-openstack-1.10.6-metrics-server.yaml
@@ -41,22 +41,19 @@ spec:
             weight: 10
       containers:
       - args:
-        - --kubeconfig
-        - /etc/kubernetes/kubeconfig/kubeconfig
-        - --authentication-kubeconfig
-        - /etc/kubernetes/kubeconfig/kubeconfig
-        - --authorization-kubeconfig
-        - /etc/kubernetes/kubeconfig/kubeconfig
-        - --kubelet-port
-        - "10250"
-        - --kubelet-insecure-tls
-        - --kubelet-preferred-address-types
-        - ExternalIP,InternalIP
-        - --v
+        - -endpoint
+        - https://apiserver-external.cluster-de-test-01.svc.cluster.local.:30000/healthz
+        - -insecure
+        - -retries
+        - "100"
+        - -retry-wait
+        - "2"
+        - -timeout
         - "1"
-        - --logtostderr
+        - -command
+        - '{"command":"/metrics-server","args":["--kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","--authentication-kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","--authorization-kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","--kubelet-port","10250","--kubelet-insecure-tls","--kubelet-preferred-address-types","ExternalIP,InternalIP","--v","1","--logtostderr"]}'
         command:
-        - /metrics-server
+        - /http-prober-bin/http-prober
         image: gcr.io/google_containers/metrics-server-amd64:v0.3.2
         name: metrics-server
         resources:
@@ -70,6 +67,8 @@ spec:
         - mountPath: /etc/kubernetes/kubeconfig
           name: metrics-server
           readOnly: true
+        - mountPath: /http-prober-bin
+          name: http-prober-bin
       - args:
         - --client
         - --proto
@@ -158,24 +157,16 @@ spec:
       imagePullSecrets:
       - name: dockercfg
       initContainers:
-      - args:
-        - -endpoint
-        - https://apiserver-external.cluster-de-test-01.svc.cluster.local.:30000/healthz
-        - -insecure
-        - -retries
-        - "100"
-        - -retry-wait
-        - "2"
-        - -timeout
-        - "1"
-        command:
+      - command:
+        - /bin/cp
         - /usr/local/bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.1
-        imagePullPolicy: IfNotPresent
-        name: apiserver-running
+        - /http-prober-bin/http-prober
+        image: quay.io/kubermatic/http-prober:v0.2-dev0
+        name: copy-http-prober
         resources: {}
-        terminationMessagePath: /dev/termination-log
-        terminationMessagePolicy: File
+        volumeMounts:
+        - mountPath: /http-prober-bin
+          name: http-prober-bin
       volumes:
       - name: metrics-server
         secret:
@@ -189,4 +180,6 @@ spec:
         secret:
           defaultMode: 292
           secretName: kubeletdnatcontroller-kubeconfig
+      - emptyDir: {}
+        name: http-prober-bin
 status: {}

--- a/api/pkg/resources/test/fixtures/deployment-openstack-1.10.6-metrics-server.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-openstack-1.10.6-metrics-server.yaml
@@ -161,7 +161,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.2-dev0
+        image: quay.io/kubermatic/http-prober:v0.2
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/api/pkg/resources/test/fixtures/deployment-openstack-1.10.6-scheduler.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-openstack-1.10.6-scheduler.yaml
@@ -100,11 +100,19 @@ spec:
           name: openvpn-client-certificates
           readOnly: true
       - args:
-        - --kubeconfig
-        - /etc/kubernetes/kubeconfig/kubeconfig
+        - -endpoint
+        - https://apiserver-external.cluster-de-test-01.svc.cluster.local.:30000/healthz
+        - -insecure
+        - -retries
+        - "100"
+        - -retry-wait
+        - "2"
+        - -timeout
+        - "1"
+        - -command
+        - '{"command":"/hyperkube","args":["kube-scheduler","--kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig"]}'
         command:
-        - /hyperkube
-        - kube-scheduler
+        - /http-prober-bin/http-prober
         image: gcr.io/google_containers/hyperkube-amd64:v1.10.6
         livenessProbe:
           failureThreshold: 8
@@ -140,6 +148,8 @@ spec:
         - mountPath: /etc/kubernetes/pki/ca
           name: ca
           readOnly: true
+        - mountPath: /http-prober-bin
+          name: http-prober-bin
       dnsConfig:
         nameservers:
         - 192.0.2.14
@@ -154,24 +164,16 @@ spec:
       imagePullSecrets:
       - name: dockercfg
       initContainers:
-      - args:
-        - -endpoint
-        - https://apiserver-external.cluster-de-test-01.svc.cluster.local.:30000/healthz
-        - -insecure
-        - -retries
-        - "100"
-        - -retry-wait
-        - "2"
-        - -timeout
-        - "1"
-        command:
+      - command:
+        - /bin/cp
         - /usr/local/bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.1
-        imagePullPolicy: IfNotPresent
-        name: apiserver-running
+        - /http-prober-bin/http-prober
+        image: quay.io/kubermatic/http-prober:v0.2-dev0
+        name: copy-http-prober
         resources: {}
-        terminationMessagePath: /dev/termination-log
-        terminationMessagePolicy: File
+        volumeMounts:
+        - mountPath: /http-prober-bin
+          name: http-prober-bin
       volumes:
       - name: openvpn-client-certificates
         secret:
@@ -188,4 +190,6 @@ spec:
         secret:
           defaultMode: 256
           secretName: scheduler-kubeconfig
+      - emptyDir: {}
+        name: http-prober-bin
 status: {}

--- a/api/pkg/resources/test/fixtures/deployment-openstack-1.10.6-scheduler.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-openstack-1.10.6-scheduler.yaml
@@ -168,7 +168,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.2-dev0
+        image: quay.io/kubermatic/http-prober:v0.2
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/api/pkg/resources/test/fixtures/deployment-openstack-1.10.6-usercluster-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-openstack-1.10.6-usercluster-controller.yaml
@@ -85,7 +85,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.2-dev0
+        image: quay.io/kubermatic/http-prober:v0.2
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/api/pkg/resources/test/fixtures/deployment-openstack-1.10.6-usercluster-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-openstack-1.10.6-usercluster-controller.yaml
@@ -29,32 +29,19 @@ spec:
     spec:
       containers:
       - args:
-        - -kubeconfig
-        - /etc/kubernetes/kubeconfig/kubeconfig
-        - -metrics-listen-address
-        - 0.0.0.0:8085
-        - -health-listen-address
-        - 0.0.0.0:8086
-        - -namespace
-        - $(NAMESPACE)
-        - -ca-cert
-        - /etc/kubernetes/pki/ca/ca.crt
-        - -cluster-url
-        - ""
-        - -openvpn-server-port
-        - "30003"
-        - -overwrite-registry
-        - ""
-        - -openshift=false
-        - -openvpn-ca-cert-file=/etc/kubernetes/pki/openvpn/ca.crt
-        - -openvpn-ca-key-file=/etc/kubernetes/pki/openvpn/ca.key
-        - -logtostderr
-        - -v
+        - -endpoint
+        - https://apiserver-external.cluster-de-test-01.svc.cluster.local.:30000/healthz
+        - -insecure
+        - -retries
+        - "100"
+        - -retry-wait
         - "2"
-        - --ipam-controller-network
-        - 192.168.1.1/24,192.168.1.1,8.8.8.8
+        - -timeout
+        - "1"
+        - -command
+        - '{"command":"/usr/local/bin/user-cluster-controller-manager","args":["-kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","-metrics-listen-address","0.0.0.0:8085","-health-listen-address","0.0.0.0:8086","-namespace","$(NAMESPACE)","-ca-cert","/etc/kubernetes/pki/ca/ca.crt","-cluster-url","","-openvpn-server-port","30003","-overwrite-registry","","-openshift=false","-openvpn-ca-cert-file=/etc/kubernetes/pki/openvpn/ca.crt","-openvpn-ca-key-file=/etc/kubernetes/pki/openvpn/ca.key","-logtostderr","-v","2","--ipam-controller-network","192.168.1.1/24,192.168.1.1,8.8.8.8"]}'
         command:
-        - /usr/local/bin/user-cluster-controller-manager
+        - /http-prober-bin/http-prober
         env:
         - name: NAMESPACE
           valueFrom:
@@ -89,27 +76,21 @@ spec:
         - mountPath: /etc/kubernetes/pki/openvpn
           name: openvpn-ca
           readOnly: true
+        - mountPath: /http-prober-bin
+          name: http-prober-bin
       imagePullSecrets:
       - name: dockercfg
       initContainers:
-      - args:
-        - -endpoint
-        - https://apiserver-external.cluster-de-test-01.svc.cluster.local.:30000/healthz
-        - -insecure
-        - -retries
-        - "100"
-        - -retry-wait
-        - "2"
-        - -timeout
-        - "1"
-        command:
+      - command:
+        - /bin/cp
         - /usr/local/bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.1
-        imagePullPolicy: IfNotPresent
-        name: apiserver-running
+        - /http-prober-bin/http-prober
+        image: quay.io/kubermatic/http-prober:v0.2-dev0
+        name: copy-http-prober
         resources: {}
-        terminationMessagePath: /dev/termination-log
-        terminationMessagePolicy: File
+        volumeMounts:
+        - mountPath: /http-prober-bin
+          name: http-prober-bin
       volumes:
       - name: internal-admin-kubeconfig
         secret:
@@ -126,4 +107,6 @@ spec:
         secret:
           defaultMode: 292
           secretName: openvpn-ca
+      - emptyDir: {}
+        name: http-prober-bin
 status: {}

--- a/api/pkg/resources/test/fixtures/deployment-openstack-1.11.0-controller-manager.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-openstack-1.11.0-controller-manager.yaml
@@ -176,7 +176,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.2-dev0
+        image: quay.io/kubermatic/http-prober:v0.2
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/api/pkg/resources/test/fixtures/deployment-openstack-1.11.0-controller-manager.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-openstack-1.11.0-controller-manager.yaml
@@ -102,32 +102,19 @@ spec:
           name: openvpn-client-certificates
           readOnly: true
       - args:
-        - --kubeconfig
-        - /etc/kubernetes/kubeconfig/kubeconfig
-        - --service-account-private-key-file
-        - /etc/kubernetes/service-account-key/sa.key
-        - --root-ca-file
-        - /etc/kubernetes/pki/ca/ca.crt
-        - --cluster-signing-cert-file
-        - /etc/kubernetes/pki/ca/ca.crt
-        - --cluster-signing-key-file
-        - /etc/kubernetes/pki/ca/ca.key
-        - --cluster-cidr
-        - 172.25.0.0/16
-        - --allocate-node-cidrs=true
-        - --controllers
-        - '*,bootstrapsigner,tokencleaner'
-        - --use-service-account-credentials=true
-        - --feature-gates
-        - RotateKubeletClientCertificate=true,RotateKubeletServerCertificate=true
-        - --cloud-provider
-        - openstack
-        - --cloud-config
-        - /etc/kubernetes/cloud/config
-        - --configure-cloud-routes=false
+        - -endpoint
+        - https://apiserver-external.cluster-de-test-01.svc.cluster.local.:30000/healthz
+        - -insecure
+        - -retries
+        - "100"
+        - -retry-wait
+        - "2"
+        - -timeout
+        - "1"
+        - -command
+        - '{"command":"/hyperkube","args":["kube-controller-manager","--kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","--service-account-private-key-file","/etc/kubernetes/service-account-key/sa.key","--root-ca-file","/etc/kubernetes/pki/ca/ca.crt","--cluster-signing-cert-file","/etc/kubernetes/pki/ca/ca.crt","--cluster-signing-key-file","/etc/kubernetes/pki/ca/ca.key","--cluster-cidr","172.25.0.0/16","--allocate-node-cidrs=true","--controllers","*,bootstrapsigner,tokencleaner","--use-service-account-credentials=true","--feature-gates","RotateKubeletClientCertificate=true,RotateKubeletServerCertificate=true","--cloud-provider","openstack","--cloud-config","/etc/kubernetes/cloud/config","--configure-cloud-routes=false"]}'
         command:
-        - /hyperkube
-        - kube-controller-manager
+        - /http-prober-bin/http-prober
         image: gcr.io/google_containers/hyperkube-amd64:v1.11.0
         livenessProbe:
           failureThreshold: 8
@@ -169,6 +156,8 @@ spec:
         - mountPath: /etc/kubernetes/kubeconfig
           name: controllermanager-kubeconfig
           readOnly: true
+        - mountPath: /http-prober-bin
+          name: http-prober-bin
       dnsConfig:
         nameservers:
         - 192.0.2.14
@@ -183,24 +172,16 @@ spec:
       imagePullSecrets:
       - name: dockercfg
       initContainers:
-      - args:
-        - -endpoint
-        - https://apiserver-external.cluster-de-test-01.svc.cluster.local.:30000/healthz
-        - -insecure
-        - -retries
-        - "100"
-        - -retry-wait
-        - "2"
-        - -timeout
-        - "1"
-        command:
+      - command:
+        - /bin/cp
         - /usr/local/bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.1
-        imagePullPolicy: IfNotPresent
-        name: apiserver-running
+        - /http-prober-bin/http-prober
+        image: quay.io/kubermatic/http-prober:v0.2-dev0
+        name: copy-http-prober
         resources: {}
-        terminationMessagePath: /dev/termination-log
-        terminationMessagePolicy: File
+        volumeMounts:
+        - mountPath: /http-prober-bin
+          name: http-prober-bin
       volumes:
       - name: ca
         secret:
@@ -222,4 +203,6 @@ spec:
         secret:
           defaultMode: 256
           secretName: controllermanager-kubeconfig
+      - emptyDir: {}
+        name: http-prober-bin
 status: {}

--- a/api/pkg/resources/test/fixtures/deployment-openstack-1.11.0-kube-state-metrics.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-openstack-1.11.0-kube-state-metrics.yaml
@@ -21,14 +21,19 @@ spec:
     spec:
       containers:
       - args:
-        - --kubeconfig
-        - /etc/kubernetes/kubeconfig/kubeconfig
-        - --port
-        - "8080"
-        - --telemetry-port
-        - "8081"
+        - -endpoint
+        - https://apiserver-external.cluster-de-test-01.svc.cluster.local.:30000/healthz
+        - -insecure
+        - -retries
+        - "100"
+        - -retry-wait
+        - "2"
+        - -timeout
+        - "1"
+        - -command
+        - '{"command":"/kube-state-metrics","args":["--kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","--port","8080","--telemetry-port","8081"]}'
         command:
-        - /kube-state-metrics
+        - /http-prober-bin/http-prober
         image: quay.io/coreos/kube-state-metrics:v1.6.0
         name: kube-state-metrics
         ports:
@@ -58,30 +63,26 @@ spec:
         - mountPath: /etc/kubernetes/kubeconfig
           name: kube-state-metrics-kubeconfig
           readOnly: true
+        - mountPath: /http-prober-bin
+          name: http-prober-bin
       imagePullSecrets:
       - name: dockercfg
       initContainers:
-      - args:
-        - -endpoint
-        - https://apiserver-external.cluster-de-test-01.svc.cluster.local.:30000/healthz
-        - -insecure
-        - -retries
-        - "100"
-        - -retry-wait
-        - "2"
-        - -timeout
-        - "1"
-        command:
+      - command:
+        - /bin/cp
         - /usr/local/bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.1
-        imagePullPolicy: IfNotPresent
-        name: apiserver-running
+        - /http-prober-bin/http-prober
+        image: quay.io/kubermatic/http-prober:v0.2-dev0
+        name: copy-http-prober
         resources: {}
-        terminationMessagePath: /dev/termination-log
-        terminationMessagePolicy: File
+        volumeMounts:
+        - mountPath: /http-prober-bin
+          name: http-prober-bin
       volumes:
       - name: kube-state-metrics-kubeconfig
         secret:
           defaultMode: 256
           secretName: kube-state-metrics-kubeconfig
+      - emptyDir: {}
+        name: http-prober-bin
 status: {}

--- a/api/pkg/resources/test/fixtures/deployment-openstack-1.11.0-kube-state-metrics.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-openstack-1.11.0-kube-state-metrics.yaml
@@ -72,7 +72,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.2-dev0
+        image: quay.io/kubermatic/http-prober:v0.2
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/api/pkg/resources/test/fixtures/deployment-openstack-1.11.0-machine-controller-webhook.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-openstack-1.11.0-machine-controller-webhook.yaml
@@ -24,15 +24,19 @@ spec:
     spec:
       containers:
       - args:
-        - -kubeconfig
-        - /etc/kubernetes/kubeconfig/kubeconfig
-        - -logtostderr
-        - -v
-        - "4"
-        - -listen-address
-        - 0.0.0.0:9876
+        - -endpoint
+        - https://apiserver-external.cluster-de-test-01.svc.cluster.local.:30000/healthz
+        - -insecure
+        - -retries
+        - "100"
+        - -retry-wait
+        - "2"
+        - -timeout
+        - "1"
+        - -command
+        - '{"command":"/usr/local/bin/webhook","args":["-kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","-logtostderr","-v","4","-listen-address","0.0.0.0:9876"]}'
         command:
-        - /usr/local/bin/webhook
+        - /http-prober-bin/http-prober
         env:
         - name: OS_AUTH_URL
           value: https://example.com:8000/v3
@@ -79,27 +83,21 @@ spec:
         - mountPath: /tmp/cert
           name: machinecontroller-webhook-serving-cert
           readOnly: true
+        - mountPath: /http-prober-bin
+          name: http-prober-bin
       imagePullSecrets:
       - name: dockercfg
       initContainers:
-      - args:
-        - -endpoint
-        - https://apiserver-external.cluster-de-test-01.svc.cluster.local.:30000/healthz
-        - -insecure
-        - -retries
-        - "100"
-        - -retry-wait
-        - "2"
-        - -timeout
-        - "1"
-        command:
+      - command:
+        - /bin/cp
         - /usr/local/bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.1
-        imagePullPolicy: IfNotPresent
-        name: apiserver-running
+        - /http-prober-bin/http-prober
+        image: quay.io/kubermatic/http-prober:v0.2-dev0
+        name: copy-http-prober
         resources: {}
-        terminationMessagePath: /dev/termination-log
-        terminationMessagePolicy: File
+        volumeMounts:
+        - mountPath: /http-prober-bin
+          name: http-prober-bin
       volumes:
       - name: machinecontroller-kubeconfig
         secret:
@@ -109,4 +107,6 @@ spec:
         secret:
           defaultMode: 292
           secretName: machinecontroller-webhook-serving-cert
+      - emptyDir: {}
+        name: http-prober-bin
 status: {}

--- a/api/pkg/resources/test/fixtures/deployment-openstack-1.11.0-machine-controller-webhook.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-openstack-1.11.0-machine-controller-webhook.yaml
@@ -92,7 +92,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.2-dev0
+        image: quay.io/kubermatic/http-prober:v0.2
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/api/pkg/resources/test/fixtures/deployment-openstack-1.11.0-machine-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-openstack-1.11.0-machine-controller.yaml
@@ -27,17 +27,19 @@ spec:
     spec:
       containers:
       - args:
-        - -kubeconfig
-        - /etc/kubernetes/kubeconfig/kubeconfig
-        - -logtostderr
-        - -v
-        - "4"
-        - -cluster-dns
-        - 169.254.20.10
-        - -internal-listen-address
-        - 0.0.0.0:8085
+        - -endpoint
+        - https://apiserver-external.cluster-de-test-01.svc.cluster.local.:30000/healthz
+        - -insecure
+        - -retries
+        - "100"
+        - -retry-wait
+        - "2"
+        - -timeout
+        - "1"
+        - -command
+        - '{"command":"/usr/local/bin/machine-controller","args":["-kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","-logtostderr","-v","4","-cluster-dns","169.254.20.10","-internal-listen-address","0.0.0.0:8085"]}'
         command:
-        - /usr/local/bin/machine-controller
+        - /http-prober-bin/http-prober
         env:
         - name: OS_AUTH_URL
           value: https://example.com:8000/v3
@@ -72,30 +74,26 @@ spec:
         - mountPath: /etc/kubernetes/kubeconfig
           name: machinecontroller-kubeconfig
           readOnly: true
+        - mountPath: /http-prober-bin
+          name: http-prober-bin
       imagePullSecrets:
       - name: dockercfg
       initContainers:
-      - args:
-        - -endpoint
-        - https://apiserver-external.cluster-de-test-01.svc.cluster.local.:30000/healthz
-        - -insecure
-        - -retries
-        - "100"
-        - -retry-wait
-        - "2"
-        - -timeout
-        - "1"
-        command:
+      - command:
+        - /bin/cp
         - /usr/local/bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.1
-        imagePullPolicy: IfNotPresent
-        name: apiserver-running
+        - /http-prober-bin/http-prober
+        image: quay.io/kubermatic/http-prober:v0.2-dev0
+        name: copy-http-prober
         resources: {}
-        terminationMessagePath: /dev/termination-log
-        terminationMessagePolicy: File
+        volumeMounts:
+        - mountPath: /http-prober-bin
+          name: http-prober-bin
       volumes:
       - name: machinecontroller-kubeconfig
         secret:
           defaultMode: 292
           secretName: machinecontroller-kubeconfig
+      - emptyDir: {}
+        name: http-prober-bin
 status: {}

--- a/api/pkg/resources/test/fixtures/deployment-openstack-1.11.0-machine-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-openstack-1.11.0-machine-controller.yaml
@@ -83,7 +83,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.2-dev0
+        image: quay.io/kubermatic/http-prober:v0.2
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/api/pkg/resources/test/fixtures/deployment-openstack-1.11.0-metrics-server.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-openstack-1.11.0-metrics-server.yaml
@@ -41,22 +41,19 @@ spec:
             weight: 10
       containers:
       - args:
-        - --kubeconfig
-        - /etc/kubernetes/kubeconfig/kubeconfig
-        - --authentication-kubeconfig
-        - /etc/kubernetes/kubeconfig/kubeconfig
-        - --authorization-kubeconfig
-        - /etc/kubernetes/kubeconfig/kubeconfig
-        - --kubelet-port
-        - "10250"
-        - --kubelet-insecure-tls
-        - --kubelet-preferred-address-types
-        - ExternalIP,InternalIP
-        - --v
+        - -endpoint
+        - https://apiserver-external.cluster-de-test-01.svc.cluster.local.:30000/healthz
+        - -insecure
+        - -retries
+        - "100"
+        - -retry-wait
+        - "2"
+        - -timeout
         - "1"
-        - --logtostderr
+        - -command
+        - '{"command":"/metrics-server","args":["--kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","--authentication-kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","--authorization-kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","--kubelet-port","10250","--kubelet-insecure-tls","--kubelet-preferred-address-types","ExternalIP,InternalIP","--v","1","--logtostderr"]}'
         command:
-        - /metrics-server
+        - /http-prober-bin/http-prober
         image: gcr.io/google_containers/metrics-server-amd64:v0.3.2
         name: metrics-server
         resources:
@@ -70,6 +67,8 @@ spec:
         - mountPath: /etc/kubernetes/kubeconfig
           name: metrics-server
           readOnly: true
+        - mountPath: /http-prober-bin
+          name: http-prober-bin
       - args:
         - --client
         - --proto
@@ -158,24 +157,16 @@ spec:
       imagePullSecrets:
       - name: dockercfg
       initContainers:
-      - args:
-        - -endpoint
-        - https://apiserver-external.cluster-de-test-01.svc.cluster.local.:30000/healthz
-        - -insecure
-        - -retries
-        - "100"
-        - -retry-wait
-        - "2"
-        - -timeout
-        - "1"
-        command:
+      - command:
+        - /bin/cp
         - /usr/local/bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.1
-        imagePullPolicy: IfNotPresent
-        name: apiserver-running
+        - /http-prober-bin/http-prober
+        image: quay.io/kubermatic/http-prober:v0.2-dev0
+        name: copy-http-prober
         resources: {}
-        terminationMessagePath: /dev/termination-log
-        terminationMessagePolicy: File
+        volumeMounts:
+        - mountPath: /http-prober-bin
+          name: http-prober-bin
       volumes:
       - name: metrics-server
         secret:
@@ -189,4 +180,6 @@ spec:
         secret:
           defaultMode: 292
           secretName: kubeletdnatcontroller-kubeconfig
+      - emptyDir: {}
+        name: http-prober-bin
 status: {}

--- a/api/pkg/resources/test/fixtures/deployment-openstack-1.11.0-metrics-server.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-openstack-1.11.0-metrics-server.yaml
@@ -161,7 +161,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.2-dev0
+        image: quay.io/kubermatic/http-prober:v0.2
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/api/pkg/resources/test/fixtures/deployment-openstack-1.11.0-scheduler.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-openstack-1.11.0-scheduler.yaml
@@ -100,11 +100,19 @@ spec:
           name: openvpn-client-certificates
           readOnly: true
       - args:
-        - --kubeconfig
-        - /etc/kubernetes/kubeconfig/kubeconfig
+        - -endpoint
+        - https://apiserver-external.cluster-de-test-01.svc.cluster.local.:30000/healthz
+        - -insecure
+        - -retries
+        - "100"
+        - -retry-wait
+        - "2"
+        - -timeout
+        - "1"
+        - -command
+        - '{"command":"/hyperkube","args":["kube-scheduler","--kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig"]}'
         command:
-        - /hyperkube
-        - kube-scheduler
+        - /http-prober-bin/http-prober
         image: gcr.io/google_containers/hyperkube-amd64:v1.11.0
         livenessProbe:
           failureThreshold: 8
@@ -140,6 +148,8 @@ spec:
         - mountPath: /etc/kubernetes/pki/ca
           name: ca
           readOnly: true
+        - mountPath: /http-prober-bin
+          name: http-prober-bin
       dnsConfig:
         nameservers:
         - 192.0.2.14
@@ -154,24 +164,16 @@ spec:
       imagePullSecrets:
       - name: dockercfg
       initContainers:
-      - args:
-        - -endpoint
-        - https://apiserver-external.cluster-de-test-01.svc.cluster.local.:30000/healthz
-        - -insecure
-        - -retries
-        - "100"
-        - -retry-wait
-        - "2"
-        - -timeout
-        - "1"
-        command:
+      - command:
+        - /bin/cp
         - /usr/local/bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.1
-        imagePullPolicy: IfNotPresent
-        name: apiserver-running
+        - /http-prober-bin/http-prober
+        image: quay.io/kubermatic/http-prober:v0.2-dev0
+        name: copy-http-prober
         resources: {}
-        terminationMessagePath: /dev/termination-log
-        terminationMessagePolicy: File
+        volumeMounts:
+        - mountPath: /http-prober-bin
+          name: http-prober-bin
       volumes:
       - name: openvpn-client-certificates
         secret:
@@ -188,4 +190,6 @@ spec:
         secret:
           defaultMode: 256
           secretName: scheduler-kubeconfig
+      - emptyDir: {}
+        name: http-prober-bin
 status: {}

--- a/api/pkg/resources/test/fixtures/deployment-openstack-1.11.0-scheduler.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-openstack-1.11.0-scheduler.yaml
@@ -168,7 +168,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.2-dev0
+        image: quay.io/kubermatic/http-prober:v0.2
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/api/pkg/resources/test/fixtures/deployment-openstack-1.11.0-usercluster-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-openstack-1.11.0-usercluster-controller.yaml
@@ -85,7 +85,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.2-dev0
+        image: quay.io/kubermatic/http-prober:v0.2
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/api/pkg/resources/test/fixtures/deployment-openstack-1.11.0-usercluster-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-openstack-1.11.0-usercluster-controller.yaml
@@ -29,32 +29,19 @@ spec:
     spec:
       containers:
       - args:
-        - -kubeconfig
-        - /etc/kubernetes/kubeconfig/kubeconfig
-        - -metrics-listen-address
-        - 0.0.0.0:8085
-        - -health-listen-address
-        - 0.0.0.0:8086
-        - -namespace
-        - $(NAMESPACE)
-        - -ca-cert
-        - /etc/kubernetes/pki/ca/ca.crt
-        - -cluster-url
-        - ""
-        - -openvpn-server-port
-        - "30003"
-        - -overwrite-registry
-        - ""
-        - -openshift=false
-        - -openvpn-ca-cert-file=/etc/kubernetes/pki/openvpn/ca.crt
-        - -openvpn-ca-key-file=/etc/kubernetes/pki/openvpn/ca.key
-        - -logtostderr
-        - -v
+        - -endpoint
+        - https://apiserver-external.cluster-de-test-01.svc.cluster.local.:30000/healthz
+        - -insecure
+        - -retries
+        - "100"
+        - -retry-wait
         - "2"
-        - --ipam-controller-network
-        - 192.168.1.1/24,192.168.1.1,8.8.8.8
+        - -timeout
+        - "1"
+        - -command
+        - '{"command":"/usr/local/bin/user-cluster-controller-manager","args":["-kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","-metrics-listen-address","0.0.0.0:8085","-health-listen-address","0.0.0.0:8086","-namespace","$(NAMESPACE)","-ca-cert","/etc/kubernetes/pki/ca/ca.crt","-cluster-url","","-openvpn-server-port","30003","-overwrite-registry","","-openshift=false","-openvpn-ca-cert-file=/etc/kubernetes/pki/openvpn/ca.crt","-openvpn-ca-key-file=/etc/kubernetes/pki/openvpn/ca.key","-logtostderr","-v","2","--ipam-controller-network","192.168.1.1/24,192.168.1.1,8.8.8.8"]}'
         command:
-        - /usr/local/bin/user-cluster-controller-manager
+        - /http-prober-bin/http-prober
         env:
         - name: NAMESPACE
           valueFrom:
@@ -89,27 +76,21 @@ spec:
         - mountPath: /etc/kubernetes/pki/openvpn
           name: openvpn-ca
           readOnly: true
+        - mountPath: /http-prober-bin
+          name: http-prober-bin
       imagePullSecrets:
       - name: dockercfg
       initContainers:
-      - args:
-        - -endpoint
-        - https://apiserver-external.cluster-de-test-01.svc.cluster.local.:30000/healthz
-        - -insecure
-        - -retries
-        - "100"
-        - -retry-wait
-        - "2"
-        - -timeout
-        - "1"
-        command:
+      - command:
+        - /bin/cp
         - /usr/local/bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.1
-        imagePullPolicy: IfNotPresent
-        name: apiserver-running
+        - /http-prober-bin/http-prober
+        image: quay.io/kubermatic/http-prober:v0.2-dev0
+        name: copy-http-prober
         resources: {}
-        terminationMessagePath: /dev/termination-log
-        terminationMessagePolicy: File
+        volumeMounts:
+        - mountPath: /http-prober-bin
+          name: http-prober-bin
       volumes:
       - name: internal-admin-kubeconfig
         secret:
@@ -126,4 +107,6 @@ spec:
         secret:
           defaultMode: 292
           secretName: openvpn-ca
+      - emptyDir: {}
+        name: http-prober-bin
 status: {}

--- a/api/pkg/resources/test/fixtures/deployment-openstack-1.11.1-controller-manager.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-openstack-1.11.1-controller-manager.yaml
@@ -176,7 +176,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.2-dev0
+        image: quay.io/kubermatic/http-prober:v0.2
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/api/pkg/resources/test/fixtures/deployment-openstack-1.11.1-controller-manager.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-openstack-1.11.1-controller-manager.yaml
@@ -102,32 +102,19 @@ spec:
           name: openvpn-client-certificates
           readOnly: true
       - args:
-        - --kubeconfig
-        - /etc/kubernetes/kubeconfig/kubeconfig
-        - --service-account-private-key-file
-        - /etc/kubernetes/service-account-key/sa.key
-        - --root-ca-file
-        - /etc/kubernetes/pki/ca/ca.crt
-        - --cluster-signing-cert-file
-        - /etc/kubernetes/pki/ca/ca.crt
-        - --cluster-signing-key-file
-        - /etc/kubernetes/pki/ca/ca.key
-        - --cluster-cidr
-        - 172.25.0.0/16
-        - --allocate-node-cidrs=true
-        - --controllers
-        - '*,bootstrapsigner,tokencleaner'
-        - --use-service-account-credentials=true
-        - --feature-gates
-        - RotateKubeletClientCertificate=true,RotateKubeletServerCertificate=true
-        - --cloud-provider
-        - openstack
-        - --cloud-config
-        - /etc/kubernetes/cloud/config
-        - --configure-cloud-routes=false
+        - -endpoint
+        - https://apiserver-external.cluster-de-test-01.svc.cluster.local.:30000/healthz
+        - -insecure
+        - -retries
+        - "100"
+        - -retry-wait
+        - "2"
+        - -timeout
+        - "1"
+        - -command
+        - '{"command":"/hyperkube","args":["kube-controller-manager","--kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","--service-account-private-key-file","/etc/kubernetes/service-account-key/sa.key","--root-ca-file","/etc/kubernetes/pki/ca/ca.crt","--cluster-signing-cert-file","/etc/kubernetes/pki/ca/ca.crt","--cluster-signing-key-file","/etc/kubernetes/pki/ca/ca.key","--cluster-cidr","172.25.0.0/16","--allocate-node-cidrs=true","--controllers","*,bootstrapsigner,tokencleaner","--use-service-account-credentials=true","--feature-gates","RotateKubeletClientCertificate=true,RotateKubeletServerCertificate=true","--cloud-provider","openstack","--cloud-config","/etc/kubernetes/cloud/config","--configure-cloud-routes=false"]}'
         command:
-        - /hyperkube
-        - kube-controller-manager
+        - /http-prober-bin/http-prober
         image: gcr.io/google_containers/hyperkube-amd64:v1.11.1
         livenessProbe:
           failureThreshold: 8
@@ -169,6 +156,8 @@ spec:
         - mountPath: /etc/kubernetes/kubeconfig
           name: controllermanager-kubeconfig
           readOnly: true
+        - mountPath: /http-prober-bin
+          name: http-prober-bin
       dnsConfig:
         nameservers:
         - 192.0.2.14
@@ -183,24 +172,16 @@ spec:
       imagePullSecrets:
       - name: dockercfg
       initContainers:
-      - args:
-        - -endpoint
-        - https://apiserver-external.cluster-de-test-01.svc.cluster.local.:30000/healthz
-        - -insecure
-        - -retries
-        - "100"
-        - -retry-wait
-        - "2"
-        - -timeout
-        - "1"
-        command:
+      - command:
+        - /bin/cp
         - /usr/local/bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.1
-        imagePullPolicy: IfNotPresent
-        name: apiserver-running
+        - /http-prober-bin/http-prober
+        image: quay.io/kubermatic/http-prober:v0.2-dev0
+        name: copy-http-prober
         resources: {}
-        terminationMessagePath: /dev/termination-log
-        terminationMessagePolicy: File
+        volumeMounts:
+        - mountPath: /http-prober-bin
+          name: http-prober-bin
       volumes:
       - name: ca
         secret:
@@ -222,4 +203,6 @@ spec:
         secret:
           defaultMode: 256
           secretName: controllermanager-kubeconfig
+      - emptyDir: {}
+        name: http-prober-bin
 status: {}

--- a/api/pkg/resources/test/fixtures/deployment-openstack-1.11.1-kube-state-metrics.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-openstack-1.11.1-kube-state-metrics.yaml
@@ -21,14 +21,19 @@ spec:
     spec:
       containers:
       - args:
-        - --kubeconfig
-        - /etc/kubernetes/kubeconfig/kubeconfig
-        - --port
-        - "8080"
-        - --telemetry-port
-        - "8081"
+        - -endpoint
+        - https://apiserver-external.cluster-de-test-01.svc.cluster.local.:30000/healthz
+        - -insecure
+        - -retries
+        - "100"
+        - -retry-wait
+        - "2"
+        - -timeout
+        - "1"
+        - -command
+        - '{"command":"/kube-state-metrics","args":["--kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","--port","8080","--telemetry-port","8081"]}'
         command:
-        - /kube-state-metrics
+        - /http-prober-bin/http-prober
         image: quay.io/coreos/kube-state-metrics:v1.6.0
         name: kube-state-metrics
         ports:
@@ -58,30 +63,26 @@ spec:
         - mountPath: /etc/kubernetes/kubeconfig
           name: kube-state-metrics-kubeconfig
           readOnly: true
+        - mountPath: /http-prober-bin
+          name: http-prober-bin
       imagePullSecrets:
       - name: dockercfg
       initContainers:
-      - args:
-        - -endpoint
-        - https://apiserver-external.cluster-de-test-01.svc.cluster.local.:30000/healthz
-        - -insecure
-        - -retries
-        - "100"
-        - -retry-wait
-        - "2"
-        - -timeout
-        - "1"
-        command:
+      - command:
+        - /bin/cp
         - /usr/local/bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.1
-        imagePullPolicy: IfNotPresent
-        name: apiserver-running
+        - /http-prober-bin/http-prober
+        image: quay.io/kubermatic/http-prober:v0.2-dev0
+        name: copy-http-prober
         resources: {}
-        terminationMessagePath: /dev/termination-log
-        terminationMessagePolicy: File
+        volumeMounts:
+        - mountPath: /http-prober-bin
+          name: http-prober-bin
       volumes:
       - name: kube-state-metrics-kubeconfig
         secret:
           defaultMode: 256
           secretName: kube-state-metrics-kubeconfig
+      - emptyDir: {}
+        name: http-prober-bin
 status: {}

--- a/api/pkg/resources/test/fixtures/deployment-openstack-1.11.1-kube-state-metrics.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-openstack-1.11.1-kube-state-metrics.yaml
@@ -72,7 +72,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.2-dev0
+        image: quay.io/kubermatic/http-prober:v0.2
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/api/pkg/resources/test/fixtures/deployment-openstack-1.11.1-machine-controller-webhook.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-openstack-1.11.1-machine-controller-webhook.yaml
@@ -24,15 +24,19 @@ spec:
     spec:
       containers:
       - args:
-        - -kubeconfig
-        - /etc/kubernetes/kubeconfig/kubeconfig
-        - -logtostderr
-        - -v
-        - "4"
-        - -listen-address
-        - 0.0.0.0:9876
+        - -endpoint
+        - https://apiserver-external.cluster-de-test-01.svc.cluster.local.:30000/healthz
+        - -insecure
+        - -retries
+        - "100"
+        - -retry-wait
+        - "2"
+        - -timeout
+        - "1"
+        - -command
+        - '{"command":"/usr/local/bin/webhook","args":["-kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","-logtostderr","-v","4","-listen-address","0.0.0.0:9876"]}'
         command:
-        - /usr/local/bin/webhook
+        - /http-prober-bin/http-prober
         env:
         - name: OS_AUTH_URL
           value: https://example.com:8000/v3
@@ -79,27 +83,21 @@ spec:
         - mountPath: /tmp/cert
           name: machinecontroller-webhook-serving-cert
           readOnly: true
+        - mountPath: /http-prober-bin
+          name: http-prober-bin
       imagePullSecrets:
       - name: dockercfg
       initContainers:
-      - args:
-        - -endpoint
-        - https://apiserver-external.cluster-de-test-01.svc.cluster.local.:30000/healthz
-        - -insecure
-        - -retries
-        - "100"
-        - -retry-wait
-        - "2"
-        - -timeout
-        - "1"
-        command:
+      - command:
+        - /bin/cp
         - /usr/local/bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.1
-        imagePullPolicy: IfNotPresent
-        name: apiserver-running
+        - /http-prober-bin/http-prober
+        image: quay.io/kubermatic/http-prober:v0.2-dev0
+        name: copy-http-prober
         resources: {}
-        terminationMessagePath: /dev/termination-log
-        terminationMessagePolicy: File
+        volumeMounts:
+        - mountPath: /http-prober-bin
+          name: http-prober-bin
       volumes:
       - name: machinecontroller-kubeconfig
         secret:
@@ -109,4 +107,6 @@ spec:
         secret:
           defaultMode: 292
           secretName: machinecontroller-webhook-serving-cert
+      - emptyDir: {}
+        name: http-prober-bin
 status: {}

--- a/api/pkg/resources/test/fixtures/deployment-openstack-1.11.1-machine-controller-webhook.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-openstack-1.11.1-machine-controller-webhook.yaml
@@ -92,7 +92,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.2-dev0
+        image: quay.io/kubermatic/http-prober:v0.2
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/api/pkg/resources/test/fixtures/deployment-openstack-1.11.1-machine-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-openstack-1.11.1-machine-controller.yaml
@@ -27,17 +27,19 @@ spec:
     spec:
       containers:
       - args:
-        - -kubeconfig
-        - /etc/kubernetes/kubeconfig/kubeconfig
-        - -logtostderr
-        - -v
-        - "4"
-        - -cluster-dns
-        - 169.254.20.10
-        - -internal-listen-address
-        - 0.0.0.0:8085
+        - -endpoint
+        - https://apiserver-external.cluster-de-test-01.svc.cluster.local.:30000/healthz
+        - -insecure
+        - -retries
+        - "100"
+        - -retry-wait
+        - "2"
+        - -timeout
+        - "1"
+        - -command
+        - '{"command":"/usr/local/bin/machine-controller","args":["-kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","-logtostderr","-v","4","-cluster-dns","169.254.20.10","-internal-listen-address","0.0.0.0:8085"]}'
         command:
-        - /usr/local/bin/machine-controller
+        - /http-prober-bin/http-prober
         env:
         - name: OS_AUTH_URL
           value: https://example.com:8000/v3
@@ -72,30 +74,26 @@ spec:
         - mountPath: /etc/kubernetes/kubeconfig
           name: machinecontroller-kubeconfig
           readOnly: true
+        - mountPath: /http-prober-bin
+          name: http-prober-bin
       imagePullSecrets:
       - name: dockercfg
       initContainers:
-      - args:
-        - -endpoint
-        - https://apiserver-external.cluster-de-test-01.svc.cluster.local.:30000/healthz
-        - -insecure
-        - -retries
-        - "100"
-        - -retry-wait
-        - "2"
-        - -timeout
-        - "1"
-        command:
+      - command:
+        - /bin/cp
         - /usr/local/bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.1
-        imagePullPolicy: IfNotPresent
-        name: apiserver-running
+        - /http-prober-bin/http-prober
+        image: quay.io/kubermatic/http-prober:v0.2-dev0
+        name: copy-http-prober
         resources: {}
-        terminationMessagePath: /dev/termination-log
-        terminationMessagePolicy: File
+        volumeMounts:
+        - mountPath: /http-prober-bin
+          name: http-prober-bin
       volumes:
       - name: machinecontroller-kubeconfig
         secret:
           defaultMode: 292
           secretName: machinecontroller-kubeconfig
+      - emptyDir: {}
+        name: http-prober-bin
 status: {}

--- a/api/pkg/resources/test/fixtures/deployment-openstack-1.11.1-machine-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-openstack-1.11.1-machine-controller.yaml
@@ -83,7 +83,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.2-dev0
+        image: quay.io/kubermatic/http-prober:v0.2
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/api/pkg/resources/test/fixtures/deployment-openstack-1.11.1-metrics-server.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-openstack-1.11.1-metrics-server.yaml
@@ -41,22 +41,19 @@ spec:
             weight: 10
       containers:
       - args:
-        - --kubeconfig
-        - /etc/kubernetes/kubeconfig/kubeconfig
-        - --authentication-kubeconfig
-        - /etc/kubernetes/kubeconfig/kubeconfig
-        - --authorization-kubeconfig
-        - /etc/kubernetes/kubeconfig/kubeconfig
-        - --kubelet-port
-        - "10250"
-        - --kubelet-insecure-tls
-        - --kubelet-preferred-address-types
-        - ExternalIP,InternalIP
-        - --v
+        - -endpoint
+        - https://apiserver-external.cluster-de-test-01.svc.cluster.local.:30000/healthz
+        - -insecure
+        - -retries
+        - "100"
+        - -retry-wait
+        - "2"
+        - -timeout
         - "1"
-        - --logtostderr
+        - -command
+        - '{"command":"/metrics-server","args":["--kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","--authentication-kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","--authorization-kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","--kubelet-port","10250","--kubelet-insecure-tls","--kubelet-preferred-address-types","ExternalIP,InternalIP","--v","1","--logtostderr"]}'
         command:
-        - /metrics-server
+        - /http-prober-bin/http-prober
         image: gcr.io/google_containers/metrics-server-amd64:v0.3.2
         name: metrics-server
         resources:
@@ -70,6 +67,8 @@ spec:
         - mountPath: /etc/kubernetes/kubeconfig
           name: metrics-server
           readOnly: true
+        - mountPath: /http-prober-bin
+          name: http-prober-bin
       - args:
         - --client
         - --proto
@@ -158,24 +157,16 @@ spec:
       imagePullSecrets:
       - name: dockercfg
       initContainers:
-      - args:
-        - -endpoint
-        - https://apiserver-external.cluster-de-test-01.svc.cluster.local.:30000/healthz
-        - -insecure
-        - -retries
-        - "100"
-        - -retry-wait
-        - "2"
-        - -timeout
-        - "1"
-        command:
+      - command:
+        - /bin/cp
         - /usr/local/bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.1
-        imagePullPolicy: IfNotPresent
-        name: apiserver-running
+        - /http-prober-bin/http-prober
+        image: quay.io/kubermatic/http-prober:v0.2-dev0
+        name: copy-http-prober
         resources: {}
-        terminationMessagePath: /dev/termination-log
-        terminationMessagePolicy: File
+        volumeMounts:
+        - mountPath: /http-prober-bin
+          name: http-prober-bin
       volumes:
       - name: metrics-server
         secret:
@@ -189,4 +180,6 @@ spec:
         secret:
           defaultMode: 292
           secretName: kubeletdnatcontroller-kubeconfig
+      - emptyDir: {}
+        name: http-prober-bin
 status: {}

--- a/api/pkg/resources/test/fixtures/deployment-openstack-1.11.1-metrics-server.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-openstack-1.11.1-metrics-server.yaml
@@ -161,7 +161,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.2-dev0
+        image: quay.io/kubermatic/http-prober:v0.2
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/api/pkg/resources/test/fixtures/deployment-openstack-1.11.1-scheduler.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-openstack-1.11.1-scheduler.yaml
@@ -100,11 +100,19 @@ spec:
           name: openvpn-client-certificates
           readOnly: true
       - args:
-        - --kubeconfig
-        - /etc/kubernetes/kubeconfig/kubeconfig
+        - -endpoint
+        - https://apiserver-external.cluster-de-test-01.svc.cluster.local.:30000/healthz
+        - -insecure
+        - -retries
+        - "100"
+        - -retry-wait
+        - "2"
+        - -timeout
+        - "1"
+        - -command
+        - '{"command":"/hyperkube","args":["kube-scheduler","--kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig"]}'
         command:
-        - /hyperkube
-        - kube-scheduler
+        - /http-prober-bin/http-prober
         image: gcr.io/google_containers/hyperkube-amd64:v1.11.1
         livenessProbe:
           failureThreshold: 8
@@ -140,6 +148,8 @@ spec:
         - mountPath: /etc/kubernetes/pki/ca
           name: ca
           readOnly: true
+        - mountPath: /http-prober-bin
+          name: http-prober-bin
       dnsConfig:
         nameservers:
         - 192.0.2.14
@@ -154,24 +164,16 @@ spec:
       imagePullSecrets:
       - name: dockercfg
       initContainers:
-      - args:
-        - -endpoint
-        - https://apiserver-external.cluster-de-test-01.svc.cluster.local.:30000/healthz
-        - -insecure
-        - -retries
-        - "100"
-        - -retry-wait
-        - "2"
-        - -timeout
-        - "1"
-        command:
+      - command:
+        - /bin/cp
         - /usr/local/bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.1
-        imagePullPolicy: IfNotPresent
-        name: apiserver-running
+        - /http-prober-bin/http-prober
+        image: quay.io/kubermatic/http-prober:v0.2-dev0
+        name: copy-http-prober
         resources: {}
-        terminationMessagePath: /dev/termination-log
-        terminationMessagePolicy: File
+        volumeMounts:
+        - mountPath: /http-prober-bin
+          name: http-prober-bin
       volumes:
       - name: openvpn-client-certificates
         secret:
@@ -188,4 +190,6 @@ spec:
         secret:
           defaultMode: 256
           secretName: scheduler-kubeconfig
+      - emptyDir: {}
+        name: http-prober-bin
 status: {}

--- a/api/pkg/resources/test/fixtures/deployment-openstack-1.11.1-scheduler.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-openstack-1.11.1-scheduler.yaml
@@ -168,7 +168,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.2-dev0
+        image: quay.io/kubermatic/http-prober:v0.2
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/api/pkg/resources/test/fixtures/deployment-openstack-1.11.1-usercluster-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-openstack-1.11.1-usercluster-controller.yaml
@@ -85,7 +85,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.2-dev0
+        image: quay.io/kubermatic/http-prober:v0.2
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/api/pkg/resources/test/fixtures/deployment-openstack-1.11.1-usercluster-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-openstack-1.11.1-usercluster-controller.yaml
@@ -29,32 +29,19 @@ spec:
     spec:
       containers:
       - args:
-        - -kubeconfig
-        - /etc/kubernetes/kubeconfig/kubeconfig
-        - -metrics-listen-address
-        - 0.0.0.0:8085
-        - -health-listen-address
-        - 0.0.0.0:8086
-        - -namespace
-        - $(NAMESPACE)
-        - -ca-cert
-        - /etc/kubernetes/pki/ca/ca.crt
-        - -cluster-url
-        - ""
-        - -openvpn-server-port
-        - "30003"
-        - -overwrite-registry
-        - ""
-        - -openshift=false
-        - -openvpn-ca-cert-file=/etc/kubernetes/pki/openvpn/ca.crt
-        - -openvpn-ca-key-file=/etc/kubernetes/pki/openvpn/ca.key
-        - -logtostderr
-        - -v
+        - -endpoint
+        - https://apiserver-external.cluster-de-test-01.svc.cluster.local.:30000/healthz
+        - -insecure
+        - -retries
+        - "100"
+        - -retry-wait
         - "2"
-        - --ipam-controller-network
-        - 192.168.1.1/24,192.168.1.1,8.8.8.8
+        - -timeout
+        - "1"
+        - -command
+        - '{"command":"/usr/local/bin/user-cluster-controller-manager","args":["-kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","-metrics-listen-address","0.0.0.0:8085","-health-listen-address","0.0.0.0:8086","-namespace","$(NAMESPACE)","-ca-cert","/etc/kubernetes/pki/ca/ca.crt","-cluster-url","","-openvpn-server-port","30003","-overwrite-registry","","-openshift=false","-openvpn-ca-cert-file=/etc/kubernetes/pki/openvpn/ca.crt","-openvpn-ca-key-file=/etc/kubernetes/pki/openvpn/ca.key","-logtostderr","-v","2","--ipam-controller-network","192.168.1.1/24,192.168.1.1,8.8.8.8"]}'
         command:
-        - /usr/local/bin/user-cluster-controller-manager
+        - /http-prober-bin/http-prober
         env:
         - name: NAMESPACE
           valueFrom:
@@ -89,27 +76,21 @@ spec:
         - mountPath: /etc/kubernetes/pki/openvpn
           name: openvpn-ca
           readOnly: true
+        - mountPath: /http-prober-bin
+          name: http-prober-bin
       imagePullSecrets:
       - name: dockercfg
       initContainers:
-      - args:
-        - -endpoint
-        - https://apiserver-external.cluster-de-test-01.svc.cluster.local.:30000/healthz
-        - -insecure
-        - -retries
-        - "100"
-        - -retry-wait
-        - "2"
-        - -timeout
-        - "1"
-        command:
+      - command:
+        - /bin/cp
         - /usr/local/bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.1
-        imagePullPolicy: IfNotPresent
-        name: apiserver-running
+        - /http-prober-bin/http-prober
+        image: quay.io/kubermatic/http-prober:v0.2-dev0
+        name: copy-http-prober
         resources: {}
-        terminationMessagePath: /dev/termination-log
-        terminationMessagePolicy: File
+        volumeMounts:
+        - mountPath: /http-prober-bin
+          name: http-prober-bin
       volumes:
       - name: internal-admin-kubeconfig
         secret:
@@ -126,4 +107,6 @@ spec:
         secret:
           defaultMode: 292
           secretName: openvpn-ca
+      - emptyDir: {}
+        name: http-prober-bin
 status: {}

--- a/api/pkg/resources/test/fixtures/deployment-openstack-1.12.0-controller-manager.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-openstack-1.12.0-controller-manager.yaml
@@ -176,7 +176,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.2-dev0
+        image: quay.io/kubermatic/http-prober:v0.2
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/api/pkg/resources/test/fixtures/deployment-openstack-1.12.0-controller-manager.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-openstack-1.12.0-controller-manager.yaml
@@ -102,37 +102,19 @@ spec:
           name: openvpn-client-certificates
           readOnly: true
       - args:
-        - --kubeconfig
-        - /etc/kubernetes/kubeconfig/kubeconfig
-        - --service-account-private-key-file
-        - /etc/kubernetes/service-account-key/sa.key
-        - --root-ca-file
-        - /etc/kubernetes/pki/ca/ca.crt
-        - --cluster-signing-cert-file
-        - /etc/kubernetes/pki/ca/ca.crt
-        - --cluster-signing-key-file
-        - /etc/kubernetes/pki/ca/ca.key
-        - --cluster-cidr
-        - 172.25.0.0/16
-        - --allocate-node-cidrs=true
-        - --controllers
-        - '*,bootstrapsigner,tokencleaner'
-        - --use-service-account-credentials=true
-        - --feature-gates
-        - RotateKubeletClientCertificate=true,RotateKubeletServerCertificate=true,ScheduleDaemonSetPods=false
-        - --cloud-provider
-        - openstack
-        - --cloud-config
-        - /etc/kubernetes/cloud/config
-        - --configure-cloud-routes=false
-        - --authentication-kubeconfig
-        - /etc/kubernetes/kubeconfig/kubeconfig
-        - --client-ca-file
-        - /etc/kubernetes/pki/ca/ca.crt
-        - --authentication-skip-lookup=true
+        - -endpoint
+        - https://apiserver-external.cluster-de-test-01.svc.cluster.local.:30000/healthz
+        - -insecure
+        - -retries
+        - "100"
+        - -retry-wait
+        - "2"
+        - -timeout
+        - "1"
+        - -command
+        - '{"command":"/hyperkube","args":["kube-controller-manager","--kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","--service-account-private-key-file","/etc/kubernetes/service-account-key/sa.key","--root-ca-file","/etc/kubernetes/pki/ca/ca.crt","--cluster-signing-cert-file","/etc/kubernetes/pki/ca/ca.crt","--cluster-signing-key-file","/etc/kubernetes/pki/ca/ca.key","--cluster-cidr","172.25.0.0/16","--allocate-node-cidrs=true","--controllers","*,bootstrapsigner,tokencleaner","--use-service-account-credentials=true","--feature-gates","RotateKubeletClientCertificate=true,RotateKubeletServerCertificate=true,ScheduleDaemonSetPods=false","--cloud-provider","openstack","--cloud-config","/etc/kubernetes/cloud/config","--configure-cloud-routes=false","--authentication-kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","--client-ca-file","/etc/kubernetes/pki/ca/ca.crt","--authentication-skip-lookup=true"]}'
         command:
-        - /hyperkube
-        - kube-controller-manager
+        - /http-prober-bin/http-prober
         image: gcr.io/google_containers/hyperkube-amd64:v1.12.0
         livenessProbe:
           failureThreshold: 8
@@ -174,6 +156,8 @@ spec:
         - mountPath: /etc/kubernetes/kubeconfig
           name: controllermanager-kubeconfig
           readOnly: true
+        - mountPath: /http-prober-bin
+          name: http-prober-bin
       dnsConfig:
         nameservers:
         - 192.0.2.14
@@ -188,24 +172,16 @@ spec:
       imagePullSecrets:
       - name: dockercfg
       initContainers:
-      - args:
-        - -endpoint
-        - https://apiserver-external.cluster-de-test-01.svc.cluster.local.:30000/healthz
-        - -insecure
-        - -retries
-        - "100"
-        - -retry-wait
-        - "2"
-        - -timeout
-        - "1"
-        command:
+      - command:
+        - /bin/cp
         - /usr/local/bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.1
-        imagePullPolicy: IfNotPresent
-        name: apiserver-running
+        - /http-prober-bin/http-prober
+        image: quay.io/kubermatic/http-prober:v0.2-dev0
+        name: copy-http-prober
         resources: {}
-        terminationMessagePath: /dev/termination-log
-        terminationMessagePolicy: File
+        volumeMounts:
+        - mountPath: /http-prober-bin
+          name: http-prober-bin
       volumes:
       - name: ca
         secret:
@@ -227,4 +203,6 @@ spec:
         secret:
           defaultMode: 256
           secretName: controllermanager-kubeconfig
+      - emptyDir: {}
+        name: http-prober-bin
 status: {}

--- a/api/pkg/resources/test/fixtures/deployment-openstack-1.12.0-kube-state-metrics.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-openstack-1.12.0-kube-state-metrics.yaml
@@ -21,14 +21,19 @@ spec:
     spec:
       containers:
       - args:
-        - --kubeconfig
-        - /etc/kubernetes/kubeconfig/kubeconfig
-        - --port
-        - "8080"
-        - --telemetry-port
-        - "8081"
+        - -endpoint
+        - https://apiserver-external.cluster-de-test-01.svc.cluster.local.:30000/healthz
+        - -insecure
+        - -retries
+        - "100"
+        - -retry-wait
+        - "2"
+        - -timeout
+        - "1"
+        - -command
+        - '{"command":"/kube-state-metrics","args":["--kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","--port","8080","--telemetry-port","8081"]}'
         command:
-        - /kube-state-metrics
+        - /http-prober-bin/http-prober
         image: quay.io/coreos/kube-state-metrics:v1.6.0
         name: kube-state-metrics
         ports:
@@ -58,30 +63,26 @@ spec:
         - mountPath: /etc/kubernetes/kubeconfig
           name: kube-state-metrics-kubeconfig
           readOnly: true
+        - mountPath: /http-prober-bin
+          name: http-prober-bin
       imagePullSecrets:
       - name: dockercfg
       initContainers:
-      - args:
-        - -endpoint
-        - https://apiserver-external.cluster-de-test-01.svc.cluster.local.:30000/healthz
-        - -insecure
-        - -retries
-        - "100"
-        - -retry-wait
-        - "2"
-        - -timeout
-        - "1"
-        command:
+      - command:
+        - /bin/cp
         - /usr/local/bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.1
-        imagePullPolicy: IfNotPresent
-        name: apiserver-running
+        - /http-prober-bin/http-prober
+        image: quay.io/kubermatic/http-prober:v0.2-dev0
+        name: copy-http-prober
         resources: {}
-        terminationMessagePath: /dev/termination-log
-        terminationMessagePolicy: File
+        volumeMounts:
+        - mountPath: /http-prober-bin
+          name: http-prober-bin
       volumes:
       - name: kube-state-metrics-kubeconfig
         secret:
           defaultMode: 256
           secretName: kube-state-metrics-kubeconfig
+      - emptyDir: {}
+        name: http-prober-bin
 status: {}

--- a/api/pkg/resources/test/fixtures/deployment-openstack-1.12.0-kube-state-metrics.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-openstack-1.12.0-kube-state-metrics.yaml
@@ -72,7 +72,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.2-dev0
+        image: quay.io/kubermatic/http-prober:v0.2
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/api/pkg/resources/test/fixtures/deployment-openstack-1.12.0-machine-controller-webhook.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-openstack-1.12.0-machine-controller-webhook.yaml
@@ -24,15 +24,19 @@ spec:
     spec:
       containers:
       - args:
-        - -kubeconfig
-        - /etc/kubernetes/kubeconfig/kubeconfig
-        - -logtostderr
-        - -v
-        - "4"
-        - -listen-address
-        - 0.0.0.0:9876
+        - -endpoint
+        - https://apiserver-external.cluster-de-test-01.svc.cluster.local.:30000/healthz
+        - -insecure
+        - -retries
+        - "100"
+        - -retry-wait
+        - "2"
+        - -timeout
+        - "1"
+        - -command
+        - '{"command":"/usr/local/bin/webhook","args":["-kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","-logtostderr","-v","4","-listen-address","0.0.0.0:9876"]}'
         command:
-        - /usr/local/bin/webhook
+        - /http-prober-bin/http-prober
         env:
         - name: OS_AUTH_URL
           value: https://example.com:8000/v3
@@ -79,27 +83,21 @@ spec:
         - mountPath: /tmp/cert
           name: machinecontroller-webhook-serving-cert
           readOnly: true
+        - mountPath: /http-prober-bin
+          name: http-prober-bin
       imagePullSecrets:
       - name: dockercfg
       initContainers:
-      - args:
-        - -endpoint
-        - https://apiserver-external.cluster-de-test-01.svc.cluster.local.:30000/healthz
-        - -insecure
-        - -retries
-        - "100"
-        - -retry-wait
-        - "2"
-        - -timeout
-        - "1"
-        command:
+      - command:
+        - /bin/cp
         - /usr/local/bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.1
-        imagePullPolicy: IfNotPresent
-        name: apiserver-running
+        - /http-prober-bin/http-prober
+        image: quay.io/kubermatic/http-prober:v0.2-dev0
+        name: copy-http-prober
         resources: {}
-        terminationMessagePath: /dev/termination-log
-        terminationMessagePolicy: File
+        volumeMounts:
+        - mountPath: /http-prober-bin
+          name: http-prober-bin
       volumes:
       - name: machinecontroller-kubeconfig
         secret:
@@ -109,4 +107,6 @@ spec:
         secret:
           defaultMode: 292
           secretName: machinecontroller-webhook-serving-cert
+      - emptyDir: {}
+        name: http-prober-bin
 status: {}

--- a/api/pkg/resources/test/fixtures/deployment-openstack-1.12.0-machine-controller-webhook.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-openstack-1.12.0-machine-controller-webhook.yaml
@@ -92,7 +92,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.2-dev0
+        image: quay.io/kubermatic/http-prober:v0.2
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/api/pkg/resources/test/fixtures/deployment-openstack-1.12.0-machine-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-openstack-1.12.0-machine-controller.yaml
@@ -27,17 +27,19 @@ spec:
     spec:
       containers:
       - args:
-        - -kubeconfig
-        - /etc/kubernetes/kubeconfig/kubeconfig
-        - -logtostderr
-        - -v
-        - "4"
-        - -cluster-dns
-        - 169.254.20.10
-        - -internal-listen-address
-        - 0.0.0.0:8085
+        - -endpoint
+        - https://apiserver-external.cluster-de-test-01.svc.cluster.local.:30000/healthz
+        - -insecure
+        - -retries
+        - "100"
+        - -retry-wait
+        - "2"
+        - -timeout
+        - "1"
+        - -command
+        - '{"command":"/usr/local/bin/machine-controller","args":["-kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","-logtostderr","-v","4","-cluster-dns","169.254.20.10","-internal-listen-address","0.0.0.0:8085"]}'
         command:
-        - /usr/local/bin/machine-controller
+        - /http-prober-bin/http-prober
         env:
         - name: OS_AUTH_URL
           value: https://example.com:8000/v3
@@ -72,30 +74,26 @@ spec:
         - mountPath: /etc/kubernetes/kubeconfig
           name: machinecontroller-kubeconfig
           readOnly: true
+        - mountPath: /http-prober-bin
+          name: http-prober-bin
       imagePullSecrets:
       - name: dockercfg
       initContainers:
-      - args:
-        - -endpoint
-        - https://apiserver-external.cluster-de-test-01.svc.cluster.local.:30000/healthz
-        - -insecure
-        - -retries
-        - "100"
-        - -retry-wait
-        - "2"
-        - -timeout
-        - "1"
-        command:
+      - command:
+        - /bin/cp
         - /usr/local/bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.1
-        imagePullPolicy: IfNotPresent
-        name: apiserver-running
+        - /http-prober-bin/http-prober
+        image: quay.io/kubermatic/http-prober:v0.2-dev0
+        name: copy-http-prober
         resources: {}
-        terminationMessagePath: /dev/termination-log
-        terminationMessagePolicy: File
+        volumeMounts:
+        - mountPath: /http-prober-bin
+          name: http-prober-bin
       volumes:
       - name: machinecontroller-kubeconfig
         secret:
           defaultMode: 292
           secretName: machinecontroller-kubeconfig
+      - emptyDir: {}
+        name: http-prober-bin
 status: {}

--- a/api/pkg/resources/test/fixtures/deployment-openstack-1.12.0-machine-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-openstack-1.12.0-machine-controller.yaml
@@ -83,7 +83,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.2-dev0
+        image: quay.io/kubermatic/http-prober:v0.2
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/api/pkg/resources/test/fixtures/deployment-openstack-1.12.0-metrics-server.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-openstack-1.12.0-metrics-server.yaml
@@ -41,22 +41,19 @@ spec:
             weight: 10
       containers:
       - args:
-        - --kubeconfig
-        - /etc/kubernetes/kubeconfig/kubeconfig
-        - --authentication-kubeconfig
-        - /etc/kubernetes/kubeconfig/kubeconfig
-        - --authorization-kubeconfig
-        - /etc/kubernetes/kubeconfig/kubeconfig
-        - --kubelet-port
-        - "10250"
-        - --kubelet-insecure-tls
-        - --kubelet-preferred-address-types
-        - ExternalIP,InternalIP
-        - --v
+        - -endpoint
+        - https://apiserver-external.cluster-de-test-01.svc.cluster.local.:30000/healthz
+        - -insecure
+        - -retries
+        - "100"
+        - -retry-wait
+        - "2"
+        - -timeout
         - "1"
-        - --logtostderr
+        - -command
+        - '{"command":"/metrics-server","args":["--kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","--authentication-kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","--authorization-kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","--kubelet-port","10250","--kubelet-insecure-tls","--kubelet-preferred-address-types","ExternalIP,InternalIP","--v","1","--logtostderr"]}'
         command:
-        - /metrics-server
+        - /http-prober-bin/http-prober
         image: gcr.io/google_containers/metrics-server-amd64:v0.3.2
         name: metrics-server
         resources:
@@ -70,6 +67,8 @@ spec:
         - mountPath: /etc/kubernetes/kubeconfig
           name: metrics-server
           readOnly: true
+        - mountPath: /http-prober-bin
+          name: http-prober-bin
       - args:
         - --client
         - --proto
@@ -158,24 +157,16 @@ spec:
       imagePullSecrets:
       - name: dockercfg
       initContainers:
-      - args:
-        - -endpoint
-        - https://apiserver-external.cluster-de-test-01.svc.cluster.local.:30000/healthz
-        - -insecure
-        - -retries
-        - "100"
-        - -retry-wait
-        - "2"
-        - -timeout
-        - "1"
-        command:
+      - command:
+        - /bin/cp
         - /usr/local/bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.1
-        imagePullPolicy: IfNotPresent
-        name: apiserver-running
+        - /http-prober-bin/http-prober
+        image: quay.io/kubermatic/http-prober:v0.2-dev0
+        name: copy-http-prober
         resources: {}
-        terminationMessagePath: /dev/termination-log
-        terminationMessagePolicy: File
+        volumeMounts:
+        - mountPath: /http-prober-bin
+          name: http-prober-bin
       volumes:
       - name: metrics-server
         secret:
@@ -189,4 +180,6 @@ spec:
         secret:
           defaultMode: 292
           secretName: kubeletdnatcontroller-kubeconfig
+      - emptyDir: {}
+        name: http-prober-bin
 status: {}

--- a/api/pkg/resources/test/fixtures/deployment-openstack-1.12.0-metrics-server.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-openstack-1.12.0-metrics-server.yaml
@@ -161,7 +161,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.2-dev0
+        image: quay.io/kubermatic/http-prober:v0.2
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/api/pkg/resources/test/fixtures/deployment-openstack-1.12.0-scheduler.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-openstack-1.12.0-scheduler.yaml
@@ -168,7 +168,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.2-dev0
+        image: quay.io/kubermatic/http-prober:v0.2
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/api/pkg/resources/test/fixtures/deployment-openstack-1.12.0-scheduler.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-openstack-1.12.0-scheduler.yaml
@@ -100,13 +100,19 @@ spec:
           name: openvpn-client-certificates
           readOnly: true
       - args:
-        - --kubeconfig
-        - /etc/kubernetes/kubeconfig/kubeconfig
-        - --feature-gates
-        - ScheduleDaemonSetPods=false
+        - -endpoint
+        - https://apiserver-external.cluster-de-test-01.svc.cluster.local.:30000/healthz
+        - -insecure
+        - -retries
+        - "100"
+        - -retry-wait
+        - "2"
+        - -timeout
+        - "1"
+        - -command
+        - '{"command":"/hyperkube","args":["kube-scheduler","--kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","--feature-gates","ScheduleDaemonSetPods=false"]}'
         command:
-        - /hyperkube
-        - kube-scheduler
+        - /http-prober-bin/http-prober
         image: gcr.io/google_containers/hyperkube-amd64:v1.12.0
         livenessProbe:
           failureThreshold: 8
@@ -142,6 +148,8 @@ spec:
         - mountPath: /etc/kubernetes/pki/ca
           name: ca
           readOnly: true
+        - mountPath: /http-prober-bin
+          name: http-prober-bin
       dnsConfig:
         nameservers:
         - 192.0.2.14
@@ -156,24 +164,16 @@ spec:
       imagePullSecrets:
       - name: dockercfg
       initContainers:
-      - args:
-        - -endpoint
-        - https://apiserver-external.cluster-de-test-01.svc.cluster.local.:30000/healthz
-        - -insecure
-        - -retries
-        - "100"
-        - -retry-wait
-        - "2"
-        - -timeout
-        - "1"
-        command:
+      - command:
+        - /bin/cp
         - /usr/local/bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.1
-        imagePullPolicy: IfNotPresent
-        name: apiserver-running
+        - /http-prober-bin/http-prober
+        image: quay.io/kubermatic/http-prober:v0.2-dev0
+        name: copy-http-prober
         resources: {}
-        terminationMessagePath: /dev/termination-log
-        terminationMessagePolicy: File
+        volumeMounts:
+        - mountPath: /http-prober-bin
+          name: http-prober-bin
       volumes:
       - name: openvpn-client-certificates
         secret:
@@ -190,4 +190,6 @@ spec:
         secret:
           defaultMode: 256
           secretName: scheduler-kubeconfig
+      - emptyDir: {}
+        name: http-prober-bin
 status: {}

--- a/api/pkg/resources/test/fixtures/deployment-openstack-1.12.0-usercluster-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-openstack-1.12.0-usercluster-controller.yaml
@@ -85,7 +85,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.2-dev0
+        image: quay.io/kubermatic/http-prober:v0.2
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/api/pkg/resources/test/fixtures/deployment-openstack-1.12.0-usercluster-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-openstack-1.12.0-usercluster-controller.yaml
@@ -29,32 +29,19 @@ spec:
     spec:
       containers:
       - args:
-        - -kubeconfig
-        - /etc/kubernetes/kubeconfig/kubeconfig
-        - -metrics-listen-address
-        - 0.0.0.0:8085
-        - -health-listen-address
-        - 0.0.0.0:8086
-        - -namespace
-        - $(NAMESPACE)
-        - -ca-cert
-        - /etc/kubernetes/pki/ca/ca.crt
-        - -cluster-url
-        - ""
-        - -openvpn-server-port
-        - "30003"
-        - -overwrite-registry
-        - ""
-        - -openshift=false
-        - -openvpn-ca-cert-file=/etc/kubernetes/pki/openvpn/ca.crt
-        - -openvpn-ca-key-file=/etc/kubernetes/pki/openvpn/ca.key
-        - -logtostderr
-        - -v
+        - -endpoint
+        - https://apiserver-external.cluster-de-test-01.svc.cluster.local.:30000/healthz
+        - -insecure
+        - -retries
+        - "100"
+        - -retry-wait
         - "2"
-        - --ipam-controller-network
-        - 192.168.1.1/24,192.168.1.1,8.8.8.8
+        - -timeout
+        - "1"
+        - -command
+        - '{"command":"/usr/local/bin/user-cluster-controller-manager","args":["-kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","-metrics-listen-address","0.0.0.0:8085","-health-listen-address","0.0.0.0:8086","-namespace","$(NAMESPACE)","-ca-cert","/etc/kubernetes/pki/ca/ca.crt","-cluster-url","","-openvpn-server-port","30003","-overwrite-registry","","-openshift=false","-openvpn-ca-cert-file=/etc/kubernetes/pki/openvpn/ca.crt","-openvpn-ca-key-file=/etc/kubernetes/pki/openvpn/ca.key","-logtostderr","-v","2","--ipam-controller-network","192.168.1.1/24,192.168.1.1,8.8.8.8"]}'
         command:
-        - /usr/local/bin/user-cluster-controller-manager
+        - /http-prober-bin/http-prober
         env:
         - name: NAMESPACE
           valueFrom:
@@ -89,27 +76,21 @@ spec:
         - mountPath: /etc/kubernetes/pki/openvpn
           name: openvpn-ca
           readOnly: true
+        - mountPath: /http-prober-bin
+          name: http-prober-bin
       imagePullSecrets:
       - name: dockercfg
       initContainers:
-      - args:
-        - -endpoint
-        - https://apiserver-external.cluster-de-test-01.svc.cluster.local.:30000/healthz
-        - -insecure
-        - -retries
-        - "100"
-        - -retry-wait
-        - "2"
-        - -timeout
-        - "1"
-        command:
+      - command:
+        - /bin/cp
         - /usr/local/bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.1
-        imagePullPolicy: IfNotPresent
-        name: apiserver-running
+        - /http-prober-bin/http-prober
+        image: quay.io/kubermatic/http-prober:v0.2-dev0
+        name: copy-http-prober
         resources: {}
-        terminationMessagePath: /dev/termination-log
-        terminationMessagePolicy: File
+        volumeMounts:
+        - mountPath: /http-prober-bin
+          name: http-prober-bin
       volumes:
       - name: internal-admin-kubeconfig
         secret:
@@ -126,4 +107,6 @@ spec:
         secret:
           defaultMode: 292
           secretName: openvpn-ca
+      - emptyDir: {}
+        name: http-prober-bin
 status: {}

--- a/api/pkg/resources/test/fixtures/deployment-openstack-1.13.0-controller-manager.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-openstack-1.13.0-controller-manager.yaml
@@ -176,7 +176,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.2-dev0
+        image: quay.io/kubermatic/http-prober:v0.2
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/api/pkg/resources/test/fixtures/deployment-openstack-1.13.0-controller-manager.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-openstack-1.13.0-controller-manager.yaml
@@ -102,42 +102,19 @@ spec:
           name: openvpn-client-certificates
           readOnly: true
       - args:
-        - --kubeconfig
-        - /etc/kubernetes/kubeconfig/kubeconfig
-        - --service-account-private-key-file
-        - /etc/kubernetes/service-account-key/sa.key
-        - --root-ca-file
-        - /etc/kubernetes/pki/ca/ca.crt
-        - --cluster-signing-cert-file
-        - /etc/kubernetes/pki/ca/ca.crt
-        - --cluster-signing-key-file
-        - /etc/kubernetes/pki/ca/ca.key
-        - --cluster-cidr
-        - 172.25.0.0/16
-        - --allocate-node-cidrs=true
-        - --controllers
-        - '*,bootstrapsigner,tokencleaner'
-        - --use-service-account-credentials=true
-        - --feature-gates
-        - RotateKubeletClientCertificate=true,RotateKubeletServerCertificate=true,ScheduleDaemonSetPods=false
-        - --cloud-provider
-        - openstack
-        - --cloud-config
-        - /etc/kubernetes/cloud/config
-        - --configure-cloud-routes=false
-        - --authentication-kubeconfig
-        - /etc/kubernetes/kubeconfig/kubeconfig
-        - --client-ca-file
-        - /etc/kubernetes/pki/ca/ca.crt
-        - --authentication-kubeconfig
-        - /etc/kubernetes/kubeconfig/kubeconfig
-        - --authorization-kubeconfig
-        - /etc/kubernetes/kubeconfig/kubeconfig
-        - --port
-        - "0"
+        - -endpoint
+        - https://apiserver-external.cluster-de-test-01.svc.cluster.local.:30000/healthz
+        - -insecure
+        - -retries
+        - "100"
+        - -retry-wait
+        - "2"
+        - -timeout
+        - "1"
+        - -command
+        - '{"command":"/hyperkube","args":["kube-controller-manager","--kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","--service-account-private-key-file","/etc/kubernetes/service-account-key/sa.key","--root-ca-file","/etc/kubernetes/pki/ca/ca.crt","--cluster-signing-cert-file","/etc/kubernetes/pki/ca/ca.crt","--cluster-signing-key-file","/etc/kubernetes/pki/ca/ca.key","--cluster-cidr","172.25.0.0/16","--allocate-node-cidrs=true","--controllers","*,bootstrapsigner,tokencleaner","--use-service-account-credentials=true","--feature-gates","RotateKubeletClientCertificate=true,RotateKubeletServerCertificate=true,ScheduleDaemonSetPods=false","--cloud-provider","openstack","--cloud-config","/etc/kubernetes/cloud/config","--configure-cloud-routes=false","--authentication-kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","--client-ca-file","/etc/kubernetes/pki/ca/ca.crt","--authentication-kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","--authorization-kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","--port","0"]}'
         command:
-        - /hyperkube
-        - kube-controller-manager
+        - /http-prober-bin/http-prober
         image: gcr.io/google_containers/hyperkube-amd64:v1.13.0
         livenessProbe:
           failureThreshold: 8
@@ -179,6 +156,8 @@ spec:
         - mountPath: /etc/kubernetes/kubeconfig
           name: controllermanager-kubeconfig
           readOnly: true
+        - mountPath: /http-prober-bin
+          name: http-prober-bin
       dnsConfig:
         nameservers:
         - 192.0.2.14
@@ -193,24 +172,16 @@ spec:
       imagePullSecrets:
       - name: dockercfg
       initContainers:
-      - args:
-        - -endpoint
-        - https://apiserver-external.cluster-de-test-01.svc.cluster.local.:30000/healthz
-        - -insecure
-        - -retries
-        - "100"
-        - -retry-wait
-        - "2"
-        - -timeout
-        - "1"
-        command:
+      - command:
+        - /bin/cp
         - /usr/local/bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.1
-        imagePullPolicy: IfNotPresent
-        name: apiserver-running
+        - /http-prober-bin/http-prober
+        image: quay.io/kubermatic/http-prober:v0.2-dev0
+        name: copy-http-prober
         resources: {}
-        terminationMessagePath: /dev/termination-log
-        terminationMessagePolicy: File
+        volumeMounts:
+        - mountPath: /http-prober-bin
+          name: http-prober-bin
       volumes:
       - name: ca
         secret:
@@ -232,4 +203,6 @@ spec:
         secret:
           defaultMode: 256
           secretName: controllermanager-kubeconfig
+      - emptyDir: {}
+        name: http-prober-bin
 status: {}

--- a/api/pkg/resources/test/fixtures/deployment-openstack-1.13.0-kube-state-metrics.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-openstack-1.13.0-kube-state-metrics.yaml
@@ -21,14 +21,19 @@ spec:
     spec:
       containers:
       - args:
-        - --kubeconfig
-        - /etc/kubernetes/kubeconfig/kubeconfig
-        - --port
-        - "8080"
-        - --telemetry-port
-        - "8081"
+        - -endpoint
+        - https://apiserver-external.cluster-de-test-01.svc.cluster.local.:30000/healthz
+        - -insecure
+        - -retries
+        - "100"
+        - -retry-wait
+        - "2"
+        - -timeout
+        - "1"
+        - -command
+        - '{"command":"/kube-state-metrics","args":["--kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","--port","8080","--telemetry-port","8081"]}'
         command:
-        - /kube-state-metrics
+        - /http-prober-bin/http-prober
         image: quay.io/coreos/kube-state-metrics:v1.6.0
         name: kube-state-metrics
         ports:
@@ -58,30 +63,26 @@ spec:
         - mountPath: /etc/kubernetes/kubeconfig
           name: kube-state-metrics-kubeconfig
           readOnly: true
+        - mountPath: /http-prober-bin
+          name: http-prober-bin
       imagePullSecrets:
       - name: dockercfg
       initContainers:
-      - args:
-        - -endpoint
-        - https://apiserver-external.cluster-de-test-01.svc.cluster.local.:30000/healthz
-        - -insecure
-        - -retries
-        - "100"
-        - -retry-wait
-        - "2"
-        - -timeout
-        - "1"
-        command:
+      - command:
+        - /bin/cp
         - /usr/local/bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.1
-        imagePullPolicy: IfNotPresent
-        name: apiserver-running
+        - /http-prober-bin/http-prober
+        image: quay.io/kubermatic/http-prober:v0.2-dev0
+        name: copy-http-prober
         resources: {}
-        terminationMessagePath: /dev/termination-log
-        terminationMessagePolicy: File
+        volumeMounts:
+        - mountPath: /http-prober-bin
+          name: http-prober-bin
       volumes:
       - name: kube-state-metrics-kubeconfig
         secret:
           defaultMode: 256
           secretName: kube-state-metrics-kubeconfig
+      - emptyDir: {}
+        name: http-prober-bin
 status: {}

--- a/api/pkg/resources/test/fixtures/deployment-openstack-1.13.0-kube-state-metrics.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-openstack-1.13.0-kube-state-metrics.yaml
@@ -72,7 +72,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.2-dev0
+        image: quay.io/kubermatic/http-prober:v0.2
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/api/pkg/resources/test/fixtures/deployment-openstack-1.13.0-machine-controller-webhook.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-openstack-1.13.0-machine-controller-webhook.yaml
@@ -24,15 +24,19 @@ spec:
     spec:
       containers:
       - args:
-        - -kubeconfig
-        - /etc/kubernetes/kubeconfig/kubeconfig
-        - -logtostderr
-        - -v
-        - "4"
-        - -listen-address
-        - 0.0.0.0:9876
+        - -endpoint
+        - https://apiserver-external.cluster-de-test-01.svc.cluster.local.:30000/healthz
+        - -insecure
+        - -retries
+        - "100"
+        - -retry-wait
+        - "2"
+        - -timeout
+        - "1"
+        - -command
+        - '{"command":"/usr/local/bin/webhook","args":["-kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","-logtostderr","-v","4","-listen-address","0.0.0.0:9876"]}'
         command:
-        - /usr/local/bin/webhook
+        - /http-prober-bin/http-prober
         env:
         - name: OS_AUTH_URL
           value: https://example.com:8000/v3
@@ -79,27 +83,21 @@ spec:
         - mountPath: /tmp/cert
           name: machinecontroller-webhook-serving-cert
           readOnly: true
+        - mountPath: /http-prober-bin
+          name: http-prober-bin
       imagePullSecrets:
       - name: dockercfg
       initContainers:
-      - args:
-        - -endpoint
-        - https://apiserver-external.cluster-de-test-01.svc.cluster.local.:30000/healthz
-        - -insecure
-        - -retries
-        - "100"
-        - -retry-wait
-        - "2"
-        - -timeout
-        - "1"
-        command:
+      - command:
+        - /bin/cp
         - /usr/local/bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.1
-        imagePullPolicy: IfNotPresent
-        name: apiserver-running
+        - /http-prober-bin/http-prober
+        image: quay.io/kubermatic/http-prober:v0.2-dev0
+        name: copy-http-prober
         resources: {}
-        terminationMessagePath: /dev/termination-log
-        terminationMessagePolicy: File
+        volumeMounts:
+        - mountPath: /http-prober-bin
+          name: http-prober-bin
       volumes:
       - name: machinecontroller-kubeconfig
         secret:
@@ -109,4 +107,6 @@ spec:
         secret:
           defaultMode: 292
           secretName: machinecontroller-webhook-serving-cert
+      - emptyDir: {}
+        name: http-prober-bin
 status: {}

--- a/api/pkg/resources/test/fixtures/deployment-openstack-1.13.0-machine-controller-webhook.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-openstack-1.13.0-machine-controller-webhook.yaml
@@ -92,7 +92,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.2-dev0
+        image: quay.io/kubermatic/http-prober:v0.2
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/api/pkg/resources/test/fixtures/deployment-openstack-1.13.0-machine-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-openstack-1.13.0-machine-controller.yaml
@@ -27,17 +27,19 @@ spec:
     spec:
       containers:
       - args:
-        - -kubeconfig
-        - /etc/kubernetes/kubeconfig/kubeconfig
-        - -logtostderr
-        - -v
-        - "4"
-        - -cluster-dns
-        - 169.254.20.10
-        - -internal-listen-address
-        - 0.0.0.0:8085
+        - -endpoint
+        - https://apiserver-external.cluster-de-test-01.svc.cluster.local.:30000/healthz
+        - -insecure
+        - -retries
+        - "100"
+        - -retry-wait
+        - "2"
+        - -timeout
+        - "1"
+        - -command
+        - '{"command":"/usr/local/bin/machine-controller","args":["-kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","-logtostderr","-v","4","-cluster-dns","169.254.20.10","-internal-listen-address","0.0.0.0:8085"]}'
         command:
-        - /usr/local/bin/machine-controller
+        - /http-prober-bin/http-prober
         env:
         - name: OS_AUTH_URL
           value: https://example.com:8000/v3
@@ -72,30 +74,26 @@ spec:
         - mountPath: /etc/kubernetes/kubeconfig
           name: machinecontroller-kubeconfig
           readOnly: true
+        - mountPath: /http-prober-bin
+          name: http-prober-bin
       imagePullSecrets:
       - name: dockercfg
       initContainers:
-      - args:
-        - -endpoint
-        - https://apiserver-external.cluster-de-test-01.svc.cluster.local.:30000/healthz
-        - -insecure
-        - -retries
-        - "100"
-        - -retry-wait
-        - "2"
-        - -timeout
-        - "1"
-        command:
+      - command:
+        - /bin/cp
         - /usr/local/bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.1
-        imagePullPolicy: IfNotPresent
-        name: apiserver-running
+        - /http-prober-bin/http-prober
+        image: quay.io/kubermatic/http-prober:v0.2-dev0
+        name: copy-http-prober
         resources: {}
-        terminationMessagePath: /dev/termination-log
-        terminationMessagePolicy: File
+        volumeMounts:
+        - mountPath: /http-prober-bin
+          name: http-prober-bin
       volumes:
       - name: machinecontroller-kubeconfig
         secret:
           defaultMode: 292
           secretName: machinecontroller-kubeconfig
+      - emptyDir: {}
+        name: http-prober-bin
 status: {}

--- a/api/pkg/resources/test/fixtures/deployment-openstack-1.13.0-machine-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-openstack-1.13.0-machine-controller.yaml
@@ -83,7 +83,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.2-dev0
+        image: quay.io/kubermatic/http-prober:v0.2
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/api/pkg/resources/test/fixtures/deployment-openstack-1.13.0-metrics-server.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-openstack-1.13.0-metrics-server.yaml
@@ -41,22 +41,19 @@ spec:
             weight: 10
       containers:
       - args:
-        - --kubeconfig
-        - /etc/kubernetes/kubeconfig/kubeconfig
-        - --authentication-kubeconfig
-        - /etc/kubernetes/kubeconfig/kubeconfig
-        - --authorization-kubeconfig
-        - /etc/kubernetes/kubeconfig/kubeconfig
-        - --kubelet-port
-        - "10250"
-        - --kubelet-insecure-tls
-        - --kubelet-preferred-address-types
-        - ExternalIP,InternalIP
-        - --v
+        - -endpoint
+        - https://apiserver-external.cluster-de-test-01.svc.cluster.local.:30000/healthz
+        - -insecure
+        - -retries
+        - "100"
+        - -retry-wait
+        - "2"
+        - -timeout
         - "1"
-        - --logtostderr
+        - -command
+        - '{"command":"/metrics-server","args":["--kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","--authentication-kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","--authorization-kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","--kubelet-port","10250","--kubelet-insecure-tls","--kubelet-preferred-address-types","ExternalIP,InternalIP","--v","1","--logtostderr"]}'
         command:
-        - /metrics-server
+        - /http-prober-bin/http-prober
         image: gcr.io/google_containers/metrics-server-amd64:v0.3.2
         name: metrics-server
         resources:
@@ -70,6 +67,8 @@ spec:
         - mountPath: /etc/kubernetes/kubeconfig
           name: metrics-server
           readOnly: true
+        - mountPath: /http-prober-bin
+          name: http-prober-bin
       - args:
         - --client
         - --proto
@@ -158,24 +157,16 @@ spec:
       imagePullSecrets:
       - name: dockercfg
       initContainers:
-      - args:
-        - -endpoint
-        - https://apiserver-external.cluster-de-test-01.svc.cluster.local.:30000/healthz
-        - -insecure
-        - -retries
-        - "100"
-        - -retry-wait
-        - "2"
-        - -timeout
-        - "1"
-        command:
+      - command:
+        - /bin/cp
         - /usr/local/bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.1
-        imagePullPolicy: IfNotPresent
-        name: apiserver-running
+        - /http-prober-bin/http-prober
+        image: quay.io/kubermatic/http-prober:v0.2-dev0
+        name: copy-http-prober
         resources: {}
-        terminationMessagePath: /dev/termination-log
-        terminationMessagePolicy: File
+        volumeMounts:
+        - mountPath: /http-prober-bin
+          name: http-prober-bin
       volumes:
       - name: metrics-server
         secret:
@@ -189,4 +180,6 @@ spec:
         secret:
           defaultMode: 292
           secretName: kubeletdnatcontroller-kubeconfig
+      - emptyDir: {}
+        name: http-prober-bin
 status: {}

--- a/api/pkg/resources/test/fixtures/deployment-openstack-1.13.0-metrics-server.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-openstack-1.13.0-metrics-server.yaml
@@ -161,7 +161,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.2-dev0
+        image: quay.io/kubermatic/http-prober:v0.2
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/api/pkg/resources/test/fixtures/deployment-openstack-1.13.0-scheduler.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-openstack-1.13.0-scheduler.yaml
@@ -100,21 +100,19 @@ spec:
           name: openvpn-client-certificates
           readOnly: true
       - args:
-        - --kubeconfig
-        - /etc/kubernetes/kubeconfig/kubeconfig
-        - --authentication-kubeconfig
-        - /etc/kubernetes/kubeconfig/kubeconfig
-        - --authorization-kubeconfig
-        - /etc/kubernetes/kubeconfig/kubeconfig
-        - --client-ca-file
-        - /etc/kubernetes/pki/ca/ca.crt
-        - --port
-        - "0"
-        - --feature-gates
-        - ScheduleDaemonSetPods=false
+        - -endpoint
+        - https://apiserver-external.cluster-de-test-01.svc.cluster.local.:30000/healthz
+        - -insecure
+        - -retries
+        - "100"
+        - -retry-wait
+        - "2"
+        - -timeout
+        - "1"
+        - -command
+        - '{"command":"/hyperkube","args":["kube-scheduler","--kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","--authentication-kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","--authorization-kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","--client-ca-file","/etc/kubernetes/pki/ca/ca.crt","--port","0","--feature-gates","ScheduleDaemonSetPods=false"]}'
         command:
-        - /hyperkube
-        - kube-scheduler
+        - /http-prober-bin/http-prober
         image: gcr.io/google_containers/hyperkube-amd64:v1.13.0
         livenessProbe:
           failureThreshold: 8
@@ -150,6 +148,8 @@ spec:
         - mountPath: /etc/kubernetes/pki/ca
           name: ca
           readOnly: true
+        - mountPath: /http-prober-bin
+          name: http-prober-bin
       dnsConfig:
         nameservers:
         - 192.0.2.14
@@ -164,24 +164,16 @@ spec:
       imagePullSecrets:
       - name: dockercfg
       initContainers:
-      - args:
-        - -endpoint
-        - https://apiserver-external.cluster-de-test-01.svc.cluster.local.:30000/healthz
-        - -insecure
-        - -retries
-        - "100"
-        - -retry-wait
-        - "2"
-        - -timeout
-        - "1"
-        command:
+      - command:
+        - /bin/cp
         - /usr/local/bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.1
-        imagePullPolicy: IfNotPresent
-        name: apiserver-running
+        - /http-prober-bin/http-prober
+        image: quay.io/kubermatic/http-prober:v0.2-dev0
+        name: copy-http-prober
         resources: {}
-        terminationMessagePath: /dev/termination-log
-        terminationMessagePolicy: File
+        volumeMounts:
+        - mountPath: /http-prober-bin
+          name: http-prober-bin
       volumes:
       - name: openvpn-client-certificates
         secret:
@@ -198,4 +190,6 @@ spec:
         secret:
           defaultMode: 256
           secretName: scheduler-kubeconfig
+      - emptyDir: {}
+        name: http-prober-bin
 status: {}

--- a/api/pkg/resources/test/fixtures/deployment-openstack-1.13.0-scheduler.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-openstack-1.13.0-scheduler.yaml
@@ -168,7 +168,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.2-dev0
+        image: quay.io/kubermatic/http-prober:v0.2
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/api/pkg/resources/test/fixtures/deployment-openstack-1.13.0-usercluster-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-openstack-1.13.0-usercluster-controller.yaml
@@ -85,7 +85,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.2-dev0
+        image: quay.io/kubermatic/http-prober:v0.2
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/api/pkg/resources/test/fixtures/deployment-openstack-1.13.0-usercluster-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-openstack-1.13.0-usercluster-controller.yaml
@@ -29,32 +29,19 @@ spec:
     spec:
       containers:
       - args:
-        - -kubeconfig
-        - /etc/kubernetes/kubeconfig/kubeconfig
-        - -metrics-listen-address
-        - 0.0.0.0:8085
-        - -health-listen-address
-        - 0.0.0.0:8086
-        - -namespace
-        - $(NAMESPACE)
-        - -ca-cert
-        - /etc/kubernetes/pki/ca/ca.crt
-        - -cluster-url
-        - ""
-        - -openvpn-server-port
-        - "30003"
-        - -overwrite-registry
-        - ""
-        - -openshift=false
-        - -openvpn-ca-cert-file=/etc/kubernetes/pki/openvpn/ca.crt
-        - -openvpn-ca-key-file=/etc/kubernetes/pki/openvpn/ca.key
-        - -logtostderr
-        - -v
+        - -endpoint
+        - https://apiserver-external.cluster-de-test-01.svc.cluster.local.:30000/healthz
+        - -insecure
+        - -retries
+        - "100"
+        - -retry-wait
         - "2"
-        - --ipam-controller-network
-        - 192.168.1.1/24,192.168.1.1,8.8.8.8
+        - -timeout
+        - "1"
+        - -command
+        - '{"command":"/usr/local/bin/user-cluster-controller-manager","args":["-kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","-metrics-listen-address","0.0.0.0:8085","-health-listen-address","0.0.0.0:8086","-namespace","$(NAMESPACE)","-ca-cert","/etc/kubernetes/pki/ca/ca.crt","-cluster-url","","-openvpn-server-port","30003","-overwrite-registry","","-openshift=false","-openvpn-ca-cert-file=/etc/kubernetes/pki/openvpn/ca.crt","-openvpn-ca-key-file=/etc/kubernetes/pki/openvpn/ca.key","-logtostderr","-v","2","--ipam-controller-network","192.168.1.1/24,192.168.1.1,8.8.8.8"]}'
         command:
-        - /usr/local/bin/user-cluster-controller-manager
+        - /http-prober-bin/http-prober
         env:
         - name: NAMESPACE
           valueFrom:
@@ -89,27 +76,21 @@ spec:
         - mountPath: /etc/kubernetes/pki/openvpn
           name: openvpn-ca
           readOnly: true
+        - mountPath: /http-prober-bin
+          name: http-prober-bin
       imagePullSecrets:
       - name: dockercfg
       initContainers:
-      - args:
-        - -endpoint
-        - https://apiserver-external.cluster-de-test-01.svc.cluster.local.:30000/healthz
-        - -insecure
-        - -retries
-        - "100"
-        - -retry-wait
-        - "2"
-        - -timeout
-        - "1"
-        command:
+      - command:
+        - /bin/cp
         - /usr/local/bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.1
-        imagePullPolicy: IfNotPresent
-        name: apiserver-running
+        - /http-prober-bin/http-prober
+        image: quay.io/kubermatic/http-prober:v0.2-dev0
+        name: copy-http-prober
         resources: {}
-        terminationMessagePath: /dev/termination-log
-        terminationMessagePolicy: File
+        volumeMounts:
+        - mountPath: /http-prober-bin
+          name: http-prober-bin
       volumes:
       - name: internal-admin-kubeconfig
         secret:
@@ -126,4 +107,6 @@ spec:
         secret:
           defaultMode: 292
           secretName: openvpn-ca
+      - emptyDir: {}
+        name: http-prober-bin
 status: {}

--- a/api/pkg/resources/test/fixtures/deployment-vsphere-1.10.0-controller-manager.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-vsphere-1.10.0-controller-manager.yaml
@@ -180,7 +180,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.2-dev0
+        image: quay.io/kubermatic/http-prober:v0.2
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/api/pkg/resources/test/fixtures/deployment-vsphere-1.10.0-controller-manager.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-vsphere-1.10.0-controller-manager.yaml
@@ -102,32 +102,19 @@ spec:
           name: openvpn-client-certificates
           readOnly: true
       - args:
-        - --kubeconfig
-        - /etc/kubernetes/kubeconfig/kubeconfig
-        - --service-account-private-key-file
-        - /etc/kubernetes/service-account-key/sa.key
-        - --root-ca-file
-        - /etc/kubernetes/pki/ca/ca.crt
-        - --cluster-signing-cert-file
-        - /etc/kubernetes/pki/ca/ca.crt
-        - --cluster-signing-key-file
-        - /etc/kubernetes/pki/ca/ca.key
-        - --cluster-cidr
-        - 172.25.0.0/16
-        - --allocate-node-cidrs=true
-        - --controllers
-        - '*,bootstrapsigner,tokencleaner'
-        - --use-service-account-credentials=true
-        - --feature-gates
-        - RotateKubeletClientCertificate=true,RotateKubeletServerCertificate=true
-        - --cloud-provider
-        - vsphere
-        - --cloud-config
-        - /etc/kubernetes/cloud/config
-        - --configure-cloud-routes=false
+        - -endpoint
+        - https://apiserver-external.cluster-de-test-01.svc.cluster.local.:30000/healthz
+        - -insecure
+        - -retries
+        - "100"
+        - -retry-wait
+        - "2"
+        - -timeout
+        - "1"
+        - -command
+        - '{"command":"/hyperkube","args":["kube-controller-manager","--kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","--service-account-private-key-file","/etc/kubernetes/service-account-key/sa.key","--root-ca-file","/etc/kubernetes/pki/ca/ca.crt","--cluster-signing-cert-file","/etc/kubernetes/pki/ca/ca.crt","--cluster-signing-key-file","/etc/kubernetes/pki/ca/ca.key","--cluster-cidr","172.25.0.0/16","--allocate-node-cidrs=true","--controllers","*,bootstrapsigner,tokencleaner","--use-service-account-credentials=true","--feature-gates","RotateKubeletClientCertificate=true,RotateKubeletServerCertificate=true","--cloud-provider","vsphere","--cloud-config","/etc/kubernetes/cloud/config","--configure-cloud-routes=false"]}'
         command:
-        - /hyperkube
-        - kube-controller-manager
+        - /http-prober-bin/http-prober
         image: gcr.io/google_containers/hyperkube-amd64:v1.10.0
         livenessProbe:
           failureThreshold: 8
@@ -173,6 +160,8 @@ spec:
           name: cloud-config
           readOnly: true
           subPath: fakeVmwareUUID
+        - mountPath: /http-prober-bin
+          name: http-prober-bin
       dnsConfig:
         nameservers:
         - 192.0.2.14
@@ -187,24 +176,16 @@ spec:
       imagePullSecrets:
       - name: dockercfg
       initContainers:
-      - args:
-        - -endpoint
-        - https://apiserver-external.cluster-de-test-01.svc.cluster.local.:30000/healthz
-        - -insecure
-        - -retries
-        - "100"
-        - -retry-wait
-        - "2"
-        - -timeout
-        - "1"
-        command:
+      - command:
+        - /bin/cp
         - /usr/local/bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.1
-        imagePullPolicy: IfNotPresent
-        name: apiserver-running
+        - /http-prober-bin/http-prober
+        image: quay.io/kubermatic/http-prober:v0.2-dev0
+        name: copy-http-prober
         resources: {}
-        terminationMessagePath: /dev/termination-log
-        terminationMessagePolicy: File
+        volumeMounts:
+        - mountPath: /http-prober-bin
+          name: http-prober-bin
       volumes:
       - name: ca
         secret:
@@ -226,4 +207,6 @@ spec:
         secret:
           defaultMode: 256
           secretName: controllermanager-kubeconfig
+      - emptyDir: {}
+        name: http-prober-bin
 status: {}

--- a/api/pkg/resources/test/fixtures/deployment-vsphere-1.10.0-kube-state-metrics.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-vsphere-1.10.0-kube-state-metrics.yaml
@@ -21,14 +21,19 @@ spec:
     spec:
       containers:
       - args:
-        - --kubeconfig
-        - /etc/kubernetes/kubeconfig/kubeconfig
-        - --port
-        - "8080"
-        - --telemetry-port
-        - "8081"
+        - -endpoint
+        - https://apiserver-external.cluster-de-test-01.svc.cluster.local.:30000/healthz
+        - -insecure
+        - -retries
+        - "100"
+        - -retry-wait
+        - "2"
+        - -timeout
+        - "1"
+        - -command
+        - '{"command":"/kube-state-metrics","args":["--kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","--port","8080","--telemetry-port","8081"]}'
         command:
-        - /kube-state-metrics
+        - /http-prober-bin/http-prober
         image: quay.io/coreos/kube-state-metrics:v1.6.0
         name: kube-state-metrics
         ports:
@@ -58,30 +63,26 @@ spec:
         - mountPath: /etc/kubernetes/kubeconfig
           name: kube-state-metrics-kubeconfig
           readOnly: true
+        - mountPath: /http-prober-bin
+          name: http-prober-bin
       imagePullSecrets:
       - name: dockercfg
       initContainers:
-      - args:
-        - -endpoint
-        - https://apiserver-external.cluster-de-test-01.svc.cluster.local.:30000/healthz
-        - -insecure
-        - -retries
-        - "100"
-        - -retry-wait
-        - "2"
-        - -timeout
-        - "1"
-        command:
+      - command:
+        - /bin/cp
         - /usr/local/bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.1
-        imagePullPolicy: IfNotPresent
-        name: apiserver-running
+        - /http-prober-bin/http-prober
+        image: quay.io/kubermatic/http-prober:v0.2-dev0
+        name: copy-http-prober
         resources: {}
-        terminationMessagePath: /dev/termination-log
-        terminationMessagePolicy: File
+        volumeMounts:
+        - mountPath: /http-prober-bin
+          name: http-prober-bin
       volumes:
       - name: kube-state-metrics-kubeconfig
         secret:
           defaultMode: 256
           secretName: kube-state-metrics-kubeconfig
+      - emptyDir: {}
+        name: http-prober-bin
 status: {}

--- a/api/pkg/resources/test/fixtures/deployment-vsphere-1.10.0-kube-state-metrics.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-vsphere-1.10.0-kube-state-metrics.yaml
@@ -72,7 +72,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.2-dev0
+        image: quay.io/kubermatic/http-prober:v0.2
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/api/pkg/resources/test/fixtures/deployment-vsphere-1.10.0-machine-controller-webhook.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-vsphere-1.10.0-machine-controller-webhook.yaml
@@ -24,15 +24,19 @@ spec:
     spec:
       containers:
       - args:
-        - -kubeconfig
-        - /etc/kubernetes/kubeconfig/kubeconfig
-        - -logtostderr
-        - -v
-        - "4"
-        - -listen-address
-        - 0.0.0.0:9876
+        - -endpoint
+        - https://apiserver-external.cluster-de-test-01.svc.cluster.local.:30000/healthz
+        - -insecure
+        - -retries
+        - "100"
+        - -retry-wait
+        - "2"
+        - -timeout
+        - "1"
+        - -command
+        - '{"command":"/usr/local/bin/webhook","args":["-kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","-logtostderr","-v","4","-listen-address","0.0.0.0:9876"]}'
         command:
-        - /usr/local/bin/webhook
+        - /http-prober-bin/http-prober
         env:
         - name: VSPHERE_ADDRESS
           value: https://vs-endpoint.io
@@ -73,27 +77,21 @@ spec:
         - mountPath: /tmp/cert
           name: machinecontroller-webhook-serving-cert
           readOnly: true
+        - mountPath: /http-prober-bin
+          name: http-prober-bin
       imagePullSecrets:
       - name: dockercfg
       initContainers:
-      - args:
-        - -endpoint
-        - https://apiserver-external.cluster-de-test-01.svc.cluster.local.:30000/healthz
-        - -insecure
-        - -retries
-        - "100"
-        - -retry-wait
-        - "2"
-        - -timeout
-        - "1"
-        command:
+      - command:
+        - /bin/cp
         - /usr/local/bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.1
-        imagePullPolicy: IfNotPresent
-        name: apiserver-running
+        - /http-prober-bin/http-prober
+        image: quay.io/kubermatic/http-prober:v0.2-dev0
+        name: copy-http-prober
         resources: {}
-        terminationMessagePath: /dev/termination-log
-        terminationMessagePolicy: File
+        volumeMounts:
+        - mountPath: /http-prober-bin
+          name: http-prober-bin
       volumes:
       - name: machinecontroller-kubeconfig
         secret:
@@ -103,4 +101,6 @@ spec:
         secret:
           defaultMode: 292
           secretName: machinecontroller-webhook-serving-cert
+      - emptyDir: {}
+        name: http-prober-bin
 status: {}

--- a/api/pkg/resources/test/fixtures/deployment-vsphere-1.10.0-machine-controller-webhook.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-vsphere-1.10.0-machine-controller-webhook.yaml
@@ -86,7 +86,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.2-dev0
+        image: quay.io/kubermatic/http-prober:v0.2
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/api/pkg/resources/test/fixtures/deployment-vsphere-1.10.0-machine-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-vsphere-1.10.0-machine-controller.yaml
@@ -27,17 +27,19 @@ spec:
     spec:
       containers:
       - args:
-        - -kubeconfig
-        - /etc/kubernetes/kubeconfig/kubeconfig
-        - -logtostderr
-        - -v
-        - "4"
-        - -cluster-dns
-        - 169.254.20.10
-        - -internal-listen-address
-        - 0.0.0.0:8085
+        - -endpoint
+        - https://apiserver-external.cluster-de-test-01.svc.cluster.local.:30000/healthz
+        - -insecure
+        - -retries
+        - "100"
+        - -retry-wait
+        - "2"
+        - -timeout
+        - "1"
+        - -command
+        - '{"command":"/usr/local/bin/machine-controller","args":["-kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","-logtostderr","-v","4","-cluster-dns","169.254.20.10","-internal-listen-address","0.0.0.0:8085"]}'
         command:
-        - /usr/local/bin/machine-controller
+        - /http-prober-bin/http-prober
         env:
         - name: VSPHERE_ADDRESS
           value: https://vs-endpoint.io
@@ -66,30 +68,26 @@ spec:
         - mountPath: /etc/kubernetes/kubeconfig
           name: machinecontroller-kubeconfig
           readOnly: true
+        - mountPath: /http-prober-bin
+          name: http-prober-bin
       imagePullSecrets:
       - name: dockercfg
       initContainers:
-      - args:
-        - -endpoint
-        - https://apiserver-external.cluster-de-test-01.svc.cluster.local.:30000/healthz
-        - -insecure
-        - -retries
-        - "100"
-        - -retry-wait
-        - "2"
-        - -timeout
-        - "1"
-        command:
+      - command:
+        - /bin/cp
         - /usr/local/bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.1
-        imagePullPolicy: IfNotPresent
-        name: apiserver-running
+        - /http-prober-bin/http-prober
+        image: quay.io/kubermatic/http-prober:v0.2-dev0
+        name: copy-http-prober
         resources: {}
-        terminationMessagePath: /dev/termination-log
-        terminationMessagePolicy: File
+        volumeMounts:
+        - mountPath: /http-prober-bin
+          name: http-prober-bin
       volumes:
       - name: machinecontroller-kubeconfig
         secret:
           defaultMode: 292
           secretName: machinecontroller-kubeconfig
+      - emptyDir: {}
+        name: http-prober-bin
 status: {}

--- a/api/pkg/resources/test/fixtures/deployment-vsphere-1.10.0-machine-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-vsphere-1.10.0-machine-controller.yaml
@@ -77,7 +77,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.2-dev0
+        image: quay.io/kubermatic/http-prober:v0.2
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/api/pkg/resources/test/fixtures/deployment-vsphere-1.10.0-metrics-server.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-vsphere-1.10.0-metrics-server.yaml
@@ -41,22 +41,19 @@ spec:
             weight: 10
       containers:
       - args:
-        - --kubeconfig
-        - /etc/kubernetes/kubeconfig/kubeconfig
-        - --authentication-kubeconfig
-        - /etc/kubernetes/kubeconfig/kubeconfig
-        - --authorization-kubeconfig
-        - /etc/kubernetes/kubeconfig/kubeconfig
-        - --kubelet-port
-        - "10250"
-        - --kubelet-insecure-tls
-        - --kubelet-preferred-address-types
-        - ExternalIP,InternalIP
-        - --v
+        - -endpoint
+        - https://apiserver-external.cluster-de-test-01.svc.cluster.local.:30000/healthz
+        - -insecure
+        - -retries
+        - "100"
+        - -retry-wait
+        - "2"
+        - -timeout
         - "1"
-        - --logtostderr
+        - -command
+        - '{"command":"/metrics-server","args":["--kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","--authentication-kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","--authorization-kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","--kubelet-port","10250","--kubelet-insecure-tls","--kubelet-preferred-address-types","ExternalIP,InternalIP","--v","1","--logtostderr"]}'
         command:
-        - /metrics-server
+        - /http-prober-bin/http-prober
         image: gcr.io/google_containers/metrics-server-amd64:v0.3.2
         name: metrics-server
         resources:
@@ -70,6 +67,8 @@ spec:
         - mountPath: /etc/kubernetes/kubeconfig
           name: metrics-server
           readOnly: true
+        - mountPath: /http-prober-bin
+          name: http-prober-bin
       - args:
         - --client
         - --proto
@@ -158,24 +157,16 @@ spec:
       imagePullSecrets:
       - name: dockercfg
       initContainers:
-      - args:
-        - -endpoint
-        - https://apiserver-external.cluster-de-test-01.svc.cluster.local.:30000/healthz
-        - -insecure
-        - -retries
-        - "100"
-        - -retry-wait
-        - "2"
-        - -timeout
-        - "1"
-        command:
+      - command:
+        - /bin/cp
         - /usr/local/bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.1
-        imagePullPolicy: IfNotPresent
-        name: apiserver-running
+        - /http-prober-bin/http-prober
+        image: quay.io/kubermatic/http-prober:v0.2-dev0
+        name: copy-http-prober
         resources: {}
-        terminationMessagePath: /dev/termination-log
-        terminationMessagePolicy: File
+        volumeMounts:
+        - mountPath: /http-prober-bin
+          name: http-prober-bin
       volumes:
       - name: metrics-server
         secret:
@@ -189,4 +180,6 @@ spec:
         secret:
           defaultMode: 292
           secretName: kubeletdnatcontroller-kubeconfig
+      - emptyDir: {}
+        name: http-prober-bin
 status: {}

--- a/api/pkg/resources/test/fixtures/deployment-vsphere-1.10.0-metrics-server.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-vsphere-1.10.0-metrics-server.yaml
@@ -161,7 +161,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.2-dev0
+        image: quay.io/kubermatic/http-prober:v0.2
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/api/pkg/resources/test/fixtures/deployment-vsphere-1.10.0-scheduler.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-vsphere-1.10.0-scheduler.yaml
@@ -100,11 +100,19 @@ spec:
           name: openvpn-client-certificates
           readOnly: true
       - args:
-        - --kubeconfig
-        - /etc/kubernetes/kubeconfig/kubeconfig
+        - -endpoint
+        - https://apiserver-external.cluster-de-test-01.svc.cluster.local.:30000/healthz
+        - -insecure
+        - -retries
+        - "100"
+        - -retry-wait
+        - "2"
+        - -timeout
+        - "1"
+        - -command
+        - '{"command":"/hyperkube","args":["kube-scheduler","--kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig"]}'
         command:
-        - /hyperkube
-        - kube-scheduler
+        - /http-prober-bin/http-prober
         image: gcr.io/google_containers/hyperkube-amd64:v1.10.0
         livenessProbe:
           failureThreshold: 8
@@ -140,6 +148,8 @@ spec:
         - mountPath: /etc/kubernetes/pki/ca
           name: ca
           readOnly: true
+        - mountPath: /http-prober-bin
+          name: http-prober-bin
       dnsConfig:
         nameservers:
         - 192.0.2.14
@@ -154,24 +164,16 @@ spec:
       imagePullSecrets:
       - name: dockercfg
       initContainers:
-      - args:
-        - -endpoint
-        - https://apiserver-external.cluster-de-test-01.svc.cluster.local.:30000/healthz
-        - -insecure
-        - -retries
-        - "100"
-        - -retry-wait
-        - "2"
-        - -timeout
-        - "1"
-        command:
+      - command:
+        - /bin/cp
         - /usr/local/bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.1
-        imagePullPolicy: IfNotPresent
-        name: apiserver-running
+        - /http-prober-bin/http-prober
+        image: quay.io/kubermatic/http-prober:v0.2-dev0
+        name: copy-http-prober
         resources: {}
-        terminationMessagePath: /dev/termination-log
-        terminationMessagePolicy: File
+        volumeMounts:
+        - mountPath: /http-prober-bin
+          name: http-prober-bin
       volumes:
       - name: openvpn-client-certificates
         secret:
@@ -188,4 +190,6 @@ spec:
         secret:
           defaultMode: 256
           secretName: scheduler-kubeconfig
+      - emptyDir: {}
+        name: http-prober-bin
 status: {}

--- a/api/pkg/resources/test/fixtures/deployment-vsphere-1.10.0-scheduler.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-vsphere-1.10.0-scheduler.yaml
@@ -168,7 +168,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.2-dev0
+        image: quay.io/kubermatic/http-prober:v0.2
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/api/pkg/resources/test/fixtures/deployment-vsphere-1.10.0-usercluster-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-vsphere-1.10.0-usercluster-controller.yaml
@@ -85,7 +85,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.2-dev0
+        image: quay.io/kubermatic/http-prober:v0.2
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/api/pkg/resources/test/fixtures/deployment-vsphere-1.10.0-usercluster-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-vsphere-1.10.0-usercluster-controller.yaml
@@ -29,32 +29,19 @@ spec:
     spec:
       containers:
       - args:
-        - -kubeconfig
-        - /etc/kubernetes/kubeconfig/kubeconfig
-        - -metrics-listen-address
-        - 0.0.0.0:8085
-        - -health-listen-address
-        - 0.0.0.0:8086
-        - -namespace
-        - $(NAMESPACE)
-        - -ca-cert
-        - /etc/kubernetes/pki/ca/ca.crt
-        - -cluster-url
-        - ""
-        - -openvpn-server-port
-        - "30003"
-        - -overwrite-registry
-        - ""
-        - -openshift=false
-        - -openvpn-ca-cert-file=/etc/kubernetes/pki/openvpn/ca.crt
-        - -openvpn-ca-key-file=/etc/kubernetes/pki/openvpn/ca.key
-        - -logtostderr
-        - -v
+        - -endpoint
+        - https://apiserver-external.cluster-de-test-01.svc.cluster.local.:30000/healthz
+        - -insecure
+        - -retries
+        - "100"
+        - -retry-wait
         - "2"
-        - --ipam-controller-network
-        - 192.168.1.1/24,192.168.1.1,8.8.8.8
+        - -timeout
+        - "1"
+        - -command
+        - '{"command":"/usr/local/bin/user-cluster-controller-manager","args":["-kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","-metrics-listen-address","0.0.0.0:8085","-health-listen-address","0.0.0.0:8086","-namespace","$(NAMESPACE)","-ca-cert","/etc/kubernetes/pki/ca/ca.crt","-cluster-url","","-openvpn-server-port","30003","-overwrite-registry","","-openshift=false","-openvpn-ca-cert-file=/etc/kubernetes/pki/openvpn/ca.crt","-openvpn-ca-key-file=/etc/kubernetes/pki/openvpn/ca.key","-logtostderr","-v","2","--ipam-controller-network","192.168.1.1/24,192.168.1.1,8.8.8.8"]}'
         command:
-        - /usr/local/bin/user-cluster-controller-manager
+        - /http-prober-bin/http-prober
         env:
         - name: NAMESPACE
           valueFrom:
@@ -89,27 +76,21 @@ spec:
         - mountPath: /etc/kubernetes/pki/openvpn
           name: openvpn-ca
           readOnly: true
+        - mountPath: /http-prober-bin
+          name: http-prober-bin
       imagePullSecrets:
       - name: dockercfg
       initContainers:
-      - args:
-        - -endpoint
-        - https://apiserver-external.cluster-de-test-01.svc.cluster.local.:30000/healthz
-        - -insecure
-        - -retries
-        - "100"
-        - -retry-wait
-        - "2"
-        - -timeout
-        - "1"
-        command:
+      - command:
+        - /bin/cp
         - /usr/local/bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.1
-        imagePullPolicy: IfNotPresent
-        name: apiserver-running
+        - /http-prober-bin/http-prober
+        image: quay.io/kubermatic/http-prober:v0.2-dev0
+        name: copy-http-prober
         resources: {}
-        terminationMessagePath: /dev/termination-log
-        terminationMessagePolicy: File
+        volumeMounts:
+        - mountPath: /http-prober-bin
+          name: http-prober-bin
       volumes:
       - name: internal-admin-kubeconfig
         secret:
@@ -126,4 +107,6 @@ spec:
         secret:
           defaultMode: 292
           secretName: openvpn-ca
+      - emptyDir: {}
+        name: http-prober-bin
 status: {}

--- a/api/pkg/resources/test/fixtures/deployment-vsphere-1.10.6-controller-manager.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-vsphere-1.10.6-controller-manager.yaml
@@ -180,7 +180,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.2-dev0
+        image: quay.io/kubermatic/http-prober:v0.2
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/api/pkg/resources/test/fixtures/deployment-vsphere-1.10.6-controller-manager.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-vsphere-1.10.6-controller-manager.yaml
@@ -102,32 +102,19 @@ spec:
           name: openvpn-client-certificates
           readOnly: true
       - args:
-        - --kubeconfig
-        - /etc/kubernetes/kubeconfig/kubeconfig
-        - --service-account-private-key-file
-        - /etc/kubernetes/service-account-key/sa.key
-        - --root-ca-file
-        - /etc/kubernetes/pki/ca/ca.crt
-        - --cluster-signing-cert-file
-        - /etc/kubernetes/pki/ca/ca.crt
-        - --cluster-signing-key-file
-        - /etc/kubernetes/pki/ca/ca.key
-        - --cluster-cidr
-        - 172.25.0.0/16
-        - --allocate-node-cidrs=true
-        - --controllers
-        - '*,bootstrapsigner,tokencleaner'
-        - --use-service-account-credentials=true
-        - --feature-gates
-        - RotateKubeletClientCertificate=true,RotateKubeletServerCertificate=true
-        - --cloud-provider
-        - vsphere
-        - --cloud-config
-        - /etc/kubernetes/cloud/config
-        - --configure-cloud-routes=false
+        - -endpoint
+        - https://apiserver-external.cluster-de-test-01.svc.cluster.local.:30000/healthz
+        - -insecure
+        - -retries
+        - "100"
+        - -retry-wait
+        - "2"
+        - -timeout
+        - "1"
+        - -command
+        - '{"command":"/hyperkube","args":["kube-controller-manager","--kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","--service-account-private-key-file","/etc/kubernetes/service-account-key/sa.key","--root-ca-file","/etc/kubernetes/pki/ca/ca.crt","--cluster-signing-cert-file","/etc/kubernetes/pki/ca/ca.crt","--cluster-signing-key-file","/etc/kubernetes/pki/ca/ca.key","--cluster-cidr","172.25.0.0/16","--allocate-node-cidrs=true","--controllers","*,bootstrapsigner,tokencleaner","--use-service-account-credentials=true","--feature-gates","RotateKubeletClientCertificate=true,RotateKubeletServerCertificate=true","--cloud-provider","vsphere","--cloud-config","/etc/kubernetes/cloud/config","--configure-cloud-routes=false"]}'
         command:
-        - /hyperkube
-        - kube-controller-manager
+        - /http-prober-bin/http-prober
         image: gcr.io/google_containers/hyperkube-amd64:v1.10.6
         livenessProbe:
           failureThreshold: 8
@@ -173,6 +160,8 @@ spec:
           name: cloud-config
           readOnly: true
           subPath: fakeVmwareUUID
+        - mountPath: /http-prober-bin
+          name: http-prober-bin
       dnsConfig:
         nameservers:
         - 192.0.2.14
@@ -187,24 +176,16 @@ spec:
       imagePullSecrets:
       - name: dockercfg
       initContainers:
-      - args:
-        - -endpoint
-        - https://apiserver-external.cluster-de-test-01.svc.cluster.local.:30000/healthz
-        - -insecure
-        - -retries
-        - "100"
-        - -retry-wait
-        - "2"
-        - -timeout
-        - "1"
-        command:
+      - command:
+        - /bin/cp
         - /usr/local/bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.1
-        imagePullPolicy: IfNotPresent
-        name: apiserver-running
+        - /http-prober-bin/http-prober
+        image: quay.io/kubermatic/http-prober:v0.2-dev0
+        name: copy-http-prober
         resources: {}
-        terminationMessagePath: /dev/termination-log
-        terminationMessagePolicy: File
+        volumeMounts:
+        - mountPath: /http-prober-bin
+          name: http-prober-bin
       volumes:
       - name: ca
         secret:
@@ -226,4 +207,6 @@ spec:
         secret:
           defaultMode: 256
           secretName: controllermanager-kubeconfig
+      - emptyDir: {}
+        name: http-prober-bin
 status: {}

--- a/api/pkg/resources/test/fixtures/deployment-vsphere-1.10.6-kube-state-metrics.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-vsphere-1.10.6-kube-state-metrics.yaml
@@ -21,14 +21,19 @@ spec:
     spec:
       containers:
       - args:
-        - --kubeconfig
-        - /etc/kubernetes/kubeconfig/kubeconfig
-        - --port
-        - "8080"
-        - --telemetry-port
-        - "8081"
+        - -endpoint
+        - https://apiserver-external.cluster-de-test-01.svc.cluster.local.:30000/healthz
+        - -insecure
+        - -retries
+        - "100"
+        - -retry-wait
+        - "2"
+        - -timeout
+        - "1"
+        - -command
+        - '{"command":"/kube-state-metrics","args":["--kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","--port","8080","--telemetry-port","8081"]}'
         command:
-        - /kube-state-metrics
+        - /http-prober-bin/http-prober
         image: quay.io/coreos/kube-state-metrics:v1.6.0
         name: kube-state-metrics
         ports:
@@ -58,30 +63,26 @@ spec:
         - mountPath: /etc/kubernetes/kubeconfig
           name: kube-state-metrics-kubeconfig
           readOnly: true
+        - mountPath: /http-prober-bin
+          name: http-prober-bin
       imagePullSecrets:
       - name: dockercfg
       initContainers:
-      - args:
-        - -endpoint
-        - https://apiserver-external.cluster-de-test-01.svc.cluster.local.:30000/healthz
-        - -insecure
-        - -retries
-        - "100"
-        - -retry-wait
-        - "2"
-        - -timeout
-        - "1"
-        command:
+      - command:
+        - /bin/cp
         - /usr/local/bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.1
-        imagePullPolicy: IfNotPresent
-        name: apiserver-running
+        - /http-prober-bin/http-prober
+        image: quay.io/kubermatic/http-prober:v0.2-dev0
+        name: copy-http-prober
         resources: {}
-        terminationMessagePath: /dev/termination-log
-        terminationMessagePolicy: File
+        volumeMounts:
+        - mountPath: /http-prober-bin
+          name: http-prober-bin
       volumes:
       - name: kube-state-metrics-kubeconfig
         secret:
           defaultMode: 256
           secretName: kube-state-metrics-kubeconfig
+      - emptyDir: {}
+        name: http-prober-bin
 status: {}

--- a/api/pkg/resources/test/fixtures/deployment-vsphere-1.10.6-kube-state-metrics.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-vsphere-1.10.6-kube-state-metrics.yaml
@@ -72,7 +72,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.2-dev0
+        image: quay.io/kubermatic/http-prober:v0.2
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/api/pkg/resources/test/fixtures/deployment-vsphere-1.10.6-machine-controller-webhook.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-vsphere-1.10.6-machine-controller-webhook.yaml
@@ -24,15 +24,19 @@ spec:
     spec:
       containers:
       - args:
-        - -kubeconfig
-        - /etc/kubernetes/kubeconfig/kubeconfig
-        - -logtostderr
-        - -v
-        - "4"
-        - -listen-address
-        - 0.0.0.0:9876
+        - -endpoint
+        - https://apiserver-external.cluster-de-test-01.svc.cluster.local.:30000/healthz
+        - -insecure
+        - -retries
+        - "100"
+        - -retry-wait
+        - "2"
+        - -timeout
+        - "1"
+        - -command
+        - '{"command":"/usr/local/bin/webhook","args":["-kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","-logtostderr","-v","4","-listen-address","0.0.0.0:9876"]}'
         command:
-        - /usr/local/bin/webhook
+        - /http-prober-bin/http-prober
         env:
         - name: VSPHERE_ADDRESS
           value: https://vs-endpoint.io
@@ -73,27 +77,21 @@ spec:
         - mountPath: /tmp/cert
           name: machinecontroller-webhook-serving-cert
           readOnly: true
+        - mountPath: /http-prober-bin
+          name: http-prober-bin
       imagePullSecrets:
       - name: dockercfg
       initContainers:
-      - args:
-        - -endpoint
-        - https://apiserver-external.cluster-de-test-01.svc.cluster.local.:30000/healthz
-        - -insecure
-        - -retries
-        - "100"
-        - -retry-wait
-        - "2"
-        - -timeout
-        - "1"
-        command:
+      - command:
+        - /bin/cp
         - /usr/local/bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.1
-        imagePullPolicy: IfNotPresent
-        name: apiserver-running
+        - /http-prober-bin/http-prober
+        image: quay.io/kubermatic/http-prober:v0.2-dev0
+        name: copy-http-prober
         resources: {}
-        terminationMessagePath: /dev/termination-log
-        terminationMessagePolicy: File
+        volumeMounts:
+        - mountPath: /http-prober-bin
+          name: http-prober-bin
       volumes:
       - name: machinecontroller-kubeconfig
         secret:
@@ -103,4 +101,6 @@ spec:
         secret:
           defaultMode: 292
           secretName: machinecontroller-webhook-serving-cert
+      - emptyDir: {}
+        name: http-prober-bin
 status: {}

--- a/api/pkg/resources/test/fixtures/deployment-vsphere-1.10.6-machine-controller-webhook.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-vsphere-1.10.6-machine-controller-webhook.yaml
@@ -86,7 +86,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.2-dev0
+        image: quay.io/kubermatic/http-prober:v0.2
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/api/pkg/resources/test/fixtures/deployment-vsphere-1.10.6-machine-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-vsphere-1.10.6-machine-controller.yaml
@@ -27,17 +27,19 @@ spec:
     spec:
       containers:
       - args:
-        - -kubeconfig
-        - /etc/kubernetes/kubeconfig/kubeconfig
-        - -logtostderr
-        - -v
-        - "4"
-        - -cluster-dns
-        - 169.254.20.10
-        - -internal-listen-address
-        - 0.0.0.0:8085
+        - -endpoint
+        - https://apiserver-external.cluster-de-test-01.svc.cluster.local.:30000/healthz
+        - -insecure
+        - -retries
+        - "100"
+        - -retry-wait
+        - "2"
+        - -timeout
+        - "1"
+        - -command
+        - '{"command":"/usr/local/bin/machine-controller","args":["-kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","-logtostderr","-v","4","-cluster-dns","169.254.20.10","-internal-listen-address","0.0.0.0:8085"]}'
         command:
-        - /usr/local/bin/machine-controller
+        - /http-prober-bin/http-prober
         env:
         - name: VSPHERE_ADDRESS
           value: https://vs-endpoint.io
@@ -66,30 +68,26 @@ spec:
         - mountPath: /etc/kubernetes/kubeconfig
           name: machinecontroller-kubeconfig
           readOnly: true
+        - mountPath: /http-prober-bin
+          name: http-prober-bin
       imagePullSecrets:
       - name: dockercfg
       initContainers:
-      - args:
-        - -endpoint
-        - https://apiserver-external.cluster-de-test-01.svc.cluster.local.:30000/healthz
-        - -insecure
-        - -retries
-        - "100"
-        - -retry-wait
-        - "2"
-        - -timeout
-        - "1"
-        command:
+      - command:
+        - /bin/cp
         - /usr/local/bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.1
-        imagePullPolicy: IfNotPresent
-        name: apiserver-running
+        - /http-prober-bin/http-prober
+        image: quay.io/kubermatic/http-prober:v0.2-dev0
+        name: copy-http-prober
         resources: {}
-        terminationMessagePath: /dev/termination-log
-        terminationMessagePolicy: File
+        volumeMounts:
+        - mountPath: /http-prober-bin
+          name: http-prober-bin
       volumes:
       - name: machinecontroller-kubeconfig
         secret:
           defaultMode: 292
           secretName: machinecontroller-kubeconfig
+      - emptyDir: {}
+        name: http-prober-bin
 status: {}

--- a/api/pkg/resources/test/fixtures/deployment-vsphere-1.10.6-machine-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-vsphere-1.10.6-machine-controller.yaml
@@ -77,7 +77,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.2-dev0
+        image: quay.io/kubermatic/http-prober:v0.2
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/api/pkg/resources/test/fixtures/deployment-vsphere-1.10.6-metrics-server.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-vsphere-1.10.6-metrics-server.yaml
@@ -41,22 +41,19 @@ spec:
             weight: 10
       containers:
       - args:
-        - --kubeconfig
-        - /etc/kubernetes/kubeconfig/kubeconfig
-        - --authentication-kubeconfig
-        - /etc/kubernetes/kubeconfig/kubeconfig
-        - --authorization-kubeconfig
-        - /etc/kubernetes/kubeconfig/kubeconfig
-        - --kubelet-port
-        - "10250"
-        - --kubelet-insecure-tls
-        - --kubelet-preferred-address-types
-        - ExternalIP,InternalIP
-        - --v
+        - -endpoint
+        - https://apiserver-external.cluster-de-test-01.svc.cluster.local.:30000/healthz
+        - -insecure
+        - -retries
+        - "100"
+        - -retry-wait
+        - "2"
+        - -timeout
         - "1"
-        - --logtostderr
+        - -command
+        - '{"command":"/metrics-server","args":["--kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","--authentication-kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","--authorization-kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","--kubelet-port","10250","--kubelet-insecure-tls","--kubelet-preferred-address-types","ExternalIP,InternalIP","--v","1","--logtostderr"]}'
         command:
-        - /metrics-server
+        - /http-prober-bin/http-prober
         image: gcr.io/google_containers/metrics-server-amd64:v0.3.2
         name: metrics-server
         resources:
@@ -70,6 +67,8 @@ spec:
         - mountPath: /etc/kubernetes/kubeconfig
           name: metrics-server
           readOnly: true
+        - mountPath: /http-prober-bin
+          name: http-prober-bin
       - args:
         - --client
         - --proto
@@ -158,24 +157,16 @@ spec:
       imagePullSecrets:
       - name: dockercfg
       initContainers:
-      - args:
-        - -endpoint
-        - https://apiserver-external.cluster-de-test-01.svc.cluster.local.:30000/healthz
-        - -insecure
-        - -retries
-        - "100"
-        - -retry-wait
-        - "2"
-        - -timeout
-        - "1"
-        command:
+      - command:
+        - /bin/cp
         - /usr/local/bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.1
-        imagePullPolicy: IfNotPresent
-        name: apiserver-running
+        - /http-prober-bin/http-prober
+        image: quay.io/kubermatic/http-prober:v0.2-dev0
+        name: copy-http-prober
         resources: {}
-        terminationMessagePath: /dev/termination-log
-        terminationMessagePolicy: File
+        volumeMounts:
+        - mountPath: /http-prober-bin
+          name: http-prober-bin
       volumes:
       - name: metrics-server
         secret:
@@ -189,4 +180,6 @@ spec:
         secret:
           defaultMode: 292
           secretName: kubeletdnatcontroller-kubeconfig
+      - emptyDir: {}
+        name: http-prober-bin
 status: {}

--- a/api/pkg/resources/test/fixtures/deployment-vsphere-1.10.6-metrics-server.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-vsphere-1.10.6-metrics-server.yaml
@@ -161,7 +161,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.2-dev0
+        image: quay.io/kubermatic/http-prober:v0.2
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/api/pkg/resources/test/fixtures/deployment-vsphere-1.10.6-scheduler.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-vsphere-1.10.6-scheduler.yaml
@@ -100,11 +100,19 @@ spec:
           name: openvpn-client-certificates
           readOnly: true
       - args:
-        - --kubeconfig
-        - /etc/kubernetes/kubeconfig/kubeconfig
+        - -endpoint
+        - https://apiserver-external.cluster-de-test-01.svc.cluster.local.:30000/healthz
+        - -insecure
+        - -retries
+        - "100"
+        - -retry-wait
+        - "2"
+        - -timeout
+        - "1"
+        - -command
+        - '{"command":"/hyperkube","args":["kube-scheduler","--kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig"]}'
         command:
-        - /hyperkube
-        - kube-scheduler
+        - /http-prober-bin/http-prober
         image: gcr.io/google_containers/hyperkube-amd64:v1.10.6
         livenessProbe:
           failureThreshold: 8
@@ -140,6 +148,8 @@ spec:
         - mountPath: /etc/kubernetes/pki/ca
           name: ca
           readOnly: true
+        - mountPath: /http-prober-bin
+          name: http-prober-bin
       dnsConfig:
         nameservers:
         - 192.0.2.14
@@ -154,24 +164,16 @@ spec:
       imagePullSecrets:
       - name: dockercfg
       initContainers:
-      - args:
-        - -endpoint
-        - https://apiserver-external.cluster-de-test-01.svc.cluster.local.:30000/healthz
-        - -insecure
-        - -retries
-        - "100"
-        - -retry-wait
-        - "2"
-        - -timeout
-        - "1"
-        command:
+      - command:
+        - /bin/cp
         - /usr/local/bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.1
-        imagePullPolicy: IfNotPresent
-        name: apiserver-running
+        - /http-prober-bin/http-prober
+        image: quay.io/kubermatic/http-prober:v0.2-dev0
+        name: copy-http-prober
         resources: {}
-        terminationMessagePath: /dev/termination-log
-        terminationMessagePolicy: File
+        volumeMounts:
+        - mountPath: /http-prober-bin
+          name: http-prober-bin
       volumes:
       - name: openvpn-client-certificates
         secret:
@@ -188,4 +190,6 @@ spec:
         secret:
           defaultMode: 256
           secretName: scheduler-kubeconfig
+      - emptyDir: {}
+        name: http-prober-bin
 status: {}

--- a/api/pkg/resources/test/fixtures/deployment-vsphere-1.10.6-scheduler.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-vsphere-1.10.6-scheduler.yaml
@@ -168,7 +168,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.2-dev0
+        image: quay.io/kubermatic/http-prober:v0.2
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/api/pkg/resources/test/fixtures/deployment-vsphere-1.10.6-usercluster-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-vsphere-1.10.6-usercluster-controller.yaml
@@ -85,7 +85,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.2-dev0
+        image: quay.io/kubermatic/http-prober:v0.2
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/api/pkg/resources/test/fixtures/deployment-vsphere-1.10.6-usercluster-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-vsphere-1.10.6-usercluster-controller.yaml
@@ -29,32 +29,19 @@ spec:
     spec:
       containers:
       - args:
-        - -kubeconfig
-        - /etc/kubernetes/kubeconfig/kubeconfig
-        - -metrics-listen-address
-        - 0.0.0.0:8085
-        - -health-listen-address
-        - 0.0.0.0:8086
-        - -namespace
-        - $(NAMESPACE)
-        - -ca-cert
-        - /etc/kubernetes/pki/ca/ca.crt
-        - -cluster-url
-        - ""
-        - -openvpn-server-port
-        - "30003"
-        - -overwrite-registry
-        - ""
-        - -openshift=false
-        - -openvpn-ca-cert-file=/etc/kubernetes/pki/openvpn/ca.crt
-        - -openvpn-ca-key-file=/etc/kubernetes/pki/openvpn/ca.key
-        - -logtostderr
-        - -v
+        - -endpoint
+        - https://apiserver-external.cluster-de-test-01.svc.cluster.local.:30000/healthz
+        - -insecure
+        - -retries
+        - "100"
+        - -retry-wait
         - "2"
-        - --ipam-controller-network
-        - 192.168.1.1/24,192.168.1.1,8.8.8.8
+        - -timeout
+        - "1"
+        - -command
+        - '{"command":"/usr/local/bin/user-cluster-controller-manager","args":["-kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","-metrics-listen-address","0.0.0.0:8085","-health-listen-address","0.0.0.0:8086","-namespace","$(NAMESPACE)","-ca-cert","/etc/kubernetes/pki/ca/ca.crt","-cluster-url","","-openvpn-server-port","30003","-overwrite-registry","","-openshift=false","-openvpn-ca-cert-file=/etc/kubernetes/pki/openvpn/ca.crt","-openvpn-ca-key-file=/etc/kubernetes/pki/openvpn/ca.key","-logtostderr","-v","2","--ipam-controller-network","192.168.1.1/24,192.168.1.1,8.8.8.8"]}'
         command:
-        - /usr/local/bin/user-cluster-controller-manager
+        - /http-prober-bin/http-prober
         env:
         - name: NAMESPACE
           valueFrom:
@@ -89,27 +76,21 @@ spec:
         - mountPath: /etc/kubernetes/pki/openvpn
           name: openvpn-ca
           readOnly: true
+        - mountPath: /http-prober-bin
+          name: http-prober-bin
       imagePullSecrets:
       - name: dockercfg
       initContainers:
-      - args:
-        - -endpoint
-        - https://apiserver-external.cluster-de-test-01.svc.cluster.local.:30000/healthz
-        - -insecure
-        - -retries
-        - "100"
-        - -retry-wait
-        - "2"
-        - -timeout
-        - "1"
-        command:
+      - command:
+        - /bin/cp
         - /usr/local/bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.1
-        imagePullPolicy: IfNotPresent
-        name: apiserver-running
+        - /http-prober-bin/http-prober
+        image: quay.io/kubermatic/http-prober:v0.2-dev0
+        name: copy-http-prober
         resources: {}
-        terminationMessagePath: /dev/termination-log
-        terminationMessagePolicy: File
+        volumeMounts:
+        - mountPath: /http-prober-bin
+          name: http-prober-bin
       volumes:
       - name: internal-admin-kubeconfig
         secret:
@@ -126,4 +107,6 @@ spec:
         secret:
           defaultMode: 292
           secretName: openvpn-ca
+      - emptyDir: {}
+        name: http-prober-bin
 status: {}

--- a/api/pkg/resources/test/fixtures/deployment-vsphere-1.11.0-controller-manager.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-vsphere-1.11.0-controller-manager.yaml
@@ -102,32 +102,19 @@ spec:
           name: openvpn-client-certificates
           readOnly: true
       - args:
-        - --kubeconfig
-        - /etc/kubernetes/kubeconfig/kubeconfig
-        - --service-account-private-key-file
-        - /etc/kubernetes/service-account-key/sa.key
-        - --root-ca-file
-        - /etc/kubernetes/pki/ca/ca.crt
-        - --cluster-signing-cert-file
-        - /etc/kubernetes/pki/ca/ca.crt
-        - --cluster-signing-key-file
-        - /etc/kubernetes/pki/ca/ca.key
-        - --cluster-cidr
-        - 172.25.0.0/16
-        - --allocate-node-cidrs=true
-        - --controllers
-        - '*,bootstrapsigner,tokencleaner'
-        - --use-service-account-credentials=true
-        - --feature-gates
-        - RotateKubeletClientCertificate=true,RotateKubeletServerCertificate=true
-        - --cloud-provider
-        - vsphere
-        - --cloud-config
-        - /etc/kubernetes/cloud/config
-        - --configure-cloud-routes=false
+        - -endpoint
+        - https://apiserver-external.cluster-de-test-01.svc.cluster.local.:30000/healthz
+        - -insecure
+        - -retries
+        - "100"
+        - -retry-wait
+        - "2"
+        - -timeout
+        - "1"
+        - -command
+        - '{"command":"/hyperkube","args":["kube-controller-manager","--kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","--service-account-private-key-file","/etc/kubernetes/service-account-key/sa.key","--root-ca-file","/etc/kubernetes/pki/ca/ca.crt","--cluster-signing-cert-file","/etc/kubernetes/pki/ca/ca.crt","--cluster-signing-key-file","/etc/kubernetes/pki/ca/ca.key","--cluster-cidr","172.25.0.0/16","--allocate-node-cidrs=true","--controllers","*,bootstrapsigner,tokencleaner","--use-service-account-credentials=true","--feature-gates","RotateKubeletClientCertificate=true,RotateKubeletServerCertificate=true","--cloud-provider","vsphere","--cloud-config","/etc/kubernetes/cloud/config","--configure-cloud-routes=false"]}'
         command:
-        - /hyperkube
-        - kube-controller-manager
+        - /http-prober-bin/http-prober
         image: gcr.io/google_containers/hyperkube-amd64:v1.11.0
         livenessProbe:
           failureThreshold: 8
@@ -173,6 +160,8 @@ spec:
           name: cloud-config
           readOnly: true
           subPath: fakeVmwareUUID
+        - mountPath: /http-prober-bin
+          name: http-prober-bin
       dnsConfig:
         nameservers:
         - 192.0.2.14
@@ -187,24 +176,16 @@ spec:
       imagePullSecrets:
       - name: dockercfg
       initContainers:
-      - args:
-        - -endpoint
-        - https://apiserver-external.cluster-de-test-01.svc.cluster.local.:30000/healthz
-        - -insecure
-        - -retries
-        - "100"
-        - -retry-wait
-        - "2"
-        - -timeout
-        - "1"
-        command:
+      - command:
+        - /bin/cp
         - /usr/local/bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.1
-        imagePullPolicy: IfNotPresent
-        name: apiserver-running
+        - /http-prober-bin/http-prober
+        image: quay.io/kubermatic/http-prober:v0.2-dev0
+        name: copy-http-prober
         resources: {}
-        terminationMessagePath: /dev/termination-log
-        terminationMessagePolicy: File
+        volumeMounts:
+        - mountPath: /http-prober-bin
+          name: http-prober-bin
       volumes:
       - name: ca
         secret:
@@ -226,4 +207,6 @@ spec:
         secret:
           defaultMode: 256
           secretName: controllermanager-kubeconfig
+      - emptyDir: {}
+        name: http-prober-bin
 status: {}

--- a/api/pkg/resources/test/fixtures/deployment-vsphere-1.11.0-controller-manager.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-vsphere-1.11.0-controller-manager.yaml
@@ -180,7 +180,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.2-dev0
+        image: quay.io/kubermatic/http-prober:v0.2
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/api/pkg/resources/test/fixtures/deployment-vsphere-1.11.0-kube-state-metrics.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-vsphere-1.11.0-kube-state-metrics.yaml
@@ -21,14 +21,19 @@ spec:
     spec:
       containers:
       - args:
-        - --kubeconfig
-        - /etc/kubernetes/kubeconfig/kubeconfig
-        - --port
-        - "8080"
-        - --telemetry-port
-        - "8081"
+        - -endpoint
+        - https://apiserver-external.cluster-de-test-01.svc.cluster.local.:30000/healthz
+        - -insecure
+        - -retries
+        - "100"
+        - -retry-wait
+        - "2"
+        - -timeout
+        - "1"
+        - -command
+        - '{"command":"/kube-state-metrics","args":["--kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","--port","8080","--telemetry-port","8081"]}'
         command:
-        - /kube-state-metrics
+        - /http-prober-bin/http-prober
         image: quay.io/coreos/kube-state-metrics:v1.6.0
         name: kube-state-metrics
         ports:
@@ -58,30 +63,26 @@ spec:
         - mountPath: /etc/kubernetes/kubeconfig
           name: kube-state-metrics-kubeconfig
           readOnly: true
+        - mountPath: /http-prober-bin
+          name: http-prober-bin
       imagePullSecrets:
       - name: dockercfg
       initContainers:
-      - args:
-        - -endpoint
-        - https://apiserver-external.cluster-de-test-01.svc.cluster.local.:30000/healthz
-        - -insecure
-        - -retries
-        - "100"
-        - -retry-wait
-        - "2"
-        - -timeout
-        - "1"
-        command:
+      - command:
+        - /bin/cp
         - /usr/local/bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.1
-        imagePullPolicy: IfNotPresent
-        name: apiserver-running
+        - /http-prober-bin/http-prober
+        image: quay.io/kubermatic/http-prober:v0.2-dev0
+        name: copy-http-prober
         resources: {}
-        terminationMessagePath: /dev/termination-log
-        terminationMessagePolicy: File
+        volumeMounts:
+        - mountPath: /http-prober-bin
+          name: http-prober-bin
       volumes:
       - name: kube-state-metrics-kubeconfig
         secret:
           defaultMode: 256
           secretName: kube-state-metrics-kubeconfig
+      - emptyDir: {}
+        name: http-prober-bin
 status: {}

--- a/api/pkg/resources/test/fixtures/deployment-vsphere-1.11.0-kube-state-metrics.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-vsphere-1.11.0-kube-state-metrics.yaml
@@ -72,7 +72,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.2-dev0
+        image: quay.io/kubermatic/http-prober:v0.2
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/api/pkg/resources/test/fixtures/deployment-vsphere-1.11.0-machine-controller-webhook.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-vsphere-1.11.0-machine-controller-webhook.yaml
@@ -24,15 +24,19 @@ spec:
     spec:
       containers:
       - args:
-        - -kubeconfig
-        - /etc/kubernetes/kubeconfig/kubeconfig
-        - -logtostderr
-        - -v
-        - "4"
-        - -listen-address
-        - 0.0.0.0:9876
+        - -endpoint
+        - https://apiserver-external.cluster-de-test-01.svc.cluster.local.:30000/healthz
+        - -insecure
+        - -retries
+        - "100"
+        - -retry-wait
+        - "2"
+        - -timeout
+        - "1"
+        - -command
+        - '{"command":"/usr/local/bin/webhook","args":["-kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","-logtostderr","-v","4","-listen-address","0.0.0.0:9876"]}'
         command:
-        - /usr/local/bin/webhook
+        - /http-prober-bin/http-prober
         env:
         - name: VSPHERE_ADDRESS
           value: https://vs-endpoint.io
@@ -73,27 +77,21 @@ spec:
         - mountPath: /tmp/cert
           name: machinecontroller-webhook-serving-cert
           readOnly: true
+        - mountPath: /http-prober-bin
+          name: http-prober-bin
       imagePullSecrets:
       - name: dockercfg
       initContainers:
-      - args:
-        - -endpoint
-        - https://apiserver-external.cluster-de-test-01.svc.cluster.local.:30000/healthz
-        - -insecure
-        - -retries
-        - "100"
-        - -retry-wait
-        - "2"
-        - -timeout
-        - "1"
-        command:
+      - command:
+        - /bin/cp
         - /usr/local/bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.1
-        imagePullPolicy: IfNotPresent
-        name: apiserver-running
+        - /http-prober-bin/http-prober
+        image: quay.io/kubermatic/http-prober:v0.2-dev0
+        name: copy-http-prober
         resources: {}
-        terminationMessagePath: /dev/termination-log
-        terminationMessagePolicy: File
+        volumeMounts:
+        - mountPath: /http-prober-bin
+          name: http-prober-bin
       volumes:
       - name: machinecontroller-kubeconfig
         secret:
@@ -103,4 +101,6 @@ spec:
         secret:
           defaultMode: 292
           secretName: machinecontroller-webhook-serving-cert
+      - emptyDir: {}
+        name: http-prober-bin
 status: {}

--- a/api/pkg/resources/test/fixtures/deployment-vsphere-1.11.0-machine-controller-webhook.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-vsphere-1.11.0-machine-controller-webhook.yaml
@@ -86,7 +86,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.2-dev0
+        image: quay.io/kubermatic/http-prober:v0.2
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/api/pkg/resources/test/fixtures/deployment-vsphere-1.11.0-machine-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-vsphere-1.11.0-machine-controller.yaml
@@ -27,17 +27,19 @@ spec:
     spec:
       containers:
       - args:
-        - -kubeconfig
-        - /etc/kubernetes/kubeconfig/kubeconfig
-        - -logtostderr
-        - -v
-        - "4"
-        - -cluster-dns
-        - 169.254.20.10
-        - -internal-listen-address
-        - 0.0.0.0:8085
+        - -endpoint
+        - https://apiserver-external.cluster-de-test-01.svc.cluster.local.:30000/healthz
+        - -insecure
+        - -retries
+        - "100"
+        - -retry-wait
+        - "2"
+        - -timeout
+        - "1"
+        - -command
+        - '{"command":"/usr/local/bin/machine-controller","args":["-kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","-logtostderr","-v","4","-cluster-dns","169.254.20.10","-internal-listen-address","0.0.0.0:8085"]}'
         command:
-        - /usr/local/bin/machine-controller
+        - /http-prober-bin/http-prober
         env:
         - name: VSPHERE_ADDRESS
           value: https://vs-endpoint.io
@@ -66,30 +68,26 @@ spec:
         - mountPath: /etc/kubernetes/kubeconfig
           name: machinecontroller-kubeconfig
           readOnly: true
+        - mountPath: /http-prober-bin
+          name: http-prober-bin
       imagePullSecrets:
       - name: dockercfg
       initContainers:
-      - args:
-        - -endpoint
-        - https://apiserver-external.cluster-de-test-01.svc.cluster.local.:30000/healthz
-        - -insecure
-        - -retries
-        - "100"
-        - -retry-wait
-        - "2"
-        - -timeout
-        - "1"
-        command:
+      - command:
+        - /bin/cp
         - /usr/local/bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.1
-        imagePullPolicy: IfNotPresent
-        name: apiserver-running
+        - /http-prober-bin/http-prober
+        image: quay.io/kubermatic/http-prober:v0.2-dev0
+        name: copy-http-prober
         resources: {}
-        terminationMessagePath: /dev/termination-log
-        terminationMessagePolicy: File
+        volumeMounts:
+        - mountPath: /http-prober-bin
+          name: http-prober-bin
       volumes:
       - name: machinecontroller-kubeconfig
         secret:
           defaultMode: 292
           secretName: machinecontroller-kubeconfig
+      - emptyDir: {}
+        name: http-prober-bin
 status: {}

--- a/api/pkg/resources/test/fixtures/deployment-vsphere-1.11.0-machine-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-vsphere-1.11.0-machine-controller.yaml
@@ -77,7 +77,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.2-dev0
+        image: quay.io/kubermatic/http-prober:v0.2
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/api/pkg/resources/test/fixtures/deployment-vsphere-1.11.0-metrics-server.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-vsphere-1.11.0-metrics-server.yaml
@@ -41,22 +41,19 @@ spec:
             weight: 10
       containers:
       - args:
-        - --kubeconfig
-        - /etc/kubernetes/kubeconfig/kubeconfig
-        - --authentication-kubeconfig
-        - /etc/kubernetes/kubeconfig/kubeconfig
-        - --authorization-kubeconfig
-        - /etc/kubernetes/kubeconfig/kubeconfig
-        - --kubelet-port
-        - "10250"
-        - --kubelet-insecure-tls
-        - --kubelet-preferred-address-types
-        - ExternalIP,InternalIP
-        - --v
+        - -endpoint
+        - https://apiserver-external.cluster-de-test-01.svc.cluster.local.:30000/healthz
+        - -insecure
+        - -retries
+        - "100"
+        - -retry-wait
+        - "2"
+        - -timeout
         - "1"
-        - --logtostderr
+        - -command
+        - '{"command":"/metrics-server","args":["--kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","--authentication-kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","--authorization-kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","--kubelet-port","10250","--kubelet-insecure-tls","--kubelet-preferred-address-types","ExternalIP,InternalIP","--v","1","--logtostderr"]}'
         command:
-        - /metrics-server
+        - /http-prober-bin/http-prober
         image: gcr.io/google_containers/metrics-server-amd64:v0.3.2
         name: metrics-server
         resources:
@@ -70,6 +67,8 @@ spec:
         - mountPath: /etc/kubernetes/kubeconfig
           name: metrics-server
           readOnly: true
+        - mountPath: /http-prober-bin
+          name: http-prober-bin
       - args:
         - --client
         - --proto
@@ -158,24 +157,16 @@ spec:
       imagePullSecrets:
       - name: dockercfg
       initContainers:
-      - args:
-        - -endpoint
-        - https://apiserver-external.cluster-de-test-01.svc.cluster.local.:30000/healthz
-        - -insecure
-        - -retries
-        - "100"
-        - -retry-wait
-        - "2"
-        - -timeout
-        - "1"
-        command:
+      - command:
+        - /bin/cp
         - /usr/local/bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.1
-        imagePullPolicy: IfNotPresent
-        name: apiserver-running
+        - /http-prober-bin/http-prober
+        image: quay.io/kubermatic/http-prober:v0.2-dev0
+        name: copy-http-prober
         resources: {}
-        terminationMessagePath: /dev/termination-log
-        terminationMessagePolicy: File
+        volumeMounts:
+        - mountPath: /http-prober-bin
+          name: http-prober-bin
       volumes:
       - name: metrics-server
         secret:
@@ -189,4 +180,6 @@ spec:
         secret:
           defaultMode: 292
           secretName: kubeletdnatcontroller-kubeconfig
+      - emptyDir: {}
+        name: http-prober-bin
 status: {}

--- a/api/pkg/resources/test/fixtures/deployment-vsphere-1.11.0-metrics-server.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-vsphere-1.11.0-metrics-server.yaml
@@ -161,7 +161,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.2-dev0
+        image: quay.io/kubermatic/http-prober:v0.2
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/api/pkg/resources/test/fixtures/deployment-vsphere-1.11.0-scheduler.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-vsphere-1.11.0-scheduler.yaml
@@ -100,11 +100,19 @@ spec:
           name: openvpn-client-certificates
           readOnly: true
       - args:
-        - --kubeconfig
-        - /etc/kubernetes/kubeconfig/kubeconfig
+        - -endpoint
+        - https://apiserver-external.cluster-de-test-01.svc.cluster.local.:30000/healthz
+        - -insecure
+        - -retries
+        - "100"
+        - -retry-wait
+        - "2"
+        - -timeout
+        - "1"
+        - -command
+        - '{"command":"/hyperkube","args":["kube-scheduler","--kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig"]}'
         command:
-        - /hyperkube
-        - kube-scheduler
+        - /http-prober-bin/http-prober
         image: gcr.io/google_containers/hyperkube-amd64:v1.11.0
         livenessProbe:
           failureThreshold: 8
@@ -140,6 +148,8 @@ spec:
         - mountPath: /etc/kubernetes/pki/ca
           name: ca
           readOnly: true
+        - mountPath: /http-prober-bin
+          name: http-prober-bin
       dnsConfig:
         nameservers:
         - 192.0.2.14
@@ -154,24 +164,16 @@ spec:
       imagePullSecrets:
       - name: dockercfg
       initContainers:
-      - args:
-        - -endpoint
-        - https://apiserver-external.cluster-de-test-01.svc.cluster.local.:30000/healthz
-        - -insecure
-        - -retries
-        - "100"
-        - -retry-wait
-        - "2"
-        - -timeout
-        - "1"
-        command:
+      - command:
+        - /bin/cp
         - /usr/local/bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.1
-        imagePullPolicy: IfNotPresent
-        name: apiserver-running
+        - /http-prober-bin/http-prober
+        image: quay.io/kubermatic/http-prober:v0.2-dev0
+        name: copy-http-prober
         resources: {}
-        terminationMessagePath: /dev/termination-log
-        terminationMessagePolicy: File
+        volumeMounts:
+        - mountPath: /http-prober-bin
+          name: http-prober-bin
       volumes:
       - name: openvpn-client-certificates
         secret:
@@ -188,4 +190,6 @@ spec:
         secret:
           defaultMode: 256
           secretName: scheduler-kubeconfig
+      - emptyDir: {}
+        name: http-prober-bin
 status: {}

--- a/api/pkg/resources/test/fixtures/deployment-vsphere-1.11.0-scheduler.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-vsphere-1.11.0-scheduler.yaml
@@ -168,7 +168,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.2-dev0
+        image: quay.io/kubermatic/http-prober:v0.2
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/api/pkg/resources/test/fixtures/deployment-vsphere-1.11.0-usercluster-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-vsphere-1.11.0-usercluster-controller.yaml
@@ -85,7 +85,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.2-dev0
+        image: quay.io/kubermatic/http-prober:v0.2
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/api/pkg/resources/test/fixtures/deployment-vsphere-1.11.0-usercluster-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-vsphere-1.11.0-usercluster-controller.yaml
@@ -29,32 +29,19 @@ spec:
     spec:
       containers:
       - args:
-        - -kubeconfig
-        - /etc/kubernetes/kubeconfig/kubeconfig
-        - -metrics-listen-address
-        - 0.0.0.0:8085
-        - -health-listen-address
-        - 0.0.0.0:8086
-        - -namespace
-        - $(NAMESPACE)
-        - -ca-cert
-        - /etc/kubernetes/pki/ca/ca.crt
-        - -cluster-url
-        - ""
-        - -openvpn-server-port
-        - "30003"
-        - -overwrite-registry
-        - ""
-        - -openshift=false
-        - -openvpn-ca-cert-file=/etc/kubernetes/pki/openvpn/ca.crt
-        - -openvpn-ca-key-file=/etc/kubernetes/pki/openvpn/ca.key
-        - -logtostderr
-        - -v
+        - -endpoint
+        - https://apiserver-external.cluster-de-test-01.svc.cluster.local.:30000/healthz
+        - -insecure
+        - -retries
+        - "100"
+        - -retry-wait
         - "2"
-        - --ipam-controller-network
-        - 192.168.1.1/24,192.168.1.1,8.8.8.8
+        - -timeout
+        - "1"
+        - -command
+        - '{"command":"/usr/local/bin/user-cluster-controller-manager","args":["-kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","-metrics-listen-address","0.0.0.0:8085","-health-listen-address","0.0.0.0:8086","-namespace","$(NAMESPACE)","-ca-cert","/etc/kubernetes/pki/ca/ca.crt","-cluster-url","","-openvpn-server-port","30003","-overwrite-registry","","-openshift=false","-openvpn-ca-cert-file=/etc/kubernetes/pki/openvpn/ca.crt","-openvpn-ca-key-file=/etc/kubernetes/pki/openvpn/ca.key","-logtostderr","-v","2","--ipam-controller-network","192.168.1.1/24,192.168.1.1,8.8.8.8"]}'
         command:
-        - /usr/local/bin/user-cluster-controller-manager
+        - /http-prober-bin/http-prober
         env:
         - name: NAMESPACE
           valueFrom:
@@ -89,27 +76,21 @@ spec:
         - mountPath: /etc/kubernetes/pki/openvpn
           name: openvpn-ca
           readOnly: true
+        - mountPath: /http-prober-bin
+          name: http-prober-bin
       imagePullSecrets:
       - name: dockercfg
       initContainers:
-      - args:
-        - -endpoint
-        - https://apiserver-external.cluster-de-test-01.svc.cluster.local.:30000/healthz
-        - -insecure
-        - -retries
-        - "100"
-        - -retry-wait
-        - "2"
-        - -timeout
-        - "1"
-        command:
+      - command:
+        - /bin/cp
         - /usr/local/bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.1
-        imagePullPolicy: IfNotPresent
-        name: apiserver-running
+        - /http-prober-bin/http-prober
+        image: quay.io/kubermatic/http-prober:v0.2-dev0
+        name: copy-http-prober
         resources: {}
-        terminationMessagePath: /dev/termination-log
-        terminationMessagePolicy: File
+        volumeMounts:
+        - mountPath: /http-prober-bin
+          name: http-prober-bin
       volumes:
       - name: internal-admin-kubeconfig
         secret:
@@ -126,4 +107,6 @@ spec:
         secret:
           defaultMode: 292
           secretName: openvpn-ca
+      - emptyDir: {}
+        name: http-prober-bin
 status: {}

--- a/api/pkg/resources/test/fixtures/deployment-vsphere-1.11.1-controller-manager.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-vsphere-1.11.1-controller-manager.yaml
@@ -102,32 +102,19 @@ spec:
           name: openvpn-client-certificates
           readOnly: true
       - args:
-        - --kubeconfig
-        - /etc/kubernetes/kubeconfig/kubeconfig
-        - --service-account-private-key-file
-        - /etc/kubernetes/service-account-key/sa.key
-        - --root-ca-file
-        - /etc/kubernetes/pki/ca/ca.crt
-        - --cluster-signing-cert-file
-        - /etc/kubernetes/pki/ca/ca.crt
-        - --cluster-signing-key-file
-        - /etc/kubernetes/pki/ca/ca.key
-        - --cluster-cidr
-        - 172.25.0.0/16
-        - --allocate-node-cidrs=true
-        - --controllers
-        - '*,bootstrapsigner,tokencleaner'
-        - --use-service-account-credentials=true
-        - --feature-gates
-        - RotateKubeletClientCertificate=true,RotateKubeletServerCertificate=true
-        - --cloud-provider
-        - vsphere
-        - --cloud-config
-        - /etc/kubernetes/cloud/config
-        - --configure-cloud-routes=false
+        - -endpoint
+        - https://apiserver-external.cluster-de-test-01.svc.cluster.local.:30000/healthz
+        - -insecure
+        - -retries
+        - "100"
+        - -retry-wait
+        - "2"
+        - -timeout
+        - "1"
+        - -command
+        - '{"command":"/hyperkube","args":["kube-controller-manager","--kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","--service-account-private-key-file","/etc/kubernetes/service-account-key/sa.key","--root-ca-file","/etc/kubernetes/pki/ca/ca.crt","--cluster-signing-cert-file","/etc/kubernetes/pki/ca/ca.crt","--cluster-signing-key-file","/etc/kubernetes/pki/ca/ca.key","--cluster-cidr","172.25.0.0/16","--allocate-node-cidrs=true","--controllers","*,bootstrapsigner,tokencleaner","--use-service-account-credentials=true","--feature-gates","RotateKubeletClientCertificate=true,RotateKubeletServerCertificate=true","--cloud-provider","vsphere","--cloud-config","/etc/kubernetes/cloud/config","--configure-cloud-routes=false"]}'
         command:
-        - /hyperkube
-        - kube-controller-manager
+        - /http-prober-bin/http-prober
         image: gcr.io/google_containers/hyperkube-amd64:v1.11.1
         livenessProbe:
           failureThreshold: 8
@@ -173,6 +160,8 @@ spec:
           name: cloud-config
           readOnly: true
           subPath: fakeVmwareUUID
+        - mountPath: /http-prober-bin
+          name: http-prober-bin
       dnsConfig:
         nameservers:
         - 192.0.2.14
@@ -187,24 +176,16 @@ spec:
       imagePullSecrets:
       - name: dockercfg
       initContainers:
-      - args:
-        - -endpoint
-        - https://apiserver-external.cluster-de-test-01.svc.cluster.local.:30000/healthz
-        - -insecure
-        - -retries
-        - "100"
-        - -retry-wait
-        - "2"
-        - -timeout
-        - "1"
-        command:
+      - command:
+        - /bin/cp
         - /usr/local/bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.1
-        imagePullPolicy: IfNotPresent
-        name: apiserver-running
+        - /http-prober-bin/http-prober
+        image: quay.io/kubermatic/http-prober:v0.2-dev0
+        name: copy-http-prober
         resources: {}
-        terminationMessagePath: /dev/termination-log
-        terminationMessagePolicy: File
+        volumeMounts:
+        - mountPath: /http-prober-bin
+          name: http-prober-bin
       volumes:
       - name: ca
         secret:
@@ -226,4 +207,6 @@ spec:
         secret:
           defaultMode: 256
           secretName: controllermanager-kubeconfig
+      - emptyDir: {}
+        name: http-prober-bin
 status: {}

--- a/api/pkg/resources/test/fixtures/deployment-vsphere-1.11.1-controller-manager.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-vsphere-1.11.1-controller-manager.yaml
@@ -180,7 +180,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.2-dev0
+        image: quay.io/kubermatic/http-prober:v0.2
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/api/pkg/resources/test/fixtures/deployment-vsphere-1.11.1-kube-state-metrics.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-vsphere-1.11.1-kube-state-metrics.yaml
@@ -21,14 +21,19 @@ spec:
     spec:
       containers:
       - args:
-        - --kubeconfig
-        - /etc/kubernetes/kubeconfig/kubeconfig
-        - --port
-        - "8080"
-        - --telemetry-port
-        - "8081"
+        - -endpoint
+        - https://apiserver-external.cluster-de-test-01.svc.cluster.local.:30000/healthz
+        - -insecure
+        - -retries
+        - "100"
+        - -retry-wait
+        - "2"
+        - -timeout
+        - "1"
+        - -command
+        - '{"command":"/kube-state-metrics","args":["--kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","--port","8080","--telemetry-port","8081"]}'
         command:
-        - /kube-state-metrics
+        - /http-prober-bin/http-prober
         image: quay.io/coreos/kube-state-metrics:v1.6.0
         name: kube-state-metrics
         ports:
@@ -58,30 +63,26 @@ spec:
         - mountPath: /etc/kubernetes/kubeconfig
           name: kube-state-metrics-kubeconfig
           readOnly: true
+        - mountPath: /http-prober-bin
+          name: http-prober-bin
       imagePullSecrets:
       - name: dockercfg
       initContainers:
-      - args:
-        - -endpoint
-        - https://apiserver-external.cluster-de-test-01.svc.cluster.local.:30000/healthz
-        - -insecure
-        - -retries
-        - "100"
-        - -retry-wait
-        - "2"
-        - -timeout
-        - "1"
-        command:
+      - command:
+        - /bin/cp
         - /usr/local/bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.1
-        imagePullPolicy: IfNotPresent
-        name: apiserver-running
+        - /http-prober-bin/http-prober
+        image: quay.io/kubermatic/http-prober:v0.2-dev0
+        name: copy-http-prober
         resources: {}
-        terminationMessagePath: /dev/termination-log
-        terminationMessagePolicy: File
+        volumeMounts:
+        - mountPath: /http-prober-bin
+          name: http-prober-bin
       volumes:
       - name: kube-state-metrics-kubeconfig
         secret:
           defaultMode: 256
           secretName: kube-state-metrics-kubeconfig
+      - emptyDir: {}
+        name: http-prober-bin
 status: {}

--- a/api/pkg/resources/test/fixtures/deployment-vsphere-1.11.1-kube-state-metrics.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-vsphere-1.11.1-kube-state-metrics.yaml
@@ -72,7 +72,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.2-dev0
+        image: quay.io/kubermatic/http-prober:v0.2
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/api/pkg/resources/test/fixtures/deployment-vsphere-1.11.1-machine-controller-webhook.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-vsphere-1.11.1-machine-controller-webhook.yaml
@@ -24,15 +24,19 @@ spec:
     spec:
       containers:
       - args:
-        - -kubeconfig
-        - /etc/kubernetes/kubeconfig/kubeconfig
-        - -logtostderr
-        - -v
-        - "4"
-        - -listen-address
-        - 0.0.0.0:9876
+        - -endpoint
+        - https://apiserver-external.cluster-de-test-01.svc.cluster.local.:30000/healthz
+        - -insecure
+        - -retries
+        - "100"
+        - -retry-wait
+        - "2"
+        - -timeout
+        - "1"
+        - -command
+        - '{"command":"/usr/local/bin/webhook","args":["-kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","-logtostderr","-v","4","-listen-address","0.0.0.0:9876"]}'
         command:
-        - /usr/local/bin/webhook
+        - /http-prober-bin/http-prober
         env:
         - name: VSPHERE_ADDRESS
           value: https://vs-endpoint.io
@@ -73,27 +77,21 @@ spec:
         - mountPath: /tmp/cert
           name: machinecontroller-webhook-serving-cert
           readOnly: true
+        - mountPath: /http-prober-bin
+          name: http-prober-bin
       imagePullSecrets:
       - name: dockercfg
       initContainers:
-      - args:
-        - -endpoint
-        - https://apiserver-external.cluster-de-test-01.svc.cluster.local.:30000/healthz
-        - -insecure
-        - -retries
-        - "100"
-        - -retry-wait
-        - "2"
-        - -timeout
-        - "1"
-        command:
+      - command:
+        - /bin/cp
         - /usr/local/bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.1
-        imagePullPolicy: IfNotPresent
-        name: apiserver-running
+        - /http-prober-bin/http-prober
+        image: quay.io/kubermatic/http-prober:v0.2-dev0
+        name: copy-http-prober
         resources: {}
-        terminationMessagePath: /dev/termination-log
-        terminationMessagePolicy: File
+        volumeMounts:
+        - mountPath: /http-prober-bin
+          name: http-prober-bin
       volumes:
       - name: machinecontroller-kubeconfig
         secret:
@@ -103,4 +101,6 @@ spec:
         secret:
           defaultMode: 292
           secretName: machinecontroller-webhook-serving-cert
+      - emptyDir: {}
+        name: http-prober-bin
 status: {}

--- a/api/pkg/resources/test/fixtures/deployment-vsphere-1.11.1-machine-controller-webhook.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-vsphere-1.11.1-machine-controller-webhook.yaml
@@ -86,7 +86,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.2-dev0
+        image: quay.io/kubermatic/http-prober:v0.2
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/api/pkg/resources/test/fixtures/deployment-vsphere-1.11.1-machine-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-vsphere-1.11.1-machine-controller.yaml
@@ -27,17 +27,19 @@ spec:
     spec:
       containers:
       - args:
-        - -kubeconfig
-        - /etc/kubernetes/kubeconfig/kubeconfig
-        - -logtostderr
-        - -v
-        - "4"
-        - -cluster-dns
-        - 169.254.20.10
-        - -internal-listen-address
-        - 0.0.0.0:8085
+        - -endpoint
+        - https://apiserver-external.cluster-de-test-01.svc.cluster.local.:30000/healthz
+        - -insecure
+        - -retries
+        - "100"
+        - -retry-wait
+        - "2"
+        - -timeout
+        - "1"
+        - -command
+        - '{"command":"/usr/local/bin/machine-controller","args":["-kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","-logtostderr","-v","4","-cluster-dns","169.254.20.10","-internal-listen-address","0.0.0.0:8085"]}'
         command:
-        - /usr/local/bin/machine-controller
+        - /http-prober-bin/http-prober
         env:
         - name: VSPHERE_ADDRESS
           value: https://vs-endpoint.io
@@ -66,30 +68,26 @@ spec:
         - mountPath: /etc/kubernetes/kubeconfig
           name: machinecontroller-kubeconfig
           readOnly: true
+        - mountPath: /http-prober-bin
+          name: http-prober-bin
       imagePullSecrets:
       - name: dockercfg
       initContainers:
-      - args:
-        - -endpoint
-        - https://apiserver-external.cluster-de-test-01.svc.cluster.local.:30000/healthz
-        - -insecure
-        - -retries
-        - "100"
-        - -retry-wait
-        - "2"
-        - -timeout
-        - "1"
-        command:
+      - command:
+        - /bin/cp
         - /usr/local/bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.1
-        imagePullPolicy: IfNotPresent
-        name: apiserver-running
+        - /http-prober-bin/http-prober
+        image: quay.io/kubermatic/http-prober:v0.2-dev0
+        name: copy-http-prober
         resources: {}
-        terminationMessagePath: /dev/termination-log
-        terminationMessagePolicy: File
+        volumeMounts:
+        - mountPath: /http-prober-bin
+          name: http-prober-bin
       volumes:
       - name: machinecontroller-kubeconfig
         secret:
           defaultMode: 292
           secretName: machinecontroller-kubeconfig
+      - emptyDir: {}
+        name: http-prober-bin
 status: {}

--- a/api/pkg/resources/test/fixtures/deployment-vsphere-1.11.1-machine-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-vsphere-1.11.1-machine-controller.yaml
@@ -77,7 +77,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.2-dev0
+        image: quay.io/kubermatic/http-prober:v0.2
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/api/pkg/resources/test/fixtures/deployment-vsphere-1.11.1-metrics-server.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-vsphere-1.11.1-metrics-server.yaml
@@ -41,22 +41,19 @@ spec:
             weight: 10
       containers:
       - args:
-        - --kubeconfig
-        - /etc/kubernetes/kubeconfig/kubeconfig
-        - --authentication-kubeconfig
-        - /etc/kubernetes/kubeconfig/kubeconfig
-        - --authorization-kubeconfig
-        - /etc/kubernetes/kubeconfig/kubeconfig
-        - --kubelet-port
-        - "10250"
-        - --kubelet-insecure-tls
-        - --kubelet-preferred-address-types
-        - ExternalIP,InternalIP
-        - --v
+        - -endpoint
+        - https://apiserver-external.cluster-de-test-01.svc.cluster.local.:30000/healthz
+        - -insecure
+        - -retries
+        - "100"
+        - -retry-wait
+        - "2"
+        - -timeout
         - "1"
-        - --logtostderr
+        - -command
+        - '{"command":"/metrics-server","args":["--kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","--authentication-kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","--authorization-kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","--kubelet-port","10250","--kubelet-insecure-tls","--kubelet-preferred-address-types","ExternalIP,InternalIP","--v","1","--logtostderr"]}'
         command:
-        - /metrics-server
+        - /http-prober-bin/http-prober
         image: gcr.io/google_containers/metrics-server-amd64:v0.3.2
         name: metrics-server
         resources:
@@ -70,6 +67,8 @@ spec:
         - mountPath: /etc/kubernetes/kubeconfig
           name: metrics-server
           readOnly: true
+        - mountPath: /http-prober-bin
+          name: http-prober-bin
       - args:
         - --client
         - --proto
@@ -158,24 +157,16 @@ spec:
       imagePullSecrets:
       - name: dockercfg
       initContainers:
-      - args:
-        - -endpoint
-        - https://apiserver-external.cluster-de-test-01.svc.cluster.local.:30000/healthz
-        - -insecure
-        - -retries
-        - "100"
-        - -retry-wait
-        - "2"
-        - -timeout
-        - "1"
-        command:
+      - command:
+        - /bin/cp
         - /usr/local/bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.1
-        imagePullPolicy: IfNotPresent
-        name: apiserver-running
+        - /http-prober-bin/http-prober
+        image: quay.io/kubermatic/http-prober:v0.2-dev0
+        name: copy-http-prober
         resources: {}
-        terminationMessagePath: /dev/termination-log
-        terminationMessagePolicy: File
+        volumeMounts:
+        - mountPath: /http-prober-bin
+          name: http-prober-bin
       volumes:
       - name: metrics-server
         secret:
@@ -189,4 +180,6 @@ spec:
         secret:
           defaultMode: 292
           secretName: kubeletdnatcontroller-kubeconfig
+      - emptyDir: {}
+        name: http-prober-bin
 status: {}

--- a/api/pkg/resources/test/fixtures/deployment-vsphere-1.11.1-metrics-server.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-vsphere-1.11.1-metrics-server.yaml
@@ -161,7 +161,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.2-dev0
+        image: quay.io/kubermatic/http-prober:v0.2
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/api/pkg/resources/test/fixtures/deployment-vsphere-1.11.1-scheduler.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-vsphere-1.11.1-scheduler.yaml
@@ -100,11 +100,19 @@ spec:
           name: openvpn-client-certificates
           readOnly: true
       - args:
-        - --kubeconfig
-        - /etc/kubernetes/kubeconfig/kubeconfig
+        - -endpoint
+        - https://apiserver-external.cluster-de-test-01.svc.cluster.local.:30000/healthz
+        - -insecure
+        - -retries
+        - "100"
+        - -retry-wait
+        - "2"
+        - -timeout
+        - "1"
+        - -command
+        - '{"command":"/hyperkube","args":["kube-scheduler","--kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig"]}'
         command:
-        - /hyperkube
-        - kube-scheduler
+        - /http-prober-bin/http-prober
         image: gcr.io/google_containers/hyperkube-amd64:v1.11.1
         livenessProbe:
           failureThreshold: 8
@@ -140,6 +148,8 @@ spec:
         - mountPath: /etc/kubernetes/pki/ca
           name: ca
           readOnly: true
+        - mountPath: /http-prober-bin
+          name: http-prober-bin
       dnsConfig:
         nameservers:
         - 192.0.2.14
@@ -154,24 +164,16 @@ spec:
       imagePullSecrets:
       - name: dockercfg
       initContainers:
-      - args:
-        - -endpoint
-        - https://apiserver-external.cluster-de-test-01.svc.cluster.local.:30000/healthz
-        - -insecure
-        - -retries
-        - "100"
-        - -retry-wait
-        - "2"
-        - -timeout
-        - "1"
-        command:
+      - command:
+        - /bin/cp
         - /usr/local/bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.1
-        imagePullPolicy: IfNotPresent
-        name: apiserver-running
+        - /http-prober-bin/http-prober
+        image: quay.io/kubermatic/http-prober:v0.2-dev0
+        name: copy-http-prober
         resources: {}
-        terminationMessagePath: /dev/termination-log
-        terminationMessagePolicy: File
+        volumeMounts:
+        - mountPath: /http-prober-bin
+          name: http-prober-bin
       volumes:
       - name: openvpn-client-certificates
         secret:
@@ -188,4 +190,6 @@ spec:
         secret:
           defaultMode: 256
           secretName: scheduler-kubeconfig
+      - emptyDir: {}
+        name: http-prober-bin
 status: {}

--- a/api/pkg/resources/test/fixtures/deployment-vsphere-1.11.1-scheduler.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-vsphere-1.11.1-scheduler.yaml
@@ -168,7 +168,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.2-dev0
+        image: quay.io/kubermatic/http-prober:v0.2
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/api/pkg/resources/test/fixtures/deployment-vsphere-1.11.1-usercluster-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-vsphere-1.11.1-usercluster-controller.yaml
@@ -85,7 +85,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.2-dev0
+        image: quay.io/kubermatic/http-prober:v0.2
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/api/pkg/resources/test/fixtures/deployment-vsphere-1.11.1-usercluster-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-vsphere-1.11.1-usercluster-controller.yaml
@@ -29,32 +29,19 @@ spec:
     spec:
       containers:
       - args:
-        - -kubeconfig
-        - /etc/kubernetes/kubeconfig/kubeconfig
-        - -metrics-listen-address
-        - 0.0.0.0:8085
-        - -health-listen-address
-        - 0.0.0.0:8086
-        - -namespace
-        - $(NAMESPACE)
-        - -ca-cert
-        - /etc/kubernetes/pki/ca/ca.crt
-        - -cluster-url
-        - ""
-        - -openvpn-server-port
-        - "30003"
-        - -overwrite-registry
-        - ""
-        - -openshift=false
-        - -openvpn-ca-cert-file=/etc/kubernetes/pki/openvpn/ca.crt
-        - -openvpn-ca-key-file=/etc/kubernetes/pki/openvpn/ca.key
-        - -logtostderr
-        - -v
+        - -endpoint
+        - https://apiserver-external.cluster-de-test-01.svc.cluster.local.:30000/healthz
+        - -insecure
+        - -retries
+        - "100"
+        - -retry-wait
         - "2"
-        - --ipam-controller-network
-        - 192.168.1.1/24,192.168.1.1,8.8.8.8
+        - -timeout
+        - "1"
+        - -command
+        - '{"command":"/usr/local/bin/user-cluster-controller-manager","args":["-kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","-metrics-listen-address","0.0.0.0:8085","-health-listen-address","0.0.0.0:8086","-namespace","$(NAMESPACE)","-ca-cert","/etc/kubernetes/pki/ca/ca.crt","-cluster-url","","-openvpn-server-port","30003","-overwrite-registry","","-openshift=false","-openvpn-ca-cert-file=/etc/kubernetes/pki/openvpn/ca.crt","-openvpn-ca-key-file=/etc/kubernetes/pki/openvpn/ca.key","-logtostderr","-v","2","--ipam-controller-network","192.168.1.1/24,192.168.1.1,8.8.8.8"]}'
         command:
-        - /usr/local/bin/user-cluster-controller-manager
+        - /http-prober-bin/http-prober
         env:
         - name: NAMESPACE
           valueFrom:
@@ -89,27 +76,21 @@ spec:
         - mountPath: /etc/kubernetes/pki/openvpn
           name: openvpn-ca
           readOnly: true
+        - mountPath: /http-prober-bin
+          name: http-prober-bin
       imagePullSecrets:
       - name: dockercfg
       initContainers:
-      - args:
-        - -endpoint
-        - https://apiserver-external.cluster-de-test-01.svc.cluster.local.:30000/healthz
-        - -insecure
-        - -retries
-        - "100"
-        - -retry-wait
-        - "2"
-        - -timeout
-        - "1"
-        command:
+      - command:
+        - /bin/cp
         - /usr/local/bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.1
-        imagePullPolicy: IfNotPresent
-        name: apiserver-running
+        - /http-prober-bin/http-prober
+        image: quay.io/kubermatic/http-prober:v0.2-dev0
+        name: copy-http-prober
         resources: {}
-        terminationMessagePath: /dev/termination-log
-        terminationMessagePolicy: File
+        volumeMounts:
+        - mountPath: /http-prober-bin
+          name: http-prober-bin
       volumes:
       - name: internal-admin-kubeconfig
         secret:
@@ -126,4 +107,6 @@ spec:
         secret:
           defaultMode: 292
           secretName: openvpn-ca
+      - emptyDir: {}
+        name: http-prober-bin
 status: {}

--- a/api/pkg/resources/test/fixtures/deployment-vsphere-1.12.0-controller-manager.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-vsphere-1.12.0-controller-manager.yaml
@@ -102,37 +102,19 @@ spec:
           name: openvpn-client-certificates
           readOnly: true
       - args:
-        - --kubeconfig
-        - /etc/kubernetes/kubeconfig/kubeconfig
-        - --service-account-private-key-file
-        - /etc/kubernetes/service-account-key/sa.key
-        - --root-ca-file
-        - /etc/kubernetes/pki/ca/ca.crt
-        - --cluster-signing-cert-file
-        - /etc/kubernetes/pki/ca/ca.crt
-        - --cluster-signing-key-file
-        - /etc/kubernetes/pki/ca/ca.key
-        - --cluster-cidr
-        - 172.25.0.0/16
-        - --allocate-node-cidrs=true
-        - --controllers
-        - '*,bootstrapsigner,tokencleaner'
-        - --use-service-account-credentials=true
-        - --feature-gates
-        - RotateKubeletClientCertificate=true,RotateKubeletServerCertificate=true,ScheduleDaemonSetPods=false
-        - --cloud-provider
-        - vsphere
-        - --cloud-config
-        - /etc/kubernetes/cloud/config
-        - --configure-cloud-routes=false
-        - --authentication-kubeconfig
-        - /etc/kubernetes/kubeconfig/kubeconfig
-        - --client-ca-file
-        - /etc/kubernetes/pki/ca/ca.crt
-        - --authentication-skip-lookup=true
+        - -endpoint
+        - https://apiserver-external.cluster-de-test-01.svc.cluster.local.:30000/healthz
+        - -insecure
+        - -retries
+        - "100"
+        - -retry-wait
+        - "2"
+        - -timeout
+        - "1"
+        - -command
+        - '{"command":"/hyperkube","args":["kube-controller-manager","--kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","--service-account-private-key-file","/etc/kubernetes/service-account-key/sa.key","--root-ca-file","/etc/kubernetes/pki/ca/ca.crt","--cluster-signing-cert-file","/etc/kubernetes/pki/ca/ca.crt","--cluster-signing-key-file","/etc/kubernetes/pki/ca/ca.key","--cluster-cidr","172.25.0.0/16","--allocate-node-cidrs=true","--controllers","*,bootstrapsigner,tokencleaner","--use-service-account-credentials=true","--feature-gates","RotateKubeletClientCertificate=true,RotateKubeletServerCertificate=true,ScheduleDaemonSetPods=false","--cloud-provider","vsphere","--cloud-config","/etc/kubernetes/cloud/config","--configure-cloud-routes=false","--authentication-kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","--client-ca-file","/etc/kubernetes/pki/ca/ca.crt","--authentication-skip-lookup=true"]}'
         command:
-        - /hyperkube
-        - kube-controller-manager
+        - /http-prober-bin/http-prober
         image: gcr.io/google_containers/hyperkube-amd64:v1.12.0
         livenessProbe:
           failureThreshold: 8
@@ -178,6 +160,8 @@ spec:
           name: cloud-config
           readOnly: true
           subPath: fakeVmwareUUID
+        - mountPath: /http-prober-bin
+          name: http-prober-bin
       dnsConfig:
         nameservers:
         - 192.0.2.14
@@ -192,24 +176,16 @@ spec:
       imagePullSecrets:
       - name: dockercfg
       initContainers:
-      - args:
-        - -endpoint
-        - https://apiserver-external.cluster-de-test-01.svc.cluster.local.:30000/healthz
-        - -insecure
-        - -retries
-        - "100"
-        - -retry-wait
-        - "2"
-        - -timeout
-        - "1"
-        command:
+      - command:
+        - /bin/cp
         - /usr/local/bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.1
-        imagePullPolicy: IfNotPresent
-        name: apiserver-running
+        - /http-prober-bin/http-prober
+        image: quay.io/kubermatic/http-prober:v0.2-dev0
+        name: copy-http-prober
         resources: {}
-        terminationMessagePath: /dev/termination-log
-        terminationMessagePolicy: File
+        volumeMounts:
+        - mountPath: /http-prober-bin
+          name: http-prober-bin
       volumes:
       - name: ca
         secret:
@@ -231,4 +207,6 @@ spec:
         secret:
           defaultMode: 256
           secretName: controllermanager-kubeconfig
+      - emptyDir: {}
+        name: http-prober-bin
 status: {}

--- a/api/pkg/resources/test/fixtures/deployment-vsphere-1.12.0-controller-manager.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-vsphere-1.12.0-controller-manager.yaml
@@ -180,7 +180,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.2-dev0
+        image: quay.io/kubermatic/http-prober:v0.2
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/api/pkg/resources/test/fixtures/deployment-vsphere-1.12.0-kube-state-metrics.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-vsphere-1.12.0-kube-state-metrics.yaml
@@ -21,14 +21,19 @@ spec:
     spec:
       containers:
       - args:
-        - --kubeconfig
-        - /etc/kubernetes/kubeconfig/kubeconfig
-        - --port
-        - "8080"
-        - --telemetry-port
-        - "8081"
+        - -endpoint
+        - https://apiserver-external.cluster-de-test-01.svc.cluster.local.:30000/healthz
+        - -insecure
+        - -retries
+        - "100"
+        - -retry-wait
+        - "2"
+        - -timeout
+        - "1"
+        - -command
+        - '{"command":"/kube-state-metrics","args":["--kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","--port","8080","--telemetry-port","8081"]}'
         command:
-        - /kube-state-metrics
+        - /http-prober-bin/http-prober
         image: quay.io/coreos/kube-state-metrics:v1.6.0
         name: kube-state-metrics
         ports:
@@ -58,30 +63,26 @@ spec:
         - mountPath: /etc/kubernetes/kubeconfig
           name: kube-state-metrics-kubeconfig
           readOnly: true
+        - mountPath: /http-prober-bin
+          name: http-prober-bin
       imagePullSecrets:
       - name: dockercfg
       initContainers:
-      - args:
-        - -endpoint
-        - https://apiserver-external.cluster-de-test-01.svc.cluster.local.:30000/healthz
-        - -insecure
-        - -retries
-        - "100"
-        - -retry-wait
-        - "2"
-        - -timeout
-        - "1"
-        command:
+      - command:
+        - /bin/cp
         - /usr/local/bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.1
-        imagePullPolicy: IfNotPresent
-        name: apiserver-running
+        - /http-prober-bin/http-prober
+        image: quay.io/kubermatic/http-prober:v0.2-dev0
+        name: copy-http-prober
         resources: {}
-        terminationMessagePath: /dev/termination-log
-        terminationMessagePolicy: File
+        volumeMounts:
+        - mountPath: /http-prober-bin
+          name: http-prober-bin
       volumes:
       - name: kube-state-metrics-kubeconfig
         secret:
           defaultMode: 256
           secretName: kube-state-metrics-kubeconfig
+      - emptyDir: {}
+        name: http-prober-bin
 status: {}

--- a/api/pkg/resources/test/fixtures/deployment-vsphere-1.12.0-kube-state-metrics.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-vsphere-1.12.0-kube-state-metrics.yaml
@@ -72,7 +72,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.2-dev0
+        image: quay.io/kubermatic/http-prober:v0.2
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/api/pkg/resources/test/fixtures/deployment-vsphere-1.12.0-machine-controller-webhook.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-vsphere-1.12.0-machine-controller-webhook.yaml
@@ -24,15 +24,19 @@ spec:
     spec:
       containers:
       - args:
-        - -kubeconfig
-        - /etc/kubernetes/kubeconfig/kubeconfig
-        - -logtostderr
-        - -v
-        - "4"
-        - -listen-address
-        - 0.0.0.0:9876
+        - -endpoint
+        - https://apiserver-external.cluster-de-test-01.svc.cluster.local.:30000/healthz
+        - -insecure
+        - -retries
+        - "100"
+        - -retry-wait
+        - "2"
+        - -timeout
+        - "1"
+        - -command
+        - '{"command":"/usr/local/bin/webhook","args":["-kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","-logtostderr","-v","4","-listen-address","0.0.0.0:9876"]}'
         command:
-        - /usr/local/bin/webhook
+        - /http-prober-bin/http-prober
         env:
         - name: VSPHERE_ADDRESS
           value: https://vs-endpoint.io
@@ -73,27 +77,21 @@ spec:
         - mountPath: /tmp/cert
           name: machinecontroller-webhook-serving-cert
           readOnly: true
+        - mountPath: /http-prober-bin
+          name: http-prober-bin
       imagePullSecrets:
       - name: dockercfg
       initContainers:
-      - args:
-        - -endpoint
-        - https://apiserver-external.cluster-de-test-01.svc.cluster.local.:30000/healthz
-        - -insecure
-        - -retries
-        - "100"
-        - -retry-wait
-        - "2"
-        - -timeout
-        - "1"
-        command:
+      - command:
+        - /bin/cp
         - /usr/local/bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.1
-        imagePullPolicy: IfNotPresent
-        name: apiserver-running
+        - /http-prober-bin/http-prober
+        image: quay.io/kubermatic/http-prober:v0.2-dev0
+        name: copy-http-prober
         resources: {}
-        terminationMessagePath: /dev/termination-log
-        terminationMessagePolicy: File
+        volumeMounts:
+        - mountPath: /http-prober-bin
+          name: http-prober-bin
       volumes:
       - name: machinecontroller-kubeconfig
         secret:
@@ -103,4 +101,6 @@ spec:
         secret:
           defaultMode: 292
           secretName: machinecontroller-webhook-serving-cert
+      - emptyDir: {}
+        name: http-prober-bin
 status: {}

--- a/api/pkg/resources/test/fixtures/deployment-vsphere-1.12.0-machine-controller-webhook.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-vsphere-1.12.0-machine-controller-webhook.yaml
@@ -86,7 +86,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.2-dev0
+        image: quay.io/kubermatic/http-prober:v0.2
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/api/pkg/resources/test/fixtures/deployment-vsphere-1.12.0-machine-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-vsphere-1.12.0-machine-controller.yaml
@@ -27,17 +27,19 @@ spec:
     spec:
       containers:
       - args:
-        - -kubeconfig
-        - /etc/kubernetes/kubeconfig/kubeconfig
-        - -logtostderr
-        - -v
-        - "4"
-        - -cluster-dns
-        - 169.254.20.10
-        - -internal-listen-address
-        - 0.0.0.0:8085
+        - -endpoint
+        - https://apiserver-external.cluster-de-test-01.svc.cluster.local.:30000/healthz
+        - -insecure
+        - -retries
+        - "100"
+        - -retry-wait
+        - "2"
+        - -timeout
+        - "1"
+        - -command
+        - '{"command":"/usr/local/bin/machine-controller","args":["-kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","-logtostderr","-v","4","-cluster-dns","169.254.20.10","-internal-listen-address","0.0.0.0:8085"]}'
         command:
-        - /usr/local/bin/machine-controller
+        - /http-prober-bin/http-prober
         env:
         - name: VSPHERE_ADDRESS
           value: https://vs-endpoint.io
@@ -66,30 +68,26 @@ spec:
         - mountPath: /etc/kubernetes/kubeconfig
           name: machinecontroller-kubeconfig
           readOnly: true
+        - mountPath: /http-prober-bin
+          name: http-prober-bin
       imagePullSecrets:
       - name: dockercfg
       initContainers:
-      - args:
-        - -endpoint
-        - https://apiserver-external.cluster-de-test-01.svc.cluster.local.:30000/healthz
-        - -insecure
-        - -retries
-        - "100"
-        - -retry-wait
-        - "2"
-        - -timeout
-        - "1"
-        command:
+      - command:
+        - /bin/cp
         - /usr/local/bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.1
-        imagePullPolicy: IfNotPresent
-        name: apiserver-running
+        - /http-prober-bin/http-prober
+        image: quay.io/kubermatic/http-prober:v0.2-dev0
+        name: copy-http-prober
         resources: {}
-        terminationMessagePath: /dev/termination-log
-        terminationMessagePolicy: File
+        volumeMounts:
+        - mountPath: /http-prober-bin
+          name: http-prober-bin
       volumes:
       - name: machinecontroller-kubeconfig
         secret:
           defaultMode: 292
           secretName: machinecontroller-kubeconfig
+      - emptyDir: {}
+        name: http-prober-bin
 status: {}

--- a/api/pkg/resources/test/fixtures/deployment-vsphere-1.12.0-machine-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-vsphere-1.12.0-machine-controller.yaml
@@ -77,7 +77,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.2-dev0
+        image: quay.io/kubermatic/http-prober:v0.2
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/api/pkg/resources/test/fixtures/deployment-vsphere-1.12.0-metrics-server.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-vsphere-1.12.0-metrics-server.yaml
@@ -41,22 +41,19 @@ spec:
             weight: 10
       containers:
       - args:
-        - --kubeconfig
-        - /etc/kubernetes/kubeconfig/kubeconfig
-        - --authentication-kubeconfig
-        - /etc/kubernetes/kubeconfig/kubeconfig
-        - --authorization-kubeconfig
-        - /etc/kubernetes/kubeconfig/kubeconfig
-        - --kubelet-port
-        - "10250"
-        - --kubelet-insecure-tls
-        - --kubelet-preferred-address-types
-        - ExternalIP,InternalIP
-        - --v
+        - -endpoint
+        - https://apiserver-external.cluster-de-test-01.svc.cluster.local.:30000/healthz
+        - -insecure
+        - -retries
+        - "100"
+        - -retry-wait
+        - "2"
+        - -timeout
         - "1"
-        - --logtostderr
+        - -command
+        - '{"command":"/metrics-server","args":["--kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","--authentication-kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","--authorization-kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","--kubelet-port","10250","--kubelet-insecure-tls","--kubelet-preferred-address-types","ExternalIP,InternalIP","--v","1","--logtostderr"]}'
         command:
-        - /metrics-server
+        - /http-prober-bin/http-prober
         image: gcr.io/google_containers/metrics-server-amd64:v0.3.2
         name: metrics-server
         resources:
@@ -70,6 +67,8 @@ spec:
         - mountPath: /etc/kubernetes/kubeconfig
           name: metrics-server
           readOnly: true
+        - mountPath: /http-prober-bin
+          name: http-prober-bin
       - args:
         - --client
         - --proto
@@ -158,24 +157,16 @@ spec:
       imagePullSecrets:
       - name: dockercfg
       initContainers:
-      - args:
-        - -endpoint
-        - https://apiserver-external.cluster-de-test-01.svc.cluster.local.:30000/healthz
-        - -insecure
-        - -retries
-        - "100"
-        - -retry-wait
-        - "2"
-        - -timeout
-        - "1"
-        command:
+      - command:
+        - /bin/cp
         - /usr/local/bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.1
-        imagePullPolicy: IfNotPresent
-        name: apiserver-running
+        - /http-prober-bin/http-prober
+        image: quay.io/kubermatic/http-prober:v0.2-dev0
+        name: copy-http-prober
         resources: {}
-        terminationMessagePath: /dev/termination-log
-        terminationMessagePolicy: File
+        volumeMounts:
+        - mountPath: /http-prober-bin
+          name: http-prober-bin
       volumes:
       - name: metrics-server
         secret:
@@ -189,4 +180,6 @@ spec:
         secret:
           defaultMode: 292
           secretName: kubeletdnatcontroller-kubeconfig
+      - emptyDir: {}
+        name: http-prober-bin
 status: {}

--- a/api/pkg/resources/test/fixtures/deployment-vsphere-1.12.0-metrics-server.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-vsphere-1.12.0-metrics-server.yaml
@@ -161,7 +161,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.2-dev0
+        image: quay.io/kubermatic/http-prober:v0.2
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/api/pkg/resources/test/fixtures/deployment-vsphere-1.12.0-scheduler.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-vsphere-1.12.0-scheduler.yaml
@@ -168,7 +168,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.2-dev0
+        image: quay.io/kubermatic/http-prober:v0.2
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/api/pkg/resources/test/fixtures/deployment-vsphere-1.12.0-scheduler.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-vsphere-1.12.0-scheduler.yaml
@@ -100,13 +100,19 @@ spec:
           name: openvpn-client-certificates
           readOnly: true
       - args:
-        - --kubeconfig
-        - /etc/kubernetes/kubeconfig/kubeconfig
-        - --feature-gates
-        - ScheduleDaemonSetPods=false
+        - -endpoint
+        - https://apiserver-external.cluster-de-test-01.svc.cluster.local.:30000/healthz
+        - -insecure
+        - -retries
+        - "100"
+        - -retry-wait
+        - "2"
+        - -timeout
+        - "1"
+        - -command
+        - '{"command":"/hyperkube","args":["kube-scheduler","--kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","--feature-gates","ScheduleDaemonSetPods=false"]}'
         command:
-        - /hyperkube
-        - kube-scheduler
+        - /http-prober-bin/http-prober
         image: gcr.io/google_containers/hyperkube-amd64:v1.12.0
         livenessProbe:
           failureThreshold: 8
@@ -142,6 +148,8 @@ spec:
         - mountPath: /etc/kubernetes/pki/ca
           name: ca
           readOnly: true
+        - mountPath: /http-prober-bin
+          name: http-prober-bin
       dnsConfig:
         nameservers:
         - 192.0.2.14
@@ -156,24 +164,16 @@ spec:
       imagePullSecrets:
       - name: dockercfg
       initContainers:
-      - args:
-        - -endpoint
-        - https://apiserver-external.cluster-de-test-01.svc.cluster.local.:30000/healthz
-        - -insecure
-        - -retries
-        - "100"
-        - -retry-wait
-        - "2"
-        - -timeout
-        - "1"
-        command:
+      - command:
+        - /bin/cp
         - /usr/local/bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.1
-        imagePullPolicy: IfNotPresent
-        name: apiserver-running
+        - /http-prober-bin/http-prober
+        image: quay.io/kubermatic/http-prober:v0.2-dev0
+        name: copy-http-prober
         resources: {}
-        terminationMessagePath: /dev/termination-log
-        terminationMessagePolicy: File
+        volumeMounts:
+        - mountPath: /http-prober-bin
+          name: http-prober-bin
       volumes:
       - name: openvpn-client-certificates
         secret:
@@ -190,4 +190,6 @@ spec:
         secret:
           defaultMode: 256
           secretName: scheduler-kubeconfig
+      - emptyDir: {}
+        name: http-prober-bin
 status: {}

--- a/api/pkg/resources/test/fixtures/deployment-vsphere-1.12.0-usercluster-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-vsphere-1.12.0-usercluster-controller.yaml
@@ -85,7 +85,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.2-dev0
+        image: quay.io/kubermatic/http-prober:v0.2
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/api/pkg/resources/test/fixtures/deployment-vsphere-1.12.0-usercluster-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-vsphere-1.12.0-usercluster-controller.yaml
@@ -29,32 +29,19 @@ spec:
     spec:
       containers:
       - args:
-        - -kubeconfig
-        - /etc/kubernetes/kubeconfig/kubeconfig
-        - -metrics-listen-address
-        - 0.0.0.0:8085
-        - -health-listen-address
-        - 0.0.0.0:8086
-        - -namespace
-        - $(NAMESPACE)
-        - -ca-cert
-        - /etc/kubernetes/pki/ca/ca.crt
-        - -cluster-url
-        - ""
-        - -openvpn-server-port
-        - "30003"
-        - -overwrite-registry
-        - ""
-        - -openshift=false
-        - -openvpn-ca-cert-file=/etc/kubernetes/pki/openvpn/ca.crt
-        - -openvpn-ca-key-file=/etc/kubernetes/pki/openvpn/ca.key
-        - -logtostderr
-        - -v
+        - -endpoint
+        - https://apiserver-external.cluster-de-test-01.svc.cluster.local.:30000/healthz
+        - -insecure
+        - -retries
+        - "100"
+        - -retry-wait
         - "2"
-        - --ipam-controller-network
-        - 192.168.1.1/24,192.168.1.1,8.8.8.8
+        - -timeout
+        - "1"
+        - -command
+        - '{"command":"/usr/local/bin/user-cluster-controller-manager","args":["-kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","-metrics-listen-address","0.0.0.0:8085","-health-listen-address","0.0.0.0:8086","-namespace","$(NAMESPACE)","-ca-cert","/etc/kubernetes/pki/ca/ca.crt","-cluster-url","","-openvpn-server-port","30003","-overwrite-registry","","-openshift=false","-openvpn-ca-cert-file=/etc/kubernetes/pki/openvpn/ca.crt","-openvpn-ca-key-file=/etc/kubernetes/pki/openvpn/ca.key","-logtostderr","-v","2","--ipam-controller-network","192.168.1.1/24,192.168.1.1,8.8.8.8"]}'
         command:
-        - /usr/local/bin/user-cluster-controller-manager
+        - /http-prober-bin/http-prober
         env:
         - name: NAMESPACE
           valueFrom:
@@ -89,27 +76,21 @@ spec:
         - mountPath: /etc/kubernetes/pki/openvpn
           name: openvpn-ca
           readOnly: true
+        - mountPath: /http-prober-bin
+          name: http-prober-bin
       imagePullSecrets:
       - name: dockercfg
       initContainers:
-      - args:
-        - -endpoint
-        - https://apiserver-external.cluster-de-test-01.svc.cluster.local.:30000/healthz
-        - -insecure
-        - -retries
-        - "100"
-        - -retry-wait
-        - "2"
-        - -timeout
-        - "1"
-        command:
+      - command:
+        - /bin/cp
         - /usr/local/bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.1
-        imagePullPolicy: IfNotPresent
-        name: apiserver-running
+        - /http-prober-bin/http-prober
+        image: quay.io/kubermatic/http-prober:v0.2-dev0
+        name: copy-http-prober
         resources: {}
-        terminationMessagePath: /dev/termination-log
-        terminationMessagePolicy: File
+        volumeMounts:
+        - mountPath: /http-prober-bin
+          name: http-prober-bin
       volumes:
       - name: internal-admin-kubeconfig
         secret:
@@ -126,4 +107,6 @@ spec:
         secret:
           defaultMode: 292
           secretName: openvpn-ca
+      - emptyDir: {}
+        name: http-prober-bin
 status: {}

--- a/api/pkg/resources/test/fixtures/deployment-vsphere-1.13.0-controller-manager.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-vsphere-1.13.0-controller-manager.yaml
@@ -102,42 +102,19 @@ spec:
           name: openvpn-client-certificates
           readOnly: true
       - args:
-        - --kubeconfig
-        - /etc/kubernetes/kubeconfig/kubeconfig
-        - --service-account-private-key-file
-        - /etc/kubernetes/service-account-key/sa.key
-        - --root-ca-file
-        - /etc/kubernetes/pki/ca/ca.crt
-        - --cluster-signing-cert-file
-        - /etc/kubernetes/pki/ca/ca.crt
-        - --cluster-signing-key-file
-        - /etc/kubernetes/pki/ca/ca.key
-        - --cluster-cidr
-        - 172.25.0.0/16
-        - --allocate-node-cidrs=true
-        - --controllers
-        - '*,bootstrapsigner,tokencleaner'
-        - --use-service-account-credentials=true
-        - --feature-gates
-        - RotateKubeletClientCertificate=true,RotateKubeletServerCertificate=true,ScheduleDaemonSetPods=false
-        - --cloud-provider
-        - vsphere
-        - --cloud-config
-        - /etc/kubernetes/cloud/config
-        - --configure-cloud-routes=false
-        - --authentication-kubeconfig
-        - /etc/kubernetes/kubeconfig/kubeconfig
-        - --client-ca-file
-        - /etc/kubernetes/pki/ca/ca.crt
-        - --authentication-kubeconfig
-        - /etc/kubernetes/kubeconfig/kubeconfig
-        - --authorization-kubeconfig
-        - /etc/kubernetes/kubeconfig/kubeconfig
-        - --port
-        - "0"
+        - -endpoint
+        - https://apiserver-external.cluster-de-test-01.svc.cluster.local.:30000/healthz
+        - -insecure
+        - -retries
+        - "100"
+        - -retry-wait
+        - "2"
+        - -timeout
+        - "1"
+        - -command
+        - '{"command":"/hyperkube","args":["kube-controller-manager","--kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","--service-account-private-key-file","/etc/kubernetes/service-account-key/sa.key","--root-ca-file","/etc/kubernetes/pki/ca/ca.crt","--cluster-signing-cert-file","/etc/kubernetes/pki/ca/ca.crt","--cluster-signing-key-file","/etc/kubernetes/pki/ca/ca.key","--cluster-cidr","172.25.0.0/16","--allocate-node-cidrs=true","--controllers","*,bootstrapsigner,tokencleaner","--use-service-account-credentials=true","--feature-gates","RotateKubeletClientCertificate=true,RotateKubeletServerCertificate=true,ScheduleDaemonSetPods=false","--cloud-provider","vsphere","--cloud-config","/etc/kubernetes/cloud/config","--configure-cloud-routes=false","--authentication-kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","--client-ca-file","/etc/kubernetes/pki/ca/ca.crt","--authentication-kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","--authorization-kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","--port","0"]}'
         command:
-        - /hyperkube
-        - kube-controller-manager
+        - /http-prober-bin/http-prober
         image: gcr.io/google_containers/hyperkube-amd64:v1.13.0
         livenessProbe:
           failureThreshold: 8
@@ -183,6 +160,8 @@ spec:
           name: cloud-config
           readOnly: true
           subPath: fakeVmwareUUID
+        - mountPath: /http-prober-bin
+          name: http-prober-bin
       dnsConfig:
         nameservers:
         - 192.0.2.14
@@ -197,24 +176,16 @@ spec:
       imagePullSecrets:
       - name: dockercfg
       initContainers:
-      - args:
-        - -endpoint
-        - https://apiserver-external.cluster-de-test-01.svc.cluster.local.:30000/healthz
-        - -insecure
-        - -retries
-        - "100"
-        - -retry-wait
-        - "2"
-        - -timeout
-        - "1"
-        command:
+      - command:
+        - /bin/cp
         - /usr/local/bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.1
-        imagePullPolicy: IfNotPresent
-        name: apiserver-running
+        - /http-prober-bin/http-prober
+        image: quay.io/kubermatic/http-prober:v0.2-dev0
+        name: copy-http-prober
         resources: {}
-        terminationMessagePath: /dev/termination-log
-        terminationMessagePolicy: File
+        volumeMounts:
+        - mountPath: /http-prober-bin
+          name: http-prober-bin
       volumes:
       - name: ca
         secret:
@@ -236,4 +207,6 @@ spec:
         secret:
           defaultMode: 256
           secretName: controllermanager-kubeconfig
+      - emptyDir: {}
+        name: http-prober-bin
 status: {}

--- a/api/pkg/resources/test/fixtures/deployment-vsphere-1.13.0-controller-manager.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-vsphere-1.13.0-controller-manager.yaml
@@ -180,7 +180,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.2-dev0
+        image: quay.io/kubermatic/http-prober:v0.2
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/api/pkg/resources/test/fixtures/deployment-vsphere-1.13.0-kube-state-metrics.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-vsphere-1.13.0-kube-state-metrics.yaml
@@ -21,14 +21,19 @@ spec:
     spec:
       containers:
       - args:
-        - --kubeconfig
-        - /etc/kubernetes/kubeconfig/kubeconfig
-        - --port
-        - "8080"
-        - --telemetry-port
-        - "8081"
+        - -endpoint
+        - https://apiserver-external.cluster-de-test-01.svc.cluster.local.:30000/healthz
+        - -insecure
+        - -retries
+        - "100"
+        - -retry-wait
+        - "2"
+        - -timeout
+        - "1"
+        - -command
+        - '{"command":"/kube-state-metrics","args":["--kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","--port","8080","--telemetry-port","8081"]}'
         command:
-        - /kube-state-metrics
+        - /http-prober-bin/http-prober
         image: quay.io/coreos/kube-state-metrics:v1.6.0
         name: kube-state-metrics
         ports:
@@ -58,30 +63,26 @@ spec:
         - mountPath: /etc/kubernetes/kubeconfig
           name: kube-state-metrics-kubeconfig
           readOnly: true
+        - mountPath: /http-prober-bin
+          name: http-prober-bin
       imagePullSecrets:
       - name: dockercfg
       initContainers:
-      - args:
-        - -endpoint
-        - https://apiserver-external.cluster-de-test-01.svc.cluster.local.:30000/healthz
-        - -insecure
-        - -retries
-        - "100"
-        - -retry-wait
-        - "2"
-        - -timeout
-        - "1"
-        command:
+      - command:
+        - /bin/cp
         - /usr/local/bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.1
-        imagePullPolicy: IfNotPresent
-        name: apiserver-running
+        - /http-prober-bin/http-prober
+        image: quay.io/kubermatic/http-prober:v0.2-dev0
+        name: copy-http-prober
         resources: {}
-        terminationMessagePath: /dev/termination-log
-        terminationMessagePolicy: File
+        volumeMounts:
+        - mountPath: /http-prober-bin
+          name: http-prober-bin
       volumes:
       - name: kube-state-metrics-kubeconfig
         secret:
           defaultMode: 256
           secretName: kube-state-metrics-kubeconfig
+      - emptyDir: {}
+        name: http-prober-bin
 status: {}

--- a/api/pkg/resources/test/fixtures/deployment-vsphere-1.13.0-kube-state-metrics.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-vsphere-1.13.0-kube-state-metrics.yaml
@@ -72,7 +72,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.2-dev0
+        image: quay.io/kubermatic/http-prober:v0.2
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/api/pkg/resources/test/fixtures/deployment-vsphere-1.13.0-machine-controller-webhook.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-vsphere-1.13.0-machine-controller-webhook.yaml
@@ -24,15 +24,19 @@ spec:
     spec:
       containers:
       - args:
-        - -kubeconfig
-        - /etc/kubernetes/kubeconfig/kubeconfig
-        - -logtostderr
-        - -v
-        - "4"
-        - -listen-address
-        - 0.0.0.0:9876
+        - -endpoint
+        - https://apiserver-external.cluster-de-test-01.svc.cluster.local.:30000/healthz
+        - -insecure
+        - -retries
+        - "100"
+        - -retry-wait
+        - "2"
+        - -timeout
+        - "1"
+        - -command
+        - '{"command":"/usr/local/bin/webhook","args":["-kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","-logtostderr","-v","4","-listen-address","0.0.0.0:9876"]}'
         command:
-        - /usr/local/bin/webhook
+        - /http-prober-bin/http-prober
         env:
         - name: VSPHERE_ADDRESS
           value: https://vs-endpoint.io
@@ -73,27 +77,21 @@ spec:
         - mountPath: /tmp/cert
           name: machinecontroller-webhook-serving-cert
           readOnly: true
+        - mountPath: /http-prober-bin
+          name: http-prober-bin
       imagePullSecrets:
       - name: dockercfg
       initContainers:
-      - args:
-        - -endpoint
-        - https://apiserver-external.cluster-de-test-01.svc.cluster.local.:30000/healthz
-        - -insecure
-        - -retries
-        - "100"
-        - -retry-wait
-        - "2"
-        - -timeout
-        - "1"
-        command:
+      - command:
+        - /bin/cp
         - /usr/local/bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.1
-        imagePullPolicy: IfNotPresent
-        name: apiserver-running
+        - /http-prober-bin/http-prober
+        image: quay.io/kubermatic/http-prober:v0.2-dev0
+        name: copy-http-prober
         resources: {}
-        terminationMessagePath: /dev/termination-log
-        terminationMessagePolicy: File
+        volumeMounts:
+        - mountPath: /http-prober-bin
+          name: http-prober-bin
       volumes:
       - name: machinecontroller-kubeconfig
         secret:
@@ -103,4 +101,6 @@ spec:
         secret:
           defaultMode: 292
           secretName: machinecontroller-webhook-serving-cert
+      - emptyDir: {}
+        name: http-prober-bin
 status: {}

--- a/api/pkg/resources/test/fixtures/deployment-vsphere-1.13.0-machine-controller-webhook.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-vsphere-1.13.0-machine-controller-webhook.yaml
@@ -86,7 +86,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.2-dev0
+        image: quay.io/kubermatic/http-prober:v0.2
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/api/pkg/resources/test/fixtures/deployment-vsphere-1.13.0-machine-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-vsphere-1.13.0-machine-controller.yaml
@@ -27,17 +27,19 @@ spec:
     spec:
       containers:
       - args:
-        - -kubeconfig
-        - /etc/kubernetes/kubeconfig/kubeconfig
-        - -logtostderr
-        - -v
-        - "4"
-        - -cluster-dns
-        - 169.254.20.10
-        - -internal-listen-address
-        - 0.0.0.0:8085
+        - -endpoint
+        - https://apiserver-external.cluster-de-test-01.svc.cluster.local.:30000/healthz
+        - -insecure
+        - -retries
+        - "100"
+        - -retry-wait
+        - "2"
+        - -timeout
+        - "1"
+        - -command
+        - '{"command":"/usr/local/bin/machine-controller","args":["-kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","-logtostderr","-v","4","-cluster-dns","169.254.20.10","-internal-listen-address","0.0.0.0:8085"]}'
         command:
-        - /usr/local/bin/machine-controller
+        - /http-prober-bin/http-prober
         env:
         - name: VSPHERE_ADDRESS
           value: https://vs-endpoint.io
@@ -66,30 +68,26 @@ spec:
         - mountPath: /etc/kubernetes/kubeconfig
           name: machinecontroller-kubeconfig
           readOnly: true
+        - mountPath: /http-prober-bin
+          name: http-prober-bin
       imagePullSecrets:
       - name: dockercfg
       initContainers:
-      - args:
-        - -endpoint
-        - https://apiserver-external.cluster-de-test-01.svc.cluster.local.:30000/healthz
-        - -insecure
-        - -retries
-        - "100"
-        - -retry-wait
-        - "2"
-        - -timeout
-        - "1"
-        command:
+      - command:
+        - /bin/cp
         - /usr/local/bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.1
-        imagePullPolicy: IfNotPresent
-        name: apiserver-running
+        - /http-prober-bin/http-prober
+        image: quay.io/kubermatic/http-prober:v0.2-dev0
+        name: copy-http-prober
         resources: {}
-        terminationMessagePath: /dev/termination-log
-        terminationMessagePolicy: File
+        volumeMounts:
+        - mountPath: /http-prober-bin
+          name: http-prober-bin
       volumes:
       - name: machinecontroller-kubeconfig
         secret:
           defaultMode: 292
           secretName: machinecontroller-kubeconfig
+      - emptyDir: {}
+        name: http-prober-bin
 status: {}

--- a/api/pkg/resources/test/fixtures/deployment-vsphere-1.13.0-machine-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-vsphere-1.13.0-machine-controller.yaml
@@ -77,7 +77,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.2-dev0
+        image: quay.io/kubermatic/http-prober:v0.2
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/api/pkg/resources/test/fixtures/deployment-vsphere-1.13.0-metrics-server.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-vsphere-1.13.0-metrics-server.yaml
@@ -41,22 +41,19 @@ spec:
             weight: 10
       containers:
       - args:
-        - --kubeconfig
-        - /etc/kubernetes/kubeconfig/kubeconfig
-        - --authentication-kubeconfig
-        - /etc/kubernetes/kubeconfig/kubeconfig
-        - --authorization-kubeconfig
-        - /etc/kubernetes/kubeconfig/kubeconfig
-        - --kubelet-port
-        - "10250"
-        - --kubelet-insecure-tls
-        - --kubelet-preferred-address-types
-        - ExternalIP,InternalIP
-        - --v
+        - -endpoint
+        - https://apiserver-external.cluster-de-test-01.svc.cluster.local.:30000/healthz
+        - -insecure
+        - -retries
+        - "100"
+        - -retry-wait
+        - "2"
+        - -timeout
         - "1"
-        - --logtostderr
+        - -command
+        - '{"command":"/metrics-server","args":["--kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","--authentication-kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","--authorization-kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","--kubelet-port","10250","--kubelet-insecure-tls","--kubelet-preferred-address-types","ExternalIP,InternalIP","--v","1","--logtostderr"]}'
         command:
-        - /metrics-server
+        - /http-prober-bin/http-prober
         image: gcr.io/google_containers/metrics-server-amd64:v0.3.2
         name: metrics-server
         resources:
@@ -70,6 +67,8 @@ spec:
         - mountPath: /etc/kubernetes/kubeconfig
           name: metrics-server
           readOnly: true
+        - mountPath: /http-prober-bin
+          name: http-prober-bin
       - args:
         - --client
         - --proto
@@ -158,24 +157,16 @@ spec:
       imagePullSecrets:
       - name: dockercfg
       initContainers:
-      - args:
-        - -endpoint
-        - https://apiserver-external.cluster-de-test-01.svc.cluster.local.:30000/healthz
-        - -insecure
-        - -retries
-        - "100"
-        - -retry-wait
-        - "2"
-        - -timeout
-        - "1"
-        command:
+      - command:
+        - /bin/cp
         - /usr/local/bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.1
-        imagePullPolicy: IfNotPresent
-        name: apiserver-running
+        - /http-prober-bin/http-prober
+        image: quay.io/kubermatic/http-prober:v0.2-dev0
+        name: copy-http-prober
         resources: {}
-        terminationMessagePath: /dev/termination-log
-        terminationMessagePolicy: File
+        volumeMounts:
+        - mountPath: /http-prober-bin
+          name: http-prober-bin
       volumes:
       - name: metrics-server
         secret:
@@ -189,4 +180,6 @@ spec:
         secret:
           defaultMode: 292
           secretName: kubeletdnatcontroller-kubeconfig
+      - emptyDir: {}
+        name: http-prober-bin
 status: {}

--- a/api/pkg/resources/test/fixtures/deployment-vsphere-1.13.0-metrics-server.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-vsphere-1.13.0-metrics-server.yaml
@@ -161,7 +161,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.2-dev0
+        image: quay.io/kubermatic/http-prober:v0.2
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/api/pkg/resources/test/fixtures/deployment-vsphere-1.13.0-scheduler.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-vsphere-1.13.0-scheduler.yaml
@@ -100,21 +100,19 @@ spec:
           name: openvpn-client-certificates
           readOnly: true
       - args:
-        - --kubeconfig
-        - /etc/kubernetes/kubeconfig/kubeconfig
-        - --authentication-kubeconfig
-        - /etc/kubernetes/kubeconfig/kubeconfig
-        - --authorization-kubeconfig
-        - /etc/kubernetes/kubeconfig/kubeconfig
-        - --client-ca-file
-        - /etc/kubernetes/pki/ca/ca.crt
-        - --port
-        - "0"
-        - --feature-gates
-        - ScheduleDaemonSetPods=false
+        - -endpoint
+        - https://apiserver-external.cluster-de-test-01.svc.cluster.local.:30000/healthz
+        - -insecure
+        - -retries
+        - "100"
+        - -retry-wait
+        - "2"
+        - -timeout
+        - "1"
+        - -command
+        - '{"command":"/hyperkube","args":["kube-scheduler","--kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","--authentication-kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","--authorization-kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","--client-ca-file","/etc/kubernetes/pki/ca/ca.crt","--port","0","--feature-gates","ScheduleDaemonSetPods=false"]}'
         command:
-        - /hyperkube
-        - kube-scheduler
+        - /http-prober-bin/http-prober
         image: gcr.io/google_containers/hyperkube-amd64:v1.13.0
         livenessProbe:
           failureThreshold: 8
@@ -150,6 +148,8 @@ spec:
         - mountPath: /etc/kubernetes/pki/ca
           name: ca
           readOnly: true
+        - mountPath: /http-prober-bin
+          name: http-prober-bin
       dnsConfig:
         nameservers:
         - 192.0.2.14
@@ -164,24 +164,16 @@ spec:
       imagePullSecrets:
       - name: dockercfg
       initContainers:
-      - args:
-        - -endpoint
-        - https://apiserver-external.cluster-de-test-01.svc.cluster.local.:30000/healthz
-        - -insecure
-        - -retries
-        - "100"
-        - -retry-wait
-        - "2"
-        - -timeout
-        - "1"
-        command:
+      - command:
+        - /bin/cp
         - /usr/local/bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.1
-        imagePullPolicy: IfNotPresent
-        name: apiserver-running
+        - /http-prober-bin/http-prober
+        image: quay.io/kubermatic/http-prober:v0.2-dev0
+        name: copy-http-prober
         resources: {}
-        terminationMessagePath: /dev/termination-log
-        terminationMessagePolicy: File
+        volumeMounts:
+        - mountPath: /http-prober-bin
+          name: http-prober-bin
       volumes:
       - name: openvpn-client-certificates
         secret:
@@ -198,4 +190,6 @@ spec:
         secret:
           defaultMode: 256
           secretName: scheduler-kubeconfig
+      - emptyDir: {}
+        name: http-prober-bin
 status: {}

--- a/api/pkg/resources/test/fixtures/deployment-vsphere-1.13.0-scheduler.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-vsphere-1.13.0-scheduler.yaml
@@ -168,7 +168,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.2-dev0
+        image: quay.io/kubermatic/http-prober:v0.2
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/api/pkg/resources/test/fixtures/deployment-vsphere-1.13.0-usercluster-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-vsphere-1.13.0-usercluster-controller.yaml
@@ -85,7 +85,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.2-dev0
+        image: quay.io/kubermatic/http-prober:v0.2
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/api/pkg/resources/test/fixtures/deployment-vsphere-1.13.0-usercluster-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-vsphere-1.13.0-usercluster-controller.yaml
@@ -29,32 +29,19 @@ spec:
     spec:
       containers:
       - args:
-        - -kubeconfig
-        - /etc/kubernetes/kubeconfig/kubeconfig
-        - -metrics-listen-address
-        - 0.0.0.0:8085
-        - -health-listen-address
-        - 0.0.0.0:8086
-        - -namespace
-        - $(NAMESPACE)
-        - -ca-cert
-        - /etc/kubernetes/pki/ca/ca.crt
-        - -cluster-url
-        - ""
-        - -openvpn-server-port
-        - "30003"
-        - -overwrite-registry
-        - ""
-        - -openshift=false
-        - -openvpn-ca-cert-file=/etc/kubernetes/pki/openvpn/ca.crt
-        - -openvpn-ca-key-file=/etc/kubernetes/pki/openvpn/ca.key
-        - -logtostderr
-        - -v
+        - -endpoint
+        - https://apiserver-external.cluster-de-test-01.svc.cluster.local.:30000/healthz
+        - -insecure
+        - -retries
+        - "100"
+        - -retry-wait
         - "2"
-        - --ipam-controller-network
-        - 192.168.1.1/24,192.168.1.1,8.8.8.8
+        - -timeout
+        - "1"
+        - -command
+        - '{"command":"/usr/local/bin/user-cluster-controller-manager","args":["-kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","-metrics-listen-address","0.0.0.0:8085","-health-listen-address","0.0.0.0:8086","-namespace","$(NAMESPACE)","-ca-cert","/etc/kubernetes/pki/ca/ca.crt","-cluster-url","","-openvpn-server-port","30003","-overwrite-registry","","-openshift=false","-openvpn-ca-cert-file=/etc/kubernetes/pki/openvpn/ca.crt","-openvpn-ca-key-file=/etc/kubernetes/pki/openvpn/ca.key","-logtostderr","-v","2","--ipam-controller-network","192.168.1.1/24,192.168.1.1,8.8.8.8"]}'
         command:
-        - /usr/local/bin/user-cluster-controller-manager
+        - /http-prober-bin/http-prober
         env:
         - name: NAMESPACE
           valueFrom:
@@ -89,27 +76,21 @@ spec:
         - mountPath: /etc/kubernetes/pki/openvpn
           name: openvpn-ca
           readOnly: true
+        - mountPath: /http-prober-bin
+          name: http-prober-bin
       imagePullSecrets:
       - name: dockercfg
       initContainers:
-      - args:
-        - -endpoint
-        - https://apiserver-external.cluster-de-test-01.svc.cluster.local.:30000/healthz
-        - -insecure
-        - -retries
-        - "100"
-        - -retry-wait
-        - "2"
-        - -timeout
-        - "1"
-        command:
+      - command:
+        - /bin/cp
         - /usr/local/bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.1
-        imagePullPolicy: IfNotPresent
-        name: apiserver-running
+        - /http-prober-bin/http-prober
+        image: quay.io/kubermatic/http-prober:v0.2-dev0
+        name: copy-http-prober
         resources: {}
-        terminationMessagePath: /dev/termination-log
-        terminationMessagePolicy: File
+        volumeMounts:
+        - mountPath: /http-prober-bin
+          name: http-prober-bin
       volumes:
       - name: internal-admin-kubeconfig
         secret:
@@ -126,4 +107,6 @@ spec:
         secret:
           defaultMode: 292
           secretName: openvpn-ca
+      - emptyDir: {}
+        name: http-prober-bin
 status: {}

--- a/api/pkg/resources/usercluster/deployment.go
+++ b/api/pkg/resources/usercluster/deployment.go
@@ -14,6 +14,7 @@ import (
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/intstr"
+	"k8s.io/apimachinery/pkg/util/sets"
 )
 
 var (
@@ -94,12 +95,6 @@ func DeploymentCreator(data userclusterControllerData, openshift bool) reconcili
 
 			dep.Spec.Template.Spec.Volumes = volumes
 
-			apiserverIsRunningContainer, err := apiserver.IsRunningInitContainer(data)
-			if err != nil {
-				return nil, err
-			}
-			dep.Spec.Template.Spec.InitContainers = []corev1.Container{*apiserverIsRunningContainer}
-
 			dep.Spec.Template.Spec.Containers = []corev1.Container{
 				{
 					Name:    name,
@@ -164,6 +159,12 @@ func DeploymentCreator(data userclusterControllerData, openshift bool) reconcili
 					},
 				},
 			}
+
+			wrappedPodSpec, err := apiserver.IsRunningWrapper(data, dep.Spec.Template.Spec, sets.NewString(name))
+			if err != nil {
+				return nil, fmt.Errorf("failed to add apiserver.IsRunningWrapper: %v", err)
+			}
+			dep.Spec.Template.Spec = *wrappedPodSpec
 
 			return dep, nil
 		}


### PR DESCRIPTION
**What this PR does / why we need it**:
This changes the http prober to act as wrapper instead of initContainer so pods that need to reach the apiserver don't go into crashloop backoff when the apiserver was initially reachable but goes offline after some time.

Cherrypicked from:
* #3857
* #3901

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Documentation**:
<!-- Add links to the related documentation changes related to this pull request. E.g. the link to the kubermatic/docs pullrequest. -->

**Does this PR introduce a user-facing change?**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If  no release note is required, just write "NONE".
-->
```release-note
none
```
