### PR TITLE
E2E tests: Fix variables for periodics

### DIFF
--- a/api/hack/ci/ci-run-minimal-conformance-tests.sh
+++ b/api/hack/ci/ci-run-minimal-conformance-tests.sh
@@ -22,6 +22,8 @@ export GIT_HEAD_HASH="$(git rev-parse HEAD|tr -d '\n')"
 export EXCLUDE_DISTRIBUTIONS=${EXCLUDE_DISTRIBUTIONS:-ubuntu,centos}
 export DEFAULT_TIMEOUT_MINUTES=${DEFAULT_TIMEOUT_MINUTES:-10}
 export ONLY_TEST_CREATION=${ONLY_TEST_CREATION:-false}
+export PULL_BASE_REF=${PULL_BASE_REF:-$(git rev-parse --abbrev-ref HEAD)}
+export PULL_BASE_SHA=${PULL_BASE_SHA:-$GIT_HEAD_HASH}
 
 # if no provider argument has been specified, default to aws
 provider=${PROVIDER:-"aws"}
@@ -275,7 +277,8 @@ if [[ -n ${UPGRADE_TEST_BASE_HASH:-} ]]; then
 fi
 
 # PULL_BASE_REF is the name of the current branch in case of a post-submit
-# or the name of the base branch in case of a PR.
+# or the name of the base branch in case of a PR. It is unset for Periodics, but
+# we default it in that case.
 #
 # The env var is named `UPGRADE_TEST_BASE_HASH`, but we really only specify release branch heads with it.
 LATEST_DASHBOARD="$(get_latest_dashboard_hash "${UPGRADE_TEST_BASE_HASH:-$PULL_BASE_REF}")"


### PR DESCRIPTION
**What this PR does / why we need it**:

Defaults the unset PULL_BASE_REF and PULL_BASE_SHA variables for periodics.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Documentation**:
<!-- Add links to the related documentation changes related to this pull request. E.g. the link to the kubermatic/docs pullrequest. -->

**Does this PR introduce a user-facing change?**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If  no release note is required, just write "NONE".
-->
```release-note
none
```
