### PR TITLE
Register Kubermatic scheme in an init func

### DIFF
--- a/api/cmd/conformance-tests/main.go
+++ b/api/cmd/conformance-tests/main.go
@@ -312,9 +312,6 @@ func main() {
 		log.Fatal(err)
 	}
 
-	if err := kubermaticv1.SchemeBuilder.AddToScheme(scheme.Scheme); err != nil {
-		log.Fatalf("failed to add kubermatic scheme to mgr: %v", err)
-	}
 	if err := clusterv1alpha1.SchemeBuilder.AddToScheme(scheme.Scheme); err != nil {
 		log.Fatalf("failed to add clusterv1alpha1 to scheme: %v", err)
 	}

--- a/api/cmd/kubermatic-api/main.go
+++ b/api/cmd/kubermatic-api/main.go
@@ -77,9 +77,6 @@ func main() {
 	}()
 	kubermaticlog.Logger = log
 
-	if err := kubermaticv1.AddToScheme(scheme.Scheme); err != nil {
-		kubermaticlog.Logger.Fatalw("failed to register scheme", zap.Stringer("api", kubermaticv1.SchemeGroupVersion), zap.Error(err))
-	}
 	if err := clusterv1alpha1.AddToScheme(scheme.Scheme); err != nil {
 		kubermaticlog.Logger.Fatalw("failed to register scheme", zap.Stringer("api", clusterv1alpha1.SchemeGroupVersion), zap.Error(err))
 	}

