### PR TITLE
DRY out restmapper caching

### DIFF
--- a/api/cmd/master-controller-manager/main.go
+++ b/api/cmd/master-controller-manager/main.go
@@ -135,7 +135,7 @@ func main() {
 
 	if runOpts.seedvalidationHook.CertFile != "" || runOpts.seedvalidationHook.KeyFile != "" {
 		seedValidationWebhookServer, err := runOpts.seedvalidationHook.Server(
-			ctx, sugarLog, runOpts.workerName, ctrlCtx.seedsGetter, ctrlCtx.seedKubeconfigGetter)
+			ctx, sugarLog, runOpts.workerName, ctrlCtx.seedsGetter, provider.SeedClientGetterFactory(ctrlCtx.seedKubeconfigGetter))
 		if err != nil {
 			sugarLog.Fatalw("failed to create validatingAdmissionWebhook server for seeds", zap.Error(err))
 		}

--- a/api/pkg/cluster/client/client.go
+++ b/api/pkg/cluster/client/client.go
@@ -3,15 +3,12 @@ package client
 import (
 	"context"
 	"fmt"
-	"sync"
 
 	kubermaticv1 "github.com/kubermatic/kubermatic/api/pkg/crd/kubermatic/v1"
-	"github.com/kubermatic/kubermatic/api/pkg/log"
 	"github.com/kubermatic/kubermatic/api/pkg/resources"
 	"github.com/kubermatic/kubermatic/api/pkg/util/restmapper"
 
 	corev1 "k8s.io/api/core/v1"
-	"k8s.io/apimachinery/pkg/api/meta"
 	"k8s.io/apimachinery/pkg/types"
 	restclient "k8s.io/client-go/rest"
 	"k8s.io/client-go/tools/clientcmd"
@@ -32,7 +29,7 @@ func NewInternal(seedClient ctrlruntimeclient.Client) (UserClusterConnectionProv
 	return &provider{
 		seedClient:         seedClient,
 		useExternalAddress: false,
-		clusterRESTMapper:  map[string]meta.RESTMapper{},
+		restMapperCache:    restmapper.New(),
 	}, nil
 }
 
@@ -43,7 +40,7 @@ func NewExternal(seedClient ctrlruntimeclient.Client) (UserClusterConnectionProv
 	return &provider{
 		seedClient:         seedClient,
 		useExternalAddress: true,
-		clusterRESTMapper:  map[string]meta.RESTMapper{},
+		restMapperCache:    restmapper.New(),
 	}, nil
 }
 
@@ -51,27 +48,8 @@ type provider struct {
 	seedClient         ctrlruntimeclient.Client
 	useExternalAddress bool
 
-	mapperLock sync.Mutex
 	// We keep the existing cluster mappings to avoid the discovery on each call to the API server
-	clusterRESTMapper map[string]meta.RESTMapper
-}
-
-func (p *provider) mapper(c *kubermaticv1.Cluster, config *restclient.Config) (meta.RESTMapper, error) {
-	p.mapperLock.Lock()
-	defer p.mapperLock.Unlock()
-
-	if mapper, found := p.clusterRESTMapper[c.Name]; found {
-		return mapper, nil
-	}
-
-	mapper, err := restmapper.NewDynamicRESTMapper(config)
-	if err != nil {
-		return nil, err
-	}
-	log.Logger.Infow("mapper created", "cluster", c.Name)
-	p.clusterRESTMapper[c.Name] = mapper
-
-	return mapper, nil
+	restMapperCache *restmapper.Cache
 }
 
 // GetAdminKubeconfig returns the admin kubeconfig for the given cluster
@@ -141,15 +119,5 @@ func (p *provider) GetClient(c *kubermaticv1.Cluster, options ...ConfigOption) (
 		return nil, err
 	}
 
-	mapper, err := p.mapper(c, config)
-	if err != nil {
-		log.Logger.Errorf("failed to get the REST mapper for the client: %v", err)
-		return ctrlruntimeclient.New(config, ctrlruntimeclient.Options{})
-	}
-
-	dynamicClient, err := ctrlruntimeclient.New(config, ctrlruntimeclient.Options{Mapper: mapper})
-	if err != nil {
-		return nil, fmt.Errorf("failed to create dynamic client: %v", err)
-	}
-	return dynamicClient, nil
+	return p.restMapperCache.Client(config)
 }

--- a/api/pkg/test/e2e/api/user_test.go
+++ b/api/pkg/test/e2e/api/user_test.go
@@ -40,7 +40,7 @@ func TestDeleteProjectOwner(t *testing.T) {
 			}
 
 			if len(projectUsers) != len(tc.expectedUsers) {
-				t.Fatalf("the number of user is diffrent than expected")
+				t.Fatalf("the number of user is different than expected")
 			}
 
 			for _, user := range projectUsers {
@@ -101,7 +101,7 @@ func TestAddUserToProject(t *testing.T) {
 			}
 
 			if len(projectUsers) != len(tc.expectedUsers) {
-				t.Fatalf("the number of user is diffrent than expected")
+				t.Fatalf("the number of user is different than expected")
 			}
 
 			for _, user := range projectUsers {

--- a/api/pkg/util/restmapper/cache.go
+++ b/api/pkg/util/restmapper/cache.go
@@ -30,7 +30,7 @@ func (c *Cache) Client(cfg *rest.Config) (ctrlruntimeclient.Client, error) {
 	rawMapper, exists := c.cache.Load(key)
 	if !exists {
 		var err error
-		mapper, err = NewDynamicRESTMapper(cfg)
+		mapper, err = newDynamicRESTMapper(cfg)
 		if err != nil {
 			return nil, fmt.Errorf("failed to create restMapper: %v", err)
 		}

--- a/api/pkg/util/restmapper/dynamic.go
+++ b/api/pkg/util/restmapper/dynamic.go
@@ -12,31 +12,31 @@ import (
 	"k8s.io/client-go/restmapper"
 )
 
-type DynamicRESTMapper struct {
+type dynamicRESTMapper struct {
 	client discovery.DiscoveryInterface
 
 	lock     sync.RWMutex
 	delegate meta.RESTMapper
 }
 
-// NewDynamicRESTMapper returns a RESTMapper that dynamically discovers resource
+// newdynamicRESTMapper returns a RESTMapper that dynamically discovers resource
 // types at runtime. This is in contrast to controller-manager's default RESTMapper, which
 // only checks resource types at startup, and so can't handle the case of first creating a
 // CRD and then creating an instance of that CRD.
-func NewDynamicRESTMapper(cfg *rest.Config) (meta.RESTMapper, error) {
+func newDynamicRESTMapper(cfg *rest.Config) (meta.RESTMapper, error) {
 	client, err := discovery.NewDiscoveryClientForConfig(cfg)
 	if err != nil {
 		return nil, err
 	}
 
-	drm := &DynamicRESTMapper{client: client}
+	drm := &dynamicRESTMapper{client: client}
 	if err := drm.reload(); err != nil {
 		return nil, err
 	}
 	return drm, nil
 }
 
-func (drm *DynamicRESTMapper) reload() error {
+func (drm *dynamicRESTMapper) reload() error {
 	gr, err := restmapper.GetAPIGroupResources(drm.client)
 	if err != nil {
 		return err
@@ -53,7 +53,7 @@ func (drm *DynamicRESTMapper) reload() error {
 
 // reloadOnError checks if an error indicates that the delegated RESTMapper needs to be
 // reloaded, and if so, reloads it and returns true.
-func (drm *DynamicRESTMapper) reloadOnError(err error) bool {
+func (drm *dynamicRESTMapper) reloadOnError(err error) bool {
 	if _, matches := err.(*meta.NoKindMatchError); !matches {
 		return false
 	}
@@ -64,7 +64,7 @@ func (drm *DynamicRESTMapper) reloadOnError(err error) bool {
 	return err == nil
 }
 
-func (drm *DynamicRESTMapper) mapper() meta.RESTMapper {
+func (drm *dynamicRESTMapper) mapper() meta.RESTMapper {
 	drm.lock.RLock()
 	defer drm.lock.RUnlock()
 
@@ -73,7 +73,7 @@ func (drm *DynamicRESTMapper) mapper() meta.RESTMapper {
 
 // KindFor takes a partial resource and returns back the single match.
 // It returns an error if there are multiple matches.
-func (drm *DynamicRESTMapper) KindFor(resource schema.GroupVersionResource) (schema.GroupVersionKind, error) {
+func (drm *dynamicRESTMapper) KindFor(resource schema.GroupVersionResource) (schema.GroupVersionKind, error) {
 	gvk, err := drm.mapper().KindFor(resource)
 	if drm.reloadOnError(err) {
 		gvk, err = drm.mapper().KindFor(resource)
@@ -83,7 +83,7 @@ func (drm *DynamicRESTMapper) KindFor(resource schema.GroupVersionResource) (sch
 
 // KindsFor takes a partial resource and returns back the list of
 // potential kinds in priority order.
-func (drm *DynamicRESTMapper) KindsFor(resource schema.GroupVersionResource) ([]schema.GroupVersionKind, error) {
+func (drm *dynamicRESTMapper) KindsFor(resource schema.GroupVersionResource) ([]schema.GroupVersionKind, error) {
 	gvks, err := drm.mapper().KindsFor(resource)
 	if drm.reloadOnError(err) {
 		gvks, err = drm.mapper().KindsFor(resource)
@@ -93,7 +93,7 @@ func (drm *DynamicRESTMapper) KindsFor(resource schema.GroupVersionResource) ([]
 
 // ResourceFor takes a partial resource and returns back the single
 // match. It returns an error if there are multiple matches.
-func (drm *DynamicRESTMapper) ResourceFor(input schema.GroupVersionResource) (schema.GroupVersionResource, error) {
+func (drm *dynamicRESTMapper) ResourceFor(input schema.GroupVersionResource) (schema.GroupVersionResource, error) {
 	gvr, err := drm.mapper().ResourceFor(input)
 	if drm.reloadOnError(err) {
 		gvr, err = drm.mapper().ResourceFor(input)
@@ -103,7 +103,7 @@ func (drm *DynamicRESTMapper) ResourceFor(input schema.GroupVersionResource) (sc
 
 // ResourcesFor takes a partial resource and returns back the list of
 // potential resource in priority order.
-func (drm *DynamicRESTMapper) ResourcesFor(input schema.GroupVersionResource) ([]schema.GroupVersionResource, error) {
+func (drm *dynamicRESTMapper) ResourcesFor(input schema.GroupVersionResource) ([]schema.GroupVersionResource, error) {
 	gvrs, err := drm.mapper().ResourcesFor(input)
 	if drm.reloadOnError(err) {
 		gvrs, err = drm.mapper().ResourcesFor(input)
@@ -113,7 +113,7 @@ func (drm *DynamicRESTMapper) ResourcesFor(input schema.GroupVersionResource) ([
 
 // RESTMapping identifies a preferred resource mapping for the
 // provided group kind.
-func (drm *DynamicRESTMapper) RESTMapping(gk schema.GroupKind, versions ...string) (*meta.RESTMapping, error) {
+func (drm *dynamicRESTMapper) RESTMapping(gk schema.GroupKind, versions ...string) (*meta.RESTMapping, error) {
 	m, err := drm.mapper().RESTMapping(gk, versions...)
 	if drm.reloadOnError(err) {
 		m, err = drm.mapper().RESTMapping(gk, versions...)
@@ -124,7 +124,7 @@ func (drm *DynamicRESTMapper) RESTMapping(gk schema.GroupKind, versions ...strin
 // RESTMappings returns the RESTMappings for the provided group kind
 // in a rough internal preferred order. If no kind is found, it will
 // return a NoResourceMatchError.
-func (drm *DynamicRESTMapper) RESTMappings(gk schema.GroupKind, versions ...string) ([]*meta.RESTMapping, error) {
+func (drm *dynamicRESTMapper) RESTMappings(gk schema.GroupKind, versions ...string) ([]*meta.RESTMapping, error) {
 	ms, err := drm.mapper().RESTMappings(gk, versions...)
 	if drm.reloadOnError(err) {
 		ms, err = drm.mapper().RESTMappings(gk, versions...)
@@ -134,7 +134,7 @@ func (drm *DynamicRESTMapper) RESTMappings(gk schema.GroupKind, versions ...stri
 
 // ResourceSingularizer converts a resource name from plural to
 // singular (e.g., from pods to pod).
-func (drm *DynamicRESTMapper) ResourceSingularizer(resource string) (singular string, err error) {
+func (drm *dynamicRESTMapper) ResourceSingularizer(resource string) (singular string, err error) {
 	s, err := drm.mapper().ResourceSingularizer(resource)
 	if drm.reloadOnError(err) {
 		s, err = drm.mapper().ResourceSingularizer(resource)

--- a/api/pkg/validation/seed/server.go
+++ b/api/pkg/validation/seed/server.go
@@ -38,7 +38,7 @@ func (opts *WebhookOpts) Server(
 	log *zap.SugaredLogger,
 	workerName string,
 	seedsGetter provider.SeedsGetter,
-	seedKubeconfigGetter provider.SeedKubeconfigGetter) (*Server, error) {
+	seedClientGetter provider.SeedClientGetter) (*Server, error) {
 
 	labelSelector, err := workerlabel.LabelSelector(workerName)
 	if err != nil {
@@ -58,7 +58,7 @@ func (opts *WebhookOpts) Server(
 		listenAddress: opts.ListenAddress,
 		certFile:      opts.CertFile,
 		keyFile:       opts.KeyFile,
-		validator:     newValidator(ctx, seedsGetter, seedKubeconfigGetter, listOpts),
+		validator:     newValidator(ctx, seedsGetter, seedClientGetter, listOpts),
 	}
 	mux := http.NewServeMux()
 	mux.HandleFunc("/", server.handleSeedValidationRequests)


### PR DESCRIPTION
**What this PR does / why we need it**:

DRYs out the implementations of a restmapper cache and moves all of them to what is in pkg/restmapper. Also unexports the `DynamicRestMapper` to force everyone to use the cache.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Documentation**:
<!-- Add links to the related documentation changes related to this pull request. E.g. the link to the kubermatic/docs pullrequest. -->

**Does this PR introduce a user-facing change?**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If  no release note is required, just write "NONE".
-->
```release-note
none
```
