### PR TITLE
Operator Cleanup

### DIFF
--- a/api/Makefile
+++ b/api/Makefile
@@ -102,6 +102,9 @@ run-controller-manager:
 run-api-server:
 	./hack/run-api.sh
 
+run-operator:
+	./hack/run-operator.sh
+
 run-master-controller-manager:
 	./hack/run-master-controller-manager.sh
 

--- a/api/cmd/kubermatic-operator/main.go
+++ b/api/cmd/kubermatic-operator/main.go
@@ -56,7 +56,7 @@ func main() {
 
 	config, err := clientcmd.BuildConfigFromFlags("", opt.kubeconfig)
 	if err != nil {
-		log.Fatalw("Failed to build config", "error", err)
+		log.Fatalw("Failed to build config", zap.Error(err))
 	}
 
 	mgr, err := manager.New(config, manager.Options{MetricsBindAddress: opt.internalAddr})
@@ -65,17 +65,17 @@ func main() {
 	}
 
 	if err := operatorv1alpha1.AddToScheme(mgr.GetScheme()); err != nil {
-		log.Fatalw("Failed to register types in Scheme", "error", err)
+		log.Fatalw("Failed to register types in Scheme", zap.Error(err))
 	}
 
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 
 	if err := operatormaster.Add(ctx, mgr, 1, log, opt.workerName); err != nil {
-		log.Fatalw("Failed to add operator-master controller", "error", err)
+		log.Fatalw("Failed to add operator-master controller", zap.Error(err))
 	}
 
 	if err := mgr.Start(signals.SetupSignalHandler()); err != nil {
-		log.Fatalw("Cannot start manager", "error", err)
+		log.Fatalw("Cannot start manager", zap.Error(err))
 	}
 }

--- a/api/hack/run-operator.sh
+++ b/api/hack/run-operator.sh
@@ -12,5 +12,5 @@ KUBERMATIC_WORKERNAME=${KUBERMATIC_WORKERNAME:-$(uname -n)}
   -worker-name="$(tr -cd '[:alnum:]' <<< $KUBERMATIC_WORKERNAME | tr '[:upper:]' '[:lower:]')" \
   -log-debug=true \
   -log-format=Console \
-	-logtostderr \
-	-v=4 # Log-level for the Kube dependencies. Increase up to 9 to get request-level logs.
+  -logtostderr \
+  -v=4 # Log-level for the Kube dependencies. Increase up to 9 to get request-level logs.

--- a/api/hack/run-operator.sh
+++ b/api/hack/run-operator.sh
@@ -1,0 +1,16 @@
+#!/usr/bin/env bash
+
+set -exuo pipefail
+
+cd $(go env GOPATH)/src/github.com/kubermatic/kubermatic/api
+make kubermatic-operator
+
+KUBERMATIC_WORKERNAME=${KUBERMATIC_WORKERNAME:-$(uname -n)}
+
+./_build/kubermatic-operator \
+  -kubeconfig=../../secrets/seed-clusters/dev.kubermatic.io/kubeconfig \
+  -worker-name="$(tr -cd '[:alnum:]' <<< $KUBERMATIC_WORKERNAME | tr '[:upper:]' '[:lower:]')" \
+  -log-debug=true \
+  -log-format=Console \
+	-logtostderr \
+	-v=4 # Log-level for the Kube dependencies. Increase up to 9 to get request-level logs.

--- a/api/pkg/controller/operator-master/controller.go
+++ b/api/pkg/controller/operator-master/controller.go
@@ -95,6 +95,9 @@ func Add(
 		}
 
 		owner := a.Meta.GetAnnotations()[ConfigurationOwnerAnnotation]
