### PR TITLE
Set __KUBERMATIC_TAG__ everywhere in the values.yaml

### DIFF
--- a/api/hack/ci/ci-deploy-ci-kubermatic-io.sh
+++ b/api/hack/ci/ci-deploy-ci-kubermatic-io.sh
@@ -19,10 +19,6 @@ retry 5 vault write \
 export VAULT_TOKEN="$(cat /tmp/vault-token-response.json| jq .auth.client_token -r)"
 export KUBECONFIG=/tmp/kubeconfig
 export VALUES_FILE=/tmp/values.yaml
-export HELM_EXTRA_ARGS="--set=kubermatic.controller.image.tag=${GIT_HEAD_HASH} \
-    --set=kubermatic.api.image.tag=${GIT_HEAD_HASH} \
-    --set=kubermatic.masterController.image.tag=${GIT_HEAD_HASH} \
-    --set=kubermatic.controller.addons.kubernetes.image.tag=${GIT_HEAD_HASH}"
 
 vault kv get -field=kubeconfig dev/seed-clusters/ci.kubermatic.io > ${KUBECONFIG}
 vault kv get -field=values.yaml dev/seed-clusters/ci.kubermatic.io > ${VALUES_FILE}
@@ -32,5 +28,5 @@ echodate "Deploying ${DEPLOY_STACK} stack to ci.kubermatic.io"
 TILLER_NAMESPACE=kubermatic \
 	DEPLOY_NODEPORT_PROXY=false \
 	DEPLOY_ALERTMANAGER=false \
-	DEPLOY_MINIO=false ./api/hack/deploy.sh master ${VALUES_FILE} ${HELM_EXTRA_ARGS}
+	DEPLOY_MINIO=false ./api/hack/deploy.sh master ${VALUES_FILE}
 echodate "Successfully deployed ${DEPLOY_STACK} stack to ci.kubermatic.io"

--- a/api/hack/ci/ci-deploy-cloud-asia.sh
+++ b/api/hack/ci/ci-deploy-cloud-asia.sh
@@ -19,10 +19,6 @@ retry 5 vault write \
 export VAULT_TOKEN="$(cat /tmp/vault-token-response.json| jq .auth.client_token -r)"
 export KUBECONFIG=/tmp/kubeconfig
 export VALUES_FILE=/tmp/values.yaml
-export HELM_EXTRA_ARGS="--set=kubermatic.controller.image.tag=${GIT_HEAD_HASH} \
-    --set=kubermatic.api.image.tag=${GIT_HEAD_HASH} \
-    --set=kubermatic.masterController.image.tag=${GIT_HEAD_HASH} \
-    --set=kubermatic.controller.addons.kubernetes.image.tag=${GIT_HEAD_HASH}"
 
 # deploy to cloud-asia
 vault kv get -field=kubeconfig dev/seed-clusters/cloud.kubermatic.io > ${KUBECONFIG}
@@ -31,5 +27,5 @@ kubectl config use-context asia-east1-a-1
 echodate "Successfully got secrets for cloud-asia from Vault"
 
 echodate "Deploying ${DEPLOY_STACK} stack to cloud-asia"
-TILLER_NAMESPACE=kubermatic-installer ./api/hack/deploy.sh seed ${VALUES_FILE} ${HELM_EXTRA_ARGS}
+TILLER_NAMESPACE=kubermatic-installer ./api/hack/deploy.sh seed ${VALUES_FILE}
 echodate "Successfully deployed ${DEPLOY_STACK} stack to cloud-asia"

--- a/api/hack/ci/ci-deploy-cloud-eu.sh
+++ b/api/hack/ci/ci-deploy-cloud-eu.sh
@@ -19,10 +19,6 @@ retry 5 vault write \
 export VAULT_TOKEN="$(cat /tmp/vault-token-response.json| jq .auth.client_token -r)"
 export KUBECONFIG=/tmp/kubeconfig
 export VALUES_FILE=/tmp/values.yaml
-export HELM_EXTRA_ARGS="--set=kubermatic.controller.image.tag=${GIT_HEAD_HASH} \
-    --set=kubermatic.api.image.tag=${GIT_HEAD_HASH} \
-    --set=kubermatic.masterController.image.tag=${GIT_HEAD_HASH} \
-    --set=kubermatic.controller.addons.kubernetes.image.tag=${GIT_HEAD_HASH}"
 
 # deploy to cloud-eu
 vault kv get -field=kubeconfig dev/seed-clusters/cloud.kubermatic.io > ${KUBECONFIG}
