### PR TITLE
update cert-manager to 0.9.1 (for real this time)

### DIFF
--- a/config/cert-manager/Chart.yaml
+++ b/config/cert-manager/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 name: cert-manager
-version: 1.0.3
-appVersion: v0.8.0
+version: 1.1.0
+appVersion: v0.9.1
 description: A Helm chart for cert-manager
 keywords:
 - kubermatic

--- a/config/cert-manager/templates/cainjector-deployment.yaml
+++ b/config/cert-manager/templates/cainjector-deployment.yaml
@@ -1,16 +1,24 @@
-apiVersion: apps/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: cainjector
+  labels:
+    app: cainjector
+    app.kubernetes.io/name: cainjector
+    app.kubernetes.io/instance: {{ .Release.Name }}
 spec:
   replicas: {{ .Values.certManager.cainjector.replicas }}
   selector:
     matchLabels:
       app: cainjector
+      app.kubernetes.io/name: cainjector
+      app.kubernetes.io/instance:  {{ .Release.Name }}
   template:
     metadata:
       labels:
         app: cainjector
+        app.kubernetes.io/name: cainjector
+        app.kubernetes.io/instance:  {{ .Release.Name }}
       annotations:
         fluentbit.io/parser: glog
     spec:

--- a/config/cert-manager/templates/cainjector-rbac.yaml
+++ b/config/cert-manager/templates/cainjector-rbac.yaml
@@ -2,28 +2,39 @@ apiVersion: rbac.authorization.k8s.io/v1beta1
 kind: ClusterRole
 metadata:
   name: cert-manager-cainjector
+  labels:
+    app: cainjector
+    app.kubernetes.io/name: cainjector
+    app.kubernetes.io/instance: {{ .Release.Name }}
 rules:
-- apiGroups: [certmanager.k8s.io]
-  resources: [certificates]
-  verbs: [get, list, watch]
-- apiGroups: ['']
-  resources: [secrets]
-  verbs: [get, list, watch]
-- apiGroups: ['']
-  resources: [configmaps, events]
-  verbs: ['*']
-- apiGroups: [admissionregistration.k8s.io]
-  resources: [validatingwebhookconfigurations, mutatingwebhookconfigurations]
-  verbs: ['*']
-- apiGroups: [apiregistration.k8s.io]
-  resources: [apiservices]
-  verbs: ['*']
+- apiGroups: ["certmanager.k8s.io"]
+  resources: ["certificates"]
+  verbs: ["get", "list", "watch"]
+- apiGroups: [""]
+  resources: ["secrets"]
+  verbs: ["get", "list", "watch"]
+- apiGroups: [""]
+  resources: ["configmaps", "events"]
+  verbs: ["get", "create", "update", "patch"]
+- apiGroups: ["admissionregistration.k8s.io"]
+  resources: ["validatingwebhookconfigurations", "mutatingwebhookconfigurations"]
+  verbs: ["get", "list", "watch", "update"]
+- apiGroups: ["apiregistration.k8s.io"]
+  resources: ["apiservices"]
+  verbs: ["get", "list", "watch", "update"]
+- apiGroups: ["apiextensions.k8s.io"]
+  resources: ["customresourcedefinitions"]
+  verbs: ["get", "list", "watch", "update"]
 
 ---
 apiVersion: rbac.authorization.k8s.io/v1beta1
 kind: ClusterRoleBinding
 metadata:
   name: cert-manager-cainjector
+  labels:
+    app: cainjector
+    app.kubernetes.io/name: cainjector
+    app.kubernetes.io/instance:  {{ .Release.Name }}
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole

--- a/config/cert-manager/templates/cainjector-serviceaccount.yaml
+++ b/config/cert-manager/templates/cainjector-serviceaccount.yaml
@@ -2,3 +2,7 @@ apiVersion: v1
 kind: ServiceAccount
 metadata:
   name: cainjector
+  labels:
+    app: cainjector
+    app.kubernetes.io/name: cainjector
+    app.kubernetes.io/instance: {{ .Release.Name }}

--- a/config/cert-manager/templates/cert-manager-deployment.yaml
+++ b/config/cert-manager/templates/cert-manager-deployment.yaml
@@ -1,16 +1,24 @@
-apiVersion: apps/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: cert-manager
+  labels:
+    app: cert-manager
+    app.kubernetes.io/name: cert-manager
+    app.kubernetes.io/instance: {{ .Release.Name }}
 spec:
   replicas: {{ .Values.certManager.controller.replicas }}
   selector:
     matchLabels:
       app: cert-manager
+      app.kubernetes.io/name: cert-manager
+      app.kubernetes.io/instance: {{ .Release.Name }}
   template:
     metadata:
       labels:
         app: cert-manager
+        app.kubernetes.io/name: cert-manager
+        app.kubernetes.io/instance: {{ .Release.Name }}
       annotations:
         kubermatic/scrape: 'true'
         kubermatic/scrape_port: '9402'

--- a/config/cert-manager/templates/cert-manager-rbac.yaml
+++ b/config/cert-manager/templates/cert-manager-rbac.yaml
@@ -1,36 +1,340 @@
 apiVersion: rbac.authorization.k8s.io/v1beta1
 kind: ClusterRole
 metadata:
-  name: cert-manager
+  name: cert-manager-leaderelection
+  labels:
+    app: cert-manager
+    app.kubernetes.io/name: cert-manager
+    app.kubernetes.io/instance:  {{ .Release.Name }}
 rules:
