### PR TITLE
[release/v2.12] add migration for cluster user labels (#4744)

### DIFF
--- a/api/pkg/crd/migrations/migrations.go
+++ b/api/pkg/crd/migrations/migrations.go
@@ -11,6 +11,7 @@ import (
 
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/util/sets"
 	"k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/rest"
 	"k8s.io/klog"
@@ -97,6 +98,7 @@ func cleanupCluster(cluster *kubermaticv1.Cluster, ctx *cleanupContext) error {
 	tasks := []ClusterTask{
 		setExposeStrategyIfEmpty,
 		setProxyModeIfEmpty,
+		migrateClusterUserLabel,
 	}
 
 	w := sync.WaitGroup{}
@@ -154,5 +156,30 @@ func setProxyModeIfEmpty(cluster *kubermaticv1.Cluster, ctx *cleanupContext) err
 		}
 		*cluster = *updatedCluster
 	}
+	return nil
+}
+
+func migrateClusterUserLabel(cluster *kubermaticv1.Cluster, ctx *cleanupContext) error {
+	// If there is not label - nothing to migrate
+	if cluster.Labels == nil {
+		return nil
+	}
+	newLabels := map[string]string{}
+	userLabelSet := sets.NewString("user", "user_RAW")
+	for key, value := range cluster.Labels {
+		if userLabelSet.Has(key) {
+			continue
+		}
+		newLabels[key] = value
+	}
+	if len(newLabels) != len(cluster.Labels) {
+		cluster.Labels = newLabels
+		updatedCluster, err := ctx.kubermaticClient.KubermaticV1().Clusters().Update(cluster)
+		if err != nil {
+			return err
+		}
+		*cluster = *updatedCluster
+	}
+
 	return nil
 }

--- a/api/pkg/provider/kubernetes/user.go
+++ b/api/pkg/provider/kubernetes/user.go
@@ -14,11 +14,6 @@ import (
 	"k8s.io/apimachinery/pkg/labels"
 )
 
-const (
-	// UserLabelKey defines the label key for the user -> cluster relation
-	UserLabelKey = "user"
-)
-
 // NewUserProvider returns a user provider
 func NewUserProvider(client kubermaticclientset.Interface, userLister kubermaticv1lister.UserLister, isServiceAccountFunc func(email string) bool) *UserProvider {
 	return &UserProvider{


### PR DESCRIPTION
**What this PR does / why we need it**: add migration for cluster user labels

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

```release-note
add migration for cluster user labels
```
