### PR TITLE
Dashboard: Keep SecurityContext.RunAsGroup for compatibility with older kube versions

### DIFF
--- a/api/pkg/resources/test/fixtures/deployment-aws-1.10.0-kubernetes-dashboard.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-aws-1.10.0-kubernetes-dashboard.yaml
@@ -64,7 +64,6 @@ spec:
         securityContext:
           allowPrivilegeEscalation: false
           readOnlyRootFilesystem: true
-          runAsGroup: 2001
           runAsUser: 1001
         volumeMounts:
         - mountPath: /etc/kubernetes/kubeconfig

--- a/api/pkg/resources/test/fixtures/deployment-aws-1.10.6-kubernetes-dashboard.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-aws-1.10.6-kubernetes-dashboard.yaml
@@ -64,7 +64,6 @@ spec:
         securityContext:
           allowPrivilegeEscalation: false
           readOnlyRootFilesystem: true
-          runAsGroup: 2001
           runAsUser: 1001
         volumeMounts:
         - mountPath: /etc/kubernetes/kubeconfig

--- a/api/pkg/resources/test/fixtures/deployment-aws-1.11.0-kubernetes-dashboard.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-aws-1.11.0-kubernetes-dashboard.yaml
@@ -64,7 +64,6 @@ spec:
         securityContext:
           allowPrivilegeEscalation: false
           readOnlyRootFilesystem: true
-          runAsGroup: 2001
           runAsUser: 1001
         volumeMounts:
         - mountPath: /etc/kubernetes/kubeconfig

--- a/api/pkg/resources/test/fixtures/deployment-aws-1.11.1-kubernetes-dashboard.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-aws-1.11.1-kubernetes-dashboard.yaml
@@ -64,7 +64,6 @@ spec:
         securityContext:
           allowPrivilegeEscalation: false
           readOnlyRootFilesystem: true
-          runAsGroup: 2001
           runAsUser: 1001
         volumeMounts:
         - mountPath: /etc/kubernetes/kubeconfig

--- a/api/pkg/resources/test/fixtures/deployment-aws-1.12.0-kubernetes-dashboard.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-aws-1.12.0-kubernetes-dashboard.yaml
@@ -64,7 +64,6 @@ spec:
         securityContext:
           allowPrivilegeEscalation: false
           readOnlyRootFilesystem: true
-          runAsGroup: 2001
           runAsUser: 1001
         volumeMounts:
         - mountPath: /etc/kubernetes/kubeconfig

--- a/api/pkg/resources/test/fixtures/deployment-aws-1.13.0-kubernetes-dashboard.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-aws-1.13.0-kubernetes-dashboard.yaml
@@ -64,7 +64,6 @@ spec:
         securityContext:
           allowPrivilegeEscalation: false
           readOnlyRootFilesystem: true
-          runAsGroup: 2001
           runAsUser: 1001
         volumeMounts:
         - mountPath: /etc/kubernetes/kubeconfig

--- a/api/pkg/resources/test/fixtures/deployment-azure-1.10.0-kubernetes-dashboard.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-azure-1.10.0-kubernetes-dashboard.yaml
@@ -64,7 +64,6 @@ spec:
         securityContext:
           allowPrivilegeEscalation: false
           readOnlyRootFilesystem: true
-          runAsGroup: 2001
           runAsUser: 1001
         volumeMounts:
         - mountPath: /etc/kubernetes/kubeconfig

--- a/api/pkg/resources/test/fixtures/deployment-azure-1.10.6-kubernetes-dashboard.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-azure-1.10.6-kubernetes-dashboard.yaml
@@ -64,7 +64,6 @@ spec:
         securityContext:
           allowPrivilegeEscalation: false
           readOnlyRootFilesystem: true
-          runAsGroup: 2001
           runAsUser: 1001
         volumeMounts:
         - mountPath: /etc/kubernetes/kubeconfig

--- a/api/pkg/resources/test/fixtures/deployment-azure-1.11.0-kubernetes-dashboard.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-azure-1.11.0-kubernetes-dashboard.yaml
@@ -64,7 +64,6 @@ spec:
         securityContext:
           allowPrivilegeEscalation: false
           readOnlyRootFilesystem: true
-          runAsGroup: 2001
           runAsUser: 1001
         volumeMounts:
         - mountPath: /etc/kubernetes/kubeconfig

--- a/api/pkg/resources/test/fixtures/deployment-azure-1.11.1-kubernetes-dashboard.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-azure-1.11.1-kubernetes-dashboard.yaml
@@ -64,7 +64,6 @@ spec:
         securityContext:
           allowPrivilegeEscalation: false
           readOnlyRootFilesystem: true
