### PR TITLE
Return error with proper code when listing AWS vpc's

### DIFF
--- a/api/pkg/handler/v1/provider/aws.go
+++ b/api/pkg/handler/v1/provider/aws.go
@@ -448,7 +448,7 @@ func listAWSVPCS(accessKeyID, secretAccessKey string, datacenter *kubermaticv1.D
 
 	vpcsResults, err := awsprovider.GetVPCS(accessKeyID, secretAccessKey, datacenter.Spec.AWS.Region)
 	if err != nil {
-		return nil, fmt.Errorf("couldn't get vpc's: %v", err)
+		return nil, err
 	}
 
 	vpcs := apiv1.AWSVPCList{}


### PR DESCRIPTION
**What this PR does / why we need it**:
Small improvement to actually allow us to recognize error returned from AWS.

**Does this PR introduce a user-facing change?**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If  no release note is required, just write "NONE".
-->
```release-note
NONE
```
