### PR TITLE
Conformance tester: Do not delete kubernetes-dashboard NS

### DIFF
--- a/api/cmd/conformance-tests/cleanup.go
+++ b/api/cmd/conformance-tests/cleanup.go
@@ -13,7 +13,12 @@ import (
 )
 
 var (
-	protectedNamespaces = sets.NewString(metav1.NamespaceDefault, metav1.NamespaceSystem, metav1.NamespacePublic, corev1.NamespaceNodeLease)
+	protectedNamespaces = sets.NewString(
+		metav1.NamespaceDefault,
+		metav1.NamespaceSystem,
+		metav1.NamespacePublic,
+		corev1.NamespaceNodeLease,
+		"kubernetes-dashboard")
 )
 
 func deleteAllNonDefaultNamespaces(log *zap.SugaredLogger, client ctrlruntimeclient.Client) error {

--- a/api/cmd/conformance-tests/cleanup.go
+++ b/api/cmd/conformance-tests/cleanup.go
@@ -5,6 +5,8 @@ import (
 
 	"go.uber.org/zap"
 
+	kubernetesdashboard "github.com/kubermatic/kubermatic/api/pkg/resources/kubernetes-dashboard"
+
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/sets"
@@ -18,7 +20,7 @@ var (
 		metav1.NamespaceSystem,
 		metav1.NamespacePublic,
 		corev1.NamespaceNodeLease,
-		"kubernetes-dashboard")
+		kubernetesdashboard.Namespace)
 )
 
 func deleteAllNonDefaultNamespaces(log *zap.SugaredLogger, client ctrlruntimeclient.Client) error {

--- a/api/pkg/resources/kubernetes-dashboard/deployment.go
+++ b/api/pkg/resources/kubernetes-dashboard/deployment.go
@@ -34,7 +34,7 @@ const (
 	imageName = "kubernetesui/dashboard"
 	tag       = "v2.0.0-beta4"
 	// Namespace used by Dashboard to find required resources.
-	namespace     = "kubernetes-dashboard"
+	Namespace     = "kubernetes-dashboard"
 	ContainerPort = 9090
 	AppLabel      = resources.AppLabelKey + "=" + name
 )
@@ -102,7 +102,7 @@ func getContainers(data kubernetesDashboardData, existingContainers []corev1.Con
 		Command:         []string{"/dashboard"},
 		Args: []string{
 			"--kubeconfig", "/etc/kubernetes/kubeconfig/kubeconfig",
-			"--namespace", namespace,
+			"--namespace", Namespace,
 			"--enable-insecure-login",
 		},
 		Resources: defaultResourceRequirements,


### PR DESCRIPTION
**What this PR does / why we need it**:

Prevents the NS cleanup that is run before each ginkgo run to delete the kubernetes-dashboard NS, to not cause errors in the userclustercontroller manager, which will try to create content in it.
**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Documentation**:
<!-- Add links to the related documentation changes related to this pull request. E.g. the link to the kubermatic/docs pullrequest. -->

**Does this PR introduce a user-facing change?**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If  no release note is required, just write "NONE".
-->
```release-note
none
```

/assign @xrstf 