### PR TITLE
chart-sync: fix listing getting latest release tag

### DIFF
--- a/api/hack/lib.sh
+++ b/api/hack/lib.sh
@@ -69,7 +69,7 @@ get_latest_dashboard_tag() {
   local DASHBOARD_URL="git@github.com:kubermatic/dashboard-v2.git"
 
   MINOR_VERSION="${FOR_BRANCH##release/}"
-  FOUND_TAG="$(retry 5 git ls-remote "$DASHBOARD_URL" "refs/tags/$MINOR_VERSION*" --sort=-authordate --count=1 | awk '{print $2}')"
+  FOUND_TAG="$(retry 5 git ls-remote --sort=-version:refname "$DASHBOARD_URL" "refs/tags/$MINOR_VERSION*" --count=1 | awk '{print $2}')"
   if [ -z "$FOUND_TAG" ]; then
     echo "Error, no Dashboard tags contain $MINOR_VERSION" >/dev/stderr
     exit 1

--- a/api/hack/lib.sh
+++ b/api/hack/lib.sh
@@ -69,7 +69,7 @@ get_latest_dashboard_tag() {
   local DASHBOARD_URL="git@github.com:kubermatic/dashboard-v2.git"
 
   MINOR_VERSION="${FOR_BRANCH##release/}"
-  FOUND_TAG="$(retry 5 git ls-remote --sort=-version:refname "$DASHBOARD_URL" "refs/tags/$MINOR_VERSION*" --count=1 | awk '{print $2}')"
+  FOUND_TAG="$(retry 5 git ls-remote --sort=-version:refname "$DASHBOARD_URL" "refs/tags/$MINOR_VERSION*" | head -n1 | awk '{print $2}')"
   if [ -z "$FOUND_TAG" ]; then
     echo "Error, no Dashboard tags contain $MINOR_VERSION" >/dev/stderr
     exit 1


### PR DESCRIPTION
**What this PR does / why we need it**:
We've agreed to use `ls-remote` instead of `for-each-ref` to avoid cloning a whole repo, however it turns out that the former does not work like the latter.

We cannot sort by `authordate`, since it is contained within the object and `ls-remote` cannot know it.
The `--count` parameter is unsupported entirely.

This PR switches to even better sorting, by `version:refname` which is refname parsed as semver. It also switches to using `head` command instead of the unsupported `--count` parameter.

```release-note
NONE
```
