### PR TITLE
fix namespace handling in s3-exporter

### DIFF
--- a/api/hack/deploy.sh
+++ b/api/hack/deploy.sh
@@ -96,7 +96,7 @@ case "${DEPLOY_STACK}" in
     # CI has its own Minio deployment as a proxy for GCS, so we do not install the default Helm chart here.
     if [[ "${DEPLOY_MINIO}" = true ]]; then
       deploy "minio" "minio" ./config/minio/
-      deploy "s3-exporter" "kube-system" ./config/s3-exporter/
+      deploy "s3-exporter" "kubermatic" ./config/s3-exporter/
     fi
 
     # The NodePort proxy is only relevant in cloud environments (Where LB services can be used)

--- a/config/s3-exporter/Chart.yaml
+++ b/config/s3-exporter/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: s3-exporter
-version: 1.0.2
+version: 1.1.0
 appVersion: v0.4
 keywords:
 - kubermatic

--- a/config/s3-exporter/templates/clusterrole.yaml
+++ b/config/s3-exporter/templates/clusterrole.yaml
@@ -1,7 +1,7 @@
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
-  name: kubermatic:s3exporter:clusters:reader
+  name: {{ .Release.Namespace }}:s3exporter:clusters:reader
 rules:
 - apiGroups:
   - kubermatic.k8s.io

--- a/config/s3-exporter/templates/clusterrolebinding.yaml
+++ b/config/s3-exporter/templates/clusterrolebinding.yaml
@@ -1,12 +1,12 @@
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
-  name: kubermatic:s3exporter:clusters:reader
+  name: {{ .Release.Namespace }}:s3exporter:clusters:reader
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
-  name: kubermatic:s3exporter:clusters:reader
+  name: {{ .Release.Namespace }}:s3exporter:clusters:reader
 subjects:
 - kind: ServiceAccount
   name: s3-exporter
-  namespace: kube-system
+  namespace: {{ .Release.Namespace }}

--- a/config/s3-exporter/templates/deployment.yaml
+++ b/config/s3-exporter/templates/deployment.yaml
@@ -2,7 +2,7 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: s3-exporter
-  namespace: kube-system
+  namespace: {{ .Release.Namespace }}
 spec:
   replicas: 2
   selector:

--- a/config/s3-exporter/templates/serviceaccount.yaml
+++ b/config/s3-exporter/templates/serviceaccount.yaml
@@ -2,4 +2,4 @@ apiVersion: v1
 kind: ServiceAccount
 metadata:
   name: s3-exporter
-  namespace: kube-system
+  namespace: {{ .Release.Namespace }}


### PR DESCRIPTION
**What this PR does / why we need it**:
The S3 exporter chart has the `kube-system` namespace hardcoded, even though on some of our clusters it's running in an `s3-exporter` namespace. This PR attempts to normalise this by making the chart more flexible (like all our other charts) and putting it into the `kubermatic` namespace by default (because without Kubermatic, the exporter is useless). It does not matter in the slightest into which namespace the exporter is installed.

I expect some ruckus and manual intervention in cases where the Chart is currently weirdly broken (i.e. our cloud clusters), but this is non-critical (at worst there will be a few non-essential metrics missing while the admin fixes the chart).

**NOTE**
This has been partially reverted by #3984 because of the location of the s3-credentials secret.

**Does this PR introduce a user-facing change?**:
```release-note
NONE
```
