### PR TITLE
Grafana Plugins & Cluster Dashboard

### DIFF
--- a/api/hack/lib.sh
+++ b/api/hack/lib.sh
@@ -93,3 +93,35 @@ get_latest_dashboard_hash() {
   echodate "The latest dashboard hash for $FOR_BRANCH is $HASH" >/dev/stderr
   echo "$HASH"
 }
+
+format_dashboard() {
+  local filename="$1"
+  local tmpfile="$filename.tmp"
+
+  cat "$filename" | \
+    jq '(.templating.list[] | select(.type=="query") | .options) = []' | \
+    jq '(.templating.list[] | select(.type=="query") | .refresh) = 2' | \
+    jq '(.templating.list[] | select(.type=="query") | .current) = {}' | \
+    jq '(.templating.list[] | select(.type=="datasource") | .current) = {}' | \
+    jq '(.templating.list[] | select(.type=="interval") | .current) = {}' | \
+    jq '(.panels[] | select(.scopedVars!=null) | .scopedVars) = {}' | \
+    jq '(.templating.list[] | select(.type=="datasource") | .hide) = 2' | \
+    jq '(.annotations.list) = []' | \
+    jq '(.links) = []' | \
+    jq '(.refresh) = "30s"' | \
+    jq '(.time.from) = "now-6h"' | \
+    jq '(.editable) = true' | \
+    jq '(.panels[] | select(.type!="row") | .editable) = true' | \
+    jq '(.panels[] | select(.type!="row") | .transparent) = true' | \
+    jq '(.panels[] | select(.type!="row") | .timeRegions) = []' | \
+    jq '(.hideControls) = false' | \
+    jq '(.time.to) = "now"' | \
+    jq '(.timezone) = ""' | \
+    jq '(.graphTooltip) = 1' | \
+    jq 'del(.panels[] | select(.repeatPanelId!=null))' | \
+    jq 'del(.id)' | \
+    jq 'del(.iteration)' | \
+    jq --sort-keys '.' > "$tmpfile"
+
+  mv "$tmpfile" "$filename"
+}

--- a/api/hack/update-grafana-dashboards.sh
+++ b/api/hack/update-grafana-dashboards.sh
@@ -2,37 +2,10 @@
 
 set -euo pipefail
 
-cd $(dirname $0)/../../config/monitoring/grafana/dashboards
+cd $(dirname $0)/../..
+source api/hack/lib.sh
 
-for dashboard in */*.json; do
-  echo "$dashboard"
-
-  tmpfile="$dashboard.tmp"
-
-  cat "$dashboard" | \
-    jq '(.templating.list[] | select(.type=="query") | .options) = []' | \
-    jq '(.templating.list[] | select(.type=="query") | .refresh) = 2' | \
-    jq '(.templating.list[] | select(.type=="query") | .current) = {}' | \
-    jq '(.templating.list[] | select(.type=="datasource") | .current) = {}' | \
-    jq '(.templating.list[] | select(.type=="interval") | .current) = {}' | \
-    jq '(.panels[] | select(.scopedVars!=null) | .scopedVars) = {}' | \
-    jq '(.templating.list[] | select(.type=="datasource") | .hide) = 2' | \
-    jq '(.annotations.list) = []' | \
-    jq '(.links) = []' | \
-    jq '(.refresh) = "30s"' | \
-    jq '(.time.from) = "now-6h"' | \
-    jq '(.editable) = true' | \
-    jq '(.panels[] | select(.type!="row") | .editable) = true' | \
-    jq '(.panels[] | select(.type!="row") | .transparent) = true' | \
-    jq '(.panels[] | select(.type!="row") | .timeRegions) = []' | \
-    jq '(.hideControls) = false' | \
-    jq '(.time.to) = "now"' | \
-    jq '(.timezone) = ""' | \
-    jq '(.graphTooltip) = 1' | \
-    jq 'del(.panels[] | select(.repeatPanelId!=null))' | \
-    jq 'del(.id)' | \
-    jq 'del(.iteration)' | \
-    jq --sort-keys '.' > "$tmpfile"
-
-  mv "$tmpfile" "$dashboard"
+for dashboard in config/monitoring/grafana/dashboards/*/*.json; do
+  echodate "$dashboard"
+  format_dashboard "$dashboard"
 done

--- a/api/hack/verify-grafana-dashboards.sh
+++ b/api/hack/verify-grafana-dashboards.sh
@@ -15,15 +15,11 @@ function cleanup() {
 trap cleanup EXIT SIGINT SIGTERM
 
 cleanup
-mkdir -p $tmpdir
+cp -r dashboards $tmpdir
 
-echodate "Verifying dashboard file format..."
-for dashboard in dashboards/*/*.json; do
-  folder=$(basename $(dirname "$dashboard"))
-  name=$(basename "$dashboard")
-
-  mkdir -p "$tmpdir/$folder"
-  cat "$dashboard" | jq --sort-keys '.' > "$tmpdir/$folder/$name"
+echodate "Verifying dashboards..."
+for dashboard in $tmpdir/*/*.json; do
+  format_dashboard "$dashboard"
 done
 diff -rdu dashboards $tmpdir
 echodate "Dashboards are properly formatted."

--- a/config/monitoring/grafana/Chart.yaml
+++ b/config/monitoring/grafana/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: grafana
-version: 1.1.0
+version: 1.2.0
 appVersion: 6.3.5
 description: Grafana for Kubermatic
 keywords:

--- a/config/monitoring/grafana/dashboards/kubermatic/controller-manager.json
+++ b/config/monitoring/grafana/dashboards/kubermatic/controller-manager.json
@@ -279,7 +279,7 @@
     ]
   },
   "timezone": "",
-  "title": "controller manager",
+  "title": "Controller Manager",
   "uid": "e_4YW2iZz",
   "version": 10
 }

