### PR TITLE
Including the limit concurrent cluster updates in openshift and…

### DIFF
--- a/api/cmd/kubermatic-controller-manager/controllers.go
+++ b/api/cmd/kubermatic-controller-manager/controllers.go
@@ -109,7 +109,8 @@ func createOpenshiftController(ctrlCtx *controllerContext) error {
 		openshiftcontroller.Features{
 			EtcdDataCorruptionChecks: ctrlCtx.runOptions.featureGates.Enabled(EtcdDataCorruptionChecks),
 			VPA:                      ctrlCtx.runOptions.featureGates.Enabled(VerticalPodAutoscaler),
-		}); err != nil {
+		},
+		ctrlCtx.runOptions.concurrentClusterUpdate); err != nil {
 		return fmt.Errorf("failed to add openshift controller to mgr: %v", err)
 	}
 	return nil
@@ -199,6 +200,7 @@ func createMonitoringController(ctrlCtx *controllerContext) error {
 		dockerPullConfigJSON,
 		strings.Contains(ctrlCtx.runOptions.kubernetesAddonsList, "nodelocal-dns-cache"),
 
+		ctrlCtx.runOptions.concurrentClusterUpdate,
 		monitoring.Features{
 			VPA: ctrlCtx.runOptions.featureGates.Enabled(VerticalPodAutoscaler),
 		},

--- a/api/pkg/controller/monitoring/monitoring_controller.go
+++ b/api/pkg/controller/monitoring/monitoring_controller.go
@@ -68,6 +68,7 @@ type Reconciler struct {
 	// example: kubermatic.io -> kubermatic.io/path,kubermatic.io/port
 	monitoringScrapeAnnotationPrefix string
 	nodeLocalDNSCacheEnabled         bool
+	concurrentClusterUpdates         int
 
 	features Features
 }
@@ -92,6 +93,7 @@ func Add(
 	inClusterPrometheusScrapingConfigsFile string,
 	dockerPullConfigJSON []byte,
 	nodeLocalDNSCacheEnabled bool,
+	concurrentClusterUpdates int,
 
 	features Features,
 ) error {
@@ -116,8 +118,8 @@ func Add(
 		inClusterPrometheusScrapingConfigsFile:           inClusterPrometheusScrapingConfigsFile,
 		dockerPullConfigJSON:                             dockerPullConfigJSON,
 		nodeLocalDNSCacheEnabled:                         nodeLocalDNSCacheEnabled,
-
-		seedGetter: seedGetter,
+		concurrentClusterUpdates:                         concurrentClusterUpdates,
+		seedGetter:                                       seedGetter,
 
 		features: features,
 	}
@@ -156,6 +158,13 @@ func (r *Reconciler) Reconcile(request reconcile.Request) (reconcile.Result, err
 	log := r.log.With("request", request)
 	log.Debug("Processing")
 
+	if limitReached, err := controllerutil.ConcurrencyLimitReached(ctx, r, r.concurrentClusterUpdates); limitReached || err != nil {
+		log.Debugf("ignore reconciling due to max parallel reconcile has reached its limit of %v", r.concurrentClusterUpdates)
+		return reconcile.Result{
+			RequeueAfter: 1 * time.Second,
+		}, err
+	}
+
 	cluster := &kubermaticv1.Cluster{}
 	if err := r.Get(ctx, request.NamespacedName, cluster); err != nil {
 		if kubeapierrors.IsNotFound(err) {
@@ -192,16 +201,25 @@ func (r *Reconciler) Reconcile(request reconcile.Request) (reconcile.Result, err
 		return reconcile.Result{RequeueAfter: healthCheckPeriod}, nil
 	}
 
+	successfullyReconciled := true
 	// Add a wrapping here so we can emit an event on error
-	result, err := r.reconcile(ctx, log, cluster)
-	if err != nil {
-		log.Errorw("Failed to reconcile cluster", zap.Error(err))
-		r.recorder.Eventf(cluster, corev1.EventTypeWarning, "ReconcilingError", "%v", err)
+	result, reconcileErr := r.reconcile(ctx, log, cluster)
+	if reconcileErr != nil {
+		successfullyReconciled = false
+		log.Errorw("Failed to reconcile cluster", zap.Error(reconcileErr))
+		r.recorder.Eventf(cluster, corev1.EventTypeWarning, "ReconcilingError", "%v", reconcileErr)
 	}
+
 	if result == nil {
 		result = &reconcile.Result{}
 	}
-	return *result, err
+
+	if err := controllerutil.SetClusterUpdatedSuccessfullyCondition(ctx, cluster, r, successfullyReconciled); err != nil {
+		log.Errorw("failed to update clusters status conditions", zap.Error(err))
+		reconcileErr = fmt.Errorf("failed to set cluster status: %v after reconciliation was done with err=%v", err, reconcileErr)
+	}
+
+	return *result, reconcileErr
 }
 
 func (r *Reconciler) reconcile(ctx context.Context, log *zap.SugaredLogger, cluster *kubermaticv1.Cluster) (*reconcile.Result, error) {

--- a/api/pkg/controller/openshift/openshift_controller_test.go
+++ b/api/pkg/controller/openshift/openshift_controller_test.go
@@ -67,8 +67,9 @@ func TestResources(t *testing.T) {
 		{
 			name: "Kubermatic API image is overwritten",
 			reconciler: Reconciler{
-				kubermaticImage: "my.corp/kubermatic",
-				log:             zap.NewNop().Sugar(),
+				kubermaticImage:          "my.corp/kubermatic",
+				log:                      zap.NewNop().Sugar(),
+				concurrentClusterUpdates: 10,
 			},
 			object: &appsv1.Deployment{
 				ObjectMeta: metav1.ObjectMeta{

--- a/api/pkg/controller/util/util.go
+++ b/api/pkg/controller/util/util.go
@@ -115,10 +115,12 @@ func SetClusterUpdatedSuccessfullyCondition(ctx context.Context, cluster *kuberm
 		}
 
 		for _, statefulSet := range statefulSets.Items {
-			if *statefulSet.Spec.Replicas != statefulSet.Status.UpdatedReplicas ||
-				*statefulSet.Spec.Replicas != statefulSet.Status.CurrentReplicas ||
-				*statefulSet.Spec.Replicas != statefulSet.Status.ReadyReplicas {
-				statefulSetHasUnfinishedUpdates = true
+			if statefulSet.Spec.Replicas != nil {
+				if *statefulSet.Spec.Replicas != statefulSet.Status.UpdatedReplicas ||
+					*statefulSet.Spec.Replicas != statefulSet.Status.CurrentReplicas ||
+					*statefulSet.Spec.Replicas != statefulSet.Status.ReadyReplicas {
+					statefulSetHasUnfinishedUpdates = true
+				}
 			}
 		}
 
@@ -127,10 +129,12 @@ func SetClusterUpdatedSuccessfullyCondition(ctx context.Context, cluster *kuberm
 		}
 
 		for _, deployment := range deployments.Items {
-			if *deployment.Spec.Replicas != deployment.Status.UpdatedReplicas ||
-				*deployment.Spec.Replicas != deployment.Status.AvailableReplicas ||
-				*deployment.Spec.Replicas != deployment.Status.ReadyReplicas {
-				deploymentHasUnfinishedUpdates = true
+			if deployment.Spec.Replicas != nil {
+				if *deployment.Spec.Replicas != deployment.Status.UpdatedReplicas ||
+					*deployment.Spec.Replicas != deployment.Status.AvailableReplicas ||
+					*deployment.Spec.Replicas != deployment.Status.ReadyReplicas {
+					deploymentHasUnfinishedUpdates = true
+				}
 			}
 		}
 


### PR DESCRIPTION
**What this PR does / why we need it**:
In another PR(https://github.com/kubermatic/kubermatic/pull/4193), we have introduced new functionality to limit any cluster resources updates in parallel if some ongoing updates are carrying on and those updates have reached a predefined limit. With this PR we include this functionality in other controllers(openshift and monitoring controllers).

**Does this PR introduce a user-facing change?**:
No

```release-note
NONE
```
