### PR TITLE
Use one config file for the kubernetes specific logging

### DIFF
--- a/config/logging/fluentbit/Chart.yaml
+++ b/config/logging/fluentbit/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: fluentbit
-version: 1.0.4
+version: 1.0.5
 appVersion: 1.1.2
 description: Helm chart to install fluent-bit as a log shipper DaemonSet.
 keywords:

--- a/config/logging/fluentbit/templates/configmap.yaml
+++ b/config/logging/fluentbit/templates/configmap.yaml
@@ -19,11 +19,10 @@ data:
         HTTP_Listen   0.0.0.0
         HTTP_Port     2020
 
-    @INCLUDE input-kubernetes.conf
-    @INCLUDE filter-kubernetes.conf
+    @INCLUDE kubernetes.conf
     @INCLUDE outputs.conf
 
-  input-kubernetes.conf: |
+  kubernetes.conf: |
     [INPUT]
         Name              tail
         Tag               kube.*
@@ -34,7 +33,6 @@ data:
         Skip_Long_Lines   On
         Refresh_Interval  10
 
-  filter-kubernetes.conf: |
     [FILTER]
         Name                kubernetes
         Match               kube.*


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR just moves the 2 kubernetes specific config files into one for readability.

**Does this PR introduce a user-facing change?**:
```release-note
NONE
```