--- a/config/monitoring/grafana/dashboards/kubermatic/user-clusters.json
+++ b/config/monitoring/grafana/dashboards/kubermatic/user-clusters.json
@@ -1,0 +1,1071 @@
+{
+  "annotations": {
+    "list": []
+  },
+  "editable": "<< editable | default false | toJson >>",
+  "gnetId": null,
+  "graphTooltip": 1,
+  "hideControls": "<< hideControls | default false | toJson >>",
+  "links": [],
+  "panels": [
+    {
+      "collapsed": false,
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 0
+      },
+      "id": 11,
+      "panels": [],
+      "title": "Overview",
+      "type": "row"
+    },
+    {
+      "aliasColors": {},
+      "breakPoint": "50%",
+      "cacheTimeout": null,
+      "combine": {
+        "label": "Others",
+        "threshold": 0
+      },
+      "datasource": "prometheus",
+      "decimals": 0,
+      "editable": "<< editable | default false | toJson >>",
+      "fontSize": "80%",
+      "format": "short",
+      "gridPos": {
+        "h": 8,
+        "w": 8,
+        "x": 0,
+        "y": 1
+      },
+      "id": 5,
+      "interval": null,
+      "legend": {
+        "percentage": true,
+        "percentageDecimals": null,
+        "show": true,
+        "values": true
+      },
+      "legendType": "Right side",
+      "links": [],
+      "maxDataPoints": 3,
+      "nullPointMode": "connected",
+      "options": {},
+      "pieType": "donut",
+      "strokeWidth": 1,
+      "targets": [
+        {
+          "expr": "count by (type) (kubermatic_cluster_info)",
+          "instant": true,
+          "legendFormat": "{{ type }}",
+          "refId": "A"
+        }
+      ],
+      "timeFrom": null,
+      "timeRegions": [],
+      "timeShift": null,
+      "title": "Cluster Types",
+      "transparent": "<< transparentPanels | default true | toJson >>",
+      "type": "grafana-piechart-panel",
+      "valueName": "current"
+    },
+    {
+      "aliasColors": {},
+      "breakPoint": "50%",
+      "cacheTimeout": null,
+      "combine": {
+        "label": "Others",
+        "threshold": 0
+      },
+      "datasource": "prometheus",
+      "decimals": 0,
+      "editable": "<< editable | default false | toJson >>",
+      "fontSize": "80%",
+      "format": "short",
+      "gridPos": {
+        "h": 8,
+        "w": 8,
+        "x": 8,
+        "y": 1
+      },
+      "id": 14,
+      "interval": null,
+      "legend": {
+        "percentage": true,
+        "show": true,
+        "values": true
+      },
+      "legendType": "Right side",
+      "links": [],
+      "maxDataPoints": 3,
+      "nullPointMode": "connected",
+      "options": {},
+      "pieType": "donut",
+      "strokeWidth": 1,
+      "targets": [
+        {
+          "expr": "count by (cloud_provider) (kubermatic_cluster_info)",
+          "instant": true,
+          "legendFormat": "{{ cloud_provider }}",
+          "refId": "A"
+        }
+      ],
+      "timeFrom": null,
+      "timeRegions": [],
+      "timeShift": null,
+      "title": "Cloud Providers",
+      "transparent": "<< transparentPanels | default true | toJson >>",
+      "type": "grafana-piechart-panel",
+      "valueName": "current"
+    },
+    {
+      "aliasColors": {},
+      "breakPoint": "50%",
+      "cacheTimeout": null,
+      "combine": {
+        "label": "Others",
+        "threshold": 0
+      },
+      "datasource": "prometheus",
+      "decimals": 0,
+      "editable": "<< editable | default false | toJson >>",
+      "fontSize": "80%",
+      "format": "short",
+      "gridPos": {
+        "h": 8,
+        "w": 8,
+        "x": 16,
+        "y": 1
+      },
+      "id": 15,
+      "interval": null,
+      "legend": {
+        "percentage": true,
+        "show": true,
+        "values": true
+      },
+      "legendType": "Right side",
+      "links": [],
+      "maxDataPoints": 3,
+      "nullPointMode": "connected",
+      "options": {},
+      "pieType": "donut",
+      "strokeWidth": 1,
+      "targets": [
+        {
+          "expr": "count by (datacenter) (kubermatic_cluster_info)",
+          "instant": true,
+          "legendFormat": "{{ datacenter }}",
+          "refId": "A"
+        }
+      ],
+      "timeFrom": null,
+      "timeRegions": [],
+      "timeShift": null,
+      "title": "Datacenters",
+      "transparent": "<< transparentPanels | default true | toJson >>",
+      "type": "grafana-piechart-panel",
+      "valueName": "current"
+    },
+    {
+      "aliasColors": {},
+      "bars": false,
+      "dashLength": 10,
+      "dashes": false,
+      "datasource": "prometheus",
+      "editable": "<< editable | default false | toJson >>",
+      "fill": 1,
+      "fillGradient": 0,
+      "gridPos": {
+        "h": 8,
+        "w": 8,
+        "x": 0,
+        "y": 9
+      },
+      "id": 3,
+      "legend": {
+        "avg": false,
+        "current": false,
+        "max": false,
+        "min": false,
+        "show": true,
+        "total": false,
+        "values": false
+      },
+      "lines": true,
+      "linewidth": 1,
+      "links": [],
+      "nullPointMode": "null as zero",
+      "options": {
+        "dataLinks": []
+      },
+      "percentage": false,
+      "pointradius": 2,
+      "points": false,
+      "renderer": "flot",
+      "seriesOverrides": [],
+      "spaceLength": 10,
+      "stack": true,
+      "steppedLine": false,
+      "targets": [
+        {
+          "expr": "count by (type) (kubermatic_cluster_info)",
+          "format": "time_series",
+          "intervalFactor": 1,
+          "legendFormat": "{{ type }}",
+          "refId": "A"
+        }
+      ],
+      "thresholds": [],
+      "timeFrom": null,
+      "timeRegions": [],
+      "timeShift": null,
+      "title": "Total User Clusters",
+      "tooltip": {
+        "shared": true,
+        "sort": 0,
+        "value_type": "individual"
+      },
+      "transparent": "<< transparentPanels | default true | toJson >>",
+      "type": "graph",
+      "xaxis": {
+        "buckets": null,
+        "mode": "time",
+        "name": null,
+        "show": true,
+        "values": []
+      },
+      "yaxes": [
+        {
+          "decimals": 0,
+          "format": "none",
+          "label": null,
+          "logBase": 1,
+          "max": null,
+          "min": null,
+          "show": true
+        },
+        {
+          "format": "short",
+          "label": null,
+          "logBase": 1,
+          "max": null,
+          "min": null,
+          "show": true
+        }
+      ],
+      "yaxis": {
+        "align": false,
+        "alignLevel": null
+      }
+    },
+    {
+      "aliasColors": {},
+      "bars": false,
+      "dashLength": 10,
+      "dashes": false,
+      "datasource": "prometheus",
+      "editable": "<< editable | default false | toJson >>",
+      "fill": 1,
+      "fillGradient": 0,
+      "gridPos": {
+        "h": 8,
+        "w": 8,
+        "x": 8,
+        "y": 9
+      },
+      "id": 13,
+      "legend": {
+        "avg": false,
+        "current": false,
+        "max": false,
+        "min": false,
+        "show": true,
+        "total": false,
+        "values": false
+      },
+      "lines": true,
+      "linewidth": 1,
+      "links": [],
+      "nullPointMode": "null as zero",
+      "options": {
+        "dataLinks": []
+      },
+      "percentage": false,
+      "pointradius": 2,
+      "points": false,
+      "renderer": "flot",
+      "seriesOverrides": [],
+      "spaceLength": 10,
+      "stack": true,
+      "steppedLine": false,
+      "targets": [
+        {
+          "expr": "count by (cloud_provider) (kubermatic_cluster_info)",
+          "format": "time_series",
+          "intervalFactor": 1,
+          "legendFormat": "{{ cloud_provider }}",
+          "refId": "A"
+        }
+      ],
+      "thresholds": [],
+      "timeFrom": null,
+      "timeRegions": [],
+      "timeShift": null,
+      "title": "Cloud Provider History",
+      "tooltip": {
+        "shared": true,
+        "sort": 0,
+        "value_type": "individual"
+      },
+      "transparent": "<< transparentPanels | default true | toJson >>",
+      "type": "graph",
+      "xaxis": {
+        "buckets": null,
+        "mode": "time",
+        "name": null,
+        "show": true,
+        "values": []
+      },
+      "yaxes": [
+        {
+          "decimals": 0,
+          "format": "none",
+          "label": null,
+          "logBase": 1,
+          "max": null,
+          "min": null,
+          "show": true
+        },
+        {
+          "format": "short",
+          "label": null,
+          "logBase": 1,
+          "max": null,
+          "min": null,
+          "show": false
+        }
+      ],
+      "yaxis": {
+        "align": false,
+        "alignLevel": null
+      }
+    },
+    {
+      "aliasColors": {},
+      "bars": false,
+      "dashLength": 10,
+      "dashes": false,
+      "datasource": "prometheus",
+      "editable": "<< editable | default false | toJson >>",
+      "fill": 1,
+      "fillGradient": 0,
+      "gridPos": {
+        "h": 8,
+        "w": 8,
+        "x": 16,
+        "y": 9
+      },
+      "id": 18,
+      "legend": {
+        "avg": false,
+        "current": false,
+        "max": false,
+        "min": false,
+        "show": true,
+        "total": false,
+        "values": false
+      },
+      "lines": true,
+      "linewidth": 1,
+      "links": [],
+      "nullPointMode": "null as zero",
+      "options": {
+        "dataLinks": []
+      },
+      "percentage": false,
+      "pointradius": 2,
+      "points": false,
+      "renderer": "flot",
+      "seriesOverrides": [],
+      "spaceLength": 10,
+      "stack": true,
+      "steppedLine": false,
+      "targets": [
+        {
+          "expr": "count by (datacenter) (kubermatic_cluster_info)",
+          "format": "time_series",
+          "intervalFactor": 1,
+          "legendFormat": "{{ datacenter }}",
+          "refId": "A"
+        }
+      ],
+      "thresholds": [],
+      "timeFrom": null,
+      "timeRegions": [],
+      "timeShift": null,
+      "title": "Datacenter History",
+      "tooltip": {
+        "shared": true,
+        "sort": 0,
+        "value_type": "individual"
+      },
+      "transparent": "<< transparentPanels | default true | toJson >>",
+      "type": "graph",
+      "xaxis": {
+        "buckets": null,
+        "mode": "time",
+        "name": null,
+        "show": true,
+        "values": []
+      },
+      "yaxes": [
+        {
+          "decimals": 0,
+          "format": "none",
+          "label": null,
+          "logBase": 1,
+          "max": null,
+          "min": null,
+          "show": true
+        },
+        {
+          "format": "short",
+          "label": null,
+          "logBase": 1,
+          "max": null,
+          "min": null,
+          "show": false
+        }
+      ],
+      "yaxis": {
+        "align": false,
+        "alignLevel": null
+      }
+    },
+    {
+      "collapsed": false,
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 17
+      },
+      "id": 9,
+      "panels": [],
+      "title": "Kubernetes",
+      "type": "row"
+    },
+    {
+      "aliasColors": {},
+      "breakPoint": "50%",
+      "cacheTimeout": null,
+      "combine": {
+        "label": "Others",
+        "threshold": 0
+      },
+      "datasource": "prometheus",
+      "editable": "<< editable | default false | toJson >>",
+      "fontSize": "80%",
+      "format": "short",
+      "gridPos": {
+        "h": 8,
+        "w": 4,
+        "x": 0,
+        "y": 18
+      },
+      "id": 6,
+      "interval": null,
+      "legend": {
+        "show": true,
+        "values": false
+      },
+      "legendType": "Right side",
+      "links": [],
+      "maxDataPoints": 3,
+      "nullPointMode": "connected",
+      "options": {},
+      "pieType": "donut",
+      "strokeWidth": 1,
+      "targets": [
+        {
+          "expr": "count by (master_version) (label_replace(kubermatic_cluster_info{type=\"kubernetes\"}, \"master_version\", \"$1\", \"master_version\", \"([0-9]+\\\\.[0-9]+).*\"))",
+          "instant": true,
+          "legendFormat": "{{ master_version }}",
+          "refId": "A"
+        }
+      ],
+      "timeFrom": null,
+      "timeRegions": [],
+      "timeShift": null,
+      "title": "Minor Releases",
+      "transparent": "<< transparentPanels | default true | toJson >>",
+      "type": "grafana-piechart-panel",
+      "valueName": "current"
+    },
+    {
+      "aliasColors": {},
+      "breakPoint": "50%",
+      "cacheTimeout": null,
+      "combine": {
+        "label": "Others",
+        "threshold": 0
+      },
+      "datasource": "prometheus",
+      "editable": "<< editable | default false | toJson >>",
+      "fontSize": "80%",
+      "format": "short",
+      "gridPos": {
+        "h": 8,
+        "w": 4,
+        "x": 4,
+        "y": 18
+      },
+      "id": 7,
+      "interval": null,
+      "legend": {
+        "show": true,
+        "values": false
+      },
+      "legendType": "Right side",
+      "links": [],
+      "maxDataPoints": 3,
+      "nullPointMode": "connected",
+      "options": {},
+      "pieType": "donut",
+      "strokeWidth": 1,
+      "targets": [
+        {
+          "expr": "count by (master_version) (kubermatic_cluster_info{type=\"kubernetes\"})",
+          "instant": true,
+          "legendFormat": "{{ master_version }}",
+          "refId": "A"
+        }
+      ],
+      "timeFrom": null,
+      "timeRegions": [],
+      "timeShift": null,
+      "title": "Releases",
+      "transparent": "<< transparentPanels | default true | toJson >>",
+      "type": "grafana-piechart-panel",
+      "valueName": "current"
+    },
+    {
+      "aliasColors": {},
+      "bars": false,
+      "dashLength": 10,
+      "dashes": false,
+      "datasource": "prometheus",
+      "editable": "<< editable | default false | toJson >>",
+      "fill": 1,
+      "fillGradient": 0,
+      "gridPos": {
+        "h": 8,
+        "w": 8,
+        "x": 8,
+        "y": 18
+      },
+      "id": 2,
+      "legend": {
+        "avg": false,
+        "current": false,
+        "max": false,
+        "min": false,
+        "show": true,
+        "total": false,
+        "values": false
+      },
+      "lines": true,
+      "linewidth": 1,
+      "links": [],
+      "nullPointMode": "null as zero",
+      "options": {
+        "dataLinks": []
+      },
+      "percentage": false,
+      "pointradius": 2,
+      "points": false,
+      "renderer": "flot",
+      "seriesOverrides": [],
+      "spaceLength": 10,
+      "stack": true,
+      "steppedLine": false,
+      "targets": [
+        {
+          "expr": "count by (master_version) (label_replace(kubermatic_cluster_info{type=\"kubernetes\"}, \"master_version\", \"$1\", \"master_version\", \"([0-9]+\\\\.[0-9]+).*\"))",
+          "format": "time_series",
+          "intervalFactor": 1,
+          "legendFormat": "{{ master_version }}",
+          "refId": "A"
+        }
+      ],
+      "thresholds": [],
+      "timeFrom": null,
+      "timeRegions": [],
+      "timeShift": null,
+      "title": "Minor Release History",
+      "tooltip": {
+        "shared": true,
+        "sort": 0,
+        "value_type": "individual"
+      },
+      "transparent": "<< transparentPanels | default true | toJson >>",
+      "type": "graph",
+      "xaxis": {
+        "buckets": null,
+        "mode": "time",
+        "name": null,
+        "show": true,
+        "values": []
+      },
+      "yaxes": [
+        {
+          "decimals": 0,
+          "format": "none",
+          "label": null,
+          "logBase": 1,
+          "max": null,
+          "min": null,
+          "show": true
+        },
+        {
+          "format": "short",
+          "label": null,
+          "logBase": 1,
+          "max": null,
+          "min": null,
+          "show": true
+        }
+      ],
+      "yaxis": {
+        "align": false,
+        "alignLevel": null
+      }
+    },
+    {
+      "aliasColors": {},
+      "bars": false,
+      "dashLength": 10,
+      "dashes": false,
+      "datasource": "prometheus",
+      "editable": "<< editable | default false | toJson >>",
+      "fill": 1,
+      "fillGradient": 0,
+      "gridPos": {
+        "h": 8,
+        "w": 8,
+        "x": 16,
+        "y": 18
+      },
+      "id": 12,
+      "legend": {
+        "avg": false,
+        "current": false,
+        "max": false,
+        "min": false,
+        "show": true,
+        "total": false,
+        "values": false
+      },
+      "lines": true,
+      "linewidth": 1,
+      "links": [],
+      "nullPointMode": "null as zero",
+      "options": {
+        "dataLinks": []
+      },
+      "percentage": false,
+      "pointradius": 2,
+      "points": false,
+      "renderer": "flot",
+      "seriesOverrides": [],
+      "spaceLength": 10,
+      "stack": true,
+      "steppedLine": false,
+      "targets": [
+        {
+          "expr": "count by (master_version) (kubermatic_cluster_info{type=\"kubernetes\"})",
+          "format": "time_series",
+          "intervalFactor": 1,
+          "legendFormat": "{{ master_version }}",
+          "refId": "A"
+        }
+      ],
+      "thresholds": [],
+      "timeFrom": null,
+      "timeRegions": [],
+      "timeShift": null,
+      "title": "Release History",
+      "tooltip": {
+        "shared": true,
+        "sort": 0,
+        "value_type": "individual"
+      },
+      "transparent": "<< transparentPanels | default true | toJson >>",
+      "type": "graph",
+      "xaxis": {
+        "buckets": null,
+        "mode": "time",
+        "name": null,
+        "show": true,
+        "values": []
+      },
+      "yaxes": [
+        {
+          "decimals": 0,
+          "format": "none",
+          "label": null,
+          "logBase": 1,
+          "max": null,
+          "min": null,
+          "show": true
+        },
+        {
+          "format": "short",
+          "label": null,
+          "logBase": 1,
+          "max": null,
+          "min": null,
+          "show": true
+        }
+      ],
+      "yaxis": {
+        "align": false,
+        "alignLevel": null
+      }
+    },
+    {
+      "collapsed": false,
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 26
+      },
+      "id": 17,
+      "panels": [],
+      "title": "OpenShift",
+      "type": "row"
+    },
+    {
+      "aliasColors": {},
+      "breakPoint": "50%",
+      "cacheTimeout": null,
+      "combine": {
+        "label": "Others",
+        "threshold": 0
+      },
+      "datasource": "prometheus",
+      "editable": "<< editable | default false | toJson >>",
+      "fontSize": "80%",
+      "format": "short",
+      "gridPos": {
+        "h": 8,
+        "w": 4,
+        "x": 0,
+        "y": 27
+      },
+      "id": 19,
+      "interval": null,
+      "legend": {
+        "show": true,
+        "values": false
+      },
+      "legendType": "Right side",
+      "links": [],
+      "maxDataPoints": 3,
+      "nullPointMode": "connected",
+      "options": {},
+      "pieType": "donut",
+      "strokeWidth": 1,
+      "targets": [
+        {
+          "expr": "count by (master_version) (label_replace(kubermatic_cluster_info{type=\"openshift\"}, \"master_version\", \"$1\", \"master_version\", \"([0-9]+\\\\.[0-9]+).*\"))",
+          "instant": true,
+          "legendFormat": "{{ master_version }}",
+          "refId": "A"
+        }
+      ],
+      "timeFrom": null,
+      "timeRegions": [],
+      "timeShift": null,
+      "title": "Minor Releases",
+      "transparent": "<< transparentPanels | default true | toJson >>",
+      "type": "grafana-piechart-panel",
+      "valueName": "current"
+    },
+    {
+      "aliasColors": {},
+      "breakPoint": "50%",
+      "cacheTimeout": null,
+      "combine": {
+        "label": "Others",
+        "threshold": 0
+      },
+      "datasource": "prometheus",
+      "editable": "<< editable | default false | toJson >>",
+      "fontSize": "80%",
+      "format": "short",
+      "gridPos": {
+        "h": 8,
+        "w": 4,
+        "x": 4,
+        "y": 27
+      },
+      "id": 20,
+      "interval": null,
+      "legend": {
+        "show": true,
+        "values": false
+      },
+      "legendType": "Right side",
+      "links": [],
+      "maxDataPoints": 3,
+      "nullPointMode": "connected",
+      "options": {},
+      "pieType": "donut",
+      "strokeWidth": 1,
+      "targets": [
+        {
+          "expr": "count by (master_version) (kubermatic_cluster_info{type=\"openshift\"})",
+          "instant": true,
+          "legendFormat": "{{ master_version }}",
+          "refId": "A"
+        }
+      ],
+      "timeFrom": null,
+      "timeRegions": [],
+      "timeShift": null,
+      "title": "Releases",
+      "transparent": "<< transparentPanels | default true | toJson >>",
+      "type": "grafana-piechart-panel",
+      "valueName": "current"
+    },
+    {
+      "aliasColors": {},
+      "bars": false,
+      "dashLength": 10,
+      "dashes": false,
+      "datasource": "prometheus",
+      "editable": "<< editable | default false | toJson >>",
+      "fill": 1,
+      "fillGradient": 0,
+      "gridPos": {
+        "h": 8,
+        "w": 8,
+        "x": 8,
+        "y": 27
+      },
+      "id": 21,
+      "legend": {
+        "avg": false,
+        "current": false,
+        "max": false,
+        "min": false,
+        "show": true,
+        "total": false,
+        "values": false
+      },
+      "lines": true,
+      "linewidth": 1,
+      "links": [],
+      "nullPointMode": "null as zero",
+      "options": {
+        "dataLinks": []
+      },
+      "percentage": false,
+      "pointradius": 2,
+      "points": false,
+      "renderer": "flot",
+      "seriesOverrides": [],
+      "spaceLength": 10,
+      "stack": true,
+      "steppedLine": false,
+      "targets": [
+        {
+          "expr": "count by (master_version) (label_replace(kubermatic_cluster_info{type=\"openshift\"}, \"master_version\", \"$1\", \"master_version\", \"([0-9]+\\\\.[0-9]+).*\"))",
+          "format": "time_series",
+          "intervalFactor": 1,
+          "legendFormat": "{{ master_version }}",
+          "refId": "A"
+        }
+      ],
+      "thresholds": [],
+      "timeFrom": null,
+      "timeRegions": [],
+      "timeShift": null,
+      "title": "Minor Release History",
+      "tooltip": {
+        "shared": true,
+        "sort": 0,
+        "value_type": "individual"
+      },
+      "transparent": "<< transparentPanels | default true | toJson >>",
+      "type": "graph",
+      "xaxis": {
+        "buckets": null,
+        "mode": "time",
+        "name": null,
+        "show": true,
+        "values": []
+      },
+      "yaxes": [
+        {
+          "decimals": 0,
+          "format": "none",
+          "label": null,
+          "logBase": 1,
+          "max": null,
+          "min": null,
+          "show": true
+        },
+        {
+          "format": "short",
+          "label": null,
+          "logBase": 1,
+          "max": null,
+          "min": null,
+          "show": true
+        }
+      ],
+      "yaxis": {
+        "align": false,
+        "alignLevel": null
+      }
+    },
+    {
+      "aliasColors": {},
+      "bars": false,
+      "dashLength": 10,
+      "dashes": false,
+      "datasource": "prometheus",
+      "editable": "<< editable | default false | toJson >>",
+      "fill": 1,
+      "fillGradient": 0,
+      "gridPos": {
+        "h": 8,
+        "w": 8,
+        "x": 16,
+        "y": 27
+      },
+      "id": 22,
+      "legend": {
+        "avg": false,
+        "current": false,
+        "max": false,
+        "min": false,
+        "show": true,
+        "total": false,
+        "values": false
+      },
+      "lines": true,
+      "linewidth": 1,
+      "links": [],
+      "nullPointMode": "null as zero",
+      "options": {
+        "dataLinks": []
+      },
+      "percentage": false,
+      "pointradius": 2,
+      "points": false,
+      "renderer": "flot",
+      "seriesOverrides": [],
+      "spaceLength": 10,
+      "stack": true,
+      "steppedLine": false,
+      "targets": [
+        {
+          "expr": "count by (master_version) (kubermatic_cluster_info{type=\"openshift\"})",
+          "format": "time_series",
+          "intervalFactor": 1,
+          "legendFormat": "{{ master_version }}",
+          "refId": "A"
+        }
+      ],
+      "thresholds": [],
+      "timeFrom": null,
+      "timeRegions": [],
+      "timeShift": null,
+      "title": "Release History",
+      "tooltip": {
+        "shared": true,
+        "sort": 0,
+        "value_type": "individual"
+      },
+      "transparent": "<< transparentPanels | default true | toJson >>",
+      "type": "graph",
+      "xaxis": {
+        "buckets": null,
+        "mode": "time",
+        "name": null,
+        "show": true,
+        "values": []
+      },
+      "yaxes": [
+        {
+          "decimals": 0,
+          "format": "none",
+          "label": null,
+          "logBase": 1,
+          "max": null,
+          "min": null,
+          "show": true
+        },
+        {
+          "format": "short",
+          "label": null,
+          "logBase": 1,
+          "max": null,
+          "min": null,
+          "show": true
+        }
+      ],
+      "yaxis": {
+        "align": false,
+        "alignLevel": null
+      }
+    }
+  ],
+  "refresh": "<< refresh | default `30s` | toJson >>",
+  "schemaVersion": 19,
+  "style": "dark",
+  "tags": [],
+  "templating": {
+    "list": []
+  },
+  "time": {
+    "from": "<< defaultRange | toJson >>",
+    "to": "now"
+  },
+  "timepicker": {
+    "refresh_intervals": [
+      "5s",
+      "10s",
+      "30s",
+      "1m",
+      "5m",
+      "15m",
+      "30m",
+      "1h",
+      "2h",
+      "1d"
+    ],
+    "time_options": [
+      "5m",
+      "15m",
+      "1h",
+      "6h",
+      "12h",
+      "24h",
+      "2d",
+      "7d",
+      "30d"
+    ]
+  },
+  "timezone": "",
+  "title": "User Clusters",
+  "uid": "9yx5UoZWz",
+  "version": 1
+}

