### PR TITLE
Increase default service cidr from 10.10.10.0/24 to 10.240.16.0/20

### DIFF
--- a/api/cmd/kubeletdnat-controller/main.go
+++ b/api/cmd/kubeletdnat-controller/main.go
@@ -29,10 +29,11 @@ func main() {
 
 	log.SetLogger(log.ZapLogger(false))
 
-	nodeAccessNetwork, _, err := net.ParseCIDR(*networkFlag)
+	_, network, err := net.ParseCIDR(*networkFlag)
 	if err != nil {
 		glog.Fatalf("node-access-network invalid or missing: %v", err)
 	}
+	nodeAccessNetwork := network.IP
 
 	config, err := clientcmd.BuildConfigFromFlags(*master, *kubeconfigFlag)
 	if err != nil {

--- a/api/hack/run-machinecontroller.sh
+++ b/api/hack/run-machinecontroller.sh
@@ -16,5 +16,5 @@ make machine-controller
   -kubeconfig=$KUBECONFIG_MACHINE_CONTROLLER \
   -logtostderr \
   -v=4 \
-  -cluster-dns=10.10.10.10 \
+  -cluster-dns=10.240.16.10 \
   -internal-listen-address=0.0.0.0:8085

--- a/api/pkg/controller/addon/addon_controller_test.go
+++ b/api/pkg/controller/addon/addon_controller_test.go
@@ -164,7 +164,7 @@ func setupTestAddon(name string) *kubermaticv1.Addon {
 }
 
 func TestController_getAddonKubeDNStManifests(t *testing.T) {
-	cluster := setupTestCluster("10.10.10.0/24")
+	cluster := setupTestCluster("10.240.16.0/20")
 	addon := setupTestAddon("kube-dns")
 
 	addonDir, err := ioutil.TempDir("/tmp", "kubermatic-tests-")
@@ -194,7 +194,7 @@ func TestController_getAddonKubeDNStManifests(t *testing.T) {
 		t.Fatalf("invalid number of manifests returned. Expected 1, Got %d", len(manifests))
 	}
 	fmt.Println(manifests)
-	expectedIP := "10.10.10.10"
+	expectedIP := "10.240.16.10"
 	if !strings.Contains(string(manifests[0].Raw), expectedIP) {
 		t.Fatalf("invalid IP returned. Expected \n%s, Got \n%s", expectedIP, manifests[0].String())
 	}
@@ -218,7 +218,7 @@ func TestController_getAddonKubeDNStManifests(t *testing.T) {
 }
 
 func TestController_getAddonDeploymentManifests(t *testing.T) {
-	cluster := setupTestCluster("10.10.10.0/24")
+	cluster := setupTestCluster("10.240.16.0/20")
 	addon := setupTestAddon("test")
 
 	addonDir, err := ioutil.TempDir("/tmp", "kubermatic-tests-")
@@ -257,7 +257,7 @@ func TestController_getAddonDeploymentManifests(t *testing.T) {
 }
 
 func TestController_getAddonDeploymentManifestsDefault(t *testing.T) {
-	cluster := setupTestCluster("10.10.10.0/24")
+	cluster := setupTestCluster("10.240.16.0/20")
 	addon := setupTestAddon("test")
 
 	addonDir, err := ioutil.TempDir("/tmp", "kubermatic-tests-")
@@ -295,7 +295,7 @@ func TestController_getAddonDeploymentManifestsDefault(t *testing.T) {
 }
 
 func TestController_getAddonManifests(t *testing.T) {
-	cluster := setupTestCluster("10.10.10.0/24")
+	cluster := setupTestCluster("10.240.16.0/20")
 	addon := setupTestAddon("test")
 	addonDir, err := ioutil.TempDir("/tmp", "kubermatic-tests-")
 	if err != nil {
@@ -441,7 +441,7 @@ Error from server (NotFound): error when stopping "/tmp/cluster-rwhxp9j5j-metric
 
 func TestHugeManifest(t *testing.T) {
 	log := kubermaticlog.New(true, kubermaticlog.FormatConsole).Sugar()
-	cluster := setupTestCluster("10.10.10.0/24")
+	cluster := setupTestCluster("10.240.16.0/20")
 	addon := setupTestAddon("istio")
 	r := &Reconciler{
 		kubernetesAddonDir: "./testdata",

--- a/api/pkg/controller/cluster/pending.go
+++ b/api/pkg/controller/cluster/pending.go
@@ -75,7 +75,7 @@ func (r *Reconciler) ensureClusterNetworkDefaults(ctx context.Context, cluster *
 
 	if len(cluster.Spec.ClusterNetwork.Services.CIDRBlocks) == 0 {
 		setServiceNetwork := func(c *kubermaticv1.Cluster) {
-			c.Spec.ClusterNetwork.Services.CIDRBlocks = []string{"10.10.10.0/24"}
+			c.Spec.ClusterNetwork.Services.CIDRBlocks = []string{"10.240.16.0/20"}
 		}
 		modifiers = append(modifiers, setServiceNetwork)
 	}

--- a/api/pkg/controller/openshift/openshift_controller.go
+++ b/api/pkg/controller/openshift/openshift_controller.go
@@ -694,7 +694,7 @@ func (r *Reconciler) networkDefaults(ctx context.Context, cluster *kubermaticv1.
 
 	if len(cluster.Spec.ClusterNetwork.Services.CIDRBlocks) == 0 {
 		setServiceNetwork := func(c *kubermaticv1.Cluster) {
-			c.Spec.ClusterNetwork.Services.CIDRBlocks = []string{"10.10.10.0/24"}
+			c.Spec.ClusterNetwork.Services.CIDRBlocks = []string{"10.240.16.0/20"}
 		}
 		modifiers = append(modifiers, setServiceNetwork)
 	}

--- a/api/pkg/controller/openshift/resources/controlplane_configmap_test.go
+++ b/api/pkg/controller/openshift/resources/controlplane_configmap_test.go
@@ -68,7 +68,7 @@ func TestGetMasterConfig(t *testing.T) {
 				Spec: kubermaticv1.ClusterSpec{
 					ClusterNetwork: kubermaticv1.ClusterNetworkingConfig{
 						Services: kubermaticv1.NetworkRanges{
-							CIDRBlocks: []string{"10.10.10.0/24"},
+							CIDRBlocks: []string{"10.240.16.0/24"},
 						},
 						Pods: kubermaticv1.NetworkRanges{
 							CIDRBlocks: []string{"172.25.0.0/16"},
@@ -102,7 +102,7 @@ func TestGetMasterConfig(t *testing.T) {
 				Spec: kubermaticv1.ClusterSpec{
 					ClusterNetwork: kubermaticv1.ClusterNetworkingConfig{
 						Services: kubermaticv1.NetworkRanges{
-							CIDRBlocks: []string{"10.10.10.0/24"},
+							CIDRBlocks: []string{"10.240.16.0/20"},
 						},
 						Pods: kubermaticv1.NetworkRanges{
 							CIDRBlocks: []string{"172.25.0.0/16"},

--- a/api/pkg/controller/openshift/resources/kube_controller_manager_test.go
+++ b/api/pkg/controller/openshift/resources/kube_controller_manager_test.go
@@ -22,7 +22,7 @@ func TestKubeControllerConfigMapCreation(t *testing.T) {
 				Spec: kubermaticv1.ClusterSpec{
 					ClusterNetwork: kubermaticv1.ClusterNetworkingConfig{
 						Pods: kubermaticv1.NetworkRanges{
-							CIDRBlocks: []string{"10.10.10.0"},
+							CIDRBlocks: []string{"10.240.16.0"},
 						},
 						Services: kubermaticv1.NetworkRanges{
 							CIDRBlocks: []string{"10.11.10.0"},

--- a/api/pkg/controller/openshift/resources/testdata/kube-config.golden.yaml
+++ b/api/pkg/controller/openshift/resources/testdata/kube-config.golden.yaml
@@ -14,7 +14,7 @@ data:
       cloud-provider: []
       #- aws
       cluster-cidr:
-      - 10.10.10.0
+      - 10.240.16.0
       cluster-signing-cert-file:
       - /etc/kubernetes/pki/ca/ca.crt
       cluster-signing-key-file:

--- a/api/pkg/controller/openshift/resources/testdata/master-config-aws-cluster-apiserver.golden.yaml
+++ b/api/pkg/controller/openshift/resources/testdata/master-config-aws-cluster-apiserver.golden.yaml
@@ -134,7 +134,7 @@ kubernetesMasterConfig:
   schedulerArguments: null
   schedulerConfigFile: /etc/origin/master/scheduler.json
   servicesNodePortRange: ''
-  servicesSubnet: "10.10.10.0/24"
+  servicesSubnet: "10.240.16.0/24"
 masterClients:
   externalKubernetesClientConnectionOverrides:
     acceptContentTypes: application/vnd.kubernetes.protobuf,application/json
@@ -157,7 +157,7 @@ networkConfig:
   externalIPNetworkCIDRs:
   - 0.0.0.0/0
   networkPluginName: redhat/openshift-ovs-subnet
-  serviceNetworkCIDR: "10.10.10.0/24"
+  serviceNetworkCIDR: "10.240.16.0/24"
 # TODO: Get this running with dex
 oauthConfig:
   alwaysShowProviderSelection: false

--- a/api/pkg/controller/openshift/resources/testdata/master-config-aws-cluster-controller.golden.yaml
+++ b/api/pkg/controller/openshift/resources/testdata/master-config-aws-cluster-controller.golden.yaml
@@ -98,7 +98,7 @@ kubernetesMasterConfig:
   schedulerArguments: null
   schedulerConfigFile: /etc/origin/master/scheduler.json
   servicesNodePortRange: ''
-  servicesSubnet: "10.10.10.0/24"
+  servicesSubnet: "10.240.16.0/24"
 masterClients:
   externalKubernetesClientConnectionOverrides:
     acceptContentTypes: application/vnd.kubernetes.protobuf,application/json
@@ -121,7 +121,7 @@ networkConfig:
   externalIPNetworkCIDRs:
   - 0.0.0.0/0
   networkPluginName: redhat/openshift-ovs-subnet
-  serviceNetworkCIDR: "10.10.10.0/24"
+  serviceNetworkCIDR: "10.240.16.0/24"
 pauseControllers: false
 policyConfig:
   bootstrapPolicyFile: /etc/origin/master/policy.json

--- a/api/pkg/controller/openshift/resources/testdata/master-config-digitalocean-cluster-apiserver.golden.yaml
+++ b/api/pkg/controller/openshift/resources/testdata/master-config-digitalocean-cluster-apiserver.golden.yaml
@@ -126,7 +126,7 @@ kubernetesMasterConfig:
   schedulerArguments: null
   schedulerConfigFile: /etc/origin/master/scheduler.json
   servicesNodePortRange: ''
-  servicesSubnet: "10.10.10.0/24"
+  servicesSubnet: "10.240.16.0/20"
 masterClients:
   externalKubernetesClientConnectionOverrides:
     acceptContentTypes: application/vnd.kubernetes.protobuf,application/json
@@ -149,7 +149,7 @@ networkConfig:
   externalIPNetworkCIDRs:
   - 0.0.0.0/0
   networkPluginName: redhat/openshift-ovs-subnet
-  serviceNetworkCIDR: "10.10.10.0/24"
+  serviceNetworkCIDR: "10.240.16.0/20"
 # TODO: Get this running with dex
 oauthConfig:
   alwaysShowProviderSelection: false

--- a/api/pkg/controller/openshift/resources/testdata/master-config-digitalocean-cluster-controller.golden.yaml
+++ b/api/pkg/controller/openshift/resources/testdata/master-config-digitalocean-cluster-controller.golden.yaml
@@ -94,7 +94,7 @@ kubernetesMasterConfig:
   schedulerArguments: null
   schedulerConfigFile: /etc/origin/master/scheduler.json
   servicesNodePortRange: ''
-  servicesSubnet: "10.10.10.0/24"
+  servicesSubnet: "10.240.16.0/20"
 masterClients:
   externalKubernetesClientConnectionOverrides:
     acceptContentTypes: application/vnd.kubernetes.protobuf,application/json
@@ -117,7 +117,7 @@ networkConfig:
   externalIPNetworkCIDRs:
   - 0.0.0.0/0
   networkPluginName: redhat/openshift-ovs-subnet
-  serviceNetworkCIDR: "10.10.10.0/24"
+  serviceNetworkCIDR: "10.240.16.0/20"
 pauseControllers: false
 policyConfig:
   bootstrapPolicyFile: /etc/origin/master/policy.json

--- a/api/pkg/resources/resources.go
+++ b/api/pkg/resources/resources.go
@@ -439,10 +439,11 @@ func UserClusterDNSResolverIP(cluster *kubermaticv1.Cluster) (string, error) {
 		return "", fmt.Errorf("failed to get cluster dns ip for cluster `%s`: empty CIDRBlocks", cluster.Name)
 	}
 	block := cluster.Spec.ClusterNetwork.Services.CIDRBlocks[0]
-	ip, _, err := net.ParseCIDR(block)
+	_, ipnet, err := net.ParseCIDR(block)
 	if err != nil {
 		return "", fmt.Errorf("failed to get cluster dns ip for cluster `%s`: %v'", block, err)
 	}
+	ip := ipnet.IP
 	ip[len(ip)-1] = ip[len(ip)-1] + 10
 	return ip.String(), nil
 }
@@ -455,10 +456,11 @@ func InClusterApiserverIP(cluster *kubermaticv1.Cluster) (*net.IP, error) {
 	}
 
 	block := cluster.Spec.ClusterNetwork.Services.CIDRBlocks[0]
-	ip, _, err := net.ParseCIDR(block)
+	_, ipnet, err := net.ParseCIDR(block)
 	if err != nil {
 		return nil, fmt.Errorf("invalid service cidr %s", block)
 	}
+	ip := ipnet.IP
 	ip[len(ip)-1] = ip[len(ip)-1] + 1
 	return &ip, nil
 }

--- a/api/pkg/resources/resources_test.go
+++ b/api/pkg/resources/resources_test.go
@@ -1,0 +1,81 @@
+package resources
+
+import (
+	"testing"
+
+	kubermaticv1 "github.com/kubermatic/kubermatic/api/pkg/crd/kubermatic/v1"
+)
+
+func TestInClusterApiserverIP(t *testing.T) {
+	testCases := []struct {
+		name           string
+		cidr           string
+		expectedResult string
+	}{
+		{
+			name:           "Parse /24",
+			cidr:           "10.10.10.0/24",
+			expectedResult: "10.10.10.1",
+		},
+		{
+			name:           "Parse /20",
+			cidr:           "10.240.20.0/20",
+			expectedResult: "10.240.16.1",
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			cluster := &kubermaticv1.Cluster{}
+			cluster.Spec.ClusterNetwork.Services.CIDRBlocks = []string{tc.cidr}
+
+			result, err := InClusterApiserverIP(cluster)
+			if err != nil {
+				t.Fatalf("error: %v", err)
+			}
+
+			if result.String() != tc.expectedResult {
+				t.Errorf("wrong result, expected: %s, result: %s", tc.expectedResult, result.String())
+			}
+		})
+	}
+}
+
+func TestUserClusterDNSResolverIP(t *testing.T) {
+	testCases := []struct {
+		name           string
+		cidr           string
+		expectedResult string
+	}{
+		{
+			name:           "Parse /24",
+			cidr:           "10.10.10.0/24",
+			expectedResult: "10.10.10.10",
+		},
+		{
+			name:           "Parse /20",
+			cidr:           "10.240.20.0/20",
+			expectedResult: "10.240.16.10",
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			cluster := &kubermaticv1.Cluster{}
+			cluster.Spec.ClusterNetwork.Services.CIDRBlocks = []string{tc.cidr}
+
+			result, err := UserClusterDNSResolverIP(cluster)
+			if err != nil {
+				t.Fatalf("error: %v", err)
+			}
+
+			if result != tc.expectedResult {
+				t.Errorf("wrong result, expected: %s, result: %s", tc.expectedResult, result)
+			}
+		})
+	}
+}

--- a/api/pkg/resources/test/fixtures/configmap-aws-1.10.0-dns-resolver.yaml
+++ b/api/pkg/resources/test/fixtures/configmap-aws-1.10.0-dns-resolver.yaml
@@ -6,7 +6,7 @@ data:
         errors
     }
     cluster.local {
-        forward . 10.10.10.10
+        forward . 10.240.16.10
         errors
     }
     . {

--- a/api/pkg/resources/test/fixtures/configmap-aws-1.10.0-openvpn-client-configs.yaml
+++ b/api/pkg/resources/test/fixtures/configmap-aws-1.10.0-openvpn-client-configs.yaml
@@ -1,7 +1,7 @@
 data:
   user-cluster-client: |
     iroute 172.25.0.0 255.255.0.0
-    iroute 10.10.10.0 255.255.255.0
+    iroute 10.240.16.0 255.255.240.0
     iroute 192.0.2.0 255.255.255.0
 metadata:
   creationTimestamp: null

--- a/api/pkg/resources/test/fixtures/configmap-aws-1.10.6-dns-resolver.yaml
+++ b/api/pkg/resources/test/fixtures/configmap-aws-1.10.6-dns-resolver.yaml
@@ -6,7 +6,7 @@ data:
         errors
     }
     cluster.local {
-        forward . 10.10.10.10
+        forward . 10.240.16.10
         errors
     }
     . {

--- a/api/pkg/resources/test/fixtures/configmap-aws-1.10.6-openvpn-client-configs.yaml
+++ b/api/pkg/resources/test/fixtures/configmap-aws-1.10.6-openvpn-client-configs.yaml
@@ -1,7 +1,7 @@
 data:
   user-cluster-client: |
     iroute 172.25.0.0 255.255.0.0
-    iroute 10.10.10.0 255.255.255.0
+    iroute 10.240.16.0 255.255.240.0
     iroute 192.0.2.0 255.255.255.0
 metadata:
   creationTimestamp: null

--- a/api/pkg/resources/test/fixtures/configmap-aws-1.11.0-dns-resolver.yaml
+++ b/api/pkg/resources/test/fixtures/configmap-aws-1.11.0-dns-resolver.yaml
@@ -6,7 +6,7 @@ data:
         errors
     }
     cluster.local {
-        forward . 10.10.10.10
+        forward . 10.240.16.10
         errors
     }
     . {

--- a/api/pkg/resources/test/fixtures/configmap-aws-1.11.0-openvpn-client-configs.yaml
+++ b/api/pkg/resources/test/fixtures/configmap-aws-1.11.0-openvpn-client-configs.yaml
@@ -1,7 +1,7 @@
 data:
   user-cluster-client: |
     iroute 172.25.0.0 255.255.0.0
-    iroute 10.10.10.0 255.255.255.0
+    iroute 10.240.16.0 255.255.240.0
     iroute 192.0.2.0 255.255.255.0
 metadata:
   creationTimestamp: null

--- a/api/pkg/resources/test/fixtures/configmap-aws-1.11.1-dns-resolver.yaml
+++ b/api/pkg/resources/test/fixtures/configmap-aws-1.11.1-dns-resolver.yaml
@@ -6,7 +6,7 @@ data:
         errors
     }
     cluster.local {
-        forward . 10.10.10.10
+        forward . 10.240.16.10
         errors
     }
     . {

--- a/api/pkg/resources/test/fixtures/configmap-aws-1.11.1-openvpn-client-configs.yaml
+++ b/api/pkg/resources/test/fixtures/configmap-aws-1.11.1-openvpn-client-configs.yaml
@@ -1,7 +1,7 @@
 data:
   user-cluster-client: |
     iroute 172.25.0.0 255.255.0.0
-    iroute 10.10.10.0 255.255.255.0
+    iroute 10.240.16.0 255.255.240.0
     iroute 192.0.2.0 255.255.255.0
 metadata:
   creationTimestamp: null

--- a/api/pkg/resources/test/fixtures/configmap-aws-1.12.0-dns-resolver.yaml
+++ b/api/pkg/resources/test/fixtures/configmap-aws-1.12.0-dns-resolver.yaml
@@ -6,7 +6,7 @@ data:
         errors
     }
     cluster.local {
-        forward . 10.10.10.10
+        forward . 10.240.16.10
         errors
     }
     . {

--- a/api/pkg/resources/test/fixtures/configmap-aws-1.12.0-openvpn-client-configs.yaml
+++ b/api/pkg/resources/test/fixtures/configmap-aws-1.12.0-openvpn-client-configs.yaml
@@ -1,7 +1,7 @@
 data:
   user-cluster-client: |
     iroute 172.25.0.0 255.255.0.0
-    iroute 10.10.10.0 255.255.255.0
+    iroute 10.240.16.0 255.255.240.0
     iroute 192.0.2.0 255.255.255.0
 metadata:
   creationTimestamp: null

--- a/api/pkg/resources/test/fixtures/configmap-aws-1.13.0-dns-resolver.yaml
+++ b/api/pkg/resources/test/fixtures/configmap-aws-1.13.0-dns-resolver.yaml
@@ -6,7 +6,7 @@ data:
         errors
     }
     cluster.local {
-        forward . 10.10.10.10
+        forward . 10.240.16.10
         errors
     }
     . {

--- a/api/pkg/resources/test/fixtures/configmap-aws-1.13.0-openvpn-client-configs.yaml
+++ b/api/pkg/resources/test/fixtures/configmap-aws-1.13.0-openvpn-client-configs.yaml
@@ -1,7 +1,7 @@
 data:
   user-cluster-client: |
     iroute 172.25.0.0 255.255.0.0
-    iroute 10.10.10.0 255.255.255.0
+    iroute 10.240.16.0 255.255.240.0
     iroute 192.0.2.0 255.255.255.0
 metadata:
   creationTimestamp: null

--- a/api/pkg/resources/test/fixtures/configmap-azure-1.10.0-dns-resolver.yaml
+++ b/api/pkg/resources/test/fixtures/configmap-azure-1.10.0-dns-resolver.yaml
@@ -6,7 +6,7 @@ data:
         errors
     }
     cluster.local {
-        forward . 10.10.10.10
+        forward . 10.240.16.10
         errors
     }
     . {

--- a/api/pkg/resources/test/fixtures/configmap-azure-1.10.0-openvpn-client-configs.yaml
+++ b/api/pkg/resources/test/fixtures/configmap-azure-1.10.0-openvpn-client-configs.yaml
@@ -1,7 +1,7 @@
 data:
   user-cluster-client: |
     iroute 172.25.0.0 255.255.0.0
-    iroute 10.10.10.0 255.255.255.0
+    iroute 10.240.16.0 255.255.240.0
     iroute 192.0.2.0 255.255.255.0
 metadata:
   creationTimestamp: null

--- a/api/pkg/resources/test/fixtures/configmap-azure-1.10.6-dns-resolver.yaml
+++ b/api/pkg/resources/test/fixtures/configmap-azure-1.10.6-dns-resolver.yaml
@@ -6,7 +6,7 @@ data:
         errors
     }
     cluster.local {
-        forward . 10.10.10.10
+        forward . 10.240.16.10
         errors
     }
     . {

--- a/api/pkg/resources/test/fixtures/configmap-azure-1.10.6-openvpn-client-configs.yaml
+++ b/api/pkg/resources/test/fixtures/configmap-azure-1.10.6-openvpn-client-configs.yaml
@@ -1,7 +1,7 @@
 data:
   user-cluster-client: |
     iroute 172.25.0.0 255.255.0.0
-    iroute 10.10.10.0 255.255.255.0
+    iroute 10.240.16.0 255.255.240.0
     iroute 192.0.2.0 255.255.255.0
 metadata:
   creationTimestamp: null

--- a/api/pkg/resources/test/fixtures/configmap-azure-1.11.0-dns-resolver.yaml
+++ b/api/pkg/resources/test/fixtures/configmap-azure-1.11.0-dns-resolver.yaml
@@ -6,7 +6,7 @@ data:
         errors
     }
     cluster.local {
-        forward . 10.10.10.10
+        forward . 10.240.16.10
         errors
     }
     . {

--- a/api/pkg/resources/test/fixtures/configmap-azure-1.11.0-openvpn-client-configs.yaml
+++ b/api/pkg/resources/test/fixtures/configmap-azure-1.11.0-openvpn-client-configs.yaml
@@ -1,7 +1,7 @@
 data:
   user-cluster-client: |
     iroute 172.25.0.0 255.255.0.0
-    iroute 10.10.10.0 255.255.255.0
+    iroute 10.240.16.0 255.255.240.0
     iroute 192.0.2.0 255.255.255.0
 metadata:
   creationTimestamp: null

--- a/api/pkg/resources/test/fixtures/configmap-azure-1.11.1-dns-resolver.yaml
+++ b/api/pkg/resources/test/fixtures/configmap-azure-1.11.1-dns-resolver.yaml
@@ -6,7 +6,7 @@ data:
         errors
     }
     cluster.local {
-        forward . 10.10.10.10
+        forward . 10.240.16.10
         errors
     }
     . {

--- a/api/pkg/resources/test/fixtures/configmap-azure-1.11.1-openvpn-client-configs.yaml
+++ b/api/pkg/resources/test/fixtures/configmap-azure-1.11.1-openvpn-client-configs.yaml
@@ -1,7 +1,7 @@
 data:
   user-cluster-client: |
     iroute 172.25.0.0 255.255.0.0
-    iroute 10.10.10.0 255.255.255.0
+    iroute 10.240.16.0 255.255.240.0
     iroute 192.0.2.0 255.255.255.0
 metadata:
   creationTimestamp: null

--- a/api/pkg/resources/test/fixtures/configmap-azure-1.12.0-dns-resolver.yaml
+++ b/api/pkg/resources/test/fixtures/configmap-azure-1.12.0-dns-resolver.yaml
@@ -6,7 +6,7 @@ data:
         errors
     }
     cluster.local {
-        forward . 10.10.10.10
+        forward . 10.240.16.10
         errors
     }
     . {

--- a/api/pkg/resources/test/fixtures/configmap-azure-1.12.0-openvpn-client-configs.yaml
+++ b/api/pkg/resources/test/fixtures/configmap-azure-1.12.0-openvpn-client-configs.yaml
@@ -1,7 +1,7 @@
 data:
   user-cluster-client: |
     iroute 172.25.0.0 255.255.0.0
-    iroute 10.10.10.0 255.255.255.0
+    iroute 10.240.16.0 255.255.240.0
     iroute 192.0.2.0 255.255.255.0
 metadata:
   creationTimestamp: null

--- a/api/pkg/resources/test/fixtures/configmap-azure-1.13.0-dns-resolver.yaml
+++ b/api/pkg/resources/test/fixtures/configmap-azure-1.13.0-dns-resolver.yaml
@@ -6,7 +6,7 @@ data:
         errors
     }
     cluster.local {
-        forward . 10.10.10.10
+        forward . 10.240.16.10
         errors
     }
     . {

--- a/api/pkg/resources/test/fixtures/configmap-azure-1.13.0-openvpn-client-configs.yaml
+++ b/api/pkg/resources/test/fixtures/configmap-azure-1.13.0-openvpn-client-configs.yaml
@@ -1,7 +1,7 @@
 data:
   user-cluster-client: |
     iroute 172.25.0.0 255.255.0.0
-    iroute 10.10.10.0 255.255.255.0
+    iroute 10.240.16.0 255.255.240.0
     iroute 192.0.2.0 255.255.255.0
 metadata:
   creationTimestamp: null

--- a/api/pkg/resources/test/fixtures/configmap-bringyourown-1.10.0-dns-resolver.yaml
+++ b/api/pkg/resources/test/fixtures/configmap-bringyourown-1.10.0-dns-resolver.yaml
@@ -6,7 +6,7 @@ data:
         errors
     }
     cluster.local {
-        forward . 10.10.10.10
+        forward . 10.240.16.10
         errors
     }
     . {

--- a/api/pkg/resources/test/fixtures/configmap-bringyourown-1.10.0-openvpn-client-configs.yaml
+++ b/api/pkg/resources/test/fixtures/configmap-bringyourown-1.10.0-openvpn-client-configs.yaml
@@ -1,7 +1,7 @@
 data:
   user-cluster-client: |
     iroute 172.25.0.0 255.255.0.0
-    iroute 10.10.10.0 255.255.255.0
+    iroute 10.240.16.0 255.255.240.0
     iroute 192.0.2.0 255.255.255.0
 metadata:
   creationTimestamp: null

--- a/api/pkg/resources/test/fixtures/configmap-bringyourown-1.10.6-dns-resolver.yaml
+++ b/api/pkg/resources/test/fixtures/configmap-bringyourown-1.10.6-dns-resolver.yaml
@@ -6,7 +6,7 @@ data:
         errors
     }
     cluster.local {
-        forward . 10.10.10.10
+        forward . 10.240.16.10
         errors
     }
     . {

--- a/api/pkg/resources/test/fixtures/configmap-bringyourown-1.10.6-openvpn-client-configs.yaml
+++ b/api/pkg/resources/test/fixtures/configmap-bringyourown-1.10.6-openvpn-client-configs.yaml
@@ -1,7 +1,7 @@
 data:
   user-cluster-client: |
     iroute 172.25.0.0 255.255.0.0
-    iroute 10.10.10.0 255.255.255.0
+    iroute 10.240.16.0 255.255.240.0
     iroute 192.0.2.0 255.255.255.0
 metadata:
   creationTimestamp: null

--- a/api/pkg/resources/test/fixtures/configmap-bringyourown-1.11.0-dns-resolver.yaml
+++ b/api/pkg/resources/test/fixtures/configmap-bringyourown-1.11.0-dns-resolver.yaml
@@ -6,7 +6,7 @@ data:
         errors
     }
     cluster.local {
-        forward . 10.10.10.10
+        forward . 10.240.16.10
         errors
     }
     . {

--- a/api/pkg/resources/test/fixtures/configmap-bringyourown-1.11.0-openvpn-client-configs.yaml
+++ b/api/pkg/resources/test/fixtures/configmap-bringyourown-1.11.0-openvpn-client-configs.yaml
@@ -1,7 +1,7 @@
 data:
   user-cluster-client: |
     iroute 172.25.0.0 255.255.0.0
-    iroute 10.10.10.0 255.255.255.0
+    iroute 10.240.16.0 255.255.240.0
     iroute 192.0.2.0 255.255.255.0
 metadata:
   creationTimestamp: null

--- a/api/pkg/resources/test/fixtures/configmap-bringyourown-1.11.1-dns-resolver.yaml
+++ b/api/pkg/resources/test/fixtures/configmap-bringyourown-1.11.1-dns-resolver.yaml
@@ -6,7 +6,7 @@ data:
         errors
     }
     cluster.local {
-        forward . 10.10.10.10
+        forward . 10.240.16.10
         errors
     }
     . {

--- a/api/pkg/resources/test/fixtures/configmap-bringyourown-1.11.1-openvpn-client-configs.yaml
+++ b/api/pkg/resources/test/fixtures/configmap-bringyourown-1.11.1-openvpn-client-configs.yaml
@@ -1,7 +1,7 @@
 data:
   user-cluster-client: |
     iroute 172.25.0.0 255.255.0.0
-    iroute 10.10.10.0 255.255.255.0
+    iroute 10.240.16.0 255.255.240.0
     iroute 192.0.2.0 255.255.255.0
 metadata:
   creationTimestamp: null

--- a/api/pkg/resources/test/fixtures/configmap-bringyourown-1.12.0-dns-resolver.yaml
+++ b/api/pkg/resources/test/fixtures/configmap-bringyourown-1.12.0-dns-resolver.yaml
@@ -6,7 +6,7 @@ data:
         errors
     }
     cluster.local {
-        forward . 10.10.10.10
+        forward . 10.240.16.10
         errors
     }
     . {

--- a/api/pkg/resources/test/fixtures/configmap-bringyourown-1.12.0-openvpn-client-configs.yaml
+++ b/api/pkg/resources/test/fixtures/configmap-bringyourown-1.12.0-openvpn-client-configs.yaml
@@ -1,7 +1,7 @@
 data:
   user-cluster-client: |
     iroute 172.25.0.0 255.255.0.0
-    iroute 10.10.10.0 255.255.255.0
+    iroute 10.240.16.0 255.255.240.0
     iroute 192.0.2.0 255.255.255.0
 metadata:
   creationTimestamp: null

--- a/api/pkg/resources/test/fixtures/configmap-bringyourown-1.13.0-dns-resolver.yaml
+++ b/api/pkg/resources/test/fixtures/configmap-bringyourown-1.13.0-dns-resolver.yaml
@@ -6,7 +6,7 @@ data:
         errors
     }
     cluster.local {
-        forward . 10.10.10.10
+        forward . 10.240.16.10
         errors
     }
     . {

--- a/api/pkg/resources/test/fixtures/configmap-bringyourown-1.13.0-openvpn-client-configs.yaml
+++ b/api/pkg/resources/test/fixtures/configmap-bringyourown-1.13.0-openvpn-client-configs.yaml
@@ -1,7 +1,7 @@
 data:
   user-cluster-client: |
     iroute 172.25.0.0 255.255.0.0
-    iroute 10.10.10.0 255.255.255.0
+    iroute 10.240.16.0 255.255.240.0
     iroute 192.0.2.0 255.255.255.0
 metadata:
   creationTimestamp: null

--- a/api/pkg/resources/test/fixtures/configmap-digitalocean-1.10.0-dns-resolver.yaml
+++ b/api/pkg/resources/test/fixtures/configmap-digitalocean-1.10.0-dns-resolver.yaml
@@ -6,7 +6,7 @@ data:
         errors
     }
     cluster.local {
-        forward . 10.10.10.10
+        forward . 10.240.16.10
         errors
     }
     . {

--- a/api/pkg/resources/test/fixtures/configmap-digitalocean-1.10.0-openvpn-client-configs.yaml
+++ b/api/pkg/resources/test/fixtures/configmap-digitalocean-1.10.0-openvpn-client-configs.yaml
@@ -1,7 +1,7 @@
 data:
   user-cluster-client: |
     iroute 172.25.0.0 255.255.0.0
-    iroute 10.10.10.0 255.255.255.0
+    iroute 10.240.16.0 255.255.240.0
     iroute 192.0.2.0 255.255.255.0
 metadata:
   creationTimestamp: null

--- a/api/pkg/resources/test/fixtures/configmap-digitalocean-1.10.6-dns-resolver.yaml
+++ b/api/pkg/resources/test/fixtures/configmap-digitalocean-1.10.6-dns-resolver.yaml
@@ -6,7 +6,7 @@ data:
         errors
     }
     cluster.local {
-        forward . 10.10.10.10
+        forward . 10.240.16.10
         errors
     }
     . {

--- a/api/pkg/resources/test/fixtures/configmap-digitalocean-1.10.6-openvpn-client-configs.yaml
+++ b/api/pkg/resources/test/fixtures/configmap-digitalocean-1.10.6-openvpn-client-configs.yaml
@@ -1,7 +1,7 @@
 data:
   user-cluster-client: |
     iroute 172.25.0.0 255.255.0.0
-    iroute 10.10.10.0 255.255.255.0
+    iroute 10.240.16.0 255.255.240.0
     iroute 192.0.2.0 255.255.255.0
 metadata:
   creationTimestamp: null

--- a/api/pkg/resources/test/fixtures/configmap-digitalocean-1.11.0-dns-resolver.yaml
+++ b/api/pkg/resources/test/fixtures/configmap-digitalocean-1.11.0-dns-resolver.yaml
@@ -6,7 +6,7 @@ data:
         errors
     }
     cluster.local {
-        forward . 10.10.10.10
+        forward . 10.240.16.10
         errors
     }
     . {

--- a/api/pkg/resources/test/fixtures/configmap-digitalocean-1.11.0-openvpn-client-configs.yaml
+++ b/api/pkg/resources/test/fixtures/configmap-digitalocean-1.11.0-openvpn-client-configs.yaml
@@ -1,7 +1,7 @@
 data:
   user-cluster-client: |
     iroute 172.25.0.0 255.255.0.0
-    iroute 10.10.10.0 255.255.255.0
+    iroute 10.240.16.0 255.255.240.0
     iroute 192.0.2.0 255.255.255.0
 metadata:
   creationTimestamp: null

--- a/api/pkg/resources/test/fixtures/configmap-digitalocean-1.11.1-dns-resolver.yaml
+++ b/api/pkg/resources/test/fixtures/configmap-digitalocean-1.11.1-dns-resolver.yaml
@@ -6,7 +6,7 @@ data:
         errors
     }
     cluster.local {
-        forward . 10.10.10.10
+        forward . 10.240.16.10
         errors
     }
     . {

--- a/api/pkg/resources/test/fixtures/configmap-digitalocean-1.11.1-openvpn-client-configs.yaml
+++ b/api/pkg/resources/test/fixtures/configmap-digitalocean-1.11.1-openvpn-client-configs.yaml
@@ -1,7 +1,7 @@
 data:
   user-cluster-client: |
     iroute 172.25.0.0 255.255.0.0
-    iroute 10.10.10.0 255.255.255.0
+    iroute 10.240.16.0 255.255.240.0
     iroute 192.0.2.0 255.255.255.0
 metadata:
   creationTimestamp: null

--- a/api/pkg/resources/test/fixtures/configmap-digitalocean-1.12.0-dns-resolver.yaml
+++ b/api/pkg/resources/test/fixtures/configmap-digitalocean-1.12.0-dns-resolver.yaml
@@ -6,7 +6,7 @@ data:
         errors
     }
     cluster.local {
-        forward . 10.10.10.10
+        forward . 10.240.16.10
         errors
     }
     . {

--- a/api/pkg/resources/test/fixtures/configmap-digitalocean-1.12.0-openvpn-client-configs.yaml
+++ b/api/pkg/resources/test/fixtures/configmap-digitalocean-1.12.0-openvpn-client-configs.yaml
@@ -1,7 +1,7 @@
 data:
   user-cluster-client: |
     iroute 172.25.0.0 255.255.0.0
-    iroute 10.10.10.0 255.255.255.0
+    iroute 10.240.16.0 255.255.240.0
     iroute 192.0.2.0 255.255.255.0
 metadata:
   creationTimestamp: null

--- a/api/pkg/resources/test/fixtures/configmap-digitalocean-1.13.0-dns-resolver.yaml
+++ b/api/pkg/resources/test/fixtures/configmap-digitalocean-1.13.0-dns-resolver.yaml
@@ -6,7 +6,7 @@ data:
         errors
     }
     cluster.local {
-        forward . 10.10.10.10
+        forward . 10.240.16.10
         errors
     }
     . {

--- a/api/pkg/resources/test/fixtures/configmap-digitalocean-1.13.0-openvpn-client-configs.yaml
+++ b/api/pkg/resources/test/fixtures/configmap-digitalocean-1.13.0-openvpn-client-configs.yaml
@@ -1,7 +1,7 @@
 data:
   user-cluster-client: |
     iroute 172.25.0.0 255.255.0.0
-    iroute 10.10.10.0 255.255.255.0
+    iroute 10.240.16.0 255.255.240.0
     iroute 192.0.2.0 255.255.255.0
 metadata:
   creationTimestamp: null

--- a/api/pkg/resources/test/fixtures/configmap-openstack-1.10.0-dns-resolver.yaml
+++ b/api/pkg/resources/test/fixtures/configmap-openstack-1.10.0-dns-resolver.yaml
@@ -6,7 +6,7 @@ data:
         errors
     }
     cluster.local {
-        forward . 10.10.10.10
+        forward . 10.240.16.10
         errors
     }
     . {

--- a/api/pkg/resources/test/fixtures/configmap-openstack-1.10.0-openvpn-client-configs.yaml
+++ b/api/pkg/resources/test/fixtures/configmap-openstack-1.10.0-openvpn-client-configs.yaml
@@ -1,7 +1,7 @@
 data:
   user-cluster-client: |
     iroute 172.25.0.0 255.255.0.0
-    iroute 10.10.10.0 255.255.255.0
+    iroute 10.240.16.0 255.255.240.0
     iroute 192.0.2.0 255.255.255.0
 metadata:
   creationTimestamp: null

--- a/api/pkg/resources/test/fixtures/configmap-openstack-1.10.6-dns-resolver.yaml
+++ b/api/pkg/resources/test/fixtures/configmap-openstack-1.10.6-dns-resolver.yaml
@@ -6,7 +6,7 @@ data:
         errors
     }
     cluster.local {
-        forward . 10.10.10.10
+        forward . 10.240.16.10
         errors
     }
     . {

--- a/api/pkg/resources/test/fixtures/configmap-openstack-1.10.6-openvpn-client-configs.yaml
+++ b/api/pkg/resources/test/fixtures/configmap-openstack-1.10.6-openvpn-client-configs.yaml
@@ -1,7 +1,7 @@
 data:
   user-cluster-client: |
     iroute 172.25.0.0 255.255.0.0
-    iroute 10.10.10.0 255.255.255.0
+    iroute 10.240.16.0 255.255.240.0
     iroute 192.0.2.0 255.255.255.0
 metadata:
   creationTimestamp: null

--- a/api/pkg/resources/test/fixtures/configmap-openstack-1.11.0-dns-resolver.yaml
+++ b/api/pkg/resources/test/fixtures/configmap-openstack-1.11.0-dns-resolver.yaml
@@ -6,7 +6,7 @@ data:
         errors
     }
     cluster.local {
-        forward . 10.10.10.10
+        forward . 10.240.16.10
         errors
     }
     . {

--- a/api/pkg/resources/test/fixtures/configmap-openstack-1.11.0-openvpn-client-configs.yaml
+++ b/api/pkg/resources/test/fixtures/configmap-openstack-1.11.0-openvpn-client-configs.yaml
@@ -1,7 +1,7 @@
 data:
   user-cluster-client: |
     iroute 172.25.0.0 255.255.0.0
-    iroute 10.10.10.0 255.255.255.0
+    iroute 10.240.16.0 255.255.240.0
     iroute 192.0.2.0 255.255.255.0
 metadata:
   creationTimestamp: null

--- a/api/pkg/resources/test/fixtures/configmap-openstack-1.11.1-dns-resolver.yaml
+++ b/api/pkg/resources/test/fixtures/configmap-openstack-1.11.1-dns-resolver.yaml
@@ -6,7 +6,7 @@ data:
         errors
     }
     cluster.local {
-        forward . 10.10.10.10
+        forward . 10.240.16.10
         errors
     }
     . {

--- a/api/pkg/resources/test/fixtures/configmap-openstack-1.11.1-openvpn-client-configs.yaml
+++ b/api/pkg/resources/test/fixtures/configmap-openstack-1.11.1-openvpn-client-configs.yaml
@@ -1,7 +1,7 @@
 data:
   user-cluster-client: |
     iroute 172.25.0.0 255.255.0.0
-    iroute 10.10.10.0 255.255.255.0
+    iroute 10.240.16.0 255.255.240.0
     iroute 192.0.2.0 255.255.255.0
 metadata:
   creationTimestamp: null

--- a/api/pkg/resources/test/fixtures/configmap-openstack-1.12.0-dns-resolver.yaml
+++ b/api/pkg/resources/test/fixtures/configmap-openstack-1.12.0-dns-resolver.yaml
@@ -6,7 +6,7 @@ data:
         errors
     }
     cluster.local {
-        forward . 10.10.10.10
+        forward . 10.240.16.10
         errors
     }
     . {

--- a/api/pkg/resources/test/fixtures/configmap-openstack-1.12.0-openvpn-client-configs.yaml
+++ b/api/pkg/resources/test/fixtures/configmap-openstack-1.12.0-openvpn-client-configs.yaml
@@ -1,7 +1,7 @@
 data:
   user-cluster-client: |
     iroute 172.25.0.0 255.255.0.0
-    iroute 10.10.10.0 255.255.255.0
+    iroute 10.240.16.0 255.255.240.0
     iroute 192.0.2.0 255.255.255.0
 metadata:
   creationTimestamp: null

--- a/api/pkg/resources/test/fixtures/configmap-openstack-1.13.0-dns-resolver.yaml
+++ b/api/pkg/resources/test/fixtures/configmap-openstack-1.13.0-dns-resolver.yaml
@@ -6,7 +6,7 @@ data:
         errors
     }
     cluster.local {
-        forward . 10.10.10.10
+        forward . 10.240.16.10
         errors
     }
     . {

--- a/api/pkg/resources/test/fixtures/configmap-openstack-1.13.0-openvpn-client-configs.yaml
+++ b/api/pkg/resources/test/fixtures/configmap-openstack-1.13.0-openvpn-client-configs.yaml
@@ -1,7 +1,7 @@
 data:
   user-cluster-client: |
     iroute 172.25.0.0 255.255.0.0
-    iroute 10.10.10.0 255.255.255.0
+    iroute 10.240.16.0 255.255.240.0
     iroute 192.0.2.0 255.255.255.0
 metadata:
   creationTimestamp: null

--- a/api/pkg/resources/test/fixtures/configmap-vsphere-1.10.0-dns-resolver.yaml
+++ b/api/pkg/resources/test/fixtures/configmap-vsphere-1.10.0-dns-resolver.yaml
@@ -6,7 +6,7 @@ data:
         errors
     }
     cluster.local {
-        forward . 10.10.10.10
+        forward . 10.240.16.10
         errors
     }
     . {

--- a/api/pkg/resources/test/fixtures/configmap-vsphere-1.10.0-openvpn-client-configs.yaml
+++ b/api/pkg/resources/test/fixtures/configmap-vsphere-1.10.0-openvpn-client-configs.yaml
@@ -1,7 +1,7 @@
 data:
   user-cluster-client: |
     iroute 172.25.0.0 255.255.0.0
-    iroute 10.10.10.0 255.255.255.0
+    iroute 10.240.16.0 255.255.240.0
     iroute 192.0.2.0 255.255.255.0
 metadata:
   creationTimestamp: null

--- a/api/pkg/resources/test/fixtures/configmap-vsphere-1.10.6-dns-resolver.yaml
+++ b/api/pkg/resources/test/fixtures/configmap-vsphere-1.10.6-dns-resolver.yaml
@@ -6,7 +6,7 @@ data:
         errors
     }
     cluster.local {
-        forward . 10.10.10.10
+        forward . 10.240.16.10
         errors
     }
     . {

--- a/api/pkg/resources/test/fixtures/configmap-vsphere-1.10.6-openvpn-client-configs.yaml
+++ b/api/pkg/resources/test/fixtures/configmap-vsphere-1.10.6-openvpn-client-configs.yaml
@@ -1,7 +1,7 @@
 data:
   user-cluster-client: |
     iroute 172.25.0.0 255.255.0.0
-    iroute 10.10.10.0 255.255.255.0
+    iroute 10.240.16.0 255.255.240.0
     iroute 192.0.2.0 255.255.255.0
 metadata:
   creationTimestamp: null

--- a/api/pkg/resources/test/fixtures/configmap-vsphere-1.11.0-dns-resolver.yaml
+++ b/api/pkg/resources/test/fixtures/configmap-vsphere-1.11.0-dns-resolver.yaml
@@ -6,7 +6,7 @@ data:
         errors
     }
     cluster.local {
-        forward . 10.10.10.10
+        forward . 10.240.16.10
         errors
     }
     . {

--- a/api/pkg/resources/test/fixtures/configmap-vsphere-1.11.0-openvpn-client-configs.yaml
+++ b/api/pkg/resources/test/fixtures/configmap-vsphere-1.11.0-openvpn-client-configs.yaml
@@ -1,7 +1,7 @@
 data:
   user-cluster-client: |
     iroute 172.25.0.0 255.255.0.0
-    iroute 10.10.10.0 255.255.255.0
+    iroute 10.240.16.0 255.255.240.0
     iroute 192.0.2.0 255.255.255.0
 metadata:
   creationTimestamp: null

--- a/api/pkg/resources/test/fixtures/configmap-vsphere-1.11.1-dns-resolver.yaml
+++ b/api/pkg/resources/test/fixtures/configmap-vsphere-1.11.1-dns-resolver.yaml
@@ -6,7 +6,7 @@ data:
         errors
     }
     cluster.local {
-        forward . 10.10.10.10
+        forward . 10.240.16.10
         errors
     }
     . {

--- a/api/pkg/resources/test/fixtures/configmap-vsphere-1.11.1-openvpn-client-configs.yaml
+++ b/api/pkg/resources/test/fixtures/configmap-vsphere-1.11.1-openvpn-client-configs.yaml
@@ -1,7 +1,7 @@
 data:
   user-cluster-client: |
     iroute 172.25.0.0 255.255.0.0
-    iroute 10.10.10.0 255.255.255.0
+    iroute 10.240.16.0 255.255.240.0
     iroute 192.0.2.0 255.255.255.0
 metadata:
   creationTimestamp: null

--- a/api/pkg/resources/test/fixtures/configmap-vsphere-1.12.0-dns-resolver.yaml
+++ b/api/pkg/resources/test/fixtures/configmap-vsphere-1.12.0-dns-resolver.yaml
@@ -6,7 +6,7 @@ data:
         errors
     }
     cluster.local {
-        forward . 10.10.10.10
+        forward . 10.240.16.10
         errors
     }
     . {

--- a/api/pkg/resources/test/fixtures/configmap-vsphere-1.12.0-openvpn-client-configs.yaml
+++ b/api/pkg/resources/test/fixtures/configmap-vsphere-1.12.0-openvpn-client-configs.yaml
@@ -1,7 +1,7 @@
 data:
   user-cluster-client: |
     iroute 172.25.0.0 255.255.0.0
-    iroute 10.10.10.0 255.255.255.0
+    iroute 10.240.16.0 255.255.240.0
     iroute 192.0.2.0 255.255.255.0
 metadata:
   creationTimestamp: null

--- a/api/pkg/resources/test/fixtures/configmap-vsphere-1.13.0-dns-resolver.yaml
+++ b/api/pkg/resources/test/fixtures/configmap-vsphere-1.13.0-dns-resolver.yaml
@@ -6,7 +6,7 @@ data:
         errors
     }
     cluster.local {
-        forward . 10.10.10.10
+        forward . 10.240.16.10
         errors
     }
     . {

--- a/api/pkg/resources/test/fixtures/configmap-vsphere-1.13.0-openvpn-client-configs.yaml
+++ b/api/pkg/resources/test/fixtures/configmap-vsphere-1.13.0-openvpn-client-configs.yaml
@@ -1,7 +1,7 @@
 data:
   user-cluster-client: |
     iroute 172.25.0.0 255.255.0.0
-    iroute 10.10.10.0 255.255.255.0
+    iroute 10.240.16.0 255.255.240.0
     iroute 192.0.2.0 255.255.255.0
 metadata:
   creationTimestamp: null

--- a/api/pkg/resources/test/fixtures/deployment-aws-1.10.0-apiserver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-aws-1.10.0-apiserver.yaml
@@ -165,7 +165,7 @@ spec:
         - --service-account-key-file
         - /etc/kubernetes/service-account-key/sa.key
         - --service-cluster-ip-range
-        - 10.10.10.0/24
+        - 10.240.16.0/20
         - --service-node-port-range
         - 30000-32767
         - --allow-privileged

--- a/api/pkg/resources/test/fixtures/deployment-aws-1.10.0-openvpn-server.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-aws-1.10.0-openvpn-server.yaml
@@ -69,10 +69,10 @@ spec:
         - 172.25.0.0
         - 255.255.0.0
         - --push
-        - route 10.10.10.0 255.255.255.0
+        - route 10.240.16.0 255.255.240.0
         - --route
-        - 10.10.10.0
-        - 255.255.255.0
+        - 10.240.16.0
+        - 255.255.240.0
         - --push
         - route 192.0.2.0 255.255.255.0
         - --route
@@ -153,7 +153,7 @@ spec:
           iptables -P FORWARD DROP
           iptables -A FORWARD -m state --state ESTABLISHED,RELATED -j ACCEPT
           iptables -A FORWARD -i tun0 -o tun0 -s 10.20.0.0/24 -d 172.25.0.0/16 -j ACCEPT
-          iptables -A FORWARD -i tun0 -o tun0 -s 10.20.0.0/24 -d 10.10.10.0/24 -j ACCEPT
+          iptables -A FORWARD -i tun0 -o tun0 -s 10.20.0.0/24 -d 10.240.16.0/20 -j ACCEPT
           iptables -A FORWARD -i tun0 -o tun0 -s 10.20.0.0/24 -d 192.0.2.0/24 -j ACCEPT
 
           iptables -A INPUT -m state --state ESTABLISHED,RELATED -j ACCEPT

--- a/api/pkg/resources/test/fixtures/deployment-aws-1.10.6-apiserver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-aws-1.10.6-apiserver.yaml
@@ -165,7 +165,7 @@ spec:
         - --service-account-key-file
         - /etc/kubernetes/service-account-key/sa.key
         - --service-cluster-ip-range
-        - 10.10.10.0/24
+        - 10.240.16.0/20
         - --service-node-port-range
         - 30000-32767
         - --allow-privileged

--- a/api/pkg/resources/test/fixtures/deployment-aws-1.10.6-openvpn-server.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-aws-1.10.6-openvpn-server.yaml
@@ -69,10 +69,10 @@ spec:
         - 172.25.0.0
         - 255.255.0.0
         - --push
-        - route 10.10.10.0 255.255.255.0
+        - route 10.240.16.0 255.255.240.0
         - --route
-        - 10.10.10.0
-        - 255.255.255.0
+        - 10.240.16.0
+        - 255.255.240.0
         - --push
         - route 192.0.2.0 255.255.255.0
         - --route
@@ -153,7 +153,7 @@ spec:
           iptables -P FORWARD DROP
           iptables -A FORWARD -m state --state ESTABLISHED,RELATED -j ACCEPT
           iptables -A FORWARD -i tun0 -o tun0 -s 10.20.0.0/24 -d 172.25.0.0/16 -j ACCEPT
-          iptables -A FORWARD -i tun0 -o tun0 -s 10.20.0.0/24 -d 10.10.10.0/24 -j ACCEPT
+          iptables -A FORWARD -i tun0 -o tun0 -s 10.20.0.0/24 -d 10.240.16.0/20 -j ACCEPT
           iptables -A FORWARD -i tun0 -o tun0 -s 10.20.0.0/24 -d 192.0.2.0/24 -j ACCEPT
 
           iptables -A INPUT -m state --state ESTABLISHED,RELATED -j ACCEPT

--- a/api/pkg/resources/test/fixtures/deployment-aws-1.11.0-apiserver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-aws-1.11.0-apiserver.yaml
@@ -165,7 +165,7 @@ spec:
         - --service-account-key-file
         - /etc/kubernetes/service-account-key/sa.key
         - --service-cluster-ip-range
-        - 10.10.10.0/24
+        - 10.240.16.0/20
         - --service-node-port-range
         - 30000-32767
         - --allow-privileged

--- a/api/pkg/resources/test/fixtures/deployment-aws-1.11.0-openvpn-server.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-aws-1.11.0-openvpn-server.yaml
@@ -69,10 +69,10 @@ spec:
         - 172.25.0.0
         - 255.255.0.0
         - --push
-        - route 10.10.10.0 255.255.255.0
+        - route 10.240.16.0 255.255.240.0
         - --route
-        - 10.10.10.0
-        - 255.255.255.0
+        - 10.240.16.0
+        - 255.255.240.0
         - --push
         - route 192.0.2.0 255.255.255.0
         - --route
@@ -153,7 +153,7 @@ spec:
           iptables -P FORWARD DROP
           iptables -A FORWARD -m state --state ESTABLISHED,RELATED -j ACCEPT
           iptables -A FORWARD -i tun0 -o tun0 -s 10.20.0.0/24 -d 172.25.0.0/16 -j ACCEPT
-          iptables -A FORWARD -i tun0 -o tun0 -s 10.20.0.0/24 -d 10.10.10.0/24 -j ACCEPT
+          iptables -A FORWARD -i tun0 -o tun0 -s 10.20.0.0/24 -d 10.240.16.0/20 -j ACCEPT
           iptables -A FORWARD -i tun0 -o tun0 -s 10.20.0.0/24 -d 192.0.2.0/24 -j ACCEPT
 
           iptables -A INPUT -m state --state ESTABLISHED,RELATED -j ACCEPT

--- a/api/pkg/resources/test/fixtures/deployment-aws-1.11.1-apiserver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-aws-1.11.1-apiserver.yaml
@@ -165,7 +165,7 @@ spec:
         - --service-account-key-file
         - /etc/kubernetes/service-account-key/sa.key
         - --service-cluster-ip-range
-        - 10.10.10.0/24
+        - 10.240.16.0/20
         - --service-node-port-range
         - 30000-32767
         - --allow-privileged

--- a/api/pkg/resources/test/fixtures/deployment-aws-1.11.1-openvpn-server.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-aws-1.11.1-openvpn-server.yaml
@@ -69,10 +69,10 @@ spec:
         - 172.25.0.0
         - 255.255.0.0
         - --push
-        - route 10.10.10.0 255.255.255.0
+        - route 10.240.16.0 255.255.240.0
         - --route
-        - 10.10.10.0
-        - 255.255.255.0
+        - 10.240.16.0
+        - 255.255.240.0
         - --push
         - route 192.0.2.0 255.255.255.0
         - --route
@@ -153,7 +153,7 @@ spec:
           iptables -P FORWARD DROP
           iptables -A FORWARD -m state --state ESTABLISHED,RELATED -j ACCEPT
           iptables -A FORWARD -i tun0 -o tun0 -s 10.20.0.0/24 -d 172.25.0.0/16 -j ACCEPT
-          iptables -A FORWARD -i tun0 -o tun0 -s 10.20.0.0/24 -d 10.10.10.0/24 -j ACCEPT
+          iptables -A FORWARD -i tun0 -o tun0 -s 10.20.0.0/24 -d 10.240.16.0/20 -j ACCEPT
           iptables -A FORWARD -i tun0 -o tun0 -s 10.20.0.0/24 -d 192.0.2.0/24 -j ACCEPT
 
           iptables -A INPUT -m state --state ESTABLISHED,RELATED -j ACCEPT

--- a/api/pkg/resources/test/fixtures/deployment-aws-1.12.0-apiserver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-aws-1.12.0-apiserver.yaml
@@ -165,7 +165,7 @@ spec:
         - --service-account-key-file
         - /etc/kubernetes/service-account-key/sa.key
         - --service-cluster-ip-range
-        - 10.10.10.0/24
+        - 10.240.16.0/20
         - --service-node-port-range
         - 30000-32767
         - --allow-privileged

--- a/api/pkg/resources/test/fixtures/deployment-aws-1.12.0-openvpn-server.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-aws-1.12.0-openvpn-server.yaml
@@ -69,10 +69,10 @@ spec:
         - 172.25.0.0
         - 255.255.0.0
         - --push
-        - route 10.10.10.0 255.255.255.0
+        - route 10.240.16.0 255.255.240.0
         - --route
-        - 10.10.10.0
-        - 255.255.255.0
+        - 10.240.16.0
+        - 255.255.240.0
         - --push
         - route 192.0.2.0 255.255.255.0
         - --route
@@ -153,7 +153,7 @@ spec:
           iptables -P FORWARD DROP
           iptables -A FORWARD -m state --state ESTABLISHED,RELATED -j ACCEPT
           iptables -A FORWARD -i tun0 -o tun0 -s 10.20.0.0/24 -d 172.25.0.0/16 -j ACCEPT
-          iptables -A FORWARD -i tun0 -o tun0 -s 10.20.0.0/24 -d 10.10.10.0/24 -j ACCEPT
+          iptables -A FORWARD -i tun0 -o tun0 -s 10.20.0.0/24 -d 10.240.16.0/20 -j ACCEPT
           iptables -A FORWARD -i tun0 -o tun0 -s 10.20.0.0/24 -d 192.0.2.0/24 -j ACCEPT
 
           iptables -A INPUT -m state --state ESTABLISHED,RELATED -j ACCEPT

--- a/api/pkg/resources/test/fixtures/deployment-aws-1.13.0-apiserver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-aws-1.13.0-apiserver.yaml
@@ -165,7 +165,7 @@ spec:
         - --service-account-key-file
         - /etc/kubernetes/service-account-key/sa.key
         - --service-cluster-ip-range
-        - 10.10.10.0/24
+        - 10.240.16.0/20
         - --service-node-port-range
         - 30000-32767
         - --allow-privileged

--- a/api/pkg/resources/test/fixtures/deployment-aws-1.13.0-openvpn-server.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-aws-1.13.0-openvpn-server.yaml
@@ -69,10 +69,10 @@ spec:
         - 172.25.0.0
         - 255.255.0.0
         - --push
-        - route 10.10.10.0 255.255.255.0
+        - route 10.240.16.0 255.255.240.0
         - --route
-        - 10.10.10.0
-        - 255.255.255.0
+        - 10.240.16.0
+        - 255.255.240.0
         - --push
         - route 192.0.2.0 255.255.255.0
         - --route
@@ -153,7 +153,7 @@ spec:
           iptables -P FORWARD DROP
           iptables -A FORWARD -m state --state ESTABLISHED,RELATED -j ACCEPT
           iptables -A FORWARD -i tun0 -o tun0 -s 10.20.0.0/24 -d 172.25.0.0/16 -j ACCEPT
-          iptables -A FORWARD -i tun0 -o tun0 -s 10.20.0.0/24 -d 10.10.10.0/24 -j ACCEPT
+          iptables -A FORWARD -i tun0 -o tun0 -s 10.20.0.0/24 -d 10.240.16.0/20 -j ACCEPT
           iptables -A FORWARD -i tun0 -o tun0 -s 10.20.0.0/24 -d 192.0.2.0/24 -j ACCEPT
 
           iptables -A INPUT -m state --state ESTABLISHED,RELATED -j ACCEPT

--- a/api/pkg/resources/test/fixtures/deployment-azure-1.10.0-apiserver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-azure-1.10.0-apiserver.yaml
@@ -165,7 +165,7 @@ spec:
         - --service-account-key-file
         - /etc/kubernetes/service-account-key/sa.key
         - --service-cluster-ip-range
-        - 10.10.10.0/24
+        - 10.240.16.0/20
         - --service-node-port-range
         - 30000-32767
         - --allow-privileged

--- a/api/pkg/resources/test/fixtures/deployment-azure-1.10.0-openvpn-server.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-azure-1.10.0-openvpn-server.yaml
@@ -69,10 +69,10 @@ spec:
         - 172.25.0.0
         - 255.255.0.0
         - --push
-        - route 10.10.10.0 255.255.255.0
+        - route 10.240.16.0 255.255.240.0
         - --route
-        - 10.10.10.0
-        - 255.255.255.0
+        - 10.240.16.0
+        - 255.255.240.0
         - --push
         - route 192.0.2.0 255.255.255.0
         - --route
@@ -153,7 +153,7 @@ spec:
           iptables -P FORWARD DROP
           iptables -A FORWARD -m state --state ESTABLISHED,RELATED -j ACCEPT
           iptables -A FORWARD -i tun0 -o tun0 -s 10.20.0.0/24 -d 172.25.0.0/16 -j ACCEPT
-          iptables -A FORWARD -i tun0 -o tun0 -s 10.20.0.0/24 -d 10.10.10.0/24 -j ACCEPT
+          iptables -A FORWARD -i tun0 -o tun0 -s 10.20.0.0/24 -d 10.240.16.0/20 -j ACCEPT
           iptables -A FORWARD -i tun0 -o tun0 -s 10.20.0.0/24 -d 192.0.2.0/24 -j ACCEPT
 
           iptables -A INPUT -m state --state ESTABLISHED,RELATED -j ACCEPT

--- a/api/pkg/resources/test/fixtures/deployment-azure-1.10.6-apiserver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-azure-1.10.6-apiserver.yaml
@@ -165,7 +165,7 @@ spec:
         - --service-account-key-file
         - /etc/kubernetes/service-account-key/sa.key
         - --service-cluster-ip-range
-        - 10.10.10.0/24
+        - 10.240.16.0/20
         - --service-node-port-range
         - 30000-32767
         - --allow-privileged

--- a/api/pkg/resources/test/fixtures/deployment-azure-1.10.6-openvpn-server.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-azure-1.10.6-openvpn-server.yaml
@@ -69,10 +69,10 @@ spec:
         - 172.25.0.0
         - 255.255.0.0
         - --push
-        - route 10.10.10.0 255.255.255.0
+        - route 10.240.16.0 255.255.240.0
         - --route
-        - 10.10.10.0
-        - 255.255.255.0
+        - 10.240.16.0
+        - 255.255.240.0
         - --push
         - route 192.0.2.0 255.255.255.0
         - --route
@@ -153,7 +153,7 @@ spec:
           iptables -P FORWARD DROP
           iptables -A FORWARD -m state --state ESTABLISHED,RELATED -j ACCEPT
           iptables -A FORWARD -i tun0 -o tun0 -s 10.20.0.0/24 -d 172.25.0.0/16 -j ACCEPT
-          iptables -A FORWARD -i tun0 -o tun0 -s 10.20.0.0/24 -d 10.10.10.0/24 -j ACCEPT
+          iptables -A FORWARD -i tun0 -o tun0 -s 10.20.0.0/24 -d 10.240.16.0/20 -j ACCEPT
           iptables -A FORWARD -i tun0 -o tun0 -s 10.20.0.0/24 -d 192.0.2.0/24 -j ACCEPT
 
           iptables -A INPUT -m state --state ESTABLISHED,RELATED -j ACCEPT

--- a/api/pkg/resources/test/fixtures/deployment-azure-1.11.0-apiserver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-azure-1.11.0-apiserver.yaml
@@ -165,7 +165,7 @@ spec:
         - --service-account-key-file
         - /etc/kubernetes/service-account-key/sa.key
         - --service-cluster-ip-range
-        - 10.10.10.0/24
+        - 10.240.16.0/20
         - --service-node-port-range
         - 30000-32767
         - --allow-privileged

--- a/api/pkg/resources/test/fixtures/deployment-azure-1.11.0-openvpn-server.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-azure-1.11.0-openvpn-server.yaml
@@ -69,10 +69,10 @@ spec:
         - 172.25.0.0
         - 255.255.0.0
         - --push
-        - route 10.10.10.0 255.255.255.0
+        - route 10.240.16.0 255.255.240.0
         - --route
-        - 10.10.10.0
-        - 255.255.255.0
+        - 10.240.16.0
+        - 255.255.240.0
         - --push
         - route 192.0.2.0 255.255.255.0
         - --route
@@ -153,7 +153,7 @@ spec:
           iptables -P FORWARD DROP
           iptables -A FORWARD -m state --state ESTABLISHED,RELATED -j ACCEPT
           iptables -A FORWARD -i tun0 -o tun0 -s 10.20.0.0/24 -d 172.25.0.0/16 -j ACCEPT
-          iptables -A FORWARD -i tun0 -o tun0 -s 10.20.0.0/24 -d 10.10.10.0/24 -j ACCEPT
+          iptables -A FORWARD -i tun0 -o tun0 -s 10.20.0.0/24 -d 10.240.16.0/20 -j ACCEPT
           iptables -A FORWARD -i tun0 -o tun0 -s 10.20.0.0/24 -d 192.0.2.0/24 -j ACCEPT
 
           iptables -A INPUT -m state --state ESTABLISHED,RELATED -j ACCEPT

--- a/api/pkg/resources/test/fixtures/deployment-azure-1.11.1-apiserver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-azure-1.11.1-apiserver.yaml
@@ -165,7 +165,7 @@ spec:
         - --service-account-key-file
         - /etc/kubernetes/service-account-key/sa.key
         - --service-cluster-ip-range
-        - 10.10.10.0/24
+        - 10.240.16.0/20
         - --service-node-port-range
         - 30000-32767
         - --allow-privileged

--- a/api/pkg/resources/test/fixtures/deployment-azure-1.11.1-openvpn-server.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-azure-1.11.1-openvpn-server.yaml
@@ -69,10 +69,10 @@ spec:
         - 172.25.0.0
         - 255.255.0.0
         - --push
-        - route 10.10.10.0 255.255.255.0
+        - route 10.240.16.0 255.255.240.0
         - --route
-        - 10.10.10.0
-        - 255.255.255.0
+        - 10.240.16.0
+        - 255.255.240.0
         - --push
         - route 192.0.2.0 255.255.255.0
         - --route
@@ -153,7 +153,7 @@ spec:
           iptables -P FORWARD DROP
           iptables -A FORWARD -m state --state ESTABLISHED,RELATED -j ACCEPT
           iptables -A FORWARD -i tun0 -o tun0 -s 10.20.0.0/24 -d 172.25.0.0/16 -j ACCEPT
-          iptables -A FORWARD -i tun0 -o tun0 -s 10.20.0.0/24 -d 10.10.10.0/24 -j ACCEPT
+          iptables -A FORWARD -i tun0 -o tun0 -s 10.20.0.0/24 -d 10.240.16.0/20 -j ACCEPT
           iptables -A FORWARD -i tun0 -o tun0 -s 10.20.0.0/24 -d 192.0.2.0/24 -j ACCEPT
 
           iptables -A INPUT -m state --state ESTABLISHED,RELATED -j ACCEPT

--- a/api/pkg/resources/test/fixtures/deployment-azure-1.12.0-apiserver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-azure-1.12.0-apiserver.yaml
@@ -165,7 +165,7 @@ spec:
         - --service-account-key-file
         - /etc/kubernetes/service-account-key/sa.key
         - --service-cluster-ip-range
-        - 10.10.10.0/24
+        - 10.240.16.0/20
         - --service-node-port-range
         - 30000-32767
         - --allow-privileged

--- a/api/pkg/resources/test/fixtures/deployment-azure-1.12.0-openvpn-server.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-azure-1.12.0-openvpn-server.yaml
@@ -69,10 +69,10 @@ spec:
         - 172.25.0.0
         - 255.255.0.0
         - --push
-        - route 10.10.10.0 255.255.255.0
+        - route 10.240.16.0 255.255.240.0
         - --route
-        - 10.10.10.0
-        - 255.255.255.0
+        - 10.240.16.0
+        - 255.255.240.0
         - --push
         - route 192.0.2.0 255.255.255.0
         - --route
@@ -153,7 +153,7 @@ spec:
           iptables -P FORWARD DROP
           iptables -A FORWARD -m state --state ESTABLISHED,RELATED -j ACCEPT
           iptables -A FORWARD -i tun0 -o tun0 -s 10.20.0.0/24 -d 172.25.0.0/16 -j ACCEPT
-          iptables -A FORWARD -i tun0 -o tun0 -s 10.20.0.0/24 -d 10.10.10.0/24 -j ACCEPT
+          iptables -A FORWARD -i tun0 -o tun0 -s 10.20.0.0/24 -d 10.240.16.0/20 -j ACCEPT
           iptables -A FORWARD -i tun0 -o tun0 -s 10.20.0.0/24 -d 192.0.2.0/24 -j ACCEPT
 
           iptables -A INPUT -m state --state ESTABLISHED,RELATED -j ACCEPT

--- a/api/pkg/resources/test/fixtures/deployment-azure-1.13.0-apiserver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-azure-1.13.0-apiserver.yaml
@@ -165,7 +165,7 @@ spec:
         - --service-account-key-file
         - /etc/kubernetes/service-account-key/sa.key
         - --service-cluster-ip-range
-        - 10.10.10.0/24
+        - 10.240.16.0/20
         - --service-node-port-range
         - 30000-32767
         - --allow-privileged

--- a/api/pkg/resources/test/fixtures/deployment-azure-1.13.0-openvpn-server.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-azure-1.13.0-openvpn-server.yaml
@@ -69,10 +69,10 @@ spec:
         - 172.25.0.0
         - 255.255.0.0
         - --push
-        - route 10.10.10.0 255.255.255.0
+        - route 10.240.16.0 255.255.240.0
         - --route
-        - 10.10.10.0
-        - 255.255.255.0
+        - 10.240.16.0
+        - 255.255.240.0
         - --push
         - route 192.0.2.0 255.255.255.0
         - --route
@@ -153,7 +153,7 @@ spec:
           iptables -P FORWARD DROP
           iptables -A FORWARD -m state --state ESTABLISHED,RELATED -j ACCEPT
           iptables -A FORWARD -i tun0 -o tun0 -s 10.20.0.0/24 -d 172.25.0.0/16 -j ACCEPT
-          iptables -A FORWARD -i tun0 -o tun0 -s 10.20.0.0/24 -d 10.10.10.0/24 -j ACCEPT
+          iptables -A FORWARD -i tun0 -o tun0 -s 10.20.0.0/24 -d 10.240.16.0/20 -j ACCEPT
           iptables -A FORWARD -i tun0 -o tun0 -s 10.20.0.0/24 -d 192.0.2.0/24 -j ACCEPT
 
           iptables -A INPUT -m state --state ESTABLISHED,RELATED -j ACCEPT

--- a/api/pkg/resources/test/fixtures/deployment-bringyourown-1.10.0-apiserver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-bringyourown-1.10.0-apiserver.yaml
@@ -165,7 +165,7 @@ spec:
         - --service-account-key-file
         - /etc/kubernetes/service-account-key/sa.key
         - --service-cluster-ip-range
-        - 10.10.10.0/24
+        - 10.240.16.0/20
         - --service-node-port-range
         - 30000-32767
         - --allow-privileged

--- a/api/pkg/resources/test/fixtures/deployment-bringyourown-1.10.0-openvpn-server.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-bringyourown-1.10.0-openvpn-server.yaml
@@ -69,10 +69,10 @@ spec:
         - 172.25.0.0
         - 255.255.0.0
         - --push
-        - route 10.10.10.0 255.255.255.0
+        - route 10.240.16.0 255.255.240.0
         - --route
-        - 10.10.10.0
-        - 255.255.255.0
+        - 10.240.16.0
+        - 255.255.240.0
         - --push
         - route 192.0.2.0 255.255.255.0
         - --route
@@ -153,7 +153,7 @@ spec:
           iptables -P FORWARD DROP
           iptables -A FORWARD -m state --state ESTABLISHED,RELATED -j ACCEPT
           iptables -A FORWARD -i tun0 -o tun0 -s 10.20.0.0/24 -d 172.25.0.0/16 -j ACCEPT
-          iptables -A FORWARD -i tun0 -o tun0 -s 10.20.0.0/24 -d 10.10.10.0/24 -j ACCEPT
+          iptables -A FORWARD -i tun0 -o tun0 -s 10.20.0.0/24 -d 10.240.16.0/20 -j ACCEPT
           iptables -A FORWARD -i tun0 -o tun0 -s 10.20.0.0/24 -d 192.0.2.0/24 -j ACCEPT
 
           iptables -A INPUT -m state --state ESTABLISHED,RELATED -j ACCEPT

--- a/api/pkg/resources/test/fixtures/deployment-bringyourown-1.10.6-apiserver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-bringyourown-1.10.6-apiserver.yaml
@@ -165,7 +165,7 @@ spec:
         - --service-account-key-file
         - /etc/kubernetes/service-account-key/sa.key
         - --service-cluster-ip-range
-        - 10.10.10.0/24
+        - 10.240.16.0/20
         - --service-node-port-range
         - 30000-32767
         - --allow-privileged

--- a/api/pkg/resources/test/fixtures/deployment-bringyourown-1.10.6-openvpn-server.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-bringyourown-1.10.6-openvpn-server.yaml
@@ -69,10 +69,10 @@ spec:
         - 172.25.0.0
         - 255.255.0.0
         - --push
-        - route 10.10.10.0 255.255.255.0
+        - route 10.240.16.0 255.255.240.0
         - --route
-        - 10.10.10.0
-        - 255.255.255.0
+        - 10.240.16.0
+        - 255.255.240.0
         - --push
         - route 192.0.2.0 255.255.255.0
         - --route
@@ -153,7 +153,7 @@ spec:
           iptables -P FORWARD DROP
           iptables -A FORWARD -m state --state ESTABLISHED,RELATED -j ACCEPT
           iptables -A FORWARD -i tun0 -o tun0 -s 10.20.0.0/24 -d 172.25.0.0/16 -j ACCEPT
-          iptables -A FORWARD -i tun0 -o tun0 -s 10.20.0.0/24 -d 10.10.10.0/24 -j ACCEPT
+          iptables -A FORWARD -i tun0 -o tun0 -s 10.20.0.0/24 -d 10.240.16.0/20 -j ACCEPT
           iptables -A FORWARD -i tun0 -o tun0 -s 10.20.0.0/24 -d 192.0.2.0/24 -j ACCEPT
 
           iptables -A INPUT -m state --state ESTABLISHED,RELATED -j ACCEPT

--- a/api/pkg/resources/test/fixtures/deployment-bringyourown-1.11.0-apiserver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-bringyourown-1.11.0-apiserver.yaml
@@ -165,7 +165,7 @@ spec:
         - --service-account-key-file
         - /etc/kubernetes/service-account-key/sa.key
         - --service-cluster-ip-range
-        - 10.10.10.0/24
+        - 10.240.16.0/20
         - --service-node-port-range
         - 30000-32767
         - --allow-privileged

--- a/api/pkg/resources/test/fixtures/deployment-bringyourown-1.11.0-openvpn-server.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-bringyourown-1.11.0-openvpn-server.yaml
@@ -69,10 +69,10 @@ spec:
         - 172.25.0.0
         - 255.255.0.0
         - --push
-        - route 10.10.10.0 255.255.255.0
+        - route 10.240.16.0 255.255.240.0
         - --route
-        - 10.10.10.0
-        - 255.255.255.0
+        - 10.240.16.0
+        - 255.255.240.0
         - --push
         - route 192.0.2.0 255.255.255.0
         - --route
@@ -153,7 +153,7 @@ spec:
           iptables -P FORWARD DROP
           iptables -A FORWARD -m state --state ESTABLISHED,RELATED -j ACCEPT
           iptables -A FORWARD -i tun0 -o tun0 -s 10.20.0.0/24 -d 172.25.0.0/16 -j ACCEPT
-          iptables -A FORWARD -i tun0 -o tun0 -s 10.20.0.0/24 -d 10.10.10.0/24 -j ACCEPT
+          iptables -A FORWARD -i tun0 -o tun0 -s 10.20.0.0/24 -d 10.240.16.0/20 -j ACCEPT
           iptables -A FORWARD -i tun0 -o tun0 -s 10.20.0.0/24 -d 192.0.2.0/24 -j ACCEPT
 
           iptables -A INPUT -m state --state ESTABLISHED,RELATED -j ACCEPT

--- a/api/pkg/resources/test/fixtures/deployment-bringyourown-1.11.1-apiserver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-bringyourown-1.11.1-apiserver.yaml
@@ -165,7 +165,7 @@ spec:
         - --service-account-key-file
         - /etc/kubernetes/service-account-key/sa.key
         - --service-cluster-ip-range
-        - 10.10.10.0/24
+        - 10.240.16.0/20
         - --service-node-port-range
         - 30000-32767
         - --allow-privileged

--- a/api/pkg/resources/test/fixtures/deployment-bringyourown-1.11.1-openvpn-server.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-bringyourown-1.11.1-openvpn-server.yaml
@@ -69,10 +69,10 @@ spec:
         - 172.25.0.0
         - 255.255.0.0
         - --push
-        - route 10.10.10.0 255.255.255.0
+        - route 10.240.16.0 255.255.240.0
         - --route
-        - 10.10.10.0
-        - 255.255.255.0
+        - 10.240.16.0
+        - 255.255.240.0
         - --push
         - route 192.0.2.0 255.255.255.0
         - --route
@@ -153,7 +153,7 @@ spec:
           iptables -P FORWARD DROP
           iptables -A FORWARD -m state --state ESTABLISHED,RELATED -j ACCEPT
           iptables -A FORWARD -i tun0 -o tun0 -s 10.20.0.0/24 -d 172.25.0.0/16 -j ACCEPT
-          iptables -A FORWARD -i tun0 -o tun0 -s 10.20.0.0/24 -d 10.10.10.0/24 -j ACCEPT
+          iptables -A FORWARD -i tun0 -o tun0 -s 10.20.0.0/24 -d 10.240.16.0/20 -j ACCEPT
           iptables -A FORWARD -i tun0 -o tun0 -s 10.20.0.0/24 -d 192.0.2.0/24 -j ACCEPT
 
           iptables -A INPUT -m state --state ESTABLISHED,RELATED -j ACCEPT

--- a/api/pkg/resources/test/fixtures/deployment-bringyourown-1.12.0-apiserver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-bringyourown-1.12.0-apiserver.yaml
@@ -165,7 +165,7 @@ spec:
         - --service-account-key-file
         - /etc/kubernetes/service-account-key/sa.key
         - --service-cluster-ip-range
-        - 10.10.10.0/24
+        - 10.240.16.0/20
         - --service-node-port-range
         - 30000-32767
         - --allow-privileged

--- a/api/pkg/resources/test/fixtures/deployment-bringyourown-1.12.0-openvpn-server.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-bringyourown-1.12.0-openvpn-server.yaml
@@ -69,10 +69,10 @@ spec:
         - 172.25.0.0
         - 255.255.0.0
         - --push
-        - route 10.10.10.0 255.255.255.0
+        - route 10.240.16.0 255.255.240.0
         - --route
-        - 10.10.10.0
-        - 255.255.255.0
+        - 10.240.16.0
+        - 255.255.240.0
         - --push
         - route 192.0.2.0 255.255.255.0
         - --route
@@ -153,7 +153,7 @@ spec:
           iptables -P FORWARD DROP
           iptables -A FORWARD -m state --state ESTABLISHED,RELATED -j ACCEPT
           iptables -A FORWARD -i tun0 -o tun0 -s 10.20.0.0/24 -d 172.25.0.0/16 -j ACCEPT
-          iptables -A FORWARD -i tun0 -o tun0 -s 10.20.0.0/24 -d 10.10.10.0/24 -j ACCEPT
+          iptables -A FORWARD -i tun0 -o tun0 -s 10.20.0.0/24 -d 10.240.16.0/20 -j ACCEPT
           iptables -A FORWARD -i tun0 -o tun0 -s 10.20.0.0/24 -d 192.0.2.0/24 -j ACCEPT
 
           iptables -A INPUT -m state --state ESTABLISHED,RELATED -j ACCEPT

--- a/api/pkg/resources/test/fixtures/deployment-bringyourown-1.13.0-apiserver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-bringyourown-1.13.0-apiserver.yaml
@@ -165,7 +165,7 @@ spec:
         - --service-account-key-file
         - /etc/kubernetes/service-account-key/sa.key
         - --service-cluster-ip-range
-        - 10.10.10.0/24
+        - 10.240.16.0/20
         - --service-node-port-range
         - 30000-32767
         - --allow-privileged

--- a/api/pkg/resources/test/fixtures/deployment-bringyourown-1.13.0-openvpn-server.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-bringyourown-1.13.0-openvpn-server.yaml
@@ -69,10 +69,10 @@ spec:
         - 172.25.0.0
         - 255.255.0.0
         - --push
-        - route 10.10.10.0 255.255.255.0
+        - route 10.240.16.0 255.255.240.0
         - --route
-        - 10.10.10.0
-        - 255.255.255.0
+        - 10.240.16.0
+        - 255.255.240.0
         - --push
         - route 192.0.2.0 255.255.255.0
         - --route
@@ -153,7 +153,7 @@ spec:
           iptables -P FORWARD DROP
           iptables -A FORWARD -m state --state ESTABLISHED,RELATED -j ACCEPT
           iptables -A FORWARD -i tun0 -o tun0 -s 10.20.0.0/24 -d 172.25.0.0/16 -j ACCEPT
-          iptables -A FORWARD -i tun0 -o tun0 -s 10.20.0.0/24 -d 10.10.10.0/24 -j ACCEPT
+          iptables -A FORWARD -i tun0 -o tun0 -s 10.20.0.0/24 -d 10.240.16.0/20 -j ACCEPT
           iptables -A FORWARD -i tun0 -o tun0 -s 10.20.0.0/24 -d 192.0.2.0/24 -j ACCEPT
 
           iptables -A INPUT -m state --state ESTABLISHED,RELATED -j ACCEPT

--- a/api/pkg/resources/test/fixtures/deployment-digitalocean-1.10.0-apiserver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-digitalocean-1.10.0-apiserver.yaml
@@ -165,7 +165,7 @@ spec:
         - --service-account-key-file
         - /etc/kubernetes/service-account-key/sa.key
         - --service-cluster-ip-range
-        - 10.10.10.0/24
+        - 10.240.16.0/20
         - --service-node-port-range
         - 30000-32767
         - --allow-privileged

--- a/api/pkg/resources/test/fixtures/deployment-digitalocean-1.10.0-openvpn-server.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-digitalocean-1.10.0-openvpn-server.yaml
@@ -69,10 +69,10 @@ spec:
         - 172.25.0.0
         - 255.255.0.0
         - --push
-        - route 10.10.10.0 255.255.255.0
+        - route 10.240.16.0 255.255.240.0
         - --route
-        - 10.10.10.0
-        - 255.255.255.0
+        - 10.240.16.0
+        - 255.255.240.0
         - --push
         - route 192.0.2.0 255.255.255.0
         - --route
@@ -153,7 +153,7 @@ spec:
           iptables -P FORWARD DROP
           iptables -A FORWARD -m state --state ESTABLISHED,RELATED -j ACCEPT
           iptables -A FORWARD -i tun0 -o tun0 -s 10.20.0.0/24 -d 172.25.0.0/16 -j ACCEPT
-          iptables -A FORWARD -i tun0 -o tun0 -s 10.20.0.0/24 -d 10.10.10.0/24 -j ACCEPT
+          iptables -A FORWARD -i tun0 -o tun0 -s 10.20.0.0/24 -d 10.240.16.0/20 -j ACCEPT
           iptables -A FORWARD -i tun0 -o tun0 -s 10.20.0.0/24 -d 192.0.2.0/24 -j ACCEPT
 
           iptables -A INPUT -m state --state ESTABLISHED,RELATED -j ACCEPT

--- a/api/pkg/resources/test/fixtures/deployment-digitalocean-1.10.6-apiserver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-digitalocean-1.10.6-apiserver.yaml
@@ -165,7 +165,7 @@ spec:
         - --service-account-key-file
         - /etc/kubernetes/service-account-key/sa.key
         - --service-cluster-ip-range
-        - 10.10.10.0/24
+        - 10.240.16.0/20
         - --service-node-port-range
         - 30000-32767
         - --allow-privileged

--- a/api/pkg/resources/test/fixtures/deployment-digitalocean-1.10.6-openvpn-server.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-digitalocean-1.10.6-openvpn-server.yaml
@@ -69,10 +69,10 @@ spec:
         - 172.25.0.0
         - 255.255.0.0
         - --push
-        - route 10.10.10.0 255.255.255.0
+        - route 10.240.16.0 255.255.240.0
         - --route
-        - 10.10.10.0
-        - 255.255.255.0
+        - 10.240.16.0
+        - 255.255.240.0
         - --push
         - route 192.0.2.0 255.255.255.0
         - --route
@@ -153,7 +153,7 @@ spec:
           iptables -P FORWARD DROP
           iptables -A FORWARD -m state --state ESTABLISHED,RELATED -j ACCEPT
           iptables -A FORWARD -i tun0 -o tun0 -s 10.20.0.0/24 -d 172.25.0.0/16 -j ACCEPT
-          iptables -A FORWARD -i tun0 -o tun0 -s 10.20.0.0/24 -d 10.10.10.0/24 -j ACCEPT
+          iptables -A FORWARD -i tun0 -o tun0 -s 10.20.0.0/24 -d 10.240.16.0/20 -j ACCEPT
           iptables -A FORWARD -i tun0 -o tun0 -s 10.20.0.0/24 -d 192.0.2.0/24 -j ACCEPT
 
           iptables -A INPUT -m state --state ESTABLISHED,RELATED -j ACCEPT

--- a/api/pkg/resources/test/fixtures/deployment-digitalocean-1.11.0-apiserver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-digitalocean-1.11.0-apiserver.yaml
@@ -165,7 +165,7 @@ spec:
         - --service-account-key-file
         - /etc/kubernetes/service-account-key/sa.key
         - --service-cluster-ip-range
-        - 10.10.10.0/24
+        - 10.240.16.0/20
         - --service-node-port-range
         - 30000-32767
         - --allow-privileged

--- a/api/pkg/resources/test/fixtures/deployment-digitalocean-1.11.0-openvpn-server.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-digitalocean-1.11.0-openvpn-server.yaml
@@ -69,10 +69,10 @@ spec:
         - 172.25.0.0
         - 255.255.0.0
         - --push
-        - route 10.10.10.0 255.255.255.0
+        - route 10.240.16.0 255.255.240.0
         - --route
-        - 10.10.10.0
-        - 255.255.255.0
+        - 10.240.16.0
+        - 255.255.240.0
         - --push
         - route 192.0.2.0 255.255.255.0
         - --route
@@ -153,7 +153,7 @@ spec:
           iptables -P FORWARD DROP
           iptables -A FORWARD -m state --state ESTABLISHED,RELATED -j ACCEPT
           iptables -A FORWARD -i tun0 -o tun0 -s 10.20.0.0/24 -d 172.25.0.0/16 -j ACCEPT
-          iptables -A FORWARD -i tun0 -o tun0 -s 10.20.0.0/24 -d 10.10.10.0/24 -j ACCEPT
+          iptables -A FORWARD -i tun0 -o tun0 -s 10.20.0.0/24 -d 10.240.16.0/20 -j ACCEPT
           iptables -A FORWARD -i tun0 -o tun0 -s 10.20.0.0/24 -d 192.0.2.0/24 -j ACCEPT
 
           iptables -A INPUT -m state --state ESTABLISHED,RELATED -j ACCEPT

--- a/api/pkg/resources/test/fixtures/deployment-digitalocean-1.11.1-apiserver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-digitalocean-1.11.1-apiserver.yaml
@@ -165,7 +165,7 @@ spec:
         - --service-account-key-file
         - /etc/kubernetes/service-account-key/sa.key
         - --service-cluster-ip-range
-        - 10.10.10.0/24
+        - 10.240.16.0/20
         - --service-node-port-range
         - 30000-32767
         - --allow-privileged

--- a/api/pkg/resources/test/fixtures/deployment-digitalocean-1.11.1-openvpn-server.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-digitalocean-1.11.1-openvpn-server.yaml
@@ -69,10 +69,10 @@ spec:
         - 172.25.0.0
         - 255.255.0.0
         - --push
-        - route 10.10.10.0 255.255.255.0
+        - route 10.240.16.0 255.255.240.0
         - --route
-        - 10.10.10.0
-        - 255.255.255.0
+        - 10.240.16.0
+        - 255.255.240.0
         - --push
         - route 192.0.2.0 255.255.255.0
         - --route
@@ -153,7 +153,7 @@ spec:
           iptables -P FORWARD DROP
           iptables -A FORWARD -m state --state ESTABLISHED,RELATED -j ACCEPT
           iptables -A FORWARD -i tun0 -o tun0 -s 10.20.0.0/24 -d 172.25.0.0/16 -j ACCEPT
-          iptables -A FORWARD -i tun0 -o tun0 -s 10.20.0.0/24 -d 10.10.10.0/24 -j ACCEPT
+          iptables -A FORWARD -i tun0 -o tun0 -s 10.20.0.0/24 -d 10.240.16.0/20 -j ACCEPT
           iptables -A FORWARD -i tun0 -o tun0 -s 10.20.0.0/24 -d 192.0.2.0/24 -j ACCEPT
 
           iptables -A INPUT -m state --state ESTABLISHED,RELATED -j ACCEPT

--- a/api/pkg/resources/test/fixtures/deployment-digitalocean-1.12.0-apiserver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-digitalocean-1.12.0-apiserver.yaml
@@ -165,7 +165,7 @@ spec:
         - --service-account-key-file
         - /etc/kubernetes/service-account-key/sa.key
         - --service-cluster-ip-range
-        - 10.10.10.0/24
+        - 10.240.16.0/20
         - --service-node-port-range
         - 30000-32767
         - --allow-privileged

--- a/api/pkg/resources/test/fixtures/deployment-digitalocean-1.12.0-openvpn-server.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-digitalocean-1.12.0-openvpn-server.yaml
@@ -69,10 +69,10 @@ spec:
         - 172.25.0.0
         - 255.255.0.0
         - --push
-        - route 10.10.10.0 255.255.255.0
+        - route 10.240.16.0 255.255.240.0
         - --route
-        - 10.10.10.0
-        - 255.255.255.0
+        - 10.240.16.0
+        - 255.255.240.0
         - --push
         - route 192.0.2.0 255.255.255.0
         - --route
@@ -153,7 +153,7 @@ spec:
           iptables -P FORWARD DROP
           iptables -A FORWARD -m state --state ESTABLISHED,RELATED -j ACCEPT
           iptables -A FORWARD -i tun0 -o tun0 -s 10.20.0.0/24 -d 172.25.0.0/16 -j ACCEPT
-          iptables -A FORWARD -i tun0 -o tun0 -s 10.20.0.0/24 -d 10.10.10.0/24 -j ACCEPT
+          iptables -A FORWARD -i tun0 -o tun0 -s 10.20.0.0/24 -d 10.240.16.0/20 -j ACCEPT
           iptables -A FORWARD -i tun0 -o tun0 -s 10.20.0.0/24 -d 192.0.2.0/24 -j ACCEPT
 
           iptables -A INPUT -m state --state ESTABLISHED,RELATED -j ACCEPT

--- a/api/pkg/resources/test/fixtures/deployment-digitalocean-1.13.0-apiserver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-digitalocean-1.13.0-apiserver.yaml
@@ -165,7 +165,7 @@ spec:
         - --service-account-key-file
         - /etc/kubernetes/service-account-key/sa.key
         - --service-cluster-ip-range
-        - 10.10.10.0/24
+        - 10.240.16.0/20
         - --service-node-port-range
         - 30000-32767
         - --allow-privileged

--- a/api/pkg/resources/test/fixtures/deployment-digitalocean-1.13.0-openvpn-server.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-digitalocean-1.13.0-openvpn-server.yaml
@@ -69,10 +69,10 @@ spec:
         - 172.25.0.0
         - 255.255.0.0
         - --push
-        - route 10.10.10.0 255.255.255.0
+        - route 10.240.16.0 255.255.240.0
         - --route
-        - 10.10.10.0
-        - 255.255.255.0
+        - 10.240.16.0
+        - 255.255.240.0
         - --push
         - route 192.0.2.0 255.255.255.0
         - --route
@@ -153,7 +153,7 @@ spec:
           iptables -P FORWARD DROP
           iptables -A FORWARD -m state --state ESTABLISHED,RELATED -j ACCEPT
           iptables -A FORWARD -i tun0 -o tun0 -s 10.20.0.0/24 -d 172.25.0.0/16 -j ACCEPT
-          iptables -A FORWARD -i tun0 -o tun0 -s 10.20.0.0/24 -d 10.10.10.0/24 -j ACCEPT
+          iptables -A FORWARD -i tun0 -o tun0 -s 10.20.0.0/24 -d 10.240.16.0/20 -j ACCEPT
           iptables -A FORWARD -i tun0 -o tun0 -s 10.20.0.0/24 -d 192.0.2.0/24 -j ACCEPT
 
           iptables -A INPUT -m state --state ESTABLISHED,RELATED -j ACCEPT

--- a/api/pkg/resources/test/fixtures/deployment-openstack-1.10.0-apiserver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-openstack-1.10.0-apiserver.yaml
@@ -165,7 +165,7 @@ spec:
         - --service-account-key-file
         - /etc/kubernetes/service-account-key/sa.key
         - --service-cluster-ip-range
-        - 10.10.10.0/24
+        - 10.240.16.0/20
         - --service-node-port-range
         - 30000-32767
         - --allow-privileged

--- a/api/pkg/resources/test/fixtures/deployment-openstack-1.10.0-openvpn-server.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-openstack-1.10.0-openvpn-server.yaml
@@ -69,10 +69,10 @@ spec:
         - 172.25.0.0
         - 255.255.0.0
         - --push
-        - route 10.10.10.0 255.255.255.0
+        - route 10.240.16.0 255.255.240.0
         - --route
-        - 10.10.10.0
-        - 255.255.255.0
+        - 10.240.16.0
+        - 255.255.240.0
         - --push
         - route 192.0.2.0 255.255.255.0
         - --route
@@ -153,7 +153,7 @@ spec:
           iptables -P FORWARD DROP
           iptables -A FORWARD -m state --state ESTABLISHED,RELATED -j ACCEPT
           iptables -A FORWARD -i tun0 -o tun0 -s 10.20.0.0/24 -d 172.25.0.0/16 -j ACCEPT
-          iptables -A FORWARD -i tun0 -o tun0 -s 10.20.0.0/24 -d 10.10.10.0/24 -j ACCEPT
+          iptables -A FORWARD -i tun0 -o tun0 -s 10.20.0.0/24 -d 10.240.16.0/20 -j ACCEPT
           iptables -A FORWARD -i tun0 -o tun0 -s 10.20.0.0/24 -d 192.0.2.0/24 -j ACCEPT
 
           iptables -A INPUT -m state --state ESTABLISHED,RELATED -j ACCEPT

--- a/api/pkg/resources/test/fixtures/deployment-openstack-1.10.6-apiserver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-openstack-1.10.6-apiserver.yaml
@@ -165,7 +165,7 @@ spec:
         - --service-account-key-file
         - /etc/kubernetes/service-account-key/sa.key
         - --service-cluster-ip-range
-        - 10.10.10.0/24
+        - 10.240.16.0/20
         - --service-node-port-range
         - 30000-32767
         - --allow-privileged

--- a/api/pkg/resources/test/fixtures/deployment-openstack-1.10.6-openvpn-server.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-openstack-1.10.6-openvpn-server.yaml
@@ -69,10 +69,10 @@ spec:
         - 172.25.0.0
         - 255.255.0.0
         - --push
-        - route 10.10.10.0 255.255.255.0
+        - route 10.240.16.0 255.255.240.0
         - --route
-        - 10.10.10.0
-        - 255.255.255.0
+        - 10.240.16.0
+        - 255.255.240.0
         - --push
         - route 192.0.2.0 255.255.255.0
         - --route
@@ -153,7 +153,7 @@ spec:
           iptables -P FORWARD DROP
           iptables -A FORWARD -m state --state ESTABLISHED,RELATED -j ACCEPT
           iptables -A FORWARD -i tun0 -o tun0 -s 10.20.0.0/24 -d 172.25.0.0/16 -j ACCEPT
-          iptables -A FORWARD -i tun0 -o tun0 -s 10.20.0.0/24 -d 10.10.10.0/24 -j ACCEPT
+          iptables -A FORWARD -i tun0 -o tun0 -s 10.20.0.0/24 -d 10.240.16.0/20 -j ACCEPT
           iptables -A FORWARD -i tun0 -o tun0 -s 10.20.0.0/24 -d 192.0.2.0/24 -j ACCEPT
 
           iptables -A INPUT -m state --state ESTABLISHED,RELATED -j ACCEPT

--- a/api/pkg/resources/test/fixtures/deployment-openstack-1.11.0-apiserver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-openstack-1.11.0-apiserver.yaml
@@ -165,7 +165,7 @@ spec:
         - --service-account-key-file
         - /etc/kubernetes/service-account-key/sa.key
         - --service-cluster-ip-range
-        - 10.10.10.0/24
+        - 10.240.16.0/20
         - --service-node-port-range
         - 30000-32767
         - --allow-privileged

--- a/api/pkg/resources/test/fixtures/deployment-openstack-1.11.0-openvpn-server.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-openstack-1.11.0-openvpn-server.yaml
@@ -69,10 +69,10 @@ spec:
         - 172.25.0.0
         - 255.255.0.0
         - --push
-        - route 10.10.10.0 255.255.255.0
+        - route 10.240.16.0 255.255.240.0
         - --route
-        - 10.10.10.0
-        - 255.255.255.0
+        - 10.240.16.0
+        - 255.255.240.0
         - --push
         - route 192.0.2.0 255.255.255.0
         - --route
@@ -153,7 +153,7 @@ spec:
           iptables -P FORWARD DROP
           iptables -A FORWARD -m state --state ESTABLISHED,RELATED -j ACCEPT
           iptables -A FORWARD -i tun0 -o tun0 -s 10.20.0.0/24 -d 172.25.0.0/16 -j ACCEPT
-          iptables -A FORWARD -i tun0 -o tun0 -s 10.20.0.0/24 -d 10.10.10.0/24 -j ACCEPT
+          iptables -A FORWARD -i tun0 -o tun0 -s 10.20.0.0/24 -d 10.240.16.0/20 -j ACCEPT
           iptables -A FORWARD -i tun0 -o tun0 -s 10.20.0.0/24 -d 192.0.2.0/24 -j ACCEPT
 
           iptables -A INPUT -m state --state ESTABLISHED,RELATED -j ACCEPT

--- a/api/pkg/resources/test/fixtures/deployment-openstack-1.11.1-apiserver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-openstack-1.11.1-apiserver.yaml
@@ -165,7 +165,7 @@ spec:
         - --service-account-key-file
         - /etc/kubernetes/service-account-key/sa.key
         - --service-cluster-ip-range
-        - 10.10.10.0/24
+        - 10.240.16.0/20
         - --service-node-port-range
         - 30000-32767
         - --allow-privileged

--- a/api/pkg/resources/test/fixtures/deployment-openstack-1.11.1-openvpn-server.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-openstack-1.11.1-openvpn-server.yaml
@@ -69,10 +69,10 @@ spec:
         - 172.25.0.0
         - 255.255.0.0
         - --push
-        - route 10.10.10.0 255.255.255.0
+        - route 10.240.16.0 255.255.240.0
         - --route
-        - 10.10.10.0
-        - 255.255.255.0
+        - 10.240.16.0
+        - 255.255.240.0
         - --push
         - route 192.0.2.0 255.255.255.0
         - --route
@@ -153,7 +153,7 @@ spec:
           iptables -P FORWARD DROP
           iptables -A FORWARD -m state --state ESTABLISHED,RELATED -j ACCEPT
           iptables -A FORWARD -i tun0 -o tun0 -s 10.20.0.0/24 -d 172.25.0.0/16 -j ACCEPT
-          iptables -A FORWARD -i tun0 -o tun0 -s 10.20.0.0/24 -d 10.10.10.0/24 -j ACCEPT
+          iptables -A FORWARD -i tun0 -o tun0 -s 10.20.0.0/24 -d 10.240.16.0/20 -j ACCEPT
           iptables -A FORWARD -i tun0 -o tun0 -s 10.20.0.0/24 -d 192.0.2.0/24 -j ACCEPT
 
           iptables -A INPUT -m state --state ESTABLISHED,RELATED -j ACCEPT

--- a/api/pkg/resources/test/fixtures/deployment-openstack-1.12.0-apiserver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-openstack-1.12.0-apiserver.yaml
@@ -165,7 +165,7 @@ spec:
         - --service-account-key-file
         - /etc/kubernetes/service-account-key/sa.key
         - --service-cluster-ip-range
-        - 10.10.10.0/24
+        - 10.240.16.0/20
         - --service-node-port-range
         - 30000-32767
         - --allow-privileged

--- a/api/pkg/resources/test/fixtures/deployment-openstack-1.12.0-openvpn-server.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-openstack-1.12.0-openvpn-server.yaml
@@ -69,10 +69,10 @@ spec:
         - 172.25.0.0
         - 255.255.0.0
         - --push
-        - route 10.10.10.0 255.255.255.0
+        - route 10.240.16.0 255.255.240.0
         - --route
-        - 10.10.10.0
-        - 255.255.255.0
+        - 10.240.16.0
+        - 255.255.240.0
         - --push
         - route 192.0.2.0 255.255.255.0
         - --route
@@ -153,7 +153,7 @@ spec:
           iptables -P FORWARD DROP
           iptables -A FORWARD -m state --state ESTABLISHED,RELATED -j ACCEPT
           iptables -A FORWARD -i tun0 -o tun0 -s 10.20.0.0/24 -d 172.25.0.0/16 -j ACCEPT
-          iptables -A FORWARD -i tun0 -o tun0 -s 10.20.0.0/24 -d 10.10.10.0/24 -j ACCEPT
+          iptables -A FORWARD -i tun0 -o tun0 -s 10.20.0.0/24 -d 10.240.16.0/20 -j ACCEPT
           iptables -A FORWARD -i tun0 -o tun0 -s 10.20.0.0/24 -d 192.0.2.0/24 -j ACCEPT
 
           iptables -A INPUT -m state --state ESTABLISHED,RELATED -j ACCEPT

--- a/api/pkg/resources/test/fixtures/deployment-openstack-1.13.0-apiserver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-openstack-1.13.0-apiserver.yaml
@@ -165,7 +165,7 @@ spec:
         - --service-account-key-file
         - /etc/kubernetes/service-account-key/sa.key
         - --service-cluster-ip-range
-        - 10.10.10.0/24
+        - 10.240.16.0/20
         - --service-node-port-range
         - 30000-32767
         - --allow-privileged

--- a/api/pkg/resources/test/fixtures/deployment-openstack-1.13.0-openvpn-server.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-openstack-1.13.0-openvpn-server.yaml
@@ -69,10 +69,10 @@ spec:
         - 172.25.0.0
         - 255.255.0.0
         - --push
-        - route 10.10.10.0 255.255.255.0
+        - route 10.240.16.0 255.255.240.0
         - --route
-        - 10.10.10.0
-        - 255.255.255.0
+        - 10.240.16.0
+        - 255.255.240.0
         - --push
         - route 192.0.2.0 255.255.255.0
         - --route
@@ -153,7 +153,7 @@ spec:
           iptables -P FORWARD DROP
           iptables -A FORWARD -m state --state ESTABLISHED,RELATED -j ACCEPT
           iptables -A FORWARD -i tun0 -o tun0 -s 10.20.0.0/24 -d 172.25.0.0/16 -j ACCEPT
-          iptables -A FORWARD -i tun0 -o tun0 -s 10.20.0.0/24 -d 10.10.10.0/24 -j ACCEPT
+          iptables -A FORWARD -i tun0 -o tun0 -s 10.20.0.0/24 -d 10.240.16.0/20 -j ACCEPT
           iptables -A FORWARD -i tun0 -o tun0 -s 10.20.0.0/24 -d 192.0.2.0/24 -j ACCEPT
 
           iptables -A INPUT -m state --state ESTABLISHED,RELATED -j ACCEPT

--- a/api/pkg/resources/test/fixtures/deployment-vsphere-1.10.0-apiserver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-vsphere-1.10.0-apiserver.yaml
@@ -165,7 +165,7 @@ spec:
         - --service-account-key-file
         - /etc/kubernetes/service-account-key/sa.key
         - --service-cluster-ip-range
-        - 10.10.10.0/24
+        - 10.240.16.0/20
         - --service-node-port-range
         - 30000-32767
         - --allow-privileged

--- a/api/pkg/resources/test/fixtures/deployment-vsphere-1.10.0-openvpn-server.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-vsphere-1.10.0-openvpn-server.yaml
@@ -69,10 +69,10 @@ spec:
         - 172.25.0.0
         - 255.255.0.0
         - --push
-        - route 10.10.10.0 255.255.255.0
+        - route 10.240.16.0 255.255.240.0
         - --route
-        - 10.10.10.0
-        - 255.255.255.0
+        - 10.240.16.0
+        - 255.255.240.0
         - --push
         - route 192.0.2.0 255.255.255.0
         - --route
@@ -153,7 +153,7 @@ spec:
           iptables -P FORWARD DROP
           iptables -A FORWARD -m state --state ESTABLISHED,RELATED -j ACCEPT
           iptables -A FORWARD -i tun0 -o tun0 -s 10.20.0.0/24 -d 172.25.0.0/16 -j ACCEPT
-          iptables -A FORWARD -i tun0 -o tun0 -s 10.20.0.0/24 -d 10.10.10.0/24 -j ACCEPT
+          iptables -A FORWARD -i tun0 -o tun0 -s 10.20.0.0/24 -d 10.240.16.0/20 -j ACCEPT
           iptables -A FORWARD -i tun0 -o tun0 -s 10.20.0.0/24 -d 192.0.2.0/24 -j ACCEPT
 
           iptables -A INPUT -m state --state ESTABLISHED,RELATED -j ACCEPT

--- a/api/pkg/resources/test/fixtures/deployment-vsphere-1.10.6-apiserver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-vsphere-1.10.6-apiserver.yaml
@@ -165,7 +165,7 @@ spec:
         - --service-account-key-file
         - /etc/kubernetes/service-account-key/sa.key
         - --service-cluster-ip-range
-        - 10.10.10.0/24
+        - 10.240.16.0/20
         - --service-node-port-range
         - 30000-32767
         - --allow-privileged

--- a/api/pkg/resources/test/fixtures/deployment-vsphere-1.10.6-openvpn-server.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-vsphere-1.10.6-openvpn-server.yaml
@@ -69,10 +69,10 @@ spec:
         - 172.25.0.0
         - 255.255.0.0
         - --push
-        - route 10.10.10.0 255.255.255.0
+        - route 10.240.16.0 255.255.240.0
         - --route
-        - 10.10.10.0
-        - 255.255.255.0
+        - 10.240.16.0
+        - 255.255.240.0
         - --push
         - route 192.0.2.0 255.255.255.0
         - --route
@@ -153,7 +153,7 @@ spec:
           iptables -P FORWARD DROP
           iptables -A FORWARD -m state --state ESTABLISHED,RELATED -j ACCEPT
           iptables -A FORWARD -i tun0 -o tun0 -s 10.20.0.0/24 -d 172.25.0.0/16 -j ACCEPT
-          iptables -A FORWARD -i tun0 -o tun0 -s 10.20.0.0/24 -d 10.10.10.0/24 -j ACCEPT
+          iptables -A FORWARD -i tun0 -o tun0 -s 10.20.0.0/24 -d 10.240.16.0/20 -j ACCEPT
           iptables -A FORWARD -i tun0 -o tun0 -s 10.20.0.0/24 -d 192.0.2.0/24 -j ACCEPT
 
           iptables -A INPUT -m state --state ESTABLISHED,RELATED -j ACCEPT

--- a/api/pkg/resources/test/fixtures/deployment-vsphere-1.11.0-apiserver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-vsphere-1.11.0-apiserver.yaml
@@ -165,7 +165,7 @@ spec:
         - --service-account-key-file
         - /etc/kubernetes/service-account-key/sa.key
         - --service-cluster-ip-range
-        - 10.10.10.0/24
+        - 10.240.16.0/20
         - --service-node-port-range
         - 30000-32767
         - --allow-privileged

--- a/api/pkg/resources/test/fixtures/deployment-vsphere-1.11.0-openvpn-server.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-vsphere-1.11.0-openvpn-server.yaml
@@ -69,10 +69,10 @@ spec:
         - 172.25.0.0
         - 255.255.0.0
         - --push
-        - route 10.10.10.0 255.255.255.0
+        - route 10.240.16.0 255.255.240.0
         - --route
-        - 10.10.10.0
-        - 255.255.255.0
+        - 10.240.16.0
+        - 255.255.240.0
         - --push
         - route 192.0.2.0 255.255.255.0
         - --route
@@ -153,7 +153,7 @@ spec:
           iptables -P FORWARD DROP
           iptables -A FORWARD -m state --state ESTABLISHED,RELATED -j ACCEPT
           iptables -A FORWARD -i tun0 -o tun0 -s 10.20.0.0/24 -d 172.25.0.0/16 -j ACCEPT
-          iptables -A FORWARD -i tun0 -o tun0 -s 10.20.0.0/24 -d 10.10.10.0/24 -j ACCEPT
+          iptables -A FORWARD -i tun0 -o tun0 -s 10.20.0.0/24 -d 10.240.16.0/20 -j ACCEPT
           iptables -A FORWARD -i tun0 -o tun0 -s 10.20.0.0/24 -d 192.0.2.0/24 -j ACCEPT
 
           iptables -A INPUT -m state --state ESTABLISHED,RELATED -j ACCEPT

--- a/api/pkg/resources/test/fixtures/deployment-vsphere-1.11.1-apiserver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-vsphere-1.11.1-apiserver.yaml
@@ -165,7 +165,7 @@ spec:
         - --service-account-key-file
         - /etc/kubernetes/service-account-key/sa.key
         - --service-cluster-ip-range
-        - 10.10.10.0/24
+        - 10.240.16.0/20
         - --service-node-port-range
         - 30000-32767
         - --allow-privileged

--- a/api/pkg/resources/test/fixtures/deployment-vsphere-1.11.1-openvpn-server.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-vsphere-1.11.1-openvpn-server.yaml
@@ -69,10 +69,10 @@ spec:
         - 172.25.0.0
         - 255.255.0.0
         - --push
-        - route 10.10.10.0 255.255.255.0
+        - route 10.240.16.0 255.255.240.0
         - --route
-        - 10.10.10.0
-        - 255.255.255.0
+        - 10.240.16.0
+        - 255.255.240.0
         - --push
         - route 192.0.2.0 255.255.255.0
         - --route
@@ -153,7 +153,7 @@ spec:
           iptables -P FORWARD DROP
           iptables -A FORWARD -m state --state ESTABLISHED,RELATED -j ACCEPT
           iptables -A FORWARD -i tun0 -o tun0 -s 10.20.0.0/24 -d 172.25.0.0/16 -j ACCEPT
-          iptables -A FORWARD -i tun0 -o tun0 -s 10.20.0.0/24 -d 10.10.10.0/24 -j ACCEPT
+          iptables -A FORWARD -i tun0 -o tun0 -s 10.20.0.0/24 -d 10.240.16.0/20 -j ACCEPT
           iptables -A FORWARD -i tun0 -o tun0 -s 10.20.0.0/24 -d 192.0.2.0/24 -j ACCEPT
 
           iptables -A INPUT -m state --state ESTABLISHED,RELATED -j ACCEPT

--- a/api/pkg/resources/test/fixtures/deployment-vsphere-1.12.0-apiserver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-vsphere-1.12.0-apiserver.yaml
@@ -165,7 +165,7 @@ spec:
         - --service-account-key-file
         - /etc/kubernetes/service-account-key/sa.key
         - --service-cluster-ip-range
-        - 10.10.10.0/24
+        - 10.240.16.0/20
         - --service-node-port-range
         - 30000-32767
         - --allow-privileged

--- a/api/pkg/resources/test/fixtures/deployment-vsphere-1.12.0-openvpn-server.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-vsphere-1.12.0-openvpn-server.yaml
@@ -69,10 +69,10 @@ spec:
         - 172.25.0.0
         - 255.255.0.0
         - --push
-        - route 10.10.10.0 255.255.255.0
+        - route 10.240.16.0 255.255.240.0
         - --route
-        - 10.10.10.0
-        - 255.255.255.0
+        - 10.240.16.0
+        - 255.255.240.0
         - --push
         - route 192.0.2.0 255.255.255.0
         - --route
@@ -153,7 +153,7 @@ spec:
           iptables -P FORWARD DROP
           iptables -A FORWARD -m state --state ESTABLISHED,RELATED -j ACCEPT
           iptables -A FORWARD -i tun0 -o tun0 -s 10.20.0.0/24 -d 172.25.0.0/16 -j ACCEPT
-          iptables -A FORWARD -i tun0 -o tun0 -s 10.20.0.0/24 -d 10.10.10.0/24 -j ACCEPT
+          iptables -A FORWARD -i tun0 -o tun0 -s 10.20.0.0/24 -d 10.240.16.0/20 -j ACCEPT
           iptables -A FORWARD -i tun0 -o tun0 -s 10.20.0.0/24 -d 192.0.2.0/24 -j ACCEPT
 
           iptables -A INPUT -m state --state ESTABLISHED,RELATED -j ACCEPT

--- a/api/pkg/resources/test/fixtures/deployment-vsphere-1.13.0-apiserver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-vsphere-1.13.0-apiserver.yaml
@@ -165,7 +165,7 @@ spec:
         - --service-account-key-file
         - /etc/kubernetes/service-account-key/sa.key
         - --service-cluster-ip-range
-        - 10.10.10.0/24
+        - 10.240.16.0/20
         - --service-node-port-range
         - 30000-32767
         - --allow-privileged

--- a/api/pkg/resources/test/fixtures/deployment-vsphere-1.13.0-openvpn-server.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-vsphere-1.13.0-openvpn-server.yaml
@@ -69,10 +69,10 @@ spec:
         - 172.25.0.0
         - 255.255.0.0
         - --push
-        - route 10.10.10.0 255.255.255.0
+        - route 10.240.16.0 255.255.240.0
         - --route
-        - 10.10.10.0
-        - 255.255.255.0
+        - 10.240.16.0
+        - 255.255.240.0
         - --push
         - route 192.0.2.0 255.255.255.0
         - --route
@@ -153,7 +153,7 @@ spec:
           iptables -P FORWARD DROP
           iptables -A FORWARD -m state --state ESTABLISHED,RELATED -j ACCEPT
           iptables -A FORWARD -i tun0 -o tun0 -s 10.20.0.0/24 -d 172.25.0.0/16 -j ACCEPT
-          iptables -A FORWARD -i tun0 -o tun0 -s 10.20.0.0/24 -d 10.10.10.0/24 -j ACCEPT
+          iptables -A FORWARD -i tun0 -o tun0 -s 10.20.0.0/24 -d 10.240.16.0/20 -j ACCEPT
           iptables -A FORWARD -i tun0 -o tun0 -s 10.20.0.0/24 -d 192.0.2.0/24 -j ACCEPT
 
           iptables -A INPUT -m state --state ESTABLISHED,RELATED -j ACCEPT

--- a/api/pkg/resources/test/load_files_test.go
+++ b/api/pkg/resources/test/load_files_test.go
@@ -208,7 +208,7 @@ func TestLoadFiles(t *testing.T) {
 						Version:        *ksemver.NewSemverOrDie(ver.Version.String()),
 						ClusterNetwork: kubermaticv1.ClusterNetworkingConfig{
 							Services: kubermaticv1.NetworkRanges{
-								CIDRBlocks: []string{"10.10.10.0/24"},
+								CIDRBlocks: []string{"10.240.16.0/20"},
 							},
 							Pods: kubermaticv1.NetworkRanges{
 								CIDRBlocks: []string{"172.25.0.0/16"},


### PR DESCRIPTION
**What this PR does / why we need it**:

Chages the default service cidr for new clusters from 10.10.10.0/24 to 10.240.16.0/20.  A maximum of 254 services is very small, because of that we even have a guide on how change this: https://docs.kubermatic.io/operation/control-plane/increase-service-pod-cidr/

A maximum of 4k services should hopefully cover almost all users.

Also fixes the IP calculation for the kubernetes.default and the kube-dns service. It uses the IP returned from `net.ParseCIDR()` which unfortunately has no netmask set, which means the result is invalid if something other than the network address is passed.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Documentation**:
<!-- Add links to the related documentation changes related to this pull request. E.g. the link to the kubermatic/docs pullrequest. -->

**Does this PR introduce a user-facing change?**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If  no release note is required, just write "NONE".
-->
```release-note
The default service CIDR for new clusters was increased and changed from 10.10.10.0/24 to 10.240.16.0/20
```

/assign @thz 
@thz can you think of anything this collides with? I chose is pretty randomly. Also it seems we basically don't have any kind of sanity checking for CIDR, so if there are colissions, users will notice it only because stuff doesn't work :grimacing: 