### PR TITLE
Openstack: retry adding the ICMPv6 rule with older protocol string

### DIFF
--- a/api/pkg/provider/cloud/openstack/helper.go
+++ b/api/pkg/provider/cloud/openstack/helper.go
@@ -216,11 +216,19 @@ func createKubermaticSecurityGroup(netClient *gophercloud.ServiceClient, cluster
 	}
 
 	for _, opts := range rules {
+	reiterate:
 		rres := osecuritygrouprules.Create(netClient, opts)
 		if rres.Err != nil {
 			if e, ok := rres.Err.(gophercloud.ErrUnexpectedResponseCode); ok && e.Actual == http.StatusConflict {
 				// already exists
 				continue
+			}
+
+			if _, ok := rres.Err.(gophercloud.ErrDefault400); ok && opts.Protocol == osecuritygrouprules.ProtocolIPv6ICMP {
+				// workaround for old versions of Opnestack with different protocol name,
+				// from before https://review.opendev.org/#/c/252155/
+				opts.Protocol = "icmpv6"
+				goto reiterate // I'm very sorry, but this was really the cleanest way.
 			}
 
 			return "", rres.Err


### PR DESCRIPTION
On old versions of Openstack, the `ipv6-icmp` protocol was named
`icmpv6`. This commit will make Kubermatic retry the rule creation with
the older name, if the request to create the rule is discarded as invalid.

Fixes #4375

```release-note
Openstack: Added a security group API compatibility workaround for very old versions of Openstack.
```
