### PR TITLE
Use own cache to use ctrlruntime's client before the manager was started

### DIFF
--- a/api/cmd/master-controller-manager/main.go
+++ b/api/cmd/master-controller-manager/main.go
@@ -23,7 +23,6 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/rest"
 	"k8s.io/client-go/tools/clientcmd"
-	"sigs.k8s.io/controller-runtime/pkg/cache"
 	ctrlruntimecache "sigs.k8s.io/controller-runtime/pkg/cache"
 	"sigs.k8s.io/controller-runtime/pkg/manager"
 	ctrlruntimelog "sigs.k8s.io/controller-runtime/pkg/runtime/log"
@@ -124,7 +123,7 @@ func main() {
 
 	// create a new cache that we can start independently of the manager, so that other
 	// components work even if the manager has not yet been started
-	cache, err := ctrlruntimecache.New(cfg, cache.Options{})
+	cache, err := ctrlruntimecache.New(cfg, ctrlruntimecache.Options{})
 	if err != nil {
 		log.Fatalw("failed to create cache", zap.Error(err))
 	}
@@ -135,7 +134,9 @@ func main() {
 		}
 	}()
 
-	cache.WaitForCacheSync(ctx.Done())
+	if !cache.WaitForCacheSync(ctx.Done()) {
+		log.Fatal("failed to wait for caches to synchronize")
+	}
 
 	mgr, err := manager.New(cfg, manager.Options{
 		MetricsBindAddress: "",

--- a/api/cmd/master-controller-manager/main.go
+++ b/api/cmd/master-controller-manager/main.go
@@ -261,10 +261,10 @@ type unstartableCache struct {
 	ctrlruntimecache.Cache
 }
 
-func (m *myCache) Start(_ <-chan struct{}) error {
+func (m *unstartableCache) Start(_ <-chan struct{}) error {
 	return nil
 }
 
-func (m *myCache) WaitForCacheSync(_ <-chan struct{}) bool {
+func (m *unstartableCache) WaitForCacheSync(_ <-chan struct{}) bool {
 	return true
 }

--- a/api/cmd/master-controller-manager/main.go
+++ b/api/cmd/master-controller-manager/main.go
@@ -254,14 +254,7 @@ func main() {
 				if migrationOptions.MigrationEnabled() {
 					log.Info("executing migrations...")
 
-					// create a dedicated client because the one from the manager is not yet
-					// initialized and returns 404's for everything
-					client, err := ctrlruntimeclient.New(cfg, ctrlruntimeclient.Options{})
-					if err != nil {
-						return fmt.Errorf("failed to create kube client: %v", err)
-					}
-
-					if err := mastermigrations.RunAll(ctx, log, client, ctrlCtx.namespace, migrationOptions); err != nil {
+					if err := mastermigrations.RunAll(ctx, log, fallbackClient, ctrlCtx.namespace, migrationOptions); err != nil {
 						return fmt.Errorf("failed to run migrations: %v", err)
 					}
 


### PR DESCRIPTION
**What this PR does / why we need it**:
Since we changed the master-controller to only start the manager once the migrations are completed, the validating webhook for seeds was (because of the migrations) still started on its own, **before** the manager is started. This leads to the situation that the webhook does not find anything (unstarted managers have clients that return 404's for everything), rejecting any Seeds because it cannot find the kubeconfig secret a Seed must reference.

Since the webhook runs in all pods (even non-leaders), moving the initialization to a different place is confusing (see early commits in this PR). That's why the PR implements a hack based on creating a dedicated cache, warming it up and then injecting it into the manager (while making sure that the manager cannot start the cache *again*). The custom cache makes it possible to use the manager's client before the manager has been started, simplifying a bunch of code.

**Does this PR introduce a user-facing change?**:
```release-note
NONE
```
