### PR TITLE
Make it possible to enable the seed migration in Kubermatic chart

### DIFF
--- a/api/hack/ci/ci-run-minimal-conformance-tests.sh
+++ b/api/hack/ci/ci-run-minimal-conformance-tests.sh
@@ -307,6 +307,7 @@ retry 3 helm upgrade --install --force --wait --timeout 300 \
   --set-string=kubermatic.worker_name=$BUILD_ID \
   --set=kubermatic.ingressClass=non-existent \
   --set=kubermatic.checks.crd.disable=true \
+  --set=kubermatic.datacenters='' \
   --set=kubermatic.dynamicDatacenters=true \
   ${OPENSHIFT_HELM_ARGS:-} \
   --values ${VALUES_FILE} \

--- a/config/kubermatic/Chart.yaml
+++ b/config/kubermatic/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: kubermatic
-version: 1.0.4
+version: 1.0.5
 appVersion: '__KUBERMATIC_TAG__'
 description: Kubermatic chart for master and/or seed clusters.
 keywords:

--- a/config/kubermatic/templates/datacenter-yaml-secret.yaml
+++ b/config/kubermatic/templates/datacenter-yaml-secret.yaml
@@ -1,4 +1,4 @@
-{{ if not .Values.kubermatic.dynamicDatacenters }}
+{{ if .Values.kubermatic.datacenters }}
 apiVersion: v1
 kind: Secret
 metadata:

--- a/config/kubermatic/templates/kubermatic-api-dep.yaml
+++ b/config/kubermatic/templates/kubermatic-api-dep.yaml
@@ -31,10 +31,11 @@ spec:
         - -address=0.0.0.0:8080
         - -v=2
         - -logtostderr
+        {{- if .Values.kubermatic.datacenters }}
+        - -datacenters=/opt/datacenter/datacenters.yaml
+        {{- end }}
         {{- if .Values.kubermatic.dynamicDatacenters }}
         - -dynamic-datacenters=true
-        {{- else }}
-        - -datacenters=/opt/datacenter/datacenters.yaml
         {{- end }}
         - -oidc-url={{ .Values.kubermatic.auth.tokenIssuer }}
         - -oidc-authenticator-client-id={{ .Values.kubermatic.auth.clientID }}
@@ -87,7 +88,7 @@ spec:
         - name: kubeconfig
           mountPath: "/opt/.kube/"
           readOnly: true
-        {{- if not .Values.kubermatic.dynamicDatacenters }}
+        {{- if .Values.kubermatic.datacenters }}
         - name: datacenters
           mountPath: "/opt/datacenter/"
           readOnly: true
@@ -108,7 +109,7 @@ spec:
       - name: kubeconfig
         secret:
           secretName: kubeconfig
-      {{- if not .Values.kubermatic.dynamicDatacenters }}
+      {{- if .Values.kubermatic.datacenters }}
       - name: datacenters
         secret:
           secretName: datacenters

--- a/config/kubermatic/templates/kubermatic-controller-manager-dep.yaml
+++ b/config/kubermatic/templates/kubermatic-controller-manager-dep.yaml
@@ -60,10 +60,11 @@ spec:
         - -datacenter-name={{ .Values.kubermatic.controller.datacenterName }}
         - -etcd-disk-size={{ .Values.kubermatic.etcd.diskSize }}
         - -master-resources=/opt/master-files
+        {{- if .Values.kubermatic.datacenters }}
+        - -datacenters=/opt/datacenter/datacenters.yaml
+        {{- end }}
         {{- if .Values.kubermatic.dynamicDatacenters }}
         - -dynamic-datacenters=true
-        {{- else }}
-        - -datacenters=/opt/datacenter/datacenters.yaml
         {{- end }}
         - -versions=/opt/master-files/versions.yaml
         - -updates=/opt/master-files/updates.yaml
@@ -142,7 +143,7 @@ spec:
         - name: master-files
           mountPath: "/opt/master-files/"
           readOnly: true
-        {{- if not .Values.kubermatic.dynamicDatacenters }}
+        {{- if .Values.kubermatic.datacenters }}
         - name: datacenters
           mountPath: "/opt/datacenter/"
           readOnly: true
@@ -181,7 +182,7 @@ spec:
       - name: master-files
         secret:
           secretName: master-files
-      {{- if not .Values.kubermatic.dynamicDatacenters }}
+      {{- if .Values.kubermatic.datacenters }}
       - name: datacenters
         secret:
           secretName: datacenters

--- a/config/kubermatic/templates/master-controller-manager-dep.yaml
+++ b/config/kubermatic/templates/master-controller-manager-dep.yaml
@@ -30,10 +30,11 @@ spec:
         - -v=2
         - -logtostderr
         - -kubeconfig=/opt/.kube/kubeconfig
+        {{- if .Values.kubermatic.datacenters }}
+        - -datacenters=/opt/datacenter/datacenters.yaml
+        {{- end }}
         {{- if .Values.kubermatic.dynamicDatacenters }}
         - -dynamic-datacenters=true
-        {{- else }}
-        - -datacenters=/opt/datacenter/datacenters.yaml
         {{- end }}
         {{- if .Values.kubermatic.worker_name }}
         - -worker-name={{ .Values.kubermatic.worker_name }}
@@ -53,7 +54,7 @@ spec:
           - name: kubeconfig
             mountPath: "/opt/.kube/"
             readOnly: true
-        {{- if not .Values.kubermatic.dynamicDatacenters }}
+        {{- if .Values.kubermatic.datacenters }}
           - name: datacenters
             mountPath: "/opt/datacenter/"
             readOnly: true
@@ -68,7 +69,7 @@ spec:
       - name: kubeconfig
         secret:
           secretName: kubeconfig
-      {{- if not .Values.kubermatic.dynamicDatacenters }}
+      {{- if .Values.kubermatic.datacenters }}
       - name: datacenters
         secret:
           secretName: datacenters


### PR DESCRIPTION
**What this PR does / why we need it**:
The Helm chart was still under the assumption that we **either** have datacenters.yaml **or** the dynamic-datacenters flag, but never both. However, having both is what actually triggers the migration, so this PR updates the chart to make that possible.

**Does this PR introduce a user-facing change?**:
```release-note
NONE
```
