### PR TITLE
replace deprecated method NewFakeClient from the API

### DIFF
--- a/api/pkg/clusterdeletion/deletion_test.go
+++ b/api/pkg/clusterdeletion/deletion_test.go
@@ -9,6 +9,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/client-go/kubernetes/scheme"
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 )
 
@@ -60,7 +61,7 @@ func TestCleanUpPVUsingWorkloads(t *testing.T) {
 
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
-			client := fake.NewFakeClient(tc.objects...)
+			client := fake.NewFakeClientWithScheme(scheme.Scheme, tc.objects...)
 			d := &Deletion{}
 			ctx := context.Background()
 

--- a/api/pkg/handler/test/helper.go
+++ b/api/pkg/handler/test/helper.go
@@ -13,16 +13,7 @@ import (
 	"testing"
 	"time"
 
-	"k8s.io/apimachinery/pkg/util/sets"
-
-	"github.com/kubermatic/kubermatic/api/pkg/presets"
-
-	"github.com/kubermatic/kubermatic/api/pkg/handler/v1/common"
-
 	prometheusapi "github.com/prometheus/client_golang/api"
-
-	corev1 "k8s.io/api/core/v1"
-	"k8s.io/client-go/kubernetes/scheme"
 
 	apiv1 "github.com/kubermatic/kubermatic/api/pkg/api/v1"
 	k8cuserclusterclient "github.com/kubermatic/kubermatic/api/pkg/cluster/client"
@@ -32,7 +23,9 @@ import (
 	kubermaticinformers "github.com/kubermatic/kubermatic/api/pkg/crd/client/informers/externalversions"
 	kubermaticv1 "github.com/kubermatic/kubermatic/api/pkg/crd/kubermatic/v1"
 	"github.com/kubermatic/kubermatic/api/pkg/handler/auth"
+	"github.com/kubermatic/kubermatic/api/pkg/handler/v1/common"
 	kubermaticlog "github.com/kubermatic/kubermatic/api/pkg/log"
+	"github.com/kubermatic/kubermatic/api/pkg/presets"
 	"github.com/kubermatic/kubermatic/api/pkg/provider"
 	"github.com/kubermatic/kubermatic/api/pkg/provider/kubernetes"
 	"github.com/kubermatic/kubermatic/api/pkg/semver"
@@ -40,13 +33,16 @@ import (
 	"github.com/kubermatic/kubermatic/api/pkg/version"
 	clusterv1alpha1 "github.com/kubermatic/machine-controller/pkg/apis/cluster/v1alpha1"
 
+	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/apimachinery/pkg/util/sets"
 	"k8s.io/apimachinery/pkg/util/wait"
 	"k8s.io/client-go/informers"
 	kubernetesclientset "k8s.io/client-go/kubernetes"
 	fakerestclient "k8s.io/client-go/kubernetes/fake"
+	"k8s.io/client-go/kubernetes/scheme"
 	restclient "k8s.io/client-go/rest"
 	"k8s.io/metrics/pkg/apis/metrics/v1beta1"
 
@@ -151,7 +147,7 @@ func initTestEndpoint(user apiv1.User, seedsGetter provider.SeedsGetter, kubeObj
 	allObjects := kubeObjects
 	allObjects = append(allObjects, machineObjects...)
 	allObjects = append(allObjects, kubermaticObjects...)
-	fakeClient := fakectrlruntimeclient.NewFakeClient(allObjects...)
+	fakeClient := fakectrlruntimeclient.NewFakeClientWithScheme(scheme.Scheme, allObjects...)
 	kubermaticClient := kubermaticfakeclentset.NewSimpleClientset(kubermaticObjects...)
 	kubermaticInformerFactory := kubermaticinformers.NewSharedInformerFactory(kubermaticClient, 10*time.Millisecond)
 	kubernetesClient := fakerestclient.NewSimpleClientset(kubeObjects...)

--- a/api/pkg/provider/datacenter_test.go
+++ b/api/pkg/provider/datacenter_test.go
@@ -12,6 +12,7 @@ import (
 	providerconfig "github.com/kubermatic/machine-controller/pkg/providerconfig/types"
 
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/kubernetes/scheme"
 	fakectrlruntimeclient "sigs.k8s.io/controller-runtime/pkg/client/fake"
 )
 
@@ -193,7 +194,7 @@ func TestSeedGetterFactorySetsDefaults(t *testing.T) {
 			Datacenters: map[string]kubermaticv1.Datacenter{"a": {}},
 		},
 	}
-	client := fakectrlruntimeclient.NewFakeClient(initSeed)
+	client := fakectrlruntimeclient.NewFakeClientWithScheme(scheme.Scheme, initSeed)
 
 	seedGetter, err := SeedGetterFactory(context.Background(), client, "my-seed", "", "my-ns", true)
 	if err != nil {
@@ -223,7 +224,7 @@ func TestSeedsGetterFactorySetsDefaults(t *testing.T) {
 			Datacenters: map[string]kubermaticv1.Datacenter{"a": {}},
 		},
 	}
-	client := fakectrlruntimeclient.NewFakeClient(initSeed)
+	client := fakectrlruntimeclient.NewFakeClientWithScheme(scheme.Scheme, initSeed)
 
 	seedsGetter, err := SeedsGetterFactory(context.Background(), client, "", "my-ns", true)
 	if err != nil {

--- a/api/pkg/resources/test/load_files_test.go
+++ b/api/pkg/resources/test/load_files_test.go
@@ -36,6 +36,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/apimachinery/pkg/util/wait"
+	"k8s.io/client-go/kubernetes/scheme"
 	ctrlruntimefakeclient "sigs.k8s.io/controller-runtime/pkg/client/fake"
 )
 
@@ -242,7 +243,7 @@ func TestLoadFiles(t *testing.T) {
 					},
 				}
 
-				dynamicClient := ctrlruntimefakeclient.NewFakeClient(
+				dynamicClient := ctrlruntimefakeclient.NewFakeClientWithScheme(scheme.Scheme,
 					&corev1.Secret{
 						ObjectMeta: metav1.ObjectMeta{
 							ResourceVersion: "123456",
@@ -1172,7 +1173,7 @@ func TestExecute(t *testing.T) {
 
 			credentialsData := testhelper.CredentialsData{
 				KubermaticCluster: test.data.Cluster,
-				Client:            ctrlruntimefakeclient.NewFakeClient(),
+				Client:            ctrlruntimefakeclient.NewFakeClientWithScheme(scheme.Scheme),
 			}
 			machine, err := machine.Machine(test.data.Cluster, test.data.Node, test.data.Datacenter, test.data.Keys, credentialsData)
 			if err != nil {

--- a/api/pkg/validation/seed/seed_test.go
+++ b/api/pkg/validation/seed/seed_test.go
@@ -7,6 +7,7 @@ import (
 
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/client-go/kubernetes/scheme"
 	ctrlruntimeclient "sigs.k8s.io/controller-runtime/pkg/client"
 	fakectrlruntimeclient "sigs.k8s.io/controller-runtime/pkg/client/fake"
 )
@@ -313,7 +314,7 @@ func TestValidate(t *testing.T) {
 			}
 
 			err := sv.validate(tc.seedToValidate,
-				fakectrlruntimeclient.NewFakeClient(tc.existingClusters...),
+				fakectrlruntimeclient.NewFakeClientWithScheme(scheme.Scheme, tc.existingClusters...),
 				tc.existingSeeds, tc.isDelete)
 
 			if (err != nil) != tc.errExpected {


### PR DESCRIPTION
**What this PR does / why we need it**: replace deprecated method NewFakeClient from the API

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

```release-note
NONE
```
