### PR TITLE
Address CVE-2019-11253 for clusters created before v1.14.0

### DIFF
--- a/api/pkg/controller/usercluster/reconciler.go
+++ b/api/pkg/controller/usercluster/reconciler.go
@@ -16,6 +16,7 @@ import (
 	"github.com/kubermatic/kubermatic/api/pkg/controller/usercluster/resources/openvpn"
 	"github.com/kubermatic/kubermatic/api/pkg/controller/usercluster/resources/prometheus"
 	"github.com/kubermatic/kubermatic/api/pkg/controller/usercluster/resources/scheduler"
+	"github.com/kubermatic/kubermatic/api/pkg/controller/usercluster/resources/system-basic-user"
 	"github.com/kubermatic/kubermatic/api/pkg/controller/usercluster/resources/user-auth"
 	"github.com/kubermatic/kubermatic/api/pkg/resources/reconciling"
 
@@ -286,6 +287,7 @@ func (r *reconciler) reconcileClusterRoleBindings(ctx context.Context) error {
 		scheduler.ClusterRoleBindingAuthDelegatorCreator(),
 		controllermanager.ClusterRoleBindingAuthDelegator(),
 		clusterautoscaler.ClusterRoleBindingCreator(),
+		systembasicuser.ClusterRoleBinding,
 	}
 
 	if err := reconciling.ReconcileClusterRoleBindings(ctx, creators, "", r.Client); err != nil {

--- a/api/pkg/controller/usercluster/resources/system-basic-user/system_basic_user.go
+++ b/api/pkg/controller/usercluster/resources/system-basic-user/system_basic_user.go
@@ -1,0 +1,23 @@
+package systembasicuser
+
+import (
+	"github.com/kubermatic/kubermatic/api/pkg/resources/reconciling"
+
+	rbacv1 "k8s.io/api/rbac/v1"
+)
+
+// ClusterRoleBinding is needed to address CVE-2019-11253 for clusters that were
+// created with a Kubernetes version < 1.14, to remove permissions from
+// unauthenticated users to post data to the API and cause a DOS.
+// For details, see https://github.com/kubernetes/kubernetes/issues/83253
+func ClusterRoleBinding() (string, reconciling.ClusterRoleBindingCreator) {
+	return "system:basic-user", func(crb *rbacv1.ClusterRoleBinding) (*rbacv1.ClusterRoleBinding, error) {
+		crb.Subjects = []rbacv1.Subject{{
+			APIGroup: rbacv1.GroupName,
+			Name:     "system:authenticated",
+			Kind:     rbacv1.GroupKind,
+		}}
+
+		return crb, nil
+	}
+}


### PR DESCRIPTION
**What this PR does / why we need it**:

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #4512

**Special notes for your reviewer**:

**Documentation**:
<!-- Add links to the related documentation changes related to this pull request. E.g. the link to the kubermatic/docs pullrequest. -->

**Does this PR introduce a user-facing change?**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If  no release note is required, just write "NONE".
-->
```release-note
A fix for CVE-2019-11253 for clusters that were created with a Kubernetes version < 1.14 was deployed
```
