### PR TITLE
Fix incorrect use of arithmetic comparison.

### DIFF
--- a/api/hack/ci/ci-push-images.sh
+++ b/api/hack/ci/ci-push-images.sh
@@ -25,11 +25,11 @@ echodate "Building addons"
 time docker build -t quay.io/kubermatic/addons:${GIT_HEAD_HASH} ./addons
 for TAG in $TAGS
 do
-    if [[ -z "$TAG" ]]; then
+    if [ -z "$TAG" ]; then
       continue
     fi
 
-    if [[ "$TAG" -eq "$GIT_HEAD_HASH" ]]; then
+    if [ "$TAG" = "$GIT_HEAD_HASH" ]; then
       continue
     fi
 


### PR DESCRIPTION
**What this PR does / why we need it**:

Script for pushing images uses arithmetic compare `-eq` for string comparison. This only works for strings which could not be interpreted as numbers. It fails on git hashes.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:

**Special notes for your reviewer**:

**Documentation**:
<!-- Add links to the related documentation changes related to this pull request. E.g. the link to the kubermatic/docs pullrequest. -->

**Does this PR introduce a user-facing change?**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If  no release note is required, just write "NONE".
-->
```release-note
NONE
```
