### PR TITLE
Add external cloud provider support for OpenStack.

### DIFF
--- a/addons/csi/controllerplugin-rbac.yaml
+++ b/addons/csi/controllerplugin-rbac.yaml
@@ -1,0 +1,212 @@
+{{ if (.Cluster.Spec.Features.externalCloudProvider) }}
+
+{{ if .Cluster.Spec.Cloud.Openstack }}
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: csi-cinder-controller-sa
+  namespace: kube-system
+
+---
+# external attacher 
+kind: ClusterRole
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: csi-attacher-role
+rules:
+  - apiGroups: [""]
+    resources: ["persistentvolumes"]
+    verbs: ["get", "list", "watch", "update"]
+  - apiGroups: [""]
+    resources: ["nodes"]
+    verbs: ["get", "list", "watch"]
+  - apiGroups: ["storage.k8s.io"]
+    resources: ["volumeattachments"]
+    verbs: ["get", "list", "watch", "update"]
+  - apiGroups: ["storage.k8s.io"]
+    resources: ["csinodes"]
+    verbs: ["get", "list", "watch"]
+
+
+---
+kind: ClusterRoleBinding
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: csi-attacher-binding
+subjects:
+  - kind: ServiceAccount
+    name: csi-cinder-controller-sa
+    namespace: kube-system
+roleRef:
+  kind: ClusterRole
+  name: csi-attacher-role
+  apiGroup: rbac.authorization.k8s.io
+
+---
+# external Provisioner
+kind: ClusterRole
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: csi-provisioner-role
+rules:
+  - apiGroups: [""]
+    resources: ["persistentvolumes"]
+    verbs: ["get", "list", "watch", "create", "delete"]
+  - apiGroups: [""]
+    resources: ["persistentvolumeclaims"]
+    verbs: ["get", "list", "watch", "update"]
+  - apiGroups: ["storage.k8s.io"]
+    resources: ["storageclasses"]
+    verbs: ["get", "list", "watch"]
+  - apiGroups: [""]
+    resources: ["nodes"]
+    verbs: ["get", "list", "watch"]
+  - apiGroups: ["storage.k8s.io"]
+    resources: ["csinodes"]
+    verbs: ["get", "list", "watch"]
+  - apiGroups: [""]
+    resources: ["events"]
+    verbs: ["list", "watch", "create", "update", "patch"]
+  - apiGroups: ["snapshot.storage.k8s.io"]
+    resources: ["volumesnapshots"]
+    verbs: ["get", "list"]
+  - apiGroups: ["snapshot.storage.k8s.io"]
+    resources: ["volumesnapshotcontents"]
+    verbs: ["get", "list"]
+
+---
+kind: ClusterRoleBinding
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: csi-provisioner-binding
+subjects:
+  - kind: ServiceAccount
+    name: csi-cinder-controller-sa
+    namespace: kube-system
+roleRef:
+  kind: ClusterRole
+  name: csi-provisioner-role
+  apiGroup: rbac.authorization.k8s.io
+
+---
+# external snapshotter
+kind: ClusterRole
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: csi-snapshotter-role
+rules:
+  - apiGroups: [""]
+    resources: ["persistentvolumes"]
+    verbs: ["get", "list", "watch"]
+  - apiGroups: [""]
+    resources: ["persistentvolumeclaims"]
+    verbs: ["get", "list", "watch"]
+  - apiGroups: ["storage.k8s.io"]
+    resources: ["storageclasses"]
+    verbs: ["get", "list", "watch"]
+  - apiGroups: [""]
+    resources: ["events"]
+    verbs: ["list", "watch", "create", "update", "patch"]
+  - apiGroups: [""]
+    resources: ["secrets"]
+    verbs: ["get", "list"]
+  - apiGroups: ["snapshot.storage.k8s.io"]
+    resources: ["volumesnapshotclasses"]
+    verbs: ["get", "list", "watch"]
+  - apiGroups: ["snapshot.storage.k8s.io"]
+    resources: ["volumesnapshotcontents"]
+    verbs: ["create", "get", "list", "watch", "update", "delete"]
+  - apiGroups: ["snapshot.storage.k8s.io"]
+    resources: ["volumesnapshots"]
+    verbs: ["get", "list", "watch", "update"]
+  - apiGroups: ["snapshot.storage.k8s.io"]
+    resources: ["volumesnapshots/status"]
+    verbs: ["update"]
+  - apiGroups: ["apiextensions.k8s.io"]
+    resources: ["customresourcedefinitions"]
+    verbs: ["create", "list", "watch", "delete"]
+
+---
+kind: ClusterRoleBinding
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: csi-snapshotter-binding
+subjects:
+  - kind: ServiceAccount
+    name: csi-cinder-controller-sa
+    namespace: kube-system
+roleRef:
+  kind: ClusterRole
+  name: csi-snapshotter-role
+  apiGroup: rbac.authorization.k8s.io
+---
+
+# External Resizer
+kind: ClusterRole
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: csi-resizer-role
+rules:
+  # The following rule should be uncommented for plugins that require secrets
+  # for provisioning.
+  # - apiGroups: [""]
+  #   resources: ["secrets"]
+  #   verbs: ["get", "list", "watch"]
+  - apiGroups: [""]
+    resources: ["persistentvolumes"]
+    verbs: ["get", "list", "watch", "update", "patch"]
+  - apiGroups: [""]
+    resources: ["persistentvolumeclaims"]
+    verbs: ["get", "list", "watch"]
+  - apiGroups: [""]
+    resources: ["persistentvolumeclaims/status"]
+    verbs: ["update", "patch"]
+  - apiGroups: ["storage.k8s.io"]
+    resources: ["storageclasses"]
+    verbs: ["get", "list", "watch"]
+  - apiGroups: [""]
+    resources: ["events"]
+    verbs: ["list", "watch", "create", "update", "patch"]
+
+---
+kind: ClusterRoleBinding
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: csi-resizer-binding
+subjects:
+  - kind: ServiceAccount
+    name: csi-cinder-controller-sa
+    namespace: kube-system
+roleRef:
+  kind: ClusterRole
+  name: csi-resizer-role
+  apiGroup: rbac.authorization.k8s.io
+
+---
+kind: Role
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  namespace: kube-system
+  name: external-resizer-cfg
+rules:
+- apiGroups: ["coordination.k8s.io"]
+  resources: ["leases"]
+  verbs: ["get", "watch", "list", "delete", "update", "create"]
+
+---
+kind: RoleBinding
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: csi-resizer-role-cfg
+  namespace: kube-system
+subjects:
+  - kind: ServiceAccount
+    name: csi-cinder-controller-sa
+    namespace: kube-system
+roleRef:
+  kind: Role
+  name: external-resizer-cfg
+  apiGroup: rbac.authorization.k8s.io
+{{ end }}
+
+{{ end }}

--- a/addons/csi/controllerplugin.yaml
+++ b/addons/csi/controllerplugin.yaml
@@ -46,7 +46,7 @@ spec:
             - name: socket-dir
               mountPath: /var/lib/csi/sockets/pluginproxy/
         - name: csi-provisioner
-          image: quay.io/k8scsi/csi-provisioner:v1.3.0
+          image: quay.io/k8scsi/csi-provisioner:v1.3.1
           args:
             - "--csi-address=$(ADDRESS)"
             - "--feature-gates=Topology=true"
@@ -58,7 +58,7 @@ spec:
             - name: socket-dir
               mountPath: /var/lib/csi/sockets/pluginproxy/
         - name: csi-snapshotter
-          image: quay.io/k8scsi/csi-snapshotter:v1.2.0
+          image: quay.io/k8scsi/csi-snapshotter:v1.2.2
           args:
             - "--csi-address=$(ADDRESS)"
           env:
@@ -69,7 +69,7 @@ spec:
             - mountPath: /var/lib/csi/sockets/pluginproxy/
               name: socket-dir
         - name: csi-resizer
-          image: quay.io/k8scsi/csi-resizer:v0.2.0
+          image: quay.io/k8scsi/csi-resizer:v0.3.0
           args:
             - "--v=5"
             - "--csi-address=$(ADDRESS)"

--- a/addons/csi/controllerplugin.yaml
+++ b/addons/csi/controllerplugin.yaml
@@ -1,0 +1,116 @@
+{{ if (.Cluster.Spec.Features.externalCloudProvider) }}
+{{ if .Cluster.Spec.Cloud.Openstack }}
+kind: Service
+apiVersion: v1
+metadata:
+  name: csi-cinder-controller-service
+  namespace: kube-system
+  labels:
+    app: csi-cinder-controllerplugin
+spec:
+  selector:
+    app: csi-cinder-controllerplugin
+  ports:
+    - name: dummy
+      port: 12345
+
+---
+kind: StatefulSet
+apiVersion: apps/v1
+metadata:
+  name: csi-cinder-controllerplugin
+  namespace: kube-system
+spec:
+  serviceName: "csi-cinder-controller-service"
+  replicas: 1
+  selector:
+    matchLabels:
+      app: csi-cinder-controllerplugin
+  template:
+    metadata:
+      labels:
+        app: csi-cinder-controllerplugin
+    spec:
+      serviceAccount: csi-cinder-controller-sa
+      containers:
+        - name: csi-attacher
+          image: quay.io/k8scsi/csi-attacher:v1.2.1
+          args:
+            - "--v=5"
+            - "--csi-address=$(ADDRESS)"
+          env:
+            - name: ADDRESS
+              value: /var/lib/csi/sockets/pluginproxy/csi.sock
+          imagePullPolicy: "IfNotPresent"
+          volumeMounts:
+            - name: socket-dir
+              mountPath: /var/lib/csi/sockets/pluginproxy/
+        - name: csi-provisioner
+          image: quay.io/k8scsi/csi-provisioner:v1.3.0
+          args:
+            - "--csi-address=$(ADDRESS)"
+            - "--feature-gates=Topology=true"
+          env:
+            - name: ADDRESS
+              value: /var/lib/csi/sockets/pluginproxy/csi.sock
+          imagePullPolicy: "IfNotPresent"
+          volumeMounts:
+            - name: socket-dir
+              mountPath: /var/lib/csi/sockets/pluginproxy/
+        - name: csi-snapshotter
+          image: quay.io/k8scsi/csi-snapshotter:v1.2.0
+          args:
+            - "--csi-address=$(ADDRESS)"
+          env:
+            - name: ADDRESS
+              value: /var/lib/csi/sockets/pluginproxy/csi.sock
+          imagePullPolicy: Always
+          volumeMounts:
+            - mountPath: /var/lib/csi/sockets/pluginproxy/
+              name: socket-dir
+        - name: csi-resizer
+          image: quay.io/k8scsi/csi-resizer:v0.2.0
+          args:
+            - "--v=5"
+            - "--csi-address=$(ADDRESS)"
+          env:
+            - name: ADDRESS
+              value: /var/lib/csi/sockets/pluginproxy/csi.sock
+          imagePullPolicy: "IfNotPresent"
+          volumeMounts:
+            - name: socket-dir
+              mountPath: /var/lib/csi/sockets/pluginproxy/
+        - name: cinder-csi-plugin
+          image: docker.io/k8scloudprovider/cinder-csi-plugin:v1.16.0
+          args :
+            - /bin/cinder-csi-plugin
+            - "--nodeid=$(NODE_ID)"
+            - "--endpoint=$(CSI_ENDPOINT)"
+            - "--cloud-config=$(CLOUD_CONFIG)"
+            - "--cluster=$(CLUSTER_NAME)"
+          env:
+            - name: NODE_ID
+              valueFrom:
+                fieldRef:
+                  fieldPath: spec.nodeName
+            - name: CSI_ENDPOINT
+              value: unix://csi/csi.sock
+            - name: CLOUD_CONFIG
+              value: /etc/config/config
+            - name: CLUSTER_NAME
+              value: kubernetes
+          imagePullPolicy: "IfNotPresent"
+          volumeMounts:
+            - name: socket-dir
+              mountPath: /csi
+            - name: cloud-config
+              mountPath: /etc/config
+              readOnly: true
+      volumes:
+        - name: socket-dir
+          emptyDir:
+        - name: cloud-config
+          secret:
+            secretName: cloud-config
+{{ end }}
+{{ end }}

--- a/addons/csi/driver.yaml
+++ b/addons/csi/driver.yaml
@@ -1,0 +1,12 @@
+{{ if (.Cluster.Spec.Features.externalCloudProvider) }}
+
+{{ if .Cluster.Spec.Cloud.Openstack }}
+apiVersion: storage.k8s.io/v1beta1
+kind: CSIDriver
+metadata:
+  name: cinder.csi.openstack.org
+spec:
+  attachRequired: true
+  podInfoOnMount: false
+{{ end }}
+{{ end }}

--- a/addons/csi/nodeplugin-rbac.yaml
+++ b/addons/csi/nodeplugin-rbac.yaml
@@ -1,0 +1,33 @@
+{{ if (.Cluster.Spec.Features.externalCloudProvider) }}
+
+{{ if .Cluster.Spec.Cloud.Openstack }}
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: csi-cinder-node-sa
+  namespace: kube-system
+---
+kind: ClusterRole
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: csi-nodeplugin-role
+rules:
+  - apiGroups: [""]
+    resources: ["events"]
+    verbs: ["get", "list", "watch", "create", "update", "patch"]
+
+---
+kind: ClusterRoleBinding
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: csi-nodeplugin-binding
+subjects:
+  - kind: ServiceAccount
+    name: csi-cinder-node-sa
+    namespace: kube-system
+roleRef:
+  kind: ClusterRole
+  name: csi-nodeplugin-role
+  apiGroup: rbac.authorization.k8s.io
+{{ end }}
+{{ end }}

