### PR TITLE
Improve error handling in cloud controller / openstack provider

### DIFF
--- a/api/pkg/provider/cloud/openstack/helper.go
+++ b/api/pkg/provider/cloud/openstack/helper.go
@@ -84,9 +84,9 @@ func getNetworkByName(netClient *gophercloud.ServiceClient, name string, isExter
 	case 1:
 		return candidates[0], nil
 	case 0:
-		return nil, errNotFound
+		return nil, fmt.Errorf("no network named '%s' with external=%v found", name, isExternal)
 	default:
-		return nil, fmt.Errorf("found %d external networks for name '%s', expected one at most", len(candidates), name)
+		return nil, fmt.Errorf("found %d networks for name '%s' (external=%v), expected exactly one", len(candidates), name, isExternal)
 	}
 }
 
@@ -102,7 +102,7 @@ func getExternalNetwork(netClient *gophercloud.ServiceClient) (*NetworkWithExter
 		}
 	}
 
-	return nil, errNotFound
+	return nil, errors.New("no external network found")
 }
 
 func validateSecurityGroupsExist(netClient *gophercloud.ServiceClient, securityGroups []string) error {
@@ -465,7 +465,7 @@ func getRouterIDForSubnet(netClient *gophercloud.ServiceClient, subnetID, networ
 		}
 	}
 
-	return "", errNotFound
+	return "", fmt.Errorf("no router found for subnet '%s', network '%s'", subnetID, networkID)
 }
 
 func getAllNetworkPorts(netClient *gophercloud.ServiceClient, networkID string) ([]osports.Port, error) {

--- a/api/pkg/provider/cloud/openstack/helper.go
+++ b/api/pkg/provider/cloud/openstack/helper.go
@@ -31,10 +31,6 @@ const (
 	resourceNamePrefix = "kubernetes-"
 )
 
-var (
-	errNotFound = errors.New("not found")
-)
-
 func getSecurityGroups(netClient *gophercloud.ServiceClient, opts ossecuritygroups.ListOpts) ([]ossecuritygroups.SecGroup, error) {
 	page, err := ossecuritygroups.List(netClient, opts).AllPages()
 	if err != nil {
@@ -465,7 +461,7 @@ func getRouterIDForSubnet(netClient *gophercloud.ServiceClient, subnetID, networ
 		}
 	}
 
-	return "", fmt.Errorf("no router found for subnet '%s', network '%s'", subnetID, networkID)
+	return "", nil
 }
 
 func getAllNetworkPorts(netClient *gophercloud.ServiceClient, networkID string) ([]osports.Port, error) {

--- a/api/pkg/provider/cloud/openstack/provider.go
+++ b/api/pkg/provider/cloud/openstack/provider.go
@@ -141,7 +141,7 @@ func validateExistingSubnetOverlap(networkID string, netClient *gophercloud.Serv
 func (os *Provider) InitializeCloudProvider(cluster *kubermaticv1.Cluster, update provider.ClusterUpdater) (*kubermaticv1.Cluster, error) {
 	creds, err := GetCredentialsForCluster(cluster.Spec.Cloud, os.secretKeySelector)
 	if err != nil {
-		return nil, err
+		return nil, fmt.Errorf("failed to get credentials: %v", err)
 	}
 
 	netClient, err := getNetClient(creds.Username, creds.Password, creds.Domain, creds.Tenant, creds.TenantID, os.dc.AuthURL, os.dc.Region)
@@ -152,14 +152,14 @@ func (os *Provider) InitializeCloudProvider(cluster *kubermaticv1.Cluster, updat
 	if cluster.Spec.Cloud.Openstack.FloatingIPPool == "" {
 		extNetwork, err := getExternalNetwork(netClient)
 		if err != nil {
-			return nil, err
+			return nil, fmt.Errorf("failed to get external network: %v", err)
 		}
 		cluster, err = update(cluster.Name, func(cluster *kubermaticv1.Cluster) {
 			cluster.Spec.Cloud.Openstack.FloatingIPPool = extNetwork.Name
 			// We're just searching for the floating ip pool here & don't create anything. Thus no need to create a finalizer
 		})
 		if err != nil {
-			return nil, err
+			return nil, fmt.Errorf("failed to update cluster floating IP pool: %v", err)
 		}
 	}
 
@@ -173,7 +173,7 @@ func (os *Provider) InitializeCloudProvider(cluster *kubermaticv1.Cluster, updat
 			kubernetes.AddFinalizer(cluster, SecurityGroupCleanupFinalizer)
 		})
 		if err != nil {
-			return nil, err
+			return nil, fmt.Errorf("failed to add security group cleanup finalizer: %v", err)
 		}
 	}
 
@@ -187,7 +187,7 @@ func (os *Provider) InitializeCloudProvider(cluster *kubermaticv1.Cluster, updat
 			kubernetes.AddFinalizer(cluster, NetworkCleanupFinalizer)
 		})
 		if err != nil {
-			return nil, err
+			return nil, fmt.Errorf("failed to add network cleanup finalizer: %v", err)
 		}
 	}
 
@@ -207,7 +207,7 @@ func (os *Provider) InitializeCloudProvider(cluster *kubermaticv1.Cluster, updat
 			kubernetes.AddFinalizer(cluster, SubnetCleanupFinalizer)
 		})
 		if err != nil {
-			return nil, err
+			return nil, fmt.Errorf("failed to add subnet cleanup finalizer: %v", err)
 		}
 	}
 
@@ -226,7 +226,7 @@ func (os *Provider) InitializeCloudProvider(cluster *kubermaticv1.Cluster, updat
 					kubernetes.AddFinalizer(cluster, RouterCleanupFinalizer)
 				})
 				if err != nil {
-					return nil, err
+					return nil, fmt.Errorf("failed to add router cleanup finalizer: %v", err)
 				}
 			} else {
 				return nil, fmt.Errorf("failed to verify that the subnet '%s' has a router attached: %v", cluster.Spec.Cloud.Openstack.SubnetID, err)
@@ -237,7 +237,7 @@ func (os *Provider) InitializeCloudProvider(cluster *kubermaticv1.Cluster, updat
 				cluster.Spec.Cloud.Openstack.RouterID = routerID
 			})
 			if err != nil {
-				return nil, err
+				return nil, fmt.Errorf("failed to add router ID to cluster: %v", err)
 			}
 		}
 	}
@@ -253,7 +253,7 @@ func (os *Provider) InitializeCloudProvider(cluster *kubermaticv1.Cluster, updat
 			kubernetes.AddFinalizer(cluster, RouterSubnetLinkCleanupFinalizer)
 		})
 		if err != nil {
-			return nil, err
+			return nil, fmt.Errorf("failed to add router subnet cleanup finalizer: %v", err)
 		}
 	}
 


### PR DESCRIPTION
**What this PR does / why we need it**:
The cloud controller and openstack provider was not very clear about the errors it can encounter. When no external network was defined, for example, you ended up with a simple `"not found"` error and nothing else.

**Does this PR introduce a user-facing change?**:
```release-note
NONE
```
