### PR TITLE
update Envoy to 1.11.1 to mitigate HTTP/2 attacks

### DIFF
--- a/config/nodeport-proxy/Chart.yaml
+++ b/config/nodeport-proxy/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: nodeport-proxy
-version: 1.4.0
+version: 1.4.1
 appVersion: v2.2.2
 description: Kubermatic nodeport-proxy
 keywords:

--- a/config/nodeport-proxy/values.yaml
+++ b/config/nodeport-proxy/values.yaml
@@ -6,7 +6,7 @@ nodePortProxy:
   envoy:
     image:
       repository: "docker.io/envoyproxy/envoy-alpine"
-      tag: v1.10.0
+      tag: v1.11.1
 
   nodeSelector: {}
   affinity:


### PR DESCRIPTION
**What this PR does / why we need it**:
This updates Envoy to 1.11.1 to include mitigations for the recent HTTP/2 attacks. This version seems to work fine on dev. Ignore the branch name, I had a branch/brain fart.

**Does this PR introduce a user-facing change?**:
```release-note
updated Envoy to 1.11.1
```
