### PR TITLE
AWS: remove the remains of hardcoded AZ from datacenter and cluster configuration

### DIFF
--- a/api/cmd/kubermatic-api/swagger.json
+++ b/api/cmd/kubermatic-api/swagger.json
@@ -4402,10 +4402,6 @@
           "type": "string",
           "x-go-name": "AccessKeyID"
         },
-        "availabilityZone": {
-          "type": "string",
-          "x-go-name": "AvailabilityZone"
-        },
         "credentialsReference": {
           "$ref": "#/definitions/GlobalSecretKeySelector"
         },

--- a/api/hack/ci/ci-run-minimal-conformance-tests.sh
+++ b/api/hack/ci/ci-run-minimal-conformance-tests.sh
@@ -237,7 +237,6 @@ spec:
       spec:
         aws:
           region: eu-central-1
-          zone_character: a
     hetzner-nbg1:
       location: Nuremberg 1 DC 3
       country: DE

--- a/api/pkg/api/v1/types_test.go
+++ b/api/pkg/api/v1/types_test.go
@@ -107,7 +107,6 @@ func TestNewClusterSpec_MarshalJSON(t *testing.T) {
 						AccessKeyID:         valueToBeFiltered,
 						SecretAccessKey:     valueToBeFiltered,
 						SecurityGroupID:     "secuirtyGroupID",
-						AvailabilityZone:    "availablityZone",
 						InstanceProfileName: "instanceProfileName",
 						RoleName:            "roleName",
 						RouteTableID:        "routeTableID",

--- a/api/pkg/controller/openshift/resources/apiserver_deployment.go
+++ b/api/pkg/controller/openshift/resources/apiserver_deployment.go
@@ -403,7 +403,6 @@ func getAPIServerEnvVars(data resources.CredentialsData) ([]corev1.EnvVar, error
 		vars = append(vars, corev1.EnvVar{Name: "AWS_ACCESS_KEY_ID", Value: credentials.AWS.AccessKeyID})
 		vars = append(vars, corev1.EnvVar{Name: "AWS_SECRET_ACCESS_KEY", Value: credentials.AWS.SecretAccessKey})
 		vars = append(vars, corev1.EnvVar{Name: "AWS_VPC_ID", Value: cluster.Spec.Cloud.AWS.VPCID})
-		vars = append(vars, corev1.EnvVar{Name: "AWS_AVAILABILITY_ZONE", Value: cluster.Spec.Cloud.AWS.AvailabilityZone})
 	}
 	return vars, nil
 }

--- a/api/pkg/controller/openshift/resources/controller_manager_deployment.go
+++ b/api/pkg/controller/openshift/resources/controller_manager_deployment.go
@@ -286,7 +286,6 @@ func getControllerManagerEnvVars(data resources.CredentialsData) ([]corev1.EnvVa
 		vars = append(vars, corev1.EnvVar{Name: "AWS_ACCESS_KEY_ID", Value: credentials.AWS.AccessKeyID})
 		vars = append(vars, corev1.EnvVar{Name: "AWS_SECRET_ACCESS_KEY", Value: credentials.AWS.SecretAccessKey})
 		vars = append(vars, corev1.EnvVar{Name: "AWS_VPC_ID", Value: cluster.Spec.Cloud.AWS.VPCID})
-		vars = append(vars, corev1.EnvVar{Name: "AWS_AVAILABILITY_ZONE", Value: cluster.Spec.Cloud.AWS.AvailabilityZone})
 	}
 	return vars, nil
 }

--- a/api/pkg/crd/kubermatic/v1/cluster.go
+++ b/api/pkg/crd/kubermatic/v1/cluster.go
@@ -316,8 +316,6 @@ type AWSCloudSpec struct {
 	RouteTableID        string `json:"routeTableId"`
 	InstanceProfileName string `json:"instanceProfileName"`
 	SecurityGroupID     string `json:"securityGroupID"`
-
-	AvailabilityZone string `json:"availabilityZone"`
 }
 
 // OpenstackCloudSpec specifies access data to an OpenStack cloud.

--- a/api/pkg/crd/kubermatic/v1/datacenter.go
+++ b/api/pkg/crd/kubermatic/v1/datacenter.go
@@ -135,9 +135,8 @@ type DatacenterSpecVSphere struct {
 
 // DatacenterSpecAWS describes a aws datacenter
 type DatacenterSpecAWS struct {
-	Region        string    `json:"region"`
-	Images        ImageList `json:"images"`
-	ZoneCharacter string    `json:"zone_character"`
+	Region string    `json:"region"`
+	Images ImageList `json:"images"`
 }
 
 // DatacenterSpecBringYourOwn describes a datacenter our of bring your own nodes

--- a/api/pkg/provider/cloud/aws/provider.go
+++ b/api/pkg/provider/cloud/aws/provider.go
@@ -523,15 +523,6 @@ func (a *AmazonEC2) InitializeCloudProvider(cluster *kubermaticv1.Cluster, updat
 		}
 	}
 
