### PR TITLE
Conformance tester: Write junit regardless of test result

### DIFF
--- a/api/cmd/conformance-tests/runner.go
+++ b/api/cmd/conformance-tests/runner.go
@@ -375,11 +375,13 @@ func (r *testRunner) testCluster(
 	var err error
 	totalStart := time.Now()
 	log.Info("Starting to test cluster...")
-	defer log.Infof("Finished testing cluster after %s", time.Since(totalStart))
+
+	// We need the closure to defer the evaluation of the time.Since(totalStart) call
+	defer func() { log.Infof("Finished testing cluster after %s", time.Since(totalStart)) }()
 
 	// Always write junit to disk
-	defer func(totalDurationSeconds float64) {
-		report.Time = totalDurationSeconds
+	defer func() {
+		report.Time = time.Since(totalStart).Seconds()
 		b, err := xml.Marshal(report)
 		if err != nil {
 			log.Errorw("failed to marshal junit", zap.Error(err))
@@ -388,7 +390,7 @@ func (r *testRunner) testCluster(
 		if err := ioutil.WriteFile(path.Join(r.reportsRoot, fmt.Sprintf("junit.%s.xml", scenarioName)), b, 0644); err != nil {
 			log.Errorw("failed to write junit", zap.Error(err))
 		}
-	}(time.Since(totalStart).Seconds())
+	}()
 
 	// We'll store the report there and all kinds of logs
 	scenarioFolder := path.Join(r.reportsRoot, scenarioName)


### PR DESCRIPTION
**What this PR does / why we need it**:

Currently the junit report created by the conformance tester will only be written if all tests were completed successfully because otherwise we do not reach the relevant code part.

This PR changes that behaviour to always write out the junit, regardless of the result.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Documentation**:
<!-- Add links to the related documentation changes related to this pull request. E.g. the link to the kubermatic/docs pullrequest. -->

**Does this PR introduce a user-facing change?**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If  no release note is required, just write "NONE".
-->
```release-note
none
```
