### PR TITLE
Usercluster-controller: Load cloudconfig from seed

### DIFF
--- a/api/cmd/user-cluster-controller-manager/main.go
+++ b/api/cmd/user-cluster-controller-manager/main.go
@@ -6,7 +6,6 @@ import (
 	"errors"
 	"flag"
 	"fmt"
-	"io/ioutil"
 	"net/http"
 	"net/url"
 	"os"
@@ -59,7 +58,6 @@ type controllerRunOptions struct {
 	overwriteRegistry             string
 	cloudProviderName             string
 	cloudCredentialSecretTemplate string
-	cloudConfig                   string
 	nodelabels                    string
 	seedKubeconfig                string
 	openshiftConsoleCallbackURI   string
@@ -87,7 +85,6 @@ func main() {
 	flag.StringVar(&runOp.nodelabels, "node-labels", "", "A json-encoded map of node labels. If set, those labels will be enforced on all nodes.")
 	flag.StringVar(&runOp.seedKubeconfig, "seed-kubeconfig", "", "Path to the seed kubeconfig. In-Cluster config will be used if unset")
 	flag.StringVar(&runOp.openshiftConsoleCallbackURI, "openshift-console-callback-uri", "", "The callback uri for the openshift console")
-	flag.StringVar(&runOp.cloudConfig, "cloud-config", "", "Path to cloud config")
 
 	flag.Parse()
 
@@ -111,14 +108,6 @@ func main() {
 	}
 	if runOp.openvpnServerPort == 0 {
 		log.Fatal("-openvpn-server-port must be set")
-	}
-
-	var cloudConfig []byte
-	if runOp.cloudConfig != "" {
-		cloudConfig, err = ioutil.ReadFile(runOp.cloudConfig)
-		if err != nil {
-			log.Fatalf("Failed to read cloud-config: %v", err)
-		}
 	}
 
 	var cloudCredentialSecretTemplate *corev1.Secret
@@ -209,7 +198,6 @@ func main() {
 		healthHandler.AddReadinessCheck,
 		cloudCredentialSecretTemplate,
 		runOp.openshiftConsoleCallbackURI,
-		cloudConfig,
 		log,
 	); err != nil {
 		log.Fatalw("Failed to register user cluster controller", zap.Error(err))

--- a/api/pkg/controller/seed-controller-manager/openshift/testdata/Kubermatic_API_image_is_overwritten-usercluster-controller.golden.yaml
+++ b/api/pkg/controller/seed-controller-manager/openshift/testdata/Kubermatic_API_image_is_overwritten-usercluster-controller.golden.yaml
@@ -23,7 +23,6 @@ spec:
       creationTimestamp: null
       labels:
         app: usercluster-controller
-        cloud-config-configmap-revision: ""
         cluster: test-cluster
         internal-admin-kubeconfig-secret-revision: ""
     spec:
@@ -39,7 +38,7 @@ spec:
         - -timeout
         - "1"
         - -command
-        - '{"command":"/usr/local/bin/user-cluster-controller-manager","args":["-kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","-metrics-listen-address","0.0.0.0:8085","-health-listen-address","0.0.0.0:8086","-namespace","$(NAMESPACE)","-cluster-url","https://test-cluster.alias-europe-west3-c.dev.kubermatic.io:0","-cloud-config","/etc/kubernetes/cloud/config","-openvpn-server-port","0","-overwrite-registry","","-openshift=true","-version","4.1.9","-cloud-provider-name","","-openshift-console-callback-uri","https://dev.kubermatic.io/api/v1/projects//dc/alias-europe-west3-c/clusters/test-cluster/openshift/console/proxy/auth/callback"]}'
+        - '{"command":"/usr/local/bin/user-cluster-controller-manager","args":["-kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","-metrics-listen-address","0.0.0.0:8085","-health-listen-address","0.0.0.0:8086","-namespace","$(NAMESPACE)","-cluster-url","https://test-cluster.alias-europe-west3-c.dev.kubermatic.io:0","-openvpn-server-port","0","-overwrite-registry","","-openshift=true","-version","4.1.9","-cloud-provider-name","","-openshift-console-callback-uri","https://dev.kubermatic.io/api/v1/projects//dc/alias-europe-west3-c/clusters/test-cluster/openshift/console/proxy/auth/callback"]}'
         command:
         - /http-prober-bin/http-prober
         env:
@@ -73,9 +72,6 @@ spec:
         - mountPath: /etc/kubernetes/kubeconfig
           name: internal-admin-kubeconfig
           readOnly: true
-        - mountPath: /etc/kubernetes/cloud
-          name: cloud-config
-          readOnly: true
         - mountPath: /http-prober-bin
           name: http-prober-bin
       imagePullSecrets:
@@ -100,10 +96,6 @@ spec:
         secret:
           defaultMode: 420
           secretName: internal-admin-kubeconfig
-      - configMap:
-          defaultMode: 420
-          name: cloud-config
-        name: cloud-config
       - emptyDir: {}
         name: http-prober-bin
 status: {}

--- a/api/pkg/controller/user-cluster-controller-manager/resources/controller.go
+++ b/api/pkg/controller/user-cluster-controller-manager/resources/controller.go
@@ -54,7 +54,6 @@ func Add(
 	registerReconciledCheck func(name string, check healthcheck.Check),
 	cloudCredentialSecretTemplate *corev1.Secret,
 	openshiftConsoleCallbackURI string,
-	cloudConfig []byte,
 	log *zap.SugaredLogger) error {
 	r := &reconciler{
 		openshift:                     openshift,
@@ -64,7 +63,6 @@ func Add(
 		clusterURL:                    clusterURL,
 		openvpnServerPort:             openvpnServerPort,
 		cloudCredentialSecretTemplate: cloudCredentialSecretTemplate,
-		cloudConfig:                   cloudConfig,
 		log:                           log,
 		platform:                      cloudProviderName,
 		openshiftConsoleCallbackURI:   openshiftConsoleCallbackURI,
@@ -167,6 +165,7 @@ func Add(
 
 	seedTypesToWatch := []runtime.Object{
 		&corev1.Secret{},
+		&corev1.ConfigMap{},
 	}
 	for _, t := range seedTypesToWatch {
 		seedWatch := &source.Kind{Type: t}
@@ -204,7 +203,6 @@ type reconciler struct {
 	platform                      string
 	cloudCredentialSecretTemplate *corev1.Secret
 	openshiftConsoleCallbackURI   string
-	cloudConfig                   []byte
 
 	rLock                      *sync.Mutex
 	reconciledSuccessfullyOnce bool
@@ -246,6 +244,19 @@ func (r *reconciler) userSSHKeys(ctx context.Context) (map[string][]byte, error)
 		return nil, err
 	}
 	return secret.Data, nil
+}
+
+func (r *reconciler) cloudConfig(ctx context.Context) ([]byte, error) {
+	configmap := &corev1.ConfigMap{}
+	name := types.NamespacedName{Namespace: r.namespace, Name: resources.CloudConfigConfigMapName}
+	if err := r.seedClient.Get(ctx, name, configmap); err != nil {
+		return nil, fmt.Errorf("failed to get cloud-config: %v", err)
+	}
+	value, exists := configmap.Data[resources.CloudConfigConfigMapKey]
+	if !exists {
+		return nil, fmt.Errorf("cloud-config configmap contains no data for key %s", resources.CloudConfigConfigMapKey)
+	}
+	return []byte(value), nil
 }
 
 func apiReadingClient(apiReader ctrlruntimeclient.Reader, writer ctrlruntimeclient.Client) ctrlruntimeclient.Client {

--- a/api/pkg/controller/user-cluster-controller-manager/resources/controller.go
+++ b/api/pkg/controller/user-cluster-controller-manager/resources/controller.go
@@ -122,6 +122,7 @@ func Add(
 		&corev1.ServiceAccount{},
 		&corev1.Service{},
 		&corev1.ConfigMap{},
+		&corev1.Secret{},
 		&rbacv1.Role{},
 		&rbacv1.RoleBinding{},
 		&rbacv1.ClusterRole{},

--- a/api/pkg/resources/cloudconfig/configmap.go
+++ b/api/pkg/resources/cloudconfig/configmap.go
@@ -49,7 +49,7 @@ func ConfigMapCreator(data configMapCreatorData) reconciling.NamedConfigMapCreat
 			}
 
 			cm.Labels = resources.BaseAppLabel(name, nil)
-			cm.Data["config"] = cloudConfig
+			cm.Data[resources.CloudConfigConfigMapKey] = cloudConfig
 			cm.Data[FakeVMWareUUIDKeyName] = fakeVMWareUUID
 
 			return cm, nil

--- a/api/pkg/resources/resources.go
+++ b/api/pkg/resources/resources.go
@@ -182,8 +182,10 @@ const (
 	// the Kubernetes Dashboard
 	KubernetesDashboardCsrfTokenSecretName = "kubernetes-dashboard-csrf"
 
-	//CloudConfigConfigMapName is the name for the configmap containing the cloud-config
+	// CloudConfigConfigMapName is the name for the configmap containing the cloud-config
 	CloudConfigConfigMapName = "cloud-config"
+	// CloudConfigConfigMapKey is the key under which the cloud-config in the cloud-config configmap can be found
+	CloudConfigConfigMapKey = "config"
 	//OpenVPNClientConfigsConfigMapName is the name for the ConfigMap containing the OpenVPN client config used within the user cluster
 	OpenVPNClientConfigsConfigMapName = "openvpn-client-configs"
 	//OpenVPNClientConfigConfigMapName is the name for the ConfigMap containing the OpenVPN client config used by the client inside the user cluster

--- a/api/pkg/resources/test/fixtures/deployment-aws-1.10.0-usercluster-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-aws-1.10.0-usercluster-controller.yaml
@@ -22,7 +22,6 @@ spec:
       creationTimestamp: null
       labels:
         app: usercluster-controller
-        cloud-config-configmap-revision: "123456"
         cluster: de-test-01
         internal-admin-kubeconfig-secret-revision: "123456"
     spec:
@@ -38,7 +37,7 @@ spec:
         - -timeout
         - "1"
         - -command
-        - '{"command":"/usr/local/bin/user-cluster-controller-manager","args":["-kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","-metrics-listen-address","0.0.0.0:8085","-health-listen-address","0.0.0.0:8086","-namespace","$(NAMESPACE)","-cluster-url","","-cloud-config","/etc/kubernetes/cloud/config","-openvpn-server-port","30003","-overwrite-registry","","-openshift=false","-version","1.10.0","-cloud-provider-name","aws","--ipam-controller-network","192.168.1.1/24,192.168.1.1,8.8.8.8","-node-labels","{\"my-label\":\"my-value\"}"]}'
+        - '{"command":"/usr/local/bin/user-cluster-controller-manager","args":["-kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","-metrics-listen-address","0.0.0.0:8085","-health-listen-address","0.0.0.0:8086","-namespace","$(NAMESPACE)","-cluster-url","","-openvpn-server-port","30003","-overwrite-registry","","-openshift=false","-version","1.10.0","-cloud-provider-name","aws","--ipam-controller-network","192.168.1.1/24,192.168.1.1,8.8.8.8","-node-labels","{\"my-label\":\"my-value\"}"]}'
         command:
         - /http-prober-bin/http-prober
         env:
@@ -69,9 +68,6 @@ spec:
         - mountPath: /etc/kubernetes/kubeconfig
           name: internal-admin-kubeconfig
           readOnly: true
-        - mountPath: /etc/kubernetes/cloud
-          name: cloud-config
-          readOnly: true
         - mountPath: /http-prober-bin
           name: http-prober-bin
       imagePullSecrets:
@@ -92,9 +88,6 @@ spec:
       - name: internal-admin-kubeconfig
         secret:
           secretName: internal-admin-kubeconfig
-      - configMap:
-          name: cloud-config
-        name: cloud-config
       - emptyDir: {}
         name: http-prober-bin
 status: {}

--- a/api/pkg/resources/test/fixtures/deployment-aws-1.10.6-usercluster-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-aws-1.10.6-usercluster-controller.yaml
@@ -22,7 +22,6 @@ spec:
       creationTimestamp: null
       labels:
         app: usercluster-controller
-        cloud-config-configmap-revision: "123456"
         cluster: de-test-01
         internal-admin-kubeconfig-secret-revision: "123456"
     spec:
@@ -38,7 +37,7 @@ spec:
         - -timeout
         - "1"
         - -command
-        - '{"command":"/usr/local/bin/user-cluster-controller-manager","args":["-kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","-metrics-listen-address","0.0.0.0:8085","-health-listen-address","0.0.0.0:8086","-namespace","$(NAMESPACE)","-cluster-url","","-cloud-config","/etc/kubernetes/cloud/config","-openvpn-server-port","30003","-overwrite-registry","","-openshift=false","-version","1.10.6","-cloud-provider-name","aws","--ipam-controller-network","192.168.1.1/24,192.168.1.1,8.8.8.8","-node-labels","{\"my-label\":\"my-value\"}"]}'
+        - '{"command":"/usr/local/bin/user-cluster-controller-manager","args":["-kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","-metrics-listen-address","0.0.0.0:8085","-health-listen-address","0.0.0.0:8086","-namespace","$(NAMESPACE)","-cluster-url","","-openvpn-server-port","30003","-overwrite-registry","","-openshift=false","-version","1.10.6","-cloud-provider-name","aws","--ipam-controller-network","192.168.1.1/24,192.168.1.1,8.8.8.8","-node-labels","{\"my-label\":\"my-value\"}"]}'
         command:
         - /http-prober-bin/http-prober
         env:
@@ -69,9 +68,6 @@ spec:
         - mountPath: /etc/kubernetes/kubeconfig
           name: internal-admin-kubeconfig
           readOnly: true
-        - mountPath: /etc/kubernetes/cloud
-          name: cloud-config
-          readOnly: true
         - mountPath: /http-prober-bin
           name: http-prober-bin
       imagePullSecrets:
@@ -92,9 +88,6 @@ spec:
       - name: internal-admin-kubeconfig
         secret:
           secretName: internal-admin-kubeconfig
-      - configMap:
-          name: cloud-config
-        name: cloud-config
       - emptyDir: {}
         name: http-prober-bin
 status: {}

--- a/api/pkg/resources/test/fixtures/deployment-aws-1.11.0-usercluster-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-aws-1.11.0-usercluster-controller.yaml
@@ -22,7 +22,6 @@ spec:
       creationTimestamp: null
       labels:
         app: usercluster-controller
-        cloud-config-configmap-revision: "123456"
         cluster: de-test-01
         internal-admin-kubeconfig-secret-revision: "123456"
     spec:
@@ -38,7 +37,7 @@ spec:
         - -timeout
         - "1"
         - -command
-        - '{"command":"/usr/local/bin/user-cluster-controller-manager","args":["-kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","-metrics-listen-address","0.0.0.0:8085","-health-listen-address","0.0.0.0:8086","-namespace","$(NAMESPACE)","-cluster-url","","-cloud-config","/etc/kubernetes/cloud/config","-openvpn-server-port","30003","-overwrite-registry","","-openshift=false","-version","1.11.0","-cloud-provider-name","aws","--ipam-controller-network","192.168.1.1/24,192.168.1.1,8.8.8.8","-node-labels","{\"my-label\":\"my-value\"}"]}'
+        - '{"command":"/usr/local/bin/user-cluster-controller-manager","args":["-kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","-metrics-listen-address","0.0.0.0:8085","-health-listen-address","0.0.0.0:8086","-namespace","$(NAMESPACE)","-cluster-url","","-openvpn-server-port","30003","-overwrite-registry","","-openshift=false","-version","1.11.0","-cloud-provider-name","aws","--ipam-controller-network","192.168.1.1/24,192.168.1.1,8.8.8.8","-node-labels","{\"my-label\":\"my-value\"}"]}'
         command:
         - /http-prober-bin/http-prober
         env:
@@ -69,9 +68,6 @@ spec:
         - mountPath: /etc/kubernetes/kubeconfig
           name: internal-admin-kubeconfig
           readOnly: true
-        - mountPath: /etc/kubernetes/cloud
-          name: cloud-config
-          readOnly: true
         - mountPath: /http-prober-bin
           name: http-prober-bin
       imagePullSecrets:
@@ -92,9 +88,6 @@ spec:
       - name: internal-admin-kubeconfig
         secret:
           secretName: internal-admin-kubeconfig
-      - configMap:
-          name: cloud-config
-        name: cloud-config
       - emptyDir: {}
         name: http-prober-bin
 status: {}

--- a/api/pkg/resources/test/fixtures/deployment-aws-1.11.1-usercluster-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-aws-1.11.1-usercluster-controller.yaml
@@ -22,7 +22,6 @@ spec:
       creationTimestamp: null
       labels:
         app: usercluster-controller
-        cloud-config-configmap-revision: "123456"
         cluster: de-test-01
         internal-admin-kubeconfig-secret-revision: "123456"
     spec:
@@ -38,7 +37,7 @@ spec:
         - -timeout
         - "1"
         - -command
-        - '{"command":"/usr/local/bin/user-cluster-controller-manager","args":["-kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","-metrics-listen-address","0.0.0.0:8085","-health-listen-address","0.0.0.0:8086","-namespace","$(NAMESPACE)","-cluster-url","","-cloud-config","/etc/kubernetes/cloud/config","-openvpn-server-port","30003","-overwrite-registry","","-openshift=false","-version","1.11.1","-cloud-provider-name","aws","--ipam-controller-network","192.168.1.1/24,192.168.1.1,8.8.8.8","-node-labels","{\"my-label\":\"my-value\"}"]}'
+        - '{"command":"/usr/local/bin/user-cluster-controller-manager","args":["-kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","-metrics-listen-address","0.0.0.0:8085","-health-listen-address","0.0.0.0:8086","-namespace","$(NAMESPACE)","-cluster-url","","-openvpn-server-port","30003","-overwrite-registry","","-openshift=false","-version","1.11.1","-cloud-provider-name","aws","--ipam-controller-network","192.168.1.1/24,192.168.1.1,8.8.8.8","-node-labels","{\"my-label\":\"my-value\"}"]}'
         command:
         - /http-prober-bin/http-prober
         env:
@@ -69,9 +68,6 @@ spec:
         - mountPath: /etc/kubernetes/kubeconfig
           name: internal-admin-kubeconfig
           readOnly: true
-        - mountPath: /etc/kubernetes/cloud
-          name: cloud-config
-          readOnly: true
         - mountPath: /http-prober-bin
           name: http-prober-bin
       imagePullSecrets:
@@ -92,9 +88,6 @@ spec:
       - name: internal-admin-kubeconfig
         secret:
           secretName: internal-admin-kubeconfig
-      - configMap:
-          name: cloud-config
-        name: cloud-config
       - emptyDir: {}
         name: http-prober-bin
 status: {}

--- a/api/pkg/resources/test/fixtures/deployment-aws-1.12.0-usercluster-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-aws-1.12.0-usercluster-controller.yaml
@@ -22,7 +22,6 @@ spec:
       creationTimestamp: null
       labels:
         app: usercluster-controller
-        cloud-config-configmap-revision: "123456"
         cluster: de-test-01
         internal-admin-kubeconfig-secret-revision: "123456"
     spec:
@@ -38,7 +37,7 @@ spec:
         - -timeout
         - "1"
         - -command
-        - '{"command":"/usr/local/bin/user-cluster-controller-manager","args":["-kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","-metrics-listen-address","0.0.0.0:8085","-health-listen-address","0.0.0.0:8086","-namespace","$(NAMESPACE)","-cluster-url","","-cloud-config","/etc/kubernetes/cloud/config","-openvpn-server-port","30003","-overwrite-registry","","-openshift=false","-version","1.12.0","-cloud-provider-name","aws","--ipam-controller-network","192.168.1.1/24,192.168.1.1,8.8.8.8","-node-labels","{\"my-label\":\"my-value\"}"]}'
+        - '{"command":"/usr/local/bin/user-cluster-controller-manager","args":["-kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","-metrics-listen-address","0.0.0.0:8085","-health-listen-address","0.0.0.0:8086","-namespace","$(NAMESPACE)","-cluster-url","","-openvpn-server-port","30003","-overwrite-registry","","-openshift=false","-version","1.12.0","-cloud-provider-name","aws","--ipam-controller-network","192.168.1.1/24,192.168.1.1,8.8.8.8","-node-labels","{\"my-label\":\"my-value\"}"]}'
         command:
         - /http-prober-bin/http-prober
         env:
@@ -69,9 +68,6 @@ spec:
         - mountPath: /etc/kubernetes/kubeconfig
           name: internal-admin-kubeconfig
           readOnly: true
-        - mountPath: /etc/kubernetes/cloud
-          name: cloud-config
-          readOnly: true
         - mountPath: /http-prober-bin
           name: http-prober-bin
       imagePullSecrets:
@@ -92,9 +88,6 @@ spec:
       - name: internal-admin-kubeconfig
         secret:
           secretName: internal-admin-kubeconfig
-      - configMap:
-          name: cloud-config
-        name: cloud-config
       - emptyDir: {}
         name: http-prober-bin
 status: {}

--- a/api/pkg/resources/test/fixtures/deployment-aws-1.13.0-usercluster-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-aws-1.13.0-usercluster-controller.yaml
@@ -22,7 +22,6 @@ spec:
       creationTimestamp: null
       labels:
         app: usercluster-controller
-        cloud-config-configmap-revision: "123456"
         cluster: de-test-01
         internal-admin-kubeconfig-secret-revision: "123456"
     spec:
@@ -38,7 +37,7 @@ spec:
         - -timeout
         - "1"
         - -command
-        - '{"command":"/usr/local/bin/user-cluster-controller-manager","args":["-kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","-metrics-listen-address","0.0.0.0:8085","-health-listen-address","0.0.0.0:8086","-namespace","$(NAMESPACE)","-cluster-url","","-cloud-config","/etc/kubernetes/cloud/config","-openvpn-server-port","30003","-overwrite-registry","","-openshift=false","-version","1.13.0","-cloud-provider-name","aws","--ipam-controller-network","192.168.1.1/24,192.168.1.1,8.8.8.8","-node-labels","{\"my-label\":\"my-value\"}"]}'
+        - '{"command":"/usr/local/bin/user-cluster-controller-manager","args":["-kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","-metrics-listen-address","0.0.0.0:8085","-health-listen-address","0.0.0.0:8086","-namespace","$(NAMESPACE)","-cluster-url","","-openvpn-server-port","30003","-overwrite-registry","","-openshift=false","-version","1.13.0","-cloud-provider-name","aws","--ipam-controller-network","192.168.1.1/24,192.168.1.1,8.8.8.8","-node-labels","{\"my-label\":\"my-value\"}"]}'
         command:
         - /http-prober-bin/http-prober
         env:
@@ -69,9 +68,6 @@ spec:
         - mountPath: /etc/kubernetes/kubeconfig
           name: internal-admin-kubeconfig
           readOnly: true
-        - mountPath: /etc/kubernetes/cloud
-          name: cloud-config
-          readOnly: true
         - mountPath: /http-prober-bin
           name: http-prober-bin
       imagePullSecrets:
@@ -92,9 +88,6 @@ spec:
       - name: internal-admin-kubeconfig
         secret:
           secretName: internal-admin-kubeconfig
-      - configMap:
-          name: cloud-config
-        name: cloud-config
       - emptyDir: {}
         name: http-prober-bin
 status: {}

--- a/api/pkg/resources/test/fixtures/deployment-azure-1.10.0-usercluster-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-azure-1.10.0-usercluster-controller.yaml
@@ -22,7 +22,6 @@ spec:
       creationTimestamp: null
       labels:
         app: usercluster-controller
-        cloud-config-configmap-revision: "123456"
         cluster: de-test-01
         internal-admin-kubeconfig-secret-revision: "123456"
     spec:
@@ -38,7 +37,7 @@ spec:
         - -timeout
         - "1"
         - -command
-        - '{"command":"/usr/local/bin/user-cluster-controller-manager","args":["-kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","-metrics-listen-address","0.0.0.0:8085","-health-listen-address","0.0.0.0:8086","-namespace","$(NAMESPACE)","-cluster-url","","-cloud-config","/etc/kubernetes/cloud/config","-openvpn-server-port","30003","-overwrite-registry","","-openshift=false","-version","1.10.0","-cloud-provider-name","azure","--ipam-controller-network","192.168.1.1/24,192.168.1.1,8.8.8.8","-node-labels","{\"my-label\":\"my-value\"}"]}'
+        - '{"command":"/usr/local/bin/user-cluster-controller-manager","args":["-kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","-metrics-listen-address","0.0.0.0:8085","-health-listen-address","0.0.0.0:8086","-namespace","$(NAMESPACE)","-cluster-url","","-openvpn-server-port","30003","-overwrite-registry","","-openshift=false","-version","1.10.0","-cloud-provider-name","azure","--ipam-controller-network","192.168.1.1/24,192.168.1.1,8.8.8.8","-node-labels","{\"my-label\":\"my-value\"}"]}'
         command:
         - /http-prober-bin/http-prober
         env:
@@ -69,9 +68,6 @@ spec:
         - mountPath: /etc/kubernetes/kubeconfig
           name: internal-admin-kubeconfig
           readOnly: true
-        - mountPath: /etc/kubernetes/cloud
-          name: cloud-config
-          readOnly: true
         - mountPath: /http-prober-bin
           name: http-prober-bin
       imagePullSecrets:
@@ -92,9 +88,6 @@ spec:
       - name: internal-admin-kubeconfig
         secret:
           secretName: internal-admin-kubeconfig
-      - configMap:
-          name: cloud-config
-        name: cloud-config
       - emptyDir: {}
         name: http-prober-bin
 status: {}

--- a/api/pkg/resources/test/fixtures/deployment-azure-1.10.6-usercluster-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-azure-1.10.6-usercluster-controller.yaml
@@ -22,7 +22,6 @@ spec:
       creationTimestamp: null
       labels:
         app: usercluster-controller
-        cloud-config-configmap-revision: "123456"
         cluster: de-test-01
         internal-admin-kubeconfig-secret-revision: "123456"
     spec:
@@ -38,7 +37,7 @@ spec:
         - -timeout
         - "1"
         - -command
-        - '{"command":"/usr/local/bin/user-cluster-controller-manager","args":["-kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","-metrics-listen-address","0.0.0.0:8085","-health-listen-address","0.0.0.0:8086","-namespace","$(NAMESPACE)","-cluster-url","","-cloud-config","/etc/kubernetes/cloud/config","-openvpn-server-port","30003","-overwrite-registry","","-openshift=false","-version","1.10.6","-cloud-provider-name","azure","--ipam-controller-network","192.168.1.1/24,192.168.1.1,8.8.8.8","-node-labels","{\"my-label\":\"my-value\"}"]}'
+        - '{"command":"/usr/local/bin/user-cluster-controller-manager","args":["-kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","-metrics-listen-address","0.0.0.0:8085","-health-listen-address","0.0.0.0:8086","-namespace","$(NAMESPACE)","-cluster-url","","-openvpn-server-port","30003","-overwrite-registry","","-openshift=false","-version","1.10.6","-cloud-provider-name","azure","--ipam-controller-network","192.168.1.1/24,192.168.1.1,8.8.8.8","-node-labels","{\"my-label\":\"my-value\"}"]}'
         command:
         - /http-prober-bin/http-prober
         env:
@@ -69,9 +68,6 @@ spec:
         - mountPath: /etc/kubernetes/kubeconfig
           name: internal-admin-kubeconfig
           readOnly: true
-        - mountPath: /etc/kubernetes/cloud
-          name: cloud-config
-          readOnly: true
         - mountPath: /http-prober-bin
           name: http-prober-bin
       imagePullSecrets:
@@ -92,9 +88,6 @@ spec:
       - name: internal-admin-kubeconfig
         secret:
           secretName: internal-admin-kubeconfig
-      - configMap:
-          name: cloud-config
-        name: cloud-config
       - emptyDir: {}
         name: http-prober-bin
 status: {}

--- a/api/pkg/resources/test/fixtures/deployment-azure-1.11.0-usercluster-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-azure-1.11.0-usercluster-controller.yaml
@@ -22,7 +22,6 @@ spec:
       creationTimestamp: null
       labels:
         app: usercluster-controller
-        cloud-config-configmap-revision: "123456"
         cluster: de-test-01
         internal-admin-kubeconfig-secret-revision: "123456"
     spec:
@@ -38,7 +37,7 @@ spec:
         - -timeout
         - "1"
         - -command
-        - '{"command":"/usr/local/bin/user-cluster-controller-manager","args":["-kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","-metrics-listen-address","0.0.0.0:8085","-health-listen-address","0.0.0.0:8086","-namespace","$(NAMESPACE)","-cluster-url","","-cloud-config","/etc/kubernetes/cloud/config","-openvpn-server-port","30003","-overwrite-registry","","-openshift=false","-version","1.11.0","-cloud-provider-name","azure","--ipam-controller-network","192.168.1.1/24,192.168.1.1,8.8.8.8","-node-labels","{\"my-label\":\"my-value\"}"]}'
+        - '{"command":"/usr/local/bin/user-cluster-controller-manager","args":["-kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","-metrics-listen-address","0.0.0.0:8085","-health-listen-address","0.0.0.0:8086","-namespace","$(NAMESPACE)","-cluster-url","","-openvpn-server-port","30003","-overwrite-registry","","-openshift=false","-version","1.11.0","-cloud-provider-name","azure","--ipam-controller-network","192.168.1.1/24,192.168.1.1,8.8.8.8","-node-labels","{\"my-label\":\"my-value\"}"]}'
         command:
         - /http-prober-bin/http-prober
         env:
@@ -69,9 +68,6 @@ spec:
         - mountPath: /etc/kubernetes/kubeconfig
           name: internal-admin-kubeconfig
           readOnly: true
-        - mountPath: /etc/kubernetes/cloud
-          name: cloud-config
-          readOnly: true
         - mountPath: /http-prober-bin
           name: http-prober-bin
       imagePullSecrets:
@@ -92,9 +88,6 @@ spec:
       - name: internal-admin-kubeconfig
         secret:
           secretName: internal-admin-kubeconfig
-      - configMap:
-          name: cloud-config
-        name: cloud-config
       - emptyDir: {}
         name: http-prober-bin
 status: {}

--- a/api/pkg/resources/test/fixtures/deployment-azure-1.11.1-usercluster-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-azure-1.11.1-usercluster-controller.yaml
@@ -22,7 +22,6 @@ spec:
       creationTimestamp: null
       labels:
         app: usercluster-controller
-        cloud-config-configmap-revision: "123456"
         cluster: de-test-01
         internal-admin-kubeconfig-secret-revision: "123456"
     spec:
@@ -38,7 +37,7 @@ spec:
         - -timeout
         - "1"
         - -command
-        - '{"command":"/usr/local/bin/user-cluster-controller-manager","args":["-kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","-metrics-listen-address","0.0.0.0:8085","-health-listen-address","0.0.0.0:8086","-namespace","$(NAMESPACE)","-cluster-url","","-cloud-config","/etc/kubernetes/cloud/config","-openvpn-server-port","30003","-overwrite-registry","","-openshift=false","-version","1.11.1","-cloud-provider-name","azure","--ipam-controller-network","192.168.1.1/24,192.168.1.1,8.8.8.8","-node-labels","{\"my-label\":\"my-value\"}"]}'
+        - '{"command":"/usr/local/bin/user-cluster-controller-manager","args":["-kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","-metrics-listen-address","0.0.0.0:8085","-health-listen-address","0.0.0.0:8086","-namespace","$(NAMESPACE)","-cluster-url","","-openvpn-server-port","30003","-overwrite-registry","","-openshift=false","-version","1.11.1","-cloud-provider-name","azure","--ipam-controller-network","192.168.1.1/24,192.168.1.1,8.8.8.8","-node-labels","{\"my-label\":\"my-value\"}"]}'
         command:
         - /http-prober-bin/http-prober
         env:
@@ -69,9 +68,6 @@ spec:
         - mountPath: /etc/kubernetes/kubeconfig
           name: internal-admin-kubeconfig
           readOnly: true
-        - mountPath: /etc/kubernetes/cloud
-          name: cloud-config
-          readOnly: true
         - mountPath: /http-prober-bin
           name: http-prober-bin
       imagePullSecrets:
@@ -92,9 +88,6 @@ spec:
       - name: internal-admin-kubeconfig
         secret:
           secretName: internal-admin-kubeconfig
-      - configMap:
-          name: cloud-config
-        name: cloud-config
       - emptyDir: {}
         name: http-prober-bin
 status: {}

--- a/api/pkg/resources/test/fixtures/deployment-azure-1.12.0-usercluster-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-azure-1.12.0-usercluster-controller.yaml
@@ -22,7 +22,6 @@ spec:
       creationTimestamp: null
       labels:
         app: usercluster-controller
-        cloud-config-configmap-revision: "123456"
         cluster: de-test-01
         internal-admin-kubeconfig-secret-revision: "123456"
     spec:
@@ -38,7 +37,7 @@ spec:
         - -timeout
         - "1"
         - -command
-        - '{"command":"/usr/local/bin/user-cluster-controller-manager","args":["-kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","-metrics-listen-address","0.0.0.0:8085","-health-listen-address","0.0.0.0:8086","-namespace","$(NAMESPACE)","-cluster-url","","-cloud-config","/etc/kubernetes/cloud/config","-openvpn-server-port","30003","-overwrite-registry","","-openshift=false","-version","1.12.0","-cloud-provider-name","azure","--ipam-controller-network","192.168.1.1/24,192.168.1.1,8.8.8.8","-node-labels","{\"my-label\":\"my-value\"}"]}'
+        - '{"command":"/usr/local/bin/user-cluster-controller-manager","args":["-kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","-metrics-listen-address","0.0.0.0:8085","-health-listen-address","0.0.0.0:8086","-namespace","$(NAMESPACE)","-cluster-url","","-openvpn-server-port","30003","-overwrite-registry","","-openshift=false","-version","1.12.0","-cloud-provider-name","azure","--ipam-controller-network","192.168.1.1/24,192.168.1.1,8.8.8.8","-node-labels","{\"my-label\":\"my-value\"}"]}'
         command:
         - /http-prober-bin/http-prober
         env:
@@ -69,9 +68,6 @@ spec:
         - mountPath: /etc/kubernetes/kubeconfig
           name: internal-admin-kubeconfig
           readOnly: true
-        - mountPath: /etc/kubernetes/cloud
-          name: cloud-config
-          readOnly: true
         - mountPath: /http-prober-bin
           name: http-prober-bin
       imagePullSecrets:
@@ -92,9 +88,6 @@ spec:
       - name: internal-admin-kubeconfig
         secret:
           secretName: internal-admin-kubeconfig
-      - configMap:
-          name: cloud-config
-        name: cloud-config
       - emptyDir: {}
         name: http-prober-bin
 status: {}

--- a/api/pkg/resources/test/fixtures/deployment-azure-1.13.0-usercluster-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-azure-1.13.0-usercluster-controller.yaml
@@ -22,7 +22,6 @@ spec:
       creationTimestamp: null
       labels:
         app: usercluster-controller
-        cloud-config-configmap-revision: "123456"
         cluster: de-test-01
         internal-admin-kubeconfig-secret-revision: "123456"
     spec:
@@ -38,7 +37,7 @@ spec:
         - -timeout
         - "1"
         - -command
-        - '{"command":"/usr/local/bin/user-cluster-controller-manager","args":["-kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","-metrics-listen-address","0.0.0.0:8085","-health-listen-address","0.0.0.0:8086","-namespace","$(NAMESPACE)","-cluster-url","","-cloud-config","/etc/kubernetes/cloud/config","-openvpn-server-port","30003","-overwrite-registry","","-openshift=false","-version","1.13.0","-cloud-provider-name","azure","--ipam-controller-network","192.168.1.1/24,192.168.1.1,8.8.8.8","-node-labels","{\"my-label\":\"my-value\"}"]}'
+        - '{"command":"/usr/local/bin/user-cluster-controller-manager","args":["-kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","-metrics-listen-address","0.0.0.0:8085","-health-listen-address","0.0.0.0:8086","-namespace","$(NAMESPACE)","-cluster-url","","-openvpn-server-port","30003","-overwrite-registry","","-openshift=false","-version","1.13.0","-cloud-provider-name","azure","--ipam-controller-network","192.168.1.1/24,192.168.1.1,8.8.8.8","-node-labels","{\"my-label\":\"my-value\"}"]}'
         command:
         - /http-prober-bin/http-prober
         env:
@@ -69,9 +68,6 @@ spec:
         - mountPath: /etc/kubernetes/kubeconfig
           name: internal-admin-kubeconfig
           readOnly: true
-        - mountPath: /etc/kubernetes/cloud
-          name: cloud-config
-          readOnly: true
         - mountPath: /http-prober-bin
           name: http-prober-bin
       imagePullSecrets:
@@ -92,9 +88,6 @@ spec:
       - name: internal-admin-kubeconfig
         secret:
           secretName: internal-admin-kubeconfig
-      - configMap:
-          name: cloud-config
-        name: cloud-config
       - emptyDir: {}
         name: http-prober-bin
 status: {}

--- a/api/pkg/resources/test/fixtures/deployment-bringyourown-1.10.0-usercluster-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-bringyourown-1.10.0-usercluster-controller.yaml
@@ -22,7 +22,6 @@ spec:
       creationTimestamp: null
       labels:
         app: usercluster-controller
-        cloud-config-configmap-revision: "123456"
         cluster: de-test-01
         internal-admin-kubeconfig-secret-revision: "123456"
     spec:
@@ -38,7 +37,7 @@ spec:
         - -timeout
         - "1"
         - -command
-        - '{"command":"/usr/local/bin/user-cluster-controller-manager","args":["-kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","-metrics-listen-address","0.0.0.0:8085","-health-listen-address","0.0.0.0:8086","-namespace","$(NAMESPACE)","-cluster-url","","-cloud-config","/etc/kubernetes/cloud/config","-openvpn-server-port","30003","-overwrite-registry","","-openshift=false","-version","1.10.0","-cloud-provider-name","","--ipam-controller-network","192.168.1.1/24,192.168.1.1,8.8.8.8","-node-labels","{\"my-label\":\"my-value\"}"]}'
+        - '{"command":"/usr/local/bin/user-cluster-controller-manager","args":["-kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","-metrics-listen-address","0.0.0.0:8085","-health-listen-address","0.0.0.0:8086","-namespace","$(NAMESPACE)","-cluster-url","","-openvpn-server-port","30003","-overwrite-registry","","-openshift=false","-version","1.10.0","-cloud-provider-name","","--ipam-controller-network","192.168.1.1/24,192.168.1.1,8.8.8.8","-node-labels","{\"my-label\":\"my-value\"}"]}'
         command:
         - /http-prober-bin/http-prober
         env:
@@ -69,9 +68,6 @@ spec:
         - mountPath: /etc/kubernetes/kubeconfig
           name: internal-admin-kubeconfig
           readOnly: true
-        - mountPath: /etc/kubernetes/cloud
-          name: cloud-config
-          readOnly: true
         - mountPath: /http-prober-bin
           name: http-prober-bin
       imagePullSecrets:
@@ -92,9 +88,6 @@ spec:
       - name: internal-admin-kubeconfig
         secret:
           secretName: internal-admin-kubeconfig
-      - configMap:
-          name: cloud-config
-        name: cloud-config
       - emptyDir: {}
         name: http-prober-bin
 status: {}

--- a/api/pkg/resources/test/fixtures/deployment-bringyourown-1.10.6-usercluster-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-bringyourown-1.10.6-usercluster-controller.yaml
@@ -22,7 +22,6 @@ spec:
       creationTimestamp: null
       labels:
         app: usercluster-controller
-        cloud-config-configmap-revision: "123456"
         cluster: de-test-01
         internal-admin-kubeconfig-secret-revision: "123456"
     spec:
@@ -38,7 +37,7 @@ spec:
         - -timeout
         - "1"
         - -command
-        - '{"command":"/usr/local/bin/user-cluster-controller-manager","args":["-kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","-metrics-listen-address","0.0.0.0:8085","-health-listen-address","0.0.0.0:8086","-namespace","$(NAMESPACE)","-cluster-url","","-cloud-config","/etc/kubernetes/cloud/config","-openvpn-server-port","30003","-overwrite-registry","","-openshift=false","-version","1.10.6","-cloud-provider-name","","--ipam-controller-network","192.168.1.1/24,192.168.1.1,8.8.8.8","-node-labels","{\"my-label\":\"my-value\"}"]}'
+        - '{"command":"/usr/local/bin/user-cluster-controller-manager","args":["-kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","-metrics-listen-address","0.0.0.0:8085","-health-listen-address","0.0.0.0:8086","-namespace","$(NAMESPACE)","-cluster-url","","-openvpn-server-port","30003","-overwrite-registry","","-openshift=false","-version","1.10.6","-cloud-provider-name","","--ipam-controller-network","192.168.1.1/24,192.168.1.1,8.8.8.8","-node-labels","{\"my-label\":\"my-value\"}"]}'
         command:
         - /http-prober-bin/http-prober
         env:
@@ -69,9 +68,6 @@ spec:
         - mountPath: /etc/kubernetes/kubeconfig
           name: internal-admin-kubeconfig
           readOnly: true
-        - mountPath: /etc/kubernetes/cloud
-          name: cloud-config
-          readOnly: true
         - mountPath: /http-prober-bin
           name: http-prober-bin
       imagePullSecrets:
@@ -92,9 +88,6 @@ spec:
       - name: internal-admin-kubeconfig
         secret:
           secretName: internal-admin-kubeconfig
-      - configMap:
-          name: cloud-config
-        name: cloud-config
       - emptyDir: {}
         name: http-prober-bin
 status: {}

--- a/api/pkg/resources/test/fixtures/deployment-bringyourown-1.11.0-usercluster-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-bringyourown-1.11.0-usercluster-controller.yaml
@@ -22,7 +22,6 @@ spec:
       creationTimestamp: null
       labels:
         app: usercluster-controller
-        cloud-config-configmap-revision: "123456"
         cluster: de-test-01
         internal-admin-kubeconfig-secret-revision: "123456"
     spec:
@@ -38,7 +37,7 @@ spec:
         - -timeout
         - "1"
         - -command
-        - '{"command":"/usr/local/bin/user-cluster-controller-manager","args":["-kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","-metrics-listen-address","0.0.0.0:8085","-health-listen-address","0.0.0.0:8086","-namespace","$(NAMESPACE)","-cluster-url","","-cloud-config","/etc/kubernetes/cloud/config","-openvpn-server-port","30003","-overwrite-registry","","-openshift=false","-version","1.11.0","-cloud-provider-name","","--ipam-controller-network","192.168.1.1/24,192.168.1.1,8.8.8.8","-node-labels","{\"my-label\":\"my-value\"}"]}'
+        - '{"command":"/usr/local/bin/user-cluster-controller-manager","args":["-kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","-metrics-listen-address","0.0.0.0:8085","-health-listen-address","0.0.0.0:8086","-namespace","$(NAMESPACE)","-cluster-url","","-openvpn-server-port","30003","-overwrite-registry","","-openshift=false","-version","1.11.0","-cloud-provider-name","","--ipam-controller-network","192.168.1.1/24,192.168.1.1,8.8.8.8","-node-labels","{\"my-label\":\"my-value\"}"]}'
         command:
         - /http-prober-bin/http-prober
         env:
@@ -69,9 +68,6 @@ spec:
         - mountPath: /etc/kubernetes/kubeconfig
           name: internal-admin-kubeconfig
           readOnly: true
-        - mountPath: /etc/kubernetes/cloud
-          name: cloud-config
-          readOnly: true
         - mountPath: /http-prober-bin
           name: http-prober-bin
       imagePullSecrets:
@@ -92,9 +88,6 @@ spec:
       - name: internal-admin-kubeconfig
         secret:
           secretName: internal-admin-kubeconfig
-      - configMap:
-          name: cloud-config
-        name: cloud-config
       - emptyDir: {}
         name: http-prober-bin
 status: {}

--- a/api/pkg/resources/test/fixtures/deployment-bringyourown-1.11.1-usercluster-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-bringyourown-1.11.1-usercluster-controller.yaml
@@ -22,7 +22,6 @@ spec:
       creationTimestamp: null
       labels:
         app: usercluster-controller
-        cloud-config-configmap-revision: "123456"
         cluster: de-test-01
         internal-admin-kubeconfig-secret-revision: "123456"
     spec:
@@ -38,7 +37,7 @@ spec:
         - -timeout
         - "1"
         - -command
-        - '{"command":"/usr/local/bin/user-cluster-controller-manager","args":["-kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","-metrics-listen-address","0.0.0.0:8085","-health-listen-address","0.0.0.0:8086","-namespace","$(NAMESPACE)","-cluster-url","","-cloud-config","/etc/kubernetes/cloud/config","-openvpn-server-port","30003","-overwrite-registry","","-openshift=false","-version","1.11.1","-cloud-provider-name","","--ipam-controller-network","192.168.1.1/24,192.168.1.1,8.8.8.8","-node-labels","{\"my-label\":\"my-value\"}"]}'
+        - '{"command":"/usr/local/bin/user-cluster-controller-manager","args":["-kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","-metrics-listen-address","0.0.0.0:8085","-health-listen-address","0.0.0.0:8086","-namespace","$(NAMESPACE)","-cluster-url","","-openvpn-server-port","30003","-overwrite-registry","","-openshift=false","-version","1.11.1","-cloud-provider-name","","--ipam-controller-network","192.168.1.1/24,192.168.1.1,8.8.8.8","-node-labels","{\"my-label\":\"my-value\"}"]}'
         command:
         - /http-prober-bin/http-prober
         env:
@@ -69,9 +68,6 @@ spec:
         - mountPath: /etc/kubernetes/kubeconfig
           name: internal-admin-kubeconfig
           readOnly: true
-        - mountPath: /etc/kubernetes/cloud
-          name: cloud-config
-          readOnly: true
         - mountPath: /http-prober-bin
           name: http-prober-bin
       imagePullSecrets:
@@ -92,9 +88,6 @@ spec:
       - name: internal-admin-kubeconfig
         secret:
           secretName: internal-admin-kubeconfig
-      - configMap:
-          name: cloud-config
-        name: cloud-config
       - emptyDir: {}
         name: http-prober-bin
 status: {}

--- a/api/pkg/resources/test/fixtures/deployment-bringyourown-1.12.0-usercluster-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-bringyourown-1.12.0-usercluster-controller.yaml
@@ -22,7 +22,6 @@ spec:
       creationTimestamp: null
       labels:
         app: usercluster-controller
-        cloud-config-configmap-revision: "123456"
         cluster: de-test-01
         internal-admin-kubeconfig-secret-revision: "123456"
     spec:
@@ -38,7 +37,7 @@ spec:
         - -timeout
         - "1"
         - -command
-        - '{"command":"/usr/local/bin/user-cluster-controller-manager","args":["-kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","-metrics-listen-address","0.0.0.0:8085","-health-listen-address","0.0.0.0:8086","-namespace","$(NAMESPACE)","-cluster-url","","-cloud-config","/etc/kubernetes/cloud/config","-openvpn-server-port","30003","-overwrite-registry","","-openshift=false","-version","1.12.0","-cloud-provider-name","","--ipam-controller-network","192.168.1.1/24,192.168.1.1,8.8.8.8","-node-labels","{\"my-label\":\"my-value\"}"]}'
+        - '{"command":"/usr/local/bin/user-cluster-controller-manager","args":["-kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","-metrics-listen-address","0.0.0.0:8085","-health-listen-address","0.0.0.0:8086","-namespace","$(NAMESPACE)","-cluster-url","","-openvpn-server-port","30003","-overwrite-registry","","-openshift=false","-version","1.12.0","-cloud-provider-name","","--ipam-controller-network","192.168.1.1/24,192.168.1.1,8.8.8.8","-node-labels","{\"my-label\":\"my-value\"}"]}'
         command:
         - /http-prober-bin/http-prober
         env:
@@ -69,9 +68,6 @@ spec:
         - mountPath: /etc/kubernetes/kubeconfig
           name: internal-admin-kubeconfig
           readOnly: true
-        - mountPath: /etc/kubernetes/cloud
-          name: cloud-config
-          readOnly: true
         - mountPath: /http-prober-bin
           name: http-prober-bin
       imagePullSecrets:
@@ -92,9 +88,6 @@ spec:
       - name: internal-admin-kubeconfig
         secret:
           secretName: internal-admin-kubeconfig
-      - configMap:
-          name: cloud-config
-        name: cloud-config
       - emptyDir: {}
         name: http-prober-bin
 status: {}

--- a/api/pkg/resources/test/fixtures/deployment-bringyourown-1.13.0-usercluster-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-bringyourown-1.13.0-usercluster-controller.yaml
@@ -22,7 +22,6 @@ spec:
       creationTimestamp: null
       labels:
         app: usercluster-controller
-        cloud-config-configmap-revision: "123456"
         cluster: de-test-01
         internal-admin-kubeconfig-secret-revision: "123456"
     spec:
@@ -38,7 +37,7 @@ spec:
         - -timeout
         - "1"
         - -command
-        - '{"command":"/usr/local/bin/user-cluster-controller-manager","args":["-kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","-metrics-listen-address","0.0.0.0:8085","-health-listen-address","0.0.0.0:8086","-namespace","$(NAMESPACE)","-cluster-url","","-cloud-config","/etc/kubernetes/cloud/config","-openvpn-server-port","30003","-overwrite-registry","","-openshift=false","-version","1.13.0","-cloud-provider-name","","--ipam-controller-network","192.168.1.1/24,192.168.1.1,8.8.8.8","-node-labels","{\"my-label\":\"my-value\"}"]}'
+        - '{"command":"/usr/local/bin/user-cluster-controller-manager","args":["-kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","-metrics-listen-address","0.0.0.0:8085","-health-listen-address","0.0.0.0:8086","-namespace","$(NAMESPACE)","-cluster-url","","-openvpn-server-port","30003","-overwrite-registry","","-openshift=false","-version","1.13.0","-cloud-provider-name","","--ipam-controller-network","192.168.1.1/24,192.168.1.1,8.8.8.8","-node-labels","{\"my-label\":\"my-value\"}"]}'
         command:
         - /http-prober-bin/http-prober
         env:
@@ -69,9 +68,6 @@ spec:
         - mountPath: /etc/kubernetes/kubeconfig
           name: internal-admin-kubeconfig
           readOnly: true
-        - mountPath: /etc/kubernetes/cloud
-          name: cloud-config
-          readOnly: true
         - mountPath: /http-prober-bin
           name: http-prober-bin
       imagePullSecrets:
@@ -92,9 +88,6 @@ spec:
       - name: internal-admin-kubeconfig
         secret:
           secretName: internal-admin-kubeconfig
-      - configMap:
-          name: cloud-config
-        name: cloud-config
       - emptyDir: {}
         name: http-prober-bin
 status: {}

--- a/api/pkg/resources/test/fixtures/deployment-digitalocean-1.10.0-usercluster-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-digitalocean-1.10.0-usercluster-controller.yaml
@@ -22,7 +22,6 @@ spec:
       creationTimestamp: null
       labels:
         app: usercluster-controller
-        cloud-config-configmap-revision: "123456"
         cluster: de-test-01
         internal-admin-kubeconfig-secret-revision: "123456"
     spec:
@@ -38,7 +37,7 @@ spec:
         - -timeout
         - "1"
         - -command
-        - '{"command":"/usr/local/bin/user-cluster-controller-manager","args":["-kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","-metrics-listen-address","0.0.0.0:8085","-health-listen-address","0.0.0.0:8086","-namespace","$(NAMESPACE)","-cluster-url","","-cloud-config","/etc/kubernetes/cloud/config","-openvpn-server-port","30003","-overwrite-registry","","-openshift=false","-version","1.10.0","-cloud-provider-name","","--ipam-controller-network","192.168.1.1/24,192.168.1.1,8.8.8.8","-node-labels","{\"my-label\":\"my-value\"}"]}'
+        - '{"command":"/usr/local/bin/user-cluster-controller-manager","args":["-kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","-metrics-listen-address","0.0.0.0:8085","-health-listen-address","0.0.0.0:8086","-namespace","$(NAMESPACE)","-cluster-url","","-openvpn-server-port","30003","-overwrite-registry","","-openshift=false","-version","1.10.0","-cloud-provider-name","","--ipam-controller-network","192.168.1.1/24,192.168.1.1,8.8.8.8","-node-labels","{\"my-label\":\"my-value\"}"]}'
         command:
         - /http-prober-bin/http-prober
         env:
@@ -69,9 +68,6 @@ spec:
         - mountPath: /etc/kubernetes/kubeconfig
           name: internal-admin-kubeconfig
           readOnly: true
-        - mountPath: /etc/kubernetes/cloud
-          name: cloud-config
-          readOnly: true
         - mountPath: /http-prober-bin
           name: http-prober-bin
       imagePullSecrets:
@@ -92,9 +88,6 @@ spec:
       - name: internal-admin-kubeconfig
         secret:
           secretName: internal-admin-kubeconfig
-      - configMap:
-          name: cloud-config
-        name: cloud-config
       - emptyDir: {}
         name: http-prober-bin
 status: {}

--- a/api/pkg/resources/test/fixtures/deployment-digitalocean-1.10.6-usercluster-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-digitalocean-1.10.6-usercluster-controller.yaml
@@ -22,7 +22,6 @@ spec:
       creationTimestamp: null
       labels:
         app: usercluster-controller
-        cloud-config-configmap-revision: "123456"
         cluster: de-test-01
         internal-admin-kubeconfig-secret-revision: "123456"
     spec:
@@ -38,7 +37,7 @@ spec:
         - -timeout
         - "1"
         - -command
-        - '{"command":"/usr/local/bin/user-cluster-controller-manager","args":["-kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","-metrics-listen-address","0.0.0.0:8085","-health-listen-address","0.0.0.0:8086","-namespace","$(NAMESPACE)","-cluster-url","","-cloud-config","/etc/kubernetes/cloud/config","-openvpn-server-port","30003","-overwrite-registry","","-openshift=false","-version","1.10.6","-cloud-provider-name","","--ipam-controller-network","192.168.1.1/24,192.168.1.1,8.8.8.8","-node-labels","{\"my-label\":\"my-value\"}"]}'
+        - '{"command":"/usr/local/bin/user-cluster-controller-manager","args":["-kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","-metrics-listen-address","0.0.0.0:8085","-health-listen-address","0.0.0.0:8086","-namespace","$(NAMESPACE)","-cluster-url","","-openvpn-server-port","30003","-overwrite-registry","","-openshift=false","-version","1.10.6","-cloud-provider-name","","--ipam-controller-network","192.168.1.1/24,192.168.1.1,8.8.8.8","-node-labels","{\"my-label\":\"my-value\"}"]}'
         command:
         - /http-prober-bin/http-prober
         env:
@@ -69,9 +68,6 @@ spec:
         - mountPath: /etc/kubernetes/kubeconfig
           name: internal-admin-kubeconfig
           readOnly: true
-        - mountPath: /etc/kubernetes/cloud
-          name: cloud-config
-          readOnly: true
         - mountPath: /http-prober-bin
           name: http-prober-bin
       imagePullSecrets:
@@ -92,9 +88,6 @@ spec:
       - name: internal-admin-kubeconfig
         secret:
           secretName: internal-admin-kubeconfig
-      - configMap:
-          name: cloud-config
-        name: cloud-config
       - emptyDir: {}
         name: http-prober-bin
 status: {}

--- a/api/pkg/resources/test/fixtures/deployment-digitalocean-1.11.0-usercluster-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-digitalocean-1.11.0-usercluster-controller.yaml
@@ -22,7 +22,6 @@ spec:
       creationTimestamp: null
       labels:
         app: usercluster-controller
-        cloud-config-configmap-revision: "123456"
         cluster: de-test-01
         internal-admin-kubeconfig-secret-revision: "123456"
     spec:
@@ -38,7 +37,7 @@ spec:
         - -timeout
         - "1"
         - -command
-        - '{"command":"/usr/local/bin/user-cluster-controller-manager","args":["-kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","-metrics-listen-address","0.0.0.0:8085","-health-listen-address","0.0.0.0:8086","-namespace","$(NAMESPACE)","-cluster-url","","-cloud-config","/etc/kubernetes/cloud/config","-openvpn-server-port","30003","-overwrite-registry","","-openshift=false","-version","1.11.0","-cloud-provider-name","","--ipam-controller-network","192.168.1.1/24,192.168.1.1,8.8.8.8","-node-labels","{\"my-label\":\"my-value\"}"]}'
+        - '{"command":"/usr/local/bin/user-cluster-controller-manager","args":["-kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","-metrics-listen-address","0.0.0.0:8085","-health-listen-address","0.0.0.0:8086","-namespace","$(NAMESPACE)","-cluster-url","","-openvpn-server-port","30003","-overwrite-registry","","-openshift=false","-version","1.11.0","-cloud-provider-name","","--ipam-controller-network","192.168.1.1/24,192.168.1.1,8.8.8.8","-node-labels","{\"my-label\":\"my-value\"}"]}'
         command:
         - /http-prober-bin/http-prober
         env:
@@ -69,9 +68,6 @@ spec:
         - mountPath: /etc/kubernetes/kubeconfig
           name: internal-admin-kubeconfig
           readOnly: true
-        - mountPath: /etc/kubernetes/cloud
-          name: cloud-config
-          readOnly: true
         - mountPath: /http-prober-bin
           name: http-prober-bin
       imagePullSecrets:
@@ -92,9 +88,6 @@ spec:
       - name: internal-admin-kubeconfig
         secret:
           secretName: internal-admin-kubeconfig
-      - configMap:
-          name: cloud-config
-        name: cloud-config
       - emptyDir: {}
         name: http-prober-bin
 status: {}

--- a/api/pkg/resources/test/fixtures/deployment-digitalocean-1.11.1-usercluster-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-digitalocean-1.11.1-usercluster-controller.yaml
@@ -22,7 +22,6 @@ spec:
       creationTimestamp: null
       labels:
         app: usercluster-controller
-        cloud-config-configmap-revision: "123456"
         cluster: de-test-01
         internal-admin-kubeconfig-secret-revision: "123456"
     spec:
@@ -38,7 +37,7 @@ spec:
         - -timeout
         - "1"
         - -command
-        - '{"command":"/usr/local/bin/user-cluster-controller-manager","args":["-kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","-metrics-listen-address","0.0.0.0:8085","-health-listen-address","0.0.0.0:8086","-namespace","$(NAMESPACE)","-cluster-url","","-cloud-config","/etc/kubernetes/cloud/config","-openvpn-server-port","30003","-overwrite-registry","","-openshift=false","-version","1.11.1","-cloud-provider-name","","--ipam-controller-network","192.168.1.1/24,192.168.1.1,8.8.8.8","-node-labels","{\"my-label\":\"my-value\"}"]}'
+        - '{"command":"/usr/local/bin/user-cluster-controller-manager","args":["-kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","-metrics-listen-address","0.0.0.0:8085","-health-listen-address","0.0.0.0:8086","-namespace","$(NAMESPACE)","-cluster-url","","-openvpn-server-port","30003","-overwrite-registry","","-openshift=false","-version","1.11.1","-cloud-provider-name","","--ipam-controller-network","192.168.1.1/24,192.168.1.1,8.8.8.8","-node-labels","{\"my-label\":\"my-value\"}"]}'
         command:
         - /http-prober-bin/http-prober
         env:
@@ -69,9 +68,6 @@ spec:
         - mountPath: /etc/kubernetes/kubeconfig
           name: internal-admin-kubeconfig
           readOnly: true
-        - mountPath: /etc/kubernetes/cloud
-          name: cloud-config
-          readOnly: true
         - mountPath: /http-prober-bin
           name: http-prober-bin
       imagePullSecrets:
@@ -92,9 +88,6 @@ spec:
       - name: internal-admin-kubeconfig
         secret:
           secretName: internal-admin-kubeconfig
-      - configMap:
-          name: cloud-config
-        name: cloud-config
       - emptyDir: {}
         name: http-prober-bin
 status: {}

--- a/api/pkg/resources/test/fixtures/deployment-digitalocean-1.12.0-usercluster-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-digitalocean-1.12.0-usercluster-controller.yaml
@@ -22,7 +22,6 @@ spec:
       creationTimestamp: null
       labels:
         app: usercluster-controller
-        cloud-config-configmap-revision: "123456"
         cluster: de-test-01
         internal-admin-kubeconfig-secret-revision: "123456"
     spec:
@@ -38,7 +37,7 @@ spec:
         - -timeout
         - "1"
         - -command
-        - '{"command":"/usr/local/bin/user-cluster-controller-manager","args":["-kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","-metrics-listen-address","0.0.0.0:8085","-health-listen-address","0.0.0.0:8086","-namespace","$(NAMESPACE)","-cluster-url","","-cloud-config","/etc/kubernetes/cloud/config","-openvpn-server-port","30003","-overwrite-registry","","-openshift=false","-version","1.12.0","-cloud-provider-name","","--ipam-controller-network","192.168.1.1/24,192.168.1.1,8.8.8.8","-node-labels","{\"my-label\":\"my-value\"}"]}'
+        - '{"command":"/usr/local/bin/user-cluster-controller-manager","args":["-kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","-metrics-listen-address","0.0.0.0:8085","-health-listen-address","0.0.0.0:8086","-namespace","$(NAMESPACE)","-cluster-url","","-openvpn-server-port","30003","-overwrite-registry","","-openshift=false","-version","1.12.0","-cloud-provider-name","","--ipam-controller-network","192.168.1.1/24,192.168.1.1,8.8.8.8","-node-labels","{\"my-label\":\"my-value\"}"]}'
         command:
         - /http-prober-bin/http-prober
         env:
@@ -69,9 +68,6 @@ spec:
         - mountPath: /etc/kubernetes/kubeconfig
           name: internal-admin-kubeconfig
           readOnly: true
-        - mountPath: /etc/kubernetes/cloud
-          name: cloud-config
-          readOnly: true
         - mountPath: /http-prober-bin
           name: http-prober-bin
       imagePullSecrets:
@@ -92,9 +88,6 @@ spec:
       - name: internal-admin-kubeconfig
         secret:
           secretName: internal-admin-kubeconfig
-      - configMap:
-          name: cloud-config
-        name: cloud-config
       - emptyDir: {}
         name: http-prober-bin
 status: {}

--- a/api/pkg/resources/test/fixtures/deployment-digitalocean-1.13.0-usercluster-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-digitalocean-1.13.0-usercluster-controller.yaml
@@ -22,7 +22,6 @@ spec:
       creationTimestamp: null
       labels:
         app: usercluster-controller
-        cloud-config-configmap-revision: "123456"
         cluster: de-test-01
         internal-admin-kubeconfig-secret-revision: "123456"
     spec:
@@ -38,7 +37,7 @@ spec:
         - -timeout
         - "1"
         - -command
-        - '{"command":"/usr/local/bin/user-cluster-controller-manager","args":["-kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","-metrics-listen-address","0.0.0.0:8085","-health-listen-address","0.0.0.0:8086","-namespace","$(NAMESPACE)","-cluster-url","","-cloud-config","/etc/kubernetes/cloud/config","-openvpn-server-port","30003","-overwrite-registry","","-openshift=false","-version","1.13.0","-cloud-provider-name","","--ipam-controller-network","192.168.1.1/24,192.168.1.1,8.8.8.8","-node-labels","{\"my-label\":\"my-value\"}"]}'
+        - '{"command":"/usr/local/bin/user-cluster-controller-manager","args":["-kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","-metrics-listen-address","0.0.0.0:8085","-health-listen-address","0.0.0.0:8086","-namespace","$(NAMESPACE)","-cluster-url","","-openvpn-server-port","30003","-overwrite-registry","","-openshift=false","-version","1.13.0","-cloud-provider-name","","--ipam-controller-network","192.168.1.1/24,192.168.1.1,8.8.8.8","-node-labels","{\"my-label\":\"my-value\"}"]}'
         command:
         - /http-prober-bin/http-prober
         env:
@@ -69,9 +68,6 @@ spec:
         - mountPath: /etc/kubernetes/kubeconfig
           name: internal-admin-kubeconfig
           readOnly: true
-        - mountPath: /etc/kubernetes/cloud
-          name: cloud-config
-          readOnly: true
         - mountPath: /http-prober-bin
           name: http-prober-bin
       imagePullSecrets:
@@ -92,9 +88,6 @@ spec:
       - name: internal-admin-kubeconfig
         secret:
           secretName: internal-admin-kubeconfig
-      - configMap:
-          name: cloud-config
-        name: cloud-config
       - emptyDir: {}
         name: http-prober-bin
 status: {}

--- a/api/pkg/resources/test/fixtures/deployment-openstack-1.10.0-usercluster-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-openstack-1.10.0-usercluster-controller.yaml
@@ -22,7 +22,6 @@ spec:
       creationTimestamp: null
       labels:
         app: usercluster-controller
-        cloud-config-configmap-revision: "123456"
         cluster: de-test-01
         internal-admin-kubeconfig-secret-revision: "123456"
     spec:
@@ -38,7 +37,7 @@ spec:
         - -timeout
         - "1"
         - -command
-        - '{"command":"/usr/local/bin/user-cluster-controller-manager","args":["-kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","-metrics-listen-address","0.0.0.0:8085","-health-listen-address","0.0.0.0:8086","-namespace","$(NAMESPACE)","-cluster-url","","-cloud-config","/etc/kubernetes/cloud/config","-openvpn-server-port","30003","-overwrite-registry","","-openshift=false","-version","1.10.0","-cloud-provider-name","openstack","--ipam-controller-network","192.168.1.1/24,192.168.1.1,8.8.8.8","-node-labels","{\"my-label\":\"my-value\"}"]}'
+        - '{"command":"/usr/local/bin/user-cluster-controller-manager","args":["-kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","-metrics-listen-address","0.0.0.0:8085","-health-listen-address","0.0.0.0:8086","-namespace","$(NAMESPACE)","-cluster-url","","-openvpn-server-port","30003","-overwrite-registry","","-openshift=false","-version","1.10.0","-cloud-provider-name","openstack","--ipam-controller-network","192.168.1.1/24,192.168.1.1,8.8.8.8","-node-labels","{\"my-label\":\"my-value\"}"]}'
         command:
         - /http-prober-bin/http-prober
         env:
@@ -69,9 +68,6 @@ spec:
         - mountPath: /etc/kubernetes/kubeconfig
           name: internal-admin-kubeconfig
           readOnly: true
-        - mountPath: /etc/kubernetes/cloud
-          name: cloud-config
-          readOnly: true
         - mountPath: /http-prober-bin
           name: http-prober-bin
       imagePullSecrets:
@@ -92,9 +88,6 @@ spec:
       - name: internal-admin-kubeconfig
         secret:
           secretName: internal-admin-kubeconfig
-      - configMap:
-          name: cloud-config
-        name: cloud-config
       - emptyDir: {}
         name: http-prober-bin
 status: {}

--- a/api/pkg/resources/test/fixtures/deployment-openstack-1.10.6-usercluster-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-openstack-1.10.6-usercluster-controller.yaml
@@ -22,7 +22,6 @@ spec:
       creationTimestamp: null
       labels:
         app: usercluster-controller
-        cloud-config-configmap-revision: "123456"
         cluster: de-test-01
         internal-admin-kubeconfig-secret-revision: "123456"
     spec:
@@ -38,7 +37,7 @@ spec:
         - -timeout
         - "1"
         - -command
-        - '{"command":"/usr/local/bin/user-cluster-controller-manager","args":["-kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","-metrics-listen-address","0.0.0.0:8085","-health-listen-address","0.0.0.0:8086","-namespace","$(NAMESPACE)","-cluster-url","","-cloud-config","/etc/kubernetes/cloud/config","-openvpn-server-port","30003","-overwrite-registry","","-openshift=false","-version","1.10.6","-cloud-provider-name","openstack","--ipam-controller-network","192.168.1.1/24,192.168.1.1,8.8.8.8","-node-labels","{\"my-label\":\"my-value\"}"]}'
+        - '{"command":"/usr/local/bin/user-cluster-controller-manager","args":["-kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","-metrics-listen-address","0.0.0.0:8085","-health-listen-address","0.0.0.0:8086","-namespace","$(NAMESPACE)","-cluster-url","","-openvpn-server-port","30003","-overwrite-registry","","-openshift=false","-version","1.10.6","-cloud-provider-name","openstack","--ipam-controller-network","192.168.1.1/24,192.168.1.1,8.8.8.8","-node-labels","{\"my-label\":\"my-value\"}"]}'
         command:
         - /http-prober-bin/http-prober
         env:
@@ -69,9 +68,6 @@ spec:
         - mountPath: /etc/kubernetes/kubeconfig
           name: internal-admin-kubeconfig
           readOnly: true
-        - mountPath: /etc/kubernetes/cloud
-          name: cloud-config
-          readOnly: true
         - mountPath: /http-prober-bin
           name: http-prober-bin
       imagePullSecrets:
@@ -92,9 +88,6 @@ spec:
       - name: internal-admin-kubeconfig
         secret:
           secretName: internal-admin-kubeconfig
-      - configMap:
-          name: cloud-config
-        name: cloud-config
       - emptyDir: {}
         name: http-prober-bin
 status: {}

--- a/api/pkg/resources/test/fixtures/deployment-openstack-1.11.0-usercluster-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-openstack-1.11.0-usercluster-controller.yaml
@@ -22,7 +22,6 @@ spec:
       creationTimestamp: null
       labels:
         app: usercluster-controller
-        cloud-config-configmap-revision: "123456"
         cluster: de-test-01
         internal-admin-kubeconfig-secret-revision: "123456"
     spec:
@@ -38,7 +37,7 @@ spec:
         - -timeout
         - "1"
         - -command
-        - '{"command":"/usr/local/bin/user-cluster-controller-manager","args":["-kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","-metrics-listen-address","0.0.0.0:8085","-health-listen-address","0.0.0.0:8086","-namespace","$(NAMESPACE)","-cluster-url","","-cloud-config","/etc/kubernetes/cloud/config","-openvpn-server-port","30003","-overwrite-registry","","-openshift=false","-version","1.11.0","-cloud-provider-name","openstack","--ipam-controller-network","192.168.1.1/24,192.168.1.1,8.8.8.8","-node-labels","{\"my-label\":\"my-value\"}"]}'
+        - '{"command":"/usr/local/bin/user-cluster-controller-manager","args":["-kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","-metrics-listen-address","0.0.0.0:8085","-health-listen-address","0.0.0.0:8086","-namespace","$(NAMESPACE)","-cluster-url","","-openvpn-server-port","30003","-overwrite-registry","","-openshift=false","-version","1.11.0","-cloud-provider-name","openstack","--ipam-controller-network","192.168.1.1/24,192.168.1.1,8.8.8.8","-node-labels","{\"my-label\":\"my-value\"}"]}'
         command:
         - /http-prober-bin/http-prober
         env:
@@ -69,9 +68,6 @@ spec:
         - mountPath: /etc/kubernetes/kubeconfig
           name: internal-admin-kubeconfig
           readOnly: true
-        - mountPath: /etc/kubernetes/cloud
-          name: cloud-config
-          readOnly: true
         - mountPath: /http-prober-bin
           name: http-prober-bin
       imagePullSecrets:
@@ -92,9 +88,6 @@ spec:
       - name: internal-admin-kubeconfig
         secret:
           secretName: internal-admin-kubeconfig
-      - configMap:
-          name: cloud-config
-        name: cloud-config
       - emptyDir: {}
         name: http-prober-bin
 status: {}

--- a/api/pkg/resources/test/fixtures/deployment-openstack-1.11.1-usercluster-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-openstack-1.11.1-usercluster-controller.yaml
@@ -22,7 +22,6 @@ spec:
       creationTimestamp: null
       labels:
         app: usercluster-controller
-        cloud-config-configmap-revision: "123456"
         cluster: de-test-01
         internal-admin-kubeconfig-secret-revision: "123456"
     spec:
@@ -38,7 +37,7 @@ spec:
         - -timeout
         - "1"
         - -command
-        - '{"command":"/usr/local/bin/user-cluster-controller-manager","args":["-kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","-metrics-listen-address","0.0.0.0:8085","-health-listen-address","0.0.0.0:8086","-namespace","$(NAMESPACE)","-cluster-url","","-cloud-config","/etc/kubernetes/cloud/config","-openvpn-server-port","30003","-overwrite-registry","","-openshift=false","-version","1.11.1","-cloud-provider-name","openstack","--ipam-controller-network","192.168.1.1/24,192.168.1.1,8.8.8.8","-node-labels","{\"my-label\":\"my-value\"}"]}'
+        - '{"command":"/usr/local/bin/user-cluster-controller-manager","args":["-kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","-metrics-listen-address","0.0.0.0:8085","-health-listen-address","0.0.0.0:8086","-namespace","$(NAMESPACE)","-cluster-url","","-openvpn-server-port","30003","-overwrite-registry","","-openshift=false","-version","1.11.1","-cloud-provider-name","openstack","--ipam-controller-network","192.168.1.1/24,192.168.1.1,8.8.8.8","-node-labels","{\"my-label\":\"my-value\"}"]}'
         command:
         - /http-prober-bin/http-prober
         env:
@@ -69,9 +68,6 @@ spec:
         - mountPath: /etc/kubernetes/kubeconfig
           name: internal-admin-kubeconfig
           readOnly: true
-        - mountPath: /etc/kubernetes/cloud
-          name: cloud-config
-          readOnly: true
         - mountPath: /http-prober-bin
           name: http-prober-bin
       imagePullSecrets:
@@ -92,9 +88,6 @@ spec:
       - name: internal-admin-kubeconfig
         secret:
           secretName: internal-admin-kubeconfig
-      - configMap:
-          name: cloud-config
-        name: cloud-config
       - emptyDir: {}
         name: http-prober-bin
 status: {}

--- a/api/pkg/resources/test/fixtures/deployment-openstack-1.12.0-usercluster-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-openstack-1.12.0-usercluster-controller.yaml
@@ -22,7 +22,6 @@ spec:
       creationTimestamp: null
       labels:
         app: usercluster-controller
-        cloud-config-configmap-revision: "123456"
         cluster: de-test-01
         internal-admin-kubeconfig-secret-revision: "123456"
     spec:
@@ -38,7 +37,7 @@ spec:
         - -timeout
         - "1"
         - -command
-        - '{"command":"/usr/local/bin/user-cluster-controller-manager","args":["-kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","-metrics-listen-address","0.0.0.0:8085","-health-listen-address","0.0.0.0:8086","-namespace","$(NAMESPACE)","-cluster-url","","-cloud-config","/etc/kubernetes/cloud/config","-openvpn-server-port","30003","-overwrite-registry","","-openshift=false","-version","1.12.0","-cloud-provider-name","openstack","--ipam-controller-network","192.168.1.1/24,192.168.1.1,8.8.8.8","-node-labels","{\"my-label\":\"my-value\"}"]}'
+        - '{"command":"/usr/local/bin/user-cluster-controller-manager","args":["-kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","-metrics-listen-address","0.0.0.0:8085","-health-listen-address","0.0.0.0:8086","-namespace","$(NAMESPACE)","-cluster-url","","-openvpn-server-port","30003","-overwrite-registry","","-openshift=false","-version","1.12.0","-cloud-provider-name","openstack","--ipam-controller-network","192.168.1.1/24,192.168.1.1,8.8.8.8","-node-labels","{\"my-label\":\"my-value\"}"]}'
         command:
         - /http-prober-bin/http-prober
         env:
@@ -69,9 +68,6 @@ spec:
         - mountPath: /etc/kubernetes/kubeconfig
           name: internal-admin-kubeconfig
           readOnly: true
-        - mountPath: /etc/kubernetes/cloud
-          name: cloud-config
-          readOnly: true
         - mountPath: /http-prober-bin
           name: http-prober-bin
       imagePullSecrets:
@@ -92,9 +88,6 @@ spec:
       - name: internal-admin-kubeconfig
         secret:
           secretName: internal-admin-kubeconfig
-      - configMap:
-          name: cloud-config
-        name: cloud-config
       - emptyDir: {}
         name: http-prober-bin
 status: {}

--- a/api/pkg/resources/test/fixtures/deployment-openstack-1.13.0-usercluster-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-openstack-1.13.0-usercluster-controller.yaml
@@ -22,7 +22,6 @@ spec:
       creationTimestamp: null
       labels:
         app: usercluster-controller
-        cloud-config-configmap-revision: "123456"
         cluster: de-test-01
         internal-admin-kubeconfig-secret-revision: "123456"
     spec:
@@ -38,7 +37,7 @@ spec:
         - -timeout
         - "1"
         - -command
-        - '{"command":"/usr/local/bin/user-cluster-controller-manager","args":["-kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","-metrics-listen-address","0.0.0.0:8085","-health-listen-address","0.0.0.0:8086","-namespace","$(NAMESPACE)","-cluster-url","","-cloud-config","/etc/kubernetes/cloud/config","-openvpn-server-port","30003","-overwrite-registry","","-openshift=false","-version","1.13.0","-cloud-provider-name","openstack","--ipam-controller-network","192.168.1.1/24,192.168.1.1,8.8.8.8","-node-labels","{\"my-label\":\"my-value\"}"]}'
+        - '{"command":"/usr/local/bin/user-cluster-controller-manager","args":["-kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","-metrics-listen-address","0.0.0.0:8085","-health-listen-address","0.0.0.0:8086","-namespace","$(NAMESPACE)","-cluster-url","","-openvpn-server-port","30003","-overwrite-registry","","-openshift=false","-version","1.13.0","-cloud-provider-name","openstack","--ipam-controller-network","192.168.1.1/24,192.168.1.1,8.8.8.8","-node-labels","{\"my-label\":\"my-value\"}"]}'
         command:
         - /http-prober-bin/http-prober
         env:
@@ -69,9 +68,6 @@ spec:
         - mountPath: /etc/kubernetes/kubeconfig
           name: internal-admin-kubeconfig
           readOnly: true
-        - mountPath: /etc/kubernetes/cloud
-          name: cloud-config
-          readOnly: true
         - mountPath: /http-prober-bin
           name: http-prober-bin
       imagePullSecrets:
@@ -92,9 +88,6 @@ spec:
       - name: internal-admin-kubeconfig
         secret:
           secretName: internal-admin-kubeconfig
-      - configMap:
-          name: cloud-config
-        name: cloud-config
       - emptyDir: {}
         name: http-prober-bin
 status: {}

--- a/api/pkg/resources/test/fixtures/deployment-vsphere-1.10.0-usercluster-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-vsphere-1.10.0-usercluster-controller.yaml
@@ -22,7 +22,6 @@ spec:
       creationTimestamp: null
       labels:
         app: usercluster-controller
-        cloud-config-configmap-revision: "123456"
         cluster: de-test-01
         internal-admin-kubeconfig-secret-revision: "123456"
     spec:
@@ -38,7 +37,7 @@ spec:
         - -timeout
         - "1"
         - -command
-        - '{"command":"/usr/local/bin/user-cluster-controller-manager","args":["-kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","-metrics-listen-address","0.0.0.0:8085","-health-listen-address","0.0.0.0:8086","-namespace","$(NAMESPACE)","-cluster-url","","-cloud-config","/etc/kubernetes/cloud/config","-openvpn-server-port","30003","-overwrite-registry","","-openshift=false","-version","1.10.0","-cloud-provider-name","vsphere","--ipam-controller-network","192.168.1.1/24,192.168.1.1,8.8.8.8","-node-labels","{\"my-label\":\"my-value\"}"]}'
+        - '{"command":"/usr/local/bin/user-cluster-controller-manager","args":["-kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","-metrics-listen-address","0.0.0.0:8085","-health-listen-address","0.0.0.0:8086","-namespace","$(NAMESPACE)","-cluster-url","","-openvpn-server-port","30003","-overwrite-registry","","-openshift=false","-version","1.10.0","-cloud-provider-name","vsphere","--ipam-controller-network","192.168.1.1/24,192.168.1.1,8.8.8.8","-node-labels","{\"my-label\":\"my-value\"}"]}'
         command:
         - /http-prober-bin/http-prober
         env:
@@ -69,9 +68,6 @@ spec:
         - mountPath: /etc/kubernetes/kubeconfig
           name: internal-admin-kubeconfig
           readOnly: true
-        - mountPath: /etc/kubernetes/cloud
-          name: cloud-config
-          readOnly: true
         - mountPath: /http-prober-bin
           name: http-prober-bin
       imagePullSecrets:
@@ -92,9 +88,6 @@ spec:
       - name: internal-admin-kubeconfig
         secret:
           secretName: internal-admin-kubeconfig
-      - configMap:
-          name: cloud-config
-        name: cloud-config
       - emptyDir: {}
         name: http-prober-bin
 status: {}

--- a/api/pkg/resources/test/fixtures/deployment-vsphere-1.10.6-usercluster-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-vsphere-1.10.6-usercluster-controller.yaml
@@ -22,7 +22,6 @@ spec:
       creationTimestamp: null
       labels:
         app: usercluster-controller
-        cloud-config-configmap-revision: "123456"
         cluster: de-test-01
         internal-admin-kubeconfig-secret-revision: "123456"
     spec:
@@ -38,7 +37,7 @@ spec:
         - -timeout
         - "1"
         - -command
-        - '{"command":"/usr/local/bin/user-cluster-controller-manager","args":["-kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","-metrics-listen-address","0.0.0.0:8085","-health-listen-address","0.0.0.0:8086","-namespace","$(NAMESPACE)","-cluster-url","","-cloud-config","/etc/kubernetes/cloud/config","-openvpn-server-port","30003","-overwrite-registry","","-openshift=false","-version","1.10.6","-cloud-provider-name","vsphere","--ipam-controller-network","192.168.1.1/24,192.168.1.1,8.8.8.8","-node-labels","{\"my-label\":\"my-value\"}"]}'
+        - '{"command":"/usr/local/bin/user-cluster-controller-manager","args":["-kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","-metrics-listen-address","0.0.0.0:8085","-health-listen-address","0.0.0.0:8086","-namespace","$(NAMESPACE)","-cluster-url","","-openvpn-server-port","30003","-overwrite-registry","","-openshift=false","-version","1.10.6","-cloud-provider-name","vsphere","--ipam-controller-network","192.168.1.1/24,192.168.1.1,8.8.8.8","-node-labels","{\"my-label\":\"my-value\"}"]}'
         command:
         - /http-prober-bin/http-prober
         env:
@@ -69,9 +68,6 @@ spec:
         - mountPath: /etc/kubernetes/kubeconfig
           name: internal-admin-kubeconfig
           readOnly: true
-        - mountPath: /etc/kubernetes/cloud
-          name: cloud-config
-          readOnly: true
         - mountPath: /http-prober-bin
           name: http-prober-bin
       imagePullSecrets:
@@ -92,9 +88,6 @@ spec:
       - name: internal-admin-kubeconfig
         secret:
           secretName: internal-admin-kubeconfig
-      - configMap:
-          name: cloud-config
-        name: cloud-config
       - emptyDir: {}
         name: http-prober-bin
 status: {}

--- a/api/pkg/resources/test/fixtures/deployment-vsphere-1.11.0-usercluster-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-vsphere-1.11.0-usercluster-controller.yaml
@@ -22,7 +22,6 @@ spec:
       creationTimestamp: null
       labels:
         app: usercluster-controller
-        cloud-config-configmap-revision: "123456"
         cluster: de-test-01
         internal-admin-kubeconfig-secret-revision: "123456"
     spec:
@@ -38,7 +37,7 @@ spec:
         - -timeout
         - "1"
         - -command
-        - '{"command":"/usr/local/bin/user-cluster-controller-manager","args":["-kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","-metrics-listen-address","0.0.0.0:8085","-health-listen-address","0.0.0.0:8086","-namespace","$(NAMESPACE)","-cluster-url","","-cloud-config","/etc/kubernetes/cloud/config","-openvpn-server-port","30003","-overwrite-registry","","-openshift=false","-version","1.11.0","-cloud-provider-name","vsphere","--ipam-controller-network","192.168.1.1/24,192.168.1.1,8.8.8.8","-node-labels","{\"my-label\":\"my-value\"}"]}'
+        - '{"command":"/usr/local/bin/user-cluster-controller-manager","args":["-kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","-metrics-listen-address","0.0.0.0:8085","-health-listen-address","0.0.0.0:8086","-namespace","$(NAMESPACE)","-cluster-url","","-openvpn-server-port","30003","-overwrite-registry","","-openshift=false","-version","1.11.0","-cloud-provider-name","vsphere","--ipam-controller-network","192.168.1.1/24,192.168.1.1,8.8.8.8","-node-labels","{\"my-label\":\"my-value\"}"]}'
         command:
         - /http-prober-bin/http-prober
         env:
@@ -69,9 +68,6 @@ spec:
         - mountPath: /etc/kubernetes/kubeconfig
           name: internal-admin-kubeconfig
           readOnly: true
-        - mountPath: /etc/kubernetes/cloud
-          name: cloud-config
-          readOnly: true
         - mountPath: /http-prober-bin
           name: http-prober-bin
       imagePullSecrets:
@@ -92,9 +88,6 @@ spec:
       - name: internal-admin-kubeconfig
         secret:
           secretName: internal-admin-kubeconfig
-      - configMap:
-          name: cloud-config
-        name: cloud-config
       - emptyDir: {}
         name: http-prober-bin
 status: {}

--- a/api/pkg/resources/test/fixtures/deployment-vsphere-1.11.1-usercluster-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-vsphere-1.11.1-usercluster-controller.yaml
@@ -22,7 +22,6 @@ spec:
       creationTimestamp: null
       labels:
         app: usercluster-controller
-        cloud-config-configmap-revision: "123456"
         cluster: de-test-01
         internal-admin-kubeconfig-secret-revision: "123456"
     spec:
@@ -38,7 +37,7 @@ spec:
         - -timeout
         - "1"
         - -command
-        - '{"command":"/usr/local/bin/user-cluster-controller-manager","args":["-kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","-metrics-listen-address","0.0.0.0:8085","-health-listen-address","0.0.0.0:8086","-namespace","$(NAMESPACE)","-cluster-url","","-cloud-config","/etc/kubernetes/cloud/config","-openvpn-server-port","30003","-overwrite-registry","","-openshift=false","-version","1.11.1","-cloud-provider-name","vsphere","--ipam-controller-network","192.168.1.1/24,192.168.1.1,8.8.8.8","-node-labels","{\"my-label\":\"my-value\"}"]}'
+        - '{"command":"/usr/local/bin/user-cluster-controller-manager","args":["-kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","-metrics-listen-address","0.0.0.0:8085","-health-listen-address","0.0.0.0:8086","-namespace","$(NAMESPACE)","-cluster-url","","-openvpn-server-port","30003","-overwrite-registry","","-openshift=false","-version","1.11.1","-cloud-provider-name","vsphere","--ipam-controller-network","192.168.1.1/24,192.168.1.1,8.8.8.8","-node-labels","{\"my-label\":\"my-value\"}"]}'
         command:
         - /http-prober-bin/http-prober
         env:
@@ -69,9 +68,6 @@ spec:
         - mountPath: /etc/kubernetes/kubeconfig
           name: internal-admin-kubeconfig
           readOnly: true
-        - mountPath: /etc/kubernetes/cloud
-          name: cloud-config
-          readOnly: true
         - mountPath: /http-prober-bin
           name: http-prober-bin
       imagePullSecrets:
@@ -92,9 +88,6 @@ spec:
       - name: internal-admin-kubeconfig
         secret:
           secretName: internal-admin-kubeconfig
-      - configMap:
-          name: cloud-config
-        name: cloud-config
       - emptyDir: {}
         name: http-prober-bin
 status: {}

--- a/api/pkg/resources/test/fixtures/deployment-vsphere-1.12.0-usercluster-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-vsphere-1.12.0-usercluster-controller.yaml
@@ -22,7 +22,6 @@ spec:
       creationTimestamp: null
       labels:
         app: usercluster-controller
-        cloud-config-configmap-revision: "123456"
         cluster: de-test-01
         internal-admin-kubeconfig-secret-revision: "123456"
     spec:
@@ -38,7 +37,7 @@ spec:
         - -timeout
         - "1"
         - -command
-        - '{"command":"/usr/local/bin/user-cluster-controller-manager","args":["-kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","-metrics-listen-address","0.0.0.0:8085","-health-listen-address","0.0.0.0:8086","-namespace","$(NAMESPACE)","-cluster-url","","-cloud-config","/etc/kubernetes/cloud/config","-openvpn-server-port","30003","-overwrite-registry","","-openshift=false","-version","1.12.0","-cloud-provider-name","vsphere","--ipam-controller-network","192.168.1.1/24,192.168.1.1,8.8.8.8","-node-labels","{\"my-label\":\"my-value\"}"]}'
+        - '{"command":"/usr/local/bin/user-cluster-controller-manager","args":["-kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","-metrics-listen-address","0.0.0.0:8085","-health-listen-address","0.0.0.0:8086","-namespace","$(NAMESPACE)","-cluster-url","","-openvpn-server-port","30003","-overwrite-registry","","-openshift=false","-version","1.12.0","-cloud-provider-name","vsphere","--ipam-controller-network","192.168.1.1/24,192.168.1.1,8.8.8.8","-node-labels","{\"my-label\":\"my-value\"}"]}'
         command:
         - /http-prober-bin/http-prober
         env:
@@ -69,9 +68,6 @@ spec:
         - mountPath: /etc/kubernetes/kubeconfig
           name: internal-admin-kubeconfig
           readOnly: true
-        - mountPath: /etc/kubernetes/cloud
-          name: cloud-config
-          readOnly: true
         - mountPath: /http-prober-bin
           name: http-prober-bin
       imagePullSecrets:
@@ -92,9 +88,6 @@ spec:
       - name: internal-admin-kubeconfig
         secret:
           secretName: internal-admin-kubeconfig
-      - configMap:
-          name: cloud-config
-        name: cloud-config
       - emptyDir: {}
         name: http-prober-bin
 status: {}

--- a/api/pkg/resources/test/fixtures/deployment-vsphere-1.13.0-usercluster-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-vsphere-1.13.0-usercluster-controller.yaml
@@ -22,7 +22,6 @@ spec:
       creationTimestamp: null
       labels:
         app: usercluster-controller
-        cloud-config-configmap-revision: "123456"
         cluster: de-test-01
         internal-admin-kubeconfig-secret-revision: "123456"
     spec:
@@ -38,7 +37,7 @@ spec:
         - -timeout
         - "1"
         - -command
-        - '{"command":"/usr/local/bin/user-cluster-controller-manager","args":["-kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","-metrics-listen-address","0.0.0.0:8085","-health-listen-address","0.0.0.0:8086","-namespace","$(NAMESPACE)","-cluster-url","","-cloud-config","/etc/kubernetes/cloud/config","-openvpn-server-port","30003","-overwrite-registry","","-openshift=false","-version","1.13.0","-cloud-provider-name","vsphere","--ipam-controller-network","192.168.1.1/24,192.168.1.1,8.8.8.8","-node-labels","{\"my-label\":\"my-value\"}"]}'
+        - '{"command":"/usr/local/bin/user-cluster-controller-manager","args":["-kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","-metrics-listen-address","0.0.0.0:8085","-health-listen-address","0.0.0.0:8086","-namespace","$(NAMESPACE)","-cluster-url","","-openvpn-server-port","30003","-overwrite-registry","","-openshift=false","-version","1.13.0","-cloud-provider-name","vsphere","--ipam-controller-network","192.168.1.1/24,192.168.1.1,8.8.8.8","-node-labels","{\"my-label\":\"my-value\"}"]}'
         command:
         - /http-prober-bin/http-prober
         env:
@@ -69,9 +68,6 @@ spec:
         - mountPath: /etc/kubernetes/kubeconfig
           name: internal-admin-kubeconfig
           readOnly: true
-        - mountPath: /etc/kubernetes/cloud
-          name: cloud-config
-          readOnly: true
         - mountPath: /http-prober-bin
           name: http-prober-bin
       imagePullSecrets:
@@ -92,9 +88,6 @@ spec:
       - name: internal-admin-kubeconfig
         secret:
           secretName: internal-admin-kubeconfig
-      - configMap:
-          name: cloud-config
-        name: cloud-config
       - emptyDir: {}
         name: http-prober-bin
 status: {}

--- a/api/pkg/resources/usercluster/deployment.go
+++ b/api/pkg/resources/usercluster/deployment.go
@@ -101,7 +101,6 @@ func DeploymentCreator(data userclusterControllerData, openshift bool) reconcili
 				"-health-listen-address", "0.0.0.0:8086",
 				"-namespace", "$(NAMESPACE)",
 				"-cluster-url", data.Cluster().Address.URL,
-				"-cloud-config", "/etc/kubernetes/cloud/config",
 				"-openvpn-server-port", fmt.Sprint(openvpnServerPort),
 				"-overwrite-registry", data.ImageRegistry(""),
 				fmt.Sprintf("-openshift=%t", openshift),
@@ -166,11 +165,6 @@ func DeploymentCreator(data userclusterControllerData, openshift bool) reconcili
 							MountPath: "/etc/kubernetes/kubeconfig",
 							ReadOnly:  true,
 						},
-						{
-							Name:      resources.CloudConfigConfigMapName,
-							MountPath: "/etc/kubernetes/cloud",
-							ReadOnly:  true,
-						},
 					},
 				},
 			}
@@ -194,16 +188,6 @@ func getVolumes() []corev1.Volume {
 			VolumeSource: corev1.VolumeSource{
 				Secret: &corev1.SecretVolumeSource{
 					SecretName: resources.InternalUserClusterAdminKubeconfigSecretName,
-				},
-			},
-		},
-		{
-			Name: resources.CloudConfigConfigMapName,
-			VolumeSource: corev1.VolumeSource{
-				ConfigMap: &corev1.ConfigMapVolumeSource{
-					LocalObjectReference: corev1.LocalObjectReference{
-						Name: resources.CloudConfigConfigMapName,
-					},
 				},
 			},
 		},

--- a/api/pkg/resources/usercluster/rbac.go
+++ b/api/pkg/resources/usercluster/rbac.go
@@ -36,6 +36,15 @@ func RoleCreator() (string, reconciling.RoleCreator) {
 			},
 			{
 				APIGroups: []string{""},
+				Resources: []string{"configmaps"},
+				Verbs: []string{
+					"get",
+					"list",
+					"watch",
+				},
+			},
+			{
+				APIGroups: []string{""},
 				Resources: []string{"secrets"},
 				ResourceNames: []string{
 					resources.AdminKubeconfigSecretName,


### PR DESCRIPTION
**What this PR does / why we need it**:

Makes the usercluster controller manager load the cloud-config from the seed namespace rather than reading it from a config map volume. This way, the UCCM doesn't have to be re-deployed everytime the cloud-config changes.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Documentation**:
<!-- Add links to the related documentation changes related to this pull request. E.g. the link to the kubermatic/docs pullrequest. -->

**Does this PR introduce a user-facing change?**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If  no release note is required, just write "NONE".
-->
```release-note
none
```
