### PR TITLE
Split cluster deletion into multiple functions for readability

### DIFF
--- a/api/pkg/clusterdeletion/deletion.go
+++ b/api/pkg/clusterdeletion/deletion.go
@@ -3,30 +3,13 @@ package clusterdeletion
 import (
 	"context"
 	"fmt"
-	"strings"
-	"time"
 
 	kubermaticapiv1 "github.com/kubermatic/kubermatic/api/pkg/api/v1"
 	kubermaticv1 "github.com/kubermatic/kubermatic/api/pkg/crd/kubermatic/v1"
 	kuberneteshelper "github.com/kubermatic/kubermatic/api/pkg/kubernetes"
-	provider "github.com/kubermatic/kubermatic/api/pkg/provider/kubernetes"
-	"github.com/kubermatic/kubermatic/api/pkg/resources"
-	"github.com/kubermatic/machine-controller/pkg/node/eviction"
-
-	admissionregistrationv1beta1 "k8s.io/api/admissionregistration/v1beta1"
-	corev1 "k8s.io/api/core/v1"
-	policyv1beta1 "k8s.io/api/policy/v1beta1"
-	kerrors "k8s.io/apimachinery/pkg/api/errors"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/apimachinery/pkg/fields"
 	"k8s.io/apimachinery/pkg/types"
-	"k8s.io/apimachinery/pkg/util/sets"
-	"k8s.io/apimachinery/pkg/util/wait"
 	"k8s.io/client-go/util/retry"
-	utilpointer "k8s.io/utils/pointer"
-	clusterv1alpha1 "sigs.k8s.io/cluster-api/pkg/apis/cluster/v1alpha1"
 	controllerruntimeclient "sigs.k8s.io/controller-runtime/pkg/client"
-	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 )
 
 const (
@@ -45,23 +28,13 @@ type Deletion struct {
 	userClusterClient controllerruntimeclient.Client
 }
 
-// CleanupCluster is responsible for cleaning up a cluster
-func (d *Deletion) CleanupCluster(ctx context.Context, cluster *kubermaticv1.Cluster) (*reconcile.Result, error) {
-	err := d.cleanupCluster(ctx, cluster)
-	result := &reconcile.Result{}
-	if cluster != nil && len(cluster.Finalizers) > 0 {
-		result.RequeueAfter = 10 * time.Second
-	}
-
-	return result, err
-}
-
-func (d *Deletion) cleanupCluster(ctx context.Context, cluster *kubermaticv1.Cluster) error {
+// CleanupCluster is responsible for cleaning up a cluster.
+func (d *Deletion) CleanupCluster(ctx context.Context, cluster *kubermaticv1.Cluster) error {
 	// Delete Volumes and LB's inside the user cluster
 	if err := d.cleanupInClusterResources(ctx, cluster); err != nil {
 		return err
 	}
-	if err := d.deletingNodeCleanup(ctx, cluster); err != nil {
+	if err := d.cleanupNodes(ctx, cluster); err != nil {
 		return err
 	}
 
@@ -91,103 +64,19 @@ func (d *Deletion) cleanupInClusterResources(ctx context.Context, cluster *kuber
 	var deletedSomeResource bool
 
 	if shouldDeleteLBs {
-		serviceList := &corev1.ServiceList{}
-		if err := d.userClusterClient.List(ctx, &controllerruntimeclient.ListOptions{}, serviceList); err != nil {
-			return fmt.Errorf("failed to list Service's from user cluster: %v", err)
+		deletedSomeLBs, err := d.cleanupLBs(ctx, cluster)
+		if err != nil {
+			return fmt.Errorf("failed to cleanup LBs: %v", err)
 		}
-
-		for _, service := range serviceList.Items {
-			// Need to change the scope so the inline func in the updateCluster call always has the service from the current iteration
-			service := service
-			if service.Spec.Type == corev1.ServiceTypeLoadBalancer {
-				if err := d.userClusterClient.Delete(ctx, &service); err != nil {
-					return fmt.Errorf("failed to delete Service '%s/%s' from user cluster: %v", service.Namespace, service.Name, err)
-				}
-				deletedSomeResource = true
-				err := d.updateCluster(ctx, cluster, func(cluster *kubermaticv1.Cluster) {
-					if cluster.Annotations == nil {
-						cluster.Annotations = map[string]string{}
-					}
-					cluster.Annotations[deletedLBAnnotationName] = cluster.Annotations[deletedLBAnnotationName] + fmt.Sprintf(",%s", string(service.UID))
-				})
-				if err != nil {
-					return fmt.Errorf("failed to update cluster when trying to add UID of deleted LoadBalancer: %v", err)
-				}
-				// Wait for the update to appear in the lister as we use the data from the lister later on to verify if the LoadBalancers
-				// are gone
-				if err := wait.Poll(10*time.Millisecond, 5*time.Second, func() (bool, error) {
-					latestCluster := &kubermaticv1.Cluster{}
-					if err := d.seedClient.Get(ctx, types.NamespacedName{Name: cluster.Name}, latestCluster); err != nil {
-						return false, err
-					}
-					if strings.Contains(latestCluster.Annotations[deletedLBAnnotationName], string(service.UID)) {
-						return true, nil
-					}
-					return false, nil
-				}); err != nil {
-					return fmt.Errorf("failed to wait for deletedLBAnnotation to appear in the lister: %v", err)
-				}
-			}
-		}
+		deletedSomeResource = deletedSomeResource || deletedSomeLBs
 	}
 
 	if shouldDeletePVs {
-		// Prevent re-creation of PVs, PVCs and PDBs by using an intentionally defunct admissionWebhook
-		admissionWebhookName, admissionWebhook := terminatingAdmissionWebhook()
-		err := d.userClusterClient.Get(ctx, types.NamespacedName{Name: admissionWebhookName}, &admissionregistrationv1beta1.ValidatingWebhookConfiguration{})
-		if err != nil && !kerrors.IsNotFound(err) {
-			return fmt.Errorf("error checking if %q webhook configuration already exists: %v", admissionWebhookName, err)
+		deletedSomeVolumes, err := d.cleanupVolumes(ctx, cluster)
+		if err != nil {
+			return fmt.Errorf("failed to cleanup LBs: %v", err)
 		}
-		if kerrors.IsNotFound(err) {
-			if err := d.userClusterClient.Create(ctx, admissionWebhook); err != nil {
-				return fmt.Errorf("failed to create %q webhook configuration: %v", admissionWebhookName, err)
-			}
-		}
-
-		pdbs := &policyv1beta1.PodDisruptionBudgetList{}
-		if err := d.userClusterClient.List(ctx, &controllerruntimeclient.ListOptions{}, pdbs); err != nil {
-			return fmt.Errorf("failed to list pdbs: %v", err)
-		}
-		for _, pdb := range pdbs.Items {
-			if err := d.userClusterClient.Delete(ctx, &pdb); err != nil {
-				return fmt.Errorf("failed to delete pdb '%s/%s': %v", pdb.Namespace, pdb.Name, err)
-			}
-		}
-		// Make sure we don't continue until all PDBs are actually gone
-		if len(pdbs.Items) > 0 {
-			return nil
-		}
-		// Delete all Pods that use PVs. We must keep the remaining pods, otherwise
-		// we end up in a deadlock when CSI is used
-		if err := d.cleanupPVCUsingPods(ctx); err != nil {
-			return fmt.Errorf("failed to clean up PV using pod from user cluster: %v", err)
-		}
-
-		// Delete PVC's
-		pvcList := &corev1.PersistentVolumeClaimList{}
-		if err := d.userClusterClient.List(ctx, &controllerruntimeclient.ListOptions{}, pvcList); err != nil {
-			return fmt.Errorf("failed to list PVCs from user cluster: %v", err)
-		}
-
-		for _, pvc := range pvcList.Items {
-			if err := d.userClusterClient.Delete(ctx, &pvc); err != nil {
-				return fmt.Errorf("failed to delete PVC '%s/%s' from user cluster: %v", pvc.Namespace, pvc.Name, err)
-			}
-			deletedSomeResource = true
-		}
-
-		// Delete PV's
-		pvList := &corev1.PersistentVolumeList{}
-		if err := d.userClusterClient.List(ctx, &controllerruntimeclient.ListOptions{}, pvList); err != nil {
-			return fmt.Errorf("failed to list PVs from user cluster: %v", err)
-		}
-
-		for _, pv := range pvList.Items {
-			if err := d.userClusterClient.Delete(ctx, &pv); err != nil {
-				return fmt.Errorf("failed to delete PV '%s' from user cluster: %v", pv.Name, err)
-			}
-			deletedSomeResource = true
-		}
+		deletedSomeResource = deletedSomeResource || deletedSomeVolumes
 	}
 
 	// If we deleted something it is implied that there was still something left. Just return
@@ -215,186 +104,6 @@ func (d *Deletion) cleanupInClusterResources(ctx context.Context, cluster *kuber
 	})
 }
 
-func (d *Deletion) cleanUpCredentialsSecrets(ctx context.Context, cluster *kubermaticv1.Cluster) error {
-	// If no relevant finalizer exists, directly return
-	if !kuberneteshelper.HasFinalizer(cluster, kubermaticapiv1.CredentialsSecretsCleanupFinalizer) {
-		return nil
-	}
-
-	if err := d.deleteSecret(ctx, cluster); err != nil {
-		return err
-	}
-
-	return d.updateCluster(ctx, cluster, func(c *kubermaticv1.Cluster) {
-		kuberneteshelper.RemoveFinalizer(c, kubermaticapiv1.CredentialsSecretsCleanupFinalizer)
-	})
-}
-
-func (d *Deletion) deleteSecret(ctx context.Context, cluster *kubermaticv1.Cluster) error {
-	secretName := getSecretName(cluster)
-	if secretName == "" {
-		return nil
-	}
-
-	secret := &corev1.Secret{}
-	err := d.seedClient.Get(ctx, types.NamespacedName{Name: secretName, Namespace: resources.KubermaticNamespace}, secret)
-	if err != nil && !kerrors.IsNotFound(err) {
-		return fmt.Errorf("failed to get Secret %s/%s: %v", resources.KubermaticNamespace, secretName, err)
-	}
-
-	if err == nil {
-		if err := d.seedClient.Delete(ctx, secret); err != nil {
-			return fmt.Errorf("failed to delete Secret '%s/%s': %v", secret.Namespace, secret.Name, err)
-		}
-	}
-	return nil
-}
-
-func getSecretName(cluster *kubermaticv1.Cluster) string {
-	if cluster.Spec.Cloud.Packet != nil {
-		return fmt.Sprintf("%s-packet-%s", provider.CredentialPrefix, cluster.Name)
-	}
-	return ""
-}
-
-func (d *Deletion) deletingNodeCleanup(ctx context.Context, cluster *kubermaticv1.Cluster) error {
-	if !kuberneteshelper.HasFinalizer(cluster, kubermaticapiv1.NodeDeletionFinalizer) {
-		return nil
-	}
-
-	nodes := &corev1.NodeList{}
-	if err := d.userClusterClient.List(ctx, &controllerruntimeclient.ListOptions{}, nodes); err != nil {
-		return fmt.Errorf("failed to get user cluster nodes: %v", err)
-	}
-
-	// If we delete a cluster, we should disable the eviction on the nodes
-	for _, node := range nodes.Items {
-		if node.Annotations[eviction.SkipEvictionAnnotationKey] == "true" {
-			continue
-		}
-
-		err := retry.RetryOnConflict(retry.DefaultBackoff, func() error {
-			// Get latest version of the node to prevent conflict errors
-			currentNode := &corev1.Node{}
-			if err := d.userClusterClient.Get(ctx, types.NamespacedName{Name: node.Name}, currentNode); err != nil {
-				return err
-			}
-			if currentNode.Annotations == nil {
-				currentNode.Annotations = map[string]string{}
-			}
-			currentNode.Annotations[eviction.SkipEvictionAnnotationKey] = "true"
-
-			return d.userClusterClient.Update(ctx, currentNode)
-		})
-		if err != nil {
-			return fmt.Errorf("failed to add the annotation '%s=true' to node '%s': %v", eviction.SkipEvictionAnnotationKey, node.Name, err)
-		}
-	}
-
-	machineDeploymentList := &clusterv1alpha1.MachineDeploymentList{}
-	listOpts := &controllerruntimeclient.ListOptions{Namespace: metav1.NamespaceSystem}
-	if err := d.userClusterClient.List(ctx, listOpts, machineDeploymentList); err != nil {
-		return fmt.Errorf("failed to list MachineDeployments: %v", err)
-	}
-	if len(machineDeploymentList.Items) > 0 {
-		// TODO: Use DeleteCollection once https://github.com/kubernetes-sigs/controller-runtime/issues/344 is resolved
-		for _, machineDeployment := range machineDeploymentList.Items {
-			if err := d.userClusterClient.Delete(ctx, &machineDeployment); err != nil {
-				return fmt.Errorf("failed to delete MachineDeployment %q: %v", machineDeployment.Name, err)
-			}
-		}
-		// Return here to make sure we don't attempt to delete MachineSets until the MachineDeployment is actually gone
-		return nil
-	}
-
-	machineSetList := &clusterv1alpha1.MachineSetList{}
-	if err := d.userClusterClient.List(ctx, listOpts, machineSetList); err != nil {
-		return fmt.Errorf("failed to list MachineSets: %v", err)
-	}
-	if len(machineSetList.Items) > 0 {
-		// TODO: Use DeleteCollection once https://github.com/kubernetes-sigs/controller-runtime/issues/344 is resolved
-		for _, machineSet := range machineSetList.Items {
-			if err := d.userClusterClient.Delete(ctx, &machineSet); err != nil {
-				return fmt.Errorf("failed to delete MachineSet %q: %v", machineSet.Name, err)
-			}
-		}
-		// Return here to make sure we don't attempt to delete Machines until the MachineSet is actually gone
-		return nil
-	}
-
-	machineList := &clusterv1alpha1.MachineList{}
-	if err := d.userClusterClient.List(ctx, listOpts, machineList); err != nil {
-		return fmt.Errorf("failed to get Machines: %v", err)
-	}
-	if len(machineList.Items) > 0 {
-		// TODO: Use DeleteCollection once https://github.com/kubernetes-sigs/controller-runtime/issues/344 is resolved
-		for _, machine := range machineList.Items {
-			if err := d.userClusterClient.Delete(ctx, &machine); err != nil {
-				return fmt.Errorf("failed to delete Machine %q: %v", machine.Name, err)
-			}
-		}
-
-		return nil
-	}
-
-	return d.updateCluster(ctx, cluster, func(c *kubermaticv1.Cluster) {
-		kuberneteshelper.RemoveFinalizer(c, kubermaticapiv1.NodeDeletionFinalizer)
-	})
-}
-
-// checkIfAllLoadbalancersAreGone checks if all the services of type LoadBalancer were successfully
-// deleted. The in-tree cloud providers do this without a finalizer and only after the service
-// object is gone from the API, the only way to check is to wait for the relevant event
-func (d *Deletion) checkIfAllLoadbalancersAreGone(ctx context.Context, cluster *kubermaticv1.Cluster) (bool, error) {
-	// This check is only required for in-tree cloud provider that support LoadBalancers
-	// TODO once we start external cloud controllers for one of these three: Make this check
-	// a bit smarter, external cloud controllers will most likely not emit the event we wait for
-	if cluster.Spec.Cloud.AWS == nil && cluster.Spec.Cloud.Azure == nil && cluster.Spec.Cloud.Openstack == nil {
-		return true, nil
-	}
-
-	// We only need to wait for this if there were actually services of type Loadbalancer deleted
-	if cluster.Annotations[deletedLBAnnotationName] == "" {
-		return true, nil
-	}
-
-	deletedLoadBalancers := sets.NewString(strings.Split(strings.TrimPrefix(cluster.Annotations[deletedLBAnnotationName], ","), ",")...)
-
-	// Kubernetes gives no guarantees at all about events, it is possible we don't get the event
-	// so bail out after 2h
-	if cluster.DeletionTimestamp.UTC().Add(2 * time.Hour).Before(time.Now().UTC()) {
-		staleLBs.WithLabelValues(cluster.Name).Set(float64(deletedLoadBalancers.Len()))
-		return true, nil
-	}
-
-	for deletedLB := range deletedLoadBalancers {
-		selector := fields.OneTermEqualSelector("involvedObject.uid", deletedLB)
-		events := &corev1.EventList{}
-		if err := d.userClusterClient.List(context.Background(), &controllerruntimeclient.ListOptions{FieldSelector: selector}, events); err != nil {
-			return false, fmt.Errorf("failed to get service events: %v", err)
-		}
-		for _, event := range events.Items {
-			if event.Reason == "DeletedLoadBalancer" {
-				deletedLoadBalancers.Delete(deletedLB)
-			}
-		}
-
-	}
-	if err := d.updateCluster(ctx, cluster, func(cluster *kubermaticv1.Cluster) {
-		if deletedLoadBalancers.Len() > 0 {
-			cluster.Annotations[deletedLBAnnotationName] = strings.Join(deletedLoadBalancers.List(), ",")
-		} else {
-			delete(cluster.Annotations, deletedLBAnnotationName)
-		}
-	}); err != nil {
-		return false, fmt.Errorf("failed to update cluster: %v", err)
-	}
-	if deletedLoadBalancers.Len() > 0 {
-		return false, nil
-	}
-	return true, nil
-}
-
 func (d *Deletion) updateCluster(ctx context.Context, cluster *kubermaticv1.Cluster, modify func(*kubermaticv1.Cluster)) error {
 	// Store it here because it may be unset later on if an update request failed
 	name := cluster.Name
@@ -408,77 +117,4 @@ func (d *Deletion) updateCluster(ctx context.Context, cluster *kubermaticv1.Clus
 		// Update the cluster
 		return d.seedClient.Update(ctx, cluster)
 	})
-}
-
-func (d *Deletion) cleanupPVCUsingPods(ctx context.Context) error {
-	podList := &corev1.PodList{}
-	if err := d.userClusterClient.List(ctx, &controllerruntimeclient.ListOptions{}, podList); err != nil {
-		return fmt.Errorf("failed to list Pods from user cluster: %v", err)
-	}
-
-	pvUsingPods := []*corev1.Pod{}
-	for _, pod := range podList.Items {
-		if podUsesPV(&pod) {
-			pvUsingPods = append(pvUsingPods, &pod)
-		}
-	}
-
-	for _, pod := range pvUsingPods {
-		namespace, name := pod.Namespace, pod.Name
-		if err := d.userClusterClient.Delete(ctx, pod); err != nil {
-			return fmt.Errorf("failed to delete pod %s/%s: %v", namespace, name, err)
-		}
-	}
-
-	return nil
-}
-
-func podUsesPV(p *corev1.Pod) bool {
-	for _, volume := range p.Spec.Volumes {
-		if volume.VolumeSource.PersistentVolumeClaim != nil {
-			return true
-		}
-	}
-	return false
-}
-
-func terminatingAdmissionWebhook() (string, *admissionregistrationv1beta1.ValidatingWebhookConfiguration) {
-	name := "kubernetes-cluster-cleanup"
-	failurePolicy := admissionregistrationv1beta1.Fail
-	return name, &admissionregistrationv1beta1.ValidatingWebhookConfiguration{
-		ObjectMeta: metav1.ObjectMeta{
-			Name: name,
-			Annotations: map[string]string{
-				"description": "This webhok configuration exists to prevent creation of any new stateful resources in a cluster that is currently being terminated",
-			},
-		},
-		Webhooks: []admissionregistrationv1beta1.Webhook{
-			{
-				// Must be a domain with at least three segments separated by dots
-				Name: "kubernetes.cluster.cleanup",
-				ClientConfig: admissionregistrationv1beta1.WebhookClientConfig{
-					URL: utilpointer.StringPtr("https://127.0.0.1:1"),
-				},
-				Rules: []admissionregistrationv1beta1.RuleWithOperations{
-					{
-						Operations: []admissionregistrationv1beta1.OperationType{admissionregistrationv1beta1.Create},
-						Rule: admissionregistrationv1beta1.Rule{
-							APIGroups:   []string{""},
-							APIVersions: []string{"*"},
-							Resources:   []string{"persistentvolumes", "persistentvolumeclaims"},
-						},
-					},
-					{
-						Operations: []admissionregistrationv1beta1.OperationType{admissionregistrationv1beta1.Create},
-						Rule: admissionregistrationv1beta1.Rule{
-							APIGroups:   []string{"policy"},
-							APIVersions: []string{"*"},
-							Resources:   []string{"poddisruptionbudgets"},
-						},
-					},
-				},
-				FailurePolicy: &failurePolicy,
-			},
-		},
-	}
 }

--- a/api/pkg/clusterdeletion/lb.go
+++ b/api/pkg/clusterdeletion/lb.go
@@ -115,17 +115,10 @@ func (d *Deletion) checkIfAllLoadbalancersAreGone(ctx context.Context, cluster *
 	}
 
 	if err := d.updateCluster(ctx, cluster, func(cluster *kubermaticv1.Cluster) {
-		if deletedLoadBalancers.Len() > 0 {
-			cluster.Annotations[deletedLBAnnotationName] = strings.Join(deletedLoadBalancers.List(), ",")
-		} else {
-			delete(cluster.Annotations, deletedLBAnnotationName)
-		}
+		cluster.Annotations[deletedLBAnnotationName] = strings.Join(deletedLoadBalancers.List(), ",")
 	}); err != nil {
 		return false, fmt.Errorf("failed to update cluster: %v", err)
 	}
-	if deletedLoadBalancers.Len() > 0 {
-		return false, nil
-	}
 
-	return true, nil
+	return deletedLoadBalancers.Len() > 0, nil
 }

--- a/api/pkg/clusterdeletion/lb.go
+++ b/api/pkg/clusterdeletion/lb.go
@@ -16,6 +16,10 @@ import (
 	controllerruntimeclient "sigs.k8s.io/controller-runtime/pkg/client"
 )
 
+const (
+	eventReasonDeletedLoadBalancer = "DeletedLoadBalancer"
+)
+
 func (d *Deletion) cleanupLBs(ctx context.Context, cluster *kubermaticv1.Cluster) (deletedSomeLBs bool, err error) {
 	serviceList := &corev1.ServiceList{}
 	if err := d.userClusterClient.List(ctx, &controllerruntimeclient.ListOptions{}, serviceList); err != nil {
@@ -104,7 +108,7 @@ func (d *Deletion) checkIfAllLoadbalancersAreGone(ctx context.Context, cluster *
 			return false, fmt.Errorf("failed to get service events: %v", err)
 		}
 		for _, event := range events.Items {
-			if event.Reason == "DeletedLoadBalancer" {
+			if event.Reason == eventReasonDeletedLoadBalancer {
 				deletedLoadBalancers.Delete(deletedLB)
 			}
 		}

--- a/api/pkg/clusterdeletion/lb.go
+++ b/api/pkg/clusterdeletion/lb.go
@@ -1,0 +1,127 @@
+package clusterdeletion
+
+import (
+	"context"
+	"fmt"
+	"strings"
+	"time"
+
+	kubermaticv1 "github.com/kubermatic/kubermatic/api/pkg/crd/kubermatic/v1"
+
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/fields"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/apimachinery/pkg/util/sets"
+	"k8s.io/apimachinery/pkg/util/wait"
+	controllerruntimeclient "sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+func (d *Deletion) cleanupLBs(ctx context.Context, cluster *kubermaticv1.Cluster) (deletedSomeLBs bool, err error) {
+	serviceList := &corev1.ServiceList{}
+	if err := d.userClusterClient.List(ctx, &controllerruntimeclient.ListOptions{}, serviceList); err != nil {
+		return false, fmt.Errorf("failed to list Service's from user cluster: %v", err)
+	}
+
+	for _, service := range serviceList.Items {
+		// Only LoadBalancer services create cost on cloud providers
+		if service.Spec.Type != corev1.ServiceTypeLoadBalancer {
+			continue
+		}
+
+		serviceName := fmt.Sprintf("%s/%s", service.Namespace, service.Name)
+		if err := d.cleanupLB(ctx, &service, cluster); err != nil {
+			return deletedSomeLBs, fmt.Errorf("failed to delete service %q inside user cluster: %v", serviceName, err)
+		}
+		deletedSomeLBs = true
+	}
+
+	return deletedSomeLBs, nil
+}
+
+func (d *Deletion) cleanupLB(ctx context.Context, service *corev1.Service, cluster *kubermaticv1.Cluster) error {
+	if err := d.userClusterClient.Delete(ctx, service); err != nil {
+		return fmt.Errorf("failed to delete service: %v", err)
+	}
+
+	// We store the deleted service UID's on the cluster so we can check on the next iteration if they are really gone.
+	// We only really know if a LoadBalancer(The cloud provider LB) is gone, until there has been an event stating that.
+	// The event contains the UID of the corresponding, deleted, service.
+	// Upstream changed that recently to use a finalizer - As soon as we only support Kubernetes versions above that, we can remove this
+	err := d.updateCluster(ctx, cluster, func(cluster *kubermaticv1.Cluster) {
+		if cluster.Annotations == nil {
+			cluster.Annotations = map[string]string{}
+		}
+		cluster.Annotations[deletedLBAnnotationName] = cluster.Annotations[deletedLBAnnotationName] + fmt.Sprintf(",%s", string(service.UID))
+	})
+	if err != nil {
+		return fmt.Errorf("failed to update cluster when trying to add UID of deleted LoadBalancer: %v", err)
+	}
+
+	// Wait for the update to appear in the lister as we use the data from the lister later on to verify if the LoadBalancers
+	// are gone
+	if err := wait.Poll(10*time.Millisecond, 5*time.Second, func() (bool, error) {
+		latestCluster := &kubermaticv1.Cluster{}
+		if err := d.seedClient.Get(ctx, types.NamespacedName{Name: cluster.Name}, latestCluster); err != nil {
+			return false, err
+		}
+		return strings.Contains(latestCluster.Annotations[deletedLBAnnotationName], string(service.UID)), nil
+	}); err != nil {
+		return fmt.Errorf("failed to wait for deletedLBAnnotation to appear in the lister: %v", err)
+	}
+
+	return nil
+}
+
+// checkIfAllLoadbalancersAreGone checks if all the services of type LoadBalancer were successfully
+// deleted. The in-tree cloud providers do this without a finalizer and only after the service
+// object is gone from the API, the only way to check is to wait for the relevant event
+func (d *Deletion) checkIfAllLoadbalancersAreGone(ctx context.Context, cluster *kubermaticv1.Cluster) (bool, error) {
+	// This check is only required for in-tree cloud provider that support LoadBalancers
+	// TODO once we start external cloud controllers for one of these three: Make this check
+	// a bit smarter, external cloud controllers will most likely not emit the event we wait for
+	if cluster.Spec.Cloud.AWS == nil && cluster.Spec.Cloud.Azure == nil && cluster.Spec.Cloud.Openstack == nil {
+		return true, nil
+	}
+
+	// We only need to wait for this if there were actually services of type Loadbalancer deleted
+	if cluster.Annotations[deletedLBAnnotationName] == "" {
+		return true, nil
+	}
+
+	deletedLoadBalancers := sets.NewString(strings.Split(strings.TrimPrefix(cluster.Annotations[deletedLBAnnotationName], ","), ",")...)
+
+	// Kubernetes gives no guarantees at all about events, it is possible we don't get the event
+	// so bail out after 2h
+	if cluster.DeletionTimestamp.UTC().Add(2 * time.Hour).Before(time.Now().UTC()) {
+		staleLBs.WithLabelValues(cluster.Name).Set(float64(deletedLoadBalancers.Len()))
+		return true, nil
+	}
+
+	for deletedLB := range deletedLoadBalancers {
+		selector := fields.OneTermEqualSelector("involvedObject.uid", deletedLB)
+		events := &corev1.EventList{}
+		if err := d.userClusterClient.List(context.Background(), &controllerruntimeclient.ListOptions{FieldSelector: selector}, events); err != nil {
+			return false, fmt.Errorf("failed to get service events: %v", err)
+		}
+		for _, event := range events.Items {
+			if event.Reason == "DeletedLoadBalancer" {
+				deletedLoadBalancers.Delete(deletedLB)
+			}
+		}
+	}
+
+	if err := d.updateCluster(ctx, cluster, func(cluster *kubermaticv1.Cluster) {
+		if deletedLoadBalancers.Len() > 0 {
+			cluster.Annotations[deletedLBAnnotationName] = strings.Join(deletedLoadBalancers.List(), ",")
+		} else {
+			delete(cluster.Annotations, deletedLBAnnotationName)
+		}
+	}); err != nil {
+		return false, fmt.Errorf("failed to update cluster: %v", err)
+	}
+	if deletedLoadBalancers.Len() > 0 {
+		return false, nil
+	}
+
+	return true, nil
+}

--- a/api/pkg/clusterdeletion/node.go
+++ b/api/pkg/clusterdeletion/node.go
@@ -1,0 +1,102 @@
+package clusterdeletion
+
+import (
+	"context"
+	"fmt"
+
+	kubermaticapiv1 "github.com/kubermatic/kubermatic/api/pkg/api/v1"
+	kubermaticv1 "github.com/kubermatic/kubermatic/api/pkg/crd/kubermatic/v1"
+	kuberneteshelper "github.com/kubermatic/kubermatic/api/pkg/kubernetes"
+	"github.com/kubermatic/machine-controller/pkg/node/eviction"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/client-go/util/retry"
+	clusterv1alpha1 "sigs.k8s.io/cluster-api/pkg/apis/cluster/v1alpha1"
+	controllerruntimeclient "sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+func (d *Deletion) cleanupNodes(ctx context.Context, cluster *kubermaticv1.Cluster) error {
+	if !kuberneteshelper.HasFinalizer(cluster, kubermaticapiv1.NodeDeletionFinalizer) {
+		return nil
+	}
+
+	nodes := &corev1.NodeList{}
+	if err := d.userClusterClient.List(ctx, &controllerruntimeclient.ListOptions{}, nodes); err != nil {
+		return fmt.Errorf("failed to get user cluster nodes: %v", err)
+	}
+
+	// If we delete a cluster, we should disable the eviction on the nodes
+	for _, node := range nodes.Items {
+		if node.Annotations[eviction.SkipEvictionAnnotationKey] == "true" {
+			continue
+		}
+
+		err := retry.RetryOnConflict(retry.DefaultBackoff, func() error {
+			// Get latest version of the node to prevent conflict errors
+			currentNode := &corev1.Node{}
+			if err := d.userClusterClient.Get(ctx, types.NamespacedName{Name: node.Name}, currentNode); err != nil {
+				return err
+			}
+			if currentNode.Annotations == nil {
+				currentNode.Annotations = map[string]string{}
+			}
+			currentNode.Annotations[eviction.SkipEvictionAnnotationKey] = "true"
+
+			return d.userClusterClient.Update(ctx, currentNode)
+		})
+		if err != nil {
+			return fmt.Errorf("failed to add the annotation '%s=true' to node '%s': %v", eviction.SkipEvictionAnnotationKey, node.Name, err)
+		}
+	}
+
+	machineDeploymentList := &clusterv1alpha1.MachineDeploymentList{}
+	listOpts := &controllerruntimeclient.ListOptions{Namespace: metav1.NamespaceSystem}
+	if err := d.userClusterClient.List(ctx, listOpts, machineDeploymentList); err != nil {
+		return fmt.Errorf("failed to list MachineDeployments: %v", err)
+	}
+	if len(machineDeploymentList.Items) > 0 {
+		// TODO: Use DeleteCollection once https://github.com/kubernetes-sigs/controller-runtime/issues/344 is resolved
+		for _, machineDeployment := range machineDeploymentList.Items {
+			if err := d.userClusterClient.Delete(ctx, &machineDeployment); err != nil {
+				return fmt.Errorf("failed to delete MachineDeployment %q: %v", machineDeployment.Name, err)
+			}
+		}
+		// Return here to make sure we don't attempt to delete MachineSets until the MachineDeployment is actually gone
+		return nil
+	}
+
+	machineSetList := &clusterv1alpha1.MachineSetList{}
+	if err := d.userClusterClient.List(ctx, listOpts, machineSetList); err != nil {
+		return fmt.Errorf("failed to list MachineSets: %v", err)
+	}
+	if len(machineSetList.Items) > 0 {
+		// TODO: Use DeleteCollection once https://github.com/kubernetes-sigs/controller-runtime/issues/344 is resolved
+		for _, machineSet := range machineSetList.Items {
+			if err := d.userClusterClient.Delete(ctx, &machineSet); err != nil {
+				return fmt.Errorf("failed to delete MachineSet %q: %v", machineSet.Name, err)
+			}
+		}
+		// Return here to make sure we don't attempt to delete Machines until the MachineSet is actually gone
+		return nil
+	}
+
+	machineList := &clusterv1alpha1.MachineList{}
+	if err := d.userClusterClient.List(ctx, listOpts, machineList); err != nil {
+		return fmt.Errorf("failed to get Machines: %v", err)
+	}
+	if len(machineList.Items) > 0 {
+		// TODO: Use DeleteCollection once https://github.com/kubernetes-sigs/controller-runtime/issues/344 is resolved
+		for _, machine := range machineList.Items {
+			if err := d.userClusterClient.Delete(ctx, &machine); err != nil {
+				return fmt.Errorf("failed to delete Machine %q: %v", machine.Name, err)
+			}
+		}
+
+		return nil
+	}
+
+	return d.updateCluster(ctx, cluster, func(c *kubermaticv1.Cluster) {
+		kuberneteshelper.RemoveFinalizer(c, kubermaticapiv1.NodeDeletionFinalizer)
+	})
+}

--- a/api/pkg/clusterdeletion/secret.go
+++ b/api/pkg/clusterdeletion/secret.go
@@ -1,0 +1,57 @@
+package clusterdeletion
+
+import (
+	"context"
+	"fmt"
+
+	kubermaticapiv1 "github.com/kubermatic/kubermatic/api/pkg/api/v1"
+	kubermaticv1 "github.com/kubermatic/kubermatic/api/pkg/crd/kubermatic/v1"
+	kuberneteshelper "github.com/kubermatic/kubermatic/api/pkg/kubernetes"
+	provider "github.com/kubermatic/kubermatic/api/pkg/provider/kubernetes"
+	"github.com/kubermatic/kubermatic/api/pkg/resources"
+	corev1 "k8s.io/api/core/v1"
+	kerrors "k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/types"
+)
+
+func (d *Deletion) cleanUpCredentialsSecrets(ctx context.Context, cluster *kubermaticv1.Cluster) error {
+	// If no relevant finalizer exists, directly return
+	if !kuberneteshelper.HasFinalizer(cluster, kubermaticapiv1.CredentialsSecretsCleanupFinalizer) {
+		return nil
+	}
+
+	if err := d.deleteSecret(ctx, cluster); err != nil {
+		return err
+	}
+
+	return d.updateCluster(ctx, cluster, func(c *kubermaticv1.Cluster) {
+		kuberneteshelper.RemoveFinalizer(c, kubermaticapiv1.CredentialsSecretsCleanupFinalizer)
+	})
+}
+
+func (d *Deletion) deleteSecret(ctx context.Context, cluster *kubermaticv1.Cluster) error {
+	secretName := getSecretName(cluster)
+	if secretName == "" {
+		return nil
+	}
+
+	secret := &corev1.Secret{}
+	err := d.seedClient.Get(ctx, types.NamespacedName{Name: secretName, Namespace: resources.KubermaticNamespace}, secret)
+	if err != nil && !kerrors.IsNotFound(err) {
+		return fmt.Errorf("failed to get Secret %s/%s: %v", resources.KubermaticNamespace, secretName, err)
+	}
+
+	if err == nil {
+		if err := d.seedClient.Delete(ctx, secret); err != nil {
+			return fmt.Errorf("failed to delete Secret '%s/%s': %v", secret.Namespace, secret.Name, err)
+		}
+	}
+	return nil
+}
+
+func getSecretName(cluster *kubermaticv1.Cluster) string {
+	if cluster.Spec.Cloud.Packet != nil {
+		return fmt.Sprintf("%s-packet-%s", provider.CredentialPrefix, cluster.Name)
+	}
+	return ""
+}

--- a/api/pkg/clusterdeletion/volumes.go
+++ b/api/pkg/clusterdeletion/volumes.go
@@ -26,6 +26,8 @@ func (d *Deletion) cleanupVolumes(ctx context.Context, cluster *kubermaticv1.Clu
 		return false, fmt.Errorf("failed to disable future PV & PVC creation: %v", err)
 	}
 
+	// TODO: Figure out why we delete PDBs at all.
+	// Henrik thinks this it not required as PDBs only block evictions & we don't trigger an eviction.
 	deletedSomePDBs, err := d.cleanupPDBs(ctx, cluster)
 	if err != nil {
 		return false, fmt.Errorf("failed to cleanup PodDisruptionBudgets: %v", err)

--- a/api/pkg/clusterdeletion/volumes.go
+++ b/api/pkg/clusterdeletion/volumes.go
@@ -158,9 +158,8 @@ func (d *Deletion) cleanupPVCUsingPods(ctx context.Context) error {
 	}
 
 	for _, pod := range pvUsingPods {
-		namespace, name := pod.Namespace, pod.Name
 		if err := d.userClusterClient.Delete(ctx, pod); err != nil {
-			return fmt.Errorf("failed to delete pod %s/%s: %v", namespace, name, err)
+			return fmt.Errorf("failed to delete pod %s/%s: %v", pod.Namespace, pod.Name, err)
 		}
 	}
 

--- a/api/pkg/clusterdeletion/volumes.go
+++ b/api/pkg/clusterdeletion/volumes.go
@@ -16,6 +16,10 @@ import (
 	controllerruntimeclient "sigs.k8s.io/controller-runtime/pkg/client"
 )
 
+const (
+	annotationKeyDescription = "description"
+)
+
 func (d *Deletion) cleanupVolumes(ctx context.Context, cluster *kubermaticv1.Cluster) (deletedSomeResource bool, err error) {
 	// We disable the PV & PVC creation so nothing creates new PV's while we delete them
 	if err := d.disablePVCreation(ctx, cluster); err != nil {
@@ -74,7 +78,7 @@ func terminatingAdmissionWebhook() (string, *admissionregistrationv1beta1.Valida
 		ObjectMeta: metav1.ObjectMeta{
 			Name: name,
 			Annotations: map[string]string{
-				"description": "This webhok configuration exists to prevent creation of any new stateful resources in a cluster that is currently being terminated",
+				annotationKeyDescription: "This webhook configuration exists to prevent creation of any new stateful resources in a cluster that is currently being terminated",
 			},
 		},
 		Webhooks: []admissionregistrationv1beta1.Webhook{

--- a/api/pkg/clusterdeletion/volumes.go
+++ b/api/pkg/clusterdeletion/volumes.go
@@ -1,0 +1,171 @@
+package clusterdeletion
+
+import (
+	"context"
+	"fmt"
+
+	kubermaticv1 "github.com/kubermatic/kubermatic/api/pkg/crd/kubermatic/v1"
+
+	admissionregistrationv1beta1 "k8s.io/api/admissionregistration/v1beta1"
+	corev1 "k8s.io/api/core/v1"
+	policyv1beta1 "k8s.io/api/policy/v1beta1"
+	kerrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+	utilpointer "k8s.io/utils/pointer"
+	controllerruntimeclient "sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+func (d *Deletion) cleanupVolumes(ctx context.Context, cluster *kubermaticv1.Cluster) (deletedSomeResource bool, err error) {
+	// We disable the PV & PVC creation so nothing creates new PV's while we delete them
+	if err := d.disablePVCreation(ctx, cluster); err != nil {
+		return false, fmt.Errorf("failed to disable future PV & PVC creation: %v", err)
+	}
+
+	deletedSomePDBs, err := d.cleanupPDBs(ctx, cluster)
+	if err != nil {
+		return false, fmt.Errorf("failed to cleanup PodDisruptionBudgets: %v", err)
+	}
+	// Make sure we don't continue until all PDBs are actually gone.
+	// TODO: Why?
+	if deletedSomePDBs {
+		return true, nil
+	}
+
+	// Delete all Pods that use PVs. We must keep the remaining pods, otherwise
+	// we end up in a deadlock when CSI is used
+	if err := d.cleanupPVCUsingPods(ctx); err != nil {
+		return false, fmt.Errorf("failed to clean up PV using pod from user cluster: %v", err)
+	}
+
+	// Delete PVC's
+	pvcList := &corev1.PersistentVolumeClaimList{}
+	if err := d.userClusterClient.List(ctx, &controllerruntimeclient.ListOptions{}, pvcList); err != nil {
+		return false, fmt.Errorf("failed to list PVCs from user cluster: %v", err)
+	}
+
+	for _, pvc := range pvcList.Items {
+		if err := d.userClusterClient.Delete(ctx, &pvc); err != nil {
+			return deletedSomeResource, fmt.Errorf("failed to delete PVC '%s/%s' from user cluster: %v", pvc.Namespace, pvc.Name, err)
+		}
+		deletedSomeResource = true
+	}
+
+	// Delete PV's
+	pvList := &corev1.PersistentVolumeList{}
+	if err := d.userClusterClient.List(ctx, &controllerruntimeclient.ListOptions{}, pvList); err != nil {
+		return deletedSomeResource, fmt.Errorf("failed to list PVs from user cluster: %v", err)
+	}
+
+	for _, pv := range pvList.Items {
+		if err := d.userClusterClient.Delete(ctx, &pv); err != nil {
+			return deletedSomeResource, fmt.Errorf("failed to delete PV '%s' from user cluster: %v", pv.Name, err)
+		}
+		deletedSomeResource = true
+	}
+
+	return deletedSomeResource, nil
+}
+
+func terminatingAdmissionWebhook() (string, *admissionregistrationv1beta1.ValidatingWebhookConfiguration) {
+	name := "kubernetes-cluster-cleanup"
+	failurePolicy := admissionregistrationv1beta1.Fail
+	return name, &admissionregistrationv1beta1.ValidatingWebhookConfiguration{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: name,
+			Annotations: map[string]string{
+				"description": "This webhok configuration exists to prevent creation of any new stateful resources in a cluster that is currently being terminated",
+			},
+		},
+		Webhooks: []admissionregistrationv1beta1.Webhook{
+			{
+				// Must be a domain with at least three segments separated by dots
+				Name: "kubernetes.cluster.cleanup",
+				ClientConfig: admissionregistrationv1beta1.WebhookClientConfig{
+					URL: utilpointer.StringPtr("https://127.0.0.1:1"),
+				},
+				Rules: []admissionregistrationv1beta1.RuleWithOperations{
+					{
+						Operations: []admissionregistrationv1beta1.OperationType{admissionregistrationv1beta1.Create},
+						Rule: admissionregistrationv1beta1.Rule{
+							APIGroups:   []string{""},
+							APIVersions: []string{"*"},
+							Resources:   []string{"persistentvolumes", "persistentvolumeclaims"},
+						},
+					},
+					{
+						Operations: []admissionregistrationv1beta1.OperationType{admissionregistrationv1beta1.Create},
+						Rule: admissionregistrationv1beta1.Rule{
+							APIGroups:   []string{"policy"},
+							APIVersions: []string{"*"},
+							Resources:   []string{"poddisruptionbudgets"},
+						},
+					},
+				},
+				FailurePolicy: &failurePolicy,
+			},
+		},
+	}
+}
+
+func (d *Deletion) disablePVCreation(ctx context.Context, cluster *kubermaticv1.Cluster) error {
+	// Prevent re-creation of PVs, PVCs and PDBs by using an intentionally defunct admissionWebhook
+	admissionWebhookName, admissionWebhook := terminatingAdmissionWebhook()
+	err := d.userClusterClient.Get(ctx, types.NamespacedName{Name: admissionWebhookName}, &admissionregistrationv1beta1.ValidatingWebhookConfiguration{})
+	if err != nil && !kerrors.IsNotFound(err) {
+		return fmt.Errorf("error checking if %q webhook configuration already exists: %v", admissionWebhookName, err)
+	}
+	if kerrors.IsNotFound(err) {
+		if err := d.userClusterClient.Create(ctx, admissionWebhook); err != nil {
+			return fmt.Errorf("failed to create %q webhook configuration: %v", admissionWebhookName, err)
+		}
+	}
+
+	return nil
+}
+
+func (d *Deletion) cleanupPDBs(ctx context.Context, cluster *kubermaticv1.Cluster) (deletedPDBs bool, err error) {
+	pdbs := &policyv1beta1.PodDisruptionBudgetList{}
+	if err := d.userClusterClient.List(ctx, &controllerruntimeclient.ListOptions{}, pdbs); err != nil {
+		return false, fmt.Errorf("failed to list pdbs: %v", err)
+	}
+	for _, pdb := range pdbs.Items {
+		if err := d.userClusterClient.Delete(ctx, &pdb); err != nil {
+			return false, fmt.Errorf("failed to delete pdb '%s/%s': %v", pdb.Namespace, pdb.Name, err)
+		}
+		deletedPDBs = true
+	}
+	return deletedPDBs, nil
+}
+
+func (d *Deletion) cleanupPVCUsingPods(ctx context.Context) error {
+	podList := &corev1.PodList{}
+	if err := d.userClusterClient.List(ctx, &controllerruntimeclient.ListOptions{}, podList); err != nil {
+		return fmt.Errorf("failed to list Pods from user cluster: %v", err)
+	}
+
+	pvUsingPods := []*corev1.Pod{}
+	for _, pod := range podList.Items {
+		if podUsesPV(&pod) {
+			pvUsingPods = append(pvUsingPods, &pod)
+		}
+	}
+
+	for _, pod := range pvUsingPods {
+		namespace, name := pod.Namespace, pod.Name
+		if err := d.userClusterClient.Delete(ctx, pod); err != nil {
+			return fmt.Errorf("failed to delete pod %s/%s: %v", namespace, name, err)
+		}
+	}
+
+	return nil
+}
+
+func podUsesPV(p *corev1.Pod) bool {
+	for _, volume := range p.Spec.Volumes {
+		if volume.VolumeSource.PersistentVolumeClaim != nil {
+			return true
+		}
+	}
+	return false
+}

--- a/api/pkg/controller/cluster/cluster_controller.go
+++ b/api/pkg/controller/cluster/cluster_controller.go
@@ -3,6 +3,7 @@ package cluster
 import (
 	"context"
 	"fmt"
+	"time"
 
 	"github.com/golang/glog"
 
@@ -212,7 +213,8 @@ func (r *Reconciler) reconcile(ctx context.Context, cluster *kubermaticv1.Cluste
 		if err != nil {
 			return nil, fmt.Errorf("failed to get user cluster client: %v", err)
 		}
-		return clusterdeletion.New(r.Client, userClusterClient).CleanupCluster(ctx, cluster)
+		// Always requeue a cluster after we executed the cleanup.
+		return &reconcile.Result{RequeueAfter: 10 * time.Second}, clusterdeletion.New(r.Client, userClusterClient).CleanupCluster(ctx, cluster)
 	}
 
 	res, err := r.reconcileCluster(ctx, cluster)

--- a/api/pkg/controller/openshift/openshift_controller.go
+++ b/api/pkg/controller/openshift/openshift_controller.go
@@ -188,7 +188,8 @@ func (r *Reconciler) reconcile(ctx context.Context, cluster *kubermaticv1.Cluste
 		if err != nil {
 			return nil, fmt.Errorf("failed to get user cluster client: %v", err)
 		}
-		return clusterdeletion.New(r.Client, userClusterClient).CleanupCluster(ctx, cluster)
+		// Always requeue a cluster after we executed the cleanup.
+		return &reconcile.Result{RequeueAfter: 10 * time.Second}, clusterdeletion.New(r.Client, userClusterClient).CleanupCluster(ctx, cluster)
 	}
 
 	// Ensure Namespace


### PR DESCRIPTION
**What this PR does / why we need it**:

Initially i just wanted to introduce structured logging here...
But adding the logging code made this code way more difficult to read than it already was.
Thus i decided to split the individual deletion logics into dedicated funcs to improve readability.
Also it adds some comments trying to explain some non-obvious behaviour.

The code does not change the behaviour of the deletion.

**Does this PR introduce a user-facing change?**:
```release-note
NONE
```

/assign @moadqassem 