### PR TITLE
Initialize CloudProviders with a SecretKeyGetter

### DIFF
--- a/api/cmd/kubermatic-api/options.go
+++ b/api/cmd/kubermatic-api/options.go
@@ -148,5 +148,6 @@ type providers struct {
 	eventRecorderProvider                 provider.EventRecorderProvider
 	clusterProviderGetter                 provider.ClusterProviderGetter
 	seedsGetter                           provider.SeedsGetter
+	seedClientGetter                      provider.SeedClientGetter
 	addons                                provider.AddonProviderGetter
 }

--- a/api/pkg/controller/cloud/cloud_controller.go
+++ b/api/pkg/controller/cloud/cloud_controller.go
@@ -122,7 +122,7 @@ func (r *Reconciler) reconcile(ctx context.Context, log *zap.SugaredLogger, clus
 	if !found {
 		return nil, fmt.Errorf("couldn't find datacentrer %q for cluster %q", cluster.Spec.Cloud.DatacenterName, cluster.Name)
 	}
-	prov, err := cloud.Provider(datacenter.DeepCopy())
+	prov, err := cloud.Provider(datacenter.DeepCopy(), r.getGlobalSecretKeySelectorValue)
 	if err != nil {
 		return nil, err
 	}
@@ -135,7 +135,7 @@ func (r *Reconciler) reconcile(ctx context.Context, log *zap.SugaredLogger, clus
 			finalizers.Has(kubermaticapiv1.NodeDeletionFinalizer) {
 			return &reconcile.Result{RequeueAfter: 5 * time.Second}, nil
 		}
-		_, err := prov.CleanUpCloudProvider(cluster, r.updateCluster, r.getGlobalSecretKeySelectorValue)
+		_, err := prov.CleanUpCloudProvider(cluster, r.updateCluster)
 		return nil, err
 	}
 
@@ -154,7 +154,7 @@ func (r *Reconciler) reconcile(ctx context.Context, log *zap.SugaredLogger, clus
 		}
 	}
 
-	_, err = prov.InitializeCloudProvider(cluster, r.updateCluster, r.getGlobalSecretKeySelectorValue)
+	_, err = prov.InitializeCloudProvider(cluster, r.updateCluster)
 	return nil, err
 }
 

