### PR TITLE
update nginx-ingress-controller to 0.25.1

### DIFF
--- a/config/nginx-ingress-controller/Chart.yaml
+++ b/config/nginx-ingress-controller/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 name: nginx-ingress-controller
-version: 1.0.1
-appVersion: 0.25.0
+version: 1.0.2
+appVersion: 0.25.1
 description: nginx-ingress-controller
 keywords:
 - kubermatic

--- a/config/nginx-ingress-controller/values.yaml
+++ b/config/nginx-ingress-controller/values.yaml
@@ -4,7 +4,7 @@ nginx:
   replicas: 3
   image:
     repository: quay.io/kubernetes-ingress-controller/nginx-ingress-controller
-    tag: 0.25.0
+    tag: 0.25.1
   config: {}
 #    load-balance: "least_conn"
   resources:


### PR DESCRIPTION
**What this PR does / why we need it**:
This brings security fixes and should be backported to 2.11.

**Does this PR introduce a user-facing change?**:
```release-note
update nginx-ingress-controller to 0.25.1
```
