### PR TITLE
Openshift: Disable image registry due to NPE issues in its operator

### DIFF
--- a/openshift_addons/registry/imageregistry.yaml
+++ b/openshift_addons/registry/imageregistry.yaml
@@ -1,32 +1,32 @@
 {{ if .Cluster.Spec.Cloud.AWS }}
-apiVersion: imageregistry.operator.openshift.io/v1
-kind: Config
-metadata:
-  name: cluster
-spec:
-  defaultRoute: false
-  logging: 2
-  managementState: Managed
-  proxy:
-    http: ""
-    https: ""
-    noProxy: ""
-  readOnly: false
-  replicas: 1
-  requests:
-    read:
-      maxInQueue: 0
-      maxRunning: 0
-      maxWaitInQueue: 0s
-    write:
-      maxInQueue: 0
-      maxRunning: 0
-      maxWaitInQueue: 0s
-  storage:
-    s3:
-      encrypt: true
-      keyID: ""
-      region: {{ index .Cluster.Annotations "kubermatic.io/aws-region" }}
+#apiVersion: imageregistry.operator.openshift.io/v1
+#kind: Config
+#metadata:
+#  name: cluster
+#spec:
+#  defaultRoute: false
+#  logging: 2
+#  managementState: Managed
+#  proxy:
+#    http: ""
+#    https: ""
+#    noProxy: ""
+#  readOnly: false
+#  replicas: 1
+#  requests:
+#    read:
+#      maxInQueue: 0
+#      maxRunning: 0
+#      maxWaitInQueue: 0s
+#    write:
+#      maxInQueue: 0
+#      maxRunning: 0
+#      maxWaitInQueue: 0s
+#  storage:
+#    s3:
+#      encrypt: true
+#      keyID: ""
+#      region: {{ index .Cluster.Annotations "kubermatic.io/aws-region" }}
 ---
 apiVersion: cloudcredential.openshift.io/v1
 kind: CredentialsRequest


### PR DESCRIPTION
**What this PR does / why we need it**:

A lot of tests are failing on the openshift deletion. During local testing, I saw that the registry operator had some NPD issues on cleanup.

While I appreciate the cat flood, merging would be nice as well for a change. This PR disables the registry on AWS again, until we know more.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Documentation**:
<!-- Add links to the related documentation changes related to this pull request. E.g. the link to the kubermatic/docs pullrequest. -->

**Does this PR introduce a user-facing change?**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If  no release note is required, just write "NONE".
-->
```release-note
none
```