-  - apiGroups: [certmanager.k8s.io]
-    resources: [certificates, certificates/finalizers, issuers, clusterissuers, orders, orders/finalizers, challenges, challenges/finalizers]
-    verbs: ['*']
-  - apiGroups: ['']
-    resources: [configmaps, secrets, events, services, pods]
-    verbs: ['*']
-  - apiGroups: [extensions]
-    resources: [ingresses, ingresses/finalizers]
-    verbs: ['*']
-  {{- if .Values.certManager.isOpenshift }}
-  - apiGroups: [route.openshift.io]
-    resources: [routes, routes/custom-host, routes/finalizers]
-    verbs: ['*']
-  {{- end }}
+  # Used for leader election by the controller
+  - apiGroups: [""]
+    resources: ["configmaps"]
+    verbs: ["get", "create", "update", "patch"]
+    apiVersion: rbac.authorization.k8s.io/v1beta1
+
+---
+# Issuer controller role
+apiVersion: rbac.authorization.k8s.io/v1beta1
+kind: ClusterRole
+metadata:
+  name: cert-manager-controller-issuers
+  labels:
+    app: cert-manager
+    app.kubernetes.io/name: cert-manager
+    app.kubernetes.io/instance:  {{ .Release.Name }}
+rules:
+  - apiGroups: ["certmanager.k8s.io"]
+    resources: ["issuers", "issuers/status"]
+    verbs: ["update"]
+  - apiGroups: ["certmanager.k8s.io"]
+    resources: ["issuers"]
+    verbs: ["get", "list", "watch"]
+  - apiGroups: [""]
+    resources: ["secrets"]
+    verbs: ["get", "list", "watch", "create", "update", "delete"]
+  - apiGroups: [""]
+    resources: ["events"]
+    verbs: ["create", "patch"]
+
+---
+# ClusterIssuer controller role
+apiVersion: rbac.authorization.k8s.io/v1beta1
+kind: ClusterRole
+metadata:
+  name: cert-manager-controller-clusterissuers
+  labels:
+    app: cert-manager
+    app.kubernetes.io/name: cert-manager
+    app.kubernetes.io/instance:  {{ .Release.Name }}
+rules:
+  - apiGroups: ["certmanager.k8s.io"]
+    resources: ["clusterissuers", "clusterissuers/status"]
+    verbs: ["update"]
+  - apiGroups: ["certmanager.k8s.io"]
+    resources: ["clusterissuers"]
+    verbs: ["get", "list", "watch"]
+  - apiGroups: [""]
+    resources: ["secrets"]
+    verbs: ["get", "list", "watch", "create", "update", "delete"]
+  - apiGroups: [""]
+    resources: ["events"]
+    verbs: ["create", "patch"]
+
+---
+# Certificates controller role
+apiVersion: rbac.authorization.k8s.io/v1beta1
+kind: ClusterRole
+metadata:
+  name: cert-manager-controller-certificates
+  labels:
+    app: cert-manager
+    app.kubernetes.io/name: cert-manager
+    app.kubernetes.io/instance:  {{ .Release.Name }}
+rules:
+  - apiGroups: ["certmanager.k8s.io"]
+    resources: ["certificates", "certificates/status", "certificaterequests", "certificaterequests/status"]
+    verbs: ["update"]
+  - apiGroups: ["certmanager.k8s.io"]
+    resources: ["certificates", "certificaterequests", "clusterissuers", "issuers", "orders"]
+    verbs: ["get", "list", "watch"]
+  # We require these rules to support users with the OwnerReferencesPermissionEnforcement
+  # admission controller enabled:
+  # https://kubernetes.io/docs/reference/access-authn-authz/admission-controllers/#ownerreferencespermissionenforcement
+  - apiGroups: ["certmanager.k8s.io"]
+    resources: ["certificates/finalizers"]
+    verbs: ["update"]
+  - apiGroups: ["certmanager.k8s.io"]
+    resources: ["orders"]
+    verbs: ["create", "delete"]
+  - apiGroups: [""]
+    resources: ["secrets"]
+    verbs: ["get", "list", "watch", "create", "update", "delete"]
+  - apiGroups: [""]
+    resources: ["events"]
+    verbs: ["create", "patch"]
+
+---
+# Orders controller role
+apiVersion: rbac.authorization.k8s.io/v1beta1
+kind: ClusterRole
+metadata:
+  name: cert-manager-controller-orders
+  labels:
+    app: cert-manager
+    app.kubernetes.io/name: cert-manager
+    app.kubernetes.io/instance:  {{ .Release.Name }}
+rules:
+  - apiGroups: ["certmanager.k8s.io"]
+    resources: ["orders", "orders/status"]
+    verbs: ["update"]
+  - apiGroups: ["certmanager.k8s.io"]
+    resources: ["orders", "clusterissuers", "issuers", "challenges"]
+    verbs: ["get", "list", "watch"]
+  - apiGroups: ["certmanager.k8s.io"]
+    resources: ["challenges"]
+    verbs: ["create", "delete"]
+  # We require these rules to support users with the OwnerReferencesPermissionEnforcement
+  # admission controller enabled:
+  # https://kubernetes.io/docs/reference/access-authn-authz/admission-controllers/#ownerreferencespermissionenforcement
+  - apiGroups: ["certmanager.k8s.io"]
+    resources: ["orders/finalizers"]
+    verbs: ["update"]
+  - apiGroups: [""]
+    resources: ["secrets"]
+    verbs: ["get", "list", "watch"]
+  - apiGroups: [""]
+    resources: ["events"]
+    verbs: ["create", "patch"]
+
+---
+# Challenges controller role
+apiVersion: rbac.authorization.k8s.io/v1beta1
+kind: ClusterRole
+metadata:
+  name: cert-manager-controller-challenges
+  labels:
+    app: cert-manager
+    app.kubernetes.io/name: cert-manager
+    app.kubernetes.io/instance:  {{ .Release.Name }}
+rules:
+  # Use to update challenge resource status
+  - apiGroups: ["certmanager.k8s.io"]
+    resources: ["challenges", "challenges/status"]
+    verbs: ["update"]
+  # Used to watch challenges, issuer and clusterissuer resources
+  - apiGroups: ["certmanager.k8s.io"]
+    resources: ["challenges", "issuers", "clusterissuers"]
+    verbs: ["get", "list", "watch"]
+  # Need to be able to retrieve ACME account private key to complete challenges
+  - apiGroups: [""]
+    resources: ["secrets"]
+    verbs: ["get", "list", "watch"]
+  # Used to create events
+  - apiGroups: [""]
+    resources: ["events"]
+    verbs: ["create", "patch"]
+  # HTTP01 rules
+  - apiGroups: [""]
+    resources: ["pods", "services"]
+    verbs: ["get", "list", "watch", "create", "delete"]
+  - apiGroups: ["extensions"]
+    resources: ["ingresses"]
+    verbs: ["get", "list", "watch", "create", "delete", "update"]
+{{- if .Values.certManager.isOpenshift }}
+  # We require the ability to specify a custom hostname when we are creating
+  # new ingress resources.
+  # See: https://github.com/openshift/origin/blob/21f191775636f9acadb44fa42beeb4f75b255532/pkg/route/apiserver/admission/ingress_admission.go#L84-L148
+  - apiGroups: ["route.openshift.io"]
+    resources: ["routes/custom-host"]
+    verbs: ["create"]
+{{- end }}
+  # We require these rules to support users with the OwnerReferencesPermissionEnforcement
+  # admission controller enabled:
+  # https://kubernetes.io/docs/reference/access-authn-authz/admission-controllers/#ownerreferencespermissionenforcement
+  - apiGroups: ["certmanager.k8s.io"]
+    resources: ["challenges/finalizers"]
+    verbs: ["update"]
+  # DNS01 rules (duplicated above)
+  - apiGroups: [""]
+    resources: ["secrets"]
+    verbs: ["get", "list", "watch"]
+
+---
+# ingress-shim controller role
+apiVersion: rbac.authorization.k8s.io/v1beta1
+kind: ClusterRole
+metadata:
+  name: cert-manager-controller-ingress-shim
+  labels:
+    app: cert-manager
+    app.kubernetes.io/name: cert-manager
+    app.kubernetes.io/instance:  {{ .Release.Name }}
+rules:
+  - apiGroups: ["certmanager.k8s.io"]
+    resources: ["certificates", "certificaterequests"]
+    verbs: ["create", "update", "delete"]
+  - apiGroups: ["certmanager.k8s.io"]
+    resources: ["certificates", "certificaterequests", "issuers", "clusterissuers"]
+    verbs: ["get", "list", "watch"]
+  - apiGroups: ["extensions"]
+    resources: ["ingresses"]
+    verbs: ["get", "list", "watch"]
+  # We require these rules to support users with the OwnerReferencesPermissionEnforcement
+  # admission controller enabled:
+  # https://kubernetes.io/docs/reference/access-authn-authz/admission-controllers/#ownerreferencespermissionenforcement
+  - apiGroups: ["extensions"]
+    resources: ["ingresses/finalizers"]
+    verbs: ["update"]
+  - apiGroups: [""]
+    resources: ["events"]
+    verbs: ["create", "patch"]
 
 ---
 apiVersion: rbac.authorization.k8s.io/v1beta1
 kind: ClusterRoleBinding
 metadata:
-  name: cert-manager
+  name: cert-manager-leaderelection
+  labels:
+    app: cert-manager
+    app.kubernetes.io/name: cert-manager
+    app.kubernetes.io/instance:  {{ .Release.Name }}
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
-  name: cert-manager
+  name: cert-manager-leaderelection
 subjects:
-- name: cert-manager
-  namespace: '{{ .Release.Namespace }}'
-  kind: ServiceAccount
+  - name: cert-manager
+    namespace: {{ .Release.Namespace | quote }}
+    kind: ServiceAccount
+
+---
+apiVersion: rbac.authorization.k8s.io/v1beta1
+kind: ClusterRoleBinding
+metadata:
+  name: cert-manager-controller-issuers
+  labels:
+    app: cert-manager
+    app.kubernetes.io/name: cert-manager
+    app.kubernetes.io/instance:  {{ .Release.Name }}
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: cert-manager-controller-issuers
+subjects:
+  - name: cert-manager
+    namespace: {{ .Release.Namespace | quote }}
+    kind: ServiceAccount
+
+---
+apiVersion: rbac.authorization.k8s.io/v1beta1
+kind: ClusterRoleBinding
+metadata:
+  name: cert-manager-controller-clusterissuers
+  labels:
+    app: cert-manager
+    app.kubernetes.io/name: cert-manager
+    app.kubernetes.io/instance:  {{ .Release.Name }}
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: cert-manager-controller-clusterissuers
+subjects:
+  - name: cert-manager
+    namespace: {{ .Release.Namespace | quote }}
+    kind: ServiceAccount
+
+---
+apiVersion: rbac.authorization.k8s.io/v1beta1
+kind: ClusterRoleBinding
+metadata:
+  name: cert-manager-controller-certificates
+  labels:
+    app: cert-manager
+    app.kubernetes.io/name: cert-manager
+    app.kubernetes.io/instance:  {{ .Release.Name }}
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: cert-manager-controller-certificates
+subjects:
+  - name: cert-manager
+    namespace: {{ .Release.Namespace | quote }}
+    kind: ServiceAccount
+
+---
+apiVersion: rbac.authorization.k8s.io/v1beta1
+kind: ClusterRoleBinding
+metadata:
+  name: cert-manager-controller-orders
+  labels:
+    app: cert-manager
+    app.kubernetes.io/name: cert-manager
+    app.kubernetes.io/instance:  {{ .Release.Name }}
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: cert-manager-controller-orders
+subjects:
+  - name: cert-manager
+    namespace: {{ .Release.Namespace | quote }}
+    kind: ServiceAccount
+
+---
+apiVersion: rbac.authorization.k8s.io/v1beta1
+kind: ClusterRoleBinding
+metadata:
+  name: cert-manager-controller-challenges
+  labels:
+    app: cert-manager
+    app.kubernetes.io/name: cert-manager
+    app.kubernetes.io/instance:  {{ .Release.Name }}
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: cert-manager-controller-challenges
+subjects:
+  - name: cert-manager
+    namespace: {{ .Release.Namespace | quote }}
+    kind: ServiceAccount
+
+---
+apiVersion: rbac.authorization.k8s.io/v1beta1
+kind: ClusterRoleBinding
+metadata:
+  name: cert-manager-controller-ingress-shim
+  labels:
+    app: cert-manager
+    app.kubernetes.io/name: cert-manager
+    app.kubernetes.io/instance:  {{ .Release.Name }}
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: cert-manager-controller-ingress-shim
+subjects:
+  - name: cert-manager
+    namespace: {{ .Release.Namespace | quote }}
+    kind: ServiceAccount
 
 ---
 apiVersion: rbac.authorization.k8s.io/v1
