### PR TITLE
Handle deleted Seeds in seed-sync controller

### DIFF
--- a/api/pkg/controller/seed-sync/reconciler.go
+++ b/api/pkg/controller/seed-sync/reconciler.go
@@ -11,6 +11,7 @@ import (
 	"github.com/kubermatic/kubermatic/api/pkg/resources/reconciling"
 
 	corev1 "k8s.io/api/core/v1"
+	kerrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/client-go/tools/record"
 	ctrlruntimeclient "sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
@@ -34,6 +35,11 @@ func (r *Reconciler) Reconcile(request reconcile.Request) (reconcile.Result, err
 
 	seed := &kubermaticv1.Seed{}
 	if err := r.Get(r.ctx, request.NamespacedName, seed); err != nil {
+		if kerrors.IsNotFound(err) {
+			logger.Warn("Seed has been deleted, skipping reconciling")
+			return reconcile.Result{}, nil
+		}
+
 		return reconcile.Result{}, fmt.Errorf("failed to get seed: %v", err)
 	}
 


### PR DESCRIPTION
**What this PR does / why we need it**:
When somebody deletes a seed, the seed-sync controller would fail to reconcile, return an error and then be re-triggered indefinitly. This PR adds an IsNotFound check to handle deleted seeds gracefully.

I chose a warn-level log message because deleting seeds is a rare event and people should know why the controller did nothing after the initial `Reconciling seed` log message.

**Does this PR introduce a user-facing change?**:
```release-note
NONE
```
