### PR TITLE
Add migrations for credential secrets

### DIFF
--- a/api/pkg/crd/migrations/credentials.go
+++ b/api/pkg/crd/migrations/credentials.go
@@ -1,0 +1,654 @@
+package migrations
+
+import (
+	"fmt"
+	"github.com/golang/glog"
+
+	apiv1 "github.com/kubermatic/kubermatic/api/pkg/api/v1"
+	kubermaticv1 "github.com/kubermatic/kubermatic/api/pkg/crd/kubermatic/v1"
+	kuberneteshelper "github.com/kubermatic/kubermatic/api/pkg/kubernetes"
+	"github.com/kubermatic/kubermatic/api/pkg/resources"
+	"github.com/kubermatic/machine-controller/pkg/providerconfig"
+
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+func createSecretsForCredentials(cluster *kubermaticv1.Cluster, ctx *cleanupContext) error {
+	var err error
+	if cluster.Spec.Cloud.AWS != nil {
+		err = createAWSSecret(cluster, ctx)
+	}
+	if cluster.Spec.Cloud.Azure != nil {
+		err = createAzureSecret(cluster, ctx)
+	}
+	if cluster.Spec.Cloud.Digitalocean != nil {
+		err = createDigitaloceanSecret(cluster, ctx)
+	}
+	if cluster.Spec.Cloud.GCP != nil {
+		err = createGCPSecret(cluster, ctx)
+	}
+	if cluster.Spec.Cloud.Hetzner != nil {
+		err = createHetznerSecret(cluster, ctx)
+	}
+	if cluster.Spec.Cloud.Openstack != nil {
+		err = createOpenstackSecret(cluster, ctx)
+	}
+	if cluster.Spec.Cloud.Packet != nil {
+		err = createPacketSecret(cluster, ctx)
+	}
+	if cluster.Spec.Cloud.Kubevirt != nil {
+		err = createKubevirtSecret(cluster, ctx)
+	}
+	if err != nil {
+		return err
+	}
+
+	kuberneteshelper.AddFinalizer(cluster, apiv1.CredentialsSecretsCleanupFinalizer)
+	updatedCluster, err := ctx.kubermaticClient.KubermaticV1().Clusters().Update(cluster)
+	if err != nil {
+		return fmt.Errorf("failed to update cluster %q: %v", cluster.Name, err)
+	}
+	*cluster = *updatedCluster
+	return nil
+}
+
+func createAWSSecret(cluster *kubermaticv1.Cluster, ctx *cleanupContext) error {
+	spec := cluster.Spec.Cloud.AWS
+	referenceDefined := spec.CredentialsReference != nil && spec.CredentialsReference.Name != ""
+	valuesDefined := spec.AccessKeyID != "" || spec.SecretAccessKey != ""
+
+	var secret *corev1.Secret
+	if !referenceDefined && valuesDefined {
+		secret = &corev1.Secret{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      cluster.GetSecretName(),
+				Namespace: resources.KubermaticNamespace,
+			},
+			Type: corev1.SecretTypeOpaque,
+			Data: map[string][]byte{
+				resources.AWSAccessKeyID:     []byte(spec.AccessKeyID),
+				resources.AWSSecretAccessKey: []byte(spec.SecretAccessKey),
+			},
+		}
+
+		if _, err := ctx.kubeClient.CoreV1().Secrets(resources.KubermaticNamespace).Create(secret); err != nil {
+			return err
+		}
+		glog.Infof("the secret = %s was created for cluster = %s resource", cluster.GetSecretName(), cluster.Name)
+	}
+
+	if !referenceDefined {
+		cluster.Spec.Cloud.AWS.CredentialsReference = &providerconfig.GlobalSecretKeySelector{
+			ObjectReference: corev1.ObjectReference{
+				Name:      cluster.GetSecretName(),
+				Namespace: resources.KubermaticNamespace,
+			},
+		}
+	}
+
+	// treat the value provided as the sourch of truth and update the secret with this value
+	if referenceDefined && valuesDefined {
+		var updateNeeded bool
+		existingSecret, err := ctx.kubeClient.CoreV1().Secrets(resources.KubermaticNamespace).Get(cluster.GetSecretName(), metav1.GetOptions{})
+		if err != nil {
+			return err
+		}
+		if existingSecret.Data == nil {
+			existingSecret.Data = map[string][]byte{}
+		}
+
+		if existingSecret.Data != nil {
+			if accessKeyID, ok := existingSecret.Data[resources.AWSAccessKeyID]; ok {
+				if string(accessKeyID) != spec.AccessKeyID {
+					existingSecret.Data[resources.AWSAccessKeyID] = []byte(spec.AccessKeyID)
+					updateNeeded = true
+				}
+			}
+			if secretAccessKey, ok := existingSecret.Data[resources.AWSSecretAccessKey]; ok {
+				if string(secretAccessKey) != spec.SecretAccessKey {
+					existingSecret.Data[resources.AWSSecretAccessKey] = []byte(spec.SecretAccessKey)
+					updateNeeded = true
+				}
+			}
+		}
+		if updateNeeded {
+			if _, err := ctx.kubeClient.CoreV1().Secrets(resources.KubermaticNamespace).Update(existingSecret); err != nil {
+				return fmt.Errorf("error updating secret: %v", err)
+			}
+		}
+	}
+
+	if valuesDefined {
+		cluster.Spec.Cloud.AWS.AccessKeyID = ""
+		cluster.Spec.Cloud.AWS.SecretAccessKey = ""
+	}
+
+	return nil
+}
+
+func createAzureSecret(cluster *kubermaticv1.Cluster, ctx *cleanupContext) error {
+	spec := cluster.Spec.Cloud.Azure
+	referenceDefined := spec.CredentialsReference != nil && spec.CredentialsReference.Name != ""
+	valuesDefined := spec.TenantID != "" || spec.SubscriptionID != "" || spec.ClientID != "" || spec.ClientSecret != ""
+
+	var secret *corev1.Secret
+	if !referenceDefined && valuesDefined {
+		secret = &corev1.Secret{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      cluster.GetSecretName(),
+				Namespace: resources.KubermaticNamespace,
+			},
+			Type: corev1.SecretTypeOpaque,
+			Data: map[string][]byte{
+				resources.AzureTenantID:       []byte(spec.TenantID),
+				resources.AzureSubscriptionID: []byte(spec.SubscriptionID),
+				resources.AzureClientID:       []byte(spec.ClientID),
+				resources.AzureClientSecret:   []byte(spec.ClientSecret),
+			},
+		}
+
+		if _, err := ctx.kubeClient.CoreV1().Secrets(resources.KubermaticNamespace).Create(secret); err != nil {
+			return err
+		}
+		glog.Infof("the secret = %s was created for cluster = %s resource", cluster.GetSecretName(), cluster.Name)
+	}
+
+	if !referenceDefined {
+		cluster.Spec.Cloud.Azure.CredentialsReference = &providerconfig.GlobalSecretKeySelector{
+			ObjectReference: corev1.ObjectReference{
+				Name:      cluster.GetSecretName(),
+				Namespace: resources.KubermaticNamespace,
+			},
+		}
+	}
+
+	// treat the value provided as the sourch of truth and update the secret with this value
+	if referenceDefined && valuesDefined {
+		var updateNeeded bool
+		existingSecret, err := ctx.kubeClient.CoreV1().Secrets(resources.KubermaticNamespace).Get(cluster.GetSecretName(), metav1.GetOptions{})
+		if err != nil {
+			return err
+		}
+		if existingSecret.Data == nil {
+			existingSecret.Data = map[string][]byte{}
+		}
+
+		if existingSecret.Data != nil {
+			if tenantID, ok := existingSecret.Data[resources.AzureTenantID]; ok {
+				if string(tenantID) != spec.TenantID {
+					existingSecret.Data[resources.AzureTenantID] = []byte(spec.TenantID)
+					updateNeeded = true
+				}
+			}
+			if subscriptionID, ok := existingSecret.Data[resources.AzureSubscriptionID]; ok {
+				if string(subscriptionID) != spec.SubscriptionID {
+					existingSecret.Data[resources.AzureSubscriptionID] = []byte(spec.SubscriptionID)
+					updateNeeded = true
+				}
+			}
+			if clientID, ok := existingSecret.Data[resources.AzureClientID]; ok {
+				if string(clientID) != spec.ClientID {
+					existingSecret.Data[resources.AzureClientID] = []byte(spec.ClientID)
+					updateNeeded = true
+				}
+			}
+			if clientSecret, ok := existingSecret.Data[resources.AzureClientSecret]; ok {
+				if string(clientSecret) != spec.ClientSecret {
+					existingSecret.Data[resources.AzureClientSecret] = []byte(spec.ClientSecret)
+					updateNeeded = true
+				}
+			}
+		}
+		if updateNeeded {
+			if _, err := ctx.kubeClient.CoreV1().Secrets(resources.KubermaticNamespace).Update(existingSecret); err != nil {
+				return fmt.Errorf("error updating secret: %v", err)
+			}
+		}
+	}
+
+	if valuesDefined {
+		cluster.Spec.Cloud.Azure.TenantID = ""
+		cluster.Spec.Cloud.Azure.SubscriptionID = ""
+		cluster.Spec.Cloud.Azure.ClientID = ""
+		cluster.Spec.Cloud.Azure.ClientSecret = ""
+	}
+
+	return nil
+}
+
+func createDigitaloceanSecret(cluster *kubermaticv1.Cluster, ctx *cleanupContext) error {
+	spec := cluster.Spec.Cloud.Digitalocean
+	referenceDefined := spec.CredentialsReference != nil && spec.CredentialsReference.Name != ""
+	valuesDefined := spec.Token != ""
+
+	var secret *corev1.Secret
+	if !referenceDefined && valuesDefined {
+		secret = &corev1.Secret{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      cluster.GetSecretName(),
+				Namespace: resources.KubermaticNamespace,
+			},
+			Type: corev1.SecretTypeOpaque,
+			Data: map[string][]byte{
+				resources.DigitaloceanToken: []byte(cluster.Spec.Cloud.Digitalocean.Token),
+			},
+		}
+
+		if _, err := ctx.kubeClient.CoreV1().Secrets(resources.KubermaticNamespace).Create(secret); err != nil {
+			return err
+		}
+		glog.Infof("the secret = %s was created for cluster = %s resource", cluster.GetSecretName(), cluster.Name)
+	}
+
+	if !referenceDefined {
+		cluster.Spec.Cloud.Digitalocean.CredentialsReference = &providerconfig.GlobalSecretKeySelector{
+			ObjectReference: corev1.ObjectReference{
+				Name:      cluster.GetSecretName(),
+				Namespace: resources.KubermaticNamespace,
+			},
+		}
+	}
+
+	// treat the value provided as the sourch of truth and update the secret with this value
+	if referenceDefined && valuesDefined {
+		var updateNeeded bool
+		existingSecret, err := ctx.kubeClient.CoreV1().Secrets(resources.KubermaticNamespace).Get(cluster.GetSecretName(), metav1.GetOptions{})
+		if err != nil {
+			return err
+		}
+		if existingSecret.Data == nil {
+			existingSecret.Data = map[string][]byte{}
+		}
+
+		if existingSecret.Data != nil {
+			if token, ok := existingSecret.Data[resources.DigitaloceanToken]; ok {
+				if string(token) != spec.Token {
+					existingSecret.Data[resources.DigitaloceanToken] = []byte(spec.Token)
+					updateNeeded = true
+				}
+			}
+		}
+		if updateNeeded {
+			if _, err := ctx.kubeClient.CoreV1().Secrets(resources.KubermaticNamespace).Update(existingSecret); err != nil {
+				return fmt.Errorf("error updating secret: %v", err)
+			}
+		}
+	}
+
+	if valuesDefined {
+		cluster.Spec.Cloud.Digitalocean.Token = ""
+	}
+
+	return nil
+}
+
+func createGCPSecret(cluster *kubermaticv1.Cluster, ctx *cleanupContext) error {
+	spec := cluster.Spec.Cloud.GCP
+	referenceDefined := spec.CredentialsReference != nil && spec.CredentialsReference.Name != ""
+	valuesDefined := spec.ServiceAccount != ""
+
+	var secret *corev1.Secret
+	if !referenceDefined && valuesDefined {
+		secret = &corev1.Secret{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      cluster.GetSecretName(),
+				Namespace: resources.KubermaticNamespace,
+			},
+			Type: corev1.SecretTypeOpaque,
+			Data: map[string][]byte{
+				resources.GCPServiceAccount: []byte(spec.ServiceAccount),
+			},
+		}
+
+		if _, err := ctx.kubeClient.CoreV1().Secrets(resources.KubermaticNamespace).Create(secret); err != nil {
+			return err
+		}
+		glog.Infof("the secret = %s was created for cluster = %s resource", cluster.GetSecretName(), cluster.Name)
+	}
+
+	if !referenceDefined {
+		cluster.Spec.Cloud.GCP.CredentialsReference = &providerconfig.GlobalSecretKeySelector{
+			ObjectReference: corev1.ObjectReference{
+				Name:      cluster.GetSecretName(),
+				Namespace: resources.KubermaticNamespace,
+			},
+		}
+	}
+
+	// treat the value provided as the sourch of truth and update the secret with this value
+	if referenceDefined && valuesDefined {
+		var updateNeeded bool
+		existingSecret, err := ctx.kubeClient.CoreV1().Secrets(resources.KubermaticNamespace).Get(cluster.GetSecretName(), metav1.GetOptions{})
+		if err != nil {
+			return err
+		}
+		if existingSecret.Data == nil {
+			existingSecret.Data = map[string][]byte{}
+		}
+
+		if existingSecret.Data != nil {
+			if sa, ok := existingSecret.Data[resources.GCPServiceAccount]; ok {
+				if string(sa) != spec.ServiceAccount {
+					existingSecret.Data[resources.GCPServiceAccount] = []byte(spec.ServiceAccount)
+					updateNeeded = true
+				}
+			}
+		}
+		if updateNeeded {
+			if _, err := ctx.kubeClient.CoreV1().Secrets(resources.KubermaticNamespace).Update(existingSecret); err != nil {
+				return fmt.Errorf("error updating secret: %v", err)
+			}
+		}
+	}
+
+	if valuesDefined {
+		cluster.Spec.Cloud.GCP.ServiceAccount = ""
+	}
+
+	return nil
+}
+
+func createHetznerSecret(cluster *kubermaticv1.Cluster, ctx *cleanupContext) error {
+	spec := cluster.Spec.Cloud.Hetzner
+	referenceDefined := spec.CredentialsReference != nil && spec.CredentialsReference.Name != ""
+	valuesDefined := spec.Token != ""
+
+	var secret *corev1.Secret
+	if !referenceDefined && valuesDefined {
+		secret = &corev1.Secret{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      cluster.GetSecretName(),
+				Namespace: resources.KubermaticNamespace,
+			},
+			Type: corev1.SecretTypeOpaque,
+			Data: map[string][]byte{
+				resources.HetznerToken: []byte(cluster.Spec.Cloud.Hetzner.Token),
+			},
+		}
+
+		if _, err := ctx.kubeClient.CoreV1().Secrets(resources.KubermaticNamespace).Create(secret); err != nil {
+			return err
+		}
+		glog.Infof("the secret = %s was created for cluster = %s resource", cluster.GetSecretName(), cluster.Name)
+	}
+
+	if !referenceDefined {
+		cluster.Spec.Cloud.Hetzner.CredentialsReference = &providerconfig.GlobalSecretKeySelector{
+			ObjectReference: corev1.ObjectReference{
+				Name:      cluster.GetSecretName(),
+				Namespace: resources.KubermaticNamespace,
+			},
+		}
+	}
+
+	// treat the value provided as the sourch of truth and update the secret with this value
+	if referenceDefined && valuesDefined {
+		var updateNeeded bool
+		existingSecret, err := ctx.kubeClient.CoreV1().Secrets(resources.KubermaticNamespace).Get(cluster.GetSecretName(), metav1.GetOptions{})
+		if err != nil {
+			return err
+		}
+		if existingSecret.Data == nil {
+			existingSecret.Data = map[string][]byte{}
+		}
+
+		if existingSecret.Data != nil {
+			if token, ok := existingSecret.Data[resources.HetznerToken]; ok {
+				if string(token) != spec.Token {
+					existingSecret.Data[resources.HetznerToken] = []byte(spec.Token)
+					updateNeeded = true
+				}
+			}
+		}
+		if updateNeeded {
+			if _, err := ctx.kubeClient.CoreV1().Secrets(resources.KubermaticNamespace).Update(existingSecret); err != nil {
+				return fmt.Errorf("error updating secret: %v", err)
+			}
+		}
+	}
+
+	if valuesDefined {
+		cluster.Spec.Cloud.Hetzner.Token = ""
+	}
+
+	return nil
+}
+
+func createOpenstackSecret(cluster *kubermaticv1.Cluster, ctx *cleanupContext) error {
+	spec := cluster.Spec.Cloud.Openstack
+	referenceDefined := spec.CredentialsReference != nil && spec.CredentialsReference.Name != ""
+	valuesDefined := spec.Username != "" || spec.Password != "" || spec.Tenant != "" || spec.TenantID != "" || spec.Domain != ""
+
+	var secret *corev1.Secret
+	if !referenceDefined && valuesDefined {
+		secret = &corev1.Secret{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      cluster.GetSecretName(),
+				Namespace: resources.KubermaticNamespace,
+			},
+			Type: corev1.SecretTypeOpaque,
+			Data: map[string][]byte{
+				resources.OpenstackUsername: []byte(spec.Username),
+				resources.OpenstackPassword: []byte(spec.Password),
+				resources.OpenstackTenant:   []byte(spec.Tenant),
+				resources.OpenstackTenantID: []byte(spec.TenantID),
+				resources.OpenstackDomain:   []byte(spec.Domain),
+			},
+		}
+
+		if _, err := ctx.kubeClient.CoreV1().Secrets(resources.KubermaticNamespace).Create(secret); err != nil {
+			return err
+		}
+		glog.Infof("the secret = %s was created for cluster = %s resource", cluster.GetSecretName(), cluster.Name)
+	}
+
+	if !referenceDefined {
+		cluster.Spec.Cloud.Openstack.CredentialsReference = &providerconfig.GlobalSecretKeySelector{
+			ObjectReference: corev1.ObjectReference{
+				Name:      cluster.GetSecretName(),
+				Namespace: resources.KubermaticNamespace,
+			},
+		}
+	}
+
+	// treat the value provided as the sourch of truth and update the secret with this value
+	if referenceDefined && valuesDefined {
+		var updateNeeded bool
+		existingSecret, err := ctx.kubeClient.CoreV1().Secrets(resources.KubermaticNamespace).Get(cluster.GetSecretName(), metav1.GetOptions{})
+		if err != nil {
+			return err
+		}
+		if existingSecret.Data == nil {
+			existingSecret.Data = map[string][]byte{}
+		}
+
+		if existingSecret.Data != nil {
+			if username, ok := existingSecret.Data[resources.OpenstackUsername]; ok {
+				if string(username) != spec.Username {
+					existingSecret.Data[resources.OpenstackUsername] = []byte(spec.Username)
+					updateNeeded = true
+				}
+			}
+			if password, ok := existingSecret.Data[resources.OpenstackPassword]; ok {
+				if string(password) != spec.Password {
+					existingSecret.Data[resources.OpenstackPassword] = []byte(spec.Password)
+					updateNeeded = true
+				}
+			}
+			if tenant, ok := existingSecret.Data[resources.OpenstackTenant]; ok {
+				if string(tenant) != spec.Tenant {
+					existingSecret.Data[resources.OpenstackTenant] = []byte(spec.Tenant)
+					updateNeeded = true
+				}
+			}
+			if tenantID, ok := existingSecret.Data[resources.OpenstackTenantID]; ok {
+				if string(tenantID) != spec.TenantID {
+					existingSecret.Data[resources.OpenstackTenantID] = []byte(spec.TenantID)
+					updateNeeded = true
+				}
+			}
+			if domain, ok := existingSecret.Data[resources.OpenstackDomain]; ok {
+				if string(domain) != spec.Domain {
+					existingSecret.Data[resources.OpenstackDomain] = []byte(spec.Domain)
+					updateNeeded = true
+				}
+			}
+		}
+		if updateNeeded {
+			if _, err := ctx.kubeClient.CoreV1().Secrets(resources.KubermaticNamespace).Update(existingSecret); err != nil {
+				return fmt.Errorf("error updating secret: %v", err)
+			}
+		}
+	}
+
+	if valuesDefined {
+		cluster.Spec.Cloud.Openstack.Username = ""
+		cluster.Spec.Cloud.Openstack.Password = ""
+		cluster.Spec.Cloud.Openstack.Tenant = ""
+		cluster.Spec.Cloud.Openstack.TenantID = ""
+		cluster.Spec.Cloud.Openstack.Domain = ""
+	}
+
+	return nil
+}
+
+func createPacketSecret(cluster *kubermaticv1.Cluster, ctx *cleanupContext) error {
+	spec := cluster.Spec.Cloud.Packet
+	referenceDefined := spec.CredentialsReference != nil && spec.CredentialsReference.Name != ""
+	valuesDefined := spec.APIKey != "" || spec.ProjectID != ""
+
+	var secret *corev1.Secret
+	if !referenceDefined && valuesDefined {
+		secret = &corev1.Secret{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      cluster.GetSecretName(),
+				Namespace: resources.KubermaticNamespace,
+			},
+			Type: corev1.SecretTypeOpaque,
+			Data: map[string][]byte{
+				resources.PacketAPIKey:    []byte(cluster.Spec.Cloud.Packet.APIKey),
+				resources.PacketProjectID: []byte(cluster.Spec.Cloud.Packet.ProjectID),
+			},
+		}
+
+		if _, err := ctx.kubeClient.CoreV1().Secrets(resources.KubermaticNamespace).Create(secret); err != nil {
+			return err
+		}
+		glog.Infof("the secret = %s was created for cluster = %s resource", cluster.GetSecretName(), cluster.Name)
+	}
+
+	if !referenceDefined {
+		cluster.Spec.Cloud.Hetzner.CredentialsReference = &providerconfig.GlobalSecretKeySelector{
+			ObjectReference: corev1.ObjectReference{
+				Name:      cluster.GetSecretName(),
+				Namespace: resources.KubermaticNamespace,
+			},
+		}
+	}
+
+	// treat the value provided as the sourch of truth and update the secret with this value
+	if referenceDefined && valuesDefined {
+		var updateNeeded bool
+		existingSecret, err := ctx.kubeClient.CoreV1().Secrets(resources.KubermaticNamespace).Get(cluster.GetSecretName(), metav1.GetOptions{})
+		if err != nil {
+			return err
+		}
+		if existingSecret.Data == nil {
+			existingSecret.Data = map[string][]byte{}
+		}
+
+		if existingSecret.Data != nil {
+			if apiKey, ok := existingSecret.Data[resources.PacketAPIKey]; ok {
+				if string(apiKey) != spec.APIKey {
+					existingSecret.Data[resources.PacketAPIKey] = []byte(spec.APIKey)
+					updateNeeded = true
+				}
+			}
+			if projectID, ok := existingSecret.Data[resources.PacketProjectID]; ok {
+				if string(projectID) != spec.ProjectID {
+					existingSecret.Data[resources.PacketProjectID] = []byte(spec.ProjectID)
+					updateNeeded = true
+				}
+			}
+		}
+		if updateNeeded {
+			if _, err := ctx.kubeClient.CoreV1().Secrets(resources.KubermaticNamespace).Update(existingSecret); err != nil {
+				return fmt.Errorf("error updating secret: %v", err)
+			}
+		}
+	}
+
+	if valuesDefined {
+		cluster.Spec.Cloud.Packet.APIKey = ""
+		cluster.Spec.Cloud.Packet.ProjectID = ""
+	}
+
+	return nil
+}
+
+func createKubevirtSecret(cluster *kubermaticv1.Cluster, ctx *cleanupContext) error {
+	spec := cluster.Spec.Cloud.Kubevirt
+	referenceDefined := spec.CredentialsReference != nil && spec.CredentialsReference.Name != ""
+	valuesDefined := spec.Kubeconfig != ""
+
+	var secret *corev1.Secret
+	if !referenceDefined && valuesDefined {
+		secret = &corev1.Secret{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      cluster.GetSecretName(),
+				Namespace: resources.KubermaticNamespace,
+			},
+			Type: corev1.SecretTypeOpaque,
+			Data: map[string][]byte{
+				resources.KubevirtKubeConfig: []byte(cluster.Spec.Cloud.Kubevirt.Kubeconfig),
+			},
+		}
+
+		if _, err := ctx.kubeClient.CoreV1().Secrets(resources.KubermaticNamespace).Create(secret); err != nil {
+			return err
+		}
+		glog.Infof("the secret = %s was created for cluster = %s resource", cluster.GetSecretName(), cluster.Name)
+	}
+
+	if !referenceDefined {
+		cluster.Spec.Cloud.Kubevirt.CredentialsReference = &providerconfig.GlobalSecretKeySelector{
+			ObjectReference: corev1.ObjectReference{
+				Name:      cluster.GetSecretName(),
+				Namespace: resources.KubermaticNamespace,
+			},
+		}
+	}
+
+	// treat the value provided as the sourch of truth and update the secret with this value
+	if referenceDefined && valuesDefined {
+		var updateNeeded bool
+		existingSecret, err := ctx.kubeClient.CoreV1().Secrets(resources.KubermaticNamespace).Get(cluster.GetSecretName(), metav1.GetOptions{})
+		if err != nil {
+			return err
+		}
+		if existingSecret.Data == nil {
+			existingSecret.Data = map[string][]byte{}
+		}
+
+		if existingSecret.Data != nil {
+			if kubeconfig, ok := existingSecret.Data[resources.KubevirtKubeConfig]; ok {
+				if string(kubeconfig) != spec.Kubeconfig {
+					existingSecret.Data[resources.KubevirtKubeConfig] = []byte(spec.Kubeconfig)
+					updateNeeded = true
+				}
+			}
+		}
+		if updateNeeded {
+			if _, err := ctx.kubeClient.CoreV1().Secrets(resources.KubermaticNamespace).Update(existingSecret); err != nil {
+				return fmt.Errorf("error updating secret: %v", err)
+			}
+		}
+	}
+
+	if valuesDefined {
+		cluster.Spec.Cloud.Kubevirt.Kubeconfig = ""
+	}
+
+	return nil
+}

