### PR TITLE
Machine cleanup: Tolerate absent CRD

### DIFF
--- a/api/pkg/clusterdeletion/credentialsrequests.go
+++ b/api/pkg/clusterdeletion/credentialsrequests.go
@@ -26,8 +26,8 @@ func (d *Deletion) cleanupCredentialsRequests(ctx context.Context, log *zap.Suga
 	credentialRequests.SetKind("CredentialsRequest")
 
 	if err := userClusterClient.List(ctx, &ctrlruntimeclient.ListOptions{}, credentialRequests); err != nil {
-		if _, matches := err.(*meta.NoKindMatchError); matches {
-			log.Debug("Got a NoKindMatchError when listing CredentialsRequests, skipping their cleanup")
+		if meta.IsNoMatchError(err) {
+			log.Debug("Got a NoMatchError when listing CredentialsRequests, skipping their cleanup")
 			return false, nil
 		}
 		return false, fmt.Errorf("failed to list CredentialsRequests: %v", err)

--- a/api/pkg/clusterdeletion/node.go
+++ b/api/pkg/clusterdeletion/node.go
@@ -9,6 +9,7 @@ import (
 	kuberneteshelper "github.com/kubermatic/kubermatic/api/pkg/kubernetes"
 	"github.com/kubermatic/machine-controller/pkg/node/eviction"
 	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/meta"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/client-go/util/retry"
@@ -57,7 +58,7 @@ func (d *Deletion) cleanupNodes(ctx context.Context, cluster *kubermaticv1.Clust
 
 	machineDeploymentList := &clusterv1alpha1.MachineDeploymentList{}
 	listOpts := &controllerruntimeclient.ListOptions{Namespace: metav1.NamespaceSystem}
-	if err := userClusterClient.List(ctx, listOpts, machineDeploymentList); err != nil {
+	if err := userClusterClient.List(ctx, listOpts, machineDeploymentList); err != nil && !meta.IsNoMatchError(err) {
 		return fmt.Errorf("failed to list MachineDeployments: %v", err)
 	}
 	if len(machineDeploymentList.Items) > 0 {
@@ -72,7 +73,7 @@ func (d *Deletion) cleanupNodes(ctx context.Context, cluster *kubermaticv1.Clust
 	}
 
 	machineSetList := &clusterv1alpha1.MachineSetList{}
-	if err := userClusterClient.List(ctx, listOpts, machineSetList); err != nil {
+	if err := userClusterClient.List(ctx, listOpts, machineSetList); err != nil && !meta.IsNoMatchError(err) {
 		return fmt.Errorf("failed to list MachineSets: %v", err)
 	}
 	if len(machineSetList.Items) > 0 {
@@ -87,7 +88,7 @@ func (d *Deletion) cleanupNodes(ctx context.Context, cluster *kubermaticv1.Clust
 	}
 
 	machineList := &clusterv1alpha1.MachineList{}
-	if err := userClusterClient.List(ctx, listOpts, machineList); err != nil {
+	if err := userClusterClient.List(ctx, listOpts, machineList); err != nil && !meta.IsNoMatchError(err) {
 		return fmt.Errorf("failed to get Machines: %v", err)
 	}
 	if len(machineList.Items) > 0 {


### PR DESCRIPTION
**What this PR does / why we need it**:
Makes the node cleanup tolerate the absence. of the Machine CRDs and not tolerate that as a failure. This may happen if  e.G. the usercluster controller manager never got ready.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Documentation**:
<!-- Add links to the related documentation changes related to this pull request. E.g. the link to the kubermatic/docs pullrequest. -->

**Does this PR introduce a user-facing change?**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If  no release note is required, just write "NONE".
-->
```release-note
none
```
