### PR TITLE
fix s3-exporter chart

### DIFF
--- a/config/s3-exporter/Chart.yaml
+++ b/config/s3-exporter/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: s3-exporter
-version: 1.0.1
+version: 1.0.2
 appVersion: v0.4
 keywords:
 - kubermatic

--- a/config/s3-exporter/templates/deployment.yaml
+++ b/config/s3-exporter/templates/deployment.yaml
@@ -24,8 +24,6 @@ spec:
           command:
           - /usr/local/bin/s3-exporter
           args:
-          - -v=4
-          - -logtostderr
           - -endpoint={{ .Values.s3Exporter.endpoint }}
           - -access-key-id=$(ACCESS_KEY_ID)
           - -secret-access-key=$(SECRET_ACCESS_KEY)


### PR DESCRIPTION
**What this PR does / why we need it**:
Since switching to zap there are no `-v` and `-logtostderr` flags needed anymore.

**Does this PR introduce a user-facing change?**:
```release-note
NONE
```
