### PR TITLE
use zap in s3-exporter

### DIFF
--- a/api/cmd/s3-exporter/Dockerfile
+++ b/api/cmd/s3-exporter/Dockerfile
@@ -1,4 +1,4 @@
-FROM alpine:3.7
+FROM alpine:3.10
 
 RUN apk add --no-cache ca-certificates
 

--- a/api/cmd/s3-exporter/README.md
+++ b/api/cmd/s3-exporter/README.md
@@ -7,35 +7,24 @@ It assumes all objects belonging to a given cluster have a prefix of `${CLUSTERN
 Usage:
 
 ```
-Usage of ./_build/s3-exporter:
+Usage of ./s3-exporter:
   -access-key-id string
-    	S3 Access key, defaults to the ACCESS_KEY_ID environment variable
+        S3 Access key, defaults to the ACCESS_KEY_ID environment variable
   -address string
-    	The port to listen on (default ":9340")
-  -alsologtostderr
-    	log to standard error as well as files
+        The port to listen on (default ":9340")
   -bucket string
-    	The bucket to monitor (default "kubermatic-etcd-backups")
+        The bucket to monitor (default "kubermatic-etcd-backups")
   -endpoint string
-    	The s3 endpoint, e.G. https://my-s3.com:9000
+        The s3 endpoint, e.G. https://my-s3.com:9000
   -kubeconfig string
-    	Path to a kubeconfig. Only required if out-of-cluster.
-  -log_backtrace_at value
-    	when logging hits line file:N, emit a stack trace
-  -log_dir string
-    	If non-empty, write log files in this directory
-  -logtostderr
-    	log to standard error instead of files
+        Path to a kubeconfig. Only required if out-of-cluster.
+  -log-debug
+        Enable more verbose logging
+  -log-format value
+        Use one of [JSON, Console] to change the log output format (default JSON)
   -secret-access-key string
-    	S3 Secret Access Key, defaults to the SECRET_ACCESS_KEY evnironment variable
-  -stderrthreshold value
-    	logs at or above this threshold go to stderr
-  -v value
-    	log level for V logs
-  -vmodule value
-    	comma-separated list of pattern=N settings for file-filtered logging
+        S3 Secret Access Key, defaults to the SECRET_ACCESS_KEY evnironment variable
 ```
-
 
 Releasing:
 

--- a/api/hack/publish-s3-exporter.sh
+++ b/api/hack/publish-s3-exporter.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 
 export REGISTRY=quay.io/kubermatic/s3-exporter
-export TAG=v0.3
+export TAG=v0.4
 
 GOOS=linux GOARCH=amd64 make -C $(dirname $0)/../ s3-exporter
 

--- a/config/s3-exporter/Chart.yaml
+++ b/config/s3-exporter/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 name: s3-exporter
-version: 1.0.0
-appVersion: v0.3
+version: 1.0.1
+appVersion: v0.4
 keywords:
 - kubermatic
 - prometheus

--- a/config/s3-exporter/templates/deployment.yaml
+++ b/config/s3-exporter/templates/deployment.yaml
@@ -15,7 +15,7 @@ spec:
       annotations:
         kubermatic/scrape: 'true'
         kubermatic/scrape_port: '9340'
-        fluentbit.io/parser: glog
+        fluentbit.io/parser: json_iso
     spec:
       serviceAccountName: s3-exporter
       containers:

--- a/config/s3-exporter/values.yaml
+++ b/config/s3-exporter/values.yaml
@@ -1,7 +1,7 @@
 s3Exporter:
   image:
     repository: quay.io/kubermatic/s3-exporter
-    tag: v0.3
+    tag: v0.4
   endpoint: http://minio.minio.svc.cluster.local:9000
   bucket: kubermatic-etcd-backups
   resources:


### PR DESCRIPTION
**What this PR does / why we need it**:
This replaces glog with zap in the s3-exporter and updates the Docker image to be based on Alpine 3.10.

**Special notes for your reviewer**:
I have no yet released the 0.4 Docker image.

**Does this PR introduce a user-facing change?**:
```release-note
NONE
```
