### PR TITLE
kubermatic-ui now uses ISO timestamps in logging

### DIFF
--- a/config/kubermatic/templates/kubermatic-ui-dep.yaml
+++ b/config/kubermatic/templates/kubermatic-ui-dep.yaml
@@ -13,6 +13,7 @@ spec:
     metadata:
       annotations:
         checksum/config: {{ include (print $.Template.BasePath "/ui-config-configmap.yaml") . | sha256sum }}
+        fluentbit.io/parser: json_iso
       labels:
         role: kubermatic-ui
         version: v1


### PR DESCRIPTION
**What this PR does / why we need it**:
It's high time we make it known that the dashboard's webserver pod logs uses JSON.

**Does this PR introduce a user-facing change?**:
```release-note
NONE
```