--- a/addons/csi/nodeplugin.yaml
+++ b/addons/csi/nodeplugin.yaml
@@ -1,0 +1,342 @@
+
+{{ if (.Cluster.Spec.Features.externalCloudProvider) }}
+
+{{ if .Cluster.Spec.Cloud.Openstack }}
+{{ $version := "UNSUPPORTED" }}
+{{ if eq .MajorMinorVersion "1.16" }}
+{{ $version = "v1.16.0 "}}
+{{ end }}
+
+kind: DaemonSet
+apiVersion: apps/v1
+metadata:
+  name: csi-cinder-nodeplugin-ubuntu
+  namespace: kube-system
+spec:
+  selector:
+    matchLabels:
+      app: csi-cinder-nodeplugin-ubuntu
+  template:
+    metadata:
+      labels:
+        app: csi-cinder-nodeplugin-ubuntu
+    spec:
+      serviceAccount: csi-cinder-node-sa
+      hostNetwork: true
+      nodeSelector:
+        kubermatic.io/distribution: ubuntu
+      containers:
+        - name: node-driver-registrar
+          image: quay.io/k8scsi/csi-node-driver-registrar:v1.1.0
+          args:
+            - "--v=5"
+            - "--csi-address=$(ADDRESS)"
+            - "--kubelet-registration-path=$(DRIVER_REG_SOCK_PATH)"
+          lifecycle:
+            preStop:
+              exec:
+                command: ["/bin/sh", "-c", "rm -rf /registration/cinder.csi.openstack.org /registration/cinder.csi.openstack.org-reg.sock"]
+          env:
+            - name: ADDRESS
+              value: /csi/csi.sock
+            - name: DRIVER_REG_SOCK_PATH
+              value: /var/lib/kubelet/plugins/cinder.csi.openstack.org/csi.sock
+            - name: KUBE_NODE_NAME
+              valueFrom:
+                fieldRef:
+                  fieldPath: spec.nodeName
+          imagePullPolicy: "IfNotPresent"
+          volumeMounts:
+            - name: socket-dir
+              mountPath: /csi
+            - name: registration-dir
+              mountPath: /registration
+        - name: cinder-csi-plugin
+          securityContext:
+            privileged: true
+            capabilities:
+              add: ["SYS_ADMIN"]
+            allowPrivilegeEscalation: true
+          image: docker.io/k8scloudprovider/cinder-csi-plugin:{{ $version }}
+          args :
+            - /bin/cinder-csi-plugin
+            - "--nodeid=$(NODE_ID)"
+            - "--endpoint=$(CSI_ENDPOINT)"
+            - "--cloud-config=$(CLOUD_CONFIG)"
+          env:
+            - name: NODE_ID
+              valueFrom:
+                fieldRef:
+                  fieldPath: spec.nodeName
+            - name: CSI_ENDPOINT
+              value: unix://csi/csi.sock
+            - name: CLOUD_CONFIG
+              value: /etc/config/config
+          imagePullPolicy: "IfNotPresent"
+          volumeMounts:
+            - name: socket-dir
+              mountPath: /csi
+            - name: pods-mount-dir
+              mountPath: /var/lib/kubelet/pods
+              mountPropagation: "Bidirectional"
+            - name: kubelet-dir
+              mountPath: /var/lib/kubelet
+              mountPropagation: "Bidirectional"
+            - name: pods-cloud-data
+              mountPath: /var/lib/cloud/data
+              readOnly: true
+            - name: pods-probe-dir
+              mountPath: /dev
+              mountPropagation: "HostToContainer"
+            - name: secret-cinderplugin
+              mountPath: /etc/config
+              readOnly: true
+      volumes:
+        - name: socket-dir
+          hostPath:
+            path: /var/lib/kubelet/plugins/cinder.csi.openstack.org
+            type: DirectoryOrCreate
+        - name: registration-dir
+          hostPath:
+            path: /var/lib/kubelet/plugins_registry/
+            type: Directory
+        - name: kubelet-dir
+          hostPath:
+            path: /var/lib/kubelet
+            type: Directory
+        - name: pods-mount-dir
+          hostPath:
+            path: /var/lib/kubelet/pods
+            type: Directory
+        - name: pods-cloud-data
+          hostPath:
+            path: /var/lib/cloud/data
+            type: Directory
+        - name: pods-probe-dir
+          hostPath:
+            path: /dev
+            type: Directory
+        - name: secret-cinderplugin
+          secret:
+            secretName: cloud-config
+---
+kind: DaemonSet
+apiVersion: apps/v1
+metadata:
+  name: csi-cinder-nodeplugin-centos
+  namespace: kube-system
+spec:
+  selector:
+    matchLabels:
+      app: csi-cinder-nodeplugin-centos
+  template:
+    metadata:
+      labels:
+        app: csi-cinder-nodeplugin-centos
+    spec:
+      serviceAccount: csi-cinder-node-sa
+      hostNetwork: true
+      nodeSelector:
+        kubermatic.io/distribution: centos
+      containers:
+        - name: node-driver-registrar
+          image: quay.io/k8scsi/csi-node-driver-registrar:v1.1.0
+          args:
+            - "--v=5"
+            - "--csi-address=$(ADDRESS)"
+            - "--kubelet-registration-path=$(DRIVER_REG_SOCK_PATH)"
+          lifecycle:
+            preStop:
+              exec:
+                command: ["/bin/sh", "-c", "rm -rf /registration/cinder.csi.openstack.org /registration/cinder.csi.openstack.org-reg.sock"]
+          env:
+            - name: ADDRESS
+              value: /csi/csi.sock
+            - name: DRIVER_REG_SOCK_PATH
+              value: /var/lib/kubelet/plugins/cinder.csi.openstack.org/csi.sock
+            - name: KUBE_NODE_NAME
+              valueFrom:
+                fieldRef:
+                  fieldPath: spec.nodeName
+          imagePullPolicy: "IfNotPresent"
+          volumeMounts:
+            - name: socket-dir
+              mountPath: /csi
+            - name: registration-dir
+              mountPath: /registration
+        - name: cinder-csi-plugin
+          securityContext:
+            privileged: true
+            capabilities:
+              add: ["SYS_ADMIN"]
+            allowPrivilegeEscalation: true
+          image: docker.io/k8scloudprovider/cinder-csi-plugin:{{ $version }}
+          args :
+            - /bin/cinder-csi-plugin
+            - "--nodeid=$(NODE_ID)"
+            - "--endpoint=$(CSI_ENDPOINT)"
+            - "--cloud-config=$(CLOUD_CONFIG)"
+          env:
+            - name: NODE_ID
+              valueFrom:
+                fieldRef:
+                  fieldPath: spec.nodeName
+            - name: CSI_ENDPOINT
+              value: unix://csi/csi.sock
+            - name: CLOUD_CONFIG
+              value: /etc/config/config
+          imagePullPolicy: "IfNotPresent"
+          volumeMounts:
+            - name: socket-dir
+              mountPath: /csi
+            - name: pods-mount-dir
+              mountPath: /var/lib/kubelet/pods
+              mountPropagation: "Bidirectional"
+            - name: kubelet-dir
+              mountPath: /var/lib/kubelet
+              mountPropagation: "Bidirectional"
+            - name: pods-cloud-data
+              mountPath: /var/lib/cloud/data
+              readOnly: true
+            - name: pods-probe-dir
+              mountPath: /dev
+              mountPropagation: "HostToContainer"
+            - name: secret-cinderplugin
+              mountPath: /etc/config
+              readOnly: true
+      volumes:
+        - name: socket-dir
+          hostPath:
+            path: /var/lib/kubelet/plugins/cinder.csi.openstack.org
+            type: DirectoryOrCreate
+        - name: registration-dir
+          hostPath:
+            path: /var/lib/kubelet/plugins_registry/
+            type: Directory
+        - name: kubelet-dir
+          hostPath:
+            path: /var/lib/kubelet
+            type: Directory
+        - name: pods-mount-dir
+          hostPath:
+            path: /var/lib/kubelet/pods
+            type: Directory
+        - name: pods-cloud-data
+          hostPath:
+            path: /var/lib/cloud/data
+            type: Directory
+        - name: pods-probe-dir
+          hostPath:
+            path: /dev
+            type: Directory
+        - name: secret-cinderplugin
+          secret:
+            secretName: cloud-config
+---
+kind: DaemonSet
+apiVersion: apps/v1
+metadata:
+  name: csi-cinder-nodeplugin-coreos
+  namespace: kube-system
+spec:
+  selector:
+    matchLabels:
+      app: csi-cinder-nodeplugin-coreos
+  template:
+    metadata:
+      labels:
+        app: csi-cinder-nodeplugin-coreos
+    spec:
+      serviceAccount: csi-cinder-node-sa
+      hostNetwork: true
+      nodeSelector:
+        kubermatic.io/distribution: container-linux
+      containers:
+        - name: node-driver-registrar
+          image: quay.io/k8scsi/csi-node-driver-registrar:v1.1.0
+          args:
+            - "--v=5"
+            - "--csi-address=$(ADDRESS)"
+            - "--kubelet-registration-path=$(DRIVER_REG_SOCK_PATH)"
+          lifecycle:
+            preStop:
+              exec:
+                command: ["/bin/sh", "-c", "rm -rf /registration/cinder.csi.openstack.org /registration/cinder.csi.openstack.org-reg.sock"]
+          env:
+            - name: ADDRESS
+              value: /csi/csi.sock
+            - name: DRIVER_REG_SOCK_PATH
+              value: /var/lib/kubelet/plugins/cinder.csi.openstack.org/csi.sock
+            - name: KUBE_NODE_NAME
+              valueFrom:
+                fieldRef:
+                  fieldPath: spec.nodeName
+          imagePullPolicy: "IfNotPresent"
+          volumeMounts:
+            - name: socket-dir
+              mountPath: /csi
+            - name: registration-dir
+              mountPath: /registration
+        - name: cinder-csi-plugin
+          securityContext:
+            privileged: true
+            capabilities:
+              add: ["SYS_ADMIN"]
+            allowPrivilegeEscalation: true
+          image: docker.io/k8scloudprovider/cinder-csi-plugin:{{ $version }}
+          args :
+            - /bin/cinder-csi-plugin
+            - "--nodeid=$(NODE_ID)"
+            - "--endpoint=$(CSI_ENDPOINT)"
+            - "--cloud-config=$(CLOUD_CONFIG)"
+          env:
+            - name: NODE_ID
+              valueFrom:
+                fieldRef:
+                  fieldPath: spec.nodeName
+            - name: CSI_ENDPOINT
+              value: unix://csi/csi.sock
+            - name: CLOUD_CONFIG
+              value: /etc/config/config
+          imagePullPolicy: "IfNotPresent"
+          volumeMounts:
+            - name: socket-dir
+              mountPath: /csi
+            - name: pods-mount-dir
+              mountPath: /var/lib/kubelet/pods
+              mountPropagation: "Bidirectional"
+            - name: kubelet-dir
+              mountPath: /var/lib/kubelet
+              mountPropagation: "Bidirectional"
+            - name: pods-probe-dir
+              mountPath: /dev
+              mountPropagation: "HostToContainer"
+            - name: secret-cinderplugin
+              mountPath: /etc/config
+              readOnly: true
+      volumes:
+        - name: socket-dir
+          hostPath:
+            path: /var/lib/kubelet/plugins/cinder.csi.openstack.org
+            type: DirectoryOrCreate
+        - name: registration-dir
+          hostPath:
+            path: /var/lib/kubelet/plugins_registry/
+            type: Directory
+        - name: kubelet-dir
+          hostPath:
+            path: /var/lib/kubelet
+            type: Directory
+        - name: pods-mount-dir
+          hostPath:
+            path: /var/lib/kubelet/pods
+            type: Directory
+        - name: pods-probe-dir
+          hostPath:
+            path: /dev
+            type: Directory
+        - name: secret-cinderplugin
+          secret:
+            secretName: cloud-config
+{{ end }}
+{{ end }}

--- a/addons/default-storage-class/storage-class.yaml
+++ b/addons/default-storage-class/storage-class.yaml
@@ -44,6 +44,18 @@ parameters:
 {{ end }}
 
 {{ if .Cluster.Spec.Cloud.Openstack }}
+{{ if (.Cluster.Spec.Features.externalCloudProvider) }}
+apiVersion: storage.k8s.io/v1
+kind: StorageClass
+metadata:
+  annotations:
+    storageclass.beta.kubernetes.io/is-default-class: "true"
+  labels:
+    kubernetes.io/cluster-service: "true"
+  name: cinder-csi
+provisioner: cinder.csi.openstack.org
+volumeBindingMode: WaitForFirstConsumer
+{{ else }}
 apiVersion: storage.k8s.io/v1
 kind: StorageClass
 metadata:
@@ -53,6 +65,7 @@ metadata:
     kubernetes.io/cluster-service: "true"
   name: standard
 provisioner: kubernetes.io/cinder
+{{ end }}
 {{ end }}
 
 {{ if .Cluster.Spec.Cloud.GCP }}

