### PR TITLE
Fix emitting multiple identical keys in log messages

### DIFF
--- a/api/cmd/conformance-tests/cleanup.go
+++ b/api/cmd/conformance-tests/cleanup.go
@@ -34,7 +34,10 @@ func deleteAllNonDefaultNamespaces(log *zap.SugaredLogger, client ctrlruntimecli
 			if protectedNamespaces.Has(namespace.Name) {
 				continue
 			}
-			log = log.With("namespace-to-delete", namespace.Name)
+
+			// make sure to create a new variable, or else subsequent With() calls will
+			// *add* new attributes instead of overriding the existing namespace-to-delete value
+			log := log.With("namespace-to-delete", namespace.Name)
 
 			// If its not gone & the DeletionTimestamp is nil, delete it
 			if namespace.DeletionTimestamp == nil {


### PR DESCRIPTION
**What this PR does / why we need it**:
Elasticsearch has an issue with log lines that contain the same key multiple times. It also doesn't make sense to have these, so this PR fixes the one occurence I randomly observed when scanning the fluentbit logs.

**Does this PR introduce a user-facing change?**:
```release-note
NONE
```
