### PR TITLE
E2E tests: Include clusterdeletion

### DIFF
--- a/api/cmd/conformance-tests/cleanup.go
+++ b/api/cmd/conformance-tests/cleanup.go
@@ -2,20 +2,13 @@ package main
 
 import (
 	"context"
-	"fmt"
 
 	"go.uber.org/zap"
 
-	clusterclient "github.com/kubermatic/kubermatic/api/pkg/cluster/client"
-	kubermaticv1 "github.com/kubermatic/kubermatic/api/pkg/crd/kubermatic/v1"
-	"github.com/kubermatic/machine-controller/pkg/node/eviction"
-
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/apimachinery/pkg/util/sets"
 	"k8s.io/apimachinery/pkg/util/wait"
-	"k8s.io/client-go/util/retry"
 	ctrlruntimeclient "sigs.k8s.io/controller-runtime/pkg/client"
 )
 
@@ -54,65 +47,4 @@ func deleteAllNonDefaultNamespaces(log *zap.SugaredLogger, client ctrlruntimecli
 		}
 		return false, nil
 	})
-}
-
-func tryToDeleteClusterWithRetries(log *zap.SugaredLogger, cluster *kubermaticv1.Cluster, clusterClientProvider clusterclient.UserClusterConnectionProvider, seedClusterClient ctrlruntimeclient.Client) error {
-	const maxAttempts = 5
-	return retryNAttempts(maxAttempts, func(attempt int) error {
-		err := tryToDeleteCluster(log, cluster, clusterClientProvider, seedClusterClient)
-		if err != nil {
-			log.Warnf("[Attempt %d/%d] Failed to delete Cluster: %v", attempt, maxAttempts, err)
-		}
-		return err
-	})
-}
-
-// tryToDeleteCluster will try to delete all potential orphaned cloud provider resources like LB's & PVC's
-// After deleting them it will delete the kubermatic cluster object
-func tryToDeleteCluster(log *zap.SugaredLogger, cluster *kubermaticv1.Cluster, clusterClientProvider clusterclient.UserClusterConnectionProvider, seedClusterClient ctrlruntimeclient.Client) error {
-	log.Infof("Trying to delete cluster...")
-
-	userClusterClient, err := clusterClientProvider.GetClient(cluster)
-	if err != nil {
-		return fmt.Errorf("failed to get the client for the cluster: %v", err)
-	}
-
-	if err := deleteAllNonDefaultNamespaces(log, userClusterClient); err != nil {
-		return fmt.Errorf("failed to delete all namespaces: %v", err)
-	}
-
-	// Disable eviction on all nodes
-	nodeList := &corev1.NodeList{}
-	ctx := context.Background()
-	if err := userClusterClient.List(ctx, &ctrlruntimeclient.ListOptions{}, nodeList); err != nil {
-		return fmt.Errorf("failed to list nodes: %v", err)
-	}
-
-	for _, node := range nodeList.Items {
-		log.Debugf("Disabling eviction on node '%s' ...", node.Name)
-		err = retry.RetryOnConflict(retry.DefaultBackoff, func() error {
-			// Get latest version of the node to prevent conflict errors
-			currentNode := &corev1.Node{}
-			if err := userClusterClient.Get(ctx, types.NamespacedName{Name: node.Name}, currentNode); err != nil {
-				return err
-			}
-			if currentNode.Annotations == nil {
-				currentNode.Annotations = map[string]string{}
-			}
-			currentNode.Annotations[eviction.SkipEvictionAnnotationKey] = "true"
-
-			return userClusterClient.Update(ctx, currentNode)
-		})
-		if err != nil {
-			return fmt.Errorf("failed to add the annotation '%s=true' to node '%s': %v", eviction.SkipEvictionAnnotationKey, node.Name, err)
-		}
-	}
-
-	log.Debug("Calling delete on the cluster resource...")
-	if err := seedClusterClient.Delete(context.Background(), cluster); err != nil {
-		return fmt.Errorf("failed to delete cluster %s: %v. Make sure to delete it manually afterwards", cluster.Name, err)
-	}
-
-	log.Info("Finished deleting cluster")
-	return nil
 }