@@ -31,5 +27,5 @@ kubectl config use-context europe-west3-c-1
 echodate "Successfully got secrets for cloud-eu from Vault"
 
 echodate "Deploying ${DEPLOY_STACK} stack to cloud-eu"
-TILLER_NAMESPACE=kubermatic-installer ./api/hack/deploy.sh master ${VALUES_FILE} ${HELM_EXTRA_ARGS}
+TILLER_NAMESPACE=kubermatic-installer ./api/hack/deploy.sh master ${VALUES_FILE}
 echodate "Successfully deployed ${DEPLOY_STACK} stack to cloud-eu"

--- a/api/hack/ci/ci-deploy-cloud-us.sh
+++ b/api/hack/ci/ci-deploy-cloud-us.sh
@@ -19,10 +19,6 @@ retry 5 vault write \
 export VAULT_TOKEN="$(cat /tmp/vault-token-response.json| jq .auth.client_token -r)"
 export KUBECONFIG=/tmp/kubeconfig
 export VALUES_FILE=/tmp/values.yaml
-export HELM_EXTRA_ARGS="--set=kubermatic.controller.image.tag=${GIT_HEAD_HASH} \
-    --set=kubermatic.api.image.tag=${GIT_HEAD_HASH} \
-    --set=kubermatic.masterController.image.tag=${GIT_HEAD_HASH} \
-    --set=kubermatic.controller.addons.kubernetes.image.tag=${GIT_HEAD_HASH}"
 
 # deploy to cloud-us
 vault kv get -field=kubeconfig dev/seed-clusters/cloud.kubermatic.io > ${KUBECONFIG}
@@ -31,5 +27,5 @@ kubectl config use-context us-central1-c-1
 echodate "Successfully got secrets for cloud-us from Vault"
 
 echodate "Deploying ${DEPLOY_STACK} stack to cloud-us"
-TILLER_NAMESPACE=kubermatic-installer ./api/hack/deploy.sh seed ${VALUES_FILE} ${HELM_EXTRA_ARGS}
+TILLER_NAMESPACE=kubermatic-installer ./api/hack/deploy.sh seed ${VALUES_FILE}
 echodate "Successfully deployed ${DEPLOY_STACK} stack to cloud-us"

--- a/api/hack/ci/ci-deploy-dev-asia.sh
+++ b/api/hack/ci/ci-deploy-dev-asia.sh
@@ -19,11 +19,6 @@ retry 5 vault write \
 export VAULT_TOKEN="$(cat /tmp/vault-token-response.json| jq .auth.client_token -r)"
 export KUBECONFIG=/tmp/kubeconfig
 export VALUES_FILE=/tmp/values.yaml
-export HELM_EXTRA_ARGS="--set=kubermatic.controller.image.tag=${GIT_HEAD_HASH} \
-    --set=kubermatic.api.image.tag=${GIT_HEAD_HASH} \
-    --set=kubermatic.masterController.image.tag=${GIT_HEAD_HASH} \
-    --set=kubermatic.controller.addons.kubernetes.image.tag=${GIT_HEAD_HASH} \
-    --set=kubermatic.controller.datacenterName=asia-south1-c"
 
 # deploy to dev-asia
 vault kv get -field=kubeconfig dev/seed-clusters/dev.kubermatic.io > ${KUBECONFIG}
@@ -32,5 +27,5 @@ kubectl config use-context asia-south1-c
 echodate "Successfully got secrets for dev-asia from Vault"
 
 echodate "Deploying ${DEPLOY_STACK} stack to dev-asia"
-TILLER_NAMESPACE=kubermatic-installer ./api/hack/deploy.sh seed ${VALUES_FILE} ${HELM_EXTRA_ARGS}
+TILLER_NAMESPACE=kubermatic-installer ./api/hack/deploy.sh seed ${VALUES_FILE}
 echodate "Successfully deployed ${DEPLOY_STACK} stack to dev-asia"

