### PR TITLE
Fix missing CA injection in cert manager

### DIFF
--- a/config/cert-manager/templates/cainjector-deployment.yaml
+++ b/config/cert-manager/templates/cainjector-deployment.yaml
@@ -12,13 +12,13 @@ spec:
     matchLabels:
       app: cainjector
       app.kubernetes.io/name: cainjector
-      app.kubernetes.io/instance:  {{ .Release.Name }}
+      app.kubernetes.io/instance: {{ .Release.Name }}
   template:
     metadata:
       labels:
         app: cainjector
         app.kubernetes.io/name: cainjector
-        app.kubernetes.io/instance:  {{ .Release.Name }}
+        app.kubernetes.io/instance: {{ .Release.Name }}
       annotations:
         fluentbit.io/parser: glog
     spec:

--- a/config/cert-manager/templates/cert-manager-rbac.yaml
+++ b/config/cert-manager/templates/cert-manager-rbac.yaml
@@ -5,7 +5,7 @@ metadata:
   labels:
     app: cert-manager
     app.kubernetes.io/name: cert-manager
-    app.kubernetes.io/instance:  {{ .Release.Name }}
+    app.kubernetes.io/instance: {{ .Release.Name }}
 rules:
   # Used for leader election by the controller
   - apiGroups: [""]
@@ -22,7 +22,7 @@ metadata:
   labels:
     app: cert-manager
     app.kubernetes.io/name: cert-manager
-    app.kubernetes.io/instance:  {{ .Release.Name }}
+    app.kubernetes.io/instance: {{ .Release.Name }}
 rules:
   - apiGroups: ["certmanager.k8s.io"]
     resources: ["issuers", "issuers/status"]
@@ -46,7 +46,7 @@ metadata:
   labels:
     app: cert-manager
     app.kubernetes.io/name: cert-manager
-    app.kubernetes.io/instance:  {{ .Release.Name }}
+    app.kubernetes.io/instance: {{ .Release.Name }}
 rules:
   - apiGroups: ["certmanager.k8s.io"]
     resources: ["clusterissuers", "clusterissuers/status"]
@@ -70,7 +70,7 @@ metadata:
   labels:
     app: cert-manager
     app.kubernetes.io/name: cert-manager
-    app.kubernetes.io/instance:  {{ .Release.Name }}
+    app.kubernetes.io/instance: {{ .Release.Name }}
 rules:
   - apiGroups: ["certmanager.k8s.io"]
     resources: ["certificates", "certificates/status", "certificaterequests", "certificaterequests/status"]
@@ -103,7 +103,7 @@ metadata:
   labels:
     app: cert-manager
     app.kubernetes.io/name: cert-manager
-    app.kubernetes.io/instance:  {{ .Release.Name }}
+    app.kubernetes.io/instance: {{ .Release.Name }}
 rules:
   - apiGroups: ["certmanager.k8s.io"]
     resources: ["orders", "orders/status"]
@@ -136,7 +136,7 @@ metadata:
   labels:
     app: cert-manager
     app.kubernetes.io/name: cert-manager
-    app.kubernetes.io/instance:  {{ .Release.Name }}
+    app.kubernetes.io/instance: {{ .Release.Name }}
 rules:
   # Use to update challenge resource status
   - apiGroups: ["certmanager.k8s.io"]
@@ -189,7 +189,7 @@ metadata:
   labels:
     app: cert-manager
     app.kubernetes.io/name: cert-manager
-    app.kubernetes.io/instance:  {{ .Release.Name }}
+    app.kubernetes.io/instance: {{ .Release.Name }}
 rules:
   - apiGroups: ["certmanager.k8s.io"]
     resources: ["certificates", "certificaterequests"]
@@ -218,7 +218,7 @@ metadata:
   labels:
     app: cert-manager
     app.kubernetes.io/name: cert-manager
-    app.kubernetes.io/instance:  {{ .Release.Name }}
+    app.kubernetes.io/instance: {{ .Release.Name }}
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
@@ -236,7 +236,7 @@ metadata:
   labels:
     app: cert-manager
     app.kubernetes.io/name: cert-manager
