### PR TITLE
Add retry for docker pull command

### DIFF
--- a/api/hack/ci/ci-deploy-offline.sh
+++ b/api/hack/ci/ci-deploy-offline.sh
@@ -80,7 +80,7 @@ docker push 127.0.0.1:5000/kubernetes-helm/tiller:${HELM_VERSION}
 
 cd ../api
 KUBERMATICCOMMIT=${GIT_HEAD_HASH} GITTAG=${GIT_HEAD_HASH} make image-loader
-./_build/image-loader \
+retry 6 ./_build/image-loader \
   -versions ../config/kubermatic/static/master/versions.yaml \
   -addons-path ../addons \
   -registry 127.0.0.1:5000 \

--- a/api/pkg/docker/docker.go
+++ b/api/pkg/docker/docker.go
@@ -58,13 +58,12 @@ func DownloadImage(ctx context.Context, log *zap.Logger, dryRun bool, image stri
 	timeout := 15 * time.Minute
 	timer := time.NewTimer(timeout)
 	interval := time.Minute
-	var err error
 	for {
 		select {
 		case <-timer.C:
 			return fmt.Errorf("failed to pull image %s during %v", image, timeout)
 		default:
-			err = execCommand(log, dryRun, cmd)
+			err := execCommand(log, dryRun, cmd)
 			if err == nil {
 				return nil
 			}

--- a/api/pkg/docker/docker.go
+++ b/api/pkg/docker/docker.go
@@ -58,16 +58,18 @@ func DownloadImage(ctx context.Context, log *zap.Logger, dryRun bool, image stri
 	timeout := 15 * time.Minute
 	timer := time.NewTimer(timeout)
 	interval := time.Minute
+	var err error
 	for {
 		select {
 		case <-timer.C:
 			return fmt.Errorf("failed to pull image %s during %v", image, timeout)
 		default:
-			if err := execCommand(log, dryRun, cmd); err == nil {
+			err = execCommand(log, dryRun, cmd)
+			if err == nil {
 				return nil
-			} else {
-				log.Debug(fmt.Sprintf("%v", err))
 			}
+
+			log.Debug(fmt.Sprintf("%v", err))
 			time.Sleep(interval)
 		}
 	}

--- a/api/pkg/docker/docker.go
+++ b/api/pkg/docker/docker.go
@@ -63,12 +63,12 @@ func DownloadImage(ctx context.Context, log *zap.Logger, dryRun bool, image stri
 		case <-timer.C:
 			return fmt.Errorf("failed to pull image %s during %v", image, timeout)
 		default:
-			time.Sleep(interval)
 			if err := execCommand(log, dryRun, cmd); err == nil {
 				return nil
 			} else {
 				log.Debug(fmt.Sprintf("%v", err))
 			}
+			time.Sleep(interval)
 		}
 	}
 }

--- a/api/pkg/docker/docker.go
+++ b/api/pkg/docker/docker.go
@@ -57,12 +57,13 @@ func DownloadImage(ctx context.Context, log *zap.Logger, dryRun bool, image stri
 	cmd := exec.CommandContext(ctx, "docker", "pull", image)
 	timeout := 15 * time.Minute
 	timer := time.NewTimer(timeout)
+	interval := time.Minute
 	for {
 		select {
 		case <-timer.C:
 			return fmt.Errorf("failed to pull image %s during %v", image, timeout)
 		default:
-			time.Sleep(time.Minute)
+			time.Sleep(interval)
 			if err := execCommand(log, dryRun, cmd); err == nil {
 				return nil
 			} else {


### PR DESCRIPTION
**What this PR does / why we need it**: https://prow.loodse.com/view/gcs/prow-data/logs/post-kubermatic-deploy-offline/1155846609490153473 is one of the sample jobs that failed due to image not being uploaded to the registry. This adds the retry mechanism for `docker pull` so we can reduce the number of the failures for now. Later we should sync the job/create pipeline.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:

**Special notes for your reviewer**:

**Documentation**:
<!-- Add links to the related documentation changes related to this pull request. E.g. the link to the kubermatic/docs pullrequest. -->

**Does this PR introduce a user-facing change?**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If  no release note is required, just write "NONE".
-->
```release-note
NONE
```
