### PR TITLE
Openshift: Wait with operator deployments until corresponding CRD exists

### DIFF
--- a/api/cmd/http-prober/Dockerfile
+++ b/api/cmd/http-prober/Dockerfile
@@ -1,4 +1,4 @@
-FROM alpine:3.9
-LABEL maintainer "henrik@loodse.com"
+FROM alpine:3.10
+LABEL maintainer "dev@loodse.com"
 
 COPY ./http-prober /usr/local/bin/

--- a/api/cmd/http-prober/main.go
+++ b/api/cmd/http-prober/main.go
@@ -1,10 +1,12 @@
 package main
 
 import (
+	"context"
 	"crypto/tls"
 	"encoding/json"
+	"errors"
 	"flag"
-	"log"
+	"fmt"
 	"net/http"
 	"net/http/httptrace"
 	"net/url"
@@ -13,35 +15,50 @@ import (
 	"syscall"
 	"time"
 
-	httpproberapi "github.com/kubermatic/kubermatic/api/cmd/http-prober/api"
-)
+	"go.uber.org/zap"
 
-const (
-	padding = "    "
+	httpproberapi "github.com/kubermatic/kubermatic/api/cmd/http-prober/api"
+	kubermaticlog "github.com/kubermatic/kubermatic/api/pkg/log"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/client-go/tools/clientcmd"
+	ctrlruntimeclient "sigs.k8s.io/controller-runtime/pkg/client"
 )
 
 func main() {
 	var (
-		endpoint   string
-		insecure   bool
-		retries    int
-		retryWait  int
-		timeout    int
-		commandRaw string
+		endpoint      string
+		insecure      bool
+		retries       int
+		retryWait     int
+		timeout       int
+		crdKind       string
+		crdAPIVersion string
+		commandRaw    string
 	)
 	flag.StringVar(&endpoint, "endpoint", "", "The endpoint which should be waited for")
 	flag.BoolVar(&insecure, "insecure", false, "Disable certificate validation")
 	flag.IntVar(&retries, "retries", 10, "Number of retries")
 	flag.IntVar(&retryWait, "retry-wait", 1, "Wait interval in seconds between retries")
 	flag.IntVar(&timeout, "timeout", 30, "Timeout in seconds")
+	flag.StringVar(&crdKind, "wait-for-crd-kind", "", "If set, wait for this CRD to be present. Requires the KUBECONFIG env var to be set.")
+	flag.StringVar(&crdAPIVersion, "wait-for-crd-apiversion", "", "If set, wait for this CRD to be present. Requires the KUBECONFIG env var to be set.")
 	flag.StringVar(&commandRaw, "command", "", "If passed, the http prober will exec this command. Must be json encoded")
 	flag.Parse()
+
+	log := kubermaticlog.Logger.Named("http-prober")
+
+	crdChecker, err := crdCheckerFactory(crdKind, crdAPIVersion)
+	if err != nil {
+		log.Fatal(err.Error())
+	}
 
 	var command *httpproberapi.Command
 	if commandRaw != "" {
 		command = &httpproberapi.Command{}
 		if err := json.Unmarshal([]byte(commandRaw), command); err != nil {
-			log.Fatalf("failed to deserialize command: %v", err)
+			log.Fatalw("Failed to deserialize command", zap.Error(err))
 		}
 	}
 
@@ -57,17 +74,17 @@ func main() {
 
 	e, err := url.Parse(endpoint)
 	if err != nil {
-		log.Fatalf("invalid endpoint specified: %v", err)
+		log.Fatalw("Invalid endpoint specified", zap.Error(err))
 	}
 
 	req, err := http.NewRequest("GET", e.String(), nil)
 	if err != nil {
-		log.Fatalf("failed to build request: %v\n", err)
+		log.Fatalw("Failed to build request", zap.Error(err))
 	}
 
 	trace := &httptrace.ClientTrace{
 		GotConn: func(connInfo httptrace.GotConnInfo) {
-			log.Printf("%s resolved to: %s", e.Hostname(), connInfo.Conn.RemoteAddr())
+			log.Infow("Hostname resolved", "hostname", e.Hostname(), "address", connInfo.Conn.RemoteAddr())
 		},
 	}
 
@@ -76,23 +93,31 @@ func main() {
 	for i := 1; i <= retries; i++ {
 		if i > 1 {
 			time.Sleep(time.Duration(retryWait) * time.Second)
-			log.Println()
 		}
 
-		log.Printf("[%02d/%02d] Probing '%s'...\n", i, retries, req.URL.String())
+		log.Infow("Probing", "attempt", i, "max-attempts", retries, "target", req.URL.String())
 		resp, err := client.Do(req)
 		if err != nil {
-			log.Printf(padding+"Failed executing request: %v", err)
+			log.Infow("Request failed", zap.Error(err))
 			continue
 		}
 		resp.Body.Close()
 
 		if resp.StatusCode < 200 || resp.StatusCode > 299 {
-			log.Printf(padding+"Failed: '%s' responded with statuscode != 2xx (%d)", req.URL.String(), resp.StatusCode)
+			log.Infow("Response did not have a 2xx status code", "statuscode", resp.StatusCode)
 			continue
 		}
 
-		log.Println("Endpoint is available!")
+		log.Info("Endpoint is available")
+
+		if err := crdChecker(); err != nil {
+			log.Infow("Check if crd is available was not successful", "crd", crdKind, zap.Error(err))
+			continue
+		}
+		if crdKind != "" {
+			log.Infow("CRD is available", "crd", crdKind)
+		}
+
 		if command != nil {
 			commandFullPath, err := exec.LookPath(command.Command)
 			if err != nil {
@@ -108,5 +133,49 @@ func main() {
 		os.Exit(0)
 	}
 
-	log.Fatalf("Failed: Reached retry limit!\n")
+	log.Fatal("Failed: Reached retry limit!")
+}
+
+func crdCheckerFactory(crdKind, crdAPIVersion string) (func() error, error) {
+	if crdKind == "" && crdAPIVersion == "" {
+		return func() error {
+			return nil
+		}, nil
+	}
+	if crdKind == "" {
+		return nil, errors.New("--wait-for-crd-kind must bet set if --wait-for-crd-apiversion is set")
+	}
+	if crdAPIVersion == "" {
+		return nil, errors.New("--wait-for-crd-apiversion must be set if --wait-for-crd-kind is set")
+	}
+
+	kubeconfig := os.Getenv("KUBECONFIG")
+	if kubeconfig == "" {
+		return nil, errors.New("--wait-for-crd was set, but KUBECONFIG env var was not")
+	}
+	cfg, err := clientcmd.BuildConfigFromFlags("", kubeconfig)
+	if err != nil {
+		return nil, fmt.Errorf("failed to create kubeconfig: %v", err)
+	}
+
+	list := &unstructured.UnstructuredList{}
+	list.SetKind(crdKind)
+	list.SetAPIVersion(crdAPIVersion)
+
+	listOpts := &ctrlruntimeclient.ListOptions{Raw: &metav1.ListOptions{Limit: 1}}
+
+	return func() error {
+		// Client creation does discovery calls, so do not attempt to do it initially
+		// when the API may not be up yet.
+		client, err := ctrlruntimeclient.New(cfg, ctrlruntimeclient.Options{})
+		if err != nil {
+			return fmt.Errorf("failed to create kube client: %v", err)
+		}
+
+		if err := client.List(context.Background(), listOpts, list); err != nil {
+			return fmt.Errorf("failed to list %q: %v", crdKind, err)
+		}
+
+		return nil
+	}, nil
 }

--- a/api/cmd/http-prober/release.sh
+++ b/api/cmd/http-prober/release.sh
@@ -1,10 +1,10 @@
 #!/usr/bin/env bash
 
-ver=v0.2
+ver=v0.3-dev3
 
 set -euox pipefail
 
-CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go build -a -installsuffix cgo -ldflags="-w -s" github.com/kubermatic/kubermatic/api/cmd/http-prober
+CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go build -v -ldflags="-w -s" github.com/kubermatic/kubermatic/api/cmd/http-prober
 
 docker build --no-cache --pull -t quay.io/kubermatic/http-prober:$ver .
 docker push quay.io/kubermatic/http-prober:$ver

--- a/api/cmd/http-prober/release.sh
+++ b/api/cmd/http-prober/release.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 
-ver=v0.3-dev3
+ver=v0.3
 
 set -euox pipefail
 

--- a/api/pkg/controller/openshift/resources/console.go
+++ b/api/pkg/controller/openshift/resources/console.go
@@ -88,6 +88,10 @@ func ConsoleDeployment(data openshiftData) reconciling.NamedDeploymentCreatorGet
 						Name:  "KUBERNETES_SERVICE_PORT",
 						Value: strconv.Itoa(int(data.Cluster().Address.Port)),
 					},
+					{
+						Name:  "KUBECONFIG",
+						Value: "/etc/kubernetes/kubeconfig/kubeconfig",
+					},
 				},
 				VolumeMounts: []corev1.VolumeMount{
 					{
@@ -111,6 +115,11 @@ func ConsoleDeployment(data openshiftData) reconciling.NamedDeploymentCreatorGet
 						Name:      resources.AdminKubeconfigSecretName,
 						MountPath: "/var/run/secrets/kubernetes.io/serviceaccount/token",
 						SubPath:   "token",
+					},
+					// Used by the http prober
+					{
+						Name:      resources.AdminKubeconfigSecretName,
+						MountPath: "/etc/kubernetes/kubeconfig",
 					},
 				},
 			}}
@@ -157,7 +166,7 @@ func ConsoleDeployment(data openshiftData) reconciling.NamedDeploymentCreatorGet
 			}
 			d.Spec.Template.Labels = podLabels
 
-			wrappedPodSpec, err := apiserver.IsRunningWrapper(data, d.Spec.Template.Spec, sets.NewString("console"))
+			wrappedPodSpec, err := apiserver.IsRunningWrapper(data, d.Spec.Template.Spec, sets.NewString("console"), "OAuthClient", "oauth.openshift.io/v1")
 			if err != nil {
 				return nil, fmt.Errorf("failed to add apiserver.IsRunningWrapper: %v", err)
 			}

--- a/api/pkg/controller/openshift/resources/dns_operator.go
+++ b/api/pkg/controller/openshift/resources/dns_operator.go
@@ -65,9 +65,12 @@ func OpenshiftDNSOperatorFactory(data openshiftData) reconciling.NamedDeployment
 			}
 
 			d.Spec.Template.Spec.Containers = []corev1.Container{{
-				Name:    openshiftDNSOperatorContainerName,
-				Image:   image,
-				Env:     env,
+				Name:  openshiftDNSOperatorContainerName,
+				Image: image,
+				Env: append(env, corev1.EnvVar{
+					Name:  "KUBECONFIG",
+					Value: "/etc/kubernetes/kubeconfig/kubeconfig",
+				}),
 				Command: []string{"dns-operator"},
 				VolumeMounts: []corev1.VolumeMount{{
 					Name:      resources.InternalUserClusterAdminKubeconfigSecretName,
@@ -92,7 +95,7 @@ func OpenshiftDNSOperatorFactory(data openshiftData) reconciling.NamedDeployment
 				return nil, err
 			}
 
-			wrappedPodSpec, err := apiserver.IsRunningWrapper(data, d.Spec.Template.Spec, sets.NewString(openshiftDNSOperatorContainerName))
+			wrappedPodSpec, err := apiserver.IsRunningWrapper(data, d.Spec.Template.Spec, sets.NewString(openshiftDNSOperatorContainerName), "DNS", "operator.openshift.io/v1")
 			if err != nil {
 				return nil, fmt.Errorf("failed to add apiserver.IsRunningWrapper: %v", err)
 			}

--- a/api/pkg/controller/openshift/resources/kube_controller_manager.go
+++ b/api/pkg/controller/openshift/resources/kube_controller_manager.go
@@ -259,7 +259,7 @@ func KubeControllerManagerDeploymentCreatorFactory(data kubeControllerManagerDat
 					return nil, err
 				}
 				dep.Spec.Template.Labels = podLabels
-				wrappedPodSpec, err := apiserver.IsRunningWrapper(data, dep.Spec.Template.Spec, sets.NewString(kubeControllerManagerContainerName))
+				wrappedPodSpec, err := apiserver.IsRunningWrapper(data, dep.Spec.Template.Spec, sets.NewString(kubeControllerManagerContainerName), "", "")
 				if err != nil {
 					return nil, fmt.Errorf("failed to add apiserver.IsRunningWrapper: %v", err)
 				}

--- a/api/pkg/controller/openshift/resources/kube_scheduler.go
+++ b/api/pkg/controller/openshift/resources/kube_scheduler.go
@@ -197,7 +197,7 @@ func KubeSchedulerDeploymentCreator(data openshiftData) reconciling.NamedDeploym
 
 			dep.Spec.Template.Spec.Affinity = resources.HostnameAntiAffinity(name, data.Cluster().Name)
 
-			wrappedPodSpec, err := apiserver.IsRunningWrapper(data, dep.Spec.Template.Spec, sets.NewString(name))
+			wrappedPodSpec, err := apiserver.IsRunningWrapper(data, dep.Spec.Template.Spec, sets.NewString(name), "", "")
 			if err != nil {
 				return nil, fmt.Errorf("failed to add apiserver.IsRunningWrapper: %v", err)
 			}

--- a/api/pkg/controller/openshift/resources/machinecontroller.go
+++ b/api/pkg/controller/openshift/resources/machinecontroller.go
@@ -55,7 +55,7 @@ func MachineController(osData openshiftData) reconciling.NamedDeploymentCreatorG
 					corev1.EnvVar{Name: openshiftuserdata.DockerCFGEnvKey, Value: osData.Cluster().Spec.Openshift.ImagePullSecret})
 			}
 
-			wrappedPodSpec, err := apiserver.IsRunningWrapper(osData, d.Spec.Template.Spec, sets.NewString(name))
+			wrappedPodSpec, err := apiserver.IsRunningWrapper(osData, d.Spec.Template.Spec, sets.NewString(name), "Machine", "cluster.k8s.io/v1alpha1")
 			if err != nil {
 				return nil, fmt.Errorf("failed to add apiserver.IsRunningWrapper: %v", err)
 			}

--- a/api/pkg/controller/openshift/resources/oauth.go
+++ b/api/pkg/controller/openshift/resources/oauth.go
@@ -366,6 +366,10 @@ func OauthDeploymentCreator(data openshiftData) reconciling.NamedDeploymentCreat
 					"--config=/etc/oauth/config.yaml",
 					"--v=2",
 				},
