### PR TITLE
extend seed-proxy to cover multiple monitoring services

### DIFF
--- a/api/pkg/controller/seed-proxy/controller.go
+++ b/api/pkg/controller/seed-proxy/controller.go
@@ -53,25 +53,23 @@ const (
 	// cluster where the service account will be created.
 	SeedServiceAccountNamespace = metav1.NamespaceSystem
 
-	// SeedPrometheusNamespace is the namespace inside the seed
-	// cluster where Prometheus is installed.
-	SeedPrometheusNamespace = "monitoring"
+	// SeedMonitoringNamespace is the namespace inside the seed
+	// cluster where Prometheus, Grafana etc. are installed.
+	SeedMonitoringNamespace = "monitoring"
 
-	// SeedPrometheusServiceName is the service that is provided by
-	// Prometheus inside the seed cluster.
-	SeedPrometheusServiceName = "prometheus-kubermatic"
+	// SeedMonitoringRoleName is the name inside the seed monitoring
+	// namespace used for the new role used for proxying to Prometheus/Grafana/...
+	SeedMonitoringRoleName = "seed-proxy"
 
-	// SeedPrometheusServicePort is the port name that is provided by
-	// Prometheus inside the seed cluster.
-	SeedPrometheusServicePort = "web"
+	// SeedMonitoringRoleBindingName is the name inside the seed
+	// monitoring namespace used for the new role binding.
+	SeedMonitoringRoleBindingName = "seed-proxy"
 
-	// SeedPrometheusRoleName is the name inside the seed
-	// used for the new role used for proxying to Prometheus.
-	SeedPrometheusRoleName = "seed-proxy-prometheus"
+	// SeedPrometheusService is the service exposed by Prometheus.
+	SeedPrometheusService = "prometheus:web"
 
-	// SeedPrometheusRoleBindingName is the name inside the seed
-	// used for the new role binding used for proxying to Prometheus.
-	SeedPrometheusRoleBindingName = "seed-proxy-prometheus"
+	// SeedAlertmanagerService is the service exposed by Alertmanager.
+	SeedAlertmanagerService = "alertmanager:web"
 
 	// KubectlProxyPort is the port used by kubectl to provide the
 	// proxy connection on. This is not the port on which any of the

--- a/api/pkg/controller/seed-proxy/reconciler.go
+++ b/api/pkg/controller/seed-proxy/reconciler.go
@@ -151,11 +151,11 @@ func (r *Reconciler) ensureSeedServiceAccounts(client ctrlruntimeclient.Client) 
 
 func (r *Reconciler) ensureSeedRoles(client ctrlruntimeclient.Client) error {
 	creators := []reconciling.NamedRoleCreatorGetter{
-		seedPrometheusRoleCreator(),
+		seedMonitoringRoleCreator(),
 	}
 
-	if err := reconciling.ReconcileRoles(r.ctx, creators, SeedPrometheusNamespace, client); err != nil {
-		return fmt.Errorf("failed to reconcile Roles in the namespace %s: %v", SeedPrometheusNamespace, err)
+	if err := reconciling.ReconcileRoles(r.ctx, creators, SeedMonitoringNamespace, client); err != nil {
+		return fmt.Errorf("failed to reconcile Roles in the namespace %s: %v", SeedMonitoringNamespace, err)
 	}
 
 	return nil
@@ -163,11 +163,11 @@ func (r *Reconciler) ensureSeedRoles(client ctrlruntimeclient.Client) error {
 
 func (r *Reconciler) ensureSeedRoleBindings(client ctrlruntimeclient.Client) error {
 	creators := []reconciling.NamedRoleBindingCreatorGetter{
-		seedPrometheusRoleBindingCreator(),
+		seedMonitoringRoleBindingCreator(),
 	}
 
-	if err := reconciling.ReconcileRoleBindings(r.ctx, creators, SeedPrometheusNamespace, client); err != nil {
-		return fmt.Errorf("failed to reconcile RoleBindings in the namespace %s: %v", SeedPrometheusNamespace, err)
+	if err := reconciling.ReconcileRoleBindings(r.ctx, creators, SeedMonitoringNamespace, client); err != nil {
+		return fmt.Errorf("failed to reconcile RoleBindings in the namespace %s: %v", SeedMonitoringNamespace, err)
 	}
 
 	return nil

--- a/api/pkg/controller/seed-proxy/resources.go
+++ b/api/pkg/controller/seed-proxy/resources.go
@@ -18,6 +18,7 @@ import (
 	"k8s.io/client-go/rest"
 	"k8s.io/client-go/tools/clientcmd"
 	"k8s.io/client-go/tools/clientcmd/api"
+	"k8s.io/utils/pointer"
 )
 
 func secretName(contextName string) string {
@@ -30,10 +31,6 @@ func deploymentName(contextName string) string {
 
 func serviceName(contextName string) string {
 	return fmt.Sprintf("seed-proxy-%s", contextName)
-}
-
-func fullPrometheusService() string {
-	return fmt.Sprintf("%s:%s", SeedPrometheusServiceName, SeedPrometheusServicePort)
 }
 
 func defaultLabels(name string, instance string) map[string]string {
@@ -65,17 +62,20 @@ func seedServiceAccountCreator() reconciling.NamedServiceAccountCreatorGetter {
 	}
 }
 
-func seedPrometheusRoleCreator() reconciling.NamedRoleCreatorGetter {
+func seedMonitoringRoleCreator() reconciling.NamedRoleCreatorGetter {
 	return func() (string, reconciling.RoleCreator) {
-		return SeedPrometheusRoleName, func(r *rbacv1.Role) (*rbacv1.Role, error) {
-			r.Labels = defaultLabels(SeedPrometheusRoleName, "")
+		return SeedMonitoringRoleName, func(r *rbacv1.Role) (*rbacv1.Role, error) {
+			r.Labels = defaultLabels(SeedMonitoringRoleName, "")
 
 			r.Rules = []rbacv1.PolicyRule{
 				{
-					APIGroups:     []string{""},
-					Resources:     []string{"services/proxy"},
-					ResourceNames: []string{fullPrometheusService()},
-					Verbs:         []string{"get"},
+					APIGroups: []string{""},
+					Verbs:     []string{"get"},
+					Resources: []string{"services/proxy"},
+					ResourceNames: []string{
+						SeedPrometheusService,
+						SeedAlertmanagerService,
+					},
 				},
 			}
 
@@ -84,15 +84,15 @@ func seedPrometheusRoleCreator() reconciling.NamedRoleCreatorGetter {
 	}
 }
 
-func seedPrometheusRoleBindingCreator() reconciling.NamedRoleBindingCreatorGetter {
+func seedMonitoringRoleBindingCreator() reconciling.NamedRoleBindingCreatorGetter {
 	return func() (string, reconciling.RoleBindingCreator) {
-		return SeedPrometheusRoleBindingName, func(rb *rbacv1.RoleBinding) (*rbacv1.RoleBinding, error) {
-			rb.Labels = defaultLabels(SeedPrometheusRoleBindingName, "")
+		return SeedMonitoringRoleBindingName, func(rb *rbacv1.RoleBinding) (*rbacv1.RoleBinding, error) {
+			rb.Labels = defaultLabels(SeedMonitoringRoleBindingName, "")
 
 			rb.RoleRef = rbacv1.RoleRef{
 				APIGroup: rbacv1.GroupName,
 				Kind:     "Role",
-				Name:     SeedPrometheusRoleName,
+				Name:     SeedMonitoringRoleName,
 			}
 
 			rb.Subjects = []rbacv1.Subject{
@@ -188,7 +188,7 @@ func masterDeploymentCreator(contextName string, secret *corev1.Secret) reconcil
 			d.Labels = labels()
 			d.Labels[ManagedByLabel] = ControllerName
 
-			d.Spec.Replicas = i32ptr(1)
+			d.Spec.Replicas = pointer.Int32Ptr(1)
 			d.Spec.Selector = &metav1.LabelSelector{
 				MatchLabels: labels(),
 			}
@@ -331,8 +331,8 @@ func buildGrafanaDatasource(seedName string) (string, error) {
 		"ServiceName":             serviceName(seedName),
 		"ServiceNamespace":        MasterTargetNamespace,
 		"ProxyPort":               KubectlProxyPort,
-		"SeedPrometheusNamespace": SeedPrometheusNamespace,
-		"SeedPrometheusService":   fullPrometheusService(),
+		"SeedMonitoringNamespace": SeedMonitoringNamespace,
+		"SeedPrometheusService":   SeedPrometheusService,
 	}
 
 	var buffer bytes.Buffer
@@ -341,10 +341,6 @@ func buildGrafanaDatasource(seedName string) (string, error) {
 	err := tpl.Execute(&buffer, data)
 
 	return strings.TrimSpace(buffer.String()), err
-}
-
-func i32ptr(i int32) *int32 {
-	return &i
 }
 
 const proxyScript = `
@@ -367,6 +363,6 @@ datasources:
   org_id: 1
   type: prometheus
   access: proxy
-  url: http://{{ .ServiceName }}.{{ .ServiceNamespace }}.svc.cluster.local:{{ .ProxyPort }}/api/v1/namespaces/{{ .SeedPrometheusNamespace }}/services/{{ .SeedPrometheusService }}/proxy/
+  url: http://{{ .ServiceName }}.{{ .ServiceNamespace }}.svc.cluster.local:{{ .ProxyPort }}/api/v1/namespaces/{{ .SeedMonitoringNamespace }}/services/{{ .SeedPrometheusService }}/proxy/
   editable: false
 `


### PR DESCRIPTION
**What this PR does / why we need it**:
We want to proxy not just Prometheus, but also the Alertmanager. This PR therefore extends the seed-proxy controller to not manage a proxy-pod just for Prometheus, but instead use one proxy pod for all services inside a given namespace (the monitoring namespace in this case).
This PR also fixes the outdated naming scheme for services. `prometheus-kubermatic` is now just `prometheus`.

**Does this PR introduce a user-facing change?**:
```release-note
NONE
```
