### PR TITLE
Extract common behaviour from operator master reconciling code

### DIFF
--- a/api/pkg/controller/operator/common/resources.go
+++ b/api/pkg/controller/operator/common/resources.go
@@ -1,0 +1,65 @@
+package common
+
+import (
+	operatorv1alpha1 "github.com/kubermatic/kubermatic/api/pkg/crd/operator/v1alpha1"
+	"github.com/kubermatic/kubermatic/api/pkg/resources/reconciling"
+
+	corev1 "k8s.io/api/core/v1"
+)
+
+const (
+	DockercfgSecretName                 = "dockercfg"
+	DexCASecretName                     = "dex-ca"
+	MasterFilesSecretName               = "extra-files"
+	BackupContainersConfigMapName       = "backup-containers"
+	SeedAdmissionWebhookName            = "kubermatic.io-seeds"
+	SeedWebhookServingCertSecretName    = "seed-webhook-serving-cert"
+	IngressName                         = "kubermatic"
+	SeedControllerManagerDeploymentName = "kubermatic-seed-controller-manager"
+	OpenIDAuthFeatureFlag               = "OpenIDAuthPlugin"
+)
+
+func DockercfgSecretCreator(cfg *operatorv1alpha1.KubermaticConfiguration) reconciling.NamedSecretCreatorGetter {
+	return func() (string, reconciling.SecretCreator) {
+		return DockercfgSecretName, func(s *corev1.Secret) (*corev1.Secret, error) {
+			s.Type = corev1.SecretTypeDockerConfigJson
+
+			return createSecretData(s, map[string]string{
+				corev1.DockerConfigJsonKey: cfg.Spec.ImagePullSecret,
+			}), nil
+		}
+	}
+}
+
+func DexCASecretCreator(cfg *operatorv1alpha1.KubermaticConfiguration) reconciling.NamedSecretCreatorGetter {
+	return func() (string, reconciling.SecretCreator) {
+		return DexCASecretName, func(s *corev1.Secret) (*corev1.Secret, error) {
+			return createSecretData(s, map[string]string{
+				"caBundle.pem": cfg.Spec.Auth.CABundle,
+			}), nil
+		}
+	}
+}
+
+func MasterFilesSecretCreator(cfg *operatorv1alpha1.KubermaticConfiguration) reconciling.NamedSecretCreatorGetter {
+	return func() (string, reconciling.SecretCreator) {
+		return MasterFilesSecretName, func(s *corev1.Secret) (*corev1.Secret, error) {
+			return createSecretData(s, cfg.Spec.MasterFiles), nil
+		}
+	}
+}
+
+func BackupContainersConfigMapCreator(cfg *operatorv1alpha1.KubermaticConfiguration) reconciling.NamedConfigMapCreatorGetter {
+	return func() (string, reconciling.ConfigMapCreator) {
+		return BackupContainersConfigMapName, func(c *corev1.ConfigMap) (*corev1.ConfigMap, error) {
+			if c.Data == nil {
+				c.Data = make(map[string]string)
+			}
+
+			c.Data["store-container.yaml"] = cfg.Spec.SeedController.BackupStoreContainer
+			c.Data["cleanup-container.yaml"] = cfg.Spec.SeedController.BackupCleanupContainer
+
+			return c, nil
+		}
+	}
+}

