### PR TITLE
Fix apiVersion in monitoring/prometheus chart

### DIFF
--- a/config/monitoring/prometheus/templates/statefulset.yaml
+++ b/config/monitoring/prometheus/templates/statefulset.yaml
@@ -1,5 +1,5 @@
 {{- if not .Values.prometheus.migration.enabled }}
-apiVersion: apps/v1beta2
+apiVersion: apps/v1
 kind: StatefulSet
 metadata:
   name: '{{ template "name" . }}'


### PR DESCRIPTION
**What this PR does / why we need it**:

Fixes the prometheus chart to be v1.16 compatible, file was missed in 4b66e46ac29e75cf9d2e91028f80d961e7835b2b.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:

**Special notes for your reviewer**:

**Documentation**:
<!-- Add links to the related documentation changes related to this pull request. E.g. the link to the kubermatic/docs pullrequest. -->

**Does this PR introduce a user-facing change?**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If  no release note is required, just write "NONE".
-->
```release-note
NONE
```
