### PR TITLE
Kubermatic controller manager controller: Set seed reconcile success condition

### DIFF
--- a/api/cmd/kubermatic-controller-manager/controllers.go
+++ b/api/cmd/kubermatic-controller-manager/controllers.go
@@ -18,7 +18,6 @@ import (
 	openshiftcontroller "github.com/kubermatic/kubermatic/api/pkg/controller/openshift"
 	updatecontroller "github.com/kubermatic/kubermatic/api/pkg/controller/update"
 	kubermaticv1 "github.com/kubermatic/kubermatic/api/pkg/crd/kubermatic/v1"
-	"github.com/kubermatic/kubermatic/api/pkg/util/workerlabel"
 	"github.com/kubermatic/kubermatic/api/pkg/version"
 
 	corev1 "k8s.io/api/core/v1"
@@ -54,7 +53,6 @@ func createAllControllers(ctrlCtx *controllerContext) error {
 }
 
 func createClusterComponentDefaulter(ctrlCtx *controllerContext) error {
-	predicates := workerlabel.Predicates(ctrlCtx.runOptions.workerName)
 	defaultCompontentsOverrides := kubermaticv1.ComponentSettings{
 		Apiserver: kubermaticv1.APIServerSettings{
 			DeploymentSettings:          kubermaticv1.DeploymentSettings{Replicas: utilpointer.Int32Ptr(int32(ctrlCtx.runOptions.apiServerDefaultReplicas))},
@@ -71,18 +69,17 @@ func createClusterComponentDefaulter(ctrlCtx *controllerContext) error {
 		ctrlCtx.mgr,
 		ctrlCtx.runOptions.workerCount,
 		defaultCompontentsOverrides,
-		predicates,
+		ctrlCtx.runOptions.workerName,
 	)
 }
 
 func createCloudController(ctrlCtx *controllerContext) error {
-	predicates := workerlabel.Predicates(ctrlCtx.runOptions.workerName)
 	if err := cloudcontroller.Add(
 		ctrlCtx.mgr,
 		ctrlCtx.log,
 		ctrlCtx.runOptions.workerCount,
 		ctrlCtx.seedGetter,
-		predicates,
+		ctrlCtx.runOptions.workerName,
 	); err != nil {
 		return fmt.Errorf("failed to add cloud controller to mgr: %v", err)
 	}

--- a/api/pkg/controller/addon/addon_controller.go
+++ b/api/pkg/controller/addon/addon_controller.go
@@ -484,28 +484,6 @@ func (r *Reconciler) ensureIsInstalled(ctx context.Context, log *zap.SugaredLogg
 	return err
 }
 
-func (r *Reconciler) cleanupManifests(ctx context.Context, log *zap.SugaredLogger, addon *kubermaticv1.Addon, cluster *kubermaticv1.Cluster) error {
-	kubeconfigFilename, manifestFilename, done, err := r.setupManifestInteraction(log, addon, cluster)
-	if err != nil {
-		return err
-	}
-	defer done()
-
-	cmd := r.getDeleteCommand(ctx, kubeconfigFilename, manifestFilename, isOpenshift(cluster))
-	cmdLog := log.With("cmd", strings.Join(cmd.Args, " "))
-
-	cmdLog.Debug("Deleting resources...")
-	out, err := cmd.CombinedOutput()
-	cmdLog.Debugw("Finished executing command", "output", string(out))
-	if err != nil {
-		if wasKubectlDeleteSuccessful(string(out)) {
-			return nil
-		}
-		return fmt.Errorf("failed to execute '%s' for addon %s of cluster %s: %v\n%s", strings.Join(cmd.Args, " "), addon.Name, cluster.Name, err, string(out))
-	}
-	return nil
-}
-
 func isOpenshift(c *kubermaticv1.Cluster) bool {
 	return c.Annotations["kubermatic.io/openshift"] != ""
 }

--- a/api/pkg/controller/addoninstaller/addoninstaller_controller.go
+++ b/api/pkg/controller/addoninstaller/addoninstaller_controller.go
@@ -102,22 +102,20 @@ func (r *Reconciler) Reconcile(request reconcile.Request) (reconcile.Result, err
 		return reconcile.Result{}, err
 	}
 
-	reconcilingStatus := corev1.ConditionFalse
-	var errs []error
 	// Add a wrapping here so we can emit an event on error
-	result, err := r.reconcile(ctx, log, cluster)
+	result, err := kubermaticv1helper.ClusterReconcileWrapper(
+		ctx,
+		r.Client,
+		r.workerName,
+		cluster,
+		kubermaticv1.ClusterConditionAddonInstallerControllerReconcilingSuccess,
+		func() (*reconcile.Result, error) {
+			return r.reconcile(ctx, log, cluster)
+		},
+	)
 	if err != nil {
-		errs = append(errs, err)
 		log.Errorw("Reconciling failed", zap.Error(err))
-		r.recorder.Eventf(cluster, corev1.EventTypeWarning, "ReconcilingError", "%v", err)
-	}
-	if result == nil && err == nil {
-		reconcilingStatus = corev1.ConditionTrue
-	}
-	kubermaticv1helper.SetClusterCondition(cluster, kubermaticv1.ClusterConditionAddonInstallerControllerReconcilingSuccess, reconcilingStatus, "", "")
-	if err := r.Update(ctx, cluster); err != nil {
-		log.Errorw("Failed to update ReconcilingSuccess condition", zap.Error(err))
-		errs = append(errs, err)
+		r.recorder.Event(cluster, corev1.EventTypeWarning, "ReconcilingError", err.Error())
 	}
 	if result == nil {
 		result = &reconcile.Result{}
@@ -135,16 +133,6 @@ func (r *Reconciler) reconcile(ctx context.Context, log *zap.SugaredLogger, clus
 	} else {
 		log = log.With("clustertype", "kubernetes")
 		addonsToInstall = r.kubernetesAddons
-	}
-
-	if cluster.Spec.Pause {
-		log.Debug("Skipping because the cluster is paused")
-		return nil, nil
-	}
-
-	if cluster.Labels[kubermaticv1.WorkerNameLabelKey] != r.workerName {
-		log.Debug("Skipping because the cluster has a different worker name set")
-		return nil, nil
 	}
 
 	// Wait until the Apiserver is running to ensure the namespace exists at least.

--- a/api/pkg/controller/backup/backup_controller.go
+++ b/api/pkg/controller/backup/backup_controller.go
@@ -11,6 +11,7 @@ import (
 	"go.uber.org/zap"
 
 	kubermaticv1 "github.com/kubermatic/kubermatic/api/pkg/crd/kubermatic/v1"
+	kubermaticv1helper "github.com/kubermatic/kubermatic/api/pkg/crd/kubermatic/v1/helper"
 	kuberneteshelper "github.com/kubermatic/kubermatic/api/pkg/kubernetes"
 	"github.com/kubermatic/kubermatic/api/pkg/resources"
 	"github.com/kubermatic/kubermatic/api/pkg/resources/certificates"
@@ -25,6 +26,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/apimachinery/pkg/types"
+	utilerrors "k8s.io/apimachinery/pkg/util/errors"
 	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
 	"k8s.io/apimachinery/pkg/util/sets"
 	"k8s.io/apimachinery/pkg/util/wait"
@@ -210,13 +212,22 @@ func (r *Reconciler) Reconcile(request reconcile.Request) (reconcile.Result, err
 		return reconcile.Result{}, err
 	}
 
+	reconcilingStatus := corev1.ConditionTrue
+	var errs []error
 	// Add a wrapping here so we can emit an event on error
 	err := r.reconcile(ctx, log, cluster)
 	if err != nil {
 		log.Errorw("Reconciling failed", zap.Error(err))
 		r.recorder.Eventf(cluster, corev1.EventTypeWarning, "ReconcilingError", "%v", err)
+		reconcilingStatus = corev1.ConditionFalse
+		errs = append(errs, err)
 	}
-	return reconcile.Result{}, err
+	kubermaticv1helper.SetClusterCondition(cluster, kubermaticv1.ClusterConditionClusterControllerReconcilingSuccess, reconcilingStatus, "", "")
+	if err := r.Update(ctx, cluster); err != nil {
+		log.Errorw("Failed to update ReconcilingSuccess condition", zap.Error(err))
+		errs = append(errs, err)
+	}
+	return reconcile.Result{}, utilerrors.NewAggregate(errs)
 }
 
 func (r *Reconciler) reconcile(ctx context.Context, log *zap.SugaredLogger, cluster *kubermaticv1.Cluster) error {

--- a/api/pkg/controller/cluster/cluster_controller.go
+++ b/api/pkg/controller/cluster/cluster_controller.go
@@ -23,7 +23,6 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
-	utilerrors "k8s.io/apimachinery/pkg/util/errors"
 	autoscalingv1beta2 "k8s.io/autoscaler/vertical-pod-autoscaler/pkg/apis/autoscaling.k8s.io/v1beta2"
 	"k8s.io/client-go/tools/record"
 	"k8s.io/client-go/util/retry"
@@ -188,64 +187,40 @@ func (r *Reconciler) Reconcile(request reconcile.Request) (reconcile.Result, err
 	}
 	log = log.With("cluster", cluster.Name)
 
-	if cluster.Spec.Pause {
-		log.Debug("Skipping because the cluster is paused")
-		return reconcile.Result{}, nil
-	}
-
-	if cluster.Labels[kubermaticv1.WorkerNameLabelKey] != r.workerName {
-		log.Debugw(
-			"Skipping because the cluster has a different worker name set",
-			"cluster-worker-name", cluster.Labels[kubermaticv1.WorkerNameLabelKey],
-		)
-		return reconcile.Result{}, nil
-	}
-
 	if cluster.Annotations["kubermatic.io/openshift"] != "" {
 		log.Debug("Skipping because the cluster is an OpenShift cluster")
 		return reconcile.Result{}, nil
 	}
 
-	// only reconcile this cluster if there are not yet too many updates running
-	if available, err := controllerutil.ClusterAvailableForReconciling(ctx, r, cluster, r.concurrentClusterUpdates); !available || err != nil {
-		log.Infow("Concurrency limit reached, checking again in 10 seconds", "concurrency-limit", r.concurrentClusterUpdates)
-		return reconcile.Result{
-			RequeueAfter: 10 * time.Second,
-		}, err
-	}
-
-	successfullyReconciled := true
 	// Add a wrapping here so we can emit an event on error
-	var errs []error
-	result, err := r.reconcile(ctx, log, cluster)
+	result, err := kubermaticv1helper.ClusterReconcileWrapper(
+		ctx,
+		r.Client,
+		r.workerName,
+		cluster,
+		kubermaticv1.ClusterConditionClusterControllerReconcilingSuccess,
+		func() (*reconcile.Result, error) {
+			// only reconcile this cluster if there are not yet too many updates running
+			if available, err := controllerutil.ClusterAvailableForReconciling(ctx, r, cluster, r.concurrentClusterUpdates); !available || err != nil {
+				log.Infow("Concurrency limit reached, checking again in 10 seconds", "concurrency-limit", r.concurrentClusterUpdates)
+				return &reconcile.Result{
+					RequeueAfter: 10 * time.Second,
+				}, err
+			}
+
+			return r.reconcile(ctx, log, cluster)
+		},
+	)
 	if err != nil {
-		successfullyReconciled = false
 		log.Errorw("Reconciling failed", zap.Error(err))
 		r.recorder.Event(cluster, corev1.EventTypeWarning, "ReconcilingError", err.Error())
-		errs = append(errs, err)
 	}
 
 	if result == nil {
 		result = &reconcile.Result{}
 	}
 
-	if err := controllerutil.SetSeedResourcesUpToDateCondition(ctx, cluster, r.Client, successfullyReconciled); err != nil {
-		log.Errorw("failed to update clusters status conditions", zap.Error(err))
-		errs = append(errs, err)
-	}
-
-	if err := r.updateCluster(ctx, cluster, func(c *kubermaticv1.Cluster) {
-		status := corev1.ConditionFalse
-		if successfullyReconciled && !result.Requeue && result.RequeueAfter == 0 {
-			status = corev1.ConditionTrue
-		}
-		kubermaticv1helper.SetClusterCondition(c, kubermaticv1.ClusterConditionClusterControllerReconcilingSuccess, status, "", "")
-	}); err != nil {
-		log.Errorw("Failed to update ReconcilingSuccess condition", zap.Error(err))
-		errs = append(errs, err)
-	}
-
-	return *result, utilerrors.NewAggregate(errs)
+	return *result, err
 }
 
 func (r *Reconciler) reconcile(ctx context.Context, log *zap.SugaredLogger, cluster *kubermaticv1.Cluster) (*reconcile.Result, error) {

--- a/api/pkg/controller/cluster/cluster_controller.go
+++ b/api/pkg/controller/cluster/cluster_controller.go
@@ -236,7 +236,7 @@ func (r *Reconciler) Reconcile(request reconcile.Request) (reconcile.Result, err
 
 	if err := r.updateCluster(ctx, cluster, func(c *kubermaticv1.Cluster) {
 		status := corev1.ConditionFalse
-		if successfullyReconciled {
+		if successfullyReconciled && !result.Requeue && result.RequeueAfter == 0 {
 			status = corev1.ConditionTrue
 		}
 		kubermaticv1helper.SetClusterCondition(c, kubermaticv1.ClusterConditionClusterControllerReconcilingSuccess, status, "", "")

--- a/api/pkg/controller/monitoring/monitoring_controller.go
+++ b/api/pkg/controller/monitoring/monitoring_controller.go
@@ -10,6 +10,7 @@ import (
 	k8cuserclusterclient "github.com/kubermatic/kubermatic/api/pkg/cluster/client"
 	controllerutil "github.com/kubermatic/kubermatic/api/pkg/controller/util"
 	kubermaticv1 "github.com/kubermatic/kubermatic/api/pkg/crd/kubermatic/v1"
+	kubermaticv1helper "github.com/kubermatic/kubermatic/api/pkg/crd/kubermatic/v1/helper"
 	"github.com/kubermatic/kubermatic/api/pkg/provider"
 
 	appsv1 "k8s.io/api/apps/v1"
@@ -17,6 +18,7 @@ import (
 	rbacv1 "k8s.io/api/rbac/v1"
 	kubeapierrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/runtime"
+	utilerrors "k8s.io/apimachinery/pkg/util/errors"
 	autoscalingv1beta2 "k8s.io/autoscaler/vertical-pod-autoscaler/pkg/apis/autoscaling.k8s.io/v1beta2"
 	"k8s.io/client-go/tools/record"
 	ctrlruntimeclient "sigs.k8s.io/controller-runtime/pkg/client"
@@ -169,15 +171,6 @@ func (r *Reconciler) Reconcile(request reconcile.Request) (reconcile.Result, err
 
 	log = log.With("cluster", cluster.Name)
 
-	if cluster.Spec.Pause {
-		log.Debug("Skipping cluster reconciling because it was set to paused")
-		return reconcile.Result{}, nil
-	}
-
-	if cluster.Labels[kubermaticv1.WorkerNameLabelKey] != r.workerName {
-		return reconcile.Result{}, nil
-	}
-
 	if cluster.DeletionTimestamp != nil {
 		// Cluster got deleted - all monitoring components will be automatically garbage collected (Due to the ownerRef)
 		return reconcile.Result{}, nil
@@ -194,21 +187,32 @@ func (r *Reconciler) Reconcile(request reconcile.Request) (reconcile.Result, err
 		return reconcile.Result{RequeueAfter: healthCheckPeriod}, nil
 	}
 
-	// only reconcile this cluster if there are not yet too many updates running
-	if available, err := controllerutil.ClusterAvailableForReconciling(ctx, r, cluster, r.concurrentClusterUpdates); !available || err != nil {
-		log.Infow("Concurrency limit reached, checking again in 10 seconds", "concurrency-limit", r.concurrentClusterUpdates)
-		return reconcile.Result{
-			RequeueAfter: 10 * time.Second,
-		}, err
-	}
-
+	var errs []error
 	successfullyReconciled := true
 	// Add a wrapping here so we can emit an event on error
-	result, reconcileErr := r.reconcile(ctx, log, cluster)
-	if reconcileErr != nil {
+	result, err := kubermaticv1helper.ClusterReconcileWrapper(
+		ctx,
+		r.Client,
+		r.workerName,
+		cluster,
+		kubermaticv1.ClusterConditionMonitoringControllerReconcilingSuccess,
+		func() (*reconcile.Result, error) {
+			// only reconcile this cluster if there are not yet too many updates running
+			if available, err := controllerutil.ClusterAvailableForReconciling(ctx, r, cluster, r.concurrentClusterUpdates); !available || err != nil {
+				log.Infow("Concurrency limit reached, checking again in 10 seconds", "concurrency-limit", r.concurrentClusterUpdates)
+				return &reconcile.Result{
+					RequeueAfter: 10 * time.Second,
+				}, err
+			}
+
+			return r.reconcile(ctx, log, cluster)
+		},
+	)
+	if err != nil {
 		successfullyReconciled = false
-		log.Errorw("Failed to reconcile cluster", zap.Error(reconcileErr))
-		r.recorder.Eventf(cluster, corev1.EventTypeWarning, "ReconcilingError", "%v", reconcileErr)
+		errs = append(errs, err)
+		log.Errorw("Failed to reconcile cluster", zap.Error(err))
+		r.recorder.Event(cluster, corev1.EventTypeWarning, "ReconcilingError", err.Error())
 	}
 
 	if result == nil {
@@ -217,10 +221,10 @@ func (r *Reconciler) Reconcile(request reconcile.Request) (reconcile.Result, err
 
 	if err := controllerutil.SetSeedResourcesUpToDateCondition(ctx, cluster, r, successfullyReconciled); err != nil {
 		log.Errorw("failed to update clusters status conditions", zap.Error(err))
-		reconcileErr = fmt.Errorf("failed to set cluster status: %v after reconciliation was done with err=%v", err, reconcileErr)
+		errs = append(errs, err)
 	}
 
-	return *result, reconcileErr
+	return *result, utilerrors.NewAggregate(errs)
 }
 
 func (r *Reconciler) reconcile(ctx context.Context, log *zap.SugaredLogger, cluster *kubermaticv1.Cluster) (*reconcile.Result, error) {

--- a/api/pkg/controller/openshift/openshift_controller.go
+++ b/api/pkg/controller/openshift/openshift_controller.go
@@ -14,6 +14,7 @@ import (
 	openshiftresources "github.com/kubermatic/kubermatic/api/pkg/controller/openshift/resources"
 	controllerutil "github.com/kubermatic/kubermatic/api/pkg/controller/util"
 	kubermaticv1 "github.com/kubermatic/kubermatic/api/pkg/crd/kubermatic/v1"
+	kubermaticv1helper "github.com/kubermatic/kubermatic/api/pkg/crd/kubermatic/v1/helper"
 	kuberneteshelper "github.com/kubermatic/kubermatic/api/pkg/kubernetes"
 	"github.com/kubermatic/kubermatic/api/pkg/provider"
 	"github.com/kubermatic/kubermatic/api/pkg/resources"
@@ -40,6 +41,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
+	utilerrors "k8s.io/apimachinery/pkg/util/errors"
 	autoscalingv1beta2 "k8s.io/autoscaler/vertical-pod-autoscaler/pkg/apis/autoscaling.k8s.io/v1beta2"
 	"k8s.io/client-go/tools/clientcmd"
 	clientcmdapi "k8s.io/client-go/tools/clientcmd/api"
@@ -171,40 +173,35 @@ func (r *Reconciler) Reconcile(request reconcile.Request) (reconcile.Result, err
 	}
 	log = log.With("cluster", cluster.Name)
 
-	if cluster.Spec.Pause {
-		log.Debug("Skipping because the cluster is paused")
-		return reconcile.Result{}, nil
-	}
-
 	if cluster.Annotations["kubermatic.io/openshift"] == "" {
 		log.Debug("Skipping because the cluster is an Kubernetes cluster")
 		return reconcile.Result{}, nil
 	}
 
-	if cluster.Labels[kubermaticv1.WorkerNameLabelKey] != r.workerName {
-		log.Debugw(
-			"Skipping because the cluster has a different worker name set",
-			"cluster-worker-name", cluster.Labels[kubermaticv1.WorkerNameLabelKey],
-		)
-		return reconcile.Result{}, nil
-	}
-
-	// only reconcile this cluster if there are not yet too many updates running
-	if available, err := controllerutil.ClusterAvailableForReconciling(ctx, r, cluster, r.concurrentClusterUpdates); !available || err != nil {
-		log.Infow("Concurrency limit reached, checking again in 10 seconds", "concurrency-limit", r.concurrentClusterUpdates)
-		return reconcile.Result{
-			RequeueAfter: 10 * time.Second,
-		}, err
-	}
-
 	successfullyReconciled := true
+	var errs []error
 	// Add a wrapping here so we can emit an event on error
-	result, reconcileErr := r.reconcile(ctx, log, cluster)
-	recorderCluster := cluster.DeepCopy()
-	if reconcileErr != nil {
+	result, err := kubermaticv1helper.ClusterReconcileWrapper(
+		ctx,
+		r.Client,
+		r.workerName,
+		cluster,
+		kubermaticv1.ClusterConditionOpenshiftControllerReconcilingSuccess,
+		func() (*reconcile.Result, error) {
+			// only reconcile this cluster if there are not yet too many updates running
+			if available, err := controllerutil.ClusterAvailableForReconciling(ctx, r, cluster, r.concurrentClusterUpdates); !available || err != nil {
+				log.Infow("Concurrency limit reached, checking again in 10 seconds", "concurrency-limit", r.concurrentClusterUpdates)
+				return &reconcile.Result{RequeueAfter: 10 * time.Second}, err
+			}
+
+			return r.reconcile(ctx, log, cluster)
+		},
+	)
+	if err != nil {
 		successfullyReconciled = false
-		log.Errorw("Reconciling failed", zap.Error(reconcileErr))
-		r.recorder.Eventf(recorderCluster, corev1.EventTypeWarning, "ReconcilingError", "%v", reconcileErr)
+		log.Errorw("Reconciling failed", zap.Error(err))
+		r.recorder.Eventf(cluster, corev1.EventTypeWarning, "ReconcilingError", err.Error())
+		errs = append(errs, err)
 	}
 
 	if result == nil {
@@ -213,10 +210,10 @@ func (r *Reconciler) Reconcile(request reconcile.Request) (reconcile.Result, err
 
 	if err := controllerutil.SetSeedResourcesUpToDateCondition(ctx, cluster, r, successfullyReconciled); err != nil {
 		log.Errorw("failed to update clusters status conditions", zap.Error(err))
-		reconcileErr = fmt.Errorf("failed to set cluster status: %v after reconciliation was done with err=%v", err, reconcileErr)
+		errs = append(errs, err)
 	}
 
-	return *result, reconcileErr
+	return *result, utilerrors.NewAggregate(errs)
 }
 
 func (r *Reconciler) reconcile(ctx context.Context, log *zap.SugaredLogger, cluster *kubermaticv1.Cluster) (*reconcile.Result, error) {

--- a/api/pkg/controller/update/update_controller.go
+++ b/api/pkg/controller/update/update_controller.go
@@ -79,11 +79,12 @@ func (r *Reconciler) Reconcile(request reconcile.Request) (reconcile.Result, err
 	}
 
 	// Add a wrapping here so we can emit an event on error
-	result, err := kubermaticv1helper.ClusterConditionSettingReconcileWrapper(
+	result, err := kubermaticv1helper.ClusterReconcileWrapper(
 		ctx,
 		r.Client,
-		cluster.Name,
-		kubermaticv1.ClusterConditionUpdateControllerReconcilingSuccessful,
+		r.workerName,
+		cluster,
+		kubermaticv1.ClusterConditionUpdateControllerReconcilingSuccess,
 		func() (*reconcile.Result, error) {
 			return r.reconcile(ctx, cluster)
 		},
@@ -99,13 +100,6 @@ func (r *Reconciler) Reconcile(request reconcile.Request) (reconcile.Result, err
 }
 
 func (r *Reconciler) reconcile(ctx context.Context, cluster *kubermaticv1.Cluster) (*reconcile.Result, error) {
-	if cluster.Labels[kubermaticv1.WorkerNameLabelKey] != r.workerName {
-		return nil, nil
-	}
-
-	if cluster.Spec.Pause {
-		return nil, nil
-	}
 
 	if !cluster.Status.ExtendedHealth.AllHealthy() {
 		// Cluster not healthy yet. Nothing to do.

--- a/api/pkg/controller/util/util.go
+++ b/api/pkg/controller/util/util.go
@@ -122,7 +122,7 @@ func SetSeedResourcesUpToDateCondition(ctx context.Context, cluster *kubermaticv
 				kubermaticv1.ClusterConditionSeedResourcesUpToDate,
 				corev1.ConditionFalse,
 				kubermaticv1.ReasonClusterUpdateSuccessful,
-				"All controlplane components are up to date")
+				"Some controlplane components did not finish updating")
 		})
 	}
 
@@ -131,7 +131,7 @@ func SetSeedResourcesUpToDateCondition(ctx context.Context, cluster *kubermaticv
 			kubermaticv1.ClusterConditionSeedResourcesUpToDate,
 			corev1.ConditionTrue,
 			kubermaticv1.ReasonClusterUpdateSuccessful,
-			"Some controlplane components did not finish updating")
+			"All controlplane components are up to date")
 	})
 }
 

--- a/api/pkg/crd/kubermatic/v1/cluster.go
+++ b/api/pkg/crd/kubermatic/v1/cluster.go
@@ -113,8 +113,9 @@ const (
 
 	// ClusterConditionAddonControllerReconcilingSuccess indicates whether the addon controller
 	// succeeded in reconciling the cluster.
-	ClusterConditionAddonControllerReconcilingSuccess          ClusterConditionType = "AddonControllerReconcilledSuccessfully"
-	ClusterConditionAddonInstallerControllerReconcilingSuccess ClusterConditionType = "AddonInstallerControllerReconcilledSuccessfully"
+	ClusterConditionAddonControllerReconcilingSuccess          ClusterConditionType = "AddonControllerReconciledSuccessfully"
+	ClusterConditionAddonInstallerControllerReconcilingSuccess ClusterConditionType = "AddonInstallerControllerReconciledSuccessfully"
+	ClusterConditionBackupControllerReconcilingSuccessful      ClusterConditionType = "BackupControllerReconciledSuccessfully"
 
 	ReasonClusterUpdateSuccessful = "ClusterUpdateSuccessful"
 	ReasonClusterUpadteInProgress = "ClusterUpdateInProgress"

--- a/api/pkg/crd/kubermatic/v1/cluster.go
+++ b/api/pkg/crd/kubermatic/v1/cluster.go
@@ -116,6 +116,7 @@ const (
 	ClusterConditionAddonControllerReconcilingSuccess          ClusterConditionType = "AddonControllerReconciledSuccessfully"
 	ClusterConditionAddonInstallerControllerReconcilingSuccess ClusterConditionType = "AddonInstallerControllerReconciledSuccessfully"
 	ClusterConditionBackupControllerReconcilingSuccessful      ClusterConditionType = "BackupControllerReconciledSuccessfully"
+	ClusterConditionCloudControllerReconcilingSuccessful       ClusterConditionType = "CloudControllerReconcilledSuccessfully"
 
 	ReasonClusterUpdateSuccessful = "ClusterUpdateSuccessful"
 	ReasonClusterUpadteInProgress = "ClusterUpdateInProgress"

--- a/api/pkg/crd/kubermatic/v1/cluster.go
+++ b/api/pkg/crd/kubermatic/v1/cluster.go
@@ -113,7 +113,8 @@ const (
 
 	// ClusterConditionAddonControllerReconcilingSuccess indicates whether the addon controller
 	// succeeded in reconciling the cluster.
-	ClusterConditionAddonControllerReconcilingSuccess ClusterConditionType = "AddonControllerReconcilledSuccessfully"
+	ClusterConditionAddonControllerReconcilingSuccess          ClusterConditionType = "AddonControllerReconcilledSuccessfully"
+	ClusterConditionAddonInstallerControllerReconcilingSuccess ClusterConditionType = "AddonInstallerControllerReconcilledSuccessfully"
 
 	ReasonClusterUpdateSuccessful = "ClusterUpdateSuccessful"
 	ReasonClusterUpadteInProgress = "ClusterUpdateInProgress"

--- a/api/pkg/crd/kubermatic/v1/cluster.go
+++ b/api/pkg/crd/kubermatic/v1/cluster.go
@@ -107,6 +107,10 @@ const (
 	// the status of cloud provider resources for a given cluster.
 	ClusterConditionSeedResourcesUpToDate ClusterConditionType = "SeedResourcesUpToDate"
 
+	// ClusterConditionClusterControllerReconcilingSuccess indicates whether the cluster
+	// controller successfully finished reconciling this cluster.
+	ClusterConditionClusterControllerReconcilingSuccess ClusterConditionType = "ClusterControllerReconciledSuccessfully"
+
 	ReasonClusterUpdateSuccessful = "ClusterUpdateSuccessful"
 	ReasonClusterUpadteInProgress = "ClusterUpdateInProgress"
 )

--- a/api/pkg/crd/kubermatic/v1/cluster.go
+++ b/api/pkg/crd/kubermatic/v1/cluster.go
@@ -107,12 +107,7 @@ const (
 	// the status of cloud provider resources for a given cluster.
 	ClusterConditionSeedResourcesUpToDate ClusterConditionType = "SeedResourcesUpToDate"
 
-	// ClusterConditionClusterControllerReconcilingSuccess indicates whether the cluster
-	// controller successfully finished reconciling this cluster.
-	ClusterConditionClusterControllerReconcilingSuccess ClusterConditionType = "ClusterControllerReconciledSuccessfully"
-
-	// ClusterConditionAddonControllerReconcilingSuccess indicates whether the addon controller
-	// succeeded in reconciling the cluster.
+	ClusterConditionClusterControllerReconcilingSuccess        ClusterConditionType = "ClusterControllerReconciledSuccessfully"
 	ClusterConditionAddonControllerReconcilingSuccess          ClusterConditionType = "AddonControllerReconciledSuccessfully"
 	ClusterConditionAddonInstallerControllerReconcilingSuccess ClusterConditionType = "AddonInstallerControllerReconciledSuccessfully"
 	ClusterConditionBackupControllerReconcilingSuccess         ClusterConditionType = "BackupControllerReconciledSuccessfully"

--- a/api/pkg/crd/kubermatic/v1/cluster.go
+++ b/api/pkg/crd/kubermatic/v1/cluster.go
@@ -117,7 +117,8 @@ const (
 	ClusterConditionAddonInstallerControllerReconcilingSuccess ClusterConditionType = "AddonInstallerControllerReconciledSuccessfully"
 	ClusterConditionBackupControllerReconcilingSuccessful      ClusterConditionType = "BackupControllerReconciledSuccessfully"
 	ClusterConditionCloudControllerReconcilingSuccessful       ClusterConditionType = "CloudControllerReconcilledSuccessfully"
-	ClusterConditionComponentDefaulterReconciledSuffessful     ClusterConditionType = "ComponentDefaulterReconciledSuccessfully"
+	ClusterConditionComponentDefaulterReconcilingSuccessful    ClusterConditionType = "ComponentDefaulterReconciledSuccessfully"
+	ClusterConditionUpdateControllerReconcilingSuccessful      ClusterConditionType = "UpdateControllerReconciledSuccessfully"
 
 	ReasonClusterUpdateSuccessful = "ClusterUpdateSuccessful"
 	ReasonClusterUpadteInProgress = "ClusterUpdateInProgress"

--- a/api/pkg/crd/kubermatic/v1/cluster.go
+++ b/api/pkg/crd/kubermatic/v1/cluster.go
@@ -111,6 +111,10 @@ const (
 	// controller successfully finished reconciling this cluster.
 	ClusterConditionClusterControllerReconcilingSuccess ClusterConditionType = "ClusterControllerReconciledSuccessfully"
 
+	// ClusterConditionAddonControllerReconcilingSuccess indicates whether the addon controller
+	// succeeded in reconciling the cluster.
+	ClusterConditionAddonControllerReconcilingSuccess ClusterConditionType = "AddonControllerReconcilledSuccessfully"
+
 	ReasonClusterUpdateSuccessful = "ClusterUpdateSuccessful"
 	ReasonClusterUpadteInProgress = "ClusterUpdateInProgress"
 )

--- a/api/pkg/crd/kubermatic/v1/cluster.go
+++ b/api/pkg/crd/kubermatic/v1/cluster.go
@@ -115,10 +115,12 @@ const (
 	// succeeded in reconciling the cluster.
 	ClusterConditionAddonControllerReconcilingSuccess          ClusterConditionType = "AddonControllerReconciledSuccessfully"
 	ClusterConditionAddonInstallerControllerReconcilingSuccess ClusterConditionType = "AddonInstallerControllerReconciledSuccessfully"
-	ClusterConditionBackupControllerReconcilingSuccessful      ClusterConditionType = "BackupControllerReconciledSuccessfully"
-	ClusterConditionCloudControllerReconcilingSuccessful       ClusterConditionType = "CloudControllerReconcilledSuccessfully"
-	ClusterConditionComponentDefaulterReconcilingSuccessful    ClusterConditionType = "ComponentDefaulterReconciledSuccessfully"
-	ClusterConditionUpdateControllerReconcilingSuccessful      ClusterConditionType = "UpdateControllerReconciledSuccessfully"
+	ClusterConditionBackupControllerReconcilingSuccess         ClusterConditionType = "BackupControllerReconciledSuccessfully"
+	ClusterConditionCloudControllerReconcilingSuccess          ClusterConditionType = "CloudControllerReconcilledSuccessfully"
+	ClusterConditionComponentDefaulterReconcilingSuccess       ClusterConditionType = "ComponentDefaulterReconciledSuccessfully"
+	ClusterConditionUpdateControllerReconcilingSuccess         ClusterConditionType = "UpdateControllerReconciledSuccessfully"
+	ClusterConditionMonitoringControllerReconcilingSuccess     ClusterConditionType = "MonitoringControllerReconciledSuccessfully"
+	ClusterConditionOpenshiftControllerReconcilingSuccess      ClusterConditionType = "OpenshiftControllerReconciledSuccessfully"
 
 	ReasonClusterUpdateSuccessful = "ClusterUpdateSuccessful"
 	ReasonClusterUpadteInProgress = "ClusterUpdateInProgress"

--- a/api/pkg/crd/kubermatic/v1/cluster.go
+++ b/api/pkg/crd/kubermatic/v1/cluster.go
@@ -117,6 +117,7 @@ const (
 	ClusterConditionAddonInstallerControllerReconcilingSuccess ClusterConditionType = "AddonInstallerControllerReconciledSuccessfully"
 	ClusterConditionBackupControllerReconcilingSuccessful      ClusterConditionType = "BackupControllerReconciledSuccessfully"
 	ClusterConditionCloudControllerReconcilingSuccessful       ClusterConditionType = "CloudControllerReconcilledSuccessfully"
+	ClusterConditionComponentDefaulterReconciledSuffessful     ClusterConditionType = "ComponentDefaulterReconciledSuccessfully"
 
 	ReasonClusterUpdateSuccessful = "ClusterUpdateSuccessful"
 	ReasonClusterUpadteInProgress = "ClusterUpdateInProgress"


### PR DESCRIPTION
**What this PR does / why we need it**:

Makes all the controllers in the kubermatic controller manager set a `reconcileSuccess` condition, which we need for #3417 

I think I'll create follow-ups for:
* Adding a variadic arg `predicates ..func(*cluster)(*reconcile.Result, error)` to the `ClusterReconcileWrapper`  which we can use for controllers that have extra conditions, e.G. openshift/kubernetes or the `ClusterAvailableForReconciling`
* Move the whole `SetSeedResourcesUpToDateCondition` into its own controller and remove the `successfullyReconciled` bit from it, as this is a condition that spans multiple controller and can currently cause racing if one controller fails to deploy some parts

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Documentation**:
<!-- Add links to the related documentation changes related to this pull request. E.g. the link to the kubermatic/docs pullrequest. -->

**Does this PR introduce a user-facing change?**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If  no release note is required, just write "NONE".
-->
```release-note
none
```
/assign @xrstf 