### PR TITLE
Revert New Reconcile Helper

### DIFF
--- a/api/cmd/kubermatic-controller-manager/controllers.go
+++ b/api/cmd/kubermatic-controller-manager/controllers.go
@@ -19,6 +19,7 @@ import (
 	updatecontroller "github.com/kubermatic/kubermatic/api/pkg/controller/update"
 	"github.com/kubermatic/kubermatic/api/pkg/controller/usersshkeys"
 	kubermaticv1 "github.com/kubermatic/kubermatic/api/pkg/crd/kubermatic/v1"
+	"github.com/kubermatic/kubermatic/api/pkg/util/workerlabel"
 	"github.com/kubermatic/kubermatic/api/pkg/version"
 
 	corev1 "k8s.io/api/core/v1"
@@ -55,6 +56,7 @@ func createAllControllers(ctrlCtx *controllerContext) error {
 }
 
 func createClusterComponentDefaulter(ctrlCtx *controllerContext) error {
+	predicates := workerlabel.Predicates(ctrlCtx.runOptions.workerName)
 	defaultCompontentsOverrides := kubermaticv1.ComponentSettings{
 		Apiserver: kubermaticv1.APIServerSettings{
 			DeploymentSettings:          kubermaticv1.DeploymentSettings{Replicas: utilpointer.Int32Ptr(int32(ctrlCtx.runOptions.apiServerDefaultReplicas))},
@@ -71,17 +73,18 @@ func createClusterComponentDefaulter(ctrlCtx *controllerContext) error {
 		ctrlCtx.mgr,
 		ctrlCtx.runOptions.workerCount,
 		defaultCompontentsOverrides,
-		ctrlCtx.runOptions.workerName,
+		predicates,
 	)
 }
 
 func createCloudController(ctrlCtx *controllerContext) error {
+	predicates := workerlabel.Predicates(ctrlCtx.runOptions.workerName)
 	if err := cloudcontroller.Add(
 		ctrlCtx.mgr,
 		ctrlCtx.log,
 		ctrlCtx.runOptions.workerCount,
 		ctrlCtx.seedGetter,
-		ctrlCtx.runOptions.workerName,
+		predicates,
 	); err != nil {
 		return fmt.Errorf("failed to add cloud controller to mgr: %v", err)
 	}

--- a/api/pkg/controller/addon/addon_controller.go
+++ b/api/pkg/controller/addon/addon_controller.go
@@ -17,7 +17,6 @@ import (
 
 	addonutils "github.com/kubermatic/kubermatic/api/pkg/addon"
 	kubermaticv1 "github.com/kubermatic/kubermatic/api/pkg/crd/kubermatic/v1"
-	kubermaticv1helper "github.com/kubermatic/kubermatic/api/pkg/crd/kubermatic/v1/helper"
 	kuberneteshelper "github.com/kubermatic/kubermatic/api/pkg/kubernetes"
 	"github.com/kubermatic/kubermatic/api/pkg/resources"
 
@@ -150,31 +149,20 @@ func (r *Reconciler) Reconcile(request reconcile.Request) (reconcile.Result, err
 	}
 	log = r.log.With("cluster", addon.Spec.Cluster.Name)
 
-	cluster := &kubermaticv1.Cluster{}
-	if err := r.Get(ctx, types.NamespacedName{Name: addon.Spec.Cluster.Name}, cluster); err != nil {
-		// If its not a NotFound return it
-		if !kerrors.IsNotFound(err) {
-			return reconcile.Result{}, err
-		}
-		return reconcile.Result{}, nil
-	}
-
 	// Add a wrapping here so we can emit an event on error
-	result, err := kubermaticv1helper.ClusterReconcileWrapper(
-		ctx,
-		r.Client,
-		r.workerName,
-		cluster,
-		kubermaticv1.ClusterConditionAddonControllerReconcilingSuccess,
-		func() (*reconcile.Result, error) {
-			return r.reconcile(ctx, log, addon, cluster)
-		},
-	)
+	result, err := r.reconcile(ctx, log, addon)
 	if err != nil {
 		log.Errorw("Reconciling failed", zap.Error(err))
-		r.recorder.Event(addon, corev1.EventTypeWarning, "ReconcilingError", err.Error())
-		r.recorder.Eventf(cluster, corev1.EventTypeWarning, "ReconcilingError",
-			"failed to reconcile Addon %q: %v", addon.Name, err)
+		r.recorder.Eventf(addon, corev1.EventTypeWarning, "ReconcilingError", "%v", err)
+		reconcilingError := err
+		//Get the cluster so we can report an event to it
+		cluster := &kubermaticv1.Cluster{}
+		if err := r.Get(ctx, types.NamespacedName{Name: addon.Spec.Cluster.Name}, cluster); err != nil {
+			log.Errorw("failed to get cluster for reporting error onto it", zap.Error(err))
+		} else {
+			r.recorder.Eventf(cluster, corev1.EventTypeWarning, "ReconcilingError",
+				"failed to reconcile Addon %q: %v", addon.Name, reconcilingError)
+		}
 	}
 	if result == nil {
 		result = &reconcile.Result{}
@@ -182,12 +170,21 @@ func (r *Reconciler) Reconcile(request reconcile.Request) (reconcile.Result, err
 	return *result, err
 }
 
-func (r *Reconciler) reconcile(ctx context.Context, log *zap.SugaredLogger, addon *kubermaticv1.Addon, cluster *kubermaticv1.Cluster) (*reconcile.Result, error) {
-	// If the addon has a deletion timestamp, delete it
-	if addon.DeletionTimestamp != nil {
-		if err := r.removeCleanupFinalizer(ctx, log, addon); err != nil {
-			return nil, fmt.Errorf("failed to ensure that the cleanup finalizer got removed from the addon: %v", err)
+func (r *Reconciler) reconcile(ctx context.Context, log *zap.SugaredLogger, addon *kubermaticv1.Addon) (*reconcile.Result, error) {
+	cluster := &kubermaticv1.Cluster{}
+	if err := r.Get(ctx, types.NamespacedName{Name: addon.Spec.Cluster.Name}, cluster); err != nil {
+		// If its not a NotFound return it
+		if !kerrors.IsNotFound(err) {
+			return nil, err
 		}
+
+		// Cluster does not exist - If the addon has the deletion timestamp - we shall delete it
+		if addon.DeletionTimestamp != nil {
+			if err := r.removeCleanupFinalizer(ctx, log, addon); err != nil {
+				return nil, fmt.Errorf("failed to ensure that the cleanup finalizer got removed from the addon: %v", err)
+			}
+		}
+		return nil, nil
 	}
 
 	if err := r.markDefaultAddons(ctx, log, addon, cluster); err != nil {
@@ -196,6 +193,24 @@ func (r *Reconciler) reconcile(ctx context.Context, log *zap.SugaredLogger, addo
 
 	if cluster.DeletionTimestamp != nil {
 		log.Debug("Skipping addon because cluster is deleted")
+		return nil, nil
+	}
+
+	if cluster.Spec.Pause {
+		log.Debug("Skipping because the cluster is paused")
+		return nil, nil
+	}
+
+	if cluster.Labels[kubermaticv1.WorkerNameLabelKey] != r.workerName {
+		log.Debug("Skipping because the cluster has a different worker name set")
+		return nil, nil
+	}
+
+	// When a cluster gets deleted - we can skip it - not worth the effort.
+	// This could lead though to a potential leak of resources in case addons deploy LB's or PV's.
+	// The correct way of handling it though should be a optional cleanup routine in the cluster controller, which will delete all PV's and LB's inside the cluster cluster.
+	if cluster.DeletionTimestamp != nil {
+		log.Debug("Skipping because the cluster is being deleted")
 		return nil, nil
 	}
 

--- a/api/pkg/controller/backup/backup_controller.go
+++ b/api/pkg/controller/backup/backup_controller.go
@@ -11,7 +11,6 @@ import (
 	"go.uber.org/zap"
 
 	kubermaticv1 "github.com/kubermatic/kubermatic/api/pkg/crd/kubermatic/v1"
-	kubermaticv1helper "github.com/kubermatic/kubermatic/api/pkg/crd/kubermatic/v1/helper"
 	kuberneteshelper "github.com/kubermatic/kubermatic/api/pkg/kubernetes"
 	"github.com/kubermatic/kubermatic/api/pkg/resources"
 	"github.com/kubermatic/kubermatic/api/pkg/resources/certificates"
@@ -212,16 +211,7 @@ func (r *Reconciler) Reconcile(request reconcile.Request) (reconcile.Result, err
 	}
 
 	// Add a wrapping here so we can emit an event on error
-	_, err := kubermaticv1helper.ClusterReconcileWrapper(
-		ctx,
-		r.Client,
-		r.workerName,
-		cluster,
-		kubermaticv1.ClusterConditionBackupControllerReconcilingSuccess,
-		func() (*reconcile.Result, error) {
-			return nil, r.reconcile(ctx, log, cluster)
-		},
-	)
+	err := r.reconcile(ctx, log, cluster)
 	if err != nil {
 		log.Errorw("Reconciling failed", zap.Error(err))
 		r.recorder.Eventf(cluster, corev1.EventTypeWarning, "ReconcilingError", "%v", err)
@@ -230,6 +220,16 @@ func (r *Reconciler) Reconcile(request reconcile.Request) (reconcile.Result, err
 }
 
 func (r *Reconciler) reconcile(ctx context.Context, log *zap.SugaredLogger, cluster *kubermaticv1.Cluster) error {
+	if cluster.Spec.Pause {
+		log.Debug("Skipping because the cluster is paused")
+		return nil
+	}
+
+	if cluster.Labels[kubermaticv1.WorkerNameLabelKey] != r.workerName {
+		log.Debug("Skipping because the cluster has a different worker name set")
+		return nil
+	}
+
 	// Cluster got deleted - regardless if the cluster was ever running, we cleanup
 	if cluster.DeletionTimestamp != nil {
 		// Need to cleanup

--- a/api/pkg/controller/cloud/cloud_controller.go
+++ b/api/pkg/controller/cloud/cloud_controller.go
@@ -8,7 +8,6 @@ import (
 
 	kubermaticapiv1 "github.com/kubermatic/kubermatic/api/pkg/api/v1"
 	kubermaticv1 "github.com/kubermatic/kubermatic/api/pkg/crd/kubermatic/v1"
-	kubermaticv1helper "github.com/kubermatic/kubermatic/api/pkg/crd/kubermatic/v1/helper"
 	"github.com/kubermatic/kubermatic/api/pkg/provider"
 	"github.com/kubermatic/kubermatic/api/pkg/provider/cloud"
 	"github.com/kubermatic/kubermatic/api/pkg/provider/cloud/aws"
@@ -28,6 +27,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/controller"
 	"sigs.k8s.io/controller-runtime/pkg/handler"
 	"sigs.k8s.io/controller-runtime/pkg/manager"
+	"sigs.k8s.io/controller-runtime/pkg/predicate"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 	"sigs.k8s.io/controller-runtime/pkg/source"
 )
@@ -54,7 +54,6 @@ type Reconciler struct {
 	log        *zap.SugaredLogger
 	recorder   record.EventRecorder
 	seedGetter provider.SeedGetter
-	workerName string
 }
 
 func Add(
@@ -62,21 +61,20 @@ func Add(
 	log *zap.SugaredLogger,
 	numWorkers int,
 	seedGetter provider.SeedGetter,
-	workerName string,
+	clusterPredicates predicate.Predicate,
 ) error {
 	reconciler := &Reconciler{
 		Client:     mgr.GetClient(),
 		log:        log.Named(ControllerName),
 		recorder:   mgr.GetRecorder(ControllerName),
 		seedGetter: seedGetter,
-		workerName: workerName,
 	}
 
 	c, err := controller.New(ControllerName, mgr, controller.Options{Reconciler: reconciler, MaxConcurrentReconciles: numWorkers})
 	if err != nil {
 		return err
 	}
-	return c.Watch(&source.Kind{Type: &kubermaticv1.Cluster{}}, &handler.EnqueueRequestForObject{})
+	return c.Watch(&source.Kind{Type: &kubermaticv1.Cluster{}}, &handler.EnqueueRequestForObject{}, clusterPredicates)
 }
 
 func (r *Reconciler) Reconcile(request reconcile.Request) (reconcile.Result, error) {
@@ -94,24 +92,24 @@ func (r *Reconciler) Reconcile(request reconcile.Request) (reconcile.Result, err
 	}
 	log = log.With("cluster", cluster.Name)
 
+	if cluster.Spec.Pause {
+		log.Debug("Skipping because the cluster is paused")
+		return reconcile.Result{}, nil
+	}
+
 	// Add a wrapping here so we can emit an event on error
-	result, err := kubermaticv1helper.ClusterReconcileWrapper(
-		ctx,
-		r.Client,
-		r.workerName,
-		cluster,
-		kubermaticv1.ClusterConditionCloudControllerReconcilingSuccess,
-		func() (*reconcile.Result, error) {
-			return r.reconcile(ctx, log, cluster)
-		},
-	)
+	result, err := r.reconcile(ctx, log, cluster)
 	if result == nil {
 		result = &reconcile.Result{}
 	}
 	if err != nil {
-		r.recorder.Event(cluster, corev1.EventTypeWarning, "ReconcilingError", err.Error())
+		r.recorder.Eventf(cluster, corev1.EventTypeWarning, "ReconcilingError", "%v", err)
 		log.Errorw("Reconciling failed", zap.Error(err))
+		return *result, err
 	}
+	_, err = r.updateCluster(cluster.Name, func(c *kubermaticv1.Cluster) {
+		c.Status.ExtendedHealth.CloudProviderInfrastructure = kubermaticv1.HealthStatusUp
+	})
 	return *result, err
 }
 
@@ -156,13 +154,7 @@ func (r *Reconciler) reconcile(ctx context.Context, log *zap.SugaredLogger, clus
 		}
 	}
 
-	if _, err := prov.InitializeCloudProvider(cluster, r.updateCluster); err != nil {
-		return nil, err
-	}
-
-	_, err = r.updateCluster(cluster.Name, func(c *kubermaticv1.Cluster) {
-		c.Status.ExtendedHealth.CloudProviderInfrastructure = kubermaticv1.HealthStatusUp
-	})
+	_, err = prov.InitializeCloudProvider(cluster, r.updateCluster)
 	return nil, err
 }
 

--- a/api/pkg/controller/cluster/cluster_controller.go
+++ b/api/pkg/controller/cluster/cluster_controller.go
@@ -11,7 +11,6 @@ import (
 	"github.com/kubermatic/kubermatic/api/pkg/clusterdeletion"
 	controllerutil "github.com/kubermatic/kubermatic/api/pkg/controller/util"
 	kubermaticv1 "github.com/kubermatic/kubermatic/api/pkg/crd/kubermatic/v1"
-	kubermaticv1helper "github.com/kubermatic/kubermatic/api/pkg/crd/kubermatic/v1/helper"
 	"github.com/kubermatic/kubermatic/api/pkg/provider"
 
 	appsv1 "k8s.io/api/apps/v1"
@@ -23,6 +22,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
+	utilerrors "k8s.io/apimachinery/pkg/util/errors"
 	autoscalingv1beta2 "k8s.io/autoscaler/vertical-pod-autoscaler/pkg/apis/autoscaling.k8s.io/v1beta2"
 	"k8s.io/client-go/tools/record"
 	"k8s.io/client-go/util/retry"
@@ -187,40 +187,53 @@ func (r *Reconciler) Reconcile(request reconcile.Request) (reconcile.Result, err
 	}
 	log = log.With("cluster", cluster.Name)
 
+	if cluster.Spec.Pause {
+		log.Debug("Skipping because the cluster is paused")
+		return reconcile.Result{}, nil
+	}
+
+	if cluster.Labels[kubermaticv1.WorkerNameLabelKey] != r.workerName {
+		log.Debugw(
+			"Skipping because the cluster has a different worker name set",
+			"cluster-worker-name", cluster.Labels[kubermaticv1.WorkerNameLabelKey],
+		)
+		return reconcile.Result{}, nil
+	}
+
 	if cluster.Annotations["kubermatic.io/openshift"] != "" {
 		log.Debug("Skipping because the cluster is an OpenShift cluster")
 		return reconcile.Result{}, nil
 	}
 
-	// Add a wrapping here so we can emit an event on error
-	result, err := kubermaticv1helper.ClusterReconcileWrapper(
-		ctx,
-		r.Client,
-		r.workerName,
-		cluster,
-		kubermaticv1.ClusterConditionClusterControllerReconcilingSuccess,
-		func() (*reconcile.Result, error) {
-			// only reconcile this cluster if there are not yet too many updates running
-			if available, err := controllerutil.ClusterAvailableForReconciling(ctx, r, cluster, r.concurrentClusterUpdates); !available || err != nil {
-				log.Infow("Concurrency limit reached, checking again in 10 seconds", "concurrency-limit", r.concurrentClusterUpdates)
-				return &reconcile.Result{
-					RequeueAfter: 10 * time.Second,
-				}, err
-			}
+	// only reconcile this cluster if there are not yet too many updates running
+	if available, err := controllerutil.ClusterAvailableForReconciling(ctx, r, cluster, r.concurrentClusterUpdates); !available || err != nil {
+		log.Infow("Concurrency limit reached, checking again in 10 seconds", "concurrency-limit", r.concurrentClusterUpdates)
+		return reconcile.Result{
+			RequeueAfter: 10 * time.Second,
+		}, err
+	}
 
-			return r.reconcile(ctx, log, cluster)
-		},
-	)
+	successfullyReconciled := true
+	// Add a wrapping here so we can emit an event on error
+	var errs []error
+	result, err := r.reconcile(ctx, log, cluster)
 	if err != nil {
+		successfullyReconciled = false
 		log.Errorw("Reconciling failed", zap.Error(err))
 		r.recorder.Event(cluster, corev1.EventTypeWarning, "ReconcilingError", err.Error())
+		errs = append(errs, err)
 	}
 
 	if result == nil {
 		result = &reconcile.Result{}
 	}
 
-	return *result, err
+	if err := controllerutil.SetSeedResourcesUpToDateCondition(ctx, cluster, r.Client, successfullyReconciled); err != nil {
+		log.Errorw("failed to update clusters status conditions", zap.Error(err))
+		errs = append(errs, err)
+	}
+
+	return *result, utilerrors.NewAggregate(errs)
 }
 
 func (r *Reconciler) reconcile(ctx context.Context, log *zap.SugaredLogger, cluster *kubermaticv1.Cluster) (*reconcile.Result, error) {

--- a/api/pkg/controller/clustercomponentdefaulter/clustercomponentdefaulter.go
+++ b/api/pkg/controller/clustercomponentdefaulter/clustercomponentdefaulter.go
@@ -5,7 +5,6 @@ import (
 	"fmt"
 
 	kubermaticv1 "github.com/kubermatic/kubermatic/api/pkg/crd/kubermatic/v1"
-	kubermaticv1helper "github.com/kubermatic/kubermatic/api/pkg/crd/kubermatic/v1/helper"
 
 	"go.uber.org/zap"
 
@@ -19,6 +18,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/controller"
 	"sigs.k8s.io/controller-runtime/pkg/handler"
 	"sigs.k8s.io/controller-runtime/pkg/manager"
+	"sigs.k8s.io/controller-runtime/pkg/predicate"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 	"sigs.k8s.io/controller-runtime/pkg/source"
 )
@@ -26,12 +26,11 @@ import (
 const ControllerName = "clustercomponent_defaulter"
 
 type Reconciler struct {
-	ctx        context.Context
-	log        *zap.SugaredLogger
-	client     ctrlruntimeclient.Client
-	recorder   record.EventRecorder
-	defaults   kubermaticv1.ComponentSettings
-	workerName string
+	ctx      context.Context
+	log      *zap.SugaredLogger
+	client   ctrlruntimeclient.Client
+	recorder record.EventRecorder
+	defaults kubermaticv1.ComponentSettings
 }
 
 func Add(
@@ -40,15 +39,14 @@ func Add(
 	mgr manager.Manager,
 	numWorkers int,
 	defaults kubermaticv1.ComponentSettings,
-	workerName string) error {
+	clusterPredicates predicate.Predicate) error {
 
 	reconciler := &Reconciler{
-		ctx:        ctx,
-		log:        log.Named(ControllerName),
-		client:     mgr.GetClient(),
-		recorder:   mgr.GetRecorder(ControllerName),
-		defaults:   defaults,
-		workerName: workerName,
+		ctx:      ctx,
+		log:      log.Named(ControllerName),
+		client:   mgr.GetClient(),
+		recorder: mgr.GetRecorder(ControllerName),
+		defaults: defaults,
 	}
 
 	c, err := controller.New(ControllerName, mgr,
@@ -56,7 +54,7 @@ func Add(
 	if err != nil {
 		return err
 	}
-	return c.Watch(&source.Kind{Type: &kubermaticv1.Cluster{}}, &handler.EnqueueRequestForObject{})
+	return c.Watch(&source.Kind{Type: &kubermaticv1.Cluster{}}, &handler.EnqueueRequestForObject{}, clusterPredicates)
 }
 
 func (r *Reconciler) Reconcile(request reconcile.Request) (reconcile.Result, error) {
@@ -73,24 +71,19 @@ func (r *Reconciler) Reconcile(request reconcile.Request) (reconcile.Result, err
 	log = r.log.With("cluster", cluster.Name)
 
 	// Add a wrapping here so we can emit an event on error
-	_, err := kubermaticv1helper.ClusterReconcileWrapper(
-		context.Background(),
-		r.client,
-		r.workerName,
-		cluster,
-		kubermaticv1.ClusterConditionComponentDefaulterReconcilingSuccess,
-		func() (*reconcile.Result, error) {
-			return nil, r.reconcile(log, cluster)
-		},
-	)
+	err := r.reconcile(log, cluster)
 	if err != nil {
-		r.recorder.Event(cluster, corev1.EventTypeWarning, "ReconcilingError", err.Error())
+		r.recorder.Eventf(cluster, corev1.EventTypeWarning, "ReconcilingError", "%v", err)
 		r.log.With("error", err).With("cluster", request.NamespacedName.Name).Error("failed to reconcile cluster")
 	}
 	return reconcile.Result{}, err
 }
 
 func (r *Reconciler) reconcile(log *zap.SugaredLogger, cluster *kubermaticv1.Cluster) error {
+	if cluster.Spec.Pause {
+		log.Debug("Skipping paused cluster")
+		return nil
+	}
 	log.Debug("Syncing cluster")
 
 	targetComponentsOverride := cluster.Spec.ComponentsOverride.DeepCopy()

--- a/api/pkg/controller/monitoring/monitoring_controller.go
+++ b/api/pkg/controller/monitoring/monitoring_controller.go
@@ -10,7 +10,6 @@ import (
 	k8cuserclusterclient "github.com/kubermatic/kubermatic/api/pkg/cluster/client"
 	controllerutil "github.com/kubermatic/kubermatic/api/pkg/controller/util"
 	kubermaticv1 "github.com/kubermatic/kubermatic/api/pkg/crd/kubermatic/v1"
-	kubermaticv1helper "github.com/kubermatic/kubermatic/api/pkg/crd/kubermatic/v1/helper"
 	"github.com/kubermatic/kubermatic/api/pkg/provider"
 
 	appsv1 "k8s.io/api/apps/v1"
@@ -18,7 +17,6 @@ import (
 	rbacv1 "k8s.io/api/rbac/v1"
 	kubeapierrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/runtime"
-	utilerrors "k8s.io/apimachinery/pkg/util/errors"
 	autoscalingv1beta2 "k8s.io/autoscaler/vertical-pod-autoscaler/pkg/apis/autoscaling.k8s.io/v1beta2"
 	"k8s.io/client-go/tools/record"
 	ctrlruntimeclient "sigs.k8s.io/controller-runtime/pkg/client"
@@ -171,6 +169,15 @@ func (r *Reconciler) Reconcile(request reconcile.Request) (reconcile.Result, err
 
 	log = log.With("cluster", cluster.Name)
 
+	if cluster.Spec.Pause {
+		log.Debug("Skipping cluster reconciling because it was set to paused")
+		return reconcile.Result{}, nil
+	}
+
+	if cluster.Labels[kubermaticv1.WorkerNameLabelKey] != r.workerName {
+		return reconcile.Result{}, nil
+	}
+
 	if cluster.DeletionTimestamp != nil {
 		// Cluster got deleted - all monitoring components will be automatically garbage collected (Due to the ownerRef)
 		return reconcile.Result{}, nil
@@ -187,32 +194,21 @@ func (r *Reconciler) Reconcile(request reconcile.Request) (reconcile.Result, err
 		return reconcile.Result{RequeueAfter: healthCheckPeriod}, nil
 	}
 
-	var errs []error
+	// only reconcile this cluster if there are not yet too many updates running
+	if available, err := controllerutil.ClusterAvailableForReconciling(ctx, r, cluster, r.concurrentClusterUpdates); !available || err != nil {
+		log.Infow("Concurrency limit reached, checking again in 10 seconds", "concurrency-limit", r.concurrentClusterUpdates)
+		return reconcile.Result{
+			RequeueAfter: 10 * time.Second,
+		}, err
+	}
+
 	successfullyReconciled := true
 	// Add a wrapping here so we can emit an event on error
-	result, err := kubermaticv1helper.ClusterReconcileWrapper(
-		ctx,
-		r.Client,
-		r.workerName,
-		cluster,
-		kubermaticv1.ClusterConditionMonitoringControllerReconcilingSuccess,
-		func() (*reconcile.Result, error) {
-			// only reconcile this cluster if there are not yet too many updates running
-			if available, err := controllerutil.ClusterAvailableForReconciling(ctx, r, cluster, r.concurrentClusterUpdates); !available || err != nil {
-				log.Infow("Concurrency limit reached, checking again in 10 seconds", "concurrency-limit", r.concurrentClusterUpdates)
-				return &reconcile.Result{
-					RequeueAfter: 10 * time.Second,
-				}, err
-			}
-
-			return r.reconcile(ctx, log, cluster)
-		},
-	)
-	if err != nil {
+	result, reconcileErr := r.reconcile(ctx, log, cluster)
+	if reconcileErr != nil {
 		successfullyReconciled = false
-		errs = append(errs, err)
-		log.Errorw("Failed to reconcile cluster", zap.Error(err))
-		r.recorder.Event(cluster, corev1.EventTypeWarning, "ReconcilingError", err.Error())
+		log.Errorw("Failed to reconcile cluster", zap.Error(reconcileErr))
+		r.recorder.Eventf(cluster, corev1.EventTypeWarning, "ReconcilingError", "%v", reconcileErr)
 	}
 
 	if result == nil {
@@ -221,10 +217,10 @@ func (r *Reconciler) Reconcile(request reconcile.Request) (reconcile.Result, err
 
 	if err := controllerutil.SetSeedResourcesUpToDateCondition(ctx, cluster, r, successfullyReconciled); err != nil {
 		log.Errorw("failed to update clusters status conditions", zap.Error(err))
-		errs = append(errs, err)
+		reconcileErr = fmt.Errorf("failed to set cluster status: %v after reconciliation was done with err=%v", err, reconcileErr)
 	}
 
-	return *result, utilerrors.NewAggregate(errs)
+	return *result, reconcileErr
 }
 
 func (r *Reconciler) reconcile(ctx context.Context, log *zap.SugaredLogger, cluster *kubermaticv1.Cluster) (*reconcile.Result, error) {

--- a/api/pkg/controller/openshift/openshift_controller.go
+++ b/api/pkg/controller/openshift/openshift_controller.go
@@ -14,7 +14,6 @@ import (
 	openshiftresources "github.com/kubermatic/kubermatic/api/pkg/controller/openshift/resources"
 	controllerutil "github.com/kubermatic/kubermatic/api/pkg/controller/util"
 	kubermaticv1 "github.com/kubermatic/kubermatic/api/pkg/crd/kubermatic/v1"
-	kubermaticv1helper "github.com/kubermatic/kubermatic/api/pkg/crd/kubermatic/v1/helper"
 	kuberneteshelper "github.com/kubermatic/kubermatic/api/pkg/kubernetes"
 	"github.com/kubermatic/kubermatic/api/pkg/provider"
 	"github.com/kubermatic/kubermatic/api/pkg/resources"
@@ -41,7 +40,6 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
-	utilerrors "k8s.io/apimachinery/pkg/util/errors"
 	autoscalingv1beta2 "k8s.io/autoscaler/vertical-pod-autoscaler/pkg/apis/autoscaling.k8s.io/v1beta2"
 	"k8s.io/client-go/tools/clientcmd"
 	clientcmdapi "k8s.io/client-go/tools/clientcmd/api"
@@ -173,35 +171,40 @@ func (r *Reconciler) Reconcile(request reconcile.Request) (reconcile.Result, err
 	}
 	log = log.With("cluster", cluster.Name)
 
+	if cluster.Spec.Pause {
+		log.Debug("Skipping because the cluster is paused")
+		return reconcile.Result{}, nil
+	}
+
 	if cluster.Annotations["kubermatic.io/openshift"] == "" {
 		log.Debug("Skipping because the cluster is an Kubernetes cluster")
 		return reconcile.Result{}, nil
 	}
 
-	successfullyReconciled := true
-	var errs []error
-	// Add a wrapping here so we can emit an event on error
-	result, err := kubermaticv1helper.ClusterReconcileWrapper(
-		ctx,
-		r.Client,
-		r.workerName,
-		cluster,
-		kubermaticv1.ClusterConditionOpenshiftControllerReconcilingSuccess,
-		func() (*reconcile.Result, error) {
-			// only reconcile this cluster if there are not yet too many updates running
-			if available, err := controllerutil.ClusterAvailableForReconciling(ctx, r, cluster, r.concurrentClusterUpdates); !available || err != nil {
-				log.Infow("Concurrency limit reached, checking again in 10 seconds", "concurrency-limit", r.concurrentClusterUpdates)
-				return &reconcile.Result{RequeueAfter: 10 * time.Second}, err
-			}
+	if cluster.Labels[kubermaticv1.WorkerNameLabelKey] != r.workerName {
+		log.Debugw(
+			"Skipping because the cluster has a different worker name set",
+			"cluster-worker-name", cluster.Labels[kubermaticv1.WorkerNameLabelKey],
+		)
+		return reconcile.Result{}, nil
+	}
 
-			return r.reconcile(ctx, log, cluster)
-		},
-	)
-	if err != nil {
+	// only reconcile this cluster if there are not yet too many updates running
+	if available, err := controllerutil.ClusterAvailableForReconciling(ctx, r, cluster, r.concurrentClusterUpdates); !available || err != nil {
+		log.Infow("Concurrency limit reached, checking again in 10 seconds", "concurrency-limit", r.concurrentClusterUpdates)
+		return reconcile.Result{
+			RequeueAfter: 10 * time.Second,
+		}, err
+	}
+
+	successfullyReconciled := true
+	// Add a wrapping here so we can emit an event on error
+	result, reconcileErr := r.reconcile(ctx, log, cluster)
+	recorderCluster := cluster.DeepCopy()
+	if reconcileErr != nil {
 		successfullyReconciled = false
-		log.Errorw("Reconciling failed", zap.Error(err))
-		r.recorder.Eventf(cluster, corev1.EventTypeWarning, "ReconcilingError", err.Error())
-		errs = append(errs, err)
+		log.Errorw("Reconciling failed", zap.Error(reconcileErr))
+		r.recorder.Eventf(recorderCluster, corev1.EventTypeWarning, "ReconcilingError", "%v", reconcileErr)
 	}
 
 	if result == nil {
@@ -210,10 +213,10 @@ func (r *Reconciler) Reconcile(request reconcile.Request) (reconcile.Result, err
 
 	if err := controllerutil.SetSeedResourcesUpToDateCondition(ctx, cluster, r, successfullyReconciled); err != nil {
 		log.Errorw("failed to update clusters status conditions", zap.Error(err))
-		errs = append(errs, err)
+		reconcileErr = fmt.Errorf("failed to set cluster status: %v after reconciliation was done with err=%v", err, reconcileErr)
 	}
 
-	return *result, utilerrors.NewAggregate(errs)
+	return *result, reconcileErr
 }
 
 func (r *Reconciler) reconcile(ctx context.Context, log *zap.SugaredLogger, cluster *kubermaticv1.Cluster) (*reconcile.Result, error) {

--- a/api/pkg/controller/util/util.go
+++ b/api/pkg/controller/util/util.go
@@ -122,7 +122,7 @@ func SetSeedResourcesUpToDateCondition(ctx context.Context, cluster *kubermaticv
 				kubermaticv1.ClusterConditionSeedResourcesUpToDate,
 				corev1.ConditionFalse,
 				kubermaticv1.ReasonClusterUpdateSuccessful,
-				"Some controlplane components did not finish updating")
+				"All controlplane components are up to date")
 		})
 	}
 
@@ -131,7 +131,7 @@ func SetSeedResourcesUpToDateCondition(ctx context.Context, cluster *kubermaticv
 			kubermaticv1.ClusterConditionSeedResourcesUpToDate,
 			corev1.ConditionTrue,
 			kubermaticv1.ReasonClusterUpdateSuccessful,
-			"All controlplane components are up to date")
+			"Some controlplane components did not finish updating")
 	})
 }
 

--- a/api/pkg/crd/kubermatic/v1/cluster.go
+++ b/api/pkg/crd/kubermatic/v1/cluster.go
@@ -107,16 +107,6 @@ const (
 	// the status of cloud provider resources for a given cluster.
 	ClusterConditionSeedResourcesUpToDate ClusterConditionType = "SeedResourcesUpToDate"
 
-	ClusterConditionClusterControllerReconcilingSuccess        ClusterConditionType = "ClusterControllerReconciledSuccessfully"
-	ClusterConditionAddonControllerReconcilingSuccess          ClusterConditionType = "AddonControllerReconciledSuccessfully"
-	ClusterConditionAddonInstallerControllerReconcilingSuccess ClusterConditionType = "AddonInstallerControllerReconciledSuccessfully"
-	ClusterConditionBackupControllerReconcilingSuccess         ClusterConditionType = "BackupControllerReconciledSuccessfully"
-	ClusterConditionCloudControllerReconcilingSuccess          ClusterConditionType = "CloudControllerReconcilledSuccessfully"
-	ClusterConditionComponentDefaulterReconcilingSuccess       ClusterConditionType = "ComponentDefaulterReconciledSuccessfully"
-	ClusterConditionUpdateControllerReconcilingSuccess         ClusterConditionType = "UpdateControllerReconciledSuccessfully"
-	ClusterConditionMonitoringControllerReconcilingSuccess     ClusterConditionType = "MonitoringControllerReconciledSuccessfully"
-	ClusterConditionOpenshiftControllerReconcilingSuccess      ClusterConditionType = "OpenshiftControllerReconciledSuccessfully"
-
 	ReasonClusterUpdateSuccessful = "ClusterUpdateSuccessful"
 	ReasonClusterUpadteInProgress = "ClusterUpdateInProgress"
 )

--- a/api/pkg/crd/kubermatic/v1/helper/helper.go
+++ b/api/pkg/crd/kubermatic/v1/helper/helper.go
@@ -1,72 +1,13 @@
 package helper
 
 import (
-	"context"
-
 	kubermaticv1 "github.com/kubermatic/kubermatic/api/pkg/crd/kubermatic/v1"
 	"github.com/kubermatic/kubermatic/api/pkg/resources"
 
 	corev1 "k8s.io/api/core/v1"
 	apiequality "k8s.io/apimachinery/pkg/api/equality"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/apimachinery/pkg/types"
-	utilerrors "k8s.io/apimachinery/pkg/util/errors"
-	"k8s.io/client-go/util/retry"
-	ctrlruntimeclient "sigs.k8s.io/controller-runtime/pkg/client"
-	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 )
-
-// ClusterReconcileWrapper is a wrapper that should be used around
-// any cluster reconciliaton. It:
-// * Checks if the cluster is paused
-// * Checks if the worker-name matches
-// * Sets the ReconcileSuccess condition for the controller
-func ClusterReconcileWrapper(
-	ctx context.Context,
-	client ctrlruntimeclient.Client,
-	workerName string,
-	cluster *kubermaticv1.Cluster,
-	conditionType kubermaticv1.ClusterConditionType,
-	reconcile func() (*reconcile.Result, error)) (*reconcile.Result, error) {
-
-	if cluster.Labels[kubermaticv1.WorkerNameLabelKey] != workerName {
-		return nil, nil
-	}
-	if cluster.Spec.Pause {
-		return nil, nil
-	}
-
-	reconcilingStatus := corev1.ConditionFalse
-	result, err := reconcile()
-	// Only set to true if we had no error and don't want to reqeue the cluster
-	if err == nil && (result == nil || (!result.Requeue && result.RequeueAfter == 0)) {
-		reconcilingStatus = corev1.ConditionTrue
-	}
-	errs := []error{err}
-	errs = append(errs, clusterUpdater(ctx, client, cluster.Name, func(c *kubermaticv1.Cluster) {
-		SetClusterCondition(c, conditionType, reconcilingStatus, "", "")
-	}))
-	return result, utilerrors.NewAggregate(errs)
-}
-
-func clusterUpdater(
-	ctx context.Context,
-	client ctrlruntimeclient.Client,
-	name string,
-	modify func(*kubermaticv1.Cluster),
-) error {
-	return retry.RetryOnConflict(retry.DefaultBackoff, func() error {
-		//Get latest version
-		c := &kubermaticv1.Cluster{}
-		if err := client.Get(ctx, types.NamespacedName{Name: name}, c); err != nil {
-			return err
-		}
-		// Apply modifications
-		modify(c)
-		// Update the cluster
-		return client.Update(ctx, c)
-	})
-}
 
 // GetClusterCondition returns the index of the given condition or -1 and the condition itself
 // or a nilpointer.


### PR DESCRIPTION
**What this PR does / why we need it**:
This reverts commit 3d030ce00dd980c0277ed4c1cc2f6a126c9cdfb8. We're temporarily reverting it for "bisecting" a cluster status bug.

**Does this PR introduce a user-facing change?**:
```release-note
NONE
```