-	if cluster.Spec.Cloud.AWS.AvailabilityZone == "" {
-		cluster, err = update(cluster.Name, func(cluster *kubermaticv1.Cluster) {
-			cluster.Spec.Cloud.AWS.AvailabilityZone = a.dc.Region + a.dc.ZoneCharacter
-		})
-		if err != nil {
-			return nil, err
-		}
-	}
-
 	if cluster.Spec.Cloud.AWS.SecurityGroupID == "" {
 		securityGroupID, err := createSecurityGroup(client, cluster.Spec.Cloud.AWS.VPCID, cluster.Name)
 		if err != nil {

--- a/api/pkg/resources/apiserver/deployment.go
+++ b/api/pkg/resources/apiserver/deployment.go
@@ -485,7 +485,6 @@ func getEnvVars(data resources.CredentialsData) ([]corev1.EnvVar, error) {
 		vars = append(vars, corev1.EnvVar{Name: "AWS_ACCESS_KEY_ID", Value: credentials.AWS.AccessKeyID})
 		vars = append(vars, corev1.EnvVar{Name: "AWS_SECRET_ACCESS_KEY", Value: credentials.AWS.SecretAccessKey})
 		vars = append(vars, corev1.EnvVar{Name: "AWS_VPC_ID", Value: cluster.Spec.Cloud.AWS.VPCID})
-		vars = append(vars, corev1.EnvVar{Name: "AWS_AVAILABILITY_ZONE", Value: cluster.Spec.Cloud.AWS.AvailabilityZone})
 	}
 	return vars, nil
 }

--- a/api/pkg/resources/controllermanager/deployment.go
+++ b/api/pkg/resources/controllermanager/deployment.go
@@ -356,7 +356,6 @@ func getEnvVars(data resources.CredentialsData) ([]corev1.EnvVar, error) {
 		vars = append(vars, corev1.EnvVar{Name: "AWS_ACCESS_KEY_ID", Value: credentials.AWS.AccessKeyID})
 		vars = append(vars, corev1.EnvVar{Name: "AWS_SECRET_ACCESS_KEY", Value: credentials.AWS.SecretAccessKey})
 		vars = append(vars, corev1.EnvVar{Name: "AWS_VPC_ID", Value: cluster.Spec.Cloud.AWS.VPCID})
-		vars = append(vars, corev1.EnvVar{Name: "AWS_AVAILABILITY_ZONE", Value: cluster.Spec.Cloud.AWS.AvailabilityZone})
 	}
 	if cluster.Spec.Cloud.GCP != nil {
 		vars = append(vars, corev1.EnvVar{Name: "GOOGLE_APPLICATION_CREDENTIALS", Value: "/etc/gcp/serviceAccount"})

--- a/api/pkg/resources/machine/common.go
+++ b/api/pkg/resources/machine/common.go
@@ -50,20 +50,13 @@ func getAWSProviderSpec(c *kubermaticv1.Cluster, nodeSpec apiv1.NodeSpec, dc *ku
 		ami = nodeSpec.Cloud.AWS.AMI
 	}
 
-	// TODO fallback to cluster-hardcoded AZ for interim compatibility.
-	// Shall be removed after the transition to multi-AZ is complete.
-	availabilityZone := nodeSpec.Cloud.AWS.AvailabilityZone
-	if availabilityZone == "" {
-		availabilityZone = dc.Spec.AWS.Region + dc.Spec.AWS.ZoneCharacter
-	}
-
 	config := aws.RawConfig{
 		// If the node spec doesn't provide a subnet ID, AWS will just pick the AZ's default subnet.
 		SubnetID:         providerconfig.ConfigVarString{Value: nodeSpec.Cloud.AWS.SubnetID},
 		VpcID:            providerconfig.ConfigVarString{Value: c.Spec.Cloud.AWS.VPCID},
 		SecurityGroupIDs: []providerconfig.ConfigVarString{{Value: c.Spec.Cloud.AWS.SecurityGroupID}},
 		Region:           providerconfig.ConfigVarString{Value: dc.Spec.AWS.Region},
-		AvailabilityZone: providerconfig.ConfigVarString{Value: availabilityZone},
+		AvailabilityZone: providerconfig.ConfigVarString{Value: nodeSpec.Cloud.AWS.AvailabilityZone},
 		InstanceProfile:  providerconfig.ConfigVarString{Value: c.Spec.Cloud.AWS.InstanceProfileName},
 		InstanceType:     providerconfig.ConfigVarString{Value: nodeSpec.Cloud.AWS.InstanceType},
 		DiskType:         providerconfig.ConfigVarString{Value: nodeSpec.Cloud.AWS.VolumeType},

--- a/api/pkg/resources/test/fixtures/deployment-aws-1.10.0-apiserver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-aws-1.10.0-apiserver.yaml
@@ -230,8 +230,6 @@ spec:
           value: aws-secret-access-key
         - name: AWS_VPC_ID
           value: aws-vpn-id
-        - name: AWS_AVAILABILITY_ZONE
-          value: aws-availability-zone
         image: gcr.io/google_containers/hyperkube-amd64:v1.10.0
         livenessProbe:
           failureThreshold: 8

--- a/api/pkg/resources/test/fixtures/deployment-aws-1.10.0-controller-manager.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-aws-1.10.0-controller-manager.yaml
@@ -121,8 +121,6 @@ spec:
           value: aws-secret-access-key
         - name: AWS_VPC_ID
           value: aws-vpn-id
-        - name: AWS_AVAILABILITY_ZONE
-          value: aws-availability-zone
         image: gcr.io/google_containers/hyperkube-amd64:v1.10.0
         livenessProbe:
           failureThreshold: 8

--- a/api/pkg/resources/test/fixtures/deployment-aws-1.10.6-apiserver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-aws-1.10.6-apiserver.yaml
@@ -230,8 +230,6 @@ spec:
           value: aws-secret-access-key
         - name: AWS_VPC_ID
           value: aws-vpn-id
-        - name: AWS_AVAILABILITY_ZONE
-          value: aws-availability-zone
         image: gcr.io/google_containers/hyperkube-amd64:v1.10.6
         livenessProbe:
           failureThreshold: 8

--- a/api/pkg/resources/test/fixtures/deployment-aws-1.10.6-controller-manager.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-aws-1.10.6-controller-manager.yaml
@@ -121,8 +121,6 @@ spec:
           value: aws-secret-access-key
         - name: AWS_VPC_ID
           value: aws-vpn-id
-        - name: AWS_AVAILABILITY_ZONE
-          value: aws-availability-zone
         image: gcr.io/google_containers/hyperkube-amd64:v1.10.6
         livenessProbe:
           failureThreshold: 8

--- a/api/pkg/resources/test/fixtures/deployment-aws-1.11.0-apiserver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-aws-1.11.0-apiserver.yaml
@@ -228,8 +228,6 @@ spec:
           value: aws-secret-access-key
         - name: AWS_VPC_ID
           value: aws-vpn-id
-        - name: AWS_AVAILABILITY_ZONE
-          value: aws-availability-zone
         image: gcr.io/google_containers/hyperkube-amd64:v1.11.0
         livenessProbe:
           failureThreshold: 8

--- a/api/pkg/resources/test/fixtures/deployment-aws-1.11.0-controller-manager.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-aws-1.11.0-controller-manager.yaml
@@ -121,8 +121,6 @@ spec:
           value: aws-secret-access-key
         - name: AWS_VPC_ID
           value: aws-vpn-id
-        - name: AWS_AVAILABILITY_ZONE
-          value: aws-availability-zone
         image: gcr.io/google_containers/hyperkube-amd64:v1.11.0
         livenessProbe:
           failureThreshold: 8

--- a/api/pkg/resources/test/fixtures/deployment-aws-1.11.1-apiserver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-aws-1.11.1-apiserver.yaml
@@ -228,8 +228,6 @@ spec:
           value: aws-secret-access-key
         - name: AWS_VPC_ID
           value: aws-vpn-id
-        - name: AWS_AVAILABILITY_ZONE
-          value: aws-availability-zone
         image: gcr.io/google_containers/hyperkube-amd64:v1.11.1
         livenessProbe:
           failureThreshold: 8

--- a/api/pkg/resources/test/fixtures/deployment-aws-1.11.1-controller-manager.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-aws-1.11.1-controller-manager.yaml
@@ -121,8 +121,6 @@ spec:
           value: aws-secret-access-key
         - name: AWS_VPC_ID
           value: aws-vpn-id
-        - name: AWS_AVAILABILITY_ZONE
-          value: aws-availability-zone
         image: gcr.io/google_containers/hyperkube-amd64:v1.11.1
         livenessProbe:
           failureThreshold: 8

--- a/api/pkg/resources/test/fixtures/deployment-aws-1.12.0-apiserver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-aws-1.12.0-apiserver.yaml
@@ -228,8 +228,6 @@ spec:
           value: aws-secret-access-key
         - name: AWS_VPC_ID
           value: aws-vpn-id
-        - name: AWS_AVAILABILITY_ZONE
-          value: aws-availability-zone
         image: gcr.io/google_containers/hyperkube-amd64:v1.12.0
         livenessProbe:
           failureThreshold: 8

--- a/api/pkg/resources/test/fixtures/deployment-aws-1.12.0-controller-manager.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-aws-1.12.0-controller-manager.yaml
@@ -121,8 +121,6 @@ spec:
           value: aws-secret-access-key
         - name: AWS_VPC_ID
           value: aws-vpn-id
-        - name: AWS_AVAILABILITY_ZONE
-          value: aws-availability-zone
         image: gcr.io/google_containers/hyperkube-amd64:v1.12.0
         livenessProbe:
           failureThreshold: 8

--- a/api/pkg/resources/test/fixtures/deployment-aws-1.13.0-apiserver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-aws-1.13.0-apiserver.yaml
@@ -228,8 +228,6 @@ spec:
           value: aws-secret-access-key
         - name: AWS_VPC_ID
           value: aws-vpn-id
-        - name: AWS_AVAILABILITY_ZONE
-          value: aws-availability-zone
         image: gcr.io/google_containers/hyperkube-amd64:v1.13.0
         livenessProbe:
           failureThreshold: 8

--- a/api/pkg/resources/test/fixtures/deployment-aws-1.13.0-controller-manager.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-aws-1.13.0-controller-manager.yaml
@@ -121,8 +121,6 @@ spec:
           value: aws-secret-access-key
         - name: AWS_VPC_ID
           value: aws-vpn-id
-        - name: AWS_AVAILABILITY_ZONE
-          value: aws-availability-zone
         image: gcr.io/google_containers/hyperkube-amd64:v1.13.0
         livenessProbe:
           failureThreshold: 8

--- a/api/pkg/resources/test/fixtures/machine-aws.yaml
+++ b/api/pkg/resources/test/fixtures/machine-aws.yaml
@@ -12,7 +12,7 @@ spec:
         accessKeyId: ""
         ami: aws-ami
         assignPublicIP: null
-        availabilityZone: fra1aws-zone-character
+        availabilityZone: ""
         diskSize: 25
         diskType: standard
         instanceProfile: aws-instance-profile-name

--- a/api/pkg/resources/test/load_files_test.go
+++ b/api/pkg/resources/test/load_files_test.go
@@ -134,7 +134,6 @@ func TestLoadFiles(t *testing.T) {
 			AWS: &kubermaticv1.AWSCloudSpec{
 				AccessKeyID:         "aws-access-key-id",
 				SecretAccessKey:     "aws-secret-access-key",
-				AvailabilityZone:    "aws-availability-zone",
 				InstanceProfileName: "aws-instance-profile-name",
 				RoleName:            "aws-role-name",
 				RouteTableID:        "aws-route-table-id",
@@ -180,8 +179,7 @@ func TestLoadFiles(t *testing.T) {
 					providerconfig.OperatingSystemCentOS: "centos-ami",
 					providerconfig.OperatingSystemCoreos: "coreos-ami",
 				},
-				Region:        "us-central1",
-				ZoneCharacter: "a",
+				Region: "us-central1",
 			},
 			Digitalocean: &kubermaticv1.DatacenterSpecDigitalocean{
 				Region: "fra1",
@@ -765,7 +763,6 @@ func TestExecute(t *testing.T) {
 								RouteTableID:        "aws-route-table-id",
 								InstanceProfileName: "aws-instance-profile-name",
 								SecurityGroupID:     "aws-security-group-id",
-								AvailabilityZone:    "aws-availability-zone",
 							},
 						},
 					},
@@ -809,7 +806,6 @@ func TestExecute(t *testing.T) {
 								providerconfig.OperatingSystemCentOS: "centos-ami",
 								providerconfig.OperatingSystemCoreos: "coreos-ami",
 							},
-							ZoneCharacter: "aws-zone-character",
 						},
 					},
 				},


### PR DESCRIPTION
**What this PR does / why we need it**:
It removes useless code and data field related to how AWS clusters behaved before we had multiple AZ support.

```release-note
ACTION REQUIRED: the `zone_character` field must be removed from all AWS datacenters in `datacenters.yaml`
```