-    app.kubernetes.io/instance:  {{ .Release.Name }}
+    app.kubernetes.io/instance: {{ .Release.Name }}
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
@@ -254,7 +254,7 @@ metadata:
   labels:
     app: cert-manager
     app.kubernetes.io/name: cert-manager
-    app.kubernetes.io/instance:  {{ .Release.Name }}
+    app.kubernetes.io/instance: {{ .Release.Name }}
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
@@ -272,7 +272,7 @@ metadata:
   labels:
     app: cert-manager
     app.kubernetes.io/name: cert-manager
-    app.kubernetes.io/instance:  {{ .Release.Name }}
+    app.kubernetes.io/instance: {{ .Release.Name }}
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
@@ -290,7 +290,7 @@ metadata:
   labels:
     app: cert-manager
     app.kubernetes.io/name: cert-manager
-    app.kubernetes.io/instance:  {{ .Release.Name }}
+    app.kubernetes.io/instance: {{ .Release.Name }}
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
@@ -308,7 +308,7 @@ metadata:
   labels:
     app: cert-manager
     app.kubernetes.io/name: cert-manager
-    app.kubernetes.io/instance:  {{ .Release.Name }}
+    app.kubernetes.io/instance: {{ .Release.Name }}
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
@@ -326,7 +326,7 @@ metadata:
   labels:
     app: cert-manager
     app.kubernetes.io/name: cert-manager
-    app.kubernetes.io/instance:  {{ .Release.Name }}
+    app.kubernetes.io/instance: {{ .Release.Name }}
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
@@ -344,7 +344,7 @@ metadata:
   labels:
     app: cert-manager
     app.kubernetes.io/name: cert-manager
-    app.kubernetes.io/instance:  {{ .Release.Name }}
+    app.kubernetes.io/instance: {{ .Release.Name }}
     rbac.authorization.k8s.io/aggregate-to-view: "true"
     rbac.authorization.k8s.io/aggregate-to-edit: "true"
     rbac.authorization.k8s.io/aggregate-to-admin: "true"
@@ -361,7 +361,7 @@ metadata:
   labels:
     app: cert-manager
     app.kubernetes.io/name: cert-manager
-    app.kubernetes.io/instance:  {{ .Release.Name }}
+    app.kubernetes.io/instance: {{ .Release.Name }}
     rbac.authorization.k8s.io/aggregate-to-edit: "true"
     rbac.authorization.k8s.io/aggregate-to-admin: "true"
 rules:

--- a/config/cert-manager/templates/cert-manager-serviceaccount.yaml
+++ b/config/cert-manager/templates/cert-manager-serviceaccount.yaml
@@ -5,4 +5,4 @@ metadata:
   labels:
     app: cert-manager
     app.kubernetes.io/name: cert-manager
-    app.kubernetes.io/instance:  {{ .Release.Name }}
+    app.kubernetes.io/instance: {{ .Release.Name }}

--- a/config/cert-manager/templates/webhook-apiservice.yaml
+++ b/config/cert-manager/templates/webhook-apiservice.yaml
@@ -5,7 +5,7 @@ metadata:
   labels:
     app: webhook
     app.kubernetes.io/name: webhook
-    app.kubernetes.io/instance:  {{ .Release.Name }}
+    app.kubernetes.io/instance: {{ .Release.Name }}
   annotations:
     certmanager.k8s.io/inject-ca-from-secret: '{{ .Release.Namespace }}/webhook-tls'
 spec:

--- a/config/cert-manager/templates/webhook-deployment.yaml
+++ b/config/cert-manager/templates/webhook-deployment.yaml
@@ -5,20 +5,20 @@ metadata:
   labels:
     app: webhook
     app.kubernetes.io/name: webhook
-    app.kubernetes.io/instance:  {{ .Release.Name }}
+    app.kubernetes.io/instance: {{ .Release.Name }}
 spec:
   replicas: {{ .Values.certManager.webhook.replicas }}
   selector:
     matchLabels:
       app: webhook
       app.kubernetes.io/name: webhook
-      app.kubernetes.io/instance:  {{ .Release.Name }}
+      app.kubernetes.io/instance: {{ .Release.Name }}
   template:
     metadata:
       labels:
         app: webhook
         app.kubernetes.io/name: webhook
