### PR TITLE
Openshift: Enable cloud provider functionality

### DIFF
--- a/api/cmd/kubermatic-controller-manager/options.go
+++ b/api/cmd/kubermatic-controller-manager/options.go
@@ -98,7 +98,7 @@ func newControllerRunOptions() (controllerRunOptions, error) {
 	flag.StringVar(&c.kubernetesAddonsPath, "kubernetes-addons-path", "/opt/addons/kubernetes", "Path to addon manifests. Should contain sub-folders for each addon")
 	flag.StringVar(&c.openshiftAddonsPath, "openshift-addons-path", "/opt/addons/openshift", "Path to addon manifests. Should contain sub-folders for each addon")
 	flag.StringVar(&c.kubernetesAddonsList, "kubernetes-addons-list", "canal,dashboard,dns,kube-proxy,openvpn,rbac,kubelet-configmap,default-storage-class,node-exporter,nodelocal-dns-cache", "Comma separated list of Addons to install into every user-cluster")
-	flag.StringVar(&c.openshiftAddonsList, "openshift-addons-list", "openvpn,rbac,crd,network", "Comma separated list of addons to install into every openshift user cluster")
+	flag.StringVar(&c.openshiftAddonsList, "openshift-addons-list", "openvpn,rbac,crd,network,default-storage-class", "Comma separated list of addons to install into every openshift user cluster")
 	flag.StringVar(&c.backupContainerFile, "backup-container", "", fmt.Sprintf("[Required] Filepath of a backup container yaml. It must mount a volume named %s from which it reads the etcd backups", backupcontroller.SharedVolumeName))
 	flag.StringVar(&c.cleanupContainerFile, "cleanup-container", "", "[Required] Filepath of a cleanup container yaml. The container will be used to cleanup the backup directory for a cluster after it got deleted.")
 	flag.StringVar(&c.backupContainerImage, "backup-container-init-image", backupcontroller.DefaultBackupContainerImage, "Docker image to use for the init container in the backup job, must be an etcd v3 image. Only set this if your cluster can not use the public quay.io registry")

--- a/api/pkg/controller/openshift/resources/testdata/kube-config.golden.yaml
+++ b/api/pkg/controller/openshift/resources/testdata/kube-config.golden.yaml
@@ -10,17 +10,12 @@ data:
       - 'true'
       cert-dir:
       - /var/run/kubernetes
-      # Must be an explicit empty slice, else the controller-manager panics
-      cloud-provider: []
-      #- aws
       cluster-cidr:
       - 10.240.16.0
       cluster-signing-cert-file:
       - /etc/kubernetes/pki/ca/ca.crt
       cluster-signing-key-file:
       - /etc/kubernetes/pki/ca/ca.key
-      configure-cloud-routes:
-      - 'false'
       controllers:
       - '*'
       - -ttl

--- a/api/pkg/controller/user-cluster-controller-manager/openshift-master-node-labeler/openshiftmasternodelabeler.go
+++ b/api/pkg/controller/user-cluster-controller-manager/openshift-master-node-labeler/openshiftmasternodelabeler.go
@@ -25,7 +25,10 @@ import (
 
 const (
 	controllerName = "kubermatic_openshift_master_node_labeler"
-	minMasterNodes = 3
+	// Keep this as low as possible. The Service controller doesn't allow
+	// using nodes that have the master label as backend:
+	// https://github.com/kubernetes/kubernetes/issues/65618
+	minMasterNodes = 1
 )
 
 type reconciler struct {

--- a/api/pkg/resources/controllermanager/deployment.go
+++ b/api/pkg/resources/controllermanager/deployment.go
@@ -141,7 +141,7 @@ func DeploymentCreator(data *resources.TemplateData) reconciling.NamedDeployment
 				resourceRequirements = *data.Cluster().Spec.ComponentsOverride.ControllerManager.Resources
 			}
 
-			envVars, err := getEnvVars(data)
+			envVars, err := GetEnvVars(data)
 			if err != nil {
 				return nil, err
 			}
@@ -327,7 +327,7 @@ func getVolumes() []corev1.Volume {
 	}
 }
 
-func getEnvVars(data resources.CredentialsData) ([]corev1.EnvVar, error) {
+func GetEnvVars(data resources.CredentialsData) ([]corev1.EnvVar, error) {
 	credentials, err := resources.GetCredentials(data)
 	if err != nil {
 		return nil, err

--- a/api/pkg/resources/controllermanager/deployment.go
+++ b/api/pkg/resources/controllermanager/deployment.go
@@ -17,6 +17,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/intstr"
 	"k8s.io/apimachinery/pkg/util/sets"
+	utilpointer "k8s.io/utils/pointer"
 )
 
 var (
@@ -221,22 +222,18 @@ func getFlags(cluster *kubermaticv1.Cluster) ([]string, error) {
 	if cluster.Spec.Cloud.AWS != nil {
 		flags = append(flags, "--cloud-provider", "aws")
 		flags = append(flags, "--cloud-config", "/etc/kubernetes/cloud/config")
-		flags = append(flags, "--configure-cloud-routes=false")
 	}
 	if cluster.Spec.Cloud.Openstack != nil {
 		flags = append(flags, "--cloud-provider", "openstack")
 		flags = append(flags, "--cloud-config", "/etc/kubernetes/cloud/config")
-		flags = append(flags, "--configure-cloud-routes=false")
 	}
 	if cluster.Spec.Cloud.VSphere != nil {
 		flags = append(flags, "--cloud-provider", "vsphere")
 		flags = append(flags, "--cloud-config", "/etc/kubernetes/cloud/config")
-		flags = append(flags, "--configure-cloud-routes=false")
 	}
 	if cluster.Spec.Cloud.Azure != nil {
 		flags = append(flags, "--cloud-provider", "azure")
 		flags = append(flags, "--cloud-config", "/etc/kubernetes/cloud/config")
-		flags = append(flags, "--configure-cloud-routes=false")
 		if cluster.Spec.Version.Semver().Minor() >= 15 {
 			// Required so multiple clusters using the same resource group can
 			// allocate public IPs. Ref: https://github.com/kubernetes/kubernetes/pull/77630
@@ -246,7 +243,10 @@ func getFlags(cluster *kubermaticv1.Cluster) ([]string, error) {
 	if cluster.Spec.Cloud.GCP != nil {
 		flags = append(flags, "--cloud-provider", "gce")
 		flags = append(flags, "--cloud-config", "/etc/kubernetes/cloud/config")
-		flags = append(flags, "--configure-cloud-routes=true")
+	}
+
+	if val := CloudRoutesFlagVal(cluster.Spec.Cloud); val != nil {
+		flags = append(flags, fmt.Sprintf("--configure-cloud-routes=%t", *val))
 	}
 
 	if cluster.Spec.Version.Semver().Minor() >= 12 {
@@ -375,4 +375,23 @@ func getHealthGetAction(data *resources.TemplateData) *corev1.HTTPGetAction {
 		action.Port = intstr.FromInt(10252)
 	}
 	return action
+}
+
+func CloudRoutesFlagVal(cloudSpec kubermaticv1.CloudSpec) *bool {
+	if cloudSpec.AWS != nil {
+		return utilpointer.BoolPtr(false)
+	}
+	if cloudSpec.Openstack != nil {
+		return utilpointer.BoolPtr(false)
+	}
+	if cloudSpec.VSphere != nil {
+		return utilpointer.BoolPtr(false)
+	}
+	if cloudSpec.Azure != nil {
+		return utilpointer.BoolPtr(false)
+	}
+	if cloudSpec.GCP != nil {
+		return utilpointer.BoolPtr(true)
+	}
+	return nil
 }

--- a/config/kubermatic/values.yaml
+++ b/config/kubermatic/values.yaml
@@ -102,6 +102,7 @@ kubermatic:
         - openvpn
         - rbac
         - network
+        - default-storage-class
         image:
           repository: "quay.io/kubermatic/openshift-addons"
           tag: "__KUBERMATIC_TAG__"

--- a/openshift_addons/default-storage-class/storage-class.yaml
+++ b/openshift_addons/default-storage-class/storage-class.yaml
@@ -1,0 +1,314 @@
+{{/* Template must only emit data in case its valid for a given provider. That way we can ensure we don't install it when not needed */}}
+{{ if .Cluster.Spec.Cloud.Azure }}
+apiVersion: storage.k8s.io/v1
+kind: StorageClass
+metadata:
+  annotations:
+    storageclass.beta.kubernetes.io/is-default-class: "true"
+  labels:
+    kubernetes.io/cluster-service: "true"
+  name: standard
+provisioner: kubernetes.io/azure-disk
+parameters:
+  kind: Managed
+  storageaccounttype: Standard_LRS
+{{ end }}
+
+{{ if .Cluster.Spec.Cloud.AWS }}
+apiVersion: storage.k8s.io/v1
+kind: StorageClass
+metadata:
+  annotations:
+    storageclass.beta.kubernetes.io/is-default-class: "true"
+  labels:
+    kubernetes.io/cluster-service: "true"
+  name: standard-v2
+provisioner: kubernetes.io/aws-ebs
+parameters:
+  type: gp2
+volumeBindingMode: WaitForFirstConsumer
+{{ end }}
+
+{{ if .Cluster.Spec.Cloud.VSphere }}
+apiVersion: storage.k8s.io/v1
+kind: StorageClass
+metadata:
+  annotations:
+    storageclass.beta.kubernetes.io/is-default-class: "true"
+  labels:
+    kubernetes.io/cluster-service: "true"
+  name: standard
+provisioner: kubernetes.io/vsphere-volume
+parameters:
+  diskformat: thin
+{{ end }}
+
+{{ if .Cluster.Spec.Cloud.Openstack }}
+apiVersion: storage.k8s.io/v1
+kind: StorageClass
+metadata:
+  annotations:
+    storageclass.beta.kubernetes.io/is-default-class: "true"
+  labels:
+    kubernetes.io/cluster-service: "true"
+  name: standard
+provisioner: kubernetes.io/cinder
+{{ end }}
+
+{{ if .Cluster.Spec.Cloud.GCP }}
+apiVersion: storage.k8s.io/v1
+kind: StorageClass
+metadata:
+  annotations:
+    storageclass.beta.kubernetes.io/is-default-class: "true"
+  labels:
+    kubernetes.io/cluster-service: "true"
+  name: standard
+provisioner: kubernetes.io/gce-pd
+parameters:
+  type: pd-ssd
+{{ end }}
+
+{{ if .Cluster.Spec.Cloud.Hetzner }}
+apiVersion: v1
+kind: Secret
+metadata:
+  name: hcloud-csi
+  namespace: kube-system
+data:
+  token: {{ .Cluster.Spec.Cloud.Hetzner.Token|b64enc }}
+---
+kind: StorageClass
+apiVersion: storage.k8s.io/v1
+metadata:
+  namespace: kube-system
+  name: hcloud-volumes
+  annotations:
+    storageclass.kubernetes.io/is-default-class: "true"
+provisioner: csi.hetzner.cloud
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: hcloud-csi
+  namespace: kube-system
+---
+kind: ClusterRole
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: hcloud-csi
+rules:
+  # attacher
+  - apiGroups: [""]
+    resources: ["persistentvolumes"]
+    verbs: ["get", "list", "watch", "update"]
+  - apiGroups: [""]
+    resources: ["nodes"]
+    verbs: ["get", "list", "watch"]
+  - apiGroups: ["csi.storage.k8s.io"]
+    resources: ["csinodeinfos"]
+    verbs: ["get", "list", "watch"]
+  - apiGroups: ["storage.k8s.io"]
+    resources: ["volumeattachments"]
+    verbs: ["get", "list", "watch", "update"]
+  # provisioner
+  - apiGroups: [""]
+    resources: ["secrets"]
+    verbs: ["get", "list"]
+  - apiGroups: [""]
+    resources: ["persistentvolumes"]
+    verbs: ["get", "list", "watch", "create", "delete"]
+  - apiGroups: [""]
+    resources: ["persistentvolumeclaims"]
+    verbs: ["get", "list", "watch", "update"]
+  - apiGroups: ["storage.k8s.io"]
+    resources: ["storageclasses"]
+    verbs: ["get", "list", "watch"]
+  - apiGroups: [""]
+    resources: ["events"]
+    verbs: ["list", "watch", "create", "update", "patch"]
+  - apiGroups: ["snapshot.storage.k8s.io"]
+    resources: ["volumesnapshots"]
+    verbs: ["get", "list"]
+  - apiGroups: ["snapshot.storage.k8s.io"]
+    resources: ["volumesnapshotcontents"]
+    verbs: ["get", "list"]
+  # cluster registrar
+  - apiGroups: ["apiextensions.k8s.io"]
+    resources: ["customresourcedefinitions"]
+    verbs: ["create", "list", "watch", "delete"]
+  - apiGroups: ["csi.storage.k8s.io"]
+    resources: ["csidrivers"]
+    verbs: ["create", "list", "watch", "delete"]
+  # node
+  - apiGroups: [""]
+    resources: ["events"]
+    verbs: ["get", "list", "watch", "create", "update", "patch"]
+---
+kind: ClusterRoleBinding
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: hcloud-csi
+subjects:
+  - kind: ServiceAccount
+    name: hcloud-csi
+    namespace: kube-system
+roleRef:
+  kind: ClusterRole
+  name: hcloud-csi
+  apiGroup: rbac.authorization.k8s.io
+---
+kind: StatefulSet
+apiVersion: apps/v1
+metadata:
+  name: hcloud-csi-controller
+  namespace: kube-system
+spec:
+  selector:
+    matchLabels:
+      app: hcloud-csi-controller
+  serviceName: hcloud-csi-controller
+  replicas: 1
+  template:
+    metadata:
+      labels:
+        app: hcloud-csi-controller
+    spec:
+      serviceAccount: hcloud-csi
+      containers:
+        - name: csi-attacher
+          image: '{{ Registry "quay.io" }}/k8scsi/csi-attacher:v1.0.1'
+          args:
+            - --csi-address=/var/lib/csi/sockets/pluginproxy/csi.sock
+            - --v=5
+          volumeMounts:
+            - name: socket-dir
+              mountPath: /var/lib/csi/sockets/pluginproxy/
+          securityContext:
+            privileged: true
+            capabilities:
+              add: ["SYS_ADMIN"]
+            allowPrivilegeEscalation: true
+        - name: csi-provisioner
+          image: '{{ Registry "quay.io" }}/k8scsi/csi-provisioner:v1.0.1'
+          args:
+            - --provisioner=csi.hetzner.cloud
+            - --csi-address=/var/lib/csi/sockets/pluginproxy/csi.sock
+            - --v=5
+          volumeMounts:
+            - name: socket-dir
+              mountPath: /var/lib/csi/sockets/pluginproxy/
+          securityContext:
+            privileged: true
+            capabilities:
+              add: ["SYS_ADMIN"]
+            allowPrivilegeEscalation: true
+        - name: csi-cluster-driver-registrar
+          image: '{{ Registry "quay.io" }}/k8scsi/csi-cluster-driver-registrar:v1.0.1'
+          args:
+            - --pod-info-mount-version="v1"
+            - --csi-address=/var/lib/csi/sockets/pluginproxy/csi.sock
+            - --v=5
+          volumeMounts:
+            - name: socket-dir
+              mountPath: /var/lib/csi/sockets/pluginproxy/
+        - name: hcloud-csi-driver
+          image: '{{ Registry "docker.io" }}/hetznercloud/hcloud-csi-driver:1.0.0'
+          imagePullPolicy: Always
+          env:
+            - name: CSI_ENDPOINT
+              value: unix:///var/lib/csi/sockets/pluginproxy/csi.sock
+            - name: HCLOUD_TOKEN
+              valueFrom:
+                secretKeyRef:
+                  name: hcloud-csi
+                  key: token
+          volumeMounts:
+            - name: socket-dir
+              mountPath: /var/lib/csi/sockets/pluginproxy/
+          securityContext:
+            privileged: true
+            capabilities:
+              add: ["SYS_ADMIN"]
+            allowPrivilegeEscalation: true
+      volumes:
+        - name: socket-dir
+          emptyDir: {}
+---
+kind: DaemonSet
+apiVersion: apps/v1
+metadata:
+  name: hcloud-csi-node
+  namespace: kube-system
+  labels:
+    app: hcloud-csi
+spec:
+  selector:
+    matchLabels:
+      app: hcloud-csi
+  template:
+    metadata:
+      labels:
+        app: hcloud-csi
+    spec:
+      serviceAccount: hcloud-csi
+      hostNetwork: true
+      containers:
+        - name: csi-node-driver-registrar
+          image: '{{ Registry "quay.io" }}/k8scsi/csi-node-driver-registrar:v1.0.1'
+          args:
+            - --v=5
+            - --csi-address=/csi/csi.sock
+            - --kubelet-registration-path=/var/lib/kubelet/plugins/csi.hetzner.cloud/csi.sock
+          env:
+            - name: KUBE_NODE_NAME
+              valueFrom:
+                fieldRef:
+                  apiVersion: v1
+                  fieldPath: spec.nodeName
+          volumeMounts:
+            - name: plugin-dir
+              mountPath: /csi
+            - name: registration-dir
+              mountPath: /registration
+          securityContext:
+            privileged: true
+        - name: hcloud-csi-driver
+          image: '{{ Registry "docker.io" }}/hetznercloud/hcloud-csi-driver:1.0.0'
+          imagePullPolicy: Always
+          env:
+            - name: CSI_ENDPOINT
+              value: unix:///csi/csi.sock
+            - name: HCLOUD_TOKEN
+              valueFrom:
+                secretKeyRef:
+                  name: hcloud-csi
+                  key: token
+          volumeMounts:
+            - name: kubelet-dir
+              mountPath: /var/lib/kubelet
+              mountPropagation: "Bidirectional"
+            - name: plugin-dir
+              mountPath: /csi
+            - name: device-dir
+              mountPath: /dev
+          securityContext:
+            privileged: true
+      volumes:
+        - name: kubelet-dir
+          hostPath:
+            path: /var/lib/kubelet
+            type: Directory
+        - name: plugin-dir
+          hostPath:
+            path: /var/lib/kubelet/plugins/csi.hetzner.cloud/
+            type: DirectoryOrCreate
+        - name: registration-dir
+          hostPath:
+            path: /var/lib/kubelet/plugins_registry/
+            type: Directory
+        - name: device-dir
+          hostPath:
+            path: /dev
+            type: Directory
+{{ end }}


### PR DESCRIPTION
**What this PR does / why we need it**:

Enables the cloud provider functionality for Openshift. I verified this on:
* AWS
* Azure
* Openstack
* Vsphere

on GCP we can't use Openshift because GCP does not support CentOS.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #4253

**Special notes for your reviewer**:

**Documentation**:
<!-- Add links to the related documentation changes related to this pull request. E.g. the link to the kubermatic/docs pullrequest. -->

**Does this PR introduce a user-facing change?**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If  no release note is required, just write "NONE".
-->
```release-note
none
```

/assign @xrstf 
