### PR TITLE
Use single timeout window in e2e tests

### DIFF
--- a/api/cmd/conformance-tests/runner.go
+++ b/api/cmd/conformance-tests/runner.go
@@ -343,7 +343,7 @@ func (r *testRunner) executeScenario(log *zap.SugaredLogger, scenario testScenar
 		return report, fmt.Errorf("failed to setup nodes: %v", err)
 	}
 
-	overallTimeout := 10 * time.Minute
+	var overallTimeout time.Duration = 10 * time.Minute
 	if cluster.Annotations["kubermatic.io/openshift"] == "true" {
 		// Openshift installs a lot more during node provisioning, hence this may take longer
 		overallTimeout = 15 * time.Minute
@@ -359,7 +359,7 @@ func (r *testRunner) executeScenario(log *zap.SugaredLogger, scenario testScenar
 	); err != nil {
 		return report, fmt.Errorf("failed to wait for machines to get a node: %v", err)
 	}
-	timeoutLeft := time.Duration(overallTimeout.Minutes() - time.Since(startTime).Minutes())
+	timeoutLeft := overallTimeout - time.Since(startTime)
 
 	startTime = time.Now()
 	if err := junitReporterWrapper(
@@ -373,7 +373,7 @@ func (r *testRunner) executeScenario(log *zap.SugaredLogger, scenario testScenar
 	); err != nil {
 		return report, fmt.Errorf("failed to wait for all nodes to be ready: %v", err)
 	}
-	timeoutLeft = time.Duration(timeoutLeft.Minutes() - time.Since(startTime).Minutes())
+	timeoutLeft = timeoutLeft - time.Since(startTime)
 
 	if err := junitReporterWrapper(
 		"[Kubermatic] Wait for Pods inside usercluster to be ready",


### PR DESCRIPTION
Uses a single timeout window of 10 minute for e2e tests, but keeps the granual feedback added in https://github.com/kubermatic/kubermatic/pull/4348.

**Does this PR introduce a user-facing change?**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If  no release note is required, just write "NONE".
-->
```release-note
NONE
```
