### PR TITLE
DNS-Operator: Wait for both the DNS and network CRD

### DIFF
--- a/api/cmd/http-prober/api/httpprober.go
+++ b/api/cmd/http-prober/api/httpprober.go
@@ -1,6 +1,6 @@
 package api
 
 type Command struct {
-	Command string   `json:"command"`
-	Args    []string `json:"args"`
+	Command string   `json:"command,omitempty"`
+	Args    []string `json:"args,omitempty"`
 }

--- a/api/cmd/http-prober/main.go
+++ b/api/cmd/http-prober/main.go
@@ -54,7 +54,7 @@ func main() {
 	flag.IntVar(&retries, "retries", 10, "Number of retries")
 	flag.IntVar(&retryWait, "retry-wait", 1, "Wait interval in seconds between retries")
 	flag.IntVar(&timeout, "timeout", 30, "Timeout in seconds")
-	flag.Var(&crdsToWaitFor, "crd-to-wait-for", "Wait for these crds to exist. Must contain kind and apiVersion comma seperated, e.G `machines,cluster.k8s.io/v1alpha1`. Can be passed multiple times. Requires the `KUBECONFIG` env var to be set and to point to a valid kubeconfig.")
+	flag.Var(&crdsToWaitFor, "crd-to-wait-for", "Wait for these crds to exist. Must contain kind and apiVersion comma separated, e.G `machines,cluster.k8s.io/v1alpha1`. Can be passed multiple times. Requires the `KUBECONFIG` env var to be set and to point to a valid kubeconfig.")
 	flag.StringVar(&commandRaw, "command", "", "If passed, the http prober will exec this command. Must be json encoded")
 	flag.Parse()
 

--- a/api/cmd/http-prober/main.go
+++ b/api/cmd/http-prober/main.go
@@ -121,11 +121,9 @@ func main() {
 
 		log.Info("Endpoint is available")
 
-		for _, crdChecker := range crdCheckers {
-			if err := crdChecker(); err != nil {
-				log.Infow("Check if crd is available was not successful", zap.Error(err))
-				continue
-			}
+		if err := executeCheckers(crdCheckers); err != nil {
+			log.Infow("Check if crd is available was not successful", zap.Error(err))
+			continue
 		}
 		if len(crdCheckers) > 0 {
 			log.Info("All CRDs became available")
@@ -178,7 +176,7 @@ func crdCheckersFactory(mvf multiValFlag) ([]func() error, error) {
 func crdCheckerFromFlag(flag string, cfg *restclient.Config) (func() error, error) {
 	splitVal := strings.Split(flag, ",")
 	if n := len(splitVal); n != 2 {
-		return nil, fmt.Errorf("comma-seperating the flag value did not yield exactly two results, but %d", n)
+		return nil, fmt.Errorf("comma-separating the flag value did not yield exactly two results, but %d", n)
 	}
 	kind := splitVal[0]
 	apiVersion := splitVal[1]
@@ -202,4 +200,13 @@ func crdCheckerFromFlag(flag string, cfg *restclient.Config) (func() error, erro
 
 		return nil
 	}, nil
+}
+
+func executeCheckers(checkers []func() error) error {
+	for _, checker := range checkers {
+		if err := checker(); err != nil {
+			return err
+		}
+	}
+	return nil
 }

--- a/api/cmd/http-prober/release.sh
+++ b/api/cmd/http-prober/release.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 
-ver=v0.3
+ver=v0.3.1-dev
 
 set -euox pipefail
 

--- a/api/cmd/http-prober/release.sh
+++ b/api/cmd/http-prober/release.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 
-ver=v0.3.1-dev
+ver=v0.3.1-dev0
 
 set -euox pipefail
 

--- a/api/cmd/http-prober/release.sh
+++ b/api/cmd/http-prober/release.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 
-ver=v0.3.1-dev0
+ver=v0.3.1
 
 set -euox pipefail
 

--- a/api/pkg/controller/openshift/resources/console.go
+++ b/api/pkg/controller/openshift/resources/console.go
@@ -166,7 +166,7 @@ func ConsoleDeployment(data openshiftData) reconciling.NamedDeploymentCreatorGet
 			}
 			d.Spec.Template.Labels = podLabels
 
-			wrappedPodSpec, err := apiserver.IsRunningWrapper(data, d.Spec.Template.Spec, sets.NewString("console"), "OAuthClient", "oauth.openshift.io/v1")
+			wrappedPodSpec, err := apiserver.IsRunningWrapper(data, d.Spec.Template.Spec, sets.NewString("console"), "OAuthClient,oauth.openshift.io/v1")
 			if err != nil {
 				return nil, fmt.Errorf("failed to add apiserver.IsRunningWrapper: %v", err)
 			}

--- a/api/pkg/controller/openshift/resources/dns_operator.go
+++ b/api/pkg/controller/openshift/resources/dns_operator.go
@@ -95,7 +95,7 @@ func OpenshiftDNSOperatorFactory(data openshiftData) reconciling.NamedDeployment
 				return nil, err
 			}
 
-			wrappedPodSpec, err := apiserver.IsRunningWrapper(data, d.Spec.Template.Spec, sets.NewString(openshiftDNSOperatorContainerName), "DNS", "operator.openshift.io/v1")
+			wrappedPodSpec, err := apiserver.IsRunningWrapper(data, d.Spec.Template.Spec, sets.NewString(openshiftDNSOperatorContainerName), "DNS,operator.openshift.io/v1", "Network,config.openshift.io/v1")
 			if err != nil {
 				return nil, fmt.Errorf("failed to add apiserver.IsRunningWrapper: %v", err)
 			}

--- a/api/pkg/controller/openshift/resources/kube_controller_manager.go
+++ b/api/pkg/controller/openshift/resources/kube_controller_manager.go
@@ -259,7 +259,7 @@ func KubeControllerManagerDeploymentCreatorFactory(data kubeControllerManagerDat
 					return nil, err
 				}
 				dep.Spec.Template.Labels = podLabels
-				wrappedPodSpec, err := apiserver.IsRunningWrapper(data, dep.Spec.Template.Spec, sets.NewString(kubeControllerManagerContainerName), "", "")
+				wrappedPodSpec, err := apiserver.IsRunningWrapper(data, dep.Spec.Template.Spec, sets.NewString(kubeControllerManagerContainerName))
 				if err != nil {
 					return nil, fmt.Errorf("failed to add apiserver.IsRunningWrapper: %v", err)
 				}

--- a/api/pkg/controller/openshift/resources/kube_scheduler.go
+++ b/api/pkg/controller/openshift/resources/kube_scheduler.go
@@ -197,7 +197,7 @@ func KubeSchedulerDeploymentCreator(data openshiftData) reconciling.NamedDeploym
 
 			dep.Spec.Template.Spec.Affinity = resources.HostnameAntiAffinity(name, data.Cluster().Name)
 
-			wrappedPodSpec, err := apiserver.IsRunningWrapper(data, dep.Spec.Template.Spec, sets.NewString(name), "", "")
+			wrappedPodSpec, err := apiserver.IsRunningWrapper(data, dep.Spec.Template.Spec, sets.NewString(name))
 			if err != nil {
 				return nil, fmt.Errorf("failed to add apiserver.IsRunningWrapper: %v", err)
 			}

--- a/api/pkg/controller/openshift/resources/machinecontroller.go
+++ b/api/pkg/controller/openshift/resources/machinecontroller.go
@@ -55,7 +55,7 @@ func MachineController(osData openshiftData) reconciling.NamedDeploymentCreatorG
 					corev1.EnvVar{Name: openshiftuserdata.DockerCFGEnvKey, Value: osData.Cluster().Spec.Openshift.ImagePullSecret})
 			}
 
-			wrappedPodSpec, err := apiserver.IsRunningWrapper(osData, d.Spec.Template.Spec, sets.NewString(name), "Machine", "cluster.k8s.io/v1alpha1")
+			wrappedPodSpec, err := apiserver.IsRunningWrapper(osData, d.Spec.Template.Spec, sets.NewString(name), "Machine,cluster.k8s.io/v1alpha1")
 			if err != nil {
 				return nil, fmt.Errorf("failed to add apiserver.IsRunningWrapper: %v", err)
 			}

--- a/api/pkg/controller/openshift/resources/oauth.go
+++ b/api/pkg/controller/openshift/resources/oauth.go
@@ -430,7 +430,7 @@ func OauthDeploymentCreator(data openshiftData) reconciling.NamedDeploymentCreat
 			}
 			dep.Spec.Template.Labels = podLabels
 
-			wrappedPodSpec, err := apiserver.IsRunningWrapper(data, dep.Spec.Template.Spec, sets.NewString(OauthName), "OAuthClient", "oauth.openshift.io/v1")
+			wrappedPodSpec, err := apiserver.IsRunningWrapper(data, dep.Spec.Template.Spec, sets.NewString(OauthName), "OAuthClient,oauth.openshift.io/v1")
 			if err != nil {
 				return nil, fmt.Errorf("failed to add apiserver.IsRunningWrapper: %v", err)
 			}

