### PR TITLE
Add support for audit logging inside user clusters

### DIFF
--- a/api/cmd/image-loader/main.go
+++ b/api/cmd/image-loader/main.go
@@ -248,8 +248,14 @@ func getTemplateData(version *kubermaticversion.MasterVersion) (*resources.Templ
 			Namespace: mockNamespaceName,
 		},
 	}
+	auditConfigMap := corev1.ConfigMap{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      resources.AuditConfigMapName,
+			Namespace: mockNamespaceName,
+		},
+	}
 	configMapList := &corev1.ConfigMapList{
-		Items: []corev1.ConfigMap{cloudConfigConfigMap, prometheusConfigMap, dnsResolverConfigMap, openvpnClientConfigsConfigMap},
+		Items: []corev1.ConfigMap{cloudConfigConfigMap, prometheusConfigMap, dnsResolverConfigMap, openvpnClientConfigsConfigMap, auditConfigMap},
 	}
 	apiServerExternalService := corev1.Service{
 		ObjectMeta: metav1.ObjectMeta{

--- a/api/pkg/controller/cluster/resources.go
+++ b/api/pkg/controller/cluster/resources.go
@@ -275,6 +275,7 @@ func GetConfigMapCreators(data *resources.TemplateData) []reconciling.NamedConfi
 		cloudconfig.ConfigMapCreator(data),
 		openvpn.ServerClientConfigsConfigMapCreator(data),
 		dns.ConfigMapCreator(data),
+		apiserver.AuditConfigMapCreator(),
 	}
 }
 

--- a/api/pkg/resources/apiserver/deployment.go
+++ b/api/pkg/resources/apiserver/deployment.go
@@ -37,6 +37,22 @@ const (
 	defaultNodePortRange = "30000-32767"
 )
 
+func AuditConfigMapCreator() reconciling.NamedConfigMapCreatorGetter {
+	return func() (string, reconciling.ConfigMapCreator) {
+		return resources.AuditConfigMapName, func(cm *corev1.ConfigMap) (*corev1.ConfigMap, error) {
+			if cm.Data == nil {
+				cm.Data = map[string]string{
+					"policy.yaml": `apiVersion: audit.k8s.io/v1
+kind: Policy
+rules:
+- level: Metadata
+`}
+			}
+			return cm, nil
+		}
+	}
+}
+
 // DeploymentCreator returns the function to create and update the API server deployment
 func DeploymentCreator(data *resources.TemplateData, enableDexCA bool) reconciling.NamedDeploymentCreatorGetter {
 	return func() (string, reconciling.DeploymentCreator) {
@@ -162,6 +178,32 @@ func DeploymentCreator(data *resources.TemplateData, enableDexCA bool) reconcili
 				},
 			}
 
+			dep.Spec.Template.Spec.Containers = append(dep.Spec.Template.Spec.Containers,
+				corev1.Container{
+					Name:    "audit-logs",
+					Image:   "docker.io/fluent/fluent-bit:1.2.2",
+					Command: []string{"/fluent-bit/bin/fluent-bit"},
+					Args:    []string{"-i", "tail", "-p", "path=/var/log/kubernetes/audit/audit.log", "-p", "db=/var/log/kubernetes/audit/fluentbit.db", "-o", "stdout"},
+					VolumeMounts: []corev1.VolumeMount{
+						{
+							Name:      resources.AuditLogVolumeName,
+							MountPath: "/var/log/kubernetes/audit",
+							ReadOnly:  false,
+						},
+					},
+					Resources: corev1.ResourceRequirements{
+						Requests: corev1.ResourceList{
+							corev1.ResourceMemory: resource.MustParse("10Mi"),
+							corev1.ResourceCPU:    resource.MustParse("5m"),
+						},
+						Limits: corev1.ResourceList{
+							corev1.ResourceMemory: resource.MustParse("60Mi"),
+							corev1.ResourceCPU:    resource.MustParse("50m"),
+						},
+					},
+				},
+			)
+
 			dep.Spec.Template.Spec.Affinity = resources.HostnameAntiAffinity(name, data.Cluster().Name)
 
 			return dep, nil
@@ -197,7 +239,7 @@ func getApiserverFlags(data *resources.TemplateData, etcdEndpoints []string, ena
 		"--audit-log-maxage", "30",
 		"--audit-log-maxbackup", "3",
 		"--audit-log-maxsize", "100",
-		"--audit-log-path", "/var/log/audit.log",
+		"--audit-log-path", "/var/log/kubernetes/audit/audit.log",
 		"--tls-cert-file", "/etc/kubernetes/tls/apiserver-tls.crt",
 		"--tls-private-key-file", "/etc/kubernetes/tls/apiserver-tls.key",
 		"--proxy-client-cert-file", "/etc/kubernetes/pki/front-proxy/client/" + resources.ApiserverProxyClientCertificateCertSecretKey,
@@ -210,6 +252,7 @@ func getApiserverFlags(data *resources.TemplateData, etcdEndpoints []string, ena
 		"--requestheader-extra-headers-prefix", "X-Remote-Extra-",
 		"--requestheader-group-headers", "X-Remote-Group",
 		"--requestheader-username-headers", "X-Remote-User",
+		"--audit-policy-file", "/etc/kubernetes/audit/policy.yaml",
 	}
 
 	if data.Cluster().Spec.Cloud.GCP != nil {
@@ -322,6 +365,16 @@ func getVolumeMounts(enableDexCA bool) []corev1.VolumeMount {
 			MountPath: "/etc/kubernetes/pki/front-proxy/ca",
 			ReadOnly:  true,
 		},
+		{
+			Name:      resources.AuditConfigMapName,
+			MountPath: "/etc/kubernetes/audit",
+			ReadOnly:  true,
+		},
+		{
+			Name:      resources.AuditLogVolumeName,
+			MountPath: "/var/log/kubernetes/audit",
+			ReadOnly:  false,
+		},
 	}
 
 	if enableDexCA {
@@ -431,6 +484,23 @@ func getVolumes() []corev1.Volume {
 				Secret: &corev1.SecretVolumeSource{
 					SecretName: resources.KubeletDnatControllerKubeconfigSecretName,
 				},
+			},
+		},
+		{
+			Name: resources.AuditConfigMapName,
+			VolumeSource: corev1.VolumeSource{
+				ConfigMap: &corev1.ConfigMapVolumeSource{
+					LocalObjectReference: corev1.LocalObjectReference{
+						Name: resources.AuditConfigMapName,
+					},
+					Optional: new(bool),
+				},
+			},
+		},
+		{
+			Name: resources.AuditLogVolumeName,
+			VolumeSource: corev1.VolumeSource{
+				EmptyDir: &corev1.EmptyDirVolumeSource{},
 			},
 		},
 	}

