### PR TITLE
Fix hack/run-controller.sh

### DIFF
--- a/api/cmd/kubermatic-controller-manager/main.go
+++ b/api/cmd/kubermatic-controller-manager/main.go
@@ -119,7 +119,7 @@ Please install the VerticalPodAutoscaler according to the documentation: https:/
 		log.Fatalw("Failed to get clientProvider", zap.Error(err))
 	}
 
-	if options.dynamicDatacenters {
+	if options.dynamicDatacenters && options.seedValidationHook.CertFile != "" && options.seedValidationHook.KeyFile != "" {
 		restMapperCache := restmapper.New()
 		seedValidationWebhookServer, err := options.seedValidationHook.Server(
 			rootCtx,

--- a/api/hack/run-controller.sh
+++ b/api/hack/run-controller.sh
@@ -14,7 +14,8 @@ make kubermatic-controller-manager
 KUBERMATIC_WORKERNAME=${KUBERMATIC_WORKERNAME:-$(uname -n)}
 
 ./_build/kubermatic-controller-manager \
-  -datacenters=../../secrets/seed-clusters/dev.kubermatic.io/datacenters.yaml \
+  -dynamic-datacenters=true \
+  -namespace=kubermatic \
   -datacenter-name=europe-west3-c \
   -kubeconfig=../../secrets/seed-clusters/dev.kubermatic.io/kubeconfig \
   -versions=../config/kubermatic/static/master/versions.yaml \
@@ -36,5 +37,5 @@ KUBERMATIC_WORKERNAME=${KUBERMATIC_WORKERNAME:-$(uname -n)}
   -log-debug=true \
   -log-format=Console \
   -max-parallel-reconcile=10 \
-	-logtostderr \
-	-v=4 # Log-level for the Kube dependencies. Increase up to 9 to get request-level logs.
+  -logtostderr \
+  -v=4 # Log-level for the Kube dependencies. Increase up to 9 to get request-level logs.


### PR DESCRIPTION
**What this PR does / why we need it**:

Running the controller-manager locally stopped working, because we don't have a datanceters.yaml for dev anymore. This PR changes the script to set `--dynamic-datacenters=true` and the code to not start the webhook server when there are no certs, as that wont work.


**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Documentation**:
<!-- Add links to the related documentation changes related to this pull request. E.g. the link to the kubermatic/docs pullrequest. -->

**Does this PR introduce a user-facing change?**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If  no release note is required, just write "NONE".
-->
```release-note
none
```
