### PR TITLE
Fix component health status shown during cluster creation

### DIFF
--- a/api/pkg/controller/seed-controller-manager/kubernetes/health.go
+++ b/api/pkg/controller/seed-controller-manager/kubernetes/health.go
@@ -8,7 +8,7 @@ import (
 	"k8s.io/apimachinery/pkg/types"
 
 	kubermaticv1 "github.com/kubermatic/kubermatic/api/pkg/crd/kubermatic/v1"
-	"github.com/kubermatic/kubermatic/api/pkg/crd/kubermatic/v1/helper"
+	kubermaticv1helper "github.com/kubermatic/kubermatic/api/pkg/crd/kubermatic/v1/helper"
 	"github.com/kubermatic/kubermatic/api/pkg/provider/kubernetes"
 	"github.com/kubermatic/kubermatic/api/pkg/resources"
 )
@@ -37,7 +37,7 @@ func (r *Reconciler) clusterHealth(ctx context.Context, cluster *kubermaticv1.Cl
 		if err != nil {
 			return nil, fmt.Errorf("failed to get dep health %q: %v", name, err)
 		}
-		*healthMapping[name].healthStatus = helper.GetHealthStatus(status, cluster)
+		*healthMapping[name].healthStatus = kubermaticv1helper.GetHealthStatus(status, cluster)
 	}
 
 	var err error
@@ -47,7 +47,7 @@ func (r *Reconciler) clusterHealth(ctx context.Context, cluster *kubermaticv1.Cl
 	if err != nil {
 		return nil, fmt.Errorf("failed to get etcd health: %v", err)
 	}
-	extendedHealth.Etcd = helper.GetHealthStatus(etcdHealthStatus, cluster)
+	extendedHealth.Etcd = kubermaticv1helper.GetHealthStatus(etcdHealthStatus, cluster)
 
 	return extendedHealth, nil
 }
@@ -67,9 +67,9 @@ func (r *Reconciler) syncHealth(ctx context.Context, cluster *kubermaticv1.Clust
 		return err
 	}
 