@@ -38,13 +342,16 @@ kind: ClusterRole
 metadata:
   name: cert-manager-view
   labels:
-    rbac.authorization.k8s.io/aggregate-to-view: 'true'
-    rbac.authorization.k8s.io/aggregate-to-edit: 'true'
-    rbac.authorization.k8s.io/aggregate-to-admin: 'true'
+    app: cert-manager
+    app.kubernetes.io/name: cert-manager
+    app.kubernetes.io/instance:  {{ .Release.Name }}
+    rbac.authorization.k8s.io/aggregate-to-view: "true"
+    rbac.authorization.k8s.io/aggregate-to-edit: "true"
+    rbac.authorization.k8s.io/aggregate-to-admin: "true"
 rules:
-- apiGroups: ['certmanager.k8s.io']
-  resources: ['certificates', 'issuers']
-  verbs: ['get', 'list', 'watch']
+  - apiGroups: ["certmanager.k8s.io"]
+    resources: ["certificates", "certificaterequests", "issuers"]
+    verbs: ["get", "list", "watch"]
 
 ---
 apiVersion: rbac.authorization.k8s.io/v1
@@ -52,9 +359,12 @@ kind: ClusterRole
 metadata:
   name: cert-manager-edit
   labels:
-    rbac.authorization.k8s.io/aggregate-to-edit: 'true'
-    rbac.authorization.k8s.io/aggregate-to-admin: 'true'
+    app: cert-manager
+    app.kubernetes.io/name: cert-manager
+    app.kubernetes.io/instance:  {{ .Release.Name }}
+    rbac.authorization.k8s.io/aggregate-to-edit: "true"
+    rbac.authorization.k8s.io/aggregate-to-admin: "true"
 rules:
-  - apiGroups: ['certmanager.k8s.io']
-    resources: ['certificates', 'issuers']
-    verbs: ['create', 'delete', 'deletecollection', 'patch', 'update']
+  - apiGroups: ["certmanager.k8s.io"]
+    resources: ["certificates", "certificaterequests", "issuers"]
+    verbs: ["create", "delete", "deletecollection", "patch", "update"]

--- a/config/cert-manager/templates/cert-manager-serviceaccount.yaml
+++ b/config/cert-manager/templates/cert-manager-serviceaccount.yaml
@@ -2,3 +2,7 @@ apiVersion: v1
 kind: ServiceAccount
 metadata:
   name: cert-manager
+  labels:
+    app: cert-manager
+    app.kubernetes.io/name: cert-manager
+    app.kubernetes.io/instance:  {{ .Release.Name }}

--- a/config/cert-manager/templates/crd.yaml
+++ b/config/cert-manager/templates/crd.yaml
@@ -77,11 +77,18 @@ spec:
               - config
               type: object
             commonName:
-              description: CommonName is a common name to be used on the Certificate
+              description: CommonName is a common name to be used on the Certificate.
+                If no CommonName is given, then the first entry in DNSNames is used
+                as the CommonName. The CommonName should have a length of 64 characters
+                or fewer to avoid generating invalid CSRs; in order to have longer
+                domain names, set the CommonName (or first DNSNames entry) to have
+                64 characters or fewer, and then add the longer domain name to DNSNames.
               type: string
             dnsNames:
               description: DNSNames is a list of subject alt names to be used on the
-                Certificate
+                Certificate. If no CommonName is given, then the first entry in DNSNames
+                is used as the CommonName and must have a length of 64 characters
+                or fewer.
               items:
                 type: string
               type: array
@@ -106,6 +113,8 @@ spec:
                 with the provided name will be used. The 'name' field in this stanza
                 is required at all times.
               properties:
+                group:
+                  type: string
                 kind:
                   type: string
                 name:
@@ -122,6 +131,13 @@ spec:
               enum:
               - rsa
               - ecdsa
