### PR TITLE
refactor DatacenterFromSeedMap to use SeedsGetter

### DIFF
--- a/api/pkg/handler/v1/node/node.go
+++ b/api/pkg/handler/v1/node/node.go
@@ -10,7 +10,7 @@ import (
 	"time"
 
 	"github.com/Masterminds/semver"
-	"github.com/evanphx/json-patch"
+	jsonpatch "github.com/evanphx/json-patch"
 	"github.com/go-kit/kit/endpoint"
 	"github.com/gorilla/mux"
 
@@ -105,11 +105,7 @@ func CreateNodeDeployment(sshKeyProvider provider.SSHKeyProvider, projectProvide
 			return nil, common.KubernetesErrorToHTTPError(err)
 		}
 
-		seeds, err := seedsGetter()
-		if err != nil {
-			return apiv1.Datacenter{}, k8cerrors.New(http.StatusInternalServerError, fmt.Sprintf("failed to list seeds: %v", err))
-		}
-		_, dc, err := provider.DatacenterFromSeedMap(seeds, cluster.Spec.Cloud.DatacenterName)
+		_, dc, err := provider.DatacenterFromSeedMap(seedsGetter, cluster.Spec.Cloud.DatacenterName)
 		if err != nil {
 			return nil, fmt.Errorf("error getting dc: %v", err)
 		}
@@ -690,11 +686,7 @@ func PatchNodeDeployment(sshKeyProvider provider.SSHKeyProvider, projectProvider
 			return nil, k8cerrors.NewBadRequest(err.Error())
 		}
 
-		seeds, err := seedsGetter()
-		if err != nil {
-			return apiv1.Datacenter{}, k8cerrors.New(http.StatusInternalServerError, fmt.Sprintf("failed to list seeds: %v", err))
-		}
-		_, dc, err := provider.DatacenterFromSeedMap(seeds, cluster.Spec.Cloud.DatacenterName)
+		_, dc, err := provider.DatacenterFromSeedMap(seedsGetter, cluster.Spec.Cloud.DatacenterName)
 		if err != nil {
 			return nil, fmt.Errorf("error getting dc: %v", err)
 		}

--- a/api/pkg/handler/v1/provider/aws.go
+++ b/api/pkg/handler/v1/provider/aws.go
@@ -224,11 +224,7 @@ func AWSSubnetEndpoint(credentialManager common.PresetsManager, seedsGetter prov
 			}
 		}
 
-		seeds, err := seedsGetter()
-		if err != nil {
-			return nil, errors.New(http.StatusInternalServerError, fmt.Sprintf("failed to list seeds: %v", err))
-		}
-		_, dc, err := provider.DatacenterFromSeedMap(seeds, req.DC)
+		_, dc, err := provider.DatacenterFromSeedMap(seedsGetter, req.DC)
 		if err != nil {
 			return nil, errors.NewBadRequest(err.Error())
 		}
@@ -255,11 +251,7 @@ func AWSSubnetWithClusterCredentialsEndpoint(projectProvider provider.ProjectPro
 			return nil, errors.NewNotFound("cloud spec for ", req.ClusterID)
 		}
 
-		seeds, err := seedsGetter()
-		if err != nil {
-			return nil, errors.New(http.StatusInternalServerError, fmt.Sprintf("failed to list seeds: %v", err))
-		}
-		_, dc, err := provider.DatacenterFromSeedMap(seeds, cluster.Spec.Cloud.DatacenterName)
+		_, dc, err := provider.DatacenterFromSeedMap(seedsGetter, cluster.Spec.Cloud.DatacenterName)
 		if err != nil {
 			return nil, errors.NewBadRequest(err.Error())
 		}
@@ -354,11 +346,7 @@ func AWSVPCEndpoint(credentialManager common.PresetsManager, seedsGetter provide
 			}
 		}
 
-		seeds, err := seedsGetter()
-		if err != nil {
-			return nil, errors.New(http.StatusInternalServerError, fmt.Sprintf("failed to list seeds: %v", err))
-		}
-		_, datacenter, err := provider.DatacenterFromSeedMap(seeds, req.DC)
+		_, datacenter, err := provider.DatacenterFromSeedMap(seedsGetter, req.DC)
 		if err != nil {
 			return nil, errors.NewBadRequest(err.Error())
 		}

--- a/api/pkg/handler/v1/provider/openstack.go
+++ b/api/pkg/handler/v1/provider/openstack.go
@@ -28,13 +28,8 @@ func OpenstackSizeEndpoint(seedsGetter provider.SeedsGetter, credentialManager c
 			return nil, errors.New(http.StatusInternalServerError, "can not get user info")
 		}
 
-		seeds, err := seedsGetter()
-		if err != nil {
-			return nil, errors.New(http.StatusInternalServerError, fmt.Sprintf("failed to list seeds: %v", err))
-		}
-
 		datacenterName := req.DatacenterName
-		_, datacenter, err := provider.DatacenterFromSeedMap(seeds, datacenterName)
+		_, datacenter, err := provider.DatacenterFromSeedMap(seedsGetter, datacenterName)
 		if err != nil {
 			return nil, fmt.Errorf("error getting dc: %v", err)
 		}
