### PR TITLE
Addon controller: Respect workername when marking default addons

### DIFF
--- a/api/pkg/controller/addon/addon_controller.go
+++ b/api/pkg/controller/addon/addon_controller.go
@@ -186,10 +186,6 @@ func (r *Reconciler) reconcile(ctx context.Context, log *zap.SugaredLogger, addo
 		return nil, nil
 	}
 
-	if err := r.markDefaultAddons(ctx, log, addon, cluster); err != nil {
-		return nil, fmt.Errorf("failed to ensure that the isDefault field is up to date in the addon: %v", err)
-	}
-
 	if cluster.DeletionTimestamp != nil {
 		log.Debug("Skipping addon because cluster is deleted")
 		return nil, nil
@@ -211,6 +207,10 @@ func (r *Reconciler) reconcile(ctx context.Context, log *zap.SugaredLogger, addo
 	if cluster.DeletionTimestamp != nil {
 		log.Debug("Skipping because the cluster is being deleted")
 		return nil, nil
+	}
+
+	if err := r.markDefaultAddons(ctx, log, addon, cluster); err != nil {
+		return nil, fmt.Errorf("failed to ensure that the isDefault field is up to date in the addon: %v", err)
 	}
 
 	// When the apiserver is not healthy, we must skip it


### PR DESCRIPTION
**What this PR does / why we need it**:

Currently, the addon controller marks the addons as default before checking for the worker-name. This PR fixes that.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Documentation**:
<!-- Add links to the related documentation changes related to this pull request. E.g. the link to the kubermatic/docs pullrequest. -->

**Does this PR introduce a user-facing change?**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If  no release note is required, just write "NONE".
-->
```release-note
none
```
