### PR TITLE
Integration test maketarget: Run integration tests only

### DIFF
--- a/api/Makefile
+++ b/api/Makefile
@@ -1,6 +1,5 @@
 export CGO_ENABLED?=0
 REPO=quay.io/kubermatic/api
-GO?=go
 CMD=$(filter-out OWNERS nodeport-proxy kubeletdnat-controller, $(notdir $(wildcard ./cmd/*)))
 GOBUILDFLAGS?=-v
 GITTAG=$(shell git describe --tags --always)
@@ -23,26 +22,26 @@ all: check vendor build test
 build: $(CMD)
 
 $(CMD):
-	$(GO) build $(GOTOOLFLAGS) -o $(BUILD_DEST)/$@ ./cmd/$@
+	go build $(GOTOOLFLAGS) -o $(BUILD_DEST)/$@ ./cmd/$@
 
 install:
-	$(GO) install $(GOTOOLFLAGS) ./cmd/...
+	go install $(GOTOOLFLAGS) ./cmd/...
 
 showenv:
-	@$(GO) env
+	@go env
 
 check: gofmt lint
 
 test:
-	CGO_ENABLED=1 $(GO) test -tags=unit -race ./...
+	CGO_ENABLED=1 go test -tags=unit -race ./...
 	@# Make sure all e2e tests compile with their individual build tag
 	@# without actually running them by using `-run` with a non-existing test.
 	@# **Imortant:** Do not replace this with one `go test` with multiple tags,
 	@# as that doesn't properly reflect if each individual tag still builds
-	$(GO) test -tags cloud -run nope ./pkg/test/e2e/api/...
-	$(GO) test -tags create -run nope ./pkg/test/e2e/api/...
-	$(GO) test -tags e2e -run nope ./pkg/test/e2e/api/...
-	$(GO) test -tags integration -run nope ./...
+	go test -tags cloud -run nope ./pkg/test/e2e/api/...
+	go test -tags create -run nope ./pkg/test/e2e/api/...
+	go test -tags e2e -run nope ./pkg/test/e2e/api/...
+	go test -tags integration -run nope ./...
 
 test-integration : CGO_ENABLED = 1
 test-integration:
@@ -55,7 +54,7 @@ test-integration:
 		|xargs --max-args=1 -I ^ go test -tags integration  -race ./^
 
 test-update:
-	-$(GO) test ./... -update
+	-go test ./... -update
 
 clean:
 	rm -f $(TARGET)

--- a/api/Makefile
+++ b/api/Makefile
@@ -44,8 +44,15 @@ test:
 	$(GO) test -tags e2e -run nope ./pkg/test/e2e/api/...
 	$(GO) test -tags integration -run nope ./...
 
+test-integration : CGO_ENABLED = 1
 test-integration:
-	CGO_ENABLED=1 $(GO) test -tags integration -race ./...
+	@# Run integration tests and only integration tests by:
+	@# * Finding all files that contain the build tag via grep
+	@# * Extracting the dirname as the `go test` command doesn't play well with individual files as args
+	@# * Prefixing them with `./` as thats needed by `go test` as well
+	grep --files-with-matches --recursive --extended-regexp '\+build.+integration' cmd/ pkg/ \
+		|xargs dirname \
+		|xargs --max-args=1 -I ^ go test -tags integration  -race ./^
 
 test-update:
 	-$(GO) test ./... -update

--- a/api/Makefile
+++ b/api/Makefile
@@ -49,7 +49,7 @@ test-integration:
 	@# * Finding all files that contain the build tag via grep
 	@# * Extracting the dirname as the `go test` command doesn't play well with individual files as args
 	@# * Prefixing them with `./` as thats needed by `go test` as well
-	grep --files-with-matches --recursive --extended-regexp '\+build.+integration' cmd/ pkg/ \
+	@grep --files-with-matches --recursive --extended-regexp '\+build.+integration' cmd/ pkg/ \
 		|xargs dirname \
 		|xargs --max-args=1 -I ^ go test -tags integration  -race ./^
 


### PR DESCRIPTION
**What this PR does / why we need it**:

This PR changes the `integration-test` maketarget to only run integration tests instead of integration tests and all unit tests. 

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Documentation**:
<!-- Add links to the related documentation changes related to this pull request. E.g. the link to the kubermatic/docs pullrequest. -->

**Does this PR introduce a user-facing change?**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If  no release note is required, just write "NONE".
-->
```release-note
none
```
