### PR TITLE
Ignore seed validation requests for other namespaces

### DIFF
--- a/api/cmd/master-controller-manager/main.go
+++ b/api/cmd/master-controller-manager/main.go
@@ -198,6 +198,7 @@ func main() {
 		seedValidationWebhookServer, err := runOpts.seedvalidationHook.Server(
 			ctx,
 			log,
+			ctrlCtx.namespace,
 			runOpts.workerName,
 			ctrlCtx.seedsGetter,
 			provider.SeedClientGetterFactory(ctrlCtx.seedKubeconfigGetter),

--- a/api/cmd/seed-controller-manager/main.go
+++ b/api/cmd/seed-controller-manager/main.go
@@ -131,6 +131,7 @@ Please install the VerticalPodAutoscaler according to the documentation: https:/
 		seedValidationWebhookServer, err := options.seedValidationHook.Server(
 			rootCtx,
 			log,
+			options.namespace,
 			options.workerName,
 			// We only have a SeedGetter and not a SeedsGetter, so construct a little
 			// wrapper


### PR DESCRIPTION
**What this PR does / why we need it**:
Seed validation can happen either in the master-controller-manager or the seed-controller-manager, depending on whether or not we're in a master or seed cluster (on shared master/seed clusters, the master-controller-manager has precedence).

* The master-controller has a seedKubeconfigGetter that is capable of working in any namespace, because it takes the namespace and name of the kubeconfig reference to find a Seed's kubeconfig. This is why the master-controller so far did not interfere much with my dummy Seeds I use for testing for operator (these dummy seeds have no Clusters, so maybe that is also helping me a bit).
* The seed-controller however has a special seedKubeconfigGetter that can only return its own Seed. This makes the webhook effectively only able to validate its own seed. For every other seed, even in the same namespace, it will complain about not being able to find the Seed's kubeconfig.

This problem goes away once the Kubermatic Operator replaces the Helm chart, because the Operator will always create Webhooks that are restricted to a given namespace. This is done by labelling the Kubermatic namespace and then using a label selector on the webhook.

To aid me in testing and make the migration easier, we have IMHO two options:

1. Label the Kubermatic namespace. Some controller could do that.
2. Ignore requests for other namespaces inside the seed webhook.

For simplicity sake and because it's only relevant during the migration, I chose option 2.

**Which issue(s) this PR fixes**:
Relates to #4723 

**Does this PR introduce a user-facing change?**:
```release-note
NONE
```
