### PR TITLE
Add type label to cluster_info metric

### DIFF
--- a/api/pkg/collectors/cluster.go
+++ b/api/pkg/collectors/cluster.go
@@ -52,6 +52,7 @@ func MustRegisterClusterCollector(registry prometheus.Registerer, client ctrlrun
 				"cloud_provider",
 				"datacenter",
 				"pause",
+				"type",
 			},
 			nil,
 		),
@@ -121,6 +122,11 @@ func (cc *ClusterCollector) clusterLabels(cluster *kubermaticv1.Cluster) ([]stri
 		pause = "true"
 	}
 
+	clusterType := "kubernetes"
+	if cluster.Spec.Openshift != nil {
+		clusterType = "openshift"
+	}
+
 	return []string{
 		cluster.Name,
 		cluster.Spec.HumanReadableName,
@@ -129,5 +135,6 @@ func (cc *ClusterCollector) clusterLabels(cluster *kubermaticv1.Cluster) ([]stri
 		provider,
 		cluster.Spec.Cloud.DatacenterName,
 		pause,
+		clusterType,
 	}, nil
 }


### PR DESCRIPTION
**What this PR does / why we need it**:
This is in preparation for a user cluster version/type Grafana dashboard.

**Does this PR introduce a user-facing change?**:
```release-note
Add type label (kubernetes/openshift) to kubermatic_cluster_info metric.
```
