### PR TITLE
Certs chart: Allow using DNS validation with route53

### DIFF
--- a/config/certs/Chart.yaml
+++ b/config/certs/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: certs
-version: 1.0.0
+version: 1.0.1
 description: Chart for creating the required certificates for Kubermatic master clusters.
 keywords:
 - kubermatic

--- a/config/certs/templates/dns-secret.yaml
+++ b/config/certs/templates/dns-secret.yaml
@@ -1,0 +1,9 @@
+{{- if .Values.certificates.dnsValidation.enabled }}
+apiVersion: v1
+kind: Secret
+metadata:
+  name: letsencrypt-prod-dns
+type: Opaque
+data:
+  secret-access-key: {{ .Values.certificates.dnsValidation.route53.secretAccessKey | b64enc | quote }}
+{{- end }}

--- a/config/certs/templates/issuer.yaml
+++ b/config/certs/templates/issuer.yaml
@@ -23,6 +23,16 @@ spec:
     # Configure the challenge solvers.
     solvers:
     - selector: {} # empty selector matches every certificate
+      {{- if .Values.certificates.dnsValidation.enabled }}
+      dns01:
+        route53:
+           region: {{ .Values.certificates.dnsValidation.route53.region | quote }}
+           accessKeyID: {{ .Values.certificates.dnsValidation.route53.accessKeyID | quote }}
+           secretAccessKeySecretRef:
+             name: letsencrypt-prod-dns
+             key: secret-access-key
+      {{- else }}
       http01:
         ingress:
           class: nginx
+      {{- end }}

--- a/config/certs/values.yaml
+++ b/config/certs/values.yaml
@@ -7,3 +7,10 @@ certificates:
   - "kibana.kubermatic.example.com"
   issuer:
     email: dev@loodse.com
+
+  dnsValidation:
+    enabled: false
+    route53:
+      region: ""
+      accessKeyID: ""
+      secretAccessKey: ""


### PR DESCRIPTION
**What this PR does / why we need it**:

Manual port of https://github.com/kubermatic/kubermatic-installer/pull/125

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Documentation**:
<!-- Add links to the related documentation changes related to this pull request. E.g. the link to the kubermatic/docs pullrequest. -->

**Does this PR introduce a user-facing change?**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If  no release note is required, just write "NONE".
-->
```release-note
An option to use AWS Route53 DNS validaiton was added to the `certs` chart.
```

/assign @xrstf 
