### PR TITLE
fix client api generation for golang v1.13

### DIFF
--- a/api/hack/gen-api-client.sh
+++ b/api/hack/gen-api-client.sh
@@ -45,4 +45,4 @@ cd ${API_DIR}/cmd/kubermatic-api/
 echo "${SWAGGER_META}$(cat ../../pkg/handler/routes_v1.go)" > ../../pkg/handler/routes_v1.go
 swagger generate spec --scan-models -o ${TMP_SWAGGER}
 mkdir -p ../../pkg/test/e2e/api/utils/apiclient/
-swagger generate client -q -f ${TMP_SWAGGER} -t ../../pkg/test/e2e/api/utils/apiclient/
+swagger generate client -q --skip-validation -f ${TMP_SWAGGER} -t ../../pkg/test/e2e/api/utils/apiclient/


### PR DESCRIPTION
**What this PR does / why we need it**: Fix client API generation for golang v1.13

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:
According to this bug https://github.com/go-swagger/go-swagger/issues/2063 the schema validation was skipped. It happens for go v1.13. Our CI uses go v1.12 and everything works fine. There is still a problem with `verify-swagger.sh` which use the command `swagger validate` and cannot be skipped for this step.

```release-note
NONE
```
