### PR TITLE
E2E tests: Dynamically fetch AWS VPC and subnets

### DIFF
--- a/api/cmd/conformance-tests/main.go
+++ b/api/cmd/conformance-tests/main.go
@@ -116,6 +116,8 @@ type secrets struct {
 	Kubevirt struct {
 		Kubeconfig string
 	}
+	kubermaticClient        *apiclient.Kubermatic
+	kubermaticAuthenticator runtime.ClientAuthInfoWriter
 }
 
 const (
@@ -245,6 +247,8 @@ func main() {
 	}
 	opts.kubermaticClient = apiclient.New(httptransport.New(kubermaticAPIServerAddress, "", []string{"http"}), nil)
 	opts.kubermaticAuthenticator = httptransport.BearerToken(kubermaticServiceaAccountToken)
+	opts.secrets.kubermaticClient = opts.kubermaticClient
+	opts.secrets.kubermaticAuthenticator = opts.kubermaticAuthenticator
 
 	if opts.openshift {
 		opts.openshiftPullSecret = os.Getenv("OPENSHIFT_IMAGE_PULL_SECRET")

--- a/api/cmd/conformance-tests/scenarios_aws.go
+++ b/api/cmd/conformance-tests/scenarios_aws.go
@@ -92,6 +92,12 @@ func (s *awsScenario) NodeDeployments(num int, secrets secrets) ([]apimodels.Nod
 		return nil, errors.New("got zero vpcs back")
 	}
 	vpcID := vpcResponse.Payload[0].VpcID
+	for _, vpc := range vpcResponse.Payload {
+		if vpc.IsDefault {
+			vpcID = vpc.VpcID
+			break
+		}
+	}
 
 	listSubnetParams := &awsapiclient.ListAWSSubnetsParams{
 		AccessKeyID:     utilpointer.StringPtr(secrets.AWS.AccessKeyID),

--- a/api/cmd/conformance-tests/scenarios_aws.go
+++ b/api/cmd/conformance-tests/scenarios_aws.go
@@ -1,11 +1,19 @@
 package main
 
 import (
+	"errors"
 	"fmt"
+	"time"
 
 	"github.com/kubermatic/kubermatic/api/pkg/semver"
+	awsapiclient "github.com/kubermatic/kubermatic/api/pkg/test/e2e/api/utils/apiclient/client/aws"
 	apimodels "github.com/kubermatic/kubermatic/api/pkg/test/e2e/api/utils/apiclient/models"
+
+	"k8s.io/apimachinery/pkg/util/sets"
+	utilpointer "k8s.io/utils/pointer"
 )
+
+const awsDC = "aws-eu-central-1a"
 
 // Returns a matrix of (version x operating system)
 func getAWSScenarios(versions []*semver.Semver) []testScenario {
@@ -53,7 +61,7 @@ func (s *awsScenario) Cluster(secrets secrets) *apimodels.CreateClusterSpec {
 			Type: "kubernetes",
 			Spec: &apimodels.ClusterSpec{
 				Cloud: &apimodels.CloudSpec{
-					DatacenterName: "aws-eu-central-1a",
+					DatacenterName: awsDC,
 					Aws: &apimodels.AWSCloudSpec{
 						SecretAccessKey: secrets.AWS.SecretAccessKey,
 						AccessKeyID:     secrets.AWS.AccessKeyID,
@@ -65,10 +73,54 @@ func (s *awsScenario) Cluster(secrets secrets) *apimodels.CreateClusterSpec {
 	}
 }
 
-func (s *awsScenario) NodeDeployments(num int, secrets secrets) []apimodels.NodeDeployment {
+func (s *awsScenario) NodeDeployments(num int, secrets secrets) ([]apimodels.NodeDeployment, error) {
 	instanceType := "t2.medium"
 	volumeType := "gp2"
 	volumeSize := int64(100)
+
+	listVPCParams := &awsapiclient.ListAWSVPCSParams{
+		AccessKeyID:     utilpointer.StringPtr(secrets.AWS.AccessKeyID),
+		SecretAccessKey: utilpointer.StringPtr(secrets.AWS.SecretAccessKey),
+		Dc:              awsDC,
+	}
+	listVPCParams.SetTimeout(15 * time.Second)
+	vpcResponse, err := secrets.kubermaticClient.Aws.ListAWSVPCS(listVPCParams, secrets.kubermaticAuthenticator)
+	if err != nil {
+		return nil, fmt.Errorf("failed to get vpcs: %s", fmtSwaggerError(err))
+	}
+	if len(vpcResponse.Payload) < 1 {
+		return nil, errors.New("got zero vpcs back")
+	}
+	vpcID := vpcResponse.Payload[0].VpcID
+
+	listSubnetParams := &awsapiclient.ListAWSSubnetsParams{
+		AccessKeyID:     utilpointer.StringPtr(secrets.AWS.AccessKeyID),
+		SecretAccessKey: utilpointer.StringPtr(secrets.AWS.SecretAccessKey),
+		Dc:              awsDC,
+		Vpc:             utilpointer.StringPtr(vpcID),
+	}
+	listSubnetParams.SetTimeout(15 * time.Second)
+	subnetResponse, err := secrets.kubermaticClient.Aws.ListAWSSubnets(listSubnetParams, secrets.kubermaticAuthenticator)
+	if err != nil {
+		return nil, fmt.Errorf("failed to get subnets: %s", fmtSwaggerError(err))
+	}
+	if n := len(subnetResponse.Payload); n < 3 {
+		return nil, fmt.Errorf("expected to get at least three subnets, got %d", n)
+	}
+
+	// Find three subnets that are in different AZs to preserve the multi az testcase
+	allAZs := sets.String{}
+	var subnets []*apimodels.AWSSubnet
+	for _, subnet := range subnetResponse.Payload {
+		if !allAZs.Has(subnet.AvailabilityZone) {
+			allAZs.Insert(subnet.AvailabilityZone)
+			subnets = append(subnets, subnet)
+		}
+	}
+
+	if n := len(subnets); n < 3 {
+		return nil, fmt.Errorf("wanted three subnets in different AZs, got only %d", n)
+	}
 
 	nds := []apimodels.NodeDeployment{
 		{
@@ -79,8 +131,8 @@ func (s *awsScenario) NodeDeployments(num int, secrets secrets) []apimodels.Node
 							InstanceType:     &instanceType,
 							VolumeType:       &volumeType,
 							VolumeSize:       &volumeSize,
-							AvailabilityZone: "eu-central-1a",
-							SubnetID:         "subnet-2bff4f43",
+							AvailabilityZone: subnets[0].AvailabilityZone,
+							SubnetID:         subnets[0].ID,
 						},
 					},
 					Versions: &apimodels.NodeVersionInfo{
@@ -98,8 +150,8 @@ func (s *awsScenario) NodeDeployments(num int, secrets secrets) []apimodels.Node
 							InstanceType:     &instanceType,
 							VolumeType:       &volumeType,
 							VolumeSize:       &volumeSize,
-							AvailabilityZone: "eu-central-1b",
-							SubnetID:         "subnet-06d1167c",
+							AvailabilityZone: subnets[1].AvailabilityZone,
+							SubnetID:         subnets[1].ID,
 						},
 					},
 					Versions: &apimodels.NodeVersionInfo{
@@ -117,8 +169,8 @@ func (s *awsScenario) NodeDeployments(num int, secrets secrets) []apimodels.Node
 							InstanceType:     &instanceType,
 							VolumeType:       &volumeType,
 							VolumeSize:       &volumeSize,
-							AvailabilityZone: "eu-central-1c",
-							SubnetID:         "subnet-f3427db9",
+							AvailabilityZone: subnets[2].AvailabilityZone,
+							SubnetID:         subnets[2].ID,
 						},
 					},
 					Versions: &apimodels.NodeVersionInfo{
@@ -144,7 +196,7 @@ func (s *awsScenario) NodeDeployments(num int, secrets secrets) []apimodels.Node
 		nds[i].Spec.Replicas = &replicas
 	}
 
-	return nds
+	return nds, nil
 }
 
 func (s *awsScenario) OS() apimodels.OperatingSystemSpec {

--- a/api/cmd/conformance-tests/scenarios_azure.go
+++ b/api/cmd/conformance-tests/scenarios_azure.go
@@ -68,7 +68,7 @@ func (s *azureScenario) Cluster(secrets secrets) *apimodels.CreateClusterSpec {
 	}
 }
 
-func (s *azureScenario) NodeDeployments(num int, _ secrets) []apimodels.NodeDeployment {
+func (s *azureScenario) NodeDeployments(num int, _ secrets) ([]apimodels.NodeDeployment, error) {
 	replicas := int32(num)
 	size := "Standard_F2"
 	return []apimodels.NodeDeployment{
@@ -88,7 +88,7 @@ func (s *azureScenario) NodeDeployments(num int, _ secrets) []apimodels.NodeDepl
 				},
 			},
 		},
-	}
+	}, nil
 }
 
 func (s *azureScenario) OS() apimodels.OperatingSystemSpec {

--- a/api/cmd/conformance-tests/scenarios_digitalocean.go
+++ b/api/cmd/conformance-tests/scenarios_digitalocean.go
@@ -66,7 +66,7 @@ func (s *digitaloceanScenario) Cluster(secrets secrets) *apimodels.CreateCluster
 	}
 }
 
-func (s *digitaloceanScenario) NodeDeployments(num int, _ secrets) []apimodels.NodeDeployment {
+func (s *digitaloceanScenario) NodeDeployments(num int, _ secrets) ([]apimodels.NodeDeployment, error) {
 	replicas := int32(num)
 	size := "4gb"
 	return []apimodels.NodeDeployment{
@@ -86,7 +86,7 @@ func (s *digitaloceanScenario) NodeDeployments(num int, _ secrets) []apimodels.N
 				},
 			},
 		},
-	}
+	}, nil
 }
 
 func (s *digitaloceanScenario) OS() apimodels.OperatingSystemSpec {

--- a/api/cmd/conformance-tests/scenarios_gcp.go
+++ b/api/cmd/conformance-tests/scenarios_gcp.go
@@ -69,7 +69,7 @@ func (s *gcpScenario) Cluster(secrets secrets) *apimodels.CreateClusterSpec {
 	}
 }
 
