### PR TITLE
handler tests: properly fill ObjectMeta for test user objects

### DIFF
--- a/api/pkg/handler/test/helper.go
+++ b/api/pkg/handler/test/helper.go
@@ -399,8 +399,16 @@ users:
 
 // APIUserToKubermaticUser simply converts apiv1.User to kubermaticv1.User type
 func APIUserToKubermaticUser(user apiv1.User) *kubermaticv1.User {
+	var deletionTimestamp *metav1.Time
+	if user.DeletionTimestamp != nil {
+		deletionTimestamp = &metav1.Time{Time: user.DeletionTimestamp.Time}
+	}
 	return &kubermaticv1.User{
-		ObjectMeta: metav1.ObjectMeta{},
+		ObjectMeta: metav1.ObjectMeta{
+			Name:              user.Name,
+			CreationTimestamp: metav1.Time{Time: user.CreationTimestamp.Time},
+			DeletionTimestamp: deletionTimestamp,
+		},
 		Spec: kubermaticv1.UserSpec{
 			Name:  user.Name,
 			Email: user.Email,


### PR DESCRIPTION
Previously, converting API users to Kubernetes objects in our tests
did not fill out the `ObjectMeta` struct - therefore as far as
the fake client's object tracker is concerened, every user
was named "". As a consequence, a test couldn't add multiple user objects.

```release-note
NONE
```

/assign @maciaszczykm 
