### PR TITLE
CI scripts: use hardcoded Github hostkey

### DIFF
--- a/api/hack/ci/ci-sync-apiclient.sh
+++ b/api/hack/ci/ci-sync-apiclient.sh
@@ -2,6 +2,8 @@
 
 set -eu
 
+. $(dirname $0)/../lib.sh
+
 URL="git@github.com:kubermatic/go-kubermatic.git"
 
 commit_and_push() {
@@ -15,7 +17,7 @@ commit_and_push() {
 
         git config --local user.email "dev@loodse.com"
         git config --local user.name "Prow CI Robot"
-        git config --local core.sshCommand 'ssh -o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no -i /ssh/id_rsa'
+        git config --local core.sshCommand 'ssh -o CheckHostIP=no -i /ssh/id_rsa'
 
         git add .
         git commit -m "Syncing client from Kubermatic $source_sha"
@@ -33,10 +35,13 @@ if [ -n "$(git rev-parse --show-prefix)" ]; then
     exit 1
 fi
 
+# Ensure Github's host key is available and disable IP checking.
+ensure_github_host_pubkey
+
 # clone the target and pick the right branch
 tempdir="$(mktemp -d)"
 trap "rm -rf '$tempdir'" EXIT
-git clone "$URL" "$tempdir"
+GIT_SSH_COMMAND="ssh -o CheckHostIP=no -i /ssh/id_rsa" git clone "$URL" "$tempdir"
 (
     cd "$tempdir"
     git checkout "$PULL_BASE_REF" || git checkout -b "$PULL_BASE_REF"

--- a/api/hack/ci/ci-sync-charts.sh
+++ b/api/hack/ci/ci-sync-charts.sh
@@ -10,7 +10,8 @@ export LATEST_VERSION=$(git describe --tags --abbrev=0)
 sed -i "s/__KUBERMATIC_TAG__/$LATEST_VERSION/g" config/*/*.yaml
 git config --global user.email "dev@loodse.com"
 git config --global user.name "Prow CI Robot"
-git config --global core.sshCommand 'ssh -o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no -i /ssh/id_rsa'
+git config --global core.sshCommand 'ssh -o CheckHostIP=no -i /ssh/id_rsa'
+ensure_github_host_pubkey
 
 if ! git describe --exact-match --tags HEAD &>/dev/null; then
   echo "No tag matches current HEAD, exitting..."

--- a/api/hack/ci/ci-update-docs.sh
+++ b/api/hack/ci/ci-update-docs.sh
@@ -10,7 +10,8 @@ REVISION=$(git rev-parse --short HEAD)
 # configure Git
 git config --global user.email "dev@loodse.com"
 git config --global user.name "Prow CI Robot"
-git config --global core.sshCommand 'ssh -o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no -i /ssh/id_rsa'
+git config --global core.sshCommand 'ssh -o CheckHostIP=no -i /ssh/id_rsa'
+ensure_github_host_pubkey
 
 # create a fresh clone
 git clone git@github.com:kubermatic/docs.git $TARGET_DIR

--- a/api/hack/lib.sh
+++ b/api/hack/lib.sh
@@ -62,10 +62,28 @@ write_junit() {
 EOF
 }
 
+ensure_github_host_pubkey() {
+  # check whether we already have a known_hosts entry for Github
+  if ssh-keygen -F github.com >/dev/null 2>&1; then
+    echo " [*] Github's SSH host key already present" >/dev/stderr
+  else
+    local github_rsa_key
+    # https://help.github.com/en/github/authenticating-to-github/githubs-ssh-key-fingerprints
+    github_rsa_key="github.com ssh-rsa AAAAB3NzaC1yc2EAAAABIwAAAQEAq2A7hRGmdnm9tUDbO9IDSwBK6TbQa+PXYPCPy6rbTrTtw7PHkccKrpp0yVhp5HdEIcKr6pLlVDBfOLX9QUsyCOV0wzfjIJNlGEYsdlLJizHhbn2mUjvSAHQqZETYP81eFzLQNnPHt4EVVUh7VfDESU84KezmD5QlWpXLmvU31/yMf+Se8xhHTvKSCZIFImWwoG6mbUoWf9nzpIoaSjB+weqqUUmpaaasXVal72J+UX2B+2RPW3RcT0eOzQgqlJL3RKrTJvdsjE3JEAvGq3lGHSZXy28G3skua2SmVi/w4yCE6gbODqnTWlg7+wC604ydGXA8VJiS5ap43JXiUFFAaQ=="
+
+    echo " [*] Adding Github's SSH host key to known hosts" >/dev/stderr
+    mkdir -p "$HOME/.ssh"
+    chmod 700 "$HOME/.ssh"
+    echo "$github_rsa_key" >> "$HOME/.ssh/known_hosts"
+    chmod 600 "$HOME/.ssh/known_hosts"
+  fi
+}
+
 get_latest_dashboard_tag() {
   FOR_BRANCH="$1"
 
-  git config --global core.sshCommand 'ssh -o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no -i /ssh/id_rsa'
+  ensure_github_host_pubkey
+  git config --global core.sshCommand 'ssh -o CheckHostIP=no -i /ssh/id_rsa'
   local DASHBOARD_URL="git@github.com:kubermatic/dashboard-v2.git"
 
   MINOR_VERSION="${FOR_BRANCH##release/}"
@@ -85,7 +103,8 @@ get_latest_dashboard_tag() {
 get_latest_dashboard_hash() {
   FOR_BRANCH="$1"
 
-  git config --global core.sshCommand 'ssh -o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no -i /ssh/id_rsa'
+  ensure_github_host_pubkey
+  git config --global core.sshCommand 'ssh -o CheckHostIP=no -i /ssh/id_rsa'
   local DASHBOARD_URL="git@github.com:kubermatic/dashboard-v2.git"
 
   # `local` always sets the rc to 0, so declare as local _before_ doing the substitution

--- a/api/hack/run-kubermatic-upgrade-test.sh
+++ b/api/hack/run-kubermatic-upgrade-test.sh
@@ -11,7 +11,8 @@ cd $(go env GOPATH)/src/github.com/kubermatic/kubermatic/api/hack/ci
 export UPGRADE_TEST_BASE_HASH=${UPGRADE_TEST_BASE_HASH:-"master"}
 
 # We need to fetch UPGRADE_TEST_BASE_HASH in case its not in either the PRs base or the Prs HEAD
-git config --global core.sshCommand 'ssh -o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no -i /ssh/id_rsa'
+ensure_github_host_pubkey
+git config --global core.sshCommand 'ssh -o CheckHostIP=no -i /ssh/id_rsa'
 git remote add origin git@github.com:kubermatic/kubermatic.git
 git fetch origin ${UPGRADE_TEST_BASE_HASH}
 


### PR DESCRIPTION
Now we no longer skip hostkey checking when contacting Github.

```release-note
NONE
```

/assign @alvaroaleman 