### PR TITLE
The UserInfoGetter can accept empty project ID

### DIFF
--- a/api/pkg/handler/routes_v1.go
+++ b/api/pkg/handler/routes_v1.go
@@ -629,8 +629,7 @@ func (r Routing) listCredentials() http.Handler {
 		endpoint.Chain(
 			middleware.TokenVerifier(r.tokenVerifiers),
 			middleware.UserSaver(r.userProvider),
-			middleware.UserInfoExtractor(r.userProjectMapper),
-		)(presets.CredentialEndpoint(r.presetsManager)),
+		)(presets.CredentialEndpoint(r.presetsManager, r.userInfoGetter)),
 		presets.DecodeProviderReq,
 		encodeJSON,
 		r.defaultServerOptions()...,

--- a/api/pkg/provider/userinfo.go
+++ b/api/pkg/provider/userinfo.go
@@ -14,19 +14,19 @@ type UserInfoGetter = func(ctx context.Context, projectID string) (*UserInfo, er
 func UserInfoGetterFactory(userProjectMapper ProjectMemberMapper) (UserInfoGetter, error) {
 
 	return func(ctx context.Context, projectID string) (*UserInfo, error) {
-		if projectID == "" {
-			return nil, fmt.Errorf("the projectID can not be empty")
-		}
-
 		user, ok := ctx.Value(kubermaticcontext.UserCRContextKey).(*kubermaticapiv1.User)
 		if !ok {
 			// This happens if middleware.UserSaver is not enabled.
 			return nil, fmt.Errorf("unable to get authenticated user object")
 		}
 
-		group, err := userProjectMapper.MapUserToGroup(user.Spec.Email, projectID)
-		if err != nil {
-			return nil, err
+		var group string
+		if projectID != "" {
+			var err error
+			group, err = userProjectMapper.MapUserToGroup(user.Spec.Email, projectID)
+			if err != nil {
+				return nil, err
+			}
 		}
 
 		return &UserInfo{Email: user.Spec.Email, Group: group}, nil


### PR DESCRIPTION
**What this PR does / why we need it**: the UserInfoGetter can accept empty project ID

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #


```release-note
NONE
```
