### PR TITLE
Fix typo in ci-download-gocache.sh

### DIFF
--- a/api/hack/ci/ci-download-gocache.sh
+++ b/api/hack/ci/ci-download-gocache.sh
@@ -45,7 +45,6 @@ TEST_NAME="Download and extract gocache"
 # in conjunction with the retry func, so we just put them in a file instead
 echo 'Content-Type: application/octet-stream' > /tmp/headers
 retry 5 curl --fail \
-    --progress-bar \
     -H @/tmp/headers \
     ${GOCACHE_MINIO_ADDRESS}/${CACHE_VERSION}.tar \
     |tar -C $GOCACHE -xf -

--- a/api/hack/ci/ci-download-gocache.sh
+++ b/api/hack/ci/ci-download-gocache.sh
@@ -27,11 +27,6 @@ GOCACHE=$(go env GOCACHE)
 # Make sure it actually exists
 mkdir -p $GOCACHE
 
-if ls -1qA $GOCACHE | grep -q .; then
-  echodate "gocache at $GOCACHE is not empty, omitting download of gocache"
-  exit 0
-fi
-
 CACHE_VERSION="${PULL_BASE_SHA}"
 if [ -z ${PULL_NUMBER:-} ]; then
   # Special case: This is called in a Postubmit. Go one revision back,

--- a/api/hack/ci/ci-download-gocache.sh
+++ b/api/hack/ci/ci-download-gocache.sh
@@ -8,7 +8,12 @@ set -euo pipefail
 set -o monitor
 
 # Make sure we never error, this is always best-effort only
-exit_gracefully() { exit 0; }
+exit_gracefully() {
+  if [ $? -ne 0 ]; then
+    echodate "Encountered error when trying to download gocache"
+  fi
+  exit 0
+}
 trap exit_gracefully EXIT
 
 source $(dirname $0)/../lib.sh
@@ -34,7 +39,7 @@ if [ -z ${PULL_NUMBER:-} ]; then
   CACHE_VERSION=$(git rev-parse ${CACHE_VERSION}~1)
 fi
 
-echodata "Downloading and extracting gocache"
+echodate "Downloading and extracting gocache"
 TEST_NAME="Download and extract gocache"
 # Passing the Headers as space-separated literals doesn't seem to work
 # in conjunction with the retry func, so we just put them in a file instead

--- a/api/hack/ci/ci-run-minimal-conformance-tests.sh
+++ b/api/hack/ci/ci-run-minimal-conformance-tests.sh
@@ -394,6 +394,11 @@ TEST_NAME="Deploy Seed Manifest"
 retry 5 kubectl apply -f $SEED_MANIFEST
 echodate "Finished installing seed"
 
+# We build the CLI after deploying to make sure we fail fast if the helm deployment fails
+echodate "Building conformance-tests cli"
+time make -C api conformance-tests
+echodate "Finished building conformance-tests cli"
+
 if [[ -n ${UPGRADE_TEST_BASE_HASH:-} ]]; then
   echodate "Upgradetest, going back to old revision"
   git checkout -

--- a/api/hack/ci/ci-run-minimal-conformance-tests.sh
+++ b/api/hack/ci/ci-run-minimal-conformance-tests.sh
@@ -395,7 +395,7 @@ retry 5 kubectl apply -f $SEED_MANIFEST
 echodate "Finished installing seed"
 
 # We build the CLI after deploying to make sure we fail fast if the helm deployment fails
-if ! ./api/_build/conformance-tests &>/dev/null; then
+if ! ls ./api/_build/conformance-tests &>/dev/null; then
   echodate "Building conformance-tests cli"
   time make -C api conformance-tests
   echodate "Finished building conformance-tests cli"

--- a/api/hack/ci/ci-run-minimal-conformance-tests.sh
+++ b/api/hack/ci/ci-run-minimal-conformance-tests.sh
@@ -395,9 +395,11 @@ retry 5 kubectl apply -f $SEED_MANIFEST
 echodate "Finished installing seed"
 
 # We build the CLI after deploying to make sure we fail fast if the helm deployment fails
-echodate "Building conformance-tests cli"
-time make -C api conformance-tests
-echodate "Finished building conformance-tests cli"
+if ! ./api/_build/conformance-tests &>/dev/null; then
+  echodate "Building conformance-tests cli"
+  time make -C api conformance-tests
+  echodate "Finished building conformance-tests cli"
+fi
 
 if [[ -n ${UPGRADE_TEST_BASE_HASH:-} ]]; then
   echodate "Upgradetest, going back to old revision"

