### PR TITLE
Operator Fixup

### DIFF
--- a/api/Makefile
+++ b/api/Makefile
@@ -7,11 +7,13 @@ TAGS?=$(GITTAG)
 DOCKERTAGS=$(TAGS) latestbuild
 DOCKER_BUILD_FLAG += $(foreach tag, $(DOCKERTAGS), -t $(REPO):$(tag))
 KUBERMATICCOMMIT?=$(shell git log -1 --format=%H)
-DASHBOARDCOMMIT?=NA
+KUBERMATICDOCKERTAG?=$(KUBERMATICCOMMIT)
+UIDOCKERTAG?=NA
 LDFLAGS += -extldflags '-static' \
   -X github.com/kubermatic/kubermatic/api/pkg/resources.KUBERMATICCOMMIT=$(KUBERMATICCOMMIT) \
   -X github.com/kubermatic/kubermatic/api/pkg/resources.KUBERMATICGITTAG=$(GITTAG) \
-  -X github.com/kubermatic/kubermatic/api/pkg/controller/operator/common.UIVERSION=$(DASHBOARDCOMMIT)
+  -X github.com/kubermatic/kubermatic/api/pkg/controller/operator/common.KUBERMATICDOCKERTAG=$(KUBERMATICDOCKERTAG) \
+  -X github.com/kubermatic/kubermatic/api/pkg/controller/operator/common.UIDOCKERTAG=$(UIDOCKERTAG)
 HAS_DEP:= $(shell command -v dep 2> /dev/null)
 HAS_GIT:= $(shell command -v git 2> /dev/null)
 BUILD_DEST?=_build

