### PR TITLE
Fluent-Bit dashboard

### DIFF
--- a/config/monitoring/grafana/Chart.yaml
+++ b/config/monitoring/grafana/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: grafana
-version: 1.2.1
+version: 1.2.2
 appVersion: 6.3.5
 description: Grafana for Kubermatic
 keywords:

--- a/config/monitoring/grafana/dashboards/logging/elasticsearch-details.json
+++ b/config/monitoring/grafana/dashboards/logging/elasticsearch-details.json
@@ -2,11 +2,11 @@
   "annotations": {
     "list": []
   },
-  "description": "ElasticSearch cluster stats",
-  "editable": "<< editable | default false | toJson >>",
+  "description": "Elasticsearch cluster stats",
+  "editable": true,
   "gnetId": null,
   "graphTooltip": 1,
-  "hideControls": "<< hideControls | default false | toJson >>",
+  "hideControls": false,
   "links": [],
   "panels": [
     {
@@ -33,7 +33,7 @@
         "#299c46"
       ],
       "datasource": "$datasource",
-      "editable": "<< editable | default false | toJson >>",
+      "editable": true,
       "format": "none",
       "gauge": {
         "maxValue": 100,
@@ -97,7 +97,7 @@
       "thresholds": "2,4",
       "timeRegions": [],
       "title": "Cluster health",
-      "transparent": "<< transparentPanels | default true | toJson >>",
+      "transparent": true,
       "type": "singlestat",
       "valueFontSize": "80%",
       "valueMaps": [
@@ -135,7 +135,7 @@
       ],
       "datasource": "$datasource",
       "decimals": null,
-      "editable": "<< editable | default false | toJson >>",
+      "editable": true,
       "format": "none",
       "gauge": {
         "maxValue": 100,
@@ -199,7 +199,7 @@
       "thresholds": "1,2",
       "timeRegions": [],
       "title": "Tripped for breakers",
-      "transparent": "<< transparentPanels | default true | toJson >>",
+      "transparent": true,
       "type": "singlestat",
       "valueFontSize": "80%",
       "valueMaps": [
@@ -231,7 +231,7 @@
         "rgba(245, 54, 54, 0.9)"
       ],
       "datasource": "$datasource",
-      "editable": "<< editable | default false | toJson >>",
+      "editable": true,
       "error": false,
       "format": "percent",
       "gauge": {
@@ -299,7 +299,7 @@
       "thresholds": "70,80",
       "timeRegions": [],
       "title": "CPU usage Avg.",
-      "transparent": "<< transparentPanels | default true | toJson >>",
+      "transparent": true,
       "type": "singlestat",
       "valueFontSize": "80%",
       "valueMaps": [
@@ -321,7 +321,7 @@
         "rgba(245, 54, 54, 0.9)"
       ],
       "datasource": "$datasource",
-      "editable": "<< editable | default false | toJson >>",
+      "editable": true,
       "error": false,
       "format": "percent",
       "gauge": {
@@ -389,7 +389,7 @@
       "thresholds": "70,80",
       "timeRegions": [],
       "title": "JVM memory used Avg.",
-      "transparent": "<< transparentPanels | default true | toJson >>",
+      "transparent": true,
       "type": "singlestat",
       "valueFontSize": "80%",
       "valueMaps": [
@@ -412,7 +412,7 @@
       ],
       "datasource": "$datasource",
       "description": "Number of nodes in the cluster",
-      "editable": "<< editable | default false | toJson >>",
+      "editable": true,
       "error": false,
       "format": "none",
       "gauge": {
@@ -480,7 +480,7 @@
       "thresholds": "",
       "timeRegions": [],
       "title": "Nodes",
-      "transparent": "<< transparentPanels | default true | toJson >>",
+      "transparent": true,
       "type": "singlestat",
       "valueFontSize": "80%",
       "valueMaps": [
@@ -503,7 +503,7 @@
       ],
       "datasource": "$datasource",
       "description": "Number of data nodes in the cluster",
-      "editable": "<< editable | default false | toJson >>",
+      "editable": true,
       "error": false,
       "format": "none",
       "gauge": {
@@ -571,7 +571,7 @@
       "thresholds": "",
       "timeRegions": [],
       "title": "Data nodes",
-      "transparent": "<< transparentPanels | default true | toJson >>",
+      "transparent": true,
       "type": "singlestat",
       "valueFontSize": "80%",
       "valueMaps": [
@@ -594,7 +594,7 @@
       ],
       "datasource": "$datasource",
       "description": "Cluster level changes which have not yet been executed",
-      "editable": "<< editable | default false | toJson >>",
+      "editable": true,
       "error": false,
       "format": "none",
       "gauge": {
@@ -663,7 +663,7 @@
       "thresholds": "1,5",
       "timeRegions": [],
       "title": "Pending tasks",
-      "transparent": "<< transparentPanels | default true | toJson >>",
+      "transparent": true,
       "type": "singlestat",
       "valueFontSize": "80%",
       "valueMaps": [
@@ -685,7 +685,7 @@
         "rgba(245, 54, 54, 0.9)"
       ],
       "datasource": "$datasource",
-      "editable": "<< editable | default false | toJson >>",
+      "editable": true,
       "error": false,
       "format": "short",
       "gauge": {
@@ -753,7 +753,7 @@
       "thresholds": "",
       "timeRegions": [],
       "title": "Open file descriptors per cluster",
-      "transparent": "<< transparentPanels | default true | toJson >>",
+      "transparent": true,
       "type": "singlestat",
       "valueFontSize": "80%",
       "valueMaps": [],
@@ -784,7 +784,7 @@
       ],
       "datasource": "$datasource",
       "description": "The number of primary shards in your cluster. This is an aggregate total across all indices.",
-      "editable": "<< editable | default false | toJson >>",
+      "editable": true,
       "error": false,
       "format": "none",
       "gauge": {
@@ -852,7 +852,7 @@
       "thresholds": "",
       "timeRegions": [],
       "title": "Active primary shards",
-      "transparent": "<< transparentPanels | default true | toJson >>",
+      "transparent": true,
       "type": "singlestat",
       "valueFontSize": "80%",
       "valueMaps": [
@@ -875,7 +875,7 @@
       ],
       "datasource": "$datasource",
       "description": "Aggregate total of all shards across all indices, which includes replica shards",
-      "editable": "<< editable | default false | toJson >>",
+      "editable": true,
       "error": false,
       "format": "none",
       "gauge": {
@@ -942,7 +942,7 @@
       "thresholds": "",
       "timeRegions": [],
       "title": "Active shards",
-      "transparent": "<< transparentPanels | default true | toJson >>",
+      "transparent": true,
       "type": "singlestat",
       "valueFontSize": "80%",
       "valueMaps": [
@@ -965,7 +965,7 @@
       ],
       "datasource": "$datasource",
       "description": "Count of shards that are being freshly created",
-      "editable": "<< editable | default false | toJson >>",
+      "editable": true,
       "error": false,
       "format": "none",
       "gauge": {
@@ -1032,7 +1032,7 @@
       "thresholds": "",
       "timeRegions": [],
       "title": "Initializing shards",
-      "transparent": "<< transparentPanels | default true | toJson >>",
+      "transparent": true,
       "type": "singlestat",
       "valueFontSize": "80%",
       "valueMaps": [
@@ -1055,7 +1055,7 @@
       ],
       "datasource": "$datasource",
       "description": "The number of shards that are currently moving from one node to another node.",
-      "editable": "<< editable | default false | toJson >>",
+      "editable": true,
       "error": false,
       "format": "none",
       "gauge": {
@@ -1122,7 +1122,7 @@
       "thresholds": "",
       "timeRegions": [],
       "title": "Relocating shards",
-      "transparent": "<< transparentPanels | default true | toJson >>",
+      "transparent": true,
       "type": "singlestat",
       "valueFontSize": "80%",
       "valueMaps": [
@@ -1145,7 +1145,7 @@
       ],
       "datasource": "$datasource",
       "description": "Shards delayed to reduce reallocation overhead",
-      "editable": "<< editable | default false | toJson >>",
+      "editable": true,
       "error": false,
       "format": "none",
       "gauge": {
@@ -1212,7 +1212,7 @@
       "thresholds": "",
       "timeRegions": [],
       "title": "Delayed shards",
-      "transparent": "<< transparentPanels | default true | toJson >>",
+      "transparent": true,
       "type": "singlestat",
       "valueFontSize": "80%",
       "valueMaps": [
@@ -1235,7 +1235,7 @@
       ],
       "datasource": "$datasource",
       "description": "The number of shards that exist in the cluster state, but cannot be found in the cluster itself",
-      "editable": "<< editable | default false | toJson >>",
+      "editable": true,
       "error": false,
       "format": "none",
       "gauge": {
@@ -1302,7 +1302,7 @@
       "thresholds": "",
       "timeRegions": [],
       "title": "Unassigned shards",
-      "transparent": "<< transparentPanels | default true | toJson >>",
+      "transparent": true,
       "type": "singlestat",
       "valueFontSize": "80%",
       "valueMaps": [
@@ -1335,7 +1335,7 @@
       "dashes": false,
       "datasource": "$datasource",
       "decimals": 2,
-      "editable": "<< editable | default false | toJson >>",
+      "editable": true,
       "error": false,
       "fill": 1,
       "grid": {},
@@ -1397,7 +1397,7 @@
         "sort": 0,
         "value_type": "cumulative"
       },
-      "transparent": "<< transparentPanels | default true | toJson >>",
+      "transparent": true,
       "type": "graph",
       "xaxis": {
         "buckets": null,
@@ -1436,7 +1436,7 @@
       "dashLength": 10,
       "dashes": false,
       "datasource": "$datasource",
-      "editable": "<< editable | default false | toJson >>",
+      "editable": true,
       "error": false,
       "fill": 1,
       "grid": {},
@@ -1496,7 +1496,7 @@
         "sort": 0,
         "value_type": "cumulative"
       },
-      "transparent": "<< transparentPanels | default true | toJson >>",
+      "transparent": true,
       "type": "graph",
       "xaxis": {
         "buckets": null,
@@ -1535,7 +1535,7 @@
       "dashes": false,
       "datasource": "$datasource",
       "description": "Count of deleted documents on this node",
-      "editable": "<< editable | default false | toJson >>",
+      "editable": true,
       "error": false,
       "fill": 1,
       "grid": {},
@@ -1597,7 +1597,7 @@
         "sort": 0,
         "value_type": "cumulative"
       },
-      "transparent": "<< transparentPanels | default true | toJson >>",
+      "transparent": true,
       "type": "graph",
       "xaxis": {
         "buckets": null,
@@ -1636,7 +1636,7 @@
       "dashes": false,
       "datasource": "$datasource",
       "decimals": 2,
-      "editable": "<< editable | default false | toJson >>",
+      "editable": true,
       "error": false,
       "fill": 1,
       "grid": {},
@@ -1696,7 +1696,7 @@
         "sort": 0,
         "value_type": "cumulative"
       },
-      "transparent": "<< transparentPanels | default true | toJson >>",
+      "transparent": true,
       "type": "graph",
       "xaxis": {
         "buckets": null,
@@ -1735,7 +1735,7 @@
       "dashLength": 10,
       "dashes": false,
       "datasource": "$datasource",
-      "editable": "<< editable | default false | toJson >>",
+      "editable": true,
       "error": false,
       "fill": 1,
       "grid": {},
@@ -1795,7 +1795,7 @@
         "sort": 0,
         "value_type": "cumulative"
       },
-      "transparent": "<< transparentPanels | default true | toJson >>",
+      "transparent": true,
       "type": "graph",
       "xaxis": {
         "buckets": null,
@@ -1848,7 +1848,7 @@
       "dashLength": 10,
       "dashes": false,
       "datasource": "$datasource",
-      "editable": "<< editable | default false | toJson >>",
+      "editable": true,
       "fill": 1,
       "gridPos": {
         "h": 7,
@@ -1901,7 +1901,7 @@
         "sort": 2,
         "value_type": "individual"
       },
-      "transparent": "<< transparentPanels | default true | toJson >>",
+      "transparent": true,
       "type": "graph",
       "xaxis": {
         "buckets": null,
@@ -1939,7 +1939,7 @@
       "dashLength": 10,
       "dashes": false,
       "datasource": "$datasource",
-      "editable": "<< editable | default false | toJson >>",
+      "editable": true,
       "fill": 1,
       "gridPos": {
         "h": 7,
@@ -1992,7 +1992,7 @@
         "sort": 2,
         "value_type": "individual"
       },
-      "transparent": "<< transparentPanels | default true | toJson >>",
+      "transparent": true,
       "type": "graph",
       "xaxis": {
         "buckets": null,
@@ -2030,7 +2030,7 @@
       "dashLength": 10,
       "dashes": false,
       "datasource": "$datasource",
-      "editable": "<< editable | default false | toJson >>",
+      "editable": true,
       "fill": 1,
       "gridPos": {
         "h": 7,
@@ -2083,7 +2083,7 @@
         "sort": 2,
         "value_type": "individual"
       },
-      "transparent": "<< transparentPanels | default true | toJson >>",
+      "transparent": true,
       "type": "graph",
       "xaxis": {
         "buckets": null,
@@ -7245,7 +7245,7 @@
       "type": "row"
     }
   ],
-  "refresh": "<< refresh | default `30s` | toJson >>",
+  "refresh": "30s",
   "schemaVersion": 18,
   "style": "dark",
   "tags": [],
@@ -7253,7 +7253,7 @@
     "list": [
       {
         "current": {},
-        "hide": "<< datasourceHide | toJson >>",
+        "hide": 2,
         "includeAll": false,
         "label": null,
         "multi": false,
@@ -7404,7 +7404,7 @@
     ]
   },
   "time": {
-    "from": "<< defaultRange | toJson >>",
+    "from": "now-6h",
     "to": "now"
   },
   "timepicker": {
@@ -7433,7 +7433,7 @@
     ]
   },
   "timezone": "",
-  "title": "Details",
+  "title": "Elasticsearch Details",
   "uid": "hqMSAnWWz",
   "version": 1
 }

--- a/config/monitoring/grafana/dashboards/logging/elasticsearch-details.json
+++ b/config/monitoring/grafana/dashboards/logging/elasticsearch-details.json
@@ -3,10 +3,10 @@
     "list": []
   },
   "description": "ElasticSearch cluster stats",
-  "editable": true,
+  "editable": "<< editable | default false | toJson >>",
   "gnetId": null,
   "graphTooltip": 1,
-  "hideControls": false,
+  "hideControls": "<< hideControls | default false | toJson >>",
   "links": [],
   "panels": [
     {
@@ -33,7 +33,7 @@
         "#299c46"
       ],
       "datasource": "$datasource",
-      "editable": true,
+      "editable": "<< editable | default false | toJson >>",
       "format": "none",
       "gauge": {
         "maxValue": 100,
@@ -97,7 +97,7 @@
       "thresholds": "2,4",
       "timeRegions": [],
       "title": "Cluster health",
-      "transparent": true,
+      "transparent": "<< transparentPanels | default true | toJson >>",
       "type": "singlestat",
       "valueFontSize": "80%",
       "valueMaps": [
@@ -135,7 +135,7 @@
       ],
       "datasource": "$datasource",
       "decimals": null,
-      "editable": true,
+      "editable": "<< editable | default false | toJson >>",
       "format": "none",
       "gauge": {
         "maxValue": 100,
@@ -199,7 +199,7 @@
       "thresholds": "1,2",
       "timeRegions": [],
       "title": "Tripped for breakers",
-      "transparent": true,
+      "transparent": "<< transparentPanels | default true | toJson >>",
       "type": "singlestat",
       "valueFontSize": "80%",
       "valueMaps": [
@@ -231,7 +231,7 @@
         "rgba(245, 54, 54, 0.9)"
       ],
       "datasource": "$datasource",
-      "editable": true,
+      "editable": "<< editable | default false | toJson >>",
       "error": false,
       "format": "percent",
       "gauge": {
@@ -299,7 +299,7 @@
       "thresholds": "70,80",
       "timeRegions": [],
       "title": "CPU usage Avg.",
-      "transparent": true,
+      "transparent": "<< transparentPanels | default true | toJson >>",
       "type": "singlestat",
       "valueFontSize": "80%",
       "valueMaps": [
@@ -321,7 +321,7 @@
         "rgba(245, 54, 54, 0.9)"
       ],
       "datasource": "$datasource",
-      "editable": true,
+      "editable": "<< editable | default false | toJson >>",
       "error": false,
       "format": "percent",
       "gauge": {
@@ -389,7 +389,7 @@
       "thresholds": "70,80",
       "timeRegions": [],
       "title": "JVM memory used Avg.",
-      "transparent": true,
+      "transparent": "<< transparentPanels | default true | toJson >>",
       "type": "singlestat",
       "valueFontSize": "80%",
       "valueMaps": [
@@ -412,7 +412,7 @@
       ],
       "datasource": "$datasource",
       "description": "Number of nodes in the cluster",
-      "editable": true,
+      "editable": "<< editable | default false | toJson >>",
       "error": false,
       "format": "none",
       "gauge": {
@@ -480,7 +480,7 @@
       "thresholds": "",
       "timeRegions": [],
       "title": "Nodes",
-      "transparent": true,
+      "transparent": "<< transparentPanels | default true | toJson >>",
       "type": "singlestat",
       "valueFontSize": "80%",
       "valueMaps": [
@@ -503,7 +503,7 @@
       ],
       "datasource": "$datasource",
       "description": "Number of data nodes in the cluster",
-      "editable": true,
+      "editable": "<< editable | default false | toJson >>",
       "error": false,
       "format": "none",
       "gauge": {
@@ -571,7 +571,7 @@
       "thresholds": "",
       "timeRegions": [],
       "title": "Data nodes",
-      "transparent": true,
+      "transparent": "<< transparentPanels | default true | toJson >>",
       "type": "singlestat",
       "valueFontSize": "80%",
       "valueMaps": [
@@ -594,7 +594,7 @@
       ],
       "datasource": "$datasource",
       "description": "Cluster level changes which have not yet been executed",
-      "editable": true,
+      "editable": "<< editable | default false | toJson >>",
       "error": false,
       "format": "none",
       "gauge": {
@@ -663,7 +663,7 @@
       "thresholds": "1,5",
       "timeRegions": [],
       "title": "Pending tasks",
-      "transparent": true,
+      "transparent": "<< transparentPanels | default true | toJson >>",
       "type": "singlestat",
       "valueFontSize": "80%",
       "valueMaps": [
@@ -685,7 +685,7 @@
         "rgba(245, 54, 54, 0.9)"
       ],
       "datasource": "$datasource",
-      "editable": true,
+      "editable": "<< editable | default false | toJson >>",
       "error": false,
       "format": "short",
       "gauge": {
@@ -753,7 +753,7 @@
       "thresholds": "",
       "timeRegions": [],
       "title": "Open file descriptors per cluster",
-      "transparent": true,
+      "transparent": "<< transparentPanels | default true | toJson >>",
       "type": "singlestat",
       "valueFontSize": "80%",
       "valueMaps": [],
@@ -784,7 +784,7 @@
       ],
       "datasource": "$datasource",
       "description": "The number of primary shards in your cluster. This is an aggregate total across all indices.",
-      "editable": true,
+      "editable": "<< editable | default false | toJson >>",
       "error": false,
       "format": "none",
       "gauge": {
@@ -852,7 +852,7 @@
       "thresholds": "",
       "timeRegions": [],
       "title": "Active primary shards",
-      "transparent": true,
+      "transparent": "<< transparentPanels | default true | toJson >>",
       "type": "singlestat",
       "valueFontSize": "80%",
       "valueMaps": [
@@ -875,7 +875,7 @@
       ],
       "datasource": "$datasource",
       "description": "Aggregate total of all shards across all indices, which includes replica shards",
-      "editable": true,
+      "editable": "<< editable | default false | toJson >>",
       "error": false,
       "format": "none",
       "gauge": {
@@ -942,7 +942,7 @@
       "thresholds": "",
       "timeRegions": [],
       "title": "Active shards",
-      "transparent": true,
+      "transparent": "<< transparentPanels | default true | toJson >>",
       "type": "singlestat",
       "valueFontSize": "80%",
       "valueMaps": [
@@ -965,7 +965,7 @@
       ],
       "datasource": "$datasource",
       "description": "Count of shards that are being freshly created",
-      "editable": true,
+      "editable": "<< editable | default false | toJson >>",
       "error": false,
       "format": "none",
       "gauge": {
@@ -1032,7 +1032,7 @@
       "thresholds": "",
       "timeRegions": [],
       "title": "Initializing shards",
-      "transparent": true,
+      "transparent": "<< transparentPanels | default true | toJson >>",
       "type": "singlestat",
       "valueFontSize": "80%",
       "valueMaps": [
@@ -1055,7 +1055,7 @@
       ],
       "datasource": "$datasource",
       "description": "The number of shards that are currently moving from one node to another node.",
-      "editable": true,
+      "editable": "<< editable | default false | toJson >>",
       "error": false,
       "format": "none",
       "gauge": {
@@ -1122,7 +1122,7 @@
       "thresholds": "",
       "timeRegions": [],
       "title": "Relocating shards",
-      "transparent": true,
+      "transparent": "<< transparentPanels | default true | toJson >>",
       "type": "singlestat",
       "valueFontSize": "80%",
       "valueMaps": [
@@ -1145,7 +1145,7 @@
       ],
       "datasource": "$datasource",
       "description": "Shards delayed to reduce reallocation overhead",
-      "editable": true,
+      "editable": "<< editable | default false | toJson >>",
       "error": false,
       "format": "none",
       "gauge": {
@@ -1212,7 +1212,7 @@
       "thresholds": "",
       "timeRegions": [],
       "title": "Delayed shards",
-      "transparent": true,
+      "transparent": "<< transparentPanels | default true | toJson >>",
       "type": "singlestat",
       "valueFontSize": "80%",
       "valueMaps": [
@@ -1235,7 +1235,7 @@
       ],
       "datasource": "$datasource",
       "description": "The number of shards that exist in the cluster state, but cannot be found in the cluster itself",
-      "editable": true,
+      "editable": "<< editable | default false | toJson >>",
       "error": false,
       "format": "none",
       "gauge": {
@@ -1302,7 +1302,7 @@
       "thresholds": "",
       "timeRegions": [],
       "title": "Unassigned shards",
-      "transparent": true,
+      "transparent": "<< transparentPanels | default true | toJson >>",
       "type": "singlestat",
       "valueFontSize": "80%",
       "valueMaps": [
@@ -1335,7 +1335,7 @@
       "dashes": false,
       "datasource": "$datasource",
       "decimals": 2,
-      "editable": true,
+      "editable": "<< editable | default false | toJson >>",
       "error": false,
       "fill": 1,
       "grid": {},
@@ -1397,7 +1397,7 @@
         "sort": 0,
         "value_type": "cumulative"
       },
-      "transparent": true,
+      "transparent": "<< transparentPanels | default true | toJson >>",
       "type": "graph",
       "xaxis": {
         "buckets": null,
@@ -1436,7 +1436,7 @@
       "dashLength": 10,
       "dashes": false,
       "datasource": "$datasource",
-      "editable": true,
+      "editable": "<< editable | default false | toJson >>",
       "error": false,
       "fill": 1,
       "grid": {},
@@ -1496,7 +1496,7 @@
         "sort": 0,
         "value_type": "cumulative"
       },
-      "transparent": true,
+      "transparent": "<< transparentPanels | default true | toJson >>",
       "type": "graph",
       "xaxis": {
         "buckets": null,
@@ -1535,7 +1535,7 @@
       "dashes": false,
       "datasource": "$datasource",
       "description": "Count of deleted documents on this node",
-      "editable": true,
+      "editable": "<< editable | default false | toJson >>",
       "error": false,
       "fill": 1,
       "grid": {},
@@ -1597,7 +1597,7 @@
         "sort": 0,
         "value_type": "cumulative"
       },
-      "transparent": true,
+      "transparent": "<< transparentPanels | default true | toJson >>",
       "type": "graph",
       "xaxis": {
         "buckets": null,
@@ -1636,7 +1636,7 @@
       "dashes": false,
       "datasource": "$datasource",
       "decimals": 2,
-      "editable": true,
+      "editable": "<< editable | default false | toJson >>",
       "error": false,
       "fill": 1,
       "grid": {},
@@ -1696,7 +1696,7 @@
         "sort": 0,
         "value_type": "cumulative"
       },
-      "transparent": true,
+      "transparent": "<< transparentPanels | default true | toJson >>",
       "type": "graph",
       "xaxis": {
         "buckets": null,
@@ -1735,7 +1735,7 @@
       "dashLength": 10,
       "dashes": false,
       "datasource": "$datasource",
-      "editable": true,
+      "editable": "<< editable | default false | toJson >>",
       "error": false,
       "fill": 1,
       "grid": {},
@@ -1795,7 +1795,7 @@
         "sort": 0,
         "value_type": "cumulative"
       },
-      "transparent": true,
+      "transparent": "<< transparentPanels | default true | toJson >>",
       "type": "graph",
       "xaxis": {
         "buckets": null,
@@ -1848,7 +1848,7 @@
       "dashLength": 10,
       "dashes": false,
       "datasource": "$datasource",
-      "editable": true,
+      "editable": "<< editable | default false | toJson >>",
       "fill": 1,
       "gridPos": {
         "h": 7,
@@ -1901,7 +1901,7 @@
         "sort": 2,
         "value_type": "individual"
       },
-      "transparent": true,
+      "transparent": "<< transparentPanels | default true | toJson >>",
       "type": "graph",
       "xaxis": {
         "buckets": null,
@@ -1939,7 +1939,7 @@
       "dashLength": 10,
       "dashes": false,
       "datasource": "$datasource",
-      "editable": true,
+      "editable": "<< editable | default false | toJson >>",
       "fill": 1,
       "gridPos": {
         "h": 7,
@@ -1992,7 +1992,7 @@
         "sort": 2,
         "value_type": "individual"
       },
-      "transparent": true,
+      "transparent": "<< transparentPanels | default true | toJson >>",
       "type": "graph",
       "xaxis": {
         "buckets": null,
@@ -2030,7 +2030,7 @@
       "dashLength": 10,
       "dashes": false,
       "datasource": "$datasource",
-      "editable": true,
+      "editable": "<< editable | default false | toJson >>",
       "fill": 1,
       "gridPos": {
         "h": 7,
@@ -2083,7 +2083,7 @@
         "sort": 2,
         "value_type": "individual"
       },
-      "transparent": true,
+      "transparent": "<< transparentPanels | default true | toJson >>",
       "type": "graph",
       "xaxis": {
         "buckets": null,
@@ -7245,7 +7245,7 @@
       "type": "row"
     }
   ],
-  "refresh": "30s",
+  "refresh": "<< refresh | default `30s` | toJson >>",
   "schemaVersion": 18,
   "style": "dark",
   "tags": [],
@@ -7253,7 +7253,7 @@
     "list": [
       {
         "current": {},
-        "hide": 2,
+        "hide": "<< datasourceHide | toJson >>",
         "includeAll": false,
         "label": null,
         "multi": false,
@@ -7404,7 +7404,7 @@
     ]
   },
   "time": {
-    "from": "now-6h",
+    "from": "<< defaultRange | toJson >>",
     "to": "now"
   },
   "timepicker": {

--- a/config/monitoring/grafana/dashboards/logging/elasticsearch-overview.json
+++ b/config/monitoring/grafana/dashboards/logging/elasticsearch-overview.json
@@ -2,10 +2,10 @@
   "annotations": {
     "list": []
   },
-  "editable": "<< editable | default false | toJson >>",
+  "editable": true,
   "gnetId": null,
   "graphTooltip": 1,
-  "hideControls": "<< hideControls | default false | toJson >>",
+  "hideControls": false,
   "links": [],
   "panels": [
     {
@@ -31,7 +31,7 @@
         "#d44a3a"
       ],
       "datasource": "$datasource",
-      "editable": "<< editable | default false | toJson >>",
+      "editable": true,
       "format": "none",
       "gauge": {
         "maxValue": 100,
@@ -94,7 +94,7 @@
       "thresholds": "2,3",
       "timeRegions": [],
       "title": "Cluster Status",
-      "transparent": "<< transparentPanels | default true | toJson >>",
+      "transparent": true,
       "type": "singlestat",
       "valueFontSize": "120%",
       "valueMaps": [
@@ -131,7 +131,7 @@
         "rgba(50, 172, 45, 0.97)"
       ],
       "datasource": "$datasource",
-      "editable": "<< editable | default false | toJson >>",
+      "editable": true,
       "error": false,
       "format": "none",
       "gauge": {
@@ -199,7 +199,7 @@
       "timeRegions": [],
       "timeShift": null,
       "title": "Running Nodes",
-      "transparent": "<< transparentPanels | default true | toJson >>",
+      "transparent": true,
       "type": "singlestat",
       "valueFontSize": "120%",
       "valueMaps": [
@@ -221,7 +221,7 @@
         "#d44a3a"
       ],
       "datasource": "$datasource",
-      "editable": "<< editable | default false | toJson >>",
+      "editable": true,
       "format": "none",
       "gauge": {
         "maxValue": 100,
@@ -282,7 +282,7 @@
       "thresholds": "",
       "timeRegions": [],
       "title": "Active Data Nodes",
-      "transparent": "<< transparentPanels | default true | toJson >>",
+      "transparent": true,
       "type": "singlestat",
       "valueFontSize": "120%",
       "valueMaps": [
@@ -304,7 +304,7 @@
         "#d44a3a"
       ],
       "datasource": "$datasource",
-      "editable": "<< editable | default false | toJson >>",
+      "editable": true,
       "format": "none",
       "gauge": {
         "maxValue": 100,
@@ -365,7 +365,7 @@
       "thresholds": "0.5,1",
       "timeRegions": [],
       "title": "Pending Tasks",
-      "transparent": "<< transparentPanels | default true | toJson >>",
+      "transparent": true,
       "type": "singlestat",
       "valueFontSize": "120%",
       "valueMaps": [
@@ -400,7 +400,7 @@
         "#d44a3a"
       ],
       "datasource": "$datasource",
-      "editable": "<< editable | default false | toJson >>",
+      "editable": true,
       "format": "none",
       "gauge": {
         "maxValue": 100,
@@ -461,7 +461,7 @@
       "thresholds": "",
       "timeRegions": [],
       "title": "Active Shards",
-      "transparent": "<< transparentPanels | default true | toJson >>",
+      "transparent": true,
       "type": "singlestat",
       "valueFontSize": "120%",
       "valueMaps": [
@@ -483,7 +483,7 @@
         "#d44a3a"
       ],
       "datasource": "$datasource",
-      "editable": "<< editable | default false | toJson >>",
+      "editable": true,
       "format": "none",
       "gauge": {
         "maxValue": 100,
@@ -544,7 +544,7 @@
       "thresholds": "",
       "timeRegions": [],
       "title": "Active Primary Shards",
-      "transparent": "<< transparentPanels | default true | toJson >>",
+      "transparent": true,
       "type": "singlestat",
       "valueFontSize": "120%",
       "valueMaps": [
@@ -566,7 +566,7 @@
         "#d44a3a"
       ],
       "datasource": "$datasource",
-      "editable": "<< editable | default false | toJson >>",
+      "editable": true,
       "format": "none",
       "gauge": {
         "maxValue": 100,
@@ -627,7 +627,7 @@
       "thresholds": "0.5,1",
       "timeRegions": [],
       "title": "Initializing Shards",
-      "transparent": "<< transparentPanels | default true | toJson >>",
+      "transparent": true,
       "type": "singlestat",
       "valueFontSize": "120%",
       "valueMaps": [
@@ -649,7 +649,7 @@
         "#d44a3a"
       ],
       "datasource": "$datasource",
-      "editable": "<< editable | default false | toJson >>",
+      "editable": true,
       "format": "none",
       "gauge": {
         "maxValue": 100,
@@ -710,7 +710,7 @@
       "thresholds": "0.5,1",
       "timeRegions": [],
       "title": "Relocating Shards",
-      "transparent": "<< transparentPanels | default true | toJson >>",
+      "transparent": true,
       "type": "singlestat",
       "valueFontSize": "120%",
       "valueMaps": [
@@ -732,7 +732,7 @@
         "#d44a3a"
       ],
       "datasource": "$datasource",
-      "editable": "<< editable | default false | toJson >>",
+      "editable": true,
       "format": "none",
       "gauge": {
         "maxValue": 100,
@@ -793,7 +793,7 @@
       "thresholds": "0.5,1",
       "timeRegions": [],
       "title": "Unassigned Shards",
-      "transparent": "<< transparentPanels | default true | toJson >>",
+      "transparent": true,
       "type": "singlestat",
       "valueFontSize": "120%",
       "valueMaps": [
@@ -815,7 +815,7 @@
         "#d44a3a"
       ],
       "datasource": "$datasource",
-      "editable": "<< editable | default false | toJson >>",
+      "editable": true,
       "format": "none",
       "gauge": {
         "maxValue": 100,
@@ -876,7 +876,7 @@
       "thresholds": "0.5,1",
       "timeRegions": [],
       "title": "Delayed Unassigned Shards",
-      "transparent": "<< transparentPanels | default true | toJson >>",
+      "transparent": true,
       "type": "singlestat",
       "valueFontSize": "120%",
       "valueMaps": [
@@ -907,7 +907,7 @@
       "dashLength": 10,
       "dashes": false,
       "datasource": "$datasource",
-      "editable": "<< editable | default false | toJson >>",
+      "editable": true,
       "error": false,
       "fill": 1,
       "grid": {},
@@ -961,7 +961,7 @@
         "sort": 0,
         "value_type": "cumulative"
       },
-      "transparent": "<< transparentPanels | default true | toJson >>",
+      "transparent": true,
       "type": "graph",
       "xaxis": {
         "buckets": null,
@@ -997,7 +997,7 @@
       "dashLength": 10,
       "dashes": false,
       "datasource": "$datasource",
-      "editable": "<< editable | default false | toJson >>",
+      "editable": true,
       "error": false,
       "fill": 1,
       "grid": {},
@@ -1051,7 +1051,7 @@
         "sort": 0,
         "value_type": "cumulative"
       },
-      "transparent": "<< transparentPanels | default true | toJson >>",
+      "transparent": true,
       "type": "graph",
       "xaxis": {
         "buckets": null,
@@ -1087,7 +1087,7 @@
       "dashLength": 10,
       "dashes": false,
       "datasource": "$datasource",
-      "editable": "<< editable | default false | toJson >>",
+      "editable": true,
       "fill": 1,
       "gridPos": {
         "h": 9,
@@ -1137,7 +1137,7 @@
         "sort": 0,
         "value_type": "individual"
       },
-      "transparent": "<< transparentPanels | default true | toJson >>",
+      "transparent": true,
       "type": "graph",
       "xaxis": {
         "buckets": null,
@@ -1175,7 +1175,7 @@
       "dashLength": 10,
       "dashes": false,
       "datasource": "$datasource",
-      "editable": "<< editable | default false | toJson >>",
+      "editable": true,
       "fill": 1,
       "gridPos": {
         "h": 9,
@@ -1225,7 +1225,7 @@
         "sort": 0,
         "value_type": "individual"
       },
-      "transparent": "<< transparentPanels | default true | toJson >>",
+      "transparent": true,
       "type": "graph",
       "xaxis": {
         "buckets": null,
@@ -1263,7 +1263,7 @@
       "dashLength": 10,
       "dashes": false,
       "datasource": "$datasource",
-      "editable": "<< editable | default false | toJson >>",
+      "editable": true,
       "error": false,
       "fill": 1,
       "grid": {},
@@ -1318,7 +1318,7 @@
         "sort": 0,
         "value_type": "cumulative"
       },
-      "transparent": "<< transparentPanels | default true | toJson >>",
+      "transparent": true,
       "type": "graph",
       "xaxis": {
         "buckets": null,
@@ -1367,7 +1367,7 @@
       "dashLength": 10,
       "dashes": false,
       "datasource": "$datasource",
-      "editable": "<< editable | default false | toJson >>",
+      "editable": true,
       "error": false,
       "fill": 1,
       "grid": {},
@@ -1421,7 +1421,7 @@
         "sort": 0,
         "value_type": "cumulative"
       },
-      "transparent": "<< transparentPanels | default true | toJson >>",
+      "transparent": true,
       "type": "graph",
       "xaxis": {
         "buckets": null,
@@ -1457,7 +1457,7 @@
       "dashLength": 10,
       "dashes": false,
       "datasource": "$datasource",
-      "editable": "<< editable | default false | toJson >>",
+      "editable": true,
       "error": false,
       "fill": 1,
       "grid": {},
@@ -1511,7 +1511,7 @@
         "sort": 0,
         "value_type": "cumulative"
       },
-      "transparent": "<< transparentPanels | default true | toJson >>",
+      "transparent": true,
       "type": "graph",
       "xaxis": {
         "buckets": null,
@@ -1547,7 +1547,7 @@
       "dashLength": 10,
       "dashes": false,
       "datasource": "$datasource",
-      "editable": "<< editable | default false | toJson >>",
+      "editable": true,
       "error": false,
       "fill": 1,
       "grid": {},
@@ -1601,7 +1601,7 @@
         "sort": 0,
         "value_type": "cumulative"
       },
-      "transparent": "<< transparentPanels | default true | toJson >>",
+      "transparent": true,
       "type": "graph",
       "xaxis": {
         "buckets": null,
@@ -1637,7 +1637,7 @@
       "dashLength": 10,
       "dashes": false,
       "datasource": "$datasource",
-      "editable": "<< editable | default false | toJson >>",
+      "editable": true,
       "error": false,
       "fill": 1,
       "grid": {},
@@ -1693,7 +1693,7 @@
         "sort": 0,
         "value_type": "cumulative"
       },
-      "transparent": "<< transparentPanels | default true | toJson >>",
+      "transparent": true,
       "type": "graph",
       "xaxis": {
         "buckets": null,
@@ -1731,7 +1731,7 @@
       "dashLength": 10,
       "dashes": false,
       "datasource": "$datasource",
-      "editable": "<< editable | default false | toJson >>",
+      "editable": true,
       "error": false,
       "fill": 1,
       "grid": {},
@@ -1793,7 +1793,7 @@
         "sort": 0,
         "value_type": "cumulative"
       },
-      "transparent": "<< transparentPanels | default true | toJson >>",
+      "transparent": true,
       "type": "graph",
       "xaxis": {
         "buckets": null,
@@ -1824,7 +1824,7 @@
       }
     }
   ],
-  "refresh": "<< refresh | default `30s` | toJson >>",
+  "refresh": "30s",
   "schemaVersion": 18,
   "style": "dark",
   "tags": [],
@@ -1832,7 +1832,7 @@
     "list": [
       {
         "current": {},
-        "hide": "<< datasourceHide | toJson >>",
+        "hide": 2,
         "includeAll": false,
         "label": null,
         "multi": false,
@@ -1869,7 +1869,7 @@
     ]
   },
   "time": {
-    "from": "<< defaultRange | toJson >>",
+    "from": "now-6h",
     "to": "now"
   },
   "timepicker": {
@@ -1898,7 +1898,7 @@
     ]
   },
   "timezone": "",
-  "title": "Overview",
+  "title": "Elasticsearch Overview",
   "uid": "n_nxrE_mk",
   "version": 1
 }

--- a/config/monitoring/grafana/dashboards/logging/elasticsearch-overview.json
+++ b/config/monitoring/grafana/dashboards/logging/elasticsearch-overview.json
@@ -2,10 +2,10 @@
   "annotations": {
     "list": []
   },
-  "editable": true,
+  "editable": "<< editable | default false | toJson >>",
   "gnetId": null,
   "graphTooltip": 1,
-  "hideControls": false,
+  "hideControls": "<< hideControls | default false | toJson >>",
   "links": [],
   "panels": [
     {
@@ -31,7 +31,7 @@
         "#d44a3a"
       ],
       "datasource": "$datasource",
-      "editable": true,
+      "editable": "<< editable | default false | toJson >>",
       "format": "none",
       "gauge": {
         "maxValue": 100,
@@ -94,7 +94,7 @@
       "thresholds": "2,3",
       "timeRegions": [],
       "title": "Cluster Status",
-      "transparent": true,
+      "transparent": "<< transparentPanels | default true | toJson >>",
       "type": "singlestat",
       "valueFontSize": "120%",
       "valueMaps": [
@@ -131,7 +131,7 @@
         "rgba(50, 172, 45, 0.97)"
       ],
       "datasource": "$datasource",
-      "editable": true,
+      "editable": "<< editable | default false | toJson >>",
       "error": false,
       "format": "none",
       "gauge": {
@@ -199,7 +199,7 @@
       "timeRegions": [],
       "timeShift": null,
       "title": "Running Nodes",
-      "transparent": true,
+      "transparent": "<< transparentPanels | default true | toJson >>",
       "type": "singlestat",
       "valueFontSize": "120%",
       "valueMaps": [
@@ -221,7 +221,7 @@
         "#d44a3a"
       ],
       "datasource": "$datasource",
-      "editable": true,
+      "editable": "<< editable | default false | toJson >>",
       "format": "none",
       "gauge": {
         "maxValue": 100,
@@ -282,7 +282,7 @@
       "thresholds": "",
       "timeRegions": [],
       "title": "Active Data Nodes",
-      "transparent": true,
+      "transparent": "<< transparentPanels | default true | toJson >>",
       "type": "singlestat",
       "valueFontSize": "120%",
       "valueMaps": [
@@ -304,7 +304,7 @@
         "#d44a3a"
       ],
       "datasource": "$datasource",
-      "editable": true,
+      "editable": "<< editable | default false | toJson >>",
       "format": "none",
       "gauge": {
         "maxValue": 100,
@@ -365,7 +365,7 @@
       "thresholds": "0.5,1",
       "timeRegions": [],
       "title": "Pending Tasks",
-      "transparent": true,
+      "transparent": "<< transparentPanels | default true | toJson >>",
       "type": "singlestat",
       "valueFontSize": "120%",
       "valueMaps": [
@@ -400,7 +400,7 @@
         "#d44a3a"
       ],
       "datasource": "$datasource",
-      "editable": true,
+      "editable": "<< editable | default false | toJson >>",
       "format": "none",
       "gauge": {
         "maxValue": 100,
@@ -461,7 +461,7 @@
       "thresholds": "",
       "timeRegions": [],
       "title": "Active Shards",
-      "transparent": true,
+      "transparent": "<< transparentPanels | default true | toJson >>",
       "type": "singlestat",
       "valueFontSize": "120%",
       "valueMaps": [
@@ -483,7 +483,7 @@
         "#d44a3a"
       ],
       "datasource": "$datasource",
-      "editable": true,
+      "editable": "<< editable | default false | toJson >>",
       "format": "none",
       "gauge": {
         "maxValue": 100,
@@ -544,7 +544,7 @@
       "thresholds": "",
       "timeRegions": [],
       "title": "Active Primary Shards",
-      "transparent": true,
+      "transparent": "<< transparentPanels | default true | toJson >>",
       "type": "singlestat",
       "valueFontSize": "120%",
       "valueMaps": [
@@ -566,7 +566,7 @@
         "#d44a3a"
       ],
       "datasource": "$datasource",
-      "editable": true,
+      "editable": "<< editable | default false | toJson >>",
       "format": "none",
       "gauge": {
         "maxValue": 100,
@@ -627,7 +627,7 @@
       "thresholds": "0.5,1",
       "timeRegions": [],
       "title": "Initializing Shards",
-      "transparent": true,
+      "transparent": "<< transparentPanels | default true | toJson >>",
       "type": "singlestat",
       "valueFontSize": "120%",
       "valueMaps": [
@@ -649,7 +649,7 @@
         "#d44a3a"
       ],
       "datasource": "$datasource",
-      "editable": true,
+      "editable": "<< editable | default false | toJson >>",
       "format": "none",
       "gauge": {
         "maxValue": 100,
@@ -710,7 +710,7 @@
       "thresholds": "0.5,1",
       "timeRegions": [],
       "title": "Relocating Shards",
-      "transparent": true,
+      "transparent": "<< transparentPanels | default true | toJson >>",
       "type": "singlestat",
       "valueFontSize": "120%",
       "valueMaps": [
@@ -732,7 +732,7 @@
         "#d44a3a"
       ],
       "datasource": "$datasource",
-      "editable": true,
+      "editable": "<< editable | default false | toJson >>",
       "format": "none",
       "gauge": {
         "maxValue": 100,
@@ -793,7 +793,7 @@
       "thresholds": "0.5,1",
       "timeRegions": [],
       "title": "Unassigned Shards",
-      "transparent": true,
+      "transparent": "<< transparentPanels | default true | toJson >>",
       "type": "singlestat",
       "valueFontSize": "120%",
       "valueMaps": [
@@ -815,7 +815,7 @@
         "#d44a3a"
       ],
       "datasource": "$datasource",
-      "editable": true,
+      "editable": "<< editable | default false | toJson >>",
       "format": "none",
       "gauge": {
         "maxValue": 100,
@@ -876,7 +876,7 @@
       "thresholds": "0.5,1",
       "timeRegions": [],
       "title": "Delayed Unassigned Shards",
-      "transparent": true,
+      "transparent": "<< transparentPanels | default true | toJson >>",
       "type": "singlestat",
       "valueFontSize": "120%",
       "valueMaps": [
@@ -907,7 +907,7 @@
       "dashLength": 10,
       "dashes": false,
       "datasource": "$datasource",
-      "editable": true,
+      "editable": "<< editable | default false | toJson >>",
       "error": false,
       "fill": 1,
       "grid": {},
@@ -961,7 +961,7 @@
         "sort": 0,
         "value_type": "cumulative"
       },
-      "transparent": true,
+      "transparent": "<< transparentPanels | default true | toJson >>",
       "type": "graph",
       "xaxis": {
         "buckets": null,
@@ -997,7 +997,7 @@
       "dashLength": 10,
       "dashes": false,
       "datasource": "$datasource",
-      "editable": true,
+      "editable": "<< editable | default false | toJson >>",
       "error": false,
       "fill": 1,
       "grid": {},
@@ -1051,7 +1051,7 @@
         "sort": 0,
         "value_type": "cumulative"
       },
-      "transparent": true,
+      "transparent": "<< transparentPanels | default true | toJson >>",
       "type": "graph",
       "xaxis": {
         "buckets": null,
@@ -1087,7 +1087,7 @@
       "dashLength": 10,
       "dashes": false,
       "datasource": "$datasource",
-      "editable": true,
+      "editable": "<< editable | default false | toJson >>",
       "fill": 1,
       "gridPos": {
         "h": 9,
@@ -1137,7 +1137,7 @@
         "sort": 0,
         "value_type": "individual"
       },
-      "transparent": true,
+      "transparent": "<< transparentPanels | default true | toJson >>",
       "type": "graph",
       "xaxis": {
         "buckets": null,
@@ -1175,7 +1175,7 @@
       "dashLength": 10,
       "dashes": false,
       "datasource": "$datasource",
-      "editable": true,
+      "editable": "<< editable | default false | toJson >>",
       "fill": 1,
       "gridPos": {
         "h": 9,
@@ -1225,7 +1225,7 @@
         "sort": 0,
         "value_type": "individual"
       },
-      "transparent": true,
+      "transparent": "<< transparentPanels | default true | toJson >>",
       "type": "graph",
       "xaxis": {
         "buckets": null,
@@ -1263,7 +1263,7 @@
       "dashLength": 10,
       "dashes": false,
       "datasource": "$datasource",
-      "editable": true,
+      "editable": "<< editable | default false | toJson >>",
       "error": false,
       "fill": 1,
       "grid": {},
@@ -1318,7 +1318,7 @@
         "sort": 0,
         "value_type": "cumulative"
       },
-      "transparent": true,
+      "transparent": "<< transparentPanels | default true | toJson >>",
       "type": "graph",
       "xaxis": {
         "buckets": null,
@@ -1367,7 +1367,7 @@
       "dashLength": 10,
       "dashes": false,
       "datasource": "$datasource",
-      "editable": true,
+      "editable": "<< editable | default false | toJson >>",
       "error": false,
       "fill": 1,
       "grid": {},
@@ -1421,7 +1421,7 @@
         "sort": 0,
         "value_type": "cumulative"
       },
-      "transparent": true,
+      "transparent": "<< transparentPanels | default true | toJson >>",
       "type": "graph",
       "xaxis": {
         "buckets": null,
@@ -1457,7 +1457,7 @@
       "dashLength": 10,
       "dashes": false,
       "datasource": "$datasource",
-      "editable": true,
+      "editable": "<< editable | default false | toJson >>",
       "error": false,
       "fill": 1,
       "grid": {},
@@ -1511,7 +1511,7 @@
         "sort": 0,
         "value_type": "cumulative"
       },
-      "transparent": true,
+      "transparent": "<< transparentPanels | default true | toJson >>",
       "type": "graph",
       "xaxis": {
         "buckets": null,
@@ -1547,7 +1547,7 @@
       "dashLength": 10,
       "dashes": false,
       "datasource": "$datasource",
-      "editable": true,
+      "editable": "<< editable | default false | toJson >>",
       "error": false,
       "fill": 1,
       "grid": {},
@@ -1601,7 +1601,7 @@
         "sort": 0,
         "value_type": "cumulative"
       },
-      "transparent": true,
+      "transparent": "<< transparentPanels | default true | toJson >>",
       "type": "graph",
       "xaxis": {
         "buckets": null,
@@ -1637,7 +1637,7 @@
       "dashLength": 10,
       "dashes": false,
       "datasource": "$datasource",
-      "editable": true,
+      "editable": "<< editable | default false | toJson >>",
       "error": false,
       "fill": 1,
       "grid": {},
@@ -1693,7 +1693,7 @@
         "sort": 0,
         "value_type": "cumulative"
       },
-      "transparent": true,
+      "transparent": "<< transparentPanels | default true | toJson >>",
       "type": "graph",
       "xaxis": {
         "buckets": null,
@@ -1731,7 +1731,7 @@
       "dashLength": 10,
       "dashes": false,
       "datasource": "$datasource",
-      "editable": true,
+      "editable": "<< editable | default false | toJson >>",
       "error": false,
       "fill": 1,
       "grid": {},
@@ -1793,7 +1793,7 @@
         "sort": 0,
         "value_type": "cumulative"
       },
-      "transparent": true,
+      "transparent": "<< transparentPanels | default true | toJson >>",
       "type": "graph",
       "xaxis": {
         "buckets": null,
@@ -1824,7 +1824,7 @@
       }
     }
   ],
-  "refresh": "30s",
+  "refresh": "<< refresh | default `30s` | toJson >>",
   "schemaVersion": 18,
   "style": "dark",
   "tags": [],
@@ -1832,7 +1832,7 @@
     "list": [
       {
         "current": {},
-        "hide": 2,
+        "hide": "<< datasourceHide | toJson >>",
         "includeAll": false,
         "label": null,
         "multi": false,
@@ -1869,7 +1869,7 @@
     ]
   },
   "time": {
-    "from": "now-6h",
+    "from": "<< defaultRange | toJson >>",
     "to": "now"
   },
   "timepicker": {

--- a/config/monitoring/grafana/dashboards/logging/fluent-bit.json
+++ b/config/monitoring/grafana/dashboards/logging/fluent-bit.json
@@ -1,0 +1,490 @@
+{
+  "annotations": {
+    "list": []
+  },
+  "editable": "<< editable | default false | toJson >>",
+  "gnetId": null,
+  "graphTooltip": 1,
+  "hideControls": "<< hideControls | default false | toJson >>",
+  "links": [],
+  "panels": [
+    {
+      "aliasColors": {},
+      "bars": false,
+      "dashLength": 10,
+      "dashes": false,
+      "datasource": "$datasource",
+      "editable": "<< editable | default false | toJson >>",
+      "fill": 1,
+      "fillGradient": 0,
+      "gridPos": {
+        "h": 10,
+        "w": 12,
+        "x": 0,
+        "y": 0
+      },
+      "id": 6,
+      "legend": {
+        "alignAsTable": false,
+        "avg": false,
+        "current": false,
+        "hideEmpty": false,
+        "hideZero": false,
+        "max": false,
+        "min": false,
+        "rightSide": false,
+        "show": true,
+        "total": false,
+        "values": false
+      },
+      "lines": true,
+      "linewidth": 1,
+      "links": [],
+      "nullPointMode": "connected",
+      "options": {
+        "dataLinks": []
+      },
+      "percentage": false,
+      "pointradius": 5,
+      "points": false,
+      "renderer": "flot",
+      "seriesOverrides": [],
+      "spaceLength": 10,
+      "stack": false,
+      "steppedLine": false,
+      "targets": [
+        {
+          "expr": "sum by (name) (rate(fluentbit_input_bytes_total{namespace=\"logging\"}[$interval]))",
+          "format": "time_series",
+          "intervalFactor": 1,
+          "legendFormat": "{{ name }}",
+          "refId": "A"
+        }
+      ],
+      "thresholds": [],
+      "timeFrom": null,
+      "timeRegions": [],
+      "timeShift": null,
+      "title": "Data Ingestion Rate",
+      "tooltip": {
+        "shared": true,
+        "sort": 0,
+        "value_type": "individual"
+      },
+      "transparent": "<< transparentPanels | default true | toJson >>",
+      "type": "graph",
+      "xaxis": {
+        "buckets": null,
+        "mode": "time",
+        "name": null,
+        "show": true,
+        "values": []
+      },
+      "yaxes": [
+        {
+          "format": "Bps",
+          "label": null,
+          "logBase": 1,
+          "max": null,
+          "min": null,
+          "show": true
+        },
+        {
+          "format": "short",
+          "label": null,
+          "logBase": 1,
+          "max": null,
+          "min": null,
+          "show": false
+        }
+      ],
+      "yaxis": {
+        "align": false,
+        "alignLevel": null
+      }
+    },
+    {
+      "aliasColors": {},
+      "bars": false,
+      "dashLength": 10,
+      "dashes": false,
+      "datasource": "$datasource",
+      "editable": "<< editable | default false | toJson >>",
+      "fill": 1,
+      "fillGradient": 0,
+      "gridPos": {
+        "h": 10,
+        "w": 12,
+        "x": 12,
+        "y": 0
+      },
+      "id": 10,
+      "legend": {
+        "alignAsTable": false,
+        "avg": false,
+        "current": false,
+        "hideEmpty": false,
+        "hideZero": false,
+        "max": false,
+        "min": false,
+        "rightSide": false,
+        "show": true,
+        "total": false,
+        "values": false
+      },
+      "lines": true,
+      "linewidth": 1,
+      "links": [],
+      "nullPointMode": "connected",
+      "options": {
+        "dataLinks": []
+      },
+      "percentage": false,
+      "pointradius": 5,
+      "points": false,
+      "renderer": "flot",
+      "seriesOverrides": [],
+      "spaceLength": 10,
+      "stack": false,
+      "steppedLine": false,
+      "targets": [
+        {
+          "expr": "sum by (name) (rate(fluentbit_input_records_total{namespace=\"logging\"}[$interval]))",
+          "format": "time_series",
+          "intervalFactor": 1,
+          "legendFormat": "{{ name }}",
+          "refId": "A"
+        }
+      ],
+      "thresholds": [],
+      "timeFrom": null,
+      "timeRegions": [],
+      "timeShift": null,
+      "title": "Record Ingestion Rate",
+      "tooltip": {
+        "shared": true,
+        "sort": 0,
+        "value_type": "individual"
+      },
+      "transparent": "<< transparentPanels | default true | toJson >>",
+      "type": "graph",
+      "xaxis": {
+        "buckets": null,
+        "mode": "time",
+        "name": null,
+        "show": true,
+        "values": []
+      },
+      "yaxes": [
+        {
+          "format": "rpm",
+          "label": null,
+          "logBase": 1,
+          "max": null,
+          "min": null,
+          "show": true
+        },
+        {
+          "format": "short",
+          "label": null,
+          "logBase": 1,
+          "max": null,
+          "min": null,
+          "show": false
+        }
+      ],
+      "yaxis": {
+        "align": false,
+        "alignLevel": null
+      }
+    },
+    {
+      "aliasColors": {},
+      "bars": false,
+      "dashLength": 10,
+      "dashes": false,
+      "datasource": "$datasource",
+      "editable": "<< editable | default false | toJson >>",
+      "fill": 1,
+      "fillGradient": 0,
+      "gridPos": {
+        "h": 9,
+        "w": 12,
+        "x": 0,
+        "y": 10
+      },
+      "id": 11,
+      "legend": {
+        "alignAsTable": false,
+        "avg": false,
+        "current": false,
+        "hideEmpty": false,
+        "hideZero": false,
+        "max": false,
+        "min": false,
+        "rightSide": false,
+        "show": true,
+        "total": false,
+        "values": false
+      },
+      "lines": true,
+      "linewidth": 1,
+      "links": [],
+      "nullPointMode": "connected",
+      "options": {
+        "dataLinks": []
+      },
+      "percentage": false,
+      "pointradius": 5,
+      "points": false,
+      "renderer": "flot",
+      "seriesOverrides": [],
+      "spaceLength": 10,
+      "stack": false,
+      "steppedLine": false,
+      "targets": [
+        {
+          "expr": "sum by (name) (rate(fluentbit_output_retries_total{namespace=\"logging\"}[$interval]))",
+          "format": "time_series",
+          "intervalFactor": 1,
+          "legendFormat": "{{ name }}",
+          "refId": "A"
+        }
+      ],
+      "thresholds": [],
+      "timeFrom": null,
+      "timeRegions": [],
+      "timeShift": null,
+      "title": "Output Retry Rate",
+      "tooltip": {
+        "shared": true,
+        "sort": 0,
+        "value_type": "individual"
+      },
+      "transparent": "<< transparentPanels | default true | toJson >>",
+      "type": "graph",
+      "xaxis": {
+        "buckets": null,
+        "mode": "time",
+        "name": null,
+        "show": true,
+        "values": []
+      },
+      "yaxes": [
+        {
+          "format": "ops",
+          "label": null,
+          "logBase": 1,
+          "max": null,
+          "min": null,
+          "show": true
+        },
+        {
+          "format": "short",
+          "label": null,
+          "logBase": 1,
+          "max": null,
+          "min": null,
+          "show": false
+        }
+      ],
+      "yaxis": {
+        "align": false,
+        "alignLevel": null
+      }
+    },
+    {
+      "aliasColors": {},
+      "bars": false,
+      "dashLength": 10,
+      "dashes": false,
+      "datasource": "$datasource",
+      "editable": "<< editable | default false | toJson >>",
+      "fill": 1,
+      "fillGradient": 0,
+      "gridPos": {
+        "h": 9,
+        "w": 12,
+        "x": 12,
+        "y": 10
+      },
+      "id": 12,
+      "legend": {
+        "alignAsTable": false,
+        "avg": false,
+        "current": false,
+        "hideEmpty": false,
+        "hideZero": false,
+        "max": false,
+        "min": false,
+        "rightSide": false,
+        "show": true,
+        "total": false,
+        "values": false
+      },
+      "lines": true,
+      "linewidth": 1,
+      "links": [],
+      "nullPointMode": "connected",
+      "options": {
+        "dataLinks": []
+      },
+      "percentage": false,
+      "pointradius": 5,
+      "points": false,
+      "renderer": "flot",
+      "seriesOverrides": [],
+      "spaceLength": 10,
+      "stack": false,
+      "steppedLine": false,
+      "targets": [
+        {
+          "expr": "sum by (name) (fluentbit_input_files_opened_total{namespace=\"logging\"} - fluentbit_input_files_closed_total{namespace=\"logging\"})",
+          "format": "time_series",
+          "intervalFactor": 1,
+          "legendFormat": "{{ name }}",
+          "refId": "A"
+        }
+      ],
+      "thresholds": [],
+      "timeFrom": null,
+      "timeRegions": [],
+      "timeShift": null,
+      "title": "Currently Open Files",
+      "tooltip": {
+        "shared": true,
+        "sort": 0,
+        "value_type": "individual"
+      },
+      "transparent": "<< transparentPanels | default true | toJson >>",
+      "type": "graph",
+      "xaxis": {
+        "buckets": null,
+        "mode": "time",
+        "name": null,
+        "show": true,
+        "values": []
+      },
+      "yaxes": [
+        {
+          "format": "short",
+          "label": null,
+          "logBase": 1,
+          "max": null,
+          "min": null,
+          "show": true
+        },
+        {
+          "format": "short",
+          "label": null,
+          "logBase": 1,
+          "max": null,
+          "min": null,
+          "show": false
+        }
+      ],
+      "yaxis": {
+        "align": false,
+        "alignLevel": null
+      }
+    }
+  ],
+  "refresh": "<< refresh | default `30s` | toJson >>",
+  "schemaVersion": 19,
+  "style": "dark",
+  "tags": [],
+  "templating": {
+    "list": [
+      {
+        "current": {},
+        "hide": "<< datasourceHide | toJson >>",
+        "includeAll": false,
+        "label": null,
+        "multi": false,
+        "name": "datasource",
+        "options": [],
+        "query": "prometheus",
+        "refresh": 1,
+        "regex": "",
+        "skipUrlSync": false,
+        "type": "datasource"
+      },
+      {
+        "allValue": null,
+        "current": {
+          "tags": [],
+          "text": "30m",
+          "value": "30m"
+        },
+        "hide": 0,
+        "includeAll": false,
+        "label": "Interval",
+        "multi": false,
+        "name": "interval",
+        "options": [
+          {
+            "selected": false,
+            "text": "1m",
+            "value": "1m"
+          },
+          {
+            "selected": false,
+            "text": "5m",
+            "value": "5m"
+          },
+          {
+            "selected": false,
+            "text": "10m",
+            "value": "10m"
+          },
+          {
+            "selected": true,
+            "text": "30m",
+            "value": "30m"
+          },
+          {
+            "selected": false,
+            "text": "60m",
+            "value": "60m"
+          }
+        ],
+        "query": "1m,5m,10m,30m,60m",
+        "skipUrlSync": false,
+        "type": "custom"
+      }
+    ]
+  },
+  "time": {
+    "from": "<< defaultRange | toJson >>",
+    "to": "now"
+  },
+  "timepicker": {
+    "refresh_intervals": [
+      "5s",
+      "10s",
+      "30s",
+      "1m",
+      "5m",
+      "15m",
+      "30m",
+      "1h",
+      "2h",
+      "1d"
+    ],
+    "time_options": [
+      "5m",
+      "15m",
+      "1h",
+      "6h",
+      "12h",
+      "24h",
+      "2d",
+      "7d",
+      "30d"
+    ]
+  },
+  "timezone": "",
+  "title": "Fluent Bit",
+  "uid": "QEP29ntZk",
+  "version": 1
+}

--- a/config/monitoring/grafana/dashboards/logging/fluent-bit.json
+++ b/config/monitoring/grafana/dashboards/logging/fluent-bit.json
@@ -2,10 +2,10 @@
   "annotations": {
     "list": []
   },
-  "editable": "<< editable | default false | toJson >>",
+  "editable": true,
   "gnetId": null,
   "graphTooltip": 1,
-  "hideControls": "<< hideControls | default false | toJson >>",
+  "hideControls": false,
   "links": [],
   "panels": [
     {
@@ -14,7 +14,7 @@
       "dashLength": 10,
       "dashes": false,
       "datasource": "$datasource",
-      "editable": "<< editable | default false | toJson >>",
+      "editable": true,
       "fill": 1,
       "fillGradient": 0,
       "gridPos": {
@@ -71,7 +71,7 @@
         "sort": 0,
         "value_type": "individual"
       },
-      "transparent": "<< transparentPanels | default true | toJson >>",
+      "transparent": true,
       "type": "graph",
       "xaxis": {
         "buckets": null,
@@ -109,7 +109,7 @@
       "dashLength": 10,
       "dashes": false,
       "datasource": "$datasource",
-      "editable": "<< editable | default false | toJson >>",
+      "editable": true,
       "fill": 1,
       "fillGradient": 0,
       "gridPos": {
@@ -166,7 +166,7 @@
         "sort": 0,
         "value_type": "individual"
       },
-      "transparent": "<< transparentPanels | default true | toJson >>",
+      "transparent": true,
       "type": "graph",
       "xaxis": {
         "buckets": null,
@@ -204,7 +204,7 @@
       "dashLength": 10,
       "dashes": false,
       "datasource": "$datasource",
-      "editable": "<< editable | default false | toJson >>",
+      "editable": true,
       "fill": 1,
       "fillGradient": 0,
       "gridPos": {
@@ -261,7 +261,7 @@
         "sort": 0,
         "value_type": "individual"
       },
-      "transparent": "<< transparentPanels | default true | toJson >>",
+      "transparent": true,
       "type": "graph",
       "xaxis": {
         "buckets": null,
@@ -299,7 +299,7 @@
       "dashLength": 10,
       "dashes": false,
       "datasource": "$datasource",
-      "editable": "<< editable | default false | toJson >>",
+      "editable": true,
       "fill": 1,
       "fillGradient": 0,
       "gridPos": {
@@ -356,7 +356,7 @@
         "sort": 0,
         "value_type": "individual"
       },
-      "transparent": "<< transparentPanels | default true | toJson >>",
+      "transparent": true,
       "type": "graph",
       "xaxis": {
         "buckets": null,
@@ -389,7 +389,7 @@
       }
     }
   ],
-  "refresh": "<< refresh | default `30s` | toJson >>",
+  "refresh": "30s",
   "schemaVersion": 19,
   "style": "dark",
   "tags": [],
@@ -397,7 +397,7 @@
     "list": [
       {
         "current": {},
-        "hide": "<< datasourceHide | toJson >>",
+        "hide": 2,
         "includeAll": false,
         "label": null,
         "multi": false,
@@ -455,7 +455,7 @@
     ]
   },
   "time": {
-    "from": "<< defaultRange | toJson >>",
+    "from": "now-6h",
     "to": "now"
   },
   "timepicker": {

--- a/config/monitoring/grafana/provisioning/dashboards/elasticsearch.yaml
+++ b/config/monitoring/grafana/provisioning/dashboards/elasticsearch.yaml
@@ -1,8 +1,0 @@
-apiVersion: 1
-providers:
-- folder: "Elasticsearch"
-  name: "elasticsearch"
-  options:
-    path: /grafana-dashboard-definitions/elasticsearch
-  org_id: 1
-  type: file

--- a/config/monitoring/grafana/provisioning/dashboards/logging.yaml
+++ b/config/monitoring/grafana/provisioning/dashboards/logging.yaml
@@ -1,0 +1,8 @@
+apiVersion: 1
+providers:
+- folder: "Logging Stack"
+  name: "logging"
+  options:
+    path: /grafana-dashboard-definitions/logging
+  org_id: 1
+  type: file


### PR DESCRIPTION
**What this PR does / why we need it**:
This adds a new, very basic fluent-bit dashboard, and moves it and the ES dashboards into a new "logging" folder.

**Does this PR introduce a user-facing change?**:
```release-note
Add fluent-bit Grafana dashboard
```
