### PR TITLE
Add openshiftmasternodelabeler controller

### DIFF
--- a/api/cmd/user-cluster-controller-manager/main.go
+++ b/api/cmd/user-cluster-controller-manager/main.go
@@ -94,31 +94,31 @@ func main() {
 		glog.Fatal(err)
 	}
 	if len(certs) != 1 {
-		glog.Fatalf("did not find exactly one but %d certificates in the given CA", len(certs))
+		glog.Fatalf("Did not find exactly one but %d certificates in the given CA", len(certs))
 	}
 
 	openVPNCACertBytes, err := ioutil.ReadFile(runOp.openvpnCACertFilePath)
 	if err != nil {
-		glog.Fatalf("failed to read openvpn-ca-cert-file: %v", err)
+		glog.Fatalf("Failed to read openvpn-ca-cert-file: %v", err)
 	}
 	openVPNCACerts, err := certutil.ParseCertsPEM(openVPNCACertBytes)
 	if err != nil {
-		glog.Fatalf("failed to parse openVPN CA file: %v", err)
+		glog.Fatalf("Failed to parse openVPN CA file: %v", err)
 	}
 	if certsLen := len(openVPNCACerts); certsLen != 1 {
-		glog.Fatalf("did not find exactly one but %v certificates in the openVPN CA file", certsLen)
+		glog.Fatalf("Did not find exactly one but %v certificates in the openVPN CA file", certsLen)
 	}
 	openVPNCAKeyBytes, err := ioutil.ReadFile(runOp.openvpnCAKeyFilePath)
 	if err != nil {
-		glog.Fatalf("failed to read openvpn-ca-key-file: %v", err)
+		glog.Fatalf("Failed to read openvpn-ca-key-file: %v", err)
 	}
 	openVPNCAKey, err := certutil.ParsePrivateKeyPEM(openVPNCAKeyBytes)
 	if err != nil {
-		glog.Fatalf("failed to parse openVPN CA key file: %v", err)
+		glog.Fatalf("Failed to parse openVPN CA key file: %v", err)
 	}
 	openVPNECSDAKey, isECDSAKey := openVPNCAKey.(*ecdsa.PrivateKey)
 	if !isECDSAKey {
-		glog.Fatal("the openVPN private key is not an ECDSA key")
+		glog.Fatal("The openVPN private key is not an ECDSA key")
 	}
 	openVPNCACert := &resources.ECDSAKeyPair{Cert: openVPNCACerts[0], Key: openVPNECSDAKey}
 
