### PR TITLE
add defaulting for AWS subnet

### DIFF
--- a/api/cmd/kubermatic-api/swagger.json
+++ b/api/cmd/kubermatic-api/swagger.json
@@ -6556,6 +6556,10 @@
           "type": "string",
           "x-go-name": "IPv6CIDR"
         },
+        "isDefaultSubnet": {
+          "type": "boolean",
+          "x-go-name": "IsDefaultSubnet"
+        },
         "name": {
           "type": "string",
           "x-go-name": "Name"

--- a/api/pkg/api/v1/types.go
+++ b/api/pkg/api/v1/types.go
@@ -166,6 +166,7 @@ type AWSSubnet struct {
 	State                   string   `json:"state"`
 	AvailableIPAddressCount int64    `json:"available_ip_address_count"`
 	DefaultForAz            bool     `json:"default"`
+	IsDefaultSubnet         bool     `json:"isDefaultSubnet"`
 }
 
 // AWSTag represents a object of AWS tags.

--- a/api/pkg/handler/v1/provider/aws_test.go
+++ b/api/pkg/handler/v1/provider/aws_test.go
@@ -1,0 +1,228 @@
+package provider_test
+
+import (
+	"reflect"
+	"testing"
+
+	"github.com/kubermatic/kubermatic/api/pkg/handler/test"
+
+	apiv1 "github.com/kubermatic/kubermatic/api/pkg/api/v1"
+	"github.com/kubermatic/kubermatic/api/pkg/handler/v1/provider"
+	clusterv1alpha1 "sigs.k8s.io/cluster-api/pkg/apis/cluster/v1alpha1"
+)
+
+func TestSetDefaultSubnet(t *testing.T) {
+	t.Parallel()
+	testcases := []struct {
+		name               string
+		machineDeployments *clusterv1alpha1.MachineDeploymentList
+		subnets            apiv1.AWSSubnetList
+		expectedResult     apiv1.AWSSubnetList
+		expectedError      string
+	}{
+		{
+			name: "test, no machines, set first as default",
+			subnets: apiv1.AWSSubnetList{
+				{
+					Name:             "subnet-a",
+					AvailabilityZone: "eu-central-1a",
+					IsDefaultSubnet:  false,
+				},
+				{
+					Name:             "subnet-b",
+					AvailabilityZone: "eu-central-1b",
+					IsDefaultSubnet:  false,
+				},
+				{
+					Name:             "subnet-c",
+					AvailabilityZone: "eu-central-1c",
+					IsDefaultSubnet:  false,
+				},
+			},
+			machineDeployments: &clusterv1alpha1.MachineDeploymentList{
+				Items: []clusterv1alpha1.MachineDeployment{},
+			},
+			expectedResult: apiv1.AWSSubnetList{
+				{
+					Name:             "subnet-a",
+					AvailabilityZone: "eu-central-1a",
+					IsDefaultSubnet:  true,
+				},
+				{
+					Name:             "subnet-b",
+					AvailabilityZone: "eu-central-1b",
+					IsDefaultSubnet:  false,
+				},
+				{
+					Name:             "subnet-c",
+					AvailabilityZone: "eu-central-1c",
+					IsDefaultSubnet:  false,
+				},
+			},
+		},
+		{
+			name: "test, no machines for eu-central-1a zone",
+			subnets: apiv1.AWSSubnetList{
+				{
+					Name:             "subnet-a",
+					AvailabilityZone: "eu-central-1a",
+					IsDefaultSubnet:  false,
+				},
+				{
+					Name:             "subnet-b",
+					AvailabilityZone: "eu-central-1b",
+					IsDefaultSubnet:  false,
+				},
+				{
+					Name:             "subnet-c",
+					AvailabilityZone: "eu-central-1c",
+					IsDefaultSubnet:  false,
+				},
+			},
+			machineDeployments: &clusterv1alpha1.MachineDeploymentList{
+				Items: []clusterv1alpha1.MachineDeployment{
+					*test.GenTestMachineDeployment("md-1-b", `{"cloudProvider":"aws","cloudProviderSpec":{"token":"dummy-token","region":"eu-central-1","availabilityZone":"eu-central-1b","vpcId":"vpc-819f62e9","subnetId":"subnet-2bff4f43","instanceType":"t2.micro","diskSize":50}, "operatingSystem":"ubuntu", "operatingSystemSpec":{"distUpgradeOnBoot":false}}`, nil),
+					*test.GenTestMachineDeployment("md-1-c", `{"cloudProvider":"aws","cloudProviderSpec":{"token":"dummy-token","region":"eu-central-1","availabilityZone":"eu-central-1c","vpcId":"vpc-819f62e9","subnetId":"subnet-2bff4f43","instanceType":"t2.micro","diskSize":50}, "operatingSystem":"ubuntu", "operatingSystemSpec":{"distUpgradeOnBoot":false}}`, nil),
+				},
+			},
+			expectedResult: apiv1.AWSSubnetList{
+				{
+					Name:             "subnet-a",
+					AvailabilityZone: "eu-central-1a",
+					IsDefaultSubnet:  true,
+				},
+				{
+					Name:             "subnet-b",
+					AvailabilityZone: "eu-central-1b",
+					IsDefaultSubnet:  false,
+				},
+				{
+					Name:             "subnet-c",
+					AvailabilityZone: "eu-central-1c",
+					IsDefaultSubnet:  false,
+				},
+			},
+		},
+		{
+			name: "test, no machines for eu-central-1c zone",
+			subnets: apiv1.AWSSubnetList{
+				{
+					Name:             "subnet-a",
+					AvailabilityZone: "eu-central-1a",
+					IsDefaultSubnet:  false,
+				},
+				{
+					Name:             "subnet-b",
+					AvailabilityZone: "eu-central-1b",
+					IsDefaultSubnet:  false,
+				},
+				{
+					Name:             "subnet-c",
+					AvailabilityZone: "eu-central-1c",
+					IsDefaultSubnet:  false,
+				},
+			},
+			machineDeployments: &clusterv1alpha1.MachineDeploymentList{
+				Items: []clusterv1alpha1.MachineDeployment{
+					*test.GenTestMachineDeployment("md-1-a", `{"cloudProvider":"aws","cloudProviderSpec":{"token":"dummy-token","region":"eu-central-1","availabilityZone":"eu-central-1a","vpcId":"vpc-819f62e9","subnetId":"subnet-2bff4f43","instanceType":"t2.micro","diskSize":50}, "operatingSystem":"ubuntu", "operatingSystemSpec":{"distUpgradeOnBoot":false}}`, nil),
+					*test.GenTestMachineDeployment("md-1-b", `{"cloudProvider":"aws","cloudProviderSpec":{"token":"dummy-token","region":"eu-central-1","availabilityZone":"eu-central-1b","vpcId":"vpc-819f62e9","subnetId":"subnet-2bff4f43","instanceType":"t2.micro","diskSize":50}, "operatingSystem":"ubuntu", "operatingSystemSpec":{"distUpgradeOnBoot":false}}`, nil),
+				},
+			},
+			expectedResult: apiv1.AWSSubnetList{
+				{
+					Name:             "subnet-a",
+					AvailabilityZone: "eu-central-1a",
+					IsDefaultSubnet:  false,
+				},
+				{
+					Name:             "subnet-b",
+					AvailabilityZone: "eu-central-1b",
+					IsDefaultSubnet:  false,
+				},
+				{
+					Name:             "subnet-c",
+					AvailabilityZone: "eu-central-1c",
+					IsDefaultSubnet:  true,
+				},
+			},
+		},
+		{
+			name: "test, machines for all zones, set the first one",
+			subnets: apiv1.AWSSubnetList{
+				{
+					Name:             "subnet-a",
+					AvailabilityZone: "eu-central-1a",
+					IsDefaultSubnet:  false,
+				},
+				{
+					Name:             "subnet-b",
+					AvailabilityZone: "eu-central-1b",
+					IsDefaultSubnet:  false,
+				},
+				{
+					Name:             "subnet-c",
+					AvailabilityZone: "eu-central-1c",
+					IsDefaultSubnet:  false,
+				},
+			},
+			machineDeployments: &clusterv1alpha1.MachineDeploymentList{
+				Items: []clusterv1alpha1.MachineDeployment{
+					*test.GenTestMachineDeployment("md-1-a", `{"cloudProvider":"aws","cloudProviderSpec":{"token":"dummy-token","region":"eu-central-1","availabilityZone":"eu-central-1a","vpcId":"vpc-819f62e9","subnetId":"subnet-2bff4f43","instanceType":"t2.micro","diskSize":50}, "operatingSystem":"ubuntu", "operatingSystemSpec":{"distUpgradeOnBoot":false}}`, nil),
+					*test.GenTestMachineDeployment("md-1-b", `{"cloudProvider":"aws","cloudProviderSpec":{"token":"dummy-token","region":"eu-central-1","availabilityZone":"eu-central-1b","vpcId":"vpc-819f62e9","subnetId":"subnet-2bff4f43","instanceType":"t2.micro","diskSize":50}, "operatingSystem":"ubuntu", "operatingSystemSpec":{"distUpgradeOnBoot":false}}`, nil),
+					*test.GenTestMachineDeployment("md-1-c", `{"cloudProvider":"aws","cloudProviderSpec":{"token":"dummy-token","region":"eu-central-1","availabilityZone":"eu-central-1c","vpcId":"vpc-819f62e9","subnetId":"subnet-2bff4f43","instanceType":"t2.micro","diskSize":50}, "operatingSystem":"ubuntu", "operatingSystemSpec":{"distUpgradeOnBoot":false}}`, nil),
+				},
+			},
+			expectedResult: apiv1.AWSSubnetList{
+				{
+					Name:             "subnet-a",
+					AvailabilityZone: "eu-central-1a",
+					IsDefaultSubnet:  true,
+				},
+				{
+					Name:             "subnet-b",
+					AvailabilityZone: "eu-central-1b",
+					IsDefaultSubnet:  false,
+				},
+				{
+					Name:             "subnet-c",
+					AvailabilityZone: "eu-central-1c",
+					IsDefaultSubnet:  false,
+				},
+			},
+		},
+		{
+			name:    "test, subnet list empty",
+			subnets: apiv1.AWSSubnetList{},
+			machineDeployments: &clusterv1alpha1.MachineDeploymentList{
+				Items: []clusterv1alpha1.MachineDeployment{
+					*test.GenTestMachineDeployment("md-1-a", `{"cloudProvider":"aws","cloudProviderSpec":{"token":"dummy-token","region":"eu-central-1","availabilityZone":"eu-central-1a","vpcId":"vpc-819f62e9","subnetId":"subnet-2bff4f43","instanceType":"t2.micro","diskSize":50}, "operatingSystem":"ubuntu", "operatingSystemSpec":{"distUpgradeOnBoot":false}}`, nil),
+					*test.GenTestMachineDeployment("md-1-b", `{"cloudProvider":"aws","cloudProviderSpec":{"token":"dummy-token","region":"eu-central-1","availabilityZone":"eu-central-1b","vpcId":"vpc-819f62e9","subnetId":"subnet-2bff4f43","instanceType":"t2.micro","diskSize":50}, "operatingSystem":"ubuntu", "operatingSystemSpec":{"distUpgradeOnBoot":false}}`, nil),
+					*test.GenTestMachineDeployment("md-1-c", `{"cloudProvider":"aws","cloudProviderSpec":{"token":"dummy-token","region":"eu-central-1","availabilityZone":"eu-central-1c","vpcId":"vpc-819f62e9","subnetId":"subnet-2bff4f43","instanceType":"t2.micro","diskSize":50}, "operatingSystem":"ubuntu", "operatingSystemSpec":{"distUpgradeOnBoot":false}}`, nil),
+				},
+			},
+			expectedError: "the subnet list can not be empty",
+		},
+	}
+
+	for _, tc := range testcases {
+		t.Run(tc.name, func(t *testing.T) {
+
+			result, err := provider.SetDefaultSubnet(tc.machineDeployments, tc.subnets)
+			if tc.expectedError != "" {
+				if err == nil {
+					t.Fatal("expected error")
+				}
+				if tc.expectedError != err.Error() {
+					t.Fatalf("expected error: %v got %v", tc.expectedError, err)
+				}
+			} else {
+				if err != nil {
+					t.Fatal(err)
+				}
+				if !reflect.DeepEqual(tc.expectedResult, result) {
+					t.Fatalf("expected: %v got %v", tc.expectedResult, result)
+				}
+			}
+		})
+	}
+}

--- a/api/pkg/test/e2e/api/utils/apiclient/models/a_w_s_subnet.go
+++ b/api/pkg/test/e2e/api/utils/apiclient/models/a_w_s_subnet.go
@@ -39,6 +39,9 @@ type AWSSubnet struct {
 	// ipv6 c ID r
 	IPV6CIDR string `json:"ipv6cidr,omitempty"`
 
+	// is default subnet
+	IsDefaultSubnet bool `json:"isDefaultSubnet,omitempty"`
+
 	// name
 	Name string `json:"name,omitempty"`
 


### PR DESCRIPTION
**What this PR does / why we need it**: add defaulting for AWS subnet. The subnet object contains `isDefaultSubnet` flag right now. The UI will sort the subnet list by this flag.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #4357

```release-note
NONE
```
