### PR TITLE
Avoid checking the selector fields when its nil

### DIFF
--- a/api/pkg/kubernetes/helper.go
+++ b/api/pkg/kubernetes/helper.go
@@ -54,7 +54,7 @@ func ValidateKubernetesToken(token string) error {
 }
 
 func ValidateSecretKeySelector(selector *providerconfig.GlobalSecretKeySelector, key string) error {
-	if selector.Name == "" && selector.Namespace == "" && key == "" {
+	if selector != nil && selector.Name == "" && selector.Namespace == "" && key == "" {
 		return fmt.Errorf("%q cannot be empty", key)
 	}
 	return nil


### PR DESCRIPTION
**What this PR does / why we need it**:
The kubermatic api will panic because of the selector being nil at the initialization of the providers.
 
```
NONE
```
