### PR TITLE
set the addon image tag during run.kubermatic.io deployment

### DIFF
--- a/api/hack/ci/ci-deploy-run.sh
+++ b/api/hack/ci/ci-deploy-run.sh
@@ -21,7 +21,8 @@ export KUBECONFIG=/tmp/kubeconfig
 export VALUES_FILE=/tmp/values.yaml
 export HELM_EXTRA_ARGS="--set=kubermatic.controller.image.tag=${GIT_HEAD_HASH} \
     --set=kubermatic.api.image.tag=${GIT_HEAD_HASH} \
-    --set=kubermatic.masterController.image.tag=${GIT_HEAD_HASH}"
+    --set=kubermatic.masterController.image.tag=${GIT_HEAD_HASH} \
+    --set=kubermatic.controller.addons.kubernetes.image.tag=${GIT_HEAD_HASH}"
 
 # deploy to dev
 vault kv get -field=kubeconfig dev/seed-clusters/run.kubermatic.io > ${KUBECONFIG}


### PR DESCRIPTION
Previously the environment run.kubermatic.io was running the v2.10 branch, which had static addon image versioning. Now that it is migrated to v2.11, the addon image is versioned together with the rest of the components, requiring us to set the tag the same way we already do on dev deployments.

```release-note
NONE
```
