### PR TITLE
add migration for cluster user labels

### DIFF
--- a/api/pkg/provider/kubernetes/user.go
+++ b/api/pkg/provider/kubernetes/user.go
@@ -14,11 +14,6 @@ import (
 	"k8s.io/apimachinery/pkg/labels"
 )
 
-const (
-	// UserLabelKey defines the label key for the user -> cluster relation
-	UserLabelKey = "user"
-)
-
 // NewUserProvider returns a user provider
 func NewUserProvider(client kubermaticclientset.Interface, userLister kubermaticv1lister.UserLister, isServiceAccountFunc func(email string) bool) *UserProvider {
 	return &UserProvider{


### PR DESCRIPTION
**What this PR does / why we need it**: add migration for cluster user labels. Some clusters still have not used `user` and `user_RAW` labels.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

```release-note
add migration for cluster user labels
```
