### PR TITLE
Fix typo in thanos-sidecar probes

### DIFF
--- a/config/monitoring/prometheus/Chart.yaml
+++ b/config/monitoring/prometheus/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: prometheus
-version: 2.2.0
+version: 2.2.1
 appVersion: v2.12.0
 description: Prometheus Monitoring for Kubernetes
 keywords:

--- a/config/monitoring/prometheus/templates/statefulset.yaml
+++ b/config/monitoring/prometheus/templates/statefulset.yaml
@@ -222,11 +222,11 @@ spec:
         livenessProbe:
           httpGet:
             path: /-/healthy
-            port: http
+            port: http-sidecar
         readinessProbe:
           httpGet:
             path: /-/ready
-            port: http
+            port: http-sidecar
         resources:
 {{ toYaml .Values.prometheus.containers.thanosSidecar.resources | indent 10 }}
       {{- end }}


### PR DESCRIPTION
**What this PR does / why we need it**:
There was a typo in my last PR which prevented the Prometheus pods from becoming ready.

**Does this PR introduce a user-facing change?**:
```release-note
NONE
```
