### PR TITLE
Fix cluster and addon collector to work without requiring leader lease

### DIFF
--- a/api/cmd/kubermatic-controller-manager/main.go
+++ b/api/cmd/kubermatic-controller-manager/main.go
@@ -175,11 +175,14 @@ Please install the VerticalPodAutoscaler according to the documentation: https:/
 		log.Fatalw("Could not create all controllers", zap.Error(err))
 	}
 
+	// Use the API reader as the cache-backed reader will only contain data when we are leader
+	// and return errors otherwise.
+	// Ideally, the cache wouldn't require the leader lease:
+	// https://github.com/kubernetes-sigs/controller-runtime/issues/677
 	log.Debug("Starting clusters collector")
-	collectors.MustRegisterClusterCollector(prometheus.DefaultRegisterer, ctrlCtx.mgr.GetClient())
-
+	collectors.MustRegisterClusterCollector(prometheus.DefaultRegisterer, ctrlCtx.mgr.GetAPIReader())
 	log.Debug("Starting addons collector")
-	collectors.MustRegisterAddonCollector(prometheus.DefaultRegisterer, ctrlCtx.mgr.GetClient())
+	collectors.MustRegisterAddonCollector(prometheus.DefaultRegisterer, ctrlCtx.mgr.GetAPIReader())
 
 	var g run.Group
 	// This group is forever waiting in a goroutine for signals to stop

--- a/api/pkg/collectors/addon.go
+++ b/api/pkg/collectors/addon.go
@@ -16,7 +16,7 @@ const (
 
 // AddonCollector exports metrics for addon resources
 type AddonCollector struct {
-	client ctrlruntimeclient.Client
+	client ctrlruntimeclient.Reader
 
 	addonCreated *prometheus.Desc
 	addonDeleted *prometheus.Desc

--- a/api/pkg/collectors/addon.go
+++ b/api/pkg/collectors/addon.go
@@ -23,7 +23,7 @@ type AddonCollector struct {
 }
 
 // MustRegisterAddonCollector registers the addon collector at the given prometheus registry
-func MustRegisterAddonCollector(registry prometheus.Registerer, client ctrlruntimeclient.Client) {
+func MustRegisterAddonCollector(registry prometheus.Registerer, client ctrlruntimeclient.Reader) {
 	cc := &AddonCollector{
 		client: client,
 		addonCreated: prometheus.NewDesc(

--- a/api/pkg/collectors/cluster.go
+++ b/api/pkg/collectors/cluster.go
@@ -26,7 +26,7 @@ type ClusterCollector struct {
 }
 
 // MustRegisterClusterCollector registers the cluster collector at the given prometheus registry
-func MustRegisterClusterCollector(registry prometheus.Registerer, client ctrlruntimeclient.Client) {
+func MustRegisterClusterCollector(registry prometheus.Registerer, client ctrlruntimeclient.Reader) {
 	cc := &ClusterCollector{
 		client: client,
 		clusterCreated: prometheus.NewDesc(

--- a/api/pkg/collectors/cluster.go
+++ b/api/pkg/collectors/cluster.go
@@ -18,7 +18,7 @@ const (
 
 // ClusterCollector exports metrics for cluster resources
 type ClusterCollector struct {
-	client ctrlruntimeclient.Client
+	client ctrlruntimeclient.Reader
 
 	clusterCreated *prometheus.Desc
 	clusterDeleted *prometheus.Desc


### PR DESCRIPTION
**What this PR does / why we need it**:

Currently, if we scape a kubermatic-controller manager without lease, it doesn't work and returns no data:

```
E1111 16:27:13.616965       1 cluster.go:75] failed to list clusters from clusterLister in ClusterCollector: the cache is not started, can not read objects
E1111 16:27:13.617171       1 addon.go:56] failed to list clusters from clusterLister in AddonCollector: the cache is not started, can not read objects
```

This PR changes it to use the API client instead, to avoid this issue. Ideally, the cache-backed reader wouldn't require leader election, I've opened an issue on upstream controller-runtime for this.
**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Documentation**:
<!-- Add links to the related documentation changes related to this pull request. E.g. the link to the kubermatic/docs pullrequest. -->

**Does this PR introduce a user-facing change?**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If  no release note is required, just write "NONE".
-->
```release-note
none
```
