### PR TITLE
Add pprof endpoint to all binaries

### DIFF
--- a/api/cmd/kubeletdnat-controller/main.go
+++ b/api/cmd/kubeletdnat-controller/main.go
@@ -12,6 +12,7 @@ import (
 
 	"github.com/kubermatic/kubermatic/api/pkg/controller/kubeletdnat"
 	kubermaticlog "github.com/kubermatic/kubermatic/api/pkg/log"
+	"github.com/kubermatic/kubermatic/api/pkg/pprof"
 
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/util/wait"
@@ -23,6 +24,8 @@ import (
 )
 
 func main() {
+	pprofOpts := &pprof.Opts{}
+	pprofOpts.AddFlags(flag.CommandLine)
 	klog.InitFlags(nil)
 	kubeconfigFlag := flag.String("kubeconfig", "", "Path to a kubeconfig.")
 	master := flag.String("master", "", "The address of the Kubernetes API server. Overrides any value in kubeconfig")
@@ -86,6 +89,10 @@ func main() {
 
 	if err := kubeletdnat.Add(mgr, *chainNameFlag, nodeAccessNetwork, log, *vpnInterfaceFlag); err != nil {
 		log.Fatalw("failed to add the kubelet dnat controller", zap.Error(err))
+	}
+
+	if err := mgr.Add(pprofOpts); err != nil {
+		log.Fatalw("failed to add pprof endpoint", zap.Error(err))
 	}
 
 	if err := mgr.Start(signals.SetupSignalHandler()); err != nil {

--- a/api/cmd/kubermatic-api/main.go
+++ b/api/cmd/kubermatic-api/main.go
@@ -21,6 +21,7 @@ package main
 
 import (
 	"context"
+	"flag"
 	"fmt"
 	"net/http"
 	"os"
@@ -41,6 +42,7 @@ import (
 	"github.com/kubermatic/kubermatic/api/pkg/handler/v1/common"
 	kubermaticlog "github.com/kubermatic/kubermatic/api/pkg/log"
 	metricspkg "github.com/kubermatic/kubermatic/api/pkg/metrics"
+	"github.com/kubermatic/kubermatic/api/pkg/pprof"
 	"github.com/kubermatic/kubermatic/api/pkg/presets"
 	"github.com/kubermatic/kubermatic/api/pkg/provider"
 	kubernetesprovider "github.com/kubermatic/kubermatic/api/pkg/provider/kubernetes"
@@ -60,6 +62,8 @@ import (
 
 func main() {
 	klog.InitFlags(nil)
+	pprofOpts := &pprof.Opts{}
+	pprofOpts.AddFlags(flag.CommandLine)
 	options, err := newServerRunOptions()
 	if err != nil {
 		fmt.Printf("failed to create server run options due to = %v\n", err)
@@ -109,6 +113,12 @@ func main() {
 	if err != nil {
 		log.Fatalw("failed to create API Handler", "error", err)
 	}
+
+	go func() {
+		if err := pprofOpts.Start(make(chan struct{})); err != nil {
+			log.Fatalw("Failed to start pprof handler", zap.Error(err))
+		}
+	}()
 
 	go metricspkg.ServeForever(options.internalAddr, "/metrics")
 	log.Infow("the API server listening", "listenAddress", options.listenAddress)

--- a/api/cmd/kubermatic-operator/main.go
+++ b/api/cmd/kubermatic-operator/main.go
@@ -13,6 +13,7 @@ import (
 	seedcontrollerlifecycle "github.com/kubermatic/kubermatic/api/pkg/controller/seed-controller-lifecycle"
 	operatorv1alpha1 "github.com/kubermatic/kubermatic/api/pkg/crd/operator/v1alpha1"
 	kubermaticlog "github.com/kubermatic/kubermatic/api/pkg/log"
+	"github.com/kubermatic/kubermatic/api/pkg/pprof"
 	"github.com/kubermatic/kubermatic/api/pkg/provider"
 	"github.com/kubermatic/kubermatic/api/pkg/signals"
 
@@ -35,6 +36,8 @@ type controllerRunOptions struct {
 
 func main() {
 	klog.InitFlags(nil)
+	pprofOpts := &pprof.Opts{}
+	pprofOpts.AddFlags(flag.CommandLine)
 	opt := &controllerRunOptions{}
 	flag.StringVar(&opt.kubeconfig, "kubeconfig", "", "Path to a kubeconfig. Only required if outside of cluster.")
 	flag.StringVar(&opt.namespace, "namespace", "", "The namespace the operator runs in, uses to determine where to look for KubermaticConfigurations.")
@@ -71,6 +74,10 @@ func main() {
 	mgr, err := manager.New(config, manager.Options{MetricsBindAddress: opt.internalAddr})
 	if err != nil {
 		log.Fatalw("Failed to create Controller Manager instance: %v", err)
+	}
+
+	if err := mgr.Add(pprofOpts); err != nil {
+		log.Fatalw("Failed to pprof endpoint", zap.Error(err))
 	}
 
 	if err := operatorv1alpha1.AddToScheme(mgr.GetScheme()); err != nil {

--- a/api/cmd/kubermatic-operator/main.go
+++ b/api/cmd/kubermatic-operator/main.go
@@ -77,7 +77,7 @@ func main() {
 	}
 
 	if err := mgr.Add(pprofOpts); err != nil {
-		log.Fatalw("Failed to pprof endpoint", zap.Error(err))
+		log.Fatalw("Failed to add pprof endpoint", zap.Error(err))
 	}
 
 	if err := operatorv1alpha1.AddToScheme(mgr.GetScheme()); err != nil {

--- a/api/cmd/user-cluster-controller-manager/main.go
+++ b/api/cmd/user-cluster-controller-manager/main.go
@@ -26,6 +26,7 @@ import (
 	"github.com/kubermatic/kubermatic/api/pkg/controller/user-cluster-controller-manager/resources"
 	machinecontrolerresources "github.com/kubermatic/kubermatic/api/pkg/controller/user-cluster-controller-manager/resources/resources/machine-controller"
 	kubermaticlog "github.com/kubermatic/kubermatic/api/pkg/log"
+	"github.com/kubermatic/kubermatic/api/pkg/pprof"
 	"github.com/kubermatic/kubermatic/api/pkg/resources/reconciling"
 	clusterv1alpha1 "github.com/kubermatic/machine-controller/pkg/apis/cluster/v1alpha1"
 
@@ -62,6 +63,8 @@ type controllerRunOptions struct {
 func main() {
 	runOp := controllerRunOptions{}
 	klog.InitFlags(nil)
+	pprofOpts := &pprof.Opts{}
+	pprofOpts.AddFlags(flag.CommandLine)
 	flag.StringVar(&runOp.metricsListenAddr, "metrics-listen-address", "127.0.0.1:8085", "The address on which the internal HTTP /metrics server is running on")
 	flag.StringVar(&runOp.healthListenAddr, "health-listen-address", "127.0.0.1:8086", "The address on which the internal HTTP /ready & /live server is running on")
 	flag.BoolVar(&runOp.openshift, "openshift", false, "Whether the managed cluster is an openshift cluster")
@@ -141,6 +144,9 @@ func main() {
 	})
 	if err != nil {
 		log.Fatalw("Failed creating user cluster controller", zap.Error(err))
+	}
+	if err := mgr.Add(pprofOpts); err != nil {
+		log.Fatalw("Failed to add pprof handler", zap.Error(err))
 	}
 
 	var seedConfig *rest.Config

--- a/api/pkg/pprof/pprof.go
+++ b/api/pkg/pprof/pprof.go
@@ -1,0 +1,38 @@
+package pprof
+
+import (
+	"flag"
+	"net/http"
+	"net/http/pprof"
+
+	"sigs.k8s.io/controller-runtime/pkg/manager"
+)
+
+var _ manager.Runnable = &Opts{}
+var _ manager.LeaderElectionRunnable = &Opts{}
+
+type Opts struct {
+	ListenAddress string
+}
+
+func (opts *Opts) AddFlags(fs *flag.FlagSet) {
+	fs.StringVar(&opts.ListenAddress, "pprof-listen-address", ":6600", "The listen address for pprof. Set to `0` to disable it.")
+}
+
+func (opts *Opts) Start(stop <-chan struct{}) error {
+	if opts.ListenAddress == "" || opts.ListenAddress == "0" {
+		<-stop
+		return nil
+	}
+	mux := http.NewServeMux()
+	mux.HandleFunc("/debug/pprof/", pprof.Index)
+	mux.HandleFunc("/debug/pprof/cmdline", pprof.Cmdline)
+	mux.HandleFunc("/debug/pprof/profile", pprof.Profile)
+	mux.HandleFunc("/debug/pprof/symbol", pprof.Symbol)
+	mux.HandleFunc("/debug/pprof/trace", pprof.Trace)
+	return http.ListenAndServe(opts.ListenAddress, mux)
+}
+
+func (opts *Opts) NeedLeaderElection() bool {
+	return false
+}

--- a/config/kubermatic/Chart.yaml
+++ b/config/kubermatic/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: kubermatic
-version: 1.0.17
+version: 1.0.18
 appVersion: '__KUBERMATIC_TAG__'
 description: Kubermatic chart for master and/or seed clusters.
 keywords:

--- a/config/kubermatic/templates/kubermatic-api-dep.yaml
+++ b/config/kubermatic/templates/kubermatic-api-dep.yaml
@@ -67,6 +67,7 @@ spec:
         - -expose-strategy={{ .Values.kubermatic.exposeStrategy }}
         {{- end }}
         - -namespace=$(NAMESPACE)
+        - -pprof-listen-address={{ .Values.kubermatic.api.pprofEndpoint}}
         image: '{{ .Values.kubermatic.api.image.repository }}:{{ .Values.kubermatic.api.image.tag }}'
         imagePullPolicy: {{ .Values.kubermatic.api.image.pullPolicy }}
         env:

--- a/config/kubermatic/templates/kubermatic-controller-manager-dep.yaml
+++ b/config/kubermatic/templates/kubermatic-controller-manager-dep.yaml
@@ -123,6 +123,7 @@ spec:
         {{- else }}
         - -apiserver-reconciling-disabled-by-default=false
         {{- end }}
+        - -pprof-listen-address={{ .Values.kubermatic.controller.pprofEndpoint }}
         image: '{{ .Values.kubermatic.controller.image.repository }}:{{ .Values.kubermatic.controller.image.tag }}'
         imagePullPolicy: {{ .Values.kubermatic.controller.image.pullPolicy }}
         env:

--- a/config/kubermatic/templates/master-controller-manager-dep.yaml
+++ b/config/kubermatic/templates/master-controller-manager-dep.yaml
@@ -48,6 +48,7 @@ spec:
         {{- else }}
         - -v=2
         {{- end }}
+        - -pprof-listen-address={{ .Values.kubermatic.masterController.pprofEndpoint }}
         image: '{{ .Values.kubermatic.masterController.image.repository }}:{{ .Values.kubermatic.masterController.image.tag }}'
         imagePullPolicy: {{ .Values.kubermatic.masterController.image.pullPolicy }}
         env:

--- a/config/kubermatic/values.yaml
+++ b/config/kubermatic/values.yaml
@@ -79,6 +79,7 @@ kubermatic:
       repository: "quay.io/kubermatic/api"
       tag: "__KUBERMATIC_TAG__"
       pullPolicy: "IfNotPresent"
+    pprofEndpoint: ":6600"
     addons:
       kubernetes:
         # list of Addons to install into every user-cluster. All need to exist in the addons image
@@ -159,6 +160,7 @@ kubermatic:
       limits:
         cpu: 250m
         memory: 1024Mi
+    pprofEndpoint: ":6600"
     affinity:
       nodeAffinity:
         preferredDuringSchedulingIgnoredDuringExecution:
@@ -268,6 +270,7 @@ kubermatic:
         cpu: 100m
         memory: 256Mi
     debugLog: false
+    pprofEndpoint: ":6600"
     workerCount: 20
     affinity: {}
     nodeSelector: {}


### PR DESCRIPTION
**What this PR does / why we need it**:

Adds a pprof endpoint on `:6600` to the kubermatic api, controller-manager and master-controller-manager

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Documentation**:
<!-- Add links to the related documentation changes related to this pull request. E.g. the link to the kubermatic/docs pullrequest. -->

**Does this PR introduce a user-facing change?**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If  no release note is required, just write "NONE".
-->
```release-note
The kubermatic components now serve pprof debug data on port 6600
```
