### PR TITLE
Add proxy endpoint for kubernetes dashboard

### DIFF
--- a/api/pkg/handler/v1/common/common.go
+++ b/api/pkg/handler/v1/common/common.go
@@ -1,18 +1,33 @@
 package common
 
 import (
+	"bytes"
 	"context"
+	"errors"
 	"fmt"
+	"net/http"
+	"strconv"
+	"strings"
+	"time"
 
 	"github.com/prometheus/client_golang/prometheus"
+	"go.uber.org/zap"
+	"k8s.io/apimachinery/pkg/util/httpstream"
+	"k8s.io/client-go/rest"
+	"k8s.io/client-go/tools/portforward"
+	"k8s.io/client-go/transport/spdy"
+
+	"github.com/kubermatic/machine-controller/pkg/providerconfig"
 
 	kubermaticv1 "github.com/kubermatic/kubermatic/api/pkg/crd/kubermatic/v1"
 	"github.com/kubermatic/kubermatic/api/pkg/provider"
+	kubermaticerrors "github.com/kubermatic/kubermatic/api/pkg/util/errors"
 	"github.com/kubermatic/kubermatic/api/pkg/version"
-	"github.com/kubermatic/machine-controller/pkg/providerconfig"
 
 	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
+	corev1interface "k8s.io/client-go/kubernetes/typed/core/v1"
 	ctrlruntimeclient "sigs.k8s.io/controller-runtime/pkg/client"
 )
 
@@ -96,4 +111,148 @@ func (d CredentialsData) GetGlobalSecretKeySelectorValue(configVar *providerconf
 		return "", fmt.Errorf("secret %q in namespace %q has no key %q", configVar.Name, configVar.Namespace, key)
 	}
 	return "", nil
