### PR TITLE
Fix periodic-kubermatic-e2e-api-cloud 

### DIFF
--- a/api/pkg/test/e2e/api/utils/oidc-proxy-client/Makefile
+++ b/api/pkg/test/e2e/api/utils/oidc-proxy-client/Makefile
@@ -5,6 +5,10 @@ LDFLAGS += -extldflags '-static'
 BUILD_DEST?=_build
 GOTOOLFLAGS?=$(GOBUILDFLAGS) -ldflags '-w $(LDFLAGS)'
 BINARYNAME=oidc-proxy-client
+KUBERMATIC_OIDC_CLIENT_ID ?= kubermatic
+KUBERMATIC_OIDC_CLIENT_SECRET ?= ZXhhbXBsZS1hcHAtc2VjcmV0
+KUBERMATIC_OIDC_ISSUER ?= http://dex.oauth:5556
+KUBERMATIC_OIDC_REDIRECT_URI ?= http://dex.oauth:5556
 
 default: all
 
@@ -23,6 +27,11 @@ fix:
 	@UNFMT=$$($(GFMT)); if [ -n "$$UNFMT" ]; then echo "goimports -w" $$UNFMT; goimports -w $$UNFMT; fi
 
 run: build
-	./$(BUILD_DEST)/$(BINARYNAME)
+	./$(BUILD_DEST)/$(BINARYNAME) \
+		--client-id=$(KUBERMATIC_OIDC_CLIENT_ID) \
+		--client-secret=$(KUBERMATIC_OIDC_CLIENT_SECRET) \
+		--issuer=$(KUBERMATIC_OIDC_ISSUER) \
+		--redirect-uri=$(KUBERMATIC_OIDC_REDIRECT_URI) \
+		--debug
 
 .PHONY: check build run


### PR DESCRIPTION
**What this PR does / why we need it**:

This fixes the API periodic-kubermatic-e2e-api-cloud  test. The settings for the oidc-proxy-client were hardcoded in #4283, which is fine for all tests except this one :)

This PR softcodes it again but continues to do the defaulting.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Documentation**:
<!-- Add links to the related documentation changes related to this pull request. E.g. the link to the kubermatic/docs pullrequest. -->

**Does this PR introduce a user-facing change?**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If  no release note is required, just write "NONE".
-->
```release-note
none
```
