### PR TITLE
[release/v2.11] Only do LB and PV cleanup when the cluster was up (#3973)

### DIFF
--- a/api/pkg/handler/test/helper.go
+++ b/api/pkg/handler/test/helper.go
@@ -28,7 +28,7 @@ import (
 	kubermaticfakeclentset "github.com/kubermatic/kubermatic/api/pkg/crd/client/clientset/versioned/fake"
 	kubermaticclientv1 "github.com/kubermatic/kubermatic/api/pkg/crd/client/clientset/versioned/typed/kubermatic/v1"
 	kubermaticinformers "github.com/kubermatic/kubermatic/api/pkg/crd/client/informers/externalversions"
-	kubermaticapiv1 "github.com/kubermatic/kubermatic/api/pkg/crd/kubermatic/v1"
+	kubermaticv1 "github.com/kubermatic/kubermatic/api/pkg/crd/kubermatic/v1"
 	"github.com/kubermatic/kubermatic/api/pkg/handler/auth"
 	kubermaticlog "github.com/kubermatic/kubermatic/api/pkg/log"
 	"github.com/kubermatic/kubermatic/api/pkg/provider"
@@ -313,11 +313,11 @@ type fakeUserClusterConnection struct {
 	fakeDynamicClient ctrlruntimeclient.Client
 }
 
-func (f *fakeUserClusterConnection) GetClient(_ *kubermaticapiv1.Cluster, _ ...k8cuserclusterclient.ConfigOption) (ctrlruntimeclient.Client, error) {
+func (f *fakeUserClusterConnection) GetClient(_ *kubermaticv1.Cluster, _ ...k8cuserclusterclient.ConfigOption) (ctrlruntimeclient.Client, error) {
 	return f.fakeDynamicClient, nil
 }
 
-func (f *fakeUserClusterConnection) GetAdminKubeconfig(c *kubermaticapiv1.Cluster) ([]byte, error) {
+func (f *fakeUserClusterConnection) GetAdminKubeconfig(c *kubermaticv1.Cluster) ([]byte, error) {
 	return []byte(generateTestKubeconfig(ClusterID, IDToken)), nil
 }
 
@@ -354,11 +354,11 @@ users:
     token: %s`, clusterID, clusterID, token)
 }
 
-// APIUserToKubermaticUser simply converts apiv1.User to kubermaticapiv1.User type
-func APIUserToKubermaticUser(user apiv1.User) *kubermaticapiv1.User {
-	return &kubermaticapiv1.User{
+// APIUserToKubermaticUser simply converts apiv1.User to kubermaticv1.User type
+func APIUserToKubermaticUser(user apiv1.User) *kubermaticv1.User {
+	return &kubermaticv1.User{
 		ObjectMeta: metav1.ObjectMeta{},
-		Spec: kubermaticapiv1.UserSpec{
+		Spec: kubermaticv1.UserSpec{
 			Name:  user.Name,
 			Email: user.Email,
 			ID:    user.ID,
@@ -384,7 +384,7 @@ func CompareWithResult(t *testing.T, res *httptest.ResponseRecorder, response st
 
 // GenUser generates a User resource
 // note if the id is empty then it will be auto generated
-func GenUser(id, name, email string) *kubermaticapiv1.User {
+func GenUser(id, name, email string) *kubermaticv1.User {
 	if len(id) == 0 {
 		// the name of the object is derived from the email address and encoded as sha256
 		id = fmt.Sprintf("%x", sha256.Sum256([]byte(email)))
@@ -400,12 +400,12 @@ func GenUser(id, name, email string) *kubermaticapiv1.User {
 		specID = fmt.Sprintf("%x_KUBE", h.Sum(nil))
 	}
 
-	return &kubermaticapiv1.User{
+	return &kubermaticv1.User{
 		ObjectMeta: metav1.ObjectMeta{
 			Name: id,
 			UID:  types.UID(fmt.Sprintf("fake-uid-%s", id)),
 		},
-		Spec: kubermaticapiv1.UserSpec{
+		Spec: kubermaticv1.UserSpec{
 			ID:    specID,
 			Name:  name,
 			Email: email,
@@ -414,13 +414,13 @@ func GenUser(id, name, email string) *kubermaticapiv1.User {
 }
 
 // GenInactiveServiceAccount generates a Service Account resource
-func GenInactiveServiceAccount(id, name, group, projectName string) *kubermaticapiv1.User {
+func GenInactiveServiceAccount(id, name, group, projectName string) *kubermaticv1.User {
 	user := GenUser(id, name, fmt.Sprintf("serviceaccount-%s@sa.kubermatic.io", id))
 	user.Labels = map[string]string{kubernetes.ServiceAccountLabelGroup: fmt.Sprintf("%s-%s", group, projectName)}
 	user.OwnerReferences = []metav1.OwnerReference{
 		{
-			APIVersion: kubermaticapiv1.SchemeGroupVersion.String(),
-			Kind:       kubermaticapiv1.ProjectKindName,
+			APIVersion: kubermaticv1.SchemeGroupVersion.String(),
+			Kind:       kubermaticv1.ProjectKindName,
 			Name:       projectName,
 			UID:        types.UID(id),
 		},
@@ -432,13 +432,13 @@ func GenInactiveServiceAccount(id, name, group, projectName string) *kubermatica
 	return user
 }
 
-func GenServiceAccount(id, name, group, projectName string) *kubermaticapiv1.User {
+func GenServiceAccount(id, name, group, projectName string) *kubermaticv1.User {
 	sa := GenInactiveServiceAccount(id, name, group, projectName)
 	sa.Labels = map[string]string{}
 	return sa
 }
 
-func GenDefaultServiceAccount() *kubermaticapiv1.User {
+func GenDefaultServiceAccount() *kubermaticv1.User {
 	return GenServiceAccount("1984", "default", "editors", GenDefaultProject().Name)
 }
 
@@ -471,28 +471,28 @@ func GenDefaultAPIUser() *apiv1.User {
 }
 
 // GenDefaultUser generates a default user
-func GenDefaultUser() *kubermaticapiv1.User {
+func GenDefaultUser() *kubermaticv1.User {
 	userEmail := "bob@acme.com"
 	return GenUser("", "Bob", userEmail)
 }
 
 // GenProject generates new empty project
-func GenProject(name, phase string, creationTime time.Time, oRef ...metav1.OwnerReference) *kubermaticapiv1.Project {
-	return &kubermaticapiv1.Project{
+func GenProject(name, phase string, creationTime time.Time, oRef ...metav1.OwnerReference) *kubermaticv1.Project {
+	return &kubermaticv1.Project{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:              fmt.Sprintf("%s-%s", name, "ID"),
 			CreationTimestamp: metav1.NewTime(creationTime),
 			OwnerReferences:   oRef,
 		},
-		Spec: kubermaticapiv1.ProjectSpec{Name: name},
-		Status: kubermaticapiv1.ProjectStatus{
+		Spec: kubermaticv1.ProjectSpec{Name: name},
+		Status: kubermaticv1.ProjectStatus{
 			Phase: phase,
 		},
 	}
 }
 
 // GenDefaultProject generates a default project
-func GenDefaultProject() *kubermaticapiv1.Project {
+func GenDefaultProject() *kubermaticv1.Project {
 	user := GenDefaultUser()
 	oRef := metav1.OwnerReference{
 		APIVersion: "kubermatic.io/v1",
@@ -500,23 +500,23 @@ func GenDefaultProject() *kubermaticapiv1.Project {
 		UID:        user.UID,
 		Name:       user.Name,
 	}
-	return GenProject("my-first-project", kubermaticapiv1.ProjectActive, DefaultCreationTimestamp(), oRef)
+	return GenProject("my-first-project", kubermaticv1.ProjectActive, DefaultCreationTimestamp(), oRef)
 }
 
 // GenBinding generates a binding
-func GenBinding(projectID, email, group string) *kubermaticapiv1.UserProjectBinding {
-	return &kubermaticapiv1.UserProjectBinding{
+func GenBinding(projectID, email, group string) *kubermaticv1.UserProjectBinding {
+	return &kubermaticv1.UserProjectBinding{
 		ObjectMeta: metav1.ObjectMeta{
 			Name: fmt.Sprintf("%s-%s-%s", projectID, email, group),
 			OwnerReferences: []metav1.OwnerReference{
 				{
-					APIVersion: kubermaticapiv1.SchemeGroupVersion.String(),
-					Kind:       kubermaticapiv1.ProjectKindName,
+					APIVersion: kubermaticv1.SchemeGroupVersion.String(),
+					Kind:       kubermaticv1.ProjectKindName,
 					Name:       projectID,
 				},
 			},
 		},
-		Spec: kubermaticapiv1.UserProjectBindingSpec{
+		Spec: kubermaticv1.UserProjectBindingSpec{
 			UserEmail: email,
 			ProjectID: projectID,
 			Group:     fmt.Sprintf("%s-%s", group, projectID),
@@ -525,7 +525,7 @@ func GenBinding(projectID, email, group string) *kubermaticapiv1.UserProjectBind
 }
 
 // GenDefaultOwnerBinding generates default owner binding
-func GenDefaultOwnerBinding() *kubermaticapiv1.UserProjectBinding {
+func GenDefaultOwnerBinding() *kubermaticv1.UserProjectBinding {
 	return GenBinding(GenDefaultProject().Name, GenDefaultUser().Spec.Email, "owners")
 }
 
@@ -543,8 +543,8 @@ func GenDefaultKubermaticObjects(objs ...runtime.Object) []runtime.Object {
 	return append(defaultsObjs, objs...)
 }
 
-func GenCluster(id string, name string, projectID string, creationTime time.Time) *kubermaticapiv1.Cluster {
-	return &kubermaticapiv1.Cluster{
+func GenCluster(id string, name string, projectID string, creationTime time.Time, modifiers ...func(*kubermaticv1.Cluster)) *kubermaticv1.Cluster {
+	cluster := &kubermaticv1.Cluster{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:   id,
 			Labels: map[string]string{"project-id": projectID},
@@ -552,23 +552,23 @@ func GenCluster(id string, name string, projectID string, creationTime time.Time
 				return metav1.NewTime(creationTime)
 			}(),
 		},
-		Spec: kubermaticapiv1.ClusterSpec{
-			Cloud: kubermaticapiv1.CloudSpec{
+		Spec: kubermaticv1.ClusterSpec{
+			Cloud: kubermaticv1.CloudSpec{
 				DatacenterName: "FakeDatacenter",
-				Fake:           &kubermaticapiv1.FakeCloudSpec{Token: "SecretToken"},
+				Fake:           &kubermaticv1.FakeCloudSpec{Token: "SecretToken"},
 			},
 			Version:           *semver.NewSemverOrDie("9.9.9"),
 			HumanReadableName: name,
 		},
-		Address: kubermaticapiv1.ClusterAddress{
+		Address: kubermaticv1.ClusterAddress{
 			AdminToken:   "drphc2.g4kq82pnlfqjqt65",
 			ExternalName: "w225mx4z66.asia-east1-a-1.cloud.kubermatic.io",
 			IP:           "35.194.142.199",
 			URL:          "https://w225mx4z66.asia-east1-a-1.cloud.kubermatic.io:31885",
 		},
-		Status: kubermaticapiv1.ClusterStatus{
-			Health: kubermaticapiv1.ClusterHealth{
-				ClusterHealthStatus: kubermaticapiv1.ClusterHealthStatus{
+		Status: kubermaticv1.ClusterStatus{
+			Health: kubermaticv1.ClusterHealth{
+				ClusterHealthStatus: kubermaticv1.ClusterHealthStatus{
 					Apiserver:         true,
 					Scheduler:         true,
 					Controller:        true,
@@ -578,9 +578,14 @@ func GenCluster(id string, name string, projectID string, creationTime time.Time
 			},
 		},
 	}
+
+	for _, modifier := range modifiers {
+		modifier(cluster)
+	}
+	return cluster
 }
 
-func GenDefaultCluster() *kubermaticapiv1.Cluster {
+func GenDefaultCluster() *kubermaticv1.Cluster {
 	return GenCluster(DefaultClusterID, DefaultClusterName, GenDefaultProject().Name, time.Date(2013, 02, 03, 19, 54, 0, 0, time.UTC))
 }
 
@@ -657,13 +662,13 @@ func GenDefaultSaToken(projectID, saID, name, id string) *v1.Secret {
 	secret.Data = map[string][]byte{}
 	secret.Data["token"] = []byte(TestFakeToken)
 	secret.Labels = map[string]string{
-		kubermaticapiv1.ProjectIDLabelKey: projectID,
-		"name":                            name,
+		kubermaticv1.ProjectIDLabelKey: projectID,
+		"name":                         name,
 	}
 	secret.OwnerReferences = []metav1.OwnerReference{
 		{
-			APIVersion: kubermaticapiv1.SchemeGroupVersion.String(),
-			Kind:       kubermaticapiv1.UserKindName,
+			APIVersion: kubermaticv1.SchemeGroupVersion.String(),
+			Kind:       kubermaticv1.UserKindName,
 			UID:        "",
 			Name:       saID,
 		},

--- a/api/pkg/handler/v1/cluster/cluster_test.go
+++ b/api/pkg/handler/v1/cluster/cluster_test.go
@@ -34,70 +34,59 @@ func init() {
 func TestDeleteClusterEndpointWithFinalizers(t *testing.T) {
 	t.Parallel()
 	testcases := []struct {
-		Name                   string
-		Body                   string
-		ExpectedResponse       string
-		HTTPStatus             int
-		ProjectToSync          string
-		ClusterToSync          string
-		ExistingKubermaticObjs []runtime.Object
-		ExistingAPIUser        *apiv1.User
-		HeaderParams           map[string]string
-		ExpectedUpdates        int
-		ExpectedFinalizers     []string
+		Name                    string
+		ExistingKubermaticObjs  []runtime.Object
+		HeaderParams            map[string]string
+		ExpectedFinalizers      []string
+		ExpectedNumberOfUpdates int
 	}{
 		{
-			Name:             "scenario 1: tests deletion of a cluster with finalizers",
-			Body:             ``,
-			ExpectedResponse: `{}`,
-			HTTPStatus:       http.StatusOK,
-			ProjectToSync:    test.GenDefaultProject().Name,
+			Name: "scenario 1: tests deletion of a cluster with finalizers",
 			ExistingKubermaticObjs: test.GenDefaultKubermaticObjects(
 				// add a cluster
-				test.GenCluster("clusterAbcID", "clusterAbc", test.GenDefaultProject().Name, time.Date(2013, 02, 03, 19, 54, 0, 0, time.UTC)),
+				test.GenCluster("clusterAbcID", "clusterAbc", test.GenDefaultProject().Name, time.Date(2013, 02, 03, 19, 54, 0, 0, time.UTC), func(cluster *kubermaticv1.Cluster) {
+					cluster.Finalizers = []string{"kubermatic.io/delete-nodes"}
+				}),
 			),
-			ClusterToSync:      "clusterAbcID",
-			ExistingAPIUser:    test.GenDefaultAPIUser(),
-			HeaderParams:       map[string]string{"DeleteVolumes": "true", "DeleteLoadBalancers": "true"},
-			ExpectedUpdates:    1,
-			ExpectedFinalizers: []string{"kubermatic.io/cleanup-in-cluster-pv", "kubermatic.io/cleanup-in-cluster-lb"},
+			HeaderParams:            map[string]string{"DeleteVolumes": "true", "DeleteLoadBalancers": "true"},
+			ExpectedFinalizers:      []string{"kubermatic.io/cleanup-in-cluster-pv", "kubermatic.io/cleanup-in-cluster-lb", "kubermatic.io/delete-nodes"},
+			ExpectedNumberOfUpdates: 1,
 		},
 		{
-			Name:             "scenario 2: tests deletion of a cluster with only volume finalizer",
-			Body:             ``,
-			ExpectedResponse: `{}`,
-			HTTPStatus:       http.StatusOK,
-			ProjectToSync:    test.GenDefaultProject().Name,
+			Name: "scenario 2: tests deletion of a cluster with only volume finalizer",
 			ExistingKubermaticObjs: test.GenDefaultKubermaticObjects(
 				// add a cluster
-				test.GenCluster("clusterAbcID", "clusterAbc", test.GenDefaultProject().Name, time.Date(2013, 02, 03, 19, 54, 0, 0, time.UTC)),
+				test.GenCluster("clusterAbcID", "clusterAbc", test.GenDefaultProject().Name, time.Date(2013, 02, 03, 19, 54, 0, 0, time.UTC), func(cluster *kubermaticv1.Cluster) {
+					cluster.Finalizers = []string{"kubermatic.io/delete-nodes"}
+				}),
 			),
-			ClusterToSync:      "clusterAbcID",
-			ExistingAPIUser:    test.GenDefaultAPIUser(),
-			HeaderParams:       map[string]string{"DeleteVolumes": "true", "DeleteLoadBalancers": "false"},
-			ExpectedUpdates:    1,
-			ExpectedFinalizers: []string{"kubermatic.io/cleanup-in-cluster-pv"},
+			HeaderParams:            map[string]string{"DeleteVolumes": "true", "DeleteLoadBalancers": "false"},
+			ExpectedFinalizers:      []string{"kubermatic.io/cleanup-in-cluster-pv", "kubermatic.io/delete-nodes"},
+			ExpectedNumberOfUpdates: 1,
 		},
 		{
-			Name:             "scenario 3: tests deletion of a cluster without finalizers",
-			Body:             ``,
-			ExpectedResponse: `{}`,
-			HTTPStatus:       http.StatusOK,
-			ProjectToSync:    test.GenDefaultProject().Name,
+			Name: "scenario 3: tests deletion of a cluster without finalizers",
 			ExistingKubermaticObjs: test.GenDefaultKubermaticObjects(
 				// add a cluster
 				test.GenCluster("clusterAbcID", "clusterAbc", test.GenDefaultProject().Name, time.Date(2013, 02, 03, 19, 54, 0, 0, time.UTC)),
 			),
-			ClusterToSync:   "clusterAbcID",
-			ExistingAPIUser: test.GenDefaultAPIUser(),
-			HeaderParams:    map[string]string{},
-			ExpectedUpdates: 0,
+			HeaderParams:       map[string]string{},
+			ExpectedFinalizers: []string{"kubermatic.io/cleanup-credentials-secrets"},
+		},
+		{
+			Name: "PV and LB finalizers do not get attached when cluster has no node delete finalizer",
+			ExistingKubermaticObjs: test.GenDefaultKubermaticObjects(
+				// add a cluster
+				test.GenCluster("clusterAbcID", "clusterAbc", test.GenDefaultProject().Name, time.Date(2013, 02, 03, 19, 54, 0, 0, time.UTC)),
+			),
+			HeaderParams: map[string]string{"DeleteVolumes": "true", "DeleteLoadBalancers": "true"},
 		},
 	}
+
 	for _, tc := range testcases {
 		t.Run(tc.Name, func(t *testing.T) {
 			// validate if deletion was successful
-			req := httptest.NewRequest("DELETE", fmt.Sprintf("/api/v1/projects/%s/dc/us-central1/clusters/%s", tc.ProjectToSync, tc.ClusterToSync), strings.NewReader(tc.Body))
+			req := httptest.NewRequest("DELETE", fmt.Sprintf("/api/v1/projects/%s/dc/us-central1/clusters/%s", test.GenDefaultProject().Name, "clusterAbcID"), strings.NewReader(""))
 
 			for k, v := range tc.HeaderParams {
 				req.Header.Add(k, v)
@@ -106,7 +95,7 @@ func TestDeleteClusterEndpointWithFinalizers(t *testing.T) {
 			res := httptest.NewRecorder()
 			kubermaticObj := []runtime.Object{}
 			kubermaticObj = append(kubermaticObj, tc.ExistingKubermaticObjs...)
-			ep, clientsSets, err := test.CreateTestEndpointAndGetClients(*tc.ExistingAPIUser, nil, []runtime.Object{}, []runtime.Object{}, kubermaticObj, nil, nil, hack.NewTestRouting)
+			ep, clientsSets, err := test.CreateTestEndpointAndGetClients(*test.GenDefaultAPIUser(), nil, []runtime.Object{}, []runtime.Object{}, kubermaticObj, nil, nil, hack.NewTestRouting)
 			if err != nil {
 				t.Fatalf("failed to create test endpoint due to %v", err)
 			}
@@ -115,10 +104,10 @@ func TestDeleteClusterEndpointWithFinalizers(t *testing.T) {
 
 			ep.ServeHTTP(res, req)
 
-			if res.Code != tc.HTTPStatus {
-				t.Fatalf("Expected HTTP status code %d, got %d: %s", tc.HTTPStatus, res.Code, res.Body.String())
+			if res.Code != http.StatusOK {
+				t.Fatalf("Expected HTTP status code %d, got %d: %s", http.StatusOK, res.Code, res.Body.String())
 			}
-			test.CompareWithResult(t, res, tc.ExpectedResponse)
+			test.CompareWithResult(t, res, "{}")
 
 			validatedActions := 0
 			for _, action := range kubermaticClient.Actions() {
@@ -131,7 +120,7 @@ func TestDeleteClusterEndpointWithFinalizers(t *testing.T) {
 					cluster := updateaction.GetObject().(*kubermaticv1.Cluster)
 					finalizers := cluster.GetFinalizers()
 					if len(finalizers) != len(tc.ExpectedFinalizers) {
-						t.Fatalf("not all finalizers were validated, expected to validate %d but validated only %d", len(tc.ExpectedFinalizers), len(finalizers))
+						t.Fatalf("expected %d finalizers, got %d", len(tc.ExpectedFinalizers), len(finalizers))
 					}
 
 					sort.Strings(finalizers)
@@ -143,8 +132,8 @@ func TestDeleteClusterEndpointWithFinalizers(t *testing.T) {
 					validatedActions = validatedActions + 1
 				}
 			}
-			if validatedActions != tc.ExpectedUpdates {
-				t.Fatalf("not all update action were validated, expected to validate %d but validated only %d", tc.ExpectedUpdates, validatedActions)
+			if validatedActions != tc.ExpectedNumberOfUpdates {
+				t.Fatalf("expected 1 update, got %d", validatedActions)
 			}
 		})
 	}


### PR DESCRIPTION
Chery-pick of  #3973

This PR changes the API do not add the LB and PV cleanup finalizer if
the usercluster APIServer was never up. We use the
node-deletion-finalizer to determine this, it gets only added after the
API came up.

**What this PR does / why we need it**:

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Documentation**:
<!-- Add links to the related documentation changes related to this pull request. E.g. the link to the kubermatic/docs pullrequest. -->

**Does this PR introduce a user-facing change?**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If  no release note is required, just write "NONE".
-->
```release-note
none
```

/assign @kdomanski 