--- a/api/cmd/kubermatic-operator/main.go
+++ b/api/cmd/kubermatic-operator/main.go
@@ -16,7 +16,6 @@ import (
 	kubermaticlog "github.com/kubermatic/kubermatic/api/pkg/log"
 	"github.com/kubermatic/kubermatic/api/pkg/pprof"
 	"github.com/kubermatic/kubermatic/api/pkg/provider"
-	"github.com/kubermatic/kubermatic/api/pkg/resources"
 	"github.com/kubermatic/kubermatic/api/pkg/signals"
 
 	certmanagerv1alpha2 "github.com/jetstack/cert-manager/pkg/apis/certmanager/v1alpha2"
@@ -69,7 +68,7 @@ func main() {
 		log.Fatal("-namespace is a mandatory flag")
 	}
 
-	log.Infow("Moin, moin, I'm the Kubermatic Operator and these are the versions I work with.", "kubermatic", resources.KUBERMATICCOMMIT, "ui", common.UIVERSION)
+	log.Infow("Moin, moin, I'm the Kubermatic Operator and these are the versions I work with.", "kubermatic", common.KUBERMATICDOCKERTAG, "ui", common.UIDOCKERTAG)
 
 	config, err := clientcmd.BuildConfigFromFlags("", opt.kubeconfig)
 	if err != nil {

--- a/api/cmd/kubermatic-operator/main.go
+++ b/api/cmd/kubermatic-operator/main.go
@@ -8,6 +8,7 @@ import (
 	"github.com/go-logr/zapr"
 	"go.uber.org/zap"
 
+	"github.com/kubermatic/kubermatic/api/pkg/controller/operator/common"
 	masterctrl "github.com/kubermatic/kubermatic/api/pkg/controller/operator/master"
 	seedctrl "github.com/kubermatic/kubermatic/api/pkg/controller/operator/seed"
 	seedcontrollerlifecycle "github.com/kubermatic/kubermatic/api/pkg/controller/seed-controller-lifecycle"
@@ -15,6 +16,7 @@ import (
 	kubermaticlog "github.com/kubermatic/kubermatic/api/pkg/log"
 	"github.com/kubermatic/kubermatic/api/pkg/pprof"
 	"github.com/kubermatic/kubermatic/api/pkg/provider"
+	"github.com/kubermatic/kubermatic/api/pkg/resources"
 	"github.com/kubermatic/kubermatic/api/pkg/signals"
 
 	certmanagerv1alpha2 "github.com/jetstack/cert-manager/pkg/apis/certmanager/v1alpha2"
@@ -66,6 +68,8 @@ func main() {
 	if len(opt.namespace) == 0 {
 		log.Fatal("-namespace is a mandatory flag")
 	}
+
+	log.Infow("Moin, moin, I'm the Kubermatic Operator and these are the versions I work with.", "kubermatic", resources.KUBERMATICCOMMIT, "ui", common.UIVERSION)
 
 	config, err := clientcmd.BuildConfigFromFlags("", opt.kubeconfig)
 	if err != nil {

--- a/api/cmd/seed-controller-manager/options.go
+++ b/api/cmd/seed-controller-manager/options.go
@@ -191,7 +191,7 @@ func (o controllerRunOptions) validate() error {
 	}
 
 	if o.monitoringScrapeAnnotationPrefix == "" {
-		return fmt.Errorf("moniotring-scrape-annotation-prefix is undefined")
+		return fmt.Errorf("monitoring-scrape-annotation-prefix is undefined")
 	}
 
 	if o.apiServerDefaultReplicas < 1 {

--- a/api/hack/ci/ci-push-images.sh
+++ b/api/hack/ci/ci-push-images.sh
@@ -23,7 +23,7 @@ echodate "Successfully logged into Quay"
 KUBERMATICDOCKERTAG="${GIT_HEAD_TAG:-$GIT_HEAD_HASH}"
 UIDOCKERTAG="$KUBERMATICDOCKERTAG"
 
-if [ -z "$GIT_HEAD_HASH" ]; then
+if [ -z "$GIT_HEAD_TAG" ]; then
   UIDOCKERTAG="$(get_latest_dashboard_hash "${PULL_BASE_REF}")"
 else
   if [ -z "$(check_dashboard_tag "$GIT_HEAD_HASH")" ]; then

--- a/api/hack/ci/ci-push-images.sh
+++ b/api/hack/ci/ci-push-images.sh
@@ -21,12 +21,16 @@ echodate "Successfully logged into Quay"
 # use the latest tagged version of the dashboard when we ourselves are a tagged
 # release
 KUBERMATICDOCKERTAG="${GIT_HEAD_TAG:-$GIT_HEAD_HASH}"
-UIDOCKERTAG=""
+UIDOCKERTAG="$KUBERMATICDOCKERTAG"
 
-if [ -z "$GIT_HEAD_TAG" ]; then
+if [ -z "$GIT_HEAD_HASH" ]; then
   UIDOCKERTAG="$(get_latest_dashboard_hash "${PULL_BASE_REF}")"
 else
-  UIDOCKERTAG="$(get_latest_dashboard_tag "${PULL_BASE_REF}")"
+  if [ -z "$(check_dashboard_tag "$GIT_HEAD_HASH")" ]; then
+    echo "Kubermatic was tagged as $GIT_HEAD_HASH, but this tag does not exist for the dashboard."
+    echo "Please release a new version for the dashboard and re-run this job."
+    exit 1
+  fi
 fi
 
 TEST_NAME="Build binaries"

--- a/api/hack/ci/ci-push-images.sh
+++ b/api/hack/ci/ci-push-images.sh
@@ -20,8 +20,8 @@ echodate "Successfully logged into Quay"
 # prepare special variables that will be injected into the Kubermatic Operator;
 # use the latest tagged version of the dashboard when we ourselves are a tagged
 # release
-KUBERMATICDOCKERTAG="${GIT_HEAD_TAG:-$GIT_HEAD_HASH}"
-UIDOCKERTAG="$KUBERMATICDOCKERTAG"
+export KUBERMATICDOCKERTAG="${GIT_HEAD_TAG:-$GIT_HEAD_HASH}"
+export UIDOCKERTAG="$KUBERMATICDOCKERTAG"
 
 if [ -z "$GIT_HEAD_TAG" ]; then
   UIDOCKERTAG="$(get_latest_dashboard_hash "${PULL_BASE_REF}")"

--- a/api/hack/lib.sh
+++ b/api/hack/lib.sh
@@ -94,19 +94,14 @@ get_latest_dashboard_hash() {
   echo "$HASH"
 }
 
-get_latest_dashboard_tag() {
-  local branch="$1"
-  local repository="git@github.com:kubermatic/dashboard-v2.git"
-  local tmpdir=local_dashboard
+check_dashboard_tag() {
+  local TAG="$1"
 
   ensure_github_host_pubkey
   git config --global core.sshCommand 'ssh -o CheckHostIP=no -i /ssh/id_rsa'
-  retry 5 git clone "$repository" -b "$branch" "$tmpdir"
+  local DASHBOARD_URL="git@github.com:kubermatic/dashboard-v2.git"
 
-  # get the latest tag in this branch
-  (cd "$tmpdir" && git describe --tags --abbrev=0)
-
-  rm -rf "$tmpdir"
+  retry 5 git ls-remote "$DASHBOARD_URL" "refs/tags/$TAG"
 }
 
 format_dashboard() {

--- a/api/hack/lib.sh
+++ b/api/hack/lib.sh
@@ -94,6 +94,21 @@ get_latest_dashboard_hash() {
   echo "$HASH"
 }
 
+get_latest_dashboard_tag() {
+  local branch="$1"
+  local repository="git@github.com:kubermatic/dashboard-v2.git"
+  local tmpdir=local_dashboard
+
+  ensure_github_host_pubkey
+  git config --global core.sshCommand 'ssh -o CheckHostIP=no -i /ssh/id_rsa'
+  retry 5 git clone "$repository" -b "$branch" "$tmpdir"
+
+  # get the latest tag in this branch
+  (cd "$tmpdir" && git describe --tags --abbrev=0)
+
+  rm -rf "$tmpdir"
+}
+
 format_dashboard() {
   local filename="$1"
   local tmpfile="$filename.tmp"

--- a/api/hack/run-operator.sh
+++ b/api/hack/run-operator.sh
@@ -1,17 +1,47 @@
 #!/usr/bin/env bash
 
-set -exuo pipefail
+set -euo pipefail
+
+export KUBERMATICDOCKERTAG="${KUBERMATICDOCKERTAG:-}"
+export UIDOCKERTAG="${UIDOCKERTAG:-}"
+export NAMESPACE="${NAMESPACE:-}"
+
+export KUBERMATIC_WORKERNAME=${KUBERMATIC_WORKERNAME:-$(uname -n)}
+KUBERMATIC_WORKERNAME=$(tr -cd '[:alnum:]' <<< $KUBERMATIC_WORKERNAME | tr '[:upper:]' '[:lower:]')
+
+if [ -z "$NAMESPACE" ]; then
+  echo "You must specify a NAMESPACE environment variable to run the operator in."
+  echo "Do not use a namespace where another operator is already running."
+  echo "Example: NAMESPACE=$KUBERMATIC_WORKERNAME ./hack/run-operator.sh"
+  exit 2
+fi
+
+if [ -z "$KUBERMATICDOCKERTAG" ]; then
+  KUBERMATICDOCKERTAG=$(git rev-parse master)
+fi
+
+if [ -z "$UIDOCKERTAG" ]; then
+  echo "Finding latest dashboard master revision..."
+  UIDOCKERTAG=$(git ls-remote git@github.com:kubermatic/dashboard-v2.git refs/heads/master | awk '{print $1}')
+  echo
+fi
+
+echo "Versions"
+echo "--------"
+echo
+echo "  Kubermatic: $KUBERMATICDOCKERTAG (KUBERMATICDOCKERTAG variable)"
+echo "  Dashboard : $UIDOCKERTAG (UIDOCKERTAG variable)"
+echo
 
 cd $(go env GOPATH)/src/github.com/kubermatic/kubermatic/api
 make kubermatic-operator
+echo
 
-KUBERMATIC_WORKERNAME=${KUBERMATIC_WORKERNAME:-$(uname -n)}
-NAMESPACE="${NAMESPACE:-kubermatic}"
-
+set -x
 ./_build/kubermatic-operator \
   -kubeconfig=../../secrets/seed-clusters/dev.kubermatic.io/kubeconfig \
-  -namespace=$NAMESPACE \
-  -worker-name="$(tr -cd '[:alnum:]' <<< $KUBERMATIC_WORKERNAME | tr '[:upper:]' '[:lower:]')" \
+  -namespace="$NAMESPACE" \
+  -worker-name="$KUBERMATIC_WORKERNAME" \
   -log-debug=true \
   -log-format=Console \
   -logtostderr \

--- a/api/pkg/controller/operator/common/resources.go
+++ b/api/pkg/controller/operator/common/resources.go
@@ -33,7 +33,6 @@ const (
 	DockercfgSecretName                   = "dockercfg"
 	DexCASecretName                       = "dex-ca"
 	MasterFilesSecretName                 = "extra-files"
-	SeedAdmissionWebhookName              = "kubermatic.io-seeds"
 	SeedWebhookServingCASecretName        = "seed-webhook-ca"
 	SeedWebhookServingCertSecretName      = "seed-webhook-cert"
 	seedWebhookCommonName                 = "seed-webhook"

--- a/api/pkg/controller/operator/common/versions.go
+++ b/api/pkg/controller/operator/common/versions.go
@@ -1,13 +1,14 @@
 package common
 
-import (
-	"github.com/kubermatic/kubermatic/api/pkg/resources"
-)
-
-// UIVERSION is a magic variable containing the tag / git commit hash
-// of the dashboard-v2 Docker repository to deploy. It gets fed by the
+// UIDOCKERTAG is a magic variable containing the tag / git commit hash
+// of the dashboard-v2 Docker image to deploy. It gets fed by the
 // Makefile as an ldflag.
-var UIVERSION string
+var UIDOCKERTAG string
+
+// KUBERMATICDOCKERTAG is a magic variable containing the tag / git commit hash
+// of the kubermatic Docker image to deploy. It gets fed by the
+// Makefile as an ldflag.
+var KUBERMATICDOCKERTAG string
 
 type Versions struct {
 	Kubermatic string
@@ -16,7 +17,7 @@ type Versions struct {
 
 func NewDefaultVersions() Versions {
 	return Versions{
-		Kubermatic: resources.KUBERMATICCOMMIT,
-		UI:         UIVERSION,
+		Kubermatic: KUBERMATICDOCKERTAG,
+		UI:         UIDOCKERTAG,
 	}
 }

--- a/api/pkg/controller/operator/master/controller.go
+++ b/api/pkg/controller/operator/master/controller.go
@@ -11,9 +11,11 @@ import (
 	operatorv1alpha1 "github.com/kubermatic/kubermatic/api/pkg/crd/operator/v1alpha1"
 
 	certmanagerv1alpha2 "github.com/jetstack/cert-manager/pkg/apis/certmanager/v1alpha2"
+	admissionregistrationv1beta1 "k8s.io/api/admissionregistration/v1beta1"
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
 	extensionsv1beta1 "k8s.io/api/extensions/v1beta1"
+	policyv1beta1 "k8s.io/api/policy/v1beta1"
 	rbacv1 "k8s.io/api/rbac/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
@@ -105,12 +107,14 @@ func Add(
 	typesToWatch := []runtime.Object{
 		&appsv1.Deployment{},
 		&corev1.ConfigMap{},
+		&corev1.Namespace{},
 		&corev1.Secret{},
 		&corev1.Service{},
 		&corev1.ServiceAccount{},
 		&extensionsv1beta1.Ingress{},
-		&rbacv1.ClusterRole{},
 		&rbacv1.ClusterRoleBinding{},
+		&policyv1beta1.PodDisruptionBudget{},
+		&admissionregistrationv1beta1.ValidatingWebhookConfiguration{},
 		&certmanagerv1alpha2.Certificate{},
 	}
 

--- a/api/pkg/controller/operator/master/controller.go
+++ b/api/pkg/controller/operator/master/controller.go
@@ -86,8 +86,9 @@ func Add(
 			return nil
 		}
 
+		// when handling namespaces, it's okay to not find a KubermaticConfiguration
+		// and simply skip reconciling
 		if len(configs.Items) == 0 {
-			log.Warnw("could not find KubermaticConfiguration this object belongs to", "object", a)
 			return nil
 		}
 

--- a/api/pkg/controller/operator/master/resources/kubermatic/api.go
+++ b/api/pkg/controller/operator/master/resources/kubermatic/api.go
@@ -80,9 +80,9 @@ func APIDeploymentCreator(cfg *operatorv1alpha1.KubermaticConfiguration, workerN
 			}
 
 			if cfg.Spec.API.DebugLog {
-				args = append(args, "-v4", "-log-debug=true")
+				args = append(args, "-v=4", "-log-debug=true")
 			} else {
-				args = append(args, "-v2")
+				args = append(args, "-v=2")
 			}
 
 			if cfg.Spec.FeatureGates.Has(features.OIDCKubeCfgEndpoint) {

--- a/api/pkg/controller/operator/master/resources/kubermatic/master-controller-manager.go
+++ b/api/pkg/controller/operator/master/resources/kubermatic/master-controller-manager.go
@@ -68,9 +68,9 @@ func MasterControllerManagerDeploymentCreator(cfg *operatorv1alpha1.KubermaticCo
 			}
 
 			if cfg.Spec.MasterController.DebugLog {
-				args = append(args, "-v4", "-log-debug=true")
+				args = append(args, "-v=4", "-log-debug=true")
 			} else {
-				args = append(args, "-v2")
+				args = append(args, "-v=2")
 			}
 
 			if workerName != "" {

--- a/api/pkg/controller/operator/seed/controller.go
+++ b/api/pkg/controller/operator/seed/controller.go
@@ -16,6 +16,7 @@ import (
 	admissionregistrationv1beta1 "k8s.io/api/admissionregistration/v1beta1"
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
+	policyv1beta1 "k8s.io/api/policy/v1beta1"
 	rbacv1 "k8s.io/api/rbac/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
@@ -134,6 +135,7 @@ func createSeedWatches(controller controller.Controller, seedName string, seedMa
 		&corev1.Service{},
 		&corev1.ServiceAccount{},
 		&rbacv1.ClusterRoleBinding{},
+		&policyv1beta1.PodDisruptionBudget{},
 		&admissionregistrationv1beta1.ValidatingWebhookConfiguration{},
 		&kubermaticv1.Seed{},
 	}

--- a/api/pkg/controller/operator/seed/controller.go
+++ b/api/pkg/controller/operator/seed/controller.go
@@ -13,6 +13,7 @@ import (
 	operatorv1alpha1 "github.com/kubermatic/kubermatic/api/pkg/crd/operator/v1alpha1"
 	"github.com/kubermatic/kubermatic/api/pkg/provider"
 
+	admissionregistrationv1beta1 "k8s.io/api/admissionregistration/v1beta1"
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
 	rbacv1 "k8s.io/api/rbac/v1"
@@ -115,11 +116,12 @@ func createSeedWatches(controller controller.Controller, seedName string, seedMa
 	typesToWatch := []runtime.Object{
 		&appsv1.Deployment{},
 		&corev1.ConfigMap{},
+		&corev1.Namespace{},
 		&corev1.Secret{},
 		&corev1.Service{},
 		&corev1.ServiceAccount{},
-		&rbacv1.ClusterRole{},
 		&rbacv1.ClusterRoleBinding{},
+		&admissionregistrationv1beta1.ValidatingWebhookConfiguration{},
 		&kubermaticv1.Seed{},
 	}
 

--- a/api/pkg/controller/operator/seed/reconciler.go
+++ b/api/pkg/controller/operator/seed/reconciler.go
@@ -166,6 +166,10 @@ func (r *Reconciler) reconcileResources(cfg *operatorv1alpha1.KubermaticConfigur
 		return err
 	}
 
+	if err := r.reconcilePodDisruptionBudgets(cfg, seed, client, log); err != nil {
+		return err
+	}
+
 	if err := r.reconcileServices(cfg, seed, client, log); err != nil {
 		return err
 	}
@@ -276,6 +280,20 @@ func (r *Reconciler) reconcileDeployments(cfg *operatorv1alpha1.KubermaticConfig
 
 	if err := reconciling.ReconcileDeployments(r.ctx, creators, r.namespace, client, modifiers...); err != nil {
 		return fmt.Errorf("failed to reconcile Deployments: %v", err)
+	}
+
+	return nil
+}
+
+func (r *Reconciler) reconcilePodDisruptionBudgets(cfg *operatorv1alpha1.KubermaticConfiguration, seed *kubermaticv1.Seed, client ctrlruntimeclient.Client, log *zap.SugaredLogger) error {
+	log.Debug("reconciling PodDisruptionBudgets")
+
+	creators := []reconciling.NamedPodDisruptionBudgetCreatorGetter{
+		kubermatic.SeedControllerManagerPDBCreator(cfg),
+	}
+
+	if err := reconciling.ReconcilePodDisruptionBudgets(r.ctx, creators, cfg.Namespace, client, common.OwnershipModifierFactory(seed, r.scheme)); err != nil {
+		return fmt.Errorf("failed to reconcile PodDisruptionBudgets: %v", err)
 	}
 
 	return nil

--- a/api/pkg/controller/operator/seed/reconciler.go
+++ b/api/pkg/controller/operator/seed/reconciler.go
@@ -288,7 +288,7 @@ func (r *Reconciler) reconcileServices(cfg *operatorv1alpha1.KubermaticConfigura
 		common.SeedAdmissionServiceCreator(cfg, client),
 	}
 
-	if err := reconciling.ReconcileServices(r.ctx, creators, cfg.Namespace, client, common.OwnershipModifierFactory(cfg, r.scheme)); err != nil {
+	if err := reconciling.ReconcileServices(r.ctx, creators, cfg.Namespace, client, common.OwnershipModifierFactory(seed, r.scheme)); err != nil {
 		return fmt.Errorf("failed to reconcile Services: %v", err)
 	}
 

--- a/api/pkg/controller/operator/seed/resources/kubermatic/seed-controller-manager.go
+++ b/api/pkg/controller/operator/seed/resources/kubermatic/seed-controller-manager.go
@@ -80,13 +80,10 @@ func SeedControllerManagerDeploymentCreator(workerName string, versions common.V
 				fmt.Sprintf("-pprof-listen-address=%s", *cfg.Spec.SeedController.PProfEndpoint),
 				fmt.Sprintf("-in-cluster-prometheus-disable-default-rules=%v", cfg.Spec.UserCluster.Monitoring.DisableDefaultRules),
 				fmt.Sprintf("-in-cluster-prometheus-disable-default-scraping-configs=%v", cfg.Spec.UserCluster.Monitoring.DisableDefaultScrapingConfigs),
-				fmt.Sprintf("-monitoring-scrape-annotation-prefix=%s", cfg.Spec.UserCluster.Monitoring.ScrapeAnnotationPrefix),
 			}
 
-			if cfg.Spec.SeedController.DebugLog {
-				args = append(args, "-v4", "-log-debug=true")
-			} else {
-				args = append(args, "-v2")
+			if cfg.Spec.UserCluster.Monitoring.ScrapeAnnotationPrefix != "" {
+				args = append(args, fmt.Sprintf("-monitoring-scrape-annotation-prefix=%s", cfg.Spec.UserCluster.Monitoring.ScrapeAnnotationPrefix))
 			}
 
 			if cfg.Spec.SeedController.DebugLog {

--- a/api/pkg/controller/operator/seed/resources/kubermatic/seed-controller-manager.go
+++ b/api/pkg/controller/operator/seed/resources/kubermatic/seed-controller-manager.go
@@ -68,7 +68,7 @@ func SeedControllerManagerDeploymentCreator(workerName string, versions common.V
 				fmt.Sprintf("-nodeport-range=%s", cfg.Spec.UserCluster.NodePortRange),
 				fmt.Sprintf("-worker-name=%s", workerName),
 				fmt.Sprintf("-kubermatic-image=%s", cfg.Spec.UserCluster.KubermaticDockerRepository),
-				fmt.Sprintf("-dnatcontoller-image=%s", cfg.Spec.UserCluster.DNATControllerDockerRepository),
+				fmt.Sprintf("-dnatcontroller-image=%s", cfg.Spec.UserCluster.DNATControllerDockerRepository),
 				fmt.Sprintf("-kubernetes-addons-list=%s", strings.Join(cfg.Spec.UserCluster.Addons.Kubernetes.Default, ",")),
 				fmt.Sprintf("-openshift-addons-list=%s", strings.Join(cfg.Spec.UserCluster.Addons.Openshift.Default, ",")),
 				fmt.Sprintf("-overwrite-registry=%s", cfg.Spec.UserCluster.OverwriteRegistry),

--- a/api/pkg/controller/operator/seed/resources/kubermatic/seed-controller-manager.go
+++ b/api/pkg/controller/operator/seed/resources/kubermatic/seed-controller-manager.go
@@ -252,7 +252,7 @@ func SeedControllerManagerDeploymentCreator(workerName string, versions common.V
 				{
 					Name:    "controller-manager",
 					Image:   cfg.Spec.SeedController.DockerRepository + ":" + versions.Kubermatic,
-					Command: []string{"kubermatic-controller-manager"},
+					Command: []string{"seed-controller-manager"},
 					Args:    args,
 					Ports: []corev1.ContainerPort{
 						{

--- a/api/pkg/controller/operator/seed/resources/kubermatic/seed-controller-manager.go
+++ b/api/pkg/controller/operator/seed/resources/kubermatic/seed-controller-manager.go
@@ -89,6 +89,12 @@ func SeedControllerManagerDeploymentCreator(workerName string, versions common.V
 				args = append(args, "-v2")
 			}
 
+			if cfg.Spec.SeedController.DebugLog {
+				args = append(args, "-v=4", "-log-debug=true")
+			} else {
+				args = append(args, "-v=2")
+			}
+
 			sharedAddonVolume := "addons"
 			volumes := []corev1.Volume{
 				{

--- a/api/pkg/controller/seed-controller-manager/cloud/cloud_controller.go
+++ b/api/pkg/controller/seed-controller-manager/cloud/cloud_controller.go
@@ -122,7 +122,7 @@ func (r *Reconciler) reconcile(ctx context.Context, log *zap.SugaredLogger, clus
 	}
 	datacenter, found := seed.Spec.Datacenters[cluster.Spec.Cloud.DatacenterName]
 	if !found {
-		return nil, fmt.Errorf("couldn't find datacentrer %q for cluster %q", cluster.Spec.Cloud.DatacenterName, cluster.Name)
+		return nil, fmt.Errorf("couldn't find datacenter %q for cluster %q", cluster.Spec.Cloud.DatacenterName, cluster.Name)
 	}
 	prov, err := cloud.Provider(datacenter.DeepCopy(), r.getGlobalSecretKeySelectorValue)
 	if err != nil {


### PR DESCRIPTION
**What this PR does / why we need it**:
While migrating stuff from Helm to Go, I made some typos and let some things "broken on purpose", mainly because testing one controller-manager without the rest is near impossible.

Now that all resources are reconciled via the Operator, it was time to fix these typos. That's this PR, a random collection of things neither me nor my reviewers noticed ^^

* To make it more obvious and user-friendly which version is going to be deployed, I added a nice helpful welcome message when the operator boots up and also added new `...DOCKERTAG` variables, because the existing GITCOMMIT and GITTAG values were not really suitable to contain Git hashes during development and tags in final releases.
* The PDB for the seed-controller-manager wasn't being reconciled.
* Some resources were not watched, even though they were managed by the operator.
* The rest is basically just typos.

With this code, the operator is able to successfully reconcile master and seed clusters and all components run without errors. :-)

**Which issue(s) this PR fixes**:
Relates to #4723 

**Does this PR introduce a user-facing change?**:
```release-note
NONE
```
