### PR TITLE
Disable cluster status

### DIFF
--- a/api/pkg/crd/kubermatic/v1/cluster.go
+++ b/api/pkg/crd/kubermatic/v1/cluster.go
@@ -127,7 +127,7 @@ type ClusterCondition struct {
 	// Status of the condition, one of True, False, Unknown.
 	Status corev1.ConditionStatus `json:"status"`
 	// KubermaticVersion current kubermatic version.
-	KubermaticVersion string `json:"kubermatic_version"`
+	KubermaticVersion string `json:"kubermaticVersion"`
 	// Last time we got an update on a given condition.
 	// +optional
 	LastHeartbeatTime metav1.Time `json:"lastHeartbeatTime,omitempty"`
@@ -149,7 +149,7 @@ type ClusterStatus struct {
 	// Extends standard health status for new states.
 	ExtendedHealth ExtendedClusterHealth `json:"extendedHealth,omitempty"`
 	// KubermaticVersion is the current kubermatic version in a cluster.
-	KubermaticVersion string `json:"kubermatic_version"`
+	KubermaticVersion string `json:"kubermaticVersion"`
 	// Deprecated
 	RootCA *KeyCert `json:"rootCA,omitempty"`
 	// Deprecated

--- a/api/pkg/crd/kubermatic/v1/helper/helper.go
+++ b/api/pkg/crd/kubermatic/v1/helper/helper.go
@@ -10,7 +10,6 @@ import (
 	apiequality "k8s.io/apimachinery/pkg/api/equality"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
-	utilerrors "k8s.io/apimachinery/pkg/util/errors"
 	"k8s.io/client-go/util/retry"
 	ctrlruntimeclient "sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
@@ -36,17 +35,19 @@ func ClusterReconcileWrapper(
 		return nil, nil
 	}
 
-	reconcilingStatus := corev1.ConditionFalse
-	result, err := reconcile()
-	// Only set to true if we had no error and don't want to reqeue the cluster
-	if err == nil && (result == nil || (!result.Requeue && result.RequeueAfter == 0)) {
-		reconcilingStatus = corev1.ConditionTrue
-	}
-	errs := []error{err}
-	errs = append(errs, clusterUpdater(ctx, client, cluster.Name, func(c *kubermaticv1.Cluster) {
-		SetClusterCondition(c, conditionType, reconcilingStatus, "", "")
-	}))
-	return result, utilerrors.NewAggregate(errs)
+	return reconcile()
+
+	// reconcilingStatus := corev1.ConditionFalse
+	// result, err := reconcile()
+	// // Only set to true if we had no error and don't want to reqeue the cluster
+	// if err == nil && (result == nil || (!result.Requeue && result.RequeueAfter == 0)) {
+	// 	reconcilingStatus = corev1.ConditionTrue
+	// }
+	// errs := []error{err}
+	// errs = append(errs, clusterUpdater(ctx, client, cluster.Name, func(c *kubermaticv1.Cluster) {
+	// 	SetClusterCondition(c, conditionType, reconcilingStatus, "", "")
+	// }))
+	// return result, utilerrors.NewAggregate(errs)
 }
 
 func clusterUpdater(

--- a/api/pkg/crd/kubermatic/v1/helper/helper.go
+++ b/api/pkg/crd/kubermatic/v1/helper/helper.go
@@ -9,8 +9,6 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	apiequality "k8s.io/apimachinery/pkg/api/equality"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/apimachinery/pkg/types"
-	"k8s.io/client-go/util/retry"
 	ctrlruntimeclient "sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 )
@@ -50,24 +48,24 @@ func ClusterReconcileWrapper(
 	// return result, utilerrors.NewAggregate(errs)
 }
 
-func clusterUpdater(
-	ctx context.Context,
-	client ctrlruntimeclient.Client,
-	name string,
-	modify func(*kubermaticv1.Cluster),
-) error {
-	return retry.RetryOnConflict(retry.DefaultBackoff, func() error {
-		//Get latest version
-		c := &kubermaticv1.Cluster{}
-		if err := client.Get(ctx, types.NamespacedName{Name: name}, c); err != nil {
-			return err
-		}
-		// Apply modifications
-		modify(c)
-		// Update the cluster
-		return client.Update(ctx, c)
-	})
-}
+// func clusterUpdater(
+// 	ctx context.Context,
+// 	client ctrlruntimeclient.Client,
+// 	name string,
+// 	modify func(*kubermaticv1.Cluster),
+// ) error {
+// 	return retry.RetryOnConflict(retry.DefaultBackoff, func() error {
+// 		//Get latest version
+// 		c := &kubermaticv1.Cluster{}
+// 		if err := client.Get(ctx, types.NamespacedName{Name: name}, c); err != nil {
+// 			return err
+// 		}
+// 		// Apply modifications
+// 		modify(c)
+// 		// Update the cluster
+// 		return client.Update(ctx, c)
+// 	})
+// }
 
 // GetClusterCondition returns the index of the given condition or -1 and the condition itself
 // or a nilpointer.


### PR DESCRIPTION
**What this PR does / why we need it**:
Setting cluster status makes e2e tests fail. This temporarily disables them.

This PR also renames the status name to something that fits better with the rest of Kubermatic and Kubernetes.

**Does this PR introduce a user-facing change?**:
```release-note
NONE
```
