### PR TITLE
Add config option for kube-proxy mode to cluster CR

### DIFF
--- a/addons/kube-proxy/configmap.yaml
+++ b/addons/kube-proxy/configmap.yaml
@@ -39,7 +39,7 @@ data:
       syncPeriod: 30s
     kind: KubeProxyConfiguration
     metricsBindAddress: 127.0.0.1:10249
-    mode: ""
+    mode: {{ .Cluster.Address.ProxyMode }}
     nodePortAddresses: null
     oomScoreAdj: -999
     portRange: ""

--- a/addons/kube-proxy/configmap.yaml
+++ b/addons/kube-proxy/configmap.yaml
@@ -39,7 +39,7 @@ data:
       syncPeriod: 30s
     kind: KubeProxyConfiguration
     metricsBindAddress: 127.0.0.1:10249
-    mode: {{ .Cluster.Address.ProxyMode }}
+    mode: {{ .Cluster.Spec.ClusterNetwork.ProxyMode }}
     nodePortAddresses: null
     oomScoreAdj: -999
     portRange: ""

--- a/api/pkg/controller/addon/addon_controller_test.go
+++ b/api/pkg/controller/addon/addon_controller_test.go
@@ -12,6 +12,7 @@ import (
 
 	kubermaticv1 "github.com/kubermatic/kubermatic/api/pkg/crd/kubermatic/v1"
 	kubermaticlog "github.com/kubermatic/kubermatic/api/pkg/log"
+	"github.com/kubermatic/kubermatic/api/pkg/resources"
 	"github.com/kubermatic/kubermatic/api/pkg/semver"
 
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -141,6 +142,7 @@ func setupTestCluster(CIDRBlock string) *kubermaticv1.Cluster {
 					},
 				},
 				DNSDomain: "cluster.local",
+				ProxyMode: resources.IPVSProxyMode,
 			},
 			Cloud: kubermaticv1.CloudSpec{
 				Digitalocean: &kubermaticv1.DigitaloceanCloudSpec{

--- a/api/pkg/controller/cluster/pending.go
+++ b/api/pkg/controller/cluster/pending.go
@@ -10,6 +10,7 @@ import (
 	kubermaticapiv1 "github.com/kubermatic/kubermatic/api/pkg/api/v1"
 	kubermaticv1 "github.com/kubermatic/kubermatic/api/pkg/crd/kubermatic/v1"
 	kuberneteshelper "github.com/kubermatic/kubermatic/api/pkg/kubernetes"
+	"github.com/kubermatic/kubermatic/api/pkg/resources"
 )
 
 const (
@@ -92,6 +93,13 @@ func (r *Reconciler) ensureClusterNetworkDefaults(ctx context.Context, cluster *
 			c.Spec.ClusterNetwork.DNSDomain = "cluster.local"
 		}
 		modifiers = append(modifiers, setDNSDomain)
+	}
+
+	if cluster.Spec.ClusterNetwork.ProxyMode == "" {
+		setProxyMode := func(c *kubermaticv1.Cluster) {
+			c.Spec.ClusterNetwork.ProxyMode = resources.IPVSProxyMode
+		}
+		modifiers = append(modifiers, setProxyMode)
 	}
 
 	return r.updateCluster(ctx, cluster, func(c *kubermaticv1.Cluster) {

--- a/api/pkg/crd/kubermatic/v1/cluster.go
+++ b/api/pkg/crd/kubermatic/v1/cluster.go
@@ -140,6 +140,10 @@ type ClusterNetworkingConfig struct {
 
 	// Domain name for services.
 	DNSDomain string `json:"dnsDomain"`
+
+	// ProxyMode defines the kube-proxy mode (ipvs/iptables).
+	// Defaults to ipvs.
+	ProxyMode string `json:"proxyMode"`
 }
 
 // MachineNetworkingConfig specifies the networking parameters used for IPAM.

--- a/api/pkg/resources/resources.go
+++ b/api/pkg/resources/resources.go
@@ -296,6 +296,11 @@ const (
 
 	// DefaultDNATControllerImage defines the default image containing the dnat controller
 	DefaultDNATControllerImage = "quay.io/kubermatic/kubeletdnat-controller"
+
+	// IPVSProxyMode defines the ipvs kube-proxy mode.
+	IPVSProxyMode = "ipvs"
+	// IPTablesProxyMode defines the iptables kube-proxy mode.
+	IPTablesProxyMode = "iptables"
 )
 
 const (

--- a/api/pkg/resources/test/load_files_test.go
+++ b/api/pkg/resources/test/load_files_test.go
@@ -214,6 +214,7 @@ func TestLoadFiles(t *testing.T) {
 								CIDRBlocks: []string{"172.25.0.0/16"},
 							},
 							DNSDomain: "cluster.local",
+							ProxyMode: resources.IPVSProxyMode,
 						},
 						MachineNetworks: []kubermaticv1.MachineNetworkingConfig{
 							{


### PR DESCRIPTION
Fixes https://github.com/kubermatic/kubermatic/issues/3935

Defaults to ipvs, if not specified.

For older clusters, they are migrated with proxy mode set to iptables
since that was the one used before.


**Does this PR introduce a user-facing change?**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If  no release note is required, just write "NONE".
-->
```release-note
The kube-proxy mode (ipvs/iptables) can now be configured. If not specified, it defaults to ipvs.
```
