### PR TITLE
Remove AWS AvailabilityZone endpoint

### DIFF
--- a/api/cmd/kubermatic-api/swagger.json
+++ b/api/cmd/kubermatic-api/swagger.json
@@ -2203,55 +2203,6 @@
         }
       }
     },
-    "/api/v1/projects/{project_id}/dc/{dc}/clusters/{cluster_id}/providers/aws/zones": {
-      "get": {
-        "description": "Lists available AWS zones",
-        "produces": [
-          "application/json"
-        ],
-        "tags": [
-          "aws"
-        ],
-        "operationId": "listAWSZonesNoCredentials",
-        "parameters": [
-          {
-            "type": "string",
-            "x-go-name": "ProjectID",
-            "name": "project_id",
-            "in": "path",
-            "required": true
-          },
-          {
-            "type": "string",
-            "x-go-name": "DC",
-            "name": "dc",
-            "in": "path",
-            "required": true
-          },
-          {
-            "type": "string",
-            "x-go-name": "ClusterID",
-            "name": "cluster_id",
-            "in": "path",
-            "required": true
-          }
-        ],
-        "responses": {
-          "200": {
-            "description": "AWSZoneList",
-            "schema": {
-              "$ref": "#/definitions/AWSZoneList"
-            }
-          },
-          "default": {
-            "description": "errorResponse",
-            "schema": {
-              "$ref": "#/definitions/errorResponse"
-            }
-          }
-        }
-      }
-    },
     "/api/v1/projects/{project_id}/dc/{dc}/clusters/{cluster_id}/providers/azure/sizes": {
       "get": {
         "description": "Lists available VM sizes in an Azure region",
@@ -4181,56 +4132,6 @@
         }
       }
     },
-    "/api/v1/providers/aws/{dc}/zones": {
-      "get": {
-        "description": "Lists available AWS zones",
-        "produces": [
-          "application/json"
-        ],
-        "tags": [
-          "aws"
-        ],
-        "operationId": "listAWSZones",
-        "parameters": [
-          {
-            "type": "string",
-            "name": "AccessKeyID",
-            "in": "header"
-          },
-          {
-            "type": "string",
-            "name": "SecretAccessKey",
-            "in": "header"
-          },
-          {
-            "type": "string",
-            "name": "Credential",
-            "in": "header"
-          },
-          {
-            "type": "string",
-            "x-go-name": "DC",
-            "name": "dc",
-            "in": "path",
-            "required": true
-          }
-        ],
-        "responses": {
-          "200": {
-            "description": "AWSZoneList",
-            "schema": {
-              "$ref": "#/definitions/AWSZoneList"
-            }
-          },
-          "default": {
-            "description": "errorResponse",
-            "schema": {
-              "$ref": "#/definitions/errorResponse"
-            }
-          }
-        }
-      }
-    },
     "/api/v1/providers/azure/sizes": {
       "get": {
         "description": "Lists available VM sizes in an Azure region",
@@ -5221,25 +5122,6 @@
           "type": "string",
           "x-go-name": "StatusMessage"
         }
-      },
-      "x-go-package": "github.com/kubermatic/kubermatic/api/pkg/api/v1"
-    },
-    "AWSZone": {
-      "type": "object",
-      "title": "AWSZone represents a object of AWS availability zone.",
-      "properties": {
-        "name": {
-          "type": "string",
-          "x-go-name": "Name"
-        }
-      },
-      "x-go-package": "github.com/kubermatic/kubermatic/api/pkg/api/v1"
-    },
-    "AWSZoneList": {
-      "type": "array",
-      "title": "AWSZoneList represents an array of AWS availability zones.",
-      "items": {
-        "$ref": "#/definitions/AWSZone"
       },
       "x-go-package": "github.com/kubermatic/kubermatic/api/pkg/api/v1"
     },

