### PR TITLE
update Kubernetes versions to address CVE-2019-11247, CVE-2019-11249

### DIFF
--- a/config/kubermatic/static/master/updates.yaml
+++ b/config/kubermatic/static/master/updates.yaml
@@ -10,6 +10,10 @@ updates:
 - from: 1.13.*
   to: 1.13.*
   automatic: false
+# CVE-2019-11247, CVE-2019-11249
+- from: <= 1.13.8, >= 1.13.0
+  to: 1.13.9
+  automatic: true
 # Allow to next minor release
 - from: 1.13.*
   to: 1.14.*
@@ -20,6 +24,10 @@ updates:
 - from: 1.14.*
   to: 1.14.*
   automatic: false
+# CVE-2019-11247, CVE-2019-11249
+- from: <= 1.14.4, >= 1.14.0
+  to: 1.14.5
+  automatic: true
 # Allow to next minor release
 - from: 1.14.*
   to: 1.15.*
@@ -30,3 +38,7 @@ updates:
 - from: 1.15.*
   to: 1.15.*
   automatic: false
+# CVE-2019-11247, CVE-2019-11249
+- from: <= 1.15.1, >= 1.15.0
+  to: 1.15.2
+  automatic: true

--- a/config/kubermatic/static/master/versions.yaml
+++ b/config/kubermatic/static/master/versions.yaml
@@ -1,38 +1,12 @@
 versions:
 # Kubernetes 1.13
-- version: "1.13.0"
-  default: false
-- version: "1.13.1"
-  default: false
-- version: "1.13.2"
-  default: false
-- version: "1.13.3"
-  default: false
-- version: "1.13.4"
-  default: false
-- version: "1.13.5"
-  default: false
-# Insecure https://github.com/kubernetes/kubernetes/issues/78308
-#- version: "1.13.6"
-#  default: false
-- version: "1.13.7"
+- version: "1.13.9"
   default: false
 # Kubernetes 1.14
-- version: "v1.14.0"
-  default: false
-- version: "v1.14.1"
-  default: false
-# Insecure https://github.com/kubernetes/kubernetes/issues/78308
-#- version: "v1.14.2"
-#  default: false
-- version: "v1.14.3"
-  default: false
-- version: "v1.14.4"
+- version: "v1.14.5"
   default: true
 # Kubernetes 1.15
-- version: "v1.15.0"
-  default: false
-- version: "v1.15.1"
+- version: "v1.15.2"
   default: false
 # OpenShift 3.11
 - version: "v3.11"


### PR DESCRIPTION
```release-note
Kubernetes versions affected by CVE-2019-11247 and CVE-2019-11249 have been dropped
```
