### PR TITLE
Sync ssh keys to authorized keys files on nodes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,5 +12,6 @@ api/_build
 api/_cache
 api/cmd/s3-exporter/s3-exporter
 api/cmd/conformance-tests/conformance-tests
+api/cmd/user-ssh-keys-agent/user-ssh-keys-agent
 api/download-gocache
 /reports

--- a/api/Gopkg.lock
+++ b/api/Gopkg.lock
@@ -289,12 +289,12 @@
   version = "v4.1.0"
 
 [[projects]]
-  digest = "1:1b91ae0dc69a41d4c2ed23ea5cffb721ea63f5037ca4b81e6d6771fbb8f45129"
+  branch = "master"
+  digest = "1:0914bf7efc3e3052163e92b859a89f3b407ad353d7c3b7f59a1bbb4fd05bb25d"
   name = "github.com/fsnotify/fsnotify"
   packages = ["."]
   pruneopts = "NUT"
-  revision = "c2828203cd70a50dcccfb2761f8b1f8ceef9a8e9"
-  version = "v1.4.7"
+  revision = "4bf2d1fec78374803a39307bfb8d340688f4f28e"
 
 [[projects]]
   digest = "1:81466b4218bf6adddac2572a30ac733a9255919bc2f470b4827a317bd4ee1756"
@@ -2103,6 +2103,7 @@
     "google.golang.org/api/compute/v1",
     "google.golang.org/api/googleapi",
     "google.golang.org/grpc",
+    "gopkg.in/fsnotify.v1",
     "gopkg.in/square/go-jose.v2",
     "gopkg.in/square/go-jose.v2/jwt",
     "gopkg.in/yaml.v2",

--- a/api/cmd/user-ssh-keys-agent/Dockerfile
+++ b/api/cmd/user-ssh-keys-agent/Dockerfile
@@ -1,0 +1,5 @@
+FROM alpine:3.10
+
+COPY ./user-ssh-keys-agent /usr/local/bin/user-ssh-keys-agent
+
+ENTRYPOINT ["/usr/local/bin/user-ssh-keys-agent"]

--- a/api/cmd/user-ssh-keys-agent/Makefile
+++ b/api/cmd/user-ssh-keys-agent/Makefile
@@ -1,0 +1,7 @@
+build:
+	CGO_ENABLED=0 go build -o user-ssh-keys-agent
+
+docker: build
+	docker build -t quay.io/kubermatic/user-ssh-keys-agent:$(TAG) .
+
+.PHONY: build docker

