### PR TITLE
Usercluster controller manager: Add seed client and cache

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -38,6 +38,7 @@ issues:
   - cyclomatic complexity [0-9]+ of func `main` is high
   - cyclomatic complexity [0-9]+ of func `TestDatacenterMetasToSeedDatacenterSpecs` is high
   - cyclomatic complexity [0-9]+ of func `\(\*Azure\)\.CleanUpCloudProvider` is high
+  - cyclomatic complexity [0-9]+ of func `\(\*Reconciler\)\.reconcile` is high
   # goconst
   - string `(get|openshift-kube-scheduler|us-central1|quay.io/openshift-release-dev/ocp-v4.0-art-dev@sha256:86255c4efe6bbc141a0f41444f863bbd5cd832ffca21d2b737a4f9c225ed00ad)` has [0-9]+ occurrences. make it a constant
   # gocritic

--- a/api/cmd/user-cluster-controller-manager/main.go
+++ b/api/cmd/user-cluster-controller-manager/main.go
@@ -281,32 +281,3 @@ func main() {
 	}
 
 }
-
-func getUserSSHKeys(path string) (map[string][]byte, error) {
-	secretsDir, err := os.Readlink(fmt.Sprintf("%v/%v", path, "..data"))
-	if err != nil {
-		return nil, err
-	}
-
-	files, err := ioutil.ReadDir(fmt.Sprintf("%v/%v", path, secretsDir))
-	if err != nil {
-		return nil, err
-	}
-
-	var data = make(map[string][]byte, len(files))
-
-	for _, file := range files {
-		if file.IsDir() {
-			continue
-		}
-
-		secret, err := ioutil.ReadFile(fmt.Sprintf("%v/%v", path, file.Name()))
-		if err != nil {
-			return nil, fmt.Errorf("failed to read file %v during secret creation: %v", file.Name(), err)
-		}
-
-		data[file.Name()] = secret
-	}
-
-	return data, nil
-}

--- a/api/cmd/user-cluster-controller-manager/main.go
+++ b/api/cmd/user-cluster-controller-manager/main.go
@@ -52,9 +52,6 @@ type controllerRunOptions struct {
 	namespace                     string
 	clusterURL                    string
 	openvpnServerPort             int
-	openvpnCACertFilePath         string
-	openvpnCAKeyFilePath          string
-	userSSHKeysDirPath            string
 	overwriteRegistry             string
 	cloudProviderName             string
 	cloudCredentialSecretTemplate string
@@ -74,7 +71,6 @@ func main() {
 	flag.StringVar(&runOp.namespace, "namespace", "", "Namespace in which the cluster is running in")
 	flag.StringVar(&runOp.clusterURL, "cluster-url", "", "Cluster URL")
 	flag.IntVar(&runOp.openvpnServerPort, "openvpn-server-port", 0, "OpenVPN server port")
-	flag.StringVar(&runOp.userSSHKeysDirPath, "user-ssh-keys-dir-path", "", "Path to the user ssh keys dir")
 	flag.StringVar(&runOp.overwriteRegistry, "overwrite-registry", "", "registry to use for all images")
 	flag.BoolVar(&runOp.log.Debug, "log-debug", false, "Enables debug logging")
 	flag.StringVar(&runOp.log.Format, "log-format", string(kubermaticlog.FormatJSON), "Log format. Available are: "+kubermaticlog.AvailableFormats.String())
@@ -105,14 +101,6 @@ func main() {
 	}
 	if runOp.openvpnServerPort == 0 {
 		log.Fatal("-openvpn-server-port must be set")
-	}
-
-	var userSSHKeys map[string][]byte
-	if runOp.userSSHKeysDirPath != "" {
-		userSSHKeys, err = getUserSSHKeys(runOp.userSSHKeysDirPath)
-		if err != nil {
-			log.Fatalw("Failed reading userSSHKey files", zap.Error(err))
-		}
 	}
 
 	var cloudCredentialSecretTemplate *corev1.Secret
@@ -197,7 +185,6 @@ func main() {
 		runOp.cloudProviderName,
 		clusterURL,
 		runOp.openvpnServerPort,
-		userSSHKeys,
 		healthHandler.AddReadinessCheck,
 		cloudCredentialSecretTemplate,
 		log); err != nil {

--- a/api/cmd/user-cluster-controller-manager/main.go
+++ b/api/cmd/user-cluster-controller-manager/main.go
@@ -3,7 +3,6 @@ package main
 import (
 	"context"
 	"crypto/ecdsa"
-	"crypto/rsa"
 	"encoding/json"
 	"errors"
 	"flag"
@@ -39,7 +38,6 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/rest"
 	"k8s.io/client-go/tools/clientcmd"
-	certutil "k8s.io/client-go/util/cert"
 	"k8s.io/klog"
 	apiregistrationv1beta1 "k8s.io/kube-aggregator/pkg/apis/apiregistration/v1beta1"
 	"sigs.k8s.io/controller-runtime/pkg/client/config"
@@ -55,8 +53,6 @@ type controllerRunOptions struct {
 	version                       string
 	networks                      networkFlags
 	namespace                     string
-	caPath                        string
-	caKeyPath                     string
 	clusterURL                    string
 	openvpnServerPort             int
 	openvpnCACertFilePath         string
@@ -79,8 +75,6 @@ func main() {
 	flag.StringVar(&runOp.version, "version", "", "The version of the cluster")
 	flag.Var(&runOp.networks, "ipam-controller-network", "The networks from which the ipam controller should allocate IPs for machines (e.g.: .--ipam-controller-network=10.0.0.0/16,10.0.0.1,8.8.8.8 --ipam-controller-network=192.168.5.0/24,192.168.5.1,1.1.1.1,8.8.4.4)")
 	flag.StringVar(&runOp.namespace, "namespace", "", "Namespace in which the cluster is running in")
-	flag.StringVar(&runOp.caPath, "ca-cert", "ca.crt", "Path to the CA cert file")
-	flag.StringVar(&runOp.caKeyPath, "ca-key", "ca.key", "Path to the ca key file")
 	flag.StringVar(&runOp.clusterURL, "cluster-url", "", "Cluster URL")
 	flag.IntVar(&runOp.openvpnServerPort, "openvpn-server-port", 0, "OpenVPN server port")
 	flag.StringVar(&runOp.openvpnCACertFilePath, "openvpn-ca-cert-file", "", "Path to the OpenVPN CA cert file")
@@ -107,9 +101,6 @@ func main() {
 	if runOp.namespace == "" {
 		log.Fatal("-namespace must be set")
 	}
-	if runOp.caPath == "" {
-		log.Fatal("-ca-cert must be set")
-	}
 	if runOp.clusterURL == "" {
 		log.Fatal("-cluster-url must be set")
 	}
@@ -120,31 +111,6 @@ func main() {
 	if runOp.openvpnServerPort == 0 {
 		log.Fatal("-openvpn-server-port must be set")
 	}
-
-	caBytes, err := ioutil.ReadFile(runOp.caPath)
-	if err != nil {
-		log.Fatalw("Failed to read CA cert", zap.Error(err))
-	}
-	certs, err := certutil.ParseCertsPEM(caBytes)
-	if err != nil {
-		log.Fatalw("Failed to parse certs", zap.Error(err))
-	}
-	if len(certs) != 1 {
-		log.Fatalw("Did not find exactly one certificate in the given CA", "certificates-count", len(certs))
-	}
-	caKeyBytes, err := ioutil.ReadFile(runOp.caKeyPath)
-	if err != nil {
-		log.Fatalw("Failed to read ca-key file", zap.Error(err))
-	}
-	caKey, err := triple.ParsePrivateKeyPEM(caKeyBytes)
-	if err != nil {
-		log.Fatalw("Failed to parse ca-key", zap.Error(err))
-	}
-	rsaCAKey, isRSAKey := caKey.(*rsa.PrivateKey)
-	if !isRSAKey {
-		log.Fatalf("Expected ca-key to be an RSA key, but was a %T", caKey)
-	}
-	caCert := &triple.KeyPair{Cert: certs[0], Key: rsaCAKey}
 
 	openVPNCACertBytes, err := ioutil.ReadFile(runOp.openvpnCACertFilePath)
 	if err != nil {
@@ -253,11 +219,11 @@ func main() {
 	// Setup all Controllers
 	log.Info("registering controllers")
 	if err := usercluster.Add(mgr,
+		seedMgr,
 		runOp.openshift,
 		runOp.version,
 		runOp.namespace,
 		runOp.cloudProviderName,
-		caCert,
 		clusterURL,
 		runOp.openvpnServerPort,
 		userSSHKeys,

--- a/api/cmd/user-cluster-controller-manager/main.go
+++ b/api/cmd/user-cluster-controller-manager/main.go
@@ -6,7 +6,6 @@ import (
 	"errors"
 	"flag"
 	"fmt"
-	"io/ioutil"
 	"net/http"
 	"net/url"
 	"os"

--- a/api/hack/run-userclustercontroller.sh
+++ b/api/hack/run-userclustercontroller.sh
@@ -10,26 +10,21 @@ make user-cluster-controller-manager
 # Getting everything we need from the api
 # TODO: append -n cluster-$CLUSTER_NAME here or switch to the namespace before
 ADMIN_KUBECONFIG_RAW="$(kubectl get secret admin-kubeconfig -o json)"
-CA_CERT_RAW="$(kubectl get secret ca -o json)"
 OPENVPN_CA_SECRET_RAW="$(kubectl get secret openvpn-ca -o json)"
 CLUSTER_RAW="$(kubectl get cluster $(echo $ADMIN_KUBECONFIG_RAW|jq -r '.metadata.namespace'|sed 's/cluster-//') -o json)"
 OPENVPN_SERVER_SERVICE_RAW="$(kubectl get service openvpn-server -o json )"
 
 SEED_SERVICEACCOUNT_TOKEN="$(kubectl get secret -o json \
-  |jq '.items[]|select(.metadata.annotations["kubernetes.io/service-account.name"] == "usercluster-controller-manager")|.data.token' -r \
+  |jq '.items[]|select(.metadata.annotations["kubernetes.io/service-account.name"] == "kubermatic-usercluster-controller-manager")|.data.token' -r \
   |base64 -d)"
 SEED_KUBECONFIG=$(mktemp)
 kubectl config view  --flatten --minify -ojson \
   |jq --arg token "$SEED_SERVICEACCOUNT_TOKEN" 'del(.users[0].user)|.users[0].user.token = $token' > $SEED_KUBECONFIG
 
-CA_CERT_FILE=$(mktemp)
-CA_CERT_KEY_FILE=$(mktemp)
 OPENVPN_CA_CERT_FILE=$(mktemp)
 OPENVPN_CA_KEY_FILE=$(mktemp)
 KUBECONFIG_USERCLUSTER_CONTROLLER_FILE=$(mktemp)
 
-echo ${CA_CERT_RAW}|jq -r '.data["ca.crt"]'|base64 -d > ${CA_CERT_FILE}
-echo ${CA_CERT_RAW}|jq -r '.data["ca.key"]'|base64 -d > ${CA_CERT_KEY_FILE}
 echo ${OPENVPN_CA_SECRET_RAW}|jq -r '.data["ca.crt"]'|base64 -d > ${OPENVPN_CA_CERT_FILE}
 echo ${OPENVPN_CA_SECRET_RAW}|jq -r '.data["ca.key"]'|base64 -d > ${OPENVPN_CA_KEY_FILE}
 echo ${ADMIN_KUBECONFIG_RAW}|jq -r '.data.kubeconfig' |base64 -d > ${KUBECONFIG_USERCLUSTER_CONTROLLER_FILE}
@@ -57,8 +52,6 @@ fi
     -openvpn-ca-cert-file=${OPENVPN_CA_CERT_FILE} \
     -openvpn-ca-key-file=${OPENVPN_CA_KEY_FILE} \
     -cluster-url=${CLUSTER_URL} \
-    -ca-cert=${CA_CERT_FILE} \
-    -ca-key=${CA_CERT_KEY_FILE} \
     -version=${CLUSTER_VERSION} \
     -log-debug=true \
     -log-format=Console \

--- a/api/hack/run-userclustercontroller.sh
+++ b/api/hack/run-userclustercontroller.sh
@@ -10,7 +10,6 @@ make user-cluster-controller-manager
 # Getting everything we need from the api
 # TODO: append -n cluster-$CLUSTER_NAME here or switch to the namespace before
 ADMIN_KUBECONFIG_RAW="$(kubectl get secret admin-kubeconfig -o json)"
-OPENVPN_CA_SECRET_RAW="$(kubectl get secret openvpn-ca -o json)"
 CLUSTER_RAW="$(kubectl get cluster $(echo $ADMIN_KUBECONFIG_RAW|jq -r '.metadata.namespace'|sed 's/cluster-//') -o json)"
 OPENVPN_SERVER_SERVICE_RAW="$(kubectl get service openvpn-server -o json )"
 
@@ -21,12 +20,8 @@ SEED_KUBECONFIG=$(mktemp)
 kubectl config view  --flatten --minify -ojson \
   |jq --arg token "$SEED_SERVICEACCOUNT_TOKEN" 'del(.users[0].user)|.users[0].user.token = $token' > $SEED_KUBECONFIG
 
-OPENVPN_CA_CERT_FILE=$(mktemp)
-OPENVPN_CA_KEY_FILE=$(mktemp)
 KUBECONFIG_USERCLUSTER_CONTROLLER_FILE=$(mktemp)
 
-echo ${OPENVPN_CA_SECRET_RAW}|jq -r '.data["ca.crt"]'|base64 -d > ${OPENVPN_CA_CERT_FILE}
-echo ${OPENVPN_CA_SECRET_RAW}|jq -r '.data["ca.key"]'|base64 -d > ${OPENVPN_CA_KEY_FILE}
 echo ${ADMIN_KUBECONFIG_RAW}|jq -r '.data.kubeconfig' |base64 -d > ${KUBECONFIG_USERCLUSTER_CONTROLLER_FILE}
 
 CLUSTER_VERSION="$(echo $CLUSTER_RAW|jq -r '.spec.version')"
@@ -49,8 +44,6 @@ fi
     -health-listen-address=127.0.0.1:8088 \
     -namespace=${CLUSTER_NAMESPACE} \
     -openvpn-server-port=${OPENVPN_SERVER_NODEPORT} \
-    -openvpn-ca-cert-file=${OPENVPN_CA_CERT_FILE} \
-    -openvpn-ca-key-file=${OPENVPN_CA_KEY_FILE} \
     -cluster-url=${CLUSTER_URL} \
     -version=${CLUSTER_VERSION} \
     -log-debug=true \

--- a/api/pkg/controller/backup/backup_controller.go
+++ b/api/pkg/controller/backup/backup_controller.go
@@ -281,7 +281,7 @@ func (r *Reconciler) ensureCronJobSecret(ctx context.Context, cluster *kubermati
 	secretName := r.getEtcdSecretName(cluster)
 
 	getCA := func() (*triple.KeyPair, error) {
-		return resources.GetClusterRootCA(ctx, cluster, r.Client)
+		return resources.GetClusterRootCA(ctx, cluster.Status.NamespaceName, r.Client)
 	}
 
 	_, creator := certificates.GetClientCertificateCreator(

--- a/api/pkg/controller/cluster/cluster_controller.go
+++ b/api/pkg/controller/cluster/cluster_controller.go
@@ -18,6 +18,7 @@ import (
 	batchv1beta1 "k8s.io/api/batch/v1beta1"
 	corev1 "k8s.io/api/core/v1"
 	policyv1beta1 "k8s.io/api/policy/v1beta1"
+	rbacv1 "k8s.io/api/rbac/v1"
 	kubeapierrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -150,6 +151,7 @@ func Add(
 
 	typesToWatch := []runtime.Object{
 		&corev1.Service{},
+		&corev1.ServiceAccount{},
 		&corev1.ConfigMap{},
 		&corev1.Secret{},
 		&corev1.Namespace{},
@@ -158,6 +160,8 @@ func Add(
 		&batchv1beta1.CronJob{},
 		&policyv1beta1.PodDisruptionBudget{},
 		&autoscalingv1beta2.VerticalPodAutoscaler{},
+		&rbacv1.Role{},
+		&rbacv1.RoleBinding{},
 	}
 
 	for _, t := range typesToWatch {

--- a/api/pkg/controller/openshift/testdata/Kubermatic_API_image_is_overwritten-usercluster-controller.golden.yaml
+++ b/api/pkg/controller/openshift/testdata/Kubermatic_API_image_is_overwritten-usercluster-controller.golden.yaml
@@ -23,11 +23,8 @@ spec:
       creationTimestamp: null
       labels:
         app: usercluster-controller
-        ca-secret-revision: ""
         cluster: test-cluster
         internal-admin-kubeconfig-secret-revision: ""
-        openvpn-ca-secret-revision: ""
-        usersshkeys-secret-revision: 1-1
     spec:
       containers:
       - args:
@@ -41,7 +38,7 @@ spec:
         - -timeout
         - "1"
         - -command
-        - '{"command":"/usr/local/bin/user-cluster-controller-manager","args":["-kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","-metrics-listen-address","0.0.0.0:8085","-health-listen-address","0.0.0.0:8086","-namespace","$(NAMESPACE)","-ca-cert","/etc/kubernetes/pki/ca/ca.crt","-ca-key","/etc/kubernetes/pki/ca/ca.key","-cluster-url","https://test-cluster.alias-europe-west3-c.dev.kubermatic.io:0","-openvpn-server-port","0","-overwrite-registry","","-openshift=true","-version","4.1.9","-cloud-provider-name","","-openvpn-ca-cert-file=/etc/kubernetes/pki/openvpn/ca.crt","-openvpn-ca-key-file=/etc/kubernetes/pki/openvpn/ca.key","-user-ssh-keys-dir-path=/etc/kubernetes/usersshkeys"]}'
+        - '{"command":"/usr/local/bin/user-cluster-controller-manager","args":["-kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","-metrics-listen-address","0.0.0.0:8085","-health-listen-address","0.0.0.0:8086","-namespace","$(NAMESPACE)","-cluster-url","https://test-cluster.alias-europe-west3-c.dev.kubermatic.io:0","-openvpn-server-port","0","-overwrite-registry","","-openshift=true","-version","4.1.9","-cloud-provider-name",""]}'
         command:
         - /http-prober-bin/http-prober
         env:
@@ -75,15 +72,6 @@ spec:
         - mountPath: /etc/kubernetes/kubeconfig
           name: internal-admin-kubeconfig
           readOnly: true
-        - mountPath: /etc/kubernetes/pki/ca
-          name: ca
-          readOnly: true
-        - mountPath: /etc/kubernetes/pki/openvpn
-          name: openvpn-ca
-          readOnly: true
-        - mountPath: /etc/kubernetes/usersshkeys
-          name: usersshkeys
-          readOnly: true
         - mountPath: /http-prober-bin
           name: http-prober-bin
       imagePullSecrets:
@@ -102,23 +90,12 @@ spec:
         volumeMounts:
         - mountPath: /http-prober-bin
           name: http-prober-bin
+      serviceAccountName: kubermatic-usercluster-controller-manager
       volumes:
       - name: internal-admin-kubeconfig
         secret:
           defaultMode: 420
           secretName: internal-admin-kubeconfig
-      - name: ca
-        secret:
-          defaultMode: 420
-          secretName: ca
-      - name: openvpn-ca
-        secret:
-          defaultMode: 420
-          secretName: openvpn-ca
-      - name: usersshkeys
-        secret:
-          defaultMode: 420
-          secretName: usersshkeys
       - emptyDir: {}
         name: http-prober-bin
 status: {}

--- a/api/pkg/controller/user-cluster-controller-manager/resources/controller.go
+++ b/api/pkg/controller/user-cluster-controller-manager/resources/controller.go
@@ -192,5 +192,5 @@ func (r *reconciler) Reconcile(request reconcile.Request) (reconcile.Result, err
 }
 
 func (r *reconciler) caCert(ctx context.Context) (*triple.KeyPair, error) {
-	return nil, nil
+	return resources.GetClusterRootCA(ctx, r.namespace, r.seedClient)
 }

--- a/api/pkg/controller/user-cluster-controller-manager/resources/controller.go
+++ b/api/pkg/controller/user-cluster-controller-manager/resources/controller.go
@@ -49,7 +49,6 @@ func Add(
 	openvpnServerPort int,
 	userSSHKeys map[string][]byte,
 	registerReconciledCheck func(name string, check healthcheck.Check),
-	openVPNCA *resources.ECDSAKeyPair,
 	cloudCredentialSecretTemplate *corev1.Secret,
 	log *zap.SugaredLogger) error {
 	reconciler := &reconciler{
@@ -62,7 +61,6 @@ func Add(
 		namespace:                     namespace,
 		clusterURL:                    clusterURL,
 		openvpnServerPort:             openvpnServerPort,
-		openVPNCA:                     openVPNCA,
 		cloudCredentialSecretTemplate: cloudCredentialSecretTemplate,
 		log:                           log,
 		platform:                      cloudProviderName,
@@ -167,7 +165,6 @@ type reconciler struct {
 	namespace                     string
 	clusterURL                    *url.URL
 	openvpnServerPort             int
-	openVPNCA                     *resources.ECDSAKeyPair
 	platform                      string
 	cloudCredentialSecretTemplate *corev1.Secret
 	userSSHKeys                   map[string][]byte
@@ -193,4 +190,8 @@ func (r *reconciler) Reconcile(request reconcile.Request) (reconcile.Result, err
 
 func (r *reconciler) caCert(ctx context.Context) (*triple.KeyPair, error) {
 	return resources.GetClusterRootCA(ctx, r.namespace, r.seedClient)
+}
+
+func (r *reconciler) openVPNCA(ctx context.Context) (*resources.ECDSAKeyPair, error) {
+	return resources.GetOpenVPNCA(ctx, r.namespace, r.seedClient)
 }

--- a/api/pkg/controller/user-cluster-controller-manager/resources/reconciler.go
+++ b/api/pkg/controller/user-cluster-controller-manager/resources/reconciler.go
@@ -29,7 +29,7 @@ import (
 
 // Reconcile creates, updates, or deletes Kubernetes resources to match the desired state.
 func (r *reconciler) reconcile(ctx context.Context) error {
-	caCert, err := r.caCert()
+	caCert, err := r.caCert(ctx)
 	if err != nil {
 		return fmt.Errorf("failed to get caCert: %v", err)
 	}

--- a/api/pkg/resources/data.go
+++ b/api/pkg/resources/data.go
@@ -224,17 +224,17 @@ func (d *TemplateData) ImageRegistry(defaultRegistry string) string {
 
 // GetRootCA returns the root CA of the cluster
 func (d *TemplateData) GetRootCA() (*triple.KeyPair, error) {
-	return GetClusterRootCA(d.ctx, d.cluster, d.client)
+	return GetClusterRootCA(d.ctx, d.cluster.Status.NamespaceName, d.client)
 }
 
 // GetFrontProxyCA returns the root CA for the front proxy
 func (d *TemplateData) GetFrontProxyCA() (*triple.KeyPair, error) {
-	return GetClusterFrontProxyCA(d.ctx, d.cluster, d.client)
+	return GetClusterFrontProxyCA(d.ctx, d.cluster.Status.NamespaceName, d.client)
 }
 
 // GetOpenVPNCA returns the root ca for the OpenVPN
 func (d *TemplateData) GetOpenVPNCA() (*ECDSAKeyPair, error) {
-	return GetOpenVPNCA(d.ctx, d.cluster, d.client)
+	return GetOpenVPNCA(d.ctx, d.cluster.Status.NamespaceName, d.client)
 }
 
 // GetPodTemplateLabels returns a set of labels for a Pod including the revisions of depending secrets and configmaps.

--- a/api/pkg/resources/resources.go
+++ b/api/pkg/resources/resources.go
@@ -659,8 +659,8 @@ func IsClientCertificateValidForAllOf(cert *x509.Certificate, commonName string,
 	return true
 }
 
-func getECDSAClusterCAFromLister(ctx context.Context, name string, cluster *kubermaticv1.Cluster, client ctrlruntimeclient.Client) (*ECDSAKeyPair, error) {
-	cert, key, err := getClusterCAFromLister(ctx, name, cluster, client)
+func getECDSAClusterCAFromLister(ctx context.Context, namespace, name string, client ctrlruntimeclient.Client) (*ECDSAKeyPair, error) {
+	cert, key, err := getClusterCAFromLister(ctx, namespace, name, client)
 	if err != nil {
 		return nil, err
 	}
@@ -671,8 +671,8 @@ func getECDSAClusterCAFromLister(ctx context.Context, name string, cluster *kube
 	return &ECDSAKeyPair{Cert: cert, Key: ecdsaKey}, nil
 }
 
-func getRSAClusterCAFromLister(ctx context.Context, name string, cluster *kubermaticv1.Cluster, client ctrlruntimeclient.Client) (*triple.KeyPair, error) {
-	cert, key, err := getClusterCAFromLister(ctx, name, cluster, client)
+func getRSAClusterCAFromLister(ctx context.Context, namespace, name string, client ctrlruntimeclient.Client) (*triple.KeyPair, error) {
+	cert, key, err := getClusterCAFromLister(ctx, namespace, name, client)
 	if err != nil {
 		return nil, err
 	}
@@ -684,9 +684,9 @@ func getRSAClusterCAFromLister(ctx context.Context, name string, cluster *kuberm
 }
 
 // getClusterCAFromLister returns the CA of the cluster from the lister
-func getClusterCAFromLister(ctx context.Context, name string, cluster *kubermaticv1.Cluster, client ctrlruntimeclient.Client) (*x509.Certificate, interface{}, error) {
+func getClusterCAFromLister(ctx context.Context, namespace, name string, client ctrlruntimeclient.Client) (*x509.Certificate, interface{}, error) {
 	caSecret := &corev1.Secret{}
-	caSecretKey := types.NamespacedName{Namespace: cluster.Status.NamespaceName, Name: name}
+	caSecretKey := types.NamespacedName{Namespace: namespace, Name: name}
 	if err := client.Get(ctx, caSecretKey, caSecret); err != nil {
 		return nil, nil, fmt.Errorf("unable to check if a CA cert already exists: %v", err)
 	}
@@ -736,18 +736,18 @@ func GetDexCAFromFile(caBundleFilePath string) ([]*x509.Certificate, error) {
 }
 
 // GetClusterRootCA returns the root CA of the cluster from the lister
-func GetClusterRootCA(ctx context.Context, cluster *kubermaticv1.Cluster, client ctrlruntimeclient.Client) (*triple.KeyPair, error) {
-	return getRSAClusterCAFromLister(ctx, CASecretName, cluster, client)
+func GetClusterRootCA(ctx context.Context, namespace string, client ctrlruntimeclient.Client) (*triple.KeyPair, error) {
+	return getRSAClusterCAFromLister(ctx, namespace, CASecretName, client)
 }
 
 // GetClusterFrontProxyCA returns the frontproxy CA of the cluster from the lister
-func GetClusterFrontProxyCA(ctx context.Context, cluster *kubermaticv1.Cluster, client ctrlruntimeclient.Client) (*triple.KeyPair, error) {
-	return getRSAClusterCAFromLister(ctx, FrontProxyCASecretName, cluster, client)
+func GetClusterFrontProxyCA(ctx context.Context, namespace string, client ctrlruntimeclient.Client) (*triple.KeyPair, error) {
+	return getRSAClusterCAFromLister(ctx, namespace, FrontProxyCASecretName, client)
 }
 
 // GetOpenVPNCA returns the OpenVPN CA of the cluster from the lister
-func GetOpenVPNCA(ctx context.Context, cluster *kubermaticv1.Cluster, client ctrlruntimeclient.Client) (*ECDSAKeyPair, error) {
-	return getECDSAClusterCAFromLister(ctx, OpenVPNCASecretName, cluster, client)
+func GetOpenVPNCA(ctx context.Context, namespace string, client ctrlruntimeclient.Client) (*ECDSAKeyPair, error) {
+	return getECDSAClusterCAFromLister(ctx, namespace, OpenVPNCASecretName, client)
 }
 
 // ClusterIPForService returns the cluster ip for the given service

--- a/api/pkg/resources/test/fixtures/deployment-aws-1.10.0-usercluster-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-aws-1.10.0-usercluster-controller.yaml
@@ -22,7 +22,6 @@ spec:
       creationTimestamp: null
       labels:
         app: usercluster-controller
-        ca-secret-revision: "123456"
         cluster: de-test-01
         internal-admin-kubeconfig-secret-revision: "123456"
         openvpn-ca-secret-revision: "123456"
@@ -40,7 +39,7 @@ spec:
         - -timeout
         - "1"
         - -command
-        - '{"command":"/usr/local/bin/user-cluster-controller-manager","args":["-kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","-metrics-listen-address","0.0.0.0:8085","-health-listen-address","0.0.0.0:8086","-namespace","$(NAMESPACE)","-ca-cert","/etc/kubernetes/pki/ca/ca.crt","-ca-key","/etc/kubernetes/pki/ca/ca.key","-cluster-url","","-openvpn-server-port","30003","-overwrite-registry","","-openshift=false","-version","1.10.0","-cloud-provider-name","aws","-openvpn-ca-cert-file=/etc/kubernetes/pki/openvpn/ca.crt","-openvpn-ca-key-file=/etc/kubernetes/pki/openvpn/ca.key","-user-ssh-keys-dir-path=/etc/kubernetes/usersshkeys","--ipam-controller-network","192.168.1.1/24,192.168.1.1,8.8.8.8","-node-labels","{\"my-label\":\"my-value\"}"]}'
+        - '{"command":"/usr/local/bin/user-cluster-controller-manager","args":["-kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","-metrics-listen-address","0.0.0.0:8085","-health-listen-address","0.0.0.0:8086","-namespace","$(NAMESPACE)","-cluster-url","","-openvpn-server-port","30003","-overwrite-registry","","-openshift=false","-version","1.10.0","-cloud-provider-name","aws","-openvpn-ca-cert-file=/etc/kubernetes/pki/openvpn/ca.crt","-openvpn-ca-key-file=/etc/kubernetes/pki/openvpn/ca.key","-user-ssh-keys-dir-path=/etc/kubernetes/usersshkeys","--ipam-controller-network","192.168.1.1/24,192.168.1.1,8.8.8.8","-node-labels","{\"my-label\":\"my-value\"}"]}'
         command:
         - /http-prober-bin/http-prober
         env:
@@ -71,9 +70,6 @@ spec:
         - mountPath: /etc/kubernetes/kubeconfig
           name: internal-admin-kubeconfig
           readOnly: true
-        - mountPath: /etc/kubernetes/pki/ca
-          name: ca
-          readOnly: true
         - mountPath: /etc/kubernetes/pki/openvpn
           name: openvpn-ca
           readOnly: true
@@ -95,13 +91,11 @@ spec:
         volumeMounts:
         - mountPath: /http-prober-bin
           name: http-prober-bin
+      serviceAccountName: kubermatic-usercluster-controller-manager
       volumes:
       - name: internal-admin-kubeconfig
         secret:
           secretName: internal-admin-kubeconfig
-      - name: ca
-        secret:
-          secretName: ca
       - name: openvpn-ca
         secret:
           secretName: openvpn-ca

--- a/api/pkg/resources/test/fixtures/deployment-aws-1.10.0-usercluster-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-aws-1.10.0-usercluster-controller.yaml
@@ -24,7 +24,6 @@ spec:
         app: usercluster-controller
         cluster: de-test-01
         internal-admin-kubeconfig-secret-revision: "123456"
-        usersshkeys-secret-revision: "123456"
     spec:
       containers:
       - args:
@@ -38,7 +37,7 @@ spec:
         - -timeout
         - "1"
         - -command
-        - '{"command":"/usr/local/bin/user-cluster-controller-manager","args":["-kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","-metrics-listen-address","0.0.0.0:8085","-health-listen-address","0.0.0.0:8086","-namespace","$(NAMESPACE)","-cluster-url","","-openvpn-server-port","30003","-overwrite-registry","","-openshift=false","-version","1.10.0","-cloud-provider-name","aws","-user-ssh-keys-dir-path=/etc/kubernetes/usersshkeys","--ipam-controller-network","192.168.1.1/24,192.168.1.1,8.8.8.8","-node-labels","{\"my-label\":\"my-value\"}"]}'
+        - '{"command":"/usr/local/bin/user-cluster-controller-manager","args":["-kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","-metrics-listen-address","0.0.0.0:8085","-health-listen-address","0.0.0.0:8086","-namespace","$(NAMESPACE)","-cluster-url","","-openvpn-server-port","30003","-overwrite-registry","","-openshift=false","-version","1.10.0","-cloud-provider-name","aws","--ipam-controller-network","192.168.1.1/24,192.168.1.1,8.8.8.8","-node-labels","{\"my-label\":\"my-value\"}"]}'
         command:
         - /http-prober-bin/http-prober
         env:
@@ -69,9 +68,6 @@ spec:
         - mountPath: /etc/kubernetes/kubeconfig
           name: internal-admin-kubeconfig
           readOnly: true
-        - mountPath: /etc/kubernetes/usersshkeys
-          name: usersshkeys
-          readOnly: true
         - mountPath: /http-prober-bin
           name: http-prober-bin
       imagePullSecrets:
@@ -92,9 +88,6 @@ spec:
       - name: internal-admin-kubeconfig
         secret:
           secretName: internal-admin-kubeconfig
-      - name: usersshkeys
-        secret:
-          secretName: usersshkeys
       - emptyDir: {}
         name: http-prober-bin
 status: {}

--- a/api/pkg/resources/test/fixtures/deployment-aws-1.10.0-usercluster-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-aws-1.10.0-usercluster-controller.yaml
@@ -24,7 +24,6 @@ spec:
         app: usercluster-controller
         cluster: de-test-01
         internal-admin-kubeconfig-secret-revision: "123456"
-        openvpn-ca-secret-revision: "123456"
         usersshkeys-secret-revision: "123456"
     spec:
       containers:
@@ -39,7 +38,7 @@ spec:
         - -timeout
         - "1"
         - -command
-        - '{"command":"/usr/local/bin/user-cluster-controller-manager","args":["-kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","-metrics-listen-address","0.0.0.0:8085","-health-listen-address","0.0.0.0:8086","-namespace","$(NAMESPACE)","-cluster-url","","-openvpn-server-port","30003","-overwrite-registry","","-openshift=false","-version","1.10.0","-cloud-provider-name","aws","-openvpn-ca-cert-file=/etc/kubernetes/pki/openvpn/ca.crt","-openvpn-ca-key-file=/etc/kubernetes/pki/openvpn/ca.key","-user-ssh-keys-dir-path=/etc/kubernetes/usersshkeys","--ipam-controller-network","192.168.1.1/24,192.168.1.1,8.8.8.8","-node-labels","{\"my-label\":\"my-value\"}"]}'
+        - '{"command":"/usr/local/bin/user-cluster-controller-manager","args":["-kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","-metrics-listen-address","0.0.0.0:8085","-health-listen-address","0.0.0.0:8086","-namespace","$(NAMESPACE)","-cluster-url","","-openvpn-server-port","30003","-overwrite-registry","","-openshift=false","-version","1.10.0","-cloud-provider-name","aws","-user-ssh-keys-dir-path=/etc/kubernetes/usersshkeys","--ipam-controller-network","192.168.1.1/24,192.168.1.1,8.8.8.8","-node-labels","{\"my-label\":\"my-value\"}"]}'
         command:
         - /http-prober-bin/http-prober
         env:
@@ -70,9 +69,6 @@ spec:
         - mountPath: /etc/kubernetes/kubeconfig
           name: internal-admin-kubeconfig
           readOnly: true
-        - mountPath: /etc/kubernetes/pki/openvpn
-          name: openvpn-ca
-          readOnly: true
         - mountPath: /etc/kubernetes/usersshkeys
           name: usersshkeys
           readOnly: true
@@ -96,9 +92,6 @@ spec:
       - name: internal-admin-kubeconfig
         secret:
           secretName: internal-admin-kubeconfig
-      - name: openvpn-ca
-        secret:
-          secretName: openvpn-ca
       - name: usersshkeys
         secret:
           secretName: usersshkeys

--- a/api/pkg/resources/test/fixtures/deployment-aws-1.10.6-usercluster-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-aws-1.10.6-usercluster-controller.yaml
@@ -24,7 +24,6 @@ spec:
         app: usercluster-controller
         cluster: de-test-01
         internal-admin-kubeconfig-secret-revision: "123456"
-        usersshkeys-secret-revision: "123456"
     spec:
       containers:
       - args:
@@ -38,7 +37,7 @@ spec:
         - -timeout
         - "1"
         - -command
-        - '{"command":"/usr/local/bin/user-cluster-controller-manager","args":["-kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","-metrics-listen-address","0.0.0.0:8085","-health-listen-address","0.0.0.0:8086","-namespace","$(NAMESPACE)","-cluster-url","","-openvpn-server-port","30003","-overwrite-registry","","-openshift=false","-version","1.10.6","-cloud-provider-name","aws","-user-ssh-keys-dir-path=/etc/kubernetes/usersshkeys","--ipam-controller-network","192.168.1.1/24,192.168.1.1,8.8.8.8","-node-labels","{\"my-label\":\"my-value\"}"]}'
+        - '{"command":"/usr/local/bin/user-cluster-controller-manager","args":["-kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","-metrics-listen-address","0.0.0.0:8085","-health-listen-address","0.0.0.0:8086","-namespace","$(NAMESPACE)","-cluster-url","","-openvpn-server-port","30003","-overwrite-registry","","-openshift=false","-version","1.10.6","-cloud-provider-name","aws","--ipam-controller-network","192.168.1.1/24,192.168.1.1,8.8.8.8","-node-labels","{\"my-label\":\"my-value\"}"]}'
         command:
         - /http-prober-bin/http-prober
         env:
@@ -69,9 +68,6 @@ spec:
         - mountPath: /etc/kubernetes/kubeconfig
           name: internal-admin-kubeconfig
           readOnly: true
-        - mountPath: /etc/kubernetes/usersshkeys
-          name: usersshkeys
-          readOnly: true
         - mountPath: /http-prober-bin
           name: http-prober-bin
       imagePullSecrets:
@@ -92,9 +88,6 @@ spec:
       - name: internal-admin-kubeconfig
         secret:
           secretName: internal-admin-kubeconfig
-      - name: usersshkeys
-        secret:
-          secretName: usersshkeys
       - emptyDir: {}
         name: http-prober-bin
 status: {}

--- a/api/pkg/resources/test/fixtures/deployment-aws-1.10.6-usercluster-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-aws-1.10.6-usercluster-controller.yaml
@@ -24,7 +24,6 @@ spec:
         app: usercluster-controller
         cluster: de-test-01
         internal-admin-kubeconfig-secret-revision: "123456"
-        openvpn-ca-secret-revision: "123456"
         usersshkeys-secret-revision: "123456"
     spec:
       containers:
@@ -39,7 +38,7 @@ spec:
         - -timeout
         - "1"
         - -command
-        - '{"command":"/usr/local/bin/user-cluster-controller-manager","args":["-kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","-metrics-listen-address","0.0.0.0:8085","-health-listen-address","0.0.0.0:8086","-namespace","$(NAMESPACE)","-cluster-url","","-openvpn-server-port","30003","-overwrite-registry","","-openshift=false","-version","1.10.6","-cloud-provider-name","aws","-openvpn-ca-cert-file=/etc/kubernetes/pki/openvpn/ca.crt","-openvpn-ca-key-file=/etc/kubernetes/pki/openvpn/ca.key","-user-ssh-keys-dir-path=/etc/kubernetes/usersshkeys","--ipam-controller-network","192.168.1.1/24,192.168.1.1,8.8.8.8","-node-labels","{\"my-label\":\"my-value\"}"]}'
+        - '{"command":"/usr/local/bin/user-cluster-controller-manager","args":["-kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","-metrics-listen-address","0.0.0.0:8085","-health-listen-address","0.0.0.0:8086","-namespace","$(NAMESPACE)","-cluster-url","","-openvpn-server-port","30003","-overwrite-registry","","-openshift=false","-version","1.10.6","-cloud-provider-name","aws","-user-ssh-keys-dir-path=/etc/kubernetes/usersshkeys","--ipam-controller-network","192.168.1.1/24,192.168.1.1,8.8.8.8","-node-labels","{\"my-label\":\"my-value\"}"]}'
         command:
         - /http-prober-bin/http-prober
         env:
@@ -70,9 +69,6 @@ spec:
         - mountPath: /etc/kubernetes/kubeconfig
           name: internal-admin-kubeconfig
           readOnly: true
-        - mountPath: /etc/kubernetes/pki/openvpn
-          name: openvpn-ca
-          readOnly: true
         - mountPath: /etc/kubernetes/usersshkeys
           name: usersshkeys
           readOnly: true
@@ -96,9 +92,6 @@ spec:
       - name: internal-admin-kubeconfig
         secret:
           secretName: internal-admin-kubeconfig
-      - name: openvpn-ca
-        secret:
-          secretName: openvpn-ca
       - name: usersshkeys
         secret:
           secretName: usersshkeys

--- a/api/pkg/resources/test/fixtures/deployment-aws-1.10.6-usercluster-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-aws-1.10.6-usercluster-controller.yaml
@@ -22,7 +22,6 @@ spec:
       creationTimestamp: null
       labels:
         app: usercluster-controller
-        ca-secret-revision: "123456"
         cluster: de-test-01
         internal-admin-kubeconfig-secret-revision: "123456"
         openvpn-ca-secret-revision: "123456"
@@ -40,7 +39,7 @@ spec:
         - -timeout
         - "1"
         - -command
-        - '{"command":"/usr/local/bin/user-cluster-controller-manager","args":["-kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","-metrics-listen-address","0.0.0.0:8085","-health-listen-address","0.0.0.0:8086","-namespace","$(NAMESPACE)","-ca-cert","/etc/kubernetes/pki/ca/ca.crt","-ca-key","/etc/kubernetes/pki/ca/ca.key","-cluster-url","","-openvpn-server-port","30003","-overwrite-registry","","-openshift=false","-version","1.10.6","-cloud-provider-name","aws","-openvpn-ca-cert-file=/etc/kubernetes/pki/openvpn/ca.crt","-openvpn-ca-key-file=/etc/kubernetes/pki/openvpn/ca.key","-user-ssh-keys-dir-path=/etc/kubernetes/usersshkeys","--ipam-controller-network","192.168.1.1/24,192.168.1.1,8.8.8.8","-node-labels","{\"my-label\":\"my-value\"}"]}'
+        - '{"command":"/usr/local/bin/user-cluster-controller-manager","args":["-kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","-metrics-listen-address","0.0.0.0:8085","-health-listen-address","0.0.0.0:8086","-namespace","$(NAMESPACE)","-cluster-url","","-openvpn-server-port","30003","-overwrite-registry","","-openshift=false","-version","1.10.6","-cloud-provider-name","aws","-openvpn-ca-cert-file=/etc/kubernetes/pki/openvpn/ca.crt","-openvpn-ca-key-file=/etc/kubernetes/pki/openvpn/ca.key","-user-ssh-keys-dir-path=/etc/kubernetes/usersshkeys","--ipam-controller-network","192.168.1.1/24,192.168.1.1,8.8.8.8","-node-labels","{\"my-label\":\"my-value\"}"]}'
         command:
         - /http-prober-bin/http-prober
         env:
@@ -71,9 +70,6 @@ spec:
         - mountPath: /etc/kubernetes/kubeconfig
           name: internal-admin-kubeconfig
           readOnly: true
-        - mountPath: /etc/kubernetes/pki/ca
-          name: ca
-          readOnly: true
         - mountPath: /etc/kubernetes/pki/openvpn
           name: openvpn-ca
           readOnly: true
@@ -95,13 +91,11 @@ spec:
         volumeMounts:
         - mountPath: /http-prober-bin
           name: http-prober-bin
+      serviceAccountName: kubermatic-usercluster-controller-manager
       volumes:
       - name: internal-admin-kubeconfig
         secret:
           secretName: internal-admin-kubeconfig
-      - name: ca
-        secret:
-          secretName: ca
       - name: openvpn-ca
         secret:
           secretName: openvpn-ca

--- a/api/pkg/resources/test/fixtures/deployment-aws-1.11.0-usercluster-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-aws-1.11.0-usercluster-controller.yaml
@@ -22,7 +22,6 @@ spec:
       creationTimestamp: null
       labels:
         app: usercluster-controller
-        ca-secret-revision: "123456"
         cluster: de-test-01
         internal-admin-kubeconfig-secret-revision: "123456"
         openvpn-ca-secret-revision: "123456"
@@ -40,7 +39,7 @@ spec:
         - -timeout
         - "1"
         - -command
-        - '{"command":"/usr/local/bin/user-cluster-controller-manager","args":["-kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","-metrics-listen-address","0.0.0.0:8085","-health-listen-address","0.0.0.0:8086","-namespace","$(NAMESPACE)","-ca-cert","/etc/kubernetes/pki/ca/ca.crt","-ca-key","/etc/kubernetes/pki/ca/ca.key","-cluster-url","","-openvpn-server-port","30003","-overwrite-registry","","-openshift=false","-version","1.11.0","-cloud-provider-name","aws","-openvpn-ca-cert-file=/etc/kubernetes/pki/openvpn/ca.crt","-openvpn-ca-key-file=/etc/kubernetes/pki/openvpn/ca.key","-user-ssh-keys-dir-path=/etc/kubernetes/usersshkeys","--ipam-controller-network","192.168.1.1/24,192.168.1.1,8.8.8.8","-node-labels","{\"my-label\":\"my-value\"}"]}'
+        - '{"command":"/usr/local/bin/user-cluster-controller-manager","args":["-kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","-metrics-listen-address","0.0.0.0:8085","-health-listen-address","0.0.0.0:8086","-namespace","$(NAMESPACE)","-cluster-url","","-openvpn-server-port","30003","-overwrite-registry","","-openshift=false","-version","1.11.0","-cloud-provider-name","aws","-openvpn-ca-cert-file=/etc/kubernetes/pki/openvpn/ca.crt","-openvpn-ca-key-file=/etc/kubernetes/pki/openvpn/ca.key","-user-ssh-keys-dir-path=/etc/kubernetes/usersshkeys","--ipam-controller-network","192.168.1.1/24,192.168.1.1,8.8.8.8","-node-labels","{\"my-label\":\"my-value\"}"]}'
         command:
         - /http-prober-bin/http-prober
         env:
@@ -71,9 +70,6 @@ spec:
         - mountPath: /etc/kubernetes/kubeconfig
           name: internal-admin-kubeconfig
           readOnly: true
-        - mountPath: /etc/kubernetes/pki/ca
-          name: ca
-          readOnly: true
         - mountPath: /etc/kubernetes/pki/openvpn
           name: openvpn-ca
           readOnly: true
@@ -95,13 +91,11 @@ spec:
         volumeMounts:
         - mountPath: /http-prober-bin
           name: http-prober-bin
+      serviceAccountName: kubermatic-usercluster-controller-manager
       volumes:
       - name: internal-admin-kubeconfig
         secret:
           secretName: internal-admin-kubeconfig
-      - name: ca
-        secret:
-          secretName: ca
       - name: openvpn-ca
         secret:
           secretName: openvpn-ca

--- a/api/pkg/resources/test/fixtures/deployment-aws-1.11.0-usercluster-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-aws-1.11.0-usercluster-controller.yaml
@@ -24,7 +24,6 @@ spec:
         app: usercluster-controller
         cluster: de-test-01
         internal-admin-kubeconfig-secret-revision: "123456"
-        openvpn-ca-secret-revision: "123456"
         usersshkeys-secret-revision: "123456"
     spec:
       containers:
@@ -39,7 +38,7 @@ spec:
         - -timeout
         - "1"
         - -command
-        - '{"command":"/usr/local/bin/user-cluster-controller-manager","args":["-kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","-metrics-listen-address","0.0.0.0:8085","-health-listen-address","0.0.0.0:8086","-namespace","$(NAMESPACE)","-cluster-url","","-openvpn-server-port","30003","-overwrite-registry","","-openshift=false","-version","1.11.0","-cloud-provider-name","aws","-openvpn-ca-cert-file=/etc/kubernetes/pki/openvpn/ca.crt","-openvpn-ca-key-file=/etc/kubernetes/pki/openvpn/ca.key","-user-ssh-keys-dir-path=/etc/kubernetes/usersshkeys","--ipam-controller-network","192.168.1.1/24,192.168.1.1,8.8.8.8","-node-labels","{\"my-label\":\"my-value\"}"]}'
+        - '{"command":"/usr/local/bin/user-cluster-controller-manager","args":["-kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","-metrics-listen-address","0.0.0.0:8085","-health-listen-address","0.0.0.0:8086","-namespace","$(NAMESPACE)","-cluster-url","","-openvpn-server-port","30003","-overwrite-registry","","-openshift=false","-version","1.11.0","-cloud-provider-name","aws","-user-ssh-keys-dir-path=/etc/kubernetes/usersshkeys","--ipam-controller-network","192.168.1.1/24,192.168.1.1,8.8.8.8","-node-labels","{\"my-label\":\"my-value\"}"]}'
         command:
         - /http-prober-bin/http-prober
         env:
@@ -70,9 +69,6 @@ spec:
         - mountPath: /etc/kubernetes/kubeconfig
           name: internal-admin-kubeconfig
           readOnly: true
-        - mountPath: /etc/kubernetes/pki/openvpn
-          name: openvpn-ca
-          readOnly: true
         - mountPath: /etc/kubernetes/usersshkeys
           name: usersshkeys
           readOnly: true
@@ -96,9 +92,6 @@ spec:
       - name: internal-admin-kubeconfig
         secret:
           secretName: internal-admin-kubeconfig
-      - name: openvpn-ca
-        secret:
-          secretName: openvpn-ca
       - name: usersshkeys
         secret:
           secretName: usersshkeys

--- a/api/pkg/resources/test/fixtures/deployment-aws-1.11.0-usercluster-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-aws-1.11.0-usercluster-controller.yaml
@@ -24,7 +24,6 @@ spec:
         app: usercluster-controller
         cluster: de-test-01
         internal-admin-kubeconfig-secret-revision: "123456"
-        usersshkeys-secret-revision: "123456"
     spec:
       containers:
       - args:
@@ -38,7 +37,7 @@ spec:
         - -timeout
         - "1"
         - -command
-        - '{"command":"/usr/local/bin/user-cluster-controller-manager","args":["-kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","-metrics-listen-address","0.0.0.0:8085","-health-listen-address","0.0.0.0:8086","-namespace","$(NAMESPACE)","-cluster-url","","-openvpn-server-port","30003","-overwrite-registry","","-openshift=false","-version","1.11.0","-cloud-provider-name","aws","-user-ssh-keys-dir-path=/etc/kubernetes/usersshkeys","--ipam-controller-network","192.168.1.1/24,192.168.1.1,8.8.8.8","-node-labels","{\"my-label\":\"my-value\"}"]}'
+        - '{"command":"/usr/local/bin/user-cluster-controller-manager","args":["-kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","-metrics-listen-address","0.0.0.0:8085","-health-listen-address","0.0.0.0:8086","-namespace","$(NAMESPACE)","-cluster-url","","-openvpn-server-port","30003","-overwrite-registry","","-openshift=false","-version","1.11.0","-cloud-provider-name","aws","--ipam-controller-network","192.168.1.1/24,192.168.1.1,8.8.8.8","-node-labels","{\"my-label\":\"my-value\"}"]}'
         command:
         - /http-prober-bin/http-prober
         env:
@@ -69,9 +68,6 @@ spec:
         - mountPath: /etc/kubernetes/kubeconfig
           name: internal-admin-kubeconfig
           readOnly: true
-        - mountPath: /etc/kubernetes/usersshkeys
-          name: usersshkeys
-          readOnly: true
         - mountPath: /http-prober-bin
           name: http-prober-bin
       imagePullSecrets:
@@ -92,9 +88,6 @@ spec:
       - name: internal-admin-kubeconfig
         secret:
           secretName: internal-admin-kubeconfig
-      - name: usersshkeys
-        secret:
-          secretName: usersshkeys
       - emptyDir: {}
         name: http-prober-bin
 status: {}

--- a/api/pkg/resources/test/fixtures/deployment-aws-1.11.1-usercluster-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-aws-1.11.1-usercluster-controller.yaml
@@ -24,7 +24,6 @@ spec:
         app: usercluster-controller
         cluster: de-test-01
         internal-admin-kubeconfig-secret-revision: "123456"
-        usersshkeys-secret-revision: "123456"
     spec:
       containers:
       - args:
@@ -38,7 +37,7 @@ spec:
         - -timeout
         - "1"
         - -command
-        - '{"command":"/usr/local/bin/user-cluster-controller-manager","args":["-kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","-metrics-listen-address","0.0.0.0:8085","-health-listen-address","0.0.0.0:8086","-namespace","$(NAMESPACE)","-cluster-url","","-openvpn-server-port","30003","-overwrite-registry","","-openshift=false","-version","1.11.1","-cloud-provider-name","aws","-user-ssh-keys-dir-path=/etc/kubernetes/usersshkeys","--ipam-controller-network","192.168.1.1/24,192.168.1.1,8.8.8.8","-node-labels","{\"my-label\":\"my-value\"}"]}'
+        - '{"command":"/usr/local/bin/user-cluster-controller-manager","args":["-kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","-metrics-listen-address","0.0.0.0:8085","-health-listen-address","0.0.0.0:8086","-namespace","$(NAMESPACE)","-cluster-url","","-openvpn-server-port","30003","-overwrite-registry","","-openshift=false","-version","1.11.1","-cloud-provider-name","aws","--ipam-controller-network","192.168.1.1/24,192.168.1.1,8.8.8.8","-node-labels","{\"my-label\":\"my-value\"}"]}'
         command:
         - /http-prober-bin/http-prober
         env:
@@ -69,9 +68,6 @@ spec:
         - mountPath: /etc/kubernetes/kubeconfig
           name: internal-admin-kubeconfig
           readOnly: true
-        - mountPath: /etc/kubernetes/usersshkeys
-          name: usersshkeys
-          readOnly: true
         - mountPath: /http-prober-bin
           name: http-prober-bin
       imagePullSecrets:
@@ -92,9 +88,6 @@ spec:
       - name: internal-admin-kubeconfig
         secret:
           secretName: internal-admin-kubeconfig
-      - name: usersshkeys
-        secret:
-          secretName: usersshkeys
       - emptyDir: {}
         name: http-prober-bin
 status: {}

--- a/api/pkg/resources/test/fixtures/deployment-aws-1.11.1-usercluster-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-aws-1.11.1-usercluster-controller.yaml
@@ -24,7 +24,6 @@ spec:
         app: usercluster-controller
         cluster: de-test-01
         internal-admin-kubeconfig-secret-revision: "123456"
-        openvpn-ca-secret-revision: "123456"
         usersshkeys-secret-revision: "123456"
     spec:
       containers:
@@ -39,7 +38,7 @@ spec:
         - -timeout
         - "1"
         - -command
-        - '{"command":"/usr/local/bin/user-cluster-controller-manager","args":["-kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","-metrics-listen-address","0.0.0.0:8085","-health-listen-address","0.0.0.0:8086","-namespace","$(NAMESPACE)","-cluster-url","","-openvpn-server-port","30003","-overwrite-registry","","-openshift=false","-version","1.11.1","-cloud-provider-name","aws","-openvpn-ca-cert-file=/etc/kubernetes/pki/openvpn/ca.crt","-openvpn-ca-key-file=/etc/kubernetes/pki/openvpn/ca.key","-user-ssh-keys-dir-path=/etc/kubernetes/usersshkeys","--ipam-controller-network","192.168.1.1/24,192.168.1.1,8.8.8.8","-node-labels","{\"my-label\":\"my-value\"}"]}'
+        - '{"command":"/usr/local/bin/user-cluster-controller-manager","args":["-kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","-metrics-listen-address","0.0.0.0:8085","-health-listen-address","0.0.0.0:8086","-namespace","$(NAMESPACE)","-cluster-url","","-openvpn-server-port","30003","-overwrite-registry","","-openshift=false","-version","1.11.1","-cloud-provider-name","aws","-user-ssh-keys-dir-path=/etc/kubernetes/usersshkeys","--ipam-controller-network","192.168.1.1/24,192.168.1.1,8.8.8.8","-node-labels","{\"my-label\":\"my-value\"}"]}'
         command:
         - /http-prober-bin/http-prober
         env:
@@ -70,9 +69,6 @@ spec:
         - mountPath: /etc/kubernetes/kubeconfig
           name: internal-admin-kubeconfig
           readOnly: true
-        - mountPath: /etc/kubernetes/pki/openvpn
-          name: openvpn-ca
-          readOnly: true
         - mountPath: /etc/kubernetes/usersshkeys
           name: usersshkeys
           readOnly: true
@@ -96,9 +92,6 @@ spec:
       - name: internal-admin-kubeconfig
         secret:
           secretName: internal-admin-kubeconfig
-      - name: openvpn-ca
-        secret:
-          secretName: openvpn-ca
       - name: usersshkeys
         secret:
           secretName: usersshkeys

--- a/api/pkg/resources/test/fixtures/deployment-aws-1.11.1-usercluster-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-aws-1.11.1-usercluster-controller.yaml
@@ -22,7 +22,6 @@ spec:
       creationTimestamp: null
       labels:
         app: usercluster-controller
-        ca-secret-revision: "123456"
         cluster: de-test-01
         internal-admin-kubeconfig-secret-revision: "123456"
         openvpn-ca-secret-revision: "123456"
@@ -40,7 +39,7 @@ spec:
         - -timeout
         - "1"
         - -command
-        - '{"command":"/usr/local/bin/user-cluster-controller-manager","args":["-kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","-metrics-listen-address","0.0.0.0:8085","-health-listen-address","0.0.0.0:8086","-namespace","$(NAMESPACE)","-ca-cert","/etc/kubernetes/pki/ca/ca.crt","-ca-key","/etc/kubernetes/pki/ca/ca.key","-cluster-url","","-openvpn-server-port","30003","-overwrite-registry","","-openshift=false","-version","1.11.1","-cloud-provider-name","aws","-openvpn-ca-cert-file=/etc/kubernetes/pki/openvpn/ca.crt","-openvpn-ca-key-file=/etc/kubernetes/pki/openvpn/ca.key","-user-ssh-keys-dir-path=/etc/kubernetes/usersshkeys","--ipam-controller-network","192.168.1.1/24,192.168.1.1,8.8.8.8","-node-labels","{\"my-label\":\"my-value\"}"]}'
+        - '{"command":"/usr/local/bin/user-cluster-controller-manager","args":["-kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","-metrics-listen-address","0.0.0.0:8085","-health-listen-address","0.0.0.0:8086","-namespace","$(NAMESPACE)","-cluster-url","","-openvpn-server-port","30003","-overwrite-registry","","-openshift=false","-version","1.11.1","-cloud-provider-name","aws","-openvpn-ca-cert-file=/etc/kubernetes/pki/openvpn/ca.crt","-openvpn-ca-key-file=/etc/kubernetes/pki/openvpn/ca.key","-user-ssh-keys-dir-path=/etc/kubernetes/usersshkeys","--ipam-controller-network","192.168.1.1/24,192.168.1.1,8.8.8.8","-node-labels","{\"my-label\":\"my-value\"}"]}'
         command:
         - /http-prober-bin/http-prober
         env:
@@ -71,9 +70,6 @@ spec:
         - mountPath: /etc/kubernetes/kubeconfig
           name: internal-admin-kubeconfig
           readOnly: true
-        - mountPath: /etc/kubernetes/pki/ca
-          name: ca
-          readOnly: true
         - mountPath: /etc/kubernetes/pki/openvpn
           name: openvpn-ca
           readOnly: true
@@ -95,13 +91,11 @@ spec:
         volumeMounts:
         - mountPath: /http-prober-bin
           name: http-prober-bin
+      serviceAccountName: kubermatic-usercluster-controller-manager
       volumes:
       - name: internal-admin-kubeconfig
         secret:
           secretName: internal-admin-kubeconfig
-      - name: ca
-        secret:
-          secretName: ca
       - name: openvpn-ca
         secret:
           secretName: openvpn-ca

--- a/api/pkg/resources/test/fixtures/deployment-aws-1.12.0-usercluster-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-aws-1.12.0-usercluster-controller.yaml
@@ -24,7 +24,6 @@ spec:
         app: usercluster-controller
         cluster: de-test-01
         internal-admin-kubeconfig-secret-revision: "123456"
-        openvpn-ca-secret-revision: "123456"
         usersshkeys-secret-revision: "123456"
     spec:
       containers:
@@ -39,7 +38,7 @@ spec:
         - -timeout
         - "1"
         - -command
-        - '{"command":"/usr/local/bin/user-cluster-controller-manager","args":["-kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","-metrics-listen-address","0.0.0.0:8085","-health-listen-address","0.0.0.0:8086","-namespace","$(NAMESPACE)","-cluster-url","","-openvpn-server-port","30003","-overwrite-registry","","-openshift=false","-version","1.12.0","-cloud-provider-name","aws","-openvpn-ca-cert-file=/etc/kubernetes/pki/openvpn/ca.crt","-openvpn-ca-key-file=/etc/kubernetes/pki/openvpn/ca.key","-user-ssh-keys-dir-path=/etc/kubernetes/usersshkeys","--ipam-controller-network","192.168.1.1/24,192.168.1.1,8.8.8.8","-node-labels","{\"my-label\":\"my-value\"}"]}'
+        - '{"command":"/usr/local/bin/user-cluster-controller-manager","args":["-kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","-metrics-listen-address","0.0.0.0:8085","-health-listen-address","0.0.0.0:8086","-namespace","$(NAMESPACE)","-cluster-url","","-openvpn-server-port","30003","-overwrite-registry","","-openshift=false","-version","1.12.0","-cloud-provider-name","aws","-user-ssh-keys-dir-path=/etc/kubernetes/usersshkeys","--ipam-controller-network","192.168.1.1/24,192.168.1.1,8.8.8.8","-node-labels","{\"my-label\":\"my-value\"}"]}'
         command:
         - /http-prober-bin/http-prober
         env:
@@ -70,9 +69,6 @@ spec:
         - mountPath: /etc/kubernetes/kubeconfig
           name: internal-admin-kubeconfig
           readOnly: true
-        - mountPath: /etc/kubernetes/pki/openvpn
-          name: openvpn-ca
-          readOnly: true
         - mountPath: /etc/kubernetes/usersshkeys
           name: usersshkeys
           readOnly: true
@@ -96,9 +92,6 @@ spec:
       - name: internal-admin-kubeconfig
         secret:
           secretName: internal-admin-kubeconfig
-      - name: openvpn-ca
-        secret:
-          secretName: openvpn-ca
       - name: usersshkeys
         secret:
           secretName: usersshkeys

--- a/api/pkg/resources/test/fixtures/deployment-aws-1.12.0-usercluster-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-aws-1.12.0-usercluster-controller.yaml
@@ -22,7 +22,6 @@ spec:
       creationTimestamp: null
       labels:
         app: usercluster-controller
-        ca-secret-revision: "123456"
         cluster: de-test-01
         internal-admin-kubeconfig-secret-revision: "123456"
         openvpn-ca-secret-revision: "123456"
@@ -40,7 +39,7 @@ spec:
         - -timeout
         - "1"
         - -command
-        - '{"command":"/usr/local/bin/user-cluster-controller-manager","args":["-kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","-metrics-listen-address","0.0.0.0:8085","-health-listen-address","0.0.0.0:8086","-namespace","$(NAMESPACE)","-ca-cert","/etc/kubernetes/pki/ca/ca.crt","-ca-key","/etc/kubernetes/pki/ca/ca.key","-cluster-url","","-openvpn-server-port","30003","-overwrite-registry","","-openshift=false","-version","1.12.0","-cloud-provider-name","aws","-openvpn-ca-cert-file=/etc/kubernetes/pki/openvpn/ca.crt","-openvpn-ca-key-file=/etc/kubernetes/pki/openvpn/ca.key","-user-ssh-keys-dir-path=/etc/kubernetes/usersshkeys","--ipam-controller-network","192.168.1.1/24,192.168.1.1,8.8.8.8","-node-labels","{\"my-label\":\"my-value\"}"]}'
+        - '{"command":"/usr/local/bin/user-cluster-controller-manager","args":["-kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","-metrics-listen-address","0.0.0.0:8085","-health-listen-address","0.0.0.0:8086","-namespace","$(NAMESPACE)","-cluster-url","","-openvpn-server-port","30003","-overwrite-registry","","-openshift=false","-version","1.12.0","-cloud-provider-name","aws","-openvpn-ca-cert-file=/etc/kubernetes/pki/openvpn/ca.crt","-openvpn-ca-key-file=/etc/kubernetes/pki/openvpn/ca.key","-user-ssh-keys-dir-path=/etc/kubernetes/usersshkeys","--ipam-controller-network","192.168.1.1/24,192.168.1.1,8.8.8.8","-node-labels","{\"my-label\":\"my-value\"}"]}'
         command:
         - /http-prober-bin/http-prober
         env:
@@ -71,9 +70,6 @@ spec:
         - mountPath: /etc/kubernetes/kubeconfig
           name: internal-admin-kubeconfig
           readOnly: true
-        - mountPath: /etc/kubernetes/pki/ca
-          name: ca
-          readOnly: true
         - mountPath: /etc/kubernetes/pki/openvpn
           name: openvpn-ca
           readOnly: true
@@ -95,13 +91,11 @@ spec:
         volumeMounts:
         - mountPath: /http-prober-bin
           name: http-prober-bin
+      serviceAccountName: kubermatic-usercluster-controller-manager
       volumes:
       - name: internal-admin-kubeconfig
         secret:
           secretName: internal-admin-kubeconfig
-      - name: ca
-        secret:
-          secretName: ca
       - name: openvpn-ca
         secret:
           secretName: openvpn-ca

--- a/api/pkg/resources/test/fixtures/deployment-aws-1.12.0-usercluster-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-aws-1.12.0-usercluster-controller.yaml
@@ -24,7 +24,6 @@ spec:
         app: usercluster-controller
         cluster: de-test-01
         internal-admin-kubeconfig-secret-revision: "123456"
-        usersshkeys-secret-revision: "123456"
     spec:
       containers:
       - args:
@@ -38,7 +37,7 @@ spec:
         - -timeout
         - "1"
         - -command
-        - '{"command":"/usr/local/bin/user-cluster-controller-manager","args":["-kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","-metrics-listen-address","0.0.0.0:8085","-health-listen-address","0.0.0.0:8086","-namespace","$(NAMESPACE)","-cluster-url","","-openvpn-server-port","30003","-overwrite-registry","","-openshift=false","-version","1.12.0","-cloud-provider-name","aws","-user-ssh-keys-dir-path=/etc/kubernetes/usersshkeys","--ipam-controller-network","192.168.1.1/24,192.168.1.1,8.8.8.8","-node-labels","{\"my-label\":\"my-value\"}"]}'
+        - '{"command":"/usr/local/bin/user-cluster-controller-manager","args":["-kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","-metrics-listen-address","0.0.0.0:8085","-health-listen-address","0.0.0.0:8086","-namespace","$(NAMESPACE)","-cluster-url","","-openvpn-server-port","30003","-overwrite-registry","","-openshift=false","-version","1.12.0","-cloud-provider-name","aws","--ipam-controller-network","192.168.1.1/24,192.168.1.1,8.8.8.8","-node-labels","{\"my-label\":\"my-value\"}"]}'
         command:
         - /http-prober-bin/http-prober
         env:
@@ -69,9 +68,6 @@ spec:
         - mountPath: /etc/kubernetes/kubeconfig
           name: internal-admin-kubeconfig
           readOnly: true
-        - mountPath: /etc/kubernetes/usersshkeys
-          name: usersshkeys
-          readOnly: true
         - mountPath: /http-prober-bin
           name: http-prober-bin
       imagePullSecrets:
@@ -92,9 +88,6 @@ spec:
       - name: internal-admin-kubeconfig
         secret:
           secretName: internal-admin-kubeconfig
-      - name: usersshkeys
-        secret:
-          secretName: usersshkeys
       - emptyDir: {}
         name: http-prober-bin
 status: {}

--- a/api/pkg/resources/test/fixtures/deployment-aws-1.13.0-usercluster-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-aws-1.13.0-usercluster-controller.yaml
@@ -24,7 +24,6 @@ spec:
         app: usercluster-controller
         cluster: de-test-01
         internal-admin-kubeconfig-secret-revision: "123456"
-        usersshkeys-secret-revision: "123456"
     spec:
       containers:
       - args:
@@ -38,7 +37,7 @@ spec:
         - -timeout
         - "1"
         - -command
-        - '{"command":"/usr/local/bin/user-cluster-controller-manager","args":["-kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","-metrics-listen-address","0.0.0.0:8085","-health-listen-address","0.0.0.0:8086","-namespace","$(NAMESPACE)","-cluster-url","","-openvpn-server-port","30003","-overwrite-registry","","-openshift=false","-version","1.13.0","-cloud-provider-name","aws","-user-ssh-keys-dir-path=/etc/kubernetes/usersshkeys","--ipam-controller-network","192.168.1.1/24,192.168.1.1,8.8.8.8","-node-labels","{\"my-label\":\"my-value\"}"]}'
+        - '{"command":"/usr/local/bin/user-cluster-controller-manager","args":["-kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","-metrics-listen-address","0.0.0.0:8085","-health-listen-address","0.0.0.0:8086","-namespace","$(NAMESPACE)","-cluster-url","","-openvpn-server-port","30003","-overwrite-registry","","-openshift=false","-version","1.13.0","-cloud-provider-name","aws","--ipam-controller-network","192.168.1.1/24,192.168.1.1,8.8.8.8","-node-labels","{\"my-label\":\"my-value\"}"]}'
         command:
         - /http-prober-bin/http-prober
         env:
@@ -69,9 +68,6 @@ spec:
         - mountPath: /etc/kubernetes/kubeconfig
           name: internal-admin-kubeconfig
           readOnly: true
-        - mountPath: /etc/kubernetes/usersshkeys
-          name: usersshkeys
-          readOnly: true
         - mountPath: /http-prober-bin
           name: http-prober-bin
       imagePullSecrets:
@@ -92,9 +88,6 @@ spec:
       - name: internal-admin-kubeconfig
         secret:
           secretName: internal-admin-kubeconfig
-      - name: usersshkeys
-        secret:
-          secretName: usersshkeys
       - emptyDir: {}
         name: http-prober-bin
 status: {}

--- a/api/pkg/resources/test/fixtures/deployment-aws-1.13.0-usercluster-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-aws-1.13.0-usercluster-controller.yaml
@@ -24,7 +24,6 @@ spec:
         app: usercluster-controller
         cluster: de-test-01
         internal-admin-kubeconfig-secret-revision: "123456"
-        openvpn-ca-secret-revision: "123456"
         usersshkeys-secret-revision: "123456"
     spec:
       containers:
@@ -39,7 +38,7 @@ spec:
         - -timeout
         - "1"
         - -command
-        - '{"command":"/usr/local/bin/user-cluster-controller-manager","args":["-kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","-metrics-listen-address","0.0.0.0:8085","-health-listen-address","0.0.0.0:8086","-namespace","$(NAMESPACE)","-cluster-url","","-openvpn-server-port","30003","-overwrite-registry","","-openshift=false","-version","1.13.0","-cloud-provider-name","aws","-openvpn-ca-cert-file=/etc/kubernetes/pki/openvpn/ca.crt","-openvpn-ca-key-file=/etc/kubernetes/pki/openvpn/ca.key","-user-ssh-keys-dir-path=/etc/kubernetes/usersshkeys","--ipam-controller-network","192.168.1.1/24,192.168.1.1,8.8.8.8","-node-labels","{\"my-label\":\"my-value\"}"]}'
+        - '{"command":"/usr/local/bin/user-cluster-controller-manager","args":["-kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","-metrics-listen-address","0.0.0.0:8085","-health-listen-address","0.0.0.0:8086","-namespace","$(NAMESPACE)","-cluster-url","","-openvpn-server-port","30003","-overwrite-registry","","-openshift=false","-version","1.13.0","-cloud-provider-name","aws","-user-ssh-keys-dir-path=/etc/kubernetes/usersshkeys","--ipam-controller-network","192.168.1.1/24,192.168.1.1,8.8.8.8","-node-labels","{\"my-label\":\"my-value\"}"]}'
         command:
         - /http-prober-bin/http-prober
         env:
@@ -70,9 +69,6 @@ spec:
         - mountPath: /etc/kubernetes/kubeconfig
           name: internal-admin-kubeconfig
           readOnly: true
-        - mountPath: /etc/kubernetes/pki/openvpn
-          name: openvpn-ca
-          readOnly: true
         - mountPath: /etc/kubernetes/usersshkeys
           name: usersshkeys
           readOnly: true
@@ -96,9 +92,6 @@ spec:
       - name: internal-admin-kubeconfig
         secret:
           secretName: internal-admin-kubeconfig
-      - name: openvpn-ca
-        secret:
-          secretName: openvpn-ca
       - name: usersshkeys
         secret:
           secretName: usersshkeys

--- a/api/pkg/resources/test/fixtures/deployment-aws-1.13.0-usercluster-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-aws-1.13.0-usercluster-controller.yaml
@@ -22,7 +22,6 @@ spec:
       creationTimestamp: null
       labels:
         app: usercluster-controller
-        ca-secret-revision: "123456"
         cluster: de-test-01
         internal-admin-kubeconfig-secret-revision: "123456"
         openvpn-ca-secret-revision: "123456"
@@ -40,7 +39,7 @@ spec:
         - -timeout
         - "1"
         - -command
-        - '{"command":"/usr/local/bin/user-cluster-controller-manager","args":["-kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","-metrics-listen-address","0.0.0.0:8085","-health-listen-address","0.0.0.0:8086","-namespace","$(NAMESPACE)","-ca-cert","/etc/kubernetes/pki/ca/ca.crt","-ca-key","/etc/kubernetes/pki/ca/ca.key","-cluster-url","","-openvpn-server-port","30003","-overwrite-registry","","-openshift=false","-version","1.13.0","-cloud-provider-name","aws","-openvpn-ca-cert-file=/etc/kubernetes/pki/openvpn/ca.crt","-openvpn-ca-key-file=/etc/kubernetes/pki/openvpn/ca.key","-user-ssh-keys-dir-path=/etc/kubernetes/usersshkeys","--ipam-controller-network","192.168.1.1/24,192.168.1.1,8.8.8.8","-node-labels","{\"my-label\":\"my-value\"}"]}'
+        - '{"command":"/usr/local/bin/user-cluster-controller-manager","args":["-kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","-metrics-listen-address","0.0.0.0:8085","-health-listen-address","0.0.0.0:8086","-namespace","$(NAMESPACE)","-cluster-url","","-openvpn-server-port","30003","-overwrite-registry","","-openshift=false","-version","1.13.0","-cloud-provider-name","aws","-openvpn-ca-cert-file=/etc/kubernetes/pki/openvpn/ca.crt","-openvpn-ca-key-file=/etc/kubernetes/pki/openvpn/ca.key","-user-ssh-keys-dir-path=/etc/kubernetes/usersshkeys","--ipam-controller-network","192.168.1.1/24,192.168.1.1,8.8.8.8","-node-labels","{\"my-label\":\"my-value\"}"]}'
         command:
         - /http-prober-bin/http-prober
         env:
@@ -71,9 +70,6 @@ spec:
         - mountPath: /etc/kubernetes/kubeconfig
           name: internal-admin-kubeconfig
           readOnly: true
-        - mountPath: /etc/kubernetes/pki/ca
-          name: ca
-          readOnly: true
         - mountPath: /etc/kubernetes/pki/openvpn
           name: openvpn-ca
           readOnly: true
@@ -95,13 +91,11 @@ spec:
         volumeMounts:
         - mountPath: /http-prober-bin
           name: http-prober-bin
+      serviceAccountName: kubermatic-usercluster-controller-manager
       volumes:
       - name: internal-admin-kubeconfig
         secret:
           secretName: internal-admin-kubeconfig
-      - name: ca
-        secret:
-          secretName: ca
       - name: openvpn-ca
         secret:
           secretName: openvpn-ca

--- a/api/pkg/resources/test/fixtures/deployment-azure-1.10.0-usercluster-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-azure-1.10.0-usercluster-controller.yaml
@@ -24,7 +24,6 @@ spec:
         app: usercluster-controller
         cluster: de-test-01
         internal-admin-kubeconfig-secret-revision: "123456"
-        openvpn-ca-secret-revision: "123456"
         usersshkeys-secret-revision: "123456"
     spec:
       containers:
@@ -39,7 +38,7 @@ spec:
         - -timeout
         - "1"
         - -command
-        - '{"command":"/usr/local/bin/user-cluster-controller-manager","args":["-kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","-metrics-listen-address","0.0.0.0:8085","-health-listen-address","0.0.0.0:8086","-namespace","$(NAMESPACE)","-cluster-url","","-openvpn-server-port","30003","-overwrite-registry","","-openshift=false","-version","1.10.0","-cloud-provider-name","azure","-openvpn-ca-cert-file=/etc/kubernetes/pki/openvpn/ca.crt","-openvpn-ca-key-file=/etc/kubernetes/pki/openvpn/ca.key","-user-ssh-keys-dir-path=/etc/kubernetes/usersshkeys","--ipam-controller-network","192.168.1.1/24,192.168.1.1,8.8.8.8","-node-labels","{\"my-label\":\"my-value\"}"]}'
+        - '{"command":"/usr/local/bin/user-cluster-controller-manager","args":["-kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","-metrics-listen-address","0.0.0.0:8085","-health-listen-address","0.0.0.0:8086","-namespace","$(NAMESPACE)","-cluster-url","","-openvpn-server-port","30003","-overwrite-registry","","-openshift=false","-version","1.10.0","-cloud-provider-name","azure","-user-ssh-keys-dir-path=/etc/kubernetes/usersshkeys","--ipam-controller-network","192.168.1.1/24,192.168.1.1,8.8.8.8","-node-labels","{\"my-label\":\"my-value\"}"]}'
         command:
         - /http-prober-bin/http-prober
         env:
@@ -70,9 +69,6 @@ spec:
         - mountPath: /etc/kubernetes/kubeconfig
           name: internal-admin-kubeconfig
           readOnly: true
-        - mountPath: /etc/kubernetes/pki/openvpn
-          name: openvpn-ca
-          readOnly: true
         - mountPath: /etc/kubernetes/usersshkeys
           name: usersshkeys
           readOnly: true
@@ -96,9 +92,6 @@ spec:
       - name: internal-admin-kubeconfig
         secret:
           secretName: internal-admin-kubeconfig
-      - name: openvpn-ca
-        secret:
-          secretName: openvpn-ca
       - name: usersshkeys
         secret:
           secretName: usersshkeys

--- a/api/pkg/resources/test/fixtures/deployment-azure-1.10.0-usercluster-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-azure-1.10.0-usercluster-controller.yaml
@@ -22,7 +22,6 @@ spec:
       creationTimestamp: null
       labels:
         app: usercluster-controller
-        ca-secret-revision: "123456"
         cluster: de-test-01
         internal-admin-kubeconfig-secret-revision: "123456"
         openvpn-ca-secret-revision: "123456"
@@ -40,7 +39,7 @@ spec:
         - -timeout
         - "1"
         - -command
-        - '{"command":"/usr/local/bin/user-cluster-controller-manager","args":["-kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","-metrics-listen-address","0.0.0.0:8085","-health-listen-address","0.0.0.0:8086","-namespace","$(NAMESPACE)","-ca-cert","/etc/kubernetes/pki/ca/ca.crt","-ca-key","/etc/kubernetes/pki/ca/ca.key","-cluster-url","","-openvpn-server-port","30003","-overwrite-registry","","-openshift=false","-version","1.10.0","-cloud-provider-name","azure","-openvpn-ca-cert-file=/etc/kubernetes/pki/openvpn/ca.crt","-openvpn-ca-key-file=/etc/kubernetes/pki/openvpn/ca.key","-user-ssh-keys-dir-path=/etc/kubernetes/usersshkeys","--ipam-controller-network","192.168.1.1/24,192.168.1.1,8.8.8.8","-node-labels","{\"my-label\":\"my-value\"}"]}'
+        - '{"command":"/usr/local/bin/user-cluster-controller-manager","args":["-kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","-metrics-listen-address","0.0.0.0:8085","-health-listen-address","0.0.0.0:8086","-namespace","$(NAMESPACE)","-cluster-url","","-openvpn-server-port","30003","-overwrite-registry","","-openshift=false","-version","1.10.0","-cloud-provider-name","azure","-openvpn-ca-cert-file=/etc/kubernetes/pki/openvpn/ca.crt","-openvpn-ca-key-file=/etc/kubernetes/pki/openvpn/ca.key","-user-ssh-keys-dir-path=/etc/kubernetes/usersshkeys","--ipam-controller-network","192.168.1.1/24,192.168.1.1,8.8.8.8","-node-labels","{\"my-label\":\"my-value\"}"]}'
         command:
         - /http-prober-bin/http-prober
         env:
@@ -71,9 +70,6 @@ spec:
         - mountPath: /etc/kubernetes/kubeconfig
           name: internal-admin-kubeconfig
           readOnly: true
-        - mountPath: /etc/kubernetes/pki/ca
-          name: ca
-          readOnly: true
         - mountPath: /etc/kubernetes/pki/openvpn
           name: openvpn-ca
           readOnly: true
@@ -95,13 +91,11 @@ spec:
         volumeMounts:
         - mountPath: /http-prober-bin
           name: http-prober-bin
+      serviceAccountName: kubermatic-usercluster-controller-manager
       volumes:
       - name: internal-admin-kubeconfig
         secret:
           secretName: internal-admin-kubeconfig
-      - name: ca
-        secret:
-          secretName: ca
       - name: openvpn-ca
         secret:
           secretName: openvpn-ca

--- a/api/pkg/resources/test/fixtures/deployment-azure-1.10.0-usercluster-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-azure-1.10.0-usercluster-controller.yaml
@@ -24,7 +24,6 @@ spec:
         app: usercluster-controller
         cluster: de-test-01
         internal-admin-kubeconfig-secret-revision: "123456"
-        usersshkeys-secret-revision: "123456"
     spec:
       containers:
       - args:
@@ -38,7 +37,7 @@ spec:
         - -timeout
         - "1"
         - -command
-        - '{"command":"/usr/local/bin/user-cluster-controller-manager","args":["-kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","-metrics-listen-address","0.0.0.0:8085","-health-listen-address","0.0.0.0:8086","-namespace","$(NAMESPACE)","-cluster-url","","-openvpn-server-port","30003","-overwrite-registry","","-openshift=false","-version","1.10.0","-cloud-provider-name","azure","-user-ssh-keys-dir-path=/etc/kubernetes/usersshkeys","--ipam-controller-network","192.168.1.1/24,192.168.1.1,8.8.8.8","-node-labels","{\"my-label\":\"my-value\"}"]}'
+        - '{"command":"/usr/local/bin/user-cluster-controller-manager","args":["-kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","-metrics-listen-address","0.0.0.0:8085","-health-listen-address","0.0.0.0:8086","-namespace","$(NAMESPACE)","-cluster-url","","-openvpn-server-port","30003","-overwrite-registry","","-openshift=false","-version","1.10.0","-cloud-provider-name","azure","--ipam-controller-network","192.168.1.1/24,192.168.1.1,8.8.8.8","-node-labels","{\"my-label\":\"my-value\"}"]}'
         command:
         - /http-prober-bin/http-prober
         env:
@@ -69,9 +68,6 @@ spec:
         - mountPath: /etc/kubernetes/kubeconfig
           name: internal-admin-kubeconfig
           readOnly: true
-        - mountPath: /etc/kubernetes/usersshkeys
-          name: usersshkeys
-          readOnly: true
         - mountPath: /http-prober-bin
           name: http-prober-bin
       imagePullSecrets:
@@ -92,9 +88,6 @@ spec:
       - name: internal-admin-kubeconfig
         secret:
           secretName: internal-admin-kubeconfig
-      - name: usersshkeys
-        secret:
-          secretName: usersshkeys
       - emptyDir: {}
         name: http-prober-bin
 status: {}

--- a/api/pkg/resources/test/fixtures/deployment-azure-1.10.6-usercluster-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-azure-1.10.6-usercluster-controller.yaml
@@ -24,7 +24,6 @@ spec:
         app: usercluster-controller
         cluster: de-test-01
         internal-admin-kubeconfig-secret-revision: "123456"
-        openvpn-ca-secret-revision: "123456"
         usersshkeys-secret-revision: "123456"
     spec:
       containers:
@@ -39,7 +38,7 @@ spec:
         - -timeout
         - "1"
         - -command
-        - '{"command":"/usr/local/bin/user-cluster-controller-manager","args":["-kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","-metrics-listen-address","0.0.0.0:8085","-health-listen-address","0.0.0.0:8086","-namespace","$(NAMESPACE)","-cluster-url","","-openvpn-server-port","30003","-overwrite-registry","","-openshift=false","-version","1.10.6","-cloud-provider-name","azure","-openvpn-ca-cert-file=/etc/kubernetes/pki/openvpn/ca.crt","-openvpn-ca-key-file=/etc/kubernetes/pki/openvpn/ca.key","-user-ssh-keys-dir-path=/etc/kubernetes/usersshkeys","--ipam-controller-network","192.168.1.1/24,192.168.1.1,8.8.8.8","-node-labels","{\"my-label\":\"my-value\"}"]}'
+        - '{"command":"/usr/local/bin/user-cluster-controller-manager","args":["-kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","-metrics-listen-address","0.0.0.0:8085","-health-listen-address","0.0.0.0:8086","-namespace","$(NAMESPACE)","-cluster-url","","-openvpn-server-port","30003","-overwrite-registry","","-openshift=false","-version","1.10.6","-cloud-provider-name","azure","-user-ssh-keys-dir-path=/etc/kubernetes/usersshkeys","--ipam-controller-network","192.168.1.1/24,192.168.1.1,8.8.8.8","-node-labels","{\"my-label\":\"my-value\"}"]}'
         command:
         - /http-prober-bin/http-prober
         env:
@@ -70,9 +69,6 @@ spec:
         - mountPath: /etc/kubernetes/kubeconfig
           name: internal-admin-kubeconfig
           readOnly: true
-        - mountPath: /etc/kubernetes/pki/openvpn
-          name: openvpn-ca
-          readOnly: true
         - mountPath: /etc/kubernetes/usersshkeys
           name: usersshkeys
           readOnly: true
@@ -96,9 +92,6 @@ spec:
       - name: internal-admin-kubeconfig
         secret:
           secretName: internal-admin-kubeconfig
-      - name: openvpn-ca
-        secret:
-          secretName: openvpn-ca
       - name: usersshkeys
         secret:
           secretName: usersshkeys

--- a/api/pkg/resources/test/fixtures/deployment-azure-1.10.6-usercluster-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-azure-1.10.6-usercluster-controller.yaml
@@ -24,7 +24,6 @@ spec:
         app: usercluster-controller
         cluster: de-test-01
         internal-admin-kubeconfig-secret-revision: "123456"
-        usersshkeys-secret-revision: "123456"
     spec:
       containers:
       - args:
@@ -38,7 +37,7 @@ spec:
         - -timeout
         - "1"
         - -command
-        - '{"command":"/usr/local/bin/user-cluster-controller-manager","args":["-kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","-metrics-listen-address","0.0.0.0:8085","-health-listen-address","0.0.0.0:8086","-namespace","$(NAMESPACE)","-cluster-url","","-openvpn-server-port","30003","-overwrite-registry","","-openshift=false","-version","1.10.6","-cloud-provider-name","azure","-user-ssh-keys-dir-path=/etc/kubernetes/usersshkeys","--ipam-controller-network","192.168.1.1/24,192.168.1.1,8.8.8.8","-node-labels","{\"my-label\":\"my-value\"}"]}'
+        - '{"command":"/usr/local/bin/user-cluster-controller-manager","args":["-kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","-metrics-listen-address","0.0.0.0:8085","-health-listen-address","0.0.0.0:8086","-namespace","$(NAMESPACE)","-cluster-url","","-openvpn-server-port","30003","-overwrite-registry","","-openshift=false","-version","1.10.6","-cloud-provider-name","azure","--ipam-controller-network","192.168.1.1/24,192.168.1.1,8.8.8.8","-node-labels","{\"my-label\":\"my-value\"}"]}'
         command:
         - /http-prober-bin/http-prober
         env:
@@ -69,9 +68,6 @@ spec:
         - mountPath: /etc/kubernetes/kubeconfig
           name: internal-admin-kubeconfig
           readOnly: true
-        - mountPath: /etc/kubernetes/usersshkeys
-          name: usersshkeys
-          readOnly: true
         - mountPath: /http-prober-bin
           name: http-prober-bin
       imagePullSecrets:
@@ -92,9 +88,6 @@ spec:
       - name: internal-admin-kubeconfig
         secret:
           secretName: internal-admin-kubeconfig
-      - name: usersshkeys
-        secret:
-          secretName: usersshkeys
       - emptyDir: {}
         name: http-prober-bin
 status: {}

--- a/api/pkg/resources/test/fixtures/deployment-azure-1.10.6-usercluster-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-azure-1.10.6-usercluster-controller.yaml
@@ -22,7 +22,6 @@ spec:
       creationTimestamp: null
       labels:
         app: usercluster-controller
-        ca-secret-revision: "123456"
         cluster: de-test-01
         internal-admin-kubeconfig-secret-revision: "123456"
         openvpn-ca-secret-revision: "123456"
@@ -40,7 +39,7 @@ spec:
         - -timeout
         - "1"
         - -command
-        - '{"command":"/usr/local/bin/user-cluster-controller-manager","args":["-kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","-metrics-listen-address","0.0.0.0:8085","-health-listen-address","0.0.0.0:8086","-namespace","$(NAMESPACE)","-ca-cert","/etc/kubernetes/pki/ca/ca.crt","-ca-key","/etc/kubernetes/pki/ca/ca.key","-cluster-url","","-openvpn-server-port","30003","-overwrite-registry","","-openshift=false","-version","1.10.6","-cloud-provider-name","azure","-openvpn-ca-cert-file=/etc/kubernetes/pki/openvpn/ca.crt","-openvpn-ca-key-file=/etc/kubernetes/pki/openvpn/ca.key","-user-ssh-keys-dir-path=/etc/kubernetes/usersshkeys","--ipam-controller-network","192.168.1.1/24,192.168.1.1,8.8.8.8","-node-labels","{\"my-label\":\"my-value\"}"]}'
+        - '{"command":"/usr/local/bin/user-cluster-controller-manager","args":["-kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","-metrics-listen-address","0.0.0.0:8085","-health-listen-address","0.0.0.0:8086","-namespace","$(NAMESPACE)","-cluster-url","","-openvpn-server-port","30003","-overwrite-registry","","-openshift=false","-version","1.10.6","-cloud-provider-name","azure","-openvpn-ca-cert-file=/etc/kubernetes/pki/openvpn/ca.crt","-openvpn-ca-key-file=/etc/kubernetes/pki/openvpn/ca.key","-user-ssh-keys-dir-path=/etc/kubernetes/usersshkeys","--ipam-controller-network","192.168.1.1/24,192.168.1.1,8.8.8.8","-node-labels","{\"my-label\":\"my-value\"}"]}'
         command:
         - /http-prober-bin/http-prober
         env:
@@ -71,9 +70,6 @@ spec:
         - mountPath: /etc/kubernetes/kubeconfig
           name: internal-admin-kubeconfig
           readOnly: true
-        - mountPath: /etc/kubernetes/pki/ca
-          name: ca
-          readOnly: true
         - mountPath: /etc/kubernetes/pki/openvpn
           name: openvpn-ca
           readOnly: true
@@ -95,13 +91,11 @@ spec:
         volumeMounts:
         - mountPath: /http-prober-bin
           name: http-prober-bin
+      serviceAccountName: kubermatic-usercluster-controller-manager
       volumes:
       - name: internal-admin-kubeconfig
         secret:
           secretName: internal-admin-kubeconfig
-      - name: ca
-        secret:
-          secretName: ca
       - name: openvpn-ca
         secret:
           secretName: openvpn-ca

--- a/api/pkg/resources/test/fixtures/deployment-azure-1.11.0-usercluster-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-azure-1.11.0-usercluster-controller.yaml
@@ -24,7 +24,6 @@ spec:
         app: usercluster-controller
         cluster: de-test-01
         internal-admin-kubeconfig-secret-revision: "123456"
-        openvpn-ca-secret-revision: "123456"
         usersshkeys-secret-revision: "123456"
     spec:
       containers:
@@ -39,7 +38,7 @@ spec:
         - -timeout
         - "1"
         - -command
-        - '{"command":"/usr/local/bin/user-cluster-controller-manager","args":["-kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","-metrics-listen-address","0.0.0.0:8085","-health-listen-address","0.0.0.0:8086","-namespace","$(NAMESPACE)","-cluster-url","","-openvpn-server-port","30003","-overwrite-registry","","-openshift=false","-version","1.11.0","-cloud-provider-name","azure","-openvpn-ca-cert-file=/etc/kubernetes/pki/openvpn/ca.crt","-openvpn-ca-key-file=/etc/kubernetes/pki/openvpn/ca.key","-user-ssh-keys-dir-path=/etc/kubernetes/usersshkeys","--ipam-controller-network","192.168.1.1/24,192.168.1.1,8.8.8.8","-node-labels","{\"my-label\":\"my-value\"}"]}'
+        - '{"command":"/usr/local/bin/user-cluster-controller-manager","args":["-kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","-metrics-listen-address","0.0.0.0:8085","-health-listen-address","0.0.0.0:8086","-namespace","$(NAMESPACE)","-cluster-url","","-openvpn-server-port","30003","-overwrite-registry","","-openshift=false","-version","1.11.0","-cloud-provider-name","azure","-user-ssh-keys-dir-path=/etc/kubernetes/usersshkeys","--ipam-controller-network","192.168.1.1/24,192.168.1.1,8.8.8.8","-node-labels","{\"my-label\":\"my-value\"}"]}'
         command:
         - /http-prober-bin/http-prober
         env:
@@ -70,9 +69,6 @@ spec:
         - mountPath: /etc/kubernetes/kubeconfig
           name: internal-admin-kubeconfig
           readOnly: true
-        - mountPath: /etc/kubernetes/pki/openvpn
-          name: openvpn-ca
-          readOnly: true
         - mountPath: /etc/kubernetes/usersshkeys
           name: usersshkeys
           readOnly: true
@@ -96,9 +92,6 @@ spec:
       - name: internal-admin-kubeconfig
         secret:
           secretName: internal-admin-kubeconfig
-      - name: openvpn-ca
-        secret:
-          secretName: openvpn-ca
       - name: usersshkeys
         secret:
           secretName: usersshkeys

--- a/api/pkg/resources/test/fixtures/deployment-azure-1.11.0-usercluster-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-azure-1.11.0-usercluster-controller.yaml
@@ -24,7 +24,6 @@ spec:
         app: usercluster-controller
         cluster: de-test-01
         internal-admin-kubeconfig-secret-revision: "123456"
-        usersshkeys-secret-revision: "123456"
     spec:
       containers:
       - args:
@@ -38,7 +37,7 @@ spec:
         - -timeout
         - "1"
         - -command
-        - '{"command":"/usr/local/bin/user-cluster-controller-manager","args":["-kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","-metrics-listen-address","0.0.0.0:8085","-health-listen-address","0.0.0.0:8086","-namespace","$(NAMESPACE)","-cluster-url","","-openvpn-server-port","30003","-overwrite-registry","","-openshift=false","-version","1.11.0","-cloud-provider-name","azure","-user-ssh-keys-dir-path=/etc/kubernetes/usersshkeys","--ipam-controller-network","192.168.1.1/24,192.168.1.1,8.8.8.8","-node-labels","{\"my-label\":\"my-value\"}"]}'
+        - '{"command":"/usr/local/bin/user-cluster-controller-manager","args":["-kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","-metrics-listen-address","0.0.0.0:8085","-health-listen-address","0.0.0.0:8086","-namespace","$(NAMESPACE)","-cluster-url","","-openvpn-server-port","30003","-overwrite-registry","","-openshift=false","-version","1.11.0","-cloud-provider-name","azure","--ipam-controller-network","192.168.1.1/24,192.168.1.1,8.8.8.8","-node-labels","{\"my-label\":\"my-value\"}"]}'
         command:
         - /http-prober-bin/http-prober
         env:
@@ -69,9 +68,6 @@ spec:
         - mountPath: /etc/kubernetes/kubeconfig
           name: internal-admin-kubeconfig
           readOnly: true
-        - mountPath: /etc/kubernetes/usersshkeys
-          name: usersshkeys
-          readOnly: true
         - mountPath: /http-prober-bin
           name: http-prober-bin
       imagePullSecrets:
@@ -92,9 +88,6 @@ spec:
       - name: internal-admin-kubeconfig
         secret:
           secretName: internal-admin-kubeconfig
-      - name: usersshkeys
-        secret:
-          secretName: usersshkeys
       - emptyDir: {}
         name: http-prober-bin
 status: {}

--- a/api/pkg/resources/test/fixtures/deployment-azure-1.11.0-usercluster-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-azure-1.11.0-usercluster-controller.yaml
@@ -22,7 +22,6 @@ spec:
       creationTimestamp: null
       labels:
         app: usercluster-controller
-        ca-secret-revision: "123456"
         cluster: de-test-01
         internal-admin-kubeconfig-secret-revision: "123456"
         openvpn-ca-secret-revision: "123456"
@@ -40,7 +39,7 @@ spec:
         - -timeout
         - "1"
         - -command
-        - '{"command":"/usr/local/bin/user-cluster-controller-manager","args":["-kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","-metrics-listen-address","0.0.0.0:8085","-health-listen-address","0.0.0.0:8086","-namespace","$(NAMESPACE)","-ca-cert","/etc/kubernetes/pki/ca/ca.crt","-ca-key","/etc/kubernetes/pki/ca/ca.key","-cluster-url","","-openvpn-server-port","30003","-overwrite-registry","","-openshift=false","-version","1.11.0","-cloud-provider-name","azure","-openvpn-ca-cert-file=/etc/kubernetes/pki/openvpn/ca.crt","-openvpn-ca-key-file=/etc/kubernetes/pki/openvpn/ca.key","-user-ssh-keys-dir-path=/etc/kubernetes/usersshkeys","--ipam-controller-network","192.168.1.1/24,192.168.1.1,8.8.8.8","-node-labels","{\"my-label\":\"my-value\"}"]}'
+        - '{"command":"/usr/local/bin/user-cluster-controller-manager","args":["-kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","-metrics-listen-address","0.0.0.0:8085","-health-listen-address","0.0.0.0:8086","-namespace","$(NAMESPACE)","-cluster-url","","-openvpn-server-port","30003","-overwrite-registry","","-openshift=false","-version","1.11.0","-cloud-provider-name","azure","-openvpn-ca-cert-file=/etc/kubernetes/pki/openvpn/ca.crt","-openvpn-ca-key-file=/etc/kubernetes/pki/openvpn/ca.key","-user-ssh-keys-dir-path=/etc/kubernetes/usersshkeys","--ipam-controller-network","192.168.1.1/24,192.168.1.1,8.8.8.8","-node-labels","{\"my-label\":\"my-value\"}"]}'
         command:
         - /http-prober-bin/http-prober
         env:
@@ -71,9 +70,6 @@ spec:
         - mountPath: /etc/kubernetes/kubeconfig
           name: internal-admin-kubeconfig
           readOnly: true
-        - mountPath: /etc/kubernetes/pki/ca
-          name: ca
-          readOnly: true
         - mountPath: /etc/kubernetes/pki/openvpn
           name: openvpn-ca
           readOnly: true
@@ -95,13 +91,11 @@ spec:
         volumeMounts:
         - mountPath: /http-prober-bin
           name: http-prober-bin
+      serviceAccountName: kubermatic-usercluster-controller-manager
       volumes:
       - name: internal-admin-kubeconfig
         secret:
           secretName: internal-admin-kubeconfig
-      - name: ca
-        secret:
-          secretName: ca
       - name: openvpn-ca
         secret:
           secretName: openvpn-ca

--- a/api/pkg/resources/test/fixtures/deployment-azure-1.11.1-usercluster-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-azure-1.11.1-usercluster-controller.yaml
@@ -22,7 +22,6 @@ spec:
       creationTimestamp: null
       labels:
         app: usercluster-controller
-        ca-secret-revision: "123456"
         cluster: de-test-01
         internal-admin-kubeconfig-secret-revision: "123456"
         openvpn-ca-secret-revision: "123456"
@@ -40,7 +39,7 @@ spec:
         - -timeout
         - "1"
         - -command
-        - '{"command":"/usr/local/bin/user-cluster-controller-manager","args":["-kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","-metrics-listen-address","0.0.0.0:8085","-health-listen-address","0.0.0.0:8086","-namespace","$(NAMESPACE)","-ca-cert","/etc/kubernetes/pki/ca/ca.crt","-ca-key","/etc/kubernetes/pki/ca/ca.key","-cluster-url","","-openvpn-server-port","30003","-overwrite-registry","","-openshift=false","-version","1.11.1","-cloud-provider-name","azure","-openvpn-ca-cert-file=/etc/kubernetes/pki/openvpn/ca.crt","-openvpn-ca-key-file=/etc/kubernetes/pki/openvpn/ca.key","-user-ssh-keys-dir-path=/etc/kubernetes/usersshkeys","--ipam-controller-network","192.168.1.1/24,192.168.1.1,8.8.8.8","-node-labels","{\"my-label\":\"my-value\"}"]}'
+        - '{"command":"/usr/local/bin/user-cluster-controller-manager","args":["-kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","-metrics-listen-address","0.0.0.0:8085","-health-listen-address","0.0.0.0:8086","-namespace","$(NAMESPACE)","-cluster-url","","-openvpn-server-port","30003","-overwrite-registry","","-openshift=false","-version","1.11.1","-cloud-provider-name","azure","-openvpn-ca-cert-file=/etc/kubernetes/pki/openvpn/ca.crt","-openvpn-ca-key-file=/etc/kubernetes/pki/openvpn/ca.key","-user-ssh-keys-dir-path=/etc/kubernetes/usersshkeys","--ipam-controller-network","192.168.1.1/24,192.168.1.1,8.8.8.8","-node-labels","{\"my-label\":\"my-value\"}"]}'
         command:
         - /http-prober-bin/http-prober
         env:
@@ -71,9 +70,6 @@ spec:
         - mountPath: /etc/kubernetes/kubeconfig
           name: internal-admin-kubeconfig
           readOnly: true
-        - mountPath: /etc/kubernetes/pki/ca
-          name: ca
-          readOnly: true
         - mountPath: /etc/kubernetes/pki/openvpn
           name: openvpn-ca
           readOnly: true
@@ -95,13 +91,11 @@ spec:
         volumeMounts:
         - mountPath: /http-prober-bin
           name: http-prober-bin
+      serviceAccountName: kubermatic-usercluster-controller-manager
       volumes:
       - name: internal-admin-kubeconfig
         secret:
           secretName: internal-admin-kubeconfig
-      - name: ca
-        secret:
-          secretName: ca
       - name: openvpn-ca
         secret:
           secretName: openvpn-ca

--- a/api/pkg/resources/test/fixtures/deployment-azure-1.11.1-usercluster-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-azure-1.11.1-usercluster-controller.yaml
@@ -24,7 +24,6 @@ spec:
         app: usercluster-controller
         cluster: de-test-01
         internal-admin-kubeconfig-secret-revision: "123456"
-        openvpn-ca-secret-revision: "123456"
         usersshkeys-secret-revision: "123456"
     spec:
       containers:
@@ -39,7 +38,7 @@ spec:
         - -timeout
         - "1"
         - -command
-        - '{"command":"/usr/local/bin/user-cluster-controller-manager","args":["-kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","-metrics-listen-address","0.0.0.0:8085","-health-listen-address","0.0.0.0:8086","-namespace","$(NAMESPACE)","-cluster-url","","-openvpn-server-port","30003","-overwrite-registry","","-openshift=false","-version","1.11.1","-cloud-provider-name","azure","-openvpn-ca-cert-file=/etc/kubernetes/pki/openvpn/ca.crt","-openvpn-ca-key-file=/etc/kubernetes/pki/openvpn/ca.key","-user-ssh-keys-dir-path=/etc/kubernetes/usersshkeys","--ipam-controller-network","192.168.1.1/24,192.168.1.1,8.8.8.8","-node-labels","{\"my-label\":\"my-value\"}"]}'
+        - '{"command":"/usr/local/bin/user-cluster-controller-manager","args":["-kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","-metrics-listen-address","0.0.0.0:8085","-health-listen-address","0.0.0.0:8086","-namespace","$(NAMESPACE)","-cluster-url","","-openvpn-server-port","30003","-overwrite-registry","","-openshift=false","-version","1.11.1","-cloud-provider-name","azure","-user-ssh-keys-dir-path=/etc/kubernetes/usersshkeys","--ipam-controller-network","192.168.1.1/24,192.168.1.1,8.8.8.8","-node-labels","{\"my-label\":\"my-value\"}"]}'
         command:
         - /http-prober-bin/http-prober
         env:
@@ -70,9 +69,6 @@ spec:
         - mountPath: /etc/kubernetes/kubeconfig
           name: internal-admin-kubeconfig
           readOnly: true
-        - mountPath: /etc/kubernetes/pki/openvpn
-          name: openvpn-ca
-          readOnly: true
         - mountPath: /etc/kubernetes/usersshkeys
           name: usersshkeys
           readOnly: true
@@ -96,9 +92,6 @@ spec:
       - name: internal-admin-kubeconfig
         secret:
           secretName: internal-admin-kubeconfig
-      - name: openvpn-ca
-        secret:
-          secretName: openvpn-ca
       - name: usersshkeys
         secret:
           secretName: usersshkeys

--- a/api/pkg/resources/test/fixtures/deployment-azure-1.11.1-usercluster-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-azure-1.11.1-usercluster-controller.yaml
@@ -24,7 +24,6 @@ spec:
         app: usercluster-controller
         cluster: de-test-01
         internal-admin-kubeconfig-secret-revision: "123456"
-        usersshkeys-secret-revision: "123456"
     spec:
       containers:
       - args:
@@ -38,7 +37,7 @@ spec:
         - -timeout
         - "1"
         - -command
-        - '{"command":"/usr/local/bin/user-cluster-controller-manager","args":["-kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","-metrics-listen-address","0.0.0.0:8085","-health-listen-address","0.0.0.0:8086","-namespace","$(NAMESPACE)","-cluster-url","","-openvpn-server-port","30003","-overwrite-registry","","-openshift=false","-version","1.11.1","-cloud-provider-name","azure","-user-ssh-keys-dir-path=/etc/kubernetes/usersshkeys","--ipam-controller-network","192.168.1.1/24,192.168.1.1,8.8.8.8","-node-labels","{\"my-label\":\"my-value\"}"]}'
+        - '{"command":"/usr/local/bin/user-cluster-controller-manager","args":["-kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","-metrics-listen-address","0.0.0.0:8085","-health-listen-address","0.0.0.0:8086","-namespace","$(NAMESPACE)","-cluster-url","","-openvpn-server-port","30003","-overwrite-registry","","-openshift=false","-version","1.11.1","-cloud-provider-name","azure","--ipam-controller-network","192.168.1.1/24,192.168.1.1,8.8.8.8","-node-labels","{\"my-label\":\"my-value\"}"]}'
         command:
         - /http-prober-bin/http-prober
         env:
@@ -69,9 +68,6 @@ spec:
         - mountPath: /etc/kubernetes/kubeconfig
           name: internal-admin-kubeconfig
           readOnly: true
-        - mountPath: /etc/kubernetes/usersshkeys
-          name: usersshkeys
-          readOnly: true
         - mountPath: /http-prober-bin
           name: http-prober-bin
       imagePullSecrets:
@@ -92,9 +88,6 @@ spec:
       - name: internal-admin-kubeconfig
         secret:
           secretName: internal-admin-kubeconfig
-      - name: usersshkeys
-        secret:
-          secretName: usersshkeys
       - emptyDir: {}
         name: http-prober-bin
 status: {}

--- a/api/pkg/resources/test/fixtures/deployment-azure-1.12.0-usercluster-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-azure-1.12.0-usercluster-controller.yaml
@@ -22,7 +22,6 @@ spec:
       creationTimestamp: null
       labels:
         app: usercluster-controller
-        ca-secret-revision: "123456"
         cluster: de-test-01
         internal-admin-kubeconfig-secret-revision: "123456"
         openvpn-ca-secret-revision: "123456"
@@ -40,7 +39,7 @@ spec:
         - -timeout
         - "1"
         - -command
-        - '{"command":"/usr/local/bin/user-cluster-controller-manager","args":["-kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","-metrics-listen-address","0.0.0.0:8085","-health-listen-address","0.0.0.0:8086","-namespace","$(NAMESPACE)","-ca-cert","/etc/kubernetes/pki/ca/ca.crt","-ca-key","/etc/kubernetes/pki/ca/ca.key","-cluster-url","","-openvpn-server-port","30003","-overwrite-registry","","-openshift=false","-version","1.12.0","-cloud-provider-name","azure","-openvpn-ca-cert-file=/etc/kubernetes/pki/openvpn/ca.crt","-openvpn-ca-key-file=/etc/kubernetes/pki/openvpn/ca.key","-user-ssh-keys-dir-path=/etc/kubernetes/usersshkeys","--ipam-controller-network","192.168.1.1/24,192.168.1.1,8.8.8.8","-node-labels","{\"my-label\":\"my-value\"}"]}'
+        - '{"command":"/usr/local/bin/user-cluster-controller-manager","args":["-kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","-metrics-listen-address","0.0.0.0:8085","-health-listen-address","0.0.0.0:8086","-namespace","$(NAMESPACE)","-cluster-url","","-openvpn-server-port","30003","-overwrite-registry","","-openshift=false","-version","1.12.0","-cloud-provider-name","azure","-openvpn-ca-cert-file=/etc/kubernetes/pki/openvpn/ca.crt","-openvpn-ca-key-file=/etc/kubernetes/pki/openvpn/ca.key","-user-ssh-keys-dir-path=/etc/kubernetes/usersshkeys","--ipam-controller-network","192.168.1.1/24,192.168.1.1,8.8.8.8","-node-labels","{\"my-label\":\"my-value\"}"]}'
         command:
         - /http-prober-bin/http-prober
         env:
@@ -71,9 +70,6 @@ spec:
         - mountPath: /etc/kubernetes/kubeconfig
           name: internal-admin-kubeconfig
           readOnly: true
-        - mountPath: /etc/kubernetes/pki/ca
-          name: ca
-          readOnly: true
         - mountPath: /etc/kubernetes/pki/openvpn
           name: openvpn-ca
           readOnly: true
@@ -95,13 +91,11 @@ spec:
         volumeMounts:
         - mountPath: /http-prober-bin
           name: http-prober-bin
+      serviceAccountName: kubermatic-usercluster-controller-manager
       volumes:
       - name: internal-admin-kubeconfig
         secret:
           secretName: internal-admin-kubeconfig
-      - name: ca
-        secret:
-          secretName: ca
       - name: openvpn-ca
         secret:
           secretName: openvpn-ca

--- a/api/pkg/resources/test/fixtures/deployment-azure-1.12.0-usercluster-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-azure-1.12.0-usercluster-controller.yaml
@@ -24,7 +24,6 @@ spec:
         app: usercluster-controller
         cluster: de-test-01
         internal-admin-kubeconfig-secret-revision: "123456"
-        openvpn-ca-secret-revision: "123456"
         usersshkeys-secret-revision: "123456"
     spec:
       containers:
@@ -39,7 +38,7 @@ spec:
         - -timeout
         - "1"
         - -command
-        - '{"command":"/usr/local/bin/user-cluster-controller-manager","args":["-kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","-metrics-listen-address","0.0.0.0:8085","-health-listen-address","0.0.0.0:8086","-namespace","$(NAMESPACE)","-cluster-url","","-openvpn-server-port","30003","-overwrite-registry","","-openshift=false","-version","1.12.0","-cloud-provider-name","azure","-openvpn-ca-cert-file=/etc/kubernetes/pki/openvpn/ca.crt","-openvpn-ca-key-file=/etc/kubernetes/pki/openvpn/ca.key","-user-ssh-keys-dir-path=/etc/kubernetes/usersshkeys","--ipam-controller-network","192.168.1.1/24,192.168.1.1,8.8.8.8","-node-labels","{\"my-label\":\"my-value\"}"]}'
+        - '{"command":"/usr/local/bin/user-cluster-controller-manager","args":["-kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","-metrics-listen-address","0.0.0.0:8085","-health-listen-address","0.0.0.0:8086","-namespace","$(NAMESPACE)","-cluster-url","","-openvpn-server-port","30003","-overwrite-registry","","-openshift=false","-version","1.12.0","-cloud-provider-name","azure","-user-ssh-keys-dir-path=/etc/kubernetes/usersshkeys","--ipam-controller-network","192.168.1.1/24,192.168.1.1,8.8.8.8","-node-labels","{\"my-label\":\"my-value\"}"]}'
         command:
         - /http-prober-bin/http-prober
         env:
@@ -70,9 +69,6 @@ spec:
         - mountPath: /etc/kubernetes/kubeconfig
           name: internal-admin-kubeconfig
           readOnly: true
-        - mountPath: /etc/kubernetes/pki/openvpn
-          name: openvpn-ca
-          readOnly: true
         - mountPath: /etc/kubernetes/usersshkeys
           name: usersshkeys
           readOnly: true
@@ -96,9 +92,6 @@ spec:
       - name: internal-admin-kubeconfig
         secret:
           secretName: internal-admin-kubeconfig
-      - name: openvpn-ca
-        secret:
-          secretName: openvpn-ca
       - name: usersshkeys
         secret:
           secretName: usersshkeys

--- a/api/pkg/resources/test/fixtures/deployment-azure-1.12.0-usercluster-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-azure-1.12.0-usercluster-controller.yaml
@@ -24,7 +24,6 @@ spec:
         app: usercluster-controller
         cluster: de-test-01
         internal-admin-kubeconfig-secret-revision: "123456"
-        usersshkeys-secret-revision: "123456"
     spec:
       containers:
       - args:
@@ -38,7 +37,7 @@ spec:
         - -timeout
         - "1"
         - -command
-        - '{"command":"/usr/local/bin/user-cluster-controller-manager","args":["-kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","-metrics-listen-address","0.0.0.0:8085","-health-listen-address","0.0.0.0:8086","-namespace","$(NAMESPACE)","-cluster-url","","-openvpn-server-port","30003","-overwrite-registry","","-openshift=false","-version","1.12.0","-cloud-provider-name","azure","-user-ssh-keys-dir-path=/etc/kubernetes/usersshkeys","--ipam-controller-network","192.168.1.1/24,192.168.1.1,8.8.8.8","-node-labels","{\"my-label\":\"my-value\"}"]}'
+        - '{"command":"/usr/local/bin/user-cluster-controller-manager","args":["-kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","-metrics-listen-address","0.0.0.0:8085","-health-listen-address","0.0.0.0:8086","-namespace","$(NAMESPACE)","-cluster-url","","-openvpn-server-port","30003","-overwrite-registry","","-openshift=false","-version","1.12.0","-cloud-provider-name","azure","--ipam-controller-network","192.168.1.1/24,192.168.1.1,8.8.8.8","-node-labels","{\"my-label\":\"my-value\"}"]}'
         command:
         - /http-prober-bin/http-prober
         env:
@@ -69,9 +68,6 @@ spec:
         - mountPath: /etc/kubernetes/kubeconfig
           name: internal-admin-kubeconfig
           readOnly: true
-        - mountPath: /etc/kubernetes/usersshkeys
-          name: usersshkeys
-          readOnly: true
         - mountPath: /http-prober-bin
           name: http-prober-bin
       imagePullSecrets:
@@ -92,9 +88,6 @@ spec:
       - name: internal-admin-kubeconfig
         secret:
           secretName: internal-admin-kubeconfig
-      - name: usersshkeys
-        secret:
-          secretName: usersshkeys
       - emptyDir: {}
         name: http-prober-bin
 status: {}

--- a/api/pkg/resources/test/fixtures/deployment-azure-1.13.0-usercluster-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-azure-1.13.0-usercluster-controller.yaml
@@ -24,7 +24,6 @@ spec:
         app: usercluster-controller
         cluster: de-test-01
         internal-admin-kubeconfig-secret-revision: "123456"
-        openvpn-ca-secret-revision: "123456"
         usersshkeys-secret-revision: "123456"
     spec:
       containers:
@@ -39,7 +38,7 @@ spec:
         - -timeout
         - "1"
         - -command
-        - '{"command":"/usr/local/bin/user-cluster-controller-manager","args":["-kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","-metrics-listen-address","0.0.0.0:8085","-health-listen-address","0.0.0.0:8086","-namespace","$(NAMESPACE)","-cluster-url","","-openvpn-server-port","30003","-overwrite-registry","","-openshift=false","-version","1.13.0","-cloud-provider-name","azure","-openvpn-ca-cert-file=/etc/kubernetes/pki/openvpn/ca.crt","-openvpn-ca-key-file=/etc/kubernetes/pki/openvpn/ca.key","-user-ssh-keys-dir-path=/etc/kubernetes/usersshkeys","--ipam-controller-network","192.168.1.1/24,192.168.1.1,8.8.8.8","-node-labels","{\"my-label\":\"my-value\"}"]}'
+        - '{"command":"/usr/local/bin/user-cluster-controller-manager","args":["-kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","-metrics-listen-address","0.0.0.0:8085","-health-listen-address","0.0.0.0:8086","-namespace","$(NAMESPACE)","-cluster-url","","-openvpn-server-port","30003","-overwrite-registry","","-openshift=false","-version","1.13.0","-cloud-provider-name","azure","-user-ssh-keys-dir-path=/etc/kubernetes/usersshkeys","--ipam-controller-network","192.168.1.1/24,192.168.1.1,8.8.8.8","-node-labels","{\"my-label\":\"my-value\"}"]}'
         command:
         - /http-prober-bin/http-prober
         env:
@@ -70,9 +69,6 @@ spec:
         - mountPath: /etc/kubernetes/kubeconfig
           name: internal-admin-kubeconfig
           readOnly: true
-        - mountPath: /etc/kubernetes/pki/openvpn
-          name: openvpn-ca
-          readOnly: true
         - mountPath: /etc/kubernetes/usersshkeys
           name: usersshkeys
           readOnly: true
@@ -96,9 +92,6 @@ spec:
       - name: internal-admin-kubeconfig
         secret:
           secretName: internal-admin-kubeconfig
-      - name: openvpn-ca
-        secret:
-          secretName: openvpn-ca
       - name: usersshkeys
         secret:
           secretName: usersshkeys

--- a/api/pkg/resources/test/fixtures/deployment-azure-1.13.0-usercluster-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-azure-1.13.0-usercluster-controller.yaml
@@ -24,7 +24,6 @@ spec:
         app: usercluster-controller
         cluster: de-test-01
         internal-admin-kubeconfig-secret-revision: "123456"
-        usersshkeys-secret-revision: "123456"
     spec:
       containers:
       - args:
@@ -38,7 +37,7 @@ spec:
         - -timeout
         - "1"
         - -command
-        - '{"command":"/usr/local/bin/user-cluster-controller-manager","args":["-kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","-metrics-listen-address","0.0.0.0:8085","-health-listen-address","0.0.0.0:8086","-namespace","$(NAMESPACE)","-cluster-url","","-openvpn-server-port","30003","-overwrite-registry","","-openshift=false","-version","1.13.0","-cloud-provider-name","azure","-user-ssh-keys-dir-path=/etc/kubernetes/usersshkeys","--ipam-controller-network","192.168.1.1/24,192.168.1.1,8.8.8.8","-node-labels","{\"my-label\":\"my-value\"}"]}'
+        - '{"command":"/usr/local/bin/user-cluster-controller-manager","args":["-kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","-metrics-listen-address","0.0.0.0:8085","-health-listen-address","0.0.0.0:8086","-namespace","$(NAMESPACE)","-cluster-url","","-openvpn-server-port","30003","-overwrite-registry","","-openshift=false","-version","1.13.0","-cloud-provider-name","azure","--ipam-controller-network","192.168.1.1/24,192.168.1.1,8.8.8.8","-node-labels","{\"my-label\":\"my-value\"}"]}'
         command:
         - /http-prober-bin/http-prober
         env:
@@ -69,9 +68,6 @@ spec:
         - mountPath: /etc/kubernetes/kubeconfig
           name: internal-admin-kubeconfig
           readOnly: true
-        - mountPath: /etc/kubernetes/usersshkeys
-          name: usersshkeys
-          readOnly: true
         - mountPath: /http-prober-bin
           name: http-prober-bin
       imagePullSecrets:
@@ -92,9 +88,6 @@ spec:
       - name: internal-admin-kubeconfig
         secret:
           secretName: internal-admin-kubeconfig
-      - name: usersshkeys
-        secret:
-          secretName: usersshkeys
       - emptyDir: {}
         name: http-prober-bin
 status: {}

--- a/api/pkg/resources/test/fixtures/deployment-azure-1.13.0-usercluster-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-azure-1.13.0-usercluster-controller.yaml
@@ -22,7 +22,6 @@ spec:
       creationTimestamp: null
       labels:
         app: usercluster-controller
-        ca-secret-revision: "123456"
         cluster: de-test-01
         internal-admin-kubeconfig-secret-revision: "123456"
         openvpn-ca-secret-revision: "123456"
@@ -40,7 +39,7 @@ spec:
         - -timeout
         - "1"
         - -command
-        - '{"command":"/usr/local/bin/user-cluster-controller-manager","args":["-kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","-metrics-listen-address","0.0.0.0:8085","-health-listen-address","0.0.0.0:8086","-namespace","$(NAMESPACE)","-ca-cert","/etc/kubernetes/pki/ca/ca.crt","-ca-key","/etc/kubernetes/pki/ca/ca.key","-cluster-url","","-openvpn-server-port","30003","-overwrite-registry","","-openshift=false","-version","1.13.0","-cloud-provider-name","azure","-openvpn-ca-cert-file=/etc/kubernetes/pki/openvpn/ca.crt","-openvpn-ca-key-file=/etc/kubernetes/pki/openvpn/ca.key","-user-ssh-keys-dir-path=/etc/kubernetes/usersshkeys","--ipam-controller-network","192.168.1.1/24,192.168.1.1,8.8.8.8","-node-labels","{\"my-label\":\"my-value\"}"]}'
+        - '{"command":"/usr/local/bin/user-cluster-controller-manager","args":["-kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","-metrics-listen-address","0.0.0.0:8085","-health-listen-address","0.0.0.0:8086","-namespace","$(NAMESPACE)","-cluster-url","","-openvpn-server-port","30003","-overwrite-registry","","-openshift=false","-version","1.13.0","-cloud-provider-name","azure","-openvpn-ca-cert-file=/etc/kubernetes/pki/openvpn/ca.crt","-openvpn-ca-key-file=/etc/kubernetes/pki/openvpn/ca.key","-user-ssh-keys-dir-path=/etc/kubernetes/usersshkeys","--ipam-controller-network","192.168.1.1/24,192.168.1.1,8.8.8.8","-node-labels","{\"my-label\":\"my-value\"}"]}'
         command:
         - /http-prober-bin/http-prober
         env:
@@ -71,9 +70,6 @@ spec:
         - mountPath: /etc/kubernetes/kubeconfig
           name: internal-admin-kubeconfig
           readOnly: true
-        - mountPath: /etc/kubernetes/pki/ca
-          name: ca
-          readOnly: true
         - mountPath: /etc/kubernetes/pki/openvpn
           name: openvpn-ca
           readOnly: true
@@ -95,13 +91,11 @@ spec:
         volumeMounts:
         - mountPath: /http-prober-bin
           name: http-prober-bin
+      serviceAccountName: kubermatic-usercluster-controller-manager
       volumes:
       - name: internal-admin-kubeconfig
         secret:
           secretName: internal-admin-kubeconfig
-      - name: ca
-        secret:
-          secretName: ca
       - name: openvpn-ca
         secret:
           secretName: openvpn-ca

--- a/api/pkg/resources/test/fixtures/deployment-bringyourown-1.10.0-usercluster-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-bringyourown-1.10.0-usercluster-controller.yaml
@@ -24,7 +24,6 @@ spec:
         app: usercluster-controller
         cluster: de-test-01
         internal-admin-kubeconfig-secret-revision: "123456"
-        usersshkeys-secret-revision: "123456"
     spec:
       containers:
       - args:
@@ -38,7 +37,7 @@ spec:
         - -timeout
         - "1"
         - -command
-        - '{"command":"/usr/local/bin/user-cluster-controller-manager","args":["-kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","-metrics-listen-address","0.0.0.0:8085","-health-listen-address","0.0.0.0:8086","-namespace","$(NAMESPACE)","-cluster-url","","-openvpn-server-port","30003","-overwrite-registry","","-openshift=false","-version","1.10.0","-cloud-provider-name","","-user-ssh-keys-dir-path=/etc/kubernetes/usersshkeys","--ipam-controller-network","192.168.1.1/24,192.168.1.1,8.8.8.8","-node-labels","{\"my-label\":\"my-value\"}"]}'
+        - '{"command":"/usr/local/bin/user-cluster-controller-manager","args":["-kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","-metrics-listen-address","0.0.0.0:8085","-health-listen-address","0.0.0.0:8086","-namespace","$(NAMESPACE)","-cluster-url","","-openvpn-server-port","30003","-overwrite-registry","","-openshift=false","-version","1.10.0","-cloud-provider-name","","--ipam-controller-network","192.168.1.1/24,192.168.1.1,8.8.8.8","-node-labels","{\"my-label\":\"my-value\"}"]}'
         command:
         - /http-prober-bin/http-prober
         env:
@@ -69,9 +68,6 @@ spec:
         - mountPath: /etc/kubernetes/kubeconfig
           name: internal-admin-kubeconfig
           readOnly: true
-        - mountPath: /etc/kubernetes/usersshkeys
-          name: usersshkeys
-          readOnly: true
         - mountPath: /http-prober-bin
           name: http-prober-bin
       imagePullSecrets:
@@ -92,9 +88,6 @@ spec:
       - name: internal-admin-kubeconfig
         secret:
           secretName: internal-admin-kubeconfig
-      - name: usersshkeys
-        secret:
-          secretName: usersshkeys
       - emptyDir: {}
         name: http-prober-bin
 status: {}

--- a/api/pkg/resources/test/fixtures/deployment-bringyourown-1.10.0-usercluster-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-bringyourown-1.10.0-usercluster-controller.yaml
@@ -24,7 +24,6 @@ spec:
         app: usercluster-controller
         cluster: de-test-01
         internal-admin-kubeconfig-secret-revision: "123456"
-        openvpn-ca-secret-revision: "123456"
         usersshkeys-secret-revision: "123456"
     spec:
       containers:
@@ -39,7 +38,7 @@ spec:
         - -timeout
         - "1"
         - -command
-        - '{"command":"/usr/local/bin/user-cluster-controller-manager","args":["-kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","-metrics-listen-address","0.0.0.0:8085","-health-listen-address","0.0.0.0:8086","-namespace","$(NAMESPACE)","-cluster-url","","-openvpn-server-port","30003","-overwrite-registry","","-openshift=false","-version","1.10.0","-cloud-provider-name","","-openvpn-ca-cert-file=/etc/kubernetes/pki/openvpn/ca.crt","-openvpn-ca-key-file=/etc/kubernetes/pki/openvpn/ca.key","-user-ssh-keys-dir-path=/etc/kubernetes/usersshkeys","--ipam-controller-network","192.168.1.1/24,192.168.1.1,8.8.8.8","-node-labels","{\"my-label\":\"my-value\"}"]}'
+        - '{"command":"/usr/local/bin/user-cluster-controller-manager","args":["-kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","-metrics-listen-address","0.0.0.0:8085","-health-listen-address","0.0.0.0:8086","-namespace","$(NAMESPACE)","-cluster-url","","-openvpn-server-port","30003","-overwrite-registry","","-openshift=false","-version","1.10.0","-cloud-provider-name","","-user-ssh-keys-dir-path=/etc/kubernetes/usersshkeys","--ipam-controller-network","192.168.1.1/24,192.168.1.1,8.8.8.8","-node-labels","{\"my-label\":\"my-value\"}"]}'
         command:
         - /http-prober-bin/http-prober
         env:
@@ -70,9 +69,6 @@ spec:
         - mountPath: /etc/kubernetes/kubeconfig
           name: internal-admin-kubeconfig
           readOnly: true
-        - mountPath: /etc/kubernetes/pki/openvpn
-          name: openvpn-ca
-          readOnly: true
         - mountPath: /etc/kubernetes/usersshkeys
           name: usersshkeys
           readOnly: true
@@ -96,9 +92,6 @@ spec:
       - name: internal-admin-kubeconfig
         secret:
           secretName: internal-admin-kubeconfig
-      - name: openvpn-ca
-        secret:
-          secretName: openvpn-ca
       - name: usersshkeys
         secret:
           secretName: usersshkeys

--- a/api/pkg/resources/test/fixtures/deployment-bringyourown-1.10.0-usercluster-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-bringyourown-1.10.0-usercluster-controller.yaml
@@ -22,7 +22,6 @@ spec:
       creationTimestamp: null
       labels:
         app: usercluster-controller
-        ca-secret-revision: "123456"
         cluster: de-test-01
         internal-admin-kubeconfig-secret-revision: "123456"
         openvpn-ca-secret-revision: "123456"
@@ -40,7 +39,7 @@ spec:
         - -timeout
         - "1"
         - -command
-        - '{"command":"/usr/local/bin/user-cluster-controller-manager","args":["-kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","-metrics-listen-address","0.0.0.0:8085","-health-listen-address","0.0.0.0:8086","-namespace","$(NAMESPACE)","-ca-cert","/etc/kubernetes/pki/ca/ca.crt","-ca-key","/etc/kubernetes/pki/ca/ca.key","-cluster-url","","-openvpn-server-port","30003","-overwrite-registry","","-openshift=false","-version","1.10.0","-cloud-provider-name","","-openvpn-ca-cert-file=/etc/kubernetes/pki/openvpn/ca.crt","-openvpn-ca-key-file=/etc/kubernetes/pki/openvpn/ca.key","-user-ssh-keys-dir-path=/etc/kubernetes/usersshkeys","--ipam-controller-network","192.168.1.1/24,192.168.1.1,8.8.8.8","-node-labels","{\"my-label\":\"my-value\"}"]}'
+        - '{"command":"/usr/local/bin/user-cluster-controller-manager","args":["-kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","-metrics-listen-address","0.0.0.0:8085","-health-listen-address","0.0.0.0:8086","-namespace","$(NAMESPACE)","-cluster-url","","-openvpn-server-port","30003","-overwrite-registry","","-openshift=false","-version","1.10.0","-cloud-provider-name","","-openvpn-ca-cert-file=/etc/kubernetes/pki/openvpn/ca.crt","-openvpn-ca-key-file=/etc/kubernetes/pki/openvpn/ca.key","-user-ssh-keys-dir-path=/etc/kubernetes/usersshkeys","--ipam-controller-network","192.168.1.1/24,192.168.1.1,8.8.8.8","-node-labels","{\"my-label\":\"my-value\"}"]}'
         command:
         - /http-prober-bin/http-prober
         env:
@@ -71,9 +70,6 @@ spec:
         - mountPath: /etc/kubernetes/kubeconfig
           name: internal-admin-kubeconfig
           readOnly: true
-        - mountPath: /etc/kubernetes/pki/ca
-          name: ca
-          readOnly: true
         - mountPath: /etc/kubernetes/pki/openvpn
           name: openvpn-ca
           readOnly: true
@@ -95,13 +91,11 @@ spec:
         volumeMounts:
         - mountPath: /http-prober-bin
           name: http-prober-bin
+      serviceAccountName: kubermatic-usercluster-controller-manager
       volumes:
       - name: internal-admin-kubeconfig
         secret:
           secretName: internal-admin-kubeconfig
-      - name: ca
-        secret:
-          secretName: ca
       - name: openvpn-ca
         secret:
           secretName: openvpn-ca

--- a/api/pkg/resources/test/fixtures/deployment-bringyourown-1.10.6-usercluster-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-bringyourown-1.10.6-usercluster-controller.yaml
@@ -22,7 +22,6 @@ spec:
       creationTimestamp: null
       labels:
         app: usercluster-controller
-        ca-secret-revision: "123456"
         cluster: de-test-01
         internal-admin-kubeconfig-secret-revision: "123456"
         openvpn-ca-secret-revision: "123456"
@@ -40,7 +39,7 @@ spec:
         - -timeout
         - "1"
         - -command
-        - '{"command":"/usr/local/bin/user-cluster-controller-manager","args":["-kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","-metrics-listen-address","0.0.0.0:8085","-health-listen-address","0.0.0.0:8086","-namespace","$(NAMESPACE)","-ca-cert","/etc/kubernetes/pki/ca/ca.crt","-ca-key","/etc/kubernetes/pki/ca/ca.key","-cluster-url","","-openvpn-server-port","30003","-overwrite-registry","","-openshift=false","-version","1.10.6","-cloud-provider-name","","-openvpn-ca-cert-file=/etc/kubernetes/pki/openvpn/ca.crt","-openvpn-ca-key-file=/etc/kubernetes/pki/openvpn/ca.key","-user-ssh-keys-dir-path=/etc/kubernetes/usersshkeys","--ipam-controller-network","192.168.1.1/24,192.168.1.1,8.8.8.8","-node-labels","{\"my-label\":\"my-value\"}"]}'
+        - '{"command":"/usr/local/bin/user-cluster-controller-manager","args":["-kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","-metrics-listen-address","0.0.0.0:8085","-health-listen-address","0.0.0.0:8086","-namespace","$(NAMESPACE)","-cluster-url","","-openvpn-server-port","30003","-overwrite-registry","","-openshift=false","-version","1.10.6","-cloud-provider-name","","-openvpn-ca-cert-file=/etc/kubernetes/pki/openvpn/ca.crt","-openvpn-ca-key-file=/etc/kubernetes/pki/openvpn/ca.key","-user-ssh-keys-dir-path=/etc/kubernetes/usersshkeys","--ipam-controller-network","192.168.1.1/24,192.168.1.1,8.8.8.8","-node-labels","{\"my-label\":\"my-value\"}"]}'
         command:
         - /http-prober-bin/http-prober
         env:
@@ -71,9 +70,6 @@ spec:
         - mountPath: /etc/kubernetes/kubeconfig
           name: internal-admin-kubeconfig
           readOnly: true
-        - mountPath: /etc/kubernetes/pki/ca
-          name: ca
-          readOnly: true
         - mountPath: /etc/kubernetes/pki/openvpn
           name: openvpn-ca
           readOnly: true
@@ -95,13 +91,11 @@ spec:
         volumeMounts:
         - mountPath: /http-prober-bin
           name: http-prober-bin
+      serviceAccountName: kubermatic-usercluster-controller-manager
       volumes:
       - name: internal-admin-kubeconfig
         secret:
           secretName: internal-admin-kubeconfig
-      - name: ca
-        secret:
-          secretName: ca
       - name: openvpn-ca
         secret:
           secretName: openvpn-ca

--- a/api/pkg/resources/test/fixtures/deployment-bringyourown-1.10.6-usercluster-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-bringyourown-1.10.6-usercluster-controller.yaml
@@ -24,7 +24,6 @@ spec:
         app: usercluster-controller
         cluster: de-test-01
         internal-admin-kubeconfig-secret-revision: "123456"
-        usersshkeys-secret-revision: "123456"
     spec:
       containers:
       - args:
@@ -38,7 +37,7 @@ spec:
         - -timeout
         - "1"
         - -command
-        - '{"command":"/usr/local/bin/user-cluster-controller-manager","args":["-kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","-metrics-listen-address","0.0.0.0:8085","-health-listen-address","0.0.0.0:8086","-namespace","$(NAMESPACE)","-cluster-url","","-openvpn-server-port","30003","-overwrite-registry","","-openshift=false","-version","1.10.6","-cloud-provider-name","","-user-ssh-keys-dir-path=/etc/kubernetes/usersshkeys","--ipam-controller-network","192.168.1.1/24,192.168.1.1,8.8.8.8","-node-labels","{\"my-label\":\"my-value\"}"]}'
+        - '{"command":"/usr/local/bin/user-cluster-controller-manager","args":["-kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","-metrics-listen-address","0.0.0.0:8085","-health-listen-address","0.0.0.0:8086","-namespace","$(NAMESPACE)","-cluster-url","","-openvpn-server-port","30003","-overwrite-registry","","-openshift=false","-version","1.10.6","-cloud-provider-name","","--ipam-controller-network","192.168.1.1/24,192.168.1.1,8.8.8.8","-node-labels","{\"my-label\":\"my-value\"}"]}'
         command:
         - /http-prober-bin/http-prober
         env:
@@ -69,9 +68,6 @@ spec:
         - mountPath: /etc/kubernetes/kubeconfig
           name: internal-admin-kubeconfig
           readOnly: true
-        - mountPath: /etc/kubernetes/usersshkeys
-          name: usersshkeys
-          readOnly: true
         - mountPath: /http-prober-bin
           name: http-prober-bin
       imagePullSecrets:
@@ -92,9 +88,6 @@ spec:
       - name: internal-admin-kubeconfig
         secret:
           secretName: internal-admin-kubeconfig
-      - name: usersshkeys
-        secret:
-          secretName: usersshkeys
       - emptyDir: {}
         name: http-prober-bin
 status: {}

--- a/api/pkg/resources/test/fixtures/deployment-bringyourown-1.10.6-usercluster-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-bringyourown-1.10.6-usercluster-controller.yaml
@@ -24,7 +24,6 @@ spec:
         app: usercluster-controller
         cluster: de-test-01
         internal-admin-kubeconfig-secret-revision: "123456"
-        openvpn-ca-secret-revision: "123456"
         usersshkeys-secret-revision: "123456"
     spec:
       containers:
@@ -39,7 +38,7 @@ spec:
         - -timeout
         - "1"
         - -command
-        - '{"command":"/usr/local/bin/user-cluster-controller-manager","args":["-kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","-metrics-listen-address","0.0.0.0:8085","-health-listen-address","0.0.0.0:8086","-namespace","$(NAMESPACE)","-cluster-url","","-openvpn-server-port","30003","-overwrite-registry","","-openshift=false","-version","1.10.6","-cloud-provider-name","","-openvpn-ca-cert-file=/etc/kubernetes/pki/openvpn/ca.crt","-openvpn-ca-key-file=/etc/kubernetes/pki/openvpn/ca.key","-user-ssh-keys-dir-path=/etc/kubernetes/usersshkeys","--ipam-controller-network","192.168.1.1/24,192.168.1.1,8.8.8.8","-node-labels","{\"my-label\":\"my-value\"}"]}'
+        - '{"command":"/usr/local/bin/user-cluster-controller-manager","args":["-kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","-metrics-listen-address","0.0.0.0:8085","-health-listen-address","0.0.0.0:8086","-namespace","$(NAMESPACE)","-cluster-url","","-openvpn-server-port","30003","-overwrite-registry","","-openshift=false","-version","1.10.6","-cloud-provider-name","","-user-ssh-keys-dir-path=/etc/kubernetes/usersshkeys","--ipam-controller-network","192.168.1.1/24,192.168.1.1,8.8.8.8","-node-labels","{\"my-label\":\"my-value\"}"]}'
         command:
         - /http-prober-bin/http-prober
         env:
@@ -70,9 +69,6 @@ spec:
         - mountPath: /etc/kubernetes/kubeconfig
           name: internal-admin-kubeconfig
           readOnly: true
-        - mountPath: /etc/kubernetes/pki/openvpn
-          name: openvpn-ca
-          readOnly: true
         - mountPath: /etc/kubernetes/usersshkeys
           name: usersshkeys
           readOnly: true
@@ -96,9 +92,6 @@ spec:
       - name: internal-admin-kubeconfig
         secret:
           secretName: internal-admin-kubeconfig
-      - name: openvpn-ca
-        secret:
-          secretName: openvpn-ca
       - name: usersshkeys
         secret:
           secretName: usersshkeys

--- a/api/pkg/resources/test/fixtures/deployment-bringyourown-1.11.0-usercluster-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-bringyourown-1.11.0-usercluster-controller.yaml
@@ -22,7 +22,6 @@ spec:
       creationTimestamp: null
       labels:
         app: usercluster-controller
-        ca-secret-revision: "123456"
         cluster: de-test-01
         internal-admin-kubeconfig-secret-revision: "123456"
         openvpn-ca-secret-revision: "123456"
@@ -40,7 +39,7 @@ spec:
         - -timeout
         - "1"
         - -command
-        - '{"command":"/usr/local/bin/user-cluster-controller-manager","args":["-kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","-metrics-listen-address","0.0.0.0:8085","-health-listen-address","0.0.0.0:8086","-namespace","$(NAMESPACE)","-ca-cert","/etc/kubernetes/pki/ca/ca.crt","-ca-key","/etc/kubernetes/pki/ca/ca.key","-cluster-url","","-openvpn-server-port","30003","-overwrite-registry","","-openshift=false","-version","1.11.0","-cloud-provider-name","","-openvpn-ca-cert-file=/etc/kubernetes/pki/openvpn/ca.crt","-openvpn-ca-key-file=/etc/kubernetes/pki/openvpn/ca.key","-user-ssh-keys-dir-path=/etc/kubernetes/usersshkeys","--ipam-controller-network","192.168.1.1/24,192.168.1.1,8.8.8.8","-node-labels","{\"my-label\":\"my-value\"}"]}'
+        - '{"command":"/usr/local/bin/user-cluster-controller-manager","args":["-kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","-metrics-listen-address","0.0.0.0:8085","-health-listen-address","0.0.0.0:8086","-namespace","$(NAMESPACE)","-cluster-url","","-openvpn-server-port","30003","-overwrite-registry","","-openshift=false","-version","1.11.0","-cloud-provider-name","","-openvpn-ca-cert-file=/etc/kubernetes/pki/openvpn/ca.crt","-openvpn-ca-key-file=/etc/kubernetes/pki/openvpn/ca.key","-user-ssh-keys-dir-path=/etc/kubernetes/usersshkeys","--ipam-controller-network","192.168.1.1/24,192.168.1.1,8.8.8.8","-node-labels","{\"my-label\":\"my-value\"}"]}'
         command:
         - /http-prober-bin/http-prober
         env:
@@ -71,9 +70,6 @@ spec:
         - mountPath: /etc/kubernetes/kubeconfig
           name: internal-admin-kubeconfig
           readOnly: true
-        - mountPath: /etc/kubernetes/pki/ca
-          name: ca
-          readOnly: true
         - mountPath: /etc/kubernetes/pki/openvpn
           name: openvpn-ca
           readOnly: true
@@ -95,13 +91,11 @@ spec:
         volumeMounts:
         - mountPath: /http-prober-bin
           name: http-prober-bin
+      serviceAccountName: kubermatic-usercluster-controller-manager
       volumes:
       - name: internal-admin-kubeconfig
         secret:
           secretName: internal-admin-kubeconfig
-      - name: ca
-        secret:
-          secretName: ca
       - name: openvpn-ca
         secret:
           secretName: openvpn-ca

--- a/api/pkg/resources/test/fixtures/deployment-bringyourown-1.11.0-usercluster-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-bringyourown-1.11.0-usercluster-controller.yaml
@@ -24,7 +24,6 @@ spec:
         app: usercluster-controller
         cluster: de-test-01
         internal-admin-kubeconfig-secret-revision: "123456"
-        openvpn-ca-secret-revision: "123456"
         usersshkeys-secret-revision: "123456"
     spec:
       containers:
@@ -39,7 +38,7 @@ spec:
         - -timeout
         - "1"
         - -command
-        - '{"command":"/usr/local/bin/user-cluster-controller-manager","args":["-kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","-metrics-listen-address","0.0.0.0:8085","-health-listen-address","0.0.0.0:8086","-namespace","$(NAMESPACE)","-cluster-url","","-openvpn-server-port","30003","-overwrite-registry","","-openshift=false","-version","1.11.0","-cloud-provider-name","","-openvpn-ca-cert-file=/etc/kubernetes/pki/openvpn/ca.crt","-openvpn-ca-key-file=/etc/kubernetes/pki/openvpn/ca.key","-user-ssh-keys-dir-path=/etc/kubernetes/usersshkeys","--ipam-controller-network","192.168.1.1/24,192.168.1.1,8.8.8.8","-node-labels","{\"my-label\":\"my-value\"}"]}'
+        - '{"command":"/usr/local/bin/user-cluster-controller-manager","args":["-kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","-metrics-listen-address","0.0.0.0:8085","-health-listen-address","0.0.0.0:8086","-namespace","$(NAMESPACE)","-cluster-url","","-openvpn-server-port","30003","-overwrite-registry","","-openshift=false","-version","1.11.0","-cloud-provider-name","","-user-ssh-keys-dir-path=/etc/kubernetes/usersshkeys","--ipam-controller-network","192.168.1.1/24,192.168.1.1,8.8.8.8","-node-labels","{\"my-label\":\"my-value\"}"]}'
         command:
         - /http-prober-bin/http-prober
         env:
@@ -70,9 +69,6 @@ spec:
         - mountPath: /etc/kubernetes/kubeconfig
           name: internal-admin-kubeconfig
           readOnly: true
-        - mountPath: /etc/kubernetes/pki/openvpn
-          name: openvpn-ca
-          readOnly: true
         - mountPath: /etc/kubernetes/usersshkeys
           name: usersshkeys
           readOnly: true
@@ -96,9 +92,6 @@ spec:
       - name: internal-admin-kubeconfig
         secret:
           secretName: internal-admin-kubeconfig
-      - name: openvpn-ca
-        secret:
-          secretName: openvpn-ca
       - name: usersshkeys
         secret:
           secretName: usersshkeys

--- a/api/pkg/resources/test/fixtures/deployment-bringyourown-1.11.0-usercluster-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-bringyourown-1.11.0-usercluster-controller.yaml
@@ -24,7 +24,6 @@ spec:
         app: usercluster-controller
         cluster: de-test-01
         internal-admin-kubeconfig-secret-revision: "123456"
-        usersshkeys-secret-revision: "123456"
     spec:
       containers:
       - args:
@@ -38,7 +37,7 @@ spec:
         - -timeout
         - "1"
         - -command
-        - '{"command":"/usr/local/bin/user-cluster-controller-manager","args":["-kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","-metrics-listen-address","0.0.0.0:8085","-health-listen-address","0.0.0.0:8086","-namespace","$(NAMESPACE)","-cluster-url","","-openvpn-server-port","30003","-overwrite-registry","","-openshift=false","-version","1.11.0","-cloud-provider-name","","-user-ssh-keys-dir-path=/etc/kubernetes/usersshkeys","--ipam-controller-network","192.168.1.1/24,192.168.1.1,8.8.8.8","-node-labels","{\"my-label\":\"my-value\"}"]}'
+        - '{"command":"/usr/local/bin/user-cluster-controller-manager","args":["-kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","-metrics-listen-address","0.0.0.0:8085","-health-listen-address","0.0.0.0:8086","-namespace","$(NAMESPACE)","-cluster-url","","-openvpn-server-port","30003","-overwrite-registry","","-openshift=false","-version","1.11.0","-cloud-provider-name","","--ipam-controller-network","192.168.1.1/24,192.168.1.1,8.8.8.8","-node-labels","{\"my-label\":\"my-value\"}"]}'
         command:
         - /http-prober-bin/http-prober
         env:
@@ -69,9 +68,6 @@ spec:
         - mountPath: /etc/kubernetes/kubeconfig
           name: internal-admin-kubeconfig
           readOnly: true
-        - mountPath: /etc/kubernetes/usersshkeys
-          name: usersshkeys
-          readOnly: true
         - mountPath: /http-prober-bin
           name: http-prober-bin
       imagePullSecrets:
@@ -92,9 +88,6 @@ spec:
       - name: internal-admin-kubeconfig
         secret:
           secretName: internal-admin-kubeconfig
-      - name: usersshkeys
-        secret:
-          secretName: usersshkeys
       - emptyDir: {}
         name: http-prober-bin
 status: {}

--- a/api/pkg/resources/test/fixtures/deployment-bringyourown-1.11.1-usercluster-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-bringyourown-1.11.1-usercluster-controller.yaml
@@ -24,7 +24,6 @@ spec:
         app: usercluster-controller
         cluster: de-test-01
         internal-admin-kubeconfig-secret-revision: "123456"
-        openvpn-ca-secret-revision: "123456"
         usersshkeys-secret-revision: "123456"
     spec:
       containers:
@@ -39,7 +38,7 @@ spec:
         - -timeout
         - "1"
         - -command
-        - '{"command":"/usr/local/bin/user-cluster-controller-manager","args":["-kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","-metrics-listen-address","0.0.0.0:8085","-health-listen-address","0.0.0.0:8086","-namespace","$(NAMESPACE)","-cluster-url","","-openvpn-server-port","30003","-overwrite-registry","","-openshift=false","-version","1.11.1","-cloud-provider-name","","-openvpn-ca-cert-file=/etc/kubernetes/pki/openvpn/ca.crt","-openvpn-ca-key-file=/etc/kubernetes/pki/openvpn/ca.key","-user-ssh-keys-dir-path=/etc/kubernetes/usersshkeys","--ipam-controller-network","192.168.1.1/24,192.168.1.1,8.8.8.8","-node-labels","{\"my-label\":\"my-value\"}"]}'
+        - '{"command":"/usr/local/bin/user-cluster-controller-manager","args":["-kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","-metrics-listen-address","0.0.0.0:8085","-health-listen-address","0.0.0.0:8086","-namespace","$(NAMESPACE)","-cluster-url","","-openvpn-server-port","30003","-overwrite-registry","","-openshift=false","-version","1.11.1","-cloud-provider-name","","-user-ssh-keys-dir-path=/etc/kubernetes/usersshkeys","--ipam-controller-network","192.168.1.1/24,192.168.1.1,8.8.8.8","-node-labels","{\"my-label\":\"my-value\"}"]}'
         command:
         - /http-prober-bin/http-prober
         env:
@@ -70,9 +69,6 @@ spec:
         - mountPath: /etc/kubernetes/kubeconfig
           name: internal-admin-kubeconfig
           readOnly: true
-        - mountPath: /etc/kubernetes/pki/openvpn
-          name: openvpn-ca
-          readOnly: true
         - mountPath: /etc/kubernetes/usersshkeys
           name: usersshkeys
           readOnly: true
@@ -96,9 +92,6 @@ spec:
       - name: internal-admin-kubeconfig
         secret:
           secretName: internal-admin-kubeconfig
-      - name: openvpn-ca
-        secret:
-          secretName: openvpn-ca
       - name: usersshkeys
         secret:
           secretName: usersshkeys

--- a/api/pkg/resources/test/fixtures/deployment-bringyourown-1.11.1-usercluster-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-bringyourown-1.11.1-usercluster-controller.yaml
@@ -24,7 +24,6 @@ spec:
         app: usercluster-controller
         cluster: de-test-01
         internal-admin-kubeconfig-secret-revision: "123456"
-        usersshkeys-secret-revision: "123456"
     spec:
       containers:
       - args:
@@ -38,7 +37,7 @@ spec:
         - -timeout
         - "1"
         - -command
-        - '{"command":"/usr/local/bin/user-cluster-controller-manager","args":["-kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","-metrics-listen-address","0.0.0.0:8085","-health-listen-address","0.0.0.0:8086","-namespace","$(NAMESPACE)","-cluster-url","","-openvpn-server-port","30003","-overwrite-registry","","-openshift=false","-version","1.11.1","-cloud-provider-name","","-user-ssh-keys-dir-path=/etc/kubernetes/usersshkeys","--ipam-controller-network","192.168.1.1/24,192.168.1.1,8.8.8.8","-node-labels","{\"my-label\":\"my-value\"}"]}'
+        - '{"command":"/usr/local/bin/user-cluster-controller-manager","args":["-kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","-metrics-listen-address","0.0.0.0:8085","-health-listen-address","0.0.0.0:8086","-namespace","$(NAMESPACE)","-cluster-url","","-openvpn-server-port","30003","-overwrite-registry","","-openshift=false","-version","1.11.1","-cloud-provider-name","","--ipam-controller-network","192.168.1.1/24,192.168.1.1,8.8.8.8","-node-labels","{\"my-label\":\"my-value\"}"]}'
         command:
         - /http-prober-bin/http-prober
         env:
@@ -69,9 +68,6 @@ spec:
         - mountPath: /etc/kubernetes/kubeconfig
           name: internal-admin-kubeconfig
           readOnly: true
-        - mountPath: /etc/kubernetes/usersshkeys
-          name: usersshkeys
-          readOnly: true
         - mountPath: /http-prober-bin
           name: http-prober-bin
       imagePullSecrets:
@@ -92,9 +88,6 @@ spec:
       - name: internal-admin-kubeconfig
         secret:
           secretName: internal-admin-kubeconfig
-      - name: usersshkeys
-        secret:
-          secretName: usersshkeys
       - emptyDir: {}
         name: http-prober-bin
 status: {}

--- a/api/pkg/resources/test/fixtures/deployment-bringyourown-1.11.1-usercluster-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-bringyourown-1.11.1-usercluster-controller.yaml
@@ -22,7 +22,6 @@ spec:
       creationTimestamp: null
       labels:
         app: usercluster-controller
-        ca-secret-revision: "123456"
         cluster: de-test-01
         internal-admin-kubeconfig-secret-revision: "123456"
         openvpn-ca-secret-revision: "123456"
@@ -40,7 +39,7 @@ spec:
         - -timeout
         - "1"
         - -command
-        - '{"command":"/usr/local/bin/user-cluster-controller-manager","args":["-kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","-metrics-listen-address","0.0.0.0:8085","-health-listen-address","0.0.0.0:8086","-namespace","$(NAMESPACE)","-ca-cert","/etc/kubernetes/pki/ca/ca.crt","-ca-key","/etc/kubernetes/pki/ca/ca.key","-cluster-url","","-openvpn-server-port","30003","-overwrite-registry","","-openshift=false","-version","1.11.1","-cloud-provider-name","","-openvpn-ca-cert-file=/etc/kubernetes/pki/openvpn/ca.crt","-openvpn-ca-key-file=/etc/kubernetes/pki/openvpn/ca.key","-user-ssh-keys-dir-path=/etc/kubernetes/usersshkeys","--ipam-controller-network","192.168.1.1/24,192.168.1.1,8.8.8.8","-node-labels","{\"my-label\":\"my-value\"}"]}'
+        - '{"command":"/usr/local/bin/user-cluster-controller-manager","args":["-kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","-metrics-listen-address","0.0.0.0:8085","-health-listen-address","0.0.0.0:8086","-namespace","$(NAMESPACE)","-cluster-url","","-openvpn-server-port","30003","-overwrite-registry","","-openshift=false","-version","1.11.1","-cloud-provider-name","","-openvpn-ca-cert-file=/etc/kubernetes/pki/openvpn/ca.crt","-openvpn-ca-key-file=/etc/kubernetes/pki/openvpn/ca.key","-user-ssh-keys-dir-path=/etc/kubernetes/usersshkeys","--ipam-controller-network","192.168.1.1/24,192.168.1.1,8.8.8.8","-node-labels","{\"my-label\":\"my-value\"}"]}'
         command:
         - /http-prober-bin/http-prober
         env:
@@ -71,9 +70,6 @@ spec:
         - mountPath: /etc/kubernetes/kubeconfig
           name: internal-admin-kubeconfig
           readOnly: true
-        - mountPath: /etc/kubernetes/pki/ca
-          name: ca
-          readOnly: true
         - mountPath: /etc/kubernetes/pki/openvpn
           name: openvpn-ca
           readOnly: true
@@ -95,13 +91,11 @@ spec:
         volumeMounts:
         - mountPath: /http-prober-bin
           name: http-prober-bin
+      serviceAccountName: kubermatic-usercluster-controller-manager
       volumes:
       - name: internal-admin-kubeconfig
         secret:
           secretName: internal-admin-kubeconfig
-      - name: ca
-        secret:
-          secretName: ca
       - name: openvpn-ca
         secret:
           secretName: openvpn-ca

--- a/api/pkg/resources/test/fixtures/deployment-bringyourown-1.12.0-usercluster-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-bringyourown-1.12.0-usercluster-controller.yaml
@@ -24,7 +24,6 @@ spec:
         app: usercluster-controller
         cluster: de-test-01
         internal-admin-kubeconfig-secret-revision: "123456"
-        usersshkeys-secret-revision: "123456"
     spec:
       containers:
       - args:
@@ -38,7 +37,7 @@ spec:
         - -timeout
         - "1"
         - -command
-        - '{"command":"/usr/local/bin/user-cluster-controller-manager","args":["-kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","-metrics-listen-address","0.0.0.0:8085","-health-listen-address","0.0.0.0:8086","-namespace","$(NAMESPACE)","-cluster-url","","-openvpn-server-port","30003","-overwrite-registry","","-openshift=false","-version","1.12.0","-cloud-provider-name","","-user-ssh-keys-dir-path=/etc/kubernetes/usersshkeys","--ipam-controller-network","192.168.1.1/24,192.168.1.1,8.8.8.8","-node-labels","{\"my-label\":\"my-value\"}"]}'
+        - '{"command":"/usr/local/bin/user-cluster-controller-manager","args":["-kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","-metrics-listen-address","0.0.0.0:8085","-health-listen-address","0.0.0.0:8086","-namespace","$(NAMESPACE)","-cluster-url","","-openvpn-server-port","30003","-overwrite-registry","","-openshift=false","-version","1.12.0","-cloud-provider-name","","--ipam-controller-network","192.168.1.1/24,192.168.1.1,8.8.8.8","-node-labels","{\"my-label\":\"my-value\"}"]}'
         command:
         - /http-prober-bin/http-prober
         env:
@@ -69,9 +68,6 @@ spec:
         - mountPath: /etc/kubernetes/kubeconfig
           name: internal-admin-kubeconfig
           readOnly: true
-        - mountPath: /etc/kubernetes/usersshkeys
-          name: usersshkeys
-          readOnly: true
         - mountPath: /http-prober-bin
           name: http-prober-bin
       imagePullSecrets:
@@ -92,9 +88,6 @@ spec:
       - name: internal-admin-kubeconfig
         secret:
           secretName: internal-admin-kubeconfig
-      - name: usersshkeys
-        secret:
-          secretName: usersshkeys
       - emptyDir: {}
         name: http-prober-bin
 status: {}

--- a/api/pkg/resources/test/fixtures/deployment-bringyourown-1.12.0-usercluster-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-bringyourown-1.12.0-usercluster-controller.yaml
@@ -24,7 +24,6 @@ spec:
         app: usercluster-controller
         cluster: de-test-01
         internal-admin-kubeconfig-secret-revision: "123456"
-        openvpn-ca-secret-revision: "123456"
         usersshkeys-secret-revision: "123456"
     spec:
       containers:
@@ -39,7 +38,7 @@ spec:
         - -timeout
         - "1"
         - -command
-        - '{"command":"/usr/local/bin/user-cluster-controller-manager","args":["-kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","-metrics-listen-address","0.0.0.0:8085","-health-listen-address","0.0.0.0:8086","-namespace","$(NAMESPACE)","-cluster-url","","-openvpn-server-port","30003","-overwrite-registry","","-openshift=false","-version","1.12.0","-cloud-provider-name","","-openvpn-ca-cert-file=/etc/kubernetes/pki/openvpn/ca.crt","-openvpn-ca-key-file=/etc/kubernetes/pki/openvpn/ca.key","-user-ssh-keys-dir-path=/etc/kubernetes/usersshkeys","--ipam-controller-network","192.168.1.1/24,192.168.1.1,8.8.8.8","-node-labels","{\"my-label\":\"my-value\"}"]}'
+        - '{"command":"/usr/local/bin/user-cluster-controller-manager","args":["-kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","-metrics-listen-address","0.0.0.0:8085","-health-listen-address","0.0.0.0:8086","-namespace","$(NAMESPACE)","-cluster-url","","-openvpn-server-port","30003","-overwrite-registry","","-openshift=false","-version","1.12.0","-cloud-provider-name","","-user-ssh-keys-dir-path=/etc/kubernetes/usersshkeys","--ipam-controller-network","192.168.1.1/24,192.168.1.1,8.8.8.8","-node-labels","{\"my-label\":\"my-value\"}"]}'
         command:
         - /http-prober-bin/http-prober
         env:
@@ -70,9 +69,6 @@ spec:
         - mountPath: /etc/kubernetes/kubeconfig
           name: internal-admin-kubeconfig
           readOnly: true
-        - mountPath: /etc/kubernetes/pki/openvpn
-          name: openvpn-ca
-          readOnly: true
         - mountPath: /etc/kubernetes/usersshkeys
           name: usersshkeys
           readOnly: true
@@ -96,9 +92,6 @@ spec:
       - name: internal-admin-kubeconfig
         secret:
           secretName: internal-admin-kubeconfig
-      - name: openvpn-ca
-        secret:
-          secretName: openvpn-ca
       - name: usersshkeys
         secret:
           secretName: usersshkeys

--- a/api/pkg/resources/test/fixtures/deployment-bringyourown-1.12.0-usercluster-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-bringyourown-1.12.0-usercluster-controller.yaml
@@ -22,7 +22,6 @@ spec:
       creationTimestamp: null
       labels:
         app: usercluster-controller
-        ca-secret-revision: "123456"
         cluster: de-test-01
         internal-admin-kubeconfig-secret-revision: "123456"
         openvpn-ca-secret-revision: "123456"
@@ -40,7 +39,7 @@ spec:
         - -timeout
         - "1"
         - -command
-        - '{"command":"/usr/local/bin/user-cluster-controller-manager","args":["-kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","-metrics-listen-address","0.0.0.0:8085","-health-listen-address","0.0.0.0:8086","-namespace","$(NAMESPACE)","-ca-cert","/etc/kubernetes/pki/ca/ca.crt","-ca-key","/etc/kubernetes/pki/ca/ca.key","-cluster-url","","-openvpn-server-port","30003","-overwrite-registry","","-openshift=false","-version","1.12.0","-cloud-provider-name","","-openvpn-ca-cert-file=/etc/kubernetes/pki/openvpn/ca.crt","-openvpn-ca-key-file=/etc/kubernetes/pki/openvpn/ca.key","-user-ssh-keys-dir-path=/etc/kubernetes/usersshkeys","--ipam-controller-network","192.168.1.1/24,192.168.1.1,8.8.8.8","-node-labels","{\"my-label\":\"my-value\"}"]}'
+        - '{"command":"/usr/local/bin/user-cluster-controller-manager","args":["-kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","-metrics-listen-address","0.0.0.0:8085","-health-listen-address","0.0.0.0:8086","-namespace","$(NAMESPACE)","-cluster-url","","-openvpn-server-port","30003","-overwrite-registry","","-openshift=false","-version","1.12.0","-cloud-provider-name","","-openvpn-ca-cert-file=/etc/kubernetes/pki/openvpn/ca.crt","-openvpn-ca-key-file=/etc/kubernetes/pki/openvpn/ca.key","-user-ssh-keys-dir-path=/etc/kubernetes/usersshkeys","--ipam-controller-network","192.168.1.1/24,192.168.1.1,8.8.8.8","-node-labels","{\"my-label\":\"my-value\"}"]}'
         command:
         - /http-prober-bin/http-prober
         env:
@@ -71,9 +70,6 @@ spec:
         - mountPath: /etc/kubernetes/kubeconfig
           name: internal-admin-kubeconfig
           readOnly: true
-        - mountPath: /etc/kubernetes/pki/ca
-          name: ca
-          readOnly: true
         - mountPath: /etc/kubernetes/pki/openvpn
           name: openvpn-ca
           readOnly: true
@@ -95,13 +91,11 @@ spec:
         volumeMounts:
         - mountPath: /http-prober-bin
           name: http-prober-bin
+      serviceAccountName: kubermatic-usercluster-controller-manager
       volumes:
       - name: internal-admin-kubeconfig
         secret:
           secretName: internal-admin-kubeconfig
-      - name: ca
-        secret:
-          secretName: ca
       - name: openvpn-ca
         secret:
           secretName: openvpn-ca

--- a/api/pkg/resources/test/fixtures/deployment-bringyourown-1.13.0-usercluster-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-bringyourown-1.13.0-usercluster-controller.yaml
@@ -22,7 +22,6 @@ spec:
       creationTimestamp: null
       labels:
         app: usercluster-controller
-        ca-secret-revision: "123456"
         cluster: de-test-01
         internal-admin-kubeconfig-secret-revision: "123456"
         openvpn-ca-secret-revision: "123456"
@@ -40,7 +39,7 @@ spec:
         - -timeout
         - "1"
         - -command
-        - '{"command":"/usr/local/bin/user-cluster-controller-manager","args":["-kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","-metrics-listen-address","0.0.0.0:8085","-health-listen-address","0.0.0.0:8086","-namespace","$(NAMESPACE)","-ca-cert","/etc/kubernetes/pki/ca/ca.crt","-ca-key","/etc/kubernetes/pki/ca/ca.key","-cluster-url","","-openvpn-server-port","30003","-overwrite-registry","","-openshift=false","-version","1.13.0","-cloud-provider-name","","-openvpn-ca-cert-file=/etc/kubernetes/pki/openvpn/ca.crt","-openvpn-ca-key-file=/etc/kubernetes/pki/openvpn/ca.key","-user-ssh-keys-dir-path=/etc/kubernetes/usersshkeys","--ipam-controller-network","192.168.1.1/24,192.168.1.1,8.8.8.8","-node-labels","{\"my-label\":\"my-value\"}"]}'
+        - '{"command":"/usr/local/bin/user-cluster-controller-manager","args":["-kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","-metrics-listen-address","0.0.0.0:8085","-health-listen-address","0.0.0.0:8086","-namespace","$(NAMESPACE)","-cluster-url","","-openvpn-server-port","30003","-overwrite-registry","","-openshift=false","-version","1.13.0","-cloud-provider-name","","-openvpn-ca-cert-file=/etc/kubernetes/pki/openvpn/ca.crt","-openvpn-ca-key-file=/etc/kubernetes/pki/openvpn/ca.key","-user-ssh-keys-dir-path=/etc/kubernetes/usersshkeys","--ipam-controller-network","192.168.1.1/24,192.168.1.1,8.8.8.8","-node-labels","{\"my-label\":\"my-value\"}"]}'
         command:
         - /http-prober-bin/http-prober
         env:
@@ -71,9 +70,6 @@ spec:
         - mountPath: /etc/kubernetes/kubeconfig
           name: internal-admin-kubeconfig
           readOnly: true
-        - mountPath: /etc/kubernetes/pki/ca
-          name: ca
-          readOnly: true
         - mountPath: /etc/kubernetes/pki/openvpn
           name: openvpn-ca
           readOnly: true
@@ -95,13 +91,11 @@ spec:
         volumeMounts:
         - mountPath: /http-prober-bin
           name: http-prober-bin
+      serviceAccountName: kubermatic-usercluster-controller-manager
       volumes:
       - name: internal-admin-kubeconfig
         secret:
           secretName: internal-admin-kubeconfig
-      - name: ca
-        secret:
-          secretName: ca
       - name: openvpn-ca
         secret:
           secretName: openvpn-ca

--- a/api/pkg/resources/test/fixtures/deployment-bringyourown-1.13.0-usercluster-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-bringyourown-1.13.0-usercluster-controller.yaml
@@ -24,7 +24,6 @@ spec:
         app: usercluster-controller
         cluster: de-test-01
         internal-admin-kubeconfig-secret-revision: "123456"
-        usersshkeys-secret-revision: "123456"
     spec:
       containers:
       - args:
@@ -38,7 +37,7 @@ spec:
         - -timeout
         - "1"
         - -command
-        - '{"command":"/usr/local/bin/user-cluster-controller-manager","args":["-kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","-metrics-listen-address","0.0.0.0:8085","-health-listen-address","0.0.0.0:8086","-namespace","$(NAMESPACE)","-cluster-url","","-openvpn-server-port","30003","-overwrite-registry","","-openshift=false","-version","1.13.0","-cloud-provider-name","","-user-ssh-keys-dir-path=/etc/kubernetes/usersshkeys","--ipam-controller-network","192.168.1.1/24,192.168.1.1,8.8.8.8","-node-labels","{\"my-label\":\"my-value\"}"]}'
+        - '{"command":"/usr/local/bin/user-cluster-controller-manager","args":["-kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","-metrics-listen-address","0.0.0.0:8085","-health-listen-address","0.0.0.0:8086","-namespace","$(NAMESPACE)","-cluster-url","","-openvpn-server-port","30003","-overwrite-registry","","-openshift=false","-version","1.13.0","-cloud-provider-name","","--ipam-controller-network","192.168.1.1/24,192.168.1.1,8.8.8.8","-node-labels","{\"my-label\":\"my-value\"}"]}'
         command:
         - /http-prober-bin/http-prober
         env:
@@ -69,9 +68,6 @@ spec:
         - mountPath: /etc/kubernetes/kubeconfig
           name: internal-admin-kubeconfig
           readOnly: true
-        - mountPath: /etc/kubernetes/usersshkeys
-          name: usersshkeys
-          readOnly: true
         - mountPath: /http-prober-bin
           name: http-prober-bin
       imagePullSecrets:
@@ -92,9 +88,6 @@ spec:
       - name: internal-admin-kubeconfig
         secret:
           secretName: internal-admin-kubeconfig
-      - name: usersshkeys
-        secret:
-          secretName: usersshkeys
       - emptyDir: {}
         name: http-prober-bin
 status: {}

--- a/api/pkg/resources/test/fixtures/deployment-bringyourown-1.13.0-usercluster-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-bringyourown-1.13.0-usercluster-controller.yaml
@@ -24,7 +24,6 @@ spec:
         app: usercluster-controller
         cluster: de-test-01
         internal-admin-kubeconfig-secret-revision: "123456"
-        openvpn-ca-secret-revision: "123456"
         usersshkeys-secret-revision: "123456"
     spec:
       containers:
@@ -39,7 +38,7 @@ spec:
         - -timeout
         - "1"
         - -command
-        - '{"command":"/usr/local/bin/user-cluster-controller-manager","args":["-kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","-metrics-listen-address","0.0.0.0:8085","-health-listen-address","0.0.0.0:8086","-namespace","$(NAMESPACE)","-cluster-url","","-openvpn-server-port","30003","-overwrite-registry","","-openshift=false","-version","1.13.0","-cloud-provider-name","","-openvpn-ca-cert-file=/etc/kubernetes/pki/openvpn/ca.crt","-openvpn-ca-key-file=/etc/kubernetes/pki/openvpn/ca.key","-user-ssh-keys-dir-path=/etc/kubernetes/usersshkeys","--ipam-controller-network","192.168.1.1/24,192.168.1.1,8.8.8.8","-node-labels","{\"my-label\":\"my-value\"}"]}'
+        - '{"command":"/usr/local/bin/user-cluster-controller-manager","args":["-kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","-metrics-listen-address","0.0.0.0:8085","-health-listen-address","0.0.0.0:8086","-namespace","$(NAMESPACE)","-cluster-url","","-openvpn-server-port","30003","-overwrite-registry","","-openshift=false","-version","1.13.0","-cloud-provider-name","","-user-ssh-keys-dir-path=/etc/kubernetes/usersshkeys","--ipam-controller-network","192.168.1.1/24,192.168.1.1,8.8.8.8","-node-labels","{\"my-label\":\"my-value\"}"]}'
         command:
         - /http-prober-bin/http-prober
         env:
@@ -70,9 +69,6 @@ spec:
         - mountPath: /etc/kubernetes/kubeconfig
           name: internal-admin-kubeconfig
           readOnly: true
-        - mountPath: /etc/kubernetes/pki/openvpn
-          name: openvpn-ca
-          readOnly: true
         - mountPath: /etc/kubernetes/usersshkeys
           name: usersshkeys
           readOnly: true
@@ -96,9 +92,6 @@ spec:
       - name: internal-admin-kubeconfig
         secret:
           secretName: internal-admin-kubeconfig
-      - name: openvpn-ca
-        secret:
-          secretName: openvpn-ca
       - name: usersshkeys
         secret:
           secretName: usersshkeys

--- a/api/pkg/resources/test/fixtures/deployment-digitalocean-1.10.0-usercluster-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-digitalocean-1.10.0-usercluster-controller.yaml
@@ -24,7 +24,6 @@ spec:
         app: usercluster-controller
         cluster: de-test-01
         internal-admin-kubeconfig-secret-revision: "123456"
-        usersshkeys-secret-revision: "123456"
     spec:
       containers:
       - args:
@@ -38,7 +37,7 @@ spec:
         - -timeout
         - "1"
         - -command
-        - '{"command":"/usr/local/bin/user-cluster-controller-manager","args":["-kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","-metrics-listen-address","0.0.0.0:8085","-health-listen-address","0.0.0.0:8086","-namespace","$(NAMESPACE)","-cluster-url","","-openvpn-server-port","30003","-overwrite-registry","","-openshift=false","-version","1.10.0","-cloud-provider-name","","-user-ssh-keys-dir-path=/etc/kubernetes/usersshkeys","--ipam-controller-network","192.168.1.1/24,192.168.1.1,8.8.8.8","-node-labels","{\"my-label\":\"my-value\"}"]}'
+        - '{"command":"/usr/local/bin/user-cluster-controller-manager","args":["-kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","-metrics-listen-address","0.0.0.0:8085","-health-listen-address","0.0.0.0:8086","-namespace","$(NAMESPACE)","-cluster-url","","-openvpn-server-port","30003","-overwrite-registry","","-openshift=false","-version","1.10.0","-cloud-provider-name","","--ipam-controller-network","192.168.1.1/24,192.168.1.1,8.8.8.8","-node-labels","{\"my-label\":\"my-value\"}"]}'
         command:
         - /http-prober-bin/http-prober
         env:
@@ -69,9 +68,6 @@ spec:
         - mountPath: /etc/kubernetes/kubeconfig
           name: internal-admin-kubeconfig
           readOnly: true
-        - mountPath: /etc/kubernetes/usersshkeys
-          name: usersshkeys
-          readOnly: true
         - mountPath: /http-prober-bin
           name: http-prober-bin
       imagePullSecrets:
@@ -92,9 +88,6 @@ spec:
       - name: internal-admin-kubeconfig
         secret:
           secretName: internal-admin-kubeconfig
-      - name: usersshkeys
-        secret:
-          secretName: usersshkeys
       - emptyDir: {}
         name: http-prober-bin
 status: {}

--- a/api/pkg/resources/test/fixtures/deployment-digitalocean-1.10.0-usercluster-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-digitalocean-1.10.0-usercluster-controller.yaml
@@ -24,7 +24,6 @@ spec:
         app: usercluster-controller
         cluster: de-test-01
         internal-admin-kubeconfig-secret-revision: "123456"
-        openvpn-ca-secret-revision: "123456"
         usersshkeys-secret-revision: "123456"
     spec:
       containers:
@@ -39,7 +38,7 @@ spec:
         - -timeout
         - "1"
         - -command
-        - '{"command":"/usr/local/bin/user-cluster-controller-manager","args":["-kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","-metrics-listen-address","0.0.0.0:8085","-health-listen-address","0.0.0.0:8086","-namespace","$(NAMESPACE)","-cluster-url","","-openvpn-server-port","30003","-overwrite-registry","","-openshift=false","-version","1.10.0","-cloud-provider-name","","-openvpn-ca-cert-file=/etc/kubernetes/pki/openvpn/ca.crt","-openvpn-ca-key-file=/etc/kubernetes/pki/openvpn/ca.key","-user-ssh-keys-dir-path=/etc/kubernetes/usersshkeys","--ipam-controller-network","192.168.1.1/24,192.168.1.1,8.8.8.8","-node-labels","{\"my-label\":\"my-value\"}"]}'
+        - '{"command":"/usr/local/bin/user-cluster-controller-manager","args":["-kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","-metrics-listen-address","0.0.0.0:8085","-health-listen-address","0.0.0.0:8086","-namespace","$(NAMESPACE)","-cluster-url","","-openvpn-server-port","30003","-overwrite-registry","","-openshift=false","-version","1.10.0","-cloud-provider-name","","-user-ssh-keys-dir-path=/etc/kubernetes/usersshkeys","--ipam-controller-network","192.168.1.1/24,192.168.1.1,8.8.8.8","-node-labels","{\"my-label\":\"my-value\"}"]}'
         command:
         - /http-prober-bin/http-prober
         env:
@@ -70,9 +69,6 @@ spec:
         - mountPath: /etc/kubernetes/kubeconfig
           name: internal-admin-kubeconfig
           readOnly: true
-        - mountPath: /etc/kubernetes/pki/openvpn
-          name: openvpn-ca
-          readOnly: true
         - mountPath: /etc/kubernetes/usersshkeys
           name: usersshkeys
           readOnly: true
@@ -96,9 +92,6 @@ spec:
       - name: internal-admin-kubeconfig
         secret:
           secretName: internal-admin-kubeconfig
-      - name: openvpn-ca
-        secret:
-          secretName: openvpn-ca
       - name: usersshkeys
         secret:
           secretName: usersshkeys

--- a/api/pkg/resources/test/fixtures/deployment-digitalocean-1.10.0-usercluster-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-digitalocean-1.10.0-usercluster-controller.yaml
@@ -22,7 +22,6 @@ spec:
       creationTimestamp: null
       labels:
         app: usercluster-controller
-        ca-secret-revision: "123456"
         cluster: de-test-01
         internal-admin-kubeconfig-secret-revision: "123456"
         openvpn-ca-secret-revision: "123456"
@@ -40,7 +39,7 @@ spec:
         - -timeout
         - "1"
         - -command
-        - '{"command":"/usr/local/bin/user-cluster-controller-manager","args":["-kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","-metrics-listen-address","0.0.0.0:8085","-health-listen-address","0.0.0.0:8086","-namespace","$(NAMESPACE)","-ca-cert","/etc/kubernetes/pki/ca/ca.crt","-ca-key","/etc/kubernetes/pki/ca/ca.key","-cluster-url","","-openvpn-server-port","30003","-overwrite-registry","","-openshift=false","-version","1.10.0","-cloud-provider-name","","-openvpn-ca-cert-file=/etc/kubernetes/pki/openvpn/ca.crt","-openvpn-ca-key-file=/etc/kubernetes/pki/openvpn/ca.key","-user-ssh-keys-dir-path=/etc/kubernetes/usersshkeys","--ipam-controller-network","192.168.1.1/24,192.168.1.1,8.8.8.8","-node-labels","{\"my-label\":\"my-value\"}"]}'
+        - '{"command":"/usr/local/bin/user-cluster-controller-manager","args":["-kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","-metrics-listen-address","0.0.0.0:8085","-health-listen-address","0.0.0.0:8086","-namespace","$(NAMESPACE)","-cluster-url","","-openvpn-server-port","30003","-overwrite-registry","","-openshift=false","-version","1.10.0","-cloud-provider-name","","-openvpn-ca-cert-file=/etc/kubernetes/pki/openvpn/ca.crt","-openvpn-ca-key-file=/etc/kubernetes/pki/openvpn/ca.key","-user-ssh-keys-dir-path=/etc/kubernetes/usersshkeys","--ipam-controller-network","192.168.1.1/24,192.168.1.1,8.8.8.8","-node-labels","{\"my-label\":\"my-value\"}"]}'
         command:
         - /http-prober-bin/http-prober
         env:
@@ -71,9 +70,6 @@ spec:
         - mountPath: /etc/kubernetes/kubeconfig
           name: internal-admin-kubeconfig
           readOnly: true
-        - mountPath: /etc/kubernetes/pki/ca
-          name: ca
-          readOnly: true
         - mountPath: /etc/kubernetes/pki/openvpn
           name: openvpn-ca
           readOnly: true
@@ -95,13 +91,11 @@ spec:
         volumeMounts:
         - mountPath: /http-prober-bin
           name: http-prober-bin
+      serviceAccountName: kubermatic-usercluster-controller-manager
       volumes:
       - name: internal-admin-kubeconfig
         secret:
           secretName: internal-admin-kubeconfig
-      - name: ca
-        secret:
-          secretName: ca
       - name: openvpn-ca
         secret:
           secretName: openvpn-ca

--- a/api/pkg/resources/test/fixtures/deployment-digitalocean-1.10.6-usercluster-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-digitalocean-1.10.6-usercluster-controller.yaml
@@ -22,7 +22,6 @@ spec:
       creationTimestamp: null
       labels:
         app: usercluster-controller
-        ca-secret-revision: "123456"
         cluster: de-test-01
         internal-admin-kubeconfig-secret-revision: "123456"
         openvpn-ca-secret-revision: "123456"
@@ -40,7 +39,7 @@ spec:
         - -timeout
         - "1"
         - -command
-        - '{"command":"/usr/local/bin/user-cluster-controller-manager","args":["-kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","-metrics-listen-address","0.0.0.0:8085","-health-listen-address","0.0.0.0:8086","-namespace","$(NAMESPACE)","-ca-cert","/etc/kubernetes/pki/ca/ca.crt","-ca-key","/etc/kubernetes/pki/ca/ca.key","-cluster-url","","-openvpn-server-port","30003","-overwrite-registry","","-openshift=false","-version","1.10.6","-cloud-provider-name","","-openvpn-ca-cert-file=/etc/kubernetes/pki/openvpn/ca.crt","-openvpn-ca-key-file=/etc/kubernetes/pki/openvpn/ca.key","-user-ssh-keys-dir-path=/etc/kubernetes/usersshkeys","--ipam-controller-network","192.168.1.1/24,192.168.1.1,8.8.8.8","-node-labels","{\"my-label\":\"my-value\"}"]}'
+        - '{"command":"/usr/local/bin/user-cluster-controller-manager","args":["-kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","-metrics-listen-address","0.0.0.0:8085","-health-listen-address","0.0.0.0:8086","-namespace","$(NAMESPACE)","-cluster-url","","-openvpn-server-port","30003","-overwrite-registry","","-openshift=false","-version","1.10.6","-cloud-provider-name","","-openvpn-ca-cert-file=/etc/kubernetes/pki/openvpn/ca.crt","-openvpn-ca-key-file=/etc/kubernetes/pki/openvpn/ca.key","-user-ssh-keys-dir-path=/etc/kubernetes/usersshkeys","--ipam-controller-network","192.168.1.1/24,192.168.1.1,8.8.8.8","-node-labels","{\"my-label\":\"my-value\"}"]}'
         command:
         - /http-prober-bin/http-prober
         env:
@@ -71,9 +70,6 @@ spec:
         - mountPath: /etc/kubernetes/kubeconfig
           name: internal-admin-kubeconfig
           readOnly: true
-        - mountPath: /etc/kubernetes/pki/ca
-          name: ca
-          readOnly: true
         - mountPath: /etc/kubernetes/pki/openvpn
           name: openvpn-ca
           readOnly: true
@@ -95,13 +91,11 @@ spec:
         volumeMounts:
         - mountPath: /http-prober-bin
           name: http-prober-bin
+      serviceAccountName: kubermatic-usercluster-controller-manager
       volumes:
       - name: internal-admin-kubeconfig
         secret:
           secretName: internal-admin-kubeconfig
-      - name: ca
-        secret:
-          secretName: ca
       - name: openvpn-ca
         secret:
           secretName: openvpn-ca

--- a/api/pkg/resources/test/fixtures/deployment-digitalocean-1.10.6-usercluster-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-digitalocean-1.10.6-usercluster-controller.yaml
@@ -24,7 +24,6 @@ spec:
         app: usercluster-controller
         cluster: de-test-01
         internal-admin-kubeconfig-secret-revision: "123456"
-        usersshkeys-secret-revision: "123456"
     spec:
       containers:
       - args:
@@ -38,7 +37,7 @@ spec:
         - -timeout
         - "1"
         - -command
-        - '{"command":"/usr/local/bin/user-cluster-controller-manager","args":["-kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","-metrics-listen-address","0.0.0.0:8085","-health-listen-address","0.0.0.0:8086","-namespace","$(NAMESPACE)","-cluster-url","","-openvpn-server-port","30003","-overwrite-registry","","-openshift=false","-version","1.10.6","-cloud-provider-name","","-user-ssh-keys-dir-path=/etc/kubernetes/usersshkeys","--ipam-controller-network","192.168.1.1/24,192.168.1.1,8.8.8.8","-node-labels","{\"my-label\":\"my-value\"}"]}'
+        - '{"command":"/usr/local/bin/user-cluster-controller-manager","args":["-kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","-metrics-listen-address","0.0.0.0:8085","-health-listen-address","0.0.0.0:8086","-namespace","$(NAMESPACE)","-cluster-url","","-openvpn-server-port","30003","-overwrite-registry","","-openshift=false","-version","1.10.6","-cloud-provider-name","","--ipam-controller-network","192.168.1.1/24,192.168.1.1,8.8.8.8","-node-labels","{\"my-label\":\"my-value\"}"]}'
         command:
         - /http-prober-bin/http-prober
         env:
@@ -69,9 +68,6 @@ spec:
         - mountPath: /etc/kubernetes/kubeconfig
           name: internal-admin-kubeconfig
           readOnly: true
-        - mountPath: /etc/kubernetes/usersshkeys
-          name: usersshkeys
-          readOnly: true
         - mountPath: /http-prober-bin
           name: http-prober-bin
       imagePullSecrets:
@@ -92,9 +88,6 @@ spec:
       - name: internal-admin-kubeconfig
         secret:
           secretName: internal-admin-kubeconfig
-      - name: usersshkeys
-        secret:
-          secretName: usersshkeys
       - emptyDir: {}
         name: http-prober-bin
 status: {}

--- a/api/pkg/resources/test/fixtures/deployment-digitalocean-1.10.6-usercluster-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-digitalocean-1.10.6-usercluster-controller.yaml
@@ -24,7 +24,6 @@ spec:
         app: usercluster-controller
         cluster: de-test-01
         internal-admin-kubeconfig-secret-revision: "123456"
-        openvpn-ca-secret-revision: "123456"
         usersshkeys-secret-revision: "123456"
     spec:
       containers:
@@ -39,7 +38,7 @@ spec:
         - -timeout
         - "1"
         - -command
-        - '{"command":"/usr/local/bin/user-cluster-controller-manager","args":["-kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","-metrics-listen-address","0.0.0.0:8085","-health-listen-address","0.0.0.0:8086","-namespace","$(NAMESPACE)","-cluster-url","","-openvpn-server-port","30003","-overwrite-registry","","-openshift=false","-version","1.10.6","-cloud-provider-name","","-openvpn-ca-cert-file=/etc/kubernetes/pki/openvpn/ca.crt","-openvpn-ca-key-file=/etc/kubernetes/pki/openvpn/ca.key","-user-ssh-keys-dir-path=/etc/kubernetes/usersshkeys","--ipam-controller-network","192.168.1.1/24,192.168.1.1,8.8.8.8","-node-labels","{\"my-label\":\"my-value\"}"]}'
+        - '{"command":"/usr/local/bin/user-cluster-controller-manager","args":["-kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","-metrics-listen-address","0.0.0.0:8085","-health-listen-address","0.0.0.0:8086","-namespace","$(NAMESPACE)","-cluster-url","","-openvpn-server-port","30003","-overwrite-registry","","-openshift=false","-version","1.10.6","-cloud-provider-name","","-user-ssh-keys-dir-path=/etc/kubernetes/usersshkeys","--ipam-controller-network","192.168.1.1/24,192.168.1.1,8.8.8.8","-node-labels","{\"my-label\":\"my-value\"}"]}'
         command:
         - /http-prober-bin/http-prober
         env:
@@ -70,9 +69,6 @@ spec:
         - mountPath: /etc/kubernetes/kubeconfig
           name: internal-admin-kubeconfig
           readOnly: true
-        - mountPath: /etc/kubernetes/pki/openvpn
-          name: openvpn-ca
-          readOnly: true
         - mountPath: /etc/kubernetes/usersshkeys
           name: usersshkeys
           readOnly: true
@@ -96,9 +92,6 @@ spec:
       - name: internal-admin-kubeconfig
         secret:
           secretName: internal-admin-kubeconfig
-      - name: openvpn-ca
-        secret:
-          secretName: openvpn-ca
       - name: usersshkeys
         secret:
           secretName: usersshkeys

--- a/api/pkg/resources/test/fixtures/deployment-digitalocean-1.11.0-usercluster-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-digitalocean-1.11.0-usercluster-controller.yaml
@@ -22,7 +22,6 @@ spec:
       creationTimestamp: null
       labels:
         app: usercluster-controller
-        ca-secret-revision: "123456"
         cluster: de-test-01
         internal-admin-kubeconfig-secret-revision: "123456"
         openvpn-ca-secret-revision: "123456"
@@ -40,7 +39,7 @@ spec:
         - -timeout
         - "1"
         - -command
-        - '{"command":"/usr/local/bin/user-cluster-controller-manager","args":["-kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","-metrics-listen-address","0.0.0.0:8085","-health-listen-address","0.0.0.0:8086","-namespace","$(NAMESPACE)","-ca-cert","/etc/kubernetes/pki/ca/ca.crt","-ca-key","/etc/kubernetes/pki/ca/ca.key","-cluster-url","","-openvpn-server-port","30003","-overwrite-registry","","-openshift=false","-version","1.11.0","-cloud-provider-name","","-openvpn-ca-cert-file=/etc/kubernetes/pki/openvpn/ca.crt","-openvpn-ca-key-file=/etc/kubernetes/pki/openvpn/ca.key","-user-ssh-keys-dir-path=/etc/kubernetes/usersshkeys","--ipam-controller-network","192.168.1.1/24,192.168.1.1,8.8.8.8","-node-labels","{\"my-label\":\"my-value\"}"]}'
+        - '{"command":"/usr/local/bin/user-cluster-controller-manager","args":["-kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","-metrics-listen-address","0.0.0.0:8085","-health-listen-address","0.0.0.0:8086","-namespace","$(NAMESPACE)","-cluster-url","","-openvpn-server-port","30003","-overwrite-registry","","-openshift=false","-version","1.11.0","-cloud-provider-name","","-openvpn-ca-cert-file=/etc/kubernetes/pki/openvpn/ca.crt","-openvpn-ca-key-file=/etc/kubernetes/pki/openvpn/ca.key","-user-ssh-keys-dir-path=/etc/kubernetes/usersshkeys","--ipam-controller-network","192.168.1.1/24,192.168.1.1,8.8.8.8","-node-labels","{\"my-label\":\"my-value\"}"]}'
         command:
         - /http-prober-bin/http-prober
         env:
@@ -71,9 +70,6 @@ spec:
         - mountPath: /etc/kubernetes/kubeconfig
           name: internal-admin-kubeconfig
           readOnly: true
-        - mountPath: /etc/kubernetes/pki/ca
-          name: ca
-          readOnly: true
         - mountPath: /etc/kubernetes/pki/openvpn
           name: openvpn-ca
           readOnly: true
@@ -95,13 +91,11 @@ spec:
         volumeMounts:
         - mountPath: /http-prober-bin
           name: http-prober-bin
+      serviceAccountName: kubermatic-usercluster-controller-manager
       volumes:
       - name: internal-admin-kubeconfig
         secret:
           secretName: internal-admin-kubeconfig
-      - name: ca
-        secret:
-          secretName: ca
       - name: openvpn-ca
         secret:
           secretName: openvpn-ca

--- a/api/pkg/resources/test/fixtures/deployment-digitalocean-1.11.0-usercluster-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-digitalocean-1.11.0-usercluster-controller.yaml
@@ -24,7 +24,6 @@ spec:
         app: usercluster-controller
         cluster: de-test-01
         internal-admin-kubeconfig-secret-revision: "123456"
-        openvpn-ca-secret-revision: "123456"
         usersshkeys-secret-revision: "123456"
     spec:
       containers:
@@ -39,7 +38,7 @@ spec:
         - -timeout
         - "1"
         - -command
-        - '{"command":"/usr/local/bin/user-cluster-controller-manager","args":["-kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","-metrics-listen-address","0.0.0.0:8085","-health-listen-address","0.0.0.0:8086","-namespace","$(NAMESPACE)","-cluster-url","","-openvpn-server-port","30003","-overwrite-registry","","-openshift=false","-version","1.11.0","-cloud-provider-name","","-openvpn-ca-cert-file=/etc/kubernetes/pki/openvpn/ca.crt","-openvpn-ca-key-file=/etc/kubernetes/pki/openvpn/ca.key","-user-ssh-keys-dir-path=/etc/kubernetes/usersshkeys","--ipam-controller-network","192.168.1.1/24,192.168.1.1,8.8.8.8","-node-labels","{\"my-label\":\"my-value\"}"]}'
+        - '{"command":"/usr/local/bin/user-cluster-controller-manager","args":["-kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","-metrics-listen-address","0.0.0.0:8085","-health-listen-address","0.0.0.0:8086","-namespace","$(NAMESPACE)","-cluster-url","","-openvpn-server-port","30003","-overwrite-registry","","-openshift=false","-version","1.11.0","-cloud-provider-name","","-user-ssh-keys-dir-path=/etc/kubernetes/usersshkeys","--ipam-controller-network","192.168.1.1/24,192.168.1.1,8.8.8.8","-node-labels","{\"my-label\":\"my-value\"}"]}'
         command:
         - /http-prober-bin/http-prober
         env:
@@ -70,9 +69,6 @@ spec:
         - mountPath: /etc/kubernetes/kubeconfig
           name: internal-admin-kubeconfig
           readOnly: true
-        - mountPath: /etc/kubernetes/pki/openvpn
-          name: openvpn-ca
-          readOnly: true
         - mountPath: /etc/kubernetes/usersshkeys
           name: usersshkeys
           readOnly: true
@@ -96,9 +92,6 @@ spec:
       - name: internal-admin-kubeconfig
         secret:
           secretName: internal-admin-kubeconfig
-      - name: openvpn-ca
-        secret:
-          secretName: openvpn-ca
       - name: usersshkeys
         secret:
           secretName: usersshkeys

--- a/api/pkg/resources/test/fixtures/deployment-digitalocean-1.11.0-usercluster-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-digitalocean-1.11.0-usercluster-controller.yaml
@@ -24,7 +24,6 @@ spec:
         app: usercluster-controller
         cluster: de-test-01
         internal-admin-kubeconfig-secret-revision: "123456"
-        usersshkeys-secret-revision: "123456"
     spec:
       containers:
       - args:
@@ -38,7 +37,7 @@ spec:
         - -timeout
         - "1"
         - -command
-        - '{"command":"/usr/local/bin/user-cluster-controller-manager","args":["-kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","-metrics-listen-address","0.0.0.0:8085","-health-listen-address","0.0.0.0:8086","-namespace","$(NAMESPACE)","-cluster-url","","-openvpn-server-port","30003","-overwrite-registry","","-openshift=false","-version","1.11.0","-cloud-provider-name","","-user-ssh-keys-dir-path=/etc/kubernetes/usersshkeys","--ipam-controller-network","192.168.1.1/24,192.168.1.1,8.8.8.8","-node-labels","{\"my-label\":\"my-value\"}"]}'
+        - '{"command":"/usr/local/bin/user-cluster-controller-manager","args":["-kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","-metrics-listen-address","0.0.0.0:8085","-health-listen-address","0.0.0.0:8086","-namespace","$(NAMESPACE)","-cluster-url","","-openvpn-server-port","30003","-overwrite-registry","","-openshift=false","-version","1.11.0","-cloud-provider-name","","--ipam-controller-network","192.168.1.1/24,192.168.1.1,8.8.8.8","-node-labels","{\"my-label\":\"my-value\"}"]}'
         command:
         - /http-prober-bin/http-prober
         env:
@@ -69,9 +68,6 @@ spec:
         - mountPath: /etc/kubernetes/kubeconfig
           name: internal-admin-kubeconfig
           readOnly: true
-        - mountPath: /etc/kubernetes/usersshkeys
-          name: usersshkeys
-          readOnly: true
         - mountPath: /http-prober-bin
           name: http-prober-bin
       imagePullSecrets:
@@ -92,9 +88,6 @@ spec:
       - name: internal-admin-kubeconfig
         secret:
           secretName: internal-admin-kubeconfig
-      - name: usersshkeys
-        secret:
-          secretName: usersshkeys
       - emptyDir: {}
         name: http-prober-bin
 status: {}

--- a/api/pkg/resources/test/fixtures/deployment-digitalocean-1.11.1-usercluster-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-digitalocean-1.11.1-usercluster-controller.yaml
@@ -24,7 +24,6 @@ spec:
         app: usercluster-controller
         cluster: de-test-01
         internal-admin-kubeconfig-secret-revision: "123456"
-        openvpn-ca-secret-revision: "123456"
         usersshkeys-secret-revision: "123456"
     spec:
       containers:
@@ -39,7 +38,7 @@ spec:
         - -timeout
         - "1"
         - -command
-        - '{"command":"/usr/local/bin/user-cluster-controller-manager","args":["-kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","-metrics-listen-address","0.0.0.0:8085","-health-listen-address","0.0.0.0:8086","-namespace","$(NAMESPACE)","-cluster-url","","-openvpn-server-port","30003","-overwrite-registry","","-openshift=false","-version","1.11.1","-cloud-provider-name","","-openvpn-ca-cert-file=/etc/kubernetes/pki/openvpn/ca.crt","-openvpn-ca-key-file=/etc/kubernetes/pki/openvpn/ca.key","-user-ssh-keys-dir-path=/etc/kubernetes/usersshkeys","--ipam-controller-network","192.168.1.1/24,192.168.1.1,8.8.8.8","-node-labels","{\"my-label\":\"my-value\"}"]}'
+        - '{"command":"/usr/local/bin/user-cluster-controller-manager","args":["-kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","-metrics-listen-address","0.0.0.0:8085","-health-listen-address","0.0.0.0:8086","-namespace","$(NAMESPACE)","-cluster-url","","-openvpn-server-port","30003","-overwrite-registry","","-openshift=false","-version","1.11.1","-cloud-provider-name","","-user-ssh-keys-dir-path=/etc/kubernetes/usersshkeys","--ipam-controller-network","192.168.1.1/24,192.168.1.1,8.8.8.8","-node-labels","{\"my-label\":\"my-value\"}"]}'
         command:
         - /http-prober-bin/http-prober
         env:
@@ -70,9 +69,6 @@ spec:
         - mountPath: /etc/kubernetes/kubeconfig
           name: internal-admin-kubeconfig
           readOnly: true
-        - mountPath: /etc/kubernetes/pki/openvpn
-          name: openvpn-ca
-          readOnly: true
         - mountPath: /etc/kubernetes/usersshkeys
           name: usersshkeys
           readOnly: true
@@ -96,9 +92,6 @@ spec:
       - name: internal-admin-kubeconfig
         secret:
           secretName: internal-admin-kubeconfig
-      - name: openvpn-ca
-        secret:
-          secretName: openvpn-ca
       - name: usersshkeys
         secret:
           secretName: usersshkeys

--- a/api/pkg/resources/test/fixtures/deployment-digitalocean-1.11.1-usercluster-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-digitalocean-1.11.1-usercluster-controller.yaml
@@ -24,7 +24,6 @@ spec:
         app: usercluster-controller
         cluster: de-test-01
         internal-admin-kubeconfig-secret-revision: "123456"
-        usersshkeys-secret-revision: "123456"
     spec:
       containers:
       - args:
@@ -38,7 +37,7 @@ spec:
         - -timeout
         - "1"
         - -command
-        - '{"command":"/usr/local/bin/user-cluster-controller-manager","args":["-kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","-metrics-listen-address","0.0.0.0:8085","-health-listen-address","0.0.0.0:8086","-namespace","$(NAMESPACE)","-cluster-url","","-openvpn-server-port","30003","-overwrite-registry","","-openshift=false","-version","1.11.1","-cloud-provider-name","","-user-ssh-keys-dir-path=/etc/kubernetes/usersshkeys","--ipam-controller-network","192.168.1.1/24,192.168.1.1,8.8.8.8","-node-labels","{\"my-label\":\"my-value\"}"]}'
+        - '{"command":"/usr/local/bin/user-cluster-controller-manager","args":["-kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","-metrics-listen-address","0.0.0.0:8085","-health-listen-address","0.0.0.0:8086","-namespace","$(NAMESPACE)","-cluster-url","","-openvpn-server-port","30003","-overwrite-registry","","-openshift=false","-version","1.11.1","-cloud-provider-name","","--ipam-controller-network","192.168.1.1/24,192.168.1.1,8.8.8.8","-node-labels","{\"my-label\":\"my-value\"}"]}'
         command:
         - /http-prober-bin/http-prober
         env:
@@ -69,9 +68,6 @@ spec:
         - mountPath: /etc/kubernetes/kubeconfig
           name: internal-admin-kubeconfig
           readOnly: true
-        - mountPath: /etc/kubernetes/usersshkeys
-          name: usersshkeys
-          readOnly: true
         - mountPath: /http-prober-bin
           name: http-prober-bin
       imagePullSecrets:
@@ -92,9 +88,6 @@ spec:
       - name: internal-admin-kubeconfig
         secret:
           secretName: internal-admin-kubeconfig
-      - name: usersshkeys
-        secret:
-          secretName: usersshkeys
       - emptyDir: {}
         name: http-prober-bin
 status: {}

--- a/api/pkg/resources/test/fixtures/deployment-digitalocean-1.11.1-usercluster-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-digitalocean-1.11.1-usercluster-controller.yaml
@@ -22,7 +22,6 @@ spec:
       creationTimestamp: null
       labels:
         app: usercluster-controller
-        ca-secret-revision: "123456"
         cluster: de-test-01
         internal-admin-kubeconfig-secret-revision: "123456"
         openvpn-ca-secret-revision: "123456"
@@ -40,7 +39,7 @@ spec:
         - -timeout
         - "1"
         - -command
-        - '{"command":"/usr/local/bin/user-cluster-controller-manager","args":["-kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","-metrics-listen-address","0.0.0.0:8085","-health-listen-address","0.0.0.0:8086","-namespace","$(NAMESPACE)","-ca-cert","/etc/kubernetes/pki/ca/ca.crt","-ca-key","/etc/kubernetes/pki/ca/ca.key","-cluster-url","","-openvpn-server-port","30003","-overwrite-registry","","-openshift=false","-version","1.11.1","-cloud-provider-name","","-openvpn-ca-cert-file=/etc/kubernetes/pki/openvpn/ca.crt","-openvpn-ca-key-file=/etc/kubernetes/pki/openvpn/ca.key","-user-ssh-keys-dir-path=/etc/kubernetes/usersshkeys","--ipam-controller-network","192.168.1.1/24,192.168.1.1,8.8.8.8","-node-labels","{\"my-label\":\"my-value\"}"]}'
+        - '{"command":"/usr/local/bin/user-cluster-controller-manager","args":["-kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","-metrics-listen-address","0.0.0.0:8085","-health-listen-address","0.0.0.0:8086","-namespace","$(NAMESPACE)","-cluster-url","","-openvpn-server-port","30003","-overwrite-registry","","-openshift=false","-version","1.11.1","-cloud-provider-name","","-openvpn-ca-cert-file=/etc/kubernetes/pki/openvpn/ca.crt","-openvpn-ca-key-file=/etc/kubernetes/pki/openvpn/ca.key","-user-ssh-keys-dir-path=/etc/kubernetes/usersshkeys","--ipam-controller-network","192.168.1.1/24,192.168.1.1,8.8.8.8","-node-labels","{\"my-label\":\"my-value\"}"]}'
         command:
         - /http-prober-bin/http-prober
         env:
@@ -71,9 +70,6 @@ spec:
         - mountPath: /etc/kubernetes/kubeconfig
           name: internal-admin-kubeconfig
           readOnly: true
-        - mountPath: /etc/kubernetes/pki/ca
-          name: ca
-          readOnly: true
         - mountPath: /etc/kubernetes/pki/openvpn
           name: openvpn-ca
           readOnly: true
@@ -95,13 +91,11 @@ spec:
         volumeMounts:
         - mountPath: /http-prober-bin
           name: http-prober-bin
+      serviceAccountName: kubermatic-usercluster-controller-manager
       volumes:
       - name: internal-admin-kubeconfig
         secret:
           secretName: internal-admin-kubeconfig
-      - name: ca
-        secret:
-          secretName: ca
       - name: openvpn-ca
         secret:
           secretName: openvpn-ca

--- a/api/pkg/resources/test/fixtures/deployment-digitalocean-1.12.0-usercluster-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-digitalocean-1.12.0-usercluster-controller.yaml
@@ -24,7 +24,6 @@ spec:
         app: usercluster-controller
         cluster: de-test-01
         internal-admin-kubeconfig-secret-revision: "123456"
-        usersshkeys-secret-revision: "123456"
     spec:
       containers:
       - args:
@@ -38,7 +37,7 @@ spec:
         - -timeout
         - "1"
         - -command
-        - '{"command":"/usr/local/bin/user-cluster-controller-manager","args":["-kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","-metrics-listen-address","0.0.0.0:8085","-health-listen-address","0.0.0.0:8086","-namespace","$(NAMESPACE)","-cluster-url","","-openvpn-server-port","30003","-overwrite-registry","","-openshift=false","-version","1.12.0","-cloud-provider-name","","-user-ssh-keys-dir-path=/etc/kubernetes/usersshkeys","--ipam-controller-network","192.168.1.1/24,192.168.1.1,8.8.8.8","-node-labels","{\"my-label\":\"my-value\"}"]}'
+        - '{"command":"/usr/local/bin/user-cluster-controller-manager","args":["-kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","-metrics-listen-address","0.0.0.0:8085","-health-listen-address","0.0.0.0:8086","-namespace","$(NAMESPACE)","-cluster-url","","-openvpn-server-port","30003","-overwrite-registry","","-openshift=false","-version","1.12.0","-cloud-provider-name","","--ipam-controller-network","192.168.1.1/24,192.168.1.1,8.8.8.8","-node-labels","{\"my-label\":\"my-value\"}"]}'
         command:
         - /http-prober-bin/http-prober
         env:
@@ -69,9 +68,6 @@ spec:
         - mountPath: /etc/kubernetes/kubeconfig
           name: internal-admin-kubeconfig
           readOnly: true
-        - mountPath: /etc/kubernetes/usersshkeys
-          name: usersshkeys
-          readOnly: true
         - mountPath: /http-prober-bin
           name: http-prober-bin
       imagePullSecrets:
@@ -92,9 +88,6 @@ spec:
       - name: internal-admin-kubeconfig
         secret:
           secretName: internal-admin-kubeconfig
-      - name: usersshkeys
-        secret:
-          secretName: usersshkeys
       - emptyDir: {}
         name: http-prober-bin
 status: {}

--- a/api/pkg/resources/test/fixtures/deployment-digitalocean-1.12.0-usercluster-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-digitalocean-1.12.0-usercluster-controller.yaml
@@ -24,7 +24,6 @@ spec:
         app: usercluster-controller
         cluster: de-test-01
         internal-admin-kubeconfig-secret-revision: "123456"
-        openvpn-ca-secret-revision: "123456"
         usersshkeys-secret-revision: "123456"
     spec:
       containers:
@@ -39,7 +38,7 @@ spec:
         - -timeout
         - "1"
         - -command
-        - '{"command":"/usr/local/bin/user-cluster-controller-manager","args":["-kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","-metrics-listen-address","0.0.0.0:8085","-health-listen-address","0.0.0.0:8086","-namespace","$(NAMESPACE)","-cluster-url","","-openvpn-server-port","30003","-overwrite-registry","","-openshift=false","-version","1.12.0","-cloud-provider-name","","-openvpn-ca-cert-file=/etc/kubernetes/pki/openvpn/ca.crt","-openvpn-ca-key-file=/etc/kubernetes/pki/openvpn/ca.key","-user-ssh-keys-dir-path=/etc/kubernetes/usersshkeys","--ipam-controller-network","192.168.1.1/24,192.168.1.1,8.8.8.8","-node-labels","{\"my-label\":\"my-value\"}"]}'
+        - '{"command":"/usr/local/bin/user-cluster-controller-manager","args":["-kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","-metrics-listen-address","0.0.0.0:8085","-health-listen-address","0.0.0.0:8086","-namespace","$(NAMESPACE)","-cluster-url","","-openvpn-server-port","30003","-overwrite-registry","","-openshift=false","-version","1.12.0","-cloud-provider-name","","-user-ssh-keys-dir-path=/etc/kubernetes/usersshkeys","--ipam-controller-network","192.168.1.1/24,192.168.1.1,8.8.8.8","-node-labels","{\"my-label\":\"my-value\"}"]}'
         command:
         - /http-prober-bin/http-prober
         env:
@@ -70,9 +69,6 @@ spec:
         - mountPath: /etc/kubernetes/kubeconfig
           name: internal-admin-kubeconfig
           readOnly: true
-        - mountPath: /etc/kubernetes/pki/openvpn
-          name: openvpn-ca
-          readOnly: true
         - mountPath: /etc/kubernetes/usersshkeys
           name: usersshkeys
           readOnly: true
@@ -96,9 +92,6 @@ spec:
       - name: internal-admin-kubeconfig
         secret:
           secretName: internal-admin-kubeconfig
-      - name: openvpn-ca
-        secret:
-          secretName: openvpn-ca
       - name: usersshkeys
         secret:
           secretName: usersshkeys

--- a/api/pkg/resources/test/fixtures/deployment-digitalocean-1.12.0-usercluster-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-digitalocean-1.12.0-usercluster-controller.yaml
@@ -22,7 +22,6 @@ spec:
       creationTimestamp: null
       labels:
         app: usercluster-controller
-        ca-secret-revision: "123456"
         cluster: de-test-01
         internal-admin-kubeconfig-secret-revision: "123456"
         openvpn-ca-secret-revision: "123456"
@@ -40,7 +39,7 @@ spec:
         - -timeout
         - "1"
         - -command
-        - '{"command":"/usr/local/bin/user-cluster-controller-manager","args":["-kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","-metrics-listen-address","0.0.0.0:8085","-health-listen-address","0.0.0.0:8086","-namespace","$(NAMESPACE)","-ca-cert","/etc/kubernetes/pki/ca/ca.crt","-ca-key","/etc/kubernetes/pki/ca/ca.key","-cluster-url","","-openvpn-server-port","30003","-overwrite-registry","","-openshift=false","-version","1.12.0","-cloud-provider-name","","-openvpn-ca-cert-file=/etc/kubernetes/pki/openvpn/ca.crt","-openvpn-ca-key-file=/etc/kubernetes/pki/openvpn/ca.key","-user-ssh-keys-dir-path=/etc/kubernetes/usersshkeys","--ipam-controller-network","192.168.1.1/24,192.168.1.1,8.8.8.8","-node-labels","{\"my-label\":\"my-value\"}"]}'
+        - '{"command":"/usr/local/bin/user-cluster-controller-manager","args":["-kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","-metrics-listen-address","0.0.0.0:8085","-health-listen-address","0.0.0.0:8086","-namespace","$(NAMESPACE)","-cluster-url","","-openvpn-server-port","30003","-overwrite-registry","","-openshift=false","-version","1.12.0","-cloud-provider-name","","-openvpn-ca-cert-file=/etc/kubernetes/pki/openvpn/ca.crt","-openvpn-ca-key-file=/etc/kubernetes/pki/openvpn/ca.key","-user-ssh-keys-dir-path=/etc/kubernetes/usersshkeys","--ipam-controller-network","192.168.1.1/24,192.168.1.1,8.8.8.8","-node-labels","{\"my-label\":\"my-value\"}"]}'
         command:
         - /http-prober-bin/http-prober
         env:
@@ -71,9 +70,6 @@ spec:
         - mountPath: /etc/kubernetes/kubeconfig
           name: internal-admin-kubeconfig
           readOnly: true
-        - mountPath: /etc/kubernetes/pki/ca
-          name: ca
-          readOnly: true
         - mountPath: /etc/kubernetes/pki/openvpn
           name: openvpn-ca
           readOnly: true
@@ -95,13 +91,11 @@ spec:
         volumeMounts:
         - mountPath: /http-prober-bin
           name: http-prober-bin
+      serviceAccountName: kubermatic-usercluster-controller-manager
       volumes:
       - name: internal-admin-kubeconfig
         secret:
           secretName: internal-admin-kubeconfig
-      - name: ca
-        secret:
-          secretName: ca
       - name: openvpn-ca
         secret:
           secretName: openvpn-ca

--- a/api/pkg/resources/test/fixtures/deployment-digitalocean-1.13.0-usercluster-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-digitalocean-1.13.0-usercluster-controller.yaml
@@ -22,7 +22,6 @@ spec:
       creationTimestamp: null
       labels:
         app: usercluster-controller
-        ca-secret-revision: "123456"
         cluster: de-test-01
         internal-admin-kubeconfig-secret-revision: "123456"
         openvpn-ca-secret-revision: "123456"
@@ -40,7 +39,7 @@ spec:
         - -timeout
         - "1"
         - -command
-        - '{"command":"/usr/local/bin/user-cluster-controller-manager","args":["-kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","-metrics-listen-address","0.0.0.0:8085","-health-listen-address","0.0.0.0:8086","-namespace","$(NAMESPACE)","-ca-cert","/etc/kubernetes/pki/ca/ca.crt","-ca-key","/etc/kubernetes/pki/ca/ca.key","-cluster-url","","-openvpn-server-port","30003","-overwrite-registry","","-openshift=false","-version","1.13.0","-cloud-provider-name","","-openvpn-ca-cert-file=/etc/kubernetes/pki/openvpn/ca.crt","-openvpn-ca-key-file=/etc/kubernetes/pki/openvpn/ca.key","-user-ssh-keys-dir-path=/etc/kubernetes/usersshkeys","--ipam-controller-network","192.168.1.1/24,192.168.1.1,8.8.8.8","-node-labels","{\"my-label\":\"my-value\"}"]}'
+        - '{"command":"/usr/local/bin/user-cluster-controller-manager","args":["-kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","-metrics-listen-address","0.0.0.0:8085","-health-listen-address","0.0.0.0:8086","-namespace","$(NAMESPACE)","-cluster-url","","-openvpn-server-port","30003","-overwrite-registry","","-openshift=false","-version","1.13.0","-cloud-provider-name","","-openvpn-ca-cert-file=/etc/kubernetes/pki/openvpn/ca.crt","-openvpn-ca-key-file=/etc/kubernetes/pki/openvpn/ca.key","-user-ssh-keys-dir-path=/etc/kubernetes/usersshkeys","--ipam-controller-network","192.168.1.1/24,192.168.1.1,8.8.8.8","-node-labels","{\"my-label\":\"my-value\"}"]}'
         command:
         - /http-prober-bin/http-prober
         env:
@@ -71,9 +70,6 @@ spec:
         - mountPath: /etc/kubernetes/kubeconfig
           name: internal-admin-kubeconfig
           readOnly: true
-        - mountPath: /etc/kubernetes/pki/ca
-          name: ca
-          readOnly: true
         - mountPath: /etc/kubernetes/pki/openvpn
           name: openvpn-ca
           readOnly: true
@@ -95,13 +91,11 @@ spec:
         volumeMounts:
         - mountPath: /http-prober-bin
           name: http-prober-bin
+      serviceAccountName: kubermatic-usercluster-controller-manager
       volumes:
       - name: internal-admin-kubeconfig
         secret:
           secretName: internal-admin-kubeconfig
-      - name: ca
-        secret:
-          secretName: ca
       - name: openvpn-ca
         secret:
           secretName: openvpn-ca

--- a/api/pkg/resources/test/fixtures/deployment-digitalocean-1.13.0-usercluster-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-digitalocean-1.13.0-usercluster-controller.yaml
@@ -24,7 +24,6 @@ spec:
         app: usercluster-controller
         cluster: de-test-01
         internal-admin-kubeconfig-secret-revision: "123456"
-        usersshkeys-secret-revision: "123456"
     spec:
       containers:
       - args:
@@ -38,7 +37,7 @@ spec:
         - -timeout
         - "1"
         - -command
-        - '{"command":"/usr/local/bin/user-cluster-controller-manager","args":["-kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","-metrics-listen-address","0.0.0.0:8085","-health-listen-address","0.0.0.0:8086","-namespace","$(NAMESPACE)","-cluster-url","","-openvpn-server-port","30003","-overwrite-registry","","-openshift=false","-version","1.13.0","-cloud-provider-name","","-user-ssh-keys-dir-path=/etc/kubernetes/usersshkeys","--ipam-controller-network","192.168.1.1/24,192.168.1.1,8.8.8.8","-node-labels","{\"my-label\":\"my-value\"}"]}'
+        - '{"command":"/usr/local/bin/user-cluster-controller-manager","args":["-kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","-metrics-listen-address","0.0.0.0:8085","-health-listen-address","0.0.0.0:8086","-namespace","$(NAMESPACE)","-cluster-url","","-openvpn-server-port","30003","-overwrite-registry","","-openshift=false","-version","1.13.0","-cloud-provider-name","","--ipam-controller-network","192.168.1.1/24,192.168.1.1,8.8.8.8","-node-labels","{\"my-label\":\"my-value\"}"]}'
         command:
         - /http-prober-bin/http-prober
         env:
@@ -69,9 +68,6 @@ spec:
         - mountPath: /etc/kubernetes/kubeconfig
           name: internal-admin-kubeconfig
           readOnly: true
-        - mountPath: /etc/kubernetes/usersshkeys
-          name: usersshkeys
-          readOnly: true
         - mountPath: /http-prober-bin
           name: http-prober-bin
       imagePullSecrets:
@@ -92,9 +88,6 @@ spec:
       - name: internal-admin-kubeconfig
         secret:
           secretName: internal-admin-kubeconfig
-      - name: usersshkeys
-        secret:
-          secretName: usersshkeys
       - emptyDir: {}
         name: http-prober-bin
 status: {}

--- a/api/pkg/resources/test/fixtures/deployment-digitalocean-1.13.0-usercluster-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-digitalocean-1.13.0-usercluster-controller.yaml
@@ -24,7 +24,6 @@ spec:
         app: usercluster-controller
         cluster: de-test-01
         internal-admin-kubeconfig-secret-revision: "123456"
-        openvpn-ca-secret-revision: "123456"
         usersshkeys-secret-revision: "123456"
     spec:
       containers:
@@ -39,7 +38,7 @@ spec:
         - -timeout
         - "1"
         - -command
-        - '{"command":"/usr/local/bin/user-cluster-controller-manager","args":["-kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","-metrics-listen-address","0.0.0.0:8085","-health-listen-address","0.0.0.0:8086","-namespace","$(NAMESPACE)","-cluster-url","","-openvpn-server-port","30003","-overwrite-registry","","-openshift=false","-version","1.13.0","-cloud-provider-name","","-openvpn-ca-cert-file=/etc/kubernetes/pki/openvpn/ca.crt","-openvpn-ca-key-file=/etc/kubernetes/pki/openvpn/ca.key","-user-ssh-keys-dir-path=/etc/kubernetes/usersshkeys","--ipam-controller-network","192.168.1.1/24,192.168.1.1,8.8.8.8","-node-labels","{\"my-label\":\"my-value\"}"]}'
+        - '{"command":"/usr/local/bin/user-cluster-controller-manager","args":["-kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","-metrics-listen-address","0.0.0.0:8085","-health-listen-address","0.0.0.0:8086","-namespace","$(NAMESPACE)","-cluster-url","","-openvpn-server-port","30003","-overwrite-registry","","-openshift=false","-version","1.13.0","-cloud-provider-name","","-user-ssh-keys-dir-path=/etc/kubernetes/usersshkeys","--ipam-controller-network","192.168.1.1/24,192.168.1.1,8.8.8.8","-node-labels","{\"my-label\":\"my-value\"}"]}'
         command:
         - /http-prober-bin/http-prober
         env:
@@ -70,9 +69,6 @@ spec:
         - mountPath: /etc/kubernetes/kubeconfig
           name: internal-admin-kubeconfig
           readOnly: true
-        - mountPath: /etc/kubernetes/pki/openvpn
-          name: openvpn-ca
-          readOnly: true
         - mountPath: /etc/kubernetes/usersshkeys
           name: usersshkeys
           readOnly: true
@@ -96,9 +92,6 @@ spec:
       - name: internal-admin-kubeconfig
         secret:
           secretName: internal-admin-kubeconfig
-      - name: openvpn-ca
-        secret:
-          secretName: openvpn-ca
       - name: usersshkeys
         secret:
           secretName: usersshkeys

--- a/api/pkg/resources/test/fixtures/deployment-openstack-1.10.0-usercluster-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-openstack-1.10.0-usercluster-controller.yaml
@@ -22,7 +22,6 @@ spec:
       creationTimestamp: null
       labels:
         app: usercluster-controller
-        ca-secret-revision: "123456"
         cluster: de-test-01
         internal-admin-kubeconfig-secret-revision: "123456"
         openvpn-ca-secret-revision: "123456"
@@ -40,7 +39,7 @@ spec:
         - -timeout
         - "1"
         - -command
-        - '{"command":"/usr/local/bin/user-cluster-controller-manager","args":["-kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","-metrics-listen-address","0.0.0.0:8085","-health-listen-address","0.0.0.0:8086","-namespace","$(NAMESPACE)","-ca-cert","/etc/kubernetes/pki/ca/ca.crt","-ca-key","/etc/kubernetes/pki/ca/ca.key","-cluster-url","","-openvpn-server-port","30003","-overwrite-registry","","-openshift=false","-version","1.10.0","-cloud-provider-name","openstack","-openvpn-ca-cert-file=/etc/kubernetes/pki/openvpn/ca.crt","-openvpn-ca-key-file=/etc/kubernetes/pki/openvpn/ca.key","-user-ssh-keys-dir-path=/etc/kubernetes/usersshkeys","--ipam-controller-network","192.168.1.1/24,192.168.1.1,8.8.8.8","-node-labels","{\"my-label\":\"my-value\"}"]}'
+        - '{"command":"/usr/local/bin/user-cluster-controller-manager","args":["-kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","-metrics-listen-address","0.0.0.0:8085","-health-listen-address","0.0.0.0:8086","-namespace","$(NAMESPACE)","-cluster-url","","-openvpn-server-port","30003","-overwrite-registry","","-openshift=false","-version","1.10.0","-cloud-provider-name","openstack","-openvpn-ca-cert-file=/etc/kubernetes/pki/openvpn/ca.crt","-openvpn-ca-key-file=/etc/kubernetes/pki/openvpn/ca.key","-user-ssh-keys-dir-path=/etc/kubernetes/usersshkeys","--ipam-controller-network","192.168.1.1/24,192.168.1.1,8.8.8.8","-node-labels","{\"my-label\":\"my-value\"}"]}'
         command:
         - /http-prober-bin/http-prober
         env:
@@ -71,9 +70,6 @@ spec:
         - mountPath: /etc/kubernetes/kubeconfig
           name: internal-admin-kubeconfig
           readOnly: true
-        - mountPath: /etc/kubernetes/pki/ca
-          name: ca
-          readOnly: true
         - mountPath: /etc/kubernetes/pki/openvpn
           name: openvpn-ca
           readOnly: true
@@ -95,13 +91,11 @@ spec:
         volumeMounts:
         - mountPath: /http-prober-bin
           name: http-prober-bin
+      serviceAccountName: kubermatic-usercluster-controller-manager
       volumes:
       - name: internal-admin-kubeconfig
         secret:
           secretName: internal-admin-kubeconfig
-      - name: ca
-        secret:
-          secretName: ca
       - name: openvpn-ca
         secret:
           secretName: openvpn-ca

--- a/api/pkg/resources/test/fixtures/deployment-openstack-1.10.0-usercluster-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-openstack-1.10.0-usercluster-controller.yaml
@@ -24,7 +24,6 @@ spec:
         app: usercluster-controller
         cluster: de-test-01
         internal-admin-kubeconfig-secret-revision: "123456"
-        usersshkeys-secret-revision: "123456"
     spec:
       containers:
       - args:
@@ -38,7 +37,7 @@ spec:
         - -timeout
         - "1"
         - -command
-        - '{"command":"/usr/local/bin/user-cluster-controller-manager","args":["-kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","-metrics-listen-address","0.0.0.0:8085","-health-listen-address","0.0.0.0:8086","-namespace","$(NAMESPACE)","-cluster-url","","-openvpn-server-port","30003","-overwrite-registry","","-openshift=false","-version","1.10.0","-cloud-provider-name","openstack","-user-ssh-keys-dir-path=/etc/kubernetes/usersshkeys","--ipam-controller-network","192.168.1.1/24,192.168.1.1,8.8.8.8","-node-labels","{\"my-label\":\"my-value\"}"]}'
+        - '{"command":"/usr/local/bin/user-cluster-controller-manager","args":["-kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","-metrics-listen-address","0.0.0.0:8085","-health-listen-address","0.0.0.0:8086","-namespace","$(NAMESPACE)","-cluster-url","","-openvpn-server-port","30003","-overwrite-registry","","-openshift=false","-version","1.10.0","-cloud-provider-name","openstack","--ipam-controller-network","192.168.1.1/24,192.168.1.1,8.8.8.8","-node-labels","{\"my-label\":\"my-value\"}"]}'
         command:
         - /http-prober-bin/http-prober
         env:
@@ -69,9 +68,6 @@ spec:
         - mountPath: /etc/kubernetes/kubeconfig
           name: internal-admin-kubeconfig
           readOnly: true
-        - mountPath: /etc/kubernetes/usersshkeys
-          name: usersshkeys
-          readOnly: true
         - mountPath: /http-prober-bin
           name: http-prober-bin
       imagePullSecrets:
@@ -92,9 +88,6 @@ spec:
       - name: internal-admin-kubeconfig
         secret:
           secretName: internal-admin-kubeconfig
-      - name: usersshkeys
-        secret:
-          secretName: usersshkeys
       - emptyDir: {}
         name: http-prober-bin
 status: {}

--- a/api/pkg/resources/test/fixtures/deployment-openstack-1.10.0-usercluster-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-openstack-1.10.0-usercluster-controller.yaml
@@ -24,7 +24,6 @@ spec:
         app: usercluster-controller
         cluster: de-test-01
         internal-admin-kubeconfig-secret-revision: "123456"
-        openvpn-ca-secret-revision: "123456"
         usersshkeys-secret-revision: "123456"
     spec:
       containers:
@@ -39,7 +38,7 @@ spec:
         - -timeout
         - "1"
         - -command
-        - '{"command":"/usr/local/bin/user-cluster-controller-manager","args":["-kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","-metrics-listen-address","0.0.0.0:8085","-health-listen-address","0.0.0.0:8086","-namespace","$(NAMESPACE)","-cluster-url","","-openvpn-server-port","30003","-overwrite-registry","","-openshift=false","-version","1.10.0","-cloud-provider-name","openstack","-openvpn-ca-cert-file=/etc/kubernetes/pki/openvpn/ca.crt","-openvpn-ca-key-file=/etc/kubernetes/pki/openvpn/ca.key","-user-ssh-keys-dir-path=/etc/kubernetes/usersshkeys","--ipam-controller-network","192.168.1.1/24,192.168.1.1,8.8.8.8","-node-labels","{\"my-label\":\"my-value\"}"]}'
+        - '{"command":"/usr/local/bin/user-cluster-controller-manager","args":["-kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","-metrics-listen-address","0.0.0.0:8085","-health-listen-address","0.0.0.0:8086","-namespace","$(NAMESPACE)","-cluster-url","","-openvpn-server-port","30003","-overwrite-registry","","-openshift=false","-version","1.10.0","-cloud-provider-name","openstack","-user-ssh-keys-dir-path=/etc/kubernetes/usersshkeys","--ipam-controller-network","192.168.1.1/24,192.168.1.1,8.8.8.8","-node-labels","{\"my-label\":\"my-value\"}"]}'
         command:
         - /http-prober-bin/http-prober
         env:
@@ -70,9 +69,6 @@ spec:
         - mountPath: /etc/kubernetes/kubeconfig
           name: internal-admin-kubeconfig
           readOnly: true
-        - mountPath: /etc/kubernetes/pki/openvpn
-          name: openvpn-ca
-          readOnly: true
         - mountPath: /etc/kubernetes/usersshkeys
           name: usersshkeys
           readOnly: true
@@ -96,9 +92,6 @@ spec:
       - name: internal-admin-kubeconfig
         secret:
           secretName: internal-admin-kubeconfig
-      - name: openvpn-ca
-        secret:
-          secretName: openvpn-ca
       - name: usersshkeys
         secret:
           secretName: usersshkeys

--- a/api/pkg/resources/test/fixtures/deployment-openstack-1.10.6-usercluster-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-openstack-1.10.6-usercluster-controller.yaml
@@ -24,7 +24,6 @@ spec:
         app: usercluster-controller
         cluster: de-test-01
         internal-admin-kubeconfig-secret-revision: "123456"
-        openvpn-ca-secret-revision: "123456"
         usersshkeys-secret-revision: "123456"
     spec:
       containers:
@@ -39,7 +38,7 @@ spec:
         - -timeout
         - "1"
         - -command
-        - '{"command":"/usr/local/bin/user-cluster-controller-manager","args":["-kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","-metrics-listen-address","0.0.0.0:8085","-health-listen-address","0.0.0.0:8086","-namespace","$(NAMESPACE)","-cluster-url","","-openvpn-server-port","30003","-overwrite-registry","","-openshift=false","-version","1.10.6","-cloud-provider-name","openstack","-openvpn-ca-cert-file=/etc/kubernetes/pki/openvpn/ca.crt","-openvpn-ca-key-file=/etc/kubernetes/pki/openvpn/ca.key","-user-ssh-keys-dir-path=/etc/kubernetes/usersshkeys","--ipam-controller-network","192.168.1.1/24,192.168.1.1,8.8.8.8","-node-labels","{\"my-label\":\"my-value\"}"]}'
+        - '{"command":"/usr/local/bin/user-cluster-controller-manager","args":["-kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","-metrics-listen-address","0.0.0.0:8085","-health-listen-address","0.0.0.0:8086","-namespace","$(NAMESPACE)","-cluster-url","","-openvpn-server-port","30003","-overwrite-registry","","-openshift=false","-version","1.10.6","-cloud-provider-name","openstack","-user-ssh-keys-dir-path=/etc/kubernetes/usersshkeys","--ipam-controller-network","192.168.1.1/24,192.168.1.1,8.8.8.8","-node-labels","{\"my-label\":\"my-value\"}"]}'
         command:
         - /http-prober-bin/http-prober
         env:
@@ -70,9 +69,6 @@ spec:
         - mountPath: /etc/kubernetes/kubeconfig
           name: internal-admin-kubeconfig
           readOnly: true
-        - mountPath: /etc/kubernetes/pki/openvpn
-          name: openvpn-ca
-          readOnly: true
         - mountPath: /etc/kubernetes/usersshkeys
           name: usersshkeys
           readOnly: true
@@ -96,9 +92,6 @@ spec:
       - name: internal-admin-kubeconfig
         secret:
           secretName: internal-admin-kubeconfig
-      - name: openvpn-ca
-        secret:
-          secretName: openvpn-ca
       - name: usersshkeys
         secret:
           secretName: usersshkeys

--- a/api/pkg/resources/test/fixtures/deployment-openstack-1.10.6-usercluster-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-openstack-1.10.6-usercluster-controller.yaml
@@ -22,7 +22,6 @@ spec:
       creationTimestamp: null
       labels:
         app: usercluster-controller
-        ca-secret-revision: "123456"
         cluster: de-test-01
         internal-admin-kubeconfig-secret-revision: "123456"
         openvpn-ca-secret-revision: "123456"
@@ -40,7 +39,7 @@ spec:
         - -timeout
         - "1"
         - -command
-        - '{"command":"/usr/local/bin/user-cluster-controller-manager","args":["-kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","-metrics-listen-address","0.0.0.0:8085","-health-listen-address","0.0.0.0:8086","-namespace","$(NAMESPACE)","-ca-cert","/etc/kubernetes/pki/ca/ca.crt","-ca-key","/etc/kubernetes/pki/ca/ca.key","-cluster-url","","-openvpn-server-port","30003","-overwrite-registry","","-openshift=false","-version","1.10.6","-cloud-provider-name","openstack","-openvpn-ca-cert-file=/etc/kubernetes/pki/openvpn/ca.crt","-openvpn-ca-key-file=/etc/kubernetes/pki/openvpn/ca.key","-user-ssh-keys-dir-path=/etc/kubernetes/usersshkeys","--ipam-controller-network","192.168.1.1/24,192.168.1.1,8.8.8.8","-node-labels","{\"my-label\":\"my-value\"}"]}'
+        - '{"command":"/usr/local/bin/user-cluster-controller-manager","args":["-kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","-metrics-listen-address","0.0.0.0:8085","-health-listen-address","0.0.0.0:8086","-namespace","$(NAMESPACE)","-cluster-url","","-openvpn-server-port","30003","-overwrite-registry","","-openshift=false","-version","1.10.6","-cloud-provider-name","openstack","-openvpn-ca-cert-file=/etc/kubernetes/pki/openvpn/ca.crt","-openvpn-ca-key-file=/etc/kubernetes/pki/openvpn/ca.key","-user-ssh-keys-dir-path=/etc/kubernetes/usersshkeys","--ipam-controller-network","192.168.1.1/24,192.168.1.1,8.8.8.8","-node-labels","{\"my-label\":\"my-value\"}"]}'
         command:
         - /http-prober-bin/http-prober
         env:
@@ -71,9 +70,6 @@ spec:
         - mountPath: /etc/kubernetes/kubeconfig
           name: internal-admin-kubeconfig
           readOnly: true
-        - mountPath: /etc/kubernetes/pki/ca
-          name: ca
-          readOnly: true
         - mountPath: /etc/kubernetes/pki/openvpn
           name: openvpn-ca
           readOnly: true
@@ -95,13 +91,11 @@ spec:
         volumeMounts:
         - mountPath: /http-prober-bin
           name: http-prober-bin
+      serviceAccountName: kubermatic-usercluster-controller-manager
       volumes:
       - name: internal-admin-kubeconfig
         secret:
           secretName: internal-admin-kubeconfig
-      - name: ca
-        secret:
-          secretName: ca
       - name: openvpn-ca
         secret:
           secretName: openvpn-ca

--- a/api/pkg/resources/test/fixtures/deployment-openstack-1.10.6-usercluster-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-openstack-1.10.6-usercluster-controller.yaml
@@ -24,7 +24,6 @@ spec:
         app: usercluster-controller
         cluster: de-test-01
         internal-admin-kubeconfig-secret-revision: "123456"
-        usersshkeys-secret-revision: "123456"
     spec:
       containers:
       - args:
@@ -38,7 +37,7 @@ spec:
         - -timeout
         - "1"
         - -command
-        - '{"command":"/usr/local/bin/user-cluster-controller-manager","args":["-kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","-metrics-listen-address","0.0.0.0:8085","-health-listen-address","0.0.0.0:8086","-namespace","$(NAMESPACE)","-cluster-url","","-openvpn-server-port","30003","-overwrite-registry","","-openshift=false","-version","1.10.6","-cloud-provider-name","openstack","-user-ssh-keys-dir-path=/etc/kubernetes/usersshkeys","--ipam-controller-network","192.168.1.1/24,192.168.1.1,8.8.8.8","-node-labels","{\"my-label\":\"my-value\"}"]}'
+        - '{"command":"/usr/local/bin/user-cluster-controller-manager","args":["-kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","-metrics-listen-address","0.0.0.0:8085","-health-listen-address","0.0.0.0:8086","-namespace","$(NAMESPACE)","-cluster-url","","-openvpn-server-port","30003","-overwrite-registry","","-openshift=false","-version","1.10.6","-cloud-provider-name","openstack","--ipam-controller-network","192.168.1.1/24,192.168.1.1,8.8.8.8","-node-labels","{\"my-label\":\"my-value\"}"]}'
         command:
         - /http-prober-bin/http-prober
         env:
@@ -69,9 +68,6 @@ spec:
         - mountPath: /etc/kubernetes/kubeconfig
           name: internal-admin-kubeconfig
           readOnly: true
-        - mountPath: /etc/kubernetes/usersshkeys
-          name: usersshkeys
-          readOnly: true
         - mountPath: /http-prober-bin
           name: http-prober-bin
       imagePullSecrets:
@@ -92,9 +88,6 @@ spec:
       - name: internal-admin-kubeconfig
         secret:
           secretName: internal-admin-kubeconfig
-      - name: usersshkeys
-        secret:
-          secretName: usersshkeys
       - emptyDir: {}
         name: http-prober-bin
 status: {}

--- a/api/pkg/resources/test/fixtures/deployment-openstack-1.11.0-usercluster-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-openstack-1.11.0-usercluster-controller.yaml
@@ -22,7 +22,6 @@ spec:
       creationTimestamp: null
       labels:
         app: usercluster-controller
-        ca-secret-revision: "123456"
         cluster: de-test-01
         internal-admin-kubeconfig-secret-revision: "123456"
         openvpn-ca-secret-revision: "123456"
@@ -40,7 +39,7 @@ spec:
         - -timeout
         - "1"
         - -command
-        - '{"command":"/usr/local/bin/user-cluster-controller-manager","args":["-kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","-metrics-listen-address","0.0.0.0:8085","-health-listen-address","0.0.0.0:8086","-namespace","$(NAMESPACE)","-ca-cert","/etc/kubernetes/pki/ca/ca.crt","-ca-key","/etc/kubernetes/pki/ca/ca.key","-cluster-url","","-openvpn-server-port","30003","-overwrite-registry","","-openshift=false","-version","1.11.0","-cloud-provider-name","openstack","-openvpn-ca-cert-file=/etc/kubernetes/pki/openvpn/ca.crt","-openvpn-ca-key-file=/etc/kubernetes/pki/openvpn/ca.key","-user-ssh-keys-dir-path=/etc/kubernetes/usersshkeys","--ipam-controller-network","192.168.1.1/24,192.168.1.1,8.8.8.8","-node-labels","{\"my-label\":\"my-value\"}"]}'
+        - '{"command":"/usr/local/bin/user-cluster-controller-manager","args":["-kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","-metrics-listen-address","0.0.0.0:8085","-health-listen-address","0.0.0.0:8086","-namespace","$(NAMESPACE)","-cluster-url","","-openvpn-server-port","30003","-overwrite-registry","","-openshift=false","-version","1.11.0","-cloud-provider-name","openstack","-openvpn-ca-cert-file=/etc/kubernetes/pki/openvpn/ca.crt","-openvpn-ca-key-file=/etc/kubernetes/pki/openvpn/ca.key","-user-ssh-keys-dir-path=/etc/kubernetes/usersshkeys","--ipam-controller-network","192.168.1.1/24,192.168.1.1,8.8.8.8","-node-labels","{\"my-label\":\"my-value\"}"]}'
         command:
         - /http-prober-bin/http-prober
         env:
@@ -71,9 +70,6 @@ spec:
         - mountPath: /etc/kubernetes/kubeconfig
           name: internal-admin-kubeconfig
           readOnly: true
-        - mountPath: /etc/kubernetes/pki/ca
-          name: ca
-          readOnly: true
         - mountPath: /etc/kubernetes/pki/openvpn
           name: openvpn-ca
           readOnly: true
@@ -95,13 +91,11 @@ spec:
         volumeMounts:
         - mountPath: /http-prober-bin
           name: http-prober-bin
+      serviceAccountName: kubermatic-usercluster-controller-manager
       volumes:
       - name: internal-admin-kubeconfig
         secret:
           secretName: internal-admin-kubeconfig
-      - name: ca
-        secret:
-          secretName: ca
       - name: openvpn-ca
         secret:
           secretName: openvpn-ca

--- a/api/pkg/resources/test/fixtures/deployment-openstack-1.11.0-usercluster-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-openstack-1.11.0-usercluster-controller.yaml
@@ -24,7 +24,6 @@ spec:
         app: usercluster-controller
         cluster: de-test-01
         internal-admin-kubeconfig-secret-revision: "123456"
-        openvpn-ca-secret-revision: "123456"
         usersshkeys-secret-revision: "123456"
     spec:
       containers:
@@ -39,7 +38,7 @@ spec:
         - -timeout
         - "1"
         - -command
-        - '{"command":"/usr/local/bin/user-cluster-controller-manager","args":["-kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","-metrics-listen-address","0.0.0.0:8085","-health-listen-address","0.0.0.0:8086","-namespace","$(NAMESPACE)","-cluster-url","","-openvpn-server-port","30003","-overwrite-registry","","-openshift=false","-version","1.11.0","-cloud-provider-name","openstack","-openvpn-ca-cert-file=/etc/kubernetes/pki/openvpn/ca.crt","-openvpn-ca-key-file=/etc/kubernetes/pki/openvpn/ca.key","-user-ssh-keys-dir-path=/etc/kubernetes/usersshkeys","--ipam-controller-network","192.168.1.1/24,192.168.1.1,8.8.8.8","-node-labels","{\"my-label\":\"my-value\"}"]}'
+        - '{"command":"/usr/local/bin/user-cluster-controller-manager","args":["-kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","-metrics-listen-address","0.0.0.0:8085","-health-listen-address","0.0.0.0:8086","-namespace","$(NAMESPACE)","-cluster-url","","-openvpn-server-port","30003","-overwrite-registry","","-openshift=false","-version","1.11.0","-cloud-provider-name","openstack","-user-ssh-keys-dir-path=/etc/kubernetes/usersshkeys","--ipam-controller-network","192.168.1.1/24,192.168.1.1,8.8.8.8","-node-labels","{\"my-label\":\"my-value\"}"]}'
         command:
         - /http-prober-bin/http-prober
         env:
@@ -70,9 +69,6 @@ spec:
         - mountPath: /etc/kubernetes/kubeconfig
           name: internal-admin-kubeconfig
           readOnly: true
-        - mountPath: /etc/kubernetes/pki/openvpn
-          name: openvpn-ca
-          readOnly: true
         - mountPath: /etc/kubernetes/usersshkeys
           name: usersshkeys
           readOnly: true
@@ -96,9 +92,6 @@ spec:
       - name: internal-admin-kubeconfig
         secret:
           secretName: internal-admin-kubeconfig
-      - name: openvpn-ca
-        secret:
-          secretName: openvpn-ca
       - name: usersshkeys
         secret:
           secretName: usersshkeys

--- a/api/pkg/resources/test/fixtures/deployment-openstack-1.11.0-usercluster-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-openstack-1.11.0-usercluster-controller.yaml
@@ -24,7 +24,6 @@ spec:
         app: usercluster-controller
         cluster: de-test-01
         internal-admin-kubeconfig-secret-revision: "123456"
-        usersshkeys-secret-revision: "123456"
     spec:
       containers:
       - args:
@@ -38,7 +37,7 @@ spec:
         - -timeout
         - "1"
         - -command
-        - '{"command":"/usr/local/bin/user-cluster-controller-manager","args":["-kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","-metrics-listen-address","0.0.0.0:8085","-health-listen-address","0.0.0.0:8086","-namespace","$(NAMESPACE)","-cluster-url","","-openvpn-server-port","30003","-overwrite-registry","","-openshift=false","-version","1.11.0","-cloud-provider-name","openstack","-user-ssh-keys-dir-path=/etc/kubernetes/usersshkeys","--ipam-controller-network","192.168.1.1/24,192.168.1.1,8.8.8.8","-node-labels","{\"my-label\":\"my-value\"}"]}'
+        - '{"command":"/usr/local/bin/user-cluster-controller-manager","args":["-kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","-metrics-listen-address","0.0.0.0:8085","-health-listen-address","0.0.0.0:8086","-namespace","$(NAMESPACE)","-cluster-url","","-openvpn-server-port","30003","-overwrite-registry","","-openshift=false","-version","1.11.0","-cloud-provider-name","openstack","--ipam-controller-network","192.168.1.1/24,192.168.1.1,8.8.8.8","-node-labels","{\"my-label\":\"my-value\"}"]}'
         command:
         - /http-prober-bin/http-prober
         env:
@@ -69,9 +68,6 @@ spec:
         - mountPath: /etc/kubernetes/kubeconfig
           name: internal-admin-kubeconfig
           readOnly: true
-        - mountPath: /etc/kubernetes/usersshkeys
-          name: usersshkeys
-          readOnly: true
         - mountPath: /http-prober-bin
           name: http-prober-bin
       imagePullSecrets:
@@ -92,9 +88,6 @@ spec:
       - name: internal-admin-kubeconfig
         secret:
           secretName: internal-admin-kubeconfig
-      - name: usersshkeys
-        secret:
-          secretName: usersshkeys
       - emptyDir: {}
         name: http-prober-bin
 status: {}

--- a/api/pkg/resources/test/fixtures/deployment-openstack-1.11.1-usercluster-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-openstack-1.11.1-usercluster-controller.yaml
@@ -24,7 +24,6 @@ spec:
         app: usercluster-controller
         cluster: de-test-01
         internal-admin-kubeconfig-secret-revision: "123456"
-        openvpn-ca-secret-revision: "123456"
         usersshkeys-secret-revision: "123456"
     spec:
       containers:
@@ -39,7 +38,7 @@ spec:
         - -timeout
         - "1"
         - -command
-        - '{"command":"/usr/local/bin/user-cluster-controller-manager","args":["-kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","-metrics-listen-address","0.0.0.0:8085","-health-listen-address","0.0.0.0:8086","-namespace","$(NAMESPACE)","-cluster-url","","-openvpn-server-port","30003","-overwrite-registry","","-openshift=false","-version","1.11.1","-cloud-provider-name","openstack","-openvpn-ca-cert-file=/etc/kubernetes/pki/openvpn/ca.crt","-openvpn-ca-key-file=/etc/kubernetes/pki/openvpn/ca.key","-user-ssh-keys-dir-path=/etc/kubernetes/usersshkeys","--ipam-controller-network","192.168.1.1/24,192.168.1.1,8.8.8.8","-node-labels","{\"my-label\":\"my-value\"}"]}'
+        - '{"command":"/usr/local/bin/user-cluster-controller-manager","args":["-kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","-metrics-listen-address","0.0.0.0:8085","-health-listen-address","0.0.0.0:8086","-namespace","$(NAMESPACE)","-cluster-url","","-openvpn-server-port","30003","-overwrite-registry","","-openshift=false","-version","1.11.1","-cloud-provider-name","openstack","-user-ssh-keys-dir-path=/etc/kubernetes/usersshkeys","--ipam-controller-network","192.168.1.1/24,192.168.1.1,8.8.8.8","-node-labels","{\"my-label\":\"my-value\"}"]}'
         command:
         - /http-prober-bin/http-prober
         env:
@@ -70,9 +69,6 @@ spec:
         - mountPath: /etc/kubernetes/kubeconfig
           name: internal-admin-kubeconfig
           readOnly: true
-        - mountPath: /etc/kubernetes/pki/openvpn
-          name: openvpn-ca
-          readOnly: true
         - mountPath: /etc/kubernetes/usersshkeys
           name: usersshkeys
           readOnly: true
@@ -96,9 +92,6 @@ spec:
       - name: internal-admin-kubeconfig
         secret:
           secretName: internal-admin-kubeconfig
-      - name: openvpn-ca
-        secret:
-          secretName: openvpn-ca
       - name: usersshkeys
         secret:
           secretName: usersshkeys

--- a/api/pkg/resources/test/fixtures/deployment-openstack-1.11.1-usercluster-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-openstack-1.11.1-usercluster-controller.yaml
@@ -24,7 +24,6 @@ spec:
         app: usercluster-controller
         cluster: de-test-01
         internal-admin-kubeconfig-secret-revision: "123456"
-        usersshkeys-secret-revision: "123456"
     spec:
       containers:
       - args:
@@ -38,7 +37,7 @@ spec:
         - -timeout
         - "1"
         - -command
-        - '{"command":"/usr/local/bin/user-cluster-controller-manager","args":["-kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","-metrics-listen-address","0.0.0.0:8085","-health-listen-address","0.0.0.0:8086","-namespace","$(NAMESPACE)","-cluster-url","","-openvpn-server-port","30003","-overwrite-registry","","-openshift=false","-version","1.11.1","-cloud-provider-name","openstack","-user-ssh-keys-dir-path=/etc/kubernetes/usersshkeys","--ipam-controller-network","192.168.1.1/24,192.168.1.1,8.8.8.8","-node-labels","{\"my-label\":\"my-value\"}"]}'
+        - '{"command":"/usr/local/bin/user-cluster-controller-manager","args":["-kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","-metrics-listen-address","0.0.0.0:8085","-health-listen-address","0.0.0.0:8086","-namespace","$(NAMESPACE)","-cluster-url","","-openvpn-server-port","30003","-overwrite-registry","","-openshift=false","-version","1.11.1","-cloud-provider-name","openstack","--ipam-controller-network","192.168.1.1/24,192.168.1.1,8.8.8.8","-node-labels","{\"my-label\":\"my-value\"}"]}'
         command:
         - /http-prober-bin/http-prober
         env:
@@ -69,9 +68,6 @@ spec:
         - mountPath: /etc/kubernetes/kubeconfig
           name: internal-admin-kubeconfig
           readOnly: true
-        - mountPath: /etc/kubernetes/usersshkeys
-          name: usersshkeys
-          readOnly: true
         - mountPath: /http-prober-bin
           name: http-prober-bin
       imagePullSecrets:
@@ -92,9 +88,6 @@ spec:
       - name: internal-admin-kubeconfig
         secret:
           secretName: internal-admin-kubeconfig
-      - name: usersshkeys
-        secret:
-          secretName: usersshkeys
       - emptyDir: {}
         name: http-prober-bin
 status: {}

--- a/api/pkg/resources/test/fixtures/deployment-openstack-1.11.1-usercluster-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-openstack-1.11.1-usercluster-controller.yaml
@@ -22,7 +22,6 @@ spec:
       creationTimestamp: null
       labels:
         app: usercluster-controller
-        ca-secret-revision: "123456"
         cluster: de-test-01
         internal-admin-kubeconfig-secret-revision: "123456"
         openvpn-ca-secret-revision: "123456"
@@ -40,7 +39,7 @@ spec:
         - -timeout
         - "1"
         - -command
-        - '{"command":"/usr/local/bin/user-cluster-controller-manager","args":["-kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","-metrics-listen-address","0.0.0.0:8085","-health-listen-address","0.0.0.0:8086","-namespace","$(NAMESPACE)","-ca-cert","/etc/kubernetes/pki/ca/ca.crt","-ca-key","/etc/kubernetes/pki/ca/ca.key","-cluster-url","","-openvpn-server-port","30003","-overwrite-registry","","-openshift=false","-version","1.11.1","-cloud-provider-name","openstack","-openvpn-ca-cert-file=/etc/kubernetes/pki/openvpn/ca.crt","-openvpn-ca-key-file=/etc/kubernetes/pki/openvpn/ca.key","-user-ssh-keys-dir-path=/etc/kubernetes/usersshkeys","--ipam-controller-network","192.168.1.1/24,192.168.1.1,8.8.8.8","-node-labels","{\"my-label\":\"my-value\"}"]}'
+        - '{"command":"/usr/local/bin/user-cluster-controller-manager","args":["-kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","-metrics-listen-address","0.0.0.0:8085","-health-listen-address","0.0.0.0:8086","-namespace","$(NAMESPACE)","-cluster-url","","-openvpn-server-port","30003","-overwrite-registry","","-openshift=false","-version","1.11.1","-cloud-provider-name","openstack","-openvpn-ca-cert-file=/etc/kubernetes/pki/openvpn/ca.crt","-openvpn-ca-key-file=/etc/kubernetes/pki/openvpn/ca.key","-user-ssh-keys-dir-path=/etc/kubernetes/usersshkeys","--ipam-controller-network","192.168.1.1/24,192.168.1.1,8.8.8.8","-node-labels","{\"my-label\":\"my-value\"}"]}'
         command:
         - /http-prober-bin/http-prober
         env:
@@ -71,9 +70,6 @@ spec:
         - mountPath: /etc/kubernetes/kubeconfig
           name: internal-admin-kubeconfig
           readOnly: true
-        - mountPath: /etc/kubernetes/pki/ca
-          name: ca
-          readOnly: true
         - mountPath: /etc/kubernetes/pki/openvpn
           name: openvpn-ca
           readOnly: true
@@ -95,13 +91,11 @@ spec:
         volumeMounts:
         - mountPath: /http-prober-bin
           name: http-prober-bin
+      serviceAccountName: kubermatic-usercluster-controller-manager
       volumes:
       - name: internal-admin-kubeconfig
         secret:
           secretName: internal-admin-kubeconfig
-      - name: ca
-        secret:
-          secretName: ca
       - name: openvpn-ca
         secret:
           secretName: openvpn-ca

--- a/api/pkg/resources/test/fixtures/deployment-openstack-1.12.0-usercluster-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-openstack-1.12.0-usercluster-controller.yaml
@@ -24,7 +24,6 @@ spec:
         app: usercluster-controller
         cluster: de-test-01
         internal-admin-kubeconfig-secret-revision: "123456"
-        usersshkeys-secret-revision: "123456"
     spec:
       containers:
       - args:
@@ -38,7 +37,7 @@ spec:
         - -timeout
         - "1"
         - -command
-        - '{"command":"/usr/local/bin/user-cluster-controller-manager","args":["-kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","-metrics-listen-address","0.0.0.0:8085","-health-listen-address","0.0.0.0:8086","-namespace","$(NAMESPACE)","-cluster-url","","-openvpn-server-port","30003","-overwrite-registry","","-openshift=false","-version","1.12.0","-cloud-provider-name","openstack","-user-ssh-keys-dir-path=/etc/kubernetes/usersshkeys","--ipam-controller-network","192.168.1.1/24,192.168.1.1,8.8.8.8","-node-labels","{\"my-label\":\"my-value\"}"]}'
+        - '{"command":"/usr/local/bin/user-cluster-controller-manager","args":["-kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","-metrics-listen-address","0.0.0.0:8085","-health-listen-address","0.0.0.0:8086","-namespace","$(NAMESPACE)","-cluster-url","","-openvpn-server-port","30003","-overwrite-registry","","-openshift=false","-version","1.12.0","-cloud-provider-name","openstack","--ipam-controller-network","192.168.1.1/24,192.168.1.1,8.8.8.8","-node-labels","{\"my-label\":\"my-value\"}"]}'
         command:
         - /http-prober-bin/http-prober
         env:
@@ -69,9 +68,6 @@ spec:
         - mountPath: /etc/kubernetes/kubeconfig
           name: internal-admin-kubeconfig
           readOnly: true
-        - mountPath: /etc/kubernetes/usersshkeys
-          name: usersshkeys
-          readOnly: true
         - mountPath: /http-prober-bin
           name: http-prober-bin
       imagePullSecrets:
@@ -92,9 +88,6 @@ spec:
       - name: internal-admin-kubeconfig
         secret:
           secretName: internal-admin-kubeconfig
-      - name: usersshkeys
-        secret:
-          secretName: usersshkeys
       - emptyDir: {}
         name: http-prober-bin
 status: {}

--- a/api/pkg/resources/test/fixtures/deployment-openstack-1.12.0-usercluster-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-openstack-1.12.0-usercluster-controller.yaml
@@ -22,7 +22,6 @@ spec:
       creationTimestamp: null
       labels:
         app: usercluster-controller
-        ca-secret-revision: "123456"
         cluster: de-test-01
         internal-admin-kubeconfig-secret-revision: "123456"
         openvpn-ca-secret-revision: "123456"
@@ -40,7 +39,7 @@ spec:
         - -timeout
         - "1"
         - -command
-        - '{"command":"/usr/local/bin/user-cluster-controller-manager","args":["-kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","-metrics-listen-address","0.0.0.0:8085","-health-listen-address","0.0.0.0:8086","-namespace","$(NAMESPACE)","-ca-cert","/etc/kubernetes/pki/ca/ca.crt","-ca-key","/etc/kubernetes/pki/ca/ca.key","-cluster-url","","-openvpn-server-port","30003","-overwrite-registry","","-openshift=false","-version","1.12.0","-cloud-provider-name","openstack","-openvpn-ca-cert-file=/etc/kubernetes/pki/openvpn/ca.crt","-openvpn-ca-key-file=/etc/kubernetes/pki/openvpn/ca.key","-user-ssh-keys-dir-path=/etc/kubernetes/usersshkeys","--ipam-controller-network","192.168.1.1/24,192.168.1.1,8.8.8.8","-node-labels","{\"my-label\":\"my-value\"}"]}'
+        - '{"command":"/usr/local/bin/user-cluster-controller-manager","args":["-kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","-metrics-listen-address","0.0.0.0:8085","-health-listen-address","0.0.0.0:8086","-namespace","$(NAMESPACE)","-cluster-url","","-openvpn-server-port","30003","-overwrite-registry","","-openshift=false","-version","1.12.0","-cloud-provider-name","openstack","-openvpn-ca-cert-file=/etc/kubernetes/pki/openvpn/ca.crt","-openvpn-ca-key-file=/etc/kubernetes/pki/openvpn/ca.key","-user-ssh-keys-dir-path=/etc/kubernetes/usersshkeys","--ipam-controller-network","192.168.1.1/24,192.168.1.1,8.8.8.8","-node-labels","{\"my-label\":\"my-value\"}"]}'
         command:
         - /http-prober-bin/http-prober
         env:
@@ -71,9 +70,6 @@ spec:
         - mountPath: /etc/kubernetes/kubeconfig
           name: internal-admin-kubeconfig
           readOnly: true
-        - mountPath: /etc/kubernetes/pki/ca
-          name: ca
-          readOnly: true
         - mountPath: /etc/kubernetes/pki/openvpn
           name: openvpn-ca
           readOnly: true
@@ -95,13 +91,11 @@ spec:
         volumeMounts:
         - mountPath: /http-prober-bin
           name: http-prober-bin
+      serviceAccountName: kubermatic-usercluster-controller-manager
       volumes:
       - name: internal-admin-kubeconfig
         secret:
           secretName: internal-admin-kubeconfig
-      - name: ca
-        secret:
-          secretName: ca
       - name: openvpn-ca
         secret:
           secretName: openvpn-ca

--- a/api/pkg/resources/test/fixtures/deployment-openstack-1.12.0-usercluster-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-openstack-1.12.0-usercluster-controller.yaml
@@ -24,7 +24,6 @@ spec:
         app: usercluster-controller
         cluster: de-test-01
         internal-admin-kubeconfig-secret-revision: "123456"
-        openvpn-ca-secret-revision: "123456"
         usersshkeys-secret-revision: "123456"
     spec:
       containers:
@@ -39,7 +38,7 @@ spec:
         - -timeout
         - "1"
         - -command
-        - '{"command":"/usr/local/bin/user-cluster-controller-manager","args":["-kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","-metrics-listen-address","0.0.0.0:8085","-health-listen-address","0.0.0.0:8086","-namespace","$(NAMESPACE)","-cluster-url","","-openvpn-server-port","30003","-overwrite-registry","","-openshift=false","-version","1.12.0","-cloud-provider-name","openstack","-openvpn-ca-cert-file=/etc/kubernetes/pki/openvpn/ca.crt","-openvpn-ca-key-file=/etc/kubernetes/pki/openvpn/ca.key","-user-ssh-keys-dir-path=/etc/kubernetes/usersshkeys","--ipam-controller-network","192.168.1.1/24,192.168.1.1,8.8.8.8","-node-labels","{\"my-label\":\"my-value\"}"]}'
+        - '{"command":"/usr/local/bin/user-cluster-controller-manager","args":["-kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","-metrics-listen-address","0.0.0.0:8085","-health-listen-address","0.0.0.0:8086","-namespace","$(NAMESPACE)","-cluster-url","","-openvpn-server-port","30003","-overwrite-registry","","-openshift=false","-version","1.12.0","-cloud-provider-name","openstack","-user-ssh-keys-dir-path=/etc/kubernetes/usersshkeys","--ipam-controller-network","192.168.1.1/24,192.168.1.1,8.8.8.8","-node-labels","{\"my-label\":\"my-value\"}"]}'
         command:
         - /http-prober-bin/http-prober
         env:
@@ -70,9 +69,6 @@ spec:
         - mountPath: /etc/kubernetes/kubeconfig
           name: internal-admin-kubeconfig
           readOnly: true
-        - mountPath: /etc/kubernetes/pki/openvpn
-          name: openvpn-ca
-          readOnly: true
         - mountPath: /etc/kubernetes/usersshkeys
           name: usersshkeys
           readOnly: true
@@ -96,9 +92,6 @@ spec:
       - name: internal-admin-kubeconfig
         secret:
           secretName: internal-admin-kubeconfig
-      - name: openvpn-ca
-        secret:
-          secretName: openvpn-ca
       - name: usersshkeys
         secret:
           secretName: usersshkeys

--- a/api/pkg/resources/test/fixtures/deployment-openstack-1.13.0-usercluster-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-openstack-1.13.0-usercluster-controller.yaml
@@ -24,7 +24,6 @@ spec:
         app: usercluster-controller
         cluster: de-test-01
         internal-admin-kubeconfig-secret-revision: "123456"
-        usersshkeys-secret-revision: "123456"
     spec:
       containers:
       - args:
@@ -38,7 +37,7 @@ spec:
         - -timeout
         - "1"
         - -command
-        - '{"command":"/usr/local/bin/user-cluster-controller-manager","args":["-kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","-metrics-listen-address","0.0.0.0:8085","-health-listen-address","0.0.0.0:8086","-namespace","$(NAMESPACE)","-cluster-url","","-openvpn-server-port","30003","-overwrite-registry","","-openshift=false","-version","1.13.0","-cloud-provider-name","openstack","-user-ssh-keys-dir-path=/etc/kubernetes/usersshkeys","--ipam-controller-network","192.168.1.1/24,192.168.1.1,8.8.8.8","-node-labels","{\"my-label\":\"my-value\"}"]}'
+        - '{"command":"/usr/local/bin/user-cluster-controller-manager","args":["-kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","-metrics-listen-address","0.0.0.0:8085","-health-listen-address","0.0.0.0:8086","-namespace","$(NAMESPACE)","-cluster-url","","-openvpn-server-port","30003","-overwrite-registry","","-openshift=false","-version","1.13.0","-cloud-provider-name","openstack","--ipam-controller-network","192.168.1.1/24,192.168.1.1,8.8.8.8","-node-labels","{\"my-label\":\"my-value\"}"]}'
         command:
         - /http-prober-bin/http-prober
         env:
@@ -69,9 +68,6 @@ spec:
         - mountPath: /etc/kubernetes/kubeconfig
           name: internal-admin-kubeconfig
           readOnly: true
-        - mountPath: /etc/kubernetes/usersshkeys
-          name: usersshkeys
-          readOnly: true
         - mountPath: /http-prober-bin
           name: http-prober-bin
       imagePullSecrets:
@@ -92,9 +88,6 @@ spec:
       - name: internal-admin-kubeconfig
         secret:
           secretName: internal-admin-kubeconfig
-      - name: usersshkeys
-        secret:
-          secretName: usersshkeys
       - emptyDir: {}
         name: http-prober-bin
 status: {}

--- a/api/pkg/resources/test/fixtures/deployment-openstack-1.13.0-usercluster-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-openstack-1.13.0-usercluster-controller.yaml
@@ -22,7 +22,6 @@ spec:
       creationTimestamp: null
       labels:
         app: usercluster-controller
-        ca-secret-revision: "123456"
         cluster: de-test-01
         internal-admin-kubeconfig-secret-revision: "123456"
         openvpn-ca-secret-revision: "123456"
@@ -40,7 +39,7 @@ spec:
         - -timeout
         - "1"
         - -command
-        - '{"command":"/usr/local/bin/user-cluster-controller-manager","args":["-kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","-metrics-listen-address","0.0.0.0:8085","-health-listen-address","0.0.0.0:8086","-namespace","$(NAMESPACE)","-ca-cert","/etc/kubernetes/pki/ca/ca.crt","-ca-key","/etc/kubernetes/pki/ca/ca.key","-cluster-url","","-openvpn-server-port","30003","-overwrite-registry","","-openshift=false","-version","1.13.0","-cloud-provider-name","openstack","-openvpn-ca-cert-file=/etc/kubernetes/pki/openvpn/ca.crt","-openvpn-ca-key-file=/etc/kubernetes/pki/openvpn/ca.key","-user-ssh-keys-dir-path=/etc/kubernetes/usersshkeys","--ipam-controller-network","192.168.1.1/24,192.168.1.1,8.8.8.8","-node-labels","{\"my-label\":\"my-value\"}"]}'
+        - '{"command":"/usr/local/bin/user-cluster-controller-manager","args":["-kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","-metrics-listen-address","0.0.0.0:8085","-health-listen-address","0.0.0.0:8086","-namespace","$(NAMESPACE)","-cluster-url","","-openvpn-server-port","30003","-overwrite-registry","","-openshift=false","-version","1.13.0","-cloud-provider-name","openstack","-openvpn-ca-cert-file=/etc/kubernetes/pki/openvpn/ca.crt","-openvpn-ca-key-file=/etc/kubernetes/pki/openvpn/ca.key","-user-ssh-keys-dir-path=/etc/kubernetes/usersshkeys","--ipam-controller-network","192.168.1.1/24,192.168.1.1,8.8.8.8","-node-labels","{\"my-label\":\"my-value\"}"]}'
         command:
         - /http-prober-bin/http-prober
         env:
@@ -71,9 +70,6 @@ spec:
         - mountPath: /etc/kubernetes/kubeconfig
           name: internal-admin-kubeconfig
           readOnly: true
-        - mountPath: /etc/kubernetes/pki/ca
-          name: ca
-          readOnly: true
         - mountPath: /etc/kubernetes/pki/openvpn
           name: openvpn-ca
           readOnly: true
@@ -95,13 +91,11 @@ spec:
         volumeMounts:
         - mountPath: /http-prober-bin
           name: http-prober-bin
+      serviceAccountName: kubermatic-usercluster-controller-manager
       volumes:
       - name: internal-admin-kubeconfig
         secret:
           secretName: internal-admin-kubeconfig
-      - name: ca
-        secret:
-          secretName: ca
       - name: openvpn-ca
         secret:
           secretName: openvpn-ca

--- a/api/pkg/resources/test/fixtures/deployment-openstack-1.13.0-usercluster-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-openstack-1.13.0-usercluster-controller.yaml
@@ -24,7 +24,6 @@ spec:
         app: usercluster-controller
         cluster: de-test-01
         internal-admin-kubeconfig-secret-revision: "123456"
-        openvpn-ca-secret-revision: "123456"
         usersshkeys-secret-revision: "123456"
     spec:
       containers:
@@ -39,7 +38,7 @@ spec:
         - -timeout
         - "1"
         - -command
-        - '{"command":"/usr/local/bin/user-cluster-controller-manager","args":["-kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","-metrics-listen-address","0.0.0.0:8085","-health-listen-address","0.0.0.0:8086","-namespace","$(NAMESPACE)","-cluster-url","","-openvpn-server-port","30003","-overwrite-registry","","-openshift=false","-version","1.13.0","-cloud-provider-name","openstack","-openvpn-ca-cert-file=/etc/kubernetes/pki/openvpn/ca.crt","-openvpn-ca-key-file=/etc/kubernetes/pki/openvpn/ca.key","-user-ssh-keys-dir-path=/etc/kubernetes/usersshkeys","--ipam-controller-network","192.168.1.1/24,192.168.1.1,8.8.8.8","-node-labels","{\"my-label\":\"my-value\"}"]}'
+        - '{"command":"/usr/local/bin/user-cluster-controller-manager","args":["-kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","-metrics-listen-address","0.0.0.0:8085","-health-listen-address","0.0.0.0:8086","-namespace","$(NAMESPACE)","-cluster-url","","-openvpn-server-port","30003","-overwrite-registry","","-openshift=false","-version","1.13.0","-cloud-provider-name","openstack","-user-ssh-keys-dir-path=/etc/kubernetes/usersshkeys","--ipam-controller-network","192.168.1.1/24,192.168.1.1,8.8.8.8","-node-labels","{\"my-label\":\"my-value\"}"]}'
         command:
         - /http-prober-bin/http-prober
         env:
@@ -70,9 +69,6 @@ spec:
         - mountPath: /etc/kubernetes/kubeconfig
           name: internal-admin-kubeconfig
           readOnly: true
-        - mountPath: /etc/kubernetes/pki/openvpn
-          name: openvpn-ca
-          readOnly: true
         - mountPath: /etc/kubernetes/usersshkeys
           name: usersshkeys
           readOnly: true
@@ -96,9 +92,6 @@ spec:
       - name: internal-admin-kubeconfig
         secret:
           secretName: internal-admin-kubeconfig
-      - name: openvpn-ca
-        secret:
-          secretName: openvpn-ca
       - name: usersshkeys
         secret:
           secretName: usersshkeys

--- a/api/pkg/resources/test/fixtures/deployment-vsphere-1.10.0-usercluster-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-vsphere-1.10.0-usercluster-controller.yaml
@@ -24,7 +24,6 @@ spec:
         app: usercluster-controller
         cluster: de-test-01
         internal-admin-kubeconfig-secret-revision: "123456"
-        openvpn-ca-secret-revision: "123456"
         usersshkeys-secret-revision: "123456"
     spec:
       containers:
@@ -39,7 +38,7 @@ spec:
         - -timeout
         - "1"
         - -command
-        - '{"command":"/usr/local/bin/user-cluster-controller-manager","args":["-kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","-metrics-listen-address","0.0.0.0:8085","-health-listen-address","0.0.0.0:8086","-namespace","$(NAMESPACE)","-cluster-url","","-openvpn-server-port","30003","-overwrite-registry","","-openshift=false","-version","1.10.0","-cloud-provider-name","vsphere","-openvpn-ca-cert-file=/etc/kubernetes/pki/openvpn/ca.crt","-openvpn-ca-key-file=/etc/kubernetes/pki/openvpn/ca.key","-user-ssh-keys-dir-path=/etc/kubernetes/usersshkeys","--ipam-controller-network","192.168.1.1/24,192.168.1.1,8.8.8.8","-node-labels","{\"my-label\":\"my-value\"}"]}'
+        - '{"command":"/usr/local/bin/user-cluster-controller-manager","args":["-kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","-metrics-listen-address","0.0.0.0:8085","-health-listen-address","0.0.0.0:8086","-namespace","$(NAMESPACE)","-cluster-url","","-openvpn-server-port","30003","-overwrite-registry","","-openshift=false","-version","1.10.0","-cloud-provider-name","vsphere","-user-ssh-keys-dir-path=/etc/kubernetes/usersshkeys","--ipam-controller-network","192.168.1.1/24,192.168.1.1,8.8.8.8","-node-labels","{\"my-label\":\"my-value\"}"]}'
         command:
         - /http-prober-bin/http-prober
         env:
@@ -70,9 +69,6 @@ spec:
         - mountPath: /etc/kubernetes/kubeconfig
           name: internal-admin-kubeconfig
           readOnly: true
-        - mountPath: /etc/kubernetes/pki/openvpn
-          name: openvpn-ca
-          readOnly: true
         - mountPath: /etc/kubernetes/usersshkeys
           name: usersshkeys
           readOnly: true
@@ -96,9 +92,6 @@ spec:
       - name: internal-admin-kubeconfig
         secret:
           secretName: internal-admin-kubeconfig
-      - name: openvpn-ca
-        secret:
-          secretName: openvpn-ca
       - name: usersshkeys
         secret:
           secretName: usersshkeys

--- a/api/pkg/resources/test/fixtures/deployment-vsphere-1.10.0-usercluster-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-vsphere-1.10.0-usercluster-controller.yaml
@@ -24,7 +24,6 @@ spec:
         app: usercluster-controller
         cluster: de-test-01
         internal-admin-kubeconfig-secret-revision: "123456"
-        usersshkeys-secret-revision: "123456"
     spec:
       containers:
       - args:
@@ -38,7 +37,7 @@ spec:
         - -timeout
         - "1"
         - -command
-        - '{"command":"/usr/local/bin/user-cluster-controller-manager","args":["-kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","-metrics-listen-address","0.0.0.0:8085","-health-listen-address","0.0.0.0:8086","-namespace","$(NAMESPACE)","-cluster-url","","-openvpn-server-port","30003","-overwrite-registry","","-openshift=false","-version","1.10.0","-cloud-provider-name","vsphere","-user-ssh-keys-dir-path=/etc/kubernetes/usersshkeys","--ipam-controller-network","192.168.1.1/24,192.168.1.1,8.8.8.8","-node-labels","{\"my-label\":\"my-value\"}"]}'
+        - '{"command":"/usr/local/bin/user-cluster-controller-manager","args":["-kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","-metrics-listen-address","0.0.0.0:8085","-health-listen-address","0.0.0.0:8086","-namespace","$(NAMESPACE)","-cluster-url","","-openvpn-server-port","30003","-overwrite-registry","","-openshift=false","-version","1.10.0","-cloud-provider-name","vsphere","--ipam-controller-network","192.168.1.1/24,192.168.1.1,8.8.8.8","-node-labels","{\"my-label\":\"my-value\"}"]}'
         command:
         - /http-prober-bin/http-prober
         env:
@@ -69,9 +68,6 @@ spec:
         - mountPath: /etc/kubernetes/kubeconfig
           name: internal-admin-kubeconfig
           readOnly: true
-        - mountPath: /etc/kubernetes/usersshkeys
-          name: usersshkeys
-          readOnly: true
         - mountPath: /http-prober-bin
           name: http-prober-bin
       imagePullSecrets:
@@ -92,9 +88,6 @@ spec:
       - name: internal-admin-kubeconfig
         secret:
           secretName: internal-admin-kubeconfig
-      - name: usersshkeys
-        secret:
-          secretName: usersshkeys
       - emptyDir: {}
         name: http-prober-bin
 status: {}

--- a/api/pkg/resources/test/fixtures/deployment-vsphere-1.10.0-usercluster-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-vsphere-1.10.0-usercluster-controller.yaml
@@ -22,7 +22,6 @@ spec:
       creationTimestamp: null
       labels:
         app: usercluster-controller
-        ca-secret-revision: "123456"
         cluster: de-test-01
         internal-admin-kubeconfig-secret-revision: "123456"
         openvpn-ca-secret-revision: "123456"
@@ -40,7 +39,7 @@ spec:
         - -timeout
         - "1"
         - -command
-        - '{"command":"/usr/local/bin/user-cluster-controller-manager","args":["-kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","-metrics-listen-address","0.0.0.0:8085","-health-listen-address","0.0.0.0:8086","-namespace","$(NAMESPACE)","-ca-cert","/etc/kubernetes/pki/ca/ca.crt","-ca-key","/etc/kubernetes/pki/ca/ca.key","-cluster-url","","-openvpn-server-port","30003","-overwrite-registry","","-openshift=false","-version","1.10.0","-cloud-provider-name","vsphere","-openvpn-ca-cert-file=/etc/kubernetes/pki/openvpn/ca.crt","-openvpn-ca-key-file=/etc/kubernetes/pki/openvpn/ca.key","-user-ssh-keys-dir-path=/etc/kubernetes/usersshkeys","--ipam-controller-network","192.168.1.1/24,192.168.1.1,8.8.8.8","-node-labels","{\"my-label\":\"my-value\"}"]}'
+        - '{"command":"/usr/local/bin/user-cluster-controller-manager","args":["-kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","-metrics-listen-address","0.0.0.0:8085","-health-listen-address","0.0.0.0:8086","-namespace","$(NAMESPACE)","-cluster-url","","-openvpn-server-port","30003","-overwrite-registry","","-openshift=false","-version","1.10.0","-cloud-provider-name","vsphere","-openvpn-ca-cert-file=/etc/kubernetes/pki/openvpn/ca.crt","-openvpn-ca-key-file=/etc/kubernetes/pki/openvpn/ca.key","-user-ssh-keys-dir-path=/etc/kubernetes/usersshkeys","--ipam-controller-network","192.168.1.1/24,192.168.1.1,8.8.8.8","-node-labels","{\"my-label\":\"my-value\"}"]}'
         command:
         - /http-prober-bin/http-prober
         env:
@@ -71,9 +70,6 @@ spec:
         - mountPath: /etc/kubernetes/kubeconfig
           name: internal-admin-kubeconfig
           readOnly: true
-        - mountPath: /etc/kubernetes/pki/ca
-          name: ca
-          readOnly: true
         - mountPath: /etc/kubernetes/pki/openvpn
           name: openvpn-ca
           readOnly: true
@@ -95,13 +91,11 @@ spec:
         volumeMounts:
         - mountPath: /http-prober-bin
           name: http-prober-bin
+      serviceAccountName: kubermatic-usercluster-controller-manager
       volumes:
       - name: internal-admin-kubeconfig
         secret:
           secretName: internal-admin-kubeconfig
-      - name: ca
-        secret:
-          secretName: ca
       - name: openvpn-ca
         secret:
           secretName: openvpn-ca

--- a/api/pkg/resources/test/fixtures/deployment-vsphere-1.10.6-usercluster-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-vsphere-1.10.6-usercluster-controller.yaml
@@ -22,7 +22,6 @@ spec:
       creationTimestamp: null
       labels:
         app: usercluster-controller
-        ca-secret-revision: "123456"
         cluster: de-test-01
         internal-admin-kubeconfig-secret-revision: "123456"
         openvpn-ca-secret-revision: "123456"
@@ -40,7 +39,7 @@ spec:
         - -timeout
         - "1"
         - -command
-        - '{"command":"/usr/local/bin/user-cluster-controller-manager","args":["-kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","-metrics-listen-address","0.0.0.0:8085","-health-listen-address","0.0.0.0:8086","-namespace","$(NAMESPACE)","-ca-cert","/etc/kubernetes/pki/ca/ca.crt","-ca-key","/etc/kubernetes/pki/ca/ca.key","-cluster-url","","-openvpn-server-port","30003","-overwrite-registry","","-openshift=false","-version","1.10.6","-cloud-provider-name","vsphere","-openvpn-ca-cert-file=/etc/kubernetes/pki/openvpn/ca.crt","-openvpn-ca-key-file=/etc/kubernetes/pki/openvpn/ca.key","-user-ssh-keys-dir-path=/etc/kubernetes/usersshkeys","--ipam-controller-network","192.168.1.1/24,192.168.1.1,8.8.8.8","-node-labels","{\"my-label\":\"my-value\"}"]}'
+        - '{"command":"/usr/local/bin/user-cluster-controller-manager","args":["-kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","-metrics-listen-address","0.0.0.0:8085","-health-listen-address","0.0.0.0:8086","-namespace","$(NAMESPACE)","-cluster-url","","-openvpn-server-port","30003","-overwrite-registry","","-openshift=false","-version","1.10.6","-cloud-provider-name","vsphere","-openvpn-ca-cert-file=/etc/kubernetes/pki/openvpn/ca.crt","-openvpn-ca-key-file=/etc/kubernetes/pki/openvpn/ca.key","-user-ssh-keys-dir-path=/etc/kubernetes/usersshkeys","--ipam-controller-network","192.168.1.1/24,192.168.1.1,8.8.8.8","-node-labels","{\"my-label\":\"my-value\"}"]}'
         command:
         - /http-prober-bin/http-prober
         env:
@@ -71,9 +70,6 @@ spec:
         - mountPath: /etc/kubernetes/kubeconfig
           name: internal-admin-kubeconfig
           readOnly: true
-        - mountPath: /etc/kubernetes/pki/ca
-          name: ca
-          readOnly: true
         - mountPath: /etc/kubernetes/pki/openvpn
           name: openvpn-ca
           readOnly: true
@@ -95,13 +91,11 @@ spec:
         volumeMounts:
         - mountPath: /http-prober-bin
           name: http-prober-bin
+      serviceAccountName: kubermatic-usercluster-controller-manager
       volumes:
       - name: internal-admin-kubeconfig
         secret:
           secretName: internal-admin-kubeconfig
-      - name: ca
-        secret:
-          secretName: ca
       - name: openvpn-ca
         secret:
           secretName: openvpn-ca

--- a/api/pkg/resources/test/fixtures/deployment-vsphere-1.10.6-usercluster-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-vsphere-1.10.6-usercluster-controller.yaml
@@ -24,7 +24,6 @@ spec:
         app: usercluster-controller
         cluster: de-test-01
         internal-admin-kubeconfig-secret-revision: "123456"
-        openvpn-ca-secret-revision: "123456"
         usersshkeys-secret-revision: "123456"
     spec:
       containers:
@@ -39,7 +38,7 @@ spec:
         - -timeout
         - "1"
         - -command
-        - '{"command":"/usr/local/bin/user-cluster-controller-manager","args":["-kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","-metrics-listen-address","0.0.0.0:8085","-health-listen-address","0.0.0.0:8086","-namespace","$(NAMESPACE)","-cluster-url","","-openvpn-server-port","30003","-overwrite-registry","","-openshift=false","-version","1.10.6","-cloud-provider-name","vsphere","-openvpn-ca-cert-file=/etc/kubernetes/pki/openvpn/ca.crt","-openvpn-ca-key-file=/etc/kubernetes/pki/openvpn/ca.key","-user-ssh-keys-dir-path=/etc/kubernetes/usersshkeys","--ipam-controller-network","192.168.1.1/24,192.168.1.1,8.8.8.8","-node-labels","{\"my-label\":\"my-value\"}"]}'
+        - '{"command":"/usr/local/bin/user-cluster-controller-manager","args":["-kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","-metrics-listen-address","0.0.0.0:8085","-health-listen-address","0.0.0.0:8086","-namespace","$(NAMESPACE)","-cluster-url","","-openvpn-server-port","30003","-overwrite-registry","","-openshift=false","-version","1.10.6","-cloud-provider-name","vsphere","-user-ssh-keys-dir-path=/etc/kubernetes/usersshkeys","--ipam-controller-network","192.168.1.1/24,192.168.1.1,8.8.8.8","-node-labels","{\"my-label\":\"my-value\"}"]}'
         command:
         - /http-prober-bin/http-prober
         env:
@@ -70,9 +69,6 @@ spec:
         - mountPath: /etc/kubernetes/kubeconfig
           name: internal-admin-kubeconfig
           readOnly: true
-        - mountPath: /etc/kubernetes/pki/openvpn
-          name: openvpn-ca
-          readOnly: true
         - mountPath: /etc/kubernetes/usersshkeys
           name: usersshkeys
           readOnly: true
@@ -96,9 +92,6 @@ spec:
       - name: internal-admin-kubeconfig
         secret:
           secretName: internal-admin-kubeconfig
-      - name: openvpn-ca
-        secret:
-          secretName: openvpn-ca
       - name: usersshkeys
         secret:
           secretName: usersshkeys

--- a/api/pkg/resources/test/fixtures/deployment-vsphere-1.10.6-usercluster-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-vsphere-1.10.6-usercluster-controller.yaml
@@ -24,7 +24,6 @@ spec:
         app: usercluster-controller
         cluster: de-test-01
         internal-admin-kubeconfig-secret-revision: "123456"
-        usersshkeys-secret-revision: "123456"
     spec:
       containers:
       - args:
@@ -38,7 +37,7 @@ spec:
         - -timeout
         - "1"
         - -command
-        - '{"command":"/usr/local/bin/user-cluster-controller-manager","args":["-kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","-metrics-listen-address","0.0.0.0:8085","-health-listen-address","0.0.0.0:8086","-namespace","$(NAMESPACE)","-cluster-url","","-openvpn-server-port","30003","-overwrite-registry","","-openshift=false","-version","1.10.6","-cloud-provider-name","vsphere","-user-ssh-keys-dir-path=/etc/kubernetes/usersshkeys","--ipam-controller-network","192.168.1.1/24,192.168.1.1,8.8.8.8","-node-labels","{\"my-label\":\"my-value\"}"]}'
+        - '{"command":"/usr/local/bin/user-cluster-controller-manager","args":["-kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","-metrics-listen-address","0.0.0.0:8085","-health-listen-address","0.0.0.0:8086","-namespace","$(NAMESPACE)","-cluster-url","","-openvpn-server-port","30003","-overwrite-registry","","-openshift=false","-version","1.10.6","-cloud-provider-name","vsphere","--ipam-controller-network","192.168.1.1/24,192.168.1.1,8.8.8.8","-node-labels","{\"my-label\":\"my-value\"}"]}'
         command:
         - /http-prober-bin/http-prober
         env:
@@ -69,9 +68,6 @@ spec:
         - mountPath: /etc/kubernetes/kubeconfig
           name: internal-admin-kubeconfig
           readOnly: true
-        - mountPath: /etc/kubernetes/usersshkeys
-          name: usersshkeys
-          readOnly: true
         - mountPath: /http-prober-bin
           name: http-prober-bin
       imagePullSecrets:
@@ -92,9 +88,6 @@ spec:
       - name: internal-admin-kubeconfig
         secret:
           secretName: internal-admin-kubeconfig
-      - name: usersshkeys
-        secret:
-          secretName: usersshkeys
       - emptyDir: {}
         name: http-prober-bin
 status: {}

--- a/api/pkg/resources/test/fixtures/deployment-vsphere-1.11.0-usercluster-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-vsphere-1.11.0-usercluster-controller.yaml
@@ -24,7 +24,6 @@ spec:
         app: usercluster-controller
         cluster: de-test-01
         internal-admin-kubeconfig-secret-revision: "123456"
-        openvpn-ca-secret-revision: "123456"
         usersshkeys-secret-revision: "123456"
     spec:
       containers:
@@ -39,7 +38,7 @@ spec:
         - -timeout
         - "1"
         - -command
-        - '{"command":"/usr/local/bin/user-cluster-controller-manager","args":["-kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","-metrics-listen-address","0.0.0.0:8085","-health-listen-address","0.0.0.0:8086","-namespace","$(NAMESPACE)","-cluster-url","","-openvpn-server-port","30003","-overwrite-registry","","-openshift=false","-version","1.11.0","-cloud-provider-name","vsphere","-openvpn-ca-cert-file=/etc/kubernetes/pki/openvpn/ca.crt","-openvpn-ca-key-file=/etc/kubernetes/pki/openvpn/ca.key","-user-ssh-keys-dir-path=/etc/kubernetes/usersshkeys","--ipam-controller-network","192.168.1.1/24,192.168.1.1,8.8.8.8","-node-labels","{\"my-label\":\"my-value\"}"]}'
+        - '{"command":"/usr/local/bin/user-cluster-controller-manager","args":["-kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","-metrics-listen-address","0.0.0.0:8085","-health-listen-address","0.0.0.0:8086","-namespace","$(NAMESPACE)","-cluster-url","","-openvpn-server-port","30003","-overwrite-registry","","-openshift=false","-version","1.11.0","-cloud-provider-name","vsphere","-user-ssh-keys-dir-path=/etc/kubernetes/usersshkeys","--ipam-controller-network","192.168.1.1/24,192.168.1.1,8.8.8.8","-node-labels","{\"my-label\":\"my-value\"}"]}'
         command:
         - /http-prober-bin/http-prober
         env:
@@ -70,9 +69,6 @@ spec:
         - mountPath: /etc/kubernetes/kubeconfig
           name: internal-admin-kubeconfig
           readOnly: true
-        - mountPath: /etc/kubernetes/pki/openvpn
-          name: openvpn-ca
-          readOnly: true
         - mountPath: /etc/kubernetes/usersshkeys
           name: usersshkeys
           readOnly: true
@@ -96,9 +92,6 @@ spec:
       - name: internal-admin-kubeconfig
         secret:
           secretName: internal-admin-kubeconfig
-      - name: openvpn-ca
-        secret:
-          secretName: openvpn-ca
       - name: usersshkeys
         secret:
           secretName: usersshkeys

--- a/api/pkg/resources/test/fixtures/deployment-vsphere-1.11.0-usercluster-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-vsphere-1.11.0-usercluster-controller.yaml
@@ -22,7 +22,6 @@ spec:
       creationTimestamp: null
       labels:
         app: usercluster-controller
-        ca-secret-revision: "123456"
         cluster: de-test-01
         internal-admin-kubeconfig-secret-revision: "123456"
         openvpn-ca-secret-revision: "123456"
@@ -40,7 +39,7 @@ spec:
         - -timeout
         - "1"
         - -command
-        - '{"command":"/usr/local/bin/user-cluster-controller-manager","args":["-kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","-metrics-listen-address","0.0.0.0:8085","-health-listen-address","0.0.0.0:8086","-namespace","$(NAMESPACE)","-ca-cert","/etc/kubernetes/pki/ca/ca.crt","-ca-key","/etc/kubernetes/pki/ca/ca.key","-cluster-url","","-openvpn-server-port","30003","-overwrite-registry","","-openshift=false","-version","1.11.0","-cloud-provider-name","vsphere","-openvpn-ca-cert-file=/etc/kubernetes/pki/openvpn/ca.crt","-openvpn-ca-key-file=/etc/kubernetes/pki/openvpn/ca.key","-user-ssh-keys-dir-path=/etc/kubernetes/usersshkeys","--ipam-controller-network","192.168.1.1/24,192.168.1.1,8.8.8.8","-node-labels","{\"my-label\":\"my-value\"}"]}'
+        - '{"command":"/usr/local/bin/user-cluster-controller-manager","args":["-kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","-metrics-listen-address","0.0.0.0:8085","-health-listen-address","0.0.0.0:8086","-namespace","$(NAMESPACE)","-cluster-url","","-openvpn-server-port","30003","-overwrite-registry","","-openshift=false","-version","1.11.0","-cloud-provider-name","vsphere","-openvpn-ca-cert-file=/etc/kubernetes/pki/openvpn/ca.crt","-openvpn-ca-key-file=/etc/kubernetes/pki/openvpn/ca.key","-user-ssh-keys-dir-path=/etc/kubernetes/usersshkeys","--ipam-controller-network","192.168.1.1/24,192.168.1.1,8.8.8.8","-node-labels","{\"my-label\":\"my-value\"}"]}'
         command:
         - /http-prober-bin/http-prober
         env:
@@ -71,9 +70,6 @@ spec:
         - mountPath: /etc/kubernetes/kubeconfig
           name: internal-admin-kubeconfig
           readOnly: true
-        - mountPath: /etc/kubernetes/pki/ca
-          name: ca
-          readOnly: true
         - mountPath: /etc/kubernetes/pki/openvpn
           name: openvpn-ca
           readOnly: true
@@ -95,13 +91,11 @@ spec:
         volumeMounts:
         - mountPath: /http-prober-bin
           name: http-prober-bin
+      serviceAccountName: kubermatic-usercluster-controller-manager
       volumes:
       - name: internal-admin-kubeconfig
         secret:
           secretName: internal-admin-kubeconfig
-      - name: ca
-        secret:
-          secretName: ca
       - name: openvpn-ca
         secret:
           secretName: openvpn-ca

--- a/api/pkg/resources/test/fixtures/deployment-vsphere-1.11.0-usercluster-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-vsphere-1.11.0-usercluster-controller.yaml
@@ -24,7 +24,6 @@ spec:
         app: usercluster-controller
         cluster: de-test-01
         internal-admin-kubeconfig-secret-revision: "123456"
-        usersshkeys-secret-revision: "123456"
     spec:
       containers:
       - args:
@@ -38,7 +37,7 @@ spec:
         - -timeout
         - "1"
         - -command
-        - '{"command":"/usr/local/bin/user-cluster-controller-manager","args":["-kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","-metrics-listen-address","0.0.0.0:8085","-health-listen-address","0.0.0.0:8086","-namespace","$(NAMESPACE)","-cluster-url","","-openvpn-server-port","30003","-overwrite-registry","","-openshift=false","-version","1.11.0","-cloud-provider-name","vsphere","-user-ssh-keys-dir-path=/etc/kubernetes/usersshkeys","--ipam-controller-network","192.168.1.1/24,192.168.1.1,8.8.8.8","-node-labels","{\"my-label\":\"my-value\"}"]}'
+        - '{"command":"/usr/local/bin/user-cluster-controller-manager","args":["-kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","-metrics-listen-address","0.0.0.0:8085","-health-listen-address","0.0.0.0:8086","-namespace","$(NAMESPACE)","-cluster-url","","-openvpn-server-port","30003","-overwrite-registry","","-openshift=false","-version","1.11.0","-cloud-provider-name","vsphere","--ipam-controller-network","192.168.1.1/24,192.168.1.1,8.8.8.8","-node-labels","{\"my-label\":\"my-value\"}"]}'
         command:
         - /http-prober-bin/http-prober
         env:
@@ -69,9 +68,6 @@ spec:
         - mountPath: /etc/kubernetes/kubeconfig
           name: internal-admin-kubeconfig
           readOnly: true
-        - mountPath: /etc/kubernetes/usersshkeys
-          name: usersshkeys
-          readOnly: true
         - mountPath: /http-prober-bin
           name: http-prober-bin
       imagePullSecrets:
@@ -92,9 +88,6 @@ spec:
       - name: internal-admin-kubeconfig
         secret:
           secretName: internal-admin-kubeconfig
-      - name: usersshkeys
-        secret:
-          secretName: usersshkeys
       - emptyDir: {}
         name: http-prober-bin
 status: {}

--- a/api/pkg/resources/test/fixtures/deployment-vsphere-1.11.1-usercluster-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-vsphere-1.11.1-usercluster-controller.yaml
@@ -22,7 +22,6 @@ spec:
       creationTimestamp: null
       labels:
         app: usercluster-controller
-        ca-secret-revision: "123456"
         cluster: de-test-01
         internal-admin-kubeconfig-secret-revision: "123456"
         openvpn-ca-secret-revision: "123456"
@@ -40,7 +39,7 @@ spec:
         - -timeout
         - "1"
         - -command
-        - '{"command":"/usr/local/bin/user-cluster-controller-manager","args":["-kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","-metrics-listen-address","0.0.0.0:8085","-health-listen-address","0.0.0.0:8086","-namespace","$(NAMESPACE)","-ca-cert","/etc/kubernetes/pki/ca/ca.crt","-ca-key","/etc/kubernetes/pki/ca/ca.key","-cluster-url","","-openvpn-server-port","30003","-overwrite-registry","","-openshift=false","-version","1.11.1","-cloud-provider-name","vsphere","-openvpn-ca-cert-file=/etc/kubernetes/pki/openvpn/ca.crt","-openvpn-ca-key-file=/etc/kubernetes/pki/openvpn/ca.key","-user-ssh-keys-dir-path=/etc/kubernetes/usersshkeys","--ipam-controller-network","192.168.1.1/24,192.168.1.1,8.8.8.8","-node-labels","{\"my-label\":\"my-value\"}"]}'
+        - '{"command":"/usr/local/bin/user-cluster-controller-manager","args":["-kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","-metrics-listen-address","0.0.0.0:8085","-health-listen-address","0.0.0.0:8086","-namespace","$(NAMESPACE)","-cluster-url","","-openvpn-server-port","30003","-overwrite-registry","","-openshift=false","-version","1.11.1","-cloud-provider-name","vsphere","-openvpn-ca-cert-file=/etc/kubernetes/pki/openvpn/ca.crt","-openvpn-ca-key-file=/etc/kubernetes/pki/openvpn/ca.key","-user-ssh-keys-dir-path=/etc/kubernetes/usersshkeys","--ipam-controller-network","192.168.1.1/24,192.168.1.1,8.8.8.8","-node-labels","{\"my-label\":\"my-value\"}"]}'
         command:
         - /http-prober-bin/http-prober
         env:
@@ -71,9 +70,6 @@ spec:
         - mountPath: /etc/kubernetes/kubeconfig
           name: internal-admin-kubeconfig
           readOnly: true
-        - mountPath: /etc/kubernetes/pki/ca
-          name: ca
-          readOnly: true
         - mountPath: /etc/kubernetes/pki/openvpn
           name: openvpn-ca
           readOnly: true
@@ -95,13 +91,11 @@ spec:
         volumeMounts:
         - mountPath: /http-prober-bin
           name: http-prober-bin
+      serviceAccountName: kubermatic-usercluster-controller-manager
       volumes:
       - name: internal-admin-kubeconfig
         secret:
           secretName: internal-admin-kubeconfig
-      - name: ca
-        secret:
-          secretName: ca
       - name: openvpn-ca
         secret:
           secretName: openvpn-ca

--- a/api/pkg/resources/test/fixtures/deployment-vsphere-1.11.1-usercluster-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-vsphere-1.11.1-usercluster-controller.yaml
@@ -24,7 +24,6 @@ spec:
         app: usercluster-controller
         cluster: de-test-01
         internal-admin-kubeconfig-secret-revision: "123456"
-        usersshkeys-secret-revision: "123456"
     spec:
       containers:
       - args:
@@ -38,7 +37,7 @@ spec:
         - -timeout
         - "1"
         - -command
-        - '{"command":"/usr/local/bin/user-cluster-controller-manager","args":["-kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","-metrics-listen-address","0.0.0.0:8085","-health-listen-address","0.0.0.0:8086","-namespace","$(NAMESPACE)","-cluster-url","","-openvpn-server-port","30003","-overwrite-registry","","-openshift=false","-version","1.11.1","-cloud-provider-name","vsphere","-user-ssh-keys-dir-path=/etc/kubernetes/usersshkeys","--ipam-controller-network","192.168.1.1/24,192.168.1.1,8.8.8.8","-node-labels","{\"my-label\":\"my-value\"}"]}'
+        - '{"command":"/usr/local/bin/user-cluster-controller-manager","args":["-kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","-metrics-listen-address","0.0.0.0:8085","-health-listen-address","0.0.0.0:8086","-namespace","$(NAMESPACE)","-cluster-url","","-openvpn-server-port","30003","-overwrite-registry","","-openshift=false","-version","1.11.1","-cloud-provider-name","vsphere","--ipam-controller-network","192.168.1.1/24,192.168.1.1,8.8.8.8","-node-labels","{\"my-label\":\"my-value\"}"]}'
         command:
         - /http-prober-bin/http-prober
         env:
@@ -69,9 +68,6 @@ spec:
         - mountPath: /etc/kubernetes/kubeconfig
           name: internal-admin-kubeconfig
           readOnly: true
-        - mountPath: /etc/kubernetes/usersshkeys
-          name: usersshkeys
-          readOnly: true
         - mountPath: /http-prober-bin
           name: http-prober-bin
       imagePullSecrets:
@@ -92,9 +88,6 @@ spec:
       - name: internal-admin-kubeconfig
         secret:
           secretName: internal-admin-kubeconfig
-      - name: usersshkeys
-        secret:
-          secretName: usersshkeys
       - emptyDir: {}
         name: http-prober-bin
 status: {}

--- a/api/pkg/resources/test/fixtures/deployment-vsphere-1.11.1-usercluster-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-vsphere-1.11.1-usercluster-controller.yaml
@@ -24,7 +24,6 @@ spec:
         app: usercluster-controller
         cluster: de-test-01
         internal-admin-kubeconfig-secret-revision: "123456"
-        openvpn-ca-secret-revision: "123456"
         usersshkeys-secret-revision: "123456"
     spec:
       containers:
@@ -39,7 +38,7 @@ spec:
         - -timeout
         - "1"
         - -command
-        - '{"command":"/usr/local/bin/user-cluster-controller-manager","args":["-kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","-metrics-listen-address","0.0.0.0:8085","-health-listen-address","0.0.0.0:8086","-namespace","$(NAMESPACE)","-cluster-url","","-openvpn-server-port","30003","-overwrite-registry","","-openshift=false","-version","1.11.1","-cloud-provider-name","vsphere","-openvpn-ca-cert-file=/etc/kubernetes/pki/openvpn/ca.crt","-openvpn-ca-key-file=/etc/kubernetes/pki/openvpn/ca.key","-user-ssh-keys-dir-path=/etc/kubernetes/usersshkeys","--ipam-controller-network","192.168.1.1/24,192.168.1.1,8.8.8.8","-node-labels","{\"my-label\":\"my-value\"}"]}'
+        - '{"command":"/usr/local/bin/user-cluster-controller-manager","args":["-kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","-metrics-listen-address","0.0.0.0:8085","-health-listen-address","0.0.0.0:8086","-namespace","$(NAMESPACE)","-cluster-url","","-openvpn-server-port","30003","-overwrite-registry","","-openshift=false","-version","1.11.1","-cloud-provider-name","vsphere","-user-ssh-keys-dir-path=/etc/kubernetes/usersshkeys","--ipam-controller-network","192.168.1.1/24,192.168.1.1,8.8.8.8","-node-labels","{\"my-label\":\"my-value\"}"]}'
         command:
         - /http-prober-bin/http-prober
         env:
@@ -70,9 +69,6 @@ spec:
         - mountPath: /etc/kubernetes/kubeconfig
           name: internal-admin-kubeconfig
           readOnly: true
-        - mountPath: /etc/kubernetes/pki/openvpn
-          name: openvpn-ca
-          readOnly: true
         - mountPath: /etc/kubernetes/usersshkeys
           name: usersshkeys
           readOnly: true
@@ -96,9 +92,6 @@ spec:
       - name: internal-admin-kubeconfig
         secret:
           secretName: internal-admin-kubeconfig
-      - name: openvpn-ca
-        secret:
-          secretName: openvpn-ca
       - name: usersshkeys
         secret:
           secretName: usersshkeys

--- a/api/pkg/resources/test/fixtures/deployment-vsphere-1.12.0-usercluster-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-vsphere-1.12.0-usercluster-controller.yaml
@@ -24,7 +24,6 @@ spec:
         app: usercluster-controller
         cluster: de-test-01
         internal-admin-kubeconfig-secret-revision: "123456"
-        openvpn-ca-secret-revision: "123456"
         usersshkeys-secret-revision: "123456"
     spec:
       containers:
@@ -39,7 +38,7 @@ spec:
         - -timeout
         - "1"
         - -command
-        - '{"command":"/usr/local/bin/user-cluster-controller-manager","args":["-kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","-metrics-listen-address","0.0.0.0:8085","-health-listen-address","0.0.0.0:8086","-namespace","$(NAMESPACE)","-cluster-url","","-openvpn-server-port","30003","-overwrite-registry","","-openshift=false","-version","1.12.0","-cloud-provider-name","vsphere","-openvpn-ca-cert-file=/etc/kubernetes/pki/openvpn/ca.crt","-openvpn-ca-key-file=/etc/kubernetes/pki/openvpn/ca.key","-user-ssh-keys-dir-path=/etc/kubernetes/usersshkeys","--ipam-controller-network","192.168.1.1/24,192.168.1.1,8.8.8.8","-node-labels","{\"my-label\":\"my-value\"}"]}'
+        - '{"command":"/usr/local/bin/user-cluster-controller-manager","args":["-kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","-metrics-listen-address","0.0.0.0:8085","-health-listen-address","0.0.0.0:8086","-namespace","$(NAMESPACE)","-cluster-url","","-openvpn-server-port","30003","-overwrite-registry","","-openshift=false","-version","1.12.0","-cloud-provider-name","vsphere","-user-ssh-keys-dir-path=/etc/kubernetes/usersshkeys","--ipam-controller-network","192.168.1.1/24,192.168.1.1,8.8.8.8","-node-labels","{\"my-label\":\"my-value\"}"]}'
         command:
         - /http-prober-bin/http-prober
         env:
@@ -70,9 +69,6 @@ spec:
         - mountPath: /etc/kubernetes/kubeconfig
           name: internal-admin-kubeconfig
           readOnly: true
-        - mountPath: /etc/kubernetes/pki/openvpn
-          name: openvpn-ca
-          readOnly: true
         - mountPath: /etc/kubernetes/usersshkeys
           name: usersshkeys
           readOnly: true
@@ -96,9 +92,6 @@ spec:
       - name: internal-admin-kubeconfig
         secret:
           secretName: internal-admin-kubeconfig
-      - name: openvpn-ca
-        secret:
-          secretName: openvpn-ca
       - name: usersshkeys
         secret:
           secretName: usersshkeys

--- a/api/pkg/resources/test/fixtures/deployment-vsphere-1.12.0-usercluster-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-vsphere-1.12.0-usercluster-controller.yaml
@@ -24,7 +24,6 @@ spec:
         app: usercluster-controller
         cluster: de-test-01
         internal-admin-kubeconfig-secret-revision: "123456"
-        usersshkeys-secret-revision: "123456"
     spec:
       containers:
       - args:
@@ -38,7 +37,7 @@ spec:
         - -timeout
         - "1"
         - -command
-        - '{"command":"/usr/local/bin/user-cluster-controller-manager","args":["-kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","-metrics-listen-address","0.0.0.0:8085","-health-listen-address","0.0.0.0:8086","-namespace","$(NAMESPACE)","-cluster-url","","-openvpn-server-port","30003","-overwrite-registry","","-openshift=false","-version","1.12.0","-cloud-provider-name","vsphere","-user-ssh-keys-dir-path=/etc/kubernetes/usersshkeys","--ipam-controller-network","192.168.1.1/24,192.168.1.1,8.8.8.8","-node-labels","{\"my-label\":\"my-value\"}"]}'
+        - '{"command":"/usr/local/bin/user-cluster-controller-manager","args":["-kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","-metrics-listen-address","0.0.0.0:8085","-health-listen-address","0.0.0.0:8086","-namespace","$(NAMESPACE)","-cluster-url","","-openvpn-server-port","30003","-overwrite-registry","","-openshift=false","-version","1.12.0","-cloud-provider-name","vsphere","--ipam-controller-network","192.168.1.1/24,192.168.1.1,8.8.8.8","-node-labels","{\"my-label\":\"my-value\"}"]}'
         command:
         - /http-prober-bin/http-prober
         env:
@@ -69,9 +68,6 @@ spec:
         - mountPath: /etc/kubernetes/kubeconfig
           name: internal-admin-kubeconfig
           readOnly: true
-        - mountPath: /etc/kubernetes/usersshkeys
-          name: usersshkeys
-          readOnly: true
         - mountPath: /http-prober-bin
           name: http-prober-bin
       imagePullSecrets:
@@ -92,9 +88,6 @@ spec:
       - name: internal-admin-kubeconfig
         secret:
           secretName: internal-admin-kubeconfig
-      - name: usersshkeys
-        secret:
-          secretName: usersshkeys
       - emptyDir: {}
         name: http-prober-bin
 status: {}

--- a/api/pkg/resources/test/fixtures/deployment-vsphere-1.12.0-usercluster-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-vsphere-1.12.0-usercluster-controller.yaml
@@ -22,7 +22,6 @@ spec:
       creationTimestamp: null
       labels:
         app: usercluster-controller
-        ca-secret-revision: "123456"
         cluster: de-test-01
         internal-admin-kubeconfig-secret-revision: "123456"
         openvpn-ca-secret-revision: "123456"
@@ -40,7 +39,7 @@ spec:
         - -timeout
         - "1"
         - -command
-        - '{"command":"/usr/local/bin/user-cluster-controller-manager","args":["-kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","-metrics-listen-address","0.0.0.0:8085","-health-listen-address","0.0.0.0:8086","-namespace","$(NAMESPACE)","-ca-cert","/etc/kubernetes/pki/ca/ca.crt","-ca-key","/etc/kubernetes/pki/ca/ca.key","-cluster-url","","-openvpn-server-port","30003","-overwrite-registry","","-openshift=false","-version","1.12.0","-cloud-provider-name","vsphere","-openvpn-ca-cert-file=/etc/kubernetes/pki/openvpn/ca.crt","-openvpn-ca-key-file=/etc/kubernetes/pki/openvpn/ca.key","-user-ssh-keys-dir-path=/etc/kubernetes/usersshkeys","--ipam-controller-network","192.168.1.1/24,192.168.1.1,8.8.8.8","-node-labels","{\"my-label\":\"my-value\"}"]}'
+        - '{"command":"/usr/local/bin/user-cluster-controller-manager","args":["-kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","-metrics-listen-address","0.0.0.0:8085","-health-listen-address","0.0.0.0:8086","-namespace","$(NAMESPACE)","-cluster-url","","-openvpn-server-port","30003","-overwrite-registry","","-openshift=false","-version","1.12.0","-cloud-provider-name","vsphere","-openvpn-ca-cert-file=/etc/kubernetes/pki/openvpn/ca.crt","-openvpn-ca-key-file=/etc/kubernetes/pki/openvpn/ca.key","-user-ssh-keys-dir-path=/etc/kubernetes/usersshkeys","--ipam-controller-network","192.168.1.1/24,192.168.1.1,8.8.8.8","-node-labels","{\"my-label\":\"my-value\"}"]}'
         command:
         - /http-prober-bin/http-prober
         env:
@@ -71,9 +70,6 @@ spec:
         - mountPath: /etc/kubernetes/kubeconfig
           name: internal-admin-kubeconfig
           readOnly: true
-        - mountPath: /etc/kubernetes/pki/ca
-          name: ca
-          readOnly: true
         - mountPath: /etc/kubernetes/pki/openvpn
           name: openvpn-ca
           readOnly: true
@@ -95,13 +91,11 @@ spec:
         volumeMounts:
         - mountPath: /http-prober-bin
           name: http-prober-bin
+      serviceAccountName: kubermatic-usercluster-controller-manager
       volumes:
       - name: internal-admin-kubeconfig
         secret:
           secretName: internal-admin-kubeconfig
-      - name: ca
-        secret:
-          secretName: ca
       - name: openvpn-ca
         secret:
           secretName: openvpn-ca

--- a/api/pkg/resources/test/fixtures/deployment-vsphere-1.13.0-usercluster-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-vsphere-1.13.0-usercluster-controller.yaml
@@ -24,7 +24,6 @@ spec:
         app: usercluster-controller
         cluster: de-test-01
         internal-admin-kubeconfig-secret-revision: "123456"
-        openvpn-ca-secret-revision: "123456"
         usersshkeys-secret-revision: "123456"
     spec:
       containers:
@@ -39,7 +38,7 @@ spec:
         - -timeout
         - "1"
         - -command
-        - '{"command":"/usr/local/bin/user-cluster-controller-manager","args":["-kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","-metrics-listen-address","0.0.0.0:8085","-health-listen-address","0.0.0.0:8086","-namespace","$(NAMESPACE)","-cluster-url","","-openvpn-server-port","30003","-overwrite-registry","","-openshift=false","-version","1.13.0","-cloud-provider-name","vsphere","-openvpn-ca-cert-file=/etc/kubernetes/pki/openvpn/ca.crt","-openvpn-ca-key-file=/etc/kubernetes/pki/openvpn/ca.key","-user-ssh-keys-dir-path=/etc/kubernetes/usersshkeys","--ipam-controller-network","192.168.1.1/24,192.168.1.1,8.8.8.8","-node-labels","{\"my-label\":\"my-value\"}"]}'
+        - '{"command":"/usr/local/bin/user-cluster-controller-manager","args":["-kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","-metrics-listen-address","0.0.0.0:8085","-health-listen-address","0.0.0.0:8086","-namespace","$(NAMESPACE)","-cluster-url","","-openvpn-server-port","30003","-overwrite-registry","","-openshift=false","-version","1.13.0","-cloud-provider-name","vsphere","-user-ssh-keys-dir-path=/etc/kubernetes/usersshkeys","--ipam-controller-network","192.168.1.1/24,192.168.1.1,8.8.8.8","-node-labels","{\"my-label\":\"my-value\"}"]}'
         command:
         - /http-prober-bin/http-prober
         env:
@@ -70,9 +69,6 @@ spec:
         - mountPath: /etc/kubernetes/kubeconfig
           name: internal-admin-kubeconfig
           readOnly: true
-        - mountPath: /etc/kubernetes/pki/openvpn
-          name: openvpn-ca
-          readOnly: true
         - mountPath: /etc/kubernetes/usersshkeys
           name: usersshkeys
           readOnly: true
@@ -96,9 +92,6 @@ spec:
       - name: internal-admin-kubeconfig
         secret:
           secretName: internal-admin-kubeconfig
-      - name: openvpn-ca
-        secret:
-          secretName: openvpn-ca
       - name: usersshkeys
         secret:
           secretName: usersshkeys

--- a/api/pkg/resources/test/fixtures/deployment-vsphere-1.13.0-usercluster-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-vsphere-1.13.0-usercluster-controller.yaml
@@ -22,7 +22,6 @@ spec:
       creationTimestamp: null
       labels:
         app: usercluster-controller
-        ca-secret-revision: "123456"
         cluster: de-test-01
         internal-admin-kubeconfig-secret-revision: "123456"
         openvpn-ca-secret-revision: "123456"
@@ -40,7 +39,7 @@ spec:
         - -timeout
         - "1"
         - -command
-        - '{"command":"/usr/local/bin/user-cluster-controller-manager","args":["-kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","-metrics-listen-address","0.0.0.0:8085","-health-listen-address","0.0.0.0:8086","-namespace","$(NAMESPACE)","-ca-cert","/etc/kubernetes/pki/ca/ca.crt","-ca-key","/etc/kubernetes/pki/ca/ca.key","-cluster-url","","-openvpn-server-port","30003","-overwrite-registry","","-openshift=false","-version","1.13.0","-cloud-provider-name","vsphere","-openvpn-ca-cert-file=/etc/kubernetes/pki/openvpn/ca.crt","-openvpn-ca-key-file=/etc/kubernetes/pki/openvpn/ca.key","-user-ssh-keys-dir-path=/etc/kubernetes/usersshkeys","--ipam-controller-network","192.168.1.1/24,192.168.1.1,8.8.8.8","-node-labels","{\"my-label\":\"my-value\"}"]}'
+        - '{"command":"/usr/local/bin/user-cluster-controller-manager","args":["-kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","-metrics-listen-address","0.0.0.0:8085","-health-listen-address","0.0.0.0:8086","-namespace","$(NAMESPACE)","-cluster-url","","-openvpn-server-port","30003","-overwrite-registry","","-openshift=false","-version","1.13.0","-cloud-provider-name","vsphere","-openvpn-ca-cert-file=/etc/kubernetes/pki/openvpn/ca.crt","-openvpn-ca-key-file=/etc/kubernetes/pki/openvpn/ca.key","-user-ssh-keys-dir-path=/etc/kubernetes/usersshkeys","--ipam-controller-network","192.168.1.1/24,192.168.1.1,8.8.8.8","-node-labels","{\"my-label\":\"my-value\"}"]}'
         command:
         - /http-prober-bin/http-prober
         env:
@@ -71,9 +70,6 @@ spec:
         - mountPath: /etc/kubernetes/kubeconfig
           name: internal-admin-kubeconfig
           readOnly: true
-        - mountPath: /etc/kubernetes/pki/ca
-          name: ca
-          readOnly: true
         - mountPath: /etc/kubernetes/pki/openvpn
           name: openvpn-ca
           readOnly: true
@@ -95,13 +91,11 @@ spec:
         volumeMounts:
         - mountPath: /http-prober-bin
           name: http-prober-bin
+      serviceAccountName: kubermatic-usercluster-controller-manager
       volumes:
       - name: internal-admin-kubeconfig
         secret:
           secretName: internal-admin-kubeconfig
-      - name: ca
-        secret:
-          secretName: ca
       - name: openvpn-ca
         secret:
           secretName: openvpn-ca

--- a/api/pkg/resources/test/fixtures/deployment-vsphere-1.13.0-usercluster-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-vsphere-1.13.0-usercluster-controller.yaml
@@ -24,7 +24,6 @@ spec:
         app: usercluster-controller
         cluster: de-test-01
         internal-admin-kubeconfig-secret-revision: "123456"
-        usersshkeys-secret-revision: "123456"
     spec:
       containers:
       - args:
@@ -38,7 +37,7 @@ spec:
         - -timeout
         - "1"
         - -command
-        - '{"command":"/usr/local/bin/user-cluster-controller-manager","args":["-kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","-metrics-listen-address","0.0.0.0:8085","-health-listen-address","0.0.0.0:8086","-namespace","$(NAMESPACE)","-cluster-url","","-openvpn-server-port","30003","-overwrite-registry","","-openshift=false","-version","1.13.0","-cloud-provider-name","vsphere","-user-ssh-keys-dir-path=/etc/kubernetes/usersshkeys","--ipam-controller-network","192.168.1.1/24,192.168.1.1,8.8.8.8","-node-labels","{\"my-label\":\"my-value\"}"]}'
+        - '{"command":"/usr/local/bin/user-cluster-controller-manager","args":["-kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","-metrics-listen-address","0.0.0.0:8085","-health-listen-address","0.0.0.0:8086","-namespace","$(NAMESPACE)","-cluster-url","","-openvpn-server-port","30003","-overwrite-registry","","-openshift=false","-version","1.13.0","-cloud-provider-name","vsphere","--ipam-controller-network","192.168.1.1/24,192.168.1.1,8.8.8.8","-node-labels","{\"my-label\":\"my-value\"}"]}'
         command:
         - /http-prober-bin/http-prober
         env:
@@ -69,9 +68,6 @@ spec:
         - mountPath: /etc/kubernetes/kubeconfig
           name: internal-admin-kubeconfig
           readOnly: true
-        - mountPath: /etc/kubernetes/usersshkeys
-          name: usersshkeys
-          readOnly: true
         - mountPath: /http-prober-bin
           name: http-prober-bin
       imagePullSecrets:
@@ -92,9 +88,6 @@ spec:
       - name: internal-admin-kubeconfig
         secret:
           secretName: internal-admin-kubeconfig
-      - name: usersshkeys
-        secret:
-          secretName: usersshkeys
       - emptyDir: {}
         name: http-prober-bin
 status: {}

--- a/api/pkg/resources/usercluster/deployment.go
+++ b/api/pkg/resources/usercluster/deployment.go
@@ -110,7 +110,6 @@ func DeploymentCreator(data userclusterControllerData, openshift bool) reconcili
 				fmt.Sprintf("-openshift=%t", openshift),
 				"-version", data.Cluster().Spec.Version.String(),
 				"-cloud-provider-name", data.GetKubernetesCloudProviderName(),
-				fmt.Sprintf("-user-ssh-keys-dir-path=%s", userSSHKeysMountDir),
 			}, getNetworkArgs(data)...)
 
 			labelArgsValue, err := getLabelsArgValue(data.Cluster())
@@ -166,11 +165,6 @@ func DeploymentCreator(data userclusterControllerData, openshift bool) reconcili
 							MountPath: "/etc/kubernetes/kubeconfig",
 							ReadOnly:  true,
 						},
-						{
-							Name:      resources.UserSSHKeys,
-							MountPath: userSSHKeysMountDir,
-							ReadOnly:  true,
-						},
 					},
 				},
 			}
@@ -194,14 +188,6 @@ func getVolumes() []corev1.Volume {
 			VolumeSource: corev1.VolumeSource{
 				Secret: &corev1.SecretVolumeSource{
 					SecretName: resources.InternalUserClusterAdminKubeconfigSecretName,
-				},
-			},
-		},
-		{
-			Name: resources.UserSSHKeys,
-			VolumeSource: corev1.VolumeSource{
-				Secret: &corev1.SecretVolumeSource{
-					SecretName: resources.UserSSHKeys,
 				},
 			},
 		},

--- a/api/pkg/resources/usercluster/deployment.go
+++ b/api/pkg/resources/usercluster/deployment.go
@@ -104,8 +104,6 @@ func DeploymentCreator(data userclusterControllerData, openshift bool) reconcili
 				"-metrics-listen-address", "0.0.0.0:8085",
 				"-health-listen-address", "0.0.0.0:8086",
 				"-namespace", "$(NAMESPACE)",
-				"-ca-cert", "/etc/kubernetes/pki/ca/ca.crt",
-				"-ca-key", "/etc/kubernetes/pki/ca/ca.key",
 				"-cluster-url", data.Cluster().Address.URL,
 				"-openvpn-server-port", fmt.Sprint(openvpnServerPort),
 				"-overwrite-registry", data.ImageRegistry(""),
@@ -171,11 +169,6 @@ func DeploymentCreator(data userclusterControllerData, openshift bool) reconcili
 							ReadOnly:  true,
 						},
 						{
-							Name:      resources.CASecretName,
-							MountPath: "/etc/kubernetes/pki/ca",
-							ReadOnly:  true,
-						},
-						{
 							Name:      resources.OpenVPNCASecretName,
 							MountPath: openvpnCAMountDir,
 							ReadOnly:  true,
@@ -208,14 +201,6 @@ func getVolumes() []corev1.Volume {
 			VolumeSource: corev1.VolumeSource{
 				Secret: &corev1.SecretVolumeSource{
 					SecretName: resources.InternalUserClusterAdminKubeconfigSecretName,
-				},
-			},
-		},
-		{
-			Name: resources.CASecretName,
-			VolumeSource: corev1.VolumeSource{
-				Secret: &corev1.SecretVolumeSource{
-					SecretName: resources.CASecretName,
 				},
 			},
 		},

--- a/api/pkg/resources/usercluster/deployment.go
+++ b/api/pkg/resources/usercluster/deployment.go
@@ -110,8 +110,6 @@ func DeploymentCreator(data userclusterControllerData, openshift bool) reconcili
 				fmt.Sprintf("-openshift=%t", openshift),
 				"-version", data.Cluster().Spec.Version.String(),
 				"-cloud-provider-name", data.GetKubernetesCloudProviderName(),
-				fmt.Sprintf("-openvpn-ca-cert-file=%s/%s", openvpnCAMountDir, resources.OpenVPNCACertKey),
-				fmt.Sprintf("-openvpn-ca-key-file=%s/%s", openvpnCAMountDir, resources.OpenVPNCAKeyKey),
 				fmt.Sprintf("-user-ssh-keys-dir-path=%s", userSSHKeysMountDir),
 			}, getNetworkArgs(data)...)
 
@@ -169,11 +167,6 @@ func DeploymentCreator(data userclusterControllerData, openshift bool) reconcili
 							ReadOnly:  true,
 						},
 						{
-							Name:      resources.OpenVPNCASecretName,
-							MountPath: openvpnCAMountDir,
-							ReadOnly:  true,
-						},
-						{
 							Name:      resources.UserSSHKeys,
 							MountPath: userSSHKeysMountDir,
 							ReadOnly:  true,
@@ -201,14 +194,6 @@ func getVolumes() []corev1.Volume {
 			VolumeSource: corev1.VolumeSource{
 				Secret: &corev1.SecretVolumeSource{
 					SecretName: resources.InternalUserClusterAdminKubeconfigSecretName,
-				},
-			},
-		},
-		{
-			Name: resources.OpenVPNCASecretName,
-			VolumeSource: corev1.VolumeSource{
-				Secret: &corev1.SecretVolumeSource{
-					SecretName: resources.OpenVPNCASecretName,
 				},
 			},
 		},

--- a/api/pkg/resources/usercluster/deployment.go
+++ b/api/pkg/resources/usercluster/deployment.go
@@ -31,11 +31,7 @@ var (
 	}
 )
 
-const (
-	name                = "usercluster-controller"
-	openvpnCAMountDir   = "/etc/kubernetes/pki/openvpn"
-	userSSHKeysMountDir = "/etc/kubernetes/usersshkeys"
-)
+const name = "usercluster-controller"
 
 // userclusterControllerData is the subet of the deploymentData interface
 // that is actually required by the usercluster deployment

--- a/api/pkg/resources/usercluster/deployment.go
+++ b/api/pkg/resources/usercluster/deployment.go
@@ -188,6 +188,7 @@ func DeploymentCreator(data userclusterControllerData, openshift bool) reconcili
 					},
 				},
 			}
+			dep.Spec.Template.Spec.ServiceAccountName = serviceAccountName
 
 			wrappedPodSpec, err := apiserver.IsRunningWrapper(data, dep.Spec.Template.Spec, sets.NewString(name))
 			if err != nil {

--- a/api/pkg/resources/usercluster/rbac.go
+++ b/api/pkg/resources/usercluster/rbac.go
@@ -1,0 +1,52 @@
+package usercluster
+
+import (
+	corev1 "k8s.io/api/core/v1"
+	rbacv1 "k8s.io/api/rbac/v1"
+
+	"github.com/kubermatic/kubermatic/api/pkg/resources/reconciling"
+)
+
+const (
+	serviceAccountName = "kubermatic-usercluster-controller-manager"
+	roleName           = "kubermatic:usercluster-controller-manager"
+	roleBindingName    = "kubermatic:usercluster-controller-manager"
+)
+
+func ServiceAccountCreator() (string, reconciling.ServiceAccountCreator) {
+	return serviceAccountName, func(sa *corev1.ServiceAccount) (*corev1.ServiceAccount, error) {
+		return sa, nil
+	}
+}
+
+func RoleCreator() (string, reconciling.RoleCreator) {
+	return roleName, func(r *rbacv1.Role) (*rbacv1.Role, error) {
+		r.Rules = []rbacv1.PolicyRule{{
+			APIGroups: []string{""},
+			Resources: []string{"secrets"},
+			Verbs: []string{
+				"get",
+				"list",
+				"watch",
+			},
+		}}
+		return r, nil
+	}
+}
+
+func RoleBindingCreator() (string, reconciling.RoleBindingCreator) {
+	return roleBindingName, func(rb *rbacv1.RoleBinding) (*rbacv1.RoleBinding, error) {
+		rb.RoleRef = rbacv1.RoleRef{
+			Name:     roleName,
+			Kind:     "Role",
+			APIGroup: rbacv1.GroupName,
+		}
+		rb.Subjects = []rbacv1.Subject{
+			{
+				Kind: rbacv1.ServiceAccountKind,
+				Name: serviceAccountName,
+			},
+		}
+		return rb, nil
+	}
+}


### PR DESCRIPTION
**What this PR does / why we need it**:

This PR:
* Creates a serviceaccount for the usercluster controller manager in the seed
* Sets up RBAC for it to allow Get/List/Watch of secrets in the namespace of the corresponding cluster
* Makes the UCCM watch secrets in its seed namespace
* Uses the seed client in the usercluster contrller manager to fetch the cluster and openvpn CAs

This is done in preparation for #4354 where we want to move management of seed resources that have their canonical source of truth in the usercluster into the UCCM, so we notice if anything changes.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Documentation**:
<!-- Add links to the related documentation changes related to this pull request. E.g. the link to the kubermatic/docs pullrequest. -->

**Does this PR introduce a user-facing change?**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If  no release note is required, just write "NONE".
-->
```release-note
none
```
