### PR TITLE
Addons: Make cluster credentials that are stored in a referenced secret available

### DIFF
--- a/addons/default-storage-class/storage-class.yaml
+++ b/addons/default-storage-class/storage-class.yaml
@@ -76,7 +76,7 @@ metadata:
   name: hcloud-csi
   namespace: kube-system
 data:
-  token: {{ .Cluster.Spec.Cloud.Hetzner.Token|b64enc }}
+  token: {{ .Credentials.Hetzner.Token|b64enc }}
 ---
 kind: StorageClass
 apiVersion: storage.k8s.io/v1

--- a/api/pkg/addon/template.go
+++ b/api/pkg/addon/template.go
@@ -17,6 +17,7 @@ import (
 	kyaml "k8s.io/apimachinery/pkg/util/yaml"
 
 	kubermaticv1 "github.com/kubermatic/kubermatic/api/pkg/crd/kubermatic/v1"
+	"github.com/kubermatic/kubermatic/api/pkg/resources"
 )
 
 func txtFuncMap(overwriteRegistry string) template.FuncMap {
@@ -35,6 +36,7 @@ type TemplateData struct {
 	Addon        *kubermaticv1.Addon
 	Kubeconfig   string
 	Cluster      *kubermaticv1.Cluster
+	Credentials  resources.Credentials
 	Variables    map[string]interface{}
 	DNSClusterIP string
 	ClusterCIDR  string

--- a/api/pkg/controller/addon/addon_controller.go
+++ b/api/pkg/controller/addon/addon_controller.go
@@ -268,9 +268,15 @@ func (r *Reconciler) getAddonManifests(log *zap.SugaredLogger, addon *kubermatic
 		return nil, err
 	}
 
+	credentials, err := resources.GetCredentials(resources.NewCredentialsData(context.Background(), cluster, r.Client))
+	if err != nil {
+		return nil, fmt.Errorf("failed to get credentials: %v", err)
+	}
+
 	data := &addonutils.TemplateData{
 		Variables:    make(map[string]interface{}),
 		Cluster:      cluster,
+		Credentials:  credentials,
 		Addon:        addon,
 		Kubeconfig:   string(kubeconfig),
 		DNSClusterIP: clusterIP,

--- a/openshift_addons/default-storage-class/storage-class.yaml
+++ b/openshift_addons/default-storage-class/storage-class.yaml
@@ -76,7 +76,7 @@ metadata:
   name: hcloud-csi
   namespace: kube-system
 data:
-  token: {{ .Cluster.Spec.Cloud.Hetzner.Token|b64enc }}
+  token: {{ .Credentials.Hetzner.Token|b64enc }}
 ---
 kind: StorageClass
 apiVersion: storage.k8s.io/v1


### PR DESCRIPTION
**What this PR does / why we need it**:

* Makes the addon controller provide the `Credentials` struct to the addons
* Use the data from the `Credential` struct to fill in the Hetzner token in the `default_storage_class` addon

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #4457 

**Special notes for your reviewer**:

**Documentation**:
<!-- Add links to the related documentation changes related to this pull request. E.g. the link to the kubermatic/docs pullrequest. -->

**Does this PR introduce a user-facing change?**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If  no release note is required, just write "NONE".
-->
```release-note
ACTION REQUIRED: The literal credentials on the `Cluster` object are being deprecated in favor of storing them in a secret. If you have addons that use credentials, replace `.Cluster.Spec.Cloud` with `.Credentials`.
```
