### PR TITLE
FluentBit: Collect kernel messages

### DIFF
--- a/config/logging/fluentbit/Chart.yaml
+++ b/config/logging/fluentbit/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: fluentbit
-version: 1.1.1
+version: 1.2.0
 appVersion: 1.1.2
 description: Helm chart to install fluent-bit as a log shipper DaemonSet.
 keywords:

--- a/config/logging/fluentbit/templates/configmap.yaml
+++ b/config/logging/fluentbit/templates/configmap.yaml
@@ -23,6 +23,9 @@ data:
     {{- if .Values.logging.fluentbit.configuration.collectSystemd }}
     @INCLUDE systemd.conf
     {{- end }}
+    {{- if .Values.logging.fluentbit.configuration.collectKernelMessages }}
+    @INCLUDE kmesg.conf
+    {{- end }}
     @INCLUDE outputs.conf
 
   kubernetes.conf: |
@@ -116,6 +119,36 @@ data:
         Name    grep
         Match systemd.*
         Exclude log libcontainer.*?test_default\.slice
+
+  kmesg.conf: |
+    ############################################################
+    # kmesg
+    ############################################################
+    [INPUT]
+        Name   kmsg
+        Tag    kmsg
+
+    # Only keep the relevant fields
+    [FILTER]
+        Name record_modifier
+        Match kmsg
+        Whitelist_key msg
+        Whitelist_key priority
+
+    [FILTER]
+        Name modify
+        Match kmsg
+        Set source kmsg
+        Rename msg log
+        Rename priority _NEST_priority
+
+    [FILTER]
+        Name nest
+        Match kmesg
+        Operation nest
+        Wildcard _NEST_*
+        Nest_under kmesg
+        Remove_prefix _NEST_
 
   outputs.conf: |
 {{- range .Values.logging.fluentbit.configuration.outputs }}

--- a/config/logging/fluentbit/templates/daemonset.yaml
+++ b/config/logging/fluentbit/templates/daemonset.yaml
@@ -60,9 +60,11 @@ spec:
           readOnly: true
         - name: config
           mountPath: /fluent-bit/etc/
+        {{- if .Values.logging.fluentbit.configuration.collectKernelMessages }}
         - name: kmsg
           mountPath: /dev/kmsg
           readOnly: true
+        {{- end }}
         resources:
 {{ toYaml .Values.logging.fluentbit.resources | indent 10 }}
       terminationGracePeriodSeconds: 10
@@ -83,9 +85,11 @@ spec:
       - name: config
         configMap:
           name: fluent-bit
+      {{- if .Values.logging.fluentbit.configuration.collectKernelMessages }}
       - name: kmsg
         hostPath:
           path: /dev/kmsg
+      {{- end }}
       nodeSelector:
 {{ toYaml .Values.logging.fluentbit.nodeSelector | indent 8 }}
       affinity:

--- a/config/logging/fluentbit/templates/daemonset.yaml
+++ b/config/logging/fluentbit/templates/daemonset.yaml
@@ -35,9 +35,11 @@ spec:
       - name: fluent-bit
         image: '{{ .Values.logging.fluentbit.image.repository }}:{{ .Values.logging.fluentbit.image.tag }}'
         imagePullPolicy: {{ .Values.logging.fluentbit.image.pullPolicy }}
+        {{- if .Values.logging.fluentbit.configuration.collectKernelMessages }}
         securityContext:
           # Required to read kmesg. TODO: Find decent capabilities
           privileged: true
+        {{- end }}
         ports:
         - containerPort: 2020
         env:

--- a/config/logging/fluentbit/templates/daemonset.yaml
+++ b/config/logging/fluentbit/templates/daemonset.yaml
@@ -35,6 +35,9 @@ spec:
       - name: fluent-bit
         image: '{{ .Values.logging.fluentbit.image.repository }}:{{ .Values.logging.fluentbit.image.tag }}'
         imagePullPolicy: {{ .Values.logging.fluentbit.image.pullPolicy }}
+        securityContext:
+          # Required to read kmesg. TODO: Find decent capabilities
+          privileged: true
         ports:
         - containerPort: 2020
         env:
@@ -55,6 +58,9 @@ spec:
           readOnly: true
         - name: config
           mountPath: /fluent-bit/etc/
+        - name: kmsg
+          mountPath: /dev/kmsg
+          readOnly: true
         resources:
 {{ toYaml .Values.logging.fluentbit.resources | indent 10 }}
       terminationGracePeriodSeconds: 10
@@ -75,6 +81,9 @@ spec:
       - name: config
         configMap:
           name: fluent-bit
+      - name: kmsg
+        hostPath:
+          path: /dev/kmsg
       nodeSelector:
 {{ toYaml .Values.logging.fluentbit.nodeSelector | indent 8 }}
       affinity:

--- a/config/logging/fluentbit/values.yaml
+++ b/config/logging/fluentbit/values.yaml
@@ -7,6 +7,7 @@ logging:
     configuration:
       containerRuntimeParser: docker
       collectSystemd: false
+      collectKernelMessages: false
       outputs:
       - |
         Name            es


### PR DESCRIPTION
**What this PR does / why we need it**:
This adds the kmesg plugin to the fluentbit chart.

**Does this PR introduce a user-facing change?**:
```release-note
FluentBit can now collect the kernel messages
```