--- a/api/pkg/resources/resources.go
+++ b/api/pkg/resources/resources.go
@@ -158,6 +158,8 @@ const (
 	GoogleServiceAccountSecretName = "google-service-account"
 	// GoogleServiceAccountVolumeName is the name of the volume containing the Google Service Account secret.
 	GoogleServiceAccountVolumeName = "google-service-account-volume"
+	// AuditLogVolumeName is the name of the volume that hold the audit log of the apiserver.
+	AuditLogVolumeName = "audit-log"
 
 	//CloudConfigConfigMapName is the name for the configmap containing the cloud-config
 	CloudConfigConfigMapName = "cloud-config"
@@ -169,6 +171,8 @@ const (
 	ClusterInfoConfigMapName = "cluster-info"
 	//PrometheusConfigConfigMapName is the name for the configmap containing the prometheus config
 	PrometheusConfigConfigMapName = "prometheus"
+	//AuditConfigMapName is the name for the configmap that contains the content of the file that will be passed to the apiserver with the flag "--audit-policy-file".
+	AuditConfigMapName = "audit-config"
 
 	//PrometheusServiceAccountName is the name for the Prometheus serviceaccount
 	PrometheusServiceAccountName = "prometheus"

--- a/api/pkg/resources/test/fixtures/configmap-aws-1.10.0-audit-config.yaml
+++ b/api/pkg/resources/test/fixtures/configmap-aws-1.10.0-audit-config.yaml
@@ -1,0 +1,8 @@
+data:
+  policy.yaml: |
+    apiVersion: audit.k8s.io/v1
+    kind: Policy
+    rules:
+    - level: Metadata
+metadata:
+  creationTimestamp: null

--- a/api/pkg/resources/test/fixtures/configmap-aws-1.10.6-audit-config.yaml
+++ b/api/pkg/resources/test/fixtures/configmap-aws-1.10.6-audit-config.yaml
@@ -1,0 +1,8 @@
+data:
+  policy.yaml: |
+    apiVersion: audit.k8s.io/v1
+    kind: Policy
+    rules:
+    - level: Metadata
+metadata:
+  creationTimestamp: null

--- a/api/pkg/resources/test/fixtures/configmap-aws-1.11.0-audit-config.yaml
+++ b/api/pkg/resources/test/fixtures/configmap-aws-1.11.0-audit-config.yaml
@@ -1,0 +1,8 @@
+data:
+  policy.yaml: |
+    apiVersion: audit.k8s.io/v1
+    kind: Policy
+    rules:
+    - level: Metadata
+metadata:
+  creationTimestamp: null

--- a/api/pkg/resources/test/fixtures/configmap-aws-1.11.1-audit-config.yaml
+++ b/api/pkg/resources/test/fixtures/configmap-aws-1.11.1-audit-config.yaml
@@ -1,0 +1,8 @@
+data:
+  policy.yaml: |
+    apiVersion: audit.k8s.io/v1
+    kind: Policy
+    rules:
+    - level: Metadata
+metadata:
+  creationTimestamp: null

--- a/api/pkg/resources/test/fixtures/configmap-aws-1.12.0-audit-config.yaml
+++ b/api/pkg/resources/test/fixtures/configmap-aws-1.12.0-audit-config.yaml
@@ -1,0 +1,8 @@
+data:
+  policy.yaml: |
+    apiVersion: audit.k8s.io/v1
+    kind: Policy
+    rules:
+    - level: Metadata
+metadata:
+  creationTimestamp: null

--- a/api/pkg/resources/test/fixtures/configmap-aws-1.13.0-audit-config.yaml
+++ b/api/pkg/resources/test/fixtures/configmap-aws-1.13.0-audit-config.yaml
@@ -1,0 +1,8 @@
+data:
+  policy.yaml: |
+    apiVersion: audit.k8s.io/v1
+    kind: Policy
+    rules:
+    - level: Metadata
+metadata:
+  creationTimestamp: null

--- a/api/pkg/resources/test/fixtures/configmap-azure-1.10.0-audit-config.yaml
+++ b/api/pkg/resources/test/fixtures/configmap-azure-1.10.0-audit-config.yaml
@@ -1,0 +1,8 @@
+data:
+  policy.yaml: |
+    apiVersion: audit.k8s.io/v1
+    kind: Policy
+    rules:
+    - level: Metadata
+metadata:
+  creationTimestamp: null

--- a/api/pkg/resources/test/fixtures/configmap-azure-1.10.6-audit-config.yaml
+++ b/api/pkg/resources/test/fixtures/configmap-azure-1.10.6-audit-config.yaml
@@ -1,0 +1,8 @@
+data:
+  policy.yaml: |
+    apiVersion: audit.k8s.io/v1
+    kind: Policy
+    rules:
+    - level: Metadata
+metadata:
+  creationTimestamp: null

--- a/api/pkg/resources/test/fixtures/configmap-azure-1.11.0-audit-config.yaml
+++ b/api/pkg/resources/test/fixtures/configmap-azure-1.11.0-audit-config.yaml
@@ -1,0 +1,8 @@
+data:
+  policy.yaml: |
+    apiVersion: audit.k8s.io/v1
+    kind: Policy
+    rules:
+    - level: Metadata
+metadata:
+  creationTimestamp: null

--- a/api/pkg/resources/test/fixtures/configmap-azure-1.11.1-audit-config.yaml
+++ b/api/pkg/resources/test/fixtures/configmap-azure-1.11.1-audit-config.yaml
@@ -1,0 +1,8 @@
+data:
+  policy.yaml: |
+    apiVersion: audit.k8s.io/v1
+    kind: Policy
+    rules:
+    - level: Metadata
+metadata:
+  creationTimestamp: null

--- a/api/pkg/resources/test/fixtures/configmap-azure-1.12.0-audit-config.yaml
+++ b/api/pkg/resources/test/fixtures/configmap-azure-1.12.0-audit-config.yaml
@@ -1,0 +1,8 @@
+data:
+  policy.yaml: |
+    apiVersion: audit.k8s.io/v1
+    kind: Policy
+    rules:
+    - level: Metadata
+metadata:
+  creationTimestamp: null

--- a/api/pkg/resources/test/fixtures/configmap-azure-1.13.0-audit-config.yaml
+++ b/api/pkg/resources/test/fixtures/configmap-azure-1.13.0-audit-config.yaml
@@ -1,0 +1,8 @@
+data:
+  policy.yaml: |
+    apiVersion: audit.k8s.io/v1
+    kind: Policy
+    rules:
+    - level: Metadata
+metadata:
+  creationTimestamp: null

--- a/api/pkg/resources/test/fixtures/configmap-bringyourown-1.10.0-audit-config.yaml
+++ b/api/pkg/resources/test/fixtures/configmap-bringyourown-1.10.0-audit-config.yaml
@@ -1,0 +1,8 @@
+data:
+  policy.yaml: |
+    apiVersion: audit.k8s.io/v1
+    kind: Policy
+    rules:
+    - level: Metadata
+metadata:
+  creationTimestamp: null

--- a/api/pkg/resources/test/fixtures/configmap-bringyourown-1.10.6-audit-config.yaml
+++ b/api/pkg/resources/test/fixtures/configmap-bringyourown-1.10.6-audit-config.yaml
@@ -1,0 +1,8 @@
+data:
+  policy.yaml: |
+    apiVersion: audit.k8s.io/v1
+    kind: Policy
+    rules:
+    - level: Metadata
+metadata:
+  creationTimestamp: null

--- a/api/pkg/resources/test/fixtures/configmap-bringyourown-1.11.0-audit-config.yaml
+++ b/api/pkg/resources/test/fixtures/configmap-bringyourown-1.11.0-audit-config.yaml
@@ -1,0 +1,8 @@
+data:
+  policy.yaml: |
+    apiVersion: audit.k8s.io/v1
+    kind: Policy
+    rules:
+    - level: Metadata
+metadata:
+  creationTimestamp: null

--- a/api/pkg/resources/test/fixtures/configmap-bringyourown-1.11.1-audit-config.yaml
+++ b/api/pkg/resources/test/fixtures/configmap-bringyourown-1.11.1-audit-config.yaml
@@ -1,0 +1,8 @@
+data:
+  policy.yaml: |
+    apiVersion: audit.k8s.io/v1
+    kind: Policy
+    rules:
+    - level: Metadata
+metadata:
+  creationTimestamp: null

--- a/api/pkg/resources/test/fixtures/configmap-bringyourown-1.12.0-audit-config.yaml
+++ b/api/pkg/resources/test/fixtures/configmap-bringyourown-1.12.0-audit-config.yaml
@@ -1,0 +1,8 @@
+data:
+  policy.yaml: |
+    apiVersion: audit.k8s.io/v1
+    kind: Policy
+    rules:
+    - level: Metadata
+metadata:
+  creationTimestamp: null

--- a/api/pkg/resources/test/fixtures/configmap-bringyourown-1.13.0-audit-config.yaml
+++ b/api/pkg/resources/test/fixtures/configmap-bringyourown-1.13.0-audit-config.yaml
@@ -1,0 +1,8 @@
+data:
+  policy.yaml: |
+    apiVersion: audit.k8s.io/v1
+    kind: Policy
+    rules:
+    - level: Metadata
+metadata:
+  creationTimestamp: null

--- a/api/pkg/resources/test/fixtures/configmap-digitalocean-1.10.0-audit-config.yaml
+++ b/api/pkg/resources/test/fixtures/configmap-digitalocean-1.10.0-audit-config.yaml
@@ -1,0 +1,8 @@
+data:
+  policy.yaml: |
+    apiVersion: audit.k8s.io/v1
+    kind: Policy
+    rules:
+    - level: Metadata
+metadata:
+  creationTimestamp: null

--- a/api/pkg/resources/test/fixtures/configmap-digitalocean-1.10.6-audit-config.yaml
+++ b/api/pkg/resources/test/fixtures/configmap-digitalocean-1.10.6-audit-config.yaml
@@ -1,0 +1,8 @@
+data:
+  policy.yaml: |
+    apiVersion: audit.k8s.io/v1
+    kind: Policy
+    rules:
+    - level: Metadata
+metadata:
+  creationTimestamp: null

--- a/api/pkg/resources/test/fixtures/configmap-digitalocean-1.11.0-audit-config.yaml
+++ b/api/pkg/resources/test/fixtures/configmap-digitalocean-1.11.0-audit-config.yaml
@@ -1,0 +1,8 @@
+data:
+  policy.yaml: |
+    apiVersion: audit.k8s.io/v1
+    kind: Policy
+    rules:
+    - level: Metadata
+metadata:
+  creationTimestamp: null

--- a/api/pkg/resources/test/fixtures/configmap-digitalocean-1.11.1-audit-config.yaml
+++ b/api/pkg/resources/test/fixtures/configmap-digitalocean-1.11.1-audit-config.yaml
@@ -1,0 +1,8 @@
+data:
+  policy.yaml: |
+    apiVersion: audit.k8s.io/v1
+    kind: Policy
+    rules:
+    - level: Metadata
+metadata:
+  creationTimestamp: null

--- a/api/pkg/resources/test/fixtures/configmap-digitalocean-1.12.0-audit-config.yaml
+++ b/api/pkg/resources/test/fixtures/configmap-digitalocean-1.12.0-audit-config.yaml
@@ -1,0 +1,8 @@
+data:
+  policy.yaml: |
+    apiVersion: audit.k8s.io/v1
+    kind: Policy
+    rules:
+    - level: Metadata
+metadata:
+  creationTimestamp: null

--- a/api/pkg/resources/test/fixtures/configmap-digitalocean-1.13.0-audit-config.yaml
+++ b/api/pkg/resources/test/fixtures/configmap-digitalocean-1.13.0-audit-config.yaml
@@ -1,0 +1,8 @@
+data:
+  policy.yaml: |
+    apiVersion: audit.k8s.io/v1
+    kind: Policy
+    rules:
+    - level: Metadata
+metadata:
+  creationTimestamp: null

--- a/api/pkg/resources/test/fixtures/configmap-openstack-1.10.0-audit-config.yaml
+++ b/api/pkg/resources/test/fixtures/configmap-openstack-1.10.0-audit-config.yaml
@@ -1,0 +1,8 @@
+data:
+  policy.yaml: |
+    apiVersion: audit.k8s.io/v1
+    kind: Policy
+    rules:
+    - level: Metadata
+metadata:
+  creationTimestamp: null

--- a/api/pkg/resources/test/fixtures/configmap-openstack-1.10.6-audit-config.yaml
+++ b/api/pkg/resources/test/fixtures/configmap-openstack-1.10.6-audit-config.yaml
@@ -1,0 +1,8 @@
+data:
+  policy.yaml: |
+    apiVersion: audit.k8s.io/v1
+    kind: Policy
+    rules:
+    - level: Metadata
+metadata:
+  creationTimestamp: null

--- a/api/pkg/resources/test/fixtures/configmap-openstack-1.11.0-audit-config.yaml
+++ b/api/pkg/resources/test/fixtures/configmap-openstack-1.11.0-audit-config.yaml
@@ -1,0 +1,8 @@
+data:
+  policy.yaml: |
+    apiVersion: audit.k8s.io/v1
+    kind: Policy
+    rules:
+    - level: Metadata
+metadata:
+  creationTimestamp: null

--- a/api/pkg/resources/test/fixtures/configmap-openstack-1.11.1-audit-config.yaml
+++ b/api/pkg/resources/test/fixtures/configmap-openstack-1.11.1-audit-config.yaml
@@ -1,0 +1,8 @@
+data:
+  policy.yaml: |
+    apiVersion: audit.k8s.io/v1
+    kind: Policy
+    rules:
+    - level: Metadata
+metadata:
+  creationTimestamp: null

--- a/api/pkg/resources/test/fixtures/configmap-openstack-1.12.0-audit-config.yaml
+++ b/api/pkg/resources/test/fixtures/configmap-openstack-1.12.0-audit-config.yaml
@@ -1,0 +1,8 @@
+data:
+  policy.yaml: |
+    apiVersion: audit.k8s.io/v1
+    kind: Policy
+    rules:
+    - level: Metadata
+metadata:
+  creationTimestamp: null

--- a/api/pkg/resources/test/fixtures/configmap-openstack-1.13.0-audit-config.yaml
+++ b/api/pkg/resources/test/fixtures/configmap-openstack-1.13.0-audit-config.yaml
@@ -1,0 +1,8 @@
+data:
+  policy.yaml: |
+    apiVersion: audit.k8s.io/v1
+    kind: Policy
+    rules:
+    - level: Metadata
+metadata:
+  creationTimestamp: null

--- a/api/pkg/resources/test/fixtures/configmap-vsphere-1.10.0-audit-config.yaml
+++ b/api/pkg/resources/test/fixtures/configmap-vsphere-1.10.0-audit-config.yaml
@@ -1,0 +1,8 @@
+data:
+  policy.yaml: |
+    apiVersion: audit.k8s.io/v1
+    kind: Policy
+    rules:
+    - level: Metadata
+metadata:
+  creationTimestamp: null

--- a/api/pkg/resources/test/fixtures/configmap-vsphere-1.10.6-audit-config.yaml
+++ b/api/pkg/resources/test/fixtures/configmap-vsphere-1.10.6-audit-config.yaml
@@ -1,0 +1,8 @@
+data:
+  policy.yaml: |
+    apiVersion: audit.k8s.io/v1
+    kind: Policy
+    rules:
+    - level: Metadata
+metadata:
+  creationTimestamp: null

--- a/api/pkg/resources/test/fixtures/configmap-vsphere-1.11.0-audit-config.yaml
+++ b/api/pkg/resources/test/fixtures/configmap-vsphere-1.11.0-audit-config.yaml
@@ -1,0 +1,8 @@
+data:
+  policy.yaml: |
+    apiVersion: audit.k8s.io/v1
+    kind: Policy
+    rules:
+    - level: Metadata
+metadata:
+  creationTimestamp: null

--- a/api/pkg/resources/test/fixtures/configmap-vsphere-1.11.1-audit-config.yaml
+++ b/api/pkg/resources/test/fixtures/configmap-vsphere-1.11.1-audit-config.yaml
@@ -1,0 +1,8 @@
+data:
+  policy.yaml: |
+    apiVersion: audit.k8s.io/v1
+    kind: Policy
+    rules:
+    - level: Metadata
+metadata:
+  creationTimestamp: null

--- a/api/pkg/resources/test/fixtures/configmap-vsphere-1.12.0-audit-config.yaml
+++ b/api/pkg/resources/test/fixtures/configmap-vsphere-1.12.0-audit-config.yaml
@@ -1,0 +1,8 @@
+data:
+  policy.yaml: |
+    apiVersion: audit.k8s.io/v1
+    kind: Policy
+    rules:
+    - level: Metadata
+metadata:
+  creationTimestamp: null

--- a/api/pkg/resources/test/fixtures/configmap-vsphere-1.13.0-audit-config.yaml
+++ b/api/pkg/resources/test/fixtures/configmap-vsphere-1.13.0-audit-config.yaml
@@ -1,0 +1,8 @@
+data:
+  policy.yaml: |
+    apiVersion: audit.k8s.io/v1
+    kind: Policy
+    rules:
+    - level: Metadata
+metadata:
+  creationTimestamp: null

--- a/api/pkg/resources/test/fixtures/deployment-aws-1.10.0-apiserver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-aws-1.10.0-apiserver.yaml
@@ -21,6 +21,7 @@ spec:
         apiserver-proxy-client-certificate-secret-revision: "123456"
         apiserver-tls-secret-revision: "123456"
         app: apiserver
+        audit-config-configmap-revision: "123456"
         ca-secret-revision: "123456"
         cloud-config-configmap-revision: "123456"
         cluster: de-test-01
@@ -175,7 +176,7 @@ spec:
         - --audit-log-maxsize
         - "100"
         - --audit-log-path
-        - /var/log/audit.log
+        - /var/log/kubernetes/audit/audit.log
         - --tls-cert-file
         - /etc/kubernetes/tls/apiserver-tls.crt
         - --tls-private-key-file
@@ -200,6 +201,8 @@ spec:
         - X-Remote-Group
         - --requestheader-username-headers
         - X-Remote-User
+        - --audit-policy-file
+        - /etc/kubernetes/audit/policy.yaml
         - --kubelet-preferred-address-types
         - ExternalIP,InternalIP
         - --feature-gates
@@ -285,9 +288,37 @@ spec:
         - mountPath: /etc/kubernetes/pki/front-proxy/ca
           name: front-proxy-ca
           readOnly: true
+        - mountPath: /etc/kubernetes/audit
+          name: audit-config
+          readOnly: true
+        - mountPath: /var/log/kubernetes/audit
+          name: audit-log
         - mountPath: /etc/kubernetes/dex/ca
           name: dex-ca
           readOnly: true
+      - args:
+        - -i
+        - tail
+        - -p
+        - path=/var/log/kubernetes/audit/audit.log
+        - -p
+        - db=/var/log/kubernetes/audit/fluentbit.db
+        - -o
+        - stdout
+        command:
+        - /fluent-bit/bin/fluent-bit
+        image: docker.io/fluent/fluent-bit:1.2.2
+        name: audit-logs
+        resources:
+          limits:
+            cpu: 50m
+            memory: 60Mi
+          requests:
+            cpu: 5m
+            memory: 10Mi
+        volumeMounts:
+        - mountPath: /var/log/kubernetes/audit
+          name: audit-log
       dnsConfig:
         nameservers:
         - 192.0.2.14
@@ -354,6 +385,12 @@ spec:
       - name: kubeletdnatcontroller-kubeconfig
         secret:
           secretName: kubeletdnatcontroller-kubeconfig
+      - configMap:
+          name: audit-config
+          optional: false
+        name: audit-config
+      - emptyDir: {}
+        name: audit-log
       - name: dex-ca
         secret:
           secretName: dex-ca

--- a/api/pkg/resources/test/fixtures/deployment-aws-1.10.6-apiserver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-aws-1.10.6-apiserver.yaml
@@ -21,6 +21,7 @@ spec:
         apiserver-proxy-client-certificate-secret-revision: "123456"
         apiserver-tls-secret-revision: "123456"
         app: apiserver
+        audit-config-configmap-revision: "123456"
         ca-secret-revision: "123456"
         cloud-config-configmap-revision: "123456"
         cluster: de-test-01
@@ -175,7 +176,7 @@ spec:
         - --audit-log-maxsize
         - "100"
         - --audit-log-path
-        - /var/log/audit.log
+        - /var/log/kubernetes/audit/audit.log
         - --tls-cert-file
         - /etc/kubernetes/tls/apiserver-tls.crt
         - --tls-private-key-file
@@ -200,6 +201,8 @@ spec:
         - X-Remote-Group
         - --requestheader-username-headers
         - X-Remote-User
+        - --audit-policy-file
+        - /etc/kubernetes/audit/policy.yaml
         - --kubelet-preferred-address-types
         - ExternalIP,InternalIP
         - --feature-gates
@@ -285,9 +288,37 @@ spec:
         - mountPath: /etc/kubernetes/pki/front-proxy/ca
           name: front-proxy-ca
           readOnly: true
+        - mountPath: /etc/kubernetes/audit
+          name: audit-config
+          readOnly: true
+        - mountPath: /var/log/kubernetes/audit
+          name: audit-log
         - mountPath: /etc/kubernetes/dex/ca
           name: dex-ca
           readOnly: true
+      - args:
+        - -i
+        - tail
+        - -p
+        - path=/var/log/kubernetes/audit/audit.log
+        - -p
+        - db=/var/log/kubernetes/audit/fluentbit.db
+        - -o
+        - stdout
+        command:
+        - /fluent-bit/bin/fluent-bit
+        image: docker.io/fluent/fluent-bit:1.2.2
+        name: audit-logs
+        resources:
+          limits:
+            cpu: 50m
+            memory: 60Mi
+          requests:
+            cpu: 5m
+            memory: 10Mi
+        volumeMounts:
+        - mountPath: /var/log/kubernetes/audit
+          name: audit-log
       dnsConfig:
         nameservers:
         - 192.0.2.14
@@ -354,6 +385,12 @@ spec:
       - name: kubeletdnatcontroller-kubeconfig
         secret:
           secretName: kubeletdnatcontroller-kubeconfig
+      - configMap:
+          name: audit-config
+          optional: false
+        name: audit-config
+      - emptyDir: {}
+        name: audit-log
       - name: dex-ca
         secret:
           secretName: dex-ca

--- a/api/pkg/resources/test/fixtures/deployment-aws-1.11.0-apiserver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-aws-1.11.0-apiserver.yaml
@@ -21,6 +21,7 @@ spec:
         apiserver-proxy-client-certificate-secret-revision: "123456"
         apiserver-tls-secret-revision: "123456"
         app: apiserver
+        audit-config-configmap-revision: "123456"
         ca-secret-revision: "123456"
         cloud-config-configmap-revision: "123456"
         cluster: de-test-01
@@ -175,7 +176,7 @@ spec:
         - --audit-log-maxsize
         - "100"
         - --audit-log-path
-        - /var/log/audit.log
+        - /var/log/kubernetes/audit/audit.log
         - --tls-cert-file
         - /etc/kubernetes/tls/apiserver-tls.crt
         - --tls-private-key-file
@@ -200,6 +201,8 @@ spec:
         - X-Remote-Group
         - --requestheader-username-headers
         - X-Remote-User
+        - --audit-policy-file
+        - /etc/kubernetes/audit/policy.yaml
         - --kubelet-preferred-address-types
         - ExternalIP,InternalIP
         - --cloud-provider
@@ -283,9 +286,37 @@ spec:
         - mountPath: /etc/kubernetes/pki/front-proxy/ca
           name: front-proxy-ca
           readOnly: true
+        - mountPath: /etc/kubernetes/audit
+          name: audit-config
+          readOnly: true
+        - mountPath: /var/log/kubernetes/audit
+          name: audit-log
         - mountPath: /etc/kubernetes/dex/ca
           name: dex-ca
           readOnly: true
+      - args:
+        - -i
+        - tail
+        - -p
+        - path=/var/log/kubernetes/audit/audit.log
+        - -p
+        - db=/var/log/kubernetes/audit/fluentbit.db
+        - -o
+        - stdout
+        command:
+        - /fluent-bit/bin/fluent-bit
+        image: docker.io/fluent/fluent-bit:1.2.2
+        name: audit-logs
+        resources:
+          limits:
+            cpu: 50m
+            memory: 60Mi
+          requests:
+            cpu: 5m
+            memory: 10Mi
+        volumeMounts:
+        - mountPath: /var/log/kubernetes/audit
+          name: audit-log
       dnsConfig:
         nameservers:
         - 192.0.2.14
@@ -352,6 +383,12 @@ spec:
       - name: kubeletdnatcontroller-kubeconfig
         secret:
           secretName: kubeletdnatcontroller-kubeconfig
+      - configMap:
+          name: audit-config
+          optional: false
+        name: audit-config
+      - emptyDir: {}
+        name: audit-log
       - name: dex-ca
         secret:
           secretName: dex-ca

--- a/api/pkg/resources/test/fixtures/deployment-aws-1.11.1-apiserver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-aws-1.11.1-apiserver.yaml
@@ -21,6 +21,7 @@ spec:
         apiserver-proxy-client-certificate-secret-revision: "123456"
         apiserver-tls-secret-revision: "123456"
         app: apiserver
+        audit-config-configmap-revision: "123456"
         ca-secret-revision: "123456"
         cloud-config-configmap-revision: "123456"
         cluster: de-test-01
@@ -175,7 +176,7 @@ spec:
         - --audit-log-maxsize
         - "100"
         - --audit-log-path
-        - /var/log/audit.log
+        - /var/log/kubernetes/audit/audit.log
         - --tls-cert-file
         - /etc/kubernetes/tls/apiserver-tls.crt
         - --tls-private-key-file
@@ -200,6 +201,8 @@ spec:
         - X-Remote-Group
         - --requestheader-username-headers
         - X-Remote-User
+        - --audit-policy-file
+        - /etc/kubernetes/audit/policy.yaml
         - --kubelet-preferred-address-types
         - ExternalIP,InternalIP
         - --cloud-provider
@@ -283,9 +286,37 @@ spec:
         - mountPath: /etc/kubernetes/pki/front-proxy/ca
           name: front-proxy-ca
           readOnly: true
+        - mountPath: /etc/kubernetes/audit
+          name: audit-config
+          readOnly: true
+        - mountPath: /var/log/kubernetes/audit
+          name: audit-log
         - mountPath: /etc/kubernetes/dex/ca
           name: dex-ca
           readOnly: true
+      - args:
+        - -i
+        - tail
+        - -p
+        - path=/var/log/kubernetes/audit/audit.log
+        - -p
+        - db=/var/log/kubernetes/audit/fluentbit.db
+        - -o
+        - stdout
+        command:
+        - /fluent-bit/bin/fluent-bit
+        image: docker.io/fluent/fluent-bit:1.2.2
+        name: audit-logs
+        resources:
+          limits:
+            cpu: 50m
+            memory: 60Mi
+          requests:
+            cpu: 5m
+            memory: 10Mi
+        volumeMounts:
+        - mountPath: /var/log/kubernetes/audit
+          name: audit-log
       dnsConfig:
         nameservers:
         - 192.0.2.14
@@ -352,6 +383,12 @@ spec:
       - name: kubeletdnatcontroller-kubeconfig
         secret:
           secretName: kubeletdnatcontroller-kubeconfig
+      - configMap:
+          name: audit-config
+          optional: false
+        name: audit-config
+      - emptyDir: {}
+        name: audit-log
       - name: dex-ca
         secret:
           secretName: dex-ca

--- a/api/pkg/resources/test/fixtures/deployment-aws-1.12.0-apiserver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-aws-1.12.0-apiserver.yaml
@@ -21,6 +21,7 @@ spec:
         apiserver-proxy-client-certificate-secret-revision: "123456"
         apiserver-tls-secret-revision: "123456"
         app: apiserver
+        audit-config-configmap-revision: "123456"
         ca-secret-revision: "123456"
         cloud-config-configmap-revision: "123456"
         cluster: de-test-01
@@ -175,7 +176,7 @@ spec:
         - --audit-log-maxsize
         - "100"
         - --audit-log-path
-        - /var/log/audit.log
+        - /var/log/kubernetes/audit/audit.log
         - --tls-cert-file
         - /etc/kubernetes/tls/apiserver-tls.crt
         - --tls-private-key-file
@@ -200,6 +201,8 @@ spec:
         - X-Remote-Group
         - --requestheader-username-headers
         - X-Remote-User
+        - --audit-policy-file
+        - /etc/kubernetes/audit/policy.yaml
         - --kubelet-preferred-address-types
         - ExternalIP,InternalIP
         - --cloud-provider
@@ -283,9 +286,37 @@ spec:
         - mountPath: /etc/kubernetes/pki/front-proxy/ca
           name: front-proxy-ca
           readOnly: true
+        - mountPath: /etc/kubernetes/audit
+          name: audit-config
+          readOnly: true
+        - mountPath: /var/log/kubernetes/audit
+          name: audit-log
         - mountPath: /etc/kubernetes/dex/ca
           name: dex-ca
           readOnly: true
+      - args:
+        - -i
+        - tail
+        - -p
+        - path=/var/log/kubernetes/audit/audit.log
+        - -p
+        - db=/var/log/kubernetes/audit/fluentbit.db
+        - -o
+        - stdout
+        command:
+        - /fluent-bit/bin/fluent-bit
+        image: docker.io/fluent/fluent-bit:1.2.2
+        name: audit-logs
+        resources:
+          limits:
+            cpu: 50m
+            memory: 60Mi
+          requests:
+            cpu: 5m
+            memory: 10Mi
+        volumeMounts:
+        - mountPath: /var/log/kubernetes/audit
+          name: audit-log
       dnsConfig:
         nameservers:
         - 192.0.2.14
@@ -352,6 +383,12 @@ spec:
       - name: kubeletdnatcontroller-kubeconfig
         secret:
           secretName: kubeletdnatcontroller-kubeconfig
+      - configMap:
+          name: audit-config
+          optional: false
+        name: audit-config
+      - emptyDir: {}
+        name: audit-log
       - name: dex-ca
         secret:
           secretName: dex-ca

--- a/api/pkg/resources/test/fixtures/deployment-aws-1.13.0-apiserver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-aws-1.13.0-apiserver.yaml
@@ -21,6 +21,7 @@ spec:
         apiserver-proxy-client-certificate-secret-revision: "123456"
         apiserver-tls-secret-revision: "123456"
         app: apiserver
+        audit-config-configmap-revision: "123456"
         ca-secret-revision: "123456"
         cloud-config-configmap-revision: "123456"
         cluster: de-test-01
@@ -175,7 +176,7 @@ spec:
         - --audit-log-maxsize
         - "100"
         - --audit-log-path
-        - /var/log/audit.log
+        - /var/log/kubernetes/audit/audit.log
         - --tls-cert-file
         - /etc/kubernetes/tls/apiserver-tls.crt
         - --tls-private-key-file
@@ -200,6 +201,8 @@ spec:
         - X-Remote-Group
         - --requestheader-username-headers
         - X-Remote-User
+        - --audit-policy-file
+        - /etc/kubernetes/audit/policy.yaml
         - --kubelet-preferred-address-types
         - ExternalIP,InternalIP
         - --cloud-provider
@@ -283,9 +286,37 @@ spec:
         - mountPath: /etc/kubernetes/pki/front-proxy/ca
           name: front-proxy-ca
           readOnly: true
+        - mountPath: /etc/kubernetes/audit
+          name: audit-config
+          readOnly: true
+        - mountPath: /var/log/kubernetes/audit
+          name: audit-log
         - mountPath: /etc/kubernetes/dex/ca
           name: dex-ca
           readOnly: true
+      - args:
+        - -i
+        - tail
+        - -p
+        - path=/var/log/kubernetes/audit/audit.log
+        - -p
+        - db=/var/log/kubernetes/audit/fluentbit.db
+        - -o
+        - stdout
+        command:
+        - /fluent-bit/bin/fluent-bit
+        image: docker.io/fluent/fluent-bit:1.2.2
+        name: audit-logs
+        resources:
+          limits:
+            cpu: 50m
+            memory: 60Mi
+          requests:
+            cpu: 5m
+            memory: 10Mi
+        volumeMounts:
+        - mountPath: /var/log/kubernetes/audit
+          name: audit-log
       dnsConfig:
         nameservers:
         - 192.0.2.14
@@ -352,6 +383,12 @@ spec:
       - name: kubeletdnatcontroller-kubeconfig
         secret:
           secretName: kubeletdnatcontroller-kubeconfig
+      - configMap:
+          name: audit-config
+          optional: false
+        name: audit-config
+      - emptyDir: {}
+        name: audit-log
       - name: dex-ca
         secret:
           secretName: dex-ca

--- a/api/pkg/resources/test/fixtures/deployment-azure-1.10.0-apiserver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-azure-1.10.0-apiserver.yaml
@@ -21,6 +21,7 @@ spec:
         apiserver-proxy-client-certificate-secret-revision: "123456"
         apiserver-tls-secret-revision: "123456"
         app: apiserver
+        audit-config-configmap-revision: "123456"
         ca-secret-revision: "123456"
         cloud-config-configmap-revision: "123456"
         cluster: de-test-01
@@ -175,7 +176,7 @@ spec:
         - --audit-log-maxsize
         - "100"
         - --audit-log-path
-        - /var/log/audit.log
+        - /var/log/kubernetes/audit/audit.log
         - --tls-cert-file
         - /etc/kubernetes/tls/apiserver-tls.crt
         - --tls-private-key-file
@@ -200,6 +201,8 @@ spec:
         - X-Remote-Group
         - --requestheader-username-headers
         - X-Remote-User
+        - --audit-policy-file
+        - /etc/kubernetes/audit/policy.yaml
         - --kubelet-preferred-address-types
         - ExternalIP,InternalIP
         - --feature-gates
@@ -278,9 +281,37 @@ spec:
         - mountPath: /etc/kubernetes/pki/front-proxy/ca
           name: front-proxy-ca
           readOnly: true
+        - mountPath: /etc/kubernetes/audit
+          name: audit-config
+          readOnly: true
+        - mountPath: /var/log/kubernetes/audit
+          name: audit-log
         - mountPath: /etc/kubernetes/dex/ca
           name: dex-ca
           readOnly: true
+      - args:
+        - -i
+        - tail
+        - -p
+        - path=/var/log/kubernetes/audit/audit.log
+        - -p
+        - db=/var/log/kubernetes/audit/fluentbit.db
+        - -o
+        - stdout
+        command:
+        - /fluent-bit/bin/fluent-bit
+        image: docker.io/fluent/fluent-bit:1.2.2
+        name: audit-logs
+        resources:
+          limits:
+            cpu: 50m
+            memory: 60Mi
+          requests:
+            cpu: 5m
+            memory: 10Mi
+        volumeMounts:
+        - mountPath: /var/log/kubernetes/audit
+          name: audit-log
       dnsConfig:
         nameservers:
         - 192.0.2.14
@@ -347,6 +378,12 @@ spec:
       - name: kubeletdnatcontroller-kubeconfig
         secret:
           secretName: kubeletdnatcontroller-kubeconfig
+      - configMap:
+          name: audit-config
+          optional: false
+        name: audit-config
+      - emptyDir: {}
+        name: audit-log
       - name: dex-ca
         secret:
           secretName: dex-ca

--- a/api/pkg/resources/test/fixtures/deployment-azure-1.10.6-apiserver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-azure-1.10.6-apiserver.yaml
@@ -21,6 +21,7 @@ spec:
         apiserver-proxy-client-certificate-secret-revision: "123456"
         apiserver-tls-secret-revision: "123456"
         app: apiserver
+        audit-config-configmap-revision: "123456"
         ca-secret-revision: "123456"
         cloud-config-configmap-revision: "123456"
         cluster: de-test-01
@@ -175,7 +176,7 @@ spec:
         - --audit-log-maxsize
         - "100"
         - --audit-log-path
-        - /var/log/audit.log
+        - /var/log/kubernetes/audit/audit.log
         - --tls-cert-file
         - /etc/kubernetes/tls/apiserver-tls.crt
         - --tls-private-key-file
@@ -200,6 +201,8 @@ spec:
         - X-Remote-Group
         - --requestheader-username-headers
         - X-Remote-User
+        - --audit-policy-file
+        - /etc/kubernetes/audit/policy.yaml
         - --kubelet-preferred-address-types
         - ExternalIP,InternalIP
         - --feature-gates
@@ -278,9 +281,37 @@ spec:
         - mountPath: /etc/kubernetes/pki/front-proxy/ca
           name: front-proxy-ca
           readOnly: true
+        - mountPath: /etc/kubernetes/audit
+          name: audit-config
+          readOnly: true
+        - mountPath: /var/log/kubernetes/audit
+          name: audit-log
         - mountPath: /etc/kubernetes/dex/ca
           name: dex-ca
           readOnly: true
+      - args:
+        - -i
+        - tail
+        - -p
+        - path=/var/log/kubernetes/audit/audit.log
+        - -p
+        - db=/var/log/kubernetes/audit/fluentbit.db
+        - -o
+        - stdout
+        command:
+        - /fluent-bit/bin/fluent-bit
+        image: docker.io/fluent/fluent-bit:1.2.2
+        name: audit-logs
+        resources:
+          limits:
+            cpu: 50m
+            memory: 60Mi
+          requests:
+            cpu: 5m
+            memory: 10Mi
+        volumeMounts:
+        - mountPath: /var/log/kubernetes/audit
+          name: audit-log
       dnsConfig:
         nameservers:
         - 192.0.2.14
@@ -347,6 +378,12 @@ spec:
       - name: kubeletdnatcontroller-kubeconfig
         secret:
           secretName: kubeletdnatcontroller-kubeconfig
+      - configMap:
+          name: audit-config
+          optional: false
+        name: audit-config
+      - emptyDir: {}
+        name: audit-log
       - name: dex-ca
         secret:
           secretName: dex-ca

--- a/api/pkg/resources/test/fixtures/deployment-azure-1.11.0-apiserver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-azure-1.11.0-apiserver.yaml
@@ -21,6 +21,7 @@ spec:
         apiserver-proxy-client-certificate-secret-revision: "123456"
         apiserver-tls-secret-revision: "123456"
         app: apiserver
+        audit-config-configmap-revision: "123456"
         ca-secret-revision: "123456"
         cloud-config-configmap-revision: "123456"
         cluster: de-test-01
@@ -175,7 +176,7 @@ spec:
         - --audit-log-maxsize
         - "100"
         - --audit-log-path
-        - /var/log/audit.log
+        - /var/log/kubernetes/audit/audit.log
         - --tls-cert-file
         - /etc/kubernetes/tls/apiserver-tls.crt
         - --tls-private-key-file
@@ -200,6 +201,8 @@ spec:
         - X-Remote-Group
         - --requestheader-username-headers
         - X-Remote-User
+        - --audit-policy-file
+        - /etc/kubernetes/audit/policy.yaml
         - --kubelet-preferred-address-types
         - ExternalIP,InternalIP
         - --cloud-provider
@@ -276,9 +279,37 @@ spec:
         - mountPath: /etc/kubernetes/pki/front-proxy/ca
           name: front-proxy-ca
           readOnly: true
+        - mountPath: /etc/kubernetes/audit
+          name: audit-config
+          readOnly: true
+        - mountPath: /var/log/kubernetes/audit
+          name: audit-log
         - mountPath: /etc/kubernetes/dex/ca
           name: dex-ca
           readOnly: true
+      - args:
+        - -i
+        - tail
+        - -p
+        - path=/var/log/kubernetes/audit/audit.log
+        - -p
+        - db=/var/log/kubernetes/audit/fluentbit.db
+        - -o
+        - stdout
+        command:
+        - /fluent-bit/bin/fluent-bit
+        image: docker.io/fluent/fluent-bit:1.2.2
+        name: audit-logs
+        resources:
+          limits:
+            cpu: 50m
+            memory: 60Mi
+          requests:
+            cpu: 5m
+            memory: 10Mi
+        volumeMounts:
+        - mountPath: /var/log/kubernetes/audit
+          name: audit-log
       dnsConfig:
         nameservers:
         - 192.0.2.14
@@ -345,6 +376,12 @@ spec:
       - name: kubeletdnatcontroller-kubeconfig
         secret:
           secretName: kubeletdnatcontroller-kubeconfig
+      - configMap:
+          name: audit-config
+          optional: false
+        name: audit-config
+      - emptyDir: {}
+        name: audit-log
       - name: dex-ca
         secret:
           secretName: dex-ca

--- a/api/pkg/resources/test/fixtures/deployment-azure-1.11.1-apiserver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-azure-1.11.1-apiserver.yaml
@@ -21,6 +21,7 @@ spec:
         apiserver-proxy-client-certificate-secret-revision: "123456"
         apiserver-tls-secret-revision: "123456"
         app: apiserver
+        audit-config-configmap-revision: "123456"
         ca-secret-revision: "123456"
         cloud-config-configmap-revision: "123456"
         cluster: de-test-01
@@ -175,7 +176,7 @@ spec:
         - --audit-log-maxsize
         - "100"
         - --audit-log-path
-        - /var/log/audit.log
+        - /var/log/kubernetes/audit/audit.log
         - --tls-cert-file
         - /etc/kubernetes/tls/apiserver-tls.crt
         - --tls-private-key-file
@@ -200,6 +201,8 @@ spec:
         - X-Remote-Group
         - --requestheader-username-headers
         - X-Remote-User
+        - --audit-policy-file
+        - /etc/kubernetes/audit/policy.yaml
         - --kubelet-preferred-address-types
         - ExternalIP,InternalIP
         - --cloud-provider
@@ -276,9 +279,37 @@ spec:
         - mountPath: /etc/kubernetes/pki/front-proxy/ca
           name: front-proxy-ca
           readOnly: true
+        - mountPath: /etc/kubernetes/audit
+          name: audit-config
+          readOnly: true
+        - mountPath: /var/log/kubernetes/audit
+          name: audit-log
         - mountPath: /etc/kubernetes/dex/ca
           name: dex-ca
           readOnly: true
+      - args:
+        - -i
+        - tail
+        - -p
+        - path=/var/log/kubernetes/audit/audit.log
+        - -p
+        - db=/var/log/kubernetes/audit/fluentbit.db
+        - -o
+        - stdout
+        command:
+        - /fluent-bit/bin/fluent-bit
+        image: docker.io/fluent/fluent-bit:1.2.2
+        name: audit-logs
+        resources:
+          limits:
+            cpu: 50m
+            memory: 60Mi
+          requests:
+            cpu: 5m
+            memory: 10Mi
+        volumeMounts:
+        - mountPath: /var/log/kubernetes/audit
+          name: audit-log
       dnsConfig:
         nameservers:
         - 192.0.2.14
@@ -345,6 +376,12 @@ spec:
       - name: kubeletdnatcontroller-kubeconfig
         secret:
           secretName: kubeletdnatcontroller-kubeconfig
+      - configMap:
+          name: audit-config
+          optional: false
+        name: audit-config
+      - emptyDir: {}
+        name: audit-log
       - name: dex-ca
         secret:
           secretName: dex-ca

--- a/api/pkg/resources/test/fixtures/deployment-azure-1.12.0-apiserver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-azure-1.12.0-apiserver.yaml
@@ -21,6 +21,7 @@ spec:
         apiserver-proxy-client-certificate-secret-revision: "123456"
         apiserver-tls-secret-revision: "123456"
         app: apiserver
+        audit-config-configmap-revision: "123456"
         ca-secret-revision: "123456"
         cloud-config-configmap-revision: "123456"
         cluster: de-test-01
@@ -175,7 +176,7 @@ spec:
         - --audit-log-maxsize
         - "100"
         - --audit-log-path
-        - /var/log/audit.log
+        - /var/log/kubernetes/audit/audit.log
         - --tls-cert-file
         - /etc/kubernetes/tls/apiserver-tls.crt
         - --tls-private-key-file
@@ -200,6 +201,8 @@ spec:
         - X-Remote-Group
         - --requestheader-username-headers
         - X-Remote-User
+        - --audit-policy-file
+        - /etc/kubernetes/audit/policy.yaml
         - --kubelet-preferred-address-types
         - ExternalIP,InternalIP
         - --cloud-provider
@@ -276,9 +279,37 @@ spec:
         - mountPath: /etc/kubernetes/pki/front-proxy/ca
           name: front-proxy-ca
           readOnly: true
+        - mountPath: /etc/kubernetes/audit
+          name: audit-config
+          readOnly: true
+        - mountPath: /var/log/kubernetes/audit
+          name: audit-log
         - mountPath: /etc/kubernetes/dex/ca
           name: dex-ca
           readOnly: true
+      - args:
+        - -i
+        - tail
+        - -p
+        - path=/var/log/kubernetes/audit/audit.log
+        - -p
+        - db=/var/log/kubernetes/audit/fluentbit.db
+        - -o
+        - stdout
+        command:
+        - /fluent-bit/bin/fluent-bit
+        image: docker.io/fluent/fluent-bit:1.2.2
+        name: audit-logs
+        resources:
+          limits:
+            cpu: 50m
+            memory: 60Mi
+          requests:
+            cpu: 5m
+            memory: 10Mi
+        volumeMounts:
+        - mountPath: /var/log/kubernetes/audit
+          name: audit-log
       dnsConfig:
         nameservers:
         - 192.0.2.14
@@ -345,6 +376,12 @@ spec:
       - name: kubeletdnatcontroller-kubeconfig
         secret:
           secretName: kubeletdnatcontroller-kubeconfig
+      - configMap:
+          name: audit-config
+          optional: false
+        name: audit-config
+      - emptyDir: {}
+        name: audit-log
       - name: dex-ca
         secret:
           secretName: dex-ca

--- a/api/pkg/resources/test/fixtures/deployment-azure-1.13.0-apiserver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-azure-1.13.0-apiserver.yaml
@@ -21,6 +21,7 @@ spec:
         apiserver-proxy-client-certificate-secret-revision: "123456"
         apiserver-tls-secret-revision: "123456"
         app: apiserver
+        audit-config-configmap-revision: "123456"
         ca-secret-revision: "123456"
         cloud-config-configmap-revision: "123456"
         cluster: de-test-01
@@ -175,7 +176,7 @@ spec:
         - --audit-log-maxsize
         - "100"
         - --audit-log-path
-        - /var/log/audit.log
+        - /var/log/kubernetes/audit/audit.log
         - --tls-cert-file
         - /etc/kubernetes/tls/apiserver-tls.crt
         - --tls-private-key-file
@@ -200,6 +201,8 @@ spec:
         - X-Remote-Group
         - --requestheader-username-headers
         - X-Remote-User
+        - --audit-policy-file
+        - /etc/kubernetes/audit/policy.yaml
         - --kubelet-preferred-address-types
         - ExternalIP,InternalIP
         - --cloud-provider
@@ -276,9 +279,37 @@ spec:
         - mountPath: /etc/kubernetes/pki/front-proxy/ca
           name: front-proxy-ca
           readOnly: true
+        - mountPath: /etc/kubernetes/audit
+          name: audit-config
+          readOnly: true
+        - mountPath: /var/log/kubernetes/audit
+          name: audit-log
         - mountPath: /etc/kubernetes/dex/ca
           name: dex-ca
           readOnly: true
+      - args:
+        - -i
+        - tail
+        - -p
+        - path=/var/log/kubernetes/audit/audit.log
+        - -p
+        - db=/var/log/kubernetes/audit/fluentbit.db
+        - -o
+        - stdout
+        command:
+        - /fluent-bit/bin/fluent-bit
+        image: docker.io/fluent/fluent-bit:1.2.2
+        name: audit-logs
+        resources:
+          limits:
+            cpu: 50m
+            memory: 60Mi
+          requests:
+            cpu: 5m
+            memory: 10Mi
+        volumeMounts:
+        - mountPath: /var/log/kubernetes/audit
+          name: audit-log
       dnsConfig:
         nameservers:
         - 192.0.2.14
@@ -345,6 +376,12 @@ spec:
       - name: kubeletdnatcontroller-kubeconfig
         secret:
           secretName: kubeletdnatcontroller-kubeconfig
+      - configMap:
+          name: audit-config
+          optional: false
+        name: audit-config
+      - emptyDir: {}
+        name: audit-log
       - name: dex-ca
         secret:
           secretName: dex-ca

--- a/api/pkg/resources/test/fixtures/deployment-bringyourown-1.10.0-apiserver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-bringyourown-1.10.0-apiserver.yaml
@@ -21,6 +21,7 @@ spec:
         apiserver-proxy-client-certificate-secret-revision: "123456"
         apiserver-tls-secret-revision: "123456"
         app: apiserver
+        audit-config-configmap-revision: "123456"
         ca-secret-revision: "123456"
         cloud-config-configmap-revision: "123456"
         cluster: de-test-01
@@ -175,7 +176,7 @@ spec:
         - --audit-log-maxsize
         - "100"
         - --audit-log-path
-        - /var/log/audit.log
+        - /var/log/kubernetes/audit/audit.log
         - --tls-cert-file
         - /etc/kubernetes/tls/apiserver-tls.crt
         - --tls-private-key-file
@@ -200,6 +201,8 @@ spec:
         - X-Remote-Group
         - --requestheader-username-headers
         - X-Remote-User
+        - --audit-policy-file
+        - /etc/kubernetes/audit/policy.yaml
         - --kubelet-preferred-address-types
         - ExternalIP,InternalIP
         - --feature-gates
@@ -274,9 +277,37 @@ spec:
         - mountPath: /etc/kubernetes/pki/front-proxy/ca
           name: front-proxy-ca
           readOnly: true
+        - mountPath: /etc/kubernetes/audit
+          name: audit-config
+          readOnly: true
+        - mountPath: /var/log/kubernetes/audit
+          name: audit-log
         - mountPath: /etc/kubernetes/dex/ca
           name: dex-ca
           readOnly: true
+      - args:
+        - -i
+        - tail
+        - -p
+        - path=/var/log/kubernetes/audit/audit.log
+        - -p
+        - db=/var/log/kubernetes/audit/fluentbit.db
+        - -o
+        - stdout
+        command:
+        - /fluent-bit/bin/fluent-bit
+        image: docker.io/fluent/fluent-bit:1.2.2
+        name: audit-logs
+        resources:
+          limits:
+            cpu: 50m
+            memory: 60Mi
+          requests:
+            cpu: 5m
+            memory: 10Mi
+        volumeMounts:
+        - mountPath: /var/log/kubernetes/audit
+          name: audit-log
       dnsConfig:
         nameservers:
         - 192.0.2.14
@@ -343,6 +374,12 @@ spec:
       - name: kubeletdnatcontroller-kubeconfig
         secret:
           secretName: kubeletdnatcontroller-kubeconfig
+      - configMap:
+          name: audit-config
+          optional: false
+        name: audit-config
+      - emptyDir: {}
+        name: audit-log
       - name: dex-ca
         secret:
           secretName: dex-ca

--- a/api/pkg/resources/test/fixtures/deployment-bringyourown-1.10.6-apiserver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-bringyourown-1.10.6-apiserver.yaml
@@ -21,6 +21,7 @@ spec:
         apiserver-proxy-client-certificate-secret-revision: "123456"
         apiserver-tls-secret-revision: "123456"
         app: apiserver
+        audit-config-configmap-revision: "123456"
         ca-secret-revision: "123456"
         cloud-config-configmap-revision: "123456"
         cluster: de-test-01
@@ -175,7 +176,7 @@ spec:
         - --audit-log-maxsize
         - "100"
         - --audit-log-path
-        - /var/log/audit.log
+        - /var/log/kubernetes/audit/audit.log
         - --tls-cert-file
         - /etc/kubernetes/tls/apiserver-tls.crt
         - --tls-private-key-file
@@ -200,6 +201,8 @@ spec:
         - X-Remote-Group
         - --requestheader-username-headers
         - X-Remote-User
+        - --audit-policy-file
+        - /etc/kubernetes/audit/policy.yaml
         - --kubelet-preferred-address-types
         - ExternalIP,InternalIP
         - --feature-gates
@@ -274,9 +277,37 @@ spec:
         - mountPath: /etc/kubernetes/pki/front-proxy/ca
           name: front-proxy-ca
           readOnly: true
+        - mountPath: /etc/kubernetes/audit
+          name: audit-config
+          readOnly: true
+        - mountPath: /var/log/kubernetes/audit
+          name: audit-log
         - mountPath: /etc/kubernetes/dex/ca
           name: dex-ca
           readOnly: true
+      - args:
+        - -i
+        - tail
+        - -p
+        - path=/var/log/kubernetes/audit/audit.log
+        - -p
+        - db=/var/log/kubernetes/audit/fluentbit.db
+        - -o
+        - stdout
+        command:
+        - /fluent-bit/bin/fluent-bit
+        image: docker.io/fluent/fluent-bit:1.2.2
+        name: audit-logs
+        resources:
+          limits:
+            cpu: 50m
+            memory: 60Mi
+          requests:
+            cpu: 5m
+            memory: 10Mi
+        volumeMounts:
+        - mountPath: /var/log/kubernetes/audit
+          name: audit-log
       dnsConfig:
         nameservers:
         - 192.0.2.14
@@ -343,6 +374,12 @@ spec:
       - name: kubeletdnatcontroller-kubeconfig
         secret:
           secretName: kubeletdnatcontroller-kubeconfig
+      - configMap:
+          name: audit-config
+          optional: false
+        name: audit-config
+      - emptyDir: {}
+        name: audit-log
       - name: dex-ca
         secret:
           secretName: dex-ca

--- a/api/pkg/resources/test/fixtures/deployment-bringyourown-1.11.0-apiserver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-bringyourown-1.11.0-apiserver.yaml
@@ -21,6 +21,7 @@ spec:
         apiserver-proxy-client-certificate-secret-revision: "123456"
         apiserver-tls-secret-revision: "123456"
         app: apiserver
+        audit-config-configmap-revision: "123456"
         ca-secret-revision: "123456"
         cloud-config-configmap-revision: "123456"
         cluster: de-test-01
@@ -175,7 +176,7 @@ spec:
         - --audit-log-maxsize
         - "100"
         - --audit-log-path
-        - /var/log/audit.log
+        - /var/log/kubernetes/audit/audit.log
         - --tls-cert-file
         - /etc/kubernetes/tls/apiserver-tls.crt
         - --tls-private-key-file
@@ -200,6 +201,8 @@ spec:
         - X-Remote-Group
         - --requestheader-username-headers
         - X-Remote-User
+        - --audit-policy-file
+        - /etc/kubernetes/audit/policy.yaml
         - --kubelet-preferred-address-types
         - ExternalIP,InternalIP
         - --oidc-issuer-url
@@ -272,9 +275,37 @@ spec:
         - mountPath: /etc/kubernetes/pki/front-proxy/ca
           name: front-proxy-ca
           readOnly: true
+        - mountPath: /etc/kubernetes/audit
+          name: audit-config
+          readOnly: true
+        - mountPath: /var/log/kubernetes/audit
+          name: audit-log
         - mountPath: /etc/kubernetes/dex/ca
           name: dex-ca
           readOnly: true
+      - args:
+        - -i
+        - tail
+        - -p
+        - path=/var/log/kubernetes/audit/audit.log
+        - -p
+        - db=/var/log/kubernetes/audit/fluentbit.db
+        - -o
+        - stdout
+        command:
+        - /fluent-bit/bin/fluent-bit
+        image: docker.io/fluent/fluent-bit:1.2.2
+        name: audit-logs
+        resources:
+          limits:
+            cpu: 50m
+            memory: 60Mi
+          requests:
+            cpu: 5m
+            memory: 10Mi
+        volumeMounts:
+        - mountPath: /var/log/kubernetes/audit
+          name: audit-log
       dnsConfig:
         nameservers:
         - 192.0.2.14
@@ -341,6 +372,12 @@ spec:
       - name: kubeletdnatcontroller-kubeconfig
         secret:
           secretName: kubeletdnatcontroller-kubeconfig
+      - configMap:
+          name: audit-config
+          optional: false
+        name: audit-config
+      - emptyDir: {}
+        name: audit-log
       - name: dex-ca
         secret:
           secretName: dex-ca

--- a/api/pkg/resources/test/fixtures/deployment-bringyourown-1.11.1-apiserver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-bringyourown-1.11.1-apiserver.yaml
@@ -21,6 +21,7 @@ spec:
         apiserver-proxy-client-certificate-secret-revision: "123456"
         apiserver-tls-secret-revision: "123456"
         app: apiserver
+        audit-config-configmap-revision: "123456"
         ca-secret-revision: "123456"
         cloud-config-configmap-revision: "123456"
         cluster: de-test-01
@@ -175,7 +176,7 @@ spec:
         - --audit-log-maxsize
         - "100"
         - --audit-log-path
-        - /var/log/audit.log
+        - /var/log/kubernetes/audit/audit.log
         - --tls-cert-file
         - /etc/kubernetes/tls/apiserver-tls.crt
         - --tls-private-key-file
@@ -200,6 +201,8 @@ spec:
         - X-Remote-Group
         - --requestheader-username-headers
         - X-Remote-User
+        - --audit-policy-file
+        - /etc/kubernetes/audit/policy.yaml
         - --kubelet-preferred-address-types
         - ExternalIP,InternalIP
         - --oidc-issuer-url
@@ -272,9 +275,37 @@ spec:
         - mountPath: /etc/kubernetes/pki/front-proxy/ca
           name: front-proxy-ca
           readOnly: true
+        - mountPath: /etc/kubernetes/audit
+          name: audit-config
+          readOnly: true
+        - mountPath: /var/log/kubernetes/audit
+          name: audit-log
         - mountPath: /etc/kubernetes/dex/ca
           name: dex-ca
           readOnly: true
+      - args:
+        - -i
+        - tail
+        - -p
+        - path=/var/log/kubernetes/audit/audit.log
+        - -p
+        - db=/var/log/kubernetes/audit/fluentbit.db
+        - -o
+        - stdout
+        command:
+        - /fluent-bit/bin/fluent-bit
+        image: docker.io/fluent/fluent-bit:1.2.2
+        name: audit-logs
+        resources:
+          limits:
+            cpu: 50m
+            memory: 60Mi
+          requests:
+            cpu: 5m
+            memory: 10Mi
+        volumeMounts:
+        - mountPath: /var/log/kubernetes/audit
+          name: audit-log
       dnsConfig:
         nameservers:
         - 192.0.2.14
@@ -341,6 +372,12 @@ spec:
       - name: kubeletdnatcontroller-kubeconfig
         secret:
           secretName: kubeletdnatcontroller-kubeconfig
+      - configMap:
+          name: audit-config
+          optional: false
+        name: audit-config
+      - emptyDir: {}
+        name: audit-log
       - name: dex-ca
         secret:
           secretName: dex-ca

--- a/api/pkg/resources/test/fixtures/deployment-bringyourown-1.12.0-apiserver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-bringyourown-1.12.0-apiserver.yaml
@@ -21,6 +21,7 @@ spec:
         apiserver-proxy-client-certificate-secret-revision: "123456"
         apiserver-tls-secret-revision: "123456"
         app: apiserver
+        audit-config-configmap-revision: "123456"
         ca-secret-revision: "123456"
         cloud-config-configmap-revision: "123456"
         cluster: de-test-01
@@ -175,7 +176,7 @@ spec:
         - --audit-log-maxsize
         - "100"
         - --audit-log-path
-        - /var/log/audit.log
+        - /var/log/kubernetes/audit/audit.log
         - --tls-cert-file
         - /etc/kubernetes/tls/apiserver-tls.crt
         - --tls-private-key-file
@@ -200,6 +201,8 @@ spec:
         - X-Remote-Group
         - --requestheader-username-headers
         - X-Remote-User
+        - --audit-policy-file
+        - /etc/kubernetes/audit/policy.yaml
         - --kubelet-preferred-address-types
         - ExternalIP,InternalIP
         - --oidc-issuer-url
@@ -272,9 +275,37 @@ spec:
         - mountPath: /etc/kubernetes/pki/front-proxy/ca
           name: front-proxy-ca
           readOnly: true
+        - mountPath: /etc/kubernetes/audit
+          name: audit-config
+          readOnly: true
+        - mountPath: /var/log/kubernetes/audit
+          name: audit-log
         - mountPath: /etc/kubernetes/dex/ca
           name: dex-ca
           readOnly: true
+      - args:
+        - -i
+        - tail
+        - -p
+        - path=/var/log/kubernetes/audit/audit.log
+        - -p
+        - db=/var/log/kubernetes/audit/fluentbit.db
+        - -o
+        - stdout
+        command:
+        - /fluent-bit/bin/fluent-bit
+        image: docker.io/fluent/fluent-bit:1.2.2
+        name: audit-logs
+        resources:
+          limits:
+            cpu: 50m
+            memory: 60Mi
+          requests:
+            cpu: 5m
+            memory: 10Mi
+        volumeMounts:
+        - mountPath: /var/log/kubernetes/audit
+          name: audit-log
       dnsConfig:
         nameservers:
         - 192.0.2.14
@@ -341,6 +372,12 @@ spec:
       - name: kubeletdnatcontroller-kubeconfig
         secret:
           secretName: kubeletdnatcontroller-kubeconfig
+      - configMap:
+          name: audit-config
+          optional: false
+        name: audit-config
+      - emptyDir: {}
+        name: audit-log
       - name: dex-ca
         secret:
           secretName: dex-ca

--- a/api/pkg/resources/test/fixtures/deployment-bringyourown-1.13.0-apiserver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-bringyourown-1.13.0-apiserver.yaml
@@ -21,6 +21,7 @@ spec:
         apiserver-proxy-client-certificate-secret-revision: "123456"
         apiserver-tls-secret-revision: "123456"
         app: apiserver
+        audit-config-configmap-revision: "123456"
         ca-secret-revision: "123456"
         cloud-config-configmap-revision: "123456"
         cluster: de-test-01
@@ -175,7 +176,7 @@ spec:
         - --audit-log-maxsize
         - "100"
         - --audit-log-path
-        - /var/log/audit.log
+        - /var/log/kubernetes/audit/audit.log
         - --tls-cert-file
         - /etc/kubernetes/tls/apiserver-tls.crt
         - --tls-private-key-file
@@ -200,6 +201,8 @@ spec:
         - X-Remote-Group
         - --requestheader-username-headers
         - X-Remote-User
+        - --audit-policy-file
+        - /etc/kubernetes/audit/policy.yaml
         - --kubelet-preferred-address-types
         - ExternalIP,InternalIP
         - --oidc-issuer-url
@@ -272,9 +275,37 @@ spec:
         - mountPath: /etc/kubernetes/pki/front-proxy/ca
           name: front-proxy-ca
           readOnly: true
+        - mountPath: /etc/kubernetes/audit
+          name: audit-config
+          readOnly: true
+        - mountPath: /var/log/kubernetes/audit
+          name: audit-log
         - mountPath: /etc/kubernetes/dex/ca
           name: dex-ca
           readOnly: true
+      - args:
+        - -i
+        - tail
+        - -p
+        - path=/var/log/kubernetes/audit/audit.log
+        - -p
+        - db=/var/log/kubernetes/audit/fluentbit.db
+        - -o
+        - stdout
+        command:
+        - /fluent-bit/bin/fluent-bit
+        image: docker.io/fluent/fluent-bit:1.2.2
+        name: audit-logs
+        resources:
+          limits:
+            cpu: 50m
+            memory: 60Mi
+          requests:
+            cpu: 5m
+            memory: 10Mi
+        volumeMounts:
+        - mountPath: /var/log/kubernetes/audit
+          name: audit-log
       dnsConfig:
         nameservers:
         - 192.0.2.14
@@ -341,6 +372,12 @@ spec:
       - name: kubeletdnatcontroller-kubeconfig
         secret:
           secretName: kubeletdnatcontroller-kubeconfig
+      - configMap:
+          name: audit-config
+          optional: false
+        name: audit-config
+      - emptyDir: {}
+        name: audit-log
       - name: dex-ca
         secret:
           secretName: dex-ca

--- a/api/pkg/resources/test/fixtures/deployment-digitalocean-1.10.0-apiserver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-digitalocean-1.10.0-apiserver.yaml
@@ -21,6 +21,7 @@ spec:
         apiserver-proxy-client-certificate-secret-revision: "123456"
         apiserver-tls-secret-revision: "123456"
         app: apiserver
+        audit-config-configmap-revision: "123456"
         ca-secret-revision: "123456"
         cloud-config-configmap-revision: "123456"
         cluster: de-test-01
@@ -175,7 +176,7 @@ spec:
         - --audit-log-maxsize
         - "100"
         - --audit-log-path
-        - /var/log/audit.log
+        - /var/log/kubernetes/audit/audit.log
         - --tls-cert-file
         - /etc/kubernetes/tls/apiserver-tls.crt
         - --tls-private-key-file
@@ -200,6 +201,8 @@ spec:
         - X-Remote-Group
         - --requestheader-username-headers
         - X-Remote-User
+        - --audit-policy-file
+        - /etc/kubernetes/audit/policy.yaml
         - --kubelet-preferred-address-types
         - ExternalIP,InternalIP
         - --feature-gates
@@ -274,9 +277,37 @@ spec:
         - mountPath: /etc/kubernetes/pki/front-proxy/ca
           name: front-proxy-ca
           readOnly: true
+        - mountPath: /etc/kubernetes/audit
+          name: audit-config
+          readOnly: true
+        - mountPath: /var/log/kubernetes/audit
+          name: audit-log
         - mountPath: /etc/kubernetes/dex/ca
           name: dex-ca
           readOnly: true
+      - args:
+        - -i
+        - tail
+        - -p
+        - path=/var/log/kubernetes/audit/audit.log
+        - -p
+        - db=/var/log/kubernetes/audit/fluentbit.db
+        - -o
+        - stdout
+        command:
+        - /fluent-bit/bin/fluent-bit
+        image: docker.io/fluent/fluent-bit:1.2.2
+        name: audit-logs
+        resources:
+          limits:
+            cpu: 50m
+            memory: 60Mi
+          requests:
+            cpu: 5m
+            memory: 10Mi
+        volumeMounts:
+        - mountPath: /var/log/kubernetes/audit
+          name: audit-log
       dnsConfig:
         nameservers:
         - 192.0.2.14
@@ -343,6 +374,12 @@ spec:
       - name: kubeletdnatcontroller-kubeconfig
         secret:
           secretName: kubeletdnatcontroller-kubeconfig
+      - configMap:
+          name: audit-config
+          optional: false
+        name: audit-config
+      - emptyDir: {}
+        name: audit-log
       - name: dex-ca
         secret:
           secretName: dex-ca

--- a/api/pkg/resources/test/fixtures/deployment-digitalocean-1.10.6-apiserver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-digitalocean-1.10.6-apiserver.yaml
@@ -21,6 +21,7 @@ spec:
         apiserver-proxy-client-certificate-secret-revision: "123456"
         apiserver-tls-secret-revision: "123456"
         app: apiserver
+        audit-config-configmap-revision: "123456"
         ca-secret-revision: "123456"
         cloud-config-configmap-revision: "123456"
         cluster: de-test-01
@@ -175,7 +176,7 @@ spec:
         - --audit-log-maxsize
         - "100"
         - --audit-log-path
-        - /var/log/audit.log
+        - /var/log/kubernetes/audit/audit.log
         - --tls-cert-file
         - /etc/kubernetes/tls/apiserver-tls.crt
         - --tls-private-key-file
@@ -200,6 +201,8 @@ spec:
         - X-Remote-Group
         - --requestheader-username-headers
         - X-Remote-User
+        - --audit-policy-file
+        - /etc/kubernetes/audit/policy.yaml
         - --kubelet-preferred-address-types
         - ExternalIP,InternalIP
         - --feature-gates
@@ -274,9 +277,37 @@ spec:
         - mountPath: /etc/kubernetes/pki/front-proxy/ca
           name: front-proxy-ca
           readOnly: true
+        - mountPath: /etc/kubernetes/audit
+          name: audit-config
+          readOnly: true
+        - mountPath: /var/log/kubernetes/audit
+          name: audit-log
         - mountPath: /etc/kubernetes/dex/ca
           name: dex-ca
           readOnly: true
+      - args:
+        - -i
+        - tail
+        - -p
+        - path=/var/log/kubernetes/audit/audit.log
+        - -p
+        - db=/var/log/kubernetes/audit/fluentbit.db
+        - -o
+        - stdout
+        command:
+        - /fluent-bit/bin/fluent-bit
+        image: docker.io/fluent/fluent-bit:1.2.2
+        name: audit-logs
+        resources:
+          limits:
+            cpu: 50m
+            memory: 60Mi
+          requests:
+            cpu: 5m
+            memory: 10Mi
+        volumeMounts:
+        - mountPath: /var/log/kubernetes/audit
+          name: audit-log
       dnsConfig:
         nameservers:
         - 192.0.2.14
@@ -343,6 +374,12 @@ spec:
       - name: kubeletdnatcontroller-kubeconfig
         secret:
           secretName: kubeletdnatcontroller-kubeconfig
+      - configMap:
+          name: audit-config
+          optional: false
+        name: audit-config
+      - emptyDir: {}
+        name: audit-log
       - name: dex-ca
         secret:
           secretName: dex-ca

--- a/api/pkg/resources/test/fixtures/deployment-digitalocean-1.11.0-apiserver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-digitalocean-1.11.0-apiserver.yaml
@@ -21,6 +21,7 @@ spec:
         apiserver-proxy-client-certificate-secret-revision: "123456"
         apiserver-tls-secret-revision: "123456"
         app: apiserver
+        audit-config-configmap-revision: "123456"
         ca-secret-revision: "123456"
         cloud-config-configmap-revision: "123456"
         cluster: de-test-01
@@ -175,7 +176,7 @@ spec:
         - --audit-log-maxsize
         - "100"
         - --audit-log-path
-        - /var/log/audit.log
+        - /var/log/kubernetes/audit/audit.log
         - --tls-cert-file
         - /etc/kubernetes/tls/apiserver-tls.crt
         - --tls-private-key-file
@@ -200,6 +201,8 @@ spec:
         - X-Remote-Group
         - --requestheader-username-headers
         - X-Remote-User
+        - --audit-policy-file
+        - /etc/kubernetes/audit/policy.yaml
         - --kubelet-preferred-address-types
         - ExternalIP,InternalIP
         - --oidc-issuer-url
@@ -272,9 +275,37 @@ spec:
         - mountPath: /etc/kubernetes/pki/front-proxy/ca
           name: front-proxy-ca
           readOnly: true
+        - mountPath: /etc/kubernetes/audit
+          name: audit-config
+          readOnly: true
+        - mountPath: /var/log/kubernetes/audit
+          name: audit-log
         - mountPath: /etc/kubernetes/dex/ca
           name: dex-ca
           readOnly: true
+      - args:
+        - -i
+        - tail
+        - -p
+        - path=/var/log/kubernetes/audit/audit.log
+        - -p
+        - db=/var/log/kubernetes/audit/fluentbit.db
+        - -o
+        - stdout
+        command:
+        - /fluent-bit/bin/fluent-bit
+        image: docker.io/fluent/fluent-bit:1.2.2
+        name: audit-logs
+        resources:
+          limits:
+            cpu: 50m
+            memory: 60Mi
+          requests:
+            cpu: 5m
+            memory: 10Mi
+        volumeMounts:
+        - mountPath: /var/log/kubernetes/audit
+          name: audit-log
       dnsConfig:
         nameservers:
         - 192.0.2.14
@@ -341,6 +372,12 @@ spec:
       - name: kubeletdnatcontroller-kubeconfig
         secret:
           secretName: kubeletdnatcontroller-kubeconfig
+      - configMap:
+          name: audit-config
+          optional: false
+        name: audit-config
+      - emptyDir: {}
+        name: audit-log
       - name: dex-ca
         secret:
           secretName: dex-ca

--- a/api/pkg/resources/test/fixtures/deployment-digitalocean-1.11.1-apiserver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-digitalocean-1.11.1-apiserver.yaml
@@ -21,6 +21,7 @@ spec:
         apiserver-proxy-client-certificate-secret-revision: "123456"
         apiserver-tls-secret-revision: "123456"
         app: apiserver
+        audit-config-configmap-revision: "123456"
         ca-secret-revision: "123456"
         cloud-config-configmap-revision: "123456"
         cluster: de-test-01
@@ -175,7 +176,7 @@ spec:
         - --audit-log-maxsize
         - "100"
         - --audit-log-path
-        - /var/log/audit.log
+        - /var/log/kubernetes/audit/audit.log
         - --tls-cert-file
         - /etc/kubernetes/tls/apiserver-tls.crt
         - --tls-private-key-file
@@ -200,6 +201,8 @@ spec:
         - X-Remote-Group
         - --requestheader-username-headers
         - X-Remote-User
+        - --audit-policy-file
+        - /etc/kubernetes/audit/policy.yaml
         - --kubelet-preferred-address-types
         - ExternalIP,InternalIP
         - --oidc-issuer-url
@@ -272,9 +275,37 @@ spec:
         - mountPath: /etc/kubernetes/pki/front-proxy/ca
           name: front-proxy-ca
           readOnly: true
+        - mountPath: /etc/kubernetes/audit
+          name: audit-config
+          readOnly: true
+        - mountPath: /var/log/kubernetes/audit
+          name: audit-log
         - mountPath: /etc/kubernetes/dex/ca
           name: dex-ca
           readOnly: true
+      - args:
+        - -i
+        - tail
+        - -p
+        - path=/var/log/kubernetes/audit/audit.log
+        - -p
+        - db=/var/log/kubernetes/audit/fluentbit.db
+        - -o
+        - stdout
+        command:
+        - /fluent-bit/bin/fluent-bit
+        image: docker.io/fluent/fluent-bit:1.2.2
+        name: audit-logs
+        resources:
+          limits:
+            cpu: 50m
+            memory: 60Mi
+          requests:
+            cpu: 5m
+            memory: 10Mi
+        volumeMounts:
+        - mountPath: /var/log/kubernetes/audit
+          name: audit-log
       dnsConfig:
         nameservers:
         - 192.0.2.14
@@ -341,6 +372,12 @@ spec:
       - name: kubeletdnatcontroller-kubeconfig
         secret:
           secretName: kubeletdnatcontroller-kubeconfig
+      - configMap:
+          name: audit-config
+          optional: false
+        name: audit-config
+      - emptyDir: {}
+        name: audit-log
       - name: dex-ca
         secret:
           secretName: dex-ca

--- a/api/pkg/resources/test/fixtures/deployment-digitalocean-1.12.0-apiserver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-digitalocean-1.12.0-apiserver.yaml
@@ -21,6 +21,7 @@ spec:
         apiserver-proxy-client-certificate-secret-revision: "123456"
         apiserver-tls-secret-revision: "123456"
         app: apiserver
+        audit-config-configmap-revision: "123456"
         ca-secret-revision: "123456"
         cloud-config-configmap-revision: "123456"
         cluster: de-test-01
@@ -175,7 +176,7 @@ spec:
         - --audit-log-maxsize
         - "100"
         - --audit-log-path
-        - /var/log/audit.log
+        - /var/log/kubernetes/audit/audit.log
         - --tls-cert-file
         - /etc/kubernetes/tls/apiserver-tls.crt
         - --tls-private-key-file
@@ -200,6 +201,8 @@ spec:
         - X-Remote-Group
         - --requestheader-username-headers
         - X-Remote-User
+        - --audit-policy-file
+        - /etc/kubernetes/audit/policy.yaml
         - --kubelet-preferred-address-types
         - ExternalIP,InternalIP
         - --oidc-issuer-url
@@ -272,9 +275,37 @@ spec:
         - mountPath: /etc/kubernetes/pki/front-proxy/ca
           name: front-proxy-ca
           readOnly: true
+        - mountPath: /etc/kubernetes/audit
+          name: audit-config
+          readOnly: true
+        - mountPath: /var/log/kubernetes/audit
+          name: audit-log
         - mountPath: /etc/kubernetes/dex/ca
           name: dex-ca
           readOnly: true
+      - args:
+        - -i
+        - tail
+        - -p
+        - path=/var/log/kubernetes/audit/audit.log
+        - -p
+        - db=/var/log/kubernetes/audit/fluentbit.db
+        - -o
+        - stdout
+        command:
+        - /fluent-bit/bin/fluent-bit
+        image: docker.io/fluent/fluent-bit:1.2.2
+        name: audit-logs
+        resources:
+          limits:
+            cpu: 50m
+            memory: 60Mi
+          requests:
+            cpu: 5m
+            memory: 10Mi
+        volumeMounts:
+        - mountPath: /var/log/kubernetes/audit
+          name: audit-log
       dnsConfig:
         nameservers:
         - 192.0.2.14
@@ -341,6 +372,12 @@ spec:
       - name: kubeletdnatcontroller-kubeconfig
         secret:
           secretName: kubeletdnatcontroller-kubeconfig
+      - configMap:
+          name: audit-config
+          optional: false
+        name: audit-config
+      - emptyDir: {}
+        name: audit-log
       - name: dex-ca
         secret:
           secretName: dex-ca

--- a/api/pkg/resources/test/fixtures/deployment-digitalocean-1.13.0-apiserver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-digitalocean-1.13.0-apiserver.yaml
@@ -21,6 +21,7 @@ spec:
         apiserver-proxy-client-certificate-secret-revision: "123456"
         apiserver-tls-secret-revision: "123456"
         app: apiserver
+        audit-config-configmap-revision: "123456"
         ca-secret-revision: "123456"
         cloud-config-configmap-revision: "123456"
         cluster: de-test-01
@@ -175,7 +176,7 @@ spec:
         - --audit-log-maxsize
         - "100"
         - --audit-log-path
-        - /var/log/audit.log
+        - /var/log/kubernetes/audit/audit.log
         - --tls-cert-file
         - /etc/kubernetes/tls/apiserver-tls.crt
         - --tls-private-key-file
@@ -200,6 +201,8 @@ spec:
         - X-Remote-Group
         - --requestheader-username-headers
         - X-Remote-User
+        - --audit-policy-file
+        - /etc/kubernetes/audit/policy.yaml
         - --kubelet-preferred-address-types
         - ExternalIP,InternalIP
         - --oidc-issuer-url
@@ -272,9 +275,37 @@ spec:
         - mountPath: /etc/kubernetes/pki/front-proxy/ca
           name: front-proxy-ca
           readOnly: true
+        - mountPath: /etc/kubernetes/audit
+          name: audit-config
+          readOnly: true
+        - mountPath: /var/log/kubernetes/audit
+          name: audit-log
         - mountPath: /etc/kubernetes/dex/ca
           name: dex-ca
           readOnly: true
+      - args:
+        - -i
+        - tail
+        - -p
+        - path=/var/log/kubernetes/audit/audit.log
+        - -p
+        - db=/var/log/kubernetes/audit/fluentbit.db
+        - -o
+        - stdout
+        command:
+        - /fluent-bit/bin/fluent-bit
+        image: docker.io/fluent/fluent-bit:1.2.2
+        name: audit-logs
+        resources:
+          limits:
+            cpu: 50m
+            memory: 60Mi
+          requests:
+            cpu: 5m
+            memory: 10Mi
+        volumeMounts:
+        - mountPath: /var/log/kubernetes/audit
+          name: audit-log
       dnsConfig:
         nameservers:
         - 192.0.2.14
@@ -341,6 +372,12 @@ spec:
       - name: kubeletdnatcontroller-kubeconfig
         secret:
           secretName: kubeletdnatcontroller-kubeconfig
+      - configMap:
+          name: audit-config
+          optional: false
+        name: audit-config
+      - emptyDir: {}
+        name: audit-log
       - name: dex-ca
         secret:
           secretName: dex-ca

--- a/api/pkg/resources/test/fixtures/deployment-openstack-1.10.0-apiserver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-openstack-1.10.0-apiserver.yaml
@@ -21,6 +21,7 @@ spec:
         apiserver-proxy-client-certificate-secret-revision: "123456"
         apiserver-tls-secret-revision: "123456"
         app: apiserver
+        audit-config-configmap-revision: "123456"
         ca-secret-revision: "123456"
         cloud-config-configmap-revision: "123456"
         cluster: de-test-01
@@ -175,7 +176,7 @@ spec:
         - --audit-log-maxsize
         - "100"
         - --audit-log-path
-        - /var/log/audit.log
+        - /var/log/kubernetes/audit/audit.log
         - --tls-cert-file
         - /etc/kubernetes/tls/apiserver-tls.crt
         - --tls-private-key-file
@@ -200,6 +201,8 @@ spec:
         - X-Remote-Group
         - --requestheader-username-headers
         - X-Remote-User
+        - --audit-policy-file
+        - /etc/kubernetes/audit/policy.yaml
         - --kubelet-preferred-address-types
         - ExternalIP,InternalIP
         - --feature-gates
@@ -278,9 +281,37 @@ spec:
         - mountPath: /etc/kubernetes/pki/front-proxy/ca
           name: front-proxy-ca
           readOnly: true
+        - mountPath: /etc/kubernetes/audit
+          name: audit-config
+          readOnly: true
+        - mountPath: /var/log/kubernetes/audit
+          name: audit-log
         - mountPath: /etc/kubernetes/dex/ca
           name: dex-ca
           readOnly: true
+      - args:
+        - -i
+        - tail
+        - -p
+        - path=/var/log/kubernetes/audit/audit.log
+        - -p
+        - db=/var/log/kubernetes/audit/fluentbit.db
+        - -o
+        - stdout
+        command:
+        - /fluent-bit/bin/fluent-bit
+        image: docker.io/fluent/fluent-bit:1.2.2
+        name: audit-logs
+        resources:
+          limits:
+            cpu: 50m
+            memory: 60Mi
+          requests:
+            cpu: 5m
+            memory: 10Mi
+        volumeMounts:
+        - mountPath: /var/log/kubernetes/audit
+          name: audit-log
       dnsConfig:
         nameservers:
         - 192.0.2.14
@@ -347,6 +378,12 @@ spec:
       - name: kubeletdnatcontroller-kubeconfig
         secret:
           secretName: kubeletdnatcontroller-kubeconfig
+      - configMap:
+          name: audit-config
+          optional: false
+        name: audit-config
+      - emptyDir: {}
+        name: audit-log
       - name: dex-ca
         secret:
           secretName: dex-ca

--- a/api/pkg/resources/test/fixtures/deployment-openstack-1.10.6-apiserver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-openstack-1.10.6-apiserver.yaml
@@ -21,6 +21,7 @@ spec:
         apiserver-proxy-client-certificate-secret-revision: "123456"
         apiserver-tls-secret-revision: "123456"
         app: apiserver
+        audit-config-configmap-revision: "123456"
         ca-secret-revision: "123456"
         cloud-config-configmap-revision: "123456"
         cluster: de-test-01
@@ -175,7 +176,7 @@ spec:
         - --audit-log-maxsize
         - "100"
         - --audit-log-path
-        - /var/log/audit.log
+        - /var/log/kubernetes/audit/audit.log
         - --tls-cert-file
         - /etc/kubernetes/tls/apiserver-tls.crt
         - --tls-private-key-file
@@ -200,6 +201,8 @@ spec:
         - X-Remote-Group
         - --requestheader-username-headers
         - X-Remote-User
+        - --audit-policy-file
+        - /etc/kubernetes/audit/policy.yaml
         - --kubelet-preferred-address-types
         - ExternalIP,InternalIP
         - --feature-gates
@@ -278,9 +281,37 @@ spec:
         - mountPath: /etc/kubernetes/pki/front-proxy/ca
           name: front-proxy-ca
           readOnly: true
+        - mountPath: /etc/kubernetes/audit
+          name: audit-config
+          readOnly: true
+        - mountPath: /var/log/kubernetes/audit
+          name: audit-log
         - mountPath: /etc/kubernetes/dex/ca
           name: dex-ca
           readOnly: true
+      - args:
+        - -i
+        - tail
+        - -p
+        - path=/var/log/kubernetes/audit/audit.log
+        - -p
+        - db=/var/log/kubernetes/audit/fluentbit.db
+        - -o
+        - stdout
+        command:
+        - /fluent-bit/bin/fluent-bit
+        image: docker.io/fluent/fluent-bit:1.2.2
+        name: audit-logs
+        resources:
+          limits:
+            cpu: 50m
+            memory: 60Mi
+          requests:
+            cpu: 5m
+            memory: 10Mi
+        volumeMounts:
+        - mountPath: /var/log/kubernetes/audit
+          name: audit-log
       dnsConfig:
         nameservers:
         - 192.0.2.14
@@ -347,6 +378,12 @@ spec:
       - name: kubeletdnatcontroller-kubeconfig
         secret:
           secretName: kubeletdnatcontroller-kubeconfig
+      - configMap:
+          name: audit-config
+          optional: false
+        name: audit-config
+      - emptyDir: {}
+        name: audit-log
       - name: dex-ca
         secret:
           secretName: dex-ca

--- a/api/pkg/resources/test/fixtures/deployment-openstack-1.11.0-apiserver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-openstack-1.11.0-apiserver.yaml
@@ -21,6 +21,7 @@ spec:
         apiserver-proxy-client-certificate-secret-revision: "123456"
         apiserver-tls-secret-revision: "123456"
         app: apiserver
+        audit-config-configmap-revision: "123456"
         ca-secret-revision: "123456"
         cloud-config-configmap-revision: "123456"
         cluster: de-test-01
@@ -175,7 +176,7 @@ spec:
         - --audit-log-maxsize
         - "100"
         - --audit-log-path
-        - /var/log/audit.log
+        - /var/log/kubernetes/audit/audit.log
         - --tls-cert-file
         - /etc/kubernetes/tls/apiserver-tls.crt
         - --tls-private-key-file
@@ -200,6 +201,8 @@ spec:
         - X-Remote-Group
         - --requestheader-username-headers
         - X-Remote-User
+        - --audit-policy-file
+        - /etc/kubernetes/audit/policy.yaml
         - --kubelet-preferred-address-types
         - ExternalIP,InternalIP
         - --cloud-provider
@@ -276,9 +279,37 @@ spec:
         - mountPath: /etc/kubernetes/pki/front-proxy/ca
           name: front-proxy-ca
           readOnly: true
+        - mountPath: /etc/kubernetes/audit
+          name: audit-config
+          readOnly: true
+        - mountPath: /var/log/kubernetes/audit
+          name: audit-log
         - mountPath: /etc/kubernetes/dex/ca
           name: dex-ca
           readOnly: true
+      - args:
+        - -i
+        - tail
+        - -p
+        - path=/var/log/kubernetes/audit/audit.log
+        - -p
+        - db=/var/log/kubernetes/audit/fluentbit.db
+        - -o
+        - stdout
+        command:
+        - /fluent-bit/bin/fluent-bit
+        image: docker.io/fluent/fluent-bit:1.2.2
+        name: audit-logs
+        resources:
+          limits:
+            cpu: 50m
+            memory: 60Mi
+          requests:
+            cpu: 5m
+            memory: 10Mi
+        volumeMounts:
+        - mountPath: /var/log/kubernetes/audit
+          name: audit-log
       dnsConfig:
         nameservers:
         - 192.0.2.14
@@ -345,6 +376,12 @@ spec:
       - name: kubeletdnatcontroller-kubeconfig
         secret:
           secretName: kubeletdnatcontroller-kubeconfig
+      - configMap:
+          name: audit-config
+          optional: false
+        name: audit-config
+      - emptyDir: {}
+        name: audit-log
       - name: dex-ca
         secret:
           secretName: dex-ca

--- a/api/pkg/resources/test/fixtures/deployment-openstack-1.11.1-apiserver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-openstack-1.11.1-apiserver.yaml
@@ -21,6 +21,7 @@ spec:
         apiserver-proxy-client-certificate-secret-revision: "123456"
         apiserver-tls-secret-revision: "123456"
         app: apiserver
+        audit-config-configmap-revision: "123456"
         ca-secret-revision: "123456"
         cloud-config-configmap-revision: "123456"
         cluster: de-test-01
@@ -175,7 +176,7 @@ spec:
         - --audit-log-maxsize
         - "100"
         - --audit-log-path
-        - /var/log/audit.log
+        - /var/log/kubernetes/audit/audit.log
         - --tls-cert-file
         - /etc/kubernetes/tls/apiserver-tls.crt
         - --tls-private-key-file
@@ -200,6 +201,8 @@ spec:
         - X-Remote-Group
         - --requestheader-username-headers
         - X-Remote-User
+        - --audit-policy-file
+        - /etc/kubernetes/audit/policy.yaml
         - --kubelet-preferred-address-types
         - ExternalIP,InternalIP
         - --cloud-provider
@@ -276,9 +279,37 @@ spec:
         - mountPath: /etc/kubernetes/pki/front-proxy/ca
           name: front-proxy-ca
           readOnly: true
+        - mountPath: /etc/kubernetes/audit
+          name: audit-config
+          readOnly: true
+        - mountPath: /var/log/kubernetes/audit
+          name: audit-log
         - mountPath: /etc/kubernetes/dex/ca
           name: dex-ca
           readOnly: true
+      - args:
+        - -i
+        - tail
+        - -p
+        - path=/var/log/kubernetes/audit/audit.log
+        - -p
+        - db=/var/log/kubernetes/audit/fluentbit.db
+        - -o
+        - stdout
+        command:
+        - /fluent-bit/bin/fluent-bit
+        image: docker.io/fluent/fluent-bit:1.2.2
+        name: audit-logs
+        resources:
+          limits:
+            cpu: 50m
+            memory: 60Mi
+          requests:
+            cpu: 5m
+            memory: 10Mi
+        volumeMounts:
+        - mountPath: /var/log/kubernetes/audit
+          name: audit-log
       dnsConfig:
         nameservers:
         - 192.0.2.14
@@ -345,6 +376,12 @@ spec:
       - name: kubeletdnatcontroller-kubeconfig
         secret:
           secretName: kubeletdnatcontroller-kubeconfig
+      - configMap:
+          name: audit-config
+          optional: false
+        name: audit-config
+      - emptyDir: {}
+        name: audit-log
       - name: dex-ca
         secret:
           secretName: dex-ca

--- a/api/pkg/resources/test/fixtures/deployment-openstack-1.12.0-apiserver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-openstack-1.12.0-apiserver.yaml
@@ -21,6 +21,7 @@ spec:
         apiserver-proxy-client-certificate-secret-revision: "123456"
         apiserver-tls-secret-revision: "123456"
         app: apiserver
+        audit-config-configmap-revision: "123456"
         ca-secret-revision: "123456"
         cloud-config-configmap-revision: "123456"
         cluster: de-test-01
@@ -175,7 +176,7 @@ spec:
         - --audit-log-maxsize
         - "100"
         - --audit-log-path
-        - /var/log/audit.log
+        - /var/log/kubernetes/audit/audit.log
         - --tls-cert-file
         - /etc/kubernetes/tls/apiserver-tls.crt
         - --tls-private-key-file
@@ -200,6 +201,8 @@ spec:
         - X-Remote-Group
         - --requestheader-username-headers
         - X-Remote-User
+        - --audit-policy-file
+        - /etc/kubernetes/audit/policy.yaml
         - --kubelet-preferred-address-types
         - ExternalIP,InternalIP
         - --cloud-provider
@@ -276,9 +279,37 @@ spec:
         - mountPath: /etc/kubernetes/pki/front-proxy/ca
           name: front-proxy-ca
           readOnly: true
+        - mountPath: /etc/kubernetes/audit
+          name: audit-config
+          readOnly: true
+        - mountPath: /var/log/kubernetes/audit
+          name: audit-log
         - mountPath: /etc/kubernetes/dex/ca
           name: dex-ca
           readOnly: true
+      - args:
+        - -i
+        - tail
+        - -p
+        - path=/var/log/kubernetes/audit/audit.log
+        - -p
+        - db=/var/log/kubernetes/audit/fluentbit.db
+        - -o
+        - stdout
+        command:
+        - /fluent-bit/bin/fluent-bit
+        image: docker.io/fluent/fluent-bit:1.2.2
+        name: audit-logs
+        resources:
+          limits:
+            cpu: 50m
+            memory: 60Mi
+          requests:
+            cpu: 5m
+            memory: 10Mi
+        volumeMounts:
+        - mountPath: /var/log/kubernetes/audit
+          name: audit-log
       dnsConfig:
         nameservers:
         - 192.0.2.14
@@ -345,6 +376,12 @@ spec:
       - name: kubeletdnatcontroller-kubeconfig
         secret:
           secretName: kubeletdnatcontroller-kubeconfig
+      - configMap:
+          name: audit-config
+          optional: false
+        name: audit-config
+      - emptyDir: {}
+        name: audit-log
       - name: dex-ca
         secret:
           secretName: dex-ca

--- a/api/pkg/resources/test/fixtures/deployment-openstack-1.13.0-apiserver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-openstack-1.13.0-apiserver.yaml
@@ -21,6 +21,7 @@ spec:
         apiserver-proxy-client-certificate-secret-revision: "123456"
         apiserver-tls-secret-revision: "123456"
         app: apiserver
+        audit-config-configmap-revision: "123456"
         ca-secret-revision: "123456"
         cloud-config-configmap-revision: "123456"
         cluster: de-test-01
@@ -175,7 +176,7 @@ spec:
         - --audit-log-maxsize
         - "100"
         - --audit-log-path
-        - /var/log/audit.log
+        - /var/log/kubernetes/audit/audit.log
         - --tls-cert-file
         - /etc/kubernetes/tls/apiserver-tls.crt
         - --tls-private-key-file
@@ -200,6 +201,8 @@ spec:
         - X-Remote-Group
         - --requestheader-username-headers
         - X-Remote-User
+        - --audit-policy-file
+        - /etc/kubernetes/audit/policy.yaml
         - --kubelet-preferred-address-types
         - ExternalIP,InternalIP
         - --cloud-provider
@@ -276,9 +279,37 @@ spec:
         - mountPath: /etc/kubernetes/pki/front-proxy/ca
           name: front-proxy-ca
           readOnly: true
+        - mountPath: /etc/kubernetes/audit
+          name: audit-config
+          readOnly: true
+        - mountPath: /var/log/kubernetes/audit
+          name: audit-log
         - mountPath: /etc/kubernetes/dex/ca
           name: dex-ca
           readOnly: true
+      - args:
+        - -i
+        - tail
+        - -p
+        - path=/var/log/kubernetes/audit/audit.log
+        - -p
+        - db=/var/log/kubernetes/audit/fluentbit.db
+        - -o
+        - stdout
+        command:
+        - /fluent-bit/bin/fluent-bit
+        image: docker.io/fluent/fluent-bit:1.2.2
+        name: audit-logs
+        resources:
+          limits:
+            cpu: 50m
+            memory: 60Mi
+          requests:
+            cpu: 5m
+            memory: 10Mi
+        volumeMounts:
+        - mountPath: /var/log/kubernetes/audit
+          name: audit-log
       dnsConfig:
         nameservers:
         - 192.0.2.14
@@ -345,6 +376,12 @@ spec:
       - name: kubeletdnatcontroller-kubeconfig
         secret:
           secretName: kubeletdnatcontroller-kubeconfig
+      - configMap:
+          name: audit-config
+          optional: false
+        name: audit-config
+      - emptyDir: {}
+        name: audit-log
       - name: dex-ca
         secret:
           secretName: dex-ca

--- a/api/pkg/resources/test/fixtures/deployment-vsphere-1.10.0-apiserver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-vsphere-1.10.0-apiserver.yaml
@@ -21,6 +21,7 @@ spec:
         apiserver-proxy-client-certificate-secret-revision: "123456"
         apiserver-tls-secret-revision: "123456"
         app: apiserver
+        audit-config-configmap-revision: "123456"
         ca-secret-revision: "123456"
         cloud-config-configmap-revision: "123456"
         cluster: de-test-01
@@ -175,7 +176,7 @@ spec:
         - --audit-log-maxsize
         - "100"
         - --audit-log-path
-        - /var/log/audit.log
+        - /var/log/kubernetes/audit/audit.log
         - --tls-cert-file
         - /etc/kubernetes/tls/apiserver-tls.crt
         - --tls-private-key-file
@@ -200,6 +201,8 @@ spec:
         - X-Remote-Group
         - --requestheader-username-headers
         - X-Remote-User
+        - --audit-policy-file
+        - /etc/kubernetes/audit/policy.yaml
         - --kubelet-preferred-address-types
         - ExternalIP,InternalIP
         - --feature-gates
@@ -278,9 +281,37 @@ spec:
         - mountPath: /etc/kubernetes/pki/front-proxy/ca
           name: front-proxy-ca
           readOnly: true
+        - mountPath: /etc/kubernetes/audit
+          name: audit-config
+          readOnly: true
+        - mountPath: /var/log/kubernetes/audit
+          name: audit-log
         - mountPath: /etc/kubernetes/dex/ca
           name: dex-ca
           readOnly: true
+      - args:
+        - -i
+        - tail
+        - -p
+        - path=/var/log/kubernetes/audit/audit.log
+        - -p
+        - db=/var/log/kubernetes/audit/fluentbit.db
+        - -o
+        - stdout
+        command:
+        - /fluent-bit/bin/fluent-bit
+        image: docker.io/fluent/fluent-bit:1.2.2
+        name: audit-logs
+        resources:
+          limits:
+            cpu: 50m
+            memory: 60Mi
+          requests:
+            cpu: 5m
+            memory: 10Mi
+        volumeMounts:
+        - mountPath: /var/log/kubernetes/audit
+          name: audit-log
       dnsConfig:
         nameservers:
         - 192.0.2.14
@@ -347,6 +378,12 @@ spec:
       - name: kubeletdnatcontroller-kubeconfig
         secret:
           secretName: kubeletdnatcontroller-kubeconfig
+      - configMap:
+          name: audit-config
+          optional: false
+        name: audit-config
+      - emptyDir: {}
+        name: audit-log
       - name: dex-ca
         secret:
           secretName: dex-ca

--- a/api/pkg/resources/test/fixtures/deployment-vsphere-1.10.6-apiserver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-vsphere-1.10.6-apiserver.yaml
@@ -21,6 +21,7 @@ spec:
         apiserver-proxy-client-certificate-secret-revision: "123456"
         apiserver-tls-secret-revision: "123456"
         app: apiserver
+        audit-config-configmap-revision: "123456"
         ca-secret-revision: "123456"
         cloud-config-configmap-revision: "123456"
         cluster: de-test-01
@@ -175,7 +176,7 @@ spec:
         - --audit-log-maxsize
         - "100"
         - --audit-log-path
-        - /var/log/audit.log
+        - /var/log/kubernetes/audit/audit.log
         - --tls-cert-file
         - /etc/kubernetes/tls/apiserver-tls.crt
         - --tls-private-key-file
@@ -200,6 +201,8 @@ spec:
         - X-Remote-Group
         - --requestheader-username-headers
         - X-Remote-User
+        - --audit-policy-file
+        - /etc/kubernetes/audit/policy.yaml
         - --kubelet-preferred-address-types
         - ExternalIP,InternalIP
         - --feature-gates
@@ -278,9 +281,37 @@ spec:
         - mountPath: /etc/kubernetes/pki/front-proxy/ca
           name: front-proxy-ca
           readOnly: true
+        - mountPath: /etc/kubernetes/audit
+          name: audit-config
+          readOnly: true
+        - mountPath: /var/log/kubernetes/audit
+          name: audit-log
         - mountPath: /etc/kubernetes/dex/ca
           name: dex-ca
           readOnly: true
+      - args:
+        - -i
+        - tail
+        - -p
+        - path=/var/log/kubernetes/audit/audit.log
+        - -p
+        - db=/var/log/kubernetes/audit/fluentbit.db
+        - -o
+        - stdout
+        command:
+        - /fluent-bit/bin/fluent-bit
+        image: docker.io/fluent/fluent-bit:1.2.2
+        name: audit-logs
+        resources:
+          limits:
+            cpu: 50m
+            memory: 60Mi
+          requests:
+            cpu: 5m
+            memory: 10Mi
+        volumeMounts:
+        - mountPath: /var/log/kubernetes/audit
+          name: audit-log
       dnsConfig:
         nameservers:
         - 192.0.2.14
@@ -347,6 +378,12 @@ spec:
       - name: kubeletdnatcontroller-kubeconfig
         secret:
           secretName: kubeletdnatcontroller-kubeconfig
+      - configMap:
+          name: audit-config
+          optional: false
+        name: audit-config
+      - emptyDir: {}
+        name: audit-log
       - name: dex-ca
         secret:
           secretName: dex-ca

--- a/api/pkg/resources/test/fixtures/deployment-vsphere-1.11.0-apiserver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-vsphere-1.11.0-apiserver.yaml
@@ -21,6 +21,7 @@ spec:
         apiserver-proxy-client-certificate-secret-revision: "123456"
         apiserver-tls-secret-revision: "123456"
         app: apiserver
+        audit-config-configmap-revision: "123456"
         ca-secret-revision: "123456"
         cloud-config-configmap-revision: "123456"
         cluster: de-test-01
@@ -175,7 +176,7 @@ spec:
         - --audit-log-maxsize
         - "100"
         - --audit-log-path
-        - /var/log/audit.log
+        - /var/log/kubernetes/audit/audit.log
         - --tls-cert-file
         - /etc/kubernetes/tls/apiserver-tls.crt
         - --tls-private-key-file
@@ -200,6 +201,8 @@ spec:
         - X-Remote-Group
         - --requestheader-username-headers
         - X-Remote-User
+        - --audit-policy-file
+        - /etc/kubernetes/audit/policy.yaml
         - --kubelet-preferred-address-types
         - ExternalIP,InternalIP
         - --cloud-provider
@@ -276,9 +279,37 @@ spec:
         - mountPath: /etc/kubernetes/pki/front-proxy/ca
           name: front-proxy-ca
           readOnly: true
+        - mountPath: /etc/kubernetes/audit
+          name: audit-config
+          readOnly: true
+        - mountPath: /var/log/kubernetes/audit
+          name: audit-log
         - mountPath: /etc/kubernetes/dex/ca
           name: dex-ca
           readOnly: true
+      - args:
+        - -i
+        - tail
+        - -p
+        - path=/var/log/kubernetes/audit/audit.log
+        - -p
+        - db=/var/log/kubernetes/audit/fluentbit.db
+        - -o
+        - stdout
+        command:
+        - /fluent-bit/bin/fluent-bit
+        image: docker.io/fluent/fluent-bit:1.2.2
+        name: audit-logs
+        resources:
+          limits:
+            cpu: 50m
+            memory: 60Mi
+          requests:
+            cpu: 5m
+            memory: 10Mi
+        volumeMounts:
+        - mountPath: /var/log/kubernetes/audit
+          name: audit-log
       dnsConfig:
         nameservers:
         - 192.0.2.14
@@ -345,6 +376,12 @@ spec:
       - name: kubeletdnatcontroller-kubeconfig
         secret:
           secretName: kubeletdnatcontroller-kubeconfig
+      - configMap:
+          name: audit-config
+          optional: false
+        name: audit-config
+      - emptyDir: {}
+        name: audit-log
       - name: dex-ca
         secret:
           secretName: dex-ca

--- a/api/pkg/resources/test/fixtures/deployment-vsphere-1.11.1-apiserver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-vsphere-1.11.1-apiserver.yaml
@@ -21,6 +21,7 @@ spec:
         apiserver-proxy-client-certificate-secret-revision: "123456"
         apiserver-tls-secret-revision: "123456"
         app: apiserver
+        audit-config-configmap-revision: "123456"
         ca-secret-revision: "123456"
         cloud-config-configmap-revision: "123456"
         cluster: de-test-01
@@ -175,7 +176,7 @@ spec:
         - --audit-log-maxsize
         - "100"
         - --audit-log-path
-        - /var/log/audit.log
+        - /var/log/kubernetes/audit/audit.log
         - --tls-cert-file
         - /etc/kubernetes/tls/apiserver-tls.crt
         - --tls-private-key-file
@@ -200,6 +201,8 @@ spec:
         - X-Remote-Group
         - --requestheader-username-headers
         - X-Remote-User
+        - --audit-policy-file
+        - /etc/kubernetes/audit/policy.yaml
         - --kubelet-preferred-address-types
         - ExternalIP,InternalIP
         - --cloud-provider
@@ -276,9 +279,37 @@ spec:
         - mountPath: /etc/kubernetes/pki/front-proxy/ca
           name: front-proxy-ca
           readOnly: true
+        - mountPath: /etc/kubernetes/audit
+          name: audit-config
+          readOnly: true
+        - mountPath: /var/log/kubernetes/audit
+          name: audit-log
         - mountPath: /etc/kubernetes/dex/ca
           name: dex-ca
           readOnly: true
+      - args:
+        - -i
+        - tail
+        - -p
+        - path=/var/log/kubernetes/audit/audit.log
+        - -p
+        - db=/var/log/kubernetes/audit/fluentbit.db
+        - -o
+        - stdout
+        command:
+        - /fluent-bit/bin/fluent-bit
+        image: docker.io/fluent/fluent-bit:1.2.2
+        name: audit-logs
+        resources:
+          limits:
+            cpu: 50m
+            memory: 60Mi
+          requests:
+            cpu: 5m
+            memory: 10Mi
+        volumeMounts:
+        - mountPath: /var/log/kubernetes/audit
+          name: audit-log
       dnsConfig:
         nameservers:
         - 192.0.2.14
@@ -345,6 +376,12 @@ spec:
       - name: kubeletdnatcontroller-kubeconfig
         secret:
           secretName: kubeletdnatcontroller-kubeconfig
+      - configMap:
+          name: audit-config
+          optional: false
+        name: audit-config
+      - emptyDir: {}
+        name: audit-log
       - name: dex-ca
         secret:
           secretName: dex-ca

--- a/api/pkg/resources/test/fixtures/deployment-vsphere-1.12.0-apiserver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-vsphere-1.12.0-apiserver.yaml
@@ -21,6 +21,7 @@ spec:
         apiserver-proxy-client-certificate-secret-revision: "123456"
         apiserver-tls-secret-revision: "123456"
         app: apiserver
+        audit-config-configmap-revision: "123456"
         ca-secret-revision: "123456"
         cloud-config-configmap-revision: "123456"
         cluster: de-test-01
@@ -175,7 +176,7 @@ spec:
         - --audit-log-maxsize
         - "100"
         - --audit-log-path
-        - /var/log/audit.log
+        - /var/log/kubernetes/audit/audit.log
         - --tls-cert-file
         - /etc/kubernetes/tls/apiserver-tls.crt
         - --tls-private-key-file
@@ -200,6 +201,8 @@ spec:
         - X-Remote-Group
         - --requestheader-username-headers
         - X-Remote-User
+        - --audit-policy-file
+        - /etc/kubernetes/audit/policy.yaml
         - --kubelet-preferred-address-types
         - ExternalIP,InternalIP
         - --cloud-provider
@@ -276,9 +279,37 @@ spec:
         - mountPath: /etc/kubernetes/pki/front-proxy/ca
           name: front-proxy-ca
           readOnly: true
+        - mountPath: /etc/kubernetes/audit
+          name: audit-config
+          readOnly: true
+        - mountPath: /var/log/kubernetes/audit
+          name: audit-log
         - mountPath: /etc/kubernetes/dex/ca
           name: dex-ca
           readOnly: true
+      - args:
+        - -i
+        - tail
+        - -p
+        - path=/var/log/kubernetes/audit/audit.log
+        - -p
+        - db=/var/log/kubernetes/audit/fluentbit.db
+        - -o
+        - stdout
+        command:
+        - /fluent-bit/bin/fluent-bit
+        image: docker.io/fluent/fluent-bit:1.2.2
+        name: audit-logs
+        resources:
+          limits:
+            cpu: 50m
+            memory: 60Mi
+          requests:
+            cpu: 5m
+            memory: 10Mi
+        volumeMounts:
+        - mountPath: /var/log/kubernetes/audit
+          name: audit-log
       dnsConfig:
         nameservers:
         - 192.0.2.14
@@ -345,6 +376,12 @@ spec:
       - name: kubeletdnatcontroller-kubeconfig
         secret:
           secretName: kubeletdnatcontroller-kubeconfig
+      - configMap:
+          name: audit-config
+          optional: false
+        name: audit-config
+      - emptyDir: {}
+        name: audit-log
       - name: dex-ca
         secret:
           secretName: dex-ca

--- a/api/pkg/resources/test/fixtures/deployment-vsphere-1.13.0-apiserver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-vsphere-1.13.0-apiserver.yaml
@@ -21,6 +21,7 @@ spec:
         apiserver-proxy-client-certificate-secret-revision: "123456"
         apiserver-tls-secret-revision: "123456"
         app: apiserver
+        audit-config-configmap-revision: "123456"
         ca-secret-revision: "123456"
         cloud-config-configmap-revision: "123456"
         cluster: de-test-01
@@ -175,7 +176,7 @@ spec:
         - --audit-log-maxsize
         - "100"
         - --audit-log-path
-        - /var/log/audit.log
+        - /var/log/kubernetes/audit/audit.log
         - --tls-cert-file
         - /etc/kubernetes/tls/apiserver-tls.crt
         - --tls-private-key-file
@@ -200,6 +201,8 @@ spec:
         - X-Remote-Group
         - --requestheader-username-headers
         - X-Remote-User
+        - --audit-policy-file
+        - /etc/kubernetes/audit/policy.yaml
         - --kubelet-preferred-address-types
         - ExternalIP,InternalIP
         - --cloud-provider
@@ -276,9 +279,37 @@ spec:
         - mountPath: /etc/kubernetes/pki/front-proxy/ca
           name: front-proxy-ca
           readOnly: true
+        - mountPath: /etc/kubernetes/audit
+          name: audit-config
+          readOnly: true
+        - mountPath: /var/log/kubernetes/audit
+          name: audit-log
         - mountPath: /etc/kubernetes/dex/ca
           name: dex-ca
           readOnly: true
+      - args:
+        - -i
+        - tail
+        - -p
+        - path=/var/log/kubernetes/audit/audit.log
+        - -p
+        - db=/var/log/kubernetes/audit/fluentbit.db
+        - -o
+        - stdout
+        command:
+        - /fluent-bit/bin/fluent-bit
+        image: docker.io/fluent/fluent-bit:1.2.2
+        name: audit-logs
+        resources:
+          limits:
+            cpu: 50m
+            memory: 60Mi
+          requests:
+            cpu: 5m
+            memory: 10Mi
+        volumeMounts:
+        - mountPath: /var/log/kubernetes/audit
+          name: audit-log
       dnsConfig:
         nameservers:
         - 192.0.2.14
@@ -345,6 +376,12 @@ spec:
       - name: kubeletdnatcontroller-kubeconfig
         secret:
           secretName: kubeletdnatcontroller-kubeconfig
+      - configMap:
+          name: audit-config
+          optional: false
+        name: audit-config
+      - emptyDir: {}
+        name: audit-log
       - name: dex-ca
         secret:
           secretName: dex-ca

--- a/api/pkg/resources/test/load_files_test.go
+++ b/api/pkg/resources/test/load_files_test.go
@@ -420,6 +420,13 @@ func TestLoadFiles(t *testing.T) {
 							Namespace:       cluster.Status.NamespaceName,
 						},
 					},
+					&corev1.ConfigMap{
+						ObjectMeta: metav1.ObjectMeta{
+							ResourceVersion: "123456",
+							Name:            resources.AuditConfigMapName,
+							Namespace:       cluster.Status.NamespaceName,
+						},
+					},
 					&corev1.Service{
 						ObjectMeta: metav1.ObjectMeta{
 							Name:      resources.ApiserverExternalServiceName,


### PR DESCRIPTION
**What this PR does / why we need it**:
Requirement for [this issue](https://app.zenhub.com/workspaces/kubermatic-customer-5caccadc8a630d4a65e9590b/issues/kubermatic/customer-projects/158).

**Special notes for your reviewer**:
None

**Documentation**:
No changes yet.

**Does this PR introduce a user-facing change?**:
```release-note
Add support for kubernetes auditing
```
