### PR TITLE
drop EOL Kubernetes 1.11

### DIFF
--- a/config/kubermatic/static/master/updates.yaml
+++ b/config/kubermatic/static/master/updates.yaml
@@ -1,42 +1,9 @@
 updates:
-# ======= 1.8 =======
-# Allow to next minor release
-- from: 1.8.*
-  to: 1.9.0
-  automatic: false
-
-# ======= 1.9 =======
-# Allow to next minor release
-- from: 1.9.*
-  to: 1.10.1
-  automatic: false
-
-# ======= 1.10 =======
-# Allow to change to any patch version
-- from: 1.10.*
-  to: 1.10.*
-  automatic: false
-- from: 1.10.*
-  to: 1.11.5
-  automatic: false
-# CVE-2018-1002105
-- from: <= 1.10.10
-  to: 1.10.11
-  automatic: true
-
 # ======= 1.11 =======
-# Allow to change to any patch version
-- from: 1.11.*
-  to: 1.11.*
-  automatic: false
 # Allow to next minor release
 - from: 1.11.*
   to: 1.12.*
   automatic: false
-# CVE-2018-1002105
-- from: <= 1.11.4, >= 1.11.0
-  to: 1.11.5
-  automatic: true
 
 # ======= 1.12 =======
 # Allow to change to any patch version

--- a/config/kubermatic/static/master/versions.yaml
+++ b/config/kubermatic/static/master/versions.yaml
@@ -1,17 +1,4 @@
 versions:
-# Kubernetes 1.11
-- version: "1.11.5"
-  default: false
-- version: "1.11.6"
-  default: false
-- version: "1.11.7"
-  default: false
-- version: "1.11.8"
-  default: false
-- version: "1.11.9"
-  default: false
-- version: "1.11.10"
-  default: false
 # Kubernetes 1.12
 - version: "1.12.3"
   default: false


### PR DESCRIPTION
```release-note
Kubernetes 1.11 which is end-of-life has been removed.
```
/assign @alvaroaleman 