### PR TITLE
Use dedicated kibana parser for fluentbit

### DIFF
--- a/config/logging/kibana/Chart.yaml
+++ b/config/logging/kibana/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: kibana
-version: 1.0.4
+version: 1.0.5
 appVersion: 6.7.1
 description: kibana
 keywords:

--- a/config/logging/kibana/templates/deployment.yaml
+++ b/config/logging/kibana/templates/deployment.yaml
@@ -18,6 +18,7 @@ spec:
       annotations:
         checksum/config: {{ include (print $.Template.BasePath "/configmap.yaml") . | sha256sum }}
         seccomp.security.alpha.kubernetes.io/pod: 'docker/default'
+        fluentbit.io/parser: kibana
     spec:
       containers:
       - name: kibana-logging


### PR DESCRIPTION
**What this PR does / why we need it**:
Kibana outputs `@timestamp`, which conflicts with Elasticsearch's internal field. This PR configures Fluentbit to use a dedicated parser that can handle the duplicated field.

**Does this PR introduce a user-facing change?**:
```release-note
Fix parsing Kibana's logs in Fluent-Bit
```
