### PR TITLE
Fix docs postsubmit

### DIFF
--- a/api/hack/ci/ci-update-docs.sh
+++ b/api/hack/ci/ci-update-docs.sh
@@ -24,6 +24,8 @@ make runbook
 
 # update repo
 git add .
-git diff --cached --stat
-git commit -m "Syncing with kubermatic/kubermatic@$REVISION"
-git push
+
+if ! git diff --cached --stat --exit-code; then
+  git commit -m "Syncing with kubermatic/kubermatic@$REVISION"
+  git push
+fi


### PR DESCRIPTION
**What this PR does / why we need it**:
`git commit` exits with 1 when there are no changes.

**Does this PR introduce a user-facing change?**:
```release-note
NONE
```
