### PR TITLE
filter datacenters based on users' email domain

### DIFF
--- a/api/cmd/kubermatic-api/swagger.json
+++ b/api/cmd/kubermatic-api/swagger.json
@@ -7356,6 +7356,10 @@
           "type": "string",
           "x-go-name": "Provider"
         },
+        "requiredEmailDomain": {
+          "type": "string",
+          "x-go-name": "RequiredEmailDomain"
+        },
         "seed": {
           "type": "string",
           "x-go-name": "Seed"

--- a/api/pkg/api/v1/types.go
+++ b/api/pkg/api/v1/types.go
@@ -119,6 +119,8 @@ type DatacenterSpec struct {
 	Hetzner      *HetznerDatacenterSpec       `json:"hetzner,omitempty"`
 	VSphere      *VSphereDatacenterSpec       `json:"vsphere,omitempty"`
 	Kubevirt     *KubevirtDatacenterSpec      `json:"kubevirt,omitempty"`
+
+	RequiredEmailDomain string `json:"requiredEmailDomain,omitempty"`
 }
 
 // DatacenterList represents a list of datacenters

--- a/api/pkg/crd/kubermatic/v1/datacenter.go
+++ b/api/pkg/crd/kubermatic/v1/datacenter.go
@@ -85,6 +85,8 @@ type DatacenterSpec struct {
 	GCP          *DatacenterSpecGCP          `json:"gcp,omitempty"`
 	Fake         *DatacenterSpecFake         `json:"fake,omitempty"`
 	Kubevirt     *DatacenterSpecKubevirt     `json:"kubevirt,omitempty"`
+
+	RequiredEmailDomain string `json:"requiredEmailDomain,omitempty"`
 }
 
 // ImageList defines a map of operating system and the image to use

--- a/api/pkg/handler/routes_v1.go
+++ b/api/pkg/handler/routes_v1.go
@@ -1041,6 +1041,7 @@ func (r Routing) datacentersHandler() http.Handler {
 		endpoint.Chain(
 			middleware.TokenVerifier(r.tokenVerifiers),
 			middleware.UserSaver(r.userProvider),
+			middleware.UserInfoExtractor(r.userProjectMapper),
 		)(dc.ListEndpoint(r.seedsGetter)),
 		dc.DecodeDatacentersReq,
 		encodeJSON,
@@ -1062,6 +1063,7 @@ func (r Routing) datacenterHandler() http.Handler {
 		endpoint.Chain(
 			middleware.TokenVerifier(r.tokenVerifiers),
 			middleware.UserSaver(r.userProvider),
+			middleware.UserInfoExtractor(r.userProjectMapper),
 		)(dc.GetEndpoint(r.seedsGetter)),
 		dc.DecodeLegacyDcReq,
 		encodeJSON,

--- a/api/pkg/handler/test/helper.go
+++ b/api/pkg/handler/test/helper.go
@@ -67,12 +67,18 @@ func init() {
 }
 
 const (
-	// UserID holds the test user ID
+	// UserID holds a test user ID
 	UserID = "1233"
-	// UserName holds the test user name
+	// UserID2 holds a test user ID
+	UserID2 = "1523"
+	// UserName holds a test user name
 	UserName = "user1"
-	// UserEmail holds the test user email
+	// UserName2 holds a test user name
+	UserName2 = "user2"
+	// UserEmail holds a test user email
 	UserEmail = "john@acme.com"
+	// UserEmail2 holds a test user email
+	UserEmail2 = "bob@example.com"
 	// ClusterID holds the test cluster ID
 	ClusterID = "AbcClusterID"
 	// DefaultClusterID holds the test default cluster ID
@@ -336,6 +342,14 @@ func buildSeeds() provider.SeedsGetter {
 								Digitalocean: &kubermaticv1.DatacenterSpecDigitalocean{
 									Region: "ams2",
 								},
+							},
+						},
+						"restricted-fake-dc": {
+							Country:  "NL",
+							Location: "Amsterdam",
+							Spec: kubermaticv1.DatacenterSpec{
+								Fake:                &kubermaticv1.DatacenterSpecFake{},
+								RequiredEmailDomain: "example.com",
 							},
 						},
 						"fake-dc": {

--- a/api/pkg/handler/v1/cluster/cluster.go
+++ b/api/pkg/handler/v1/cluster/cluster.go
@@ -75,9 +75,9 @@ func CreateEndpoint(sshKeyProvider provider.SSHKeyProvider, projectProvider prov
 			return nil, errors.New(int(http.StatusBadRequest), "cluster.ID is read-only")
 		}
 
-		_, dc, err := provider.DatacenterFromSeedMap(seedsGetter, req.Body.Cluster.Spec.Cloud.DatacenterName)
+		_, dc, err := provider.DatacenterFromSeedMap(userInfo, seedsGetter, req.Body.Cluster.Spec.Cloud.DatacenterName)
 		if err != nil {
-			return nil, fmt.Errorf("error getting dc: %v", err)
+			return nil, common.KubernetesErrorToHTTPError(err)
 		}
 
 		credentialName := req.Body.Cluster.Credential
@@ -207,7 +207,7 @@ func createInitialNodeDeployment(nodeDeployment *apiv1.NodeDeployment, cluster *
 		return err
 	}
 
-	_, dc, err := provider.DatacenterFromSeedMap(seedsGetter, cluster.Spec.Cloud.DatacenterName)
+	_, dc, err := provider.DatacenterFromSeedMap(userInfo, seedsGetter, cluster.Spec.Cloud.DatacenterName)
 	if err != nil {
 		return fmt.Errorf("error getting dc: %v", err)
 	}
@@ -239,6 +239,7 @@ func getNodeDeploymentDisplayName(nd *apiv1.NodeDeployment) string {
 
 func GetEndpoint(projectProvider provider.ProjectProvider) endpoint.Endpoint {
 	return func(ctx context.Context, request interface{}) (interface{}, error) {
+		fmt.Println("asa")
 		req := request.(common.GetClusterReq)
 
 		cluster, err := GetCluster(ctx, req, projectProvider)
@@ -363,7 +364,7 @@ func PatchEndpoint(projectProvider provider.ProjectProvider, seedsGetter provide
 			return nil, errors.NewBadRequest("Cluster contains nodes running the following incompatible kubelet versions: %v. Upgrade your nodes before you upgrade the cluster.", incompatibleKubelets)
 		}
 
-		_, dc, err := provider.DatacenterFromSeedMap(seedsGetter, newInternalCluster.Spec.Cloud.DatacenterName)
+		_, dc, err := provider.DatacenterFromSeedMap(userInfo, seedsGetter, newInternalCluster.Spec.Cloud.DatacenterName)
 		if err != nil {
 			return nil, fmt.Errorf("error getting dc: %v", err)
 		}

--- a/api/pkg/handler/v1/dc/datacenter.go
+++ b/api/pkg/handler/v1/dc/datacenter.go
@@ -5,12 +5,14 @@ import (
 	"fmt"
 	"net/http"
 	"sort"
+	"strings"
 
 	"github.com/go-kit/kit/endpoint"
 	"github.com/gorilla/mux"
 
 	apiv1 "github.com/kubermatic/kubermatic/api/pkg/api/v1"
 	kubermaticv1 "github.com/kubermatic/kubermatic/api/pkg/crd/kubermatic/v1"
+	"github.com/kubermatic/kubermatic/api/pkg/handler/middleware"
 	"github.com/kubermatic/kubermatic/api/pkg/log"
 	"github.com/kubermatic/kubermatic/api/pkg/provider"
 	"github.com/kubermatic/kubermatic/api/pkg/util/errors"
@@ -23,8 +25,18 @@ func ListEndpoint(seedsGetter provider.SeedsGetter) endpoint.Endpoint {
 		if err != nil {
 			return nil, errors.New(http.StatusInternalServerError, fmt.Sprintf("failed to list seeds: %v", err))
 		}
+
+		userInfo, ok := ctx.Value(middleware.UserInfoContextKey).(*provider.UserInfo)
+		if !ok {
+			return nil, errors.New(http.StatusInternalServerError, "can not get user info")
+		}
+
+		// Get the DCs and immediately filter out the ones restricted by e-mail domain.
+		dcs, err := filterDCsByEmail(userInfo, getAPIDCsFromSeedMap(seeds))
+		if err != nil {
+			return apiv1.Datacenter{}, errors.New(http.StatusInternalServerError, fmt.Sprintf("failed to list datacenters: %v", err))
+		}
 		// Maintain a stable order. We do not check for duplicate names here
-		dcs := getAPIDCsFromSeedMap(seeds)
 		sort.SliceStable(dcs, func(i, j int) bool {
 			return dcs[i].Metadata.Name < dcs[j].Metadata.Name
 		})
@@ -37,20 +49,33 @@ func ListEndpoint(seedsGetter provider.SeedsGetter) endpoint.Endpoint {
 func GetEndpoint(seedsGetter provider.SeedsGetter) endpoint.Endpoint {
 	return func(ctx context.Context, request interface{}) (interface{}, error) {
 		req := request.(LegacyDCReq)
-		return GetDatacenter(seedsGetter, req.DC)
+
+		userInfo, ok := ctx.Value(middleware.UserInfoContextKey).(*provider.UserInfo)
+		if !ok {
+			return nil, errors.New(http.StatusInternalServerError, "can not get user info")
+		}
+
+		return GetDatacenter(userInfo, seedsGetter, req.DC)
 	}
 }
 
 // GetDatacenter a function that gives you a single apiv1.Datacenter object
-func GetDatacenter(seedsGetter provider.SeedsGetter, datacenterToGet string) (apiv1.Datacenter, error) {
+func GetDatacenter(userInfo *provider.UserInfo, seedsGetter provider.SeedsGetter, datacenterToGet string) (apiv1.Datacenter, error) {
 	seeds, err := seedsGetter()
 	if err != nil {
 		return apiv1.Datacenter{}, errors.New(http.StatusInternalServerError, fmt.Sprintf("failed to list seeds: %v", err))
 	}
+
+	// Get the DCs and immediately filter out the ones restricted by e-mail domain.
+	dcs, err := filterDCsByEmail(userInfo, getAPIDCsFromSeedMap(seeds))
+	if err != nil {
+		return apiv1.Datacenter{}, errors.New(http.StatusInternalServerError, fmt.Sprintf("failed to list datacenters: %v", err))
+	}
+
 	// The datacenter endpoints return both node and seed dcs, so we have to iterate through
 	// everything
 	var foundDCs []apiv1.Datacenter
-	for _, unfilteredDC := range getAPIDCsFromSeedMap(seeds) {
+	for _, unfilteredDC := range dcs {
 		if unfilteredDC.Metadata.Name == datacenterToGet {
 			foundDCs = append(foundDCs, unfilteredDC)
 		}
@@ -64,6 +89,28 @@ func GetDatacenter(seedsGetter provider.SeedsGetter, datacenterToGet string) (ap
 	}
 
 	return foundDCs[0], nil
+}
+
+func filterDCsByEmail(userInfo *provider.UserInfo, list []apiv1.Datacenter) ([]apiv1.Datacenter, error) {
+	if list == nil {
+		return nil, fmt.Errorf("filterDCsByEmail: the datacenter list can not be nil")
+	}
+	var dcList []apiv1.Datacenter
+
+	for _, dc := range list {
+		requiredEmailDomain := dc.Spec.RequiredEmailDomain
+		// find preset for specific email domain
+		if requiredEmailDomain != "" {
+			userDomain := strings.Split(userInfo.Email, "@")
+			if len(userDomain) == 2 && strings.EqualFold(userDomain[1], requiredEmailDomain) {
+				dcList = append(dcList, dc)
+			}
+		} else {
+			// find preset for "all" without RequiredEmailDomain field
+			dcList = append(dcList, dc)
+		}
+	}
+	return dcList, nil
 }
 
 func getAPIDCsFromSeedMap(seeds map[string]*kubermaticv1.Seed) []apiv1.Datacenter {
@@ -165,6 +212,8 @@ func apiSpec(dc *kubermaticv1.Datacenter) (*apiv1.DatacenterSpec, error) {
 	case dc.Spec.Kubevirt != nil:
 		spec.Kubevirt = &apiv1.KubevirtDatacenterSpec{}
 	}
+
+	spec.RequiredEmailDomain = dc.Spec.RequiredEmailDomain
 
 	return spec, nil
 }

--- a/api/pkg/handler/v1/node/node.go
+++ b/api/pkg/handler/v1/node/node.go
@@ -105,7 +105,7 @@ func CreateNodeDeployment(sshKeyProvider provider.SSHKeyProvider, projectProvide
 			return nil, common.KubernetesErrorToHTTPError(err)
 		}
 
-		_, dc, err := provider.DatacenterFromSeedMap(seedsGetter, cluster.Spec.Cloud.DatacenterName)
+		_, dc, err := provider.DatacenterFromSeedMap(userInfo, seedsGetter, cluster.Spec.Cloud.DatacenterName)
 		if err != nil {
 			return nil, fmt.Errorf("error getting dc: %v", err)
 		}
@@ -686,7 +686,7 @@ func PatchNodeDeployment(sshKeyProvider provider.SSHKeyProvider, projectProvider
 			return nil, k8cerrors.NewBadRequest(err.Error())
 		}
 
-		_, dc, err := provider.DatacenterFromSeedMap(seedsGetter, cluster.Spec.Cloud.DatacenterName)
+		_, dc, err := provider.DatacenterFromSeedMap(userInfo, seedsGetter, cluster.Spec.Cloud.DatacenterName)
 		if err != nil {
 			return nil, fmt.Errorf("error getting dc: %v", err)
 		}

--- a/api/pkg/handler/v1/provider/aws.go
+++ b/api/pkg/handler/v1/provider/aws.go
@@ -151,7 +151,7 @@ func AWSSizeNoCredentialsEndpoint(projectProvider provider.ProjectProvider, seed
 			return nil, errors.NewNotFound("cloud spec for ", req.ClusterID)
 		}
 
-		dc, err := dc.GetDatacenter(seedsGetter, cluster.Spec.Cloud.DatacenterName)
+		dc, err := dc.GetDatacenter(userInfo, seedsGetter, cluster.Spec.Cloud.DatacenterName)
 		if err != nil {
 			return nil, errors.New(http.StatusInternalServerError, err.Error())
 		}

--- a/api/pkg/handler/v1/provider/aws.go
+++ b/api/pkg/handler/v1/provider/aws.go
@@ -224,7 +224,7 @@ func AWSSubnetEndpoint(credentialManager common.PresetsManager, seedsGetter prov
 			}
 		}
 
-		_, dc, err := provider.DatacenterFromSeedMap(seedsGetter, req.DC)
+		_, dc, err := provider.DatacenterFromSeedMap(userInfo, seedsGetter, req.DC)
 		if err != nil {
 			return nil, errors.NewBadRequest(err.Error())
 		}
@@ -251,7 +251,7 @@ func AWSSubnetWithClusterCredentialsEndpoint(projectProvider provider.ProjectPro
 			return nil, errors.NewNotFound("cloud spec for ", req.ClusterID)
 		}
 
-		_, dc, err := provider.DatacenterFromSeedMap(seedsGetter, cluster.Spec.Cloud.DatacenterName)
+		_, dc, err := provider.DatacenterFromSeedMap(userInfo, seedsGetter, cluster.Spec.Cloud.DatacenterName)
 		if err != nil {
 			return nil, errors.NewBadRequest(err.Error())
 		}
@@ -346,7 +346,7 @@ func AWSVPCEndpoint(credentialManager common.PresetsManager, seedsGetter provide
 			}
 		}
 
-		_, datacenter, err := provider.DatacenterFromSeedMap(seedsGetter, req.DC)
+		_, datacenter, err := provider.DatacenterFromSeedMap(userInfo, seedsGetter, req.DC)
 		if err != nil {
 			return nil, errors.NewBadRequest(err.Error())
 		}

--- a/api/pkg/handler/v1/provider/azure.go
+++ b/api/pkg/handler/v1/provider/azure.go
@@ -133,7 +133,7 @@ func AzureSizeWithClusterCredentialsEndpoint(projectProvider provider.ProjectPro
 			return nil, errors.NewNotFound("cloud spec for ", req.ClusterID)
 		}
 
-		dc, err := dc.GetDatacenter(seedsGetter, cluster.Spec.Cloud.DatacenterName)
+		dc, err := dc.GetDatacenter(userInfo, seedsGetter, cluster.Spec.Cloud.DatacenterName)
 		if err != nil {
 			return nil, errors.New(http.StatusInternalServerError, err.Error())
 		}

--- a/api/pkg/handler/v1/provider/gcp.go
+++ b/api/pkg/handler/v1/provider/gcp.go
@@ -296,7 +296,7 @@ func GCPZoneEndpoint(credentialManager common.PresetsManager, seedsGetter provid
 			}
 		}
 
-		return listGCPZones(ctx, sa, req.DC, seedsGetter)
+		return listGCPZones(ctx, userInfo, sa, req.DC, seedsGetter)
 	}
 }
 
@@ -327,12 +327,12 @@ func GCPZoneWithClusterCredentialsEndpoint(projectProvider provider.ProjectProvi
 		if err != nil {
 			return nil, err
 		}
-		return listGCPZones(ctx, sa, cluster.Spec.Cloud.DatacenterName, seedsGetter)
+		return listGCPZones(ctx, userInfo, sa, cluster.Spec.Cloud.DatacenterName, seedsGetter)
 	}
 }
 
-func listGCPZones(ctx context.Context, sa, datacenterName string, seedsGetter provider.SeedsGetter) (apiv1.GCPZoneList, error) {
-	datacenter, err := dc.GetDatacenter(seedsGetter, datacenterName)
+func listGCPZones(ctx context.Context, userInfo *provider.UserInfo, sa, datacenterName string, seedsGetter provider.SeedsGetter) (apiv1.GCPZoneList, error) {
+	datacenter, err := dc.GetDatacenter(userInfo, seedsGetter, datacenterName)
 	if err != nil {
 		return nil, errors.NewBadRequest("%v", err)
 	}

--- a/api/pkg/handler/v1/provider/vsphere.go
+++ b/api/pkg/handler/v1/provider/vsphere.go
@@ -40,7 +40,7 @@ func VsphereNetworksEndpoint(seedsGetter provider.SeedsGetter, credentialManager
 			}
 		}
 
-		return getVsphereNetworks(seedsGetter, username, password, req.DatacenterName)
+		return getVsphereNetworks(userInfo, seedsGetter, username, password, req.DatacenterName)
 	}
 }
 
@@ -69,7 +69,7 @@ func VsphereNetworksWithClusterCredentialsEndpoint(projectProvider provider.Proj
 		}
 		secretKeySelector := provider.SecretKeySelectorValueFuncFactory(ctx, assertedClusterProvider.GetSeedClusterAdminRuntimeClient())
 
-		_, datacenter, err := provider.DatacenterFromSeedMap(seedsGetter, datacenterName)
+		_, datacenter, err := provider.DatacenterFromSeedMap(userInfo, seedsGetter, datacenterName)
 		if err != nil {
 			return nil, fmt.Errorf("failed to find Datacenter %q: %v", datacenterName, err)
 		}
@@ -78,12 +78,12 @@ func VsphereNetworksWithClusterCredentialsEndpoint(projectProvider provider.Proj
 		if err != nil {
 			return nil, err
 		}
-		return getVsphereNetworks(seedsGetter, username, password, datacenterName)
+		return getVsphereNetworks(userInfo, seedsGetter, username, password, datacenterName)
 	}
 }
 
-func getVsphereNetworks(seedsGetter provider.SeedsGetter, username, password, datacenterName string) ([]apiv1.VSphereNetwork, error) {
-	_, datacenter, err := provider.DatacenterFromSeedMap(seedsGetter, datacenterName)
+func getVsphereNetworks(userInfo *provider.UserInfo, seedsGetter provider.SeedsGetter, username, password, datacenterName string) ([]apiv1.VSphereNetwork, error) {
+	_, datacenter, err := provider.DatacenterFromSeedMap(userInfo, seedsGetter, datacenterName)
 	if err != nil {
 		return nil, fmt.Errorf("failed to find Datacenter %q: %v", datacenterName, err)
 	}
@@ -130,7 +130,7 @@ func VsphereFoldersEndpoint(seedsGetter provider.SeedsGetter, credentialManager 
 			}
 		}
 
-		return getVsphereFolders(seedsGetter, username, password, req.DatacenterName)
+		return getVsphereFolders(userInfo, seedsGetter, username, password, req.DatacenterName)
 	}
 }
 
@@ -158,7 +158,7 @@ func VsphereFoldersWithClusterCredentialsEndpoint(projectProvider provider.Proje
 		}
 		secretKeySelector := provider.SecretKeySelectorValueFuncFactory(ctx, assertedClusterProvider.GetSeedClusterAdminRuntimeClient())
 
-		_, datacenter, err := provider.DatacenterFromSeedMap(seedsGetter, datacenterName)
+		_, datacenter, err := provider.DatacenterFromSeedMap(userInfo, seedsGetter, datacenterName)
 		if err != nil {
 			return nil, fmt.Errorf("failed to find Datacenter %q: %v", datacenterName, err)
 		}
@@ -167,12 +167,12 @@ func VsphereFoldersWithClusterCredentialsEndpoint(projectProvider provider.Proje
 		if err != nil {
 			return nil, err
 		}
-		return getVsphereFolders(seedsGetter, username, password, datacenterName)
+		return getVsphereFolders(userInfo, seedsGetter, username, password, datacenterName)
 	}
 }
 
-func getVsphereFolders(seedsGetter provider.SeedsGetter, username, password, datacenterName string) ([]apiv1.VSphereFolder, error) {
-	_, datacenter, err := provider.DatacenterFromSeedMap(seedsGetter, datacenterName)
+func getVsphereFolders(userInfo *provider.UserInfo, seedsGetter provider.SeedsGetter, username, password, datacenterName string) ([]apiv1.VSphereFolder, error) {
+	_, datacenter, err := provider.DatacenterFromSeedMap(userInfo, seedsGetter, datacenterName)
 	if err != nil {
 		return nil, fmt.Errorf("failed to find Datacenter %q: %v", datacenterName, err)
 	}

--- a/api/pkg/provider/conversions.go
+++ b/api/pkg/provider/conversions.go
@@ -95,7 +95,10 @@ func DatacenterFromSeedMap(seedsGetter SeedsGetter, datacenterName string) (*kub
 		foundDatacenters = append(foundDatacenters, datacenter)
 	}
 
-	if n := len(foundDatacenters); n != 1 {
+	if len(foundDatacenters) == 0 {
+		return nil, nil, errors.New(http.StatusNotFound, fmt.Sprintf("datacenter %q not found", datacenterName))
+	}
+	if n := len(foundDatacenters); n > 1 {
 		return nil, nil, fmt.Errorf("expected to find exactly one datacenter with name %q, got %d", datacenterName, n)
 	}
 

--- a/api/pkg/test/e2e/api/utils/apiclient/models/datacenter_spec.go
+++ b/api/pkg/test/e2e/api/utils/apiclient/models/datacenter_spec.go
@@ -25,6 +25,9 @@ type DatacenterSpec struct {
 	// provider
 	Provider string `json:"provider,omitempty"`
 
+	// required email domain
+	RequiredEmailDomain string `json:"requiredEmailDomain,omitempty"`
+
 	// seed
 	Seed string `json:"seed,omitempty"`
 


### PR DESCRIPTION
Fixes #4370

Documentation PR: https://github.com/kubermatic/docs/pull/174

```release-note
Access to datacenters can now be restricted based on the user's email domain.
```