--- a/api/hack/ci/ci-deploy-dev.sh
+++ b/api/hack/ci/ci-deploy-dev.sh
@@ -19,10 +19,6 @@ retry 5 vault write \
 export VAULT_TOKEN="$(cat /tmp/vault-token-response.json| jq .auth.client_token -r)"
 export KUBECONFIG=/tmp/kubeconfig
 export VALUES_FILE=/tmp/values.yaml
-export HELM_EXTRA_ARGS="--set=kubermatic.controller.image.tag=${GIT_HEAD_HASH} \
-    --set=kubermatic.api.image.tag=${GIT_HEAD_HASH} \
-    --set=kubermatic.masterController.image.tag=${GIT_HEAD_HASH} \
-    --set=kubermatic.controller.addons.kubernetes.image.tag=${GIT_HEAD_HASH}"
 
 # deploy to dev
 vault kv get -field=kubeconfig dev/seed-clusters/dev.kubermatic.io > ${KUBECONFIG}
@@ -30,5 +26,5 @@ vault kv get -field=values.yaml dev/seed-clusters/dev.kubermatic.io > ${VALUES_F
 echodate "Successfully got secrets for dev from Vault"
 
 echodate "Deploying ${DEPLOY_STACK} stack to dev"
-TILLER_NAMESPACE=kubermatic-installer ./api/hack/deploy.sh master ${VALUES_FILE} ${HELM_EXTRA_ARGS}
+TILLER_NAMESPACE=kubermatic-installer ./api/hack/deploy.sh master ${VALUES_FILE}
 echodate "Successfully deployed ${DEPLOY_STACK} stack to dev"

--- a/api/hack/ci/ci-deploy-run.sh
+++ b/api/hack/ci/ci-deploy-run.sh
@@ -19,10 +19,6 @@ retry 5 vault write \
 export VAULT_TOKEN="$(cat /tmp/vault-token-response.json| jq .auth.client_token -r)"
 export KUBECONFIG=/tmp/kubeconfig
 export VALUES_FILE=/tmp/values.yaml
-export HELM_EXTRA_ARGS="--set=kubermatic.controller.image.tag=${GIT_HEAD_HASH} \
-    --set=kubermatic.api.image.tag=${GIT_HEAD_HASH} \
-    --set=kubermatic.masterController.image.tag=${GIT_HEAD_HASH} \
-    --set=kubermatic.controller.addons.kubernetes.image.tag=${GIT_HEAD_HASH}"
 
 # deploy to dev
 vault kv get -field=kubeconfig dev/seed-clusters/run.kubermatic.io > ${KUBECONFIG}
@@ -30,5 +26,5 @@ vault kv get -field=values.yaml dev/seed-clusters/run.kubermatic.io > ${VALUES_F
 echodate "Successfully got secrets for run from Vault"
 
 echodate "Deploying ${DEPLOY_STACK} stack to run.kubermatic.io"
-TILLER_NAMESPACE=kube-system ./api/hack/deploy.sh master ${VALUES_FILE} ${HELM_EXTRA_ARGS}
+TILLER_NAMESPACE=kube-system ./api/hack/deploy.sh master ${VALUES_FILE}
 echodate "Successfully deployed ${DEPLOY_STACK} stack to run.kubermatic.io"

--- a/api/hack/deploy.sh
+++ b/api/hack/deploy.sh
@@ -65,6 +65,7 @@ function initTiller() {
 }
 
 sed -i "s/__KUBERMATIC_TAG__/${GIT_HEAD_HASH}/g" ./config/kubermatic/Chart.yaml
+sed -i "s/__KUBERMATIC_TAG__/${GIT_HEAD_HASH}/g" ./config/kubermatic/values.yaml
 sed -i "s/__KUBERMATIC_TAG__/${GIT_HEAD_HASH}/g" ./config/kubermatic-operator/*
 
 echodate "Deploying ${DEPLOY_STACK} stack..."


### PR DESCRIPTION
**What this PR does / why we need it**:

Because it fixes the Kubermatic deployment that currently fails because of `Back-off pulling image "quay.io/kubermatic/openshift-addons:__KUBERMATIC_TAG__"`

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Documentation**:
<!-- Add links to the related documentation changes related to this pull request. E.g. the link to the kubermatic/docs pullrequest. -->

**Does this PR introduce a user-facing change?**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If  no release note is required, just write "NONE".
-->
```release-note
none
```

/assign @xrstf 
