### PR TITLE
Download gocache in CI builds

### DIFF
--- a/api/Makefile
+++ b/api/Makefile
@@ -21,7 +21,7 @@ all: check vendor build test
 
 build: $(CMD)
 
-$(CMD):
+$(CMD): download-gocache
 	go build $(GOTOOLFLAGS) -o $(BUILD_DEST)/$@ ./cmd/$@
 
 install:
@@ -32,7 +32,10 @@ showenv:
 
 check: gofmt lint
 
-test:
+download-gocache:
+	@./hack/ci/ci-download-gocache.sh
+
+test: download-gocache
 	CGO_ENABLED=1 go test -tags=unit -race ./...
 	@# Make sure all e2e tests compile with their individual build tag
 	@# without actually running them by using `-run` with a non-existing test.
@@ -44,7 +47,7 @@ test:
 	go test -tags integration -run nope ./...
 
 test-integration : CGO_ENABLED = 1
-test-integration:
+test-integration: download-gocache
 	@# Run integration tests and only integration tests by:
 	@# * Finding all files that contain the build tag via grep
 	@# * Extracting the dirname as the `go test` command doesn't play well with individual files as args

--- a/api/cmd/nodeport-proxy/Makefile
+++ b/api/cmd/nodeport-proxy/Makefile
@@ -1,10 +1,10 @@
 default: test build
 
 lb-updater:
-	CGO_ENABLED=0 go build -o ./_build/lb-updater -a -installsuffix cgo github.com/kubermatic/kubermatic/api/cmd/nodeport-proxy/lb-updater
+	CGO_ENABLED=0 go build -o ./_build/lb-updater github.com/kubermatic/kubermatic/api/cmd/nodeport-proxy/lb-updater
 
 envoy-manager:
-	CGO_ENABLED=0 go build -o ./_build/envoy-manager -a -installsuffix cgo github.com/kubermatic/kubermatic/api/cmd/nodeport-proxy/envoy-manager
+	CGO_ENABLED=0 go build -o ./_build/envoy-manager github.com/kubermatic/kubermatic/api/cmd/nodeport-proxy/envoy-manager
 
 build: envoy-manager lb-updater
 

--- a/api/hack/ci/ci-download-gocache.sh
+++ b/api/hack/ci/ci-download-gocache.sh
@@ -13,7 +13,6 @@ trap exit_gracefully EXIT
 
 source $(dirname $0)/../lib.sh
 
-export GOCACHE_MINIO_ADDRESS='http://minio.gocache.svc.cluster.local.:9000/gocache'
 if [ -z ${GOCACHE_MINIO_ADDRESS:-} ]; then
   echodate "env var GOCACHE_MINIO_ADDRESS unset, can not download gocache"
   exit 0
@@ -34,8 +33,6 @@ if [ -z $PULL_NUMBER ]; then
   # as there can't be a cache for the current revision
   CACHE_VERSION=$(git rev-parse ${CACHE_VERSION}~1)
 fi
-# Hardcoded for testing
-CACHE_VERSION=cc824851648f78ea93effe97d223fd52fe16c1f3
 
 echodata "Downloading and extracting gocache"
 TEST_NAME="Download and extract gocache"

--- a/api/hack/ci/ci-download-gocache.sh
+++ b/api/hack/ci/ci-download-gocache.sh
@@ -11,7 +11,7 @@ set -o monitor
 exit_gracefully() { exit 0; }
 trap exit_gracefully EXIT
 
-source ./api/hack/lib.sh
+source $(dirname $0)/../lib.sh
 
 if [ -z $GOCACHE_MINIO_ADDRESS ]; then
   echodate "env var GOCACHE_MINIO_ADDRESS unset, can not download gocache"
@@ -45,3 +45,5 @@ retry 5 curl --fail
     -H @/tmp/headers \
     ${GOCACHE_MINIO_ADDRESS}/${CACHE_VERSION}.tar \
     |tar -C $GOCACHE -xvf -
+
+echodate "Successfully fetched gocache"

--- a/api/hack/ci/ci-download-gocache.sh
+++ b/api/hack/ci/ci-download-gocache.sh
@@ -8,7 +8,7 @@ set -euo pipefail
 set -o monitor
 
 # Make sure we never error, this is always best-effort only
-exit_gracefully { exit 0 }
+exit_gracefully() { exit 0; }
 trap exit_gracefully EXIT
 
 source ./api/hack/lib.sh

