### PR TITLE
Fix nginx chart

### DIFF
--- a/config/nginx-ingress-controller/Chart.yaml
+++ b/config/nginx-ingress-controller/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: nginx-ingress-controller
-version: 1.0.3
+version: 1.0.4
 appVersion: 0.26.1
 description: nginx-ingress-controller
 keywords:

--- a/config/nginx-ingress-controller/templates/cluster-role.yaml
+++ b/config/nginx-ingress-controller/templates/cluster-role.yaml
@@ -32,14 +32,8 @@ rules:
   verbs:
   - get
   - list
+  - update
   - watch
-- apiGroups:
-  - ""
-  resources:
-  - events
-  verbs:
-  - create
-  - patch
 - apiGroups:
   - extensions
   - networking.k8s.io
@@ -49,6 +43,13 @@ rules:
   - get
   - list
   - watch
+- apiGroups:
+  - ""
+  resources:
+  - events
+  verbs:
+  - create
+  - patch
 - apiGroups:
   - extensions
   - networking.k8s.io

--- a/config/nginx-ingress-controller/templates/clusterrole.yaml
+++ b/config/nginx-ingress-controller/templates/clusterrole.yaml
@@ -1,7 +1,7 @@
-apiVersion: rbac.authorization.k8s.io/v1beta1
+apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
-  name: nginx-ingress-clusterrole
+  name: nginx-ingress-controller
   labels:
     app.kubernetes.io/name: ingress-nginx
     app.kubernetes.io/instance: '{{ .Release.Name }}'

--- a/config/nginx-ingress-controller/templates/clusterrolebinding.yaml
+++ b/config/nginx-ingress-controller/templates/clusterrolebinding.yaml
@@ -1,7 +1,7 @@
-apiVersion: rbac.authorization.k8s.io/v1beta1
+apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
-  name: nginx-ingress-clusterrole-nisa-binding
+  name: nginx-ingress-controller
   labels:
     app.kubernetes.io/name: ingress-nginx
     app.kubernetes.io/instance: '{{ .Release.Name }}'
@@ -10,8 +10,8 @@ metadata:
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
-  name: nginx-ingress-clusterrole
+  name: nginx-ingress-controller
 subjects:
 - kind: ServiceAccount
-  name: nginx-ingress-serviceaccount
+  name: nginx-ingress-controller
   namespace: {{ .Release.Namespace }}

--- a/config/nginx-ingress-controller/templates/configmaps.yaml
+++ b/config/nginx-ingress-controller/templates/configmaps.yaml
@@ -11,25 +11,3 @@ data:
   {{- range $key, $val := .Values.nginx.config }}
   {{ $key }}: {{ $val }}
   {{- end }}
-
----
-kind: ConfigMap
-apiVersion: v1
-metadata:
-  name: tcp-services
-  labels:
-    app.kubernetes.io/name: ingress-nginx
-    app.kubernetes.io/instance: '{{ .Release.Name }}'
-    app.kubernetes.io/part-of: ingress-nginx
-    app.kubernetes.io/managed-by: helm
-
----
-kind: ConfigMap
-apiVersion: v1
-metadata:
-  name: udp-services
-  labels:
-    app.kubernetes.io/name: ingress-nginx
-    app.kubernetes.io/instance: '{{ .Release.Name }}'
-    app.kubernetes.io/part-of: ingress-nginx
-    app.kubernetes.io/managed-by: helm

--- a/config/nginx-ingress-controller/templates/nginx-ds-dep.yaml
+++ b/config/nginx-ingress-controller/templates/nginx-ds-dep.yaml
@@ -35,7 +35,7 @@ spec:
       hostNetwork: {{ .Values.nginx.hostNetwork }}
       # wait up to five minutes for the drain of connections
       terminationGracePeriodSeconds: 300
-      serviceAccountName: nginx-ingress-serviceaccount
+      serviceAccountName: nginx-ingress-controller
       containers:
       - name: nginx-ingress-controller
         image: '{{ .Values.nginx.image.repository }}:{{ .Values.nginx.image.tag }}'

--- a/config/nginx-ingress-controller/templates/nginx-ds-dep.yaml
+++ b/config/nginx-ingress-controller/templates/nginx-ds-dep.yaml
@@ -31,6 +31,7 @@ spec:
         kubermatic/scrape: 'true'
         kubermatic/scrape_port: '10254'
     spec:
+      dnsPolicy: {{ .Values.nginx.dnsPolicy }}
       hostNetwork: {{ .Values.nginx.hostNetwork }}
       # wait up to five minutes for the drain of connections
       terminationGracePeriodSeconds: 300
@@ -41,9 +42,7 @@ spec:
         args:
         - /nginx-ingress-controller
         - --configmap=$(POD_NAMESPACE)/nginx-configuration
-        - --tcp-services-configmap=$(POD_NAMESPACE)/tcp-services
-        - --udp-services-configmap=$(POD_NAMESPACE)/udp-services
-        - --publish-service=$(POD_NAMESPACE)/ingress-nginx
+        - --ingress-class=nginx
         - --annotations-prefix=ingress.kubernetes.io
         {{- range .Values.nginx.extraArgs }}
         - {{ . | quote }}
@@ -69,8 +68,10 @@ spec:
         ports:
         - name: http
           containerPort: 80