-func (s *gcpScenario) NodeDeployments(num int, secrets secrets) []apimodels.NodeDeployment {
+func (s *gcpScenario) NodeDeployments(num int, secrets secrets) ([]apimodels.NodeDeployment, error) {
 	replicas := int32(num)
 
 	return []apimodels.NodeDeployment{
@@ -96,7 +96,7 @@ func (s *gcpScenario) NodeDeployments(num int, secrets secrets) []apimodels.Node
 				},
 			},
 		},
-	}
+	}, nil
 }
 
 func (s *gcpScenario) OS() apimodels.OperatingSystemSpec {

--- a/api/cmd/conformance-tests/scenarios_hetzner.go
+++ b/api/cmd/conformance-tests/scenarios_hetzner.go
@@ -56,7 +56,7 @@ func (s *hetznerScenario) Cluster(secrets secrets) *apimodels.CreateClusterSpec 
 	}
 }
 
-func (s *hetznerScenario) NodeDeployments(num int, _ secrets) []apimodels.NodeDeployment {
+func (s *hetznerScenario) NodeDeployments(num int, _ secrets) ([]apimodels.NodeDeployment, error) {
 	replicas := int32(num)
 	nodeType := "cx31"
 
@@ -77,7 +77,7 @@ func (s *hetznerScenario) NodeDeployments(num int, _ secrets) []apimodels.NodeDe
 				},
 			},
 		},
