### PR TITLE
Defensive Seed Proxy Reconciling

### DIFF
--- a/api/cmd/master-controller-manager/controllers.go
+++ b/api/cmd/master-controller-manager/controllers.go
@@ -50,7 +50,7 @@ func createAllControllers(ctrlCtx *controllerContext) error {
 	if err := seedsync.Add(ctrlCtx.mgr, 1, ctrlCtx.log, ctrlCtx.namespace, ctrlCtx.seedKubeconfigGetter); err != nil {
 		return fmt.Errorf("failed to create seedsync controller: %v", err)
 	}
-	if err := seedproxy.Add(ctrlCtx.mgr, 1, ctrlCtx.seedsGetter, ctrlCtx.seedKubeconfigGetter); err != nil {
+	if err := seedproxy.Add(ctrlCtx.mgr, 1, ctrlCtx.log, ctrlCtx.seedsGetter, ctrlCtx.seedKubeconfigGetter); err != nil {
 		return fmt.Errorf("failed to create seedproxy controller: %v", err)
 	}
 	return nil

--- a/api/pkg/controller/seed-proxy/controller.go
+++ b/api/pkg/controller/seed-proxy/controller.go
@@ -5,6 +5,7 @@ import (
 
 	"go.uber.org/zap"
 
+	"github.com/kubermatic/kubermatic/api/pkg/controller/util/predicate"
 	"github.com/kubermatic/kubermatic/api/pkg/provider"
 
 	appsv1 "k8s.io/api/apps/v1"
@@ -13,10 +14,8 @@ import (
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
 	"sigs.k8s.io/controller-runtime/pkg/controller"
-	"sigs.k8s.io/controller-runtime/pkg/event"
 	"sigs.k8s.io/controller-runtime/pkg/handler"
 	"sigs.k8s.io/controller-runtime/pkg/manager"
-	"sigs.k8s.io/controller-runtime/pkg/predicate"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 	"sigs.k8s.io/controller-runtime/pkg/source"
 )
@@ -134,23 +133,9 @@ func Add(
 		return requests
 	})}
 
-	ownedByPred := predicate.Funcs{
-		CreateFunc: func(e event.CreateEvent) bool {
-			return managedByController(e.Meta)
-		},
-
-		UpdateFunc: func(e event.UpdateEvent) bool {
-			return managedByController(e.MetaOld) || managedByController(e.MetaNew)
-		},
-
-		DeleteFunc: func(e event.DeleteEvent) bool {
-			return managedByController(e.Meta)
-		},
-
-		GenericFunc: func(e event.GenericEvent) bool {
-			return managedByController(e.Meta)
-		},
-	}
+	ownedByController := predicate.Factory(func(meta metav1.Object, _ runtime.Object) bool {
+		return meta.GetLabels()[ManagedByLabel] == ControllerName
+	})
 
 	typesToWatch := []runtime.Object{
 		&appsv1.Deployment{},
@@ -160,15 +145,10 @@ func Add(
 	}
 
 	for _, t := range typesToWatch {
-		if err := c.Watch(&source.Kind{Type: t}, eventHandler, ownedByPred); err != nil {
+		if err := c.Watch(&source.Kind{Type: t}, eventHandler, ownedByController); err != nil {
 			return fmt.Errorf("failed to create watcher for %T: %v", t, err)
 		}
 	}
 
 	return nil
-}
-
-func managedByController(meta metav1.Object) bool {
-	labels := meta.GetLabels()
-	return labels[ManagedByLabel] == ControllerName
 }

--- a/api/pkg/controller/seed-proxy/controller.go
+++ b/api/pkg/controller/seed-proxy/controller.go
@@ -108,6 +108,7 @@ func Add(
 		log:                  log,
 		seedsGetter:          seedsGetter,
 		seedKubeconfigGetter: seedKubeconfigGetter,
+		seedClientGetter:     provider.SeedClientGetterFactory(seedKubeconfigGetter),
 	}
 
 	ctrlOptions := controller.Options{Reconciler: reconciler, MaxConcurrentReconciles: numWorkers}

--- a/api/pkg/controller/seed-proxy/reconciler.go
+++ b/api/pkg/controller/seed-proxy/reconciler.go
@@ -11,6 +11,7 @@ import (
 	"github.com/kubermatic/kubermatic/api/pkg/resources/reconciling"
 
 	corev1 "k8s.io/api/core/v1"
+	kerrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/client-go/rest"
@@ -30,6 +31,7 @@ type Reconciler struct {
 
 	seedsGetter          provider.SeedsGetter
 	seedKubeconfigGetter provider.SeedKubeconfigGetter
+	seedClientGetter     provider.SeedClientGetter
 
 	recorder record.EventRecorder
 }
@@ -52,18 +54,40 @@ func (r *Reconciler) Reconcile(request reconcile.Request) (reconcile.Result, err
 		return reconcile.Result{}, fmt.Errorf("failed to garbage collect: %v", err)
 	}
 
-	log.Debug("reconciling seed cluster...")
 	seed, found := seeds[request.Name]
 	if !found {
 		return reconcile.Result{}, fmt.Errorf("didn't find seed %q", request.Name)
 	}
-	if err := r.reconcileSeed(seed, log); err != nil {
+
+	// both of these namespaces must exist or else we cannot establish
+	// the service account token sharing
+	if !r.namespaceExists(r, MasterTargetNamespace, log) {
+		log.Debug("skipping because target master namespace does not exist", "namespace", MasterTargetNamespace)
+		return reconcile.Result{}, nil
+	}
+
+	client, err := r.seedClientGetter(seed)
+	if err != nil {
+		return reconcile.Result{}, fmt.Errorf("failed to get seed client: %v", err)
+	}
+
+	if !r.namespaceExists(client, SeedServiceAccountNamespace, log) {
+		log.Debug("skipping because seed namespace does not exist", "namespace", SeedServiceAccountNamespace)
+		return reconcile.Result{}, nil
+	}
+
+	log.Debug("reconciling seed cluster...")
+	if err := r.reconcileSeedProxy(seed, client, log); err != nil {
 		return reconcile.Result{}, fmt.Errorf("failed to reconcile: %v", err)
 	}
 
-	log.Debug("reconciling Grafana provisioning...")
-	if err := r.ensureMasterGrafanaProvisioning(seeds); err != nil {
-		return reconcile.Result{}, fmt.Errorf("failed to reconcile Grafana: %v", err)
+	if r.namespaceExists(r, MasterGrafanaNamespace, log) {
+		log.Debug("reconciling Grafana provisioning...")
+		if err := r.ensureMasterGrafanaProvisioning(seeds); err != nil {
+			return reconcile.Result{}, fmt.Errorf("failed to reconcile Grafana: %v", err)
+		}
+	} else {
+		log.Debugw("skipping Grafana setup because namespace does not exist in master", "namespace", MasterGrafanaNamespace)
 	}
 
 	log.Debug("successfully reconciled seed")
@@ -99,59 +123,57 @@ func (r *Reconciler) garbageCollect(seeds map[string]*kubermaticv1.Seed, log *za
 	return nil
 }
 
-func (r *Reconciler) reconcileSeed(seed *kubermaticv1.Seed, log *zap.SugaredLogger) error {
+func (r *Reconciler) reconcileSeedProxy(seed *kubermaticv1.Seed, client ctrlruntimeclient.Client, log *zap.SugaredLogger) error {
 	cfg, err := r.seedKubeconfigGetter(seed)
 	if err != nil {
 		return err
 	}
-	name := seed.Name
-
-	client, err := ctrlruntimeclient.New(cfg, ctrlruntimeclient.Options{})
-	if err != nil {
-		return fmt.Errorf("failed to create client for seed: %v", err)
-	}
 
 	log.Debug("reconciling service accounts...")
-	if err := r.ensureSeedServiceAccounts(client); err != nil {
+	if err := r.ensureSeedServiceAccounts(client, log); err != nil {
 		return fmt.Errorf("failed to ensure service account: %v", err)
 	}
 
-	log.Debug("reconciling roles...")
-	if err := r.ensureSeedRoles(client); err != nil {
-		return fmt.Errorf("failed to ensure role: %v", err)
-	}
+	if r.namespaceExists(client, SeedPrometheusNamespace, log) {
+		log.Debug("reconciling roles...")
+		if err := r.ensureSeedRoles(client, log); err != nil {
+			return fmt.Errorf("failed to ensure role: %v", err)
+		}
 
-	log.Debug("reconciling role bindings...")
-	if err := r.ensureSeedRoleBindings(client); err != nil {
-		return fmt.Errorf("failed to ensure role binding: %v", err)
+		log.Debug("reconciling role bindings...")
+		if err := r.ensureSeedRoleBindings(client, log); err != nil {
+			return fmt.Errorf("failed to ensure role binding: %v", err)
+		}
+	} else {
+		log.Debugw("skipping RBAC setup because Prometheus namespace does not exist in master", "namespace", SeedPrometheusNamespace)
 	}
 
 	log.Debug("fetching service account details from seed cluster...")
-	serviceAccountSecret, err := r.fetchServiceAccountSecret(client)
+	serviceAccountSecret, err := r.fetchServiceAccountSecret(client, log)
 	if err != nil {
 		return fmt.Errorf("failed to fetch service account: %v", err)
 	}
 
-	if err := r.reconcileMaster(name, cfg, serviceAccountSecret, log); err != nil {
+	if err := r.reconcileMaster(seed.Name, cfg, serviceAccountSecret, log); err != nil {
 		return fmt.Errorf("failed to reconcile master: %v", err)
 	}
 
 	return nil
 }
 
-func (r *Reconciler) ensureSeedServiceAccounts(client ctrlruntimeclient.Client) error {
+func (r *Reconciler) ensureSeedServiceAccounts(client ctrlruntimeclient.Client, log *zap.SugaredLogger) error {
 	creators := []reconciling.NamedServiceAccountCreatorGetter{
 		seedServiceAccountCreator(),
 	}
 
 	if err := reconciling.ReconcileServiceAccounts(r.ctx, creators, SeedServiceAccountNamespace, client); err != nil {
-		return fmt.Errorf("failed to reconcile ServiceAccounts in the namespace %s: %v", SeedServiceAccountNamespace, err)
+		return fmt.Errorf("failed to reconcile service accounts in the namespace %s: %v", SeedServiceAccountNamespace, err)
 	}
 
 	return nil
 }
 
-func (r *Reconciler) ensureSeedRoles(client ctrlruntimeclient.Client) error {
+func (r *Reconciler) ensureSeedRoles(client ctrlruntimeclient.Client, log *zap.SugaredLogger) error {
 	creators := []reconciling.NamedRoleCreatorGetter{
 		seedMonitoringRoleCreator(),
 	}
@@ -163,7 +185,7 @@ func (r *Reconciler) ensureSeedRoles(client ctrlruntimeclient.Client) error {
 	return nil
 }
 
-func (r *Reconciler) ensureSeedRoleBindings(client ctrlruntimeclient.Client) error {
+func (r *Reconciler) ensureSeedRoleBindings(client ctrlruntimeclient.Client, log *zap.SugaredLogger) error {
 	creators := []reconciling.NamedRoleBindingCreatorGetter{
 		seedMonitoringRoleBindingCreator(),
 	}
@@ -175,7 +197,7 @@ func (r *Reconciler) ensureSeedRoleBindings(client ctrlruntimeclient.Client) err
 	return nil
 }
 
-func (r *Reconciler) fetchServiceAccountSecret(client ctrlruntimeclient.Client) (*corev1.Secret, error) {
+func (r *Reconciler) fetchServiceAccountSecret(client ctrlruntimeclient.Client, log *zap.SugaredLogger) (*corev1.Secret, error) {
 	sa := &corev1.ServiceAccount{}
 	name := types.NamespacedName{
 		Namespace: SeedServiceAccountNamespace,
@@ -183,11 +205,11 @@ func (r *Reconciler) fetchServiceAccountSecret(client ctrlruntimeclient.Client) 
 	}
 
 	if err := client.Get(r.ctx, name, sa); err != nil {
-		return nil, fmt.Errorf("could not find ServiceAccount '%s'", name)
+		return nil, fmt.Errorf("could not find service account '%s'", name)
 	}
 
 	if len(sa.Secrets) == 0 {
-		return nil, fmt.Errorf("no Secret associated with ServiceAccount '%s'", name)
+		return nil, fmt.Errorf("no secret associated with service account '%s'", name)
 	}
 
 	secret := &corev1.Secret{}
@@ -197,7 +219,7 @@ func (r *Reconciler) fetchServiceAccountSecret(client ctrlruntimeclient.Client) 
 	}
 
 	if err := r.Get(r.ctx, name, secret); err != nil {
-		return nil, fmt.Errorf("could not find Secret '%s'", name)
+		return nil, fmt.Errorf("could not find secret '%s'", name)
 	}
 
 	return secret, nil
@@ -279,4 +301,17 @@ func (r *Reconciler) ensureMasterGrafanaProvisioning(seeds map[string]*kubermati
 	}
 
 	return nil
+}
+
+func (r *Reconciler) namespaceExists(client ctrlruntimeclient.Client, namespace string, log *zap.SugaredLogger) bool {
+	ns := corev1.Namespace{}
+	if err := client.Get(r.ctx, types.NamespacedName{Name: namespace}, &ns); err != nil {
+		if !kerrors.IsNotFound(err) {
+			log.Errorw("failed to check for namespace", "namespace", namespace, zap.Error(err))
+		}
+
+		return false
+	}
+
+	return true
 }


### PR DESCRIPTION
**What this PR does / why we need it**:
This makes sure that the seed-proxy controller does nothing if the required namespaces do not exist. So if there is no `monitoring-master` namespace, it will not attempt to put Grafana stuff in there.

This PR also replaces glog with Zap, uses the new predicate factory and makes use of the caching SeedGetterFactory.

**Does this PR introduce a user-facing change?**:
```release-note
NONE
```
