### PR TITLE
add Karma dashboard Chart

### DIFF
--- a/api/hack/deploy.sh
+++ b/api/hack/deploy.sh
@@ -83,6 +83,10 @@ case "${DEPLOY_STACK}" in
     deploy "helm-exporter" "monitoring" ./config/monitoring/helm-exporter/
     if [[ "${DEPLOY_ALERTMANAGER}" = true ]]; then
       deploy "alertmanager" "monitoring" ./config/monitoring/alertmanager/
+
+      if [[ "${1}" = "master" ]]; then
+        deploy "karma" "monitoring" ./config/monitoring/karma/
+      fi
     fi
 
     # Prometheus can take a long time to become ready, depending on the WAL size.

--- a/config/monitoring/karma/Chart.yaml
+++ b/config/monitoring/karma/Chart.yaml
@@ -1,0 +1,17 @@
+apiVersion: v1
+name: karma
+version: 0.0.1
+appVersion: v0.43
+description: Dashboard for Prometheus Alertmanager
+keywords:
+- kubermatic
+- monitoring
+- prometheus
+- alertmanager
+- dashboard
+home: https://github.com/prymitive/karma
+sources:
+- https://github.com/kubermatic/kubermatic
+maintainers:
+- name: Loodse GmbH
+  email: support@loodse.com

--- a/config/monitoring/karma/templates/_helpers.tpl
+++ b/config/monitoring/karma/templates/_helpers.tpl
@@ -1,0 +1,3 @@
+{{- define "name" -}}
+{{- default .Release.Name .Values.karma.nameOverride -}}
+{{- end }}

--- a/config/monitoring/karma/templates/configmap.yaml
+++ b/config/monitoring/karma/templates/configmap.yaml
@@ -9,21 +9,4 @@ metadata:
     app.kubernetes.io/managed-by: helm
 data:
   karma.yaml: |
-    log:
-      config: false
-      level: warning
-      format: json
-
-    filters:
-      default:
-      # only show active alerts
-      - "@state=active"
-
-    receivers:
-      strip:
-      # prevent alerts from showing up multiple times
-      - '@critical-alerts'
-
-    alertmanager:
-      interval: 60s
-      servers:
+{{ .Values.karma.config | indent 4 }}

--- a/config/monitoring/karma/templates/configmap.yaml
+++ b/config/monitoring/karma/templates/configmap.yaml
@@ -1,0 +1,29 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: '{{ template "name" . }}-config'
+  labels:
+    app.kubernetes.io/name: karma
+    app.kubernetes.io/instance: '{{ .Release.Name }}'
+    app.kubernetes.io/version: '{{ .Chart.Version }}'
+    app.kubernetes.io/managed-by: helm
+data:
+  karma.yaml: |
+    log:
+      config: false
+      level: warning
+      format: json
+
+    filters:
+      default:
+      # only show active alerts
+      - "@state=active"
+
+    receivers:
+      strip:
+      # prevent alerts from showing up multiple times
+      - '@critical-alerts'
+
+    alertmanager:
+      interval: 60s
+      servers:

--- a/config/monitoring/karma/templates/deployment.yaml
+++ b/config/monitoring/karma/templates/deployment.yaml
@@ -1,0 +1,67 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: '{{ template "name" . }}'
+  labels:
+    app.kubernetes.io/name: karma
+    app.kubernetes.io/instance: '{{ .Release.Name }}'
+    app.kubernetes.io/version: '{{ .Chart.Version }}'
+    app.kubernetes.io/managed-by: helm
+spec:
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: karma
+      app.kubernetes.io/instance: '{{ .Release.Name }}'
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: karma
+        app.kubernetes.io/instance: '{{ .Release.Name }}'
+      annotations:
+        fluentbit.io/parser: json_iso
+        checksum/config: {{ include (print $.Template.BasePath "/configmap.yaml") $ | sha1sum }}
+    spec:
+      serviceAccountName: '{{ template "name" .}}'
+      initContainers:
+      - name: init-seeds
+        image: '{{ .Values.karma.images.initContainer.repository }}:{{ .Values.karma.images.initContainer.tag }}'
+        imagePullPolicy: {{ .Values.karma.images.initContainer.pullPolicy }}
+        command:
+        - /bin/sh
+        - -c
+        - |
+          set -euo pipefail
+
+          ns={{ .Values.karma.kubermaticNamespace }}
+          out=/etc/karma-shared/karma.yaml
+
+          cp /etc/karma/karma.yaml $out
+
+          kubectl -n "$ns" get services -l 'app.kubernetes.io/name=seed-proxy' -o "custom-columns=name:{.metadata.labels['app\.kubernetes\.io/instance']}" --no-headers | while read seed; do
+            echo "  - name: $seed" >> $out
+            echo "    uri: http://seed-proxy-$seed.$ns.svc.cluster.local:8001/api/v1/namespaces/monitoring/services/alertmanager:web/proxy/" >> $out
+            echo "    proxy: true" >> $out
+          done
+        volumeMounts:
+        - name: config
+          mountPath: /etc/karma
+        - name: shared-config
+          mountPath: /etc/karma-shared
+      containers:
+      - name: karma
+        image: '{{ .Values.karma.images.karma.repository }}:{{ .Values.karma.images.karma.tag }}'
+        imagePullPolicy: {{ .Values.karma.images.karma.pullPolicy }}
+        args:
+        - --config.file=/etc/karma/karma.yaml
+        ports:
+        - containerPort: 8080
+          name: web
+        volumeMounts:
+        - name: shared-config
+          mountPath: /etc/karma
+      volumes:
+      - name: config
+        configMap:
+          name: '{{ template "name" . }}-config'
+      - name: shared-config
+        emptyDir: {}