+              type: string
+            keyEncoding:
+              description: KeyEncoding is the private key cryptography standards (PKCS)
+                for this certificate's private key to be encoded in. If provided,
+                allowed values are "pkcs1" and "pkcs8" standing for PKCS#1 and PKCS#8,
+                respectively. If KeyEncoding is not specified, then PKCS#1 will be
+                used by default.
               type: string
             keySize:
               description: KeySize is the key bit size of the corresponding private
@@ -205,6 +221,144 @@ metadata:
     "helm.sh/hook": "crd-install"
   labels:
     controller-tools.k8s.io: "1.0"
+  name: certificaterequests.certmanager.k8s.io
+spec:
+  additionalPrinterColumns:
+  - JSONPath: .status.conditions[?(@.type=="Ready")].status
+    name: Ready
+    type: string
+  - JSONPath: .spec.issuerRef.name
+    name: Issuer
+    priority: 1
+    type: string
+  - JSONPath: .status.conditions[?(@.type=="Ready")].message
+    name: Status
+    priority: 1
+    type: string
+  - JSONPath: .metadata.creationTimestamp
+    description: CreationTimestamp is a timestamp representing the server time when
+      this object was created. It is not guaranteed to be set in happens-before order
+      across separate operations. Clients may not set this value. It is represented
+      in RFC3339 form and is in UTC.
+    name: Age
+    type: date
+  group: certmanager.k8s.io
+  names:
+    kind: CertificateRequest
+    plural: certificaterequests
+    shortNames:
+    - cr
+    - crs
+  scope: Namespaced
+  validation:
+    openAPIV3Schema:
+      properties:
+        apiVersion:
+          description: 'APIVersion defines the versioned schema of this representation
+            of an object. Servers should convert recognized schemas to the latest
+            internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#resources'
+          type: string
+        kind:
+          description: 'Kind is a string value representing the REST resource this
+            object represents. Servers may infer this from the endpoint the client
+            submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#types-kinds'
+          type: string
+        metadata:
+          type: object
+        spec:
+          properties:
+            csr:
+              description: Byte slice containing the PEM encoded CertificateSigningRequest
+              format: byte
+              type: string
+            duration:
+              description: Requested certificate default Duration
+              type: string
+            isCA:
+              description: IsCA will mark the resulting certificate as valid for signing.
+                This implies that the 'signing' usage is set
+              type: boolean
+            issuerRef:
+              description: IssuerRef is a reference to the issuer for this CertificateRequest.  If
+                the 'kind' field is not set, or set to 'Issuer', an Issuer resource
+                with the given name in the same namespace as the CertificateRequest
+                will be used.  If the 'kind' field is set to 'ClusterIssuer', a ClusterIssuer
+                with the provided name will be used. The 'name' field in this stanza
+                is required at all times. The group field refers to the API group
+                of the issuer which defaults to 'certmanager.k8s.io' if empty.
+              properties:
+                group:
+                  type: string
+                kind:
+                  type: string
+                name:
+                  type: string
+              required:
+              - name
+              type: object
+          required:
+          - issuerRef
+          type: object
+        status:
+          properties:
+            ca:
+              description: Byte slice containing the PEM encoded certificate authority
+                of the signed certificate.
+              format: byte
+              type: string
+            certificate:
+              description: Byte slice containing a PEM encoded signed certificate
+                resulting from the given certificate signing request.
+              format: byte
+              type: string
+            conditions:
+              items:
+                properties:
+                  lastTransitionTime:
+                    description: LastTransitionTime is the timestamp corresponding
+                      to the last status change of this condition.
+                    format: date-time
+                    type: string
+                  message:
+                    description: Message is a human readable description of the details
+                      of the last transition, complementing reason.
+                    type: string
+                  reason:
+                    description: Reason is a brief machine readable explanation for
+                      the condition's last transition.
+                    type: string
+                  status:
+                    description: Status of the condition, one of ('True', 'False',
+                      'Unknown').
+                    enum:
+                    - "True"
+                    - "False"
+                    - Unknown
+                    type: string
+                  type:
+                    description: Type of the condition, currently ('Ready').
+                    type: string
+                required:
+                - type
+                - status
+                type: object
+              type: array
+          type: object
+  version: v1alpha1
+status:
+  acceptedNames:
+    kind: ""
+    plural: ""
+  conditions: []
+  storedVersions: []
+---
+apiVersion: apiextensions.k8s.io/v1beta1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    "helm.sh/hook": "crd-install"
+  labels:
+    controller-tools.k8s.io: "1.0"
   name: challenges.certmanager.k8s.io
 spec:
   additionalPrinterColumns:
@@ -268,6 +422,8 @@ spec:
                 Issuer, an error will be returned and the Challenge will be marked
                 as failed.
               properties:
+                group:
+                  type: string
                 kind:
                   type: string
                 name:
@@ -289,15 +445,32 @@ spec:
                     resource that should be solved using this challenge solver.
                   properties:
                     dnsNames:
-                      description: List of DNSNames that can be used to further refine
-                        the domains that this solver applies to.
+                      description: List of DNSNames that this solver will be used
+                        to solve. If specified and a match is found, a dnsNames selector
+                        will take precedence over a dnsZones selector. If multiple
+                        solvers match with the same dnsNames value, the solver with
+                        the most matching labels in matchLabels will be selected.
+                        If neither has more matches, the solver defined earlier in
+                        the list will be selected.
+                      items:
+                        type: string
+                      type: array
+                    dnsZones:
+                      description: List of DNSZones that this solver will be used
+                        to solve. The most specific DNS zone match specified here
+                        will take precedence over other DNS zone matches, so a solver
+                        specifying sys.example.com will be selected over one specifying
+                        example.com for the domain www.sys.example.com. If multiple
+                        solvers match with the same dnsZones value, the solver with
+                        the most matching labels in matchLabels will be selected.
+                        If neither has more matches, the solver defined earlier in
+                        the list will be selected.
                       items:
                         type: string
                       type: array
                     matchLabels:
