### PR TITLE
conformance tests: dump logs for all control plane pods

### DIFF
--- a/api/hack/ci/ci-run-minimal-conformance-tests.sh
+++ b/api/hack/ci/ci-run-minimal-conformance-tests.sh
@@ -68,7 +68,18 @@ function cleanup {
     fi
 
     # Controller manager logs
-    kubectl logs -n $NAMESPACE  $(kubectl get pod -n $NAMESPACE -l role=controller-manager |tail -n 1|awk '{print $1}')
+    echodate "Dumping controller-manager logs"
+    for pod in $(kubectl get pods -n $NAMESPACE -l role=controller-manager -o go-template='{{ range .items }}{{.metadata.name}}{{ "\n" }}{{end}}'); do
+      echo "Pod $pod:"
+      kubectl logs -n $NAMESPACE $pod controller-manager
+    done
+
+    # Kubermatic api logs
+    echodate "Dumping kubermatic-api logs"
+    for pod in $(kubectl get pods -n $NAMESPACE -l role=kubermatic-api -o go-template='{{ range .items }}{{.metadata.name}}{{ "\n" }}{{end}}'); do
+      echo "Pod $pod:"
+      kubectl logs -n $NAMESPACE $pod api
+    done
 
     # Display machine events, we don't have to worry about secrets here as they are stored in the machine-controllers env
     # Except for vSphere

--- a/api/hack/ci/ci-run-minimal-conformance-tests.sh
+++ b/api/hack/ci/ci-run-minimal-conformance-tests.sh
@@ -74,7 +74,7 @@ function cleanup {
       local POD="${i%,*}"
       local CONTAINER="${i#*,}"
 
-      echo "Pod $POD, container $CONTAINER:"
+      echo " [*] Pod $POD, container $CONTAINER:"
       kubectl logs -n $NAMESPACE "$POD" "$CONTAINER"
     done
 

--- a/api/hack/ci/ci-run-offline-test.sh
+++ b/api/hack/ci/ci-run-offline-test.sh
@@ -59,18 +59,15 @@ function finish {
     # Describe cluster
     kubectl describe cluster -l worker-name=${BUILD_ID}|egrep -vi 'Service Account'
 
-    # Controller manager logs
-    echodate "Dumping controller-manager logs"
-    for pod in $(kubectl get pods -n $NAMESPACE -l role=controller-manager -o go-template='{{ range .items }}{{.metadata.name}}{{ "\n" }}{{end}}'); do
-      echo "Pod $pod:"
-      kubectl logs -n $NAMESPACE $pod controller-manager
-    done
+    # Control plane logs
+    echodate "Dumping all conntrol plane logs"
+    local GOTEMPLATE='{{ range $pod := .items }}{{ range $container := .spec.containers }}{{ printf "%s,%s\n" $pod.metadata.name $container.name }}{{end}}{{end}}'
+    for i in $(kubectl get pods -n $NAMESPACE -o go-template="$GOTEMPLATE"); do
+      local POD="${i%,*}"
+      local CONTAINER="${i#*,}"
 
-    # Kubermatic api logs
-    echodate "Dumping kubermatic-api logs"
-    for pod in $(kubectl get pods -n $NAMESPACE -l role=kubermatic-api -o go-template='{{ range .items }}{{.metadata.name}}{{ "\n" }}{{end}}'); do
-      echo "Pod $pod:"
-      kubectl logs -n $NAMESPACE $pod api
+      echo " [*] Pod $POD, container $CONTAINER:"
+      kubectl logs -n "$NAMESPACE" "$POD" "$CONTAINER"
     done
 
     # Display machine events, we don't have to worry about secrets here as they are stored in the machine-controllers env

--- a/api/hack/ci/ci-run-offline-test.sh
+++ b/api/hack/ci/ci-run-offline-test.sh
@@ -60,7 +60,18 @@ function finish {
     kubectl describe cluster -l worker-name=${BUILD_ID}|egrep -vi 'Service Account'
 
     # Controller manager logs
-    kubectl logs -n ${NAMESPACE} $(kubectl get pod -n $NAMESPACE -l role=controller-manager |tail -n 1|awk '{print $1}')
+    echodate "Dumping controller-manager logs"
+    for pod in $(kubectl get pods -n $NAMESPACE -l role=controller-manager -o go-template='{{ range .items }}{{.metadata.name}}{{ "\n" }}{{end}}'); do
+      echo "Pod $pod:"
+      kubectl logs -n $NAMESPACE $pod controller-manager
+    done
+
+    # Kubermatic api logs
+    echodate "Dumping kubermatic-api logs"
+    for pod in $(kubectl get pods -n $NAMESPACE -l role=kubermatic-api -o go-template='{{ range .items }}{{.metadata.name}}{{ "\n" }}{{end}}'); do
+      echo "Pod $pod:"
+      kubectl logs -n $NAMESPACE $pod api
+    done
 
     # Display machine events, we don't have to worry about secrets here as they are stored in the machine-controllers env
     # Except for vSphere


### PR DESCRIPTION
**Why we need it**:
I'm debugging a failed test and according to the log, the kubermatic api server returns an empty error response. I'd like to be able to easily see what it has to say in its logs.

In addition, the existing code that dumps the controller-manager logs assumes that there is only one replica. I generalized it to always iterate over all pods, to avoid misleading the user.

**Does this PR introduce a user-facing change?**:
```release-note
NONE
```