--- a/api/cmd/image-loader/main.go
+++ b/api/cmd/image-loader/main.go
@@ -424,9 +424,10 @@ func getVersions(log *zap.Logger, versionsFile, versionFilter string) ([]*kuberm
 
 func getImagesFromAddons(log *zap.Logger, addonsPath string, cluster *kubermaticv1.Cluster) ([]string, error) {
 	addonData := &addonutil.TemplateData{
-		Cluster:   cluster,
-		Addon:     &kubermaticv1.Addon{},
-		Variables: map[string]interface{}{},
+		Cluster:           cluster,
+		MajorMinorVersion: cluster.Spec.Version.MajorMinor(),
+		Addon:             &kubermaticv1.Addon{},
+		Variables:         map[string]interface{}{},
 	}
 	infos, err := ioutil.ReadDir(addonsPath)
 	if err != nil {

--- a/api/cmd/seed-controller-manager/options.go
+++ b/api/cmd/seed-controller-manager/options.go
@@ -99,7 +99,7 @@ func newControllerRunOptions() (controllerRunOptions, error) {
 	flag.StringVar(&c.nodeAccessNetwork, "node-access-network", "10.254.0.0/16", "A network which allows direct access to nodes via VPN. Uses CIDR notation.")
 	flag.StringVar(&c.kubernetesAddonsPath, "kubernetes-addons-path", "/opt/addons/kubernetes", "Path to addon manifests. Should contain sub-folders for each addon")
 	flag.StringVar(&c.openshiftAddonsPath, "openshift-addons-path", "/opt/addons/openshift", "Path to addon manifests. Should contain sub-folders for each addon")
-	flag.StringVar(&c.kubernetesAddonsList, "kubernetes-addons-list", "canal,dns,kube-proxy,openvpn,rbac,kubelet-configmap,default-storage-class,node-exporter,nodelocal-dns-cache", "Comma separated list of Addons to install into every user-cluster")
+	flag.StringVar(&c.kubernetesAddonsList, "kubernetes-addons-list", "canal,csi,dns,kube-proxy,openvpn,rbac,kubelet-configmap,default-storage-class,node-exporter,nodelocal-dns-cache", "Comma separated list of Addons to install into every user-cluster")
 	flag.StringVar(&c.openshiftAddonsList, "openshift-addons-list", "openvpn,rbac,crd,network,default-storage-class,registry", "Comma separated list of addons to install into every openshift user cluster")
 	flag.StringVar(&c.backupContainerFile, "backup-container", "", fmt.Sprintf("[Required] Filepath of a backup container yaml. It must mount a volume named %s from which it reads the etcd backups", backupcontroller.SharedVolumeName))
 	flag.StringVar(&c.cleanupContainerFile, "cleanup-container", "", "[Required] Filepath of a cleanup container yaml. The container will be used to cleanup the backup directory for a cluster after it got deleted.")

--- a/api/pkg/addon/template.go
+++ b/api/pkg/addon/template.go
@@ -33,13 +33,14 @@ func txtFuncMap(overwriteRegistry string) template.FuncMap {
 }
 
 type TemplateData struct {
-	Addon        *kubermaticv1.Addon
-	Kubeconfig   string
-	Cluster      *kubermaticv1.Cluster
-	Credentials  resources.Credentials
-	Variables    map[string]interface{}
-	DNSClusterIP string
-	ClusterCIDR  string
+	Addon             *kubermaticv1.Addon
+	Kubeconfig        string
+	MajorMinorVersion string
+	Cluster           *kubermaticv1.Cluster
+	Credentials       resources.Credentials
+	Variables         map[string]interface{}
+	DNSClusterIP      string
+	ClusterCIDR       string
 }
 
 func ParseFromFolder(log *zap.SugaredLogger, overwriteRegistry string, manifestPath string, data *TemplateData) ([]runtime.RawExtension, error) {

--- a/api/pkg/controller/seed-controller-manager/addon/addon_controller.go
+++ b/api/pkg/controller/seed-controller-manager/addon/addon_controller.go
@@ -287,13 +287,14 @@ func (r *Reconciler) getAddonManifests(log *zap.SugaredLogger, addon *kubermatic
 	}
 
 	data := &addonutils.TemplateData{
-		Variables:    make(map[string]interface{}),
-		Cluster:      cluster,
-		Credentials:  credentials,
-		Addon:        addon,
-		Kubeconfig:   string(kubeconfig),
-		DNSClusterIP: clusterIP,
-		ClusterCIDR:  cluster.Spec.ClusterNetwork.Pods.CIDRBlocks[0],
+		Variables:         make(map[string]interface{}),
+		Cluster:           cluster,
+		Credentials:       credentials,
+		MajorMinorVersion: cluster.Spec.Version.MajorMinor(),
+		Addon:             addon,
+		Kubeconfig:        string(kubeconfig),
+		DNSClusterIP:      clusterIP,
+		ClusterCIDR:       cluster.Spec.ClusterNetwork.Pods.CIDRBlocks[0],
 	}
 
 	// Add addon variables if available.

--- a/api/pkg/controller/seed-controller-manager/openshift/testdata/Kubermatic_API_image_is_overwritten-usercluster-controller.golden.yaml
+++ b/api/pkg/controller/seed-controller-manager/openshift/testdata/Kubermatic_API_image_is_overwritten-usercluster-controller.golden.yaml
@@ -23,6 +23,7 @@ spec:
       creationTimestamp: null
       labels:
         app: usercluster-controller
+        cloud-config-configmap-revision: ""
         cluster: test-cluster
         internal-admin-kubeconfig-secret-revision: ""
     spec:
@@ -72,6 +73,9 @@ spec:
         - mountPath: /etc/kubernetes/kubeconfig
           name: internal-admin-kubeconfig
           readOnly: true
+        - mountPath: /etc/kubernetes/cloud
+          name: cloud-config
+          readOnly: true
         - mountPath: /http-prober-bin
           name: http-prober-bin
       imagePullSecrets:
@@ -96,6 +100,10 @@ spec:
         secret:
           defaultMode: 420
           secretName: internal-admin-kubeconfig
+      - configMap:
+          defaultMode: 420
+          name: cloud-config
+        name: cloud-config
       - emptyDir: {}
         name: http-prober-bin
 status: {}

--- a/api/pkg/controller/seed-controller-manager/openshift/testdata/Kubermatic_API_image_is_overwritten-usercluster-controller.golden.yaml
+++ b/api/pkg/controller/seed-controller-manager/openshift/testdata/Kubermatic_API_image_is_overwritten-usercluster-controller.golden.yaml
@@ -39,7 +39,7 @@ spec:
         - -timeout
         - "1"
         - -command
-        - '{"command":"/usr/local/bin/user-cluster-controller-manager","args":["-kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","-metrics-listen-address","0.0.0.0:8085","-health-listen-address","0.0.0.0:8086","-namespace","$(NAMESPACE)","-cluster-url","https://test-cluster.alias-europe-west3-c.dev.kubermatic.io:0","-openvpn-server-port","0","-overwrite-registry","","-openshift=true","-version","4.1.9","-cloud-provider-name","","-openshift-console-callback-uri","https://dev.kubermatic.io/api/v1/projects//dc/alias-europe-west3-c/clusters/test-cluster/openshift/console/proxy/auth/callback"]}'
+        - '{"command":"/usr/local/bin/user-cluster-controller-manager","args":["-kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","-metrics-listen-address","0.0.0.0:8085","-health-listen-address","0.0.0.0:8086","-namespace","$(NAMESPACE)","-cluster-url","https://test-cluster.alias-europe-west3-c.dev.kubermatic.io:0","-cloud-config","/etc/kubernetes/cloud/config","-openvpn-server-port","0","-overwrite-registry","","-openshift=true","-version","4.1.9","-cloud-provider-name","","-openshift-console-callback-uri","https://dev.kubermatic.io/api/v1/projects//dc/alias-europe-west3-c/clusters/test-cluster/openshift/console/proxy/auth/callback"]}'
         command:
         - /http-prober-bin/http-prober
         env:

--- a/api/pkg/controller/user-cluster-controller-manager/nodelabel/node_label_controller.go
+++ b/api/pkg/controller/user-cluster-controller-manager/nodelabel/node_label_controller.go
@@ -1,0 +1,140 @@
+package nodelabel
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	"go.uber.org/zap"
+
+	"github.com/kubermatic/kubermatic/api/pkg/controller/user-cluster-controller-manager/nodelabel/resources"
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/client-go/util/retry"
+	ctrlruntimeclient "sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/controller"
+	"sigs.k8s.io/controller-runtime/pkg/event"
+	"sigs.k8s.io/controller-runtime/pkg/handler"
+	"sigs.k8s.io/controller-runtime/pkg/manager"
+	"sigs.k8s.io/controller-runtime/pkg/predicate"
+	"sigs.k8s.io/controller-runtime/pkg/reconcile"
+	"sigs.k8s.io/controller-runtime/pkg/source"
+)
+
+const (
+	// ControllerName is the name of the controller.
+	ControllerName = "kubermatic_node_label_controller"
+)
+
+// Reconciler is the node label
+type Reconciler struct {
+	log *zap.SugaredLogger
+	ctrlruntimeclient.Client
+}
+
+// Add adds the reconciler to the controller.
+func Add(log *zap.SugaredLogger, mgr manager.Manager) error {
+	reconciler := &Reconciler{
+		log:    log,
+		Client: mgr.GetClient(),
+	}
+
+	ctrlOpts := controller.Options{
+		Reconciler:              reconciler,
+		MaxConcurrentReconciles: 1,
+	}
+
+	c, err := controller.New(ControllerName, mgr, ctrlOpts)
+	if err != nil {
+		return err
+	}
+
+	predicates := predicate.Funcs{
+		UpdateFunc: func(e event.UpdateEvent) bool {
+			// TODO: Add proper func when they exist.
+			return true
+		},
+	}
+
+	return c.Watch(&source.Kind{Type: &corev1.Node{}}, &handler.EnqueueRequestForObject{}, predicates)
+}
+
+// Reconcile is the main reconcilliation loop for the controller.
+func (r *Reconciler) Reconcile(_ reconcile.Request) (reconcile.Result, error) {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	err := r.labelAllNodes(ctx)
+	if err != nil {
+		return reconcile.Result{}, fmt.Errorf("failed to ensure all nodes have the %s label: %v", resources.DistributionLabelKey, err)
+	}
+
+	return reconcile.Result{}, nil
+}
+
+func (r *Reconciler) labelAllNodes(ctx context.Context) error {
+	nodeList := &corev1.NodeList{}
+	if err := r.List(ctx, nodeList); err != nil {
+		return fmt.Errorf("failed to list nodes: %v", err)
+	}
+
+	for _, node := range nodeList.Items {
+		label, err := detectLabel(&node)
+		if err != nil {
+			return fmt.Errorf("could not detect label on node %q: %v", node.Name, err)
+		}
+		hasLabel := hasCorrectDistributionLabel(&node, label)
+
+		if !hasLabel {
+			err := r.applyLabel(ctx, &node, label)
+			if err != nil {
+				return fmt.Errorf("could not apply label on node %q: %v", node.Name, err)
+			}
+		}
+	}
+
+	return nil
+}
+
+func (r *Reconciler) applyLabel(ctx context.Context, node *corev1.Node, label string) error {
+	oldNode := node.DeepCopy()
+	if node.Labels == nil {
+		node.Labels = map[string]string{}
+	}
+	if node.Labels[resources.DistributionLabelKey] != label {
+		r.log.Debugf("Changing label %q from value %q to value %q", resources.DistributionLabelKey, node.Labels[resources.DistributionLabelKey], label)
+		node.Labels[resources.DistributionLabelKey] = label
+		if err := r.Client.Patch(ctx, node, ctrlruntimeclient.MergeFrom(oldNode)); err != nil {
+			return fmt.Errorf("failed to update node: %v", err)
+		}
+	}
+
+	r.log.Debug("No label changes, not updating node.")
+
+	if err := retry.RetryOnConflict(retry.DefaultBackoff, func() error {
+		newNode := &corev1.Node{}
+		if err := r.Get(ctx, types.NamespacedName{Name: node.Name}, newNode); err != nil {
+			return err
+		}
+
+		return r.Client.Update(ctx, newNode)
+	}); err != nil {
+		return fmt.Errorf("failed to update node %q: %v", node.Name, err)
+	}
+
+	return nil
+}
+
+func detectLabel(node *corev1.Node) (string, error) {
+	osImage := strings.ToLower(node.Status.NodeInfo.OSImage)
+	for k, v := range resources.OSLabelMatchValues {
+		if strings.Contains(osImage, v) {
+			return k, nil
+		}
+	}
+	return "", fmt.Errorf("Could not detect distribution from image name %s", node.Status.NodeInfo.OSImage)
+}
+
+func hasCorrectDistributionLabel(node *corev1.Node, label string) bool {
+	return node.Labels[resources.DistributionLabelKey] == label
+}

--- a/api/pkg/controller/user-cluster-controller-manager/nodelabel/resources/label.go
+++ b/api/pkg/controller/user-cluster-controller-manager/nodelabel/resources/label.go
@@ -1,0 +1,23 @@
+package resources
+
+const (
+	// DistributionLabelKey is the label that gets applied.
+	DistributionLabelKey = "kubermatic.io/distribution"
+
+	// CentOSLabelValue is the value of the label for CentOS
+	CentOSLabelValue = "centos"
+
+	// UbuntuLabelValue is the value of the label for Ubuntu
+	UbuntuLabelValue = "ubuntu"
+
+	// ContainerLinuxLabelValue is the value of the label for Container Linux
+	ContainerLinuxLabelValue = "container-linux"
+)
+
+// OSLabelMatchValues is a mapping between OS labels and the strings to match on in OSImage.
+// Note that these are all lower case.
+var OSLabelMatchValues = map[string]string{
+	CentOSLabelValue:         "centos",
+	UbuntuLabelValue:         "ubuntu",
+	ContainerLinuxLabelValue: "container linux",
+}

--- a/api/pkg/controller/user-cluster-controller-manager/resources/controller.go
+++ b/api/pkg/controller/user-cluster-controller-manager/resources/controller.go
@@ -54,6 +54,7 @@ func Add(
 	registerReconciledCheck func(name string, check healthcheck.Check),
 	cloudCredentialSecretTemplate *corev1.Secret,
 	openshiftConsoleCallbackURI string,
+	cloudConfig []byte,
 	log *zap.SugaredLogger) error {
 	r := &reconciler{
 		openshift:                     openshift,
@@ -63,6 +64,7 @@ func Add(
 		clusterURL:                    clusterURL,
 		openvpnServerPort:             openvpnServerPort,
 		cloudCredentialSecretTemplate: cloudCredentialSecretTemplate,
+		cloudConfig:                   cloudConfig,
 		log:                           log,
 		platform:                      cloudProviderName,
 		openshiftConsoleCallbackURI:   openshiftConsoleCallbackURI,
@@ -202,6 +204,7 @@ type reconciler struct {
 	platform                      string
 	cloudCredentialSecretTemplate *corev1.Secret
 	openshiftConsoleCallbackURI   string
+	cloudConfig                   []byte
 
 	rLock                      *sync.Mutex
 	reconciledSuccessfullyOnce bool

--- a/api/pkg/controller/user-cluster-controller-manager/resources/reconciler.go
+++ b/api/pkg/controller/user-cluster-controller-manager/resources/reconciler.go
@@ -19,6 +19,7 @@ import (
 	"github.com/kubermatic/kubermatic/api/pkg/controller/user-cluster-controller-manager/resources/resources/system-basic-user"
 	"github.com/kubermatic/kubermatic/api/pkg/controller/user-cluster-controller-manager/resources/resources/user-auth"
 	"github.com/kubermatic/kubermatic/api/pkg/controller/user-cluster-controller-manager/resources/resources/usersshkeys"
+	"github.com/kubermatic/kubermatic/api/pkg/controller/usercluster/resources/cloudcontroller"
 	"github.com/kubermatic/kubermatic/api/pkg/resources"
 	"github.com/kubermatic/kubermatic/api/pkg/resources/certificates/triple"
 	"github.com/kubermatic/kubermatic/api/pkg/resources/reconciling"
@@ -312,6 +313,7 @@ func (r *reconciler) reconcileClusterRoleBindings(ctx context.Context) error {
 		controllermanager.ClusterRoleBindingAuthDelegator(),
 		clusterautoscaler.ClusterRoleBindingCreator(),
 		systembasicuser.ClusterRoleBinding,
+		cloudcontroller.ClusterRoleBindingCreator(),
 	}
 
 	if r.openshift {
@@ -412,6 +414,10 @@ func (r *reconciler) reconcileSecrets(ctx context.Context, data reconcileData) e
 		if r.cloudCredentialSecretTemplate != nil {
 			creators = append(creators, openshift.CloudCredentialSecretCreator(*r.cloudCredentialSecretTemplate))
 		}
+	}
+
+	if len(r.cloudConfig) > 0 {
+		creators = append(creators, cloudcontroller.CloudConfig(r.cloudConfig))
 	}
 
 	if err := reconciling.ReconcileSecrets(ctx, creators, metav1.NamespaceSystem, r.Client); err != nil {

--- a/api/pkg/controller/usercluster/resources/cloudcontroller/clusterrolebinding.go
+++ b/api/pkg/controller/usercluster/resources/cloudcontroller/clusterrolebinding.go
@@ -1,0 +1,32 @@
+package cloudcontroller
+
+import (
+	"github.com/kubermatic/kubermatic/api/pkg/resources"
+	"github.com/kubermatic/kubermatic/api/pkg/resources/reconciling"
+	rbacv1 "k8s.io/api/rbac/v1"
+)
+
+// ClusterRoleBindingCreator returns a func to create/update the ClusterRoleBinding for external cloud controllers.
+func ClusterRoleBindingCreator() reconciling.NamedClusterRoleBindingCreatorGetter {
+	return func() (string, reconciling.ClusterRoleBindingCreator) {
+		return resources.CloudControllerManagerRoleBindingName, func(crb *rbacv1.ClusterRoleBinding) (*rbacv1.ClusterRoleBinding, error) {
+			crb.Labels = resources.BaseAppLabel(resources.CloudControllerManagerRoleBindingName, nil)
+
+			crb.RoleRef = rbacv1.RoleRef{
+				// Can probably be tightened up a bit but for now I'm following the documentation.
+				// https://kubernetes.io/docs/tasks/administer-cluster/running-cloud-controller/
+				Name:     "cluster-admin",
+				Kind:     "ClusterRole",
+				APIGroup: rbacv1.GroupName,
+			}
+			crb.Subjects = []rbacv1.Subject{
+				{
+					Kind:     "User",
+					Name:     resources.CloudControllerManagerCertUsername,
+					APIGroup: rbacv1.GroupName,
+				},
+			}
+			return crb, nil
+		}
+	}
+}

--- a/api/pkg/controller/usercluster/resources/cloudcontroller/secret.go
+++ b/api/pkg/controller/usercluster/resources/cloudcontroller/secret.go
@@ -1,0 +1,22 @@
+package cloudcontroller
+
+import (
+	"github.com/kubermatic/kubermatic/api/pkg/resources"
+	"github.com/kubermatic/kubermatic/api/pkg/resources/reconciling"
+	corev1 "k8s.io/api/core/v1"
+)
+
+// CloudConfig generates the cloud-config secret to be injected in the user cluster.
+func CloudConfig(cloudConfig []byte) reconciling.NamedSecretCreatorGetter {
+	return func() (string, reconciling.SecretCreator) {
+		return resources.CloudConfigSecretName, func(existing *corev1.Secret) (*corev1.Secret, error) {
+			existing.Name = resources.CloudConfigSecretName
+			if existing.Data == nil {
+				existing.Data = map[string][]byte{}
+			}
+			existing.Data[resources.CloudConfigSecretKey] = cloudConfig
+			return existing, nil
+		}
+
+	}
+}

--- a/api/pkg/crd/kubermatic/v1/cluster.go
+++ b/api/pkg/crd/kubermatic/v1/cluster.go
@@ -93,6 +93,9 @@ type ClusterSpec struct {
 
 	OIDC OIDCSettings `json:"oidc,omitempty"`
 
+	// Feature flags
+	Features map[string]bool `json:"features"`
+
 	// Openshift holds all openshift-specific settings
 	Openshift *Openshift `json:"openshift,omitempty"`
 

--- a/api/pkg/crd/kubermatic/v1/zz_generated.deepcopy.go
+++ b/api/pkg/crd/kubermatic/v1/zz_generated.deepcopy.go
@@ -556,6 +556,13 @@ func (in *ClusterSpec) DeepCopyInto(out *ClusterSpec) {
 	out.Version = in.Version.DeepCopy()
 	in.ComponentsOverride.DeepCopyInto(&out.ComponentsOverride)
 	out.OIDC = in.OIDC
+	if in.Features != nil {
+		in, out := &in.Features, &out.Features
+		*out = make(map[string]bool, len(*in))
+		for key, val := range *in {
+			(*out)[key] = val
+		}
+	}
 	if in.Openshift != nil {
 		in, out := &in.Openshift, &out.Openshift
 		*out = new(Openshift)

--- a/api/pkg/resources/apiserver/deployment.go
+++ b/api/pkg/resources/apiserver/deployment.go
@@ -300,7 +300,7 @@ func getApiserverFlags(data *resources.TemplateData, etcdEndpoints []string, ena
 	}
 
 	cloudProviderName := data.GetKubernetesCloudProviderName()
-	if cloudProviderName != "" {
+	if cloudProviderName != "" && cloudProviderName != "external" {
 		flags = append(flags, "--cloud-provider", cloudProviderName)
 		flags = append(flags, "--cloud-config", "/etc/kubernetes/cloud/config")
 	}

--- a/api/pkg/resources/cloudcontroller/deployment.go
+++ b/api/pkg/resources/cloudcontroller/deployment.go
@@ -1,0 +1,22 @@
+package cloudcontroller
+
+import (
+	"errors"
+
+	"github.com/kubermatic/kubermatic/api/pkg/resources"
+	"github.com/kubermatic/kubermatic/api/pkg/resources/reconciling"
+	appsv1 "k8s.io/api/apps/v1"
+)
+
+// DeploymentCreator returns the function to create and update the external cloud provider deployment.
+func DeploymentCreator(data *resources.TemplateData) reconciling.NamedDeploymentCreatorGetter {
+	if data.Cluster().Spec.Cloud.Openstack != nil {
+		return openStackDeploymentCreator(data)
+	}
+
+	return func() (name string, create reconciling.DeploymentCreator) {
+		return osName, func(dep *appsv1.Deployment) (*appsv1.Deployment, error) {
+			return nil, errors.New("unsupported external cloud controller")
+		}
+	}
+}

--- a/api/pkg/resources/cloudcontroller/openstack.go
+++ b/api/pkg/resources/cloudcontroller/openstack.go
@@ -1,0 +1,165 @@
+package cloudcontroller
+
+import (
+	"fmt"
+
+	"k8s.io/apimachinery/pkg/api/resource"
+
+	"github.com/kubermatic/kubermatic/api/pkg/resources"
+	"github.com/kubermatic/kubermatic/api/pkg/resources/reconciling"
+	"github.com/kubermatic/kubermatic/api/pkg/resources/vpnsidecar"
+	appsv1 "k8s.io/api/apps/v1"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+const (
+	osName = "openstack-cloud-controller-manager"
+)
+
+var (
+	osResourceRequirements = corev1.ResourceRequirements{
+		Requests: corev1.ResourceList{
+			corev1.ResourceMemory: resource.MustParse("100Mi"),
+			corev1.ResourceCPU:    resource.MustParse("100m"),
+		},
+		Limits: corev1.ResourceList{
+			corev1.ResourceMemory: resource.MustParse("512Mi"),
+			corev1.ResourceCPU:    resource.MustParse("500m"),
+		},
+	}
+)
+
+func openStackDeploymentCreator(data *resources.TemplateData) reconciling.NamedDeploymentCreatorGetter {
+	return func() (string, reconciling.DeploymentCreator) {
+		return osName, func(dep *appsv1.Deployment) (*appsv1.Deployment, error) {
+			dep.Name = osName
+			dep.Labels = resources.BaseAppLabel(osName, nil)
+
+			dep.Spec.Replicas = resources.Int32(1)
+
+			dep.Spec.Selector = &metav1.LabelSelector{
+				MatchLabels: resources.BaseAppLabel(osName, nil),
+			}
+
+			dep.Spec.Template.Spec.Volumes = getOSVolumes()
+
+			podLabels, err := data.GetPodTemplateLabels(osName, dep.Spec.Template.Spec.Volumes, nil)
+			if err != nil {
+				return nil, err
+			}
+
+			dep.Spec.Template.ObjectMeta = metav1.ObjectMeta{
+				Labels: podLabels,
+			}
+
+			dep.Spec.Template.Spec.DNSPolicy, dep.Spec.Template.Spec.DNSConfig, err =
+				resources.UserClusterDNSPolicyAndConfig(data)
+			if err != nil {
+				return nil, err
+			}
+
+			f := false
+			dep.Spec.Template.Spec.AutomountServiceAccountToken = &f
+
+			openvpnSidecar, err := vpnsidecar.OpenVPNSidecarContainer(data, "openvpn-client")
+			if err != nil {
+				return nil, fmt.Errorf("failed to get openvpn sidecar: %v", err)
+			}
+
+			osCloudProviderMounts := []corev1.VolumeMount{
+				{
+					Name:      resources.CloudControllerManagerKubeconfigSecretName,
+					MountPath: "/etc/kubernetes/kubeconfig",
+					ReadOnly:  true,
+				},
+				{
+					Name:      resources.CloudConfigConfigMapName,
+					MountPath: "/etc/kubernetes/cloud",
+					ReadOnly:  true,
+				},
+			}
+
+			version, err := getOSVersion(data)
+			if err != nil {
+				return nil, err
+			}
+			flags := getOSFlags(data)
+
+			dep.Spec.Template.Spec.Containers = []corev1.Container{
+				*openvpnSidecar,
+				{
+					Name:         osName,
+					Image:        data.ImageRegistry(resources.RegistryDocker) + "/k8scloudprovider/openstack-cloud-controller-manager:v" + version,
+					Command:      []string{"/bin/openstack-cloud-controller-manager"},
+					Args:         flags,
+					Resources:    osResourceRequirements,
+					VolumeMounts: osCloudProviderMounts,
+				},
+			}
+
+			return dep, nil
+		}
+	}
+}
+
+func getOSVolumes() []corev1.Volume {
+	return []corev1.Volume{
+		{
+			Name: resources.CloudConfigConfigMapName,
+			VolumeSource: corev1.VolumeSource{
+				ConfigMap: &corev1.ConfigMapVolumeSource{
+					LocalObjectReference: corev1.LocalObjectReference{
+						Name: resources.CloudConfigConfigMapName,
+					},
+				},
+			},
+		},
+		{
+			Name: resources.OpenVPNClientCertificatesSecretName,
+			VolumeSource: corev1.VolumeSource{
+				Secret: &corev1.SecretVolumeSource{
+					SecretName: resources.OpenVPNClientCertificatesSecretName,
+				},
+			},
+		},
+		{
+			Name: resources.CloudControllerManagerKubeconfigSecretName,
+			VolumeSource: corev1.VolumeSource{
+				Secret: &corev1.SecretVolumeSource{
+					SecretName: resources.CloudControllerManagerKubeconfigSecretName,
+				},
+			},
+		},
+	}
+}
+
+func getOSFlags(data *resources.TemplateData) []string {
+	flags := []string{
+		"--kubeconfig=/etc/kubernetes/kubeconfig/kubeconfig",
+		"--v=1",
+		"--cloud-config=/etc/kubernetes/cloud/config",
+		"--cloud-provider=openstack",
+	}
+	return flags
+}
+
+func getOSVersion(data *resources.TemplateData) (string, error) {
+	switch x := data.Cluster().Spec.Version.MajorMinor(); x {
+	case "1.16":
+		return "1.16.0", nil
+	default:
+		return "", fmt.Errorf("kubernetes version %s not supported", x)
+	}
+}
+
+// OpenStackCloudControllerSupported checks if this version of Kubernetes is supported
+// by our implementation of the external cloud controller.
+// This is not called for now, but it's here so we can use it later to automagically
+// enable external cloud controller support for supported versions.
+func OpenStackCloudControllerSupported(data *resources.TemplateData) bool {
+	if _, err := getOSVersion(data); err != nil {
+		return false
+	}
+	return true
+}

--- a/api/pkg/resources/data.go
+++ b/api/pkg/resources/data.go
@@ -333,6 +333,9 @@ func GetKubernetesCloudProviderName(cluster *kubermaticv1.Cluster) string {
 		return "aws"
 	}
 	if cluster.Spec.Cloud.Openstack != nil {
+		if flag := cluster.Spec.Features[FeatureNameExternalCloudProvider]; flag {
+			return "external"
+		}
 		return "openstack"
 	}
 	if cluster.Spec.Cloud.VSphere != nil {

--- a/api/pkg/resources/resources.go
+++ b/api/pkg/resources/resources.go
@@ -117,6 +117,8 @@ const (
 	ControllerManagerKubeconfigSecretName = "controllermanager-kubeconfig"
 	//MachineControllerKubeconfigSecretName is the name for the secret containing the kubeconfig used by the machinecontroller
 	MachineControllerKubeconfigSecretName = "machinecontroller-kubeconfig"
+	//CloudControllerManagerKubeconfigSecretName is the name for the secret containing the kubeconfig used by the external cloud provider
+	CloudControllerManagerKubeconfigSecretName = "cloud-controller-manager-kubeconfig"
 	//MachineControllerWebhookServingCertSecretName is the name for the secret containing the serving cert for the
 	//machine-controller webhook
 	MachineControllerWebhookServingCertSecretName = "machinecontroller-webhook-serving-cert"
@@ -155,6 +157,8 @@ const (
 	OpenVPNServerCertificatesSecretName = "openvpn-server-certificates"
 	//OpenVPNClientCertificatesSecretName is the name for the secret containing the openvpn client certificates
 	OpenVPNClientCertificatesSecretName = "openvpn-client-certificates"
+	//CloudConfigSecretName is the name for the secret containing the cloud-config inside the user cluster.
+	CloudConfigSecretName = "cloud-config"
 	//EtcdTLSCertificateSecretName is the name for the secret containing the etcd tls certificate used for transport security
 	EtcdTLSCertificateSecretName = "etcd-tls-certificate"
 	//ApiserverEtcdClientCertificateSecretName is the name for the secret containing the client certificate used by the apiserver for authenticating against etcd
@@ -200,6 +204,9 @@ const (
 	//PrometheusRoleBindingName is the name for the Prometheus rolebinding
 	PrometheusRoleBindingName = "prometheus"
 
+	//CloudControllerManagerRoleBindingName is the name for the cloud controller manager rolebinding.
+	CloudControllerManagerRoleBindingName = "cloud-controller-manager"
+
 	//MachineControllerCertUsername is the name of the user coming from kubeconfig cert
 	MachineControllerCertUsername = "machine-controller"
 	//KubeStateMetricsCertUsername is the name of the user coming from kubeconfig cert
@@ -208,6 +215,8 @@ const (
 	MetricsServerCertUsername = "metrics-server"
 	//ControllerManagerCertUsername is the name of the user coming from kubeconfig cert
 	ControllerManagerCertUsername = "system:kube-controller-manager"
+	//CloudControllerManagerCertUsername is the name of the user coming from kubeconfig cert
+	CloudControllerManagerCertUsername = "system:cloud-controller-manager"
 	//SchedulerCertUsername is the name of the user coming from kubeconfig cert
 	SchedulerCertUsername = "system:kube-scheduler"
 	//KubeletDnatControllerCertUsername is the name of the user coming from kubeconfig cert
@@ -330,6 +339,11 @@ const (
 	IPVSProxyMode = "ipvs"
 	// IPTablesProxyMode defines the iptables kube-proxy mode.
 	IPTablesProxyMode = "iptables"
+
+	// Feature flags, maybe move inside own const block.
+
+	// FeatureNameExternalCloudProvider enables external cloud provider support.
+	FeatureNameExternalCloudProvider = "externalCloudProvider"
 )
 
 const (
@@ -401,6 +415,9 @@ const (
 	ServingCertSecretKey = "serving.crt"
 	// ServingCertKeySecretKey is the secret key for the key of a generic serving cert
 	ServingCertKeySecretKey = "serving.key"
+
+	// CloudConfigSecretKey is the secret key for cloud-config
+	CloudConfigSecretKey = "config"
 )
 
 const (

--- a/api/pkg/resources/test/fixtures/deployment-aws-1.10.0-usercluster-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-aws-1.10.0-usercluster-controller.yaml
@@ -22,6 +22,7 @@ spec:
       creationTimestamp: null
       labels:
         app: usercluster-controller
+        cloud-config-configmap-revision: "123456"
         cluster: de-test-01
         internal-admin-kubeconfig-secret-revision: "123456"
     spec:
@@ -37,7 +38,7 @@ spec:
         - -timeout
         - "1"
         - -command
-        - '{"command":"/usr/local/bin/user-cluster-controller-manager","args":["-kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","-metrics-listen-address","0.0.0.0:8085","-health-listen-address","0.0.0.0:8086","-namespace","$(NAMESPACE)","-cluster-url","","-openvpn-server-port","30003","-overwrite-registry","","-openshift=false","-version","1.10.0","-cloud-provider-name","aws","--ipam-controller-network","192.168.1.1/24,192.168.1.1,8.8.8.8","-node-labels","{\"my-label\":\"my-value\"}"]}'
+        - '{"command":"/usr/local/bin/user-cluster-controller-manager","args":["-kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","-metrics-listen-address","0.0.0.0:8085","-health-listen-address","0.0.0.0:8086","-namespace","$(NAMESPACE)","-cluster-url","","-cloud-config","/etc/kubernetes/cloud/config","-openvpn-server-port","30003","-overwrite-registry","","-openshift=false","-version","1.10.0","-cloud-provider-name","aws","--ipam-controller-network","192.168.1.1/24,192.168.1.1,8.8.8.8","-node-labels","{\"my-label\":\"my-value\"}"]}'
         command:
         - /http-prober-bin/http-prober
         env:
@@ -68,6 +69,9 @@ spec:
         - mountPath: /etc/kubernetes/kubeconfig
           name: internal-admin-kubeconfig
           readOnly: true
+        - mountPath: /etc/kubernetes/cloud
+          name: cloud-config
+          readOnly: true
         - mountPath: /http-prober-bin
           name: http-prober-bin
       imagePullSecrets:
@@ -88,6 +92,9 @@ spec:
       - name: internal-admin-kubeconfig
         secret:
           secretName: internal-admin-kubeconfig
+      - configMap:
+          name: cloud-config
+        name: cloud-config
       - emptyDir: {}
         name: http-prober-bin
 status: {}

--- a/api/pkg/resources/test/fixtures/deployment-aws-1.10.6-usercluster-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-aws-1.10.6-usercluster-controller.yaml
@@ -22,6 +22,7 @@ spec:
       creationTimestamp: null
       labels:
         app: usercluster-controller
+        cloud-config-configmap-revision: "123456"
         cluster: de-test-01
         internal-admin-kubeconfig-secret-revision: "123456"
     spec:
@@ -37,7 +38,7 @@ spec:
         - -timeout
         - "1"
         - -command
-        - '{"command":"/usr/local/bin/user-cluster-controller-manager","args":["-kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","-metrics-listen-address","0.0.0.0:8085","-health-listen-address","0.0.0.0:8086","-namespace","$(NAMESPACE)","-cluster-url","","-openvpn-server-port","30003","-overwrite-registry","","-openshift=false","-version","1.10.6","-cloud-provider-name","aws","--ipam-controller-network","192.168.1.1/24,192.168.1.1,8.8.8.8","-node-labels","{\"my-label\":\"my-value\"}"]}'
+        - '{"command":"/usr/local/bin/user-cluster-controller-manager","args":["-kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","-metrics-listen-address","0.0.0.0:8085","-health-listen-address","0.0.0.0:8086","-namespace","$(NAMESPACE)","-cluster-url","","-cloud-config","/etc/kubernetes/cloud/config","-openvpn-server-port","30003","-overwrite-registry","","-openshift=false","-version","1.10.6","-cloud-provider-name","aws","--ipam-controller-network","192.168.1.1/24,192.168.1.1,8.8.8.8","-node-labels","{\"my-label\":\"my-value\"}"]}'
         command:
         - /http-prober-bin/http-prober
         env:
@@ -68,6 +69,9 @@ spec:
         - mountPath: /etc/kubernetes/kubeconfig
           name: internal-admin-kubeconfig
           readOnly: true
+        - mountPath: /etc/kubernetes/cloud
+          name: cloud-config
+          readOnly: true
         - mountPath: /http-prober-bin
           name: http-prober-bin
       imagePullSecrets:
@@ -88,6 +92,9 @@ spec:
       - name: internal-admin-kubeconfig
         secret:
           secretName: internal-admin-kubeconfig
+      - configMap:
+          name: cloud-config
+        name: cloud-config
       - emptyDir: {}
         name: http-prober-bin
 status: {}

--- a/api/pkg/resources/test/fixtures/deployment-aws-1.11.0-usercluster-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-aws-1.11.0-usercluster-controller.yaml
@@ -22,6 +22,7 @@ spec:
       creationTimestamp: null
       labels:
         app: usercluster-controller
+        cloud-config-configmap-revision: "123456"
         cluster: de-test-01
         internal-admin-kubeconfig-secret-revision: "123456"
     spec:
@@ -37,7 +38,7 @@ spec:
         - -timeout
         - "1"
         - -command
-        - '{"command":"/usr/local/bin/user-cluster-controller-manager","args":["-kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","-metrics-listen-address","0.0.0.0:8085","-health-listen-address","0.0.0.0:8086","-namespace","$(NAMESPACE)","-cluster-url","","-openvpn-server-port","30003","-overwrite-registry","","-openshift=false","-version","1.11.0","-cloud-provider-name","aws","--ipam-controller-network","192.168.1.1/24,192.168.1.1,8.8.8.8","-node-labels","{\"my-label\":\"my-value\"}"]}'
+        - '{"command":"/usr/local/bin/user-cluster-controller-manager","args":["-kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","-metrics-listen-address","0.0.0.0:8085","-health-listen-address","0.0.0.0:8086","-namespace","$(NAMESPACE)","-cluster-url","","-cloud-config","/etc/kubernetes/cloud/config","-openvpn-server-port","30003","-overwrite-registry","","-openshift=false","-version","1.11.0","-cloud-provider-name","aws","--ipam-controller-network","192.168.1.1/24,192.168.1.1,8.8.8.8","-node-labels","{\"my-label\":\"my-value\"}"]}'
         command:
         - /http-prober-bin/http-prober
         env:
@@ -68,6 +69,9 @@ spec:
         - mountPath: /etc/kubernetes/kubeconfig
           name: internal-admin-kubeconfig
           readOnly: true
+        - mountPath: /etc/kubernetes/cloud
+          name: cloud-config
+          readOnly: true
         - mountPath: /http-prober-bin
           name: http-prober-bin
       imagePullSecrets:
@@ -88,6 +92,9 @@ spec:
       - name: internal-admin-kubeconfig
         secret:
           secretName: internal-admin-kubeconfig
+      - configMap:
+          name: cloud-config
+        name: cloud-config
       - emptyDir: {}
         name: http-prober-bin
 status: {}

--- a/api/pkg/resources/test/fixtures/deployment-aws-1.11.1-usercluster-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-aws-1.11.1-usercluster-controller.yaml
@@ -22,6 +22,7 @@ spec:
       creationTimestamp: null
       labels:
         app: usercluster-controller
+        cloud-config-configmap-revision: "123456"
         cluster: de-test-01
         internal-admin-kubeconfig-secret-revision: "123456"
     spec:
@@ -37,7 +38,7 @@ spec:
         - -timeout
         - "1"
         - -command
-        - '{"command":"/usr/local/bin/user-cluster-controller-manager","args":["-kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","-metrics-listen-address","0.0.0.0:8085","-health-listen-address","0.0.0.0:8086","-namespace","$(NAMESPACE)","-cluster-url","","-openvpn-server-port","30003","-overwrite-registry","","-openshift=false","-version","1.11.1","-cloud-provider-name","aws","--ipam-controller-network","192.168.1.1/24,192.168.1.1,8.8.8.8","-node-labels","{\"my-label\":\"my-value\"}"]}'
+        - '{"command":"/usr/local/bin/user-cluster-controller-manager","args":["-kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","-metrics-listen-address","0.0.0.0:8085","-health-listen-address","0.0.0.0:8086","-namespace","$(NAMESPACE)","-cluster-url","","-cloud-config","/etc/kubernetes/cloud/config","-openvpn-server-port","30003","-overwrite-registry","","-openshift=false","-version","1.11.1","-cloud-provider-name","aws","--ipam-controller-network","192.168.1.1/24,192.168.1.1,8.8.8.8","-node-labels","{\"my-label\":\"my-value\"}"]}'
         command:
         - /http-prober-bin/http-prober
         env:
@@ -68,6 +69,9 @@ spec:
         - mountPath: /etc/kubernetes/kubeconfig
           name: internal-admin-kubeconfig
           readOnly: true
+        - mountPath: /etc/kubernetes/cloud
+          name: cloud-config
+          readOnly: true
         - mountPath: /http-prober-bin
           name: http-prober-bin
       imagePullSecrets:
@@ -88,6 +92,9 @@ spec:
       - name: internal-admin-kubeconfig
         secret:
           secretName: internal-admin-kubeconfig
+      - configMap:
+          name: cloud-config
+        name: cloud-config
       - emptyDir: {}
         name: http-prober-bin
 status: {}

--- a/api/pkg/resources/test/fixtures/deployment-aws-1.12.0-usercluster-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-aws-1.12.0-usercluster-controller.yaml
@@ -22,6 +22,7 @@ spec:
       creationTimestamp: null
       labels:
         app: usercluster-controller
+        cloud-config-configmap-revision: "123456"
         cluster: de-test-01
         internal-admin-kubeconfig-secret-revision: "123456"
     spec:
@@ -37,7 +38,7 @@ spec:
         - -timeout
         - "1"
         - -command
-        - '{"command":"/usr/local/bin/user-cluster-controller-manager","args":["-kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","-metrics-listen-address","0.0.0.0:8085","-health-listen-address","0.0.0.0:8086","-namespace","$(NAMESPACE)","-cluster-url","","-openvpn-server-port","30003","-overwrite-registry","","-openshift=false","-version","1.12.0","-cloud-provider-name","aws","--ipam-controller-network","192.168.1.1/24,192.168.1.1,8.8.8.8","-node-labels","{\"my-label\":\"my-value\"}"]}'
+        - '{"command":"/usr/local/bin/user-cluster-controller-manager","args":["-kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","-metrics-listen-address","0.0.0.0:8085","-health-listen-address","0.0.0.0:8086","-namespace","$(NAMESPACE)","-cluster-url","","-cloud-config","/etc/kubernetes/cloud/config","-openvpn-server-port","30003","-overwrite-registry","","-openshift=false","-version","1.12.0","-cloud-provider-name","aws","--ipam-controller-network","192.168.1.1/24,192.168.1.1,8.8.8.8","-node-labels","{\"my-label\":\"my-value\"}"]}'
         command:
         - /http-prober-bin/http-prober
         env:
@@ -68,6 +69,9 @@ spec:
         - mountPath: /etc/kubernetes/kubeconfig
           name: internal-admin-kubeconfig
           readOnly: true
+        - mountPath: /etc/kubernetes/cloud
+          name: cloud-config
+          readOnly: true
         - mountPath: /http-prober-bin
           name: http-prober-bin
       imagePullSecrets:
@@ -88,6 +92,9 @@ spec:
       - name: internal-admin-kubeconfig
         secret:
           secretName: internal-admin-kubeconfig
+      - configMap:
+          name: cloud-config
+        name: cloud-config
       - emptyDir: {}
         name: http-prober-bin
 status: {}

--- a/api/pkg/resources/test/fixtures/deployment-aws-1.13.0-usercluster-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-aws-1.13.0-usercluster-controller.yaml
@@ -22,6 +22,7 @@ spec:
       creationTimestamp: null
       labels:
         app: usercluster-controller
+        cloud-config-configmap-revision: "123456"
         cluster: de-test-01
         internal-admin-kubeconfig-secret-revision: "123456"
     spec:
@@ -37,7 +38,7 @@ spec:
         - -timeout
         - "1"
         - -command
-        - '{"command":"/usr/local/bin/user-cluster-controller-manager","args":["-kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","-metrics-listen-address","0.0.0.0:8085","-health-listen-address","0.0.0.0:8086","-namespace","$(NAMESPACE)","-cluster-url","","-openvpn-server-port","30003","-overwrite-registry","","-openshift=false","-version","1.13.0","-cloud-provider-name","aws","--ipam-controller-network","192.168.1.1/24,192.168.1.1,8.8.8.8","-node-labels","{\"my-label\":\"my-value\"}"]}'
+        - '{"command":"/usr/local/bin/user-cluster-controller-manager","args":["-kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","-metrics-listen-address","0.0.0.0:8085","-health-listen-address","0.0.0.0:8086","-namespace","$(NAMESPACE)","-cluster-url","","-cloud-config","/etc/kubernetes/cloud/config","-openvpn-server-port","30003","-overwrite-registry","","-openshift=false","-version","1.13.0","-cloud-provider-name","aws","--ipam-controller-network","192.168.1.1/24,192.168.1.1,8.8.8.8","-node-labels","{\"my-label\":\"my-value\"}"]}'
         command:
         - /http-prober-bin/http-prober
         env:
@@ -68,6 +69,9 @@ spec:
         - mountPath: /etc/kubernetes/kubeconfig
           name: internal-admin-kubeconfig
           readOnly: true
+        - mountPath: /etc/kubernetes/cloud
+          name: cloud-config
+          readOnly: true
         - mountPath: /http-prober-bin
           name: http-prober-bin
       imagePullSecrets:
@@ -88,6 +92,9 @@ spec:
       - name: internal-admin-kubeconfig
         secret:
           secretName: internal-admin-kubeconfig
+      - configMap:
+          name: cloud-config
+        name: cloud-config
       - emptyDir: {}
         name: http-prober-bin
 status: {}

--- a/api/pkg/resources/test/fixtures/deployment-azure-1.10.0-usercluster-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-azure-1.10.0-usercluster-controller.yaml
@@ -22,6 +22,7 @@ spec:
       creationTimestamp: null
       labels:
         app: usercluster-controller
+        cloud-config-configmap-revision: "123456"
         cluster: de-test-01
         internal-admin-kubeconfig-secret-revision: "123456"
     spec:
@@ -37,7 +38,7 @@ spec:
         - -timeout
         - "1"
         - -command
-        - '{"command":"/usr/local/bin/user-cluster-controller-manager","args":["-kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","-metrics-listen-address","0.0.0.0:8085","-health-listen-address","0.0.0.0:8086","-namespace","$(NAMESPACE)","-cluster-url","","-openvpn-server-port","30003","-overwrite-registry","","-openshift=false","-version","1.10.0","-cloud-provider-name","azure","--ipam-controller-network","192.168.1.1/24,192.168.1.1,8.8.8.8","-node-labels","{\"my-label\":\"my-value\"}"]}'
+        - '{"command":"/usr/local/bin/user-cluster-controller-manager","args":["-kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","-metrics-listen-address","0.0.0.0:8085","-health-listen-address","0.0.0.0:8086","-namespace","$(NAMESPACE)","-cluster-url","","-cloud-config","/etc/kubernetes/cloud/config","-openvpn-server-port","30003","-overwrite-registry","","-openshift=false","-version","1.10.0","-cloud-provider-name","azure","--ipam-controller-network","192.168.1.1/24,192.168.1.1,8.8.8.8","-node-labels","{\"my-label\":\"my-value\"}"]}'
         command:
         - /http-prober-bin/http-prober
         env:
@@ -68,6 +69,9 @@ spec:
         - mountPath: /etc/kubernetes/kubeconfig
           name: internal-admin-kubeconfig
           readOnly: true
+        - mountPath: /etc/kubernetes/cloud
+          name: cloud-config
+          readOnly: true
         - mountPath: /http-prober-bin
           name: http-prober-bin
       imagePullSecrets:
@@ -88,6 +92,9 @@ spec:
       - name: internal-admin-kubeconfig
         secret:
           secretName: internal-admin-kubeconfig
+      - configMap:
+          name: cloud-config
+        name: cloud-config
       - emptyDir: {}
         name: http-prober-bin
 status: {}

--- a/api/pkg/resources/test/fixtures/deployment-azure-1.10.6-usercluster-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-azure-1.10.6-usercluster-controller.yaml
@@ -22,6 +22,7 @@ spec:
       creationTimestamp: null
       labels:
         app: usercluster-controller
+        cloud-config-configmap-revision: "123456"
         cluster: de-test-01
         internal-admin-kubeconfig-secret-revision: "123456"
     spec:
@@ -37,7 +38,7 @@ spec:
         - -timeout
         - "1"
         - -command
-        - '{"command":"/usr/local/bin/user-cluster-controller-manager","args":["-kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","-metrics-listen-address","0.0.0.0:8085","-health-listen-address","0.0.0.0:8086","-namespace","$(NAMESPACE)","-cluster-url","","-openvpn-server-port","30003","-overwrite-registry","","-openshift=false","-version","1.10.6","-cloud-provider-name","azure","--ipam-controller-network","192.168.1.1/24,192.168.1.1,8.8.8.8","-node-labels","{\"my-label\":\"my-value\"}"]}'
+        - '{"command":"/usr/local/bin/user-cluster-controller-manager","args":["-kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","-metrics-listen-address","0.0.0.0:8085","-health-listen-address","0.0.0.0:8086","-namespace","$(NAMESPACE)","-cluster-url","","-cloud-config","/etc/kubernetes/cloud/config","-openvpn-server-port","30003","-overwrite-registry","","-openshift=false","-version","1.10.6","-cloud-provider-name","azure","--ipam-controller-network","192.168.1.1/24,192.168.1.1,8.8.8.8","-node-labels","{\"my-label\":\"my-value\"}"]}'
         command:
         - /http-prober-bin/http-prober
         env:
@@ -68,6 +69,9 @@ spec:
         - mountPath: /etc/kubernetes/kubeconfig
           name: internal-admin-kubeconfig
           readOnly: true
+        - mountPath: /etc/kubernetes/cloud
+          name: cloud-config
+          readOnly: true
         - mountPath: /http-prober-bin
           name: http-prober-bin
       imagePullSecrets:
@@ -88,6 +92,9 @@ spec:
       - name: internal-admin-kubeconfig
         secret:
           secretName: internal-admin-kubeconfig
+      - configMap:
+          name: cloud-config
+        name: cloud-config
       - emptyDir: {}
         name: http-prober-bin
 status: {}

--- a/api/pkg/resources/test/fixtures/deployment-azure-1.11.0-usercluster-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-azure-1.11.0-usercluster-controller.yaml
@@ -22,6 +22,7 @@ spec:
       creationTimestamp: null
       labels:
         app: usercluster-controller
+        cloud-config-configmap-revision: "123456"
         cluster: de-test-01
         internal-admin-kubeconfig-secret-revision: "123456"
     spec:
@@ -37,7 +38,7 @@ spec:
         - -timeout
         - "1"
         - -command
-        - '{"command":"/usr/local/bin/user-cluster-controller-manager","args":["-kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","-metrics-listen-address","0.0.0.0:8085","-health-listen-address","0.0.0.0:8086","-namespace","$(NAMESPACE)","-cluster-url","","-openvpn-server-port","30003","-overwrite-registry","","-openshift=false","-version","1.11.0","-cloud-provider-name","azure","--ipam-controller-network","192.168.1.1/24,192.168.1.1,8.8.8.8","-node-labels","{\"my-label\":\"my-value\"}"]}'
+        - '{"command":"/usr/local/bin/user-cluster-controller-manager","args":["-kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","-metrics-listen-address","0.0.0.0:8085","-health-listen-address","0.0.0.0:8086","-namespace","$(NAMESPACE)","-cluster-url","","-cloud-config","/etc/kubernetes/cloud/config","-openvpn-server-port","30003","-overwrite-registry","","-openshift=false","-version","1.11.0","-cloud-provider-name","azure","--ipam-controller-network","192.168.1.1/24,192.168.1.1,8.8.8.8","-node-labels","{\"my-label\":\"my-value\"}"]}'
         command:
         - /http-prober-bin/http-prober
         env:
@@ -68,6 +69,9 @@ spec:
         - mountPath: /etc/kubernetes/kubeconfig
           name: internal-admin-kubeconfig
           readOnly: true
+        - mountPath: /etc/kubernetes/cloud
+          name: cloud-config
+          readOnly: true
         - mountPath: /http-prober-bin
           name: http-prober-bin
       imagePullSecrets:
@@ -88,6 +92,9 @@ spec:
       - name: internal-admin-kubeconfig
         secret:
           secretName: internal-admin-kubeconfig
+      - configMap:
+          name: cloud-config
+        name: cloud-config
       - emptyDir: {}
         name: http-prober-bin
 status: {}

--- a/api/pkg/resources/test/fixtures/deployment-azure-1.11.1-usercluster-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-azure-1.11.1-usercluster-controller.yaml
@@ -22,6 +22,7 @@ spec:
       creationTimestamp: null
       labels:
         app: usercluster-controller
+        cloud-config-configmap-revision: "123456"
         cluster: de-test-01
         internal-admin-kubeconfig-secret-revision: "123456"
     spec:
@@ -37,7 +38,7 @@ spec:
         - -timeout
         - "1"
         - -command
-        - '{"command":"/usr/local/bin/user-cluster-controller-manager","args":["-kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","-metrics-listen-address","0.0.0.0:8085","-health-listen-address","0.0.0.0:8086","-namespace","$(NAMESPACE)","-cluster-url","","-openvpn-server-port","30003","-overwrite-registry","","-openshift=false","-version","1.11.1","-cloud-provider-name","azure","--ipam-controller-network","192.168.1.1/24,192.168.1.1,8.8.8.8","-node-labels","{\"my-label\":\"my-value\"}"]}'
+        - '{"command":"/usr/local/bin/user-cluster-controller-manager","args":["-kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","-metrics-listen-address","0.0.0.0:8085","-health-listen-address","0.0.0.0:8086","-namespace","$(NAMESPACE)","-cluster-url","","-cloud-config","/etc/kubernetes/cloud/config","-openvpn-server-port","30003","-overwrite-registry","","-openshift=false","-version","1.11.1","-cloud-provider-name","azure","--ipam-controller-network","192.168.1.1/24,192.168.1.1,8.8.8.8","-node-labels","{\"my-label\":\"my-value\"}"]}'
         command:
         - /http-prober-bin/http-prober
         env:
@@ -68,6 +69,9 @@ spec:
         - mountPath: /etc/kubernetes/kubeconfig
           name: internal-admin-kubeconfig
           readOnly: true
+        - mountPath: /etc/kubernetes/cloud
+          name: cloud-config
+          readOnly: true
         - mountPath: /http-prober-bin
           name: http-prober-bin
       imagePullSecrets:
@@ -88,6 +92,9 @@ spec:
       - name: internal-admin-kubeconfig
         secret:
           secretName: internal-admin-kubeconfig
+      - configMap:
+          name: cloud-config
+        name: cloud-config
       - emptyDir: {}
         name: http-prober-bin
 status: {}

--- a/api/pkg/resources/test/fixtures/deployment-azure-1.12.0-usercluster-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-azure-1.12.0-usercluster-controller.yaml
@@ -22,6 +22,7 @@ spec:
       creationTimestamp: null
       labels:
         app: usercluster-controller
+        cloud-config-configmap-revision: "123456"
         cluster: de-test-01
         internal-admin-kubeconfig-secret-revision: "123456"
     spec:
@@ -37,7 +38,7 @@ spec:
         - -timeout
         - "1"
         - -command
-        - '{"command":"/usr/local/bin/user-cluster-controller-manager","args":["-kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","-metrics-listen-address","0.0.0.0:8085","-health-listen-address","0.0.0.0:8086","-namespace","$(NAMESPACE)","-cluster-url","","-openvpn-server-port","30003","-overwrite-registry","","-openshift=false","-version","1.12.0","-cloud-provider-name","azure","--ipam-controller-network","192.168.1.1/24,192.168.1.1,8.8.8.8","-node-labels","{\"my-label\":\"my-value\"}"]}'
+        - '{"command":"/usr/local/bin/user-cluster-controller-manager","args":["-kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","-metrics-listen-address","0.0.0.0:8085","-health-listen-address","0.0.0.0:8086","-namespace","$(NAMESPACE)","-cluster-url","","-cloud-config","/etc/kubernetes/cloud/config","-openvpn-server-port","30003","-overwrite-registry","","-openshift=false","-version","1.12.0","-cloud-provider-name","azure","--ipam-controller-network","192.168.1.1/24,192.168.1.1,8.8.8.8","-node-labels","{\"my-label\":\"my-value\"}"]}'
         command:
         - /http-prober-bin/http-prober
         env:
@@ -68,6 +69,9 @@ spec:
         - mountPath: /etc/kubernetes/kubeconfig
           name: internal-admin-kubeconfig
           readOnly: true
+        - mountPath: /etc/kubernetes/cloud
+          name: cloud-config
+          readOnly: true
         - mountPath: /http-prober-bin
           name: http-prober-bin
       imagePullSecrets:
@@ -88,6 +92,9 @@ spec:
       - name: internal-admin-kubeconfig
         secret:
           secretName: internal-admin-kubeconfig
+      - configMap:
+          name: cloud-config
+        name: cloud-config
       - emptyDir: {}
         name: http-prober-bin
 status: {}

--- a/api/pkg/resources/test/fixtures/deployment-azure-1.13.0-usercluster-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-azure-1.13.0-usercluster-controller.yaml
@@ -22,6 +22,7 @@ spec:
       creationTimestamp: null
       labels:
         app: usercluster-controller
+        cloud-config-configmap-revision: "123456"
         cluster: de-test-01
         internal-admin-kubeconfig-secret-revision: "123456"
     spec:
@@ -37,7 +38,7 @@ spec:
         - -timeout
         - "1"
         - -command
-        - '{"command":"/usr/local/bin/user-cluster-controller-manager","args":["-kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","-metrics-listen-address","0.0.0.0:8085","-health-listen-address","0.0.0.0:8086","-namespace","$(NAMESPACE)","-cluster-url","","-openvpn-server-port","30003","-overwrite-registry","","-openshift=false","-version","1.13.0","-cloud-provider-name","azure","--ipam-controller-network","192.168.1.1/24,192.168.1.1,8.8.8.8","-node-labels","{\"my-label\":\"my-value\"}"]}'
+        - '{"command":"/usr/local/bin/user-cluster-controller-manager","args":["-kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","-metrics-listen-address","0.0.0.0:8085","-health-listen-address","0.0.0.0:8086","-namespace","$(NAMESPACE)","-cluster-url","","-cloud-config","/etc/kubernetes/cloud/config","-openvpn-server-port","30003","-overwrite-registry","","-openshift=false","-version","1.13.0","-cloud-provider-name","azure","--ipam-controller-network","192.168.1.1/24,192.168.1.1,8.8.8.8","-node-labels","{\"my-label\":\"my-value\"}"]}'
         command:
         - /http-prober-bin/http-prober
         env:
@@ -68,6 +69,9 @@ spec:
         - mountPath: /etc/kubernetes/kubeconfig
           name: internal-admin-kubeconfig
           readOnly: true
+        - mountPath: /etc/kubernetes/cloud
+          name: cloud-config
+          readOnly: true
         - mountPath: /http-prober-bin
           name: http-prober-bin
       imagePullSecrets:
@@ -88,6 +92,9 @@ spec:
       - name: internal-admin-kubeconfig
         secret:
           secretName: internal-admin-kubeconfig
+      - configMap:
+          name: cloud-config
+        name: cloud-config
       - emptyDir: {}
         name: http-prober-bin
 status: {}

--- a/api/pkg/resources/test/fixtures/deployment-bringyourown-1.10.0-usercluster-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-bringyourown-1.10.0-usercluster-controller.yaml
@@ -22,6 +22,7 @@ spec:
       creationTimestamp: null
       labels:
         app: usercluster-controller
+        cloud-config-configmap-revision: "123456"
         cluster: de-test-01
         internal-admin-kubeconfig-secret-revision: "123456"
     spec:
@@ -37,7 +38,7 @@ spec:
         - -timeout
         - "1"
         - -command
-        - '{"command":"/usr/local/bin/user-cluster-controller-manager","args":["-kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","-metrics-listen-address","0.0.0.0:8085","-health-listen-address","0.0.0.0:8086","-namespace","$(NAMESPACE)","-cluster-url","","-openvpn-server-port","30003","-overwrite-registry","","-openshift=false","-version","1.10.0","-cloud-provider-name","","--ipam-controller-network","192.168.1.1/24,192.168.1.1,8.8.8.8","-node-labels","{\"my-label\":\"my-value\"}"]}'
+        - '{"command":"/usr/local/bin/user-cluster-controller-manager","args":["-kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","-metrics-listen-address","0.0.0.0:8085","-health-listen-address","0.0.0.0:8086","-namespace","$(NAMESPACE)","-cluster-url","","-cloud-config","/etc/kubernetes/cloud/config","-openvpn-server-port","30003","-overwrite-registry","","-openshift=false","-version","1.10.0","-cloud-provider-name","","--ipam-controller-network","192.168.1.1/24,192.168.1.1,8.8.8.8","-node-labels","{\"my-label\":\"my-value\"}"]}'
         command:
         - /http-prober-bin/http-prober
         env:
@@ -68,6 +69,9 @@ spec:
         - mountPath: /etc/kubernetes/kubeconfig
           name: internal-admin-kubeconfig
           readOnly: true
+        - mountPath: /etc/kubernetes/cloud
+          name: cloud-config
+          readOnly: true
         - mountPath: /http-prober-bin
           name: http-prober-bin
       imagePullSecrets:
@@ -88,6 +92,9 @@ spec:
       - name: internal-admin-kubeconfig
         secret:
           secretName: internal-admin-kubeconfig
+      - configMap:
+          name: cloud-config
+        name: cloud-config
       - emptyDir: {}
         name: http-prober-bin
 status: {}

--- a/api/pkg/resources/test/fixtures/deployment-bringyourown-1.10.6-usercluster-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-bringyourown-1.10.6-usercluster-controller.yaml
@@ -22,6 +22,7 @@ spec:
       creationTimestamp: null
       labels:
         app: usercluster-controller
+        cloud-config-configmap-revision: "123456"
         cluster: de-test-01
         internal-admin-kubeconfig-secret-revision: "123456"
     spec:
@@ -37,7 +38,7 @@ spec:
         - -timeout
         - "1"
         - -command
-        - '{"command":"/usr/local/bin/user-cluster-controller-manager","args":["-kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","-metrics-listen-address","0.0.0.0:8085","-health-listen-address","0.0.0.0:8086","-namespace","$(NAMESPACE)","-cluster-url","","-openvpn-server-port","30003","-overwrite-registry","","-openshift=false","-version","1.10.6","-cloud-provider-name","","--ipam-controller-network","192.168.1.1/24,192.168.1.1,8.8.8.8","-node-labels","{\"my-label\":\"my-value\"}"]}'
+        - '{"command":"/usr/local/bin/user-cluster-controller-manager","args":["-kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","-metrics-listen-address","0.0.0.0:8085","-health-listen-address","0.0.0.0:8086","-namespace","$(NAMESPACE)","-cluster-url","","-cloud-config","/etc/kubernetes/cloud/config","-openvpn-server-port","30003","-overwrite-registry","","-openshift=false","-version","1.10.6","-cloud-provider-name","","--ipam-controller-network","192.168.1.1/24,192.168.1.1,8.8.8.8","-node-labels","{\"my-label\":\"my-value\"}"]}'
         command:
         - /http-prober-bin/http-prober
         env:
@@ -68,6 +69,9 @@ spec:
         - mountPath: /etc/kubernetes/kubeconfig
           name: internal-admin-kubeconfig
           readOnly: true
+        - mountPath: /etc/kubernetes/cloud
+          name: cloud-config
+          readOnly: true
         - mountPath: /http-prober-bin
           name: http-prober-bin
       imagePullSecrets:
@@ -88,6 +92,9 @@ spec:
       - name: internal-admin-kubeconfig
         secret:
           secretName: internal-admin-kubeconfig
+      - configMap:
+          name: cloud-config
+        name: cloud-config
       - emptyDir: {}
         name: http-prober-bin
 status: {}

--- a/api/pkg/resources/test/fixtures/deployment-bringyourown-1.11.0-usercluster-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-bringyourown-1.11.0-usercluster-controller.yaml
@@ -22,6 +22,7 @@ spec:
       creationTimestamp: null
       labels:
         app: usercluster-controller
+        cloud-config-configmap-revision: "123456"
         cluster: de-test-01
         internal-admin-kubeconfig-secret-revision: "123456"
     spec:
@@ -37,7 +38,7 @@ spec:
         - -timeout
         - "1"
         - -command
-        - '{"command":"/usr/local/bin/user-cluster-controller-manager","args":["-kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","-metrics-listen-address","0.0.0.0:8085","-health-listen-address","0.0.0.0:8086","-namespace","$(NAMESPACE)","-cluster-url","","-openvpn-server-port","30003","-overwrite-registry","","-openshift=false","-version","1.11.0","-cloud-provider-name","","--ipam-controller-network","192.168.1.1/24,192.168.1.1,8.8.8.8","-node-labels","{\"my-label\":\"my-value\"}"]}'
+        - '{"command":"/usr/local/bin/user-cluster-controller-manager","args":["-kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","-metrics-listen-address","0.0.0.0:8085","-health-listen-address","0.0.0.0:8086","-namespace","$(NAMESPACE)","-cluster-url","","-cloud-config","/etc/kubernetes/cloud/config","-openvpn-server-port","30003","-overwrite-registry","","-openshift=false","-version","1.11.0","-cloud-provider-name","","--ipam-controller-network","192.168.1.1/24,192.168.1.1,8.8.8.8","-node-labels","{\"my-label\":\"my-value\"}"]}'
         command:
         - /http-prober-bin/http-prober
         env:
@@ -68,6 +69,9 @@ spec:
         - mountPath: /etc/kubernetes/kubeconfig
           name: internal-admin-kubeconfig
           readOnly: true
+        - mountPath: /etc/kubernetes/cloud
+          name: cloud-config
+          readOnly: true
         - mountPath: /http-prober-bin
           name: http-prober-bin
       imagePullSecrets:
@@ -88,6 +92,9 @@ spec:
       - name: internal-admin-kubeconfig
         secret:
           secretName: internal-admin-kubeconfig
+      - configMap:
+          name: cloud-config
+        name: cloud-config
       - emptyDir: {}
         name: http-prober-bin
 status: {}

--- a/api/pkg/resources/test/fixtures/deployment-bringyourown-1.11.1-usercluster-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-bringyourown-1.11.1-usercluster-controller.yaml
@@ -22,6 +22,7 @@ spec:
       creationTimestamp: null
       labels:
         app: usercluster-controller
+        cloud-config-configmap-revision: "123456"
         cluster: de-test-01
         internal-admin-kubeconfig-secret-revision: "123456"
     spec:
@@ -37,7 +38,7 @@ spec:
         - -timeout
         - "1"
         - -command
-        - '{"command":"/usr/local/bin/user-cluster-controller-manager","args":["-kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","-metrics-listen-address","0.0.0.0:8085","-health-listen-address","0.0.0.0:8086","-namespace","$(NAMESPACE)","-cluster-url","","-openvpn-server-port","30003","-overwrite-registry","","-openshift=false","-version","1.11.1","-cloud-provider-name","","--ipam-controller-network","192.168.1.1/24,192.168.1.1,8.8.8.8","-node-labels","{\"my-label\":\"my-value\"}"]}'
+        - '{"command":"/usr/local/bin/user-cluster-controller-manager","args":["-kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","-metrics-listen-address","0.0.0.0:8085","-health-listen-address","0.0.0.0:8086","-namespace","$(NAMESPACE)","-cluster-url","","-cloud-config","/etc/kubernetes/cloud/config","-openvpn-server-port","30003","-overwrite-registry","","-openshift=false","-version","1.11.1","-cloud-provider-name","","--ipam-controller-network","192.168.1.1/24,192.168.1.1,8.8.8.8","-node-labels","{\"my-label\":\"my-value\"}"]}'
         command:
         - /http-prober-bin/http-prober
         env:
@@ -68,6 +69,9 @@ spec:
         - mountPath: /etc/kubernetes/kubeconfig
           name: internal-admin-kubeconfig
           readOnly: true
+        - mountPath: /etc/kubernetes/cloud
+          name: cloud-config
+          readOnly: true
         - mountPath: /http-prober-bin
           name: http-prober-bin
       imagePullSecrets:
@@ -88,6 +92,9 @@ spec:
       - name: internal-admin-kubeconfig
         secret:
           secretName: internal-admin-kubeconfig
+      - configMap:
+          name: cloud-config
+        name: cloud-config
       - emptyDir: {}
         name: http-prober-bin
 status: {}

--- a/api/pkg/resources/test/fixtures/deployment-bringyourown-1.12.0-usercluster-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-bringyourown-1.12.0-usercluster-controller.yaml
@@ -22,6 +22,7 @@ spec:
       creationTimestamp: null
       labels:
         app: usercluster-controller
+        cloud-config-configmap-revision: "123456"
         cluster: de-test-01
         internal-admin-kubeconfig-secret-revision: "123456"
     spec:
@@ -37,7 +38,7 @@ spec:
         - -timeout
         - "1"
         - -command
-        - '{"command":"/usr/local/bin/user-cluster-controller-manager","args":["-kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","-metrics-listen-address","0.0.0.0:8085","-health-listen-address","0.0.0.0:8086","-namespace","$(NAMESPACE)","-cluster-url","","-openvpn-server-port","30003","-overwrite-registry","","-openshift=false","-version","1.12.0","-cloud-provider-name","","--ipam-controller-network","192.168.1.1/24,192.168.1.1,8.8.8.8","-node-labels","{\"my-label\":\"my-value\"}"]}'
+        - '{"command":"/usr/local/bin/user-cluster-controller-manager","args":["-kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","-metrics-listen-address","0.0.0.0:8085","-health-listen-address","0.0.0.0:8086","-namespace","$(NAMESPACE)","-cluster-url","","-cloud-config","/etc/kubernetes/cloud/config","-openvpn-server-port","30003","-overwrite-registry","","-openshift=false","-version","1.12.0","-cloud-provider-name","","--ipam-controller-network","192.168.1.1/24,192.168.1.1,8.8.8.8","-node-labels","{\"my-label\":\"my-value\"}"]}'
         command:
         - /http-prober-bin/http-prober
         env:
@@ -68,6 +69,9 @@ spec:
         - mountPath: /etc/kubernetes/kubeconfig
           name: internal-admin-kubeconfig
           readOnly: true
+        - mountPath: /etc/kubernetes/cloud
+          name: cloud-config
+          readOnly: true
         - mountPath: /http-prober-bin
           name: http-prober-bin
       imagePullSecrets:
@@ -88,6 +92,9 @@ spec:
       - name: internal-admin-kubeconfig
         secret:
           secretName: internal-admin-kubeconfig
+      - configMap:
+          name: cloud-config
+        name: cloud-config
       - emptyDir: {}
         name: http-prober-bin
 status: {}

--- a/api/pkg/resources/test/fixtures/deployment-bringyourown-1.13.0-usercluster-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-bringyourown-1.13.0-usercluster-controller.yaml
@@ -22,6 +22,7 @@ spec:
       creationTimestamp: null
       labels:
         app: usercluster-controller
+        cloud-config-configmap-revision: "123456"
         cluster: de-test-01
         internal-admin-kubeconfig-secret-revision: "123456"
     spec:
@@ -37,7 +38,7 @@ spec:
         - -timeout
         - "1"
         - -command
-        - '{"command":"/usr/local/bin/user-cluster-controller-manager","args":["-kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","-metrics-listen-address","0.0.0.0:8085","-health-listen-address","0.0.0.0:8086","-namespace","$(NAMESPACE)","-cluster-url","","-openvpn-server-port","30003","-overwrite-registry","","-openshift=false","-version","1.13.0","-cloud-provider-name","","--ipam-controller-network","192.168.1.1/24,192.168.1.1,8.8.8.8","-node-labels","{\"my-label\":\"my-value\"}"]}'
+        - '{"command":"/usr/local/bin/user-cluster-controller-manager","args":["-kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","-metrics-listen-address","0.0.0.0:8085","-health-listen-address","0.0.0.0:8086","-namespace","$(NAMESPACE)","-cluster-url","","-cloud-config","/etc/kubernetes/cloud/config","-openvpn-server-port","30003","-overwrite-registry","","-openshift=false","-version","1.13.0","-cloud-provider-name","","--ipam-controller-network","192.168.1.1/24,192.168.1.1,8.8.8.8","-node-labels","{\"my-label\":\"my-value\"}"]}'
         command:
         - /http-prober-bin/http-prober
         env:
@@ -68,6 +69,9 @@ spec:
         - mountPath: /etc/kubernetes/kubeconfig
           name: internal-admin-kubeconfig
           readOnly: true
+        - mountPath: /etc/kubernetes/cloud
+          name: cloud-config
+          readOnly: true
         - mountPath: /http-prober-bin
           name: http-prober-bin
       imagePullSecrets:
@@ -88,6 +92,9 @@ spec:
       - name: internal-admin-kubeconfig
         secret:
           secretName: internal-admin-kubeconfig
+      - configMap:
+          name: cloud-config
+        name: cloud-config
       - emptyDir: {}
         name: http-prober-bin
 status: {}

--- a/api/pkg/resources/test/fixtures/deployment-digitalocean-1.10.0-usercluster-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-digitalocean-1.10.0-usercluster-controller.yaml
@@ -22,6 +22,7 @@ spec:
       creationTimestamp: null
       labels:
         app: usercluster-controller
+        cloud-config-configmap-revision: "123456"
         cluster: de-test-01
         internal-admin-kubeconfig-secret-revision: "123456"
     spec:
@@ -37,7 +38,7 @@ spec:
         - -timeout
         - "1"
         - -command
-        - '{"command":"/usr/local/bin/user-cluster-controller-manager","args":["-kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","-metrics-listen-address","0.0.0.0:8085","-health-listen-address","0.0.0.0:8086","-namespace","$(NAMESPACE)","-cluster-url","","-openvpn-server-port","30003","-overwrite-registry","","-openshift=false","-version","1.10.0","-cloud-provider-name","","--ipam-controller-network","192.168.1.1/24,192.168.1.1,8.8.8.8","-node-labels","{\"my-label\":\"my-value\"}"]}'
+        - '{"command":"/usr/local/bin/user-cluster-controller-manager","args":["-kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","-metrics-listen-address","0.0.0.0:8085","-health-listen-address","0.0.0.0:8086","-namespace","$(NAMESPACE)","-cluster-url","","-cloud-config","/etc/kubernetes/cloud/config","-openvpn-server-port","30003","-overwrite-registry","","-openshift=false","-version","1.10.0","-cloud-provider-name","","--ipam-controller-network","192.168.1.1/24,192.168.1.1,8.8.8.8","-node-labels","{\"my-label\":\"my-value\"}"]}'
         command:
         - /http-prober-bin/http-prober
         env:
@@ -68,6 +69,9 @@ spec:
         - mountPath: /etc/kubernetes/kubeconfig
           name: internal-admin-kubeconfig
           readOnly: true
+        - mountPath: /etc/kubernetes/cloud
+          name: cloud-config
+          readOnly: true
         - mountPath: /http-prober-bin
           name: http-prober-bin
       imagePullSecrets:
@@ -88,6 +92,9 @@ spec:
       - name: internal-admin-kubeconfig
         secret:
           secretName: internal-admin-kubeconfig
+      - configMap:
+          name: cloud-config
+        name: cloud-config
       - emptyDir: {}
         name: http-prober-bin
 status: {}

--- a/api/pkg/resources/test/fixtures/deployment-digitalocean-1.10.6-usercluster-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-digitalocean-1.10.6-usercluster-controller.yaml
@@ -22,6 +22,7 @@ spec:
       creationTimestamp: null
       labels:
         app: usercluster-controller
+        cloud-config-configmap-revision: "123456"
         cluster: de-test-01
         internal-admin-kubeconfig-secret-revision: "123456"
     spec:
@@ -37,7 +38,7 @@ spec:
         - -timeout
         - "1"
         - -command
-        - '{"command":"/usr/local/bin/user-cluster-controller-manager","args":["-kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","-metrics-listen-address","0.0.0.0:8085","-health-listen-address","0.0.0.0:8086","-namespace","$(NAMESPACE)","-cluster-url","","-openvpn-server-port","30003","-overwrite-registry","","-openshift=false","-version","1.10.6","-cloud-provider-name","","--ipam-controller-network","192.168.1.1/24,192.168.1.1,8.8.8.8","-node-labels","{\"my-label\":\"my-value\"}"]}'
+        - '{"command":"/usr/local/bin/user-cluster-controller-manager","args":["-kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","-metrics-listen-address","0.0.0.0:8085","-health-listen-address","0.0.0.0:8086","-namespace","$(NAMESPACE)","-cluster-url","","-cloud-config","/etc/kubernetes/cloud/config","-openvpn-server-port","30003","-overwrite-registry","","-openshift=false","-version","1.10.6","-cloud-provider-name","","--ipam-controller-network","192.168.1.1/24,192.168.1.1,8.8.8.8","-node-labels","{\"my-label\":\"my-value\"}"]}'
         command:
         - /http-prober-bin/http-prober
         env:
@@ -68,6 +69,9 @@ spec:
         - mountPath: /etc/kubernetes/kubeconfig
           name: internal-admin-kubeconfig
           readOnly: true
+        - mountPath: /etc/kubernetes/cloud
+          name: cloud-config
+          readOnly: true
         - mountPath: /http-prober-bin
           name: http-prober-bin
       imagePullSecrets:
@@ -88,6 +92,9 @@ spec:
       - name: internal-admin-kubeconfig
         secret:
           secretName: internal-admin-kubeconfig
+      - configMap:
+          name: cloud-config
+        name: cloud-config
       - emptyDir: {}
         name: http-prober-bin
 status: {}

--- a/api/pkg/resources/test/fixtures/deployment-digitalocean-1.11.0-usercluster-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-digitalocean-1.11.0-usercluster-controller.yaml
@@ -22,6 +22,7 @@ spec:
       creationTimestamp: null
       labels:
         app: usercluster-controller
+        cloud-config-configmap-revision: "123456"
         cluster: de-test-01
         internal-admin-kubeconfig-secret-revision: "123456"
     spec:
@@ -37,7 +38,7 @@ spec:
         - -timeout
         - "1"
         - -command
-        - '{"command":"/usr/local/bin/user-cluster-controller-manager","args":["-kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","-metrics-listen-address","0.0.0.0:8085","-health-listen-address","0.0.0.0:8086","-namespace","$(NAMESPACE)","-cluster-url","","-openvpn-server-port","30003","-overwrite-registry","","-openshift=false","-version","1.11.0","-cloud-provider-name","","--ipam-controller-network","192.168.1.1/24,192.168.1.1,8.8.8.8","-node-labels","{\"my-label\":\"my-value\"}"]}'
+        - '{"command":"/usr/local/bin/user-cluster-controller-manager","args":["-kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","-metrics-listen-address","0.0.0.0:8085","-health-listen-address","0.0.0.0:8086","-namespace","$(NAMESPACE)","-cluster-url","","-cloud-config","/etc/kubernetes/cloud/config","-openvpn-server-port","30003","-overwrite-registry","","-openshift=false","-version","1.11.0","-cloud-provider-name","","--ipam-controller-network","192.168.1.1/24,192.168.1.1,8.8.8.8","-node-labels","{\"my-label\":\"my-value\"}"]}'
         command:
         - /http-prober-bin/http-prober
         env:
@@ -68,6 +69,9 @@ spec:
         - mountPath: /etc/kubernetes/kubeconfig
           name: internal-admin-kubeconfig
           readOnly: true
+        - mountPath: /etc/kubernetes/cloud
+          name: cloud-config
+          readOnly: true
         - mountPath: /http-prober-bin
           name: http-prober-bin
       imagePullSecrets:
@@ -88,6 +92,9 @@ spec:
       - name: internal-admin-kubeconfig
         secret:
           secretName: internal-admin-kubeconfig
+      - configMap:
+          name: cloud-config
+        name: cloud-config
       - emptyDir: {}
         name: http-prober-bin
 status: {}

--- a/api/pkg/resources/test/fixtures/deployment-digitalocean-1.11.1-usercluster-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-digitalocean-1.11.1-usercluster-controller.yaml
@@ -22,6 +22,7 @@ spec:
       creationTimestamp: null
       labels:
         app: usercluster-controller
+        cloud-config-configmap-revision: "123456"
         cluster: de-test-01
         internal-admin-kubeconfig-secret-revision: "123456"
     spec:
@@ -37,7 +38,7 @@ spec:
         - -timeout
         - "1"
         - -command
-        - '{"command":"/usr/local/bin/user-cluster-controller-manager","args":["-kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","-metrics-listen-address","0.0.0.0:8085","-health-listen-address","0.0.0.0:8086","-namespace","$(NAMESPACE)","-cluster-url","","-openvpn-server-port","30003","-overwrite-registry","","-openshift=false","-version","1.11.1","-cloud-provider-name","","--ipam-controller-network","192.168.1.1/24,192.168.1.1,8.8.8.8","-node-labels","{\"my-label\":\"my-value\"}"]}'
+        - '{"command":"/usr/local/bin/user-cluster-controller-manager","args":["-kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","-metrics-listen-address","0.0.0.0:8085","-health-listen-address","0.0.0.0:8086","-namespace","$(NAMESPACE)","-cluster-url","","-cloud-config","/etc/kubernetes/cloud/config","-openvpn-server-port","30003","-overwrite-registry","","-openshift=false","-version","1.11.1","-cloud-provider-name","","--ipam-controller-network","192.168.1.1/24,192.168.1.1,8.8.8.8","-node-labels","{\"my-label\":\"my-value\"}"]}'
         command:
         - /http-prober-bin/http-prober
         env:
@@ -68,6 +69,9 @@ spec:
         - mountPath: /etc/kubernetes/kubeconfig
           name: internal-admin-kubeconfig
           readOnly: true
+        - mountPath: /etc/kubernetes/cloud
+          name: cloud-config
+          readOnly: true
         - mountPath: /http-prober-bin
           name: http-prober-bin
       imagePullSecrets:
@@ -88,6 +92,9 @@ spec:
       - name: internal-admin-kubeconfig
         secret:
           secretName: internal-admin-kubeconfig
+      - configMap:
+          name: cloud-config
+        name: cloud-config
       - emptyDir: {}
         name: http-prober-bin
 status: {}

--- a/api/pkg/resources/test/fixtures/deployment-digitalocean-1.12.0-usercluster-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-digitalocean-1.12.0-usercluster-controller.yaml
@@ -22,6 +22,7 @@ spec:
       creationTimestamp: null
       labels:
         app: usercluster-controller
+        cloud-config-configmap-revision: "123456"
         cluster: de-test-01
         internal-admin-kubeconfig-secret-revision: "123456"
     spec:
@@ -37,7 +38,7 @@ spec:
         - -timeout
         - "1"
         - -command
-        - '{"command":"/usr/local/bin/user-cluster-controller-manager","args":["-kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","-metrics-listen-address","0.0.0.0:8085","-health-listen-address","0.0.0.0:8086","-namespace","$(NAMESPACE)","-cluster-url","","-openvpn-server-port","30003","-overwrite-registry","","-openshift=false","-version","1.12.0","-cloud-provider-name","","--ipam-controller-network","192.168.1.1/24,192.168.1.1,8.8.8.8","-node-labels","{\"my-label\":\"my-value\"}"]}'
+        - '{"command":"/usr/local/bin/user-cluster-controller-manager","args":["-kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","-metrics-listen-address","0.0.0.0:8085","-health-listen-address","0.0.0.0:8086","-namespace","$(NAMESPACE)","-cluster-url","","-cloud-config","/etc/kubernetes/cloud/config","-openvpn-server-port","30003","-overwrite-registry","","-openshift=false","-version","1.12.0","-cloud-provider-name","","--ipam-controller-network","192.168.1.1/24,192.168.1.1,8.8.8.8","-node-labels","{\"my-label\":\"my-value\"}"]}'
         command:
         - /http-prober-bin/http-prober
         env:
@@ -68,6 +69,9 @@ spec:
         - mountPath: /etc/kubernetes/kubeconfig
           name: internal-admin-kubeconfig
           readOnly: true
+        - mountPath: /etc/kubernetes/cloud
+          name: cloud-config
+          readOnly: true
         - mountPath: /http-prober-bin
           name: http-prober-bin
       imagePullSecrets:
@@ -88,6 +92,9 @@ spec:
       - name: internal-admin-kubeconfig
         secret:
           secretName: internal-admin-kubeconfig
+      - configMap:
+          name: cloud-config
+        name: cloud-config
       - emptyDir: {}
         name: http-prober-bin
 status: {}

--- a/api/pkg/resources/test/fixtures/deployment-digitalocean-1.13.0-usercluster-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-digitalocean-1.13.0-usercluster-controller.yaml
@@ -22,6 +22,7 @@ spec:
       creationTimestamp: null
       labels:
         app: usercluster-controller
+        cloud-config-configmap-revision: "123456"
         cluster: de-test-01
         internal-admin-kubeconfig-secret-revision: "123456"
     spec:
@@ -37,7 +38,7 @@ spec:
         - -timeout
         - "1"
         - -command
-        - '{"command":"/usr/local/bin/user-cluster-controller-manager","args":["-kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","-metrics-listen-address","0.0.0.0:8085","-health-listen-address","0.0.0.0:8086","-namespace","$(NAMESPACE)","-cluster-url","","-openvpn-server-port","30003","-overwrite-registry","","-openshift=false","-version","1.13.0","-cloud-provider-name","","--ipam-controller-network","192.168.1.1/24,192.168.1.1,8.8.8.8","-node-labels","{\"my-label\":\"my-value\"}"]}'
+        - '{"command":"/usr/local/bin/user-cluster-controller-manager","args":["-kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","-metrics-listen-address","0.0.0.0:8085","-health-listen-address","0.0.0.0:8086","-namespace","$(NAMESPACE)","-cluster-url","","-cloud-config","/etc/kubernetes/cloud/config","-openvpn-server-port","30003","-overwrite-registry","","-openshift=false","-version","1.13.0","-cloud-provider-name","","--ipam-controller-network","192.168.1.1/24,192.168.1.1,8.8.8.8","-node-labels","{\"my-label\":\"my-value\"}"]}'
         command:
         - /http-prober-bin/http-prober
         env:
@@ -68,6 +69,9 @@ spec:
         - mountPath: /etc/kubernetes/kubeconfig
           name: internal-admin-kubeconfig
           readOnly: true
+        - mountPath: /etc/kubernetes/cloud
+          name: cloud-config
+          readOnly: true
         - mountPath: /http-prober-bin
           name: http-prober-bin
       imagePullSecrets:
@@ -88,6 +92,9 @@ spec:
       - name: internal-admin-kubeconfig
         secret:
           secretName: internal-admin-kubeconfig
+      - configMap:
+          name: cloud-config
+        name: cloud-config
       - emptyDir: {}
         name: http-prober-bin
 status: {}

--- a/api/pkg/resources/test/fixtures/deployment-openstack-1.10.0-usercluster-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-openstack-1.10.0-usercluster-controller.yaml
@@ -22,6 +22,7 @@ spec:
       creationTimestamp: null
       labels:
         app: usercluster-controller
+        cloud-config-configmap-revision: "123456"
         cluster: de-test-01
         internal-admin-kubeconfig-secret-revision: "123456"
     spec:
@@ -37,7 +38,7 @@ spec:
         - -timeout
         - "1"
         - -command
-        - '{"command":"/usr/local/bin/user-cluster-controller-manager","args":["-kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","-metrics-listen-address","0.0.0.0:8085","-health-listen-address","0.0.0.0:8086","-namespace","$(NAMESPACE)","-cluster-url","","-openvpn-server-port","30003","-overwrite-registry","","-openshift=false","-version","1.10.0","-cloud-provider-name","openstack","--ipam-controller-network","192.168.1.1/24,192.168.1.1,8.8.8.8","-node-labels","{\"my-label\":\"my-value\"}"]}'
+        - '{"command":"/usr/local/bin/user-cluster-controller-manager","args":["-kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","-metrics-listen-address","0.0.0.0:8085","-health-listen-address","0.0.0.0:8086","-namespace","$(NAMESPACE)","-cluster-url","","-cloud-config","/etc/kubernetes/cloud/config","-openvpn-server-port","30003","-overwrite-registry","","-openshift=false","-version","1.10.0","-cloud-provider-name","openstack","--ipam-controller-network","192.168.1.1/24,192.168.1.1,8.8.8.8","-node-labels","{\"my-label\":\"my-value\"}"]}'
         command:
         - /http-prober-bin/http-prober
         env:
@@ -68,6 +69,9 @@ spec:
         - mountPath: /etc/kubernetes/kubeconfig
           name: internal-admin-kubeconfig
           readOnly: true
+        - mountPath: /etc/kubernetes/cloud
+          name: cloud-config
+          readOnly: true
         - mountPath: /http-prober-bin
           name: http-prober-bin
       imagePullSecrets:
@@ -88,6 +92,9 @@ spec:
       - name: internal-admin-kubeconfig
         secret:
           secretName: internal-admin-kubeconfig
+      - configMap:
+          name: cloud-config
+        name: cloud-config
       - emptyDir: {}
         name: http-prober-bin
 status: {}

--- a/api/pkg/resources/test/fixtures/deployment-openstack-1.10.6-usercluster-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-openstack-1.10.6-usercluster-controller.yaml
@@ -22,6 +22,7 @@ spec:
       creationTimestamp: null
       labels:
         app: usercluster-controller
+        cloud-config-configmap-revision: "123456"
         cluster: de-test-01
         internal-admin-kubeconfig-secret-revision: "123456"
     spec:
@@ -37,7 +38,7 @@ spec:
         - -timeout
         - "1"
         - -command
-        - '{"command":"/usr/local/bin/user-cluster-controller-manager","args":["-kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","-metrics-listen-address","0.0.0.0:8085","-health-listen-address","0.0.0.0:8086","-namespace","$(NAMESPACE)","-cluster-url","","-openvpn-server-port","30003","-overwrite-registry","","-openshift=false","-version","1.10.6","-cloud-provider-name","openstack","--ipam-controller-network","192.168.1.1/24,192.168.1.1,8.8.8.8","-node-labels","{\"my-label\":\"my-value\"}"]}'
+        - '{"command":"/usr/local/bin/user-cluster-controller-manager","args":["-kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","-metrics-listen-address","0.0.0.0:8085","-health-listen-address","0.0.0.0:8086","-namespace","$(NAMESPACE)","-cluster-url","","-cloud-config","/etc/kubernetes/cloud/config","-openvpn-server-port","30003","-overwrite-registry","","-openshift=false","-version","1.10.6","-cloud-provider-name","openstack","--ipam-controller-network","192.168.1.1/24,192.168.1.1,8.8.8.8","-node-labels","{\"my-label\":\"my-value\"}"]}'
         command:
         - /http-prober-bin/http-prober
         env:
@@ -68,6 +69,9 @@ spec:
         - mountPath: /etc/kubernetes/kubeconfig
           name: internal-admin-kubeconfig
           readOnly: true
+        - mountPath: /etc/kubernetes/cloud
+          name: cloud-config
+          readOnly: true
         - mountPath: /http-prober-bin
           name: http-prober-bin
       imagePullSecrets:
@@ -88,6 +92,9 @@ spec:
       - name: internal-admin-kubeconfig
         secret:
           secretName: internal-admin-kubeconfig
+      - configMap:
+          name: cloud-config
+        name: cloud-config
       - emptyDir: {}
         name: http-prober-bin
 status: {}

--- a/api/pkg/resources/test/fixtures/deployment-openstack-1.11.0-usercluster-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-openstack-1.11.0-usercluster-controller.yaml
@@ -22,6 +22,7 @@ spec:
       creationTimestamp: null
       labels:
         app: usercluster-controller
+        cloud-config-configmap-revision: "123456"
         cluster: de-test-01
         internal-admin-kubeconfig-secret-revision: "123456"
     spec:
@@ -37,7 +38,7 @@ spec:
         - -timeout
         - "1"
         - -command
-        - '{"command":"/usr/local/bin/user-cluster-controller-manager","args":["-kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","-metrics-listen-address","0.0.0.0:8085","-health-listen-address","0.0.0.0:8086","-namespace","$(NAMESPACE)","-cluster-url","","-openvpn-server-port","30003","-overwrite-registry","","-openshift=false","-version","1.11.0","-cloud-provider-name","openstack","--ipam-controller-network","192.168.1.1/24,192.168.1.1,8.8.8.8","-node-labels","{\"my-label\":\"my-value\"}"]}'
+        - '{"command":"/usr/local/bin/user-cluster-controller-manager","args":["-kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","-metrics-listen-address","0.0.0.0:8085","-health-listen-address","0.0.0.0:8086","-namespace","$(NAMESPACE)","-cluster-url","","-cloud-config","/etc/kubernetes/cloud/config","-openvpn-server-port","30003","-overwrite-registry","","-openshift=false","-version","1.11.0","-cloud-provider-name","openstack","--ipam-controller-network","192.168.1.1/24,192.168.1.1,8.8.8.8","-node-labels","{\"my-label\":\"my-value\"}"]}'
         command:
         - /http-prober-bin/http-prober
         env:
@@ -68,6 +69,9 @@ spec:
         - mountPath: /etc/kubernetes/kubeconfig
           name: internal-admin-kubeconfig
           readOnly: true
+        - mountPath: /etc/kubernetes/cloud
+          name: cloud-config
+          readOnly: true
         - mountPath: /http-prober-bin
           name: http-prober-bin
       imagePullSecrets:
@@ -88,6 +92,9 @@ spec:
       - name: internal-admin-kubeconfig
         secret:
           secretName: internal-admin-kubeconfig
+      - configMap:
+          name: cloud-config
+        name: cloud-config
       - emptyDir: {}
         name: http-prober-bin
 status: {}

--- a/api/pkg/resources/test/fixtures/deployment-openstack-1.11.1-usercluster-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-openstack-1.11.1-usercluster-controller.yaml
@@ -22,6 +22,7 @@ spec:
       creationTimestamp: null
       labels:
         app: usercluster-controller
+        cloud-config-configmap-revision: "123456"
         cluster: de-test-01
         internal-admin-kubeconfig-secret-revision: "123456"
     spec:
@@ -37,7 +38,7 @@ spec:
         - -timeout
         - "1"
         - -command
-        - '{"command":"/usr/local/bin/user-cluster-controller-manager","args":["-kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","-metrics-listen-address","0.0.0.0:8085","-health-listen-address","0.0.0.0:8086","-namespace","$(NAMESPACE)","-cluster-url","","-openvpn-server-port","30003","-overwrite-registry","","-openshift=false","-version","1.11.1","-cloud-provider-name","openstack","--ipam-controller-network","192.168.1.1/24,192.168.1.1,8.8.8.8","-node-labels","{\"my-label\":\"my-value\"}"]}'
+        - '{"command":"/usr/local/bin/user-cluster-controller-manager","args":["-kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","-metrics-listen-address","0.0.0.0:8085","-health-listen-address","0.0.0.0:8086","-namespace","$(NAMESPACE)","-cluster-url","","-cloud-config","/etc/kubernetes/cloud/config","-openvpn-server-port","30003","-overwrite-registry","","-openshift=false","-version","1.11.1","-cloud-provider-name","openstack","--ipam-controller-network","192.168.1.1/24,192.168.1.1,8.8.8.8","-node-labels","{\"my-label\":\"my-value\"}"]}'
         command:
         - /http-prober-bin/http-prober
         env:
@@ -68,6 +69,9 @@ spec:
         - mountPath: /etc/kubernetes/kubeconfig
           name: internal-admin-kubeconfig
           readOnly: true
+        - mountPath: /etc/kubernetes/cloud
+          name: cloud-config
+          readOnly: true
         - mountPath: /http-prober-bin
           name: http-prober-bin
       imagePullSecrets:
@@ -88,6 +92,9 @@ spec:
       - name: internal-admin-kubeconfig
         secret:
           secretName: internal-admin-kubeconfig
+      - configMap:
+          name: cloud-config
+        name: cloud-config
       - emptyDir: {}
         name: http-prober-bin
 status: {}

--- a/api/pkg/resources/test/fixtures/deployment-openstack-1.12.0-usercluster-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-openstack-1.12.0-usercluster-controller.yaml
@@ -22,6 +22,7 @@ spec:
       creationTimestamp: null
       labels:
         app: usercluster-controller
+        cloud-config-configmap-revision: "123456"
         cluster: de-test-01
         internal-admin-kubeconfig-secret-revision: "123456"
     spec:
@@ -37,7 +38,7 @@ spec:
         - -timeout
         - "1"
         - -command
-        - '{"command":"/usr/local/bin/user-cluster-controller-manager","args":["-kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","-metrics-listen-address","0.0.0.0:8085","-health-listen-address","0.0.0.0:8086","-namespace","$(NAMESPACE)","-cluster-url","","-openvpn-server-port","30003","-overwrite-registry","","-openshift=false","-version","1.12.0","-cloud-provider-name","openstack","--ipam-controller-network","192.168.1.1/24,192.168.1.1,8.8.8.8","-node-labels","{\"my-label\":\"my-value\"}"]}'
+        - '{"command":"/usr/local/bin/user-cluster-controller-manager","args":["-kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","-metrics-listen-address","0.0.0.0:8085","-health-listen-address","0.0.0.0:8086","-namespace","$(NAMESPACE)","-cluster-url","","-cloud-config","/etc/kubernetes/cloud/config","-openvpn-server-port","30003","-overwrite-registry","","-openshift=false","-version","1.12.0","-cloud-provider-name","openstack","--ipam-controller-network","192.168.1.1/24,192.168.1.1,8.8.8.8","-node-labels","{\"my-label\":\"my-value\"}"]}'
         command:
         - /http-prober-bin/http-prober
         env:
@@ -68,6 +69,9 @@ spec:
         - mountPath: /etc/kubernetes/kubeconfig
           name: internal-admin-kubeconfig
           readOnly: true
+        - mountPath: /etc/kubernetes/cloud
+          name: cloud-config
+          readOnly: true
         - mountPath: /http-prober-bin
           name: http-prober-bin
       imagePullSecrets:
@@ -88,6 +92,9 @@ spec:
       - name: internal-admin-kubeconfig
         secret:
           secretName: internal-admin-kubeconfig
+      - configMap:
+          name: cloud-config
+        name: cloud-config
       - emptyDir: {}
         name: http-prober-bin
 status: {}

--- a/api/pkg/resources/test/fixtures/deployment-openstack-1.13.0-usercluster-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-openstack-1.13.0-usercluster-controller.yaml
@@ -22,6 +22,7 @@ spec:
       creationTimestamp: null
       labels:
         app: usercluster-controller
+        cloud-config-configmap-revision: "123456"
         cluster: de-test-01
         internal-admin-kubeconfig-secret-revision: "123456"
     spec:
@@ -37,7 +38,7 @@ spec:
         - -timeout
         - "1"
         - -command
-        - '{"command":"/usr/local/bin/user-cluster-controller-manager","args":["-kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","-metrics-listen-address","0.0.0.0:8085","-health-listen-address","0.0.0.0:8086","-namespace","$(NAMESPACE)","-cluster-url","","-openvpn-server-port","30003","-overwrite-registry","","-openshift=false","-version","1.13.0","-cloud-provider-name","openstack","--ipam-controller-network","192.168.1.1/24,192.168.1.1,8.8.8.8","-node-labels","{\"my-label\":\"my-value\"}"]}'
+        - '{"command":"/usr/local/bin/user-cluster-controller-manager","args":["-kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","-metrics-listen-address","0.0.0.0:8085","-health-listen-address","0.0.0.0:8086","-namespace","$(NAMESPACE)","-cluster-url","","-cloud-config","/etc/kubernetes/cloud/config","-openvpn-server-port","30003","-overwrite-registry","","-openshift=false","-version","1.13.0","-cloud-provider-name","openstack","--ipam-controller-network","192.168.1.1/24,192.168.1.1,8.8.8.8","-node-labels","{\"my-label\":\"my-value\"}"]}'
         command:
         - /http-prober-bin/http-prober
         env:
@@ -68,6 +69,9 @@ spec:
         - mountPath: /etc/kubernetes/kubeconfig
           name: internal-admin-kubeconfig
           readOnly: true
+        - mountPath: /etc/kubernetes/cloud
+          name: cloud-config
+          readOnly: true
         - mountPath: /http-prober-bin
           name: http-prober-bin
       imagePullSecrets:
@@ -88,6 +92,9 @@ spec:
       - name: internal-admin-kubeconfig
         secret:
           secretName: internal-admin-kubeconfig
+      - configMap:
+          name: cloud-config
+        name: cloud-config
       - emptyDir: {}
         name: http-prober-bin
 status: {}

--- a/api/pkg/resources/test/fixtures/deployment-vsphere-1.10.0-usercluster-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-vsphere-1.10.0-usercluster-controller.yaml
@@ -22,6 +22,7 @@ spec:
       creationTimestamp: null
       labels:
         app: usercluster-controller
+        cloud-config-configmap-revision: "123456"
         cluster: de-test-01
         internal-admin-kubeconfig-secret-revision: "123456"
     spec:
@@ -37,7 +38,7 @@ spec:
         - -timeout
         - "1"
         - -command
-        - '{"command":"/usr/local/bin/user-cluster-controller-manager","args":["-kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","-metrics-listen-address","0.0.0.0:8085","-health-listen-address","0.0.0.0:8086","-namespace","$(NAMESPACE)","-cluster-url","","-openvpn-server-port","30003","-overwrite-registry","","-openshift=false","-version","1.10.0","-cloud-provider-name","vsphere","--ipam-controller-network","192.168.1.1/24,192.168.1.1,8.8.8.8","-node-labels","{\"my-label\":\"my-value\"}"]}'
+        - '{"command":"/usr/local/bin/user-cluster-controller-manager","args":["-kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","-metrics-listen-address","0.0.0.0:8085","-health-listen-address","0.0.0.0:8086","-namespace","$(NAMESPACE)","-cluster-url","","-cloud-config","/etc/kubernetes/cloud/config","-openvpn-server-port","30003","-overwrite-registry","","-openshift=false","-version","1.10.0","-cloud-provider-name","vsphere","--ipam-controller-network","192.168.1.1/24,192.168.1.1,8.8.8.8","-node-labels","{\"my-label\":\"my-value\"}"]}'
         command:
         - /http-prober-bin/http-prober
         env:
@@ -68,6 +69,9 @@ spec:
         - mountPath: /etc/kubernetes/kubeconfig
           name: internal-admin-kubeconfig
           readOnly: true
+        - mountPath: /etc/kubernetes/cloud
+          name: cloud-config
+          readOnly: true
         - mountPath: /http-prober-bin
           name: http-prober-bin
       imagePullSecrets:
@@ -88,6 +92,9 @@ spec:
       - name: internal-admin-kubeconfig
         secret:
           secretName: internal-admin-kubeconfig
+      - configMap:
+          name: cloud-config
+        name: cloud-config
       - emptyDir: {}
         name: http-prober-bin
 status: {}

--- a/api/pkg/resources/test/fixtures/deployment-vsphere-1.10.6-usercluster-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-vsphere-1.10.6-usercluster-controller.yaml
@@ -22,6 +22,7 @@ spec:
       creationTimestamp: null
       labels:
         app: usercluster-controller
+        cloud-config-configmap-revision: "123456"
         cluster: de-test-01
         internal-admin-kubeconfig-secret-revision: "123456"
     spec:
@@ -37,7 +38,7 @@ spec:
         - -timeout
         - "1"
         - -command
-        - '{"command":"/usr/local/bin/user-cluster-controller-manager","args":["-kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","-metrics-listen-address","0.0.0.0:8085","-health-listen-address","0.0.0.0:8086","-namespace","$(NAMESPACE)","-cluster-url","","-openvpn-server-port","30003","-overwrite-registry","","-openshift=false","-version","1.10.6","-cloud-provider-name","vsphere","--ipam-controller-network","192.168.1.1/24,192.168.1.1,8.8.8.8","-node-labels","{\"my-label\":\"my-value\"}"]}'
+        - '{"command":"/usr/local/bin/user-cluster-controller-manager","args":["-kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","-metrics-listen-address","0.0.0.0:8085","-health-listen-address","0.0.0.0:8086","-namespace","$(NAMESPACE)","-cluster-url","","-cloud-config","/etc/kubernetes/cloud/config","-openvpn-server-port","30003","-overwrite-registry","","-openshift=false","-version","1.10.6","-cloud-provider-name","vsphere","--ipam-controller-network","192.168.1.1/24,192.168.1.1,8.8.8.8","-node-labels","{\"my-label\":\"my-value\"}"]}'
         command:
         - /http-prober-bin/http-prober
         env:
@@ -68,6 +69,9 @@ spec:
         - mountPath: /etc/kubernetes/kubeconfig
           name: internal-admin-kubeconfig
           readOnly: true
+        - mountPath: /etc/kubernetes/cloud
+          name: cloud-config
+          readOnly: true
         - mountPath: /http-prober-bin
           name: http-prober-bin
       imagePullSecrets:
@@ -88,6 +92,9 @@ spec:
       - name: internal-admin-kubeconfig
         secret:
           secretName: internal-admin-kubeconfig
+      - configMap:
+          name: cloud-config
+        name: cloud-config
       - emptyDir: {}
         name: http-prober-bin
 status: {}

--- a/api/pkg/resources/test/fixtures/deployment-vsphere-1.11.0-usercluster-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-vsphere-1.11.0-usercluster-controller.yaml
@@ -22,6 +22,7 @@ spec:
       creationTimestamp: null
       labels:
         app: usercluster-controller
+        cloud-config-configmap-revision: "123456"
         cluster: de-test-01
         internal-admin-kubeconfig-secret-revision: "123456"
     spec:
@@ -37,7 +38,7 @@ spec:
         - -timeout
         - "1"
         - -command
-        - '{"command":"/usr/local/bin/user-cluster-controller-manager","args":["-kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","-metrics-listen-address","0.0.0.0:8085","-health-listen-address","0.0.0.0:8086","-namespace","$(NAMESPACE)","-cluster-url","","-openvpn-server-port","30003","-overwrite-registry","","-openshift=false","-version","1.11.0","-cloud-provider-name","vsphere","--ipam-controller-network","192.168.1.1/24,192.168.1.1,8.8.8.8","-node-labels","{\"my-label\":\"my-value\"}"]}'
+        - '{"command":"/usr/local/bin/user-cluster-controller-manager","args":["-kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","-metrics-listen-address","0.0.0.0:8085","-health-listen-address","0.0.0.0:8086","-namespace","$(NAMESPACE)","-cluster-url","","-cloud-config","/etc/kubernetes/cloud/config","-openvpn-server-port","30003","-overwrite-registry","","-openshift=false","-version","1.11.0","-cloud-provider-name","vsphere","--ipam-controller-network","192.168.1.1/24,192.168.1.1,8.8.8.8","-node-labels","{\"my-label\":\"my-value\"}"]}'
         command:
         - /http-prober-bin/http-prober
         env:
@@ -68,6 +69,9 @@ spec:
         - mountPath: /etc/kubernetes/kubeconfig
           name: internal-admin-kubeconfig
           readOnly: true
+        - mountPath: /etc/kubernetes/cloud
+          name: cloud-config
+          readOnly: true
         - mountPath: /http-prober-bin
           name: http-prober-bin
       imagePullSecrets:
@@ -88,6 +92,9 @@ spec:
       - name: internal-admin-kubeconfig
         secret:
           secretName: internal-admin-kubeconfig
+      - configMap:
+          name: cloud-config
+        name: cloud-config
       - emptyDir: {}
         name: http-prober-bin
 status: {}

--- a/api/pkg/resources/test/fixtures/deployment-vsphere-1.11.1-usercluster-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-vsphere-1.11.1-usercluster-controller.yaml
@@ -22,6 +22,7 @@ spec:
       creationTimestamp: null
       labels:
         app: usercluster-controller
+        cloud-config-configmap-revision: "123456"
         cluster: de-test-01
         internal-admin-kubeconfig-secret-revision: "123456"
     spec:
@@ -37,7 +38,7 @@ spec:
         - -timeout
         - "1"
         - -command
-        - '{"command":"/usr/local/bin/user-cluster-controller-manager","args":["-kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","-metrics-listen-address","0.0.0.0:8085","-health-listen-address","0.0.0.0:8086","-namespace","$(NAMESPACE)","-cluster-url","","-openvpn-server-port","30003","-overwrite-registry","","-openshift=false","-version","1.11.1","-cloud-provider-name","vsphere","--ipam-controller-network","192.168.1.1/24,192.168.1.1,8.8.8.8","-node-labels","{\"my-label\":\"my-value\"}"]}'
+        - '{"command":"/usr/local/bin/user-cluster-controller-manager","args":["-kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","-metrics-listen-address","0.0.0.0:8085","-health-listen-address","0.0.0.0:8086","-namespace","$(NAMESPACE)","-cluster-url","","-cloud-config","/etc/kubernetes/cloud/config","-openvpn-server-port","30003","-overwrite-registry","","-openshift=false","-version","1.11.1","-cloud-provider-name","vsphere","--ipam-controller-network","192.168.1.1/24,192.168.1.1,8.8.8.8","-node-labels","{\"my-label\":\"my-value\"}"]}'
         command:
         - /http-prober-bin/http-prober
         env:
@@ -68,6 +69,9 @@ spec:
         - mountPath: /etc/kubernetes/kubeconfig
           name: internal-admin-kubeconfig
           readOnly: true
+        - mountPath: /etc/kubernetes/cloud
+          name: cloud-config
+          readOnly: true
         - mountPath: /http-prober-bin
           name: http-prober-bin
       imagePullSecrets:
@@ -88,6 +92,9 @@ spec:
       - name: internal-admin-kubeconfig
         secret:
           secretName: internal-admin-kubeconfig
+      - configMap:
+          name: cloud-config
+        name: cloud-config
       - emptyDir: {}
         name: http-prober-bin
 status: {}

--- a/api/pkg/resources/test/fixtures/deployment-vsphere-1.12.0-usercluster-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-vsphere-1.12.0-usercluster-controller.yaml
@@ -22,6 +22,7 @@ spec:
       creationTimestamp: null
       labels:
         app: usercluster-controller
+        cloud-config-configmap-revision: "123456"
         cluster: de-test-01
         internal-admin-kubeconfig-secret-revision: "123456"
     spec:
@@ -37,7 +38,7 @@ spec:
         - -timeout
         - "1"
         - -command
-        - '{"command":"/usr/local/bin/user-cluster-controller-manager","args":["-kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","-metrics-listen-address","0.0.0.0:8085","-health-listen-address","0.0.0.0:8086","-namespace","$(NAMESPACE)","-cluster-url","","-openvpn-server-port","30003","-overwrite-registry","","-openshift=false","-version","1.12.0","-cloud-provider-name","vsphere","--ipam-controller-network","192.168.1.1/24,192.168.1.1,8.8.8.8","-node-labels","{\"my-label\":\"my-value\"}"]}'
+        - '{"command":"/usr/local/bin/user-cluster-controller-manager","args":["-kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","-metrics-listen-address","0.0.0.0:8085","-health-listen-address","0.0.0.0:8086","-namespace","$(NAMESPACE)","-cluster-url","","-cloud-config","/etc/kubernetes/cloud/config","-openvpn-server-port","30003","-overwrite-registry","","-openshift=false","-version","1.12.0","-cloud-provider-name","vsphere","--ipam-controller-network","192.168.1.1/24,192.168.1.1,8.8.8.8","-node-labels","{\"my-label\":\"my-value\"}"]}'
         command:
         - /http-prober-bin/http-prober
         env:
@@ -68,6 +69,9 @@ spec:
         - mountPath: /etc/kubernetes/kubeconfig
           name: internal-admin-kubeconfig
           readOnly: true
+        - mountPath: /etc/kubernetes/cloud
+          name: cloud-config
+          readOnly: true
         - mountPath: /http-prober-bin
           name: http-prober-bin
       imagePullSecrets:
@@ -88,6 +92,9 @@ spec:
       - name: internal-admin-kubeconfig
         secret:
           secretName: internal-admin-kubeconfig
+      - configMap:
+          name: cloud-config
+        name: cloud-config
       - emptyDir: {}
         name: http-prober-bin
 status: {}

--- a/api/pkg/resources/test/fixtures/deployment-vsphere-1.13.0-usercluster-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-vsphere-1.13.0-usercluster-controller.yaml
@@ -22,6 +22,7 @@ spec:
       creationTimestamp: null
       labels:
         app: usercluster-controller
+        cloud-config-configmap-revision: "123456"
         cluster: de-test-01
         internal-admin-kubeconfig-secret-revision: "123456"
     spec:
@@ -37,7 +38,7 @@ spec:
         - -timeout
         - "1"
         - -command
-        - '{"command":"/usr/local/bin/user-cluster-controller-manager","args":["-kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","-metrics-listen-address","0.0.0.0:8085","-health-listen-address","0.0.0.0:8086","-namespace","$(NAMESPACE)","-cluster-url","","-openvpn-server-port","30003","-overwrite-registry","","-openshift=false","-version","1.13.0","-cloud-provider-name","vsphere","--ipam-controller-network","192.168.1.1/24,192.168.1.1,8.8.8.8","-node-labels","{\"my-label\":\"my-value\"}"]}'
+        - '{"command":"/usr/local/bin/user-cluster-controller-manager","args":["-kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","-metrics-listen-address","0.0.0.0:8085","-health-listen-address","0.0.0.0:8086","-namespace","$(NAMESPACE)","-cluster-url","","-cloud-config","/etc/kubernetes/cloud/config","-openvpn-server-port","30003","-overwrite-registry","","-openshift=false","-version","1.13.0","-cloud-provider-name","vsphere","--ipam-controller-network","192.168.1.1/24,192.168.1.1,8.8.8.8","-node-labels","{\"my-label\":\"my-value\"}"]}'
         command:
         - /http-prober-bin/http-prober
         env:
@@ -68,6 +69,9 @@ spec:
         - mountPath: /etc/kubernetes/kubeconfig
           name: internal-admin-kubeconfig
           readOnly: true
+        - mountPath: /etc/kubernetes/cloud
+          name: cloud-config
+          readOnly: true
         - mountPath: /http-prober-bin
           name: http-prober-bin
       imagePullSecrets:
@@ -88,6 +92,9 @@ spec:
       - name: internal-admin-kubeconfig
         secret:
           secretName: internal-admin-kubeconfig
+      - configMap:
+          name: cloud-config
+        name: cloud-config
       - emptyDir: {}
         name: http-prober-bin
 status: {}

--- a/api/pkg/resources/usercluster/deployment.go
+++ b/api/pkg/resources/usercluster/deployment.go
@@ -101,6 +101,7 @@ func DeploymentCreator(data userclusterControllerData, openshift bool) reconcili
 				"-health-listen-address", "0.0.0.0:8086",
 				"-namespace", "$(NAMESPACE)",
 				"-cluster-url", data.Cluster().Address.URL,
+				"-cloud-config", "/etc/kubernetes/cloud/config",
 				"-openvpn-server-port", fmt.Sprint(openvpnServerPort),
 				"-overwrite-registry", data.ImageRegistry(""),
 				fmt.Sprintf("-openshift=%t", openshift),
@@ -165,6 +166,11 @@ func DeploymentCreator(data userclusterControllerData, openshift bool) reconcili
 							MountPath: "/etc/kubernetes/kubeconfig",
 							ReadOnly:  true,
 						},
+						{
+							Name:      resources.CloudConfigConfigMapName,
+							MountPath: "/etc/kubernetes/cloud",
+							ReadOnly:  true,
+						},
 					},
 				},
 			}
@@ -188,6 +194,16 @@ func getVolumes() []corev1.Volume {
 			VolumeSource: corev1.VolumeSource{
 				Secret: &corev1.SecretVolumeSource{
 					SecretName: resources.InternalUserClusterAdminKubeconfigSecretName,
+				},
+			},
+		},
+		{
+			Name: resources.CloudConfigConfigMapName,
+			VolumeSource: corev1.VolumeSource{
+				ConfigMap: &corev1.ConfigMapVolumeSource{
+					LocalObjectReference: corev1.LocalObjectReference{
+						Name: resources.CloudConfigConfigMapName,
+					},
 				},
 			},
 		},

--- a/api/pkg/semver/semver.go
+++ b/api/pkg/semver/semver.go
@@ -2,6 +2,7 @@ package semver
 
 import (
 	"encoding/json"
+	"fmt"
 	"strconv"
 
 	semverlib "github.com/Masterminds/semver"
@@ -58,6 +59,11 @@ func (s *Semver) String() string {
 		return ""
 	}
 	return s.Version.String()
+}
+
+// MajorMinor returns a string like "Major.Minor"
+func (s *Semver) MajorMinor() string {
+	return fmt.Sprintf("%d.%d", s.Major(), s.Minor())
 }
 
 // UnmarshalJSON converts JSON to Semver struct

--- a/config/kubermatic/Chart.yaml
+++ b/config/kubermatic/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: kubermatic
-version: 1.0.19
+version: 1.0.20
 appVersion: '__KUBERMATIC_TAG__'
 description: Kubermatic chart for master and/or seed clusters.
 keywords:

--- a/config/kubermatic/values.yaml
+++ b/config/kubermatic/values.yaml
@@ -85,6 +85,7 @@ kubermatic:
         # list of Addons to install into every user-cluster. All need to exist in the addons image
         defaultAddons:
         - canal
+        - csi
         - dns
         - kube-proxy
         - openvpn


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR adds external cloud provider support for OpenStack, to accomplish this, the following changes and additions have been made:
    
    * Add a node labeller operator to add distribution labels to nodes.
    * Add Cluster.Spec.Features to the API.
    * Add the FeatureNameExternalCloudProvider feature flag.
    * Create the external cloud provider deployment to the user cluster
      namespace.
    * Add the CSI addon to the addons.
    * Mount the cloud-config into the usercluster controller.
    * Inject the cloud-config into the user cluster.
    * Add a MajorMinor function to semver.

**Does this PR introduce a user-facing change?**:
```release-note
Add support for the external cloud provider for OpenStack.
```
