### PR TITLE
extend viewer ClusterRole

### DIFF
--- a/api/pkg/controller/rbac-user-cluster/mapper.go
+++ b/api/pkg/controller/rbac-user-cluster/mapper.go
@@ -8,6 +8,10 @@ import (
 
 	"github.com/kubermatic/kubermatic/api/pkg/controller/rbac"
 
+	apps "k8s.io/api/apps/v1"
+	autoscaling "k8s.io/api/autoscaling/v1"
+	batch "k8s.io/api/batch/v1"
+	extensions "k8s.io/api/extensions/v1beta1"
 	rbacv1 "k8s.io/api/rbac/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
@@ -30,7 +34,7 @@ func generateVerbsForGroup(groupName string) ([]string, error) {
 	}
 
 	if groupName == rbac.ViewerGroupNamePrefix {
-		return []string{"list", "get"}, nil
+		return []string{"list", "get", "watch"}, nil
 	}
 
 	// unknown group passed
@@ -61,8 +65,73 @@ func GenerateRBACClusterRole(resourceName string) (*rbacv1.ClusterRole, error) {
 			},
 			{
 				APIGroups: []string{""},
-				Resources: []string{"pods", "nodes"},
-				Verbs:     []string{"get", "list"},
+				Resources: []string{"configmaps",
+					"endpoints",
+					"persistentvolumeclaims",
+					"pods",
+					"replicationcontrollers",
+					"replicationcontrollers/scale",
+					"serviceaccounts",
+					"services",
+					"nodes",
+					"namespaces",
+				},
+				Verbs: verbs,
+			},
+			{
+				APIGroups: []string{""},
+				Resources: []string{"bindings",
+					"events",
+					"limitranges",
+					"namespaces/status",
+					"pods/log",
+					"pods/status",
+					"replicationcontrollers/status",
+					"resourcequotas",
+					"resourcequotas/status",
+				},
+				Verbs: verbs,
+			},
+			{
+				APIGroups: []string{apps.GroupName},
+				Resources: []string{"controllerrevisions",
+					"daemonsets",
+					"deployments",
+					"deployments/scale",
+					"replicasets",
+					"replicasets/scale",
+					"statefulsets",
+					"statefulsets/scale",
+				},
+				Verbs: verbs,
+			},
+			{
+				APIGroups: []string{autoscaling.GroupName},
+				Resources: []string{"horizontalpodautoscalers"},
+				Verbs:     verbs,
+			},
+			{
+				APIGroups: []string{batch.GroupName},
+				Resources: []string{"cronjobs", "jobs"},
+				Verbs:     verbs,
+			},
+			{
+				APIGroups: []string{extensions.GroupName},
+				Resources: []string{"daemonsets",
+					"deployments",
+					"deployments/scale",
+					"ingresses",
+					"networkpolicies",
+					"replicasets",
+					"replicasets/scale",
+					"replicationcontrollers/scale",
+				},
+				Verbs: verbs,
+			},
+			{
+				APIGroups: []string{"networking.k8s.io"},
+				Resources: []string{"ingresses", "networkpolicies"},
+				Verbs:     verbs,
 			},
 		},
 	}

--- a/api/pkg/controller/rbac-user-cluster/mapper_test.go
+++ b/api/pkg/controller/rbac-user-cluster/mapper_test.go
@@ -89,7 +89,7 @@ func TestGenerateVerbsForGroup(t *testing.T) {
 		{
 			name:          "scenario 3: generate verbs for viewers",
 			resurceName:   genResourceName(rbac.ViewerGroupNamePrefix),
-			expectedVerbs: []string{"list", "get"},
+			expectedVerbs: []string{"list", "get", "watch"},
 			expectError:   false,
 		},
 		{


### PR DESCRIPTION
**What this PR does / why we need it**: Allows read-only access to see most objects in a namespace. It does not allow viewing roles or rolebindings. It does not allow viewing secrets.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #4497 

```release-note
extend viewer ClusterRole in the user cluster
```