--- a/api/cmd/conformance-tests/main.go
+++ b/api/cmd/conformance-tests/main.go
@@ -164,7 +164,7 @@ func main() {
 	flag.StringVar(&opts.reportsRoot, "reports-root", "/opt/reports", "Root for reports")
 	flag.BoolVar(&opts.cleanupOnStart, "cleanup-on-start", false, "Cleans up all clusters on start and exit afterwards - must be used with name-prefix.")
 	flag.DurationVar(&opts.controlPlaneReadyWaitTimeout, "kubermatic-cluster-timeout", defaultTimeout, "cluster creation timeout")
-	flag.BoolVar(&opts.deleteClusterAfterTests, "kubermatic-delete-cluster", true, "delete test cluster at the exit")
+	flag.BoolVar(&opts.deleteClusterAfterTests, "kubermatic-delete-cluster", true, "delete test cluster when tests where successful")
 	flag.StringVar(&pubKeyPath, "node-ssh-pub-key", pubkeyPath, "path to a public key which gets deployed onto every node")
 	flag.StringVar(&opts.workerName, "worker-name", "", "name of the worker, if set the 'worker-name' label will be set on all clusters")
 	flag.StringVar(&sversions, "versions", "v1.10.11,v1.11.6,v1.12.4,v1.13.1", "a comma-separated list of versions to test")

--- a/api/cmd/conformance-tests/main.go
+++ b/api/cmd/conformance-tests/main.go
@@ -14,7 +14,6 @@ import (
 	"os/user"
 	"path"
 	"strings"
-	"sync"
 	"time"
 
 	"github.com/go-openapi/runtime"
@@ -58,7 +57,6 @@ type Opts struct {
 	clusterClientProvider        clusterclient.UserClusterConnectionProvider
 	repoRoot                     string
 	seed                         *kubermaticv1.Seed
-	cleanupOnStart               bool
 	clusterParallelCount         int
 	workerName                   string
 	homeDir                      string
@@ -162,7 +160,7 @@ func main() {
 	flag.IntVar(&opts.clusterParallelCount, "kubermatic-parallel-clusters", 5, "number of clusters to test in parallel")
 	_ = flag.String("datacenters", "", "No-Op flag kept for compatibility reasons")
 	flag.StringVar(&opts.reportsRoot, "reports-root", "/opt/reports", "Root for reports")
-	flag.BoolVar(&opts.cleanupOnStart, "cleanup-on-start", false, "Cleans up all clusters on start and exit afterwards - must be used with name-prefix.")
+	_ = flag.Bool("cleanup-on-start", false, "No-Op kept for compatibility reasons")
 	flag.DurationVar(&opts.controlPlaneReadyWaitTimeout, "kubermatic-cluster-timeout", defaultTimeout, "cluster creation timeout")
 	flag.BoolVar(&opts.deleteClusterAfterTests, "kubermatic-delete-cluster", true, "delete test cluster when tests where successful")
 	flag.StringVar(&pubKeyPath, "node-ssh-pub-key", pubkeyPath, "path to a public key which gets deployed onto every node")
@@ -325,12 +323,6 @@ func main() {
 	}
 	opts.clusterClientProvider = clusterClientProvider
 
-	if opts.cleanupOnStart {
-		if err := cleanupClusters(opts, log, seedClusterClient, clusterClientProvider); err != nil {
-			log.Fatalf("failed to cleanup old clusters: %v", err)
-		}
-	}
-
 	log.Info("Starting E2E tests...")
 	runner := newRunner(getScenarios(opts, log), &opts, log)
 
@@ -339,33 +331,6 @@ func main() {
 		log.Fatal(err)
 	}
 	log.Infof("Whole suite took: %.2f seconds", time.Since(start).Seconds())
-}
-
-func cleanupClusters(opts Opts, log *zap.SugaredLogger, seedClusterClient ctrlruntimeclient.Client, clusterClientProvider clusterclient.UserClusterConnectionProvider) error {
-	if opts.namePrefix == "" {
-		log.Fatalf("cleanup-on-start was specified but name-prefix is empty")
-	}
-	clusterList := &kubermaticv1.ClusterList{}
-	if err := seedClusterClient.List(context.Background(), &ctrlruntimeclient.ListOptions{}, clusterList); err != nil {
-		return err
-	}
-
-	var wg sync.WaitGroup
-	for _, cluster := range clusterList.Items {
-		if strings.HasPrefix(cluster.Name, opts.namePrefix) {
-			wg.Add(1)
-			go func(cluster kubermaticv1.Cluster) {
-				clusterDeleteLog := log.With("cluster", cluster.Name)
-				defer wg.Done()
-				if err := tryToDeleteClusterWithRetries(clusterDeleteLog, &cluster, clusterClientProvider, seedClusterClient); err != nil {
-					clusterDeleteLog.Errorf("failed to delete cluster: %v", err)
-				}
-			}(cluster)
-		}
-	}
-	wg.Wait()
-	log.Info("Cleaned up all old clusters")
-	return nil
 }
 
 func getScenarios(opts Opts, log *zap.SugaredLogger) []testScenario {

--- a/api/cmd/conformance-tests/runner.go
+++ b/api/cmd/conformance-tests/runner.go
@@ -479,7 +479,8 @@ func (r *testRunner) testCluster(
 				clusterList := &kubermaticv1.ClusterList{}
 				listOpts := &ctrlruntimeclient.ListOptions{LabelSelector: selector}
 				if err := r.seedClusterClient.List(r.ctx, listOpts, clusterList); err != nil {
-					return false, fmt.Errorf("failed to list clusters: %v", err)
+					log.Errorw("listing clusters failed", zap.Error(err))
+					return false, nil
 				}
 				// Success!
 				if len(clusterList.Items) == 0 {

--- a/api/cmd/conformance-tests/runner.go
+++ b/api/cmd/conformance-tests/runner.go
@@ -497,7 +497,8 @@ func (r *testRunner) testCluster(
 				log.With("cluster", clusterList.Items[0].Name).Info("Issuing DELETE call for cluster")
 				deleteParms.ClusterID = clusterList.Items[0].Name
 				_, err := r.kubermaticClient.Project.DeleteCluster(deleteParms, r.kubermaticAuthenticator)
-				return false, err
+				log.Errorw("cluster delete call returned error", zap.Error(errors.New(fmtSwaggerError(err))))
+				return false, nil
 			})
 		},
 	); err != nil {

--- a/api/cmd/conformance-tests/runner.go
+++ b/api/cmd/conformance-tests/runner.go
@@ -293,15 +293,6 @@ func (r *testRunner) executeScenario(log *zap.SugaredLogger, scenario testScenar
 		return nil, fmt.Errorf("Datacenter %q doesn't exist", cluster.Spec.Cloud.DatacenterName)
 	}
 
-	if r.deleteClusterAfterTests {
-		defer func() {
-			if err := tryToDeleteClusterWithRetries(log, cluster, r.clusterClientProvider, r.seedClusterClient); err != nil {
-				log.Errorf("failed to delete cluster: %v", err)
-				log.Errorf("Please manually cleanup the cluster. Either by restarting with `-cleanup-on-start=true` or by doing the cleanup by hand: %v", err)
-			}
-		}()
-	}
-
 	kubeconfigFilename, err := r.getKubeconfig(log, cluster)
 	if err != nil {
 		return nil, fmt.Errorf("failed to get kubeconfig: %v", err)
@@ -465,6 +456,53 @@ func (r *testRunner) testCluster(
 				})
 		}); err != nil {
 		log.Errorf("Failed to verify that user cluster RBAC controller work: %v", err)
+	}
+
+	if !r.deleteClusterAfterTests {
+		return nil
+	}
+
+	deleteParms := &projectclient.DeleteClusterParams{
+		ProjectID: r.kubermatcProjectID,
+		Dc:        r.seed.Name,
+	}
+	deleteParms.SetTimeout(15 * time.Second)
+	if err := junitReporterWrapper(
+		"[Kubermatic] Delete cluster",
+		report,
+		func() error {
+			selector, err := labels.Parse(fmt.Sprintf("worker-name=%s", r.workerName))
+			if err != nil {
+				return fmt.Errorf("failed to parse selector: %v", err)
+			}
+			return wait.PollImmediate(5*time.Second, 5*time.Minute, func() (bool, error) {
+				clusterList := &kubermaticv1.ClusterList{}
+				listOpts := &ctrlruntimeclient.ListOptions{LabelSelector: selector}
+				if err := r.seedClusterClient.List(r.ctx, listOpts, clusterList); err != nil {
+					return false, fmt.Errorf("failed to list clusters: %v", err)
+				}
+				// Success!
+				if len(clusterList.Items) == 0 {
+					return true, nil
+				}
+				// Should never happen
+				if len(clusterList.Items) > 1 {
+					return false, fmt.Errorf("expected to find zero or one cluster, got %d", len(clusterList.Items))
+				}
+				// Cluster is currently being deleted
+				if clusterList.Items[0].DeletionTimestamp != nil {
+					return false, nil
+				}
+				// Issue Delete call
+				log.With("cluster", clusterList.Items[0].Name).Info("Issuing DELETE call for cluster")
+				deleteParms.ClusterID = clusterList.Items[0].Name
+				_, err := r.kubermaticClient.Project.DeleteCluster(deleteParms, r.kubermaticAuthenticator)
+				return false, err
+			})
+		},
+	); err != nil {
+		log.Errorw("failed to delete cluster", zap.Error(err))
+		return err
 	}
 
 	return nil

--- a/api/hack/ci/ci-run-minimal-conformance-tests.sh
+++ b/api/hack/ci/ci-run-minimal-conformance-tests.sh
@@ -410,6 +410,11 @@ fi
 setup_elasped_time=$((${SECONDS:-} - $setup_start_time))
 TEST_NAME="Setup Kubermatic total" write_junit "0" "$setup_elasped_time"
 
+kubermatic_delete_cluster="true"
+if [ -n "${UPGRADE_TEST_BASE_HASH:-}" ]; then
+	kubermatic_delete_cluster="false"
+fi
+
 timeout -s 9 90m ./conformance-tests $EXTRA_ARGS \
   -debug \
   -worker-name=$BUILD_ID \
@@ -425,7 +430,7 @@ timeout -s 9 90m ./conformance-tests $EXTRA_ARGS \
   -providers=$provider \
   -exclude-distributions="${EXCLUDE_DISTRIBUTIONS}" \
   ${OPENSHIFT_ARG:-} \
-  -kubermatic-delete-cluster=false \
+  -kubermatic-delete-cluster=${kubermatic_delete_cluster} \
   -print-ginkgo-logs=true \
   -default-timeout-minutes=${DEFAULT_TIMEOUT_MINUTES}
 
@@ -482,6 +487,5 @@ timeout -s 9 60m ./conformance-tests $EXTRA_ARGS \
   -providers=$provider \
   -exclude-distributions="${EXCLUDE_DISTRIBUTIONS}" \
   ${OPENSHIFT_ARG:-} \
-  -kubermatic-delete-cluster=false \
   -print-ginkgo-logs=true \
   -default-timeout-minutes=${DEFAULT_TIMEOUT_MINUTES}


### PR DESCRIPTION
**What this PR does / why we need it**:

This changes the conformance tester to also delete the cluster at the end via the API and wait for it to be gone.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #3987 

**Special notes for your reviewer**:

**Documentation**:
<!-- Add links to the related documentation changes related to this pull request. E.g. the link to the kubermatic/docs pullrequest. -->

**Does this PR introduce a user-facing change?**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If  no release note is required, just write "NONE".
-->
```release-note
none
```
