### PR TITLE
Wait until UCCM is up before deploying monitoring resources

### DIFF
--- a/api/pkg/controller/seed-controller-manager/monitoring/monitoring_controller.go
+++ b/api/pkg/controller/seed-controller-manager/monitoring/monitoring_controller.go
@@ -180,7 +180,7 @@ func (r *Reconciler) Reconcile(request reconcile.Request) (reconcile.Result, err
 	}
 
 	// Wait until the UCCM is ready - otherwise we deploy with missing RBAC resources
-	if kubermaticv1.HealthStatusDown == cluster.Status.ExtendedHealth.UserClusterControllerManager {
+	if cluster.Status.ExtendedHealth.UserClusterControllerManager != kubermaticv1.HealthStatusUp {
 		log.Debug("Skipping cluster reconciling because the UserClusterControllerManager is not ready yet")
 		return reconcile.Result{RequeueAfter: healthCheckPeriod}, nil
 	}


### PR DESCRIPTION
**What this PR does / why we need it**:

Currently, we check in the monitoring controller if the UCCM is down and only then skip reconciliation. However we started to initially put everything into the "provisioning" state, which is why it is neither down nor up, which means that we start deploying the monitoring resources before the usercluster is ready and RBAC exists, which makes them start off crashlooping.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Documentation**:
<!-- Add links to the related documentation changes related to this pull request. E.g. the link to the kubermatic/docs pullrequest. -->

**Does this PR introduce a user-facing change?**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If  no release note is required, just write "NONE".
-->
```release-note
none
```
