### PR TITLE
Prometheus metrics and alerts for addons

### DIFF
--- a/api/cmd/kubermatic-controller-manager/main.go
+++ b/api/cmd/kubermatic-controller-manager/main.go
@@ -137,6 +137,9 @@ Please install the VerticalPodAutoscaler according to the documentation: https:/
 	log.Debug("Starting clusters collector")
 	collectors.MustRegisterClusterCollector(prometheus.DefaultRegisterer, ctrlCtx.mgr.GetClient())
 
+	log.Debug("Starting addons collector")
+	collectors.MustRegisterAddonCollector(prometheus.DefaultRegisterer, ctrlCtx.mgr.GetClient())
+
 	var g run.Group
 	// This group is forever waiting in a goroutine for signals to stop
 	{

--- a/api/pkg/collectors/addon.go
+++ b/api/pkg/collectors/addon.go
@@ -1,0 +1,93 @@
+package collectors
+
+import (
+	"context"
+	"fmt"
+
+	kubermaticv1 "github.com/kubermatic/kubermatic/api/pkg/crd/kubermatic/v1"
+	"github.com/prometheus/client_golang/prometheus"
+	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
+	ctrlruntimeclient "sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+const (
+	addonPrefix = "kubermatic_addon_"
+)
+
+// AddonCollector exports metrics for addon resources
+type AddonCollector struct {
+	client ctrlruntimeclient.Client
+
+	addonCreated *prometheus.Desc
+	addonDeleted *prometheus.Desc
+}
+
+// MustRegisterAddonCollector registers the addon collector at the given prometheus registry
+func MustRegisterAddonCollector(registry prometheus.Registerer, client ctrlruntimeclient.Client) {
+	cc := &AddonCollector{
+		client: client,
+		addonCreated: prometheus.NewDesc(
+			addonPrefix+"created",
+			"Unix creation timestamp",
+			[]string{"cluster", "addon"},
+			nil,
+		),
+		addonDeleted: prometheus.NewDesc(
+			addonPrefix+"deleted",
+			"Unix deletion timestamp",
+			[]string{"cluster", "addon"},
+			nil,
+		),
+	}
+
+	registry.MustRegister(cc)
+}
+
+// Describe returns the metrics descriptors
+func (cc AddonCollector) Describe(ch chan<- *prometheus.Desc) {
+	ch <- cc.addonCreated
+	ch <- cc.addonDeleted
+}
+
+// Collect gets called by prometheus to collect the metrics
+func (cc AddonCollector) Collect(ch chan<- prometheus.Metric) {
+	clusters := &kubermaticv1.ClusterList{}
+	if err := cc.client.List(context.Background(), &ctrlruntimeclient.ListOptions{}, clusters); err != nil {
+		utilruntime.HandleError(fmt.Errorf("failed to list clusters from clusterLister in AddonCollector: %v", err))
+		return
+	}
+
+	for _, cluster := range clusters.Items {
+		addons := &kubermaticv1.AddonList{}
+		// todo filter by cluster namespace
+		if err := cc.client.List(context.Background(), &ctrlruntimeclient.ListOptions{
+			Namespace: fmt.Sprintf("cluster-%s", cluster.Name),
+		}, addons); err != nil {
+			utilruntime.HandleError(fmt.Errorf("failed to list addons for cluster %s from addonLister in AddonCollector: %v", cluster.Name, err))
+			return
+		}
+		for _, addon := range addons.Items {
+			cc.collectAddon(ch, &cluster, &addon)
+		}
+	}
+}
+
+func (cc *AddonCollector) collectAddon(ch chan<- prometheus.Metric, c *kubermaticv1.Cluster, addon *kubermaticv1.Addon) {
+	ch <- prometheus.MustNewConstMetric(
+		cc.addonCreated,
+		prometheus.GaugeValue,
+		float64(c.CreationTimestamp.Unix()),
+		c.Name,
+		addon.Name,
+	)
+
+	if addon.DeletionTimestamp != nil {
+		ch <- prometheus.MustNewConstMetric(
+			cc.addonDeleted,
+			prometheus.GaugeValue,
+			float64(c.DeletionTimestamp.Unix()),
+			c.Name,
+			addon.Name,
+		)
+	}
+}

--- a/api/pkg/collectors/addon.go
+++ b/api/pkg/collectors/addon.go
@@ -76,7 +76,7 @@ func (cc *AddonCollector) collectAddon(ch chan<- prometheus.Metric, c *kubermati
 	ch <- prometheus.MustNewConstMetric(
 		cc.addonCreated,
 		prometheus.GaugeValue,
-		float64(c.CreationTimestamp.Unix()),
+		float64(addon.CreationTimestamp.Unix()),
 		c.Name,
 		addon.Name,
 	)
@@ -85,7 +85,7 @@ func (cc *AddonCollector) collectAddon(ch chan<- prometheus.Metric, c *kubermati
 		ch <- prometheus.MustNewConstMetric(
 			cc.addonDeleted,
 			prometheus.GaugeValue,
-			float64(c.DeletionTimestamp.Unix()),
+			float64(addon.DeletionTimestamp.Unix()),
 			c.Name,
 			addon.Name,
 		)

--- a/config/monitoring/prometheus/rules/kubermatic-seed-kubermatic.yaml
+++ b/config/monitoring/prometheus/rules/kubermatic-seed-kubermatic.yaml
@@ -19,6 +19,14 @@ groups:
     for: 0m
     labels:
       severity: warning
+  - alert: KubermaticAddonDeletionTakesTooLong
+    annotations:
+      message: Addon {{ $labels.addon }} in cluster {{ $labels.cluster }} is stuck in deletion for more than 30min.
+      runbook_url: https://docs.kubermatic.io/monitoring/runbook/#alert-kubermaticaddondeletiontakestoolong
+    expr: (time() - max by (cluster,addon) (kubermatic_addon_deleted)) > 30*60
+    for: 0m
+    labels:
+      severity: warning
   - alert: KubermaticControllerManagerDown
     annotations:
       message: KubermaticControllerManager has disappeared from Prometheus target

--- a/config/monitoring/prometheus/rules/src/kubermatic-seed/kubermatic.yaml
+++ b/config/monitoring/prometheus/rules/src/kubermatic-seed/kubermatic.yaml
@@ -29,6 +29,20 @@ groups:
       - If all resources have been cleaned up, remove the blocking finalizer (e.g. `kubermatic.io/delete-nodes`) from the cluster resource.
       - If nothing else helps, manually delete the cluster namespace as a last resort.
 
+  - alert: KubermaticAddonDeletionTakesTooLong
+    annotations:
+      message: Addon {{ $labels.addon }} in cluster {{ $labels.cluster }} is stuck in deletion for more than 30min.
+      runbook_url: https://docs.kubermatic.io/monitoring/runbook/#alert-kubermaticaddondeletiontakestoolong
+    expr: (time() - max by (cluster,addon) (kubermatic_addon_deleted)) > 30*60
+    for: 0m
+    labels:
+      severity: warning
+    runbook:
+      steps:
+        - Check the kubermatic controller-manager's logs via `kubectl -n kubermatic logs -l 'role=controller-manager'` for errors related to deletion of the addon.
+          Manually deleted resources inside of the user cluster is a common reason for failing deletions.
+        - If all resources of the addon inside the user cluster have been cleaned up, remove the blocking finalizer (e.g. `cleanup-manifests`) from the addon resource.
+
   - alert: KubermaticControllerManagerDown
     annotations:
       message: KubermaticControllerManager has disappeared from Prometheus target discovery.


### PR DESCRIPTION
**What this PR does / why we need it**:
Adds a Prometheus metrics collector for addons with the new metrics:
* kubermatic_addon_created
* kubermatic_addon_deleted

Adds an alert KubermaticAddonDeletionTakesTooLong which fires if an addon is stuck in deletion for more than 30 minutes.

The helps identifying problems when an addon fails to be deleted because of an error in the controller manager when cleaning up the addons manifests.

**Does this PR introduce a user-facing change?**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If  no release note is required, just write "NONE".
-->
```release-note
New Prometheus metrics kubermatic_addon_created and kubermatic_addon_deleted
New alert KubermaticAddonDeletionTakesTooLong
```
