### PR TITLE
Conformance tester: Fix junitWrapper to show extraOutput

### DIFF
--- a/api/cmd/conformance-tests/runner.go
+++ b/api/cmd/conformance-tests/runner.go
@@ -1156,7 +1156,7 @@ func junitReporterWrapper(
 	testCaseName string,
 	report *reporters.JUnitTestSuite,
 	executor func() error,
-	extraOutputFn ...func() string,
+	extraErrOutputFn ...func() string,
 ) error {
 	junitTestCase := reporters.JUnitTestCase{
 		Name:      testCaseName,
@@ -1169,10 +1169,11 @@ func junitReporterWrapper(
 	if err != nil {
 		junitTestCase.FailureMessage = &reporters.JUnitFailureMessage{Message: err.Error()}
 		report.Failures++
-	}
-
-	for _, extraOut := range extraOutputFn {
-		junitTestCase.SystemOut = junitTestCase.SystemOut + "\n" + extraOut()
+		for _, extraOut := range extraErrOutputFn {
+			extraOutString := extraOut()
+			err = fmt.Errorf("%v\n%s", err, extraOutString)
+			junitTestCase.FailureMessage.Message += "\n" + extraOutString
+		}
 	}
 
 	report.TestCases = append(report.TestCases, junitTestCase)


### PR DESCRIPTION
**What this PR does / why we need it**:

Fixes the junitWrapper func to the failureMessage instead of the SystemOut, as prow doesn't show the latter. Also changes it to only do so on errors, as the only case where we use this is when waiting for the controlplane to come up and the extra log there shows the unready pods, which only makes sense if we ran into a timeout.

Additionally, the extraOut is appended to the error message, so it will also get logged.

Here is a sample of a job where we should have the extra out but dont, the `openStdout` link doesn't work: https://prow.loodse.com/view/gcs/prow-data/pr-logs/pull/kubermatic_kubermatic/4437/pull-kubermatic-e2e-aws-coreos-1.14/1181941570966917122 

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Documentation**:
<!-- Add links to the related documentation changes related to this pull request. E.g. the link to the kubermatic/docs pullrequest. -->

**Does this PR introduce a user-facing change?**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If  no release note is required, just write "NONE".
-->
```release-note
none
```
