### PR TITLE
ci-update-docs: source missing bash lib

### DIFF
--- a/api/hack/ci/ci-update-docs.sh
+++ b/api/hack/ci/ci-update-docs.sh
@@ -2,6 +2,8 @@
 
 set -euo pipefail
 
+source $(dirname $0)/../lib.sh
+
 cd $(dirname $0)/../../..
 
 TARGET_DIR=docs_sync


### PR DESCRIPTION
**What this PR does / why we need it**:
I've switched this script to adding the hardcoded Github host pubkey using a function from `lib.sh`, but forgot to make sure the lib is actually getting sourced.

```release-note
NONE
```