--- a/api/cmd/user-ssh-keys-agent/main.go
+++ b/api/cmd/user-ssh-keys-agent/main.go
@@ -1,0 +1,151 @@
+package main
+
+import (
+	"context"
+	"flag"
+	"fmt"
+	"os"
+	"syscall"
+
+	"github.com/go-logr/zapr"
+
+	"go.uber.org/zap"
+
+	usersshkeys "github.com/kubermatic/kubermatic/api/pkg/controller/usersshkeysagent"
+	kubermaticlog "github.com/kubermatic/kubermatic/api/pkg/log"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"sigs.k8s.io/controller-runtime/pkg/client/config"
+	ctrlruntimelog "sigs.k8s.io/controller-runtime/pkg/log"
+	"sigs.k8s.io/controller-runtime/pkg/manager"
+)
+
+type controllerRunOptions struct {
+	log kubermaticlog.Options
+}
+
+func main() {
+	runOp := controllerRunOptions{}
+	flag.BoolVar(&runOp.log.Debug, "log-debug", false, "Enables debug logging")
+	flag.StringVar(&runOp.log.Format, "log-format", string(kubermaticlog.FormatJSON), "Log format. Available are: "+kubermaticlog.AvailableFormats.String())
+
+	flag.Parse()
+
+	if err := runOp.log.Validate(); err != nil {
+		fmt.Printf("error occurred while validating zap logger options: %v\n", err)
+		os.Exit(1)
+	}
+
+	rawLog := kubermaticlog.New(runOp.log.Debug, kubermaticlog.Format(runOp.log.Format))
+	log := rawLog.Sugar()
+
+	cfg, err := config.GetConfig()
+	if err != nil {
+		log.Fatalw("Failed getting user cluster controller config", zap.Error(err))
+	}
+
+	ctx, ctxDone := context.WithCancel(context.Background())
+	defer ctxDone()
+
+	// Create Context
+	done := ctx.Done()
+	ctrlruntimelog.Log = ctrlruntimelog.NewDelegatingLogger(zapr.NewLogger(rawLog).WithName("controller_runtime"))
+
+	mgr, err := manager.New(cfg, manager.Options{Namespace: metav1.NamespaceSystem})
+	if err != nil {
+		log.Fatalw("Failed creating user ssh key controller", zap.Error(err))
+	}
+
+	paths, err := availableUsersPaths()
+	if err != nil {
+		log.Fatalw("Failed to get users directories", zap.Error(err))
+	}
+	if err := usersshkeys.Add(mgr, log, paths); err != nil {
+		log.Fatalw("Failed registering user ssh key controller", zap.Error(err))
+	}
+
+	if err := mgr.Start(done); err != nil {
+		log.Fatalw("error occurred while running the controller manager", zap.Error(err))
+	}
+}
+
+func availableUsersPaths() ([]string, error) {
+	var paths []string
+	for _, user := range []string{"root", "core", "ubuntu", "centos"} {
+		path := fmt.Sprintf("/%v", user)
+		if user != "root" {
+			path = fmt.Sprintf("/home%v", path)
+		}
+		fileInfo, err := os.Stat(path)
+		if err != nil {
+			if os.IsNotExist(err) {
+				continue
+			}
+
+			return nil, fmt.Errorf("failed describing file info: %v", err)
+		}
+
+		uid := fileInfo.Sys().(*syscall.Stat_t).Uid
+		gid := fileInfo.Sys().(*syscall.Stat_t).Gid
+
+		sshPath := fmt.Sprintf("%v/.ssh", path)
+		if err := createDirIfNotExist(sshPath, int(uid), int(gid)); err != nil {
+			return nil, err
+		}
+
+		authorizedKeysPath := fmt.Sprintf("%v/authorized_keys", sshPath)
+		if err := createFileIfNotExist(authorizedKeysPath, int(uid), int(gid)); err != nil {
+			return nil, err
+		}
+
+		paths = append(paths, authorizedKeysPath)
+	}
+
+	return paths, nil
+}
+
+func createDirIfNotExist(path string, uid, gid int) error {
+	_, err := os.Stat(path)
+	if err == nil {
+		return nil
+	}
+
+	if !os.IsNotExist(err) {
+		return fmt.Errorf("failed describing file info: %v", err)
+	}
+
+	if err := os.Mkdir(path, 0700); err != nil {
+		return fmt.Errorf("failed creating .ssh dir in %s: %v", path, err)
+	}
+
+	if err := os.Chown(path, uid, gid); err != nil {
+		return fmt.Errorf("failed changing the numeric uid and gid of %s: %v", path, err)
+	}
+
+	return nil
+}
+
+func createFileIfNotExist(path string, uid, gid int) error {
+	_, err := os.Stat(path)
+	if err == nil {
+		return nil
+	}
+
+	if !os.IsNotExist(err) {
+		return fmt.Errorf("failed describing file info: %v", err)
+	}
+
+	if _, err := os.Create(path); err != nil {
+		return fmt.Errorf("failed creating authorized_keys file in %s: %v", path, err)
+	}
+
+	if err := os.Chmod(path, os.FileMode(0600)); err != nil {
+		return fmt.Errorf("failed changing file mode for authorized_keys file in %s: %v", path, err)
+	}
+
+	if err := os.Chown(path, uid, gid); err != nil {
+		return fmt.Errorf("failed changing the numeric uid and gid of %s: %v", path, err)
+	}
+
+	return nil
+}

--- a/api/hack/ci/ci-run-minimal-conformance-tests.sh
+++ b/api/hack/ci/ci-run-minimal-conformance-tests.sh
@@ -187,6 +187,13 @@ EOF
       make build
       time retry 5 buildah build-using-dockerfile --squash -t "registry.registry.svc.cluster.local:5000/kubermatic/kubeletdnat-controller:$current_git_hash ."
     )
+    (
+      echodate "Building user-ssh-keys-agent image"
+      TEST_NAME="Build user-ssh-keys-agent Docker image"
+      cd api/cmd/user-ssh-keys-agent
+      make build
+      time retry 5 buildah build-using-dockerfile --squash -t "quay.io/kubermatic/user-ssh-keys-agent:$current_git_hash ."
+    )
     echodate "Pushing docker image"
     TEST_NAME="Push Kubermatic Docker image"
     time retry 5 buildah push "registry.registry.svc.cluster.local:5000/kubermatic/api:$current_git_hash"
@@ -199,6 +206,10 @@ EOF
     TEST_NAME="Push dnatcontroller Docker image"
     echodate "Pushing dnatcontroller image"
     time retry 5 buildah push "registry.registry.svc.cluster.local:5000/kubermatic/kubeletdnat-controller:$current_git_hash"
