### PR TITLE
Disable metrics for sub managers

### DIFF
--- a/api/cmd/master-controller-manager/controllers.go
+++ b/api/cmd/master-controller-manager/controllers.go
@@ -175,7 +175,9 @@ func projectLabelSynchronizerFactoryCreator(ctrlCtx *controllerContext) seedcont
 				// in the rbac controller factory, so just log it here
 				continue
 			}
-			seedMgr, err := manager.New(kubeconfig, manager.Options{})
+			seedMgr, err := manager.New(kubeconfig, manager.Options{
+				MetricsBindAddress: "0",
+			})
 			if err != nil {
 				log.Errorw("Failed to construct mgr for seed", zap.Error(err))
 				continue


### PR DESCRIPTION
**What this PR does / why we need it**:
There can be only one server listening on the metrics port.

**Does this PR introduce a user-facing change?**:
```release-note
Fix master-controller failing to create project-label-synchronizer controllers.
```
