### PR TITLE
Fix dynamic seed getter returning the same seed multiple times

### DIFF
--- a/api/pkg/provider/datacenter.go
+++ b/api/pkg/provider/datacenter.go
@@ -193,8 +193,8 @@ func SeedsGetterFactory(ctx context.Context, client ctrlruntimeclient.Client, dc
 				return nil, fmt.Errorf("failed to list the seeds: %v", err)
 			}
 			seedMap := map[string]*kubermaticv1.Seed{}
-			for _, seed := range seeds.Items {
-				seedMap[seed.Name] = &seed
+			for idx, seed := range seeds.Items {
+				seedMap[seed.Name] = &seeds.Items[idx]
 			}
 			return seedMap, nil
 		}, nil


### PR DESCRIPTION
**What this PR does / why we need it**:
The API returned the same seed multiple times. This fixes that behaviour.

**Does this PR introduce a user-facing change?**:
```release-note
NONE
```
