### PR TITLE
Make the operator-master controller run namespaced

### DIFF
--- a/api/cmd/kubermatic-operator/main.go
+++ b/api/cmd/kubermatic-operator/main.go
@@ -23,6 +23,7 @@ import (
 
 type controllerRunOptions struct {
 	kubeconfig   string
+	namespace    string
 	internalAddr string
 	log          kubermaticlog.Options
 	workerCount  int
@@ -33,6 +34,7 @@ func main() {
 	klog.InitFlags(nil)
 	opt := &controllerRunOptions{}
 	flag.StringVar(&opt.kubeconfig, "kubeconfig", "", "Path to a kubeconfig. Only required if outside of cluster.")
+	flag.StringVar(&opt.namespace, "namespace", "", "The namespace the operator runs in, uses to determine where to look for KubermaticConfigurations.")
 	flag.IntVar(&opt.workerCount, "worker-count", 4, "Number of workers which process the clusters in parallel.")
 	flag.StringVar(&opt.internalAddr, "internal-address", "127.0.0.1:8085", "The address on which the /metrics endpoint will be served")
 	flag.BoolVar(&opt.log.Debug, "log-debug", false, "Enables debug logging")
@@ -54,6 +56,10 @@ func main() {
 	// set the logger used by sigs.k8s.io/controller-runtime
 	ctrllog.SetLogger(zapr.NewLogger(rawLog.WithOptions(zap.AddCallerSkip(1))))
 
+	if len(opt.namespace) == 0 {
+		log.Fatal("-namespace is a mandatory flag")
+	}
+
 	config, err := clientcmd.BuildConfigFromFlags("", opt.kubeconfig)
 	if err != nil {
 		log.Fatalw("Failed to build config", zap.Error(err))
@@ -71,7 +77,7 @@ func main() {
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 
-	if err := operatormaster.Add(ctx, mgr, 1, log, opt.workerName); err != nil {
+	if err := operatormaster.Add(ctx, mgr, log, opt.namespace, 1, opt.workerName); err != nil {
 		log.Fatalw("Failed to add operator-master controller", zap.Error(err))
 	}
 

--- a/api/cmd/kubermatic-operator/main.go
+++ b/api/cmd/kubermatic-operator/main.go
@@ -35,7 +35,7 @@ func main() {
 	opt := &controllerRunOptions{}
 	flag.StringVar(&opt.kubeconfig, "kubeconfig", "", "Path to a kubeconfig. Only required if outside of cluster.")
 	flag.StringVar(&opt.namespace, "namespace", "", "The namespace the operator runs in, uses to determine where to look for KubermaticConfigurations.")
-	flag.IntVar(&opt.workerCount, "worker-count", 4, "Number of workers which process the clusters in parallel.")
+	flag.IntVar(&opt.workerCount, "worker-count", 4, "Number of workers which process reconcilings in parallel.")
 	flag.StringVar(&opt.internalAddr, "internal-address", "127.0.0.1:8085", "The address on which the /metrics endpoint will be served")
 	flag.BoolVar(&opt.log.Debug, "log-debug", false, "Enables debug logging")
 	flag.StringVar(&opt.log.Format, "log-format", string(kubermaticlog.FormatJSON), "Log format, one of "+kubermaticlog.AvailableFormats.String())
@@ -77,7 +77,7 @@ func main() {
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 
-	if err := operatormaster.Add(ctx, mgr, log, opt.namespace, 1, opt.workerName); err != nil {
+	if err := operatormaster.Add(ctx, mgr, log, opt.namespace, opt.workerCount, opt.workerName); err != nil {
 		log.Fatalw("Failed to add operator-master controller", zap.Error(err))
 	}
 

--- a/api/hack/run-operator.sh
+++ b/api/hack/run-operator.sh
@@ -9,6 +9,7 @@ KUBERMATIC_WORKERNAME=${KUBERMATIC_WORKERNAME:-$(uname -n)}
 
 ./_build/kubermatic-operator \
   -kubeconfig=../../secrets/seed-clusters/dev.kubermatic.io/kubeconfig \
+  -namespace=kubermatic \
   -worker-name="$(tr -cd '[:alnum:]' <<< $KUBERMATIC_WORKERNAME | tr '[:upper:]' '[:lower:]')" \
   -log-debug=true \
   -log-format=Console \

--- a/api/pkg/controller/operator-master/defaults.go
+++ b/api/pkg/controller/operator-master/defaults.go
@@ -21,11 +21,6 @@ func (r *Reconciler) defaultConfiguration(config *operatorv1alpha1.KubermaticCon
 
 	original := config.DeepCopy()
 
-	if config.Spec.Namespace == "" {
-		config.Spec.Namespace = config.Namespace
-		logger.Debugf("Defaulting field namespace to %s", config.Spec.Namespace)
-	}
-
 	if config.Spec.ExposeStrategy == "" {
 		config.Spec.ExposeStrategy = "NodePort"
 		logger.Debugf("Defaulting field exposeStrategy to %s", config.Spec.ExposeStrategy)

--- a/api/pkg/controller/operator-master/defaults_test.go
+++ b/api/pkg/controller/operator-master/defaults_test.go
@@ -30,22 +30,6 @@ func TestDefaultingConfigurations(t *testing.T) {
 		validate func(c *operatorv1alpha1.KubermaticConfiguration) error
 	}{
 		{
-			name: "Namespace is defaulted to the configuration's namespace",
-			input: &operatorv1alpha1.KubermaticConfiguration{
-				ObjectMeta: metav1.ObjectMeta{
-					Name:      "foo",
-					Namespace: "bar",
-				},
-			},
-			validate: func(c *operatorv1alpha1.KubermaticConfiguration) error {
-				if c.Spec.Namespace != c.Namespace {
-					return fmt.Errorf("expected namespace %s, but got '%s'", c.Namespace, c.Spec.Namespace)
-				}
-
-				return nil
-			},
-		},
-		{
 			name: "Auth fields are defaulted",
 			input: &operatorv1alpha1.KubermaticConfiguration{
 				ObjectMeta: metav1.ObjectMeta{

--- a/api/pkg/controller/operator-master/reconciler.go
+++ b/api/pkg/controller/operator-master/reconciler.go
@@ -70,10 +70,6 @@ func (r *Reconciler) Reconcile(request reconcile.Request) (reconcile.Result, err
 func (r *Reconciler) reconcile(config *operatorv1alpha1.KubermaticConfiguration, logger *zap.SugaredLogger) error {
 	logger.Debug("Reconciling Kubermatic configuration")
 
-	if err := r.reconcileNamespaces(config, logger); err != nil {
-		return err
-	}
-
 	if err := r.reconcileServiceAccounts(config, logger); err != nil {
 		return err
 	}
@@ -109,20 +105,6 @@ func (r *Reconciler) reconcile(config *operatorv1alpha1.KubermaticConfiguration,
 	return nil
 }
 
-func (r *Reconciler) reconcileNamespaces(config *operatorv1alpha1.KubermaticConfiguration, logger *zap.SugaredLogger) error {
-	logger.Debug("Reconciling Namespaces")
-
-	creators := []reconciling.NamedNamespaceCreatorGetter{
-		kubermatic.NamespaceCreator(config),
-	}
-
-	if err := reconciling.ReconcileNamespaces(r.ctx, creators, "", r.Client, r.applyOwnerLabels(config)); err != nil {
-		return fmt.Errorf("failed to reconcile Namespaces: %v", err)
-	}
-
-	return nil
-}
-
 func (r *Reconciler) reconcileConfigMaps(config *operatorv1alpha1.KubermaticConfiguration, logger *zap.SugaredLogger) error {
 	logger.Debug("Reconciling ConfigMaps")
 
@@ -131,7 +113,7 @@ func (r *Reconciler) reconcileConfigMaps(config *operatorv1alpha1.KubermaticConf
 		kubermatic.BackupContainersConfigMapCreator(config),
 	}
 
-	if err := reconciling.ReconcileConfigMaps(r.ctx, creators, config.Spec.Namespace, r.Client, r.applyOwnerLabels(config)); err != nil {
+	if err := reconciling.ReconcileConfigMaps(r.ctx, creators, config.Namespace, r.Client, r.applyOwnerLabels(config)); err != nil {
 		return fmt.Errorf("failed to reconcile ConfigMaps: %v", err)
 	}
 
@@ -154,7 +136,7 @@ func (r *Reconciler) reconcileSecrets(config *operatorv1alpha1.KubermaticConfigu
 		creators = append(creators, kubermatic.PresetsSecretCreator(config))
 	}
 
-	if err := reconciling.ReconcileSecrets(r.ctx, creators, config.Spec.Namespace, r.Client, r.applyOwnerLabels(config)); err != nil {
+	if err := reconciling.ReconcileSecrets(r.ctx, creators, config.Namespace, r.Client, r.applyOwnerLabels(config)); err != nil {
 		return fmt.Errorf("failed to reconcile Secrets: %v", err)
 	}
 
@@ -168,7 +150,7 @@ func (r *Reconciler) reconcileServiceAccounts(config *operatorv1alpha1.Kubermati
 		kubermatic.ServiceAccountCreator(config),
 	}
 
-	if err := reconciling.ReconcileServiceAccounts(r.ctx, creators, config.Spec.Namespace, r.Client, r.applyOwnerLabels(config)); err != nil {
+	if err := reconciling.ReconcileServiceAccounts(r.ctx, creators, config.Namespace, r.Client, r.applyOwnerLabels(config)); err != nil {
 		return fmt.Errorf("failed to reconcile ServiceAccounts: %v", err)
 	}
 
@@ -203,7 +185,7 @@ func (r *Reconciler) reconcileDeployments(config *operatorv1alpha1.KubermaticCon
 		r.volumeRevisionLabels(),
 	}
 
-	if err := reconciling.ReconcileDeployments(r.ctx, creators, config.Spec.Namespace, r.Client, modifiers...); err != nil {
+	if err := reconciling.ReconcileDeployments(r.ctx, creators, config.Namespace, r.Client, modifiers...); err != nil {
 		return fmt.Errorf("failed to reconcile Deployments: %v", err)
 	}
 
@@ -219,7 +201,7 @@ func (r *Reconciler) reconcilePodDisruptionBudgets(config *operatorv1alpha1.Kube
 		kubermatic.MasterControllerManagerPDBCreator(config),
 	}
 
-	if err := reconciling.ReconcilePodDisruptionBudgets(r.ctx, creators, config.Spec.Namespace, r.Client, r.applyOwnerLabels(config)); err != nil {
+	if err := reconciling.ReconcilePodDisruptionBudgets(r.ctx, creators, config.Namespace, r.Client, r.applyOwnerLabels(config)); err != nil {
 		return fmt.Errorf("failed to reconcile PodDisruptionBudgets: %v", err)
 	}
 
@@ -234,7 +216,7 @@ func (r *Reconciler) reconcileServices(config *operatorv1alpha1.KubermaticConfig
 		kubermatic.UIServiceCreator(config),
 	}
 
-	if err := reconciling.ReconcileServices(r.ctx, creators, config.Spec.Namespace, r.Client, r.applyOwnerLabels(config)); err != nil {
+	if err := reconciling.ReconcileServices(r.ctx, creators, config.Namespace, r.Client, r.applyOwnerLabels(config)); err != nil {
 		return fmt.Errorf("failed to reconcile Services: %v", err)
 	}
 
@@ -248,7 +230,7 @@ func (r *Reconciler) reconcileIngresses(config *operatorv1alpha1.KubermaticConfi
 		kubermatic.IngressCreator(config),
 	}
 
-	if err := reconciling.ReconcileIngresses(r.ctx, creators, config.Spec.Namespace, r.Client, r.applyOwnerLabels(config)); err != nil {
+	if err := reconciling.ReconcileIngresses(r.ctx, creators, config.Namespace, r.Client, r.applyOwnerLabels(config)); err != nil {
 		return fmt.Errorf("failed to reconcile Ingresses: %v", err)
 	}
 

--- a/api/pkg/controller/operator-master/resources/kubermatic/kubermatic.go
+++ b/api/pkg/controller/operator-master/resources/kubermatic/kubermatic.go
@@ -28,13 +28,13 @@ const (
 	uiServiceName                         = "kubermatic-ui"
 )
 
-func clusterRoleBindingName(ns string) string {
-	return fmt.Sprintf("%s:kubermatic:cluster-admin", ns)
+func clusterRoleBindingName(cfg *operatorv1alpha1.KubermaticConfiguration) string {
+	return fmt.Sprintf("%s:%s:cluster-admin", cfg.Namespace, cfg.Name)
 }
 
 func NamespaceCreator(cfg *operatorv1alpha1.KubermaticConfiguration) reconciling.NamedNamespaceCreatorGetter {
 	return func() (string, reconciling.NamespaceCreator) {
-		return cfg.Spec.Namespace, func(ns *corev1.Namespace) (*corev1.Namespace, error) {
+		return cfg.Namespace, func(ns *corev1.Namespace) (*corev1.Namespace, error) {
 			return ns, nil
 		}
 	}
@@ -118,7 +118,7 @@ func ServiceAccountCreator(cfg *operatorv1alpha1.KubermaticConfiguration) reconc
 }
 
 func ClusterRoleBindingCreator(cfg *operatorv1alpha1.KubermaticConfiguration) reconciling.NamedClusterRoleBindingCreatorGetter {
-	name := clusterRoleBindingName(cfg.Spec.Namespace)
+	name := clusterRoleBindingName(cfg)
 
 	return func() (string, reconciling.ClusterRoleBindingCreator) {
 		return name, func(crb *rbacv1.ClusterRoleBinding) (*rbacv1.ClusterRoleBinding, error) {
@@ -132,7 +132,7 @@ func ClusterRoleBindingCreator(cfg *operatorv1alpha1.KubermaticConfiguration) re
 				{
 					Kind:      rbacv1.ServiceAccountKind,
 					Name:      serviceAccountName,
-					Namespace: cfg.Spec.Namespace,
+					Namespace: cfg.Namespace,
 				},
 			}
 

--- a/config/kubermatic-operator/deployment.yaml
+++ b/config/kubermatic-operator/deployment.yaml
@@ -1,4 +1,4 @@
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: kubermatic-operator
@@ -26,7 +26,13 @@ spec:
         - kubermatic-operator
         args:
         - -internal-address=0.0.0.0:8085
+        - -namespace=$(POD_NAMESPACE)
         - -log-format=json
+        env:
+        - name: POD_NAMESPACE
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.namespace
         ports:
         - name: metrics
           containerPort: 8085


### PR DESCRIPTION
**What this PR does / why we need it**:
After learning about all the various troubles we get into when doing seed-cluster reconciles from a single operator pod, we decided that it would make more sense to

- have the master-operator only reconcile its own namespace (or whatever is specified via `-namespace=...`), and
- deploy the seed-operator into the Kubermatic namespace, i.e. have one seed-operator pod per Kubermatic installation. This will significantly simplify the seed-operator logic.

**Does this PR introduce a user-facing change?**:
```release-note
NONE
```
