### PR TITLE
addons: remove release.sh

### DIFF
--- a/addons/README.md
+++ b/addons/README.md
@@ -6,15 +6,8 @@ The docker image should be freely accessible to let customers extend & modify th
 
 ### Release / Development Cycle
 
-1) Change the tag in the `release.sh` script to the next version + `-dev` suffix
-2) Do your development and testing. Feel free to `./release.sh` the image with the `-dev` as you need it.
-3) When finishing your PR for approval, change the tag-suffix to `-rc` and `./release.sh` so that CI pipeline will refetch it.
-4) Get your PR approval.
-5) Change the tag to the final version without suffix.
-6) Increment the tag in `../config/kubermatic/values.yaml`
-7) `./release.sh`, update PR, get re-approval, merge.
-
-If your `-rc` image needs yet another change, add indices as well. Of course you might need step 6) also during your development cycle.
+The tag of the addons image is automatically set to the HEAD commit (the commit referenced by `KUBERMATICCOMMIT`)
+so no additional steps are necessary.
 
 ### Using in the kubermatic-addon-controller
 The addons docker image will be used as a init-container to copy all addon-manifests to a shared volume.

--- a/addons/release.sh
+++ b/addons/release.sh
@@ -1,7 +1,0 @@
-#!/usr/bin/env bash
-
-set -ex
-export TAG=v0.2.20
-
-docker build -t quay.io/kubermatic/addons:${TAG} .
-docker push quay.io/kubermatic/addons:${TAG}


### PR DESCRIPTION
The tag uses the git `HEAD` commit value directly so additional steps for setting up the `-dev` suffix, etc are not necessary anymore.

/assign @alvaroaleman 

**Does this PR introduce a user-facing change?**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If  no release note is required, just write "NONE".
-->
```release-note
NONE
```
