### PR TITLE
Correctly return openstack.useFloatingIP in NodeDeployment API

### DIFF
--- a/api/pkg/machine/convert.go
+++ b/api/pkg/machine/convert.go
@@ -118,10 +118,10 @@ func GetAPIV2NodeCloudSpec(machineSpec clusterv1alpha1.MachineSpec) (*apiv1.Node
 			Image:  config.Image.Value,
 			Tags:   config.Tags,
 		}
+		cloudSpec.Openstack.UseFloatingIP = config.FloatingIPPool.Value != ""
 		if config.RootDiskSizeGB != nil && *config.RootDiskSizeGB > 0 {
 			cloudSpec.Openstack.RootDiskSizeGB = config.RootDiskSizeGB
 		}
-		cloudSpec.Openstack.UseFloatingIP = len(config.FloatingIPPool.Value) > 0
 	case providerconfig.CloudProviderHetzner:
 		config := &hetzner.RawConfig{}
 		if err := json.Unmarshal(decodedProviderSpec.CloudProviderSpec.Raw, &config); err != nil {

--- a/api/pkg/machine/convert.go
+++ b/api/pkg/machine/convert.go
@@ -121,6 +121,7 @@ func GetAPIV2NodeCloudSpec(machineSpec clusterv1alpha1.MachineSpec) (*apiv1.Node
 		if config.RootDiskSizeGB != nil && *config.RootDiskSizeGB > 0 {
 			cloudSpec.Openstack.RootDiskSizeGB = config.RootDiskSizeGB
 		}
+		cloudSpec.Openstack.UseFloatingIP = len(config.FloatingIPPool.Value) > 0
 	case providerconfig.CloudProviderHetzner:
 		config := &hetzner.RawConfig{}
 		if err := json.Unmarshal(decodedProviderSpec.CloudProviderSpec.Raw, &config); err != nil {


### PR DESCRIPTION
**What this PR does / why we need it**:
Correctly return openstack.useFloatingIP in NodeDeployment API. 

This fixes editing a NodeDeployment which uses floating IPs when it's not required by the datacenter.

**Does this PR introduce a user-facing change?**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If  no release note is required, just write "NONE".
-->
```release-note
NONE
```
