### PR TITLE
Add pod-security-policy addon

### DIFF
--- a/addons/pod-security-policy/psp-privileged.yaml
+++ b/addons/pod-security-policy/psp-privileged.yaml
@@ -1,0 +1,27 @@
+apiVersion: policy/v1beta1
+kind: PodSecurityPolicy
+metadata:
+  name: kubermatic-privileged
+  annotations:
+    seccomp.security.alpha.kubernetes.io/allowedProfileNames: '*'
+spec:
+  privileged: true
+  allowPrivilegeEscalation: true
+  allowedCapabilities:
+    - '*'
+  volumes:
+    - '*'
+  hostNetwork: true
+  hostPorts:
+    - min: 0
+      max: 65535
+  hostIPC: true
+  hostPID: true
+  runAsUser:
+    rule: 'RunAsAny'
+  seLinux:
+    rule: 'RunAsAny'
+  supplementalGroups:
+    rule: 'RunAsAny'
+  fsGroup:
+    rule: 'RunAsAny'

--- a/addons/pod-security-policy/rbac-kube-system.yaml
+++ b/addons/pod-security-policy/rbac-kube-system.yaml
@@ -1,0 +1,26 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: psp:kube-system
+  namespace: kube-system
+rules:
+  - apiGroups: ['policy']
+    resources: ['podsecuritypolicies']
+    verbs:     ['use']
+    resourceNames:
+      - kubermatic-privileged
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: psp:kube-system
+  namespace: kube-system
+roleRef:
+  kind: Role
+  name: psp:kube-system
+  apiGroup: rbac.authorization.k8s.io
+subjects:
+  # Authorize all service accounts
+  - kind: Group
+    apiGroup: rbac.authorization.k8s.io
+    name: system:serviceaccounts

--- a/api/cmd/conformance-tests/main.go
+++ b/api/cmd/conformance-tests/main.go
@@ -67,6 +67,7 @@ type Opts struct {
 	openshift                    bool
 	printGinkoLogs               bool
 	onlyTestCreation             bool
+	pspEnabled                   bool
 	kubermatcProjectID           string
 	kubermaticClient             *apiclient.Kubermatic
 	kubermaticAuthenticator      runtime.ClientAuthInfoWriter
@@ -240,6 +241,11 @@ func main() {
 	}
 	opts.kubermaticClient = apiclient.New(httptransport.New(kubermaticAPIServerAddress, "", []string{"http"}), nil)
 	opts.kubermaticAuthenticator = httptransport.BearerToken(kubermaticServiceaAccountToken)
+
+	if val := os.Getenv("KUBERMATIC_PSP_ENABLED"); val == "true" {
+		opts.pspEnabled = true
+		log.Info("Enabling PSPs")
+	}
 
 	// We use environment variables instead of flags for compatibility reasons, because during upgrade tests we
 	// run two versions of the conformance tester with the same set of flags, which breaks if the older version

--- a/api/cmd/conformance-tests/runner.go
+++ b/api/cmd/conformance-tests/runner.go
@@ -81,6 +81,7 @@ func newRunner(scenarios []testScenario, opts *Opts, log *zap.SugaredLogger) *te
 		openshift:                    opts.openshift,
 		printGinkoLogs:               opts.printGinkoLogs,
 		onlyTestCreation:             opts.onlyTestCreation,
+		pspEnabled:                   opts.pspEnabled,
 		kubermatcProjectID:           opts.kubermatcProjectID,
 		kubermaticClient:             opts.kubermaticClient,
 		kubermaticAuthenticator:      opts.kubermaticAuthenticator,
@@ -101,6 +102,7 @@ type testRunner struct {
 	openshift        bool
 	printGinkoLogs   bool
 	onlyTestCreation bool
+	pspEnabled       bool
 
 	controlPlaneReadyWaitTimeout time.Duration
 	deleteClusterAfterTests      bool
@@ -633,6 +635,8 @@ func (r *testRunner) createCluster(log *zap.SugaredLogger, scenario testScenario
 	}
 	cluster.Cluster.Name += scenario.Name() + "-"
 	cluster.Cluster.Name += rand.String(8)
+
+	cluster.Cluster.Spec.UsePodSecurityPolicyAdmissionPlugin = r.pspEnabled
 
 	params := &projectclient.CreateClusterParams{
 		ProjectID: r.kubermatcProjectID,

--- a/api/hack/ci/ci-run-minimal-conformance-tests.sh
+++ b/api/hack/ci/ci-run-minimal-conformance-tests.sh
@@ -21,6 +21,7 @@ echodate "Testing versions: ${VERSIONS}"
 export GIT_HEAD_HASH="$(git rev-parse HEAD|tr -d '\n')"
 export EXCLUDE_DISTRIBUTIONS=${EXCLUDE_DISTRIBUTIONS:-ubuntu,centos}
 export DEFAULT_TIMEOUT_MINUTES=${DEFAULT_TIMEOUT_MINUTES:-10}
+export ONLY_TEST_CREATION=${ONLY_TEST_CREATION:-false}
 
 # if no provider argument has been specified, default to aws
 provider=${PROVIDER:-"aws"}
@@ -423,7 +424,7 @@ TEST_NAME="Setup Kubermatic total" write_junit "0" "$setup_elasped_time"
 
 kubermatic_delete_cluster="true"
 if [ -n "${UPGRADE_TEST_BASE_HASH:-}" ]; then
-	kubermatic_delete_cluster="false"
+  kubermatic_delete_cluster="false"
 fi
 
 timeout -s 9 90m ./conformance-tests $EXTRA_ARGS \
@@ -439,6 +440,7 @@ timeout -s 9 90m ./conformance-tests $EXTRA_ARGS \
   -run-kubermatic-controller-manager=false \
   -versions="$VERSIONS" \
   -providers=$provider \
+  -only-test-creation="${ONLY_TEST_CREATION}" \
   -exclude-distributions="${EXCLUDE_DISTRIBUTIONS}" \
   ${OPENSHIFT_ARG:-} \
   -kubermatic-delete-cluster=${kubermatic_delete_cluster} \
@@ -498,6 +500,7 @@ timeout -s 9 60m ./conformance-tests $EXTRA_ARGS \
   -cleanup-on-start=false \
   -versions="$VERSIONS" \
   -providers=$provider \
+  -only-test-creation="${ONLY_TEST_CREATION}" \
   -exclude-distributions="${EXCLUDE_DISTRIBUTIONS}" \
   ${OPENSHIFT_ARG:-} \
   -print-ginkgo-logs=true \

--- a/config/kubermatic/values.yaml
+++ b/config/kubermatic/values.yaml
@@ -89,6 +89,7 @@ kubermatic:
         - default-storage-class
         - node-exporter
         - nodelocal-dns-cache
+        - pod-security-policy
         image:
           repository: "quay.io/kubermatic/addons"
           tag: "__KUBERMATIC_TAG__"


### PR DESCRIPTION
**What this PR does / why we need it**:
Add pod-security-policy addon that allows priviledged pods in the kube-system namespace.

**Does this PR introduce a user-facing change?**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If  no release note is required, just write "NONE".
-->
```release-note
Support PodSecurityPolicies in addons
```
