### PR TITLE
Remove worker-name handling from the seedsGetter

### DIFF
--- a/api/cmd/kubermatic-api/main.go
+++ b/api/cmd/kubermatic-api/main.go
@@ -135,7 +135,7 @@ func createInitProviders(options serverRunOptions) (providers, error) {
 	if err != nil {
 		return providers{}, fmt.Errorf("failed to construct manager: %v", err)
 	}
-	seedsGetter, err := provider.SeedsGetterFactory(context.Background(), mgr.GetClient(), options.dcFile, options.namespace, options.workerName, options.dynamicDatacenters)
+	seedsGetter, err := provider.SeedsGetterFactory(context.Background(), mgr.GetClient(), options.dcFile, options.namespace, options.dynamicDatacenters)
 	if err != nil {
 		return providers{}, err
 	}

--- a/api/cmd/kubermatic-operator/main.go
+++ b/api/cmd/kubermatic-operator/main.go
@@ -80,7 +80,7 @@ func main() {
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 
-	seedsGetter, err := provider.SeedsGetterFactory(ctx, mgr.GetClient(), "", opt.namespace, opt.workerName, true)
+	seedsGetter, err := provider.SeedsGetterFactory(ctx, mgr.GetClient(), "", opt.namespace, true)
 	if err != nil {
 		log.Fatalw("Failed to construct seedsGetter", zap.Error(err))
 	}

--- a/api/cmd/master-controller-manager/main.go
+++ b/api/cmd/master-controller-manager/main.go
@@ -159,7 +159,7 @@ func main() {
 
 	// these two getters rely on the ctrlruntime manager being started; they are
 	// only used inside controllers
-	ctrlCtx.seedsGetter, err = provider.SeedsGetterFactory(ctx, mgr.GetClient(), runOpts.dcFile, ctrlCtx.namespace, runOpts.workerName, runOpts.dynamicDatacenters)
+	ctrlCtx.seedsGetter, err = provider.SeedsGetterFactory(ctx, mgr.GetClient(), runOpts.dcFile, ctrlCtx.namespace, runOpts.dynamicDatacenters)
 	if err != nil {
 		log.Fatalw("failed to construct seedsGetter", zap.Error(err))
 	}

--- a/api/pkg/provider/datacenter.go
+++ b/api/pkg/provider/datacenter.go
@@ -10,7 +10,6 @@ import (
 	kubermaticv1 "github.com/kubermatic/kubermatic/api/pkg/crd/kubermatic/v1"
 	kubermaticlog "github.com/kubermatic/kubermatic/api/pkg/log"
 	"github.com/kubermatic/kubermatic/api/pkg/util/restmapper"
-	"github.com/kubermatic/kubermatic/api/pkg/util/workerlabel"
 	providerconfig "github.com/kubermatic/machine-controller/pkg/providerconfig/types"
 
 	corev1 "k8s.io/api/core/v1"
@@ -196,8 +195,8 @@ func seedGetterFactory(ctx context.Context, client ctrlruntimeclient.Client, see
 
 }
 
-func SeedsGetterFactory(ctx context.Context, client ctrlruntimeclient.Client, dcFile, namespace, workerName string, dynamicDatacenters bool) (SeedsGetter, error) {
-	seedsGetter, err := seedsGetterFactory(ctx, client, dcFile, namespace, workerName, dynamicDatacenters)
+func SeedsGetterFactory(ctx context.Context, client ctrlruntimeclient.Client, dcFile, namespace string, dynamicDatacenters bool) (SeedsGetter, error) {
+	seedsGetter, err := seedsGetterFactory(ctx, client, dcFile, namespace, dynamicDatacenters)
 	if err != nil {
 		return nil, err
 	}
@@ -213,16 +212,11 @@ func SeedsGetterFactory(ctx context.Context, client ctrlruntimeclient.Client, dc
 	}, nil
 }
 
-func seedsGetterFactory(ctx context.Context, client ctrlruntimeclient.Client, dcFile, namespace, workerName string, dynamicDatacenters bool) (SeedsGetter, error) {
+func seedsGetterFactory(ctx context.Context, client ctrlruntimeclient.Client, dcFile, namespace string, dynamicDatacenters bool) (SeedsGetter, error) {
 	if dynamicDatacenters {
-		labelSelector, err := workerlabel.LabelSelector(workerName)
-		if err != nil {
-			return nil, fmt.Errorf("failed to construct label selector for worker-name: %v", err)
-		}
 		// We only have a options func for raw *metav1.ListOpts as the rbac controller currently required that
 		listOpts := &ctrlruntimeclient.ListOptions{
-			LabelSelector: labelSelector,
-			Namespace:     namespace,
+			Namespace: namespace,
 		}
 
 		return func() (map[string]*kubermaticv1.Seed, error) {

--- a/api/pkg/provider/datacenter_test.go
+++ b/api/pkg/provider/datacenter_test.go
@@ -225,7 +225,7 @@ func TestSeedsGetterFactorySetsDefaults(t *testing.T) {
 	}
 	client := fakectrlruntimeclient.NewFakeClient(initSeed)
 
-	seedsGetter, err := SeedsGetterFactory(context.Background(), client, "", "my-ns", "", true)
+	seedsGetter, err := SeedsGetterFactory(context.Background(), client, "", "my-ns", true)
 	if err != nil {
 		t.Fatalf("failed getting seedsGetter: %v", err)
 	}


### PR DESCRIPTION
**What this PR does / why we need it**:

This PR makes the `seedsGetter` not respect the worker name anymore. The rationale behind that is:
* This was only half-implemented as the `seedGetter`  never respected the worker-name
* Using the `worker-name` breaks our dev workflow where the components are running locally but use the config of the seed, because it would require to have `seed` crd with all correct workername
* We already separate `seeds` via Namespace they are in, having a second mechanism is redudant

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Documentation**:
<!-- Add links to the related documentation changes related to this pull request. E.g. the link to the kubermatic/docs pullrequest. -->

**Does this PR introduce a user-facing change?**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If  no release note is required, just write "NONE".
-->
```release-note
none
```

/assign @xrstf 
