### PR TITLE
Extend Seed CR Validation

### DIFF
--- a/api/pkg/crd/kubermatic/v1/datacenter.go
+++ b/api/pkg/crd/kubermatic/v1/datacenter.go
@@ -51,12 +51,12 @@ type Datacenter struct {
 	Country string `json:"country,omitempty"`
 	// Detailed location of the cluster. For informational purposes only
 	Location string `json:"location,omitempty"`
-	// Node holds node-specific settings, like e.G. HTTP proxy, insecure registrys and the like
+	// Node holds node-specific settings, like e.g. HTTP proxy, insecure registries and the like
 	Node NodeSettings   `json:"node"`
 	Spec DatacenterSpec `json:"spec"`
 }
 
-// DatacenterSpec describes mutually points to provider datacenter spec
+// DatacenterSpec mutually points to provider datacenter spec
 type DatacenterSpec struct {
 	Digitalocean *DatacenterSpecDigitalocean `json:"digitalocean,omitempty"`
 	BringYourOwn *DatacenterSpecBringYourOwn `json:"bringyourown,omitempty"`
@@ -85,7 +85,7 @@ type DatacenterSpecDigitalocean struct {
 	Region string `json:"region"`
 }
 
-// DatacenterSpecOpenstack describes a open stack datacenter
+// DatacenterSpecOpenstack describes an Openstack datacenter
 type DatacenterSpecOpenstack struct {
 	AuthURL           string `json:"auth_url"`
 	AvailabilityZone  string `json:"availability_zone"`
@@ -117,7 +117,7 @@ type DatacenterSpecAzure struct {
 	Location string `json:"location"`
 }
 
-// DatacenterSpecVSphere describes a vsphere datacenter
+// DatacenterSpecVSphere describes a vSphere datacenter
 type DatacenterSpecVSphere struct {
 	Endpoint      string `json:"endpoint"`
 	AllowInsecure bool   `json:"allow_insecure"`
@@ -138,7 +138,7 @@ type DatacenterSpecVSphere struct {
 	InfraManagementUser *VSphereCredentials `json:"infra_management_user,omitempty"`
 }
 
-// DatacenterSpecAWS describes a aws datacenter
+// DatacenterSpecAWS describes an AWS datacenter
 type DatacenterSpecAWS struct {
 	Region string    `json:"region"`
 	Images ImageList `json:"images"`
@@ -148,7 +148,7 @@ type DatacenterSpecAWS struct {
 type DatacenterSpecBringYourOwn struct {
 }
 
-// DatacenterSpecPacket describes a packet datacenter
+// DatacenterSpecPacket describes a Packet datacenter
 type DatacenterSpecPacket struct {
 	Facilities []string `json:"facilities"`
 }
@@ -169,7 +169,7 @@ type DatacenterSpecFake struct {
 type DatacenterSpecKubevirt struct {
 }
 
-// NodeSettings are node specific which can be configured on datacenter level
+// NodeSettings are node specific flags which can be configured on datacenter level
 type NodeSettings struct {
 	// If set, this proxy will be configured on all nodes.
 	HTTPProxy string `json:"http_proxy,omitempty"`

--- a/api/pkg/provider/conversions.go
+++ b/api/pkg/provider/conversions.go
@@ -17,7 +17,7 @@ func DatacenterMetasToSeeds(dm map[string]DatacenterMeta) (map[string]*kubermati
 
 	for dcName, datacenterSpec := range dm {
 		if datacenterSpec.IsSeed && datacenterSpec.Seed != "" {
-			return nil, fmt.Errorf("datacenter %q is configured as seed but has a seed configured(%q) which is only allowed for datacenters that are not a seed", dcName, datacenterSpec.Seed)
+			return nil, fmt.Errorf("datacenter %q is configured as seed but has a seed configured (%q) which is only allowed for datacenters that are not a seed", dcName, datacenterSpec.Seed)
 		}
 		if !datacenterSpec.IsSeed && datacenterSpec.Seed == "" {
 			return nil, fmt.Errorf("datacenter %q is not configured as seed but does not have a corresponding seed configured. Configuring a seed datacenter is required for all node datacenters", dcName)
@@ -43,10 +43,10 @@ func DatacenterMetasToSeeds(dm map[string]DatacenterMeta) (map[string]*kubermati
 
 		} else {
 			if _, exists := dm[datacenterSpec.Seed]; !exists {
-				return nil, fmt.Errorf("seedDatacenter %q used by nodeDatacenter %q does not exist", datacenterSpec.Seed, dcName)
+				return nil, fmt.Errorf("seedDatacenter %q used by node datacenter %q does not exist", datacenterSpec.Seed, dcName)
 			}
 			if !dm[datacenterSpec.Seed].IsSeed {
-				return nil, fmt.Errorf("datacenter %q referenced by nodeDatacenter %q as its seed is not configured to be a seed",
+				return nil, fmt.Errorf("datacenter %q referenced by node datacenter %q as its seed is not configured to be a seed",
 					datacenterSpec.Seed, dcName)
 
 			}

--- a/api/pkg/provider/conversions_test.go
+++ b/api/pkg/provider/conversions_test.go
@@ -51,7 +51,7 @@ func TestDatacenterMetasToSeedDatacenterSpecs(t *testing.T) {
 				},
 			},
 			verify: func(_ map[string]*kubermaticv1.Seed, err error) error {
-				expectedErr := `seedDatacenter "my-seed" used by nodeDatacenter "my-dc" does not exist`
+				expectedErr := `seedDatacenter "my-seed" used by node datacenter "my-dc" does not exist`
 				if err == nil || err.Error() != expectedErr {
 					return fmt.Errorf("Expected error to be %q, was %v", expectedErr, err)
 				}
@@ -66,7 +66,7 @@ func TestDatacenterMetasToSeedDatacenterSpecs(t *testing.T) {
 				"my-invalid-datacenter": {Seed: "my-valid-datacenter"},
 			},
 			verify: func(_ map[string]*kubermaticv1.Seed, err error) error {
-				expectedErr := `datacenter "my-valid-datacenter" referenced by nodeDatacenter "my-invalid-datacenter" as its seed is not configured to be a seed`
+				expectedErr := `datacenter "my-valid-datacenter" referenced by node datacenter "my-invalid-datacenter" as its seed is not configured to be a seed`
 				if err == nil || err.Error() != expectedErr {
 					return fmt.Errorf("expected error to be %q, was %v", expectedErr, err)
 				}

--- a/api/pkg/provider/datacenter.go
+++ b/api/pkg/provider/datacenter.go
@@ -136,7 +136,7 @@ func validateDatacenters(datacenters map[string]DatacenterMeta) error {
 			continue
 		}
 		if errs := validation.IsDNS1123Subdomain(datacenterName); errs != nil {
-			return fmt.Errorf("Datacentername %q is not a valid DNS name: %v", datacenterName, errs)
+			return fmt.Errorf("Datacenter name %q is not a valid DNS name: %v", datacenterName, errs)
 		}
 	}
 

--- a/api/pkg/provider/datacenter.go
+++ b/api/pkg/provider/datacenter.go
@@ -126,6 +126,8 @@ func ValidateSeed(seed *kubermaticv1.Seed) error {
 		}
 	}
 
+	// invalid DNS overwrites can happen when a seed was freshly converted from
+	// the datacenters.yaml and has not yet been validated
 	if seed.Spec.SeedDNSOverwrite != nil && *seed.Spec.SeedDNSOverwrite != "" {
 		if errs := validation.IsDNS1123Subdomain(*seed.Spec.SeedDNSOverwrite); errs != nil {
 			return fmt.Errorf("DNS overwrite %q is not a valid DNS name: %v", *seed.Spec.SeedDNSOverwrite, errs)

--- a/api/pkg/provider/datacenter.go
+++ b/api/pkg/provider/datacenter.go
@@ -74,16 +74,18 @@ func loadSeeds(path string) (map[string]*kubermaticv1.Seed, error) {
 		return nil, fmt.Errorf("failed to parse datacenters.yaml: %v", err)
 	}
 
-	if err := validateDatacenters(dcMetas.Datacenters); err != nil {
-		return nil, fmt.Errorf("failed to validate datacenters.yaml: %v", err)
-	}
-
-	dcs, err := DatacenterMetasToSeeds(dcMetas.Datacenters)
+	seeds, err := DatacenterMetasToSeeds(dcMetas.Datacenters)
 	if err != nil {
 		return nil, fmt.Errorf("failed to convert datacenters.yaml: %v", err)
 	}
 
-	return dcs, nil
+	for seedName, seed := range seeds {
+		if err := ValidateSeed(seed); err != nil {
+			return nil, fmt.Errorf("failed to validate datacenters.yaml: seed %q is invalid: %v", seedName, err)
+		}
+	}
+
+	return seeds, nil
 }
 
 func LoadSeed(path, datacenterName string) (*kubermaticv1.Seed, error) {
@@ -110,8 +112,8 @@ func validateImageList(images kubermaticv1.ImageList) error {
 	return nil
 }
 
-func validateDatacenters(datacenters map[string]DatacenterMeta) error {
-	for name, dc := range datacenters {
+func ValidateSeed(seed *kubermaticv1.Seed) error {
+	for name, dc := range seed.Spec.Datacenters {
 		if dc.Spec.VSphere != nil {
 			if err := validateImageList(dc.Spec.VSphere.Templates); err != nil {
 				return fmt.Errorf("invalid datacenter defined '%s': %v", name, err)
@@ -124,19 +126,13 @@ func validateDatacenters(datacenters map[string]DatacenterMeta) error {
 		}
 	}
 
-	for datacenterName, datacenter := range datacenters {
-		if !datacenter.IsSeed {
-			continue
+	if seed.Spec.SeedDNSOverwrite != nil && *seed.Spec.SeedDNSOverwrite != "" {
+		if errs := validation.IsDNS1123Subdomain(*seed.Spec.SeedDNSOverwrite); errs != nil {
+			return fmt.Errorf("DNS overwrite %q is not a valid DNS name: %v", *seed.Spec.SeedDNSOverwrite, errs)
 		}
-		if datacenter.SeedDNSOverwrite != nil && *datacenter.SeedDNSOverwrite != "" {
-			if errs := validation.IsDNS1123Subdomain(*datacenter.SeedDNSOverwrite); errs != nil {
-				return fmt.Errorf("SeedDNS overwrite %q of datacenter %q is not a valid DNS name: %v",
-					*datacenter.SeedDNSOverwrite, datacenterName, errs)
-			}
-			continue
-		}
-		if errs := validation.IsDNS1123Subdomain(datacenterName); errs != nil {
-			return fmt.Errorf("Datacenter name %q is not a valid DNS name: %v", datacenterName, errs)
+	} else {
+		if errs := validation.IsDNS1123Subdomain(seed.Name); errs != nil {
+			return fmt.Errorf("seed name %q is not a valid DNS name: %v", seed.Name, errs)
 		}
 	}
 

--- a/api/pkg/provider/datacenter_test.go
+++ b/api/pkg/provider/datacenter_test.go
@@ -158,6 +158,12 @@ func TestMigrateDatacenters(t *testing.T) {
 			},
 			errExpected: true,
 		},
+		{
+			name: "Invalid name, but is not a seed",
+			datacenters: map[string]DatacenterMeta{
+				"&invalid": {},
+			},
+		},
 	}
 
 	for _, tc := range testCases {

--- a/api/pkg/provider/datacenter_test.go
+++ b/api/pkg/provider/datacenter_test.go
@@ -116,59 +116,57 @@ datacenters:
 	assert.Equal(t, expectedSeeds, resultDatacenters)
 }
 
-func TestValidateDataCenters(t *testing.T) {
+func TestValidateSeed(t *testing.T) {
 	testCases := []struct {
 		name        string
-		datacenters map[string]DatacenterMeta
+		seed        *kubermaticv1.Seed
 		errExpected bool
 	}{
 		{
 			name: "Invalid name, error",
-			datacenters: map[string]DatacenterMeta{
-				"&invalid": {
-					IsSeed: true,
+			seed: &kubermaticv1.Seed{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "&invalid",
 				},
 			},
 			errExpected: true,
 		},
 		{
 			name: "Valid name succeeds",
-			datacenters: map[string]DatacenterMeta{
-				"valid": {
-					IsSeed: true,
+			seed: &kubermaticv1.Seed{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "valid-name",
 				},
 			},
 		},
 		{
 			name: "Invalid name, valid seed dns override",
-			datacenters: map[string]DatacenterMeta{
-				"&invalid": {
-					IsSeed:           true,
+			seed: &kubermaticv1.Seed{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "&invalid",
+				},
+				Spec: kubermaticv1.SeedSpec{
 					SeedDNSOverwrite: utilpointer.StringPtr("valid"),
 				},
 			},
 		},
 		{
 			name: "Valid name, invalid seed dns override",
-			datacenters: map[string]DatacenterMeta{
-				"valid": {
-					IsSeed:           true,
+			seed: &kubermaticv1.Seed{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "valid-name",
+				},
+				Spec: kubermaticv1.SeedSpec{
 					SeedDNSOverwrite: utilpointer.StringPtr("&invalid"),
 				},
 			},
 			errExpected: true,
 		},
-		{
-			name: "Invalid name, but is not a seed",
-			datacenters: map[string]DatacenterMeta{
-				"&invalid": {},
-			},
-		},
 	}
 
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
-			if err := validateDatacenters(tc.datacenters); (err != nil) != tc.errExpected {
+			if err := ValidateSeed(tc.seed); (err != nil) != tc.errExpected {
 				t.Fatalf("Expected err: %t, but got err: %v", tc.errExpected, err)
 			}
 		})

--- a/api/pkg/provider/datacenter_test.go
+++ b/api/pkg/provider/datacenter_test.go
@@ -158,12 +158,6 @@ func TestMigrateDatacenters(t *testing.T) {
 			},
 			errExpected: true,
 		},
-		{
-			name: "Invalid name, but is not a seed",
-			datacenters: map[string]DatacenterMeta{
-				"&invalid": {},
-			},
-		},
 	}
 
 	for _, tc := range testCases {

--- a/api/pkg/validation/seed/seed.go
+++ b/api/pkg/validation/seed/seed.go
@@ -36,6 +36,7 @@ type seedValidator struct {
 	listOpts *ctrlruntimeclient.ListOptions
 }
 
+// Validate returns an error if the given seed does not pass all validation steps.
 func (sv *seedValidator) Validate(seed *kubermaticv1.Seed, isDelete bool) error {
 	// We need locking to make the validation concurrency-safe
 	sv.lock.Lock()
@@ -54,30 +55,68 @@ func (sv *seedValidator) Validate(seed *kubermaticv1.Seed, isDelete bool) error 
 	return sv.validate(seed, client, seeds, isDelete)
 }
 
-func (sv *seedValidator) validate(seed *kubermaticv1.Seed, seedClient ctrlruntimeclient.Client, existingSeeds map[string]*kubermaticv1.Seed, isDelete bool) error {
+func (sv *seedValidator) validate(seed *kubermaticv1.Seed, seedClient ctrlruntimeclient.Client, seeds map[string]*kubermaticv1.Seed, isDelete bool) error {
+	existingSeed := seeds[seed.Name]
 
-	newDatacenters := sets.NewString()
+	// remove the seed itself from the list, so uniqueness checks won't fail
+	delete(seeds, seed.Name)
+
+	affectedDatacenters := sets.NewString()
 	for datacenter := range seed.Spec.Datacenters {
-		newDatacenters.Insert(datacenter)
+		affectedDatacenters.Insert(datacenter)
 	}
 
-	for _, existingSeed := range existingSeeds {
-		for existingDatacenter := range existingSeed.Spec.Datacenters {
-			if newDatacenters.Has(existingDatacenter) {
-				return fmt.Errorf("datacenter %q already exists in seed %q, can only have one datacenter with a given name", existingDatacenter, existingSeed.Name)
+	// list of datacenters that remain after the operation we validate would be completed
+	finalDatacenters := sets.NewString()
+	for _, s := range seeds {
+		for dc := range s.Spec.Datacenters {
+			finalDatacenters.Insert(dc)
+		}
+	}
+
+	if !isDelete {
+		finalDatacenters = finalDatacenters.Union(affectedDatacenters)
+	}
+
+	// check if all the DCs in the seed are unique
+	for _, s := range seeds {
+		for dc := range s.Spec.Datacenters {
+			if affectedDatacenters.Has(dc) {
+				return fmt.Errorf("datacenter %q already exists in seed %q, can only have one datacenter with a given name", dc, s.Name)
 			}
 		}
 	}
 
+	// check if all DCs have exactly one provider and that the provider
+	// is never changed after it has been set once
+	for dcName, dc := range seed.Spec.Datacenters {
+		providerName, err := provider.DatacenterCloudProviderName(&dc.Spec)
+		if err != nil {
+			return fmt.Errorf("datacenter %q is invalid: %v", dcName, err)
+		}
+		if providerName == "" {
+			return fmt.Errorf("datacenter %q has no provider defined", dcName)
+		}
+
+		if existingSeed != nil {
+			if existingDC, ok := existingSeed.Spec.Datacenters[dcName]; ok {
+				existingProvider, _ := provider.DatacenterCloudProviderName(&existingDC.Spec)
+				if providerName != existingProvider {
+					return fmt.Errorf("cannot change datacenter %q provider from %q", dcName, existingProvider)
+				}
+			}
+		}
+	}
+
+	// check if there are still clusters using DCs not defined anymore
 	clusters := &kubermaticv1.ClusterList{}
 	if err := seedClient.List(sv.ctx, sv.listOpts, clusters); err != nil {
 		return fmt.Errorf("failed to list clusters: %v", err)
 	}
 
 	for _, cluster := range clusters.Items {
-		if !newDatacenters.Has(cluster.Spec.Cloud.DatacenterName) {
-			return fmt.Errorf("datacenter %q is still in use, can not delete it",
-				cluster.Spec.Cloud.DatacenterName)
+		if !affectedDatacenters.Has(cluster.Spec.Cloud.DatacenterName) {
+			return fmt.Errorf("datacenter %q is still in use, cannot delete it", cluster.Spec.Cloud.DatacenterName)
 		}
 	}
 

--- a/api/pkg/validation/seed/seed_test.go
+++ b/api/pkg/validation/seed/seed_test.go
@@ -123,7 +123,7 @@ func TestValidate(t *testing.T) {
 					},
 					Spec: kubermaticv1.SeedSpec{
 						Datacenters: map[string]kubermaticv1.Datacenter{
-							"in-use": {
+							"dc1": {
 								Spec: fakeProviderSpec,
 							},
 						},

--- a/api/pkg/validation/seed/seed_test.go
+++ b/api/pkg/validation/seed/seed_test.go
@@ -13,7 +13,7 @@ import (
 )
 
 func init() {
-	// We call this in init because even thought it is possible to register the same
+	// We call this in init because even though it is possible to register the same
 	// scheme multiple times it is an unprotected concurrent map access and these tests
 	// are very good at making that panic
 	if err := kubermaticv1.SchemeBuilder.AddToScheme(scheme.Scheme); err != nil {
@@ -22,21 +22,39 @@ func init() {
 }
 
 func TestValidate(t *testing.T) {
+	fakeProviderSpec := kubermaticv1.DatacenterSpec{
+		Fake: &kubermaticv1.DatacenterSpecFake{},
+	}
 
 	testCases := []struct {
 		name             string
 		existingSeeds    map[string]*kubermaticv1.Seed
 		seedToValidate   *kubermaticv1.Seed
-		existingClusters []runtime.Object
+		existingClusters map[string][]runtime.Object
 		isDelete         bool
 		errExpected      bool
 	}{
 		{
-			name:           "Happy path, no error",
+			name:           "Adding an empty seed should be possible",
 			seedToValidate: &kubermaticv1.Seed{},
 		},
 		{
-			name: "DatacenterName already in use, error",
+			name: "Adding a seed with a single datacenter and valid provider should succeed",
+			seedToValidate: &kubermaticv1.Seed{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "new-seed",
+				},
+				Spec: kubermaticv1.SeedSpec{
+					Datacenters: map[string]kubermaticv1.Datacenter{
+						"dc1": {
+							Spec: fakeProviderSpec,
+						},
+					},
+				},
+			},
+		},
+		{
+			name: "No changes, no error",
 			existingSeeds: map[string]*kubermaticv1.Seed{
 				"existing-seed": {
 					ObjectMeta: metav1.ObjectMeta{
@@ -44,38 +62,271 @@ func TestValidate(t *testing.T) {
 					},
 					Spec: kubermaticv1.SeedSpec{
 						Datacenters: map[string]kubermaticv1.Datacenter{
-							"in-use": {},
+							"dc1": {
+								Spec: fakeProviderSpec,
+							},
 						},
 					},
 				},
 			},
 			seedToValidate: &kubermaticv1.Seed{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "existing-seed",
+				},
 				Spec: kubermaticv1.SeedSpec{
 					Datacenters: map[string]kubermaticv1.Datacenter{
-						"in-use": {},
+						"dc1": {
+							Spec: fakeProviderSpec,
+						},
+					},
+				},
+			},
+		},
+		{
+			name: "Adding new datacenter should be possible",
+			existingSeeds: map[string]*kubermaticv1.Seed{
+				"existing-seed": {
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "existing-seed",
+					},
+					Spec: kubermaticv1.SeedSpec{
+						Datacenters: map[string]kubermaticv1.Datacenter{
+							"dc1": {
+								Spec: fakeProviderSpec,
+							},
+						},
+					},
+				},
+			},
+			seedToValidate: &kubermaticv1.Seed{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "existing-seed",
+				},
+				Spec: kubermaticv1.SeedSpec{
+					Datacenters: map[string]kubermaticv1.Datacenter{
+						"dc1": {
+							Spec: fakeProviderSpec,
+						},
+						"dc2": {
+							Spec: fakeProviderSpec,
+						},
+					},
+				},
+			},
+		},
+		{
+			name: "Should be able to remove unused datacenters from a seed",
+			existingSeeds: map[string]*kubermaticv1.Seed{
+				"existing-seed": {
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "existing-seed",
+					},
+					Spec: kubermaticv1.SeedSpec{
+						Datacenters: map[string]kubermaticv1.Datacenter{
+							"in-use": {
+								Spec: fakeProviderSpec,
+							},
+						},
+					},
+				},
+			},
+			seedToValidate: &kubermaticv1.Seed{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "new-seed",
+				},
+				Spec: kubermaticv1.SeedSpec{
+					Datacenters: map[string]kubermaticv1.Datacenter{},
+				},
+			},
+		},
+		{
+			name: "Datacenters must have a provider defined",
+			seedToValidate: &kubermaticv1.Seed{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "myseed",
+				},
+				Spec: kubermaticv1.SeedSpec{
+					Datacenters: map[string]kubermaticv1.Datacenter{
+						"a": {},
 					},
 				},
 			},
 			errExpected: true,
 		},
 		{
-			name:           "Removed datacenter still in use, error",
-			seedToValidate: &kubermaticv1.Seed{},
-			existingClusters: []runtime.Object{&kubermaticv1.Cluster{
-				Spec: kubermaticv1.ClusterSpec{
-					Cloud: kubermaticv1.CloudSpec{
-						DatacenterName: "keep-me",
+			name: "Datacenters cannot have multiple providers",
+			seedToValidate: &kubermaticv1.Seed{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "myseed",
+				},
+				Spec: kubermaticv1.SeedSpec{
+					Datacenters: map[string]kubermaticv1.Datacenter{
+						"a": {
+							Spec: kubermaticv1.DatacenterSpec{
+								AWS:   &kubermaticv1.DatacenterSpecAWS{},
+								Azure: &kubermaticv1.DatacenterSpecAzure{},
+							},
+						},
 					},
 				},
-			}},
+			},
 			errExpected: true,
 		},
 		{
-			name:             "Deletion when there are still clusters, error",
-			seedToValidate:   &kubermaticv1.Seed{},
-			existingClusters: []runtime.Object{&kubermaticv1.Cluster{}},
-			isDelete:         true,
-			errExpected:      true,
+			name: "It should not be possible to change a datacenter's provider",
+			existingSeeds: map[string]*kubermaticv1.Seed{
+				"existing-seed": {
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "existing-seed",
+					},
+					Spec: kubermaticv1.SeedSpec{
+						Datacenters: map[string]kubermaticv1.Datacenter{
+							"dc1": {
+								Spec: fakeProviderSpec,
+							},
+						},
+					},
+				},
+			},
+			seedToValidate: &kubermaticv1.Seed{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "existing-seed",
+				},
+				Spec: kubermaticv1.SeedSpec{
+					Datacenters: map[string]kubermaticv1.Datacenter{
+						"dc1": {},
+					},
+				},
+			},
+			errExpected: true,
+		},
+		{
+			name: "Datacenter names are unique across all seeds",
+			existingSeeds: map[string]*kubermaticv1.Seed{
+				"existing-seed": {
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "existing-seed",
+					},
+					Spec: kubermaticv1.SeedSpec{
+						Datacenters: map[string]kubermaticv1.Datacenter{
+							"in-use": {
+								Spec: fakeProviderSpec,
+							},
+						},
+					},
+				},
+			},
+			seedToValidate: &kubermaticv1.Seed{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "new-seed",
+				},
+				Spec: kubermaticv1.SeedSpec{
+					Datacenters: map[string]kubermaticv1.Datacenter{
+						"in-use": {
+							Spec: fakeProviderSpec,
+						},
+					},
+				},
+			},
+			errExpected: true,
+		},
+		{
+			name: "Cannot remove datacenters that are used by clusters",
+			existingSeeds: map[string]*kubermaticv1.Seed{
+				"existing-seed": {
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "existing-seed",
+					},
+					Spec: kubermaticv1.SeedSpec{
+						Datacenters: map[string]kubermaticv1.Datacenter{
+							"dc1": {
+								Spec: fakeProviderSpec,
+							},
+						},
+					},
+				},
+			},
+			existingClusters: map[string][]runtime.Object{
+				"existing-seed": []runtime.Object{
+					&kubermaticv1.Cluster{
+						Spec: kubermaticv1.ClusterSpec{
+							Cloud: kubermaticv1.CloudSpec{
+								DatacenterName: "dc1",
+							},
+						},
+					},
+				},
+			},
+			seedToValidate: &kubermaticv1.Seed{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "existing-seed",
+				},
+			},
+			errExpected: true,
+		},
+		{
+			name:           "Shuld be able to delete empty seeds",
+			seedToValidate: &kubermaticv1.Seed{},
+			isDelete:       true,
+		},
+		{
+			name: "Shuld be able to delete seeds with no used datacenters",
+			existingSeeds: map[string]*kubermaticv1.Seed{
+				"existing-seed": {
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "existing-seed",
+					},
+					Spec: kubermaticv1.SeedSpec{
+						Datacenters: map[string]kubermaticv1.Datacenter{
+							"dc1": {
+								Spec: fakeProviderSpec,
+							},
+						},
+					},
+				},
+				"other-seed": {
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "other-seed",
+					},
+					Spec: kubermaticv1.SeedSpec{
+						Datacenters: map[string]kubermaticv1.Datacenter{
+							"other-dc": {
+								Spec: fakeProviderSpec,
+							},
+						},
+					},
+				},
+			},
+			existingClusters: map[string][]runtime.Object{
+				"other-seed": []runtime.Object{
+					&kubermaticv1.Cluster{
+						Spec: kubermaticv1.ClusterSpec{
+							Cloud: kubermaticv1.CloudSpec{
+								DatacenterName: "other-dc",
+							},
+						},
+					},
+				},
+			},
+			seedToValidate: &kubermaticv1.Seed{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "existing-seed",
+				},
+			},
+			isDelete: true,
+		},
+		{
+			name: "Cannot delete a seed when there are still clusters left",
+			seedToValidate: &kubermaticv1.Seed{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "myseed",
+				},
+			},
+			existingClusters: map[string][]runtime.Object{
+				"myseed": []runtime.Object{&kubermaticv1.Cluster{}},
+			},
+			isDelete:    true,
+			errExpected: true,
 		},
 	}
 
@@ -85,12 +336,14 @@ func TestValidate(t *testing.T) {
 				listOpts: &ctrlruntimeclient.ListOptions{},
 			}
 
+			existingClusters := tc.existingClusters[tc.seedToValidate.Name]
+
 			err := sv.validate(tc.seedToValidate,
-				fakectrlruntimeclient.NewFakeClient(tc.existingClusters...),
+				fakectrlruntimeclient.NewFakeClient(existingClusters...),
 				tc.existingSeeds, tc.isDelete)
 
 			if (err != nil) != tc.errExpected {
-				t.Fatalf("expected err: %t, but got err: %v", tc.errExpected, err)
+				t.Fatalf("Expected err: %t, but got err: %v", tc.errExpected, err)
 			}
 		})
 	}

--- a/api/pkg/validation/seed/seed_test.go
+++ b/api/pkg/validation/seed/seed_test.go
@@ -247,7 +247,7 @@ func TestValidate(t *testing.T) {
 				},
 			},
 			existingClusters: map[string][]runtime.Object{
-				"existing-seed": []runtime.Object{
+				"existing-seed": {
 					&kubermaticv1.Cluster{
 						Spec: kubermaticv1.ClusterSpec{
 							Cloud: kubermaticv1.CloudSpec{
@@ -298,7 +298,7 @@ func TestValidate(t *testing.T) {
 				},
 			},
 			existingClusters: map[string][]runtime.Object{
-				"other-seed": []runtime.Object{
+				"other-seed": {
 					&kubermaticv1.Cluster{
 						Spec: kubermaticv1.ClusterSpec{
 							Cloud: kubermaticv1.CloudSpec{
@@ -323,7 +323,7 @@ func TestValidate(t *testing.T) {
 				},
 			},
 			existingClusters: map[string][]runtime.Object{
-				"myseed": []runtime.Object{&kubermaticv1.Cluster{}},
+				"myseed": {&kubermaticv1.Cluster{}},
 			},
 			isDelete:    true,
 			errExpected: true,

--- a/api/pkg/validation/seed/server.go
+++ b/api/pkg/validation/seed/server.go
@@ -27,7 +27,7 @@ type WebhookOpts struct {
 }
 
 func (opts *WebhookOpts) AddFlags(fs *flag.FlagSet) {
-	fs.StringVar(&opts.ListenAddress, "seed-admisisonwebhook-listen-address", ":8100", "The listen address for the seed amission webhook")
+	fs.StringVar(&opts.ListenAddress, "seed-admissionwebhook-listen-address", ":8100", "The listen address for the seed amission webhook")
 	fs.StringVar(&opts.CertFile, "seed-admissionwebhook-cert-file", "", "The location of the certificate file")
 	fs.StringVar(&opts.KeyFile, "seed-admissionwebhook-key-file", "", "The location of the certificate key file")
 }

--- a/api/pkg/validation/seed/server.go
+++ b/api/pkg/validation/seed/server.go
@@ -76,7 +76,7 @@ type Server struct {
 	validator     *seedValidator
 }
 
-// This implements sigs.k8s.io/controller-runtime/pkg/manager.Runnable
+// Start implements sigs.k8s.io/controller-runtime/pkg/manager.Runnable
 func (s *Server) Start(_ <-chan struct{}) error {
 	return s.ListenAndServeTLS(s.certFile, s.keyFile)
 }
@@ -99,13 +99,13 @@ func (s *Server) handleSeedValidationRequests(resp http.ResponseWriter, req *htt
 	}
 	serializedAdmissionResponse, err := json.Marshal(response)
 	if err != nil {
-		s.log.Errorw("failed to serialize admission response", zap.Error(err))
+		s.log.Errorw("Failed to serialize admission response", zap.Error(err))
 		http.Error(resp, "failed to serialize response", http.StatusInternalServerError)
 		return
 	}
 	resp.WriteHeader(http.StatusOK)
 	if _, err := resp.Write(serializedAdmissionResponse); err != nil {
-		s.log.Errorw("failed to write response body", zap.Error(err))
+		s.log.Errorw("Failed to write response body", zap.Error(err))
 		return
 	}
 	s.log.Debug("Successfully validated seed")
@@ -142,7 +142,7 @@ func (s *Server) handle(req *http.Request) (*admissionv1beta1.AdmissionRequest, 
 
 	validationErr := s.validator.Validate(seed, admissionReview.Request.Operation == admissionv1beta1.Delete)
 	if validationErr != nil {
-		s.log.Errorw("seed failed validation", "seed", seed.Name, "validationError", validationErr.Error())
+		s.log.Errorw("Seed failed validation", "seed", seed.Name, "validationError", validationErr.Error())
 	}
 
 	return admissionReview.Request, validationErr

--- a/api/pkg/validation/seed/server.go
+++ b/api/pkg/validation/seed/server.go
@@ -58,7 +58,6 @@ func (opts *WebhookOpts) Server(
 		listenAddress: opts.ListenAddress,
 		certFile:      opts.CertFile,
 		keyFile:       opts.KeyFile,
-		workerName:    workerName,
 		validator:     newValidator(ctx, seedsGetter, seedClientGetter, listOpts),
 	}
 	mux := http.NewServeMux()
@@ -74,7 +73,6 @@ type Server struct {
 	listenAddress string
 	certFile      string
 	keyFile       string
-	workerName    string
 	validator     *seedValidator
 }
 

--- a/api/pkg/validation/seed/server.go
+++ b/api/pkg/validation/seed/server.go
@@ -142,11 +142,6 @@ func (s *Server) handle(req *http.Request) (*admissionv1beta1.AdmissionRequest, 
 		}
 	}
 
-	// ignore requests for non-matcher worker names
-	if seed.Labels[kubermaticv1.WorkerNameLabelKey] != s.workerName {
-		return admissionReview.Request, nil
-	}
-
 	validationErr := s.validator.Validate(seed, admissionReview.Request.Operation == admissionv1beta1.Delete)
 	if validationErr != nil {
 		s.log.Errorw("Seed failed validation", "seed", seed.Name, "validationError", validationErr.Error())


### PR DESCRIPTION
**What this PR does / why we need it**:
This implements the remaining validation features for seed CRs. It also converts the existing `provider.validateDatacenters` function to work based on seeds, i.e. it is now called *after* the conversion has happened. _This also means that datacenters that belong to no seed are not validated anymore,_ as they are dropped anyway.

By accident I also found a typo for a CLI flag and included the fix here because why not.

**Which issue(s) this PR fixes**:
Part of #2113, fixes #3888

**Does this PR introduce a user-facing change?**:
```release-note
NONE
```