-	if !cluster.Status.HasConditionValue(kubermaticv1.ClusterConditionClusterInitialized, corev1.ConditionTrue) && helper.IsClusterInitialized(cluster) {
+	if !cluster.Status.HasConditionValue(kubermaticv1.ClusterConditionClusterInitialized, corev1.ConditionTrue) && kubermaticv1helper.IsClusterInitialized(cluster) {
 		err = r.updateCluster(ctx, cluster, func(c *kubermaticv1.Cluster) {
-			helper.SetClusterCondition(
+			kubermaticv1helper.SetClusterCondition(
 				c,
 				kubermaticv1.ClusterConditionClusterInitialized,
 				corev1.ConditionTrue,

--- a/api/pkg/controller/seed-controller-manager/openshift/openshift_controller.go
+++ b/api/pkg/controller/seed-controller-manager/openshift/openshift_controller.go
@@ -14,7 +14,6 @@ import (
 	openshiftresources "github.com/kubermatic/kubermatic/api/pkg/controller/seed-controller-manager/openshift/resources"
 	controllerutil "github.com/kubermatic/kubermatic/api/pkg/controller/util"
 	kubermaticv1 "github.com/kubermatic/kubermatic/api/pkg/crd/kubermatic/v1"
-	"github.com/kubermatic/kubermatic/api/pkg/crd/kubermatic/v1/helper"
 	kubermaticv1helper "github.com/kubermatic/kubermatic/api/pkg/crd/kubermatic/v1/helper"
 	kuberneteshelper "github.com/kubermatic/kubermatic/api/pkg/kubernetes"
 	"github.com/kubermatic/kubermatic/api/pkg/provider"
@@ -417,14 +416,14 @@ func (r *Reconciler) syncHeath(ctx context.Context, osData *openshiftData) error
 		if err != nil {
 			return fmt.Errorf("failed to get dep health %q: %v", name, err)
 		}
-		*healthMapping[name].healthStatus = helper.GetHealthStatus(status, cluster)
+		*healthMapping[name].healthStatus = kubermaticv1helper.GetHealthStatus(status, cluster)
 	}
 
 	status, err := resources.HealthyStatefulSet(ctx, r.Client, nn(cluster.Status.NamespaceName, resources.EtcdStatefulSetName), 2)
 	if err != nil {
 		return fmt.Errorf("failed to get etcd health: %v", err)
 	}
-	currentHealth.Etcd = helper.GetHealthStatus(status, cluster)
+	currentHealth.Etcd = kubermaticv1helper.GetHealthStatus(status, cluster)
 
 	//TODO: Revisit this. This is a tiny bit ugly, but Openshift doesn't have a distinct scheduler
 	// and introducing a distinct health struct for Openshift means we have to change the API as well
@@ -436,9 +435,9 @@ func (r *Reconciler) syncHeath(ctx context.Context, osData *openshiftData) error
 		})
 	}
 
-	if !cluster.Status.HasConditionValue(kubermaticv1.ClusterConditionClusterInitialized, corev1.ConditionTrue) && helper.IsClusterInitialized(cluster) {
+	if !cluster.Status.HasConditionValue(kubermaticv1.ClusterConditionClusterInitialized, corev1.ConditionTrue) && kubermaticv1helper.IsClusterInitialized(cluster) {
 		err = r.updateCluster(ctx, cluster, func(c *kubermaticv1.Cluster) {
-			helper.SetClusterCondition(
+			kubermaticv1helper.SetClusterCondition(
 				c,
 				kubermaticv1.ClusterConditionClusterInitialized,
 				corev1.ConditionTrue,

--- a/api/pkg/controller/seed-controller-manager/openshift/openshift_controller.go
+++ b/api/pkg/controller/seed-controller-manager/openshift/openshift_controller.go
@@ -14,6 +14,7 @@ import (
 	openshiftresources "github.com/kubermatic/kubermatic/api/pkg/controller/seed-controller-manager/openshift/resources"
 	controllerutil "github.com/kubermatic/kubermatic/api/pkg/controller/util"
 	kubermaticv1 "github.com/kubermatic/kubermatic/api/pkg/crd/kubermatic/v1"
+	"github.com/kubermatic/kubermatic/api/pkg/crd/kubermatic/v1/helper"
 	kubermaticv1helper "github.com/kubermatic/kubermatic/api/pkg/crd/kubermatic/v1/helper"
 	kuberneteshelper "github.com/kubermatic/kubermatic/api/pkg/kubernetes"
 	"github.com/kubermatic/kubermatic/api/pkg/provider"
@@ -395,7 +396,8 @@ func (r *Reconciler) clusterIsReachable(ctx context.Context, c *kubermaticv1.Clu
 }
 
 func (r *Reconciler) syncHeath(ctx context.Context, osData *openshiftData) error {
-	currentHealth := osData.Cluster().Status.ExtendedHealth.DeepCopy()
+	cluster := osData.Cluster()
+	currentHealth := cluster.Status.ExtendedHealth.DeepCopy()
 	type depInfo struct {
 		healthStatus *kubermaticv1.HealthStatus
 		minReady     int32
@@ -410,30 +412,42 @@ func (r *Reconciler) syncHeath(ctx context.Context, osData *openshiftData) error
 	}
 
 	for name := range healthMapping {
-		status, err := resources.HealthyDeployment(ctx, r.Client, nn(osData.Cluster().Status.NamespaceName, name), healthMapping[name].minReady)
+		status, err := resources.HealthyDeployment(ctx, r.Client, nn(cluster.Status.NamespaceName, name), healthMapping[name].minReady)
 		if err != nil {
 			return fmt.Errorf("failed to get dep health %q: %v", name, err)
 		}
-		*healthMapping[name].healthStatus = status
+		*healthMapping[name].healthStatus = helper.GetHealthStatus(status, cluster)
 	}
 
-	status, err := resources.HealthyStatefulSet(ctx, r.Client, nn(osData.Cluster().Status.NamespaceName, resources.EtcdStatefulSetName), 2)
+	status, err := resources.HealthyStatefulSet(ctx, r.Client, nn(cluster.Status.NamespaceName, resources.EtcdStatefulSetName), 2)
 	if err != nil {
 		return fmt.Errorf("failed to get etcd health: %v", err)
 	}
-	currentHealth.Etcd = status
+	currentHealth.Etcd = helper.GetHealthStatus(status, cluster)
 
 	//TODO: Revisit this. This is a tiny bit ugly, but Openshift doesn't have a distinct scheduler
 	// and introducing a distinct health struct for Openshift means we have to change the API as well
 	currentHealth.Scheduler = currentHealth.Controller
 
-	if osData.Cluster().Status.ExtendedHealth != *currentHealth {
-		return r.updateCluster(ctx, osData.Cluster(), func(c *kubermaticv1.Cluster) {
+	if cluster.Status.ExtendedHealth != *currentHealth {
+		return r.updateCluster(ctx, cluster, func(c *kubermaticv1.Cluster) {
 			c.Status.ExtendedHealth = *currentHealth
 		})
 	}
 
-	return nil
+	if !cluster.Status.HasConditionValue(kubermaticv1.ClusterConditionClusterInitialized, corev1.ConditionTrue) && helper.IsClusterInitialized(cluster) {
+		err = r.updateCluster(ctx, cluster, func(c *kubermaticv1.Cluster) {
+			helper.SetClusterCondition(
+				c,
+				kubermaticv1.ClusterConditionClusterInitialized,
+				corev1.ConditionTrue,
+				"",
+				"Cluster has been initialized successfully",
+			)
+		})
+	}
+
+	return err
 }
 
 func (r *Reconciler) updateCluster(ctx context.Context, c *kubermaticv1.Cluster, modify func(*kubermaticv1.Cluster)) error {

--- a/api/pkg/controller/seed-controller-manager/openshift/openshift_controller.go
+++ b/api/pkg/controller/seed-controller-manager/openshift/openshift_controller.go
@@ -336,7 +336,8 @@ func (r *Reconciler) reconcile(ctx context.Context, log *zap.SugaredLogger, clus
 		return nil, fmt.Errorf("failed to sync health: %v", err)
 	}
 
-	if kubermaticv1.HealthStatusDown == osData.Cluster().Status.ExtendedHealth.Apiserver {
+	if kubermaticv1.HealthStatusDown == osData.Cluster().Status.ExtendedHealth.Apiserver ||
+		kubermaticv1.HealthStatusProvisioning == osData.Cluster().Status.ExtendedHealth.Apiserver {
 		return &reconcile.Result{RequeueAfter: 5 * time.Second}, nil
 	}
 

--- a/api/pkg/controller/seed-controller-manager/seedresourcesuptodatecondition/seedresourcesuptodatecondition_controller.go
+++ b/api/pkg/controller/seed-controller-manager/seedresourcesuptodatecondition/seedresourcesuptodatecondition_controller.go
@@ -109,7 +109,7 @@ func (r *reconciler) reconcile(cluster *kubermaticv1.Cluster) error {
 			kubermaticv1.ClusterConditionSeedResourcesUpToDate,
 			corev1.ConditionFalse,
 			kubermaticv1.ReasonClusterUpdateSuccessful,
-			"Some controlplane components did not finish updating",
+			"Some control plane components did not finish updating",
 		)
 		return r.client.Patch(r.ctx, cluster, ctrlruntimeclient.MergeFrom(oldCluster))
 	}
@@ -119,7 +119,7 @@ func (r *reconciler) reconcile(cluster *kubermaticv1.Cluster) error {
 		kubermaticv1.ClusterConditionSeedResourcesUpToDate,
 		corev1.ConditionTrue,
 		kubermaticv1.ReasonClusterUpdateSuccessful,
-		"All controlplane components are up to date",
+		"All control plane components are up to date",
 	)
 	return r.client.Patch(r.ctx, cluster, ctrlruntimeclient.MergeFrom(oldCluster))
 }

--- a/api/pkg/crd/kubermatic/v1/cluster.go
+++ b/api/pkg/crd/kubermatic/v1/cluster.go
@@ -107,7 +107,7 @@ type ClusterSpec struct {
 type ClusterConditionType string
 
 const (
-	// ClusterConditionSeedResourcesUpToDate indicates that alle controllers have finished setting up the
+	// ClusterConditionSeedResourcesUpToDate indicates that all controllers have finished setting up the
 	// resources for a user clusters that run inside the seed cluster, i.e. this ignores
 	// the status of cloud provider resources for a given cluster.
 	ClusterConditionSeedResourcesUpToDate ClusterConditionType = "SeedResourcesUpToDate"
@@ -121,9 +121,10 @@ const (
 	ClusterConditionUpdateControllerReconcilingSuccess         ClusterConditionType = "UpdateControllerReconciledSuccessfully"
 	ClusterConditionMonitoringControllerReconcilingSuccess     ClusterConditionType = "MonitoringControllerReconciledSuccessfully"
 	ClusterConditionOpenshiftControllerReconcilingSuccess      ClusterConditionType = "OpenshiftControllerReconciledSuccessfully"
+	ClusterConditionClusterInitialized                         ClusterConditionType = "ClusterInitialized"
 
 	ReasonClusterUpdateSuccessful = "ClusterUpdateSuccessful"
-	ReasonClusterUpadteInProgress = "ClusterUpdateInProgress"
+	ReasonClusterUpdateInProgress = "ClusterUpdateInProgress"
 )
 
 var AllClusterConditionTypes = []ClusterConditionType{

--- a/api/pkg/crd/kubermatic/v1/cluster.go
+++ b/api/pkg/crd/kubermatic/v1/cluster.go
@@ -571,3 +571,11 @@ func (cluster *Cluster) GetSecretName() string {
 	}
 	return ""
 }
+
+func (cluster *Cluster) IsOpenshift() bool {
+	return cluster.Annotations["kubermatic.io/openshift"] != ""
+}
+
+func (cluster *Cluster) IsKubernetes() bool {
+	return !cluster.IsOpenshift()
+}

--- a/api/pkg/provider/kubernetes/cluster.go
+++ b/api/pkg/provider/kubernetes/cluster.go
@@ -114,6 +114,16 @@ func (p *ClusterProvider) New(project *kubermaticv1.Project, userInfo *provider.
 			NamespaceName:          NamespaceName(name),
 			CloudMigrationRevision: cloud.CurrentMigrationRevision,
 			KubermaticVersion:      resources.KUBERMATICCOMMIT,
+			ExtendedHealth: kubermaticv1.ExtendedClusterHealth{
+				Apiserver:                    kubermaticv1.HealthStatusProvisioning,
+				Scheduler:                    kubermaticv1.HealthStatusProvisioning,
+				Controller:                   kubermaticv1.HealthStatusProvisioning,
+				MachineController:            kubermaticv1.HealthStatusProvisioning,
+				Etcd:                         kubermaticv1.HealthStatusProvisioning,
+				OpenVPN:                      kubermaticv1.HealthStatusProvisioning,
+				CloudProviderInfrastructure:  kubermaticv1.HealthStatusProvisioning,
+				UserClusterControllerManager: kubermaticv1.HealthStatusProvisioning,
+			},
 		},
 		Address: kubermaticv1.ClusterAddress{},
 	}

--- a/api/pkg/provider/kubernetes/util_test.go
+++ b/api/pkg/provider/kubernetes/util_test.go
@@ -298,6 +298,16 @@ func genCluster(name, clusterType, projectID, workerName, userEmail string) *kub
 	}
 	cluster.Address = kubermaticv1.ClusterAddress{}
 	cluster.Finalizers = []string{TestFakeFinalizer}
+	cluster.Status.ExtendedHealth = kubermaticv1.ExtendedClusterHealth{
+		Apiserver:                    kubermaticv1.HealthStatusProvisioning,
+		Scheduler:                    kubermaticv1.HealthStatusProvisioning,
+		Controller:                   kubermaticv1.HealthStatusProvisioning,
+		MachineController:            kubermaticv1.HealthStatusProvisioning,
+		Etcd:                         kubermaticv1.HealthStatusProvisioning,
+		OpenVPN:                      kubermaticv1.HealthStatusProvisioning,
+		CloudProviderInfrastructure:  kubermaticv1.HealthStatusProvisioning,
+		UserClusterControllerManager: kubermaticv1.HealthStatusProvisioning,
+	}
 
 	if clusterType == "openshift" {
 		cluster.Annotations = map[string]string{


### PR DESCRIPTION
**What this PR does / why we need it**:
Makes control plane appear as pending instead of failed until the cluster is fully initialized.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #3880

**Does this PR introduce a user-facing change?**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If  no release note is required, just write "NONE".
-->
```release-note
NONE
```
