### PR TITLE
Add leader election to master controller manager

### DIFF
--- a/api/cmd/kubermatic-api/main.go
+++ b/api/cmd/kubermatic-api/main.go
@@ -130,7 +130,7 @@ func createInitProviders(options serverRunOptions) (providers, error) {
 
 	// We use the manager only to get a lister-backed ctrlruntimeclient.Client. We can not use it for most
 	// other actions, because it doesn't support impersonation (and cant be changed to do that as that would mean it has to replicate the apiservers RBAC for the lister)
-	mgr, err := manager.New(masterCfg, manager.Options{MetricsBindAddress: "0", LeaderElection: false})
+	mgr, err := manager.New(masterCfg, manager.Options{MetricsBindAddress: "0"})
 	if err != nil {
 		return providers{}, fmt.Errorf("failed to construct manager: %v", err)
 	}

--- a/api/cmd/master-controller-manager/main.go
+++ b/api/cmd/master-controller-manager/main.go
@@ -180,12 +180,12 @@ func main() {
 				electionName += "-" + runOpts.workerName
 			}
 
-			return leaderelection.RunAsLeader(leaderCtx, log, cfg, mgr.GetRecorder(controllerName), electionName, func(ctx context.Context) {
+			return leaderelection.RunAsLeader(leaderCtx, log, cfg, mgr.GetRecorder(controllerName), electionName, func(ctx context.Context) error {
 				log.Info("starting the master-controller-manager...")
 				if err := mgr.Start(ctx.Done()); err != nil {
-					log.Errorw("the controller-manager stopped with an error", zap.Error(err))
-					stopLeaderElection()
+					return fmt.Errorf("the controller-manager stopped with an error: %v", err)
 				}
+				return nil
 			})
 		}, func(err error) {
 			stopLeaderElection()

--- a/api/cmd/owner-remover/main.go
+++ b/api/cmd/owner-remover/main.go
@@ -2,14 +2,14 @@ package main
 
 import (
 	"flag"
-
 	"fmt"
+	"io/ioutil"
 	"os/exec"
 
-	"io/ioutil"
-
 	"github.com/golang/glog"
+
 	kubermaticclientset "github.com/kubermatic/kubermatic/api/pkg/crd/client/clientset/versioned"
+
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/tools/clientcmd"

--- a/api/pkg/leaderelection/leaderelection.go
+++ b/api/pkg/leaderelection/leaderelection.go
@@ -67,7 +67,7 @@ func RunAsLeader(ctx context.Context, log *zap.SugaredLogger, cfg *rest.Config, 
 		OnStartedLeading: func(ctx context.Context) {
 			log.Info("acquired the leader lease")
 			if err := callback(ctx); err != nil {
-				log.Error(zap.Error(err))
+				log.Error(err)
 				cancel()
 			}
 		},

--- a/api/pkg/leaderelection/leaderelection.go
+++ b/api/pkg/leaderelection/leaderelection.go
@@ -1,13 +1,18 @@
 package leaderelection
 
 import (
+	"context"
 	"fmt"
 	"os"
 	"time"
 
+	"go.uber.org/zap"
+
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/kubernetes"
+	"k8s.io/client-go/rest"
 	"k8s.io/client-go/tools/leaderelection"
+	kubeleaderelection "k8s.io/client-go/tools/leaderelection"
 	"k8s.io/client-go/tools/leaderelection/resourcelock"
 	"k8s.io/client-go/tools/record"
 )
@@ -47,4 +52,34 @@ func New(name string, leaderElectionClient kubernetes.Interface, recorder record
 		RetryPeriod:   retryPeriod,
 		Callbacks:     callbacks,
 	})
+}
+
+func RunAsLeader(ctx context.Context, log *zap.SugaredLogger, cfg *rest.Config, recorder record.EventRecorder, leaderName string, callback func(context.Context)) error {
+	leaderElectionClient, err := kubernetes.NewForConfig(rest.AddUserAgent(cfg, leaderName))
+	if err != nil {
+		return err
+	}
+
+	leaderElectionCtx, cancel := context.WithCancel(ctx)
+	defer cancel()
+
+	callbacks := kubeleaderelection.LeaderCallbacks{
+		OnStartedLeading: func(ctx context.Context) {
+			log.Info("acquired the leader lease")
+			callback(ctx)
+		},
+		OnStoppedLeading: func() {
+			// Gets called when we could not renew the lease or the parent context was closed
+			log.Info("lost leader lease")
+			cancel()
+		},
+	}
+
+	elector, err := New(leaderName, leaderElectionClient, recorder, callbacks)
+	if err != nil {
+		return fmt.Errorf("failed to create a leaderelection: %v", err)
+	}
+
+	elector.Run(leaderElectionCtx)
+	return nil
 }


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR adds leader election to the master controller manager, because the regular controller manager does the same. It also renames `sugarLog` to our more common `log` variable and removes one seemingly pointless variable (`done := ctx.Done()`).

**Does this PR introduce a user-facing change?**:
```release-note
master-controller-manager can now be deployed with multiple replicas
```
