### PR TITLE
update delete methods for roles and bindigs

### DIFF
--- a/api/pkg/handler/v1/cluster/binding.go
+++ b/api/pkg/handler/v1/cluster/binding.go
@@ -268,11 +268,12 @@ func DeleteRoleBindingEndpoint() endpoint.Endpoint {
 		}
 
 		bindingID := addUserClusterRBACPrefix(req.BindingID)
-		binding := &rbacv1.RoleBinding{}
-		if err := client.Get(ctx, ctrlruntimeclient.ObjectKey{Name: bindingID, Namespace: req.Namespace}, binding); err != nil {
-			return nil, common.KubernetesErrorToHTTPError(err)
+		binding := &rbacv1.RoleBinding{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      bindingID,
+				Namespace: req.Namespace,
+			},
 		}
-
 		if err := client.Delete(ctx, binding); err != nil {
 			return nil, common.KubernetesErrorToHTTPError(err)
 		}
@@ -660,9 +661,10 @@ func DeleteClusterRoleBindingEndpoint() endpoint.Endpoint {
 		}
 
 		bindingID := addUserClusterRBACPrefix(req.BindingID)
-		binding := &rbacv1.ClusterRoleBinding{}
-		if err := client.Get(ctx, ctrlruntimeclient.ObjectKey{Name: bindingID}, binding); err != nil {
-			return nil, common.KubernetesErrorToHTTPError(err)
+		binding := &rbacv1.ClusterRoleBinding{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: bindingID,
+			},
 		}
 
 		if err := client.Delete(ctx, binding); err != nil {

--- a/api/pkg/handler/v1/cluster/role.go
+++ b/api/pkg/handler/v1/cluster/role.go
@@ -345,9 +345,10 @@ func DeleteClusterRoleEndpoint() endpoint.Endpoint {
 		}
 		userClusterRoleID := addUserClusterRBACPrefix(req.RoleID)
 
-		clusterRole := &rbacv1.ClusterRole{}
-		if err := client.Get(ctx, ctrlruntimeclient.ObjectKey{Name: userClusterRoleID}, clusterRole); err != nil {
-			return nil, common.KubernetesErrorToHTTPError(err)
+		clusterRole := &rbacv1.ClusterRole{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: userClusterRoleID,
+			},
 		}
 		if err := client.Delete(ctx, clusterRole); err != nil {
 			return nil, common.KubernetesErrorToHTTPError(err)
@@ -374,9 +375,11 @@ func DeleteRoleEndpoint() endpoint.Endpoint {
 		}
 		roleID := addUserClusterRBACPrefix(req.RoleID)
 
-		role := &rbacv1.Role{}
-		if err := client.Get(ctx, ctrlruntimeclient.ObjectKey{Name: roleID, Namespace: req.Namespace}, role); err != nil {
-			return nil, common.KubernetesErrorToHTTPError(err)
+		role := &rbacv1.Role{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      roleID,
+				Namespace: req.Namespace,
+			},
 		}
 		if err := client.Delete(ctx, role); err != nil {
 			return nil, common.KubernetesErrorToHTTPError(err)


### PR DESCRIPTION
**What this PR does / why we need it**: update delete methods for roles and bindings. Removes additional calls.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #


```release-note
NONE
```
