### PR TITLE
Nilcheck configvar in secretkeyselector

### DIFF
--- a/api/pkg/provider/types.go
+++ b/api/pkg/provider/types.go
@@ -71,6 +71,9 @@ type SecretKeySelectorValueFunc func(configVar *providerconfig.GlobalSecretKeySe
 
 func SecretKeySelectorValueFuncFactory(ctx context.Context, client ctrlruntimeclient.Client) SecretKeySelectorValueFunc {
 	return func(configVar *providerconfig.GlobalSecretKeySelector, key string) (string, error) {
+		if configVar == nil {
+			return "", errors.New("configVar is nil")
+		}
 		if configVar.Name == "" {
 			return "", errors.New("configVar.Name is empty")
 		}

--- a/api/pkg/provider/types_test.go
+++ b/api/pkg/provider/types_test.go
@@ -1,0 +1,106 @@
+package provider
+
+import (
+	"context"
+	"testing"
+
+	providerconfig "github.com/kubermatic/machine-controller/pkg/providerconfig/types"
+
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	ctrlruntimeclient "sigs.k8s.io/controller-runtime/pkg/client"
+	fakectrlruntimeclient "sigs.k8s.io/controller-runtime/pkg/client/fake"
+)
+
+func TestSecretKeySelectorValueFuncFactory(t *testing.T) {
+	testCases := []struct {
+		name      string
+		configVar *providerconfig.GlobalSecretKeySelector
+		secret    *corev1.Secret
+		key       string
+
+		expectedError  string
+		expectedResult string
+	}{
+		{
+			name:          "error on nil configVar",
+			expectedError: "configVar is nil",
+		},
+		{
+			name: "error on empty name",
+			configVar: &providerconfig.GlobalSecretKeySelector{
+				ObjectReference: corev1.ObjectReference{
+					Namespace: "foo",
+				},
+			},
+			key:           "hello",
+			expectedError: "configVar.Name is empty",
+		},
+		{
+			name: "error on empty namespace",
+			configVar: &providerconfig.GlobalSecretKeySelector{
+				ObjectReference: corev1.ObjectReference{
+					Name: "foo",
+				},
+			},
+			key:           "bar",
+			expectedError: "configVar.Namspace is empty",
+		},
+		{
+			name: "error on empty key",
+			configVar: &providerconfig.GlobalSecretKeySelector{
+				ObjectReference: corev1.ObjectReference{
+					Namespace: "default",
+					Name:      "foo",
+				},
+			},
+			expectedError: "key is empty",
+		},
+		{
+			name: "happy path",
+			configVar: &providerconfig.GlobalSecretKeySelector{
+				ObjectReference: corev1.ObjectReference{
+					Namespace: "default",
+					Name:      "foo",
+				},
+			},
+			key: "bar",
+			secret: &corev1.Secret{
+				ObjectMeta: metav1.ObjectMeta{
+					Namespace: "default",
+					Name:      "foo",
+				},
+				Data: map[string][]byte{"bar": []byte("value")},
+			},
+			expectedResult: "value",
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			var client ctrlruntimeclient.Client
+			if tc.secret != nil {
+				client = fakectrlruntimeclient.NewFakeClient(tc.secret)
+			} else {
+				client = fakectrlruntimeclient.NewFakeClient()
+			}
+
+			valueFunc := SecretKeySelectorValueFuncFactory(context.Background(), client)
+
+			result, err := valueFunc(tc.configVar, tc.key)
+
+			var actualErr string
+			if err != nil {
+				actualErr = err.Error()
+			}
+
+			if actualErr != tc.expectedError {
+				t.Fatalf("actual err %q does not match expected err %q", actualErr, tc.expectedError)
+			}
+
+			if result != tc.expectedResult {
+				t.Errorf("actual result %q does not match expected result %q", result, tc.expectedResult)
+			}
+		})
+	}
+}


### PR DESCRIPTION
**What this PR does / why we need it**:

Avoids panic when clusters neither contain certain secrets, nor a secretKeySelector.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Documentation**:
<!-- Add links to the related documentation changes related to this pull request. E.g. the link to the kubermatic/docs pullrequest. -->

**Does this PR introduce a user-facing change?**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If  no release note is required, just write "NONE".
-->
```release-note
A panic that could occur on clusters that lack both credentials and a credentialsSecret was fixed.
```
