### PR TITLE
Default user settings for patch endpoint

### DIFF
--- a/api/pkg/handler/v1/user/user.go
+++ b/api/pkg/handler/v1/user/user.go
@@ -239,7 +239,12 @@ func PatchSettingsEndpoint(userProvider provider.UserProvider) endpoint.Endpoint
 		req := request.(PatchSettingsReq)
 		existingUser := ctx.Value(middleware.UserCRContextKey).(*kubermaticapiv1.User)
 
-		existingSettingsJSON, err := json.Marshal(existingUser.Spec.Settings)
+		existingSettings := existingUser.Spec.Settings
+		if existingSettings == nil {
+			existingSettings = &kubermaticapiv1.UserSettings{}
+		}
+
+		existingSettingsJSON, err := json.Marshal(existingSettings)
 		if err != nil {
 			return nil, errors.NewBadRequest(fmt.Sprintf("cannot decode existing user settings: %v", err))
 		}


### PR DESCRIPTION
**What this PR does / why we need it**: It fixes the problem for users that don't have their settings initialized (set to null). `jsonpatch.MergePatch` doesn't accept `nil`s.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Documentation**:
<!-- Add links to the related documentation changes related to this pull request. E.g. the link to the kubermatic/docs pullrequest. -->

**Does this PR introduce a user-facing change?**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If  no release note is required, just write "NONE".
-->
```release-note
NONE
```
