### PR TITLE
allow get global settings for no admin user

### DIFF
--- a/api/pkg/handler/routes_v1_admin.go
+++ b/api/pkg/handler/routes_v1_admin.go
@@ -49,7 +49,7 @@ func (r Routing) getKubermaticSettings() http.Handler {
 		endpoint.Chain(
 			middleware.TokenVerifier(r.tokenVerifiers),
 			middleware.UserSaver(r.userProvider),
-		)(admin.KubermaticSettingsEndpoint(r.userInfoGetter, r.settingsProvider)),
+		)(admin.KubermaticSettingsEndpoint(r.settingsProvider)),
 		decodeEmptyReq,
 		encodeJSON,
 		r.defaultServerOptions()...,

--- a/api/pkg/handler/v1/admin/settings.go
+++ b/api/pkg/handler/v1/admin/settings.go
@@ -17,14 +17,9 @@ import (
 )
 
 // KubermaticSettingsEndpoint returns global settings
-func KubermaticSettingsEndpoint(userInfoGetter provider.UserInfoGetter, settingsProvider provider.SettingsProvider) endpoint.Endpoint {
+func KubermaticSettingsEndpoint(settingsProvider provider.SettingsProvider) endpoint.Endpoint {
 	return func(ctx context.Context, request interface{}) (interface{}, error) {
-		userInfo, err := userInfoGetter(ctx, "")
-		if err != nil {
-			return nil, common.KubernetesErrorToHTTPError(err)
-		}
-
-		globalSettings, err := settingsProvider.GetGlobalSettings(userInfo)
+		globalSettings, err := settingsProvider.GetGlobalSettings()
 		if err != nil {
 			return nil, common.KubernetesErrorToHTTPError(err)
 		}
@@ -42,7 +37,7 @@ func UpdateKubermaticSettingsEndpoint(userInfoGetter provider.UserInfoGetter, se
 			return nil, common.KubernetesErrorToHTTPError(err)
 		}
 
-		existingGlobalSettings, err := settingsProvider.GetGlobalSettings(userInfo)
+		existingGlobalSettings, err := settingsProvider.GetGlobalSettings()
 		if err != nil {
 			return nil, common.KubernetesErrorToHTTPError(err)
 		}

--- a/api/pkg/handler/v1/admin/settings_test.go
+++ b/api/pkg/handler/v1/admin/settings_test.go
@@ -27,23 +27,15 @@ func TestGetGlobalSettings(t *testing.T) {
 	}{
 		// scenario 1
 		{
-			name:                   "scenario 1: unauthorized user gets settings",
-			expectedResponse:       `{"error":{"code":403,"message":"forbidden: \"bob@acme.com\" doesn't have admin rights"}}`,
-			httpStatus:             http.StatusForbidden,
-			existingKubermaticObjs: test.GenDefaultKubermaticObjects(),
-			existingAPIUser:        test.GenDefaultAPIUser(),
-		},
-		// scenario 2
-		{
-			name:                   "scenario 2: authorized user gets settings first time",
+			name:                   "scenario 1: user gets settings first time",
 			expectedResponse:       `{"customLinks":[],"cleanupOptions":{"Enabled":false,"Enforced":false},"defaultNodeCount":10,"clusterTypeOptions":10,"displayDemoInfo":false,"displayAPIDocs":false,"displayTermsOfService":false}`,
 			httpStatus:             http.StatusOK,
 			existingKubermaticObjs: []runtime.Object{genUser("Bob", "bob@acme.com", true)},
 			existingAPIUser:        test.GenDefaultAPIUser(),
 		},
-		// scenario 3
+		// scenario 2
 		{
-			name:             "scenario 3: authorized user gets existing global settings",
+			name:             "scenario 2: user gets existing global settings",
 			expectedResponse: `{"customLinks":[{"label":"label","url":"url:label","icon":"icon","location":"EU"}],"cleanupOptions":{"Enabled":true,"Enforced":true},"defaultNodeCount":5,"clusterTypeOptions":5,"displayDemoInfo":true,"displayAPIDocs":true,"displayTermsOfService":true}`,
 			httpStatus:       http.StatusOK,
 			existingKubermaticObjs: []runtime.Object{genUser("Bob", "bob@acme.com", true),
@@ -90,6 +82,7 @@ func TestUpdateGlobalSettings(t *testing.T) {
 		// scenario 1
 		{
 			name:                   "scenario 1: unauthorized user updates settings",
+			body:                   `{"customLinks":[{"label":"label","url":"url:label","icon":"icon","location":"EU"}],"cleanupOptions":{"Enabled":true,"Enforced":true},"defaultNodeCount":100,"clusterTypeOptions":20,"displayDemoInfo":false,"displayAPIDocs":false,"displayTermsOfService":true}`,
 			expectedResponse:       `{"error":{"code":403,"message":"forbidden: \"bob@acme.com\" doesn't have admin rights"}}`,
 			httpStatus:             http.StatusForbidden,
 			existingKubermaticObjs: test.GenDefaultKubermaticObjects(),

--- a/api/pkg/provider/kubernetes/settings.go
+++ b/api/pkg/provider/kubernetes/settings.go
@@ -27,10 +27,7 @@ func NewSettingsProvider(client kubermaticclientset.Interface, settingsLister ku
 	}
 }
 
-func (s *SettingsProvider) GetGlobalSettings(userInfo *provider.UserInfo) (*kubermaticv1.KubermaticSetting, error) {
-	if !userInfo.IsAdmin {
-		return nil, kerrors.NewForbidden(schema.GroupResource{}, userInfo.Email, fmt.Errorf("%q doesn't have admin rights", userInfo.Email))
-	}
+func (s *SettingsProvider) GetGlobalSettings() (*kubermaticv1.KubermaticSetting, error) {
 	settings, err := s.settingsLister.Get(kubermaticv1.GlobalSettingsName)
 	if err != nil {
 		if kerrors.IsNotFound(err) {

--- a/api/pkg/provider/types.go
+++ b/api/pkg/provider/types.go
@@ -481,7 +481,7 @@ type AddonProvider interface {
 
 // SettingsProvider declares the set of methods for interacting global settings
 type SettingsProvider interface {
-	GetGlobalSettings(userInfo *UserInfo) (*kubermaticv1.KubermaticSetting, error)
+	GetGlobalSettings() (*kubermaticv1.KubermaticSetting, error)
 	UpdateGlobalSettings(userInfo *UserInfo, settings *kubermaticv1.KubermaticSetting) (*kubermaticv1.KubermaticSetting, error)
 }
 


### PR DESCRIPTION
**What this PR does / why we need it**: allow get global settings for no admin user

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

```release-note
NONE
```
