### PR TITLE
Openstack: continue when trying to add a security rule that already exists

### DIFF
--- a/api/pkg/provider/cloud/openstack/helper.go
+++ b/api/pkg/provider/cloud/openstack/helper.go
@@ -3,6 +3,7 @@ package openstack
 import (
 	"errors"
 	"fmt"
+	"net/http"
 	"strings"
 
 	"github.com/gophercloud/gophercloud"
@@ -217,6 +218,11 @@ func createKubermaticSecurityGroup(netClient *gophercloud.ServiceClient, cluster
 	for _, opts := range rules {
 		rres := osecuritygrouprules.Create(netClient, opts)
 		if rres.Err != nil {
+			if e, ok := rres.Err.(gophercloud.ErrUnexpectedResponseCode); ok && e.Actual == http.StatusConflict {
+				// already exists
+				continue
+			}
+
 			return "", rres.Err
 		}
 


### PR DESCRIPTION
**What this PR does / why we need it**:
Prevents `Security group rule already exists. Rule id is $UUID.` error when resuming a failed security group creation attempt.

```release-note
Openstack: Fixed a bug preventing an interrupted cluster creation from being resumed.
```
