### PR TITLE
API e2e tests: Print cluster events when it doesn't get ready

### DIFF
--- a/api/pkg/test/e2e/api/cluster_test.go
+++ b/api/pkg/test/e2e/api/cluster_test.go
@@ -79,7 +79,10 @@ func TestCreateAWSCluster(t *testing.T) {
 			}
 
 			if !clusterReady {
-				t.Fatalf("cluster is not redy after %d attempts", getAWSMaxAttempts)
+				if err := apiRunner.PrintClusterEvents(project.ID, tc.dc, cluster.ID); err != nil {
+					t.Errorf("failed to print cluster events: %v", err)
+				}
+				t.Fatalf("cluster is not ready after %d attempts", getAWSMaxAttempts)
 			}
 
 			var ndReady bool

--- a/api/pkg/test/e2e/api/digitalocean_test.go
+++ b/api/pkg/test/e2e/api/digitalocean_test.go
@@ -64,7 +64,10 @@ func TestCreateDOCluster(t *testing.T) {
 			}
 
 			if !clusterReady {
-				t.Fatalf("cluster is not redy after %d attempts", getDOMaxAttempts)
+				if err := apiRunner.PrintClusterEvents(project.ID, tc.dc, cluster.ID); err != nil {
+					t.Errorf("failed to print cluster events: %v", err)
+				}
+				t.Fatalf("cluster is not ready after %d attempts", getDOMaxAttempts)
 			}
 
 			var ndReady bool

--- a/api/pkg/test/e2e/api/helper.go
+++ b/api/pkg/test/e2e/api/helper.go
@@ -451,6 +451,32 @@ func (r *APIRunner) GetCluster(projectID, dc, clusterID string) (*apiv1.Cluster,
 	return convertCluster(cluster.Payload)
 }
 
+// GetClusterEvents returns the cluster events
+func (r *APIRunner) GetClusterEvents(projectID, dc, clusterID string) ([]*models.Event, error) {
+	params := &project.GetClusterEventsParams{ProjectID: projectID, Dc: dc, ClusterID: clusterID}
+	params.WithTimeout(timeout)
+
+	events, err := r.client.Project.GetClusterEvents(params, r.bearerToken)
+	if err != nil {
+		return nil, err
+	}
+	return events.Payload, nil
+}
+
+// PrintClusterEvents prints all cluster events using its test.Logf
+func (r *APIRunner) PrintClusterEvents(projectID, dc, clusterID string) error {
+	events, err := r.GetClusterEvents(projectID, dc, clusterID)
+	if err != nil {
+		return fmt.Errorf("failed to get cluster events: %v", err)
+	}
+	encodedEvents, err := json.Marshal(events)
+	if err != nil {
+		return fmt.Errorf("failed to serialize events: %v", err)
+	}
+	r.test.Logf("Cluster events:\n%s", string(encodedEvents))
+	return nil
+}
+
 // GetClusterHealthStatus gets the cluster status
 func (r *APIRunner) GetClusterHealthStatus(projectID, dc, clusterID string) (*apiv1.ClusterHealth, error) {
 	params := &project.GetClusterHealthParams{Dc: dc, ProjectID: projectID, ClusterID: clusterID}


### PR DESCRIPTION
**What this PR does / why we need it**:

The `periodic-kubermatic-e2e-api-cloud` is failing since a couple of days with a timeout, e.G. [here](https://prow.loodse.com/view/gcs/prow-data/logs/periodic-kubermatic-e2e-api-cloud/1171302432915853312) and we have no idea why. The change here may help figuring that out.

/assign @zreigz 

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Documentation**:
<!-- Add links to the related documentation changes related to this pull request. E.g. the link to the kubermatic/docs pullrequest. -->

**Does this PR introduce a user-facing change?**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If  no release note is required, just write "NONE".
-->
```release-note
none
```