--- a/api/pkg/controller/operator/common/util.go
+++ b/api/pkg/controller/operator/common/util.go
@@ -1,0 +1,128 @@
+package common
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	operatorv1alpha1 "github.com/kubermatic/kubermatic/api/pkg/crd/operator/v1alpha1"
+	"github.com/kubermatic/kubermatic/api/pkg/resources"
+	"github.com/kubermatic/kubermatic/api/pkg/resources/reconciling"
+
+	appsv1 "k8s.io/api/apps/v1"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/client-go/tools/cache"
+	ctrlruntimeclient "sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+const (
+	// OperatorName is used as the value for ManagedBy labels to establish
+	// a weak ownership to reconciled resources.
+	OperatorName = "kubermatic-operator"
+
+	// ManagedByLabel is the label used to identify the resources
+	// created by this controller.
+	ManagedByLabel = "app.kubernetes.io/managed-by"
+
+	// ConfigurationOwnerAnnotation is the annotation containing a resource's
+	// owning configuration name and namespace.
+	ConfigurationOwnerAnnotation = "operator.kubermatic.io/configuration"
+)
+
+func StringifyFeatureGates(cfg *operatorv1alpha1.KubermaticConfiguration) string {
+	features := make([]string, 0)
+	for _, feature := range cfg.Spec.FeatureGates.List() {
+		features = append(features, fmt.Sprintf("%s=true", feature))
+	}
+
+	return strings.Join(features, ",")
+}
+
+// OwnerLabelsModifierFactory is generating a new ObjectModifier that wraps an ObjectCreator
+// and takes care of applying the default labels and annotations from this operator.
+// These are then used to establish a weak ownership.
+func OwnerLabelsModifierFactory(cfg *operatorv1alpha1.KubermaticConfiguration) reconciling.ObjectModifier {
+	return func(create reconciling.ObjectCreator) reconciling.ObjectCreator {
+		return func(existing runtime.Object) (runtime.Object, error) {
+			obj, err := create(existing)
+			if err != nil {
+				return obj, err
+			}
+
+			o, ok := obj.(metav1.Object)
+			if !ok {
+				return obj, nil
+			}
+
+			annotations := o.GetAnnotations()
+			if annotations == nil {
+				annotations = make(map[string]string)
+			}
+
+			identifier, err := cache.MetaNamespaceKeyFunc(cfg)
+			if err != nil {
+				return obj, fmt.Errorf("failed to determine KubermaticConfiguration string key: %v", err)
+			}
+
+			annotations[ConfigurationOwnerAnnotation] = identifier
+			o.SetAnnotations(annotations)
+
+			labels := o.GetLabels()
+			if labels == nil {
+				labels = make(map[string]string)
+			}
+			labels[ManagedByLabel] = OperatorName
+			o.SetLabels(labels)
+
+			return obj, nil
+		}
+	}
+}
+
+// VolumeRevisionLabelsModifierFactory scans volume mounts for pod templates for ConfigMaps
+// and Secrets and will then put new labels for these mounts onto the pod template, causing
+// restarts when the volumes changed.
+func VolumeRevisionLabelsModifierFactory(ctx context.Context, client ctrlruntimeclient.Client) reconciling.ObjectModifier {
+	return func(create reconciling.ObjectCreator) reconciling.ObjectCreator {
+		return func(existing runtime.Object) (runtime.Object, error) {
+			obj, err := create(existing)
+			if err != nil {
+				return obj, err
+			}
+
+			deployment, ok := obj.(*appsv1.Deployment)
+			if !ok {
+				return obj, nil
+			}
+
+			volumeLabels, err := resources.VolumeRevisionLabels(ctx, client, deployment.Namespace, deployment.Spec.Template.Spec.Volumes)
+			if err != nil {
+				return obj, fmt.Errorf("failed to determine revision labels for volumes: %v", err)
+			}
+
+			// switch to a new map in case the deployment used the same map for selector.matchLabels and labels
+			oldLabels := deployment.Spec.Template.Labels
+			deployment.Spec.Template.Labels = volumeLabels
+
+			for k, v := range oldLabels {
+				deployment.Spec.Template.Labels[k] = v
+			}
+
+			return obj, nil
+		}
+	}
+}
+
+func createSecretData(s *corev1.Secret, data map[string]string) *corev1.Secret {
+	if s.Data == nil {
+		s.Data = make(map[string][]byte)
+	}
+
+	for k, v := range data {
+		s.Data[k] = []byte(v)
+	}
+
+	return s
+}

