### PR TITLE
Revert "fix json name for securityGroupId (#4344)"

### DIFF
--- a/api/cmd/kubermatic-api/swagger.json
+++ b/api/cmd/kubermatic-api/swagger.json
@@ -4873,7 +4873,7 @@
           "type": "string",
           "x-go-name": "SecretAccessKey"
         },
-        "securityGroupId": {
+        "securityGroupID": {
           "type": "string",
           "x-go-name": "SecurityGroupID"
         },

--- a/api/pkg/crd/OWNERS
+++ b/api/pkg/crd/OWNERS
@@ -1,0 +1,13 @@
+# See the OWNERS docs: https://git.k8s.io/community/contributors/guide/owners.md
+
+approvers:
+  - team-lifecycle
+
+reviewers:
+  - team-lifecycle
+
+labels:
+  - team/lifecycle
+
+options:
+  no_parent_owners: true

--- a/api/pkg/crd/kubermatic/v1/cluster.go
+++ b/api/pkg/crd/kubermatic/v1/cluster.go
@@ -403,7 +403,7 @@ type AWSCloudSpec struct {
 	ControlPlaneRoleARN string `json:"roleARN"`
 	RouteTableID        string `json:"routeTableId"`
 	InstanceProfileName string `json:"instanceProfileName"`
-	SecurityGroupID     string `json:"securityGroupId"`
+	SecurityGroupID     string `json:"securityGroupID"`
 
 	// DEPRECATED. Don't care for the role name. We only require the ControlPlaneRoleARN to be set so the control plane
 	// can perform the assume-role.

--- a/api/pkg/test/e2e/api/utils/apiclient/models/a_w_s_cloud_spec.go
+++ b/api/pkg/test/e2e/api/utils/apiclient/models/a_w_s_cloud_spec.go
@@ -37,7 +37,7 @@ type AWSCloudSpec struct {
 	SecretAccessKey string `json:"secretAccessKey,omitempty"`
 
 	// security group ID
-	SecurityGroupID string `json:"securityGroupId,omitempty"`
+	SecurityGroupID string `json:"securityGroupID,omitempty"`
 
 	// v p c ID
 	VPCID string `json:"vpcId,omitempty"`


### PR DESCRIPTION
This reverts commit 7a264ae13cfaf964edb979c612a95662f841937f.

This change caused us to drop the existing `securityGroupID` field on all AWS
clusters because the tag got renamed, causing us to not recognize the existing field.

**What this PR does / why we need it**:

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Documentation**:
<!-- Add links to the related documentation changes related to this pull request. E.g. the link to the kubermatic/docs pullrequest. -->

**Does this PR introduce a user-facing change?**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If  no release note is required, just write "NONE".
-->
```release-note
none
```
