### PR TITLE
Prometheus 2.14

### DIFF
--- a/api/pkg/resources/prometheus/statefulset.go
+++ b/api/pkg/resources/prometheus/statefulset.go
@@ -15,7 +15,7 @@ import (
 
 const (
 	name = "prometheus"
-	tag  = "v2.9.2"
+	tag  = "v2.14.0"
 
 	volumeConfigName = "config"
 	volumeDataName   = "data"

--- a/api/pkg/resources/test/fixtures/statefulset-aws-1.10.0-prometheus.yaml
+++ b/api/pkg/resources/test/fixtures/statefulset-aws-1.10.0-prometheus.yaml
@@ -38,7 +38,7 @@ spec:
         - --web.enable-lifecycle
         - --storage.tsdb.no-lockfile
         - --web.route-prefix=/
-        image: quay.io/prometheus/prometheus:v2.9.2
+        image: quay.io/prometheus/prometheus:v2.14.0
         livenessProbe:
           failureThreshold: 10
           httpGet:

--- a/api/pkg/resources/test/fixtures/statefulset-aws-1.10.6-prometheus.yaml
+++ b/api/pkg/resources/test/fixtures/statefulset-aws-1.10.6-prometheus.yaml
@@ -38,7 +38,7 @@ spec:
         - --web.enable-lifecycle
         - --storage.tsdb.no-lockfile
         - --web.route-prefix=/
-        image: quay.io/prometheus/prometheus:v2.9.2
+        image: quay.io/prometheus/prometheus:v2.14.0
         livenessProbe:
           failureThreshold: 10
           httpGet:

--- a/api/pkg/resources/test/fixtures/statefulset-aws-1.11.0-prometheus.yaml
+++ b/api/pkg/resources/test/fixtures/statefulset-aws-1.11.0-prometheus.yaml
@@ -38,7 +38,7 @@ spec:
         - --web.enable-lifecycle
         - --storage.tsdb.no-lockfile
         - --web.route-prefix=/
-        image: quay.io/prometheus/prometheus:v2.9.2
+        image: quay.io/prometheus/prometheus:v2.14.0
         livenessProbe:
           failureThreshold: 10
           httpGet:

--- a/api/pkg/resources/test/fixtures/statefulset-aws-1.11.1-prometheus.yaml
+++ b/api/pkg/resources/test/fixtures/statefulset-aws-1.11.1-prometheus.yaml
@@ -38,7 +38,7 @@ spec:
         - --web.enable-lifecycle
         - --storage.tsdb.no-lockfile
         - --web.route-prefix=/
-        image: quay.io/prometheus/prometheus:v2.9.2
+        image: quay.io/prometheus/prometheus:v2.14.0
         livenessProbe:
           failureThreshold: 10
           httpGet:

--- a/api/pkg/resources/test/fixtures/statefulset-aws-1.12.0-prometheus.yaml
+++ b/api/pkg/resources/test/fixtures/statefulset-aws-1.12.0-prometheus.yaml
@@ -38,7 +38,7 @@ spec:
         - --web.enable-lifecycle
         - --storage.tsdb.no-lockfile
         - --web.route-prefix=/
-        image: quay.io/prometheus/prometheus:v2.9.2
+        image: quay.io/prometheus/prometheus:v2.14.0
         livenessProbe:
           failureThreshold: 10
           httpGet:

--- a/api/pkg/resources/test/fixtures/statefulset-aws-1.13.0-prometheus.yaml
+++ b/api/pkg/resources/test/fixtures/statefulset-aws-1.13.0-prometheus.yaml
@@ -38,7 +38,7 @@ spec:
         - --web.enable-lifecycle
         - --storage.tsdb.no-lockfile
         - --web.route-prefix=/
-        image: quay.io/prometheus/prometheus:v2.9.2
+        image: quay.io/prometheus/prometheus:v2.14.0
         livenessProbe:
           failureThreshold: 10
           httpGet:

--- a/api/pkg/resources/test/fixtures/statefulset-azure-1.10.0-prometheus.yaml
+++ b/api/pkg/resources/test/fixtures/statefulset-azure-1.10.0-prometheus.yaml
@@ -38,7 +38,7 @@ spec:
         - --web.enable-lifecycle
         - --storage.tsdb.no-lockfile
         - --web.route-prefix=/
-        image: quay.io/prometheus/prometheus:v2.9.2
+        image: quay.io/prometheus/prometheus:v2.14.0
         livenessProbe:
           failureThreshold: 10
           httpGet:

--- a/api/pkg/resources/test/fixtures/statefulset-azure-1.10.6-prometheus.yaml
+++ b/api/pkg/resources/test/fixtures/statefulset-azure-1.10.6-prometheus.yaml
@@ -38,7 +38,7 @@ spec:
         - --web.enable-lifecycle
         - --storage.tsdb.no-lockfile
         - --web.route-prefix=/
-        image: quay.io/prometheus/prometheus:v2.9.2
+        image: quay.io/prometheus/prometheus:v2.14.0
         livenessProbe:
           failureThreshold: 10
           httpGet:

--- a/api/pkg/resources/test/fixtures/statefulset-azure-1.11.0-prometheus.yaml
+++ b/api/pkg/resources/test/fixtures/statefulset-azure-1.11.0-prometheus.yaml
@@ -38,7 +38,7 @@ spec:
         - --web.enable-lifecycle
         - --storage.tsdb.no-lockfile
         - --web.route-prefix=/
-        image: quay.io/prometheus/prometheus:v2.9.2
+        image: quay.io/prometheus/prometheus:v2.14.0
         livenessProbe:
           failureThreshold: 10
           httpGet:

--- a/api/pkg/resources/test/fixtures/statefulset-azure-1.11.1-prometheus.yaml
+++ b/api/pkg/resources/test/fixtures/statefulset-azure-1.11.1-prometheus.yaml
@@ -38,7 +38,7 @@ spec:
         - --web.enable-lifecycle
         - --storage.tsdb.no-lockfile
         - --web.route-prefix=/
-        image: quay.io/prometheus/prometheus:v2.9.2
+        image: quay.io/prometheus/prometheus:v2.14.0
         livenessProbe:
           failureThreshold: 10
           httpGet:

--- a/api/pkg/resources/test/fixtures/statefulset-azure-1.12.0-prometheus.yaml
+++ b/api/pkg/resources/test/fixtures/statefulset-azure-1.12.0-prometheus.yaml
@@ -38,7 +38,7 @@ spec:
         - --web.enable-lifecycle
         - --storage.tsdb.no-lockfile
         - --web.route-prefix=/
-        image: quay.io/prometheus/prometheus:v2.9.2
+        image: quay.io/prometheus/prometheus:v2.14.0
         livenessProbe:
           failureThreshold: 10
           httpGet:

--- a/api/pkg/resources/test/fixtures/statefulset-azure-1.13.0-prometheus.yaml
+++ b/api/pkg/resources/test/fixtures/statefulset-azure-1.13.0-prometheus.yaml
@@ -38,7 +38,7 @@ spec:
         - --web.enable-lifecycle
         - --storage.tsdb.no-lockfile
         - --web.route-prefix=/
-        image: quay.io/prometheus/prometheus:v2.9.2
+        image: quay.io/prometheus/prometheus:v2.14.0
         livenessProbe:
           failureThreshold: 10
           httpGet:

--- a/api/pkg/resources/test/fixtures/statefulset-bringyourown-1.10.0-prometheus.yaml
+++ b/api/pkg/resources/test/fixtures/statefulset-bringyourown-1.10.0-prometheus.yaml
@@ -38,7 +38,7 @@ spec:
         - --web.enable-lifecycle
         - --storage.tsdb.no-lockfile
         - --web.route-prefix=/
-        image: quay.io/prometheus/prometheus:v2.9.2
+        image: quay.io/prometheus/prometheus:v2.14.0
         livenessProbe:
           failureThreshold: 10
           httpGet:

--- a/api/pkg/resources/test/fixtures/statefulset-bringyourown-1.10.6-prometheus.yaml
+++ b/api/pkg/resources/test/fixtures/statefulset-bringyourown-1.10.6-prometheus.yaml
@@ -38,7 +38,7 @@ spec:
         - --web.enable-lifecycle
         - --storage.tsdb.no-lockfile
         - --web.route-prefix=/
-        image: quay.io/prometheus/prometheus:v2.9.2
+        image: quay.io/prometheus/prometheus:v2.14.0
         livenessProbe:
           failureThreshold: 10
           httpGet:

--- a/api/pkg/resources/test/fixtures/statefulset-bringyourown-1.11.0-prometheus.yaml
+++ b/api/pkg/resources/test/fixtures/statefulset-bringyourown-1.11.0-prometheus.yaml
@@ -38,7 +38,7 @@ spec:
         - --web.enable-lifecycle
         - --storage.tsdb.no-lockfile
         - --web.route-prefix=/
-        image: quay.io/prometheus/prometheus:v2.9.2
+        image: quay.io/prometheus/prometheus:v2.14.0
         livenessProbe:
           failureThreshold: 10
           httpGet:

--- a/api/pkg/resources/test/fixtures/statefulset-bringyourown-1.11.1-prometheus.yaml
+++ b/api/pkg/resources/test/fixtures/statefulset-bringyourown-1.11.1-prometheus.yaml
@@ -38,7 +38,7 @@ spec:
         - --web.enable-lifecycle
         - --storage.tsdb.no-lockfile
         - --web.route-prefix=/
-        image: quay.io/prometheus/prometheus:v2.9.2
+        image: quay.io/prometheus/prometheus:v2.14.0
         livenessProbe:
           failureThreshold: 10
           httpGet:

--- a/api/pkg/resources/test/fixtures/statefulset-bringyourown-1.12.0-prometheus.yaml
+++ b/api/pkg/resources/test/fixtures/statefulset-bringyourown-1.12.0-prometheus.yaml
@@ -38,7 +38,7 @@ spec:
         - --web.enable-lifecycle
         - --storage.tsdb.no-lockfile
         - --web.route-prefix=/
-        image: quay.io/prometheus/prometheus:v2.9.2
+        image: quay.io/prometheus/prometheus:v2.14.0
         livenessProbe:
           failureThreshold: 10
           httpGet:

--- a/api/pkg/resources/test/fixtures/statefulset-bringyourown-1.13.0-prometheus.yaml
+++ b/api/pkg/resources/test/fixtures/statefulset-bringyourown-1.13.0-prometheus.yaml
@@ -38,7 +38,7 @@ spec:
         - --web.enable-lifecycle
         - --storage.tsdb.no-lockfile
         - --web.route-prefix=/
-        image: quay.io/prometheus/prometheus:v2.9.2
+        image: quay.io/prometheus/prometheus:v2.14.0
         livenessProbe:
           failureThreshold: 10
           httpGet:

--- a/api/pkg/resources/test/fixtures/statefulset-digitalocean-1.10.0-prometheus.yaml
+++ b/api/pkg/resources/test/fixtures/statefulset-digitalocean-1.10.0-prometheus.yaml
@@ -38,7 +38,7 @@ spec:
         - --web.enable-lifecycle
         - --storage.tsdb.no-lockfile
         - --web.route-prefix=/
-        image: quay.io/prometheus/prometheus:v2.9.2
+        image: quay.io/prometheus/prometheus:v2.14.0
         livenessProbe:
           failureThreshold: 10
           httpGet:

--- a/api/pkg/resources/test/fixtures/statefulset-digitalocean-1.10.6-prometheus.yaml
+++ b/api/pkg/resources/test/fixtures/statefulset-digitalocean-1.10.6-prometheus.yaml
@@ -38,7 +38,7 @@ spec:
         - --web.enable-lifecycle
         - --storage.tsdb.no-lockfile
         - --web.route-prefix=/
-        image: quay.io/prometheus/prometheus:v2.9.2
+        image: quay.io/prometheus/prometheus:v2.14.0
         livenessProbe:
           failureThreshold: 10
           httpGet:

--- a/api/pkg/resources/test/fixtures/statefulset-digitalocean-1.11.0-prometheus.yaml
+++ b/api/pkg/resources/test/fixtures/statefulset-digitalocean-1.11.0-prometheus.yaml
@@ -38,7 +38,7 @@ spec:
         - --web.enable-lifecycle
         - --storage.tsdb.no-lockfile
         - --web.route-prefix=/
-        image: quay.io/prometheus/prometheus:v2.9.2
+        image: quay.io/prometheus/prometheus:v2.14.0
         livenessProbe:
           failureThreshold: 10
           httpGet:

--- a/api/pkg/resources/test/fixtures/statefulset-digitalocean-1.11.1-prometheus.yaml
+++ b/api/pkg/resources/test/fixtures/statefulset-digitalocean-1.11.1-prometheus.yaml
@@ -38,7 +38,7 @@ spec:
         - --web.enable-lifecycle
         - --storage.tsdb.no-lockfile
         - --web.route-prefix=/
-        image: quay.io/prometheus/prometheus:v2.9.2
+        image: quay.io/prometheus/prometheus:v2.14.0
         livenessProbe:
           failureThreshold: 10
           httpGet:

--- a/api/pkg/resources/test/fixtures/statefulset-digitalocean-1.12.0-prometheus.yaml
+++ b/api/pkg/resources/test/fixtures/statefulset-digitalocean-1.12.0-prometheus.yaml
@@ -38,7 +38,7 @@ spec:
         - --web.enable-lifecycle
         - --storage.tsdb.no-lockfile
         - --web.route-prefix=/
-        image: quay.io/prometheus/prometheus:v2.9.2
+        image: quay.io/prometheus/prometheus:v2.14.0
         livenessProbe:
           failureThreshold: 10
           httpGet:

--- a/api/pkg/resources/test/fixtures/statefulset-digitalocean-1.13.0-prometheus.yaml
+++ b/api/pkg/resources/test/fixtures/statefulset-digitalocean-1.13.0-prometheus.yaml
@@ -38,7 +38,7 @@ spec:
         - --web.enable-lifecycle
         - --storage.tsdb.no-lockfile
         - --web.route-prefix=/
-        image: quay.io/prometheus/prometheus:v2.9.2
+        image: quay.io/prometheus/prometheus:v2.14.0
         livenessProbe:
           failureThreshold: 10
           httpGet:

--- a/api/pkg/resources/test/fixtures/statefulset-openstack-1.10.0-prometheus.yaml
+++ b/api/pkg/resources/test/fixtures/statefulset-openstack-1.10.0-prometheus.yaml
@@ -38,7 +38,7 @@ spec:
         - --web.enable-lifecycle
         - --storage.tsdb.no-lockfile
         - --web.route-prefix=/
-        image: quay.io/prometheus/prometheus:v2.9.2
+        image: quay.io/prometheus/prometheus:v2.14.0
         livenessProbe:
           failureThreshold: 10
           httpGet:

--- a/api/pkg/resources/test/fixtures/statefulset-openstack-1.10.6-prometheus.yaml
+++ b/api/pkg/resources/test/fixtures/statefulset-openstack-1.10.6-prometheus.yaml
@@ -38,7 +38,7 @@ spec:
         - --web.enable-lifecycle
         - --storage.tsdb.no-lockfile
         - --web.route-prefix=/
-        image: quay.io/prometheus/prometheus:v2.9.2
+        image: quay.io/prometheus/prometheus:v2.14.0
         livenessProbe:
           failureThreshold: 10
           httpGet:

--- a/api/pkg/resources/test/fixtures/statefulset-openstack-1.11.0-prometheus.yaml
+++ b/api/pkg/resources/test/fixtures/statefulset-openstack-1.11.0-prometheus.yaml
@@ -38,7 +38,7 @@ spec:
         - --web.enable-lifecycle
         - --storage.tsdb.no-lockfile
         - --web.route-prefix=/
-        image: quay.io/prometheus/prometheus:v2.9.2
+        image: quay.io/prometheus/prometheus:v2.14.0
         livenessProbe:
           failureThreshold: 10
           httpGet:

--- a/api/pkg/resources/test/fixtures/statefulset-openstack-1.11.1-prometheus.yaml
+++ b/api/pkg/resources/test/fixtures/statefulset-openstack-1.11.1-prometheus.yaml
@@ -38,7 +38,7 @@ spec:
         - --web.enable-lifecycle
         - --storage.tsdb.no-lockfile
         - --web.route-prefix=/
-        image: quay.io/prometheus/prometheus:v2.9.2
+        image: quay.io/prometheus/prometheus:v2.14.0
         livenessProbe:
           failureThreshold: 10
           httpGet:

--- a/api/pkg/resources/test/fixtures/statefulset-openstack-1.12.0-prometheus.yaml
+++ b/api/pkg/resources/test/fixtures/statefulset-openstack-1.12.0-prometheus.yaml
@@ -38,7 +38,7 @@ spec:
         - --web.enable-lifecycle
         - --storage.tsdb.no-lockfile
         - --web.route-prefix=/
-        image: quay.io/prometheus/prometheus:v2.9.2
+        image: quay.io/prometheus/prometheus:v2.14.0
         livenessProbe:
           failureThreshold: 10
           httpGet:

--- a/api/pkg/resources/test/fixtures/statefulset-openstack-1.13.0-prometheus.yaml
+++ b/api/pkg/resources/test/fixtures/statefulset-openstack-1.13.0-prometheus.yaml
@@ -38,7 +38,7 @@ spec:
         - --web.enable-lifecycle
         - --storage.tsdb.no-lockfile
         - --web.route-prefix=/
-        image: quay.io/prometheus/prometheus:v2.9.2
+        image: quay.io/prometheus/prometheus:v2.14.0
         livenessProbe:
           failureThreshold: 10
           httpGet:

--- a/api/pkg/resources/test/fixtures/statefulset-vsphere-1.10.0-prometheus.yaml
+++ b/api/pkg/resources/test/fixtures/statefulset-vsphere-1.10.0-prometheus.yaml
@@ -38,7 +38,7 @@ spec:
         - --web.enable-lifecycle
         - --storage.tsdb.no-lockfile
         - --web.route-prefix=/
-        image: quay.io/prometheus/prometheus:v2.9.2
+        image: quay.io/prometheus/prometheus:v2.14.0
         livenessProbe:
           failureThreshold: 10
           httpGet:

--- a/api/pkg/resources/test/fixtures/statefulset-vsphere-1.10.6-prometheus.yaml
+++ b/api/pkg/resources/test/fixtures/statefulset-vsphere-1.10.6-prometheus.yaml
@@ -38,7 +38,7 @@ spec:
         - --web.enable-lifecycle
         - --storage.tsdb.no-lockfile
         - --web.route-prefix=/
-        image: quay.io/prometheus/prometheus:v2.9.2
+        image: quay.io/prometheus/prometheus:v2.14.0
         livenessProbe:
           failureThreshold: 10
           httpGet:

--- a/api/pkg/resources/test/fixtures/statefulset-vsphere-1.11.0-prometheus.yaml
+++ b/api/pkg/resources/test/fixtures/statefulset-vsphere-1.11.0-prometheus.yaml
@@ -38,7 +38,7 @@ spec:
         - --web.enable-lifecycle
         - --storage.tsdb.no-lockfile
         - --web.route-prefix=/
-        image: quay.io/prometheus/prometheus:v2.9.2
+        image: quay.io/prometheus/prometheus:v2.14.0
         livenessProbe:
           failureThreshold: 10
           httpGet:

--- a/api/pkg/resources/test/fixtures/statefulset-vsphere-1.11.1-prometheus.yaml
+++ b/api/pkg/resources/test/fixtures/statefulset-vsphere-1.11.1-prometheus.yaml
@@ -38,7 +38,7 @@ spec:
         - --web.enable-lifecycle
         - --storage.tsdb.no-lockfile
         - --web.route-prefix=/
-        image: quay.io/prometheus/prometheus:v2.9.2
+        image: quay.io/prometheus/prometheus:v2.14.0
         livenessProbe:
           failureThreshold: 10
           httpGet:

--- a/api/pkg/resources/test/fixtures/statefulset-vsphere-1.12.0-prometheus.yaml
+++ b/api/pkg/resources/test/fixtures/statefulset-vsphere-1.12.0-prometheus.yaml
@@ -38,7 +38,7 @@ spec:
         - --web.enable-lifecycle
         - --storage.tsdb.no-lockfile
         - --web.route-prefix=/
-        image: quay.io/prometheus/prometheus:v2.9.2
+        image: quay.io/prometheus/prometheus:v2.14.0
         livenessProbe:
           failureThreshold: 10
           httpGet:

--- a/api/pkg/resources/test/fixtures/statefulset-vsphere-1.13.0-prometheus.yaml
+++ b/api/pkg/resources/test/fixtures/statefulset-vsphere-1.13.0-prometheus.yaml
@@ -38,7 +38,7 @@ spec:
         - --web.enable-lifecycle
         - --storage.tsdb.no-lockfile
         - --web.route-prefix=/
-        image: quay.io/prometheus/prometheus:v2.9.2
+        image: quay.io/prometheus/prometheus:v2.14.0
         livenessProbe:
           failureThreshold: 10
           httpGet:

--- a/config/monitoring/grafana/Chart.yaml
+++ b/config/monitoring/grafana/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: grafana
-version: 1.2.4
+version: 1.2.5
 appVersion: 6.3.5
 description: Grafana for Kubermatic
 keywords:

--- a/config/monitoring/grafana/dashboards/monitoring/prometheus.json
+++ b/config/monitoring/grafana/dashboards/monitoring/prometheus.json
@@ -983,7 +983,7 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "prometheus_tsdb_head_chunks{job=\"pods\",pod=~\"$pod\"}",
+          "expr": "sum by (pod) (prometheus_tsdb_head_chunks{job=\"pods\",pod=~\"$pod\"})",
           "format": "time_series",
           "interval": "$interval",
           "intervalFactor": 1,
@@ -1076,7 +1076,7 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "prometheus_tsdb_head_series{job=\"pods\",pod=~\"$pod\"}",
+          "expr": "sum by (pod) (prometheus_tsdb_head_series{job=\"pods\",pod=~\"$pod\"})",
           "format": "time_series",
           "interval": "$interval",
           "intervalFactor": 1,
@@ -1275,7 +1275,7 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "rate(prometheus_tsdb_head_samples_appended_total{job=\"pods\",pod=~\"$pod\"}[$interval])",
+          "expr": "sum by (pod) (rate(prometheus_tsdb_head_samples_appended_total{job=\"pods\",pod=~\"$pod\"}[$interval]))",
           "format": "time_series",
           "intervalFactor": 1,
           "legendFormat": "{{ pod }}",
@@ -1555,7 +1555,7 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "scrape_duration_seconds{job=\"pods\",pod=~\"$pod\"}",
+          "expr": "sum by (pod) (scrape_duration_seconds{job=\"pods\",pod=~\"$pod\"})",
           "format": "time_series",
           "interval": "$interval",
           "intervalFactor": 1,
@@ -1770,7 +1770,7 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "rate(prometheus_rule_evaluation_duration_seconds_sum{job=\"pods\",pod=~\"$pod\"}[$interval]) / rate(prometheus_rule_evaluation_duration_seconds_count{job=\"pods\",pod=~\"$pod\"}[$interval])",
+          "expr": "sum by (pod) (rate(prometheus_rule_evaluation_duration_seconds_sum{job=\"pods\",pod=~\"$pod\"}[$interval]) / rate(prometheus_rule_evaluation_duration_seconds_count{job=\"pods\",pod=~\"$pod\"}[$interval]))",
           "format": "time_series",
           "intervalFactor": 1,
           "legendFormat": "{{ pod }}",
@@ -2332,7 +2332,7 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "prometheus_config_last_reload_successful{job=\"pods\",pod=~\"$pod\"}",
+          "expr": "min by (pod) (prometheus_config_last_reload_successful{job=\"pods\",pod=~\"$pod\"})",
           "format": "time_series",
           "intervalFactor": 1,
           "legendFormat": "{{ pod }}",
@@ -2500,7 +2500,7 @@
       {
         "allValue": null,
         "current": {
-          "tags": [],
+          "selected": true,
           "text": "5m",
           "value": "5m"
         },

--- a/config/monitoring/grafana/dashboards/monitoring/prometheus.json
+++ b/config/monitoring/grafana/dashboards/monitoring/prometheus.json
@@ -889,7 +889,7 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "up{job=\"pods\",pod=~\"$pod\"}",
+          "expr": "min(up{job=\"pods\",pod=~\"$pod\"}) by (pod)",
           "format": "time_series",
           "interval": "$interval",
           "intervalFactor": 1,

--- a/config/monitoring/prometheus/Chart.yaml
+++ b/config/monitoring/prometheus/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 name: prometheus
-version: 2.2.3
-appVersion: v2.12.0
+version: 2.2.4
+appVersion: v2.14.0
 description: Prometheus Monitoring for Kubernetes
 keywords:
 - kubermatic

--- a/config/monitoring/prometheus/values.yaml
+++ b/config/monitoring/prometheus/values.yaml
@@ -1,7 +1,7 @@
 prometheus:
   image:
     repository: quay.io/prometheus/prometheus
-    tag: v2.12.0
+    tag: v2.14.0
     pullPolicy: IfNotPresent
 
   host: ''
@@ -18,7 +18,7 @@ prometheus:
 
   configReloaderImage:
     repository: docker.io/jimmidyson/configmap-reload
-    tag: v0.2.2
+    tag: v0.3.0
     pullPolicy: IfNotPresent
 
   # If you install Prometheus using a different Helm release name,


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR updates Prometheus both in the seed and user clusters to the latest stable version.

**Does this PR introduce a user-facing change?**:
```release-note
update Prometheus to 2.14 in Seed and User clusters
```