--- a/api/hack/ci/ci-download-gocache.sh
+++ b/api/hack/ci/ci-download-gocache.sh
@@ -33,10 +33,15 @@ if [ -z $PULL_NUMBER ]; then
   # as there can't be a cache for the current revision
   CACHE_VERSION=$(git rev-parse ${CACHE_VERSION}~1)
 fi
+# Hardcoded for testing
+CACHE_VERSION=6af928d8093bbf096986170f1496fb134f7db843
 
 TEST_NAME="Download and extract gocache"
+# Passing the Headers as space-separated literals doesn't seem to work
+# in conjunction with the retry func, so we just put them in a file instead
+echo 'Content-Type: application/octet-stream' > /tmp/headers
 retry 5 curl --fail
     --progress-bar \
-    -H "Content-Type: binary/octet-stream" \
+    -H @/tmp/headers \
     ${GOCACHE_MINIO_ADDRESS}/${CACHE_VERSION}.tar \
     |tar -C $GOCACHE -xvf -

--- a/api/hack/ci/ci-download-gocache.sh
+++ b/api/hack/ci/ci-download-gocache.sh
@@ -28,7 +28,7 @@ if ls -1qA $GOCACHE | grep -q .; then
 fi
 
 CACHE_VERSION="${PULL_BASE_SHA}"
-if [ -z $PULL_NUMBER ]; then
+if [ -z ${PULL_NUMBER:-} ]; then
   # Special case: This is called in a Postubmit. Go one revision back,
   # as there can't be a cache for the current revision
   CACHE_VERSION=$(git rev-parse ${CACHE_VERSION}~1)

--- a/api/hack/ci/ci-download-gocache.sh
+++ b/api/hack/ci/ci-download-gocache.sh
@@ -31,12 +31,12 @@ CACHE_VERSION="${PULL_BASE_SHA}"
 if [ -z $PULL_NUMBER ]; then
   # Special case: This is called in a Postubmit. Go one revision back,
   # as there can't be a cache for the current revision
-  CACHE_VERSION=$(git rev-parse ${CACHE_VERSION}~1|tr -d '\n')
+  CACHE_VERSION=$(git rev-parse ${CACHE_VERSION}~1)
 fi
 
 TEST_NAME="Download and extract gocache"
 retry 5 curl --fail
-    --progress-bar\
+    --progress-bar \
     -H "Content-Type: binary/octet-stream" \
     ${GOCACHE_MINIO_ADDRESS}/${CACHE_VERSION}.tar \
     |tar -C $GOCACHE -xvf -

--- a/api/hack/ci/ci-download-gocache.sh
+++ b/api/hack/ci/ci-download-gocache.sh
@@ -41,7 +41,7 @@ TEST_NAME="Download and extract gocache"
 # Passing the Headers as space-separated literals doesn't seem to work
 # in conjunction with the retry func, so we just put them in a file instead
 echo 'Content-Type: application/octet-stream' > /tmp/headers
-retry 5 curl --fail
+retry 5 curl --fail \
     --progress-bar \
     -H @/tmp/headers \
     ${GOCACHE_MINIO_ADDRESS}/${CACHE_VERSION}.tar \

--- a/api/hack/ci/ci-download-gocache.sh
+++ b/api/hack/ci/ci-download-gocache.sh
@@ -35,7 +35,7 @@ if [ -z $PULL_NUMBER ]; then
   CACHE_VERSION=$(git rev-parse ${CACHE_VERSION}~1)
 fi
 # Hardcoded for testing
-CACHE_VERSION=6af928d8093bbf096986170f1496fb134f7db843
+CACHE_VERSION=cc824851648f78ea93effe97d223fd52fe16c1f3
 
 TEST_NAME="Download and extract gocache"
 # Passing the Headers as space-separated literals doesn't seem to work
@@ -47,4 +47,4 @@ retry 5 curl --fail \
     ${GOCACHE_MINIO_ADDRESS}/${CACHE_VERSION}.tar \
     |tar -C $GOCACHE -xf -
 
-echodate "Successfully fetched gocache"
+echodate "Successfully fetched gocache into $GOCACHE"

--- a/api/hack/ci/ci-download-gocache.sh
+++ b/api/hack/ci/ci-download-gocache.sh
@@ -37,6 +37,7 @@ fi
 # Hardcoded for testing
 CACHE_VERSION=cc824851648f78ea93effe97d223fd52fe16c1f3
 