--- a/config/monitoring/karma/templates/deployment.yaml
+++ b/config/monitoring/karma/templates/deployment.yaml
@@ -65,3 +65,9 @@ spec:
           name: '{{ template "name" . }}-config'
       - name: shared-config
         emptyDir: {}
+      nodeSelector:
+{{ toYaml .Values.karma.nodeSelector | indent 8 }}
+      affinity:
+{{ (tpl (toYaml .Values.karma.affinity) .) | fromYaml | toYaml | indent 8 }}
+      tolerations:
+{{ toYaml .Values.karma.tolerations | indent 8 }}

--- a/config/monitoring/karma/templates/role.yaml
+++ b/config/monitoring/karma/templates/role.yaml
@@ -1,0 +1,19 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: '{{ template "name" . }}-seed-reader'
+  namespace: '{{ .Values.karma.kubermaticNamespace }}'
+  labels:
+    app.kubernetes.io/name: karma
+    app.kubernetes.io/instance: '{{ .Release.Name }}'
+    app.kubernetes.io/version: '{{ .Chart.Version }}'
+    app.kubernetes.io/managed-by: helm
+rules:
+- apiGroups:
+  - ""
+  resources:
+  - services
+  verbs:
+  - get
+  - list
+  - watch

--- a/config/monitoring/karma/templates/rolebinding.yaml
+++ b/config/monitoring/karma/templates/rolebinding.yaml
@@ -1,0 +1,18 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: '{{ template "name" . }}-seed-reader'
+  namespace: '{{ .Values.karma.kubermaticNamespace }}'
+  labels:
+    app.kubernetes.io/name: karma
+    app.kubernetes.io/instance: '{{ .Release.Name }}'
+    app.kubernetes.io/version: '{{ .Chart.Version }}'
+    app.kubernetes.io/managed-by: helm
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: '{{ template "name" . }}-seed-reader'
+subjects:
+- kind: ServiceAccount
+  name: '{{ template "name" . }}'
+  namespace: '{{ .Release.Namespace }}'

--- a/config/monitoring/karma/templates/service.yaml
+++ b/config/monitoring/karma/templates/service.yaml
@@ -1,0 +1,17 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: '{{ template "name" . }}'
+  labels:
+    app.kubernetes.io/name: karma
+    app.kubernetes.io/instance: '{{ .Release.Name }}'
+    app.kubernetes.io/version: '{{ .Chart.Version }}'
+    app.kubernetes.io/managed-by: helm
+spec:
+  ports:
+  - name: web
+    port: 8080
+    targetPort: web
+  selector:
+    app.kubernetes.io/name: karma
+    app.kubernetes.io/instance: '{{ .Release.Name }}'

--- a/config/monitoring/karma/templates/serviceaccount.yaml
+++ b/config/monitoring/karma/templates/serviceaccount.yaml
@@ -1,0 +1,9 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: '{{ template "name" . }}'
+  labels:
+    app.kubernetes.io/name: karma
+    app.kubernetes.io/instance: '{{ .Release.Name }}'
+    app.kubernetes.io/version: '{{ .Chart.Version }}'
+    app.kubernetes.io/managed-by: helm

--- a/config/monitoring/karma/values.yaml
+++ b/config/monitoring/karma/values.yaml
@@ -1,0 +1,30 @@
+karma:
+  kubermaticNamespace: kubermatic
+  images:
+    karma:
+      repository: docker.io/lmierzwa/karma
+      tag: v0.43
+      pullPolicy: IfNotPresent
+    initContainer:
+      repository: quay.io/kubermatic/util
+      tag: 1.1.2
+      pullPolicy: IfNotPresent
+  resources:
+    karma:
+      requests:
+        cpu: 50m
+        memory: 32Mi
+      limits:
+        cpu: 200m
+        memory: 48Mi
+  nodeSelector: {}
+  affinity:
+    podAntiAffinity:
+      preferredDuringSchedulingIgnoredDuringExecution:
+      - podAffinityTerm:
+          labelSelector:
+            matchLabels:
+              app: '{{ template "name" . }}'
+          topologyKey: kubernetes.io/hostname
+        weight: 100
+  tolerations: []

--- a/config/monitoring/karma/values.yaml
+++ b/config/monitoring/karma/values.yaml
@@ -1,5 +1,25 @@
 karma:
   kubermaticNamespace: kubermatic
+  config: |
+    log:
+      config: false
+      level: warning
+      format: json
+
+    filters:
+      default:
+      # only show active alerts
+      - "@state=active"
+
+    receivers:
+      strip:
+      # prevent alerts from showing up multiple times
+      - '@critical-alerts'
+
+    alertmanager:
+      interval: 60s
+      servers:
+
   images:
     karma:
       repository: docker.io/lmierzwa/karma


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR adds a Helm Chart for https://github.com/prymitive/karma to our monitoring stack. It's meant to be deployed into master clusters and then aggregate all the alerts from the various seeds by simply using the seed-proxy pods.

This solves not only the visibility issue, but it can also be used to *silence* alerts inside the seeds. And since it's only a dashboard it's not a single point of failure (if the dashboard dies, the Alertmanagers will continue to work).

The very simple init container approach will not handle seeds being added or deleted, so admins will have to restart the Karma pod when they modify seeds. For now this is IMHO acceptable until we have more experience with this and can build something more sophisticated.

**Does this PR introduce a user-facing change?**:
```release-note
NONE
```