--- a/config/monitoring/grafana/dashboards/kubermatic/user-clusters.json
+++ b/config/monitoring/grafana/dashboards/kubermatic/user-clusters.json
@@ -2,10 +2,10 @@
   "annotations": {
     "list": []
   },
-  "editable": "<< editable | default false | toJson >>",
+  "editable": true,
   "gnetId": null,
   "graphTooltip": 1,
-  "hideControls": "<< hideControls | default false | toJson >>",
+  "hideControls": false,
   "links": [],
   "panels": [
     {
@@ -31,7 +31,7 @@
       },
       "datasource": "prometheus",
       "decimals": 0,
-      "editable": "<< editable | default false | toJson >>",
+      "editable": true,
       "fontSize": "80%",
       "format": "short",
       "gridPos": {
@@ -67,7 +67,7 @@
       "timeRegions": [],
       "timeShift": null,
       "title": "Cluster Types",
-      "transparent": "<< transparentPanels | default true | toJson >>",
+      "transparent": true,
       "type": "grafana-piechart-panel",
       "valueName": "current"
     },
@@ -81,7 +81,7 @@
       },
       "datasource": "prometheus",
       "decimals": 0,
-      "editable": "<< editable | default false | toJson >>",
+      "editable": true,
       "fontSize": "80%",
       "format": "short",
       "gridPos": {
@@ -116,7 +116,7 @@
       "timeRegions": [],
       "timeShift": null,
       "title": "Cloud Providers",
-      "transparent": "<< transparentPanels | default true | toJson >>",
+      "transparent": true,
       "type": "grafana-piechart-panel",
       "valueName": "current"
     },
