### PR TITLE
Add presets to local api start script

### DIFF
--- a/api/hack/run-api.sh
+++ b/api/hack/run-api.sh
@@ -18,6 +18,7 @@ cd $(go env GOPATH)/src/github.com/kubermatic/kubermatic/api
 ./_build/kubermatic-api \
   -kubeconfig=../../secrets/seed-clusters/dev.kubermatic.io/kubeconfig \
   -datacenters=../../secrets/seed-clusters/dev.kubermatic.io/datacenters.yaml \
+  -presets=../../secrets/seed-clusters/dev.kubermatic.io/presets.yaml \
   -versions=../config/kubermatic/static/master/versions.yaml \
   -updates=../config/kubermatic/static/master/updates.yaml \
   -master-resources=../config/kubermatic/static/master \


### PR DESCRIPTION
**What this PR does / why we need it**:
~~That was the fastest way I could think of to fix concurrent access to this method.~~ As a bonus I have added `-presets` flag to our `run-api.sh` as it is also in our vault and is useful for local development.

**Does this PR introduce a user-facing change?**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If  no release note is required, just write "NONE".
-->
```release-note
NONE
```
