### PR TITLE
Add credentials-cleanup finalizer after secret creation

### DIFF
--- a/api/pkg/handler/v1/cluster/cluster.go
+++ b/api/pkg/handler/v1/cluster/cluster.go
@@ -127,6 +127,7 @@ func CreateEndpoint(sshKeyProvider provider.SSHKeyProvider, projectProvider prov
 		if err := kubernetesprovider.CreateCredentialSecretForCluster(ctx, privilegedClusterProvider.GetSeedClusterAdminRuntimeClient(), partialCluster, req.ProjectID); err != nil {
 			return nil, err
 		}
+		kuberneteshelper.AddFinalizer(partialCluster, apiv1.CredentialsSecretsCleanupFinalizer)
 
 		newCluster, err := clusterProvider.New(project, userInfo, partialCluster)
 		if err != nil {
@@ -424,8 +425,6 @@ func DeleteEndpoint(sshKeyProvider provider.SSHKeyProvider, projectProvider prov
 		if err != nil {
 			return nil, common.KubernetesErrorToHTTPError(err)
 		}
-
-		kuberneteshelper.AddFinalizer(existingCluster, apiv1.CredentialsSecretsCleanupFinalizer)
 
 		// Use the NodeDeletionFinalizer to determine if the cluster was ever up, the LB and PV finalizers
 		// will prevent cluster deletion if the APIserver was never created

--- a/api/pkg/handler/v1/cluster/cluster_test.go
+++ b/api/pkg/handler/v1/cluster/cluster_test.go
@@ -45,7 +45,7 @@ func TestDeleteClusterEndpointWithFinalizers(t *testing.T) {
 				}),
 			),
 			HeaderParams:       map[string]string{"DeleteVolumes": "true", "DeleteLoadBalancers": "true"},
-			ExpectedFinalizers: []string{"kubermatic.io/cleanup-in-cluster-pv", "kubermatic.io/cleanup-in-cluster-lb", "kubermatic.io/cleanup-credentials-secrets", "kubermatic.io/delete-nodes"},
+			ExpectedFinalizers: []string{"kubermatic.io/cleanup-in-cluster-pv", "kubermatic.io/cleanup-in-cluster-lb", "kubermatic.io/delete-nodes"},
 		},
 		{
 			Name: "scenario 2: tests deletion of a cluster with only volume finalizer",
@@ -56,7 +56,7 @@ func TestDeleteClusterEndpointWithFinalizers(t *testing.T) {
 				}),
 			),
 			HeaderParams:       map[string]string{"DeleteVolumes": "true", "DeleteLoadBalancers": "false"},
-			ExpectedFinalizers: []string{"kubermatic.io/cleanup-in-cluster-pv", "kubermatic.io/cleanup-credentials-secrets", "kubermatic.io/delete-nodes"},
+			ExpectedFinalizers: []string{"kubermatic.io/cleanup-in-cluster-pv", "kubermatic.io/delete-nodes"},
 		},
 		{
 			Name: "scenario 3: tests deletion of a cluster without finalizers",
@@ -65,7 +65,7 @@ func TestDeleteClusterEndpointWithFinalizers(t *testing.T) {
 				test.GenCluster("clusterAbcID", "clusterAbc", test.GenDefaultProject().Name, time.Date(2013, 02, 03, 19, 54, 0, 0, time.UTC)),
 			),
 			HeaderParams:       map[string]string{},
-			ExpectedFinalizers: []string{"kubermatic.io/cleanup-credentials-secrets"},
+			ExpectedFinalizers: []string{},
 		},
 		{
 			Name: "PV and LB finalizers do not get attached when cluster has no node delete finalizer",
@@ -74,7 +74,7 @@ func TestDeleteClusterEndpointWithFinalizers(t *testing.T) {
 				test.GenCluster("clusterAbcID", "clusterAbc", test.GenDefaultProject().Name, time.Date(2013, 02, 03, 19, 54, 0, 0, time.UTC)),
 			),
 			HeaderParams:       map[string]string{"DeleteVolumes": "true", "DeleteLoadBalancers": "true"},
-			ExpectedFinalizers: []string{"kubermatic.io/cleanup-credentials-secrets"},
+			ExpectedFinalizers: []string{},
 		},
 	}
 	for _, tc := range testcases {


### PR DESCRIPTION
Fixes https://github.com/kubermatic/kubermatic/issues/4388

Current behaviour is to add the finalizer while deleting the cluster
in the `DeleteEndpoint` method. This works fine if we are deleting
the cluster using the API/dashboard.

But if someone manually issues a `kubectl delete cluster` command, it
does not hit the `DeleteEndpoint` method, due to which the cleanup
finalizer is not added and the secret gets orphaned.

To prevent this scenario, we can directly add the finalizer when we
create the secret. This would also help in cases when `kubectl` is
directly used.

**Does this PR introduce a user-facing change?**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If  no release note is required, just write "NONE".
-->
```release-note
NONE
```

/kind bug
