### PR TITLE
Deploy imagePullSecret to openshift nodes

### DIFF
--- a/api/pkg/controller/openshift/resources/machinecontroller.go
+++ b/api/pkg/controller/openshift/resources/machinecontroller.go
@@ -7,6 +7,7 @@ import (
 	"github.com/kubermatic/kubermatic/api/pkg/resources/apiserver"
 	"github.com/kubermatic/kubermatic/api/pkg/resources/machinecontroller"
 	"github.com/kubermatic/kubermatic/api/pkg/resources/reconciling"
+	openshiftuserdata "github.com/kubermatic/kubermatic/api/pkg/userdata/openshift"
 
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
@@ -50,6 +51,8 @@ func MachineController(osData openshiftData) reconciling.NamedDeploymentCreatorG
 					Name: "userdata-plugins", MountPath: "/userdata-plugins"})
 				d.Spec.Template.Spec.Containers[idx].Env = append(d.Spec.Template.Spec.Containers[idx].Env,
 					corev1.EnvVar{Name: "MACHINE_CONTROLLER_USERDATA_PLUGIN_DIR", Value: "/userdata-plugins"})
+				d.Spec.Template.Spec.Containers[idx].Env = append(d.Spec.Template.Spec.Containers[idx].Env,
+					corev1.EnvVar{Name: openshiftuserdata.DockerCFGEnvKey, Value: osData.Cluster().Spec.Openshift.ImagePullSecret})
 			}
 
 			wrappedPodSpec, err := apiserver.IsRunningWrapper(osData, d.Spec.Template.Spec, sets.NewString(name))

--- a/api/pkg/userdata/openshift/openshift.go
+++ b/api/pkg/userdata/openshift/openshift.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"os"
 	"text/template"
 
 	"github.com/Masterminds/semver"
@@ -15,6 +16,8 @@ import (
 
 	"k8s.io/apimachinery/pkg/runtime"
 )
