### PR TITLE
Fix FluentBit scraping annotations

### DIFF
--- a/config/logging/fluentbit/Chart.yaml
+++ b/config/logging/fluentbit/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: fluentbit
-version: 1.2.2
+version: 1.2.3
 appVersion: 1.1.2
 description: Helm chart to install fluent-bit as a log shipper DaemonSet.
 keywords:

--- a/config/logging/fluentbit/templates/daemonset.yaml
+++ b/config/logging/fluentbit/templates/daemonset.yaml
@@ -25,9 +25,9 @@ spec:
         version: v1
         kubernetes.io/cluster-service: "true"
       annotations:
-        prometheus.io/scrape: 'true'
-        prometheus.io/port: '2020'
-        prometheus.io/path: /api/v1/metrics/prometheus
+        kubermatic/metric_path: /api/v1/metrics/prometheus
+        kubermatic/scrape: "true"
+        kubermatic/scrape_port: "2020"
         checksum/config: {{ include (print $.Template.BasePath "/configmap.yaml") . | sha256sum }}
     spec:
       serviceAccountName: fluent-bit


### PR DESCRIPTION
**What this PR does / why we need it**:
This fixes the scraping annotations on the FluentBit pods so they get scraped from the Prometheus we deploy.

**Does this PR introduce a user-facing change?**:
```release-note
NONE
```

/assign @xrstf 