### PR TITLE
Datacenters-to-Seeds Migration

### DIFF
--- a/api/cmd/kubermatic-controller-manager/main.go
+++ b/api/cmd/kubermatic-controller-manager/main.go
@@ -151,7 +151,8 @@ Please install the VerticalPodAutoscaler according to the documentation: https:/
 					return nil, fmt.Errorf("can only return kubeconfig for our own seed (%q), got request for %q", options.dc, seed.Name)
 				}
 				return restMapperCache.Client(mgr.GetConfig())
-			})
+			},
+			false)
 		if err != nil {
 			log.Fatalw("Failed to get seedValidationWebhookServer", zap.Error(err))
 		}

--- a/api/cmd/master-controller-manager/main.go
+++ b/api/cmd/master-controller-manager/main.go
@@ -102,12 +102,6 @@ func main() {
 	defer ctxCancel()
 	ctrlCtx.ctx = ctx
 
-	// prepare migration options
-	migrationOptions := mastermigrations.MigrationOptions{
-		DatacentersFile:    runOpts.dcFile,
-		DynamicDatacenters: runOpts.dynamicDatacenters,
-	}
-
 	// load kubeconfig and create API client
 	kubeconfig, err := clientcmd.LoadFromFile(runOpts.kubeconfig)
 	if err != nil {
@@ -143,6 +137,13 @@ func main() {
 		ctx, mgr.GetClient(), runOpts.kubeconfig, ctrlCtx.namespace, runOpts.dynamicDatacenters)
 	if err != nil {
 		log.Fatalw("failed to construct seedKubeconfigGetter", zap.Error(err))
+	}
+
+	// prepare migration options
+	migrationOptions := mastermigrations.MigrationOptions{
+		DatacentersFile:    runOpts.dcFile,
+		DynamicDatacenters: runOpts.dynamicDatacenters,
+		Kubeconfig:         kubeconfig,
 	}
 
 	if runOpts.seedvalidationHook.CertFile != "" || runOpts.seedvalidationHook.KeyFile != "" {

--- a/api/cmd/master-controller-manager/main.go
+++ b/api/cmd/master-controller-manager/main.go
@@ -182,7 +182,7 @@ func main() {
 			}
 
 			return leaderelection.RunAsLeader(leaderCtx, log, cfg, mgr.GetRecorder(controllerName), electionName, func(ctx context.Context) error {
-				log.Info("Executing migrations...")
+				log.Info("executing migrations...")
 				options := master.MigrationOptions{
 					DatacentersFile:    runOpts.dcFile,
 					DynamicDatacenters: runOpts.dynamicDatacenters,
@@ -190,7 +190,7 @@ func main() {
 				if err := master.RunAll(ctx, log, mgr.GetClient(), runOpts.workerName, ctrlCtx.namespace, options); err != nil {
 					return fmt.Errorf("failed to run migrations: %v", err)
 				}
-				log.Info("Migrations executed successfully")
+				log.Info("migrations executed successfully")
 
 				log.Info("starting the master-controller-manager...")
 				if err := mgr.Start(ctx.Done()); err != nil {

--- a/api/pkg/crd/migrations/master/migrations.go
+++ b/api/pkg/crd/migrations/master/migrations.go
@@ -35,6 +35,10 @@ func RunAll(ctx context.Context, log *zap.SugaredLogger, client ctrlruntimeclien
 	return nil
 }
 
+// migrateDatacenters creates Seed CRs based on the given datacenters file.
+// Seeds are only ever created and never updated/reconciled to match the
+// datacenters.yaml, because the validation webhook prevents any modifications
+// while the migration is enabled.
 func migrateDatacenters(ctx context.Context, log *zap.SugaredLogger, client ctrlruntimeclient.Client, kubermaticNamespace string, dcFile string) error {
 	seeds, err := provider.LoadSeeds(dcFile)
 	if err != nil {

--- a/api/pkg/crd/migrations/master/migrations.go
+++ b/api/pkg/crd/migrations/master/migrations.go
@@ -8,8 +8,8 @@ import (
 
 	kubermaticv1 "github.com/kubermatic/kubermatic/api/pkg/crd/kubermatic/v1"
 	"github.com/kubermatic/kubermatic/api/pkg/provider"
-	"github.com/kubermatic/kubermatic/api/pkg/util/workerlabel"
 
+	kerrors "k8s.io/apimachinery/pkg/api/errors"
 	ctrlruntimeclient "sigs.k8s.io/controller-runtime/pkg/client"
 )
 
@@ -22,27 +22,11 @@ func (o MigrationOptions) SeedMigrationEnabled() bool {
 	return o.DatacentersFile != "" && o.DynamicDatacenters
 }
 
-type migrationContext struct {
-	ctx                 context.Context
-	log                 *zap.SugaredLogger
-	workerName          string
-	kubermaticNamespace string
-	client              ctrlruntimeclient.Client
-}
-
 // RunAll runs all migrations that should be run inside a master cluster.
-func RunAll(ctx context.Context, log *zap.SugaredLogger, client ctrlruntimeclient.Client, workerName string, kubermaticNamespace string, opt MigrationOptions) error {
-	migrationCtx := &migrationContext{
-		ctx:                 ctx,
-		log:                 log,
-		client:              client,
-		workerName:          workerName,
-		kubermaticNamespace: kubermaticNamespace,
-	}
-
+func RunAll(ctx context.Context, log *zap.SugaredLogger, client ctrlruntimeclient.Client, kubermaticNamespace string, opt MigrationOptions) error {
 	if opt.SeedMigrationEnabled() {
 		log.Info("datacenters given and dynamic datacenters enabled, attempting to migrate datacenters to Seeds")
-		if err := migrateDatacenters(migrationCtx, opt.DatacentersFile); err != nil {
+		if err := migrateDatacenters(ctx, log, client, kubermaticNamespace, opt.DatacentersFile); err != nil {
 			return fmt.Errorf("failed to migrate datacenters.yaml: %v", err)
 		}
 		log.Info("migration completed successfully")
@@ -51,38 +35,35 @@ func RunAll(ctx context.Context, log *zap.SugaredLogger, client ctrlruntimeclien
 	return nil
 }
 
-func migrateDatacenters(ctx *migrationContext, dcFile string) error {
-	labelSelector, err := workerlabel.LabelSelector(ctx.workerName)
-	if err != nil {
-		return fmt.Errorf("failed to create workername label selector: %v", err)
-	}
-
-	// check if we performed/attempted a migration at an earlier point in time and if so, do not run it a second time;
-	// in case of errors, the cluster operator has to remove broken Seeds to restart the migration
-	existingSeeds := kubermaticv1.SeedList{}
-	if err := ctx.client.List(ctx.ctx, &ctrlruntimeclient.ListOptions{
-		Namespace:     ctx.kubermaticNamespace,
-		LabelSelector: labelSelector,
-	}, &existingSeeds); err != nil {
-		return fmt.Errorf("failed to list existing Seeds in %s: %v", ctx.kubermaticNamespace, err)
-	}
-
-	if len(existingSeeds.Items) > 0 {
-		ctx.log.Warn("migration enabled, but existing Seed CRs found; refusing to migrate again")
-		return nil
-	}
-
+func migrateDatacenters(ctx context.Context, log *zap.SugaredLogger, client ctrlruntimeclient.Client, kubermaticNamespace string, dcFile string) error {
 	seeds, err := provider.LoadSeeds(dcFile)
 	if err != nil {
 		return fmt.Errorf("failed to load %s: %v", dcFile, err)
 	}
 
 	for name, seed := range seeds {
-		seed.Namespace = ctx.kubermaticNamespace
-		if err := ctx.client.Create(ctx.ctx, seed); err != nil {
-			return fmt.Errorf("failed to create seed %s: %v", name, seed)
+		log := log.With("seed", seed)
+
+		seed.Namespace = kubermaticNamespace
+
+		key, err := ctrlruntimeclient.ObjectKeyFromObject(seed)
+		if err != nil {
+			return fmt.Errorf("failed to create object key for seed %s: %v", name, err)
 		}
-		ctx.log.Infow("Seed created", "name", name)
+
+		log.Info("checking for Seed existence...")
+		existingSeed := kubermaticv1.Seed{}
+		err = client.Get(ctx, key, &existingSeed)
+		if err != nil {
+			if !kerrors.IsNotFound(err) {
+				return fmt.Errorf("failed to get Seed %s: %v", name, err)
+			}
+
+			log.Info("creating Seed CR...")
+			if err := client.Create(ctx, seed); err != nil {
+				return fmt.Errorf("failed to create seed %s: %v", name, err)
+			}
+		}
 	}
 
 	return nil

--- a/api/pkg/crd/migrations/master/migrations.go
+++ b/api/pkg/crd/migrations/master/migrations.go
@@ -18,6 +18,10 @@ type MigrationOptions struct {
 	DynamicDatacenters bool
 }
 
+func (o MigrationOptions) SeedMigrationEnabled() bool {
+	return o.DatacentersFile != "" && o.DynamicDatacenters
+}
+
 type migrationContext struct {
 	ctx                 context.Context
 	log                 *zap.SugaredLogger
@@ -36,7 +40,7 @@ func RunAll(ctx context.Context, log *zap.SugaredLogger, client ctrlruntimeclien
 		kubermaticNamespace: kubermaticNamespace,
 	}
 
-	if opt.DatacentersFile != "" && opt.DynamicDatacenters {
+	if opt.SeedMigrationEnabled() {
 		log.Info("datacenters given and dynamic datacenters enabled, attempting to migrate datacenters to Seeds")
 		if err := migrateDatacenters(migrationCtx, opt.DatacentersFile); err != nil {
 			return fmt.Errorf("failed to migrate datacenters.yaml: %v", err)

--- a/api/pkg/crd/migrations/master/migrations.go
+++ b/api/pkg/crd/migrations/master/migrations.go
@@ -105,7 +105,7 @@ func createSeedKubeconfig(ctx context.Context, log *zap.SugaredLogger, client ct
 	}
 
 	secret := &corev1.Secret{}
-	secret.Name = seed.Name
+	secret.Name = "kubeconfig-" + seed.Name
 	secret.Namespace = seed.Namespace
 	secret.Data = map[string][]byte{
 		kubeconfigFieldPath: encoded,
@@ -133,8 +133,8 @@ func createSeedKubeconfig(ctx context.Context, log *zap.SugaredLogger, client ct
 	return &corev1.ObjectReference{
 		APIVersion: "v1",
 		Kind:       "Secret",
-		Name:       seed.Name,
-		Namespace:  seed.Namespace,
+		Name:       secret.Name,
+		Namespace:  secret.Namespace,
 		FieldPath:  kubeconfigFieldPath,
 	}, nil
 }

--- a/api/pkg/crd/migrations/master/migrations.go
+++ b/api/pkg/crd/migrations/master/migrations.go
@@ -4,12 +4,11 @@ import (
 	"context"
 	"fmt"
 
-	"github.com/kubermatic/kubermatic/api/pkg/util/workerlabel"
-
 	"go.uber.org/zap"
 
 	kubermaticv1 "github.com/kubermatic/kubermatic/api/pkg/crd/kubermatic/v1"
 	"github.com/kubermatic/kubermatic/api/pkg/provider"
+	"github.com/kubermatic/kubermatic/api/pkg/util/workerlabel"
 
 	ctrlruntimeclient "sigs.k8s.io/controller-runtime/pkg/client"
 )

--- a/api/pkg/crd/migrations/master/migrations.go
+++ b/api/pkg/crd/migrations/master/migrations.go
@@ -41,6 +41,7 @@ func RunAll(ctx context.Context, log *zap.SugaredLogger, client ctrlruntimeclien
 		if err := migrateDatacenters(migrationCtx, opt.DatacentersFile); err != nil {
 			return fmt.Errorf("failed to migrate datacenters.yaml: %v", err)
 		}
+		log.Info("migration completed successfully")
 	}
 
 	return nil
@@ -77,9 +78,8 @@ func migrateDatacenters(ctx *migrationContext, dcFile string) error {
 		if err := ctx.client.Create(ctx.ctx, seed); err != nil {
 			return fmt.Errorf("failed to create seed %s: %v", name, seed)
 		}
+		ctx.log.Infow("Seed created", "name", name)
 	}
-
-	ctx.log.Infof("created %d Seed CRs", len(seeds))
 
 	return nil
 }

--- a/api/pkg/crd/migrations/master/migrations.go
+++ b/api/pkg/crd/migrations/master/migrations.go
@@ -1,0 +1,86 @@
+package master
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/kubermatic/kubermatic/api/pkg/util/workerlabel"
+
+	"go.uber.org/zap"
+
+	kubermaticv1 "github.com/kubermatic/kubermatic/api/pkg/crd/kubermatic/v1"
+	"github.com/kubermatic/kubermatic/api/pkg/provider"
+
+	ctrlruntimeclient "sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+type MigrationOptions struct {
+	DatacentersFile    string
+	DynamicDatacenters bool
+}
+
+type migrationContext struct {
+	ctx                 context.Context
+	log                 *zap.SugaredLogger
+	workerName          string
+	kubermaticNamespace string
+	client              ctrlruntimeclient.Client
+}
+
+// RunAll runs all migrations that should be run inside a master cluster.
+func RunAll(ctx context.Context, log *zap.SugaredLogger, client ctrlruntimeclient.Client, workerName string, kubermaticNamespace string, opt MigrationOptions) error {
+	migrationCtx := &migrationContext{
+		ctx:                 ctx,
+		log:                 log,
+		client:              client,
+		workerName:          workerName,
+		kubermaticNamespace: kubermaticNamespace,
+	}
+
+	if opt.DatacentersFile != "" && opt.DynamicDatacenters {
+		log.Info("datacenters given and dynamic datacenters enabled, attempting to migrate datacenters to Seeds")
+		if err := migrateDatacenters(migrationCtx, opt.DatacentersFile); err != nil {
+			return fmt.Errorf("failed to migrate datacenters.yaml: %v", err)
+		}
+	}
+
+	return nil
+}
+
+func migrateDatacenters(ctx *migrationContext, dcFile string) error {
+	labelSelector, err := workerlabel.LabelSelector(ctx.workerName)
+	if err != nil {
+		return fmt.Errorf("failed to create workername label selector: %v", err)
+	}
+
+	// check if we performed/attempted a migration at an earlier point in time and if so, do not run it a second time;
+	// in case of errors, the cluster operator has to remove broken Seeds to restart the migration
+	existingSeeds := kubermaticv1.SeedList{}
+	if err := ctx.client.List(ctx.ctx, &ctrlruntimeclient.ListOptions{
+		Namespace:     ctx.kubermaticNamespace,
+		LabelSelector: labelSelector,
+	}, &existingSeeds); err != nil {
+		return fmt.Errorf("failed to list existing Seeds in %s: %v", ctx.kubermaticNamespace, err)
+	}
+
+	if len(existingSeeds.Items) > 0 {
+		ctx.log.Warn("migration enabled, but existing Seed CRs found; refusing to migrate again")
+		return nil
+	}
+
+	seeds, err := provider.LoadSeeds(dcFile)
+	if err != nil {
+		return fmt.Errorf("failed to load %s: %v", dcFile, err)
+	}
+
+	for name, seed := range seeds {
+		seed.Namespace = ctx.kubermaticNamespace
+		if err := ctx.client.Create(ctx.ctx, seed); err != nil {
+			return fmt.Errorf("failed to create seed %s: %v", name, seed)
+		}
+	}
+
+	ctx.log.Infof("created %d Seed CRs", len(seeds))
+
+	return nil
+}

--- a/api/pkg/crd/migrations/migrations.go
+++ b/api/pkg/crd/migrations/migrations.go
@@ -32,14 +32,14 @@ func RunAll(config *rest.Config, workerName string) error {
 	if err != nil {
 		return fmt.Errorf("failed to create kubeClient: %v", err)
 	}
-	kubermatiClient, err := kubermaticclientset.NewForConfig(config)
+	kubermaticClient, err := kubermaticclientset.NewForConfig(config)
 	if err != nil {
 		return fmt.Errorf("failed to create Kubermatic client: %v", err)
 	}
 
 	ctx := &cleanupContext{
 		kubeClient:       kubeClient,
-		kubermaticClient: kubermatiClient,
+		kubermaticClient: kubermaticClient,
 	}
 
 	if err := cleanupClusters(workerName, ctx); err != nil {

--- a/api/pkg/provider/conversions.go
+++ b/api/pkg/provider/conversions.go
@@ -3,8 +3,6 @@ package provider
 import (
 	"fmt"
 
-	corev1 "k8s.io/api/core/v1"
-
 	kubermaticv1 "github.com/kubermatic/kubermatic/api/pkg/crd/kubermatic/v1"
 )
 
@@ -37,10 +35,9 @@ func DatacenterMetasToSeeds(dm map[string]DatacenterMeta) (map[string]*kubermati
 			seeds[dcName].Name = dcName
 			seeds[dcName].Spec.Country = datacenterSpec.Country
 			seeds[dcName].Spec.Location = datacenterSpec.Location
-			// TODO: What to do about the kubeconfig?
-			seeds[dcName].Spec.Kubeconfig = corev1.ObjectReference{}
 			seeds[dcName].Spec.SeedDNSOverwrite = datacenterSpec.SeedDNSOverwrite
 
+			// Kubeconfig object ref is injected during the automated migration.
 		} else {
 			if _, exists := dm[datacenterSpec.Seed]; !exists {
 				return nil, fmt.Errorf("seedDatacenter %q used by node datacenter %q does not exist", datacenterSpec.Seed, dcName)

--- a/api/pkg/provider/datacenter.go
+++ b/api/pkg/provider/datacenter.go
@@ -147,10 +147,6 @@ func ValidateSeed(seed *kubermaticv1.Seed) error {
 
 // SeedGetterFactory returns a SeedGetter. It has validation of all its arguments
 func SeedGetterFactory(ctx context.Context, client ctrlruntimeclient.Client, seedName, dcFile, namespace string, dynamicDatacenters bool) (SeedGetter, error) {
-	if dcFile != "" && dynamicDatacenters {
-		return nil, errors.New("--datacenters must be empty when --dynamic-datacenters is enabled")
-	}
-
 	if dynamicDatacenters {
 		return func() (*kubermaticv1.Seed, error) {
 			seed := &kubermaticv1.Seed{}
@@ -180,10 +176,6 @@ func SeedGetterFactory(ctx context.Context, client ctrlruntimeclient.Client, see
 }
 
 func SeedsGetterFactory(ctx context.Context, client ctrlruntimeclient.Client, dcFile, namespace, workerName string, dynamicDatacenters bool) (SeedsGetter, error) {
-	if dcFile != "" && dynamicDatacenters {
-		return nil, errors.New("--datacenters must be empty when --dynamic-datacenters is enabled")
-	}
-
 	if dynamicDatacenters {
 		labelSelector, err := workerlabel.LabelSelector(workerName)
 		if err != nil {

--- a/api/pkg/provider/datacenter.go
+++ b/api/pkg/provider/datacenter.go
@@ -63,8 +63,8 @@ type datacentersMeta struct {
 	Datacenters map[string]DatacenterMeta `json:"datacenters"`
 }
 
-// loadDatacenters loads all Datacenters from the given path.
-func loadSeeds(path string) (map[string]*kubermaticv1.Seed, error) {
+// LoadSeeds loads all Datacenters from the given path.
+func LoadSeeds(path string) (map[string]*kubermaticv1.Seed, error) {
 	bytes, err := ioutil.ReadFile(path)
 	if err != nil {
 		return nil, fmt.Errorf("failed to read datacenter.yaml: %v", err)
@@ -89,8 +89,10 @@ func loadSeeds(path string) (map[string]*kubermaticv1.Seed, error) {
 	return seeds, nil
 }
 
+// LoadSeed loads an existing datacenters.yaml from disk and returns the given
+// datacenter as a seed or an error if the datacenter does not exist.
 func LoadSeed(path, datacenterName string) (*kubermaticv1.Seed, error) {
-	seeds, err := loadSeeds(path)
+	seeds, err := LoadSeeds(path)
 	if err != nil {
 		return nil, err
 	}
@@ -113,6 +115,7 @@ func validateImageList(images kubermaticv1.ImageList) error {
 	return nil
 }
 
+// ValidateSeed takes a seed and returns an error if the seed's spec is invalid.
 func ValidateSeed(seed *kubermaticv1.Seed) error {
 	for name, dc := range seed.Spec.Datacenters {
 		if dc.Spec.VSphere != nil {
@@ -208,8 +211,8 @@ func SeedsGetterFactory(ctx context.Context, client ctrlruntimeclient.Client, dc
 	if dcFile == "" {
 		return nil, errors.New("--datacenters is required")
 	}
-	// Make sure we fail early, an error here is nor recoverable
-	seedMap, err := loadSeeds(dcFile)
+	// Make sure we fail early, an error here is not recoverable
+	seedMap, err := LoadSeeds(dcFile)
 	if err != nil {
 		return nil, err
 	}

--- a/api/pkg/provider/datacenter_test.go
+++ b/api/pkg/provider/datacenter_test.go
@@ -108,7 +108,7 @@ datacenters:
 	err = file.Sync()
 	assert.NoError(t, err)
 
-	resultDatacenters, err := loadSeeds(file.Name())
+	resultDatacenters, err := LoadSeeds(file.Name())
 	if err != nil {
 		t.Fatalf("failed to load datacenters: %v", err)
 	}


### PR DESCRIPTION
**What this PR does / why we need it**:
This implements a basic migration for datacenters. For safety reasons the migration will not do anything if a Seed CR already exists.

**Which issue(s) this PR fixes**:
Fixes #2116

**Does this PR introduce a user-facing change?**:
```release-note
NONE
```
