### PR TITLE
[release/v2.11] Cherrpick PV cleanup: Do not attempt to delete pods when there are no PVs/PVCs #4079

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -27,7 +27,7 @@ issues:
   - cyclomatic complexity 32 of func `main` is high
   - cyclomatic complexity 37 of func `migrateToProject` is high
   - cyclomatic complexity 33 of func `ValidateCloudSpec` is high
-  - cyclomatic complexity 32 of func `\(\*Deletion\)\.cleanupInClusterResources` is high
+  - cyclomatic complexity 35 of func `\(\*Deletion\)\.cleanupInClusterResources` is high
   - 'CleanUpCloudProvider` is high'
   - string `get` has 6 occurrences, make it a constant
   - struct of size 536 bytes could be of size 520 bytes


### PR DESCRIPTION
**What this PR does / why we need it**:

Makes the cleanup not attempt to delete any pods if there are no PVs and PVCs, also makes all of the Pod/PV/PVC deletion tolerate a 404 and not treat it as an error.

Cherrypicking required a bit more shuffling code around as the code in master has diverged quite a bit.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Documentation**:
<!-- Add links to the related documentation changes related to this pull request. E.g. the link to the kubermatic/docs pullrequest. -->

**Does this PR introduce a user-facing change?**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If  no release note is required, just write "NONE".
-->
```release-note
Fixed a bug that could result in the clusterdeletion sometimes getting stuck
```

/assign @kdomanski 