+    TEST_NAME="Push user-ssh-keys-agent Docker image"
+    echodate "Pushing user-ssh-keys-agent image"
+    retry 5 buildah login -u "$QUAY_IO_USERNAME" -p "$QUAY_IO_PASSWORD" quay.io
+    time retry 5 buildah push "quay.io/kubermatic/user-ssh-keys-agent:$current_git_hash"
     echodate "Finished building and pushing docker images"
   else
     echodate "Omitting building of binaries and docker image, as tag $current_git_hash already exists in local registry"

--- a/api/hack/push_image.sh
+++ b/api/hack/push_image.sh
@@ -19,6 +19,7 @@ cd cmd/nodeport-proxy && export TAG=${1} && make docker && unset TAG && cd -
 cd cmd/kubeletdnat-controller && export TAG=${1} && make docker && unset TAG && cd -
 docker build -t "quay.io/kubermatic/addons:${1}" ../addons
 docker build -t "quay.io/kubermatic/openshift-addons:${1}" ../openshift_addons
+cd cmd/user-ssh-keys-agent && export TAG=${1} && make docker && unset TAG && cd -
 
 for TAG in "$@"
 do
@@ -32,10 +33,12 @@ do
     docker tag quay.io/kubermatic/kubeletdnat-controller:${1}  quay.io/kubermatic/kubeletdnat-controller:${TAG}
     docker tag quay.io/kubermatic/addons:${1} quay.io/kubermatic/addons:${TAG}
     docker tag quay.io/kubermatic/openshift-addons:${1} quay.io/kubermatic/openshift-addons:${TAG}
+    docker tag quay.io/kubermatic/user-ssh-keys-agent:${1} quay.io/kubermatic/user-ssh-keys-agent:${TAG}
 
     docker push quay.io/kubermatic/api:${TAG}
     docker push quay.io/kubermatic/nodeport-proxy:${TAG}
     docker push quay.io/kubermatic/kubeletdnat-controller:${TAG}
     docker push quay.io/kubermatic/addons:${TAG}
     docker push quay.io/kubermatic/openshift-addons:${TAG}
+    docker push quay.io/kubermatic/user-ssh-keys-agent:${TAG}
 done

--- a/api/pkg/controller/user-cluster-controller-manager/resources/reconciler.go
+++ b/api/pkg/controller/user-cluster-controller-manager/resources/reconciler.go
@@ -112,6 +112,9 @@ func (r *reconciler) reconcile(ctx context.Context) error {
 	if err := r.reconcileSecrets(ctx, data); err != nil {
 		return err
 	}
+	if err := r.reconcileDaemonSet(ctx); err != nil {
+		return err
+	}
 
 	return nil
 }
