### PR TITLE
Update nginx-ingress-controller to 0.26.1

### DIFF
--- a/config/nginx-ingress-controller/Chart.yaml
+++ b/config/nginx-ingress-controller/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 name: nginx-ingress-controller
-version: 1.0.2
-appVersion: 0.25.1
+version: 1.0.3
+appVersion: 0.26.0
 description: nginx-ingress-controller
 keywords:
 - kubermatic

--- a/config/nginx-ingress-controller/Chart.yaml
+++ b/config/nginx-ingress-controller/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 name: nginx-ingress-controller
 version: 1.0.3
-appVersion: 0.26.0
+appVersion: 0.26.1
 description: nginx-ingress-controller
 keywords:
 - kubermatic

--- a/config/nginx-ingress-controller/templates/cluster-role-binding.yaml
+++ b/config/nginx-ingress-controller/templates/cluster-role-binding.yaml
@@ -2,6 +2,11 @@ apiVersion: rbac.authorization.k8s.io/v1beta1
 kind: ClusterRoleBinding
 metadata:
   name: nginx-ingress-clusterrole-nisa-binding
+  labels:
+    app.kubernetes.io/name: ingress-nginx
+    app.kubernetes.io/instance: '{{ .Release.Name }}'
+    app.kubernetes.io/part-of: ingress-nginx
+    app.kubernetes.io/managed-by: helm
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole

--- a/config/nginx-ingress-controller/templates/cluster-role.yaml
+++ b/config/nginx-ingress-controller/templates/cluster-role.yaml
@@ -2,6 +2,11 @@ apiVersion: rbac.authorization.k8s.io/v1beta1
 kind: ClusterRole
 metadata:
   name: nginx-ingress-clusterrole
+  labels:
+    app.kubernetes.io/name: ingress-nginx
+    app.kubernetes.io/instance: '{{ .Release.Name }}'
+    app.kubernetes.io/part-of: ingress-nginx
+    app.kubernetes.io/managed-by: helm
 rules:
 - apiGroups:
   - ""
@@ -29,6 +34,13 @@ rules:
   - list
   - watch
 - apiGroups:
+  - ""
+  resources:
+  - events
+  verbs:
+  - create
+  - patch
+- apiGroups:
   - extensions
   - networking.k8s.io
   resources:
@@ -37,13 +49,6 @@ rules:
   - get
   - list
   - watch
-- apiGroups:
-  - ""
-  resources:
-  - events
-  verbs:
-  - create
-  - patch
 - apiGroups:
   - extensions
   - networking.k8s.io

--- a/config/nginx-ingress-controller/templates/configmaps.yaml
+++ b/config/nginx-ingress-controller/templates/configmaps.yaml
@@ -2,6 +2,11 @@ kind: ConfigMap
 apiVersion: v1
 metadata:
   name: nginx-configuration
+  labels:
+    app.kubernetes.io/name: ingress-nginx
+    app.kubernetes.io/instance: '{{ .Release.Name }}'
+    app.kubernetes.io/part-of: ingress-nginx
+    app.kubernetes.io/managed-by: helm
 data:
   {{- range $key, $val := .Values.nginx.config }}
   {{ $key }}: {{ $val }}
@@ -12,9 +17,19 @@ kind: ConfigMap
 apiVersion: v1
 metadata:
   name: tcp-services
+  labels:
+    app.kubernetes.io/name: ingress-nginx
+    app.kubernetes.io/instance: '{{ .Release.Name }}'
+    app.kubernetes.io/part-of: ingress-nginx
+    app.kubernetes.io/managed-by: helm
 
 ---
 kind: ConfigMap
 apiVersion: v1
 metadata:
   name: udp-services
+  labels:
+    app.kubernetes.io/name: ingress-nginx
+    app.kubernetes.io/instance: '{{ .Release.Name }}'
+    app.kubernetes.io/part-of: ingress-nginx
+    app.kubernetes.io/managed-by: helm

--- a/config/nginx-ingress-controller/templates/nginx-ds-dep.yaml
+++ b/config/nginx-ingress-controller/templates/nginx-ds-dep.yaml
@@ -6,15 +6,20 @@ kind: Deployment
 {{ end }}
 metadata:
   name: nginx-ingress-controller
+  labels:
+    app.kubernetes.io/name: ingress-nginx
+    app.kubernetes.io/instance: '{{ .Release.Name }}'
+    app.kubernetes.io/part-of: ingress-nginx
+    app.kubernetes.io/managed-by: helm
 spec:
-{{ if not .Values.nginx.asDaemonSet }}
+  {{- if not .Values.nginx.asDaemonSet }}
   replicas: {{ .Values.nginx.replicas }}
-{{ else }}
+  {{- else }}
   updateStrategy:
     type: RollingUpdate
     rollingUpdate:
       maxUnavailable: 35%
-{{ end }}
+  {{- end }}
   selector:
     matchLabels:
       app: ingress-nginx
@@ -27,6 +32,8 @@ spec:
         kubermatic/scrape_port: '10254'
     spec:
       hostNetwork: {{ .Values.nginx.hostNetwork }}
+      # wait up to five minutes for the drain of connections
+      terminationGracePeriodSeconds: 300
       serviceAccountName: nginx-ingress-serviceaccount
       containers:
       - name: nginx-ingress-controller
