### PR TITLE
Make worker-count of controller-manager and master-controller configurable

### DIFF
--- a/config/kubermatic/templates/kubermatic-controller-manager-dep.yaml
+++ b/config/kubermatic/templates/kubermatic-controller-manager-dep.yaml
@@ -93,6 +93,7 @@ spec:
         {{- if .Values.kubermatic.monitoringScrapeAnnotationPrefix }}
         - -monitoring-scrape-annotation-prefix={{ .Values.kubermatic.monitoringScrapeAnnotationPrefix }}
         {{- end }}
+        - -worker-count={{ .Values.kubermatic.controller.workerCount }}
         {{- if .Values.kubermatic.worker_name }}
         - -worker-name={{ .Values.kubermatic.worker_name }}
         {{- end }}

--- a/config/kubermatic/templates/master-controller-manager-dep.yaml
+++ b/config/kubermatic/templates/master-controller-manager-dep.yaml
@@ -50,6 +50,7 @@ spec:
         - -logtostderr
         - -kubeconfig=/opt/.kube/kubeconfig
         - -datacenters=/opt/datacenter/datacenters.yaml
+        - -worker-count={{ .Values.kubermatic.masterController.workerCount }}
         {{- if .Values.kubermatic.worker_name }}
         - -worker-name={{ .Values.kubermatic.worker_name }}
         {{- end }}

--- a/config/kubermatic/values.yaml
+++ b/config/kubermatic/values.yaml
@@ -107,6 +107,7 @@ kubermatic:
       limits:
         cpu: 500m
         memory: 1Gi
+    workerCount: 4
     affinity:
       nodeAffinity:
         preferredDuringSchedulingIgnoredDuringExecution:
@@ -232,6 +233,7 @@ kubermatic:
       limits:
         cpu: 100m
         memory: 256Mi
+    workerCount: 20
     affinity: {}
     nodeSelector: {}
     tolerations: []


### PR DESCRIPTION
**What this PR does / why we need it**:
Make worker-count of controller-manager and master-controller configurable in helm chart

A higher worker count can speed up the controllers, especially the rbac controller significantly in larger installations

**Does this PR introduce a user-facing change?**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If  no release note is required, just write "NONE".
-->
```release-note
The worker-count of controller-manager and master-controller are now configurable
```