+echodata "Downloading and extracting gocache"
 TEST_NAME="Download and extract gocache"
 # Passing the Headers as space-separated literals doesn't seem to work
 # in conjunction with the retry func, so we just put them in a file instead

--- a/api/hack/ci/ci-download-gocache.sh
+++ b/api/hack/ci/ci-download-gocache.sh
@@ -23,7 +23,7 @@ GOCACHE=$(go env GOCACHE)
 # Make sure it actually exists
 mkdir -p $GOCACHE
 
-if ls -1qA ./somedir/ | grep -q .; then
+if ls -1qA $GOCACHE | grep -q .; then
   echodate "gocache at $GOCACHE is not empty, omitting download of gocache"
   exit 0
 fi

--- a/api/hack/ci/ci-download-gocache.sh
+++ b/api/hack/ci/ci-download-gocache.sh
@@ -1,0 +1,36 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+# Required for signal propagation to work so
+# the cleanup trap gets executed when the script
+# receives a SIGINT
+set -o monitor
+
+# Make sure we never error, this is always best-effort only
+exit_gracefully { exit 0 }
+trap exit_gracefully EXIT
+
+source ./api/hack/lib.sh
+
+if [ -z $GOCACHE_MINIO_ADDRESS ]; then
+  echodate "env var GOCACHE_MINIO_ADDRESS unset, can not download gocache"
+  exit 0
+fi
+
+GOCACHE=$(go env GOCACHE)
+# Make sure it actually exists
+mkdir -p $GOCACHE
+
+if ls -1qA ./somedir/ | grep -q .; then
+  echodate "gocache at $GOCACHE is not empty, omitting download of gocache"
+  exit 0
+fi
+
+CACHE_VERSION="${PULL_BASE_SHA}"
+TEST_NAME="Download and extract gocache"
+retry 5 curl --fail
+    --progress-bar\
+    -H "Content-Type: binary/octet-stream" \
+    ${GOCACHE_MINIO_ADDRESS}/${CACHE_VERSION}.tar \
+    |tar -C $GOCACHE -xvf -

--- a/api/hack/ci/ci-download-gocache.sh
+++ b/api/hack/ci/ci-download-gocache.sh
@@ -45,6 +45,6 @@ retry 5 curl --fail \
     --progress-bar \
     -H @/tmp/headers \
     ${GOCACHE_MINIO_ADDRESS}/${CACHE_VERSION}.tar \
-    |tar -C $GOCACHE -xvf -
+    |tar -C $GOCACHE -xf -
 
 echodate "Successfully fetched gocache"

--- a/api/hack/ci/ci-download-gocache.sh
+++ b/api/hack/ci/ci-download-gocache.sh
@@ -28,6 +28,12 @@ if ls -1qA ./somedir/ | grep -q .; then
 fi
 
 CACHE_VERSION="${PULL_BASE_SHA}"
+if [ -z $PULL_NUMBER ]; then
+  # Special case: This is called in a Postubmit. Go one revision back,
+  # as there can't be a cache for the current revision
+  CACHE_VERSION=$(git rev-parse ${CACHE_VERSION}~1|tr -d '\n')
+fi
+
 TEST_NAME="Download and extract gocache"
 retry 5 curl --fail
     --progress-bar\

--- a/api/hack/ci/ci-download-gocache.sh
+++ b/api/hack/ci/ci-download-gocache.sh
@@ -13,7 +13,8 @@ trap exit_gracefully EXIT
 
 source $(dirname $0)/../lib.sh
 
-if [ -z $GOCACHE_MINIO_ADDRESS ]; then
+export GOCACHE_MINIO_ADDRESS='http://minio.gocache.svc.cluster.local.:9000/gocache'
+if [ -z ${GOCACHE_MINIO_ADDRESS:-} ]; then
   echodate "env var GOCACHE_MINIO_ADDRESS unset, can not download gocache"
   exit 0
 fi

--- a/api/hack/ci/ci-upload-gocache.sh
+++ b/api/hack/ci/ci-upload-gocache.sh
@@ -1,4 +1,4 @@
-#/usr/bin/env bash
+#!/usr/bin/env bash
 
 set -euo pipefail
 

--- a/api/hack/ci/ci-upload-gocache.sh
+++ b/api/hack/ci/ci-upload-gocache.sh
@@ -9,7 +9,7 @@ set -o monitor
 
 source $(dirname $0)/../lib.sh
 