+
+const DockerCFGEnvKey = "OPENSHIFT_DOCKER_CFG"
 
 func getConfig(r runtime.RawExtension) (*Config, error) {
 	p := Config{}
@@ -82,6 +85,11 @@ func (p Provider) UserData(req plugin.UserDataRequest) (string, error) {
 		return "", fmt.Errorf("error extracting cacert: %v", err)
 	}
 
+	dockerPullSecret := os.Getenv(DockerCFGEnvKey)
+	if dockerPullSecret == "" {
+		return "", errors.New("dockercfg must not be empty")
+	}
+
 	// The OpenShift 4 minor release is: Kubernetes minor - 12
 	// We require it to download some tooling which follows the Kubernetes versioning
 	kubernetesMinor := openShiftVersion.Minor() + 12
@@ -95,6 +103,7 @@ func (p Provider) UserData(req plugin.UserDataRequest) (string, error) {
 		ServerAddr            string
 		Kubeconfig            string
 		KubernetesCACert      string
+		DockerPullSecret      string
 		CRIORepo              string
 	}{
 		UserDataRequest:       req,
@@ -105,6 +114,7 @@ func (p Provider) UserData(req plugin.UserDataRequest) (string, error) {
 		ServerAddr:            serverAddr,
 		Kubeconfig:            kubeconfigString,
 		KubernetesCACert:      kubernetesCACert,
+		DockerPullSecret:      dockerPullSecret,
 		// There is a CRI-O release for every Kubernetes release.
 		CRIORepo: fmt.Sprintf("https://cbs.centos.org/repos/paas7-crio-1%d-candidate/x86_64/os/", kubernetesMinor),
 	}
@@ -157,7 +167,7 @@ write_files:
     #!/bin/bash
     set -xeuo pipefail
 
-    # TODO: Figure out why the hyperkube binary installation does not work with selinux enabled 
+    # TODO: Figure out why the hyperkube binary installation does not work with selinux enabled
     setenforce 0 || true
 
     systemctl daemon-reload
@@ -311,7 +321,7 @@ write_files:
     [Unit]
     Description=Kubernetes Kubelet
     Wants=rpc-statd.service
-  
+
     [Service]
     Type=notify
     ExecStartPre=/bin/mkdir --parents /etc/kubernetes/manifests
@@ -319,7 +329,7 @@ write_files:
     EnvironmentFile=/etc/os-release
     EnvironmentFile=-/etc/kubernetes/kubelet-workaround
     EnvironmentFile=-/etc/kubernetes/kubelet-env
-  
+
     ExecStart=/usr/bin/hyperkube \
         kubelet \
           --config=/etc/kubernetes/kubelet.conf \
@@ -337,10 +347,10 @@ write_files:
           {{- end }}
           --anonymous-auth=false \
           --v=3 \
-  
+
     Restart=always
     RestartSec=10
-  
+
     [Install]
     WantedBy=multi-user.target
 
@@ -381,6 +391,10 @@ write_files:
     size = ""
     override_kernel_check = "true"
     [storage.options.thinpool]
+
+- path: /var/lib/kubelet/config.json
+  content: |
+{{ .DockerPullSecret | indent 4 }}
 
 - path: "/etc/kubernetes/ca.crt"
   content: |

--- a/api/pkg/userdata/openshift/testdata/aws-v4.1.7.golden.yaml
+++ b/api/pkg/userdata/openshift/testdata/aws-v4.1.7.golden.yaml
@@ -27,7 +27,7 @@ write_files:
     #!/bin/bash
     set -xeuo pipefail
 
-    # TODO: Figure out why the hyperkube binary installation does not work with selinux enabled 
+    # TODO: Figure out why the hyperkube binary installation does not work with selinux enabled
     setenforce 0 || true
 
     systemctl daemon-reload
@@ -180,7 +180,7 @@ write_files:
     [Unit]
     Description=Kubernetes Kubelet
     Wants=rpc-statd.service
-  
+
     [Service]
     Type=notify
     ExecStartPre=/bin/mkdir --parents /etc/kubernetes/manifests
@@ -188,7 +188,7 @@ write_files:
     EnvironmentFile=/etc/os-release
     EnvironmentFile=-/etc/kubernetes/kubelet-workaround
     EnvironmentFile=-/etc/kubernetes/kubelet-env
-  
+
     ExecStart=/usr/bin/hyperkube \
         kubelet \
           --config=/etc/kubernetes/kubelet.conf \
@@ -204,10 +204,10 @@ write_files:
           --cloud-config=/etc/kubernetes/cloud-config \
           --anonymous-auth=false \
           --v=3 \
-  
+
     Restart=always
     RestartSec=10
-  
+
     [Install]
     WantedBy=multi-user.target
 
@@ -248,6 +248,10 @@ write_files:
     size = ""
     override_kernel_check = "true"
     [storage.options.thinpool]
+
+- path: /var/lib/kubelet/config.json
+  content: |
+    {"registry": {"user": "user", "pass": "pss"}}
 
 - path: "/etc/kubernetes/ca.crt"
   content: |

--- a/api/pkg/userdata/openshift/testdata/aws-v4.2.0.golden.yaml
+++ b/api/pkg/userdata/openshift/testdata/aws-v4.2.0.golden.yaml
@@ -27,7 +27,7 @@ write_files:
     #!/bin/bash
     set -xeuo pipefail
 
-    # TODO: Figure out why the hyperkube binary installation does not work with selinux enabled 
+    # TODO: Figure out why the hyperkube binary installation does not work with selinux enabled
     setenforce 0 || true
 
     systemctl daemon-reload
@@ -180,7 +180,7 @@ write_files:
     [Unit]
     Description=Kubernetes Kubelet
     Wants=rpc-statd.service
-  
+
     [Service]
     Type=notify
     ExecStartPre=/bin/mkdir --parents /etc/kubernetes/manifests
@@ -188,7 +188,7 @@ write_files:
     EnvironmentFile=/etc/os-release
     EnvironmentFile=-/etc/kubernetes/kubelet-workaround
     EnvironmentFile=-/etc/kubernetes/kubelet-env
-  
+
     ExecStart=/usr/bin/hyperkube \
         kubelet \
           --config=/etc/kubernetes/kubelet.conf \
@@ -204,10 +204,10 @@ write_files:
           --cloud-config=/etc/kubernetes/cloud-config \
           --anonymous-auth=false \
           --v=3 \
-  
+
     Restart=always
     RestartSec=10
-  
+
     [Install]
     WantedBy=multi-user.target
 
@@ -248,6 +248,10 @@ write_files:
     size = ""
     override_kernel_check = "true"
     [storage.options.thinpool]
+
+- path: /var/lib/kubelet/config.json
+  content: |
+    {"registry": {"user": "user", "pass": "pss"}}
 
 - path: "/etc/kubernetes/ca.crt"
   content: |

--- a/api/pkg/userdata/openshift/testdata/vsphere-v4.1.7.golden.yaml
+++ b/api/pkg/userdata/openshift/testdata/vsphere-v4.1.7.golden.yaml
@@ -30,7 +30,7 @@ write_files:
     #!/bin/bash
     set -xeuo pipefail
 
-    # TODO: Figure out why the hyperkube binary installation does not work with selinux enabled 
+    # TODO: Figure out why the hyperkube binary installation does not work with selinux enabled
     setenforce 0 || true
 
     systemctl daemon-reload
@@ -189,7 +189,7 @@ write_files:
     [Unit]
     Description=Kubernetes Kubelet
     Wants=rpc-statd.service
-  
+
     [Service]
     Type=notify
     ExecStartPre=/bin/mkdir --parents /etc/kubernetes/manifests
@@ -197,7 +197,7 @@ write_files:
     EnvironmentFile=/etc/os-release
     EnvironmentFile=-/etc/kubernetes/kubelet-workaround
     EnvironmentFile=-/etc/kubernetes/kubelet-env
-  
+
     ExecStart=/usr/bin/hyperkube \
         kubelet \
           --config=/etc/kubernetes/kubelet.conf \
@@ -213,10 +213,10 @@ write_files:
           --cloud-config=/etc/kubernetes/cloud-config \
           --anonymous-auth=false \
           --v=3 \
-  
+
     Restart=always
     RestartSec=10
-  
+
     [Install]
     WantedBy=multi-user.target
 
@@ -257,6 +257,10 @@ write_files:
     size = ""
     override_kernel_check = "true"
     [storage.options.thinpool]
+
+- path: /var/lib/kubelet/config.json
+  content: |
+    {"registry": {"user": "user", "pass": "pss"}}
 
 - path: "/etc/kubernetes/ca.crt"
   content: |

--- a/api/pkg/userdata/openshift/userdata_test.go
+++ b/api/pkg/userdata/openshift/userdata_test.go
@@ -3,6 +3,7 @@ package openshift
 import (
 	"flag"
 	"net"
+	"os"
 	"testing"
 
 	testhelper "github.com/kubermatic/kubermatic/api/pkg/test"
@@ -70,6 +71,9 @@ func TestUserdataGeneration(t *testing.T) {
 		},
 	}
 
+	if err := os.Setenv(DockerCFGEnvKey, `{"registry": {"user": "user", "pass": "pss"}}`); err != nil {
+		t.Fatalf("failed to set dockercfg: %v", err)
+	}
 	for _, test := range tests {
 		kubeconfig := &clientcmdapi.Config{
 			Clusters: map[string]*clientcmdapi.Cluster{


### PR DESCRIPTION
**What this PR does / why we need it**:

In order to be able to pull the various Openshift images e.G. for the netwoking stack, we need an imagePullSecret. Clusters created via the openshift installer just put it into `/var/lib/kubelet/config.json` so we do the same.

Require https://github.com/kubermatic/machine-controller/pull/623 to actually work.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:

Needed for #4168 

**Special notes for your reviewer**:

**Documentation**:
<!-- Add links to the related documentation changes related to this pull request. E.g. the link to the kubermatic/docs pullrequest. -->

**Does this PR introduce a user-facing change?**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If  no release note is required, just write "NONE".
-->
```release-note
none
```

/assign @nikhita @thz  