-	}
+	}, nil
 }
 
 func (s *hetznerScenario) OS() apimodels.OperatingSystemSpec {

--- a/api/cmd/conformance-tests/scenarios_kubevirt.go
+++ b/api/cmd/conformance-tests/scenarios_kubevirt.go
@@ -62,7 +62,7 @@ func (s *kubevirtScenario) Cluster(secrets secrets) *apimodels.CreateClusterSpec
 	}
 }
 
-func (s *kubevirtScenario) NodeDeployments(num int, _ secrets) []apimodels.NodeDeployment {
+func (s *kubevirtScenario) NodeDeployments(num int, _ secrets) ([]apimodels.NodeDeployment, error) {
 	var sourceURL string
 
 	switch {
@@ -96,7 +96,7 @@ func (s *kubevirtScenario) NodeDeployments(num int, _ secrets) []apimodels.NodeD
 				},
 			},
 		},
-	}
+	}, nil
 }
 
 func (s *kubevirtScenario) OS() apimodels.OperatingSystemSpec {

--- a/api/cmd/conformance-tests/scenarios_openstack.go
+++ b/api/cmd/conformance-tests/scenarios_openstack.go
@@ -70,7 +70,7 @@ func (s *openStackScenario) Cluster(secrets secrets) *apimodels.CreateClusterSpe
 	}
 }
 