--- a/api/pkg/controller/operator/master/controller.go
+++ b/api/pkg/controller/operator/master/controller.go
@@ -6,6 +6,7 @@ import (
 
 	"go.uber.org/zap"
 
+	"github.com/kubermatic/kubermatic/api/pkg/controller/operator/common"
 	predicateutil "github.com/kubermatic/kubermatic/api/pkg/controller/util/predicate"
 	operatorv1alpha1 "github.com/kubermatic/kubermatic/api/pkg/crd/operator/v1alpha1"
 	"github.com/kubermatic/kubermatic/api/pkg/util/workerlabel"
@@ -33,19 +34,6 @@ const (
 
 	// VersionLabel is the label containing the application's version.
 	VersionLabel = "app.kubernetes.io/version"
-
-	// ManagedByLabel is the label used to identify the resources
-	// created by this controller.
-	ManagedByLabel = "app.kubernetes.io/managed-by"
-
-	// ConfigurationOwnerAnnotation is the annotation containing a resource's
-	// owning configuration name and namespace.
-	ConfigurationOwnerAnnotation = "operator.kubermatic.io/configuration"
-
-	// WorkerNameLabel is the label containing the worker-name,
-	// restricting the operator that is willing to work on a given
-	// resource.
-	WorkerNameLabel = "operator.kubermatic.io/worker"
 )
 
 func Add(
@@ -92,11 +80,11 @@ func Add(
 
 	// for each child put the parent configuration onto the queue
 	childEventHandler := newEventHandler(func(a handler.MapObject) []reconcile.Request {
-		if a.Meta.GetLabels()[ManagedByLabel] != ControllerName {
+		if a.Meta.GetLabels()[common.ManagedByLabel] != common.OperatorName {
 			return nil
 		}
 
-		owner := a.Meta.GetAnnotations()[ConfigurationOwnerAnnotation]
+		owner := a.Meta.GetAnnotations()[common.ConfigurationOwnerAnnotation]
 		if owner == "" {
 			return nil
 		}

--- a/api/pkg/controller/operator/master/defaults.go
+++ b/api/pkg/controller/operator/master/defaults.go
@@ -7,13 +7,8 @@ import (
 
 	operatorv1alpha1 "github.com/kubermatic/kubermatic/api/pkg/crd/operator/v1alpha1"
 	"github.com/kubermatic/kubermatic/api/pkg/resources"
-	"github.com/kubermatic/kubermatic/api/pkg/resources/reconciling"
 
-	appsv1 "k8s.io/api/apps/v1"
 	"k8s.io/apimachinery/pkg/api/equality"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/apimachinery/pkg/runtime"
-	"k8s.io/client-go/tools/cache"
 )
 
 func (r *Reconciler) defaultConfiguration(config *operatorv1alpha1.KubermaticConfiguration, logger *zap.SugaredLogger) (bool, error) {
@@ -77,80 +72,5 @@ func (r *Reconciler) defaultImage(img *string, defaultImage string, key string, 
 	if *img == "" {
 		*img = defaultImage
 		logger.Debugf("Defaulting Docker image for %s to %s", key, defaultImage)
-	}
-}
-
-// applyOwnerLabels is generating a new ObjectModifier that wraps an ObjectCreator and takes care
-// of applying the default labels and annotations from this operator. These are then used to
-// establish a weak ownership.
-func (r *Reconciler) applyOwnerLabels(config *operatorv1alpha1.KubermaticConfiguration) reconciling.ObjectModifier {
-	return func(create reconciling.ObjectCreator) reconciling.ObjectCreator {
-		return func(existing runtime.Object) (runtime.Object, error) {
-			obj, err := create(existing)
-			if err != nil {
-				return obj, err
-			}
-
-			o, ok := obj.(metav1.Object)
-			if !ok {
-				return obj, nil
-			}
-
-			annotations := o.GetAnnotations()
-			if annotations == nil {
-				annotations = make(map[string]string)
-			}
-
-			identifier, err := cache.MetaNamespaceKeyFunc(config)
-			if err != nil {
-				return obj, fmt.Errorf("failed to determine KubermaticConfiguration string key: %v", err)
-			}
-
-			annotations[ConfigurationOwnerAnnotation] = identifier
-			o.SetAnnotations(annotations)
-
-			labels := o.GetLabels()
-			if labels == nil {
-				labels = make(map[string]string)
-			}
-			labels[ManagedByLabel] = ControllerName
-			o.SetLabels(labels)
-
-			return obj, nil
-		}
-	}
-}
-
-// volumeRevisionLabels scans volume mounts for pod templates for ConfigMaps and Secrets and
-// will then put new labels for these mounts onto the pod template, causing restarts when
-// the volumes changed.
-func (r *Reconciler) volumeRevisionLabels() reconciling.ObjectModifier {
-	return func(create reconciling.ObjectCreator) reconciling.ObjectCreator {
-		return func(existing runtime.Object) (runtime.Object, error) {
-			obj, err := create(existing)
-			if err != nil {
-				return obj, err
-			}
-
-			deployment, ok := obj.(*appsv1.Deployment)
-			if !ok {
-				return obj, nil
-			}
-
-			volumeLabels, err := resources.VolumeRevisionLabels(r.ctx, r.Client, deployment.Namespace, deployment.Spec.Template.Spec.Volumes)
-			if err != nil {
-				return obj, fmt.Errorf("failed to determine revision labels for volumes: %v", err)
-			}
-
-			// switch to a new map in case the deployment used the same map for selector.matchLabels and labels
-			oldLabels := deployment.Spec.Template.Labels
-			deployment.Spec.Template.Labels = volumeLabels
-
-			for k, v := range oldLabels {
-				deployment.Spec.Template.Labels[k] = v
-			}
-
-			return obj, nil
-		}
 	}
 }

--- a/api/pkg/controller/operator/master/defaults_test.go
+++ b/api/pkg/controller/operator/master/defaults_test.go
@@ -6,7 +6,6 @@ import (
 	"testing"
 
 	"github.com/go-logr/zapr"
-
 	"go.uber.org/zap"
 
 	operatorv1alpha1 "github.com/kubermatic/kubermatic/api/pkg/crd/operator/v1alpha1"

--- a/api/pkg/controller/operator/master/resources/kubermatic/api.go
+++ b/api/pkg/controller/operator/master/resources/kubermatic/api.go
@@ -3,6 +3,7 @@ package kubermatic
 import (
 	"fmt"
 
+	"github.com/kubermatic/kubermatic/api/pkg/controller/operator/common"
 	operatorv1alpha1 "github.com/kubermatic/kubermatic/api/pkg/crd/operator/v1alpha1"
 	"github.com/kubermatic/kubermatic/api/pkg/resources/reconciling"
 
@@ -54,7 +55,7 @@ func APIDeploymentCreator(cfg *operatorv1alpha1.KubermaticConfiguration) reconci
 			d.Spec.Template.Spec.ServiceAccountName = serviceAccountName
 			d.Spec.Template.Spec.ImagePullSecrets = []corev1.LocalObjectReference{
 				{
-					Name: dockercfgSecretName,
+					Name: common.DockercfgSecretName,
 				},
 			}
 
@@ -98,7 +99,7 @@ func APIDeploymentCreator(cfg *operatorv1alpha1.KubermaticConfiguration) reconci
 					Name: "master-files",
 					VolumeSource: corev1.VolumeSource{
 						Secret: &corev1.SecretVolumeSource{
-							SecretName: masterFilesSecretName,
+							SecretName: common.MasterFilesSecretName,
 						},
 					},
 				})

--- a/api/pkg/controller/operator/master/resources/kubermatic/master-controller-manager.go
+++ b/api/pkg/controller/operator/master/resources/kubermatic/master-controller-manager.go
@@ -1,8 +1,7 @@
 package kubermatic
 
 import (
-	"fmt"
-
+	"github.com/kubermatic/kubermatic/api/pkg/controller/operator/common"
 	operatorv1alpha1 "github.com/kubermatic/kubermatic/api/pkg/crd/operator/v1alpha1"
 	"github.com/kubermatic/kubermatic/api/pkg/resources/reconciling"
 
@@ -39,7 +38,7 @@ func MasterControllerManagerDeploymentCreator(cfg *operatorv1alpha1.KubermaticCo
 			d.Spec.Template.Spec.ServiceAccountName = serviceAccountName
 			d.Spec.Template.Spec.ImagePullSecrets = []corev1.LocalObjectReference{
 				{
-					Name: dockercfgSecretName,
+					Name: common.DockercfgSecretName,
 				},
 			}
 
@@ -50,7 +49,6 @@ func MasterControllerManagerDeploymentCreator(cfg *operatorv1alpha1.KubermaticCo
 				"-dynamic-datacenters=true",
 			}
 
-			d.Spec.Template.Spec.InitContainers = []corev1.Container{projectsMigratorContainer(cfg)}
 			d.Spec.Template.Spec.Containers = []corev1.Container{
 				{
 					Name:    "controller-manager",
@@ -79,19 +77,6 @@ func MasterControllerManagerDeploymentCreator(cfg *operatorv1alpha1.KubermaticCo
 
 			return d, nil
 		}
-	}
-}
-
-func projectsMigratorContainer(cfg *operatorv1alpha1.KubermaticConfiguration) corev1.Container {
-	return corev1.Container{
-		Name:    "projects-migrator",
-		Image:   cfg.Spec.MasterController.Image,
-		Command: []string{"projects-migrator"},
-		Args: []string{
-			"-v=2",
-			"-logtostderr",
-			fmt.Sprintf("-dry-run=%v", cfg.Spec.MasterController.ProjectsMigrator.DryRun),
-		},
 	}
 }
 

--- a/api/pkg/controller/operator/master/resources/kubermatic/ui.go
+++ b/api/pkg/controller/operator/master/resources/kubermatic/ui.go
@@ -1,6 +1,7 @@
 package kubermatic
 
 import (
+	"github.com/kubermatic/kubermatic/api/pkg/controller/operator/common"
 	operatorv1alpha1 "github.com/kubermatic/kubermatic/api/pkg/crd/operator/v1alpha1"
 	"github.com/kubermatic/kubermatic/api/pkg/resources/reconciling"
 
@@ -30,7 +31,7 @@ func UIDeploymentCreator(cfg *operatorv1alpha1.KubermaticConfiguration) reconcil
 			d.Spec.Template.Labels = d.Spec.Selector.MatchLabels
 			d.Spec.Template.Spec.ImagePullSecrets = []corev1.LocalObjectReference{
 				{
-					Name: dockercfgSecretName,
+					Name: common.DockercfgSecretName,
 				},
 			}
 
@@ -82,10 +83,8 @@ func UIDeploymentCreator(cfg *operatorv1alpha1.KubermaticConfiguration) reconcil
 }
 
 func UIPDBCreator(cfg *operatorv1alpha1.KubermaticConfiguration) reconciling.NamedPodDisruptionBudgetCreatorGetter {
-	name := "kubermatic-ui"
-
 	return func() (string, reconciling.PodDisruptionBudgetCreator) {
-		return name, func(pdb *policyv1beta1.PodDisruptionBudget) (*policyv1beta1.PodDisruptionBudget, error) {
+		return "kubermatic-ui", func(pdb *policyv1beta1.PodDisruptionBudget) (*policyv1beta1.PodDisruptionBudget, error) {
 			min := intstr.FromInt(1)
 
 			pdb.Spec.MinAvailable = &min

--- a/api/pkg/controller/operator/seed/controller.go
+++ b/api/pkg/controller/operator/seed/controller.go
@@ -36,19 +36,6 @@ const (
 
 	// VersionLabel is the label containing the application's version.
 	VersionLabel = "app.kubernetes.io/version"
-
-	// ManagedByLabel is the label used to identify the resources
-	// created by this controller.
-	ManagedByLabel = "app.kubernetes.io/managed-by"
-
-	// ConfigurationOwnerAnnotation is the annotation containing a resource's
-	// owning configuration name and namespace.
-	ConfigurationOwnerAnnotation = "operator.kubermatic.io/configuration"
-
-	// WorkerNameLabel is the label containing the worker-name,
-	// restricting the operator that is willing to work on a given
-	// resource.
-	WorkerNameLabel = "operator.kubermatic.io/worker"
 )
 
 func Add(
@@ -61,17 +48,24 @@ func Add(
 	numWorkers int,
 	workerName string,
 ) error {
+	workerNameSelector, err := workerlabel.LabelSelector(workerName)
+	if err != nil {
+		return fmt.Errorf("failed to create worker-name label selector: %v", err)
+	}
+
 	namespacePredicate := predicateutil.ByNamespace(namespace)
 	workerNamePredicate := workerlabel.Predicates(workerName)
 
 	reconciler := &Reconciler{
-		ctx:            ctx,
-		log:            log.Named(ControllerName),
-		namespace:      namespace,
-		masterClient:   masterManager.GetClient(),
-		seedClients:    map[string]ctrlruntimeclient.Client{},
-		masterRecorder: masterManager.GetEventRecorderFor(ControllerName),
-		workerName:     workerName,
+		ctx:                ctx,
+		log:                log.Named(ControllerName),
+		namespace:          namespace,
+		masterClient:       masterManager.GetClient(),
+		seedsGetter:        seedsGetter,
+		seedClients:        map[string]ctrlruntimeclient.Client{},
+		masterRecorder:     masterManager.GetEventRecorderFor(ControllerName),
+		workerName:         workerName,
+		workerNameSelector: workerNameSelector,
 	}
 
 	ctrlOpts := controller.Options{

--- a/api/pkg/controller/operator/seed/controller.go
+++ b/api/pkg/controller/operator/seed/controller.go
@@ -48,24 +48,17 @@ func Add(
 	numWorkers int,
 	workerName string,
 ) error {
-	workerNameSelector, err := workerlabel.LabelSelector(workerName)
-	if err != nil {
-		return fmt.Errorf("failed to create worker-name label selector: %v", err)
-	}
-
 	namespacePredicate := predicateutil.ByNamespace(namespace)
 	workerNamePredicate := workerlabel.Predicates(workerName)
 
 	reconciler := &Reconciler{
-		ctx:                ctx,
-		log:                log.Named(ControllerName),
-		namespace:          namespace,
-		masterClient:       masterManager.GetClient(),
-		seedsGetter:        seedsGetter,
-		seedClients:        map[string]ctrlruntimeclient.Client{},
-		masterRecorder:     masterManager.GetEventRecorderFor(ControllerName),
-		workerName:         workerName,
-		workerNameSelector: workerNameSelector,
+		ctx:            ctx,
+		log:            log.Named(ControllerName),
+		namespace:      namespace,
+		masterClient:   masterManager.GetClient(),
+		seedClients:    map[string]ctrlruntimeclient.Client{},
+		masterRecorder: masterManager.GetEventRecorderFor(ControllerName),
+		workerName:     workerName,
 	}
 
 	ctrlOpts := controller.Options{

--- a/api/pkg/controller/operator/seed/reconciler.go
+++ b/api/pkg/controller/operator/seed/reconciler.go
@@ -3,8 +3,10 @@ package seed
 import (
 	"context"
 
+	"github.com/kubermatic/kubermatic/api/pkg/provider"
 	"go.uber.org/zap"
 
+	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/client-go/tools/record"
 	ctrlruntimeclient "sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
@@ -15,13 +17,15 @@ import (
 type Reconciler struct {
 	ctrlruntimeclient.Client
 
-	ctx            context.Context
-	log            *zap.SugaredLogger
-	namespace      string
-	masterClient   ctrlruntimeclient.Client
-	seedClients    map[string]ctrlruntimeclient.Client
-	masterRecorder record.EventRecorder
-	workerName     string
+	ctx                context.Context
+	log                *zap.SugaredLogger
+	namespace          string
+	masterClient       ctrlruntimeclient.Client
+	seedsGetter        provider.SeedsGetter
+	seedClients        map[string]ctrlruntimeclient.Client
+	masterRecorder     record.EventRecorder
+	workerName         string
+	workerNameSelector labels.Selector
 }
 
 // Reconcile acts upon requests and will restore the state of resources

--- a/api/pkg/controller/operator/seed/reconciler.go
+++ b/api/pkg/controller/operator/seed/reconciler.go
@@ -3,10 +3,8 @@ package seed
 import (
 	"context"
 
-	"github.com/kubermatic/kubermatic/api/pkg/provider"
 	"go.uber.org/zap"
 
-	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/client-go/tools/record"
 	ctrlruntimeclient "sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
@@ -17,15 +15,13 @@ import (
 type Reconciler struct {
 	ctrlruntimeclient.Client
 
-	ctx                context.Context
-	log                *zap.SugaredLogger
-	namespace          string
-	masterClient       ctrlruntimeclient.Client
-	seedsGetter        provider.SeedsGetter
-	seedClients        map[string]ctrlruntimeclient.Client
-	masterRecorder     record.EventRecorder
-	workerName         string
-	workerNameSelector labels.Selector
+	ctx            context.Context
+	log            *zap.SugaredLogger
+	namespace      string
+	masterClient   ctrlruntimeclient.Client
+	seedClients    map[string]ctrlruntimeclient.Client
+	masterRecorder record.EventRecorder
+	workerName     string
 }
 
 // Reconcile acts upon requests and will restore the state of resources


### PR DESCRIPTION
**What this PR does / why we need it**:
This has been extracted from a much larger diff, hopefully it's small enough to make sense. This PR extracts behaviour common to master and seed reconciling into a new package, `common`. This new package contains a couple of resource creators, constants and object modifiers.

**Does this PR introduce a user-facing change?**:
```release-note
NONE
```
