### PR TITLE
define basic alerts for Fluentbit

### DIFF
--- a/config/monitoring/prometheus/rules/general-fluentbit.yaml
+++ b/config/monitoring/prometheus/rules/general-fluentbit.yaml
@@ -1,0 +1,31 @@
+# This file has been generated, do not edit.
+groups:
+- name: fluentbit
+  rules:
+  - alert: FluentbitManyRetries
+    annotations:
+      message: Fluentbit pod `{{ $labels.pod }}` is experiencing an elevated retry
+        rate.
+      runbook_url: https://docs.kubermatic.io/monitoring/runbook/#alert-fluentbitmanyretries
+    expr: rate(fluentbit_output_retries_total[1m]) > 0
+    for: 10m
+    labels:
+      severity: warning
+  - alert: FluentbitManyOutputErrors
+    annotations:
+      message: Fluentbit pod `{{ $labels.pod }}` is experiencing an elevated output
+        error rate.
+      runbook_url: https://docs.kubermatic.io/monitoring/runbook/#alert-fluentbitmanyoutputerrors
+    expr: rate(fluentbit_output_errors_total[1m]) > 0
+    for: 10m
+    labels:
+      severity: warning
+  - alert: FluentbitNotProcessingNewLogs
+    annotations:
+      message: Fluentbit pod `{{ $labels.pod }}` has not processed any new logs for
+        the last 30 minutes.
+      runbook_url: https://docs.kubermatic.io/monitoring/runbook/#alert-fluentbitnotprocessingnewlogs
+    expr: rate(fluentbit_output_proc_records_total[1m]) == 0
+    for: 30m
+    labels:
+      severity: warning

--- a/config/monitoring/prometheus/rules/general-fluentbit.yaml
+++ b/config/monitoring/prometheus/rules/general-fluentbit.yaml
@@ -8,7 +8,7 @@ groups:
         an elevated retry rate.
       runbook_url: https://docs.kubermatic.io/monitoring/runbook/#alert-fluentbitmanyretries
     expr: |
-      sum by (namespace, pod) (kube_pod_info) *
+      sum by (namespace, pod, node) (kube_pod_info) *
         on (namespace, pod)
         group_right (node)
         rate(fluentbit_output_retries_total[1m]) > 0
@@ -21,7 +21,7 @@ groups:
         an elevated output error rate.
       runbook_url: https://docs.kubermatic.io/monitoring/runbook/#alert-fluentbitmanyoutputerrors
     expr: |
-      sum by (namespace, pod) (kube_pod_info) *
+      sum by (namespace, pod, node) (kube_pod_info) *
         on (namespace, pod)
         group_right (node)
         rate(fluentbit_output_errors_total[1m]) > 0
@@ -34,7 +34,7 @@ groups:
         any new logs for the last 30 minutes.
       runbook_url: https://docs.kubermatic.io/monitoring/runbook/#alert-fluentbitnotprocessingnewlogs
     expr: |
-      sum by (namespace, pod) (kube_pod_info) *
+      sum by (namespace, pod, node) (kube_pod_info) *
         on (namespace, pod)
         group_right (node)
         rate(fluentbit_output_proc_records_total[1m]) == 0

--- a/config/monitoring/prometheus/rules/general-fluentbit.yaml
+++ b/config/monitoring/prometheus/rules/general-fluentbit.yaml
@@ -4,28 +4,40 @@ groups:
   rules:
   - alert: FluentbitManyRetries
     annotations:
-      message: Fluentbit pod `{{ $labels.pod }}` is experiencing an elevated retry
-        rate.
+      message: Fluentbit pod `{{ $labels.pod }}` on `{{ $labels.node }}` is experiencing
+        an elevated retry rate.
       runbook_url: https://docs.kubermatic.io/monitoring/runbook/#alert-fluentbitmanyretries
-    expr: rate(fluentbit_output_retries_total[1m]) > 0
+    expr: |
+      sum by (namespace, pod) (kube_pod_info) *
+        on (namespace, pod)
+        group_right (node)
+        rate(fluentbit_output_retries_total[1m]) > 0
     for: 10m
     labels:
       severity: warning
   - alert: FluentbitManyOutputErrors
     annotations:
-      message: Fluentbit pod `{{ $labels.pod }}` is experiencing an elevated output
-        error rate.
+      message: Fluentbit pod `{{ $labels.pod }}` on `{{ $labels.node }}` is experiencing
+        an elevated output error rate.
       runbook_url: https://docs.kubermatic.io/monitoring/runbook/#alert-fluentbitmanyoutputerrors
-    expr: rate(fluentbit_output_errors_total[1m]) > 0
+    expr: |
+      sum by (namespace, pod) (kube_pod_info) *
+        on (namespace, pod)
+        group_right (node)
+        rate(fluentbit_output_errors_total[1m]) > 0
     for: 10m
     labels:
       severity: warning
   - alert: FluentbitNotProcessingNewLogs
     annotations:
-      message: Fluentbit pod `{{ $labels.pod }}` has not processed any new logs for
-        the last 30 minutes.
+      message: Fluentbit pod `{{ $labels.pod }}` on `{{ $labels.node }}` has not processed
+        any new logs for the last 30 minutes.
       runbook_url: https://docs.kubermatic.io/monitoring/runbook/#alert-fluentbitnotprocessingnewlogs
-    expr: rate(fluentbit_output_proc_records_total[1m]) == 0
+    expr: |
+      sum by (namespace, pod) (kube_pod_info) *
+        on (namespace, pod)
+        group_right (node)
+        rate(fluentbit_output_proc_records_total[1m]) == 0
     for: 30m
     labels:
       severity: warning

--- a/config/monitoring/prometheus/rules/kubermatic-seed-kubermatic.yaml
+++ b/config/monitoring/prometheus/rules/kubermatic-seed-kubermatic.yaml
@@ -21,7 +21,8 @@ groups:
       severity: warning
   - alert: KubermaticAddonDeletionTakesTooLong
     annotations:
-      message: Addon {{ $labels.addon }} in cluster {{ $labels.cluster }} is stuck in deletion for more than 30min.
+      message: Addon {{ $labels.addon }} in cluster {{ $labels.cluster }} is stuck
+        in deletion for more than 30min.
       runbook_url: https://docs.kubermatic.io/monitoring/runbook/#alert-kubermaticaddondeletiontakestoolong
     expr: (time() - max by (cluster,addon) (kubermatic_addon_deleted)) > 30*60
     for: 0m

--- a/config/monitoring/prometheus/rules/src/general/fluentbit.yaml
+++ b/config/monitoring/prometheus/rules/src/general/fluentbit.yaml
@@ -6,7 +6,7 @@ groups:
       message: Fluentbit pod `{{ $labels.pod }}` on `{{ $labels.node }}` is experiencing an elevated retry rate.
       runbook_url: https://docs.kubermatic.io/monitoring/runbook/#alert-fluentbitmanyretries
     expr: |
-      sum by (namespace, pod) (kube_pod_info) *
+      sum by (namespace, pod, node) (kube_pod_info) *
         on (namespace, pod)
         group_right (node)
         rate(fluentbit_output_retries_total[1m]) > 0
@@ -23,7 +23,7 @@ groups:
       message: Fluentbit pod `{{ $labels.pod }}` on `{{ $labels.node }}` is experiencing an elevated output error rate.
       runbook_url: https://docs.kubermatic.io/monitoring/runbook/#alert-fluentbitmanyoutputerrors
     expr: |
-      sum by (namespace, pod) (kube_pod_info) *
+      sum by (namespace, pod, node) (kube_pod_info) *
         on (namespace, pod)
         group_right (node)
         rate(fluentbit_output_errors_total[1m]) > 0
@@ -40,7 +40,7 @@ groups:
       message: Fluentbit pod `{{ $labels.pod }}` on `{{ $labels.node }}` has not processed any new logs for the last 30 minutes.
       runbook_url: https://docs.kubermatic.io/monitoring/runbook/#alert-fluentbitnotprocessingnewlogs
     expr: |
-      sum by (namespace, pod) (kube_pod_info) *
+      sum by (namespace, pod, node) (kube_pod_info) *
         on (namespace, pod)
         group_right (node)
         rate(fluentbit_output_proc_records_total[1m]) == 0

--- a/config/monitoring/prometheus/rules/src/general/fluentbit.yaml
+++ b/config/monitoring/prometheus/rules/src/general/fluentbit.yaml
@@ -3,9 +3,13 @@ groups:
   rules:
   - alert: FluentbitManyRetries
     annotations:
