### PR TITLE
Remove dead code to handle APIServer service type == LoadBalancer

### DIFF
--- a/api/pkg/resources/apiserver/service.go
+++ b/api/pkg/resources/apiserver/service.go
@@ -77,14 +77,8 @@ func ExternalServiceCreator(exposeStrategy corev1.ServiceType) reconciling.Named
 
 			se.Spec.Ports[0].Name = "secure"
 			se.Spec.Ports[0].Protocol = corev1.ProtocolTCP
-
-			if se.Spec.Type == corev1.ServiceTypeLoadBalancer {
-				se.Spec.Ports[0].Port = int32(443)
-				se.Spec.Ports[0].TargetPort = intstr.FromInt(443)
-			} else {
-				se.Spec.Ports[0].Port = se.Spec.Ports[0].NodePort
-				se.Spec.Ports[0].TargetPort = intstr.FromInt(int(se.Spec.Ports[0].NodePort))
-			}
+			se.Spec.Ports[0].Port = se.Spec.Ports[0].NodePort
+			se.Spec.Ports[0].TargetPort = intstr.FromInt(int(se.Spec.Ports[0].NodePort))
 
 			return se, nil
 		}


### PR DESCRIPTION
While we do have an exposeStrategy=LoadBalancer, the apiserver service
itself is always of type NodePort, because we create a dedicated
LoadBalancer service in that case.

**What this PR does / why we need it**:

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Documentation**:
<!-- Add links to the related documentation changes related to this pull request. E.g. the link to the kubermatic/docs pullrequest. -->

**Does this PR introduce a user-facing change?**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If  no release note is required, just write "NONE".
-->
```release-note
none
```

/assign @mrIncompetent 