-func (s *openStackScenario) NodeDeployments(num int, _ secrets) []apimodels.NodeDeployment {
+func (s *openStackScenario) NodeDeployments(num int, _ secrets) ([]apimodels.NodeDeployment, error) {
 	osName := getOSNameFromSpec(s.nodeOsSpec)
 	image := "kubermatic-e2e-" + osName
 	flavor := "m1.small"
@@ -94,7 +94,7 @@ func (s *openStackScenario) NodeDeployments(num int, _ secrets) []apimodels.Node
 				},
 			},
 		},
-	}
+	}, nil
 }
 
 func (s *openStackScenario) OS() apimodels.OperatingSystemSpec {

--- a/api/cmd/conformance-tests/scenarios_packet.go
+++ b/api/cmd/conformance-tests/scenarios_packet.go
@@ -67,7 +67,7 @@ func (s *packetScenario) Cluster(secrets secrets) *apimodels.CreateClusterSpec {
 	}
 }
 
-func (s *packetScenario) NodeDeployments(num int, _ secrets) []apimodels.NodeDeployment {
+func (s *packetScenario) NodeDeployments(num int, _ secrets) ([]apimodels.NodeDeployment, error) {
 	instanceType := "t1.small.x86"
 	replicas := int32(num)
 	return []apimodels.NodeDeployment{
@@ -87,7 +87,7 @@ func (s *packetScenario) NodeDeployments(num int, _ secrets) []apimodels.NodeDep
 				},
 			},
 		},
-	}
+	}, nil
 }
 
 func (s *packetScenario) OS() apimodels.OperatingSystemSpec {

--- a/api/cmd/conformance-tests/scenarios_vsphere.go
+++ b/api/cmd/conformance-tests/scenarios_vsphere.go
@@ -67,7 +67,7 @@ func (s *vSphereScenario) Cluster(secrets secrets) *apimodels.CreateClusterSpec 
 	}
 }
 
-func (s *vSphereScenario) NodeDeployments(num int, _ secrets) []apimodels.NodeDeployment {
+func (s *vSphereScenario) NodeDeployments(num int, _ secrets) ([]apimodels.NodeDeployment, error) {
 	osName := getOSNameFromSpec(s.nodeOsSpec)
 	replicas := int32(num)
 	return []apimodels.NodeDeployment{
@@ -89,7 +89,7 @@ func (s *vSphereScenario) NodeDeployments(num int, _ secrets) []apimodels.NodeDe
 				},
 			},
 		},
-	}
+	}, nil
 }
 
 func (s *vSphereScenario) OS() apimodels.OperatingSystemSpec {

--- a/api/hack/ci/ci-run-minimal-conformance-tests.sh
+++ b/api/hack/ci/ci-run-minimal-conformance-tests.sh
@@ -276,12 +276,10 @@ if [[ -n ${UPGRADE_TEST_BASE_HASH:-} ]]; then
   build_tag_if_not_exists "$UPGRADE_TEST_BASE_HASH"
 fi
 
-# PULL_BASE_REF is the name of the current branch in case of a post-submit
-# or the name of the base branch in case of a PR. It is unset for Periodics, but
-# we default it in that case.
-#
-# The env var is named `UPGRADE_TEST_BASE_HASH`, but we really only specify release branch heads with it.
-LATEST_DASHBOARD="$(get_latest_dashboard_hash "${UPGRADE_TEST_BASE_HASH:-$PULL_BASE_REF}")"
+# Hardcoded as the only thing these tests test about the dashboard is that the pod comes up. In order to
+# not introduce a dependency on the dashboard push postsubmit being successfully run, we just harcode it
+# here.
+LATEST_DASHBOARD=43037e8f118f0e310cfcae713bc2b3bd1a2c8496
 
 # We must delete all templates for cluster-scoped resources
 # because those already exist because of the main Kubermatic installation


### PR DESCRIPTION
**What this PR does / why we need it**:

Changes the e2e tests to dynamically fetch AWS VPC and subnets. This is needed in order to use boskos, as it results in multiple accounts being used and hence the current approach of hardcoding the subnets wont work anymore.

Also has the nice side-effect that it tests whether our VPC and subnet endpoints work.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Documentation**:
<!-- Add links to the related documentation changes related to this pull request. E.g. the link to the kubermatic/docs pullrequest. -->

**Does this PR introduce a user-facing change?**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If  no release note is required, just write "NONE".
-->
```release-note
none
```

/assign @xrstf 