### PR TITLE
Keep reconciling unready clusters regardless of the concurrency limit

### DIFF
--- a/api/pkg/controller/monitoring/monitoring_controller.go
+++ b/api/pkg/controller/monitoring/monitoring_controller.go
@@ -194,7 +194,8 @@ func (r *Reconciler) Reconcile(request reconcile.Request) (reconcile.Result, err
 		return reconcile.Result{RequeueAfter: healthCheckPeriod}, nil
 	}
 
-	if limitReached, err := controllerutil.ConcurrencyLimitReached(ctx, r, r.concurrentClusterUpdates); limitReached || err != nil {
+	// only reconcile this cluster if there are not yet too many updates running
+	if available, err := controllerutil.ClusterAvailableForReconciling(ctx, r, cluster, r.concurrentClusterUpdates); !available || err != nil {
 		log.Infow("Concurrency limit reached, checking again in 10 seconds", "concurrency-limit", r.concurrentClusterUpdates)
 		return reconcile.Result{
 			RequeueAfter: 10 * time.Second,
@@ -214,7 +215,7 @@ func (r *Reconciler) Reconcile(request reconcile.Request) (reconcile.Result, err
 		result = &reconcile.Result{}
 	}
 
-	if err := controllerutil.SetClusterUpdatedSuccessfullyCondition(ctx, cluster, r, successfullyReconciled); err != nil {
+	if err := controllerutil.SetSeedResourcesUpToDateCondition(ctx, cluster, r, successfullyReconciled); err != nil {
 		log.Errorw("failed to update clusters status conditions", zap.Error(err))
 		reconcileErr = fmt.Errorf("failed to set cluster status: %v after reconciliation was done with err=%v", err, reconcileErr)
 	}

--- a/api/pkg/controller/openshift/openshift_controller.go
+++ b/api/pkg/controller/openshift/openshift_controller.go
@@ -189,7 +189,8 @@ func (r *Reconciler) Reconcile(request reconcile.Request) (reconcile.Result, err
 		return reconcile.Result{}, nil
 	}
 
-	if limitReached, err := controllerutil.ConcurrencyLimitReached(ctx, r, r.concurrentClusterUpdates); limitReached || err != nil {
+	// only reconcile this cluster if there are not yet too many updates running
+	if available, err := controllerutil.ClusterAvailableForReconciling(ctx, r, cluster, r.concurrentClusterUpdates); !available || err != nil {
 		log.Infow("Concurrency limit reached, checking again in 10 seconds", "concurrency-limit", r.concurrentClusterUpdates)
 		return reconcile.Result{
 			RequeueAfter: 10 * time.Second,
@@ -210,7 +211,7 @@ func (r *Reconciler) Reconcile(request reconcile.Request) (reconcile.Result, err
 		result = &reconcile.Result{}
 	}
 
-	if err := controllerutil.SetClusterUpdatedSuccessfullyCondition(ctx, cluster, r, successfullyReconciled); err != nil {
+	if err := controllerutil.SetSeedResourcesUpToDateCondition(ctx, cluster, r, successfullyReconciled); err != nil {
 		log.Errorw("failed to update clusters status conditions", zap.Error(err))
 		reconcileErr = fmt.Errorf("failed to set cluster status: %v after reconciliation was done with err=%v", err, reconcileErr)
 	}

--- a/api/pkg/controller/update/update_controller.go
+++ b/api/pkg/controller/update/update_controller.go
@@ -7,7 +7,7 @@ import (
 
 	"go.uber.org/zap"
 
-	"github.com/kubermatic/kubermatic/api/pkg/api/v1"
+	v1 "github.com/kubermatic/kubermatic/api/pkg/api/v1"
 	"github.com/kubermatic/kubermatic/api/pkg/cluster/client"
 	kubermaticv1 "github.com/kubermatic/kubermatic/api/pkg/crd/kubermatic/v1"
 	"github.com/kubermatic/kubermatic/api/pkg/semver"
@@ -117,7 +117,7 @@ func (r *Reconciler) reconcile(ctx context.Context, cluster *kubermaticv1.Cluste
 	// Give the controller time to do the update
 	// TODO: This is not really safe. We should add a `Version` to the status
 	// that gets incremented when the controller does this. Combined with a
-	// `ClusterUpdatedSuccessfully` condition, that should do the trick
+	// `SeedResourcesUpToDate` condition, that should do the trick
 	if updated {
 		return &reconcile.Result{RequeueAfter: time.Minute}, nil
 	}

--- a/api/pkg/crd/kubermatic/v1/cluster.go
+++ b/api/pkg/crd/kubermatic/v1/cluster.go
@@ -188,9 +188,8 @@ type ClusterStatus struct {
 // the existence.
 func (cs *ClusterStatus) HasConditionValue(conditionType ClusterConditionType, conditionStatus corev1.ConditionStatus) bool {
 	for _, clusterCondition := range cs.Conditions {
-		if clusterCondition.Type == conditionType &&
-			clusterCondition.Status == conditionStatus {
-			return true
+		if clusterCondition.Type == conditionType {
+			return clusterCondition.Status == conditionStatus
 		}
 	}
 


### PR DESCRIPTION
**What this PR does / why we need it**:
The concurrency limit for controllers lead to cases where more than N clusters were unready, which made the controllers simply stop working entirely. This meant that the controllers also would never add the condition to clusters that they are ready, so the situation never fixes itself.

This PR changes the logic so that unready clusters are not considered for the concurrency limit, so they will always be reconciled. We only want to limit *new* reconciles (e.g. when a cluster update is performed, we don't want to start updating all clusters at the same time). A new `ClusterAvailableForReconciling` helper takes care of checking clusters.

I also renamed the `ClusterConditionControllerFinishedUpdatingSuccessfully` constant to `SeedResourcesUpToDate`, because

* the constant is used not just by the cluster controller,
* the new name reflects that the constant is only representing *in-cluster* resources (control plane, Prometheus, ...), but not cloud provider resources.

Fixes #4455.

**Does this PR introduce a user-facing change?**:
```release-note
NONE
```
