### PR TITLE
Synchronize usersshkeys into the userclusters

### DIFF
--- a/api/cmd/image-loader/main.go
+++ b/api/cmd/image-loader/main.go
@@ -334,6 +334,7 @@ func getTemplateData(version *kubermaticversion.Version) (*resources.TemplateDat
 		resources.ClusterAutoscalerKubeconfigSecretName,
 		resources.KubernetesDashboardKubeconfigSecretName,
 		metricsserver.ServingCertSecretName,
+		resources.UserSSHKeys,
 	})
 	objects := []runtime.Object{configMapList, secretList, serviceList}
 

--- a/api/cmd/kubermatic-controller-manager/controllers.go
+++ b/api/cmd/kubermatic-controller-manager/controllers.go
@@ -302,7 +302,6 @@ func createAddonInstallerController(ctrlCtx *controllerContext) error {
 func createUserSSHKeyController(ctrlCtx *controllerContext) error {
 	return usersshkeys.Add(
 		ctrlCtx.mgr,
-		nil,
 		ctrlCtx.log,
 		ctrlCtx.runOptions.workerName,
 		ctrlCtx.runOptions.workerCount)

--- a/api/cmd/kubermatic-controller-manager/controllers.go
+++ b/api/cmd/kubermatic-controller-manager/controllers.go
@@ -17,6 +17,7 @@ import (
 	"github.com/kubermatic/kubermatic/api/pkg/controller/monitoring"
 	openshiftcontroller "github.com/kubermatic/kubermatic/api/pkg/controller/openshift"
 	updatecontroller "github.com/kubermatic/kubermatic/api/pkg/controller/update"
+	"github.com/kubermatic/kubermatic/api/pkg/controller/usersshkeys"
 	kubermaticv1 "github.com/kubermatic/kubermatic/api/pkg/crd/kubermatic/v1"
 	"github.com/kubermatic/kubermatic/api/pkg/util/workerlabel"
 	"github.com/kubermatic/kubermatic/api/pkg/version"
@@ -40,6 +41,7 @@ var allControllers = map[string]controllerCreator{
 	cloudcontroller.ControllerName:           createCloudController,
 	openshiftcontroller.ControllerName:       createOpenshiftController,
 	clustercomponentdefaulter.ControllerName: createClusterComponentDefaulter,
+	usersshkeys.ControllerName:               createUserSSHKeyController,
 }
 
 type controllerCreator func(*controllerContext) error
@@ -295,4 +297,13 @@ func createAddonInstallerController(ctrlCtx *controllerContext) error {
 		ctrlCtx.runOptions.workerName,
 		kubernetesAddons,
 		openshiftAddons)
+}
+
+func createUserSSHKeyController(ctrlCtx *controllerContext) error {
+	return usersshkeys.Add(
+		ctrlCtx.mgr,
+		nil,
+		ctrlCtx.log,
+		ctrlCtx.runOptions.workerName,
+		ctrlCtx.runOptions.workerCount)
 }

--- a/api/cmd/user-cluster-controller-manager/main.go
+++ b/api/cmd/user-cluster-controller-manager/main.go
@@ -59,6 +59,7 @@ type controllerRunOptions struct {
 	openvpnServerPort             int
 	openvpnCACertFilePath         string
 	openvpnCAKeyFilePath          string
+	userSSHKeysDirPath            string
 	overwriteRegistry             string
 	cloudProviderName             string
 	cloudCredentialSecretTemplate string
@@ -81,6 +82,7 @@ func main() {
 	flag.IntVar(&runOp.openvpnServerPort, "openvpn-server-port", 0, "OpenVPN server port")
 	flag.StringVar(&runOp.openvpnCACertFilePath, "openvpn-ca-cert-file", "", "Path to the OpenVPN CA cert file")
 	flag.StringVar(&runOp.openvpnCAKeyFilePath, "openvpn-ca-key-file", "", "Path to the OpenVPN CA key file")
+	flag.StringVar(&runOp.userSSHKeysDirPath, "user-ssh-keys-dir-path", "", "Path to the user ssh keys dir")
 	flag.StringVar(&runOp.overwriteRegistry, "overwrite-registry", "", "registry to use for all images")
 	flag.BoolVar(&runOp.log.Debug, "log-debug", false, "Enables debug logging")
 	flag.StringVar(&runOp.log.Format, "log-format", string(kubermaticlog.FormatJSON), "Log format. Available are: "+kubermaticlog.AvailableFormats.String())
@@ -226,6 +228,7 @@ func main() {
 		runOp.openvpnServerPort,
 		healthHandler.AddReadinessCheck,
 		openVPNCACert,
+		runOp.userSSHKeysDirPath,
 		cloudCredentialSecretTemplate,
 		log); err != nil {
 		log.Fatalw("Failed to register user cluster controller", zap.Error(err))

--- a/api/hack/ci/ci-run-minimal-conformance-tests.sh
+++ b/api/hack/ci/ci-run-minimal-conformance-tests.sh
@@ -87,15 +87,6 @@ function cleanup {
     # Except for vSphere
     TMP_KUBECONFIG=$(mktemp);
     USERCLUSTER_NS=$(kubectl get cluster -o name -l worker-name=${BUILD_ID} |sed 's#.kubermatic.k8s.io/#-#g')
-
-    for i in $(kubectl get pods -n ${USERCLUSTER_NS} -o go-template="$GOTEMPLATE"); do
-      local POD="${i%,*}"
-      local CONTAINER="${i#*,}"
-
-      echo " [*] User Cluster Pod $POD, container $CONTAINER:"
-      kubectl logs -n ${USERCLUSTER_NS} "$POD" "$CONTAINER"
-    done
-
     kubectl get secret -n ${USERCLUSTER_NS} admin-kubeconfig -o go-template='{{ index .data "kubeconfig" }}' | base64 -d > $TMP_KUBECONFIG
     kubectl --kubeconfig=${TMP_KUBECONFIG} describe machine -n kube-system|egrep -vi 'password|user'
   fi

--- a/api/hack/ci/ci-run-minimal-conformance-tests.sh
+++ b/api/hack/ci/ci-run-minimal-conformance-tests.sh
@@ -87,6 +87,15 @@ function cleanup {
     # Except for vSphere
     TMP_KUBECONFIG=$(mktemp);
     USERCLUSTER_NS=$(kubectl get cluster -o name -l worker-name=${BUILD_ID} |sed 's#.kubermatic.k8s.io/#-#g')
+
+    for i in $(kubectl get pods -n ${USERCLUSTER_NS} -o go-template="$GOTEMPLATE"); do
+      local POD="${i%,*}"
+      local CONTAINER="${i#*,}"
+
+      echo " [*] User Cluster Pod $POD, container $CONTAINER:"
+      kubectl logs -n ${USERCLUSTER_NS} "$POD" "$CONTAINER"
+    done
+
     kubectl get secret -n ${USERCLUSTER_NS} admin-kubeconfig -o go-template='{{ index .data "kubeconfig" }}' | base64 -d > $TMP_KUBECONFIG
     kubectl --kubeconfig=${TMP_KUBECONFIG} describe machine -n kube-system|egrep -vi 'password|user'
   fi

--- a/api/pkg/controller/openshift/testdata/Kubermatic_API_image_is_overwritten-usercluster-controller.golden.yaml
+++ b/api/pkg/controller/openshift/testdata/Kubermatic_API_image_is_overwritten-usercluster-controller.golden.yaml
@@ -27,6 +27,7 @@ spec:
         cluster: test-cluster
         internal-admin-kubeconfig-secret-revision: ""
         openvpn-ca-secret-revision: ""
+        usersshkeys-secret-revision: 1-1
     spec:
       containers:
       - args:
@@ -80,6 +81,9 @@ spec:
         - mountPath: /etc/kubernetes/pki/openvpn
           name: openvpn-ca
           readOnly: true
+        - mountPath: /etc/kubernetes/usersshkeys
+          name: usersshkeys
+          readOnly: true
         - mountPath: /http-prober-bin
           name: http-prober-bin
       imagePullSecrets:
@@ -111,6 +115,10 @@ spec:
         secret:
           defaultMode: 420
           secretName: openvpn-ca
+      - name: usersshkeys
+        secret:
+          defaultMode: 420
+          secretName: usersshkeys
       - emptyDir: {}
         name: http-prober-bin
 status: {}

--- a/api/pkg/controller/openshift/testdata/Kubermatic_API_image_is_overwritten-usercluster-controller.golden.yaml
+++ b/api/pkg/controller/openshift/testdata/Kubermatic_API_image_is_overwritten-usercluster-controller.golden.yaml
@@ -41,7 +41,7 @@ spec:
         - -timeout
         - "1"
         - -command
-        - '{"command":"/usr/local/bin/user-cluster-controller-manager","args":["-kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","-metrics-listen-address","0.0.0.0:8085","-health-listen-address","0.0.0.0:8086","-namespace","$(NAMESPACE)","-ca-cert","/etc/kubernetes/pki/ca/ca.crt","-ca-key","/etc/kubernetes/pki/ca/ca.key","-cluster-url","https://test-cluster.alias-europe-west3-c.dev.kubermatic.io:0","-openvpn-server-port","0","-overwrite-registry","","-openshift=true","-version","4.1.9","-cloud-provider-name","","-openvpn-ca-cert-file=/etc/kubernetes/pki/openvpn/ca.crt","-openvpn-ca-key-file=/etc/kubernetes/pki/openvpn/ca.key"]}'
+        - '{"command":"/usr/local/bin/user-cluster-controller-manager","args":["-kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","-metrics-listen-address","0.0.0.0:8085","-health-listen-address","0.0.0.0:8086","-namespace","$(NAMESPACE)","-ca-cert","/etc/kubernetes/pki/ca/ca.crt","-ca-key","/etc/kubernetes/pki/ca/ca.key","-cluster-url","https://test-cluster.alias-europe-west3-c.dev.kubermatic.io:0","-openvpn-server-port","0","-overwrite-registry","","-openshift=true","-version","4.1.9","-cloud-provider-name","","-openvpn-ca-cert-file=/etc/kubernetes/pki/openvpn/ca.crt","-openvpn-ca-key-file=/etc/kubernetes/pki/openvpn/ca.key","-user-ssh-keys-dir-path=/etc/kubernetes/usersshkeys"]}'
         command:
         - /http-prober-bin/http-prober
         env:

--- a/api/pkg/controller/usercluster/controller.go
+++ b/api/pkg/controller/usercluster/controller.go
@@ -49,6 +49,7 @@ func Add(
 	openvpnServerPort int,
 	registerReconciledCheck func(name string, check healthcheck.Check),
 	openVPNCA *resources.ECDSAKeyPair,
+	userSSHKeyDirPath string,
 	cloudCredentialSecretTemplate *corev1.Secret,
 	log *zap.SugaredLogger) error {
 	reconciler := &reconciler{
@@ -62,6 +63,7 @@ func Add(
 		clusterURL:                    clusterURL,
 		openvpnServerPort:             openvpnServerPort,
 		openVPNCA:                     openVPNCA,
+		userSSHKeyDirPath:             userSSHKeyDirPath,
 		cloudCredentialSecretTemplate: cloudCredentialSecretTemplate,
 		log:                           log,
 		platform:                      cloudProviderName,
@@ -153,6 +155,7 @@ type reconciler struct {
 	clusterURL                    *url.URL
 	openvpnServerPort             int
 	openVPNCA                     *resources.ECDSAKeyPair
+	userSSHKeyDirPath             string
 	platform                      string
 	cloudCredentialSecretTemplate *corev1.Secret
 

--- a/api/pkg/controller/usercluster/controller.go
+++ b/api/pkg/controller/usercluster/controller.go
@@ -47,6 +47,7 @@ func Add(
 	caCert *triple.KeyPair,
 	clusterURL *url.URL,
 	openvpnServerPort int,
+	userSSHKeys map[string][]byte,
 	registerReconciledCheck func(name string, check healthcheck.Check),
 	openVPNCA *resources.ECDSAKeyPair,
 	userSSHKeyDirPath string,
@@ -67,6 +68,7 @@ func Add(
 		cloudCredentialSecretTemplate: cloudCredentialSecretTemplate,
 		log:                           log,
 		platform:                      cloudProviderName,
+		userSSHKeys:                   userSSHKeys,
 	}
 	c, err := controller.New(controllerName, mgr, controller.Options{Reconciler: reconciler})
 	if err != nil {
@@ -158,6 +160,7 @@ type reconciler struct {
 	userSSHKeyDirPath             string
 	platform                      string
 	cloudCredentialSecretTemplate *corev1.Secret
+	userSSHKeys                   map[string][]byte
 
 	rLock                      *sync.Mutex
 	reconciledSuccessfullyOnce bool

--- a/api/pkg/controller/usercluster/reconciler.go
+++ b/api/pkg/controller/usercluster/reconciler.go
@@ -3,6 +3,7 @@ package usercluster
 import (
 	"context"
 	"fmt"
+	"github.com/kubermatic/kubermatic/api/pkg/controller/usercluster/resources/usersshkeys"
 
 	openshiftresources "github.com/kubermatic/kubermatic/api/pkg/controller/openshift/resources"
 	"github.com/kubermatic/kubermatic/api/pkg/controller/usercluster/resources/clusterautoscaler"
@@ -372,6 +373,7 @@ func (r *reconciler) reconcileConfigMaps(ctx context.Context) error {
 func (r *reconciler) reconcileSecrets(ctx context.Context) error {
 	creators := []reconciling.NamedSecretCreatorGetter{
 		openvpn.ClientCertificate(r.openVPNCA),
+		usersshkeys.CreateUserSSHKeysSecrets(r.userSSHKeyDirPath),
 	}
 	if r.openshift {
 		if r.cloudCredentialSecretTemplate != nil {

--- a/api/pkg/controller/usercluster/reconciler.go
+++ b/api/pkg/controller/usercluster/reconciler.go
@@ -373,7 +373,7 @@ func (r *reconciler) reconcileConfigMaps(ctx context.Context) error {
 func (r *reconciler) reconcileSecrets(ctx context.Context) error {
 	creators := []reconciling.NamedSecretCreatorGetter{
 		openvpn.ClientCertificate(r.openVPNCA),
-		usersshkeys.CreateUserSSHKeysSecrets(r.userSSHKeyDirPath),
+		usersshkeys.CreateUserSSHKeysSecrets(r.userSSHKeys),
 	}
 	if r.openshift {
 		if r.cloudCredentialSecretTemplate != nil {

--- a/api/pkg/controller/usercluster/reconciler.go
+++ b/api/pkg/controller/usercluster/reconciler.go
@@ -3,7 +3,6 @@ package usercluster
 import (
 	"context"
 	"fmt"
-	"github.com/kubermatic/kubermatic/api/pkg/controller/usercluster/resources/usersshkeys"
 
 	openshiftresources "github.com/kubermatic/kubermatic/api/pkg/controller/openshift/resources"
 	"github.com/kubermatic/kubermatic/api/pkg/controller/usercluster/resources/clusterautoscaler"
@@ -18,6 +17,7 @@ import (
 	"github.com/kubermatic/kubermatic/api/pkg/controller/usercluster/resources/prometheus"
 	"github.com/kubermatic/kubermatic/api/pkg/controller/usercluster/resources/scheduler"
 	"github.com/kubermatic/kubermatic/api/pkg/controller/usercluster/resources/user-auth"
+	"github.com/kubermatic/kubermatic/api/pkg/controller/usercluster/resources/usersshkeys"
 	"github.com/kubermatic/kubermatic/api/pkg/resources/reconciling"
 
 	rbacv1 "k8s.io/api/rbac/v1"

--- a/api/pkg/controller/usercluster/resources/usersshkeys/secrets.go
+++ b/api/pkg/controller/usercluster/resources/usersshkeys/secrets.go
@@ -1,0 +1,37 @@
+package usersshkeys
+
+import (
+	"fmt"
+	"io/ioutil"
+
+	"github.com/kubermatic/kubermatic/api/pkg/resources"
+	"github.com/kubermatic/kubermatic/api/pkg/resources/reconciling"
+
+	corev1 "k8s.io/api/core/v1"
+)
+
+// CreateUserSSHKeysSecrets creates a secret in the usercluster from the user ssh keys.
+func CreateUserSSHKeysSecrets(path string) reconciling.NamedSecretCreatorGetter {
+	return func() (string, reconciling.SecretCreator) {
+		return resources.UserSSHKeys, createSecretsFromUserSSHDirPath(path)
+	}
+}
+
+func createSecretsFromUserSSHDirPath(path string) reconciling.SecretCreator {
+	return func(existing *corev1.Secret) (secret *corev1.Secret, e error) {
+		files, err := ioutil.ReadDir(path)
+		if err != nil {
+			return nil, err
+		}
+
+		existing.Data = map[string][]byte{}
+		for _, file := range files {
+			data, err := ioutil.ReadFile(fmt.Sprintf("%v/%v", path, file.Name()))
+			if err != nil {
+				return nil, err
+			}
+			existing.Data[file.Name()] = data
+		}
+		return existing, nil
+	}
+}

--- a/api/pkg/controller/usercluster/resources/usersshkeys/secrets.go
+++ b/api/pkg/controller/usercluster/resources/usersshkeys/secrets.go
@@ -24,11 +24,18 @@ func createSecretsFromUserSSHDirPath(path string) reconciling.SecretCreator {
 			return nil, err
 		}
 
-		existing.Data = map[string][]byte{}
+		if existing.Data == nil {
+			existing.Data = map[string][]byte{}
+		}
+
 		for _, file := range files {
+			if _, ok := existing.Data[file.Name()]; ok {
+				continue
+			}
+
 			data, err := ioutil.ReadFile(fmt.Sprintf("%v/%v", path, file.Name()))
 			if err != nil {
-				return nil, err
+				return nil, fmt.Errorf("failed to read file %v during secret creation", file.Name())
 			}
 			existing.Data[file.Name()] = data
 		}

--- a/api/pkg/controller/usercluster/resources/usersshkeys/secrets.go
+++ b/api/pkg/controller/usercluster/resources/usersshkeys/secrets.go
@@ -1,57 +1,25 @@
 package usersshkeys
 
 import (
-	"fmt"
-	"io/ioutil"
-	"os"
-
 	"github.com/kubermatic/kubermatic/api/pkg/resources"
 	"github.com/kubermatic/kubermatic/api/pkg/resources/reconciling"
 
 	corev1 "k8s.io/api/core/v1"
 )
 
-const (
-	secretsDirLink = "..data"
-)
-
 // CreateUserSSHKeysSecrets creates a secret in the usercluster from the user ssh keys.
-func CreateUserSSHKeysSecrets(path string) reconciling.NamedSecretCreatorGetter {
+func CreateUserSSHKeysSecrets(userSSHKeys map[string][]byte) reconciling.NamedSecretCreatorGetter {
 	return func() (string, reconciling.SecretCreator) {
-		return resources.UserSSHKeys, createSecretsFromUserSSHDirPath(path)
+		return resources.UserSSHKeys, createSecretsFromUserSSHDirPath(userSSHKeys)
 	}
 }
 
-func createSecretsFromUserSSHDirPath(path string) reconciling.SecretCreator {
+func createSecretsFromUserSSHDirPath(userSSHKeys map[string][]byte) reconciling.SecretCreator {
 	return func(existing *corev1.Secret) (secret *corev1.Secret, e error) {
-		secretsDir, err := os.Readlink(fmt.Sprintf("%v/%v", path, secretsDirLink))
-		if err != nil {
-			return nil, err
-		}
+		existing.Data = map[string][]byte{}
 
-		files, err := ioutil.ReadDir(fmt.Sprintf("%v/%v", path, secretsDir))
-		if err != nil {
-			return nil, err
-		}
-
-		if existing.Data == nil {
-			existing.Data = map[string][]byte{}
-		}
-
-		for _, file := range files {
-			if file.IsDir() {
-				continue
-			}
-
-			if _, ok := existing.Data[file.Name()]; ok {
-				continue
-			}
-
-			data, err := ioutil.ReadFile(fmt.Sprintf("%v/%v", path, file.Name()))
-			if err != nil {
-				return nil, fmt.Errorf("failed to read file %v during secret creation: %v", file.Name(), err)
-			}
-			existing.Data[file.Name()] = data
+		for k, v := range userSSHKeys {
+			existing.Data[k] = v
 		}
 		return existing, nil
 	}

--- a/api/pkg/controller/usercluster/resources/usersshkeys/secrets.go
+++ b/api/pkg/controller/usercluster/resources/usersshkeys/secrets.go
@@ -4,12 +4,15 @@ import (
 	"fmt"
 	"io/ioutil"
 	"os"
-	"path/filepath"
 
 	"github.com/kubermatic/kubermatic/api/pkg/resources"
 	"github.com/kubermatic/kubermatic/api/pkg/resources/reconciling"
 
 	corev1 "k8s.io/api/core/v1"
+)
+
+const (
+	secretsDirLink = "..data"
 )
 
 // CreateUserSSHKeysSecrets creates a secret in the usercluster from the user ssh keys.
@@ -21,27 +24,18 @@ func CreateUserSSHKeysSecrets(path string) reconciling.NamedSecretCreatorGetter 
 
 func createSecretsFromUserSSHDirPath(path string) reconciling.SecretCreator {
 	return func(existing *corev1.Secret) (secret *corev1.Secret, e error) {
-		files, err := ioutil.ReadDir(path)
+		secretsDir, err := os.Readlink(fmt.Sprintf("%v/%v", path, secretsDirLink))
+		if err != nil {
+			return nil, err
+		}
+
+		files, err := ioutil.ReadDir(fmt.Sprintf("%v/%v", path, secretsDir))
 		if err != nil {
 			return nil, err
 		}
 
 		if existing.Data == nil {
 			existing.Data = map[string][]byte{}
-		}
-
-		if err := filepath.Walk(path, func(path string, info os.FileInfo, err error) error {
-			if err != nil {
-				return err
-			}
-
-			if info.IsDir() {
-
-			}
-			fmt.Printf("Path: %v, File name: %v, IsDir: %v", path, info.Name(), info.IsDir())
-			return nil
-		}); err != nil {
-			return nil, fmt.Errorf("failed to walk directory: %v", err)
 		}
 
 		for _, file := range files {

--- a/api/pkg/controller/usersshkeys/controller.go
+++ b/api/pkg/controller/usersshkeys/controller.go
@@ -7,7 +7,6 @@ import (
 	"go.uber.org/zap"
 
 	kubermaticv1 "github.com/kubermatic/kubermatic/api/pkg/crd/kubermatic/v1"
-	"github.com/kubermatic/kubermatic/api/pkg/provider"
 	kubernetesprovider "github.com/kubermatic/kubermatic/api/pkg/provider/kubernetes"
 	"github.com/kubermatic/kubermatic/api/pkg/resources"
 
@@ -37,7 +36,6 @@ type Reconciler struct {
 	log            *zap.SugaredLogger
 	workerName     string
 	recorder       record.EventRecorder
-	seedGetter     provider.SeedGetter
 }
 
 func Add(
@@ -114,10 +112,6 @@ func (r *Reconciler) reconcileCluster(ctx context.Context, cluster *kubermaticv1
 	}
 
 	keys := buildUserSSHKeysForCluster(cluster.Name, userSSHKeys)
-	if len(keys) == 0 {
-		r.log.Debugw("No user ssh keys are assigned to cluster", "cluster", cluster.Name)
-		return nil
-	}
 
 	return r.reconcileClustersUserSSHKeys(ctx, keys, cluster)
 }
@@ -144,8 +138,8 @@ func (r *Reconciler) reconcileClustersUserSSHKeys(ctx context.Context, sshKeys [
 func buildUserSSHKeysForCluster(clusterName string, list *kubermaticv1.UserSSHKeyList) []kubermaticv1.UserSSHKey {
 	var clusterKeys []kubermaticv1.UserSSHKey
 	for _, item := range list.Items {
-		for _, clusterId := range item.Spec.Clusters {
-			if clusterName == clusterId {
+		for _, clusterID := range item.Spec.Clusters {
+			if clusterName == clusterID {
 				clusterKeys = append(clusterKeys, item)
 			}
 		}

--- a/api/pkg/controller/usersshkeys/controller.go
+++ b/api/pkg/controller/usersshkeys/controller.go
@@ -1,0 +1,161 @@
+package usersshkeys
+
+import (
+	"context"
+	"fmt"
+	"github.com/kubermatic/kubermatic/api/pkg/resources"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/client-go/tools/record"
+
+	"go.uber.org/zap"
+
+	kubermaticv1 "github.com/kubermatic/kubermatic/api/pkg/crd/kubermatic/v1"
+	kubernetesprovider "github.com/kubermatic/kubermatic/api/pkg/provider/kubernetes"
+
+	corev1 "k8s.io/api/core/v1"
+
+	kubeapierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	ctrlruntimeclient "sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/controller"
+	"sigs.k8s.io/controller-runtime/pkg/handler"
+	"sigs.k8s.io/controller-runtime/pkg/manager"
+	"sigs.k8s.io/controller-runtime/pkg/reconcile"
+	"sigs.k8s.io/controller-runtime/pkg/source"
+)
+
+const (
+	ControllerName = "kubermatic_usersshkeys_controller"
+)
+
+// Reconciler is a controller which is responsible for managing clusters
+type Reconciler struct {
+	ctrlruntimeclient.Client
+	sshKeyProvdier *kubernetesprovider.SSHKeyProvider
+	log            *zap.SugaredLogger
+	workerName     string
+	recorder       record.EventRecorder
+}
+
+func Add(
+	mgr manager.Manager,
+	sshProvdier *kubernetesprovider.SSHKeyProvider,
+	log *zap.SugaredLogger,
+	workerName string,
+	numWorkers int,
+) error {
+
+	reconciler := &Reconciler{
+		sshKeyProvdier: sshProvdier,
+		log:            log,
+		workerName:     workerName,
+		Client:         mgr.GetClient(),
+		recorder:       mgr.GetRecorder(ControllerName),
+	}
+
+	c, err := controller.New(ControllerName, mgr, controller.Options{Reconciler: reconciler, MaxConcurrentReconciles: numWorkers})
+	if err != nil {
+		return err
+	}
+
+	return c.Watch(&source.Kind{Type: &kubermaticv1.UserSSHKey{}}, &handler.EnqueueRequestForObject{})
+}
+
+func (r *Reconciler) Reconcile(request reconcile.Request) (reconcile.Result, error) {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	log := r.log.With("request", request)
+	log.Debug("Processing")
+
+	userSSHKey := &kubermaticv1.UserSSHKey{}
+	if err := r.Get(ctx, request.NamespacedName, userSSHKey); err != nil {
+		if kubeapierrors.IsNotFound(err) {
+			log.Debug("Could not find user ssh key")
+			return reconcile.Result{}, nil
+		}
+		return reconcile.Result{}, err
+	}
+
+	err := r.reconcileUserSSHKeys(ctx, userSSHKey)
+	if err != nil {
+		log.Errorw("Failed to reconcile user ssh keys", zap.Error(err))
+	}
+
+	return reconcile.Result{}, err
+}
+
+func (r *Reconciler) reconcileUserSSHKeys(ctx context.Context, userSSHKey *kubermaticv1.UserSSHKey) error {
+	clusterList := &kubermaticv1.ClusterList{}
+	if err := r.List(ctx, &ctrlruntimeclient.ListOptions{}, clusterList); err != nil {
+		return err
+	}
+
+	clustersNames := buildClustersMapFromSecret(userSSHKey.Spec.Clusters)
+	for _, cluster := range clusterList.Items {
+		namespace := fmt.Sprintf("cluster-%v", cluster.Name)
+		if _, found := clustersNames[cluster.Name]; !found {
+			return r.deleteUserSSHKey(ctx, cluster, namespace, userSSHKey.Name)
+		}
+
+		return r.updateUserSSHKeysSecrets(ctx, userSSHKey, cluster.Name, namespace)
+	}
+
+	return nil
+}
+
+func (r *Reconciler) updateUserSSHKeysSecrets(ctx context.Context, userSSHKey *kubermaticv1.UserSSHKey, clusterName, namespace string) error {
+	key := types.NamespacedName{
+		Namespace: namespace,
+		Name:      fmt.Sprintf("%v-%v", resources.UserSSHKeys, clusterName),
+	}
+
+	secret := &corev1.Secret{}
+	if err := r.Get(ctx, key, secret); err != nil {
+		if kubeapierrors.IsNotFound(err) {
+			secret = &corev1.Secret{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      key.Name,
+					Namespace: namespace,
+				},
+				Type: corev1.SecretTypeOpaque,
+				Data: map[string][]byte{
+					userSSHKey.Name: []byte(userSSHKey.Spec.PublicKey),
+				},
+			}
+			return r.Create(ctx, secret)
+		}
+		return err
+	}
+
+	if _, found := secret.Data[userSSHKey.Name]; !found {
+		secret.Data[userSSHKey.Name] = []byte(userSSHKey.Spec.PublicKey)
+		return r.Update(ctx, secret)
+	}
+
+	return nil
+}
+
+func (r *Reconciler) deleteUserSSHKey(ctx context.Context, cluster kubermaticv1.Cluster, namespace, keyName string) error {
+	key := types.NamespacedName{
+		Namespace: namespace,
+		Name:      fmt.Sprintf("%v-%v", resources.UserSSHKeys, cluster.Name),
+	}
+	secret := &corev1.Secret{}
+	if err := r.Get(ctx, key, secret); err != nil {
+		if kubeapierrors.IsNotFound(err) {
+			return nil
+		}
+		return err
+	}
+
+	delete(secret.Data, keyName)
+	return r.Update(ctx, secret)
+}
+
+func buildClustersMapFromSecret(clusters []string) (mappedClusters map[string]struct{}) {
+	for _, cluster := range clusters {
+		mappedClusters[cluster] = struct{}{}
+	}
+
+	return mappedClusters
+}

--- a/api/pkg/handler/v1/cluster/cluster.go
+++ b/api/pkg/handler/v1/cluster/cluster.go
@@ -575,7 +575,7 @@ func AssignSSHKeyEndpoint(sshKeyProvider provider.SSHKeyProvider, projectProvide
 				}
 			}
 			if !found {
-				return nil, fmt.Errorf(fmt.Sprintf("the given ssh key %s does not belong to the given project %s (%s)", req.KeyID, project.Spec.Name, project.Name))
+				return nil, fmt.Errorf("the given ssh key %s does not belong to the given project %s (%s)", req.KeyID, project.Spec.Name, project.Name)
 			}
 		}
 

--- a/api/pkg/handler/v1/cluster/cluster.go
+++ b/api/pkg/handler/v1/cluster/cluster.go
@@ -575,7 +575,7 @@ func AssignSSHKeyEndpoint(sshKeyProvider provider.SSHKeyProvider, projectProvide
 				}
 			}
 			if !found {
-				return nil, errors.NewBadRequest(fmt.Sprintf("the given ssh key %s does not belong to the given project %s (%s)", req.KeyID, project.Spec.Name, project.Name))
+				return nil, fmt.Errorf(fmt.Sprintf("the given ssh key %s does not belong to the given project %s (%s)", req.KeyID, project.Spec.Name, project.Name))
 			}
 		}
 

--- a/api/pkg/handler/v1/cluster/cluster.go
+++ b/api/pkg/handler/v1/cluster/cluster.go
@@ -575,7 +575,7 @@ func AssignSSHKeyEndpoint(sshKeyProvider provider.SSHKeyProvider, projectProvide
 				}
 			}
 			if !found {
-				return nil, fmt.Errorf("the given ssh key %s does not belong to the given project %s (%s)", req.KeyID, project.Spec.Name, project.Name)
+				return nil, errors.NewBadRequest(fmt.Sprintf("the given ssh key %s does not belong to the given project %s (%s)", req.KeyID, project.Spec.Name, project.Name))
 			}
 		}
 

--- a/api/pkg/resources/resources.go
+++ b/api/pkg/resources/resources.go
@@ -437,6 +437,8 @@ const (
 	VspherePassword                    = "password"
 	VsphereInfraManagementUserUsername = "infraManagementUserUsername"
 	VsphereInfraManagementUserPassword = "infraManagementUserPassword"
+
+	UserSSHKeys = "usersshkeys"
 )
 
 // ECDSAKeyPair is a ECDSA x509 certifcate and private key

--- a/api/pkg/resources/test/fixtures/deployment-aws-1.10.0-usercluster-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-aws-1.10.0-usercluster-controller.yaml
@@ -26,6 +26,7 @@ spec:
         cluster: de-test-01
         internal-admin-kubeconfig-secret-revision: "123456"
         openvpn-ca-secret-revision: "123456"
+        usersshkeys-secret-revision: "123456"
     spec:
       containers:
       - args:
@@ -76,6 +77,9 @@ spec:
         - mountPath: /etc/kubernetes/pki/openvpn
           name: openvpn-ca
           readOnly: true
+        - mountPath: /etc/kubernetes/usersshkeys
+          name: usersshkeys
+          readOnly: true
         - mountPath: /http-prober-bin
           name: http-prober-bin
       imagePullSecrets:
@@ -101,6 +105,9 @@ spec:
       - name: openvpn-ca
         secret:
           secretName: openvpn-ca
+      - name: usersshkeys
+        secret:
+          secretName: usersshkeys
       - emptyDir: {}
         name: http-prober-bin
 status: {}

--- a/api/pkg/resources/test/fixtures/deployment-aws-1.10.0-usercluster-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-aws-1.10.0-usercluster-controller.yaml
@@ -40,7 +40,7 @@ spec:
         - -timeout
         - "1"
         - -command
-        - '{"command":"/usr/local/bin/user-cluster-controller-manager","args":["-kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","-metrics-listen-address","0.0.0.0:8085","-health-listen-address","0.0.0.0:8086","-namespace","$(NAMESPACE)","-ca-cert","/etc/kubernetes/pki/ca/ca.crt","-ca-key","/etc/kubernetes/pki/ca/ca.key","-cluster-url","","-openvpn-server-port","30003","-overwrite-registry","","-openshift=false","-version","1.10.0","-cloud-provider-name","aws","-openvpn-ca-cert-file=/etc/kubernetes/pki/openvpn/ca.crt","-openvpn-ca-key-file=/etc/kubernetes/pki/openvpn/ca.key","--ipam-controller-network","192.168.1.1/24,192.168.1.1,8.8.8.8","-node-labels","{\"my-label\":\"my-value\"}"]}'
+        - '{"command":"/usr/local/bin/user-cluster-controller-manager","args":["-kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","-metrics-listen-address","0.0.0.0:8085","-health-listen-address","0.0.0.0:8086","-namespace","$(NAMESPACE)","-ca-cert","/etc/kubernetes/pki/ca/ca.crt","-ca-key","/etc/kubernetes/pki/ca/ca.key","-cluster-url","","-openvpn-server-port","30003","-overwrite-registry","","-openshift=false","-version","1.10.0","-cloud-provider-name","aws","-openvpn-ca-cert-file=/etc/kubernetes/pki/openvpn/ca.crt","-openvpn-ca-key-file=/etc/kubernetes/pki/openvpn/ca.key","-user-ssh-keys-dir-path=/etc/kubernetes/usersshkeys","--ipam-controller-network","192.168.1.1/24,192.168.1.1,8.8.8.8","-node-labels","{\"my-label\":\"my-value\"}"]}'
         command:
         - /http-prober-bin/http-prober
         env:

--- a/api/pkg/resources/test/fixtures/deployment-aws-1.10.6-usercluster-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-aws-1.10.6-usercluster-controller.yaml
@@ -26,6 +26,7 @@ spec:
         cluster: de-test-01
         internal-admin-kubeconfig-secret-revision: "123456"
         openvpn-ca-secret-revision: "123456"
+        usersshkeys-secret-revision: "123456"
     spec:
       containers:
       - args:
@@ -76,6 +77,9 @@ spec:
         - mountPath: /etc/kubernetes/pki/openvpn
           name: openvpn-ca
           readOnly: true
+        - mountPath: /etc/kubernetes/usersshkeys
+          name: usersshkeys
+          readOnly: true
         - mountPath: /http-prober-bin
           name: http-prober-bin
       imagePullSecrets:
@@ -101,6 +105,9 @@ spec:
       - name: openvpn-ca
         secret:
           secretName: openvpn-ca
+      - name: usersshkeys
+        secret:
+          secretName: usersshkeys
       - emptyDir: {}
         name: http-prober-bin
 status: {}

--- a/api/pkg/resources/test/fixtures/deployment-aws-1.10.6-usercluster-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-aws-1.10.6-usercluster-controller.yaml
@@ -40,7 +40,7 @@ spec:
         - -timeout
         - "1"
         - -command
-        - '{"command":"/usr/local/bin/user-cluster-controller-manager","args":["-kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","-metrics-listen-address","0.0.0.0:8085","-health-listen-address","0.0.0.0:8086","-namespace","$(NAMESPACE)","-ca-cert","/etc/kubernetes/pki/ca/ca.crt","-ca-key","/etc/kubernetes/pki/ca/ca.key","-cluster-url","","-openvpn-server-port","30003","-overwrite-registry","","-openshift=false","-version","1.10.6","-cloud-provider-name","aws","-openvpn-ca-cert-file=/etc/kubernetes/pki/openvpn/ca.crt","-openvpn-ca-key-file=/etc/kubernetes/pki/openvpn/ca.key","--ipam-controller-network","192.168.1.1/24,192.168.1.1,8.8.8.8","-node-labels","{\"my-label\":\"my-value\"}"]}'
+        - '{"command":"/usr/local/bin/user-cluster-controller-manager","args":["-kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","-metrics-listen-address","0.0.0.0:8085","-health-listen-address","0.0.0.0:8086","-namespace","$(NAMESPACE)","-ca-cert","/etc/kubernetes/pki/ca/ca.crt","-ca-key","/etc/kubernetes/pki/ca/ca.key","-cluster-url","","-openvpn-server-port","30003","-overwrite-registry","","-openshift=false","-version","1.10.6","-cloud-provider-name","aws","-openvpn-ca-cert-file=/etc/kubernetes/pki/openvpn/ca.crt","-openvpn-ca-key-file=/etc/kubernetes/pki/openvpn/ca.key","-user-ssh-keys-dir-path=/etc/kubernetes/usersshkeys","--ipam-controller-network","192.168.1.1/24,192.168.1.1,8.8.8.8","-node-labels","{\"my-label\":\"my-value\"}"]}'
         command:
         - /http-prober-bin/http-prober
         env:

--- a/api/pkg/resources/test/fixtures/deployment-aws-1.11.0-usercluster-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-aws-1.11.0-usercluster-controller.yaml
@@ -26,6 +26,7 @@ spec:
         cluster: de-test-01
         internal-admin-kubeconfig-secret-revision: "123456"
         openvpn-ca-secret-revision: "123456"
+        usersshkeys-secret-revision: "123456"
     spec:
       containers:
       - args:
@@ -76,6 +77,9 @@ spec:
         - mountPath: /etc/kubernetes/pki/openvpn
           name: openvpn-ca
           readOnly: true
+        - mountPath: /etc/kubernetes/usersshkeys
+          name: usersshkeys
+          readOnly: true
         - mountPath: /http-prober-bin
           name: http-prober-bin
       imagePullSecrets:
@@ -101,6 +105,9 @@ spec:
       - name: openvpn-ca
         secret:
           secretName: openvpn-ca
+      - name: usersshkeys
+        secret:
+          secretName: usersshkeys
       - emptyDir: {}
         name: http-prober-bin
 status: {}

--- a/api/pkg/resources/test/fixtures/deployment-aws-1.11.0-usercluster-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-aws-1.11.0-usercluster-controller.yaml
@@ -40,7 +40,7 @@ spec:
         - -timeout
         - "1"
         - -command
-        - '{"command":"/usr/local/bin/user-cluster-controller-manager","args":["-kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","-metrics-listen-address","0.0.0.0:8085","-health-listen-address","0.0.0.0:8086","-namespace","$(NAMESPACE)","-ca-cert","/etc/kubernetes/pki/ca/ca.crt","-ca-key","/etc/kubernetes/pki/ca/ca.key","-cluster-url","","-openvpn-server-port","30003","-overwrite-registry","","-openshift=false","-version","1.11.0","-cloud-provider-name","aws","-openvpn-ca-cert-file=/etc/kubernetes/pki/openvpn/ca.crt","-openvpn-ca-key-file=/etc/kubernetes/pki/openvpn/ca.key","--ipam-controller-network","192.168.1.1/24,192.168.1.1,8.8.8.8","-node-labels","{\"my-label\":\"my-value\"}"]}'
+        - '{"command":"/usr/local/bin/user-cluster-controller-manager","args":["-kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","-metrics-listen-address","0.0.0.0:8085","-health-listen-address","0.0.0.0:8086","-namespace","$(NAMESPACE)","-ca-cert","/etc/kubernetes/pki/ca/ca.crt","-ca-key","/etc/kubernetes/pki/ca/ca.key","-cluster-url","","-openvpn-server-port","30003","-overwrite-registry","","-openshift=false","-version","1.11.0","-cloud-provider-name","aws","-openvpn-ca-cert-file=/etc/kubernetes/pki/openvpn/ca.crt","-openvpn-ca-key-file=/etc/kubernetes/pki/openvpn/ca.key","-user-ssh-keys-dir-path=/etc/kubernetes/usersshkeys","--ipam-controller-network","192.168.1.1/24,192.168.1.1,8.8.8.8","-node-labels","{\"my-label\":\"my-value\"}"]}'
         command:
         - /http-prober-bin/http-prober
         env:

--- a/api/pkg/resources/test/fixtures/deployment-aws-1.11.1-usercluster-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-aws-1.11.1-usercluster-controller.yaml
@@ -26,6 +26,7 @@ spec:
         cluster: de-test-01
         internal-admin-kubeconfig-secret-revision: "123456"
         openvpn-ca-secret-revision: "123456"
+        usersshkeys-secret-revision: "123456"
     spec:
       containers:
       - args:
@@ -76,6 +77,9 @@ spec:
         - mountPath: /etc/kubernetes/pki/openvpn
           name: openvpn-ca
           readOnly: true
+        - mountPath: /etc/kubernetes/usersshkeys
+          name: usersshkeys
+          readOnly: true
         - mountPath: /http-prober-bin
           name: http-prober-bin
       imagePullSecrets:
@@ -101,6 +105,9 @@ spec:
       - name: openvpn-ca
         secret:
           secretName: openvpn-ca
+      - name: usersshkeys
+        secret:
+          secretName: usersshkeys
       - emptyDir: {}
         name: http-prober-bin
 status: {}

--- a/api/pkg/resources/test/fixtures/deployment-aws-1.11.1-usercluster-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-aws-1.11.1-usercluster-controller.yaml
@@ -40,7 +40,7 @@ spec:
         - -timeout
         - "1"
         - -command
-        - '{"command":"/usr/local/bin/user-cluster-controller-manager","args":["-kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","-metrics-listen-address","0.0.0.0:8085","-health-listen-address","0.0.0.0:8086","-namespace","$(NAMESPACE)","-ca-cert","/etc/kubernetes/pki/ca/ca.crt","-ca-key","/etc/kubernetes/pki/ca/ca.key","-cluster-url","","-openvpn-server-port","30003","-overwrite-registry","","-openshift=false","-version","1.11.1","-cloud-provider-name","aws","-openvpn-ca-cert-file=/etc/kubernetes/pki/openvpn/ca.crt","-openvpn-ca-key-file=/etc/kubernetes/pki/openvpn/ca.key","--ipam-controller-network","192.168.1.1/24,192.168.1.1,8.8.8.8","-node-labels","{\"my-label\":\"my-value\"}"]}'
+        - '{"command":"/usr/local/bin/user-cluster-controller-manager","args":["-kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","-metrics-listen-address","0.0.0.0:8085","-health-listen-address","0.0.0.0:8086","-namespace","$(NAMESPACE)","-ca-cert","/etc/kubernetes/pki/ca/ca.crt","-ca-key","/etc/kubernetes/pki/ca/ca.key","-cluster-url","","-openvpn-server-port","30003","-overwrite-registry","","-openshift=false","-version","1.11.1","-cloud-provider-name","aws","-openvpn-ca-cert-file=/etc/kubernetes/pki/openvpn/ca.crt","-openvpn-ca-key-file=/etc/kubernetes/pki/openvpn/ca.key","-user-ssh-keys-dir-path=/etc/kubernetes/usersshkeys","--ipam-controller-network","192.168.1.1/24,192.168.1.1,8.8.8.8","-node-labels","{\"my-label\":\"my-value\"}"]}'
         command:
         - /http-prober-bin/http-prober
         env:

--- a/api/pkg/resources/test/fixtures/deployment-aws-1.12.0-usercluster-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-aws-1.12.0-usercluster-controller.yaml
@@ -26,6 +26,7 @@ spec:
         cluster: de-test-01
         internal-admin-kubeconfig-secret-revision: "123456"
         openvpn-ca-secret-revision: "123456"
+        usersshkeys-secret-revision: "123456"
     spec:
       containers:
       - args:
@@ -76,6 +77,9 @@ spec:
         - mountPath: /etc/kubernetes/pki/openvpn
           name: openvpn-ca
           readOnly: true
+        - mountPath: /etc/kubernetes/usersshkeys
+          name: usersshkeys
+          readOnly: true
         - mountPath: /http-prober-bin
           name: http-prober-bin
       imagePullSecrets:
@@ -101,6 +105,9 @@ spec:
       - name: openvpn-ca
         secret:
           secretName: openvpn-ca
+      - name: usersshkeys
+        secret:
+          secretName: usersshkeys
       - emptyDir: {}
         name: http-prober-bin
 status: {}

--- a/api/pkg/resources/test/fixtures/deployment-aws-1.12.0-usercluster-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-aws-1.12.0-usercluster-controller.yaml
@@ -40,7 +40,7 @@ spec:
         - -timeout
         - "1"
         - -command
-        - '{"command":"/usr/local/bin/user-cluster-controller-manager","args":["-kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","-metrics-listen-address","0.0.0.0:8085","-health-listen-address","0.0.0.0:8086","-namespace","$(NAMESPACE)","-ca-cert","/etc/kubernetes/pki/ca/ca.crt","-ca-key","/etc/kubernetes/pki/ca/ca.key","-cluster-url","","-openvpn-server-port","30003","-overwrite-registry","","-openshift=false","-version","1.12.0","-cloud-provider-name","aws","-openvpn-ca-cert-file=/etc/kubernetes/pki/openvpn/ca.crt","-openvpn-ca-key-file=/etc/kubernetes/pki/openvpn/ca.key","--ipam-controller-network","192.168.1.1/24,192.168.1.1,8.8.8.8","-node-labels","{\"my-label\":\"my-value\"}"]}'
+        - '{"command":"/usr/local/bin/user-cluster-controller-manager","args":["-kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","-metrics-listen-address","0.0.0.0:8085","-health-listen-address","0.0.0.0:8086","-namespace","$(NAMESPACE)","-ca-cert","/etc/kubernetes/pki/ca/ca.crt","-ca-key","/etc/kubernetes/pki/ca/ca.key","-cluster-url","","-openvpn-server-port","30003","-overwrite-registry","","-openshift=false","-version","1.12.0","-cloud-provider-name","aws","-openvpn-ca-cert-file=/etc/kubernetes/pki/openvpn/ca.crt","-openvpn-ca-key-file=/etc/kubernetes/pki/openvpn/ca.key","-user-ssh-keys-dir-path=/etc/kubernetes/usersshkeys","--ipam-controller-network","192.168.1.1/24,192.168.1.1,8.8.8.8","-node-labels","{\"my-label\":\"my-value\"}"]}'
         command:
         - /http-prober-bin/http-prober
         env:

--- a/api/pkg/resources/test/fixtures/deployment-aws-1.13.0-usercluster-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-aws-1.13.0-usercluster-controller.yaml
@@ -26,6 +26,7 @@ spec:
         cluster: de-test-01
         internal-admin-kubeconfig-secret-revision: "123456"
         openvpn-ca-secret-revision: "123456"
+        usersshkeys-secret-revision: "123456"
     spec:
       containers:
       - args:
@@ -76,6 +77,9 @@ spec:
         - mountPath: /etc/kubernetes/pki/openvpn
           name: openvpn-ca
           readOnly: true
+        - mountPath: /etc/kubernetes/usersshkeys
+          name: usersshkeys
+          readOnly: true
         - mountPath: /http-prober-bin
           name: http-prober-bin
       imagePullSecrets:
@@ -101,6 +105,9 @@ spec:
       - name: openvpn-ca
         secret:
           secretName: openvpn-ca
+      - name: usersshkeys
+        secret:
+          secretName: usersshkeys
       - emptyDir: {}
         name: http-prober-bin
 status: {}

--- a/api/pkg/resources/test/fixtures/deployment-aws-1.13.0-usercluster-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-aws-1.13.0-usercluster-controller.yaml
@@ -40,7 +40,7 @@ spec:
         - -timeout
         - "1"
         - -command
-        - '{"command":"/usr/local/bin/user-cluster-controller-manager","args":["-kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","-metrics-listen-address","0.0.0.0:8085","-health-listen-address","0.0.0.0:8086","-namespace","$(NAMESPACE)","-ca-cert","/etc/kubernetes/pki/ca/ca.crt","-ca-key","/etc/kubernetes/pki/ca/ca.key","-cluster-url","","-openvpn-server-port","30003","-overwrite-registry","","-openshift=false","-version","1.13.0","-cloud-provider-name","aws","-openvpn-ca-cert-file=/etc/kubernetes/pki/openvpn/ca.crt","-openvpn-ca-key-file=/etc/kubernetes/pki/openvpn/ca.key","--ipam-controller-network","192.168.1.1/24,192.168.1.1,8.8.8.8","-node-labels","{\"my-label\":\"my-value\"}"]}'
+        - '{"command":"/usr/local/bin/user-cluster-controller-manager","args":["-kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","-metrics-listen-address","0.0.0.0:8085","-health-listen-address","0.0.0.0:8086","-namespace","$(NAMESPACE)","-ca-cert","/etc/kubernetes/pki/ca/ca.crt","-ca-key","/etc/kubernetes/pki/ca/ca.key","-cluster-url","","-openvpn-server-port","30003","-overwrite-registry","","-openshift=false","-version","1.13.0","-cloud-provider-name","aws","-openvpn-ca-cert-file=/etc/kubernetes/pki/openvpn/ca.crt","-openvpn-ca-key-file=/etc/kubernetes/pki/openvpn/ca.key","-user-ssh-keys-dir-path=/etc/kubernetes/usersshkeys","--ipam-controller-network","192.168.1.1/24,192.168.1.1,8.8.8.8","-node-labels","{\"my-label\":\"my-value\"}"]}'
         command:
         - /http-prober-bin/http-prober
         env:

--- a/api/pkg/resources/test/fixtures/deployment-azure-1.10.0-usercluster-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-azure-1.10.0-usercluster-controller.yaml
@@ -40,7 +40,7 @@ spec:
         - -timeout
         - "1"
         - -command
-        - '{"command":"/usr/local/bin/user-cluster-controller-manager","args":["-kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","-metrics-listen-address","0.0.0.0:8085","-health-listen-address","0.0.0.0:8086","-namespace","$(NAMESPACE)","-ca-cert","/etc/kubernetes/pki/ca/ca.crt","-ca-key","/etc/kubernetes/pki/ca/ca.key","-cluster-url","","-openvpn-server-port","30003","-overwrite-registry","","-openshift=false","-version","1.10.0","-cloud-provider-name","azure","-openvpn-ca-cert-file=/etc/kubernetes/pki/openvpn/ca.crt","-openvpn-ca-key-file=/etc/kubernetes/pki/openvpn/ca.key","--ipam-controller-network","192.168.1.1/24,192.168.1.1,8.8.8.8","-node-labels","{\"my-label\":\"my-value\"}"]}'
+        - '{"command":"/usr/local/bin/user-cluster-controller-manager","args":["-kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","-metrics-listen-address","0.0.0.0:8085","-health-listen-address","0.0.0.0:8086","-namespace","$(NAMESPACE)","-ca-cert","/etc/kubernetes/pki/ca/ca.crt","-ca-key","/etc/kubernetes/pki/ca/ca.key","-cluster-url","","-openvpn-server-port","30003","-overwrite-registry","","-openshift=false","-version","1.10.0","-cloud-provider-name","azure","-openvpn-ca-cert-file=/etc/kubernetes/pki/openvpn/ca.crt","-openvpn-ca-key-file=/etc/kubernetes/pki/openvpn/ca.key","-user-ssh-keys-dir-path=/etc/kubernetes/usersshkeys","--ipam-controller-network","192.168.1.1/24,192.168.1.1,8.8.8.8","-node-labels","{\"my-label\":\"my-value\"}"]}'
         command:
         - /http-prober-bin/http-prober
         env:

--- a/api/pkg/resources/test/fixtures/deployment-azure-1.10.0-usercluster-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-azure-1.10.0-usercluster-controller.yaml
@@ -26,6 +26,7 @@ spec:
         cluster: de-test-01
         internal-admin-kubeconfig-secret-revision: "123456"
         openvpn-ca-secret-revision: "123456"
+        usersshkeys-secret-revision: "123456"
     spec:
       containers:
       - args:
@@ -76,6 +77,9 @@ spec:
         - mountPath: /etc/kubernetes/pki/openvpn
           name: openvpn-ca
           readOnly: true
+        - mountPath: /etc/kubernetes/usersshkeys
+          name: usersshkeys
+          readOnly: true
         - mountPath: /http-prober-bin
           name: http-prober-bin
       imagePullSecrets:
@@ -101,6 +105,9 @@ spec:
       - name: openvpn-ca
         secret:
           secretName: openvpn-ca
+      - name: usersshkeys
+        secret:
+          secretName: usersshkeys
       - emptyDir: {}
         name: http-prober-bin
 status: {}

--- a/api/pkg/resources/test/fixtures/deployment-azure-1.10.6-usercluster-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-azure-1.10.6-usercluster-controller.yaml
@@ -40,7 +40,7 @@ spec:
         - -timeout
         - "1"
         - -command
-        - '{"command":"/usr/local/bin/user-cluster-controller-manager","args":["-kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","-metrics-listen-address","0.0.0.0:8085","-health-listen-address","0.0.0.0:8086","-namespace","$(NAMESPACE)","-ca-cert","/etc/kubernetes/pki/ca/ca.crt","-ca-key","/etc/kubernetes/pki/ca/ca.key","-cluster-url","","-openvpn-server-port","30003","-overwrite-registry","","-openshift=false","-version","1.10.6","-cloud-provider-name","azure","-openvpn-ca-cert-file=/etc/kubernetes/pki/openvpn/ca.crt","-openvpn-ca-key-file=/etc/kubernetes/pki/openvpn/ca.key","--ipam-controller-network","192.168.1.1/24,192.168.1.1,8.8.8.8","-node-labels","{\"my-label\":\"my-value\"}"]}'
+        - '{"command":"/usr/local/bin/user-cluster-controller-manager","args":["-kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","-metrics-listen-address","0.0.0.0:8085","-health-listen-address","0.0.0.0:8086","-namespace","$(NAMESPACE)","-ca-cert","/etc/kubernetes/pki/ca/ca.crt","-ca-key","/etc/kubernetes/pki/ca/ca.key","-cluster-url","","-openvpn-server-port","30003","-overwrite-registry","","-openshift=false","-version","1.10.6","-cloud-provider-name","azure","-openvpn-ca-cert-file=/etc/kubernetes/pki/openvpn/ca.crt","-openvpn-ca-key-file=/etc/kubernetes/pki/openvpn/ca.key","-user-ssh-keys-dir-path=/etc/kubernetes/usersshkeys","--ipam-controller-network","192.168.1.1/24,192.168.1.1,8.8.8.8","-node-labels","{\"my-label\":\"my-value\"}"]}'
         command:
         - /http-prober-bin/http-prober
         env:

--- a/api/pkg/resources/test/fixtures/deployment-azure-1.10.6-usercluster-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-azure-1.10.6-usercluster-controller.yaml
@@ -26,6 +26,7 @@ spec:
         cluster: de-test-01
         internal-admin-kubeconfig-secret-revision: "123456"
         openvpn-ca-secret-revision: "123456"
+        usersshkeys-secret-revision: "123456"
     spec:
       containers:
       - args:
@@ -76,6 +77,9 @@ spec:
         - mountPath: /etc/kubernetes/pki/openvpn
           name: openvpn-ca
           readOnly: true
+        - mountPath: /etc/kubernetes/usersshkeys
+          name: usersshkeys
+          readOnly: true
         - mountPath: /http-prober-bin
           name: http-prober-bin
       imagePullSecrets:
@@ -101,6 +105,9 @@ spec:
       - name: openvpn-ca
         secret:
           secretName: openvpn-ca
+      - name: usersshkeys
+        secret:
+          secretName: usersshkeys
       - emptyDir: {}
         name: http-prober-bin
 status: {}

--- a/api/pkg/resources/test/fixtures/deployment-azure-1.11.0-usercluster-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-azure-1.11.0-usercluster-controller.yaml
@@ -26,6 +26,7 @@ spec:
         cluster: de-test-01
         internal-admin-kubeconfig-secret-revision: "123456"
         openvpn-ca-secret-revision: "123456"
+        usersshkeys-secret-revision: "123456"
     spec:
       containers:
       - args:
@@ -76,6 +77,9 @@ spec:
         - mountPath: /etc/kubernetes/pki/openvpn
           name: openvpn-ca
           readOnly: true
+        - mountPath: /etc/kubernetes/usersshkeys
+          name: usersshkeys
+          readOnly: true
         - mountPath: /http-prober-bin
           name: http-prober-bin
       imagePullSecrets:
@@ -101,6 +105,9 @@ spec:
       - name: openvpn-ca
         secret:
           secretName: openvpn-ca
+      - name: usersshkeys
+        secret:
+          secretName: usersshkeys
       - emptyDir: {}
         name: http-prober-bin
 status: {}

--- a/api/pkg/resources/test/fixtures/deployment-azure-1.11.0-usercluster-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-azure-1.11.0-usercluster-controller.yaml
@@ -40,7 +40,7 @@ spec:
         - -timeout
         - "1"
         - -command
-        - '{"command":"/usr/local/bin/user-cluster-controller-manager","args":["-kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","-metrics-listen-address","0.0.0.0:8085","-health-listen-address","0.0.0.0:8086","-namespace","$(NAMESPACE)","-ca-cert","/etc/kubernetes/pki/ca/ca.crt","-ca-key","/etc/kubernetes/pki/ca/ca.key","-cluster-url","","-openvpn-server-port","30003","-overwrite-registry","","-openshift=false","-version","1.11.0","-cloud-provider-name","azure","-openvpn-ca-cert-file=/etc/kubernetes/pki/openvpn/ca.crt","-openvpn-ca-key-file=/etc/kubernetes/pki/openvpn/ca.key","--ipam-controller-network","192.168.1.1/24,192.168.1.1,8.8.8.8","-node-labels","{\"my-label\":\"my-value\"}"]}'
+        - '{"command":"/usr/local/bin/user-cluster-controller-manager","args":["-kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","-metrics-listen-address","0.0.0.0:8085","-health-listen-address","0.0.0.0:8086","-namespace","$(NAMESPACE)","-ca-cert","/etc/kubernetes/pki/ca/ca.crt","-ca-key","/etc/kubernetes/pki/ca/ca.key","-cluster-url","","-openvpn-server-port","30003","-overwrite-registry","","-openshift=false","-version","1.11.0","-cloud-provider-name","azure","-openvpn-ca-cert-file=/etc/kubernetes/pki/openvpn/ca.crt","-openvpn-ca-key-file=/etc/kubernetes/pki/openvpn/ca.key","-user-ssh-keys-dir-path=/etc/kubernetes/usersshkeys","--ipam-controller-network","192.168.1.1/24,192.168.1.1,8.8.8.8","-node-labels","{\"my-label\":\"my-value\"}"]}'
         command:
         - /http-prober-bin/http-prober
         env:

--- a/api/pkg/resources/test/fixtures/deployment-azure-1.11.1-usercluster-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-azure-1.11.1-usercluster-controller.yaml
@@ -26,6 +26,7 @@ spec:
         cluster: de-test-01
         internal-admin-kubeconfig-secret-revision: "123456"
         openvpn-ca-secret-revision: "123456"
+        usersshkeys-secret-revision: "123456"
     spec:
       containers:
       - args:
@@ -76,6 +77,9 @@ spec:
         - mountPath: /etc/kubernetes/pki/openvpn
           name: openvpn-ca
           readOnly: true
+        - mountPath: /etc/kubernetes/usersshkeys
+          name: usersshkeys
+          readOnly: true
         - mountPath: /http-prober-bin
           name: http-prober-bin
       imagePullSecrets:
@@ -101,6 +105,9 @@ spec:
       - name: openvpn-ca
         secret:
           secretName: openvpn-ca
+      - name: usersshkeys
+        secret:
+          secretName: usersshkeys
       - emptyDir: {}
         name: http-prober-bin
 status: {}

--- a/api/pkg/resources/test/fixtures/deployment-azure-1.11.1-usercluster-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-azure-1.11.1-usercluster-controller.yaml
@@ -40,7 +40,7 @@ spec:
         - -timeout
         - "1"
         - -command
-        - '{"command":"/usr/local/bin/user-cluster-controller-manager","args":["-kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","-metrics-listen-address","0.0.0.0:8085","-health-listen-address","0.0.0.0:8086","-namespace","$(NAMESPACE)","-ca-cert","/etc/kubernetes/pki/ca/ca.crt","-ca-key","/etc/kubernetes/pki/ca/ca.key","-cluster-url","","-openvpn-server-port","30003","-overwrite-registry","","-openshift=false","-version","1.11.1","-cloud-provider-name","azure","-openvpn-ca-cert-file=/etc/kubernetes/pki/openvpn/ca.crt","-openvpn-ca-key-file=/etc/kubernetes/pki/openvpn/ca.key","--ipam-controller-network","192.168.1.1/24,192.168.1.1,8.8.8.8","-node-labels","{\"my-label\":\"my-value\"}"]}'
+        - '{"command":"/usr/local/bin/user-cluster-controller-manager","args":["-kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","-metrics-listen-address","0.0.0.0:8085","-health-listen-address","0.0.0.0:8086","-namespace","$(NAMESPACE)","-ca-cert","/etc/kubernetes/pki/ca/ca.crt","-ca-key","/etc/kubernetes/pki/ca/ca.key","-cluster-url","","-openvpn-server-port","30003","-overwrite-registry","","-openshift=false","-version","1.11.1","-cloud-provider-name","azure","-openvpn-ca-cert-file=/etc/kubernetes/pki/openvpn/ca.crt","-openvpn-ca-key-file=/etc/kubernetes/pki/openvpn/ca.key","-user-ssh-keys-dir-path=/etc/kubernetes/usersshkeys","--ipam-controller-network","192.168.1.1/24,192.168.1.1,8.8.8.8","-node-labels","{\"my-label\":\"my-value\"}"]}'
         command:
         - /http-prober-bin/http-prober
         env:

--- a/api/pkg/resources/test/fixtures/deployment-azure-1.12.0-usercluster-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-azure-1.12.0-usercluster-controller.yaml
@@ -26,6 +26,7 @@ spec:
         cluster: de-test-01
         internal-admin-kubeconfig-secret-revision: "123456"
         openvpn-ca-secret-revision: "123456"
+        usersshkeys-secret-revision: "123456"
     spec:
       containers:
       - args:
@@ -76,6 +77,9 @@ spec:
         - mountPath: /etc/kubernetes/pki/openvpn
           name: openvpn-ca
           readOnly: true
+        - mountPath: /etc/kubernetes/usersshkeys
+          name: usersshkeys
+          readOnly: true
         - mountPath: /http-prober-bin
           name: http-prober-bin
       imagePullSecrets:
@@ -101,6 +105,9 @@ spec:
       - name: openvpn-ca
         secret:
           secretName: openvpn-ca
+      - name: usersshkeys
+        secret:
+          secretName: usersshkeys
       - emptyDir: {}
         name: http-prober-bin
 status: {}

--- a/api/pkg/resources/test/fixtures/deployment-azure-1.12.0-usercluster-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-azure-1.12.0-usercluster-controller.yaml
@@ -40,7 +40,7 @@ spec:
         - -timeout
         - "1"
         - -command
-        - '{"command":"/usr/local/bin/user-cluster-controller-manager","args":["-kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","-metrics-listen-address","0.0.0.0:8085","-health-listen-address","0.0.0.0:8086","-namespace","$(NAMESPACE)","-ca-cert","/etc/kubernetes/pki/ca/ca.crt","-ca-key","/etc/kubernetes/pki/ca/ca.key","-cluster-url","","-openvpn-server-port","30003","-overwrite-registry","","-openshift=false","-version","1.12.0","-cloud-provider-name","azure","-openvpn-ca-cert-file=/etc/kubernetes/pki/openvpn/ca.crt","-openvpn-ca-key-file=/etc/kubernetes/pki/openvpn/ca.key","--ipam-controller-network","192.168.1.1/24,192.168.1.1,8.8.8.8","-node-labels","{\"my-label\":\"my-value\"}"]}'
+        - '{"command":"/usr/local/bin/user-cluster-controller-manager","args":["-kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","-metrics-listen-address","0.0.0.0:8085","-health-listen-address","0.0.0.0:8086","-namespace","$(NAMESPACE)","-ca-cert","/etc/kubernetes/pki/ca/ca.crt","-ca-key","/etc/kubernetes/pki/ca/ca.key","-cluster-url","","-openvpn-server-port","30003","-overwrite-registry","","-openshift=false","-version","1.12.0","-cloud-provider-name","azure","-openvpn-ca-cert-file=/etc/kubernetes/pki/openvpn/ca.crt","-openvpn-ca-key-file=/etc/kubernetes/pki/openvpn/ca.key","-user-ssh-keys-dir-path=/etc/kubernetes/usersshkeys","--ipam-controller-network","192.168.1.1/24,192.168.1.1,8.8.8.8","-node-labels","{\"my-label\":\"my-value\"}"]}'
         command:
         - /http-prober-bin/http-prober
         env:

--- a/api/pkg/resources/test/fixtures/deployment-azure-1.13.0-usercluster-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-azure-1.13.0-usercluster-controller.yaml
@@ -26,6 +26,7 @@ spec:
         cluster: de-test-01
         internal-admin-kubeconfig-secret-revision: "123456"
         openvpn-ca-secret-revision: "123456"
+        usersshkeys-secret-revision: "123456"
     spec:
       containers:
       - args:
@@ -76,6 +77,9 @@ spec:
         - mountPath: /etc/kubernetes/pki/openvpn
           name: openvpn-ca
           readOnly: true
+        - mountPath: /etc/kubernetes/usersshkeys
+          name: usersshkeys
+          readOnly: true
         - mountPath: /http-prober-bin
           name: http-prober-bin
       imagePullSecrets:
@@ -101,6 +105,9 @@ spec:
       - name: openvpn-ca
         secret:
           secretName: openvpn-ca
+      - name: usersshkeys
+        secret:
+          secretName: usersshkeys
       - emptyDir: {}
         name: http-prober-bin
 status: {}

--- a/api/pkg/resources/test/fixtures/deployment-azure-1.13.0-usercluster-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-azure-1.13.0-usercluster-controller.yaml
@@ -40,7 +40,7 @@ spec:
         - -timeout
         - "1"
         - -command
-        - '{"command":"/usr/local/bin/user-cluster-controller-manager","args":["-kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","-metrics-listen-address","0.0.0.0:8085","-health-listen-address","0.0.0.0:8086","-namespace","$(NAMESPACE)","-ca-cert","/etc/kubernetes/pki/ca/ca.crt","-ca-key","/etc/kubernetes/pki/ca/ca.key","-cluster-url","","-openvpn-server-port","30003","-overwrite-registry","","-openshift=false","-version","1.13.0","-cloud-provider-name","azure","-openvpn-ca-cert-file=/etc/kubernetes/pki/openvpn/ca.crt","-openvpn-ca-key-file=/etc/kubernetes/pki/openvpn/ca.key","--ipam-controller-network","192.168.1.1/24,192.168.1.1,8.8.8.8","-node-labels","{\"my-label\":\"my-value\"}"]}'
+        - '{"command":"/usr/local/bin/user-cluster-controller-manager","args":["-kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","-metrics-listen-address","0.0.0.0:8085","-health-listen-address","0.0.0.0:8086","-namespace","$(NAMESPACE)","-ca-cert","/etc/kubernetes/pki/ca/ca.crt","-ca-key","/etc/kubernetes/pki/ca/ca.key","-cluster-url","","-openvpn-server-port","30003","-overwrite-registry","","-openshift=false","-version","1.13.0","-cloud-provider-name","azure","-openvpn-ca-cert-file=/etc/kubernetes/pki/openvpn/ca.crt","-openvpn-ca-key-file=/etc/kubernetes/pki/openvpn/ca.key","-user-ssh-keys-dir-path=/etc/kubernetes/usersshkeys","--ipam-controller-network","192.168.1.1/24,192.168.1.1,8.8.8.8","-node-labels","{\"my-label\":\"my-value\"}"]}'
         command:
         - /http-prober-bin/http-prober
         env:

--- a/api/pkg/resources/test/fixtures/deployment-bringyourown-1.10.0-usercluster-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-bringyourown-1.10.0-usercluster-controller.yaml
@@ -26,6 +26,7 @@ spec:
         cluster: de-test-01
         internal-admin-kubeconfig-secret-revision: "123456"
         openvpn-ca-secret-revision: "123456"
+        usersshkeys-secret-revision: "123456"
     spec:
       containers:
       - args:
@@ -76,6 +77,9 @@ spec:
         - mountPath: /etc/kubernetes/pki/openvpn
           name: openvpn-ca
           readOnly: true
+        - mountPath: /etc/kubernetes/usersshkeys
+          name: usersshkeys
+          readOnly: true
         - mountPath: /http-prober-bin
           name: http-prober-bin
       imagePullSecrets:
@@ -101,6 +105,9 @@ spec:
       - name: openvpn-ca
         secret:
           secretName: openvpn-ca
+      - name: usersshkeys
+        secret:
+          secretName: usersshkeys
       - emptyDir: {}
         name: http-prober-bin
 status: {}

--- a/api/pkg/resources/test/fixtures/deployment-bringyourown-1.10.0-usercluster-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-bringyourown-1.10.0-usercluster-controller.yaml
@@ -40,7 +40,7 @@ spec:
         - -timeout
         - "1"
         - -command
-        - '{"command":"/usr/local/bin/user-cluster-controller-manager","args":["-kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","-metrics-listen-address","0.0.0.0:8085","-health-listen-address","0.0.0.0:8086","-namespace","$(NAMESPACE)","-ca-cert","/etc/kubernetes/pki/ca/ca.crt","-ca-key","/etc/kubernetes/pki/ca/ca.key","-cluster-url","","-openvpn-server-port","30003","-overwrite-registry","","-openshift=false","-version","1.10.0","-cloud-provider-name","","-openvpn-ca-cert-file=/etc/kubernetes/pki/openvpn/ca.crt","-openvpn-ca-key-file=/etc/kubernetes/pki/openvpn/ca.key","--ipam-controller-network","192.168.1.1/24,192.168.1.1,8.8.8.8","-node-labels","{\"my-label\":\"my-value\"}"]}'
+        - '{"command":"/usr/local/bin/user-cluster-controller-manager","args":["-kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","-metrics-listen-address","0.0.0.0:8085","-health-listen-address","0.0.0.0:8086","-namespace","$(NAMESPACE)","-ca-cert","/etc/kubernetes/pki/ca/ca.crt","-ca-key","/etc/kubernetes/pki/ca/ca.key","-cluster-url","","-openvpn-server-port","30003","-overwrite-registry","","-openshift=false","-version","1.10.0","-cloud-provider-name","","-openvpn-ca-cert-file=/etc/kubernetes/pki/openvpn/ca.crt","-openvpn-ca-key-file=/etc/kubernetes/pki/openvpn/ca.key","-user-ssh-keys-dir-path=/etc/kubernetes/usersshkeys","--ipam-controller-network","192.168.1.1/24,192.168.1.1,8.8.8.8","-node-labels","{\"my-label\":\"my-value\"}"]}'
         command:
         - /http-prober-bin/http-prober
         env:

--- a/api/pkg/resources/test/fixtures/deployment-bringyourown-1.10.6-usercluster-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-bringyourown-1.10.6-usercluster-controller.yaml
@@ -26,6 +26,7 @@ spec:
         cluster: de-test-01
         internal-admin-kubeconfig-secret-revision: "123456"
         openvpn-ca-secret-revision: "123456"
+        usersshkeys-secret-revision: "123456"
     spec:
       containers:
       - args:
@@ -76,6 +77,9 @@ spec:
         - mountPath: /etc/kubernetes/pki/openvpn
           name: openvpn-ca
           readOnly: true
+        - mountPath: /etc/kubernetes/usersshkeys
+          name: usersshkeys
+          readOnly: true
         - mountPath: /http-prober-bin
           name: http-prober-bin
       imagePullSecrets:
@@ -101,6 +105,9 @@ spec:
       - name: openvpn-ca
         secret:
           secretName: openvpn-ca
+      - name: usersshkeys
+        secret:
+          secretName: usersshkeys
       - emptyDir: {}
         name: http-prober-bin
 status: {}

--- a/api/pkg/resources/test/fixtures/deployment-bringyourown-1.10.6-usercluster-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-bringyourown-1.10.6-usercluster-controller.yaml
@@ -40,7 +40,7 @@ spec:
         - -timeout
         - "1"
         - -command
-        - '{"command":"/usr/local/bin/user-cluster-controller-manager","args":["-kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","-metrics-listen-address","0.0.0.0:8085","-health-listen-address","0.0.0.0:8086","-namespace","$(NAMESPACE)","-ca-cert","/etc/kubernetes/pki/ca/ca.crt","-ca-key","/etc/kubernetes/pki/ca/ca.key","-cluster-url","","-openvpn-server-port","30003","-overwrite-registry","","-openshift=false","-version","1.10.6","-cloud-provider-name","","-openvpn-ca-cert-file=/etc/kubernetes/pki/openvpn/ca.crt","-openvpn-ca-key-file=/etc/kubernetes/pki/openvpn/ca.key","--ipam-controller-network","192.168.1.1/24,192.168.1.1,8.8.8.8","-node-labels","{\"my-label\":\"my-value\"}"]}'
+        - '{"command":"/usr/local/bin/user-cluster-controller-manager","args":["-kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","-metrics-listen-address","0.0.0.0:8085","-health-listen-address","0.0.0.0:8086","-namespace","$(NAMESPACE)","-ca-cert","/etc/kubernetes/pki/ca/ca.crt","-ca-key","/etc/kubernetes/pki/ca/ca.key","-cluster-url","","-openvpn-server-port","30003","-overwrite-registry","","-openshift=false","-version","1.10.6","-cloud-provider-name","","-openvpn-ca-cert-file=/etc/kubernetes/pki/openvpn/ca.crt","-openvpn-ca-key-file=/etc/kubernetes/pki/openvpn/ca.key","-user-ssh-keys-dir-path=/etc/kubernetes/usersshkeys","--ipam-controller-network","192.168.1.1/24,192.168.1.1,8.8.8.8","-node-labels","{\"my-label\":\"my-value\"}"]}'
         command:
         - /http-prober-bin/http-prober
         env:

--- a/api/pkg/resources/test/fixtures/deployment-bringyourown-1.11.0-usercluster-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-bringyourown-1.11.0-usercluster-controller.yaml
@@ -40,7 +40,7 @@ spec:
         - -timeout
         - "1"
         - -command
-        - '{"command":"/usr/local/bin/user-cluster-controller-manager","args":["-kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","-metrics-listen-address","0.0.0.0:8085","-health-listen-address","0.0.0.0:8086","-namespace","$(NAMESPACE)","-ca-cert","/etc/kubernetes/pki/ca/ca.crt","-ca-key","/etc/kubernetes/pki/ca/ca.key","-cluster-url","","-openvpn-server-port","30003","-overwrite-registry","","-openshift=false","-version","1.11.0","-cloud-provider-name","","-openvpn-ca-cert-file=/etc/kubernetes/pki/openvpn/ca.crt","-openvpn-ca-key-file=/etc/kubernetes/pki/openvpn/ca.key","--ipam-controller-network","192.168.1.1/24,192.168.1.1,8.8.8.8","-node-labels","{\"my-label\":\"my-value\"}"]}'
+        - '{"command":"/usr/local/bin/user-cluster-controller-manager","args":["-kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","-metrics-listen-address","0.0.0.0:8085","-health-listen-address","0.0.0.0:8086","-namespace","$(NAMESPACE)","-ca-cert","/etc/kubernetes/pki/ca/ca.crt","-ca-key","/etc/kubernetes/pki/ca/ca.key","-cluster-url","","-openvpn-server-port","30003","-overwrite-registry","","-openshift=false","-version","1.11.0","-cloud-provider-name","","-openvpn-ca-cert-file=/etc/kubernetes/pki/openvpn/ca.crt","-openvpn-ca-key-file=/etc/kubernetes/pki/openvpn/ca.key","-user-ssh-keys-dir-path=/etc/kubernetes/usersshkeys","--ipam-controller-network","192.168.1.1/24,192.168.1.1,8.8.8.8","-node-labels","{\"my-label\":\"my-value\"}"]}'
         command:
         - /http-prober-bin/http-prober
         env:

--- a/api/pkg/resources/test/fixtures/deployment-bringyourown-1.11.0-usercluster-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-bringyourown-1.11.0-usercluster-controller.yaml
@@ -26,6 +26,7 @@ spec:
         cluster: de-test-01
         internal-admin-kubeconfig-secret-revision: "123456"
         openvpn-ca-secret-revision: "123456"
+        usersshkeys-secret-revision: "123456"
     spec:
       containers:
       - args:
@@ -76,6 +77,9 @@ spec:
         - mountPath: /etc/kubernetes/pki/openvpn
           name: openvpn-ca
           readOnly: true
+        - mountPath: /etc/kubernetes/usersshkeys
+          name: usersshkeys
+          readOnly: true
         - mountPath: /http-prober-bin
           name: http-prober-bin
       imagePullSecrets:
@@ -101,6 +105,9 @@ spec:
       - name: openvpn-ca
         secret:
           secretName: openvpn-ca
+      - name: usersshkeys
+        secret:
+          secretName: usersshkeys
       - emptyDir: {}
         name: http-prober-bin
 status: {}

--- a/api/pkg/resources/test/fixtures/deployment-bringyourown-1.11.1-usercluster-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-bringyourown-1.11.1-usercluster-controller.yaml
@@ -26,6 +26,7 @@ spec:
         cluster: de-test-01
         internal-admin-kubeconfig-secret-revision: "123456"
         openvpn-ca-secret-revision: "123456"
+        usersshkeys-secret-revision: "123456"
     spec:
       containers:
       - args:
@@ -76,6 +77,9 @@ spec:
         - mountPath: /etc/kubernetes/pki/openvpn
           name: openvpn-ca
           readOnly: true
+        - mountPath: /etc/kubernetes/usersshkeys
+          name: usersshkeys
+          readOnly: true
         - mountPath: /http-prober-bin
           name: http-prober-bin
       imagePullSecrets:
@@ -101,6 +105,9 @@ spec:
       - name: openvpn-ca
         secret:
           secretName: openvpn-ca
+      - name: usersshkeys
+        secret:
+          secretName: usersshkeys
       - emptyDir: {}
         name: http-prober-bin
 status: {}

--- a/api/pkg/resources/test/fixtures/deployment-bringyourown-1.11.1-usercluster-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-bringyourown-1.11.1-usercluster-controller.yaml
@@ -40,7 +40,7 @@ spec:
         - -timeout
         - "1"
         - -command
-        - '{"command":"/usr/local/bin/user-cluster-controller-manager","args":["-kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","-metrics-listen-address","0.0.0.0:8085","-health-listen-address","0.0.0.0:8086","-namespace","$(NAMESPACE)","-ca-cert","/etc/kubernetes/pki/ca/ca.crt","-ca-key","/etc/kubernetes/pki/ca/ca.key","-cluster-url","","-openvpn-server-port","30003","-overwrite-registry","","-openshift=false","-version","1.11.1","-cloud-provider-name","","-openvpn-ca-cert-file=/etc/kubernetes/pki/openvpn/ca.crt","-openvpn-ca-key-file=/etc/kubernetes/pki/openvpn/ca.key","--ipam-controller-network","192.168.1.1/24,192.168.1.1,8.8.8.8","-node-labels","{\"my-label\":\"my-value\"}"]}'
+        - '{"command":"/usr/local/bin/user-cluster-controller-manager","args":["-kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","-metrics-listen-address","0.0.0.0:8085","-health-listen-address","0.0.0.0:8086","-namespace","$(NAMESPACE)","-ca-cert","/etc/kubernetes/pki/ca/ca.crt","-ca-key","/etc/kubernetes/pki/ca/ca.key","-cluster-url","","-openvpn-server-port","30003","-overwrite-registry","","-openshift=false","-version","1.11.1","-cloud-provider-name","","-openvpn-ca-cert-file=/etc/kubernetes/pki/openvpn/ca.crt","-openvpn-ca-key-file=/etc/kubernetes/pki/openvpn/ca.key","-user-ssh-keys-dir-path=/etc/kubernetes/usersshkeys","--ipam-controller-network","192.168.1.1/24,192.168.1.1,8.8.8.8","-node-labels","{\"my-label\":\"my-value\"}"]}'
         command:
         - /http-prober-bin/http-prober
         env:

--- a/api/pkg/resources/test/fixtures/deployment-bringyourown-1.12.0-usercluster-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-bringyourown-1.12.0-usercluster-controller.yaml
@@ -26,6 +26,7 @@ spec:
         cluster: de-test-01
         internal-admin-kubeconfig-secret-revision: "123456"
         openvpn-ca-secret-revision: "123456"
+        usersshkeys-secret-revision: "123456"
     spec:
       containers:
       - args:
@@ -76,6 +77,9 @@ spec:
         - mountPath: /etc/kubernetes/pki/openvpn
           name: openvpn-ca
           readOnly: true
+        - mountPath: /etc/kubernetes/usersshkeys
+          name: usersshkeys
+          readOnly: true
         - mountPath: /http-prober-bin
           name: http-prober-bin
       imagePullSecrets:
@@ -101,6 +105,9 @@ spec:
       - name: openvpn-ca
         secret:
           secretName: openvpn-ca
+      - name: usersshkeys
+        secret:
+          secretName: usersshkeys
       - emptyDir: {}
         name: http-prober-bin
 status: {}

--- a/api/pkg/resources/test/fixtures/deployment-bringyourown-1.12.0-usercluster-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-bringyourown-1.12.0-usercluster-controller.yaml
@@ -40,7 +40,7 @@ spec:
         - -timeout
         - "1"
         - -command
-        - '{"command":"/usr/local/bin/user-cluster-controller-manager","args":["-kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","-metrics-listen-address","0.0.0.0:8085","-health-listen-address","0.0.0.0:8086","-namespace","$(NAMESPACE)","-ca-cert","/etc/kubernetes/pki/ca/ca.crt","-ca-key","/etc/kubernetes/pki/ca/ca.key","-cluster-url","","-openvpn-server-port","30003","-overwrite-registry","","-openshift=false","-version","1.12.0","-cloud-provider-name","","-openvpn-ca-cert-file=/etc/kubernetes/pki/openvpn/ca.crt","-openvpn-ca-key-file=/etc/kubernetes/pki/openvpn/ca.key","--ipam-controller-network","192.168.1.1/24,192.168.1.1,8.8.8.8","-node-labels","{\"my-label\":\"my-value\"}"]}'
+        - '{"command":"/usr/local/bin/user-cluster-controller-manager","args":["-kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","-metrics-listen-address","0.0.0.0:8085","-health-listen-address","0.0.0.0:8086","-namespace","$(NAMESPACE)","-ca-cert","/etc/kubernetes/pki/ca/ca.crt","-ca-key","/etc/kubernetes/pki/ca/ca.key","-cluster-url","","-openvpn-server-port","30003","-overwrite-registry","","-openshift=false","-version","1.12.0","-cloud-provider-name","","-openvpn-ca-cert-file=/etc/kubernetes/pki/openvpn/ca.crt","-openvpn-ca-key-file=/etc/kubernetes/pki/openvpn/ca.key","-user-ssh-keys-dir-path=/etc/kubernetes/usersshkeys","--ipam-controller-network","192.168.1.1/24,192.168.1.1,8.8.8.8","-node-labels","{\"my-label\":\"my-value\"}"]}'
         command:
         - /http-prober-bin/http-prober
         env:

--- a/api/pkg/resources/test/fixtures/deployment-bringyourown-1.13.0-usercluster-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-bringyourown-1.13.0-usercluster-controller.yaml
@@ -26,6 +26,7 @@ spec:
         cluster: de-test-01
         internal-admin-kubeconfig-secret-revision: "123456"
         openvpn-ca-secret-revision: "123456"
+        usersshkeys-secret-revision: "123456"
     spec:
       containers:
       - args:
@@ -76,6 +77,9 @@ spec:
         - mountPath: /etc/kubernetes/pki/openvpn
           name: openvpn-ca
           readOnly: true
+        - mountPath: /etc/kubernetes/usersshkeys
+          name: usersshkeys
+          readOnly: true
         - mountPath: /http-prober-bin
           name: http-prober-bin
       imagePullSecrets:
@@ -101,6 +105,9 @@ spec:
       - name: openvpn-ca
         secret:
           secretName: openvpn-ca
+      - name: usersshkeys
+        secret:
+          secretName: usersshkeys
       - emptyDir: {}
         name: http-prober-bin
 status: {}

--- a/api/pkg/resources/test/fixtures/deployment-bringyourown-1.13.0-usercluster-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-bringyourown-1.13.0-usercluster-controller.yaml
@@ -40,7 +40,7 @@ spec:
         - -timeout
         - "1"
         - -command
-        - '{"command":"/usr/local/bin/user-cluster-controller-manager","args":["-kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","-metrics-listen-address","0.0.0.0:8085","-health-listen-address","0.0.0.0:8086","-namespace","$(NAMESPACE)","-ca-cert","/etc/kubernetes/pki/ca/ca.crt","-ca-key","/etc/kubernetes/pki/ca/ca.key","-cluster-url","","-openvpn-server-port","30003","-overwrite-registry","","-openshift=false","-version","1.13.0","-cloud-provider-name","","-openvpn-ca-cert-file=/etc/kubernetes/pki/openvpn/ca.crt","-openvpn-ca-key-file=/etc/kubernetes/pki/openvpn/ca.key","--ipam-controller-network","192.168.1.1/24,192.168.1.1,8.8.8.8","-node-labels","{\"my-label\":\"my-value\"}"]}'
+        - '{"command":"/usr/local/bin/user-cluster-controller-manager","args":["-kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","-metrics-listen-address","0.0.0.0:8085","-health-listen-address","0.0.0.0:8086","-namespace","$(NAMESPACE)","-ca-cert","/etc/kubernetes/pki/ca/ca.crt","-ca-key","/etc/kubernetes/pki/ca/ca.key","-cluster-url","","-openvpn-server-port","30003","-overwrite-registry","","-openshift=false","-version","1.13.0","-cloud-provider-name","","-openvpn-ca-cert-file=/etc/kubernetes/pki/openvpn/ca.crt","-openvpn-ca-key-file=/etc/kubernetes/pki/openvpn/ca.key","-user-ssh-keys-dir-path=/etc/kubernetes/usersshkeys","--ipam-controller-network","192.168.1.1/24,192.168.1.1,8.8.8.8","-node-labels","{\"my-label\":\"my-value\"}"]}'
         command:
         - /http-prober-bin/http-prober
         env:

--- a/api/pkg/resources/test/fixtures/deployment-digitalocean-1.10.0-usercluster-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-digitalocean-1.10.0-usercluster-controller.yaml
@@ -26,6 +26,7 @@ spec:
         cluster: de-test-01
         internal-admin-kubeconfig-secret-revision: "123456"
         openvpn-ca-secret-revision: "123456"
+        usersshkeys-secret-revision: "123456"
     spec:
       containers:
       - args:
@@ -76,6 +77,9 @@ spec:
         - mountPath: /etc/kubernetes/pki/openvpn
           name: openvpn-ca
           readOnly: true
+        - mountPath: /etc/kubernetes/usersshkeys
+          name: usersshkeys
+          readOnly: true
         - mountPath: /http-prober-bin
           name: http-prober-bin
       imagePullSecrets:
@@ -101,6 +105,9 @@ spec:
       - name: openvpn-ca
         secret:
           secretName: openvpn-ca
+      - name: usersshkeys
+        secret:
+          secretName: usersshkeys
       - emptyDir: {}
         name: http-prober-bin
 status: {}

--- a/api/pkg/resources/test/fixtures/deployment-digitalocean-1.10.0-usercluster-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-digitalocean-1.10.0-usercluster-controller.yaml
@@ -40,7 +40,7 @@ spec:
         - -timeout
         - "1"
         - -command
-        - '{"command":"/usr/local/bin/user-cluster-controller-manager","args":["-kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","-metrics-listen-address","0.0.0.0:8085","-health-listen-address","0.0.0.0:8086","-namespace","$(NAMESPACE)","-ca-cert","/etc/kubernetes/pki/ca/ca.crt","-ca-key","/etc/kubernetes/pki/ca/ca.key","-cluster-url","","-openvpn-server-port","30003","-overwrite-registry","","-openshift=false","-version","1.10.0","-cloud-provider-name","","-openvpn-ca-cert-file=/etc/kubernetes/pki/openvpn/ca.crt","-openvpn-ca-key-file=/etc/kubernetes/pki/openvpn/ca.key","--ipam-controller-network","192.168.1.1/24,192.168.1.1,8.8.8.8","-node-labels","{\"my-label\":\"my-value\"}"]}'
+        - '{"command":"/usr/local/bin/user-cluster-controller-manager","args":["-kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","-metrics-listen-address","0.0.0.0:8085","-health-listen-address","0.0.0.0:8086","-namespace","$(NAMESPACE)","-ca-cert","/etc/kubernetes/pki/ca/ca.crt","-ca-key","/etc/kubernetes/pki/ca/ca.key","-cluster-url","","-openvpn-server-port","30003","-overwrite-registry","","-openshift=false","-version","1.10.0","-cloud-provider-name","","-openvpn-ca-cert-file=/etc/kubernetes/pki/openvpn/ca.crt","-openvpn-ca-key-file=/etc/kubernetes/pki/openvpn/ca.key","-user-ssh-keys-dir-path=/etc/kubernetes/usersshkeys","--ipam-controller-network","192.168.1.1/24,192.168.1.1,8.8.8.8","-node-labels","{\"my-label\":\"my-value\"}"]}'
         command:
         - /http-prober-bin/http-prober
         env:

--- a/api/pkg/resources/test/fixtures/deployment-digitalocean-1.10.6-usercluster-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-digitalocean-1.10.6-usercluster-controller.yaml
@@ -26,6 +26,7 @@ spec:
         cluster: de-test-01
         internal-admin-kubeconfig-secret-revision: "123456"
         openvpn-ca-secret-revision: "123456"
+        usersshkeys-secret-revision: "123456"
     spec:
       containers:
       - args:
@@ -76,6 +77,9 @@ spec:
         - mountPath: /etc/kubernetes/pki/openvpn
           name: openvpn-ca
           readOnly: true
+        - mountPath: /etc/kubernetes/usersshkeys
+          name: usersshkeys
+          readOnly: true
         - mountPath: /http-prober-bin
           name: http-prober-bin
       imagePullSecrets:
@@ -101,6 +105,9 @@ spec:
       - name: openvpn-ca
         secret:
           secretName: openvpn-ca
+      - name: usersshkeys
+        secret:
+          secretName: usersshkeys
       - emptyDir: {}
         name: http-prober-bin
 status: {}

--- a/api/pkg/resources/test/fixtures/deployment-digitalocean-1.10.6-usercluster-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-digitalocean-1.10.6-usercluster-controller.yaml
@@ -40,7 +40,7 @@ spec:
         - -timeout
         - "1"
         - -command
-        - '{"command":"/usr/local/bin/user-cluster-controller-manager","args":["-kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","-metrics-listen-address","0.0.0.0:8085","-health-listen-address","0.0.0.0:8086","-namespace","$(NAMESPACE)","-ca-cert","/etc/kubernetes/pki/ca/ca.crt","-ca-key","/etc/kubernetes/pki/ca/ca.key","-cluster-url","","-openvpn-server-port","30003","-overwrite-registry","","-openshift=false","-version","1.10.6","-cloud-provider-name","","-openvpn-ca-cert-file=/etc/kubernetes/pki/openvpn/ca.crt","-openvpn-ca-key-file=/etc/kubernetes/pki/openvpn/ca.key","--ipam-controller-network","192.168.1.1/24,192.168.1.1,8.8.8.8","-node-labels","{\"my-label\":\"my-value\"}"]}'
+        - '{"command":"/usr/local/bin/user-cluster-controller-manager","args":["-kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","-metrics-listen-address","0.0.0.0:8085","-health-listen-address","0.0.0.0:8086","-namespace","$(NAMESPACE)","-ca-cert","/etc/kubernetes/pki/ca/ca.crt","-ca-key","/etc/kubernetes/pki/ca/ca.key","-cluster-url","","-openvpn-server-port","30003","-overwrite-registry","","-openshift=false","-version","1.10.6","-cloud-provider-name","","-openvpn-ca-cert-file=/etc/kubernetes/pki/openvpn/ca.crt","-openvpn-ca-key-file=/etc/kubernetes/pki/openvpn/ca.key","-user-ssh-keys-dir-path=/etc/kubernetes/usersshkeys","--ipam-controller-network","192.168.1.1/24,192.168.1.1,8.8.8.8","-node-labels","{\"my-label\":\"my-value\"}"]}'
         command:
         - /http-prober-bin/http-prober
         env:

--- a/api/pkg/resources/test/fixtures/deployment-digitalocean-1.11.0-usercluster-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-digitalocean-1.11.0-usercluster-controller.yaml
@@ -40,7 +40,7 @@ spec:
         - -timeout
         - "1"
         - -command
-        - '{"command":"/usr/local/bin/user-cluster-controller-manager","args":["-kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","-metrics-listen-address","0.0.0.0:8085","-health-listen-address","0.0.0.0:8086","-namespace","$(NAMESPACE)","-ca-cert","/etc/kubernetes/pki/ca/ca.crt","-ca-key","/etc/kubernetes/pki/ca/ca.key","-cluster-url","","-openvpn-server-port","30003","-overwrite-registry","","-openshift=false","-version","1.11.0","-cloud-provider-name","","-openvpn-ca-cert-file=/etc/kubernetes/pki/openvpn/ca.crt","-openvpn-ca-key-file=/etc/kubernetes/pki/openvpn/ca.key","--ipam-controller-network","192.168.1.1/24,192.168.1.1,8.8.8.8","-node-labels","{\"my-label\":\"my-value\"}"]}'
+        - '{"command":"/usr/local/bin/user-cluster-controller-manager","args":["-kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","-metrics-listen-address","0.0.0.0:8085","-health-listen-address","0.0.0.0:8086","-namespace","$(NAMESPACE)","-ca-cert","/etc/kubernetes/pki/ca/ca.crt","-ca-key","/etc/kubernetes/pki/ca/ca.key","-cluster-url","","-openvpn-server-port","30003","-overwrite-registry","","-openshift=false","-version","1.11.0","-cloud-provider-name","","-openvpn-ca-cert-file=/etc/kubernetes/pki/openvpn/ca.crt","-openvpn-ca-key-file=/etc/kubernetes/pki/openvpn/ca.key","-user-ssh-keys-dir-path=/etc/kubernetes/usersshkeys","--ipam-controller-network","192.168.1.1/24,192.168.1.1,8.8.8.8","-node-labels","{\"my-label\":\"my-value\"}"]}'
         command:
         - /http-prober-bin/http-prober
         env:

--- a/api/pkg/resources/test/fixtures/deployment-digitalocean-1.11.0-usercluster-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-digitalocean-1.11.0-usercluster-controller.yaml
@@ -26,6 +26,7 @@ spec:
         cluster: de-test-01
         internal-admin-kubeconfig-secret-revision: "123456"
         openvpn-ca-secret-revision: "123456"
+        usersshkeys-secret-revision: "123456"
     spec:
       containers:
       - args:
@@ -76,6 +77,9 @@ spec:
         - mountPath: /etc/kubernetes/pki/openvpn
           name: openvpn-ca
           readOnly: true
+        - mountPath: /etc/kubernetes/usersshkeys
+          name: usersshkeys
+          readOnly: true
         - mountPath: /http-prober-bin
           name: http-prober-bin
       imagePullSecrets:
@@ -101,6 +105,9 @@ spec:
       - name: openvpn-ca
         secret:
           secretName: openvpn-ca
+      - name: usersshkeys
+        secret:
+          secretName: usersshkeys
       - emptyDir: {}
         name: http-prober-bin
 status: {}

--- a/api/pkg/resources/test/fixtures/deployment-digitalocean-1.11.1-usercluster-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-digitalocean-1.11.1-usercluster-controller.yaml
@@ -26,6 +26,7 @@ spec:
         cluster: de-test-01
         internal-admin-kubeconfig-secret-revision: "123456"
         openvpn-ca-secret-revision: "123456"
+        usersshkeys-secret-revision: "123456"
     spec:
       containers:
       - args:
@@ -76,6 +77,9 @@ spec:
         - mountPath: /etc/kubernetes/pki/openvpn
           name: openvpn-ca
           readOnly: true
+        - mountPath: /etc/kubernetes/usersshkeys
+          name: usersshkeys
+          readOnly: true
         - mountPath: /http-prober-bin
           name: http-prober-bin
       imagePullSecrets:
@@ -101,6 +105,9 @@ spec:
       - name: openvpn-ca
         secret:
           secretName: openvpn-ca
+      - name: usersshkeys
+        secret:
+          secretName: usersshkeys
       - emptyDir: {}
         name: http-prober-bin
 status: {}

--- a/api/pkg/resources/test/fixtures/deployment-digitalocean-1.11.1-usercluster-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-digitalocean-1.11.1-usercluster-controller.yaml
@@ -40,7 +40,7 @@ spec:
         - -timeout
         - "1"
         - -command
-        - '{"command":"/usr/local/bin/user-cluster-controller-manager","args":["-kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","-metrics-listen-address","0.0.0.0:8085","-health-listen-address","0.0.0.0:8086","-namespace","$(NAMESPACE)","-ca-cert","/etc/kubernetes/pki/ca/ca.crt","-ca-key","/etc/kubernetes/pki/ca/ca.key","-cluster-url","","-openvpn-server-port","30003","-overwrite-registry","","-openshift=false","-version","1.11.1","-cloud-provider-name","","-openvpn-ca-cert-file=/etc/kubernetes/pki/openvpn/ca.crt","-openvpn-ca-key-file=/etc/kubernetes/pki/openvpn/ca.key","--ipam-controller-network","192.168.1.1/24,192.168.1.1,8.8.8.8","-node-labels","{\"my-label\":\"my-value\"}"]}'
+        - '{"command":"/usr/local/bin/user-cluster-controller-manager","args":["-kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","-metrics-listen-address","0.0.0.0:8085","-health-listen-address","0.0.0.0:8086","-namespace","$(NAMESPACE)","-ca-cert","/etc/kubernetes/pki/ca/ca.crt","-ca-key","/etc/kubernetes/pki/ca/ca.key","-cluster-url","","-openvpn-server-port","30003","-overwrite-registry","","-openshift=false","-version","1.11.1","-cloud-provider-name","","-openvpn-ca-cert-file=/etc/kubernetes/pki/openvpn/ca.crt","-openvpn-ca-key-file=/etc/kubernetes/pki/openvpn/ca.key","-user-ssh-keys-dir-path=/etc/kubernetes/usersshkeys","--ipam-controller-network","192.168.1.1/24,192.168.1.1,8.8.8.8","-node-labels","{\"my-label\":\"my-value\"}"]}'
         command:
         - /http-prober-bin/http-prober
         env:

--- a/api/pkg/resources/test/fixtures/deployment-digitalocean-1.12.0-usercluster-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-digitalocean-1.12.0-usercluster-controller.yaml
@@ -26,6 +26,7 @@ spec:
         cluster: de-test-01
         internal-admin-kubeconfig-secret-revision: "123456"
         openvpn-ca-secret-revision: "123456"
+        usersshkeys-secret-revision: "123456"
     spec:
       containers:
       - args:
@@ -76,6 +77,9 @@ spec:
         - mountPath: /etc/kubernetes/pki/openvpn
           name: openvpn-ca
           readOnly: true
+        - mountPath: /etc/kubernetes/usersshkeys
+          name: usersshkeys
+          readOnly: true
         - mountPath: /http-prober-bin
           name: http-prober-bin
       imagePullSecrets:
@@ -101,6 +105,9 @@ spec:
       - name: openvpn-ca
         secret:
           secretName: openvpn-ca
+      - name: usersshkeys
+        secret:
+          secretName: usersshkeys
       - emptyDir: {}
         name: http-prober-bin
 status: {}

--- a/api/pkg/resources/test/fixtures/deployment-digitalocean-1.12.0-usercluster-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-digitalocean-1.12.0-usercluster-controller.yaml
@@ -40,7 +40,7 @@ spec:
         - -timeout
         - "1"
         - -command
-        - '{"command":"/usr/local/bin/user-cluster-controller-manager","args":["-kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","-metrics-listen-address","0.0.0.0:8085","-health-listen-address","0.0.0.0:8086","-namespace","$(NAMESPACE)","-ca-cert","/etc/kubernetes/pki/ca/ca.crt","-ca-key","/etc/kubernetes/pki/ca/ca.key","-cluster-url","","-openvpn-server-port","30003","-overwrite-registry","","-openshift=false","-version","1.12.0","-cloud-provider-name","","-openvpn-ca-cert-file=/etc/kubernetes/pki/openvpn/ca.crt","-openvpn-ca-key-file=/etc/kubernetes/pki/openvpn/ca.key","--ipam-controller-network","192.168.1.1/24,192.168.1.1,8.8.8.8","-node-labels","{\"my-label\":\"my-value\"}"]}'
+        - '{"command":"/usr/local/bin/user-cluster-controller-manager","args":["-kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","-metrics-listen-address","0.0.0.0:8085","-health-listen-address","0.0.0.0:8086","-namespace","$(NAMESPACE)","-ca-cert","/etc/kubernetes/pki/ca/ca.crt","-ca-key","/etc/kubernetes/pki/ca/ca.key","-cluster-url","","-openvpn-server-port","30003","-overwrite-registry","","-openshift=false","-version","1.12.0","-cloud-provider-name","","-openvpn-ca-cert-file=/etc/kubernetes/pki/openvpn/ca.crt","-openvpn-ca-key-file=/etc/kubernetes/pki/openvpn/ca.key","-user-ssh-keys-dir-path=/etc/kubernetes/usersshkeys","--ipam-controller-network","192.168.1.1/24,192.168.1.1,8.8.8.8","-node-labels","{\"my-label\":\"my-value\"}"]}'
         command:
         - /http-prober-bin/http-prober
         env:

--- a/api/pkg/resources/test/fixtures/deployment-digitalocean-1.13.0-usercluster-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-digitalocean-1.13.0-usercluster-controller.yaml
@@ -26,6 +26,7 @@ spec:
         cluster: de-test-01
         internal-admin-kubeconfig-secret-revision: "123456"
         openvpn-ca-secret-revision: "123456"
+        usersshkeys-secret-revision: "123456"
     spec:
       containers:
       - args:
@@ -76,6 +77,9 @@ spec:
         - mountPath: /etc/kubernetes/pki/openvpn
           name: openvpn-ca
           readOnly: true
+        - mountPath: /etc/kubernetes/usersshkeys
+          name: usersshkeys
+          readOnly: true
         - mountPath: /http-prober-bin
           name: http-prober-bin
       imagePullSecrets:
@@ -101,6 +105,9 @@ spec:
       - name: openvpn-ca
         secret:
           secretName: openvpn-ca
+      - name: usersshkeys
+        secret:
+          secretName: usersshkeys
       - emptyDir: {}
         name: http-prober-bin
 status: {}

--- a/api/pkg/resources/test/fixtures/deployment-digitalocean-1.13.0-usercluster-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-digitalocean-1.13.0-usercluster-controller.yaml
@@ -40,7 +40,7 @@ spec:
         - -timeout
         - "1"
         - -command
-        - '{"command":"/usr/local/bin/user-cluster-controller-manager","args":["-kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","-metrics-listen-address","0.0.0.0:8085","-health-listen-address","0.0.0.0:8086","-namespace","$(NAMESPACE)","-ca-cert","/etc/kubernetes/pki/ca/ca.crt","-ca-key","/etc/kubernetes/pki/ca/ca.key","-cluster-url","","-openvpn-server-port","30003","-overwrite-registry","","-openshift=false","-version","1.13.0","-cloud-provider-name","","-openvpn-ca-cert-file=/etc/kubernetes/pki/openvpn/ca.crt","-openvpn-ca-key-file=/etc/kubernetes/pki/openvpn/ca.key","--ipam-controller-network","192.168.1.1/24,192.168.1.1,8.8.8.8","-node-labels","{\"my-label\":\"my-value\"}"]}'
+        - '{"command":"/usr/local/bin/user-cluster-controller-manager","args":["-kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","-metrics-listen-address","0.0.0.0:8085","-health-listen-address","0.0.0.0:8086","-namespace","$(NAMESPACE)","-ca-cert","/etc/kubernetes/pki/ca/ca.crt","-ca-key","/etc/kubernetes/pki/ca/ca.key","-cluster-url","","-openvpn-server-port","30003","-overwrite-registry","","-openshift=false","-version","1.13.0","-cloud-provider-name","","-openvpn-ca-cert-file=/etc/kubernetes/pki/openvpn/ca.crt","-openvpn-ca-key-file=/etc/kubernetes/pki/openvpn/ca.key","-user-ssh-keys-dir-path=/etc/kubernetes/usersshkeys","--ipam-controller-network","192.168.1.1/24,192.168.1.1,8.8.8.8","-node-labels","{\"my-label\":\"my-value\"}"]}'
         command:
         - /http-prober-bin/http-prober
         env:

--- a/api/pkg/resources/test/fixtures/deployment-openstack-1.10.0-usercluster-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-openstack-1.10.0-usercluster-controller.yaml
@@ -26,6 +26,7 @@ spec:
         cluster: de-test-01
         internal-admin-kubeconfig-secret-revision: "123456"
         openvpn-ca-secret-revision: "123456"
+        usersshkeys-secret-revision: "123456"
     spec:
       containers:
       - args:
@@ -76,6 +77,9 @@ spec:
         - mountPath: /etc/kubernetes/pki/openvpn
           name: openvpn-ca
           readOnly: true
+        - mountPath: /etc/kubernetes/usersshkeys
+          name: usersshkeys
+          readOnly: true
         - mountPath: /http-prober-bin
           name: http-prober-bin
       imagePullSecrets:
@@ -101,6 +105,9 @@ spec:
       - name: openvpn-ca
         secret:
           secretName: openvpn-ca
+      - name: usersshkeys
+        secret:
+          secretName: usersshkeys
       - emptyDir: {}
         name: http-prober-bin
 status: {}

--- a/api/pkg/resources/test/fixtures/deployment-openstack-1.10.0-usercluster-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-openstack-1.10.0-usercluster-controller.yaml
@@ -40,7 +40,7 @@ spec:
         - -timeout
         - "1"
         - -command
-        - '{"command":"/usr/local/bin/user-cluster-controller-manager","args":["-kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","-metrics-listen-address","0.0.0.0:8085","-health-listen-address","0.0.0.0:8086","-namespace","$(NAMESPACE)","-ca-cert","/etc/kubernetes/pki/ca/ca.crt","-ca-key","/etc/kubernetes/pki/ca/ca.key","-cluster-url","","-openvpn-server-port","30003","-overwrite-registry","","-openshift=false","-version","1.10.0","-cloud-provider-name","openstack","-openvpn-ca-cert-file=/etc/kubernetes/pki/openvpn/ca.crt","-openvpn-ca-key-file=/etc/kubernetes/pki/openvpn/ca.key","--ipam-controller-network","192.168.1.1/24,192.168.1.1,8.8.8.8","-node-labels","{\"my-label\":\"my-value\"}"]}'
+        - '{"command":"/usr/local/bin/user-cluster-controller-manager","args":["-kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","-metrics-listen-address","0.0.0.0:8085","-health-listen-address","0.0.0.0:8086","-namespace","$(NAMESPACE)","-ca-cert","/etc/kubernetes/pki/ca/ca.crt","-ca-key","/etc/kubernetes/pki/ca/ca.key","-cluster-url","","-openvpn-server-port","30003","-overwrite-registry","","-openshift=false","-version","1.10.0","-cloud-provider-name","openstack","-openvpn-ca-cert-file=/etc/kubernetes/pki/openvpn/ca.crt","-openvpn-ca-key-file=/etc/kubernetes/pki/openvpn/ca.key","-user-ssh-keys-dir-path=/etc/kubernetes/usersshkeys","--ipam-controller-network","192.168.1.1/24,192.168.1.1,8.8.8.8","-node-labels","{\"my-label\":\"my-value\"}"]}'
         command:
         - /http-prober-bin/http-prober
         env:

--- a/api/pkg/resources/test/fixtures/deployment-openstack-1.10.6-usercluster-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-openstack-1.10.6-usercluster-controller.yaml
@@ -26,6 +26,7 @@ spec:
         cluster: de-test-01
         internal-admin-kubeconfig-secret-revision: "123456"
         openvpn-ca-secret-revision: "123456"
+        usersshkeys-secret-revision: "123456"
     spec:
       containers:
       - args:
@@ -76,6 +77,9 @@ spec:
         - mountPath: /etc/kubernetes/pki/openvpn
           name: openvpn-ca
           readOnly: true
+        - mountPath: /etc/kubernetes/usersshkeys
+          name: usersshkeys
+          readOnly: true
         - mountPath: /http-prober-bin
           name: http-prober-bin
       imagePullSecrets:
@@ -101,6 +105,9 @@ spec:
       - name: openvpn-ca
         secret:
           secretName: openvpn-ca
+      - name: usersshkeys
+        secret:
+          secretName: usersshkeys
       - emptyDir: {}
         name: http-prober-bin
 status: {}

--- a/api/pkg/resources/test/fixtures/deployment-openstack-1.10.6-usercluster-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-openstack-1.10.6-usercluster-controller.yaml
@@ -40,7 +40,7 @@ spec:
         - -timeout
         - "1"
         - -command
-        - '{"command":"/usr/local/bin/user-cluster-controller-manager","args":["-kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","-metrics-listen-address","0.0.0.0:8085","-health-listen-address","0.0.0.0:8086","-namespace","$(NAMESPACE)","-ca-cert","/etc/kubernetes/pki/ca/ca.crt","-ca-key","/etc/kubernetes/pki/ca/ca.key","-cluster-url","","-openvpn-server-port","30003","-overwrite-registry","","-openshift=false","-version","1.10.6","-cloud-provider-name","openstack","-openvpn-ca-cert-file=/etc/kubernetes/pki/openvpn/ca.crt","-openvpn-ca-key-file=/etc/kubernetes/pki/openvpn/ca.key","--ipam-controller-network","192.168.1.1/24,192.168.1.1,8.8.8.8","-node-labels","{\"my-label\":\"my-value\"}"]}'
+        - '{"command":"/usr/local/bin/user-cluster-controller-manager","args":["-kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","-metrics-listen-address","0.0.0.0:8085","-health-listen-address","0.0.0.0:8086","-namespace","$(NAMESPACE)","-ca-cert","/etc/kubernetes/pki/ca/ca.crt","-ca-key","/etc/kubernetes/pki/ca/ca.key","-cluster-url","","-openvpn-server-port","30003","-overwrite-registry","","-openshift=false","-version","1.10.6","-cloud-provider-name","openstack","-openvpn-ca-cert-file=/etc/kubernetes/pki/openvpn/ca.crt","-openvpn-ca-key-file=/etc/kubernetes/pki/openvpn/ca.key","-user-ssh-keys-dir-path=/etc/kubernetes/usersshkeys","--ipam-controller-network","192.168.1.1/24,192.168.1.1,8.8.8.8","-node-labels","{\"my-label\":\"my-value\"}"]}'
         command:
         - /http-prober-bin/http-prober
         env:

--- a/api/pkg/resources/test/fixtures/deployment-openstack-1.11.0-usercluster-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-openstack-1.11.0-usercluster-controller.yaml
@@ -26,6 +26,7 @@ spec:
         cluster: de-test-01
         internal-admin-kubeconfig-secret-revision: "123456"
         openvpn-ca-secret-revision: "123456"
+        usersshkeys-secret-revision: "123456"
     spec:
       containers:
       - args:
@@ -76,6 +77,9 @@ spec:
         - mountPath: /etc/kubernetes/pki/openvpn
           name: openvpn-ca
           readOnly: true
+        - mountPath: /etc/kubernetes/usersshkeys
+          name: usersshkeys
+          readOnly: true
         - mountPath: /http-prober-bin
           name: http-prober-bin
       imagePullSecrets:
@@ -101,6 +105,9 @@ spec:
       - name: openvpn-ca
         secret:
           secretName: openvpn-ca
+      - name: usersshkeys
+        secret:
+          secretName: usersshkeys
       - emptyDir: {}
         name: http-prober-bin
 status: {}

--- a/api/pkg/resources/test/fixtures/deployment-openstack-1.11.0-usercluster-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-openstack-1.11.0-usercluster-controller.yaml
@@ -40,7 +40,7 @@ spec:
         - -timeout
         - "1"
         - -command
-        - '{"command":"/usr/local/bin/user-cluster-controller-manager","args":["-kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","-metrics-listen-address","0.0.0.0:8085","-health-listen-address","0.0.0.0:8086","-namespace","$(NAMESPACE)","-ca-cert","/etc/kubernetes/pki/ca/ca.crt","-ca-key","/etc/kubernetes/pki/ca/ca.key","-cluster-url","","-openvpn-server-port","30003","-overwrite-registry","","-openshift=false","-version","1.11.0","-cloud-provider-name","openstack","-openvpn-ca-cert-file=/etc/kubernetes/pki/openvpn/ca.crt","-openvpn-ca-key-file=/etc/kubernetes/pki/openvpn/ca.key","--ipam-controller-network","192.168.1.1/24,192.168.1.1,8.8.8.8","-node-labels","{\"my-label\":\"my-value\"}"]}'
+        - '{"command":"/usr/local/bin/user-cluster-controller-manager","args":["-kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","-metrics-listen-address","0.0.0.0:8085","-health-listen-address","0.0.0.0:8086","-namespace","$(NAMESPACE)","-ca-cert","/etc/kubernetes/pki/ca/ca.crt","-ca-key","/etc/kubernetes/pki/ca/ca.key","-cluster-url","","-openvpn-server-port","30003","-overwrite-registry","","-openshift=false","-version","1.11.0","-cloud-provider-name","openstack","-openvpn-ca-cert-file=/etc/kubernetes/pki/openvpn/ca.crt","-openvpn-ca-key-file=/etc/kubernetes/pki/openvpn/ca.key","-user-ssh-keys-dir-path=/etc/kubernetes/usersshkeys","--ipam-controller-network","192.168.1.1/24,192.168.1.1,8.8.8.8","-node-labels","{\"my-label\":\"my-value\"}"]}'
         command:
         - /http-prober-bin/http-prober
         env:

--- a/api/pkg/resources/test/fixtures/deployment-openstack-1.11.1-usercluster-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-openstack-1.11.1-usercluster-controller.yaml
@@ -26,6 +26,7 @@ spec:
         cluster: de-test-01
         internal-admin-kubeconfig-secret-revision: "123456"
         openvpn-ca-secret-revision: "123456"
+        usersshkeys-secret-revision: "123456"
     spec:
       containers:
       - args:
@@ -76,6 +77,9 @@ spec:
         - mountPath: /etc/kubernetes/pki/openvpn
           name: openvpn-ca
           readOnly: true
+        - mountPath: /etc/kubernetes/usersshkeys
+          name: usersshkeys
+          readOnly: true
         - mountPath: /http-prober-bin
           name: http-prober-bin
       imagePullSecrets:
@@ -101,6 +105,9 @@ spec:
       - name: openvpn-ca
         secret:
           secretName: openvpn-ca
+      - name: usersshkeys
+        secret:
+          secretName: usersshkeys
       - emptyDir: {}
         name: http-prober-bin
 status: {}

--- a/api/pkg/resources/test/fixtures/deployment-openstack-1.11.1-usercluster-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-openstack-1.11.1-usercluster-controller.yaml
@@ -40,7 +40,7 @@ spec:
         - -timeout
         - "1"
         - -command
-        - '{"command":"/usr/local/bin/user-cluster-controller-manager","args":["-kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","-metrics-listen-address","0.0.0.0:8085","-health-listen-address","0.0.0.0:8086","-namespace","$(NAMESPACE)","-ca-cert","/etc/kubernetes/pki/ca/ca.crt","-ca-key","/etc/kubernetes/pki/ca/ca.key","-cluster-url","","-openvpn-server-port","30003","-overwrite-registry","","-openshift=false","-version","1.11.1","-cloud-provider-name","openstack","-openvpn-ca-cert-file=/etc/kubernetes/pki/openvpn/ca.crt","-openvpn-ca-key-file=/etc/kubernetes/pki/openvpn/ca.key","--ipam-controller-network","192.168.1.1/24,192.168.1.1,8.8.8.8","-node-labels","{\"my-label\":\"my-value\"}"]}'
+        - '{"command":"/usr/local/bin/user-cluster-controller-manager","args":["-kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","-metrics-listen-address","0.0.0.0:8085","-health-listen-address","0.0.0.0:8086","-namespace","$(NAMESPACE)","-ca-cert","/etc/kubernetes/pki/ca/ca.crt","-ca-key","/etc/kubernetes/pki/ca/ca.key","-cluster-url","","-openvpn-server-port","30003","-overwrite-registry","","-openshift=false","-version","1.11.1","-cloud-provider-name","openstack","-openvpn-ca-cert-file=/etc/kubernetes/pki/openvpn/ca.crt","-openvpn-ca-key-file=/etc/kubernetes/pki/openvpn/ca.key","-user-ssh-keys-dir-path=/etc/kubernetes/usersshkeys","--ipam-controller-network","192.168.1.1/24,192.168.1.1,8.8.8.8","-node-labels","{\"my-label\":\"my-value\"}"]}'
         command:
         - /http-prober-bin/http-prober
         env:

--- a/api/pkg/resources/test/fixtures/deployment-openstack-1.12.0-usercluster-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-openstack-1.12.0-usercluster-controller.yaml
@@ -40,7 +40,7 @@ spec:
         - -timeout
         - "1"
         - -command
-        - '{"command":"/usr/local/bin/user-cluster-controller-manager","args":["-kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","-metrics-listen-address","0.0.0.0:8085","-health-listen-address","0.0.0.0:8086","-namespace","$(NAMESPACE)","-ca-cert","/etc/kubernetes/pki/ca/ca.crt","-ca-key","/etc/kubernetes/pki/ca/ca.key","-cluster-url","","-openvpn-server-port","30003","-overwrite-registry","","-openshift=false","-version","1.12.0","-cloud-provider-name","openstack","-openvpn-ca-cert-file=/etc/kubernetes/pki/openvpn/ca.crt","-openvpn-ca-key-file=/etc/kubernetes/pki/openvpn/ca.key","--ipam-controller-network","192.168.1.1/24,192.168.1.1,8.8.8.8","-node-labels","{\"my-label\":\"my-value\"}"]}'
+        - '{"command":"/usr/local/bin/user-cluster-controller-manager","args":["-kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","-metrics-listen-address","0.0.0.0:8085","-health-listen-address","0.0.0.0:8086","-namespace","$(NAMESPACE)","-ca-cert","/etc/kubernetes/pki/ca/ca.crt","-ca-key","/etc/kubernetes/pki/ca/ca.key","-cluster-url","","-openvpn-server-port","30003","-overwrite-registry","","-openshift=false","-version","1.12.0","-cloud-provider-name","openstack","-openvpn-ca-cert-file=/etc/kubernetes/pki/openvpn/ca.crt","-openvpn-ca-key-file=/etc/kubernetes/pki/openvpn/ca.key","-user-ssh-keys-dir-path=/etc/kubernetes/usersshkeys","--ipam-controller-network","192.168.1.1/24,192.168.1.1,8.8.8.8","-node-labels","{\"my-label\":\"my-value\"}"]}'
         command:
         - /http-prober-bin/http-prober
         env:

--- a/api/pkg/resources/test/fixtures/deployment-openstack-1.12.0-usercluster-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-openstack-1.12.0-usercluster-controller.yaml
@@ -26,6 +26,7 @@ spec:
         cluster: de-test-01
         internal-admin-kubeconfig-secret-revision: "123456"
         openvpn-ca-secret-revision: "123456"
+        usersshkeys-secret-revision: "123456"
     spec:
       containers:
       - args:
@@ -76,6 +77,9 @@ spec:
         - mountPath: /etc/kubernetes/pki/openvpn
           name: openvpn-ca
           readOnly: true
+        - mountPath: /etc/kubernetes/usersshkeys
+          name: usersshkeys
+          readOnly: true
         - mountPath: /http-prober-bin
           name: http-prober-bin
       imagePullSecrets:
@@ -101,6 +105,9 @@ spec:
       - name: openvpn-ca
         secret:
           secretName: openvpn-ca
+      - name: usersshkeys
+        secret:
+          secretName: usersshkeys
       - emptyDir: {}
         name: http-prober-bin
 status: {}

--- a/api/pkg/resources/test/fixtures/deployment-openstack-1.13.0-usercluster-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-openstack-1.13.0-usercluster-controller.yaml
@@ -26,6 +26,7 @@ spec:
         cluster: de-test-01
         internal-admin-kubeconfig-secret-revision: "123456"
         openvpn-ca-secret-revision: "123456"
+        usersshkeys-secret-revision: "123456"
     spec:
       containers:
       - args:
@@ -76,6 +77,9 @@ spec:
         - mountPath: /etc/kubernetes/pki/openvpn
           name: openvpn-ca
           readOnly: true
+        - mountPath: /etc/kubernetes/usersshkeys
+          name: usersshkeys
+          readOnly: true
         - mountPath: /http-prober-bin
           name: http-prober-bin
       imagePullSecrets:
@@ -101,6 +105,9 @@ spec:
       - name: openvpn-ca
         secret:
           secretName: openvpn-ca
+      - name: usersshkeys
+        secret:
+          secretName: usersshkeys
       - emptyDir: {}
         name: http-prober-bin
 status: {}

--- a/api/pkg/resources/test/fixtures/deployment-openstack-1.13.0-usercluster-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-openstack-1.13.0-usercluster-controller.yaml
@@ -40,7 +40,7 @@ spec:
         - -timeout
         - "1"
         - -command
-        - '{"command":"/usr/local/bin/user-cluster-controller-manager","args":["-kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","-metrics-listen-address","0.0.0.0:8085","-health-listen-address","0.0.0.0:8086","-namespace","$(NAMESPACE)","-ca-cert","/etc/kubernetes/pki/ca/ca.crt","-ca-key","/etc/kubernetes/pki/ca/ca.key","-cluster-url","","-openvpn-server-port","30003","-overwrite-registry","","-openshift=false","-version","1.13.0","-cloud-provider-name","openstack","-openvpn-ca-cert-file=/etc/kubernetes/pki/openvpn/ca.crt","-openvpn-ca-key-file=/etc/kubernetes/pki/openvpn/ca.key","--ipam-controller-network","192.168.1.1/24,192.168.1.1,8.8.8.8","-node-labels","{\"my-label\":\"my-value\"}"]}'
+        - '{"command":"/usr/local/bin/user-cluster-controller-manager","args":["-kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","-metrics-listen-address","0.0.0.0:8085","-health-listen-address","0.0.0.0:8086","-namespace","$(NAMESPACE)","-ca-cert","/etc/kubernetes/pki/ca/ca.crt","-ca-key","/etc/kubernetes/pki/ca/ca.key","-cluster-url","","-openvpn-server-port","30003","-overwrite-registry","","-openshift=false","-version","1.13.0","-cloud-provider-name","openstack","-openvpn-ca-cert-file=/etc/kubernetes/pki/openvpn/ca.crt","-openvpn-ca-key-file=/etc/kubernetes/pki/openvpn/ca.key","-user-ssh-keys-dir-path=/etc/kubernetes/usersshkeys","--ipam-controller-network","192.168.1.1/24,192.168.1.1,8.8.8.8","-node-labels","{\"my-label\":\"my-value\"}"]}'
         command:
         - /http-prober-bin/http-prober
         env:

--- a/api/pkg/resources/test/fixtures/deployment-vsphere-1.10.0-usercluster-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-vsphere-1.10.0-usercluster-controller.yaml
@@ -26,6 +26,7 @@ spec:
         cluster: de-test-01
         internal-admin-kubeconfig-secret-revision: "123456"
         openvpn-ca-secret-revision: "123456"
+        usersshkeys-secret-revision: "123456"
     spec:
       containers:
       - args:
@@ -76,6 +77,9 @@ spec:
         - mountPath: /etc/kubernetes/pki/openvpn
           name: openvpn-ca
           readOnly: true
+        - mountPath: /etc/kubernetes/usersshkeys
+          name: usersshkeys
+          readOnly: true
         - mountPath: /http-prober-bin
           name: http-prober-bin
       imagePullSecrets:
@@ -101,6 +105,9 @@ spec:
       - name: openvpn-ca
         secret:
           secretName: openvpn-ca
+      - name: usersshkeys
+        secret:
+          secretName: usersshkeys
       - emptyDir: {}
         name: http-prober-bin
 status: {}

--- a/api/pkg/resources/test/fixtures/deployment-vsphere-1.10.0-usercluster-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-vsphere-1.10.0-usercluster-controller.yaml
@@ -40,7 +40,7 @@ spec:
         - -timeout
         - "1"
         - -command
-        - '{"command":"/usr/local/bin/user-cluster-controller-manager","args":["-kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","-metrics-listen-address","0.0.0.0:8085","-health-listen-address","0.0.0.0:8086","-namespace","$(NAMESPACE)","-ca-cert","/etc/kubernetes/pki/ca/ca.crt","-ca-key","/etc/kubernetes/pki/ca/ca.key","-cluster-url","","-openvpn-server-port","30003","-overwrite-registry","","-openshift=false","-version","1.10.0","-cloud-provider-name","vsphere","-openvpn-ca-cert-file=/etc/kubernetes/pki/openvpn/ca.crt","-openvpn-ca-key-file=/etc/kubernetes/pki/openvpn/ca.key","--ipam-controller-network","192.168.1.1/24,192.168.1.1,8.8.8.8","-node-labels","{\"my-label\":\"my-value\"}"]}'
+        - '{"command":"/usr/local/bin/user-cluster-controller-manager","args":["-kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","-metrics-listen-address","0.0.0.0:8085","-health-listen-address","0.0.0.0:8086","-namespace","$(NAMESPACE)","-ca-cert","/etc/kubernetes/pki/ca/ca.crt","-ca-key","/etc/kubernetes/pki/ca/ca.key","-cluster-url","","-openvpn-server-port","30003","-overwrite-registry","","-openshift=false","-version","1.10.0","-cloud-provider-name","vsphere","-openvpn-ca-cert-file=/etc/kubernetes/pki/openvpn/ca.crt","-openvpn-ca-key-file=/etc/kubernetes/pki/openvpn/ca.key","-user-ssh-keys-dir-path=/etc/kubernetes/usersshkeys","--ipam-controller-network","192.168.1.1/24,192.168.1.1,8.8.8.8","-node-labels","{\"my-label\":\"my-value\"}"]}'
         command:
         - /http-prober-bin/http-prober
         env:

--- a/api/pkg/resources/test/fixtures/deployment-vsphere-1.10.6-usercluster-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-vsphere-1.10.6-usercluster-controller.yaml
@@ -26,6 +26,7 @@ spec:
         cluster: de-test-01
         internal-admin-kubeconfig-secret-revision: "123456"
         openvpn-ca-secret-revision: "123456"
+        usersshkeys-secret-revision: "123456"
     spec:
       containers:
       - args:
@@ -76,6 +77,9 @@ spec:
         - mountPath: /etc/kubernetes/pki/openvpn
           name: openvpn-ca
           readOnly: true
+        - mountPath: /etc/kubernetes/usersshkeys
+          name: usersshkeys
+          readOnly: true
         - mountPath: /http-prober-bin
           name: http-prober-bin
       imagePullSecrets:
@@ -101,6 +105,9 @@ spec:
       - name: openvpn-ca
         secret:
           secretName: openvpn-ca
+      - name: usersshkeys
+        secret:
+          secretName: usersshkeys
       - emptyDir: {}
         name: http-prober-bin
 status: {}

--- a/api/pkg/resources/test/fixtures/deployment-vsphere-1.10.6-usercluster-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-vsphere-1.10.6-usercluster-controller.yaml
@@ -40,7 +40,7 @@ spec:
         - -timeout
         - "1"
         - -command
-        - '{"command":"/usr/local/bin/user-cluster-controller-manager","args":["-kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","-metrics-listen-address","0.0.0.0:8085","-health-listen-address","0.0.0.0:8086","-namespace","$(NAMESPACE)","-ca-cert","/etc/kubernetes/pki/ca/ca.crt","-ca-key","/etc/kubernetes/pki/ca/ca.key","-cluster-url","","-openvpn-server-port","30003","-overwrite-registry","","-openshift=false","-version","1.10.6","-cloud-provider-name","vsphere","-openvpn-ca-cert-file=/etc/kubernetes/pki/openvpn/ca.crt","-openvpn-ca-key-file=/etc/kubernetes/pki/openvpn/ca.key","--ipam-controller-network","192.168.1.1/24,192.168.1.1,8.8.8.8","-node-labels","{\"my-label\":\"my-value\"}"]}'
+        - '{"command":"/usr/local/bin/user-cluster-controller-manager","args":["-kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","-metrics-listen-address","0.0.0.0:8085","-health-listen-address","0.0.0.0:8086","-namespace","$(NAMESPACE)","-ca-cert","/etc/kubernetes/pki/ca/ca.crt","-ca-key","/etc/kubernetes/pki/ca/ca.key","-cluster-url","","-openvpn-server-port","30003","-overwrite-registry","","-openshift=false","-version","1.10.6","-cloud-provider-name","vsphere","-openvpn-ca-cert-file=/etc/kubernetes/pki/openvpn/ca.crt","-openvpn-ca-key-file=/etc/kubernetes/pki/openvpn/ca.key","-user-ssh-keys-dir-path=/etc/kubernetes/usersshkeys","--ipam-controller-network","192.168.1.1/24,192.168.1.1,8.8.8.8","-node-labels","{\"my-label\":\"my-value\"}"]}'
         command:
         - /http-prober-bin/http-prober
         env:

--- a/api/pkg/resources/test/fixtures/deployment-vsphere-1.11.0-usercluster-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-vsphere-1.11.0-usercluster-controller.yaml
@@ -26,6 +26,7 @@ spec:
         cluster: de-test-01
         internal-admin-kubeconfig-secret-revision: "123456"
         openvpn-ca-secret-revision: "123456"
+        usersshkeys-secret-revision: "123456"
     spec:
       containers:
       - args:
@@ -76,6 +77,9 @@ spec:
         - mountPath: /etc/kubernetes/pki/openvpn
           name: openvpn-ca
           readOnly: true
+        - mountPath: /etc/kubernetes/usersshkeys
+          name: usersshkeys
+          readOnly: true
         - mountPath: /http-prober-bin
           name: http-prober-bin
       imagePullSecrets:
@@ -101,6 +105,9 @@ spec:
       - name: openvpn-ca
         secret:
           secretName: openvpn-ca
+      - name: usersshkeys
+        secret:
+          secretName: usersshkeys
       - emptyDir: {}
         name: http-prober-bin
 status: {}

--- a/api/pkg/resources/test/fixtures/deployment-vsphere-1.11.0-usercluster-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-vsphere-1.11.0-usercluster-controller.yaml
@@ -40,7 +40,7 @@ spec:
         - -timeout
         - "1"
         - -command
-        - '{"command":"/usr/local/bin/user-cluster-controller-manager","args":["-kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","-metrics-listen-address","0.0.0.0:8085","-health-listen-address","0.0.0.0:8086","-namespace","$(NAMESPACE)","-ca-cert","/etc/kubernetes/pki/ca/ca.crt","-ca-key","/etc/kubernetes/pki/ca/ca.key","-cluster-url","","-openvpn-server-port","30003","-overwrite-registry","","-openshift=false","-version","1.11.0","-cloud-provider-name","vsphere","-openvpn-ca-cert-file=/etc/kubernetes/pki/openvpn/ca.crt","-openvpn-ca-key-file=/etc/kubernetes/pki/openvpn/ca.key","--ipam-controller-network","192.168.1.1/24,192.168.1.1,8.8.8.8","-node-labels","{\"my-label\":\"my-value\"}"]}'
+        - '{"command":"/usr/local/bin/user-cluster-controller-manager","args":["-kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","-metrics-listen-address","0.0.0.0:8085","-health-listen-address","0.0.0.0:8086","-namespace","$(NAMESPACE)","-ca-cert","/etc/kubernetes/pki/ca/ca.crt","-ca-key","/etc/kubernetes/pki/ca/ca.key","-cluster-url","","-openvpn-server-port","30003","-overwrite-registry","","-openshift=false","-version","1.11.0","-cloud-provider-name","vsphere","-openvpn-ca-cert-file=/etc/kubernetes/pki/openvpn/ca.crt","-openvpn-ca-key-file=/etc/kubernetes/pki/openvpn/ca.key","-user-ssh-keys-dir-path=/etc/kubernetes/usersshkeys","--ipam-controller-network","192.168.1.1/24,192.168.1.1,8.8.8.8","-node-labels","{\"my-label\":\"my-value\"}"]}'
         command:
         - /http-prober-bin/http-prober
         env:

--- a/api/pkg/resources/test/fixtures/deployment-vsphere-1.11.1-usercluster-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-vsphere-1.11.1-usercluster-controller.yaml
@@ -40,7 +40,7 @@ spec:
         - -timeout
         - "1"
         - -command
-        - '{"command":"/usr/local/bin/user-cluster-controller-manager","args":["-kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","-metrics-listen-address","0.0.0.0:8085","-health-listen-address","0.0.0.0:8086","-namespace","$(NAMESPACE)","-ca-cert","/etc/kubernetes/pki/ca/ca.crt","-ca-key","/etc/kubernetes/pki/ca/ca.key","-cluster-url","","-openvpn-server-port","30003","-overwrite-registry","","-openshift=false","-version","1.11.1","-cloud-provider-name","vsphere","-openvpn-ca-cert-file=/etc/kubernetes/pki/openvpn/ca.crt","-openvpn-ca-key-file=/etc/kubernetes/pki/openvpn/ca.key","--ipam-controller-network","192.168.1.1/24,192.168.1.1,8.8.8.8","-node-labels","{\"my-label\":\"my-value\"}"]}'
+        - '{"command":"/usr/local/bin/user-cluster-controller-manager","args":["-kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","-metrics-listen-address","0.0.0.0:8085","-health-listen-address","0.0.0.0:8086","-namespace","$(NAMESPACE)","-ca-cert","/etc/kubernetes/pki/ca/ca.crt","-ca-key","/etc/kubernetes/pki/ca/ca.key","-cluster-url","","-openvpn-server-port","30003","-overwrite-registry","","-openshift=false","-version","1.11.1","-cloud-provider-name","vsphere","-openvpn-ca-cert-file=/etc/kubernetes/pki/openvpn/ca.crt","-openvpn-ca-key-file=/etc/kubernetes/pki/openvpn/ca.key","-user-ssh-keys-dir-path=/etc/kubernetes/usersshkeys","--ipam-controller-network","192.168.1.1/24,192.168.1.1,8.8.8.8","-node-labels","{\"my-label\":\"my-value\"}"]}'
         command:
         - /http-prober-bin/http-prober
         env:

--- a/api/pkg/resources/test/fixtures/deployment-vsphere-1.11.1-usercluster-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-vsphere-1.11.1-usercluster-controller.yaml
@@ -26,6 +26,7 @@ spec:
         cluster: de-test-01
         internal-admin-kubeconfig-secret-revision: "123456"
         openvpn-ca-secret-revision: "123456"
+        usersshkeys-secret-revision: "123456"
     spec:
       containers:
       - args:
@@ -76,6 +77,9 @@ spec:
         - mountPath: /etc/kubernetes/pki/openvpn
           name: openvpn-ca
           readOnly: true
+        - mountPath: /etc/kubernetes/usersshkeys
+          name: usersshkeys
+          readOnly: true
         - mountPath: /http-prober-bin
           name: http-prober-bin
       imagePullSecrets:
@@ -101,6 +105,9 @@ spec:
       - name: openvpn-ca
         secret:
           secretName: openvpn-ca
+      - name: usersshkeys
+        secret:
+          secretName: usersshkeys
       - emptyDir: {}
         name: http-prober-bin
 status: {}

--- a/api/pkg/resources/test/fixtures/deployment-vsphere-1.12.0-usercluster-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-vsphere-1.12.0-usercluster-controller.yaml
@@ -26,6 +26,7 @@ spec:
         cluster: de-test-01
         internal-admin-kubeconfig-secret-revision: "123456"
         openvpn-ca-secret-revision: "123456"
+        usersshkeys-secret-revision: "123456"
     spec:
       containers:
       - args:
@@ -76,6 +77,9 @@ spec:
         - mountPath: /etc/kubernetes/pki/openvpn
           name: openvpn-ca
           readOnly: true
+        - mountPath: /etc/kubernetes/usersshkeys
+          name: usersshkeys
+          readOnly: true
         - mountPath: /http-prober-bin
           name: http-prober-bin
       imagePullSecrets:
@@ -101,6 +105,9 @@ spec:
       - name: openvpn-ca
         secret:
           secretName: openvpn-ca
+      - name: usersshkeys
+        secret:
+          secretName: usersshkeys
       - emptyDir: {}
         name: http-prober-bin
 status: {}

--- a/api/pkg/resources/test/fixtures/deployment-vsphere-1.12.0-usercluster-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-vsphere-1.12.0-usercluster-controller.yaml
@@ -40,7 +40,7 @@ spec:
         - -timeout
         - "1"
         - -command
-        - '{"command":"/usr/local/bin/user-cluster-controller-manager","args":["-kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","-metrics-listen-address","0.0.0.0:8085","-health-listen-address","0.0.0.0:8086","-namespace","$(NAMESPACE)","-ca-cert","/etc/kubernetes/pki/ca/ca.crt","-ca-key","/etc/kubernetes/pki/ca/ca.key","-cluster-url","","-openvpn-server-port","30003","-overwrite-registry","","-openshift=false","-version","1.12.0","-cloud-provider-name","vsphere","-openvpn-ca-cert-file=/etc/kubernetes/pki/openvpn/ca.crt","-openvpn-ca-key-file=/etc/kubernetes/pki/openvpn/ca.key","--ipam-controller-network","192.168.1.1/24,192.168.1.1,8.8.8.8","-node-labels","{\"my-label\":\"my-value\"}"]}'
+        - '{"command":"/usr/local/bin/user-cluster-controller-manager","args":["-kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","-metrics-listen-address","0.0.0.0:8085","-health-listen-address","0.0.0.0:8086","-namespace","$(NAMESPACE)","-ca-cert","/etc/kubernetes/pki/ca/ca.crt","-ca-key","/etc/kubernetes/pki/ca/ca.key","-cluster-url","","-openvpn-server-port","30003","-overwrite-registry","","-openshift=false","-version","1.12.0","-cloud-provider-name","vsphere","-openvpn-ca-cert-file=/etc/kubernetes/pki/openvpn/ca.crt","-openvpn-ca-key-file=/etc/kubernetes/pki/openvpn/ca.key","-user-ssh-keys-dir-path=/etc/kubernetes/usersshkeys","--ipam-controller-network","192.168.1.1/24,192.168.1.1,8.8.8.8","-node-labels","{\"my-label\":\"my-value\"}"]}'
         command:
         - /http-prober-bin/http-prober
         env:

--- a/api/pkg/resources/test/fixtures/deployment-vsphere-1.13.0-usercluster-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-vsphere-1.13.0-usercluster-controller.yaml
@@ -26,6 +26,7 @@ spec:
         cluster: de-test-01
         internal-admin-kubeconfig-secret-revision: "123456"
         openvpn-ca-secret-revision: "123456"
+        usersshkeys-secret-revision: "123456"
     spec:
       containers:
       - args:
@@ -76,6 +77,9 @@ spec:
         - mountPath: /etc/kubernetes/pki/openvpn
           name: openvpn-ca
           readOnly: true
+        - mountPath: /etc/kubernetes/usersshkeys
+          name: usersshkeys
+          readOnly: true
         - mountPath: /http-prober-bin
           name: http-prober-bin
       imagePullSecrets:
@@ -101,6 +105,9 @@ spec:
       - name: openvpn-ca
         secret:
           secretName: openvpn-ca
+      - name: usersshkeys
+        secret:
+          secretName: usersshkeys
       - emptyDir: {}
         name: http-prober-bin
 status: {}

--- a/api/pkg/resources/test/fixtures/deployment-vsphere-1.13.0-usercluster-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-vsphere-1.13.0-usercluster-controller.yaml
@@ -40,7 +40,7 @@ spec:
         - -timeout
         - "1"
         - -command
-        - '{"command":"/usr/local/bin/user-cluster-controller-manager","args":["-kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","-metrics-listen-address","0.0.0.0:8085","-health-listen-address","0.0.0.0:8086","-namespace","$(NAMESPACE)","-ca-cert","/etc/kubernetes/pki/ca/ca.crt","-ca-key","/etc/kubernetes/pki/ca/ca.key","-cluster-url","","-openvpn-server-port","30003","-overwrite-registry","","-openshift=false","-version","1.13.0","-cloud-provider-name","vsphere","-openvpn-ca-cert-file=/etc/kubernetes/pki/openvpn/ca.crt","-openvpn-ca-key-file=/etc/kubernetes/pki/openvpn/ca.key","--ipam-controller-network","192.168.1.1/24,192.168.1.1,8.8.8.8","-node-labels","{\"my-label\":\"my-value\"}"]}'
+        - '{"command":"/usr/local/bin/user-cluster-controller-manager","args":["-kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","-metrics-listen-address","0.0.0.0:8085","-health-listen-address","0.0.0.0:8086","-namespace","$(NAMESPACE)","-ca-cert","/etc/kubernetes/pki/ca/ca.crt","-ca-key","/etc/kubernetes/pki/ca/ca.key","-cluster-url","","-openvpn-server-port","30003","-overwrite-registry","","-openshift=false","-version","1.13.0","-cloud-provider-name","vsphere","-openvpn-ca-cert-file=/etc/kubernetes/pki/openvpn/ca.crt","-openvpn-ca-key-file=/etc/kubernetes/pki/openvpn/ca.key","-user-ssh-keys-dir-path=/etc/kubernetes/usersshkeys","--ipam-controller-network","192.168.1.1/24,192.168.1.1,8.8.8.8","-node-labels","{\"my-label\":\"my-value\"}"]}'
         command:
         - /http-prober-bin/http-prober
         env:

--- a/api/pkg/resources/test/load_files_test.go
+++ b/api/pkg/resources/test/load_files_test.go
@@ -411,6 +411,13 @@ func TestLoadFiles(t *testing.T) {
 							Namespace:       cluster.Status.NamespaceName,
 						},
 					},
+					&corev1.Secret{
+						ObjectMeta: metav1.ObjectMeta{
+							ResourceVersion: "123456",
+							Name:            resources.UserSSHKeys,
+							Namespace:       cluster.Status.NamespaceName,
+						},
+					},
 					&corev1.ConfigMap{
 						ObjectMeta: metav1.ObjectMeta{
 							ResourceVersion: "123456",

--- a/api/pkg/resources/usercluster/deployment.go
+++ b/api/pkg/resources/usercluster/deployment.go
@@ -32,8 +32,9 @@ var (
 )
 
 const (
-	name              = "usercluster-controller"
-	openvpnCAMountDir = "/etc/kubernetes/pki/openvpn"
+	name                = "usercluster-controller"
+	openvpnCAMountDir   = "/etc/kubernetes/pki/openvpn"
+	userSSHKeysMountDir = "/etc/kubernetes/usersshkeys"
 )
 
 // userclusterControllerData is the subet of the deploymentData interface
@@ -178,6 +179,11 @@ func DeploymentCreator(data userclusterControllerData, openshift bool) reconcili
 							MountPath: openvpnCAMountDir,
 							ReadOnly:  true,
 						},
+						{
+							Name:      resources.UserSSHKeys,
+							MountPath: userSSHKeysMountDir,
+							ReadOnly:  true,
+						},
 					},
 				},
 			}
@@ -216,6 +222,14 @@ func getVolumes() []corev1.Volume {
 			VolumeSource: corev1.VolumeSource{
 				Secret: &corev1.SecretVolumeSource{
 					SecretName: resources.OpenVPNCASecretName,
+				},
+			},
+		},
+		{
+			Name: resources.UserSSHKeys,
+			VolumeSource: corev1.VolumeSource{
+				Secret: &corev1.SecretVolumeSource{
+					SecretName: resources.UserSSHKeys,
 				},
 			},
 		},

--- a/api/pkg/resources/usercluster/deployment.go
+++ b/api/pkg/resources/usercluster/deployment.go
@@ -114,6 +114,7 @@ func DeploymentCreator(data userclusterControllerData, openshift bool) reconcili
 				"-cloud-provider-name", data.GetKubernetesCloudProviderName(),
 				fmt.Sprintf("-openvpn-ca-cert-file=%s/%s", openvpnCAMountDir, resources.OpenVPNCACertKey),
 				fmt.Sprintf("-openvpn-ca-key-file=%s/%s", openvpnCAMountDir, resources.OpenVPNCAKeyKey),
+				fmt.Sprintf("-user-ssh-keys-dir-path=%s", userSSHKeysMountDir),
 			}, getNetworkArgs(data)...)
 
 			labelArgsValue, err := getLabelsArgValue(data.Cluster())


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR creates secrets out of the UserSSHKeys and inside the user cluster namespace and syncs these secrets inside the usercluster. The reason behind it is, we would like to add&remove SSH keys to a cluster & directly access all nodes via the newly added SSH key. Right now I'm required to rotate all nodes which impose a risk to my workload.

**Special notes for your reviewer**:
This PR is a subset of the required changes to fix this ticket: https://app.zenhub.com/workspaces/all-kubermatic-58863654794153994b62af76/issues/kubermatic/kubermatic/3573

**Does this PR introduce a user-facing change?**:
No
 
```release-note
NONE
```
