### PR TITLE
Make seed-proxy controller work in its own namespace

### DIFF
--- a/api/pkg/controller/seed-proxy/controller.go
+++ b/api/pkg/controller/seed-proxy/controller.go
@@ -24,10 +24,6 @@ const (
 	// ControllerName is the name of this very controller.
 	ControllerName = "seed-proxy-controller"
 
-	// MasterTargetNamespace is the namespace inside the
-	// master where the components will be created in.
-	MasterTargetNamespace = "kubermatic"
-
 	// MasterDeploymentName is the name used for deployments'
 	// NameLabel value.
 	MasterDeploymentName = "seed-proxy"
@@ -48,21 +44,9 @@ const (
 	// inside the seed cluster.
 	SeedServiceAccountName = "seed-proxy"
 
-	// SeedServiceAccountNamespace is the namespace inside the seed
-	// cluster where the service account will be created.
-	SeedServiceAccountNamespace = metav1.NamespaceSystem
-
 	// SeedMonitoringNamespace is the namespace inside the seed
 	// cluster where Prometheus, Grafana etc. are installed.
 	SeedMonitoringNamespace = "monitoring"
-
-	// SeedMonitoringRoleName is the name inside the seed monitoring
-	// namespace used for the new role used for proxying to Prometheus/Grafana/...
-	SeedMonitoringRoleName = "seed-proxy"
-
-	// SeedMonitoringRoleBindingName is the name inside the seed
-	// monitoring namespace used for the new role binding.
-	SeedMonitoringRoleBindingName = "seed-proxy"
 
 	// SeedPrometheusService is the service exposed by Prometheus.
 	SeedPrometheusService = "prometheus:web"

--- a/api/pkg/controller/seed-proxy/reconciler.go
+++ b/api/pkg/controller/seed-proxy/reconciler.go
@@ -344,7 +344,7 @@ func (r *Reconciler) reconcileMasterGrafanaProvisioning(seeds map[string]*kuberm
 func (r *Reconciler) deleteResource(client ctrlruntimeclient.Client, name string, namespace string, obj runtime.Object) error {
 	key := types.NamespacedName{Name: name, Namespace: namespace}
 
-	if err := client.Get(context.Background(), key, obj); err != nil {
+	if err := client.Get(r.ctx, key, obj); err != nil {
 		if !kerrors.IsNotFound(err) {
 			return fmt.Errorf("failed to probe for %s: %v", key, err)
 		}
@@ -352,7 +352,7 @@ func (r *Reconciler) deleteResource(client ctrlruntimeclient.Client, name string
 		return nil
 	}
 
-	if err := client.Delete(context.Background(), obj); err != nil {
+	if err := client.Delete(r.ctx, obj); err != nil {
 		return fmt.Errorf("failed to delete %s: %v", key, err)
 	}
 

--- a/api/pkg/controller/seed-proxy/reconciler.go
+++ b/api/pkg/controller/seed-proxy/reconciler.go
@@ -63,30 +63,18 @@ func (r *Reconciler) reconcile(seedName string, log *zap.SugaredLogger) error {
 		return fmt.Errorf("didn't find seed %q", seedName)
 	}
 
-	// both of these namespaces must exist or else we cannot establish
-	// the service account token sharing
-	err = r.Get(r.ctx, types.NamespacedName{Name: MasterTargetNamespace}, &corev1.Namespace{})
-	if err != nil {
-		if !kerrors.IsNotFound(err) {
-			return fmt.Errorf("failed to check for namespace %s: %v", MasterTargetNamespace, err)
-		}
-
-		log.Debugw("skipping because target master namespace does not exist", "namespace", MasterTargetNamespace)
-		return nil
-	}
-
 	client, err := r.seedClientGetter(seed)
 	if err != nil {
 		return fmt.Errorf("failed to get seed client: %v", err)
 	}
 
-	err = client.Get(r.ctx, types.NamespacedName{Name: SeedServiceAccountNamespace}, &corev1.Namespace{})
+	err = client.Get(r.ctx, types.NamespacedName{Name: seed.Namespace}, &corev1.Namespace{})
 	if err != nil {
 		if !kerrors.IsNotFound(err) {
-			return fmt.Errorf("failed to check for namespace %s: %v", SeedServiceAccountNamespace, err)
+			return fmt.Errorf("failed to check for namespace %s in seed cluster: %v", seed.Namespace, err)
 		}
 
-		log.Debug("skipping because seed namespace does not exist", "namespace", SeedServiceAccountNamespace)
+		log.Debug("skipping because seed namespace does not exist", "namespace", seed.Namespace)
 		return nil
 	}
 
@@ -140,7 +128,7 @@ func (r *Reconciler) reconcileSeedProxy(seed *kubermaticv1.Seed, client ctrlrunt
 	}
 
 	log.Debug("reconciling ServiceAccounts...")
-	if err := r.reconcileSeedServiceAccounts(client, log); err != nil {
+	if err := r.reconcileSeedServiceAccounts(seed, client, log); err != nil {
 		return fmt.Errorf("failed to ensure ServiceAccount: %v", err)
 	}
 
@@ -150,33 +138,33 @@ func (r *Reconciler) reconcileSeedProxy(seed *kubermaticv1.Seed, client ctrlrunt
 	}
 
 	log.Debug("fetching ServiceAccount details from seed cluster...")
-	serviceAccountSecret, err := r.fetchServiceAccountSecret(client, log)
+	serviceAccountSecret, err := r.fetchServiceAccountSecret(seed, client, log)
 	if err != nil {
 		return fmt.Errorf("failed to fetch ServiceAccount: %v", err)
 	}
 
-	if err := r.reconcileMaster(seed.Name, cfg, serviceAccountSecret, log); err != nil {
+	if err := r.reconcileMaster(seed, cfg, serviceAccountSecret, log); err != nil {
 		return fmt.Errorf("failed to reconcile master: %v", err)
 	}
 
 	return nil
 }
 
-func (r *Reconciler) reconcileSeedServiceAccounts(client ctrlruntimeclient.Client, log *zap.SugaredLogger) error {
+func (r *Reconciler) reconcileSeedServiceAccounts(seed *kubermaticv1.Seed, client ctrlruntimeclient.Client, log *zap.SugaredLogger) error {
 	creators := []reconciling.NamedServiceAccountCreatorGetter{
-		seedServiceAccountCreator(),
+		seedServiceAccountCreator(seed),
 	}
 
-	if err := reconciling.ReconcileServiceAccounts(r.ctx, creators, SeedServiceAccountNamespace, client); err != nil {
-		return fmt.Errorf("failed to reconcile ServiceAccounts in the namespace %s: %v", SeedServiceAccountNamespace, err)
+	if err := reconciling.ReconcileServiceAccounts(r.ctx, creators, seed.Namespace, client); err != nil {
+		return fmt.Errorf("failed to reconcile ServiceAccounts in the namespace %s: %v", seed.Namespace, err)
 	}
 
 	return nil
 }
 
-func (r *Reconciler) reconcileSeedRoles(client ctrlruntimeclient.Client, log *zap.SugaredLogger) error {
+func (r *Reconciler) reconcileSeedRoles(seed *kubermaticv1.Seed, client ctrlruntimeclient.Client, log *zap.SugaredLogger) error {
 	creators := []reconciling.NamedRoleCreatorGetter{
-		seedMonitoringRoleCreator(),
+		seedMonitoringRoleCreator(seed),
 	}
 
 	if err := reconciling.ReconcileRoles(r.ctx, creators, SeedMonitoringNamespace, client); err != nil {
@@ -186,9 +174,9 @@ func (r *Reconciler) reconcileSeedRoles(client ctrlruntimeclient.Client, log *za
 	return nil
 }
 
-func (r *Reconciler) reconcileSeedRoleBindings(client ctrlruntimeclient.Client, log *zap.SugaredLogger) error {
+func (r *Reconciler) reconcileSeedRoleBindings(seed *kubermaticv1.Seed, client ctrlruntimeclient.Client, log *zap.SugaredLogger) error {
 	creators := []reconciling.NamedRoleBindingCreatorGetter{
-		seedMonitoringRoleBindingCreator(),
+		seedMonitoringRoleBindingCreator(seed),
 	}
 
 	if err := reconciling.ReconcileRoleBindings(r.ctx, creators, SeedMonitoringNamespace, client); err != nil {
@@ -210,22 +198,22 @@ func (r *Reconciler) reconcileSeedRBAC(seed *kubermaticv1.Seed, client ctrlrunti
 	}
 
 	log.Debug("reconciling Roles...")
-	if err := r.reconcileSeedRoles(client, log); err != nil {
+	if err := r.reconcileSeedRoles(seed, client, log); err != nil {
 		return fmt.Errorf("failed to ensure Role: %v", err)
 	}
 
 	log.Debug("reconciling RoleBindings...")
-	if err := r.reconcileSeedRoleBindings(client, log); err != nil {
+	if err := r.reconcileSeedRoleBindings(seed, client, log); err != nil {
 		return fmt.Errorf("failed to ensure RoleBinding: %v", err)
 	}
 
 	return nil
 }
 
-func (r *Reconciler) fetchServiceAccountSecret(client ctrlruntimeclient.Client, log *zap.SugaredLogger) (*corev1.Secret, error) {
+func (r *Reconciler) fetchServiceAccountSecret(seed *kubermaticv1.Seed, client ctrlruntimeclient.Client, log *zap.SugaredLogger) (*corev1.Secret, error) {
 	sa := &corev1.ServiceAccount{}
 	name := types.NamespacedName{
-		Namespace: SeedServiceAccountNamespace,
+		Namespace: seed.Namespace,
 		Name:      SeedServiceAccountName,
 	}
 
@@ -239,7 +227,7 @@ func (r *Reconciler) fetchServiceAccountSecret(client ctrlruntimeclient.Client, 
 
 	secret := &corev1.Secret{}
 	name = types.NamespacedName{
-		Namespace: SeedServiceAccountNamespace,
+		Namespace: seed.Namespace,
 		Name:      sa.Secrets[0].Name,
 	}
 
@@ -250,39 +238,39 @@ func (r *Reconciler) fetchServiceAccountSecret(client ctrlruntimeclient.Client, 
 	return secret, nil
 }
 
-func (r *Reconciler) reconcileMaster(seedName string, kubeconfig *rest.Config, credentials *corev1.Secret, log *zap.SugaredLogger) error {
+func (r *Reconciler) reconcileMaster(seed *kubermaticv1.Seed, kubeconfig *rest.Config, credentials *corev1.Secret, log *zap.SugaredLogger) error {
 	log.Debug("reconciling Secrets...")
-	secret, err := r.reconcileMasterSecrets(seedName, kubeconfig, credentials)
+	secret, err := r.reconcileMasterSecrets(seed, kubeconfig, credentials)
 	if err != nil {
 		return fmt.Errorf("failed to ensure Secrets: %v", err)
 	}
 
 	log.Debug("reconciling Deployments...")
-	if err := r.reconcileMasterDeployments(seedName, secret); err != nil {
+	if err := r.reconcileMasterDeployments(seed, secret); err != nil {
 		return fmt.Errorf("failed to ensure Deployments: %v", err)
 	}
 
 	log.Debug("reconciling Services...")
-	if err := r.reconcileMasterServices(seedName, secret); err != nil {
+	if err := r.reconcileMasterServices(seed, secret); err != nil {
 		return fmt.Errorf("failed to ensure Services: %v", err)
 	}
 
 	return nil
 }
 
-func (r *Reconciler) reconcileMasterSecrets(seedName string, kubeconfig *rest.Config, credentials *corev1.Secret) (*corev1.Secret, error) {
+func (r *Reconciler) reconcileMasterSecrets(seed *kubermaticv1.Seed, kubeconfig *rest.Config, credentials *corev1.Secret) (*corev1.Secret, error) {
 	creators := []reconciling.NamedSecretCreatorGetter{
-		masterSecretCreator(seedName, kubeconfig, credentials),
+		masterSecretCreator(seed, kubeconfig, credentials),
 	}
 
-	if err := reconciling.ReconcileSecrets(r.ctx, creators, MasterTargetNamespace, r.Client); err != nil {
-		return nil, fmt.Errorf("failed to reconcile Secrets in the namespace %s: %v", MasterTargetNamespace, err)
+	if err := reconciling.ReconcileSecrets(r.ctx, creators, seed.Namespace, r.Client); err != nil {
+		return nil, fmt.Errorf("failed to reconcile Secrets in the namespace %s: %v", seed.Namespace, err)
 	}
 
 	secret := &corev1.Secret{}
 	name := types.NamespacedName{
-		Namespace: MasterTargetNamespace,
-		Name:      secretName(seedName),
+		Namespace: seed.Namespace,
+		Name:      secretName(seed),
 	}
 
 	if err := r.Get(r.ctx, name, secret); err != nil {
@@ -292,25 +280,25 @@ func (r *Reconciler) reconcileMasterSecrets(seedName string, kubeconfig *rest.Co
 	return secret, nil
 }
 
-func (r *Reconciler) reconcileMasterDeployments(seedName string, secret *corev1.Secret) error {
+func (r *Reconciler) reconcileMasterDeployments(seed *kubermaticv1.Seed, secret *corev1.Secret) error {
 	creators := []reconciling.NamedDeploymentCreatorGetter{
-		masterDeploymentCreator(seedName, secret),
+		masterDeploymentCreator(seed, secret),
 	}
 
-	if err := reconciling.ReconcileDeployments(r.ctx, creators, MasterTargetNamespace, r.Client); err != nil {
-		return fmt.Errorf("failed to reconcile Deployments in the namespace %s: %v", MasterTargetNamespace, err)
+	if err := reconciling.ReconcileDeployments(r.ctx, creators, seed.Namespace, r.Client); err != nil {
+		return fmt.Errorf("failed to reconcile Deployments in the namespace %s: %v", seed.Namespace, err)
 	}
 
 	return nil
 }
 
-func (r *Reconciler) reconcileMasterServices(seedName string, secret *corev1.Secret) error {
+func (r *Reconciler) reconcileMasterServices(seed *kubermaticv1.Seed, secret *corev1.Secret) error {
 	creators := []reconciling.NamedServiceCreatorGetter{
-		masterServiceCreator(seedName, secret),
+		masterServiceCreator(seed, secret),
 	}
 
-	if err := reconciling.ReconcileServices(r.ctx, creators, MasterTargetNamespace, r.Client); err != nil {
-		return fmt.Errorf("failed to reconcile Services in the namespace %s: %v", MasterTargetNamespace, err)
+	if err := reconciling.ReconcileServices(r.ctx, creators, seed.Namespace, r.Client); err != nil {
+		return fmt.Errorf("failed to reconcile Services in the namespace %s: %v", seed.Namespace, err)
 	}
 
 	return nil

--- a/api/pkg/controller/seed-proxy/resources.go
+++ b/api/pkg/controller/seed-proxy/resources.go
@@ -21,16 +21,24 @@ import (
 	"k8s.io/utils/pointer"
 )
 
-func secretName(contextName string) string {
-	return fmt.Sprintf("seed-proxy-%s", contextName)
+func secretName(seed *kubermaticv1.Seed) string {
+	return fmt.Sprintf("seed-proxy-%s", seed.Name)
 }
 
-func deploymentName(contextName string) string {
-	return fmt.Sprintf("seed-proxy-%s", contextName)
+func deploymentName(seed *kubermaticv1.Seed) string {
+	return fmt.Sprintf("seed-proxy-%s", seed.Name)
 }
 
-func serviceName(contextName string) string {
-	return fmt.Sprintf("seed-proxy-%s", contextName)
+func serviceName(seed *kubermaticv1.Seed) string {
+	return fmt.Sprintf("seed-proxy-%s", seed.Name)
+}
+
+func seedMonitoringRoleName(seed *kubermaticv1.Seed) string {
+	return fmt.Sprintf("seed-proxy-%s", seed.Namespace)
+}
+
+func seedMonitoringRoleBindingName(seed *kubermaticv1.Seed) string {
+	return fmt.Sprintf("seed-proxy-%s", seed.Namespace)
 }
 
 func defaultLabels(name string, instance string) map[string]string {
@@ -52,7 +60,7 @@ func ownerReferences(secret *corev1.Secret) []metav1.OwnerReference {
 	}
 }
 
-func seedServiceAccountCreator() reconciling.NamedServiceAccountCreatorGetter {
+func seedServiceAccountCreator(seed *kubermaticv1.Seed) reconciling.NamedServiceAccountCreatorGetter {
 	return func() (string, reconciling.ServiceAccountCreator) {
 		return SeedServiceAccountName, func(sa *corev1.ServiceAccount) (*corev1.ServiceAccount, error) {
 			sa.Labels = defaultLabels(SeedServiceAccountName, "")
@@ -62,10 +70,12 @@ func seedServiceAccountCreator() reconciling.NamedServiceAccountCreatorGetter {
 	}
 }
 
-func seedMonitoringRoleCreator() reconciling.NamedRoleCreatorGetter {
+func seedMonitoringRoleCreator(seed *kubermaticv1.Seed) reconciling.NamedRoleCreatorGetter {
+	name := seedMonitoringRoleName(seed)
+
 	return func() (string, reconciling.RoleCreator) {
-		return SeedMonitoringRoleName, func(r *rbacv1.Role) (*rbacv1.Role, error) {
-			r.Labels = defaultLabels(SeedMonitoringRoleName, "")
+		return name, func(r *rbacv1.Role) (*rbacv1.Role, error) {
+			r.Labels = defaultLabels(name, "")
 
 			r.Rules = []rbacv1.PolicyRule{
 				{
@@ -84,22 +94,24 @@ func seedMonitoringRoleCreator() reconciling.NamedRoleCreatorGetter {
 	}
 }
 
-func seedMonitoringRoleBindingCreator() reconciling.NamedRoleBindingCreatorGetter {
+func seedMonitoringRoleBindingCreator(seed *kubermaticv1.Seed) reconciling.NamedRoleBindingCreatorGetter {
+	name := seedMonitoringRoleBindingName(seed)
+
 	return func() (string, reconciling.RoleBindingCreator) {
-		return SeedMonitoringRoleBindingName, func(rb *rbacv1.RoleBinding) (*rbacv1.RoleBinding, error) {
-			rb.Labels = defaultLabels(SeedMonitoringRoleBindingName, "")
+		return name, func(rb *rbacv1.RoleBinding) (*rbacv1.RoleBinding, error) {
+			rb.Labels = defaultLabels(name, "")
 
 			rb.RoleRef = rbacv1.RoleRef{
 				APIGroup: rbacv1.GroupName,
 				Kind:     "Role",
-				Name:     SeedMonitoringRoleName,
+				Name:     seedMonitoringRoleName(seed),
 			}
 
 			rb.Subjects = []rbacv1.Subject{
 				{
 					Kind:      rbacv1.ServiceAccountKind,
 					Name:      SeedServiceAccountName,
-					Namespace: SeedServiceAccountNamespace,
+					Namespace: seed.Namespace,
 				},
 			}
 
@@ -108,13 +120,13 @@ func seedMonitoringRoleBindingCreator() reconciling.NamedRoleBindingCreatorGette
 	}
 }
 
-func masterSecretCreator(contextName string, kubeconfig *rest.Config, credentials *corev1.Secret) reconciling.NamedSecretCreatorGetter {
-	name := secretName(contextName)
+func masterSecretCreator(seed *kubermaticv1.Seed, kubeconfig *rest.Config, credentials *corev1.Secret) reconciling.NamedSecretCreatorGetter {
+	name := secretName(seed)
 	host := kubeconfig.Host
 
 	return func() (string, reconciling.SecretCreator) {
 		return name, func(s *corev1.Secret) (*corev1.Secret, error) {
-			s.Labels = defaultLabels("seed-proxy", contextName)
+			s.Labels = defaultLabels("seed-proxy", seed.Name)
 
 			if s.Data == nil {
 				s.Data = make(map[string][]byte)
@@ -159,15 +171,15 @@ func convertServiceAccountToKubeconfig(host string, credentials *corev1.Secret) 
 	return clientcmd.Write(*kubeconfig)
 }
 
-func masterDeploymentCreator(contextName string, secret *corev1.Secret) reconciling.NamedDeploymentCreatorGetter {
-	name := deploymentName(contextName)
+func masterDeploymentCreator(seed *kubermaticv1.Seed, secret *corev1.Secret) reconciling.NamedDeploymentCreatorGetter {
+	name := deploymentName(seed)
 
 	return func() (string, reconciling.DeploymentCreator) {
 		return name, func(d *appsv1.Deployment) (*appsv1.Deployment, error) {
 			labels := func() map[string]string {
 				return map[string]string{
 					NameLabel:     MasterDeploymentName,
-					InstanceLabel: contextName,
+					InstanceLabel: seed.Name,
 				}
 			}
 
@@ -206,7 +218,7 @@ func masterDeploymentCreator(contextName string, secret *corev1.Secret) reconcil
 					Env: []corev1.EnvVar{
 						{
 							Name:  "KUBERNETES_CONTEXT",
-							Value: contextName,
+							Value: seed.Name,
 						},
 						{
 							Name:  "KUBECONFIG",
@@ -261,15 +273,15 @@ func masterDeploymentCreator(contextName string, secret *corev1.Secret) reconcil
 	}
 }
 
-func masterServiceCreator(contextName string, secret *corev1.Secret) reconciling.NamedServiceCreatorGetter {
-	name := serviceName(contextName)
+func masterServiceCreator(seed *kubermaticv1.Seed, secret *corev1.Secret) reconciling.NamedServiceCreatorGetter {
+	name := serviceName(seed)
 
 	return func() (string, reconciling.ServiceCreator) {
 		return name, func(s *corev1.Service) (*corev1.Service, error) {
 			s.OwnerReferences = ownerReferences(secret)
 			s.Labels = map[string]string{
 				NameLabel:      MasterServiceName,
-				InstanceLabel:  contextName,
+				InstanceLabel:  seed.Name,
 				ManagedByLabel: ControllerName,
 			}
 
@@ -279,7 +291,6 @@ func masterServiceCreator(contextName string, secret *corev1.Secret) reconciling
 					Port: KubectlProxyPort,
 					TargetPort: intstr.IntOrString{
 						IntVal: KubectlProxyPort,
-						// StrVal: "http",
 					},
 					Protocol: corev1.ProtocolTCP,
 				},
@@ -287,7 +298,7 @@ func masterServiceCreator(contextName string, secret *corev1.Secret) reconciling
 
 			s.Spec.Selector = map[string]string{
 				NameLabel:     MasterServiceName,
-				InstanceLabel: contextName,
+				InstanceLabel: seed.Name,
 			}
 
 			return s, nil
@@ -309,10 +320,10 @@ func (r *Reconciler) masterGrafanaConfigmapCreator(seeds map[string]*kubermaticv
 			c.Labels = labels()
 			c.Labels[ManagedByLabel] = ControllerName
 
-			for seedName := range seeds {
+			for seedName, seed := range seeds {
 				filename := fmt.Sprintf("prometheus-%s.yaml", seedName)
 
-				config, err := buildGrafanaDatasource(seedName)
+				config, err := buildGrafanaDatasource(seed)
 				if err != nil {
 					return nil, fmt.Errorf("failed to build Grafana config for seed %s: %v", seedName, err)
 				}
@@ -325,11 +336,11 @@ func (r *Reconciler) masterGrafanaConfigmapCreator(seeds map[string]*kubermaticv
 	}
 }
 
-func buildGrafanaDatasource(seedName string) (string, error) {
+func buildGrafanaDatasource(seed *kubermaticv1.Seed) (string, error) {
 	data := map[string]interface{}{
-		"ContextName":             seedName,
-		"ServiceName":             serviceName(seedName),
-		"ServiceNamespace":        MasterTargetNamespace,
+		"ContextName":             seed.Name,
+		"ServiceName":             serviceName(seed),
+		"ServiceNamespace":        seed.Namespace,
 		"ProxyPort":               KubectlProxyPort,
 		"SeedMonitoringNamespace": SeedMonitoringNamespace,
 		"SeedPrometheusService":   SeedPrometheusService,


### PR DESCRIPTION
**What this PR does / why we need it**:
It's pretty bad for testing Kubermatic when the seed-proxy controller always operates in the same, fixed namespace. This PR changes:

* Master
  * Namespace for all resources is taken from the Seed CR instead of the hardcoded `kubermatic`.
* Seed
  * The ServiceAccount was moved from `kube-system` into the Seed CR's namespace.
  * The RBAC stuff in the `monitoring` namespace is now suffixed with the Seed CR's namespace, so the Role is now named `seed-proxy-kubermatic` for example.

Old resources are automatically removed after their new replacements have been provisioned.

**Does this PR introduce a user-facing change?**:
```release-note
Fix seed-proxy controller not working in namespaces other than `kubermatic`.
```
