### PR TITLE
Add missing AWS AssignPublicIP 

### DIFF
--- a/api/pkg/machine/convert.go
+++ b/api/pkg/machine/convert.go
@@ -86,6 +86,7 @@ func GetAPIV2NodeCloudSpec(machineSpec clusterv1alpha1.MachineSpec) (*apiv1.Node
 			AMI:              config.AMI.Value,
 			AvailabilityZone: config.AvailabilityZone.Value,
 			SubnetID:         config.SubnetID.Value,
+			AssignPublicIP:   config.AssignPublicIP,
 		}
 	case providerconfig.CloudProviderAzure:
 		config := &azure.RawConfig{}


### PR DESCRIPTION
**What this PR does / why we need it**:
Add missing AWS AssignPublicIP, as it seems it wasn't recognized and related endpoints only returned `assignedPublicIP: null` even though it was send via frontend.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Related to https://github.com/kubermatic/dashboard-v2/issues/1814

**Special notes for your reviewer**:
/

**Does this PR introduce a user-facing change?**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If  no release note is required, just write "NONE".
-->
```release-note
NONE
```
