### PR TITLE
Add script for syncing data to the docs repository

### DIFF
--- a/api/hack/ci/ci-update-docs.sh
+++ b/api/hack/ci/ci-update-docs.sh
@@ -25,4 +25,4 @@ make runbook
 # update repo
 git add .
 git commit -m "update data files to kubermatic@$REVISION"
-git push
+# git push

--- a/api/hack/ci/ci-update-docs.sh
+++ b/api/hack/ci/ci-update-docs.sh
@@ -24,5 +24,6 @@ make runbook
 
 # update repo
 git add .
+git diff --cached
 git commit -m "update data files to kubermatic@$REVISION"
 # git push

--- a/api/hack/ci/ci-update-docs.sh
+++ b/api/hack/ci/ci-update-docs.sh
@@ -24,6 +24,6 @@ make runbook
 
 # update repo
 git add .
-git diff --cached
+git diff --cached --stat
 git commit -m "update data files to kubermatic@$REVISION"
-# git push
+git push

--- a/api/hack/ci/ci-update-docs.sh
+++ b/api/hack/ci/ci-update-docs.sh
@@ -1,0 +1,28 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+cd $(dirname $0)/../../..
+
+TARGET_DIR=docs_sync
+REVISION=$(git rev-parse --short HEAD)
+
+# configure Git
+git config --global user.email "dev@loodse.com"
+git config --global user.name "Prow CI Robot"
+git config --global core.sshCommand 'ssh -o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no -i /ssh/id_rsa'
+
+# create a fresh clone
+git clone git@github.com:kubermatic/docs.git $TARGET_DIR
+cd $TARGET_DIR
+
+# copy interesting files over
+cp ../docs/zz_generated.seed.yaml data/seed.yaml
+
+# re-create Prometheus runbook
+make runbook
+
+# update repo
+git add .
+git commit -m "update data files to kubermatic@$REVISION"
+git push

--- a/api/hack/ci/ci-update-docs.sh
+++ b/api/hack/ci/ci-update-docs.sh
@@ -25,5 +25,5 @@ make runbook
 # update repo
 git add .
 git diff --cached --stat
-git commit -m "update data files to kubermatic@$REVISION"
+git commit -m "Syncing with kubermatic/kubermatic@$REVISION"
 git push

--- a/containers/util/Dockerfile
+++ b/containers/util/Dockerfile
@@ -15,6 +15,8 @@ RUN apk add --no-cache -U \
     iptables \
     ipvsadm \
     jq \
+    make \
+    openssh-client \
     rsync \
     socat \
     unzip

--- a/containers/util/release.sh
+++ b/containers/util/release.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 
 SUFFIX=""
-VERSION=1.2.0
+VERSION=1.3.0
 
 set -euox pipefail
 


### PR DESCRIPTION
**What this PR does / why we need it**:
This new script copies the shiny new Seed CRD example to the docs repo, as well as updating the Prometheus runbook based on our current ruleset.

The Seed CRD YAML file can then be imported by whatever content page wants to. This way we don't hardcode any document structure into this script.

**Does this PR introduce a user-facing change?**:
```release-note
NONE
```
