### PR TITLE
Use env vars for Azure credentials

### DIFF
--- a/api/pkg/resources/machine/common.go
+++ b/api/pkg/resources/machine/common.go
@@ -94,11 +94,6 @@ func getAWSProviderSpec(c *kubermaticv1.Cluster, nodeSpec apiv1.NodeSpec, dc *ku
 
 func getAzureProviderSpec(c *kubermaticv1.Cluster, nodeSpec apiv1.NodeSpec, dc *kubermaticv1.Datacenter) (*runtime.RawExtension, error) {
 	config := azure.RawConfig{
-		SubscriptionID: providerconfig.ConfigVarString{Value: c.Spec.Cloud.Azure.SubscriptionID},
-		TenantID:       providerconfig.ConfigVarString{Value: c.Spec.Cloud.Azure.TenantID},
-		ClientID:       providerconfig.ConfigVarString{Value: c.Spec.Cloud.Azure.ClientID},
-		ClientSecret:   providerconfig.ConfigVarString{Value: c.Spec.Cloud.Azure.ClientSecret},
-
 		Location:          providerconfig.ConfigVarString{Value: dc.Spec.Azure.Location},
 		ResourceGroup:     providerconfig.ConfigVarString{Value: c.Spec.Cloud.Azure.ResourceGroup},
 		VMSize:            providerconfig.ConfigVarString{Value: nodeSpec.Cloud.Azure.Size},

--- a/api/pkg/resources/machinecontroller/deployment.go
+++ b/api/pkg/resources/machinecontroller/deployment.go
@@ -175,6 +175,12 @@ func getEnvVars(data machinecontrollerData) ([]corev1.EnvVar, error) {
 		vars = append(vars, corev1.EnvVar{Name: "AWS_ACCESS_KEY_ID", Value: credentials.AWS.AccessKeyID})
 		vars = append(vars, corev1.EnvVar{Name: "AWS_SECRET_ACCESS_KEY", Value: credentials.AWS.SecretAccessKey})
 	}
+	if data.Cluster().Spec.Cloud.Azure != nil {
+		vars = append(vars, corev1.EnvVar{Name: "AZURE_CLIENT_ID", Value: data.Cluster().Spec.Cloud.Azure.ClientID})
+		vars = append(vars, corev1.EnvVar{Name: "AZURE_CLIENT_SECRET", Value: data.Cluster().Spec.Cloud.Azure.ClientSecret})
+		vars = append(vars, corev1.EnvVar{Name: "AZURE_TENANT_ID", Value: data.Cluster().Spec.Cloud.Azure.TenantID})
+		vars = append(vars, corev1.EnvVar{Name: "AZURE_SUBSCRIPTION_ID", Value: data.Cluster().Spec.Cloud.Azure.SubscriptionID})
+	}
 	if data.Cluster().Spec.Cloud.Openstack != nil {
 		vars = append(vars, corev1.EnvVar{Name: "OS_AUTH_URL", Value: data.DC().Spec.Openstack.AuthURL})
 		vars = append(vars, corev1.EnvVar{Name: "OS_USER_NAME", Value: data.Cluster().Spec.Cloud.Openstack.Username})

--- a/api/pkg/resources/test/fixtures/deployment-azure-1.10.0-machine-controller-webhook.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-azure-1.10.0-machine-controller-webhook.yaml
@@ -33,6 +33,15 @@ spec:
         - '{"command":"/usr/local/bin/webhook","args":["-kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","-logtostderr","-v","4","-listen-address","0.0.0.0:9876"]}'
         command:
         - /http-prober-bin/http-prober
+        env:
+        - name: AZURE_CLIENT_ID
+          value: az-client-id
+        - name: AZURE_CLIENT_SECRET
+          value: az-client-secret
+        - name: AZURE_TENANT_ID
+          value: az-tenant-id
+        - name: AZURE_SUBSCRIPTION_ID
+          value: az-subscription-id
         image: docker.io/kubermatic/machine-controller:v1.5.5
         livenessProbe:
           failureThreshold: 8

--- a/api/pkg/resources/test/fixtures/deployment-azure-1.10.0-machine-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-azure-1.10.0-machine-controller.yaml
@@ -36,6 +36,15 @@ spec:
         - '{"command":"/usr/local/bin/machine-controller","args":["-kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","-logtostderr","-v","4","-cluster-dns","169.254.20.10","-internal-listen-address","0.0.0.0:8085"]}'
         command:
         - /http-prober-bin/http-prober
+        env:
+        - name: AZURE_CLIENT_ID
+          value: az-client-id
+        - name: AZURE_CLIENT_SECRET
+          value: az-client-secret
+        - name: AZURE_TENANT_ID
+          value: az-tenant-id
+        - name: AZURE_SUBSCRIPTION_ID
+          value: az-subscription-id
         image: docker.io/kubermatic/machine-controller:v1.5.5
         livenessProbe:
           failureThreshold: 3

--- a/api/pkg/resources/test/fixtures/deployment-azure-1.10.6-machine-controller-webhook.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-azure-1.10.6-machine-controller-webhook.yaml
@@ -33,6 +33,15 @@ spec:
         - '{"command":"/usr/local/bin/webhook","args":["-kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","-logtostderr","-v","4","-listen-address","0.0.0.0:9876"]}'
         command:
         - /http-prober-bin/http-prober
+        env:
+        - name: AZURE_CLIENT_ID
+          value: az-client-id
+        - name: AZURE_CLIENT_SECRET
+          value: az-client-secret
+        - name: AZURE_TENANT_ID
+          value: az-tenant-id
+        - name: AZURE_SUBSCRIPTION_ID
+          value: az-subscription-id
         image: docker.io/kubermatic/machine-controller:v1.5.5
         livenessProbe:
           failureThreshold: 8

--- a/api/pkg/resources/test/fixtures/deployment-azure-1.10.6-machine-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-azure-1.10.6-machine-controller.yaml
@@ -36,6 +36,15 @@ spec:
         - '{"command":"/usr/local/bin/machine-controller","args":["-kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","-logtostderr","-v","4","-cluster-dns","169.254.20.10","-internal-listen-address","0.0.0.0:8085"]}'
         command:
         - /http-prober-bin/http-prober
+        env:
+        - name: AZURE_CLIENT_ID
+          value: az-client-id
+        - name: AZURE_CLIENT_SECRET
+          value: az-client-secret
+        - name: AZURE_TENANT_ID
+          value: az-tenant-id
+        - name: AZURE_SUBSCRIPTION_ID
+          value: az-subscription-id
         image: docker.io/kubermatic/machine-controller:v1.5.5
         livenessProbe:
           failureThreshold: 3

--- a/api/pkg/resources/test/fixtures/deployment-azure-1.11.0-machine-controller-webhook.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-azure-1.11.0-machine-controller-webhook.yaml
@@ -33,6 +33,15 @@ spec:
         - '{"command":"/usr/local/bin/webhook","args":["-kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","-logtostderr","-v","4","-listen-address","0.0.0.0:9876"]}'
         command:
         - /http-prober-bin/http-prober
+        env:
+        - name: AZURE_CLIENT_ID
+          value: az-client-id
+        - name: AZURE_CLIENT_SECRET
+          value: az-client-secret
+        - name: AZURE_TENANT_ID
+          value: az-tenant-id
+        - name: AZURE_SUBSCRIPTION_ID
+          value: az-subscription-id
         image: docker.io/kubermatic/machine-controller:v1.5.5
         livenessProbe:
           failureThreshold: 8

--- a/api/pkg/resources/test/fixtures/deployment-azure-1.11.0-machine-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-azure-1.11.0-machine-controller.yaml
@@ -36,6 +36,15 @@ spec:
         - '{"command":"/usr/local/bin/machine-controller","args":["-kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","-logtostderr","-v","4","-cluster-dns","169.254.20.10","-internal-listen-address","0.0.0.0:8085"]}'
         command:
         - /http-prober-bin/http-prober
+        env:
+        - name: AZURE_CLIENT_ID
+          value: az-client-id
+        - name: AZURE_CLIENT_SECRET
+          value: az-client-secret
+        - name: AZURE_TENANT_ID
+          value: az-tenant-id
+        - name: AZURE_SUBSCRIPTION_ID
+          value: az-subscription-id
         image: docker.io/kubermatic/machine-controller:v1.5.5
         livenessProbe:
           failureThreshold: 3

--- a/api/pkg/resources/test/fixtures/deployment-azure-1.11.1-machine-controller-webhook.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-azure-1.11.1-machine-controller-webhook.yaml
@@ -33,6 +33,15 @@ spec:
         - '{"command":"/usr/local/bin/webhook","args":["-kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","-logtostderr","-v","4","-listen-address","0.0.0.0:9876"]}'
         command:
         - /http-prober-bin/http-prober
+        env:
+        - name: AZURE_CLIENT_ID
+          value: az-client-id
+        - name: AZURE_CLIENT_SECRET
+          value: az-client-secret
+        - name: AZURE_TENANT_ID
+          value: az-tenant-id
+        - name: AZURE_SUBSCRIPTION_ID
+          value: az-subscription-id
         image: docker.io/kubermatic/machine-controller:v1.5.5
         livenessProbe:
           failureThreshold: 8

--- a/api/pkg/resources/test/fixtures/deployment-azure-1.11.1-machine-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-azure-1.11.1-machine-controller.yaml
@@ -36,6 +36,15 @@ spec:
         - '{"command":"/usr/local/bin/machine-controller","args":["-kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","-logtostderr","-v","4","-cluster-dns","169.254.20.10","-internal-listen-address","0.0.0.0:8085"]}'
         command:
         - /http-prober-bin/http-prober
+        env:
+        - name: AZURE_CLIENT_ID
+          value: az-client-id
+        - name: AZURE_CLIENT_SECRET
+          value: az-client-secret
+        - name: AZURE_TENANT_ID
+          value: az-tenant-id
+        - name: AZURE_SUBSCRIPTION_ID
+          value: az-subscription-id
         image: docker.io/kubermatic/machine-controller:v1.5.5
         livenessProbe:
           failureThreshold: 3

--- a/api/pkg/resources/test/fixtures/deployment-azure-1.12.0-machine-controller-webhook.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-azure-1.12.0-machine-controller-webhook.yaml
@@ -33,6 +33,15 @@ spec:
         - '{"command":"/usr/local/bin/webhook","args":["-kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","-logtostderr","-v","4","-listen-address","0.0.0.0:9876"]}'
         command:
         - /http-prober-bin/http-prober
+        env:
+        - name: AZURE_CLIENT_ID
+          value: az-client-id
+        - name: AZURE_CLIENT_SECRET
+          value: az-client-secret
+        - name: AZURE_TENANT_ID
+          value: az-tenant-id
+        - name: AZURE_SUBSCRIPTION_ID
+          value: az-subscription-id
         image: docker.io/kubermatic/machine-controller:v1.5.5
         livenessProbe:
           failureThreshold: 8

--- a/api/pkg/resources/test/fixtures/deployment-azure-1.12.0-machine-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-azure-1.12.0-machine-controller.yaml
@@ -36,6 +36,15 @@ spec:
         - '{"command":"/usr/local/bin/machine-controller","args":["-kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","-logtostderr","-v","4","-cluster-dns","169.254.20.10","-internal-listen-address","0.0.0.0:8085"]}'
         command:
         - /http-prober-bin/http-prober
+        env:
+        - name: AZURE_CLIENT_ID
+          value: az-client-id
+        - name: AZURE_CLIENT_SECRET
+          value: az-client-secret
+        - name: AZURE_TENANT_ID
+          value: az-tenant-id
+        - name: AZURE_SUBSCRIPTION_ID
+          value: az-subscription-id
         image: docker.io/kubermatic/machine-controller:v1.5.5
         livenessProbe:
           failureThreshold: 3

--- a/api/pkg/resources/test/fixtures/deployment-azure-1.13.0-machine-controller-webhook.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-azure-1.13.0-machine-controller-webhook.yaml
@@ -33,6 +33,15 @@ spec:
         - '{"command":"/usr/local/bin/webhook","args":["-kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","-logtostderr","-v","4","-listen-address","0.0.0.0:9876"]}'
         command:
         - /http-prober-bin/http-prober
+        env:
+        - name: AZURE_CLIENT_ID
+          value: az-client-id
+        - name: AZURE_CLIENT_SECRET
+          value: az-client-secret
+        - name: AZURE_TENANT_ID
+          value: az-tenant-id
+        - name: AZURE_SUBSCRIPTION_ID
+          value: az-subscription-id
         image: docker.io/kubermatic/machine-controller:v1.5.5
         livenessProbe:
           failureThreshold: 8

--- a/api/pkg/resources/test/fixtures/deployment-azure-1.13.0-machine-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-azure-1.13.0-machine-controller.yaml
@@ -36,6 +36,15 @@ spec:
         - '{"command":"/usr/local/bin/machine-controller","args":["-kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","-logtostderr","-v","4","-cluster-dns","169.254.20.10","-internal-listen-address","0.0.0.0:8085"]}'
         command:
         - /http-prober-bin/http-prober
+        env:
+        - name: AZURE_CLIENT_ID
+          value: az-client-id
+        - name: AZURE_CLIENT_SECRET
+          value: az-client-secret
+        - name: AZURE_TENANT_ID
+          value: az-tenant-id
+        - name: AZURE_SUBSCRIPTION_ID
+          value: az-subscription-id
         image: docker.io/kubermatic/machine-controller:v1.5.5
         livenessProbe:
           failureThreshold: 3

--- a/api/pkg/resources/test/fixtures/machine-azure.yaml
+++ b/api/pkg/resources/test/fixtures/machine-azure.yaml
@@ -11,19 +11,19 @@ spec:
       cloudProviderSpec:
         assignPublicIP: true
         availabilitySet: ""
-        clientID: 32hrf23oh89f32
-        clientSecret: rbyughv438oh32f23v2
+        clientID: ""
+        clientSecret: ""
         location: westeurope
         resourceGroup: cluster-azurecluster-1a2b3c4d5e
         routeTableName: cluster-azurecluster-1a2b3c4d5e
         securityGroupName: ""
         subnetName: cluster-azurecluster-1a2b3c4d5e
-        subscriptionID: 32h9q8r8xqp3h9
+        subscriptionID: ""
         tags:
           KubernetesCluster: azurecluster-1a2b3c4d5e
           foo: bar
           system-cluster: azurecluster-1a2b3c4d5e
-        tenantID: 38w7giefb32fhifw3q
+        tenantID: ""
         vmSize: Standard_B1ms
         vnetName: cluster-azurecluster-1a2b3c4d5e
       operatingSystem: coreos


### PR DESCRIPTION
Fixes https://github.com/kubermatic/kubermatic/issues/3555

This is done so that credentials are not embedded in the Machine object anymore and won't be visible to anyone who can see the Machine object.

**Does this PR introduce a user-facing change?**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If  no release note is required, just write "NONE".
-->
```release-note
NONE
```
