### PR TITLE
sync-api client: exit with success if there's nothing to sync

### DIFF
--- a/api/hack/ci/ci-sync-apiclient.sh
+++ b/api/hack/ci/ci-sync-apiclient.sh
@@ -20,8 +20,10 @@ commit_and_push() {
         git config --local core.sshCommand 'ssh -o CheckHostIP=no -i /ssh/id_rsa'
 
         git add .
-        git commit -m "Syncing client from Kubermatic $source_sha"
-        git push origin "$branch"
+        if ! git status | grep -q 'nothing to commit'; then
+            git commit -m "Syncing client from Kubermatic $source_sha"
+            git push origin "$branch"
+        fi
     )
 }
 


### PR DESCRIPTION
**What this PR does / why we need it**:
`git commit` will return an error code if there are no staged changes.

```release-note
NONE
```
