### PR TITLE
Read bearer token from the cookie token header

### DIFF
--- a/api/cmd/kubermatic-api/main.go
+++ b/api/cmd/kubermatic-api/main.go
@@ -245,6 +245,7 @@ func createAuthClients(options serverRunOptions, prov providers) (auth.TokenVeri
 		"",
 		auth.NewCombinedExtractor(
 			auth.NewHeaderBearerTokenExtractor("Authorization"),
+			auth.NewCookieHeaderBearerTokenExtractor("token"),
 			auth.NewQueryParamBearerTokenExtractor("token"),
 		),
 		options.oidcSkipTLSVerify,

--- a/api/pkg/handler/auth/oidc.go
+++ b/api/pkg/handler/auth/oidc.go
@@ -7,7 +7,6 @@ import (
 	"fmt"
 	"net"
 	"net/http"
-	"strings"
 	"time"
 
 	"github.com/coreos/go-oidc"
@@ -242,26 +241,12 @@ type cookieHeaderBearerTokenExtractor struct {
 }
 
 func (e cookieHeaderBearerTokenExtractor) Extract(r *http.Request) (string, error) {
-	header := r.Header.Get("Cookie")
-	cookies := strings.Split(header, ";")
-
-	for _, cookie := range cookies {
-		cookie = strings.TrimSpace(cookie)
-		parts := strings.Split(cookie, "=")
-
-		if len(parts) != 2 {
-			continue
-		}
-
-		headerName := parts[0]
-		headerValue := parts[1]
-
-		if headerName == e.name {
-			return headerValue, nil
-		}
+	cookie, err := r.Cookie("token")
+	if err != nil {
+		return "", fmt.Errorf("haven't found a Bearer token in the Cookie header %s: %v", e.name, err)
 	}
 
-	return "", fmt.Errorf("haven't found a Bearer token in the Cookie %s header", e.name)
+	return cookie.Value, nil
 }
 
 // NewCombinedExtractor returns an token extractor which tries a list of token extractors until it finds a token

--- a/api/pkg/handler/v1/openshift/openshift.go
+++ b/api/pkg/handler/v1/openshift/openshift.go
@@ -79,7 +79,7 @@ func ConsoleLoginEndpoint(
 				writeHTTPError(log, w, kubermaticerrors.New(http.StatusInternalServerError, "couldn't get userInfo"))
 				return nil, nil
 			}
-			if strings.HasPrefix(userInfo.Group, "editors") {
+			if strings.HasPrefix(userInfo.Group, "editors") || strings.HasPrefix(userInfo.Group, "owners") {
 				consoleLogin(ctx, log, w, cluster, clusterProvider.GetSeedClusterAdminRuntimeClient(), r)
 			} else {
 				writeHTTPError(log, w, kubermaticerrors.New(http.StatusBadRequest, fmt.Sprintf("user %q does not belong to the editors group", userInfo.Email)))


### PR DESCRIPTION
**What this PR does / why we need it**:
Allows reading the bearer token from a `Cookie` request header. Our UI already saves the token in a cookie named `token` and it is sent to the server as a part of `Cookie` header.

**Does this PR introduce a user-facing change?**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If  no release note is required, just write "NONE".
-->
```release-note
NONE
```
