### PR TITLE
Usercluster controller: Avoid getting triggered by leader lease

### DIFF
--- a/api/pkg/controller/usercluster/controller.go
+++ b/api/pkg/controller/usercluster/controller.go
@@ -20,12 +20,15 @@ import (
 	apiextensionsv1beta1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1beta1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/client-go/tools/leaderelection/resourcelock"
 	apiregistrationv1beta1 "k8s.io/kube-aggregator/pkg/apis/apiregistration/v1beta1"
 	"sigs.k8s.io/controller-runtime/pkg/cache"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/controller"
+	"sigs.k8s.io/controller-runtime/pkg/event"
 	"sigs.k8s.io/controller-runtime/pkg/handler"
 	"sigs.k8s.io/controller-runtime/pkg/manager"
+	"sigs.k8s.io/controller-runtime/pkg/predicate"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 	"sigs.k8s.io/controller-runtime/pkg/source"
 )
@@ -65,6 +68,10 @@ func Add(
 	}
 
 	mapFn := handler.ToRequestsFunc(func(o handler.MapObject) []reconcile.Request {
+		log.Debugw("Controller got triggered",
+			"type", fmt.Sprintf("%T", o.Object),
+			"name", o.Meta.GetName(),
+			"namespace", o.Meta.GetNamespace())
 		return []reconcile.Request{
 			{NamespacedName: types.NamespacedName{
 				// There is no "parent object" like e.G. a cluster that can be used to reconcile, we just have a random set of resources
@@ -87,8 +94,23 @@ func Add(
 		&admissionregistrationv1beta1.MutatingWebhookConfiguration{},
 		&apiextensionsv1beta1.CustomResourceDefinition{},
 	}
+
+	// Avoid getting triggered by the leader lease AKA: If the annotation exists AND changed on
+	// UPDATE, do not reconcile
+	predicateIgnoreLeaderLeaseRenew := predicate.Funcs{
+		UpdateFunc: func(e event.UpdateEvent) bool {
+			if e.MetaOld.GetAnnotations()[resourcelock.LeaderElectionRecordAnnotationKey] == "" {
+				return true
+			}
+			if e.MetaOld.GetAnnotations()[resourcelock.LeaderElectionRecordAnnotationKey] ==
+				e.MetaNew.GetAnnotations()[resourcelock.LeaderElectionRecordAnnotationKey] {
+				return true
+			}
+			return false
+		},
+	}
 	for _, t := range typesToWatch {
-		if err := c.Watch(&source.Kind{Type: t}, &handler.EnqueueRequestsFromMapFunc{ToRequests: mapFn}); err != nil {
+		if err := c.Watch(&source.Kind{Type: t}, &handler.EnqueueRequestsFromMapFunc{ToRequests: mapFn}, predicateIgnoreLeaderLeaseRenew); err != nil {
 			return fmt.Errorf("failed to create watch for %T: %v", t, err)
 		}
 	}


### PR DESCRIPTION
**What this PR does / why we need it**:

Currently, the user-cluster controller triggers itself with its own leader lease, as it changes an annotation on a configmap every two seconds. To avoid excessive, unneeded reconciling, this PR filters those out.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Documentation**:
<!-- Add links to the related documentation changes related to this pull request. E.g. the link to the kubermatic/docs pullrequest. -->

**Does this PR introduce a user-facing change?**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If  no release note is required, just write "NONE".
-->
```release-note
none
```
