### PR TITLE
fix OpenIDAuthPlugin feature

### DIFF
--- a/api/cmd/kubermatic-controller-manager/controllers.go
+++ b/api/cmd/kubermatic-controller-manager/controllers.go
@@ -141,8 +141,9 @@ func createClusterController(ctrlCtx *controllerContext) error {
 		ctrlCtx.runOptions.kubermaticImage,
 		ctrlCtx.runOptions.dnatControllerImage,
 		cluster.Features{
-			VPA:                      ctrlCtx.runOptions.featureGates.Enabled(VerticalPodAutoscaler),
-			EtcdDataCorruptionChecks: ctrlCtx.runOptions.featureGates.Enabled(EtcdDataCorruptionChecks),
+			VPA:                          ctrlCtx.runOptions.featureGates.Enabled(VerticalPodAutoscaler),
+			EtcdDataCorruptionChecks:     ctrlCtx.runOptions.featureGates.Enabled(EtcdDataCorruptionChecks),
+			KubernetesOIDCAuthentication: ctrlCtx.runOptions.featureGates.Enabled(OpenIDAuthPlugin),
 		},
 	)
 }


### PR DESCRIPTION
**What this PR does / why we need it**: OpenIDAuthPlugin feature flag is not passed to the cluster controller

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #4110

```release-note
Enabling the OIDC feature flag in clusters has been fixed.
```