-          runAsGroup: 2001
           runAsUser: 1001
         volumeMounts:
         - mountPath: /etc/kubernetes/kubeconfig

--- a/api/pkg/resources/test/fixtures/deployment-azure-1.12.0-kubernetes-dashboard.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-azure-1.12.0-kubernetes-dashboard.yaml
@@ -64,7 +64,6 @@ spec:
         securityContext:
           allowPrivilegeEscalation: false
           readOnlyRootFilesystem: true
-          runAsGroup: 2001
           runAsUser: 1001
         volumeMounts:
         - mountPath: /etc/kubernetes/kubeconfig

--- a/api/pkg/resources/test/fixtures/deployment-azure-1.13.0-kubernetes-dashboard.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-azure-1.13.0-kubernetes-dashboard.yaml
@@ -64,7 +64,6 @@ spec:
         securityContext:
           allowPrivilegeEscalation: false
           readOnlyRootFilesystem: true
-          runAsGroup: 2001
           runAsUser: 1001
         volumeMounts:
         - mountPath: /etc/kubernetes/kubeconfig

--- a/api/pkg/resources/test/fixtures/deployment-bringyourown-1.10.0-kubernetes-dashboard.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-bringyourown-1.10.0-kubernetes-dashboard.yaml
@@ -64,7 +64,6 @@ spec:
         securityContext:
           allowPrivilegeEscalation: false
           readOnlyRootFilesystem: true
-          runAsGroup: 2001
           runAsUser: 1001
         volumeMounts:
         - mountPath: /etc/kubernetes/kubeconfig

--- a/api/pkg/resources/test/fixtures/deployment-bringyourown-1.10.6-kubernetes-dashboard.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-bringyourown-1.10.6-kubernetes-dashboard.yaml
@@ -64,7 +64,6 @@ spec:
         securityContext:
           allowPrivilegeEscalation: false
           readOnlyRootFilesystem: true
-          runAsGroup: 2001
           runAsUser: 1001
         volumeMounts:
         - mountPath: /etc/kubernetes/kubeconfig

--- a/api/pkg/resources/test/fixtures/deployment-bringyourown-1.11.0-kubernetes-dashboard.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-bringyourown-1.11.0-kubernetes-dashboard.yaml
@@ -64,7 +64,6 @@ spec:
         securityContext:
           allowPrivilegeEscalation: false
           readOnlyRootFilesystem: true
-          runAsGroup: 2001
           runAsUser: 1001
         volumeMounts:
         - mountPath: /etc/kubernetes/kubeconfig

--- a/api/pkg/resources/test/fixtures/deployment-bringyourown-1.11.1-kubernetes-dashboard.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-bringyourown-1.11.1-kubernetes-dashboard.yaml
@@ -64,7 +64,6 @@ spec:
         securityContext:
           allowPrivilegeEscalation: false
           readOnlyRootFilesystem: true
-          runAsGroup: 2001
           runAsUser: 1001
         volumeMounts:
         - mountPath: /etc/kubernetes/kubeconfig

--- a/api/pkg/resources/test/fixtures/deployment-bringyourown-1.12.0-kubernetes-dashboard.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-bringyourown-1.12.0-kubernetes-dashboard.yaml
@@ -64,7 +64,6 @@ spec:
         securityContext:
           allowPrivilegeEscalation: false
           readOnlyRootFilesystem: true
-          runAsGroup: 2001
           runAsUser: 1001
         volumeMounts:
         - mountPath: /etc/kubernetes/kubeconfig

--- a/api/pkg/resources/test/fixtures/deployment-bringyourown-1.13.0-kubernetes-dashboard.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-bringyourown-1.13.0-kubernetes-dashboard.yaml
@@ -64,7 +64,6 @@ spec:
         securityContext:
           allowPrivilegeEscalation: false
           readOnlyRootFilesystem: true
-          runAsGroup: 2001
           runAsUser: 1001
         volumeMounts:
         - mountPath: /etc/kubernetes/kubeconfig

--- a/api/pkg/resources/test/fixtures/deployment-digitalocean-1.10.0-kubernetes-dashboard.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-digitalocean-1.10.0-kubernetes-dashboard.yaml
@@ -64,7 +64,6 @@ spec:
         securityContext:
           allowPrivilegeEscalation: false
           readOnlyRootFilesystem: true
-          runAsGroup: 2001
           runAsUser: 1001
         volumeMounts:
         - mountPath: /etc/kubernetes/kubeconfig