--- a/api/cmd/kubermatic-controller-manager/main.go
+++ b/api/cmd/kubermatic-controller-manager/main.go
@@ -80,9 +80,6 @@ func main() {
 	if err := autoscalingv1beta2.AddToScheme(mgr.GetScheme()); err != nil {
 		log.Fatalw("Failed to register scheme", zap.Stringer("api", autoscalingv1beta2.SchemeGroupVersion), zap.Error(err))
 	}
-	if err := kubermaticv1.SchemeBuilder.AddToScheme(mgr.GetScheme()); err != nil {
-		log.Fatalw("Failed to register scheme", zap.Stringer("api", kubermaticv1.SchemeGroupVersion), zap.Error(err))
-	}
 	if err := clusterv1alpha1.AddToScheme(mgr.GetScheme()); err != nil {
 		kubermaticlog.Logger.Fatalw("failed to register scheme", zap.Stringer("api", clusterv1alpha1.SchemeGroupVersion), zap.Error(err))
 	}

--- a/api/cmd/master-controller-manager/main.go
+++ b/api/cmd/master-controller-manager/main.go
@@ -10,7 +10,6 @@ import (
 	"github.com/prometheus/client_golang/prometheus"
 	"go.uber.org/zap"
 
-	kubermaticv1 "github.com/kubermatic/kubermatic/api/pkg/crd/kubermatic/v1"
 	kubermaticlog "github.com/kubermatic/kubermatic/api/pkg/log"
 	"github.com/kubermatic/kubermatic/api/pkg/metrics"
 	metricserver "github.com/kubermatic/kubermatic/api/pkg/metrics/server"
@@ -20,7 +19,6 @@ import (
 	seedvalidation "github.com/kubermatic/kubermatic/api/pkg/validation/seed"
 
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/client-go/kubernetes/scheme"
 	"k8s.io/client-go/tools/clientcmd"
 	"sigs.k8s.io/controller-runtime/pkg/manager"
 	"sigs.k8s.io/controller-runtime/pkg/runtime/log"
@@ -82,10 +80,6 @@ func main() {
 		sugarLog.Fatalw("Failed to create the label selector for the given worker", "workerName", runOpts.workerName, zap.Error(err))
 	}
 
-	if err := kubermaticv1.SchemeBuilder.AddToScheme(scheme.Scheme); err != nil {
-		kubermaticlog.Logger.Fatalw("failed to add kubermaticv1 scheme to scheme.Scheme", zap.Error(err))
-	}
-
 	// register the global error metric. Ensures that runtime.HandleError() increases the error metric
 	metrics.RegisterRuntimErrorMetricCounter("kubermatic_master_controller_manager", prometheus.DefaultRegisterer)
 
@@ -120,9 +114,6 @@ func main() {
 	mgr, err := manager.New(cfg, manager.Options{MetricsBindAddress: ""})
 	if err != nil {
 		sugarLog.Fatalw("failed to create Controller Manager instance", zap.Error(err))
-	}
-	if err := kubermaticv1.AddToScheme(mgr.GetScheme()); err != nil {
-		sugarLog.Fatalw("failed to register types in Scheme", zap.Error(err))
 	}
 	ctrlCtx.mgr = mgr
 	ctrlCtx.seedsGetter, err = provider.SeedsGetterFactory(ctx, ctrlCtx.mgr.GetClient(), runOpts.dcFile, ctrlCtx.namespace, runOpts.workerName, runOpts.dynamicDatacenters)

--- a/api/pkg/controller/addoninstaller/addoninstaller_controller_test.go
+++ b/api/pkg/controller/addoninstaller/addoninstaller_controller_test.go
@@ -12,7 +12,6 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
-	"k8s.io/client-go/kubernetes/scheme"
 	ctrlruntimefakeclient "sigs.k8s.io/controller-runtime/pkg/client/fake"
 )
 
@@ -96,9 +95,6 @@ func TestCreateAddon(t *testing.T) {
 	}
 
 	for _, test := range tests {
-		if err := kubermaticv1.SchemeBuilder.AddToScheme(scheme.Scheme); err != nil {
-			t.Fatalf("failed to add kubermaticv1 scheme to scheme.Scheme: %v", err)
-		}
 
 		t.Run(test.name, func(t *testing.T) {
 			objs := []runtime.Object{test.cluster}

--- a/api/pkg/controller/backup/backup_controller_test.go
+++ b/api/pkg/controller/backup/backup_controller_test.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"testing"
 
-	kubermaticscheme "github.com/kubermatic/kubermatic/api/pkg/crd/client/clientset/versioned/scheme"
 	kubermaticv1 "github.com/kubermatic/kubermatic/api/pkg/crd/kubermatic/v1"
 	kubermaticlog "github.com/kubermatic/kubermatic/api/pkg/log"
 	"github.com/kubermatic/kubermatic/api/pkg/resources"
@@ -13,7 +12,6 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
-	"k8s.io/client-go/kubernetes/scheme"
 	certutil "k8s.io/client-go/util/cert"
 	ctrlruntimeclient "sigs.k8s.io/controller-runtime/pkg/client"
 	ctrlruntimefakeclient "sigs.k8s.io/controller-runtime/pkg/client/fake"
@@ -30,10 +28,6 @@ var (
 )
 
 func TestEnsureBackupCronJob(t *testing.T) {
-	if err := kubermaticscheme.AddToScheme(scheme.Scheme); err != nil {
-		t.Fatalf("failed to add kubermatic scheme: %v", err)
-	}
-
 	cluster := &kubermaticv1.Cluster{
 		ObjectMeta: metav1.ObjectMeta{
 			Name: "test-cluster",

--- a/api/pkg/controller/monitoring/monitoring_controller_test.go
+++ b/api/pkg/controller/monitoring/monitoring_controller_test.go
@@ -3,12 +3,10 @@ package monitoring
 import (
 	"testing"
 
-	kubermaticscheme "github.com/kubermatic/kubermatic/api/pkg/crd/client/clientset/versioned/scheme"
 	kubermaticv1 "github.com/kubermatic/kubermatic/api/pkg/crd/kubermatic/v1"
 
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
-	"k8s.io/client-go/kubernetes/scheme"
 	ctrlruntimefakeclient "sigs.k8s.io/controller-runtime/pkg/client/fake"
 )
 
@@ -17,10 +15,6 @@ const (
 )
 
 func newTestReconciler(t *testing.T, objects []runtime.Object) *Reconciler {
-	if err := kubermaticscheme.AddToScheme(scheme.Scheme); err != nil {
-		t.Fatalf("failed to add kubermatic scheme: %v", err)
-	}
-
 	dynamicClient := ctrlruntimefakeclient.NewFakeClient(objects...)
 	reconciler := &Reconciler{
 		Client:               dynamicClient,

--- a/api/pkg/controller/openshift/openshift_controller_test.go
+++ b/api/pkg/controller/openshift/openshift_controller_test.go
@@ -90,11 +90,7 @@ func TestResources(t *testing.T) {
 
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
-
 			ctrlruntimelog.SetLogger(ctrlruntimelog.ZapLogger(true))
-			if err := kubermaticv1.SchemeBuilder.AddToScheme(scheme.Scheme); err != nil {
-				t.Fatalf("failed to add kubermatic scheme to mgr: %v", err)
-			}
 			if err := autoscalingv1beta2.AddToScheme(scheme.Scheme); err != nil {
 				t.Fatalf("failed to add the autoscaling.k8s.io scheme to mgr: %v", err)
 			}

--- a/api/pkg/controller/seed-sync/reconciler_test.go
+++ b/api/pkg/controller/seed-sync/reconciler_test.go
@@ -14,7 +14,6 @@ import (
 	kerrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
-	"k8s.io/client-go/kubernetes/scheme"
 	"k8s.io/client-go/tools/record"
 	ctrlruntimeclient "sigs.k8s.io/controller-runtime/pkg/client"
 	ctrlruntimefake "sigs.k8s.io/controller-runtime/pkg/client/fake"
@@ -86,9 +85,6 @@ func TestReconcilingSeed(t *testing.T) {
 	log := rawLog.Sugar()
 
 	ctrlruntimelog.SetLogger(zapr.NewLogger(rawLog).WithName("controller_runtime"))
-	if err := kubermaticv1.AddToScheme(scheme.Scheme); err != nil {
-		t.Fatalf("failed to register types in scheme: %v", err)
-	}
 
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {

--- a/api/pkg/controller/service-account/service_account_binding_test.go
+++ b/api/pkg/controller/service-account/service_account_binding_test.go
@@ -14,7 +14,6 @@ import (
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/apimachinery/pkg/util/diff"
-	"k8s.io/client-go/kubernetes/scheme"
 
 	controllerclient "sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
@@ -54,11 +53,7 @@ func TestReconcileBinding(t *testing.T) {
 		t.Run(test.name, func(t *testing.T) {
 			// setup the test scenario
 
-			scheme := scheme.Scheme
-			if err := kubermaticv1.AddToScheme(scheme); err != nil {
-				t.Fatal(err)
-			}
-			kubermaticFakeClient := fake.NewFakeClientWithScheme(scheme, test.existingKubermaticObjects...)
+			kubermaticFakeClient := fake.NewFakeClient(test.existingKubermaticObjects...)
 
 			// act
 			target := reconcileServiceAccountProjectBinding{ctx: context.TODO(), Client: kubermaticFakeClient}

--- a/api/pkg/controller/user-project-binding/user_project_binding_test.go
+++ b/api/pkg/controller/user-project-binding/user_project_binding_test.go
@@ -11,7 +11,6 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/util/diff"
-	"k8s.io/client-go/kubernetes/scheme"
 
 	controllerclient "sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
@@ -97,11 +96,7 @@ func TestEnsureNotProjectOwnerForBinding(t *testing.T) {
 				objs = append(objs, test.existingProject)
 			}
 
-			scheme := scheme.Scheme
-			if err := kubermaticv1.AddToScheme(scheme); err != nil {
-				t.Fatal(err)
-			}
-			kubermaticFakeClient := fake.NewFakeClientWithScheme(scheme, objs...)
+			kubermaticFakeClient := fake.NewFakeClient(objs...)
 
 			// act
 			target := reconcileSyncProjectBinding{ctx: context.TODO(), Client: kubermaticFakeClient}
@@ -186,11 +181,7 @@ func TestEnsureProjectOwnerForBinding(t *testing.T) {
 				objs = append(objs, test.existingProject)
 			}
 
-			scheme := scheme.Scheme
-			if err := kubermaticv1.AddToScheme(scheme); err != nil {
-				t.Fatal(err)
-			}
-			kubermaticFakeClient := fake.NewFakeClientWithScheme(scheme, objs...)
+			kubermaticFakeClient := fake.NewFakeClient(objs...)
 
 			// act
 			target := reconcileSyncProjectBinding{ctx: context.TODO(), Client: kubermaticFakeClient}

--- a/api/pkg/controller/util/util_test.go
+++ b/api/pkg/controller/util/util_test.go
@@ -12,19 +12,8 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	utilpointer "k8s.io/utils/pointer"
 
-	"k8s.io/client-go/kubernetes/scheme"
-
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 )
-
-func init() {
-	// We call this in init because even thought it is possible to register the same
-	// scheme multiple times it is an unprotected concurrent map access and these tests
-	// are very good at making that panic
-	if err := kubermaticv1.SchemeBuilder.AddToScheme(scheme.Scheme); err != nil {
-		panic(err)
-	}
-}
 
 func TestConcurrencyLimitReached(t *testing.T) {
 	concurrencyLimitReachedTestCases := []struct {

--- a/api/pkg/crd/kubermatic/v1/register.go
+++ b/api/pkg/crd/kubermatic/v1/register.go
@@ -1,10 +1,19 @@
 package v1
 
 import (
+	"fmt"
+
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/client-go/kubernetes/scheme"
 )
+
+func init() {
+	if err := AddToScheme(scheme.Scheme); err != nil {
+		panic(fmt.Sprintf("failed to add kubermatic scheme: %v", err))
+	}
+}
 
 var (
 	SchemeBuilder = runtime.NewSchemeBuilder(addKnownTypes)

--- a/api/pkg/handler/test/helper.go
+++ b/api/pkg/handler/test/helper.go
@@ -61,9 +61,6 @@ func init() {
 	if err := clusterv1alpha1.SchemeBuilder.AddToScheme(scheme.Scheme); err != nil {
 		kubermaticlog.Logger.Fatalw("failed to add clusterv1alpha1 scheme to scheme.Scheme", "error", err)
 	}
-	if err := kubermaticv1.SchemeBuilder.AddToScheme(scheme.Scheme); err != nil {
-		kubermaticlog.Logger.Fatalw("failed to add kubermaticv1 scheme to scheme.Scheme", "error", err)
-	}
 	if err := v1beta1.AddToScheme(scheme.Scheme); err != nil {
 		kubermaticlog.Logger.Fatalw("failed to register scheme v1beta1", "error", err)
 	}

--- a/api/pkg/validation/seed/seed_test.go
+++ b/api/pkg/validation/seed/seed_test.go
@@ -7,19 +7,9 @@ import (
 
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
-	"k8s.io/client-go/kubernetes/scheme"
 	ctrlruntimeclient "sigs.k8s.io/controller-runtime/pkg/client"
 	fakectrlruntimeclient "sigs.k8s.io/controller-runtime/pkg/client/fake"
 )
-
-func init() {
-	// We call this in init because even though it is possible to register the same
-	// scheme multiple times it is an unprotected concurrent map access and these tests
-	// are very good at making that panic
-	if err := kubermaticv1.SchemeBuilder.AddToScheme(scheme.Scheme); err != nil {
-		panic(err)
-	}
-}
 
 func TestValidate(t *testing.T) {
 	fakeProviderSpec := kubermaticv1.DatacenterSpec{


### PR DESCRIPTION
**What this PR does / why we need it**:

Registers the kubermatic scheme in an init within the API package, so this gets done automatically instead of requiring everyone who uses the package to know about the registration and do it.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Documentation**:
<!-- Add links to the related documentation changes related to this pull request. E.g. the link to the kubermatic/docs pullrequest. -->

**Does this PR introduce a user-facing change?**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If  no release note is required, just write "NONE".
-->
```release-note
none
```
