### PR TITLE
update Kubernetes versions to address CVE-2019-9512, CVE-2019-9514

### DIFF
--- a/config/kubermatic/static/master/updates.yaml
+++ b/config/kubermatic/static/master/updates.yaml
@@ -10,9 +10,9 @@ updates:
 - from: 1.13.*
   to: 1.13.*
   automatic: false
-# CVE-2019-11247, CVE-2019-11249
-- from: <= 1.13.8, >= 1.13.0
-  to: 1.13.9
+# CVE-2019-11247, CVE-2019-11249, CVE-2019-9512, CVE-2019-9514
+- from: <= 1.13.9, >= 1.13.0
+  to: 1.13.10
   automatic: true
 # Allow to next minor release
 - from: 1.13.*
@@ -24,9 +24,9 @@ updates:
 - from: 1.14.*
   to: 1.14.*
   automatic: false
-# CVE-2019-11247, CVE-2019-11249
-- from: <= 1.14.4, >= 1.14.0
-  to: 1.14.5
+# CVE-2019-11247, CVE-2019-11249, CVE-2019-9512, CVE-2019-9514
+- from: <= 1.14.5, >= 1.14.0
+  to: 1.14.6
   automatic: true
 # Allow to next minor release
 - from: 1.14.*
@@ -38,7 +38,7 @@ updates:
 - from: 1.15.*
   to: 1.15.*
   automatic: false
-# CVE-2019-11247, CVE-2019-11249
-- from: <= 1.15.1, >= 1.15.0
-  to: 1.15.2
+# CVE-2019-11247, CVE-2019-11249, CVE-2019-9512, CVE-2019-9514
+- from: <= 1.15.2, >= 1.15.0
+  to: 1.15.3
   automatic: true

--- a/config/kubermatic/static/master/versions.yaml
+++ b/config/kubermatic/static/master/versions.yaml
@@ -1,12 +1,12 @@
 versions:
 # Kubernetes 1.13
-- version: "1.13.9"
+- version: "1.13.10"
   default: false
 # Kubernetes 1.14
-- version: "v1.14.5"
+- version: "v1.14.6"
   default: true
 # Kubernetes 1.15
-- version: "v1.15.2"
+- version: "v1.15.3"
   default: false
 # OpenShift 3.11
 - version: "v3.11"


### PR DESCRIPTION
```release-note
Kubernetes versions affected by CVE-2019-9512 and CVE-2019-9514 have been dropped
```
