### PR TITLE
label/tag MachineDeployments with the project and cluster IDs

### DIFF
--- a/api/pkg/handler/v1/node/node_test.go
+++ b/api/pkg/handler/v1/node/node_test.go
@@ -471,7 +471,7 @@ func TestCreateNodeDeployment(t *testing.T) {
 		{
 			Name:                   "scenario 1: create a node deployment that match the given spec",
 			Body:                   `{"spec":{"replicas":1,"template":{"cloud":{"digitalocean":{"size":"s-1vcpu-1gb","backups":false,"ipv6":false,"monitoring":false,"tags":[]}},"operatingSystem":{"ubuntu":{"distUpgradeOnBoot":false}}}}}`,
-			ExpectedResponse:       `{"name":"%s","creationTimestamp":"0001-01-01T00:00:00Z","spec":{"replicas":1,"template":{"cloud":{"digitalocean":{"size":"s-1vcpu-1gb","backups":false,"ipv6":false,"monitoring":false,"tags":["kubernetes","kubernetes-cluster-defClusterID"]}},"operatingSystem":{"ubuntu":{"distUpgradeOnBoot":false}},"versions":{"kubelet":"9.9.9"}},"paused":false},"status":{}}`,
+			ExpectedResponse:       `{"name":"%s","creationTimestamp":"0001-01-01T00:00:00Z","spec":{"replicas":1,"template":{"cloud":{"digitalocean":{"size":"s-1vcpu-1gb","backups":false,"ipv6":false,"monitoring":false,"tags":["kubernetes","kubernetes-cluster-defClusterID","system/cluster:defClusterID","system/project:my-first-project-ID"]}},"operatingSystem":{"ubuntu":{"distUpgradeOnBoot":false}},"versions":{"kubelet":"9.9.9"},"labels":{"system/cluster":"defClusterID","system/project":"my-first-project-ID"}},"paused":false},"status":{}}`,
 			HTTPStatus:             http.StatusCreated,
 			ProjectID:              test.GenDefaultProject().Name,
 			ClusterID:              test.GenDefaultCluster().Name,
@@ -519,7 +519,7 @@ func TestCreateNodeDeployment(t *testing.T) {
 		{
 			Name:                   "scenario 5: set taints",
 			Body:                   `{"spec":{"replicas":1,"template":{"taints": [{"key":"foo","value":"bar","effect":"NoExecute"}],"cloud":{"digitalocean":{"size":"s-1vcpu-1gb","backups":false,"ipv6":false,"monitoring":false,"tags":[]}},"operatingSystem":{"ubuntu":{"distUpgradeOnBoot":false}},"versions":{"kubelet":"9.9.9"}}}}`,
-			ExpectedResponse:       `{"name":"%s","creationTimestamp":"0001-01-01T00:00:00Z","spec":{"replicas":1,"template":{"cloud":{"digitalocean":{"size":"s-1vcpu-1gb","backups":false,"ipv6":false,"monitoring":false,"tags":["kubernetes","kubernetes-cluster-defClusterID"]}},"operatingSystem":{"ubuntu":{"distUpgradeOnBoot":false}},"versions":{"kubelet":"9.9.9"},"taints":[{"key":"foo","value":"bar","effect":"NoExecute"}]},"paused":false},"status":{}}`,
+			ExpectedResponse:       `{"name":"%s","creationTimestamp":"0001-01-01T00:00:00Z","spec":{"replicas":1,"template":{"cloud":{"digitalocean":{"size":"s-1vcpu-1gb","backups":false,"ipv6":false,"monitoring":false,"tags":["kubernetes","kubernetes-cluster-defClusterID","system/cluster:defClusterID","system/project:my-first-project-ID"]}},"operatingSystem":{"ubuntu":{"distUpgradeOnBoot":false}},"versions":{"kubelet":"9.9.9"},"labels":{"system/cluster":"defClusterID","system/project":"my-first-project-ID"},"taints":[{"key":"foo","value":"bar","effect":"NoExecute"}]},"paused":false},"status":{}}`,
 			HTTPStatus:             http.StatusCreated,
 			ProjectID:              test.GenDefaultProject().Name,
 			ClusterID:              test.GenDefaultCluster().Name,
@@ -1070,7 +1070,7 @@ func TestPatchNodeDeployment(t *testing.T) {
 		{
 			Name:                       "Scenario 1: Update replicas count",
 			Body:                       fmt.Sprintf(`{"spec":{"replicas":%v}}`, replicasUpdated),
-			ExpectedResponse:           fmt.Sprintf(`{"id":"venus","name":"venus","creationTimestamp":"0001-01-01T00:00:00Z","spec":{"replicas":%v,"template":{"cloud":{"digitalocean":{"size":"2GB","backups":false,"ipv6":false,"monitoring":false,"tags":["kubernetes","kubernetes-cluster-defClusterID"]}},"operatingSystem":{"ubuntu":{"distUpgradeOnBoot":true}},"versions":{"kubelet":"v9.9.9"}},"paused":false},"status":{}}`, replicasUpdated),
+			ExpectedResponse:           fmt.Sprintf(`{"id":"venus","name":"venus","creationTimestamp":"0001-01-01T00:00:00Z","spec":{"replicas":%v,"template":{"cloud":{"digitalocean":{"size":"2GB","backups":false,"ipv6":false,"monitoring":false,"tags":["kubernetes","kubernetes-cluster-defClusterID","system/cluster:defClusterID","system/project:my-first-project-ID"]}},"operatingSystem":{"ubuntu":{"distUpgradeOnBoot":true}},"versions":{"kubelet":"v9.9.9"},"labels":{"system/cluster":"defClusterID","system/project":"my-first-project-ID"}},"paused":false},"status":{}}`, replicasUpdated),
 			cluster:                    "keen-snyder",
 			HTTPStatus:                 http.StatusOK,
 			project:                    test.GenDefaultProject().Name,
@@ -1083,7 +1083,7 @@ func TestPatchNodeDeployment(t *testing.T) {
 		{
 			Name:                       "Scenario 2: Update kubelet version",
 			Body:                       fmt.Sprintf(`{"spec":{"template":{"versions":{"kubelet":"%v"}}}}`, kubeletVerUpdated),
-			ExpectedResponse:           fmt.Sprintf(`{"id":"venus","name":"venus","creationTimestamp":"0001-01-01T00:00:00Z","spec":{"replicas":%v,"template":{"cloud":{"digitalocean":{"size":"2GB","backups":false,"ipv6":false,"monitoring":false,"tags":["kubernetes","kubernetes-cluster-defClusterID"]}},"operatingSystem":{"ubuntu":{"distUpgradeOnBoot":true}},"versions":{"kubelet":"%v"}},"paused":false},"status":{}}`, replicas, kubeletVerUpdated),
+			ExpectedResponse:           fmt.Sprintf(`{"id":"venus","name":"venus","creationTimestamp":"0001-01-01T00:00:00Z","spec":{"replicas":%v,"template":{"cloud":{"digitalocean":{"size":"2GB","backups":false,"ipv6":false,"monitoring":false,"tags":["kubernetes","kubernetes-cluster-defClusterID","system/cluster:defClusterID","system/project:my-first-project-ID"]}},"operatingSystem":{"ubuntu":{"distUpgradeOnBoot":true}},"versions":{"kubelet":"%v"},"labels":{"system/cluster":"defClusterID","system/project":"my-first-project-ID"}},"paused":false},"status":{}}`, replicas, kubeletVerUpdated),
 			cluster:                    "keen-snyder",
 			HTTPStatus:                 http.StatusOK,
 			project:                    test.GenDefaultProject().Name,
@@ -1096,7 +1096,7 @@ func TestPatchNodeDeployment(t *testing.T) {
 		{
 			Name:                       "Scenario 3: Change to paused",
 			Body:                       `{"spec":{"paused":true}}`,
-			ExpectedResponse:           `{"id":"venus","name":"venus","creationTimestamp":"0001-01-01T00:00:00Z","spec":{"replicas":1,"template":{"cloud":{"digitalocean":{"size":"2GB","backups":false,"ipv6":false,"monitoring":false,"tags":["kubernetes","kubernetes-cluster-defClusterID"]}},"operatingSystem":{"ubuntu":{"distUpgradeOnBoot":true}},"versions":{"kubelet":"v9.9.9"}},"paused":true},"status":{}}`,
+			ExpectedResponse:           `{"id":"venus","name":"venus","creationTimestamp":"0001-01-01T00:00:00Z","spec":{"replicas":1,"template":{"cloud":{"digitalocean":{"size":"2GB","backups":false,"ipv6":false,"monitoring":false,"tags":["kubernetes","kubernetes-cluster-defClusterID","system/cluster:defClusterID","system/project:my-first-project-ID"]}},"operatingSystem":{"ubuntu":{"distUpgradeOnBoot":true}},"versions":{"kubelet":"v9.9.9"},"labels":{"system/cluster":"defClusterID","system/project":"my-first-project-ID"}},"paused":true},"status":{}}`,
 			cluster:                    "keen-snyder",
 			HTTPStatus:                 http.StatusOK,
 			project:                    test.GenDefaultProject().Name,

--- a/api/pkg/resources/machine/common.go
+++ b/api/pkg/resources/machine/common.go
@@ -82,6 +82,11 @@ func getAWSProviderSpec(c *kubermaticv1.Cluster, nodeSpec apiv1.NodeSpec, dc *ku
 		config.Tags[key] = value
 	}
 	config.Tags["kubernetes.io/cluster/"+c.Name] = ""
+	config.Tags["system/cluster"] = c.Name
+	projectID, ok := c.Labels[kubermaticv1.ProjectIDLabelKey]
+	if ok {
+		config.Tags["system/project"] = projectID
+	}
 
 	ext := &runtime.RawExtension{}
 	b, err := json.Marshal(config)
@@ -117,6 +122,11 @@ func getAzureProviderSpec(c *kubermaticv1.Cluster, nodeSpec apiv1.NodeSpec, dc *
 		config.Tags[key] = value
 	}
 	config.Tags["KubernetesCluster"] = c.Name
+	config.Tags["system/cluster"] = c.Name
+	projectID, ok := c.Labels[kubermaticv1.ProjectIDLabelKey]
+	if ok {
+		config.Tags["system/project"] = projectID
+	}
 
 	ext := &runtime.RawExtension{}
 	b, err := json.Marshal(config)
@@ -178,7 +188,11 @@ func getOpenstackProviderSpec(c *kubermaticv1.Cluster, nodeSpec apiv1.NodeSpec, 
 		config.Tags[key] = value
 	}
 	config.Tags["kubernetes-cluster"] = c.Name
-
+	config.Tags["system/cluster"] = c.Name
+	projectID, ok := c.Labels[kubermaticv1.ProjectIDLabelKey]
+	if ok {
+		config.Tags["system/project"] = projectID
+	}
 	ext := &runtime.RawExtension{}
 	b, err := json.Marshal(config)
 	if err != nil {
@@ -217,7 +231,12 @@ func getDigitaloceanProviderSpec(c *kubermaticv1.Cluster, nodeSpec apiv1.NodeSpe
 	}
 
 	tags := sets.NewString(nodeSpec.Cloud.Digitalocean.Tags...)
-	tags.Insert("kubernetes", "kubernetes-cluster-"+c.Name)
+	tags.Insert("kubernetes", fmt.Sprintf("kubernetes-cluster-%s", c.Name), fmt.Sprintf("system/cluster:%s", c.Name))
+	projectID, ok := c.Labels[kubermaticv1.ProjectIDLabelKey]
+	if ok {
+		tags.Insert(fmt.Sprintf("system/project:%s", projectID))
+	}
+
 	config.Tags = make([]providerconfig.ConfigVarString, len(tags.List()))
 	for i, tag := range tags.List() {
 		config.Tags[i].Value = tag
@@ -239,7 +258,11 @@ func getPacketProviderSpec(c *kubermaticv1.Cluster, nodeSpec apiv1.NodeSpec, dc 
 	}
 
 	tags := sets.NewString(nodeSpec.Cloud.Packet.Tags...)
-	tags.Insert("kubernetes", "kubernetes-cluster-"+c.Name)
+	tags.Insert("kubernetes", fmt.Sprintf("kubernetes-cluster-%s", c.Name), fmt.Sprintf("system/cluster:%s", c.Name))
+	projectID, ok := c.Labels[kubermaticv1.ProjectIDLabelKey]
+	if ok {
+		tags.Insert(fmt.Sprintf("system/project:%s", projectID))
+	}
 	config.Tags = make([]providerconfig.ConfigVarString, len(tags.List()))
 	for i, tag := range tags.List() {
 		config.Tags[i].Value = tag
@@ -274,7 +297,11 @@ func getGCPProviderSpec(c *kubermaticv1.Cluster, nodeSpec apiv1.NodeSpec, dc *ku
 	}
 
 	tags := sets.NewString(nodeSpec.Cloud.GCP.Tags...)
-	tags.Insert(fmt.Sprintf("kubernetes-cluster-%s", c.Name))
+	tags.Insert(fmt.Sprintf("kubernetes-cluster-%s", c.Name), fmt.Sprintf("system/cluster:%s", c.Name))
+	projectID, ok := c.Labels[kubermaticv1.ProjectIDLabelKey]
+	if ok {
+		tags.Insert(fmt.Sprintf("system/project:%s", projectID))
+	}
 	config.Tags = tags.List()
 
 	config.Labels = map[string]string{}

--- a/api/pkg/resources/machine/machinedeployment.go
+++ b/api/pkg/resources/machine/machinedeployment.go
@@ -43,6 +43,14 @@ func Deployment(c *kubermaticv1.Cluster, nd *apiv1.NodeDeployment, dc *kubermati
 	}
 	md.Spec.Template.Labels = md.Spec.Selector.MatchLabels
 	md.Spec.Template.Spec.Labels = nd.Spec.Template.Labels
+	if md.Spec.Template.Spec.Labels == nil {
+		md.Spec.Template.Spec.Labels = make(map[string]string)
+	}
+	md.Spec.Template.Spec.Labels["system/cluster"] = c.Name
+	projectID, ok := c.Labels[kubermaticv1.ProjectIDLabelKey]
+	if ok {
+		md.Spec.Template.Spec.Labels["system/project"] = projectID
+	}
 
 	var taints []corev1.Taint
 	for _, taint := range nd.Spec.Template.Taints {

--- a/api/pkg/resources/test/fixtures/machine-aws.yaml
+++ b/api/pkg/resources/test/fixtures/machine-aws.yaml
@@ -26,6 +26,7 @@ spec:
           AWSExampleTagKey1: AWSExampleTagValue1
           AWSExampleTagKey2: AWSExampleTagValue2
           kubernetes.io/cluster/awscluster-1a2b3c4d5e: ""
+          system/cluster: awscluster-1a2b3c4d5e
         vpcId: aws-vpc-ic
       operatingSystem: ubuntu
       operatingSystemSpec:

--- a/api/pkg/resources/test/fixtures/machine-azure.yaml
+++ b/api/pkg/resources/test/fixtures/machine-azure.yaml
@@ -22,6 +22,7 @@ spec:
         tags:
           KubernetesCluster: azurecluster-1a2b3c4d5e
           foo: bar
+          system/cluster: azurecluster-1a2b3c4d5e
         tenantID: 38w7giefb32fhifw3q
         vmSize: Standard_B1ms
         vnetName: cluster-azurecluster-1a2b3c4d5e

--- a/api/pkg/resources/test/fixtures/machine-digitalocean.yaml
+++ b/api/pkg/resources/test/fixtures/machine-digitalocean.yaml
@@ -20,6 +20,7 @@ spec:
         - digitalocean-example-tag-2
         - kubernetes
         - kubernetes-cluster-docluster-1a2b3c4d5e
+        - system/cluster:docluster-1a2b3c4d5e
         token: ""
       operatingSystem: ubuntu
       operatingSystemSpec:

--- a/api/pkg/resources/test/fixtures/machine-openstack.yaml
+++ b/api/pkg/resources/test/fixtures/machine-openstack.yaml
@@ -26,6 +26,7 @@ spec:
         tags:
           foo: bar
           kubernetes-cluster: openstackcluster-1a2b3c4d5e
+          system/cluster: openstackcluster-1a2b3c4d5e
         tenantID: ""
         tenantName: ""
         tokenId: ""


### PR DESCRIPTION
**What this PR does / why we need it**: label/tag MachineDeployments with the project and cluster IDs
The machines are tagged/labeled with `system/project: PROJECT_ID` and `system/cluster: CLUSTER_ID`

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #3822
![labels](https://user-images.githubusercontent.com/13030040/62462679-4609e680-b788-11e9-8128-e62371204a7f.png)


```release-note
The machines are tagged/labeled with system/project: PROJECT_ID and system/cluster: CLUSTER_ID
```
