### PR TITLE
use alias for fluentbit input, filter & output plugins

### DIFF
--- a/config/logging/fluentbit/Chart.yaml
+++ b/config/logging/fluentbit/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: fluentbit
-version: 1.3.0
+version: 1.3.1
 appVersion: 1.2.2
 description: Helm chart to install fluent-bit as a log shipper DaemonSet.
 keywords:

--- a/config/logging/fluentbit/templates/configmap.yaml
+++ b/config/logging/fluentbit/templates/configmap.yaml
@@ -29,15 +29,17 @@ data:
 
     # We attach the node name to each log line
     [FILTER]
-        Name modify
+        Name  modify
         Match *
-        Set node ${NODE_NAME}
+        Alias set_node_name
+        Set   node ${NODE_NAME}
 
     @INCLUDE outputs.conf
 
   kubernetes.conf: |
     [INPUT]
         Name              tail
+        Alias             container_logs
         Tag               kube.*
         Path              /var/log/containers/*.log
         Parser            {{ .Values.logging.fluentbit.configuration.containerRuntimeParser }}
@@ -48,6 +50,7 @@ data:
 
     [FILTER]
         Name                kubernetes
+        Alias               kubernetes
         Match               kube.*
         Kube_URL            https://kubernetes.default.svc.cluster.local:443
         Merge_Log           On
@@ -70,14 +73,17 @@ data:
     # By using both we should cover 95% of all systems. FluentBit will just log an error in case one directory does not exist - Acceptable
     [INPUT]
         Name              systemd
+        Alias             systemd_var_log
         Path              /var/log/journal
         Tag               systemd.*
         DB                /var/log/fluentbit_systemd_persistent.db
         Max_Entries       1000
         Read_From_Tail    true
         Strip_Underscores true
+
     [INPUT]
         Name              systemd
+        Alias             systemd_run_log
         Path              /run/log/journal
         Tag               systemd.*
         DB                /var/log/fluentbit_systemd_volatile.db
@@ -87,8 +93,9 @@ data:
 
     # Only keep the relevant fields
     [FILTER]
-        Name record_modifier
-        Match systemd.*
+        Name          record_modifier
+        Alias         systemd_remove_unused_fields
+        Match         systemd.*
         Whitelist_key SYSTEMD_UNIT
         Whitelist_key MESSAGE
         Whitelist_key SYSTEMD_CGROUP
@@ -101,8 +108,9 @@ data:
     # Give all fields except MESSAGE a prefix, so we can later nest all prefixed fields below "systemd"
     # Also lowercase all systemd keys to be consistend with the kubernetes fields
     [FILTER]
-        Name modify
-        Match systemd.*
+        Name   modify
+        Alias  systemd_rename_fields
+        Match  systemd.*
         Set source systemd
         # We use log for all logging. Using a consistent field makes searching easier
         Rename MESSAGE log
@@ -118,10 +126,11 @@ data:
     # We nest all systemd specific fields below a top level systemd key. That makes it easier to check what fields we have available during troubleshooting
     [FILTER]
         Name nest
-        Match systemd.*
-        Operation nest
-        Wildcard _NEST_*
-        Nest_under systemd
+        Alias         systemd_nest_fields
+        Match         systemd.*
+        Operation     nest
+        Wildcard      _NEST_*
+        Nest_under    systemd
         Remove_prefix _NEST_
 
     # When using systemd as cgroup driver, runc tests systemd compatibility with each invocation (At least it looks like that).
@@ -130,7 +139,8 @@ data:
     # This filter will filter all messages related to the test cgroups
     [FILTER]
         Name    grep
-        Match systemd.*
+        Alias   systemd_filter_out_kubelet_systemd_noise
+        Match   systemd.*
         Exclude log libcontainer.*?test_default\.slice
 
   kmesg.conf: |
@@ -138,29 +148,33 @@ data:
     # kmesg
     ############################################################
     [INPUT]
-        Name   kmsg
-        Tag    kmsg
+        Name  kmsg
+        Alias kernel_messages
+        Tag   kmsg
 
     # Only keep the relevant fields
     [FILTER]
-        Name record_modifier
-        Match kmsg
+        Name          record_modifier
+        Alias         kernel_messages_remove_unused_fields
+        Match         kmsg
         Whitelist_key msg
         Whitelist_key priority
 
     [FILTER]
-        Name modify
-        Match kmsg
-        Set source kmsg
+        Name   modify
+        Alias  kernel_messages_rename_fields
+        Match  kmsg
+        Set    source kmsg
         Rename msg log
         Rename priority _NEST_priority
 
     [FILTER]
         Name nest
-        Match kmesg
-        Operation nest
-        Wildcard _NEST_*
-        Nest_under kmesg
+        Alias         kernel_messages_nest_fields
+        Match         kmesg
+        Operation     nest
+        Wildcard      _NEST_*
+        Nest_under    kmesg
         Remove_prefix _NEST_
 
   outputs.conf: |

--- a/config/logging/fluentbit/values.yaml
+++ b/config/logging/fluentbit/values.yaml
@@ -11,6 +11,7 @@ logging:
       outputs:
       - |
         Name            es
+        Alias           elasticsearch
         Match           *
         Host            ${FLUENT_ELASTICSEARCH_HOST}
         Port            ${FLUENT_ELASTICSEARCH_PORT}


### PR DESCRIPTION
**What this PR does / why we need it**:
This sets the `Alias` field for all input, filter & output plugins.
The Alias will be used as label on the Prometheus metrics - Without an alias, fluenbit will use the plugin name+id (like `grep.5`).

**Does this PR introduce a user-facing change?**:
```release-note
NONE
```

/assign @xrstf 