### PR TITLE
Allow enabling PSPs

### DIFF
--- a/api/cmd/kubermatic-api/swagger.json
+++ b/api/cmd/kubermatic-api/swagger.json
@@ -5534,6 +5534,11 @@
         "oidc": {
           "$ref": "#/definitions/OIDCSettings"
         },
+        "usePodSecurityPolicyAdmissionPlugin": {
+          "description": "If active the PodSecurityPolicy admission plugin is configured at the apiserver",
+          "type": "boolean",
+          "x-go-name": "UsePodSecurityPolicyAdmissionPlugin"
+        },
         "version": {
           "$ref": "#/definitions/Semver"
         }

--- a/api/pkg/api/v1/types.go
+++ b/api/pkg/api/v1/types.go
@@ -565,16 +565,20 @@ type ClusterSpec struct {
 
 	// OIDC settings
 	OIDC kubermaticv1.OIDCSettings `json:"oidc,omitempty"`
+
+	// If active the PodSecurityPolicy admission plugin is configured at the apiserver
+	UsePodSecurityPolicyAdmissionPlugin bool `json:"usePodSecurityPolicyAdmissionPlugin,omitempty"`
 }
 
 // MarshalJSON marshals ClusterSpec object into JSON. It is overwritten to control data
 // that will be returned in the API responses (see: PublicCloudSpec struct).
 func (cs *ClusterSpec) MarshalJSON() ([]byte, error) {
 	ret, err := json.Marshal(struct {
-		Cloud           PublicCloudSpec                        `json:"cloud"`
-		MachineNetworks []kubermaticv1.MachineNetworkingConfig `json:"machineNetworks,omitempty"`
-		Version         ksemver.Semver                         `json:"version"`
-		OIDC            kubermaticv1.OIDCSettings              `json:"oidc"`
+		Cloud                               PublicCloudSpec                        `json:"cloud"`
+		MachineNetworks                     []kubermaticv1.MachineNetworkingConfig `json:"machineNetworks,omitempty"`
+		Version                             ksemver.Semver                         `json:"version"`
+		OIDC                                kubermaticv1.OIDCSettings              `json:"oidc"`
+		UsePodSecurityPolicyAdmissionPlugin bool                                   `json:"usePodSecurityPolicyAdmissionPlugin,omitempty"`
 	}{
 		Cloud: PublicCloudSpec{
 			DatacenterName: cs.Cloud.DatacenterName,
@@ -589,9 +593,10 @@ func (cs *ClusterSpec) MarshalJSON() ([]byte, error) {
 			VSphere:        newPublicVSphereCloudSpec(cs.Cloud.VSphere),
 			GCP:            newPublicGCPCloudSpec(cs.Cloud.GCP),
 		},
-		Version:         cs.Version,
-		MachineNetworks: cs.MachineNetworks,
-		OIDC:            cs.OIDC,
+		Version:                             cs.Version,
+		MachineNetworks:                     cs.MachineNetworks,
+		OIDC:                                cs.OIDC,
+		UsePodSecurityPolicyAdmissionPlugin: cs.UsePodSecurityPolicyAdmissionPlugin,
 	})
 
 	return ret, err

--- a/api/pkg/crd/kubermatic/v1/cluster.go
+++ b/api/pkg/crd/kubermatic/v1/cluster.go
@@ -88,6 +88,8 @@ type ClusterSpec struct {
 
 	// Openshift holds all openshift-specific settings
 	Openshift *Openshift `json:"openshift,omitempty"`
+
+	UsePodSecurityPolicyAdmissionPlugin bool `json:"usePodSecurityPolicyAdmissionPlugin,omitempty"`
 }
 
 type Openshift struct {

--- a/api/pkg/handler/v1/cluster/cluster.go
+++ b/api/pkg/handler/v1/cluster/cluster.go
@@ -597,10 +597,11 @@ func convertInternalClusterToExternal(internalCluster *kubermaticv1.Cluster) *ap
 			}(),
 		},
 		Spec: apiv1.ClusterSpec{
-			Cloud:           internalCluster.Spec.Cloud,
-			Version:         internalCluster.Spec.Version,
-			MachineNetworks: internalCluster.Spec.MachineNetworks,
-			OIDC:            internalCluster.Spec.OIDC,
+			Cloud:                               internalCluster.Spec.Cloud,
+			Version:                             internalCluster.Spec.Version,
+			MachineNetworks:                     internalCluster.Spec.MachineNetworks,
+			OIDC:                                internalCluster.Spec.OIDC,
+			UsePodSecurityPolicyAdmissionPlugin: internalCluster.Spec.UsePodSecurityPolicyAdmissionPlugin,
 		},
 		Status: apiv1.ClusterStatus{
 			Version: internalCluster.Spec.Version,

--- a/api/pkg/resources/apiserver/deployment.go
+++ b/api/pkg/resources/apiserver/deployment.go
@@ -175,6 +175,21 @@ func getApiserverFlags(data *resources.TemplateData, etcdEndpoints []string, ena
 		nodePortRange = defaultNodePortRange
 	}
 
+	admissionPlugins := []string{
+		"NamespaceLifecycle",
+		"LimitRanger",
+		"ServiceAccount",
+		"DefaultStorageClass",
+		"DefaultTolerationSeconds",
+		"MutatingAdmissionWebhook",
+		"ValidatingAdmissionWebhook",
+		"Priority",
+		"ResourceQuota",
+	}
+	if data.Cluster().Spec.UsePodSecurityPolicyAdmissionPlugin {
+		admissionPlugins = append(admissionPlugins, "PodSecurityPolicy")
+	}
+
 	flags := []string{
 		"--advertise-address", data.Cluster().Address.IP,
 		"--secure-port", fmt.Sprint(data.Cluster().Address.Port),
@@ -184,7 +199,7 @@ func getApiserverFlags(data *resources.TemplateData, etcdEndpoints []string, ena
 		"--etcd-certfile", "/etc/etcd/pki/client/apiserver-etcd-client.crt",
 		"--etcd-keyfile", "/etc/etcd/pki/client/apiserver-etcd-client.key",
 		"--storage-backend", "etcd3",
-		"--enable-admission-plugins", "NamespaceLifecycle,LimitRanger,ServiceAccount,DefaultStorageClass,DefaultTolerationSeconds,MutatingAdmissionWebhook,ValidatingAdmissionWebhook,Priority,ResourceQuota",
+		"--enable-admission-plugins", strings.Join(admissionPlugins, ","),
 		"--authorization-mode", "Node,RBAC",
 		"--external-hostname", data.Cluster().Address.ExternalName,
 		"--token-auth-file", "/etc/kubernetes/tokens/tokens.csv",

--- a/api/pkg/resources/cluster/cluster.go
+++ b/api/pkg/resources/cluster/cluster.go
@@ -15,11 +15,12 @@ import (
 // Spec builds ClusterSpec kubermatic Custom Resource from API Cluster
 func Spec(apiCluster apiv1.Cluster, dc *kubermaticv1.Datacenter, secretKeyGetter provider.SecretKeySelectorValueFunc) (*kubermaticv1.ClusterSpec, error) {
 	spec := &kubermaticv1.ClusterSpec{
-		HumanReadableName: apiCluster.Name,
-		Cloud:             apiCluster.Spec.Cloud,
-		MachineNetworks:   apiCluster.Spec.MachineNetworks,
-		OIDC:              apiCluster.Spec.OIDC,
-		Version:           apiCluster.Spec.Version,
+		HumanReadableName:                   apiCluster.Name,
+		Cloud:                               apiCluster.Spec.Cloud,
+		MachineNetworks:                     apiCluster.Spec.MachineNetworks,
+		OIDC:                                apiCluster.Spec.OIDC,
+		Version:                             apiCluster.Spec.Version,
+		UsePodSecurityPolicyAdmissionPlugin: apiCluster.Spec.UsePodSecurityPolicyAdmissionPlugin,
 	}
 
 	providerName, err := provider.ClusterCloudProviderName(spec.Cloud)

--- a/api/pkg/test/e2e/api/utils/apiclient/models/cluster_spec.go
+++ b/api/pkg/test/e2e/api/utils/apiclient/models/cluster_spec.go
@@ -21,6 +21,9 @@ type ClusterSpec struct {
 	// MachineNetworks optionally specifies the parameters for IPAM.
 	MachineNetworks []*MachineNetworkingConfig `json:"machineNetworks"`
 
+	// If active the PodSecurityPolicy admission plugin is configured at the apiserver
+	UsePodSecurityPolicyAdmissionPlugin bool `json:"usePodSecurityPolicyAdmissionPlugin,omitempty"`
+
 	// cloud
 	Cloud *CloudSpec `json:"cloud,omitempty"`
 


### PR DESCRIPTION
**What this PR does / why we need it**:
Make additional admission plugins configurable per cluster. This can be used to for example enable Pod Security Policies on a per cluster level. See #4053.

What is still missing to make this complete:
* Dashboard support to easily activate and deactivate PodSecurityPolicy (we can provide a PR for this as well)
* Adding PodSecurityPolicies and corresponding RBAC bindings for all addons
* e2e tests

**Does this PR introduce a user-facing change?**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If  no release note is required, just write "NONE".
-->
```release-note
Pod Security Policies can now be enabled
```
