### PR TITLE
Configure tolerations for container-linux-update-agent

### DIFF
--- a/api/pkg/controller/container-linux/resources/daemonset.go
+++ b/api/pkg/controller/container-linux/resources/daemonset.go
@@ -84,6 +84,17 @@ func DaemonSetCreator(getRegistry GetImageRegistry) reconciling.NamedDaemonSetCr
 				},
 			}
 
+			ds.Spec.Template.Spec.Tolerations = []corev1.Toleration{
+				{
+					Effect:   corev1.TaintEffectNoSchedule,
+					Operator: corev1.TolerationOpExists,
+				},
+				{
+					Effect:   corev1.TaintEffectNoExecute,
+					Operator: corev1.TolerationOpExists,
+				},
+			}
+
 			ds.Spec.Template.Spec.Volumes = []corev1.Volume{
 				{
 					Name: "var-run-dbus",


### PR DESCRIPTION
**What this PR does / why we need it**:
Configure tolerations for container-linux-update-agent so that it is also deployed to nodes with taints

**Does this PR introduce a user-facing change?**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If  no release note is required, just write "NONE".
-->
```release-note
NONE
```