--- a/api/pkg/crd/migrations/credentials_test.go
+++ b/api/pkg/crd/migrations/credentials_test.go
@@ -1,0 +1,132 @@
+package migrations
+
+import (
+	"testing"
+
+	kubermaticfakeclientset "github.com/kubermatic/kubermatic/api/pkg/crd/client/clientset/versioned/fake"
+	kubermaticv1 "github.com/kubermatic/kubermatic/api/pkg/crd/kubermatic/v1"
+	"github.com/kubermatic/kubermatic/api/pkg/resources"
+	"github.com/kubermatic/machine-controller/pkg/providerconfig"
+
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/client-go/kubernetes/fake"
+)
+
+func TestCreateSecretsForCredentials(t *testing.T) {
+	tests := []struct {
+		name        string
+		spec        kubermaticv1.CloudSpec
+		secretToken string
+	}{
+		{
+			name: "cluster with only value defined",
+			spec: kubermaticv1.CloudSpec{
+				Hetzner: &kubermaticv1.HetznerCloudSpec{
+					Token: "some-token",
+				},
+			},
+		},
+		{
+			name:        "cluster with only reference defined",
+			secretToken: "some-token",
+			spec: kubermaticv1.CloudSpec{
+				Hetzner: &kubermaticv1.HetznerCloudSpec{
+					CredentialsReference: &providerconfig.GlobalSecretKeySelector{
+						ObjectReference: corev1.ObjectReference{
+							Name:      "credential-hetzner-test-cluster",
+							Namespace: resources.KubermaticNamespace,
+						},
+						Key: resources.HetznerToken,
+					},
+				},
+			},
+		},
+		{
+			name:        "cluster with both reference and values defined",
+			secretToken: "some-other-token",
+			spec: kubermaticv1.CloudSpec{
+				Hetzner: &kubermaticv1.HetznerCloudSpec{
+					CredentialsReference: &providerconfig.GlobalSecretKeySelector{
+						ObjectReference: corev1.ObjectReference{
+							Name:      "credential-hetzner-test-cluster",
+							Namespace: resources.KubermaticNamespace,
+						},
+						Key: resources.HetznerToken,
+					},
+					Token: "some-token",
+				},
+			},
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			kubeObjs := []runtime.Object{}
+			if test.spec.Hetzner.CredentialsReference != nil {
+				kubeObjs = append(kubeObjs, newSecret(test.secretToken))
+			}
+			fakeKubeClient := fake.NewSimpleClientset(kubeObjs...)
+
+			cluster := newCluster(test.spec)
+			kubermaticObjs := []runtime.Object{cluster}
+			fakeKubermaticClient := kubermaticfakeclientset.NewSimpleClientset(kubermaticObjs...)
+
+			ctx := &cleanupContext{
+				kubeClient:       fakeKubeClient,
+				kubermaticClient: fakeKubermaticClient,
+			}
+			if err := createSecretsForCredentials(cluster, ctx); err != nil {
+				t.Errorf("%s: error creating secrets for credentials: %v", test.name, err)
+			}
+
+			if cluster.Spec.Cloud.Hetzner.CredentialsReference == nil {
+				t.Errorf("%s: credentialsReference field is not set", test.name)
+			}
+			if cluster.Spec.Cloud.Hetzner.Token != "" {
+				t.Errorf("%s: token field is not cleared", test.name)
+			}
+
+			secret, err := ctx.kubeClient.CoreV1().Secrets(resources.KubermaticNamespace).Get(cluster.GetSecretName(), metav1.GetOptions{})
+			if err != nil {
+				t.Fatalf("%s: error getting secret %s: %v", test.name, cluster.GetSecretName(), err)
+			}
+			if secret.Data == nil {
+				t.Fatalf("%s: secret %s has empty data", test.name, cluster.GetSecretName())
+			}
+
+			token, ok := secret.Data[resources.HetznerToken]
+			if !ok {
+				t.Fatalf("%s: secret %s does not have %s key", test.name, cluster.GetSecretName(), resources.HetznerToken)
+			}
+			if string(token) != "some-token" {
+				t.Errorf("%s: expected token value in secret: \"some-token\", got: %s", test.name, string(token))
+			}
+		})
+	}
+}
+
+func newCluster(cloudSpec kubermaticv1.CloudSpec) *kubermaticv1.Cluster {
+	return &kubermaticv1.Cluster{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "test-cluster",
+		},
+		Spec: kubermaticv1.ClusterSpec{
+			Cloud: cloudSpec,
+		},
+	}
+}
+
+func newSecret(token string) *corev1.Secret {
+	return &corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "credential-hetzner-test-cluster",
+			Namespace: resources.KubermaticNamespace,
+		},
+		Type: corev1.SecretTypeOpaque,
+		Data: map[string][]byte{
+			resources.HetznerToken: []byte(token),
+		},
+	}
+}