--- a/api/pkg/controller/cloud/cloud_controller.go
+++ b/api/pkg/controller/cloud/cloud_controller.go
@@ -190,7 +190,7 @@ func (r *Reconciler) migrateICMP(ctx context.Context, log *zap.SugaredLogger, cl
 
 func (r *Reconciler) migrateAWSMultiAZ(ctx context.Context, cluster *kubermaticv1.Cluster, cloudProvider provider.CloudProvider) error {
 	if prov, ok := cloudProvider.(*aws.AmazonEC2); ok {
-		if err := prov.MigrateToMultiAZ(cluster); err != nil {
+		if err := prov.MigrateToMultiAZ(cluster, r.updateCluster); err != nil {
 			return fmt.Errorf("failed to migrate AWS cluster %q to multi-AZ: %q", cluster.Name, err)
 		}
 	}

--- a/api/pkg/handler/middleware/middleware.go
+++ b/api/pkg/handler/middleware/middleware.go
@@ -275,7 +275,10 @@ func createUserInfo(user *kubermaticapiv1.User, projectID string, userProjectMap
 }
 
 func getClusterProvider(ctx context.Context, request interface{}, seedsGetter provider.SeedsGetter, clusterProviderGetter provider.ClusterProviderGetter) (provider.ClusterProvider, context.Context, error) {
-	getter := request.(dCGetter)
+	getter, ok := request.(dCGetter)
+	if !ok {
+		return nil, nil, fmt.Errorf("request is no dcGetter")
+	}
 	seeds, err := seedsGetter()
 	if err != nil {
 		return nil, ctx, errors.New(http.StatusInternalServerError, fmt.Sprintf("failed to list seeds: %v", err))

--- a/api/pkg/handler/routes_v1.go
+++ b/api/pkg/handler/routes_v1.go
@@ -524,8 +524,7 @@ func (r Routing) listAWSZones() http.Handler {
 		endpoint.Chain(
 			middleware.TokenVerifier(r.tokenVerifiers),
 			middleware.UserSaver(r.userProvider),
-			middleware.SetPrivilegedClusterProvider(r.clusterProviderGetter, r.seedsGetter),
-		)(provider.AWSZoneEndpoint(r.presetsManager, r.seedsGetter)),
+		)(provider.AWSZoneEndpoint(r.presetsManager, r.seedsGetter, r.privilegedSeedClientGetter)),
 		provider.DecodeAWSZoneReq,
 		encodeJSON,
 		r.defaultServerOptions()...,
@@ -547,8 +546,7 @@ func (r Routing) listAWSSubnets() http.Handler {
 		endpoint.Chain(
 			middleware.TokenVerifier(r.tokenVerifiers),
 			middleware.UserSaver(r.userProvider),
-			middleware.SetPrivilegedClusterProvider(r.clusterProviderGetter, r.seedsGetter),
-		)(provider.AWSSubnetEndpoint(r.presetsManager, r.seedsGetter)),
+		)(provider.AWSSubnetEndpoint(r.presetsManager, r.seedsGetter, r.privilegedSeedClientGetter)),
 		provider.DecodeAWSSubnetReq,
 		encodeJSON,
 		r.defaultServerOptions()...,
@@ -570,8 +568,7 @@ func (r Routing) listAWSVPCS() http.Handler {
 		endpoint.Chain(
 			middleware.TokenVerifier(r.tokenVerifiers),
 			middleware.UserSaver(r.userProvider),
-			middleware.SetPrivilegedClusterProvider(r.clusterProviderGetter, r.seedsGetter),
-		)(provider.AWSVPCEndpoint(r.presetsManager, r.seedsGetter)),
+		)(provider.AWSVPCEndpoint(r.presetsManager, r.seedsGetter, r.privilegedSeedClientGetter)),
 		provider.DecodeAWSVPCReq,
 		encodeJSON,
 		r.defaultServerOptions()...,

--- a/api/pkg/handler/routes_v1.go
+++ b/api/pkg/handler/routes_v1.go
@@ -524,6 +524,7 @@ func (r Routing) listAWSZones() http.Handler {
 		endpoint.Chain(
 			middleware.TokenVerifier(r.tokenVerifiers),
 			middleware.UserSaver(r.userProvider),
+			middleware.SetPrivilegedClusterProvider(r.clusterProviderGetter, r.seedsGetter),
 		)(provider.AWSZoneEndpoint(r.presetsManager, r.seedsGetter)),
 		provider.DecodeAWSZoneReq,
 		encodeJSON,
@@ -546,6 +547,7 @@ func (r Routing) listAWSSubnets() http.Handler {
 		endpoint.Chain(
 			middleware.TokenVerifier(r.tokenVerifiers),
 			middleware.UserSaver(r.userProvider),
+			middleware.SetPrivilegedClusterProvider(r.clusterProviderGetter, r.seedsGetter),
 		)(provider.AWSSubnetEndpoint(r.presetsManager, r.seedsGetter)),
 		provider.DecodeAWSSubnetReq,
 		encodeJSON,
@@ -568,6 +570,7 @@ func (r Routing) listAWSVPCS() http.Handler {
 		endpoint.Chain(
 			middleware.TokenVerifier(r.tokenVerifiers),
 			middleware.UserSaver(r.userProvider),
+			middleware.SetPrivilegedClusterProvider(r.clusterProviderGetter, r.seedsGetter),
 		)(provider.AWSVPCEndpoint(r.presetsManager, r.seedsGetter)),
 		provider.DecodeAWSVPCReq,
 		encodeJSON,

--- a/api/pkg/handler/routing.go
+++ b/api/pkg/handler/routing.go
@@ -29,6 +29,7 @@ type UpdateManager interface {
 // Routing represents an object which binds endpoints to http handlers.
 type Routing struct {
 	seedsGetter                 provider.SeedsGetter
+	privilegedSeedClientGetter  provider.SeedClientGetter
 	sshKeyProvider              provider.SSHKeyProvider
 	userProvider                provider.UserProvider
 	serviceAccountProvider      provider.ServiceAccountProvider
@@ -55,6 +56,7 @@ type Routing struct {
 // NewRouting creates a new Routing.
 func NewRouting(
 	seedsGetter provider.SeedsGetter,
+	seedClientGetter provider.SeedClientGetter,
 	clusterProviderGetter provider.ClusterProviderGetter,
 	addonProviderGetter provider.AddonProviderGetter,
 	newSSHKeyProvider provider.SSHKeyProvider,
@@ -78,6 +80,7 @@ func NewRouting(
 ) Routing {
 	return Routing{
 		seedsGetter:                 seedsGetter,
+		privilegedSeedClientGetter:  seedClientGetter,
 		clusterProviderGetter:       clusterProviderGetter,
 		addonProviderGetter:         addonProviderGetter,
 		sshKeyProvider:              newSSHKeyProvider,

--- a/api/pkg/handler/test/hack/hack.go
+++ b/api/pkg/handler/test/hack/hack.go
@@ -23,6 +23,7 @@ import (
 // for example handler package uses v1/dc and v1/dc needs handler for testing
 func NewTestRouting(
 	seedsGetter provider.SeedsGetter,
+	seedClientGetter provider.SeedClientGetter,
 	clusterProvidersGetter provider.ClusterProviderGetter,
 	addonProviderGetter provider.AddonProviderGetter,
 	sshKeyProvider provider.SSHKeyProvider,
@@ -46,6 +47,7 @@ func NewTestRouting(
 	updateManager := version.New(versions, updates)
 	r := handler.NewRouting(
 		seedsGetter,
+		seedClientGetter,
 		clusterProvidersGetter,
 		addonProviderGetter,
 		sshKeyProvider,

--- a/api/pkg/handler/test/helper.go
+++ b/api/pkg/handler/test/helper.go
@@ -115,6 +115,7 @@ func GetUser(email, id, name string, admin bool) apiv1.User {
 // it is meant to be used by legacy handler.createTestEndpointAndGetClients function
 type newRoutingFunc func(
 	seedsGetter provider.SeedsGetter,
+	privilgedClientGetter provider.SeedClientGetter,
 	clusterProviderGetter provider.ClusterProviderGetter,
 	addonProviderGetter provider.AddonProviderGetter,
 	newSSHKeyProvider provider.SSHKeyProvider,
@@ -143,6 +144,9 @@ func initTestEndpoint(user apiv1.User, seedsGetter provider.SeedsGetter, kubeObj
 	allObjects = append(allObjects, machineObjects...)
 	allObjects = append(allObjects, kubermaticObjects...)
 	fakeClient := fakectrlruntimeclient.NewFakeClient(allObjects...)
+	seedClientGetter := func(_ *kubermaticv1.Seed) (ctrlruntimeclient.Client, error) {
+		return fakeClient, nil
+	}
 	kubermaticClient := kubermaticfakeclentset.NewSimpleClientset(kubermaticObjects...)
 	kubermaticInformerFactory := kubermaticinformers.NewSharedInformerFactory(kubermaticClient, 10*time.Millisecond)
 	kubernetesClient := fakerestclient.NewSimpleClientset(kubeObjects...)
@@ -248,6 +252,7 @@ func initTestEndpoint(user apiv1.User, seedsGetter provider.SeedsGetter, kubeObj
 
 	mainRouter := routingFunc(
 		seedsGetter,
+		seedClientGetter,
 		clusterProviderGetter,
 		addonProviderGetter,
 		sshKeyProvider,

--- a/api/pkg/handler/v1/cluster/cluster.go
+++ b/api/pkg/handler/v1/cluster/cluster.go
@@ -82,7 +82,7 @@ func CreateEndpoint(sshKeyProvider provider.SSHKeyProvider, projectProvider prov
 			return apiv1.Datacenter{}, errors.New(http.StatusInternalServerError, fmt.Sprintf("failed to list seeds: %v", err))
 		}
 
-		dc, err := provider.DatacenterFromSeedMap(seeds, req.Body.Cluster.Spec.Cloud.DatacenterName)
+		_, dc, err := provider.DatacenterFromSeedMap(seeds, req.Body.Cluster.Spec.Cloud.DatacenterName)
 		if err != nil {
 			return nil, fmt.Errorf("error getting dc: %v", err)
 		}
@@ -210,7 +210,7 @@ func createInitialNodeDeployment(nodeDeployment *apiv1.NodeDeployment, cluster *
 		return err
 	}
 
-	dc, err := provider.DatacenterFromSeedMap(seeds, cluster.Spec.Cloud.DatacenterName)
+	_, dc, err := provider.DatacenterFromSeedMap(seeds, cluster.Spec.Cloud.DatacenterName)
 	if err != nil {
 		return fmt.Errorf("error getting dc: %v", err)
 	}
@@ -318,7 +318,7 @@ func PatchEndpoint(projectProvider provider.ProjectProvider, seedsGetter provide
 		if err != nil {
 			return apiv1.Datacenter{}, errors.New(http.StatusInternalServerError, fmt.Sprintf("failed to list seeds: %v", err))
 		}
-		dc, err := provider.DatacenterFromSeedMap(seeds, patchedCluster.Spec.Cloud.DatacenterName)
+		_, dc, err := provider.DatacenterFromSeedMap(seeds, patchedCluster.Spec.Cloud.DatacenterName)
 		if err != nil {
 			return nil, fmt.Errorf("error getting dc: %v", err)
 		}

--- a/api/pkg/handler/v1/node/node.go
+++ b/api/pkg/handler/v1/node/node.go
@@ -107,7 +107,7 @@ func CreateNodeDeployment(sshKeyProvider provider.SSHKeyProvider, projectProvide
 		if err != nil {
 			return apiv1.Datacenter{}, errors.New(http.StatusInternalServerError, fmt.Sprintf("failed to list seeds: %v", err))
 		}
-		dc, err := provider.DatacenterFromSeedMap(seeds, cluster.Spec.Cloud.DatacenterName)
+		_, dc, err := provider.DatacenterFromSeedMap(seeds, cluster.Spec.Cloud.DatacenterName)
 		if err != nil {
 			return nil, fmt.Errorf("error getting dc: %v", err)
 		}
@@ -556,7 +556,7 @@ func PatchNodeDeployment(sshKeyProvider provider.SSHKeyProvider, projectProvider
 		if err != nil {
 			return apiv1.Datacenter{}, errors.New(http.StatusInternalServerError, fmt.Sprintf("failed to list seeds: %v", err))
 		}
-		dc, err := provider.DatacenterFromSeedMap(seeds, cluster.Spec.Cloud.DatacenterName)
+		_, dc, err := provider.DatacenterFromSeedMap(seeds, cluster.Spec.Cloud.DatacenterName)
 		if err != nil {
 			return nil, fmt.Errorf("error getting dc: %v", err)
 		}

--- a/api/pkg/handler/v1/provider/openstack.go
+++ b/api/pkg/handler/v1/provider/openstack.go
@@ -29,7 +29,7 @@ func OpenstackSizeEndpoint(seedsGetter provider.SeedsGetter, credentialManager c
 		}
 
 		datacenterName := req.DatacenterName
-		datacenter, err := provider.DatacenterFromSeedMap(seeds, datacenterName)
+		_, datacenter, err := provider.DatacenterFromSeedMap(seeds, datacenterName)
 		if err != nil {
 			return nil, fmt.Errorf("error getting dc: %v", err)
 		}
@@ -55,7 +55,7 @@ func OpenstackSizeNoCredentialsEndpoint(projectProvider provider.ProjectProvider
 			return nil, errors.New(http.StatusInternalServerError, fmt.Sprintf("failed to list seeds: %v", err))
 		}
 
-		datacenter, err := provider.DatacenterFromSeedMap(seeds, datacenterName)
+		_, datacenter, err := provider.DatacenterFromSeedMap(seeds, datacenterName)
 		if err != nil {
 			return nil, fmt.Errorf("error getting dc: %v", err)
 		}
@@ -512,7 +512,7 @@ func getOpenstackCredentials(credentialName, username, password, domain, tenant,
 }
 
 func getOpenstackCloudProvider(seeds map[string]*kubermaticv1.Seed, datacenterName string) (*openstack.Provider, error) {
-	dc, err := provider.DatacenterFromSeedMap(seeds, datacenterName)
+	_, dc, err := provider.DatacenterFromSeedMap(seeds, datacenterName)
 	if err != nil {
 		return nil, fmt.Errorf("failed to find datacenter %q: %v", datacenterName, err)
 	}

--- a/api/pkg/handler/v1/provider/vsphere.go
+++ b/api/pkg/handler/v1/provider/vsphere.go
@@ -68,7 +68,7 @@ func getVsphereNetworks(seedsGetter provider.SeedsGetter, username, password, da
 	if err != nil {
 		return nil, errors.New(http.StatusInternalServerError, fmt.Sprintf("failed to list seeds: %v", err))
 	}
-	datacenter, err := provider.DatacenterFromSeedMap(seeds, datacenterName)
+	_, datacenter, err := provider.DatacenterFromSeedMap(seeds, datacenterName)
 	if err != nil {
 		return nil, fmt.Errorf("failed to find Datacenter %q: %v", datacenterName, err)
 	}
@@ -150,7 +150,7 @@ func getVsphereFolders(seedsGetter provider.SeedsGetter, username, password, dat
 	if err != nil {
 		return nil, errors.New(http.StatusInternalServerError, fmt.Sprintf("failed to list seeds: %v", err))
 	}
-	datacenter, err := provider.DatacenterFromSeedMap(seeds, datacenterName)
+	_, datacenter, err := provider.DatacenterFromSeedMap(seeds, datacenterName)
 	if err != nil {
 		return nil, fmt.Errorf("failed to find Datacenter %q: %v", datacenterName, err)
 	}

--- a/api/pkg/provider/cloud/aws/provider.go
+++ b/api/pkg/provider/cloud/aws/provider.go
@@ -31,7 +31,6 @@ const (
 
 type AmazonEC2 struct {
 	dc                *kubermaticv1.DatacenterSpecAWS
-	clusterUpdater    provider.ClusterUpdater
 	secretKeySelector provider.SecretKeySelectorValueFunc
 }
 
@@ -69,7 +68,7 @@ func (a *AmazonEC2) ValidateCloudSpec(spec kubermaticv1.CloudSpec) error {
 }
 
 // MigrateToMultiAZ migrates an AWS cluster from the old AZ-hardcoded spec to multi-AZ spec
-func (a *AmazonEC2) MigrateToMultiAZ(cluster *kubermaticv1.Cluster) error {
+func (a *AmazonEC2) MigrateToMultiAZ(cluster *kubermaticv1.Cluster, clusterUpdater provider.ClusterUpdater) error {
 	// If not even the role name is set, then the cluster is not fully
 	// initialized and we don't need to worry about this migration just yet.
 	if cluster.Spec.Cloud.AWS.RoleName == "" {
@@ -88,7 +87,7 @@ func (a *AmazonEC2) MigrateToMultiAZ(cluster *kubermaticv1.Cluster) error {
 			return fmt.Errorf("failed to get already existing aws IAM role %s: %v", cluster.Spec.Cloud.AWS.RoleName, err)
 		}
 
-		cluster, err = a.clusterUpdater(cluster.Name, func(cluster *kubermaticv1.Cluster) {
+		cluster, err = clusterUpdater(cluster.Name, func(cluster *kubermaticv1.Cluster) {
 			cluster.Spec.Cloud.AWS.ControlPlaneRoleARN = *getRoleOut.Role.Arn
 		})
 		if err != nil {
@@ -186,11 +185,7 @@ func NewCloudProvider(dc *kubermaticv1.Datacenter, secretKeyGetter provider.Secr
 		return nil, errors.New("datacenter is not an AWS datacenter")
 	}
 	return &AmazonEC2{
-		dc: dc.Spec.AWS,
-		// This is hacky at best, but dodge a couple of NPDs this way and trade them for errors
-		clusterUpdater: func(string, func(*kubermaticv1.Cluster)) (*kubermaticv1.Cluster, error) {
-			return nil, errors.New("NPD when calling clusterUpdater")
-		},
+		dc:                dc.Spec.AWS,
 		secretKeySelector: secretKeyGetter,
 	}, nil
 }
@@ -395,8 +390,6 @@ func createSecurityGroup(client ec2iface.EC2API, vpcID, clusterName string) (str
 }
 
 func (a *AmazonEC2) InitializeCloudProvider(cluster *kubermaticv1.Cluster, update provider.ClusterUpdater) (*kubermaticv1.Cluster, error) {
-	a.clusterUpdater = update
-
 	client, err := a.getClientSet(cluster.Spec.Cloud)
 	if err != nil {
 		return nil, fmt.Errorf("failed to get API client: %v", err)
@@ -516,8 +509,6 @@ func (a *AmazonEC2) getClientSet(cloud kubermaticv1.CloudSpec) (*ClientSet, erro
 }
 
 func (a *AmazonEC2) CleanUpCloudProvider(cluster *kubermaticv1.Cluster, updater provider.ClusterUpdater) (*kubermaticv1.Cluster, error) {
-	a.clusterUpdater = updater
-
 	client, err := a.getClientSet(cluster.Spec.Cloud)
 	if err != nil {
 		return nil, fmt.Errorf("failed to get API client: %v", err)
@@ -533,7 +524,7 @@ func (a *AmazonEC2) CleanUpCloudProvider(cluster *kubermaticv1.Cluster, updater 
 				return nil, fmt.Errorf("failed to delete security group %s: %s", cluster.Spec.Cloud.AWS.SecurityGroupID, err.(awserr.Error).Message())
 			}
 		}
-		cluster, err = a.clusterUpdater(cluster.Name, func(cluster *kubermaticv1.Cluster) {
+		cluster, err = updater(cluster.Name, func(cluster *kubermaticv1.Cluster) {
 			kuberneteshelper.RemoveFinalizer(cluster, securityGroupCleanupFinalizer)
 		})
 		if err != nil {
@@ -560,7 +551,7 @@ func (a *AmazonEC2) CleanUpCloudProvider(cluster *kubermaticv1.Cluster, updater 
 			}
 		}
 
-		cluster, err = a.clusterUpdater(cluster.Name, func(cluster *kubermaticv1.Cluster) {
+		cluster, err = updater(cluster.Name, func(cluster *kubermaticv1.Cluster) {
 			kuberneteshelper.RemoveFinalizer(cluster, instanceProfileCleanupFinalizer)
 		})
 		if err != nil {
@@ -573,7 +564,7 @@ func (a *AmazonEC2) CleanUpCloudProvider(cluster *kubermaticv1.Cluster, updater 
 		if err := deleteRole(client.IAM, roleName); err != nil {
 			return nil, fmt.Errorf("failed to delete role %q: %v", roleName, err)
 		}
-		cluster, err = a.clusterUpdater(cluster.Name, func(cluster *kubermaticv1.Cluster) {
+		cluster, err = updater(cluster.Name, func(cluster *kubermaticv1.Cluster) {
 			kuberneteshelper.RemoveFinalizer(cluster, controlPlaneRoleCleanupFinalizer)
 		})
 		if err != nil {
@@ -585,7 +576,7 @@ func (a *AmazonEC2) CleanUpCloudProvider(cluster *kubermaticv1.Cluster, updater 
 		if err := removeTags(cluster, client.EC2); err != nil {
 			return nil, err
 		}
-		cluster, err = a.clusterUpdater(cluster.Name, func(cluster *kubermaticv1.Cluster) {
+		cluster, err = updater(cluster.Name, func(cluster *kubermaticv1.Cluster) {
 			kuberneteshelper.RemoveFinalizer(cluster, tagCleanupFinalizer)
 		})
 		if err != nil {

--- a/api/pkg/provider/cloud/aws/provider.go
+++ b/api/pkg/provider/cloud/aws/provider.go
@@ -484,21 +484,24 @@ func (a *AmazonEC2) InitializeCloudProvider(cluster *kubermaticv1.Cluster, updat
 }
 
 func (a *AmazonEC2) getClientSet(cloud kubermaticv1.CloudSpec) (*ClientSet, error) {
-	var accessKeyID, secretAccessKey string
+	accessKeyID := cloud.AWS.AccessKeyID
+	secretAccessKey := cloud.AWS.SecretAccessKey
 	var err error
 
-	if cloud.AWS.AccessKeyID != "" {
-		accessKeyID = cloud.AWS.AccessKeyID
-	} else {
+	if accessKeyID == "" {
+		if cloud.AWS.CredentialsReference == nil {
+			return nil, errors.New("no credentials provided")
+		}
 		accessKeyID, err = a.secretKeySelector(cloud.AWS.CredentialsReference, resources.AWSAccessKeyID)
 		if err != nil {
 			return nil, err
 		}
 	}
 
-	if cloud.AWS.SecretAccessKey != "" {
-		secretAccessKey = cloud.AWS.SecretAccessKey
-	} else {
+	if secretAccessKey == "" {
+		if cloud.AWS.CredentialsReference == nil {
+			return nil, errors.New("no credentials provided")
+		}
 		secretAccessKey, err = a.secretKeySelector(cloud.AWS.CredentialsReference, resources.AWSSecretAccessKey)
 		if err != nil {
 			return nil, err

--- a/api/pkg/provider/cloud/azure/provider.go
+++ b/api/pkg/provider/cloud/azure/provider.go
@@ -203,7 +203,7 @@ func deleteSecurityGroup(ctx context.Context, cloud kubermaticv1.CloudSpec) erro
 	return nil
 }
 
-func (a *Azure) CleanUpCloudProvider(cluster *kubermaticv1.Cluster, update provider.ClusterUpdater, _ provider.SecretKeySelectorValueFunc) (*kubermaticv1.Cluster, error) {
+func (a *Azure) CleanUpCloudProvider(cluster *kubermaticv1.Cluster, update provider.ClusterUpdater) (*kubermaticv1.Cluster, error) {
 	a.clusterUpdater = update
 
 	var err error
@@ -515,7 +515,7 @@ func ensureRouteTable(ctx context.Context, cloud kubermaticv1.CloudSpec, locatio
 	return nil
 }
 
-func (a *Azure) InitializeCloudProvider(cluster *kubermaticv1.Cluster, update provider.ClusterUpdater, secretKeySelector provider.SecretKeySelectorValueFunc) (*kubermaticv1.Cluster, error) {
+func (a *Azure) InitializeCloudProvider(cluster *kubermaticv1.Cluster, update provider.ClusterUpdater) (*kubermaticv1.Cluster, error) {
 	a.clusterUpdater = update
 	var err error
 	logger := a.log.With("cluster", cluster.Name)

--- a/api/pkg/provider/cloud/bringyourown/provider.go
+++ b/api/pkg/provider/cloud/bringyourown/provider.go
@@ -20,11 +20,11 @@ func (b *bringyourown) ValidateCloudSpec(spec kubermaticv1.CloudSpec) error {
 	return nil
 }
 
-func (b *bringyourown) InitializeCloudProvider(cluster *kubermaticv1.Cluster, update provider.ClusterUpdater, secretKeySelector provider.SecretKeySelectorValueFunc) (*kubermaticv1.Cluster, error) {
+func (b *bringyourown) InitializeCloudProvider(cluster *kubermaticv1.Cluster, update provider.ClusterUpdater) (*kubermaticv1.Cluster, error) {
 	return cluster, nil
 }
 
-func (b *bringyourown) CleanUpCloudProvider(cluster *kubermaticv1.Cluster, _ provider.ClusterUpdater, _ provider.SecretKeySelectorValueFunc) (*kubermaticv1.Cluster, error) {
+func (b *bringyourown) CleanUpCloudProvider(cluster *kubermaticv1.Cluster, _ provider.ClusterUpdater) (*kubermaticv1.Cluster, error) {
 	return cluster, nil
 }
 

--- a/api/pkg/provider/cloud/digitalocean/provider.go
+++ b/api/pkg/provider/cloud/digitalocean/provider.go
@@ -29,11 +29,11 @@ func (do *digitalocean) ValidateCloudSpec(spec kubermaticv1.CloudSpec) error {
 	return err
 }
 
-func (do *digitalocean) InitializeCloudProvider(cluster *kubermaticv1.Cluster, update provider.ClusterUpdater, secretKeySelector provider.SecretKeySelectorValueFunc) (*kubermaticv1.Cluster, error) {
+func (do *digitalocean) InitializeCloudProvider(cluster *kubermaticv1.Cluster, update provider.ClusterUpdater) (*kubermaticv1.Cluster, error) {
 	return cluster, nil
 }
 
-func (do *digitalocean) CleanUpCloudProvider(cluster *kubermaticv1.Cluster, _ provider.ClusterUpdater, _ provider.SecretKeySelectorValueFunc) (*kubermaticv1.Cluster, error) {
+func (do *digitalocean) CleanUpCloudProvider(cluster *kubermaticv1.Cluster, _ provider.ClusterUpdater) (*kubermaticv1.Cluster, error) {
 	return cluster, nil
 }
 

--- a/api/pkg/provider/cloud/fake/provider.go
+++ b/api/pkg/provider/cloud/fake/provider.go
@@ -25,11 +25,11 @@ func (p *fakeCloudProvider) ValidateCloudSpec(spec kubermaticv1.CloudSpec) error
 	return nil
 }
 
-func (p *fakeCloudProvider) InitializeCloudProvider(cluster *kubermaticv1.Cluster, update provider.ClusterUpdater, secretKeySelector provider.SecretKeySelectorValueFunc) (*kubermaticv1.Cluster, error) {
+func (p *fakeCloudProvider) InitializeCloudProvider(cluster *kubermaticv1.Cluster, update provider.ClusterUpdater) (*kubermaticv1.Cluster, error) {
 	return cluster, nil
 }
 
-func (p *fakeCloudProvider) CleanUpCloudProvider(cluster *kubermaticv1.Cluster, _ provider.ClusterUpdater, _ provider.SecretKeySelectorValueFunc) (*kubermaticv1.Cluster, error) {
+func (p *fakeCloudProvider) CleanUpCloudProvider(cluster *kubermaticv1.Cluster, _ provider.ClusterUpdater) (*kubermaticv1.Cluster, error) {
 	return cluster, nil
 }
 

--- a/api/pkg/provider/cloud/gcp/provider.go
+++ b/api/pkg/provider/cloud/gcp/provider.go
@@ -34,7 +34,7 @@ func NewCloudProvider() provider.CloudProvider {
 
 // TODO: update behaviour of all these methods
 // InitializeCloudProvider initializes a cluster.
-func (g *gcp) InitializeCloudProvider(cluster *kubermaticv1.Cluster, update provider.ClusterUpdater, secretKeySelector provider.SecretKeySelectorValueFunc) (*kubermaticv1.Cluster, error) {
+func (g *gcp) InitializeCloudProvider(cluster *kubermaticv1.Cluster, update provider.ClusterUpdater) (*kubermaticv1.Cluster, error) {
 	g.clusterUpdater = update
 
 	var err error
@@ -68,7 +68,7 @@ func (g *gcp) ValidateCloudSpec(spec kubermaticv1.CloudSpec) error {
 }
 
 // CleanUpCloudProvider removes firewall rules and related finalizer.
-func (g *gcp) CleanUpCloudProvider(cluster *kubermaticv1.Cluster, update provider.ClusterUpdater, _ provider.SecretKeySelectorValueFunc) (*kubermaticv1.Cluster, error) {
+func (g *gcp) CleanUpCloudProvider(cluster *kubermaticv1.Cluster, update provider.ClusterUpdater) (*kubermaticv1.Cluster, error) {
 	g.clusterUpdater = update
 
 	svc, projectID, err := ConnectToComputeService(cluster.Spec.Cloud.GCP.ServiceAccount)

--- a/api/pkg/provider/cloud/hetzner/provider.go
+++ b/api/pkg/provider/cloud/hetzner/provider.go
@@ -29,12 +29,12 @@ func (h *hetzner) ValidateCloudSpec(spec kubermaticv1.CloudSpec) error {
 }
 
 // InitializeCloudProvider
-func (h *hetzner) InitializeCloudProvider(cluster *kubermaticv1.Cluster, update provider.ClusterUpdater, secretKeySelector provider.SecretKeySelectorValueFunc) (*kubermaticv1.Cluster, error) {
+func (h *hetzner) InitializeCloudProvider(cluster *kubermaticv1.Cluster, update provider.ClusterUpdater) (*kubermaticv1.Cluster, error) {
 	return cluster, nil
 }
 
 // CleanUpCloudProvider
-func (h *hetzner) CleanUpCloudProvider(cluster *kubermaticv1.Cluster, _ provider.ClusterUpdater, _ provider.SecretKeySelectorValueFunc) (*kubermaticv1.Cluster, error) {
+func (h *hetzner) CleanUpCloudProvider(cluster *kubermaticv1.Cluster, _ provider.ClusterUpdater) (*kubermaticv1.Cluster, error) {
 	return cluster, nil
 }
 

--- a/api/pkg/provider/cloud/openstack/provider.go
+++ b/api/pkg/provider/cloud/openstack/provider.go
@@ -130,7 +130,7 @@ func validateExistingSubnetOverlap(networkID string, netClient *gophercloud.Serv
 
 // InitializeCloudProvider initializes a cluster, in particular
 // creates security group and network configuration
-func (os *Provider) InitializeCloudProvider(cluster *kubermaticv1.Cluster, update provider.ClusterUpdater, secretKeySelector provider.SecretKeySelectorValueFunc) (*kubermaticv1.Cluster, error) {
+func (os *Provider) InitializeCloudProvider(cluster *kubermaticv1.Cluster, update provider.ClusterUpdater) (*kubermaticv1.Cluster, error) {
 	os.clusterUpdater = update
 	netClient, err := os.getNetClient(cluster.Spec.Cloud)
 	if err != nil {
@@ -250,7 +250,7 @@ func (os *Provider) InitializeCloudProvider(cluster *kubermaticv1.Cluster, updat
 
 // CleanUpCloudProvider does the clean-up in particular:
 // removes security group and network configuration
-func (os *Provider) CleanUpCloudProvider(cluster *kubermaticv1.Cluster, update provider.ClusterUpdater, _ provider.SecretKeySelectorValueFunc) (*kubermaticv1.Cluster, error) {
+func (os *Provider) CleanUpCloudProvider(cluster *kubermaticv1.Cluster, update provider.ClusterUpdater) (*kubermaticv1.Cluster, error) {
 	os.clusterUpdater = update
 
 	netClient, err := os.getNetClient(cluster.Spec.Cloud)

--- a/api/pkg/provider/cloud/packet/provider.go
+++ b/api/pkg/provider/cloud/packet/provider.go
@@ -37,7 +37,7 @@ func (p *packet) ValidateCloudSpec(spec kubermaticv1.CloudSpec) error {
 
 // InitializeCloudProvider initializes a cluster, in particular
 // updates BillingCycle to the defaultBillingCycle, if it is not set.
-func (p *packet) InitializeCloudProvider(cluster *kubermaticv1.Cluster, update provider.ClusterUpdater, secretKeySelector provider.SecretKeySelectorValueFunc) (*kubermaticv1.Cluster, error) {
+func (p *packet) InitializeCloudProvider(cluster *kubermaticv1.Cluster, update provider.ClusterUpdater) (*kubermaticv1.Cluster, error) {
 	var err error
 	if cluster.Spec.Cloud.Packet.BillingCycle == "" {
 		cluster, err = update(cluster.Name, func(cluster *kubermaticv1.Cluster) {
@@ -52,7 +52,7 @@ func (p *packet) InitializeCloudProvider(cluster *kubermaticv1.Cluster, update p
 }
 
 // CleanUpCloudProvider
-func (p *packet) CleanUpCloudProvider(cluster *kubermaticv1.Cluster, _ provider.ClusterUpdater, _ provider.SecretKeySelectorValueFunc) (*kubermaticv1.Cluster, error) {
+func (p *packet) CleanUpCloudProvider(cluster *kubermaticv1.Cluster, _ provider.ClusterUpdater) (*kubermaticv1.Cluster, error) {
 	return cluster, nil
 }
 

--- a/api/pkg/provider/cloud/provider.go
+++ b/api/pkg/provider/cloud/provider.go
@@ -17,7 +17,7 @@ import (
 	"github.com/kubermatic/kubermatic/api/pkg/provider/cloud/vsphere"
 )
 
-func Provider(datacenter *kubermaticv1.Datacenter) (provider.CloudProvider, error) {
+func Provider(datacenter *kubermaticv1.Datacenter, secretKeyGetter provider.SecretKeySelectorValueFunc) (provider.CloudProvider, error) {
 	if datacenter.Spec.Digitalocean != nil {
 		return digitalocean.NewCloudProvider(), nil
 	}
@@ -25,7 +25,7 @@ func Provider(datacenter *kubermaticv1.Datacenter) (provider.CloudProvider, erro
 		return bringyourown.NewCloudProvider(), nil
 	}
 	if datacenter.Spec.AWS != nil {
-		return aws.NewCloudProvider(datacenter)
+		return aws.NewCloudProvider(datacenter, secretKeyGetter)
 	}
 	if datacenter.Spec.Azure != nil {
 		return azure.New(datacenter)

--- a/api/pkg/provider/cloud/vsphere/provider.go
+++ b/api/pkg/provider/cloud/vsphere/provider.go
@@ -84,7 +84,7 @@ func (v *Provider) getVMRootPath(cloud kubermaticv1.CloudSpec) string {
 }
 
 // InitializeCloudProvider initializes the vsphere cloud provider by setting up vm folders for the cluster.
-func (v *Provider) InitializeCloudProvider(cluster *kubermaticv1.Cluster, update provider.ClusterUpdater, secretKeySelector provider.SecretKeySelectorValueFunc) (*kubermaticv1.Cluster, error) {
+func (v *Provider) InitializeCloudProvider(cluster *kubermaticv1.Cluster, update provider.ClusterUpdater) (*kubermaticv1.Cluster, error) {
 	v.clusterUpdater = update
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
@@ -253,7 +253,7 @@ func (v *Provider) ValidateCloudSpec(spec kubermaticv1.CloudSpec) error {
 // CleanUpCloudProvider we always check if the folder is there and remove it if yes because we know its absolute path
 // This covers cases where the finalizer was not added
 // We also remove the finalizer if either the folder is not present or we successfully deleted it
-func (v *Provider) CleanUpCloudProvider(cluster *kubermaticv1.Cluster, update provider.ClusterUpdater, _ provider.SecretKeySelectorValueFunc) (*kubermaticv1.Cluster, error) {
+func (v *Provider) CleanUpCloudProvider(cluster *kubermaticv1.Cluster, update provider.ClusterUpdater) (*kubermaticv1.Cluster, error) {
 	v.clusterUpdater = update
 
 	ctx, cancel := context.WithCancel(context.Background())

--- a/api/pkg/provider/conversions.go
+++ b/api/pkg/provider/conversions.go
@@ -78,21 +78,23 @@ func DatacenterMetasToSeeds(dm map[string]DatacenterMeta) (map[string]*kubermati
 // once we support datacenters as CRDs.
 // TODO: Find a way to lift the current requirement of unique nodeDatacenter names. It is needed
 // only because we put the nodeDatacenter name on the cluster but not the seed
-func DatacenterFromSeedMap(seeds map[string]*kubermaticv1.Seed, datacenterName string) (*kubermaticv1.Datacenter, error) {
+func DatacenterFromSeedMap(seeds map[string]*kubermaticv1.Seed, datacenterName string) (*kubermaticv1.Seed, *kubermaticv1.Datacenter, error) {
 
-	var results []kubermaticv1.Datacenter
+	var foundDatacenters []kubermaticv1.Datacenter
+	var foundSeeds []*kubermaticv1.Seed
 	for _, seed := range seeds {
 		datacenter, exists := seed.Spec.Datacenters[datacenterName]
 		if !exists {
 			continue
 		}
 
-		results = append(results, datacenter)
+		foundSeeds = append(foundSeeds, seed)
+		foundDatacenters = append(foundDatacenters, datacenter)
 	}
 
-	if n := len(results); n != 1 {
-		return nil, fmt.Errorf("expected to find exactly one datacenter with name %q, got %d", datacenterName, n)
+	if n := len(foundDatacenters); n != 1 {
+		return nil, nil, fmt.Errorf("expected to find exactly one datacenter with name %q, got %d", datacenterName, n)
 	}
 
-	return &results[0], nil
+	return foundSeeds[0], &foundDatacenters[0], nil
 }

--- a/api/pkg/resources/cluster/cluster.go
+++ b/api/pkg/resources/cluster/cluster.go
@@ -13,7 +13,7 @@ import (
 )
 
 // Spec builds ClusterSpec kubermatic Custom Resource from API Cluster
-func Spec(apiCluster apiv1.Cluster, dc *kubermaticv1.Datacenter) (*kubermaticv1.ClusterSpec, error) {
+func Spec(apiCluster apiv1.Cluster, dc *kubermaticv1.Datacenter, secretKeyGetter provider.SecretKeySelectorValueFunc) (*kubermaticv1.ClusterSpec, error) {
 	spec := &kubermaticv1.ClusterSpec{
 		HumanReadableName: apiCluster.Name,
 		Cloud:             apiCluster.Spec.Cloud,
@@ -29,7 +29,7 @@ func Spec(apiCluster apiv1.Cluster, dc *kubermaticv1.Datacenter) (*kubermaticv1.
 	if providerName == "" {
 		return nil, errors.New("cluster has no cloudprovider")
 	}
-	cloudProvider, err := cloud.Provider(dc)
+	cloudProvider, err := cloud.Provider(dc, secretKeyGetter)
 	if err != nil {
 		return nil, err
 	}

--- a/api/pkg/util/restmapper/cache.go
+++ b/api/pkg/util/restmapper/cache.go
@@ -1,0 +1,47 @@
+package restmapper
+
+import (
+	"fmt"
+	"sync"
+
+	"k8s.io/apimachinery/pkg/api/meta"
+	"k8s.io/client-go/rest"
+	ctrlruntimeclient "sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+// New returns a new Cache
+func New() *Cache {
+	return &Cache{cache: &sync.Map{}}
+}
+
+// RestMapperCache is used to dynamically create controllerruntimeClients whilst caching the RestMapper. It uses properties of the
+// *cfg as cache key
+type Cache struct {
+	cache *sync.Map
+}
+
+// Client returns a brand new controllerruntime.Client, using a cache for the restMapping to avoid doing discovery during startup.
+// It uses properties of the *cfg as cache Key
+func (c *Cache) Client(cfg *rest.Config) (ctrlruntimeclient.Client, error) {
+	key := fmt.Sprintf("%s/%s/%s/%s/%s/%s/%s/%s/%s", cfg.Host, cfg.APIPath, cfg.Username, cfg.Password, cfg.BearerToken, cfg.BearerTokenFile, string(cfg.CertData), string(cfg.KeyData), string(cfg.CAData))
+
+	var mapper meta.RESTMapper
+
+	rawMapper, exists := c.cache.Load(key)
+	if !exists {
+		var err error
+		mapper, err = NewDynamicRESTMapper(cfg)
+		if err != nil {
+			return nil, fmt.Errorf("failed to create restMapper: %v", err)
+		}
+		c.cache.Store(key, mapper)
+	} else {
+		var ok bool
+		mapper, ok = rawMapper.(meta.RESTMapper)
+		if !ok {
+			return nil, fmt.Errorf("didn't get a restMapper from the cache")
+		}
+	}
+
+	return ctrlruntimeclient.New(cfg, ctrlruntimeclient.Options{Mapper: mapper})
+}


### PR DESCRIPTION
**What this PR does / why we need it**:

This PR changes the cloud provider interface in a away that they get initialized with a SecretKeyGetter, ensuring they are always able to get credentials. This fixes various AWS endpoints.

The whole thing is done by:

* Creating a factory for a `SecretKeySelectorValueFunc` in the provider pkg
* Asserting the `ClusterProvider` to its implementation `*kubernetesprovider.ClusterProvider` then using its `GetSeedClusterAdminRuntimeClient` to call the factory
* For all endpoints that do not have a cluster already, the `ClusterProvider` can not be uses as its creation needs a DC which we don't have. Hence a `SeedClientGetter` was added to the `Routing`, it is an abstraction on top of the `KubeconfigGetter` with an integrated restMapper cache. It needs the seed thought, which is why `DatacenterFromSeedMap` had to be extended to also return the seed

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

What is really bad about all of this is that a lot of changes had to be done in order to have a `SecretKeySelector` in endpoints that do not operate on existing clusters _even thought it will never be used_ down the line in the AWS provider.

IMHO we should refactor the VPC/Subnet/Zone endpoints to not require an initialized AWS cloud provider but instead be standalone and just take the credentials as args.

What I will do as follow-ups are:
* DRY out restmapper cache usage and use the `*restmapper.Cache` everywhere
* DRY out `SecretKeySelectorValueFunc` creation and use the factory in the provider package everywhere

**Documentation**:
<!-- Add links to the related documentation changes related to this pull request. E.g. the link to the kubermatic/docs pullrequest. -->

**Does this PR introduce a user-facing change?**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If  no release note is required, just write "NONE".
-->
```release-note
none
```

/assign @mrIncompetent @zreigz @thz 
