### PR TITLE
3241: extending the cluster crd by adding new condition

### DIFF
--- a/api/pkg/crd/kubermatic/v1/cluster.go
+++ b/api/pkg/crd/kubermatic/v1/cluster.go
@@ -164,6 +164,10 @@ type ClusterAddress struct {
 
 type ClusterConditionType string
 
+const (
+	ClusterControllerUpdateInProgressCondition ClusterConditionType = "ClusterControllerUpdateInProgress"
+)
+
 type ClusterCondition struct {
 	// Type of cluster condition.
 	Type ClusterConditionType `json:"type"`


### PR DESCRIPTION
Signed-off-by: Moath Qasim <moad.qassem@gmail.com>

**What this PR does / why we need it**:
This PR extends the cluster crd by adding a condition to check if a cluster upgrade is still in progress. We need to limit the number of concurrent cluster upgrades in the seed cluster.

**Which issue(s) this PR fixes** 
Fixes #3748 

**Special notes for your reviewer**:
This PR is part of several upcoming PRs so the added code is still not used but it has to be merged first as the ticket issue suggests.

**Does this PR introduce a user-facing change?**:
No

```release-note
NONE
```