### PR TITLE
Fix conformance tests npd when loggin wait timeout error

### DIFF
--- a/api/cmd/conformance-tests/runner.go
+++ b/api/cmd/conformance-tests/runner.go
@@ -252,19 +252,19 @@ func (r *testRunner) executeScenario(log *zap.SugaredLogger, scenario testScenar
 		cluster = &clusterList.Items[0]
 	}
 
+	// We must store the name here because the cluster object may be nil on error
+	clusterName := cluster.Name
 	if err := junitReporterWrapper(
 		"[Kubermatic] Wait for controlplane",
 		report,
 		func() error {
-			cluster, err = r.waitForControlPlane(log, cluster.Name)
+			cluster, err = r.waitForControlPlane(log, clusterName)
 			return err
 		},
-		func() string { return r.controlplaneWaitFailureStdout(cluster.Name) }); err != nil {
+		func() string { return r.controlplaneWaitFailureStdout(clusterName) }); err != nil {
 		return report, fmt.Errorf("failed waiting for control plane to become ready: %v", err)
 	}
 
-	// We must store the name here because the cluster object may be nil on error
-	clusterName := cluster.Name
 	if err := junitReporterWrapper(
 		"[Kubermatic] Add LB and PV Finalizers",
 		report,


### PR DESCRIPTION
**What this PR does / why we need it**:

Fixes a NPD when logging extra output after the controlplane waiting timed out, e.G. seen here: https://prow.loodse.com/view/gcs/prow-data/pr-logs/pull/kubermatic_kubermatic/4114/pull-kubermatic-e2e-aws-coreos-1.13/1163790708843220993

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Documentation**:
<!-- Add links to the related documentation changes related to this pull request. E.g. the link to the kubermatic/docs pullrequest. -->

**Does this PR introduce a user-facing change?**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If  no release note is required, just write "NONE".
-->
```release-note
none
```

/assign @xrstf 