### PR TITLE
drop Kubernetes 1.13

### DIFF
--- a/config/kubermatic/static/master/updates.yaml
+++ b/config/kubermatic/static/master/updates.yaml
@@ -23,10 +23,6 @@ updates:
   automatic: false
 
 # ======= 1.13 =======
-# Allow to change to any patch version
-- from: 1.13.*
-  to: 1.13.*
-  automatic: false
 # CVE-2019-11247, CVE-2019-11249, CVE-2019-9512, CVE-2019-9514
 - from: <= 1.13.9, >= 1.13.0
   to: 1.13.10

--- a/config/kubermatic/static/master/versions.yaml
+++ b/config/kubermatic/static/master/versions.yaml
@@ -1,7 +1,4 @@
 versions:
-# Kubernetes 1.13
-- version: "1.13.10"
-  default: false
 # Kubernetes 1.14
 - version: "v1.14.6"
   default: true


### PR DESCRIPTION
```release-note
Kubernetes 1.13 which is end-of-life has been removed.
```

/assign @alvaroaleman 