### PR TITLE
Share cluster: Set up oidc groups-claim

### DIFF
--- a/api/hack/run-controller.sh
+++ b/api/hack/run-controller.sh
@@ -22,6 +22,7 @@ KUBERMATIC_WORKERNAME=${KUBERMATIC_WORKERNAME:-$(uname -n)}
   -master-resources=../config/kubermatic/static/master \
   -kubernetes-addons-path=../addons \
   -openshift-addons-path=../openshift_addons \
+  -feature-gates=OpenIDAuthPlugin=true \
   -worker-name="$(tr -cd '[:alnum:]' <<< $KUBERMATIC_WORKERNAME | tr '[:upper:]' '[:lower:]')" \
   -external-url=dev.kubermatic.io \
   -backup-container=../config/kubermatic/static/backup-container.yaml \

--- a/api/pkg/resources/apiserver/deployment.go
+++ b/api/pkg/resources/apiserver/deployment.go
@@ -310,9 +310,13 @@ func getApiserverFlags(data *resources.TemplateData, etcdEndpoints []string, ena
 			flags = append(flags, "--oidc-required-claim", data.Cluster().Spec.OIDC.RequiredClaim)
 		}
 	} else if enableDexCA {
-		flags = append(flags, "--oidc-issuer-url", data.OIDCIssuerURL())
-		flags = append(flags, "--oidc-client-id", data.OIDCIssuerClientID())
-		flags = append(flags, "--oidc-username-claim", "email")
+		flags = append(flags,
+			"--oidc-issuer-url", data.OIDCIssuerURL(),
+			"--oidc-client-id", data.OIDCIssuerClientID(),
+			"--oidc-username-claim", "email",
+			"--oidc-groups-prefix", "oidc:",
+			"--oidc-groups-claim", "groups",
+		)
 		if len(data.OIDCCAFile()) > 0 {
 			flags = append(flags, "--oidc-ca-file", "/etc/kubernetes/dex/ca/caBundle.pem")
 		}

--- a/api/pkg/resources/test/fixtures/deployment-aws-1.10.0-apiserver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-aws-1.10.0-apiserver.yaml
@@ -215,6 +215,10 @@ spec:
         - kubermaticIssuer
         - --oidc-username-claim
         - email
+        - --oidc-groups-prefix
+        - 'oidc:'
+        - --oidc-groups-claim
+        - groups
         - --oidc-ca-file
         - /etc/kubernetes/dex/ca/caBundle.pem
         command:

--- a/api/pkg/resources/test/fixtures/deployment-aws-1.10.6-apiserver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-aws-1.10.6-apiserver.yaml
@@ -215,6 +215,10 @@ spec:
         - kubermaticIssuer
         - --oidc-username-claim
         - email
+        - --oidc-groups-prefix
+        - 'oidc:'
+        - --oidc-groups-claim
+        - groups
         - --oidc-ca-file
         - /etc/kubernetes/dex/ca/caBundle.pem
         command:

--- a/api/pkg/resources/test/fixtures/deployment-aws-1.11.0-apiserver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-aws-1.11.0-apiserver.yaml
@@ -213,6 +213,10 @@ spec:
         - kubermaticIssuer
         - --oidc-username-claim
         - email
+        - --oidc-groups-prefix
+        - 'oidc:'
+        - --oidc-groups-claim
+        - groups
         - --oidc-ca-file
         - /etc/kubernetes/dex/ca/caBundle.pem
         command:

--- a/api/pkg/resources/test/fixtures/deployment-aws-1.11.1-apiserver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-aws-1.11.1-apiserver.yaml
@@ -213,6 +213,10 @@ spec:
         - kubermaticIssuer
         - --oidc-username-claim
         - email
+        - --oidc-groups-prefix
+        - 'oidc:'
+        - --oidc-groups-claim
+        - groups
         - --oidc-ca-file
         - /etc/kubernetes/dex/ca/caBundle.pem
         command:

--- a/api/pkg/resources/test/fixtures/deployment-aws-1.12.0-apiserver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-aws-1.12.0-apiserver.yaml
@@ -213,6 +213,10 @@ spec:
         - kubermaticIssuer
         - --oidc-username-claim
         - email
+        - --oidc-groups-prefix
+        - 'oidc:'
+        - --oidc-groups-claim
+        - groups
         - --oidc-ca-file
         - /etc/kubernetes/dex/ca/caBundle.pem
         command:

--- a/api/pkg/resources/test/fixtures/deployment-aws-1.13.0-apiserver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-aws-1.13.0-apiserver.yaml
@@ -213,6 +213,10 @@ spec:
         - kubermaticIssuer
         - --oidc-username-claim
         - email
+        - --oidc-groups-prefix
+        - 'oidc:'
+        - --oidc-groups-claim
+        - groups
         - --oidc-ca-file
         - /etc/kubernetes/dex/ca/caBundle.pem
         command:

--- a/api/pkg/resources/test/fixtures/deployment-azure-1.10.0-apiserver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-azure-1.10.0-apiserver.yaml
@@ -215,6 +215,10 @@ spec:
         - kubermaticIssuer
         - --oidc-username-claim
         - email
+        - --oidc-groups-prefix
+        - 'oidc:'
+        - --oidc-groups-claim
+        - groups
         - --oidc-ca-file
         - /etc/kubernetes/dex/ca/caBundle.pem
         command:

--- a/api/pkg/resources/test/fixtures/deployment-azure-1.10.6-apiserver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-azure-1.10.6-apiserver.yaml
@@ -215,6 +215,10 @@ spec:
         - kubermaticIssuer
         - --oidc-username-claim
         - email
+        - --oidc-groups-prefix
+        - 'oidc:'
+        - --oidc-groups-claim
+        - groups
         - --oidc-ca-file
         - /etc/kubernetes/dex/ca/caBundle.pem
         command:

--- a/api/pkg/resources/test/fixtures/deployment-azure-1.11.0-apiserver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-azure-1.11.0-apiserver.yaml
@@ -213,6 +213,10 @@ spec:
         - kubermaticIssuer
         - --oidc-username-claim
         - email
+        - --oidc-groups-prefix
+        - 'oidc:'
+        - --oidc-groups-claim
+        - groups
         - --oidc-ca-file
         - /etc/kubernetes/dex/ca/caBundle.pem
         command:

--- a/api/pkg/resources/test/fixtures/deployment-azure-1.11.1-apiserver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-azure-1.11.1-apiserver.yaml
@@ -213,6 +213,10 @@ spec:
         - kubermaticIssuer
         - --oidc-username-claim
         - email
+        - --oidc-groups-prefix
+        - 'oidc:'
+        - --oidc-groups-claim
+        - groups
         - --oidc-ca-file
         - /etc/kubernetes/dex/ca/caBundle.pem
         command:

--- a/api/pkg/resources/test/fixtures/deployment-azure-1.12.0-apiserver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-azure-1.12.0-apiserver.yaml
@@ -213,6 +213,10 @@ spec:
         - kubermaticIssuer
         - --oidc-username-claim
         - email
+        - --oidc-groups-prefix
+        - 'oidc:'
+        - --oidc-groups-claim
+        - groups
         - --oidc-ca-file
         - /etc/kubernetes/dex/ca/caBundle.pem
         command:

--- a/api/pkg/resources/test/fixtures/deployment-azure-1.13.0-apiserver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-azure-1.13.0-apiserver.yaml
@@ -213,6 +213,10 @@ spec:
         - kubermaticIssuer
         - --oidc-username-claim
         - email
+        - --oidc-groups-prefix
+        - 'oidc:'
+        - --oidc-groups-claim
+        - groups
         - --oidc-ca-file
         - /etc/kubernetes/dex/ca/caBundle.pem
         command:

--- a/api/pkg/resources/test/fixtures/deployment-bringyourown-1.10.0-apiserver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-bringyourown-1.10.0-apiserver.yaml
@@ -211,6 +211,10 @@ spec:
         - kubermaticIssuer
         - --oidc-username-claim
         - email
+        - --oidc-groups-prefix
+        - 'oidc:'
+        - --oidc-groups-claim
+        - groups
         - --oidc-ca-file
         - /etc/kubernetes/dex/ca/caBundle.pem
         command:

--- a/api/pkg/resources/test/fixtures/deployment-bringyourown-1.10.6-apiserver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-bringyourown-1.10.6-apiserver.yaml
@@ -211,6 +211,10 @@ spec:
         - kubermaticIssuer
         - --oidc-username-claim
         - email
+        - --oidc-groups-prefix
+        - 'oidc:'
+        - --oidc-groups-claim
+        - groups
         - --oidc-ca-file
         - /etc/kubernetes/dex/ca/caBundle.pem
         command:

--- a/api/pkg/resources/test/fixtures/deployment-bringyourown-1.11.0-apiserver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-bringyourown-1.11.0-apiserver.yaml
@@ -209,6 +209,10 @@ spec:
         - kubermaticIssuer
         - --oidc-username-claim
         - email
+        - --oidc-groups-prefix
+        - 'oidc:'
+        - --oidc-groups-claim
+        - groups
         - --oidc-ca-file
         - /etc/kubernetes/dex/ca/caBundle.pem
         command:

--- a/api/pkg/resources/test/fixtures/deployment-bringyourown-1.11.1-apiserver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-bringyourown-1.11.1-apiserver.yaml
@@ -209,6 +209,10 @@ spec:
         - kubermaticIssuer
         - --oidc-username-claim
         - email
+        - --oidc-groups-prefix
+        - 'oidc:'
+        - --oidc-groups-claim
+        - groups
         - --oidc-ca-file
         - /etc/kubernetes/dex/ca/caBundle.pem
         command:

--- a/api/pkg/resources/test/fixtures/deployment-bringyourown-1.12.0-apiserver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-bringyourown-1.12.0-apiserver.yaml
@@ -209,6 +209,10 @@ spec:
         - kubermaticIssuer
         - --oidc-username-claim
         - email
+        - --oidc-groups-prefix
+        - 'oidc:'
+        - --oidc-groups-claim
+        - groups
         - --oidc-ca-file
         - /etc/kubernetes/dex/ca/caBundle.pem
         command:

--- a/api/pkg/resources/test/fixtures/deployment-bringyourown-1.13.0-apiserver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-bringyourown-1.13.0-apiserver.yaml
@@ -209,6 +209,10 @@ spec:
         - kubermaticIssuer
         - --oidc-username-claim
         - email
+        - --oidc-groups-prefix
+        - 'oidc:'
+        - --oidc-groups-claim
+        - groups
         - --oidc-ca-file
         - /etc/kubernetes/dex/ca/caBundle.pem
         command:

--- a/api/pkg/resources/test/fixtures/deployment-digitalocean-1.10.0-apiserver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-digitalocean-1.10.0-apiserver.yaml
@@ -211,6 +211,10 @@ spec:
         - kubermaticIssuer
         - --oidc-username-claim
         - email
+        - --oidc-groups-prefix
+        - 'oidc:'
+        - --oidc-groups-claim
+        - groups
         - --oidc-ca-file
         - /etc/kubernetes/dex/ca/caBundle.pem
         command:

--- a/api/pkg/resources/test/fixtures/deployment-digitalocean-1.10.6-apiserver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-digitalocean-1.10.6-apiserver.yaml
@@ -211,6 +211,10 @@ spec:
         - kubermaticIssuer
         - --oidc-username-claim
         - email
+        - --oidc-groups-prefix
+        - 'oidc:'
+        - --oidc-groups-claim
+        - groups
         - --oidc-ca-file
         - /etc/kubernetes/dex/ca/caBundle.pem
         command:

--- a/api/pkg/resources/test/fixtures/deployment-digitalocean-1.11.0-apiserver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-digitalocean-1.11.0-apiserver.yaml
@@ -209,6 +209,10 @@ spec:
         - kubermaticIssuer
         - --oidc-username-claim
         - email
+        - --oidc-groups-prefix
+        - 'oidc:'
+        - --oidc-groups-claim
+        - groups
         - --oidc-ca-file
         - /etc/kubernetes/dex/ca/caBundle.pem
         command:

--- a/api/pkg/resources/test/fixtures/deployment-digitalocean-1.11.1-apiserver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-digitalocean-1.11.1-apiserver.yaml
@@ -209,6 +209,10 @@ spec:
         - kubermaticIssuer
         - --oidc-username-claim
         - email
+        - --oidc-groups-prefix
+        - 'oidc:'
+        - --oidc-groups-claim
+        - groups
         - --oidc-ca-file
         - /etc/kubernetes/dex/ca/caBundle.pem
         command:

--- a/api/pkg/resources/test/fixtures/deployment-digitalocean-1.12.0-apiserver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-digitalocean-1.12.0-apiserver.yaml
@@ -209,6 +209,10 @@ spec:
         - kubermaticIssuer
         - --oidc-username-claim
         - email
+        - --oidc-groups-prefix
+        - 'oidc:'
+        - --oidc-groups-claim
+        - groups
         - --oidc-ca-file
         - /etc/kubernetes/dex/ca/caBundle.pem
         command:

--- a/api/pkg/resources/test/fixtures/deployment-digitalocean-1.13.0-apiserver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-digitalocean-1.13.0-apiserver.yaml
@@ -209,6 +209,10 @@ spec:
         - kubermaticIssuer
         - --oidc-username-claim
         - email
+        - --oidc-groups-prefix
+        - 'oidc:'
+        - --oidc-groups-claim
+        - groups
         - --oidc-ca-file
         - /etc/kubernetes/dex/ca/caBundle.pem
         command:

--- a/api/pkg/resources/test/fixtures/deployment-openstack-1.10.0-apiserver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-openstack-1.10.0-apiserver.yaml
@@ -215,6 +215,10 @@ spec:
         - kubermaticIssuer
         - --oidc-username-claim
         - email
+        - --oidc-groups-prefix
+        - 'oidc:'
+        - --oidc-groups-claim
+        - groups
         - --oidc-ca-file
         - /etc/kubernetes/dex/ca/caBundle.pem
         command:

--- a/api/pkg/resources/test/fixtures/deployment-openstack-1.10.6-apiserver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-openstack-1.10.6-apiserver.yaml
@@ -215,6 +215,10 @@ spec:
         - kubermaticIssuer
         - --oidc-username-claim
         - email
+        - --oidc-groups-prefix
+        - 'oidc:'
+        - --oidc-groups-claim
+        - groups
         - --oidc-ca-file
         - /etc/kubernetes/dex/ca/caBundle.pem
         command:

--- a/api/pkg/resources/test/fixtures/deployment-openstack-1.11.0-apiserver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-openstack-1.11.0-apiserver.yaml
@@ -213,6 +213,10 @@ spec:
         - kubermaticIssuer
         - --oidc-username-claim
         - email
+        - --oidc-groups-prefix
+        - 'oidc:'
+        - --oidc-groups-claim
+        - groups
         - --oidc-ca-file
         - /etc/kubernetes/dex/ca/caBundle.pem
         command:

--- a/api/pkg/resources/test/fixtures/deployment-openstack-1.11.1-apiserver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-openstack-1.11.1-apiserver.yaml
@@ -213,6 +213,10 @@ spec:
         - kubermaticIssuer
         - --oidc-username-claim
         - email
+        - --oidc-groups-prefix
+        - 'oidc:'
+        - --oidc-groups-claim
+        - groups
         - --oidc-ca-file
         - /etc/kubernetes/dex/ca/caBundle.pem
         command:

--- a/api/pkg/resources/test/fixtures/deployment-openstack-1.12.0-apiserver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-openstack-1.12.0-apiserver.yaml
@@ -213,6 +213,10 @@ spec:
         - kubermaticIssuer
         - --oidc-username-claim
         - email
+        - --oidc-groups-prefix
+        - 'oidc:'
+        - --oidc-groups-claim
+        - groups
         - --oidc-ca-file
         - /etc/kubernetes/dex/ca/caBundle.pem
         command:

--- a/api/pkg/resources/test/fixtures/deployment-openstack-1.13.0-apiserver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-openstack-1.13.0-apiserver.yaml
@@ -213,6 +213,10 @@ spec:
         - kubermaticIssuer
         - --oidc-username-claim
         - email
+        - --oidc-groups-prefix
+        - 'oidc:'
+        - --oidc-groups-claim
+        - groups
         - --oidc-ca-file
         - /etc/kubernetes/dex/ca/caBundle.pem
         command:

--- a/api/pkg/resources/test/fixtures/deployment-vsphere-1.10.0-apiserver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-vsphere-1.10.0-apiserver.yaml
@@ -215,6 +215,10 @@ spec:
         - kubermaticIssuer
         - --oidc-username-claim
         - email
+        - --oidc-groups-prefix
+        - 'oidc:'
+        - --oidc-groups-claim
+        - groups
         - --oidc-ca-file
         - /etc/kubernetes/dex/ca/caBundle.pem
         command:

--- a/api/pkg/resources/test/fixtures/deployment-vsphere-1.10.6-apiserver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-vsphere-1.10.6-apiserver.yaml
@@ -215,6 +215,10 @@ spec:
         - kubermaticIssuer
         - --oidc-username-claim
         - email
+        - --oidc-groups-prefix
+        - 'oidc:'
+        - --oidc-groups-claim
+        - groups
         - --oidc-ca-file
         - /etc/kubernetes/dex/ca/caBundle.pem
         command:

--- a/api/pkg/resources/test/fixtures/deployment-vsphere-1.11.0-apiserver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-vsphere-1.11.0-apiserver.yaml
@@ -213,6 +213,10 @@ spec:
         - kubermaticIssuer
         - --oidc-username-claim
         - email
+        - --oidc-groups-prefix
+        - 'oidc:'
+        - --oidc-groups-claim
+        - groups
         - --oidc-ca-file
         - /etc/kubernetes/dex/ca/caBundle.pem
         command:

--- a/api/pkg/resources/test/fixtures/deployment-vsphere-1.11.1-apiserver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-vsphere-1.11.1-apiserver.yaml
@@ -213,6 +213,10 @@ spec:
         - kubermaticIssuer
         - --oidc-username-claim
         - email
+        - --oidc-groups-prefix
+        - 'oidc:'
+        - --oidc-groups-claim
+        - groups
         - --oidc-ca-file
         - /etc/kubernetes/dex/ca/caBundle.pem
         command:

--- a/api/pkg/resources/test/fixtures/deployment-vsphere-1.12.0-apiserver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-vsphere-1.12.0-apiserver.yaml
@@ -213,6 +213,10 @@ spec:
         - kubermaticIssuer
         - --oidc-username-claim
         - email
+        - --oidc-groups-prefix
+        - 'oidc:'
+        - --oidc-groups-claim
+        - groups
         - --oidc-ca-file
         - /etc/kubernetes/dex/ca/caBundle.pem
         command:

--- a/api/pkg/resources/test/fixtures/deployment-vsphere-1.13.0-apiserver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-vsphere-1.13.0-apiserver.yaml
@@ -213,6 +213,10 @@ spec:
         - kubermaticIssuer
         - --oidc-username-claim
         - email
+        - --oidc-groups-prefix
+        - 'oidc:'
+        - --oidc-groups-claim
+        - groups
         - --oidc-ca-file
         - /etc/kubernetes/dex/ca/caBundle.pem
         command:


### PR DESCRIPTION
**What this PR does / why we need it**:

Sets the oidc groups claim when the share cluster feature is enabled, so groups can be used for permission management.

I've tested that this does't cause issues when the IDP does not set the `groups` property

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Documentation**:
<!-- Add links to the related documentation changes related to this pull request. E.g. the link to the kubermatic/docs pullrequest. -->

**Does this PR introduce a user-facing change?**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If  no release note is required, just write "NONE".
-->
```release-note
The share cluster feature now allows to use groups, if passed by the IDP. All groups are prefixed with `oidc:`
```

/assign @thz @zreigz 