### PR TITLE
Only do LB and PV cleanup when the cluster was up

### DIFF
--- a/api/pkg/handler/v1/cluster/cluster.go
+++ b/api/pkg/handler/v1/cluster/cluster.go
@@ -397,7 +397,10 @@ func DeleteEndpoint(sshKeyProvider provider.SSHKeyProvider, projectProvider prov
 
 		kuberneteshelper.AddFinalizer(existingCluster, apiv1.CredentialsSecretsCleanupFinalizer)
 
-		if req.DeleteVolumes || req.DeleteLoadBalancers {
+		// Use the NodeDeletionFinalizer to determine if the cluster was ever up, the LB and PV finalizers
+		// will prevent cluster deletion if the APIserver was never created
+		wasUpOnce := kuberneteshelper.HasFinalizer(existingCluster, apiv1.NodeDeletionFinalizer)
+		if wasUpOnce && (req.DeleteVolumes || req.DeleteLoadBalancers) {
 			if req.DeleteLoadBalancers {
 				kuberneteshelper.AddFinalizer(existingCluster, apiv1.InClusterLBCleanupFinalizer)
 			}


### PR DESCRIPTION
This PR changes the API do not add the LB and PV cleanup finalizer if
the usercluster APIServer was never up. We use the
node-deletion-finalizer to determine this, it gets only added after the
API came up. This prevents deadlocks in cases where the usercluster API never came up successfully.

Also it
* Changes the api finalizer testcases to only contain the attributes that actually change
* Removes the `kubermaticapiv1` import in which was a second alias in `api/pkg/handler/test/helper.go` for the `github.com/kubermatic/kubermatic/api/pkg/crd/kubermatic/v1` package which was very confusing because we usually use that import alias for a different package
* Extends the `GenCluster` used for testing to accept an optional `...func(*kubermaticv1.Cluster)` so the cluster can be manipulated which was required in order to update the existing tests

**What this PR does / why we need it**:

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Documentation**:
<!-- Add links to the related documentation changes related to this pull request. E.g. the link to the kubermatic/docs pullrequest. -->

**Does this PR introduce a user-facing change?**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If  no release note is required, just write "NONE".
-->
```release-note
Fixed an issue that kept clusters stuck if their creation didn't succeed and they got deleted with LB and/or PV cleanup enabled
```

/assign @mrIncompetent @zreigz 