### PR TITLE
Mark default addons

### DIFF
--- a/api/cmd/kubermatic-api/swagger.json
+++ b/api/cmd/kubermatic-api/swagger.json
@@ -6744,6 +6744,11 @@
       "description": "AddonSpec addon specification",
       "type": "object",
       "properties": {
+        "isDefault": {
+          "description": "IsDefault indicates whether the addon is default",
+          "type": "boolean",
+          "x-go-name": "IsDefault"
+        },
         "variables": {
           "description": "Variables is free form data to use for parsing the manifest templates",
           "type": "object",

--- a/api/cmd/kubermatic-controller-manager/controllers.go
+++ b/api/cmd/kubermatic-controller-manager/controllers.go
@@ -5,7 +5,6 @@ import (
 	"context"
 	"fmt"
 	"io/ioutil"
-	"k8s.io/apimachinery/pkg/util/sets"
 	"strings"
 	"time"
 
@@ -23,6 +22,7 @@ import (
 	"github.com/kubermatic/kubermatic/api/pkg/version"
 
 	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/util/sets"
 	"k8s.io/apimachinery/pkg/util/yaml"
 	utilpointer "k8s.io/utils/pointer"
 )

--- a/api/cmd/kubermatic-controller-manager/controllers.go
+++ b/api/cmd/kubermatic-controller-manager/controllers.go
@@ -245,6 +245,16 @@ func createUpdateController(ctrlCtx *controllerContext) error {
 }
 
 func createAddonController(ctrlCtx *controllerContext) error {
+	kubernetesAddons := strings.Split(ctrlCtx.runOptions.kubernetesAddonsList, ",")
+	for i, a := range kubernetesAddons {
+		kubernetesAddons[i] = strings.TrimSpace(a)
+	}
+
+	openshiftAddons := strings.Split(ctrlCtx.runOptions.openshiftAddonsList, ",")
+	for i, a := range openshiftAddons {
+		openshiftAddons[i] = strings.TrimSpace(a)
+	}
+
 	return addon.Add(
 		ctrlCtx.mgr,
 		ctrlCtx.log,
@@ -255,6 +265,8 @@ func createAddonController(ctrlCtx *controllerContext) error {
 				"NodeAccessNetwork": ctrlCtx.runOptions.nodeAccessNetwork,
 			},
 		},
+		kubernetesAddons,
+		openshiftAddons,
 		ctrlCtx.runOptions.kubernetesAddonsPath,
 		ctrlCtx.runOptions.openshiftAddonsPath,
 		ctrlCtx.runOptions.overwriteRegistry,
@@ -263,7 +275,6 @@ func createAddonController(ctrlCtx *controllerContext) error {
 }
 
 func createAddonInstallerController(ctrlCtx *controllerContext) error {
-
 	kubernetesAddons := strings.Split(ctrlCtx.runOptions.kubernetesAddonsList, ",")
 	for i, a := range kubernetesAddons {
 		kubernetesAddons[i] = strings.TrimSpace(a)

--- a/api/cmd/kubermatic-controller-manager/controllers.go
+++ b/api/cmd/kubermatic-controller-manager/controllers.go
@@ -5,6 +5,7 @@ import (
 	"context"
 	"fmt"
 	"io/ioutil"
+	"k8s.io/apimachinery/pkg/util/sets"
 	"strings"
 	"time"
 
@@ -246,13 +247,15 @@ func createUpdateController(ctrlCtx *controllerContext) error {
 
 func createAddonController(ctrlCtx *controllerContext) error {
 	kubernetesAddons := strings.Split(ctrlCtx.runOptions.kubernetesAddonsList, ",")
-	for i, a := range kubernetesAddons {
-		kubernetesAddons[i] = strings.TrimSpace(a)
+	kubernetesAddonsSet := sets.String{}
+	for _, a := range kubernetesAddons {
+		kubernetesAddonsSet.Insert(strings.TrimSpace(a))
 	}
 
 	openshiftAddons := strings.Split(ctrlCtx.runOptions.openshiftAddonsList, ",")
-	for i, a := range openshiftAddons {
-		openshiftAddons[i] = strings.TrimSpace(a)
+	openshiftAddonsSet := sets.String{}
+	for _, a := range openshiftAddons {
+		openshiftAddonsSet.Insert(strings.TrimSpace(a))
 	}
 
 	return addon.Add(
@@ -265,8 +268,8 @@ func createAddonController(ctrlCtx *controllerContext) error {
 				"NodeAccessNetwork": ctrlCtx.runOptions.nodeAccessNetwork,
 			},
 		},
-		kubernetesAddons,
-		openshiftAddons,
+		kubernetesAddonsSet,
+		openshiftAddonsSet,
 		ctrlCtx.runOptions.kubernetesAddonsPath,
 		ctrlCtx.runOptions.openshiftAddonsPath,
 		ctrlCtx.runOptions.overwriteRegistry,

--- a/api/pkg/api/v1/types.go
+++ b/api/pkg/api/v1/types.go
@@ -804,6 +804,8 @@ type Addon struct {
 type AddonSpec struct {
 	// Variables is free form data to use for parsing the manifest templates
 	Variables map[string]interface{} `json:"variables,omitempty"`
+	// IsDefault indicates whether the addon is default
+	IsDefault bool `json:"isDefault,omitempty"`
 }
 
 // ClusterList represents a list of clusters

--- a/api/pkg/crd/kubermatic/v1/addon.go
+++ b/api/pkg/crd/kubermatic/v1/addon.go
@@ -33,6 +33,8 @@ type AddonSpec struct {
 	Cluster corev1.ObjectReference `json:"cluster"`
 	// Variables is free form data to use for parsing the manifest templates
 	Variables runtime.RawExtension `json:"variables,omitempty"`
+	// IsDefault indicates whether the addon is default
+	IsDefault bool `json:"isDefault,omitempty"`
 }
 
 // AddonList is a list of addons

--- a/api/pkg/handler/v1/addon/addon.go
+++ b/api/pkg/handler/v1/addon/addon.go
@@ -291,6 +291,9 @@ func convertInternalAddonToExternal(internalAddon *kubermaticapiv1.Addon) (*apiv
 				return nil
 			}(),
 		},
+		Spec: apiv1.AddonSpec{
+			IsDefault: internalAddon.Spec.IsDefault,
+		},
 	}
 	if len(internalAddon.Spec.Variables.Raw) > 0 {
 		if err := k8sjson.Unmarshal(internalAddon.Spec.Variables.Raw, &result.Spec.Variables); err != nil {

--- a/api/pkg/test/e2e/api/utils/apiclient/models/addon_spec.go
+++ b/api/pkg/test/e2e/api/utils/apiclient/models/addon_spec.go
@@ -15,6 +15,9 @@ import (
 // swagger:model AddonSpec
 type AddonSpec struct {
 
+	// IsDefault indicates whether the addon is default
+	IsDefault bool `json:"isDefault,omitempty"`
+
 	// Variables is free form data to use for parsing the manifest templates
 	Variables map[string]interface{} `json:"variables,omitempty"`
 }


### PR DESCRIPTION
**What this PR does / why we need it**: We need it to be able to tell in the UI if the addon is default or not. User should be aware that he is trying to delete default addon that will be recreated automatically. We could even block such an operation then.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*: Related to https://github.com/kubermatic/dashboard-v2/pull/1683.

**Special notes for your reviewer**:

**Documentation**:
<!-- Add links to the related documentation changes related to this pull request. E.g. the link to the kubermatic/docs pullrequest. -->

**Does this PR introduce a user-facing change?**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If  no release note is required, just write "NONE".
-->
```release-note
Added isDefault field for addons.
```
