### PR TITLE
conformance-tests: use zap logger

### DIFF
--- a/api/cmd/conformance-tests/custom_tests.go
+++ b/api/cmd/conformance-tests/custom_tests.go
@@ -9,7 +9,7 @@ import (
 	"strings"
 	"time"
 
-	"github.com/sirupsen/logrus"
+	"go.uber.org/zap"
 
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
@@ -21,7 +21,7 @@ import (
 	ctrlruntimeclient "sigs.k8s.io/controller-runtime/pkg/client"
 )
 
-func (r *testRunner) testPVC(log *logrus.Entry, userClusterClient ctrlruntimeclient.Client, attempt int) error {
+func (r *testRunner) testPVC(log *zap.SugaredLogger, userClusterClient ctrlruntimeclient.Client, attempt int) error {
 	log.Info("Testing support for PVC's...")
 
 	ns := &corev1.Namespace{
@@ -125,7 +125,7 @@ func (r *testRunner) testPVC(log *logrus.Entry, userClusterClient ctrlruntimecli
 	return nil
 }
 
-func (r *testRunner) testLB(log *logrus.Entry, userClusterClient ctrlruntimeclient.Client, attempt int) error {
+func (r *testRunner) testLB(log *zap.SugaredLogger, userClusterClient ctrlruntimeclient.Client, attempt int) error {
 	log.Info("Testing support for LB's...")
 
 	ns := &corev1.Namespace{

--- a/api/cmd/conformance-tests/usercluster_controller_tests.go
+++ b/api/cmd/conformance-tests/usercluster_controller_tests.go
@@ -4,7 +4,7 @@ import (
 	"context"
 	"fmt"
 
-	"github.com/sirupsen/logrus"
+	"go.uber.org/zap"
 	"k8s.io/apimachinery/pkg/types"
 
 	"github.com/kubermatic/kubermatic/api/pkg/controller/rbac-user-cluster"
@@ -17,7 +17,7 @@ import (
 	ctrlruntimeclient "sigs.k8s.io/controller-runtime/pkg/client"
 )
 
-func (r *testRunner) testUserclusterControllerRBAC(log *logrus.Entry, cluster *kubermaticv1.Cluster, userClusterClient, seedClusterClient ctrlruntimeclient.Client) error {
+func (r *testRunner) testUserclusterControllerRBAC(log *zap.SugaredLogger, cluster *kubermaticv1.Cluster, userClusterClient, seedClusterClient ctrlruntimeclient.Client) error {
 	log.Info("Testing user cluster RBAC controller")
 	ctx := context.Background()
 	clusterNamespace := fmt.Sprintf("cluster-%s", cluster.Name)


### PR DESCRIPTION
To ensure that we delete the cluster in conformance tests (https://github.com/kubermatic/kubermatic/issues/3987), we'll need to use `CleanupCluster`, which needs the zap logger:

https://github.com/kubermatic/kubermatic/blob/15598e6f69881c52327993a5313498aeddec4018/api/pkg/clusterdeletion/deletion.go#L35

**Does this PR introduce a user-facing change?**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If  no release note is required, just write "NONE".
-->
```release-note
NONE
```

/cc @alvaroaleman @mrIncompetent 