+}
+
+// GetReadyPod returns a pod matching provided label selector if it is posting ready status, error otherwise.
+// Namespace can be ensured by creating proper PodInterface client.
+func GetReadyPod(client corev1interface.PodInterface, labelSelector string) (*corev1.Pod, error) {
+	pods, err := client.List(metav1.ListOptions{LabelSelector: labelSelector})
+	if err != nil {
+		return nil, fmt.Errorf("failed to get pod: %v", err)
+	}
+
+	readyPods := getReadyPods(pods)
+	if len(readyPods.Items) < 1 {
+		return nil, kubermaticerrors.New(http.StatusBadRequest, "pod is not ready")
+	}
+
+	return &readyPods.Items[0], nil
+}
+
+// While it is tempting to write our own roundTripper to do all the reading/writing
+// in memory intead of opening a TCP port it has some drawbacks:
+// * net/http.ReadResponse does not work with websockets, because its body is hardcoded to be an
+//   io.ReadCloster and not an io.ReadWriteCloser:
+//   * https://github.com/golang/go/blob/361ab73305788c4bf35359a02d8873c36d654f1b/src/net/http/transfer.go#L550
+//   * https://github.com/golang/go/blob/361ab73305788c4bf35359a02d8873c36d654f1b/src/net/http/httputil/reverseproxy.go#L518
+// * RoundTripping is a bit more complicated than just read and write, mimicking that badly is likely
+//   to be more expensive than doing the extra round via the TCP socket:
+//   https://github.com/golang/go/blob/361ab73305788c4bf35359a02d8873c36d654f1b/src/net/http/transport.go#L454
+func GetPortForwarder(
+	coreClient corev1interface.CoreV1Interface,
+	cfg *rest.Config,
+	namespace string,
+	labelSelector string,
+	containerPort int) (*portforward.PortForwarder, *bytes.Buffer, error) {
+	pod, err := GetReadyPod(coreClient.Pods(namespace), labelSelector)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	fmt.Println(pod)
+
+	dialer, err := getDialerForPod(pod, coreClient.RESTClient(), cfg)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	readyChan := make(chan struct{})
+	stopChan := make(chan struct{})
+	errorBuffer := bytes.NewBuffer(make([]byte, 1024))
+	outBuffer := bytes.NewBuffer(make([]byte, 1024))
+	portforwarder, err := portforward.NewOnAddresses(dialer, []string{"127.0.0.1"}, []string{"0:" + strconv.Itoa(containerPort)}, stopChan, readyChan, outBuffer, errorBuffer)
+	if err != nil {
+		return nil, nil, fmt.Errorf("failed to create portforwarder: %v", err)
+	}
+
+	// Portforwarding is blocking, so we can't do it here
+	return portforwarder, outBuffer, nil
+}
+
+func getReadyPods(pods *corev1.PodList) *corev1.PodList {
+	res := &corev1.PodList{}
+	for _, pod := range pods.Items {
+		if isPodReady(pod) {
+			res.Items = append(res.Items, pod)
+		}
+	}
+	return res
+}
+
+func isPodReady(pod corev1.Pod) bool {
+	for _, condition := range pod.Status.Conditions {
+		if condition.Type == corev1.PodReady {
+			return condition.Status == corev1.ConditionTrue
+		}
+	}
+	return false
+}
+
+func getDialerForPod(
+	pod *corev1.Pod,
+	restClient rest.Interface,
+	cfg *rest.Config) (httpstream.Dialer, error) {
+
+	// The logic here is copied straight from kubectl at
+	// https://github.com/kubernetes/kubernetes/blob/b88662505d288297750becf968bf307dacf872fa/staging/src/k8s.io/kubectl/pkg/cmd/portforward/portforward.go#L334
+	req := restClient.Post().
+		Resource("pods").
+		Namespace(pod.Namespace).
+		Name(pod.Name).
+		SubResource("portforward")
+
+	transport, upgrader, err := spdy.RoundTripperFor(cfg)
+	if err != nil {
+		return nil, fmt.Errorf("failed to get spdy roundTripper: %v", err)
+	}
+
+	return spdy.NewDialer(upgrader, &http.Client{Transport: transport}, http.MethodPost, req.URL()), nil
+}
+
+// WaitForPortForwarder waits until started port forwarder is ready, or emits an error to provided errChan
+func WaitForPortForwarder(p *portforward.PortForwarder, errChan <-chan error) error {
+	timeout := time.After(10 * time.Second)
+	select {
+	case <-timeout:
+		return errors.New("timeout waiting for backend connection")
+	case err := <-errChan:
+		return fmt.Errorf("failed to get connection to backend: %v", err)
+	case <-p.Ready:
+		return nil
+	}
+}
+
+// GetLocalPortFromPortForwardOutput parses outBuffer returned by GetPortForwarder method and returns
+// local port on which port forwarder exposed the pod.
+func GetLocalPortFromPortForwardOutput(out string) (int, error) {
+	colonSplit := strings.Split(out, ":")
+	if n := len(colonSplit); n < 2 {
+		return 0, fmt.Errorf("expected at least two results when splitting by colon, got %d", n)
+	}
+	spaceSplit := strings.Split(colonSplit[1], " ")
+	if n := len(spaceSplit); n < 1 {
+		return 0, fmt.Errorf("expected at least one result when splitting by space, got %d", n)
+	}
+	result, err := strconv.Atoi(spaceSplit[0])
+	if err != nil {
+		return 0, fmt.Errorf("failed to parse int: %v", err)
+	}
+	return result, nil
+}
+
+// WriteHTTPError writes an http error out. If debug is enabled, it also gets logged.
+func WriteHTTPError(log *zap.SugaredLogger, w http.ResponseWriter, err error) {
+	log.Debugw("Encountered error", zap.Error(err))
+	var httpErr kubermaticerrors.HTTPError
+
+	if asserted, ok := err.(kubermaticerrors.HTTPError); ok {
+		httpErr = asserted
+	} else {
+		httpErr = kubermaticerrors.New(http.StatusInternalServerError, err.Error())
+	}
+
+	w.WriteHeader(httpErr.StatusCode())
+	if _, wErr := w.Write([]byte(httpErr.Error())); wErr != nil {
+		log.Errorw("Failed to write body", zap.Error(err))
+	}
 }

