### PR TITLE
Do not forget finalizers on new clusters

### DIFF
--- a/api/pkg/provider/kubernetes/cluster.go
+++ b/api/pkg/provider/kubernetes/cluster.go
@@ -103,6 +103,7 @@ func (p *ClusterProvider) New(project *kubermaticv1.Project, userInfo *provider.
 	newCluster := &kubermaticv1.Cluster{
 		ObjectMeta: metav1.ObjectMeta{
 			Annotations: cluster.Annotations,
+			Finalizers:  cluster.Finalizers,
 			Labels:      getClusterLabels(cluster.Labels, project.Name, p.workerName),
 			Name:        name,
 		},

--- a/api/pkg/provider/kubernetes/cluster_test.go
+++ b/api/pkg/provider/kubernetes/cluster_test.go
@@ -94,6 +94,9 @@ func TestCreateCluster(t *testing.T) {
 					"kubermatic.io/openshift": "true",
 				}
 			}
+			if tc.expectedCluster != nil {
+				partialCluster.Finalizers = tc.expectedCluster.Finalizers
+			}
 
 			cluster, err := target.New(tc.project, tc.userInfo, partialCluster)
 			if len(tc.expectedError) > 0 {

--- a/api/pkg/provider/kubernetes/util_test.go
+++ b/api/pkg/provider/kubernetes/util_test.go
@@ -31,6 +31,9 @@ import (
 const (
 	// TestFakeToken signed JWT token with fake data
 	TestFakeToken = "eyJhbGciOiJIUzI1NiJ9.eyJlbWFpbCI6IjEiLCJleHAiOjE2NDk3NDg4NTYsImlhdCI6MTU1NTA1NDQ1NiwibmJmIjoxNTU1MDU0NDU2LCJwcm9qZWN0X2lkIjoiMSIsInRva2VuX2lkIjoiMSJ9.Q4qxzOaCvUnWfXneY654YiQjUTd_Lsmw56rE17W2ouo"
+
+	// TestFakeFinalizer is a dummy finalizer with no special meaning
+	TestFakeFinalizer = "test.kubermatic.io/dummy"
 )
 
 // fakeKubernetesImpersonationClient gives kubernetes client set that uses user impersonation
@@ -294,6 +297,7 @@ func genCluster(name, clusterType, projectID, workerName, userEmail string) *kub
 		CloudMigrationRevision: cloud.CurrentMigrationRevision,
 	}
 	cluster.Address = kubermaticv1.ClusterAddress{}
+	cluster.Finalizers = []string{TestFakeFinalizer}
 
 	if clusterType == "openshift" {
 		cluster.Annotations = map[string]string{


### PR DESCRIPTION
**What this PR does / why we need it**:
PR #4390 introduced a new finalizer for cleaning up cluster credential secret. However it seems that the cluster provider, when creating a new cluster, was ignoring the finalizers. This made Kubermatic forget the Secrets and not clean up when deleting a cluster.

**Does this PR introduce a user-facing change?**:
```release-note
NONE
```