@@ -57,12 +52,7 @@ func OpenstackSizeWithClusterCredentialsEndpoint(projectProvider provider.Projec
 
 		datacenterName := cluster.Spec.Cloud.DatacenterName
 
-		seeds, err := seedsGetter()
-		if err != nil {
-			return nil, errors.New(http.StatusInternalServerError, fmt.Sprintf("failed to list seeds: %v", err))
-		}
-
-		_, datacenter, err := provider.DatacenterFromSeedMap(seeds, datacenterName)
+		_, datacenter, err := provider.DatacenterFromSeedMap(seedsGetter, datacenterName)
 		if err != nil {
 			return nil, fmt.Errorf("error getting dc: %v", err)
 		}
@@ -162,12 +152,7 @@ func OpenstackTenantWithClusterCredentialsEndpoint(projectProvider provider.Proj
 }
 
 func getOpenstackTenants(seedsGetter provider.SeedsGetter, username, password, domain, tenant, tenantID, datacenterName string) ([]apiv1.OpenstackTenant, error) {
-	seeds, err := seedsGetter()
-	if err != nil {
-		return nil, errors.New(http.StatusInternalServerError, fmt.Sprintf("failed to list seeds: %v", err))
-	}
-
-	authURL, region, err := getOpenstackAuthURLAndRegion(seeds, datacenterName)
+	authURL, region, err := getOpenstackAuthURLAndRegion(seedsGetter, datacenterName)
 	if err != nil {
 		return nil, err
 	}
@@ -234,12 +219,7 @@ func OpenstackNetworkWithClusterCredentialsEndpoint(projectProvider provider.Pro
 }
 
 func getOpenstackNetworks(seedsGetter provider.SeedsGetter, username, password, tenant, tenantID, domain, datacenterName string) ([]apiv1.OpenstackNetwork, error) {
-	seeds, err := seedsGetter()
-	if err != nil {
-		return nil, errors.New(http.StatusInternalServerError, fmt.Sprintf("failed to list seeds: %v", err))
-	}
-
-	authURL, region, err := getOpenstackAuthURLAndRegion(seeds, datacenterName)
+	authURL, region, err := getOpenstackAuthURLAndRegion(seedsGetter, datacenterName)
 	if err != nil {
 		return nil, err
 	}
@@ -307,12 +287,7 @@ func OpenstackSecurityGroupWithClusterCredentialsEndpoint(projectProvider provid
 }
 
 func getOpenstackSecurityGroups(seedsGetter provider.SeedsGetter, username, password, tenant, tenantID, domain, datacenterName string) ([]apiv1.OpenstackSecurityGroup, error) {
-	seeds, err := seedsGetter()
-	if err != nil {
-		return nil, errors.New(http.StatusInternalServerError, fmt.Sprintf("failed to list seeds: %v", err))
-	}
-
-	authURL, region, err := getOpenstackAuthURLAndRegion(seeds, datacenterName)
+	authURL, region, err := getOpenstackAuthURLAndRegion(seedsGetter, datacenterName)
 	if err != nil {
 		return nil, err
 	}
@@ -379,12 +354,7 @@ func OpenstackSubnetsWithClusterCredentialsEndpoint(projectProvider provider.Pro
 }
 
 func getOpenstackSubnets(seedsGetter provider.SeedsGetter, username, password, domain, tenant, tenantID, networkID, datacenterName string) ([]apiv1.OpenstackSubnet, error) {
-	seeds, err := seedsGetter()
-	if err != nil {
-		return nil, errors.New(http.StatusInternalServerError, fmt.Sprintf("failed to list seeds: %v", err))
-	}
-
-	authURL, region, err := getOpenstackAuthURLAndRegion(seeds, datacenterName)
+	authURL, region, err := getOpenstackAuthURLAndRegion(seedsGetter, datacenterName)
 	if err != nil {
 		return nil, err
 	}
@@ -549,8 +519,8 @@ func getOpenstackCredentials(userInfo *provider.UserInfo, credentialName, userna
 	return username, password, domain, tenant, tenantID, nil
 }
 
-func getOpenstackAuthURLAndRegion(seeds map[string]*kubermaticv1.Seed, datacenterName string) (string, string, error) {
-	_, dc, err := provider.DatacenterFromSeedMap(seeds, datacenterName)
+func getOpenstackAuthURLAndRegion(seedsGetter provider.SeedsGetter, datacenterName string) (string, string, error) {
+	_, dc, err := provider.DatacenterFromSeedMap(seedsGetter, datacenterName)
 	if err != nil {
 		return "", "", fmt.Errorf("failed to find datacenter %q: %v", datacenterName, err)
 	}

--- a/api/pkg/handler/v1/provider/vsphere.go
+++ b/api/pkg/handler/v1/provider/vsphere.go
@@ -69,11 +69,7 @@ func VsphereNetworksWithClusterCredentialsEndpoint(projectProvider provider.Proj
 		}
 		secretKeySelector := provider.SecretKeySelectorValueFuncFactory(ctx, assertedClusterProvider.GetSeedClusterAdminRuntimeClient())
 
-		seeds, err := seedsGetter()
-		if err != nil {
-			return nil, errors.New(http.StatusInternalServerError, fmt.Sprintf("failed to list seeds: %v", err))
-		}
-		_, datacenter, err := provider.DatacenterFromSeedMap(seeds, datacenterName)
+		_, datacenter, err := provider.DatacenterFromSeedMap(seedsGetter, datacenterName)
 		if err != nil {
 			return nil, fmt.Errorf("failed to find Datacenter %q: %v", datacenterName, err)
 		}
@@ -87,11 +83,7 @@ func VsphereNetworksWithClusterCredentialsEndpoint(projectProvider provider.Proj
 }
 
 func getVsphereNetworks(seedsGetter provider.SeedsGetter, username, password, datacenterName string) ([]apiv1.VSphereNetwork, error) {
-	seeds, err := seedsGetter()
-	if err != nil {
-		return nil, errors.New(http.StatusInternalServerError, fmt.Sprintf("failed to list seeds: %v", err))
-	}
-	_, datacenter, err := provider.DatacenterFromSeedMap(seeds, datacenterName)
+	_, datacenter, err := provider.DatacenterFromSeedMap(seedsGetter, datacenterName)
 	if err != nil {
 		return nil, fmt.Errorf("failed to find Datacenter %q: %v", datacenterName, err)
 	}
@@ -166,11 +158,7 @@ func VsphereFoldersWithClusterCredentialsEndpoint(projectProvider provider.Proje
 		}
 		secretKeySelector := provider.SecretKeySelectorValueFuncFactory(ctx, assertedClusterProvider.GetSeedClusterAdminRuntimeClient())
 
-		seeds, err := seedsGetter()
-		if err != nil {
-			return nil, errors.New(http.StatusInternalServerError, fmt.Sprintf("failed to list seeds: %v", err))
-		}
-		_, datacenter, err := provider.DatacenterFromSeedMap(seeds, datacenterName)
+		_, datacenter, err := provider.DatacenterFromSeedMap(seedsGetter, datacenterName)
 		if err != nil {
 			return nil, fmt.Errorf("failed to find Datacenter %q: %v", datacenterName, err)
 		}
@@ -184,11 +172,7 @@ func VsphereFoldersWithClusterCredentialsEndpoint(projectProvider provider.Proje
 }
 
 func getVsphereFolders(seedsGetter provider.SeedsGetter, username, password, datacenterName string) ([]apiv1.VSphereFolder, error) {
-	seeds, err := seedsGetter()
-	if err != nil {
-		return nil, errors.New(http.StatusInternalServerError, fmt.Sprintf("failed to list seeds: %v", err))
-	}
-	_, datacenter, err := provider.DatacenterFromSeedMap(seeds, datacenterName)
+	_, datacenter, err := provider.DatacenterFromSeedMap(seedsGetter, datacenterName)
 	if err != nil {
 		return nil, fmt.Errorf("failed to find Datacenter %q: %v", datacenterName, err)
 	}

--- a/api/pkg/provider/conversions.go
+++ b/api/pkg/provider/conversions.go
@@ -2,8 +2,10 @@ package provider
 
 import (
 	"fmt"
+	"net/http"
 
 	kubermaticv1 "github.com/kubermatic/kubermatic/api/pkg/crd/kubermatic/v1"
+	"github.com/kubermatic/kubermatic/api/pkg/util/errors"
 )
 
 // We can not convert a single DatacenterMeta as the SeedDatacenter contains its NodeDatacenter
@@ -75,7 +77,11 @@ func DatacenterMetasToSeeds(dm map[string]DatacenterMeta) (map[string]*kubermati
 // once we support datacenters as CRDs.
 // TODO: Find a way to lift the current requirement of unique nodeDatacenter names. It is needed
 // only because we put the nodeDatacenter name on the cluster but not the seed
-func DatacenterFromSeedMap(seeds map[string]*kubermaticv1.Seed, datacenterName string) (*kubermaticv1.Seed, *kubermaticv1.Datacenter, error) {
+func DatacenterFromSeedMap(seedsGetter SeedsGetter, datacenterName string) (*kubermaticv1.Seed, *kubermaticv1.Datacenter, error) {
+	seeds, err := seedsGetter()
+	if err != nil {
+		return nil, nil, errors.New(http.StatusInternalServerError, fmt.Sprintf("failed to list seeds: %v", err))
+	}
 
 	var foundDatacenters []kubermaticv1.Datacenter
 	var foundSeeds []*kubermaticv1.Seed


### PR DESCRIPTION
DatacenterFromSeedMap is heavily based on handler/v1/dc.GetDatacenter,
however the first one uses SeedsGetter while the other uses a seed map,
unnecessarily duplicating the usage of SeedsGetter in its callers.
This commit moves the call to seedGetter() into the function, avoiding
code duplication.

```release-note
NONE
```
