### PR TITLE
When choosing a preset on AWS, use the defined vpc

### DIFF
--- a/api/pkg/handler/v1/provider/aws.go
+++ b/api/pkg/handler/v1/provider/aws.go
@@ -332,12 +332,14 @@ func AWSSubnetEndpoint(credentialManager common.PresetsManager, seedsGetter prov
 
 		keyID := req.AccessKeyID
 		keySecret := req.SecretAccessKey
+		vpcID := req.VPC
 
 		if len(req.Credential) > 0 && credentialManager.GetPresets().AWS.Credentials != nil {
 			for _, credential := range credentialManager.GetPresets().AWS.Credentials {
 				if credential.Name == req.Credential {
 					keyID = credential.AccessKeyID
 					keySecret = credential.SecretAccessKey
+					vpcID = credential.VPCID
 					break
 				}
 			}
@@ -356,7 +358,7 @@ func AWSSubnetEndpoint(credentialManager common.PresetsManager, seedsGetter prov
 			return nil, errors.New(http.StatusInternalServerError, fmt.Sprintf("failed to get client for seed: %v", err))
 		}
 
-		return listAWSSubnets(ctx, keyID, keySecret, req.VPC, dc, privilegedSeedClient, nil)
+		return listAWSSubnets(ctx, keyID, keySecret, vpcID, dc, privilegedSeedClient, nil)
 	}
 }
 


### PR DESCRIPTION
**What this PR does / why we need it**:
When choosing a preset on AWS, use the defined vpc. Otherwise subnets will not get listed during cluster creation.

**Special notes for your reviewer**:
/

**Does this PR introduce a user-facing change?**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If  no release note is required, just write "NONE".
-->
```release-note
NONE
```