--- a/api/pkg/handler/v1/kubernetes-dashboard/dashboard.go
+++ b/api/pkg/handler/v1/kubernetes-dashboard/dashboard.go
@@ -1,0 +1,200 @@
+package kubernetesdashboard
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"net/http"
+	"net/http/httputil"
+	"net/url"
+	"strings"
+
+	"github.com/go-kit/kit/endpoint"
+	transporthttp "github.com/go-kit/kit/transport/http"
+	"go.uber.org/zap"
+	"k8s.io/client-go/tools/clientcmd/api"
+
+	"github.com/kubermatic/kubermatic/api/pkg/handler/middleware"
+	"github.com/kubermatic/kubermatic/api/pkg/handler/v1/cluster"
+	"github.com/kubermatic/kubermatic/api/pkg/handler/v1/common"
+	"github.com/kubermatic/kubermatic/api/pkg/provider"
+	kubernetesdashboard "github.com/kubermatic/kubermatic/api/pkg/resources/kubernetes-dashboard"
+	kubermaticerrors "github.com/kubermatic/kubermatic/api/pkg/util/errors"
+
+	"k8s.io/client-go/tools/portforward"
+)
+
+// Minimal wrapper to implement the http.Handler interface
+type dynamicHTTPHandler func(http.ResponseWriter, *http.Request)
+
+// ServeHTTP implements http.Handler
+func (dHandler dynamicHTTPHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
+	dHandler(w, r)
+}
+
+func ProxyEndpoint(
+	log *zap.SugaredLogger,
+	extractor transporthttp.RequestFunc,
+	projectProvider provider.ProjectProvider,
+	middlewares endpoint.Middleware) http.Handler {
+	return dynamicHTTPHandler(func(w http.ResponseWriter, r *http.Request) {
+
+		log := log.With("endpoint", "kubernetes-dashboard-proxy", "uri", r.URL.Path)
+		ctx := extractor(r.Context(), r)
+		request, err := common.DecodeGetClusterReq(ctx, r)
+		if err != nil {
+			common.WriteHTTPError(log, w, kubermaticerrors.New(http.StatusBadRequest, err.Error()))
+			return
+		}
+
+		// The endpoint the middleware is called with is the innermost one, hence we must
+		// define it as closure and pass it to the middleware() call below.
+		ep := func(ctx context.Context, request interface{}) (interface{}, error) {
+			// Simple redirect in case proxy call path does not end with trailing slash
+			if strings.HasSuffix(r.URL.Path, "proxy") {
+				http.Redirect(w, r, r.URL.Path+"/", http.StatusFound)
+				return nil, nil
+			}
+
+			userCluster, clusterProvider, err := cluster.GetClusterProviderFromRequest(ctx, request, projectProvider)
+			userInfo := ctx.Value(middleware.UserInfoContextKey).(*provider.UserInfo)
+			if err != nil {
+				common.WriteHTTPError(log, w, err)
+				return nil, nil
+			}
+
+			adminClientCfg, err := clusterProvider.GetAdminKubeconfigForCustomerCluster(userCluster)
+			if err != nil {
+				common.WriteHTTPError(log, w, err)
+				return nil, nil
+			}
+
+			if !strings.HasPrefix(userInfo.Group, "editors") && !strings.HasPrefix(userInfo.Group, "owners") {
+				common.WriteHTTPError(log, w, kubermaticerrors.New(http.StatusBadRequest, fmt.Sprintf("user %q does not belong to the owners|editors group", userInfo.Email)))
+				return nil, nil
+			}
+
+			token, err := extractBearerToken(adminClientCfg)
+			if err != nil {
+				common.WriteHTTPError(log, w, err)
+				return nil, nil
+			}
+
+			log = log.With("cluster", userCluster.Name)
+
+			// Ideally we would cache these to not open a port for every single request
+			portforwarder, outBuffer, err := common.GetPortForwarder(
+				clusterProvider.GetSeedClusterAdminClient().CoreV1(),
+				clusterProvider.SeedAdminConfig(),
+				userCluster.Status.NamespaceName,
+				kubernetesdashboard.AppLabel,
+				kubernetesdashboard.ContainerPort)
+			if err != nil {
+				return nil, fmt.Errorf("failed to get portforwarder for console: %v", err)
+			}
+			defer portforwarder.Close()
+
+			if err = forwardPort(log, portforwarder); err != nil {
+				common.WriteHTTPError(log, w, err)
+				return nil, nil
+			}
+
+			port, err := common.GetLocalPortFromPortForwardOutput(outBuffer.String())
+			if err != nil {
+				common.WriteHTTPError(log, w, fmt.Errorf("failed to get backend port: %v", err))
+				return nil, nil
+			}
+
+			proxyUrl := &url.URL{
+				Scheme: "http",
+				Host:   fmt.Sprintf("127.0.0.1:%d", port),
+			}
+
+			// Override strict CSP policy for proxy
+			w.Header().Set("Content-Security-Policy", "default-src 'self'; script-src 'self' 'unsafe-inline'; object-src 'self'; style-src 'self' 'unsafe-inline'; img-src 'self'; media-src 'self'; frame-ancestors 'self'; frame-src 'self'; connect-src 'self'; font-src 'self' data:")
+
+			// Proxy the request
+			proxy := httputil.NewSingleHostReverseProxy(proxyUrl)
+			proxy.Director = newDashboardProxyDirector(proxyUrl, token, r).director()
+			proxy.ServeHTTP(w, r)
+
+			return nil, nil
+		}
+
+		if _, err := middlewares(ep)(ctx, request); err != nil {
+			common.WriteHTTPError(log, w, err)
+			return
+		}
+	})
+}
+
+// It's responsible for adjusting proxy request, so we can properly access Kubernetes Dashboard
+type dashboardProxyDirector struct {
+	proxyUrl        *url.URL
+	token           string
+	originalRequest *http.Request
+}
+
+func (self *dashboardProxyDirector) director() func(*http.Request) {
+	return func(req *http.Request) {
+		req.URL.Scheme = self.proxyUrl.Scheme
+		req.URL.Host = self.proxyUrl.Host
+		req.URL.Path = self.getBasePath(self.originalRequest.URL.Path)
+
+		req.Header.Set("Authorization", self.getAuthorizationHeader())
+	}
+}
+
+func (self *dashboardProxyDirector) getAuthorizationHeader() string {
+	return fmt.Sprintf("Bearer %s", self.token)
+}
+
+// We need to get proper path to Dashboard API and strip the URL from the Kubermatic API request part.
+func (self *dashboardProxyDirector) getBasePath(path string) string {
+	separator := "proxy"
+	if !strings.Contains(path, separator) {
+		return "/"
+	}
+
+	parts := strings.Split(path, separator)
+	if len(parts) != 2 {
+		return "/"
+	}
+
+	return parts[1]
+}
+
+func newDashboardProxyDirector(proxyUrl *url.URL, token string, request *http.Request) *dashboardProxyDirector {
+	return &dashboardProxyDirector{
+		proxyUrl:        proxyUrl,
+		token:           token,
+		originalRequest: request,
+	}
+}
+
+func extractBearerToken(kubeconfig *api.Config) (string, error) {
+	for _, info := range kubeconfig.AuthInfos {
+		if len(info.Token) > 0 {
+			return info.Token, nil
+		}
+	}
+
+	return "", errors.New("could not find bearer token in kubeconfig file")
+}
+
+func forwardPort(log *zap.SugaredLogger, forwarder *portforward.PortForwarder) error {
+	// This is blocking so we have to do it in a distinct goroutine
+	errorChan := make(chan error)
+	go func() {
+		log.Debug("Starting to forward port")
+		if err := forwarder.ForwardPorts(); err != nil {
+			errorChan <- err
+		}
+	}()
+
+	if err := common.WaitForPortForwarder(forwarder, errorChan); err != nil {
+		return err
+	}
+
+	return nil
+}

