### PR TITLE
Cluster cleanup: Only create usercluster client if its actually needed

### DIFF
--- a/api/pkg/clusterdeletion/deletion.go
+++ b/api/pkg/clusterdeletion/deletion.go
@@ -16,16 +16,16 @@ const (
 	deletedLBAnnotationName = "kubermatic.io/cleaned-up-loadbalancers"
 )
 
-func New(seedClient, userClusterClient controllerruntimeclient.Client) *Deletion {
+func New(seedClient controllerruntimeclient.Client, userClusterClientGetter func() (controllerruntimeclient.Client, error)) *Deletion {
 	return &Deletion{
-		seedClient:        seedClient,
-		userClusterClient: userClusterClient,
+		seedClient:              seedClient,
+		userClusterClientGetter: userClusterClientGetter,
 	}
 }
 
 type Deletion struct {
-	seedClient        controllerruntimeclient.Client
-	userClusterClient controllerruntimeclient.Client
+	seedClient              controllerruntimeclient.Client
+	userClusterClientGetter func() (controllerruntimeclient.Client, error)
 }
 
 // CleanupCluster is responsible for cleaning up a cluster.

--- a/api/pkg/clusterdeletion/deletion_test.go
+++ b/api/pkg/clusterdeletion/deletion_test.go
@@ -61,10 +61,10 @@ func TestCleanUpPVUsingWorkloads(t *testing.T) {
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
 			client := fake.NewFakeClient(tc.objects...)
-			d := &Deletion{userClusterClient: client}
+			d := &Deletion{}
 			ctx := context.Background()
 
-			if err := d.cleanupPVCUsingPods(ctx); (err != nil) != tc.errExpected {
+			if err := d.cleanupPVCUsingPods(ctx, client); (err != nil) != tc.errExpected {
 				t.Fatalf("Expected err=%v, got err=%v", tc.errExpected, err)
 			}
 			if tc.errExpected {

--- a/api/pkg/clusterdeletion/node.go
+++ b/api/pkg/clusterdeletion/node.go
@@ -21,8 +21,13 @@ func (d *Deletion) cleanupNodes(ctx context.Context, cluster *kubermaticv1.Clust
 		return nil
 	}
 
+	userClusterClient, err := d.userClusterClientGetter()
+	if err != nil {
+		return err
+	}
+
 	nodes := &corev1.NodeList{}
-	if err := d.userClusterClient.List(ctx, &controllerruntimeclient.ListOptions{}, nodes); err != nil {
+	if err := userClusterClient.List(ctx, &controllerruntimeclient.ListOptions{}, nodes); err != nil {
 		return fmt.Errorf("failed to get user cluster nodes: %v", err)
 	}
 
@@ -35,7 +40,7 @@ func (d *Deletion) cleanupNodes(ctx context.Context, cluster *kubermaticv1.Clust
 		err := retry.RetryOnConflict(retry.DefaultBackoff, func() error {
 			// Get latest version of the node to prevent conflict errors
 			currentNode := &corev1.Node{}
-			if err := d.userClusterClient.Get(ctx, types.NamespacedName{Name: node.Name}, currentNode); err != nil {
+			if err := userClusterClient.Get(ctx, types.NamespacedName{Name: node.Name}, currentNode); err != nil {
 				return err
 			}
 			if currentNode.Annotations == nil {
@@ -43,7 +48,7 @@ func (d *Deletion) cleanupNodes(ctx context.Context, cluster *kubermaticv1.Clust
 			}
 			currentNode.Annotations[eviction.SkipEvictionAnnotationKey] = "true"
 
-			return d.userClusterClient.Update(ctx, currentNode)
+			return userClusterClient.Update(ctx, currentNode)
 		})
 		if err != nil {
 			return fmt.Errorf("failed to add the annotation '%s=true' to node '%s': %v", eviction.SkipEvictionAnnotationKey, node.Name, err)
@@ -52,13 +57,13 @@ func (d *Deletion) cleanupNodes(ctx context.Context, cluster *kubermaticv1.Clust
 
 	machineDeploymentList := &clusterv1alpha1.MachineDeploymentList{}
 	listOpts := &controllerruntimeclient.ListOptions{Namespace: metav1.NamespaceSystem}
-	if err := d.userClusterClient.List(ctx, listOpts, machineDeploymentList); err != nil {
+	if err := userClusterClient.List(ctx, listOpts, machineDeploymentList); err != nil {
 		return fmt.Errorf("failed to list MachineDeployments: %v", err)
 	}
 	if len(machineDeploymentList.Items) > 0 {
 		// TODO: Use DeleteCollection once https://github.com/kubernetes-sigs/controller-runtime/issues/344 is resolved
 		for _, machineDeployment := range machineDeploymentList.Items {
-			if err := d.userClusterClient.Delete(ctx, &machineDeployment); err != nil {
+			if err := userClusterClient.Delete(ctx, &machineDeployment); err != nil {
 				return fmt.Errorf("failed to delete MachineDeployment %q: %v", machineDeployment.Name, err)
 			}
 		}
@@ -67,13 +72,13 @@ func (d *Deletion) cleanupNodes(ctx context.Context, cluster *kubermaticv1.Clust
 	}
 
 	machineSetList := &clusterv1alpha1.MachineSetList{}
-	if err := d.userClusterClient.List(ctx, listOpts, machineSetList); err != nil {
+	if err := userClusterClient.List(ctx, listOpts, machineSetList); err != nil {
 		return fmt.Errorf("failed to list MachineSets: %v", err)
 	}
 	if len(machineSetList.Items) > 0 {
 		// TODO: Use DeleteCollection once https://github.com/kubernetes-sigs/controller-runtime/issues/344 is resolved
 		for _, machineSet := range machineSetList.Items {
-			if err := d.userClusterClient.Delete(ctx, &machineSet); err != nil {
+			if err := userClusterClient.Delete(ctx, &machineSet); err != nil {
 				return fmt.Errorf("failed to delete MachineSet %q: %v", machineSet.Name, err)
 			}
 		}
@@ -82,13 +87,13 @@ func (d *Deletion) cleanupNodes(ctx context.Context, cluster *kubermaticv1.Clust
 	}
 
 	machineList := &clusterv1alpha1.MachineList{}
-	if err := d.userClusterClient.List(ctx, listOpts, machineList); err != nil {
+	if err := userClusterClient.List(ctx, listOpts, machineList); err != nil {
 		return fmt.Errorf("failed to get Machines: %v", err)
 	}
 	if len(machineList.Items) > 0 {
 		// TODO: Use DeleteCollection once https://github.com/kubernetes-sigs/controller-runtime/issues/344 is resolved
 		for _, machine := range machineList.Items {
-			if err := d.userClusterClient.Delete(ctx, &machine); err != nil {
+			if err := userClusterClient.Delete(ctx, &machine); err != nil {
 				return fmt.Errorf("failed to delete Machine %q: %v", machine.Name, err)
 			}
 		}

--- a/api/pkg/controller/cloud/cloud_controller.go
+++ b/api/pkg/controller/cloud/cloud_controller.go
@@ -120,8 +120,7 @@ func (r *Reconciler) reconcile(ctx context.Context, cluster *kubermaticv1.Cluste
 		finalizers := sets.NewString(cluster.Finalizers...)
 		if finalizers.Has(kubermaticapiv1.InClusterLBCleanupFinalizer) ||
 			finalizers.Has(kubermaticapiv1.InClusterPVCleanupFinalizer) ||
-			finalizers.Has(kubermaticapiv1.NodeDeletionFinalizer) ||
-			finalizers.Has(kubermaticapiv1.CredentialsSecretsCleanupFinalizer) {
+			finalizers.Has(kubermaticapiv1.NodeDeletionFinalizer) {
 			return &reconcile.Result{RequeueAfter: 5 * time.Second}, nil
 		}
 		_, err := prov.CleanUpCloudProvider(cluster, r.updateCluster)


### PR DESCRIPTION
We currently always require a usercluster client to even attempt to
cleanup a cluster. This means cleanup for clusters that were deleted too
quick can not work.

This PR fixes that by defering the creation of the usercluster client
until its actually being used.

**What this PR does / why we need it**:

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Documentation**:
<!-- Add links to the related documentation changes related to this pull request. E.g. the link to the kubermatic/docs pullrequest. -->

**Does this PR introduce a user-facing change?**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If  no release note is required, just write "NONE".
-->
```release-note
none
```

/assign @nikhita @mrIncompetent 
