### PR TITLE
Reduce master-controller-manager glog level, as its currently extremley spammy

### DIFF
--- a/config/kubermatic/templates/master-controller-manager-dep.yaml
+++ b/config/kubermatic/templates/master-controller-manager-dep.yaml
@@ -26,7 +26,7 @@ spec:
         - master-controller-manager
         args:
         - -internal-address=0.0.0.0:8085
-        - -v=4
+        - -v=2
         - -logtostderr
         - -kubeconfig=/opt/.kube/kubeconfig
         {{- if .Values.kubermatic.dynamicDatacenters }}


### PR DESCRIPTION

**What this PR does / why we need it**:
Example: The master controller running on cloud for 3.5 hours at the time of writing emitted 34k loglines: 
```
alvaro@t470s-[2019-08-12-10:02]:[reduce-master-controller-manager-loglevel][2]~/.../kubermatic/api
$ k get pod|grep master-contro
master-controller-v1-8c77ffd8b-nt76v        1/1     Running   0          3h22m
alvaro@t470s-[2019-08-12-10:03]:[reduce-master-controller-manager-loglevel][2]~/.../kubermatic/api
$ k logs master-controller-v1-8c77ffd8b-nt76v |wc -l
34031
```

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Documentation**:
<!-- Add links to the related documentation changes related to this pull request. E.g. the link to the kubermatic/docs pullrequest. -->

**Does this PR introduce a user-facing change?**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If  no release note is required, just write "NONE".
-->
```release-note
none
```

/assign @zreigz 