@@ -168,12 +168,12 @@ func main() {
 		runOp.openvpnServerPort,
 		healthHandler.AddReadinessCheck,
 		openVPNCACert); err != nil {
-		glog.Fatalf("failed to register user cluster controller: %v", err)
+		glog.Fatalf("Failed to register user cluster controller: %v", err)
 	}
 
 	if len(runOp.networks) > 0 {
 		if err := clusterv1alpha1.AddToScheme(mgr.GetScheme()); err != nil {
-			glog.Fatalf("failed to add clusterv1alpha1 scheme: %v", err)
+			glog.Fatalf("Failed to add clusterv1alpha1 scheme: %v", err)
 		}
 		// We need to add the machine CRDs once here, because otherwise the IPAM
 		// controller keeps the manager from starting as it can not establish a
@@ -184,31 +184,31 @@ func main() {
 		if err := reconciling.ReconcileCustomResourceDefinitions(context.Background(), creators, "", mgr.GetClient()); err != nil {
 			// The mgr.Client is uninitianlized here and hence always returns a 404, regardless of the object existing or not
 			if !strings.Contains(err.Error(), `customresourcedefinitions.apiextensions.k8s.io "machines.cluster.k8s.io" already exists`) {
-				glog.Fatalf("failed to initially create the Machine CR: %v", err)
+				glog.Fatalf("Failed to initially create the Machine CR: %v", err)
 			}
 		}
 		if err := ipam.Add(mgr, runOp.networks); err != nil {
-			glog.Fatalf("failed to add IPAM controller to mgr: %v", err)
+			glog.Fatalf("Failed to add IPAM controller to mgr: %v", err)
 		}
 		glog.Infof("Added IPAM controller to mgr")
 	}
 
 	if err := rbacusercluster.Add(mgr, healthHandler.AddReadinessCheck); err != nil {
-		glog.Fatalf("failed to add user RBAC controller to mgr: %v", err)
+		glog.Fatalf("Failed to add user RBAC controller to mgr: %v", err)
 	}
 
 	if runOp.openshift {
 		if err := nodecsrapprover.Add(mgr, 4, cfg); err != nil {
-			glog.Fatalf("failed to add nodecsrapprover controller: %v", err)
+			glog.Fatalf("Failed to add nodecsrapprover controller: %v", err)
 		}
 		if err := openshiftmasternodelabeler.Add(context.Background(), kubermaticlog.Logger, mgr); err != nil {
-			glog.Fatalf("failed to add openshiftmasternodelabeler contorller: %v", err)
+			glog.Fatalf("Failed to add openshiftmasternodelabeler contorller: %v", err)
 		}
 		glog.Infof("Registered nodecsrapprover controller")
 	}
 
 	if err := containerlinux.Add(mgr, runOp.overwriteRegistry); err != nil {
-		glog.Fatalf("failed to register the ContainerLinux controller: %v", err)
+		glog.Fatalf("Failed to register the ContainerLinux controller: %v", err)
 	}
 
 	// This group is forever waiting in a goroutine for signals to stop

--- a/api/cmd/user-cluster-controller-manager/main.go
+++ b/api/cmd/user-cluster-controller-manager/main.go
@@ -19,8 +19,10 @@ import (
 	"github.com/kubermatic/kubermatic/api/pkg/controller/ipam"
 	"github.com/kubermatic/kubermatic/api/pkg/controller/nodecsrapprover"
 	"github.com/kubermatic/kubermatic/api/pkg/controller/rbac-user-cluster"
+	openshiftmasternodelabeler "github.com/kubermatic/kubermatic/api/pkg/controller/user-cluster-controller-manager/openshift-master-node-labeler"
 	"github.com/kubermatic/kubermatic/api/pkg/controller/usercluster"
 	machinecontrolerresources "github.com/kubermatic/kubermatic/api/pkg/controller/usercluster/resources/machine-controller"
+	kubermaticlog "github.com/kubermatic/kubermatic/api/pkg/log"
 	"github.com/kubermatic/kubermatic/api/pkg/resources"
 	"github.com/kubermatic/kubermatic/api/pkg/resources/reconciling"
 
@@ -198,6 +200,9 @@ func main() {
 	if runOp.openshift {
 		if err := nodecsrapprover.Add(mgr, 4, cfg); err != nil {
 			glog.Fatalf("failed to add nodecsrapprover controller: %v", err)
+		}
+		if err := openshiftmasternodelabeler.Add(context.Background(), kubermaticlog.Logger, mgr); err != nil {
+			glog.Fatalf("failed to add openshiftmasternodelabeler contorller: %v", err)
 		}
 		glog.Infof("Registered nodecsrapprover controller")
 	}

--- a/api/pkg/controller/openshift/resources/openshift_network_operator.go
+++ b/api/pkg/controller/openshift/resources/openshift_network_operator.go
@@ -2,6 +2,7 @@ package resources
 
 import (
 	"fmt"
+	"strconv"
 
 	"github.com/kubermatic/kubermatic/api/pkg/resources"
 	"github.com/kubermatic/kubermatic/api/pkg/resources/apiserver"
@@ -49,7 +50,7 @@ func OpenshiftNetworkOperatorCreatorFactory(data openshiftData) reconciling.Name
 				},
 				corev1.EnvVar{
 					Name:  "KUBERNETES_SERVICE_PORT",
-					Value: string(data.Cluster().Address.Port),
+					Value: strconv.Itoa(int(data.Cluster().Address.Port)),
 				})
 
 			d.Spec.Selector = &metav1.LabelSelector{

--- a/api/pkg/controller/user-cluster-controller-manager/openshift-master-node-labeler/README.md
+++ b/api/pkg/controller/user-cluster-controller-manager/openshift-master-node-labeler/README.md
@@ -1,0 +1,8 @@
+# Openshift master node labeler
+
+A simple controller that makes sure there are always three randomly selected nodes
+with a `node-role.kubernetes.io/master` label on them.
+
+This is required because the following components have label selectors for that label:
+
+* `sdn-controller`, managed by the `openshift-network-operator`

--- a/api/pkg/controller/user-cluster-controller-manager/openshift-master-node-labeler/openshiftmasternodelabeler.go
+++ b/api/pkg/controller/user-cluster-controller-manager/openshift-master-node-labeler/openshiftmasternodelabeler.go
@@ -23,7 +23,10 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/source"
 )
 
-const controllerName = "kubermatic_openshift_master_node_labeler"
+const (
+	controllerName = "kubermatic_openshift_master_node_labeler"
+	minMasterNodes = 3
+)
 
 type reconciler struct {
 	ctx    context.Context
@@ -72,7 +75,7 @@ func (r *reconciler) Reconcile(_ reconcile.Request) (reconcile.Result, error) {
 	r.log.Info("Reconciling")
 	result, err := r.reconcile()
 	if err != nil {
-		r.log.Errorw("failed to reconcile", zap.Error(err))
+		r.log.Errorw("Failed to reconcile", zap.Error(err))
 	}
 	if result == nil {
 		result = &reconcile.Result{}
@@ -97,11 +100,11 @@ func (r *reconciler) reconcile() (*reconcile.Result, error) {
 		}
 	}
 
-	if numNodesWithMasterLabel >= 3 {
+	if numNodesWithMasterLabel >= minMasterNodes {
 		return nil, nil
 	}
 
-	for i := 0; i < 3-numNodesWithMasterLabel; i++ {
+	for i := 0; i < minMasterNodes-numNodesWithMasterLabel; i++ {
 		nodeToLabel, hasNode := nodesWithoutMasterLabel.PopAny()
 		// Try again later
 		if !hasNode {

--- a/api/pkg/controller/user-cluster-controller-manager/openshift-master-node-labeler/openshiftmasternodelabeler.go
+++ b/api/pkg/controller/user-cluster-controller-manager/openshift-master-node-labeler/openshiftmasternodelabeler.go
@@ -1,0 +1,136 @@
+package openshiftmasternodelabeler
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	"go.uber.org/zap"
+
+	controllerutil "github.com/kubermatic/kubermatic/api/pkg/controller/util"
+
+	corev1 "k8s.io/api/core/v1"
+	apiequality "k8s.io/apimachinery/pkg/api/equality"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/apimachinery/pkg/util/sets"
+	"k8s.io/client-go/util/retry"
+	ctrlruntimeclient "sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/controller"
+	"sigs.k8s.io/controller-runtime/pkg/event"
+	"sigs.k8s.io/controller-runtime/pkg/manager"
+	"sigs.k8s.io/controller-runtime/pkg/predicate"
+	"sigs.k8s.io/controller-runtime/pkg/reconcile"
+	"sigs.k8s.io/controller-runtime/pkg/source"
+)
+
+const controllerName = "kubermatic_openshift_master_node_labeler"
+
+type reconciler struct {
+	ctx    context.Context
+	log    *zap.SugaredLogger
+	client ctrlruntimeclient.Client
+}
+
+func Add(ctx context.Context, log *zap.SugaredLogger, mgr manager.Manager) error {
+	r := &reconciler{
+		ctx:    ctx,
+		log:    log.Named(controllerName),
+		client: mgr.GetClient(),
+	}
+	c, err := controller.New(controllerName, mgr, controller.Options{
+		Reconciler: r,
+		// This controller is not safe to run with more than one worker
+		// as it looks at the state of the whole cluster, which may result
+		// in race bahaviour if there are more.
+		MaxConcurrentReconciles: 1,
+	})
+	if err != nil {
+		return fmt.Errorf("failed to create controller: %v", err)
+	}
+
+	// Ignore update events that don't touch the metadata
+	metadataChangedPredicate := predicate.Funcs{
+		UpdateFunc: func(e event.UpdateEvent) bool {
+			if apiequality.Semantic.DeepEqual(e.MetaOld, e.MetaNew) {
+				return false
+			}
+			return true
+		},
+	}
+	if err := c.Watch(
+		&source.Kind{Type: &corev1.Node{}},
+		controllerutil.EnqueueConst(""),
+		metadataChangedPredicate,
+	); err != nil {
+		return fmt.Errorf("failed to establish watch for nodes: %v", err)
+	}
+
+	return nil
+}
+
+func (r *reconciler) Reconcile(_ reconcile.Request) (reconcile.Result, error) {
+	r.log.Info("Reconciling")
+	result, err := r.reconcile()
+	if err != nil {
+		r.log.Errorw("failed to reconcile", zap.Error(err))
+	}
+	if result == nil {
+		result = &reconcile.Result{}
+	}
+	return *result, err
+}
+
+func (r *reconciler) reconcile() (*reconcile.Result, error) {
+
+	nodes := &corev1.NodeList{}
+	if err := r.client.List(r.ctx, &ctrlruntimeclient.ListOptions{}, nodes); err != nil {
+		return nil, fmt.Errorf("failed to list nodes: %v", err)
+	}
+
+	numNodesWithMasterLabel := 0
+	nodesWithoutMasterLabel := sets.String{}
+	for _, node := range nodes.Items {
+		if _, exists := node.Labels["node-role.kubernetes.io/master"]; exists {
+			numNodesWithMasterLabel++
+		} else {
+			nodesWithoutMasterLabel.Insert(node.Name)
+		}
+	}
+
+	if numNodesWithMasterLabel >= 3 {
+		return nil, nil
+	}
+
+	for i := 0; i < 3-numNodesWithMasterLabel; i++ {
+		nodeToLabel, hasNode := nodesWithoutMasterLabel.PopAny()
+		// Try again later
+		if !hasNode {
+			return &reconcile.Result{RequeueAfter: time.Minute}, nil
+		}
+
+		if err := r.updateNode(nodeToLabel, func(n *corev1.Node) {
+			if n.Labels == nil {
+				n.Labels = map[string]string{}
+			}
+			n.Labels["node-role.kubernetes.io/master"] = ""
+		}); err != nil {
+			return nil, fmt.Errorf("failed to update node %q: %v", nodeToLabel, err)
+		}
+	}
+
+	return nil, nil
+}
+
+func (r *reconciler) updateNode(name string, modify func(*corev1.Node)) error {
+	return retry.RetryOnConflict(retry.DefaultBackoff, func() (err error) {
+		//Get latest version
+		node := &corev1.Node{}
+		if err := r.client.Get(r.ctx, types.NamespacedName{Name: name}, node); err != nil {
+			return err
+		}
+		// Apply modifications
+		modify(node)
+		// Update the cluster
+		return r.client.Update(r.ctx, node)
+	})
+}

--- a/api/pkg/controller/user-cluster-controller-manager/openshift-master-node-labeler/openshiftmasternodelabeler_test.go
+++ b/api/pkg/controller/user-cluster-controller-manager/openshift-master-node-labeler/openshiftmasternodelabeler_test.go
@@ -1,0 +1,171 @@
+package openshiftmasternodelabeler
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"testing"
+	"time"
+
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	ctrlruntimeclient "sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+	"sigs.k8s.io/controller-runtime/pkg/reconcile"
+)
+
+func TestReconciliation(t *testing.T) {
+	testCases := []struct {
+		name   string
+		nodes  []runtime.Object
+		verify func(*reconcile.Result, error, ctrlruntimeclient.Client) error
+	}{
+		{
+			name: "Labeled nodes already exist, nothing to do",
+			nodes: []runtime.Object{
+				&corev1.Node{ObjectMeta: metav1.ObjectMeta{
+					Name:   "one",
+					Labels: map[string]string{"node-role.kubernetes.io/master": ""},
+				}},
+				&corev1.Node{ObjectMeta: metav1.ObjectMeta{
+					Name:   "two",
+					Labels: map[string]string{"node-role.kubernetes.io/master": ""},
+				}},
+				&corev1.Node{ObjectMeta: metav1.ObjectMeta{
+					Name:   "three",
+					Labels: map[string]string{"node-role.kubernetes.io/master": ""},
+				}},
+			},
+			verify: func(r *reconcile.Result, err error, client ctrlruntimeclient.Client) error {
+				if r != nil {
+					return fmt.Errorf("expected reconcile.Result to be nil, was %v", r)
+				}
+				if err != nil {
+					return fmt.Errorf("expected err to be nil, was %v", err)
+				}
+				nodes := &corev1.NodeList{}
+				if err := client.List(context.Background(), &ctrlruntimeclient.ListOptions{}, nodes); err != nil {
+					return fmt.Errorf("error listing nodes: %v", err)
+				}
+				if n := len(nodes.Items); n != 3 {
+					return fmt.Errorf("expected three nodes, got %d", n)
+				}
+				for _, node := range nodes.Items {
+					if _, exists := node.Labels["node-role.kubernetes.io/master"]; !exists {
+						return fmt.Errorf("node %q didnt have the master label anymore", node.Name)
+					}
+				}
+				return nil
+			},
+		},
+		{
+			name: "Labeling three nodes",
+			nodes: []runtime.Object{
+				&corev1.Node{ObjectMeta: metav1.ObjectMeta{
+					Name: "one",
+				}},
+				&corev1.Node{ObjectMeta: metav1.ObjectMeta{
+					Name: "two",
+				}},
+				&corev1.Node{ObjectMeta: metav1.ObjectMeta{
+					Name: "three",
+				}},
+			},
+			verify: func(r *reconcile.Result, err error, client ctrlruntimeclient.Client) error {
+				if r != nil {
+					return fmt.Errorf("expected reconcile.Result to be nil, was %v", r)
+				}
+				if err != nil {
+					return fmt.Errorf("expected err to be nil, was %v", err)
+				}
+				nodes := &corev1.NodeList{}
+				if err := client.List(context.Background(), &ctrlruntimeclient.ListOptions{}, nodes); err != nil {
+					return fmt.Errorf("error listing nodes: %v", err)
+				}
+				if n := len(nodes.Items); n != 3 {
+					return fmt.Errorf("expected three nodes, got %d", n)
+				}
+				for _, node := range nodes.Items {
+					if _, exists := node.Labels["node-role.kubernetes.io/master"]; !exists {
+						return fmt.Errorf("node %q didnt have the master label", node.Name)
+					}
+				}
+				return nil
+			},
+		},
+		{
+			name: "Labeling one node",
+			nodes: []runtime.Object{
+				&corev1.Node{ObjectMeta: metav1.ObjectMeta{
+					Name:   "one",
+					Labels: map[string]string{"node-role.kubernetes.io/master": ""},
+				}},
+				&corev1.Node{ObjectMeta: metav1.ObjectMeta{
+					Name:   "two",
+					Labels: map[string]string{"node-role.kubernetes.io/master": ""},
+				}},
+				&corev1.Node{ObjectMeta: metav1.ObjectMeta{
+					Name: "three",
+				}},
+			},
+			verify: func(r *reconcile.Result, err error, client ctrlruntimeclient.Client) error {
+				if r != nil {
+					return fmt.Errorf("expected reconcile.Result to be nil, was %v", r)
+				}
+				if err != nil {
+					return fmt.Errorf("expected err to be nil, was %v", err)
+				}
+				nodes := &corev1.NodeList{}
+				if err := client.List(context.Background(), &ctrlruntimeclient.ListOptions{}, nodes); err != nil {
+					return fmt.Errorf("error listing nodes: %v", err)
+				}
+				if n := len(nodes.Items); n != 3 {
+					return fmt.Errorf("expected three nodes, got %d", n)
+				}
+				for _, node := range nodes.Items {
+					if _, exists := node.Labels["node-role.kubernetes.io/master"]; !exists {
+						return fmt.Errorf("node %q didnt have the master label", node.Name)
+					}
+				}
+				return nil
+			},
+		},
+		{
+			name: "Not enough nodes exist, retrying later",
+			nodes: []runtime.Object{
+				&corev1.Node{ObjectMeta: metav1.ObjectMeta{
+					Name:   "one",
+					Labels: map[string]string{"node-role.kubernetes.io/master": ""},
+				}},
+				&corev1.Node{ObjectMeta: metav1.ObjectMeta{
+					Name:   "two",
+					Labels: map[string]string{"node-role.kubernetes.io/master": ""},
+				}},
+			},
+			verify: func(r *reconcile.Result, err error, client ctrlruntimeclient.Client) error {
+				if err != nil {
+					return fmt.Errorf("expected err to be nil, was %v", err)
+				}
+				if r == nil {
+					return errors.New("expcted to get reconcile.Result, but was nil")
+				}
+				if r.RequeueAfter != time.Minute {
+					return fmt.Errorf("expected RequeueAfter to be 1 Minute, was %v", r.RequeueAfter)
+				}
+				return nil
+			},
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			client := fake.NewFakeClient(tc.nodes...)
+			r := &reconciler{client: client}
+			result, err := r.reconcile()
+			if err := tc.verify(result, err, client); err != nil {
+				t.Fatalf("verification failed: %v", err)
+			}
+		})
+	}
+}

--- a/openshift_addons/network/network.yaml
+++ b/openshift_addons/network/network.yaml
@@ -1,4 +1,4 @@
-apiVersion: operator.openshift.io/v1
+apiVersion: config.openshift.io/v1
 kind: Network
 metadata:
   name: cluster
@@ -6,7 +6,6 @@ spec:
   clusterNetwork:{{ range .Cluster.Spec.ClusterNetwork.Pods.CIDRBlocks }}
   - cidr: {{ . }}
     hostPrefix: 23{{ end }}
-  defaultNetwork:
-    type: OpenShiftSDN
+  networkType: OpenShiftSDN
   serviceNetwork:{{ range .Cluster.Spec.ClusterNetwork.Services.CIDRBlocks }}
   - {{ . }}{{ end }}


### PR DESCRIPTION
**What this PR does / why we need it**:

This pr adds the `openshiftmasternodelabeler `, which is a simplistic controller that makes sure there are always three nodes labeled as master in an openshift cluster. This is necesary for network to function, because the network-operator creates a `sdn-controller` Daemonset which has a labelselector for master needs.

I manually verififed that with this changes here and a machine-controller version from master all of:
* Pod to Pod on same node
* Pod to Pod on different node
* Pod to service
* Node to Pod
* Pod to node

work.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #4168 

**Special notes for your reviewer**:

**Documentation**:
<!-- Add links to the related documentation changes related to this pull request. E.g. the link to the kubermatic/docs pullrequest. -->

**Does this PR introduce a user-facing change?**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If  no release note is required, just write "NONE".
-->
```release-note
none
```
/approve