### PR TITLE
E2E tests: Make sure the reports dir exists

### DIFF
--- a/api/cmd/conformance-tests/runner.go
+++ b/api/cmd/conformance-tests/runner.go
@@ -229,6 +229,12 @@ func (r *testRunner) executeScenario(log *zap.SugaredLogger, scenario testScenar
 	}
 	totalStart := time.Now()
 
+	// We'll store the report there and all kinds of logs
+	scenarioFolder := path.Join(r.reportsRoot, scenario.Name())
+	if err := os.MkdirAll(scenarioFolder, os.ModePerm); err != nil {
+		return nil, fmt.Errorf("failed to create the scenario folder '%s': %v", scenarioFolder, err)
+	}
+
 	// We need the closure to defer the evaluation of the time.Since(totalStart) call
 	defer func() { log.Infof("Finished testing cluster after %s", time.Since(totalStart)) }()
 	// Always write junit to disk
@@ -383,12 +389,6 @@ func (r *testRunner) testCluster(
 	const maxTestAttempts = 3
 	var err error
 	log.Info("Starting to test cluster...")
-
-	// We'll store the report there and all kinds of logs
-	scenarioFolder := path.Join(r.reportsRoot, scenarioName)
-	if err := os.MkdirAll(scenarioFolder, os.ModePerm); err != nil {
-		return fmt.Errorf("failed to create the scenario folder '%s': %v", scenarioFolder, err)
-	}
 
 	if r.openshift {
 		// Openshift supports neither the conformance tests nor PVs/LBs yet :/


### PR DESCRIPTION
**What this PR does / why we need it**:

Currently, if e2e tests fail early, the junit can not be written because the dir does not exist:
```
{"level":"error","time":"2019-08-28T15:01:47.932Z","caller":"conformance-tests/runner.go:243","msg":"failed to write junit","worker-name":"1166726271871225856","home":"/tmp/e2e-home-463058470","scenario":"kubevirt-centos-1.15.3","worker":1,"error":"open /reports/junit.kubevirt-centos-1.15.3.xml: no such file or directory"}
```

E.G. here:  https://prow.loodse.com/view/gcs/prow-data/pr-logs/pull/kubermatic_kubermatic/3942/pull-kubermatic-e2e-kubevirt-centos-1.15/1166726271871225856

This PR fixes that.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Documentation**:
<!-- Add links to the related documentation changes related to this pull request. E.g. the link to the kubermatic/docs pullrequest. -->

**Does this PR introduce a user-facing change?**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If  no release note is required, just write "NONE".
-->
```release-note
none
```

/assign @xrstf 
