### PR TITLE
increase Prometheus and Thanos resources

### DIFF
--- a/config/monitoring/prometheus/values.yaml
+++ b/config/monitoring/prometheus/values.yaml
@@ -190,11 +190,11 @@ prometheus:
     prometheus:
       resources:
         requests:
-          cpu: 150m
-          memory: 1Gi
-        limits:
-          cpu: 500m
+          cpu: 1
           memory: 3Gi
+        limits:
+          cpu: 2
+          memory: 6Gi
     backup:
       resources:
         requests:
@@ -231,10 +231,10 @@ prometheus:
       resources:
         requests:
           cpu: 100m
-          memory: 1536Mi
+          memory: 3Gi
         limits:
           cpu: 250m
-          memory: 3Gi
+          memory: 6Gi
     thanosQuery:
       resources:
         requests:
@@ -246,11 +246,11 @@ prometheus:
     thanosCompact:
       resources:
         requests:
-          cpu: 250m
-          memory: 1Gi
-        limits:
-          cpu: 1
+          cpu: 500m
           memory: 4Gi
+        limits:
+          cpu: 2
+          memory: 8Gi
 
   nodeSelector: {}
   affinity:


### PR DESCRIPTION
**What this PR does / why we need it**:
We have adjusted Prometheus and Thanos resources pretty much in every deployment. It makes sense to increase the defaults to fit a realistic Kubermatic setup. Small POCs use hopefully machines large enough to hold the monitoring stack when/if customers decide to try out the stack.

**Does this PR introduce a user-facing change?**:
```release-note
NONE
```