--- a/api/pkg/api/v1/types.go
+++ b/api/pkg/api/v1/types.go
@@ -146,16 +146,6 @@ type AWSSize struct {
 // swagger:model AWSSizeList
 type AWSSizeList []AWSSize
 
-// AWSZone represents a object of AWS availability zone.
-// swagger:model AWSZone
-type AWSZone struct {
-	Name string `json:"name"`
-}
-
-// AWSZoneList represents an array of AWS availability zones.
-// swagger:model AWSZoneList
-type AWSZoneList []AWSZone
-
 // AWSSubnetList represents an array of AWS availability subnets.
 // swagger:model AWSSubnetList
 type AWSSubnetList []AWSSubnet

--- a/api/pkg/handler/routes_v1.go
+++ b/api/pkg/handler/routes_v1.go
@@ -49,10 +49,6 @@ func (r Routing) RegisterV1(mux *mux.Router, metrics common.ServerMetrics) {
 		Handler(r.listAWSSizes())
 
 	mux.Methods(http.MethodGet).
-		Path("/providers/aws/{dc}/zones").
-		Handler(r.listAWSZones())
-
-	mux.Methods(http.MethodGet).
 		Path("/providers/aws/{dc}/subnets").
 		Handler(r.listAWSSubnets())
 
@@ -292,10 +288,6 @@ func (r Routing) RegisterV1(mux *mux.Router, metrics common.ServerMetrics) {
 	mux.Methods(http.MethodGet).
 		Path("/projects/{project_id}/dc/{dc}/clusters/{cluster_id}/providers/aws/sizes").
 		Handler(r.listAWSSizesNoCredentials())
-
-	mux.Methods(http.MethodGet).
-		Path("/projects/{project_id}/dc/{dc}/clusters/{cluster_id}/providers/aws/zones").
-		Handler(r.listAWSZonesNoCredentials())
 
 	mux.Methods(http.MethodGet).
 		Path("/projects/{project_id}/dc/{dc}/clusters/{cluster_id}/providers/aws/subnets").
@@ -542,28 +534,6 @@ func (r Routing) listAWSSizes() http.Handler {
 			middleware.UserSaver(r.userProvider),
 		)(provider.AWSSizeEndpoint()),
 		provider.DecodeAWSSizesReq,
-		encodeJSON,
-		r.defaultServerOptions()...,
-	)
-}
-
-// swagger:route GET /api/v1/providers/aws/{dc}/zones aws listAWSZones
-//
-// Lists available AWS zones
-//
-//     Produces:
-//     - application/json
-//
-//     Responses:
-//       default: errorResponse
-//       200: AWSZoneList
-func (r Routing) listAWSZones() http.Handler {
-	return httptransport.NewServer(
-		endpoint.Chain(
-			middleware.TokenVerifier(r.tokenVerifiers),
-			middleware.UserSaver(r.userProvider),
-		)(provider.AWSZoneEndpoint(r.presetsManager, r.seedsGetter)),
-		provider.DecodeAWSZoneReq,
 		encodeJSON,
 		r.defaultServerOptions()...,
 	)
@@ -2017,30 +1987,6 @@ func (r Routing) listAWSSizesNoCredentials() http.Handler {
 			middleware.SetClusterProvider(r.clusterProviderGetter, r.seedsGetter),
 			middleware.UserInfoExtractor(r.userProjectMapper),
 		)(provider.AWSSizeNoCredentialsEndpoint(r.projectProvider, r.seedsGetter)),
-		common.DecodeGetClusterReq,
-		encodeJSON,
-		r.defaultServerOptions()...,
-	)
-}
-
-// swagger:route GET /api/v1/projects/{project_id}/dc/{dc}/clusters/{cluster_id}/providers/aws/zones aws listAWSZonesNoCredentials
-//
-// Lists available AWS zones
-//
-//     Produces:
-//     - application/json
-//
-//     Responses:
-//       default: errorResponse
-//       200: AWSZoneList
-func (r Routing) listAWSZonesNoCredentials() http.Handler {
-	return httptransport.NewServer(
-		endpoint.Chain(
-			middleware.TokenVerifier(r.tokenVerifiers),
-			middleware.UserSaver(r.userProvider),
-			middleware.SetClusterProvider(r.clusterProviderGetter, r.seedsGetter),
-			middleware.UserInfoExtractor(r.userProjectMapper),
-		)(provider.AWSZoneWithClusterCredentialsEndpoint(r.projectProvider, r.seedsGetter)),
 		common.DecodeGetClusterReq,
 		encodeJSON,
 		r.defaultServerOptions()...,

--- a/api/pkg/provider/cloud/aws/provider.go
+++ b/api/pkg/provider/cloud/aws/provider.go
@@ -622,25 +622,6 @@ func (a *AmazonEC2) ValidateCloudSpecUpdate(oldSpec kubermaticv1.CloudSpec, newS
 	return nil
 }
 
-// GetAvailabilityZonesInRegion returns the list of availability zones in the selected AWS region.
-func GetAvailabilityZonesInRegion(accessKeyID, secretAccessKey, region string) ([]*ec2.AvailabilityZone, error) {
-	client, err := GetClientSet(accessKeyID, secretAccessKey, region)
-	if err != nil {
-		return nil, err
-	}
-
-	filters := []*ec2.Filter{
-		{Name: aws.String("region-name"), Values: []*string{aws.String(region)}},
-	}
-	azinput := &ec2.DescribeAvailabilityZonesInput{Filters: filters}
-	out, err := client.EC2.DescribeAvailabilityZones(azinput)
-	if err != nil {
-		return nil, err
-	}
-
-	return out.AvailabilityZones, nil
-}
-
 // GetSubnets returns the list of subnets for a selected AWS vpc.
 func GetSubnets(accessKeyID, secretAccessKey, region, vpcID string) ([]*ec2.Subnet, error) {
 	client, err := GetClientSet(accessKeyID, secretAccessKey, region)

--- a/api/pkg/test/e2e/api/utils/apiclient/client/aws/aws_client.go
+++ b/api/pkg/test/e2e/api/utils/apiclient/client/aws/aws_client.go
@@ -169,64 +169,6 @@ func (a *Client) ListAWSVPCS(params *ListAWSVPCSParams, authInfo runtime.ClientA
 
 }
 
-/*
-ListAWSZones Lists available AWS zones
-*/
-func (a *Client) ListAWSZones(params *ListAWSZonesParams, authInfo runtime.ClientAuthInfoWriter) (*ListAWSZonesOK, error) {
-	// TODO: Validate the params before sending
-	if params == nil {
-		params = NewListAWSZonesParams()
-	}
-
-	result, err := a.transport.Submit(&runtime.ClientOperation{
-		ID:                 "listAWSZones",
-		Method:             "GET",
-		PathPattern:        "/api/v1/providers/aws/{dc}/zones",
-		ProducesMediaTypes: []string{"application/json"},
-		ConsumesMediaTypes: []string{"application/json"},
-		Schemes:            []string{"https"},
-		Params:             params,
-		Reader:             &ListAWSZonesReader{formats: a.formats},
-		AuthInfo:           authInfo,
-		Context:            params.Context,
-		Client:             params.HTTPClient,
-	})
-	if err != nil {
-		return nil, err
-	}
-	return result.(*ListAWSZonesOK), nil
-
-}
-
-/*
-ListAWSZonesNoCredentials Lists available AWS zones
-*/
-func (a *Client) ListAWSZonesNoCredentials(params *ListAWSZonesNoCredentialsParams, authInfo runtime.ClientAuthInfoWriter) (*ListAWSZonesNoCredentialsOK, error) {
-	// TODO: Validate the params before sending
-	if params == nil {
-		params = NewListAWSZonesNoCredentialsParams()
-	}
-
-	result, err := a.transport.Submit(&runtime.ClientOperation{
-		ID:                 "listAWSZonesNoCredentials",
-		Method:             "GET",
-		PathPattern:        "/api/v1/projects/{project_id}/dc/{dc}/clusters/{cluster_id}/providers/aws/zones",
-		ProducesMediaTypes: []string{"application/json"},
-		ConsumesMediaTypes: []string{"application/json"},
-		Schemes:            []string{"https"},
-		Params:             params,
-		Reader:             &ListAWSZonesNoCredentialsReader{formats: a.formats},
-		AuthInfo:           authInfo,
-		Context:            params.Context,
-		Client:             params.HTTPClient,
-	})
-	if err != nil {
-		return nil, err
-	}
-	return result.(*ListAWSZonesNoCredentialsOK), nil
-
-}
-
 // SetTransport changes the transport on the client
 func (a *Client) SetTransport(transport runtime.ClientTransport) {
 	a.transport = transport


### PR DESCRIPTION
We care about the subnets only and the subnets contain the AZ they
belong to, so there is no reason to have a dedicated AZ endpoint.

/assign @kgroschoff 

Please verify the UI doesn't use this :)

**What this PR does / why we need it**:

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Documentation**:
<!-- Add links to the related documentation changes related to this pull request. E.g. the link to the kubermatic/docs pullrequest. -->

**Does this PR introduce a user-facing change?**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If  no release note is required, just write "NONE".
-->
```release-note
none
```
