### PR TITLE
FluentBit: Always set the node name in logs

### DIFF
--- a/config/logging/fluentbit/Chart.yaml
+++ b/config/logging/fluentbit/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: fluentbit
-version: 1.2.0
+version: 1.2.1
 appVersion: 1.1.2
 description: Helm chart to install fluent-bit as a log shipper DaemonSet.
 keywords:

--- a/config/logging/fluentbit/templates/configmap.yaml
+++ b/config/logging/fluentbit/templates/configmap.yaml
@@ -26,6 +26,13 @@ data:
     {{- if .Values.logging.fluentbit.configuration.collectKernelMessages }}
     @INCLUDE kmesg.conf
     {{- end }}
+
+    # We attach the node name to each log line
+    [FILTER]
+        Name modify
+        Match *
+        Set node ${NODE_NAME}
+
     @INCLUDE outputs.conf
 
   kubernetes.conf: |

--- a/config/logging/fluentbit/templates/daemonset.yaml
+++ b/config/logging/fluentbit/templates/daemonset.yaml
@@ -47,6 +47,11 @@ spec:
           value: es-data
         - name: FLUENT_ELASTICSEARCH_PORT
           value: '9200'
+        # We attach the node name to each log line
+        - name: NODE_NAME
+          valueFrom:
+            fieldRef:
+              fieldPath: spec.nodeName
         volumeMounts:
         - name: etcmachineid
           mountPath: /etc/machine-id


### PR DESCRIPTION
**What this PR does / why we need it**:
This change ensures that we always set the node name on logs.
This is especially useful if we collect logs from multiple sources (kmesg, journald).

**Does this PR introduce a user-facing change?**:
```release-note
FluentBit now always sets the node name in logs
```
