### PR TITLE
Deploy Seed CRs when deploying the Kubermatic chart

### DIFF
--- a/api/hack/ci/ci-deploy-dev.sh
+++ b/api/hack/ci/ci-deploy-dev.sh
@@ -19,6 +19,7 @@ retry 5 vault write \
 export VAULT_TOKEN="$(cat /tmp/vault-token-response.json| jq .auth.client_token -r)"
 export KUBECONFIG=/tmp/kubeconfig
 export VALUES_FILE=/tmp/values.yaml
+export KUBERMATIC_SEEDS=dev.kubermatic.io
 
 # deploy to dev
 vault kv get -field=kubeconfig dev/seed-clusters/dev.kubermatic.io > ${KUBECONFIG}

--- a/api/hack/deploy.sh
+++ b/api/hack/deploy.sh
@@ -164,6 +164,16 @@ case "${DEPLOY_STACK}" in
 
     # Kubermatic
     deploy "kubermatic" "kubermatic" ./config/kubermatic/
+
+    # deploy Seed CRs
+    if [[ -n "${KUBERMATIC_SEEDS}" ]]; then
+      echodate "Deploying Seed CRs for ${KUBERMATIC_SEEDS}..."
+      infratmp=infra_clone
+      git clone --depth=1 git@github.com:kubermatic/docs.git "${infratmp}"
+      cd "${infratmp}"
+      echodate "Infra repository cloned at: $(git show --oneline --no-patch --no-decorate --no-color)"
+      retry 5 kubectl apply -f "seeds/${KUBERMATIC_SEEDS}/"
+    fi
     ;;
 
   kubermatic-operator)


### PR DESCRIPTION
**What this PR does / why we need it**:
This adds a new option to the `deploy.sh` script, which can deploy a number of manifests from the infra repo when `KUBERMATIC_SEEDS` is set.

**Does this PR introduce a user-facing change?**:
```release-note
NONE
```