--- a/api/pkg/handler/v1/openshift/openshift.go
+++ b/api/pkg/handler/v1/openshift/openshift.go
@@ -125,18 +125,11 @@ func ConsoleProxyEndpoint(
 			}
 			defer portforwarder.Close()
 
-			// This is blocking so we have to do it in a distinct goroutine
-			errorChan := make(chan error)
-			go func() {
-				log.Debug("Starting to forward port")
-				if err := portforwarder.ForwardPorts(); err != nil {
-					errorChan <- err
-				}
-			}()
-			if err := common.WaitForPortForwarder(portforwarder, errorChan); err != nil {
+			if err = common.ForwardPort(log, portforwarder); err != nil {
 				common.WriteHTTPError(log, w, err)
 				return nil, nil
 			}
+
 			// PortForwarder does have a `GetPorts` but its plain broken in case the portforwarder picks
 			// a random port and always returns 0.
 			// TODO @alvaroaleman: Fix upstream

--- a/api/pkg/handler/v1/openshift/openshift.go
+++ b/api/pkg/handler/v1/openshift/openshift.go
@@ -1,7 +1,6 @@
 package openshift
 
 import (
-	"bytes"
 	"context"
 	"crypto/rand"
 	"crypto/tls"
@@ -11,9 +10,7 @@ import (
 	"net/http"
 	"net/http/httputil"
 	"net/url"
-	"strconv"
 	"strings"
-	"time"
 
 	"github.com/go-kit/kit/endpoint"
 	transporthttp "github.com/go-kit/kit/transport/http"
@@ -25,17 +22,10 @@ import (
 	"github.com/kubermatic/kubermatic/api/pkg/handler/v1/cluster"
 	"github.com/kubermatic/kubermatic/api/pkg/handler/v1/common"
 	"github.com/kubermatic/kubermatic/api/pkg/provider"
-	kubernetesprovider "github.com/kubermatic/kubermatic/api/pkg/provider/kubernetes"
 	kubermaticerrors "github.com/kubermatic/kubermatic/api/pkg/util/errors"
 
 	corev1 "k8s.io/api/core/v1"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
-	"k8s.io/apimachinery/pkg/util/httpstream"
-	corev1interface "k8s.io/client-go/kubernetes/typed/core/v1"
-	"k8s.io/client-go/rest"
-	"k8s.io/client-go/tools/portforward"
-	"k8s.io/client-go/transport/spdy"
 	ctrlruntimeclient "sigs.k8s.io/controller-runtime/pkg/client"
 )
 
@@ -60,35 +50,35 @@ func ConsoleLoginEndpoint(
 		ctx := extractor(r.Context(), r)
 		request, err := common.DecodeGetClusterReq(ctx, r)
 		if err != nil {
-			writeHTTPError(log, w, kubermaticerrors.New(http.StatusBadRequest, err.Error()))
+			common.WriteHTTPError(log, w, kubermaticerrors.New(http.StatusBadRequest, err.Error()))
 			return
 		}
 
 		// The endpoint the middleware is called with is the innermost one, hence we must
 		// define it as closure and pass it to the middleware() call below.
 		endpoint := func(ctx context.Context, request interface{}) (interface{}, error) {
-			cluster, clusterProvider, err := getClusterProviderFromRequest(ctx, request, projectProvider)
+			cluster, clusterProvider, err := cluster.GetClusterProviderFromRequest(ctx, request, projectProvider)
 			if err != nil {
-				writeHTTPError(log, w, err)
+				common.WriteHTTPError(log, w, err)
 				return nil, nil
 			}
 			log = log.With("cluster", cluster.Name)
 
 			userInfo, ok := ctx.Value(middleware.UserInfoContextKey).(*provider.UserInfo)
 			if !ok {
-				writeHTTPError(log, w, kubermaticerrors.New(http.StatusInternalServerError, "couldn't get userInfo"))
+				common.WriteHTTPError(log, w, kubermaticerrors.New(http.StatusInternalServerError, "couldn't get userInfo"))
 				return nil, nil
 			}
 			if strings.HasPrefix(userInfo.Group, "editors") || strings.HasPrefix(userInfo.Group, "owners") {
 				consoleLogin(ctx, log, w, cluster, clusterProvider.GetSeedClusterAdminRuntimeClient(), r)
 			} else {
-				writeHTTPError(log, w, kubermaticerrors.New(http.StatusBadRequest, fmt.Sprintf("user %q does not belong to the editors group", userInfo.Email)))
+				common.WriteHTTPError(log, w, kubermaticerrors.New(http.StatusBadRequest, fmt.Sprintf("user %q does not belong to the editors group", userInfo.Email)))
 			}
 
 			return nil, nil
 		}
 		if _, err := middlewares(endpoint)(ctx, request); err != nil {
-			writeHTTPError(log, w, err)
+			common.WriteHTTPError(log, w, err)
 			return
 		}
 	})
@@ -108,27 +98,28 @@ func ConsoleProxyEndpoint(
 		ctx := extractor(r.Context(), r)
 		request, err := common.DecodeGetClusterReq(ctx, r)
 		if err != nil {
-			writeHTTPError(log, w, kubermaticerrors.New(http.StatusBadRequest, err.Error()))
+			common.WriteHTTPError(log, w, kubermaticerrors.New(http.StatusBadRequest, err.Error()))
 			return
 		}
 
 		// The endpoint the middleware is called with is the innermost one, hence we must
 		// define it as closure and pass it to the middleware() call below.
 		endpoint := func(ctx context.Context, request interface{}) (interface{}, error) {
-			cluster, clusterProvider, err := getClusterProviderFromRequest(ctx, request, projectProvider)
+			cluster, clusterProvider, err := cluster.GetClusterProviderFromRequest(ctx, request, projectProvider)
 			if err != nil {
-				writeHTTPError(log, w, err)
+				common.WriteHTTPError(log, w, err)
 				return nil, nil
 			}
 			log = log.With("cluster", cluster.Name)
 
 			// Ideally we would cache these to not open a port for every single request
-			portforwarder, outBuffer, err := consolePortForwarder(
-				ctx,
-				log,
+			portforwarder, outBuffer, err := common.GetPortForwarder(
 				clusterProvider.GetSeedClusterAdminClient().CoreV1(),
 				clusterProvider.SeedAdminConfig(),
-				cluster)
+				cluster.Status.NamespaceName,
+				// TODO: Export the labelselector from the openshift resources
+				"app=openshift-console",
+				openshiftresources.ConsoleListenPort)
 			if err != nil {
 				return nil, fmt.Errorf("failed to get portforwarder for console: %v", err)
 			}
@@ -142,21 +133,21 @@ func ConsoleProxyEndpoint(
 					errorChan <- err
 				}
 			}()
-			if err := waitForPortForwarder(portforwarder, errorChan); err != nil {
-				writeHTTPError(log, w, err)
+			if err := common.WaitForPortForwarder(portforwarder, errorChan); err != nil {
+				common.WriteHTTPError(log, w, err)
 				return nil, nil
 			}
 			// PortForwarder does have a `GetPorts` but its plain broken in case the portforwarder picks
 			// a random port and always returns 0.
 			// TODO @alvaroaleman: Fix upstream
-			port, err := getLocalPortFromPortForwardOutput(outBuffer.String())
+			port, err := common.GetLocalPortFromPortForwardOutput(outBuffer.String())
 			if err != nil {
-				writeHTTPError(log, w, fmt.Errorf("failed to get backend port: %v", err))
+				common.WriteHTTPError(log, w, fmt.Errorf("failed to get backend port: %v", err))
 				return nil, nil
 			}
 			url, err := url.Parse(fmt.Sprintf("http://127.0.0.1:%d", port))
 			if err != nil {
-				writeHTTPError(log, w, fmt.Errorf("failed to parse backend url: %v", err))
+				common.WriteHTTPError(log, w, fmt.Errorf("failed to parse backend url: %v", err))
 				return nil, nil
 			}
 
@@ -171,7 +162,7 @@ func ConsoleProxyEndpoint(
 		}
 
 		if _, err := middlewares(endpoint)(ctx, request); err != nil {
-			writeHTTPError(log, w, err)
+			common.WriteHTTPError(log, w, err)
 			return
 		}
 	})
@@ -200,11 +191,11 @@ func consoleLogin(
 	}
 	oauthService := &corev1.Service{}
 	if err := seedClient.Get(ctx, oauthServiceName, oauthService); err != nil {
-		writeHTTPError(log, w, fmt.Errorf("failed to retrieve oauth service: %v", err))
+		common.WriteHTTPError(log, w, fmt.Errorf("failed to retrieve oauth service: %v", err))
 		return
 	}
 	if n := len(oauthService.Spec.Ports); n != 1 {
-		writeHTTPError(log, w, fmt.Errorf("OAuth service doesn't have exactly one port but %d", n))
+		common.WriteHTTPError(log, w, fmt.Errorf("OAuth service doesn't have exactly one port but %d", n))
 		return
 	}
 	oauthPort := oauthService.Spec.Ports[0].NodePort
@@ -215,18 +206,18 @@ func consoleLogin(
 	}
 	oauthPasswordSecret := &corev1.Secret{}
 	if err := seedClient.Get(ctx, oauthPasswordSecretName, oauthPasswordSecret); err != nil {
-		writeHTTPError(log, w, fmt.Errorf("failed to get OAuth credential secret: %v", err))
+		common.WriteHTTPError(log, w, fmt.Errorf("failed to get OAuth credential secret: %v", err))
 		return
 	}
 	oauthPassword := string(oauthPasswordSecret.Data[openshiftresources.ConsoleAdminUserName])
 	if oauthPassword == "" {
-		writeHTTPError(log, w, errors.New("no OAuth password found"))
+		common.WriteHTTPError(log, w, errors.New("no OAuth password found"))
 		return
 	}
 
 	oauthStateValue, err := generateRandomOauthState()
 	if err != nil {
-		writeHTTPError(log, w, fmt.Errorf("failed to get oauth state token: %v", err))
+		common.WriteHTTPError(log, w, fmt.Errorf("failed to get oauth state token: %v", err))
 		return
 	}
 
@@ -239,34 +230,34 @@ func consoleLogin(
 	// TODO: Should we put that into cluster.Address?
 	oauthURL, err := url.Parse(fmt.Sprintf("https://%s:%d/oauth/authorize", cluster.Address.ExternalName, oauthPort))
 	if err != nil {
-		writeHTTPError(log, w, fmt.Errorf("failed to parse oauth url: %v", err))
+		common.WriteHTTPError(log, w, fmt.Errorf("failed to parse oauth url: %v", err))
 		return
 	}
 	oauthURL.RawQuery = queryArgs.Encode()
 
 	oauthRequest, err := http.NewRequest(http.MethodGet, oauthURL.String(), nil)
 	if err != nil {
-		writeHTTPError(log, w, fmt.Errorf("failed to construct query for oauthRequest: %v", err))
+		common.WriteHTTPError(log, w, fmt.Errorf("failed to construct query for oauthRequest: %v", err))
 		return
 	}
 	oauthRequest.SetBasicAuth(openshiftresources.ConsoleAdminUserName, oauthPassword)
 
 	resp, err := httpRequestOAuthClient().Do(oauthRequest)
 	if err != nil {
-		writeHTTPError(log, w, fmt.Errorf("failed to get oauth code: %v", err))
+		common.WriteHTTPError(log, w, fmt.Errorf("failed to get oauth code: %v", err))
 		return
 	}
 	defer resp.Body.Close()
 
 	redirectURL, err := resp.Location()
 	if err != nil {
-		writeHTTPError(log, w, fmt.Errorf("failed to get redirectURL: %v", err))
+		common.WriteHTTPError(log, w, fmt.Errorf("failed to get redirectURL: %v", err))
 		return
 	}
 
 	oauthCode := redirectURL.Query().Get("code")
 	if oauthCode == "" {
-		writeHTTPError(log, w, errors.New("did not get an OAuth code back from Openshift OAuth server"))
+		common.WriteHTTPError(log, w, errors.New("did not get an OAuth code back from Openshift OAuth server"))
 	}
 	// We don't check this here again. If something is wrong with it, Openshift will complain
 	returnedOAuthState := redirectURL.Query().Get("state")
@@ -280,7 +271,7 @@ func consoleLogin(
 	redirectTargetURLRaw := strings.Replace(initialRequest.URL.Path, "login", "proxy/auth/callback", 1)
 	redirectTargetURL, err := url.Parse(redirectTargetURLRaw)
 	if err != nil {
-		writeHTTPError(log, w, fmt.Errorf("failed to parse target redirect URL: %v", err))
+		common.WriteHTTPError(log, w, fmt.Errorf("failed to parse target redirect URL: %v", err))
 		return
 	}
 	redirectTargetURL.RawQuery = redirectQueryArgs.Encode()
@@ -300,23 +291,6 @@ func generateRandomOauthState() (string, error) {
 	return base64.URLEncoding.EncodeToString(b), nil
 }
 
-// writeHTTPError writes an http error out. If debug is enabled, it also gets logged.
-func writeHTTPError(log *zap.SugaredLogger, w http.ResponseWriter, err error) {
-	log.Debugw("Encountered error", zap.Error(err))
-	var httpErr kubermaticerrors.HTTPError
-
-	if asserted, ok := err.(kubermaticerrors.HTTPError); ok {
-		httpErr = asserted
-	} else {
-		httpErr = kubermaticerrors.New(http.StatusInternalServerError, err.Error())
-	}
-
-	w.WriteHeader(httpErr.StatusCode())
-	if _, wErr := w.Write([]byte(httpErr.Error())); wErr != nil {
-		log.Errorw("Failed to write body", zap.Error(err))
-	}
-}
-
 // httpRequestOAuthClient is used to perform the OAuth request.
 // it needs some special settings.
 func httpRequestOAuthClient() *http.Client {
@@ -332,150 +306,4 @@ func httpRequestOAuthClient() *http.Client {
 			return http.ErrUseLastResponse
 		},
 	}
-}
-
-// While it is tempting to write our own roundTripper to do all the reading/writing
-// in memory intead of opening a TCP port it has some drawbacks:
-// * net/http.ReadResponse does not work with websockets, because its body is hardcoded to be an
-//   io.ReadCloster and not an io.ReadWriteCloser:
-//   * https://github.com/golang/go/blob/361ab73305788c4bf35359a02d8873c36d654f1b/src/net/http/transfer.go#L550
-//   * https://github.com/golang/go/blob/361ab73305788c4bf35359a02d8873c36d654f1b/src/net/http/httputil/reverseproxy.go#L518
-// * RoundTripping is a bit more complicated than just read and write, mimicking that badly is likely
-//   to be more expensive than doing the extra round via the TCP socket:
-//   https://github.com/golang/go/blob/361ab73305788c4bf35359a02d8873c36d654f1b/src/net/http/transport.go#L454
-func consolePortForwarder(
-	ctx context.Context,
-	log *zap.SugaredLogger,
-	corev1Client corev1interface.CoreV1Interface,
-	cfg *rest.Config,
-	cluster *kubermaticv1.Cluster) (*portforward.PortForwarder, *bytes.Buffer, error) {
-
-	consolePod, err := getReadyOpenshiftConsolePod(corev1Client.Pods(cluster.Status.NamespaceName))
-	if err != nil {
-		return nil, nil, err
-	}
-
-	dealer, err := getDialerForPod(consolePod, corev1Client.RESTClient(), cfg)
-	if err != nil {
-		return nil, nil, err
-	}
-
-	readyChan := make(chan struct{})
-	stopChan := make(chan struct{})
-	errorBuffer := bytes.NewBuffer(make([]byte, 1024))
-	outBuffer := bytes.NewBuffer(make([]byte, 1024))
-	portforwarder, err := portforward.NewOnAddresses(dealer, []string{"127.0.0.1"}, []string{"0:" + strconv.Itoa(openshiftresources.ConsoleListenPort)}, stopChan, readyChan, outBuffer, errorBuffer)
-	if err != nil {
-		return nil, nil, fmt.Errorf("failed to create portforwarder: %v", err)
-	}
-	// Portforwarding is blocking, so we can't do it here
-	return portforwarder, outBuffer, nil
-}
-
-func getDialerForPod(
-	pod *corev1.Pod,
-	restClient rest.Interface,
-	cfg *rest.Config) (httpstream.Dialer, error) {
-
-	// The logic here is copied straight from kubectl at
-	// https://github.com/kubernetes/kubernetes/blob/b88662505d288297750becf968bf307dacf872fa/staging/src/k8s.io/kubectl/pkg/cmd/portforward/portforward.go#L334
-	req := restClient.Post().
-		Resource("pods").
-		Namespace(pod.Namespace).
-		Name(pod.Name).
-		SubResource("portforward")
-
-	transport, upgrader, err := spdy.RoundTripperFor(cfg)
-	if err != nil {
-		return nil, fmt.Errorf("failed to get spdy roundTripper: %v", err)
-	}
-
-	return spdy.NewDialer(upgrader, &http.Client{Transport: transport}, http.MethodPost, req.URL()), nil
-}
-
-func getReadyOpenshiftConsolePod(client corev1interface.PodInterface) (*corev1.Pod, error) {
-	// TODO: Export the labelselector from the openshift resources
-	consolePods, err := client.List(metav1.ListOptions{LabelSelector: "app=openshift-console"})
-	if err != nil {
-		return nil, fmt.Errorf("failed to get openshift console pod: %v", err)
-	}
-
-	readyConsolePods := getReadyPods(consolePods)
-	if len(readyConsolePods.Items) < 1 {
-		return nil, kubermaticerrors.New(http.StatusBadRequest, "openshift console is not ready")
-	}
-
-	return &readyConsolePods.Items[0], nil
-}
-
-func getReadyPods(pods *corev1.PodList) *corev1.PodList {
-	res := &corev1.PodList{}
-	for _, pod := range pods.Items {
-		if isPodReady(pod) {
-			res.Items = append(res.Items, pod)
-		}
-	}
-	return res
-}
-
-func isPodReady(pod corev1.Pod) bool {
-	for _, condition := range pod.Status.Conditions {
-		if condition.Type == corev1.PodReady {
-			return condition.Status == corev1.ConditionTrue
-		}
-	}
-	return false
-}
-
-func waitForPortForwarder(p *portforward.PortForwarder, errChan <-chan error) error {
-	timeout := time.After(10 * time.Second)
-	select {
-	case <-timeout:
-		return errors.New("timeout waiting for backend connection")
-	case err := <-errChan:
-		return fmt.Errorf("failed to get connection to backend: %v", err)
-	case <-p.Ready:
-		return nil
-	}
-}
-
-func getLocalPortFromPortForwardOutput(out string) (int, error) {
-	colonSplit := strings.Split(out, ":")
-	if n := len(colonSplit); n < 2 {
-		return 0, fmt.Errorf("expected at least two results when splitting by colon, got %d", n)
-	}
-	spaceSplit := strings.Split(colonSplit[1], " ")
-	if n := len(spaceSplit); n < 1 {
-		return 0, fmt.Errorf("expected at least one result when splitting by space, got %d", n)
-	}
-	result, err := strconv.Atoi(spaceSplit[0])
-	if err != nil {
-		return 0, fmt.Errorf("failed to parse int: %v", err)
-	}
-	return result, nil
-}
-
-func getClusterProviderFromRequest(
-	ctx context.Context,
-	request interface{},
-	projectProvider provider.ProjectProvider) (*kubermaticv1.Cluster, *kubernetesprovider.ClusterProvider, error) {
-
-	req, ok := request.(common.GetClusterReq)
-	if !ok {
-		return nil, nil, kubermaticerrors.New(http.StatusBadRequest, "invalid request")
-	}
-	cluster, err := cluster.GetCluster(ctx, req, projectProvider)
-	if err != nil {
-		return nil, nil, kubermaticerrors.New(http.StatusInternalServerError, err.Error())
-	}
-
-	rawClusterProvider, ok := ctx.Value(middleware.PrivilegedClusterProviderContextKey).(provider.PrivilegedClusterProvider)
-	if !ok {
-		return nil, nil, kubermaticerrors.New(http.StatusInternalServerError, "no clusterProvider in request")
-	}
-	clusterProvider, ok := rawClusterProvider.(*kubernetesprovider.ClusterProvider)
-	if !ok {
-		return nil, nil, kubermaticerrors.New(http.StatusInternalServerError, "failed to assert clusterProvider")
-	}
-	return cluster, clusterProvider, nil
 }

--- a/api/pkg/resources/kubernetes-dashboard/deployment.go
+++ b/api/pkg/resources/kubernetes-dashboard/deployment.go
@@ -34,7 +34,9 @@ const (
 	imageName = "kubernetesui/dashboard"
 	tag       = "v2.0.0-beta4"
 	// Namespace used by Dashboard to find required resources.
-	namespace = "kubernetes-dashboard"
+	namespace     = "kubernetes-dashboard"
+	ContainerPort = 9090
+	AppLabel      = resources.AppLabelKey + "=" + name
 )
 
 // kubernetesDashboardData is the data needed to construct the Kubernetes Dashboard components
@@ -106,7 +108,7 @@ func getContainers(data kubernetesDashboardData) []corev1.Container {
 			},
 			Ports: []corev1.ContainerPort{
 				{
-					ContainerPort: 9090,
+					ContainerPort: ContainerPort,
 					Protocol:      corev1.ProtocolTCP,
 				},
 			},


### PR DESCRIPTION
**What this PR does / why we need it**:
It adds a new endpoint that allows access to Kubernetes Dashboard installed for the user cluster. Access will be limited to owners and editors of the project and they will be granted admin privileges in the Kubernetes Dashboard. Later on, we will reuse RBAC for the user clusters feature to limit the privileges.

`/projects/{project_id}/dc/{dc}/clusters/{cluster_id}/dashboard/proxy`

**Special notes for your reviewer**:
I have cleaned up some code and moved it so it can be reused by the dashboard proxy.

**Does this PR introduce a user-facing change?**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If  no release note is required, just write "NONE".
-->
```release-note
Add a new proxy endpoint to access Kubernetes Dashboard for the user cluster.
```
