### PR TITLE
sync-charts: configure proper version sorting in get_latest_dashboard_tag

### DIFF
--- a/api/hack/lib.sh
+++ b/api/hack/lib.sh
@@ -69,7 +69,9 @@ get_latest_dashboard_tag() {
   local DASHBOARD_URL="git@github.com:kubermatic/dashboard-v2.git"
 
   MINOR_VERSION="${FOR_BRANCH##release/}"
-  FOUND_TAG="$(retry 5 git ls-remote --sort=-version:refname "$DASHBOARD_URL" "refs/tags/$MINOR_VERSION*" | head -n1 | awk '{print $2}')"
+  # --sort=-version:refname will treat the tag names as semvers and sort by version number.
+  # -c versionsort.suffix=-alpha -c versionsort.suffix=-rc tell git that alphas and RCs come before versions wihtout any suffix.
+  FOUND_TAG="$(retry 5 git ls-remote -c versionsort.suffix=-alpha -c versionsort.suffix=-rc --sort=-version:refname "$DASHBOARD_URL" "refs/tags/$MINOR_VERSION*" | head -n1 | awk '{print $2}')"
   if [ -z "$FOUND_TAG" ]; then
     echo "Error, no Dashboard tags contain $MINOR_VERSION" >/dev/stderr
     exit 1


### PR DESCRIPTION
By default git treats any version with a suffix as being newer (greater)
than a version without, e.g. 1.0 < 1.0-alpha.1
This commit will tell git to treat the -rc and -alpha suffix version as older.

**What this PR does / why we need it**:
chart-sync is broken without it. The latest RC is selected instead of the public releases.

```release-note
NONE
```
