### PR TITLE
 Add pod antiaffinity to spread etcd among availability zones

### DIFF
--- a/api/cmd/image-loader/main.go
+++ b/api/cmd/image-loader/main.go
@@ -368,6 +368,7 @@ func getTemplateData(version *kubermaticversion.MasterVersion) (*resources.Templ
 		// Since this is the image-loader we hardcode the default image for pulling.
 		resources.DefaultKubermaticImage,
 		resources.DefaultDNATControllerImage,
+		false,
 	), nil
 }
 

--- a/api/pkg/controller/cluster/resources.go
+++ b/api/pkg/controller/cluster/resources.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 
+	controllerutil "github.com/kubermatic/kubermatic/api/pkg/controller/util"
 	kubermaticv1 "github.com/kubermatic/kubermatic/api/pkg/crd/kubermatic/v1"
 	"github.com/kubermatic/kubermatic/api/pkg/resources"
 	"github.com/kubermatic/kubermatic/api/pkg/resources/apiserver"
@@ -112,6 +113,11 @@ func (r *Reconciler) getClusterTemplateData(ctx context.Context, cluster *kuberm
 		return nil, fmt.Errorf("failed to get datacenter %s", cluster.Spec.Cloud.DatacenterName)
 	}
 
+	supportsFailureDomainZoneAntiAffinity, err := controllerutil.SupportsFailureDomainZoneAntiAffinity(ctx, r.Client)
+	if err != nil {
+		return nil, err
+	}
+
 	return resources.NewTemplateData(
 		ctx,
 		r,
@@ -133,6 +139,7 @@ func (r *Reconciler) getClusterTemplateData(ctx context.Context, cluster *kuberm
 		r.nodeLocalDNSCacheEnabled,
 		r.kubermaticImage,
 		r.dnatControllerImage,
+		supportsFailureDomainZoneAntiAffinity,
 	), nil
 }
 

--- a/api/pkg/controller/monitoring/resources.go
+++ b/api/pkg/controller/monitoring/resources.go
@@ -47,6 +47,7 @@ func (r *Reconciler) getClusterTemplateData(ctx context.Context, client ctrlrunt
 		r.nodeLocalDNSCacheEnabled,
 		"",
 		"",
+		false,
 	), nil
 }
 

