### PR TITLE
allow cluster owner to manage RBACs

### DIFF
--- a/api/pkg/controller/rbac-user-cluster/mapper.go
+++ b/api/pkg/controller/rbac-user-cluster/mapper.go
@@ -24,8 +24,11 @@ const (
 
 // generateVerbsForGroup generates a set of verbs for a group
 func generateVerbsForGroup(groupName string) ([]string, error) {
-	// verbs for owners or editors
-	if groupName == rbac.OwnerGroupNamePrefix || groupName == rbac.EditorGroupNamePrefix {
+	// verbs for owners
+	if groupName == rbac.OwnerGroupNamePrefix {
+		return []string{"create", "list", "get", "update", "delete", "patch", "watch", "deletecollection"}, nil
+	}
+	if groupName == rbac.EditorGroupNamePrefix {
 		return []string{"create", "list", "get", "update", "delete"}, nil
 	}
 
@@ -65,6 +68,13 @@ func GenerateRBACClusterRole(resourceName string) (*rbacv1.ClusterRole, error) {
 				Verbs:     []string{"get", "list"},
 			},
 		},
+	}
+	if groupName == rbac.OwnerGroupNamePrefix {
+		clusterRole.Rules = append(clusterRole.Rules, rbacv1.PolicyRule{
+			APIGroups: []string{"rbac.authorization.k8s.io"},
+			Resources: []string{"*"},
+			Verbs:     verbs,
+		})
 	}
 	return clusterRole, nil
 }

--- a/api/pkg/controller/rbac-user-cluster/mapper_test.go
+++ b/api/pkg/controller/rbac-user-cluster/mapper_test.go
@@ -77,7 +77,7 @@ func TestGenerateVerbsForGroup(t *testing.T) {
 		{
 			name:          "scenario 1: generate verbs for owners",
 			resurceName:   genResourceName(rbac.OwnerGroupNamePrefix),
-			expectedVerbs: []string{"create", "list", "get", "update", "delete"},
+			expectedVerbs: []string{"create", "list", "get", "update", "delete", "patch", "watch", "deletecollection"},
 			expectError:   false,
 		},
 		{


### PR DESCRIPTION
**What this PR does / why we need it**: allow cluster owner to manage RBACs

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #4320 

```release-note
allow cluster owner to manage RBACs from Kubermatic API
```
