### PR TITLE
Correctly default vsphere inframanagement user to user

### DIFF
--- a/api/pkg/provider/cloud/vsphere/provider.go
+++ b/api/pkg/provider/cloud/vsphere/provider.go
@@ -244,54 +244,67 @@ func (v *Provider) ValidateCloudSpecUpdate(oldSpec kubermaticv1.CloudSpec, newSp
 	return nil
 }
 
+// Precedence if not infraManagementUser:
+// * User from cluster
+// * User from Secret
+// Precedence if infraManagementUser:
+// * User from clusters infraManagementUser
+// * User from cluster
+// * User form clusters secret infraManagementUser
+// * User from clusters secret
 func getUsernameAndPassword(cloud kubermaticv1.CloudSpec, secretKeySelector provider.SecretKeySelectorValueFunc, infraManagementUser bool) (username, password string, err error) {
 	if infraManagementUser {
 		username = cloud.VSphere.InfraManagementUser.Username
 		password = cloud.VSphere.InfraManagementUser.Password
-	} else {
+	}
+	if username == "" {
 		username = cloud.VSphere.Username
+	}
+	if password == "" {
 		password = cloud.VSphere.Password
 	}
 
-	if username == "" && cloud.VSphere.CredentialsReference != nil && cloud.VSphere.CredentialsReference.Name != "" {
-		var key string
-		if infraManagementUser {
-			key = resources.VsphereInfraManagementUserUsername
-		} else {
-			key = resources.VsphereUsername
-		}
+	if username != "" && password != "" {
+		return username, password, nil
+	}
 
-		username, err = secretKeySelector(cloud.VSphere.CredentialsReference, key)
+	if cloud.VSphere.CredentialsReference == nil {
+		return "", "", errors.New("cluster contains no password an and empty credentialsReference")
+	}
+
+	if username == "" && infraManagementUser {
+		username, err = secretKeySelector(cloud.VSphere.CredentialsReference, resources.VsphereInfraManagementUserUsername)
 		if err != nil {
 			return "", "", err
 		}
-
-		if username == "" && infraManagementUser {
-			username, err = secretKeySelector(cloud.VSphere.CredentialsReference, resources.VsphereUsername)
-			if err != nil {
-				return "", "", err
-			}
+	}
+	if username == "" {
+		username, err = secretKeySelector(cloud.VSphere.CredentialsReference, resources.VsphereUsername)
+		if err != nil {
+			return "", "", err
 		}
 	}
 
-	if password == "" && cloud.VSphere.CredentialsReference != nil && cloud.VSphere.CredentialsReference.Name != "" {
-		var key string
-		if infraManagementUser {
-			key = resources.VsphereInfraManagementUserPassword
-		} else {
-			key = resources.VspherePassword
-		}
-
-		password, err = secretKeySelector(cloud.VSphere.CredentialsReference, key)
+	if password == "" && infraManagementUser {
+		password, err = secretKeySelector(cloud.VSphere.CredentialsReference, resources.VsphereInfraManagementUserPassword)
 		if err != nil {
 			return "", "", err
 		}
-		if password == "" && infraManagementUser {
-			password, err = secretKeySelector(cloud.VSphere.CredentialsReference, key)
-			if err != nil {
-				return "", "", err
-			}
+	}
+
+	if password == "" {
+		password, err = secretKeySelector(cloud.VSphere.CredentialsReference, resources.VspherePassword)
+		if err != nil {
+			return "", "", err
 		}
+	}
+
+	if username == "" {
+		return "", "", errors.New("unable to get username")
+	}
+
+	if password == "" {
+		return "", "", errors.New("unable to get password")
 	}
 
 	return username, password, nil
@@ -301,15 +314,6 @@ func GetCredentialsForCluster(cloud kubermaticv1.CloudSpec, secretKeySelector pr
 	var username, password string
 	var err error
 
-	// InfraManagementUser from Cluster
-	username, password, err = getUsernameAndPassword(cloud, secretKeySelector, true)
-	if err != nil {
-		return "", "", err
-	}
-	if username != "" && password != "" {
-		return username, password, nil
-	}
-
 	// InfraManagementUser from Datacenter
 	if dc != nil && dc.InfraManagementUser != nil {
 		if dc.InfraManagementUser.Username != "" && dc.InfraManagementUser.Password != "" {
@@ -317,8 +321,8 @@ func GetCredentialsForCluster(cloud kubermaticv1.CloudSpec, secretKeySelector pr
 		}
 	}
 
-	// Normal user from cluster
-	username, password, err = getUsernameAndPassword(cloud, secretKeySelector, false)
+	// InfraManagementUser from Cluster
+	username, password, err = getUsernameAndPassword(cloud, secretKeySelector, true)
 	if err != nil {
 		return "", "", err
 	}

--- a/api/pkg/provider/cloud/vsphere/provider.go
+++ b/api/pkg/provider/cloud/vsphere/provider.go
@@ -265,6 +265,13 @@ func getUsernameAndPassword(cloud kubermaticv1.CloudSpec, secretKeySelector prov
 		if err != nil {
 			return "", "", err
 		}
+
+		if username == "" && infraManagementUser {
+			username, err = secretKeySelector(cloud.VSphere.CredentialsReference, resources.VsphereUsername)
+			if err != nil {
+				return "", "", err
+			}
+		}
 	}
 
 	if password == "" && cloud.VSphere.CredentialsReference != nil && cloud.VSphere.CredentialsReference.Name != "" {
@@ -278,6 +285,12 @@ func getUsernameAndPassword(cloud kubermaticv1.CloudSpec, secretKeySelector prov
 		password, err = secretKeySelector(cloud.VSphere.CredentialsReference, key)
 		if err != nil {
 			return "", "", err
+		}
+		if password == "" && infraManagementUser {
+			password, err = secretKeySelector(cloud.VSphere.CredentialsReference, key)
+			if err != nil {
+				return "", "", err
+			}
 		}
 	}
 

--- a/api/pkg/provider/cloud/vsphere/provider_test.go
+++ b/api/pkg/provider/cloud/vsphere/provider_test.go
@@ -1,0 +1,130 @@
+package vsphere
+
+import (
+	"testing"
+
+	kubermaticv1 "github.com/kubermatic/kubermatic/api/pkg/crd/kubermatic/v1"
+	"github.com/kubermatic/kubermatic/api/pkg/provider"
+	"github.com/kubermatic/kubermatic/api/pkg/resources"
+	"github.com/kubermatic/machine-controller/pkg/providerconfig"
+)
+
+func TestGetCredentialsForCluster(t *testing.T) {
+	tcs := []struct {
+		name              string
+		cloudspec         kubermaticv1.CloudSpec
+		secretKeySelector provider.SecretKeySelectorValueFunc
+		dc                *kubermaticv1.DatacenterSpecVSphere
+		expectedUser      string
+		expectedPasword   string
+		expectedError     string
+	}{
+		{
+			name:            "User from cluster",
+			cloudspec:       testVsphereCloudSpec("user", "pass", "a", "b", true),
+			expectedUser:    "user",
+			expectedPasword: "pass",
+		},
+		{
+			name:      "User from secret",
+			cloudspec: testVsphereCloudSpec("", "", "a", "b", true),
+			secretKeySelector: testSecretKeySelectorValueFuncFactory(map[string]string{
+				resources.VsphereUsername: "user",
+				resources.VspherePassword: "pass",
+			}),
+			expectedUser:    "user",
+			expectedPasword: "pass",
+		},
+		{
+			name:            "InfraManagementUser from clusters InfraManagementUser field",
+			cloudspec:       testVsphereCloudSpec("a", "b", "infraManagementUser", "infraManagementUserPass", true),
+			expectedUser:    "infraManagementUser",
+			expectedPasword: "infraManagementUserPass",
+		},
+		{
+			name:            "InfraManagementUser from clusters user field",
+			cloudspec:       testVsphereCloudSpec("user", "pass", "", "", false),
+			expectedUser:    "user",
+			expectedPasword: "pass",
+		},
+		{
+			name:      "InfraManagementUser from secrets InfraManagementUser field",
+			cloudspec: testVsphereCloudSpec("a", "b", "", "", true),
+			secretKeySelector: testSecretKeySelectorValueFuncFactory(map[string]string{
+				resources.VsphereInfraManagementUserUsername: "user",
+				resources.VsphereInfraManagementUserPassword: "pass",
+			}),
+			expectedUser:    "user",
+			expectedPasword: "pass",
+		},
+		{
+			name:      "InfraManagementUser from secrets User field",
+			cloudspec: testVsphereCloudSpec("", "", "", "", true),
+			secretKeySelector: testSecretKeySelectorValueFuncFactory(map[string]string{
+				resources.VsphereUsername: "user",
+				resources.VspherePassword: "pass",
+			}),
+			expectedUser:    "user",
+			expectedPasword: "pass",
+		},
+		{
+			name:      "InfraManagementUser from DC takes precedence",
+			cloudspec: testVsphereCloudSpec("", "", "", "", true),
+			secretKeySelector: testSecretKeySelectorValueFuncFactory(map[string]string{
+				resources.VsphereUsername: "user",
+				resources.VspherePassword: "pass",
+			}),
+			dc: &kubermaticv1.DatacenterSpecVSphere{
+				InfraManagementUser: &kubermaticv1.VSphereCredentials{
+					Username: "dc-user",
+					Password: "dc-pass",
+				},
+			},
+			expectedUser:    "dc-user",
+			expectedPasword: "dc-pass",
+		},
+	}
+
+	for idx := range tcs {
+		t.Run(tcs[idx].name, func(t *testing.T) {
+			t.Parallel()
+			user, password, err := GetCredentialsForCluster(tcs[idx].cloudspec, tcs[idx].secretKeySelector, tcs[idx].dc)
+			if (tcs[idx].expectedError == "" && err != nil) || (tcs[idx].expectedError != "" && err == nil) {
+				t.Fatalf("Expected error %q, got error %v", tcs[idx].expectedError, err)
+			}
+			if user != tcs[idx].expectedUser {
+				t.Errorf("expected user %q, got user %q", tcs[idx].expectedUser, user)
+			}
+			if password != tcs[idx].expectedPasword {
+				t.Errorf("expected password %q, got password %q", tcs[idx].expectedPasword, password)
+			}
+		})
+	}
+}
+
+func testSecretKeySelectorValueFuncFactory(values map[string]string) provider.SecretKeySelectorValueFunc {
+	return func(_ *providerconfig.GlobalSecretKeySelector, key string) (string, error) {
+		if val, ok := values[key]; ok {
+			return val, nil
+		}
+		return "", nil
+	}
+}
+
+func testVsphereCloudSpec(user, password, infraManagementUser, infraManagementUserPass string, credRefSet bool) kubermaticv1.CloudSpec {
+	var credRef *providerconfig.GlobalSecretKeySelector
+	if credRefSet {
+		credRef = &providerconfig.GlobalSecretKeySelector{}
+	}
+	return kubermaticv1.CloudSpec{
+		VSphere: &kubermaticv1.VSphereCloudSpec{
+			CredentialsReference: credRef,
+			Username:             user,
+			Password:             password,
+			InfraManagementUser: kubermaticv1.VSphereCredentials{
+				Username: infraManagementUser,
+				Password: infraManagementUserPass,
+			},
+		},
+	}
+}


### PR DESCRIPTION
**What this PR does / why we need it**:

This pr fixes the infraManagementUser defaulting logic for vsphere with its rather complicated precedence:
* DCs infraManagementUser
* clusters infraManagementUser
* clusters user
* secretKeyRefs InframanagementUser
* secretKeyRefs user

I've also added some tests because else I wouldn't trust code and because this is extremely likely to get accidentally broken in the future.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Documentation**:
<!-- Add links to the related documentation changes related to this pull request. E.g. the link to the kubermatic/docs pullrequest. -->

**Does this PR introduce a user-facing change?**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If  no release note is required, just write "NONE".
-->
```release-note
none
```

/assign @nikhita 
