### PR TITLE
[release/v2.10] update Kubernetes versions to address CVE-2019-9512, CVE-2019-9514 (#4113)

### DIFF
--- a/config/kubermatic/static/master/updates.yaml
+++ b/config/kubermatic/static/master/updates.yaml
@@ -10,9 +10,9 @@ updates:
 - from: 1.13.*
   to: 1.13.*
   automatic: false
-# CVE-2019-11247, CVE-2019-11249
-- from: <= 1.13.8, >= 1.13.0
-  to: 1.13.9
+# CVE-2019-11247, CVE-2019-11249, CVE-2019-9512, CVE-2019-9514
+- from: <= 1.13.9, >= 1.13.0
+  to: 1.13.10
   automatic: true
 # Allow to next minor release
 - from: 1.13.*
@@ -24,9 +24,9 @@ updates:
 - from: 1.14.*
   to: 1.14.*
   automatic: false
-# CVE-2019-11247, CVE-2019-11249
-- from: <= 1.14.4, >= 1.14.0
-  to: 1.14.5
+# CVE-2019-11247, CVE-2019-11249, CVE-2019-9512, CVE-2019-9514
+- from: <= 1.14.5, >= 1.14.0
+  to: 1.14.6
   automatic: true
 # Allow to next minor release
 - from: 1.14.*

--- a/config/kubermatic/static/master/versions.yaml
+++ b/config/kubermatic/static/master/versions.yaml
@@ -1,7 +1,7 @@
 versions:
 # Kubernetes 1.13
-- version: "1.13.9"
+- version: "1.13.10"
   default: false
 # Kubernetes 1.14
-- version: "v1.14.5"
+- version: "v1.14.6"
   default: true


### PR DESCRIPTION

```release-note
Kubernetes versions affected by CVE-2019-9512 and CVE-2019-9514 have been dropped
```
