### PR TITLE
Create ClusterIssuers in cert-manager chart

### DIFF
--- a/config/cert-manager/Chart.yaml
+++ b/config/cert-manager/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: cert-manager
-version: 1.1.4
+version: 1.1.5
 appVersion: v0.12.0-beta.1
 description: A Helm chart for cert-manager
 keywords:

--- a/config/cert-manager/templates/clusterissuer.yaml
+++ b/config/cert-manager/templates/clusterissuer.yaml
@@ -1,0 +1,42 @@
+{{ range $name, $issuer := .Values.certManager.clusterIssuers }}
+---
+apiVersion: cert-manager.io/v1alpha2
+kind: ClusterIssuer
+metadata:
+  name: {{ $name }}
+spec:
+  acme:
+    server: {{ $issuer.server }}
+    email: {{ $issuer.email }}
+    privateKeySecretRef:
+      name: {{ $name }}-acme-account-key
+    solvers:
+    - selector:
+{{ toYaml $issuer.solver.selector | indent 8 }}
+      {{- if $issuer.solver.dnsValidation.enabled }}
+      dns01:
+        {{- with $issuer.solver.dnsValidation.route53 }}
+        route53:
+           region: {{ .region | quote }}
+           accessKeyID: {{ .accessKeyID | quote }}
+           secretAccessKeySecretRef:
+             name: {{ $name }}-dns-route53
+             key: secret-access-key
+        {{- end }}
+      {{- else }}
+      http01:
+        ingress:
+          class: nginx
+      {{- end }}
+
+{{- if and $issuer.solver.dnsValidation.enabled $issuer.solver.dnsValidation.route53.region }}
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  name: {{ $name }}-dns-route53
+type: Opaque
+data:
+  secret-access-key: {{ $issuer.solver.dnsValidation.route53.secretAccessKey | b64enc | quote }}
+{{- end }}
+{{ end }}

--- a/config/cert-manager/templates/crd.yaml
+++ b/config/cert-manager/templates/crd.yaml
@@ -1,3 +1,7 @@
+# When updating the CRDs, make sure to remove the `preserveUnknownFields` flag
+# to keep compatibility with Kubernetes < 1.15; see
+# https://docs.cert-manager.io/en/latest/tasks/upgrading/index.html
+
 apiVersion: apiextensions.k8s.io/v1beta1
 kind: CustomResourceDefinition
 metadata:
@@ -25,7 +29,7 @@ spec:
     name: Age
     type: date
   group: cert-manager.io
-  preserveUnknownFields: false
+  # preserveUnknownFields: false
   names:
     kind: CertificateRequest
     listKind: CertificateRequestList
@@ -221,7 +225,7 @@ spec:
     name: Age
     type: date
   group: cert-manager.io
-  preserveUnknownFields: false
+  # preserveUnknownFields: false
   names:
     kind: Certificate
     listKind: CertificateList
@@ -463,7 +467,7 @@ spec:
     name: Age
     type: date
   group: acme.cert-manager.io
-  preserveUnknownFields: false
+  # preserveUnknownFields: false
   names:
     kind: Challenge
     listKind: ChallengeList
@@ -1842,7 +1846,7 @@ spec:
     name: Age
     type: date
   group: cert-manager.io
-  preserveUnknownFields: false
+  # preserveUnknownFields: false
   names:
     kind: ClusterIssuer
     listKind: ClusterIssuerList
@@ -3528,7 +3532,7 @@ spec:
     name: Age
     type: date
   group: cert-manager.io
-  preserveUnknownFields: false
+  # preserveUnknownFields: false
   names:
     kind: Issuer
     listKind: IssuerList
@@ -5218,7 +5222,7 @@ spec:
     name: Age
     type: date
   group: acme.cert-manager.io
-  preserveUnknownFields: false
+  # preserveUnknownFields: false
   names:
     kind: Order
     listKind: OrderList

--- a/config/cert-manager/values.yaml
+++ b/config/cert-manager/values.yaml
@@ -94,3 +94,32 @@ certManager:
     # defaultIssuerName: ""
     # defaultIssuerKind: ""
     # defaultIssuerGroup: ""
+
+  clusterIssuers:
+    letsencrypt-prod:
+      server: https://acme-v02.api.letsencrypt.org/directory
+      email: dev@loodse.com
+      solver:
+        selector: {}
+        # if DNS validation is disabled, HTTP01 validation using
+        # ingresses with class=nginx will be used
+        dnsValidation:
+          enabled: false
+          route53:
+            region: ''
+            accessKeyID: ''
+            secretAccessKey: ''
+
+    letsencrypt-staging:
+      server: https://acme-staging-v02.api.letsencrypt.org/directory
+      email: dev@loodse.com
+      solver:
+        selector: {}
+        # if DNS validation is disabled, HTTP01 validation using
+        # ingresses with class=nginx will be used
+        dnsValidation:
+          enabled: false
+          route53:
+            region: ''
+            accessKeyID: ''
+            secretAccessKey: ''


### PR DESCRIPTION
**What this PR does / why we need it**:
For the Kubermatic Operator and for more charts in general, we want to move away from a single cert for everything (which is then also configured as the global nginx fallback cert), towards one cert per app (i.e. kubermatic can get its own cert, so can the keycloak proxies and every other chart). To make this managable, we need s single place to configure the ACME solvers. Up until a few weeks ago there wasn't much configuration for those solvers, but now that we support DNS via Route53, it make sense to ensure we have a single place to configure that.

This PR therefore allows creating ClusterIssuers right in the cert-manager chart, relying on Helm to install the CRD before setting up the ClusterIssuers.

While I'm at it, this PR also includes the compat fixes for cert-manager.

**Which issue(s) this PR fixes**:
Fixes #4725

**Does this PR introduce a user-facing change?**:
```release-note
The cert-manager Helm chart now creates global ClusterIssuers for Let's Encrypt.
```
