### PR TITLE
Fix PacketSizesWithClusterCredentialsEndpoint

### DIFF
--- a/api/pkg/handler/routes_v1.go
+++ b/api/pkg/handler/routes_v1.go
@@ -826,6 +826,8 @@ func (r Routing) listPacketSizesNoCredentials() http.Handler {
 		endpoint.Chain(
 			middleware.TokenVerifier(r.tokenVerifiers),
 			middleware.UserSaver(r.userProvider),
+			middleware.SetClusterProvider(r.clusterProviderGetter, r.seedsGetter),
+			middleware.UserInfoExtractor(r.userProjectMapper),
 		)(provider.PacketSizesWithClusterCredentialsEndpoint(r.projectProvider)),
 		provider.DecodePacketSizesNoCredentialsReq,
 		encodeJSON,


### PR DESCRIPTION
**What this PR does / why we need it**:

The PacketSizesWithClusterCredentialsEndpoint threw NPEs because user and clustreprovider were not set, and it also didn't have logic to extract the credentials from the  `CredentialsReference`.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Documentation**:
<!-- Add links to the related documentation changes related to this pull request. E.g. the link to the kubermatic/docs pullrequest. -->

**Does this PR introduce a user-facing change?**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If  no release note is required, just write "NONE".
-->
```release-note
none
```

/assign @zreigz cc @nikhita 
