### PR TITLE
AWS: rename default StorageClass

### DIFF
--- a/addons/default-storage-class/storage-class.yaml
+++ b/addons/default-storage-class/storage-class.yaml
@@ -22,7 +22,7 @@ metadata:
     storageclass.beta.kubernetes.io/is-default-class: "true"
   labels:
     kubernetes.io/cluster-service: "true"
-  name: standard
+  name: standard-v2
 provisioner: kubernetes.io/aws-ebs
 parameters:
   type: gp2


### PR DESCRIPTION
We've reconfigured the default AWS StorageClass in kubermatic/kubermatic#3693
in order to allow multiple Availability Zones. However, that cannot be
changed on an existing StorageClass. Instead, we'll make the old class
get deleted and the new (renamed) one will get created in its stead.

```release-note
NONE
```
