### PR TITLE
Update OWNERS_ALIASES to reflect new team structure

### DIFF
--- a/OWNERS_ALIASES
+++ b/OWNERS_ALIASES
@@ -8,6 +8,7 @@ aliases:
     - xmudrii
 
   team-seed:
+    - kron4eg
     - xrstf
     - thetechnick
 

--- a/OWNERS_ALIASES
+++ b/OWNERS_ALIASES
@@ -10,7 +10,6 @@ aliases:
   team-seed:
     - kron4eg
     - xrstf
-    - thetechnick
 
   team-ui:
     - kgroschoff

--- a/OWNERS_ALIASES
+++ b/OWNERS_ALIASES
@@ -1,22 +1,19 @@
 aliases:
   team-lifecycle:
     - alvaroaleman
-    - mrIncompetent
     - kdomanski
     - moadqassem
-    - nikhita
     - thz
-    - themue
-
-  team-seed:
     - kron4eg
-    - xrstf
-    - thetechnick
     - xmudrii
 
+  team-seed:
+    - xrstf
+    - thetechnick
+
   team-ui:
-    - p0lyn0mial
     - kgroschoff
     - maciaszczykm
     - zreigz
     - floreks
+    - nikhita


### PR DESCRIPTION
I'm not completely sure if the cluster-lifecycle and seed teams are reflected accurately through this change, happy to punt those two teams to another PR.
/hold

/cc @kron4eg @xmudrii 
/assign @alvaroaleman @xrstf @zreigz 

**Does this PR introduce a user-facing change?**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If  no release note is required, just write "NONE".
-->
```release-note
NONE
```
