### PR TITLE
enable Replace_Dots in fluentbit to allow all kubernetes label names

### DIFF
--- a/config/logging/fluentbit/Chart.yaml
+++ b/config/logging/fluentbit/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: fluentbit
-version: 1.3.1
+version: 1.3.2
 appVersion: 1.2.2
 description: Helm chart to install fluent-bit as a log shipper DaemonSet.
 keywords:

--- a/config/logging/fluentbit/values.yaml
+++ b/config/logging/fluentbit/values.yaml
@@ -16,6 +16,8 @@ logging:
         Host            ${FLUENT_ELASTICSEARCH_HOST}
         Port            ${FLUENT_ELASTICSEARCH_PORT}
         Logstash_Format On
+        Replace_Dots    On
+        Generate_ID     On
         Retry_Limit     False
     resources:
       requests:


### PR DESCRIPTION
**What this PR does / why we need it**:
Elasticsearch interprets fields with dots as objects with sub-fields. This means that a label like `app.kubernetes.io/name=foo` is stored as a `kubernetes.labels.app.kubernetes.io/name=foo` field. If another pod has a simple `app` label, there is a conflict between string and the pre-existing object and the insert operation fails.

This PR enables the Replace_Dots option to fix this. See https://github.com/fluent/fluent-bit/issues/854#issuecomment-431853224 for more information.

It also enables generating an `_id`, because it should not hurt and help in fast-moving clusters.

**Does this PR introduce a user-facing change?**:
```release-note
NONE
```
