### PR TITLE
Support non-namespaced predicates in seed-lifecycle controller

### DIFF
--- a/api/cmd/master-controller-manager/controllers.go
+++ b/api/cmd/master-controller-manager/controllers.go
@@ -45,7 +45,7 @@ func createAllControllers(ctrlCtx *controllerContext) error {
 		ctrlCtx.mgr,
 		ctrlCtx.seedsGetter,
 		ctrlCtx.seedKubeconfigGetter,
-		predicates
+		predicates,
 		rbacControllerFactory,
 		projectLabelSynchronizerFactory); err != nil {
 		//TODO: Find a better name

--- a/api/pkg/controller/seed-controller-lifecycle/seed_controller_lifecycle.go
+++ b/api/pkg/controller/seed-controller-lifecycle/seed_controller_lifecycle.go
@@ -9,7 +9,6 @@ import (
 
 	controllerutil "github.com/kubermatic/kubermatic/api/pkg/controller/util"
 	kubermaticv1 "github.com/kubermatic/kubermatic/api/pkg/crd/kubermatic/v1"
-	operatorv1 "github.com/kubermatic/kubermatic/api/pkg/crd/operator/v1alpha1"
 	"github.com/kubermatic/kubermatic/api/pkg/provider"
 
 	corev1 "k8s.io/api/core/v1"
@@ -82,7 +81,7 @@ func Add(
 		return fmt.Errorf("failed to construct controller: %v", err)
 	}
 
-	for _, t := range []runtime.Object{&operatorv1.KubermaticConfiguration{}, &kubermaticv1.Seed{}, &corev1.Secret{}} {
+	for _, t := range []runtime.Object{&kubermaticv1.Seed{}, &corev1.Secret{}} {
 		if err := c.Watch(
 			&source.Kind{Type: t},
 			controllerutil.EnqueueConst(queueKey),


### PR DESCRIPTION
**What this PR does / why we need it**:
The seed-operator will soon need to have a lifecycle controller for seeds across all namespaces. To prevent naming conflicts, this PR changes the internal key for seeds to be `namespace/name` and to allow arbitrary predicates. It would have been nice to make predicates a variadic parameter too, but AFAIK there can be only one(tm).

NB: This does not yet solve the question as to how the SeedsGetter itself would handle naming conflicts.

**Does this PR introduce a user-facing change?**:
```release-note
NONE
```
