### PR TITLE
Fix seed-validation cluster check

### DIFF
--- a/api/pkg/validation/seed/seed.go
+++ b/api/pkg/validation/seed/seed.go
@@ -55,30 +55,37 @@ func (sv *seedValidator) Validate(seed *kubermaticv1.Seed, isDelete bool) error 
 	return sv.validate(seed, client, seeds, isDelete)
 }
 
-func (sv *seedValidator) validate(seed *kubermaticv1.Seed, seedClient ctrlruntimeclient.Client, existingSeeds map[string]*kubermaticv1.Seed, isDelete bool) error {
-	// this can be nil on fresh seed clusters
-	existingSeed := existingSeeds[seed.Name]
+func (sv *seedValidator) validate(subject *kubermaticv1.Seed, seedClient ctrlruntimeclient.Client, existingSeeds map[string]*kubermaticv1.Seed, isDelete bool) error {
+	// this can be nil on new seed clusters
+	existingSeed := existingSeeds[subject.Name]
 
 	// remove the seed itself from the list, so uniqueness checks won't fail
-	delete(existingSeeds, seed.Name)
+	delete(existingSeeds, subject.Name)
 
-	ourDatacenters := sets.NewString()
-	for datacenter := range seed.Spec.Datacenters {
-		ourDatacenters.Insert(datacenter)
+	// collect datacenter names
+	subjectDatacenters := sets.NewString()
+	existingDatacenters := sets.NewString()
+
+	if !isDelete {
+		// this has no effect on the DC uniqueness check, but makes the
+		// cluster-remaining-in-DC check easier
+		subjectDatacenters = sets.StringKeySet(subject.Spec.Datacenters)
 	}
 
-	// check if all the DCs in the seed are unique
-	for _, s := range existingSeeds {
-		for dc := range s.Spec.Datacenters {
-			if ourDatacenters.Has(dc) {
-				return fmt.Errorf("datacenter %q already exists in seed %q, can only have one datacenter with a given name", dc, s.Name)
-			}
+	// check if the subject introduces a datacenter that already exists
+	for _, existingSeed := range existingSeeds {
+		datacenters := sets.StringKeySet(existingSeed.Spec.Datacenters)
+
+		if duplicates := subjectDatacenters.Intersection(datacenters); duplicates.Len() > 0 {
+			return fmt.Errorf("seed redefines existing datacenters %v from seed %q; datacenter names must be globally unique", duplicates.List(), existingSeed.Name)
 		}
+
+		existingDatacenters = existingDatacenters.Union(datacenters)
 	}
 
 	// check if all DCs have exactly one provider and that the provider
 	// is never changed after it has been set once
-	for dcName, dc := range seed.Spec.Datacenters {
+	for dcName, dc := range subject.Spec.Datacenters {
 		providerName, err := provider.DatacenterCloudProviderName(&dc.Spec)
 		if err != nil {
 			return fmt.Errorf("datacenter %q is invalid: %v", dcName, err)
@@ -108,14 +115,13 @@ func (sv *seedValidator) validate(seed *kubermaticv1.Seed, seedClient ctrlruntim
 		return fmt.Errorf("failed to list clusters: %v", err)
 	}
 
-	for _, cluster := range clusters.Items {
-		if !ourDatacenters.Has(cluster.Spec.Cloud.DatacenterName) {
-			return fmt.Errorf("datacenter %q is still in use, cannot delete it", cluster.Spec.Cloud.DatacenterName)
-		}
-	}
+	// list of all datacenters after the seed would have been persisted
+	finalDatacenters := subjectDatacenters.Union(existingDatacenters)
 
-	if isDelete && len(clusters.Items) > 0 {
-		return fmt.Errorf("can not delete seed, there are still %d clusters in it", len(clusters.Items))
+	for _, cluster := range clusters.Items {
+		if !finalDatacenters.Has(cluster.Spec.Cloud.DatacenterName) {
+			return fmt.Errorf("datacenter %q is still in use by cluster %q, cannot delete it", cluster.Spec.Cloud.DatacenterName, cluster.Name)
+		}
 	}
 
 	return nil

--- a/api/pkg/validation/seed/seed_test.go
+++ b/api/pkg/validation/seed/seed_test.go
@@ -74,6 +74,91 @@ func TestValidate(t *testing.T) {
 			},
 		},
 		{
+			name: "Clusters from other seeds should have no effect on new empty seeds",
+			existingSeeds: map[string]*kubermaticv1.Seed{
+				"europe-west3-c": {
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "europe-west3-c",
+					},
+					Spec: kubermaticv1.SeedSpec{
+						Datacenters: map[string]kubermaticv1.Datacenter{
+							"do-fra1": {
+								Spec: fakeProviderSpec,
+							},
+						},
+					},
+				},
+			},
+			existingClusters: []runtime.Object{
+				&kubermaticv1.Cluster{
+					Spec: kubermaticv1.ClusterSpec{
+						Cloud: kubermaticv1.CloudSpec{
+							DatacenterName: "do-fra1",
+						},
+					},
+				},
+			},
+			seedToValidate: &kubermaticv1.Seed{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "asia-south1-a",
+				},
+				Spec: kubermaticv1.SeedSpec{
+					Datacenters: map[string]kubermaticv1.Datacenter{},
+				},
+			},
+		},
+		{
+			name: "Clusters from other seeds should have no effect when deleting seeds",
+			existingSeeds: map[string]*kubermaticv1.Seed{
+				"europe-west3-c": {
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "europe-west3-c",
+					},
+					Spec: kubermaticv1.SeedSpec{
+						Datacenters: map[string]kubermaticv1.Datacenter{
+							"do-fra1": {
+								Spec: fakeProviderSpec,
+							},
+						},
+					},
+				},
+				"asia-south1-a": {
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "asia-south1-a",
+					},
+					Spec: kubermaticv1.SeedSpec{
+						Datacenters: map[string]kubermaticv1.Datacenter{
+							"aws-asia-south1-a": {
+								Spec: fakeProviderSpec,
+							},
+						},
+					},
+				},
+			},
+			existingClusters: []runtime.Object{
+				&kubermaticv1.Cluster{
+					Spec: kubermaticv1.ClusterSpec{
+						Cloud: kubermaticv1.CloudSpec{
+							DatacenterName: "do-fra1",
+						},
+					},
+				},
+			},
+			seedToValidate: &kubermaticv1.Seed{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "asia-south1-a",
+				},
+				Spec: kubermaticv1.SeedSpec{
+					Datacenters: map[string]kubermaticv1.Datacenter{
+						"aws-asia-south1-a": {
+							Spec: fakeProviderSpec,
+						},
+					},
+				},
+			},
+			isDelete: true,
+		},
+		{
 			name: "Adding new datacenter should be possible",
 			existingSeeds: map[string]*kubermaticv1.Seed{
 				"existing-seed": {


### PR DESCRIPTION
**What this PR does / why we need it**:
For testing the operator, I wanted to create a test seed in my own testing namespace on dev. The current webhook however rejected this Seed:

```yaml
apiVersion: kubermatic.k8s.io/v1
kind: Seed
metadata:
  name: xrstf-europe
  namespace: xrstf
spec:
  country: DE
  location: Hamburg
  datacenters: {}
  kubeconfig:
    apiVersion: v1
    fieldPath: kubeconfig
    kind: Secret
    name: kubeconfig-europe
    namespace: xrstf
```

Error message was:

```
Error from server: error when creating "eu.yaml": admission webhook "seeds.kubermatic.io" denied the request: datacenter "do-fra1" is still in use, cannot delete it
```

The root cause was that the cluster-existence check was just checking *all* clusters against the subject Seed, and of course the subject does not neccessarily have datacenters for all clusters.

**Does this PR introduce a user-facing change?**:
```release-note
Fix Seed Validation Webhook rejecting new Seeds in certain situations
```
