### PR TITLE
Enable external CCM for Opentstack on cluster creation when supported

### DIFF
--- a/addons/csi/controllerplugin-rbac.yaml
+++ b/addons/csi/controllerplugin-rbac.yaml
@@ -8,7 +8,7 @@ metadata:
   namespace: kube-system
 
 ---
-# external attacher 
+# external attacher
 kind: ClusterRole
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:

--- a/addons/csi/controllerplugin.yaml
+++ b/addons/csi/controllerplugin.yaml
@@ -32,6 +32,9 @@ spec:
         app: csi-cinder-controllerplugin
     spec:
       serviceAccount: csi-cinder-controller-sa
+      tolerations:
+      - key: "node.cloudprovider.kubernetes.io/uninitialized"
+        operator: "Exists"
       containers:
         - name: csi-attacher
           image: quay.io/k8scsi/csi-attacher:v1.2.1

--- a/addons/csi/nodeplugin.yaml
+++ b/addons/csi/nodeplugin.yaml
@@ -25,6 +25,9 @@ spec:
       hostNetwork: true
       nodeSelector:
         x-kubernetes.io/distribution: ubuntu
+      tolerations:
+      - key: "node.cloudprovider.kubernetes.io/uninitialized"
+        operator: "Exists"
       containers:
         - name: node-driver-registrar
           image: quay.io/k8scsi/csi-node-driver-registrar:v1.1.0
@@ -138,6 +141,9 @@ spec:
       hostNetwork: true
       nodeSelector:
         x-kubernetes.io/distribution: centos
+      tolerations:
+      - key: "node.cloudprovider.kubernetes.io/uninitialized"
+        operator: "Exists"
       containers:
         - name: node-driver-registrar
           image: quay.io/k8scsi/csi-node-driver-registrar:v1.1.0
@@ -251,6 +257,9 @@ spec:
       hostNetwork: true
       nodeSelector:
         x-kubernetes.io/distribution: container-linux
+      tolerations:
+      - key: "node.cloudprovider.kubernetes.io/uninitialized"
+        operator: "Exists"
       containers:
         - name: node-driver-registrar
           image: quay.io/k8scsi/csi-node-driver-registrar:v1.1.0

