### PR TITLE
Put download-gocache file on .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,4 +9,5 @@ api/_build
 api/_cache
 api/cmd/s3-exporter/s3-exporter
 api/cmd/conformance-tests/conformance-tests
+api/download-gocache
 /reports


### PR DESCRIPTION
**What this PR does / why we need it**:

Puts the `download-gocache` file on .gitignore, its only used in CI as a marker to indicate if the gocache was downloaded already.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Documentation**:
<!-- Add links to the related documentation changes related to this pull request. E.g. the link to the kubermatic/docs pullrequest. -->

**Does this PR introduce a user-facing change?**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If  no release note is required, just write "NONE".
-->
```release-note
none
```

/assign @nikhita 