@@ -130,7 +130,7 @@
       },
       "datasource": "prometheus",
       "decimals": 0,
-      "editable": "<< editable | default false | toJson >>",
+      "editable": true,
       "fontSize": "80%",
       "format": "short",
       "gridPos": {
@@ -165,7 +165,7 @@
       "timeRegions": [],
       "timeShift": null,
       "title": "Datacenters",
-      "transparent": "<< transparentPanels | default true | toJson >>",
+      "transparent": true,
       "type": "grafana-piechart-panel",
       "valueName": "current"
     },
@@ -175,7 +175,7 @@
       "dashLength": 10,
       "dashes": false,
       "datasource": "prometheus",
-      "editable": "<< editable | default false | toJson >>",
+      "editable": true,
       "fill": 1,
       "fillGradient": 0,
       "gridPos": {
@@ -228,7 +228,7 @@
         "sort": 0,
         "value_type": "individual"
       },
-      "transparent": "<< transparentPanels | default true | toJson >>",
+      "transparent": true,
       "type": "graph",
       "xaxis": {
         "buckets": null,
@@ -267,7 +267,7 @@
       "dashLength": 10,
       "dashes": false,
       "datasource": "prometheus",
-      "editable": "<< editable | default false | toJson >>",
+      "editable": true,
       "fill": 1,
       "fillGradient": 0,
       "gridPos": {
@@ -320,7 +320,7 @@
         "sort": 0,
         "value_type": "individual"
       },
-      "transparent": "<< transparentPanels | default true | toJson >>",
+      "transparent": true,
       "type": "graph",
       "xaxis": {
         "buckets": null,
@@ -359,7 +359,7 @@
       "dashLength": 10,
       "dashes": false,
       "datasource": "prometheus",
-      "editable": "<< editable | default false | toJson >>",
+      "editable": true,
       "fill": 1,
       "fillGradient": 0,
       "gridPos": {
@@ -412,7 +412,7 @@
         "sort": 0,
         "value_type": "individual"
       },
-      "transparent": "<< transparentPanels | default true | toJson >>",
+      "transparent": true,
       "type": "graph",
       "xaxis": {
         "buckets": null,
@@ -467,7 +467,7 @@
         "threshold": 0
       },
       "datasource": "prometheus",
-      "editable": "<< editable | default false | toJson >>",
+      "editable": true,
       "fontSize": "80%",
       "format": "short",
       "gridPos": {
@@ -501,7 +501,7 @@
       "timeRegions": [],
       "timeShift": null,
       "title": "Minor Releases",
-      "transparent": "<< transparentPanels | default true | toJson >>",
+      "transparent": true,
       "type": "grafana-piechart-panel",
       "valueName": "current"
     },
@@ -514,7 +514,7 @@
         "threshold": 0
       },
       "datasource": "prometheus",
-      "editable": "<< editable | default false | toJson >>",
+      "editable": true,
       "fontSize": "80%",
       "format": "short",
       "gridPos": {
@@ -548,7 +548,7 @@
       "timeRegions": [],
       "timeShift": null,
       "title": "Releases",
-      "transparent": "<< transparentPanels | default true | toJson >>",
+      "transparent": true,
       "type": "grafana-piechart-panel",
       "valueName": "current"
     },
@@ -558,7 +558,7 @@
       "dashLength": 10,
       "dashes": false,
       "datasource": "prometheus",
-      "editable": "<< editable | default false | toJson >>",
+      "editable": true,
       "fill": 1,
       "fillGradient": 0,
       "gridPos": {
@@ -611,7 +611,7 @@
         "sort": 0,
         "value_type": "individual"
       },
-      "transparent": "<< transparentPanels | default true | toJson >>",
+      "transparent": true,
       "type": "graph",
       "xaxis": {
         "buckets": null,
@@ -650,7 +650,7 @@
       "dashLength": 10,
       "dashes": false,
       "datasource": "prometheus",
-      "editable": "<< editable | default false | toJson >>",
+      "editable": true,
       "fill": 1,
       "fillGradient": 0,
       "gridPos": {
@@ -703,7 +703,7 @@
         "sort": 0,
         "value_type": "individual"
       },
-      "transparent": "<< transparentPanels | default true | toJson >>",
+      "transparent": true,
       "type": "graph",
       "xaxis": {
         "buckets": null,
@@ -758,7 +758,7 @@
         "threshold": 0
       },
       "datasource": "prometheus",
-      "editable": "<< editable | default false | toJson >>",
+      "editable": true,
       "fontSize": "80%",
       "format": "short",
       "gridPos": {
@@ -792,7 +792,7 @@
       "timeRegions": [],
       "timeShift": null,
       "title": "Minor Releases",
-      "transparent": "<< transparentPanels | default true | toJson >>",
+      "transparent": true,
       "type": "grafana-piechart-panel",
       "valueName": "current"
     },
@@ -805,7 +805,7 @@
         "threshold": 0
       },
       "datasource": "prometheus",
-      "editable": "<< editable | default false | toJson >>",
+      "editable": true,
       "fontSize": "80%",
       "format": "short",
       "gridPos": {
@@ -839,7 +839,7 @@
       "timeRegions": [],
       "timeShift": null,
       "title": "Releases",
-      "transparent": "<< transparentPanels | default true | toJson >>",
+      "transparent": true,
       "type": "grafana-piechart-panel",
       "valueName": "current"
     },
@@ -849,7 +849,7 @@
       "dashLength": 10,
       "dashes": false,
       "datasource": "prometheus",
-      "editable": "<< editable | default false | toJson >>",
+      "editable": true,
       "fill": 1,
       "fillGradient": 0,
       "gridPos": {
@@ -902,7 +902,7 @@
         "sort": 0,
         "value_type": "individual"
       },
-      "transparent": "<< transparentPanels | default true | toJson >>",
+      "transparent": true,
       "type": "graph",
       "xaxis": {
         "buckets": null,
@@ -941,7 +941,7 @@
       "dashLength": 10,
       "dashes": false,
       "datasource": "prometheus",
-      "editable": "<< editable | default false | toJson >>",
+      "editable": true,
       "fill": 1,
       "fillGradient": 0,
       "gridPos": {
@@ -994,7 +994,7 @@
         "sort": 0,
         "value_type": "individual"
       },
-      "transparent": "<< transparentPanels | default true | toJson >>",
+      "transparent": true,
       "type": "graph",
       "xaxis": {
         "buckets": null,
@@ -1028,7 +1028,7 @@
       }
     }
   ],
