### PR TITLE
extend permissions to get pods for the user cluster

### DIFF
--- a/api/pkg/controller/rbac-user-cluster/mapper.go
+++ b/api/pkg/controller/rbac-user-cluster/mapper.go
@@ -64,7 +64,7 @@ func GenerateRBACClusterRole(resourceName string) (*rbacv1.ClusterRole, error) {
 			},
 			{
 				APIGroups: []string{""},
-				Resources: []string{"nodes"},
+				Resources: []string{"pods", "nodes"},
 				Verbs:     []string{"get", "list"},
 			},
 		},


### PR DESCRIPTION
**What this PR does / why we need it**: Extend permissions to get pods for the user cluster. It's needed to manage RBACs for the owners: `(groups=[\"owners\" \"system:authenticated\"]) is attempting to grant RBAC permissions not currently held:\n{APIGroups:[\"\"], Resources:[\"pods\"], Verbs:[\"get\"]}"`

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

```release-note
NONE
```
