### PR TITLE
upgrade-test: include our lib, to be able to use ensure_github_host_pubkey()

### DIFF
--- a/api/hack/run-kubermatic-upgrade-test.sh
+++ b/api/hack/run-kubermatic-upgrade-test.sh
@@ -6,6 +6,8 @@ set -euo pipefail
 # receives a SIGINT
 set -o monitor
 
+. $(dirname $0)/lib.sh
+
 cd $(go env GOPATH)/src/github.com/kubermatic/kubermatic/api/hack/ci
 
 export UPGRADE_TEST_BASE_HASH=${UPGRADE_TEST_BASE_HASH:-"master"}


### PR DESCRIPTION
I switched to the usage of that helper, but yet again forgot to include the file that contains it.

/assign @alvaroaleman 

```release-note
NONE
```
