### PR TITLE
fix validating seed CRs in new seed clusters

### DIFF
--- a/api/pkg/validation/seed/seed.go
+++ b/api/pkg/validation/seed/seed.go
@@ -56,6 +56,7 @@ func (sv *seedValidator) Validate(seed *kubermaticv1.Seed, isDelete bool) error 
 }
 
 func (sv *seedValidator) validate(seed *kubermaticv1.Seed, seedClient ctrlruntimeclient.Client, existingSeeds map[string]*kubermaticv1.Seed, isDelete bool) error {
+	// this can be nil on fresh seed clusters
 	existingSeed := existingSeeds[seed.Name]
 
 	// remove the seed itself from the list, so uniqueness checks won't fail


### PR DESCRIPTION
**What this PR does / why we need it**:
In new seed clusters, there is no Seed CR yet. WIthout handling this, the validation webhook cannot call its seedsGetter and therefore denies every validation request. This PR exposes a possible NotFound error to the caller and handles it gracefully by returning a non-nil, though empty map.

**Which issue(s) this PR fixes:**
Part of #2113

**Does this PR introduce a user-facing change?**:
```release-note
NONE
```
