### PR TITLE
update Prometheus to 2.12.0

### DIFF
--- a/config/monitoring/prometheus/Chart.yaml
+++ b/config/monitoring/prometheus/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 name: prometheus
-version: 2.1.6
-appVersion: v2.11.0
+version: 2.1.7
+appVersion: v2.12.0
 description: Prometheus Monitoring for Kubernetes
 keywords:
 - kubermatic

--- a/config/monitoring/prometheus/values.yaml
+++ b/config/monitoring/prometheus/values.yaml
@@ -1,7 +1,7 @@
 prometheus:
   image:
     repository: quay.io/prometheus/prometheus
-    tag: v2.11.0
+    tag: v2.12.0
     pullPolicy: IfNotPresent
 
   host: ''


### PR DESCRIPTION
**What this PR does / why we need it**:
No special incompatibilities according to the changelog.

**Does this PR introduce a user-facing change?**:
```release-note
update Prometheus to 2.12.0
```
