### PR TITLE
Correctly return token-based kubeconfigs via API

### DIFF
--- a/api/pkg/cluster/client/client.go
+++ b/api/pkg/cluster/client/client.go
@@ -4,14 +4,11 @@ import (
 	"context"
 	"fmt"
 
-	openshiftuserclusterresources "github.com/kubermatic/kubermatic/api/pkg/controller/user-cluster-controller-manager/resources/resources/openshift"
 	kubermaticv1 "github.com/kubermatic/kubermatic/api/pkg/crd/kubermatic/v1"
-	kuberneteshelper "github.com/kubermatic/kubermatic/api/pkg/kubernetes"
 	"github.com/kubermatic/kubermatic/api/pkg/resources"
 	"github.com/kubermatic/kubermatic/api/pkg/util/restmapper"
 
 	corev1 "k8s.io/api/core/v1"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
 	restclient "k8s.io/client-go/rest"
 	"k8s.io/client-go/tools/clientcmd"
@@ -46,37 +43,15 @@ type Provider struct {
 
 	// We keep the existing cluster mappings to avoid the discovery on each call to the API server
 	restMapperCache *restmapper.Cache
-
-	// Can be set for tests
-	overrideGetClientFunc func(*kubermaticv1.Cluster, ...ConfigOption) (ctrlruntimeclient.Client, error)
 }
 
-// GetAdminKubeconfig returns the admin kubeconfig for the given cluster
+// GetAdminKubeconfig returns the admin kubeconfig for the given cluster. For internal use
+// by ourselves only.
 func (p *Provider) GetAdminKubeconfig(c *kubermaticv1.Cluster) ([]byte, error) {
 	s := &corev1.Secret{}
 	if err := p.seedClient.Get(context.Background(), types.NamespacedName{Namespace: c.Status.NamespaceName, Name: resources.InternalUserClusterAdminKubeconfigSecretName}, s); err != nil {
 		return nil, err
 	}
-	d := s.Data[resources.KubeconfigSecretKey]
-	if len(d) == 0 {
-		return nil, fmt.Errorf("no kubeconfig found")
-	}
-
-	if p.useExternalAddress {
-		return setExternalAddress(c, d)
-	}
-
-	return d, nil
-}
-
-// GetViewerKubeconfig returns the viewer kubeconfig for the given cluster
-func (p *Provider) GetViewerKubeconfig(c *kubermaticv1.Cluster) ([]byte, error) {
-	s := &corev1.Secret{}
-
-	if err := p.seedClient.Get(context.Background(), types.NamespacedName{Namespace: c.Status.NamespaceName, Name: resources.ViewerKubeconfigSecretName}, s); err != nil {
-		return nil, err
-	}
-
 	d := s.Data[resources.KubeconfigSecretKey]
 	if len(d) == 0 {
 		return nil, fmt.Errorf("no kubeconfig found")
@@ -103,48 +78,6 @@ func setExternalAddress(c *kubermaticv1.Cluster, config []byte) ([]byte, error) 
 	}
 
 	return data, nil
-}
-
-// RevokeViewerKubeconfig deletes viewer token to deploy new one and regenerate viewer-kubeconfig
-func (p *Provider) RevokeViewerKubeconfig(c *kubermaticv1.Cluster) error {
-	s := &corev1.Secret{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:      resources.ViewerTokenSecretName,
-			Namespace: c.Status.NamespaceName,
-		},
-	}
-
-	if err := p.seedClient.Delete(context.Background(), s); err != nil {
-		return err
-	}
-	return nil
-}
-
-func (p *Provider) RevokeAdminKubeconfig(c *kubermaticv1.Cluster) error {
-	isOpenshift := c.Annotations["kubermatic.io/openshift"] != ""
-	ctx := context.Background()
-	if !isOpenshift {
-		oldCluster := c.DeepCopy()
-		c.Address.AdminToken = kuberneteshelper.GenerateToken()
-		if err := p.seedClient.Patch(ctx, c, ctrlruntimeclient.MergeFrom(oldCluster)); err != nil {
-			return fmt.Errorf("failed to patch cluster with new token: %v", err)
-		}
-		return nil
-	}
-	userClusterClient, err := p.GetClient(c)
-	if err != nil {
-		return fmt.Errorf("failed to get usercluster client: %v", err)
-	}
-	serviceAccount := &corev1.ServiceAccount{
-		ObjectMeta: metav1.ObjectMeta{
-			Namespace: metav1.NamespaceSystem,
-			Name:      openshiftuserclusterresources.TokenOwnerServiceAccountName,
-		},
-	}
-	if err := userClusterClient.Delete(ctx, serviceAccount); err != nil {
-		return fmt.Errorf("failed to remove the token owner: %v", err)
-	}
-	return nil
 }
 
 // ConfigOption defines a function that applies additional configuration to restclient.Config in a generic way.
