### PR TITLE
Disable thanos-store readiness probes

### DIFF
--- a/config/monitoring/prometheus/Chart.yaml
+++ b/config/monitoring/prometheus/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: prometheus
-version: 2.2.2
+version: 2.2.3
 appVersion: v2.12.0
 description: Prometheus Monitoring for Kubernetes
 keywords:

--- a/config/monitoring/prometheus/templates/thanos-store-deployment.yaml
+++ b/config/monitoring/prometheus/templates/thanos-store-deployment.yaml
@@ -43,6 +43,7 @@ spec:
           mountPath: /var/store-data
         - name: thanos
           mountPath: /etc/thanos
+        {{- if ge (int .Values.prometheus.thanos.store.probeDelaySeconds) 0 }}
         livenessProbe:
           httpGet:
             path: /-/healthy
@@ -55,6 +56,7 @@ spec:
             port: http
           initialDelaySeconds: {{ .Values.prometheus.thanos.store.probeDelaySeconds }}
           failureThreshold: 10
+        {{- end }}
         resources:
 {{ toYaml .Values.prometheus.containers.thanosStore.resources | indent 10 }}
       volumes:

--- a/config/monitoring/prometheus/values.yaml
+++ b/config/monitoring/prometheus/values.yaml
@@ -125,7 +125,15 @@ prometheus:
       replicas: 2
       indexCacheSize: 500MB
       chunkPoolSize: 2GB
-      probeDelaySeconds: 60
+
+      # Thanos Store downloads blocks from the storage to create its local
+      # cache before enabling the readiness/liveness endpoints, see
+      # https://github.com/thanos-io/thanos/pull/1460
+      # This means that pods can stay un-ready for quite some time, which
+      # can slow down rollouts significantly. By default the probes for
+      # Thanos Store are therefore disabled, but you can re-enable them
+      # by setting probeDelaySeconds to any value >= 0.
+      probeDelaySeconds: -1
 
       nodeSelector: {}
       affinity:


### PR DESCRIPTION
**What this PR does / why we need it**:
See the new comment in the values.yaml.

**Does this PR introduce a user-facing change?**:
```release-note
NONE
```
