### PR TITLE
Return SSH key when assigning it to cluster

### DIFF
--- a/api/cmd/kubermatic-api/swagger.json
+++ b/api/cmd/kubermatic-api/swagger.json
@@ -2768,7 +2768,10 @@
         ],
         "responses": {
           "201": {
-            "$ref": "#/responses/empty"
+            "description": "SSHKey",
+            "schema": {
+              "$ref": "#/definitions/SSHKey"
+            }
           },
           "401": {
             "$ref": "#/responses/empty"

--- a/api/pkg/api/v1/types.go
+++ b/api/pkg/api/v1/types.go
@@ -2,6 +2,7 @@ package v1
 
 import (
 	"encoding/json"
+
 	"github.com/Masterminds/semver"
 
 	kubermaticv1 "github.com/kubermatic/kubermatic/api/pkg/crd/kubermatic/v1"

--- a/api/pkg/handler/routes_v1.go
+++ b/api/pkg/handler/routes_v1.go
@@ -1319,7 +1319,7 @@ func (r Routing) getClusterHealth() http.Handler {
 //
 //     Responses:
 //       default: errorResponse
-//       201: empty
+//       201: SSHKey
 //       401: empty
 //       403: empty
 func (r Routing) assignSSHKeyToCluster() http.Handler {

--- a/api/pkg/handler/v1/cluster/cluster.go
+++ b/api/pkg/handler/v1/cluster/cluster.go
@@ -527,14 +527,6 @@ func AssignSSHKeyEndpoint(sshKeyProvider provider.SSHKeyProvider, projectProvide
 		if err != nil {
 			return nil, common.KubernetesErrorToHTTPError(err)
 		}
-		if sshKey.IsUsedByCluster(req.ClusterID) {
-			return nil, nil
-		}
-		sshKey.AddToCluster(req.ClusterID)
-		_, err = sshKeyProvider.Update(userInfo, sshKey)
-		if err != nil {
-			return nil, common.KubernetesErrorToHTTPError(err)
-		}
 
 		apiKey := apiv1.SSHKey{
 			ObjectMeta: apiv1.ObjectMeta{
@@ -546,6 +538,15 @@ func AssignSSHKeyEndpoint(sshKeyProvider provider.SSHKeyProvider, projectProvide
 				Fingerprint: sshKey.Spec.Fingerprint,
 				PublicKey:   sshKey.Spec.PublicKey,
 			},
+		}
+
+		if sshKey.IsUsedByCluster(req.ClusterID) {
+			return apiKey, nil
+		}
+		sshKey.AddToCluster(req.ClusterID)
+		_, err = sshKeyProvider.Update(userInfo, sshKey)
+		if err != nil {
+			return nil, common.KubernetesErrorToHTTPError(err)
 		}
 
 		return apiKey, nil

--- a/api/pkg/handler/v1/cluster/cluster.go
+++ b/api/pkg/handler/v1/cluster/cluster.go
@@ -534,10 +534,6 @@ func AssignSSHKeyEndpoint(sshKeyProvider provider.SSHKeyProvider, projectProvide
 				Name:              sshKey.Spec.Name,
 				CreationTimestamp: apiv1.NewTime(sshKey.CreationTimestamp.Time),
 			},
-			Spec: apiv1.SSHKeySpec{
-				Fingerprint: sshKey.Spec.Fingerprint,
-				PublicKey:   sshKey.Spec.PublicKey,
-			},
 		}
 
 		if sshKey.IsUsedByCluster(req.ClusterID) {

--- a/api/pkg/handler/v1/cluster/cluster.go
+++ b/api/pkg/handler/v1/cluster/cluster.go
@@ -536,7 +536,19 @@ func AssignSSHKeyEndpoint(sshKeyProvider provider.SSHKeyProvider, projectProvide
 			return nil, common.KubernetesErrorToHTTPError(err)
 		}
 
-		return nil, nil
+		apiKey := apiv1.SSHKey{
+			ObjectMeta: apiv1.ObjectMeta{
+				ID:                sshKey.Name,
+				Name:              sshKey.Spec.Name,
+				CreationTimestamp: apiv1.NewTime(sshKey.CreationTimestamp.Time),
+			},
+			Spec: apiv1.SSHKeySpec{
+				Fingerprint: sshKey.Spec.Fingerprint,
+				PublicKey:   sshKey.Spec.PublicKey,
+			},
+		}
+
+		return apiKey, nil
 	}
 }
 

--- a/api/pkg/handler/v1/cluster/cluster_test.go
+++ b/api/pkg/handler/v1/cluster/cluster_test.go
@@ -524,7 +524,7 @@ func TestAssignSSHKeyToClusterEndpoint(t *testing.T) {
 		{
 			Name:             "scenario 1: an ssh key that belongs to the given project is assigned to the cluster",
 			SSHKeyID:         "key-c08aa5c7abf34504f18552846485267d-yafn",
-			ExpectedResponse: `{"id":"key-c08aa5c7abf34504f18552846485267d-yafn","name":"yafn","creationTimestamp":"0001-01-01T00:00:00Z","spec":{"fingerprint":"","publicKey":""}}`,
+			ExpectedResponse: `{"id":"key-c08aa5c7abf34504f18552846485267d-yafn","name":"","creationTimestamp":"0001-01-01T00:00:00Z","spec":{"fingerprint":"","publicKey":""}}`,
 			HTTPStatus:       http.StatusCreated,
 			ProjectToSync:    test.GenDefaultProject().Name,
 			ExistingAPIUser:  test.GenDefaultAPIUser(),
@@ -808,11 +808,11 @@ func TestGetClusterHealth(t *testing.T) {
 					cluster := test.GenCluster("keen-snyder", "clusterAbc", test.GenDefaultProject().Name, time.Date(2013, 02, 03, 19, 54, 0, 0, time.UTC))
 					cluster.Status.ExtendedHealth = kubermaticv1.ExtendedClusterHealth{
 
-						Apiserver:         kubermaticv1.HealthStatusUp,
-						Scheduler:         kubermaticv1.HealthStatusDown,
-						Controller:        kubermaticv1.HealthStatusUp,
-						MachineController: kubermaticv1.HealthStatusDown,
-						Etcd:              kubermaticv1.HealthStatusUp,
+						Apiserver:                    kubermaticv1.HealthStatusUp,
+						Scheduler:                    kubermaticv1.HealthStatusDown,
+						Controller:                   kubermaticv1.HealthStatusUp,
+						MachineController:            kubermaticv1.HealthStatusDown,
+						Etcd:                         kubermaticv1.HealthStatusUp,
 						CloudProviderInfrastructure:  kubermaticv1.HealthStatusUp,
 						UserClusterControllerManager: kubermaticv1.HealthStatusUp,
 					}

--- a/api/pkg/handler/v1/cluster/cluster_test.go
+++ b/api/pkg/handler/v1/cluster/cluster_test.go
@@ -524,7 +524,7 @@ func TestAssignSSHKeyToClusterEndpoint(t *testing.T) {
 		{
 			Name:             "scenario 1: an ssh key that belongs to the given project is assigned to the cluster",
 			SSHKeyID:         "key-c08aa5c7abf34504f18552846485267d-yafn",
-			ExpectedResponse: `{}`,
+			ExpectedResponse: `{"id":"key-c08aa5c7abf34504f18552846485267d-yafn","name":"yafn","creationTimestamp":"0001-01-01T00:00:00Z","spec":{"fingerprint":"","publicKey":""}}`,
 			HTTPStatus:       http.StatusCreated,
 			ProjectToSync:    test.GenDefaultProject().Name,
 			ExistingAPIUser:  test.GenDefaultAPIUser(),
@@ -808,11 +808,11 @@ func TestGetClusterHealth(t *testing.T) {
 					cluster := test.GenCluster("keen-snyder", "clusterAbc", test.GenDefaultProject().Name, time.Date(2013, 02, 03, 19, 54, 0, 0, time.UTC))
 					cluster.Status.ExtendedHealth = kubermaticv1.ExtendedClusterHealth{
 
-						Apiserver:                    kubermaticv1.HealthStatusUp,
-						Scheduler:                    kubermaticv1.HealthStatusDown,
-						Controller:                   kubermaticv1.HealthStatusUp,
-						MachineController:            kubermaticv1.HealthStatusDown,
-						Etcd:                         kubermaticv1.HealthStatusUp,
+						Apiserver:         kubermaticv1.HealthStatusUp,
+						Scheduler:         kubermaticv1.HealthStatusDown,
+						Controller:        kubermaticv1.HealthStatusUp,
+						MachineController: kubermaticv1.HealthStatusDown,
+						Etcd:              kubermaticv1.HealthStatusUp,
 						CloudProviderInfrastructure:  kubermaticv1.HealthStatusUp,
 						UserClusterControllerManager: kubermaticv1.HealthStatusUp,
 					}


### PR DESCRIPTION
**What this PR does / why we need it**:
Return SSH key when calling `PUT ​/api​/v1​/projects​/{project_id}​/dc​/{dc}​/clusters​/{cluster_id}​/sshkeys​/{key_id}`.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Related to https://github.com/kubermatic/dashboard-v2/issues/1443 

**Special notes for your reviewer**:
@zreigz `GET` request for SSH keys that belong to a cluster already returns full object. Therefor I think it's okay to also do that in `PUT` request.

**Does this PR introduce a user-facing change?**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If  no release note is required, just write "NONE".
-->
```release-note
NONE
```
