### PR TITLE
Update Alertmanager to 0.19

### DIFF
--- a/config/monitoring/alertmanager/Chart.yaml
+++ b/config/monitoring/alertmanager/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 name: alertmanager
-version: 2.0.3
-appVersion: v0.18.0
+version: 2.0.4
+appVersion: v0.19.0
 description: Alertmanager for Kubermatic
 keywords:
 - kubermatic

--- a/config/monitoring/alertmanager/values.yaml
+++ b/config/monitoring/alertmanager/values.yaml
@@ -1,7 +1,7 @@
 alertmanager:
   image:
     repository: quay.io/prometheus/alertmanager
-    tag: v0.18.0
+    tag: v0.19.0
     pullPolicy: IfNotPresent
   configReloaderImage:
     repository: docker.io/jimmidyson/configmap-reload


### PR DESCRIPTION
**What this PR does / why we need it**:
Nothing fancy to see here.

**Does this PR introduce a user-facing change?**:
```release-note
update Alertmanager to 0.19
```

/hold until #4339 is merged so the version bumps work as expected