### PR TITLE
Add a metrics for master-controller-manager seed kubeconfig retrieval errors

### DIFF
--- a/api/cmd/master-controller-manager/controllers.go
+++ b/api/cmd/master-controller-manager/controllers.go
@@ -16,6 +16,7 @@ import (
 	"github.com/prometheus/client_golang/prometheus"
 
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/util/sets"
 	"k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/rest"
 	"sigs.k8s.io/controller-runtime/pkg/manager"
@@ -59,7 +60,17 @@ func rbacControllerFactoryCreator(
 ) func() (manager.Runnable, error) {
 
 	rbacMetrics := rbac.NewMetrics()
-	prometheus.MustRegister(rbacMetrics.Workers)
+	seedKubeconfigRetrievalSuccessMetric := prometheus.NewGaugeVec(prometheus.GaugeOpts{
+		Namespace: "kubermatic",
+		Subsystem: "master_controller_manager",
+		Name:      "seed_kubeconfig_retrieval_success",
+		Help:      "Indicates if retrieving the kubeconfig for the given seed was successful",
+	}, []string{"seed"})
+	// GaugeVec doesn't have a func to only keep metrics with a given label value, it only
+	// has a func to delete metrics with a given label value. Hence we have to track ourselves
+	// which label values get removed
+	seedsWithMetrics := sets.NewString()
+	prometheus.MustRegister(rbacMetrics.Workers, seedKubeconfigRetrievalSuccessMetric)
 
 	return func() (manager.Runnable, error) {
 		seeds, err := seedsGetter()
@@ -72,19 +83,27 @@ func rbacControllerFactoryCreator(
 		}
 		allClusterProviders := []*rbac.ClusterProvider{masterClusterProvider}
 
+		newSeedsWithMetrics := sets.NewString()
 		for seedName := range seeds {
+			newSeedsWithMetrics.Insert(seedName)
 			kubeConfig, err := seedKubeconfigGetter(seedName)
 			if err != nil {
 				kubermaticlog.Logger.With("error", err).With("seed", seedName).Error("error getting kubeconfig")
 				// Dont let a single broken kubeconfig break the whole controller creation
+				seedKubeconfigRetrievalSuccessMetric.WithLabelValues(seedName).Set(0)
 				continue
 			}
+			seedKubeconfigRetrievalSuccessMetric.WithLabelValues(seedName).Set(1)
 			clusterProvider, err := rbacClusterProvider(kubeConfig, seedName, false, selectorOps)
 			if err != nil {
 				return nil, fmt.Errorf("failed to create rbac provider for seed %q: %v", seedName, err)
 			}
 			allClusterProviders = append(allClusterProviders, clusterProvider)
 		}
+		removedSeeds := sets.NewString(seedsWithMetrics.List()...)
+		removedSeeds.Delete(newSeedsWithMetrics.List()...)
+		_ = seedKubeconfigRetrievalSuccessMetric.DeleteLabelValues(removedSeeds.List()...)
+		seedsWithMetrics = newSeedsWithMetrics
 
 		ctrl, err := rbac.New(rbacMetrics, allClusterProviders, workerCount)
 		if err != nil {


### PR DESCRIPTION
**What this PR does / why we need it**:

Allows to have alerts for errors when retrieving the kubeconfig for a seed.

Also fixes the master-controller-manger to expose our own metrics and not just the ones from controller-runtime.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Documentation**:
<!-- Add links to the related documentation changes related to this pull request. E.g. the link to the kubermatic/docs pullrequest. -->

**Does this PR introduce a user-facing change?**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If  no release note is required, just write "NONE".
-->
```release-note
none
```

/assign @mrIncompetent 