--- a/api/pkg/resources/test/fixtures/deployment-digitalocean-1.10.6-kubernetes-dashboard.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-digitalocean-1.10.6-kubernetes-dashboard.yaml
@@ -64,7 +64,6 @@ spec:
         securityContext:
           allowPrivilegeEscalation: false
           readOnlyRootFilesystem: true
-          runAsGroup: 2001
           runAsUser: 1001
         volumeMounts:
         - mountPath: /etc/kubernetes/kubeconfig

--- a/api/pkg/resources/test/fixtures/deployment-digitalocean-1.11.0-kubernetes-dashboard.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-digitalocean-1.11.0-kubernetes-dashboard.yaml
@@ -64,7 +64,6 @@ spec:
         securityContext:
           allowPrivilegeEscalation: false
           readOnlyRootFilesystem: true
-          runAsGroup: 2001
           runAsUser: 1001
         volumeMounts:
         - mountPath: /etc/kubernetes/kubeconfig

--- a/api/pkg/resources/test/fixtures/deployment-digitalocean-1.11.1-kubernetes-dashboard.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-digitalocean-1.11.1-kubernetes-dashboard.yaml
@@ -64,7 +64,6 @@ spec:
         securityContext:
           allowPrivilegeEscalation: false
           readOnlyRootFilesystem: true
-          runAsGroup: 2001
           runAsUser: 1001
         volumeMounts:
         - mountPath: /etc/kubernetes/kubeconfig

--- a/api/pkg/resources/test/fixtures/deployment-digitalocean-1.12.0-kubernetes-dashboard.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-digitalocean-1.12.0-kubernetes-dashboard.yaml
@@ -64,7 +64,6 @@ spec:
         securityContext:
           allowPrivilegeEscalation: false
           readOnlyRootFilesystem: true
-          runAsGroup: 2001
           runAsUser: 1001
         volumeMounts:
         - mountPath: /etc/kubernetes/kubeconfig

--- a/api/pkg/resources/test/fixtures/deployment-digitalocean-1.13.0-kubernetes-dashboard.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-digitalocean-1.13.0-kubernetes-dashboard.yaml
@@ -64,7 +64,6 @@ spec:
         securityContext:
           allowPrivilegeEscalation: false
           readOnlyRootFilesystem: true
-          runAsGroup: 2001
           runAsUser: 1001
         volumeMounts:
         - mountPath: /etc/kubernetes/kubeconfig

--- a/api/pkg/resources/test/fixtures/deployment-openstack-1.10.0-kubernetes-dashboard.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-openstack-1.10.0-kubernetes-dashboard.yaml
@@ -64,7 +64,6 @@ spec:
         securityContext:
           allowPrivilegeEscalation: false
           readOnlyRootFilesystem: true
-          runAsGroup: 2001
           runAsUser: 1001
         volumeMounts:
         - mountPath: /etc/kubernetes/kubeconfig

--- a/api/pkg/resources/test/fixtures/deployment-openstack-1.10.6-kubernetes-dashboard.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-openstack-1.10.6-kubernetes-dashboard.yaml
@@ -64,7 +64,6 @@ spec:
         securityContext:
           allowPrivilegeEscalation: false
           readOnlyRootFilesystem: true
-          runAsGroup: 2001
           runAsUser: 1001
         volumeMounts:
         - mountPath: /etc/kubernetes/kubeconfig

--- a/api/pkg/resources/test/fixtures/deployment-openstack-1.11.0-kubernetes-dashboard.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-openstack-1.11.0-kubernetes-dashboard.yaml
@@ -64,7 +64,6 @@ spec:
         securityContext:
           allowPrivilegeEscalation: false
           readOnlyRootFilesystem: true
-          runAsGroup: 2001
           runAsUser: 1001
         volumeMounts:
         - mountPath: /etc/kubernetes/kubeconfig

--- a/api/pkg/resources/test/fixtures/deployment-openstack-1.11.1-kubernetes-dashboard.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-openstack-1.11.1-kubernetes-dashboard.yaml
@@ -64,7 +64,6 @@ spec:
         securityContext:
           allowPrivilegeEscalation: false
           readOnlyRootFilesystem: true
-          runAsGroup: 2001
           runAsUser: 1001
         volumeMounts:
         - mountPath: /etc/kubernetes/kubeconfig