+		if owner == "" {
+			return nil
+		}
 
 		ns, n, err := cache.SplitMetaNamespaceKey(owner)
 		if err != nil {

--- a/api/pkg/controller/operator-master/defaults.go
+++ b/api/pkg/controller/operator-master/defaults.go
@@ -143,7 +143,7 @@ func (r *Reconciler) volumeRevisionLabels() reconciling.ObjectModifier {
 			}
 
 			volumeLabels, err := resources.VolumeRevisionLabels(r.ctx, r.Client, deployment.Namespace, deployment.Spec.Template.Spec.Volumes)
-			if !ok {
+			if err != nil {
 				return obj, fmt.Errorf("failed to determine revision labels for volumes: %v", err)
 			}
 

--- a/api/pkg/controller/operator-master/reconciler.go
+++ b/api/pkg/controller/operator-master/reconciler.go
@@ -143,7 +143,6 @@ func (r *Reconciler) reconcileSecrets(config *operatorv1alpha1.KubermaticConfigu
 
 	creators := []reconciling.NamedSecretCreatorGetter{
 		kubermatic.DockercfgSecretCreator(config),
-		kubermatic.KubeconfigSecretCreator(config),
 		kubermatic.DexCASecretCreator(config),
 	}
 

--- a/api/pkg/controller/operator-master/reconciler.go
+++ b/api/pkg/controller/operator-master/reconciler.go
@@ -142,10 +142,6 @@ func (r *Reconciler) reconcileSecrets(config *operatorv1alpha1.KubermaticConfigu
 		kubermatic.DexCASecretCreator(config),
 	}
 
-	if config.Spec.Datacenters != "" {
-		creators = append(creators, kubermatic.DatacentersSecretCreator(config))
-	}
-
 	if len(config.Spec.MasterFiles) > 0 {
 		creators = append(creators, kubermatic.MasterFilesSecretCreator(config))
 	}

--- a/api/pkg/controller/operator-master/reconciler.go
+++ b/api/pkg/controller/operator-master/reconciler.go
@@ -10,6 +10,7 @@ import (
 	operatorv1alpha1 "github.com/kubermatic/kubermatic/api/pkg/crd/operator/v1alpha1"
 	"github.com/kubermatic/kubermatic/api/pkg/resources/reconciling"
 
+	kerrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/client-go/tools/cache"
 	"k8s.io/client-go/tools/record"
 	ctrlruntimeclient "sigs.k8s.io/controller-runtime/pkg/client"
@@ -34,6 +35,10 @@ func (r *Reconciler) Reconcile(request reconcile.Request) (reconcile.Result, err
 	// find the requested configuration
 	config := &operatorv1alpha1.KubermaticConfiguration{}
 	if err := r.Get(r.ctx, request.NamespacedName, config); err != nil {
+		if kerrors.IsNotFound(err) {
+			return reconcile.Result{}, nil
+		}
+
 		return reconcile.Result{}, fmt.Errorf("could not get KubermaticConfiguration %q: %v", request, err)
 	}
 

--- a/api/pkg/controller/operator-master/resources/kubermatic/api.go
+++ b/api/pkg/controller/operator-master/resources/kubermatic/api.go
@@ -65,6 +65,7 @@ func APIDeploymentCreator(cfg *operatorv1alpha1.KubermaticConfiguration) reconci
 				"-address=0.0.0.0:8080",
 				"-internal-address=0.0.0.0:8085",
 				"-kubeconfig=/opt/.kube/kubeconfig",
+				"-dynamic-datacenters=true",
 				fmt.Sprintf("-oidc-url=%s", cfg.Spec.Auth.TokenIssuer),
 				fmt.Sprintf("-oidc-authenticator-client-id=%s", cfg.Spec.Auth.ClientID),
 				fmt.Sprintf("-oidc-skip-tls-verify=%v", cfg.Spec.Auth.SkipTokenIssuerTLSVerify),
@@ -142,25 +143,6 @@ func APIDeploymentCreator(cfg *operatorv1alpha1.KubermaticConfiguration) reconci
 				volumeMounts = append(volumeMounts, corev1.VolumeMount{
 					MountPath: "/opt/presets/",
 					Name:      "presets",
-					ReadOnly:  true,
-				})
-			}
-
-			if cfg.Spec.Datacenters != "" {
-				args = append(args, "-datacenters=/opt/datacenters/datacenters.yaml")
-
-				volumes = append(volumes, corev1.Volume{
-					Name: "datacenters",
-					VolumeSource: corev1.VolumeSource{
-						Secret: &corev1.SecretVolumeSource{
-							SecretName: datacentersSecretName,
-						},
-					},
-				})
-
-				volumeMounts = append(volumeMounts, corev1.VolumeMount{
-					MountPath: "/opt/datacenters/",
-					Name:      "datacenters",
 					ReadOnly:  true,
 				})
 			}

--- a/api/pkg/controller/operator-master/resources/kubermatic/api.go
+++ b/api/pkg/controller/operator-master/resources/kubermatic/api.go
@@ -64,7 +64,6 @@ func APIDeploymentCreator(cfg *operatorv1alpha1.KubermaticConfiguration) reconci
 				"-logtostderr",
 				"-address=0.0.0.0:8080",
 				"-internal-address=0.0.0.0:8085",
-				"-kubeconfig=/opt/.kube/kubeconfig",
 				"-dynamic-datacenters=true",
 				fmt.Sprintf("-oidc-url=%s", cfg.Spec.Auth.TokenIssuer),
 				fmt.Sprintf("-oidc-authenticator-client-id=%s", cfg.Spec.Auth.ClientID),
@@ -85,24 +84,8 @@ func APIDeploymentCreator(cfg *operatorv1alpha1.KubermaticConfiguration) reconci
 				)
 			}
 
-			volumes := []corev1.Volume{
-				{
-					Name: "kubeconfig",
-					VolumeSource: corev1.VolumeSource{
-						Secret: &corev1.SecretVolumeSource{
-							SecretName: kubeconfigSecretName,
-						},
-					},
-				},
-			}
-
-			volumeMounts := []corev1.VolumeMount{
-				{
-					MountPath: "/opt/.kube/",
-					Name:      "kubeconfig",
-					ReadOnly:  true,
-				},
-			}
+			volumes := []corev1.Volume{}
+			volumeMounts := []corev1.VolumeMount{}
 
 			if len(cfg.Spec.MasterFiles) > 0 {
 				args = append(

--- a/api/pkg/controller/operator-master/resources/kubermatic/api.go
+++ b/api/pkg/controller/operator-master/resources/kubermatic/api.go
@@ -170,11 +170,11 @@ func APIDeploymentCreator(cfg *operatorv1alpha1.KubermaticConfiguration) reconci
 					Resources: corev1.ResourceRequirements{
 						Requests: corev1.ResourceList{
 							corev1.ResourceCPU:    resource.MustParse("100m"),
-							corev1.ResourceMemory: resource.MustParse("64Mi"),
+							corev1.ResourceMemory: resource.MustParse("512Mi"),
 						},
 						Limits: corev1.ResourceList{
 							corev1.ResourceCPU:    resource.MustParse("250m"),
-							corev1.ResourceMemory: resource.MustParse("128Mi"),
+							corev1.ResourceMemory: resource.MustParse("1Gi"),
 						},
 					},
 					ReadinessProbe: &probe,

--- a/api/pkg/controller/operator-master/resources/kubermatic/kubermatic.go
+++ b/api/pkg/controller/operator-master/resources/kubermatic/kubermatic.go
@@ -14,7 +14,6 @@ import (
 
 const (
 	dockercfgSecretName                   = "dockercfg"
-	kubeconfigSecretName                  = "kubeconfig"
 	presetsSecretName                     = "presets"
 	dexCASecretName                       = "dex-ca"
 	masterFilesSecretName                 = "extra-files"
@@ -48,16 +47,6 @@ func DockercfgSecretCreator(cfg *operatorv1alpha1.KubermaticConfiguration) recon
 
 			return createSecretData(s, map[string]string{
 				corev1.DockerConfigJsonKey: cfg.Spec.ImagePullSecret,
-			}), nil
-		}
-	}
-}
-
-func KubeconfigSecretCreator(cfg *operatorv1alpha1.KubermaticConfiguration) reconciling.NamedSecretCreatorGetter {
-	return func() (string, reconciling.SecretCreator) {
-		return kubeconfigSecretName, func(s *corev1.Secret) (*corev1.Secret, error) {
-			return createSecretData(s, map[string]string{
-				"kubeconfig": cfg.Spec.Auth.CABundle,
 			}), nil
 		}
 	}

--- a/api/pkg/controller/operator-master/resources/kubermatic/kubermatic.go
+++ b/api/pkg/controller/operator-master/resources/kubermatic/kubermatic.go
@@ -64,16 +64,6 @@ func KubeconfigSecretCreator(cfg *operatorv1alpha1.KubermaticConfiguration) reco
 	}
 }
 
-func DatacentersSecretCreator(cfg *operatorv1alpha1.KubermaticConfiguration) reconciling.NamedSecretCreatorGetter {
-	return func() (string, reconciling.SecretCreator) {
-		return datacentersSecretName, func(s *corev1.Secret) (*corev1.Secret, error) {
-			return createSecretData(s, map[string]string{
-				"datacenters.yaml": cfg.Spec.Datacenters,
-			}), nil
-		}
-	}
-}
-
 func DexCASecretCreator(cfg *operatorv1alpha1.KubermaticConfiguration) reconciling.NamedSecretCreatorGetter {
 	return func() (string, reconciling.SecretCreator) {
 		return dexCASecretName, func(s *corev1.Secret) (*corev1.Secret, error) {

--- a/api/pkg/controller/operator-master/resources/kubermatic/kubermatic.go
+++ b/api/pkg/controller/operator-master/resources/kubermatic/kubermatic.go
@@ -15,7 +15,6 @@ import (
 const (
 	dockercfgSecretName                   = "dockercfg"
 	kubeconfigSecretName                  = "kubeconfig"
-	datacentersSecretName                 = "datacenters"
 	presetsSecretName                     = "presets"
 	dexCASecretName                       = "dex-ca"
 	masterFilesSecretName                 = "extra-files"

--- a/api/pkg/controller/operator-master/resources/kubermatic/master-controller-manager.go
+++ b/api/pkg/controller/operator-master/resources/kubermatic/master-controller-manager.go
@@ -49,6 +49,7 @@ func MasterControllerManagerDeploymentCreator(cfg *operatorv1alpha1.KubermaticCo
 				"-logtostderr",
 				"-internal-address=0.0.0.0:8085",
 				"-kubeconfig=/opt/.kube/kubeconfig",
+				"-dynamic-datacenters=true",
 			}
 
 			volumes := []corev1.Volume{
@@ -68,25 +69,6 @@ func MasterControllerManagerDeploymentCreator(cfg *operatorv1alpha1.KubermaticCo
 					Name:      "kubeconfig",
 					ReadOnly:  true,
 				},
-			}
-
-			if cfg.Spec.Datacenters != "" {
-				args = append(args, "-datacenters=/opt/datacenters/datacenters.yaml")
-
-				volumes = append(volumes, corev1.Volume{
-					Name: "datacenters",
-					VolumeSource: corev1.VolumeSource{
-						Secret: &corev1.SecretVolumeSource{
-							SecretName: datacentersSecretName,
-						},
-					},
-				})
-
-				volumeMounts = append(volumeMounts, corev1.VolumeMount{
-					MountPath: "/opt/datacenters/",
-					Name:      "datacenters",
-					ReadOnly:  true,
-				})
 			}
 
 			d.Spec.Template.Spec.Volumes = volumes

--- a/api/pkg/controller/operator-master/resources/kubermatic/master-controller-manager.go
+++ b/api/pkg/controller/operator-master/resources/kubermatic/master-controller-manager.go
@@ -48,30 +48,9 @@ func MasterControllerManagerDeploymentCreator(cfg *operatorv1alpha1.KubermaticCo
 				"-v=4",
 				"-logtostderr",
 				"-internal-address=0.0.0.0:8085",
-				"-kubeconfig=/opt/.kube/kubeconfig",
 				"-dynamic-datacenters=true",
 			}
 
-			volumes := []corev1.Volume{
-				{
-					Name: "kubeconfig",
-					VolumeSource: corev1.VolumeSource{
-						Secret: &corev1.SecretVolumeSource{
-							SecretName: kubeconfigSecretName,
-						},
-					},
-				},
-			}
-
-			volumeMounts := []corev1.VolumeMount{
-				{
-					MountPath: "/opt/.kube/",
-					Name:      "kubeconfig",
-					ReadOnly:  true,
-				},
-			}
-
-			d.Spec.Template.Spec.Volumes = volumes
 			d.Spec.Template.Spec.InitContainers = []corev1.Container{projectsMigratorContainer(cfg)}
 			d.Spec.Template.Spec.Containers = []corev1.Container{
 				{
@@ -86,7 +65,6 @@ func MasterControllerManagerDeploymentCreator(cfg *operatorv1alpha1.KubermaticCo
 							Protocol:      corev1.ProtocolTCP,
 						},
 					},
-					VolumeMounts: volumeMounts,
 					Resources: corev1.ResourceRequirements{
 						Requests: corev1.ResourceList{
 							corev1.ResourceCPU:    resource.MustParse("50m"),
@@ -113,15 +91,7 @@ func projectsMigratorContainer(cfg *operatorv1alpha1.KubermaticConfiguration) co
 		Args: []string{
 			"-v=2",
 			"-logtostderr",
-			"-kubeconfig=/opt/.kube/kubeconfig",
 			fmt.Sprintf("-dry-run=%v", cfg.Spec.MasterController.ProjectsMigrator.DryRun),
-		},
-		VolumeMounts: []corev1.VolumeMount{
-			{
-				MountPath: "/opt/.kube/",
-				Name:      "kubeconfig",
-				ReadOnly:  true,
-			},
 		},
 	}
 }

--- a/api/pkg/crd/operator/v1alpha1/configuration.go
+++ b/api/pkg/crd/operator/v1alpha1/configuration.go
@@ -32,8 +32,6 @@ type KubermaticConfigurationSpec struct {
 	Namespace string `json:"namespace,omitempty"`
 	// Domain is the base domain where the dashboard shall be available.
 	Domain string `json:"domain"`
-	// IsMaster controls whether the dashboard and API will be deployed.
-	IsMaster bool `json:"isMaster,omitempty"`
 	// ImagePullSecret is used to authenticate against Docker registries.
 	ImagePullSecret string `json:"imagePullSecret,omitempty"`
 	// Auth defines keys and URLs for Dex.

--- a/api/pkg/crd/operator/v1alpha1/configuration.go
+++ b/api/pkg/crd/operator/v1alpha1/configuration.go
@@ -34,9 +34,6 @@ type KubermaticConfigurationSpec struct {
 	Domain string `json:"domain"`
 	// IsMaster controls whether the dashboard and API will be deployed.
 	IsMaster bool `json:"isMaster,omitempty"`
-	// Datacenters is a YAML string containing the available node datacenters. Note that
-	// this is deprecated and you should use explicit Datacenter CRDs instead.
-	Datacenters string `json:"datacenters,omitempty"`
 	// ImagePullSecret is used to authenticate against Docker registries.
 	ImagePullSecret string `json:"imagePullSecret,omitempty"`
 	// Auth defines keys and URLs for Dex.

--- a/docs/proposals/kubermatic-operator.md
+++ b/docs/proposals/kubermatic-operator.md
@@ -45,20 +45,19 @@ spec:
   # this is effectively a copy of the "auth" section in your ~/.docker/config.json.
   # You must configure credentials for quay.io and docker.io at the
   # very least.
-  secrets:
-    imagePullSecret: |
-      {
-        "auths": {
-          "https://index.docker.io/v1/": {
-            "auth": "[base64-encoded credentials here]",
-            "email": ""
-          },
-          "quay.io": {
-            "auth": "[base64-encoded credentials here]",
-            "email": ""
-          }
+  imagePullSecret: |
+    {
+      "auths": {
+        "https://index.docker.io/v1/": {
+          "auth": "[base64-encoded credentials here]",
+          "email": ""
+        },
+        "quay.io": {
+          "auth": "[base64-encoded credentials here]",
+          "email": ""
         }
       }
+    }
 
   # Dex integration
   auth:

--- a/docs/proposals/kubermatic-operator.md
+++ b/docs/proposals/kubermatic-operator.md
@@ -41,10 +41,6 @@ spec:
   # services as well as user clusters will be hosted as subdomains.
   domain: my.kubermatic.io
 
-  # Whether or not this installation is a master, i.e. where
-  # the Kubermatic dashboard and API should be deployed.
-  isMaster: true
-
   # The secrets are used to pull images from private Docker repositories;
   # this is effectively a copy of the "auth" section in your ~/.docker/config.json.
   # You must configure credentials for quay.io and docker.io at the


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR brings the existing operator code up to speed with the changes in Kubermatic:

* The support for datacenters.yaml has been removed, as we rely on the new Seed CRD for new setups.
* The `isMaster` flag has been removed. Instead, the operator will always reconcile a master setup for each `KubermaticConfiguration`, and seed reconciling is then performed based on Seed CRs. This finally makes it possible to have master-only clusters. :-)
* The `kubeconfig` Secret has been removed, as all controllers now only need their service account or fetch the kubeconfig for a seed dynamically.
* A couple of other tiny fixes are included as well, just so that the operator in its current form does not explode entirely when started.

**Does this PR introduce a user-facing change?**:
```release-note
NONE
```
