### PR TITLE
Volume mode defaulting for secrets and configmaps

### DIFF
--- a/api/pkg/controller/backup/backup_controller.go
+++ b/api/pkg/controller/backup/backup_controller.go
@@ -410,8 +410,7 @@ func (r *Reconciler) cronjob(cluster *kubermaticv1.Cluster) reconciling.NamedCro
 					Name: r.getEtcdSecretName(cluster),
 					VolumeSource: corev1.VolumeSource{
 						Secret: &corev1.SecretVolumeSource{
-							SecretName:  r.getEtcdSecretName(cluster),
-							DefaultMode: resources.Int32(resources.DefaultOwnerReadOnlyMode),
+							SecretName: r.getEtcdSecretName(cluster),
 						},
 					},
 				},

--- a/api/pkg/controller/openshift/resources/apiserver_deployment.go
+++ b/api/pkg/controller/openshift/resources/apiserver_deployment.go
@@ -254,8 +254,7 @@ func getAPIServerVolumes() []corev1.Volume {
 			Name: resources.ApiserverTLSSecretName,
 			VolumeSource: corev1.VolumeSource{
 				Secret: &corev1.SecretVolumeSource{
-					SecretName:  resources.ApiserverTLSSecretName,
-					DefaultMode: resources.Int32(resources.DefaultOwnerReadOnlyMode),
+					SecretName: resources.ApiserverTLSSecretName,
 				},
 			},
 		},
@@ -263,8 +262,7 @@ func getAPIServerVolumes() []corev1.Volume {
 			Name: resources.OpenVPNClientCertificatesSecretName,
 			VolumeSource: corev1.VolumeSource{
 				Secret: &corev1.SecretVolumeSource{
-					SecretName:  resources.OpenVPNClientCertificatesSecretName,
-					DefaultMode: resources.Int32(resources.DefaultOwnerReadOnlyMode),
+					SecretName: resources.OpenVPNClientCertificatesSecretName,
 				},
 			},
 		},
@@ -272,8 +270,7 @@ func getAPIServerVolumes() []corev1.Volume {
 			Name: resources.KubeletClientCertificatesSecretName,
 			VolumeSource: corev1.VolumeSource{
 				Secret: &corev1.SecretVolumeSource{
-					SecretName:  resources.KubeletClientCertificatesSecretName,
-					DefaultMode: resources.Int32(resources.DefaultOwnerReadOnlyMode),
+					SecretName: resources.KubeletClientCertificatesSecretName,
 				},
 			},
 		},
@@ -281,8 +278,7 @@ func getAPIServerVolumes() []corev1.Volume {
 			Name: resources.CASecretName,
 			VolumeSource: corev1.VolumeSource{
 				Secret: &corev1.SecretVolumeSource{
-					SecretName:  resources.CASecretName,
-					DefaultMode: resources.Int32(resources.DefaultOwnerReadOnlyMode),
+					SecretName: resources.CASecretName,
 					Items: []corev1.KeyToPath{
 						{
 							Path: resources.CACertSecretKey,
@@ -296,8 +292,7 @@ func getAPIServerVolumes() []corev1.Volume {
 			Name: resources.ServiceAccountKeySecretName,
 			VolumeSource: corev1.VolumeSource{
 				Secret: &corev1.SecretVolumeSource{
-					SecretName:  resources.ServiceAccountKeySecretName,
-					DefaultMode: resources.Int32(resources.DefaultOwnerReadOnlyMode),
+					SecretName: resources.ServiceAccountKeySecretName,
 				},
 			},
 		},
@@ -308,7 +303,6 @@ func getAPIServerVolumes() []corev1.Volume {
 					LocalObjectReference: corev1.LocalObjectReference{
 						Name: resources.CloudConfigConfigMapName,
 					},
-					DefaultMode: resources.Int32(420),
 				},
 			},
 		},
@@ -316,8 +310,7 @@ func getAPIServerVolumes() []corev1.Volume {
 			Name: resources.ApiserverEtcdClientCertificateSecretName,
 			VolumeSource: corev1.VolumeSource{
 				Secret: &corev1.SecretVolumeSource{
-					SecretName:  resources.ApiserverEtcdClientCertificateSecretName,
-					DefaultMode: resources.Int32(resources.DefaultOwnerReadOnlyMode),
+					SecretName: resources.ApiserverEtcdClientCertificateSecretName,
 				},
 			},
 		},
@@ -325,8 +318,7 @@ func getAPIServerVolumes() []corev1.Volume {
 			Name: resources.ApiserverFrontProxyClientCertificateSecretName,
 			VolumeSource: corev1.VolumeSource{
 				Secret: &corev1.SecretVolumeSource{
-					SecretName:  resources.ApiserverFrontProxyClientCertificateSecretName,
-					DefaultMode: resources.Int32(resources.DefaultOwnerReadOnlyMode),
+					SecretName: resources.ApiserverFrontProxyClientCertificateSecretName,
 				},
 			},
 		},
@@ -334,8 +326,7 @@ func getAPIServerVolumes() []corev1.Volume {
 			Name: resources.FrontProxyCASecretName,
 			VolumeSource: corev1.VolumeSource{
 				Secret: &corev1.SecretVolumeSource{
-					SecretName:  resources.FrontProxyCASecretName,
-					DefaultMode: resources.Int32(resources.DefaultOwnerReadOnlyMode),
+					SecretName: resources.FrontProxyCASecretName,
 				},
 			},
 		},
@@ -343,8 +334,7 @@ func getAPIServerVolumes() []corev1.Volume {
 			Name: resources.KubeletDnatControllerKubeconfigSecretName,
 			VolumeSource: corev1.VolumeSource{
 				Secret: &corev1.SecretVolumeSource{
-					SecretName:  resources.KubeletDnatControllerKubeconfigSecretName,
-					DefaultMode: resources.Int32(resources.DefaultAllReadOnlyMode),
+					SecretName: resources.KubeletDnatControllerKubeconfigSecretName,
 				},
 			},
 		},
@@ -353,7 +343,6 @@ func getAPIServerVolumes() []corev1.Volume {
 			VolumeSource: corev1.VolumeSource{
 				ConfigMap: &corev1.ConfigMapVolumeSource{
 					LocalObjectReference: corev1.LocalObjectReference{Name: openshiftKubeAPIServerConfigMapName},
-					DefaultMode:          resources.Int32(420),
 				},
 			},
 		},
@@ -361,8 +350,7 @@ func getAPIServerVolumes() []corev1.Volume {
 			Name: apiserverLoopbackKubeconfigName,
 			VolumeSource: corev1.VolumeSource{
 				Secret: &corev1.SecretVolumeSource{
-					SecretName:  apiserverLoopbackKubeconfigName,
-					DefaultMode: resources.Int32(resources.DefaultOwnerReadOnlyMode),
+					SecretName: apiserverLoopbackKubeconfigName,
 				},
 			},
 		},
@@ -370,8 +358,7 @@ func getAPIServerVolumes() []corev1.Volume {
 			Name: ServiceSignerCASecretName,
 			VolumeSource: corev1.VolumeSource{
 				Secret: &corev1.SecretVolumeSource{
-					SecretName:  ServiceSignerCASecretName,
-					DefaultMode: resources.Int32(resources.DefaultOwnerReadOnlyMode),
+					SecretName: ServiceSignerCASecretName,
 				},
 			},
 		},
@@ -379,8 +366,7 @@ func getAPIServerVolumes() []corev1.Volume {
 			Name: resources.DexCASecretName,
 			VolumeSource: corev1.VolumeSource{
 				Secret: &corev1.SecretVolumeSource{
-					SecretName:  resources.DexCASecretName,
-					DefaultMode: resources.Int32(resources.DefaultOwnerReadOnlyMode),
+					SecretName: resources.DexCASecretName,
 				},
 			},
 		},

--- a/api/pkg/controller/openshift/resources/controller_manager_deployment.go
+++ b/api/pkg/controller/openshift/resources/controller_manager_deployment.go
@@ -199,8 +199,7 @@ func getControllerManagerVolumes() []corev1.Volume {
 			Name: resources.CASecretName,
 			VolumeSource: corev1.VolumeSource{
 				Secret: &corev1.SecretVolumeSource{
-					SecretName:  resources.CASecretName,
-					DefaultMode: resources.Int32(resources.DefaultOwnerReadOnlyMode),
+					SecretName: resources.CASecretName,
 				},
 			},
 		},
@@ -208,8 +207,7 @@ func getControllerManagerVolumes() []corev1.Volume {
 			Name: resources.ServiceAccountKeySecretName,
 			VolumeSource: corev1.VolumeSource{
 				Secret: &corev1.SecretVolumeSource{
-					SecretName:  resources.ServiceAccountKeySecretName,
-					DefaultMode: resources.Int32(resources.DefaultOwnerReadOnlyMode),
+					SecretName: resources.ServiceAccountKeySecretName,
 				},
 			},
 		},
@@ -220,7 +218,6 @@ func getControllerManagerVolumes() []corev1.Volume {
 					LocalObjectReference: corev1.LocalObjectReference{
 						Name: resources.CloudConfigConfigMapName,
 					},
-					DefaultMode: resources.Int32(420),
 				},
 			},
 		},
@@ -228,8 +225,7 @@ func getControllerManagerVolumes() []corev1.Volume {
 			Name: resources.OpenVPNClientCertificatesSecretName,
 			VolumeSource: corev1.VolumeSource{
 				Secret: &corev1.SecretVolumeSource{
-					SecretName:  resources.OpenVPNClientCertificatesSecretName,
-					DefaultMode: resources.Int32(resources.DefaultOwnerReadOnlyMode),
+					SecretName: resources.OpenVPNClientCertificatesSecretName,
 				},
 			},
 		},
@@ -237,8 +233,7 @@ func getControllerManagerVolumes() []corev1.Volume {
 			Name: resources.InternalUserClusterAdminKubeconfigSecretName,
 			VolumeSource: corev1.VolumeSource{
 				Secret: &corev1.SecretVolumeSource{
-					SecretName:  resources.InternalUserClusterAdminKubeconfigSecretName,
-					DefaultMode: resources.Int32(resources.DefaultOwnerReadOnlyMode),
+					SecretName: resources.InternalUserClusterAdminKubeconfigSecretName,
 				},
 			},
 		},
@@ -247,7 +242,6 @@ func getControllerManagerVolumes() []corev1.Volume {
 			VolumeSource: corev1.VolumeSource{
 				ConfigMap: &corev1.ConfigMapVolumeSource{
 					LocalObjectReference: corev1.LocalObjectReference{Name: openshiftControllerMangerConfigMapName},
-					DefaultMode:          resources.Int32(420),
 				},
 			},
 		},
@@ -255,8 +249,7 @@ func getControllerManagerVolumes() []corev1.Volume {
 			Name: ServiceSignerCASecretName,
 			VolumeSource: corev1.VolumeSource{
 				Secret: &corev1.SecretVolumeSource{
-					SecretName:  ServiceSignerCASecretName,
-					DefaultMode: resources.Int32(resources.DefaultOwnerReadOnlyMode),
+					SecretName: ServiceSignerCASecretName,
 				},
 			},
 		},
@@ -266,8 +259,7 @@ func getControllerManagerVolumes() []corev1.Volume {
 			Name: resources.ApiserverTLSSecretName,
 			VolumeSource: corev1.VolumeSource{
 				Secret: &corev1.SecretVolumeSource{
-					SecretName:  resources.ApiserverTLSSecretName,
-					DefaultMode: resources.Int32(resources.DefaultOwnerReadOnlyMode),
+					SecretName: resources.ApiserverTLSSecretName,
 				},
 			},
 		},

--- a/api/pkg/controller/openshift/resources/openshift_apiserver_deployment.go
+++ b/api/pkg/controller/openshift/resources/openshift_apiserver_deployment.go
@@ -90,8 +90,7 @@ func OpenshiftAPIServerDeploymentCreator(ctx context.Context, data openshiftData
 					Name: resources.CASecretName,
 					VolumeSource: corev1.VolumeSource{
 						Secret: &corev1.SecretVolumeSource{
-							SecretName:  resources.CASecretName,
-							DefaultMode: resources.Int32(resources.DefaultOwnerReadOnlyMode),
+							SecretName: resources.CASecretName,
 							Items: []corev1.KeyToPath{
 								{
 									Path: "ca-bundle.crt",
@@ -105,8 +104,7 @@ func OpenshiftAPIServerDeploymentCreator(ctx context.Context, data openshiftData
 					Name: openshiftAPIServerTLSServingCertSecretName,
 					VolumeSource: corev1.VolumeSource{
 						Secret: &corev1.SecretVolumeSource{
-							SecretName:  openshiftAPIServerTLSServingCertSecretName,
-							DefaultMode: resources.Int32(resources.DefaultOwnerReadOnlyMode),
+							SecretName: openshiftAPIServerTLSServingCertSecretName,
 						},
 					},
 				},
@@ -114,8 +112,7 @@ func OpenshiftAPIServerDeploymentCreator(ctx context.Context, data openshiftData
 					Name: resources.FrontProxyCASecretName,
 					VolumeSource: corev1.VolumeSource{
 						Secret: &corev1.SecretVolumeSource{
-							SecretName:  resources.FrontProxyCASecretName,
-							DefaultMode: resources.Int32(resources.DefaultOwnerReadOnlyMode),
+							SecretName: resources.FrontProxyCASecretName,
 						},
 					},
 				},
@@ -123,8 +120,7 @@ func OpenshiftAPIServerDeploymentCreator(ctx context.Context, data openshiftData
 					Name: resources.ApiserverEtcdClientCertificateSecretName,
 					VolumeSource: corev1.VolumeSource{
 						Secret: &corev1.SecretVolumeSource{
-							SecretName:  resources.ApiserverEtcdClientCertificateSecretName,
-							DefaultMode: resources.Int32(resources.DefaultOwnerReadOnlyMode),
+							SecretName: resources.ApiserverEtcdClientCertificateSecretName,
 						},
 					},
 				},
@@ -132,8 +128,7 @@ func OpenshiftAPIServerDeploymentCreator(ctx context.Context, data openshiftData
 					Name: resources.OpenVPNClientCertificatesSecretName,
 					VolumeSource: corev1.VolumeSource{
 						Secret: &corev1.SecretVolumeSource{
-							SecretName:  resources.OpenVPNClientCertificatesSecretName,
-							DefaultMode: resources.Int32(resources.DefaultOwnerReadOnlyMode),
+							SecretName: resources.OpenVPNClientCertificatesSecretName,
 						},
 					},
 				},
@@ -141,8 +136,7 @@ func OpenshiftAPIServerDeploymentCreator(ctx context.Context, data openshiftData
 					Name: resources.KubeletDnatControllerKubeconfigSecretName,
 					VolumeSource: corev1.VolumeSource{
 						Secret: &corev1.SecretVolumeSource{
-							SecretName:  resources.KubeletDnatControllerKubeconfigSecretName,
-							DefaultMode: resources.Int32(resources.DefaultAllReadOnlyMode),
+							SecretName: resources.KubeletDnatControllerKubeconfigSecretName,
 						},
 					},
 				},
@@ -151,7 +145,6 @@ func OpenshiftAPIServerDeploymentCreator(ctx context.Context, data openshiftData
 					VolumeSource: corev1.VolumeSource{
 						ConfigMap: &corev1.ConfigMapVolumeSource{
 							LocalObjectReference: corev1.LocalObjectReference{Name: openshiftAPIServerConfigMapName},
-							DefaultMode:          resources.Int32(resources.DefaultAllReadOnlyMode),
 						},
 					},
 				},
@@ -159,8 +152,7 @@ func OpenshiftAPIServerDeploymentCreator(ctx context.Context, data openshiftData
 					Name: resources.InternalUserClusterAdminKubeconfigSecretName,
 					VolumeSource: corev1.VolumeSource{
 						Secret: &corev1.SecretVolumeSource{
-							SecretName:  resources.InternalUserClusterAdminKubeconfigSecretName,
-							DefaultMode: resources.Int32(resources.DefaultAllReadOnlyMode),
+							SecretName: resources.InternalUserClusterAdminKubeconfigSecretName,
 						},
 					},
 				},

--- a/api/pkg/controller/openshift/testdata/Kubermatic_API_image_is_overwritten-usercluster-controller.golden.yaml
+++ b/api/pkg/controller/openshift/testdata/Kubermatic_API_image_is_overwritten-usercluster-controller.golden.yaml
@@ -101,18 +101,18 @@ spec:
       volumes:
       - name: internal-admin-kubeconfig
         secret:
-          defaultMode: 292
+          defaultMode: 420
           secretName: internal-admin-kubeconfig
       - name: ca
         secret:
-          defaultMode: 292
+          defaultMode: 420
           items:
           - key: ca.crt
             path: ca.crt
           secretName: ca
       - name: openvpn-ca
         secret:
-          defaultMode: 292
+          defaultMode: 420
           secretName: openvpn-ca
       - emptyDir: {}
         name: http-prober-bin

--- a/api/pkg/controller/operator-master/resources/kubermatic/api.go
+++ b/api/pkg/controller/operator-master/resources/kubermatic/api.go
@@ -89,8 +89,7 @@ func APIDeploymentCreator(cfg *operatorv1alpha1.KubermaticConfiguration) reconci
 					Name: "kubeconfig",
 					VolumeSource: corev1.VolumeSource{
 						Secret: &corev1.SecretVolumeSource{
-							DefaultMode: pointer.Int32Ptr(420),
-							SecretName:  kubeconfigSecretName,
+							SecretName: kubeconfigSecretName,
 						},
 					},
 				},
@@ -116,8 +115,7 @@ func APIDeploymentCreator(cfg *operatorv1alpha1.KubermaticConfiguration) reconci
 					Name: "master-files",
 					VolumeSource: corev1.VolumeSource{
 						Secret: &corev1.SecretVolumeSource{
-							DefaultMode: pointer.Int32Ptr(420),
-							SecretName:  masterFilesSecretName,
+							SecretName: masterFilesSecretName,
 						},
 					},
 				})
@@ -136,8 +134,7 @@ func APIDeploymentCreator(cfg *operatorv1alpha1.KubermaticConfiguration) reconci
 					Name: "presets",
 					VolumeSource: corev1.VolumeSource{
 						Secret: &corev1.SecretVolumeSource{
-							DefaultMode: pointer.Int32Ptr(420),
-							SecretName:  presetsSecretName,
+							SecretName: presetsSecretName,
 						},
 					},
 				})
@@ -156,8 +153,7 @@ func APIDeploymentCreator(cfg *operatorv1alpha1.KubermaticConfiguration) reconci
 					Name: "datacenters",
 					VolumeSource: corev1.VolumeSource{
 						Secret: &corev1.SecretVolumeSource{
-							DefaultMode: pointer.Int32Ptr(420),
-							SecretName:  datacentersSecretName,
+							SecretName: datacentersSecretName,
 						},
 					},
 				})

--- a/api/pkg/controller/operator-master/resources/kubermatic/master-controller-manager.go
+++ b/api/pkg/controller/operator-master/resources/kubermatic/master-controller-manager.go
@@ -56,8 +56,7 @@ func MasterControllerManagerDeploymentCreator(cfg *operatorv1alpha1.KubermaticCo
 					Name: "kubeconfig",
 					VolumeSource: corev1.VolumeSource{
 						Secret: &corev1.SecretVolumeSource{
-							DefaultMode: pointer.Int32Ptr(420),
-							SecretName:  kubeconfigSecretName,
+							SecretName: kubeconfigSecretName,
 						},
 					},
 				},
@@ -78,8 +77,7 @@ func MasterControllerManagerDeploymentCreator(cfg *operatorv1alpha1.KubermaticCo
 					Name: "datacenters",
 					VolumeSource: corev1.VolumeSource{
 						Secret: &corev1.SecretVolumeSource{
-							DefaultMode: pointer.Int32Ptr(420),
-							SecretName:  datacentersSecretName,
+							SecretName: datacentersSecretName,
 						},
 					},
 				})

--- a/api/pkg/controller/operator-master/resources/kubermatic/ui.go
+++ b/api/pkg/controller/operator-master/resources/kubermatic/ui.go
@@ -71,7 +71,6 @@ func UIDeploymentCreator(cfg *operatorv1alpha1.KubermaticConfiguration) reconcil
 					Name: "config",
 					VolumeSource: corev1.VolumeSource{
 						ConfigMap: &corev1.ConfigMapVolumeSource{
-							DefaultMode:          pointer.Int32Ptr(420),
 							LocalObjectReference: corev1.LocalObjectReference{Name: uiConfigConfigMapName},
 						},
 					},

--- a/api/pkg/controller/seed-proxy/resources.go
+++ b/api/pkg/controller/seed-proxy/resources.go
@@ -250,8 +250,7 @@ func masterDeploymentCreator(contextName string, secret *corev1.Secret) reconcil
 					Name: "kubeconfig",
 					VolumeSource: corev1.VolumeSource{
 						Secret: &corev1.SecretVolumeSource{
-							DefaultMode: i32ptr(420),
-							SecretName:  secret.Name,
+							SecretName: secret.Name,
 						},
 					},
 				},

--- a/api/pkg/resources/apiserver/deployment.go
+++ b/api/pkg/resources/apiserver/deployment.go
@@ -341,8 +341,7 @@ func getVolumes() []corev1.Volume {
 			Name: resources.ApiserverTLSSecretName,
 			VolumeSource: corev1.VolumeSource{
 				Secret: &corev1.SecretVolumeSource{
-					SecretName:  resources.ApiserverTLSSecretName,
-					DefaultMode: resources.Int32(resources.DefaultOwnerReadOnlyMode),
+					SecretName: resources.ApiserverTLSSecretName,
 				},
 			},
 		},
@@ -350,8 +349,7 @@ func getVolumes() []corev1.Volume {
 			Name: resources.TokensSecretName,
 			VolumeSource: corev1.VolumeSource{
 				Secret: &corev1.SecretVolumeSource{
-					SecretName:  resources.TokensSecretName,
-					DefaultMode: resources.Int32(resources.DefaultOwnerReadOnlyMode),
+					SecretName: resources.TokensSecretName,
 				},
 			},
 		},
@@ -359,8 +357,7 @@ func getVolumes() []corev1.Volume {
 			Name: resources.OpenVPNClientCertificatesSecretName,
 			VolumeSource: corev1.VolumeSource{
 				Secret: &corev1.SecretVolumeSource{
-					SecretName:  resources.OpenVPNClientCertificatesSecretName,
-					DefaultMode: resources.Int32(resources.DefaultOwnerReadOnlyMode),
+					SecretName: resources.OpenVPNClientCertificatesSecretName,
 				},
 			},
 		},
@@ -368,8 +365,7 @@ func getVolumes() []corev1.Volume {
 			Name: resources.KubeletClientCertificatesSecretName,
 			VolumeSource: corev1.VolumeSource{
 				Secret: &corev1.SecretVolumeSource{
-					SecretName:  resources.KubeletClientCertificatesSecretName,
-					DefaultMode: resources.Int32(resources.DefaultOwnerReadOnlyMode),
+					SecretName: resources.KubeletClientCertificatesSecretName,
 				},
 			},
 		},
@@ -377,8 +373,7 @@ func getVolumes() []corev1.Volume {
 			Name: resources.CASecretName,
 			VolumeSource: corev1.VolumeSource{
 				Secret: &corev1.SecretVolumeSource{
-					SecretName:  resources.CASecretName,
-					DefaultMode: resources.Int32(resources.DefaultOwnerReadOnlyMode),
+					SecretName: resources.CASecretName,
 					Items: []corev1.KeyToPath{
 						{
 							Path: resources.CACertSecretKey,
@@ -392,8 +387,7 @@ func getVolumes() []corev1.Volume {
 			Name: resources.ServiceAccountKeySecretName,
 			VolumeSource: corev1.VolumeSource{
 				Secret: &corev1.SecretVolumeSource{
-					SecretName:  resources.ServiceAccountKeySecretName,
-					DefaultMode: resources.Int32(resources.DefaultOwnerReadOnlyMode),
+					SecretName: resources.ServiceAccountKeySecretName,
 				},
 			},
 		},
@@ -404,7 +398,6 @@ func getVolumes() []corev1.Volume {
 					LocalObjectReference: corev1.LocalObjectReference{
 						Name: resources.CloudConfigConfigMapName,
 					},
-					DefaultMode: resources.Int32(420),
 				},
 			},
 		},
@@ -412,8 +405,7 @@ func getVolumes() []corev1.Volume {
 			Name: resources.ApiserverEtcdClientCertificateSecretName,
 			VolumeSource: corev1.VolumeSource{
 				Secret: &corev1.SecretVolumeSource{
-					SecretName:  resources.ApiserverEtcdClientCertificateSecretName,
-					DefaultMode: resources.Int32(resources.DefaultOwnerReadOnlyMode),
+					SecretName: resources.ApiserverEtcdClientCertificateSecretName,
 				},
 			},
 		},
@@ -421,8 +413,7 @@ func getVolumes() []corev1.Volume {
 			Name: resources.ApiserverFrontProxyClientCertificateSecretName,
 			VolumeSource: corev1.VolumeSource{
 				Secret: &corev1.SecretVolumeSource{
-					SecretName:  resources.ApiserverFrontProxyClientCertificateSecretName,
-					DefaultMode: resources.Int32(resources.DefaultOwnerReadOnlyMode),
+					SecretName: resources.ApiserverFrontProxyClientCertificateSecretName,
 				},
 			},
 		},
@@ -430,8 +421,7 @@ func getVolumes() []corev1.Volume {
 			Name: resources.FrontProxyCASecretName,
 			VolumeSource: corev1.VolumeSource{
 				Secret: &corev1.SecretVolumeSource{
-					SecretName:  resources.FrontProxyCASecretName,
-					DefaultMode: resources.Int32(resources.DefaultOwnerReadOnlyMode),
+					SecretName: resources.FrontProxyCASecretName,
 				},
 			},
 		},
@@ -439,8 +429,7 @@ func getVolumes() []corev1.Volume {
 			Name: resources.KubeletDnatControllerKubeconfigSecretName,
 			VolumeSource: corev1.VolumeSource{
 				Secret: &corev1.SecretVolumeSource{
-					SecretName:  resources.KubeletDnatControllerKubeconfigSecretName,
-					DefaultMode: resources.Int32(resources.DefaultAllReadOnlyMode),
+					SecretName: resources.KubeletDnatControllerKubeconfigSecretName,
 				},
 			},
 		},
@@ -464,13 +453,11 @@ func getEnvVars(data resources.CredentialsData) ([]corev1.EnvVar, error) {
 }
 
 func getDexCASecretVolume() corev1.Volume {
-
 	return corev1.Volume{
 		Name: resources.DexCASecretName,
 		VolumeSource: corev1.VolumeSource{
 			Secret: &corev1.SecretVolumeSource{
-				SecretName:  resources.DexCASecretName,
-				DefaultMode: resources.Int32(resources.DefaultOwnerReadOnlyMode),
+				SecretName: resources.DexCASecretName,
 			},
 		},
 	}

--- a/api/pkg/resources/clusterautoscaler/clusterautoscaler.go
+++ b/api/pkg/resources/clusterautoscaler/clusterautoscaler.go
@@ -45,9 +45,6 @@ func DeploymentCreator(data clusterautoscalerData) reconciling.NamedDeploymentCr
 					VolumeSource: corev1.VolumeSource{
 						Secret: &corev1.SecretVolumeSource{
 							SecretName: resources.ClusterAutoscalerKubeconfigSecretName,
-							// We have to make the secret readable for all for now because owner/group cannot be changed.
-							// ( upstream proposal: https://github.com/kubernetes/kubernetes/pull/28733 )
-							DefaultMode: resources.Int32(resources.DefaultAllReadOnlyMode),
 						},
 					},
 				},

--- a/api/pkg/resources/controllermanager/deployment.go
+++ b/api/pkg/resources/controllermanager/deployment.go
@@ -64,8 +64,7 @@ func DeploymentCreator(data *resources.TemplateData) reconciling.NamedDeployment
 					Name: resources.GoogleServiceAccountVolumeName,
 					VolumeSource: corev1.VolumeSource{
 						Secret: &corev1.SecretVolumeSource{
-							SecretName:  resources.GoogleServiceAccountSecretName,
-							DefaultMode: resources.Int32(resources.DefaultOwnerReadOnlyMode),
+							SecretName: resources.GoogleServiceAccountSecretName,
 						},
 					},
 				}
@@ -287,8 +286,7 @@ func getVolumes() []corev1.Volume {
 			Name: resources.CASecretName,
 			VolumeSource: corev1.VolumeSource{
 				Secret: &corev1.SecretVolumeSource{
-					SecretName:  resources.CASecretName,
-					DefaultMode: resources.Int32(resources.DefaultOwnerReadOnlyMode),
+					SecretName: resources.CASecretName,
 				},
 			},
 		},
@@ -296,8 +294,7 @@ func getVolumes() []corev1.Volume {
 			Name: resources.ServiceAccountKeySecretName,
 			VolumeSource: corev1.VolumeSource{
 				Secret: &corev1.SecretVolumeSource{
-					SecretName:  resources.ServiceAccountKeySecretName,
-					DefaultMode: resources.Int32(resources.DefaultOwnerReadOnlyMode),
+					SecretName: resources.ServiceAccountKeySecretName,
 				},
 			},
 		},
@@ -308,7 +305,6 @@ func getVolumes() []corev1.Volume {
 					LocalObjectReference: corev1.LocalObjectReference{
 						Name: resources.CloudConfigConfigMapName,
 					},
-					DefaultMode: resources.Int32(420),
 				},
 			},
 		},
@@ -316,8 +312,7 @@ func getVolumes() []corev1.Volume {
 			Name: resources.OpenVPNClientCertificatesSecretName,
 			VolumeSource: corev1.VolumeSource{
 				Secret: &corev1.SecretVolumeSource{
-					SecretName:  resources.OpenVPNClientCertificatesSecretName,
-					DefaultMode: resources.Int32(resources.DefaultOwnerReadOnlyMode),
+					SecretName: resources.OpenVPNClientCertificatesSecretName,
 				},
 			},
 		},
@@ -325,8 +320,7 @@ func getVolumes() []corev1.Volume {
 			Name: resources.ControllerManagerKubeconfigSecretName,
 			VolumeSource: corev1.VolumeSource{
 				Secret: &corev1.SecretVolumeSource{
-					SecretName:  resources.ControllerManagerKubeconfigSecretName,
-					DefaultMode: resources.Int32(resources.DefaultOwnerReadOnlyMode),
+					SecretName: resources.ControllerManagerKubeconfigSecretName,
 				},
 			},
 		},

--- a/api/pkg/resources/dns/dns.go
+++ b/api/pkg/resources/dns/dns.go
@@ -138,7 +138,6 @@ func getVolumes() []corev1.Volume {
 					LocalObjectReference: corev1.LocalObjectReference{
 						Name: resources.DNSResolverConfigMapName,
 					},
-					DefaultMode: resources.Int32(resources.DefaultOwnerReadOnlyMode),
 				},
 			},
 		},
@@ -146,8 +145,7 @@ func getVolumes() []corev1.Volume {
 			Name: resources.OpenVPNClientCertificatesSecretName,
 			VolumeSource: corev1.VolumeSource{
 				Secret: &corev1.SecretVolumeSource{
-					SecretName:  resources.OpenVPNClientCertificatesSecretName,
-					DefaultMode: resources.Int32(resources.DefaultOwnerReadOnlyMode),
+					SecretName: resources.OpenVPNClientCertificatesSecretName,
 				},
 			},
 		},
@@ -155,8 +153,7 @@ func getVolumes() []corev1.Volume {
 			Name: resources.CASecretName,
 			VolumeSource: corev1.VolumeSource{
 				Secret: &corev1.SecretVolumeSource{
-					SecretName:  resources.CASecretName,
-					DefaultMode: resources.Int32(resources.DefaultOwnerReadOnlyMode),
+					SecretName: resources.CASecretName,
 					Items: []corev1.KeyToPath{
 						{
 							Path: resources.CACertSecretKey,

--- a/api/pkg/resources/etcd/cronjob.go
+++ b/api/pkg/resources/etcd/cronjob.go
@@ -59,8 +59,7 @@ func CronJobCreator(data cronJobCreatorData) reconciling.NamedCronJobCreatorGett
 					Name: resources.ApiserverEtcdClientCertificateSecretName,
 					VolumeSource: corev1.VolumeSource{
 						Secret: &corev1.SecretVolumeSource{
-							SecretName:  resources.ApiserverEtcdClientCertificateSecretName,
-							DefaultMode: resources.Int32(resources.DefaultOwnerReadOnlyMode),
+							SecretName: resources.ApiserverEtcdClientCertificateSecretName,
 						},
 					},
 				},

--- a/api/pkg/resources/etcd/statefulset.go
+++ b/api/pkg/resources/etcd/statefulset.go
@@ -208,8 +208,7 @@ func getVolumes() []corev1.Volume {
 			Name: resources.EtcdTLSCertificateSecretName,
 			VolumeSource: corev1.VolumeSource{
 				Secret: &corev1.SecretVolumeSource{
-					SecretName:  resources.EtcdTLSCertificateSecretName,
-					DefaultMode: resources.Int32(resources.DefaultOwnerReadOnlyMode),
+					SecretName: resources.EtcdTLSCertificateSecretName,
 				},
 			},
 		},
@@ -217,8 +216,7 @@ func getVolumes() []corev1.Volume {
 			Name: resources.CASecretName,
 			VolumeSource: corev1.VolumeSource{
 				Secret: &corev1.SecretVolumeSource{
-					SecretName:  resources.CASecretName,
-					DefaultMode: resources.Int32(resources.DefaultOwnerReadOnlyMode),
+					SecretName: resources.CASecretName,
 					Items: []corev1.KeyToPath{
 						{
 							Path: resources.CACertSecretKey,
@@ -232,8 +230,7 @@ func getVolumes() []corev1.Volume {
 			Name: resources.ApiserverEtcdClientCertificateSecretName,
 			VolumeSource: corev1.VolumeSource{
 				Secret: &corev1.SecretVolumeSource{
-					SecretName:  resources.ApiserverEtcdClientCertificateSecretName,
-					DefaultMode: resources.Int32(resources.DefaultOwnerReadOnlyMode),
+					SecretName: resources.ApiserverEtcdClientCertificateSecretName,
 				},
 			},
 		},

--- a/api/pkg/resources/kubestatemetrics/deployment.go
+++ b/api/pkg/resources/kubestatemetrics/deployment.go
@@ -126,8 +126,7 @@ func getVolumes() []corev1.Volume {
 			Name: resources.KubeStateMetricsKubeconfigSecretName,
 			VolumeSource: corev1.VolumeSource{
 				Secret: &corev1.SecretVolumeSource{
-					SecretName:  resources.KubeStateMetricsKubeconfigSecretName,
-					DefaultMode: resources.Int32(resources.DefaultOwnerReadOnlyMode),
+					SecretName: resources.KubeStateMetricsKubeconfigSecretName,
 				},
 			},
 		},

--- a/api/pkg/resources/machinecontroller/deployment.go
+++ b/api/pkg/resources/machinecontroller/deployment.go
@@ -141,9 +141,6 @@ func getKubeconfigVolume() corev1.Volume {
 		VolumeSource: corev1.VolumeSource{
 			Secret: &corev1.SecretVolumeSource{
 				SecretName: resources.MachineControllerKubeconfigSecretName,
-				// We have to make the secret readable for all for now because owner/group cannot be changed.
-				// ( upstream proposal: https://github.com/kubernetes/kubernetes/pull/28733 )
-				DefaultMode: resources.Int32(resources.DefaultAllReadOnlyMode),
 			},
 		},
 	}

--- a/api/pkg/resources/machinecontroller/webhook.go
+++ b/api/pkg/resources/machinecontroller/webhook.go
@@ -151,8 +151,7 @@ func getServingCertVolume() corev1.Volume {
 		Name: resources.MachineControllerWebhookServingCertSecretName,
 		VolumeSource: corev1.VolumeSource{
 			Secret: &corev1.SecretVolumeSource{
-				SecretName:  resources.MachineControllerWebhookServingCertSecretName,
-				DefaultMode: resources.Int32(resources.DefaultAllReadOnlyMode),
+				SecretName: resources.MachineControllerWebhookServingCertSecretName,
 			},
 		},
 	}

--- a/api/pkg/resources/metrics-server/deployment.go
+++ b/api/pkg/resources/metrics-server/deployment.go
@@ -118,9 +118,6 @@ func getVolumes() []corev1.Volume {
 			VolumeSource: corev1.VolumeSource{
 				Secret: &corev1.SecretVolumeSource{
 					SecretName: resources.MetricsServerKubeconfigSecretName,
-					// We have to make the secret readable for all for now because owner/group cannot be changed.
-					// ( upstream proposal: https://github.com/kubernetes/kubernetes/pull/28733 )
-					DefaultMode: resources.Int32(resources.DefaultAllReadOnlyMode),
 				},
 			},
 		},
@@ -128,8 +125,7 @@ func getVolumes() []corev1.Volume {
 			Name: resources.OpenVPNClientCertificatesSecretName,
 			VolumeSource: corev1.VolumeSource{
 				Secret: &corev1.SecretVolumeSource{
-					SecretName:  resources.OpenVPNClientCertificatesSecretName,
-					DefaultMode: resources.Int32(resources.DefaultOwnerReadOnlyMode),
+					SecretName: resources.OpenVPNClientCertificatesSecretName,
 				},
 			},
 		},
@@ -137,8 +133,7 @@ func getVolumes() []corev1.Volume {
 			Name: resources.KubeletDnatControllerKubeconfigSecretName,
 			VolumeSource: corev1.VolumeSource{
 				Secret: &corev1.SecretVolumeSource{
-					SecretName:  resources.KubeletDnatControllerKubeconfigSecretName,
-					DefaultMode: resources.Int32(resources.DefaultAllReadOnlyMode),
+					SecretName: resources.KubeletDnatControllerKubeconfigSecretName,
 				},
 			},
 		},

--- a/api/pkg/resources/openvpn/deployment.go
+++ b/api/pkg/resources/openvpn/deployment.go
@@ -256,8 +256,7 @@ func getVolumes() []corev1.Volume {
 			Name: resources.CASecretName,
 			VolumeSource: corev1.VolumeSource{
 				Secret: &corev1.SecretVolumeSource{
-					SecretName:  resources.OpenVPNCASecretName,
-					DefaultMode: resources.Int32(resources.DefaultOwnerReadOnlyMode),
+					SecretName: resources.OpenVPNCASecretName,
 					Items: []corev1.KeyToPath{
 						{
 							Path: resources.OpenVPNCACertKey,
@@ -271,8 +270,7 @@ func getVolumes() []corev1.Volume {
 			Name: resources.OpenVPNServerCertificatesSecretName,
 			VolumeSource: corev1.VolumeSource{
 				Secret: &corev1.SecretVolumeSource{
-					SecretName:  resources.OpenVPNServerCertificatesSecretName,
-					DefaultMode: resources.Int32(resources.DefaultOwnerReadOnlyMode),
+					SecretName: resources.OpenVPNServerCertificatesSecretName,
 				},
 			},
 		},
@@ -283,7 +281,6 @@ func getVolumes() []corev1.Volume {
 					LocalObjectReference: corev1.LocalObjectReference{
 						Name: resources.OpenVPNClientConfigsConfigMapName,
 					},
-					DefaultMode: resources.Int32(resources.DefaultOwnerReadOnlyMode),
 				},
 			},
 		},

--- a/api/pkg/resources/prometheus/statefulset.go
+++ b/api/pkg/resources/prometheus/statefulset.go
@@ -172,7 +172,6 @@ func getVolumes() []corev1.Volume {
 					LocalObjectReference: corev1.LocalObjectReference{
 						Name: resources.PrometheusConfigConfigMapName,
 					},
-					DefaultMode: resources.Int32(resources.DefaultOwnerReadOnlyMode),
 				},
 			},
 		},
@@ -186,8 +185,7 @@ func getVolumes() []corev1.Volume {
 			Name: resources.ApiserverEtcdClientCertificateSecretName,
 			VolumeSource: corev1.VolumeSource{
 				Secret: &corev1.SecretVolumeSource{
-					SecretName:  resources.ApiserverEtcdClientCertificateSecretName,
-					DefaultMode: resources.Int32(resources.DefaultOwnerReadOnlyMode),
+					SecretName: resources.ApiserverEtcdClientCertificateSecretName,
 				},
 			},
 		},
@@ -195,8 +193,7 @@ func getVolumes() []corev1.Volume {
 			Name: resources.PrometheusApiserverClientCertificateSecretName,
 			VolumeSource: corev1.VolumeSource{
 				Secret: &corev1.SecretVolumeSource{
-					SecretName:  resources.PrometheusApiserverClientCertificateSecretName,
-					DefaultMode: resources.Int32(resources.DefaultOwnerReadOnlyMode),
+					SecretName: resources.PrometheusApiserverClientCertificateSecretName,
 				},
 			},
 		},

--- a/api/pkg/resources/reconciling/wrapper.go
+++ b/api/pkg/resources/reconciling/wrapper.go
@@ -7,6 +7,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/util/intstr"
+	utilpointer "k8s.io/utils/pointer"
 )
 
 // OwnerRefWrapper is responsible for wrapping a ObjectCreator function, solely to set the OwnerReference to the cluster object
@@ -72,6 +73,15 @@ func DefaultPodSpec(old, new corev1.PodSpec) (corev1.PodSpec, error) {
 
 	for idx, container := range new.Containers {
 		DefaultContainer(&new.Containers[idx], containerProcMountType[container.Name])
+	}
+
+	for idx, vol := range new.Volumes {
+		if vol.VolumeSource.Secret != nil && vol.VolumeSource.Secret.DefaultMode == nil {
+			new.Volumes[idx].Secret.DefaultMode = utilpointer.Int32Ptr(corev1.SecretVolumeSourceDefaultMode)
+		}
+		if vol.VolumeSource.ConfigMap != nil && vol.VolumeSource.ConfigMap.DefaultMode == nil {
+			new.Volumes[idx].ConfigMap.DefaultMode = utilpointer.Int32Ptr(corev1.ConfigMapVolumeSourceDefaultMode)
+		}
 	}
 
 	return new, nil

--- a/api/pkg/resources/reconciling/wrapper_test.go
+++ b/api/pkg/resources/reconciling/wrapper_test.go
@@ -16,6 +16,7 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/intstr"
+	utilpointer "k8s.io/utils/pointer"
 )
 
 func TestDefaultPodSpec(t *testing.T) {
@@ -241,6 +242,86 @@ func TestDefaultPodSpec(t *testing.T) {
 						SecurityContext:          &corev1.SecurityContext{},
 					},
 				},
+			},
+		},
+		{
+			name: "Default mode for secret volume gets defaulted",
+			newObject: corev1.PodSpec{
+				Volumes: []corev1.Volume{{
+					VolumeSource: corev1.VolumeSource{
+						Secret: &corev1.SecretVolumeSource{},
+					},
+				},
+				}},
+			expectedObject: corev1.PodSpec{
+				Volumes: []corev1.Volume{{
+					VolumeSource: corev1.VolumeSource{
+						Secret: &corev1.SecretVolumeSource{
+							DefaultMode: utilpointer.Int32Ptr(0644),
+						},
+					},
+				}},
+			},
+		},
+		{
+			name: "Default mode for secret volume doesnt get overwritten",
+			newObject: corev1.PodSpec{
+				Volumes: []corev1.Volume{{
+					VolumeSource: corev1.VolumeSource{
+						Secret: &corev1.SecretVolumeSource{
+							DefaultMode: utilpointer.Int32Ptr(0600),
+						},
+					},
+				},
+				}},
+			expectedObject: corev1.PodSpec{
+				Volumes: []corev1.Volume{{
+					VolumeSource: corev1.VolumeSource{
+						Secret: &corev1.SecretVolumeSource{
+							DefaultMode: utilpointer.Int32Ptr(0600),
+						},
+					},
+				}},
+			},
+		},
+		{
+			name: "Default mode for configmap volume gets defaulted",
+			newObject: corev1.PodSpec{
+				Volumes: []corev1.Volume{{
+					VolumeSource: corev1.VolumeSource{
+						ConfigMap: &corev1.ConfigMapVolumeSource{},
+					},
+				},
+				}},
+			expectedObject: corev1.PodSpec{
+				Volumes: []corev1.Volume{{
+					VolumeSource: corev1.VolumeSource{
+						ConfigMap: &corev1.ConfigMapVolumeSource{
+							DefaultMode: utilpointer.Int32Ptr(0644),
+						},
+					},
+				}},
+			},
+		},
+		{
+			name: "Default mode for configmap volume doesnt get overwritten",
+			newObject: corev1.PodSpec{
+				Volumes: []corev1.Volume{{
+					VolumeSource: corev1.VolumeSource{
+						ConfigMap: &corev1.ConfigMapVolumeSource{
+							DefaultMode: utilpointer.Int32Ptr(0600),
+						},
+					},
+				},
+				}},
+			expectedObject: corev1.PodSpec{
+				Volumes: []corev1.Volume{{
+					VolumeSource: corev1.VolumeSource{
+						ConfigMap: &corev1.ConfigMapVolumeSource{
+							DefaultMode: utilpointer.Int32Ptr(0600),
+						},
+					},
+				}},
 			},
 		},
 	}

--- a/api/pkg/resources/scheduler/deployment.go
+++ b/api/pkg/resources/scheduler/deployment.go
@@ -148,8 +148,7 @@ func getVolumes() []corev1.Volume {
 			Name: resources.OpenVPNClientCertificatesSecretName,
 			VolumeSource: corev1.VolumeSource{
 				Secret: &corev1.SecretVolumeSource{
-					SecretName:  resources.OpenVPNClientCertificatesSecretName,
-					DefaultMode: resources.Int32(resources.DefaultOwnerReadOnlyMode),
+					SecretName: resources.OpenVPNClientCertificatesSecretName,
 				},
 			},
 		},
@@ -157,8 +156,7 @@ func getVolumes() []corev1.Volume {
 			Name: resources.CASecretName,
 			VolumeSource: corev1.VolumeSource{
 				Secret: &corev1.SecretVolumeSource{
-					SecretName:  resources.CASecretName,
-					DefaultMode: resources.Int32(resources.DefaultOwnerReadOnlyMode),
+					SecretName: resources.CASecretName,
 					Items: []corev1.KeyToPath{
 						{
 							Path: resources.CACertSecretKey,
@@ -172,8 +170,7 @@ func getVolumes() []corev1.Volume {
 			Name: resources.SchedulerKubeconfigSecretName,
 			VolumeSource: corev1.VolumeSource{
 				Secret: &corev1.SecretVolumeSource{
-					SecretName:  resources.SchedulerKubeconfigSecretName,
-					DefaultMode: resources.Int32(resources.DefaultOwnerReadOnlyMode),
+					SecretName: resources.SchedulerKubeconfigSecretName,
 				},
 			},
 		},

--- a/api/pkg/resources/test/fixtures/cronjob-aws-1.10.0-etcd-defragger.yaml
+++ b/api/pkg/resources/test/fixtures/cronjob-aws-1.10.0-etcd-defragger.yaml
@@ -57,7 +57,6 @@ spec:
           volumes:
           - name: apiserver-etcd-client-certificate
             secret:
-              defaultMode: 256
               secretName: apiserver-etcd-client-certificate
   schedule: '@every 3h'
   successfulJobsHistoryLimit: 0

--- a/api/pkg/resources/test/fixtures/cronjob-aws-1.10.6-etcd-defragger.yaml
+++ b/api/pkg/resources/test/fixtures/cronjob-aws-1.10.6-etcd-defragger.yaml
@@ -57,7 +57,6 @@ spec:
           volumes:
           - name: apiserver-etcd-client-certificate
             secret:
-              defaultMode: 256
               secretName: apiserver-etcd-client-certificate
   schedule: '@every 3h'
   successfulJobsHistoryLimit: 0

--- a/api/pkg/resources/test/fixtures/cronjob-aws-1.11.0-etcd-defragger.yaml
+++ b/api/pkg/resources/test/fixtures/cronjob-aws-1.11.0-etcd-defragger.yaml
@@ -57,7 +57,6 @@ spec:
           volumes:
           - name: apiserver-etcd-client-certificate
             secret:
-              defaultMode: 256
               secretName: apiserver-etcd-client-certificate
   schedule: '@every 3h'
   successfulJobsHistoryLimit: 0

--- a/api/pkg/resources/test/fixtures/cronjob-aws-1.11.1-etcd-defragger.yaml
+++ b/api/pkg/resources/test/fixtures/cronjob-aws-1.11.1-etcd-defragger.yaml
@@ -57,7 +57,6 @@ spec:
           volumes:
           - name: apiserver-etcd-client-certificate
             secret:
-              defaultMode: 256
               secretName: apiserver-etcd-client-certificate
   schedule: '@every 3h'
   successfulJobsHistoryLimit: 0

--- a/api/pkg/resources/test/fixtures/cronjob-aws-1.12.0-etcd-defragger.yaml
+++ b/api/pkg/resources/test/fixtures/cronjob-aws-1.12.0-etcd-defragger.yaml
@@ -57,7 +57,6 @@ spec:
           volumes:
           - name: apiserver-etcd-client-certificate
             secret:
-              defaultMode: 256
               secretName: apiserver-etcd-client-certificate
   schedule: '@every 3h'
   successfulJobsHistoryLimit: 0

--- a/api/pkg/resources/test/fixtures/cronjob-aws-1.13.0-etcd-defragger.yaml
+++ b/api/pkg/resources/test/fixtures/cronjob-aws-1.13.0-etcd-defragger.yaml
@@ -57,7 +57,6 @@ spec:
           volumes:
           - name: apiserver-etcd-client-certificate
             secret:
-              defaultMode: 256
               secretName: apiserver-etcd-client-certificate
   schedule: '@every 3h'
   successfulJobsHistoryLimit: 0

--- a/api/pkg/resources/test/fixtures/cronjob-azure-1.10.0-etcd-defragger.yaml
+++ b/api/pkg/resources/test/fixtures/cronjob-azure-1.10.0-etcd-defragger.yaml
@@ -57,7 +57,6 @@ spec:
           volumes:
           - name: apiserver-etcd-client-certificate
             secret:
-              defaultMode: 256
               secretName: apiserver-etcd-client-certificate
   schedule: '@every 3h'
   successfulJobsHistoryLimit: 0

--- a/api/pkg/resources/test/fixtures/cronjob-azure-1.10.6-etcd-defragger.yaml
+++ b/api/pkg/resources/test/fixtures/cronjob-azure-1.10.6-etcd-defragger.yaml
@@ -57,7 +57,6 @@ spec:
           volumes:
           - name: apiserver-etcd-client-certificate
             secret:
-              defaultMode: 256
               secretName: apiserver-etcd-client-certificate
   schedule: '@every 3h'
   successfulJobsHistoryLimit: 0

--- a/api/pkg/resources/test/fixtures/cronjob-azure-1.11.0-etcd-defragger.yaml
+++ b/api/pkg/resources/test/fixtures/cronjob-azure-1.11.0-etcd-defragger.yaml
@@ -57,7 +57,6 @@ spec:
           volumes:
           - name: apiserver-etcd-client-certificate
             secret:
-              defaultMode: 256
               secretName: apiserver-etcd-client-certificate
   schedule: '@every 3h'
   successfulJobsHistoryLimit: 0

--- a/api/pkg/resources/test/fixtures/cronjob-azure-1.11.1-etcd-defragger.yaml
+++ b/api/pkg/resources/test/fixtures/cronjob-azure-1.11.1-etcd-defragger.yaml
@@ -57,7 +57,6 @@ spec:
           volumes:
           - name: apiserver-etcd-client-certificate
             secret:
-              defaultMode: 256
               secretName: apiserver-etcd-client-certificate
   schedule: '@every 3h'
   successfulJobsHistoryLimit: 0

--- a/api/pkg/resources/test/fixtures/cronjob-azure-1.12.0-etcd-defragger.yaml
+++ b/api/pkg/resources/test/fixtures/cronjob-azure-1.12.0-etcd-defragger.yaml
@@ -57,7 +57,6 @@ spec:
           volumes:
           - name: apiserver-etcd-client-certificate
             secret:
-              defaultMode: 256
               secretName: apiserver-etcd-client-certificate
   schedule: '@every 3h'
   successfulJobsHistoryLimit: 0

--- a/api/pkg/resources/test/fixtures/cronjob-azure-1.13.0-etcd-defragger.yaml
+++ b/api/pkg/resources/test/fixtures/cronjob-azure-1.13.0-etcd-defragger.yaml
@@ -57,7 +57,6 @@ spec:
           volumes:
           - name: apiserver-etcd-client-certificate
             secret:
-              defaultMode: 256
               secretName: apiserver-etcd-client-certificate
   schedule: '@every 3h'
   successfulJobsHistoryLimit: 0

--- a/api/pkg/resources/test/fixtures/cronjob-bringyourown-1.10.0-etcd-defragger.yaml
+++ b/api/pkg/resources/test/fixtures/cronjob-bringyourown-1.10.0-etcd-defragger.yaml
@@ -57,7 +57,6 @@ spec:
           volumes:
           - name: apiserver-etcd-client-certificate
             secret:
-              defaultMode: 256
               secretName: apiserver-etcd-client-certificate
   schedule: '@every 3h'
   successfulJobsHistoryLimit: 0

--- a/api/pkg/resources/test/fixtures/cronjob-bringyourown-1.10.6-etcd-defragger.yaml
+++ b/api/pkg/resources/test/fixtures/cronjob-bringyourown-1.10.6-etcd-defragger.yaml
@@ -57,7 +57,6 @@ spec:
           volumes:
           - name: apiserver-etcd-client-certificate
             secret:
-              defaultMode: 256
               secretName: apiserver-etcd-client-certificate
   schedule: '@every 3h'
   successfulJobsHistoryLimit: 0

--- a/api/pkg/resources/test/fixtures/cronjob-bringyourown-1.11.0-etcd-defragger.yaml
+++ b/api/pkg/resources/test/fixtures/cronjob-bringyourown-1.11.0-etcd-defragger.yaml
@@ -57,7 +57,6 @@ spec:
           volumes:
           - name: apiserver-etcd-client-certificate
             secret:
-              defaultMode: 256
               secretName: apiserver-etcd-client-certificate
   schedule: '@every 3h'
   successfulJobsHistoryLimit: 0

--- a/api/pkg/resources/test/fixtures/cronjob-bringyourown-1.11.1-etcd-defragger.yaml
+++ b/api/pkg/resources/test/fixtures/cronjob-bringyourown-1.11.1-etcd-defragger.yaml
@@ -57,7 +57,6 @@ spec:
           volumes:
           - name: apiserver-etcd-client-certificate
             secret:
-              defaultMode: 256
               secretName: apiserver-etcd-client-certificate
   schedule: '@every 3h'
   successfulJobsHistoryLimit: 0

--- a/api/pkg/resources/test/fixtures/cronjob-bringyourown-1.12.0-etcd-defragger.yaml
+++ b/api/pkg/resources/test/fixtures/cronjob-bringyourown-1.12.0-etcd-defragger.yaml
@@ -57,7 +57,6 @@ spec:
           volumes:
           - name: apiserver-etcd-client-certificate
             secret:
-              defaultMode: 256
               secretName: apiserver-etcd-client-certificate
   schedule: '@every 3h'
   successfulJobsHistoryLimit: 0

--- a/api/pkg/resources/test/fixtures/cronjob-bringyourown-1.13.0-etcd-defragger.yaml
+++ b/api/pkg/resources/test/fixtures/cronjob-bringyourown-1.13.0-etcd-defragger.yaml
@@ -57,7 +57,6 @@ spec:
           volumes:
           - name: apiserver-etcd-client-certificate
             secret:
-              defaultMode: 256
               secretName: apiserver-etcd-client-certificate
   schedule: '@every 3h'
   successfulJobsHistoryLimit: 0

--- a/api/pkg/resources/test/fixtures/cronjob-digitalocean-1.10.0-etcd-defragger.yaml
+++ b/api/pkg/resources/test/fixtures/cronjob-digitalocean-1.10.0-etcd-defragger.yaml
@@ -57,7 +57,6 @@ spec:
           volumes:
           - name: apiserver-etcd-client-certificate
             secret:
-              defaultMode: 256
               secretName: apiserver-etcd-client-certificate
   schedule: '@every 3h'
   successfulJobsHistoryLimit: 0

--- a/api/pkg/resources/test/fixtures/cronjob-digitalocean-1.10.6-etcd-defragger.yaml
+++ b/api/pkg/resources/test/fixtures/cronjob-digitalocean-1.10.6-etcd-defragger.yaml
@@ -57,7 +57,6 @@ spec:
           volumes:
           - name: apiserver-etcd-client-certificate
             secret:
-              defaultMode: 256
               secretName: apiserver-etcd-client-certificate
   schedule: '@every 3h'
   successfulJobsHistoryLimit: 0

--- a/api/pkg/resources/test/fixtures/cronjob-digitalocean-1.11.0-etcd-defragger.yaml
+++ b/api/pkg/resources/test/fixtures/cronjob-digitalocean-1.11.0-etcd-defragger.yaml
@@ -57,7 +57,6 @@ spec:
           volumes:
           - name: apiserver-etcd-client-certificate
             secret:
-              defaultMode: 256
               secretName: apiserver-etcd-client-certificate
   schedule: '@every 3h'
   successfulJobsHistoryLimit: 0

--- a/api/pkg/resources/test/fixtures/cronjob-digitalocean-1.11.1-etcd-defragger.yaml
+++ b/api/pkg/resources/test/fixtures/cronjob-digitalocean-1.11.1-etcd-defragger.yaml
@@ -57,7 +57,6 @@ spec:
           volumes:
           - name: apiserver-etcd-client-certificate
             secret:
-              defaultMode: 256
               secretName: apiserver-etcd-client-certificate
   schedule: '@every 3h'
   successfulJobsHistoryLimit: 0

--- a/api/pkg/resources/test/fixtures/cronjob-digitalocean-1.12.0-etcd-defragger.yaml
+++ b/api/pkg/resources/test/fixtures/cronjob-digitalocean-1.12.0-etcd-defragger.yaml
@@ -57,7 +57,6 @@ spec:
           volumes:
           - name: apiserver-etcd-client-certificate
             secret:
-              defaultMode: 256
               secretName: apiserver-etcd-client-certificate
   schedule: '@every 3h'
   successfulJobsHistoryLimit: 0

--- a/api/pkg/resources/test/fixtures/cronjob-digitalocean-1.13.0-etcd-defragger.yaml
+++ b/api/pkg/resources/test/fixtures/cronjob-digitalocean-1.13.0-etcd-defragger.yaml
@@ -57,7 +57,6 @@ spec:
           volumes:
           - name: apiserver-etcd-client-certificate
             secret:
-              defaultMode: 256
               secretName: apiserver-etcd-client-certificate
   schedule: '@every 3h'
   successfulJobsHistoryLimit: 0

--- a/api/pkg/resources/test/fixtures/cronjob-openstack-1.10.0-etcd-defragger.yaml
+++ b/api/pkg/resources/test/fixtures/cronjob-openstack-1.10.0-etcd-defragger.yaml
@@ -57,7 +57,6 @@ spec:
           volumes:
           - name: apiserver-etcd-client-certificate
             secret:
-              defaultMode: 256
               secretName: apiserver-etcd-client-certificate
   schedule: '@every 3h'
   successfulJobsHistoryLimit: 0

--- a/api/pkg/resources/test/fixtures/cronjob-openstack-1.10.6-etcd-defragger.yaml
+++ b/api/pkg/resources/test/fixtures/cronjob-openstack-1.10.6-etcd-defragger.yaml
@@ -57,7 +57,6 @@ spec:
           volumes:
           - name: apiserver-etcd-client-certificate
             secret:
-              defaultMode: 256
               secretName: apiserver-etcd-client-certificate
   schedule: '@every 3h'
   successfulJobsHistoryLimit: 0

--- a/api/pkg/resources/test/fixtures/cronjob-openstack-1.11.0-etcd-defragger.yaml
+++ b/api/pkg/resources/test/fixtures/cronjob-openstack-1.11.0-etcd-defragger.yaml
@@ -57,7 +57,6 @@ spec:
           volumes:
           - name: apiserver-etcd-client-certificate
             secret:
-              defaultMode: 256
               secretName: apiserver-etcd-client-certificate
   schedule: '@every 3h'
   successfulJobsHistoryLimit: 0

--- a/api/pkg/resources/test/fixtures/cronjob-openstack-1.11.1-etcd-defragger.yaml
+++ b/api/pkg/resources/test/fixtures/cronjob-openstack-1.11.1-etcd-defragger.yaml
@@ -57,7 +57,6 @@ spec:
           volumes:
           - name: apiserver-etcd-client-certificate
             secret:
-              defaultMode: 256
               secretName: apiserver-etcd-client-certificate
   schedule: '@every 3h'
   successfulJobsHistoryLimit: 0

--- a/api/pkg/resources/test/fixtures/cronjob-openstack-1.12.0-etcd-defragger.yaml
+++ b/api/pkg/resources/test/fixtures/cronjob-openstack-1.12.0-etcd-defragger.yaml
@@ -57,7 +57,6 @@ spec:
           volumes:
           - name: apiserver-etcd-client-certificate
             secret:
-              defaultMode: 256
               secretName: apiserver-etcd-client-certificate
   schedule: '@every 3h'
   successfulJobsHistoryLimit: 0

--- a/api/pkg/resources/test/fixtures/cronjob-openstack-1.13.0-etcd-defragger.yaml
+++ b/api/pkg/resources/test/fixtures/cronjob-openstack-1.13.0-etcd-defragger.yaml
@@ -57,7 +57,6 @@ spec:
           volumes:
           - name: apiserver-etcd-client-certificate
             secret:
-              defaultMode: 256
               secretName: apiserver-etcd-client-certificate
   schedule: '@every 3h'
   successfulJobsHistoryLimit: 0

--- a/api/pkg/resources/test/fixtures/cronjob-vsphere-1.10.0-etcd-defragger.yaml
+++ b/api/pkg/resources/test/fixtures/cronjob-vsphere-1.10.0-etcd-defragger.yaml
@@ -57,7 +57,6 @@ spec:
           volumes:
           - name: apiserver-etcd-client-certificate
             secret:
-              defaultMode: 256
               secretName: apiserver-etcd-client-certificate
   schedule: '@every 3h'
   successfulJobsHistoryLimit: 0

--- a/api/pkg/resources/test/fixtures/cronjob-vsphere-1.10.6-etcd-defragger.yaml
+++ b/api/pkg/resources/test/fixtures/cronjob-vsphere-1.10.6-etcd-defragger.yaml
@@ -57,7 +57,6 @@ spec:
           volumes:
           - name: apiserver-etcd-client-certificate
             secret:
-              defaultMode: 256
               secretName: apiserver-etcd-client-certificate
   schedule: '@every 3h'
   successfulJobsHistoryLimit: 0

--- a/api/pkg/resources/test/fixtures/cronjob-vsphere-1.11.0-etcd-defragger.yaml
+++ b/api/pkg/resources/test/fixtures/cronjob-vsphere-1.11.0-etcd-defragger.yaml
@@ -57,7 +57,6 @@ spec:
           volumes:
           - name: apiserver-etcd-client-certificate
             secret:
-              defaultMode: 256
               secretName: apiserver-etcd-client-certificate
   schedule: '@every 3h'
   successfulJobsHistoryLimit: 0

--- a/api/pkg/resources/test/fixtures/cronjob-vsphere-1.11.1-etcd-defragger.yaml
+++ b/api/pkg/resources/test/fixtures/cronjob-vsphere-1.11.1-etcd-defragger.yaml
@@ -57,7 +57,6 @@ spec:
           volumes:
           - name: apiserver-etcd-client-certificate
             secret:
-              defaultMode: 256
               secretName: apiserver-etcd-client-certificate
   schedule: '@every 3h'
   successfulJobsHistoryLimit: 0

--- a/api/pkg/resources/test/fixtures/cronjob-vsphere-1.12.0-etcd-defragger.yaml
+++ b/api/pkg/resources/test/fixtures/cronjob-vsphere-1.12.0-etcd-defragger.yaml
@@ -57,7 +57,6 @@ spec:
           volumes:
           - name: apiserver-etcd-client-certificate
             secret:
-              defaultMode: 256
               secretName: apiserver-etcd-client-certificate
   schedule: '@every 3h'
   successfulJobsHistoryLimit: 0

--- a/api/pkg/resources/test/fixtures/cronjob-vsphere-1.13.0-etcd-defragger.yaml
+++ b/api/pkg/resources/test/fixtures/cronjob-vsphere-1.13.0-etcd-defragger.yaml
@@ -57,7 +57,6 @@ spec:
           volumes:
           - name: apiserver-etcd-client-certificate
             secret:
-              defaultMode: 256
               secretName: apiserver-etcd-client-certificate
   schedule: '@every 3h'
   successfulJobsHistoryLimit: 0

--- a/api/pkg/resources/test/fixtures/deployment-aws-1.10.0-apiserver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-aws-1.10.0-apiserver.yaml
@@ -320,53 +320,41 @@ spec:
       volumes:
       - name: apiserver-tls
         secret:
-          defaultMode: 256
           secretName: apiserver-tls
       - name: tokens
         secret:
-          defaultMode: 256
           secretName: tokens
       - name: openvpn-client-certificates
         secret:
-          defaultMode: 256
           secretName: openvpn-client-certificates
       - name: kubelet-client-certificates
         secret:
-          defaultMode: 256
           secretName: kubelet-client-certificates
       - name: ca
         secret:
-          defaultMode: 256
           items:
           - key: ca.crt
             path: ca.crt
           secretName: ca
       - name: service-account-key
         secret:
-          defaultMode: 256
           secretName: service-account-key
       - configMap:
-          defaultMode: 420
           name: cloud-config
         name: cloud-config
       - name: apiserver-etcd-client-certificate
         secret:
-          defaultMode: 256
           secretName: apiserver-etcd-client-certificate
       - name: apiserver-proxy-client-certificate
         secret:
-          defaultMode: 256
           secretName: apiserver-proxy-client-certificate
       - name: front-proxy-ca
         secret:
-          defaultMode: 256
           secretName: front-proxy-ca
       - name: kubeletdnatcontroller-kubeconfig
         secret:
-          defaultMode: 292
           secretName: kubeletdnatcontroller-kubeconfig
       - name: dex-ca
         secret:
-          defaultMode: 256
           secretName: dex-ca
 status: {}

--- a/api/pkg/resources/test/fixtures/deployment-aws-1.10.0-controller-manager.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-aws-1.10.0-controller-manager.yaml
@@ -187,23 +187,18 @@ spec:
       volumes:
       - name: ca
         secret:
-          defaultMode: 256
           secretName: ca
       - name: service-account-key
         secret:
-          defaultMode: 256
           secretName: service-account-key
       - configMap:
-          defaultMode: 420
           name: cloud-config
         name: cloud-config
       - name: openvpn-client-certificates
         secret:
-          defaultMode: 256
           secretName: openvpn-client-certificates
       - name: controllermanager-kubeconfig
         secret:
-          defaultMode: 256
           secretName: controllermanager-kubeconfig
       - emptyDir: {}
         name: http-prober-bin

--- a/api/pkg/resources/test/fixtures/deployment-aws-1.10.0-dns-resolver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-aws-1.10.0-dns-resolver.yaml
@@ -124,16 +124,13 @@ spec:
       - name: dockercfg
       volumes:
       - configMap:
-          defaultMode: 256
           name: dns-resolver
         name: dns-resolver
       - name: openvpn-client-certificates
         secret:
-          defaultMode: 256
           secretName: openvpn-client-certificates
       - name: ca
         secret:
-          defaultMode: 256
           items:
           - key: ca.crt
             path: ca.crt

--- a/api/pkg/resources/test/fixtures/deployment-aws-1.10.0-kube-state-metrics.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-aws-1.10.0-kube-state-metrics.yaml
@@ -81,7 +81,6 @@ spec:
       volumes:
       - name: kube-state-metrics-kubeconfig
         secret:
-          defaultMode: 256
           secretName: kube-state-metrics-kubeconfig
       - emptyDir: {}
         name: http-prober-bin

--- a/api/pkg/resources/test/fixtures/deployment-aws-1.10.0-machine-controller-webhook.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-aws-1.10.0-machine-controller-webhook.yaml
@@ -91,11 +91,9 @@ spec:
       volumes:
       - name: machinecontroller-kubeconfig
         secret:
-          defaultMode: 292
           secretName: machinecontroller-kubeconfig
       - name: machinecontroller-webhook-serving-cert
         secret:
-          defaultMode: 292
           secretName: machinecontroller-webhook-serving-cert
       - emptyDir: {}
         name: http-prober-bin

--- a/api/pkg/resources/test/fixtures/deployment-aws-1.10.0-machine-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-aws-1.10.0-machine-controller.yaml
@@ -82,7 +82,6 @@ spec:
       volumes:
       - name: machinecontroller-kubeconfig
         secret:
-          defaultMode: 292
           secretName: machinecontroller-kubeconfig
       - emptyDir: {}
         name: http-prober-bin

--- a/api/pkg/resources/test/fixtures/deployment-aws-1.10.0-metrics-server.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-aws-1.10.0-metrics-server.yaml
@@ -164,15 +164,12 @@ spec:
       volumes:
       - name: metrics-server
         secret:
-          defaultMode: 292
           secretName: metrics-server
       - name: openvpn-client-certificates
         secret:
-          defaultMode: 256
           secretName: openvpn-client-certificates
       - name: kubeletdnatcontroller-kubeconfig
         secret:
-          defaultMode: 292
           secretName: kubeletdnatcontroller-kubeconfig
       - emptyDir: {}
         name: http-prober-bin

--- a/api/pkg/resources/test/fixtures/deployment-aws-1.10.0-openvpn-server.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-aws-1.10.0-openvpn-server.yaml
@@ -178,17 +178,14 @@ spec:
       volumes:
       - name: ca
         secret:
-          defaultMode: 256
           items:
           - key: ca.crt
             path: ca.crt
           secretName: openvpn-ca
       - name: openvpn-server-certificates
         secret:
-          defaultMode: 256
           secretName: openvpn-server-certificates
       - configMap:
-          defaultMode: 256
           name: openvpn-client-configs
         name: openvpn-client-configs
 status: {}

--- a/api/pkg/resources/test/fixtures/deployment-aws-1.10.0-scheduler.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-aws-1.10.0-scheduler.yaml
@@ -172,18 +172,15 @@ spec:
       volumes:
       - name: openvpn-client-certificates
         secret:
-          defaultMode: 256
           secretName: openvpn-client-certificates
       - name: ca
         secret:
-          defaultMode: 256
           items:
           - key: ca.crt
             path: ca.crt
           secretName: ca
       - name: scheduler-kubeconfig
         secret:
-          defaultMode: 256
           secretName: scheduler-kubeconfig
       - emptyDir: {}
         name: http-prober-bin

--- a/api/pkg/resources/test/fixtures/deployment-aws-1.10.0-usercluster-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-aws-1.10.0-usercluster-controller.yaml
@@ -94,18 +94,15 @@ spec:
       volumes:
       - name: internal-admin-kubeconfig
         secret:
-          defaultMode: 292
           secretName: internal-admin-kubeconfig
       - name: ca
         secret:
-          defaultMode: 292
           items:
           - key: ca.crt
             path: ca.crt
           secretName: ca
       - name: openvpn-ca
         secret:
-          defaultMode: 292
           secretName: openvpn-ca
       - emptyDir: {}
         name: http-prober-bin

--- a/api/pkg/resources/test/fixtures/deployment-aws-1.10.6-apiserver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-aws-1.10.6-apiserver.yaml
@@ -320,53 +320,41 @@ spec:
       volumes:
       - name: apiserver-tls
         secret:
-          defaultMode: 256
           secretName: apiserver-tls
       - name: tokens
         secret:
-          defaultMode: 256
           secretName: tokens
       - name: openvpn-client-certificates
         secret:
-          defaultMode: 256
           secretName: openvpn-client-certificates
       - name: kubelet-client-certificates
         secret:
-          defaultMode: 256
           secretName: kubelet-client-certificates
       - name: ca
         secret:
-          defaultMode: 256
           items:
           - key: ca.crt
             path: ca.crt
           secretName: ca
       - name: service-account-key
         secret:
-          defaultMode: 256
           secretName: service-account-key
       - configMap:
-          defaultMode: 420
           name: cloud-config
         name: cloud-config
       - name: apiserver-etcd-client-certificate
         secret:
-          defaultMode: 256
           secretName: apiserver-etcd-client-certificate
       - name: apiserver-proxy-client-certificate
         secret:
-          defaultMode: 256
           secretName: apiserver-proxy-client-certificate
       - name: front-proxy-ca
         secret:
-          defaultMode: 256
           secretName: front-proxy-ca
       - name: kubeletdnatcontroller-kubeconfig
         secret:
-          defaultMode: 292
           secretName: kubeletdnatcontroller-kubeconfig
       - name: dex-ca
         secret:
-          defaultMode: 256
           secretName: dex-ca
 status: {}

--- a/api/pkg/resources/test/fixtures/deployment-aws-1.10.6-controller-manager.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-aws-1.10.6-controller-manager.yaml
@@ -187,23 +187,18 @@ spec:
       volumes:
       - name: ca
         secret:
-          defaultMode: 256
           secretName: ca
       - name: service-account-key
         secret:
-          defaultMode: 256
           secretName: service-account-key
       - configMap:
-          defaultMode: 420
           name: cloud-config
         name: cloud-config
       - name: openvpn-client-certificates
         secret:
-          defaultMode: 256
           secretName: openvpn-client-certificates
       - name: controllermanager-kubeconfig
         secret:
-          defaultMode: 256
           secretName: controllermanager-kubeconfig
       - emptyDir: {}
         name: http-prober-bin

--- a/api/pkg/resources/test/fixtures/deployment-aws-1.10.6-dns-resolver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-aws-1.10.6-dns-resolver.yaml
@@ -124,16 +124,13 @@ spec:
       - name: dockercfg
       volumes:
       - configMap:
-          defaultMode: 256
           name: dns-resolver
         name: dns-resolver
       - name: openvpn-client-certificates
         secret:
-          defaultMode: 256
           secretName: openvpn-client-certificates
       - name: ca
         secret:
-          defaultMode: 256
           items:
           - key: ca.crt
             path: ca.crt

--- a/api/pkg/resources/test/fixtures/deployment-aws-1.10.6-kube-state-metrics.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-aws-1.10.6-kube-state-metrics.yaml
@@ -81,7 +81,6 @@ spec:
       volumes:
       - name: kube-state-metrics-kubeconfig
         secret:
-          defaultMode: 256
           secretName: kube-state-metrics-kubeconfig
       - emptyDir: {}
         name: http-prober-bin

--- a/api/pkg/resources/test/fixtures/deployment-aws-1.10.6-machine-controller-webhook.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-aws-1.10.6-machine-controller-webhook.yaml
@@ -91,11 +91,9 @@ spec:
       volumes:
       - name: machinecontroller-kubeconfig
         secret:
-          defaultMode: 292
           secretName: machinecontroller-kubeconfig
       - name: machinecontroller-webhook-serving-cert
         secret:
-          defaultMode: 292
           secretName: machinecontroller-webhook-serving-cert
       - emptyDir: {}
         name: http-prober-bin

--- a/api/pkg/resources/test/fixtures/deployment-aws-1.10.6-machine-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-aws-1.10.6-machine-controller.yaml
@@ -82,7 +82,6 @@ spec:
       volumes:
       - name: machinecontroller-kubeconfig
         secret:
-          defaultMode: 292
           secretName: machinecontroller-kubeconfig
       - emptyDir: {}
         name: http-prober-bin

--- a/api/pkg/resources/test/fixtures/deployment-aws-1.10.6-metrics-server.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-aws-1.10.6-metrics-server.yaml
@@ -164,15 +164,12 @@ spec:
       volumes:
       - name: metrics-server
         secret:
-          defaultMode: 292
           secretName: metrics-server
       - name: openvpn-client-certificates
         secret:
-          defaultMode: 256
           secretName: openvpn-client-certificates
       - name: kubeletdnatcontroller-kubeconfig
         secret:
-          defaultMode: 292
           secretName: kubeletdnatcontroller-kubeconfig
       - emptyDir: {}
         name: http-prober-bin

--- a/api/pkg/resources/test/fixtures/deployment-aws-1.10.6-openvpn-server.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-aws-1.10.6-openvpn-server.yaml
@@ -178,17 +178,14 @@ spec:
       volumes:
       - name: ca
         secret:
-          defaultMode: 256
           items:
           - key: ca.crt
             path: ca.crt
           secretName: openvpn-ca
       - name: openvpn-server-certificates
         secret:
-          defaultMode: 256
           secretName: openvpn-server-certificates
       - configMap:
-          defaultMode: 256
           name: openvpn-client-configs
         name: openvpn-client-configs
 status: {}

--- a/api/pkg/resources/test/fixtures/deployment-aws-1.10.6-scheduler.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-aws-1.10.6-scheduler.yaml
@@ -172,18 +172,15 @@ spec:
       volumes:
       - name: openvpn-client-certificates
         secret:
-          defaultMode: 256
           secretName: openvpn-client-certificates
       - name: ca
         secret:
-          defaultMode: 256
           items:
           - key: ca.crt
             path: ca.crt
           secretName: ca
       - name: scheduler-kubeconfig
         secret:
-          defaultMode: 256
           secretName: scheduler-kubeconfig
       - emptyDir: {}
         name: http-prober-bin

--- a/api/pkg/resources/test/fixtures/deployment-aws-1.10.6-usercluster-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-aws-1.10.6-usercluster-controller.yaml
@@ -94,18 +94,15 @@ spec:
       volumes:
       - name: internal-admin-kubeconfig
         secret:
-          defaultMode: 292
           secretName: internal-admin-kubeconfig
       - name: ca
         secret:
-          defaultMode: 292
           items:
           - key: ca.crt
             path: ca.crt
           secretName: ca
       - name: openvpn-ca
         secret:
-          defaultMode: 292
           secretName: openvpn-ca
       - emptyDir: {}
         name: http-prober-bin

--- a/api/pkg/resources/test/fixtures/deployment-aws-1.11.0-apiserver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-aws-1.11.0-apiserver.yaml
@@ -318,53 +318,41 @@ spec:
       volumes:
       - name: apiserver-tls
         secret:
-          defaultMode: 256
           secretName: apiserver-tls
       - name: tokens
         secret:
-          defaultMode: 256
           secretName: tokens
       - name: openvpn-client-certificates
         secret:
-          defaultMode: 256
           secretName: openvpn-client-certificates
       - name: kubelet-client-certificates
         secret:
-          defaultMode: 256
           secretName: kubelet-client-certificates
       - name: ca
         secret:
-          defaultMode: 256
           items:
           - key: ca.crt
             path: ca.crt
           secretName: ca
       - name: service-account-key
         secret:
-          defaultMode: 256
           secretName: service-account-key
       - configMap:
-          defaultMode: 420
           name: cloud-config
         name: cloud-config
       - name: apiserver-etcd-client-certificate
         secret:
-          defaultMode: 256
           secretName: apiserver-etcd-client-certificate
       - name: apiserver-proxy-client-certificate
         secret:
-          defaultMode: 256
           secretName: apiserver-proxy-client-certificate
       - name: front-proxy-ca
         secret:
-          defaultMode: 256
           secretName: front-proxy-ca
       - name: kubeletdnatcontroller-kubeconfig
         secret:
-          defaultMode: 292
           secretName: kubeletdnatcontroller-kubeconfig
       - name: dex-ca
         secret:
-          defaultMode: 256
           secretName: dex-ca
 status: {}

--- a/api/pkg/resources/test/fixtures/deployment-aws-1.11.0-controller-manager.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-aws-1.11.0-controller-manager.yaml
@@ -187,23 +187,18 @@ spec:
       volumes:
       - name: ca
         secret:
-          defaultMode: 256
           secretName: ca
       - name: service-account-key
         secret:
-          defaultMode: 256
           secretName: service-account-key
       - configMap:
-          defaultMode: 420
           name: cloud-config
         name: cloud-config
       - name: openvpn-client-certificates
         secret:
-          defaultMode: 256
           secretName: openvpn-client-certificates
       - name: controllermanager-kubeconfig
         secret:
-          defaultMode: 256
           secretName: controllermanager-kubeconfig
       - emptyDir: {}
         name: http-prober-bin

--- a/api/pkg/resources/test/fixtures/deployment-aws-1.11.0-dns-resolver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-aws-1.11.0-dns-resolver.yaml
@@ -124,16 +124,13 @@ spec:
       - name: dockercfg
       volumes:
       - configMap:
-          defaultMode: 256
           name: dns-resolver
         name: dns-resolver
       - name: openvpn-client-certificates
         secret:
-          defaultMode: 256
           secretName: openvpn-client-certificates
       - name: ca
         secret:
-          defaultMode: 256
           items:
           - key: ca.crt
             path: ca.crt

--- a/api/pkg/resources/test/fixtures/deployment-aws-1.11.0-kube-state-metrics.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-aws-1.11.0-kube-state-metrics.yaml
@@ -81,7 +81,6 @@ spec:
       volumes:
       - name: kube-state-metrics-kubeconfig
         secret:
-          defaultMode: 256
           secretName: kube-state-metrics-kubeconfig
       - emptyDir: {}
         name: http-prober-bin

--- a/api/pkg/resources/test/fixtures/deployment-aws-1.11.0-machine-controller-webhook.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-aws-1.11.0-machine-controller-webhook.yaml
@@ -91,11 +91,9 @@ spec:
       volumes:
       - name: machinecontroller-kubeconfig
         secret:
-          defaultMode: 292
           secretName: machinecontroller-kubeconfig
       - name: machinecontroller-webhook-serving-cert
         secret:
-          defaultMode: 292
           secretName: machinecontroller-webhook-serving-cert
       - emptyDir: {}
         name: http-prober-bin

--- a/api/pkg/resources/test/fixtures/deployment-aws-1.11.0-machine-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-aws-1.11.0-machine-controller.yaml
@@ -82,7 +82,6 @@ spec:
       volumes:
       - name: machinecontroller-kubeconfig
         secret:
-          defaultMode: 292
           secretName: machinecontroller-kubeconfig
       - emptyDir: {}
         name: http-prober-bin

--- a/api/pkg/resources/test/fixtures/deployment-aws-1.11.0-metrics-server.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-aws-1.11.0-metrics-server.yaml
@@ -164,15 +164,12 @@ spec:
       volumes:
       - name: metrics-server
         secret:
-          defaultMode: 292
           secretName: metrics-server
       - name: openvpn-client-certificates
         secret:
-          defaultMode: 256
           secretName: openvpn-client-certificates
       - name: kubeletdnatcontroller-kubeconfig
         secret:
-          defaultMode: 292
           secretName: kubeletdnatcontroller-kubeconfig
       - emptyDir: {}
         name: http-prober-bin

--- a/api/pkg/resources/test/fixtures/deployment-aws-1.11.0-openvpn-server.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-aws-1.11.0-openvpn-server.yaml
@@ -178,17 +178,14 @@ spec:
       volumes:
       - name: ca
         secret:
-          defaultMode: 256
           items:
           - key: ca.crt
             path: ca.crt
           secretName: openvpn-ca
       - name: openvpn-server-certificates
         secret:
-          defaultMode: 256
           secretName: openvpn-server-certificates
       - configMap:
-          defaultMode: 256
           name: openvpn-client-configs
         name: openvpn-client-configs
 status: {}

--- a/api/pkg/resources/test/fixtures/deployment-aws-1.11.0-scheduler.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-aws-1.11.0-scheduler.yaml
@@ -172,18 +172,15 @@ spec:
       volumes:
       - name: openvpn-client-certificates
         secret:
-          defaultMode: 256
           secretName: openvpn-client-certificates
       - name: ca
         secret:
-          defaultMode: 256
           items:
           - key: ca.crt
             path: ca.crt
           secretName: ca
       - name: scheduler-kubeconfig
         secret:
-          defaultMode: 256
           secretName: scheduler-kubeconfig
       - emptyDir: {}
         name: http-prober-bin

--- a/api/pkg/resources/test/fixtures/deployment-aws-1.11.0-usercluster-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-aws-1.11.0-usercluster-controller.yaml
@@ -94,18 +94,15 @@ spec:
       volumes:
       - name: internal-admin-kubeconfig
         secret:
-          defaultMode: 292
           secretName: internal-admin-kubeconfig
       - name: ca
         secret:
-          defaultMode: 292
           items:
           - key: ca.crt
             path: ca.crt
           secretName: ca
       - name: openvpn-ca
         secret:
-          defaultMode: 292
           secretName: openvpn-ca
       - emptyDir: {}
         name: http-prober-bin

--- a/api/pkg/resources/test/fixtures/deployment-aws-1.11.1-apiserver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-aws-1.11.1-apiserver.yaml
@@ -318,53 +318,41 @@ spec:
       volumes:
       - name: apiserver-tls
         secret:
-          defaultMode: 256
           secretName: apiserver-tls
       - name: tokens
         secret:
-          defaultMode: 256
           secretName: tokens
       - name: openvpn-client-certificates
         secret:
-          defaultMode: 256
           secretName: openvpn-client-certificates
       - name: kubelet-client-certificates
         secret:
-          defaultMode: 256
           secretName: kubelet-client-certificates
       - name: ca
         secret:
-          defaultMode: 256
           items:
           - key: ca.crt
             path: ca.crt
           secretName: ca
       - name: service-account-key
         secret:
-          defaultMode: 256
           secretName: service-account-key
       - configMap:
-          defaultMode: 420
           name: cloud-config
         name: cloud-config
       - name: apiserver-etcd-client-certificate
         secret:
-          defaultMode: 256
           secretName: apiserver-etcd-client-certificate
       - name: apiserver-proxy-client-certificate
         secret:
-          defaultMode: 256
           secretName: apiserver-proxy-client-certificate
       - name: front-proxy-ca
         secret:
-          defaultMode: 256
           secretName: front-proxy-ca
       - name: kubeletdnatcontroller-kubeconfig
         secret:
-          defaultMode: 292
           secretName: kubeletdnatcontroller-kubeconfig
       - name: dex-ca
         secret:
-          defaultMode: 256
           secretName: dex-ca
 status: {}

--- a/api/pkg/resources/test/fixtures/deployment-aws-1.11.1-controller-manager.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-aws-1.11.1-controller-manager.yaml
@@ -187,23 +187,18 @@ spec:
       volumes:
       - name: ca
         secret:
-          defaultMode: 256
           secretName: ca
       - name: service-account-key
         secret:
-          defaultMode: 256
           secretName: service-account-key
       - configMap:
-          defaultMode: 420
           name: cloud-config
         name: cloud-config
       - name: openvpn-client-certificates
         secret:
-          defaultMode: 256
           secretName: openvpn-client-certificates
       - name: controllermanager-kubeconfig
         secret:
-          defaultMode: 256
           secretName: controllermanager-kubeconfig
       - emptyDir: {}
         name: http-prober-bin

--- a/api/pkg/resources/test/fixtures/deployment-aws-1.11.1-dns-resolver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-aws-1.11.1-dns-resolver.yaml
@@ -124,16 +124,13 @@ spec:
       - name: dockercfg
       volumes:
       - configMap:
-          defaultMode: 256
           name: dns-resolver
         name: dns-resolver
       - name: openvpn-client-certificates
         secret:
-          defaultMode: 256
           secretName: openvpn-client-certificates
       - name: ca
         secret:
-          defaultMode: 256
           items:
           - key: ca.crt
             path: ca.crt

--- a/api/pkg/resources/test/fixtures/deployment-aws-1.11.1-kube-state-metrics.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-aws-1.11.1-kube-state-metrics.yaml
@@ -81,7 +81,6 @@ spec:
       volumes:
       - name: kube-state-metrics-kubeconfig
         secret:
-          defaultMode: 256
           secretName: kube-state-metrics-kubeconfig
       - emptyDir: {}
         name: http-prober-bin

--- a/api/pkg/resources/test/fixtures/deployment-aws-1.11.1-machine-controller-webhook.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-aws-1.11.1-machine-controller-webhook.yaml
@@ -91,11 +91,9 @@ spec:
       volumes:
       - name: machinecontroller-kubeconfig
         secret:
-          defaultMode: 292
           secretName: machinecontroller-kubeconfig
       - name: machinecontroller-webhook-serving-cert
         secret:
-          defaultMode: 292
           secretName: machinecontroller-webhook-serving-cert
       - emptyDir: {}
         name: http-prober-bin

--- a/api/pkg/resources/test/fixtures/deployment-aws-1.11.1-machine-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-aws-1.11.1-machine-controller.yaml
@@ -82,7 +82,6 @@ spec:
       volumes:
       - name: machinecontroller-kubeconfig
         secret:
-          defaultMode: 292
           secretName: machinecontroller-kubeconfig
       - emptyDir: {}
         name: http-prober-bin

--- a/api/pkg/resources/test/fixtures/deployment-aws-1.11.1-metrics-server.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-aws-1.11.1-metrics-server.yaml
@@ -164,15 +164,12 @@ spec:
       volumes:
       - name: metrics-server
         secret:
-          defaultMode: 292
           secretName: metrics-server
       - name: openvpn-client-certificates
         secret:
-          defaultMode: 256
           secretName: openvpn-client-certificates
       - name: kubeletdnatcontroller-kubeconfig
         secret:
-          defaultMode: 292
           secretName: kubeletdnatcontroller-kubeconfig
       - emptyDir: {}
         name: http-prober-bin

--- a/api/pkg/resources/test/fixtures/deployment-aws-1.11.1-openvpn-server.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-aws-1.11.1-openvpn-server.yaml
@@ -178,17 +178,14 @@ spec:
       volumes:
       - name: ca
         secret:
-          defaultMode: 256
           items:
           - key: ca.crt
             path: ca.crt
           secretName: openvpn-ca
       - name: openvpn-server-certificates
         secret:
-          defaultMode: 256
           secretName: openvpn-server-certificates
       - configMap:
-          defaultMode: 256
           name: openvpn-client-configs
         name: openvpn-client-configs
 status: {}

--- a/api/pkg/resources/test/fixtures/deployment-aws-1.11.1-scheduler.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-aws-1.11.1-scheduler.yaml
@@ -172,18 +172,15 @@ spec:
       volumes:
       - name: openvpn-client-certificates
         secret:
-          defaultMode: 256
           secretName: openvpn-client-certificates
       - name: ca
         secret:
-          defaultMode: 256
           items:
           - key: ca.crt
             path: ca.crt
           secretName: ca
       - name: scheduler-kubeconfig
         secret:
-          defaultMode: 256
           secretName: scheduler-kubeconfig
       - emptyDir: {}
         name: http-prober-bin

--- a/api/pkg/resources/test/fixtures/deployment-aws-1.11.1-usercluster-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-aws-1.11.1-usercluster-controller.yaml
@@ -94,18 +94,15 @@ spec:
       volumes:
       - name: internal-admin-kubeconfig
         secret:
-          defaultMode: 292
           secretName: internal-admin-kubeconfig
       - name: ca
         secret:
-          defaultMode: 292
           items:
           - key: ca.crt
             path: ca.crt
           secretName: ca
       - name: openvpn-ca
         secret:
-          defaultMode: 292
           secretName: openvpn-ca
       - emptyDir: {}
         name: http-prober-bin

--- a/api/pkg/resources/test/fixtures/deployment-aws-1.12.0-apiserver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-aws-1.12.0-apiserver.yaml
@@ -318,53 +318,41 @@ spec:
       volumes:
       - name: apiserver-tls
         secret:
-          defaultMode: 256
           secretName: apiserver-tls
       - name: tokens
         secret:
-          defaultMode: 256
           secretName: tokens
       - name: openvpn-client-certificates
         secret:
-          defaultMode: 256
           secretName: openvpn-client-certificates
       - name: kubelet-client-certificates
         secret:
-          defaultMode: 256
           secretName: kubelet-client-certificates
       - name: ca
         secret:
-          defaultMode: 256
           items:
           - key: ca.crt
             path: ca.crt
           secretName: ca
       - name: service-account-key
         secret:
-          defaultMode: 256
           secretName: service-account-key
       - configMap:
-          defaultMode: 420
           name: cloud-config
         name: cloud-config
       - name: apiserver-etcd-client-certificate
         secret:
-          defaultMode: 256
           secretName: apiserver-etcd-client-certificate
       - name: apiserver-proxy-client-certificate
         secret:
-          defaultMode: 256
           secretName: apiserver-proxy-client-certificate
       - name: front-proxy-ca
         secret:
-          defaultMode: 256
           secretName: front-proxy-ca
       - name: kubeletdnatcontroller-kubeconfig
         secret:
-          defaultMode: 292
           secretName: kubeletdnatcontroller-kubeconfig
       - name: dex-ca
         secret:
-          defaultMode: 256
           secretName: dex-ca
 status: {}

--- a/api/pkg/resources/test/fixtures/deployment-aws-1.12.0-controller-manager.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-aws-1.12.0-controller-manager.yaml
@@ -187,23 +187,18 @@ spec:
       volumes:
       - name: ca
         secret:
-          defaultMode: 256
           secretName: ca
       - name: service-account-key
         secret:
-          defaultMode: 256
           secretName: service-account-key
       - configMap:
-          defaultMode: 420
           name: cloud-config
         name: cloud-config
       - name: openvpn-client-certificates
         secret:
-          defaultMode: 256
           secretName: openvpn-client-certificates
       - name: controllermanager-kubeconfig
         secret:
-          defaultMode: 256
           secretName: controllermanager-kubeconfig
       - emptyDir: {}
         name: http-prober-bin

--- a/api/pkg/resources/test/fixtures/deployment-aws-1.12.0-dns-resolver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-aws-1.12.0-dns-resolver.yaml
@@ -124,16 +124,13 @@ spec:
       - name: dockercfg
       volumes:
       - configMap:
-          defaultMode: 256
           name: dns-resolver
         name: dns-resolver
       - name: openvpn-client-certificates
         secret:
-          defaultMode: 256
           secretName: openvpn-client-certificates
       - name: ca
         secret:
-          defaultMode: 256
           items:
           - key: ca.crt
             path: ca.crt

--- a/api/pkg/resources/test/fixtures/deployment-aws-1.12.0-kube-state-metrics.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-aws-1.12.0-kube-state-metrics.yaml
@@ -81,7 +81,6 @@ spec:
       volumes:
       - name: kube-state-metrics-kubeconfig
         secret:
-          defaultMode: 256
           secretName: kube-state-metrics-kubeconfig
       - emptyDir: {}
         name: http-prober-bin

--- a/api/pkg/resources/test/fixtures/deployment-aws-1.12.0-machine-controller-webhook.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-aws-1.12.0-machine-controller-webhook.yaml
@@ -91,11 +91,9 @@ spec:
       volumes:
       - name: machinecontroller-kubeconfig
         secret:
-          defaultMode: 292
           secretName: machinecontroller-kubeconfig
       - name: machinecontroller-webhook-serving-cert
         secret:
-          defaultMode: 292
           secretName: machinecontroller-webhook-serving-cert
       - emptyDir: {}
         name: http-prober-bin

--- a/api/pkg/resources/test/fixtures/deployment-aws-1.12.0-machine-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-aws-1.12.0-machine-controller.yaml
@@ -82,7 +82,6 @@ spec:
       volumes:
       - name: machinecontroller-kubeconfig
         secret:
-          defaultMode: 292
           secretName: machinecontroller-kubeconfig
       - emptyDir: {}
         name: http-prober-bin

--- a/api/pkg/resources/test/fixtures/deployment-aws-1.12.0-metrics-server.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-aws-1.12.0-metrics-server.yaml
@@ -164,15 +164,12 @@ spec:
       volumes:
       - name: metrics-server
         secret:
-          defaultMode: 292
           secretName: metrics-server
       - name: openvpn-client-certificates
         secret:
-          defaultMode: 256
           secretName: openvpn-client-certificates
       - name: kubeletdnatcontroller-kubeconfig
         secret:
-          defaultMode: 292
           secretName: kubeletdnatcontroller-kubeconfig
       - emptyDir: {}
         name: http-prober-bin

--- a/api/pkg/resources/test/fixtures/deployment-aws-1.12.0-openvpn-server.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-aws-1.12.0-openvpn-server.yaml
@@ -178,17 +178,14 @@ spec:
       volumes:
       - name: ca
         secret:
-          defaultMode: 256
           items:
           - key: ca.crt
             path: ca.crt
           secretName: openvpn-ca
       - name: openvpn-server-certificates
         secret:
-          defaultMode: 256
           secretName: openvpn-server-certificates
       - configMap:
-          defaultMode: 256
           name: openvpn-client-configs
         name: openvpn-client-configs
 status: {}

--- a/api/pkg/resources/test/fixtures/deployment-aws-1.12.0-scheduler.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-aws-1.12.0-scheduler.yaml
@@ -172,18 +172,15 @@ spec:
       volumes:
       - name: openvpn-client-certificates
         secret:
-          defaultMode: 256
           secretName: openvpn-client-certificates
       - name: ca
         secret:
-          defaultMode: 256
           items:
           - key: ca.crt
             path: ca.crt
           secretName: ca
       - name: scheduler-kubeconfig
         secret:
-          defaultMode: 256
           secretName: scheduler-kubeconfig
       - emptyDir: {}
         name: http-prober-bin

--- a/api/pkg/resources/test/fixtures/deployment-aws-1.12.0-usercluster-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-aws-1.12.0-usercluster-controller.yaml
@@ -94,18 +94,15 @@ spec:
       volumes:
       - name: internal-admin-kubeconfig
         secret:
-          defaultMode: 292
           secretName: internal-admin-kubeconfig
       - name: ca
         secret:
-          defaultMode: 292
           items:
           - key: ca.crt
             path: ca.crt
           secretName: ca
       - name: openvpn-ca
         secret:
-          defaultMode: 292
           secretName: openvpn-ca
       - emptyDir: {}
         name: http-prober-bin

--- a/api/pkg/resources/test/fixtures/deployment-aws-1.13.0-apiserver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-aws-1.13.0-apiserver.yaml
@@ -318,53 +318,41 @@ spec:
       volumes:
       - name: apiserver-tls
         secret:
-          defaultMode: 256
           secretName: apiserver-tls
       - name: tokens
         secret:
-          defaultMode: 256
           secretName: tokens
       - name: openvpn-client-certificates
         secret:
-          defaultMode: 256
           secretName: openvpn-client-certificates
       - name: kubelet-client-certificates
         secret:
-          defaultMode: 256
           secretName: kubelet-client-certificates
       - name: ca
         secret:
-          defaultMode: 256
           items:
           - key: ca.crt
             path: ca.crt
           secretName: ca
       - name: service-account-key
         secret:
-          defaultMode: 256
           secretName: service-account-key
       - configMap:
-          defaultMode: 420
           name: cloud-config
         name: cloud-config
       - name: apiserver-etcd-client-certificate
         secret:
-          defaultMode: 256
           secretName: apiserver-etcd-client-certificate
       - name: apiserver-proxy-client-certificate
         secret:
-          defaultMode: 256
           secretName: apiserver-proxy-client-certificate
       - name: front-proxy-ca
         secret:
-          defaultMode: 256
           secretName: front-proxy-ca
       - name: kubeletdnatcontroller-kubeconfig
         secret:
-          defaultMode: 292
           secretName: kubeletdnatcontroller-kubeconfig
       - name: dex-ca
         secret:
-          defaultMode: 256
           secretName: dex-ca
 status: {}

--- a/api/pkg/resources/test/fixtures/deployment-aws-1.13.0-controller-manager.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-aws-1.13.0-controller-manager.yaml
@@ -187,23 +187,18 @@ spec:
       volumes:
       - name: ca
         secret:
-          defaultMode: 256
           secretName: ca
       - name: service-account-key
         secret:
-          defaultMode: 256
           secretName: service-account-key
       - configMap:
-          defaultMode: 420
           name: cloud-config
         name: cloud-config
       - name: openvpn-client-certificates
         secret:
-          defaultMode: 256
           secretName: openvpn-client-certificates
       - name: controllermanager-kubeconfig
         secret:
-          defaultMode: 256
           secretName: controllermanager-kubeconfig
       - emptyDir: {}
         name: http-prober-bin

--- a/api/pkg/resources/test/fixtures/deployment-aws-1.13.0-dns-resolver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-aws-1.13.0-dns-resolver.yaml
@@ -124,16 +124,13 @@ spec:
       - name: dockercfg
       volumes:
       - configMap:
-          defaultMode: 256
           name: dns-resolver
         name: dns-resolver
       - name: openvpn-client-certificates
         secret:
-          defaultMode: 256
           secretName: openvpn-client-certificates
       - name: ca
         secret:
-          defaultMode: 256
           items:
           - key: ca.crt
             path: ca.crt

--- a/api/pkg/resources/test/fixtures/deployment-aws-1.13.0-kube-state-metrics.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-aws-1.13.0-kube-state-metrics.yaml
@@ -81,7 +81,6 @@ spec:
       volumes:
       - name: kube-state-metrics-kubeconfig
         secret:
-          defaultMode: 256
           secretName: kube-state-metrics-kubeconfig
       - emptyDir: {}
         name: http-prober-bin

--- a/api/pkg/resources/test/fixtures/deployment-aws-1.13.0-machine-controller-webhook.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-aws-1.13.0-machine-controller-webhook.yaml
@@ -91,11 +91,9 @@ spec:
       volumes:
       - name: machinecontroller-kubeconfig
         secret:
-          defaultMode: 292
           secretName: machinecontroller-kubeconfig
       - name: machinecontroller-webhook-serving-cert
         secret:
-          defaultMode: 292
           secretName: machinecontroller-webhook-serving-cert
       - emptyDir: {}
         name: http-prober-bin

--- a/api/pkg/resources/test/fixtures/deployment-aws-1.13.0-machine-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-aws-1.13.0-machine-controller.yaml
@@ -82,7 +82,6 @@ spec:
       volumes:
       - name: machinecontroller-kubeconfig
         secret:
-          defaultMode: 292
           secretName: machinecontroller-kubeconfig
       - emptyDir: {}
         name: http-prober-bin

--- a/api/pkg/resources/test/fixtures/deployment-aws-1.13.0-metrics-server.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-aws-1.13.0-metrics-server.yaml
@@ -164,15 +164,12 @@ spec:
       volumes:
       - name: metrics-server
         secret:
-          defaultMode: 292
           secretName: metrics-server
       - name: openvpn-client-certificates
         secret:
-          defaultMode: 256
           secretName: openvpn-client-certificates
       - name: kubeletdnatcontroller-kubeconfig
         secret:
-          defaultMode: 292
           secretName: kubeletdnatcontroller-kubeconfig
       - emptyDir: {}
         name: http-prober-bin

--- a/api/pkg/resources/test/fixtures/deployment-aws-1.13.0-openvpn-server.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-aws-1.13.0-openvpn-server.yaml
@@ -178,17 +178,14 @@ spec:
       volumes:
       - name: ca
         secret:
-          defaultMode: 256
           items:
           - key: ca.crt
             path: ca.crt
           secretName: openvpn-ca
       - name: openvpn-server-certificates
         secret:
-          defaultMode: 256
           secretName: openvpn-server-certificates
       - configMap:
-          defaultMode: 256
           name: openvpn-client-configs
         name: openvpn-client-configs
 status: {}

--- a/api/pkg/resources/test/fixtures/deployment-aws-1.13.0-scheduler.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-aws-1.13.0-scheduler.yaml
@@ -172,18 +172,15 @@ spec:
       volumes:
       - name: openvpn-client-certificates
         secret:
-          defaultMode: 256
           secretName: openvpn-client-certificates
       - name: ca
         secret:
-          defaultMode: 256
           items:
           - key: ca.crt
             path: ca.crt
           secretName: ca
       - name: scheduler-kubeconfig
         secret:
-          defaultMode: 256
           secretName: scheduler-kubeconfig
       - emptyDir: {}
         name: http-prober-bin

--- a/api/pkg/resources/test/fixtures/deployment-aws-1.13.0-usercluster-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-aws-1.13.0-usercluster-controller.yaml
@@ -94,18 +94,15 @@ spec:
       volumes:
       - name: internal-admin-kubeconfig
         secret:
-          defaultMode: 292
           secretName: internal-admin-kubeconfig
       - name: ca
         secret:
-          defaultMode: 292
           items:
           - key: ca.crt
             path: ca.crt
           secretName: ca
       - name: openvpn-ca
         secret:
-          defaultMode: 292
           secretName: openvpn-ca
       - emptyDir: {}
         name: http-prober-bin

--- a/api/pkg/resources/test/fixtures/deployment-azure-1.10.0-apiserver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-azure-1.10.0-apiserver.yaml
@@ -313,53 +313,41 @@ spec:
       volumes:
       - name: apiserver-tls
         secret:
-          defaultMode: 256
           secretName: apiserver-tls
       - name: tokens
         secret:
-          defaultMode: 256
           secretName: tokens
       - name: openvpn-client-certificates
         secret:
-          defaultMode: 256
           secretName: openvpn-client-certificates
       - name: kubelet-client-certificates
         secret:
-          defaultMode: 256
           secretName: kubelet-client-certificates
       - name: ca
         secret:
-          defaultMode: 256
           items:
           - key: ca.crt
             path: ca.crt
           secretName: ca
       - name: service-account-key
         secret:
-          defaultMode: 256
           secretName: service-account-key
       - configMap:
-          defaultMode: 420
           name: cloud-config
         name: cloud-config
       - name: apiserver-etcd-client-certificate
         secret:
-          defaultMode: 256
           secretName: apiserver-etcd-client-certificate
       - name: apiserver-proxy-client-certificate
         secret:
-          defaultMode: 256
           secretName: apiserver-proxy-client-certificate
       - name: front-proxy-ca
         secret:
-          defaultMode: 256
           secretName: front-proxy-ca
       - name: kubeletdnatcontroller-kubeconfig
         secret:
-          defaultMode: 292
           secretName: kubeletdnatcontroller-kubeconfig
       - name: dex-ca
         secret:
-          defaultMode: 256
           secretName: dex-ca
 status: {}

--- a/api/pkg/resources/test/fixtures/deployment-azure-1.10.0-controller-manager.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-azure-1.10.0-controller-manager.yaml
@@ -180,23 +180,18 @@ spec:
       volumes:
       - name: ca
         secret:
-          defaultMode: 256
           secretName: ca
       - name: service-account-key
         secret:
-          defaultMode: 256
           secretName: service-account-key
       - configMap:
-          defaultMode: 420
           name: cloud-config
         name: cloud-config
       - name: openvpn-client-certificates
         secret:
-          defaultMode: 256
           secretName: openvpn-client-certificates
       - name: controllermanager-kubeconfig
         secret:
-          defaultMode: 256
           secretName: controllermanager-kubeconfig
       - emptyDir: {}
         name: http-prober-bin

--- a/api/pkg/resources/test/fixtures/deployment-azure-1.10.0-dns-resolver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-azure-1.10.0-dns-resolver.yaml
@@ -124,16 +124,13 @@ spec:
       - name: dockercfg
       volumes:
       - configMap:
-          defaultMode: 256
           name: dns-resolver
         name: dns-resolver
       - name: openvpn-client-certificates
         secret:
-          defaultMode: 256
           secretName: openvpn-client-certificates
       - name: ca
         secret:
-          defaultMode: 256
           items:
           - key: ca.crt
             path: ca.crt

--- a/api/pkg/resources/test/fixtures/deployment-azure-1.10.0-kube-state-metrics.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-azure-1.10.0-kube-state-metrics.yaml
@@ -81,7 +81,6 @@ spec:
       volumes:
       - name: kube-state-metrics-kubeconfig
         secret:
-          defaultMode: 256
           secretName: kube-state-metrics-kubeconfig
       - emptyDir: {}
         name: http-prober-bin

--- a/api/pkg/resources/test/fixtures/deployment-azure-1.10.0-machine-controller-webhook.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-azure-1.10.0-machine-controller-webhook.yaml
@@ -86,11 +86,9 @@ spec:
       volumes:
       - name: machinecontroller-kubeconfig
         secret:
-          defaultMode: 292
           secretName: machinecontroller-kubeconfig
       - name: machinecontroller-webhook-serving-cert
         secret:
-          defaultMode: 292
           secretName: machinecontroller-webhook-serving-cert
       - emptyDir: {}
         name: http-prober-bin

--- a/api/pkg/resources/test/fixtures/deployment-azure-1.10.0-machine-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-azure-1.10.0-machine-controller.yaml
@@ -77,7 +77,6 @@ spec:
       volumes:
       - name: machinecontroller-kubeconfig
         secret:
-          defaultMode: 292
           secretName: machinecontroller-kubeconfig
       - emptyDir: {}
         name: http-prober-bin

--- a/api/pkg/resources/test/fixtures/deployment-azure-1.10.0-metrics-server.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-azure-1.10.0-metrics-server.yaml
@@ -164,15 +164,12 @@ spec:
       volumes:
       - name: metrics-server
         secret:
-          defaultMode: 292
           secretName: metrics-server
       - name: openvpn-client-certificates
         secret:
-          defaultMode: 256
           secretName: openvpn-client-certificates
       - name: kubeletdnatcontroller-kubeconfig
         secret:
-          defaultMode: 292
           secretName: kubeletdnatcontroller-kubeconfig
       - emptyDir: {}
         name: http-prober-bin

--- a/api/pkg/resources/test/fixtures/deployment-azure-1.10.0-openvpn-server.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-azure-1.10.0-openvpn-server.yaml
@@ -178,17 +178,14 @@ spec:
       volumes:
       - name: ca
         secret:
-          defaultMode: 256
           items:
           - key: ca.crt
             path: ca.crt
           secretName: openvpn-ca
       - name: openvpn-server-certificates
         secret:
-          defaultMode: 256
           secretName: openvpn-server-certificates
       - configMap:
-          defaultMode: 256
           name: openvpn-client-configs
         name: openvpn-client-configs
 status: {}

--- a/api/pkg/resources/test/fixtures/deployment-azure-1.10.0-scheduler.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-azure-1.10.0-scheduler.yaml
@@ -172,18 +172,15 @@ spec:
       volumes:
       - name: openvpn-client-certificates
         secret:
-          defaultMode: 256
           secretName: openvpn-client-certificates
       - name: ca
         secret:
-          defaultMode: 256
           items:
           - key: ca.crt
             path: ca.crt
           secretName: ca
       - name: scheduler-kubeconfig
         secret:
-          defaultMode: 256
           secretName: scheduler-kubeconfig
       - emptyDir: {}
         name: http-prober-bin

--- a/api/pkg/resources/test/fixtures/deployment-azure-1.10.0-usercluster-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-azure-1.10.0-usercluster-controller.yaml
@@ -94,18 +94,15 @@ spec:
       volumes:
       - name: internal-admin-kubeconfig
         secret:
-          defaultMode: 292
           secretName: internal-admin-kubeconfig
       - name: ca
         secret:
-          defaultMode: 292
           items:
           - key: ca.crt
             path: ca.crt
           secretName: ca
       - name: openvpn-ca
         secret:
-          defaultMode: 292
           secretName: openvpn-ca
       - emptyDir: {}
         name: http-prober-bin

--- a/api/pkg/resources/test/fixtures/deployment-azure-1.10.6-apiserver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-azure-1.10.6-apiserver.yaml
@@ -313,53 +313,41 @@ spec:
       volumes:
       - name: apiserver-tls
         secret:
-          defaultMode: 256
           secretName: apiserver-tls
       - name: tokens
         secret:
-          defaultMode: 256
           secretName: tokens
       - name: openvpn-client-certificates
         secret:
-          defaultMode: 256
           secretName: openvpn-client-certificates
       - name: kubelet-client-certificates
         secret:
-          defaultMode: 256
           secretName: kubelet-client-certificates
       - name: ca
         secret:
-          defaultMode: 256
           items:
           - key: ca.crt
             path: ca.crt
           secretName: ca
       - name: service-account-key
         secret:
-          defaultMode: 256
           secretName: service-account-key
       - configMap:
-          defaultMode: 420
           name: cloud-config
         name: cloud-config
       - name: apiserver-etcd-client-certificate
         secret:
-          defaultMode: 256
           secretName: apiserver-etcd-client-certificate
       - name: apiserver-proxy-client-certificate
         secret:
-          defaultMode: 256
           secretName: apiserver-proxy-client-certificate
       - name: front-proxy-ca
         secret:
-          defaultMode: 256
           secretName: front-proxy-ca
       - name: kubeletdnatcontroller-kubeconfig
         secret:
-          defaultMode: 292
           secretName: kubeletdnatcontroller-kubeconfig
       - name: dex-ca
         secret:
-          defaultMode: 256
           secretName: dex-ca
 status: {}

--- a/api/pkg/resources/test/fixtures/deployment-azure-1.10.6-controller-manager.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-azure-1.10.6-controller-manager.yaml
@@ -180,23 +180,18 @@ spec:
       volumes:
       - name: ca
         secret:
-          defaultMode: 256
           secretName: ca
       - name: service-account-key
         secret:
-          defaultMode: 256
           secretName: service-account-key
       - configMap:
-          defaultMode: 420
           name: cloud-config
         name: cloud-config
       - name: openvpn-client-certificates
         secret:
-          defaultMode: 256
           secretName: openvpn-client-certificates
       - name: controllermanager-kubeconfig
         secret:
-          defaultMode: 256
           secretName: controllermanager-kubeconfig
       - emptyDir: {}
         name: http-prober-bin

--- a/api/pkg/resources/test/fixtures/deployment-azure-1.10.6-dns-resolver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-azure-1.10.6-dns-resolver.yaml
@@ -124,16 +124,13 @@ spec:
       - name: dockercfg
       volumes:
       - configMap:
-          defaultMode: 256
           name: dns-resolver
         name: dns-resolver
       - name: openvpn-client-certificates
         secret:
-          defaultMode: 256
           secretName: openvpn-client-certificates
       - name: ca
         secret:
-          defaultMode: 256
           items:
           - key: ca.crt
             path: ca.crt

--- a/api/pkg/resources/test/fixtures/deployment-azure-1.10.6-kube-state-metrics.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-azure-1.10.6-kube-state-metrics.yaml
@@ -81,7 +81,6 @@ spec:
       volumes:
       - name: kube-state-metrics-kubeconfig
         secret:
-          defaultMode: 256
           secretName: kube-state-metrics-kubeconfig
       - emptyDir: {}
         name: http-prober-bin

--- a/api/pkg/resources/test/fixtures/deployment-azure-1.10.6-machine-controller-webhook.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-azure-1.10.6-machine-controller-webhook.yaml
@@ -86,11 +86,9 @@ spec:
       volumes:
       - name: machinecontroller-kubeconfig
         secret:
-          defaultMode: 292
           secretName: machinecontroller-kubeconfig
       - name: machinecontroller-webhook-serving-cert
         secret:
-          defaultMode: 292
           secretName: machinecontroller-webhook-serving-cert
       - emptyDir: {}
         name: http-prober-bin

--- a/api/pkg/resources/test/fixtures/deployment-azure-1.10.6-machine-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-azure-1.10.6-machine-controller.yaml
@@ -77,7 +77,6 @@ spec:
       volumes:
       - name: machinecontroller-kubeconfig
         secret:
-          defaultMode: 292
           secretName: machinecontroller-kubeconfig
       - emptyDir: {}
         name: http-prober-bin

--- a/api/pkg/resources/test/fixtures/deployment-azure-1.10.6-metrics-server.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-azure-1.10.6-metrics-server.yaml
@@ -164,15 +164,12 @@ spec:
       volumes:
       - name: metrics-server
         secret:
-          defaultMode: 292
           secretName: metrics-server
       - name: openvpn-client-certificates
         secret:
-          defaultMode: 256
           secretName: openvpn-client-certificates
       - name: kubeletdnatcontroller-kubeconfig
         secret:
-          defaultMode: 292
           secretName: kubeletdnatcontroller-kubeconfig
       - emptyDir: {}
         name: http-prober-bin

--- a/api/pkg/resources/test/fixtures/deployment-azure-1.10.6-openvpn-server.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-azure-1.10.6-openvpn-server.yaml
@@ -178,17 +178,14 @@ spec:
       volumes:
       - name: ca
         secret:
-          defaultMode: 256
           items:
           - key: ca.crt
             path: ca.crt
           secretName: openvpn-ca
       - name: openvpn-server-certificates
         secret:
-          defaultMode: 256
           secretName: openvpn-server-certificates
       - configMap:
-          defaultMode: 256
           name: openvpn-client-configs
         name: openvpn-client-configs
 status: {}

--- a/api/pkg/resources/test/fixtures/deployment-azure-1.10.6-scheduler.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-azure-1.10.6-scheduler.yaml
@@ -172,18 +172,15 @@ spec:
       volumes:
       - name: openvpn-client-certificates
         secret:
-          defaultMode: 256
           secretName: openvpn-client-certificates
       - name: ca
         secret:
-          defaultMode: 256
           items:
           - key: ca.crt
             path: ca.crt
           secretName: ca
       - name: scheduler-kubeconfig
         secret:
-          defaultMode: 256
           secretName: scheduler-kubeconfig
       - emptyDir: {}
         name: http-prober-bin

--- a/api/pkg/resources/test/fixtures/deployment-azure-1.10.6-usercluster-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-azure-1.10.6-usercluster-controller.yaml
@@ -94,18 +94,15 @@ spec:
       volumes:
       - name: internal-admin-kubeconfig
         secret:
-          defaultMode: 292
           secretName: internal-admin-kubeconfig
       - name: ca
         secret:
-          defaultMode: 292
           items:
           - key: ca.crt
             path: ca.crt
           secretName: ca
       - name: openvpn-ca
         secret:
-          defaultMode: 292
           secretName: openvpn-ca
       - emptyDir: {}
         name: http-prober-bin

--- a/api/pkg/resources/test/fixtures/deployment-azure-1.11.0-apiserver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-azure-1.11.0-apiserver.yaml
@@ -311,53 +311,41 @@ spec:
       volumes:
       - name: apiserver-tls
         secret:
-          defaultMode: 256
           secretName: apiserver-tls
       - name: tokens
         secret:
-          defaultMode: 256
           secretName: tokens
       - name: openvpn-client-certificates
         secret:
-          defaultMode: 256
           secretName: openvpn-client-certificates
       - name: kubelet-client-certificates
         secret:
-          defaultMode: 256
           secretName: kubelet-client-certificates
       - name: ca
         secret:
-          defaultMode: 256
           items:
           - key: ca.crt
             path: ca.crt
           secretName: ca
       - name: service-account-key
         secret:
-          defaultMode: 256
           secretName: service-account-key
       - configMap:
-          defaultMode: 420
           name: cloud-config
         name: cloud-config
       - name: apiserver-etcd-client-certificate
         secret:
-          defaultMode: 256
           secretName: apiserver-etcd-client-certificate
       - name: apiserver-proxy-client-certificate
         secret:
-          defaultMode: 256
           secretName: apiserver-proxy-client-certificate
       - name: front-proxy-ca
         secret:
-          defaultMode: 256
           secretName: front-proxy-ca
       - name: kubeletdnatcontroller-kubeconfig
         secret:
-          defaultMode: 292
           secretName: kubeletdnatcontroller-kubeconfig
       - name: dex-ca
         secret:
-          defaultMode: 256
           secretName: dex-ca
 status: {}

--- a/api/pkg/resources/test/fixtures/deployment-azure-1.11.0-controller-manager.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-azure-1.11.0-controller-manager.yaml
@@ -180,23 +180,18 @@ spec:
       volumes:
       - name: ca
         secret:
-          defaultMode: 256
           secretName: ca
       - name: service-account-key
         secret:
-          defaultMode: 256
           secretName: service-account-key
       - configMap:
-          defaultMode: 420
           name: cloud-config
         name: cloud-config
       - name: openvpn-client-certificates
         secret:
-          defaultMode: 256
           secretName: openvpn-client-certificates
       - name: controllermanager-kubeconfig
         secret:
-          defaultMode: 256
           secretName: controllermanager-kubeconfig
       - emptyDir: {}
         name: http-prober-bin

--- a/api/pkg/resources/test/fixtures/deployment-azure-1.11.0-dns-resolver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-azure-1.11.0-dns-resolver.yaml
@@ -124,16 +124,13 @@ spec:
       - name: dockercfg
       volumes:
       - configMap:
-          defaultMode: 256
           name: dns-resolver
         name: dns-resolver
       - name: openvpn-client-certificates
         secret:
-          defaultMode: 256
           secretName: openvpn-client-certificates
       - name: ca
         secret:
-          defaultMode: 256
           items:
           - key: ca.crt
             path: ca.crt

--- a/api/pkg/resources/test/fixtures/deployment-azure-1.11.0-kube-state-metrics.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-azure-1.11.0-kube-state-metrics.yaml
@@ -81,7 +81,6 @@ spec:
       volumes:
       - name: kube-state-metrics-kubeconfig
         secret:
-          defaultMode: 256
           secretName: kube-state-metrics-kubeconfig
       - emptyDir: {}
         name: http-prober-bin

--- a/api/pkg/resources/test/fixtures/deployment-azure-1.11.0-machine-controller-webhook.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-azure-1.11.0-machine-controller-webhook.yaml
@@ -86,11 +86,9 @@ spec:
       volumes:
       - name: machinecontroller-kubeconfig
         secret:
-          defaultMode: 292
           secretName: machinecontroller-kubeconfig
       - name: machinecontroller-webhook-serving-cert
         secret:
-          defaultMode: 292
           secretName: machinecontroller-webhook-serving-cert
       - emptyDir: {}
         name: http-prober-bin

--- a/api/pkg/resources/test/fixtures/deployment-azure-1.11.0-machine-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-azure-1.11.0-machine-controller.yaml
@@ -77,7 +77,6 @@ spec:
       volumes:
       - name: machinecontroller-kubeconfig
         secret:
-          defaultMode: 292
           secretName: machinecontroller-kubeconfig
       - emptyDir: {}
         name: http-prober-bin

--- a/api/pkg/resources/test/fixtures/deployment-azure-1.11.0-metrics-server.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-azure-1.11.0-metrics-server.yaml
@@ -164,15 +164,12 @@ spec:
       volumes:
       - name: metrics-server
         secret:
-          defaultMode: 292
           secretName: metrics-server
       - name: openvpn-client-certificates
         secret:
-          defaultMode: 256
           secretName: openvpn-client-certificates
       - name: kubeletdnatcontroller-kubeconfig
         secret:
-          defaultMode: 292
           secretName: kubeletdnatcontroller-kubeconfig
       - emptyDir: {}
         name: http-prober-bin

--- a/api/pkg/resources/test/fixtures/deployment-azure-1.11.0-openvpn-server.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-azure-1.11.0-openvpn-server.yaml
@@ -178,17 +178,14 @@ spec:
       volumes:
       - name: ca
         secret:
-          defaultMode: 256
           items:
           - key: ca.crt
             path: ca.crt
           secretName: openvpn-ca
       - name: openvpn-server-certificates
         secret:
-          defaultMode: 256
           secretName: openvpn-server-certificates
       - configMap:
-          defaultMode: 256
           name: openvpn-client-configs
         name: openvpn-client-configs
 status: {}

--- a/api/pkg/resources/test/fixtures/deployment-azure-1.11.0-scheduler.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-azure-1.11.0-scheduler.yaml
@@ -172,18 +172,15 @@ spec:
       volumes:
       - name: openvpn-client-certificates
         secret:
-          defaultMode: 256
           secretName: openvpn-client-certificates
       - name: ca
         secret:
-          defaultMode: 256
           items:
           - key: ca.crt
             path: ca.crt
           secretName: ca
       - name: scheduler-kubeconfig
         secret:
-          defaultMode: 256
           secretName: scheduler-kubeconfig
       - emptyDir: {}
         name: http-prober-bin

--- a/api/pkg/resources/test/fixtures/deployment-azure-1.11.0-usercluster-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-azure-1.11.0-usercluster-controller.yaml
@@ -94,18 +94,15 @@ spec:
       volumes:
       - name: internal-admin-kubeconfig
         secret:
-          defaultMode: 292
           secretName: internal-admin-kubeconfig
       - name: ca
         secret:
-          defaultMode: 292
           items:
           - key: ca.crt
             path: ca.crt
           secretName: ca
       - name: openvpn-ca
         secret:
-          defaultMode: 292
           secretName: openvpn-ca
       - emptyDir: {}
         name: http-prober-bin

--- a/api/pkg/resources/test/fixtures/deployment-azure-1.11.1-apiserver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-azure-1.11.1-apiserver.yaml
@@ -311,53 +311,41 @@ spec:
       volumes:
       - name: apiserver-tls
         secret:
-          defaultMode: 256
           secretName: apiserver-tls
       - name: tokens
         secret:
-          defaultMode: 256
           secretName: tokens
       - name: openvpn-client-certificates
         secret:
-          defaultMode: 256
           secretName: openvpn-client-certificates
       - name: kubelet-client-certificates
         secret:
-          defaultMode: 256
           secretName: kubelet-client-certificates
       - name: ca
         secret:
-          defaultMode: 256
           items:
           - key: ca.crt
             path: ca.crt
           secretName: ca
       - name: service-account-key
         secret:
-          defaultMode: 256
           secretName: service-account-key
       - configMap:
-          defaultMode: 420
           name: cloud-config
         name: cloud-config
       - name: apiserver-etcd-client-certificate
         secret:
-          defaultMode: 256
           secretName: apiserver-etcd-client-certificate
       - name: apiserver-proxy-client-certificate
         secret:
-          defaultMode: 256
           secretName: apiserver-proxy-client-certificate
       - name: front-proxy-ca
         secret:
-          defaultMode: 256
           secretName: front-proxy-ca
       - name: kubeletdnatcontroller-kubeconfig
         secret:
-          defaultMode: 292
           secretName: kubeletdnatcontroller-kubeconfig
       - name: dex-ca
         secret:
-          defaultMode: 256
           secretName: dex-ca
 status: {}

--- a/api/pkg/resources/test/fixtures/deployment-azure-1.11.1-controller-manager.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-azure-1.11.1-controller-manager.yaml
@@ -180,23 +180,18 @@ spec:
       volumes:
       - name: ca
         secret:
-          defaultMode: 256
           secretName: ca
       - name: service-account-key
         secret:
-          defaultMode: 256
           secretName: service-account-key
       - configMap:
-          defaultMode: 420
           name: cloud-config
         name: cloud-config
       - name: openvpn-client-certificates
         secret:
-          defaultMode: 256
           secretName: openvpn-client-certificates
       - name: controllermanager-kubeconfig
         secret:
-          defaultMode: 256
           secretName: controllermanager-kubeconfig
       - emptyDir: {}
         name: http-prober-bin

--- a/api/pkg/resources/test/fixtures/deployment-azure-1.11.1-dns-resolver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-azure-1.11.1-dns-resolver.yaml
@@ -124,16 +124,13 @@ spec:
       - name: dockercfg
       volumes:
       - configMap:
-          defaultMode: 256
           name: dns-resolver
         name: dns-resolver
       - name: openvpn-client-certificates
         secret:
-          defaultMode: 256
           secretName: openvpn-client-certificates
       - name: ca
         secret:
-          defaultMode: 256
           items:
           - key: ca.crt
             path: ca.crt

--- a/api/pkg/resources/test/fixtures/deployment-azure-1.11.1-kube-state-metrics.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-azure-1.11.1-kube-state-metrics.yaml
@@ -81,7 +81,6 @@ spec:
       volumes:
       - name: kube-state-metrics-kubeconfig
         secret:
-          defaultMode: 256
           secretName: kube-state-metrics-kubeconfig
       - emptyDir: {}
         name: http-prober-bin

--- a/api/pkg/resources/test/fixtures/deployment-azure-1.11.1-machine-controller-webhook.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-azure-1.11.1-machine-controller-webhook.yaml
@@ -86,11 +86,9 @@ spec:
       volumes:
       - name: machinecontroller-kubeconfig
         secret:
-          defaultMode: 292
           secretName: machinecontroller-kubeconfig
       - name: machinecontroller-webhook-serving-cert
         secret:
-          defaultMode: 292
           secretName: machinecontroller-webhook-serving-cert
       - emptyDir: {}
         name: http-prober-bin

--- a/api/pkg/resources/test/fixtures/deployment-azure-1.11.1-machine-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-azure-1.11.1-machine-controller.yaml
@@ -77,7 +77,6 @@ spec:
       volumes:
       - name: machinecontroller-kubeconfig
         secret:
-          defaultMode: 292
           secretName: machinecontroller-kubeconfig
       - emptyDir: {}
         name: http-prober-bin

--- a/api/pkg/resources/test/fixtures/deployment-azure-1.11.1-metrics-server.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-azure-1.11.1-metrics-server.yaml
@@ -164,15 +164,12 @@ spec:
       volumes:
       - name: metrics-server
         secret:
-          defaultMode: 292
           secretName: metrics-server
       - name: openvpn-client-certificates
         secret:
-          defaultMode: 256
           secretName: openvpn-client-certificates
       - name: kubeletdnatcontroller-kubeconfig
         secret:
-          defaultMode: 292
           secretName: kubeletdnatcontroller-kubeconfig
       - emptyDir: {}
         name: http-prober-bin

--- a/api/pkg/resources/test/fixtures/deployment-azure-1.11.1-openvpn-server.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-azure-1.11.1-openvpn-server.yaml
@@ -178,17 +178,14 @@ spec:
       volumes:
       - name: ca
         secret:
-          defaultMode: 256
           items:
           - key: ca.crt
             path: ca.crt
           secretName: openvpn-ca
       - name: openvpn-server-certificates
         secret:
-          defaultMode: 256
           secretName: openvpn-server-certificates
       - configMap:
-          defaultMode: 256
           name: openvpn-client-configs
         name: openvpn-client-configs
 status: {}

--- a/api/pkg/resources/test/fixtures/deployment-azure-1.11.1-scheduler.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-azure-1.11.1-scheduler.yaml
@@ -172,18 +172,15 @@ spec:
       volumes:
       - name: openvpn-client-certificates
         secret:
-          defaultMode: 256
           secretName: openvpn-client-certificates
       - name: ca
         secret:
-          defaultMode: 256
           items:
           - key: ca.crt
             path: ca.crt
           secretName: ca
       - name: scheduler-kubeconfig
         secret:
-          defaultMode: 256
           secretName: scheduler-kubeconfig
       - emptyDir: {}
         name: http-prober-bin

--- a/api/pkg/resources/test/fixtures/deployment-azure-1.11.1-usercluster-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-azure-1.11.1-usercluster-controller.yaml
@@ -94,18 +94,15 @@ spec:
       volumes:
       - name: internal-admin-kubeconfig
         secret:
-          defaultMode: 292
           secretName: internal-admin-kubeconfig
       - name: ca
         secret:
-          defaultMode: 292
           items:
           - key: ca.crt
             path: ca.crt
           secretName: ca
       - name: openvpn-ca
         secret:
-          defaultMode: 292
           secretName: openvpn-ca
       - emptyDir: {}
         name: http-prober-bin

--- a/api/pkg/resources/test/fixtures/deployment-azure-1.12.0-apiserver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-azure-1.12.0-apiserver.yaml
@@ -311,53 +311,41 @@ spec:
       volumes:
       - name: apiserver-tls
         secret:
-          defaultMode: 256
           secretName: apiserver-tls
       - name: tokens
         secret:
-          defaultMode: 256
           secretName: tokens
       - name: openvpn-client-certificates
         secret:
-          defaultMode: 256
           secretName: openvpn-client-certificates
       - name: kubelet-client-certificates
         secret:
-          defaultMode: 256
           secretName: kubelet-client-certificates
       - name: ca
         secret:
-          defaultMode: 256
           items:
           - key: ca.crt
             path: ca.crt
           secretName: ca
       - name: service-account-key
         secret:
-          defaultMode: 256
           secretName: service-account-key
       - configMap:
-          defaultMode: 420
           name: cloud-config
         name: cloud-config
       - name: apiserver-etcd-client-certificate
         secret:
-          defaultMode: 256
           secretName: apiserver-etcd-client-certificate
       - name: apiserver-proxy-client-certificate
         secret:
-          defaultMode: 256
           secretName: apiserver-proxy-client-certificate
       - name: front-proxy-ca
         secret:
-          defaultMode: 256
           secretName: front-proxy-ca
       - name: kubeletdnatcontroller-kubeconfig
         secret:
-          defaultMode: 292
           secretName: kubeletdnatcontroller-kubeconfig
       - name: dex-ca
         secret:
-          defaultMode: 256
           secretName: dex-ca
 status: {}

--- a/api/pkg/resources/test/fixtures/deployment-azure-1.12.0-controller-manager.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-azure-1.12.0-controller-manager.yaml
@@ -180,23 +180,18 @@ spec:
       volumes:
       - name: ca
         secret:
-          defaultMode: 256
           secretName: ca
       - name: service-account-key
         secret:
-          defaultMode: 256
           secretName: service-account-key
       - configMap:
-          defaultMode: 420
           name: cloud-config
         name: cloud-config
       - name: openvpn-client-certificates
         secret:
-          defaultMode: 256
           secretName: openvpn-client-certificates
       - name: controllermanager-kubeconfig
         secret:
-          defaultMode: 256
           secretName: controllermanager-kubeconfig
       - emptyDir: {}
         name: http-prober-bin

--- a/api/pkg/resources/test/fixtures/deployment-azure-1.12.0-dns-resolver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-azure-1.12.0-dns-resolver.yaml
@@ -124,16 +124,13 @@ spec:
       - name: dockercfg
       volumes:
       - configMap:
-          defaultMode: 256
           name: dns-resolver
         name: dns-resolver
       - name: openvpn-client-certificates
         secret:
-          defaultMode: 256
           secretName: openvpn-client-certificates
       - name: ca
         secret:
-          defaultMode: 256
           items:
           - key: ca.crt
             path: ca.crt

--- a/api/pkg/resources/test/fixtures/deployment-azure-1.12.0-kube-state-metrics.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-azure-1.12.0-kube-state-metrics.yaml
@@ -81,7 +81,6 @@ spec:
       volumes:
       - name: kube-state-metrics-kubeconfig
         secret:
-          defaultMode: 256
           secretName: kube-state-metrics-kubeconfig
       - emptyDir: {}
         name: http-prober-bin

--- a/api/pkg/resources/test/fixtures/deployment-azure-1.12.0-machine-controller-webhook.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-azure-1.12.0-machine-controller-webhook.yaml
@@ -86,11 +86,9 @@ spec:
       volumes:
       - name: machinecontroller-kubeconfig
         secret:
-          defaultMode: 292
           secretName: machinecontroller-kubeconfig
       - name: machinecontroller-webhook-serving-cert
         secret:
-          defaultMode: 292
           secretName: machinecontroller-webhook-serving-cert
       - emptyDir: {}
         name: http-prober-bin

--- a/api/pkg/resources/test/fixtures/deployment-azure-1.12.0-machine-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-azure-1.12.0-machine-controller.yaml
@@ -77,7 +77,6 @@ spec:
       volumes:
       - name: machinecontroller-kubeconfig
         secret:
-          defaultMode: 292
           secretName: machinecontroller-kubeconfig
       - emptyDir: {}
         name: http-prober-bin

--- a/api/pkg/resources/test/fixtures/deployment-azure-1.12.0-metrics-server.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-azure-1.12.0-metrics-server.yaml
@@ -164,15 +164,12 @@ spec:
       volumes:
       - name: metrics-server
         secret:
-          defaultMode: 292
           secretName: metrics-server
       - name: openvpn-client-certificates
         secret:
-          defaultMode: 256
           secretName: openvpn-client-certificates
       - name: kubeletdnatcontroller-kubeconfig
         secret:
-          defaultMode: 292
           secretName: kubeletdnatcontroller-kubeconfig
       - emptyDir: {}
         name: http-prober-bin

--- a/api/pkg/resources/test/fixtures/deployment-azure-1.12.0-openvpn-server.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-azure-1.12.0-openvpn-server.yaml
@@ -178,17 +178,14 @@ spec:
       volumes:
       - name: ca
         secret:
-          defaultMode: 256
           items:
           - key: ca.crt
             path: ca.crt
           secretName: openvpn-ca
       - name: openvpn-server-certificates
         secret:
-          defaultMode: 256
           secretName: openvpn-server-certificates
       - configMap:
-          defaultMode: 256
           name: openvpn-client-configs
         name: openvpn-client-configs
 status: {}

--- a/api/pkg/resources/test/fixtures/deployment-azure-1.12.0-scheduler.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-azure-1.12.0-scheduler.yaml
@@ -172,18 +172,15 @@ spec:
       volumes:
       - name: openvpn-client-certificates
         secret:
-          defaultMode: 256
           secretName: openvpn-client-certificates
       - name: ca
         secret:
-          defaultMode: 256
           items:
           - key: ca.crt
             path: ca.crt
           secretName: ca
       - name: scheduler-kubeconfig
         secret:
-          defaultMode: 256
           secretName: scheduler-kubeconfig
       - emptyDir: {}
         name: http-prober-bin

--- a/api/pkg/resources/test/fixtures/deployment-azure-1.12.0-usercluster-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-azure-1.12.0-usercluster-controller.yaml
@@ -94,18 +94,15 @@ spec:
       volumes:
       - name: internal-admin-kubeconfig
         secret:
-          defaultMode: 292
           secretName: internal-admin-kubeconfig
       - name: ca
         secret:
-          defaultMode: 292
           items:
           - key: ca.crt
             path: ca.crt
           secretName: ca
       - name: openvpn-ca
         secret:
-          defaultMode: 292
           secretName: openvpn-ca
       - emptyDir: {}
         name: http-prober-bin

--- a/api/pkg/resources/test/fixtures/deployment-azure-1.13.0-apiserver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-azure-1.13.0-apiserver.yaml
@@ -311,53 +311,41 @@ spec:
       volumes:
       - name: apiserver-tls
         secret:
-          defaultMode: 256
           secretName: apiserver-tls
       - name: tokens
         secret:
-          defaultMode: 256
           secretName: tokens
       - name: openvpn-client-certificates
         secret:
-          defaultMode: 256
           secretName: openvpn-client-certificates
       - name: kubelet-client-certificates
         secret:
-          defaultMode: 256
           secretName: kubelet-client-certificates
       - name: ca
         secret:
-          defaultMode: 256
           items:
           - key: ca.crt
             path: ca.crt
           secretName: ca
       - name: service-account-key
         secret:
-          defaultMode: 256
           secretName: service-account-key
       - configMap:
-          defaultMode: 420
           name: cloud-config
         name: cloud-config
       - name: apiserver-etcd-client-certificate
         secret:
-          defaultMode: 256
           secretName: apiserver-etcd-client-certificate
       - name: apiserver-proxy-client-certificate
         secret:
-          defaultMode: 256
           secretName: apiserver-proxy-client-certificate
       - name: front-proxy-ca
         secret:
-          defaultMode: 256
           secretName: front-proxy-ca
       - name: kubeletdnatcontroller-kubeconfig
         secret:
-          defaultMode: 292
           secretName: kubeletdnatcontroller-kubeconfig
       - name: dex-ca
         secret:
-          defaultMode: 256
           secretName: dex-ca
 status: {}

--- a/api/pkg/resources/test/fixtures/deployment-azure-1.13.0-controller-manager.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-azure-1.13.0-controller-manager.yaml
@@ -180,23 +180,18 @@ spec:
       volumes:
       - name: ca
         secret:
-          defaultMode: 256
           secretName: ca
       - name: service-account-key
         secret:
-          defaultMode: 256
           secretName: service-account-key
       - configMap:
-          defaultMode: 420
           name: cloud-config
         name: cloud-config
       - name: openvpn-client-certificates
         secret:
-          defaultMode: 256
           secretName: openvpn-client-certificates
       - name: controllermanager-kubeconfig
         secret:
-          defaultMode: 256
           secretName: controllermanager-kubeconfig
       - emptyDir: {}
         name: http-prober-bin

--- a/api/pkg/resources/test/fixtures/deployment-azure-1.13.0-dns-resolver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-azure-1.13.0-dns-resolver.yaml
@@ -124,16 +124,13 @@ spec:
       - name: dockercfg
       volumes:
       - configMap:
-          defaultMode: 256
           name: dns-resolver
         name: dns-resolver
       - name: openvpn-client-certificates
         secret:
-          defaultMode: 256
           secretName: openvpn-client-certificates
       - name: ca
         secret:
-          defaultMode: 256
           items:
           - key: ca.crt
             path: ca.crt

--- a/api/pkg/resources/test/fixtures/deployment-azure-1.13.0-kube-state-metrics.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-azure-1.13.0-kube-state-metrics.yaml
@@ -81,7 +81,6 @@ spec:
       volumes:
       - name: kube-state-metrics-kubeconfig
         secret:
-          defaultMode: 256
           secretName: kube-state-metrics-kubeconfig
       - emptyDir: {}
         name: http-prober-bin

--- a/api/pkg/resources/test/fixtures/deployment-azure-1.13.0-machine-controller-webhook.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-azure-1.13.0-machine-controller-webhook.yaml
@@ -86,11 +86,9 @@ spec:
       volumes:
       - name: machinecontroller-kubeconfig
         secret:
-          defaultMode: 292
           secretName: machinecontroller-kubeconfig
       - name: machinecontroller-webhook-serving-cert
         secret:
-          defaultMode: 292
           secretName: machinecontroller-webhook-serving-cert
       - emptyDir: {}
         name: http-prober-bin

--- a/api/pkg/resources/test/fixtures/deployment-azure-1.13.0-machine-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-azure-1.13.0-machine-controller.yaml
@@ -77,7 +77,6 @@ spec:
       volumes:
       - name: machinecontroller-kubeconfig
         secret:
-          defaultMode: 292
           secretName: machinecontroller-kubeconfig
       - emptyDir: {}
         name: http-prober-bin

--- a/api/pkg/resources/test/fixtures/deployment-azure-1.13.0-metrics-server.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-azure-1.13.0-metrics-server.yaml
@@ -164,15 +164,12 @@ spec:
       volumes:
       - name: metrics-server
         secret:
-          defaultMode: 292
           secretName: metrics-server
       - name: openvpn-client-certificates
         secret:
-          defaultMode: 256
           secretName: openvpn-client-certificates
       - name: kubeletdnatcontroller-kubeconfig
         secret:
-          defaultMode: 292
           secretName: kubeletdnatcontroller-kubeconfig
       - emptyDir: {}
         name: http-prober-bin

--- a/api/pkg/resources/test/fixtures/deployment-azure-1.13.0-openvpn-server.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-azure-1.13.0-openvpn-server.yaml
@@ -178,17 +178,14 @@ spec:
       volumes:
       - name: ca
         secret:
-          defaultMode: 256
           items:
           - key: ca.crt
             path: ca.crt
           secretName: openvpn-ca
       - name: openvpn-server-certificates
         secret:
-          defaultMode: 256
           secretName: openvpn-server-certificates
       - configMap:
-          defaultMode: 256
           name: openvpn-client-configs
         name: openvpn-client-configs
 status: {}

--- a/api/pkg/resources/test/fixtures/deployment-azure-1.13.0-scheduler.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-azure-1.13.0-scheduler.yaml
@@ -172,18 +172,15 @@ spec:
       volumes:
       - name: openvpn-client-certificates
         secret:
-          defaultMode: 256
           secretName: openvpn-client-certificates
       - name: ca
         secret:
-          defaultMode: 256
           items:
           - key: ca.crt
             path: ca.crt
           secretName: ca
       - name: scheduler-kubeconfig
         secret:
-          defaultMode: 256
           secretName: scheduler-kubeconfig
       - emptyDir: {}
         name: http-prober-bin

--- a/api/pkg/resources/test/fixtures/deployment-azure-1.13.0-usercluster-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-azure-1.13.0-usercluster-controller.yaml
@@ -94,18 +94,15 @@ spec:
       volumes:
       - name: internal-admin-kubeconfig
         secret:
-          defaultMode: 292
           secretName: internal-admin-kubeconfig
       - name: ca
         secret:
-          defaultMode: 292
           items:
           - key: ca.crt
             path: ca.crt
           secretName: ca
       - name: openvpn-ca
         secret:
-          defaultMode: 292
           secretName: openvpn-ca
       - emptyDir: {}
         name: http-prober-bin

--- a/api/pkg/resources/test/fixtures/deployment-bringyourown-1.10.0-apiserver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-bringyourown-1.10.0-apiserver.yaml
@@ -309,53 +309,41 @@ spec:
       volumes:
       - name: apiserver-tls
         secret:
-          defaultMode: 256
           secretName: apiserver-tls
       - name: tokens
         secret:
-          defaultMode: 256
           secretName: tokens
       - name: openvpn-client-certificates
         secret:
-          defaultMode: 256
           secretName: openvpn-client-certificates
       - name: kubelet-client-certificates
         secret:
-          defaultMode: 256
           secretName: kubelet-client-certificates
       - name: ca
         secret:
-          defaultMode: 256
           items:
           - key: ca.crt
             path: ca.crt
           secretName: ca
       - name: service-account-key
         secret:
-          defaultMode: 256
           secretName: service-account-key
       - configMap:
-          defaultMode: 420
           name: cloud-config
         name: cloud-config
       - name: apiserver-etcd-client-certificate
         secret:
-          defaultMode: 256
           secretName: apiserver-etcd-client-certificate
       - name: apiserver-proxy-client-certificate
         secret:
-          defaultMode: 256
           secretName: apiserver-proxy-client-certificate
       - name: front-proxy-ca
         secret:
-          defaultMode: 256
           secretName: front-proxy-ca
       - name: kubeletdnatcontroller-kubeconfig
         secret:
-          defaultMode: 292
           secretName: kubeletdnatcontroller-kubeconfig
       - name: dex-ca
         secret:
-          defaultMode: 256
           secretName: dex-ca
 status: {}

--- a/api/pkg/resources/test/fixtures/deployment-bringyourown-1.10.0-controller-manager.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-bringyourown-1.10.0-controller-manager.yaml
@@ -180,23 +180,18 @@ spec:
       volumes:
       - name: ca
         secret:
-          defaultMode: 256
           secretName: ca
       - name: service-account-key
         secret:
-          defaultMode: 256
           secretName: service-account-key
       - configMap:
-          defaultMode: 420
           name: cloud-config
         name: cloud-config
       - name: openvpn-client-certificates
         secret:
-          defaultMode: 256
           secretName: openvpn-client-certificates
       - name: controllermanager-kubeconfig
         secret:
-          defaultMode: 256
           secretName: controllermanager-kubeconfig
       - emptyDir: {}
         name: http-prober-bin

--- a/api/pkg/resources/test/fixtures/deployment-bringyourown-1.10.0-dns-resolver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-bringyourown-1.10.0-dns-resolver.yaml
@@ -124,16 +124,13 @@ spec:
       - name: dockercfg
       volumes:
       - configMap:
-          defaultMode: 256
           name: dns-resolver
         name: dns-resolver
       - name: openvpn-client-certificates
         secret:
-          defaultMode: 256
           secretName: openvpn-client-certificates
       - name: ca
         secret:
-          defaultMode: 256
           items:
           - key: ca.crt
             path: ca.crt

--- a/api/pkg/resources/test/fixtures/deployment-bringyourown-1.10.0-kube-state-metrics.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-bringyourown-1.10.0-kube-state-metrics.yaml
@@ -81,7 +81,6 @@ spec:
       volumes:
       - name: kube-state-metrics-kubeconfig
         secret:
-          defaultMode: 256
           secretName: kube-state-metrics-kubeconfig
       - emptyDir: {}
         name: http-prober-bin

--- a/api/pkg/resources/test/fixtures/deployment-bringyourown-1.10.0-machine-controller-webhook.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-bringyourown-1.10.0-machine-controller-webhook.yaml
@@ -86,11 +86,9 @@ spec:
       volumes:
       - name: machinecontroller-kubeconfig
         secret:
-          defaultMode: 292
           secretName: machinecontroller-kubeconfig
       - name: machinecontroller-webhook-serving-cert
         secret:
-          defaultMode: 292
           secretName: machinecontroller-webhook-serving-cert
       - emptyDir: {}
         name: http-prober-bin

--- a/api/pkg/resources/test/fixtures/deployment-bringyourown-1.10.0-machine-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-bringyourown-1.10.0-machine-controller.yaml
@@ -77,7 +77,6 @@ spec:
       volumes:
       - name: machinecontroller-kubeconfig
         secret:
-          defaultMode: 292
           secretName: machinecontroller-kubeconfig
       - emptyDir: {}
         name: http-prober-bin

--- a/api/pkg/resources/test/fixtures/deployment-bringyourown-1.10.0-metrics-server.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-bringyourown-1.10.0-metrics-server.yaml
@@ -164,15 +164,12 @@ spec:
       volumes:
       - name: metrics-server
         secret:
-          defaultMode: 292
           secretName: metrics-server
       - name: openvpn-client-certificates
         secret:
-          defaultMode: 256
           secretName: openvpn-client-certificates
       - name: kubeletdnatcontroller-kubeconfig
         secret:
-          defaultMode: 292
           secretName: kubeletdnatcontroller-kubeconfig
       - emptyDir: {}
         name: http-prober-bin

--- a/api/pkg/resources/test/fixtures/deployment-bringyourown-1.10.0-openvpn-server.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-bringyourown-1.10.0-openvpn-server.yaml
@@ -178,17 +178,14 @@ spec:
       volumes:
       - name: ca
         secret:
-          defaultMode: 256
           items:
           - key: ca.crt
             path: ca.crt
           secretName: openvpn-ca
       - name: openvpn-server-certificates
         secret:
-          defaultMode: 256
           secretName: openvpn-server-certificates
       - configMap:
-          defaultMode: 256
           name: openvpn-client-configs
         name: openvpn-client-configs
 status: {}

--- a/api/pkg/resources/test/fixtures/deployment-bringyourown-1.10.0-scheduler.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-bringyourown-1.10.0-scheduler.yaml
@@ -172,18 +172,15 @@ spec:
       volumes:
       - name: openvpn-client-certificates
         secret:
-          defaultMode: 256
           secretName: openvpn-client-certificates
       - name: ca
         secret:
-          defaultMode: 256
           items:
           - key: ca.crt
             path: ca.crt
           secretName: ca
       - name: scheduler-kubeconfig
         secret:
-          defaultMode: 256
           secretName: scheduler-kubeconfig
       - emptyDir: {}
         name: http-prober-bin

--- a/api/pkg/resources/test/fixtures/deployment-bringyourown-1.10.0-usercluster-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-bringyourown-1.10.0-usercluster-controller.yaml
@@ -94,18 +94,15 @@ spec:
       volumes:
       - name: internal-admin-kubeconfig
         secret:
-          defaultMode: 292
           secretName: internal-admin-kubeconfig
       - name: ca
         secret:
-          defaultMode: 292
           items:
           - key: ca.crt
             path: ca.crt
           secretName: ca
       - name: openvpn-ca
         secret:
-          defaultMode: 292
           secretName: openvpn-ca
       - emptyDir: {}
         name: http-prober-bin

--- a/api/pkg/resources/test/fixtures/deployment-bringyourown-1.10.6-apiserver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-bringyourown-1.10.6-apiserver.yaml
@@ -309,53 +309,41 @@ spec:
       volumes:
       - name: apiserver-tls
         secret:
-          defaultMode: 256
           secretName: apiserver-tls
       - name: tokens
         secret:
-          defaultMode: 256
           secretName: tokens
       - name: openvpn-client-certificates
         secret:
-          defaultMode: 256
           secretName: openvpn-client-certificates
       - name: kubelet-client-certificates
         secret:
-          defaultMode: 256
           secretName: kubelet-client-certificates
       - name: ca
         secret:
-          defaultMode: 256
           items:
           - key: ca.crt
             path: ca.crt
           secretName: ca
       - name: service-account-key
         secret:
-          defaultMode: 256
           secretName: service-account-key
       - configMap:
-          defaultMode: 420
           name: cloud-config
         name: cloud-config
       - name: apiserver-etcd-client-certificate
         secret:
-          defaultMode: 256
           secretName: apiserver-etcd-client-certificate
       - name: apiserver-proxy-client-certificate
         secret:
-          defaultMode: 256
           secretName: apiserver-proxy-client-certificate
       - name: front-proxy-ca
         secret:
-          defaultMode: 256
           secretName: front-proxy-ca
       - name: kubeletdnatcontroller-kubeconfig
         secret:
-          defaultMode: 292
           secretName: kubeletdnatcontroller-kubeconfig
       - name: dex-ca
         secret:
-          defaultMode: 256
           secretName: dex-ca
 status: {}

--- a/api/pkg/resources/test/fixtures/deployment-bringyourown-1.10.6-controller-manager.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-bringyourown-1.10.6-controller-manager.yaml
@@ -180,23 +180,18 @@ spec:
       volumes:
       - name: ca
         secret:
-          defaultMode: 256
           secretName: ca
       - name: service-account-key
         secret:
-          defaultMode: 256
           secretName: service-account-key
       - configMap:
-          defaultMode: 420
           name: cloud-config
         name: cloud-config
       - name: openvpn-client-certificates
         secret:
-          defaultMode: 256
           secretName: openvpn-client-certificates
       - name: controllermanager-kubeconfig
         secret:
-          defaultMode: 256
           secretName: controllermanager-kubeconfig
       - emptyDir: {}
         name: http-prober-bin

--- a/api/pkg/resources/test/fixtures/deployment-bringyourown-1.10.6-dns-resolver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-bringyourown-1.10.6-dns-resolver.yaml
@@ -124,16 +124,13 @@ spec:
       - name: dockercfg
       volumes:
       - configMap:
-          defaultMode: 256
           name: dns-resolver
         name: dns-resolver
       - name: openvpn-client-certificates
         secret:
-          defaultMode: 256
           secretName: openvpn-client-certificates
       - name: ca
         secret:
-          defaultMode: 256
           items:
           - key: ca.crt
             path: ca.crt

--- a/api/pkg/resources/test/fixtures/deployment-bringyourown-1.10.6-kube-state-metrics.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-bringyourown-1.10.6-kube-state-metrics.yaml
@@ -81,7 +81,6 @@ spec:
       volumes:
       - name: kube-state-metrics-kubeconfig
         secret:
-          defaultMode: 256
           secretName: kube-state-metrics-kubeconfig
       - emptyDir: {}
         name: http-prober-bin

--- a/api/pkg/resources/test/fixtures/deployment-bringyourown-1.10.6-machine-controller-webhook.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-bringyourown-1.10.6-machine-controller-webhook.yaml
@@ -86,11 +86,9 @@ spec:
       volumes:
       - name: machinecontroller-kubeconfig
         secret:
-          defaultMode: 292
           secretName: machinecontroller-kubeconfig
       - name: machinecontroller-webhook-serving-cert
         secret:
-          defaultMode: 292
           secretName: machinecontroller-webhook-serving-cert
       - emptyDir: {}
         name: http-prober-bin

--- a/api/pkg/resources/test/fixtures/deployment-bringyourown-1.10.6-machine-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-bringyourown-1.10.6-machine-controller.yaml
@@ -77,7 +77,6 @@ spec:
       volumes:
       - name: machinecontroller-kubeconfig
         secret:
-          defaultMode: 292
           secretName: machinecontroller-kubeconfig
       - emptyDir: {}
         name: http-prober-bin

--- a/api/pkg/resources/test/fixtures/deployment-bringyourown-1.10.6-metrics-server.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-bringyourown-1.10.6-metrics-server.yaml
@@ -164,15 +164,12 @@ spec:
       volumes:
       - name: metrics-server
         secret:
-          defaultMode: 292
           secretName: metrics-server
       - name: openvpn-client-certificates
         secret:
-          defaultMode: 256
           secretName: openvpn-client-certificates
       - name: kubeletdnatcontroller-kubeconfig
         secret:
-          defaultMode: 292
           secretName: kubeletdnatcontroller-kubeconfig
       - emptyDir: {}
         name: http-prober-bin

--- a/api/pkg/resources/test/fixtures/deployment-bringyourown-1.10.6-openvpn-server.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-bringyourown-1.10.6-openvpn-server.yaml
@@ -178,17 +178,14 @@ spec:
       volumes:
       - name: ca
         secret:
-          defaultMode: 256
           items:
           - key: ca.crt
             path: ca.crt
           secretName: openvpn-ca
       - name: openvpn-server-certificates
         secret:
-          defaultMode: 256
           secretName: openvpn-server-certificates
       - configMap:
-          defaultMode: 256
           name: openvpn-client-configs
         name: openvpn-client-configs
 status: {}

--- a/api/pkg/resources/test/fixtures/deployment-bringyourown-1.10.6-scheduler.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-bringyourown-1.10.6-scheduler.yaml
@@ -172,18 +172,15 @@ spec:
       volumes:
       - name: openvpn-client-certificates
         secret:
-          defaultMode: 256
           secretName: openvpn-client-certificates
       - name: ca
         secret:
-          defaultMode: 256
           items:
           - key: ca.crt
             path: ca.crt
           secretName: ca
       - name: scheduler-kubeconfig
         secret:
-          defaultMode: 256
           secretName: scheduler-kubeconfig
       - emptyDir: {}
         name: http-prober-bin

--- a/api/pkg/resources/test/fixtures/deployment-bringyourown-1.10.6-usercluster-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-bringyourown-1.10.6-usercluster-controller.yaml
@@ -94,18 +94,15 @@ spec:
       volumes:
       - name: internal-admin-kubeconfig
         secret:
-          defaultMode: 292
           secretName: internal-admin-kubeconfig
       - name: ca
         secret:
-          defaultMode: 292
           items:
           - key: ca.crt
             path: ca.crt
           secretName: ca
       - name: openvpn-ca
         secret:
-          defaultMode: 292
           secretName: openvpn-ca
       - emptyDir: {}
         name: http-prober-bin

--- a/api/pkg/resources/test/fixtures/deployment-bringyourown-1.11.0-apiserver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-bringyourown-1.11.0-apiserver.yaml
@@ -307,53 +307,41 @@ spec:
       volumes:
       - name: apiserver-tls
         secret:
-          defaultMode: 256
           secretName: apiserver-tls
       - name: tokens
         secret:
-          defaultMode: 256
           secretName: tokens
       - name: openvpn-client-certificates
         secret:
-          defaultMode: 256
           secretName: openvpn-client-certificates
       - name: kubelet-client-certificates
         secret:
-          defaultMode: 256
           secretName: kubelet-client-certificates
       - name: ca
         secret:
-          defaultMode: 256
           items:
           - key: ca.crt
             path: ca.crt
           secretName: ca
       - name: service-account-key
         secret:
-          defaultMode: 256
           secretName: service-account-key
       - configMap:
-          defaultMode: 420
           name: cloud-config
         name: cloud-config
       - name: apiserver-etcd-client-certificate
         secret:
-          defaultMode: 256
           secretName: apiserver-etcd-client-certificate
       - name: apiserver-proxy-client-certificate
         secret:
-          defaultMode: 256
           secretName: apiserver-proxy-client-certificate
       - name: front-proxy-ca
         secret:
-          defaultMode: 256
           secretName: front-proxy-ca
       - name: kubeletdnatcontroller-kubeconfig
         secret:
-          defaultMode: 292
           secretName: kubeletdnatcontroller-kubeconfig
       - name: dex-ca
         secret:
-          defaultMode: 256
           secretName: dex-ca
 status: {}

--- a/api/pkg/resources/test/fixtures/deployment-bringyourown-1.11.0-controller-manager.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-bringyourown-1.11.0-controller-manager.yaml
@@ -180,23 +180,18 @@ spec:
       volumes:
       - name: ca
         secret:
-          defaultMode: 256
           secretName: ca
       - name: service-account-key
         secret:
-          defaultMode: 256
           secretName: service-account-key
       - configMap:
-          defaultMode: 420
           name: cloud-config
         name: cloud-config
       - name: openvpn-client-certificates
         secret:
-          defaultMode: 256
           secretName: openvpn-client-certificates
       - name: controllermanager-kubeconfig
         secret:
-          defaultMode: 256
           secretName: controllermanager-kubeconfig
       - emptyDir: {}
         name: http-prober-bin

--- a/api/pkg/resources/test/fixtures/deployment-bringyourown-1.11.0-dns-resolver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-bringyourown-1.11.0-dns-resolver.yaml
@@ -124,16 +124,13 @@ spec:
       - name: dockercfg
       volumes:
       - configMap:
-          defaultMode: 256
           name: dns-resolver
         name: dns-resolver
       - name: openvpn-client-certificates
         secret:
-          defaultMode: 256
           secretName: openvpn-client-certificates
       - name: ca
         secret:
-          defaultMode: 256
           items:
           - key: ca.crt
             path: ca.crt

--- a/api/pkg/resources/test/fixtures/deployment-bringyourown-1.11.0-kube-state-metrics.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-bringyourown-1.11.0-kube-state-metrics.yaml
@@ -81,7 +81,6 @@ spec:
       volumes:
       - name: kube-state-metrics-kubeconfig
         secret:
-          defaultMode: 256
           secretName: kube-state-metrics-kubeconfig
       - emptyDir: {}
         name: http-prober-bin

--- a/api/pkg/resources/test/fixtures/deployment-bringyourown-1.11.0-machine-controller-webhook.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-bringyourown-1.11.0-machine-controller-webhook.yaml
@@ -86,11 +86,9 @@ spec:
       volumes:
       - name: machinecontroller-kubeconfig
         secret:
-          defaultMode: 292
           secretName: machinecontroller-kubeconfig
       - name: machinecontroller-webhook-serving-cert
         secret:
-          defaultMode: 292
           secretName: machinecontroller-webhook-serving-cert
       - emptyDir: {}
         name: http-prober-bin

--- a/api/pkg/resources/test/fixtures/deployment-bringyourown-1.11.0-machine-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-bringyourown-1.11.0-machine-controller.yaml
@@ -77,7 +77,6 @@ spec:
       volumes:
       - name: machinecontroller-kubeconfig
         secret:
-          defaultMode: 292
           secretName: machinecontroller-kubeconfig
       - emptyDir: {}
         name: http-prober-bin

--- a/api/pkg/resources/test/fixtures/deployment-bringyourown-1.11.0-metrics-server.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-bringyourown-1.11.0-metrics-server.yaml
@@ -164,15 +164,12 @@ spec:
       volumes:
       - name: metrics-server
         secret:
-          defaultMode: 292
           secretName: metrics-server
       - name: openvpn-client-certificates
         secret:
-          defaultMode: 256
           secretName: openvpn-client-certificates
       - name: kubeletdnatcontroller-kubeconfig
         secret:
-          defaultMode: 292
           secretName: kubeletdnatcontroller-kubeconfig
       - emptyDir: {}
         name: http-prober-bin

--- a/api/pkg/resources/test/fixtures/deployment-bringyourown-1.11.0-openvpn-server.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-bringyourown-1.11.0-openvpn-server.yaml
@@ -178,17 +178,14 @@ spec:
       volumes:
       - name: ca
         secret:
-          defaultMode: 256
           items:
           - key: ca.crt
             path: ca.crt
           secretName: openvpn-ca
       - name: openvpn-server-certificates
         secret:
-          defaultMode: 256
           secretName: openvpn-server-certificates
       - configMap:
-          defaultMode: 256
           name: openvpn-client-configs
         name: openvpn-client-configs
 status: {}

--- a/api/pkg/resources/test/fixtures/deployment-bringyourown-1.11.0-scheduler.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-bringyourown-1.11.0-scheduler.yaml
@@ -172,18 +172,15 @@ spec:
       volumes:
       - name: openvpn-client-certificates
         secret:
-          defaultMode: 256
           secretName: openvpn-client-certificates
       - name: ca
         secret:
-          defaultMode: 256
           items:
           - key: ca.crt
             path: ca.crt
           secretName: ca
       - name: scheduler-kubeconfig
         secret:
-          defaultMode: 256
           secretName: scheduler-kubeconfig
       - emptyDir: {}
         name: http-prober-bin

--- a/api/pkg/resources/test/fixtures/deployment-bringyourown-1.11.0-usercluster-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-bringyourown-1.11.0-usercluster-controller.yaml
@@ -94,18 +94,15 @@ spec:
       volumes:
       - name: internal-admin-kubeconfig
         secret:
-          defaultMode: 292
           secretName: internal-admin-kubeconfig
       - name: ca
         secret:
-          defaultMode: 292
           items:
           - key: ca.crt
             path: ca.crt
           secretName: ca
       - name: openvpn-ca
         secret:
-          defaultMode: 292
           secretName: openvpn-ca
       - emptyDir: {}
         name: http-prober-bin

--- a/api/pkg/resources/test/fixtures/deployment-bringyourown-1.11.1-apiserver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-bringyourown-1.11.1-apiserver.yaml
@@ -307,53 +307,41 @@ spec:
       volumes:
       - name: apiserver-tls
         secret:
-          defaultMode: 256
           secretName: apiserver-tls
       - name: tokens
         secret:
-          defaultMode: 256
           secretName: tokens
       - name: openvpn-client-certificates
         secret:
-          defaultMode: 256
           secretName: openvpn-client-certificates
       - name: kubelet-client-certificates
         secret:
-          defaultMode: 256
           secretName: kubelet-client-certificates
       - name: ca
         secret:
-          defaultMode: 256
           items:
           - key: ca.crt
             path: ca.crt
           secretName: ca
       - name: service-account-key
         secret:
-          defaultMode: 256
           secretName: service-account-key
       - configMap:
-          defaultMode: 420
           name: cloud-config
         name: cloud-config
       - name: apiserver-etcd-client-certificate
         secret:
-          defaultMode: 256
           secretName: apiserver-etcd-client-certificate
       - name: apiserver-proxy-client-certificate
         secret:
-          defaultMode: 256
           secretName: apiserver-proxy-client-certificate
       - name: front-proxy-ca
         secret:
-          defaultMode: 256
           secretName: front-proxy-ca
       - name: kubeletdnatcontroller-kubeconfig
         secret:
-          defaultMode: 292
           secretName: kubeletdnatcontroller-kubeconfig
       - name: dex-ca
         secret:
-          defaultMode: 256
           secretName: dex-ca
 status: {}

--- a/api/pkg/resources/test/fixtures/deployment-bringyourown-1.11.1-controller-manager.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-bringyourown-1.11.1-controller-manager.yaml
@@ -180,23 +180,18 @@ spec:
       volumes:
       - name: ca
         secret:
-          defaultMode: 256
           secretName: ca
       - name: service-account-key
         secret:
-          defaultMode: 256
           secretName: service-account-key
       - configMap:
-          defaultMode: 420
           name: cloud-config
         name: cloud-config
       - name: openvpn-client-certificates
         secret:
-          defaultMode: 256
           secretName: openvpn-client-certificates
       - name: controllermanager-kubeconfig
         secret:
-          defaultMode: 256
           secretName: controllermanager-kubeconfig
       - emptyDir: {}
         name: http-prober-bin

--- a/api/pkg/resources/test/fixtures/deployment-bringyourown-1.11.1-dns-resolver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-bringyourown-1.11.1-dns-resolver.yaml
@@ -124,16 +124,13 @@ spec:
       - name: dockercfg
       volumes:
       - configMap:
-          defaultMode: 256
           name: dns-resolver
         name: dns-resolver
       - name: openvpn-client-certificates
         secret:
-          defaultMode: 256
           secretName: openvpn-client-certificates
       - name: ca
         secret:
-          defaultMode: 256
           items:
           - key: ca.crt
             path: ca.crt

--- a/api/pkg/resources/test/fixtures/deployment-bringyourown-1.11.1-kube-state-metrics.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-bringyourown-1.11.1-kube-state-metrics.yaml
@@ -81,7 +81,6 @@ spec:
       volumes:
       - name: kube-state-metrics-kubeconfig
         secret:
-          defaultMode: 256
           secretName: kube-state-metrics-kubeconfig
       - emptyDir: {}
         name: http-prober-bin

--- a/api/pkg/resources/test/fixtures/deployment-bringyourown-1.11.1-machine-controller-webhook.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-bringyourown-1.11.1-machine-controller-webhook.yaml
@@ -86,11 +86,9 @@ spec:
       volumes:
       - name: machinecontroller-kubeconfig
         secret:
-          defaultMode: 292
           secretName: machinecontroller-kubeconfig
       - name: machinecontroller-webhook-serving-cert
         secret:
-          defaultMode: 292
           secretName: machinecontroller-webhook-serving-cert
       - emptyDir: {}
         name: http-prober-bin

--- a/api/pkg/resources/test/fixtures/deployment-bringyourown-1.11.1-machine-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-bringyourown-1.11.1-machine-controller.yaml
@@ -77,7 +77,6 @@ spec:
       volumes:
       - name: machinecontroller-kubeconfig
         secret:
-          defaultMode: 292
           secretName: machinecontroller-kubeconfig
       - emptyDir: {}
         name: http-prober-bin

--- a/api/pkg/resources/test/fixtures/deployment-bringyourown-1.11.1-metrics-server.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-bringyourown-1.11.1-metrics-server.yaml
@@ -164,15 +164,12 @@ spec:
       volumes:
       - name: metrics-server
         secret:
-          defaultMode: 292
           secretName: metrics-server
       - name: openvpn-client-certificates
         secret:
-          defaultMode: 256
           secretName: openvpn-client-certificates
       - name: kubeletdnatcontroller-kubeconfig
         secret:
-          defaultMode: 292
           secretName: kubeletdnatcontroller-kubeconfig
       - emptyDir: {}
         name: http-prober-bin

--- a/api/pkg/resources/test/fixtures/deployment-bringyourown-1.11.1-openvpn-server.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-bringyourown-1.11.1-openvpn-server.yaml
@@ -178,17 +178,14 @@ spec:
       volumes:
       - name: ca
         secret:
-          defaultMode: 256
           items:
           - key: ca.crt
             path: ca.crt
           secretName: openvpn-ca
       - name: openvpn-server-certificates
         secret:
-          defaultMode: 256
           secretName: openvpn-server-certificates
       - configMap:
-          defaultMode: 256
           name: openvpn-client-configs
         name: openvpn-client-configs
 status: {}

--- a/api/pkg/resources/test/fixtures/deployment-bringyourown-1.11.1-scheduler.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-bringyourown-1.11.1-scheduler.yaml
@@ -172,18 +172,15 @@ spec:
       volumes:
       - name: openvpn-client-certificates
         secret:
-          defaultMode: 256
           secretName: openvpn-client-certificates
       - name: ca
         secret:
-          defaultMode: 256
           items:
           - key: ca.crt
             path: ca.crt
           secretName: ca
       - name: scheduler-kubeconfig
         secret:
-          defaultMode: 256
           secretName: scheduler-kubeconfig
       - emptyDir: {}
         name: http-prober-bin

--- a/api/pkg/resources/test/fixtures/deployment-bringyourown-1.11.1-usercluster-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-bringyourown-1.11.1-usercluster-controller.yaml
@@ -94,18 +94,15 @@ spec:
       volumes:
       - name: internal-admin-kubeconfig
         secret:
-          defaultMode: 292
           secretName: internal-admin-kubeconfig
       - name: ca
         secret:
-          defaultMode: 292
           items:
           - key: ca.crt
             path: ca.crt
           secretName: ca
       - name: openvpn-ca
         secret:
-          defaultMode: 292
           secretName: openvpn-ca
       - emptyDir: {}
         name: http-prober-bin

--- a/api/pkg/resources/test/fixtures/deployment-bringyourown-1.12.0-apiserver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-bringyourown-1.12.0-apiserver.yaml
@@ -307,53 +307,41 @@ spec:
       volumes:
       - name: apiserver-tls
         secret:
-          defaultMode: 256
           secretName: apiserver-tls
       - name: tokens
         secret:
-          defaultMode: 256
           secretName: tokens
       - name: openvpn-client-certificates
         secret:
-          defaultMode: 256
           secretName: openvpn-client-certificates
       - name: kubelet-client-certificates
         secret:
-          defaultMode: 256
           secretName: kubelet-client-certificates
       - name: ca
         secret:
-          defaultMode: 256
           items:
           - key: ca.crt
             path: ca.crt
           secretName: ca
       - name: service-account-key
         secret:
-          defaultMode: 256
           secretName: service-account-key
       - configMap:
-          defaultMode: 420
           name: cloud-config
         name: cloud-config
       - name: apiserver-etcd-client-certificate
         secret:
-          defaultMode: 256
           secretName: apiserver-etcd-client-certificate
       - name: apiserver-proxy-client-certificate
         secret:
-          defaultMode: 256
           secretName: apiserver-proxy-client-certificate
       - name: front-proxy-ca
         secret:
-          defaultMode: 256
           secretName: front-proxy-ca
       - name: kubeletdnatcontroller-kubeconfig
         secret:
-          defaultMode: 292
           secretName: kubeletdnatcontroller-kubeconfig
       - name: dex-ca
         secret:
-          defaultMode: 256
           secretName: dex-ca
 status: {}

--- a/api/pkg/resources/test/fixtures/deployment-bringyourown-1.12.0-controller-manager.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-bringyourown-1.12.0-controller-manager.yaml
@@ -180,23 +180,18 @@ spec:
       volumes:
       - name: ca
         secret:
-          defaultMode: 256
           secretName: ca
       - name: service-account-key
         secret:
-          defaultMode: 256
           secretName: service-account-key
       - configMap:
-          defaultMode: 420
           name: cloud-config
         name: cloud-config
       - name: openvpn-client-certificates
         secret:
-          defaultMode: 256
           secretName: openvpn-client-certificates
       - name: controllermanager-kubeconfig
         secret:
-          defaultMode: 256
           secretName: controllermanager-kubeconfig
       - emptyDir: {}
         name: http-prober-bin

--- a/api/pkg/resources/test/fixtures/deployment-bringyourown-1.12.0-dns-resolver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-bringyourown-1.12.0-dns-resolver.yaml
@@ -124,16 +124,13 @@ spec:
       - name: dockercfg
       volumes:
       - configMap:
-          defaultMode: 256
           name: dns-resolver
         name: dns-resolver
       - name: openvpn-client-certificates
         secret:
-          defaultMode: 256
           secretName: openvpn-client-certificates
       - name: ca
         secret:
-          defaultMode: 256
           items:
           - key: ca.crt
             path: ca.crt

--- a/api/pkg/resources/test/fixtures/deployment-bringyourown-1.12.0-kube-state-metrics.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-bringyourown-1.12.0-kube-state-metrics.yaml
@@ -81,7 +81,6 @@ spec:
       volumes:
       - name: kube-state-metrics-kubeconfig
         secret:
-          defaultMode: 256
           secretName: kube-state-metrics-kubeconfig
       - emptyDir: {}
         name: http-prober-bin

--- a/api/pkg/resources/test/fixtures/deployment-bringyourown-1.12.0-machine-controller-webhook.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-bringyourown-1.12.0-machine-controller-webhook.yaml
@@ -86,11 +86,9 @@ spec:
       volumes:
       - name: machinecontroller-kubeconfig
         secret:
-          defaultMode: 292
           secretName: machinecontroller-kubeconfig
       - name: machinecontroller-webhook-serving-cert
         secret:
-          defaultMode: 292
           secretName: machinecontroller-webhook-serving-cert
       - emptyDir: {}
         name: http-prober-bin

--- a/api/pkg/resources/test/fixtures/deployment-bringyourown-1.12.0-machine-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-bringyourown-1.12.0-machine-controller.yaml
@@ -77,7 +77,6 @@ spec:
       volumes:
       - name: machinecontroller-kubeconfig
         secret:
-          defaultMode: 292
           secretName: machinecontroller-kubeconfig
       - emptyDir: {}
         name: http-prober-bin

--- a/api/pkg/resources/test/fixtures/deployment-bringyourown-1.12.0-metrics-server.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-bringyourown-1.12.0-metrics-server.yaml
@@ -164,15 +164,12 @@ spec:
       volumes:
       - name: metrics-server
         secret:
-          defaultMode: 292
           secretName: metrics-server
       - name: openvpn-client-certificates
         secret:
-          defaultMode: 256
           secretName: openvpn-client-certificates
       - name: kubeletdnatcontroller-kubeconfig
         secret:
-          defaultMode: 292
           secretName: kubeletdnatcontroller-kubeconfig
       - emptyDir: {}
         name: http-prober-bin

--- a/api/pkg/resources/test/fixtures/deployment-bringyourown-1.12.0-openvpn-server.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-bringyourown-1.12.0-openvpn-server.yaml
@@ -178,17 +178,14 @@ spec:
       volumes:
       - name: ca
         secret:
-          defaultMode: 256
           items:
           - key: ca.crt
             path: ca.crt
           secretName: openvpn-ca
       - name: openvpn-server-certificates
         secret:
-          defaultMode: 256
           secretName: openvpn-server-certificates
       - configMap:
-          defaultMode: 256
           name: openvpn-client-configs
         name: openvpn-client-configs
 status: {}

--- a/api/pkg/resources/test/fixtures/deployment-bringyourown-1.12.0-scheduler.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-bringyourown-1.12.0-scheduler.yaml
@@ -172,18 +172,15 @@ spec:
       volumes:
       - name: openvpn-client-certificates
         secret:
-          defaultMode: 256
           secretName: openvpn-client-certificates
       - name: ca
         secret:
-          defaultMode: 256
           items:
           - key: ca.crt
             path: ca.crt
           secretName: ca
       - name: scheduler-kubeconfig
         secret:
-          defaultMode: 256
           secretName: scheduler-kubeconfig
       - emptyDir: {}
         name: http-prober-bin

--- a/api/pkg/resources/test/fixtures/deployment-bringyourown-1.12.0-usercluster-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-bringyourown-1.12.0-usercluster-controller.yaml
@@ -94,18 +94,15 @@ spec:
       volumes:
       - name: internal-admin-kubeconfig
         secret:
-          defaultMode: 292
           secretName: internal-admin-kubeconfig
       - name: ca
         secret:
-          defaultMode: 292
           items:
           - key: ca.crt
             path: ca.crt
           secretName: ca
       - name: openvpn-ca
         secret:
-          defaultMode: 292
           secretName: openvpn-ca
       - emptyDir: {}
         name: http-prober-bin

--- a/api/pkg/resources/test/fixtures/deployment-bringyourown-1.13.0-apiserver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-bringyourown-1.13.0-apiserver.yaml
@@ -307,53 +307,41 @@ spec:
       volumes:
       - name: apiserver-tls
         secret:
-          defaultMode: 256
           secretName: apiserver-tls
       - name: tokens
         secret:
-          defaultMode: 256
           secretName: tokens
       - name: openvpn-client-certificates
         secret:
-          defaultMode: 256
           secretName: openvpn-client-certificates
       - name: kubelet-client-certificates
         secret:
-          defaultMode: 256
           secretName: kubelet-client-certificates
       - name: ca
         secret:
-          defaultMode: 256
           items:
           - key: ca.crt
             path: ca.crt
           secretName: ca
       - name: service-account-key
         secret:
-          defaultMode: 256
           secretName: service-account-key
       - configMap:
-          defaultMode: 420
           name: cloud-config
         name: cloud-config
       - name: apiserver-etcd-client-certificate
         secret:
-          defaultMode: 256
           secretName: apiserver-etcd-client-certificate
       - name: apiserver-proxy-client-certificate
         secret:
-          defaultMode: 256
           secretName: apiserver-proxy-client-certificate
       - name: front-proxy-ca
         secret:
-          defaultMode: 256
           secretName: front-proxy-ca
       - name: kubeletdnatcontroller-kubeconfig
         secret:
-          defaultMode: 292
           secretName: kubeletdnatcontroller-kubeconfig
       - name: dex-ca
         secret:
-          defaultMode: 256
           secretName: dex-ca
 status: {}

--- a/api/pkg/resources/test/fixtures/deployment-bringyourown-1.13.0-controller-manager.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-bringyourown-1.13.0-controller-manager.yaml
@@ -180,23 +180,18 @@ spec:
       volumes:
       - name: ca
         secret:
-          defaultMode: 256
           secretName: ca
       - name: service-account-key
         secret:
-          defaultMode: 256
           secretName: service-account-key
       - configMap:
-          defaultMode: 420
           name: cloud-config
         name: cloud-config
       - name: openvpn-client-certificates
         secret:
-          defaultMode: 256
           secretName: openvpn-client-certificates
       - name: controllermanager-kubeconfig
         secret:
-          defaultMode: 256
           secretName: controllermanager-kubeconfig
       - emptyDir: {}
         name: http-prober-bin

--- a/api/pkg/resources/test/fixtures/deployment-bringyourown-1.13.0-dns-resolver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-bringyourown-1.13.0-dns-resolver.yaml
@@ -124,16 +124,13 @@ spec:
       - name: dockercfg
       volumes:
       - configMap:
-          defaultMode: 256
           name: dns-resolver
         name: dns-resolver
       - name: openvpn-client-certificates
         secret:
-          defaultMode: 256
           secretName: openvpn-client-certificates
       - name: ca
         secret:
-          defaultMode: 256
           items:
           - key: ca.crt
             path: ca.crt

--- a/api/pkg/resources/test/fixtures/deployment-bringyourown-1.13.0-kube-state-metrics.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-bringyourown-1.13.0-kube-state-metrics.yaml
@@ -81,7 +81,6 @@ spec:
       volumes:
       - name: kube-state-metrics-kubeconfig
         secret:
-          defaultMode: 256
           secretName: kube-state-metrics-kubeconfig
       - emptyDir: {}
         name: http-prober-bin

--- a/api/pkg/resources/test/fixtures/deployment-bringyourown-1.13.0-machine-controller-webhook.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-bringyourown-1.13.0-machine-controller-webhook.yaml
@@ -86,11 +86,9 @@ spec:
       volumes:
       - name: machinecontroller-kubeconfig
         secret:
-          defaultMode: 292
           secretName: machinecontroller-kubeconfig
       - name: machinecontroller-webhook-serving-cert
         secret:
-          defaultMode: 292
           secretName: machinecontroller-webhook-serving-cert
       - emptyDir: {}
         name: http-prober-bin

--- a/api/pkg/resources/test/fixtures/deployment-bringyourown-1.13.0-machine-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-bringyourown-1.13.0-machine-controller.yaml
@@ -77,7 +77,6 @@ spec:
       volumes:
       - name: machinecontroller-kubeconfig
         secret:
-          defaultMode: 292
           secretName: machinecontroller-kubeconfig
       - emptyDir: {}
         name: http-prober-bin

--- a/api/pkg/resources/test/fixtures/deployment-bringyourown-1.13.0-metrics-server.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-bringyourown-1.13.0-metrics-server.yaml
@@ -164,15 +164,12 @@ spec:
       volumes:
       - name: metrics-server
         secret:
-          defaultMode: 292
           secretName: metrics-server
       - name: openvpn-client-certificates
         secret:
-          defaultMode: 256
           secretName: openvpn-client-certificates
       - name: kubeletdnatcontroller-kubeconfig
         secret:
-          defaultMode: 292
           secretName: kubeletdnatcontroller-kubeconfig
       - emptyDir: {}
         name: http-prober-bin

--- a/api/pkg/resources/test/fixtures/deployment-bringyourown-1.13.0-openvpn-server.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-bringyourown-1.13.0-openvpn-server.yaml
@@ -178,17 +178,14 @@ spec:
       volumes:
       - name: ca
         secret:
-          defaultMode: 256
           items:
           - key: ca.crt
             path: ca.crt
           secretName: openvpn-ca
       - name: openvpn-server-certificates
         secret:
-          defaultMode: 256
           secretName: openvpn-server-certificates
       - configMap:
-          defaultMode: 256
           name: openvpn-client-configs
         name: openvpn-client-configs
 status: {}

--- a/api/pkg/resources/test/fixtures/deployment-bringyourown-1.13.0-scheduler.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-bringyourown-1.13.0-scheduler.yaml
@@ -172,18 +172,15 @@ spec:
       volumes:
       - name: openvpn-client-certificates
         secret:
-          defaultMode: 256
           secretName: openvpn-client-certificates
       - name: ca
         secret:
-          defaultMode: 256
           items:
           - key: ca.crt
             path: ca.crt
           secretName: ca
       - name: scheduler-kubeconfig
         secret:
-          defaultMode: 256
           secretName: scheduler-kubeconfig
       - emptyDir: {}
         name: http-prober-bin

--- a/api/pkg/resources/test/fixtures/deployment-bringyourown-1.13.0-usercluster-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-bringyourown-1.13.0-usercluster-controller.yaml
@@ -94,18 +94,15 @@ spec:
       volumes:
       - name: internal-admin-kubeconfig
         secret:
-          defaultMode: 292
           secretName: internal-admin-kubeconfig
       - name: ca
         secret:
-          defaultMode: 292
           items:
           - key: ca.crt
             path: ca.crt
           secretName: ca
       - name: openvpn-ca
         secret:
-          defaultMode: 292
           secretName: openvpn-ca
       - emptyDir: {}
         name: http-prober-bin

--- a/api/pkg/resources/test/fixtures/deployment-digitalocean-1.10.0-apiserver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-digitalocean-1.10.0-apiserver.yaml
@@ -309,53 +309,41 @@ spec:
       volumes:
       - name: apiserver-tls
         secret:
-          defaultMode: 256
           secretName: apiserver-tls
       - name: tokens
         secret:
-          defaultMode: 256
           secretName: tokens
       - name: openvpn-client-certificates
         secret:
-          defaultMode: 256
           secretName: openvpn-client-certificates
       - name: kubelet-client-certificates
         secret:
-          defaultMode: 256
           secretName: kubelet-client-certificates
       - name: ca
         secret:
-          defaultMode: 256
           items:
           - key: ca.crt
             path: ca.crt
           secretName: ca
       - name: service-account-key
         secret:
-          defaultMode: 256
           secretName: service-account-key
       - configMap:
-          defaultMode: 420
           name: cloud-config
         name: cloud-config
       - name: apiserver-etcd-client-certificate
         secret:
-          defaultMode: 256
           secretName: apiserver-etcd-client-certificate
       - name: apiserver-proxy-client-certificate
         secret:
-          defaultMode: 256
           secretName: apiserver-proxy-client-certificate
       - name: front-proxy-ca
         secret:
-          defaultMode: 256
           secretName: front-proxy-ca
       - name: kubeletdnatcontroller-kubeconfig
         secret:
-          defaultMode: 292
           secretName: kubeletdnatcontroller-kubeconfig
       - name: dex-ca
         secret:
-          defaultMode: 256
           secretName: dex-ca
 status: {}

--- a/api/pkg/resources/test/fixtures/deployment-digitalocean-1.10.0-controller-manager.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-digitalocean-1.10.0-controller-manager.yaml
@@ -180,23 +180,18 @@ spec:
       volumes:
       - name: ca
         secret:
-          defaultMode: 256
           secretName: ca
       - name: service-account-key
         secret:
-          defaultMode: 256
           secretName: service-account-key
       - configMap:
-          defaultMode: 420
           name: cloud-config
         name: cloud-config
       - name: openvpn-client-certificates
         secret:
-          defaultMode: 256
           secretName: openvpn-client-certificates
       - name: controllermanager-kubeconfig
         secret:
-          defaultMode: 256
           secretName: controllermanager-kubeconfig
       - emptyDir: {}
         name: http-prober-bin

--- a/api/pkg/resources/test/fixtures/deployment-digitalocean-1.10.0-dns-resolver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-digitalocean-1.10.0-dns-resolver.yaml
@@ -124,16 +124,13 @@ spec:
       - name: dockercfg
       volumes:
       - configMap:
-          defaultMode: 256
           name: dns-resolver
         name: dns-resolver
       - name: openvpn-client-certificates
         secret:
-          defaultMode: 256
           secretName: openvpn-client-certificates
       - name: ca
         secret:
-          defaultMode: 256
           items:
           - key: ca.crt
             path: ca.crt

--- a/api/pkg/resources/test/fixtures/deployment-digitalocean-1.10.0-kube-state-metrics.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-digitalocean-1.10.0-kube-state-metrics.yaml
@@ -81,7 +81,6 @@ spec:
       volumes:
       - name: kube-state-metrics-kubeconfig
         secret:
-          defaultMode: 256
           secretName: kube-state-metrics-kubeconfig
       - emptyDir: {}
         name: http-prober-bin

--- a/api/pkg/resources/test/fixtures/deployment-digitalocean-1.10.0-machine-controller-webhook.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-digitalocean-1.10.0-machine-controller-webhook.yaml
@@ -89,11 +89,9 @@ spec:
       volumes:
       - name: machinecontroller-kubeconfig
         secret:
-          defaultMode: 292
           secretName: machinecontroller-kubeconfig
       - name: machinecontroller-webhook-serving-cert
         secret:
-          defaultMode: 292
           secretName: machinecontroller-webhook-serving-cert
       - emptyDir: {}
         name: http-prober-bin

--- a/api/pkg/resources/test/fixtures/deployment-digitalocean-1.10.0-machine-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-digitalocean-1.10.0-machine-controller.yaml
@@ -80,7 +80,6 @@ spec:
       volumes:
       - name: machinecontroller-kubeconfig
         secret:
-          defaultMode: 292
           secretName: machinecontroller-kubeconfig
       - emptyDir: {}
         name: http-prober-bin

--- a/api/pkg/resources/test/fixtures/deployment-digitalocean-1.10.0-metrics-server.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-digitalocean-1.10.0-metrics-server.yaml
@@ -164,15 +164,12 @@ spec:
       volumes:
       - name: metrics-server
         secret:
-          defaultMode: 292
           secretName: metrics-server
       - name: openvpn-client-certificates
         secret:
-          defaultMode: 256
           secretName: openvpn-client-certificates
       - name: kubeletdnatcontroller-kubeconfig
         secret:
-          defaultMode: 292
           secretName: kubeletdnatcontroller-kubeconfig
       - emptyDir: {}
         name: http-prober-bin

--- a/api/pkg/resources/test/fixtures/deployment-digitalocean-1.10.0-openvpn-server.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-digitalocean-1.10.0-openvpn-server.yaml
@@ -178,17 +178,14 @@ spec:
       volumes:
       - name: ca
         secret:
-          defaultMode: 256
           items:
           - key: ca.crt
             path: ca.crt
           secretName: openvpn-ca
       - name: openvpn-server-certificates
         secret:
-          defaultMode: 256
           secretName: openvpn-server-certificates
       - configMap:
-          defaultMode: 256
           name: openvpn-client-configs
         name: openvpn-client-configs
 status: {}

--- a/api/pkg/resources/test/fixtures/deployment-digitalocean-1.10.0-scheduler.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-digitalocean-1.10.0-scheduler.yaml
@@ -172,18 +172,15 @@ spec:
       volumes:
       - name: openvpn-client-certificates
         secret:
-          defaultMode: 256
           secretName: openvpn-client-certificates
       - name: ca
         secret:
-          defaultMode: 256
           items:
           - key: ca.crt
             path: ca.crt
           secretName: ca
       - name: scheduler-kubeconfig
         secret:
-          defaultMode: 256
           secretName: scheduler-kubeconfig
       - emptyDir: {}
         name: http-prober-bin

--- a/api/pkg/resources/test/fixtures/deployment-digitalocean-1.10.0-usercluster-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-digitalocean-1.10.0-usercluster-controller.yaml
@@ -94,18 +94,15 @@ spec:
       volumes:
       - name: internal-admin-kubeconfig
         secret:
-          defaultMode: 292
           secretName: internal-admin-kubeconfig
       - name: ca
         secret:
-          defaultMode: 292
           items:
           - key: ca.crt
             path: ca.crt
           secretName: ca
       - name: openvpn-ca
         secret:
-          defaultMode: 292
           secretName: openvpn-ca
       - emptyDir: {}
         name: http-prober-bin

--- a/api/pkg/resources/test/fixtures/deployment-digitalocean-1.10.6-apiserver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-digitalocean-1.10.6-apiserver.yaml
@@ -309,53 +309,41 @@ spec:
       volumes:
       - name: apiserver-tls
         secret:
-          defaultMode: 256
           secretName: apiserver-tls
       - name: tokens
         secret:
-          defaultMode: 256
           secretName: tokens
       - name: openvpn-client-certificates
         secret:
-          defaultMode: 256
           secretName: openvpn-client-certificates
       - name: kubelet-client-certificates
         secret:
-          defaultMode: 256
           secretName: kubelet-client-certificates
       - name: ca
         secret:
-          defaultMode: 256
           items:
           - key: ca.crt
             path: ca.crt
           secretName: ca
       - name: service-account-key
         secret:
-          defaultMode: 256
           secretName: service-account-key
       - configMap:
-          defaultMode: 420
           name: cloud-config
         name: cloud-config
       - name: apiserver-etcd-client-certificate
         secret:
-          defaultMode: 256
           secretName: apiserver-etcd-client-certificate
       - name: apiserver-proxy-client-certificate
         secret:
-          defaultMode: 256
           secretName: apiserver-proxy-client-certificate
       - name: front-proxy-ca
         secret:
-          defaultMode: 256
           secretName: front-proxy-ca
       - name: kubeletdnatcontroller-kubeconfig
         secret:
-          defaultMode: 292
           secretName: kubeletdnatcontroller-kubeconfig
       - name: dex-ca
         secret:
-          defaultMode: 256
           secretName: dex-ca
 status: {}

--- a/api/pkg/resources/test/fixtures/deployment-digitalocean-1.10.6-controller-manager.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-digitalocean-1.10.6-controller-manager.yaml
@@ -180,23 +180,18 @@ spec:
       volumes:
       - name: ca
         secret:
-          defaultMode: 256
           secretName: ca
       - name: service-account-key
         secret:
-          defaultMode: 256
           secretName: service-account-key
       - configMap:
-          defaultMode: 420
           name: cloud-config
         name: cloud-config
       - name: openvpn-client-certificates
         secret:
-          defaultMode: 256
           secretName: openvpn-client-certificates
       - name: controllermanager-kubeconfig
         secret:
-          defaultMode: 256
           secretName: controllermanager-kubeconfig
       - emptyDir: {}
         name: http-prober-bin

--- a/api/pkg/resources/test/fixtures/deployment-digitalocean-1.10.6-dns-resolver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-digitalocean-1.10.6-dns-resolver.yaml
@@ -124,16 +124,13 @@ spec:
       - name: dockercfg
       volumes:
       - configMap:
-          defaultMode: 256
           name: dns-resolver
         name: dns-resolver
       - name: openvpn-client-certificates
         secret:
-          defaultMode: 256
           secretName: openvpn-client-certificates
       - name: ca
         secret:
-          defaultMode: 256
           items:
           - key: ca.crt
             path: ca.crt

--- a/api/pkg/resources/test/fixtures/deployment-digitalocean-1.10.6-kube-state-metrics.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-digitalocean-1.10.6-kube-state-metrics.yaml
@@ -81,7 +81,6 @@ spec:
       volumes:
       - name: kube-state-metrics-kubeconfig
         secret:
-          defaultMode: 256
           secretName: kube-state-metrics-kubeconfig
       - emptyDir: {}
         name: http-prober-bin

--- a/api/pkg/resources/test/fixtures/deployment-digitalocean-1.10.6-machine-controller-webhook.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-digitalocean-1.10.6-machine-controller-webhook.yaml
@@ -89,11 +89,9 @@ spec:
       volumes:
       - name: machinecontroller-kubeconfig
         secret:
-          defaultMode: 292
           secretName: machinecontroller-kubeconfig
       - name: machinecontroller-webhook-serving-cert
         secret:
-          defaultMode: 292
           secretName: machinecontroller-webhook-serving-cert
       - emptyDir: {}
         name: http-prober-bin

--- a/api/pkg/resources/test/fixtures/deployment-digitalocean-1.10.6-machine-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-digitalocean-1.10.6-machine-controller.yaml
@@ -80,7 +80,6 @@ spec:
       volumes:
       - name: machinecontroller-kubeconfig
         secret:
-          defaultMode: 292
           secretName: machinecontroller-kubeconfig
       - emptyDir: {}
         name: http-prober-bin

--- a/api/pkg/resources/test/fixtures/deployment-digitalocean-1.10.6-metrics-server.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-digitalocean-1.10.6-metrics-server.yaml
@@ -164,15 +164,12 @@ spec:
       volumes:
       - name: metrics-server
         secret:
-          defaultMode: 292
           secretName: metrics-server
       - name: openvpn-client-certificates
         secret:
-          defaultMode: 256
           secretName: openvpn-client-certificates
       - name: kubeletdnatcontroller-kubeconfig
         secret:
-          defaultMode: 292
           secretName: kubeletdnatcontroller-kubeconfig
       - emptyDir: {}
         name: http-prober-bin

--- a/api/pkg/resources/test/fixtures/deployment-digitalocean-1.10.6-openvpn-server.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-digitalocean-1.10.6-openvpn-server.yaml
@@ -178,17 +178,14 @@ spec:
       volumes:
       - name: ca
         secret:
-          defaultMode: 256
           items:
           - key: ca.crt
             path: ca.crt
           secretName: openvpn-ca
       - name: openvpn-server-certificates
         secret:
-          defaultMode: 256
           secretName: openvpn-server-certificates
       - configMap:
-          defaultMode: 256
           name: openvpn-client-configs
         name: openvpn-client-configs
 status: {}

--- a/api/pkg/resources/test/fixtures/deployment-digitalocean-1.10.6-scheduler.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-digitalocean-1.10.6-scheduler.yaml
@@ -172,18 +172,15 @@ spec:
       volumes:
       - name: openvpn-client-certificates
         secret:
-          defaultMode: 256
           secretName: openvpn-client-certificates
       - name: ca
         secret:
-          defaultMode: 256
           items:
           - key: ca.crt
             path: ca.crt
           secretName: ca
       - name: scheduler-kubeconfig
         secret:
-          defaultMode: 256
           secretName: scheduler-kubeconfig
       - emptyDir: {}
         name: http-prober-bin

--- a/api/pkg/resources/test/fixtures/deployment-digitalocean-1.10.6-usercluster-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-digitalocean-1.10.6-usercluster-controller.yaml
@@ -94,18 +94,15 @@ spec:
       volumes:
       - name: internal-admin-kubeconfig
         secret:
-          defaultMode: 292
           secretName: internal-admin-kubeconfig
       - name: ca
         secret:
-          defaultMode: 292
           items:
           - key: ca.crt
             path: ca.crt
           secretName: ca
       - name: openvpn-ca
         secret:
-          defaultMode: 292
           secretName: openvpn-ca
       - emptyDir: {}
         name: http-prober-bin

--- a/api/pkg/resources/test/fixtures/deployment-digitalocean-1.11.0-apiserver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-digitalocean-1.11.0-apiserver.yaml
@@ -307,53 +307,41 @@ spec:
       volumes:
       - name: apiserver-tls
         secret:
-          defaultMode: 256
           secretName: apiserver-tls
       - name: tokens
         secret:
-          defaultMode: 256
           secretName: tokens
       - name: openvpn-client-certificates
         secret:
-          defaultMode: 256
           secretName: openvpn-client-certificates
       - name: kubelet-client-certificates
         secret:
-          defaultMode: 256
           secretName: kubelet-client-certificates
       - name: ca
         secret:
-          defaultMode: 256
           items:
           - key: ca.crt
             path: ca.crt
           secretName: ca
       - name: service-account-key
         secret:
-          defaultMode: 256
           secretName: service-account-key
       - configMap:
-          defaultMode: 420
           name: cloud-config
         name: cloud-config
       - name: apiserver-etcd-client-certificate
         secret:
-          defaultMode: 256
           secretName: apiserver-etcd-client-certificate
       - name: apiserver-proxy-client-certificate
         secret:
-          defaultMode: 256
           secretName: apiserver-proxy-client-certificate
       - name: front-proxy-ca
         secret:
-          defaultMode: 256
           secretName: front-proxy-ca
       - name: kubeletdnatcontroller-kubeconfig
         secret:
-          defaultMode: 292
           secretName: kubeletdnatcontroller-kubeconfig
       - name: dex-ca
         secret:
-          defaultMode: 256
           secretName: dex-ca
 status: {}

--- a/api/pkg/resources/test/fixtures/deployment-digitalocean-1.11.0-controller-manager.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-digitalocean-1.11.0-controller-manager.yaml
@@ -180,23 +180,18 @@ spec:
       volumes:
       - name: ca
         secret:
-          defaultMode: 256
           secretName: ca
       - name: service-account-key
         secret:
-          defaultMode: 256
           secretName: service-account-key
       - configMap:
-          defaultMode: 420
           name: cloud-config
         name: cloud-config
       - name: openvpn-client-certificates
         secret:
-          defaultMode: 256
           secretName: openvpn-client-certificates
       - name: controllermanager-kubeconfig
         secret:
-          defaultMode: 256
           secretName: controllermanager-kubeconfig
       - emptyDir: {}
         name: http-prober-bin

--- a/api/pkg/resources/test/fixtures/deployment-digitalocean-1.11.0-dns-resolver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-digitalocean-1.11.0-dns-resolver.yaml
@@ -124,16 +124,13 @@ spec:
       - name: dockercfg
       volumes:
       - configMap:
-          defaultMode: 256
           name: dns-resolver
         name: dns-resolver
       - name: openvpn-client-certificates
         secret:
-          defaultMode: 256
           secretName: openvpn-client-certificates
       - name: ca
         secret:
-          defaultMode: 256
           items:
           - key: ca.crt
             path: ca.crt

--- a/api/pkg/resources/test/fixtures/deployment-digitalocean-1.11.0-kube-state-metrics.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-digitalocean-1.11.0-kube-state-metrics.yaml
@@ -81,7 +81,6 @@ spec:
       volumes:
       - name: kube-state-metrics-kubeconfig
         secret:
-          defaultMode: 256
           secretName: kube-state-metrics-kubeconfig
       - emptyDir: {}
         name: http-prober-bin

--- a/api/pkg/resources/test/fixtures/deployment-digitalocean-1.11.0-machine-controller-webhook.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-digitalocean-1.11.0-machine-controller-webhook.yaml
@@ -89,11 +89,9 @@ spec:
       volumes:
       - name: machinecontroller-kubeconfig
         secret:
-          defaultMode: 292
           secretName: machinecontroller-kubeconfig
       - name: machinecontroller-webhook-serving-cert
         secret:
-          defaultMode: 292
           secretName: machinecontroller-webhook-serving-cert
       - emptyDir: {}
         name: http-prober-bin

--- a/api/pkg/resources/test/fixtures/deployment-digitalocean-1.11.0-machine-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-digitalocean-1.11.0-machine-controller.yaml
@@ -80,7 +80,6 @@ spec:
       volumes:
       - name: machinecontroller-kubeconfig
         secret:
-          defaultMode: 292
           secretName: machinecontroller-kubeconfig
       - emptyDir: {}
         name: http-prober-bin

--- a/api/pkg/resources/test/fixtures/deployment-digitalocean-1.11.0-metrics-server.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-digitalocean-1.11.0-metrics-server.yaml
@@ -164,15 +164,12 @@ spec:
       volumes:
       - name: metrics-server
         secret:
-          defaultMode: 292
           secretName: metrics-server
       - name: openvpn-client-certificates
         secret:
-          defaultMode: 256
           secretName: openvpn-client-certificates
       - name: kubeletdnatcontroller-kubeconfig
         secret:
-          defaultMode: 292
           secretName: kubeletdnatcontroller-kubeconfig
       - emptyDir: {}
         name: http-prober-bin

--- a/api/pkg/resources/test/fixtures/deployment-digitalocean-1.11.0-openvpn-server.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-digitalocean-1.11.0-openvpn-server.yaml
@@ -178,17 +178,14 @@ spec:
       volumes:
       - name: ca
         secret:
-          defaultMode: 256
           items:
           - key: ca.crt
             path: ca.crt
           secretName: openvpn-ca
       - name: openvpn-server-certificates
         secret:
-          defaultMode: 256
           secretName: openvpn-server-certificates
       - configMap:
-          defaultMode: 256
           name: openvpn-client-configs
         name: openvpn-client-configs
 status: {}

--- a/api/pkg/resources/test/fixtures/deployment-digitalocean-1.11.0-scheduler.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-digitalocean-1.11.0-scheduler.yaml
@@ -172,18 +172,15 @@ spec:
       volumes:
       - name: openvpn-client-certificates
         secret:
-          defaultMode: 256
           secretName: openvpn-client-certificates
       - name: ca
         secret:
-          defaultMode: 256
           items:
           - key: ca.crt
             path: ca.crt
           secretName: ca
       - name: scheduler-kubeconfig
         secret:
-          defaultMode: 256
           secretName: scheduler-kubeconfig
       - emptyDir: {}
         name: http-prober-bin

--- a/api/pkg/resources/test/fixtures/deployment-digitalocean-1.11.0-usercluster-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-digitalocean-1.11.0-usercluster-controller.yaml
@@ -94,18 +94,15 @@ spec:
       volumes:
       - name: internal-admin-kubeconfig
         secret:
-          defaultMode: 292
           secretName: internal-admin-kubeconfig
       - name: ca
         secret:
-          defaultMode: 292
           items:
           - key: ca.crt
             path: ca.crt
           secretName: ca
       - name: openvpn-ca
         secret:
-          defaultMode: 292
           secretName: openvpn-ca
       - emptyDir: {}
         name: http-prober-bin

--- a/api/pkg/resources/test/fixtures/deployment-digitalocean-1.11.1-apiserver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-digitalocean-1.11.1-apiserver.yaml
@@ -307,53 +307,41 @@ spec:
       volumes:
       - name: apiserver-tls
         secret:
-          defaultMode: 256
           secretName: apiserver-tls
       - name: tokens
         secret:
-          defaultMode: 256
           secretName: tokens
       - name: openvpn-client-certificates
         secret:
-          defaultMode: 256
           secretName: openvpn-client-certificates
       - name: kubelet-client-certificates
         secret:
-          defaultMode: 256
           secretName: kubelet-client-certificates
       - name: ca
         secret:
-          defaultMode: 256
           items:
           - key: ca.crt
             path: ca.crt
           secretName: ca
       - name: service-account-key
         secret:
-          defaultMode: 256
           secretName: service-account-key
       - configMap:
-          defaultMode: 420
           name: cloud-config
         name: cloud-config
       - name: apiserver-etcd-client-certificate
         secret:
-          defaultMode: 256
           secretName: apiserver-etcd-client-certificate
       - name: apiserver-proxy-client-certificate
         secret:
-          defaultMode: 256
           secretName: apiserver-proxy-client-certificate
       - name: front-proxy-ca
         secret:
-          defaultMode: 256
           secretName: front-proxy-ca
       - name: kubeletdnatcontroller-kubeconfig
         secret:
-          defaultMode: 292
           secretName: kubeletdnatcontroller-kubeconfig
       - name: dex-ca
         secret:
-          defaultMode: 256
           secretName: dex-ca
 status: {}

--- a/api/pkg/resources/test/fixtures/deployment-digitalocean-1.11.1-controller-manager.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-digitalocean-1.11.1-controller-manager.yaml
@@ -180,23 +180,18 @@ spec:
       volumes:
       - name: ca
         secret:
-          defaultMode: 256
           secretName: ca
       - name: service-account-key
         secret:
-          defaultMode: 256
           secretName: service-account-key
       - configMap:
-          defaultMode: 420
           name: cloud-config
         name: cloud-config
       - name: openvpn-client-certificates
         secret:
-          defaultMode: 256
           secretName: openvpn-client-certificates
       - name: controllermanager-kubeconfig
         secret:
-          defaultMode: 256
           secretName: controllermanager-kubeconfig
       - emptyDir: {}
         name: http-prober-bin

--- a/api/pkg/resources/test/fixtures/deployment-digitalocean-1.11.1-dns-resolver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-digitalocean-1.11.1-dns-resolver.yaml
@@ -124,16 +124,13 @@ spec:
       - name: dockercfg
       volumes:
       - configMap:
-          defaultMode: 256
           name: dns-resolver
         name: dns-resolver
       - name: openvpn-client-certificates
         secret:
-          defaultMode: 256
           secretName: openvpn-client-certificates
       - name: ca
         secret:
-          defaultMode: 256
           items:
           - key: ca.crt
             path: ca.crt

--- a/api/pkg/resources/test/fixtures/deployment-digitalocean-1.11.1-kube-state-metrics.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-digitalocean-1.11.1-kube-state-metrics.yaml
@@ -81,7 +81,6 @@ spec:
       volumes:
       - name: kube-state-metrics-kubeconfig
         secret:
-          defaultMode: 256
           secretName: kube-state-metrics-kubeconfig
       - emptyDir: {}
         name: http-prober-bin

--- a/api/pkg/resources/test/fixtures/deployment-digitalocean-1.11.1-machine-controller-webhook.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-digitalocean-1.11.1-machine-controller-webhook.yaml
@@ -89,11 +89,9 @@ spec:
       volumes:
       - name: machinecontroller-kubeconfig
         secret:
-          defaultMode: 292
           secretName: machinecontroller-kubeconfig
       - name: machinecontroller-webhook-serving-cert
         secret:
-          defaultMode: 292
           secretName: machinecontroller-webhook-serving-cert
       - emptyDir: {}
         name: http-prober-bin

--- a/api/pkg/resources/test/fixtures/deployment-digitalocean-1.11.1-machine-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-digitalocean-1.11.1-machine-controller.yaml
@@ -80,7 +80,6 @@ spec:
       volumes:
       - name: machinecontroller-kubeconfig
         secret:
-          defaultMode: 292
           secretName: machinecontroller-kubeconfig
       - emptyDir: {}
         name: http-prober-bin

--- a/api/pkg/resources/test/fixtures/deployment-digitalocean-1.11.1-metrics-server.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-digitalocean-1.11.1-metrics-server.yaml
@@ -164,15 +164,12 @@ spec:
       volumes:
       - name: metrics-server
         secret:
-          defaultMode: 292
           secretName: metrics-server
       - name: openvpn-client-certificates
         secret:
-          defaultMode: 256
           secretName: openvpn-client-certificates
       - name: kubeletdnatcontroller-kubeconfig
         secret:
-          defaultMode: 292
           secretName: kubeletdnatcontroller-kubeconfig
       - emptyDir: {}
         name: http-prober-bin

--- a/api/pkg/resources/test/fixtures/deployment-digitalocean-1.11.1-openvpn-server.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-digitalocean-1.11.1-openvpn-server.yaml
@@ -178,17 +178,14 @@ spec:
       volumes:
       - name: ca
         secret:
-          defaultMode: 256
           items:
           - key: ca.crt
             path: ca.crt
           secretName: openvpn-ca
       - name: openvpn-server-certificates
         secret:
-          defaultMode: 256
           secretName: openvpn-server-certificates
       - configMap:
-          defaultMode: 256
           name: openvpn-client-configs
         name: openvpn-client-configs
 status: {}

--- a/api/pkg/resources/test/fixtures/deployment-digitalocean-1.11.1-scheduler.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-digitalocean-1.11.1-scheduler.yaml
@@ -172,18 +172,15 @@ spec:
       volumes:
       - name: openvpn-client-certificates
         secret:
-          defaultMode: 256
           secretName: openvpn-client-certificates
       - name: ca
         secret:
-          defaultMode: 256
           items:
           - key: ca.crt
             path: ca.crt
           secretName: ca
       - name: scheduler-kubeconfig
         secret:
-          defaultMode: 256
           secretName: scheduler-kubeconfig
       - emptyDir: {}
         name: http-prober-bin

--- a/api/pkg/resources/test/fixtures/deployment-digitalocean-1.11.1-usercluster-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-digitalocean-1.11.1-usercluster-controller.yaml
@@ -94,18 +94,15 @@ spec:
       volumes:
       - name: internal-admin-kubeconfig
         secret:
-          defaultMode: 292
           secretName: internal-admin-kubeconfig
       - name: ca
         secret:
-          defaultMode: 292
           items:
           - key: ca.crt
             path: ca.crt
           secretName: ca
       - name: openvpn-ca
         secret:
-          defaultMode: 292
           secretName: openvpn-ca
       - emptyDir: {}
         name: http-prober-bin

--- a/api/pkg/resources/test/fixtures/deployment-digitalocean-1.12.0-apiserver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-digitalocean-1.12.0-apiserver.yaml
@@ -307,53 +307,41 @@ spec:
       volumes:
       - name: apiserver-tls
         secret:
-          defaultMode: 256
           secretName: apiserver-tls
       - name: tokens
         secret:
-          defaultMode: 256
           secretName: tokens
       - name: openvpn-client-certificates
         secret:
-          defaultMode: 256
           secretName: openvpn-client-certificates
       - name: kubelet-client-certificates
         secret:
-          defaultMode: 256
           secretName: kubelet-client-certificates
       - name: ca
         secret:
-          defaultMode: 256
           items:
           - key: ca.crt
             path: ca.crt
           secretName: ca
       - name: service-account-key
         secret:
-          defaultMode: 256
           secretName: service-account-key
       - configMap:
-          defaultMode: 420
           name: cloud-config
         name: cloud-config
       - name: apiserver-etcd-client-certificate
         secret:
-          defaultMode: 256
           secretName: apiserver-etcd-client-certificate
       - name: apiserver-proxy-client-certificate
         secret:
-          defaultMode: 256
           secretName: apiserver-proxy-client-certificate
       - name: front-proxy-ca
         secret:
-          defaultMode: 256
           secretName: front-proxy-ca
       - name: kubeletdnatcontroller-kubeconfig
         secret:
-          defaultMode: 292
           secretName: kubeletdnatcontroller-kubeconfig
       - name: dex-ca
         secret:
-          defaultMode: 256
           secretName: dex-ca
 status: {}

--- a/api/pkg/resources/test/fixtures/deployment-digitalocean-1.12.0-controller-manager.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-digitalocean-1.12.0-controller-manager.yaml
@@ -180,23 +180,18 @@ spec:
       volumes:
       - name: ca
         secret:
-          defaultMode: 256
           secretName: ca
       - name: service-account-key
         secret:
-          defaultMode: 256
           secretName: service-account-key
       - configMap:
-          defaultMode: 420
           name: cloud-config
         name: cloud-config
       - name: openvpn-client-certificates
         secret:
-          defaultMode: 256
           secretName: openvpn-client-certificates
       - name: controllermanager-kubeconfig
         secret:
-          defaultMode: 256
           secretName: controllermanager-kubeconfig
       - emptyDir: {}
         name: http-prober-bin

--- a/api/pkg/resources/test/fixtures/deployment-digitalocean-1.12.0-dns-resolver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-digitalocean-1.12.0-dns-resolver.yaml
@@ -124,16 +124,13 @@ spec:
       - name: dockercfg
       volumes:
       - configMap:
-          defaultMode: 256
           name: dns-resolver
         name: dns-resolver
       - name: openvpn-client-certificates
         secret:
-          defaultMode: 256
           secretName: openvpn-client-certificates
       - name: ca
         secret:
-          defaultMode: 256
           items:
           - key: ca.crt
             path: ca.crt

--- a/api/pkg/resources/test/fixtures/deployment-digitalocean-1.12.0-kube-state-metrics.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-digitalocean-1.12.0-kube-state-metrics.yaml
@@ -81,7 +81,6 @@ spec:
       volumes:
       - name: kube-state-metrics-kubeconfig
         secret:
-          defaultMode: 256
           secretName: kube-state-metrics-kubeconfig
       - emptyDir: {}
         name: http-prober-bin

--- a/api/pkg/resources/test/fixtures/deployment-digitalocean-1.12.0-machine-controller-webhook.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-digitalocean-1.12.0-machine-controller-webhook.yaml
@@ -89,11 +89,9 @@ spec:
       volumes:
       - name: machinecontroller-kubeconfig
         secret:
-          defaultMode: 292
           secretName: machinecontroller-kubeconfig
       - name: machinecontroller-webhook-serving-cert
         secret:
-          defaultMode: 292
           secretName: machinecontroller-webhook-serving-cert
       - emptyDir: {}
         name: http-prober-bin

--- a/api/pkg/resources/test/fixtures/deployment-digitalocean-1.12.0-machine-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-digitalocean-1.12.0-machine-controller.yaml
@@ -80,7 +80,6 @@ spec:
       volumes:
       - name: machinecontroller-kubeconfig
         secret:
-          defaultMode: 292
           secretName: machinecontroller-kubeconfig
       - emptyDir: {}
         name: http-prober-bin

--- a/api/pkg/resources/test/fixtures/deployment-digitalocean-1.12.0-metrics-server.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-digitalocean-1.12.0-metrics-server.yaml
@@ -164,15 +164,12 @@ spec:
       volumes:
       - name: metrics-server
         secret:
-          defaultMode: 292
           secretName: metrics-server
       - name: openvpn-client-certificates
         secret:
-          defaultMode: 256
           secretName: openvpn-client-certificates
       - name: kubeletdnatcontroller-kubeconfig
         secret:
-          defaultMode: 292
           secretName: kubeletdnatcontroller-kubeconfig
       - emptyDir: {}
         name: http-prober-bin

--- a/api/pkg/resources/test/fixtures/deployment-digitalocean-1.12.0-openvpn-server.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-digitalocean-1.12.0-openvpn-server.yaml
@@ -178,17 +178,14 @@ spec:
       volumes:
       - name: ca
         secret:
-          defaultMode: 256
           items:
           - key: ca.crt
             path: ca.crt
           secretName: openvpn-ca
       - name: openvpn-server-certificates
         secret:
-          defaultMode: 256
           secretName: openvpn-server-certificates
       - configMap:
-          defaultMode: 256
           name: openvpn-client-configs
         name: openvpn-client-configs
 status: {}

--- a/api/pkg/resources/test/fixtures/deployment-digitalocean-1.12.0-scheduler.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-digitalocean-1.12.0-scheduler.yaml
@@ -172,18 +172,15 @@ spec:
       volumes:
       - name: openvpn-client-certificates
         secret:
-          defaultMode: 256
           secretName: openvpn-client-certificates
       - name: ca
         secret:
-          defaultMode: 256
           items:
           - key: ca.crt
             path: ca.crt
           secretName: ca
       - name: scheduler-kubeconfig
         secret:
-          defaultMode: 256
           secretName: scheduler-kubeconfig
       - emptyDir: {}
         name: http-prober-bin

--- a/api/pkg/resources/test/fixtures/deployment-digitalocean-1.12.0-usercluster-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-digitalocean-1.12.0-usercluster-controller.yaml
@@ -94,18 +94,15 @@ spec:
       volumes:
       - name: internal-admin-kubeconfig
         secret:
-          defaultMode: 292
           secretName: internal-admin-kubeconfig
       - name: ca
         secret:
-          defaultMode: 292
           items:
           - key: ca.crt
             path: ca.crt
           secretName: ca
       - name: openvpn-ca
         secret:
-          defaultMode: 292
           secretName: openvpn-ca
       - emptyDir: {}
         name: http-prober-bin

--- a/api/pkg/resources/test/fixtures/deployment-digitalocean-1.13.0-apiserver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-digitalocean-1.13.0-apiserver.yaml
@@ -307,53 +307,41 @@ spec:
       volumes:
       - name: apiserver-tls
         secret:
-          defaultMode: 256
           secretName: apiserver-tls
       - name: tokens
         secret:
-          defaultMode: 256
           secretName: tokens
       - name: openvpn-client-certificates
         secret:
-          defaultMode: 256
           secretName: openvpn-client-certificates
       - name: kubelet-client-certificates
         secret:
-          defaultMode: 256
           secretName: kubelet-client-certificates
       - name: ca
         secret:
-          defaultMode: 256
           items:
           - key: ca.crt
             path: ca.crt
           secretName: ca
       - name: service-account-key
         secret:
-          defaultMode: 256
           secretName: service-account-key
       - configMap:
-          defaultMode: 420
           name: cloud-config
         name: cloud-config
       - name: apiserver-etcd-client-certificate
         secret:
-          defaultMode: 256
           secretName: apiserver-etcd-client-certificate
       - name: apiserver-proxy-client-certificate
         secret:
-          defaultMode: 256
           secretName: apiserver-proxy-client-certificate
       - name: front-proxy-ca
         secret:
-          defaultMode: 256
           secretName: front-proxy-ca
       - name: kubeletdnatcontroller-kubeconfig
         secret:
-          defaultMode: 292
           secretName: kubeletdnatcontroller-kubeconfig
       - name: dex-ca
         secret:
-          defaultMode: 256
           secretName: dex-ca
 status: {}

--- a/api/pkg/resources/test/fixtures/deployment-digitalocean-1.13.0-controller-manager.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-digitalocean-1.13.0-controller-manager.yaml
@@ -180,23 +180,18 @@ spec:
       volumes:
       - name: ca
         secret:
-          defaultMode: 256
           secretName: ca
       - name: service-account-key
         secret:
-          defaultMode: 256
           secretName: service-account-key
       - configMap:
-          defaultMode: 420
           name: cloud-config
         name: cloud-config
       - name: openvpn-client-certificates
         secret:
-          defaultMode: 256
           secretName: openvpn-client-certificates
       - name: controllermanager-kubeconfig
         secret:
-          defaultMode: 256
           secretName: controllermanager-kubeconfig
       - emptyDir: {}
         name: http-prober-bin

--- a/api/pkg/resources/test/fixtures/deployment-digitalocean-1.13.0-dns-resolver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-digitalocean-1.13.0-dns-resolver.yaml
@@ -124,16 +124,13 @@ spec:
       - name: dockercfg
       volumes:
       - configMap:
-          defaultMode: 256
           name: dns-resolver
         name: dns-resolver
       - name: openvpn-client-certificates
         secret:
-          defaultMode: 256
           secretName: openvpn-client-certificates
       - name: ca
         secret:
-          defaultMode: 256
           items:
           - key: ca.crt
             path: ca.crt

--- a/api/pkg/resources/test/fixtures/deployment-digitalocean-1.13.0-kube-state-metrics.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-digitalocean-1.13.0-kube-state-metrics.yaml
@@ -81,7 +81,6 @@ spec:
       volumes:
       - name: kube-state-metrics-kubeconfig
         secret:
-          defaultMode: 256
           secretName: kube-state-metrics-kubeconfig
       - emptyDir: {}
         name: http-prober-bin

--- a/api/pkg/resources/test/fixtures/deployment-digitalocean-1.13.0-machine-controller-webhook.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-digitalocean-1.13.0-machine-controller-webhook.yaml
@@ -89,11 +89,9 @@ spec:
       volumes:
       - name: machinecontroller-kubeconfig
         secret:
-          defaultMode: 292
           secretName: machinecontroller-kubeconfig
       - name: machinecontroller-webhook-serving-cert
         secret:
-          defaultMode: 292
           secretName: machinecontroller-webhook-serving-cert
       - emptyDir: {}
         name: http-prober-bin

--- a/api/pkg/resources/test/fixtures/deployment-digitalocean-1.13.0-machine-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-digitalocean-1.13.0-machine-controller.yaml
@@ -80,7 +80,6 @@ spec:
       volumes:
       - name: machinecontroller-kubeconfig
         secret:
-          defaultMode: 292
           secretName: machinecontroller-kubeconfig
       - emptyDir: {}
         name: http-prober-bin

--- a/api/pkg/resources/test/fixtures/deployment-digitalocean-1.13.0-metrics-server.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-digitalocean-1.13.0-metrics-server.yaml
@@ -164,15 +164,12 @@ spec:
       volumes:
       - name: metrics-server
         secret:
-          defaultMode: 292
           secretName: metrics-server
       - name: openvpn-client-certificates
         secret:
-          defaultMode: 256
           secretName: openvpn-client-certificates
       - name: kubeletdnatcontroller-kubeconfig
         secret:
-          defaultMode: 292
           secretName: kubeletdnatcontroller-kubeconfig
       - emptyDir: {}
         name: http-prober-bin

--- a/api/pkg/resources/test/fixtures/deployment-digitalocean-1.13.0-openvpn-server.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-digitalocean-1.13.0-openvpn-server.yaml
@@ -178,17 +178,14 @@ spec:
       volumes:
       - name: ca
         secret:
-          defaultMode: 256
           items:
           - key: ca.crt
             path: ca.crt
           secretName: openvpn-ca
       - name: openvpn-server-certificates
         secret:
-          defaultMode: 256
           secretName: openvpn-server-certificates
       - configMap:
-          defaultMode: 256
           name: openvpn-client-configs
         name: openvpn-client-configs
 status: {}

--- a/api/pkg/resources/test/fixtures/deployment-digitalocean-1.13.0-scheduler.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-digitalocean-1.13.0-scheduler.yaml
@@ -172,18 +172,15 @@ spec:
       volumes:
       - name: openvpn-client-certificates
         secret:
-          defaultMode: 256
           secretName: openvpn-client-certificates
       - name: ca
         secret:
-          defaultMode: 256
           items:
           - key: ca.crt
             path: ca.crt
           secretName: ca
       - name: scheduler-kubeconfig
         secret:
-          defaultMode: 256
           secretName: scheduler-kubeconfig
       - emptyDir: {}
         name: http-prober-bin

--- a/api/pkg/resources/test/fixtures/deployment-digitalocean-1.13.0-usercluster-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-digitalocean-1.13.0-usercluster-controller.yaml
@@ -94,18 +94,15 @@ spec:
       volumes:
       - name: internal-admin-kubeconfig
         secret:
-          defaultMode: 292
           secretName: internal-admin-kubeconfig
       - name: ca
         secret:
-          defaultMode: 292
           items:
           - key: ca.crt
             path: ca.crt
           secretName: ca
       - name: openvpn-ca
         secret:
-          defaultMode: 292
           secretName: openvpn-ca
       - emptyDir: {}
         name: http-prober-bin

--- a/api/pkg/resources/test/fixtures/deployment-openstack-1.10.0-apiserver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-openstack-1.10.0-apiserver.yaml
@@ -313,53 +313,41 @@ spec:
       volumes:
       - name: apiserver-tls
         secret:
-          defaultMode: 256
           secretName: apiserver-tls
       - name: tokens
         secret:
-          defaultMode: 256
           secretName: tokens
       - name: openvpn-client-certificates
         secret:
-          defaultMode: 256
           secretName: openvpn-client-certificates
       - name: kubelet-client-certificates
         secret:
-          defaultMode: 256
           secretName: kubelet-client-certificates
       - name: ca
         secret:
-          defaultMode: 256
           items:
           - key: ca.crt
             path: ca.crt
           secretName: ca
       - name: service-account-key
         secret:
-          defaultMode: 256
           secretName: service-account-key
       - configMap:
-          defaultMode: 420
           name: cloud-config
         name: cloud-config
       - name: apiserver-etcd-client-certificate
         secret:
-          defaultMode: 256
           secretName: apiserver-etcd-client-certificate
       - name: apiserver-proxy-client-certificate
         secret:
-          defaultMode: 256
           secretName: apiserver-proxy-client-certificate
       - name: front-proxy-ca
         secret:
-          defaultMode: 256
           secretName: front-proxy-ca
       - name: kubeletdnatcontroller-kubeconfig
         secret:
-          defaultMode: 292
           secretName: kubeletdnatcontroller-kubeconfig
       - name: dex-ca
         secret:
-          defaultMode: 256
           secretName: dex-ca
 status: {}

--- a/api/pkg/resources/test/fixtures/deployment-openstack-1.10.0-controller-manager.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-openstack-1.10.0-controller-manager.yaml
@@ -180,23 +180,18 @@ spec:
       volumes:
       - name: ca
         secret:
-          defaultMode: 256
           secretName: ca
       - name: service-account-key
         secret:
-          defaultMode: 256
           secretName: service-account-key
       - configMap:
-          defaultMode: 420
           name: cloud-config
         name: cloud-config
       - name: openvpn-client-certificates
         secret:
-          defaultMode: 256
           secretName: openvpn-client-certificates
       - name: controllermanager-kubeconfig
         secret:
-          defaultMode: 256
           secretName: controllermanager-kubeconfig
       - emptyDir: {}
         name: http-prober-bin

--- a/api/pkg/resources/test/fixtures/deployment-openstack-1.10.0-dns-resolver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-openstack-1.10.0-dns-resolver.yaml
@@ -124,16 +124,13 @@ spec:
       - name: dockercfg
       volumes:
       - configMap:
-          defaultMode: 256
           name: dns-resolver
         name: dns-resolver
       - name: openvpn-client-certificates
         secret:
-          defaultMode: 256
           secretName: openvpn-client-certificates
       - name: ca
         secret:
-          defaultMode: 256
           items:
           - key: ca.crt
             path: ca.crt

--- a/api/pkg/resources/test/fixtures/deployment-openstack-1.10.0-kube-state-metrics.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-openstack-1.10.0-kube-state-metrics.yaml
@@ -81,7 +81,6 @@ spec:
       volumes:
       - name: kube-state-metrics-kubeconfig
         secret:
-          defaultMode: 256
           secretName: kube-state-metrics-kubeconfig
       - emptyDir: {}
         name: http-prober-bin

--- a/api/pkg/resources/test/fixtures/deployment-openstack-1.10.0-machine-controller-webhook.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-openstack-1.10.0-machine-controller-webhook.yaml
@@ -98,11 +98,9 @@ spec:
       volumes:
       - name: machinecontroller-kubeconfig
         secret:
-          defaultMode: 292
           secretName: machinecontroller-kubeconfig
       - name: machinecontroller-webhook-serving-cert
         secret:
-          defaultMode: 292
           secretName: machinecontroller-webhook-serving-cert
       - emptyDir: {}
         name: http-prober-bin

--- a/api/pkg/resources/test/fixtures/deployment-openstack-1.10.0-machine-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-openstack-1.10.0-machine-controller.yaml
@@ -89,7 +89,6 @@ spec:
       volumes:
       - name: machinecontroller-kubeconfig
         secret:
-          defaultMode: 292
           secretName: machinecontroller-kubeconfig
       - emptyDir: {}
         name: http-prober-bin

--- a/api/pkg/resources/test/fixtures/deployment-openstack-1.10.0-metrics-server.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-openstack-1.10.0-metrics-server.yaml
@@ -164,15 +164,12 @@ spec:
       volumes:
       - name: metrics-server
         secret:
-          defaultMode: 292
           secretName: metrics-server
       - name: openvpn-client-certificates
         secret:
-          defaultMode: 256
           secretName: openvpn-client-certificates
       - name: kubeletdnatcontroller-kubeconfig
         secret:
-          defaultMode: 292
           secretName: kubeletdnatcontroller-kubeconfig
       - emptyDir: {}
         name: http-prober-bin

--- a/api/pkg/resources/test/fixtures/deployment-openstack-1.10.0-openvpn-server.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-openstack-1.10.0-openvpn-server.yaml
@@ -178,17 +178,14 @@ spec:
       volumes:
       - name: ca
         secret:
-          defaultMode: 256
           items:
           - key: ca.crt
             path: ca.crt
           secretName: openvpn-ca
       - name: openvpn-server-certificates
         secret:
-          defaultMode: 256
           secretName: openvpn-server-certificates
       - configMap:
-          defaultMode: 256
           name: openvpn-client-configs
         name: openvpn-client-configs
 status: {}

--- a/api/pkg/resources/test/fixtures/deployment-openstack-1.10.0-scheduler.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-openstack-1.10.0-scheduler.yaml
@@ -172,18 +172,15 @@ spec:
       volumes:
       - name: openvpn-client-certificates
         secret:
-          defaultMode: 256
           secretName: openvpn-client-certificates
       - name: ca
         secret:
-          defaultMode: 256
           items:
           - key: ca.crt
             path: ca.crt
           secretName: ca
       - name: scheduler-kubeconfig
         secret:
-          defaultMode: 256
           secretName: scheduler-kubeconfig
       - emptyDir: {}
         name: http-prober-bin

--- a/api/pkg/resources/test/fixtures/deployment-openstack-1.10.0-usercluster-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-openstack-1.10.0-usercluster-controller.yaml
@@ -94,18 +94,15 @@ spec:
       volumes:
       - name: internal-admin-kubeconfig
         secret:
-          defaultMode: 292
           secretName: internal-admin-kubeconfig
       - name: ca
         secret:
-          defaultMode: 292
           items:
           - key: ca.crt
             path: ca.crt
           secretName: ca
       - name: openvpn-ca
         secret:
-          defaultMode: 292
           secretName: openvpn-ca
       - emptyDir: {}
         name: http-prober-bin

--- a/api/pkg/resources/test/fixtures/deployment-openstack-1.10.6-apiserver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-openstack-1.10.6-apiserver.yaml
@@ -313,53 +313,41 @@ spec:
       volumes:
       - name: apiserver-tls
         secret:
-          defaultMode: 256
           secretName: apiserver-tls
       - name: tokens
         secret:
-          defaultMode: 256
           secretName: tokens
       - name: openvpn-client-certificates
         secret:
-          defaultMode: 256
           secretName: openvpn-client-certificates
       - name: kubelet-client-certificates
         secret:
-          defaultMode: 256
           secretName: kubelet-client-certificates
       - name: ca
         secret:
-          defaultMode: 256
           items:
           - key: ca.crt
             path: ca.crt
           secretName: ca
       - name: service-account-key
         secret:
-          defaultMode: 256
           secretName: service-account-key
       - configMap:
-          defaultMode: 420
           name: cloud-config
         name: cloud-config
       - name: apiserver-etcd-client-certificate
         secret:
-          defaultMode: 256
           secretName: apiserver-etcd-client-certificate
       - name: apiserver-proxy-client-certificate
         secret:
-          defaultMode: 256
           secretName: apiserver-proxy-client-certificate
       - name: front-proxy-ca
         secret:
-          defaultMode: 256
           secretName: front-proxy-ca
       - name: kubeletdnatcontroller-kubeconfig
         secret:
-          defaultMode: 292
           secretName: kubeletdnatcontroller-kubeconfig
       - name: dex-ca
         secret:
-          defaultMode: 256
           secretName: dex-ca
 status: {}

--- a/api/pkg/resources/test/fixtures/deployment-openstack-1.10.6-controller-manager.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-openstack-1.10.6-controller-manager.yaml
@@ -180,23 +180,18 @@ spec:
       volumes:
       - name: ca
         secret:
-          defaultMode: 256
           secretName: ca
       - name: service-account-key
         secret:
-          defaultMode: 256
           secretName: service-account-key
       - configMap:
-          defaultMode: 420
           name: cloud-config
         name: cloud-config
       - name: openvpn-client-certificates
         secret:
-          defaultMode: 256
           secretName: openvpn-client-certificates
       - name: controllermanager-kubeconfig
         secret:
-          defaultMode: 256
           secretName: controllermanager-kubeconfig
       - emptyDir: {}
         name: http-prober-bin

--- a/api/pkg/resources/test/fixtures/deployment-openstack-1.10.6-dns-resolver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-openstack-1.10.6-dns-resolver.yaml
@@ -124,16 +124,13 @@ spec:
       - name: dockercfg
       volumes:
       - configMap:
-          defaultMode: 256
           name: dns-resolver
         name: dns-resolver
       - name: openvpn-client-certificates
         secret:
-          defaultMode: 256
           secretName: openvpn-client-certificates
       - name: ca
         secret:
-          defaultMode: 256
           items:
           - key: ca.crt
             path: ca.crt

--- a/api/pkg/resources/test/fixtures/deployment-openstack-1.10.6-kube-state-metrics.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-openstack-1.10.6-kube-state-metrics.yaml
@@ -81,7 +81,6 @@ spec:
       volumes:
       - name: kube-state-metrics-kubeconfig
         secret:
-          defaultMode: 256
           secretName: kube-state-metrics-kubeconfig
       - emptyDir: {}
         name: http-prober-bin

--- a/api/pkg/resources/test/fixtures/deployment-openstack-1.10.6-machine-controller-webhook.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-openstack-1.10.6-machine-controller-webhook.yaml
@@ -98,11 +98,9 @@ spec:
       volumes:
       - name: machinecontroller-kubeconfig
         secret:
-          defaultMode: 292
           secretName: machinecontroller-kubeconfig
       - name: machinecontroller-webhook-serving-cert
         secret:
-          defaultMode: 292
           secretName: machinecontroller-webhook-serving-cert
       - emptyDir: {}
         name: http-prober-bin

--- a/api/pkg/resources/test/fixtures/deployment-openstack-1.10.6-machine-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-openstack-1.10.6-machine-controller.yaml
@@ -89,7 +89,6 @@ spec:
       volumes:
       - name: machinecontroller-kubeconfig
         secret:
-          defaultMode: 292
           secretName: machinecontroller-kubeconfig
       - emptyDir: {}
         name: http-prober-bin

--- a/api/pkg/resources/test/fixtures/deployment-openstack-1.10.6-metrics-server.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-openstack-1.10.6-metrics-server.yaml
@@ -164,15 +164,12 @@ spec:
       volumes:
       - name: metrics-server
         secret:
-          defaultMode: 292
           secretName: metrics-server
       - name: openvpn-client-certificates
         secret:
-          defaultMode: 256
           secretName: openvpn-client-certificates
       - name: kubeletdnatcontroller-kubeconfig
         secret:
-          defaultMode: 292
           secretName: kubeletdnatcontroller-kubeconfig
       - emptyDir: {}
         name: http-prober-bin

--- a/api/pkg/resources/test/fixtures/deployment-openstack-1.10.6-openvpn-server.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-openstack-1.10.6-openvpn-server.yaml
@@ -178,17 +178,14 @@ spec:
       volumes:
       - name: ca
         secret:
-          defaultMode: 256
           items:
           - key: ca.crt
             path: ca.crt
           secretName: openvpn-ca
       - name: openvpn-server-certificates
         secret:
-          defaultMode: 256
           secretName: openvpn-server-certificates
       - configMap:
-          defaultMode: 256
           name: openvpn-client-configs
         name: openvpn-client-configs
 status: {}

--- a/api/pkg/resources/test/fixtures/deployment-openstack-1.10.6-scheduler.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-openstack-1.10.6-scheduler.yaml
@@ -172,18 +172,15 @@ spec:
       volumes:
       - name: openvpn-client-certificates
         secret:
-          defaultMode: 256
           secretName: openvpn-client-certificates
       - name: ca
         secret:
-          defaultMode: 256
           items:
           - key: ca.crt
             path: ca.crt
           secretName: ca
       - name: scheduler-kubeconfig
         secret:
-          defaultMode: 256
           secretName: scheduler-kubeconfig
       - emptyDir: {}
         name: http-prober-bin

--- a/api/pkg/resources/test/fixtures/deployment-openstack-1.10.6-usercluster-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-openstack-1.10.6-usercluster-controller.yaml
@@ -94,18 +94,15 @@ spec:
       volumes:
       - name: internal-admin-kubeconfig
         secret:
-          defaultMode: 292
           secretName: internal-admin-kubeconfig
       - name: ca
         secret:
-          defaultMode: 292
           items:
           - key: ca.crt
             path: ca.crt
           secretName: ca
       - name: openvpn-ca
         secret:
-          defaultMode: 292
           secretName: openvpn-ca
       - emptyDir: {}
         name: http-prober-bin

--- a/api/pkg/resources/test/fixtures/deployment-openstack-1.11.0-apiserver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-openstack-1.11.0-apiserver.yaml
@@ -311,53 +311,41 @@ spec:
       volumes:
       - name: apiserver-tls
         secret:
-          defaultMode: 256
           secretName: apiserver-tls
       - name: tokens
         secret:
-          defaultMode: 256
           secretName: tokens
       - name: openvpn-client-certificates
         secret:
-          defaultMode: 256
           secretName: openvpn-client-certificates
       - name: kubelet-client-certificates
         secret:
-          defaultMode: 256
           secretName: kubelet-client-certificates
       - name: ca
         secret:
-          defaultMode: 256
           items:
           - key: ca.crt
             path: ca.crt
           secretName: ca
       - name: service-account-key
         secret:
-          defaultMode: 256
           secretName: service-account-key
       - configMap:
-          defaultMode: 420
           name: cloud-config
         name: cloud-config
       - name: apiserver-etcd-client-certificate
         secret:
-          defaultMode: 256
           secretName: apiserver-etcd-client-certificate
       - name: apiserver-proxy-client-certificate
         secret:
-          defaultMode: 256
           secretName: apiserver-proxy-client-certificate
       - name: front-proxy-ca
         secret:
-          defaultMode: 256
           secretName: front-proxy-ca
       - name: kubeletdnatcontroller-kubeconfig
         secret:
-          defaultMode: 292
           secretName: kubeletdnatcontroller-kubeconfig
       - name: dex-ca
         secret:
-          defaultMode: 256
           secretName: dex-ca
 status: {}

--- a/api/pkg/resources/test/fixtures/deployment-openstack-1.11.0-controller-manager.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-openstack-1.11.0-controller-manager.yaml
@@ -180,23 +180,18 @@ spec:
       volumes:
       - name: ca
         secret:
-          defaultMode: 256
           secretName: ca
       - name: service-account-key
         secret:
-          defaultMode: 256
           secretName: service-account-key
       - configMap:
-          defaultMode: 420
           name: cloud-config
         name: cloud-config
       - name: openvpn-client-certificates
         secret:
-          defaultMode: 256
           secretName: openvpn-client-certificates
       - name: controllermanager-kubeconfig
         secret:
-          defaultMode: 256
           secretName: controllermanager-kubeconfig
       - emptyDir: {}
         name: http-prober-bin

--- a/api/pkg/resources/test/fixtures/deployment-openstack-1.11.0-dns-resolver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-openstack-1.11.0-dns-resolver.yaml
@@ -124,16 +124,13 @@ spec:
       - name: dockercfg
       volumes:
       - configMap:
-          defaultMode: 256
           name: dns-resolver
         name: dns-resolver
       - name: openvpn-client-certificates
         secret:
-          defaultMode: 256
           secretName: openvpn-client-certificates
       - name: ca
         secret:
-          defaultMode: 256
           items:
           - key: ca.crt
             path: ca.crt

--- a/api/pkg/resources/test/fixtures/deployment-openstack-1.11.0-kube-state-metrics.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-openstack-1.11.0-kube-state-metrics.yaml
@@ -81,7 +81,6 @@ spec:
       volumes:
       - name: kube-state-metrics-kubeconfig
         secret:
-          defaultMode: 256
           secretName: kube-state-metrics-kubeconfig
       - emptyDir: {}
         name: http-prober-bin

--- a/api/pkg/resources/test/fixtures/deployment-openstack-1.11.0-machine-controller-webhook.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-openstack-1.11.0-machine-controller-webhook.yaml
@@ -98,11 +98,9 @@ spec:
       volumes:
       - name: machinecontroller-kubeconfig
         secret:
-          defaultMode: 292
           secretName: machinecontroller-kubeconfig
       - name: machinecontroller-webhook-serving-cert
         secret:
-          defaultMode: 292
           secretName: machinecontroller-webhook-serving-cert
       - emptyDir: {}
         name: http-prober-bin

--- a/api/pkg/resources/test/fixtures/deployment-openstack-1.11.0-machine-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-openstack-1.11.0-machine-controller.yaml
@@ -89,7 +89,6 @@ spec:
       volumes:
       - name: machinecontroller-kubeconfig
         secret:
-          defaultMode: 292
           secretName: machinecontroller-kubeconfig
       - emptyDir: {}
         name: http-prober-bin

--- a/api/pkg/resources/test/fixtures/deployment-openstack-1.11.0-metrics-server.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-openstack-1.11.0-metrics-server.yaml
@@ -164,15 +164,12 @@ spec:
       volumes:
       - name: metrics-server
         secret:
-          defaultMode: 292
           secretName: metrics-server
       - name: openvpn-client-certificates
         secret:
-          defaultMode: 256
           secretName: openvpn-client-certificates
       - name: kubeletdnatcontroller-kubeconfig
         secret:
-          defaultMode: 292
           secretName: kubeletdnatcontroller-kubeconfig
       - emptyDir: {}
         name: http-prober-bin

--- a/api/pkg/resources/test/fixtures/deployment-openstack-1.11.0-openvpn-server.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-openstack-1.11.0-openvpn-server.yaml
@@ -178,17 +178,14 @@ spec:
       volumes:
       - name: ca
         secret:
-          defaultMode: 256
           items:
           - key: ca.crt
             path: ca.crt
           secretName: openvpn-ca
       - name: openvpn-server-certificates
         secret:
-          defaultMode: 256
           secretName: openvpn-server-certificates
       - configMap:
-          defaultMode: 256
           name: openvpn-client-configs
         name: openvpn-client-configs
 status: {}

--- a/api/pkg/resources/test/fixtures/deployment-openstack-1.11.0-scheduler.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-openstack-1.11.0-scheduler.yaml
@@ -172,18 +172,15 @@ spec:
       volumes:
       - name: openvpn-client-certificates
         secret:
-          defaultMode: 256
           secretName: openvpn-client-certificates
       - name: ca
         secret:
-          defaultMode: 256
           items:
           - key: ca.crt
             path: ca.crt
           secretName: ca
       - name: scheduler-kubeconfig
         secret:
-          defaultMode: 256
           secretName: scheduler-kubeconfig
       - emptyDir: {}
         name: http-prober-bin

--- a/api/pkg/resources/test/fixtures/deployment-openstack-1.11.0-usercluster-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-openstack-1.11.0-usercluster-controller.yaml
@@ -94,18 +94,15 @@ spec:
       volumes:
       - name: internal-admin-kubeconfig
         secret:
-          defaultMode: 292
           secretName: internal-admin-kubeconfig
       - name: ca
         secret:
-          defaultMode: 292
           items:
           - key: ca.crt
             path: ca.crt
           secretName: ca
       - name: openvpn-ca
         secret:
-          defaultMode: 292
           secretName: openvpn-ca
       - emptyDir: {}
         name: http-prober-bin

--- a/api/pkg/resources/test/fixtures/deployment-openstack-1.11.1-apiserver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-openstack-1.11.1-apiserver.yaml
@@ -311,53 +311,41 @@ spec:
       volumes:
       - name: apiserver-tls
         secret:
-          defaultMode: 256
           secretName: apiserver-tls
       - name: tokens
         secret:
-          defaultMode: 256
           secretName: tokens
       - name: openvpn-client-certificates
         secret:
-          defaultMode: 256
           secretName: openvpn-client-certificates
       - name: kubelet-client-certificates
         secret:
-          defaultMode: 256
           secretName: kubelet-client-certificates
       - name: ca
         secret:
-          defaultMode: 256
           items:
           - key: ca.crt
             path: ca.crt
           secretName: ca
       - name: service-account-key
         secret:
-          defaultMode: 256
           secretName: service-account-key
       - configMap:
-          defaultMode: 420
           name: cloud-config
         name: cloud-config
       - name: apiserver-etcd-client-certificate
         secret:
-          defaultMode: 256
           secretName: apiserver-etcd-client-certificate
       - name: apiserver-proxy-client-certificate
         secret:
-          defaultMode: 256
           secretName: apiserver-proxy-client-certificate
       - name: front-proxy-ca
         secret:
-          defaultMode: 256
           secretName: front-proxy-ca
       - name: kubeletdnatcontroller-kubeconfig
         secret:
-          defaultMode: 292
           secretName: kubeletdnatcontroller-kubeconfig
       - name: dex-ca
         secret:
-          defaultMode: 256
           secretName: dex-ca
 status: {}

--- a/api/pkg/resources/test/fixtures/deployment-openstack-1.11.1-controller-manager.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-openstack-1.11.1-controller-manager.yaml
@@ -180,23 +180,18 @@ spec:
       volumes:
       - name: ca
         secret:
-          defaultMode: 256
           secretName: ca
       - name: service-account-key
         secret:
-          defaultMode: 256
           secretName: service-account-key
       - configMap:
-          defaultMode: 420
           name: cloud-config
         name: cloud-config
       - name: openvpn-client-certificates
         secret:
-          defaultMode: 256
           secretName: openvpn-client-certificates
       - name: controllermanager-kubeconfig
         secret:
-          defaultMode: 256
           secretName: controllermanager-kubeconfig
       - emptyDir: {}
         name: http-prober-bin

--- a/api/pkg/resources/test/fixtures/deployment-openstack-1.11.1-dns-resolver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-openstack-1.11.1-dns-resolver.yaml
@@ -124,16 +124,13 @@ spec:
       - name: dockercfg
       volumes:
       - configMap:
-          defaultMode: 256
           name: dns-resolver
         name: dns-resolver
       - name: openvpn-client-certificates
         secret:
-          defaultMode: 256
           secretName: openvpn-client-certificates
       - name: ca
         secret:
-          defaultMode: 256
           items:
           - key: ca.crt
             path: ca.crt

--- a/api/pkg/resources/test/fixtures/deployment-openstack-1.11.1-kube-state-metrics.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-openstack-1.11.1-kube-state-metrics.yaml
@@ -81,7 +81,6 @@ spec:
       volumes:
       - name: kube-state-metrics-kubeconfig
         secret:
-          defaultMode: 256
           secretName: kube-state-metrics-kubeconfig
       - emptyDir: {}
         name: http-prober-bin

--- a/api/pkg/resources/test/fixtures/deployment-openstack-1.11.1-machine-controller-webhook.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-openstack-1.11.1-machine-controller-webhook.yaml
@@ -98,11 +98,9 @@ spec:
       volumes:
       - name: machinecontroller-kubeconfig
         secret:
-          defaultMode: 292
           secretName: machinecontroller-kubeconfig
       - name: machinecontroller-webhook-serving-cert
         secret:
-          defaultMode: 292
           secretName: machinecontroller-webhook-serving-cert
       - emptyDir: {}
         name: http-prober-bin

--- a/api/pkg/resources/test/fixtures/deployment-openstack-1.11.1-machine-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-openstack-1.11.1-machine-controller.yaml
@@ -89,7 +89,6 @@ spec:
       volumes:
       - name: machinecontroller-kubeconfig
         secret:
-          defaultMode: 292
           secretName: machinecontroller-kubeconfig
       - emptyDir: {}
         name: http-prober-bin

--- a/api/pkg/resources/test/fixtures/deployment-openstack-1.11.1-metrics-server.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-openstack-1.11.1-metrics-server.yaml
@@ -164,15 +164,12 @@ spec:
       volumes:
       - name: metrics-server
         secret:
-          defaultMode: 292
           secretName: metrics-server
       - name: openvpn-client-certificates
         secret:
-          defaultMode: 256
           secretName: openvpn-client-certificates
       - name: kubeletdnatcontroller-kubeconfig
         secret:
-          defaultMode: 292
           secretName: kubeletdnatcontroller-kubeconfig
       - emptyDir: {}
         name: http-prober-bin

--- a/api/pkg/resources/test/fixtures/deployment-openstack-1.11.1-openvpn-server.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-openstack-1.11.1-openvpn-server.yaml
@@ -178,17 +178,14 @@ spec:
       volumes:
       - name: ca
         secret:
-          defaultMode: 256
           items:
           - key: ca.crt
             path: ca.crt
           secretName: openvpn-ca
       - name: openvpn-server-certificates
         secret:
-          defaultMode: 256
           secretName: openvpn-server-certificates
       - configMap:
-          defaultMode: 256
           name: openvpn-client-configs
         name: openvpn-client-configs
 status: {}

--- a/api/pkg/resources/test/fixtures/deployment-openstack-1.11.1-scheduler.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-openstack-1.11.1-scheduler.yaml
@@ -172,18 +172,15 @@ spec:
       volumes:
       - name: openvpn-client-certificates
         secret:
-          defaultMode: 256
           secretName: openvpn-client-certificates
       - name: ca
         secret:
-          defaultMode: 256
           items:
           - key: ca.crt
             path: ca.crt
           secretName: ca
       - name: scheduler-kubeconfig
         secret:
-          defaultMode: 256
           secretName: scheduler-kubeconfig
       - emptyDir: {}
         name: http-prober-bin

--- a/api/pkg/resources/test/fixtures/deployment-openstack-1.11.1-usercluster-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-openstack-1.11.1-usercluster-controller.yaml
@@ -94,18 +94,15 @@ spec:
       volumes:
       - name: internal-admin-kubeconfig
         secret:
-          defaultMode: 292
           secretName: internal-admin-kubeconfig
       - name: ca
         secret:
-          defaultMode: 292
           items:
           - key: ca.crt
             path: ca.crt
           secretName: ca
       - name: openvpn-ca
         secret:
-          defaultMode: 292
           secretName: openvpn-ca
       - emptyDir: {}
         name: http-prober-bin

--- a/api/pkg/resources/test/fixtures/deployment-openstack-1.12.0-apiserver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-openstack-1.12.0-apiserver.yaml
@@ -311,53 +311,41 @@ spec:
       volumes:
       - name: apiserver-tls
         secret:
-          defaultMode: 256
           secretName: apiserver-tls
       - name: tokens
         secret:
-          defaultMode: 256
           secretName: tokens
       - name: openvpn-client-certificates
         secret:
-          defaultMode: 256
           secretName: openvpn-client-certificates
       - name: kubelet-client-certificates
         secret:
-          defaultMode: 256
           secretName: kubelet-client-certificates
       - name: ca
         secret:
-          defaultMode: 256
           items:
           - key: ca.crt
             path: ca.crt
           secretName: ca
       - name: service-account-key
         secret:
-          defaultMode: 256
           secretName: service-account-key
       - configMap:
-          defaultMode: 420
           name: cloud-config
         name: cloud-config
       - name: apiserver-etcd-client-certificate
         secret:
-          defaultMode: 256
           secretName: apiserver-etcd-client-certificate
       - name: apiserver-proxy-client-certificate
         secret:
-          defaultMode: 256
           secretName: apiserver-proxy-client-certificate
       - name: front-proxy-ca
         secret:
-          defaultMode: 256
           secretName: front-proxy-ca
       - name: kubeletdnatcontroller-kubeconfig
         secret:
-          defaultMode: 292
           secretName: kubeletdnatcontroller-kubeconfig
       - name: dex-ca
         secret:
-          defaultMode: 256
           secretName: dex-ca
 status: {}

--- a/api/pkg/resources/test/fixtures/deployment-openstack-1.12.0-controller-manager.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-openstack-1.12.0-controller-manager.yaml
@@ -180,23 +180,18 @@ spec:
       volumes:
       - name: ca
         secret:
-          defaultMode: 256
           secretName: ca
       - name: service-account-key
         secret:
-          defaultMode: 256
           secretName: service-account-key
       - configMap:
-          defaultMode: 420
           name: cloud-config
         name: cloud-config
       - name: openvpn-client-certificates
         secret:
-          defaultMode: 256
           secretName: openvpn-client-certificates
       - name: controllermanager-kubeconfig
         secret:
-          defaultMode: 256
           secretName: controllermanager-kubeconfig
       - emptyDir: {}
         name: http-prober-bin

--- a/api/pkg/resources/test/fixtures/deployment-openstack-1.12.0-dns-resolver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-openstack-1.12.0-dns-resolver.yaml
@@ -124,16 +124,13 @@ spec:
       - name: dockercfg
       volumes:
       - configMap:
-          defaultMode: 256
           name: dns-resolver
         name: dns-resolver
       - name: openvpn-client-certificates
         secret:
-          defaultMode: 256
           secretName: openvpn-client-certificates
       - name: ca
         secret:
-          defaultMode: 256
           items:
           - key: ca.crt
             path: ca.crt

--- a/api/pkg/resources/test/fixtures/deployment-openstack-1.12.0-kube-state-metrics.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-openstack-1.12.0-kube-state-metrics.yaml
@@ -81,7 +81,6 @@ spec:
       volumes:
       - name: kube-state-metrics-kubeconfig
         secret:
-          defaultMode: 256
           secretName: kube-state-metrics-kubeconfig
       - emptyDir: {}
         name: http-prober-bin

--- a/api/pkg/resources/test/fixtures/deployment-openstack-1.12.0-machine-controller-webhook.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-openstack-1.12.0-machine-controller-webhook.yaml
@@ -98,11 +98,9 @@ spec:
       volumes:
       - name: machinecontroller-kubeconfig
         secret:
-          defaultMode: 292
           secretName: machinecontroller-kubeconfig
       - name: machinecontroller-webhook-serving-cert
         secret:
-          defaultMode: 292
           secretName: machinecontroller-webhook-serving-cert
       - emptyDir: {}
         name: http-prober-bin

--- a/api/pkg/resources/test/fixtures/deployment-openstack-1.12.0-machine-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-openstack-1.12.0-machine-controller.yaml
@@ -89,7 +89,6 @@ spec:
       volumes:
       - name: machinecontroller-kubeconfig
         secret:
-          defaultMode: 292
           secretName: machinecontroller-kubeconfig
       - emptyDir: {}
         name: http-prober-bin

--- a/api/pkg/resources/test/fixtures/deployment-openstack-1.12.0-metrics-server.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-openstack-1.12.0-metrics-server.yaml
@@ -164,15 +164,12 @@ spec:
       volumes:
       - name: metrics-server
         secret:
-          defaultMode: 292
           secretName: metrics-server
       - name: openvpn-client-certificates
         secret:
-          defaultMode: 256
           secretName: openvpn-client-certificates
       - name: kubeletdnatcontroller-kubeconfig
         secret:
-          defaultMode: 292
           secretName: kubeletdnatcontroller-kubeconfig
       - emptyDir: {}
         name: http-prober-bin

--- a/api/pkg/resources/test/fixtures/deployment-openstack-1.12.0-openvpn-server.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-openstack-1.12.0-openvpn-server.yaml
@@ -178,17 +178,14 @@ spec:
       volumes:
       - name: ca
         secret:
-          defaultMode: 256
           items:
           - key: ca.crt
             path: ca.crt
           secretName: openvpn-ca
       - name: openvpn-server-certificates
         secret:
-          defaultMode: 256
           secretName: openvpn-server-certificates
       - configMap:
-          defaultMode: 256
           name: openvpn-client-configs
         name: openvpn-client-configs
 status: {}

--- a/api/pkg/resources/test/fixtures/deployment-openstack-1.12.0-scheduler.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-openstack-1.12.0-scheduler.yaml
@@ -172,18 +172,15 @@ spec:
       volumes:
       - name: openvpn-client-certificates
         secret:
-          defaultMode: 256
           secretName: openvpn-client-certificates
       - name: ca
         secret:
-          defaultMode: 256
           items:
           - key: ca.crt
             path: ca.crt
           secretName: ca
       - name: scheduler-kubeconfig
         secret:
-          defaultMode: 256
           secretName: scheduler-kubeconfig
       - emptyDir: {}
         name: http-prober-bin

--- a/api/pkg/resources/test/fixtures/deployment-openstack-1.12.0-usercluster-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-openstack-1.12.0-usercluster-controller.yaml
@@ -94,18 +94,15 @@ spec:
       volumes:
       - name: internal-admin-kubeconfig
         secret:
-          defaultMode: 292
           secretName: internal-admin-kubeconfig
       - name: ca
         secret:
-          defaultMode: 292
           items:
           - key: ca.crt
             path: ca.crt
           secretName: ca
       - name: openvpn-ca
         secret:
-          defaultMode: 292
           secretName: openvpn-ca
       - emptyDir: {}
         name: http-prober-bin

--- a/api/pkg/resources/test/fixtures/deployment-openstack-1.13.0-apiserver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-openstack-1.13.0-apiserver.yaml
@@ -311,53 +311,41 @@ spec:
       volumes:
       - name: apiserver-tls
         secret:
-          defaultMode: 256
           secretName: apiserver-tls
       - name: tokens
         secret:
-          defaultMode: 256
           secretName: tokens
       - name: openvpn-client-certificates
         secret:
-          defaultMode: 256
           secretName: openvpn-client-certificates
       - name: kubelet-client-certificates
         secret:
-          defaultMode: 256
           secretName: kubelet-client-certificates
       - name: ca
         secret:
-          defaultMode: 256
           items:
           - key: ca.crt
             path: ca.crt
           secretName: ca
       - name: service-account-key
         secret:
-          defaultMode: 256
           secretName: service-account-key
       - configMap:
-          defaultMode: 420
           name: cloud-config
         name: cloud-config
       - name: apiserver-etcd-client-certificate
         secret:
-          defaultMode: 256
           secretName: apiserver-etcd-client-certificate
       - name: apiserver-proxy-client-certificate
         secret:
-          defaultMode: 256
           secretName: apiserver-proxy-client-certificate
       - name: front-proxy-ca
         secret:
-          defaultMode: 256
           secretName: front-proxy-ca
       - name: kubeletdnatcontroller-kubeconfig
         secret:
-          defaultMode: 292
           secretName: kubeletdnatcontroller-kubeconfig
       - name: dex-ca
         secret:
-          defaultMode: 256
           secretName: dex-ca
 status: {}

--- a/api/pkg/resources/test/fixtures/deployment-openstack-1.13.0-controller-manager.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-openstack-1.13.0-controller-manager.yaml
@@ -180,23 +180,18 @@ spec:
       volumes:
       - name: ca
         secret:
-          defaultMode: 256
           secretName: ca
       - name: service-account-key
         secret:
-          defaultMode: 256
           secretName: service-account-key
       - configMap:
-          defaultMode: 420
           name: cloud-config
         name: cloud-config
       - name: openvpn-client-certificates
         secret:
-          defaultMode: 256
           secretName: openvpn-client-certificates
       - name: controllermanager-kubeconfig
         secret:
-          defaultMode: 256
           secretName: controllermanager-kubeconfig
       - emptyDir: {}
         name: http-prober-bin

--- a/api/pkg/resources/test/fixtures/deployment-openstack-1.13.0-dns-resolver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-openstack-1.13.0-dns-resolver.yaml
@@ -124,16 +124,13 @@ spec:
       - name: dockercfg
       volumes:
       - configMap:
-          defaultMode: 256
           name: dns-resolver
         name: dns-resolver
       - name: openvpn-client-certificates
         secret:
-          defaultMode: 256
           secretName: openvpn-client-certificates
       - name: ca
         secret:
-          defaultMode: 256
           items:
           - key: ca.crt
             path: ca.crt

--- a/api/pkg/resources/test/fixtures/deployment-openstack-1.13.0-kube-state-metrics.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-openstack-1.13.0-kube-state-metrics.yaml
@@ -81,7 +81,6 @@ spec:
       volumes:
       - name: kube-state-metrics-kubeconfig
         secret:
-          defaultMode: 256
           secretName: kube-state-metrics-kubeconfig
       - emptyDir: {}
         name: http-prober-bin

--- a/api/pkg/resources/test/fixtures/deployment-openstack-1.13.0-machine-controller-webhook.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-openstack-1.13.0-machine-controller-webhook.yaml
@@ -98,11 +98,9 @@ spec:
       volumes:
       - name: machinecontroller-kubeconfig
         secret:
-          defaultMode: 292
           secretName: machinecontroller-kubeconfig
       - name: machinecontroller-webhook-serving-cert
         secret:
-          defaultMode: 292
           secretName: machinecontroller-webhook-serving-cert
       - emptyDir: {}
         name: http-prober-bin

--- a/api/pkg/resources/test/fixtures/deployment-openstack-1.13.0-machine-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-openstack-1.13.0-machine-controller.yaml
@@ -89,7 +89,6 @@ spec:
       volumes:
       - name: machinecontroller-kubeconfig
         secret:
-          defaultMode: 292
           secretName: machinecontroller-kubeconfig
       - emptyDir: {}
         name: http-prober-bin

--- a/api/pkg/resources/test/fixtures/deployment-openstack-1.13.0-metrics-server.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-openstack-1.13.0-metrics-server.yaml
@@ -164,15 +164,12 @@ spec:
       volumes:
       - name: metrics-server
         secret:
-          defaultMode: 292
           secretName: metrics-server
       - name: openvpn-client-certificates
         secret:
-          defaultMode: 256
           secretName: openvpn-client-certificates
       - name: kubeletdnatcontroller-kubeconfig
         secret:
-          defaultMode: 292
           secretName: kubeletdnatcontroller-kubeconfig
       - emptyDir: {}
         name: http-prober-bin

--- a/api/pkg/resources/test/fixtures/deployment-openstack-1.13.0-openvpn-server.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-openstack-1.13.0-openvpn-server.yaml
@@ -178,17 +178,14 @@ spec:
       volumes:
       - name: ca
         secret:
-          defaultMode: 256
           items:
           - key: ca.crt
             path: ca.crt
           secretName: openvpn-ca
       - name: openvpn-server-certificates
         secret:
-          defaultMode: 256
           secretName: openvpn-server-certificates
       - configMap:
-          defaultMode: 256
           name: openvpn-client-configs
         name: openvpn-client-configs
 status: {}

--- a/api/pkg/resources/test/fixtures/deployment-openstack-1.13.0-scheduler.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-openstack-1.13.0-scheduler.yaml
@@ -172,18 +172,15 @@ spec:
       volumes:
       - name: openvpn-client-certificates
         secret:
-          defaultMode: 256
           secretName: openvpn-client-certificates
       - name: ca
         secret:
-          defaultMode: 256
           items:
           - key: ca.crt
             path: ca.crt
           secretName: ca
       - name: scheduler-kubeconfig
         secret:
-          defaultMode: 256
           secretName: scheduler-kubeconfig
       - emptyDir: {}
         name: http-prober-bin

--- a/api/pkg/resources/test/fixtures/deployment-openstack-1.13.0-usercluster-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-openstack-1.13.0-usercluster-controller.yaml
@@ -94,18 +94,15 @@ spec:
       volumes:
       - name: internal-admin-kubeconfig
         secret:
-          defaultMode: 292
           secretName: internal-admin-kubeconfig
       - name: ca
         secret:
-          defaultMode: 292
           items:
           - key: ca.crt
             path: ca.crt
           secretName: ca
       - name: openvpn-ca
         secret:
-          defaultMode: 292
           secretName: openvpn-ca
       - emptyDir: {}
         name: http-prober-bin

--- a/api/pkg/resources/test/fixtures/deployment-vsphere-1.10.0-apiserver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-vsphere-1.10.0-apiserver.yaml
@@ -313,53 +313,41 @@ spec:
       volumes:
       - name: apiserver-tls
         secret:
-          defaultMode: 256
           secretName: apiserver-tls
       - name: tokens
         secret:
-          defaultMode: 256
           secretName: tokens
       - name: openvpn-client-certificates
         secret:
-          defaultMode: 256
           secretName: openvpn-client-certificates
       - name: kubelet-client-certificates
         secret:
-          defaultMode: 256
           secretName: kubelet-client-certificates
       - name: ca
         secret:
-          defaultMode: 256
           items:
           - key: ca.crt
             path: ca.crt
           secretName: ca
       - name: service-account-key
         secret:
-          defaultMode: 256
           secretName: service-account-key
       - configMap:
-          defaultMode: 420
           name: cloud-config
         name: cloud-config
       - name: apiserver-etcd-client-certificate
         secret:
-          defaultMode: 256
           secretName: apiserver-etcd-client-certificate
       - name: apiserver-proxy-client-certificate
         secret:
-          defaultMode: 256
           secretName: apiserver-proxy-client-certificate
       - name: front-proxy-ca
         secret:
-          defaultMode: 256
           secretName: front-proxy-ca
       - name: kubeletdnatcontroller-kubeconfig
         secret:
-          defaultMode: 292
           secretName: kubeletdnatcontroller-kubeconfig
       - name: dex-ca
         secret:
-          defaultMode: 256
           secretName: dex-ca
 status: {}

--- a/api/pkg/resources/test/fixtures/deployment-vsphere-1.10.0-controller-manager.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-vsphere-1.10.0-controller-manager.yaml
@@ -184,23 +184,18 @@ spec:
       volumes:
       - name: ca
         secret:
-          defaultMode: 256
           secretName: ca
       - name: service-account-key
         secret:
-          defaultMode: 256
           secretName: service-account-key
       - configMap:
-          defaultMode: 420
           name: cloud-config
         name: cloud-config
       - name: openvpn-client-certificates
         secret:
-          defaultMode: 256
           secretName: openvpn-client-certificates
       - name: controllermanager-kubeconfig
         secret:
-          defaultMode: 256
           secretName: controllermanager-kubeconfig
       - emptyDir: {}
         name: http-prober-bin

--- a/api/pkg/resources/test/fixtures/deployment-vsphere-1.10.0-dns-resolver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-vsphere-1.10.0-dns-resolver.yaml
@@ -124,16 +124,13 @@ spec:
       - name: dockercfg
       volumes:
       - configMap:
-          defaultMode: 256
           name: dns-resolver
         name: dns-resolver
       - name: openvpn-client-certificates
         secret:
-          defaultMode: 256
           secretName: openvpn-client-certificates
       - name: ca
         secret:
-          defaultMode: 256
           items:
           - key: ca.crt
             path: ca.crt

--- a/api/pkg/resources/test/fixtures/deployment-vsphere-1.10.0-kube-state-metrics.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-vsphere-1.10.0-kube-state-metrics.yaml
@@ -81,7 +81,6 @@ spec:
       volumes:
       - name: kube-state-metrics-kubeconfig
         secret:
-          defaultMode: 256
           secretName: kube-state-metrics-kubeconfig
       - emptyDir: {}
         name: http-prober-bin

--- a/api/pkg/resources/test/fixtures/deployment-vsphere-1.10.0-machine-controller-webhook.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-vsphere-1.10.0-machine-controller-webhook.yaml
@@ -91,11 +91,9 @@ spec:
       volumes:
       - name: machinecontroller-kubeconfig
         secret:
-          defaultMode: 292
           secretName: machinecontroller-kubeconfig
       - name: machinecontroller-webhook-serving-cert
         secret:
-          defaultMode: 292
           secretName: machinecontroller-webhook-serving-cert
       - emptyDir: {}
         name: http-prober-bin

--- a/api/pkg/resources/test/fixtures/deployment-vsphere-1.10.0-machine-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-vsphere-1.10.0-machine-controller.yaml
@@ -82,7 +82,6 @@ spec:
       volumes:
       - name: machinecontroller-kubeconfig
         secret:
-          defaultMode: 292
           secretName: machinecontroller-kubeconfig
       - emptyDir: {}
         name: http-prober-bin

--- a/api/pkg/resources/test/fixtures/deployment-vsphere-1.10.0-metrics-server.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-vsphere-1.10.0-metrics-server.yaml
@@ -164,15 +164,12 @@ spec:
       volumes:
       - name: metrics-server
         secret:
-          defaultMode: 292
           secretName: metrics-server
       - name: openvpn-client-certificates
         secret:
-          defaultMode: 256
           secretName: openvpn-client-certificates
       - name: kubeletdnatcontroller-kubeconfig
         secret:
-          defaultMode: 292
           secretName: kubeletdnatcontroller-kubeconfig
       - emptyDir: {}
         name: http-prober-bin

--- a/api/pkg/resources/test/fixtures/deployment-vsphere-1.10.0-openvpn-server.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-vsphere-1.10.0-openvpn-server.yaml
@@ -178,17 +178,14 @@ spec:
       volumes:
       - name: ca
         secret:
-          defaultMode: 256
           items:
           - key: ca.crt
             path: ca.crt
           secretName: openvpn-ca
       - name: openvpn-server-certificates
         secret:
-          defaultMode: 256
           secretName: openvpn-server-certificates
       - configMap:
-          defaultMode: 256
           name: openvpn-client-configs
         name: openvpn-client-configs
 status: {}

--- a/api/pkg/resources/test/fixtures/deployment-vsphere-1.10.0-scheduler.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-vsphere-1.10.0-scheduler.yaml
@@ -172,18 +172,15 @@ spec:
       volumes:
       - name: openvpn-client-certificates
         secret:
-          defaultMode: 256
           secretName: openvpn-client-certificates
       - name: ca
         secret:
-          defaultMode: 256
           items:
           - key: ca.crt
             path: ca.crt
           secretName: ca
       - name: scheduler-kubeconfig
         secret:
-          defaultMode: 256
           secretName: scheduler-kubeconfig
       - emptyDir: {}
         name: http-prober-bin

--- a/api/pkg/resources/test/fixtures/deployment-vsphere-1.10.0-usercluster-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-vsphere-1.10.0-usercluster-controller.yaml
@@ -94,18 +94,15 @@ spec:
       volumes:
       - name: internal-admin-kubeconfig
         secret:
-          defaultMode: 292
           secretName: internal-admin-kubeconfig
       - name: ca
         secret:
-          defaultMode: 292
           items:
           - key: ca.crt
             path: ca.crt
           secretName: ca
       - name: openvpn-ca
         secret:
-          defaultMode: 292
           secretName: openvpn-ca
       - emptyDir: {}
         name: http-prober-bin

--- a/api/pkg/resources/test/fixtures/deployment-vsphere-1.10.6-apiserver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-vsphere-1.10.6-apiserver.yaml
@@ -313,53 +313,41 @@ spec:
       volumes:
       - name: apiserver-tls
         secret:
-          defaultMode: 256
           secretName: apiserver-tls
       - name: tokens
         secret:
-          defaultMode: 256
           secretName: tokens
       - name: openvpn-client-certificates
         secret:
-          defaultMode: 256
           secretName: openvpn-client-certificates
       - name: kubelet-client-certificates
         secret:
-          defaultMode: 256
           secretName: kubelet-client-certificates
       - name: ca
         secret:
-          defaultMode: 256
           items:
           - key: ca.crt
             path: ca.crt
           secretName: ca
       - name: service-account-key
         secret:
-          defaultMode: 256
           secretName: service-account-key
       - configMap:
-          defaultMode: 420
           name: cloud-config
         name: cloud-config
       - name: apiserver-etcd-client-certificate
         secret:
-          defaultMode: 256
           secretName: apiserver-etcd-client-certificate
       - name: apiserver-proxy-client-certificate
         secret:
-          defaultMode: 256
           secretName: apiserver-proxy-client-certificate
       - name: front-proxy-ca
         secret:
-          defaultMode: 256
           secretName: front-proxy-ca
       - name: kubeletdnatcontroller-kubeconfig
         secret:
-          defaultMode: 292
           secretName: kubeletdnatcontroller-kubeconfig
       - name: dex-ca
         secret:
-          defaultMode: 256
           secretName: dex-ca
 status: {}

--- a/api/pkg/resources/test/fixtures/deployment-vsphere-1.10.6-controller-manager.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-vsphere-1.10.6-controller-manager.yaml
@@ -184,23 +184,18 @@ spec:
       volumes:
       - name: ca
         secret:
-          defaultMode: 256
           secretName: ca
       - name: service-account-key
         secret:
-          defaultMode: 256
           secretName: service-account-key
       - configMap:
-          defaultMode: 420
           name: cloud-config
         name: cloud-config
       - name: openvpn-client-certificates
         secret:
-          defaultMode: 256
           secretName: openvpn-client-certificates
       - name: controllermanager-kubeconfig
         secret:
-          defaultMode: 256
           secretName: controllermanager-kubeconfig
       - emptyDir: {}
         name: http-prober-bin

--- a/api/pkg/resources/test/fixtures/deployment-vsphere-1.10.6-dns-resolver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-vsphere-1.10.6-dns-resolver.yaml
@@ -124,16 +124,13 @@ spec:
       - name: dockercfg
       volumes:
       - configMap:
-          defaultMode: 256
           name: dns-resolver
         name: dns-resolver
       - name: openvpn-client-certificates
         secret:
-          defaultMode: 256
           secretName: openvpn-client-certificates
       - name: ca
         secret:
-          defaultMode: 256
           items:
           - key: ca.crt
             path: ca.crt

--- a/api/pkg/resources/test/fixtures/deployment-vsphere-1.10.6-kube-state-metrics.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-vsphere-1.10.6-kube-state-metrics.yaml
@@ -81,7 +81,6 @@ spec:
       volumes:
       - name: kube-state-metrics-kubeconfig
         secret:
-          defaultMode: 256
           secretName: kube-state-metrics-kubeconfig
       - emptyDir: {}
         name: http-prober-bin

--- a/api/pkg/resources/test/fixtures/deployment-vsphere-1.10.6-machine-controller-webhook.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-vsphere-1.10.6-machine-controller-webhook.yaml
@@ -91,11 +91,9 @@ spec:
       volumes:
       - name: machinecontroller-kubeconfig
         secret:
-          defaultMode: 292
           secretName: machinecontroller-kubeconfig
       - name: machinecontroller-webhook-serving-cert
         secret:
-          defaultMode: 292
           secretName: machinecontroller-webhook-serving-cert
       - emptyDir: {}
         name: http-prober-bin

--- a/api/pkg/resources/test/fixtures/deployment-vsphere-1.10.6-machine-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-vsphere-1.10.6-machine-controller.yaml
@@ -82,7 +82,6 @@ spec:
       volumes:
       - name: machinecontroller-kubeconfig
         secret:
-          defaultMode: 292
           secretName: machinecontroller-kubeconfig
       - emptyDir: {}
         name: http-prober-bin

--- a/api/pkg/resources/test/fixtures/deployment-vsphere-1.10.6-metrics-server.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-vsphere-1.10.6-metrics-server.yaml
@@ -164,15 +164,12 @@ spec:
       volumes:
       - name: metrics-server
         secret:
-          defaultMode: 292
           secretName: metrics-server
       - name: openvpn-client-certificates
         secret:
-          defaultMode: 256
           secretName: openvpn-client-certificates
       - name: kubeletdnatcontroller-kubeconfig
         secret:
-          defaultMode: 292
           secretName: kubeletdnatcontroller-kubeconfig
       - emptyDir: {}
         name: http-prober-bin

--- a/api/pkg/resources/test/fixtures/deployment-vsphere-1.10.6-openvpn-server.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-vsphere-1.10.6-openvpn-server.yaml
@@ -178,17 +178,14 @@ spec:
       volumes:
       - name: ca
         secret:
-          defaultMode: 256
           items:
           - key: ca.crt
             path: ca.crt
           secretName: openvpn-ca
       - name: openvpn-server-certificates
         secret:
-          defaultMode: 256
           secretName: openvpn-server-certificates
       - configMap:
-          defaultMode: 256
           name: openvpn-client-configs
         name: openvpn-client-configs
 status: {}

--- a/api/pkg/resources/test/fixtures/deployment-vsphere-1.10.6-scheduler.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-vsphere-1.10.6-scheduler.yaml
@@ -172,18 +172,15 @@ spec:
       volumes:
       - name: openvpn-client-certificates
         secret:
-          defaultMode: 256
           secretName: openvpn-client-certificates
       - name: ca
         secret:
-          defaultMode: 256
           items:
           - key: ca.crt
             path: ca.crt
           secretName: ca
       - name: scheduler-kubeconfig
         secret:
-          defaultMode: 256
           secretName: scheduler-kubeconfig
       - emptyDir: {}
         name: http-prober-bin

--- a/api/pkg/resources/test/fixtures/deployment-vsphere-1.10.6-usercluster-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-vsphere-1.10.6-usercluster-controller.yaml
@@ -94,18 +94,15 @@ spec:
       volumes:
       - name: internal-admin-kubeconfig
         secret:
-          defaultMode: 292
           secretName: internal-admin-kubeconfig
       - name: ca
         secret:
-          defaultMode: 292
           items:
           - key: ca.crt
             path: ca.crt
           secretName: ca
       - name: openvpn-ca
         secret:
-          defaultMode: 292
           secretName: openvpn-ca
       - emptyDir: {}
         name: http-prober-bin

--- a/api/pkg/resources/test/fixtures/deployment-vsphere-1.11.0-apiserver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-vsphere-1.11.0-apiserver.yaml
@@ -311,53 +311,41 @@ spec:
       volumes:
       - name: apiserver-tls
         secret:
-          defaultMode: 256
           secretName: apiserver-tls
       - name: tokens
         secret:
-          defaultMode: 256
           secretName: tokens
       - name: openvpn-client-certificates
         secret:
-          defaultMode: 256
           secretName: openvpn-client-certificates
       - name: kubelet-client-certificates
         secret:
-          defaultMode: 256
           secretName: kubelet-client-certificates
       - name: ca
         secret:
-          defaultMode: 256
           items:
           - key: ca.crt
             path: ca.crt
           secretName: ca
       - name: service-account-key
         secret:
-          defaultMode: 256
           secretName: service-account-key
       - configMap:
-          defaultMode: 420
           name: cloud-config
         name: cloud-config
       - name: apiserver-etcd-client-certificate
         secret:
-          defaultMode: 256
           secretName: apiserver-etcd-client-certificate
       - name: apiserver-proxy-client-certificate
         secret:
-          defaultMode: 256
           secretName: apiserver-proxy-client-certificate
       - name: front-proxy-ca
         secret:
-          defaultMode: 256
           secretName: front-proxy-ca
       - name: kubeletdnatcontroller-kubeconfig
         secret:
-          defaultMode: 292
           secretName: kubeletdnatcontroller-kubeconfig
       - name: dex-ca
         secret:
-          defaultMode: 256
           secretName: dex-ca
 status: {}

--- a/api/pkg/resources/test/fixtures/deployment-vsphere-1.11.0-controller-manager.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-vsphere-1.11.0-controller-manager.yaml
@@ -184,23 +184,18 @@ spec:
       volumes:
       - name: ca
         secret:
-          defaultMode: 256
           secretName: ca
       - name: service-account-key
         secret:
-          defaultMode: 256
           secretName: service-account-key
       - configMap:
-          defaultMode: 420
           name: cloud-config
         name: cloud-config
       - name: openvpn-client-certificates
         secret:
-          defaultMode: 256
           secretName: openvpn-client-certificates
       - name: controllermanager-kubeconfig
         secret:
-          defaultMode: 256
           secretName: controllermanager-kubeconfig
       - emptyDir: {}
         name: http-prober-bin

--- a/api/pkg/resources/test/fixtures/deployment-vsphere-1.11.0-dns-resolver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-vsphere-1.11.0-dns-resolver.yaml
@@ -124,16 +124,13 @@ spec:
       - name: dockercfg
       volumes:
       - configMap:
-          defaultMode: 256
           name: dns-resolver
         name: dns-resolver
       - name: openvpn-client-certificates
         secret:
-          defaultMode: 256
           secretName: openvpn-client-certificates
       - name: ca
         secret:
-          defaultMode: 256
           items:
           - key: ca.crt
             path: ca.crt

--- a/api/pkg/resources/test/fixtures/deployment-vsphere-1.11.0-kube-state-metrics.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-vsphere-1.11.0-kube-state-metrics.yaml
@@ -81,7 +81,6 @@ spec:
       volumes:
       - name: kube-state-metrics-kubeconfig
         secret:
-          defaultMode: 256
           secretName: kube-state-metrics-kubeconfig
       - emptyDir: {}
         name: http-prober-bin

--- a/api/pkg/resources/test/fixtures/deployment-vsphere-1.11.0-machine-controller-webhook.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-vsphere-1.11.0-machine-controller-webhook.yaml
@@ -91,11 +91,9 @@ spec:
       volumes:
       - name: machinecontroller-kubeconfig
         secret:
-          defaultMode: 292
           secretName: machinecontroller-kubeconfig
       - name: machinecontroller-webhook-serving-cert
         secret:
-          defaultMode: 292
           secretName: machinecontroller-webhook-serving-cert
       - emptyDir: {}
         name: http-prober-bin

--- a/api/pkg/resources/test/fixtures/deployment-vsphere-1.11.0-machine-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-vsphere-1.11.0-machine-controller.yaml
@@ -82,7 +82,6 @@ spec:
       volumes:
       - name: machinecontroller-kubeconfig
         secret:
-          defaultMode: 292
           secretName: machinecontroller-kubeconfig
       - emptyDir: {}
         name: http-prober-bin

--- a/api/pkg/resources/test/fixtures/deployment-vsphere-1.11.0-metrics-server.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-vsphere-1.11.0-metrics-server.yaml
@@ -164,15 +164,12 @@ spec:
       volumes:
       - name: metrics-server
         secret:
-          defaultMode: 292
           secretName: metrics-server
       - name: openvpn-client-certificates
         secret:
-          defaultMode: 256
           secretName: openvpn-client-certificates
       - name: kubeletdnatcontroller-kubeconfig
         secret:
-          defaultMode: 292
           secretName: kubeletdnatcontroller-kubeconfig
       - emptyDir: {}
         name: http-prober-bin

--- a/api/pkg/resources/test/fixtures/deployment-vsphere-1.11.0-openvpn-server.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-vsphere-1.11.0-openvpn-server.yaml
@@ -178,17 +178,14 @@ spec:
       volumes:
       - name: ca
         secret:
-          defaultMode: 256
           items:
           - key: ca.crt
             path: ca.crt
           secretName: openvpn-ca
       - name: openvpn-server-certificates
         secret:
-          defaultMode: 256
           secretName: openvpn-server-certificates
       - configMap:
-          defaultMode: 256
           name: openvpn-client-configs
         name: openvpn-client-configs
 status: {}

--- a/api/pkg/resources/test/fixtures/deployment-vsphere-1.11.0-scheduler.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-vsphere-1.11.0-scheduler.yaml
@@ -172,18 +172,15 @@ spec:
       volumes:
       - name: openvpn-client-certificates
         secret:
-          defaultMode: 256
           secretName: openvpn-client-certificates
       - name: ca
         secret:
-          defaultMode: 256
           items:
           - key: ca.crt
             path: ca.crt
           secretName: ca
       - name: scheduler-kubeconfig
         secret:
-          defaultMode: 256
           secretName: scheduler-kubeconfig
       - emptyDir: {}
         name: http-prober-bin

--- a/api/pkg/resources/test/fixtures/deployment-vsphere-1.11.0-usercluster-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-vsphere-1.11.0-usercluster-controller.yaml
@@ -94,18 +94,15 @@ spec:
       volumes:
       - name: internal-admin-kubeconfig
         secret:
-          defaultMode: 292
           secretName: internal-admin-kubeconfig
       - name: ca
         secret:
-          defaultMode: 292
           items:
           - key: ca.crt
             path: ca.crt
           secretName: ca
       - name: openvpn-ca
         secret:
-          defaultMode: 292
           secretName: openvpn-ca
       - emptyDir: {}
         name: http-prober-bin

--- a/api/pkg/resources/test/fixtures/deployment-vsphere-1.11.1-apiserver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-vsphere-1.11.1-apiserver.yaml
@@ -311,53 +311,41 @@ spec:
       volumes:
       - name: apiserver-tls
         secret:
-          defaultMode: 256
           secretName: apiserver-tls
       - name: tokens
         secret:
-          defaultMode: 256
           secretName: tokens
       - name: openvpn-client-certificates
         secret:
-          defaultMode: 256
           secretName: openvpn-client-certificates
       - name: kubelet-client-certificates
         secret:
-          defaultMode: 256
           secretName: kubelet-client-certificates
       - name: ca
         secret:
-          defaultMode: 256
           items:
           - key: ca.crt
             path: ca.crt
           secretName: ca
       - name: service-account-key
         secret:
-          defaultMode: 256
           secretName: service-account-key
       - configMap:
-          defaultMode: 420
           name: cloud-config
         name: cloud-config
       - name: apiserver-etcd-client-certificate
         secret:
-          defaultMode: 256
           secretName: apiserver-etcd-client-certificate
       - name: apiserver-proxy-client-certificate
         secret:
-          defaultMode: 256
           secretName: apiserver-proxy-client-certificate
       - name: front-proxy-ca
         secret:
-          defaultMode: 256
           secretName: front-proxy-ca
       - name: kubeletdnatcontroller-kubeconfig
         secret:
-          defaultMode: 292
           secretName: kubeletdnatcontroller-kubeconfig
       - name: dex-ca
         secret:
-          defaultMode: 256
           secretName: dex-ca
 status: {}

--- a/api/pkg/resources/test/fixtures/deployment-vsphere-1.11.1-controller-manager.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-vsphere-1.11.1-controller-manager.yaml
@@ -184,23 +184,18 @@ spec:
       volumes:
       - name: ca
         secret:
-          defaultMode: 256
           secretName: ca
       - name: service-account-key
         secret:
-          defaultMode: 256
           secretName: service-account-key
       - configMap:
-          defaultMode: 420
           name: cloud-config
         name: cloud-config
       - name: openvpn-client-certificates
         secret:
-          defaultMode: 256
           secretName: openvpn-client-certificates
       - name: controllermanager-kubeconfig
         secret:
-          defaultMode: 256
           secretName: controllermanager-kubeconfig
       - emptyDir: {}
         name: http-prober-bin

--- a/api/pkg/resources/test/fixtures/deployment-vsphere-1.11.1-dns-resolver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-vsphere-1.11.1-dns-resolver.yaml
@@ -124,16 +124,13 @@ spec:
       - name: dockercfg
       volumes:
       - configMap:
-          defaultMode: 256
           name: dns-resolver
         name: dns-resolver
       - name: openvpn-client-certificates
         secret:
-          defaultMode: 256
           secretName: openvpn-client-certificates
       - name: ca
         secret:
-          defaultMode: 256
           items:
           - key: ca.crt
             path: ca.crt

--- a/api/pkg/resources/test/fixtures/deployment-vsphere-1.11.1-kube-state-metrics.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-vsphere-1.11.1-kube-state-metrics.yaml
@@ -81,7 +81,6 @@ spec:
       volumes:
       - name: kube-state-metrics-kubeconfig
         secret:
-          defaultMode: 256
           secretName: kube-state-metrics-kubeconfig
       - emptyDir: {}
         name: http-prober-bin

--- a/api/pkg/resources/test/fixtures/deployment-vsphere-1.11.1-machine-controller-webhook.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-vsphere-1.11.1-machine-controller-webhook.yaml
@@ -91,11 +91,9 @@ spec:
       volumes:
       - name: machinecontroller-kubeconfig
         secret:
-          defaultMode: 292
           secretName: machinecontroller-kubeconfig
       - name: machinecontroller-webhook-serving-cert
         secret:
-          defaultMode: 292
           secretName: machinecontroller-webhook-serving-cert
       - emptyDir: {}
         name: http-prober-bin

--- a/api/pkg/resources/test/fixtures/deployment-vsphere-1.11.1-machine-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-vsphere-1.11.1-machine-controller.yaml
@@ -82,7 +82,6 @@ spec:
       volumes:
       - name: machinecontroller-kubeconfig
         secret:
-          defaultMode: 292
           secretName: machinecontroller-kubeconfig
       - emptyDir: {}
         name: http-prober-bin

--- a/api/pkg/resources/test/fixtures/deployment-vsphere-1.11.1-metrics-server.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-vsphere-1.11.1-metrics-server.yaml
@@ -164,15 +164,12 @@ spec:
       volumes:
       - name: metrics-server
         secret:
-          defaultMode: 292
           secretName: metrics-server
       - name: openvpn-client-certificates
         secret:
-          defaultMode: 256
           secretName: openvpn-client-certificates
       - name: kubeletdnatcontroller-kubeconfig
         secret:
-          defaultMode: 292
           secretName: kubeletdnatcontroller-kubeconfig
       - emptyDir: {}
         name: http-prober-bin

--- a/api/pkg/resources/test/fixtures/deployment-vsphere-1.11.1-openvpn-server.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-vsphere-1.11.1-openvpn-server.yaml
@@ -178,17 +178,14 @@ spec:
       volumes:
       - name: ca
         secret:
-          defaultMode: 256
           items:
           - key: ca.crt
             path: ca.crt
           secretName: openvpn-ca
       - name: openvpn-server-certificates
         secret:
-          defaultMode: 256
           secretName: openvpn-server-certificates
       - configMap:
-          defaultMode: 256
           name: openvpn-client-configs
         name: openvpn-client-configs
 status: {}

--- a/api/pkg/resources/test/fixtures/deployment-vsphere-1.11.1-scheduler.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-vsphere-1.11.1-scheduler.yaml
@@ -172,18 +172,15 @@ spec:
       volumes:
       - name: openvpn-client-certificates
         secret:
-          defaultMode: 256
           secretName: openvpn-client-certificates
       - name: ca
         secret:
-          defaultMode: 256
           items:
           - key: ca.crt
             path: ca.crt
           secretName: ca
       - name: scheduler-kubeconfig
         secret:
-          defaultMode: 256
           secretName: scheduler-kubeconfig
       - emptyDir: {}
         name: http-prober-bin

--- a/api/pkg/resources/test/fixtures/deployment-vsphere-1.11.1-usercluster-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-vsphere-1.11.1-usercluster-controller.yaml
@@ -94,18 +94,15 @@ spec:
       volumes:
       - name: internal-admin-kubeconfig
         secret:
-          defaultMode: 292
           secretName: internal-admin-kubeconfig
       - name: ca
         secret:
-          defaultMode: 292
           items:
           - key: ca.crt
             path: ca.crt
           secretName: ca
       - name: openvpn-ca
         secret:
-          defaultMode: 292
           secretName: openvpn-ca
       - emptyDir: {}
         name: http-prober-bin

--- a/api/pkg/resources/test/fixtures/deployment-vsphere-1.12.0-apiserver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-vsphere-1.12.0-apiserver.yaml
@@ -311,53 +311,41 @@ spec:
       volumes:
       - name: apiserver-tls
         secret:
-          defaultMode: 256
           secretName: apiserver-tls
       - name: tokens
         secret:
-          defaultMode: 256
           secretName: tokens
       - name: openvpn-client-certificates
         secret:
-          defaultMode: 256
           secretName: openvpn-client-certificates
       - name: kubelet-client-certificates
         secret:
-          defaultMode: 256
           secretName: kubelet-client-certificates
       - name: ca
         secret:
-          defaultMode: 256
           items:
           - key: ca.crt
             path: ca.crt
           secretName: ca
       - name: service-account-key
         secret:
-          defaultMode: 256
           secretName: service-account-key
       - configMap:
-          defaultMode: 420
           name: cloud-config
         name: cloud-config
       - name: apiserver-etcd-client-certificate
         secret:
-          defaultMode: 256
           secretName: apiserver-etcd-client-certificate
       - name: apiserver-proxy-client-certificate
         secret:
-          defaultMode: 256
           secretName: apiserver-proxy-client-certificate
       - name: front-proxy-ca
         secret:
-          defaultMode: 256
           secretName: front-proxy-ca
       - name: kubeletdnatcontroller-kubeconfig
         secret:
-          defaultMode: 292
           secretName: kubeletdnatcontroller-kubeconfig
       - name: dex-ca
         secret:
-          defaultMode: 256
           secretName: dex-ca
 status: {}

--- a/api/pkg/resources/test/fixtures/deployment-vsphere-1.12.0-controller-manager.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-vsphere-1.12.0-controller-manager.yaml
@@ -184,23 +184,18 @@ spec:
       volumes:
       - name: ca
         secret:
-          defaultMode: 256
           secretName: ca
       - name: service-account-key
         secret:
-          defaultMode: 256
           secretName: service-account-key
       - configMap:
-          defaultMode: 420
           name: cloud-config
         name: cloud-config
       - name: openvpn-client-certificates
         secret:
-          defaultMode: 256
           secretName: openvpn-client-certificates
       - name: controllermanager-kubeconfig
         secret:
-          defaultMode: 256
           secretName: controllermanager-kubeconfig
       - emptyDir: {}
         name: http-prober-bin

--- a/api/pkg/resources/test/fixtures/deployment-vsphere-1.12.0-dns-resolver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-vsphere-1.12.0-dns-resolver.yaml
@@ -124,16 +124,13 @@ spec:
       - name: dockercfg
       volumes:
       - configMap:
-          defaultMode: 256
           name: dns-resolver
         name: dns-resolver
       - name: openvpn-client-certificates
         secret:
-          defaultMode: 256
           secretName: openvpn-client-certificates
       - name: ca
         secret:
-          defaultMode: 256
           items:
           - key: ca.crt
             path: ca.crt

--- a/api/pkg/resources/test/fixtures/deployment-vsphere-1.12.0-kube-state-metrics.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-vsphere-1.12.0-kube-state-metrics.yaml
@@ -81,7 +81,6 @@ spec:
       volumes:
       - name: kube-state-metrics-kubeconfig
         secret:
-          defaultMode: 256
           secretName: kube-state-metrics-kubeconfig
       - emptyDir: {}
         name: http-prober-bin

--- a/api/pkg/resources/test/fixtures/deployment-vsphere-1.12.0-machine-controller-webhook.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-vsphere-1.12.0-machine-controller-webhook.yaml
@@ -91,11 +91,9 @@ spec:
       volumes:
       - name: machinecontroller-kubeconfig
         secret:
-          defaultMode: 292
           secretName: machinecontroller-kubeconfig
       - name: machinecontroller-webhook-serving-cert
         secret:
-          defaultMode: 292
           secretName: machinecontroller-webhook-serving-cert
       - emptyDir: {}
         name: http-prober-bin

--- a/api/pkg/resources/test/fixtures/deployment-vsphere-1.12.0-machine-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-vsphere-1.12.0-machine-controller.yaml
@@ -82,7 +82,6 @@ spec:
       volumes:
       - name: machinecontroller-kubeconfig
         secret:
-          defaultMode: 292
           secretName: machinecontroller-kubeconfig
       - emptyDir: {}
         name: http-prober-bin

--- a/api/pkg/resources/test/fixtures/deployment-vsphere-1.12.0-metrics-server.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-vsphere-1.12.0-metrics-server.yaml
@@ -164,15 +164,12 @@ spec:
       volumes:
       - name: metrics-server
         secret:
-          defaultMode: 292
           secretName: metrics-server
       - name: openvpn-client-certificates
         secret:
-          defaultMode: 256
           secretName: openvpn-client-certificates
       - name: kubeletdnatcontroller-kubeconfig
         secret:
-          defaultMode: 292
           secretName: kubeletdnatcontroller-kubeconfig
       - emptyDir: {}
         name: http-prober-bin

--- a/api/pkg/resources/test/fixtures/deployment-vsphere-1.12.0-openvpn-server.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-vsphere-1.12.0-openvpn-server.yaml
@@ -178,17 +178,14 @@ spec:
       volumes:
       - name: ca
         secret:
-          defaultMode: 256
           items:
           - key: ca.crt
             path: ca.crt
           secretName: openvpn-ca
       - name: openvpn-server-certificates
         secret:
-          defaultMode: 256
           secretName: openvpn-server-certificates
       - configMap:
-          defaultMode: 256
           name: openvpn-client-configs
         name: openvpn-client-configs
 status: {}

--- a/api/pkg/resources/test/fixtures/deployment-vsphere-1.12.0-scheduler.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-vsphere-1.12.0-scheduler.yaml
@@ -172,18 +172,15 @@ spec:
       volumes:
       - name: openvpn-client-certificates
         secret:
-          defaultMode: 256
           secretName: openvpn-client-certificates
       - name: ca
         secret:
-          defaultMode: 256
           items:
           - key: ca.crt
             path: ca.crt
           secretName: ca
       - name: scheduler-kubeconfig
         secret:
-          defaultMode: 256
           secretName: scheduler-kubeconfig
       - emptyDir: {}
         name: http-prober-bin

--- a/api/pkg/resources/test/fixtures/deployment-vsphere-1.12.0-usercluster-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-vsphere-1.12.0-usercluster-controller.yaml
@@ -94,18 +94,15 @@ spec:
       volumes:
       - name: internal-admin-kubeconfig
         secret:
-          defaultMode: 292
           secretName: internal-admin-kubeconfig
       - name: ca
         secret:
-          defaultMode: 292
           items:
           - key: ca.crt
             path: ca.crt
           secretName: ca
       - name: openvpn-ca
         secret:
-          defaultMode: 292
           secretName: openvpn-ca
       - emptyDir: {}
         name: http-prober-bin

--- a/api/pkg/resources/test/fixtures/deployment-vsphere-1.13.0-apiserver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-vsphere-1.13.0-apiserver.yaml
@@ -311,53 +311,41 @@ spec:
       volumes:
       - name: apiserver-tls
         secret:
-          defaultMode: 256
           secretName: apiserver-tls
       - name: tokens
         secret:
-          defaultMode: 256
           secretName: tokens
       - name: openvpn-client-certificates
         secret:
-          defaultMode: 256
           secretName: openvpn-client-certificates
       - name: kubelet-client-certificates
         secret:
-          defaultMode: 256
           secretName: kubelet-client-certificates
       - name: ca
         secret:
-          defaultMode: 256
           items:
           - key: ca.crt
             path: ca.crt
           secretName: ca
       - name: service-account-key
         secret:
-          defaultMode: 256
           secretName: service-account-key
       - configMap:
-          defaultMode: 420
           name: cloud-config
         name: cloud-config
       - name: apiserver-etcd-client-certificate
         secret:
-          defaultMode: 256
           secretName: apiserver-etcd-client-certificate
       - name: apiserver-proxy-client-certificate
         secret:
-          defaultMode: 256
           secretName: apiserver-proxy-client-certificate
       - name: front-proxy-ca
         secret:
-          defaultMode: 256
           secretName: front-proxy-ca
       - name: kubeletdnatcontroller-kubeconfig
         secret:
-          defaultMode: 292
           secretName: kubeletdnatcontroller-kubeconfig
       - name: dex-ca
         secret:
-          defaultMode: 256
           secretName: dex-ca
 status: {}

--- a/api/pkg/resources/test/fixtures/deployment-vsphere-1.13.0-controller-manager.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-vsphere-1.13.0-controller-manager.yaml
@@ -184,23 +184,18 @@ spec:
       volumes:
       - name: ca
         secret:
-          defaultMode: 256
           secretName: ca
       - name: service-account-key
         secret:
-          defaultMode: 256
           secretName: service-account-key
       - configMap:
-          defaultMode: 420
           name: cloud-config
         name: cloud-config
       - name: openvpn-client-certificates
         secret:
-          defaultMode: 256
           secretName: openvpn-client-certificates
       - name: controllermanager-kubeconfig
         secret:
-          defaultMode: 256
           secretName: controllermanager-kubeconfig
       - emptyDir: {}
         name: http-prober-bin

--- a/api/pkg/resources/test/fixtures/deployment-vsphere-1.13.0-dns-resolver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-vsphere-1.13.0-dns-resolver.yaml
@@ -124,16 +124,13 @@ spec:
       - name: dockercfg
       volumes:
       - configMap:
-          defaultMode: 256
           name: dns-resolver
         name: dns-resolver
       - name: openvpn-client-certificates
         secret:
-          defaultMode: 256
           secretName: openvpn-client-certificates
       - name: ca
         secret:
-          defaultMode: 256
           items:
           - key: ca.crt
             path: ca.crt

--- a/api/pkg/resources/test/fixtures/deployment-vsphere-1.13.0-kube-state-metrics.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-vsphere-1.13.0-kube-state-metrics.yaml
@@ -81,7 +81,6 @@ spec:
       volumes:
       - name: kube-state-metrics-kubeconfig
         secret:
-          defaultMode: 256
           secretName: kube-state-metrics-kubeconfig
       - emptyDir: {}
         name: http-prober-bin

--- a/api/pkg/resources/test/fixtures/deployment-vsphere-1.13.0-machine-controller-webhook.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-vsphere-1.13.0-machine-controller-webhook.yaml
@@ -91,11 +91,9 @@ spec:
       volumes:
       - name: machinecontroller-kubeconfig
         secret:
-          defaultMode: 292
           secretName: machinecontroller-kubeconfig
       - name: machinecontroller-webhook-serving-cert
         secret:
-          defaultMode: 292
           secretName: machinecontroller-webhook-serving-cert
       - emptyDir: {}
         name: http-prober-bin

--- a/api/pkg/resources/test/fixtures/deployment-vsphere-1.13.0-machine-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-vsphere-1.13.0-machine-controller.yaml
@@ -82,7 +82,6 @@ spec:
       volumes:
       - name: machinecontroller-kubeconfig
         secret:
-          defaultMode: 292
           secretName: machinecontroller-kubeconfig
       - emptyDir: {}
         name: http-prober-bin

--- a/api/pkg/resources/test/fixtures/deployment-vsphere-1.13.0-metrics-server.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-vsphere-1.13.0-metrics-server.yaml
@@ -164,15 +164,12 @@ spec:
       volumes:
       - name: metrics-server
         secret:
-          defaultMode: 292
           secretName: metrics-server
       - name: openvpn-client-certificates
         secret:
-          defaultMode: 256
           secretName: openvpn-client-certificates
       - name: kubeletdnatcontroller-kubeconfig
         secret:
-          defaultMode: 292
           secretName: kubeletdnatcontroller-kubeconfig
       - emptyDir: {}
         name: http-prober-bin

--- a/api/pkg/resources/test/fixtures/deployment-vsphere-1.13.0-openvpn-server.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-vsphere-1.13.0-openvpn-server.yaml
@@ -178,17 +178,14 @@ spec:
       volumes:
       - name: ca
         secret:
-          defaultMode: 256
           items:
           - key: ca.crt
             path: ca.crt
           secretName: openvpn-ca
       - name: openvpn-server-certificates
         secret:
-          defaultMode: 256
           secretName: openvpn-server-certificates
       - configMap:
-          defaultMode: 256
           name: openvpn-client-configs
         name: openvpn-client-configs
 status: {}

--- a/api/pkg/resources/test/fixtures/deployment-vsphere-1.13.0-scheduler.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-vsphere-1.13.0-scheduler.yaml
@@ -172,18 +172,15 @@ spec:
       volumes:
       - name: openvpn-client-certificates
         secret:
-          defaultMode: 256
           secretName: openvpn-client-certificates
       - name: ca
         secret:
-          defaultMode: 256
           items:
           - key: ca.crt
             path: ca.crt
           secretName: ca
       - name: scheduler-kubeconfig
         secret:
-          defaultMode: 256
           secretName: scheduler-kubeconfig
       - emptyDir: {}
         name: http-prober-bin

--- a/api/pkg/resources/test/fixtures/deployment-vsphere-1.13.0-usercluster-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-vsphere-1.13.0-usercluster-controller.yaml
@@ -94,18 +94,15 @@ spec:
       volumes:
       - name: internal-admin-kubeconfig
         secret:
-          defaultMode: 292
           secretName: internal-admin-kubeconfig
       - name: ca
         secret:
-          defaultMode: 292
           items:
           - key: ca.crt
             path: ca.crt
           secretName: ca
       - name: openvpn-ca
         secret:
-          defaultMode: 292
           secretName: openvpn-ca
       - emptyDir: {}
         name: http-prober-bin

--- a/api/pkg/resources/test/fixtures/statefulset-aws-1.10.0-etcd.yaml
+++ b/api/pkg/resources/test/fixtures/statefulset-aws-1.10.0-etcd.yaml
@@ -131,18 +131,15 @@ spec:
       volumes:
       - name: etcd-tls-certificate
         secret:
-          defaultMode: 256
           secretName: etcd-tls-certificate
       - name: ca
         secret:
-          defaultMode: 256
           items:
           - key: ca.crt
             path: ca.crt
           secretName: ca
       - name: apiserver-etcd-client-certificate
         secret:
-          defaultMode: 256
           secretName: apiserver-etcd-client-certificate
   updateStrategy:
     type: RollingUpdate

--- a/api/pkg/resources/test/fixtures/statefulset-aws-1.10.0-prometheus.yaml
+++ b/api/pkg/resources/test/fixtures/statefulset-aws-1.10.0-prometheus.yaml
@@ -94,18 +94,15 @@ spec:
       terminationGracePeriodSeconds: 0
       volumes:
       - configMap:
-          defaultMode: 256
           name: prometheus
         name: config
       - emptyDir: {}
         name: data
       - name: apiserver-etcd-client-certificate
         secret:
-          defaultMode: 256
           secretName: apiserver-etcd-client-certificate
       - name: prometheus-apiserver-certificate
         secret:
-          defaultMode: 256
           secretName: prometheus-apiserver-certificate
   updateStrategy:
     type: RollingUpdate

--- a/api/pkg/resources/test/fixtures/statefulset-aws-1.10.6-etcd.yaml
+++ b/api/pkg/resources/test/fixtures/statefulset-aws-1.10.6-etcd.yaml
@@ -131,18 +131,15 @@ spec:
       volumes:
       - name: etcd-tls-certificate
         secret:
-          defaultMode: 256
           secretName: etcd-tls-certificate
       - name: ca
         secret:
-          defaultMode: 256
           items:
           - key: ca.crt
             path: ca.crt
           secretName: ca
       - name: apiserver-etcd-client-certificate
         secret:
-          defaultMode: 256
           secretName: apiserver-etcd-client-certificate
   updateStrategy:
     type: RollingUpdate

--- a/api/pkg/resources/test/fixtures/statefulset-aws-1.10.6-prometheus.yaml
+++ b/api/pkg/resources/test/fixtures/statefulset-aws-1.10.6-prometheus.yaml
@@ -94,18 +94,15 @@ spec:
       terminationGracePeriodSeconds: 0
       volumes:
       - configMap:
-          defaultMode: 256
           name: prometheus
         name: config
       - emptyDir: {}
         name: data
       - name: apiserver-etcd-client-certificate
         secret:
-          defaultMode: 256
           secretName: apiserver-etcd-client-certificate
       - name: prometheus-apiserver-certificate
         secret:
-          defaultMode: 256
           secretName: prometheus-apiserver-certificate
   updateStrategy:
     type: RollingUpdate

--- a/api/pkg/resources/test/fixtures/statefulset-aws-1.11.0-etcd.yaml
+++ b/api/pkg/resources/test/fixtures/statefulset-aws-1.11.0-etcd.yaml
@@ -131,18 +131,15 @@ spec:
       volumes:
       - name: etcd-tls-certificate
         secret:
-          defaultMode: 256
           secretName: etcd-tls-certificate
       - name: ca
         secret:
-          defaultMode: 256
           items:
           - key: ca.crt
             path: ca.crt
           secretName: ca
       - name: apiserver-etcd-client-certificate
         secret:
-          defaultMode: 256
           secretName: apiserver-etcd-client-certificate
   updateStrategy:
     type: RollingUpdate

--- a/api/pkg/resources/test/fixtures/statefulset-aws-1.11.0-prometheus.yaml
+++ b/api/pkg/resources/test/fixtures/statefulset-aws-1.11.0-prometheus.yaml
@@ -94,18 +94,15 @@ spec:
       terminationGracePeriodSeconds: 0
       volumes:
       - configMap:
-          defaultMode: 256
           name: prometheus
         name: config
       - emptyDir: {}
         name: data
       - name: apiserver-etcd-client-certificate
         secret:
-          defaultMode: 256
           secretName: apiserver-etcd-client-certificate
       - name: prometheus-apiserver-certificate
         secret:
-          defaultMode: 256
           secretName: prometheus-apiserver-certificate
   updateStrategy:
     type: RollingUpdate

--- a/api/pkg/resources/test/fixtures/statefulset-aws-1.11.1-etcd.yaml
+++ b/api/pkg/resources/test/fixtures/statefulset-aws-1.11.1-etcd.yaml
@@ -131,18 +131,15 @@ spec:
       volumes:
       - name: etcd-tls-certificate
         secret:
-          defaultMode: 256
           secretName: etcd-tls-certificate
       - name: ca
         secret:
-          defaultMode: 256
           items:
           - key: ca.crt
             path: ca.crt
           secretName: ca
       - name: apiserver-etcd-client-certificate
         secret:
-          defaultMode: 256
           secretName: apiserver-etcd-client-certificate
   updateStrategy:
     type: RollingUpdate

--- a/api/pkg/resources/test/fixtures/statefulset-aws-1.11.1-prometheus.yaml
+++ b/api/pkg/resources/test/fixtures/statefulset-aws-1.11.1-prometheus.yaml
@@ -94,18 +94,15 @@ spec:
       terminationGracePeriodSeconds: 0
       volumes:
       - configMap:
-          defaultMode: 256
           name: prometheus
         name: config
       - emptyDir: {}
         name: data
       - name: apiserver-etcd-client-certificate
         secret:
-          defaultMode: 256
           secretName: apiserver-etcd-client-certificate
       - name: prometheus-apiserver-certificate
         secret:
-          defaultMode: 256
           secretName: prometheus-apiserver-certificate
   updateStrategy:
     type: RollingUpdate

--- a/api/pkg/resources/test/fixtures/statefulset-aws-1.12.0-etcd.yaml
+++ b/api/pkg/resources/test/fixtures/statefulset-aws-1.12.0-etcd.yaml
@@ -131,18 +131,15 @@ spec:
       volumes:
       - name: etcd-tls-certificate
         secret:
-          defaultMode: 256
           secretName: etcd-tls-certificate
       - name: ca
         secret:
-          defaultMode: 256
           items:
           - key: ca.crt
             path: ca.crt
           secretName: ca
       - name: apiserver-etcd-client-certificate
         secret:
-          defaultMode: 256
           secretName: apiserver-etcd-client-certificate
   updateStrategy:
     type: RollingUpdate

--- a/api/pkg/resources/test/fixtures/statefulset-aws-1.12.0-prometheus.yaml
+++ b/api/pkg/resources/test/fixtures/statefulset-aws-1.12.0-prometheus.yaml
@@ -94,18 +94,15 @@ spec:
       terminationGracePeriodSeconds: 0
       volumes:
       - configMap:
-          defaultMode: 256
           name: prometheus
         name: config
       - emptyDir: {}
         name: data
       - name: apiserver-etcd-client-certificate
         secret:
-          defaultMode: 256
           secretName: apiserver-etcd-client-certificate
       - name: prometheus-apiserver-certificate
         secret:
-          defaultMode: 256
           secretName: prometheus-apiserver-certificate
   updateStrategy:
     type: RollingUpdate

--- a/api/pkg/resources/test/fixtures/statefulset-aws-1.13.0-etcd.yaml
+++ b/api/pkg/resources/test/fixtures/statefulset-aws-1.13.0-etcd.yaml
@@ -131,18 +131,15 @@ spec:
       volumes:
       - name: etcd-tls-certificate
         secret:
-          defaultMode: 256
           secretName: etcd-tls-certificate
       - name: ca
         secret:
-          defaultMode: 256
           items:
           - key: ca.crt
             path: ca.crt
           secretName: ca
       - name: apiserver-etcd-client-certificate
         secret:
-          defaultMode: 256
           secretName: apiserver-etcd-client-certificate
   updateStrategy:
     type: RollingUpdate

--- a/api/pkg/resources/test/fixtures/statefulset-aws-1.13.0-prometheus.yaml
+++ b/api/pkg/resources/test/fixtures/statefulset-aws-1.13.0-prometheus.yaml
@@ -94,18 +94,15 @@ spec:
       terminationGracePeriodSeconds: 0
       volumes:
       - configMap:
-          defaultMode: 256
           name: prometheus
         name: config
       - emptyDir: {}
         name: data
       - name: apiserver-etcd-client-certificate
         secret:
-          defaultMode: 256
           secretName: apiserver-etcd-client-certificate
       - name: prometheus-apiserver-certificate
         secret:
-          defaultMode: 256
           secretName: prometheus-apiserver-certificate
   updateStrategy:
     type: RollingUpdate

--- a/api/pkg/resources/test/fixtures/statefulset-azure-1.10.0-etcd.yaml
+++ b/api/pkg/resources/test/fixtures/statefulset-azure-1.10.0-etcd.yaml
@@ -131,18 +131,15 @@ spec:
       volumes:
       - name: etcd-tls-certificate
         secret:
-          defaultMode: 256
           secretName: etcd-tls-certificate
       - name: ca
         secret:
-          defaultMode: 256
           items:
           - key: ca.crt
             path: ca.crt
           secretName: ca
       - name: apiserver-etcd-client-certificate
         secret:
-          defaultMode: 256
           secretName: apiserver-etcd-client-certificate
   updateStrategy:
     type: RollingUpdate

--- a/api/pkg/resources/test/fixtures/statefulset-azure-1.10.0-prometheus.yaml
+++ b/api/pkg/resources/test/fixtures/statefulset-azure-1.10.0-prometheus.yaml
@@ -94,18 +94,15 @@ spec:
       terminationGracePeriodSeconds: 0
       volumes:
       - configMap:
-          defaultMode: 256
           name: prometheus
         name: config
       - emptyDir: {}
         name: data
       - name: apiserver-etcd-client-certificate
         secret:
-          defaultMode: 256
           secretName: apiserver-etcd-client-certificate
       - name: prometheus-apiserver-certificate
         secret:
-          defaultMode: 256
           secretName: prometheus-apiserver-certificate
   updateStrategy:
     type: RollingUpdate

--- a/api/pkg/resources/test/fixtures/statefulset-azure-1.10.6-etcd.yaml
+++ b/api/pkg/resources/test/fixtures/statefulset-azure-1.10.6-etcd.yaml
@@ -131,18 +131,15 @@ spec:
       volumes:
       - name: etcd-tls-certificate
         secret:
-          defaultMode: 256
           secretName: etcd-tls-certificate
       - name: ca
         secret:
-          defaultMode: 256
           items:
           - key: ca.crt
             path: ca.crt
           secretName: ca
       - name: apiserver-etcd-client-certificate
         secret:
-          defaultMode: 256
           secretName: apiserver-etcd-client-certificate
   updateStrategy:
     type: RollingUpdate

--- a/api/pkg/resources/test/fixtures/statefulset-azure-1.10.6-prometheus.yaml
+++ b/api/pkg/resources/test/fixtures/statefulset-azure-1.10.6-prometheus.yaml
@@ -94,18 +94,15 @@ spec:
       terminationGracePeriodSeconds: 0
       volumes:
       - configMap:
-          defaultMode: 256
           name: prometheus
         name: config
       - emptyDir: {}
         name: data
       - name: apiserver-etcd-client-certificate
         secret:
-          defaultMode: 256
           secretName: apiserver-etcd-client-certificate
       - name: prometheus-apiserver-certificate
         secret:
-          defaultMode: 256
           secretName: prometheus-apiserver-certificate
   updateStrategy:
     type: RollingUpdate

--- a/api/pkg/resources/test/fixtures/statefulset-azure-1.11.0-etcd.yaml
+++ b/api/pkg/resources/test/fixtures/statefulset-azure-1.11.0-etcd.yaml
@@ -131,18 +131,15 @@ spec:
       volumes:
       - name: etcd-tls-certificate
         secret:
-          defaultMode: 256
           secretName: etcd-tls-certificate
       - name: ca
         secret:
-          defaultMode: 256
           items:
           - key: ca.crt
             path: ca.crt
           secretName: ca
       - name: apiserver-etcd-client-certificate
         secret:
-          defaultMode: 256
           secretName: apiserver-etcd-client-certificate
   updateStrategy:
     type: RollingUpdate

--- a/api/pkg/resources/test/fixtures/statefulset-azure-1.11.0-prometheus.yaml
+++ b/api/pkg/resources/test/fixtures/statefulset-azure-1.11.0-prometheus.yaml
@@ -94,18 +94,15 @@ spec:
       terminationGracePeriodSeconds: 0
       volumes:
       - configMap:
-          defaultMode: 256
           name: prometheus
         name: config
       - emptyDir: {}
         name: data
       - name: apiserver-etcd-client-certificate
         secret:
-          defaultMode: 256
           secretName: apiserver-etcd-client-certificate
       - name: prometheus-apiserver-certificate
         secret:
-          defaultMode: 256
           secretName: prometheus-apiserver-certificate
   updateStrategy:
     type: RollingUpdate

--- a/api/pkg/resources/test/fixtures/statefulset-azure-1.11.1-etcd.yaml
+++ b/api/pkg/resources/test/fixtures/statefulset-azure-1.11.1-etcd.yaml
@@ -131,18 +131,15 @@ spec:
       volumes:
       - name: etcd-tls-certificate
         secret:
-          defaultMode: 256
           secretName: etcd-tls-certificate
       - name: ca
         secret:
-          defaultMode: 256
           items:
           - key: ca.crt
             path: ca.crt
           secretName: ca
       - name: apiserver-etcd-client-certificate
         secret:
-          defaultMode: 256
           secretName: apiserver-etcd-client-certificate
   updateStrategy:
     type: RollingUpdate

--- a/api/pkg/resources/test/fixtures/statefulset-azure-1.11.1-prometheus.yaml
+++ b/api/pkg/resources/test/fixtures/statefulset-azure-1.11.1-prometheus.yaml
@@ -94,18 +94,15 @@ spec:
       terminationGracePeriodSeconds: 0
       volumes:
       - configMap:
-          defaultMode: 256
           name: prometheus
         name: config
       - emptyDir: {}
         name: data
       - name: apiserver-etcd-client-certificate
         secret:
-          defaultMode: 256
           secretName: apiserver-etcd-client-certificate
       - name: prometheus-apiserver-certificate
         secret:
-          defaultMode: 256
           secretName: prometheus-apiserver-certificate
   updateStrategy:
     type: RollingUpdate

--- a/api/pkg/resources/test/fixtures/statefulset-azure-1.12.0-etcd.yaml
+++ b/api/pkg/resources/test/fixtures/statefulset-azure-1.12.0-etcd.yaml
@@ -131,18 +131,15 @@ spec:
       volumes:
       - name: etcd-tls-certificate
         secret:
-          defaultMode: 256
           secretName: etcd-tls-certificate
       - name: ca
         secret:
-          defaultMode: 256
           items:
           - key: ca.crt
             path: ca.crt
           secretName: ca
       - name: apiserver-etcd-client-certificate
         secret:
-          defaultMode: 256
           secretName: apiserver-etcd-client-certificate
   updateStrategy:
     type: RollingUpdate

--- a/api/pkg/resources/test/fixtures/statefulset-azure-1.12.0-prometheus.yaml
+++ b/api/pkg/resources/test/fixtures/statefulset-azure-1.12.0-prometheus.yaml
@@ -94,18 +94,15 @@ spec:
       terminationGracePeriodSeconds: 0
       volumes:
       - configMap:
-          defaultMode: 256
           name: prometheus
         name: config
       - emptyDir: {}
         name: data
       - name: apiserver-etcd-client-certificate
         secret:
-          defaultMode: 256
           secretName: apiserver-etcd-client-certificate
       - name: prometheus-apiserver-certificate
         secret:
-          defaultMode: 256
           secretName: prometheus-apiserver-certificate
   updateStrategy:
     type: RollingUpdate

--- a/api/pkg/resources/test/fixtures/statefulset-azure-1.13.0-etcd.yaml
+++ b/api/pkg/resources/test/fixtures/statefulset-azure-1.13.0-etcd.yaml
@@ -131,18 +131,15 @@ spec:
       volumes:
       - name: etcd-tls-certificate
         secret:
-          defaultMode: 256
           secretName: etcd-tls-certificate
       - name: ca
         secret:
-          defaultMode: 256
           items:
           - key: ca.crt
             path: ca.crt
           secretName: ca
       - name: apiserver-etcd-client-certificate
         secret:
-          defaultMode: 256
           secretName: apiserver-etcd-client-certificate
   updateStrategy:
     type: RollingUpdate

--- a/api/pkg/resources/test/fixtures/statefulset-azure-1.13.0-prometheus.yaml
+++ b/api/pkg/resources/test/fixtures/statefulset-azure-1.13.0-prometheus.yaml
@@ -94,18 +94,15 @@ spec:
       terminationGracePeriodSeconds: 0
       volumes:
       - configMap:
-          defaultMode: 256
           name: prometheus
         name: config
       - emptyDir: {}
         name: data
       - name: apiserver-etcd-client-certificate
         secret:
-          defaultMode: 256
           secretName: apiserver-etcd-client-certificate
       - name: prometheus-apiserver-certificate
         secret:
-          defaultMode: 256
           secretName: prometheus-apiserver-certificate
   updateStrategy:
     type: RollingUpdate

--- a/api/pkg/resources/test/fixtures/statefulset-bringyourown-1.10.0-etcd.yaml
+++ b/api/pkg/resources/test/fixtures/statefulset-bringyourown-1.10.0-etcd.yaml
@@ -131,18 +131,15 @@ spec:
       volumes:
       - name: etcd-tls-certificate
         secret:
-          defaultMode: 256
           secretName: etcd-tls-certificate
       - name: ca
         secret:
-          defaultMode: 256
           items:
           - key: ca.crt
             path: ca.crt
           secretName: ca
       - name: apiserver-etcd-client-certificate
         secret:
-          defaultMode: 256
           secretName: apiserver-etcd-client-certificate
   updateStrategy:
     type: RollingUpdate

--- a/api/pkg/resources/test/fixtures/statefulset-bringyourown-1.10.0-prometheus.yaml
+++ b/api/pkg/resources/test/fixtures/statefulset-bringyourown-1.10.0-prometheus.yaml
@@ -94,18 +94,15 @@ spec:
       terminationGracePeriodSeconds: 0
       volumes:
       - configMap:
-          defaultMode: 256
           name: prometheus
         name: config
       - emptyDir: {}
         name: data
       - name: apiserver-etcd-client-certificate
         secret:
-          defaultMode: 256
           secretName: apiserver-etcd-client-certificate
       - name: prometheus-apiserver-certificate
         secret:
-          defaultMode: 256
           secretName: prometheus-apiserver-certificate
   updateStrategy:
     type: RollingUpdate

--- a/api/pkg/resources/test/fixtures/statefulset-bringyourown-1.10.6-etcd.yaml
+++ b/api/pkg/resources/test/fixtures/statefulset-bringyourown-1.10.6-etcd.yaml
@@ -131,18 +131,15 @@ spec:
       volumes:
       - name: etcd-tls-certificate
         secret:
-          defaultMode: 256
           secretName: etcd-tls-certificate
       - name: ca
         secret:
-          defaultMode: 256
           items:
           - key: ca.crt
             path: ca.crt
           secretName: ca
       - name: apiserver-etcd-client-certificate
         secret:
-          defaultMode: 256
           secretName: apiserver-etcd-client-certificate
   updateStrategy:
     type: RollingUpdate

--- a/api/pkg/resources/test/fixtures/statefulset-bringyourown-1.10.6-prometheus.yaml
+++ b/api/pkg/resources/test/fixtures/statefulset-bringyourown-1.10.6-prometheus.yaml
@@ -94,18 +94,15 @@ spec:
       terminationGracePeriodSeconds: 0
       volumes:
       - configMap:
-          defaultMode: 256
           name: prometheus
         name: config
       - emptyDir: {}
         name: data
       - name: apiserver-etcd-client-certificate
         secret:
-          defaultMode: 256
           secretName: apiserver-etcd-client-certificate
       - name: prometheus-apiserver-certificate
         secret:
-          defaultMode: 256
           secretName: prometheus-apiserver-certificate
   updateStrategy:
     type: RollingUpdate

--- a/api/pkg/resources/test/fixtures/statefulset-bringyourown-1.11.0-etcd.yaml
+++ b/api/pkg/resources/test/fixtures/statefulset-bringyourown-1.11.0-etcd.yaml
@@ -131,18 +131,15 @@ spec:
       volumes:
       - name: etcd-tls-certificate
         secret:
-          defaultMode: 256
           secretName: etcd-tls-certificate
       - name: ca
         secret:
-          defaultMode: 256
           items:
           - key: ca.crt
             path: ca.crt
           secretName: ca
       - name: apiserver-etcd-client-certificate
         secret:
-          defaultMode: 256
           secretName: apiserver-etcd-client-certificate
   updateStrategy:
     type: RollingUpdate

--- a/api/pkg/resources/test/fixtures/statefulset-bringyourown-1.11.0-prometheus.yaml
+++ b/api/pkg/resources/test/fixtures/statefulset-bringyourown-1.11.0-prometheus.yaml
@@ -94,18 +94,15 @@ spec:
       terminationGracePeriodSeconds: 0
       volumes:
       - configMap:
-          defaultMode: 256
           name: prometheus
         name: config
       - emptyDir: {}
         name: data
       - name: apiserver-etcd-client-certificate
         secret:
-          defaultMode: 256
           secretName: apiserver-etcd-client-certificate
       - name: prometheus-apiserver-certificate
         secret:
-          defaultMode: 256
           secretName: prometheus-apiserver-certificate
   updateStrategy:
     type: RollingUpdate

--- a/api/pkg/resources/test/fixtures/statefulset-bringyourown-1.11.1-etcd.yaml
+++ b/api/pkg/resources/test/fixtures/statefulset-bringyourown-1.11.1-etcd.yaml
@@ -131,18 +131,15 @@ spec:
       volumes:
       - name: etcd-tls-certificate
         secret:
-          defaultMode: 256
           secretName: etcd-tls-certificate
       - name: ca
         secret:
-          defaultMode: 256
           items:
           - key: ca.crt
             path: ca.crt
           secretName: ca
       - name: apiserver-etcd-client-certificate
         secret:
-          defaultMode: 256
           secretName: apiserver-etcd-client-certificate
   updateStrategy:
     type: RollingUpdate

--- a/api/pkg/resources/test/fixtures/statefulset-bringyourown-1.11.1-prometheus.yaml
+++ b/api/pkg/resources/test/fixtures/statefulset-bringyourown-1.11.1-prometheus.yaml
@@ -94,18 +94,15 @@ spec:
       terminationGracePeriodSeconds: 0
       volumes:
       - configMap:
-          defaultMode: 256
           name: prometheus
         name: config
       - emptyDir: {}
         name: data
       - name: apiserver-etcd-client-certificate
         secret:
-          defaultMode: 256
           secretName: apiserver-etcd-client-certificate
       - name: prometheus-apiserver-certificate
         secret:
-          defaultMode: 256
           secretName: prometheus-apiserver-certificate
   updateStrategy:
     type: RollingUpdate

--- a/api/pkg/resources/test/fixtures/statefulset-bringyourown-1.12.0-etcd.yaml
+++ b/api/pkg/resources/test/fixtures/statefulset-bringyourown-1.12.0-etcd.yaml
@@ -131,18 +131,15 @@ spec:
       volumes:
       - name: etcd-tls-certificate
         secret:
-          defaultMode: 256
           secretName: etcd-tls-certificate
       - name: ca
         secret:
-          defaultMode: 256
           items:
           - key: ca.crt
             path: ca.crt
           secretName: ca
       - name: apiserver-etcd-client-certificate
         secret:
-          defaultMode: 256
           secretName: apiserver-etcd-client-certificate
   updateStrategy:
     type: RollingUpdate

--- a/api/pkg/resources/test/fixtures/statefulset-bringyourown-1.12.0-prometheus.yaml
+++ b/api/pkg/resources/test/fixtures/statefulset-bringyourown-1.12.0-prometheus.yaml
@@ -94,18 +94,15 @@ spec:
       terminationGracePeriodSeconds: 0
       volumes:
       - configMap:
-          defaultMode: 256
           name: prometheus
         name: config
       - emptyDir: {}
         name: data
       - name: apiserver-etcd-client-certificate
         secret:
-          defaultMode: 256
           secretName: apiserver-etcd-client-certificate
       - name: prometheus-apiserver-certificate
         secret:
-          defaultMode: 256
           secretName: prometheus-apiserver-certificate
   updateStrategy:
     type: RollingUpdate

--- a/api/pkg/resources/test/fixtures/statefulset-bringyourown-1.13.0-etcd.yaml
+++ b/api/pkg/resources/test/fixtures/statefulset-bringyourown-1.13.0-etcd.yaml
@@ -131,18 +131,15 @@ spec:
       volumes:
       - name: etcd-tls-certificate
         secret:
-          defaultMode: 256
           secretName: etcd-tls-certificate
       - name: ca
         secret:
-          defaultMode: 256
           items:
           - key: ca.crt
             path: ca.crt
           secretName: ca
       - name: apiserver-etcd-client-certificate
         secret:
-          defaultMode: 256
           secretName: apiserver-etcd-client-certificate
   updateStrategy:
     type: RollingUpdate

--- a/api/pkg/resources/test/fixtures/statefulset-bringyourown-1.13.0-prometheus.yaml
+++ b/api/pkg/resources/test/fixtures/statefulset-bringyourown-1.13.0-prometheus.yaml
@@ -94,18 +94,15 @@ spec:
       terminationGracePeriodSeconds: 0
       volumes:
       - configMap:
-          defaultMode: 256
           name: prometheus
         name: config
       - emptyDir: {}
         name: data
       - name: apiserver-etcd-client-certificate
         secret:
-          defaultMode: 256
           secretName: apiserver-etcd-client-certificate
       - name: prometheus-apiserver-certificate
         secret:
-          defaultMode: 256
           secretName: prometheus-apiserver-certificate
   updateStrategy:
     type: RollingUpdate

--- a/api/pkg/resources/test/fixtures/statefulset-digitalocean-1.10.0-etcd.yaml
+++ b/api/pkg/resources/test/fixtures/statefulset-digitalocean-1.10.0-etcd.yaml
@@ -131,18 +131,15 @@ spec:
       volumes:
       - name: etcd-tls-certificate
         secret:
-          defaultMode: 256
           secretName: etcd-tls-certificate
       - name: ca
         secret:
-          defaultMode: 256
           items:
           - key: ca.crt
             path: ca.crt
           secretName: ca
       - name: apiserver-etcd-client-certificate
         secret:
-          defaultMode: 256
           secretName: apiserver-etcd-client-certificate
   updateStrategy:
     type: RollingUpdate

--- a/api/pkg/resources/test/fixtures/statefulset-digitalocean-1.10.0-prometheus.yaml
+++ b/api/pkg/resources/test/fixtures/statefulset-digitalocean-1.10.0-prometheus.yaml
@@ -94,18 +94,15 @@ spec:
       terminationGracePeriodSeconds: 0
       volumes:
       - configMap:
-          defaultMode: 256
           name: prometheus
         name: config
       - emptyDir: {}
         name: data
       - name: apiserver-etcd-client-certificate
         secret:
-          defaultMode: 256
           secretName: apiserver-etcd-client-certificate
       - name: prometheus-apiserver-certificate
         secret:
-          defaultMode: 256
           secretName: prometheus-apiserver-certificate
   updateStrategy:
     type: RollingUpdate

--- a/api/pkg/resources/test/fixtures/statefulset-digitalocean-1.10.6-etcd.yaml
+++ b/api/pkg/resources/test/fixtures/statefulset-digitalocean-1.10.6-etcd.yaml
@@ -131,18 +131,15 @@ spec:
       volumes:
       - name: etcd-tls-certificate
         secret:
-          defaultMode: 256
           secretName: etcd-tls-certificate
       - name: ca
         secret:
-          defaultMode: 256
           items:
           - key: ca.crt
             path: ca.crt
           secretName: ca
       - name: apiserver-etcd-client-certificate
         secret:
-          defaultMode: 256
           secretName: apiserver-etcd-client-certificate
   updateStrategy:
     type: RollingUpdate

--- a/api/pkg/resources/test/fixtures/statefulset-digitalocean-1.10.6-prometheus.yaml
+++ b/api/pkg/resources/test/fixtures/statefulset-digitalocean-1.10.6-prometheus.yaml
@@ -94,18 +94,15 @@ spec:
       terminationGracePeriodSeconds: 0
       volumes:
       - configMap:
-          defaultMode: 256
           name: prometheus
         name: config
       - emptyDir: {}
         name: data
       - name: apiserver-etcd-client-certificate
         secret:
-          defaultMode: 256
           secretName: apiserver-etcd-client-certificate
       - name: prometheus-apiserver-certificate
         secret:
-          defaultMode: 256
           secretName: prometheus-apiserver-certificate
   updateStrategy:
     type: RollingUpdate

--- a/api/pkg/resources/test/fixtures/statefulset-digitalocean-1.11.0-etcd.yaml
+++ b/api/pkg/resources/test/fixtures/statefulset-digitalocean-1.11.0-etcd.yaml
@@ -131,18 +131,15 @@ spec:
       volumes:
       - name: etcd-tls-certificate
         secret:
-          defaultMode: 256
           secretName: etcd-tls-certificate
       - name: ca
         secret:
-          defaultMode: 256
           items:
           - key: ca.crt
             path: ca.crt
           secretName: ca
       - name: apiserver-etcd-client-certificate
         secret:
-          defaultMode: 256
           secretName: apiserver-etcd-client-certificate
   updateStrategy:
     type: RollingUpdate

--- a/api/pkg/resources/test/fixtures/statefulset-digitalocean-1.11.0-prometheus.yaml
+++ b/api/pkg/resources/test/fixtures/statefulset-digitalocean-1.11.0-prometheus.yaml
@@ -94,18 +94,15 @@ spec:
       terminationGracePeriodSeconds: 0
       volumes:
       - configMap:
-          defaultMode: 256
           name: prometheus
         name: config
       - emptyDir: {}
         name: data
       - name: apiserver-etcd-client-certificate
         secret:
-          defaultMode: 256
           secretName: apiserver-etcd-client-certificate
       - name: prometheus-apiserver-certificate
         secret:
-          defaultMode: 256
           secretName: prometheus-apiserver-certificate
   updateStrategy:
     type: RollingUpdate

--- a/api/pkg/resources/test/fixtures/statefulset-digitalocean-1.11.1-etcd.yaml
+++ b/api/pkg/resources/test/fixtures/statefulset-digitalocean-1.11.1-etcd.yaml
@@ -131,18 +131,15 @@ spec:
       volumes:
       - name: etcd-tls-certificate
         secret:
-          defaultMode: 256
           secretName: etcd-tls-certificate
       - name: ca
         secret:
-          defaultMode: 256
           items:
           - key: ca.crt
             path: ca.crt
           secretName: ca
       - name: apiserver-etcd-client-certificate
         secret:
-          defaultMode: 256
           secretName: apiserver-etcd-client-certificate
   updateStrategy:
     type: RollingUpdate

--- a/api/pkg/resources/test/fixtures/statefulset-digitalocean-1.11.1-prometheus.yaml
+++ b/api/pkg/resources/test/fixtures/statefulset-digitalocean-1.11.1-prometheus.yaml
@@ -94,18 +94,15 @@ spec:
       terminationGracePeriodSeconds: 0
       volumes:
       - configMap:
-          defaultMode: 256
           name: prometheus
         name: config
       - emptyDir: {}
         name: data
       - name: apiserver-etcd-client-certificate
         secret:
-          defaultMode: 256
           secretName: apiserver-etcd-client-certificate
       - name: prometheus-apiserver-certificate
         secret:
-          defaultMode: 256
           secretName: prometheus-apiserver-certificate
   updateStrategy:
     type: RollingUpdate

--- a/api/pkg/resources/test/fixtures/statefulset-digitalocean-1.12.0-etcd.yaml
+++ b/api/pkg/resources/test/fixtures/statefulset-digitalocean-1.12.0-etcd.yaml
@@ -131,18 +131,15 @@ spec:
       volumes:
       - name: etcd-tls-certificate
         secret:
-          defaultMode: 256
           secretName: etcd-tls-certificate
       - name: ca
         secret:
-          defaultMode: 256
           items:
           - key: ca.crt
             path: ca.crt
           secretName: ca
       - name: apiserver-etcd-client-certificate
         secret:
-          defaultMode: 256
           secretName: apiserver-etcd-client-certificate
   updateStrategy:
     type: RollingUpdate

--- a/api/pkg/resources/test/fixtures/statefulset-digitalocean-1.12.0-prometheus.yaml
+++ b/api/pkg/resources/test/fixtures/statefulset-digitalocean-1.12.0-prometheus.yaml
@@ -94,18 +94,15 @@ spec:
       terminationGracePeriodSeconds: 0
       volumes:
       - configMap:
-          defaultMode: 256
           name: prometheus
         name: config
       - emptyDir: {}
         name: data
       - name: apiserver-etcd-client-certificate
         secret:
-          defaultMode: 256
           secretName: apiserver-etcd-client-certificate
       - name: prometheus-apiserver-certificate
         secret:
-          defaultMode: 256
           secretName: prometheus-apiserver-certificate
   updateStrategy:
     type: RollingUpdate

--- a/api/pkg/resources/test/fixtures/statefulset-digitalocean-1.13.0-etcd.yaml
+++ b/api/pkg/resources/test/fixtures/statefulset-digitalocean-1.13.0-etcd.yaml
@@ -131,18 +131,15 @@ spec:
       volumes:
       - name: etcd-tls-certificate
         secret:
-          defaultMode: 256
           secretName: etcd-tls-certificate
       - name: ca
         secret:
-          defaultMode: 256
           items:
           - key: ca.crt
             path: ca.crt
           secretName: ca
       - name: apiserver-etcd-client-certificate
         secret:
-          defaultMode: 256
           secretName: apiserver-etcd-client-certificate
   updateStrategy:
     type: RollingUpdate

--- a/api/pkg/resources/test/fixtures/statefulset-digitalocean-1.13.0-prometheus.yaml
+++ b/api/pkg/resources/test/fixtures/statefulset-digitalocean-1.13.0-prometheus.yaml
@@ -94,18 +94,15 @@ spec:
       terminationGracePeriodSeconds: 0
       volumes:
       - configMap:
-          defaultMode: 256
           name: prometheus
         name: config
       - emptyDir: {}
         name: data
       - name: apiserver-etcd-client-certificate
         secret:
-          defaultMode: 256
           secretName: apiserver-etcd-client-certificate
       - name: prometheus-apiserver-certificate
         secret:
-          defaultMode: 256
           secretName: prometheus-apiserver-certificate
   updateStrategy:
     type: RollingUpdate

--- a/api/pkg/resources/test/fixtures/statefulset-openstack-1.10.0-etcd.yaml
+++ b/api/pkg/resources/test/fixtures/statefulset-openstack-1.10.0-etcd.yaml
@@ -131,18 +131,15 @@ spec:
       volumes:
       - name: etcd-tls-certificate
         secret:
-          defaultMode: 256
           secretName: etcd-tls-certificate
       - name: ca
         secret:
-          defaultMode: 256
           items:
           - key: ca.crt
             path: ca.crt
           secretName: ca
       - name: apiserver-etcd-client-certificate
         secret:
-          defaultMode: 256
           secretName: apiserver-etcd-client-certificate
   updateStrategy:
     type: RollingUpdate

--- a/api/pkg/resources/test/fixtures/statefulset-openstack-1.10.0-prometheus.yaml
+++ b/api/pkg/resources/test/fixtures/statefulset-openstack-1.10.0-prometheus.yaml
@@ -94,18 +94,15 @@ spec:
       terminationGracePeriodSeconds: 0
       volumes:
       - configMap:
-          defaultMode: 256
           name: prometheus
         name: config
       - emptyDir: {}
         name: data
       - name: apiserver-etcd-client-certificate
         secret:
-          defaultMode: 256
           secretName: apiserver-etcd-client-certificate
       - name: prometheus-apiserver-certificate
         secret:
-          defaultMode: 256
           secretName: prometheus-apiserver-certificate
   updateStrategy:
     type: RollingUpdate

--- a/api/pkg/resources/test/fixtures/statefulset-openstack-1.10.6-etcd.yaml
+++ b/api/pkg/resources/test/fixtures/statefulset-openstack-1.10.6-etcd.yaml
@@ -131,18 +131,15 @@ spec:
       volumes:
       - name: etcd-tls-certificate
         secret:
-          defaultMode: 256
           secretName: etcd-tls-certificate
       - name: ca
         secret:
-          defaultMode: 256
           items:
           - key: ca.crt
             path: ca.crt
           secretName: ca
       - name: apiserver-etcd-client-certificate
         secret:
-          defaultMode: 256
           secretName: apiserver-etcd-client-certificate
   updateStrategy:
     type: RollingUpdate

--- a/api/pkg/resources/test/fixtures/statefulset-openstack-1.10.6-prometheus.yaml
+++ b/api/pkg/resources/test/fixtures/statefulset-openstack-1.10.6-prometheus.yaml
@@ -94,18 +94,15 @@ spec:
       terminationGracePeriodSeconds: 0
       volumes:
       - configMap:
-          defaultMode: 256
           name: prometheus
         name: config
       - emptyDir: {}
         name: data
       - name: apiserver-etcd-client-certificate
         secret:
-          defaultMode: 256
           secretName: apiserver-etcd-client-certificate
       - name: prometheus-apiserver-certificate
         secret:
-          defaultMode: 256
           secretName: prometheus-apiserver-certificate
   updateStrategy:
     type: RollingUpdate

--- a/api/pkg/resources/test/fixtures/statefulset-openstack-1.11.0-etcd.yaml
+++ b/api/pkg/resources/test/fixtures/statefulset-openstack-1.11.0-etcd.yaml
@@ -131,18 +131,15 @@ spec:
       volumes:
       - name: etcd-tls-certificate
         secret:
-          defaultMode: 256
           secretName: etcd-tls-certificate
       - name: ca
         secret:
-          defaultMode: 256
           items:
           - key: ca.crt
             path: ca.crt
           secretName: ca
       - name: apiserver-etcd-client-certificate
         secret:
-          defaultMode: 256
           secretName: apiserver-etcd-client-certificate
   updateStrategy:
     type: RollingUpdate

--- a/api/pkg/resources/test/fixtures/statefulset-openstack-1.11.0-prometheus.yaml
+++ b/api/pkg/resources/test/fixtures/statefulset-openstack-1.11.0-prometheus.yaml
@@ -94,18 +94,15 @@ spec:
       terminationGracePeriodSeconds: 0
       volumes:
       - configMap:
-          defaultMode: 256
           name: prometheus
         name: config
       - emptyDir: {}
         name: data
       - name: apiserver-etcd-client-certificate
         secret:
-          defaultMode: 256
           secretName: apiserver-etcd-client-certificate
       - name: prometheus-apiserver-certificate
         secret:
-          defaultMode: 256
           secretName: prometheus-apiserver-certificate
   updateStrategy:
     type: RollingUpdate

--- a/api/pkg/resources/test/fixtures/statefulset-openstack-1.11.1-etcd.yaml
+++ b/api/pkg/resources/test/fixtures/statefulset-openstack-1.11.1-etcd.yaml
@@ -131,18 +131,15 @@ spec:
       volumes:
       - name: etcd-tls-certificate
         secret:
-          defaultMode: 256
           secretName: etcd-tls-certificate
       - name: ca
         secret:
-          defaultMode: 256
           items:
           - key: ca.crt
             path: ca.crt
           secretName: ca
       - name: apiserver-etcd-client-certificate
         secret:
-          defaultMode: 256
           secretName: apiserver-etcd-client-certificate
   updateStrategy:
     type: RollingUpdate

--- a/api/pkg/resources/test/fixtures/statefulset-openstack-1.11.1-prometheus.yaml
+++ b/api/pkg/resources/test/fixtures/statefulset-openstack-1.11.1-prometheus.yaml
@@ -94,18 +94,15 @@ spec:
       terminationGracePeriodSeconds: 0
       volumes:
       - configMap:
-          defaultMode: 256
           name: prometheus
         name: config
       - emptyDir: {}
         name: data
       - name: apiserver-etcd-client-certificate
         secret:
-          defaultMode: 256
           secretName: apiserver-etcd-client-certificate
       - name: prometheus-apiserver-certificate
         secret:
-          defaultMode: 256
           secretName: prometheus-apiserver-certificate
   updateStrategy:
     type: RollingUpdate

--- a/api/pkg/resources/test/fixtures/statefulset-openstack-1.12.0-etcd.yaml
+++ b/api/pkg/resources/test/fixtures/statefulset-openstack-1.12.0-etcd.yaml
@@ -131,18 +131,15 @@ spec:
       volumes:
       - name: etcd-tls-certificate
         secret:
-          defaultMode: 256
           secretName: etcd-tls-certificate
       - name: ca
         secret:
-          defaultMode: 256
           items:
           - key: ca.crt
             path: ca.crt
           secretName: ca
       - name: apiserver-etcd-client-certificate
         secret:
-          defaultMode: 256
           secretName: apiserver-etcd-client-certificate
   updateStrategy:
     type: RollingUpdate

--- a/api/pkg/resources/test/fixtures/statefulset-openstack-1.12.0-prometheus.yaml
+++ b/api/pkg/resources/test/fixtures/statefulset-openstack-1.12.0-prometheus.yaml
@@ -94,18 +94,15 @@ spec:
       terminationGracePeriodSeconds: 0
       volumes:
       - configMap:
-          defaultMode: 256
           name: prometheus
         name: config
       - emptyDir: {}
         name: data
       - name: apiserver-etcd-client-certificate
         secret:
-          defaultMode: 256
           secretName: apiserver-etcd-client-certificate
       - name: prometheus-apiserver-certificate
         secret:
-          defaultMode: 256
           secretName: prometheus-apiserver-certificate
   updateStrategy:
     type: RollingUpdate

--- a/api/pkg/resources/test/fixtures/statefulset-openstack-1.13.0-etcd.yaml
+++ b/api/pkg/resources/test/fixtures/statefulset-openstack-1.13.0-etcd.yaml
@@ -131,18 +131,15 @@ spec:
       volumes:
       - name: etcd-tls-certificate
         secret:
-          defaultMode: 256
           secretName: etcd-tls-certificate
       - name: ca
         secret:
-          defaultMode: 256
           items:
           - key: ca.crt
             path: ca.crt
           secretName: ca
       - name: apiserver-etcd-client-certificate
         secret:
-          defaultMode: 256
           secretName: apiserver-etcd-client-certificate
   updateStrategy:
     type: RollingUpdate

--- a/api/pkg/resources/test/fixtures/statefulset-openstack-1.13.0-prometheus.yaml
+++ b/api/pkg/resources/test/fixtures/statefulset-openstack-1.13.0-prometheus.yaml
@@ -94,18 +94,15 @@ spec:
       terminationGracePeriodSeconds: 0
       volumes:
       - configMap:
-          defaultMode: 256
           name: prometheus
         name: config
       - emptyDir: {}
         name: data
       - name: apiserver-etcd-client-certificate
         secret:
-          defaultMode: 256
           secretName: apiserver-etcd-client-certificate
       - name: prometheus-apiserver-certificate
         secret:
-          defaultMode: 256
           secretName: prometheus-apiserver-certificate
   updateStrategy:
     type: RollingUpdate

--- a/api/pkg/resources/test/fixtures/statefulset-vsphere-1.10.0-etcd.yaml
+++ b/api/pkg/resources/test/fixtures/statefulset-vsphere-1.10.0-etcd.yaml
@@ -131,18 +131,15 @@ spec:
       volumes:
       - name: etcd-tls-certificate
         secret:
-          defaultMode: 256
           secretName: etcd-tls-certificate
       - name: ca
         secret:
-          defaultMode: 256
           items:
           - key: ca.crt
             path: ca.crt
           secretName: ca
       - name: apiserver-etcd-client-certificate
         secret:
-          defaultMode: 256
           secretName: apiserver-etcd-client-certificate
   updateStrategy:
     type: RollingUpdate

--- a/api/pkg/resources/test/fixtures/statefulset-vsphere-1.10.0-prometheus.yaml
+++ b/api/pkg/resources/test/fixtures/statefulset-vsphere-1.10.0-prometheus.yaml
@@ -94,18 +94,15 @@ spec:
       terminationGracePeriodSeconds: 0
       volumes:
       - configMap:
-          defaultMode: 256
           name: prometheus
         name: config
       - emptyDir: {}
         name: data
       - name: apiserver-etcd-client-certificate
         secret:
-          defaultMode: 256
           secretName: apiserver-etcd-client-certificate
       - name: prometheus-apiserver-certificate
         secret:
-          defaultMode: 256
           secretName: prometheus-apiserver-certificate
   updateStrategy:
     type: RollingUpdate

--- a/api/pkg/resources/test/fixtures/statefulset-vsphere-1.10.6-etcd.yaml
+++ b/api/pkg/resources/test/fixtures/statefulset-vsphere-1.10.6-etcd.yaml
@@ -131,18 +131,15 @@ spec:
       volumes:
       - name: etcd-tls-certificate
         secret:
-          defaultMode: 256
           secretName: etcd-tls-certificate
       - name: ca
         secret:
-          defaultMode: 256
           items:
           - key: ca.crt
             path: ca.crt
           secretName: ca
       - name: apiserver-etcd-client-certificate
         secret:
-          defaultMode: 256
           secretName: apiserver-etcd-client-certificate
   updateStrategy:
     type: RollingUpdate

--- a/api/pkg/resources/test/fixtures/statefulset-vsphere-1.10.6-prometheus.yaml
+++ b/api/pkg/resources/test/fixtures/statefulset-vsphere-1.10.6-prometheus.yaml
@@ -94,18 +94,15 @@ spec:
       terminationGracePeriodSeconds: 0
       volumes:
       - configMap:
-          defaultMode: 256
           name: prometheus
         name: config
       - emptyDir: {}
         name: data
       - name: apiserver-etcd-client-certificate
         secret:
-          defaultMode: 256
           secretName: apiserver-etcd-client-certificate
       - name: prometheus-apiserver-certificate
         secret:
-          defaultMode: 256
           secretName: prometheus-apiserver-certificate
   updateStrategy:
     type: RollingUpdate

--- a/api/pkg/resources/test/fixtures/statefulset-vsphere-1.11.0-etcd.yaml
+++ b/api/pkg/resources/test/fixtures/statefulset-vsphere-1.11.0-etcd.yaml
@@ -131,18 +131,15 @@ spec:
       volumes:
       - name: etcd-tls-certificate
         secret:
-          defaultMode: 256
           secretName: etcd-tls-certificate
       - name: ca
         secret:
-          defaultMode: 256
           items:
           - key: ca.crt
             path: ca.crt
           secretName: ca
       - name: apiserver-etcd-client-certificate
         secret:
-          defaultMode: 256
           secretName: apiserver-etcd-client-certificate
   updateStrategy:
     type: RollingUpdate

--- a/api/pkg/resources/test/fixtures/statefulset-vsphere-1.11.0-prometheus.yaml
+++ b/api/pkg/resources/test/fixtures/statefulset-vsphere-1.11.0-prometheus.yaml
@@ -94,18 +94,15 @@ spec:
       terminationGracePeriodSeconds: 0
       volumes:
       - configMap:
-          defaultMode: 256
           name: prometheus
         name: config
       - emptyDir: {}
         name: data
       - name: apiserver-etcd-client-certificate
         secret:
-          defaultMode: 256
           secretName: apiserver-etcd-client-certificate
       - name: prometheus-apiserver-certificate
         secret:
-          defaultMode: 256
           secretName: prometheus-apiserver-certificate
   updateStrategy:
     type: RollingUpdate

--- a/api/pkg/resources/test/fixtures/statefulset-vsphere-1.11.1-etcd.yaml
+++ b/api/pkg/resources/test/fixtures/statefulset-vsphere-1.11.1-etcd.yaml
@@ -131,18 +131,15 @@ spec:
       volumes:
       - name: etcd-tls-certificate
         secret:
-          defaultMode: 256
           secretName: etcd-tls-certificate
       - name: ca
         secret:
-          defaultMode: 256
           items:
           - key: ca.crt
             path: ca.crt
           secretName: ca
       - name: apiserver-etcd-client-certificate
         secret:
-          defaultMode: 256
           secretName: apiserver-etcd-client-certificate
   updateStrategy:
     type: RollingUpdate

--- a/api/pkg/resources/test/fixtures/statefulset-vsphere-1.11.1-prometheus.yaml
+++ b/api/pkg/resources/test/fixtures/statefulset-vsphere-1.11.1-prometheus.yaml
@@ -94,18 +94,15 @@ spec:
       terminationGracePeriodSeconds: 0
       volumes:
       - configMap:
-          defaultMode: 256
           name: prometheus
         name: config
       - emptyDir: {}
         name: data
       - name: apiserver-etcd-client-certificate
         secret:
-          defaultMode: 256
           secretName: apiserver-etcd-client-certificate
       - name: prometheus-apiserver-certificate
         secret:
-          defaultMode: 256
           secretName: prometheus-apiserver-certificate
   updateStrategy:
     type: RollingUpdate

--- a/api/pkg/resources/test/fixtures/statefulset-vsphere-1.12.0-etcd.yaml
+++ b/api/pkg/resources/test/fixtures/statefulset-vsphere-1.12.0-etcd.yaml
@@ -131,18 +131,15 @@ spec:
       volumes:
       - name: etcd-tls-certificate
         secret:
-          defaultMode: 256
           secretName: etcd-tls-certificate
       - name: ca
         secret:
-          defaultMode: 256
           items:
           - key: ca.crt
             path: ca.crt
           secretName: ca
       - name: apiserver-etcd-client-certificate
         secret:
-          defaultMode: 256
           secretName: apiserver-etcd-client-certificate
   updateStrategy:
     type: RollingUpdate

--- a/api/pkg/resources/test/fixtures/statefulset-vsphere-1.12.0-prometheus.yaml
+++ b/api/pkg/resources/test/fixtures/statefulset-vsphere-1.12.0-prometheus.yaml
@@ -94,18 +94,15 @@ spec:
       terminationGracePeriodSeconds: 0
       volumes:
       - configMap:
-          defaultMode: 256
           name: prometheus
         name: config
       - emptyDir: {}
         name: data
       - name: apiserver-etcd-client-certificate
         secret:
-          defaultMode: 256
           secretName: apiserver-etcd-client-certificate
       - name: prometheus-apiserver-certificate
         secret:
-          defaultMode: 256
           secretName: prometheus-apiserver-certificate
   updateStrategy:
     type: RollingUpdate

--- a/api/pkg/resources/test/fixtures/statefulset-vsphere-1.13.0-etcd.yaml
+++ b/api/pkg/resources/test/fixtures/statefulset-vsphere-1.13.0-etcd.yaml
@@ -131,18 +131,15 @@ spec:
       volumes:
       - name: etcd-tls-certificate
         secret:
-          defaultMode: 256
           secretName: etcd-tls-certificate
       - name: ca
         secret:
-          defaultMode: 256
           items:
           - key: ca.crt
             path: ca.crt
           secretName: ca
       - name: apiserver-etcd-client-certificate
         secret:
-          defaultMode: 256
           secretName: apiserver-etcd-client-certificate
   updateStrategy:
     type: RollingUpdate

--- a/api/pkg/resources/test/fixtures/statefulset-vsphere-1.13.0-prometheus.yaml
+++ b/api/pkg/resources/test/fixtures/statefulset-vsphere-1.13.0-prometheus.yaml
@@ -94,18 +94,15 @@ spec:
       terminationGracePeriodSeconds: 0
       volumes:
       - configMap:
-          defaultMode: 256
           name: prometheus
         name: config
       - emptyDir: {}
         name: data
       - name: apiserver-etcd-client-certificate
         secret:
-          defaultMode: 256
           secretName: apiserver-etcd-client-certificate
       - name: prometheus-apiserver-certificate
         secret:
-          defaultMode: 256
           secretName: prometheus-apiserver-certificate
   updateStrategy:
     type: RollingUpdate

--- a/api/pkg/resources/usercluster/deployment.go
+++ b/api/pkg/resources/usercluster/deployment.go
@@ -179,9 +179,6 @@ func getVolumes() []corev1.Volume {
 			VolumeSource: corev1.VolumeSource{
 				Secret: &corev1.SecretVolumeSource{
 					SecretName: resources.InternalUserClusterAdminKubeconfigSecretName,
-					// We have to make the secret readable for all for now because owner/group cannot be changed.
-					// ( upstream proposal: https://github.com/kubernetes/kubernetes/pull/28733 )
-					DefaultMode: resources.Int32(resources.DefaultAllReadOnlyMode),
 				},
 			},
 		},
@@ -189,8 +186,7 @@ func getVolumes() []corev1.Volume {
 			Name: resources.CASecretName,
 			VolumeSource: corev1.VolumeSource{
 				Secret: &corev1.SecretVolumeSource{
-					SecretName:  resources.CASecretName,
-					DefaultMode: resources.Int32(resources.DefaultAllReadOnlyMode),
+					SecretName: resources.CASecretName,
 					Items: []corev1.KeyToPath{
 						{
 							Path: resources.CACertSecretKey,
@@ -204,8 +200,7 @@ func getVolumes() []corev1.Volume {
 			Name: resources.OpenVPNCASecretName,
 			VolumeSource: corev1.VolumeSource{
 				Secret: &corev1.SecretVolumeSource{
-					SecretName:  resources.OpenVPNCASecretName,
-					DefaultMode: resources.Int32(resources.DefaultAllReadOnlyMode),
+					SecretName: resources.OpenVPNCASecretName,
 				},
 			},
 		},


### PR DESCRIPTION
**What this PR does / why we need it**:

Defaults the DefaultVolumeMode for secrets and configmaps in the reconciling package

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Documentation**:
<!-- Add links to the related documentation changes related to this pull request. E.g. the link to the kubermatic/docs pullrequest. -->

**Does this PR introduce a user-facing change?**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If  no release note is required, just write "NONE".
-->
```release-note
none
```

/assign @xrstf 