-                      description: 'A label selector that is used to refine the set
-                        of certificate''s that this challenge solver will apply to.
-                        TODO: use kubernetes standard types for matchLabels'
+                      description: A label selector that is used to refine the set
+                        of certificate's that this challenge solver will apply to.
                       type: object
                   type: object
               type: object
@@ -445,16 +618,33 @@ spec:
                           resource that should be solved using this challenge solver.
                         properties:
                           dnsNames:
-                            description: List of DNSNames that can be used to further
-                              refine the domains that this solver applies to.
+                            description: List of DNSNames that this solver will be
+                              used to solve. If specified and a match is found, a
+                              dnsNames selector will take precedence over a dnsZones
+                              selector. If multiple solvers match with the same dnsNames
+                              value, the solver with the most matching labels in matchLabels
+                              will be selected. If neither has more matches, the solver
+                              defined earlier in the list will be selected.
+                            items:
+                              type: string
+                            type: array
+                          dnsZones:
+                            description: List of DNSZones that this solver will be
+                              used to solve. The most specific DNS zone match specified
+                              here will take precedence over other DNS zone matches,
+                              so a solver specifying sys.example.com will be selected
+                              over one specifying example.com for the domain www.sys.example.com.
+                              If multiple solvers match with the same dnsZones value,
+                              the solver with the most matching labels in matchLabels
+                              will be selected. If neither has more matches, the solver
+                              defined earlier in the list will be selected.
                             items:
                               type: string
                             type: array
                           matchLabels:
-                            description: 'A label selector that is used to refine
-                              the set of certificate''s that this challenge solver
-                              will apply to. TODO: use kubernetes standard types for
-                              matchLabels'
+                            description: A label selector that is used to refine the
+                              set of certificate's that this challenge solver will
+                              apply to.
                             type: object
                         type: object
                     type: object
@@ -612,6 +802,11 @@ spec:
           properties:
             acme:
               properties:
+                lastRegisteredEmail:
+                  description: LastRegisteredEmail is the email associated with the
+                    latest registered ACME account, in order to track changes made
+                    to registered account associated with the  Issuer
+                  type: string
                 uri:
                   description: URI is the unique account identifier, which can also
                     be used to retrieve account details from the CA
@@ -725,16 +920,33 @@ spec:
                           resource that should be solved using this challenge solver.
                         properties:
                           dnsNames:
-                            description: List of DNSNames that can be used to further
-                              refine the domains that this solver applies to.
+                            description: List of DNSNames that this solver will be
+                              used to solve. If specified and a match is found, a
+                              dnsNames selector will take precedence over a dnsZones
+                              selector. If multiple solvers match with the same dnsNames
+                              value, the solver with the most matching labels in matchLabels
+                              will be selected. If neither has more matches, the solver
+                              defined earlier in the list will be selected.
+                            items:
+                              type: string
+                            type: array
+                          dnsZones:
+                            description: List of DNSZones that this solver will be
+                              used to solve. The most specific DNS zone match specified
+                              here will take precedence over other DNS zone matches,
+                              so a solver specifying sys.example.com will be selected
+                              over one specifying example.com for the domain www.sys.example.com.
+                              If multiple solvers match with the same dnsZones value,
+                              the solver with the most matching labels in matchLabels
+                              will be selected. If neither has more matches, the solver
+                              defined earlier in the list will be selected.
                             items:
                               type: string
                             type: array
                           matchLabels:
-                            description: 'A label selector that is used to refine
-                              the set of certificate''s that this challenge solver
-                              will apply to. TODO: use kubernetes standard types for
-                              matchLabels'
+                            description: A label selector that is used to refine the
+                              set of certificate's that this challenge solver will
+                              apply to.
                             type: object
                         type: object
                     type: object
@@ -892,6 +1104,11 @@ spec:
           properties:
             acme:
               properties:
+                lastRegisteredEmail:
+                  description: LastRegisteredEmail is the email associated with the
+                    latest registered ACME account, in order to track changes made
+                    to registered account associated with the  Issuer
+                  type: string
                 uri:
                   description: URI is the unique account identifier, which can also
                     be used to retrieve account details from the CA
@@ -1039,6 +1256,8 @@ spec:
                 Issuer, an error will be returned and the Order will be marked as
                 failed.
               properties:
+                group:
+                  type: string
                 kind:
                   type: string
                 name:
@@ -1086,6 +1305,8 @@ spec:
                       is not an 'ACME' Issuer, an error will be returned and the Challenge
                       will be marked as failed.
                     properties:
+                      group:
+                        type: string
                       kind:
                         type: string
                       name:
@@ -1107,16 +1328,33 @@ spec:
                           resource that should be solved using this challenge solver.
                         properties:
                           dnsNames:
-                            description: List of DNSNames that can be used to further
-                              refine the domains that this solver applies to.
+                            description: List of DNSNames that this solver will be
+                              used to solve. If specified and a match is found, a
+                              dnsNames selector will take precedence over a dnsZones
+                              selector. If multiple solvers match with the same dnsNames
+                              value, the solver with the most matching labels in matchLabels
+                              will be selected. If neither has more matches, the solver
+                              defined earlier in the list will be selected.
+                            items:
+                              type: string
+                            type: array
+                          dnsZones:
+                            description: List of DNSZones that this solver will be
+                              used to solve. The most specific DNS zone match specified
+                              here will take precedence over other DNS zone matches,
+                              so a solver specifying sys.example.com will be selected
+                              over one specifying example.com for the domain www.sys.example.com.
+                              If multiple solvers match with the same dnsZones value,
+                              the solver with the most matching labels in matchLabels
+                              will be selected. If neither has more matches, the solver
+                              defined earlier in the list will be selected.
                             items:
                               type: string
                             type: array
                           matchLabels:
