### PR TITLE
E2E tests: Increase deletion timeout to accomodate Azure

### DIFF
--- a/api/cmd/conformance-tests/runner.go
+++ b/api/cmd/conformance-tests/runner.go
@@ -476,7 +476,7 @@ func (r *testRunner) testCluster(
 			if err != nil {
 				return fmt.Errorf("failed to parse selector: %v", err)
 			}
-			return wait.PollImmediate(5*time.Second, 5*time.Minute, func() (bool, error) {
+			return wait.PollImmediate(5*time.Second, 15*time.Minute, func() (bool, error) {
 				clusterList := &kubermaticv1.ClusterList{}
 				listOpts := &ctrlruntimeclient.ListOptions{LabelSelector: selector}
 				if err := r.seedClusterClient.List(r.ctx, listOpts, clusterList); err != nil {


### PR DESCRIPTION
**What this PR does / why we need it**:
Azure e2e tests are consistently failing with timeout on deletion, I think just increasing the timeout should fix it.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Documentation**:
<!-- Add links to the related documentation changes related to this pull request. E.g. the link to the kubermatic/docs pullrequest. -->

**Does this PR introduce a user-facing change?**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If  no release note is required, just write "NONE".
-->
```release-note
none
```

/test pull-kubermatic-e2e-azure-coreos-1.15
