### PR TITLE
extend AWS presets for roleARN

### DIFF
--- a/api/pkg/crd/kubermatic/v1/preset.go
+++ b/api/pkg/crd/kubermatic/v1/preset.go
@@ -83,6 +83,7 @@ type AWS struct {
 	RouteTableID        string `json:"routeTableId,omitempty"`
 	InstanceProfileName string `json:"instanceProfileName,omitempty"`
 	SecurityGroupID     string `json:"securityGroupID,omitempty"`
+	ControlPlaneRoleARN string `json:"roleARN,omitempty"`
 }
 
 type Openstack struct {

--- a/api/pkg/presets/manager.go
+++ b/api/pkg/presets/manager.go
@@ -214,6 +214,7 @@ func (m *Manager) setAWSCredentials(userInfo *provider.UserInfo, presetName stri
 	cloud.AWS.RouteTableID = credentials.RouteTableID
 	cloud.AWS.SecurityGroupID = credentials.SecurityGroupID
 	cloud.AWS.VPCID = credentials.VPCID
+	cloud.AWS.ControlPlaneRoleARN = credentials.ControlPlaneRoleARN
 	return &cloud, nil
 }
 


### PR DESCRIPTION
**What this PR does / why we need it**: extend AWS presets for roleARN

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #4456

```release-note
 extend AWS presets for roleARN:
presets:
  items:
    - metadata:
        name: test
      spec:
        aws:
          accessKeyId: 
          secretAccessKey: 
          vpcId:
          roleARN:
```
