### PR TITLE
Improve handling of deleted cluster

### DIFF
--- a/api/pkg/controller/seed-controller-manager/monitoring/monitoring_controller.go
+++ b/api/pkg/controller/seed-controller-manager/monitoring/monitoring_controller.go
@@ -162,10 +162,9 @@ func (r *Reconciler) Reconcile(request reconcile.Request) (reconcile.Result, err
 	cluster := &kubermaticv1.Cluster{}
 	if err := r.Get(ctx, request.NamespacedName, cluster); err != nil {
 		if kubeapierrors.IsNotFound(err) {
-			log.Errorw("Couldn't find cluster", zap.Error(err))
 			return reconcile.Result{}, nil
 		}
-		return reconcile.Result{}, err
+		return reconcile.Result{}, fmt.Errorf("failed to get cluster: %v", err)
 	}
 
 	log = log.With("cluster", cluster.Name)

--- a/api/pkg/crd/kubermatic/v1/helper/helper.go
+++ b/api/pkg/crd/kubermatic/v1/helper/helper.go
@@ -43,7 +43,7 @@ func ClusterReconcileWrapper(
 	errs := []error{err}
 	oldCluster := cluster.DeepCopy()
 	SetClusterCondition(cluster, conditionType, reconcilingStatus, "", "")
-	errs = append(errs, client.Patch(ctx, cluster, ctrlruntimeclient.MergeFrom(oldCluster)))
+	errs = append(errs, ctrlruntimeclient.IgnoreNotFound(client.Patch(ctx, cluster, ctrlruntimeclient.MergeFrom(oldCluster))))
 	return result, utilerrors.NewAggregate(errs)
 }
 


### PR DESCRIPTION
**What this PR does / why we need it**:

Improves the handling of deleted clusters by:
* Not emitting an error-level log when we get a 404 in the monitoring controller
* Ignoring 404s when trying to patch the cluster status

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Documentation**:
<!-- Add links to the related documentation changes related to this pull request. E.g. the link to the kubermatic/docs pullrequest. -->

**Does this PR introduce a user-facing change?**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If  no release note is required, just write "NONE".
-->
```release-note
none
```

/assign @kron4eg 
