### PR TITLE
Downgrade nginx-ingress to 0.25.1 to fix TLS redirect

### DIFF
--- a/config/nginx-ingress-controller/Chart.yaml
+++ b/config/nginx-ingress-controller/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 name: nginx-ingress-controller
-version: 1.0.4
-appVersion: 0.26.1
+version: 1.0.5
+appVersion: 0.25.1
 description: nginx-ingress-controller
 keywords:
 - kubermatic

--- a/config/nginx-ingress-controller/values.yaml
+++ b/config/nginx-ingress-controller/values.yaml
@@ -4,7 +4,7 @@ nginx:
   replicas: 3
   image:
     repository: quay.io/kubernetes-ingress-controller/nginx-ingress-controller
-    tag: 0.26.1
+    tag: 0.25.1
   config: {}
 #   load-balance: "least_conn"
   extraArgs:


### PR DESCRIPTION
**What this PR does / why we need it**:
Roll back to 0.25.1 because of https://github.com/kubernetes/ingress-nginx/issues/4628

**Does this PR introduce a user-facing change?**:
```release-note
Rolled nginx-ingress-controller back to 0.25.1 to fix SSL redirect issues.
```
