### PR TITLE
Fix update docs script

### DIFF
--- a/api/hack/ci/ci-update-docs.sh
+++ b/api/hack/ci/ci-update-docs.sh
@@ -4,6 +4,8 @@ set -euo pipefail
 
 cd $(dirname $0)/../../..
 
+source $(dirname $0)/../lib.sh
+
 TARGET_DIR=docs_sync
 REVISION=$(git rev-parse --short HEAD)
 


### PR DESCRIPTION
**What this PR does / why we need it**:

Fixes the update docs script to not error out with `./api/hack/ci/ci-update-docs.sh: line 14: ensure_github_host_pubkey: command not found` anymore.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Documentation**:
<!-- Add links to the related documentation changes related to this pull request. E.g. the link to the kubermatic/docs pullrequest. -->

**Does this PR introduce a user-facing change?**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If  no release note is required, just write "NONE".
-->
```release-note
none
```
