### PR TITLE
Use an owner reference instead of an annotation

### DIFF
--- a/api/pkg/controller/operator/common/util.go
+++ b/api/pkg/controller/operator/common/util.go
@@ -52,8 +52,8 @@ func OwnershipModifierFactory(cfg *operatorv1alpha1.KubermaticConfiguration) rec
 			}
 
 			o.SetOwnerReferences([]metav1.OwnerReference{{
-				APIVersion:         "operator.kubermatic.io/v1alpha1",
-				Kind:               "KubermaticConfiguration",
+				APIVersion:         cfg.APIVersion,
+				Kind:               cfg.Kind,
 				Name:               cfg.Name,
 				UID:                cfg.UID,
 				Controller:         pointer.BoolPtr(true),

--- a/api/pkg/controller/operator/master/controller.go
+++ b/api/pkg/controller/operator/master/controller.go
@@ -72,9 +72,9 @@ func Add(
 		}
 	})
 
-	obj := &operatorv1alpha1.KubermaticConfiguration{}
-	if err := c.Watch(&source.Kind{Type: obj}, kubermaticConfigHandler, namespacePredicate, workerNamePredicate); err != nil {
-		return fmt.Errorf("failed to create watcher for %T: %v", obj, err)
+	dummyConfig := &operatorv1alpha1.KubermaticConfiguration{}
+	if err := c.Watch(&source.Kind{Type: dummyConfig}, kubermaticConfigHandler, namespacePredicate, workerNamePredicate); err != nil {
+		return fmt.Errorf("failed to create watcher for %T: %v", dummyConfig, err)
 	}
 
 	// for each child put the parent configuration onto the queue
@@ -84,7 +84,7 @@ func Add(
 		}
 
 		for _, ref := range a.Meta.GetOwnerReferences() {
-			if ref.Kind == "KubermaticConfiguration" {
+			if ref.Kind == dummyConfig.Kind && ref.APIVersion == dummyConfig.APIVersion {
 				return []reconcile.Request{{
 					NamespacedName: types.NamespacedName{
 						Namespace: a.Meta.GetNamespace(),

--- a/api/pkg/controller/operator/master/reconciler.go
+++ b/api/pkg/controller/operator/master/reconciler.go
@@ -115,7 +115,7 @@ func (r *Reconciler) reconcileConfigMaps(config *operatorv1alpha1.KubermaticConf
 		common.BackupContainersConfigMapCreator(config),
 	}
 
-	if err := reconciling.ReconcileConfigMaps(r.ctx, creators, config.Namespace, r.Client, common.OwnerLabelsModifierFactory(config)); err != nil {
+	if err := reconciling.ReconcileConfigMaps(r.ctx, creators, config.Namespace, r.Client, common.OwnershipModifierFactory(config)); err != nil {
 		return fmt.Errorf("failed to reconcile ConfigMaps: %v", err)
 	}
 
@@ -138,7 +138,7 @@ func (r *Reconciler) reconcileSecrets(config *operatorv1alpha1.KubermaticConfigu
 		creators = append(creators, kubermatic.PresetsSecretCreator(config))
 	}
 
-	if err := reconciling.ReconcileSecrets(r.ctx, creators, config.Namespace, r.Client, common.OwnerLabelsModifierFactory(config)); err != nil {
+	if err := reconciling.ReconcileSecrets(r.ctx, creators, config.Namespace, r.Client, common.OwnershipModifierFactory(config)); err != nil {
 		return fmt.Errorf("failed to reconcile Secrets: %v", err)
 	}
 
@@ -152,7 +152,7 @@ func (r *Reconciler) reconcileServiceAccounts(config *operatorv1alpha1.Kubermati
 		kubermatic.ServiceAccountCreator(config),
 	}
 
-	if err := reconciling.ReconcileServiceAccounts(r.ctx, creators, config.Namespace, r.Client, common.OwnerLabelsModifierFactory(config)); err != nil {
+	if err := reconciling.ReconcileServiceAccounts(r.ctx, creators, config.Namespace, r.Client, common.OwnershipModifierFactory(config)); err != nil {
 		return fmt.Errorf("failed to reconcile ServiceAccounts: %v", err)
 	}
 
@@ -166,7 +166,7 @@ func (r *Reconciler) reconcileClusterRoleBindings(config *operatorv1alpha1.Kuber
 		kubermatic.ClusterRoleBindingCreator(config),
 	}
 
-	if err := reconciling.ReconcileClusterRoleBindings(r.ctx, creators, "", r.Client, common.OwnerLabelsModifierFactory(config)); err != nil {
+	if err := reconciling.ReconcileClusterRoleBindings(r.ctx, creators, "", r.Client, common.OwnershipModifierFactory(config)); err != nil {
 		return fmt.Errorf("failed to reconcile ClusterRoleBindings: %v", err)
 	}
 
@@ -183,7 +183,7 @@ func (r *Reconciler) reconcileDeployments(config *operatorv1alpha1.KubermaticCon
 	}
 
 	modifiers := []reconciling.ObjectModifier{
-		common.OwnerLabelsModifierFactory(config),
+		common.OwnershipModifierFactory(config),
 		common.VolumeRevisionLabelsModifierFactory(r.ctx, r.Client),
 	}
 
@@ -203,7 +203,7 @@ func (r *Reconciler) reconcilePodDisruptionBudgets(config *operatorv1alpha1.Kube
 		kubermatic.MasterControllerManagerPDBCreator(config),
 	}
 
-	if err := reconciling.ReconcilePodDisruptionBudgets(r.ctx, creators, config.Namespace, r.Client, common.OwnerLabelsModifierFactory(config)); err != nil {
+	if err := reconciling.ReconcilePodDisruptionBudgets(r.ctx, creators, config.Namespace, r.Client, common.OwnershipModifierFactory(config)); err != nil {
 		return fmt.Errorf("failed to reconcile PodDisruptionBudgets: %v", err)
 	}
 
@@ -218,7 +218,7 @@ func (r *Reconciler) reconcileServices(config *operatorv1alpha1.KubermaticConfig
 		kubermatic.UIServiceCreator(config),
 	}
 
-	if err := reconciling.ReconcileServices(r.ctx, creators, config.Namespace, r.Client, common.OwnerLabelsModifierFactory(config)); err != nil {
+	if err := reconciling.ReconcileServices(r.ctx, creators, config.Namespace, r.Client, common.OwnershipModifierFactory(config)); err != nil {
 		return fmt.Errorf("failed to reconcile Services: %v", err)
 	}
 
@@ -232,7 +232,7 @@ func (r *Reconciler) reconcileIngresses(config *operatorv1alpha1.KubermaticConfi
 		kubermatic.IngressCreator(config),
 	}
 
-	if err := reconciling.ReconcileIngresses(r.ctx, creators, config.Namespace, r.Client, common.OwnerLabelsModifierFactory(config)); err != nil {
+	if err := reconciling.ReconcileIngresses(r.ctx, creators, config.Namespace, r.Client, common.OwnershipModifierFactory(config)); err != nil {
 		return fmt.Errorf("failed to reconcile Ingresses: %v", err)
 	}
 


### PR DESCRIPTION
**What this PR does / why we need it**:
Originally we wanted to avoid strong ownership, but we cannot really remember why. Also since the operator has been turned into a namespaced thing and Seed CRs now exist, the old weak ownership system via annotations seems like a poor reimplementation of actual ownership references.

This PR replaces the old system with ownership refs.

**Does this PR introduce a user-facing change?**:
```release-note
NONE
```
