### PR TITLE
Make inherited labels a status rather than a top-level attribute

### DIFF
--- a/api/pkg/controller/project-label-synchronizer/project_label_synchronizer.go
+++ b/api/pkg/controller/project-label-synchronizer/project_label_synchronizer.go
@@ -152,7 +152,7 @@ func (r *reconciler) reconcile(log *zap.SugaredLogger, request reconcile.Request
 			}
 			oldCluster := cluster.DeepCopy()
 			cluster.Labels = newClusterLabels
-			cluster.InheritedLabels = getInheritedLabels(project.Labels)
+			cluster.Status.InheritedLabels = getInheritedLabels(project.Labels)
 			log.Debug("Updating labels on cluster")
 			if err := seedClient.Patch(r.ctx, cluster, ctrlruntimeclient.MergeFrom(oldCluster)); err != nil {
 				errs = append(errs, fmt.Errorf("failed to update cluster %q", cluster.Name))

--- a/api/pkg/controller/project-label-synchronizer/project_label_synchronizer_test.go
+++ b/api/pkg/controller/project-label-synchronizer/project_label_synchronizer_test.go
@@ -127,7 +127,7 @@ func TestReconciliation(t *testing.T) {
 					t.Errorf("Expected labels on cluster %q do not match actual labels, diff: %v", cluster.Name, diff)
 				}
 
-				if diff := deep.Equal(cluster.InheritedLabels, tc.expectedInheritedLabels[cluster.Name]); diff != nil {
+				if diff := deep.Equal(cluster.Status.InheritedLabels, tc.expectedInheritedLabels[cluster.Name]); diff != nil {
 					t.Errorf("Expected inherited labels on cluster %q do not match actual inherited labels, diff: %v", cluster.Name, diff)
 				}
 			}

--- a/api/pkg/crd/kubermatic/v1/cluster.go
+++ b/api/pkg/crd/kubermatic/v1/cluster.go
@@ -48,10 +48,9 @@ type Cluster struct {
 	metav1.TypeMeta   `json:",inline"`
 	metav1.ObjectMeta `json:"metadata,omitempty"`
 
-	Spec            ClusterSpec       `json:"spec"`
-	Address         ClusterAddress    `json:"address,omitempty"`
-	Status          ClusterStatus     `json:"status,omitempty"`
-	InheritedLabels map[string]string `json:"inheritedLabels"`
+	Spec    ClusterSpec    `json:"spec"`
+	Address ClusterAddress `json:"address,omitempty"`
+	Status  ClusterStatus  `json:"status,omitempty"`
 }
 
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object
@@ -201,6 +200,9 @@ type ClusterStatus struct {
 	// CloudMigrationRevision describes the latest version of the migration that has been done
 	// It is used to avoid redundant and potentially costly migrations
 	CloudMigrationRevision int `json:"cloudMigrationRevision"`
+
+	// InheritedLabels are labels the cluster inherited from the project. They are read-only for users.
+	InheritedLabels map[string]string `json:"inheritedLabels,omitempty"`
 }
 
 // HasConditionValue returns true if the cluster status has the given condition with the given status.

--- a/api/pkg/crd/kubermatic/v1/zz_generated.deepcopy.go
+++ b/api/pkg/crd/kubermatic/v1/zz_generated.deepcopy.go
@@ -428,13 +428,6 @@ func (in *Cluster) DeepCopyInto(out *Cluster) {
 	in.Spec.DeepCopyInto(&out.Spec)
 	out.Address = in.Address
 	in.Status.DeepCopyInto(&out.Status)
-	if in.InheritedLabels != nil {
-		in, out := &in.InheritedLabels, &out.InheritedLabels
-		*out = make(map[string]string, len(*in))
-		for key, val := range *in {
-			(*out)[key] = val
-		}
-	}
 	return
 }
 
@@ -631,6 +624,13 @@ func (in *ClusterStatus) DeepCopyInto(out *ClusterStatus) {
 		*out = make([]ClusterCondition, len(*in))
 		for i := range *in {
 			(*in)[i].DeepCopyInto(&(*out)[i])
+		}
+	}
+	if in.InheritedLabels != nil {
+		in, out := &in.InheritedLabels, &out.InheritedLabels
+		*out = make(map[string]string, len(*in))
+		for key, val := range *in {
+			(*out)[key] = val
 		}
 	}
 	return

--- a/api/pkg/handler/v1/cluster/cluster.go
+++ b/api/pkg/handler/v1/cluster/cluster.go
@@ -688,7 +688,7 @@ func convertInternalClusterToExternal(internalCluster *kubermaticv1.Cluster) *ap
 			}(),
 		},
 		Labels:          label.FilterLabels(label.ClusterResourceType, internalCluster.Labels),
-		InheritedLabels: internalCluster.InheritedLabels,
+		InheritedLabels: internalCluster.Status.InheritedLabels,
 		Spec: apiv1.ClusterSpec{
 			Cloud:                               internalCluster.Spec.Cloud,
 			Version:                             internalCluster.Spec.Version,


### PR DESCRIPTION
**What this PR does / why we need it**:

Moves the inheritedLabels attribute on the cluster from the top level to status, as Kube objects should only contain spec, status and metadata: https://github.com/kubernetes/community/blob/master/contributors/devel/sig-architecture/api-conventions.md#spec-and-status

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Documentation**:
<!-- Add links to the related documentation changes related to this pull request. E.g. the link to the kubermatic/docs pullrequest. -->

**Does this PR introduce a user-facing change?**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If  no release note is required, just write "NONE".
-->
```release-note
none
```
/assign @maciaszczykm 