+          protocol: TCP
         - name: https
           containerPort: 443
+          protocol: TCP
         livenessProbe:
           failureThreshold: 3
           httpGet:

--- a/config/nginx-ingress-controller/templates/role.yaml
+++ b/config/nginx-ingress-controller/templates/role.yaml
@@ -11,9 +11,6 @@ rules:
 - apiGroups:
   - ""
   resources:
-  - configmaps
-  - pods
-  - secrets
   - namespaces
   verbs:
   - get
@@ -21,11 +18,43 @@ rules:
   - ""
   resources:
   - configmaps
+  - pods
+  - secrets
+  - endpoints
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - ""
+  resources:
+  - services
+  verbs:
+  - get
+  - list
+  - update
+  - watch
+- apiGroups:
+  - extensions
+  - "networking.k8s.io" # k8s 1.14+
+  resources:
+  - ingresses
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - extensions
+  - "networking.k8s.io" # k8s 1.14+
+  resources:
+  - ingresses/status
+  verbs:
+  - update
+- apiGroups:
+  - ""
+  resources:
+  - configmaps
   resourceNames:
-  # Defaults to "<election-id>-<ingress-class>"
-  # Here: "<ingress-controller-leader>-<nginx>"
-  # This has to be adapted if you change either parameter
-  # when launching the nginx-ingress-controller.
   - "ingress-controller-leader-nginx"
   verbs:
   - get
@@ -41,4 +70,13 @@ rules:
   resources:
   - endpoints
   verbs:
+  - create
   - get
+  - update
+- apiGroups:
+  - ""
+  resources:
+  - events
+  verbs:
+  - create
+  - patch

--- a/config/nginx-ingress-controller/templates/role.yaml
+++ b/config/nginx-ingress-controller/templates/role.yaml
@@ -1,7 +1,7 @@
-apiVersion: rbac.authorization.k8s.io/v1beta1
+apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
 metadata:
-  name: nginx-ingress-role
+  name: nginx-ingress-controller
   labels:
     app.kubernetes.io/name: ingress-nginx
     app.kubernetes.io/instance: '{{ .Release.Name }}'

--- a/config/nginx-ingress-controller/templates/rolebinding.yaml
+++ b/config/nginx-ingress-controller/templates/rolebinding.yaml
@@ -1,7 +1,7 @@
-apiVersion: rbac.authorization.k8s.io/v1beta1
+apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
-  name: nginx-ingress-role-nisa-binding
+  name: nginx-ingress-controller
   labels:
     app.kubernetes.io/name: ingress-nginx
     app.kubernetes.io/instance: '{{ .Release.Name }}'
@@ -10,8 +10,8 @@ metadata:
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: Role
-  name: nginx-ingress-role
+  name: nginx-ingress-controller
 subjects:
 - kind: ServiceAccount
-  name: nginx-ingress-serviceaccount
+  name: nginx-ingress-controller
   namespace: {{ .Release.Namespace }}

--- a/config/nginx-ingress-controller/templates/serviceaccount.yaml
+++ b/config/nginx-ingress-controller/templates/serviceaccount.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 kind: ServiceAccount
 metadata:
-  name: nginx-ingress-serviceaccount
+  name: nginx-ingress-controller
   labels:
     app.kubernetes.io/name: ingress-nginx
     app.kubernetes.io/instance: '{{ .Release.Name }}'

--- a/config/nginx-ingress-controller/values.yaml
+++ b/config/nginx-ingress-controller/values.yaml
@@ -6,9 +6,9 @@ nginx:
     repository: quay.io/kubernetes-ingress-controller/nginx-ingress-controller
     tag: 0.26.1
   config: {}
+#   load-balance: "least_conn"
   extraArgs:
   - '--default-ssl-certificate=default/kubermatic-tls-certificates'
-#    load-balance: "least_conn"
   resources:
     requests:
       cpu: 50m

--- a/config/nginx-ingress-controller/values.yaml
+++ b/config/nginx-ingress-controller/values.yaml
@@ -38,3 +38,8 @@ nginx:
   #   - { key: dedicated, operator: Equal, value: master, effect: NoSchedule }
   #   - { key: node-role.kubernetes.io/master, effect: NoSchedule }
   ignoreMasterTaint: false
+
+  # Optionally change this to ClusterFirstWithHostNet in case you have 'hostNetwork: true'.
+  # By default, while using host network, name resolution uses the host's DNS. If you wish nginx-controller
+  # to keep resolving names inside the k8s network, use ClusterFirstWithHostNet.
+  dnsPolicy: ClusterFirst


### PR DESCRIPTION
**What this PR does / why we need it**:
This syncs the nginx-ingress-controller chart with what upstream does.

* A bunch of missing permissions have been defined. Not sure if all of them are really required with our feature set, but better be safe than sorry.
* The publish-service stuff has been removed. We don't use it and if someone wants to use it, they can easily get it back via extraArgs.
* Same goes for the tcp/udp configmaps.
* The dnspolicy stuff could be a helpful addition.
* The old naming scheme for RBAC stuff has been harmonized with the other charts and updated to v1.

**Does this PR introduce a user-facing change?**:
```release-note
Fix missing nginx-ingress-controller permissions.
ACTION REQUIRED: Removed default publishing of services in nginx-ingress-controller.
```