--- a/api/pkg/resources/test/fixtures/deployment-openstack-1.12.0-kubernetes-dashboard.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-openstack-1.12.0-kubernetes-dashboard.yaml
@@ -64,7 +64,6 @@ spec:
         securityContext:
           allowPrivilegeEscalation: false
           readOnlyRootFilesystem: true
-          runAsGroup: 2001
           runAsUser: 1001
         volumeMounts:
         - mountPath: /etc/kubernetes/kubeconfig

--- a/api/pkg/resources/test/fixtures/deployment-openstack-1.13.0-kubernetes-dashboard.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-openstack-1.13.0-kubernetes-dashboard.yaml
@@ -64,7 +64,6 @@ spec:
         securityContext:
           allowPrivilegeEscalation: false
           readOnlyRootFilesystem: true
-          runAsGroup: 2001
           runAsUser: 1001
         volumeMounts:
         - mountPath: /etc/kubernetes/kubeconfig

--- a/api/pkg/resources/test/fixtures/deployment-vsphere-1.10.0-kubernetes-dashboard.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-vsphere-1.10.0-kubernetes-dashboard.yaml
@@ -64,7 +64,6 @@ spec:
         securityContext:
           allowPrivilegeEscalation: false
           readOnlyRootFilesystem: true
-          runAsGroup: 2001
           runAsUser: 1001
         volumeMounts:
         - mountPath: /etc/kubernetes/kubeconfig

--- a/api/pkg/resources/test/fixtures/deployment-vsphere-1.10.6-kubernetes-dashboard.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-vsphere-1.10.6-kubernetes-dashboard.yaml
@@ -64,7 +64,6 @@ spec:
         securityContext:
           allowPrivilegeEscalation: false
           readOnlyRootFilesystem: true
-          runAsGroup: 2001
           runAsUser: 1001
         volumeMounts:
         - mountPath: /etc/kubernetes/kubeconfig

--- a/api/pkg/resources/test/fixtures/deployment-vsphere-1.11.0-kubernetes-dashboard.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-vsphere-1.11.0-kubernetes-dashboard.yaml
@@ -64,7 +64,6 @@ spec:
         securityContext:
           allowPrivilegeEscalation: false
           readOnlyRootFilesystem: true
-          runAsGroup: 2001
           runAsUser: 1001
         volumeMounts:
         - mountPath: /etc/kubernetes/kubeconfig

--- a/api/pkg/resources/test/fixtures/deployment-vsphere-1.11.1-kubernetes-dashboard.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-vsphere-1.11.1-kubernetes-dashboard.yaml
@@ -64,7 +64,6 @@ spec:
         securityContext:
           allowPrivilegeEscalation: false
           readOnlyRootFilesystem: true
-          runAsGroup: 2001
           runAsUser: 1001
         volumeMounts:
         - mountPath: /etc/kubernetes/kubeconfig

--- a/api/pkg/resources/test/fixtures/deployment-vsphere-1.12.0-kubernetes-dashboard.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-vsphere-1.12.0-kubernetes-dashboard.yaml
@@ -64,7 +64,6 @@ spec:
         securityContext:
           allowPrivilegeEscalation: false
           readOnlyRootFilesystem: true
-          runAsGroup: 2001
           runAsUser: 1001
         volumeMounts:
         - mountPath: /etc/kubernetes/kubeconfig

--- a/api/pkg/resources/test/fixtures/deployment-vsphere-1.13.0-kubernetes-dashboard.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-vsphere-1.13.0-kubernetes-dashboard.yaml
@@ -64,7 +64,6 @@ spec:
         securityContext:
           allowPrivilegeEscalation: false
           readOnlyRootFilesystem: true
-          runAsGroup: 2001
           runAsUser: 1001
         volumeMounts:
         - mountPath: /etc/kubernetes/kubeconfig


### PR DESCRIPTION

**What this PR does / why we need it**:

Makes Kubermatic keep the `securityContext.RunAsGroup` settings, as it may or may not be supported depending on the Kube apiserver version, e.G. on GKEs `1.13.7-gke.24` it does not exist, which results in reconciling getting stuck:

```
I1014 07:41:35.195213       1 compare.go:40] Object *v1.Deployment cluster-8t8f67r25f/kubernetes-dashboard differs from the generated one: [Spec.Template.Spec.Containers.slice[0].SecurityContext.RunAsGroup: int64 != <nil pointer>]
```

/assign @floreks 

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Documentation**:
<!-- Add links to the related documentation changes related to this pull request. E.g. the link to the kubermatic/docs pullrequest. -->

**Does this PR introduce a user-facing change?**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If  no release note is required, just write "NONE".
-->
```release-note
none
```
