### PR TITLE
Use Seed CRD for the conformance-tester

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -23,9 +23,7 @@ linters:
 
 issues:
   exclude:
-  - cyclomatic complexity 32 of func `main` is high
-  - cyclomatic complexity 33 of func `main` is high
-  - cyclomatic complexity 43 of func `main` is high
+  - cyclomatic complexity [0-9]+ of func `main` is high
   - cyclomatic complexity 37 of func `migrateToProject` is high
   - cyclomatic complexity 33 of func `ValidateCloudSpec` is high
   - cyclomatic complexity 38 of func `migrateToProject` is high


### PR DESCRIPTION
**What this PR does / why we need it**:

Makes the conformance tester use the seed crd instead of the `datacenters.yaml` file

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Documentation**:
<!-- Add links to the related documentation changes related to this pull request. E.g. the link to the kubermatic/docs pullrequest. -->

**Does this PR introduce a user-facing change?**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If  no release note is required, just write "NONE".
-->
```release-note
none
```

/assign @kdomanski 
