### PR TITLE
 Make openstack rootDiskSize configurable over API

### DIFF
--- a/api/cmd/kubermatic-api/swagger.json
+++ b/api/cmd/kubermatic-api/swagger.json
@@ -7011,6 +7011,12 @@
         "image"
       ],
       "properties": {
+        "diskSize": {
+          "description": "if set, the rootDisk will be a volume. If not, the rootDisk will be on ephemeral storage and its size will be derived from the flavor",
+          "type": "integer",
+          "format": "int64",
+          "x-go-name": "RootDiskSizeGB"
+        },
         "flavor": {
           "description": "instance flavor",
           "type": "string",

--- a/api/pkg/api/v1/types.go
+++ b/api/pkg/api/v1/types.go
@@ -911,7 +911,7 @@ type OpenstackNodeSpec struct {
 	UseFloatingIP bool `json:"useFloatingIP,omitempty"`
 	// if set, the rootDisk will be a volume. If not, the rootDisk will be on ephemeral storage and its size will be derived from the flavor
 	// required: false
-	RootDiskSizeGB int64 `json:"diskSize"`
+	RootDiskSizeGB *int `json:"diskSize"`
 }
 
 // AWSNodeSpec aws specific node settings

--- a/api/pkg/api/v1/types.go
+++ b/api/pkg/api/v1/types.go
@@ -909,6 +909,9 @@ type OpenstackNodeSpec struct {
 	// Defines whether floating ip should be used
 	// required: false
 	UseFloatingIP bool `json:"useFloatingIP,omitempty"`
+	// if set, the rootDisk will be a volume. If not, the rootDisk will be on ephemeral storage and its size will be derived from the flavor
+	// required: false
+	RootDiskSizeGB int64 `json:"diskSize"`
 }
 
 // AWSNodeSpec aws specific node settings

--- a/api/pkg/machine/convert.go
+++ b/api/pkg/machine/convert.go
@@ -119,7 +119,7 @@ func GetAPIV2NodeCloudSpec(machineSpec clusterv1alpha1.MachineSpec) (*apiv1.Node
 			Tags:   config.Tags,
 		}
 		if config.RootDiskSizeGB != nil && *config.RootDiskSizeGB > 0 {
-			cloudSpec.Openstack.RootDiskSizeGB = int64(*config.RootDiskSizeGB)
+			cloudSpec.Openstack.RootDiskSizeGB = config.RootDiskSizeGB
 		}
 	case providerconfig.CloudProviderHetzner:
 		config := &hetzner.RawConfig{}

--- a/api/pkg/machine/convert.go
+++ b/api/pkg/machine/convert.go
@@ -118,6 +118,9 @@ func GetAPIV2NodeCloudSpec(machineSpec clusterv1alpha1.MachineSpec) (*apiv1.Node
 			Image:  config.Image.Value,
 			Tags:   config.Tags,
 		}
+		if config.RootDiskSizeGB != nil && *config.RootDiskSizeGB > 0 {
+			cloudSpec.Openstack.RootDiskSizeGB = int64(*config.RootDiskSizeGB)
+		}
 	case providerconfig.CloudProviderHetzner:
 		config := &hetzner.RawConfig{}
 		if err := json.Unmarshal(decodedProviderSpec.CloudProviderSpec.Raw, &config); err != nil {

--- a/api/pkg/resources/machine/common.go
+++ b/api/pkg/resources/machine/common.go
@@ -171,6 +171,11 @@ func getOpenstackProviderSpec(c *kubermaticv1.Cluster, nodeSpec apiv1.NodeSpec, 
 		config.FloatingIPPool = providerconfig.ConfigVarString{Value: c.Spec.Cloud.Openstack.FloatingIPPool}
 	}
 
+	if nodeSpec.Cloud.Openstack.RootDiskSizeGB > 0 {
+		rootDiskSizeGB := int(nodeSpec.Cloud.Openstack.RootDiskSizeGB)
+		config.RootDiskSizeGB = &rootDiskSizeGB
+	}
+
 	if dc.Spec.Openstack.TrustDevicePath != nil {
 		config.TrustDevicePath = providerconfig.ConfigVarBool{Value: *dc.Spec.Openstack.TrustDevicePath}
 	}

--- a/api/pkg/resources/machine/common.go
+++ b/api/pkg/resources/machine/common.go
@@ -171,9 +171,8 @@ func getOpenstackProviderSpec(c *kubermaticv1.Cluster, nodeSpec apiv1.NodeSpec, 
 		config.FloatingIPPool = providerconfig.ConfigVarString{Value: c.Spec.Cloud.Openstack.FloatingIPPool}
 	}
 
-	if nodeSpec.Cloud.Openstack.RootDiskSizeGB > 0 {
-		rootDiskSizeGB := int(nodeSpec.Cloud.Openstack.RootDiskSizeGB)
-		config.RootDiskSizeGB = &rootDiskSizeGB
+	if nodeSpec.Cloud.Openstack.RootDiskSizeGB != nil && *nodeSpec.Cloud.Openstack.RootDiskSizeGB > 0 {
+		config.RootDiskSizeGB = nodeSpec.Cloud.Openstack.RootDiskSizeGB
 	}
 
 	if dc.Spec.Openstack.TrustDevicePath != nil {

--- a/api/pkg/test/e2e/api/utils/apiclient/models/openstack_node_spec.go
+++ b/api/pkg/test/e2e/api/utils/apiclient/models/openstack_node_spec.go
@@ -25,6 +25,9 @@ type OpenstackNodeSpec struct {
 	// Required: true
 	Image *string `json:"image"`
 
+	// if set, the rootDisk will be a volume. If not, the rootDisk will be on ephemeral storage and its size will be derived from the flavor
+	RootDiskSizeGB int64 `json:"diskSize,omitempty"`
+
 	// Additional metadata to set
 	Tags map[string]string `json:"tags,omitempty"`
 


### PR DESCRIPTION
**What this PR does / why we need it**:
This adds support to the API to make the root disk size of OpenStack nodes configurable. Support was already added to machine-controller in https://github.com/kubermatic/machine-controller/pull/579.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #3251

**Does this PR introduce a user-facing change?**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If  no release note is required, just write "NONE".
-->
```release-note
Disk size of OpenStack nodes is now configurable
```
