### PR TITLE
AWS handler: add missing decoding of the "Credential" header

### DIFF
--- a/api/pkg/handler/v1/provider/aws.go
+++ b/api/pkg/handler/v1/provider/aws.go
@@ -45,6 +45,7 @@ func DecodeAWSCommonReq(c context.Context, r *http.Request) (interface{}, error)
 
 	req.AccessKeyID = r.Header.Get("AccessKeyID")
 	req.SecretAccessKey = r.Header.Get("SecretAccessKey")
+	req.Credential = r.Header.Get("Credential")
 
 	return req, nil
 }


### PR DESCRIPTION
**What this PR does / why we need it**:
The creation of AWS clusters with credential presets is currently broken, because the `Credential` header is not being decoded when the list of availability zones is being fetched.

```release-note
NONE
```
