### PR TITLE
Do not GC seed-proxy secrets in foreign namespaces

### DIFF
--- a/api/cmd/master-controller-manager/controllers.go
+++ b/api/cmd/master-controller-manager/controllers.go
@@ -58,7 +58,7 @@ func createAllControllers(ctrlCtx *controllerContext) error {
 	if err := seedsync.Add(ctrlCtx.mgr, 1, ctrlCtx.log, ctrlCtx.namespace, ctrlCtx.seedKubeconfigGetter); err != nil {
 		return fmt.Errorf("failed to create seedsync controller: %v", err)
 	}
-	if err := seedproxy.Add(ctrlCtx.mgr, 1, ctrlCtx.log, ctrlCtx.seedsGetter, ctrlCtx.seedKubeconfigGetter); err != nil {
+	if err := seedproxy.Add(ctrlCtx.mgr, 1, ctrlCtx.log, ctrlCtx.namespace, ctrlCtx.seedsGetter, ctrlCtx.seedKubeconfigGetter); err != nil {
 		return fmt.Errorf("failed to create seedproxy controller: %v", err)
 	}
 	return nil

--- a/api/pkg/controller/seed-proxy/controller.go
+++ b/api/pkg/controller/seed-proxy/controller.go
@@ -81,6 +81,7 @@ func Add(
 	mgr manager.Manager,
 	numWorkers int,
 	log *zap.SugaredLogger,
+	namespace string,
 	seedsGetter provider.SeedsGetter,
 	seedKubeconfigGetter provider.SeedKubeconfigGetter,
 ) error {
@@ -90,6 +91,7 @@ func Add(
 		Client:               mgr.GetClient(),
 		recorder:             mgr.GetEventRecorderFor(ControllerName),
 		log:                  log,
+		namespace:            namespace,
 		seedsGetter:          seedsGetter,
 		seedKubeconfigGetter: seedKubeconfigGetter,
 		seedClientGetter:     provider.SeedClientGetterFactory(seedKubeconfigGetter),

--- a/api/pkg/controller/seed-proxy/reconciler.go
+++ b/api/pkg/controller/seed-proxy/reconciler.go
@@ -29,8 +29,9 @@ import (
 type Reconciler struct {
 	ctrlruntimeclient.Client
 
-	ctx context.Context
-	log *zap.SugaredLogger
+	ctx       context.Context
+	log       *zap.SugaredLogger
+	namespace string
 
 	seedsGetter          provider.SeedsGetter
 	seedKubeconfigGetter provider.SeedKubeconfigGetter
@@ -101,6 +102,7 @@ func (r *Reconciler) reconcile(seedName string, log *zap.SugaredLogger) error {
 func (r *Reconciler) garbageCollect(seeds map[string]*kubermaticv1.Seed, log *zap.SugaredLogger) error {
 	list := &corev1.SecretList{}
 	options := &ctrlruntimeclient.ListOptions{
+		Namespace: r.namespace,
 		LabelSelector: labels.SelectorFromSet(labels.Set{
 			ManagedByLabel: ControllerName,
 		}),


### PR DESCRIPTION
**What this PR does / why we need it**:
#4775 forgot to also restrict the GC to a given namespace. With two Kubermatic namespaces in the same cluster, the namespaces were constantly deleting each others' secrets.

**Does this PR introduce a user-facing change?**:
```release-note
NONE
```