--- a/api/hack/ci/ci-run-minimal-conformance-tests.sh
+++ b/api/hack/ci/ci-run-minimal-conformance-tests.sh
@@ -394,11 +394,6 @@ TEST_NAME="Deploy Seed Manifest"
 retry 5 kubectl apply -f $SEED_MANIFEST
 echodate "Finished installing seed"
 
-# We build the CLI after deploying to make sure we fail fast if the helm deployment fails
-echodate "Building conformance-tests cli"
-time go build -v github.com/kubermatic/kubermatic/api/cmd/conformance-tests
-echodate "Finished building conformance-tests cli"
-
 if [[ -n ${UPGRADE_TEST_BASE_HASH:-} ]]; then
   echodate "Upgradetest, going back to old revision"
   git checkout -
@@ -444,7 +439,7 @@ if [ -n "${UPGRADE_TEST_BASE_HASH:-}" ]; then
   kubermatic_delete_cluster="false"
 fi
 
-timeout -s 9 90m ./conformance-tests ${EXTRA_ARGS:-} \
+timeout -s 9 90m ./api/_build/conformance-tests ${EXTRA_ARGS:-} \
   -debug \
   -worker-name=$BUILD_ID \
   -kubeconfig=$KUBECONFIG \

--- a/api/hack/ci/ci-upload-gocache.sh
+++ b/api/hack/ci/ci-upload-gocache.sh
@@ -46,7 +46,7 @@ echodate "Creating gocache archive"
 TEST_NAME="Creating gocache archive"
 ARCHIVE_FILE=/tmp/${GIT_HEAD_HASH}.tar
 # No compression because that needs quite a bit of CPU
-retry 2 tar -C $GOCACHE -cvf $ARCHIVE_FILE .
+retry 2 tar -C $GOCACHE -cf $ARCHIVE_FILE .
 
 echodate "Uploading gocache archive"
 TEST_NAME="Uploading gocache archive"

--- a/api/hack/ci/ci-upload-gocache.sh
+++ b/api/hack/ci/ci-upload-gocache.sh
@@ -54,7 +54,6 @@ TEST_NAME="Uploading gocache archive"
 # in conjunction with the retry func, so we just put them in a file instead
 echo 'Content-Type: application/octet-stream' > /tmp/headers
 retry 2 curl --fail \
-  --progress-bar \
   -T ${ARCHIVE_FILE} \
   -H @/tmp/headers \
   ${GOCACHE_MINIO_ADDRESS}/${GIT_HEAD_HASH}.tar

--- a/api/hack/lib.sh
+++ b/api/hack/lib.sh
@@ -49,7 +49,7 @@ write_junit() {
     errors=1
     failure='<failure type="Failure">Step failed</failure>'
   fi
-  [ "${TEST_NAME#[Kubermatic\]}" = "$TEST_NAME" ] && TEST_NAME="[Kubermatic] $TEST_NAME"
+  TEST_NAME="[Kubermatic] ${TEST_NAME#\[Kubermatic\] }"
   cat <<EOF > ${ARTIFACTS}/junit.$(echo $TEST_NAME|sed 's/ /_/g').xml
 <?xml version="1.0" ?>
 <testsuites>

--- a/api/hack/lib.sh
+++ b/api/hack/lib.sh
@@ -49,7 +49,7 @@ write_junit() {
     errors=1
     failure='<failure type="Failure">Step failed</failure>'
   fi
-  TEST_NAME="[Kubermatic] $TEST_NAME"
+  [ "${TEST_NAME#[Kubermatic\]}" = "$TEST_NAME" ] && TEST_NAME="[Kubermatic] $TEST_NAME"
   cat <<EOF > ${ARTIFACTS}/junit.$(echo $TEST_NAME|sed 's/ /_/g').xml
 <?xml version="1.0" ?>
 <testsuites>


### PR DESCRIPTION
**What this PR does / why we need it**:

Fixes a typo that broke the `ci-download-gocache.sh` script, its `echodate` not `echodata`. And some other small things I found along the way.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Documentation**:
<!-- Add links to the related documentation changes related to this pull request. E.g. the link to the kubermatic/docs pullrequest. -->

**Does this PR introduce a user-facing change?**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If  no release note is required, just write "NONE".
-->
```release-note
none
```
