### PR TITLE
client-sync: remove not-posix parameter from the script

### DIFF
--- a/api/hack/ci/ci-sync-apiclient.sh
+++ b/api/hack/ci/ci-sync-apiclient.sh
@@ -34,7 +34,7 @@ if [ -n "$(git rev-parse --show-prefix)" ]; then
 fi
 
 # clone the target and pick the right branch
-tempdir="$(mktemp -d --suffix "-apiclient-sync")"
+tempdir="$(mktemp -d)"
 trap "rm -rf '$tempdir'" EXIT
 git clone "$URL" "$tempdir"
 (


### PR DESCRIPTION
Apparently the `--suffix` param is a GNU thing and doesn't exist in busybox mktemp.

```release-note
NONE
```
