### PR TITLE
update kube-state-metrics to 1.7.2

### DIFF
--- a/config/monitoring/kube-state-metrics/Chart.yaml
+++ b/config/monitoring/kube-state-metrics/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 name: kube-state-metrics
-version: 1.0.2
-appVersion: v1.6.0
+version: 1.0.3
+appVersion: v1.7.2
 description: Kube-State-Metrics for Kubermatic
 keywords:
 - kubermatic

--- a/config/monitoring/kube-state-metrics/values.yaml
+++ b/config/monitoring/kube-state-metrics/values.yaml
@@ -13,7 +13,7 @@ kubeStateMetrics:
   resizer:
     image:
       repository: gcr.io/google_containers/addon-resizer
-      tag: '1.8.4'
+      tag: '2.3'
     resources:
       requests:
         cpu: 50m

--- a/config/monitoring/kube-state-metrics/values.yaml
+++ b/config/monitoring/kube-state-metrics/values.yaml
@@ -1,7 +1,7 @@
 kubeStateMetrics:
   image:
     repository: quay.io/coreos/kube-state-metrics
-    tag: v1.6.0
+    tag: v1.7.2
   resources:
     requests:
       cpu: 50m


### PR DESCRIPTION
**What this PR does / why we need it**:
This might cause trouble, let's see. The Addon-Resizer had only 1.8.5 released between 1.8.4 and 2.3 and the only changes seem to be harmless for us.

**Does this PR introduce a user-facing change?**:
```release-note
update kube-state-metrics to 1.7.2
```