-      message: Fluentbit pod `{{ $labels.pod }}` is experiencing an elevated retry rate.
+      message: Fluentbit pod `{{ $labels.pod }}` on `{{ $labels.node }}` is experiencing an elevated retry rate.
       runbook_url: https://docs.kubermatic.io/monitoring/runbook/#alert-fluentbitmanyretries
-    expr: rate(fluentbit_output_retries_total[1m]) > 0
+    expr: |
+      sum by (namespace, pod) (kube_pod_info) *
+        on (namespace, pod)
+        group_right (node)
+        rate(fluentbit_output_retries_total[1m]) > 0
     for: 10m
     labels:
       severity: warning
@@ -16,9 +20,13 @@ groups:
 
   - alert: FluentbitManyOutputErrors
     annotations:
-      message: Fluentbit pod `{{ $labels.pod }}` is experiencing an elevated output error rate.
+      message: Fluentbit pod `{{ $labels.pod }}` on `{{ $labels.node }}` is experiencing an elevated output error rate.
       runbook_url: https://docs.kubermatic.io/monitoring/runbook/#alert-fluentbitmanyoutputerrors
-    expr: rate(fluentbit_output_errors_total[1m]) > 0
+    expr: |
+      sum by (namespace, pod) (kube_pod_info) *
+        on (namespace, pod)
+        group_right (node)
+        rate(fluentbit_output_errors_total[1m]) > 0
     for: 10m
     labels:
       severity: warning
@@ -29,9 +37,13 @@ groups:
 
   - alert: FluentbitNotProcessingNewLogs
     annotations:
-      message: Fluentbit pod `{{ $labels.pod }}` has not processed any new logs for the last 30 minutes.
+      message: Fluentbit pod `{{ $labels.pod }}` on `{{ $labels.node }}` has not processed any new logs for the last 30 minutes.
       runbook_url: https://docs.kubermatic.io/monitoring/runbook/#alert-fluentbitnotprocessingnewlogs
-    expr: rate(fluentbit_output_proc_records_total[1m]) == 0
+    expr: |
+      sum by (namespace, pod) (kube_pod_info) *
+        on (namespace, pod)
+        group_right (node)
+        rate(fluentbit_output_proc_records_total[1m]) == 0
     for: 30m
     labels:
       severity: warning

--- a/config/monitoring/prometheus/rules/src/general/fluentbit.yaml
+++ b/config/monitoring/prometheus/rules/src/general/fluentbit.yaml
@@ -1,0 +1,40 @@
+groups:
+- name: fluentbit
+  rules:
+  - alert: FluentbitManyRetries
+    annotations:
+      message: Fluentbit pod `{{ $labels.pod }}` is experiencing an elevated retry rate.
+      runbook_url: https://docs.kubermatic.io/monitoring/runbook/#alert-fluentbitmanyretries
+    expr: rate(fluentbit_output_retries_total[1m]) > 0
+    for: 10m
+    labels:
+      severity: warning
+    runbook:
+      steps:
+      - Ensure the target Elasticsearch cluster is healthy and accepts new documents (in certain
+        conditions Elasticsearch clusters become read-only).
+
+  - alert: FluentbitManyOutputErrors
+    annotations:
+      message: Fluentbit pod `{{ $labels.pod }}` is experiencing an elevated output error rate.
+      runbook_url: https://docs.kubermatic.io/monitoring/runbook/#alert-fluentbitmanyoutputerrors
+    expr: rate(fluentbit_output_errors_total[1m]) > 0
+    for: 10m
+    labels:
+      severity: warning
+    runbook:
+      steps:
+      - Ensure the target Elasticsearch cluster is healthy and accepts new documents (in certain
+        conditions Elasticsearch clusters become read-only).
+
+  - alert: FluentbitNotProcessingNewLogs
+    annotations:
+      message: Fluentbit pod `{{ $labels.pod }}` has not processed any new logs for the last 30 minutes.
+      runbook_url: https://docs.kubermatic.io/monitoring/runbook/#alert-fluentbitnotprocessingnewlogs
+    expr: rate(fluentbit_output_proc_records_total[1m]) == 0
+    for: 30m
+    labels:
+      severity: warning
+    runbook:
+      steps:
+      - Check if there are no other log-generating pods running on the same node.


### PR DESCRIPTION
**What this PR does / why we need it**:
This adds a couple of alerts to detect misbehaving Fluentbit pods.

**Does this PR introduce a user-facing change?**:
```release-note
NONE
```
