### PR TITLE
E2e tests: Increase Azure delete timeout to 30 minutes

### DIFF
--- a/api/cmd/conformance-tests/runner.go
+++ b/api/cmd/conformance-tests/runner.go
@@ -380,6 +380,11 @@ func (r *testRunner) executeScenario(log *zap.SugaredLogger, scenario testScenar
 		ProjectID: r.kubermatcProjectID,
 		Dc:        r.seed.Name,
 	}
+	deleteTimeout := 15 * time.Minute
+	if cluster.Spec.Cloud.Azure != nil {
+		// 15 Minutes are not enough for Azure
+		deleteTimeout = 30 * time.Minute
+	}
 	deleteParms.SetTimeout(15 * time.Second)
 	if err := junitReporterWrapper(
 		"[Kubermatic] Delete cluster",
@@ -389,7 +394,7 @@ func (r *testRunner) executeScenario(log *zap.SugaredLogger, scenario testScenar
 			if err != nil {
 				return fmt.Errorf("failed to parse selector: %v", err)
 			}
-			return wait.PollImmediate(5*time.Second, 15*time.Minute, func() (bool, error) {
+			return wait.PollImmediate(5*time.Second, deleteTimeout, func() (bool, error) {
 				clusterList := &kubermaticv1.ClusterList{}
 				listOpts := &ctrlruntimeclient.ListOptions{LabelSelector: selector}
 				if err := r.seedClusterClient.List(r.ctx, listOpts, clusterList); err != nil {

--- a/api/cmd/conformance-tests/runner.go
+++ b/api/cmd/conformance-tests/runner.go
@@ -376,6 +376,11 @@ func (r *testRunner) executeScenario(log *zap.SugaredLogger, scenario testScenar
 		return report, nil
 	}
 
+	return report, r.deleteCluster(report, cluster, log)
+}
+
+func (r *testRunner) deleteCluster(report *reporters.JUnitTestSuite, cluster *kubermaticv1.Cluster, log *zap.SugaredLogger) error {
+
 	deleteParms := &projectclient.DeleteClusterParams{
 		ProjectID: r.kubermatcProjectID,
 		Dc:        r.seed.Name,
@@ -423,10 +428,10 @@ func (r *testRunner) executeScenario(log *zap.SugaredLogger, scenario testScenar
 		},
 	); err != nil {
 		log.Errorw("failed to delete cluster", zap.Error(err))
-		return report, err
+		return err
 	}
 
-	return report, nil
+	return nil
 }
 
 func retryNAttempts(maxAttempts int, f func(attempt int) error) error {


### PR DESCRIPTION
**What this PR does / why we need it**:

Azure e2e tests frequently fail with "Timeout waiting for deletion", e.G. [here](https://prow.loodse.com/view/gcs/prow-data/logs/periodic-kubermatic-e2e-azure-coreos-1.14/1171226938111430656). We already increased it to 15 Minutes because of that, but it seems that is still enough.

Because all other providers are way quicker, this PR changes the timeout to 30 Minutes just for azure.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Documentation**:
<!-- Add links to the related documentation changes related to this pull request. E.g. the link to the kubermatic/docs pullrequest. -->

**Does this PR introduce a user-facing change?**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If  no release note is required, just write "NONE".
-->
```release-note
none
```
