### PR TITLE
Reduce number of cluster updates

### DIFF
--- a/api/pkg/controller/seed-controller-manager/cloud/cloud_controller.go
+++ b/api/pkg/controller/seed-controller-manager/cloud/cloud_controller.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"reflect"
 	"time"
 
 	"go.uber.org/zap"
@@ -226,6 +227,9 @@ func (r *Reconciler) updateCluster(name string, modify func(*kubermaticv1.Cluste
 	}
 	oldCluster := cluster.DeepCopy()
 	modify(cluster)
+	if reflect.DeepEqual(oldCluster, cluster) {
+		return cluster, nil
+	}
 	return cluster, r.Patch(context.Background(), cluster, client.MergeFrom(oldCluster))
 }
 

--- a/api/pkg/controller/seed-controller-manager/kubernetes/cluster_controller.go
+++ b/api/pkg/controller/seed-controller-manager/kubernetes/cluster_controller.go
@@ -3,6 +3,7 @@ package kubernetes
 import (
 	"context"
 	"fmt"
+	"reflect"
 	"time"
 
 	"go.uber.org/zap"
@@ -260,6 +261,9 @@ func (r *Reconciler) reconcile(ctx context.Context, log *zap.SugaredLogger, clus
 func (r *Reconciler) updateCluster(ctx context.Context, cluster *kubermaticv1.Cluster, modify func(*kubermaticv1.Cluster)) error {
 	oldCluster := cluster.DeepCopy()
 	modify(cluster)
+	if reflect.DeepEqual(oldCluster, cluster) {
+		return nil
+	}
 	return r.Patch(ctx, cluster, ctrlruntimeclient.MergeFrom(oldCluster))
 }
 

--- a/api/pkg/controller/seed-controller-manager/kubernetes/pending.go
+++ b/api/pkg/controller/seed-controller-manager/kubernetes/pending.go
@@ -37,7 +37,7 @@ func (r *Reconciler) reconcileCluster(ctx context.Context, cluster *kubermaticv1
 		return nil, err
 	}
 
-	if cluster.Status.ExtendedHealth.Apiserver == kubermaticv1.HealthStatusUp {
+	if cluster.Status.ExtendedHealth.Apiserver != kubermaticv1.HealthStatusDown {
 		// Controlling of user-cluster resources
 		reachable, err := r.clusterIsReachable(ctx, cluster)
 		if err != nil {
@@ -59,11 +59,6 @@ func (r *Reconciler) reconcileCluster(ctx context.Context, cluster *kubermaticv1
 			}
 		}
 
-	}
-
-	if !cluster.Status.ExtendedHealth.AllHealthy() {
-		r.log.Debugf("Cluster %q not yet healthy: %+v", cluster.Name, cluster.Status.ExtendedHealth)
-		return &reconcile.Result{RequeueAfter: reachableCheckPeriod}, nil
 	}
 
 	return &reconcile.Result{}, nil

--- a/api/pkg/controller/seed-controller-manager/openshift/openshift_controller.go
+++ b/api/pkg/controller/seed-controller-manager/openshift/openshift_controller.go
@@ -335,8 +335,7 @@ func (r *Reconciler) reconcile(ctx context.Context, log *zap.SugaredLogger, clus
 		return nil, fmt.Errorf("failed to sync health: %v", err)
 	}
 
-	if kubermaticv1.HealthStatusDown == osData.Cluster().Status.ExtendedHealth.Apiserver ||
-		kubermaticv1.HealthStatusProvisioning == osData.Cluster().Status.ExtendedHealth.Apiserver {
+	if kubermaticv1.HealthStatusDown == osData.Cluster().Status.ExtendedHealth.Apiserver {
 		return &reconcile.Result{RequeueAfter: 5 * time.Second}, nil
 	}
 

--- a/api/pkg/controller/seed-controller-manager/seedresourcesuptodatecondition/seedresourcesuptodatecondition_controller.go
+++ b/api/pkg/controller/seed-controller-manager/seedresourcesuptodatecondition/seedresourcesuptodatecondition_controller.go
@@ -3,6 +3,7 @@ package seedresourcesuptodatecondition
 import (
 	"context"
 	"fmt"
+	"reflect"
 
 	"go.uber.org/zap"
 
@@ -111,16 +112,19 @@ func (r *reconciler) reconcile(cluster *kubermaticv1.Cluster) error {
 			kubermaticv1.ReasonClusterUpdateSuccessful,
 			"Some control plane components did not finish updating",
 		)
-		return r.client.Patch(r.ctx, cluster, ctrlruntimeclient.MergeFrom(oldCluster))
+	} else {
+		kubermaticv1helper.SetClusterCondition(
+			cluster,
+			kubermaticv1.ClusterConditionSeedResourcesUpToDate,
+			corev1.ConditionTrue,
+			kubermaticv1.ReasonClusterUpdateSuccessful,
+			"All control plane components are up to date",
+		)
+	}
+	if reflect.DeepEqual(oldCluster, cluster) {
+		return nil
 	}
 
-	kubermaticv1helper.SetClusterCondition(
-		cluster,
-		kubermaticv1.ClusterConditionSeedResourcesUpToDate,
-		corev1.ConditionTrue,
-		kubermaticv1.ReasonClusterUpdateSuccessful,
-		"All control plane components are up to date",
-	)
 	return r.client.Patch(r.ctx, cluster, ctrlruntimeclient.MergeFrom(oldCluster))
 }
 

--- a/api/pkg/crd/kubermatic/v1/helper/helper_test.go
+++ b/api/pkg/crd/kubermatic/v1/helper/helper_test.go
@@ -56,6 +56,27 @@ func TestGetClusterCondition(t *testing.T) {
 	}
 }
 
+func TestSetClusterCondition_sorts(t *testing.T) {
+	cluster := &kubermaticv1.Cluster{
+		Status: kubermaticv1.ClusterStatus{
+			Conditions: []kubermaticv1.ClusterCondition{
+				{Type: kubermaticv1.ClusterConditionCloudControllerReconcilingSuccess},
+				{Type: kubermaticv1.ClusterConditionAddonControllerReconcilingSuccess},
+			},
+		},
+	}
+	SetClusterCondition(
+		cluster,
+		kubermaticv1.ClusterConditionUpdateControllerReconcilingSuccess,
+		corev1.ConditionTrue,
+		"",
+		"",
+	)
+	if cluster.Status.Conditions[0].Type != kubermaticv1.ClusterConditionAddonControllerReconcilingSuccess {
+		t.Fatal("ClusterConditions are unsorted")
+	}
+}
+
 func TestSetClusterCondition(t *testing.T) {
 	conditionType := kubermaticv1.ClusterConditionSeedResourcesUpToDate
 	testCases := []struct {


### PR DESCRIPTION
**What this PR does / why we need it**:

Reduces the number of cluster updates (which each trigger a reconciliation for most controllers) by:
* Checking if there is actually a diff in the various PATCH calls
* Sorting the cluster conditions
* Making the kubernetes controller not return a retry-after (which sets its success condition to false) when the apiserver available replica count is < total replicas, but instead only waiting on the minimum replica count

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Documentation**:
<!-- Add links to the related documentation changes related to this pull request. E.g. the link to the kubermatic/docs pullrequest. -->

**Does this PR introduce a user-facing change?**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If  no release note is required, just write "NONE".
-->
```release-note
none
```