@@ -194,9 +127,6 @@ func (p *Provider) GetClientConfig(c *kubermaticv1.Cluster, options ...ConfigOpt
 
 // GetClient returns a dynamic client
 func (p *Provider) GetClient(c *kubermaticv1.Cluster, options ...ConfigOption) (ctrlruntimeclient.Client, error) {
-	if p.overrideGetClientFunc != nil {
-		return p.overrideGetClientFunc(c, options...)
-	}
 	config, err := p.GetClientConfig(c, options...)
 	if err != nil {
 		return nil, err

--- a/api/pkg/handler/test/helper.go
+++ b/api/pkg/handler/test/helper.go
@@ -1,7 +1,6 @@
 package test
 
 import (
-	"context"
 	"crypto/sha256"
 	"crypto/sha512"
 	"fmt"
@@ -25,7 +24,6 @@ import (
 	kubermaticv1 "github.com/kubermatic/kubermatic/api/pkg/crd/kubermatic/v1"
 	"github.com/kubermatic/kubermatic/api/pkg/handler/auth"
 	"github.com/kubermatic/kubermatic/api/pkg/handler/v1/common"
-	kuberneteshelper "github.com/kubermatic/kubermatic/api/pkg/kubernetes"
 	kubermaticlog "github.com/kubermatic/kubermatic/api/pkg/log"
 	"github.com/kubermatic/kubermatic/api/pkg/presets"
 	"github.com/kubermatic/kubermatic/api/pkg/provider"
@@ -393,21 +391,6 @@ func (f *fakeUserClusterConnection) GetClient(_ *kubermaticv1.Cluster, _ ...k8cu
 	return f.fakeDynamicClient, nil
 }
 
-func (f *fakeUserClusterConnection) GetAdminKubeconfig(c *kubermaticv1.Cluster) ([]byte, error) {
-	return []byte(generateTestKubeconfig(ClusterID, IDToken)), nil
-}
-
-func (f *fakeUserClusterConnection) GetViewerKubeconfig(c *kubermaticv1.Cluster) ([]byte, error) {
-	return []byte(generateTestKubeconfig(ClusterID, IDViewerToken)), nil
-}
-func (f *fakeUserClusterConnection) RevokeViewerKubeconfig(c *kubermaticv1.Cluster) error {
-	return nil
-}
-func (f *fakeUserClusterConnection) RevokeAdminKubeconfig(c *kubermaticv1.Cluster) error {
-	c.Address.AdminToken = kuberneteshelper.GenerateToken()
-	return f.fakeDynamicClient.Update(context.Background(), c)
-}
-
 // ClientsSets a simple wrapper that holds fake client sets
 type ClientsSets struct {
 	FakeKubermaticClient *kubermaticfakeclentset.Clientset
@@ -419,8 +402,8 @@ type ClientsSets struct {
 	TokenGenerator     serviceaccount.TokenGenerator
 }
 
-// generateTestKubeconfig returns test kubeconfig yaml structure
-func generateTestKubeconfig(clusterID, token string) string {
+// GenerateTestKubeconfig returns test kubeconfig yaml structure
+func GenerateTestKubeconfig(clusterID, token string) string {
 	return fmt.Sprintf(`
 apiVersion: v1
 clusters:
@@ -667,6 +650,7 @@ func GenCluster(id string, name string, projectID string, creationTime time.Time
 				UserClusterControllerManager: kubermaticv1.HealthStatusUp,
 				CloudProviderInfrastructure:  kubermaticv1.HealthStatusUp,
 			},
+			NamespaceName: "cluster-" + id,
 		},
 	}
 


### PR DESCRIPTION
**What this PR does / why we need it**:

* Makes the API correctly return the token-based kubeconfig
* Removes all GetKubeconfig and RevokeKubeconfig functions from the userClusterConnectionProvider and instead defines them directly in the ClusterProvider because the UserClusterConnectionProvider is used by various other components of Kubermatic, none of them need this functions, they are only used in the API

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Documentation**:
<!-- Add links to the related documentation changes related to this pull request. E.g. the link to the kubermatic/docs pullrequest. -->

**Does this PR introduce a user-facing change?**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If  no release note is required, just write "NONE".
-->
```release-note
none
```
