### PR TITLE
Add TestNodesRemainUntilIClusterResourcesAreGone

### DIFF
--- a/api/pkg/clusterdeletion/deletion_test.go
+++ b/api/pkg/clusterdeletion/deletion_test.go
@@ -2,16 +2,30 @@ package clusterdeletion
 
 import (
 	"context"
+	"fmt"
 	"testing"
+
+	kubermaticapiv1 "github.com/kubermatic/kubermatic/api/pkg/api/v1"
+	kubermaticv1 "github.com/kubermatic/kubermatic/api/pkg/crd/kubermatic/v1"
+	kubermaticlog "github.com/kubermatic/kubermatic/api/pkg/log"
+	clusterv1alpha1 "github.com/kubermatic/machine-controller/pkg/apis/cluster/v1alpha1"
 
 	corev1 "k8s.io/api/core/v1"
 	kerrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/client-go/kubernetes/scheme"
+	controllerruntimeclient "sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 )
+
+func init() {
+	if err := clusterv1alpha1.SchemeBuilder.AddToScheme(scheme.Scheme); err != nil {
+		panic(fmt.Sprintf("failed to add clusterv1alpha1 to scheme: %v", err))
+	}
+}
 
 const testNS = "test-ns"
 
@@ -86,4 +100,89 @@ func TestCleanUpPVUsingWorkloads(t *testing.T) {
 			}
 		})
 	}
+}
+
+func TestNodesRemainUntilInClusterResourcesAreGone(t *testing.T) {
+	const clusterName = "cluster"
+	testCases := []struct {
+		name    string
+		cluster *kubermaticv1.Cluster
+		objects []runtime.Object
+	}{
+		{
+			name:    "Nodes remain because LB finalizer exists",
+			cluster: getClusterWithFinalizer(clusterName, kubermaticapiv1.InClusterLBCleanupFinalizer),
+			objects: []runtime.Object{&corev1.Service{
+				Spec: corev1.ServiceSpec{Type: corev1.ServiceTypeLoadBalancer},
+			}},
+		},
+		{
+			name:    "Nodes remain because PV finalizer exists",
+			cluster: getClusterWithFinalizer(clusterName, kubermaticapiv1.InClusterPVCleanupFinalizer),
+			objects: []runtime.Object{&corev1.PersistentVolume{}},
+		},
+		// https://github.com/kubernetes-sigs/controller-runtime/issues/702
+		//	{
+		//		name:    "Nodes remain because credentialRequests finalizer exists",
+		//		cluster: getClusterWithFinalizer(clusterName, kubermaticapiv1.InClusterCredentialsRequestsCleanupFinalizer),
+		//		objects: []runtime.Object{unstructuredWithAPIVersionAndKind("cloudcredential.openshift.io/v1", "CredentialsRequest")},
+		//	},
+		//	{
+		//		name:    "Nodes remain because imageRegistryConfigs finalizer exists",
+		//		cluster: getClusterWithFinalizer(clusterName, kubermaticapiv1.InClusterImageRegistryConfigCleanupFinalizer),
+		//		objects: []runtime.Object{unstructuredWithAPIVersionAndKind("imageregistry.operator.openshift.io/v1", "Config")},
+		//	},
+	}
+
+	for idx := range testCases {
+		tc := testCases[idx]
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			m := &clusterv1alpha1.Machine{}
+			tc.objects = append(tc.objects, m)
+			userClusterClient := fake.NewFakeClient(tc.objects...)
+			userClusterClientGetter := func() (controllerruntimeclient.Client, error) {
+				return userClusterClient, nil
+			}
+			seedClient := fake.NewFakeClient(tc.cluster)
+
+			deletion := &Deletion{
+				seedClient:              seedClient,
+				userClusterClientGetter: userClusterClientGetter,
+			}
+
+			if err := deletion.CleanupCluster(context.Background(), kubermaticlog.Logger, tc.cluster); err != nil {
+				t.Fatalf("Deletion failed: %v", err)
+			}
+
+			resultingMachines := &clusterv1alpha1.MachineList{}
+			if err := userClusterClient.List(context.Background(), resultingMachines); err != nil {
+				t.Fatalf("failed to list machines: %v", err)
+			}
+			if len(resultingMachines.Items) < 1 {
+				t.Errorf("machines got deleted before in-cluster cleanup was done")
+			}
+		})
+	}
+}
+
+func getClusterWithFinalizer(name string, finalizers ...string) *kubermaticv1.Cluster {
+	return &kubermaticv1.Cluster{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:       name,
+			Finalizers: finalizers,
+		},
+	}
+}
+
+// Short circuit linter, we want to use this once https://github.com/kubernetes-sigs/controller-runtime/issues/702
+// is resolved and we can enable all tests.
+var _ = unstructuredWithAPIVersionAndKind
+
+func unstructuredWithAPIVersionAndKind(apiVersion, kind string) *unstructured.Unstructured {
+	u := &unstructured.Unstructured{}
+	u.SetAPIVersion(apiVersion)
+	u.SetKind(kind)
+	return u
 }


### PR DESCRIPTION
**What this PR does / why we need it**:

Adds a test that verifies that we do not delete nodes before all in-cluster resources are gone, as otherwise we risk getting deadlocked in case a controller that runs inside the cluster is used for cleanup, as its e.G. the case for CSI.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Documentation**:
<!-- Add links to the related documentation changes related to this pull request. E.g. the link to the kubermatic/docs pullrequest. -->

**Does this PR introduce a user-facing change?**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If  no release note is required, just write "NONE".
-->
```release-note
none
```
