### PR TITLE
Use StringDurationEncoder in Zap

### DIFF
--- a/api/pkg/log/zap.go
+++ b/api/pkg/log/zap.go
@@ -97,6 +97,10 @@ func New(debug bool, format Format) *zap.Logger {
 	encCfg.TimeKey = "time"
 	encCfg.EncodeTime = zapcore.ISO8601TimeEncoder
 
+	// production config encodes durations as a float of the seconds value, but we want a more
+	// readable, precise representation
+	encCfg.EncodeDuration = zapcore.StringDurationEncoder
+
 	var enc zapcore.Encoder
 	if format == FormatJSON {
 		enc = zapcore.NewJSONEncoder(encCfg)


### PR DESCRIPTION
**What this PR does / why we need it**:
We use durations in logs mostly for information purpose and rarely (to my knowledge) evaluate them systematically, so I think it's a good idea to use Go's default formatting for durations instead of manually (or automatically) converting to a number of seconds.

**Does this PR introduce a user-facing change?**:
```release-note
NONE
```
