### PR TITLE
AWS: Decouple Get{Zone,Subnet,VPC} from cloud provider implementation

### DIFF
--- a/api/cmd/kubermatic-api/main.go
+++ b/api/cmd/kubermatic-api/main.go
@@ -225,7 +225,6 @@ func createInitProviders(options serverRunOptions) (providers, error) {
 		eventRecorderProvider:                 eventRecorderProvider,
 		clusterProviderGetter:                 clusterProviderGetter,
 		seedsGetter:                           seedsGetter,
-		seedClientGetter:                      seedClientGetter,
 		addons:                                addonProviderGetter}, nil
 }
 
@@ -290,7 +289,6 @@ func createAPIHandler(options serverRunOptions, prov providers, oidcIssuerVerifi
 
 	r := handler.NewRouting(
 		prov.seedsGetter,
-		prov.seedClientGetter,
 		prov.clusterProviderGetter,
 		prov.addons,
 		prov.sshKey,

--- a/api/cmd/kubermatic-api/options.go
+++ b/api/cmd/kubermatic-api/options.go
@@ -150,6 +150,5 @@ type providers struct {
 	eventRecorderProvider                 provider.EventRecorderProvider
 	clusterProviderGetter                 provider.ClusterProviderGetter
 	seedsGetter                           provider.SeedsGetter
-	seedClientGetter                      provider.SeedClientGetter
 	addons                                provider.AddonProviderGetter
 }

--- a/api/pkg/handler/routes_v1.go
+++ b/api/pkg/handler/routes_v1.go
@@ -562,7 +562,7 @@ func (r Routing) listAWSZones() http.Handler {
 		endpoint.Chain(
 			middleware.TokenVerifier(r.tokenVerifiers),
 			middleware.UserSaver(r.userProvider),
-		)(provider.AWSZoneEndpoint(r.presetsManager, r.seedsGetter, r.privilegedSeedClientGetter)),
+		)(provider.AWSZoneEndpoint(r.presetsManager, r.seedsGetter)),
 		provider.DecodeAWSZoneReq,
 		encodeJSON,
 		r.defaultServerOptions()...,
@@ -584,7 +584,7 @@ func (r Routing) listAWSSubnets() http.Handler {
 		endpoint.Chain(
 			middleware.TokenVerifier(r.tokenVerifiers),
 			middleware.UserSaver(r.userProvider),
-		)(provider.AWSSubnetEndpoint(r.presetsManager, r.seedsGetter, r.privilegedSeedClientGetter)),
+		)(provider.AWSSubnetEndpoint(r.presetsManager, r.seedsGetter)),
 		provider.DecodeAWSSubnetReq,
 		encodeJSON,
 		r.defaultServerOptions()...,
@@ -606,7 +606,7 @@ func (r Routing) listAWSVPCS() http.Handler {
 		endpoint.Chain(
 			middleware.TokenVerifier(r.tokenVerifiers),
 			middleware.UserSaver(r.userProvider),
-		)(provider.AWSVPCEndpoint(r.presetsManager, r.seedsGetter, r.privilegedSeedClientGetter)),
+		)(provider.AWSVPCEndpoint(r.presetsManager, r.seedsGetter)),
 		provider.DecodeAWSVPCReq,
 		encodeJSON,
 		r.defaultServerOptions()...,

--- a/api/pkg/handler/routing.go
+++ b/api/pkg/handler/routing.go
@@ -29,7 +29,6 @@ type UpdateManager interface {
 // Routing represents an object which binds endpoints to http handlers.
 type Routing struct {
 	seedsGetter                 provider.SeedsGetter
-	privilegedSeedClientGetter  provider.SeedClientGetter
 	sshKeyProvider              provider.SSHKeyProvider
 	userProvider                provider.UserProvider
 	serviceAccountProvider      provider.ServiceAccountProvider
@@ -56,7 +55,6 @@ type Routing struct {
 // NewRouting creates a new Routing.
 func NewRouting(
 	seedsGetter provider.SeedsGetter,
-	seedClientGetter provider.SeedClientGetter,
 	clusterProviderGetter provider.ClusterProviderGetter,
 	addonProviderGetter provider.AddonProviderGetter,
 	newSSHKeyProvider provider.SSHKeyProvider,
@@ -80,7 +78,6 @@ func NewRouting(
 ) Routing {
 	return Routing{
 		seedsGetter:                 seedsGetter,
-		privilegedSeedClientGetter:  seedClientGetter,
 		clusterProviderGetter:       clusterProviderGetter,
 		addonProviderGetter:         addonProviderGetter,
 		sshKeyProvider:              newSSHKeyProvider,

--- a/api/pkg/handler/test/hack/hack.go
+++ b/api/pkg/handler/test/hack/hack.go
@@ -23,7 +23,6 @@ import (
 // for example handler package uses v1/dc and v1/dc needs handler for testing
 func NewTestRouting(
 	seedsGetter provider.SeedsGetter,
-	seedClientGetter provider.SeedClientGetter,
 	clusterProvidersGetter provider.ClusterProviderGetter,
 	addonProviderGetter provider.AddonProviderGetter,
 	sshKeyProvider provider.SSHKeyProvider,
@@ -47,7 +46,6 @@ func NewTestRouting(
 	updateManager := version.New(versions, updates)
 	r := handler.NewRouting(
 		seedsGetter,
-		seedClientGetter,
 		clusterProvidersGetter,
 		addonProviderGetter,
 		sshKeyProvider,

--- a/api/pkg/handler/test/helper.go
+++ b/api/pkg/handler/test/helper.go
@@ -120,7 +120,6 @@ func GetUser(email, id, name string, admin bool) apiv1.User {
 // it is meant to be used by legacy handler.createTestEndpointAndGetClients function
 type newRoutingFunc func(
 	seedsGetter provider.SeedsGetter,
-	privilgedClientGetter provider.SeedClientGetter,
 	clusterProviderGetter provider.ClusterProviderGetter,
 	addonProviderGetter provider.AddonProviderGetter,
 	newSSHKeyProvider provider.SSHKeyProvider,
@@ -149,9 +148,6 @@ func initTestEndpoint(user apiv1.User, seedsGetter provider.SeedsGetter, kubeObj
 	allObjects = append(allObjects, machineObjects...)
 	allObjects = append(allObjects, kubermaticObjects...)
 	fakeClient := fakectrlruntimeclient.NewFakeClient(allObjects...)
-	seedClientGetter := func(_ *kubermaticv1.Seed) (ctrlruntimeclient.Client, error) {
-		return fakeClient, nil
-	}
 	kubermaticClient := kubermaticfakeclentset.NewSimpleClientset(kubermaticObjects...)
 	kubermaticInformerFactory := kubermaticinformers.NewSharedInformerFactory(kubermaticClient, 10*time.Millisecond)
 	kubernetesClient := fakerestclient.NewSimpleClientset(kubeObjects...)
@@ -257,7 +253,6 @@ func initTestEndpoint(user apiv1.User, seedsGetter provider.SeedsGetter, kubeObj
 
 	mainRouter := routingFunc(
 		seedsGetter,
-		seedClientGetter,
 		clusterProviderGetter,
 		addonProviderGetter,
 		sshKeyProvider,

--- a/api/pkg/handler/v1/provider/aws.go
+++ b/api/pkg/handler/v1/provider/aws.go
@@ -15,12 +15,9 @@ import (
 	"github.com/kubermatic/kubermatic/api/pkg/handler/v1/common"
 	"github.com/kubermatic/kubermatic/api/pkg/handler/v1/dc"
 	"github.com/kubermatic/kubermatic/api/pkg/provider"
-	awsProvider "github.com/kubermatic/kubermatic/api/pkg/provider/cloud/aws"
+	awsprovider "github.com/kubermatic/kubermatic/api/pkg/provider/cloud/aws"
 	kubernetesprovider "github.com/kubermatic/kubermatic/api/pkg/provider/kubernetes"
 	"github.com/kubermatic/kubermatic/api/pkg/util/errors"
-	"github.com/kubermatic/machine-controller/pkg/providerconfig"
-
-	ctrlruntimeclient "sigs.k8s.io/controller-runtime/pkg/client"
 )
 
 var data *ec2.InstanceData
@@ -234,14 +231,14 @@ func AWSZoneEndpoint(credentialManager common.PresetsManager, seedsGetter provid
 	return func(ctx context.Context, request interface{}) (interface{}, error) {
 		req := request.(AWSZoneReq)
 
-		keyID := req.AccessKeyID
-		keySecret := req.SecretAccessKey
+		accessKeyID := req.AccessKeyID
+		secretAccessKey := req.SecretAccessKey
 
 		if len(req.Credential) > 0 && credentialManager.GetPresets().AWS.Credentials != nil {
 			for _, credential := range credentialManager.GetPresets().AWS.Credentials {
 				if credential.Name == req.Credential {
-					keyID = credential.AccessKeyID
-					keySecret = credential.SecretAccessKey
+					accessKeyID = credential.AccessKeyID
+					secretAccessKey = credential.SecretAccessKey
 					break
 				}
 			}
@@ -251,15 +248,11 @@ func AWSZoneEndpoint(credentialManager common.PresetsManager, seedsGetter provid
 		if err != nil {
 			return nil, errors.New(http.StatusInternalServerError, fmt.Sprintf("failed to list seeds: %v", err))
 		}
-		seed, datacenter, err := provider.DatacenterFromSeedMap(seeds, req.DC)
+		_, datacenter, err := provider.DatacenterFromSeedMap(seeds, req.DC)
 		if err != nil {
 			return nil, errors.NewBadRequest("%v", err)
 		}
-		privilegedSeedClient, err := privilegedSeedClientGetter(seed)
-		if err != nil {
-			return nil, errors.New(http.StatusInternalServerError, fmt.Sprintf("failed to get client for seed: %v", err))
-		}
-		return listAWSZones(ctx, keyID, keySecret, datacenter, privilegedSeedClient, nil)
+		return listAWSZones(accessKeyID, secretAccessKey, datacenter)
 	}
 }
 
@@ -295,31 +288,23 @@ func AWSZoneWithClusterCredentialsEndpoint(projectProvider provider.ProjectProvi
 			return nil, errors.New(http.StatusInternalServerError, "clusterprovider is not a kubernetesprovider.Clusterprovider")
 		}
 
-		keyID := cluster.Spec.Cloud.AWS.AccessKeyID
-		keySecret := cluster.Spec.Cloud.AWS.SecretAccessKey
-		return listAWSZones(ctx, keyID, keySecret, datacenter, assertedClusterProvider.GetSeedClusterAdminRuntimeClient(), cluster.Spec.Cloud.AWS.CredentialsReference)
+		secretKeySelector := provider.SecretKeySelectorValueFuncFactory(ctx, assertedClusterProvider.GetSeedClusterAdminRuntimeClient())
+		accessKeyID, secretAccessKey, err := awsprovider.GetCredentialsForCluster(cluster.Spec.Cloud, secretKeySelector)
+		if err != nil {
+			return nil, err
+		}
+		return listAWSZones(accessKeyID, secretAccessKey, datacenter)
 	}
 }
 
-func listAWSZones(ctx context.Context, keyID, keySecret string, datacenter *kubermaticv1.Datacenter, privilegedSeedClient ctrlruntimeclient.Client, credRef *providerconfig.GlobalSecretKeySelector) (apiv1.AWSZoneList, error) {
+func listAWSZones(accessKeyID, secretAccessKey string, datacenter *kubermaticv1.Datacenter) (apiv1.AWSZoneList, error) {
 	zones := apiv1.AWSZoneList{}
 
 	if datacenter.Spec.AWS == nil {
 		return nil, errors.NewBadRequest("cluster is not in an AWS Datacenter")
 	}
 
-	ec2, err := awsProvider.NewCloudProvider(datacenter, provider.SecretKeySelectorValueFuncFactory(ctx, privilegedSeedClient))
-	if err != nil {
-		return nil, err
-	}
-
-	zoneResults, err := ec2.GetAvailabilityZonesInRegion(kubermaticv1.CloudSpec{
-		AWS: &kubermaticv1.AWSCloudSpec{
-			AccessKeyID:          keyID,
-			SecretAccessKey:      keySecret,
-			CredentialsReference: credRef,
-		},
-	}, datacenter.Spec.AWS.Region)
+	zoneResults, err := awsprovider.GetAvailabilityZonesInRegion(accessKeyID, secretAccessKey, datacenter.Spec.AWS.Region)
 	if err != nil {
 		return nil, err
 	}
@@ -336,15 +321,15 @@ func AWSSubnetEndpoint(credentialManager common.PresetsManager, seedsGetter prov
 	return func(ctx context.Context, request interface{}) (interface{}, error) {
 		req := request.(AWSSubnetReq)
 
-		keyID := req.AccessKeyID
-		keySecret := req.SecretAccessKey
+		accessKeyID := req.AccessKeyID
+		secretAccessKey := req.SecretAccessKey
 		vpcID := req.VPC
 
 		if len(req.Credential) > 0 && credentialManager.GetPresets().AWS.Credentials != nil {
 			for _, credential := range credentialManager.GetPresets().AWS.Credentials {
 				if credential.Name == req.Credential {
-					keyID = credential.AccessKeyID
-					keySecret = credential.SecretAccessKey
+					accessKeyID = credential.AccessKeyID
+					secretAccessKey = credential.SecretAccessKey
 					vpcID = credential.VPCID
 					break
 				}
@@ -355,16 +340,12 @@ func AWSSubnetEndpoint(credentialManager common.PresetsManager, seedsGetter prov
 		if err != nil {
 			return nil, errors.New(http.StatusInternalServerError, fmt.Sprintf("failed to list seeds: %v", err))
 		}
-		seed, dc, err := provider.DatacenterFromSeedMap(seeds, req.DC)
+		_, dc, err := provider.DatacenterFromSeedMap(seeds, req.DC)
 		if err != nil {
 			return nil, errors.NewBadRequest(err.Error())
 		}
-		privilegedSeedClient, err := privilegedSeedClientGetter(seed)
-		if err != nil {
-			return nil, errors.New(http.StatusInternalServerError, fmt.Sprintf("failed to get client for seed: %v", err))
-		}
 
-		return listAWSSubnets(ctx, keyID, keySecret, vpcID, dc, privilegedSeedClient, nil)
+		return listAWSSubnets(accessKeyID, secretAccessKey, vpcID, dc)
 	}
 }
 
@@ -399,35 +380,28 @@ func AWSSubnetWithClusterCredentialsEndpoint(projectProvider provider.ProjectPro
 			return nil, errors.New(http.StatusInternalServerError, "failed to assert clusterProvider")
 		}
 
-		keyID := cluster.Spec.Cloud.AWS.AccessKeyID
-		keySecret := cluster.Spec.Cloud.AWS.SecretAccessKey
-		return listAWSSubnets(ctx, keyID, keySecret, cluster.Spec.Cloud.AWS.VPCID, dc, assertedClusterProvider.GetSeedClusterAdminRuntimeClient(), cluster.Spec.Cloud.AWS.CredentialsReference)
+		secretKeySelector := provider.SecretKeySelectorValueFuncFactory(ctx, assertedClusterProvider.GetSeedClusterAdminRuntimeClient())
+		accessKeyID, secretAccessKey, err := awsprovider.GetCredentialsForCluster(cluster.Spec.Cloud, secretKeySelector)
+		if err != nil {
+			return nil, err
+		}
+
+		return listAWSSubnets(accessKeyID, secretAccessKey, cluster.Spec.Cloud.AWS.VPCID, dc)
 	}
 }
 
-func listAWSSubnets(ctx context.Context, keyID, keySecret, vpcID string, datacenter *kubermaticv1.Datacenter, privilegedSeedClient ctrlruntimeclient.Client, credRef *providerconfig.GlobalSecretKeySelector) (apiv1.AWSSubnetList, error) {
-	subnets := apiv1.AWSSubnetList{}
+func listAWSSubnets(accessKeyID, secretAccessKey, vpcID string, datacenter *kubermaticv1.Datacenter) (apiv1.AWSSubnetList, error) {
 
 	if datacenter.Spec.AWS == nil {
 		return nil, errors.NewBadRequest("datacenter is not an AWS datacenter")
 	}
 
-	ec2, err := awsProvider.NewCloudProvider(datacenter, provider.SecretKeySelectorValueFuncFactory(ctx, privilegedSeedClient))
-	if err != nil {
-		return nil, fmt.Errorf("couldn't create cloud provider: %v", err)
-	}
-
-	subnetResults, err := ec2.GetSubnets(kubermaticv1.CloudSpec{
-		AWS: &kubermaticv1.AWSCloudSpec{
-			AccessKeyID:          keyID,
-			SecretAccessKey:      keySecret,
-			CredentialsReference: credRef,
-		},
-	}, vpcID)
+	subnetResults, err := awsprovider.GetSubnets(accessKeyID, secretAccessKey, datacenter.Spec.AWS.Region, vpcID)
 	if err != nil {
 		return nil, fmt.Errorf("couldn't get subnets: %v", err)
 	}
 
+	subnets := apiv1.AWSSubnetList{}
 	for _, s := range subnetResults {
 		subnetTags := []apiv1.AWSTag{}
 		var subnetName string
@@ -465,7 +439,7 @@ func listAWSSubnets(ctx context.Context, keyID, keySecret, vpcID string, datacen
 
 	}
 
-	return subnets, err
+	return subnets, nil
 }
 
 // AWSVPCEndpoint handles the request to list AWS VPC's, using provided credentials
@@ -473,14 +447,14 @@ func AWSVPCEndpoint(credentialManager common.PresetsManager, seedsGetter provide
 	return func(ctx context.Context, request interface{}) (interface{}, error) {
 		req := request.(AWSVPCReq)
 
-		keyID := req.AccessKeyID
-		keySecret := req.SecretAccessKey
+		accessKeyID := req.AccessKeyID
+		secretAccessKey := req.SecretAccessKey
 
 		if len(req.Credential) > 0 && credentialManager.GetPresets().AWS.Credentials != nil {
 			for _, credential := range credentialManager.GetPresets().AWS.Credentials {
 				if credential.Name == req.Credential {
-					keyID = credential.AccessKeyID
-					keySecret = credential.SecretAccessKey
+					accessKeyID = credential.AccessKeyID
+					secretAccessKey = credential.SecretAccessKey
 					break
 				}
 			}
@@ -490,41 +464,27 @@ func AWSVPCEndpoint(credentialManager common.PresetsManager, seedsGetter provide
 		if err != nil {
 			return nil, errors.New(http.StatusInternalServerError, fmt.Sprintf("failed to list seeds: %v", err))
 		}
-		seed, datacenter, err := provider.DatacenterFromSeedMap(seeds, req.DC)
+		_, datacenter, err := provider.DatacenterFromSeedMap(seeds, req.DC)
 		if err != nil {
 			return nil, errors.NewBadRequest(err.Error())
 		}
-		privilegedSeedClient, err := privilegedSeedClientGetter(seed)
-		if err != nil {
-			return nil, errors.New(http.StatusInternalServerError, fmt.Sprintf("failed to get client for seed: %v", err))
-		}
 
-		return listAWSVPCS(ctx, keyID, keySecret, datacenter, privilegedSeedClient)
+		return listAWSVPCS(accessKeyID, secretAccessKey, datacenter)
 	}
 }
 
-func listAWSVPCS(ctx context.Context, keyID, keySecret string, datacenter *kubermaticv1.Datacenter, privilegedSeedClient ctrlruntimeclient.Client) (apiv1.AWSVPCList, error) {
-	vpcs := apiv1.AWSVPCList{}
+func listAWSVPCS(accessKeyID, secretAccessKey string, datacenter *kubermaticv1.Datacenter) (apiv1.AWSVPCList, error) {
 
 	if datacenter.Spec.AWS == nil {
 		return nil, errors.NewBadRequest("datacenter is not an AWS datacenter")
 	}
 
-	ec2, err := awsProvider.NewCloudProvider(datacenter, provider.SecretKeySelectorValueFuncFactory(ctx, privilegedSeedClient))
-	if err != nil {
-		return nil, fmt.Errorf("couldn't create cloud provider: %v", err)
-	}
-
-	vpcsResults, err := ec2.GetVPCS(kubermaticv1.CloudSpec{
-		AWS: &kubermaticv1.AWSCloudSpec{
-			AccessKeyID:     keyID,
-			SecretAccessKey: keySecret,
-		},
-	})
+	vpcsResults, err := awsprovider.GetVPCS(accessKeyID, secretAccessKey, datacenter.Spec.AWS.Region)
 	if err != nil {
 		return nil, fmt.Errorf("couldn't get vpc's: %v", err)
 	}
 
+	vpcs := apiv1.AWSVPCList{}
 	for _, vpc := range vpcsResults {
 		var tags []apiv1.AWSTag
 		var cidrBlockList []apiv1.AWSVpcCidrBlockAssociation

--- a/api/pkg/handler/v1/provider/aws.go
+++ b/api/pkg/handler/v1/provider/aws.go
@@ -227,7 +227,7 @@ func awsSizes(region string) (apiv1.AWSSizeList, error) {
 }
 
 // AWSZoneEndpoint handles the request to list AWS availability zones in a given region, using provided credentials
-func AWSZoneEndpoint(credentialManager common.PresetsManager, seedsGetter provider.SeedsGetter, privilegedSeedClientGetter provider.SeedClientGetter) endpoint.Endpoint {
+func AWSZoneEndpoint(credentialManager common.PresetsManager, seedsGetter provider.SeedsGetter) endpoint.Endpoint {
 	return func(ctx context.Context, request interface{}) (interface{}, error) {
 		req := request.(AWSZoneReq)
 
@@ -317,7 +317,7 @@ func listAWSZones(accessKeyID, secretAccessKey string, datacenter *kubermaticv1.
 }
 
 // AWSSubnetEndpoint handles the request to list AWS availability subnets in a given vpc, using provided credentials
-func AWSSubnetEndpoint(credentialManager common.PresetsManager, seedsGetter provider.SeedsGetter, privilegedSeedClientGetter provider.SeedClientGetter) endpoint.Endpoint {
+func AWSSubnetEndpoint(credentialManager common.PresetsManager, seedsGetter provider.SeedsGetter) endpoint.Endpoint {
 	return func(ctx context.Context, request interface{}) (interface{}, error) {
 		req := request.(AWSSubnetReq)
 
@@ -443,7 +443,7 @@ func listAWSSubnets(accessKeyID, secretAccessKey, vpcID string, datacenter *kube
 }
 
 // AWSVPCEndpoint handles the request to list AWS VPC's, using provided credentials
-func AWSVPCEndpoint(credentialManager common.PresetsManager, seedsGetter provider.SeedsGetter, privilegedSeedClientGetter provider.SeedClientGetter) endpoint.Endpoint {
+func AWSVPCEndpoint(credentialManager common.PresetsManager, seedsGetter provider.SeedsGetter) endpoint.Endpoint {
 	return func(ctx context.Context, request interface{}) (interface{}, error) {
 		req := request.(AWSVPCReq)
 


### PR DESCRIPTION
**What this PR does / why we need it**:

Currently, the `GetZone`, `GetSubnet` and `GetVPC` funcs in the AWS cloudprovider package require an initialized cloudprovider.

Since we do not want to save secrets on the Cluster CR anymore, we require cloudproviders to contain a `provider.SecretKeySelectorValueFunc` in order to be able to resolve the secrets for their cluster.

However, the `GetZone` and `GetSubnet` are not necesarily used with a cluster and `GetVPC` is never.

This forced us to pass around a `SeedClientGetter` to be used when one of the aforementioned clusters does not have a Cluster available, because by default such a seed client is obtained by using a cluster to satisfy the cloudproviders `New`, even thought it will never be used because its only needed to resolve secrets from a cluster.

This PR decouples the GetZone, GetSubnet and GetVPC in `pkg/cloudprovider/provider/aws` funcs from the cloudprovider implementation. The cloudprovider implementation has basically nothing to do with those  and the state the cloudproviuder requires is not required for them, so there is no reason at all why they should be coupled.

We could even think about moving them from `pkg/cloudprovider/provider/aws` to `pkg/handler/v1/provider/`.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

I've manually tested that the endpoints still work, both before a cluster exists and afterwards.

**Documentation**:
<!-- Add links to the related documentation changes related to this pull request. E.g. the link to the kubermatic/docs pullrequest. -->

**Does this PR introduce a user-facing change?**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If  no release note is required, just write "NONE".
-->
```release-note
none
```

/assign @thz @zreigz 
