### PR TITLE
Fix apiservervice reconciling

### DIFF
--- a/api/pkg/controller/usercluster/resources/metrics-server/apiservice.go
+++ b/api/pkg/controller/usercluster/resources/metrics-server/apiservice.go
@@ -19,10 +19,11 @@ func APIServiceCreator(caBundle []byte) reconciling.NamedAPIServiceCreatorGetter
 			labels := resources.BaseAppLabel(Name, nil)
 			se.Labels = labels
 
-			se.Spec.Service = &apiregistrationv1beta1.ServiceReference{
-				Namespace: metav1.NamespaceSystem,
-				Name:      resources.MetricsServerExternalNameServiceName,
+			if se.Spec.Service == nil {
+				se.Spec.Service = &apiregistrationv1beta1.ServiceReference{}
 			}
+			se.Spec.Service.Namespace = metav1.NamespaceSystem
+			se.Spec.Service.Name = resources.MetricsServerExternalNameServiceName
 			se.Spec.Group = "metrics.k8s.io"
 			se.Spec.Version = "v1beta1"
 			se.Spec.InsecureSkipTLSVerify = false

--- a/api/pkg/controller/usercluster/resources/openshift/apiservices.go
+++ b/api/pkg/controller/usercluster/resources/openshift/apiservices.go
@@ -41,10 +41,11 @@ func apiServiceFactory(
 	return func() (string, reconciling.APIServiceCreator) {
 		return name, func(s *apiregistrationv1beta1.APIService) (*apiregistrationv1beta1.APIService, error) {
 
-			s.Spec.Service = &apiregistrationv1beta1.ServiceReference{
-				Namespace: "openshift-apiserver",
-				Name:      "api",
+			if s.Spec.Service == nil {
+				s.Spec.Service = &apiregistrationv1beta1.ServiceReference{}
 			}
+			s.Spec.Service.Namespace = "openshift-apiserver"
+			s.Spec.Service.Name = "api"
 			s.Spec.Group = group
 			s.Spec.Version = version
 			s.Spec.InsecureSkipTLSVerify = false


### PR DESCRIPTION
**What this PR does / why we need it**:

Because the usercluster controller permanently loggs a 
```
{"level":"error","time":"2019-10-28T19:14:12.476Z","caller":"usercluster/controller.go:174","msg":"Reconciling failed","error":"failed to reconcile APIServices: failed to ensure APIService /v1beta1.metrics.k8s.io: failed waiting for the cache to contain our latest changes: timed out waiting for the condition"}
```

e.G. here: https://prow.loodse.com/view/gcs/prow-data/pr-logs/pull/kubermatic_kubermatic/4581/pull-kubermatic-e2e-aws-coreos-1.15/1188892650560819202

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Documentation**:
<!-- Add links to the related documentation changes related to this pull request. E.g. the link to the kubermatic/docs pullrequest. -->

**Does this PR introduce a user-facing change?**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If  no release note is required, just write "NONE".
-->
```release-note
none
```
