### PR TITLE
conformance-tests: bump k8s versions

### DIFF
--- a/containers/conformance-tests/install-kube-tests.sh
+++ b/containers/conformance-tests/install-kube-tests.sh
@@ -7,10 +7,10 @@ set -euox pipefail
 TMP_ROOT="./.install-tmp"
 
 declare -A FULL_VERSIONS
-FULL_VERSIONS["1.13"]="v1.13.5"
-FULL_VERSIONS["1.14"]="v1.14.3"
-FULL_VERSIONS["1.15"]="v1.15.0"
-FULL_VERSIONS["1.16"]="v1.16.0-rc.2"
+FULL_VERSIONS["1.13"]="v1.13.11"
+FULL_VERSIONS["1.14"]="v1.14.7"
+FULL_VERSIONS["1.15"]="v1.15.4"
+FULL_VERSIONS["1.16"]="v1.16.0"
 
 for VERSION in 1.{13..16}; do
     DIRECTORY="${ROOT_DIR}/${VERSION}"

--- a/containers/conformance-tests/release.sh
+++ b/containers/conformance-tests/release.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 
-TAG=v0.10.4
+TAG=v0.10.5
 
 set -euox pipefail
 


### PR DESCRIPTION
**What this PR does / why we need it**:

This PR bumps Kubernetes versions used for the conformance tests binaries to the latest ones.

**Special notes for your reviewer**:

I don't have permissions to push to Docker Hub, so someone will have to do that for me.

**Does this PR introduce a user-facing change?**:
```release-note
NONE
```
