### PR TITLE
avoid using PULL_PULL_SHA as it's not defined in batch jobs

### DIFF
--- a/api/hack/verify-chart-versions.sh
+++ b/api/hack/verify-chart-versions.sh
@@ -18,7 +18,7 @@ exitCode=0
   echo "Verifying $name chart..."
 
   # if this chart was touched in this PR
-  if ! git diff --exit-code --no-patch "$PULL_BASE_SHA...$PULL_PULL_SHA" "$(dirname "$chartYAML")"; then
+  if ! git diff --exit-code --no-patch "$PULL_BASE_SHA..." "$(dirname "$chartYAML")"; then
     oldVersion=""
 
     # as we scan for charts by looking through the current files, we can always


### PR DESCRIPTION
**What this PR does / why we need it**:
This should fix the job. Cursory testing showed that "master...HEAD" and "master..." are identical.

**Does this PR introduce a user-facing change?**:
```release-note
NONE
```
