### PR TITLE
Use LeaderElectionRunnable to run seed webhook in mgr

### DIFF
--- a/api/cmd/master-controller-manager/main.go
+++ b/api/cmd/master-controller-manager/main.go
@@ -187,17 +187,10 @@ func main() {
 		if err != nil {
 			log.Fatalw("failed to create validatingAdmissionWebhook server for seeds", zap.Error(err))
 		}
-
-		// This group starts the validation webhook server; it's not using the
-		// mgr because we want the webhook to run so that migrations can perform
-		// operations on seeds
-		{
-			g.Add(func() error {
-				return seedValidationWebhookServer.Start(ctx.Done())
-			}, func(err error) {
-				ctxCancel()
-			})
+		if err := mgr.Add(seedValidationWebhookServer); err != nil {
+			log.Fatalw("failed to add the seedValidationWebhookServer to the mgr", zap.Error(err))
 		}
+
 	} else {
 		log.Info("the validatingAdmissionWebhook server can not be started because seed-admissionwebhook-cert-file and seed-admissionwebhook-key-file are empty")
 	}

--- a/api/pkg/metrics/server/server.go
+++ b/api/pkg/metrics/server/server.go
@@ -9,6 +9,7 @@ import (
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/client_golang/prometheus/promhttp"
 
+	"sigs.k8s.io/controller-runtime/pkg/manager"
 	ctrlruntimemetrics "sigs.k8s.io/controller-runtime/pkg/metrics"
 )
 
@@ -62,4 +63,12 @@ func (m *MetricsServer) Start(stop <-chan struct{}) error {
 	}
 
 	return fmt.Errorf("metrics server stopped: %v", s.ListenAndServe())
+}
+
+// MetricsServer implements LeaderElectionRunnable to indicate that it does not require to run
+// within an elected leader
+var _ manager.LeaderElectionRunnable = &MetricsServer{}
+
+func (m *MetricsServer) NeedLeaderElection() bool {
+	return false
 }

--- a/api/pkg/validation/seed/server.go
+++ b/api/pkg/validation/seed/server.go
@@ -19,6 +19,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
 	ctrlruntimeclient "sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/manager"
 )
 
 type WebhookOpts struct {
@@ -80,6 +81,14 @@ type Server struct {
 	keyFile              string
 	validator            *seedValidator
 	migrationModeEnabled bool
+}
+
+// Server implements LeaderElectionRunnable to indicate that it does not require to run
+// within an elected leader
+var _ manager.LeaderElectionRunnable = &Server{}
+
+func (s *Server) NeedLeaderElection() bool {
+	return false
 }
 
 // Start implements sigs.k8s.io/controller-runtime/pkg/manager.Runnable


### PR DESCRIPTION
**What this PR does / why we need it**:

Avoids using a rungroup for the seed webhook and instead makes it implement `LeaderElectionRunnable` to let it indicate that it doesn't need to run in an elected leader, allowing it to run within the `mgr`.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Documentation**:
<!-- Add links to the related documentation changes related to this pull request. E.g. the link to the kubermatic/docs pullrequest. -->

**Does this PR introduce a user-facing change?**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If  no release note is required, just write "NONE".
-->
```release-note
none
```