-                            description: 'A label selector that is used to refine
-                              the set of certificate''s that this challenge solver
-                              will apply to. TODO: use kubernetes standard types for
-                              matchLabels'
+                            description: A label selector that is used to refine the
+                              set of certificate's that this challenge solver will
+                              apply to.
                             type: object
                         type: object
                     type: object

--- a/config/cert-manager/templates/webhook-apiservice.yaml
+++ b/config/cert-manager/templates/webhook-apiservice.yaml
@@ -2,6 +2,10 @@ apiVersion: apiregistration.k8s.io/v1beta1
 kind: APIService
 metadata:
   name: v1beta1.admission.certmanager.k8s.io
+  labels:
+    app: webhook
+    app.kubernetes.io/name: webhook
+    app.kubernetes.io/instance:  {{ .Release.Name }}
   annotations:
     certmanager.k8s.io/inject-ca-from: '{{ .Release.Namespace }}/webhook-tls'
 spec:

--- a/config/cert-manager/templates/webhook-deployment.yaml
+++ b/config/cert-manager/templates/webhook-deployment.yaml
@@ -2,15 +2,23 @@ apiVersion: apps/v1beta1
 kind: Deployment
 metadata:
   name: webhook
+  labels:
+    app: webhook
+    app.kubernetes.io/name: webhook
+    app.kubernetes.io/instance:  {{ .Release.Name }}
 spec:
   replicas: {{ .Values.certManager.webhook.replicas }}
   selector:
     matchLabels:
       app: webhook
+      app.kubernetes.io/name: webhook
+      app.kubernetes.io/instance:  {{ .Release.Name }}
   template:
     metadata:
       labels:
         app: webhook
+        app.kubernetes.io/name: webhook
+        app.kubernetes.io/instance:  {{ .Release.Name }}
       annotations:
         fluentbit.io/parser: glog
     spec:

--- a/config/cert-manager/templates/webhook-pki.yaml
+++ b/config/cert-manager/templates/webhook-pki.yaml
@@ -4,6 +4,10 @@ apiVersion: certmanager.k8s.io/v1alpha1
 kind: Issuer
 metadata:
   name: webhook-selfsign
+  labels:
+    app: webhook
+    app.kubernetes.io/name: webhook
+    app.kubernetes.io/instance:  {{ .Release.Name }}
 spec:
   selfSigned: {}
 
@@ -13,6 +17,10 @@ apiVersion: certmanager.k8s.io/v1alpha1
 kind: Certificate
 metadata:
   name: webhook-ca
+  labels:
+    app: webhook
+    app.kubernetes.io/name: webhook
+    app.kubernetes.io/instance:  {{ .Release.Name }}
 spec:
   secretName: webhook-ca
   duration: 43800h # 5y
@@ -27,6 +35,10 @@ apiVersion: certmanager.k8s.io/v1alpha1
 kind: Issuer
 metadata:
   name: webhook-ca
+  labels:
+    app: webhook
+    app.kubernetes.io/name: webhook
+    app.kubernetes.io/instance:  {{ .Release.Name }}
 spec:
   ca:
     secretName: webhook-ca
@@ -37,6 +49,10 @@ apiVersion: certmanager.k8s.io/v1alpha1
 kind: Certificate
 metadata:
   name: webhook-tls
+  labels:
+    app: webhook
+    app.kubernetes.io/name: webhook
+    app.kubernetes.io/instance:  {{ .Release.Name }}
 spec:
   secretName: webhook-tls
   duration: 8760h # 1y

--- a/config/cert-manager/templates/webhook-rbac.yaml
+++ b/config/cert-manager/templates/webhook-rbac.yaml
@@ -4,6 +4,10 @@ apiVersion: rbac.authorization.k8s.io/v1beta1
 kind: ClusterRoleBinding
 metadata:
   name: cert-manager-webhook:auth-delegator
+  labels:
+    app: webhook
+    app.kubernetes.io/name: webhook
+    app.kubernetes.io/instance:  {{ .Release.Name }}
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
@@ -23,6 +27,10 @@ kind: RoleBinding
 metadata:
   name: cert-manager-webhook:webhook-authentication-reader
   namespace: kube-system
+  labels:
+    app: webhook
+    app.kubernetes.io/name: webhook
+    app.kubernetes.io/instance:  {{ .Release.Name }}
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: Role
@@ -38,11 +46,16 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
   name: cert-manager-webhook:webhook-requester
+  labels:
+    app: webhook
+    app.kubernetes.io/name: webhook
+    app.kubernetes.io/instance:  {{ .Release.Name }}
 rules:
 - apiGroups:
   - admission.certmanager.k8s.io
   resources:
   - certificates
+  - certificaterequests
   - issuers
   - clusterissuers
   verbs:

--- a/config/cert-manager/templates/webhook-service.yaml
+++ b/config/cert-manager/templates/webhook-service.yaml
@@ -2,6 +2,10 @@ apiVersion: v1
 kind: Service
 metadata:
   name: webhook
+  labels:
+    app: webhook
+    app.kubernetes.io/name: webhook
+    app.kubernetes.io/instance:  {{ .Release.Name }}
 spec:
   type: ClusterIP
   ports:
@@ -10,3 +14,5 @@ spec:
     targetPort: 6443
   selector:
     app: webhook
