### PR TITLE
Fix deployment to offline env

### DIFF
--- a/api/hack/ci/ci-deploy-offline.sh
+++ b/api/hack/ci/ci-deploy-offline.sh
@@ -56,7 +56,8 @@ helm template oauth | ../api/hack/retag-images.sh
 helm template iap | ../api/hack/retag-images.sh
 helm template minio | ../api/hack/retag-images.sh
 helm template s3-exporter | ../api/hack/retag-images.sh
-helm template nodeport-proxy | ../api/hack/retag-images.sh
+helm template nodeport-proxy --set=nodePortProxy.image.tag=${GIT_HEAD_HASH}	\
+	| ../api/hack/retag-images.sh
 
 helm template monitoring/prometheus | ../api/hack/retag-images.sh
 helm template monitoring/node-exporter | ../api/hack/retag-images.sh
@@ -69,7 +70,7 @@ helm template logging/elasticsearch | ../api/hack/retag-images.sh
 helm template logging/fluentbit | ../api/hack/retag-images.sh
 helm template logging/kibana | ../api/hack/retag-images.sh
 
-HELM_EXTRA_ARGS="--set kubermatic.controller.image.tag=${GIT_HEAD_HASH},kubermatic.api.image.tag=${GIT_HEAD_HASH},kubermatic.masterController.image.tag=${GIT_HEAD_HASH},kubermatic.controller.addons.kubernetes.image.tag=${GIT_HEAD_HASH}"
+HELM_EXTRA_ARGS="--set kubermatic.controller.image.tag=${GIT_HEAD_HASH},kubermatic.api.image.tag=${GIT_HEAD_HASH},kubermatic.masterController.image.tag=${GIT_HEAD_HASH},kubermatic.controller.addons.kubernetes.image.tag=${GIT_HEAD_HASH},kubermatic.controller.addons.openshift.image.tag=${GIT_HEAD_HASH}"
 helm template ${HELM_EXTRA_ARGS} kubermatic | ../api/hack/retag-images.sh
 
 # Push a tiller image


### PR DESCRIPTION
This is currently broken because the following PRs started moving some
images to use the GIT_HEAD_HASH as tag, but didn't bother to update the
deployment scripting:

* https://github.com/kubermatic/kubermatic/pull/4213
* https://github.com/kubermatic/kubermatic/pull/4114

**What this PR does / why we need it**:

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Documentation**:
<!-- Add links to the related documentation changes related to this pull request. E.g. the link to the kubermatic/docs pullrequest. -->

**Does this PR introduce a user-facing change?**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If  no release note is required, just write "NONE".
-->
```release-note
none
```
