### PR TITLE
Prevent that removed owners come back part 2

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -44,4 +44,3 @@ issues:
   - "`osData` can be `github.com/kubermatic/kubermatic/api/pkg/resources.RoleBindingDataProvider`"
   - "cyclomatic complexity 31 of func `main` is high"
   - "`currentMigrationRevision` is unused"
-  - "unreachable code"

--- a/api/pkg/controller/rbac/sync_project.go
+++ b/api/pkg/controller/rbac/sync_project.go
@@ -98,11 +98,6 @@ func (c *projectController) ensureProjectIsInActivePhase(project *kubermaticv1.P
 
 // ensureProjectOwner makes sure that the owner of the project is assign to "owners" group
 func (c *projectController) ensureProjectOwner(project *kubermaticv1.Project) error {
-	// TODO: Cleanup
-	// This is a hotfix to prevent that owners that got removed from a project get a new UserProjectBinding.
-	// We already create & delete the appropriate UserProjectBinding in the API when adding/removing users, so this should not be needed.
-	// TODO: Revisit the OwnerReferences approach. This has the potential to delete clusters unintentionally.
-	return nil
 	var sharedOwner *kubermaticv1.User
 	for _, ref := range project.OwnerReferences {
 		if ref.Kind == kubermaticv1.UserKindName {

--- a/api/pkg/controller/rbac/sync_project_test.go
+++ b/api/pkg/controller/rbac/sync_project_test.go
@@ -1371,7 +1371,6 @@ func TestEnsureProjectClusterRBACRoleForResources(t *testing.T) {
 }
 
 func TestEnsureProjectOwner(t *testing.T) {
-	t.Skip("Hotfix to prevent removed owners to come back")
 	tests := []struct {
 		name            string
 		projectToSync   *kubermaticv1.Project

--- a/api/pkg/controller/user-project-binding/user_project_binding_controller.go
+++ b/api/pkg/controller/user-project-binding/user_project_binding_controller.go
@@ -54,7 +54,7 @@ func (r *reconcileSyncProjectBinding) Reconcile(request reconcile.Request) (reco
 	}
 
 	if projectBinding.DeletionTimestamp != nil {
-		return reconcile.Result{}, r.removeFinalizerFromBinding(projectBinding)
+		return reconcile.Result{}, r.ensureNotProjectOwnerForBinding(projectBinding)
 	}
 	if rbac.ExtractGroupPrefix(projectBinding.Spec.Group) == rbac.OwnerGroupNamePrefix {
 		return reconcile.Result{}, r.ensureProjectOwnerForBinding(projectBinding)


### PR DESCRIPTION
**What this PR does / why we need it**: Prevent that removed owners come back part 2

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #4018


```release-note
Fixed an issue where deleted project owners would come back after a while
```