+    app.kubernetes.io/name: webhook
+    app.kubernetes.io/instance:  {{ .Release.Name }}

--- a/config/cert-manager/templates/webhook-serviceaccount.yaml
+++ b/config/cert-manager/templates/webhook-serviceaccount.yaml
@@ -2,3 +2,7 @@ apiVersion: v1
 kind: ServiceAccount
 metadata:
   name: webhook
+  labels:
+    app: webhook
+    app.kubernetes.io/name: webhook
+    app.kubernetes.io/instance:  {{ .Release.Name }}

--- a/config/cert-manager/templates/webhook-validating-webhook.yaml
+++ b/config/cert-manager/templates/webhook-validating-webhook.yaml
@@ -2,6 +2,10 @@ apiVersion: admissionregistration.k8s.io/v1beta1
 kind: ValidatingWebhookConfiguration
 metadata:
   name: cert-manager-webhook
+  labels:
+    app: webhook
+    app.kubernetes.io/name: webhook
+    app.kubernetes.io/instance:  {{ .Release.Name }}
   annotations:
 {{- if .Values.certManager.injectAPIServerCA }}
     certmanager.k8s.io/inject-apiserver-ca: 'true'
@@ -10,80 +14,78 @@ webhooks:
 - name: certificates.admission.certmanager.k8s.io
   namespaceSelector:
     matchExpressions:
-    - key: certmanager.k8s.io/disable-validation
-      operator: NotIn
+    - key: "certmanager.k8s.io/disable-validation"
+      operator: "NotIn"
       values:
       - "true"
-    - key: name
-      operator: NotIn
+    - key: "name"
+      operator: "NotIn"
       values:
-      - '{{ .Release.Namespace }}'
+      - {{ .Release.Namespace }}
   rules:
-  - apiGroups:
-    - certmanager.k8s.io
-    apiVersions:
-    - v1alpha1
-    operations:
-    - CREATE
-    - UPDATE
-    resources:
-    - certificates
+    - apiGroups:
+        - "certmanager.k8s.io"
+      apiVersions:
+        - v1alpha1
+      operations:
+        - CREATE
+        - UPDATE
+      resources:
+        - certificates
   failurePolicy: Fail
   clientConfig:
     service:
       name: kubernetes
       namespace: default
       path: /apis/admission.certmanager.k8s.io/v1beta1/certificates
-
 - name: issuers.admission.certmanager.k8s.io
   namespaceSelector:
     matchExpressions:
-    - key: certmanager.k8s.io/disable-validation
-      operator: NotIn
+    - key: "certmanager.k8s.io/disable-validation"
+      operator: "NotIn"
       values:
       - "true"
-    - key: name
-      operator: NotIn
+    - key: "name"
+      operator: "NotIn"
       values:
-      - '{{ .Release.Namespace }}'
+      - {{ .Release.Namespace }}
   rules:
-  - apiGroups:
-    - certmanager.k8s.io
-    apiVersions:
-    - v1alpha1
-    operations:
-    - CREATE
-    - UPDATE
-    resources:
-    - issuers
+    - apiGroups:
+        - "certmanager.k8s.io"
+      apiVersions:
+        - v1alpha1
+      operations:
+        - CREATE
+        - UPDATE
+      resources:
+        - issuers
   failurePolicy: Fail
   clientConfig:
     service:
       name: kubernetes
       namespace: default
       path: /apis/admission.certmanager.k8s.io/v1beta1/issuers
-
 - name: clusterissuers.admission.certmanager.k8s.io
   namespaceSelector:
     matchExpressions:
-    - key: certmanager.k8s.io/disable-validation
-      operator: NotIn
+    - key: "certmanager.k8s.io/disable-validation"
+      operator: "NotIn"
       values:
       - "true"
-    - key: name
-      operator: NotIn
+    - key: "name"
+      operator: "NotIn"
       values:
-      - '{{ .Release.Namespace }}'
+      - {{ .Release.Namespace }}
   rules:
-  - apiGroups:
-    - certmanager.k8s.io
-    apiVersions:
-    - v1alpha1
-    operations:
-    - CREATE
-    - UPDATE
-    resources:
-    - clusterissuers
+    - apiGroups:
+        - "certmanager.k8s.io"
+      apiVersions:
+        - v1alpha1
+      operations:
+        - CREATE
+        - UPDATE
+      resources:
+        - clusterissuers
   failurePolicy: Fail
   clientConfig:
     service:

--- a/config/cert-manager/values.yaml
+++ b/config/cert-manager/values.yaml
@@ -5,7 +5,7 @@ certManager:
     replicas: 1
     image:
       repository: quay.io/jetstack/cert-manager-controller
-      tag: v0.8.0
+      tag: v0.9.1
       pullPolicy: IfNotPresent
 
     resources:
@@ -24,7 +24,7 @@ certManager:
     replicas: 1
     image:
       repository: quay.io/jetstack/cert-manager-webhook
-      tag: v0.8.0
+      tag: v0.9.1
       pullPolicy: IfNotPresent
 
     resources:
@@ -49,7 +49,7 @@ certManager:
     replicas: 1
     image:
       repository: quay.io/jetstack/cert-manager-cainjector
-      tag: v0.8.0
+      tag: v0.9.1
       pullPolicy: IfNotPresent
 
     resources:


### PR DESCRIPTION
**What this PR does / why we need it**:
This brings back #4117, but this time with the proper APIService. I accidentally took the new inject annotation from the master branch and did not realize that 0.9 still used the old annotation. That caused the endless "bad certificate" errors in the webhook.

**Does this PR introduce a user-facing change?**:
```release-note
NONE
```

(the other PR already has a release-note about this)