### PR TITLE
run dashboard as a non-root user

### DIFF
--- a/config/kubermatic/templates/kubermatic-ui-dep.yaml
+++ b/config/kubermatic/templates/kubermatic-ui-dep.yaml
@@ -31,6 +31,9 @@ spec:
           readOnly: true
         resources:
 {{ toYaml .Values.kubermatic.ui.resources | indent 10 }}
+      securityContext:
+        runAsNonRoot: true
+        runAsUser: 65534
       imagePullSecrets:
       - name: dockercfg
       volumes:


### PR DESCRIPTION
**What this PR does / why we need it**:
Fixes kubermatic/dashboard-v2#1579

```release-note
NONE
```

/assign @floreks 
