### PR TITLE
Add missing fluentbit mounts for the systemd plugin

### DIFF
--- a/config/logging/fluentbit/Chart.yaml
+++ b/config/logging/fluentbit/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: fluentbit
-version: 1.1.0
+version: 1.1.1
 appVersion: 1.1.2
 description: Helm chart to install fluent-bit as a log shipper DaemonSet.
 keywords:

--- a/config/logging/fluentbit/templates/daemonset.yaml
+++ b/config/logging/fluentbit/templates/daemonset.yaml
@@ -43,8 +43,13 @@ spec:
         - name: FLUENT_ELASTICSEARCH_PORT
           value: '9200'
         volumeMounts:
+        - name: etcmachineid
+          mountPath: /etc/machine-id
+          readOnly: true
         - name: varlog
           mountPath: /var/log
+        - name: runlogjournal
+          mountPath: /run/log/journal
         - name: varlibdockercontainers
           mountPath: /var/lib/docker/containers
           readOnly: true
@@ -54,9 +59,16 @@ spec:
 {{ toYaml .Values.logging.fluentbit.resources | indent 10 }}
       terminationGracePeriodSeconds: 10
       volumes:
+      - name: etcmachineid
+        hostPath:
+          path: /etc/machine-id
+          type: File
       - name: varlog
         hostPath:
           path: /var/log
+      - name: runlogjournal
+        hostPath:
+          path: /run/log/journal
       - name: varlibdockercontainers
         hostPath:
           path: /var/lib/docker/containers


### PR DESCRIPTION
**What this PR does / why we need it**:
This adds missing fluentbit mounts for the systemd plugin.
Fix for changes made in https://github.com/kubermatic/kubermatic/pull/4001

**Does this PR introduce a user-facing change?**:
```release-note
NONE
```
