### PR TITLE
Allow configuring extra args and env for the cert-manager controller

### DIFF
--- a/config/cert-manager/Chart.yaml
+++ b/config/cert-manager/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: cert-manager
-version: 1.1.1
+version: 1.1.2
 appVersion: v0.10.0
 description: A Helm chart for cert-manager
 keywords:

--- a/config/cert-manager/templates/cert-manager-deployment.yaml
+++ b/config/cert-manager/templates/cert-manager-deployment.yaml
@@ -50,6 +50,9 @@ spec:
         - --webhook-ca-secret=webhook-ca
         - --webhook-serving-secret=webhook-tls
         - --webhook-dns-names=webhook,webhook.{{ .Release.Namespace }},webhook.{{ .Release.Namespace }}.svc
+        {{- if .Values.certManager.controller.extraArgs }}
+{{ toYaml .Values.certManager.controller.extraArgs | indent 8 }}
+        {{- end }}
         env:
         - name: POD_NAMESPACE
           valueFrom:
@@ -66,6 +69,9 @@ spec:
         {{- if .Values.certManager.no_proxy }}
         - name: NO_PROXY
           value: {{ .Values.certManager.no_proxy }}
+        {{- end }}
+        {{- if .Values.certManager.controller.extraEnv }}
+{{ toYaml .Values.certManager.controller.extraEnv | indent 8 }}
         {{- end }}
         ports:
         - name: metrics

--- a/config/cert-manager/values.yaml
+++ b/config/cert-manager/values.yaml
@@ -1,6 +1,11 @@
 certManager:
   isOpenshift: false
 
+  # Optional proxy server configuration
+  # http_proxy: ""
+  # https_proxy: ""
+  # no_proxy: ""
+
   controller:
     replicas: 1
     image:
@@ -19,6 +24,17 @@ certManager:
     affinity: {}
     nodeSelector: {}
     tolerations: []
+
+    # Optional additional arguments. Use at your own risk.
+    extraArgs: []
+    # Must be a list of `--`-denoted args, e.G.:
+    # - --foo-args=foo-value
+
+    # Optional adddional env vars. Use at your own risk.
+    extraEnv: []
+    # Must be a list of valid env var definitions, e.G.:
+    # - name: SOME_VAR
+    #   value: 'some value'
 
   webhook:
     replicas: 1


### PR DESCRIPTION
**What this PR does / why we need it**:

Manual port of https://github.com/kubermatic/kubermatic-installer/pull/124. Allows setting custom args and env for the cert-manager controller.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Documentation**:
<!-- Add links to the related documentation changes related to this pull request. E.g. the link to the kubermatic/docs pullrequest. -->

**Does this PR introduce a user-facing change?**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If  no release note is required, just write "NONE".
-->
```release-note
The cert-manager Helm chart now allows configuring extra values for its controllers args and env vars.
```