-if [ -z $GOCACHE_MINIO_ADDRESS ]; then
+if [ -z ${GOCACHE_MINIO_ADDRESS:-} ]; then
   echodate "Fatal: env var GOCACHE_MINIO_ADDRESS unset"
   exit 1
 fi
@@ -22,7 +22,7 @@ export CGO_ENABLED=0
 cd $(dirname $0)/../..
 
 echodate "Building binaries"
-TEST_NAME="Buil Kubermatic"
+TEST_NAME="Build Kubermatic"
 retry 2 make build
 (
   TEST_NAME="Building Nodeport proxy"

--- a/api/hack/ci/ci-upload-gocache.sh
+++ b/api/hack/ci/ci-upload-gocache.sh
@@ -53,8 +53,11 @@ trap debug_sleep EXIT
 
 echodate "Uploading gocache archive"
 TEST_NAME="Uploading gocache archive"
+# Passing the Headers as space-separated literals doesn't seem to work
+# in conjunction with the retry func, so we just put them in a file instead
+echo 'Content-Type: application/octet-stream' > /tmp/headers
 retry 2 curl --fail \
   --progress-bar \
   -T ${ARCHIVE_FILE} \
-  -H "Content-Type: application/octet-stream" \
-  ${GOCACHE_MINIO_ADDRESS}/${ARCHIVE_FILE}
+  -H @/tmp/headers \
+  ${GOCACHE_MINIO_ADDRESS}/${GIT_HEAD_HASH}.tar

--- a/api/hack/ci/ci-upload-gocache.sh
+++ b/api/hack/ci/ci-upload-gocache.sh
@@ -48,6 +48,9 @@ ARCHIVE_FILE=/tmp/${GIT_HEAD_HASH}.tar
 # No compression because that needs quite a bit of CPU
 retry 2 tar -C $GOCACHE -cvf $ARCHIVE_FILE .
 
+sleep() { sleep 1d; }
+trap sleep EXIT
+
 echodate "Uploading gocache archive"
 TEST_NAME="Uploading gocache archive"
 retry 2 curl --fail \

--- a/api/hack/ci/ci-upload-gocache.sh
+++ b/api/hack/ci/ci-upload-gocache.sh
@@ -48,9 +48,6 @@ ARCHIVE_FILE=/tmp/${GIT_HEAD_HASH}.tar
 # No compression because that needs quite a bit of CPU
 retry 2 tar -C $GOCACHE -cvf $ARCHIVE_FILE .
 
-debug_sleep() { sleep 1d; }
-trap debug_sleep EXIT
-
 echodate "Uploading gocache archive"
 TEST_NAME="Uploading gocache archive"
 # Passing the Headers as space-separated literals doesn't seem to work

--- a/api/hack/ci/ci-upload-gocache.sh
+++ b/api/hack/ci/ci-upload-gocache.sh
@@ -1,0 +1,54 @@
+#/usr/bin/env bash
+
+set -euo pipefail
+
+# Required for signal propagation to work so
+# the cleanup trap gets executed when the script
+# receives a SIGINT
+set -o monitor
+
+source ./api/hack/lib.sh
+
+if [ -z $GOCACHE_MINIO_ADDRESS ]; then
+  echodate "Fatal: env var GOCACHE_MINIO_ADDRESS unset"
+  exit 1
+fi
+
+GOCACHE_DIR=$(mktemp -d)
+export GOCACHE="${GOCACHE_DIR}"
+export GIT_HEAD_HASH="$(git rev-parse HEAD|tr -d '\n')"
+
+export CGO_ENABLED=0
+cd $(dirname $0)/../..
+
+echodata "Building binaries"
+TEST_NAME="Buil Kubermatic"
+retry 2 make build
+(
+  TEST_NAME="Building Nodeport proxy"
+  cd cmd/nodeport-proxy
+  retry 2 make build
+)
+(
+  TEST_NAME="Building kubeletdnat controller"
+  cd cmd/kubeletdnat-controller
+  retry 2 make build
+)
+
+echodate "Building tests"
+TEST_NAME="Build tests"
+retry 2 go test -tags=cloud,create,e2e,integration ./... -run nope
+
+echodate "Creating gocache archive"
+TEST_NAME="Creating gocache archive"
+ARCHIVE_FILE=/tmp/${GIT_HEAD_HASH}.tar
+# No compression because that needs quite a bit of CPU
+retry 2 tar -C $GOCACHE -cvf $ARCHIVE_FILE .
+
+echodate "Uploading gocache archive"
+TEST_NAME="Uploading gocache archive"
+retry 2 curl --fail \
+  --progress-bar \
+  -T ${ARCHIVE_FILE} \
+  -H "Content-Type: application/octet-stream" \
+  ${GOCACHE_MINIO_ADDRESS}/${ARCHIVE_FILE}

--- a/api/hack/ci/ci-upload-gocache.sh
+++ b/api/hack/ci/ci-upload-gocache.sh
@@ -37,7 +37,7 @@ retry 2 make build
 
 echodate "Building tests"
 TEST_NAME="Build tests"
-retry 2 go test -tags cloud e2e integration ./... -run nope
+retry 2 go test -tags cloud ./... -run nope
 retry 2 go test -tags create ./... -run nope
 retry 2 go test -tags e2e ./... -run nope
 retry 2 go test -tags integration ./... -run nope

--- a/api/hack/ci/ci-upload-gocache.sh
+++ b/api/hack/ci/ci-upload-gocache.sh
@@ -37,7 +37,7 @@ retry 2 make build
 
 echodate "Building tests"
 TEST_NAME="Build tests"
-retry 2 go test -tags=cloud,create,e2e,integration ./... -run nope
+retry 2 go test -tags"=cloud create e2e integration" ./... -run nope
 
 echodate "Creating gocache archive"
 TEST_NAME="Creating gocache archive"

--- a/api/hack/ci/ci-upload-gocache.sh
+++ b/api/hack/ci/ci-upload-gocache.sh
@@ -7,7 +7,7 @@ set -euo pipefail
 # receives a SIGINT
 set -o monitor
 
-source ./api/hack/lib.sh
+source $(dirname $0)/../lib.sh
 
 if [ -z $GOCACHE_MINIO_ADDRESS ]; then
   echodate "Fatal: env var GOCACHE_MINIO_ADDRESS unset"

--- a/api/hack/ci/ci-upload-gocache.sh
+++ b/api/hack/ci/ci-upload-gocache.sh
@@ -37,7 +37,10 @@ retry 2 make build
 
 echodate "Building tests"
 TEST_NAME="Build tests"
-retry 2 go test -tags"=cloud create e2e integration" ./... -run nope
+retry 2 go test -tags cloud e2e integration ./... -run nope
+retry 2 go test -tags create ./... -run nope
+retry 2 go test -tags e2e ./... -run nope
+retry 2 go test -tags integration ./... -run nope
 
 echodate "Creating gocache archive"
 TEST_NAME="Creating gocache archive"

--- a/api/hack/ci/ci-upload-gocache.sh
+++ b/api/hack/ci/ci-upload-gocache.sh
@@ -48,8 +48,8 @@ ARCHIVE_FILE=/tmp/${GIT_HEAD_HASH}.tar
 # No compression because that needs quite a bit of CPU
 retry 2 tar -C $GOCACHE -cvf $ARCHIVE_FILE .
 
-sleep() { sleep 1d; }
-trap sleep EXIT
+debug_sleep() { sleep 1d; }
+trap debug_sleep EXIT
 
 echodate "Uploading gocache archive"
 TEST_NAME="Uploading gocache archive"

--- a/api/hack/ci/ci-upload-gocache.sh
+++ b/api/hack/ci/ci-upload-gocache.sh
@@ -21,7 +21,7 @@ export GIT_HEAD_HASH="$(git rev-parse HEAD|tr -d '\n')"
 export CGO_ENABLED=0
 cd $(dirname $0)/../..
 
-echodata "Building binaries"
+echodate "Building binaries"
 TEST_NAME="Buil Kubermatic"
 retry 2 make build
 (


### PR DESCRIPTION
**What this PR does / why we need it**:

Following up on a suggestion by @bentheelder (who cant see this), this PR makes our go building in CI much, much more efficient by downloading a `tar` with a gocache prior to building anything. The tar archive will be uploaded via a postsubmit that runs on the `master` branch.

The downloading of the gocache is built in  a way that it wont cause test failures if it doesn't work.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Documentation**:
<!-- Add links to the related documentation changes related to this pull request. E.g. the link to the kubermatic/docs pullrequest. -->

**Does this PR introduce a user-facing change?**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If  no release note is required, just write "NONE".
-->
```release-note
none
```

/assign @nikhita  @xrstf 