### PR TITLE
allow user owner for all operations in the cluster

### DIFF
--- a/api/pkg/controller/rbac-user-cluster/mapper.go
+++ b/api/pkg/controller/rbac-user-cluster/mapper.go
@@ -25,11 +25,8 @@ const (
 // generateVerbsForGroup generates a set of verbs for a group
 func generateVerbsForGroup(groupName string) ([]string, error) {
 	// verbs for owners
-	if groupName == rbac.OwnerGroupNamePrefix {
-		return []string{"create", "list", "get", "update", "delete", "patch", "watch", "deletecollection"}, nil
-	}
-	if groupName == rbac.EditorGroupNamePrefix {
-		return []string{"create", "list", "get", "update", "delete"}, nil
+	if groupName == rbac.OwnerGroupNamePrefix || groupName == rbac.EditorGroupNamePrefix {
+		return []string{"*"}, nil
 	}
 
 	if groupName == rbac.ViewerGroupNamePrefix {
@@ -69,12 +66,13 @@ func GenerateRBACClusterRole(resourceName string) (*rbacv1.ClusterRole, error) {
 			},
 		},
 	}
-	if groupName == rbac.OwnerGroupNamePrefix {
-		clusterRole.Rules = append(clusterRole.Rules, rbacv1.PolicyRule{
-			APIGroups: []string{"rbac.authorization.k8s.io"},
-			Resources: []string{"*"},
-			Verbs:     verbs,
-		})
+	if groupName == rbac.OwnerGroupNamePrefix || groupName == rbac.EditorGroupNamePrefix {
+		clusterRole.Rules = []rbacv1.PolicyRule{
+			{
+				APIGroups: []string{"*"},
+				Resources: []string{"*"},
+				Verbs:     verbs,
+			}}
 	}
 	return clusterRole, nil
 }

--- a/api/pkg/controller/rbac-user-cluster/mapper_test.go
+++ b/api/pkg/controller/rbac-user-cluster/mapper_test.go
@@ -19,13 +19,13 @@ func TestGeneratedResourcesForGroups(t *testing.T) {
 		{
 			name:              "scenario 1: check resources for owners",
 			resurceName:       genResourceName(rbac.OwnerGroupNamePrefix),
-			expectedResources: []string{"machinedeployments", "machinesets", "machines"},
+			expectedResources: []string{"*"},
 			expectError:       false,
 		},
 		{
 			name:              "scenario 2: check resources for editors",
 			resurceName:       genResourceName(rbac.EditorGroupNamePrefix),
-			expectedResources: []string{"machinedeployments", "machinesets", "machines"},
+			expectedResources: []string{"*"},
 			expectError:       false,
 		},
 		{
@@ -77,13 +77,13 @@ func TestGenerateVerbsForGroup(t *testing.T) {
 		{
 			name:          "scenario 1: generate verbs for owners",
 			resurceName:   genResourceName(rbac.OwnerGroupNamePrefix),
-			expectedVerbs: []string{"create", "list", "get", "update", "delete", "patch", "watch", "deletecollection"},
+			expectedVerbs: []string{"*"},
 			expectError:   false,
 		},
 		{
 			name:          "scenario 2: generate verbs for editors",
 			resurceName:   genResourceName(rbac.EditorGroupNamePrefix),
-			expectedVerbs: []string{"create", "list", "get", "update", "delete"},
+			expectedVerbs: []string{"*"},
 			expectError:   false,
 		},
 		{


### PR DESCRIPTION
**What this PR does / why we need it**: allow user owner and editor for all operations in the cluster

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #


```release-note
allow user owner and editor for all operations in the cluster
```
