### PR TITLE
[release/v2.12] downgrade nginx-ingress to 0.25.1 to fix TLS redirect (#4693)

### DIFF
--- a/config/nginx-ingress-controller/Chart.yaml
+++ b/config/nginx-ingress-controller/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 name: nginx-ingress-controller
-version: 1.0.3
-appVersion: 0.26.1
+version: 1.0.5
+appVersion: 0.25.1
 description: nginx-ingress-controller
 keywords:
 - kubermatic

--- a/config/nginx-ingress-controller/values.yaml
+++ b/config/nginx-ingress-controller/values.yaml
@@ -4,7 +4,7 @@ nginx:
   replicas: 3
   image:
     repository: quay.io/kubernetes-ingress-controller/nginx-ingress-controller
-    tag: 0.26.1
+    tag: 0.25.1
   config: {}
   extraArgs:
   - '--default-ssl-certificate=default/kubermatic-tls-certificates'


### PR DESCRIPTION
This is a manual cherry-pick of #4693

```release-note
Rolled nginx-ingress-controller back to 0.25.1 to fix SSL redirect issues.
```