@@ -140,6 +143,7 @@ func (r *reconciler) ensureAPIServices(ctx context.Context, data reconcileData) 
 func (r *reconciler) reconcileServiceAcconts(ctx context.Context) error {
 	creators := []reconciling.NamedServiceAccountCreatorGetter{
 		userauth.ServiceAccountCreator(),
+		usersshkeys.ServiceAccountCreator(),
 	}
 
 	if r.openshift {
@@ -168,6 +172,7 @@ func (r *reconciler) reconcileRoles(ctx context.Context) error {
 	creators := []reconciling.NamedRoleCreatorGetter{
 		machinecontroller.KubeSystemRoleCreator(),
 		clusterautoscaler.KubeSystemRoleCreator(),
+		usersshkeys.RoleCreator(),
 	}
 
 	if err := reconciling.ReconcileRoles(ctx, creators, metav1.NamespaceSystem, r.Client); err != nil {
@@ -234,6 +239,7 @@ func (r *reconciler) reconcileRoleBindings(ctx context.Context) error {
 		scheduler.RoleBindingAuthDelegator(),
 		controllermanager.RoleBindingAuthDelegator(),
 		clusterautoscaler.KubeSystemRoleBindingCreator(),
+		usersshkeys.RoleBindingCreator(),
 	}
 	if err := reconciling.ReconcileRoleBindings(ctx, creators, metav1.NamespaceSystem, r.Client); err != nil {
 		return fmt.Errorf("failed to reconcile RoleBindings in kube-system Namespace: %v", err)
@@ -445,6 +451,18 @@ func (r *reconciler) reconcileSecrets(ctx context.Context, data reconcileData) e
 		if err := reconciling.ReconcileSecrets(ctx, creators, openshiftresources.RegistryNamespaceName, r.Client); err != nil {
 			return fmt.Errorf("failed to create secrets in %q namespace: %v", openshiftresources.RegistryNamespaceName, err)
 		}
+	}
+
+	return nil
+}
+
+func (r *reconciler) reconcileDaemonSet(ctx context.Context) error {
+	dsCreators := []reconciling.NamedDaemonSetCreatorGetter{
+		usersshkeys.DaemonSetCreator(),
+	}
+
+	if err := reconciling.ReconcileDaemonSets(ctx, dsCreators, metav1.NamespaceSystem, r.Client); err != nil {
+		return fmt.Errorf("failed to reconcile the DaemonSet: %v", err)
 	}
 
 	return nil

--- a/api/pkg/controller/user-cluster-controller-manager/resources/resources/usersshkeys/daemonset.go
+++ b/api/pkg/controller/user-cluster-controller-manager/resources/resources/usersshkeys/daemonset.go
@@ -1,0 +1,82 @@
+package usersshkeys
+
+import (
+	"fmt"
+
+	"github.com/kubermatic/kubermatic/api/pkg/resources"
+	"github.com/kubermatic/kubermatic/api/pkg/resources/reconciling"
+
+	appsv1 "k8s.io/api/apps/v1"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/util/intstr"
+)
+
+const (
+	daemonSetName = "user-ssh-keys-agent"
+)
+
+var (
+	daemonSetMaxUnavailable = intstr.FromInt(1)
+	hostPathType            = corev1.HostPathDirectoryOrCreate
+)
+
+func DaemonSetCreator() reconciling.NamedDaemonSetCreatorGetter {
+	return func() (string, reconciling.DaemonSetCreator) {
+		return daemonSetName, func(ds *appsv1.DaemonSet) (*appsv1.DaemonSet, error) {
+			ds.Spec.UpdateStrategy = appsv1.DaemonSetUpdateStrategy{
+				Type: appsv1.RollingUpdateDaemonSetStrategyType,
+				RollingUpdate: &appsv1.RollingUpdateDaemonSet{
+					MaxUnavailable: &daemonSetMaxUnavailable,
+				},
+			}
+			labels := map[string]string{"app": "user-ssh-keys-agent"}
+			ds.Spec.Selector = &metav1.LabelSelector{MatchLabels: labels}
+			ds.Spec.Template.ObjectMeta.Labels = labels
+
+			ds.Spec.Template.Spec.ServiceAccountName = serviceAccountName
+
+			ds.Spec.Template.Spec.Containers = []corev1.Container{
+				{
+					Name:            daemonSetName,
+					ImagePullPolicy: corev1.PullAlways,
+					Image:           fmt.Sprintf("quay.io/kubermatic/user-ssh-keys-agent:%s", resources.KUBERMATICCOMMIT),
+					Command:         []string{fmt.Sprintf("/usr/local/bin/%v", daemonSetName)},
+					VolumeMounts: []corev1.VolumeMount{
+						{
+							Name:      "root",
+							MountPath: "/root",
+						},
+						{
+							Name:      "home",
+							MountPath: "/home",
+						},
+					},
+				},
+			}
+
+			ds.Spec.Template.Spec.Volumes = []corev1.Volume{
+				{
+					Name: "root",
+					VolumeSource: corev1.VolumeSource{
+						HostPath: &corev1.HostPathVolumeSource{
+							Path: "/root",
+							Type: &hostPathType,
+						},
+					},
+				},
+				{
+					Name: "home",
+					VolumeSource: corev1.VolumeSource{
+						HostPath: &corev1.HostPathVolumeSource{
+							Path: "/home",
+							Type: &hostPathType,
+						},
+					},
+				},
+			}
+
+			return ds, nil
+		}
+	}
+}

--- a/api/pkg/controller/user-cluster-controller-manager/resources/resources/usersshkeys/serviceaccount.go
+++ b/api/pkg/controller/user-cluster-controller-manager/resources/resources/usersshkeys/serviceaccount.go
@@ -1,0 +1,61 @@
+package usersshkeys
+
+import (
+	"github.com/kubermatic/kubermatic/api/pkg/resources/reconciling"
+
+	corev1 "k8s.io/api/core/v1"
+	rbacv1 "k8s.io/api/rbac/v1"
+)
+
+const (
+	serviceAccountName = "user-ssh-keys-agent"
+	roleName           = "user-ssh-keys-agent"
+	roleBindingName    = "user-ssh-keys-agent"
+)
+
+func ServiceAccountCreator() reconciling.NamedServiceAccountCreatorGetter {
+	return func() (string, reconciling.ServiceAccountCreator) {
+		return serviceAccountName, func(sa *corev1.ServiceAccount) (*corev1.ServiceAccount, error) {
+			return sa, nil
+		}
+	}
+}
+
+func RoleCreator() reconciling.NamedRoleCreatorGetter {
+	return func() (string, reconciling.RoleCreator) {
+		return roleName,
+			func(r *rbacv1.Role) (*rbacv1.Role, error) {
+				r.Rules = []rbacv1.PolicyRule{
+					{
+						APIGroups: []string{""},
+						Resources: []string{"secrets"},
+						Verbs: []string{
+							"get",
+							"list",
+							"watch",
+						},
+					},
+				}
+				return r, nil
+			}
+	}
+}
+
+func RoleBindingCreator() reconciling.NamedRoleBindingCreatorGetter {
+	return func() (string, reconciling.RoleBindingCreator) {
+		return roleBindingName, func(rb *rbacv1.RoleBinding) (*rbacv1.RoleBinding, error) {
+			rb.RoleRef = rbacv1.RoleRef{
+				Name:     roleName,
+				Kind:     "Role",
+				APIGroup: rbacv1.GroupName,
+			}
+			rb.Subjects = []rbacv1.Subject{
+				{
+					Name: serviceAccountName,
+					Kind: rbacv1.ServiceAccountKind,
+				},
+			}
+			return rb, nil
+		}
+	}
+}

--- a/api/pkg/controller/usersshkeysagent/usersshkeys_controller.go
+++ b/api/pkg/controller/usersshkeysagent/usersshkeys_controller.go
@@ -1,0 +1,242 @@
+package usersshkeysagent
+
+import (
+	"bytes"
+	"context"
+	"fmt"
+	"io/ioutil"
+	"os"
+	"sort"
+	"strings"
+	"syscall"
+
+	"gopkg.in/fsnotify.v1"
+
+	"go.uber.org/zap"
+
+	predicateutil "github.com/kubermatic/kubermatic/api/pkg/controller/util/predicate"
+	"github.com/kubermatic/kubermatic/api/pkg/resources"
+
+	ctrlruntimeclient "sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/controller"
+	"sigs.k8s.io/controller-runtime/pkg/event"
+	"sigs.k8s.io/controller-runtime/pkg/handler"
+	"sigs.k8s.io/controller-runtime/pkg/manager"
+	"sigs.k8s.io/controller-runtime/pkg/reconcile"
+	"sigs.k8s.io/controller-runtime/pkg/source"
+
+	corev1 "k8s.io/api/core/v1"
+	kubeapierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+)
+
+const (
+	operatorName = "usersshkeys-controller"
+)
+
+type Reconciler struct {
+	ctrlruntimeclient.Client
+	log                *zap.SugaredLogger
+	authorizedKeysPath []string
+	events             chan event.GenericEvent
+}
+
+func Add(
+	mgr manager.Manager,
+	log *zap.SugaredLogger,
+	authorizedKeysPaths []string) error {
+	reconciler := &Reconciler{
+		Client:             mgr.GetClient(),
+		log:                log,
+		authorizedKeysPath: authorizedKeysPaths,
+		events:             make(chan event.GenericEvent),
+	}
+
+	c, err := controller.New(operatorName, mgr, controller.Options{Reconciler: reconciler})
+	if err != nil {
+		return fmt.Errorf("failed creating a new runtime controller: %v", err)
+	}
+
+	namePredicate := predicateutil.ByName(resources.UserSSHKeys)
+	namespacePredicate := predicateutil.ByNamespace(metav1.NamespaceSystem)
+	if err := c.Watch(&source.Kind{Type: &corev1.Secret{}}, &handler.EnqueueRequestForObject{}, namePredicate, namespacePredicate); err != nil {
+		return fmt.Errorf("failed to create watcher for secrets: %v", err)
+	}
+
+	if err := reconciler.watchAuthorizedKeys(context.TODO(), authorizedKeysPaths); err != nil {
+		return fmt.Errorf("failed to watch authorized_keys files: %v", err)
+	}
+
+	userSSHKeySecret := newEventHandler(func(a handler.MapObject) []reconcile.Request {
+		return []reconcile.Request{
+			{
+				NamespacedName: types.NamespacedName{
+					Namespace: metav1.NamespaceSystem,
+					Name:      resources.UserSSHKeys,
+				},
+			},
+		}
+	})
+
+	if err := c.Watch(&source.Channel{Source: reconciler.events}, userSSHKeySecret); err != nil {
+		return fmt.Errorf("failed to create watch for channelSource: %v", err)
+	}
+
+	return nil
+}
+
+func (r *Reconciler) Reconcile(request reconcile.Request) (reconcile.Result, error) {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	r.log.Debug("Processing")
+
+	secret, err := r.fetchUserSSHKeySecret(ctx, request.NamespacedName.Namespace)
+	if err != nil || secret == nil {
+		return reconcile.Result{}, fmt.Errorf("failed to fetch user ssh keys: %v", err)
+	}
+
+	if err := r.updateAuthorizedKeys(secret.Data); err != nil {
+		r.log.Errorw("Failed reconciling user ssh key secret", zap.Error(err))
+		return reconcile.Result{}, fmt.Errorf("failed to reconcile user ssh keys: %v", err)
+	}
+
+	return reconcile.Result{}, nil
+}
+
+func (r *Reconciler) watchAuthorizedKeys(ctx context.Context, paths []string) error {
+	watcher, err := fsnotify.NewWatcher()
+	if err != nil {
+		return fmt.Errorf("failed creating a new file watcher: %v", err)
+	}
+
+	go func() {
+		for {
+			select {
+			case e, ok := <-watcher.Events:
+				if !ok {
+					return
+				}
+				if e.Op&fsnotify.Write == fsnotify.Write {
+					r.events <- event.GenericEvent{}
+				}
+			case err, ok := <-watcher.Errors:
+				if !ok {
+					return
+				}
+				r.log.Errorw("Error occurred during watching authorized_keys file", zap.Error(err))
+				r.events <- event.GenericEvent{}
+			}
+		}
+	}()
+
+	for _, path := range paths {
+		if err := watcher.Add(path); err != nil {
+			return fmt.Errorf("failed adding a new path to the files watcher: %v", err)
+		}
+	}
+
+	return nil
+}
+
+func (r *Reconciler) fetchUserSSHKeySecret(ctx context.Context, namespace string) (*corev1.Secret, error) {
+	secret := &corev1.Secret{}
+	if err := r.Get(ctx, ctrlruntimeclient.ObjectKey{Name: resources.UserSSHKeys, Namespace: namespace}, secret); err != nil {
+		if kubeapierrors.IsNotFound(err) {
+			r.log.Debugw("Secret is not found", "secret", secret.Name)
+			return nil, nil
+		}
+		r.log.Errorw("Cannot get secret", "secret", resources.UserSSHKeys)
+		return nil, err
+	}
+
+	return secret, nil
+}
+
+func (r *Reconciler) updateAuthorizedKeys(sshKeys map[string][]byte) error {
+	expectedUserSSHKeys, err := createBuffer(sshKeys)
+	if err != nil {
+		return fmt.Errorf("failed creating user ssh keys buffer: %v", err)
+	}
+
+	for _, path := range r.authorizedKeysPath {
+		if err := updateOwnAndPermissions(path); err != nil {
+			return fmt.Errorf("failed updating permissions %s: %v", path, err)
+		}
+
+		actualUserSSHKeys, err := ioutil.ReadFile(path)
+		if err != nil {
+			return fmt.Errorf("failed reading file in path %s: %v", path, err)
+		}
+
+		if !bytes.Equal(actualUserSSHKeys, expectedUserSSHKeys.Bytes()) {
+			if err := ioutil.WriteFile(path, expectedUserSSHKeys.Bytes(), 0600); err != nil {
+				return fmt.Errorf("failed to overwrite file in path %s: %v", path, err)
+			}
+			r.log.Infow("File has been updated successfully", "file", path)
+		}
+	}
+
+	return nil
+}
+
+// newEventHandler takes a obj->request mapper function and wraps it into an
+// handler.EnqueueRequestsFromMapFunc.
+func newEventHandler(rf handler.ToRequestsFunc) *handler.EnqueueRequestsFromMapFunc {
+	return &handler.EnqueueRequestsFromMapFunc{
+		ToRequests: rf,
+	}
+}
+
+func createBuffer(data map[string][]byte) (*bytes.Buffer, error) {
+	var (
+		keys   = make([]string, 0, len(data))
+		buffer = &bytes.Buffer{}
+	)
+
+	for key := range data {
+		keys = append(keys, key)
+	}
+
+	sort.Strings(keys)
+
+	for k := range keys {
+		key := keys[k]
+		data[key] = append(data[key], []byte("\n")...)
+		if _, err := buffer.Write(data[key]); err != nil {
+			return nil, fmt.Errorf("failed writing user ssh keys to buffer: %v", err)
+		}
+	}
+
+	return buffer, nil
+}
+
+func updateOwnAndPermissions(path string) error {
+	sshPath := strings.TrimSuffix(path, "/authorized_keys")
+	if err := os.Chmod(sshPath, os.FileMode(0700)); err != nil {
+		return fmt.Errorf("failed to change permission on file: %v", err)
+	}
+
+	if err := os.Chmod(path, os.FileMode(0600)); err != nil {
+		return fmt.Errorf("failed to change permission on file: %v", err)
+	}
+
+	userHome := strings.TrimSuffix(sshPath, "/.ssh")
+	fileInfo, err := os.Stat(userHome)
+	if err != nil {
+		return fmt.Errorf("faild describing the authorized_keys file in path %s: %v", userHome, err)
+	}
+
+	uid := fileInfo.Sys().(*syscall.Stat_t).Uid
+	gid := fileInfo.Sys().(*syscall.Stat_t).Gid
+
+	if err := os.Chown(path, int(uid), int(gid)); err != nil {
+		return fmt.Errorf("failed changing the numeric uid and gid of %s: %v", path, err)
+	}
+
+	if err := os.Chown(sshPath, int(uid), int(gid)); err != nil {
+		return fmt.Errorf("failed changing the numeric uid and gid of %s: %v", sshPath, err)
+	}
+
+	return nil
+}

--- a/api/pkg/controller/usersshkeysagent/usersshkeys_controller_test.go
+++ b/api/pkg/controller/usersshkeysagent/usersshkeys_controller_test.go
@@ -1,0 +1,165 @@
+package usersshkeysagent
+
+import (
+	"fmt"
+	"io/ioutil"
+	"os"
+	"strings"
+	"testing"
+
+	kubermaticlog "github.com/kubermatic/kubermatic/api/pkg/log"
+	"github.com/kubermatic/kubermatic/api/pkg/resources"
+
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+	"sigs.k8s.io/controller-runtime/pkg/reconcile"
+
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+)
+
+func TestReconcileUserSSHKeys(t *testing.T) {
+	sshPath := fmt.Sprintf("%v%v", os.TempDir(), ".ssh")
+	if err := os.Mkdir(sshPath, 0700); err != nil {
+		t.Fatalf("error while creating .ssh dir: %v", err)
+	}
+
+	defer func() {
+		if err := cleanupFiles([]string{sshPath}); err != nil {
+			t.Fatalf("failed to cleanup test files: %v", err)
+		}
+	}()
+
+	authorizedKeysPath := fmt.Sprintf("%v/%v", sshPath, "authorized_keys")
+	_, err := os.Create(authorizedKeysPath)
+	if err != nil {
+		t.Fatalf("error while creating authorized_keys file: %v", err)
+	}
+
+	if err := os.Chmod(authorizedKeysPath, os.FileMode(0600)); err != nil {
+		t.Fatalf("error while changing file mode: %v", err)
+	}
+
+	testCases := []struct {
+		name             string
+		reconciler       Reconciler
+		modifier         func(string, string) error
+		sshDirPath       string
+		expectedSSHKey   string
+		expectedFileMode int16
+		expectedDirMode  int16
+	}{
+		{
+			name: "Test updating authorized_keys file from reconcile",
+			reconciler: Reconciler{
+				log: kubermaticlog.New(true, kubermaticlog.FormatConsole).Sugar(),
+				authorizedKeysPath: []string{
+					authorizedKeysPath,
+				},
+			},
+			expectedSSHKey: "ssh-rsa test_user_ssh_key\nssh-rsa test_user_ssh_key_2",
+		},
+		{
+			name: "Test ssh dir file mode",
+			reconciler: Reconciler{
+				log: kubermaticlog.New(true, kubermaticlog.FormatConsole).Sugar(),
+				authorizedKeysPath: []string{
+					authorizedKeysPath,
+				},
+			},
+			modifier:         changeFileModes,
+			expectedSSHKey:   "ssh-rsa test_user_ssh_key\nssh-rsa test_user_ssh_key_2",
+			sshDirPath:       sshPath,
+			expectedFileMode: 384,
+			expectedDirMode:  448,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			tc.reconciler.Client = fake.NewFakeClient(
+				&corev1.Secret{
+					ObjectMeta: metav1.ObjectMeta{
+						ResourceVersion: "123456",
+						Name:            resources.UserSSHKeys,
+						Namespace:       metav1.NamespaceSystem,
+					},
+					Data: map[string][]byte{
+						"key-test":   []byte("ssh-rsa test_user_ssh_key"),
+						"key-test-2": []byte("ssh-rsa test_user_ssh_key_2"),
+					},
+				})
+
+			if tc.modifier != nil {
+				if err := tc.modifier(sshPath, authorizedKeysPath); err != nil {
+					t.Fatalf("error while executing test modifier: %v", err)
+				}
+			}
+
+			if _, err := tc.reconciler.Reconcile(reconcile.Request{
+				NamespacedName: types.NamespacedName{Name: resources.UserSSHKeys, Namespace: metav1.NamespaceSystem}}); err != nil {
+				t.Fatalf("failed to run reconcile: %v", err)
+			}
+
+			for _, path := range tc.reconciler.authorizedKeysPath {
+				key, err := readAuthorizedKeysFile(path)
+				if err != nil {
+					t.Fatal(err)
+				}
+
+				if key != tc.expectedSSHKey {
+					t.Fatal("usersshkey secret and authorized_keys file don't match")
+				}
+
+				if tc.modifier != nil {
+					authorizedKeysInfo, err := os.Stat(path)
+					if err != nil {
+						t.Fatalf("failed describing file %s: %v", path, err)
+					}
+
+					if int16(authorizedKeysInfo.Mode()) != tc.expectedFileMode {
+						t.Fatal("authorized_keys file mode and its expected file mode don't match")
+					}
+
+					sshDirInfo, err := os.Stat(tc.sshDirPath)
+					if err != nil {
+						t.Fatalf("failed describing file %s: %v", path, err)
+					}
+
+					if int16(sshDirInfo.Mode()) != tc.expectedDirMode {
+						t.Fatal(".ssh dir mode and its expected file mode don't match")
+					}
+
+				}
+			}
+		})
+	}
+}
+
+func readAuthorizedKeysFile(path string) (string, error) {
+	data, err := ioutil.ReadFile(path)
+	if err != nil {
+		return "", err
+	}
+	return strings.TrimSuffix(string(data), "\n"), nil
+}
+
+func cleanupFiles(tmpFiles []string) error {
+	for _, tmpFile := range tmpFiles {
+		if err := os.RemoveAll(tmpFile); err == nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func changeFileModes(sshDir, authorizedKeysFile string) error {
+	if err := os.Chmod(authorizedKeysFile, 0700); err != nil {
+		return fmt.Errorf("error while changing file mode: %v", err)
+	}
+
+	if err := os.Chmod(sshDir, 0600); err != nil {
+		return fmt.Errorf("error while changing file mode: %v", err)
+	}
+	return nil
+}

--- a/api/vendor/github.com/fsnotify/fsnotify/LICENSE
+++ b/api/vendor/github.com/fsnotify/fsnotify/LICENSE
@@ -1,5 +1,5 @@
 Copyright (c) 2012 The Go Authors. All rights reserved.
-Copyright (c) 2012 fsnotify Authors. All rights reserved.
+Copyright (c) 2012-2019 fsnotify Authors. All rights reserved.
 
 Redistribution and use in source and binary forms, with or without
 modification, are permitted provided that the following conditions are

--- a/api/vendor/github.com/fsnotify/fsnotify/fsnotify.go
+++ b/api/vendor/github.com/fsnotify/fsnotify/fsnotify.go
@@ -63,4 +63,6 @@ func (e Event) String() string {
 }
 
 // Common errors that can be reported by a watcher
-var ErrEventOverflow = errors.New("fsnotify queue overflow")
+var (
+	ErrEventOverflow = errors.New("fsnotify queue overflow")
+)

--- a/api/vendor/github.com/fsnotify/fsnotify/inotify_poller.go
+++ b/api/vendor/github.com/fsnotify/fsnotify/inotify_poller.go
@@ -40,12 +40,12 @@ func newFdPoller(fd int) (*fdPoller, error) {
 	poller.fd = fd
 
 	// Create epoll fd
-	poller.epfd, errno = unix.EpollCreate1(0)
+	poller.epfd, errno = unix.EpollCreate1(unix.EPOLL_CLOEXEC)
 	if poller.epfd == -1 {
 		return nil, errno
 	}
 	// Create pipe; pipe[0] is the read end, pipe[1] the write end.
-	errno = unix.Pipe2(poller.pipe[:], unix.O_NONBLOCK)
+	errno = unix.Pipe2(poller.pipe[:], unix.O_NONBLOCK|unix.O_CLOEXEC)
 	if errno != nil {
 		return nil, errno
 	}

--- a/api/vendor/github.com/fsnotify/fsnotify/open_mode_bsd.go
+++ b/api/vendor/github.com/fsnotify/fsnotify/open_mode_bsd.go
@@ -8,4 +8,4 @@ package fsnotify
 
 import "golang.org/x/sys/unix"
 
-const openMode = unix.O_NONBLOCK | unix.O_RDONLY
+const openMode = unix.O_NONBLOCK | unix.O_RDONLY | unix.O_CLOEXEC

--- a/api/vendor/github.com/fsnotify/fsnotify/open_mode_darwin.go
+++ b/api/vendor/github.com/fsnotify/fsnotify/open_mode_darwin.go
@@ -9,4 +9,4 @@ package fsnotify
 import "golang.org/x/sys/unix"
 
 // note: this constant is not defined on BSD
-const openMode = unix.O_EVTONLY
+const openMode = unix.O_EVTONLY | unix.O_CLOEXEC


### PR DESCRIPTION
**What this PR does / why we need it**:
Adding the daemonset in the usercluster in order to sync the usersshkeys secret with the authorized_keys file on the node.

**Which issue(s) this PR fixes**
Fixes #3573

**Does this PR introduce a user-facing change?**:
No

```release-note
The `authorized_keys` files on nodes are now updated whenever the SSH keys for a cluster are changed
```