--- a/api/pkg/crd/migrations/migrations.go
+++ b/api/pkg/crd/migrations/migrations.go
@@ -98,6 +98,7 @@ func cleanupCluster(cluster *kubermaticv1.Cluster, ctx *cleanupContext) error {
 	tasks := []ClusterTask{
 		setExposeStrategyIfEmpty,
 		setProxyModeIfEmpty,
+		createSecretsForCredentials,
 	}
 
 	w := sync.WaitGroup{}

--- a/api/pkg/handler/routes_v1.go
+++ b/api/pkg/handler/routes_v1.go
@@ -1353,6 +1353,7 @@ func (r Routing) patchCluster() http.Handler {
 			middleware.TokenVerifier(r.tokenVerifiers),
 			middleware.UserSaver(r.userProvider),
 			middleware.SetClusterProvider(r.clusterProviderGetter, r.seedsGetter),
+			middleware.SetPrivilegedClusterProvider(r.clusterProviderGetter, r.seedsGetter),
 			middleware.UserInfoExtractor(r.userProjectMapper),
 		)(cluster.PatchEndpoint(r.projectProvider, r.seedsGetter)),
 		cluster.DecodePatchReq,

--- a/api/pkg/provider/kubernetes/credentials.go
+++ b/api/pkg/provider/kubernetes/credentials.go
@@ -9,335 +9,628 @@ import (
 
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
 	ctrlruntimeclient "sigs.k8s.io/controller-runtime/pkg/client"
 )
 
 // CreateCredentialSecretForCluster creates a new secret for a credential
-func CreateCredentialSecretForCluster(ctx context.Context, seedClient ctrlruntimeclient.Client, cluster *kubermaticv1.Cluster, projectID string) error {
+func CreateOrUpdateCredentialSecretForCluster(ctx context.Context, seedClient ctrlruntimeclient.Client, cluster *kubermaticv1.Cluster, projectID string) error {
 	if cluster.Spec.Cloud.AWS != nil {
-		return createAWSSecret(ctx, seedClient, cluster, projectID)
+		return createOrUpdateAWSSecret(ctx, seedClient, cluster, projectID)
 	}
 	if cluster.Spec.Cloud.Azure != nil {
-		return createAzureSecret(ctx, seedClient, cluster, projectID)
+		return createOrUpdateAzureSecret(ctx, seedClient, cluster, projectID)
 	}
 	if cluster.Spec.Cloud.Digitalocean != nil {
-		return createDigitaloceanSecret(ctx, seedClient, cluster, projectID)
+		return createOrUpdateDigitaloceanSecret(ctx, seedClient, cluster, projectID)
 	}
 	if cluster.Spec.Cloud.GCP != nil {
-		return createGCPSecret(ctx, seedClient, cluster, projectID)
+		return createOrUpdateGCPSecret(ctx, seedClient, cluster, projectID)
 	}
 	if cluster.Spec.Cloud.Hetzner != nil {
-		return createHetznerSecret(ctx, seedClient, cluster, projectID)
+		return createOrUpdateHetznerSecret(ctx, seedClient, cluster, projectID)
 	}
 	if cluster.Spec.Cloud.Openstack != nil {
-		return createOpenstackSecret(ctx, seedClient, cluster, projectID)
+		return createOrUpdateOpenstackSecret(ctx, seedClient, cluster, projectID)
 	}
 	if cluster.Spec.Cloud.Packet != nil {
-		return createPacketSecret(ctx, seedClient, cluster, projectID)
+		return createOrUpdatePacketSecret(ctx, seedClient, cluster, projectID)
 	}
 	if cluster.Spec.Cloud.Kubevirt != nil {
-		return createKubevirtSecret(ctx, seedClient, cluster, projectID)
+		return createOrUpdateKubevirtSecret(ctx, seedClient, cluster, projectID)
 	}
 	return nil
 }
 
-func createAWSSecret(ctx context.Context, seedClient ctrlruntimeclient.Client, cluster *kubermaticv1.Cluster, projectID string) error {
-	// create secret for storing credentials
-	name := cluster.GetSecretName()
-	secret := &corev1.Secret{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:      name,
-			Namespace: resources.KubermaticNamespace,
-			Labels: map[string]string{
-				kubermaticv1.ProjectIDLabelKey: projectID,
-				"name":                         name,
+func createOrUpdateAWSSecret(ctx context.Context, seedClient ctrlruntimeclient.Client, cluster *kubermaticv1.Cluster, projectID string) error {
+	spec := cluster.Spec.Cloud.AWS
+	referenceDefined := spec.CredentialsReference != nil && spec.CredentialsReference.Name != ""
+	valuesDefined := spec.AccessKeyID != "" || spec.SecretAccessKey != ""
+
+	if !referenceDefined && valuesDefined {
+		name := cluster.GetSecretName()
+		secret := &corev1.Secret{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      name,
+				Namespace: resources.KubermaticNamespace,
+				Labels: map[string]string{
+					kubermaticv1.ProjectIDLabelKey: projectID,
+					"name":                         name,
+				},
 			},
-		},
-		Type: corev1.SecretTypeOpaque,
-		Data: map[string][]byte{
-			resources.AWSAccessKeyID:     []byte(cluster.Spec.Cloud.AWS.AccessKeyID),
-			resources.AWSSecretAccessKey: []byte(cluster.Spec.Cloud.AWS.SecretAccessKey),
-		},
+			Type: corev1.SecretTypeOpaque,
+			Data: map[string][]byte{
+				resources.AWSAccessKeyID:     []byte(spec.AccessKeyID),
+				resources.AWSSecretAccessKey: []byte(spec.SecretAccessKey),
+			},
+		}
+
+		if err := seedClient.Create(ctx, secret); err != nil {
+			return err
+		}
+
+		// add secret key selectors to cluster object
+		cluster.Spec.Cloud.AWS.CredentialsReference = &providerconfig.GlobalSecretKeySelector{
+			ObjectReference: corev1.ObjectReference{
+				Name:      cluster.GetSecretName(),
+				Namespace: resources.KubermaticNamespace,
+			},
+		}
 	}
 
-	if err := seedClient.Create(ctx, secret); err != nil {
-		return err
+	if referenceDefined && valuesDefined {
+		namespacedName := types.NamespacedName{Namespace: resources.KubermaticNamespace, Name: cluster.GetSecretName()}
+		existingSecret := &corev1.Secret{}
+		if err := seedClient.Get(ctx, namespacedName, existingSecret); err != nil {
+			return err
+		}
+
+		var updateNeeded bool
+		if existingSecret.Data != nil {
+			if accessKeyID, ok := existingSecret.Data[resources.AWSAccessKeyID]; ok {
+				if string(accessKeyID) != spec.AccessKeyID {
+					existingSecret.Data[resources.AWSAccessKeyID] = []byte(spec.AccessKeyID)
+					updateNeeded = true
+				}
+			}
+			if secretAccessKey, ok := existingSecret.Data[resources.AWSSecretAccessKey]; ok {
+				if string(secretAccessKey) != spec.SecretAccessKey {
+					existingSecret.Data[resources.AWSSecretAccessKey] = []byte(spec.SecretAccessKey)
+					updateNeeded = true
+				}
+			}
+		}
+		if updateNeeded {
+			if err := seedClient.Update(ctx, existingSecret); err != nil {
+				return err
+			}
+		}
 	}
 
-	// add secret key selectors to cluster object
-	cluster.Spec.Cloud.AWS.CredentialsReference = &providerconfig.GlobalSecretKeySelector{
-		ObjectReference: corev1.ObjectReference{
-			Name:      secret.Name,
-			Namespace: secret.Namespace,
-		},
+	if valuesDefined {
+		cluster.Spec.Cloud.AWS.AccessKeyID = ""
+		cluster.Spec.Cloud.AWS.SecretAccessKey = ""
 	}
-
-	// remove credentials from cluster object
-	cluster.Spec.Cloud.AWS.AccessKeyID = ""
-	cluster.Spec.Cloud.AWS.SecretAccessKey = ""
 
 	return nil
 }
 
-func createAzureSecret(ctx context.Context, seedClient ctrlruntimeclient.Client, cluster *kubermaticv1.Cluster, projectID string) error {
-	name := cluster.GetSecretName()
-	secret := &corev1.Secret{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:      name,
-			Namespace: resources.KubermaticNamespace,
-			Labels: map[string]string{
-				kubermaticv1.ProjectIDLabelKey: projectID,
-				"name":                         name,
+func createOrUpdateAzureSecret(ctx context.Context, seedClient ctrlruntimeclient.Client, cluster *kubermaticv1.Cluster, projectID string) error {
+	spec := cluster.Spec.Cloud.Azure
+	referenceDefined := spec.CredentialsReference != nil && spec.CredentialsReference.Name != ""
+	valuesDefined := spec.TenantID != "" || spec.SubscriptionID != "" || spec.ClientID != "" || spec.ClientSecret != ""
+
+	if !referenceDefined && valuesDefined {
+		name := cluster.GetSecretName()
+		secret := &corev1.Secret{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      name,
+				Namespace: resources.KubermaticNamespace,
+				Labels: map[string]string{
+					kubermaticv1.ProjectIDLabelKey: projectID,
+					"name":                         name,
+				},
 			},
-		},
-		Type: corev1.SecretTypeOpaque,
-		Data: map[string][]byte{
-			resources.AzureTenantID:       []byte(cluster.Spec.Cloud.Azure.TenantID),
-			resources.AzureSubscriptionID: []byte(cluster.Spec.Cloud.Azure.SubscriptionID),
-			resources.AzureClientID:       []byte(cluster.Spec.Cloud.Azure.ClientID),
-			resources.AzureClientSecret:   []byte(cluster.Spec.Cloud.Azure.ClientSecret),
-		},
+			Type: corev1.SecretTypeOpaque,
+			Data: map[string][]byte{
+				resources.AzureTenantID:       []byte(spec.TenantID),
+				resources.AzureSubscriptionID: []byte(spec.SubscriptionID),
+				resources.AzureClientID:       []byte(spec.ClientID),
+				resources.AzureClientSecret:   []byte(spec.ClientSecret),
+			},
+		}
+
+		if err := seedClient.Create(ctx, secret); err != nil {
+			return err
+		}
+
+		// add secret key selectors to cluster object
+		cluster.Spec.Cloud.Azure.CredentialsReference = &providerconfig.GlobalSecretKeySelector{
+			ObjectReference: corev1.ObjectReference{
+				Name:      cluster.GetSecretName(),
+				Namespace: resources.KubermaticNamespace,
+			},
+		}
 	}
 
-	if err := seedClient.Create(ctx, secret); err != nil {
-		return err
+	if referenceDefined && valuesDefined {
+		namespacedName := types.NamespacedName{Namespace: resources.KubermaticNamespace, Name: cluster.GetSecretName()}
+		existingSecret := &corev1.Secret{}
+		if err := seedClient.Get(ctx, namespacedName, existingSecret); err != nil {
+			return err
+		}
+
+		var updateNeeded bool
+		if existingSecret.Data != nil {
+			if tenantID, ok := existingSecret.Data[resources.AzureTenantID]; ok {
+				if string(tenantID) != spec.TenantID {
+					existingSecret.Data[resources.AzureTenantID] = []byte(spec.TenantID)
+					updateNeeded = true
+				}
+			}
+			if subscriptionID, ok := existingSecret.Data[resources.AzureSubscriptionID]; ok {
+				if string(subscriptionID) != spec.SubscriptionID {
+					existingSecret.Data[resources.AzureSubscriptionID] = []byte(spec.SubscriptionID)
+					updateNeeded = true
+				}
+			}
+			if clientID, ok := existingSecret.Data[resources.AzureClientID]; ok {
+				if string(clientID) != spec.ClientID {
+					existingSecret.Data[resources.AzureClientID] = []byte(spec.ClientID)
+					updateNeeded = true
+				}
+			}
+			if clientSecret, ok := existingSecret.Data[resources.AzureClientSecret]; ok {
+				if string(clientSecret) != spec.ClientSecret {
+					existingSecret.Data[resources.AzureClientSecret] = []byte(spec.ClientSecret)
+					updateNeeded = true
+				}
+			}
+		}
+		if updateNeeded {
+			if err := seedClient.Update(ctx, existingSecret); err != nil {
+				return err
+			}
+		}
 	}
 
-	// add secret key selectors to cluster object
-	cluster.Spec.Cloud.Azure.CredentialsReference = &providerconfig.GlobalSecretKeySelector{
-		ObjectReference: corev1.ObjectReference{
-			Name:      secret.Name,
-			Namespace: secret.Namespace,
-		},
+	if valuesDefined {
+		cluster.Spec.Cloud.Azure.TenantID = ""
+		cluster.Spec.Cloud.Azure.SubscriptionID = ""
+		cluster.Spec.Cloud.Azure.ClientID = ""
+		cluster.Spec.Cloud.Azure.ClientSecret = ""
 	}
-
-	// remove credentials from cluster object
-	cluster.Spec.Cloud.Azure.TenantID = ""
-	cluster.Spec.Cloud.Azure.SubscriptionID = ""
-	cluster.Spec.Cloud.Azure.ClientID = ""
-	cluster.Spec.Cloud.Azure.ClientSecret = ""
 
 	return nil
 }
 
-func createDigitaloceanSecret(ctx context.Context, seedClient ctrlruntimeclient.Client, cluster *kubermaticv1.Cluster, projectID string) error {
-	name := cluster.GetSecretName()
-	secret := &corev1.Secret{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:      name,
-			Namespace: resources.KubermaticNamespace,
-			Labels: map[string]string{
-				kubermaticv1.ProjectIDLabelKey: projectID,
-				"name":                         name,
+func createOrUpdateDigitaloceanSecret(ctx context.Context, seedClient ctrlruntimeclient.Client, cluster *kubermaticv1.Cluster, projectID string) error {
+	spec := cluster.Spec.Cloud.Digitalocean
+	referenceDefined := spec.CredentialsReference != nil && spec.CredentialsReference.Name != ""
+	valuesDefined := spec.Token != ""
+
+	if !referenceDefined && valuesDefined {
+		name := cluster.GetSecretName()
+		secret := &corev1.Secret{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      name,
+				Namespace: resources.KubermaticNamespace,
+				Labels: map[string]string{
+					kubermaticv1.ProjectIDLabelKey: projectID,
+					"name":                         name,
+				},
 			},
-		},
-		Type: corev1.SecretTypeOpaque,
-		Data: map[string][]byte{
-			resources.DigitaloceanToken: []byte(cluster.Spec.Cloud.Digitalocean.Token),
-		},
+			Type: corev1.SecretTypeOpaque,
+			Data: map[string][]byte{
+				resources.DigitaloceanToken: []byte(spec.Token),
+			},
+		}
+
+		if err := seedClient.Create(ctx, secret); err != nil {
+			return err
+		}
+
+		// add secret key selectors to cluster object
+		cluster.Spec.Cloud.Digitalocean.CredentialsReference = &providerconfig.GlobalSecretKeySelector{
+			ObjectReference: corev1.ObjectReference{
+				Name:      cluster.GetSecretName(),
+				Namespace: resources.KubermaticNamespace,
+			},
+		}
 	}
 
-	if err := seedClient.Create(ctx, secret); err != nil {
-		return err
+	if referenceDefined && valuesDefined {
+		namespacedName := types.NamespacedName{Namespace: resources.KubermaticNamespace, Name: cluster.GetSecretName()}
+		existingSecret := &corev1.Secret{}
+		if err := seedClient.Get(ctx, namespacedName, existingSecret); err != nil {
+			return err
+		}
+
+		var updateNeeded bool
+		if existingSecret.Data != nil {
+			if token, ok := existingSecret.Data[resources.DigitaloceanToken]; ok {
+				if string(token) != spec.Token {
+					existingSecret.Data[resources.DigitaloceanToken] = []byte(spec.Token)
+					updateNeeded = true
+				}
+			}
+		}
+
+		if updateNeeded {
+			if err := seedClient.Update(ctx, existingSecret); err != nil {
+				return err
+			}
+		}
 	}
 
-	// add secret key selectors to cluster object
-	cluster.Spec.Cloud.Digitalocean.CredentialsReference = &providerconfig.GlobalSecretKeySelector{
-		ObjectReference: corev1.ObjectReference{
-			Name:      secret.Name,
-			Namespace: secret.Namespace,
-		},
+	if valuesDefined {
+		cluster.Spec.Cloud.Digitalocean.Token = ""
 	}
-
-	// remove credentials from cluster object
-	cluster.Spec.Cloud.Digitalocean.Token = ""
 
 	return nil
 }
 
-func createGCPSecret(ctx context.Context, seedClient ctrlruntimeclient.Client, cluster *kubermaticv1.Cluster, projectID string) error {
-	name := cluster.GetSecretName()
-	secret := &corev1.Secret{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:      name,
-			Namespace: resources.KubermaticNamespace,
-			Labels: map[string]string{
-				kubermaticv1.ProjectIDLabelKey: projectID,
-				"name":                         name,
+func createOrUpdateGCPSecret(ctx context.Context, seedClient ctrlruntimeclient.Client, cluster *kubermaticv1.Cluster, projectID string) error {
+	spec := cluster.Spec.Cloud.GCP
+	referenceDefined := spec.CredentialsReference != nil && spec.CredentialsReference.Name != ""
+	valuesDefined := spec.ServiceAccount != ""
+
+	if !referenceDefined && valuesDefined {
+		name := cluster.GetSecretName()
+		secret := &corev1.Secret{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      name,
+				Namespace: resources.KubermaticNamespace,
+				Labels: map[string]string{
+					kubermaticv1.ProjectIDLabelKey: projectID,
+					"name":                         name,
+				},
 			},
-		},
-		Type: corev1.SecretTypeOpaque,
-		Data: map[string][]byte{
-			resources.GCPServiceAccount: []byte(cluster.Spec.Cloud.GCP.ServiceAccount),
-		},
+			Type: corev1.SecretTypeOpaque,
+			Data: map[string][]byte{
+				resources.GCPServiceAccount: []byte(spec.ServiceAccount),
+			},
+		}
+
+		if err := seedClient.Create(ctx, secret); err != nil {
+			return err
+		}
+
+		cluster.Spec.Cloud.GCP.CredentialsReference = &providerconfig.GlobalSecretKeySelector{
+			ObjectReference: corev1.ObjectReference{
+				Name:      cluster.GetSecretName(),
+				Namespace: resources.KubermaticNamespace,
+			},
+		}
 	}
 
-	if err := seedClient.Create(ctx, secret); err != nil {
-		return err
+	if referenceDefined && valuesDefined {
+		namespacedName := types.NamespacedName{Namespace: resources.KubermaticNamespace, Name: cluster.GetSecretName()}
+		existingSecret := &corev1.Secret{}
+		if err := seedClient.Get(ctx, namespacedName, existingSecret); err != nil {
+			return err
+		}
+
+		var updateNeeded bool
+		if existingSecret.Data != nil {
+			if sa, ok := existingSecret.Data[resources.GCPServiceAccount]; ok {
+				if string(sa) != spec.ServiceAccount {
+					existingSecret.Data[resources.GCPServiceAccount] = []byte(spec.ServiceAccount)
+					updateNeeded = true
+				}
+			}
+		}
+
+		if updateNeeded {
+			if err := seedClient.Update(ctx, existingSecret); err != nil {
+				return err
+			}
+		}
 	}
 
-	// add secret key selectors to cluster object
-	cluster.Spec.Cloud.GCP.CredentialsReference = &providerconfig.GlobalSecretKeySelector{
-		ObjectReference: corev1.ObjectReference{
-			Name:      secret.Name,
-			Namespace: secret.Namespace,
-		},
+	if valuesDefined {
+		cluster.Spec.Cloud.GCP.ServiceAccount = ""
 	}
-
-	// remove credentials from cluster object
-	cluster.Spec.Cloud.GCP.ServiceAccount = ""
 
 	return nil
 }
 
-func createHetznerSecret(ctx context.Context, seedClient ctrlruntimeclient.Client, cluster *kubermaticv1.Cluster, projectID string) error {
-	name := cluster.GetSecretName()
-	secret := &corev1.Secret{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:      name,
-			Namespace: resources.KubermaticNamespace,
-			Labels: map[string]string{
-				kubermaticv1.ProjectIDLabelKey: projectID,
-				"name":                         name,
+func createOrUpdateHetznerSecret(ctx context.Context, seedClient ctrlruntimeclient.Client, cluster *kubermaticv1.Cluster, projectID string) error {
+	spec := cluster.Spec.Cloud.Hetzner
+	referenceDefined := spec.CredentialsReference != nil && spec.CredentialsReference.Name != ""
+	valuesDefined := spec.Token != ""
+
+	if !referenceDefined && valuesDefined {
+		name := cluster.GetSecretName()
+		secret := &corev1.Secret{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      name,
+				Namespace: resources.KubermaticNamespace,
+				Labels: map[string]string{
+					kubermaticv1.ProjectIDLabelKey: projectID,
+					"name":                         name,
+				},
 			},
-		},
-		Type: corev1.SecretTypeOpaque,
-		Data: map[string][]byte{
-			resources.HetznerToken: []byte(cluster.Spec.Cloud.Hetzner.Token),
-		},
+			Type: corev1.SecretTypeOpaque,
+			Data: map[string][]byte{
+				resources.HetznerToken: []byte(spec.Token),
+			},
+		}
+
+		if err := seedClient.Create(ctx, secret); err != nil {
+			return err
+		}
+
+		cluster.Spec.Cloud.Hetzner.CredentialsReference = &providerconfig.GlobalSecretKeySelector{
+			ObjectReference: corev1.ObjectReference{
+				Name:      cluster.GetSecretName(),
+				Namespace: resources.KubermaticNamespace,
+			},
+		}
 	}
 
-	if err := seedClient.Create(ctx, secret); err != nil {
-		return err
+	if referenceDefined && valuesDefined {
+		namespacedName := types.NamespacedName{Namespace: resources.KubermaticNamespace, Name: cluster.GetSecretName()}
+		existingSecret := &corev1.Secret{}
+		if err := seedClient.Get(ctx, namespacedName, existingSecret); err != nil {
+			return err
+		}
+
+		var updateNeeded bool
+		if existingSecret.Data != nil {
+			if token, ok := existingSecret.Data[resources.HetznerToken]; ok {
+				if string(token) != spec.Token {
+					existingSecret.Data[resources.HetznerToken] = []byte(spec.Token)
+					updateNeeded = true
+				}
+			}
+		}
+
+		if updateNeeded {
+			if err := seedClient.Update(ctx, existingSecret); err != nil {
+				return err
+			}
+		}
 	}
 
-	// add secret key selectors to cluster object
-	cluster.Spec.Cloud.Hetzner.CredentialsReference = &providerconfig.GlobalSecretKeySelector{
-		ObjectReference: corev1.ObjectReference{
-			Name:      secret.Name,
-			Namespace: secret.Namespace,
-		},
+	if valuesDefined {
+		cluster.Spec.Cloud.Hetzner.Token = ""
 	}
-
-	// remove credentials from cluster object
-	cluster.Spec.Cloud.Hetzner.Token = ""
 
 	return nil
 }
 
-func createOpenstackSecret(ctx context.Context, seedClient ctrlruntimeclient.Client, cluster *kubermaticv1.Cluster, projectID string) error {
-	name := cluster.GetSecretName()
-	secret := &corev1.Secret{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:      name,
-			Namespace: resources.KubermaticNamespace,
-			Labels: map[string]string{
-				kubermaticv1.ProjectIDLabelKey: projectID,
-				"name":                         name,
+func createOrUpdateOpenstackSecret(ctx context.Context, seedClient ctrlruntimeclient.Client, cluster *kubermaticv1.Cluster, projectID string) error {
+	spec := cluster.Spec.Cloud.Openstack
+	referenceDefined := spec.CredentialsReference != nil && spec.CredentialsReference.Name != ""
+	valuesDefined := spec.Username != "" || spec.Password != "" || spec.Tenant != "" || spec.TenantID != "" || spec.Domain != ""
+
+	if !referenceDefined && valuesDefined {
+		name := cluster.GetSecretName()
+		secret := &corev1.Secret{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      name,
+				Namespace: resources.KubermaticNamespace,
+				Labels: map[string]string{
+					kubermaticv1.ProjectIDLabelKey: projectID,
+					"name":                         name,
+				},
 			},
-		},
-		Type: corev1.SecretTypeOpaque,
-		Data: map[string][]byte{
-			resources.OpenstackUsername: []byte(cluster.Spec.Cloud.Openstack.Username),
-			resources.OpenstackPassword: []byte(cluster.Spec.Cloud.Openstack.Password),
-			resources.OpenstackTenant:   []byte(cluster.Spec.Cloud.Openstack.Tenant),
-			resources.OpenstackTenantID: []byte(cluster.Spec.Cloud.Openstack.TenantID),
-			resources.OpenstackDomain:   []byte(cluster.Spec.Cloud.Openstack.Domain),
-		},
+			Type: corev1.SecretTypeOpaque,
+			Data: map[string][]byte{
+				resources.OpenstackUsername: []byte(spec.Username),
+				resources.OpenstackPassword: []byte(spec.Password),
+				resources.OpenstackTenant:   []byte(spec.Tenant),
+				resources.OpenstackTenantID: []byte(spec.TenantID),
+				resources.OpenstackDomain:   []byte(spec.Domain),
+			},
+		}
+
+		if err := seedClient.Create(ctx, secret); err != nil {
+			return err
+		}
+
+		// add secret key selectors to cluster object
+		cluster.Spec.Cloud.Openstack.CredentialsReference = &providerconfig.GlobalSecretKeySelector{
+			ObjectReference: corev1.ObjectReference{
+				Name:      cluster.GetSecretName(),
+				Namespace: resources.KubermaticNamespace,
+			},
+		}
 	}
 
-	if err := seedClient.Create(ctx, secret); err != nil {
-		return err
+	if referenceDefined && valuesDefined {
+		namespacedName := types.NamespacedName{Namespace: resources.KubermaticNamespace, Name: cluster.GetSecretName()}
+		existingSecret := &corev1.Secret{}
+		if err := seedClient.Get(ctx, namespacedName, existingSecret); err != nil {
+			return err
+		}
+
+		var updateNeeded bool
+		if existingSecret.Data != nil {
+			if username, ok := existingSecret.Data[resources.OpenstackUsername]; ok {
+				if string(username) != spec.Username {
+					existingSecret.Data[resources.OpenstackUsername] = []byte(spec.Username)
+					updateNeeded = true
+				}
+			}
+			if password, ok := existingSecret.Data[resources.OpenstackPassword]; ok {
+				if string(password) != spec.Password {
+					existingSecret.Data[resources.OpenstackPassword] = []byte(spec.Password)
+					updateNeeded = true
+				}
+			}
+			if tenant, ok := existingSecret.Data[resources.OpenstackTenant]; ok {
+				if string(tenant) != spec.Tenant {
+					existingSecret.Data[resources.OpenstackTenant] = []byte(spec.Tenant)
+					updateNeeded = true
+				}
+			}
+			if tenantID, ok := existingSecret.Data[resources.OpenstackTenantID]; ok {
+				if string(tenantID) != spec.TenantID {
+					existingSecret.Data[resources.OpenstackTenantID] = []byte(spec.TenantID)
+					updateNeeded = true
+				}
+			}
+			if domain, ok := existingSecret.Data[resources.OpenstackDomain]; ok {
+				if string(domain) != spec.Domain {
+					existingSecret.Data[resources.OpenstackDomain] = []byte(spec.Domain)
+					updateNeeded = true
+				}
+			}
+		}
+		if updateNeeded {
+			if err := seedClient.Update(ctx, existingSecret); err != nil {
+				return err
+			}
+		}
 	}
 
-	// add secret key selectors to cluster object
-	cluster.Spec.Cloud.Openstack.CredentialsReference = &providerconfig.GlobalSecretKeySelector{
-		ObjectReference: corev1.ObjectReference{
-			Name:      secret.Name,
-			Namespace: secret.Namespace,
-		},
+	if valuesDefined {
+		cluster.Spec.Cloud.Openstack.Username = ""
+		cluster.Spec.Cloud.Openstack.Password = ""
+		cluster.Spec.Cloud.Openstack.Tenant = ""
+		cluster.Spec.Cloud.Openstack.TenantID = ""
+		cluster.Spec.Cloud.Openstack.Domain = ""
 	}
-
-	// remove credentials from cluster object
-	cluster.Spec.Cloud.Openstack.Username = ""
-	cluster.Spec.Cloud.Openstack.Password = ""
-	cluster.Spec.Cloud.Openstack.Tenant = ""
-	cluster.Spec.Cloud.Openstack.TenantID = ""
-	cluster.Spec.Cloud.Openstack.Domain = ""
 
 	return nil
 }
 
-func createPacketSecret(ctx context.Context, seedClient ctrlruntimeclient.Client, cluster *kubermaticv1.Cluster, projectID string) error {
-	// create secret for storing credentials
-	name := cluster.GetSecretName()
-	secret := &corev1.Secret{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:      name,
-			Namespace: resources.KubermaticNamespace,
-			Labels: map[string]string{
-				kubermaticv1.ProjectIDLabelKey: projectID,
-				"name":                         name,
+func createOrUpdatePacketSecret(ctx context.Context, seedClient ctrlruntimeclient.Client, cluster *kubermaticv1.Cluster, projectID string) error {
+	spec := cluster.Spec.Cloud.Packet
+	referenceDefined := spec.CredentialsReference != nil && spec.CredentialsReference.Name != ""
+	valuesDefined := spec.APIKey != "" || spec.ProjectID != ""
+
+	if !referenceDefined && valuesDefined {
+		name := cluster.GetSecretName()
+		secret := &corev1.Secret{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      name,
+				Namespace: resources.KubermaticNamespace,
+				Labels: map[string]string{
+					kubermaticv1.ProjectIDLabelKey: projectID,
+					"name":                         name,
+				},
 			},
-		},
-		Type: corev1.SecretTypeOpaque,
-		Data: map[string][]byte{
-			resources.PacketAPIKey:    []byte(cluster.Spec.Cloud.Packet.APIKey),
-			resources.PacketProjectID: []byte(cluster.Spec.Cloud.Packet.ProjectID),
-		},
+			Type: corev1.SecretTypeOpaque,
+			Data: map[string][]byte{
+				resources.PacketAPIKey:    []byte(spec.APIKey),
+				resources.PacketProjectID: []byte(spec.ProjectID),
+			},
+		}
+
+		if err := seedClient.Create(ctx, secret); err != nil {
+			return err
+		}
+
+		// add secret key selectors to cluster object
+		cluster.Spec.Cloud.Packet.CredentialsReference = &providerconfig.GlobalSecretKeySelector{
+			ObjectReference: corev1.ObjectReference{
+				Name:      cluster.GetSecretName(),
+				Namespace: resources.KubermaticNamespace,
+			},
+		}
 	}
 
-	if err := seedClient.Create(ctx, secret); err != nil {
-		return err
+	if referenceDefined && valuesDefined {
+		namespacedName := types.NamespacedName{Namespace: resources.KubermaticNamespace, Name: cluster.GetSecretName()}
+		existingSecret := &corev1.Secret{}
+		if err := seedClient.Get(ctx, namespacedName, existingSecret); err != nil {
+			return err
+		}
+
+		var updateNeeded bool
+		if existingSecret.Data != nil {
+			if apiKey, ok := existingSecret.Data[resources.PacketAPIKey]; ok {
+				if string(apiKey) != spec.APIKey {
+					existingSecret.Data[resources.PacketAPIKey] = []byte(spec.APIKey)
+					updateNeeded = true
+				}
+			}
+			if projectID, ok := existingSecret.Data[resources.PacketProjectID]; ok {
+				if string(projectID) != spec.ProjectID {
+					existingSecret.Data[resources.PacketProjectID] = []byte(spec.ProjectID)
+					updateNeeded = true
+				}
+			}
+		}
+		if updateNeeded {
+			if err := seedClient.Update(ctx, existingSecret); err != nil {
+				return err
+			}
+		}
 	}
 
-	// add secret key selectors to cluster object
-	cluster.Spec.Cloud.Packet.CredentialsReference = &providerconfig.GlobalSecretKeySelector{
-		ObjectReference: corev1.ObjectReference{
-			Name:      secret.Name,
-			Namespace: secret.Namespace,
-		},
+	if valuesDefined {
+		cluster.Spec.Cloud.Packet.APIKey = ""
+		cluster.Spec.Cloud.Packet.ProjectID = ""
 	}
-
-	// remove credentials from cluster object
-	cluster.Spec.Cloud.Packet.APIKey = ""
-	cluster.Spec.Cloud.Packet.ProjectID = ""
 
 	return nil
 }
 
-func createKubevirtSecret(ctx context.Context, seedClient ctrlruntimeclient.Client, cluster *kubermaticv1.Cluster, projectID string) error {
-	// create secret for storing credentials
-	name := cluster.GetSecretName()
-	secret := &corev1.Secret{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:      name,
-			Namespace: resources.KubermaticNamespace,
-			Labels: map[string]string{
-				kubermaticv1.ProjectIDLabelKey: projectID,
-				"name":                         name,
+func createOrUpdateKubevirtSecret(ctx context.Context, seedClient ctrlruntimeclient.Client, cluster *kubermaticv1.Cluster, projectID string) error {
+	spec := cluster.Spec.Cloud.Kubevirt
+	referenceDefined := spec.CredentialsReference != nil && spec.CredentialsReference.Name != ""
+	valuesDefined := spec.Kubeconfig != ""
+
+	if !referenceDefined && valuesDefined {
+		name := cluster.GetSecretName()
+		secret := &corev1.Secret{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      name,
+				Namespace: resources.KubermaticNamespace,
+				Labels: map[string]string{
+					kubermaticv1.ProjectIDLabelKey: projectID,
+					"name":                         name,
+				},
 			},
-		},
-		Type: corev1.SecretTypeOpaque,
-		Data: map[string][]byte{
-			resources.KubevirtKubeConfig: []byte(cluster.Spec.Cloud.Kubevirt.Kubeconfig),
-		},
+			Type: corev1.SecretTypeOpaque,
+			Data: map[string][]byte{
+				resources.KubevirtKubeConfig: []byte(spec.Kubeconfig),
+			},
+		}
+
+		if err := seedClient.Create(ctx, secret); err != nil {
+			return err
+		}
+
+		// add secret key selectors to cluster object
+		cluster.Spec.Cloud.Kubevirt.CredentialsReference = &providerconfig.GlobalSecretKeySelector{
+			ObjectReference: corev1.ObjectReference{
+				Name:      cluster.GetSecretName(),
+				Namespace: resources.KubermaticNamespace,
+			},
+		}
 	}
 
-	if err := seedClient.Create(ctx, secret); err != nil {
-		return err
+	if referenceDefined && valuesDefined {
+		namespacedName := types.NamespacedName{Namespace: resources.KubermaticNamespace, Name: cluster.GetSecretName()}
+		existingSecret := &corev1.Secret{}
+		if err := seedClient.Get(ctx, namespacedName, existingSecret); err != nil {
+			return err
+		}
+
+		var updateNeeded bool
+		if existingSecret.Data != nil {
+			if kubeconfig, ok := existingSecret.Data[resources.KubevirtKubeConfig]; ok {
+				if string(kubeconfig) != spec.Kubeconfig {
+					existingSecret.Data[resources.KubevirtKubeConfig] = []byte(spec.Kubeconfig)
+					updateNeeded = true
+				}
+			}
+		}
+		if updateNeeded {
+			if err := seedClient.Update(ctx, existingSecret); err != nil {
+				return err
+			}
+		}
 	}
 
-	// add secret key selectors to cluster object
-	cluster.Spec.Cloud.Kubevirt.CredentialsReference = &providerconfig.GlobalSecretKeySelector{
-		ObjectReference: corev1.ObjectReference{
-			Name:      secret.Name,
-			Namespace: secret.Namespace,
-		},
+	if valuesDefined {
+		cluster.Spec.Cloud.Kubevirt.Kubeconfig = ""
 	}
-
-	// remove credentials from cluster object
-	cluster.Spec.Cloud.Kubevirt.Kubeconfig = ""
 
 	return nil
 }


### PR DESCRIPTION
For https://github.com/kubermatic/kubermatic/issues/3792

**Does this PR introduce a user-facing change?**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If  no release note is required, just write "NONE".
-->
```release-note
NONE
```
