### PR TITLE
fix missing permissions for kube-state-metrics and storageclasses

### DIFF
--- a/config/monitoring/kube-state-metrics/Chart.yaml
+++ b/config/monitoring/kube-state-metrics/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: kube-state-metrics
-version: 1.0.3
+version: 1.0.4
 appVersion: v1.7.2
 description: Kube-State-Metrics for Kubermatic
 keywords:

--- a/config/monitoring/kube-state-metrics/templates/cluster-role.yaml
+++ b/config/monitoring/kube-state-metrics/templates/cluster-role.yaml
@@ -47,5 +47,13 @@ rules:
   verbs: ["list", "watch"]
 - apiGroups: ["certificates.k8s.io"]
   resources:
-    - certificatesigningrequests
+  - certificatesigningrequests
+  verbs: ["list", "watch"]
+- apiGroups: ["storage.k8s.io"]
+  resources:
+  - storageclasses
+  verbs: ["list", "watch"]
+- apiGroups: ["autoscaling.k8s.io"]
+  resources:
+  - verticalpodautoscalers
   verbs: ["list", "watch"]

--- a/config/monitoring/kube-state-metrics/templates/role-binding.yaml
+++ b/config/monitoring/kube-state-metrics/templates/role-binding.yaml
@@ -9,4 +9,3 @@ roleRef:
 subjects:
 - kind: ServiceAccount
   name: kube-state-metrics
-

--- a/config/monitoring/kube-state-metrics/templates/role.yaml
+++ b/config/monitoring/kube-state-metrics/templates/role.yaml
@@ -12,4 +12,3 @@ rules:
   - deployments
   resourceNames: ["kube-state-metrics"]
   verbs: ["get", "update"]
-

--- a/config/monitoring/kube-state-metrics/values.yaml
+++ b/config/monitoring/kube-state-metrics/values.yaml
@@ -13,7 +13,7 @@ kubeStateMetrics:
   resizer:
     image:
       repository: gcr.io/google_containers/addon-resizer
-      tag: '2.3'
+      tag: '1.8.4' # is still the recommended version
     resources:
       requests:
         cpu: 50m


### PR DESCRIPTION
**What this PR does / why we need it**:
This adds the missing permissions from the last 1.7 update (#4129).

**Does this PR introduce a user-facing change?**:
```release-note
NONE
```
