### PR TITLE
Increase resources for nodeportproxy when using LB exposeStrategy

### DIFF
--- a/api/pkg/resources/nodeportproxy/nodeportproxy.go
+++ b/api/pkg/resources/nodeportproxy/nodeportproxy.go
@@ -176,8 +176,8 @@ func deploymentEnvoy(image string, data nodePortProxyData) reconciling.NamedDepl
 						corev1.ResourceMemory: resource.MustParse("32Mi"),
 					},
 					Limits: corev1.ResourceList{
-						corev1.ResourceCPU:    resource.MustParse("10m"),
-						corev1.ResourceMemory: resource.MustParse("32Mi"),
+						corev1.ResourceCPU:    resource.MustParse("50m"),
+						corev1.ResourceMemory: resource.MustParse("48Mi"),
 					},
 				}}, {
 				Name:  "envoy",
@@ -204,12 +204,12 @@ func deploymentEnvoy(image string, data nodePortProxyData) reconciling.NamedDepl
 				},
 				Resources: corev1.ResourceRequirements{
 					Requests: corev1.ResourceList{
-						corev1.ResourceCPU:    resource.MustParse("10m"),
+						corev1.ResourceCPU:    resource.MustParse("50m"),
 						corev1.ResourceMemory: resource.MustParse("32Mi"),
 					},
 					Limits: corev1.ResourceList{
-						corev1.ResourceCPU:    resource.MustParse("10m"),
-						corev1.ResourceMemory: resource.MustParse("32Mi"),
+						corev1.ResourceCPU:    resource.MustParse("100m"),
+						corev1.ResourceMemory: resource.MustParse("64Mi"),
 					},
 				},
 				ReadinessProbe: &corev1.Probe{
@@ -276,7 +276,7 @@ func deploymentLBUpdater(image string) reconciling.NamedDeploymentCreatorGetter 
 						corev1.ResourceMemory: resource.MustParse("32Mi"),
 					},
 					Limits: corev1.ResourceList{
-						corev1.ResourceCPU:    resource.MustParse("10m"),
+						corev1.ResourceCPU:    resource.MustParse("50m"),
 						corev1.ResourceMemory: resource.MustParse("32Mi"),
 					},
 				},


### PR DESCRIPTION
**What this PR does / why we need it**:

A customer that is using the LB expose strategy saw delays due to CPU starvation of the envoy.
This matches with our observations which is why we extended the resources for the nodeport proxy in #3702 but forgot to do so for the nodeport proxy that is being deployed for each usercluster when using the LB expose strategy.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Documentation**:
<!-- Add links to the related documentation changes related to this pull request. E.g. the link to the kubermatic/docs pullrequest. -->

**Does this PR introduce a user-facing change?**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If  no release note is required, just write "NONE".
-->
```release-note
Fixed a bug that could cause intermittent delays when using kubectl logs/exec with `exposeStrategy: LoadBalancer`
```
