### PR TITLE
Fix periodic-kubermatic-e2e-api-cloud

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -2,6 +2,10 @@ run:
   deadline: 20m
   skip-dirs:
     - vendor
+  build-tags:
+    - cloud
+    - create
+    - e2e
 
 linters:
   enable:

--- a/api/Makefile
+++ b/api/Makefile
@@ -35,6 +35,13 @@ check: gofmt lint
 
 test:
 	CGO_ENABLED=1 $(GO) test -tags=unit -race ./...
+	@# Make sure all e2e tests compile with their individual build tag
+	@# without actually running them by using `-run` with a non-existing test.
+	@# **Imortant:** Do not replace this with one `go test` with multiple tags,
+	@# as that doesn't properly reflect if each individual tag still builds
+	$(GO) test -tags cloud -run nope ./pkg/test/e2e/api/...
+	$(GO) test -tags create -run nope ./pkg/test/e2e/api/...
+	$(GO) test -tags e2e -run nope ./pkg/test/e2e/api/...
 
 test-update:
 	-$(GO) test ./... -update

--- a/api/pkg/test/e2e/api/cluster_test.go
+++ b/api/pkg/test/e2e/api/cluster_test.go
@@ -54,7 +54,7 @@ func TestCreateAWSCluster(t *testing.T) {
 			if err != nil {
 				t.Fatalf("can not create project %v", GetErrorResponse(err))
 			}
-			teardown := cleanUpProject(project.ID)
+			teardown := cleanUpProject(project.ID, 1)
 			defer teardown(t)
 
 			cluster, err := apiRunner.CreateAWSCluster(project.ID, tc.dc, rand.String(10), getSecretAccessKey(), getAccessKeyID(), getKubernetesVersion(), tc.location, tc.replicas)

--- a/api/pkg/test/e2e/api/digitalocean_test.go
+++ b/api/pkg/test/e2e/api/digitalocean_test.go
@@ -11,31 +11,6 @@ import (
 
 const getDOMaxAttempts = 24
 
-func cleanUpProject(id string) func(t *testing.T) {
-	return func(t *testing.T) {
-		masterToken, err := GetMasterToken()
-		if err != nil {
-			t.Fatalf("can not get master token due error: %v", err)
-		}
-		apiRunner := CreateAPIRunner(masterToken, t)
-
-		if err := apiRunner.DeleteProject(id); err != nil {
-			t.Fatalf("can not delete project due error: %v", err)
-		}
-		for attempt := 1; attempt <= getDOMaxAttempts; attempt++ {
-			_, err := apiRunner.GetProject(id, 5)
-			if err != nil {
-				break
-			}
-			time.Sleep(3 * time.Second)
-		}
-		_, err = apiRunner.GetProject(id, 5)
-		if err == nil {
-			t.Fatalf("can not delete the project")
-		}
-	}
-}
-
 func TestCreateDOCluster(t *testing.T) {
 	tests := []struct {
 		name       string
@@ -66,7 +41,7 @@ func TestCreateDOCluster(t *testing.T) {
 			if err != nil {
 				t.Fatalf("can not create project %v", GetErrorResponse(err))
 			}
-			teardown := cleanUpProject(project.ID)
+			teardown := cleanUpProject(project.ID, getDOMaxAttempts)
 			defer teardown(t)
 
 			cluster, err := apiRunner.CreateDOCluster(project.ID, tc.dc, rand.String(10), tc.credential, tc.version, tc.location, tc.replicas)

--- a/api/pkg/test/e2e/api/sa_test.go
+++ b/api/pkg/test/e2e/api/sa_test.go
@@ -9,20 +9,6 @@ import (
 	"k8s.io/apimachinery/pkg/util/rand"
 )
 
-func cleanUpProject(id string) func(t *testing.T) {
-	return func(t *testing.T) {
-		masterToken, err := GetMasterToken()
-		if err != nil {
-			t.Fatalf("can not get master token due error: %v", err)
-		}
-		apiRunner := CreateAPIRunner(masterToken, t)
-
-		if err := apiRunner.DeleteProject(id); err != nil {
-			t.Fatalf("can not delete project due error: %v", err)
-		}
-	}
-}
-
 func TestCreateSA(t *testing.T) {
 	tests := []struct {
 		name  string
@@ -49,7 +35,7 @@ func TestCreateSA(t *testing.T) {
 			if err != nil {
 				t.Fatalf("can not create project due error: %v", err)
 			}
-			teardown := cleanUpProject(project.ID)
+			teardown := cleanUpProject(project.ID, 1)
 			defer teardown(t)
 
 			sa, err := apiRunner.CreateServiceAccount(rand.String(10), tc.group, project.ID)
@@ -89,7 +75,7 @@ func TestTokenAccessForProject(t *testing.T) {
 			if err != nil {
 				t.Fatalf("can not create project due error: %v", GetErrorResponse(err))
 			}
-			teardown := cleanUpProject(project.ID)
+			teardown := cleanUpProject(project.ID, 1)
 			defer teardown(t)
 
 			sa, err := apiRunner.CreateServiceAccount(rand.String(10), tc.group, project.ID)
@@ -137,7 +123,7 @@ func TestTokenAccessForProject(t *testing.T) {
 			if err != nil {
 				t.Fatalf("can not create project due error: %v", GetErrorResponse(err))
 			}
-			teardownNotOwnedProject := cleanUpProject(notOwnedProject.ID)
+			teardownNotOwnedProject := cleanUpProject(notOwnedProject.ID, 1)
 			defer teardownNotOwnedProject(t)
 
 			_, err = apiRunnerWithSAToken.GetProject(notOwnedProject.ID, 1)


### PR DESCRIPTION
**What this PR does / why we need it**:

Fixes the periodic-kubermatic-e2e-api-cloud to build again by moving the `cleanUpProject` func into a file that doens't have any build tags and making the `attemtps` of it configurable to make it re-usable.

Also extends the `make test` target to build all e2e tests using their build tag without running them by using the `-run nope`, which is a non-existing test, to make sure CI catches this kind of failure which now happened multiple times.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Documentation**:
<!-- Add links to the related documentation changes related to this pull request. E.g. the link to the kubermatic/docs pullrequest. -->

**Does this PR introduce a user-facing change?**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If  no release note is required, just write "NONE".
-->
```release-note
none
```

/assign @zreigz 
