### PR TITLE
Ensure name/namespace are set before object modifiers are called

### DIFF
--- a/api/codegen/reconcile/main.go
+++ b/api/codegen/reconcile/main.go
@@ -251,6 +251,9 @@ func Reconcile{{ .ResourceNamePlural }}(ctx context.Context, namedGetters []Name
 		create = {{ .DefaultingFunc }}(create)
 {{- end }}
 		createObject := {{ .ResourceName }}ObjectWrapper(create)
+		createObject = createWithNamespace(createObject, namespace)
+		createObject = createWithName(createObject, name)
+
 		for _, objectModifier := range objectModifiers {
 			createObject = objectModifier(createObject)
 		}

--- a/api/pkg/resources/reconciling/zz_generated_reconcile.go
+++ b/api/pkg/resources/reconciling/zz_generated_reconcile.go
@@ -44,6 +44,9 @@ func ReconcileNamespaces(ctx context.Context, namedGetters []NamedNamespaceCreat
 	for _, get := range namedGetters {
 		name, create := get()
 		createObject := NamespaceObjectWrapper(create)
+		createObject = createWithNamespace(createObject, namespace)
+		createObject = createWithName(createObject, name)
+
 		for _, objectModifier := range objectModifiers {
 			createObject = objectModifier(createObject)
 		}
@@ -78,6 +81,9 @@ func ReconcileServices(ctx context.Context, namedGetters []NamedServiceCreatorGe
 	for _, get := range namedGetters {
 		name, create := get()
 		createObject := ServiceObjectWrapper(create)
+		createObject = createWithNamespace(createObject, namespace)
+		createObject = createWithName(createObject, name)
+
 		for _, objectModifier := range objectModifiers {
 			createObject = objectModifier(createObject)
 		}
@@ -112,6 +118,9 @@ func ReconcileSecrets(ctx context.Context, namedGetters []NamedSecretCreatorGett
 	for _, get := range namedGetters {
 		name, create := get()
 		createObject := SecretObjectWrapper(create)
+		createObject = createWithNamespace(createObject, namespace)
+		createObject = createWithName(createObject, name)
+
 		for _, objectModifier := range objectModifiers {
 			createObject = objectModifier(createObject)
 		}
@@ -146,6 +155,9 @@ func ReconcileConfigMaps(ctx context.Context, namedGetters []NamedConfigMapCreat
 	for _, get := range namedGetters {
 		name, create := get()
 		createObject := ConfigMapObjectWrapper(create)
+		createObject = createWithNamespace(createObject, namespace)
+		createObject = createWithName(createObject, name)
+
 		for _, objectModifier := range objectModifiers {
 			createObject = objectModifier(createObject)
 		}
@@ -180,6 +192,9 @@ func ReconcileServiceAccounts(ctx context.Context, namedGetters []NamedServiceAc
 	for _, get := range namedGetters {
 		name, create := get()
 		createObject := ServiceAccountObjectWrapper(create)
+		createObject = createWithNamespace(createObject, namespace)
+		createObject = createWithName(createObject, name)
+
 		for _, objectModifier := range objectModifiers {
 			createObject = objectModifier(createObject)
 		}
@@ -215,6 +230,9 @@ func ReconcileStatefulSets(ctx context.Context, namedGetters []NamedStatefulSetC
 		name, create := get()
 		create = DefaultStatefulSet(create)
 		createObject := StatefulSetObjectWrapper(create)
+		createObject = createWithNamespace(createObject, namespace)
+		createObject = createWithName(createObject, name)
+
 		for _, objectModifier := range objectModifiers {
 			createObject = objectModifier(createObject)
 		}
@@ -250,6 +268,9 @@ func ReconcileDeployments(ctx context.Context, namedGetters []NamedDeploymentCre
 		name, create := get()
 		create = DefaultDeployment(create)
 		createObject := DeploymentObjectWrapper(create)
+		createObject = createWithNamespace(createObject, namespace)
+		createObject = createWithName(createObject, name)
+
 		for _, objectModifier := range objectModifiers {
 			createObject = objectModifier(createObject)
 		}
@@ -285,6 +306,9 @@ func ReconcileDaemonSets(ctx context.Context, namedGetters []NamedDaemonSetCreat
 		name, create := get()
 		create = DefaultDaemonSet(create)
 		createObject := DaemonSetObjectWrapper(create)
+		createObject = createWithNamespace(createObject, namespace)
+		createObject = createWithName(createObject, name)
+
 		for _, objectModifier := range objectModifiers {
 			createObject = objectModifier(createObject)
 		}
@@ -319,6 +343,9 @@ func ReconcilePodDisruptionBudgets(ctx context.Context, namedGetters []NamedPodD
 	for _, get := range namedGetters {
 		name, create := get()
 		createObject := PodDisruptionBudgetObjectWrapper(create)
+		createObject = createWithNamespace(createObject, namespace)
+		createObject = createWithName(createObject, name)
+
 		for _, objectModifier := range objectModifiers {
 			createObject = objectModifier(createObject)
 		}
@@ -353,6 +380,9 @@ func ReconcileVerticalPodAutoscalers(ctx context.Context, namedGetters []NamedVe
 	for _, get := range namedGetters {
 		name, create := get()
 		createObject := VerticalPodAutoscalerObjectWrapper(create)
+		createObject = createWithNamespace(createObject, namespace)
+		createObject = createWithName(createObject, name)
+
 		for _, objectModifier := range objectModifiers {
 			createObject = objectModifier(createObject)
 		}
@@ -387,6 +417,9 @@ func ReconcileClusterRoleBindings(ctx context.Context, namedGetters []NamedClust
 	for _, get := range namedGetters {
 		name, create := get()
 		createObject := ClusterRoleBindingObjectWrapper(create)
+		createObject = createWithNamespace(createObject, namespace)
+		createObject = createWithName(createObject, name)
+
 		for _, objectModifier := range objectModifiers {
 			createObject = objectModifier(createObject)
 		}
@@ -421,6 +454,9 @@ func ReconcileClusterRoles(ctx context.Context, namedGetters []NamedClusterRoleC
 	for _, get := range namedGetters {
 		name, create := get()
 		createObject := ClusterRoleObjectWrapper(create)
+		createObject = createWithNamespace(createObject, namespace)
+		createObject = createWithName(createObject, name)
+
 		for _, objectModifier := range objectModifiers {
 			createObject = objectModifier(createObject)
 		}
@@ -455,6 +491,9 @@ func ReconcileRoles(ctx context.Context, namedGetters []NamedRoleCreatorGetter, 
 	for _, get := range namedGetters {
 		name, create := get()
 		createObject := RoleObjectWrapper(create)
+		createObject = createWithNamespace(createObject, namespace)
+		createObject = createWithName(createObject, name)
+
 		for _, objectModifier := range objectModifiers {
 			createObject = objectModifier(createObject)
 		}
@@ -489,6 +528,9 @@ func ReconcileRoleBindings(ctx context.Context, namedGetters []NamedRoleBindingC
 	for _, get := range namedGetters {
 		name, create := get()
 		createObject := RoleBindingObjectWrapper(create)
+		createObject = createWithNamespace(createObject, namespace)
+		createObject = createWithName(createObject, name)
+
 		for _, objectModifier := range objectModifiers {
 			createObject = objectModifier(createObject)
 		}
@@ -523,6 +565,9 @@ func ReconcileCustomResourceDefinitions(ctx context.Context, namedGetters []Name
 	for _, get := range namedGetters {
 		name, create := get()
 		createObject := CustomResourceDefinitionObjectWrapper(create)
+		createObject = createWithNamespace(createObject, namespace)
+		createObject = createWithName(createObject, name)
+
 		for _, objectModifier := range objectModifiers {
 			createObject = objectModifier(createObject)
 		}
@@ -558,6 +603,9 @@ func ReconcileCronJobs(ctx context.Context, namedGetters []NamedCronJobCreatorGe
 		name, create := get()
 		create = DefaultCronJob(create)
 		createObject := CronJobObjectWrapper(create)
+		createObject = createWithNamespace(createObject, namespace)
+		createObject = createWithName(createObject, name)
+
 		for _, objectModifier := range objectModifiers {
 			createObject = objectModifier(createObject)
 		}
@@ -592,6 +640,9 @@ func ReconcileMutatingWebhookConfigurations(ctx context.Context, namedGetters []
 	for _, get := range namedGetters {
 		name, create := get()
 		createObject := MutatingWebhookConfigurationObjectWrapper(create)
+		createObject = createWithNamespace(createObject, namespace)
+		createObject = createWithName(createObject, name)
+
 		for _, objectModifier := range objectModifiers {
 			createObject = objectModifier(createObject)
 		}
@@ -626,6 +677,9 @@ func ReconcileValidatingWebhookConfigurations(ctx context.Context, namedGetters 
 	for _, get := range namedGetters {
 		name, create := get()
 		createObject := ValidatingWebhookConfigurationObjectWrapper(create)
+		createObject = createWithNamespace(createObject, namespace)
+		createObject = createWithName(createObject, name)
+
 		for _, objectModifier := range objectModifiers {
 			createObject = objectModifier(createObject)
 		}
@@ -660,6 +714,9 @@ func ReconcileAPIServices(ctx context.Context, namedGetters []NamedAPIServiceCre
 	for _, get := range namedGetters {
 		name, create := get()
 		createObject := APIServiceObjectWrapper(create)
+		createObject = createWithNamespace(createObject, namespace)
+		createObject = createWithName(createObject, name)
+
 		for _, objectModifier := range objectModifiers {
 			createObject = objectModifier(createObject)
 		}
@@ -694,6 +751,9 @@ func ReconcileIngresses(ctx context.Context, namedGetters []NamedIngressCreatorG
 	for _, get := range namedGetters {
 		name, create := get()
 		createObject := IngressObjectWrapper(create)
+		createObject = createWithNamespace(createObject, namespace)
+		createObject = createWithName(createObject, name)
+
 		for _, objectModifier := range objectModifiers {
 			createObject = objectModifier(createObject)
 		}
@@ -728,6 +788,9 @@ func ReconcileSeeds(ctx context.Context, namedGetters []NamedSeedCreatorGetter, 
 	for _, get := range namedGetters {
 		name, create := get()
 		createObject := SeedObjectWrapper(create)
+		createObject = createWithNamespace(createObject, namespace)
+		createObject = createWithName(createObject, name)
+
 		for _, objectModifier := range objectModifiers {
 			createObject = objectModifier(createObject)
 		}


### PR DESCRIPTION
**What this PR does / why we need it**:
When an object modifier is used to apply volume revision labels, the modifier needs to know the Deployment's namespace. Right now the namespace and name would be set too late.

**Does this PR introduce a user-facing change?**:
```release-note
NONE
```
