### PR TITLE
Openstack: Cope with already existing subnet router port

### DIFF
--- a/api/pkg/provider/cloud/openstack/helper.go
+++ b/api/pkg/provider/cloud/openstack/helper.go
@@ -316,13 +316,16 @@ func createKubermaticRouter(netClient *gophercloud.ServiceClient, clusterName, e
 }
 
 func attachSubnetToRouter(netClient *gophercloud.ServiceClient, subnetID, routerID string) (*osrouters.InterfaceInfo, error) {
-	res := osrouters.AddInterface(netClient, routerID, osrouters.AddInterfaceOpts{
-		SubnetID: subnetID,
-	})
-	if res.Err != nil {
-		return nil, res.Err
-	}
-	return res.Extract()
+	interf, err := func() (*osrouters.InterfaceInfo, error) {
+		res := osrouters.AddInterface(netClient, routerID, osrouters.AddInterfaceOpts{
+			SubnetID: subnetID,
+		})
+		if res.Err != nil {
+			return nil, res.Err
+		}
+		return res.Extract()
+	}()
+	return interf, ignoreRouterAlreadyHasPortInSubnetError(err, subnetID)
 }
 
 func detachSubnetFromRouter(netClient *gophercloud.ServiceClient, subnetID, routerID string) (*osrouters.InterfaceInfo, error) {

--- a/api/pkg/provider/cloud/openstack/provider.go
+++ b/api/pkg/provider/cloud/openstack/provider.go
@@ -618,3 +618,17 @@ func GetCredentialsForCluster(cloud kubermaticv1.CloudSpec, secretKeySelector pr
 		Domain:   domain,
 	}, nil
 }
+
+func ignoreRouterAlreadyHasPortInSubnetError(err error, subnetID string) error {
+	gopherCloud400Err, ok := err.(gophercloud.ErrDefault400)
+	if !ok {
+		return err
+	}
+
+	matchString := fmt.Sprintf("Router already has a port on subnet %s", subnetID)
+	if !strings.Contains(string(gopherCloud400Err.Body), matchString) {
+		return err
+	}
+
+	return nil
+}

--- a/api/pkg/provider/cloud/openstack/provider_test.go
+++ b/api/pkg/provider/cloud/openstack/provider_test.go
@@ -1,0 +1,43 @@
+package openstack
+
+import (
+	"testing"
+
+	"github.com/gophercloud/gophercloud"
+)
+
+func TestIgnoreRouterAlreadyHasPortInSubnetError(t *testing.T) {
+	const subnetID = "123"
+	testCases := []struct {
+		name            string
+		inErr           error
+		expectReturnErr bool
+	}{
+		{
+			name: "Matches",
+			inErr: gophercloud.ErrDefault400{
+				ErrUnexpectedResponseCode: gophercloud.ErrUnexpectedResponseCode{
+					Body: []byte("Router already has a port on subnet " + subnetID),
+				},
+			},
+			expectReturnErr: false,
+		},
+		{
+			name: "Doesn't match",
+			inErr: gophercloud.ErrDefault400{
+				ErrUnexpectedResponseCode: gophercloud.ErrUnexpectedResponseCode{
+					Body: []byte("Need moar permissions"),
+				},
+			},
+			expectReturnErr: true,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			if err := ignoreRouterAlreadyHasPortInSubnetError(tc.inErr, subnetID); (err != nil) != tc.expectReturnErr {
+				t.Errorf("expect return err: %t, but got err: %v", tc.expectReturnErr, err)
+			}
+		})
+	}
+}


### PR DESCRIPTION
**What this PR does / why we need it**:

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Documentation**:
<!-- Add links to the related documentation changes related to this pull request. E.g. the link to the kubermatic/docs pullrequest. -->

**Does this PR introduce a user-facing change?**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If  no release note is required, just write "NONE".
-->
```release-note
Openstack: A bug that caused cluster reconciliation to fail if the controller crashed at the wrong time was fixed
```

/assign @kdomanski 