### PR TITLE
drop EOL Kubernetes 1.12

### DIFF
--- a/config/kubermatic/static/master/updates.yaml
+++ b/config/kubermatic/static/master/updates.yaml
@@ -1,19 +1,5 @@
 updates:
-# ======= 1.11 =======
-# Allow to next minor release
-- from: 1.11.*
-  to: 1.12.*
-  automatic: false
-
 # ======= 1.12 =======
-# Allow to change to any patch version
-- from: 1.12.*
-  to: 1.12.*
-  automatic: false
-# CVE-2018-1002105
-- from: <= 1.12.2, >= 1.12.0
-  to: 1.12.3
-  automatic: true
 # Allow to next minor release
 - from: 1.12.*
   to: 1.13.*

--- a/config/kubermatic/static/master/versions.yaml
+++ b/config/kubermatic/static/master/versions.yaml
@@ -1,21 +1,4 @@
 versions:
-# Kubernetes 1.12
-- version: "1.12.3"
-  default: false
-- version: "1.12.4"
-  default: false
-- version: "1.12.5"
-  default: false
-- version: "1.12.6"
-  default: false
-- version: "1.12.7"
-  default: false
-- version: "1.12.8"
-  default: false
-- version: "1.12.9"
-  default: false
-- version: "1.12.10"
-  default: false
 # Kubernetes 1.13
 - version: "1.13.0"
   default: false


### PR DESCRIPTION
**What this PR does / why we need it**:

```release-note
Kubernetes 1.12 which is end-of-life has been removed.
```
