### PR TITLE
Use patch instead of retry.RetryOnConflict

### DIFF
--- a/api/pkg/controller/container-linux/container_linux_controller.go
+++ b/api/pkg/controller/container-linux/container_linux_controller.go
@@ -10,8 +10,6 @@ import (
 
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/apimachinery/pkg/types"
-	"k8s.io/client-go/util/retry"
 	ctrlruntimeclient "sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/controller"
 	"sigs.k8s.io/controller-runtime/pkg/event"
@@ -93,17 +91,12 @@ func (r *Reconciler) labelAllContainerLinuxNodes(ctx context.Context) (bool, err
 		hasLabel := hasContainerLinuxLabel(&node)
 
 		if usesContainerLinux && !hasLabel {
-			if err := retry.RetryOnConflict(retry.DefaultBackoff, func() error {
-				newNode := &corev1.Node{}
-				if err := r.Get(ctx, types.NamespacedName{Name: node.Name}, newNode); err != nil {
-					return err
-				}
-				if newNode.Labels == nil {
-					newNode.Labels = map[string]string{}
-				}
-				newNode.Labels[resources.NodeSelectorLabelKey] = resources.NodeSelectorLabelValue
-				return r.Client.Update(ctx, newNode)
-			}); err != nil {
+			oldNode := node.DeepCopy()
+			if node.Labels == nil {
+				node.Labels = map[string]string{}
+			}
+			node.Labels[resources.NodeSelectorLabelKey] = resources.NodeSelectorLabelValue
+			if err := r.Client.Patch(ctx, &node, ctrlruntimeclient.MergeFrom(oldNode)); err != nil {
 				return false, fmt.Errorf("failed to update node %q: %v", node.Name, err)
 			}
 		}

--- a/api/pkg/controller/update/update_controller.go
+++ b/api/pkg/controller/update/update_controller.go
@@ -168,13 +168,14 @@ func (r *Reconciler) controlPlaneUpgrade(ctx context.Context, cluster *kubermati
 	if update == nil {
 		return false, nil
 	}
+	oldCluster := cluster.DeepCopy()
 
 	cluster.Spec.Version = *semver.NewSemverOrDie(update.Version.String())
 	// Invalidating the health to prevent automatic updates directly on the next processing.
 	cluster.Status.ExtendedHealth.Apiserver = kubermaticv1.HealthStatusDown
 	cluster.Status.ExtendedHealth.Controller = kubermaticv1.HealthStatusDown
 	cluster.Status.ExtendedHealth.Scheduler = kubermaticv1.HealthStatusDown
-	if err := r.Update(ctx, cluster); err != nil {
+	if err := r.Patch(ctx, cluster, ctrlruntimeclient.MergeFrom(oldCluster)); err != nil {
 		return false, fmt.Errorf("failed to update cluster: %v", err)
 	}
 	return true, nil


### PR DESCRIPTION
**What this PR does / why we need it**:

This PR changes the various controllers to update objects via PATCH instead of via `retry.RetryOnConflict`, as the latter causes more requests and has a decent chance of failing due to the fact that we read from the cache so the version we get from the cache may lag behind.

This is done in order to avoid errors due to controllers trying to concurrently update the cluster object.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Documentation**:
<!-- Add links to the related documentation changes related to this pull request. E.g. the link to the kubermatic/docs pullrequest. -->

**Does this PR introduce a user-facing change?**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If  no release note is required, just write "NONE".
-->
```release-note
none
```
