### PR TITLE
Conformance tests: Write out junit even when testCluster is not called

### DIFF
--- a/api/cmd/conformance-tests/runner.go
+++ b/api/cmd/conformance-tests/runner.go
@@ -225,6 +225,22 @@ func (r *testRunner) executeScenario(log *zap.SugaredLogger, scenario testScenar
 	report := &reporters.JUnitTestSuite{
 		Name: scenario.Name(),
 	}
+	totalStart := time.Now()
+
+	// We need the closure to defer the evaluation of the time.Since(totalStart) call
+	defer func() { log.Infof("Finished testing cluster after %s", time.Since(totalStart)) }()
+	// Always write junit to disk
+	defer func() {
+		report.Time = time.Since(totalStart).Seconds()
+		b, err := xml.Marshal(report)
+		if err != nil {
+			log.Errorw("failed to marshal junit", zap.Error(err))
+			return
+		}
+		if err := ioutil.WriteFile(path.Join(r.reportsRoot, fmt.Sprintf("junit.%s.xml", scenario.Name())), b, 0644); err != nil {
+			log.Errorw("failed to write junit", zap.Error(err))
+		}
+	}()
 
 	if r.existingClusterLabel == "" {
 		if err := junitReporterWrapper(
@@ -364,24 +380,7 @@ func (r *testRunner) testCluster(
 ) error {
 	const maxTestAttempts = 3
 	var err error
-	totalStart := time.Now()
 	log.Info("Starting to test cluster...")
-
-	// We need the closure to defer the evaluation of the time.Since(totalStart) call
-	defer func() { log.Infof("Finished testing cluster after %s", time.Since(totalStart)) }()
-
-	// Always write junit to disk
-	defer func() {
-		report.Time = time.Since(totalStart).Seconds()
-		b, err := xml.Marshal(report)
-		if err != nil {
-			log.Errorw("failed to marshal junit", zap.Error(err))
-			return
-		}
-		if err := ioutil.WriteFile(path.Join(r.reportsRoot, fmt.Sprintf("junit.%s.xml", scenarioName)), b, 0644); err != nil {
-			log.Errorw("failed to write junit", zap.Error(err))
-		}
-	}()
 
 	// We'll store the report there and all kinds of logs
 	scenarioFolder := path.Join(r.reportsRoot, scenarioName)


### PR DESCRIPTION
**What this PR does / why we need it**:

Currently we write the Junit in `testCluster`. However `testCluster` is only called after the creation of the controlplane succeeded and when `--only-test-creation=false`. 

This PR changes that to always write out the Junit after the report exists.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Documentation**:
<!-- Add links to the related documentation changes related to this pull request. E.g. the link to the kubermatic/docs pullrequest. -->

**Does this PR introduce a user-facing change?**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If  no release note is required, just write "NONE".
-->
```release-note
none
```

/assign @xrstf 