--- a/api/cmd/conformance-tests/runner.go
+++ b/api/cmd/conformance-tests/runner.go
@@ -414,11 +414,11 @@ func (r *testRunner) executeTests(
 	var timeoutLeft time.Duration
 	if cluster.Annotations["kubermatic.io/openshift"] == "true" {
 		// Openshift installs a lot more during node provisioning, hence this may take longer
-		overallTimeout = overallTimeout + 5*time.Minute
+		overallTimeout += 5 * time.Minute
 	}
-	// The initalization of the external CCM is super slow
+	// The initialization of the external CCM is super slow
 	if cluster.Spec.Features[kubermaticv1.ClusterFeatureExternalCloudProvider] {
-		overallTimeout = overallTimeout + 5*time.Minute
+		overallTimeout += 5 * time.Minute
 	}
 
 	if err := junitReporterWrapper(

--- a/api/cmd/conformance-tests/runner.go
+++ b/api/cmd/conformance-tests/runner.go
@@ -414,7 +414,11 @@ func (r *testRunner) executeTests(
 	var timeoutLeft time.Duration
 	if cluster.Annotations["kubermatic.io/openshift"] == "true" {
 		// Openshift installs a lot more during node provisioning, hence this may take longer
-		overallTimeout = 15 * time.Minute
+		overallTimeout = overallTimeout + 5*time.Minute
+	}
+	// The initalization of the external CCM is super slow
+	if cluster.Spec.Features[kubermaticv1.ClusterFeatureExternalCloudProvider] {
+		overallTimeout = overallTimeout + 5*time.Minute
 	}
 
 	if err := junitReporterWrapper(

--- a/api/pkg/controller/seed-controller-manager/kubernetes/resources.go
+++ b/api/pkg/controller/seed-controller-manager/kubernetes/resources.go
@@ -228,7 +228,7 @@ func GetDeploymentCreators(data *resources.TemplateData, enableAPIserverOIDCAuth
 		data.Cluster().Spec.Version.Minor() > 13 {
 		deployments = append(deployments, clusterautoscaler.DeploymentCreator(data))
 	}
-	if flag := data.Cluster().Spec.Features[resources.FeatureNameExternalCloudProvider]; flag {
+	if flag := data.Cluster().Spec.Features[kubermaticv1.ClusterFeatureExternalCloudProvider]; flag {
 		deployments = append(deployments, cloudcontroller.DeploymentCreator(data))
 	}
 
@@ -277,7 +277,7 @@ func (r *Reconciler) GetSecretCreators(data *resources.TemplateData) []reconcili
 		creators = append(creators, resources.GetInternalKubeconfigCreator(resources.ClusterAutoscalerKubeconfigSecretName, resources.ClusterAutoscalerCertUsername, nil, data))
 	}
 
-	if flag := data.Cluster().Spec.Features[resources.FeatureNameExternalCloudProvider]; flag {
+	if flag := data.Cluster().Spec.Features[kubermaticv1.ClusterFeatureExternalCloudProvider]; flag {
 		creators = append(creators, resources.GetInternalKubeconfigCreator(
 			resources.CloudControllerManagerKubeconfigSecretName, resources.CloudControllerManagerCertUsername, nil, data,
 		))

--- a/api/pkg/controller/user-cluster-controller-manager/node-labeler/node_labeleler.go
+++ b/api/pkg/controller/user-cluster-controller-manager/node-labeler/node_labeleler.go
@@ -38,10 +38,6 @@ type reconciler struct {
 
 func Add(ctx context.Context, log *zap.SugaredLogger, mgr manager.Manager, labels map[string]string) error {
 	log = log.Named(controllerName)
-	if len(labels) == 0 {
-		log.Info("Not starting controller as there are no labels configured on the cluster")
-		return nil
-	}
 
 	r := &reconciler{
 		ctx:      ctx,

--- a/api/pkg/crd/kubermatic/v1/cluster.go
+++ b/api/pkg/crd/kubermatic/v1/cluster.go
@@ -93,7 +93,7 @@ type ClusterSpec struct {
 	OIDC OIDCSettings `json:"oidc,omitempty"`
 
 	// Feature flags
-	Features map[string]bool `json:"features"`
+	Features map[ClusterFeature]bool `json:"features"`
 
 	// Openshift holds all openshift-specific settings
 	Openshift *Openshift `json:"openshift,omitempty"`
@@ -102,6 +102,15 @@ type ClusterSpec struct {
 
 	AuditLogging *AuditLoggingSettings `json:"auditLogging,omitempty"`
 }
+
+type ClusterFeature string
+
+const (
+	// ClusterFeatureExternalCloudProvider describes the external cloud provider feature. It is
+	// only supported on a limited set of providers for a specific set of Kube versions. It must
+	// not be set if its not supported.
+	ClusterFeatureExternalCloudProvider ClusterFeature = "externalCloudProvider"
+)
 
 // ClusterConditionType is used to indicate the type of a cluster condition. For all condition
 // types, the `true` value must indicate success. All condition types must be registered within

--- a/api/pkg/crd/kubermatic/v1/cluster.go
+++ b/api/pkg/crd/kubermatic/v1/cluster.go
@@ -93,7 +93,9 @@ type ClusterSpec struct {
 	OIDC OIDCSettings `json:"oidc,omitempty"`
 
 	// Feature flags
-	Features map[ClusterFeature]bool `json:"features"`
+	// This unfortunately has to be a string map, because we use it in templating and that
+	// can not cope with string types
+	Features map[string]bool `json:"features"`
 
 	// Openshift holds all openshift-specific settings
 	Openshift *Openshift `json:"openshift,omitempty"`
@@ -103,13 +105,11 @@ type ClusterSpec struct {
 	AuditLogging *AuditLoggingSettings `json:"auditLogging,omitempty"`
 }
 
-type ClusterFeature string
-
 const (
 	// ClusterFeatureExternalCloudProvider describes the external cloud provider feature. It is
 	// only supported on a limited set of providers for a specific set of Kube versions. It must
 	// not be set if its not supported.
-	ClusterFeatureExternalCloudProvider ClusterFeature = "externalCloudProvider"
+	ClusterFeatureExternalCloudProvider = "externalCloudProvider"
 )
 
 // ClusterConditionType is used to indicate the type of a cluster condition. For all condition

--- a/api/pkg/crd/kubermatic/v1/zz_generated.deepcopy.go
+++ b/api/pkg/crd/kubermatic/v1/zz_generated.deepcopy.go
@@ -551,7 +551,7 @@ func (in *ClusterSpec) DeepCopyInto(out *ClusterSpec) {
 	out.OIDC = in.OIDC
 	if in.Features != nil {
 		in, out := &in.Features, &out.Features
-		*out = make(map[ClusterFeature]bool, len(*in))
+		*out = make(map[string]bool, len(*in))
 		for key, val := range *in {
 			(*out)[key] = val
 		}

--- a/api/pkg/crd/kubermatic/v1/zz_generated.deepcopy.go
+++ b/api/pkg/crd/kubermatic/v1/zz_generated.deepcopy.go
@@ -551,7 +551,7 @@ func (in *ClusterSpec) DeepCopyInto(out *ClusterSpec) {
 	out.OIDC = in.OIDC
 	if in.Features != nil {
 		in, out := &in.Features, &out.Features
-		*out = make(map[string]bool, len(*in))
+		*out = make(map[ClusterFeature]bool, len(*in))
 		for key, val := range *in {
 			(*out)[key] = val
 		}

--- a/api/pkg/handler/v1/cluster/cluster.go
+++ b/api/pkg/handler/v1/cluster/cluster.go
@@ -25,6 +25,7 @@ import (
 	kubermaticlog "github.com/kubermatic/kubermatic/api/pkg/log"
 	"github.com/kubermatic/kubermatic/api/pkg/provider"
 	kubernetesprovider "github.com/kubermatic/kubermatic/api/pkg/provider/kubernetes"
+	"github.com/kubermatic/kubermatic/api/pkg/resources/cloudcontroller"
 	"github.com/kubermatic/kubermatic/api/pkg/resources/cluster"
 	machineresource "github.com/kubermatic/kubermatic/api/pkg/resources/machine"
 	"github.com/kubermatic/kubermatic/api/pkg/util/errors"
@@ -127,6 +128,10 @@ func CreateEndpoint(sshKeyProvider provider.SSHKeyProvider, projectProvider prov
 		}
 		// generate the name here so that it can be used in the secretName below
 		partialCluster.Name = rand.String(10)
+
+		if cloudcontroller.ExternalCloudControllerFeatureSupported(partialCluster) {
+			partialCluster.Spec.Features = map[kubermaticv1.ClusterFeature]bool{kubermaticv1.ClusterFeatureExternalCloudProvider: true}
+		}
 
 		if err := kubernetesprovider.CreateCredentialSecretForCluster(ctx, privilegedClusterProvider.GetSeedClusterAdminRuntimeClient(), partialCluster, req.ProjectID); err != nil {
 			return nil, err

--- a/api/pkg/handler/v1/cluster/cluster.go
+++ b/api/pkg/handler/v1/cluster/cluster.go
@@ -130,7 +130,7 @@ func CreateEndpoint(sshKeyProvider provider.SSHKeyProvider, projectProvider prov
 		partialCluster.Name = rand.String(10)
 
 		if cloudcontroller.ExternalCloudControllerFeatureSupported(partialCluster) {
-			partialCluster.Spec.Features = map[kubermaticv1.ClusterFeature]bool{kubermaticv1.ClusterFeatureExternalCloudProvider: true}
+			partialCluster.Spec.Features = map[string]bool{kubermaticv1.ClusterFeatureExternalCloudProvider: true}
 		}
 
 		if err := kubernetesprovider.CreateCredentialSecretForCluster(ctx, privilegedClusterProvider.GetSeedClusterAdminRuntimeClient(), partialCluster, req.ProjectID); err != nil {

--- a/api/pkg/kubernetes/helper.go
+++ b/api/pkg/kubernetes/helper.go
@@ -18,6 +18,10 @@ func HasFinalizer(o metav1.Object, names ...string) bool {
 	return sets.NewString(o.GetFinalizers()...).HasAll(names...)
 }
 
+func HasAnyFinalizer(o metav1.Object, names ...string) bool {
+	return sets.NewString(o.GetFinalizers()...).HasAny(names...)
+}
+
 // HasOnlyFinalizer tells if an object has only the given finalizer
 func HasOnlyFinalizer(o metav1.Object, name string) bool {
 	set := sets.NewString(o.GetFinalizers()...)

--- a/api/pkg/resources/data.go
+++ b/api/pkg/resources/data.go
@@ -333,7 +333,7 @@ func GetKubernetesCloudProviderName(cluster *kubermaticv1.Cluster) string {
 		return "aws"
 	}
 	if cluster.Spec.Cloud.Openstack != nil {
-		if flag := cluster.Spec.Features[FeatureNameExternalCloudProvider]; flag {
+		if flag := cluster.Spec.Features[kubermaticv1.ClusterFeatureExternalCloudProvider]; flag {
 			return "external"
 		}
 		return "openstack"

--- a/api/pkg/resources/machinecontroller/deployment.go
+++ b/api/pkg/resources/machinecontroller/deployment.go
@@ -114,7 +114,7 @@ func DeploymentCreatorWithoutInitWrapper(data machinecontrollerData) reconciling
 				return nil, err
 			}
 
-			externalCloudProvider := data.Cluster().Spec.Features[resources.FeatureNameExternalCloudProvider]
+			externalCloudProvider := data.Cluster().Spec.Features[kubermaticv1.ClusterFeatureExternalCloudProvider]
 
 			dep.Spec.Template.Spec.Containers = []corev1.Container{
 				{

--- a/api/pkg/resources/resources.go
+++ b/api/pkg/resources/resources.go
@@ -341,11 +341,6 @@ const (
 	IPVSProxyMode = "ipvs"
 	// IPTablesProxyMode defines the iptables kube-proxy mode.
 	IPTablesProxyMode = "iptables"
-
-	// Feature flags, maybe move inside own const block.
-
-	// FeatureNameExternalCloudProvider enables external cloud provider support.
-	FeatureNameExternalCloudProvider = "externalCloudProvider"
 )
 
 const (


### PR DESCRIPTION
**What this PR does / why we need it**:

Enables Opentstack external CCM by default on creation of 1.16+ clusters.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #4730 

**Special notes for your reviewer**:

**Documentation**:
<!-- Add links to the related documentation changes related to this pull request. E.g. the link to the kubermatic/docs pullrequest. -->

**Does this PR introduce a user-facing change?**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If  no release note is required, just write "NONE".
-->
```release-note
Openstack: New Kubernetes 1.16+ clusters use the external Cloud Controller Manager and CSI by default
```
