### PR TITLE
VSphere cloudconfig: Use port from endpoint if configured

### DIFF
--- a/api/pkg/resources/cloudconfig/configmap_test.go
+++ b/api/pkg/resources/cloudconfig/configmap_test.go
@@ -1,0 +1,79 @@
+package cloudconfig
+
+import (
+	"fmt"
+	"testing"
+
+	kubermaticv1 "github.com/kubermatic/kubermatic/api/pkg/crd/kubermatic/v1"
+	"github.com/kubermatic/kubermatic/api/pkg/resources"
+	"github.com/kubermatic/machine-controller/pkg/cloudprovider/provider/vsphere"
+)
+
+func TestGetVsphereCloudConfig(t *testing.T) {
+	testCases := []struct {
+		name    string
+		cluster *kubermaticv1.Cluster
+		dc      *kubermaticv1.Datacenter
+		verify  func(*vsphere.CloudConfig) error
+	}{
+		{
+			name: "Vsphere port gets defaulted to 443",
+			cluster: &kubermaticv1.Cluster{
+				Spec: kubermaticv1.ClusterSpec{
+					Cloud: kubermaticv1.CloudSpec{
+						VSphere: &kubermaticv1.VSphereCloudSpec{},
+					},
+				},
+			},
+			dc: &kubermaticv1.Datacenter{
+				Spec: kubermaticv1.DatacenterSpec{
+					VSphere: &kubermaticv1.DatacenterSpecVSphere{
+						Endpoint: "https://vsphere.com",
+					},
+				},
+			},
+			verify: func(cc *vsphere.CloudConfig) error {
+				if cc.Global.VCenterPort != "443" {
+					return fmt.Errorf("Expected port to be 443, was %q", cc.Global.VCenterPort)
+				}
+				return nil
+			},
+		},
+		{
+			name: "Vsphere port from url gets used",
+			cluster: &kubermaticv1.Cluster{
+				Spec: kubermaticv1.ClusterSpec{
+					Cloud: kubermaticv1.CloudSpec{
+						VSphere: &kubermaticv1.VSphereCloudSpec{},
+					},
+				},
+			},
+			dc: &kubermaticv1.Datacenter{
+				Spec: kubermaticv1.DatacenterSpec{
+					VSphere: &kubermaticv1.DatacenterSpecVSphere{
+						Endpoint: "https://vsphere.com:9443",
+					},
+				},
+			},
+			verify: func(cc *vsphere.CloudConfig) error {
+				if cc.Global.VCenterPort != "9443" {
+					return fmt.Errorf("Expected port to be 9443, was %q", cc.Global.VCenterPort)
+				}
+				return nil
+			},
+		},
+	}
+
+	for idx := range testCases {
+		tc := testCases[idx]
+		t.Run(tc.name, func(t *testing.T) {
+			cloudConfig, err := getVsphereCloudConfig(tc.cluster, tc.dc, resources.Credentials{})
+			if err != nil {
+				t.Fatalf("Error trying to get cloudconfig: %v", err)
+			}
+			if err := tc.verify(cloudConfig); err != nil {
+				t.Error(err)
+			}
+		})
+	}
+}

--- a/api/pkg/resources/test/fixtures/machine-vsphere.yaml
+++ b/api/pkg/resources/test/fixtures/machine-vsphere.yaml
@@ -33,13 +33,13 @@ spec:
         working-dir       = "vsphere-1a2b3c4d5e"
         datacenter        = "vsphere-datacenter"
         datastore         = "vsphere-datastore"
-        server            = "http://vsphere.local"
+        server            = "vsphere.local"
 
         [Disk]
         scsicontrollertype = "pvscsi"
 
         [Workspace]
-        server            = "http://vsphere.local"
+        server            = "vsphere.local"
         datacenter        = "vsphere-datacenter"
         folder            = "vsphere-1a2b3c4d5e"
         default-datastore = "vsphere-datastore"


### PR DESCRIPTION
**What this PR does / why we need it**:

Fixes #4540

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Documentation**:
<!-- Add links to the related documentation changes related to this pull request. E.g. the link to the kubermatic/docs pullrequest. -->

**Does this PR introduce a user-facing change?**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If  no release note is required, just write "NONE".
-->
```release-note
VSphere: Fixed a bug that resulted in a faulty cloud config when using a non-default port
```