+				Env: []corev1.EnvVar{{
+					Name:  "KUBECONFIG",
+					Value: "/etc/kubernetes/kubeconfig/kubeconfig",
+				}},
 				VolumeMounts: []corev1.VolumeMount{
 					{
 						Name:      "config",
@@ -426,7 +430,7 @@ func OauthDeploymentCreator(data openshiftData) reconciling.NamedDeploymentCreat
 			}
 			dep.Spec.Template.Labels = podLabels
 
-			wrappedPodSpec, err := apiserver.IsRunningWrapper(data, dep.Spec.Template.Spec, sets.NewString(OauthName))
+			wrappedPodSpec, err := apiserver.IsRunningWrapper(data, dep.Spec.Template.Spec, sets.NewString(OauthName), "OAuthClient", "oauth.openshift.io/v1")
 			if err != nil {
 				return nil, fmt.Errorf("failed to add apiserver.IsRunningWrapper: %v", err)
 			}

--- a/api/pkg/controller/openshift/resources/openshift_apiserver_deployment.go
+++ b/api/pkg/controller/openshift/resources/openshift_apiserver_deployment.go
@@ -5,8 +5,7 @@ import (
 	"fmt"
 
 	"github.com/kubermatic/kubermatic/api/pkg/resources"
-	"github.com/kubermatic/kubermatic/api/pkg/resources/etcd"
-	"github.com/kubermatic/kubermatic/api/pkg/resources/etcd/etcdrunning"
+	"github.com/kubermatic/kubermatic/api/pkg/resources/apiserver"
 	"github.com/kubermatic/kubermatic/api/pkg/resources/reconciling"
 	"github.com/kubermatic/kubermatic/api/pkg/resources/vpnsidecar"
 
@@ -15,6 +14,7 @@ import (
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/intstr"
+	"k8s.io/apimachinery/pkg/util/sets"
 	utilpointer "k8s.io/utils/pointer"
 )
 
@@ -163,11 +163,6 @@ func OpenshiftAPIServerDeploymentCreator(ctx context.Context, data openshiftData
 				return nil, err
 			}
 
-			etcdEndpoints := etcd.GetClientEndpoints(data.Cluster().Status.NamespaceName)
-			dep.Spec.Template.Spec.InitContainers = []corev1.Container{
-				etcdrunning.Container(etcdEndpoints, data),
-			}
-
 			openvpnSidecar, err := vpnsidecar.OpenVPNSidecarContainer(data, "openvpn-client")
 			if err != nil {
 				return nil, fmt.Errorf("failed to get openvpn-client sidecar: %v", err)
@@ -271,6 +266,13 @@ func OpenshiftAPIServerDeploymentCreator(ctx context.Context, data openshiftData
 				return nil, err
 			}
 			dep.Spec.Template.Labels = podLabels
+
+			// The openshift apiserver needs the normal apiserver
+			wrappedPodSpec, err := apiserver.IsRunningWrapper(data, dep.Spec.Template.Spec, sets.NewString(OpenshiftAPIServerDeploymentName), "", "")
+			if err != nil {
+				return nil, fmt.Errorf("failed to add apiserver.IsRunningWrapper: %v", err)
+			}
+			dep.Spec.Template.Spec = *wrappedPodSpec
 
 			return dep, nil
 		}

--- a/api/pkg/controller/openshift/resources/openshift_controller_manager.go
+++ b/api/pkg/controller/openshift/resources/openshift_controller_manager.go
@@ -163,6 +163,10 @@ func OpenshiftControllerManagerDeploymentCreator(ctx context.Context, data opens
 					Command:   []string{"hypershift", "openshift-controller-manager"},
 					Args:      []string{"--config=/etc/origin/master/config.yaml", "-v=2"},
 					Resources: resourceRequirements,
+					Env: []corev1.EnvVar{{
+						Name:  "KUBECONFIG",
+						Value: "/etc/kubernetes/kubeconfig/kubeconfig",
+					}},
 					VolumeMounts: []corev1.VolumeMount{
 						{
 							Name:      resources.InternalUserClusterAdminKubeconfigSecretName,
@@ -190,7 +194,7 @@ func OpenshiftControllerManagerDeploymentCreator(ctx context.Context, data opens
 
 			dep.Spec.Template.Spec.Affinity = resources.HostnameAntiAffinity(OpenshiftControllerManagerDeploymentName, data.Cluster().Name)
 
-			wrappedPodSpec, err := apiserver.IsRunningWrapper(data, dep.Spec.Template.Spec, sets.NewString(OpenshiftControllerManagerDeploymentName))
+			wrappedPodSpec, err := apiserver.IsRunningWrapper(data, dep.Spec.Template.Spec, sets.NewString(OpenshiftControllerManagerDeploymentName), "OAuthClient", "oauth.openshift.io/v1")
 			if err != nil {
 				return nil, fmt.Errorf("failed to add apiserver.IsRunningWrapper: %v", err)
 			}

--- a/api/pkg/controller/openshift/resources/openshift_network_operator.go
+++ b/api/pkg/controller/openshift/resources/openshift_network_operator.go
@@ -68,7 +68,10 @@ func OpenshiftNetworkOperatorCreatorFactory(data openshiftData) reconciling.Name
 			d.Spec.Template.Spec.Containers = []corev1.Container{{
 				Name:  "network-operator",
 				Image: image,
-				Env:   env,
+				Env: append(env, corev1.EnvVar{
+					Name:  "KUBECONFIG",
+					Value: "/etc/kubernetes/kubeconfig/kubeconfig",
+				}),
 				Command: []string{
 					"/usr/bin/cluster-network-operator",
 					"--kubeconfig=/etc/kubernetes/kubeconfig/kubeconfig",
@@ -95,7 +98,7 @@ func OpenshiftNetworkOperatorCreatorFactory(data openshiftData) reconciling.Name
 				return nil, err
 			}
 
-			wrappedPodSpec, err := apiserver.IsRunningWrapper(data, d.Spec.Template.Spec, sets.NewString("network-operator"))
+			wrappedPodSpec, err := apiserver.IsRunningWrapper(data, d.Spec.Template.Spec, sets.NewString("network-operator"), "Network", "operator.openshift.io/v1")
 			if err != nil {
 				return nil, fmt.Errorf("failed to add apiserver.IsRunningWrapper: %v", err)
 			}

--- a/api/pkg/controller/openshift/testdata/Kubermatic_API_image_is_overwritten-usercluster-controller.golden.yaml
+++ b/api/pkg/controller/openshift/testdata/Kubermatic_API_image_is_overwritten-usercluster-controller.golden.yaml
@@ -89,7 +89,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.2
+        image: quay.io/kubermatic/http-prober:v0.3-dev3
         imagePullPolicy: IfNotPresent
         name: copy-http-prober
         resources: {}

--- a/api/pkg/controller/openshift/testdata/Kubermatic_API_image_is_overwritten-usercluster-controller.golden.yaml
+++ b/api/pkg/controller/openshift/testdata/Kubermatic_API_image_is_overwritten-usercluster-controller.golden.yaml
@@ -89,7 +89,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3-dev3
+        image: quay.io/kubermatic/http-prober:v0.3
         imagePullPolicy: IfNotPresent
         name: copy-http-prober
         resources: {}

--- a/api/pkg/resources/apiserver/is-running.go
+++ b/api/pkg/resources/apiserver/is-running.go
@@ -14,7 +14,7 @@ import (
 )
 
 const (
-	tag                = "v0.2"
+	tag                = "v0.3-dev3"
 	emptyDirVolumeName = "http-prober-bin"
 	initContainerName  = "copy-http-prober"
 )
@@ -30,7 +30,7 @@ type isRunningInitContainerData interface {
 // then mounting that volume onto all named containers and replacing the command with a call to
 // the `http-prober` binary. The http prober binary gets the original command as serialized string
 // and does an syscall.Exec onto it once the apiserver became reachable
-func IsRunningWrapper(data isRunningInitContainerData, spec corev1.PodSpec, containersToWrap sets.String) (*corev1.PodSpec, error) {
+func IsRunningWrapper(data isRunningInitContainerData, spec corev1.PodSpec, containersToWrap sets.String, crdKindToWaitFor, crdAPIVersionToWaitFor string) (*corev1.PodSpec, error) {
 	if containersToWrap.Len() == 0 {
 		return nil, errors.New("no containers to wrap passed")
 	}
@@ -80,7 +80,7 @@ func IsRunningWrapper(data isRunningInitContainerData, spec corev1.PodSpec, cont
 		if !containersToWrap.Has(spec.InitContainers[idx].Name) {
 			continue
 		}
-		wrappedContainer, err := wrapContainer(data, spec.InitContainers[idx])
+		wrappedContainer, err := wrapContainer(data, spec.InitContainers[idx], crdKindToWaitFor, crdAPIVersionToWaitFor)
 		if err != nil {
 			return nil, fmt.Errorf("failed to wrap initContainer %q: %v", spec.InitContainers[idx].Name, err)
 		}
@@ -90,7 +90,7 @@ func IsRunningWrapper(data isRunningInitContainerData, spec corev1.PodSpec, cont
 		if !containersToWrap.Has(spec.Containers[idx].Name) {
 			continue
 		}
-		wrappedContainer, err := wrapContainer(data, spec.Containers[idx])
+		wrappedContainer, err := wrapContainer(data, spec.Containers[idx], crdKindToWaitFor, crdAPIVersionToWaitFor)
 		if err != nil {
 			return nil, fmt.Errorf("failed to wrap container %q: %v", spec.Containers[idx].Name, err)
 		}
@@ -109,7 +109,7 @@ func hasContainerNamed(spec corev1.PodSpec, name string) bool {
 	return false
 }
 
-func wrapContainer(data isRunningInitContainerData, container corev1.Container) (*corev1.Container, error) {
+func wrapContainer(data isRunningInitContainerData, container corev1.Container, crdKindToWaitFor, crdAPIVersionToWaitFor string) (*corev1.Container, error) {
 	commandWithArgs := append(container.Command, container.Args...)
 	if len(commandWithArgs) == 0 {
 		return nil, fmt.Errorf("container %q has no command or args set", container.Name)
@@ -137,6 +137,11 @@ func wrapContainer(data isRunningInitContainerData, container corev1.Container) 
 		"-retry-wait", "2",
 		"-timeout", "1",
 		"-command", string(serializedCommand),
+	}
+	if crdKindToWaitFor != "" {
+		container.Args = append(container.Args,
+			"-wait-for-crd-kind", crdKindToWaitFor,
+			"-wait-for-crd-apiversion", crdAPIVersionToWaitFor)
 	}
 
 	return &container, nil

--- a/api/pkg/resources/apiserver/is-running.go
+++ b/api/pkg/resources/apiserver/is-running.go
@@ -14,7 +14,7 @@ import (
 )
 
 const (
-	tag                = "v0.3-dev3"
+	tag                = "v0.3"
 	emptyDirVolumeName = "http-prober-bin"
 	initContainerName  = "copy-http-prober"
 )

--- a/api/pkg/resources/clusterautoscaler/clusterautoscaler.go
+++ b/api/pkg/resources/clusterautoscaler/clusterautoscaler.go
@@ -118,7 +118,7 @@ func DeploymentCreator(data clusterautoscalerData) reconciling.NamedDeploymentCr
 				},
 			}
 
-			wrappedPodSpec, err := apiserver.IsRunningWrapper(data, dep.Spec.Template.Spec, sets.NewString(resources.ClusterAutoscalerDeploymentName))
+			wrappedPodSpec, err := apiserver.IsRunningWrapper(data, dep.Spec.Template.Spec, sets.NewString(resources.ClusterAutoscalerDeploymentName), "", "")
 			if err != nil {
 				return nil, fmt.Errorf("failed to add apiserver.IsRunningWrapper: %v", err)
 			}

--- a/api/pkg/resources/controllermanager/deployment.go
+++ b/api/pkg/resources/controllermanager/deployment.go
@@ -179,7 +179,7 @@ func DeploymentCreator(data *resources.TemplateData) reconciling.NamedDeployment
 
 			dep.Spec.Template.Spec.Affinity = resources.HostnameAntiAffinity(name, data.Cluster().Name)
 
-			wrappedPodSpec, err := apiserver.IsRunningWrapper(data, dep.Spec.Template.Spec, sets.NewString(name))
+			wrappedPodSpec, err := apiserver.IsRunningWrapper(data, dep.Spec.Template.Spec, sets.NewString(name), "", "")
 			if err != nil {
 				return nil, fmt.Errorf("failed to add apiserver.IsRunningWrapper: %v", err)
 			}

--- a/api/pkg/resources/kubestatemetrics/deployment.go
+++ b/api/pkg/resources/kubestatemetrics/deployment.go
@@ -109,7 +109,7 @@ func DeploymentCreator(data *resources.TemplateData) reconciling.NamedDeployment
 				},
 			}
 
-			wrappedPodSpec, err := apiserver.IsRunningWrapper(data, dep.Spec.Template.Spec, sets.NewString(name))
+			wrappedPodSpec, err := apiserver.IsRunningWrapper(data, dep.Spec.Template.Spec, sets.NewString(name), "", "")
 			if err != nil {
 				return nil, fmt.Errorf("failed to add apiserver.IsRunningWrapper: %v", err)
 			}

--- a/api/pkg/resources/machinecontroller/webhook.go
+++ b/api/pkg/resources/machinecontroller/webhook.go
@@ -67,7 +67,10 @@ func WebhookDeploymentCreator(data machinecontrollerData) reconciling.NamedDeplo
 						"-v", "4",
 						"-listen-address", "0.0.0.0:9876",
 					},
-					Env:       envVars,
+					Env: append(envVars, corev1.EnvVar{
+						Name:  "KUBECONFIG",
+						Value: "/etc/kubernetes/kubeconfig/kubeconfig",
+					}),
 					Resources: webhookResourceRequirements,
 					ReadinessProbe: &corev1.Probe{
 						Handler: corev1.Handler{
@@ -110,7 +113,7 @@ func WebhookDeploymentCreator(data machinecontrollerData) reconciling.NamedDeplo
 					},
 				},
 			}
-			wrappedPodSpec, err := apiserver.IsRunningWrapper(data, dep.Spec.Template.Spec, sets.NewString(Name))
+			wrappedPodSpec, err := apiserver.IsRunningWrapper(data, dep.Spec.Template.Spec, sets.NewString(Name), "Machine", "cluster.k8s.io/v1alpha1")
 			if err != nil {
 				return nil, fmt.Errorf("failed to add apiserver.IsRunningWrapper: %v", err)
 			}

--- a/api/pkg/resources/metrics-server/deployment.go
+++ b/api/pkg/resources/metrics-server/deployment.go
@@ -100,7 +100,7 @@ func DeploymentCreator(data *resources.TemplateData) reconciling.NamedDeployment
 
 			dep.Spec.Template.Spec.Affinity = resources.HostnameAntiAffinity(name, data.Cluster().Name)
 
-			wrappedPodSpec, err := apiserver.IsRunningWrapper(data, dep.Spec.Template.Spec, sets.NewString(name))
+			wrappedPodSpec, err := apiserver.IsRunningWrapper(data, dep.Spec.Template.Spec, sets.NewString(name), "", "")
 			if err != nil {
 				return nil, fmt.Errorf("failed to add apiserver.IsRunningWrapper: %v", err)
 			}

--- a/api/pkg/resources/scheduler/deployment.go
+++ b/api/pkg/resources/scheduler/deployment.go
@@ -131,7 +131,7 @@ func DeploymentCreator(data *resources.TemplateData) reconciling.NamedDeployment
 
 			dep.Spec.Template.Spec.Affinity = resources.HostnameAntiAffinity(name, data.Cluster().Name)
 
-			wrappedPodSpec, err := apiserver.IsRunningWrapper(data, dep.Spec.Template.Spec, sets.NewString(name))
+			wrappedPodSpec, err := apiserver.IsRunningWrapper(data, dep.Spec.Template.Spec, sets.NewString(name), "", "")
 			if err != nil {
 				return nil, fmt.Errorf("failed to add apiserver.IsRunningWrapper: %v", err)
 			}

--- a/api/pkg/resources/test/fixtures/deployment-aws-1.10.0-controller-manager.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-aws-1.10.0-controller-manager.yaml
@@ -178,7 +178,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3-dev3
+        image: quay.io/kubermatic/http-prober:v0.3
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/api/pkg/resources/test/fixtures/deployment-aws-1.10.0-controller-manager.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-aws-1.10.0-controller-manager.yaml
@@ -178,7 +178,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.2
+        image: quay.io/kubermatic/http-prober:v0.3-dev3
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/api/pkg/resources/test/fixtures/deployment-aws-1.10.0-kube-state-metrics.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-aws-1.10.0-kube-state-metrics.yaml
@@ -72,7 +72,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3-dev3
+        image: quay.io/kubermatic/http-prober:v0.3
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/api/pkg/resources/test/fixtures/deployment-aws-1.10.0-kube-state-metrics.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-aws-1.10.0-kube-state-metrics.yaml
@@ -72,7 +72,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.2
+        image: quay.io/kubermatic/http-prober:v0.3-dev3
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/api/pkg/resources/test/fixtures/deployment-aws-1.10.0-machine-controller-webhook.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-aws-1.10.0-machine-controller-webhook.yaml
@@ -31,6 +31,10 @@ spec:
         - "1"
         - -command
         - '{"command":"/usr/local/bin/webhook","args":["-kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","-logtostderr","-v","4","-listen-address","0.0.0.0:9876"]}'
+        - -wait-for-crd-kind
+        - Machine
+        - -wait-for-crd-apiversion
+        - cluster.k8s.io/v1alpha1
         command:
         - /http-prober-bin/http-prober
         env:
@@ -38,6 +42,8 @@ spec:
           value: aws-access-key-id
         - name: AWS_SECRET_ACCESS_KEY
           value: aws-secret-access-key
+        - name: KUBECONFIG
+          value: /etc/kubernetes/kubeconfig/kubeconfig
         image: docker.io/kubermatic/machine-controller:v1.5.6
         livenessProbe:
           failureThreshold: 8
@@ -82,7 +88,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.2
+        image: quay.io/kubermatic/http-prober:v0.3-dev3
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/api/pkg/resources/test/fixtures/deployment-aws-1.10.0-machine-controller-webhook.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-aws-1.10.0-machine-controller-webhook.yaml
@@ -88,7 +88,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3-dev3
+        image: quay.io/kubermatic/http-prober:v0.3
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/api/pkg/resources/test/fixtures/deployment-aws-1.10.0-machine-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-aws-1.10.0-machine-controller.yaml
@@ -34,6 +34,10 @@ spec:
         - "1"
         - -command
         - '{"command":"/usr/local/bin/machine-controller","args":["-kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","-logtostderr","-v","4","-cluster-dns","169.254.20.10","-internal-listen-address","0.0.0.0:8085"]}'
+        - -wait-for-crd-kind
+        - Machine
+        - -wait-for-crd-apiversion
+        - cluster.k8s.io/v1alpha1
         command:
         - /http-prober-bin/http-prober
         env:
@@ -41,6 +45,8 @@ spec:
           value: aws-access-key-id
         - name: AWS_SECRET_ACCESS_KEY
           value: aws-secret-access-key
+        - name: KUBECONFIG
+          value: /etc/kubernetes/kubeconfig/kubeconfig
         image: docker.io/kubermatic/machine-controller:v1.5.6
         livenessProbe:
           failureThreshold: 3
@@ -73,7 +79,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.2
+        image: quay.io/kubermatic/http-prober:v0.3-dev3
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/api/pkg/resources/test/fixtures/deployment-aws-1.10.0-machine-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-aws-1.10.0-machine-controller.yaml
@@ -79,7 +79,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3-dev3
+        image: quay.io/kubermatic/http-prober:v0.3
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/api/pkg/resources/test/fixtures/deployment-aws-1.10.0-metrics-server.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-aws-1.10.0-metrics-server.yaml
@@ -152,7 +152,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.2
+        image: quay.io/kubermatic/http-prober:v0.3-dev3
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/api/pkg/resources/test/fixtures/deployment-aws-1.10.0-metrics-server.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-aws-1.10.0-metrics-server.yaml
@@ -152,7 +152,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3-dev3
+        image: quay.io/kubermatic/http-prober:v0.3
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/api/pkg/resources/test/fixtures/deployment-aws-1.10.0-scheduler.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-aws-1.10.0-scheduler.yaml
@@ -163,7 +163,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3-dev3
+        image: quay.io/kubermatic/http-prober:v0.3
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/api/pkg/resources/test/fixtures/deployment-aws-1.10.0-scheduler.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-aws-1.10.0-scheduler.yaml
@@ -163,7 +163,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.2
+        image: quay.io/kubermatic/http-prober:v0.3-dev3
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/api/pkg/resources/test/fixtures/deployment-aws-1.10.0-usercluster-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-aws-1.10.0-usercluster-controller.yaml
@@ -85,7 +85,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.2
+        image: quay.io/kubermatic/http-prober:v0.3-dev3
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/api/pkg/resources/test/fixtures/deployment-aws-1.10.0-usercluster-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-aws-1.10.0-usercluster-controller.yaml
@@ -85,7 +85,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3-dev3
+        image: quay.io/kubermatic/http-prober:v0.3
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/api/pkg/resources/test/fixtures/deployment-aws-1.10.6-controller-manager.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-aws-1.10.6-controller-manager.yaml
@@ -178,7 +178,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3-dev3
+        image: quay.io/kubermatic/http-prober:v0.3
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/api/pkg/resources/test/fixtures/deployment-aws-1.10.6-controller-manager.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-aws-1.10.6-controller-manager.yaml
@@ -178,7 +178,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.2
+        image: quay.io/kubermatic/http-prober:v0.3-dev3
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/api/pkg/resources/test/fixtures/deployment-aws-1.10.6-kube-state-metrics.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-aws-1.10.6-kube-state-metrics.yaml
@@ -72,7 +72,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3-dev3
+        image: quay.io/kubermatic/http-prober:v0.3
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/api/pkg/resources/test/fixtures/deployment-aws-1.10.6-kube-state-metrics.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-aws-1.10.6-kube-state-metrics.yaml
@@ -72,7 +72,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.2
+        image: quay.io/kubermatic/http-prober:v0.3-dev3
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/api/pkg/resources/test/fixtures/deployment-aws-1.10.6-machine-controller-webhook.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-aws-1.10.6-machine-controller-webhook.yaml
@@ -31,6 +31,10 @@ spec:
         - "1"
         - -command
         - '{"command":"/usr/local/bin/webhook","args":["-kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","-logtostderr","-v","4","-listen-address","0.0.0.0:9876"]}'
+        - -wait-for-crd-kind
+        - Machine
+        - -wait-for-crd-apiversion
+        - cluster.k8s.io/v1alpha1
         command:
         - /http-prober-bin/http-prober
         env:
@@ -38,6 +42,8 @@ spec:
           value: aws-access-key-id
         - name: AWS_SECRET_ACCESS_KEY
           value: aws-secret-access-key
+        - name: KUBECONFIG
+          value: /etc/kubernetes/kubeconfig/kubeconfig
         image: docker.io/kubermatic/machine-controller:v1.5.6
         livenessProbe:
           failureThreshold: 8
@@ -82,7 +88,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.2
+        image: quay.io/kubermatic/http-prober:v0.3-dev3
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/api/pkg/resources/test/fixtures/deployment-aws-1.10.6-machine-controller-webhook.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-aws-1.10.6-machine-controller-webhook.yaml
@@ -88,7 +88,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3-dev3
+        image: quay.io/kubermatic/http-prober:v0.3
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/api/pkg/resources/test/fixtures/deployment-aws-1.10.6-machine-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-aws-1.10.6-machine-controller.yaml
@@ -34,6 +34,10 @@ spec:
         - "1"
         - -command
         - '{"command":"/usr/local/bin/machine-controller","args":["-kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","-logtostderr","-v","4","-cluster-dns","169.254.20.10","-internal-listen-address","0.0.0.0:8085"]}'
+        - -wait-for-crd-kind
+        - Machine
+        - -wait-for-crd-apiversion
+        - cluster.k8s.io/v1alpha1
         command:
         - /http-prober-bin/http-prober
         env:
@@ -41,6 +45,8 @@ spec:
           value: aws-access-key-id
         - name: AWS_SECRET_ACCESS_KEY
           value: aws-secret-access-key
+        - name: KUBECONFIG
+          value: /etc/kubernetes/kubeconfig/kubeconfig
         image: docker.io/kubermatic/machine-controller:v1.5.6
         livenessProbe:
           failureThreshold: 3
@@ -73,7 +79,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.2
+        image: quay.io/kubermatic/http-prober:v0.3-dev3
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/api/pkg/resources/test/fixtures/deployment-aws-1.10.6-machine-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-aws-1.10.6-machine-controller.yaml
@@ -79,7 +79,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3-dev3
+        image: quay.io/kubermatic/http-prober:v0.3
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/api/pkg/resources/test/fixtures/deployment-aws-1.10.6-metrics-server.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-aws-1.10.6-metrics-server.yaml
@@ -152,7 +152,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.2
+        image: quay.io/kubermatic/http-prober:v0.3-dev3
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/api/pkg/resources/test/fixtures/deployment-aws-1.10.6-metrics-server.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-aws-1.10.6-metrics-server.yaml
@@ -152,7 +152,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3-dev3
+        image: quay.io/kubermatic/http-prober:v0.3
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/api/pkg/resources/test/fixtures/deployment-aws-1.10.6-scheduler.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-aws-1.10.6-scheduler.yaml
@@ -163,7 +163,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3-dev3
+        image: quay.io/kubermatic/http-prober:v0.3
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/api/pkg/resources/test/fixtures/deployment-aws-1.10.6-scheduler.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-aws-1.10.6-scheduler.yaml
@@ -163,7 +163,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.2
+        image: quay.io/kubermatic/http-prober:v0.3-dev3
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/api/pkg/resources/test/fixtures/deployment-aws-1.10.6-usercluster-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-aws-1.10.6-usercluster-controller.yaml
@@ -85,7 +85,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.2
+        image: quay.io/kubermatic/http-prober:v0.3-dev3
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/api/pkg/resources/test/fixtures/deployment-aws-1.10.6-usercluster-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-aws-1.10.6-usercluster-controller.yaml
@@ -85,7 +85,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3-dev3
+        image: quay.io/kubermatic/http-prober:v0.3
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/api/pkg/resources/test/fixtures/deployment-aws-1.11.0-controller-manager.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-aws-1.11.0-controller-manager.yaml
@@ -178,7 +178,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3-dev3
+        image: quay.io/kubermatic/http-prober:v0.3
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/api/pkg/resources/test/fixtures/deployment-aws-1.11.0-controller-manager.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-aws-1.11.0-controller-manager.yaml
@@ -178,7 +178,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.2
+        image: quay.io/kubermatic/http-prober:v0.3-dev3
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/api/pkg/resources/test/fixtures/deployment-aws-1.11.0-kube-state-metrics.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-aws-1.11.0-kube-state-metrics.yaml
@@ -72,7 +72,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3-dev3
+        image: quay.io/kubermatic/http-prober:v0.3
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/api/pkg/resources/test/fixtures/deployment-aws-1.11.0-kube-state-metrics.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-aws-1.11.0-kube-state-metrics.yaml
@@ -72,7 +72,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.2
+        image: quay.io/kubermatic/http-prober:v0.3-dev3
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/api/pkg/resources/test/fixtures/deployment-aws-1.11.0-machine-controller-webhook.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-aws-1.11.0-machine-controller-webhook.yaml
@@ -31,6 +31,10 @@ spec:
         - "1"
         - -command
         - '{"command":"/usr/local/bin/webhook","args":["-kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","-logtostderr","-v","4","-listen-address","0.0.0.0:9876"]}'
+        - -wait-for-crd-kind
+        - Machine
+        - -wait-for-crd-apiversion
+        - cluster.k8s.io/v1alpha1
         command:
         - /http-prober-bin/http-prober
         env:
@@ -38,6 +42,8 @@ spec:
           value: aws-access-key-id
         - name: AWS_SECRET_ACCESS_KEY
           value: aws-secret-access-key
+        - name: KUBECONFIG
+          value: /etc/kubernetes/kubeconfig/kubeconfig
         image: docker.io/kubermatic/machine-controller:v1.5.6
         livenessProbe:
           failureThreshold: 8
@@ -82,7 +88,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.2
+        image: quay.io/kubermatic/http-prober:v0.3-dev3
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/api/pkg/resources/test/fixtures/deployment-aws-1.11.0-machine-controller-webhook.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-aws-1.11.0-machine-controller-webhook.yaml
@@ -88,7 +88,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3-dev3
+        image: quay.io/kubermatic/http-prober:v0.3
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/api/pkg/resources/test/fixtures/deployment-aws-1.11.0-machine-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-aws-1.11.0-machine-controller.yaml
@@ -34,6 +34,10 @@ spec:
         - "1"
         - -command
         - '{"command":"/usr/local/bin/machine-controller","args":["-kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","-logtostderr","-v","4","-cluster-dns","169.254.20.10","-internal-listen-address","0.0.0.0:8085"]}'
+        - -wait-for-crd-kind
+        - Machine
+        - -wait-for-crd-apiversion
+        - cluster.k8s.io/v1alpha1
         command:
         - /http-prober-bin/http-prober
         env:
@@ -41,6 +45,8 @@ spec:
           value: aws-access-key-id
         - name: AWS_SECRET_ACCESS_KEY
           value: aws-secret-access-key
+        - name: KUBECONFIG
+          value: /etc/kubernetes/kubeconfig/kubeconfig
         image: docker.io/kubermatic/machine-controller:v1.5.6
         livenessProbe:
           failureThreshold: 3
@@ -73,7 +79,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.2
+        image: quay.io/kubermatic/http-prober:v0.3-dev3
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/api/pkg/resources/test/fixtures/deployment-aws-1.11.0-machine-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-aws-1.11.0-machine-controller.yaml
@@ -79,7 +79,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3-dev3
+        image: quay.io/kubermatic/http-prober:v0.3
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/api/pkg/resources/test/fixtures/deployment-aws-1.11.0-metrics-server.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-aws-1.11.0-metrics-server.yaml
@@ -152,7 +152,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.2
+        image: quay.io/kubermatic/http-prober:v0.3-dev3
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/api/pkg/resources/test/fixtures/deployment-aws-1.11.0-metrics-server.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-aws-1.11.0-metrics-server.yaml
@@ -152,7 +152,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3-dev3
+        image: quay.io/kubermatic/http-prober:v0.3
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/api/pkg/resources/test/fixtures/deployment-aws-1.11.0-scheduler.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-aws-1.11.0-scheduler.yaml
@@ -163,7 +163,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3-dev3
+        image: quay.io/kubermatic/http-prober:v0.3
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/api/pkg/resources/test/fixtures/deployment-aws-1.11.0-scheduler.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-aws-1.11.0-scheduler.yaml
@@ -163,7 +163,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.2
+        image: quay.io/kubermatic/http-prober:v0.3-dev3
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/api/pkg/resources/test/fixtures/deployment-aws-1.11.0-usercluster-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-aws-1.11.0-usercluster-controller.yaml
@@ -85,7 +85,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.2
+        image: quay.io/kubermatic/http-prober:v0.3-dev3
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/api/pkg/resources/test/fixtures/deployment-aws-1.11.0-usercluster-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-aws-1.11.0-usercluster-controller.yaml
@@ -85,7 +85,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3-dev3
+        image: quay.io/kubermatic/http-prober:v0.3
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/api/pkg/resources/test/fixtures/deployment-aws-1.11.1-controller-manager.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-aws-1.11.1-controller-manager.yaml
@@ -178,7 +178,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3-dev3
+        image: quay.io/kubermatic/http-prober:v0.3
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/api/pkg/resources/test/fixtures/deployment-aws-1.11.1-controller-manager.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-aws-1.11.1-controller-manager.yaml
@@ -178,7 +178,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.2
+        image: quay.io/kubermatic/http-prober:v0.3-dev3
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/api/pkg/resources/test/fixtures/deployment-aws-1.11.1-kube-state-metrics.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-aws-1.11.1-kube-state-metrics.yaml
@@ -72,7 +72,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3-dev3
+        image: quay.io/kubermatic/http-prober:v0.3
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/api/pkg/resources/test/fixtures/deployment-aws-1.11.1-kube-state-metrics.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-aws-1.11.1-kube-state-metrics.yaml
@@ -72,7 +72,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.2
+        image: quay.io/kubermatic/http-prober:v0.3-dev3
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/api/pkg/resources/test/fixtures/deployment-aws-1.11.1-machine-controller-webhook.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-aws-1.11.1-machine-controller-webhook.yaml
@@ -31,6 +31,10 @@ spec:
         - "1"
         - -command
         - '{"command":"/usr/local/bin/webhook","args":["-kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","-logtostderr","-v","4","-listen-address","0.0.0.0:9876"]}'
+        - -wait-for-crd-kind
+        - Machine
+        - -wait-for-crd-apiversion
+        - cluster.k8s.io/v1alpha1
         command:
         - /http-prober-bin/http-prober
         env:
@@ -38,6 +42,8 @@ spec:
           value: aws-access-key-id
         - name: AWS_SECRET_ACCESS_KEY
           value: aws-secret-access-key
+        - name: KUBECONFIG
+          value: /etc/kubernetes/kubeconfig/kubeconfig
         image: docker.io/kubermatic/machine-controller:v1.5.6
         livenessProbe:
           failureThreshold: 8
@@ -82,7 +88,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.2
+        image: quay.io/kubermatic/http-prober:v0.3-dev3
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/api/pkg/resources/test/fixtures/deployment-aws-1.11.1-machine-controller-webhook.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-aws-1.11.1-machine-controller-webhook.yaml
@@ -88,7 +88,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3-dev3
+        image: quay.io/kubermatic/http-prober:v0.3
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/api/pkg/resources/test/fixtures/deployment-aws-1.11.1-machine-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-aws-1.11.1-machine-controller.yaml
@@ -34,6 +34,10 @@ spec:
         - "1"
         - -command
         - '{"command":"/usr/local/bin/machine-controller","args":["-kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","-logtostderr","-v","4","-cluster-dns","169.254.20.10","-internal-listen-address","0.0.0.0:8085"]}'
+        - -wait-for-crd-kind
+        - Machine
+        - -wait-for-crd-apiversion
+        - cluster.k8s.io/v1alpha1
         command:
         - /http-prober-bin/http-prober
         env:
@@ -41,6 +45,8 @@ spec:
           value: aws-access-key-id
         - name: AWS_SECRET_ACCESS_KEY
           value: aws-secret-access-key
+        - name: KUBECONFIG
+          value: /etc/kubernetes/kubeconfig/kubeconfig
         image: docker.io/kubermatic/machine-controller:v1.5.6
         livenessProbe:
           failureThreshold: 3
@@ -73,7 +79,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.2
+        image: quay.io/kubermatic/http-prober:v0.3-dev3
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/api/pkg/resources/test/fixtures/deployment-aws-1.11.1-machine-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-aws-1.11.1-machine-controller.yaml
@@ -79,7 +79,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3-dev3
+        image: quay.io/kubermatic/http-prober:v0.3
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/api/pkg/resources/test/fixtures/deployment-aws-1.11.1-metrics-server.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-aws-1.11.1-metrics-server.yaml
@@ -152,7 +152,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.2
+        image: quay.io/kubermatic/http-prober:v0.3-dev3
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/api/pkg/resources/test/fixtures/deployment-aws-1.11.1-metrics-server.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-aws-1.11.1-metrics-server.yaml
@@ -152,7 +152,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3-dev3
+        image: quay.io/kubermatic/http-prober:v0.3
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/api/pkg/resources/test/fixtures/deployment-aws-1.11.1-scheduler.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-aws-1.11.1-scheduler.yaml
@@ -163,7 +163,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3-dev3
+        image: quay.io/kubermatic/http-prober:v0.3
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/api/pkg/resources/test/fixtures/deployment-aws-1.11.1-scheduler.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-aws-1.11.1-scheduler.yaml
@@ -163,7 +163,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.2
+        image: quay.io/kubermatic/http-prober:v0.3-dev3
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/api/pkg/resources/test/fixtures/deployment-aws-1.11.1-usercluster-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-aws-1.11.1-usercluster-controller.yaml
@@ -85,7 +85,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.2
+        image: quay.io/kubermatic/http-prober:v0.3-dev3
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/api/pkg/resources/test/fixtures/deployment-aws-1.11.1-usercluster-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-aws-1.11.1-usercluster-controller.yaml
@@ -85,7 +85,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3-dev3
+        image: quay.io/kubermatic/http-prober:v0.3
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/api/pkg/resources/test/fixtures/deployment-aws-1.12.0-controller-manager.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-aws-1.12.0-controller-manager.yaml
@@ -178,7 +178,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3-dev3
+        image: quay.io/kubermatic/http-prober:v0.3
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/api/pkg/resources/test/fixtures/deployment-aws-1.12.0-controller-manager.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-aws-1.12.0-controller-manager.yaml
@@ -178,7 +178,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.2
+        image: quay.io/kubermatic/http-prober:v0.3-dev3
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/api/pkg/resources/test/fixtures/deployment-aws-1.12.0-kube-state-metrics.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-aws-1.12.0-kube-state-metrics.yaml
@@ -72,7 +72,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3-dev3
+        image: quay.io/kubermatic/http-prober:v0.3
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/api/pkg/resources/test/fixtures/deployment-aws-1.12.0-kube-state-metrics.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-aws-1.12.0-kube-state-metrics.yaml
@@ -72,7 +72,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.2
+        image: quay.io/kubermatic/http-prober:v0.3-dev3
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/api/pkg/resources/test/fixtures/deployment-aws-1.12.0-machine-controller-webhook.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-aws-1.12.0-machine-controller-webhook.yaml
@@ -31,6 +31,10 @@ spec:
         - "1"
         - -command
         - '{"command":"/usr/local/bin/webhook","args":["-kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","-logtostderr","-v","4","-listen-address","0.0.0.0:9876"]}'
+        - -wait-for-crd-kind
+        - Machine
+        - -wait-for-crd-apiversion
+        - cluster.k8s.io/v1alpha1
         command:
         - /http-prober-bin/http-prober
         env:
@@ -38,6 +42,8 @@ spec:
           value: aws-access-key-id
         - name: AWS_SECRET_ACCESS_KEY
           value: aws-secret-access-key
+        - name: KUBECONFIG
+          value: /etc/kubernetes/kubeconfig/kubeconfig
         image: docker.io/kubermatic/machine-controller:v1.5.6
         livenessProbe:
           failureThreshold: 8
@@ -82,7 +88,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.2
+        image: quay.io/kubermatic/http-prober:v0.3-dev3
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/api/pkg/resources/test/fixtures/deployment-aws-1.12.0-machine-controller-webhook.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-aws-1.12.0-machine-controller-webhook.yaml
@@ -88,7 +88,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3-dev3
+        image: quay.io/kubermatic/http-prober:v0.3
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/api/pkg/resources/test/fixtures/deployment-aws-1.12.0-machine-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-aws-1.12.0-machine-controller.yaml
@@ -34,6 +34,10 @@ spec:
         - "1"
         - -command
         - '{"command":"/usr/local/bin/machine-controller","args":["-kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","-logtostderr","-v","4","-cluster-dns","169.254.20.10","-internal-listen-address","0.0.0.0:8085"]}'
+        - -wait-for-crd-kind
+        - Machine
+        - -wait-for-crd-apiversion
+        - cluster.k8s.io/v1alpha1
         command:
         - /http-prober-bin/http-prober
         env:
@@ -41,6 +45,8 @@ spec:
           value: aws-access-key-id
         - name: AWS_SECRET_ACCESS_KEY
           value: aws-secret-access-key
+        - name: KUBECONFIG
+          value: /etc/kubernetes/kubeconfig/kubeconfig
         image: docker.io/kubermatic/machine-controller:v1.5.6
         livenessProbe:
           failureThreshold: 3
@@ -73,7 +79,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.2
+        image: quay.io/kubermatic/http-prober:v0.3-dev3
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/api/pkg/resources/test/fixtures/deployment-aws-1.12.0-machine-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-aws-1.12.0-machine-controller.yaml
@@ -79,7 +79,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3-dev3
+        image: quay.io/kubermatic/http-prober:v0.3
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/api/pkg/resources/test/fixtures/deployment-aws-1.12.0-metrics-server.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-aws-1.12.0-metrics-server.yaml
@@ -152,7 +152,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.2
+        image: quay.io/kubermatic/http-prober:v0.3-dev3
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/api/pkg/resources/test/fixtures/deployment-aws-1.12.0-metrics-server.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-aws-1.12.0-metrics-server.yaml
@@ -152,7 +152,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3-dev3
+        image: quay.io/kubermatic/http-prober:v0.3
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/api/pkg/resources/test/fixtures/deployment-aws-1.12.0-scheduler.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-aws-1.12.0-scheduler.yaml
@@ -163,7 +163,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3-dev3
+        image: quay.io/kubermatic/http-prober:v0.3
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/api/pkg/resources/test/fixtures/deployment-aws-1.12.0-scheduler.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-aws-1.12.0-scheduler.yaml
@@ -163,7 +163,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.2
+        image: quay.io/kubermatic/http-prober:v0.3-dev3
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/api/pkg/resources/test/fixtures/deployment-aws-1.12.0-usercluster-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-aws-1.12.0-usercluster-controller.yaml
@@ -85,7 +85,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.2
+        image: quay.io/kubermatic/http-prober:v0.3-dev3
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/api/pkg/resources/test/fixtures/deployment-aws-1.12.0-usercluster-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-aws-1.12.0-usercluster-controller.yaml
@@ -85,7 +85,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3-dev3
+        image: quay.io/kubermatic/http-prober:v0.3
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/api/pkg/resources/test/fixtures/deployment-aws-1.13.0-controller-manager.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-aws-1.13.0-controller-manager.yaml
@@ -178,7 +178,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3-dev3
+        image: quay.io/kubermatic/http-prober:v0.3
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/api/pkg/resources/test/fixtures/deployment-aws-1.13.0-controller-manager.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-aws-1.13.0-controller-manager.yaml
@@ -178,7 +178,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.2
+        image: quay.io/kubermatic/http-prober:v0.3-dev3
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/api/pkg/resources/test/fixtures/deployment-aws-1.13.0-kube-state-metrics.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-aws-1.13.0-kube-state-metrics.yaml
@@ -72,7 +72,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3-dev3
+        image: quay.io/kubermatic/http-prober:v0.3
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/api/pkg/resources/test/fixtures/deployment-aws-1.13.0-kube-state-metrics.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-aws-1.13.0-kube-state-metrics.yaml
@@ -72,7 +72,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.2
+        image: quay.io/kubermatic/http-prober:v0.3-dev3
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/api/pkg/resources/test/fixtures/deployment-aws-1.13.0-machine-controller-webhook.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-aws-1.13.0-machine-controller-webhook.yaml
@@ -31,6 +31,10 @@ spec:
         - "1"
         - -command
         - '{"command":"/usr/local/bin/webhook","args":["-kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","-logtostderr","-v","4","-listen-address","0.0.0.0:9876"]}'
+        - -wait-for-crd-kind
+        - Machine
+        - -wait-for-crd-apiversion
+        - cluster.k8s.io/v1alpha1
         command:
         - /http-prober-bin/http-prober
         env:
@@ -38,6 +42,8 @@ spec:
           value: aws-access-key-id
         - name: AWS_SECRET_ACCESS_KEY
           value: aws-secret-access-key
+        - name: KUBECONFIG
+          value: /etc/kubernetes/kubeconfig/kubeconfig
         image: docker.io/kubermatic/machine-controller:v1.5.6
         livenessProbe:
           failureThreshold: 8
@@ -82,7 +88,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.2
+        image: quay.io/kubermatic/http-prober:v0.3-dev3
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/api/pkg/resources/test/fixtures/deployment-aws-1.13.0-machine-controller-webhook.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-aws-1.13.0-machine-controller-webhook.yaml
@@ -88,7 +88,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3-dev3
+        image: quay.io/kubermatic/http-prober:v0.3
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/api/pkg/resources/test/fixtures/deployment-aws-1.13.0-machine-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-aws-1.13.0-machine-controller.yaml
@@ -34,6 +34,10 @@ spec:
         - "1"
         - -command
         - '{"command":"/usr/local/bin/machine-controller","args":["-kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","-logtostderr","-v","4","-cluster-dns","169.254.20.10","-internal-listen-address","0.0.0.0:8085"]}'
+        - -wait-for-crd-kind
+        - Machine
+        - -wait-for-crd-apiversion
+        - cluster.k8s.io/v1alpha1
         command:
         - /http-prober-bin/http-prober
         env:
@@ -41,6 +45,8 @@ spec:
           value: aws-access-key-id
         - name: AWS_SECRET_ACCESS_KEY
           value: aws-secret-access-key
+        - name: KUBECONFIG
+          value: /etc/kubernetes/kubeconfig/kubeconfig
         image: docker.io/kubermatic/machine-controller:v1.5.6
         livenessProbe:
           failureThreshold: 3
@@ -73,7 +79,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.2
+        image: quay.io/kubermatic/http-prober:v0.3-dev3
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/api/pkg/resources/test/fixtures/deployment-aws-1.13.0-machine-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-aws-1.13.0-machine-controller.yaml
@@ -79,7 +79,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3-dev3
+        image: quay.io/kubermatic/http-prober:v0.3
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/api/pkg/resources/test/fixtures/deployment-aws-1.13.0-metrics-server.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-aws-1.13.0-metrics-server.yaml
@@ -152,7 +152,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.2
+        image: quay.io/kubermatic/http-prober:v0.3-dev3
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/api/pkg/resources/test/fixtures/deployment-aws-1.13.0-metrics-server.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-aws-1.13.0-metrics-server.yaml
@@ -152,7 +152,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3-dev3
+        image: quay.io/kubermatic/http-prober:v0.3
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/api/pkg/resources/test/fixtures/deployment-aws-1.13.0-scheduler.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-aws-1.13.0-scheduler.yaml
@@ -163,7 +163,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3-dev3
+        image: quay.io/kubermatic/http-prober:v0.3
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/api/pkg/resources/test/fixtures/deployment-aws-1.13.0-scheduler.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-aws-1.13.0-scheduler.yaml
@@ -163,7 +163,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.2
+        image: quay.io/kubermatic/http-prober:v0.3-dev3
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/api/pkg/resources/test/fixtures/deployment-aws-1.13.0-usercluster-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-aws-1.13.0-usercluster-controller.yaml
@@ -85,7 +85,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.2
+        image: quay.io/kubermatic/http-prober:v0.3-dev3
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/api/pkg/resources/test/fixtures/deployment-aws-1.13.0-usercluster-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-aws-1.13.0-usercluster-controller.yaml
@@ -85,7 +85,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3-dev3
+        image: quay.io/kubermatic/http-prober:v0.3
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/api/pkg/resources/test/fixtures/deployment-azure-1.10.0-controller-manager.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-azure-1.10.0-controller-manager.yaml
@@ -171,7 +171,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3-dev3
+        image: quay.io/kubermatic/http-prober:v0.3
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/api/pkg/resources/test/fixtures/deployment-azure-1.10.0-controller-manager.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-azure-1.10.0-controller-manager.yaml
@@ -171,7 +171,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.2
+        image: quay.io/kubermatic/http-prober:v0.3-dev3
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/api/pkg/resources/test/fixtures/deployment-azure-1.10.0-kube-state-metrics.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-azure-1.10.0-kube-state-metrics.yaml
@@ -72,7 +72,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3-dev3
+        image: quay.io/kubermatic/http-prober:v0.3
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/api/pkg/resources/test/fixtures/deployment-azure-1.10.0-kube-state-metrics.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-azure-1.10.0-kube-state-metrics.yaml
@@ -72,7 +72,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.2
+        image: quay.io/kubermatic/http-prober:v0.3-dev3
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/api/pkg/resources/test/fixtures/deployment-azure-1.10.0-machine-controller-webhook.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-azure-1.10.0-machine-controller-webhook.yaml
@@ -92,7 +92,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3-dev3
+        image: quay.io/kubermatic/http-prober:v0.3
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/api/pkg/resources/test/fixtures/deployment-azure-1.10.0-machine-controller-webhook.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-azure-1.10.0-machine-controller-webhook.yaml
@@ -31,6 +31,10 @@ spec:
         - "1"
         - -command
         - '{"command":"/usr/local/bin/webhook","args":["-kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","-logtostderr","-v","4","-listen-address","0.0.0.0:9876"]}'
+        - -wait-for-crd-kind
+        - Machine
+        - -wait-for-crd-apiversion
+        - cluster.k8s.io/v1alpha1
         command:
         - /http-prober-bin/http-prober
         env:
@@ -42,6 +46,8 @@ spec:
           value: az-tenant-id
         - name: AZURE_SUBSCRIPTION_ID
           value: az-subscription-id
+        - name: KUBECONFIG
+          value: /etc/kubernetes/kubeconfig/kubeconfig
         image: docker.io/kubermatic/machine-controller:v1.5.6
         livenessProbe:
           failureThreshold: 8
@@ -86,7 +92,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.2
+        image: quay.io/kubermatic/http-prober:v0.3-dev3
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/api/pkg/resources/test/fixtures/deployment-azure-1.10.0-machine-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-azure-1.10.0-machine-controller.yaml
@@ -83,7 +83,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3-dev3
+        image: quay.io/kubermatic/http-prober:v0.3
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/api/pkg/resources/test/fixtures/deployment-azure-1.10.0-machine-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-azure-1.10.0-machine-controller.yaml
@@ -34,6 +34,10 @@ spec:
         - "1"
         - -command
         - '{"command":"/usr/local/bin/machine-controller","args":["-kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","-logtostderr","-v","4","-cluster-dns","169.254.20.10","-internal-listen-address","0.0.0.0:8085"]}'
+        - -wait-for-crd-kind
+        - Machine
+        - -wait-for-crd-apiversion
+        - cluster.k8s.io/v1alpha1
         command:
         - /http-prober-bin/http-prober
         env:
@@ -45,6 +49,8 @@ spec:
           value: az-tenant-id
         - name: AZURE_SUBSCRIPTION_ID
           value: az-subscription-id
+        - name: KUBECONFIG
+          value: /etc/kubernetes/kubeconfig/kubeconfig
         image: docker.io/kubermatic/machine-controller:v1.5.6
         livenessProbe:
           failureThreshold: 3
@@ -77,7 +83,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.2
+        image: quay.io/kubermatic/http-prober:v0.3-dev3
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/api/pkg/resources/test/fixtures/deployment-azure-1.10.0-metrics-server.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-azure-1.10.0-metrics-server.yaml
@@ -152,7 +152,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.2
+        image: quay.io/kubermatic/http-prober:v0.3-dev3
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/api/pkg/resources/test/fixtures/deployment-azure-1.10.0-metrics-server.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-azure-1.10.0-metrics-server.yaml
@@ -152,7 +152,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3-dev3
+        image: quay.io/kubermatic/http-prober:v0.3
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/api/pkg/resources/test/fixtures/deployment-azure-1.10.0-scheduler.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-azure-1.10.0-scheduler.yaml
@@ -163,7 +163,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3-dev3
+        image: quay.io/kubermatic/http-prober:v0.3
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/api/pkg/resources/test/fixtures/deployment-azure-1.10.0-scheduler.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-azure-1.10.0-scheduler.yaml
@@ -163,7 +163,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.2
+        image: quay.io/kubermatic/http-prober:v0.3-dev3
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/api/pkg/resources/test/fixtures/deployment-azure-1.10.0-usercluster-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-azure-1.10.0-usercluster-controller.yaml
@@ -85,7 +85,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.2
+        image: quay.io/kubermatic/http-prober:v0.3-dev3
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/api/pkg/resources/test/fixtures/deployment-azure-1.10.0-usercluster-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-azure-1.10.0-usercluster-controller.yaml
@@ -85,7 +85,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3-dev3
+        image: quay.io/kubermatic/http-prober:v0.3
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/api/pkg/resources/test/fixtures/deployment-azure-1.10.6-controller-manager.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-azure-1.10.6-controller-manager.yaml
@@ -171,7 +171,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3-dev3
+        image: quay.io/kubermatic/http-prober:v0.3
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/api/pkg/resources/test/fixtures/deployment-azure-1.10.6-controller-manager.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-azure-1.10.6-controller-manager.yaml
@@ -171,7 +171,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.2
+        image: quay.io/kubermatic/http-prober:v0.3-dev3
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/api/pkg/resources/test/fixtures/deployment-azure-1.10.6-kube-state-metrics.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-azure-1.10.6-kube-state-metrics.yaml
@@ -72,7 +72,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3-dev3
+        image: quay.io/kubermatic/http-prober:v0.3
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/api/pkg/resources/test/fixtures/deployment-azure-1.10.6-kube-state-metrics.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-azure-1.10.6-kube-state-metrics.yaml
@@ -72,7 +72,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.2
+        image: quay.io/kubermatic/http-prober:v0.3-dev3
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/api/pkg/resources/test/fixtures/deployment-azure-1.10.6-machine-controller-webhook.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-azure-1.10.6-machine-controller-webhook.yaml
@@ -92,7 +92,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3-dev3
+        image: quay.io/kubermatic/http-prober:v0.3
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/api/pkg/resources/test/fixtures/deployment-azure-1.10.6-machine-controller-webhook.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-azure-1.10.6-machine-controller-webhook.yaml
@@ -31,6 +31,10 @@ spec:
         - "1"
         - -command
         - '{"command":"/usr/local/bin/webhook","args":["-kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","-logtostderr","-v","4","-listen-address","0.0.0.0:9876"]}'
+        - -wait-for-crd-kind
+        - Machine
+        - -wait-for-crd-apiversion
+        - cluster.k8s.io/v1alpha1
         command:
         - /http-prober-bin/http-prober
         env:
@@ -42,6 +46,8 @@ spec:
           value: az-tenant-id
         - name: AZURE_SUBSCRIPTION_ID
           value: az-subscription-id
+        - name: KUBECONFIG
+          value: /etc/kubernetes/kubeconfig/kubeconfig
         image: docker.io/kubermatic/machine-controller:v1.5.6
         livenessProbe:
           failureThreshold: 8
@@ -86,7 +92,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.2
+        image: quay.io/kubermatic/http-prober:v0.3-dev3
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/api/pkg/resources/test/fixtures/deployment-azure-1.10.6-machine-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-azure-1.10.6-machine-controller.yaml
@@ -83,7 +83,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3-dev3
+        image: quay.io/kubermatic/http-prober:v0.3
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/api/pkg/resources/test/fixtures/deployment-azure-1.10.6-machine-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-azure-1.10.6-machine-controller.yaml
@@ -34,6 +34,10 @@ spec:
         - "1"
         - -command
         - '{"command":"/usr/local/bin/machine-controller","args":["-kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","-logtostderr","-v","4","-cluster-dns","169.254.20.10","-internal-listen-address","0.0.0.0:8085"]}'
+        - -wait-for-crd-kind
+        - Machine
+        - -wait-for-crd-apiversion
+        - cluster.k8s.io/v1alpha1
         command:
         - /http-prober-bin/http-prober
         env:
@@ -45,6 +49,8 @@ spec:
           value: az-tenant-id
         - name: AZURE_SUBSCRIPTION_ID
           value: az-subscription-id
+        - name: KUBECONFIG
+          value: /etc/kubernetes/kubeconfig/kubeconfig
         image: docker.io/kubermatic/machine-controller:v1.5.6
         livenessProbe:
           failureThreshold: 3
@@ -77,7 +83,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.2
+        image: quay.io/kubermatic/http-prober:v0.3-dev3
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/api/pkg/resources/test/fixtures/deployment-azure-1.10.6-metrics-server.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-azure-1.10.6-metrics-server.yaml
@@ -152,7 +152,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.2
+        image: quay.io/kubermatic/http-prober:v0.3-dev3
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/api/pkg/resources/test/fixtures/deployment-azure-1.10.6-metrics-server.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-azure-1.10.6-metrics-server.yaml
@@ -152,7 +152,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3-dev3
+        image: quay.io/kubermatic/http-prober:v0.3
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/api/pkg/resources/test/fixtures/deployment-azure-1.10.6-scheduler.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-azure-1.10.6-scheduler.yaml
@@ -163,7 +163,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3-dev3
+        image: quay.io/kubermatic/http-prober:v0.3
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/api/pkg/resources/test/fixtures/deployment-azure-1.10.6-scheduler.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-azure-1.10.6-scheduler.yaml
@@ -163,7 +163,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.2
+        image: quay.io/kubermatic/http-prober:v0.3-dev3
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/api/pkg/resources/test/fixtures/deployment-azure-1.10.6-usercluster-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-azure-1.10.6-usercluster-controller.yaml
@@ -85,7 +85,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.2
+        image: quay.io/kubermatic/http-prober:v0.3-dev3
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/api/pkg/resources/test/fixtures/deployment-azure-1.10.6-usercluster-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-azure-1.10.6-usercluster-controller.yaml
@@ -85,7 +85,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3-dev3
+        image: quay.io/kubermatic/http-prober:v0.3
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/api/pkg/resources/test/fixtures/deployment-azure-1.11.0-controller-manager.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-azure-1.11.0-controller-manager.yaml
@@ -171,7 +171,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3-dev3
+        image: quay.io/kubermatic/http-prober:v0.3
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/api/pkg/resources/test/fixtures/deployment-azure-1.11.0-controller-manager.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-azure-1.11.0-controller-manager.yaml
@@ -171,7 +171,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.2
+        image: quay.io/kubermatic/http-prober:v0.3-dev3
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/api/pkg/resources/test/fixtures/deployment-azure-1.11.0-kube-state-metrics.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-azure-1.11.0-kube-state-metrics.yaml
@@ -72,7 +72,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3-dev3
+        image: quay.io/kubermatic/http-prober:v0.3
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/api/pkg/resources/test/fixtures/deployment-azure-1.11.0-kube-state-metrics.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-azure-1.11.0-kube-state-metrics.yaml
@@ -72,7 +72,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.2
+        image: quay.io/kubermatic/http-prober:v0.3-dev3
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/api/pkg/resources/test/fixtures/deployment-azure-1.11.0-machine-controller-webhook.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-azure-1.11.0-machine-controller-webhook.yaml
@@ -92,7 +92,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3-dev3
+        image: quay.io/kubermatic/http-prober:v0.3
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/api/pkg/resources/test/fixtures/deployment-azure-1.11.0-machine-controller-webhook.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-azure-1.11.0-machine-controller-webhook.yaml
@@ -31,6 +31,10 @@ spec:
         - "1"
         - -command
         - '{"command":"/usr/local/bin/webhook","args":["-kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","-logtostderr","-v","4","-listen-address","0.0.0.0:9876"]}'
+        - -wait-for-crd-kind
+        - Machine
+        - -wait-for-crd-apiversion
+        - cluster.k8s.io/v1alpha1
         command:
         - /http-prober-bin/http-prober
         env:
@@ -42,6 +46,8 @@ spec:
           value: az-tenant-id
         - name: AZURE_SUBSCRIPTION_ID
           value: az-subscription-id
+        - name: KUBECONFIG
+          value: /etc/kubernetes/kubeconfig/kubeconfig
         image: docker.io/kubermatic/machine-controller:v1.5.6
         livenessProbe:
           failureThreshold: 8
@@ -86,7 +92,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.2
+        image: quay.io/kubermatic/http-prober:v0.3-dev3
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/api/pkg/resources/test/fixtures/deployment-azure-1.11.0-machine-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-azure-1.11.0-machine-controller.yaml
@@ -83,7 +83,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3-dev3
+        image: quay.io/kubermatic/http-prober:v0.3
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/api/pkg/resources/test/fixtures/deployment-azure-1.11.0-machine-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-azure-1.11.0-machine-controller.yaml
@@ -34,6 +34,10 @@ spec:
         - "1"
         - -command
         - '{"command":"/usr/local/bin/machine-controller","args":["-kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","-logtostderr","-v","4","-cluster-dns","169.254.20.10","-internal-listen-address","0.0.0.0:8085"]}'
+        - -wait-for-crd-kind
+        - Machine
+        - -wait-for-crd-apiversion
+        - cluster.k8s.io/v1alpha1
         command:
         - /http-prober-bin/http-prober
         env:
@@ -45,6 +49,8 @@ spec:
           value: az-tenant-id
         - name: AZURE_SUBSCRIPTION_ID
           value: az-subscription-id
+        - name: KUBECONFIG
+          value: /etc/kubernetes/kubeconfig/kubeconfig
         image: docker.io/kubermatic/machine-controller:v1.5.6
         livenessProbe:
           failureThreshold: 3
@@ -77,7 +83,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.2
+        image: quay.io/kubermatic/http-prober:v0.3-dev3
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/api/pkg/resources/test/fixtures/deployment-azure-1.11.0-metrics-server.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-azure-1.11.0-metrics-server.yaml
@@ -152,7 +152,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.2
+        image: quay.io/kubermatic/http-prober:v0.3-dev3
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/api/pkg/resources/test/fixtures/deployment-azure-1.11.0-metrics-server.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-azure-1.11.0-metrics-server.yaml
@@ -152,7 +152,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3-dev3
+        image: quay.io/kubermatic/http-prober:v0.3
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/api/pkg/resources/test/fixtures/deployment-azure-1.11.0-scheduler.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-azure-1.11.0-scheduler.yaml
@@ -163,7 +163,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3-dev3
+        image: quay.io/kubermatic/http-prober:v0.3
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/api/pkg/resources/test/fixtures/deployment-azure-1.11.0-scheduler.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-azure-1.11.0-scheduler.yaml
@@ -163,7 +163,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.2
+        image: quay.io/kubermatic/http-prober:v0.3-dev3
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/api/pkg/resources/test/fixtures/deployment-azure-1.11.0-usercluster-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-azure-1.11.0-usercluster-controller.yaml
@@ -85,7 +85,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.2
+        image: quay.io/kubermatic/http-prober:v0.3-dev3
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/api/pkg/resources/test/fixtures/deployment-azure-1.11.0-usercluster-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-azure-1.11.0-usercluster-controller.yaml
@@ -85,7 +85,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3-dev3
+        image: quay.io/kubermatic/http-prober:v0.3
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/api/pkg/resources/test/fixtures/deployment-azure-1.11.1-controller-manager.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-azure-1.11.1-controller-manager.yaml
@@ -171,7 +171,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3-dev3
+        image: quay.io/kubermatic/http-prober:v0.3
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/api/pkg/resources/test/fixtures/deployment-azure-1.11.1-controller-manager.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-azure-1.11.1-controller-manager.yaml
@@ -171,7 +171,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.2
+        image: quay.io/kubermatic/http-prober:v0.3-dev3
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/api/pkg/resources/test/fixtures/deployment-azure-1.11.1-kube-state-metrics.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-azure-1.11.1-kube-state-metrics.yaml
@@ -72,7 +72,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3-dev3
+        image: quay.io/kubermatic/http-prober:v0.3
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/api/pkg/resources/test/fixtures/deployment-azure-1.11.1-kube-state-metrics.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-azure-1.11.1-kube-state-metrics.yaml
@@ -72,7 +72,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.2
+        image: quay.io/kubermatic/http-prober:v0.3-dev3
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/api/pkg/resources/test/fixtures/deployment-azure-1.11.1-machine-controller-webhook.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-azure-1.11.1-machine-controller-webhook.yaml
@@ -92,7 +92,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3-dev3
+        image: quay.io/kubermatic/http-prober:v0.3
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/api/pkg/resources/test/fixtures/deployment-azure-1.11.1-machine-controller-webhook.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-azure-1.11.1-machine-controller-webhook.yaml
@@ -31,6 +31,10 @@ spec:
         - "1"
         - -command
         - '{"command":"/usr/local/bin/webhook","args":["-kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","-logtostderr","-v","4","-listen-address","0.0.0.0:9876"]}'
+        - -wait-for-crd-kind
+        - Machine
+        - -wait-for-crd-apiversion
+        - cluster.k8s.io/v1alpha1
         command:
         - /http-prober-bin/http-prober
         env:
@@ -42,6 +46,8 @@ spec:
           value: az-tenant-id
         - name: AZURE_SUBSCRIPTION_ID
           value: az-subscription-id
+        - name: KUBECONFIG
+          value: /etc/kubernetes/kubeconfig/kubeconfig
         image: docker.io/kubermatic/machine-controller:v1.5.6
         livenessProbe:
           failureThreshold: 8
@@ -86,7 +92,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.2
+        image: quay.io/kubermatic/http-prober:v0.3-dev3
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/api/pkg/resources/test/fixtures/deployment-azure-1.11.1-machine-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-azure-1.11.1-machine-controller.yaml
@@ -83,7 +83,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3-dev3
+        image: quay.io/kubermatic/http-prober:v0.3
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/api/pkg/resources/test/fixtures/deployment-azure-1.11.1-machine-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-azure-1.11.1-machine-controller.yaml
@@ -34,6 +34,10 @@ spec:
         - "1"
         - -command
         - '{"command":"/usr/local/bin/machine-controller","args":["-kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","-logtostderr","-v","4","-cluster-dns","169.254.20.10","-internal-listen-address","0.0.0.0:8085"]}'
+        - -wait-for-crd-kind
+        - Machine
+        - -wait-for-crd-apiversion
+        - cluster.k8s.io/v1alpha1
         command:
         - /http-prober-bin/http-prober
         env:
@@ -45,6 +49,8 @@ spec:
           value: az-tenant-id
         - name: AZURE_SUBSCRIPTION_ID
           value: az-subscription-id
+        - name: KUBECONFIG
+          value: /etc/kubernetes/kubeconfig/kubeconfig
         image: docker.io/kubermatic/machine-controller:v1.5.6
         livenessProbe:
           failureThreshold: 3
@@ -77,7 +83,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.2
+        image: quay.io/kubermatic/http-prober:v0.3-dev3
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/api/pkg/resources/test/fixtures/deployment-azure-1.11.1-metrics-server.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-azure-1.11.1-metrics-server.yaml
@@ -152,7 +152,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.2
+        image: quay.io/kubermatic/http-prober:v0.3-dev3
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/api/pkg/resources/test/fixtures/deployment-azure-1.11.1-metrics-server.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-azure-1.11.1-metrics-server.yaml
@@ -152,7 +152,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3-dev3
+        image: quay.io/kubermatic/http-prober:v0.3
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/api/pkg/resources/test/fixtures/deployment-azure-1.11.1-scheduler.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-azure-1.11.1-scheduler.yaml
@@ -163,7 +163,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3-dev3
+        image: quay.io/kubermatic/http-prober:v0.3
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/api/pkg/resources/test/fixtures/deployment-azure-1.11.1-scheduler.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-azure-1.11.1-scheduler.yaml
@@ -163,7 +163,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.2
+        image: quay.io/kubermatic/http-prober:v0.3-dev3
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/api/pkg/resources/test/fixtures/deployment-azure-1.11.1-usercluster-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-azure-1.11.1-usercluster-controller.yaml
@@ -85,7 +85,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.2
+        image: quay.io/kubermatic/http-prober:v0.3-dev3
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/api/pkg/resources/test/fixtures/deployment-azure-1.11.1-usercluster-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-azure-1.11.1-usercluster-controller.yaml
@@ -85,7 +85,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3-dev3
+        image: quay.io/kubermatic/http-prober:v0.3
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/api/pkg/resources/test/fixtures/deployment-azure-1.12.0-controller-manager.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-azure-1.12.0-controller-manager.yaml
@@ -171,7 +171,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3-dev3
+        image: quay.io/kubermatic/http-prober:v0.3
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/api/pkg/resources/test/fixtures/deployment-azure-1.12.0-controller-manager.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-azure-1.12.0-controller-manager.yaml
@@ -171,7 +171,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.2
+        image: quay.io/kubermatic/http-prober:v0.3-dev3
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/api/pkg/resources/test/fixtures/deployment-azure-1.12.0-kube-state-metrics.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-azure-1.12.0-kube-state-metrics.yaml
@@ -72,7 +72,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3-dev3
+        image: quay.io/kubermatic/http-prober:v0.3
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/api/pkg/resources/test/fixtures/deployment-azure-1.12.0-kube-state-metrics.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-azure-1.12.0-kube-state-metrics.yaml
@@ -72,7 +72,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.2
+        image: quay.io/kubermatic/http-prober:v0.3-dev3
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/api/pkg/resources/test/fixtures/deployment-azure-1.12.0-machine-controller-webhook.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-azure-1.12.0-machine-controller-webhook.yaml
@@ -92,7 +92,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3-dev3
+        image: quay.io/kubermatic/http-prober:v0.3
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/api/pkg/resources/test/fixtures/deployment-azure-1.12.0-machine-controller-webhook.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-azure-1.12.0-machine-controller-webhook.yaml
@@ -31,6 +31,10 @@ spec:
         - "1"
         - -command
         - '{"command":"/usr/local/bin/webhook","args":["-kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","-logtostderr","-v","4","-listen-address","0.0.0.0:9876"]}'
+        - -wait-for-crd-kind
+        - Machine
+        - -wait-for-crd-apiversion
+        - cluster.k8s.io/v1alpha1
         command:
         - /http-prober-bin/http-prober
         env:
@@ -42,6 +46,8 @@ spec:
           value: az-tenant-id
         - name: AZURE_SUBSCRIPTION_ID
           value: az-subscription-id
+        - name: KUBECONFIG
+          value: /etc/kubernetes/kubeconfig/kubeconfig
         image: docker.io/kubermatic/machine-controller:v1.5.6
         livenessProbe:
           failureThreshold: 8
@@ -86,7 +92,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.2
+        image: quay.io/kubermatic/http-prober:v0.3-dev3
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/api/pkg/resources/test/fixtures/deployment-azure-1.12.0-machine-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-azure-1.12.0-machine-controller.yaml
@@ -83,7 +83,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3-dev3
+        image: quay.io/kubermatic/http-prober:v0.3
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/api/pkg/resources/test/fixtures/deployment-azure-1.12.0-machine-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-azure-1.12.0-machine-controller.yaml
@@ -34,6 +34,10 @@ spec:
         - "1"
         - -command
         - '{"command":"/usr/local/bin/machine-controller","args":["-kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","-logtostderr","-v","4","-cluster-dns","169.254.20.10","-internal-listen-address","0.0.0.0:8085"]}'
+        - -wait-for-crd-kind
+        - Machine
+        - -wait-for-crd-apiversion
+        - cluster.k8s.io/v1alpha1
         command:
         - /http-prober-bin/http-prober
         env:
@@ -45,6 +49,8 @@ spec:
           value: az-tenant-id
         - name: AZURE_SUBSCRIPTION_ID
           value: az-subscription-id
+        - name: KUBECONFIG
+          value: /etc/kubernetes/kubeconfig/kubeconfig
         image: docker.io/kubermatic/machine-controller:v1.5.6
         livenessProbe:
           failureThreshold: 3
@@ -77,7 +83,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.2
+        image: quay.io/kubermatic/http-prober:v0.3-dev3
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/api/pkg/resources/test/fixtures/deployment-azure-1.12.0-metrics-server.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-azure-1.12.0-metrics-server.yaml
@@ -152,7 +152,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.2
+        image: quay.io/kubermatic/http-prober:v0.3-dev3
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/api/pkg/resources/test/fixtures/deployment-azure-1.12.0-metrics-server.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-azure-1.12.0-metrics-server.yaml
@@ -152,7 +152,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3-dev3
+        image: quay.io/kubermatic/http-prober:v0.3
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/api/pkg/resources/test/fixtures/deployment-azure-1.12.0-scheduler.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-azure-1.12.0-scheduler.yaml
@@ -163,7 +163,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3-dev3
+        image: quay.io/kubermatic/http-prober:v0.3
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/api/pkg/resources/test/fixtures/deployment-azure-1.12.0-scheduler.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-azure-1.12.0-scheduler.yaml
@@ -163,7 +163,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.2
+        image: quay.io/kubermatic/http-prober:v0.3-dev3
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/api/pkg/resources/test/fixtures/deployment-azure-1.12.0-usercluster-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-azure-1.12.0-usercluster-controller.yaml
@@ -85,7 +85,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.2
+        image: quay.io/kubermatic/http-prober:v0.3-dev3
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/api/pkg/resources/test/fixtures/deployment-azure-1.12.0-usercluster-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-azure-1.12.0-usercluster-controller.yaml
@@ -85,7 +85,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3-dev3
+        image: quay.io/kubermatic/http-prober:v0.3
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/api/pkg/resources/test/fixtures/deployment-azure-1.13.0-controller-manager.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-azure-1.13.0-controller-manager.yaml
@@ -171,7 +171,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3-dev3
+        image: quay.io/kubermatic/http-prober:v0.3
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/api/pkg/resources/test/fixtures/deployment-azure-1.13.0-controller-manager.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-azure-1.13.0-controller-manager.yaml
@@ -171,7 +171,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.2
+        image: quay.io/kubermatic/http-prober:v0.3-dev3
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/api/pkg/resources/test/fixtures/deployment-azure-1.13.0-kube-state-metrics.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-azure-1.13.0-kube-state-metrics.yaml
@@ -72,7 +72,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3-dev3
+        image: quay.io/kubermatic/http-prober:v0.3
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/api/pkg/resources/test/fixtures/deployment-azure-1.13.0-kube-state-metrics.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-azure-1.13.0-kube-state-metrics.yaml
@@ -72,7 +72,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.2
+        image: quay.io/kubermatic/http-prober:v0.3-dev3
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/api/pkg/resources/test/fixtures/deployment-azure-1.13.0-machine-controller-webhook.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-azure-1.13.0-machine-controller-webhook.yaml
@@ -92,7 +92,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3-dev3
+        image: quay.io/kubermatic/http-prober:v0.3
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/api/pkg/resources/test/fixtures/deployment-azure-1.13.0-machine-controller-webhook.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-azure-1.13.0-machine-controller-webhook.yaml
@@ -31,6 +31,10 @@ spec:
         - "1"
         - -command
         - '{"command":"/usr/local/bin/webhook","args":["-kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","-logtostderr","-v","4","-listen-address","0.0.0.0:9876"]}'
+        - -wait-for-crd-kind
+        - Machine
+        - -wait-for-crd-apiversion
+        - cluster.k8s.io/v1alpha1
         command:
         - /http-prober-bin/http-prober
         env:
@@ -42,6 +46,8 @@ spec:
           value: az-tenant-id
         - name: AZURE_SUBSCRIPTION_ID
           value: az-subscription-id
+        - name: KUBECONFIG
+          value: /etc/kubernetes/kubeconfig/kubeconfig
         image: docker.io/kubermatic/machine-controller:v1.5.6
         livenessProbe:
           failureThreshold: 8
@@ -86,7 +92,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.2
+        image: quay.io/kubermatic/http-prober:v0.3-dev3
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/api/pkg/resources/test/fixtures/deployment-azure-1.13.0-machine-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-azure-1.13.0-machine-controller.yaml
@@ -83,7 +83,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3-dev3
+        image: quay.io/kubermatic/http-prober:v0.3
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/api/pkg/resources/test/fixtures/deployment-azure-1.13.0-machine-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-azure-1.13.0-machine-controller.yaml
@@ -34,6 +34,10 @@ spec:
         - "1"
         - -command
         - '{"command":"/usr/local/bin/machine-controller","args":["-kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","-logtostderr","-v","4","-cluster-dns","169.254.20.10","-internal-listen-address","0.0.0.0:8085"]}'
+        - -wait-for-crd-kind
+        - Machine
+        - -wait-for-crd-apiversion
+        - cluster.k8s.io/v1alpha1
         command:
         - /http-prober-bin/http-prober
         env:
@@ -45,6 +49,8 @@ spec:
           value: az-tenant-id
         - name: AZURE_SUBSCRIPTION_ID
           value: az-subscription-id
+        - name: KUBECONFIG
+          value: /etc/kubernetes/kubeconfig/kubeconfig
         image: docker.io/kubermatic/machine-controller:v1.5.6
         livenessProbe:
           failureThreshold: 3
@@ -77,7 +83,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.2
+        image: quay.io/kubermatic/http-prober:v0.3-dev3
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/api/pkg/resources/test/fixtures/deployment-azure-1.13.0-metrics-server.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-azure-1.13.0-metrics-server.yaml
@@ -152,7 +152,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.2
+        image: quay.io/kubermatic/http-prober:v0.3-dev3
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/api/pkg/resources/test/fixtures/deployment-azure-1.13.0-metrics-server.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-azure-1.13.0-metrics-server.yaml
@@ -152,7 +152,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3-dev3
+        image: quay.io/kubermatic/http-prober:v0.3
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/api/pkg/resources/test/fixtures/deployment-azure-1.13.0-scheduler.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-azure-1.13.0-scheduler.yaml
@@ -163,7 +163,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3-dev3
+        image: quay.io/kubermatic/http-prober:v0.3
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/api/pkg/resources/test/fixtures/deployment-azure-1.13.0-scheduler.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-azure-1.13.0-scheduler.yaml
@@ -163,7 +163,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.2
+        image: quay.io/kubermatic/http-prober:v0.3-dev3
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/api/pkg/resources/test/fixtures/deployment-azure-1.13.0-usercluster-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-azure-1.13.0-usercluster-controller.yaml
@@ -85,7 +85,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.2
+        image: quay.io/kubermatic/http-prober:v0.3-dev3
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/api/pkg/resources/test/fixtures/deployment-azure-1.13.0-usercluster-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-azure-1.13.0-usercluster-controller.yaml
@@ -85,7 +85,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3-dev3
+        image: quay.io/kubermatic/http-prober:v0.3
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/api/pkg/resources/test/fixtures/deployment-bringyourown-1.10.0-controller-manager.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-bringyourown-1.10.0-controller-manager.yaml
@@ -171,7 +171,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3-dev3
+        image: quay.io/kubermatic/http-prober:v0.3
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/api/pkg/resources/test/fixtures/deployment-bringyourown-1.10.0-controller-manager.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-bringyourown-1.10.0-controller-manager.yaml
@@ -171,7 +171,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.2
+        image: quay.io/kubermatic/http-prober:v0.3-dev3
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/api/pkg/resources/test/fixtures/deployment-bringyourown-1.10.0-kube-state-metrics.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-bringyourown-1.10.0-kube-state-metrics.yaml
@@ -72,7 +72,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3-dev3
+        image: quay.io/kubermatic/http-prober:v0.3
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/api/pkg/resources/test/fixtures/deployment-bringyourown-1.10.0-kube-state-metrics.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-bringyourown-1.10.0-kube-state-metrics.yaml
@@ -72,7 +72,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.2
+        image: quay.io/kubermatic/http-prober:v0.3-dev3
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/api/pkg/resources/test/fixtures/deployment-bringyourown-1.10.0-machine-controller-webhook.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-bringyourown-1.10.0-machine-controller-webhook.yaml
@@ -31,8 +31,15 @@ spec:
         - "1"
         - -command
         - '{"command":"/usr/local/bin/webhook","args":["-kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","-logtostderr","-v","4","-listen-address","0.0.0.0:9876"]}'
+        - -wait-for-crd-kind
+        - Machine
+        - -wait-for-crd-apiversion
+        - cluster.k8s.io/v1alpha1
         command:
         - /http-prober-bin/http-prober
+        env:
+        - name: KUBECONFIG
+          value: /etc/kubernetes/kubeconfig/kubeconfig
         image: docker.io/kubermatic/machine-controller:v1.5.6
         livenessProbe:
           failureThreshold: 8
@@ -77,7 +84,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.2
+        image: quay.io/kubermatic/http-prober:v0.3-dev3
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/api/pkg/resources/test/fixtures/deployment-bringyourown-1.10.0-machine-controller-webhook.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-bringyourown-1.10.0-machine-controller-webhook.yaml
@@ -84,7 +84,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3-dev3
+        image: quay.io/kubermatic/http-prober:v0.3
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/api/pkg/resources/test/fixtures/deployment-bringyourown-1.10.0-machine-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-bringyourown-1.10.0-machine-controller.yaml
@@ -75,7 +75,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3-dev3
+        image: quay.io/kubermatic/http-prober:v0.3
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/api/pkg/resources/test/fixtures/deployment-bringyourown-1.10.0-machine-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-bringyourown-1.10.0-machine-controller.yaml
@@ -34,8 +34,15 @@ spec:
         - "1"
         - -command
         - '{"command":"/usr/local/bin/machine-controller","args":["-kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","-logtostderr","-v","4","-cluster-dns","169.254.20.10","-internal-listen-address","0.0.0.0:8085"]}'
+        - -wait-for-crd-kind
+        - Machine
+        - -wait-for-crd-apiversion
+        - cluster.k8s.io/v1alpha1
         command:
         - /http-prober-bin/http-prober
+        env:
+        - name: KUBECONFIG
+          value: /etc/kubernetes/kubeconfig/kubeconfig
         image: docker.io/kubermatic/machine-controller:v1.5.6
         livenessProbe:
           failureThreshold: 3
@@ -68,7 +75,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.2
+        image: quay.io/kubermatic/http-prober:v0.3-dev3
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/api/pkg/resources/test/fixtures/deployment-bringyourown-1.10.0-metrics-server.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-bringyourown-1.10.0-metrics-server.yaml
@@ -152,7 +152,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.2
+        image: quay.io/kubermatic/http-prober:v0.3-dev3
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/api/pkg/resources/test/fixtures/deployment-bringyourown-1.10.0-metrics-server.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-bringyourown-1.10.0-metrics-server.yaml
@@ -152,7 +152,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3-dev3
+        image: quay.io/kubermatic/http-prober:v0.3
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/api/pkg/resources/test/fixtures/deployment-bringyourown-1.10.0-scheduler.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-bringyourown-1.10.0-scheduler.yaml
@@ -163,7 +163,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3-dev3
+        image: quay.io/kubermatic/http-prober:v0.3
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/api/pkg/resources/test/fixtures/deployment-bringyourown-1.10.0-scheduler.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-bringyourown-1.10.0-scheduler.yaml
@@ -163,7 +163,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.2
+        image: quay.io/kubermatic/http-prober:v0.3-dev3
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/api/pkg/resources/test/fixtures/deployment-bringyourown-1.10.0-usercluster-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-bringyourown-1.10.0-usercluster-controller.yaml
@@ -85,7 +85,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.2
+        image: quay.io/kubermatic/http-prober:v0.3-dev3
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/api/pkg/resources/test/fixtures/deployment-bringyourown-1.10.0-usercluster-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-bringyourown-1.10.0-usercluster-controller.yaml
@@ -85,7 +85,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3-dev3
+        image: quay.io/kubermatic/http-prober:v0.3
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/api/pkg/resources/test/fixtures/deployment-bringyourown-1.10.6-controller-manager.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-bringyourown-1.10.6-controller-manager.yaml
@@ -171,7 +171,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3-dev3
+        image: quay.io/kubermatic/http-prober:v0.3
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/api/pkg/resources/test/fixtures/deployment-bringyourown-1.10.6-controller-manager.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-bringyourown-1.10.6-controller-manager.yaml
@@ -171,7 +171,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.2
+        image: quay.io/kubermatic/http-prober:v0.3-dev3
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/api/pkg/resources/test/fixtures/deployment-bringyourown-1.10.6-kube-state-metrics.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-bringyourown-1.10.6-kube-state-metrics.yaml
@@ -72,7 +72,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3-dev3
+        image: quay.io/kubermatic/http-prober:v0.3
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/api/pkg/resources/test/fixtures/deployment-bringyourown-1.10.6-kube-state-metrics.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-bringyourown-1.10.6-kube-state-metrics.yaml
@@ -72,7 +72,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.2
+        image: quay.io/kubermatic/http-prober:v0.3-dev3
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/api/pkg/resources/test/fixtures/deployment-bringyourown-1.10.6-machine-controller-webhook.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-bringyourown-1.10.6-machine-controller-webhook.yaml
@@ -31,8 +31,15 @@ spec:
         - "1"
         - -command
         - '{"command":"/usr/local/bin/webhook","args":["-kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","-logtostderr","-v","4","-listen-address","0.0.0.0:9876"]}'
+        - -wait-for-crd-kind
+        - Machine
+        - -wait-for-crd-apiversion
+        - cluster.k8s.io/v1alpha1
         command:
         - /http-prober-bin/http-prober
+        env:
+        - name: KUBECONFIG
+          value: /etc/kubernetes/kubeconfig/kubeconfig
         image: docker.io/kubermatic/machine-controller:v1.5.6
         livenessProbe:
           failureThreshold: 8
@@ -77,7 +84,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.2
+        image: quay.io/kubermatic/http-prober:v0.3-dev3
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/api/pkg/resources/test/fixtures/deployment-bringyourown-1.10.6-machine-controller-webhook.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-bringyourown-1.10.6-machine-controller-webhook.yaml
@@ -84,7 +84,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3-dev3
+        image: quay.io/kubermatic/http-prober:v0.3
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/api/pkg/resources/test/fixtures/deployment-bringyourown-1.10.6-machine-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-bringyourown-1.10.6-machine-controller.yaml
@@ -75,7 +75,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3-dev3
+        image: quay.io/kubermatic/http-prober:v0.3
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/api/pkg/resources/test/fixtures/deployment-bringyourown-1.10.6-machine-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-bringyourown-1.10.6-machine-controller.yaml
@@ -34,8 +34,15 @@ spec:
         - "1"
         - -command
         - '{"command":"/usr/local/bin/machine-controller","args":["-kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","-logtostderr","-v","4","-cluster-dns","169.254.20.10","-internal-listen-address","0.0.0.0:8085"]}'
+        - -wait-for-crd-kind
+        - Machine
+        - -wait-for-crd-apiversion
+        - cluster.k8s.io/v1alpha1
         command:
         - /http-prober-bin/http-prober
+        env:
+        - name: KUBECONFIG
+          value: /etc/kubernetes/kubeconfig/kubeconfig
         image: docker.io/kubermatic/machine-controller:v1.5.6
         livenessProbe:
           failureThreshold: 3
@@ -68,7 +75,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.2
+        image: quay.io/kubermatic/http-prober:v0.3-dev3
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/api/pkg/resources/test/fixtures/deployment-bringyourown-1.10.6-metrics-server.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-bringyourown-1.10.6-metrics-server.yaml
@@ -152,7 +152,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.2
+        image: quay.io/kubermatic/http-prober:v0.3-dev3
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/api/pkg/resources/test/fixtures/deployment-bringyourown-1.10.6-metrics-server.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-bringyourown-1.10.6-metrics-server.yaml
@@ -152,7 +152,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3-dev3
+        image: quay.io/kubermatic/http-prober:v0.3
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/api/pkg/resources/test/fixtures/deployment-bringyourown-1.10.6-scheduler.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-bringyourown-1.10.6-scheduler.yaml
@@ -163,7 +163,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3-dev3
+        image: quay.io/kubermatic/http-prober:v0.3
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/api/pkg/resources/test/fixtures/deployment-bringyourown-1.10.6-scheduler.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-bringyourown-1.10.6-scheduler.yaml
@@ -163,7 +163,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.2
+        image: quay.io/kubermatic/http-prober:v0.3-dev3
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/api/pkg/resources/test/fixtures/deployment-bringyourown-1.10.6-usercluster-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-bringyourown-1.10.6-usercluster-controller.yaml
@@ -85,7 +85,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.2
+        image: quay.io/kubermatic/http-prober:v0.3-dev3
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/api/pkg/resources/test/fixtures/deployment-bringyourown-1.10.6-usercluster-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-bringyourown-1.10.6-usercluster-controller.yaml
@@ -85,7 +85,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3-dev3
+        image: quay.io/kubermatic/http-prober:v0.3
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/api/pkg/resources/test/fixtures/deployment-bringyourown-1.11.0-controller-manager.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-bringyourown-1.11.0-controller-manager.yaml
@@ -171,7 +171,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3-dev3
+        image: quay.io/kubermatic/http-prober:v0.3
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/api/pkg/resources/test/fixtures/deployment-bringyourown-1.11.0-controller-manager.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-bringyourown-1.11.0-controller-manager.yaml
@@ -171,7 +171,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.2
+        image: quay.io/kubermatic/http-prober:v0.3-dev3
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/api/pkg/resources/test/fixtures/deployment-bringyourown-1.11.0-kube-state-metrics.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-bringyourown-1.11.0-kube-state-metrics.yaml
@@ -72,7 +72,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3-dev3
+        image: quay.io/kubermatic/http-prober:v0.3
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/api/pkg/resources/test/fixtures/deployment-bringyourown-1.11.0-kube-state-metrics.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-bringyourown-1.11.0-kube-state-metrics.yaml
@@ -72,7 +72,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.2
+        image: quay.io/kubermatic/http-prober:v0.3-dev3
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/api/pkg/resources/test/fixtures/deployment-bringyourown-1.11.0-machine-controller-webhook.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-bringyourown-1.11.0-machine-controller-webhook.yaml
@@ -31,8 +31,15 @@ spec:
         - "1"
         - -command
         - '{"command":"/usr/local/bin/webhook","args":["-kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","-logtostderr","-v","4","-listen-address","0.0.0.0:9876"]}'
+        - -wait-for-crd-kind
+        - Machine
+        - -wait-for-crd-apiversion
+        - cluster.k8s.io/v1alpha1
         command:
         - /http-prober-bin/http-prober
+        env:
+        - name: KUBECONFIG
+          value: /etc/kubernetes/kubeconfig/kubeconfig
         image: docker.io/kubermatic/machine-controller:v1.5.6
         livenessProbe:
           failureThreshold: 8
@@ -77,7 +84,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.2
+        image: quay.io/kubermatic/http-prober:v0.3-dev3
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/api/pkg/resources/test/fixtures/deployment-bringyourown-1.11.0-machine-controller-webhook.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-bringyourown-1.11.0-machine-controller-webhook.yaml
@@ -84,7 +84,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3-dev3
+        image: quay.io/kubermatic/http-prober:v0.3
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/api/pkg/resources/test/fixtures/deployment-bringyourown-1.11.0-machine-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-bringyourown-1.11.0-machine-controller.yaml
@@ -75,7 +75,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3-dev3
+        image: quay.io/kubermatic/http-prober:v0.3
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/api/pkg/resources/test/fixtures/deployment-bringyourown-1.11.0-machine-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-bringyourown-1.11.0-machine-controller.yaml
@@ -34,8 +34,15 @@ spec:
         - "1"
         - -command
         - '{"command":"/usr/local/bin/machine-controller","args":["-kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","-logtostderr","-v","4","-cluster-dns","169.254.20.10","-internal-listen-address","0.0.0.0:8085"]}'
+        - -wait-for-crd-kind
+        - Machine
+        - -wait-for-crd-apiversion
+        - cluster.k8s.io/v1alpha1
         command:
         - /http-prober-bin/http-prober
+        env:
+        - name: KUBECONFIG
+          value: /etc/kubernetes/kubeconfig/kubeconfig
         image: docker.io/kubermatic/machine-controller:v1.5.6
         livenessProbe:
           failureThreshold: 3
@@ -68,7 +75,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.2
+        image: quay.io/kubermatic/http-prober:v0.3-dev3
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/api/pkg/resources/test/fixtures/deployment-bringyourown-1.11.0-metrics-server.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-bringyourown-1.11.0-metrics-server.yaml
@@ -152,7 +152,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.2
+        image: quay.io/kubermatic/http-prober:v0.3-dev3
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/api/pkg/resources/test/fixtures/deployment-bringyourown-1.11.0-metrics-server.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-bringyourown-1.11.0-metrics-server.yaml
@@ -152,7 +152,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3-dev3
+        image: quay.io/kubermatic/http-prober:v0.3
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/api/pkg/resources/test/fixtures/deployment-bringyourown-1.11.0-scheduler.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-bringyourown-1.11.0-scheduler.yaml
@@ -163,7 +163,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3-dev3
+        image: quay.io/kubermatic/http-prober:v0.3
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/api/pkg/resources/test/fixtures/deployment-bringyourown-1.11.0-scheduler.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-bringyourown-1.11.0-scheduler.yaml
@@ -163,7 +163,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.2
+        image: quay.io/kubermatic/http-prober:v0.3-dev3
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/api/pkg/resources/test/fixtures/deployment-bringyourown-1.11.0-usercluster-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-bringyourown-1.11.0-usercluster-controller.yaml
@@ -85,7 +85,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.2
+        image: quay.io/kubermatic/http-prober:v0.3-dev3
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/api/pkg/resources/test/fixtures/deployment-bringyourown-1.11.0-usercluster-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-bringyourown-1.11.0-usercluster-controller.yaml
@@ -85,7 +85,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3-dev3
+        image: quay.io/kubermatic/http-prober:v0.3
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/api/pkg/resources/test/fixtures/deployment-bringyourown-1.11.1-controller-manager.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-bringyourown-1.11.1-controller-manager.yaml
@@ -171,7 +171,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3-dev3
+        image: quay.io/kubermatic/http-prober:v0.3
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/api/pkg/resources/test/fixtures/deployment-bringyourown-1.11.1-controller-manager.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-bringyourown-1.11.1-controller-manager.yaml
@@ -171,7 +171,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.2
+        image: quay.io/kubermatic/http-prober:v0.3-dev3
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/api/pkg/resources/test/fixtures/deployment-bringyourown-1.11.1-kube-state-metrics.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-bringyourown-1.11.1-kube-state-metrics.yaml
@@ -72,7 +72,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3-dev3
+        image: quay.io/kubermatic/http-prober:v0.3
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/api/pkg/resources/test/fixtures/deployment-bringyourown-1.11.1-kube-state-metrics.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-bringyourown-1.11.1-kube-state-metrics.yaml
@@ -72,7 +72,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.2
+        image: quay.io/kubermatic/http-prober:v0.3-dev3
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/api/pkg/resources/test/fixtures/deployment-bringyourown-1.11.1-machine-controller-webhook.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-bringyourown-1.11.1-machine-controller-webhook.yaml
@@ -31,8 +31,15 @@ spec:
         - "1"
         - -command
         - '{"command":"/usr/local/bin/webhook","args":["-kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","-logtostderr","-v","4","-listen-address","0.0.0.0:9876"]}'
+        - -wait-for-crd-kind
+        - Machine
+        - -wait-for-crd-apiversion
+        - cluster.k8s.io/v1alpha1
         command:
         - /http-prober-bin/http-prober
+        env:
+        - name: KUBECONFIG
+          value: /etc/kubernetes/kubeconfig/kubeconfig
         image: docker.io/kubermatic/machine-controller:v1.5.6
         livenessProbe:
           failureThreshold: 8
@@ -77,7 +84,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.2
+        image: quay.io/kubermatic/http-prober:v0.3-dev3
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/api/pkg/resources/test/fixtures/deployment-bringyourown-1.11.1-machine-controller-webhook.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-bringyourown-1.11.1-machine-controller-webhook.yaml
@@ -84,7 +84,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3-dev3
+        image: quay.io/kubermatic/http-prober:v0.3
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/api/pkg/resources/test/fixtures/deployment-bringyourown-1.11.1-machine-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-bringyourown-1.11.1-machine-controller.yaml
@@ -75,7 +75,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3-dev3
+        image: quay.io/kubermatic/http-prober:v0.3
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/api/pkg/resources/test/fixtures/deployment-bringyourown-1.11.1-machine-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-bringyourown-1.11.1-machine-controller.yaml
@@ -34,8 +34,15 @@ spec:
         - "1"
         - -command
         - '{"command":"/usr/local/bin/machine-controller","args":["-kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","-logtostderr","-v","4","-cluster-dns","169.254.20.10","-internal-listen-address","0.0.0.0:8085"]}'
+        - -wait-for-crd-kind
+        - Machine
+        - -wait-for-crd-apiversion
+        - cluster.k8s.io/v1alpha1
         command:
         - /http-prober-bin/http-prober
+        env:
+        - name: KUBECONFIG
+          value: /etc/kubernetes/kubeconfig/kubeconfig
         image: docker.io/kubermatic/machine-controller:v1.5.6
         livenessProbe:
           failureThreshold: 3
@@ -68,7 +75,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.2
+        image: quay.io/kubermatic/http-prober:v0.3-dev3
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/api/pkg/resources/test/fixtures/deployment-bringyourown-1.11.1-metrics-server.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-bringyourown-1.11.1-metrics-server.yaml
@@ -152,7 +152,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.2
+        image: quay.io/kubermatic/http-prober:v0.3-dev3
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/api/pkg/resources/test/fixtures/deployment-bringyourown-1.11.1-metrics-server.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-bringyourown-1.11.1-metrics-server.yaml
@@ -152,7 +152,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3-dev3
+        image: quay.io/kubermatic/http-prober:v0.3
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/api/pkg/resources/test/fixtures/deployment-bringyourown-1.11.1-scheduler.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-bringyourown-1.11.1-scheduler.yaml
@@ -163,7 +163,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3-dev3
+        image: quay.io/kubermatic/http-prober:v0.3
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/api/pkg/resources/test/fixtures/deployment-bringyourown-1.11.1-scheduler.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-bringyourown-1.11.1-scheduler.yaml
@@ -163,7 +163,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.2
+        image: quay.io/kubermatic/http-prober:v0.3-dev3
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/api/pkg/resources/test/fixtures/deployment-bringyourown-1.11.1-usercluster-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-bringyourown-1.11.1-usercluster-controller.yaml
@@ -85,7 +85,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.2
+        image: quay.io/kubermatic/http-prober:v0.3-dev3
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/api/pkg/resources/test/fixtures/deployment-bringyourown-1.11.1-usercluster-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-bringyourown-1.11.1-usercluster-controller.yaml
@@ -85,7 +85,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3-dev3
+        image: quay.io/kubermatic/http-prober:v0.3
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/api/pkg/resources/test/fixtures/deployment-bringyourown-1.12.0-controller-manager.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-bringyourown-1.12.0-controller-manager.yaml
@@ -171,7 +171,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3-dev3
+        image: quay.io/kubermatic/http-prober:v0.3
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/api/pkg/resources/test/fixtures/deployment-bringyourown-1.12.0-controller-manager.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-bringyourown-1.12.0-controller-manager.yaml
@@ -171,7 +171,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.2
+        image: quay.io/kubermatic/http-prober:v0.3-dev3
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/api/pkg/resources/test/fixtures/deployment-bringyourown-1.12.0-kube-state-metrics.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-bringyourown-1.12.0-kube-state-metrics.yaml
@@ -72,7 +72,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3-dev3
+        image: quay.io/kubermatic/http-prober:v0.3
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/api/pkg/resources/test/fixtures/deployment-bringyourown-1.12.0-kube-state-metrics.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-bringyourown-1.12.0-kube-state-metrics.yaml
@@ -72,7 +72,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.2
+        image: quay.io/kubermatic/http-prober:v0.3-dev3
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/api/pkg/resources/test/fixtures/deployment-bringyourown-1.12.0-machine-controller-webhook.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-bringyourown-1.12.0-machine-controller-webhook.yaml
@@ -31,8 +31,15 @@ spec:
         - "1"
         - -command
         - '{"command":"/usr/local/bin/webhook","args":["-kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","-logtostderr","-v","4","-listen-address","0.0.0.0:9876"]}'
+        - -wait-for-crd-kind
+        - Machine
+        - -wait-for-crd-apiversion
+        - cluster.k8s.io/v1alpha1
         command:
         - /http-prober-bin/http-prober
+        env:
+        - name: KUBECONFIG
+          value: /etc/kubernetes/kubeconfig/kubeconfig
         image: docker.io/kubermatic/machine-controller:v1.5.6
         livenessProbe:
           failureThreshold: 8
@@ -77,7 +84,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.2
+        image: quay.io/kubermatic/http-prober:v0.3-dev3
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/api/pkg/resources/test/fixtures/deployment-bringyourown-1.12.0-machine-controller-webhook.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-bringyourown-1.12.0-machine-controller-webhook.yaml
@@ -84,7 +84,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3-dev3
+        image: quay.io/kubermatic/http-prober:v0.3
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/api/pkg/resources/test/fixtures/deployment-bringyourown-1.12.0-machine-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-bringyourown-1.12.0-machine-controller.yaml
@@ -75,7 +75,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3-dev3
+        image: quay.io/kubermatic/http-prober:v0.3
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/api/pkg/resources/test/fixtures/deployment-bringyourown-1.12.0-machine-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-bringyourown-1.12.0-machine-controller.yaml
@@ -34,8 +34,15 @@ spec:
         - "1"
         - -command
         - '{"command":"/usr/local/bin/machine-controller","args":["-kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","-logtostderr","-v","4","-cluster-dns","169.254.20.10","-internal-listen-address","0.0.0.0:8085"]}'
+        - -wait-for-crd-kind
+        - Machine
+        - -wait-for-crd-apiversion
+        - cluster.k8s.io/v1alpha1
         command:
         - /http-prober-bin/http-prober
+        env:
+        - name: KUBECONFIG
+          value: /etc/kubernetes/kubeconfig/kubeconfig
         image: docker.io/kubermatic/machine-controller:v1.5.6
         livenessProbe:
           failureThreshold: 3
@@ -68,7 +75,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.2
+        image: quay.io/kubermatic/http-prober:v0.3-dev3
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/api/pkg/resources/test/fixtures/deployment-bringyourown-1.12.0-metrics-server.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-bringyourown-1.12.0-metrics-server.yaml
@@ -152,7 +152,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.2
+        image: quay.io/kubermatic/http-prober:v0.3-dev3
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/api/pkg/resources/test/fixtures/deployment-bringyourown-1.12.0-metrics-server.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-bringyourown-1.12.0-metrics-server.yaml
@@ -152,7 +152,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3-dev3
+        image: quay.io/kubermatic/http-prober:v0.3
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/api/pkg/resources/test/fixtures/deployment-bringyourown-1.12.0-scheduler.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-bringyourown-1.12.0-scheduler.yaml
@@ -163,7 +163,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3-dev3
+        image: quay.io/kubermatic/http-prober:v0.3
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/api/pkg/resources/test/fixtures/deployment-bringyourown-1.12.0-scheduler.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-bringyourown-1.12.0-scheduler.yaml
@@ -163,7 +163,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.2
+        image: quay.io/kubermatic/http-prober:v0.3-dev3
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/api/pkg/resources/test/fixtures/deployment-bringyourown-1.12.0-usercluster-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-bringyourown-1.12.0-usercluster-controller.yaml
@@ -85,7 +85,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.2
+        image: quay.io/kubermatic/http-prober:v0.3-dev3
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/api/pkg/resources/test/fixtures/deployment-bringyourown-1.12.0-usercluster-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-bringyourown-1.12.0-usercluster-controller.yaml
@@ -85,7 +85,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3-dev3
+        image: quay.io/kubermatic/http-prober:v0.3
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/api/pkg/resources/test/fixtures/deployment-bringyourown-1.13.0-controller-manager.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-bringyourown-1.13.0-controller-manager.yaml
@@ -171,7 +171,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3-dev3
+        image: quay.io/kubermatic/http-prober:v0.3
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/api/pkg/resources/test/fixtures/deployment-bringyourown-1.13.0-controller-manager.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-bringyourown-1.13.0-controller-manager.yaml
@@ -171,7 +171,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.2
+        image: quay.io/kubermatic/http-prober:v0.3-dev3
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/api/pkg/resources/test/fixtures/deployment-bringyourown-1.13.0-kube-state-metrics.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-bringyourown-1.13.0-kube-state-metrics.yaml
@@ -72,7 +72,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3-dev3
+        image: quay.io/kubermatic/http-prober:v0.3
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/api/pkg/resources/test/fixtures/deployment-bringyourown-1.13.0-kube-state-metrics.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-bringyourown-1.13.0-kube-state-metrics.yaml
@@ -72,7 +72,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.2
+        image: quay.io/kubermatic/http-prober:v0.3-dev3
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/api/pkg/resources/test/fixtures/deployment-bringyourown-1.13.0-machine-controller-webhook.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-bringyourown-1.13.0-machine-controller-webhook.yaml
@@ -31,8 +31,15 @@ spec:
         - "1"
         - -command
         - '{"command":"/usr/local/bin/webhook","args":["-kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","-logtostderr","-v","4","-listen-address","0.0.0.0:9876"]}'
+        - -wait-for-crd-kind
+        - Machine
+        - -wait-for-crd-apiversion
+        - cluster.k8s.io/v1alpha1
         command:
         - /http-prober-bin/http-prober
+        env:
+        - name: KUBECONFIG
+          value: /etc/kubernetes/kubeconfig/kubeconfig
         image: docker.io/kubermatic/machine-controller:v1.5.6
         livenessProbe:
           failureThreshold: 8
@@ -77,7 +84,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.2
+        image: quay.io/kubermatic/http-prober:v0.3-dev3
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/api/pkg/resources/test/fixtures/deployment-bringyourown-1.13.0-machine-controller-webhook.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-bringyourown-1.13.0-machine-controller-webhook.yaml
@@ -84,7 +84,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3-dev3
+        image: quay.io/kubermatic/http-prober:v0.3
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/api/pkg/resources/test/fixtures/deployment-bringyourown-1.13.0-machine-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-bringyourown-1.13.0-machine-controller.yaml
@@ -75,7 +75,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3-dev3
+        image: quay.io/kubermatic/http-prober:v0.3
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/api/pkg/resources/test/fixtures/deployment-bringyourown-1.13.0-machine-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-bringyourown-1.13.0-machine-controller.yaml
@@ -34,8 +34,15 @@ spec:
         - "1"
         - -command
         - '{"command":"/usr/local/bin/machine-controller","args":["-kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","-logtostderr","-v","4","-cluster-dns","169.254.20.10","-internal-listen-address","0.0.0.0:8085"]}'
+        - -wait-for-crd-kind
+        - Machine
+        - -wait-for-crd-apiversion
+        - cluster.k8s.io/v1alpha1
         command:
         - /http-prober-bin/http-prober
+        env:
+        - name: KUBECONFIG
+          value: /etc/kubernetes/kubeconfig/kubeconfig
         image: docker.io/kubermatic/machine-controller:v1.5.6
         livenessProbe:
           failureThreshold: 3
@@ -68,7 +75,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.2
+        image: quay.io/kubermatic/http-prober:v0.3-dev3
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/api/pkg/resources/test/fixtures/deployment-bringyourown-1.13.0-metrics-server.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-bringyourown-1.13.0-metrics-server.yaml
@@ -152,7 +152,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.2
+        image: quay.io/kubermatic/http-prober:v0.3-dev3
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/api/pkg/resources/test/fixtures/deployment-bringyourown-1.13.0-metrics-server.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-bringyourown-1.13.0-metrics-server.yaml
@@ -152,7 +152,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3-dev3
+        image: quay.io/kubermatic/http-prober:v0.3
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/api/pkg/resources/test/fixtures/deployment-bringyourown-1.13.0-scheduler.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-bringyourown-1.13.0-scheduler.yaml
@@ -163,7 +163,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3-dev3
+        image: quay.io/kubermatic/http-prober:v0.3
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/api/pkg/resources/test/fixtures/deployment-bringyourown-1.13.0-scheduler.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-bringyourown-1.13.0-scheduler.yaml
@@ -163,7 +163,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.2
+        image: quay.io/kubermatic/http-prober:v0.3-dev3
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/api/pkg/resources/test/fixtures/deployment-bringyourown-1.13.0-usercluster-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-bringyourown-1.13.0-usercluster-controller.yaml
@@ -85,7 +85,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.2
+        image: quay.io/kubermatic/http-prober:v0.3-dev3
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/api/pkg/resources/test/fixtures/deployment-bringyourown-1.13.0-usercluster-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-bringyourown-1.13.0-usercluster-controller.yaml
@@ -85,7 +85,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3-dev3
+        image: quay.io/kubermatic/http-prober:v0.3
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/api/pkg/resources/test/fixtures/deployment-digitalocean-1.10.0-controller-manager.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-digitalocean-1.10.0-controller-manager.yaml
@@ -171,7 +171,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3-dev3
+        image: quay.io/kubermatic/http-prober:v0.3
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/api/pkg/resources/test/fixtures/deployment-digitalocean-1.10.0-controller-manager.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-digitalocean-1.10.0-controller-manager.yaml
@@ -171,7 +171,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.2
+        image: quay.io/kubermatic/http-prober:v0.3-dev3
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/api/pkg/resources/test/fixtures/deployment-digitalocean-1.10.0-kube-state-metrics.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-digitalocean-1.10.0-kube-state-metrics.yaml
@@ -72,7 +72,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3-dev3
+        image: quay.io/kubermatic/http-prober:v0.3
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/api/pkg/resources/test/fixtures/deployment-digitalocean-1.10.0-kube-state-metrics.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-digitalocean-1.10.0-kube-state-metrics.yaml
@@ -72,7 +72,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.2
+        image: quay.io/kubermatic/http-prober:v0.3-dev3
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/api/pkg/resources/test/fixtures/deployment-digitalocean-1.10.0-machine-controller-webhook.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-digitalocean-1.10.0-machine-controller-webhook.yaml
@@ -31,11 +31,17 @@ spec:
         - "1"
         - -command
         - '{"command":"/usr/local/bin/webhook","args":["-kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","-logtostderr","-v","4","-listen-address","0.0.0.0:9876"]}'
+        - -wait-for-crd-kind
+        - Machine
+        - -wait-for-crd-apiversion
+        - cluster.k8s.io/v1alpha1
         command:
         - /http-prober-bin/http-prober
         env:
         - name: DO_TOKEN
           value: do-token
+        - name: KUBECONFIG
+          value: /etc/kubernetes/kubeconfig/kubeconfig
         image: docker.io/kubermatic/machine-controller:v1.5.6
         livenessProbe:
           failureThreshold: 8
@@ -80,7 +86,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.2
+        image: quay.io/kubermatic/http-prober:v0.3-dev3
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/api/pkg/resources/test/fixtures/deployment-digitalocean-1.10.0-machine-controller-webhook.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-digitalocean-1.10.0-machine-controller-webhook.yaml
@@ -86,7 +86,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3-dev3
+        image: quay.io/kubermatic/http-prober:v0.3
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/api/pkg/resources/test/fixtures/deployment-digitalocean-1.10.0-machine-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-digitalocean-1.10.0-machine-controller.yaml
@@ -77,7 +77,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3-dev3
+        image: quay.io/kubermatic/http-prober:v0.3
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/api/pkg/resources/test/fixtures/deployment-digitalocean-1.10.0-machine-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-digitalocean-1.10.0-machine-controller.yaml
@@ -34,11 +34,17 @@ spec:
         - "1"
         - -command
         - '{"command":"/usr/local/bin/machine-controller","args":["-kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","-logtostderr","-v","4","-cluster-dns","169.254.20.10","-internal-listen-address","0.0.0.0:8085"]}'
+        - -wait-for-crd-kind
+        - Machine
+        - -wait-for-crd-apiversion
+        - cluster.k8s.io/v1alpha1
         command:
         - /http-prober-bin/http-prober
         env:
         - name: DO_TOKEN
           value: do-token
+        - name: KUBECONFIG
+          value: /etc/kubernetes/kubeconfig/kubeconfig
         image: docker.io/kubermatic/machine-controller:v1.5.6
         livenessProbe:
           failureThreshold: 3
@@ -71,7 +77,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.2
+        image: quay.io/kubermatic/http-prober:v0.3-dev3
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/api/pkg/resources/test/fixtures/deployment-digitalocean-1.10.0-metrics-server.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-digitalocean-1.10.0-metrics-server.yaml
@@ -152,7 +152,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.2
+        image: quay.io/kubermatic/http-prober:v0.3-dev3
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/api/pkg/resources/test/fixtures/deployment-digitalocean-1.10.0-metrics-server.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-digitalocean-1.10.0-metrics-server.yaml
@@ -152,7 +152,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3-dev3
+        image: quay.io/kubermatic/http-prober:v0.3
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/api/pkg/resources/test/fixtures/deployment-digitalocean-1.10.0-scheduler.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-digitalocean-1.10.0-scheduler.yaml
@@ -163,7 +163,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3-dev3
+        image: quay.io/kubermatic/http-prober:v0.3
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/api/pkg/resources/test/fixtures/deployment-digitalocean-1.10.0-scheduler.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-digitalocean-1.10.0-scheduler.yaml
@@ -163,7 +163,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.2
+        image: quay.io/kubermatic/http-prober:v0.3-dev3
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/api/pkg/resources/test/fixtures/deployment-digitalocean-1.10.0-usercluster-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-digitalocean-1.10.0-usercluster-controller.yaml
@@ -85,7 +85,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.2
+        image: quay.io/kubermatic/http-prober:v0.3-dev3
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/api/pkg/resources/test/fixtures/deployment-digitalocean-1.10.0-usercluster-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-digitalocean-1.10.0-usercluster-controller.yaml
@@ -85,7 +85,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3-dev3
+        image: quay.io/kubermatic/http-prober:v0.3
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/api/pkg/resources/test/fixtures/deployment-digitalocean-1.10.6-controller-manager.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-digitalocean-1.10.6-controller-manager.yaml
@@ -171,7 +171,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3-dev3
+        image: quay.io/kubermatic/http-prober:v0.3
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/api/pkg/resources/test/fixtures/deployment-digitalocean-1.10.6-controller-manager.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-digitalocean-1.10.6-controller-manager.yaml
@@ -171,7 +171,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.2
+        image: quay.io/kubermatic/http-prober:v0.3-dev3
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/api/pkg/resources/test/fixtures/deployment-digitalocean-1.10.6-kube-state-metrics.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-digitalocean-1.10.6-kube-state-metrics.yaml
@@ -72,7 +72,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3-dev3
+        image: quay.io/kubermatic/http-prober:v0.3
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/api/pkg/resources/test/fixtures/deployment-digitalocean-1.10.6-kube-state-metrics.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-digitalocean-1.10.6-kube-state-metrics.yaml
@@ -72,7 +72,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.2
+        image: quay.io/kubermatic/http-prober:v0.3-dev3
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/api/pkg/resources/test/fixtures/deployment-digitalocean-1.10.6-machine-controller-webhook.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-digitalocean-1.10.6-machine-controller-webhook.yaml
@@ -31,11 +31,17 @@ spec:
         - "1"
         - -command
         - '{"command":"/usr/local/bin/webhook","args":["-kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","-logtostderr","-v","4","-listen-address","0.0.0.0:9876"]}'
+        - -wait-for-crd-kind
+        - Machine
+        - -wait-for-crd-apiversion
+        - cluster.k8s.io/v1alpha1
         command:
         - /http-prober-bin/http-prober
         env:
         - name: DO_TOKEN
           value: do-token
+        - name: KUBECONFIG
+          value: /etc/kubernetes/kubeconfig/kubeconfig
         image: docker.io/kubermatic/machine-controller:v1.5.6
         livenessProbe:
           failureThreshold: 8
@@ -80,7 +86,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.2
+        image: quay.io/kubermatic/http-prober:v0.3-dev3
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/api/pkg/resources/test/fixtures/deployment-digitalocean-1.10.6-machine-controller-webhook.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-digitalocean-1.10.6-machine-controller-webhook.yaml
@@ -86,7 +86,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3-dev3
+        image: quay.io/kubermatic/http-prober:v0.3
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/api/pkg/resources/test/fixtures/deployment-digitalocean-1.10.6-machine-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-digitalocean-1.10.6-machine-controller.yaml
@@ -77,7 +77,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3-dev3
+        image: quay.io/kubermatic/http-prober:v0.3
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/api/pkg/resources/test/fixtures/deployment-digitalocean-1.10.6-machine-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-digitalocean-1.10.6-machine-controller.yaml
@@ -34,11 +34,17 @@ spec:
         - "1"
         - -command
         - '{"command":"/usr/local/bin/machine-controller","args":["-kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","-logtostderr","-v","4","-cluster-dns","169.254.20.10","-internal-listen-address","0.0.0.0:8085"]}'
+        - -wait-for-crd-kind
+        - Machine
+        - -wait-for-crd-apiversion
+        - cluster.k8s.io/v1alpha1
         command:
         - /http-prober-bin/http-prober
         env:
         - name: DO_TOKEN
           value: do-token
+        - name: KUBECONFIG
+          value: /etc/kubernetes/kubeconfig/kubeconfig
         image: docker.io/kubermatic/machine-controller:v1.5.6
         livenessProbe:
           failureThreshold: 3
@@ -71,7 +77,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.2
+        image: quay.io/kubermatic/http-prober:v0.3-dev3
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/api/pkg/resources/test/fixtures/deployment-digitalocean-1.10.6-metrics-server.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-digitalocean-1.10.6-metrics-server.yaml
@@ -152,7 +152,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.2
+        image: quay.io/kubermatic/http-prober:v0.3-dev3
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/api/pkg/resources/test/fixtures/deployment-digitalocean-1.10.6-metrics-server.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-digitalocean-1.10.6-metrics-server.yaml
@@ -152,7 +152,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3-dev3
+        image: quay.io/kubermatic/http-prober:v0.3
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/api/pkg/resources/test/fixtures/deployment-digitalocean-1.10.6-scheduler.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-digitalocean-1.10.6-scheduler.yaml
@@ -163,7 +163,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3-dev3
+        image: quay.io/kubermatic/http-prober:v0.3
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/api/pkg/resources/test/fixtures/deployment-digitalocean-1.10.6-scheduler.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-digitalocean-1.10.6-scheduler.yaml
@@ -163,7 +163,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.2
+        image: quay.io/kubermatic/http-prober:v0.3-dev3
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/api/pkg/resources/test/fixtures/deployment-digitalocean-1.10.6-usercluster-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-digitalocean-1.10.6-usercluster-controller.yaml
@@ -85,7 +85,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.2
+        image: quay.io/kubermatic/http-prober:v0.3-dev3
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/api/pkg/resources/test/fixtures/deployment-digitalocean-1.10.6-usercluster-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-digitalocean-1.10.6-usercluster-controller.yaml
@@ -85,7 +85,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3-dev3
+        image: quay.io/kubermatic/http-prober:v0.3
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/api/pkg/resources/test/fixtures/deployment-digitalocean-1.11.0-controller-manager.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-digitalocean-1.11.0-controller-manager.yaml
@@ -171,7 +171,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3-dev3
+        image: quay.io/kubermatic/http-prober:v0.3
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/api/pkg/resources/test/fixtures/deployment-digitalocean-1.11.0-controller-manager.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-digitalocean-1.11.0-controller-manager.yaml
@@ -171,7 +171,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.2
+        image: quay.io/kubermatic/http-prober:v0.3-dev3
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/api/pkg/resources/test/fixtures/deployment-digitalocean-1.11.0-kube-state-metrics.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-digitalocean-1.11.0-kube-state-metrics.yaml
@@ -72,7 +72,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3-dev3
+        image: quay.io/kubermatic/http-prober:v0.3
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/api/pkg/resources/test/fixtures/deployment-digitalocean-1.11.0-kube-state-metrics.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-digitalocean-1.11.0-kube-state-metrics.yaml
@@ -72,7 +72,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.2
+        image: quay.io/kubermatic/http-prober:v0.3-dev3
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/api/pkg/resources/test/fixtures/deployment-digitalocean-1.11.0-machine-controller-webhook.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-digitalocean-1.11.0-machine-controller-webhook.yaml
@@ -31,11 +31,17 @@ spec:
         - "1"
         - -command
         - '{"command":"/usr/local/bin/webhook","args":["-kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","-logtostderr","-v","4","-listen-address","0.0.0.0:9876"]}'
+        - -wait-for-crd-kind
+        - Machine
+        - -wait-for-crd-apiversion
+        - cluster.k8s.io/v1alpha1
         command:
         - /http-prober-bin/http-prober
         env:
         - name: DO_TOKEN
           value: do-token
+        - name: KUBECONFIG
+          value: /etc/kubernetes/kubeconfig/kubeconfig
         image: docker.io/kubermatic/machine-controller:v1.5.6
         livenessProbe:
           failureThreshold: 8
@@ -80,7 +86,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.2
+        image: quay.io/kubermatic/http-prober:v0.3-dev3
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/api/pkg/resources/test/fixtures/deployment-digitalocean-1.11.0-machine-controller-webhook.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-digitalocean-1.11.0-machine-controller-webhook.yaml
@@ -86,7 +86,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3-dev3
+        image: quay.io/kubermatic/http-prober:v0.3
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/api/pkg/resources/test/fixtures/deployment-digitalocean-1.11.0-machine-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-digitalocean-1.11.0-machine-controller.yaml
@@ -77,7 +77,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3-dev3
+        image: quay.io/kubermatic/http-prober:v0.3
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/api/pkg/resources/test/fixtures/deployment-digitalocean-1.11.0-machine-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-digitalocean-1.11.0-machine-controller.yaml
@@ -34,11 +34,17 @@ spec:
         - "1"
         - -command
         - '{"command":"/usr/local/bin/machine-controller","args":["-kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","-logtostderr","-v","4","-cluster-dns","169.254.20.10","-internal-listen-address","0.0.0.0:8085"]}'
+        - -wait-for-crd-kind
+        - Machine
+        - -wait-for-crd-apiversion
+        - cluster.k8s.io/v1alpha1
         command:
         - /http-prober-bin/http-prober
         env:
         - name: DO_TOKEN
           value: do-token
+        - name: KUBECONFIG
+          value: /etc/kubernetes/kubeconfig/kubeconfig
         image: docker.io/kubermatic/machine-controller:v1.5.6
         livenessProbe:
           failureThreshold: 3
@@ -71,7 +77,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.2
+        image: quay.io/kubermatic/http-prober:v0.3-dev3
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/api/pkg/resources/test/fixtures/deployment-digitalocean-1.11.0-metrics-server.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-digitalocean-1.11.0-metrics-server.yaml
@@ -152,7 +152,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.2
+        image: quay.io/kubermatic/http-prober:v0.3-dev3
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/api/pkg/resources/test/fixtures/deployment-digitalocean-1.11.0-metrics-server.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-digitalocean-1.11.0-metrics-server.yaml
@@ -152,7 +152,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3-dev3
+        image: quay.io/kubermatic/http-prober:v0.3
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/api/pkg/resources/test/fixtures/deployment-digitalocean-1.11.0-scheduler.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-digitalocean-1.11.0-scheduler.yaml
@@ -163,7 +163,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3-dev3
+        image: quay.io/kubermatic/http-prober:v0.3
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/api/pkg/resources/test/fixtures/deployment-digitalocean-1.11.0-scheduler.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-digitalocean-1.11.0-scheduler.yaml
@@ -163,7 +163,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.2
+        image: quay.io/kubermatic/http-prober:v0.3-dev3
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/api/pkg/resources/test/fixtures/deployment-digitalocean-1.11.0-usercluster-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-digitalocean-1.11.0-usercluster-controller.yaml
@@ -85,7 +85,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.2
+        image: quay.io/kubermatic/http-prober:v0.3-dev3
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/api/pkg/resources/test/fixtures/deployment-digitalocean-1.11.0-usercluster-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-digitalocean-1.11.0-usercluster-controller.yaml
@@ -85,7 +85,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3-dev3
+        image: quay.io/kubermatic/http-prober:v0.3
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/api/pkg/resources/test/fixtures/deployment-digitalocean-1.11.1-controller-manager.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-digitalocean-1.11.1-controller-manager.yaml
@@ -171,7 +171,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3-dev3
+        image: quay.io/kubermatic/http-prober:v0.3
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/api/pkg/resources/test/fixtures/deployment-digitalocean-1.11.1-controller-manager.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-digitalocean-1.11.1-controller-manager.yaml
@@ -171,7 +171,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.2
+        image: quay.io/kubermatic/http-prober:v0.3-dev3
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/api/pkg/resources/test/fixtures/deployment-digitalocean-1.11.1-kube-state-metrics.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-digitalocean-1.11.1-kube-state-metrics.yaml
@@ -72,7 +72,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3-dev3
+        image: quay.io/kubermatic/http-prober:v0.3
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/api/pkg/resources/test/fixtures/deployment-digitalocean-1.11.1-kube-state-metrics.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-digitalocean-1.11.1-kube-state-metrics.yaml
@@ -72,7 +72,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.2
+        image: quay.io/kubermatic/http-prober:v0.3-dev3
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/api/pkg/resources/test/fixtures/deployment-digitalocean-1.11.1-machine-controller-webhook.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-digitalocean-1.11.1-machine-controller-webhook.yaml
@@ -31,11 +31,17 @@ spec:
         - "1"
         - -command
         - '{"command":"/usr/local/bin/webhook","args":["-kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","-logtostderr","-v","4","-listen-address","0.0.0.0:9876"]}'
+        - -wait-for-crd-kind
+        - Machine
+        - -wait-for-crd-apiversion
+        - cluster.k8s.io/v1alpha1
         command:
         - /http-prober-bin/http-prober
         env:
         - name: DO_TOKEN
           value: do-token
+        - name: KUBECONFIG
+          value: /etc/kubernetes/kubeconfig/kubeconfig
         image: docker.io/kubermatic/machine-controller:v1.5.6
         livenessProbe:
           failureThreshold: 8
@@ -80,7 +86,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.2
+        image: quay.io/kubermatic/http-prober:v0.3-dev3
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/api/pkg/resources/test/fixtures/deployment-digitalocean-1.11.1-machine-controller-webhook.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-digitalocean-1.11.1-machine-controller-webhook.yaml
@@ -86,7 +86,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3-dev3
+        image: quay.io/kubermatic/http-prober:v0.3
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/api/pkg/resources/test/fixtures/deployment-digitalocean-1.11.1-machine-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-digitalocean-1.11.1-machine-controller.yaml
@@ -77,7 +77,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3-dev3
+        image: quay.io/kubermatic/http-prober:v0.3
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/api/pkg/resources/test/fixtures/deployment-digitalocean-1.11.1-machine-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-digitalocean-1.11.1-machine-controller.yaml
@@ -34,11 +34,17 @@ spec:
         - "1"
         - -command
         - '{"command":"/usr/local/bin/machine-controller","args":["-kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","-logtostderr","-v","4","-cluster-dns","169.254.20.10","-internal-listen-address","0.0.0.0:8085"]}'
+        - -wait-for-crd-kind
+        - Machine
+        - -wait-for-crd-apiversion
+        - cluster.k8s.io/v1alpha1
         command:
         - /http-prober-bin/http-prober
         env:
         - name: DO_TOKEN
           value: do-token
+        - name: KUBECONFIG
+          value: /etc/kubernetes/kubeconfig/kubeconfig
         image: docker.io/kubermatic/machine-controller:v1.5.6
         livenessProbe:
           failureThreshold: 3
@@ -71,7 +77,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.2
+        image: quay.io/kubermatic/http-prober:v0.3-dev3
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/api/pkg/resources/test/fixtures/deployment-digitalocean-1.11.1-metrics-server.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-digitalocean-1.11.1-metrics-server.yaml
@@ -152,7 +152,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.2
+        image: quay.io/kubermatic/http-prober:v0.3-dev3
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/api/pkg/resources/test/fixtures/deployment-digitalocean-1.11.1-metrics-server.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-digitalocean-1.11.1-metrics-server.yaml
@@ -152,7 +152,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3-dev3
+        image: quay.io/kubermatic/http-prober:v0.3
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/api/pkg/resources/test/fixtures/deployment-digitalocean-1.11.1-scheduler.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-digitalocean-1.11.1-scheduler.yaml
@@ -163,7 +163,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3-dev3
+        image: quay.io/kubermatic/http-prober:v0.3
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/api/pkg/resources/test/fixtures/deployment-digitalocean-1.11.1-scheduler.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-digitalocean-1.11.1-scheduler.yaml
@@ -163,7 +163,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.2
+        image: quay.io/kubermatic/http-prober:v0.3-dev3
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/api/pkg/resources/test/fixtures/deployment-digitalocean-1.11.1-usercluster-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-digitalocean-1.11.1-usercluster-controller.yaml
@@ -85,7 +85,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.2
+        image: quay.io/kubermatic/http-prober:v0.3-dev3
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/api/pkg/resources/test/fixtures/deployment-digitalocean-1.11.1-usercluster-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-digitalocean-1.11.1-usercluster-controller.yaml
@@ -85,7 +85,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3-dev3
+        image: quay.io/kubermatic/http-prober:v0.3
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/api/pkg/resources/test/fixtures/deployment-digitalocean-1.12.0-controller-manager.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-digitalocean-1.12.0-controller-manager.yaml
@@ -171,7 +171,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3-dev3
+        image: quay.io/kubermatic/http-prober:v0.3
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/api/pkg/resources/test/fixtures/deployment-digitalocean-1.12.0-controller-manager.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-digitalocean-1.12.0-controller-manager.yaml
@@ -171,7 +171,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.2
+        image: quay.io/kubermatic/http-prober:v0.3-dev3
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/api/pkg/resources/test/fixtures/deployment-digitalocean-1.12.0-kube-state-metrics.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-digitalocean-1.12.0-kube-state-metrics.yaml
@@ -72,7 +72,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3-dev3
+        image: quay.io/kubermatic/http-prober:v0.3
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/api/pkg/resources/test/fixtures/deployment-digitalocean-1.12.0-kube-state-metrics.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-digitalocean-1.12.0-kube-state-metrics.yaml
@@ -72,7 +72,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.2
+        image: quay.io/kubermatic/http-prober:v0.3-dev3
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/api/pkg/resources/test/fixtures/deployment-digitalocean-1.12.0-machine-controller-webhook.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-digitalocean-1.12.0-machine-controller-webhook.yaml
@@ -31,11 +31,17 @@ spec:
         - "1"
         - -command
         - '{"command":"/usr/local/bin/webhook","args":["-kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","-logtostderr","-v","4","-listen-address","0.0.0.0:9876"]}'
+        - -wait-for-crd-kind
+        - Machine
+        - -wait-for-crd-apiversion
+        - cluster.k8s.io/v1alpha1
         command:
         - /http-prober-bin/http-prober
         env:
         - name: DO_TOKEN
           value: do-token
+        - name: KUBECONFIG
+          value: /etc/kubernetes/kubeconfig/kubeconfig
         image: docker.io/kubermatic/machine-controller:v1.5.6
         livenessProbe:
           failureThreshold: 8
@@ -80,7 +86,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.2
+        image: quay.io/kubermatic/http-prober:v0.3-dev3
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/api/pkg/resources/test/fixtures/deployment-digitalocean-1.12.0-machine-controller-webhook.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-digitalocean-1.12.0-machine-controller-webhook.yaml
@@ -86,7 +86,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3-dev3
+        image: quay.io/kubermatic/http-prober:v0.3
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/api/pkg/resources/test/fixtures/deployment-digitalocean-1.12.0-machine-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-digitalocean-1.12.0-machine-controller.yaml
@@ -77,7 +77,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3-dev3
+        image: quay.io/kubermatic/http-prober:v0.3
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/api/pkg/resources/test/fixtures/deployment-digitalocean-1.12.0-machine-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-digitalocean-1.12.0-machine-controller.yaml
@@ -34,11 +34,17 @@ spec:
         - "1"
         - -command
         - '{"command":"/usr/local/bin/machine-controller","args":["-kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","-logtostderr","-v","4","-cluster-dns","169.254.20.10","-internal-listen-address","0.0.0.0:8085"]}'
+        - -wait-for-crd-kind
+        - Machine
+        - -wait-for-crd-apiversion
+        - cluster.k8s.io/v1alpha1
         command:
         - /http-prober-bin/http-prober
         env:
         - name: DO_TOKEN
           value: do-token
+        - name: KUBECONFIG
+          value: /etc/kubernetes/kubeconfig/kubeconfig
         image: docker.io/kubermatic/machine-controller:v1.5.6
         livenessProbe:
           failureThreshold: 3
@@ -71,7 +77,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.2
+        image: quay.io/kubermatic/http-prober:v0.3-dev3
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/api/pkg/resources/test/fixtures/deployment-digitalocean-1.12.0-metrics-server.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-digitalocean-1.12.0-metrics-server.yaml
@@ -152,7 +152,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.2
+        image: quay.io/kubermatic/http-prober:v0.3-dev3
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/api/pkg/resources/test/fixtures/deployment-digitalocean-1.12.0-metrics-server.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-digitalocean-1.12.0-metrics-server.yaml
@@ -152,7 +152,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3-dev3
+        image: quay.io/kubermatic/http-prober:v0.3
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/api/pkg/resources/test/fixtures/deployment-digitalocean-1.12.0-scheduler.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-digitalocean-1.12.0-scheduler.yaml
@@ -163,7 +163,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3-dev3
+        image: quay.io/kubermatic/http-prober:v0.3
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/api/pkg/resources/test/fixtures/deployment-digitalocean-1.12.0-scheduler.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-digitalocean-1.12.0-scheduler.yaml
@@ -163,7 +163,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.2
+        image: quay.io/kubermatic/http-prober:v0.3-dev3
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/api/pkg/resources/test/fixtures/deployment-digitalocean-1.12.0-usercluster-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-digitalocean-1.12.0-usercluster-controller.yaml
@@ -85,7 +85,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.2
+        image: quay.io/kubermatic/http-prober:v0.3-dev3
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/api/pkg/resources/test/fixtures/deployment-digitalocean-1.12.0-usercluster-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-digitalocean-1.12.0-usercluster-controller.yaml
@@ -85,7 +85,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3-dev3
+        image: quay.io/kubermatic/http-prober:v0.3
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/api/pkg/resources/test/fixtures/deployment-digitalocean-1.13.0-controller-manager.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-digitalocean-1.13.0-controller-manager.yaml
@@ -171,7 +171,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3-dev3
+        image: quay.io/kubermatic/http-prober:v0.3
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/api/pkg/resources/test/fixtures/deployment-digitalocean-1.13.0-controller-manager.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-digitalocean-1.13.0-controller-manager.yaml
@@ -171,7 +171,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.2
+        image: quay.io/kubermatic/http-prober:v0.3-dev3
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/api/pkg/resources/test/fixtures/deployment-digitalocean-1.13.0-kube-state-metrics.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-digitalocean-1.13.0-kube-state-metrics.yaml
@@ -72,7 +72,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3-dev3
+        image: quay.io/kubermatic/http-prober:v0.3
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/api/pkg/resources/test/fixtures/deployment-digitalocean-1.13.0-kube-state-metrics.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-digitalocean-1.13.0-kube-state-metrics.yaml
@@ -72,7 +72,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.2
+        image: quay.io/kubermatic/http-prober:v0.3-dev3
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/api/pkg/resources/test/fixtures/deployment-digitalocean-1.13.0-machine-controller-webhook.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-digitalocean-1.13.0-machine-controller-webhook.yaml
@@ -31,11 +31,17 @@ spec:
         - "1"
         - -command
         - '{"command":"/usr/local/bin/webhook","args":["-kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","-logtostderr","-v","4","-listen-address","0.0.0.0:9876"]}'
+        - -wait-for-crd-kind
+        - Machine
+        - -wait-for-crd-apiversion
+        - cluster.k8s.io/v1alpha1
         command:
         - /http-prober-bin/http-prober
         env:
         - name: DO_TOKEN
           value: do-token
+        - name: KUBECONFIG
+          value: /etc/kubernetes/kubeconfig/kubeconfig
         image: docker.io/kubermatic/machine-controller:v1.5.6
         livenessProbe:
           failureThreshold: 8
@@ -80,7 +86,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.2
+        image: quay.io/kubermatic/http-prober:v0.3-dev3
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/api/pkg/resources/test/fixtures/deployment-digitalocean-1.13.0-machine-controller-webhook.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-digitalocean-1.13.0-machine-controller-webhook.yaml
@@ -86,7 +86,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3-dev3
+        image: quay.io/kubermatic/http-prober:v0.3
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/api/pkg/resources/test/fixtures/deployment-digitalocean-1.13.0-machine-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-digitalocean-1.13.0-machine-controller.yaml
@@ -77,7 +77,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3-dev3
+        image: quay.io/kubermatic/http-prober:v0.3
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/api/pkg/resources/test/fixtures/deployment-digitalocean-1.13.0-machine-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-digitalocean-1.13.0-machine-controller.yaml
@@ -34,11 +34,17 @@ spec:
         - "1"
         - -command
         - '{"command":"/usr/local/bin/machine-controller","args":["-kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","-logtostderr","-v","4","-cluster-dns","169.254.20.10","-internal-listen-address","0.0.0.0:8085"]}'
+        - -wait-for-crd-kind
+        - Machine
+        - -wait-for-crd-apiversion
+        - cluster.k8s.io/v1alpha1
         command:
         - /http-prober-bin/http-prober
         env:
         - name: DO_TOKEN
           value: do-token
+        - name: KUBECONFIG
+          value: /etc/kubernetes/kubeconfig/kubeconfig
         image: docker.io/kubermatic/machine-controller:v1.5.6
         livenessProbe:
           failureThreshold: 3
@@ -71,7 +77,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.2
+        image: quay.io/kubermatic/http-prober:v0.3-dev3
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/api/pkg/resources/test/fixtures/deployment-digitalocean-1.13.0-metrics-server.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-digitalocean-1.13.0-metrics-server.yaml
@@ -152,7 +152,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.2
+        image: quay.io/kubermatic/http-prober:v0.3-dev3
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/api/pkg/resources/test/fixtures/deployment-digitalocean-1.13.0-metrics-server.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-digitalocean-1.13.0-metrics-server.yaml
@@ -152,7 +152,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3-dev3
+        image: quay.io/kubermatic/http-prober:v0.3
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/api/pkg/resources/test/fixtures/deployment-digitalocean-1.13.0-scheduler.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-digitalocean-1.13.0-scheduler.yaml
@@ -163,7 +163,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3-dev3
+        image: quay.io/kubermatic/http-prober:v0.3
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/api/pkg/resources/test/fixtures/deployment-digitalocean-1.13.0-scheduler.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-digitalocean-1.13.0-scheduler.yaml
@@ -163,7 +163,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.2
+        image: quay.io/kubermatic/http-prober:v0.3-dev3
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/api/pkg/resources/test/fixtures/deployment-digitalocean-1.13.0-usercluster-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-digitalocean-1.13.0-usercluster-controller.yaml
@@ -85,7 +85,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.2
+        image: quay.io/kubermatic/http-prober:v0.3-dev3
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/api/pkg/resources/test/fixtures/deployment-digitalocean-1.13.0-usercluster-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-digitalocean-1.13.0-usercluster-controller.yaml
@@ -85,7 +85,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3-dev3
+        image: quay.io/kubermatic/http-prober:v0.3
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/api/pkg/resources/test/fixtures/deployment-openstack-1.10.0-controller-manager.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-openstack-1.10.0-controller-manager.yaml
@@ -171,7 +171,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3-dev3
+        image: quay.io/kubermatic/http-prober:v0.3
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/api/pkg/resources/test/fixtures/deployment-openstack-1.10.0-controller-manager.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-openstack-1.10.0-controller-manager.yaml
@@ -171,7 +171,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.2
+        image: quay.io/kubermatic/http-prober:v0.3-dev3
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/api/pkg/resources/test/fixtures/deployment-openstack-1.10.0-kube-state-metrics.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-openstack-1.10.0-kube-state-metrics.yaml
@@ -72,7 +72,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3-dev3
+        image: quay.io/kubermatic/http-prober:v0.3
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/api/pkg/resources/test/fixtures/deployment-openstack-1.10.0-kube-state-metrics.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-openstack-1.10.0-kube-state-metrics.yaml
@@ -72,7 +72,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.2
+        image: quay.io/kubermatic/http-prober:v0.3-dev3
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/api/pkg/resources/test/fixtures/deployment-openstack-1.10.0-machine-controller-webhook.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-openstack-1.10.0-machine-controller-webhook.yaml
@@ -31,6 +31,10 @@ spec:
         - "1"
         - -command
         - '{"command":"/usr/local/bin/webhook","args":["-kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","-logtostderr","-v","4","-listen-address","0.0.0.0:9876"]}'
+        - -wait-for-crd-kind
+        - Machine
+        - -wait-for-crd-apiversion
+        - cluster.k8s.io/v1alpha1
         command:
         - /http-prober-bin/http-prober
         env:
@@ -45,6 +49,8 @@ spec:
         - name: OS_TENANT_NAME
           value: openstack-tenant
         - name: OS_TENANT_ID
+        - name: KUBECONFIG
+          value: /etc/kubernetes/kubeconfig/kubeconfig
         image: docker.io/kubermatic/machine-controller:v1.5.6
         livenessProbe:
           failureThreshold: 8
@@ -89,7 +95,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.2
+        image: quay.io/kubermatic/http-prober:v0.3-dev3
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/api/pkg/resources/test/fixtures/deployment-openstack-1.10.0-machine-controller-webhook.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-openstack-1.10.0-machine-controller-webhook.yaml
@@ -95,7 +95,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3-dev3
+        image: quay.io/kubermatic/http-prober:v0.3
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/api/pkg/resources/test/fixtures/deployment-openstack-1.10.0-machine-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-openstack-1.10.0-machine-controller.yaml
@@ -86,7 +86,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3-dev3
+        image: quay.io/kubermatic/http-prober:v0.3
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/api/pkg/resources/test/fixtures/deployment-openstack-1.10.0-machine-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-openstack-1.10.0-machine-controller.yaml
@@ -34,6 +34,10 @@ spec:
         - "1"
         - -command
         - '{"command":"/usr/local/bin/machine-controller","args":["-kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","-logtostderr","-v","4","-cluster-dns","169.254.20.10","-internal-listen-address","0.0.0.0:8085"]}'
+        - -wait-for-crd-kind
+        - Machine
+        - -wait-for-crd-apiversion
+        - cluster.k8s.io/v1alpha1
         command:
         - /http-prober-bin/http-prober
         env:
@@ -48,6 +52,8 @@ spec:
         - name: OS_TENANT_NAME
           value: openstack-tenant
         - name: OS_TENANT_ID
+        - name: KUBECONFIG
+          value: /etc/kubernetes/kubeconfig/kubeconfig
         image: docker.io/kubermatic/machine-controller:v1.5.6
         livenessProbe:
           failureThreshold: 3
@@ -80,7 +86,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.2
+        image: quay.io/kubermatic/http-prober:v0.3-dev3
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/api/pkg/resources/test/fixtures/deployment-openstack-1.10.0-metrics-server.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-openstack-1.10.0-metrics-server.yaml
@@ -152,7 +152,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.2
+        image: quay.io/kubermatic/http-prober:v0.3-dev3
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/api/pkg/resources/test/fixtures/deployment-openstack-1.10.0-metrics-server.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-openstack-1.10.0-metrics-server.yaml
@@ -152,7 +152,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3-dev3
+        image: quay.io/kubermatic/http-prober:v0.3
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/api/pkg/resources/test/fixtures/deployment-openstack-1.10.0-scheduler.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-openstack-1.10.0-scheduler.yaml
@@ -163,7 +163,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3-dev3
+        image: quay.io/kubermatic/http-prober:v0.3
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/api/pkg/resources/test/fixtures/deployment-openstack-1.10.0-scheduler.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-openstack-1.10.0-scheduler.yaml
@@ -163,7 +163,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.2
+        image: quay.io/kubermatic/http-prober:v0.3-dev3
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/api/pkg/resources/test/fixtures/deployment-openstack-1.10.0-usercluster-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-openstack-1.10.0-usercluster-controller.yaml
@@ -85,7 +85,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.2
+        image: quay.io/kubermatic/http-prober:v0.3-dev3
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/api/pkg/resources/test/fixtures/deployment-openstack-1.10.0-usercluster-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-openstack-1.10.0-usercluster-controller.yaml
@@ -85,7 +85,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3-dev3
+        image: quay.io/kubermatic/http-prober:v0.3
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/api/pkg/resources/test/fixtures/deployment-openstack-1.10.6-controller-manager.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-openstack-1.10.6-controller-manager.yaml
@@ -171,7 +171,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3-dev3
+        image: quay.io/kubermatic/http-prober:v0.3
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/api/pkg/resources/test/fixtures/deployment-openstack-1.10.6-controller-manager.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-openstack-1.10.6-controller-manager.yaml
@@ -171,7 +171,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.2
+        image: quay.io/kubermatic/http-prober:v0.3-dev3
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/api/pkg/resources/test/fixtures/deployment-openstack-1.10.6-kube-state-metrics.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-openstack-1.10.6-kube-state-metrics.yaml
@@ -72,7 +72,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3-dev3
+        image: quay.io/kubermatic/http-prober:v0.3
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/api/pkg/resources/test/fixtures/deployment-openstack-1.10.6-kube-state-metrics.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-openstack-1.10.6-kube-state-metrics.yaml
@@ -72,7 +72,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.2
+        image: quay.io/kubermatic/http-prober:v0.3-dev3
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/api/pkg/resources/test/fixtures/deployment-openstack-1.10.6-machine-controller-webhook.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-openstack-1.10.6-machine-controller-webhook.yaml
@@ -31,6 +31,10 @@ spec:
         - "1"
         - -command
         - '{"command":"/usr/local/bin/webhook","args":["-kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","-logtostderr","-v","4","-listen-address","0.0.0.0:9876"]}'
+        - -wait-for-crd-kind
+        - Machine
+        - -wait-for-crd-apiversion
+        - cluster.k8s.io/v1alpha1
         command:
         - /http-prober-bin/http-prober
         env:
@@ -45,6 +49,8 @@ spec:
         - name: OS_TENANT_NAME
           value: openstack-tenant
         - name: OS_TENANT_ID
+        - name: KUBECONFIG
+          value: /etc/kubernetes/kubeconfig/kubeconfig
         image: docker.io/kubermatic/machine-controller:v1.5.6
         livenessProbe:
           failureThreshold: 8
@@ -89,7 +95,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.2
+        image: quay.io/kubermatic/http-prober:v0.3-dev3
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/api/pkg/resources/test/fixtures/deployment-openstack-1.10.6-machine-controller-webhook.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-openstack-1.10.6-machine-controller-webhook.yaml
@@ -95,7 +95,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3-dev3
+        image: quay.io/kubermatic/http-prober:v0.3
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/api/pkg/resources/test/fixtures/deployment-openstack-1.10.6-machine-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-openstack-1.10.6-machine-controller.yaml
@@ -86,7 +86,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3-dev3
+        image: quay.io/kubermatic/http-prober:v0.3
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/api/pkg/resources/test/fixtures/deployment-openstack-1.10.6-machine-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-openstack-1.10.6-machine-controller.yaml
@@ -34,6 +34,10 @@ spec:
         - "1"
         - -command
         - '{"command":"/usr/local/bin/machine-controller","args":["-kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","-logtostderr","-v","4","-cluster-dns","169.254.20.10","-internal-listen-address","0.0.0.0:8085"]}'
+        - -wait-for-crd-kind
+        - Machine
+        - -wait-for-crd-apiversion
+        - cluster.k8s.io/v1alpha1
         command:
         - /http-prober-bin/http-prober
         env:
@@ -48,6 +52,8 @@ spec:
         - name: OS_TENANT_NAME
           value: openstack-tenant
         - name: OS_TENANT_ID
+        - name: KUBECONFIG
+          value: /etc/kubernetes/kubeconfig/kubeconfig
         image: docker.io/kubermatic/machine-controller:v1.5.6
         livenessProbe:
           failureThreshold: 3
@@ -80,7 +86,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.2
+        image: quay.io/kubermatic/http-prober:v0.3-dev3
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/api/pkg/resources/test/fixtures/deployment-openstack-1.10.6-metrics-server.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-openstack-1.10.6-metrics-server.yaml
@@ -152,7 +152,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.2
+        image: quay.io/kubermatic/http-prober:v0.3-dev3
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/api/pkg/resources/test/fixtures/deployment-openstack-1.10.6-metrics-server.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-openstack-1.10.6-metrics-server.yaml
@@ -152,7 +152,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3-dev3
+        image: quay.io/kubermatic/http-prober:v0.3
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/api/pkg/resources/test/fixtures/deployment-openstack-1.10.6-scheduler.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-openstack-1.10.6-scheduler.yaml
@@ -163,7 +163,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3-dev3
+        image: quay.io/kubermatic/http-prober:v0.3
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/api/pkg/resources/test/fixtures/deployment-openstack-1.10.6-scheduler.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-openstack-1.10.6-scheduler.yaml
@@ -163,7 +163,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.2
+        image: quay.io/kubermatic/http-prober:v0.3-dev3
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/api/pkg/resources/test/fixtures/deployment-openstack-1.10.6-usercluster-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-openstack-1.10.6-usercluster-controller.yaml
@@ -85,7 +85,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.2
+        image: quay.io/kubermatic/http-prober:v0.3-dev3
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/api/pkg/resources/test/fixtures/deployment-openstack-1.10.6-usercluster-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-openstack-1.10.6-usercluster-controller.yaml
@@ -85,7 +85,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3-dev3
+        image: quay.io/kubermatic/http-prober:v0.3
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/api/pkg/resources/test/fixtures/deployment-openstack-1.11.0-controller-manager.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-openstack-1.11.0-controller-manager.yaml
@@ -171,7 +171,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3-dev3
+        image: quay.io/kubermatic/http-prober:v0.3
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/api/pkg/resources/test/fixtures/deployment-openstack-1.11.0-controller-manager.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-openstack-1.11.0-controller-manager.yaml
@@ -171,7 +171,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.2
+        image: quay.io/kubermatic/http-prober:v0.3-dev3
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/api/pkg/resources/test/fixtures/deployment-openstack-1.11.0-kube-state-metrics.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-openstack-1.11.0-kube-state-metrics.yaml
@@ -72,7 +72,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3-dev3
+        image: quay.io/kubermatic/http-prober:v0.3
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/api/pkg/resources/test/fixtures/deployment-openstack-1.11.0-kube-state-metrics.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-openstack-1.11.0-kube-state-metrics.yaml
@@ -72,7 +72,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.2
+        image: quay.io/kubermatic/http-prober:v0.3-dev3
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/api/pkg/resources/test/fixtures/deployment-openstack-1.11.0-machine-controller-webhook.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-openstack-1.11.0-machine-controller-webhook.yaml
@@ -31,6 +31,10 @@ spec:
         - "1"
         - -command
         - '{"command":"/usr/local/bin/webhook","args":["-kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","-logtostderr","-v","4","-listen-address","0.0.0.0:9876"]}'
+        - -wait-for-crd-kind
+        - Machine
+        - -wait-for-crd-apiversion
+        - cluster.k8s.io/v1alpha1
         command:
         - /http-prober-bin/http-prober
         env:
@@ -45,6 +49,8 @@ spec:
         - name: OS_TENANT_NAME
           value: openstack-tenant
         - name: OS_TENANT_ID
+        - name: KUBECONFIG
+          value: /etc/kubernetes/kubeconfig/kubeconfig
         image: docker.io/kubermatic/machine-controller:v1.5.6
         livenessProbe:
           failureThreshold: 8
@@ -89,7 +95,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.2
+        image: quay.io/kubermatic/http-prober:v0.3-dev3
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/api/pkg/resources/test/fixtures/deployment-openstack-1.11.0-machine-controller-webhook.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-openstack-1.11.0-machine-controller-webhook.yaml
@@ -95,7 +95,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3-dev3
+        image: quay.io/kubermatic/http-prober:v0.3
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/api/pkg/resources/test/fixtures/deployment-openstack-1.11.0-machine-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-openstack-1.11.0-machine-controller.yaml
@@ -86,7 +86,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3-dev3
+        image: quay.io/kubermatic/http-prober:v0.3
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/api/pkg/resources/test/fixtures/deployment-openstack-1.11.0-machine-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-openstack-1.11.0-machine-controller.yaml
@@ -34,6 +34,10 @@ spec:
         - "1"
         - -command
         - '{"command":"/usr/local/bin/machine-controller","args":["-kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","-logtostderr","-v","4","-cluster-dns","169.254.20.10","-internal-listen-address","0.0.0.0:8085"]}'
+        - -wait-for-crd-kind
+        - Machine
+        - -wait-for-crd-apiversion
+        - cluster.k8s.io/v1alpha1
         command:
         - /http-prober-bin/http-prober
         env:
@@ -48,6 +52,8 @@ spec:
         - name: OS_TENANT_NAME
           value: openstack-tenant
         - name: OS_TENANT_ID
+        - name: KUBECONFIG
+          value: /etc/kubernetes/kubeconfig/kubeconfig
         image: docker.io/kubermatic/machine-controller:v1.5.6
         livenessProbe:
           failureThreshold: 3
@@ -80,7 +86,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.2
+        image: quay.io/kubermatic/http-prober:v0.3-dev3
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/api/pkg/resources/test/fixtures/deployment-openstack-1.11.0-metrics-server.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-openstack-1.11.0-metrics-server.yaml
@@ -152,7 +152,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.2
+        image: quay.io/kubermatic/http-prober:v0.3-dev3
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/api/pkg/resources/test/fixtures/deployment-openstack-1.11.0-metrics-server.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-openstack-1.11.0-metrics-server.yaml
@@ -152,7 +152,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3-dev3
+        image: quay.io/kubermatic/http-prober:v0.3
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/api/pkg/resources/test/fixtures/deployment-openstack-1.11.0-scheduler.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-openstack-1.11.0-scheduler.yaml
@@ -163,7 +163,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3-dev3
+        image: quay.io/kubermatic/http-prober:v0.3
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/api/pkg/resources/test/fixtures/deployment-openstack-1.11.0-scheduler.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-openstack-1.11.0-scheduler.yaml
@@ -163,7 +163,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.2
+        image: quay.io/kubermatic/http-prober:v0.3-dev3
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/api/pkg/resources/test/fixtures/deployment-openstack-1.11.0-usercluster-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-openstack-1.11.0-usercluster-controller.yaml
@@ -85,7 +85,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.2
+        image: quay.io/kubermatic/http-prober:v0.3-dev3
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/api/pkg/resources/test/fixtures/deployment-openstack-1.11.0-usercluster-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-openstack-1.11.0-usercluster-controller.yaml
@@ -85,7 +85,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3-dev3
+        image: quay.io/kubermatic/http-prober:v0.3
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/api/pkg/resources/test/fixtures/deployment-openstack-1.11.1-controller-manager.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-openstack-1.11.1-controller-manager.yaml
@@ -171,7 +171,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3-dev3
+        image: quay.io/kubermatic/http-prober:v0.3
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/api/pkg/resources/test/fixtures/deployment-openstack-1.11.1-controller-manager.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-openstack-1.11.1-controller-manager.yaml
@@ -171,7 +171,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.2
+        image: quay.io/kubermatic/http-prober:v0.3-dev3
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/api/pkg/resources/test/fixtures/deployment-openstack-1.11.1-kube-state-metrics.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-openstack-1.11.1-kube-state-metrics.yaml
@@ -72,7 +72,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3-dev3
+        image: quay.io/kubermatic/http-prober:v0.3
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/api/pkg/resources/test/fixtures/deployment-openstack-1.11.1-kube-state-metrics.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-openstack-1.11.1-kube-state-metrics.yaml
@@ -72,7 +72,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.2
+        image: quay.io/kubermatic/http-prober:v0.3-dev3
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/api/pkg/resources/test/fixtures/deployment-openstack-1.11.1-machine-controller-webhook.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-openstack-1.11.1-machine-controller-webhook.yaml
@@ -31,6 +31,10 @@ spec:
         - "1"
         - -command
         - '{"command":"/usr/local/bin/webhook","args":["-kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","-logtostderr","-v","4","-listen-address","0.0.0.0:9876"]}'
+        - -wait-for-crd-kind
+        - Machine
+        - -wait-for-crd-apiversion
+        - cluster.k8s.io/v1alpha1
         command:
         - /http-prober-bin/http-prober
         env:
@@ -45,6 +49,8 @@ spec:
         - name: OS_TENANT_NAME
           value: openstack-tenant
         - name: OS_TENANT_ID
+        - name: KUBECONFIG
+          value: /etc/kubernetes/kubeconfig/kubeconfig
         image: docker.io/kubermatic/machine-controller:v1.5.6
         livenessProbe:
           failureThreshold: 8
@@ -89,7 +95,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.2
+        image: quay.io/kubermatic/http-prober:v0.3-dev3
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/api/pkg/resources/test/fixtures/deployment-openstack-1.11.1-machine-controller-webhook.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-openstack-1.11.1-machine-controller-webhook.yaml
@@ -95,7 +95,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3-dev3
+        image: quay.io/kubermatic/http-prober:v0.3
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/api/pkg/resources/test/fixtures/deployment-openstack-1.11.1-machine-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-openstack-1.11.1-machine-controller.yaml
@@ -86,7 +86,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3-dev3
+        image: quay.io/kubermatic/http-prober:v0.3
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/api/pkg/resources/test/fixtures/deployment-openstack-1.11.1-machine-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-openstack-1.11.1-machine-controller.yaml
@@ -34,6 +34,10 @@ spec:
         - "1"
         - -command
         - '{"command":"/usr/local/bin/machine-controller","args":["-kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","-logtostderr","-v","4","-cluster-dns","169.254.20.10","-internal-listen-address","0.0.0.0:8085"]}'
+        - -wait-for-crd-kind
+        - Machine
+        - -wait-for-crd-apiversion
+        - cluster.k8s.io/v1alpha1
         command:
         - /http-prober-bin/http-prober
         env:
@@ -48,6 +52,8 @@ spec:
         - name: OS_TENANT_NAME
           value: openstack-tenant
         - name: OS_TENANT_ID
+        - name: KUBECONFIG
+          value: /etc/kubernetes/kubeconfig/kubeconfig
         image: docker.io/kubermatic/machine-controller:v1.5.6
         livenessProbe:
           failureThreshold: 3
@@ -80,7 +86,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.2
+        image: quay.io/kubermatic/http-prober:v0.3-dev3
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/api/pkg/resources/test/fixtures/deployment-openstack-1.11.1-metrics-server.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-openstack-1.11.1-metrics-server.yaml
@@ -152,7 +152,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.2
+        image: quay.io/kubermatic/http-prober:v0.3-dev3
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/api/pkg/resources/test/fixtures/deployment-openstack-1.11.1-metrics-server.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-openstack-1.11.1-metrics-server.yaml
@@ -152,7 +152,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3-dev3
+        image: quay.io/kubermatic/http-prober:v0.3
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/api/pkg/resources/test/fixtures/deployment-openstack-1.11.1-scheduler.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-openstack-1.11.1-scheduler.yaml
@@ -163,7 +163,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3-dev3
+        image: quay.io/kubermatic/http-prober:v0.3
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/api/pkg/resources/test/fixtures/deployment-openstack-1.11.1-scheduler.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-openstack-1.11.1-scheduler.yaml
@@ -163,7 +163,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.2
+        image: quay.io/kubermatic/http-prober:v0.3-dev3
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/api/pkg/resources/test/fixtures/deployment-openstack-1.11.1-usercluster-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-openstack-1.11.1-usercluster-controller.yaml
@@ -85,7 +85,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.2
+        image: quay.io/kubermatic/http-prober:v0.3-dev3
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/api/pkg/resources/test/fixtures/deployment-openstack-1.11.1-usercluster-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-openstack-1.11.1-usercluster-controller.yaml
@@ -85,7 +85,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3-dev3
+        image: quay.io/kubermatic/http-prober:v0.3
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/api/pkg/resources/test/fixtures/deployment-openstack-1.12.0-controller-manager.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-openstack-1.12.0-controller-manager.yaml
@@ -171,7 +171,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3-dev3
+        image: quay.io/kubermatic/http-prober:v0.3
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/api/pkg/resources/test/fixtures/deployment-openstack-1.12.0-controller-manager.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-openstack-1.12.0-controller-manager.yaml
@@ -171,7 +171,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.2
+        image: quay.io/kubermatic/http-prober:v0.3-dev3
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/api/pkg/resources/test/fixtures/deployment-openstack-1.12.0-kube-state-metrics.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-openstack-1.12.0-kube-state-metrics.yaml
@@ -72,7 +72,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3-dev3
+        image: quay.io/kubermatic/http-prober:v0.3
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/api/pkg/resources/test/fixtures/deployment-openstack-1.12.0-kube-state-metrics.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-openstack-1.12.0-kube-state-metrics.yaml
@@ -72,7 +72,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.2
+        image: quay.io/kubermatic/http-prober:v0.3-dev3
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/api/pkg/resources/test/fixtures/deployment-openstack-1.12.0-machine-controller-webhook.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-openstack-1.12.0-machine-controller-webhook.yaml
@@ -31,6 +31,10 @@ spec:
         - "1"
         - -command
         - '{"command":"/usr/local/bin/webhook","args":["-kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","-logtostderr","-v","4","-listen-address","0.0.0.0:9876"]}'
+        - -wait-for-crd-kind
+        - Machine
+        - -wait-for-crd-apiversion
+        - cluster.k8s.io/v1alpha1
         command:
         - /http-prober-bin/http-prober
         env:
@@ -45,6 +49,8 @@ spec:
         - name: OS_TENANT_NAME
           value: openstack-tenant
         - name: OS_TENANT_ID
+        - name: KUBECONFIG
+          value: /etc/kubernetes/kubeconfig/kubeconfig
         image: docker.io/kubermatic/machine-controller:v1.5.6
         livenessProbe:
           failureThreshold: 8
@@ -89,7 +95,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.2
+        image: quay.io/kubermatic/http-prober:v0.3-dev3
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/api/pkg/resources/test/fixtures/deployment-openstack-1.12.0-machine-controller-webhook.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-openstack-1.12.0-machine-controller-webhook.yaml
@@ -95,7 +95,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3-dev3
+        image: quay.io/kubermatic/http-prober:v0.3
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/api/pkg/resources/test/fixtures/deployment-openstack-1.12.0-machine-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-openstack-1.12.0-machine-controller.yaml
@@ -86,7 +86,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3-dev3
+        image: quay.io/kubermatic/http-prober:v0.3
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/api/pkg/resources/test/fixtures/deployment-openstack-1.12.0-machine-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-openstack-1.12.0-machine-controller.yaml
@@ -34,6 +34,10 @@ spec:
         - "1"
         - -command
         - '{"command":"/usr/local/bin/machine-controller","args":["-kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","-logtostderr","-v","4","-cluster-dns","169.254.20.10","-internal-listen-address","0.0.0.0:8085"]}'
+        - -wait-for-crd-kind
+        - Machine
+        - -wait-for-crd-apiversion
+        - cluster.k8s.io/v1alpha1
         command:
         - /http-prober-bin/http-prober
         env:
@@ -48,6 +52,8 @@ spec:
         - name: OS_TENANT_NAME
           value: openstack-tenant
         - name: OS_TENANT_ID
+        - name: KUBECONFIG
+          value: /etc/kubernetes/kubeconfig/kubeconfig
         image: docker.io/kubermatic/machine-controller:v1.5.6
         livenessProbe:
           failureThreshold: 3
@@ -80,7 +86,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.2
+        image: quay.io/kubermatic/http-prober:v0.3-dev3
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/api/pkg/resources/test/fixtures/deployment-openstack-1.12.0-metrics-server.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-openstack-1.12.0-metrics-server.yaml
@@ -152,7 +152,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.2
+        image: quay.io/kubermatic/http-prober:v0.3-dev3
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/api/pkg/resources/test/fixtures/deployment-openstack-1.12.0-metrics-server.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-openstack-1.12.0-metrics-server.yaml
@@ -152,7 +152,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3-dev3
+        image: quay.io/kubermatic/http-prober:v0.3
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/api/pkg/resources/test/fixtures/deployment-openstack-1.12.0-scheduler.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-openstack-1.12.0-scheduler.yaml
@@ -163,7 +163,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3-dev3
+        image: quay.io/kubermatic/http-prober:v0.3
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/api/pkg/resources/test/fixtures/deployment-openstack-1.12.0-scheduler.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-openstack-1.12.0-scheduler.yaml
@@ -163,7 +163,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.2
+        image: quay.io/kubermatic/http-prober:v0.3-dev3
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/api/pkg/resources/test/fixtures/deployment-openstack-1.12.0-usercluster-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-openstack-1.12.0-usercluster-controller.yaml
@@ -85,7 +85,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.2
+        image: quay.io/kubermatic/http-prober:v0.3-dev3
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/api/pkg/resources/test/fixtures/deployment-openstack-1.12.0-usercluster-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-openstack-1.12.0-usercluster-controller.yaml
@@ -85,7 +85,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3-dev3
+        image: quay.io/kubermatic/http-prober:v0.3
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/api/pkg/resources/test/fixtures/deployment-openstack-1.13.0-controller-manager.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-openstack-1.13.0-controller-manager.yaml
@@ -171,7 +171,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3-dev3
+        image: quay.io/kubermatic/http-prober:v0.3
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/api/pkg/resources/test/fixtures/deployment-openstack-1.13.0-controller-manager.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-openstack-1.13.0-controller-manager.yaml
@@ -171,7 +171,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.2
+        image: quay.io/kubermatic/http-prober:v0.3-dev3
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/api/pkg/resources/test/fixtures/deployment-openstack-1.13.0-kube-state-metrics.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-openstack-1.13.0-kube-state-metrics.yaml
@@ -72,7 +72,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3-dev3
+        image: quay.io/kubermatic/http-prober:v0.3
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/api/pkg/resources/test/fixtures/deployment-openstack-1.13.0-kube-state-metrics.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-openstack-1.13.0-kube-state-metrics.yaml
@@ -72,7 +72,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.2
+        image: quay.io/kubermatic/http-prober:v0.3-dev3
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/api/pkg/resources/test/fixtures/deployment-openstack-1.13.0-machine-controller-webhook.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-openstack-1.13.0-machine-controller-webhook.yaml
@@ -31,6 +31,10 @@ spec:
         - "1"
         - -command
         - '{"command":"/usr/local/bin/webhook","args":["-kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","-logtostderr","-v","4","-listen-address","0.0.0.0:9876"]}'
+        - -wait-for-crd-kind
+        - Machine
+        - -wait-for-crd-apiversion
+        - cluster.k8s.io/v1alpha1
         command:
         - /http-prober-bin/http-prober
         env:
@@ -45,6 +49,8 @@ spec:
         - name: OS_TENANT_NAME
           value: openstack-tenant
         - name: OS_TENANT_ID
+        - name: KUBECONFIG
+          value: /etc/kubernetes/kubeconfig/kubeconfig
         image: docker.io/kubermatic/machine-controller:v1.5.6
         livenessProbe:
           failureThreshold: 8
@@ -89,7 +95,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.2
+        image: quay.io/kubermatic/http-prober:v0.3-dev3
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/api/pkg/resources/test/fixtures/deployment-openstack-1.13.0-machine-controller-webhook.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-openstack-1.13.0-machine-controller-webhook.yaml
@@ -95,7 +95,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3-dev3
+        image: quay.io/kubermatic/http-prober:v0.3
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/api/pkg/resources/test/fixtures/deployment-openstack-1.13.0-machine-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-openstack-1.13.0-machine-controller.yaml
@@ -86,7 +86,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3-dev3
+        image: quay.io/kubermatic/http-prober:v0.3
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/api/pkg/resources/test/fixtures/deployment-openstack-1.13.0-machine-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-openstack-1.13.0-machine-controller.yaml
@@ -34,6 +34,10 @@ spec:
         - "1"
         - -command
         - '{"command":"/usr/local/bin/machine-controller","args":["-kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","-logtostderr","-v","4","-cluster-dns","169.254.20.10","-internal-listen-address","0.0.0.0:8085"]}'
+        - -wait-for-crd-kind
+        - Machine
+        - -wait-for-crd-apiversion
+        - cluster.k8s.io/v1alpha1
         command:
         - /http-prober-bin/http-prober
         env:
@@ -48,6 +52,8 @@ spec:
         - name: OS_TENANT_NAME
           value: openstack-tenant
         - name: OS_TENANT_ID
+        - name: KUBECONFIG
+          value: /etc/kubernetes/kubeconfig/kubeconfig
         image: docker.io/kubermatic/machine-controller:v1.5.6
         livenessProbe:
           failureThreshold: 3
@@ -80,7 +86,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.2
+        image: quay.io/kubermatic/http-prober:v0.3-dev3
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/api/pkg/resources/test/fixtures/deployment-openstack-1.13.0-metrics-server.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-openstack-1.13.0-metrics-server.yaml
@@ -152,7 +152,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.2
+        image: quay.io/kubermatic/http-prober:v0.3-dev3
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/api/pkg/resources/test/fixtures/deployment-openstack-1.13.0-metrics-server.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-openstack-1.13.0-metrics-server.yaml
@@ -152,7 +152,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3-dev3
+        image: quay.io/kubermatic/http-prober:v0.3
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/api/pkg/resources/test/fixtures/deployment-openstack-1.13.0-scheduler.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-openstack-1.13.0-scheduler.yaml
@@ -163,7 +163,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3-dev3
+        image: quay.io/kubermatic/http-prober:v0.3
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/api/pkg/resources/test/fixtures/deployment-openstack-1.13.0-scheduler.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-openstack-1.13.0-scheduler.yaml
@@ -163,7 +163,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.2
+        image: quay.io/kubermatic/http-prober:v0.3-dev3
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/api/pkg/resources/test/fixtures/deployment-openstack-1.13.0-usercluster-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-openstack-1.13.0-usercluster-controller.yaml
@@ -85,7 +85,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.2
+        image: quay.io/kubermatic/http-prober:v0.3-dev3
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/api/pkg/resources/test/fixtures/deployment-openstack-1.13.0-usercluster-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-openstack-1.13.0-usercluster-controller.yaml
@@ -85,7 +85,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3-dev3
+        image: quay.io/kubermatic/http-prober:v0.3
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/api/pkg/resources/test/fixtures/deployment-vsphere-1.10.0-controller-manager.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-vsphere-1.10.0-controller-manager.yaml
@@ -175,7 +175,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.2
+        image: quay.io/kubermatic/http-prober:v0.3-dev3
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/api/pkg/resources/test/fixtures/deployment-vsphere-1.10.0-controller-manager.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-vsphere-1.10.0-controller-manager.yaml
@@ -175,7 +175,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3-dev3
+        image: quay.io/kubermatic/http-prober:v0.3
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/api/pkg/resources/test/fixtures/deployment-vsphere-1.10.0-kube-state-metrics.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-vsphere-1.10.0-kube-state-metrics.yaml
@@ -72,7 +72,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3-dev3
+        image: quay.io/kubermatic/http-prober:v0.3
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/api/pkg/resources/test/fixtures/deployment-vsphere-1.10.0-kube-state-metrics.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-vsphere-1.10.0-kube-state-metrics.yaml
@@ -72,7 +72,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.2
+        image: quay.io/kubermatic/http-prober:v0.3-dev3
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/api/pkg/resources/test/fixtures/deployment-vsphere-1.10.0-machine-controller-webhook.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-vsphere-1.10.0-machine-controller-webhook.yaml
@@ -31,6 +31,10 @@ spec:
         - "1"
         - -command
         - '{"command":"/usr/local/bin/webhook","args":["-kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","-logtostderr","-v","4","-listen-address","0.0.0.0:9876"]}'
+        - -wait-for-crd-kind
+        - Machine
+        - -wait-for-crd-apiversion
+        - cluster.k8s.io/v1alpha1
         command:
         - /http-prober-bin/http-prober
         env:
@@ -38,6 +42,8 @@ spec:
           value: https://vs-endpoint.io
         - name: VSPHERE_USERNAME
         - name: VSPHERE_PASSWORD
+        - name: KUBECONFIG
+          value: /etc/kubernetes/kubeconfig/kubeconfig
         image: docker.io/kubermatic/machine-controller:v1.5.6
         livenessProbe:
           failureThreshold: 8
@@ -82,7 +88,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.2
+        image: quay.io/kubermatic/http-prober:v0.3-dev3
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/api/pkg/resources/test/fixtures/deployment-vsphere-1.10.0-machine-controller-webhook.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-vsphere-1.10.0-machine-controller-webhook.yaml
@@ -88,7 +88,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3-dev3
+        image: quay.io/kubermatic/http-prober:v0.3
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/api/pkg/resources/test/fixtures/deployment-vsphere-1.10.0-machine-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-vsphere-1.10.0-machine-controller.yaml
@@ -34,6 +34,10 @@ spec:
         - "1"
         - -command
         - '{"command":"/usr/local/bin/machine-controller","args":["-kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","-logtostderr","-v","4","-cluster-dns","169.254.20.10","-internal-listen-address","0.0.0.0:8085"]}'
+        - -wait-for-crd-kind
+        - Machine
+        - -wait-for-crd-apiversion
+        - cluster.k8s.io/v1alpha1
         command:
         - /http-prober-bin/http-prober
         env:
@@ -41,6 +45,8 @@ spec:
           value: https://vs-endpoint.io
         - name: VSPHERE_USERNAME
         - name: VSPHERE_PASSWORD
+        - name: KUBECONFIG
+          value: /etc/kubernetes/kubeconfig/kubeconfig
         image: docker.io/kubermatic/machine-controller:v1.5.6
         livenessProbe:
           failureThreshold: 3
@@ -73,7 +79,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.2
+        image: quay.io/kubermatic/http-prober:v0.3-dev3
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/api/pkg/resources/test/fixtures/deployment-vsphere-1.10.0-machine-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-vsphere-1.10.0-machine-controller.yaml
@@ -79,7 +79,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3-dev3
+        image: quay.io/kubermatic/http-prober:v0.3
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/api/pkg/resources/test/fixtures/deployment-vsphere-1.10.0-metrics-server.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-vsphere-1.10.0-metrics-server.yaml
@@ -152,7 +152,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.2
+        image: quay.io/kubermatic/http-prober:v0.3-dev3
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/api/pkg/resources/test/fixtures/deployment-vsphere-1.10.0-metrics-server.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-vsphere-1.10.0-metrics-server.yaml
@@ -152,7 +152,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3-dev3
+        image: quay.io/kubermatic/http-prober:v0.3
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/api/pkg/resources/test/fixtures/deployment-vsphere-1.10.0-scheduler.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-vsphere-1.10.0-scheduler.yaml
@@ -163,7 +163,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3-dev3
+        image: quay.io/kubermatic/http-prober:v0.3
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/api/pkg/resources/test/fixtures/deployment-vsphere-1.10.0-scheduler.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-vsphere-1.10.0-scheduler.yaml
@@ -163,7 +163,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.2
+        image: quay.io/kubermatic/http-prober:v0.3-dev3
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/api/pkg/resources/test/fixtures/deployment-vsphere-1.10.0-usercluster-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-vsphere-1.10.0-usercluster-controller.yaml
@@ -85,7 +85,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.2
+        image: quay.io/kubermatic/http-prober:v0.3-dev3
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/api/pkg/resources/test/fixtures/deployment-vsphere-1.10.0-usercluster-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-vsphere-1.10.0-usercluster-controller.yaml
@@ -85,7 +85,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3-dev3
+        image: quay.io/kubermatic/http-prober:v0.3
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/api/pkg/resources/test/fixtures/deployment-vsphere-1.10.6-controller-manager.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-vsphere-1.10.6-controller-manager.yaml
@@ -175,7 +175,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.2
+        image: quay.io/kubermatic/http-prober:v0.3-dev3
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/api/pkg/resources/test/fixtures/deployment-vsphere-1.10.6-controller-manager.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-vsphere-1.10.6-controller-manager.yaml
@@ -175,7 +175,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3-dev3
+        image: quay.io/kubermatic/http-prober:v0.3
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/api/pkg/resources/test/fixtures/deployment-vsphere-1.10.6-kube-state-metrics.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-vsphere-1.10.6-kube-state-metrics.yaml
@@ -72,7 +72,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3-dev3
+        image: quay.io/kubermatic/http-prober:v0.3
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/api/pkg/resources/test/fixtures/deployment-vsphere-1.10.6-kube-state-metrics.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-vsphere-1.10.6-kube-state-metrics.yaml
@@ -72,7 +72,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.2
+        image: quay.io/kubermatic/http-prober:v0.3-dev3
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/api/pkg/resources/test/fixtures/deployment-vsphere-1.10.6-machine-controller-webhook.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-vsphere-1.10.6-machine-controller-webhook.yaml
@@ -31,6 +31,10 @@ spec:
         - "1"
         - -command
         - '{"command":"/usr/local/bin/webhook","args":["-kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","-logtostderr","-v","4","-listen-address","0.0.0.0:9876"]}'
+        - -wait-for-crd-kind
+        - Machine
+        - -wait-for-crd-apiversion
+        - cluster.k8s.io/v1alpha1
         command:
         - /http-prober-bin/http-prober
         env:
@@ -38,6 +42,8 @@ spec:
           value: https://vs-endpoint.io
         - name: VSPHERE_USERNAME
         - name: VSPHERE_PASSWORD
+        - name: KUBECONFIG
+          value: /etc/kubernetes/kubeconfig/kubeconfig
         image: docker.io/kubermatic/machine-controller:v1.5.6
         livenessProbe:
           failureThreshold: 8
@@ -82,7 +88,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.2
+        image: quay.io/kubermatic/http-prober:v0.3-dev3
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/api/pkg/resources/test/fixtures/deployment-vsphere-1.10.6-machine-controller-webhook.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-vsphere-1.10.6-machine-controller-webhook.yaml
@@ -88,7 +88,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3-dev3
+        image: quay.io/kubermatic/http-prober:v0.3
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/api/pkg/resources/test/fixtures/deployment-vsphere-1.10.6-machine-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-vsphere-1.10.6-machine-controller.yaml
@@ -34,6 +34,10 @@ spec:
         - "1"
         - -command
         - '{"command":"/usr/local/bin/machine-controller","args":["-kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","-logtostderr","-v","4","-cluster-dns","169.254.20.10","-internal-listen-address","0.0.0.0:8085"]}'
+        - -wait-for-crd-kind
+        - Machine
+        - -wait-for-crd-apiversion
+        - cluster.k8s.io/v1alpha1
         command:
         - /http-prober-bin/http-prober
         env:
@@ -41,6 +45,8 @@ spec:
           value: https://vs-endpoint.io
         - name: VSPHERE_USERNAME
         - name: VSPHERE_PASSWORD
+        - name: KUBECONFIG
+          value: /etc/kubernetes/kubeconfig/kubeconfig
         image: docker.io/kubermatic/machine-controller:v1.5.6
         livenessProbe:
           failureThreshold: 3
@@ -73,7 +79,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.2
+        image: quay.io/kubermatic/http-prober:v0.3-dev3
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/api/pkg/resources/test/fixtures/deployment-vsphere-1.10.6-machine-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-vsphere-1.10.6-machine-controller.yaml
@@ -79,7 +79,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3-dev3
+        image: quay.io/kubermatic/http-prober:v0.3
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/api/pkg/resources/test/fixtures/deployment-vsphere-1.10.6-metrics-server.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-vsphere-1.10.6-metrics-server.yaml
@@ -152,7 +152,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.2
+        image: quay.io/kubermatic/http-prober:v0.3-dev3
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/api/pkg/resources/test/fixtures/deployment-vsphere-1.10.6-metrics-server.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-vsphere-1.10.6-metrics-server.yaml
@@ -152,7 +152,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3-dev3
+        image: quay.io/kubermatic/http-prober:v0.3
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/api/pkg/resources/test/fixtures/deployment-vsphere-1.10.6-scheduler.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-vsphere-1.10.6-scheduler.yaml
@@ -163,7 +163,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3-dev3
+        image: quay.io/kubermatic/http-prober:v0.3
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/api/pkg/resources/test/fixtures/deployment-vsphere-1.10.6-scheduler.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-vsphere-1.10.6-scheduler.yaml
@@ -163,7 +163,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.2
+        image: quay.io/kubermatic/http-prober:v0.3-dev3
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/api/pkg/resources/test/fixtures/deployment-vsphere-1.10.6-usercluster-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-vsphere-1.10.6-usercluster-controller.yaml
@@ -85,7 +85,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.2
+        image: quay.io/kubermatic/http-prober:v0.3-dev3
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/api/pkg/resources/test/fixtures/deployment-vsphere-1.10.6-usercluster-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-vsphere-1.10.6-usercluster-controller.yaml
@@ -85,7 +85,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3-dev3
+        image: quay.io/kubermatic/http-prober:v0.3
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/api/pkg/resources/test/fixtures/deployment-vsphere-1.11.0-controller-manager.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-vsphere-1.11.0-controller-manager.yaml
@@ -175,7 +175,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.2
+        image: quay.io/kubermatic/http-prober:v0.3-dev3
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/api/pkg/resources/test/fixtures/deployment-vsphere-1.11.0-controller-manager.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-vsphere-1.11.0-controller-manager.yaml
@@ -175,7 +175,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3-dev3
+        image: quay.io/kubermatic/http-prober:v0.3
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/api/pkg/resources/test/fixtures/deployment-vsphere-1.11.0-kube-state-metrics.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-vsphere-1.11.0-kube-state-metrics.yaml
@@ -72,7 +72,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3-dev3
+        image: quay.io/kubermatic/http-prober:v0.3
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/api/pkg/resources/test/fixtures/deployment-vsphere-1.11.0-kube-state-metrics.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-vsphere-1.11.0-kube-state-metrics.yaml
@@ -72,7 +72,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.2
+        image: quay.io/kubermatic/http-prober:v0.3-dev3
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/api/pkg/resources/test/fixtures/deployment-vsphere-1.11.0-machine-controller-webhook.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-vsphere-1.11.0-machine-controller-webhook.yaml
@@ -31,6 +31,10 @@ spec:
         - "1"
         - -command
         - '{"command":"/usr/local/bin/webhook","args":["-kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","-logtostderr","-v","4","-listen-address","0.0.0.0:9876"]}'
+        - -wait-for-crd-kind
+        - Machine
+        - -wait-for-crd-apiversion
+        - cluster.k8s.io/v1alpha1
         command:
         - /http-prober-bin/http-prober
         env:
@@ -38,6 +42,8 @@ spec:
           value: https://vs-endpoint.io
         - name: VSPHERE_USERNAME
         - name: VSPHERE_PASSWORD
+        - name: KUBECONFIG
+          value: /etc/kubernetes/kubeconfig/kubeconfig
         image: docker.io/kubermatic/machine-controller:v1.5.6
         livenessProbe:
           failureThreshold: 8
@@ -82,7 +88,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.2
+        image: quay.io/kubermatic/http-prober:v0.3-dev3
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/api/pkg/resources/test/fixtures/deployment-vsphere-1.11.0-machine-controller-webhook.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-vsphere-1.11.0-machine-controller-webhook.yaml
@@ -88,7 +88,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3-dev3
+        image: quay.io/kubermatic/http-prober:v0.3
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/api/pkg/resources/test/fixtures/deployment-vsphere-1.11.0-machine-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-vsphere-1.11.0-machine-controller.yaml
@@ -34,6 +34,10 @@ spec:
         - "1"
         - -command
         - '{"command":"/usr/local/bin/machine-controller","args":["-kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","-logtostderr","-v","4","-cluster-dns","169.254.20.10","-internal-listen-address","0.0.0.0:8085"]}'
+        - -wait-for-crd-kind
+        - Machine
+        - -wait-for-crd-apiversion
+        - cluster.k8s.io/v1alpha1
         command:
         - /http-prober-bin/http-prober
         env:
@@ -41,6 +45,8 @@ spec:
           value: https://vs-endpoint.io
         - name: VSPHERE_USERNAME
         - name: VSPHERE_PASSWORD
+        - name: KUBECONFIG
+          value: /etc/kubernetes/kubeconfig/kubeconfig
         image: docker.io/kubermatic/machine-controller:v1.5.6
         livenessProbe:
           failureThreshold: 3
@@ -73,7 +79,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.2
+        image: quay.io/kubermatic/http-prober:v0.3-dev3
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/api/pkg/resources/test/fixtures/deployment-vsphere-1.11.0-machine-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-vsphere-1.11.0-machine-controller.yaml
@@ -79,7 +79,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3-dev3
+        image: quay.io/kubermatic/http-prober:v0.3
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/api/pkg/resources/test/fixtures/deployment-vsphere-1.11.0-metrics-server.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-vsphere-1.11.0-metrics-server.yaml
@@ -152,7 +152,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.2
+        image: quay.io/kubermatic/http-prober:v0.3-dev3
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/api/pkg/resources/test/fixtures/deployment-vsphere-1.11.0-metrics-server.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-vsphere-1.11.0-metrics-server.yaml
@@ -152,7 +152,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3-dev3
+        image: quay.io/kubermatic/http-prober:v0.3
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/api/pkg/resources/test/fixtures/deployment-vsphere-1.11.0-scheduler.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-vsphere-1.11.0-scheduler.yaml
@@ -163,7 +163,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3-dev3
+        image: quay.io/kubermatic/http-prober:v0.3
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/api/pkg/resources/test/fixtures/deployment-vsphere-1.11.0-scheduler.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-vsphere-1.11.0-scheduler.yaml
@@ -163,7 +163,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.2
+        image: quay.io/kubermatic/http-prober:v0.3-dev3
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/api/pkg/resources/test/fixtures/deployment-vsphere-1.11.0-usercluster-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-vsphere-1.11.0-usercluster-controller.yaml
@@ -85,7 +85,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.2
+        image: quay.io/kubermatic/http-prober:v0.3-dev3
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/api/pkg/resources/test/fixtures/deployment-vsphere-1.11.0-usercluster-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-vsphere-1.11.0-usercluster-controller.yaml
@@ -85,7 +85,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3-dev3
+        image: quay.io/kubermatic/http-prober:v0.3
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/api/pkg/resources/test/fixtures/deployment-vsphere-1.11.1-controller-manager.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-vsphere-1.11.1-controller-manager.yaml
@@ -175,7 +175,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.2
+        image: quay.io/kubermatic/http-prober:v0.3-dev3
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/api/pkg/resources/test/fixtures/deployment-vsphere-1.11.1-controller-manager.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-vsphere-1.11.1-controller-manager.yaml
@@ -175,7 +175,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3-dev3
+        image: quay.io/kubermatic/http-prober:v0.3
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/api/pkg/resources/test/fixtures/deployment-vsphere-1.11.1-kube-state-metrics.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-vsphere-1.11.1-kube-state-metrics.yaml
@@ -72,7 +72,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3-dev3
+        image: quay.io/kubermatic/http-prober:v0.3
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/api/pkg/resources/test/fixtures/deployment-vsphere-1.11.1-kube-state-metrics.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-vsphere-1.11.1-kube-state-metrics.yaml
@@ -72,7 +72,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.2
+        image: quay.io/kubermatic/http-prober:v0.3-dev3
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/api/pkg/resources/test/fixtures/deployment-vsphere-1.11.1-machine-controller-webhook.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-vsphere-1.11.1-machine-controller-webhook.yaml
@@ -31,6 +31,10 @@ spec:
         - "1"
         - -command
         - '{"command":"/usr/local/bin/webhook","args":["-kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","-logtostderr","-v","4","-listen-address","0.0.0.0:9876"]}'
+        - -wait-for-crd-kind
+        - Machine
+        - -wait-for-crd-apiversion
+        - cluster.k8s.io/v1alpha1
         command:
         - /http-prober-bin/http-prober
         env:
@@ -38,6 +42,8 @@ spec:
           value: https://vs-endpoint.io
         - name: VSPHERE_USERNAME
         - name: VSPHERE_PASSWORD
+        - name: KUBECONFIG
+          value: /etc/kubernetes/kubeconfig/kubeconfig
         image: docker.io/kubermatic/machine-controller:v1.5.6
         livenessProbe:
           failureThreshold: 8
@@ -82,7 +88,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.2
+        image: quay.io/kubermatic/http-prober:v0.3-dev3
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/api/pkg/resources/test/fixtures/deployment-vsphere-1.11.1-machine-controller-webhook.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-vsphere-1.11.1-machine-controller-webhook.yaml
@@ -88,7 +88,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3-dev3
+        image: quay.io/kubermatic/http-prober:v0.3
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/api/pkg/resources/test/fixtures/deployment-vsphere-1.11.1-machine-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-vsphere-1.11.1-machine-controller.yaml
@@ -34,6 +34,10 @@ spec:
         - "1"
         - -command
         - '{"command":"/usr/local/bin/machine-controller","args":["-kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","-logtostderr","-v","4","-cluster-dns","169.254.20.10","-internal-listen-address","0.0.0.0:8085"]}'
+        - -wait-for-crd-kind
+        - Machine
+        - -wait-for-crd-apiversion
+        - cluster.k8s.io/v1alpha1
         command:
         - /http-prober-bin/http-prober
         env:
@@ -41,6 +45,8 @@ spec:
           value: https://vs-endpoint.io
         - name: VSPHERE_USERNAME
         - name: VSPHERE_PASSWORD
+        - name: KUBECONFIG
+          value: /etc/kubernetes/kubeconfig/kubeconfig
         image: docker.io/kubermatic/machine-controller:v1.5.6
         livenessProbe:
           failureThreshold: 3
@@ -73,7 +79,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.2
+        image: quay.io/kubermatic/http-prober:v0.3-dev3
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/api/pkg/resources/test/fixtures/deployment-vsphere-1.11.1-machine-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-vsphere-1.11.1-machine-controller.yaml
@@ -79,7 +79,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3-dev3
+        image: quay.io/kubermatic/http-prober:v0.3
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/api/pkg/resources/test/fixtures/deployment-vsphere-1.11.1-metrics-server.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-vsphere-1.11.1-metrics-server.yaml
@@ -152,7 +152,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.2
+        image: quay.io/kubermatic/http-prober:v0.3-dev3
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/api/pkg/resources/test/fixtures/deployment-vsphere-1.11.1-metrics-server.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-vsphere-1.11.1-metrics-server.yaml
@@ -152,7 +152,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3-dev3
+        image: quay.io/kubermatic/http-prober:v0.3
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/api/pkg/resources/test/fixtures/deployment-vsphere-1.11.1-scheduler.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-vsphere-1.11.1-scheduler.yaml
@@ -163,7 +163,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3-dev3
+        image: quay.io/kubermatic/http-prober:v0.3
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/api/pkg/resources/test/fixtures/deployment-vsphere-1.11.1-scheduler.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-vsphere-1.11.1-scheduler.yaml
@@ -163,7 +163,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.2
+        image: quay.io/kubermatic/http-prober:v0.3-dev3
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/api/pkg/resources/test/fixtures/deployment-vsphere-1.11.1-usercluster-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-vsphere-1.11.1-usercluster-controller.yaml
@@ -85,7 +85,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.2
+        image: quay.io/kubermatic/http-prober:v0.3-dev3
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/api/pkg/resources/test/fixtures/deployment-vsphere-1.11.1-usercluster-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-vsphere-1.11.1-usercluster-controller.yaml
@@ -85,7 +85,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3-dev3
+        image: quay.io/kubermatic/http-prober:v0.3
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/api/pkg/resources/test/fixtures/deployment-vsphere-1.12.0-controller-manager.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-vsphere-1.12.0-controller-manager.yaml
@@ -175,7 +175,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.2
+        image: quay.io/kubermatic/http-prober:v0.3-dev3
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/api/pkg/resources/test/fixtures/deployment-vsphere-1.12.0-controller-manager.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-vsphere-1.12.0-controller-manager.yaml
@@ -175,7 +175,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3-dev3
+        image: quay.io/kubermatic/http-prober:v0.3
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/api/pkg/resources/test/fixtures/deployment-vsphere-1.12.0-kube-state-metrics.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-vsphere-1.12.0-kube-state-metrics.yaml
@@ -72,7 +72,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3-dev3
+        image: quay.io/kubermatic/http-prober:v0.3
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/api/pkg/resources/test/fixtures/deployment-vsphere-1.12.0-kube-state-metrics.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-vsphere-1.12.0-kube-state-metrics.yaml
@@ -72,7 +72,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.2
+        image: quay.io/kubermatic/http-prober:v0.3-dev3
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/api/pkg/resources/test/fixtures/deployment-vsphere-1.12.0-machine-controller-webhook.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-vsphere-1.12.0-machine-controller-webhook.yaml
@@ -31,6 +31,10 @@ spec:
         - "1"
         - -command
         - '{"command":"/usr/local/bin/webhook","args":["-kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","-logtostderr","-v","4","-listen-address","0.0.0.0:9876"]}'
+        - -wait-for-crd-kind
+        - Machine
+        - -wait-for-crd-apiversion
+        - cluster.k8s.io/v1alpha1
         command:
         - /http-prober-bin/http-prober
         env:
@@ -38,6 +42,8 @@ spec:
           value: https://vs-endpoint.io
         - name: VSPHERE_USERNAME
         - name: VSPHERE_PASSWORD
+        - name: KUBECONFIG
+          value: /etc/kubernetes/kubeconfig/kubeconfig
         image: docker.io/kubermatic/machine-controller:v1.5.6
         livenessProbe:
           failureThreshold: 8
@@ -82,7 +88,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.2
+        image: quay.io/kubermatic/http-prober:v0.3-dev3
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/api/pkg/resources/test/fixtures/deployment-vsphere-1.12.0-machine-controller-webhook.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-vsphere-1.12.0-machine-controller-webhook.yaml
@@ -88,7 +88,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3-dev3
+        image: quay.io/kubermatic/http-prober:v0.3
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/api/pkg/resources/test/fixtures/deployment-vsphere-1.12.0-machine-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-vsphere-1.12.0-machine-controller.yaml
@@ -34,6 +34,10 @@ spec:
         - "1"
         - -command
         - '{"command":"/usr/local/bin/machine-controller","args":["-kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","-logtostderr","-v","4","-cluster-dns","169.254.20.10","-internal-listen-address","0.0.0.0:8085"]}'
+        - -wait-for-crd-kind
+        - Machine
+        - -wait-for-crd-apiversion
+        - cluster.k8s.io/v1alpha1
         command:
         - /http-prober-bin/http-prober
         env:
@@ -41,6 +45,8 @@ spec:
           value: https://vs-endpoint.io
         - name: VSPHERE_USERNAME
         - name: VSPHERE_PASSWORD
+        - name: KUBECONFIG
+          value: /etc/kubernetes/kubeconfig/kubeconfig
         image: docker.io/kubermatic/machine-controller:v1.5.6
         livenessProbe:
           failureThreshold: 3
@@ -73,7 +79,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.2
+        image: quay.io/kubermatic/http-prober:v0.3-dev3
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/api/pkg/resources/test/fixtures/deployment-vsphere-1.12.0-machine-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-vsphere-1.12.0-machine-controller.yaml
@@ -79,7 +79,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3-dev3
+        image: quay.io/kubermatic/http-prober:v0.3
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/api/pkg/resources/test/fixtures/deployment-vsphere-1.12.0-metrics-server.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-vsphere-1.12.0-metrics-server.yaml
@@ -152,7 +152,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.2
+        image: quay.io/kubermatic/http-prober:v0.3-dev3
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/api/pkg/resources/test/fixtures/deployment-vsphere-1.12.0-metrics-server.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-vsphere-1.12.0-metrics-server.yaml
@@ -152,7 +152,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3-dev3
+        image: quay.io/kubermatic/http-prober:v0.3
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/api/pkg/resources/test/fixtures/deployment-vsphere-1.12.0-scheduler.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-vsphere-1.12.0-scheduler.yaml
@@ -163,7 +163,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3-dev3
+        image: quay.io/kubermatic/http-prober:v0.3
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/api/pkg/resources/test/fixtures/deployment-vsphere-1.12.0-scheduler.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-vsphere-1.12.0-scheduler.yaml
@@ -163,7 +163,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.2
+        image: quay.io/kubermatic/http-prober:v0.3-dev3
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/api/pkg/resources/test/fixtures/deployment-vsphere-1.12.0-usercluster-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-vsphere-1.12.0-usercluster-controller.yaml
@@ -85,7 +85,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.2
+        image: quay.io/kubermatic/http-prober:v0.3-dev3
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/api/pkg/resources/test/fixtures/deployment-vsphere-1.12.0-usercluster-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-vsphere-1.12.0-usercluster-controller.yaml
@@ -85,7 +85,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3-dev3
+        image: quay.io/kubermatic/http-prober:v0.3
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/api/pkg/resources/test/fixtures/deployment-vsphere-1.13.0-controller-manager.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-vsphere-1.13.0-controller-manager.yaml
@@ -175,7 +175,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.2
+        image: quay.io/kubermatic/http-prober:v0.3-dev3
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/api/pkg/resources/test/fixtures/deployment-vsphere-1.13.0-controller-manager.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-vsphere-1.13.0-controller-manager.yaml
@@ -175,7 +175,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3-dev3
+        image: quay.io/kubermatic/http-prober:v0.3
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/api/pkg/resources/test/fixtures/deployment-vsphere-1.13.0-kube-state-metrics.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-vsphere-1.13.0-kube-state-metrics.yaml
@@ -72,7 +72,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3-dev3
+        image: quay.io/kubermatic/http-prober:v0.3
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/api/pkg/resources/test/fixtures/deployment-vsphere-1.13.0-kube-state-metrics.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-vsphere-1.13.0-kube-state-metrics.yaml
@@ -72,7 +72,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.2
+        image: quay.io/kubermatic/http-prober:v0.3-dev3
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/api/pkg/resources/test/fixtures/deployment-vsphere-1.13.0-machine-controller-webhook.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-vsphere-1.13.0-machine-controller-webhook.yaml
@@ -31,6 +31,10 @@ spec:
         - "1"
         - -command
         - '{"command":"/usr/local/bin/webhook","args":["-kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","-logtostderr","-v","4","-listen-address","0.0.0.0:9876"]}'
+        - -wait-for-crd-kind
+        - Machine
+        - -wait-for-crd-apiversion
+        - cluster.k8s.io/v1alpha1
         command:
         - /http-prober-bin/http-prober
         env:
@@ -38,6 +42,8 @@ spec:
           value: https://vs-endpoint.io
         - name: VSPHERE_USERNAME
         - name: VSPHERE_PASSWORD
+        - name: KUBECONFIG
+          value: /etc/kubernetes/kubeconfig/kubeconfig
         image: docker.io/kubermatic/machine-controller:v1.5.6
         livenessProbe:
           failureThreshold: 8
@@ -82,7 +88,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.2
+        image: quay.io/kubermatic/http-prober:v0.3-dev3
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/api/pkg/resources/test/fixtures/deployment-vsphere-1.13.0-machine-controller-webhook.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-vsphere-1.13.0-machine-controller-webhook.yaml
@@ -88,7 +88,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3-dev3
+        image: quay.io/kubermatic/http-prober:v0.3
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/api/pkg/resources/test/fixtures/deployment-vsphere-1.13.0-machine-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-vsphere-1.13.0-machine-controller.yaml
@@ -34,6 +34,10 @@ spec:
         - "1"
         - -command
         - '{"command":"/usr/local/bin/machine-controller","args":["-kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","-logtostderr","-v","4","-cluster-dns","169.254.20.10","-internal-listen-address","0.0.0.0:8085"]}'
+        - -wait-for-crd-kind
+        - Machine
+        - -wait-for-crd-apiversion
+        - cluster.k8s.io/v1alpha1
         command:
         - /http-prober-bin/http-prober
         env:
@@ -41,6 +45,8 @@ spec:
           value: https://vs-endpoint.io
         - name: VSPHERE_USERNAME
         - name: VSPHERE_PASSWORD
+        - name: KUBECONFIG
+          value: /etc/kubernetes/kubeconfig/kubeconfig
         image: docker.io/kubermatic/machine-controller:v1.5.6
         livenessProbe:
           failureThreshold: 3
@@ -73,7 +79,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.2
+        image: quay.io/kubermatic/http-prober:v0.3-dev3
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/api/pkg/resources/test/fixtures/deployment-vsphere-1.13.0-machine-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-vsphere-1.13.0-machine-controller.yaml
@@ -79,7 +79,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3-dev3
+        image: quay.io/kubermatic/http-prober:v0.3
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/api/pkg/resources/test/fixtures/deployment-vsphere-1.13.0-metrics-server.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-vsphere-1.13.0-metrics-server.yaml
@@ -152,7 +152,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.2
+        image: quay.io/kubermatic/http-prober:v0.3-dev3
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/api/pkg/resources/test/fixtures/deployment-vsphere-1.13.0-metrics-server.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-vsphere-1.13.0-metrics-server.yaml
@@ -152,7 +152,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3-dev3
+        image: quay.io/kubermatic/http-prober:v0.3
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/api/pkg/resources/test/fixtures/deployment-vsphere-1.13.0-scheduler.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-vsphere-1.13.0-scheduler.yaml
@@ -163,7 +163,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3-dev3
+        image: quay.io/kubermatic/http-prober:v0.3
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/api/pkg/resources/test/fixtures/deployment-vsphere-1.13.0-scheduler.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-vsphere-1.13.0-scheduler.yaml
@@ -163,7 +163,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.2
+        image: quay.io/kubermatic/http-prober:v0.3-dev3
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/api/pkg/resources/test/fixtures/deployment-vsphere-1.13.0-usercluster-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-vsphere-1.13.0-usercluster-controller.yaml
@@ -85,7 +85,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.2
+        image: quay.io/kubermatic/http-prober:v0.3-dev3
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/api/pkg/resources/test/fixtures/deployment-vsphere-1.13.0-usercluster-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-vsphere-1.13.0-usercluster-controller.yaml
@@ -85,7 +85,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3-dev3
+        image: quay.io/kubermatic/http-prober:v0.3
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/api/pkg/resources/usercluster/deployment.go
+++ b/api/pkg/resources/usercluster/deployment.go
@@ -159,7 +159,7 @@ func DeploymentCreator(data userclusterControllerData, openshift bool) reconcili
 				},
 			}
 
-			wrappedPodSpec, err := apiserver.IsRunningWrapper(data, dep.Spec.Template.Spec, sets.NewString(name))
+			wrappedPodSpec, err := apiserver.IsRunningWrapper(data, dep.Spec.Template.Spec, sets.NewString(name), "", "")
 			if err != nil {
 				return nil, fmt.Errorf("failed to add apiserver.IsRunningWrapper: %v", err)
 			}


### PR DESCRIPTION
**What this PR does / why we need it**:

Currently, creation of new Openshift clusters takes an unecesarily long amount of time because:
* The openshift apiserver doesn't wait for the kube-apiserver even thought it needs it
* The openshift network operator, openshift dns operator, openshift oauth and console deployments dont wait for their CRD to be available and just start crashlooping initially

This PR fixes that by extending the http-proberl to be able to optionally check for the existence of a configurable CRD.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Documentation**:
<!-- Add links to the related documentation changes related to this pull request. E.g. the link to the kubermatic/docs pullrequest. -->

**Does this PR introduce a user-facing change?**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If  no release note is required, just write "NONE".
-->
```release-note
none
```

/assign @xrstf 
/hold

To bump the image to something without a `-dev` suffix