### PR TITLE
sync-charts: create matching version tags in the installer repo

### DIFF
--- a/api/hack/ci/ci-sync-charts.sh
+++ b/api/hack/ci/ci-sync-charts.sh
@@ -144,7 +144,8 @@ cd ${TARGET_DIR}
 git add .
 if ! git status|grep 'nothing to commit'; then
   git commit -m "Syncing charts from release ${LATEST_VERSION}"
-  git push origin ${INSTALLER_BRANCH}
+  git tag $LATEST_VERSION
+  git push --tags origin ${INSTALLER_BRANCH}
 fi
 
 cd ..


### PR DESCRIPTION
**What this PR does / why we need it**:
```release-note
NONE
```
