### PR TITLE
improve error handling and logging in s3-storeuploader

### DIFF
--- a/api/cmd/s3-storeuploader/main.go
+++ b/api/cmd/s3-storeuploader/main.go
@@ -76,7 +76,7 @@ func main() {
 	logFormatFlag := cli.GenericFlag{
 		Name:  "log-format",
 		Value: &defaultLogFormat,
-		Usage: fmt.Sprintf("Use either %s or %s to change the log output", log.FormatConsole, log.FormatJSON),
+		Usage: fmt.Sprintf("Use one of [%v] to change the log output", log.AvailableFormats),
 	}
 
 	app.Flags = []cli.Flag{

--- a/api/cmd/s3-storeuploader/main.go
+++ b/api/cmd/s3-storeuploader/main.go
@@ -150,7 +150,7 @@ func main() {
 	// we know it's been a CLI parsing failure and the cli package
 	// has already output the error and printed the usage hints.
 	if err != nil && logger != nil {
-		logger.Fatalw("Failed to run command", "err", err)
+		logger.Fatal("Failed to run command", zap.Error(err))
 	}
 }
 

--- a/api/cmd/s3-storeuploader/main.go
+++ b/api/cmd/s3-storeuploader/main.go
@@ -4,12 +4,10 @@ import (
 	"fmt"
 	"os"
 
-	"github.com/go-logr/zapr"
 	"github.com/kubermatic/kubermatic/api/pkg/log"
 	"github.com/kubermatic/kubermatic/api/pkg/storeuploader"
 	"github.com/urfave/cli"
 	"go.uber.org/zap"
-	ctrllog "sigs.k8s.io/controller-runtime/pkg/runtime/log"
 )
 
 var logger *zap.SugaredLogger
@@ -135,11 +133,6 @@ func main() {
 		format := c.GlobalGeneric("log-format").(*log.Format)
 		rawLog := log.New(c.GlobalBool("log-debug"), *format)
 		logger = rawLog.Sugar()
-
-		// update global logger instance
-		log.Logger = logger
-
-		ctrllog.SetLogger(zapr.NewLogger(rawLog.WithOptions(zap.AddCallerSkip(1))))
 
 		return nil
 	}

--- a/api/cmd/s3-storeuploader/main.go
+++ b/api/cmd/s3-storeuploader/main.go
@@ -70,7 +70,7 @@ func main() {
 		Usage: "Enables more verbose logging",
 	}
 
-	defaultLogFormat := log.FormatConsole
+	defaultLogFormat := log.FormatJSON
 	logFormatFlag := cli.GenericFlag{
 		Name:  "log-format",
 		Value: &defaultLogFormat,

--- a/api/cmd/s3-storeuploader/main.go
+++ b/api/cmd/s3-storeuploader/main.go
@@ -150,7 +150,7 @@ func main() {
 	// we know it's been a CLI parsing failure and the cli package
 	// has already output the error and printed the usage hints.
 	if err != nil && logger != nil {
-		logger.Fatal("Failed to run command", zap.Error(err))
+		logger.Fatalw("Failed to run command", zap.Error(err))
 	}
 }
 

--- a/api/pkg/log/zap.go
+++ b/api/pkg/log/zap.go
@@ -34,6 +34,25 @@ func (o *Options) Validate() error {
 
 type Format string
 
+// String implements the cli.Generic and flag.Value interfaces
+func (f *Format) String() string {
+	return string(*f)
+}
+
+// SetValue implements the cli.Generic and flag.Value interfaces
+func (f *Format) Set(s string) error {
+	switch strings.ToLower(s) {
+	case "json":
+		*f = FormatJSON
+		return nil
+	case "console":
+		*f = FormatConsole
+		return nil
+	default:
+		return fmt.Errorf("invalid format '%s'", s)
+	}
+}
+
 type Formats []Format
 
 const (

--- a/api/pkg/log/zap.go
+++ b/api/pkg/log/zap.go
@@ -34,12 +34,12 @@ func (o *Options) Validate() error {
 
 type Format string
 
-// String implements the cli.Generic and flag.Value interfaces
+// String implements the cli.Value and flag.Value interfaces
 func (f *Format) String() string {
 	return string(*f)
 }
 
-// SetValue implements the cli.Generic and flag.Value interfaces
+// Set implements the cli.Value and flag.Value interfaces
 func (f *Format) Set(s string) error {
 	switch strings.ToLower(s) {
 	case "json":

--- a/api/pkg/storeuploader/storeuploader.go
+++ b/api/pkg/storeuploader/storeuploader.go
@@ -1,6 +1,7 @@
 package storeuploader
 
 import (
+	"errors"
 	"fmt"
 	"os"
 	"path"
@@ -8,6 +9,7 @@ import (
 	"time"
 
 	"github.com/minio/minio-go"
+	"go.uber.org/zap"
 )
 
 // prefix separator separates the prefix
@@ -21,10 +23,11 @@ const prefixSeparator = "storeuploader"
 type StoreUploader struct {
 	// client is a pointer to an initialized client
 	client *minio.Client
+	logger *zap.SugaredLogger
 }
 
 // New returns a new instance of the StoreUploader
-func New(endpoint string, secure bool, accessKeyID, secretAccessKey string) (*StoreUploader, error) {
+func New(endpoint string, secure bool, accessKeyID, secretAccessKey string, logger *zap.SugaredLogger) (*StoreUploader, error) {
 	client, err := minio.New(endpoint, accessKeyID, secretAccessKey, secure)
 	if err != nil {
 		return nil, err
@@ -32,21 +35,28 @@ func New(endpoint string, secure bool, accessKeyID, secretAccessKey string) (*St
 	client.SetAppInfo("kubermatic-store-uploader", "v0.1")
 	return &StoreUploader{
 		client: client,
+		logger: logger,
 	}, nil
 }
 
 // Store uploads the given file to S3
 func (u *StoreUploader) Store(file, bucket, prefix string, createBucket bool) error {
+	if len(prefix) == 0 {
+		return errors.New("prefix cannot be empty")
+	}
+
 	if _, err := os.Stat(file); os.IsNotExist(err) {
 		return fmt.Errorf("%s not found", file)
 	}
 
 	if createBucket {
+		u.logger.Debugw("Check if bucket exists", "bucket", bucket)
 		exists, err := u.client.BucketExists(bucket)
 		if err != nil {
 			return err
 		}
 		if !exists {
+			u.logger.Infow("Creating bucket", "bucket", bucket)
 			if err := u.client.MakeBucket(bucket, ""); err != nil {
 				return err
 			}
@@ -54,21 +64,32 @@ func (u *StoreUploader) Store(file, bucket, prefix string, createBucket bool) er
 	}
 
 	objectName := fmt.Sprintf("%s-%s-%s-%s", prefix, prefixSeparator, time.Now().Format("2006-01-02T15:04:05"), path.Base(file))
+	u.logger.Infow("Uploading file", "bucket", bucket, "src", file, "dst", objectName)
+
 	_, err := u.client.FPutObject(bucket, objectName, file, minio.PutObjectOptions{})
 	return err
 }
 
-// DeleteOldBackups deletes revisions of the given file which are older than max-revisions
-func (u *StoreUploader) DeleteOldBackups(file, bucket, prefix string, revisionsToKeep int) error {
+// DeleteOldBackups deletes revisions of all files of the given prefix which are older than max-revisions
+func (u *StoreUploader) DeleteOldBackups(bucket, prefix string, revisionsToKeep int) error {
+	if len(prefix) == 0 {
+		return errors.New("prefix cannot be empty")
+	}
+
 	doneCh := make(chan struct{})
 	defer close(doneCh)
+
+	u.logger.Debugw("Listing existing objects", "bucket", bucket, "prefix", prefix)
 
 	var existingObjects []minio.ObjectInfo
 	for object := range u.client.ListObjects(bucket, fmt.Sprintf("%s-%s", prefix, prefixSeparator), true, doneCh) {
 		existingObjects = append(existingObjects, object)
 	}
 
+	u.logger.Debugw("Done listing bucket", "bucket", bucket, "prefix", prefix, "objects", len(existingObjects))
+
 	for _, object := range u.getObjectsToDelete(existingObjects, revisionsToKeep) {
+		u.logger.Debugw("Removing object", "bucket", bucket, "object", object.Key)
 		if err := u.client.RemoveObject(bucket, object.Key); err != nil {
 			return err
 		}
@@ -77,17 +98,26 @@ func (u *StoreUploader) DeleteOldBackups(file, bucket, prefix string, revisionsT
 	return nil
 }
 
-// DeleteAll deletes all revisions of the given file
-func (u *StoreUploader) DeleteAll(file, bucket, prefix string) error {
+// DeleteAll deletes all revisions of all files matching the given prefix
+func (u *StoreUploader) DeleteAll(bucket, prefix string) error {
+	if len(prefix) == 0 {
+		return errors.New("prefix cannot be empty")
+	}
+
 	doneCh := make(chan struct{})
 	defer close(doneCh)
+
+	u.logger.Debugw("Listing existing objects", "bucket", bucket, "prefix", prefix)
 
 	var existingObjects []minio.ObjectInfo
 	for object := range u.client.ListObjects(bucket, fmt.Sprintf("%s-%s", prefix, prefixSeparator), true, doneCh) {
 		existingObjects = append(existingObjects, object)
 	}
 
+	u.logger.Debugw("Done listing bucket", "bucket", bucket, "prefix", prefix, "objects", len(existingObjects))
+
 	for _, object := range existingObjects {
+		u.logger.Debugw("Removing object", "bucket", bucket, "object", object.Key)
 		if err := u.client.RemoveObject(bucket, object.Key); err != nil {
 			return err
 		}

--- a/api/pkg/storeuploader/storeuploader.go
+++ b/api/pkg/storeuploader/storeuploader.go
@@ -92,7 +92,7 @@ func (u *StoreUploader) DeleteOldBackups(bucket, prefix string, revisionsToKeep 
 	u.logger.Debugw("Done listing bucket", "bucket", bucket, "prefix", prefix, "objects", len(existingObjects))
 
 	for _, object := range u.getObjectsToDelete(existingObjects, revisionsToKeep) {
-		u.logger.Debugw("Removing object", "bucket", bucket, "object", object.Key)
+		u.logger.Infow("Removing object", "bucket", bucket, "object", object.Key)
 		if err := u.client.RemoveObject(bucket, object.Key); err != nil {
 			return err
 		}
@@ -123,7 +123,7 @@ func (u *StoreUploader) DeleteAll(bucket, prefix string) error {
 	u.logger.Debugw("Done listing bucket", "bucket", bucket, "prefix", prefix, "objects", len(existingObjects))
 
 	for _, object := range existingObjects {
-		u.logger.Debugw("Removing object", "bucket", bucket, "object", object.Key)
+		u.logger.Infow("Removing object", "bucket", bucket, "object", object.Key)
 		if err := u.client.RemoveObject(bucket, object.Key); err != nil {
 			return err
 		}

--- a/api/pkg/storeuploader/storeuploader.go
+++ b/api/pkg/storeuploader/storeuploader.go
@@ -83,6 +83,9 @@ func (u *StoreUploader) DeleteOldBackups(bucket, prefix string, revisionsToKeep 
 
 	var existingObjects []minio.ObjectInfo
 	for object := range u.client.ListObjects(bucket, fmt.Sprintf("%s-%s", prefix, prefixSeparator), true, doneCh) {
+		if object.Err != nil {
+			return object.Err
+		}
 		existingObjects = append(existingObjects, object)
 	}
 
@@ -111,6 +114,9 @@ func (u *StoreUploader) DeleteAll(bucket, prefix string) error {
 
 	var existingObjects []minio.ObjectInfo
 	for object := range u.client.ListObjects(bucket, fmt.Sprintf("%s-%s", prefix, prefixSeparator), true, doneCh) {
+		if object.Err != nil {
+			return object.Err
+		}
 		existingObjects = append(existingObjects, object)
 	}
 


### PR DESCRIPTION
**What this PR does / why we need it**:
This replaces glog with zap in the s3-storeuploader and generally improves its error handling. The most important fix is that bad endpoints (bad URL, HTTP failures, network failures) are no longer hidden behind a bogus "object name cannot be empty" error, but rather displayed to the user:

```
./s3-storeuploader delete-all --endpoint=foo --prefix=foo
2019-08-02T22:14:46.143+0200    fatal   s3-storeuploader/main.go:153    Failed to run command   {"err": "Get http://foo/kubermatic-backups/?location=: dial tcp: lookup foo: no such host"}
```

Likewise, empty prefixes are no longer allowed.

I made the two new logging CLI flags global because otherwise I could not access them in my global Before() handler. Alternatively we could (maybe?) use a Before() handler for each action, so that the CLI flags can be per-command. Given urfave's parsing, users now **must** put the logging flags before the subcommand name: `./s3-storeuploader --log-debug delete-all --endpoint=...`.

**Does this PR introduce a user-facing change?**:
```release-note
NONE
```
