### PR TITLE
Remove not needed port

### DIFF
--- a/api/pkg/provider/cloud/aws/provider.go
+++ b/api/pkg/provider/cloud/aws/provider.go
@@ -379,14 +379,6 @@ func createSecurityGroup(client ec2iface.EC2API, vpcID, clusterName string) (str
 					{CidrIp: aws.String("0.0.0.0/0")},
 				}),
 			(&ec2.IpPermission{}).
-				// tcp:10250 from everywhere
-				SetIpProtocol("tcp").
-				SetFromPort(provider.DefaultKubeletPort).
-				SetToPort(provider.DefaultKubeletPort).
-				SetIpRanges([]*ec2.IpRange{
-					{CidrIp: aws.String("0.0.0.0/0")},
-				}),
-			(&ec2.IpPermission{}).
 				// ICMP from/to everywhere
 				SetIpProtocol("icmp").
 				SetFromPort(-1). // any port

--- a/api/pkg/provider/cloud/azure/provider.go
+++ b/api/pkg/provider/cloud/azure/provider.go
@@ -367,19 +367,6 @@ func (a *Azure) ensureSecurityGroup(cloud kubermaticv1.CloudSpec, location strin
 					},
 				},
 				{
-					Name: to.StringPtr("kubelet"),
-					SecurityRulePropertiesFormat: &network.SecurityRulePropertiesFormat{
-						Direction:                network.SecurityRuleDirectionInbound,
-						Protocol:                 network.SecurityRuleProtocolTCP,
-						SourceAddressPrefix:      to.StringPtr("*"),
-						SourcePortRange:          to.StringPtr("*"),
-						DestinationAddressPrefix: to.StringPtr("*"),
-						DestinationPortRange:     to.StringPtr("10250"),
-						Access:                   network.SecurityRuleAccessAllow,
-						Priority:                 to.Int32Ptr(101),
-					},
-				},
-				{
 					Name: to.StringPtr("inter_node_comm"),
 					SecurityRulePropertiesFormat: &network.SecurityRulePropertiesFormat{
 						Direction:                network.SecurityRuleDirectionInbound,

--- a/api/pkg/provider/cloud/openstack/helper.go
+++ b/api/pkg/provider/cloud/openstack/helper.go
@@ -187,15 +187,6 @@ func createKubermaticSecurityGroup(netClient *gophercloud.ServiceClient, cluster
 			Protocol:     osecuritygrouprules.ProtocolTCP,
 		},
 		{
-			// Allows kubelet from external
-			Direction:    osecuritygrouprules.DirIngress,
-			EtherType:    osecuritygrouprules.EtherType4,
-			SecGroupID:   securityGroupID,
-			PortRangeMin: provider.DefaultKubeletPort,
-			PortRangeMax: provider.DefaultKubeletPort,
-			Protocol:     osecuritygrouprules.ProtocolTCP,
-		},
-		{
 			// Allows ICMP traffic
 			Direction:  osecuritygrouprules.DirIngress,
 			EtherType:  osecuritygrouprules.EtherType4,


### PR DESCRIPTION
**What this PR does / why we need it**:
In a recent discussion with @kdomanski it came up that it is not necessary anymore to expose the kubelet port 10250 to the outside.
This PR removes this from the OpenStack, AWS and Azure security groups.

**Documentation**:
<!-- Add links to the related documentation changes related to this pull request. E.g. the link to the kubermatic/docs pullrequest. -->

**Does this PR introduce a user-facing change?**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If  no release note is required, just write "NONE".
-->
```release-note
For new clusters, the Kubelet port 12050 is not exposed publicly anymore
```