--- a/api/pkg/controller/openshift/resources/openshift_apiserver_deployment.go
+++ b/api/pkg/controller/openshift/resources/openshift_apiserver_deployment.go
@@ -268,7 +268,7 @@ func OpenshiftAPIServerDeploymentCreator(ctx context.Context, data openshiftData
 			dep.Spec.Template.Labels = podLabels
 
 			// The openshift apiserver needs the normal apiserver
-			wrappedPodSpec, err := apiserver.IsRunningWrapper(data, dep.Spec.Template.Spec, sets.NewString(OpenshiftAPIServerDeploymentName), "", "")
+			wrappedPodSpec, err := apiserver.IsRunningWrapper(data, dep.Spec.Template.Spec, sets.NewString(OpenshiftAPIServerDeploymentName))
 			if err != nil {
 				return nil, fmt.Errorf("failed to add apiserver.IsRunningWrapper: %v", err)
 			}

--- a/api/pkg/controller/openshift/resources/openshift_controller_manager.go
+++ b/api/pkg/controller/openshift/resources/openshift_controller_manager.go
@@ -194,7 +194,7 @@ func OpenshiftControllerManagerDeploymentCreator(ctx context.Context, data opens
 
 			dep.Spec.Template.Spec.Affinity = resources.HostnameAntiAffinity(OpenshiftControllerManagerDeploymentName, data.Cluster().Name)
 
-			wrappedPodSpec, err := apiserver.IsRunningWrapper(data, dep.Spec.Template.Spec, sets.NewString(OpenshiftControllerManagerDeploymentName), "OAuthClient", "oauth.openshift.io/v1")
+			wrappedPodSpec, err := apiserver.IsRunningWrapper(data, dep.Spec.Template.Spec, sets.NewString(OpenshiftControllerManagerDeploymentName), "OAuthClient,oauth.openshift.io/v1")
 			if err != nil {
 				return nil, fmt.Errorf("failed to add apiserver.IsRunningWrapper: %v", err)
 			}

--- a/api/pkg/controller/openshift/resources/openshift_network_operator.go
+++ b/api/pkg/controller/openshift/resources/openshift_network_operator.go
@@ -98,7 +98,7 @@ func OpenshiftNetworkOperatorCreatorFactory(data openshiftData) reconciling.Name
 				return nil, err
 			}
 
-			wrappedPodSpec, err := apiserver.IsRunningWrapper(data, d.Spec.Template.Spec, sets.NewString("network-operator"), "Network", "operator.openshift.io/v1")
+			wrappedPodSpec, err := apiserver.IsRunningWrapper(data, d.Spec.Template.Spec, sets.NewString("network-operator"), "Network,operator.openshift.io/v1")
 			if err != nil {
 				return nil, fmt.Errorf("failed to add apiserver.IsRunningWrapper: %v", err)
 			}

--- a/api/pkg/controller/openshift/testdata/Kubermatic_API_image_is_overwritten-usercluster-controller.golden.yaml
+++ b/api/pkg/controller/openshift/testdata/Kubermatic_API_image_is_overwritten-usercluster-controller.golden.yaml
@@ -89,7 +89,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3
+        image: quay.io/kubermatic/http-prober:v0.3.1-dev
         imagePullPolicy: IfNotPresent
         name: copy-http-prober
         resources: {}

--- a/api/pkg/controller/openshift/testdata/Kubermatic_API_image_is_overwritten-usercluster-controller.golden.yaml
+++ b/api/pkg/controller/openshift/testdata/Kubermatic_API_image_is_overwritten-usercluster-controller.golden.yaml
@@ -89,7 +89,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3.1-dev0
+        image: quay.io/kubermatic/http-prober:v0.3.1
         imagePullPolicy: IfNotPresent
         name: copy-http-prober
         resources: {}

--- a/api/pkg/controller/openshift/testdata/Kubermatic_API_image_is_overwritten-usercluster-controller.golden.yaml
+++ b/api/pkg/controller/openshift/testdata/Kubermatic_API_image_is_overwritten-usercluster-controller.golden.yaml
@@ -89,7 +89,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3.1-dev
+        image: quay.io/kubermatic/http-prober:v0.3.1-dev0
         imagePullPolicy: IfNotPresent
         name: copy-http-prober
         resources: {}

--- a/api/pkg/resources/apiserver/is-running.go
+++ b/api/pkg/resources/apiserver/is-running.go
@@ -14,7 +14,7 @@ import (
 )
 
 const (
-	tag                = "v0.3.1-dev"
+	tag                = "v0.3.1-dev0"
 	emptyDirVolumeName = "http-prober-bin"
 	initContainerName  = "copy-http-prober"
 )

--- a/api/pkg/resources/apiserver/is-running.go
+++ b/api/pkg/resources/apiserver/is-running.go
@@ -14,7 +14,7 @@ import (
 )
 
 const (
-	tag                = "v0.3"
+	tag                = "v0.3.1-dev"
 	emptyDirVolumeName = "http-prober-bin"
 	initContainerName  = "copy-http-prober"
 )
@@ -30,7 +30,7 @@ type isRunningInitContainerData interface {
 // then mounting that volume onto all named containers and replacing the command with a call to
 // the `http-prober` binary. The http prober binary gets the original command as serialized string
 // and does an syscall.Exec onto it once the apiserver became reachable
-func IsRunningWrapper(data isRunningInitContainerData, spec corev1.PodSpec, containersToWrap sets.String, crdKindToWaitFor, crdAPIVersionToWaitFor string) (*corev1.PodSpec, error) {
+func IsRunningWrapper(data isRunningInitContainerData, spec corev1.PodSpec, containersToWrap sets.String, crdsToWaitFor ...string) (*corev1.PodSpec, error) {
 	if containersToWrap.Len() == 0 {
 		return nil, errors.New("no containers to wrap passed")
 	}
@@ -80,7 +80,7 @@ func IsRunningWrapper(data isRunningInitContainerData, spec corev1.PodSpec, cont
 		if !containersToWrap.Has(spec.InitContainers[idx].Name) {
 			continue
 		}
-		wrappedContainer, err := wrapContainer(data, spec.InitContainers[idx], crdKindToWaitFor, crdAPIVersionToWaitFor)
+		wrappedContainer, err := wrapContainer(data, spec.InitContainers[idx], crdsToWaitFor...)
 		if err != nil {
 			return nil, fmt.Errorf("failed to wrap initContainer %q: %v", spec.InitContainers[idx].Name, err)
 		}
@@ -90,7 +90,7 @@ func IsRunningWrapper(data isRunningInitContainerData, spec corev1.PodSpec, cont
 		if !containersToWrap.Has(spec.Containers[idx].Name) {
 			continue
 		}
-		wrappedContainer, err := wrapContainer(data, spec.Containers[idx], crdKindToWaitFor, crdAPIVersionToWaitFor)
+		wrappedContainer, err := wrapContainer(data, spec.Containers[idx], crdsToWaitFor...)
 		if err != nil {
 			return nil, fmt.Errorf("failed to wrap container %q: %v", spec.Containers[idx].Name, err)
 		}
@@ -109,7 +109,7 @@ func hasContainerNamed(spec corev1.PodSpec, name string) bool {
 	return false
 }
 
-func wrapContainer(data isRunningInitContainerData, container corev1.Container, crdKindToWaitFor, crdAPIVersionToWaitFor string) (*corev1.Container, error) {
+func wrapContainer(data isRunningInitContainerData, container corev1.Container, crdsToWaitFor ...string) (*corev1.Container, error) {
 	commandWithArgs := append(container.Command, container.Args...)
 	if len(commandWithArgs) == 0 {
 		return nil, fmt.Errorf("container %q has no command or args set", container.Name)
@@ -138,10 +138,8 @@ func wrapContainer(data isRunningInitContainerData, container corev1.Container, 
 		"-timeout", "1",
 		"-command", string(serializedCommand),
 	}
-	if crdKindToWaitFor != "" {
-		container.Args = append(container.Args,
-			"-wait-for-crd-kind", crdKindToWaitFor,
-			"-wait-for-crd-apiversion", crdAPIVersionToWaitFor)
+	for _, crdToWaitFor := range crdsToWaitFor {
+		container.Args = append(container.Args, "--crd-to-wait-for", crdToWaitFor)
 	}
 
 	return &container, nil

--- a/api/pkg/resources/apiserver/is-running.go
+++ b/api/pkg/resources/apiserver/is-running.go
@@ -14,7 +14,7 @@ import (
 )
 
 const (
-	tag                = "v0.3.1-dev0"
+	tag                = "v0.3.1"
 	emptyDirVolumeName = "http-prober-bin"
 	initContainerName  = "copy-http-prober"
 )

--- a/api/pkg/resources/clusterautoscaler/clusterautoscaler.go
+++ b/api/pkg/resources/clusterautoscaler/clusterautoscaler.go
@@ -118,7 +118,7 @@ func DeploymentCreator(data clusterautoscalerData) reconciling.NamedDeploymentCr
 				},
 			}
 
-			wrappedPodSpec, err := apiserver.IsRunningWrapper(data, dep.Spec.Template.Spec, sets.NewString(resources.ClusterAutoscalerDeploymentName), "", "")
+			wrappedPodSpec, err := apiserver.IsRunningWrapper(data, dep.Spec.Template.Spec, sets.NewString(resources.ClusterAutoscalerDeploymentName))
 			if err != nil {
 				return nil, fmt.Errorf("failed to add apiserver.IsRunningWrapper: %v", err)
 			}

--- a/api/pkg/resources/controllermanager/deployment.go
+++ b/api/pkg/resources/controllermanager/deployment.go
@@ -179,7 +179,7 @@ func DeploymentCreator(data *resources.TemplateData) reconciling.NamedDeployment
 
 			dep.Spec.Template.Spec.Affinity = resources.HostnameAntiAffinity(name, data.Cluster().Name)
 
-			wrappedPodSpec, err := apiserver.IsRunningWrapper(data, dep.Spec.Template.Spec, sets.NewString(name), "", "")
+			wrappedPodSpec, err := apiserver.IsRunningWrapper(data, dep.Spec.Template.Spec, sets.NewString(name))
 			if err != nil {
 				return nil, fmt.Errorf("failed to add apiserver.IsRunningWrapper: %v", err)
 			}

--- a/api/pkg/resources/kubestatemetrics/deployment.go
+++ b/api/pkg/resources/kubestatemetrics/deployment.go
@@ -109,7 +109,7 @@ func DeploymentCreator(data *resources.TemplateData) reconciling.NamedDeployment
 				},
 			}
 
-			wrappedPodSpec, err := apiserver.IsRunningWrapper(data, dep.Spec.Template.Spec, sets.NewString(name), "", "")
+			wrappedPodSpec, err := apiserver.IsRunningWrapper(data, dep.Spec.Template.Spec, sets.NewString(name))
 			if err != nil {
 				return nil, fmt.Errorf("failed to add apiserver.IsRunningWrapper: %v", err)
 			}

--- a/api/pkg/resources/machinecontroller/deployment.go
+++ b/api/pkg/resources/machinecontroller/deployment.go
@@ -58,7 +58,7 @@ func DeploymentCreator(data machinecontrollerData) reconciling.NamedDeploymentCr
 			if err != nil {
 				return nil, err
 			}
-			wrappedPodSpec, err := apiserver.IsRunningWrapper(data, deployment.Spec.Template.Spec, sets.NewString(Name), "Machine", "cluster.k8s.io/v1alpha1")
+			wrappedPodSpec, err := apiserver.IsRunningWrapper(data, deployment.Spec.Template.Spec, sets.NewString(Name), "Machine,cluster.k8s.io/v1alpha1")
 			if err != nil {
 				return nil, fmt.Errorf("failed to add apiserver.IsRunningWrapper: %v", err)
 			}

--- a/api/pkg/resources/machinecontroller/webhook.go
+++ b/api/pkg/resources/machinecontroller/webhook.go
@@ -113,7 +113,7 @@ func WebhookDeploymentCreator(data machinecontrollerData) reconciling.NamedDeplo
 					},
 				},
 			}
-			wrappedPodSpec, err := apiserver.IsRunningWrapper(data, dep.Spec.Template.Spec, sets.NewString(Name), "Machine", "cluster.k8s.io/v1alpha1")
+			wrappedPodSpec, err := apiserver.IsRunningWrapper(data, dep.Spec.Template.Spec, sets.NewString(Name), "Machine,cluster.k8s.io/v1alpha1")
 			if err != nil {
 				return nil, fmt.Errorf("failed to add apiserver.IsRunningWrapper: %v", err)
 			}

--- a/api/pkg/resources/metrics-server/deployment.go
+++ b/api/pkg/resources/metrics-server/deployment.go
@@ -137,7 +137,7 @@ func DeploymentCreator(data metricsServerData) reconciling.NamedDeploymentCreato
 
 			dep.Spec.Template.Spec.Affinity = resources.HostnameAntiAffinity(name, data.Cluster().Name)
 
-			wrappedPodSpec, err := apiserver.IsRunningWrapper(data, dep.Spec.Template.Spec, sets.NewString(name), "", "")
+			wrappedPodSpec, err := apiserver.IsRunningWrapper(data, dep.Spec.Template.Spec, sets.NewString(name))
 			if err != nil {
 				return nil, fmt.Errorf("failed to add apiserver.IsRunningWrapper: %v", err)
 			}

--- a/api/pkg/resources/scheduler/deployment.go
+++ b/api/pkg/resources/scheduler/deployment.go
@@ -131,7 +131,7 @@ func DeploymentCreator(data *resources.TemplateData) reconciling.NamedDeployment
 
 			dep.Spec.Template.Spec.Affinity = resources.HostnameAntiAffinity(name, data.Cluster().Name)
 
-			wrappedPodSpec, err := apiserver.IsRunningWrapper(data, dep.Spec.Template.Spec, sets.NewString(name), "", "")
+			wrappedPodSpec, err := apiserver.IsRunningWrapper(data, dep.Spec.Template.Spec, sets.NewString(name))
 			if err != nil {
 				return nil, fmt.Errorf("failed to add apiserver.IsRunningWrapper: %v", err)
 			}

--- a/api/pkg/resources/test/fixtures/deployment-aws-1.10.0-controller-manager.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-aws-1.10.0-controller-manager.yaml
@@ -178,7 +178,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3
+        image: quay.io/kubermatic/http-prober:v0.3.1-dev
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/api/pkg/resources/test/fixtures/deployment-aws-1.10.0-controller-manager.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-aws-1.10.0-controller-manager.yaml
@@ -178,7 +178,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3.1-dev0
+        image: quay.io/kubermatic/http-prober:v0.3.1
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/api/pkg/resources/test/fixtures/deployment-aws-1.10.0-controller-manager.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-aws-1.10.0-controller-manager.yaml
@@ -178,7 +178,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3.1-dev
+        image: quay.io/kubermatic/http-prober:v0.3.1-dev0
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/api/pkg/resources/test/fixtures/deployment-aws-1.10.0-kube-state-metrics.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-aws-1.10.0-kube-state-metrics.yaml
@@ -72,7 +72,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3.1-dev0
+        image: quay.io/kubermatic/http-prober:v0.3.1
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/api/pkg/resources/test/fixtures/deployment-aws-1.10.0-kube-state-metrics.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-aws-1.10.0-kube-state-metrics.yaml
@@ -72,7 +72,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3
+        image: quay.io/kubermatic/http-prober:v0.3.1-dev
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/api/pkg/resources/test/fixtures/deployment-aws-1.10.0-kube-state-metrics.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-aws-1.10.0-kube-state-metrics.yaml
@@ -72,7 +72,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3.1-dev
+        image: quay.io/kubermatic/http-prober:v0.3.1-dev0
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/api/pkg/resources/test/fixtures/deployment-aws-1.10.0-machine-controller-webhook.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-aws-1.10.0-machine-controller-webhook.yaml
@@ -86,7 +86,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3.1-dev
+        image: quay.io/kubermatic/http-prober:v0.3.1-dev0
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/api/pkg/resources/test/fixtures/deployment-aws-1.10.0-machine-controller-webhook.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-aws-1.10.0-machine-controller-webhook.yaml
@@ -31,10 +31,8 @@ spec:
         - "1"
         - -command
         - '{"command":"/usr/local/bin/webhook","args":["-kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","-logtostderr","-v","4","-listen-address","0.0.0.0:9876"]}'
-        - -wait-for-crd-kind
-        - Machine
-        - -wait-for-crd-apiversion
-        - cluster.k8s.io/v1alpha1
+        - --crd-to-wait-for
+        - Machine,cluster.k8s.io/v1alpha1
         command:
         - /http-prober-bin/http-prober
         env:
@@ -88,7 +86,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3
+        image: quay.io/kubermatic/http-prober:v0.3.1-dev
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/api/pkg/resources/test/fixtures/deployment-aws-1.10.0-machine-controller-webhook.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-aws-1.10.0-machine-controller-webhook.yaml
@@ -86,7 +86,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3.1-dev0
+        image: quay.io/kubermatic/http-prober:v0.3.1
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/api/pkg/resources/test/fixtures/deployment-aws-1.10.0-machine-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-aws-1.10.0-machine-controller.yaml
@@ -77,7 +77,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3.1-dev
+        image: quay.io/kubermatic/http-prober:v0.3.1-dev0
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/api/pkg/resources/test/fixtures/deployment-aws-1.10.0-machine-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-aws-1.10.0-machine-controller.yaml
@@ -34,10 +34,8 @@ spec:
         - "1"
         - -command
         - '{"command":"/usr/local/bin/machine-controller","args":["-kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","-logtostderr","-v","4","-cluster-dns","169.254.20.10","-internal-listen-address","0.0.0.0:8085"]}'
-        - -wait-for-crd-kind
-        - Machine
-        - -wait-for-crd-apiversion
-        - cluster.k8s.io/v1alpha1
+        - --crd-to-wait-for
+        - Machine,cluster.k8s.io/v1alpha1
         command:
         - /http-prober-bin/http-prober
         env:
@@ -79,7 +77,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3
+        image: quay.io/kubermatic/http-prober:v0.3.1-dev
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/api/pkg/resources/test/fixtures/deployment-aws-1.10.0-machine-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-aws-1.10.0-machine-controller.yaml
@@ -77,7 +77,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3.1-dev0
+        image: quay.io/kubermatic/http-prober:v0.3.1
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/api/pkg/resources/test/fixtures/deployment-aws-1.10.0-metrics-server.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-aws-1.10.0-metrics-server.yaml
@@ -156,7 +156,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3
+        image: quay.io/kubermatic/http-prober:v0.3.1-dev
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/api/pkg/resources/test/fixtures/deployment-aws-1.10.0-metrics-server.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-aws-1.10.0-metrics-server.yaml
@@ -156,7 +156,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3.1-dev
+        image: quay.io/kubermatic/http-prober:v0.3.1-dev0
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/api/pkg/resources/test/fixtures/deployment-aws-1.10.0-metrics-server.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-aws-1.10.0-metrics-server.yaml
@@ -156,7 +156,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3.1-dev0
+        image: quay.io/kubermatic/http-prober:v0.3.1
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/api/pkg/resources/test/fixtures/deployment-aws-1.10.0-scheduler.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-aws-1.10.0-scheduler.yaml
@@ -163,7 +163,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3.1-dev
+        image: quay.io/kubermatic/http-prober:v0.3.1-dev0
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/api/pkg/resources/test/fixtures/deployment-aws-1.10.0-scheduler.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-aws-1.10.0-scheduler.yaml
@@ -163,7 +163,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3.1-dev0
+        image: quay.io/kubermatic/http-prober:v0.3.1
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/api/pkg/resources/test/fixtures/deployment-aws-1.10.0-scheduler.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-aws-1.10.0-scheduler.yaml
@@ -163,7 +163,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3
+        image: quay.io/kubermatic/http-prober:v0.3.1-dev
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/api/pkg/resources/test/fixtures/deployment-aws-1.10.0-usercluster-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-aws-1.10.0-usercluster-controller.yaml
@@ -85,7 +85,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3.1-dev0
+        image: quay.io/kubermatic/http-prober:v0.3.1
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/api/pkg/resources/test/fixtures/deployment-aws-1.10.0-usercluster-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-aws-1.10.0-usercluster-controller.yaml
@@ -85,7 +85,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3
+        image: quay.io/kubermatic/http-prober:v0.3.1-dev
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/api/pkg/resources/test/fixtures/deployment-aws-1.10.0-usercluster-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-aws-1.10.0-usercluster-controller.yaml
@@ -85,7 +85,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3.1-dev
+        image: quay.io/kubermatic/http-prober:v0.3.1-dev0
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/api/pkg/resources/test/fixtures/deployment-aws-1.10.6-controller-manager.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-aws-1.10.6-controller-manager.yaml
@@ -178,7 +178,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3
+        image: quay.io/kubermatic/http-prober:v0.3.1-dev
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/api/pkg/resources/test/fixtures/deployment-aws-1.10.6-controller-manager.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-aws-1.10.6-controller-manager.yaml
@@ -178,7 +178,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3.1-dev0
+        image: quay.io/kubermatic/http-prober:v0.3.1
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/api/pkg/resources/test/fixtures/deployment-aws-1.10.6-controller-manager.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-aws-1.10.6-controller-manager.yaml
@@ -178,7 +178,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3.1-dev
+        image: quay.io/kubermatic/http-prober:v0.3.1-dev0
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/api/pkg/resources/test/fixtures/deployment-aws-1.10.6-kube-state-metrics.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-aws-1.10.6-kube-state-metrics.yaml
@@ -72,7 +72,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3.1-dev0
+        image: quay.io/kubermatic/http-prober:v0.3.1
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/api/pkg/resources/test/fixtures/deployment-aws-1.10.6-kube-state-metrics.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-aws-1.10.6-kube-state-metrics.yaml
@@ -72,7 +72,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3
+        image: quay.io/kubermatic/http-prober:v0.3.1-dev
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/api/pkg/resources/test/fixtures/deployment-aws-1.10.6-kube-state-metrics.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-aws-1.10.6-kube-state-metrics.yaml
@@ -72,7 +72,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3.1-dev
+        image: quay.io/kubermatic/http-prober:v0.3.1-dev0
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/api/pkg/resources/test/fixtures/deployment-aws-1.10.6-machine-controller-webhook.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-aws-1.10.6-machine-controller-webhook.yaml
@@ -86,7 +86,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3.1-dev
+        image: quay.io/kubermatic/http-prober:v0.3.1-dev0
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/api/pkg/resources/test/fixtures/deployment-aws-1.10.6-machine-controller-webhook.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-aws-1.10.6-machine-controller-webhook.yaml
@@ -31,10 +31,8 @@ spec:
         - "1"
         - -command
         - '{"command":"/usr/local/bin/webhook","args":["-kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","-logtostderr","-v","4","-listen-address","0.0.0.0:9876"]}'
-        - -wait-for-crd-kind
-        - Machine
-        - -wait-for-crd-apiversion
-        - cluster.k8s.io/v1alpha1
+        - --crd-to-wait-for
+        - Machine,cluster.k8s.io/v1alpha1
         command:
         - /http-prober-bin/http-prober
         env:
@@ -88,7 +86,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3
+        image: quay.io/kubermatic/http-prober:v0.3.1-dev
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/api/pkg/resources/test/fixtures/deployment-aws-1.10.6-machine-controller-webhook.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-aws-1.10.6-machine-controller-webhook.yaml
@@ -86,7 +86,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3.1-dev0
+        image: quay.io/kubermatic/http-prober:v0.3.1
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/api/pkg/resources/test/fixtures/deployment-aws-1.10.6-machine-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-aws-1.10.6-machine-controller.yaml
@@ -77,7 +77,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3.1-dev
+        image: quay.io/kubermatic/http-prober:v0.3.1-dev0
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/api/pkg/resources/test/fixtures/deployment-aws-1.10.6-machine-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-aws-1.10.6-machine-controller.yaml
@@ -34,10 +34,8 @@ spec:
         - "1"
         - -command
         - '{"command":"/usr/local/bin/machine-controller","args":["-kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","-logtostderr","-v","4","-cluster-dns","169.254.20.10","-internal-listen-address","0.0.0.0:8085"]}'
-        - -wait-for-crd-kind
-        - Machine
-        - -wait-for-crd-apiversion
-        - cluster.k8s.io/v1alpha1
+        - --crd-to-wait-for
+        - Machine,cluster.k8s.io/v1alpha1
         command:
         - /http-prober-bin/http-prober
         env:
@@ -79,7 +77,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3
+        image: quay.io/kubermatic/http-prober:v0.3.1-dev
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/api/pkg/resources/test/fixtures/deployment-aws-1.10.6-machine-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-aws-1.10.6-machine-controller.yaml
@@ -77,7 +77,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3.1-dev0
+        image: quay.io/kubermatic/http-prober:v0.3.1
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/api/pkg/resources/test/fixtures/deployment-aws-1.10.6-metrics-server.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-aws-1.10.6-metrics-server.yaml
@@ -156,7 +156,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3
+        image: quay.io/kubermatic/http-prober:v0.3.1-dev
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/api/pkg/resources/test/fixtures/deployment-aws-1.10.6-metrics-server.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-aws-1.10.6-metrics-server.yaml
@@ -156,7 +156,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3.1-dev
+        image: quay.io/kubermatic/http-prober:v0.3.1-dev0
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/api/pkg/resources/test/fixtures/deployment-aws-1.10.6-metrics-server.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-aws-1.10.6-metrics-server.yaml
@@ -156,7 +156,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3.1-dev0
+        image: quay.io/kubermatic/http-prober:v0.3.1
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/api/pkg/resources/test/fixtures/deployment-aws-1.10.6-scheduler.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-aws-1.10.6-scheduler.yaml
@@ -163,7 +163,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3.1-dev
+        image: quay.io/kubermatic/http-prober:v0.3.1-dev0
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/api/pkg/resources/test/fixtures/deployment-aws-1.10.6-scheduler.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-aws-1.10.6-scheduler.yaml
@@ -163,7 +163,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3.1-dev0
+        image: quay.io/kubermatic/http-prober:v0.3.1
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/api/pkg/resources/test/fixtures/deployment-aws-1.10.6-scheduler.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-aws-1.10.6-scheduler.yaml
@@ -163,7 +163,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3
+        image: quay.io/kubermatic/http-prober:v0.3.1-dev
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/api/pkg/resources/test/fixtures/deployment-aws-1.10.6-usercluster-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-aws-1.10.6-usercluster-controller.yaml
@@ -85,7 +85,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3.1-dev0
+        image: quay.io/kubermatic/http-prober:v0.3.1
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/api/pkg/resources/test/fixtures/deployment-aws-1.10.6-usercluster-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-aws-1.10.6-usercluster-controller.yaml
@@ -85,7 +85,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3
+        image: quay.io/kubermatic/http-prober:v0.3.1-dev
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/api/pkg/resources/test/fixtures/deployment-aws-1.10.6-usercluster-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-aws-1.10.6-usercluster-controller.yaml
@@ -85,7 +85,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3.1-dev
+        image: quay.io/kubermatic/http-prober:v0.3.1-dev0
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/api/pkg/resources/test/fixtures/deployment-aws-1.11.0-controller-manager.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-aws-1.11.0-controller-manager.yaml
@@ -178,7 +178,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3
+        image: quay.io/kubermatic/http-prober:v0.3.1-dev
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/api/pkg/resources/test/fixtures/deployment-aws-1.11.0-controller-manager.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-aws-1.11.0-controller-manager.yaml
@@ -178,7 +178,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3.1-dev0
+        image: quay.io/kubermatic/http-prober:v0.3.1
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/api/pkg/resources/test/fixtures/deployment-aws-1.11.0-controller-manager.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-aws-1.11.0-controller-manager.yaml
@@ -178,7 +178,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3.1-dev
+        image: quay.io/kubermatic/http-prober:v0.3.1-dev0
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/api/pkg/resources/test/fixtures/deployment-aws-1.11.0-kube-state-metrics.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-aws-1.11.0-kube-state-metrics.yaml
@@ -72,7 +72,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3.1-dev0
+        image: quay.io/kubermatic/http-prober:v0.3.1
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/api/pkg/resources/test/fixtures/deployment-aws-1.11.0-kube-state-metrics.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-aws-1.11.0-kube-state-metrics.yaml
@@ -72,7 +72,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3
+        image: quay.io/kubermatic/http-prober:v0.3.1-dev
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/api/pkg/resources/test/fixtures/deployment-aws-1.11.0-kube-state-metrics.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-aws-1.11.0-kube-state-metrics.yaml
@@ -72,7 +72,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3.1-dev
+        image: quay.io/kubermatic/http-prober:v0.3.1-dev0
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/api/pkg/resources/test/fixtures/deployment-aws-1.11.0-machine-controller-webhook.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-aws-1.11.0-machine-controller-webhook.yaml
@@ -86,7 +86,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3.1-dev
+        image: quay.io/kubermatic/http-prober:v0.3.1-dev0
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/api/pkg/resources/test/fixtures/deployment-aws-1.11.0-machine-controller-webhook.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-aws-1.11.0-machine-controller-webhook.yaml
@@ -31,10 +31,8 @@ spec:
         - "1"
         - -command
         - '{"command":"/usr/local/bin/webhook","args":["-kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","-logtostderr","-v","4","-listen-address","0.0.0.0:9876"]}'
-        - -wait-for-crd-kind
-        - Machine
-        - -wait-for-crd-apiversion
-        - cluster.k8s.io/v1alpha1
+        - --crd-to-wait-for
+        - Machine,cluster.k8s.io/v1alpha1
         command:
         - /http-prober-bin/http-prober
         env:
@@ -88,7 +86,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3
+        image: quay.io/kubermatic/http-prober:v0.3.1-dev
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/api/pkg/resources/test/fixtures/deployment-aws-1.11.0-machine-controller-webhook.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-aws-1.11.0-machine-controller-webhook.yaml
@@ -86,7 +86,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3.1-dev0
+        image: quay.io/kubermatic/http-prober:v0.3.1
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/api/pkg/resources/test/fixtures/deployment-aws-1.11.0-machine-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-aws-1.11.0-machine-controller.yaml
@@ -77,7 +77,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3.1-dev
+        image: quay.io/kubermatic/http-prober:v0.3.1-dev0
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/api/pkg/resources/test/fixtures/deployment-aws-1.11.0-machine-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-aws-1.11.0-machine-controller.yaml
@@ -34,10 +34,8 @@ spec:
         - "1"
         - -command
         - '{"command":"/usr/local/bin/machine-controller","args":["-kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","-logtostderr","-v","4","-cluster-dns","169.254.20.10","-internal-listen-address","0.0.0.0:8085"]}'
-        - -wait-for-crd-kind
-        - Machine
-        - -wait-for-crd-apiversion
-        - cluster.k8s.io/v1alpha1
+        - --crd-to-wait-for
+        - Machine,cluster.k8s.io/v1alpha1
         command:
         - /http-prober-bin/http-prober
         env:
@@ -79,7 +77,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3
+        image: quay.io/kubermatic/http-prober:v0.3.1-dev
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/api/pkg/resources/test/fixtures/deployment-aws-1.11.0-machine-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-aws-1.11.0-machine-controller.yaml
@@ -77,7 +77,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3.1-dev0
+        image: quay.io/kubermatic/http-prober:v0.3.1
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/api/pkg/resources/test/fixtures/deployment-aws-1.11.0-metrics-server.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-aws-1.11.0-metrics-server.yaml
@@ -156,7 +156,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3
+        image: quay.io/kubermatic/http-prober:v0.3.1-dev
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/api/pkg/resources/test/fixtures/deployment-aws-1.11.0-metrics-server.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-aws-1.11.0-metrics-server.yaml
@@ -156,7 +156,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3.1-dev
+        image: quay.io/kubermatic/http-prober:v0.3.1-dev0
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/api/pkg/resources/test/fixtures/deployment-aws-1.11.0-metrics-server.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-aws-1.11.0-metrics-server.yaml
@@ -156,7 +156,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3.1-dev0
+        image: quay.io/kubermatic/http-prober:v0.3.1
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/api/pkg/resources/test/fixtures/deployment-aws-1.11.0-scheduler.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-aws-1.11.0-scheduler.yaml
@@ -163,7 +163,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3.1-dev
+        image: quay.io/kubermatic/http-prober:v0.3.1-dev0
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/api/pkg/resources/test/fixtures/deployment-aws-1.11.0-scheduler.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-aws-1.11.0-scheduler.yaml
@@ -163,7 +163,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3.1-dev0
+        image: quay.io/kubermatic/http-prober:v0.3.1
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/api/pkg/resources/test/fixtures/deployment-aws-1.11.0-scheduler.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-aws-1.11.0-scheduler.yaml
@@ -163,7 +163,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3
+        image: quay.io/kubermatic/http-prober:v0.3.1-dev
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/api/pkg/resources/test/fixtures/deployment-aws-1.11.0-usercluster-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-aws-1.11.0-usercluster-controller.yaml
@@ -85,7 +85,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3.1-dev0
+        image: quay.io/kubermatic/http-prober:v0.3.1
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/api/pkg/resources/test/fixtures/deployment-aws-1.11.0-usercluster-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-aws-1.11.0-usercluster-controller.yaml
@@ -85,7 +85,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3
+        image: quay.io/kubermatic/http-prober:v0.3.1-dev
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/api/pkg/resources/test/fixtures/deployment-aws-1.11.0-usercluster-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-aws-1.11.0-usercluster-controller.yaml
@@ -85,7 +85,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3.1-dev
+        image: quay.io/kubermatic/http-prober:v0.3.1-dev0
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/api/pkg/resources/test/fixtures/deployment-aws-1.11.1-controller-manager.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-aws-1.11.1-controller-manager.yaml
@@ -178,7 +178,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3
+        image: quay.io/kubermatic/http-prober:v0.3.1-dev
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/api/pkg/resources/test/fixtures/deployment-aws-1.11.1-controller-manager.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-aws-1.11.1-controller-manager.yaml
@@ -178,7 +178,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3.1-dev0
+        image: quay.io/kubermatic/http-prober:v0.3.1
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/api/pkg/resources/test/fixtures/deployment-aws-1.11.1-controller-manager.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-aws-1.11.1-controller-manager.yaml
@@ -178,7 +178,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3.1-dev
+        image: quay.io/kubermatic/http-prober:v0.3.1-dev0
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/api/pkg/resources/test/fixtures/deployment-aws-1.11.1-kube-state-metrics.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-aws-1.11.1-kube-state-metrics.yaml
@@ -72,7 +72,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3.1-dev0
+        image: quay.io/kubermatic/http-prober:v0.3.1
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/api/pkg/resources/test/fixtures/deployment-aws-1.11.1-kube-state-metrics.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-aws-1.11.1-kube-state-metrics.yaml
@@ -72,7 +72,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3
+        image: quay.io/kubermatic/http-prober:v0.3.1-dev
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/api/pkg/resources/test/fixtures/deployment-aws-1.11.1-kube-state-metrics.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-aws-1.11.1-kube-state-metrics.yaml
@@ -72,7 +72,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3.1-dev
+        image: quay.io/kubermatic/http-prober:v0.3.1-dev0
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/api/pkg/resources/test/fixtures/deployment-aws-1.11.1-machine-controller-webhook.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-aws-1.11.1-machine-controller-webhook.yaml
@@ -86,7 +86,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3.1-dev
+        image: quay.io/kubermatic/http-prober:v0.3.1-dev0
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/api/pkg/resources/test/fixtures/deployment-aws-1.11.1-machine-controller-webhook.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-aws-1.11.1-machine-controller-webhook.yaml
@@ -31,10 +31,8 @@ spec:
         - "1"
         - -command
         - '{"command":"/usr/local/bin/webhook","args":["-kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","-logtostderr","-v","4","-listen-address","0.0.0.0:9876"]}'
-        - -wait-for-crd-kind
-        - Machine
-        - -wait-for-crd-apiversion
-        - cluster.k8s.io/v1alpha1
+        - --crd-to-wait-for
+        - Machine,cluster.k8s.io/v1alpha1
         command:
         - /http-prober-bin/http-prober
         env:
@@ -88,7 +86,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3
+        image: quay.io/kubermatic/http-prober:v0.3.1-dev
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/api/pkg/resources/test/fixtures/deployment-aws-1.11.1-machine-controller-webhook.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-aws-1.11.1-machine-controller-webhook.yaml
@@ -86,7 +86,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3.1-dev0
+        image: quay.io/kubermatic/http-prober:v0.3.1
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/api/pkg/resources/test/fixtures/deployment-aws-1.11.1-machine-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-aws-1.11.1-machine-controller.yaml
@@ -77,7 +77,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3.1-dev
+        image: quay.io/kubermatic/http-prober:v0.3.1-dev0
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/api/pkg/resources/test/fixtures/deployment-aws-1.11.1-machine-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-aws-1.11.1-machine-controller.yaml
@@ -34,10 +34,8 @@ spec:
         - "1"
         - -command
         - '{"command":"/usr/local/bin/machine-controller","args":["-kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","-logtostderr","-v","4","-cluster-dns","169.254.20.10","-internal-listen-address","0.0.0.0:8085"]}'
-        - -wait-for-crd-kind
-        - Machine
-        - -wait-for-crd-apiversion
-        - cluster.k8s.io/v1alpha1
+        - --crd-to-wait-for
+        - Machine,cluster.k8s.io/v1alpha1
         command:
         - /http-prober-bin/http-prober
         env:
@@ -79,7 +77,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3
+        image: quay.io/kubermatic/http-prober:v0.3.1-dev
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/api/pkg/resources/test/fixtures/deployment-aws-1.11.1-machine-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-aws-1.11.1-machine-controller.yaml
@@ -77,7 +77,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3.1-dev0
+        image: quay.io/kubermatic/http-prober:v0.3.1
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/api/pkg/resources/test/fixtures/deployment-aws-1.11.1-metrics-server.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-aws-1.11.1-metrics-server.yaml
@@ -156,7 +156,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3
+        image: quay.io/kubermatic/http-prober:v0.3.1-dev
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/api/pkg/resources/test/fixtures/deployment-aws-1.11.1-metrics-server.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-aws-1.11.1-metrics-server.yaml
@@ -156,7 +156,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3.1-dev
+        image: quay.io/kubermatic/http-prober:v0.3.1-dev0
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/api/pkg/resources/test/fixtures/deployment-aws-1.11.1-metrics-server.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-aws-1.11.1-metrics-server.yaml
@@ -156,7 +156,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3.1-dev0
+        image: quay.io/kubermatic/http-prober:v0.3.1
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/api/pkg/resources/test/fixtures/deployment-aws-1.11.1-scheduler.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-aws-1.11.1-scheduler.yaml
@@ -163,7 +163,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3.1-dev
+        image: quay.io/kubermatic/http-prober:v0.3.1-dev0
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/api/pkg/resources/test/fixtures/deployment-aws-1.11.1-scheduler.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-aws-1.11.1-scheduler.yaml
@@ -163,7 +163,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3.1-dev0
+        image: quay.io/kubermatic/http-prober:v0.3.1
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/api/pkg/resources/test/fixtures/deployment-aws-1.11.1-scheduler.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-aws-1.11.1-scheduler.yaml
@@ -163,7 +163,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3
+        image: quay.io/kubermatic/http-prober:v0.3.1-dev
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/api/pkg/resources/test/fixtures/deployment-aws-1.11.1-usercluster-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-aws-1.11.1-usercluster-controller.yaml
@@ -85,7 +85,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3.1-dev0
+        image: quay.io/kubermatic/http-prober:v0.3.1
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/api/pkg/resources/test/fixtures/deployment-aws-1.11.1-usercluster-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-aws-1.11.1-usercluster-controller.yaml
@@ -85,7 +85,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3
+        image: quay.io/kubermatic/http-prober:v0.3.1-dev
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/api/pkg/resources/test/fixtures/deployment-aws-1.11.1-usercluster-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-aws-1.11.1-usercluster-controller.yaml
@@ -85,7 +85,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3.1-dev
+        image: quay.io/kubermatic/http-prober:v0.3.1-dev0
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/api/pkg/resources/test/fixtures/deployment-aws-1.12.0-controller-manager.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-aws-1.12.0-controller-manager.yaml
@@ -178,7 +178,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3
+        image: quay.io/kubermatic/http-prober:v0.3.1-dev
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/api/pkg/resources/test/fixtures/deployment-aws-1.12.0-controller-manager.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-aws-1.12.0-controller-manager.yaml
@@ -178,7 +178,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3.1-dev0
+        image: quay.io/kubermatic/http-prober:v0.3.1
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/api/pkg/resources/test/fixtures/deployment-aws-1.12.0-controller-manager.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-aws-1.12.0-controller-manager.yaml
@@ -178,7 +178,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3.1-dev
+        image: quay.io/kubermatic/http-prober:v0.3.1-dev0
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/api/pkg/resources/test/fixtures/deployment-aws-1.12.0-kube-state-metrics.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-aws-1.12.0-kube-state-metrics.yaml
@@ -72,7 +72,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3.1-dev0
+        image: quay.io/kubermatic/http-prober:v0.3.1
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/api/pkg/resources/test/fixtures/deployment-aws-1.12.0-kube-state-metrics.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-aws-1.12.0-kube-state-metrics.yaml
@@ -72,7 +72,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3
+        image: quay.io/kubermatic/http-prober:v0.3.1-dev
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/api/pkg/resources/test/fixtures/deployment-aws-1.12.0-kube-state-metrics.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-aws-1.12.0-kube-state-metrics.yaml
@@ -72,7 +72,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3.1-dev
+        image: quay.io/kubermatic/http-prober:v0.3.1-dev0
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/api/pkg/resources/test/fixtures/deployment-aws-1.12.0-machine-controller-webhook.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-aws-1.12.0-machine-controller-webhook.yaml
@@ -86,7 +86,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3.1-dev
+        image: quay.io/kubermatic/http-prober:v0.3.1-dev0
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/api/pkg/resources/test/fixtures/deployment-aws-1.12.0-machine-controller-webhook.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-aws-1.12.0-machine-controller-webhook.yaml
@@ -31,10 +31,8 @@ spec:
         - "1"
         - -command
         - '{"command":"/usr/local/bin/webhook","args":["-kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","-logtostderr","-v","4","-listen-address","0.0.0.0:9876"]}'
-        - -wait-for-crd-kind
-        - Machine
-        - -wait-for-crd-apiversion
-        - cluster.k8s.io/v1alpha1
+        - --crd-to-wait-for
+        - Machine,cluster.k8s.io/v1alpha1
         command:
         - /http-prober-bin/http-prober
         env:
@@ -88,7 +86,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3
+        image: quay.io/kubermatic/http-prober:v0.3.1-dev
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/api/pkg/resources/test/fixtures/deployment-aws-1.12.0-machine-controller-webhook.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-aws-1.12.0-machine-controller-webhook.yaml
@@ -86,7 +86,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3.1-dev0
+        image: quay.io/kubermatic/http-prober:v0.3.1
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/api/pkg/resources/test/fixtures/deployment-aws-1.12.0-machine-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-aws-1.12.0-machine-controller.yaml
@@ -77,7 +77,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3.1-dev
+        image: quay.io/kubermatic/http-prober:v0.3.1-dev0
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/api/pkg/resources/test/fixtures/deployment-aws-1.12.0-machine-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-aws-1.12.0-machine-controller.yaml
@@ -34,10 +34,8 @@ spec:
         - "1"
         - -command
         - '{"command":"/usr/local/bin/machine-controller","args":["-kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","-logtostderr","-v","4","-cluster-dns","169.254.20.10","-internal-listen-address","0.0.0.0:8085"]}'
-        - -wait-for-crd-kind
-        - Machine
-        - -wait-for-crd-apiversion
-        - cluster.k8s.io/v1alpha1
+        - --crd-to-wait-for
+        - Machine,cluster.k8s.io/v1alpha1
         command:
         - /http-prober-bin/http-prober
         env:
@@ -79,7 +77,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3
+        image: quay.io/kubermatic/http-prober:v0.3.1-dev
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/api/pkg/resources/test/fixtures/deployment-aws-1.12.0-machine-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-aws-1.12.0-machine-controller.yaml
@@ -77,7 +77,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3.1-dev0
+        image: quay.io/kubermatic/http-prober:v0.3.1
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/api/pkg/resources/test/fixtures/deployment-aws-1.12.0-metrics-server.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-aws-1.12.0-metrics-server.yaml
@@ -156,7 +156,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3
+        image: quay.io/kubermatic/http-prober:v0.3.1-dev
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/api/pkg/resources/test/fixtures/deployment-aws-1.12.0-metrics-server.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-aws-1.12.0-metrics-server.yaml
@@ -156,7 +156,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3.1-dev
+        image: quay.io/kubermatic/http-prober:v0.3.1-dev0
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/api/pkg/resources/test/fixtures/deployment-aws-1.12.0-metrics-server.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-aws-1.12.0-metrics-server.yaml
@@ -156,7 +156,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3.1-dev0
+        image: quay.io/kubermatic/http-prober:v0.3.1
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/api/pkg/resources/test/fixtures/deployment-aws-1.12.0-scheduler.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-aws-1.12.0-scheduler.yaml
@@ -163,7 +163,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3.1-dev
+        image: quay.io/kubermatic/http-prober:v0.3.1-dev0
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/api/pkg/resources/test/fixtures/deployment-aws-1.12.0-scheduler.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-aws-1.12.0-scheduler.yaml
@@ -163,7 +163,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3.1-dev0
+        image: quay.io/kubermatic/http-prober:v0.3.1
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/api/pkg/resources/test/fixtures/deployment-aws-1.12.0-scheduler.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-aws-1.12.0-scheduler.yaml
@@ -163,7 +163,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3
+        image: quay.io/kubermatic/http-prober:v0.3.1-dev
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/api/pkg/resources/test/fixtures/deployment-aws-1.12.0-usercluster-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-aws-1.12.0-usercluster-controller.yaml
@@ -85,7 +85,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3.1-dev0
+        image: quay.io/kubermatic/http-prober:v0.3.1
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/api/pkg/resources/test/fixtures/deployment-aws-1.12.0-usercluster-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-aws-1.12.0-usercluster-controller.yaml
@@ -85,7 +85,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3
+        image: quay.io/kubermatic/http-prober:v0.3.1-dev
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/api/pkg/resources/test/fixtures/deployment-aws-1.12.0-usercluster-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-aws-1.12.0-usercluster-controller.yaml
@@ -85,7 +85,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3.1-dev
+        image: quay.io/kubermatic/http-prober:v0.3.1-dev0
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/api/pkg/resources/test/fixtures/deployment-aws-1.13.0-controller-manager.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-aws-1.13.0-controller-manager.yaml
@@ -178,7 +178,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3
+        image: quay.io/kubermatic/http-prober:v0.3.1-dev
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/api/pkg/resources/test/fixtures/deployment-aws-1.13.0-controller-manager.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-aws-1.13.0-controller-manager.yaml
@@ -178,7 +178,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3.1-dev0
+        image: quay.io/kubermatic/http-prober:v0.3.1
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/api/pkg/resources/test/fixtures/deployment-aws-1.13.0-controller-manager.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-aws-1.13.0-controller-manager.yaml
@@ -178,7 +178,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3.1-dev
+        image: quay.io/kubermatic/http-prober:v0.3.1-dev0
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/api/pkg/resources/test/fixtures/deployment-aws-1.13.0-kube-state-metrics.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-aws-1.13.0-kube-state-metrics.yaml
@@ -72,7 +72,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3.1-dev0
+        image: quay.io/kubermatic/http-prober:v0.3.1
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/api/pkg/resources/test/fixtures/deployment-aws-1.13.0-kube-state-metrics.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-aws-1.13.0-kube-state-metrics.yaml
@@ -72,7 +72,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3
+        image: quay.io/kubermatic/http-prober:v0.3.1-dev
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/api/pkg/resources/test/fixtures/deployment-aws-1.13.0-kube-state-metrics.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-aws-1.13.0-kube-state-metrics.yaml
@@ -72,7 +72,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3.1-dev
+        image: quay.io/kubermatic/http-prober:v0.3.1-dev0
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/api/pkg/resources/test/fixtures/deployment-aws-1.13.0-machine-controller-webhook.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-aws-1.13.0-machine-controller-webhook.yaml
@@ -86,7 +86,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3.1-dev
+        image: quay.io/kubermatic/http-prober:v0.3.1-dev0
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/api/pkg/resources/test/fixtures/deployment-aws-1.13.0-machine-controller-webhook.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-aws-1.13.0-machine-controller-webhook.yaml
@@ -31,10 +31,8 @@ spec:
         - "1"
         - -command
         - '{"command":"/usr/local/bin/webhook","args":["-kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","-logtostderr","-v","4","-listen-address","0.0.0.0:9876"]}'
-        - -wait-for-crd-kind
-        - Machine
-        - -wait-for-crd-apiversion
-        - cluster.k8s.io/v1alpha1
+        - --crd-to-wait-for
+        - Machine,cluster.k8s.io/v1alpha1
         command:
         - /http-prober-bin/http-prober
         env:
@@ -88,7 +86,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3
+        image: quay.io/kubermatic/http-prober:v0.3.1-dev
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/api/pkg/resources/test/fixtures/deployment-aws-1.13.0-machine-controller-webhook.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-aws-1.13.0-machine-controller-webhook.yaml
@@ -86,7 +86,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3.1-dev0
+        image: quay.io/kubermatic/http-prober:v0.3.1
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/api/pkg/resources/test/fixtures/deployment-aws-1.13.0-machine-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-aws-1.13.0-machine-controller.yaml
@@ -77,7 +77,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3.1-dev
+        image: quay.io/kubermatic/http-prober:v0.3.1-dev0
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/api/pkg/resources/test/fixtures/deployment-aws-1.13.0-machine-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-aws-1.13.0-machine-controller.yaml
@@ -34,10 +34,8 @@ spec:
         - "1"
         - -command
         - '{"command":"/usr/local/bin/machine-controller","args":["-kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","-logtostderr","-v","4","-cluster-dns","169.254.20.10","-internal-listen-address","0.0.0.0:8085"]}'
-        - -wait-for-crd-kind
-        - Machine
-        - -wait-for-crd-apiversion
-        - cluster.k8s.io/v1alpha1
+        - --crd-to-wait-for
+        - Machine,cluster.k8s.io/v1alpha1
         command:
         - /http-prober-bin/http-prober
         env:
@@ -79,7 +77,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3
+        image: quay.io/kubermatic/http-prober:v0.3.1-dev
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/api/pkg/resources/test/fixtures/deployment-aws-1.13.0-machine-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-aws-1.13.0-machine-controller.yaml
@@ -77,7 +77,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3.1-dev0
+        image: quay.io/kubermatic/http-prober:v0.3.1
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/api/pkg/resources/test/fixtures/deployment-aws-1.13.0-metrics-server.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-aws-1.13.0-metrics-server.yaml
@@ -156,7 +156,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3
+        image: quay.io/kubermatic/http-prober:v0.3.1-dev
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/api/pkg/resources/test/fixtures/deployment-aws-1.13.0-metrics-server.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-aws-1.13.0-metrics-server.yaml
@@ -156,7 +156,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3.1-dev
+        image: quay.io/kubermatic/http-prober:v0.3.1-dev0
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/api/pkg/resources/test/fixtures/deployment-aws-1.13.0-metrics-server.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-aws-1.13.0-metrics-server.yaml
@@ -156,7 +156,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3.1-dev0
+        image: quay.io/kubermatic/http-prober:v0.3.1
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/api/pkg/resources/test/fixtures/deployment-aws-1.13.0-scheduler.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-aws-1.13.0-scheduler.yaml
@@ -163,7 +163,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3.1-dev
+        image: quay.io/kubermatic/http-prober:v0.3.1-dev0
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/api/pkg/resources/test/fixtures/deployment-aws-1.13.0-scheduler.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-aws-1.13.0-scheduler.yaml
@@ -163,7 +163,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3.1-dev0
+        image: quay.io/kubermatic/http-prober:v0.3.1
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/api/pkg/resources/test/fixtures/deployment-aws-1.13.0-scheduler.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-aws-1.13.0-scheduler.yaml
@@ -163,7 +163,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3
+        image: quay.io/kubermatic/http-prober:v0.3.1-dev
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/api/pkg/resources/test/fixtures/deployment-aws-1.13.0-usercluster-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-aws-1.13.0-usercluster-controller.yaml
@@ -85,7 +85,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3.1-dev0
+        image: quay.io/kubermatic/http-prober:v0.3.1
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/api/pkg/resources/test/fixtures/deployment-aws-1.13.0-usercluster-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-aws-1.13.0-usercluster-controller.yaml
@@ -85,7 +85,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3
+        image: quay.io/kubermatic/http-prober:v0.3.1-dev
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/api/pkg/resources/test/fixtures/deployment-aws-1.13.0-usercluster-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-aws-1.13.0-usercluster-controller.yaml
@@ -85,7 +85,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3.1-dev
+        image: quay.io/kubermatic/http-prober:v0.3.1-dev0
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/api/pkg/resources/test/fixtures/deployment-azure-1.10.0-controller-manager.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-azure-1.10.0-controller-manager.yaml
@@ -171,7 +171,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3.1-dev0
+        image: quay.io/kubermatic/http-prober:v0.3.1
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/api/pkg/resources/test/fixtures/deployment-azure-1.10.0-controller-manager.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-azure-1.10.0-controller-manager.yaml
@@ -171,7 +171,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3
+        image: quay.io/kubermatic/http-prober:v0.3.1-dev
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/api/pkg/resources/test/fixtures/deployment-azure-1.10.0-controller-manager.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-azure-1.10.0-controller-manager.yaml
@@ -171,7 +171,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3.1-dev
+        image: quay.io/kubermatic/http-prober:v0.3.1-dev0
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/api/pkg/resources/test/fixtures/deployment-azure-1.10.0-kube-state-metrics.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-azure-1.10.0-kube-state-metrics.yaml
@@ -72,7 +72,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3.1-dev0
+        image: quay.io/kubermatic/http-prober:v0.3.1
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/api/pkg/resources/test/fixtures/deployment-azure-1.10.0-kube-state-metrics.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-azure-1.10.0-kube-state-metrics.yaml
@@ -72,7 +72,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3
+        image: quay.io/kubermatic/http-prober:v0.3.1-dev
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/api/pkg/resources/test/fixtures/deployment-azure-1.10.0-kube-state-metrics.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-azure-1.10.0-kube-state-metrics.yaml
@@ -72,7 +72,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3.1-dev
+        image: quay.io/kubermatic/http-prober:v0.3.1-dev0
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/api/pkg/resources/test/fixtures/deployment-azure-1.10.0-machine-controller-webhook.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-azure-1.10.0-machine-controller-webhook.yaml
@@ -90,7 +90,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3.1-dev0
+        image: quay.io/kubermatic/http-prober:v0.3.1
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/api/pkg/resources/test/fixtures/deployment-azure-1.10.0-machine-controller-webhook.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-azure-1.10.0-machine-controller-webhook.yaml
@@ -31,10 +31,8 @@ spec:
         - "1"
         - -command
         - '{"command":"/usr/local/bin/webhook","args":["-kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","-logtostderr","-v","4","-listen-address","0.0.0.0:9876"]}'
-        - -wait-for-crd-kind
-        - Machine
-        - -wait-for-crd-apiversion
-        - cluster.k8s.io/v1alpha1
+        - --crd-to-wait-for
+        - Machine,cluster.k8s.io/v1alpha1
         command:
         - /http-prober-bin/http-prober
         env:
@@ -92,7 +90,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3
+        image: quay.io/kubermatic/http-prober:v0.3.1-dev
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/api/pkg/resources/test/fixtures/deployment-azure-1.10.0-machine-controller-webhook.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-azure-1.10.0-machine-controller-webhook.yaml
@@ -90,7 +90,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3.1-dev
+        image: quay.io/kubermatic/http-prober:v0.3.1-dev0
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/api/pkg/resources/test/fixtures/deployment-azure-1.10.0-machine-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-azure-1.10.0-machine-controller.yaml
@@ -34,10 +34,8 @@ spec:
         - "1"
         - -command
         - '{"command":"/usr/local/bin/machine-controller","args":["-kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","-logtostderr","-v","4","-cluster-dns","169.254.20.10","-internal-listen-address","0.0.0.0:8085"]}'
-        - -wait-for-crd-kind
-        - Machine
-        - -wait-for-crd-apiversion
-        - cluster.k8s.io/v1alpha1
+        - --crd-to-wait-for
+        - Machine,cluster.k8s.io/v1alpha1
         command:
         - /http-prober-bin/http-prober
         env:
@@ -83,7 +81,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3
+        image: quay.io/kubermatic/http-prober:v0.3.1-dev
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/api/pkg/resources/test/fixtures/deployment-azure-1.10.0-machine-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-azure-1.10.0-machine-controller.yaml
@@ -81,7 +81,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3.1-dev0
+        image: quay.io/kubermatic/http-prober:v0.3.1
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/api/pkg/resources/test/fixtures/deployment-azure-1.10.0-machine-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-azure-1.10.0-machine-controller.yaml
@@ -81,7 +81,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3.1-dev
+        image: quay.io/kubermatic/http-prober:v0.3.1-dev0
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/api/pkg/resources/test/fixtures/deployment-azure-1.10.0-metrics-server.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-azure-1.10.0-metrics-server.yaml
@@ -156,7 +156,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3
+        image: quay.io/kubermatic/http-prober:v0.3.1-dev
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/api/pkg/resources/test/fixtures/deployment-azure-1.10.0-metrics-server.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-azure-1.10.0-metrics-server.yaml
@@ -156,7 +156,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3.1-dev
+        image: quay.io/kubermatic/http-prober:v0.3.1-dev0
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/api/pkg/resources/test/fixtures/deployment-azure-1.10.0-metrics-server.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-azure-1.10.0-metrics-server.yaml
@@ -156,7 +156,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3.1-dev0
+        image: quay.io/kubermatic/http-prober:v0.3.1
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/api/pkg/resources/test/fixtures/deployment-azure-1.10.0-scheduler.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-azure-1.10.0-scheduler.yaml
@@ -163,7 +163,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3.1-dev
+        image: quay.io/kubermatic/http-prober:v0.3.1-dev0
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/api/pkg/resources/test/fixtures/deployment-azure-1.10.0-scheduler.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-azure-1.10.0-scheduler.yaml
@@ -163,7 +163,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3.1-dev0
+        image: quay.io/kubermatic/http-prober:v0.3.1
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/api/pkg/resources/test/fixtures/deployment-azure-1.10.0-scheduler.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-azure-1.10.0-scheduler.yaml
@@ -163,7 +163,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3
+        image: quay.io/kubermatic/http-prober:v0.3.1-dev
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/api/pkg/resources/test/fixtures/deployment-azure-1.10.0-usercluster-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-azure-1.10.0-usercluster-controller.yaml
@@ -85,7 +85,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3.1-dev0
+        image: quay.io/kubermatic/http-prober:v0.3.1
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/api/pkg/resources/test/fixtures/deployment-azure-1.10.0-usercluster-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-azure-1.10.0-usercluster-controller.yaml
@@ -85,7 +85,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3
+        image: quay.io/kubermatic/http-prober:v0.3.1-dev
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/api/pkg/resources/test/fixtures/deployment-azure-1.10.0-usercluster-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-azure-1.10.0-usercluster-controller.yaml
@@ -85,7 +85,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3.1-dev
+        image: quay.io/kubermatic/http-prober:v0.3.1-dev0
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/api/pkg/resources/test/fixtures/deployment-azure-1.10.6-controller-manager.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-azure-1.10.6-controller-manager.yaml
@@ -171,7 +171,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3.1-dev0
+        image: quay.io/kubermatic/http-prober:v0.3.1
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/api/pkg/resources/test/fixtures/deployment-azure-1.10.6-controller-manager.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-azure-1.10.6-controller-manager.yaml
@@ -171,7 +171,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3
+        image: quay.io/kubermatic/http-prober:v0.3.1-dev
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/api/pkg/resources/test/fixtures/deployment-azure-1.10.6-controller-manager.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-azure-1.10.6-controller-manager.yaml
@@ -171,7 +171,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3.1-dev
+        image: quay.io/kubermatic/http-prober:v0.3.1-dev0
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/api/pkg/resources/test/fixtures/deployment-azure-1.10.6-kube-state-metrics.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-azure-1.10.6-kube-state-metrics.yaml
@@ -72,7 +72,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3.1-dev0
+        image: quay.io/kubermatic/http-prober:v0.3.1
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/api/pkg/resources/test/fixtures/deployment-azure-1.10.6-kube-state-metrics.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-azure-1.10.6-kube-state-metrics.yaml
@@ -72,7 +72,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3
+        image: quay.io/kubermatic/http-prober:v0.3.1-dev
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/api/pkg/resources/test/fixtures/deployment-azure-1.10.6-kube-state-metrics.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-azure-1.10.6-kube-state-metrics.yaml
@@ -72,7 +72,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3.1-dev
+        image: quay.io/kubermatic/http-prober:v0.3.1-dev0
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/api/pkg/resources/test/fixtures/deployment-azure-1.10.6-machine-controller-webhook.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-azure-1.10.6-machine-controller-webhook.yaml
@@ -90,7 +90,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3.1-dev0
+        image: quay.io/kubermatic/http-prober:v0.3.1
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/api/pkg/resources/test/fixtures/deployment-azure-1.10.6-machine-controller-webhook.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-azure-1.10.6-machine-controller-webhook.yaml
@@ -31,10 +31,8 @@ spec:
         - "1"
         - -command
         - '{"command":"/usr/local/bin/webhook","args":["-kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","-logtostderr","-v","4","-listen-address","0.0.0.0:9876"]}'
-        - -wait-for-crd-kind
-        - Machine
-        - -wait-for-crd-apiversion
-        - cluster.k8s.io/v1alpha1
+        - --crd-to-wait-for
+        - Machine,cluster.k8s.io/v1alpha1
         command:
         - /http-prober-bin/http-prober
         env:
@@ -92,7 +90,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3
+        image: quay.io/kubermatic/http-prober:v0.3.1-dev
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/api/pkg/resources/test/fixtures/deployment-azure-1.10.6-machine-controller-webhook.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-azure-1.10.6-machine-controller-webhook.yaml
@@ -90,7 +90,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3.1-dev
+        image: quay.io/kubermatic/http-prober:v0.3.1-dev0
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/api/pkg/resources/test/fixtures/deployment-azure-1.10.6-machine-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-azure-1.10.6-machine-controller.yaml
@@ -34,10 +34,8 @@ spec:
         - "1"
         - -command
         - '{"command":"/usr/local/bin/machine-controller","args":["-kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","-logtostderr","-v","4","-cluster-dns","169.254.20.10","-internal-listen-address","0.0.0.0:8085"]}'
-        - -wait-for-crd-kind
-        - Machine
-        - -wait-for-crd-apiversion
-        - cluster.k8s.io/v1alpha1
+        - --crd-to-wait-for
+        - Machine,cluster.k8s.io/v1alpha1
         command:
         - /http-prober-bin/http-prober
         env:
@@ -83,7 +81,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3
+        image: quay.io/kubermatic/http-prober:v0.3.1-dev
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/api/pkg/resources/test/fixtures/deployment-azure-1.10.6-machine-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-azure-1.10.6-machine-controller.yaml
@@ -81,7 +81,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3.1-dev0
+        image: quay.io/kubermatic/http-prober:v0.3.1
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/api/pkg/resources/test/fixtures/deployment-azure-1.10.6-machine-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-azure-1.10.6-machine-controller.yaml
@@ -81,7 +81,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3.1-dev
+        image: quay.io/kubermatic/http-prober:v0.3.1-dev0
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/api/pkg/resources/test/fixtures/deployment-azure-1.10.6-metrics-server.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-azure-1.10.6-metrics-server.yaml
@@ -156,7 +156,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3
+        image: quay.io/kubermatic/http-prober:v0.3.1-dev
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/api/pkg/resources/test/fixtures/deployment-azure-1.10.6-metrics-server.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-azure-1.10.6-metrics-server.yaml
@@ -156,7 +156,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3.1-dev
+        image: quay.io/kubermatic/http-prober:v0.3.1-dev0
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/api/pkg/resources/test/fixtures/deployment-azure-1.10.6-metrics-server.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-azure-1.10.6-metrics-server.yaml
@@ -156,7 +156,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3.1-dev0
+        image: quay.io/kubermatic/http-prober:v0.3.1
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/api/pkg/resources/test/fixtures/deployment-azure-1.10.6-scheduler.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-azure-1.10.6-scheduler.yaml
@@ -163,7 +163,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3.1-dev
+        image: quay.io/kubermatic/http-prober:v0.3.1-dev0
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/api/pkg/resources/test/fixtures/deployment-azure-1.10.6-scheduler.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-azure-1.10.6-scheduler.yaml
@@ -163,7 +163,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3.1-dev0
+        image: quay.io/kubermatic/http-prober:v0.3.1
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/api/pkg/resources/test/fixtures/deployment-azure-1.10.6-scheduler.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-azure-1.10.6-scheduler.yaml
@@ -163,7 +163,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3
+        image: quay.io/kubermatic/http-prober:v0.3.1-dev
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/api/pkg/resources/test/fixtures/deployment-azure-1.10.6-usercluster-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-azure-1.10.6-usercluster-controller.yaml
@@ -85,7 +85,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3.1-dev0
+        image: quay.io/kubermatic/http-prober:v0.3.1
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/api/pkg/resources/test/fixtures/deployment-azure-1.10.6-usercluster-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-azure-1.10.6-usercluster-controller.yaml
@@ -85,7 +85,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3
+        image: quay.io/kubermatic/http-prober:v0.3.1-dev
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/api/pkg/resources/test/fixtures/deployment-azure-1.10.6-usercluster-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-azure-1.10.6-usercluster-controller.yaml
@@ -85,7 +85,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3.1-dev
+        image: quay.io/kubermatic/http-prober:v0.3.1-dev0
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/api/pkg/resources/test/fixtures/deployment-azure-1.11.0-controller-manager.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-azure-1.11.0-controller-manager.yaml
@@ -171,7 +171,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3.1-dev0
+        image: quay.io/kubermatic/http-prober:v0.3.1
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/api/pkg/resources/test/fixtures/deployment-azure-1.11.0-controller-manager.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-azure-1.11.0-controller-manager.yaml
@@ -171,7 +171,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3
+        image: quay.io/kubermatic/http-prober:v0.3.1-dev
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/api/pkg/resources/test/fixtures/deployment-azure-1.11.0-controller-manager.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-azure-1.11.0-controller-manager.yaml
@@ -171,7 +171,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3.1-dev
+        image: quay.io/kubermatic/http-prober:v0.3.1-dev0
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/api/pkg/resources/test/fixtures/deployment-azure-1.11.0-kube-state-metrics.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-azure-1.11.0-kube-state-metrics.yaml
@@ -72,7 +72,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3.1-dev0
+        image: quay.io/kubermatic/http-prober:v0.3.1
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/api/pkg/resources/test/fixtures/deployment-azure-1.11.0-kube-state-metrics.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-azure-1.11.0-kube-state-metrics.yaml
@@ -72,7 +72,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3
+        image: quay.io/kubermatic/http-prober:v0.3.1-dev
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/api/pkg/resources/test/fixtures/deployment-azure-1.11.0-kube-state-metrics.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-azure-1.11.0-kube-state-metrics.yaml
@@ -72,7 +72,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3.1-dev
+        image: quay.io/kubermatic/http-prober:v0.3.1-dev0
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/api/pkg/resources/test/fixtures/deployment-azure-1.11.0-machine-controller-webhook.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-azure-1.11.0-machine-controller-webhook.yaml
@@ -90,7 +90,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3.1-dev0
+        image: quay.io/kubermatic/http-prober:v0.3.1
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/api/pkg/resources/test/fixtures/deployment-azure-1.11.0-machine-controller-webhook.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-azure-1.11.0-machine-controller-webhook.yaml
@@ -31,10 +31,8 @@ spec:
         - "1"
         - -command
         - '{"command":"/usr/local/bin/webhook","args":["-kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","-logtostderr","-v","4","-listen-address","0.0.0.0:9876"]}'
-        - -wait-for-crd-kind
-        - Machine
-        - -wait-for-crd-apiversion
-        - cluster.k8s.io/v1alpha1
+        - --crd-to-wait-for
+        - Machine,cluster.k8s.io/v1alpha1
         command:
         - /http-prober-bin/http-prober
         env:
@@ -92,7 +90,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3
+        image: quay.io/kubermatic/http-prober:v0.3.1-dev
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/api/pkg/resources/test/fixtures/deployment-azure-1.11.0-machine-controller-webhook.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-azure-1.11.0-machine-controller-webhook.yaml
@@ -90,7 +90,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3.1-dev
+        image: quay.io/kubermatic/http-prober:v0.3.1-dev0
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/api/pkg/resources/test/fixtures/deployment-azure-1.11.0-machine-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-azure-1.11.0-machine-controller.yaml
@@ -34,10 +34,8 @@ spec:
         - "1"
         - -command
         - '{"command":"/usr/local/bin/machine-controller","args":["-kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","-logtostderr","-v","4","-cluster-dns","169.254.20.10","-internal-listen-address","0.0.0.0:8085"]}'
-        - -wait-for-crd-kind
-        - Machine
-        - -wait-for-crd-apiversion
-        - cluster.k8s.io/v1alpha1
+        - --crd-to-wait-for
+        - Machine,cluster.k8s.io/v1alpha1
         command:
         - /http-prober-bin/http-prober
         env:
@@ -83,7 +81,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3
+        image: quay.io/kubermatic/http-prober:v0.3.1-dev
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/api/pkg/resources/test/fixtures/deployment-azure-1.11.0-machine-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-azure-1.11.0-machine-controller.yaml
@@ -81,7 +81,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3.1-dev0
+        image: quay.io/kubermatic/http-prober:v0.3.1
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/api/pkg/resources/test/fixtures/deployment-azure-1.11.0-machine-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-azure-1.11.0-machine-controller.yaml
@@ -81,7 +81,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3.1-dev
+        image: quay.io/kubermatic/http-prober:v0.3.1-dev0
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/api/pkg/resources/test/fixtures/deployment-azure-1.11.0-metrics-server.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-azure-1.11.0-metrics-server.yaml
@@ -156,7 +156,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3
+        image: quay.io/kubermatic/http-prober:v0.3.1-dev
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/api/pkg/resources/test/fixtures/deployment-azure-1.11.0-metrics-server.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-azure-1.11.0-metrics-server.yaml
@@ -156,7 +156,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3.1-dev
+        image: quay.io/kubermatic/http-prober:v0.3.1-dev0
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/api/pkg/resources/test/fixtures/deployment-azure-1.11.0-metrics-server.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-azure-1.11.0-metrics-server.yaml
@@ -156,7 +156,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3.1-dev0
+        image: quay.io/kubermatic/http-prober:v0.3.1
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/api/pkg/resources/test/fixtures/deployment-azure-1.11.0-scheduler.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-azure-1.11.0-scheduler.yaml
@@ -163,7 +163,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3.1-dev
+        image: quay.io/kubermatic/http-prober:v0.3.1-dev0
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/api/pkg/resources/test/fixtures/deployment-azure-1.11.0-scheduler.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-azure-1.11.0-scheduler.yaml
@@ -163,7 +163,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3.1-dev0
+        image: quay.io/kubermatic/http-prober:v0.3.1
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/api/pkg/resources/test/fixtures/deployment-azure-1.11.0-scheduler.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-azure-1.11.0-scheduler.yaml
@@ -163,7 +163,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3
+        image: quay.io/kubermatic/http-prober:v0.3.1-dev
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/api/pkg/resources/test/fixtures/deployment-azure-1.11.0-usercluster-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-azure-1.11.0-usercluster-controller.yaml
@@ -85,7 +85,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3.1-dev0
+        image: quay.io/kubermatic/http-prober:v0.3.1
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/api/pkg/resources/test/fixtures/deployment-azure-1.11.0-usercluster-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-azure-1.11.0-usercluster-controller.yaml
@@ -85,7 +85,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3
+        image: quay.io/kubermatic/http-prober:v0.3.1-dev
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/api/pkg/resources/test/fixtures/deployment-azure-1.11.0-usercluster-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-azure-1.11.0-usercluster-controller.yaml
@@ -85,7 +85,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3.1-dev
+        image: quay.io/kubermatic/http-prober:v0.3.1-dev0
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/api/pkg/resources/test/fixtures/deployment-azure-1.11.1-controller-manager.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-azure-1.11.1-controller-manager.yaml
@@ -171,7 +171,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3.1-dev0
+        image: quay.io/kubermatic/http-prober:v0.3.1
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/api/pkg/resources/test/fixtures/deployment-azure-1.11.1-controller-manager.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-azure-1.11.1-controller-manager.yaml
@@ -171,7 +171,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3
+        image: quay.io/kubermatic/http-prober:v0.3.1-dev
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/api/pkg/resources/test/fixtures/deployment-azure-1.11.1-controller-manager.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-azure-1.11.1-controller-manager.yaml
@@ -171,7 +171,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3.1-dev
+        image: quay.io/kubermatic/http-prober:v0.3.1-dev0
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/api/pkg/resources/test/fixtures/deployment-azure-1.11.1-kube-state-metrics.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-azure-1.11.1-kube-state-metrics.yaml
@@ -72,7 +72,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3.1-dev0
+        image: quay.io/kubermatic/http-prober:v0.3.1
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/api/pkg/resources/test/fixtures/deployment-azure-1.11.1-kube-state-metrics.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-azure-1.11.1-kube-state-metrics.yaml
@@ -72,7 +72,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3
+        image: quay.io/kubermatic/http-prober:v0.3.1-dev
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/api/pkg/resources/test/fixtures/deployment-azure-1.11.1-kube-state-metrics.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-azure-1.11.1-kube-state-metrics.yaml
@@ -72,7 +72,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3.1-dev
+        image: quay.io/kubermatic/http-prober:v0.3.1-dev0
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/api/pkg/resources/test/fixtures/deployment-azure-1.11.1-machine-controller-webhook.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-azure-1.11.1-machine-controller-webhook.yaml
@@ -90,7 +90,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3.1-dev0
+        image: quay.io/kubermatic/http-prober:v0.3.1
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/api/pkg/resources/test/fixtures/deployment-azure-1.11.1-machine-controller-webhook.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-azure-1.11.1-machine-controller-webhook.yaml
@@ -31,10 +31,8 @@ spec:
         - "1"
         - -command
         - '{"command":"/usr/local/bin/webhook","args":["-kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","-logtostderr","-v","4","-listen-address","0.0.0.0:9876"]}'
-        - -wait-for-crd-kind
-        - Machine
-        - -wait-for-crd-apiversion
-        - cluster.k8s.io/v1alpha1
+        - --crd-to-wait-for
+        - Machine,cluster.k8s.io/v1alpha1
         command:
         - /http-prober-bin/http-prober
         env:
@@ -92,7 +90,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3
+        image: quay.io/kubermatic/http-prober:v0.3.1-dev
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/api/pkg/resources/test/fixtures/deployment-azure-1.11.1-machine-controller-webhook.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-azure-1.11.1-machine-controller-webhook.yaml
@@ -90,7 +90,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3.1-dev
+        image: quay.io/kubermatic/http-prober:v0.3.1-dev0
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/api/pkg/resources/test/fixtures/deployment-azure-1.11.1-machine-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-azure-1.11.1-machine-controller.yaml
@@ -34,10 +34,8 @@ spec:
         - "1"
         - -command
         - '{"command":"/usr/local/bin/machine-controller","args":["-kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","-logtostderr","-v","4","-cluster-dns","169.254.20.10","-internal-listen-address","0.0.0.0:8085"]}'
-        - -wait-for-crd-kind
-        - Machine
-        - -wait-for-crd-apiversion
-        - cluster.k8s.io/v1alpha1
+        - --crd-to-wait-for
+        - Machine,cluster.k8s.io/v1alpha1
         command:
         - /http-prober-bin/http-prober
         env:
@@ -83,7 +81,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3
+        image: quay.io/kubermatic/http-prober:v0.3.1-dev
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/api/pkg/resources/test/fixtures/deployment-azure-1.11.1-machine-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-azure-1.11.1-machine-controller.yaml
@@ -81,7 +81,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3.1-dev0
+        image: quay.io/kubermatic/http-prober:v0.3.1
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/api/pkg/resources/test/fixtures/deployment-azure-1.11.1-machine-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-azure-1.11.1-machine-controller.yaml
@@ -81,7 +81,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3.1-dev
+        image: quay.io/kubermatic/http-prober:v0.3.1-dev0
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/api/pkg/resources/test/fixtures/deployment-azure-1.11.1-metrics-server.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-azure-1.11.1-metrics-server.yaml
@@ -156,7 +156,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3
+        image: quay.io/kubermatic/http-prober:v0.3.1-dev
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/api/pkg/resources/test/fixtures/deployment-azure-1.11.1-metrics-server.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-azure-1.11.1-metrics-server.yaml
@@ -156,7 +156,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3.1-dev
+        image: quay.io/kubermatic/http-prober:v0.3.1-dev0
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/api/pkg/resources/test/fixtures/deployment-azure-1.11.1-metrics-server.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-azure-1.11.1-metrics-server.yaml
@@ -156,7 +156,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3.1-dev0
+        image: quay.io/kubermatic/http-prober:v0.3.1
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/api/pkg/resources/test/fixtures/deployment-azure-1.11.1-scheduler.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-azure-1.11.1-scheduler.yaml
@@ -163,7 +163,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3.1-dev
+        image: quay.io/kubermatic/http-prober:v0.3.1-dev0
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/api/pkg/resources/test/fixtures/deployment-azure-1.11.1-scheduler.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-azure-1.11.1-scheduler.yaml
@@ -163,7 +163,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3.1-dev0
+        image: quay.io/kubermatic/http-prober:v0.3.1
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/api/pkg/resources/test/fixtures/deployment-azure-1.11.1-scheduler.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-azure-1.11.1-scheduler.yaml
@@ -163,7 +163,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3
+        image: quay.io/kubermatic/http-prober:v0.3.1-dev
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/api/pkg/resources/test/fixtures/deployment-azure-1.11.1-usercluster-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-azure-1.11.1-usercluster-controller.yaml
@@ -85,7 +85,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3.1-dev0
+        image: quay.io/kubermatic/http-prober:v0.3.1
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/api/pkg/resources/test/fixtures/deployment-azure-1.11.1-usercluster-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-azure-1.11.1-usercluster-controller.yaml
@@ -85,7 +85,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3
+        image: quay.io/kubermatic/http-prober:v0.3.1-dev
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/api/pkg/resources/test/fixtures/deployment-azure-1.11.1-usercluster-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-azure-1.11.1-usercluster-controller.yaml
@@ -85,7 +85,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3.1-dev
+        image: quay.io/kubermatic/http-prober:v0.3.1-dev0
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/api/pkg/resources/test/fixtures/deployment-azure-1.12.0-controller-manager.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-azure-1.12.0-controller-manager.yaml
@@ -171,7 +171,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3.1-dev0
+        image: quay.io/kubermatic/http-prober:v0.3.1
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/api/pkg/resources/test/fixtures/deployment-azure-1.12.0-controller-manager.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-azure-1.12.0-controller-manager.yaml
@@ -171,7 +171,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3
+        image: quay.io/kubermatic/http-prober:v0.3.1-dev
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/api/pkg/resources/test/fixtures/deployment-azure-1.12.0-controller-manager.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-azure-1.12.0-controller-manager.yaml
@@ -171,7 +171,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3.1-dev
+        image: quay.io/kubermatic/http-prober:v0.3.1-dev0
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/api/pkg/resources/test/fixtures/deployment-azure-1.12.0-kube-state-metrics.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-azure-1.12.0-kube-state-metrics.yaml
@@ -72,7 +72,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3.1-dev0
+        image: quay.io/kubermatic/http-prober:v0.3.1
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/api/pkg/resources/test/fixtures/deployment-azure-1.12.0-kube-state-metrics.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-azure-1.12.0-kube-state-metrics.yaml
@@ -72,7 +72,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3
+        image: quay.io/kubermatic/http-prober:v0.3.1-dev
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/api/pkg/resources/test/fixtures/deployment-azure-1.12.0-kube-state-metrics.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-azure-1.12.0-kube-state-metrics.yaml
@@ -72,7 +72,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3.1-dev
+        image: quay.io/kubermatic/http-prober:v0.3.1-dev0
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/api/pkg/resources/test/fixtures/deployment-azure-1.12.0-machine-controller-webhook.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-azure-1.12.0-machine-controller-webhook.yaml
@@ -90,7 +90,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3.1-dev0
+        image: quay.io/kubermatic/http-prober:v0.3.1
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/api/pkg/resources/test/fixtures/deployment-azure-1.12.0-machine-controller-webhook.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-azure-1.12.0-machine-controller-webhook.yaml
@@ -31,10 +31,8 @@ spec:
         - "1"
         - -command
         - '{"command":"/usr/local/bin/webhook","args":["-kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","-logtostderr","-v","4","-listen-address","0.0.0.0:9876"]}'
-        - -wait-for-crd-kind
-        - Machine
-        - -wait-for-crd-apiversion
-        - cluster.k8s.io/v1alpha1
+        - --crd-to-wait-for
+        - Machine,cluster.k8s.io/v1alpha1
         command:
         - /http-prober-bin/http-prober
         env:
@@ -92,7 +90,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3
+        image: quay.io/kubermatic/http-prober:v0.3.1-dev
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/api/pkg/resources/test/fixtures/deployment-azure-1.12.0-machine-controller-webhook.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-azure-1.12.0-machine-controller-webhook.yaml
@@ -90,7 +90,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3.1-dev
+        image: quay.io/kubermatic/http-prober:v0.3.1-dev0
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/api/pkg/resources/test/fixtures/deployment-azure-1.12.0-machine-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-azure-1.12.0-machine-controller.yaml
@@ -34,10 +34,8 @@ spec:
         - "1"
         - -command
         - '{"command":"/usr/local/bin/machine-controller","args":["-kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","-logtostderr","-v","4","-cluster-dns","169.254.20.10","-internal-listen-address","0.0.0.0:8085"]}'
-        - -wait-for-crd-kind
-        - Machine
-        - -wait-for-crd-apiversion
-        - cluster.k8s.io/v1alpha1
+        - --crd-to-wait-for
+        - Machine,cluster.k8s.io/v1alpha1
         command:
         - /http-prober-bin/http-prober
         env:
@@ -83,7 +81,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3
+        image: quay.io/kubermatic/http-prober:v0.3.1-dev
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/api/pkg/resources/test/fixtures/deployment-azure-1.12.0-machine-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-azure-1.12.0-machine-controller.yaml
@@ -81,7 +81,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3.1-dev0
+        image: quay.io/kubermatic/http-prober:v0.3.1
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/api/pkg/resources/test/fixtures/deployment-azure-1.12.0-machine-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-azure-1.12.0-machine-controller.yaml
@@ -81,7 +81,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3.1-dev
+        image: quay.io/kubermatic/http-prober:v0.3.1-dev0
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/api/pkg/resources/test/fixtures/deployment-azure-1.12.0-metrics-server.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-azure-1.12.0-metrics-server.yaml
@@ -156,7 +156,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3
+        image: quay.io/kubermatic/http-prober:v0.3.1-dev
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/api/pkg/resources/test/fixtures/deployment-azure-1.12.0-metrics-server.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-azure-1.12.0-metrics-server.yaml
@@ -156,7 +156,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3.1-dev
+        image: quay.io/kubermatic/http-prober:v0.3.1-dev0
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/api/pkg/resources/test/fixtures/deployment-azure-1.12.0-metrics-server.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-azure-1.12.0-metrics-server.yaml
@@ -156,7 +156,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3.1-dev0
+        image: quay.io/kubermatic/http-prober:v0.3.1
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/api/pkg/resources/test/fixtures/deployment-azure-1.12.0-scheduler.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-azure-1.12.0-scheduler.yaml
@@ -163,7 +163,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3.1-dev
+        image: quay.io/kubermatic/http-prober:v0.3.1-dev0
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/api/pkg/resources/test/fixtures/deployment-azure-1.12.0-scheduler.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-azure-1.12.0-scheduler.yaml
@@ -163,7 +163,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3.1-dev0
+        image: quay.io/kubermatic/http-prober:v0.3.1
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/api/pkg/resources/test/fixtures/deployment-azure-1.12.0-scheduler.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-azure-1.12.0-scheduler.yaml
@@ -163,7 +163,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3
+        image: quay.io/kubermatic/http-prober:v0.3.1-dev
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/api/pkg/resources/test/fixtures/deployment-azure-1.12.0-usercluster-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-azure-1.12.0-usercluster-controller.yaml
@@ -85,7 +85,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3.1-dev0
+        image: quay.io/kubermatic/http-prober:v0.3.1
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/api/pkg/resources/test/fixtures/deployment-azure-1.12.0-usercluster-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-azure-1.12.0-usercluster-controller.yaml
@@ -85,7 +85,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3
+        image: quay.io/kubermatic/http-prober:v0.3.1-dev
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/api/pkg/resources/test/fixtures/deployment-azure-1.12.0-usercluster-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-azure-1.12.0-usercluster-controller.yaml
@@ -85,7 +85,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3.1-dev
+        image: quay.io/kubermatic/http-prober:v0.3.1-dev0
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/api/pkg/resources/test/fixtures/deployment-azure-1.13.0-controller-manager.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-azure-1.13.0-controller-manager.yaml
@@ -171,7 +171,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3.1-dev0
+        image: quay.io/kubermatic/http-prober:v0.3.1
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/api/pkg/resources/test/fixtures/deployment-azure-1.13.0-controller-manager.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-azure-1.13.0-controller-manager.yaml
@@ -171,7 +171,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3
+        image: quay.io/kubermatic/http-prober:v0.3.1-dev
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/api/pkg/resources/test/fixtures/deployment-azure-1.13.0-controller-manager.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-azure-1.13.0-controller-manager.yaml
@@ -171,7 +171,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3.1-dev
+        image: quay.io/kubermatic/http-prober:v0.3.1-dev0
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/api/pkg/resources/test/fixtures/deployment-azure-1.13.0-kube-state-metrics.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-azure-1.13.0-kube-state-metrics.yaml
@@ -72,7 +72,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3.1-dev0
+        image: quay.io/kubermatic/http-prober:v0.3.1
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/api/pkg/resources/test/fixtures/deployment-azure-1.13.0-kube-state-metrics.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-azure-1.13.0-kube-state-metrics.yaml
@@ -72,7 +72,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3
+        image: quay.io/kubermatic/http-prober:v0.3.1-dev
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/api/pkg/resources/test/fixtures/deployment-azure-1.13.0-kube-state-metrics.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-azure-1.13.0-kube-state-metrics.yaml
@@ -72,7 +72,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3.1-dev
+        image: quay.io/kubermatic/http-prober:v0.3.1-dev0
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/api/pkg/resources/test/fixtures/deployment-azure-1.13.0-machine-controller-webhook.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-azure-1.13.0-machine-controller-webhook.yaml
@@ -90,7 +90,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3.1-dev0
+        image: quay.io/kubermatic/http-prober:v0.3.1
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/api/pkg/resources/test/fixtures/deployment-azure-1.13.0-machine-controller-webhook.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-azure-1.13.0-machine-controller-webhook.yaml
@@ -31,10 +31,8 @@ spec:
         - "1"
         - -command
         - '{"command":"/usr/local/bin/webhook","args":["-kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","-logtostderr","-v","4","-listen-address","0.0.0.0:9876"]}'
-        - -wait-for-crd-kind
-        - Machine
-        - -wait-for-crd-apiversion
-        - cluster.k8s.io/v1alpha1
+        - --crd-to-wait-for
+        - Machine,cluster.k8s.io/v1alpha1
         command:
         - /http-prober-bin/http-prober
         env:
@@ -92,7 +90,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3
+        image: quay.io/kubermatic/http-prober:v0.3.1-dev
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/api/pkg/resources/test/fixtures/deployment-azure-1.13.0-machine-controller-webhook.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-azure-1.13.0-machine-controller-webhook.yaml
@@ -90,7 +90,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3.1-dev
+        image: quay.io/kubermatic/http-prober:v0.3.1-dev0
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/api/pkg/resources/test/fixtures/deployment-azure-1.13.0-machine-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-azure-1.13.0-machine-controller.yaml
@@ -34,10 +34,8 @@ spec:
         - "1"
         - -command
         - '{"command":"/usr/local/bin/machine-controller","args":["-kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","-logtostderr","-v","4","-cluster-dns","169.254.20.10","-internal-listen-address","0.0.0.0:8085"]}'
-        - -wait-for-crd-kind
-        - Machine
-        - -wait-for-crd-apiversion
-        - cluster.k8s.io/v1alpha1
+        - --crd-to-wait-for
+        - Machine,cluster.k8s.io/v1alpha1
         command:
         - /http-prober-bin/http-prober
         env:
@@ -83,7 +81,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3
+        image: quay.io/kubermatic/http-prober:v0.3.1-dev
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/api/pkg/resources/test/fixtures/deployment-azure-1.13.0-machine-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-azure-1.13.0-machine-controller.yaml
@@ -81,7 +81,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3.1-dev0
+        image: quay.io/kubermatic/http-prober:v0.3.1
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/api/pkg/resources/test/fixtures/deployment-azure-1.13.0-machine-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-azure-1.13.0-machine-controller.yaml
@@ -81,7 +81,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3.1-dev
+        image: quay.io/kubermatic/http-prober:v0.3.1-dev0
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/api/pkg/resources/test/fixtures/deployment-azure-1.13.0-metrics-server.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-azure-1.13.0-metrics-server.yaml
@@ -156,7 +156,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3
+        image: quay.io/kubermatic/http-prober:v0.3.1-dev
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/api/pkg/resources/test/fixtures/deployment-azure-1.13.0-metrics-server.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-azure-1.13.0-metrics-server.yaml
@@ -156,7 +156,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3.1-dev
+        image: quay.io/kubermatic/http-prober:v0.3.1-dev0
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/api/pkg/resources/test/fixtures/deployment-azure-1.13.0-metrics-server.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-azure-1.13.0-metrics-server.yaml
@@ -156,7 +156,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3.1-dev0
+        image: quay.io/kubermatic/http-prober:v0.3.1
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/api/pkg/resources/test/fixtures/deployment-azure-1.13.0-scheduler.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-azure-1.13.0-scheduler.yaml
@@ -163,7 +163,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3.1-dev
+        image: quay.io/kubermatic/http-prober:v0.3.1-dev0
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/api/pkg/resources/test/fixtures/deployment-azure-1.13.0-scheduler.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-azure-1.13.0-scheduler.yaml
@@ -163,7 +163,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3.1-dev0
+        image: quay.io/kubermatic/http-prober:v0.3.1
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/api/pkg/resources/test/fixtures/deployment-azure-1.13.0-scheduler.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-azure-1.13.0-scheduler.yaml
@@ -163,7 +163,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3
+        image: quay.io/kubermatic/http-prober:v0.3.1-dev
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/api/pkg/resources/test/fixtures/deployment-azure-1.13.0-usercluster-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-azure-1.13.0-usercluster-controller.yaml
@@ -85,7 +85,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3.1-dev0
+        image: quay.io/kubermatic/http-prober:v0.3.1
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/api/pkg/resources/test/fixtures/deployment-azure-1.13.0-usercluster-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-azure-1.13.0-usercluster-controller.yaml
@@ -85,7 +85,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3
+        image: quay.io/kubermatic/http-prober:v0.3.1-dev
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/api/pkg/resources/test/fixtures/deployment-azure-1.13.0-usercluster-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-azure-1.13.0-usercluster-controller.yaml
@@ -85,7 +85,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3.1-dev
+        image: quay.io/kubermatic/http-prober:v0.3.1-dev0
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/api/pkg/resources/test/fixtures/deployment-bringyourown-1.10.0-controller-manager.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-bringyourown-1.10.0-controller-manager.yaml
@@ -171,7 +171,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3.1-dev0
+        image: quay.io/kubermatic/http-prober:v0.3.1
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/api/pkg/resources/test/fixtures/deployment-bringyourown-1.10.0-controller-manager.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-bringyourown-1.10.0-controller-manager.yaml
@@ -171,7 +171,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3
+        image: quay.io/kubermatic/http-prober:v0.3.1-dev
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/api/pkg/resources/test/fixtures/deployment-bringyourown-1.10.0-controller-manager.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-bringyourown-1.10.0-controller-manager.yaml
@@ -171,7 +171,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3.1-dev
+        image: quay.io/kubermatic/http-prober:v0.3.1-dev0
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/api/pkg/resources/test/fixtures/deployment-bringyourown-1.10.0-kube-state-metrics.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-bringyourown-1.10.0-kube-state-metrics.yaml
@@ -72,7 +72,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3.1-dev0
+        image: quay.io/kubermatic/http-prober:v0.3.1
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/api/pkg/resources/test/fixtures/deployment-bringyourown-1.10.0-kube-state-metrics.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-bringyourown-1.10.0-kube-state-metrics.yaml
@@ -72,7 +72,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3
+        image: quay.io/kubermatic/http-prober:v0.3.1-dev
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/api/pkg/resources/test/fixtures/deployment-bringyourown-1.10.0-kube-state-metrics.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-bringyourown-1.10.0-kube-state-metrics.yaml
@@ -72,7 +72,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3.1-dev
+        image: quay.io/kubermatic/http-prober:v0.3.1-dev0
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/api/pkg/resources/test/fixtures/deployment-bringyourown-1.10.0-machine-controller-webhook.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-bringyourown-1.10.0-machine-controller-webhook.yaml
@@ -31,10 +31,8 @@ spec:
         - "1"
         - -command
         - '{"command":"/usr/local/bin/webhook","args":["-kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","-logtostderr","-v","4","-listen-address","0.0.0.0:9876"]}'
-        - -wait-for-crd-kind
-        - Machine
-        - -wait-for-crd-apiversion
-        - cluster.k8s.io/v1alpha1
+        - --crd-to-wait-for
+        - Machine,cluster.k8s.io/v1alpha1
         command:
         - /http-prober-bin/http-prober
         env:
@@ -84,7 +82,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3
+        image: quay.io/kubermatic/http-prober:v0.3.1-dev
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/api/pkg/resources/test/fixtures/deployment-bringyourown-1.10.0-machine-controller-webhook.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-bringyourown-1.10.0-machine-controller-webhook.yaml
@@ -82,7 +82,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3.1-dev
+        image: quay.io/kubermatic/http-prober:v0.3.1-dev0
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/api/pkg/resources/test/fixtures/deployment-bringyourown-1.10.0-machine-controller-webhook.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-bringyourown-1.10.0-machine-controller-webhook.yaml
@@ -82,7 +82,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3.1-dev0
+        image: quay.io/kubermatic/http-prober:v0.3.1
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/api/pkg/resources/test/fixtures/deployment-bringyourown-1.10.0-machine-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-bringyourown-1.10.0-machine-controller.yaml
@@ -73,7 +73,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3.1-dev0
+        image: quay.io/kubermatic/http-prober:v0.3.1
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/api/pkg/resources/test/fixtures/deployment-bringyourown-1.10.0-machine-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-bringyourown-1.10.0-machine-controller.yaml
@@ -34,10 +34,8 @@ spec:
         - "1"
         - -command
         - '{"command":"/usr/local/bin/machine-controller","args":["-kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","-logtostderr","-v","4","-cluster-dns","169.254.20.10","-internal-listen-address","0.0.0.0:8085"]}'
-        - -wait-for-crd-kind
-        - Machine
-        - -wait-for-crd-apiversion
-        - cluster.k8s.io/v1alpha1
+        - --crd-to-wait-for
+        - Machine,cluster.k8s.io/v1alpha1
         command:
         - /http-prober-bin/http-prober
         env:
@@ -75,7 +73,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3
+        image: quay.io/kubermatic/http-prober:v0.3.1-dev
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/api/pkg/resources/test/fixtures/deployment-bringyourown-1.10.0-machine-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-bringyourown-1.10.0-machine-controller.yaml
@@ -73,7 +73,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3.1-dev
+        image: quay.io/kubermatic/http-prober:v0.3.1-dev0
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/api/pkg/resources/test/fixtures/deployment-bringyourown-1.10.0-metrics-server.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-bringyourown-1.10.0-metrics-server.yaml
@@ -156,7 +156,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3
+        image: quay.io/kubermatic/http-prober:v0.3.1-dev
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/api/pkg/resources/test/fixtures/deployment-bringyourown-1.10.0-metrics-server.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-bringyourown-1.10.0-metrics-server.yaml
@@ -156,7 +156,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3.1-dev
+        image: quay.io/kubermatic/http-prober:v0.3.1-dev0
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/api/pkg/resources/test/fixtures/deployment-bringyourown-1.10.0-metrics-server.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-bringyourown-1.10.0-metrics-server.yaml
@@ -156,7 +156,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3.1-dev0
+        image: quay.io/kubermatic/http-prober:v0.3.1
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/api/pkg/resources/test/fixtures/deployment-bringyourown-1.10.0-scheduler.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-bringyourown-1.10.0-scheduler.yaml
@@ -163,7 +163,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3.1-dev
+        image: quay.io/kubermatic/http-prober:v0.3.1-dev0
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/api/pkg/resources/test/fixtures/deployment-bringyourown-1.10.0-scheduler.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-bringyourown-1.10.0-scheduler.yaml
@@ -163,7 +163,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3.1-dev0
+        image: quay.io/kubermatic/http-prober:v0.3.1
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/api/pkg/resources/test/fixtures/deployment-bringyourown-1.10.0-scheduler.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-bringyourown-1.10.0-scheduler.yaml
@@ -163,7 +163,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3
+        image: quay.io/kubermatic/http-prober:v0.3.1-dev
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/api/pkg/resources/test/fixtures/deployment-bringyourown-1.10.0-usercluster-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-bringyourown-1.10.0-usercluster-controller.yaml
@@ -85,7 +85,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3.1-dev0
+        image: quay.io/kubermatic/http-prober:v0.3.1
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/api/pkg/resources/test/fixtures/deployment-bringyourown-1.10.0-usercluster-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-bringyourown-1.10.0-usercluster-controller.yaml
@@ -85,7 +85,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3
+        image: quay.io/kubermatic/http-prober:v0.3.1-dev
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/api/pkg/resources/test/fixtures/deployment-bringyourown-1.10.0-usercluster-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-bringyourown-1.10.0-usercluster-controller.yaml
@@ -85,7 +85,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3.1-dev
+        image: quay.io/kubermatic/http-prober:v0.3.1-dev0
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/api/pkg/resources/test/fixtures/deployment-bringyourown-1.10.6-controller-manager.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-bringyourown-1.10.6-controller-manager.yaml
@@ -171,7 +171,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3.1-dev0
+        image: quay.io/kubermatic/http-prober:v0.3.1
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/api/pkg/resources/test/fixtures/deployment-bringyourown-1.10.6-controller-manager.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-bringyourown-1.10.6-controller-manager.yaml
@@ -171,7 +171,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3
+        image: quay.io/kubermatic/http-prober:v0.3.1-dev
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/api/pkg/resources/test/fixtures/deployment-bringyourown-1.10.6-controller-manager.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-bringyourown-1.10.6-controller-manager.yaml
@@ -171,7 +171,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3.1-dev
+        image: quay.io/kubermatic/http-prober:v0.3.1-dev0
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/api/pkg/resources/test/fixtures/deployment-bringyourown-1.10.6-kube-state-metrics.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-bringyourown-1.10.6-kube-state-metrics.yaml
@@ -72,7 +72,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3.1-dev0
+        image: quay.io/kubermatic/http-prober:v0.3.1
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/api/pkg/resources/test/fixtures/deployment-bringyourown-1.10.6-kube-state-metrics.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-bringyourown-1.10.6-kube-state-metrics.yaml
@@ -72,7 +72,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3
+        image: quay.io/kubermatic/http-prober:v0.3.1-dev
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/api/pkg/resources/test/fixtures/deployment-bringyourown-1.10.6-kube-state-metrics.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-bringyourown-1.10.6-kube-state-metrics.yaml
@@ -72,7 +72,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3.1-dev
+        image: quay.io/kubermatic/http-prober:v0.3.1-dev0
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/api/pkg/resources/test/fixtures/deployment-bringyourown-1.10.6-machine-controller-webhook.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-bringyourown-1.10.6-machine-controller-webhook.yaml
@@ -31,10 +31,8 @@ spec:
         - "1"
         - -command
         - '{"command":"/usr/local/bin/webhook","args":["-kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","-logtostderr","-v","4","-listen-address","0.0.0.0:9876"]}'
-        - -wait-for-crd-kind
-        - Machine
-        - -wait-for-crd-apiversion
-        - cluster.k8s.io/v1alpha1
+        - --crd-to-wait-for
+        - Machine,cluster.k8s.io/v1alpha1
         command:
         - /http-prober-bin/http-prober
         env:
@@ -84,7 +82,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3
+        image: quay.io/kubermatic/http-prober:v0.3.1-dev
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/api/pkg/resources/test/fixtures/deployment-bringyourown-1.10.6-machine-controller-webhook.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-bringyourown-1.10.6-machine-controller-webhook.yaml
@@ -82,7 +82,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3.1-dev
+        image: quay.io/kubermatic/http-prober:v0.3.1-dev0
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/api/pkg/resources/test/fixtures/deployment-bringyourown-1.10.6-machine-controller-webhook.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-bringyourown-1.10.6-machine-controller-webhook.yaml
@@ -82,7 +82,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3.1-dev0
+        image: quay.io/kubermatic/http-prober:v0.3.1
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/api/pkg/resources/test/fixtures/deployment-bringyourown-1.10.6-machine-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-bringyourown-1.10.6-machine-controller.yaml
@@ -73,7 +73,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3.1-dev0
+        image: quay.io/kubermatic/http-prober:v0.3.1
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/api/pkg/resources/test/fixtures/deployment-bringyourown-1.10.6-machine-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-bringyourown-1.10.6-machine-controller.yaml
@@ -34,10 +34,8 @@ spec:
         - "1"
         - -command
         - '{"command":"/usr/local/bin/machine-controller","args":["-kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","-logtostderr","-v","4","-cluster-dns","169.254.20.10","-internal-listen-address","0.0.0.0:8085"]}'
-        - -wait-for-crd-kind
-        - Machine
-        - -wait-for-crd-apiversion
-        - cluster.k8s.io/v1alpha1
+        - --crd-to-wait-for
+        - Machine,cluster.k8s.io/v1alpha1
         command:
         - /http-prober-bin/http-prober
         env:
@@ -75,7 +73,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3
+        image: quay.io/kubermatic/http-prober:v0.3.1-dev
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/api/pkg/resources/test/fixtures/deployment-bringyourown-1.10.6-machine-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-bringyourown-1.10.6-machine-controller.yaml
@@ -73,7 +73,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3.1-dev
+        image: quay.io/kubermatic/http-prober:v0.3.1-dev0
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/api/pkg/resources/test/fixtures/deployment-bringyourown-1.10.6-metrics-server.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-bringyourown-1.10.6-metrics-server.yaml
@@ -156,7 +156,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3
+        image: quay.io/kubermatic/http-prober:v0.3.1-dev
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/api/pkg/resources/test/fixtures/deployment-bringyourown-1.10.6-metrics-server.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-bringyourown-1.10.6-metrics-server.yaml
@@ -156,7 +156,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3.1-dev
+        image: quay.io/kubermatic/http-prober:v0.3.1-dev0
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/api/pkg/resources/test/fixtures/deployment-bringyourown-1.10.6-metrics-server.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-bringyourown-1.10.6-metrics-server.yaml
@@ -156,7 +156,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3.1-dev0
+        image: quay.io/kubermatic/http-prober:v0.3.1
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/api/pkg/resources/test/fixtures/deployment-bringyourown-1.10.6-scheduler.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-bringyourown-1.10.6-scheduler.yaml
@@ -163,7 +163,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3.1-dev
+        image: quay.io/kubermatic/http-prober:v0.3.1-dev0
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/api/pkg/resources/test/fixtures/deployment-bringyourown-1.10.6-scheduler.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-bringyourown-1.10.6-scheduler.yaml
@@ -163,7 +163,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3.1-dev0
+        image: quay.io/kubermatic/http-prober:v0.3.1
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/api/pkg/resources/test/fixtures/deployment-bringyourown-1.10.6-scheduler.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-bringyourown-1.10.6-scheduler.yaml
@@ -163,7 +163,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3
+        image: quay.io/kubermatic/http-prober:v0.3.1-dev
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/api/pkg/resources/test/fixtures/deployment-bringyourown-1.10.6-usercluster-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-bringyourown-1.10.6-usercluster-controller.yaml
@@ -85,7 +85,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3.1-dev0
+        image: quay.io/kubermatic/http-prober:v0.3.1
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/api/pkg/resources/test/fixtures/deployment-bringyourown-1.10.6-usercluster-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-bringyourown-1.10.6-usercluster-controller.yaml
@@ -85,7 +85,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3
+        image: quay.io/kubermatic/http-prober:v0.3.1-dev
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/api/pkg/resources/test/fixtures/deployment-bringyourown-1.10.6-usercluster-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-bringyourown-1.10.6-usercluster-controller.yaml
@@ -85,7 +85,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3.1-dev
+        image: quay.io/kubermatic/http-prober:v0.3.1-dev0
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/api/pkg/resources/test/fixtures/deployment-bringyourown-1.11.0-controller-manager.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-bringyourown-1.11.0-controller-manager.yaml
@@ -171,7 +171,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3.1-dev0
+        image: quay.io/kubermatic/http-prober:v0.3.1
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/api/pkg/resources/test/fixtures/deployment-bringyourown-1.11.0-controller-manager.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-bringyourown-1.11.0-controller-manager.yaml
@@ -171,7 +171,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3
+        image: quay.io/kubermatic/http-prober:v0.3.1-dev
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/api/pkg/resources/test/fixtures/deployment-bringyourown-1.11.0-controller-manager.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-bringyourown-1.11.0-controller-manager.yaml
@@ -171,7 +171,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3.1-dev
+        image: quay.io/kubermatic/http-prober:v0.3.1-dev0
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/api/pkg/resources/test/fixtures/deployment-bringyourown-1.11.0-kube-state-metrics.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-bringyourown-1.11.0-kube-state-metrics.yaml
@@ -72,7 +72,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3.1-dev0
+        image: quay.io/kubermatic/http-prober:v0.3.1
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/api/pkg/resources/test/fixtures/deployment-bringyourown-1.11.0-kube-state-metrics.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-bringyourown-1.11.0-kube-state-metrics.yaml
@@ -72,7 +72,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3
+        image: quay.io/kubermatic/http-prober:v0.3.1-dev
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/api/pkg/resources/test/fixtures/deployment-bringyourown-1.11.0-kube-state-metrics.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-bringyourown-1.11.0-kube-state-metrics.yaml
@@ -72,7 +72,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3.1-dev
+        image: quay.io/kubermatic/http-prober:v0.3.1-dev0
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/api/pkg/resources/test/fixtures/deployment-bringyourown-1.11.0-machine-controller-webhook.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-bringyourown-1.11.0-machine-controller-webhook.yaml
@@ -31,10 +31,8 @@ spec:
         - "1"
         - -command
         - '{"command":"/usr/local/bin/webhook","args":["-kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","-logtostderr","-v","4","-listen-address","0.0.0.0:9876"]}'
-        - -wait-for-crd-kind
-        - Machine
-        - -wait-for-crd-apiversion
-        - cluster.k8s.io/v1alpha1
+        - --crd-to-wait-for
+        - Machine,cluster.k8s.io/v1alpha1
         command:
         - /http-prober-bin/http-prober
         env:
@@ -84,7 +82,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3
+        image: quay.io/kubermatic/http-prober:v0.3.1-dev
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/api/pkg/resources/test/fixtures/deployment-bringyourown-1.11.0-machine-controller-webhook.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-bringyourown-1.11.0-machine-controller-webhook.yaml
@@ -82,7 +82,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3.1-dev
+        image: quay.io/kubermatic/http-prober:v0.3.1-dev0
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/api/pkg/resources/test/fixtures/deployment-bringyourown-1.11.0-machine-controller-webhook.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-bringyourown-1.11.0-machine-controller-webhook.yaml
@@ -82,7 +82,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3.1-dev0
+        image: quay.io/kubermatic/http-prober:v0.3.1
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/api/pkg/resources/test/fixtures/deployment-bringyourown-1.11.0-machine-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-bringyourown-1.11.0-machine-controller.yaml
@@ -73,7 +73,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3.1-dev0
+        image: quay.io/kubermatic/http-prober:v0.3.1
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/api/pkg/resources/test/fixtures/deployment-bringyourown-1.11.0-machine-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-bringyourown-1.11.0-machine-controller.yaml
@@ -34,10 +34,8 @@ spec:
         - "1"
         - -command
         - '{"command":"/usr/local/bin/machine-controller","args":["-kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","-logtostderr","-v","4","-cluster-dns","169.254.20.10","-internal-listen-address","0.0.0.0:8085"]}'
-        - -wait-for-crd-kind
-        - Machine
-        - -wait-for-crd-apiversion
-        - cluster.k8s.io/v1alpha1
+        - --crd-to-wait-for
+        - Machine,cluster.k8s.io/v1alpha1
         command:
         - /http-prober-bin/http-prober
         env:
@@ -75,7 +73,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3
+        image: quay.io/kubermatic/http-prober:v0.3.1-dev
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/api/pkg/resources/test/fixtures/deployment-bringyourown-1.11.0-machine-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-bringyourown-1.11.0-machine-controller.yaml
@@ -73,7 +73,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3.1-dev
+        image: quay.io/kubermatic/http-prober:v0.3.1-dev0
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/api/pkg/resources/test/fixtures/deployment-bringyourown-1.11.0-metrics-server.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-bringyourown-1.11.0-metrics-server.yaml
@@ -156,7 +156,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3
+        image: quay.io/kubermatic/http-prober:v0.3.1-dev
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/api/pkg/resources/test/fixtures/deployment-bringyourown-1.11.0-metrics-server.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-bringyourown-1.11.0-metrics-server.yaml
@@ -156,7 +156,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3.1-dev
+        image: quay.io/kubermatic/http-prober:v0.3.1-dev0
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/api/pkg/resources/test/fixtures/deployment-bringyourown-1.11.0-metrics-server.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-bringyourown-1.11.0-metrics-server.yaml
@@ -156,7 +156,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3.1-dev0
+        image: quay.io/kubermatic/http-prober:v0.3.1
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/api/pkg/resources/test/fixtures/deployment-bringyourown-1.11.0-scheduler.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-bringyourown-1.11.0-scheduler.yaml
@@ -163,7 +163,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3.1-dev
+        image: quay.io/kubermatic/http-prober:v0.3.1-dev0
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/api/pkg/resources/test/fixtures/deployment-bringyourown-1.11.0-scheduler.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-bringyourown-1.11.0-scheduler.yaml
@@ -163,7 +163,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3.1-dev0
+        image: quay.io/kubermatic/http-prober:v0.3.1
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/api/pkg/resources/test/fixtures/deployment-bringyourown-1.11.0-scheduler.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-bringyourown-1.11.0-scheduler.yaml
@@ -163,7 +163,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3
+        image: quay.io/kubermatic/http-prober:v0.3.1-dev
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/api/pkg/resources/test/fixtures/deployment-bringyourown-1.11.0-usercluster-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-bringyourown-1.11.0-usercluster-controller.yaml
@@ -85,7 +85,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3.1-dev0
+        image: quay.io/kubermatic/http-prober:v0.3.1
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/api/pkg/resources/test/fixtures/deployment-bringyourown-1.11.0-usercluster-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-bringyourown-1.11.0-usercluster-controller.yaml
@@ -85,7 +85,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3
+        image: quay.io/kubermatic/http-prober:v0.3.1-dev
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/api/pkg/resources/test/fixtures/deployment-bringyourown-1.11.0-usercluster-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-bringyourown-1.11.0-usercluster-controller.yaml
@@ -85,7 +85,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3.1-dev
+        image: quay.io/kubermatic/http-prober:v0.3.1-dev0
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/api/pkg/resources/test/fixtures/deployment-bringyourown-1.11.1-controller-manager.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-bringyourown-1.11.1-controller-manager.yaml
@@ -171,7 +171,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3.1-dev0
+        image: quay.io/kubermatic/http-prober:v0.3.1
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/api/pkg/resources/test/fixtures/deployment-bringyourown-1.11.1-controller-manager.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-bringyourown-1.11.1-controller-manager.yaml
@@ -171,7 +171,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3
+        image: quay.io/kubermatic/http-prober:v0.3.1-dev
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/api/pkg/resources/test/fixtures/deployment-bringyourown-1.11.1-controller-manager.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-bringyourown-1.11.1-controller-manager.yaml
@@ -171,7 +171,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3.1-dev
+        image: quay.io/kubermatic/http-prober:v0.3.1-dev0
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/api/pkg/resources/test/fixtures/deployment-bringyourown-1.11.1-kube-state-metrics.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-bringyourown-1.11.1-kube-state-metrics.yaml
@@ -72,7 +72,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3.1-dev0
+        image: quay.io/kubermatic/http-prober:v0.3.1
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/api/pkg/resources/test/fixtures/deployment-bringyourown-1.11.1-kube-state-metrics.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-bringyourown-1.11.1-kube-state-metrics.yaml
@@ -72,7 +72,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3
+        image: quay.io/kubermatic/http-prober:v0.3.1-dev
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/api/pkg/resources/test/fixtures/deployment-bringyourown-1.11.1-kube-state-metrics.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-bringyourown-1.11.1-kube-state-metrics.yaml
@@ -72,7 +72,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3.1-dev
+        image: quay.io/kubermatic/http-prober:v0.3.1-dev0
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/api/pkg/resources/test/fixtures/deployment-bringyourown-1.11.1-machine-controller-webhook.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-bringyourown-1.11.1-machine-controller-webhook.yaml
@@ -31,10 +31,8 @@ spec:
         - "1"
         - -command
         - '{"command":"/usr/local/bin/webhook","args":["-kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","-logtostderr","-v","4","-listen-address","0.0.0.0:9876"]}'
-        - -wait-for-crd-kind
-        - Machine
-        - -wait-for-crd-apiversion
-        - cluster.k8s.io/v1alpha1
+        - --crd-to-wait-for
+        - Machine,cluster.k8s.io/v1alpha1
         command:
         - /http-prober-bin/http-prober
         env:
@@ -84,7 +82,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3
+        image: quay.io/kubermatic/http-prober:v0.3.1-dev
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/api/pkg/resources/test/fixtures/deployment-bringyourown-1.11.1-machine-controller-webhook.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-bringyourown-1.11.1-machine-controller-webhook.yaml
@@ -82,7 +82,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3.1-dev
+        image: quay.io/kubermatic/http-prober:v0.3.1-dev0
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/api/pkg/resources/test/fixtures/deployment-bringyourown-1.11.1-machine-controller-webhook.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-bringyourown-1.11.1-machine-controller-webhook.yaml
@@ -82,7 +82,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3.1-dev0
+        image: quay.io/kubermatic/http-prober:v0.3.1
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/api/pkg/resources/test/fixtures/deployment-bringyourown-1.11.1-machine-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-bringyourown-1.11.1-machine-controller.yaml
@@ -73,7 +73,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3.1-dev0
+        image: quay.io/kubermatic/http-prober:v0.3.1
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/api/pkg/resources/test/fixtures/deployment-bringyourown-1.11.1-machine-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-bringyourown-1.11.1-machine-controller.yaml
@@ -34,10 +34,8 @@ spec:
         - "1"
         - -command
         - '{"command":"/usr/local/bin/machine-controller","args":["-kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","-logtostderr","-v","4","-cluster-dns","169.254.20.10","-internal-listen-address","0.0.0.0:8085"]}'
-        - -wait-for-crd-kind
-        - Machine
-        - -wait-for-crd-apiversion
-        - cluster.k8s.io/v1alpha1
+        - --crd-to-wait-for
+        - Machine,cluster.k8s.io/v1alpha1
         command:
         - /http-prober-bin/http-prober
         env:
@@ -75,7 +73,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3
+        image: quay.io/kubermatic/http-prober:v0.3.1-dev
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/api/pkg/resources/test/fixtures/deployment-bringyourown-1.11.1-machine-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-bringyourown-1.11.1-machine-controller.yaml
@@ -73,7 +73,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3.1-dev
+        image: quay.io/kubermatic/http-prober:v0.3.1-dev0
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/api/pkg/resources/test/fixtures/deployment-bringyourown-1.11.1-metrics-server.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-bringyourown-1.11.1-metrics-server.yaml
@@ -156,7 +156,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3
+        image: quay.io/kubermatic/http-prober:v0.3.1-dev
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/api/pkg/resources/test/fixtures/deployment-bringyourown-1.11.1-metrics-server.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-bringyourown-1.11.1-metrics-server.yaml
@@ -156,7 +156,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3.1-dev
+        image: quay.io/kubermatic/http-prober:v0.3.1-dev0
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/api/pkg/resources/test/fixtures/deployment-bringyourown-1.11.1-metrics-server.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-bringyourown-1.11.1-metrics-server.yaml
@@ -156,7 +156,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3.1-dev0
+        image: quay.io/kubermatic/http-prober:v0.3.1
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/api/pkg/resources/test/fixtures/deployment-bringyourown-1.11.1-scheduler.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-bringyourown-1.11.1-scheduler.yaml
@@ -163,7 +163,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3.1-dev
+        image: quay.io/kubermatic/http-prober:v0.3.1-dev0
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/api/pkg/resources/test/fixtures/deployment-bringyourown-1.11.1-scheduler.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-bringyourown-1.11.1-scheduler.yaml
@@ -163,7 +163,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3.1-dev0
+        image: quay.io/kubermatic/http-prober:v0.3.1
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/api/pkg/resources/test/fixtures/deployment-bringyourown-1.11.1-scheduler.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-bringyourown-1.11.1-scheduler.yaml
@@ -163,7 +163,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3
+        image: quay.io/kubermatic/http-prober:v0.3.1-dev
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/api/pkg/resources/test/fixtures/deployment-bringyourown-1.11.1-usercluster-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-bringyourown-1.11.1-usercluster-controller.yaml
@@ -85,7 +85,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3.1-dev0
+        image: quay.io/kubermatic/http-prober:v0.3.1
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/api/pkg/resources/test/fixtures/deployment-bringyourown-1.11.1-usercluster-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-bringyourown-1.11.1-usercluster-controller.yaml
@@ -85,7 +85,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3
+        image: quay.io/kubermatic/http-prober:v0.3.1-dev
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/api/pkg/resources/test/fixtures/deployment-bringyourown-1.11.1-usercluster-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-bringyourown-1.11.1-usercluster-controller.yaml
@@ -85,7 +85,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3.1-dev
+        image: quay.io/kubermatic/http-prober:v0.3.1-dev0
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/api/pkg/resources/test/fixtures/deployment-bringyourown-1.12.0-controller-manager.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-bringyourown-1.12.0-controller-manager.yaml
@@ -171,7 +171,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3.1-dev0
+        image: quay.io/kubermatic/http-prober:v0.3.1
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/api/pkg/resources/test/fixtures/deployment-bringyourown-1.12.0-controller-manager.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-bringyourown-1.12.0-controller-manager.yaml
@@ -171,7 +171,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3
+        image: quay.io/kubermatic/http-prober:v0.3.1-dev
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/api/pkg/resources/test/fixtures/deployment-bringyourown-1.12.0-controller-manager.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-bringyourown-1.12.0-controller-manager.yaml
@@ -171,7 +171,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3.1-dev
+        image: quay.io/kubermatic/http-prober:v0.3.1-dev0
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/api/pkg/resources/test/fixtures/deployment-bringyourown-1.12.0-kube-state-metrics.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-bringyourown-1.12.0-kube-state-metrics.yaml
@@ -72,7 +72,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3.1-dev0
+        image: quay.io/kubermatic/http-prober:v0.3.1
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/api/pkg/resources/test/fixtures/deployment-bringyourown-1.12.0-kube-state-metrics.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-bringyourown-1.12.0-kube-state-metrics.yaml
@@ -72,7 +72,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3
+        image: quay.io/kubermatic/http-prober:v0.3.1-dev
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/api/pkg/resources/test/fixtures/deployment-bringyourown-1.12.0-kube-state-metrics.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-bringyourown-1.12.0-kube-state-metrics.yaml
@@ -72,7 +72,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3.1-dev
+        image: quay.io/kubermatic/http-prober:v0.3.1-dev0
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/api/pkg/resources/test/fixtures/deployment-bringyourown-1.12.0-machine-controller-webhook.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-bringyourown-1.12.0-machine-controller-webhook.yaml
@@ -31,10 +31,8 @@ spec:
         - "1"
         - -command
         - '{"command":"/usr/local/bin/webhook","args":["-kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","-logtostderr","-v","4","-listen-address","0.0.0.0:9876"]}'
-        - -wait-for-crd-kind
-        - Machine
-        - -wait-for-crd-apiversion
-        - cluster.k8s.io/v1alpha1
+        - --crd-to-wait-for
+        - Machine,cluster.k8s.io/v1alpha1
         command:
         - /http-prober-bin/http-prober
         env:
@@ -84,7 +82,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3
+        image: quay.io/kubermatic/http-prober:v0.3.1-dev
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/api/pkg/resources/test/fixtures/deployment-bringyourown-1.12.0-machine-controller-webhook.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-bringyourown-1.12.0-machine-controller-webhook.yaml
@@ -82,7 +82,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3.1-dev
+        image: quay.io/kubermatic/http-prober:v0.3.1-dev0
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/api/pkg/resources/test/fixtures/deployment-bringyourown-1.12.0-machine-controller-webhook.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-bringyourown-1.12.0-machine-controller-webhook.yaml
@@ -82,7 +82,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3.1-dev0
+        image: quay.io/kubermatic/http-prober:v0.3.1
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/api/pkg/resources/test/fixtures/deployment-bringyourown-1.12.0-machine-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-bringyourown-1.12.0-machine-controller.yaml
@@ -73,7 +73,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3.1-dev0
+        image: quay.io/kubermatic/http-prober:v0.3.1
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/api/pkg/resources/test/fixtures/deployment-bringyourown-1.12.0-machine-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-bringyourown-1.12.0-machine-controller.yaml
@@ -34,10 +34,8 @@ spec:
         - "1"
         - -command
         - '{"command":"/usr/local/bin/machine-controller","args":["-kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","-logtostderr","-v","4","-cluster-dns","169.254.20.10","-internal-listen-address","0.0.0.0:8085"]}'
-        - -wait-for-crd-kind
-        - Machine
-        - -wait-for-crd-apiversion
-        - cluster.k8s.io/v1alpha1
+        - --crd-to-wait-for
+        - Machine,cluster.k8s.io/v1alpha1
         command:
         - /http-prober-bin/http-prober
         env:
@@ -75,7 +73,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3
+        image: quay.io/kubermatic/http-prober:v0.3.1-dev
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/api/pkg/resources/test/fixtures/deployment-bringyourown-1.12.0-machine-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-bringyourown-1.12.0-machine-controller.yaml
@@ -73,7 +73,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3.1-dev
+        image: quay.io/kubermatic/http-prober:v0.3.1-dev0
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/api/pkg/resources/test/fixtures/deployment-bringyourown-1.12.0-metrics-server.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-bringyourown-1.12.0-metrics-server.yaml
@@ -156,7 +156,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3
+        image: quay.io/kubermatic/http-prober:v0.3.1-dev
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/api/pkg/resources/test/fixtures/deployment-bringyourown-1.12.0-metrics-server.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-bringyourown-1.12.0-metrics-server.yaml
@@ -156,7 +156,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3.1-dev
+        image: quay.io/kubermatic/http-prober:v0.3.1-dev0
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/api/pkg/resources/test/fixtures/deployment-bringyourown-1.12.0-metrics-server.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-bringyourown-1.12.0-metrics-server.yaml
@@ -156,7 +156,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3.1-dev0
+        image: quay.io/kubermatic/http-prober:v0.3.1
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/api/pkg/resources/test/fixtures/deployment-bringyourown-1.12.0-scheduler.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-bringyourown-1.12.0-scheduler.yaml
@@ -163,7 +163,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3.1-dev
+        image: quay.io/kubermatic/http-prober:v0.3.1-dev0
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/api/pkg/resources/test/fixtures/deployment-bringyourown-1.12.0-scheduler.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-bringyourown-1.12.0-scheduler.yaml
@@ -163,7 +163,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3.1-dev0
+        image: quay.io/kubermatic/http-prober:v0.3.1
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/api/pkg/resources/test/fixtures/deployment-bringyourown-1.12.0-scheduler.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-bringyourown-1.12.0-scheduler.yaml
@@ -163,7 +163,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3
+        image: quay.io/kubermatic/http-prober:v0.3.1-dev
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/api/pkg/resources/test/fixtures/deployment-bringyourown-1.12.0-usercluster-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-bringyourown-1.12.0-usercluster-controller.yaml
@@ -85,7 +85,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3.1-dev0
+        image: quay.io/kubermatic/http-prober:v0.3.1
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/api/pkg/resources/test/fixtures/deployment-bringyourown-1.12.0-usercluster-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-bringyourown-1.12.0-usercluster-controller.yaml
@@ -85,7 +85,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3
+        image: quay.io/kubermatic/http-prober:v0.3.1-dev
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/api/pkg/resources/test/fixtures/deployment-bringyourown-1.12.0-usercluster-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-bringyourown-1.12.0-usercluster-controller.yaml
@@ -85,7 +85,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3.1-dev
+        image: quay.io/kubermatic/http-prober:v0.3.1-dev0
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/api/pkg/resources/test/fixtures/deployment-bringyourown-1.13.0-controller-manager.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-bringyourown-1.13.0-controller-manager.yaml
@@ -171,7 +171,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3.1-dev0
+        image: quay.io/kubermatic/http-prober:v0.3.1
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/api/pkg/resources/test/fixtures/deployment-bringyourown-1.13.0-controller-manager.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-bringyourown-1.13.0-controller-manager.yaml
@@ -171,7 +171,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3
+        image: quay.io/kubermatic/http-prober:v0.3.1-dev
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/api/pkg/resources/test/fixtures/deployment-bringyourown-1.13.0-controller-manager.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-bringyourown-1.13.0-controller-manager.yaml
@@ -171,7 +171,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3.1-dev
+        image: quay.io/kubermatic/http-prober:v0.3.1-dev0
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/api/pkg/resources/test/fixtures/deployment-bringyourown-1.13.0-kube-state-metrics.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-bringyourown-1.13.0-kube-state-metrics.yaml
@@ -72,7 +72,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3.1-dev0
+        image: quay.io/kubermatic/http-prober:v0.3.1
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/api/pkg/resources/test/fixtures/deployment-bringyourown-1.13.0-kube-state-metrics.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-bringyourown-1.13.0-kube-state-metrics.yaml
@@ -72,7 +72,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3
+        image: quay.io/kubermatic/http-prober:v0.3.1-dev
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/api/pkg/resources/test/fixtures/deployment-bringyourown-1.13.0-kube-state-metrics.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-bringyourown-1.13.0-kube-state-metrics.yaml
@@ -72,7 +72,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3.1-dev
+        image: quay.io/kubermatic/http-prober:v0.3.1-dev0
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/api/pkg/resources/test/fixtures/deployment-bringyourown-1.13.0-machine-controller-webhook.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-bringyourown-1.13.0-machine-controller-webhook.yaml
@@ -31,10 +31,8 @@ spec:
         - "1"
         - -command
         - '{"command":"/usr/local/bin/webhook","args":["-kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","-logtostderr","-v","4","-listen-address","0.0.0.0:9876"]}'
-        - -wait-for-crd-kind
-        - Machine
-        - -wait-for-crd-apiversion
-        - cluster.k8s.io/v1alpha1
+        - --crd-to-wait-for
+        - Machine,cluster.k8s.io/v1alpha1
         command:
         - /http-prober-bin/http-prober
         env:
@@ -84,7 +82,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3
+        image: quay.io/kubermatic/http-prober:v0.3.1-dev
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/api/pkg/resources/test/fixtures/deployment-bringyourown-1.13.0-machine-controller-webhook.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-bringyourown-1.13.0-machine-controller-webhook.yaml
@@ -82,7 +82,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3.1-dev
+        image: quay.io/kubermatic/http-prober:v0.3.1-dev0
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/api/pkg/resources/test/fixtures/deployment-bringyourown-1.13.0-machine-controller-webhook.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-bringyourown-1.13.0-machine-controller-webhook.yaml
@@ -82,7 +82,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3.1-dev0
+        image: quay.io/kubermatic/http-prober:v0.3.1
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/api/pkg/resources/test/fixtures/deployment-bringyourown-1.13.0-machine-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-bringyourown-1.13.0-machine-controller.yaml
@@ -73,7 +73,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3.1-dev0
+        image: quay.io/kubermatic/http-prober:v0.3.1
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/api/pkg/resources/test/fixtures/deployment-bringyourown-1.13.0-machine-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-bringyourown-1.13.0-machine-controller.yaml
@@ -34,10 +34,8 @@ spec:
         - "1"
         - -command
         - '{"command":"/usr/local/bin/machine-controller","args":["-kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","-logtostderr","-v","4","-cluster-dns","169.254.20.10","-internal-listen-address","0.0.0.0:8085"]}'
-        - -wait-for-crd-kind
-        - Machine
-        - -wait-for-crd-apiversion
-        - cluster.k8s.io/v1alpha1
+        - --crd-to-wait-for
+        - Machine,cluster.k8s.io/v1alpha1
         command:
         - /http-prober-bin/http-prober
         env:
@@ -75,7 +73,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3
+        image: quay.io/kubermatic/http-prober:v0.3.1-dev
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/api/pkg/resources/test/fixtures/deployment-bringyourown-1.13.0-machine-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-bringyourown-1.13.0-machine-controller.yaml
@@ -73,7 +73,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3.1-dev
+        image: quay.io/kubermatic/http-prober:v0.3.1-dev0
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/api/pkg/resources/test/fixtures/deployment-bringyourown-1.13.0-metrics-server.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-bringyourown-1.13.0-metrics-server.yaml
@@ -156,7 +156,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3
+        image: quay.io/kubermatic/http-prober:v0.3.1-dev
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/api/pkg/resources/test/fixtures/deployment-bringyourown-1.13.0-metrics-server.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-bringyourown-1.13.0-metrics-server.yaml
@@ -156,7 +156,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3.1-dev
+        image: quay.io/kubermatic/http-prober:v0.3.1-dev0
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/api/pkg/resources/test/fixtures/deployment-bringyourown-1.13.0-metrics-server.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-bringyourown-1.13.0-metrics-server.yaml
@@ -156,7 +156,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3.1-dev0
+        image: quay.io/kubermatic/http-prober:v0.3.1
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/api/pkg/resources/test/fixtures/deployment-bringyourown-1.13.0-scheduler.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-bringyourown-1.13.0-scheduler.yaml
@@ -163,7 +163,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3.1-dev
+        image: quay.io/kubermatic/http-prober:v0.3.1-dev0
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/api/pkg/resources/test/fixtures/deployment-bringyourown-1.13.0-scheduler.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-bringyourown-1.13.0-scheduler.yaml
@@ -163,7 +163,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3.1-dev0
+        image: quay.io/kubermatic/http-prober:v0.3.1
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/api/pkg/resources/test/fixtures/deployment-bringyourown-1.13.0-scheduler.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-bringyourown-1.13.0-scheduler.yaml
@@ -163,7 +163,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3
+        image: quay.io/kubermatic/http-prober:v0.3.1-dev
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/api/pkg/resources/test/fixtures/deployment-bringyourown-1.13.0-usercluster-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-bringyourown-1.13.0-usercluster-controller.yaml
@@ -85,7 +85,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3.1-dev0
+        image: quay.io/kubermatic/http-prober:v0.3.1
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/api/pkg/resources/test/fixtures/deployment-bringyourown-1.13.0-usercluster-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-bringyourown-1.13.0-usercluster-controller.yaml
@@ -85,7 +85,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3
+        image: quay.io/kubermatic/http-prober:v0.3.1-dev
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/api/pkg/resources/test/fixtures/deployment-bringyourown-1.13.0-usercluster-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-bringyourown-1.13.0-usercluster-controller.yaml
@@ -85,7 +85,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3.1-dev
+        image: quay.io/kubermatic/http-prober:v0.3.1-dev0
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/api/pkg/resources/test/fixtures/deployment-digitalocean-1.10.0-controller-manager.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-digitalocean-1.10.0-controller-manager.yaml
@@ -171,7 +171,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3.1-dev0
+        image: quay.io/kubermatic/http-prober:v0.3.1
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/api/pkg/resources/test/fixtures/deployment-digitalocean-1.10.0-controller-manager.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-digitalocean-1.10.0-controller-manager.yaml
@@ -171,7 +171,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3
+        image: quay.io/kubermatic/http-prober:v0.3.1-dev
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/api/pkg/resources/test/fixtures/deployment-digitalocean-1.10.0-controller-manager.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-digitalocean-1.10.0-controller-manager.yaml
@@ -171,7 +171,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3.1-dev
+        image: quay.io/kubermatic/http-prober:v0.3.1-dev0
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/api/pkg/resources/test/fixtures/deployment-digitalocean-1.10.0-kube-state-metrics.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-digitalocean-1.10.0-kube-state-metrics.yaml
@@ -72,7 +72,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3.1-dev0
+        image: quay.io/kubermatic/http-prober:v0.3.1
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/api/pkg/resources/test/fixtures/deployment-digitalocean-1.10.0-kube-state-metrics.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-digitalocean-1.10.0-kube-state-metrics.yaml
@@ -72,7 +72,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3
+        image: quay.io/kubermatic/http-prober:v0.3.1-dev
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/api/pkg/resources/test/fixtures/deployment-digitalocean-1.10.0-kube-state-metrics.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-digitalocean-1.10.0-kube-state-metrics.yaml
@@ -72,7 +72,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3.1-dev
+        image: quay.io/kubermatic/http-prober:v0.3.1-dev0
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/api/pkg/resources/test/fixtures/deployment-digitalocean-1.10.0-machine-controller-webhook.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-digitalocean-1.10.0-machine-controller-webhook.yaml
@@ -31,10 +31,8 @@ spec:
         - "1"
         - -command
         - '{"command":"/usr/local/bin/webhook","args":["-kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","-logtostderr","-v","4","-listen-address","0.0.0.0:9876"]}'
-        - -wait-for-crd-kind
-        - Machine
-        - -wait-for-crd-apiversion
-        - cluster.k8s.io/v1alpha1
+        - --crd-to-wait-for
+        - Machine,cluster.k8s.io/v1alpha1
         command:
         - /http-prober-bin/http-prober
         env:
@@ -86,7 +84,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3
+        image: quay.io/kubermatic/http-prober:v0.3.1-dev
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/api/pkg/resources/test/fixtures/deployment-digitalocean-1.10.0-machine-controller-webhook.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-digitalocean-1.10.0-machine-controller-webhook.yaml
@@ -84,7 +84,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3.1-dev
+        image: quay.io/kubermatic/http-prober:v0.3.1-dev0
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/api/pkg/resources/test/fixtures/deployment-digitalocean-1.10.0-machine-controller-webhook.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-digitalocean-1.10.0-machine-controller-webhook.yaml
@@ -84,7 +84,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3.1-dev0
+        image: quay.io/kubermatic/http-prober:v0.3.1
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/api/pkg/resources/test/fixtures/deployment-digitalocean-1.10.0-machine-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-digitalocean-1.10.0-machine-controller.yaml
@@ -34,10 +34,8 @@ spec:
         - "1"
         - -command
         - '{"command":"/usr/local/bin/machine-controller","args":["-kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","-logtostderr","-v","4","-cluster-dns","169.254.20.10","-internal-listen-address","0.0.0.0:8085"]}'
-        - -wait-for-crd-kind
-        - Machine
-        - -wait-for-crd-apiversion
-        - cluster.k8s.io/v1alpha1
+        - --crd-to-wait-for
+        - Machine,cluster.k8s.io/v1alpha1
         command:
         - /http-prober-bin/http-prober
         env:
@@ -77,7 +75,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3
+        image: quay.io/kubermatic/http-prober:v0.3.1-dev
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/api/pkg/resources/test/fixtures/deployment-digitalocean-1.10.0-machine-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-digitalocean-1.10.0-machine-controller.yaml
@@ -75,7 +75,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3.1-dev
+        image: quay.io/kubermatic/http-prober:v0.3.1-dev0
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/api/pkg/resources/test/fixtures/deployment-digitalocean-1.10.0-machine-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-digitalocean-1.10.0-machine-controller.yaml
@@ -75,7 +75,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3.1-dev0
+        image: quay.io/kubermatic/http-prober:v0.3.1
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/api/pkg/resources/test/fixtures/deployment-digitalocean-1.10.0-metrics-server.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-digitalocean-1.10.0-metrics-server.yaml
@@ -156,7 +156,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3
+        image: quay.io/kubermatic/http-prober:v0.3.1-dev
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/api/pkg/resources/test/fixtures/deployment-digitalocean-1.10.0-metrics-server.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-digitalocean-1.10.0-metrics-server.yaml
@@ -156,7 +156,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3.1-dev
+        image: quay.io/kubermatic/http-prober:v0.3.1-dev0
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/api/pkg/resources/test/fixtures/deployment-digitalocean-1.10.0-metrics-server.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-digitalocean-1.10.0-metrics-server.yaml
@@ -156,7 +156,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3.1-dev0
+        image: quay.io/kubermatic/http-prober:v0.3.1
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/api/pkg/resources/test/fixtures/deployment-digitalocean-1.10.0-scheduler.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-digitalocean-1.10.0-scheduler.yaml
@@ -163,7 +163,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3.1-dev
+        image: quay.io/kubermatic/http-prober:v0.3.1-dev0
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/api/pkg/resources/test/fixtures/deployment-digitalocean-1.10.0-scheduler.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-digitalocean-1.10.0-scheduler.yaml
@@ -163,7 +163,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3.1-dev0
+        image: quay.io/kubermatic/http-prober:v0.3.1
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/api/pkg/resources/test/fixtures/deployment-digitalocean-1.10.0-scheduler.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-digitalocean-1.10.0-scheduler.yaml
@@ -163,7 +163,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3
+        image: quay.io/kubermatic/http-prober:v0.3.1-dev
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/api/pkg/resources/test/fixtures/deployment-digitalocean-1.10.0-usercluster-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-digitalocean-1.10.0-usercluster-controller.yaml
@@ -85,7 +85,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3.1-dev0
+        image: quay.io/kubermatic/http-prober:v0.3.1
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/api/pkg/resources/test/fixtures/deployment-digitalocean-1.10.0-usercluster-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-digitalocean-1.10.0-usercluster-controller.yaml
@@ -85,7 +85,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3
+        image: quay.io/kubermatic/http-prober:v0.3.1-dev
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/api/pkg/resources/test/fixtures/deployment-digitalocean-1.10.0-usercluster-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-digitalocean-1.10.0-usercluster-controller.yaml
@@ -85,7 +85,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3.1-dev
+        image: quay.io/kubermatic/http-prober:v0.3.1-dev0
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/api/pkg/resources/test/fixtures/deployment-digitalocean-1.10.6-controller-manager.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-digitalocean-1.10.6-controller-manager.yaml
@@ -171,7 +171,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3.1-dev0
+        image: quay.io/kubermatic/http-prober:v0.3.1
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/api/pkg/resources/test/fixtures/deployment-digitalocean-1.10.6-controller-manager.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-digitalocean-1.10.6-controller-manager.yaml
@@ -171,7 +171,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3
+        image: quay.io/kubermatic/http-prober:v0.3.1-dev
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/api/pkg/resources/test/fixtures/deployment-digitalocean-1.10.6-controller-manager.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-digitalocean-1.10.6-controller-manager.yaml
@@ -171,7 +171,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3.1-dev
+        image: quay.io/kubermatic/http-prober:v0.3.1-dev0
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/api/pkg/resources/test/fixtures/deployment-digitalocean-1.10.6-kube-state-metrics.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-digitalocean-1.10.6-kube-state-metrics.yaml
@@ -72,7 +72,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3.1-dev0
+        image: quay.io/kubermatic/http-prober:v0.3.1
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/api/pkg/resources/test/fixtures/deployment-digitalocean-1.10.6-kube-state-metrics.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-digitalocean-1.10.6-kube-state-metrics.yaml
@@ -72,7 +72,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3
+        image: quay.io/kubermatic/http-prober:v0.3.1-dev
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/api/pkg/resources/test/fixtures/deployment-digitalocean-1.10.6-kube-state-metrics.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-digitalocean-1.10.6-kube-state-metrics.yaml
@@ -72,7 +72,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3.1-dev
+        image: quay.io/kubermatic/http-prober:v0.3.1-dev0
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/api/pkg/resources/test/fixtures/deployment-digitalocean-1.10.6-machine-controller-webhook.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-digitalocean-1.10.6-machine-controller-webhook.yaml
@@ -31,10 +31,8 @@ spec:
         - "1"
         - -command
         - '{"command":"/usr/local/bin/webhook","args":["-kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","-logtostderr","-v","4","-listen-address","0.0.0.0:9876"]}'
-        - -wait-for-crd-kind
-        - Machine
-        - -wait-for-crd-apiversion
-        - cluster.k8s.io/v1alpha1
+        - --crd-to-wait-for
+        - Machine,cluster.k8s.io/v1alpha1
         command:
         - /http-prober-bin/http-prober
         env:
@@ -86,7 +84,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3
+        image: quay.io/kubermatic/http-prober:v0.3.1-dev
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/api/pkg/resources/test/fixtures/deployment-digitalocean-1.10.6-machine-controller-webhook.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-digitalocean-1.10.6-machine-controller-webhook.yaml
@@ -84,7 +84,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3.1-dev
+        image: quay.io/kubermatic/http-prober:v0.3.1-dev0
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/api/pkg/resources/test/fixtures/deployment-digitalocean-1.10.6-machine-controller-webhook.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-digitalocean-1.10.6-machine-controller-webhook.yaml
@@ -84,7 +84,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3.1-dev0
+        image: quay.io/kubermatic/http-prober:v0.3.1
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/api/pkg/resources/test/fixtures/deployment-digitalocean-1.10.6-machine-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-digitalocean-1.10.6-machine-controller.yaml
@@ -34,10 +34,8 @@ spec:
         - "1"
         - -command
         - '{"command":"/usr/local/bin/machine-controller","args":["-kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","-logtostderr","-v","4","-cluster-dns","169.254.20.10","-internal-listen-address","0.0.0.0:8085"]}'
-        - -wait-for-crd-kind
-        - Machine
-        - -wait-for-crd-apiversion
-        - cluster.k8s.io/v1alpha1
+        - --crd-to-wait-for
+        - Machine,cluster.k8s.io/v1alpha1
         command:
         - /http-prober-bin/http-prober
         env:
@@ -77,7 +75,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3
+        image: quay.io/kubermatic/http-prober:v0.3.1-dev
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/api/pkg/resources/test/fixtures/deployment-digitalocean-1.10.6-machine-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-digitalocean-1.10.6-machine-controller.yaml
@@ -75,7 +75,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3.1-dev
+        image: quay.io/kubermatic/http-prober:v0.3.1-dev0
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/api/pkg/resources/test/fixtures/deployment-digitalocean-1.10.6-machine-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-digitalocean-1.10.6-machine-controller.yaml
@@ -75,7 +75,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3.1-dev0
+        image: quay.io/kubermatic/http-prober:v0.3.1
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/api/pkg/resources/test/fixtures/deployment-digitalocean-1.10.6-metrics-server.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-digitalocean-1.10.6-metrics-server.yaml
@@ -156,7 +156,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3
+        image: quay.io/kubermatic/http-prober:v0.3.1-dev
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/api/pkg/resources/test/fixtures/deployment-digitalocean-1.10.6-metrics-server.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-digitalocean-1.10.6-metrics-server.yaml
@@ -156,7 +156,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3.1-dev
+        image: quay.io/kubermatic/http-prober:v0.3.1-dev0
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/api/pkg/resources/test/fixtures/deployment-digitalocean-1.10.6-metrics-server.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-digitalocean-1.10.6-metrics-server.yaml
@@ -156,7 +156,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3.1-dev0
+        image: quay.io/kubermatic/http-prober:v0.3.1
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/api/pkg/resources/test/fixtures/deployment-digitalocean-1.10.6-scheduler.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-digitalocean-1.10.6-scheduler.yaml
@@ -163,7 +163,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3.1-dev
+        image: quay.io/kubermatic/http-prober:v0.3.1-dev0
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/api/pkg/resources/test/fixtures/deployment-digitalocean-1.10.6-scheduler.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-digitalocean-1.10.6-scheduler.yaml
@@ -163,7 +163,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3.1-dev0
+        image: quay.io/kubermatic/http-prober:v0.3.1
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/api/pkg/resources/test/fixtures/deployment-digitalocean-1.10.6-scheduler.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-digitalocean-1.10.6-scheduler.yaml
@@ -163,7 +163,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3
+        image: quay.io/kubermatic/http-prober:v0.3.1-dev
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/api/pkg/resources/test/fixtures/deployment-digitalocean-1.10.6-usercluster-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-digitalocean-1.10.6-usercluster-controller.yaml
@@ -85,7 +85,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3.1-dev0
+        image: quay.io/kubermatic/http-prober:v0.3.1
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/api/pkg/resources/test/fixtures/deployment-digitalocean-1.10.6-usercluster-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-digitalocean-1.10.6-usercluster-controller.yaml
@@ -85,7 +85,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3
+        image: quay.io/kubermatic/http-prober:v0.3.1-dev
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/api/pkg/resources/test/fixtures/deployment-digitalocean-1.10.6-usercluster-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-digitalocean-1.10.6-usercluster-controller.yaml
@@ -85,7 +85,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3.1-dev
+        image: quay.io/kubermatic/http-prober:v0.3.1-dev0
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/api/pkg/resources/test/fixtures/deployment-digitalocean-1.11.0-controller-manager.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-digitalocean-1.11.0-controller-manager.yaml
@@ -171,7 +171,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3.1-dev0
+        image: quay.io/kubermatic/http-prober:v0.3.1
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/api/pkg/resources/test/fixtures/deployment-digitalocean-1.11.0-controller-manager.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-digitalocean-1.11.0-controller-manager.yaml
@@ -171,7 +171,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3
+        image: quay.io/kubermatic/http-prober:v0.3.1-dev
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/api/pkg/resources/test/fixtures/deployment-digitalocean-1.11.0-controller-manager.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-digitalocean-1.11.0-controller-manager.yaml
@@ -171,7 +171,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3.1-dev
+        image: quay.io/kubermatic/http-prober:v0.3.1-dev0
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/api/pkg/resources/test/fixtures/deployment-digitalocean-1.11.0-kube-state-metrics.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-digitalocean-1.11.0-kube-state-metrics.yaml
@@ -72,7 +72,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3.1-dev0
+        image: quay.io/kubermatic/http-prober:v0.3.1
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/api/pkg/resources/test/fixtures/deployment-digitalocean-1.11.0-kube-state-metrics.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-digitalocean-1.11.0-kube-state-metrics.yaml
@@ -72,7 +72,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3
+        image: quay.io/kubermatic/http-prober:v0.3.1-dev
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/api/pkg/resources/test/fixtures/deployment-digitalocean-1.11.0-kube-state-metrics.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-digitalocean-1.11.0-kube-state-metrics.yaml
@@ -72,7 +72,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3.1-dev
+        image: quay.io/kubermatic/http-prober:v0.3.1-dev0
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/api/pkg/resources/test/fixtures/deployment-digitalocean-1.11.0-machine-controller-webhook.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-digitalocean-1.11.0-machine-controller-webhook.yaml
@@ -31,10 +31,8 @@ spec:
         - "1"
         - -command
         - '{"command":"/usr/local/bin/webhook","args":["-kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","-logtostderr","-v","4","-listen-address","0.0.0.0:9876"]}'
-        - -wait-for-crd-kind
-        - Machine
-        - -wait-for-crd-apiversion
-        - cluster.k8s.io/v1alpha1
+        - --crd-to-wait-for
+        - Machine,cluster.k8s.io/v1alpha1
         command:
         - /http-prober-bin/http-prober
         env:
@@ -86,7 +84,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3
+        image: quay.io/kubermatic/http-prober:v0.3.1-dev
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/api/pkg/resources/test/fixtures/deployment-digitalocean-1.11.0-machine-controller-webhook.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-digitalocean-1.11.0-machine-controller-webhook.yaml
@@ -84,7 +84,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3.1-dev
+        image: quay.io/kubermatic/http-prober:v0.3.1-dev0
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/api/pkg/resources/test/fixtures/deployment-digitalocean-1.11.0-machine-controller-webhook.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-digitalocean-1.11.0-machine-controller-webhook.yaml
@@ -84,7 +84,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3.1-dev0
+        image: quay.io/kubermatic/http-prober:v0.3.1
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/api/pkg/resources/test/fixtures/deployment-digitalocean-1.11.0-machine-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-digitalocean-1.11.0-machine-controller.yaml
@@ -34,10 +34,8 @@ spec:
         - "1"
         - -command
         - '{"command":"/usr/local/bin/machine-controller","args":["-kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","-logtostderr","-v","4","-cluster-dns","169.254.20.10","-internal-listen-address","0.0.0.0:8085"]}'
-        - -wait-for-crd-kind
-        - Machine
-        - -wait-for-crd-apiversion
-        - cluster.k8s.io/v1alpha1
+        - --crd-to-wait-for
+        - Machine,cluster.k8s.io/v1alpha1
         command:
         - /http-prober-bin/http-prober
         env:
@@ -77,7 +75,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3
+        image: quay.io/kubermatic/http-prober:v0.3.1-dev
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/api/pkg/resources/test/fixtures/deployment-digitalocean-1.11.0-machine-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-digitalocean-1.11.0-machine-controller.yaml
@@ -75,7 +75,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3.1-dev
+        image: quay.io/kubermatic/http-prober:v0.3.1-dev0
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/api/pkg/resources/test/fixtures/deployment-digitalocean-1.11.0-machine-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-digitalocean-1.11.0-machine-controller.yaml
@@ -75,7 +75,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3.1-dev0
+        image: quay.io/kubermatic/http-prober:v0.3.1
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/api/pkg/resources/test/fixtures/deployment-digitalocean-1.11.0-metrics-server.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-digitalocean-1.11.0-metrics-server.yaml
@@ -156,7 +156,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3
+        image: quay.io/kubermatic/http-prober:v0.3.1-dev
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/api/pkg/resources/test/fixtures/deployment-digitalocean-1.11.0-metrics-server.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-digitalocean-1.11.0-metrics-server.yaml
@@ -156,7 +156,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3.1-dev
+        image: quay.io/kubermatic/http-prober:v0.3.1-dev0
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/api/pkg/resources/test/fixtures/deployment-digitalocean-1.11.0-metrics-server.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-digitalocean-1.11.0-metrics-server.yaml
@@ -156,7 +156,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3.1-dev0
+        image: quay.io/kubermatic/http-prober:v0.3.1
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/api/pkg/resources/test/fixtures/deployment-digitalocean-1.11.0-scheduler.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-digitalocean-1.11.0-scheduler.yaml
@@ -163,7 +163,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3.1-dev
+        image: quay.io/kubermatic/http-prober:v0.3.1-dev0
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/api/pkg/resources/test/fixtures/deployment-digitalocean-1.11.0-scheduler.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-digitalocean-1.11.0-scheduler.yaml
@@ -163,7 +163,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3.1-dev0
+        image: quay.io/kubermatic/http-prober:v0.3.1
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/api/pkg/resources/test/fixtures/deployment-digitalocean-1.11.0-scheduler.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-digitalocean-1.11.0-scheduler.yaml
@@ -163,7 +163,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3
+        image: quay.io/kubermatic/http-prober:v0.3.1-dev
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/api/pkg/resources/test/fixtures/deployment-digitalocean-1.11.0-usercluster-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-digitalocean-1.11.0-usercluster-controller.yaml
@@ -85,7 +85,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3.1-dev0
+        image: quay.io/kubermatic/http-prober:v0.3.1
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/api/pkg/resources/test/fixtures/deployment-digitalocean-1.11.0-usercluster-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-digitalocean-1.11.0-usercluster-controller.yaml
@@ -85,7 +85,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3
+        image: quay.io/kubermatic/http-prober:v0.3.1-dev
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/api/pkg/resources/test/fixtures/deployment-digitalocean-1.11.0-usercluster-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-digitalocean-1.11.0-usercluster-controller.yaml
@@ -85,7 +85,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3.1-dev
+        image: quay.io/kubermatic/http-prober:v0.3.1-dev0
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/api/pkg/resources/test/fixtures/deployment-digitalocean-1.11.1-controller-manager.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-digitalocean-1.11.1-controller-manager.yaml
@@ -171,7 +171,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3.1-dev0
+        image: quay.io/kubermatic/http-prober:v0.3.1
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/api/pkg/resources/test/fixtures/deployment-digitalocean-1.11.1-controller-manager.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-digitalocean-1.11.1-controller-manager.yaml
@@ -171,7 +171,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3
+        image: quay.io/kubermatic/http-prober:v0.3.1-dev
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/api/pkg/resources/test/fixtures/deployment-digitalocean-1.11.1-controller-manager.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-digitalocean-1.11.1-controller-manager.yaml
@@ -171,7 +171,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3.1-dev
+        image: quay.io/kubermatic/http-prober:v0.3.1-dev0
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/api/pkg/resources/test/fixtures/deployment-digitalocean-1.11.1-kube-state-metrics.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-digitalocean-1.11.1-kube-state-metrics.yaml
@@ -72,7 +72,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3.1-dev0
+        image: quay.io/kubermatic/http-prober:v0.3.1
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/api/pkg/resources/test/fixtures/deployment-digitalocean-1.11.1-kube-state-metrics.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-digitalocean-1.11.1-kube-state-metrics.yaml
@@ -72,7 +72,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3
+        image: quay.io/kubermatic/http-prober:v0.3.1-dev
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/api/pkg/resources/test/fixtures/deployment-digitalocean-1.11.1-kube-state-metrics.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-digitalocean-1.11.1-kube-state-metrics.yaml
@@ -72,7 +72,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3.1-dev
+        image: quay.io/kubermatic/http-prober:v0.3.1-dev0
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/api/pkg/resources/test/fixtures/deployment-digitalocean-1.11.1-machine-controller-webhook.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-digitalocean-1.11.1-machine-controller-webhook.yaml
@@ -31,10 +31,8 @@ spec:
         - "1"
         - -command
         - '{"command":"/usr/local/bin/webhook","args":["-kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","-logtostderr","-v","4","-listen-address","0.0.0.0:9876"]}'
-        - -wait-for-crd-kind
-        - Machine
-        - -wait-for-crd-apiversion
-        - cluster.k8s.io/v1alpha1
+        - --crd-to-wait-for
+        - Machine,cluster.k8s.io/v1alpha1
         command:
         - /http-prober-bin/http-prober
         env:
@@ -86,7 +84,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3
+        image: quay.io/kubermatic/http-prober:v0.3.1-dev
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/api/pkg/resources/test/fixtures/deployment-digitalocean-1.11.1-machine-controller-webhook.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-digitalocean-1.11.1-machine-controller-webhook.yaml
@@ -84,7 +84,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3.1-dev
+        image: quay.io/kubermatic/http-prober:v0.3.1-dev0
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/api/pkg/resources/test/fixtures/deployment-digitalocean-1.11.1-machine-controller-webhook.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-digitalocean-1.11.1-machine-controller-webhook.yaml
@@ -84,7 +84,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3.1-dev0
+        image: quay.io/kubermatic/http-prober:v0.3.1
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/api/pkg/resources/test/fixtures/deployment-digitalocean-1.11.1-machine-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-digitalocean-1.11.1-machine-controller.yaml
@@ -34,10 +34,8 @@ spec:
         - "1"
         - -command
         - '{"command":"/usr/local/bin/machine-controller","args":["-kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","-logtostderr","-v","4","-cluster-dns","169.254.20.10","-internal-listen-address","0.0.0.0:8085"]}'
-        - -wait-for-crd-kind
-        - Machine
-        - -wait-for-crd-apiversion
-        - cluster.k8s.io/v1alpha1
+        - --crd-to-wait-for
+        - Machine,cluster.k8s.io/v1alpha1
         command:
         - /http-prober-bin/http-prober
         env:
@@ -77,7 +75,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3
+        image: quay.io/kubermatic/http-prober:v0.3.1-dev
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/api/pkg/resources/test/fixtures/deployment-digitalocean-1.11.1-machine-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-digitalocean-1.11.1-machine-controller.yaml
@@ -75,7 +75,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3.1-dev
+        image: quay.io/kubermatic/http-prober:v0.3.1-dev0
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/api/pkg/resources/test/fixtures/deployment-digitalocean-1.11.1-machine-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-digitalocean-1.11.1-machine-controller.yaml
@@ -75,7 +75,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3.1-dev0
+        image: quay.io/kubermatic/http-prober:v0.3.1
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/api/pkg/resources/test/fixtures/deployment-digitalocean-1.11.1-metrics-server.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-digitalocean-1.11.1-metrics-server.yaml
@@ -156,7 +156,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3
+        image: quay.io/kubermatic/http-prober:v0.3.1-dev
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/api/pkg/resources/test/fixtures/deployment-digitalocean-1.11.1-metrics-server.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-digitalocean-1.11.1-metrics-server.yaml
@@ -156,7 +156,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3.1-dev
+        image: quay.io/kubermatic/http-prober:v0.3.1-dev0
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/api/pkg/resources/test/fixtures/deployment-digitalocean-1.11.1-metrics-server.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-digitalocean-1.11.1-metrics-server.yaml
@@ -156,7 +156,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3.1-dev0
+        image: quay.io/kubermatic/http-prober:v0.3.1
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/api/pkg/resources/test/fixtures/deployment-digitalocean-1.11.1-scheduler.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-digitalocean-1.11.1-scheduler.yaml
@@ -163,7 +163,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3.1-dev
+        image: quay.io/kubermatic/http-prober:v0.3.1-dev0
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/api/pkg/resources/test/fixtures/deployment-digitalocean-1.11.1-scheduler.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-digitalocean-1.11.1-scheduler.yaml
@@ -163,7 +163,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3.1-dev0
+        image: quay.io/kubermatic/http-prober:v0.3.1
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/api/pkg/resources/test/fixtures/deployment-digitalocean-1.11.1-scheduler.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-digitalocean-1.11.1-scheduler.yaml
@@ -163,7 +163,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3
+        image: quay.io/kubermatic/http-prober:v0.3.1-dev
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/api/pkg/resources/test/fixtures/deployment-digitalocean-1.11.1-usercluster-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-digitalocean-1.11.1-usercluster-controller.yaml
@@ -85,7 +85,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3.1-dev0
+        image: quay.io/kubermatic/http-prober:v0.3.1
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/api/pkg/resources/test/fixtures/deployment-digitalocean-1.11.1-usercluster-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-digitalocean-1.11.1-usercluster-controller.yaml
@@ -85,7 +85,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3
+        image: quay.io/kubermatic/http-prober:v0.3.1-dev
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/api/pkg/resources/test/fixtures/deployment-digitalocean-1.11.1-usercluster-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-digitalocean-1.11.1-usercluster-controller.yaml
@@ -85,7 +85,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3.1-dev
+        image: quay.io/kubermatic/http-prober:v0.3.1-dev0
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/api/pkg/resources/test/fixtures/deployment-digitalocean-1.12.0-controller-manager.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-digitalocean-1.12.0-controller-manager.yaml
@@ -171,7 +171,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3.1-dev0
+        image: quay.io/kubermatic/http-prober:v0.3.1
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/api/pkg/resources/test/fixtures/deployment-digitalocean-1.12.0-controller-manager.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-digitalocean-1.12.0-controller-manager.yaml
@@ -171,7 +171,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3
+        image: quay.io/kubermatic/http-prober:v0.3.1-dev
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/api/pkg/resources/test/fixtures/deployment-digitalocean-1.12.0-controller-manager.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-digitalocean-1.12.0-controller-manager.yaml
@@ -171,7 +171,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3.1-dev
+        image: quay.io/kubermatic/http-prober:v0.3.1-dev0
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/api/pkg/resources/test/fixtures/deployment-digitalocean-1.12.0-kube-state-metrics.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-digitalocean-1.12.0-kube-state-metrics.yaml
@@ -72,7 +72,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3.1-dev0
+        image: quay.io/kubermatic/http-prober:v0.3.1
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/api/pkg/resources/test/fixtures/deployment-digitalocean-1.12.0-kube-state-metrics.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-digitalocean-1.12.0-kube-state-metrics.yaml
@@ -72,7 +72,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3
+        image: quay.io/kubermatic/http-prober:v0.3.1-dev
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/api/pkg/resources/test/fixtures/deployment-digitalocean-1.12.0-kube-state-metrics.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-digitalocean-1.12.0-kube-state-metrics.yaml
@@ -72,7 +72,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3.1-dev
+        image: quay.io/kubermatic/http-prober:v0.3.1-dev0
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/api/pkg/resources/test/fixtures/deployment-digitalocean-1.12.0-machine-controller-webhook.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-digitalocean-1.12.0-machine-controller-webhook.yaml
@@ -31,10 +31,8 @@ spec:
         - "1"
         - -command
         - '{"command":"/usr/local/bin/webhook","args":["-kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","-logtostderr","-v","4","-listen-address","0.0.0.0:9876"]}'
-        - -wait-for-crd-kind
-        - Machine
-        - -wait-for-crd-apiversion
-        - cluster.k8s.io/v1alpha1
+        - --crd-to-wait-for
+        - Machine,cluster.k8s.io/v1alpha1
         command:
         - /http-prober-bin/http-prober
         env:
@@ -86,7 +84,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3
+        image: quay.io/kubermatic/http-prober:v0.3.1-dev
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/api/pkg/resources/test/fixtures/deployment-digitalocean-1.12.0-machine-controller-webhook.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-digitalocean-1.12.0-machine-controller-webhook.yaml
@@ -84,7 +84,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3.1-dev
+        image: quay.io/kubermatic/http-prober:v0.3.1-dev0
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/api/pkg/resources/test/fixtures/deployment-digitalocean-1.12.0-machine-controller-webhook.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-digitalocean-1.12.0-machine-controller-webhook.yaml
@@ -84,7 +84,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3.1-dev0
+        image: quay.io/kubermatic/http-prober:v0.3.1
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/api/pkg/resources/test/fixtures/deployment-digitalocean-1.12.0-machine-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-digitalocean-1.12.0-machine-controller.yaml
@@ -34,10 +34,8 @@ spec:
         - "1"
         - -command
         - '{"command":"/usr/local/bin/machine-controller","args":["-kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","-logtostderr","-v","4","-cluster-dns","169.254.20.10","-internal-listen-address","0.0.0.0:8085"]}'
-        - -wait-for-crd-kind
-        - Machine
-        - -wait-for-crd-apiversion
-        - cluster.k8s.io/v1alpha1
+        - --crd-to-wait-for
+        - Machine,cluster.k8s.io/v1alpha1
         command:
         - /http-prober-bin/http-prober
         env:
@@ -77,7 +75,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3
+        image: quay.io/kubermatic/http-prober:v0.3.1-dev
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/api/pkg/resources/test/fixtures/deployment-digitalocean-1.12.0-machine-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-digitalocean-1.12.0-machine-controller.yaml
@@ -75,7 +75,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3.1-dev
+        image: quay.io/kubermatic/http-prober:v0.3.1-dev0
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/api/pkg/resources/test/fixtures/deployment-digitalocean-1.12.0-machine-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-digitalocean-1.12.0-machine-controller.yaml
@@ -75,7 +75,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3.1-dev0
+        image: quay.io/kubermatic/http-prober:v0.3.1
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/api/pkg/resources/test/fixtures/deployment-digitalocean-1.12.0-metrics-server.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-digitalocean-1.12.0-metrics-server.yaml
@@ -156,7 +156,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3
+        image: quay.io/kubermatic/http-prober:v0.3.1-dev
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/api/pkg/resources/test/fixtures/deployment-digitalocean-1.12.0-metrics-server.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-digitalocean-1.12.0-metrics-server.yaml
@@ -156,7 +156,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3.1-dev
+        image: quay.io/kubermatic/http-prober:v0.3.1-dev0
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/api/pkg/resources/test/fixtures/deployment-digitalocean-1.12.0-metrics-server.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-digitalocean-1.12.0-metrics-server.yaml
@@ -156,7 +156,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3.1-dev0
+        image: quay.io/kubermatic/http-prober:v0.3.1
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/api/pkg/resources/test/fixtures/deployment-digitalocean-1.12.0-scheduler.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-digitalocean-1.12.0-scheduler.yaml
@@ -163,7 +163,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3.1-dev
+        image: quay.io/kubermatic/http-prober:v0.3.1-dev0
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/api/pkg/resources/test/fixtures/deployment-digitalocean-1.12.0-scheduler.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-digitalocean-1.12.0-scheduler.yaml
@@ -163,7 +163,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3.1-dev0
+        image: quay.io/kubermatic/http-prober:v0.3.1
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/api/pkg/resources/test/fixtures/deployment-digitalocean-1.12.0-scheduler.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-digitalocean-1.12.0-scheduler.yaml
@@ -163,7 +163,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3
+        image: quay.io/kubermatic/http-prober:v0.3.1-dev
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/api/pkg/resources/test/fixtures/deployment-digitalocean-1.12.0-usercluster-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-digitalocean-1.12.0-usercluster-controller.yaml
@@ -85,7 +85,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3.1-dev0
+        image: quay.io/kubermatic/http-prober:v0.3.1
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/api/pkg/resources/test/fixtures/deployment-digitalocean-1.12.0-usercluster-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-digitalocean-1.12.0-usercluster-controller.yaml
@@ -85,7 +85,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3
+        image: quay.io/kubermatic/http-prober:v0.3.1-dev
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/api/pkg/resources/test/fixtures/deployment-digitalocean-1.12.0-usercluster-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-digitalocean-1.12.0-usercluster-controller.yaml
@@ -85,7 +85,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3.1-dev
+        image: quay.io/kubermatic/http-prober:v0.3.1-dev0
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/api/pkg/resources/test/fixtures/deployment-digitalocean-1.13.0-controller-manager.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-digitalocean-1.13.0-controller-manager.yaml
@@ -171,7 +171,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3.1-dev0
+        image: quay.io/kubermatic/http-prober:v0.3.1
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/api/pkg/resources/test/fixtures/deployment-digitalocean-1.13.0-controller-manager.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-digitalocean-1.13.0-controller-manager.yaml
@@ -171,7 +171,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3
+        image: quay.io/kubermatic/http-prober:v0.3.1-dev
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/api/pkg/resources/test/fixtures/deployment-digitalocean-1.13.0-controller-manager.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-digitalocean-1.13.0-controller-manager.yaml
@@ -171,7 +171,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3.1-dev
+        image: quay.io/kubermatic/http-prober:v0.3.1-dev0
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/api/pkg/resources/test/fixtures/deployment-digitalocean-1.13.0-kube-state-metrics.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-digitalocean-1.13.0-kube-state-metrics.yaml
@@ -72,7 +72,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3.1-dev0
+        image: quay.io/kubermatic/http-prober:v0.3.1
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/api/pkg/resources/test/fixtures/deployment-digitalocean-1.13.0-kube-state-metrics.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-digitalocean-1.13.0-kube-state-metrics.yaml
@@ -72,7 +72,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3
+        image: quay.io/kubermatic/http-prober:v0.3.1-dev
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/api/pkg/resources/test/fixtures/deployment-digitalocean-1.13.0-kube-state-metrics.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-digitalocean-1.13.0-kube-state-metrics.yaml
@@ -72,7 +72,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3.1-dev
+        image: quay.io/kubermatic/http-prober:v0.3.1-dev0
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/api/pkg/resources/test/fixtures/deployment-digitalocean-1.13.0-machine-controller-webhook.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-digitalocean-1.13.0-machine-controller-webhook.yaml
@@ -31,10 +31,8 @@ spec:
         - "1"
         - -command
         - '{"command":"/usr/local/bin/webhook","args":["-kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","-logtostderr","-v","4","-listen-address","0.0.0.0:9876"]}'
-        - -wait-for-crd-kind
-        - Machine
-        - -wait-for-crd-apiversion
-        - cluster.k8s.io/v1alpha1
+        - --crd-to-wait-for
+        - Machine,cluster.k8s.io/v1alpha1
         command:
         - /http-prober-bin/http-prober
         env:
@@ -86,7 +84,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3
+        image: quay.io/kubermatic/http-prober:v0.3.1-dev
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/api/pkg/resources/test/fixtures/deployment-digitalocean-1.13.0-machine-controller-webhook.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-digitalocean-1.13.0-machine-controller-webhook.yaml
@@ -84,7 +84,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3.1-dev
+        image: quay.io/kubermatic/http-prober:v0.3.1-dev0
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/api/pkg/resources/test/fixtures/deployment-digitalocean-1.13.0-machine-controller-webhook.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-digitalocean-1.13.0-machine-controller-webhook.yaml
@@ -84,7 +84,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3.1-dev0
+        image: quay.io/kubermatic/http-prober:v0.3.1
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/api/pkg/resources/test/fixtures/deployment-digitalocean-1.13.0-machine-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-digitalocean-1.13.0-machine-controller.yaml
@@ -34,10 +34,8 @@ spec:
         - "1"
         - -command
         - '{"command":"/usr/local/bin/machine-controller","args":["-kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","-logtostderr","-v","4","-cluster-dns","169.254.20.10","-internal-listen-address","0.0.0.0:8085"]}'
-        - -wait-for-crd-kind
-        - Machine
-        - -wait-for-crd-apiversion
-        - cluster.k8s.io/v1alpha1
+        - --crd-to-wait-for
+        - Machine,cluster.k8s.io/v1alpha1
         command:
         - /http-prober-bin/http-prober
         env:
@@ -77,7 +75,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3
+        image: quay.io/kubermatic/http-prober:v0.3.1-dev
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/api/pkg/resources/test/fixtures/deployment-digitalocean-1.13.0-machine-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-digitalocean-1.13.0-machine-controller.yaml
@@ -75,7 +75,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3.1-dev
+        image: quay.io/kubermatic/http-prober:v0.3.1-dev0
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/api/pkg/resources/test/fixtures/deployment-digitalocean-1.13.0-machine-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-digitalocean-1.13.0-machine-controller.yaml
@@ -75,7 +75,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3.1-dev0
+        image: quay.io/kubermatic/http-prober:v0.3.1
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/api/pkg/resources/test/fixtures/deployment-digitalocean-1.13.0-metrics-server.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-digitalocean-1.13.0-metrics-server.yaml
@@ -156,7 +156,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3
+        image: quay.io/kubermatic/http-prober:v0.3.1-dev
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/api/pkg/resources/test/fixtures/deployment-digitalocean-1.13.0-metrics-server.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-digitalocean-1.13.0-metrics-server.yaml
@@ -156,7 +156,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3.1-dev
+        image: quay.io/kubermatic/http-prober:v0.3.1-dev0
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/api/pkg/resources/test/fixtures/deployment-digitalocean-1.13.0-metrics-server.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-digitalocean-1.13.0-metrics-server.yaml
@@ -156,7 +156,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3.1-dev0
+        image: quay.io/kubermatic/http-prober:v0.3.1
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/api/pkg/resources/test/fixtures/deployment-digitalocean-1.13.0-scheduler.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-digitalocean-1.13.0-scheduler.yaml
@@ -163,7 +163,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3.1-dev
+        image: quay.io/kubermatic/http-prober:v0.3.1-dev0
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/api/pkg/resources/test/fixtures/deployment-digitalocean-1.13.0-scheduler.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-digitalocean-1.13.0-scheduler.yaml
@@ -163,7 +163,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3.1-dev0
+        image: quay.io/kubermatic/http-prober:v0.3.1
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/api/pkg/resources/test/fixtures/deployment-digitalocean-1.13.0-scheduler.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-digitalocean-1.13.0-scheduler.yaml
@@ -163,7 +163,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3
+        image: quay.io/kubermatic/http-prober:v0.3.1-dev
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/api/pkg/resources/test/fixtures/deployment-digitalocean-1.13.0-usercluster-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-digitalocean-1.13.0-usercluster-controller.yaml
@@ -85,7 +85,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3.1-dev0
+        image: quay.io/kubermatic/http-prober:v0.3.1
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/api/pkg/resources/test/fixtures/deployment-digitalocean-1.13.0-usercluster-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-digitalocean-1.13.0-usercluster-controller.yaml
@@ -85,7 +85,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3
+        image: quay.io/kubermatic/http-prober:v0.3.1-dev
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/api/pkg/resources/test/fixtures/deployment-digitalocean-1.13.0-usercluster-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-digitalocean-1.13.0-usercluster-controller.yaml
@@ -85,7 +85,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3.1-dev
+        image: quay.io/kubermatic/http-prober:v0.3.1-dev0
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/api/pkg/resources/test/fixtures/deployment-openstack-1.10.0-controller-manager.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-openstack-1.10.0-controller-manager.yaml
@@ -171,7 +171,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3.1-dev0
+        image: quay.io/kubermatic/http-prober:v0.3.1
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/api/pkg/resources/test/fixtures/deployment-openstack-1.10.0-controller-manager.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-openstack-1.10.0-controller-manager.yaml
@@ -171,7 +171,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3
+        image: quay.io/kubermatic/http-prober:v0.3.1-dev
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/api/pkg/resources/test/fixtures/deployment-openstack-1.10.0-controller-manager.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-openstack-1.10.0-controller-manager.yaml
@@ -171,7 +171,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3.1-dev
+        image: quay.io/kubermatic/http-prober:v0.3.1-dev0
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/api/pkg/resources/test/fixtures/deployment-openstack-1.10.0-kube-state-metrics.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-openstack-1.10.0-kube-state-metrics.yaml
@@ -72,7 +72,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3.1-dev0
+        image: quay.io/kubermatic/http-prober:v0.3.1
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/api/pkg/resources/test/fixtures/deployment-openstack-1.10.0-kube-state-metrics.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-openstack-1.10.0-kube-state-metrics.yaml
@@ -72,7 +72,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3
+        image: quay.io/kubermatic/http-prober:v0.3.1-dev
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/api/pkg/resources/test/fixtures/deployment-openstack-1.10.0-kube-state-metrics.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-openstack-1.10.0-kube-state-metrics.yaml
@@ -72,7 +72,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3.1-dev
+        image: quay.io/kubermatic/http-prober:v0.3.1-dev0
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/api/pkg/resources/test/fixtures/deployment-openstack-1.10.0-machine-controller-webhook.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-openstack-1.10.0-machine-controller-webhook.yaml
@@ -93,7 +93,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3.1-dev
+        image: quay.io/kubermatic/http-prober:v0.3.1-dev0
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/api/pkg/resources/test/fixtures/deployment-openstack-1.10.0-machine-controller-webhook.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-openstack-1.10.0-machine-controller-webhook.yaml
@@ -31,10 +31,8 @@ spec:
         - "1"
         - -command
         - '{"command":"/usr/local/bin/webhook","args":["-kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","-logtostderr","-v","4","-listen-address","0.0.0.0:9876"]}'
-        - -wait-for-crd-kind
-        - Machine
-        - -wait-for-crd-apiversion
-        - cluster.k8s.io/v1alpha1
+        - --crd-to-wait-for
+        - Machine,cluster.k8s.io/v1alpha1
         command:
         - /http-prober-bin/http-prober
         env:
@@ -95,7 +93,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3
+        image: quay.io/kubermatic/http-prober:v0.3.1-dev
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/api/pkg/resources/test/fixtures/deployment-openstack-1.10.0-machine-controller-webhook.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-openstack-1.10.0-machine-controller-webhook.yaml
@@ -93,7 +93,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3.1-dev0
+        image: quay.io/kubermatic/http-prober:v0.3.1
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/api/pkg/resources/test/fixtures/deployment-openstack-1.10.0-machine-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-openstack-1.10.0-machine-controller.yaml
@@ -84,7 +84,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3.1-dev
+        image: quay.io/kubermatic/http-prober:v0.3.1-dev0
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/api/pkg/resources/test/fixtures/deployment-openstack-1.10.0-machine-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-openstack-1.10.0-machine-controller.yaml
@@ -34,10 +34,8 @@ spec:
         - "1"
         - -command
         - '{"command":"/usr/local/bin/machine-controller","args":["-kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","-logtostderr","-v","4","-cluster-dns","169.254.20.10","-internal-listen-address","0.0.0.0:8085"]}'
-        - -wait-for-crd-kind
-        - Machine
-        - -wait-for-crd-apiversion
-        - cluster.k8s.io/v1alpha1
+        - --crd-to-wait-for
+        - Machine,cluster.k8s.io/v1alpha1
         command:
         - /http-prober-bin/http-prober
         env:
@@ -86,7 +84,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3
+        image: quay.io/kubermatic/http-prober:v0.3.1-dev
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/api/pkg/resources/test/fixtures/deployment-openstack-1.10.0-machine-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-openstack-1.10.0-machine-controller.yaml
@@ -84,7 +84,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3.1-dev0
+        image: quay.io/kubermatic/http-prober:v0.3.1
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/api/pkg/resources/test/fixtures/deployment-openstack-1.10.0-metrics-server.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-openstack-1.10.0-metrics-server.yaml
@@ -156,7 +156,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3
+        image: quay.io/kubermatic/http-prober:v0.3.1-dev
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/api/pkg/resources/test/fixtures/deployment-openstack-1.10.0-metrics-server.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-openstack-1.10.0-metrics-server.yaml
@@ -156,7 +156,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3.1-dev
+        image: quay.io/kubermatic/http-prober:v0.3.1-dev0
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/api/pkg/resources/test/fixtures/deployment-openstack-1.10.0-metrics-server.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-openstack-1.10.0-metrics-server.yaml
@@ -156,7 +156,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3.1-dev0
+        image: quay.io/kubermatic/http-prober:v0.3.1
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/api/pkg/resources/test/fixtures/deployment-openstack-1.10.0-scheduler.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-openstack-1.10.0-scheduler.yaml
@@ -163,7 +163,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3.1-dev
+        image: quay.io/kubermatic/http-prober:v0.3.1-dev0
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/api/pkg/resources/test/fixtures/deployment-openstack-1.10.0-scheduler.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-openstack-1.10.0-scheduler.yaml
@@ -163,7 +163,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3.1-dev0
+        image: quay.io/kubermatic/http-prober:v0.3.1
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/api/pkg/resources/test/fixtures/deployment-openstack-1.10.0-scheduler.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-openstack-1.10.0-scheduler.yaml
@@ -163,7 +163,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3
+        image: quay.io/kubermatic/http-prober:v0.3.1-dev
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/api/pkg/resources/test/fixtures/deployment-openstack-1.10.0-usercluster-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-openstack-1.10.0-usercluster-controller.yaml
@@ -85,7 +85,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3.1-dev0
+        image: quay.io/kubermatic/http-prober:v0.3.1
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/api/pkg/resources/test/fixtures/deployment-openstack-1.10.0-usercluster-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-openstack-1.10.0-usercluster-controller.yaml
@@ -85,7 +85,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3
+        image: quay.io/kubermatic/http-prober:v0.3.1-dev
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/api/pkg/resources/test/fixtures/deployment-openstack-1.10.0-usercluster-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-openstack-1.10.0-usercluster-controller.yaml
@@ -85,7 +85,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3.1-dev
+        image: quay.io/kubermatic/http-prober:v0.3.1-dev0
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/api/pkg/resources/test/fixtures/deployment-openstack-1.10.6-controller-manager.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-openstack-1.10.6-controller-manager.yaml
@@ -171,7 +171,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3.1-dev0
+        image: quay.io/kubermatic/http-prober:v0.3.1
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/api/pkg/resources/test/fixtures/deployment-openstack-1.10.6-controller-manager.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-openstack-1.10.6-controller-manager.yaml
@@ -171,7 +171,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3
+        image: quay.io/kubermatic/http-prober:v0.3.1-dev
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/api/pkg/resources/test/fixtures/deployment-openstack-1.10.6-controller-manager.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-openstack-1.10.6-controller-manager.yaml
@@ -171,7 +171,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3.1-dev
+        image: quay.io/kubermatic/http-prober:v0.3.1-dev0
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/api/pkg/resources/test/fixtures/deployment-openstack-1.10.6-kube-state-metrics.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-openstack-1.10.6-kube-state-metrics.yaml
@@ -72,7 +72,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3.1-dev0
+        image: quay.io/kubermatic/http-prober:v0.3.1
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/api/pkg/resources/test/fixtures/deployment-openstack-1.10.6-kube-state-metrics.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-openstack-1.10.6-kube-state-metrics.yaml
@@ -72,7 +72,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3
+        image: quay.io/kubermatic/http-prober:v0.3.1-dev
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/api/pkg/resources/test/fixtures/deployment-openstack-1.10.6-kube-state-metrics.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-openstack-1.10.6-kube-state-metrics.yaml
@@ -72,7 +72,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3.1-dev
+        image: quay.io/kubermatic/http-prober:v0.3.1-dev0
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/api/pkg/resources/test/fixtures/deployment-openstack-1.10.6-machine-controller-webhook.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-openstack-1.10.6-machine-controller-webhook.yaml
@@ -93,7 +93,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3.1-dev
+        image: quay.io/kubermatic/http-prober:v0.3.1-dev0
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/api/pkg/resources/test/fixtures/deployment-openstack-1.10.6-machine-controller-webhook.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-openstack-1.10.6-machine-controller-webhook.yaml
@@ -31,10 +31,8 @@ spec:
         - "1"
         - -command
         - '{"command":"/usr/local/bin/webhook","args":["-kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","-logtostderr","-v","4","-listen-address","0.0.0.0:9876"]}'
-        - -wait-for-crd-kind
-        - Machine
-        - -wait-for-crd-apiversion
-        - cluster.k8s.io/v1alpha1
+        - --crd-to-wait-for
+        - Machine,cluster.k8s.io/v1alpha1
         command:
         - /http-prober-bin/http-prober
         env:
@@ -95,7 +93,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3
+        image: quay.io/kubermatic/http-prober:v0.3.1-dev
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/api/pkg/resources/test/fixtures/deployment-openstack-1.10.6-machine-controller-webhook.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-openstack-1.10.6-machine-controller-webhook.yaml
@@ -93,7 +93,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3.1-dev0
+        image: quay.io/kubermatic/http-prober:v0.3.1
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/api/pkg/resources/test/fixtures/deployment-openstack-1.10.6-machine-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-openstack-1.10.6-machine-controller.yaml
@@ -84,7 +84,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3.1-dev
+        image: quay.io/kubermatic/http-prober:v0.3.1-dev0
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/api/pkg/resources/test/fixtures/deployment-openstack-1.10.6-machine-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-openstack-1.10.6-machine-controller.yaml
@@ -34,10 +34,8 @@ spec:
         - "1"
         - -command
         - '{"command":"/usr/local/bin/machine-controller","args":["-kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","-logtostderr","-v","4","-cluster-dns","169.254.20.10","-internal-listen-address","0.0.0.0:8085"]}'
-        - -wait-for-crd-kind
-        - Machine
-        - -wait-for-crd-apiversion
-        - cluster.k8s.io/v1alpha1
+        - --crd-to-wait-for
+        - Machine,cluster.k8s.io/v1alpha1
         command:
         - /http-prober-bin/http-prober
         env:
@@ -86,7 +84,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3
+        image: quay.io/kubermatic/http-prober:v0.3.1-dev
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/api/pkg/resources/test/fixtures/deployment-openstack-1.10.6-machine-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-openstack-1.10.6-machine-controller.yaml
@@ -84,7 +84,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3.1-dev0
+        image: quay.io/kubermatic/http-prober:v0.3.1
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/api/pkg/resources/test/fixtures/deployment-openstack-1.10.6-metrics-server.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-openstack-1.10.6-metrics-server.yaml
@@ -156,7 +156,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3
+        image: quay.io/kubermatic/http-prober:v0.3.1-dev
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/api/pkg/resources/test/fixtures/deployment-openstack-1.10.6-metrics-server.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-openstack-1.10.6-metrics-server.yaml
@@ -156,7 +156,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3.1-dev
+        image: quay.io/kubermatic/http-prober:v0.3.1-dev0
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/api/pkg/resources/test/fixtures/deployment-openstack-1.10.6-metrics-server.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-openstack-1.10.6-metrics-server.yaml
@@ -156,7 +156,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3.1-dev0
+        image: quay.io/kubermatic/http-prober:v0.3.1
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/api/pkg/resources/test/fixtures/deployment-openstack-1.10.6-scheduler.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-openstack-1.10.6-scheduler.yaml
@@ -163,7 +163,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3.1-dev
+        image: quay.io/kubermatic/http-prober:v0.3.1-dev0
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/api/pkg/resources/test/fixtures/deployment-openstack-1.10.6-scheduler.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-openstack-1.10.6-scheduler.yaml
@@ -163,7 +163,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3.1-dev0
+        image: quay.io/kubermatic/http-prober:v0.3.1
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/api/pkg/resources/test/fixtures/deployment-openstack-1.10.6-scheduler.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-openstack-1.10.6-scheduler.yaml
@@ -163,7 +163,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3
+        image: quay.io/kubermatic/http-prober:v0.3.1-dev
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/api/pkg/resources/test/fixtures/deployment-openstack-1.10.6-usercluster-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-openstack-1.10.6-usercluster-controller.yaml
@@ -85,7 +85,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3.1-dev0
+        image: quay.io/kubermatic/http-prober:v0.3.1
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/api/pkg/resources/test/fixtures/deployment-openstack-1.10.6-usercluster-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-openstack-1.10.6-usercluster-controller.yaml
@@ -85,7 +85,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3
+        image: quay.io/kubermatic/http-prober:v0.3.1-dev
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/api/pkg/resources/test/fixtures/deployment-openstack-1.10.6-usercluster-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-openstack-1.10.6-usercluster-controller.yaml
@@ -85,7 +85,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3.1-dev
+        image: quay.io/kubermatic/http-prober:v0.3.1-dev0
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/api/pkg/resources/test/fixtures/deployment-openstack-1.11.0-controller-manager.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-openstack-1.11.0-controller-manager.yaml
@@ -171,7 +171,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3.1-dev0
+        image: quay.io/kubermatic/http-prober:v0.3.1
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/api/pkg/resources/test/fixtures/deployment-openstack-1.11.0-controller-manager.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-openstack-1.11.0-controller-manager.yaml
@@ -171,7 +171,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3
+        image: quay.io/kubermatic/http-prober:v0.3.1-dev
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/api/pkg/resources/test/fixtures/deployment-openstack-1.11.0-controller-manager.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-openstack-1.11.0-controller-manager.yaml
@@ -171,7 +171,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3.1-dev
+        image: quay.io/kubermatic/http-prober:v0.3.1-dev0
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/api/pkg/resources/test/fixtures/deployment-openstack-1.11.0-kube-state-metrics.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-openstack-1.11.0-kube-state-metrics.yaml
@@ -72,7 +72,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3.1-dev0
+        image: quay.io/kubermatic/http-prober:v0.3.1
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/api/pkg/resources/test/fixtures/deployment-openstack-1.11.0-kube-state-metrics.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-openstack-1.11.0-kube-state-metrics.yaml
@@ -72,7 +72,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3
+        image: quay.io/kubermatic/http-prober:v0.3.1-dev
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/api/pkg/resources/test/fixtures/deployment-openstack-1.11.0-kube-state-metrics.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-openstack-1.11.0-kube-state-metrics.yaml
@@ -72,7 +72,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3.1-dev
+        image: quay.io/kubermatic/http-prober:v0.3.1-dev0
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/api/pkg/resources/test/fixtures/deployment-openstack-1.11.0-machine-controller-webhook.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-openstack-1.11.0-machine-controller-webhook.yaml
@@ -93,7 +93,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3.1-dev
+        image: quay.io/kubermatic/http-prober:v0.3.1-dev0
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/api/pkg/resources/test/fixtures/deployment-openstack-1.11.0-machine-controller-webhook.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-openstack-1.11.0-machine-controller-webhook.yaml
@@ -31,10 +31,8 @@ spec:
         - "1"
         - -command
         - '{"command":"/usr/local/bin/webhook","args":["-kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","-logtostderr","-v","4","-listen-address","0.0.0.0:9876"]}'
-        - -wait-for-crd-kind
-        - Machine
-        - -wait-for-crd-apiversion
-        - cluster.k8s.io/v1alpha1
+        - --crd-to-wait-for
+        - Machine,cluster.k8s.io/v1alpha1
         command:
         - /http-prober-bin/http-prober
         env:
@@ -95,7 +93,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3
+        image: quay.io/kubermatic/http-prober:v0.3.1-dev
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/api/pkg/resources/test/fixtures/deployment-openstack-1.11.0-machine-controller-webhook.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-openstack-1.11.0-machine-controller-webhook.yaml
@@ -93,7 +93,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3.1-dev0
+        image: quay.io/kubermatic/http-prober:v0.3.1
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/api/pkg/resources/test/fixtures/deployment-openstack-1.11.0-machine-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-openstack-1.11.0-machine-controller.yaml
@@ -84,7 +84,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3.1-dev
+        image: quay.io/kubermatic/http-prober:v0.3.1-dev0
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/api/pkg/resources/test/fixtures/deployment-openstack-1.11.0-machine-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-openstack-1.11.0-machine-controller.yaml
@@ -34,10 +34,8 @@ spec:
         - "1"
         - -command
         - '{"command":"/usr/local/bin/machine-controller","args":["-kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","-logtostderr","-v","4","-cluster-dns","169.254.20.10","-internal-listen-address","0.0.0.0:8085"]}'
-        - -wait-for-crd-kind
-        - Machine
-        - -wait-for-crd-apiversion
-        - cluster.k8s.io/v1alpha1
+        - --crd-to-wait-for
+        - Machine,cluster.k8s.io/v1alpha1
         command:
         - /http-prober-bin/http-prober
         env:
@@ -86,7 +84,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3
+        image: quay.io/kubermatic/http-prober:v0.3.1-dev
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/api/pkg/resources/test/fixtures/deployment-openstack-1.11.0-machine-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-openstack-1.11.0-machine-controller.yaml
@@ -84,7 +84,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3.1-dev0
+        image: quay.io/kubermatic/http-prober:v0.3.1
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/api/pkg/resources/test/fixtures/deployment-openstack-1.11.0-metrics-server.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-openstack-1.11.0-metrics-server.yaml
@@ -156,7 +156,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3
+        image: quay.io/kubermatic/http-prober:v0.3.1-dev
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/api/pkg/resources/test/fixtures/deployment-openstack-1.11.0-metrics-server.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-openstack-1.11.0-metrics-server.yaml
@@ -156,7 +156,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3.1-dev
+        image: quay.io/kubermatic/http-prober:v0.3.1-dev0
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/api/pkg/resources/test/fixtures/deployment-openstack-1.11.0-metrics-server.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-openstack-1.11.0-metrics-server.yaml
@@ -156,7 +156,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3.1-dev0
+        image: quay.io/kubermatic/http-prober:v0.3.1
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/api/pkg/resources/test/fixtures/deployment-openstack-1.11.0-scheduler.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-openstack-1.11.0-scheduler.yaml
@@ -163,7 +163,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3.1-dev
+        image: quay.io/kubermatic/http-prober:v0.3.1-dev0
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/api/pkg/resources/test/fixtures/deployment-openstack-1.11.0-scheduler.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-openstack-1.11.0-scheduler.yaml
@@ -163,7 +163,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3.1-dev0
+        image: quay.io/kubermatic/http-prober:v0.3.1
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/api/pkg/resources/test/fixtures/deployment-openstack-1.11.0-scheduler.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-openstack-1.11.0-scheduler.yaml
@@ -163,7 +163,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3
+        image: quay.io/kubermatic/http-prober:v0.3.1-dev
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/api/pkg/resources/test/fixtures/deployment-openstack-1.11.0-usercluster-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-openstack-1.11.0-usercluster-controller.yaml
@@ -85,7 +85,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3.1-dev0
+        image: quay.io/kubermatic/http-prober:v0.3.1
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/api/pkg/resources/test/fixtures/deployment-openstack-1.11.0-usercluster-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-openstack-1.11.0-usercluster-controller.yaml
@@ -85,7 +85,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3
+        image: quay.io/kubermatic/http-prober:v0.3.1-dev
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/api/pkg/resources/test/fixtures/deployment-openstack-1.11.0-usercluster-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-openstack-1.11.0-usercluster-controller.yaml
@@ -85,7 +85,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3.1-dev
+        image: quay.io/kubermatic/http-prober:v0.3.1-dev0
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/api/pkg/resources/test/fixtures/deployment-openstack-1.11.1-controller-manager.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-openstack-1.11.1-controller-manager.yaml
@@ -171,7 +171,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3.1-dev0
+        image: quay.io/kubermatic/http-prober:v0.3.1
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/api/pkg/resources/test/fixtures/deployment-openstack-1.11.1-controller-manager.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-openstack-1.11.1-controller-manager.yaml
@@ -171,7 +171,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3
+        image: quay.io/kubermatic/http-prober:v0.3.1-dev
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/api/pkg/resources/test/fixtures/deployment-openstack-1.11.1-controller-manager.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-openstack-1.11.1-controller-manager.yaml
@@ -171,7 +171,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3.1-dev
+        image: quay.io/kubermatic/http-prober:v0.3.1-dev0
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/api/pkg/resources/test/fixtures/deployment-openstack-1.11.1-kube-state-metrics.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-openstack-1.11.1-kube-state-metrics.yaml
@@ -72,7 +72,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3.1-dev0
+        image: quay.io/kubermatic/http-prober:v0.3.1
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/api/pkg/resources/test/fixtures/deployment-openstack-1.11.1-kube-state-metrics.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-openstack-1.11.1-kube-state-metrics.yaml
@@ -72,7 +72,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3
+        image: quay.io/kubermatic/http-prober:v0.3.1-dev
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/api/pkg/resources/test/fixtures/deployment-openstack-1.11.1-kube-state-metrics.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-openstack-1.11.1-kube-state-metrics.yaml
@@ -72,7 +72,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3.1-dev
+        image: quay.io/kubermatic/http-prober:v0.3.1-dev0
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/api/pkg/resources/test/fixtures/deployment-openstack-1.11.1-machine-controller-webhook.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-openstack-1.11.1-machine-controller-webhook.yaml
@@ -93,7 +93,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3.1-dev
+        image: quay.io/kubermatic/http-prober:v0.3.1-dev0
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/api/pkg/resources/test/fixtures/deployment-openstack-1.11.1-machine-controller-webhook.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-openstack-1.11.1-machine-controller-webhook.yaml
@@ -31,10 +31,8 @@ spec:
         - "1"
         - -command
         - '{"command":"/usr/local/bin/webhook","args":["-kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","-logtostderr","-v","4","-listen-address","0.0.0.0:9876"]}'
-        - -wait-for-crd-kind
-        - Machine
-        - -wait-for-crd-apiversion
-        - cluster.k8s.io/v1alpha1
+        - --crd-to-wait-for
+        - Machine,cluster.k8s.io/v1alpha1
         command:
         - /http-prober-bin/http-prober
         env:
@@ -95,7 +93,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3
+        image: quay.io/kubermatic/http-prober:v0.3.1-dev
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/api/pkg/resources/test/fixtures/deployment-openstack-1.11.1-machine-controller-webhook.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-openstack-1.11.1-machine-controller-webhook.yaml
@@ -93,7 +93,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3.1-dev0
+        image: quay.io/kubermatic/http-prober:v0.3.1
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/api/pkg/resources/test/fixtures/deployment-openstack-1.11.1-machine-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-openstack-1.11.1-machine-controller.yaml
@@ -84,7 +84,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3.1-dev
+        image: quay.io/kubermatic/http-prober:v0.3.1-dev0
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/api/pkg/resources/test/fixtures/deployment-openstack-1.11.1-machine-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-openstack-1.11.1-machine-controller.yaml
@@ -34,10 +34,8 @@ spec:
         - "1"
         - -command
         - '{"command":"/usr/local/bin/machine-controller","args":["-kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","-logtostderr","-v","4","-cluster-dns","169.254.20.10","-internal-listen-address","0.0.0.0:8085"]}'
-        - -wait-for-crd-kind
-        - Machine
-        - -wait-for-crd-apiversion
-        - cluster.k8s.io/v1alpha1
+        - --crd-to-wait-for
+        - Machine,cluster.k8s.io/v1alpha1
         command:
         - /http-prober-bin/http-prober
         env:
@@ -86,7 +84,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3
+        image: quay.io/kubermatic/http-prober:v0.3.1-dev
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/api/pkg/resources/test/fixtures/deployment-openstack-1.11.1-machine-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-openstack-1.11.1-machine-controller.yaml
@@ -84,7 +84,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3.1-dev0
+        image: quay.io/kubermatic/http-prober:v0.3.1
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/api/pkg/resources/test/fixtures/deployment-openstack-1.11.1-metrics-server.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-openstack-1.11.1-metrics-server.yaml
@@ -156,7 +156,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3
+        image: quay.io/kubermatic/http-prober:v0.3.1-dev
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/api/pkg/resources/test/fixtures/deployment-openstack-1.11.1-metrics-server.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-openstack-1.11.1-metrics-server.yaml
@@ -156,7 +156,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3.1-dev
+        image: quay.io/kubermatic/http-prober:v0.3.1-dev0
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/api/pkg/resources/test/fixtures/deployment-openstack-1.11.1-metrics-server.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-openstack-1.11.1-metrics-server.yaml
@@ -156,7 +156,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3.1-dev0
+        image: quay.io/kubermatic/http-prober:v0.3.1
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/api/pkg/resources/test/fixtures/deployment-openstack-1.11.1-scheduler.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-openstack-1.11.1-scheduler.yaml
@@ -163,7 +163,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3.1-dev
+        image: quay.io/kubermatic/http-prober:v0.3.1-dev0
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/api/pkg/resources/test/fixtures/deployment-openstack-1.11.1-scheduler.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-openstack-1.11.1-scheduler.yaml
@@ -163,7 +163,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3.1-dev0
+        image: quay.io/kubermatic/http-prober:v0.3.1
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/api/pkg/resources/test/fixtures/deployment-openstack-1.11.1-scheduler.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-openstack-1.11.1-scheduler.yaml
@@ -163,7 +163,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3
+        image: quay.io/kubermatic/http-prober:v0.3.1-dev
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/api/pkg/resources/test/fixtures/deployment-openstack-1.11.1-usercluster-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-openstack-1.11.1-usercluster-controller.yaml
@@ -85,7 +85,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3.1-dev0
+        image: quay.io/kubermatic/http-prober:v0.3.1
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/api/pkg/resources/test/fixtures/deployment-openstack-1.11.1-usercluster-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-openstack-1.11.1-usercluster-controller.yaml
@@ -85,7 +85,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3
+        image: quay.io/kubermatic/http-prober:v0.3.1-dev
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/api/pkg/resources/test/fixtures/deployment-openstack-1.11.1-usercluster-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-openstack-1.11.1-usercluster-controller.yaml
@@ -85,7 +85,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3.1-dev
+        image: quay.io/kubermatic/http-prober:v0.3.1-dev0
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/api/pkg/resources/test/fixtures/deployment-openstack-1.12.0-controller-manager.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-openstack-1.12.0-controller-manager.yaml
@@ -171,7 +171,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3.1-dev0
+        image: quay.io/kubermatic/http-prober:v0.3.1
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/api/pkg/resources/test/fixtures/deployment-openstack-1.12.0-controller-manager.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-openstack-1.12.0-controller-manager.yaml
@@ -171,7 +171,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3
+        image: quay.io/kubermatic/http-prober:v0.3.1-dev
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/api/pkg/resources/test/fixtures/deployment-openstack-1.12.0-controller-manager.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-openstack-1.12.0-controller-manager.yaml
@@ -171,7 +171,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3.1-dev
+        image: quay.io/kubermatic/http-prober:v0.3.1-dev0
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/api/pkg/resources/test/fixtures/deployment-openstack-1.12.0-kube-state-metrics.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-openstack-1.12.0-kube-state-metrics.yaml
@@ -72,7 +72,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3.1-dev0
+        image: quay.io/kubermatic/http-prober:v0.3.1
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/api/pkg/resources/test/fixtures/deployment-openstack-1.12.0-kube-state-metrics.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-openstack-1.12.0-kube-state-metrics.yaml
@@ -72,7 +72,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3
+        image: quay.io/kubermatic/http-prober:v0.3.1-dev
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/api/pkg/resources/test/fixtures/deployment-openstack-1.12.0-kube-state-metrics.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-openstack-1.12.0-kube-state-metrics.yaml
@@ -72,7 +72,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3.1-dev
+        image: quay.io/kubermatic/http-prober:v0.3.1-dev0
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/api/pkg/resources/test/fixtures/deployment-openstack-1.12.0-machine-controller-webhook.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-openstack-1.12.0-machine-controller-webhook.yaml
@@ -93,7 +93,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3.1-dev
+        image: quay.io/kubermatic/http-prober:v0.3.1-dev0
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/api/pkg/resources/test/fixtures/deployment-openstack-1.12.0-machine-controller-webhook.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-openstack-1.12.0-machine-controller-webhook.yaml
@@ -31,10 +31,8 @@ spec:
         - "1"
         - -command
         - '{"command":"/usr/local/bin/webhook","args":["-kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","-logtostderr","-v","4","-listen-address","0.0.0.0:9876"]}'
-        - -wait-for-crd-kind
-        - Machine
-        - -wait-for-crd-apiversion
-        - cluster.k8s.io/v1alpha1
+        - --crd-to-wait-for
+        - Machine,cluster.k8s.io/v1alpha1
         command:
         - /http-prober-bin/http-prober
         env:
@@ -95,7 +93,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3
+        image: quay.io/kubermatic/http-prober:v0.3.1-dev
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/api/pkg/resources/test/fixtures/deployment-openstack-1.12.0-machine-controller-webhook.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-openstack-1.12.0-machine-controller-webhook.yaml
@@ -93,7 +93,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3.1-dev0
+        image: quay.io/kubermatic/http-prober:v0.3.1
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/api/pkg/resources/test/fixtures/deployment-openstack-1.12.0-machine-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-openstack-1.12.0-machine-controller.yaml
@@ -84,7 +84,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3.1-dev
+        image: quay.io/kubermatic/http-prober:v0.3.1-dev0
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/api/pkg/resources/test/fixtures/deployment-openstack-1.12.0-machine-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-openstack-1.12.0-machine-controller.yaml
@@ -34,10 +34,8 @@ spec:
         - "1"
         - -command
         - '{"command":"/usr/local/bin/machine-controller","args":["-kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","-logtostderr","-v","4","-cluster-dns","169.254.20.10","-internal-listen-address","0.0.0.0:8085"]}'
-        - -wait-for-crd-kind
-        - Machine
-        - -wait-for-crd-apiversion
-        - cluster.k8s.io/v1alpha1
+        - --crd-to-wait-for
+        - Machine,cluster.k8s.io/v1alpha1
         command:
         - /http-prober-bin/http-prober
         env:
@@ -86,7 +84,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3
+        image: quay.io/kubermatic/http-prober:v0.3.1-dev
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/api/pkg/resources/test/fixtures/deployment-openstack-1.12.0-machine-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-openstack-1.12.0-machine-controller.yaml
@@ -84,7 +84,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3.1-dev0
+        image: quay.io/kubermatic/http-prober:v0.3.1
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/api/pkg/resources/test/fixtures/deployment-openstack-1.12.0-metrics-server.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-openstack-1.12.0-metrics-server.yaml
@@ -156,7 +156,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3
+        image: quay.io/kubermatic/http-prober:v0.3.1-dev
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/api/pkg/resources/test/fixtures/deployment-openstack-1.12.0-metrics-server.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-openstack-1.12.0-metrics-server.yaml
@@ -156,7 +156,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3.1-dev
+        image: quay.io/kubermatic/http-prober:v0.3.1-dev0
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/api/pkg/resources/test/fixtures/deployment-openstack-1.12.0-metrics-server.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-openstack-1.12.0-metrics-server.yaml
@@ -156,7 +156,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3.1-dev0
+        image: quay.io/kubermatic/http-prober:v0.3.1
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/api/pkg/resources/test/fixtures/deployment-openstack-1.12.0-scheduler.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-openstack-1.12.0-scheduler.yaml
@@ -163,7 +163,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3.1-dev
+        image: quay.io/kubermatic/http-prober:v0.3.1-dev0
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/api/pkg/resources/test/fixtures/deployment-openstack-1.12.0-scheduler.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-openstack-1.12.0-scheduler.yaml
@@ -163,7 +163,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3.1-dev0
+        image: quay.io/kubermatic/http-prober:v0.3.1
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/api/pkg/resources/test/fixtures/deployment-openstack-1.12.0-scheduler.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-openstack-1.12.0-scheduler.yaml
@@ -163,7 +163,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3
+        image: quay.io/kubermatic/http-prober:v0.3.1-dev
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/api/pkg/resources/test/fixtures/deployment-openstack-1.12.0-usercluster-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-openstack-1.12.0-usercluster-controller.yaml
@@ -85,7 +85,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3.1-dev0
+        image: quay.io/kubermatic/http-prober:v0.3.1
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/api/pkg/resources/test/fixtures/deployment-openstack-1.12.0-usercluster-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-openstack-1.12.0-usercluster-controller.yaml
@@ -85,7 +85,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3
+        image: quay.io/kubermatic/http-prober:v0.3.1-dev
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/api/pkg/resources/test/fixtures/deployment-openstack-1.12.0-usercluster-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-openstack-1.12.0-usercluster-controller.yaml
@@ -85,7 +85,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3.1-dev
+        image: quay.io/kubermatic/http-prober:v0.3.1-dev0
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/api/pkg/resources/test/fixtures/deployment-openstack-1.13.0-controller-manager.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-openstack-1.13.0-controller-manager.yaml
@@ -171,7 +171,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3.1-dev0
+        image: quay.io/kubermatic/http-prober:v0.3.1
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/api/pkg/resources/test/fixtures/deployment-openstack-1.13.0-controller-manager.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-openstack-1.13.0-controller-manager.yaml
@@ -171,7 +171,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3
+        image: quay.io/kubermatic/http-prober:v0.3.1-dev
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/api/pkg/resources/test/fixtures/deployment-openstack-1.13.0-controller-manager.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-openstack-1.13.0-controller-manager.yaml
@@ -171,7 +171,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3.1-dev
+        image: quay.io/kubermatic/http-prober:v0.3.1-dev0
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/api/pkg/resources/test/fixtures/deployment-openstack-1.13.0-kube-state-metrics.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-openstack-1.13.0-kube-state-metrics.yaml
@@ -72,7 +72,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3.1-dev0
+        image: quay.io/kubermatic/http-prober:v0.3.1
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/api/pkg/resources/test/fixtures/deployment-openstack-1.13.0-kube-state-metrics.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-openstack-1.13.0-kube-state-metrics.yaml
@@ -72,7 +72,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3
+        image: quay.io/kubermatic/http-prober:v0.3.1-dev
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/api/pkg/resources/test/fixtures/deployment-openstack-1.13.0-kube-state-metrics.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-openstack-1.13.0-kube-state-metrics.yaml
@@ -72,7 +72,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3.1-dev
+        image: quay.io/kubermatic/http-prober:v0.3.1-dev0
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/api/pkg/resources/test/fixtures/deployment-openstack-1.13.0-machine-controller-webhook.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-openstack-1.13.0-machine-controller-webhook.yaml
@@ -93,7 +93,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3.1-dev
+        image: quay.io/kubermatic/http-prober:v0.3.1-dev0
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/api/pkg/resources/test/fixtures/deployment-openstack-1.13.0-machine-controller-webhook.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-openstack-1.13.0-machine-controller-webhook.yaml
@@ -31,10 +31,8 @@ spec:
         - "1"
         - -command
         - '{"command":"/usr/local/bin/webhook","args":["-kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","-logtostderr","-v","4","-listen-address","0.0.0.0:9876"]}'
-        - -wait-for-crd-kind
-        - Machine
-        - -wait-for-crd-apiversion
-        - cluster.k8s.io/v1alpha1
+        - --crd-to-wait-for
+        - Machine,cluster.k8s.io/v1alpha1
         command:
         - /http-prober-bin/http-prober
         env:
@@ -95,7 +93,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3
+        image: quay.io/kubermatic/http-prober:v0.3.1-dev
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/api/pkg/resources/test/fixtures/deployment-openstack-1.13.0-machine-controller-webhook.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-openstack-1.13.0-machine-controller-webhook.yaml
@@ -93,7 +93,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3.1-dev0
+        image: quay.io/kubermatic/http-prober:v0.3.1
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/api/pkg/resources/test/fixtures/deployment-openstack-1.13.0-machine-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-openstack-1.13.0-machine-controller.yaml
@@ -84,7 +84,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3.1-dev
+        image: quay.io/kubermatic/http-prober:v0.3.1-dev0
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/api/pkg/resources/test/fixtures/deployment-openstack-1.13.0-machine-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-openstack-1.13.0-machine-controller.yaml
@@ -34,10 +34,8 @@ spec:
         - "1"
         - -command
         - '{"command":"/usr/local/bin/machine-controller","args":["-kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","-logtostderr","-v","4","-cluster-dns","169.254.20.10","-internal-listen-address","0.0.0.0:8085"]}'
-        - -wait-for-crd-kind
-        - Machine
-        - -wait-for-crd-apiversion
-        - cluster.k8s.io/v1alpha1
+        - --crd-to-wait-for
+        - Machine,cluster.k8s.io/v1alpha1
         command:
         - /http-prober-bin/http-prober
         env:
@@ -86,7 +84,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3
+        image: quay.io/kubermatic/http-prober:v0.3.1-dev
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/api/pkg/resources/test/fixtures/deployment-openstack-1.13.0-machine-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-openstack-1.13.0-machine-controller.yaml
@@ -84,7 +84,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3.1-dev0
+        image: quay.io/kubermatic/http-prober:v0.3.1
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/api/pkg/resources/test/fixtures/deployment-openstack-1.13.0-metrics-server.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-openstack-1.13.0-metrics-server.yaml
@@ -156,7 +156,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3
+        image: quay.io/kubermatic/http-prober:v0.3.1-dev
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/api/pkg/resources/test/fixtures/deployment-openstack-1.13.0-metrics-server.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-openstack-1.13.0-metrics-server.yaml
@@ -156,7 +156,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3.1-dev
+        image: quay.io/kubermatic/http-prober:v0.3.1-dev0
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/api/pkg/resources/test/fixtures/deployment-openstack-1.13.0-metrics-server.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-openstack-1.13.0-metrics-server.yaml
@@ -156,7 +156,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3.1-dev0
+        image: quay.io/kubermatic/http-prober:v0.3.1
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/api/pkg/resources/test/fixtures/deployment-openstack-1.13.0-scheduler.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-openstack-1.13.0-scheduler.yaml
@@ -163,7 +163,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3.1-dev
+        image: quay.io/kubermatic/http-prober:v0.3.1-dev0
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/api/pkg/resources/test/fixtures/deployment-openstack-1.13.0-scheduler.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-openstack-1.13.0-scheduler.yaml
@@ -163,7 +163,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3.1-dev0
+        image: quay.io/kubermatic/http-prober:v0.3.1
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/api/pkg/resources/test/fixtures/deployment-openstack-1.13.0-scheduler.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-openstack-1.13.0-scheduler.yaml
@@ -163,7 +163,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3
+        image: quay.io/kubermatic/http-prober:v0.3.1-dev
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/api/pkg/resources/test/fixtures/deployment-openstack-1.13.0-usercluster-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-openstack-1.13.0-usercluster-controller.yaml
@@ -85,7 +85,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3.1-dev0
+        image: quay.io/kubermatic/http-prober:v0.3.1
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/api/pkg/resources/test/fixtures/deployment-openstack-1.13.0-usercluster-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-openstack-1.13.0-usercluster-controller.yaml
@@ -85,7 +85,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3
+        image: quay.io/kubermatic/http-prober:v0.3.1-dev
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/api/pkg/resources/test/fixtures/deployment-openstack-1.13.0-usercluster-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-openstack-1.13.0-usercluster-controller.yaml
@@ -85,7 +85,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3.1-dev
+        image: quay.io/kubermatic/http-prober:v0.3.1-dev0
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/api/pkg/resources/test/fixtures/deployment-vsphere-1.10.0-controller-manager.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-vsphere-1.10.0-controller-manager.yaml
@@ -175,7 +175,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3.1-dev
+        image: quay.io/kubermatic/http-prober:v0.3.1-dev0
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/api/pkg/resources/test/fixtures/deployment-vsphere-1.10.0-controller-manager.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-vsphere-1.10.0-controller-manager.yaml
@@ -175,7 +175,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3.1-dev0
+        image: quay.io/kubermatic/http-prober:v0.3.1
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/api/pkg/resources/test/fixtures/deployment-vsphere-1.10.0-controller-manager.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-vsphere-1.10.0-controller-manager.yaml
@@ -175,7 +175,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3
+        image: quay.io/kubermatic/http-prober:v0.3.1-dev
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/api/pkg/resources/test/fixtures/deployment-vsphere-1.10.0-kube-state-metrics.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-vsphere-1.10.0-kube-state-metrics.yaml
@@ -72,7 +72,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3.1-dev0
+        image: quay.io/kubermatic/http-prober:v0.3.1
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/api/pkg/resources/test/fixtures/deployment-vsphere-1.10.0-kube-state-metrics.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-vsphere-1.10.0-kube-state-metrics.yaml
@@ -72,7 +72,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3
+        image: quay.io/kubermatic/http-prober:v0.3.1-dev
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/api/pkg/resources/test/fixtures/deployment-vsphere-1.10.0-kube-state-metrics.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-vsphere-1.10.0-kube-state-metrics.yaml
@@ -72,7 +72,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3.1-dev
+        image: quay.io/kubermatic/http-prober:v0.3.1-dev0
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/api/pkg/resources/test/fixtures/deployment-vsphere-1.10.0-machine-controller-webhook.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-vsphere-1.10.0-machine-controller-webhook.yaml
@@ -86,7 +86,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3.1-dev
+        image: quay.io/kubermatic/http-prober:v0.3.1-dev0
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/api/pkg/resources/test/fixtures/deployment-vsphere-1.10.0-machine-controller-webhook.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-vsphere-1.10.0-machine-controller-webhook.yaml
@@ -31,10 +31,8 @@ spec:
         - "1"
         - -command
         - '{"command":"/usr/local/bin/webhook","args":["-kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","-logtostderr","-v","4","-listen-address","0.0.0.0:9876"]}'
-        - -wait-for-crd-kind
-        - Machine
-        - -wait-for-crd-apiversion
-        - cluster.k8s.io/v1alpha1
+        - --crd-to-wait-for
+        - Machine,cluster.k8s.io/v1alpha1
         command:
         - /http-prober-bin/http-prober
         env:
@@ -88,7 +86,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3
+        image: quay.io/kubermatic/http-prober:v0.3.1-dev
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/api/pkg/resources/test/fixtures/deployment-vsphere-1.10.0-machine-controller-webhook.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-vsphere-1.10.0-machine-controller-webhook.yaml
@@ -86,7 +86,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3.1-dev0
+        image: quay.io/kubermatic/http-prober:v0.3.1
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/api/pkg/resources/test/fixtures/deployment-vsphere-1.10.0-machine-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-vsphere-1.10.0-machine-controller.yaml
@@ -77,7 +77,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3.1-dev
+        image: quay.io/kubermatic/http-prober:v0.3.1-dev0
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/api/pkg/resources/test/fixtures/deployment-vsphere-1.10.0-machine-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-vsphere-1.10.0-machine-controller.yaml
@@ -34,10 +34,8 @@ spec:
         - "1"
         - -command
         - '{"command":"/usr/local/bin/machine-controller","args":["-kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","-logtostderr","-v","4","-cluster-dns","169.254.20.10","-internal-listen-address","0.0.0.0:8085"]}'
-        - -wait-for-crd-kind
-        - Machine
-        - -wait-for-crd-apiversion
-        - cluster.k8s.io/v1alpha1
+        - --crd-to-wait-for
+        - Machine,cluster.k8s.io/v1alpha1
         command:
         - /http-prober-bin/http-prober
         env:
@@ -79,7 +77,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3
+        image: quay.io/kubermatic/http-prober:v0.3.1-dev
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/api/pkg/resources/test/fixtures/deployment-vsphere-1.10.0-machine-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-vsphere-1.10.0-machine-controller.yaml
@@ -77,7 +77,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3.1-dev0
+        image: quay.io/kubermatic/http-prober:v0.3.1
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/api/pkg/resources/test/fixtures/deployment-vsphere-1.10.0-metrics-server.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-vsphere-1.10.0-metrics-server.yaml
@@ -156,7 +156,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3
+        image: quay.io/kubermatic/http-prober:v0.3.1-dev
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/api/pkg/resources/test/fixtures/deployment-vsphere-1.10.0-metrics-server.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-vsphere-1.10.0-metrics-server.yaml
@@ -156,7 +156,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3.1-dev
+        image: quay.io/kubermatic/http-prober:v0.3.1-dev0
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/api/pkg/resources/test/fixtures/deployment-vsphere-1.10.0-metrics-server.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-vsphere-1.10.0-metrics-server.yaml
@@ -156,7 +156,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3.1-dev0
+        image: quay.io/kubermatic/http-prober:v0.3.1
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/api/pkg/resources/test/fixtures/deployment-vsphere-1.10.0-scheduler.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-vsphere-1.10.0-scheduler.yaml
@@ -163,7 +163,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3.1-dev
+        image: quay.io/kubermatic/http-prober:v0.3.1-dev0
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/api/pkg/resources/test/fixtures/deployment-vsphere-1.10.0-scheduler.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-vsphere-1.10.0-scheduler.yaml
@@ -163,7 +163,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3.1-dev0
+        image: quay.io/kubermatic/http-prober:v0.3.1
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/api/pkg/resources/test/fixtures/deployment-vsphere-1.10.0-scheduler.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-vsphere-1.10.0-scheduler.yaml
@@ -163,7 +163,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3
+        image: quay.io/kubermatic/http-prober:v0.3.1-dev
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/api/pkg/resources/test/fixtures/deployment-vsphere-1.10.0-usercluster-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-vsphere-1.10.0-usercluster-controller.yaml
@@ -85,7 +85,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3.1-dev0
+        image: quay.io/kubermatic/http-prober:v0.3.1
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/api/pkg/resources/test/fixtures/deployment-vsphere-1.10.0-usercluster-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-vsphere-1.10.0-usercluster-controller.yaml
@@ -85,7 +85,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3
+        image: quay.io/kubermatic/http-prober:v0.3.1-dev
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/api/pkg/resources/test/fixtures/deployment-vsphere-1.10.0-usercluster-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-vsphere-1.10.0-usercluster-controller.yaml
@@ -85,7 +85,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3.1-dev
+        image: quay.io/kubermatic/http-prober:v0.3.1-dev0
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/api/pkg/resources/test/fixtures/deployment-vsphere-1.10.6-controller-manager.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-vsphere-1.10.6-controller-manager.yaml
@@ -175,7 +175,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3.1-dev
+        image: quay.io/kubermatic/http-prober:v0.3.1-dev0
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/api/pkg/resources/test/fixtures/deployment-vsphere-1.10.6-controller-manager.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-vsphere-1.10.6-controller-manager.yaml
@@ -175,7 +175,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3.1-dev0
+        image: quay.io/kubermatic/http-prober:v0.3.1
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/api/pkg/resources/test/fixtures/deployment-vsphere-1.10.6-controller-manager.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-vsphere-1.10.6-controller-manager.yaml
@@ -175,7 +175,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3
+        image: quay.io/kubermatic/http-prober:v0.3.1-dev
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/api/pkg/resources/test/fixtures/deployment-vsphere-1.10.6-kube-state-metrics.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-vsphere-1.10.6-kube-state-metrics.yaml
@@ -72,7 +72,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3.1-dev0
+        image: quay.io/kubermatic/http-prober:v0.3.1
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/api/pkg/resources/test/fixtures/deployment-vsphere-1.10.6-kube-state-metrics.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-vsphere-1.10.6-kube-state-metrics.yaml
@@ -72,7 +72,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3
+        image: quay.io/kubermatic/http-prober:v0.3.1-dev
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/api/pkg/resources/test/fixtures/deployment-vsphere-1.10.6-kube-state-metrics.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-vsphere-1.10.6-kube-state-metrics.yaml
@@ -72,7 +72,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3.1-dev
+        image: quay.io/kubermatic/http-prober:v0.3.1-dev0
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/api/pkg/resources/test/fixtures/deployment-vsphere-1.10.6-machine-controller-webhook.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-vsphere-1.10.6-machine-controller-webhook.yaml
@@ -86,7 +86,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3.1-dev
+        image: quay.io/kubermatic/http-prober:v0.3.1-dev0
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/api/pkg/resources/test/fixtures/deployment-vsphere-1.10.6-machine-controller-webhook.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-vsphere-1.10.6-machine-controller-webhook.yaml
@@ -31,10 +31,8 @@ spec:
         - "1"
         - -command
         - '{"command":"/usr/local/bin/webhook","args":["-kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","-logtostderr","-v","4","-listen-address","0.0.0.0:9876"]}'
-        - -wait-for-crd-kind
-        - Machine
-        - -wait-for-crd-apiversion
-        - cluster.k8s.io/v1alpha1
+        - --crd-to-wait-for
+        - Machine,cluster.k8s.io/v1alpha1
         command:
         - /http-prober-bin/http-prober
         env:
@@ -88,7 +86,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3
+        image: quay.io/kubermatic/http-prober:v0.3.1-dev
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/api/pkg/resources/test/fixtures/deployment-vsphere-1.10.6-machine-controller-webhook.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-vsphere-1.10.6-machine-controller-webhook.yaml
@@ -86,7 +86,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3.1-dev0
+        image: quay.io/kubermatic/http-prober:v0.3.1
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/api/pkg/resources/test/fixtures/deployment-vsphere-1.10.6-machine-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-vsphere-1.10.6-machine-controller.yaml
@@ -77,7 +77,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3.1-dev
+        image: quay.io/kubermatic/http-prober:v0.3.1-dev0
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/api/pkg/resources/test/fixtures/deployment-vsphere-1.10.6-machine-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-vsphere-1.10.6-machine-controller.yaml
@@ -34,10 +34,8 @@ spec:
         - "1"
         - -command
         - '{"command":"/usr/local/bin/machine-controller","args":["-kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","-logtostderr","-v","4","-cluster-dns","169.254.20.10","-internal-listen-address","0.0.0.0:8085"]}'
-        - -wait-for-crd-kind
-        - Machine
-        - -wait-for-crd-apiversion
-        - cluster.k8s.io/v1alpha1
+        - --crd-to-wait-for
+        - Machine,cluster.k8s.io/v1alpha1
         command:
         - /http-prober-bin/http-prober
         env:
@@ -79,7 +77,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3
+        image: quay.io/kubermatic/http-prober:v0.3.1-dev
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/api/pkg/resources/test/fixtures/deployment-vsphere-1.10.6-machine-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-vsphere-1.10.6-machine-controller.yaml
@@ -77,7 +77,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3.1-dev0
+        image: quay.io/kubermatic/http-prober:v0.3.1
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/api/pkg/resources/test/fixtures/deployment-vsphere-1.10.6-metrics-server.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-vsphere-1.10.6-metrics-server.yaml
@@ -156,7 +156,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3
+        image: quay.io/kubermatic/http-prober:v0.3.1-dev
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/api/pkg/resources/test/fixtures/deployment-vsphere-1.10.6-metrics-server.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-vsphere-1.10.6-metrics-server.yaml
@@ -156,7 +156,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3.1-dev
+        image: quay.io/kubermatic/http-prober:v0.3.1-dev0
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/api/pkg/resources/test/fixtures/deployment-vsphere-1.10.6-metrics-server.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-vsphere-1.10.6-metrics-server.yaml
@@ -156,7 +156,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3.1-dev0
+        image: quay.io/kubermatic/http-prober:v0.3.1
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/api/pkg/resources/test/fixtures/deployment-vsphere-1.10.6-scheduler.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-vsphere-1.10.6-scheduler.yaml
@@ -163,7 +163,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3.1-dev
+        image: quay.io/kubermatic/http-prober:v0.3.1-dev0
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/api/pkg/resources/test/fixtures/deployment-vsphere-1.10.6-scheduler.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-vsphere-1.10.6-scheduler.yaml
@@ -163,7 +163,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3.1-dev0
+        image: quay.io/kubermatic/http-prober:v0.3.1
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/api/pkg/resources/test/fixtures/deployment-vsphere-1.10.6-scheduler.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-vsphere-1.10.6-scheduler.yaml
@@ -163,7 +163,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3
+        image: quay.io/kubermatic/http-prober:v0.3.1-dev
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/api/pkg/resources/test/fixtures/deployment-vsphere-1.10.6-usercluster-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-vsphere-1.10.6-usercluster-controller.yaml
@@ -85,7 +85,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3.1-dev0
+        image: quay.io/kubermatic/http-prober:v0.3.1
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/api/pkg/resources/test/fixtures/deployment-vsphere-1.10.6-usercluster-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-vsphere-1.10.6-usercluster-controller.yaml
@@ -85,7 +85,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3
+        image: quay.io/kubermatic/http-prober:v0.3.1-dev
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/api/pkg/resources/test/fixtures/deployment-vsphere-1.10.6-usercluster-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-vsphere-1.10.6-usercluster-controller.yaml
@@ -85,7 +85,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3.1-dev
+        image: quay.io/kubermatic/http-prober:v0.3.1-dev0
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/api/pkg/resources/test/fixtures/deployment-vsphere-1.11.0-controller-manager.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-vsphere-1.11.0-controller-manager.yaml
@@ -175,7 +175,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3.1-dev
+        image: quay.io/kubermatic/http-prober:v0.3.1-dev0
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/api/pkg/resources/test/fixtures/deployment-vsphere-1.11.0-controller-manager.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-vsphere-1.11.0-controller-manager.yaml
@@ -175,7 +175,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3.1-dev0
+        image: quay.io/kubermatic/http-prober:v0.3.1
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/api/pkg/resources/test/fixtures/deployment-vsphere-1.11.0-controller-manager.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-vsphere-1.11.0-controller-manager.yaml
@@ -175,7 +175,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3
+        image: quay.io/kubermatic/http-prober:v0.3.1-dev
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/api/pkg/resources/test/fixtures/deployment-vsphere-1.11.0-kube-state-metrics.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-vsphere-1.11.0-kube-state-metrics.yaml
@@ -72,7 +72,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3.1-dev0
+        image: quay.io/kubermatic/http-prober:v0.3.1
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/api/pkg/resources/test/fixtures/deployment-vsphere-1.11.0-kube-state-metrics.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-vsphere-1.11.0-kube-state-metrics.yaml
@@ -72,7 +72,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3
+        image: quay.io/kubermatic/http-prober:v0.3.1-dev
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/api/pkg/resources/test/fixtures/deployment-vsphere-1.11.0-kube-state-metrics.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-vsphere-1.11.0-kube-state-metrics.yaml
@@ -72,7 +72,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3.1-dev
+        image: quay.io/kubermatic/http-prober:v0.3.1-dev0
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/api/pkg/resources/test/fixtures/deployment-vsphere-1.11.0-machine-controller-webhook.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-vsphere-1.11.0-machine-controller-webhook.yaml
@@ -86,7 +86,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3.1-dev
+        image: quay.io/kubermatic/http-prober:v0.3.1-dev0
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/api/pkg/resources/test/fixtures/deployment-vsphere-1.11.0-machine-controller-webhook.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-vsphere-1.11.0-machine-controller-webhook.yaml
@@ -31,10 +31,8 @@ spec:
         - "1"
         - -command
         - '{"command":"/usr/local/bin/webhook","args":["-kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","-logtostderr","-v","4","-listen-address","0.0.0.0:9876"]}'
-        - -wait-for-crd-kind
-        - Machine
-        - -wait-for-crd-apiversion
-        - cluster.k8s.io/v1alpha1
+        - --crd-to-wait-for
+        - Machine,cluster.k8s.io/v1alpha1
         command:
         - /http-prober-bin/http-prober
         env:
@@ -88,7 +86,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3
+        image: quay.io/kubermatic/http-prober:v0.3.1-dev
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/api/pkg/resources/test/fixtures/deployment-vsphere-1.11.0-machine-controller-webhook.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-vsphere-1.11.0-machine-controller-webhook.yaml
@@ -86,7 +86,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3.1-dev0
+        image: quay.io/kubermatic/http-prober:v0.3.1
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/api/pkg/resources/test/fixtures/deployment-vsphere-1.11.0-machine-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-vsphere-1.11.0-machine-controller.yaml
@@ -77,7 +77,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3.1-dev
+        image: quay.io/kubermatic/http-prober:v0.3.1-dev0
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/api/pkg/resources/test/fixtures/deployment-vsphere-1.11.0-machine-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-vsphere-1.11.0-machine-controller.yaml
@@ -34,10 +34,8 @@ spec:
         - "1"
         - -command
         - '{"command":"/usr/local/bin/machine-controller","args":["-kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","-logtostderr","-v","4","-cluster-dns","169.254.20.10","-internal-listen-address","0.0.0.0:8085"]}'
-        - -wait-for-crd-kind
-        - Machine
-        - -wait-for-crd-apiversion
-        - cluster.k8s.io/v1alpha1
+        - --crd-to-wait-for
+        - Machine,cluster.k8s.io/v1alpha1
         command:
         - /http-prober-bin/http-prober
         env:
@@ -79,7 +77,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3
+        image: quay.io/kubermatic/http-prober:v0.3.1-dev
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/api/pkg/resources/test/fixtures/deployment-vsphere-1.11.0-machine-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-vsphere-1.11.0-machine-controller.yaml
@@ -77,7 +77,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3.1-dev0
+        image: quay.io/kubermatic/http-prober:v0.3.1
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/api/pkg/resources/test/fixtures/deployment-vsphere-1.11.0-metrics-server.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-vsphere-1.11.0-metrics-server.yaml
@@ -156,7 +156,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3
+        image: quay.io/kubermatic/http-prober:v0.3.1-dev
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/api/pkg/resources/test/fixtures/deployment-vsphere-1.11.0-metrics-server.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-vsphere-1.11.0-metrics-server.yaml
@@ -156,7 +156,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3.1-dev
+        image: quay.io/kubermatic/http-prober:v0.3.1-dev0
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/api/pkg/resources/test/fixtures/deployment-vsphere-1.11.0-metrics-server.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-vsphere-1.11.0-metrics-server.yaml
@@ -156,7 +156,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3.1-dev0
+        image: quay.io/kubermatic/http-prober:v0.3.1
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/api/pkg/resources/test/fixtures/deployment-vsphere-1.11.0-scheduler.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-vsphere-1.11.0-scheduler.yaml
@@ -163,7 +163,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3.1-dev
+        image: quay.io/kubermatic/http-prober:v0.3.1-dev0
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/api/pkg/resources/test/fixtures/deployment-vsphere-1.11.0-scheduler.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-vsphere-1.11.0-scheduler.yaml
@@ -163,7 +163,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3.1-dev0
+        image: quay.io/kubermatic/http-prober:v0.3.1
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/api/pkg/resources/test/fixtures/deployment-vsphere-1.11.0-scheduler.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-vsphere-1.11.0-scheduler.yaml
@@ -163,7 +163,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3
+        image: quay.io/kubermatic/http-prober:v0.3.1-dev
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/api/pkg/resources/test/fixtures/deployment-vsphere-1.11.0-usercluster-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-vsphere-1.11.0-usercluster-controller.yaml
@@ -85,7 +85,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3.1-dev0
+        image: quay.io/kubermatic/http-prober:v0.3.1
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/api/pkg/resources/test/fixtures/deployment-vsphere-1.11.0-usercluster-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-vsphere-1.11.0-usercluster-controller.yaml
@@ -85,7 +85,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3
+        image: quay.io/kubermatic/http-prober:v0.3.1-dev
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/api/pkg/resources/test/fixtures/deployment-vsphere-1.11.0-usercluster-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-vsphere-1.11.0-usercluster-controller.yaml
@@ -85,7 +85,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3.1-dev
+        image: quay.io/kubermatic/http-prober:v0.3.1-dev0
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/api/pkg/resources/test/fixtures/deployment-vsphere-1.11.1-controller-manager.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-vsphere-1.11.1-controller-manager.yaml
@@ -175,7 +175,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3.1-dev
+        image: quay.io/kubermatic/http-prober:v0.3.1-dev0
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/api/pkg/resources/test/fixtures/deployment-vsphere-1.11.1-controller-manager.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-vsphere-1.11.1-controller-manager.yaml
@@ -175,7 +175,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3.1-dev0
+        image: quay.io/kubermatic/http-prober:v0.3.1
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/api/pkg/resources/test/fixtures/deployment-vsphere-1.11.1-controller-manager.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-vsphere-1.11.1-controller-manager.yaml
@@ -175,7 +175,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3
+        image: quay.io/kubermatic/http-prober:v0.3.1-dev
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/api/pkg/resources/test/fixtures/deployment-vsphere-1.11.1-kube-state-metrics.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-vsphere-1.11.1-kube-state-metrics.yaml
@@ -72,7 +72,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3.1-dev0
+        image: quay.io/kubermatic/http-prober:v0.3.1
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/api/pkg/resources/test/fixtures/deployment-vsphere-1.11.1-kube-state-metrics.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-vsphere-1.11.1-kube-state-metrics.yaml
@@ -72,7 +72,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3
+        image: quay.io/kubermatic/http-prober:v0.3.1-dev
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/api/pkg/resources/test/fixtures/deployment-vsphere-1.11.1-kube-state-metrics.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-vsphere-1.11.1-kube-state-metrics.yaml
@@ -72,7 +72,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3.1-dev
+        image: quay.io/kubermatic/http-prober:v0.3.1-dev0
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/api/pkg/resources/test/fixtures/deployment-vsphere-1.11.1-machine-controller-webhook.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-vsphere-1.11.1-machine-controller-webhook.yaml
@@ -86,7 +86,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3.1-dev
+        image: quay.io/kubermatic/http-prober:v0.3.1-dev0
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/api/pkg/resources/test/fixtures/deployment-vsphere-1.11.1-machine-controller-webhook.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-vsphere-1.11.1-machine-controller-webhook.yaml
@@ -31,10 +31,8 @@ spec:
         - "1"
         - -command
         - '{"command":"/usr/local/bin/webhook","args":["-kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","-logtostderr","-v","4","-listen-address","0.0.0.0:9876"]}'
-        - -wait-for-crd-kind
-        - Machine
-        - -wait-for-crd-apiversion
-        - cluster.k8s.io/v1alpha1
+        - --crd-to-wait-for
+        - Machine,cluster.k8s.io/v1alpha1
         command:
         - /http-prober-bin/http-prober
         env:
@@ -88,7 +86,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3
+        image: quay.io/kubermatic/http-prober:v0.3.1-dev
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/api/pkg/resources/test/fixtures/deployment-vsphere-1.11.1-machine-controller-webhook.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-vsphere-1.11.1-machine-controller-webhook.yaml
@@ -86,7 +86,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3.1-dev0
+        image: quay.io/kubermatic/http-prober:v0.3.1
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/api/pkg/resources/test/fixtures/deployment-vsphere-1.11.1-machine-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-vsphere-1.11.1-machine-controller.yaml
@@ -77,7 +77,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3.1-dev
+        image: quay.io/kubermatic/http-prober:v0.3.1-dev0
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/api/pkg/resources/test/fixtures/deployment-vsphere-1.11.1-machine-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-vsphere-1.11.1-machine-controller.yaml
@@ -34,10 +34,8 @@ spec:
         - "1"
         - -command
         - '{"command":"/usr/local/bin/machine-controller","args":["-kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","-logtostderr","-v","4","-cluster-dns","169.254.20.10","-internal-listen-address","0.0.0.0:8085"]}'
-        - -wait-for-crd-kind
-        - Machine
-        - -wait-for-crd-apiversion
-        - cluster.k8s.io/v1alpha1
+        - --crd-to-wait-for
+        - Machine,cluster.k8s.io/v1alpha1
         command:
         - /http-prober-bin/http-prober
         env:
@@ -79,7 +77,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3
+        image: quay.io/kubermatic/http-prober:v0.3.1-dev
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/api/pkg/resources/test/fixtures/deployment-vsphere-1.11.1-machine-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-vsphere-1.11.1-machine-controller.yaml
@@ -77,7 +77,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3.1-dev0
+        image: quay.io/kubermatic/http-prober:v0.3.1
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/api/pkg/resources/test/fixtures/deployment-vsphere-1.11.1-metrics-server.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-vsphere-1.11.1-metrics-server.yaml
@@ -156,7 +156,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3
+        image: quay.io/kubermatic/http-prober:v0.3.1-dev
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/api/pkg/resources/test/fixtures/deployment-vsphere-1.11.1-metrics-server.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-vsphere-1.11.1-metrics-server.yaml
@@ -156,7 +156,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3.1-dev
+        image: quay.io/kubermatic/http-prober:v0.3.1-dev0
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/api/pkg/resources/test/fixtures/deployment-vsphere-1.11.1-metrics-server.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-vsphere-1.11.1-metrics-server.yaml
@@ -156,7 +156,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3.1-dev0
+        image: quay.io/kubermatic/http-prober:v0.3.1
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/api/pkg/resources/test/fixtures/deployment-vsphere-1.11.1-scheduler.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-vsphere-1.11.1-scheduler.yaml
@@ -163,7 +163,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3.1-dev
+        image: quay.io/kubermatic/http-prober:v0.3.1-dev0
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/api/pkg/resources/test/fixtures/deployment-vsphere-1.11.1-scheduler.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-vsphere-1.11.1-scheduler.yaml
@@ -163,7 +163,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3.1-dev0
+        image: quay.io/kubermatic/http-prober:v0.3.1
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/api/pkg/resources/test/fixtures/deployment-vsphere-1.11.1-scheduler.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-vsphere-1.11.1-scheduler.yaml
@@ -163,7 +163,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3
+        image: quay.io/kubermatic/http-prober:v0.3.1-dev
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/api/pkg/resources/test/fixtures/deployment-vsphere-1.11.1-usercluster-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-vsphere-1.11.1-usercluster-controller.yaml
@@ -85,7 +85,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3.1-dev0
+        image: quay.io/kubermatic/http-prober:v0.3.1
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/api/pkg/resources/test/fixtures/deployment-vsphere-1.11.1-usercluster-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-vsphere-1.11.1-usercluster-controller.yaml
@@ -85,7 +85,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3
+        image: quay.io/kubermatic/http-prober:v0.3.1-dev
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/api/pkg/resources/test/fixtures/deployment-vsphere-1.11.1-usercluster-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-vsphere-1.11.1-usercluster-controller.yaml
@@ -85,7 +85,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3.1-dev
+        image: quay.io/kubermatic/http-prober:v0.3.1-dev0
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/api/pkg/resources/test/fixtures/deployment-vsphere-1.12.0-controller-manager.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-vsphere-1.12.0-controller-manager.yaml
@@ -175,7 +175,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3.1-dev
+        image: quay.io/kubermatic/http-prober:v0.3.1-dev0
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/api/pkg/resources/test/fixtures/deployment-vsphere-1.12.0-controller-manager.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-vsphere-1.12.0-controller-manager.yaml
@@ -175,7 +175,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3.1-dev0
+        image: quay.io/kubermatic/http-prober:v0.3.1
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/api/pkg/resources/test/fixtures/deployment-vsphere-1.12.0-controller-manager.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-vsphere-1.12.0-controller-manager.yaml
@@ -175,7 +175,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3
+        image: quay.io/kubermatic/http-prober:v0.3.1-dev
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/api/pkg/resources/test/fixtures/deployment-vsphere-1.12.0-kube-state-metrics.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-vsphere-1.12.0-kube-state-metrics.yaml
@@ -72,7 +72,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3.1-dev0
+        image: quay.io/kubermatic/http-prober:v0.3.1
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/api/pkg/resources/test/fixtures/deployment-vsphere-1.12.0-kube-state-metrics.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-vsphere-1.12.0-kube-state-metrics.yaml
@@ -72,7 +72,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3
+        image: quay.io/kubermatic/http-prober:v0.3.1-dev
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/api/pkg/resources/test/fixtures/deployment-vsphere-1.12.0-kube-state-metrics.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-vsphere-1.12.0-kube-state-metrics.yaml
@@ -72,7 +72,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3.1-dev
+        image: quay.io/kubermatic/http-prober:v0.3.1-dev0
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/api/pkg/resources/test/fixtures/deployment-vsphere-1.12.0-machine-controller-webhook.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-vsphere-1.12.0-machine-controller-webhook.yaml
@@ -86,7 +86,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3.1-dev
+        image: quay.io/kubermatic/http-prober:v0.3.1-dev0
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/api/pkg/resources/test/fixtures/deployment-vsphere-1.12.0-machine-controller-webhook.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-vsphere-1.12.0-machine-controller-webhook.yaml
@@ -31,10 +31,8 @@ spec:
         - "1"
         - -command
         - '{"command":"/usr/local/bin/webhook","args":["-kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","-logtostderr","-v","4","-listen-address","0.0.0.0:9876"]}'
-        - -wait-for-crd-kind
-        - Machine
-        - -wait-for-crd-apiversion
-        - cluster.k8s.io/v1alpha1
+        - --crd-to-wait-for
+        - Machine,cluster.k8s.io/v1alpha1
         command:
         - /http-prober-bin/http-prober
         env:
@@ -88,7 +86,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3
+        image: quay.io/kubermatic/http-prober:v0.3.1-dev
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/api/pkg/resources/test/fixtures/deployment-vsphere-1.12.0-machine-controller-webhook.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-vsphere-1.12.0-machine-controller-webhook.yaml
@@ -86,7 +86,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3.1-dev0
+        image: quay.io/kubermatic/http-prober:v0.3.1
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/api/pkg/resources/test/fixtures/deployment-vsphere-1.12.0-machine-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-vsphere-1.12.0-machine-controller.yaml
@@ -77,7 +77,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3.1-dev
+        image: quay.io/kubermatic/http-prober:v0.3.1-dev0
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/api/pkg/resources/test/fixtures/deployment-vsphere-1.12.0-machine-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-vsphere-1.12.0-machine-controller.yaml
@@ -34,10 +34,8 @@ spec:
         - "1"
         - -command
         - '{"command":"/usr/local/bin/machine-controller","args":["-kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","-logtostderr","-v","4","-cluster-dns","169.254.20.10","-internal-listen-address","0.0.0.0:8085"]}'
-        - -wait-for-crd-kind
-        - Machine
-        - -wait-for-crd-apiversion
-        - cluster.k8s.io/v1alpha1
+        - --crd-to-wait-for
+        - Machine,cluster.k8s.io/v1alpha1
         command:
         - /http-prober-bin/http-prober
         env:
@@ -79,7 +77,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3
+        image: quay.io/kubermatic/http-prober:v0.3.1-dev
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/api/pkg/resources/test/fixtures/deployment-vsphere-1.12.0-machine-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-vsphere-1.12.0-machine-controller.yaml
@@ -77,7 +77,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3.1-dev0
+        image: quay.io/kubermatic/http-prober:v0.3.1
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/api/pkg/resources/test/fixtures/deployment-vsphere-1.12.0-metrics-server.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-vsphere-1.12.0-metrics-server.yaml
@@ -156,7 +156,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3
+        image: quay.io/kubermatic/http-prober:v0.3.1-dev
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/api/pkg/resources/test/fixtures/deployment-vsphere-1.12.0-metrics-server.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-vsphere-1.12.0-metrics-server.yaml
@@ -156,7 +156,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3.1-dev
+        image: quay.io/kubermatic/http-prober:v0.3.1-dev0
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/api/pkg/resources/test/fixtures/deployment-vsphere-1.12.0-metrics-server.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-vsphere-1.12.0-metrics-server.yaml
@@ -156,7 +156,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3.1-dev0
+        image: quay.io/kubermatic/http-prober:v0.3.1
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/api/pkg/resources/test/fixtures/deployment-vsphere-1.12.0-scheduler.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-vsphere-1.12.0-scheduler.yaml
@@ -163,7 +163,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3.1-dev
+        image: quay.io/kubermatic/http-prober:v0.3.1-dev0
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/api/pkg/resources/test/fixtures/deployment-vsphere-1.12.0-scheduler.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-vsphere-1.12.0-scheduler.yaml
@@ -163,7 +163,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3.1-dev0
+        image: quay.io/kubermatic/http-prober:v0.3.1
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/api/pkg/resources/test/fixtures/deployment-vsphere-1.12.0-scheduler.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-vsphere-1.12.0-scheduler.yaml
@@ -163,7 +163,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3
+        image: quay.io/kubermatic/http-prober:v0.3.1-dev
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/api/pkg/resources/test/fixtures/deployment-vsphere-1.12.0-usercluster-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-vsphere-1.12.0-usercluster-controller.yaml
@@ -85,7 +85,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3.1-dev0
+        image: quay.io/kubermatic/http-prober:v0.3.1
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/api/pkg/resources/test/fixtures/deployment-vsphere-1.12.0-usercluster-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-vsphere-1.12.0-usercluster-controller.yaml
@@ -85,7 +85,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3
+        image: quay.io/kubermatic/http-prober:v0.3.1-dev
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/api/pkg/resources/test/fixtures/deployment-vsphere-1.12.0-usercluster-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-vsphere-1.12.0-usercluster-controller.yaml
@@ -85,7 +85,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3.1-dev
+        image: quay.io/kubermatic/http-prober:v0.3.1-dev0
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/api/pkg/resources/test/fixtures/deployment-vsphere-1.13.0-controller-manager.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-vsphere-1.13.0-controller-manager.yaml
@@ -175,7 +175,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3.1-dev
+        image: quay.io/kubermatic/http-prober:v0.3.1-dev0
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/api/pkg/resources/test/fixtures/deployment-vsphere-1.13.0-controller-manager.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-vsphere-1.13.0-controller-manager.yaml
@@ -175,7 +175,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3.1-dev0
+        image: quay.io/kubermatic/http-prober:v0.3.1
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/api/pkg/resources/test/fixtures/deployment-vsphere-1.13.0-controller-manager.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-vsphere-1.13.0-controller-manager.yaml
@@ -175,7 +175,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3
+        image: quay.io/kubermatic/http-prober:v0.3.1-dev
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/api/pkg/resources/test/fixtures/deployment-vsphere-1.13.0-kube-state-metrics.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-vsphere-1.13.0-kube-state-metrics.yaml
@@ -72,7 +72,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3.1-dev0
+        image: quay.io/kubermatic/http-prober:v0.3.1
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/api/pkg/resources/test/fixtures/deployment-vsphere-1.13.0-kube-state-metrics.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-vsphere-1.13.0-kube-state-metrics.yaml
@@ -72,7 +72,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3
+        image: quay.io/kubermatic/http-prober:v0.3.1-dev
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/api/pkg/resources/test/fixtures/deployment-vsphere-1.13.0-kube-state-metrics.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-vsphere-1.13.0-kube-state-metrics.yaml
@@ -72,7 +72,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3.1-dev
+        image: quay.io/kubermatic/http-prober:v0.3.1-dev0
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/api/pkg/resources/test/fixtures/deployment-vsphere-1.13.0-machine-controller-webhook.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-vsphere-1.13.0-machine-controller-webhook.yaml
@@ -86,7 +86,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3.1-dev
+        image: quay.io/kubermatic/http-prober:v0.3.1-dev0
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/api/pkg/resources/test/fixtures/deployment-vsphere-1.13.0-machine-controller-webhook.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-vsphere-1.13.0-machine-controller-webhook.yaml
@@ -31,10 +31,8 @@ spec:
         - "1"
         - -command
         - '{"command":"/usr/local/bin/webhook","args":["-kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","-logtostderr","-v","4","-listen-address","0.0.0.0:9876"]}'
-        - -wait-for-crd-kind
-        - Machine
-        - -wait-for-crd-apiversion
-        - cluster.k8s.io/v1alpha1
+        - --crd-to-wait-for
+        - Machine,cluster.k8s.io/v1alpha1
         command:
         - /http-prober-bin/http-prober
         env:
@@ -88,7 +86,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3
+        image: quay.io/kubermatic/http-prober:v0.3.1-dev
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/api/pkg/resources/test/fixtures/deployment-vsphere-1.13.0-machine-controller-webhook.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-vsphere-1.13.0-machine-controller-webhook.yaml
@@ -86,7 +86,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3.1-dev0
+        image: quay.io/kubermatic/http-prober:v0.3.1
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/api/pkg/resources/test/fixtures/deployment-vsphere-1.13.0-machine-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-vsphere-1.13.0-machine-controller.yaml
@@ -77,7 +77,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3.1-dev
+        image: quay.io/kubermatic/http-prober:v0.3.1-dev0
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/api/pkg/resources/test/fixtures/deployment-vsphere-1.13.0-machine-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-vsphere-1.13.0-machine-controller.yaml
@@ -34,10 +34,8 @@ spec:
         - "1"
         - -command
         - '{"command":"/usr/local/bin/machine-controller","args":["-kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","-logtostderr","-v","4","-cluster-dns","169.254.20.10","-internal-listen-address","0.0.0.0:8085"]}'
-        - -wait-for-crd-kind
-        - Machine
-        - -wait-for-crd-apiversion
-        - cluster.k8s.io/v1alpha1
+        - --crd-to-wait-for
+        - Machine,cluster.k8s.io/v1alpha1
         command:
         - /http-prober-bin/http-prober
         env:
@@ -79,7 +77,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3
+        image: quay.io/kubermatic/http-prober:v0.3.1-dev
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/api/pkg/resources/test/fixtures/deployment-vsphere-1.13.0-machine-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-vsphere-1.13.0-machine-controller.yaml
@@ -77,7 +77,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3.1-dev0
+        image: quay.io/kubermatic/http-prober:v0.3.1
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/api/pkg/resources/test/fixtures/deployment-vsphere-1.13.0-metrics-server.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-vsphere-1.13.0-metrics-server.yaml
@@ -156,7 +156,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3
+        image: quay.io/kubermatic/http-prober:v0.3.1-dev
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/api/pkg/resources/test/fixtures/deployment-vsphere-1.13.0-metrics-server.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-vsphere-1.13.0-metrics-server.yaml
@@ -156,7 +156,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3.1-dev
+        image: quay.io/kubermatic/http-prober:v0.3.1-dev0
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/api/pkg/resources/test/fixtures/deployment-vsphere-1.13.0-metrics-server.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-vsphere-1.13.0-metrics-server.yaml
@@ -156,7 +156,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3.1-dev0
+        image: quay.io/kubermatic/http-prober:v0.3.1
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/api/pkg/resources/test/fixtures/deployment-vsphere-1.13.0-scheduler.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-vsphere-1.13.0-scheduler.yaml
@@ -163,7 +163,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3.1-dev
+        image: quay.io/kubermatic/http-prober:v0.3.1-dev0
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/api/pkg/resources/test/fixtures/deployment-vsphere-1.13.0-scheduler.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-vsphere-1.13.0-scheduler.yaml
@@ -163,7 +163,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3.1-dev0
+        image: quay.io/kubermatic/http-prober:v0.3.1
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/api/pkg/resources/test/fixtures/deployment-vsphere-1.13.0-scheduler.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-vsphere-1.13.0-scheduler.yaml
@@ -163,7 +163,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3
+        image: quay.io/kubermatic/http-prober:v0.3.1-dev
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/api/pkg/resources/test/fixtures/deployment-vsphere-1.13.0-usercluster-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-vsphere-1.13.0-usercluster-controller.yaml
@@ -85,7 +85,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3.1-dev0
+        image: quay.io/kubermatic/http-prober:v0.3.1
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/api/pkg/resources/test/fixtures/deployment-vsphere-1.13.0-usercluster-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-vsphere-1.13.0-usercluster-controller.yaml
@@ -85,7 +85,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3
+        image: quay.io/kubermatic/http-prober:v0.3.1-dev
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/api/pkg/resources/test/fixtures/deployment-vsphere-1.13.0-usercluster-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-vsphere-1.13.0-usercluster-controller.yaml
@@ -85,7 +85,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3.1-dev
+        image: quay.io/kubermatic/http-prober:v0.3.1-dev0
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/api/pkg/resources/usercluster/deployment.go
+++ b/api/pkg/resources/usercluster/deployment.go
@@ -159,7 +159,7 @@ func DeploymentCreator(data userclusterControllerData, openshift bool) reconcili
 				},
 			}
 
-			wrappedPodSpec, err := apiserver.IsRunningWrapper(data, dep.Spec.Template.Spec, sets.NewString(name), "", "")
+			wrappedPodSpec, err := apiserver.IsRunningWrapper(data, dep.Spec.Template.Spec, sets.NewString(name))
 			if err != nil {
 				return nil, fmt.Errorf("failed to add apiserver.IsRunningWrapper: %v", err)
 			}


### PR DESCRIPTION
**What this PR does / why we need it**:

* Extends the http prober to be able to wait for multiple crds
* Updates the dns-operator deployment to wait for both the network and the DNS crd

This should fix spurious issues we saw in CI with Openshift clusters not coming up. This happened, because the dns-operator seems to have a limited maximum amount of tries for applying its resources and will just stop doing anything after that happpened.

Because of that,  the clusters had no DNS, hence the openVPN client didn't come up as it couldn't resolve its server, hence the tests fails.

Note that this issue is not specific to tests, it also happens outside of CI.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Documentation**:
<!-- Add links to the related documentation changes related to this pull request. E.g. the link to the kubermatic/docs pullrequest. -->

**Does this PR introduce a user-facing change?**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If  no release note is required, just write "NONE".
-->
```release-note
none
```
