### PR TITLE
increase clean up cluster period

### DIFF
--- a/api/pkg/test/e2e/api/helper.go
+++ b/api/pkg/test/e2e/api/helper.go
@@ -647,7 +647,7 @@ func cleanUpCluster(t *testing.T, apiRunner *APIRunner, projectID, dc, clusterID
 			t.Logf("cluster deleted %v", GetErrorResponse(err))
 			break
 		}
-		time.Sleep(10 * time.Second)
+		time.Sleep(30 * time.Second)
 	}
 	_, err := apiRunner.GetCluster(projectID, dc, clusterID)
 	if err == nil {


### PR DESCRIPTION
**What this PR does / why we need it**: increase clean up cluster period. It's needed for AWS

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

```release-note
NONE
```
