### PR TITLE
Add proposals for edge cluster management

### DIFF
--- a/docs/proposals/grpc-agent.md
+++ b/docs/proposals/grpc-agent.md
@@ -1,0 +1,25 @@
+# Creating a gRPC agent component for enabling KubeOne cluster management in Kubermatic
+
+**Authors:** Tobias Hintze, Indradhanush Gupta, Alexander Sowitzki, Manuel Stößel
+
+**Status:** Draft proposal; prototype in progress.
+
+**Abstract:** The gRPC agent will create a gRPC connection to the gRPC server component running in Kubermatic with a token and URL provided via a config file or the Kubermatic UI. Over that connection the agent will tunnel TCP to allow ssh connections to the node.
+
+## Motivation and Background
+
+To be able to provision k8s on on-premise customer infrastructure we need a simple and minimal way to pre-provision the customers infrastructure that enables Kubermatic to then provision the customer machines.
+
+## Implementation
+
+- Simple to configure (token + URL only?)
+    - for PoC scope: token and URL are passed as flags to the agent
+- Running as a service just on the machines OS
+    - systemd unit
+- Connects with the gRPC server running on the seed cluster via URL with the token
+- Receives client TLS key pair from the gRPC server
+- Establishes gRPC TLS connection to the gRPC server
+- Accepts public SSH key from the gRPC server
+- Inject public key into authorized_keys on the machines OS and tell Kubermatic which user id should be used for connecting to the customer machine
+- Retries when connection is lost
+- Allows SSH access to the node via the gRPC connection

--- a/docs/proposals/kubeone-provider.md
+++ b/docs/proposals/kubeone-provider.md
@@ -8,11 +8,6 @@
 
 ## Motivation and Background
 
-The current approaches to deploy and manage k8s nodes with Kubermatic won’t work well with the edge computing use-case:
-- Unstable network connectivity to on-premise client infrastructure could break the user-clusters because the connection between master components deployed in the seed cluster to the on-premise nodes will be unstable
-- Clients willing to pay extra for on-premise management of k8s have interest in running the whole k8s infrastructure onsite for data protection/security reasons
-- Innovo needs the client infrastructure setup to be independently timeable of cluster creation in Kubermatic
-
 With the enhancements described in this proposal we want to enable:
 - Independent hardware deployment on the customer site
 - Provision the customer hardware with k8s via a central Kubermatic installation

--- a/docs/proposals/kubeone-provider.md
+++ b/docs/proposals/kubeone-provider.md
@@ -4,7 +4,7 @@
 
 **Status:** Draft proposal; prototype in progress.
 
-**Abstract:* To be able to support edge compute functionality with Kubermatic there is a need to support the management of user-clusters provisioned by KubeOne within Kubermatic.
+**Abstract:** To be able to support edge compute functionality with Kubermatic there is a need to support the management of user-clusters provisioned by KubeOne within Kubermatic.
 
 ## Motivation and Background
 

--- a/docs/proposals/kubeone-provider.md
+++ b/docs/proposals/kubeone-provider.md
@@ -1,0 +1,54 @@
+# Enabling KubeOne cluster management in Kubermatic
+
+**Authors:** Tobias Hintze, Indradhanush Gupta, Alexander Sowitzki, Manuel Stößel
+
+**Status:** Draft proposal; prototype in progress.
+
+**Abstract:* To be able to support edge compute functionality with Kubermatic there is a need to support the management of user-clusters provisioned by KubeOne within Kubermatic.
+
+## Motivation and Background
+
+The current approaches to deploy and manage k8s nodes with Kubermatic won’t work well with the edge computing use-case:
+- Unstable network connectivity to on-premise client infrastructure could break the user-clusters because the connection between master components deployed in the seed cluster to the on-premise nodes will be unstable
+- Clients willing to pay extra for on-premise management of k8s have interest in running the whole k8s infrastructure onsite for data protection/security reasons
+- Innovo needs the client infrastructure setup to be independently timeable of cluster creation in Kubermatic
+
+With the enhancements described in this proposal we want to enable:
+- Independent hardware deployment on the customer site
+- Provision the customer hardware with k8s via a central Kubermatic installation
+- Enable possibility to update of on-premise customer cluster from a central Kubermatic installation
+- Kubermatic installation can run completely separate from customers infrastructure
+- Kubermatic and customer clusters can tolerate network connectivity issues between customer site and Kubermatic
+
+## Implementation
+
+### Kubermatic:
+
+#### Add “KubeOne” provider:
+
+Add a new provider to Kubermatic that will not deploy a k8s control plane in the seed cluster. The cluster CRD will be used with some sort of specification that it is a KubeOne cluster (e.g. cluster-type) and will have a status field for the health of the gRPC connection. The cluster namespace (unique per user-cluster) will be created. Kubermatic generates and stores a random string in a K8s-Secret for the gRPC server to use as the token. Kubermatic will also create a KubeOne SSH key-pair and store it in a K8s-Secret. The KubeOne configuration will be created in a ConfigMap in the cluster namespace. In addition to that the gRPC server for that cluster needs to be deployed in the cluster namespace and wait for the agent registration.
+
+#### Start KubeOne install:
+When the agent successfully establishes connection with the gRPC server (running in the user-cluster namespace) a KubeOne install will be triggered (by watching gRPC agent connection health status in cluster CRD) that uses the created KubeOne ConfigMap, the KubeOne SSH key-pair, and provisions the master node via SSH through the gRPC connection (TCP tunnel). This could be accomplished by e.g. starting a Job with a simple KubeOne install.
+
+### UI:
+
+#### Add “KubeOne” provider for cluster creation:
+
+To enable the UI there needs to be a new provider added. For the POC phase there will be no changes to the region selection although for this use-case there is no need for a region. We’ll use a dummy region for now that does nothing.
+
+#### Display gRPC agent config details:
+
+To be able to configure the gRPC agent the credentials/config for the agent needs to be displayed after cluster creation. Details on how these infos look like still need to be defined.
+
+### gRPC server:
+
+- Needs to be reachable from the outside to accept connection from agent. This will be achieved by a Service of type LoadBalancer created for the gRPC server.
+- Needs to expose a health endpoint that shows the status of the gRPC connection with the agent.
+- Takes generated TLS certificates for itself and the agent from a k8s secret
+- Takes generated SSH key pair from a k8s secret
+- Accepts agent connection with token and then sends the certificates for the agent to the agent via the gRPC connection
+- Copies TLS certificates to the agent
+- Accepts new gRPC connection from the agent with TLS certificates
+- Copies SSH public key to the agent
+- Creates a TCP tunnel to the agent


### PR DESCRIPTION
**What this PR does / why we need it**:

This PR adds two new proposals that describe how we can enable the management of Edge clusters running on hardware boxes at a customer site. For this we'll need a new "KubeOne" provider in Kubermatic and a gRPC connector that will allow SSH access to the hardware boxes.