-  "refresh": "<< refresh | default `30s` | toJson >>",
+  "refresh": "30s",
   "schemaVersion": 19,
   "style": "dark",
   "tags": [],
@@ -1036,7 +1036,7 @@
     "list": []
   },
   "time": {
-    "from": "<< defaultRange | toJson >>",
+    "from": "now-6h",
     "to": "now"
   },
   "timepicker": {

--- a/config/monitoring/grafana/dashboards/nginx-ingress-controller/overview.json
+++ b/config/monitoring/grafana/dashboards/nginx-ingress-controller/overview.json
@@ -1176,7 +1176,7 @@
     ]
   },
   "timezone": "",
-  "title": "NGINX Ingress controller",
+  "title": "Overview",
   "uid": "4ecf28ac7c24",
   "version": 1
 }

--- a/config/monitoring/grafana/provisioning/dashboards/nginx-ingress-controller.yaml
+++ b/config/monitoring/grafana/provisioning/dashboards/nginx-ingress-controller.yaml
@@ -1,0 +1,8 @@
+apiVersion: 1
+providers:
+- folder: "NGINX Ingress Controller"
+  name: "nginx-ingress-controller"
+  options:
+    path: /grafana-dashboard-definitions/nginx-ingress-controller
+  org_id: 1
+  type: file

