### PR TITLE
Fix seed-proxy controller not actually talking to seeds

### DIFF
--- a/api/pkg/controller/seed-proxy/resources.go
+++ b/api/pkg/controller/seed-proxy/resources.go
@@ -194,13 +194,13 @@ func masterDeploymentCreator(contextName string, secret *corev1.Secret) reconcil
 							Protocol:      corev1.ProtocolTCP,
 						},
 					},
-					VolumeMounts: []corev1.VolumeMount{
-						{
-							MountPath: "var/run/secrets/kubernetes.io/serviceaccount/",
-							Name:      "serviceaccount",
-							ReadOnly:  true,
-						},
-					},
+					//		VolumeMounts: []corev1.VolumeMount{
+					//			{
+					//				MountPath: "var/run/secrets/kubernetes.io/serviceaccount/",
+					//				Name:      "serviceaccount",
+					//				ReadOnly:  true,
+					//			},
+					//		},
 					Resources: corev1.ResourceRequirements{
 						Requests: corev1.ResourceList{
 							corev1.ResourceCPU:    resource.MustParse("10m"),
@@ -217,7 +217,7 @@ func masterDeploymentCreator(contextName string, secret *corev1.Secret) reconcil
 
 			d.Spec.Template.Spec.Volumes = []corev1.Volume{
 				{
-					Name: "serviceaccount",
+					Name: "kubeconfig",
 					VolumeSource: corev1.VolumeSource{
 						Secret: &corev1.SecretVolumeSource{
 							DefaultMode: i32ptr(420),


### PR DESCRIPTION
The current deployment creates pods Kubernetes wont create, resulting in
the Deployments failing:

```
$ k describe pod seed-proxy-europe-west3-c-1-579fd55967-dg5j5|grep Error
      Reason:       CreateContainerError
  Warning  Failed     3m36s (x12 over 5m54s)  kubelet, gke-kubermatic-cloud-euro-preemtible2-8982be0c-z2gs  Error: Error response from daemon: Duplicate mount point: /var/run/secrets/kubernetes.io/serviceaccount
```

**What this PR does / why we need it**:

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Documentation**:
<!-- Add links to the related documentation changes related to this pull request. E.g. the link to the kubermatic/docs pullrequest. -->

**Does this PR introduce a user-facing change?**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If  no release note is required, just write "NONE".
-->
```release-note
none
```

/assign @xrstf 
/approve
