### PR TITLE
FluentBit: set the source field for the kubernetes input

### DIFF
--- a/config/logging/fluentbit/Chart.yaml
+++ b/config/logging/fluentbit/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: fluentbit
-version: 1.2.1
+version: 1.2.2
 appVersion: 1.1.2
 description: Helm chart to install fluent-bit as a log shipper DaemonSet.
 keywords:

--- a/config/logging/fluentbit/templates/configmap.yaml
+++ b/config/logging/fluentbit/templates/configmap.yaml
@@ -55,6 +55,12 @@ data:
         K8S-Logging.Parser  On
         Annotations         Off
 
+    # Set the source field so we can later check identify from which input the data was coming
+    [FILTER]
+        Name modify
+        Match kube.*
+        Set source kubernetes
+
   systemd.conf: |
     ############################################################
     # Systemd / Journald


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR ensures we set the `source` field for logs coming from containers.

**Does this PR introduce a user-facing change?**:
```release-note
NONE
```