--- a/config/monitoring/grafana/templates/deployment.yaml
+++ b/config/monitoring/grafana/templates/deployment.yaml
@@ -16,8 +16,8 @@ spec:
       annotations:
         checksum/config: {{ include (print $.Template.BasePath "/configmaps.yaml") . | sha256sum }}
     spec:
-      {{ if .Values.grafana.provisioning.datasources.paths }}
       initContainers:
+      {{- if .Values.grafana.provisioning.datasources.paths }}
       - image: '{{ .Values.grafana.utilImage.repository }}:{{ .Values.grafana.utilImage.tag }}'
         name: datasource-assembler
         command: [/bin/bash]
@@ -68,7 +68,21 @@ spec:
           readOnly: true
         {{- end }}
         {{- end }}
-      {{ end }}
+      {{- end }}
+
+      - image: '{{ $.Values.grafana.pluginImage.repository }}:{{ $.Values.grafana.pluginImage.tag }}'
+        name: plugin-installer
+        command: [/bin/sh]
+        args:
+        - -c
+        - |
+          set -euo pipefail
+          echo "Installing plugins..."
+          cp -r /plugins /var/lib/grafana
+          ls -1 /var/lib/grafana/plugins
+        volumeMounts:
+        - mountPath: /var/lib/grafana
+          name: grafana-storage
 
       containers:
       - image: '{{ .Values.grafana.image.repository }}:{{ .Values.grafana.image.tag }}'

