### PR TITLE
Addon controller: Retry addon updates to prevent cache races

### DIFF
--- a/api/pkg/controller/addon/addon_controller.go
+++ b/api/pkg/controller/addon/addon_controller.go
@@ -268,7 +268,7 @@ func (r *Reconciler) markDefaultAddons(
 	// Update only when the value was incorrect
 	if isDefault := defaultAddons.Has(addon.Name); addon.Spec.IsDefault != isDefault {
 		if err := r.updateAddon(ctx, addon.Namespace, addon.Name, func(a *kubermaticv1.Addon) {
-			addon.Spec.IsDefault = isDefault
+			a.Spec.IsDefault = isDefault
 		}); err != nil {
 			return err
 		}
@@ -280,7 +280,7 @@ func (r *Reconciler) markDefaultAddons(
 func (r *Reconciler) removeCleanupFinalizer(ctx context.Context, log *zap.SugaredLogger, addon *kubermaticv1.Addon) error {
 	if kuberneteshelper.HasFinalizer(addon, cleanupFinalizerName) {
 		if err := r.updateAddon(ctx, addon.Namespace, addon.Name, func(a *kubermaticv1.Addon) {
-			kuberneteshelper.RemoveFinalizer(addon, cleanupFinalizerName)
+			kuberneteshelper.RemoveFinalizer(a, cleanupFinalizerName)
 		}); err != nil {
 			return err
 		}
@@ -482,7 +482,7 @@ func (r *Reconciler) ensureFinalizerIsSet(ctx context.Context, addon *kubermatic
 	}
 
 	return r.updateAddon(ctx, addon.Namespace, addon.Name, func(a *kubermaticv1.Addon) {
-		kuberneteshelper.AddFinalizer(addon, cleanupFinalizerName)
+		kuberneteshelper.AddFinalizer(a, cleanupFinalizerName)
 	})
 }
 


### PR DESCRIPTION
**What this PR does / why we need it**:

Currently, there are a lot of `failed to reconcile Addon "dns": failed to ensure that the isDefault field is up to date in the addon: Operation cannot be fulfilled on addons.kubermatic.k8s.io "dns": the object has been modified; please apply your changes to the latest version and try again` errors on the cluster, this PR aims at preventing that by retrying the update when it was a conflict.

Ideally we'd be using patch for this to avoid the issue altogether, but for that we need an updated controller-runtime.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Documentation**:
<!-- Add links to the related documentation changes related to this pull request. E.g. the link to the kubermatic/docs pullrequest. -->

**Does this PR introduce a user-facing change?**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If  no release note is required, just write "NONE".
-->
```release-note
none
```
