### PR TITLE
Kube-State-Metrics: Add missing perms to watch storageclasses

### DIFF
--- a/api/pkg/controller/usercluster/resources/kube-state-metrics/clusterrole.go
+++ b/api/pkg/controller/usercluster/resources/kube-state-metrics/clusterrole.go
@@ -85,6 +85,11 @@ func ClusterRoleCreator() reconciling.NamedClusterRoleCreatorGetter {
 					},
 					Verbs: []string{"list", "watch"},
 				},
+				{
+					APIGroups: []string{"storage.k8s.io"},
+					Resources: []string{"storageclasses"},
+					Verbs:     []string{"list", "watch"},
+				},
 			}
 			return cr, nil
 		}


### PR DESCRIPTION
**What this PR does / why we need it**:

Adds a missing permission to kube-state-metrics to watch storageclasses.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Documentation**:
<!-- Add links to the related documentation changes related to this pull request. E.g. the link to the kubermatic/docs pullrequest. -->

**Does this PR introduce a user-facing change?**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If  no release note is required, just write "NONE".
-->
```release-note
none
```