--- a/config/monitoring/grafana/values.yaml
+++ b/config/monitoring/grafana/values.yaml
@@ -9,6 +9,9 @@ grafana:
   utilImage:
     repository: quay.io/kubermatic/util
     tag: 1.1.3
+  pluginImage:
+    repository: quay.io/kubermatic/grafana-plugins
+    tag: 1.0.0
   resources:
     requests:
       cpu: 100m

--- a/containers/grafana-plugins/Dockerfile
+++ b/containers/grafana-plugins/Dockerfile
@@ -1,0 +1,16 @@
+FROM alpine:3.10
+
+RUN mkdir -p /plugins
+WORKDIR /plugins
+
+RUN wget -O- https://grafana.com/api/plugins/grafana-piechart-panel/versions/1.3.9/download | unzip - && \
+    mv grafana-piechart-panel-* grafana-piechart-panel
+
+RUN wget -O- https://grafana.com/api/plugins/farski-blendstat-panel/versions/1.0.1/download | unzip - && \
+    mv farski-blendstat-grafana-* farski-blendstat-panel
+
+RUN wget -O- https://grafana.com/api/plugins/michaeldmoore-multistat-panel/versions/1.2.3/download | unzip - && \
+    mv michaeldmoore-michaeldmoore-multistat-panel-* michaeldmoore-multistat-panel
+
+RUN wget -O- https://grafana.com/api/plugins/vonage-status-panel/versions/1.0.9/download | unzip - && \
+    mv Vonage-Grafana_Status_panel-* vonage-status-panel

--- a/containers/grafana-plugins/release.sh
+++ b/containers/grafana-plugins/release.sh
@@ -1,0 +1,8 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+VERSION=1.0.0
+
+docker build --no-cache --pull -t quay.io/kubermatic/grafana-plugins:${VERSION} .
+docker push quay.io/kubermatic/grafana-plugins:${VERSION}


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR introduces a new public Docker image for carrying Grafana plugins, `quay.io/kubermatic/grafana-plugins`. We use some of the new plugins in the new, fancy User Cluster dashboard already:

![screenshot-2019-10-11-142255](https://user-images.githubusercontent.com/127499/66651164-a6a71b00-ec32-11e9-8366-a58f74a6d275.png)

This PR also moves the NGINX dashboard to a better place and makes the dashboard verification job stricter by not just requiring properly formatted JSON, but also that all the other normalizations have been applied.

Fixes #1782 (mostly; not all plugins can be installed this way, but this is an 80/20 solution to the problem and customers can easily create their own Docker image with plugins).

**Does this PR introduce a user-facing change?**:
```release-note
NONE
```
