### PR TITLE
Log concurrency limit reached at info level

### DIFF
--- a/api/pkg/controller/cluster/cluster_controller.go
+++ b/api/pkg/controller/cluster/cluster_controller.go
@@ -176,13 +176,6 @@ func (r *Reconciler) Reconcile(request reconcile.Request) (reconcile.Result, err
 	log := r.log.With("request", request)
 	log.Debug("Processing")
 
-	if limitReached, err := controllerutil.ConcurrencyLimitReached(ctx, r, r.concurrentClusterUpdates); limitReached || err != nil {
-		log.Debugf("ignore reconciling due to max parallel reconcile has reached its limit of %v", r.concurrentClusterUpdates)
-		return reconcile.Result{
-			RequeueAfter: 1 * time.Second,
-		}, err
-	}
-
 	cluster := &kubermaticv1.Cluster{}
 	if err := r.Get(ctx, request.NamespacedName, cluster); err != nil {
 		if kubeapierrors.IsNotFound(err) {
@@ -209,6 +202,13 @@ func (r *Reconciler) Reconcile(request reconcile.Request) (reconcile.Result, err
 	if cluster.Annotations["kubermatic.io/openshift"] != "" {
 		log.Debug("Skipping because the cluster is an OpenShift cluster")
 		return reconcile.Result{}, nil
+	}
+
+	if limitReached, err := controllerutil.ConcurrencyLimitReached(ctx, r, r.concurrentClusterUpdates); limitReached || err != nil {
+		log.Infow("Concurrency limit reached, checking again in 10 seconds", "concurrency-limit", r.concurrentClusterUpdates)
+		return reconcile.Result{
+			RequeueAfter: 10 * time.Second,
+		}, err
 	}
 
 	successfullyReconciled := true

--- a/api/pkg/controller/monitoring/monitoring_controller.go
+++ b/api/pkg/controller/monitoring/monitoring_controller.go
@@ -158,13 +158,6 @@ func (r *Reconciler) Reconcile(request reconcile.Request) (reconcile.Result, err
 	log := r.log.With("request", request)
 	log.Debug("Processing")
 
-	if limitReached, err := controllerutil.ConcurrencyLimitReached(ctx, r, r.concurrentClusterUpdates); limitReached || err != nil {
-		log.Debugf("ignore reconciling due to max parallel reconcile has reached its limit of %v", r.concurrentClusterUpdates)
-		return reconcile.Result{
-			RequeueAfter: 1 * time.Second,
-		}, err
-	}
-
 	cluster := &kubermaticv1.Cluster{}
 	if err := r.Get(ctx, request.NamespacedName, cluster); err != nil {
 		if kubeapierrors.IsNotFound(err) {
@@ -199,6 +192,13 @@ func (r *Reconciler) Reconcile(request reconcile.Request) (reconcile.Result, err
 	if kubermaticv1.HealthStatusDown == cluster.Status.ExtendedHealth.UserClusterControllerManager {
 		log.Debug("Skipping cluster reconciling because the UserClusterControllerManager is not ready yet")
 		return reconcile.Result{RequeueAfter: healthCheckPeriod}, nil
+	}
+
+	if limitReached, err := controllerutil.ConcurrencyLimitReached(ctx, r, r.concurrentClusterUpdates); limitReached || err != nil {
+		log.Infow("Concurrency limit reached, checking again in 10 seconds", "concurrency-limit", r.concurrentClusterUpdates)
+		return reconcile.Result{
+			RequeueAfter: 10 * time.Second,
+		}, err
 	}
 
 	successfullyReconciled := true


### PR DESCRIPTION
**What this PR does / why we need it**:

Logs concurrency limit reached at info level, as this should rarely if ever happen but is not very obvious to understand without logs.

Also moves the concurrency limit checks down after all other checks, else clusters that are not getting reconciled by a given controller can still block it.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Documentation**:
<!-- Add links to the related documentation changes related to this pull request. E.g. the link to the kubermatic/docs pullrequest. -->

**Does this PR introduce a user-facing change?**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If  no release note is required, just write "NONE".
-->
```release-note
none
```
