### PR TITLE
Nodeport proxy: Dont rotate nodeport when target services port changed

### DIFF
--- a/api/cmd/nodeport-proxy/README.md
+++ b/api/cmd/nodeport-proxy/README.md
@@ -7,6 +7,4 @@ The NodePort-Proxy watches services with the annotation `nodeport-proxy.k8s.io/e
 
 ## Release
 
-```bash
-TAG=v2.0.0 make docker
-```
+The nodeportproxy gets automatically built in CI.

--- a/api/cmd/nodeport-proxy/lb-updater/main_test.go
+++ b/api/cmd/nodeport-proxy/lb-updater/main_test.go
@@ -1,0 +1,505 @@
+package main
+
+import (
+	"context"
+	"encoding/json"
+	"testing"
+
+	"github.com/go-test/deep"
+
+	corev1 "k8s.io/api/core/v1"
+	apiequality "k8s.io/apimachinery/pkg/api/equality"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/util/intstr"
+	ctrlruntimeclient "sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+	"sigs.k8s.io/controller-runtime/pkg/reconcile"
+)
+
+func init() {
+	exposeAnnotationKey = defaultExposeAnnotationKey
+}
+
+func TestReconciliation(t *testing.T) {
+	testCases := []struct {
+		name             string
+		initialServices  []runtime.Object
+		expectedServices corev1.ServiceList
+	}{
+		{
+			name: "Service without annotation gets ignored",
+			initialServices: []runtime.Object{
+				&corev1.Service{
+					Spec: corev1.ServiceSpec{
+						ClusterIP: "1.2.3.4",
+						Ports: []corev1.ServicePort{{
+							Port:     443,
+							NodePort: 30443,
+						}},
+					},
+				},
+				&corev1.Service{
+					ObjectMeta: metav1.ObjectMeta{
+						Namespace: "lb-ns",
+						Name:      "lb",
+					},
+					Spec: corev1.ServiceSpec{
+						ClusterIP: "1.2.3.4",
+					},
+				},
+			},
+			expectedServices: corev1.ServiceList{
+				Items: []corev1.Service{
+					{
+						Spec: corev1.ServiceSpec{
+							ClusterIP: "1.2.3.4",
+							Ports: []corev1.ServicePort{{
+								Port:     443,
+								NodePort: 30443,
+							}},
+						},
+					},
+					{
+						ObjectMeta: metav1.ObjectMeta{
+							Namespace: "lb-ns",
+							Name:      "lb",
+						},
+						Spec: corev1.ServiceSpec{
+							ClusterIP: "1.2.3.4",
+							Ports: []corev1.ServicePort{{
+								Name:       "healthz",
+								Port:       8002,
+								TargetPort: intstr.FromInt(8002),
+								Protocol:   corev1.ProtocolTCP,
+							}},
+						},
+					},
+				},
+			},
+		},
+		{
+			name: "Service without clusterIP gets ignored",
+			initialServices: []runtime.Object{
+				&corev1.Service{
+					ObjectMeta: metav1.ObjectMeta{
+						Annotations: map[string]string{"nodeport-proxy.k8s.io/expose": "true"},
+					},
+					Spec: corev1.ServiceSpec{
+						Ports: []corev1.ServicePort{{
+							Port:     443,
+							NodePort: 30443,
+						}},
+					},
+				},
+				&corev1.Service{
+					ObjectMeta: metav1.ObjectMeta{
+						Namespace: "lb-ns",
+						Name:      "lb",
+					},
+					Spec: corev1.ServiceSpec{
+						ClusterIP: "1.2.3.4",
+					},
+				},
+			},
+			expectedServices: corev1.ServiceList{
+				Items: []corev1.Service{
+					{
+						ObjectMeta: metav1.ObjectMeta{
+							Annotations: map[string]string{"nodeport-proxy.k8s.io/expose": "true"},
+						},
+						Spec: corev1.ServiceSpec{
+							Ports: []corev1.ServicePort{{
+								Port:     443,
+								NodePort: 30443,
+							}},
+						},
+					},
+					{
+						ObjectMeta: metav1.ObjectMeta{
+							Namespace: "lb-ns",
+							Name:      "lb",
+						},
+						Spec: corev1.ServiceSpec{
+							ClusterIP: "1.2.3.4",
+							Ports: []corev1.ServicePort{{
+								Name:       "healthz",
+								Port:       8002,
+								TargetPort: intstr.FromInt(8002),
+								Protocol:   corev1.ProtocolTCP,
+							}},
+						},
+					},
+				},
+			},
+		},
+		{
+			name: "Service without NodePort gets ignored",
+			initialServices: []runtime.Object{
+				&corev1.Service{
+					ObjectMeta: metav1.ObjectMeta{
+						Annotations: map[string]string{"nodeport-proxy.k8s.io/expose": "true"},
+					},
+					Spec: corev1.ServiceSpec{
+						ClusterIP: "1.2.3.4",
+						Ports: []corev1.ServicePort{{
+							Port: 443,
+						}},
+					},
+				},
+				&corev1.Service{
+					ObjectMeta: metav1.ObjectMeta{
+						Namespace: "lb-ns",
+						Name:      "lb",
+					},
+				},
+			},
+			expectedServices: corev1.ServiceList{
+				Items: []corev1.Service{
+					{
+						ObjectMeta: metav1.ObjectMeta{
+							Annotations: map[string]string{"nodeport-proxy.k8s.io/expose": "true"},
+						},
+						Spec: corev1.ServiceSpec{
+							ClusterIP: "1.2.3.4",
+							Ports: []corev1.ServicePort{{
+								Port: 443,
+							}},
+						},
+					},
+					{
+						ObjectMeta: metav1.ObjectMeta{
+							Namespace: "lb-ns",
+							Name:      "lb",
+						},
+						Spec: corev1.ServiceSpec{
+							Ports: []corev1.ServicePort{{
+								Name:       "healthz",
+								Port:       8002,
+								TargetPort: intstr.FromInt(8002),
+								Protocol:   corev1.ProtocolTCP,
+							}},
+						},
+					},
+				},
+			},
+		},
+		{
+			name: "Reconciliation with existing port following old nameschema",
+			initialServices: []runtime.Object{
+				&corev1.Service{
+					ObjectMeta: metav1.ObjectMeta{
+						Namespace:   "cluster",
+						Name:        "apiserver",
+						Annotations: map[string]string{"nodeport-proxy.k8s.io/expose": "true"},
+					},
+					Spec: corev1.ServiceSpec{
+						ClusterIP: "1.2.3.4",
+						Ports: []corev1.ServicePort{{
+							Port:     443,
+							NodePort: 30443,
+						}},
+					},
+				},
+				&corev1.Service{
+					ObjectMeta: metav1.ObjectMeta{
+						Namespace: "lb-ns",
+						Name:      "lb",
+					},
+					Spec: corev1.ServiceSpec{
+						Ports: []corev1.ServicePort{{
+							Name:       "cluster-apiserver-443-30443",
+							Port:       30443,
+							TargetPort: intstr.FromInt(30443),
+							NodePort:   31443,
+						}},
+					},
+				},
+			},
+			expectedServices: corev1.ServiceList{
+				Items: []corev1.Service{
+					{
+						ObjectMeta: metav1.ObjectMeta{
+							Namespace:   "cluster",
+							Name:        "apiserver",
+							Annotations: map[string]string{"nodeport-proxy.k8s.io/expose": "true"},
+						},
+						Spec: corev1.ServiceSpec{
+							ClusterIP: "1.2.3.4",
+							Ports: []corev1.ServicePort{{
+								Port:     443,
+								NodePort: 30443,
+							}},
+						},
+					},
+					{
+						ObjectMeta: metav1.ObjectMeta{
+							Namespace: "lb-ns",
+							Name:      "lb",
+						},
+						Spec: corev1.ServiceSpec{
+							Ports: []corev1.ServicePort{
+								{
+									Name:       "cluster-apiserver-443-30443",
+									Port:       30443,
+									TargetPort: intstr.FromInt(30443),
+									NodePort:   31443,
+									Protocol:   corev1.ProtocolTCP,
+								},
+								{
+									Name:       "healthz",
+									Port:       8002,
+									TargetPort: intstr.FromInt(8002),
+									Protocol:   corev1.ProtocolTCP,
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+		{
+			name: "Reconciliation with exiting port following new nameschema",
+			initialServices: []runtime.Object{
+				&corev1.Service{
+					ObjectMeta: metav1.ObjectMeta{
+						Namespace:   "cluster",
+						Name:        "apiserver",
+						Annotations: map[string]string{"nodeport-proxy.k8s.io/expose": "true"},
+					},
+					Spec: corev1.ServiceSpec{
+						ClusterIP: "1.2.3.4",
+						Ports: []corev1.ServicePort{{
+							Port:     443,
+							NodePort: 30443,
+						}},
+					},
+				},
+				&corev1.Service{
+					ObjectMeta: metav1.ObjectMeta{
+						Namespace: "lb-ns",
+						Name:      "lb",
+					},
+					Spec: corev1.ServiceSpec{
+						Ports: []corev1.ServicePort{{
+							Name:       "cluster-apiserver-30443",
+							Port:       30443,
+							TargetPort: intstr.FromInt(30443),
+							NodePort:   31443,
+						}},
+					},
+				},
+			},
+			expectedServices: corev1.ServiceList{
+				Items: []corev1.Service{
+					{
+						ObjectMeta: metav1.ObjectMeta{
+							Namespace:   "cluster",
+							Name:        "apiserver",
+							Annotations: map[string]string{"nodeport-proxy.k8s.io/expose": "true"},
+						},
+						Spec: corev1.ServiceSpec{
+							ClusterIP: "1.2.3.4",
+							Ports: []corev1.ServicePort{{
+								Port:     443,
+								NodePort: 30443,
+							}},
+						},
+					},
+					{
+						ObjectMeta: metav1.ObjectMeta{
+							Namespace: "lb-ns",
+							Name:      "lb",
+						},
+						Spec: corev1.ServiceSpec{
+							Ports: []corev1.ServicePort{
+								{
+									Name:       "cluster-apiserver-30443",
+									Port:       30443,
+									TargetPort: intstr.FromInt(30443),
+									NodePort:   31443,
+									Protocol:   corev1.ProtocolTCP,
+								},
+								{
+									Name:       "healthz",
+									Port:       8002,
+									TargetPort: intstr.FromInt(8002),
+									Protocol:   corev1.ProtocolTCP,
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+		{
+			name: "Reconciliation without existing port uses new nameschema",
+			initialServices: []runtime.Object{
+				&corev1.Service{
+					ObjectMeta: metav1.ObjectMeta{
+						Namespace:   "cluster",
+						Name:        "apiserver",
+						Annotations: map[string]string{"nodeport-proxy.k8s.io/expose": "true"},
+					},
+					Spec: corev1.ServiceSpec{
+						ClusterIP: "1.2.3.4",
+						Ports: []corev1.ServicePort{{
+							Port:     443,
+							NodePort: 30443,
+						}},
+					},
+				},
+				&corev1.Service{
+					ObjectMeta: metav1.ObjectMeta{
+						Namespace: "lb-ns",
+						Name:      "lb",
+					},
+				},
+			},
+			expectedServices: corev1.ServiceList{
+				Items: []corev1.Service{
+					{
+						ObjectMeta: metav1.ObjectMeta{
+							Namespace:   "cluster",
+							Name:        "apiserver",
+							Annotations: map[string]string{"nodeport-proxy.k8s.io/expose": "true"},
+						},
+						Spec: corev1.ServiceSpec{
+							ClusterIP: "1.2.3.4",
+							Ports: []corev1.ServicePort{{
+								Port:     443,
+								NodePort: 30443,
+							}},
+						},
+					},
+					{
+						ObjectMeta: metav1.ObjectMeta{
+							Namespace: "lb-ns",
+							Name:      "lb",
+						},
+						Spec: corev1.ServiceSpec{
+							Ports: []corev1.ServicePort{
+								{
+									Name:       "cluster-apiserver-30443",
+									Port:       30443,
+									TargetPort: intstr.FromInt(30443),
+									Protocol:   corev1.ProtocolTCP,
+								},
+								{
+									Name:       "healthz",
+									Port:       8002,
+									TargetPort: intstr.FromInt(8002),
+									Protocol:   corev1.ProtocolTCP,
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+
+	var breakNow bool
+	for _, tc := range testCases {
+		if breakNow {
+			break
+		}
+		t.Run(tc.name, func(t *testing.T) {
+			client := fake.NewFakeClient(tc.initialServices...)
+			updater := &LBUpdater{
+				lbNamespace: "lb-ns",
+				lbName:      "lb",
+				client:      client,
+			}
+
+			if _, err := updater.Reconcile(reconcile.Request{}); err != nil {
+				t.Fatalf("error reconciling: %v", err)
+			}
+
+			resultingServices := &corev1.ServiceList{}
+			if err := client.List(context.Background(), &ctrlruntimeclient.ListOptions{}, resultingServices); err != nil {
+				t.Fatalf("failed to list services: %v", err)
+			}
+
+			if diff := deep.Equal(*resultingServices, tc.expectedServices); diff != nil {
+				expected, _ := json.Marshal(tc.expectedServices)
+				actual, _ := json.Marshal(*resultingServices)
+				breakNow = true
+				t.Fatalf("resulting services differ from expected services, diff:\n%v, expected:\n%s\nactual:\n%s", diff, expected, actual)
+			}
+		})
+	}
+}
+
+// These tests are here for good reasons. Do not change them and make sure
+// they continue to pass.
+//
+// Desired behavior in a nutshell:
+// * Treat the name of the Port on the LoadBalancer service as canonical source of truth
+// * Copy over the NodePort from the LoadBalancer service
+// * If there is no corresponding port on the LoadBalancer service use the new name schema
+// * If there is no corresponding port on the LoadBalancer service reset the NodePort
+func TestFillNodePortsAndNames(t *testing.T) {
+	testCases := []struct {
+		name      string
+		inputPort corev1.ServicePort
+		lbPorts   []corev1.ServicePort
+		expected  corev1.ServicePort
+	}{
+		{
+			name: "Matching via old name schema",
+			inputPort: corev1.ServicePort{
+				Name:     "namespace-name",
+				Port:     30443,
+				NodePort: 443,
+			},
+			lbPorts: []corev1.ServicePort{{
+				Name:     "namespace-name-443-30443",
+				NodePort: 31443,
+			}},
+			expected: corev1.ServicePort{
+				Name:     "namespace-name-443-30443",
+				Port:     30443,
+				NodePort: 31443,
+			},
+		},
+		{
+			name: "Matching via new name schema",
+			inputPort: corev1.ServicePort{
+				Name:     "namespace-name",
+				Port:     30443,
+				NodePort: 443,
+			},
+			lbPorts: []corev1.ServicePort{{
+				Name:     "namespace-name-30443",
+				NodePort: 31443,
+			}},
+			expected: corev1.ServicePort{
+				Name:     "namespace-name-30443",
+				Port:     30443,
+				NodePort: 31443,
+			},
+		},
+		{
+			name: "Default to new name schema, reset NodePort",
+			inputPort: corev1.ServicePort{
+				Name:     "namespace-name",
+				Port:     30443,
+				NodePort: 443,
+			},
+			expected: corev1.ServicePort{
+				Name: "namespace-name-30443",
+				Port: 30443,
+			},
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			result := fillNodePortsAndNames([]corev1.ServicePort{tc.inputPort}, tc.lbPorts)
+			if !apiequality.Semantic.DeepEqual(result[0], tc.expected) {
+				t.Fatalf("result differs from expected, result:\n%v\nexpected:\n%v", result[0], tc.expected)
+			}
+		})
+	}
+}

--- a/api/cmd/nodeport-proxy/release.sh
+++ b/api/cmd/nodeport-proxy/release.sh
@@ -1,8 +1,0 @@
-#!/usr/bin/env bash
-
-set -euo pipefail
-
-TAG=v2.2.2
-export TAG
-make docker
-docker push quay.io/kubermatic/nodeport-proxy:${TAG}

--- a/api/hack/ci/ci-sync-charts.sh
+++ b/api/hack/ci/ci-sync-charts.sh
@@ -6,7 +6,7 @@ apk add --no-cache -U git bash openssh
 cd $(dirname $0)/../../..
 git fetch
 export LATEST_VERSION=$(git describe --tags --abbrev=0)
-sed -i "s/__KUBERMATIC_TAG__/$LATEST_VERSION/g" config/kubermatic/values.yaml config/kubermatic/Chart.yaml
+sed -i "s/__KUBERMATIC_TAG__/$LATEST_VERSION/g" config/*/*.yaml
 git config --global user.email "dev@loodse.com"
 git config --global user.name "Prow CI Robot"
 git config --global core.sshCommand 'ssh -o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no'

--- a/api/hack/deploy.sh
+++ b/api/hack/deploy.sh
@@ -64,9 +64,9 @@ function initTiller() {
   unset TEST_NAME
 }
 
-sed -i "s/__KUBERMATIC_TAG__/${GIT_HEAD_HASH}/g" ./config/kubermatic/Chart.yaml
-sed -i "s/__KUBERMATIC_TAG__/${GIT_HEAD_HASH}/g" ./config/kubermatic/values.yaml
-sed -i "s/__KUBERMATIC_TAG__/${GIT_HEAD_HASH}/g" ./config/kubermatic-operator/*
+sed -i "s/__KUBERMATIC_TAG__/${GIT_HEAD_HASH}/g" ./config/kubermatic/*.yaml
+sed -i "s/__KUBERMATIC_TAG__/${GIT_HEAD_HASH}/g" ./config/kubermatic-operator/*.yaml
+sed -i "s/__KUBERMATIC_TAG__/${GIT_HEAD_HASH}/g" ./config/nodeport-proxy/*.yaml
 
 echodate "Deploying ${DEPLOY_STACK} stack..."
 case "${DEPLOY_STACK}" in

--- a/config/nodeport-proxy/Chart.yaml
+++ b/config/nodeport-proxy/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 name: nodeport-proxy
 version: 1.4.1
-appVersion: v2.2.2
+appVersion: __KUBERMATIC_TAG__
 description: Kubermatic nodeport-proxy
 keywords:
 - kubermatic

--- a/config/nodeport-proxy/values.yaml
+++ b/config/nodeport-proxy/values.yaml
@@ -2,7 +2,7 @@ nodePortProxy:
   replicas: 3
   image:
     repository: "quay.io/kubermatic/nodeport-proxy"
-    tag: v2.2.2
+    tag: "__KUBERMATIC_TAG__"
   envoy:
     image:
       repository: "docker.io/envoyproxy/envoy-alpine"


### PR DESCRIPTION
**What this PR does / why we need it**:

Fixes the nodeport proxy to not rotate nodeports

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #4210

**Special notes for your reviewer**:

**Documentation**:
<!-- Add links to the related documentation changes related to this pull request. E.g. the link to the kubermatic/docs pullrequest. -->

**Does this PR introduce a user-facing change?**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If  no release note is required, just write "NONE".
-->
```release-note
none
```

/assign @thz 
/assign @xrstf 

Please review thoroughly.