-        app.kubernetes.io/instance:  {{ .Release.Name }}
+        app.kubernetes.io/instance: {{ .Release.Name }}
       annotations:
         fluentbit.io/parser: glog
     spec:

--- a/config/cert-manager/templates/webhook-mutating-webhook.yaml
+++ b/config/cert-manager/templates/webhook-mutating-webhook.yaml
@@ -7,7 +7,7 @@ metadata:
     app.kubernetes.io/name: webhook
     app.kubernetes.io/instance: {{ .Release.Name }}
   annotations:
-{{- if .Values.certManager.injectAPIServerCA }}
+{{- if .Values.certManager.webhook.injectAPIServerCA }}
     certmanager.k8s.io/inject-apiserver-ca: 'true'
 {{- end }}
 webhooks:

--- a/config/cert-manager/templates/webhook-rbac.yaml
+++ b/config/cert-manager/templates/webhook-rbac.yaml
@@ -7,7 +7,7 @@ metadata:
   labels:
     app: webhook
     app.kubernetes.io/name: webhook
-    app.kubernetes.io/instance:  {{ .Release.Name }}
+    app.kubernetes.io/instance: {{ .Release.Name }}
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
@@ -30,7 +30,7 @@ metadata:
   labels:
     app: webhook
     app.kubernetes.io/name: webhook
-    app.kubernetes.io/instance:  {{ .Release.Name }}
+    app.kubernetes.io/instance: {{ .Release.Name }}
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: Role
@@ -49,7 +49,7 @@ metadata:
   labels:
     app: webhook
     app.kubernetes.io/name: webhook
-    app.kubernetes.io/instance:  {{ .Release.Name }}
+    app.kubernetes.io/instance: {{ .Release.Name }}
 rules:
 - apiGroups:
   - admission.certmanager.k8s.io

--- a/config/cert-manager/templates/webhook-service.yaml
+++ b/config/cert-manager/templates/webhook-service.yaml
@@ -5,7 +5,7 @@ metadata:
   labels:
     app: webhook
     app.kubernetes.io/name: webhook
-    app.kubernetes.io/instance:  {{ .Release.Name }}
+    app.kubernetes.io/instance: {{ .Release.Name }}
 spec:
   type: ClusterIP
   ports:
@@ -15,4 +15,4 @@ spec:
   selector:
     app: webhook
     app.kubernetes.io/name: webhook
-    app.kubernetes.io/instance:  {{ .Release.Name }}
+    app.kubernetes.io/instance: {{ .Release.Name }}

--- a/config/cert-manager/templates/webhook-serviceaccount.yaml
+++ b/config/cert-manager/templates/webhook-serviceaccount.yaml
@@ -5,4 +5,4 @@ metadata:
   labels:
     app: webhook
     app.kubernetes.io/name: webhook
-    app.kubernetes.io/instance:  {{ .Release.Name }}
+    app.kubernetes.io/instance: {{ .Release.Name }}

--- a/config/cert-manager/templates/webhook-validating-webhook.yaml
+++ b/config/cert-manager/templates/webhook-validating-webhook.yaml
@@ -7,7 +7,7 @@ metadata:
     app.kubernetes.io/name: webhook
     app.kubernetes.io/instance: {{ .Release.Name }}
   annotations:
-{{- if .Values.certManager.injectAPIServerCA }}
+{{- if .Values.certManager.webhook.injectAPIServerCA }}
     certmanager.k8s.io/inject-apiserver-ca: 'true'
 {{- end }}
 webhooks:

--- a/config/cert-manager/values.yaml
+++ b/config/cert-manager/values.yaml
@@ -41,9 +41,7 @@ certManager:
 
     # If true, the apiserver's cabundle will be automatically injected into the
     # webhook's ValidatingWebhookConfiguration resource by the CA injector.
-    # If you're running on Kubernetes 1.11+, you can set this to false already.
-    # see https://github.com/kubernetes/kubernetes/pull/62649
-    injectAPIServerCA: false
+    injectAPIServerCA: true
 
   cainjector:
     replicas: 1


### PR DESCRIPTION
**What this PR does / why we need it**:
When updating to 0.10, the default value for the injectAPIServiceCA flag was changed to true. We also had a slgiht error in our template, which would have made the flag ineffective.

**Does this PR introduce a user-facing change?**:
```release-note
NONE
```