@@ -36,10 +43,13 @@ spec:
         - --configmap=$(POD_NAMESPACE)/nginx-configuration
         - --tcp-services-configmap=$(POD_NAMESPACE)/tcp-services
         - --udp-services-configmap=$(POD_NAMESPACE)/udp-services
-        - --default-ssl-certificate=default/kubermatic-tls-certificates
         - --publish-service=$(POD_NAMESPACE)/ingress-nginx
         - --annotations-prefix=ingress.kubernetes.io
+        {{- range .Values.nginx.extraArgs }}
+        - {{ . | quote }}
+        {{- end }}
         securityContext:
+          allowPrivilegeEscalation: true
           capabilities:
             drop:
             - ALL
@@ -57,8 +67,6 @@ spec:
             fieldRef:
               fieldPath: metadata.namespace
         ports:
-        - name: metrics
-          containerPort: 10254
         - name: http
           containerPort: 80
         - name: https
@@ -82,6 +90,11 @@ spec:
           periodSeconds: 10
           successThreshold: 1
           timeoutSeconds: 10
+        lifecycle:
+          preStop:
+            exec:
+              command:
+              - /wait-shutdown
         resources:
 {{ toYaml .Values.nginx.resources | indent 10 }}
       tolerations:

--- a/config/nginx-ingress-controller/templates/role-binding.yaml
+++ b/config/nginx-ingress-controller/templates/role-binding.yaml
@@ -2,6 +2,11 @@ apiVersion: rbac.authorization.k8s.io/v1beta1
 kind: RoleBinding
 metadata:
   name: nginx-ingress-role-nisa-binding
+  labels:
+    app.kubernetes.io/name: ingress-nginx
+    app.kubernetes.io/instance: '{{ .Release.Name }}'
+    app.kubernetes.io/part-of: ingress-nginx
+    app.kubernetes.io/managed-by: helm
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: Role

--- a/config/nginx-ingress-controller/templates/role.yaml
+++ b/config/nginx-ingress-controller/templates/role.yaml
@@ -2,6 +2,11 @@ apiVersion: rbac.authorization.k8s.io/v1beta1
 kind: Role
 metadata:
   name: nginx-ingress-role
+  labels:
+    app.kubernetes.io/name: ingress-nginx
+    app.kubernetes.io/instance: '{{ .Release.Name }}'
+    app.kubernetes.io/part-of: ingress-nginx
+    app.kubernetes.io/managed-by: helm
 rules:
 - apiGroups:
   - ""

--- a/config/nginx-ingress-controller/templates/service.yaml
+++ b/config/nginx-ingress-controller/templates/service.yaml
@@ -3,6 +3,11 @@ apiVersion: v1
 kind: Service
 metadata:
   name: nginx-ingress-controller
+  labels:
+    app.kubernetes.io/name: ingress-nginx
+    app.kubernetes.io/instance: '{{ .Release.Name }}'
+    app.kubernetes.io/part-of: ingress-nginx
+    app.kubernetes.io/managed-by: helm
   annotations:
     "helm.sh/resource-policy": keep
 spec:

--- a/config/nginx-ingress-controller/templates/serviceaccount.yaml
+++ b/config/nginx-ingress-controller/templates/serviceaccount.yaml
@@ -2,3 +2,8 @@ apiVersion: v1
 kind: ServiceAccount
 metadata:
   name: nginx-ingress-serviceaccount
+  labels:
+    app.kubernetes.io/name: ingress-nginx
+    app.kubernetes.io/instance: '{{ .Release.Name }}'
+    app.kubernetes.io/part-of: ingress-nginx
+    app.kubernetes.io/managed-by: helm

--- a/config/nginx-ingress-controller/values.yaml
+++ b/config/nginx-ingress-controller/values.yaml
@@ -4,8 +4,10 @@ nginx:
   replicas: 3
   image:
     repository: quay.io/kubernetes-ingress-controller/nginx-ingress-controller
-    tag: 0.25.1
+    tag: 0.26.0
   config: {}
+  extraArgs:
+  - '--default-ssl-certificate=default/kubermatic-tls-certificates'
 #    load-balance: "least_conn"
   resources:
     requests:
@@ -13,7 +15,7 @@ nginx:
       memory: 128Mi
     limits:
       cpu: 250m
-      memory: 256Mi
+      memory: 512Mi
   nodeSelector: {}
   affinity:
     nodeAffinity:

--- a/config/nginx-ingress-controller/values.yaml
+++ b/config/nginx-ingress-controller/values.yaml
@@ -4,7 +4,7 @@ nginx:
   replicas: 3
   image:
     repository: quay.io/kubernetes-ingress-controller/nginx-ingress-controller
-    tag: 0.26.0
+    tag: 0.26.1
   config: {}
   extraArgs:
   - '--default-ssl-certificate=default/kubermatic-tls-certificates'


### PR DESCRIPTION
**What this PR does / why we need it**:
This has a fix for the issue plaguing our offline cluster. It was a smooth update on dev.

This PR also adds the `allowPrivilegeEscalation` field to the security context, which was set since 0.22 by https://github.com/kubernetes/ingress-nginx/pull/3342 but we never noticed because we don't have policies forbidding this behaviour by default.

The memory limit was increased because the release notes for 0.26 mentioned higher resource usage while connections are drained.

**Does this PR introduce a user-facing change?**:
```release-note
Update nginx-ingress-controller to 0.26.1
```