--- a/api/pkg/controller/openshift/data.go
+++ b/api/pkg/controller/openshift/data.go
@@ -25,15 +25,16 @@ import (
 // openshiftData implements the openshiftData interface which is
 // passed into all creator funcs and contains all data they need
 type openshiftData struct {
-	cluster             *kubermaticv1.Cluster
-	client              client.Client
-	dc                  *kubermaticv1.Datacenter
-	overwriteRegistry   string
-	nodeAccessNetwork   string
-	oidc                OIDCConfig
-	etcdDiskSize        resource.Quantity
-	kubermaticImage     string
-	dnatControllerImage string
+	cluster                               *kubermaticv1.Cluster
+	client                                client.Client
+	dc                                    *kubermaticv1.Datacenter
+	overwriteRegistry                     string
+	nodeAccessNetwork                     string
+	oidc                                  OIDCConfig
+	etcdDiskSize                          resource.Quantity
+	kubermaticImage                       string
+	dnatControllerImage                   string
+	supportsFailureDomainZoneAntiAffinity bool
 }
 
 func (od *openshiftData) DC() *kubermaticv1.Datacenter {
@@ -299,4 +300,8 @@ func (od *openshiftData) DNATControllerImage() string {
 		imageWithoutRegistry = strings.Join(dnatControllerImageSplit[1:], "/")
 	}
 	return od.ImageRegistry(registry) + "/" + imageWithoutRegistry
+}
+
+func (od *openshiftData) SupportsFailureDomainZoneAntiAffinity() bool {
+	return od.supportsFailureDomainZoneAntiAffinity
 }

--- a/api/pkg/controller/openshift/openshift_controller.go
+++ b/api/pkg/controller/openshift/openshift_controller.go
@@ -228,16 +228,22 @@ func (r *Reconciler) reconcile(ctx context.Context, log *zap.SugaredLogger, clus
 	if !found {
 		return nil, fmt.Errorf("couldn't find dc %s", cluster.Spec.Cloud.DatacenterName)
 	}
+	supportsFailureDomainZoneAntiAffinity, err := controllerutil.SupportsFailureDomainZoneAntiAffinity(ctx, r.Client)
+	if err != nil {
+		return nil, err
+	}
+
 	osData := &openshiftData{
-		cluster:             cluster,
-		client:              r.Client,
-		dc:                  &datacenter,
-		overwriteRegistry:   r.overwriteRegistry,
-		nodeAccessNetwork:   r.nodeAccessNetwork,
-		oidc:                r.oidc,
-		etcdDiskSize:        r.etcdDiskSize,
-		kubermaticImage:     r.kubermaticImage,
-		dnatControllerImage: r.dnatControllerImage,
+		cluster:                               cluster,
+		client:                                r.Client,
+		dc:                                    &datacenter,
+		overwriteRegistry:                     r.overwriteRegistry,
+		nodeAccessNetwork:                     r.nodeAccessNetwork,
+		oidc:                                  r.oidc,
+		etcdDiskSize:                          r.etcdDiskSize,
+		kubermaticImage:                       r.kubermaticImage,
+		dnatControllerImage:                   r.dnatControllerImage,
+		supportsFailureDomainZoneAntiAffinity: supportsFailureDomainZoneAntiAffinity,
 	}
 
 	if err := r.networkDefaults(ctx, cluster); err != nil {

--- a/api/pkg/resources/antiaffinity.go
+++ b/api/pkg/resources/antiaffinity.go
@@ -14,33 +14,52 @@ import (
 func HostnameAntiAffinity(app, clusterName string) *corev1.Affinity {
 	return &corev1.Affinity{
 		PodAntiAffinity: &corev1.PodAntiAffinity{
-			PreferredDuringSchedulingIgnoredDuringExecution: []corev1.WeightedPodAffinityTerm{
-				// Avoid that we schedule multiple same-kind pods of a cluster on a single node
-				{
-					Weight: 100,
-					PodAffinityTerm: corev1.PodAffinityTerm{
-						LabelSelector: &metav1.LabelSelector{
-							MatchLabels: map[string]string{
-								AppLabelKey:     app,
-								ClusterLabelKey: clusterName,
-							},
-						},
-						TopologyKey: TopologyKeyHostname,
+			PreferredDuringSchedulingIgnoredDuringExecution: hostnameAntiAffinity(app, clusterName),
+		},
+	}
+}
+
+func hostnameAntiAffinity(app, clusterName string) []corev1.WeightedPodAffinityTerm {
+	return []corev1.WeightedPodAffinityTerm{
+		// Avoid that we schedule multiple same-kind pods of a cluster on a single node
+		{
+			Weight: 100,
+			PodAffinityTerm: corev1.PodAffinityTerm{
+				LabelSelector: &metav1.LabelSelector{
+					MatchLabels: map[string]string{
+						AppLabelKey:     app,
+						ClusterLabelKey: clusterName,
 					},
 				},
-				// Avoid that we schedule multiple same-kind pods on a single node
-				{
-					Weight: 10,
-					PodAffinityTerm: corev1.PodAffinityTerm{
-						LabelSelector: &metav1.LabelSelector{
-							MatchLabels: map[string]string{
-								AppLabelKey: app,
-							},
-						},
-						TopologyKey: TopologyKeyHostname,
+				TopologyKey: TopologyKeyHostname,
+			},
+		},
+		// Avoid that we schedule multiple same-kind pods on a single node
+		{
+			Weight: 10,
+			PodAffinityTerm: corev1.PodAffinityTerm{
+				LabelSelector: &metav1.LabelSelector{
+					MatchLabels: map[string]string{
+						AppLabelKey: app,
 					},
+				},
+				TopologyKey: TopologyKeyHostname,
+			},
+		},
+	}
+}
+
+// FailureDomainZoneAntiAffinity ensures that same-kind pods are spread across different availability zones.
+func FailureDomainZoneAntiAffinity(app, clusterName string) corev1.WeightedPodAffinityTerm {
+	return corev1.WeightedPodAffinityTerm{
+		Weight: 100,
+		PodAffinityTerm: corev1.PodAffinityTerm{
+			LabelSelector: &metav1.LabelSelector{
+				MatchLabels: map[string]string{
+					AppLabelKey: app,
 				},
 			},
+			TopologyKey: TopologyKeyFailureDomainZone,
 		},
 	}
 }

--- a/api/pkg/resources/data.go
+++ b/api/pkg/resources/data.go
@@ -43,6 +43,7 @@ type TemplateData struct {
 	nodeLocalDNSCacheEnabled                         bool
 	kubermaticImage                                  string
 	dnatControllerImage                              string
+	supportsFailureDomainZoneAntiAffinity            bool
 }
 
 // NewTemplateData returns an instance of TemplateData
@@ -66,7 +67,8 @@ func NewTemplateData(
 	oidcIssuerClientID string,
 	nodeLocalDNSCacheEnabled bool,
 	kubermaticImage string,
-	dnatControllerImage string) *TemplateData {
+	dnatControllerImage string,
+	supportsFailureDomainZoneAntiAffinity bool) *TemplateData {
 	return &TemplateData{
 		ctx:                                    ctx,
 		client:                                 client,
@@ -88,6 +90,7 @@ func NewTemplateData(
 		nodeLocalDNSCacheEnabled:                         nodeLocalDNSCacheEnabled,
 		kubermaticImage:                                  kubermaticImage,
 		dnatControllerImage:                              dnatControllerImage,
+		supportsFailureDomainZoneAntiAffinity:            supportsFailureDomainZoneAntiAffinity,
 	}
 }
 
@@ -284,6 +287,10 @@ func (d *TemplateData) DNATControllerImage() string {
 		imageWithoutRegistry = strings.Join(dnatControllerImageSplit[1:], "/")
 	}
 	return d.ImageRegistry(registry) + "/" + imageWithoutRegistry
+}
+
+func (d *TemplateData) SupportsFailureDomainZoneAntiAffinity() bool {
+	return d.supportsFailureDomainZoneAntiAffinity
 }
 
 func (d *TemplateData) GetGlobalSecretKeySelectorValue(configVar *providerconfig.GlobalSecretKeySelector, key string) (string, error) {

--- a/api/pkg/resources/resources.go
+++ b/api/pkg/resources/resources.go
@@ -269,6 +269,8 @@ const (
 
 	// TopologyKeyHostname defines the topology key for the node hostname
 	TopologyKeyHostname = "kubernetes.io/hostname"
+	// TopologyKeyFailureDomainZone defines the topology key for the node's cloud provider zone
+	TopologyKeyFailureDomainZone = "failure-domain.beta.kubernetes.io/zone"
 
 	// MachineCRDName defines the CRD name for machine objects
 	MachineCRDName = "machines.cluster.k8s.io"

--- a/api/pkg/resources/test/load_files_test.go
+++ b/api/pkg/resources/test/load_files_test.go
@@ -536,7 +536,8 @@ func TestLoadFiles(t *testing.T) {
 					"kubermaticIssuer",
 					true,
 					"quay.io/kubermatic/api",
-					"quay.io/kubermatic/kubeletdnat-controller")
+					"quay.io/kubermatic/kubeletdnat-controller",
+					false)
 
 				var deploymentCreators []reconciling.NamedDeploymentCreatorGetter
 				deploymentCreators = append(deploymentCreators, clustercontroller.GetDeploymentCreators(data, true)...)


### PR DESCRIPTION
Fixes https://github.com/kubermatic/kubermatic/issues/4078

This is done to ensure that etcd is still fully functional after an AZ outage.

**Does this PR introduce a user-facing change?**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If  no release note is required, just write "NONE".
-->
```release-note
NONE
```

/assign @alvaroaleman 