### PR TITLE
Cleanup Resources when deleting KubermaticConfigurations/Seeds

### DIFF
--- a/api/cmd/master-controller-manager/controllers.go
+++ b/api/cmd/master-controller-manager/controllers.go
@@ -55,10 +55,10 @@ func createAllControllers(ctrlCtx *controllerContext) error {
 	if err := serviceaccount.Add(ctrlCtx.mgr); err != nil {
 		return fmt.Errorf("failed to create serviceaccount controller: %v", err)
 	}
-	if err := seedsync.Add(ctrlCtx.mgr, 1, ctrlCtx.log, ctrlCtx.namespace, ctrlCtx.seedKubeconfigGetter); err != nil {
+	if err := seedsync.Add(ctrlCtx.ctx, ctrlCtx.mgr, 1, ctrlCtx.log, ctrlCtx.namespace, ctrlCtx.seedKubeconfigGetter); err != nil {
 		return fmt.Errorf("failed to create seedsync controller: %v", err)
 	}
-	if err := seedproxy.Add(ctrlCtx.mgr, 1, ctrlCtx.log, ctrlCtx.namespace, ctrlCtx.seedsGetter, ctrlCtx.seedKubeconfigGetter); err != nil {
+	if err := seedproxy.Add(ctrlCtx.ctx, ctrlCtx.mgr, 1, ctrlCtx.log, ctrlCtx.namespace, ctrlCtx.seedsGetter, ctrlCtx.seedKubeconfigGetter); err != nil {
 		return fmt.Errorf("failed to create seedproxy controller: %v", err)
 	}
 	return nil

--- a/api/hack/ci/ci-run-minimal-conformance-tests.sh
+++ b/api/hack/ci/ci-run-minimal-conformance-tests.sh
@@ -88,13 +88,13 @@ function cleanup {
     -o go-template='{{range .items}}{{.metadata.name}}{{end}}' \
       |xargs -I ^ kubectl label cluster ^ worker-name-
 
+  # Remove the custom seed so the master-controller-manager can clean it up
+  # and we don't end up with a stuck Seed CR.
+  kubectl delete -n $NAMESPACE seeds $SEED_NAME
+
   # Delete the Helm Deployment of Kubermatic
   helm delete --purge kubermatic-$BUILD_ID  \
     --tiller-namespace=$NAMESPACE
-
-  # Delete our custom seed so that a stuck webhook will not cause the
-  # namespace to be stuck in Terminating state.
-  kubectl delete -n $NAMESPACE seeds $SEED_NAME
 
   # Delete the Helm installation
   kubectl delete clusterrolebinding -l prowjob=$BUILD_ID

--- a/api/pkg/controller/operator/common/resources.go
+++ b/api/pkg/controller/operator/common/resources.go
@@ -40,6 +40,8 @@ const (
 	IngressName                           = "kubermatic"
 	MasterControllerManagerDeploymentName = "kubermatic-master-controller-manager"
 	SeedControllerManagerDeploymentName   = "kubermatic-seed-controller-manager"
+
+	CleanupFinalizer = "operator.kubermatic.io/cleanup"
 )
 
 func NamespaceCreator(cfg *operatorv1alpha1.KubermaticConfiguration) reconciling.NamedNamespaceCreatorGetter {
@@ -129,13 +131,13 @@ func SeedWebhookServingCertSecretCreator(cfg *operatorv1alpha1.KubermaticConfigu
 	return servingcerthelper.ServingCertSecretCreator(caGetter, SeedWebhookServingCertSecretName, seedWebhookCommonName, altNames, nil)
 }
 
-func seedAdmissionWebhookName(cfg *operatorv1alpha1.KubermaticConfiguration) string {
+func SeedAdmissionWebhookName(cfg *operatorv1alpha1.KubermaticConfiguration) string {
 	return fmt.Sprintf("kubermatic-seeds-%s", cfg.Namespace)
 }
 
 func SeedAdmissionWebhookCreator(cfg *operatorv1alpha1.KubermaticConfiguration, client ctrlruntimeclient.Client) reconciling.NamedValidatingWebhookConfigurationCreatorGetter {
 	return func() (string, reconciling.ValidatingWebhookConfigurationCreator) {
-		return seedAdmissionWebhookName(cfg), func(hook *admissionregistrationv1beta1.ValidatingWebhookConfiguration) (*admissionregistrationv1beta1.ValidatingWebhookConfiguration, error) {
+		return SeedAdmissionWebhookName(cfg), func(hook *admissionregistrationv1beta1.ValidatingWebhookConfiguration) (*admissionregistrationv1beta1.ValidatingWebhookConfiguration, error) {
 			policy := admissionregistrationv1beta1.Fail
 			sideEffects := admissionregistrationv1beta1.SideEffectClassUnknown
 			scope := admissionregistrationv1beta1.AllScopes

--- a/api/pkg/controller/operator/common/util.go
+++ b/api/pkg/controller/operator/common/util.go
@@ -148,3 +148,19 @@ func createSecretData(s *corev1.Secret, data map[string]string) *corev1.Secret {
 
 	return s
 }
+
+type patchFunction func(*operatorv1alpha1.KubermaticConfiguration) error
+
+func PatchKubermaticConfiguration(client ctrlruntimeclient.Client, config *operatorv1alpha1.KubermaticConfiguration, patch patchFunction) error {
+	oldConfig := config.DeepCopy()
+
+	if err := patch(config); err != nil {
+		return err
+	}
+
+	if err := client.Patch(context.Background(), config, ctrlruntimeclient.MergeFrom(oldConfig)); err != nil {
+		return fmt.Errorf("failed to patch KubermaticConfiguration: %v", err)
+	}
+
+	return nil
+}

--- a/api/pkg/controller/operator/common/util.go
+++ b/api/pkg/controller/operator/common/util.go
@@ -59,6 +59,8 @@ func isSeed(ref metav1.OwnerReference) bool {
 	return ref.APIVersion == kubermaticv1.SchemeGroupVersion.String() && ref.Kind == "Seed"
 }
 
+// StringifyFeatureGates takes a set of enabled features and returns a comma-separated
+// key=value list like "featureA=true,featureB=true,...".
 func StringifyFeatureGates(cfg *operatorv1alpha1.KubermaticConfiguration) string {
 	features := make([]string, 0)
 	for _, feature := range cfg.Spec.FeatureGates.List() {
@@ -153,6 +155,8 @@ func createSecretData(s *corev1.Secret, data map[string]string) *corev1.Secret {
 
 type patchConfigFunction func(*operatorv1alpha1.KubermaticConfiguration) error
 
+// PatchKubermaticConfiguration applies the given patch function to the
+// KubermaticConfiguration and performs a PATCH operation afterwards to update the resource.
 func PatchKubermaticConfiguration(client ctrlruntimeclient.Client, config *operatorv1alpha1.KubermaticConfiguration, patch patchConfigFunction) error {
 	oldConfig := config.DeepCopy()
 
@@ -169,6 +173,8 @@ func PatchKubermaticConfiguration(client ctrlruntimeclient.Client, config *opera
 
 type patchSeedFunction func(*kubermaticv1.Seed) error
 
+// PatchSeed applies the given patch function to the Seed and performs
+// a PATCH operation afterwards to update the resource.
 func PatchSeed(client ctrlruntimeclient.Client, seed *kubermaticv1.Seed, patch patchSeedFunction) error {
 	oldSeed := seed.DeepCopy()
 
@@ -183,6 +189,9 @@ func PatchSeed(client ctrlruntimeclient.Client, seed *kubermaticv1.Seed, patch p
 	return nil
 }
 
+// CleanupClusterResource attempts to find a cluster-wide resource and
+// deletes it if it was found. If no resource with the given name exists,
+// nil is returned.
 func CleanupClusterResource(client ctrlruntimeclient.Client, obj runtime.Object, name string) error {
 	key := types.NamespacedName{Name: name}
 	ctx := context.Background()

--- a/api/pkg/controller/operator/common/util.go
+++ b/api/pkg/controller/operator/common/util.go
@@ -153,42 +153,6 @@ func createSecretData(s *corev1.Secret, data map[string]string) *corev1.Secret {
 	return s
 }
 
-type patchConfigFunction func(*operatorv1alpha1.KubermaticConfiguration) error
-
-// PatchKubermaticConfiguration applies the given patch function to the
-// KubermaticConfiguration and performs a PATCH operation afterwards to update the resource.
-func PatchKubermaticConfiguration(client ctrlruntimeclient.Client, config *operatorv1alpha1.KubermaticConfiguration, patch patchConfigFunction) error {
-	oldConfig := config.DeepCopy()
-
-	if err := patch(config); err != nil {
-		return err
-	}
-
-	if err := client.Patch(context.Background(), config, ctrlruntimeclient.MergeFrom(oldConfig)); err != nil {
-		return fmt.Errorf("failed to patch KubermaticConfiguration: %v", err)
-	}
-
-	return nil
-}
-
-type patchSeedFunction func(*kubermaticv1.Seed) error
-
-// PatchSeed applies the given patch function to the Seed and performs
-// a PATCH operation afterwards to update the resource.
-func PatchSeed(client ctrlruntimeclient.Client, seed *kubermaticv1.Seed, patch patchSeedFunction) error {
-	oldSeed := seed.DeepCopy()
-
-	if err := patch(seed); err != nil {
-		return err
-	}
-
-	if err := client.Patch(context.Background(), seed, ctrlruntimeclient.MergeFrom(oldSeed)); err != nil {
-		return fmt.Errorf("failed to patch Seed: %v", err)
-	}
-
-	return nil
-}
-
 // CleanupClusterResource attempts to find a cluster-wide resource and
 // deletes it if it was found. If no resource with the given name exists,
 // nil is returned.

--- a/api/pkg/controller/operator/master/resources/kubermatic/common.go
+++ b/api/pkg/controller/operator/master/resources/kubermatic/common.go
@@ -27,7 +27,7 @@ const (
 	certificateSecretName = "kubermatic-tls"
 )
 
-func clusterRoleBindingName(cfg *operatorv1alpha1.KubermaticConfiguration) string {
+func ClusterRoleBindingName(cfg *operatorv1alpha1.KubermaticConfiguration) string {
 	return fmt.Sprintf("%s:%s-master:cluster-admin", cfg.Namespace, cfg.Name)
 }
 
@@ -64,7 +64,7 @@ func ServiceAccountCreator(cfg *operatorv1alpha1.KubermaticConfiguration) reconc
 }
 
 func ClusterRoleBindingCreator(cfg *operatorv1alpha1.KubermaticConfiguration) reconciling.NamedClusterRoleBindingCreatorGetter {
-	name := clusterRoleBindingName(cfg)
+	name := ClusterRoleBindingName(cfg)
 
 	return func() (string, reconciling.ClusterRoleBindingCreator) {
 		return name, func(crb *rbacv1.ClusterRoleBinding) (*rbacv1.ClusterRoleBinding, error) {

--- a/api/pkg/controller/operator/seed/reconciler.go
+++ b/api/pkg/controller/operator/seed/reconciler.go
@@ -162,7 +162,7 @@ func (r *Reconciler) cleanupDeletedSeed(cfg *operatorv1alpha1.KubermaticConfigur
 			return fmt.Errorf("failed to clean up ValidatingWebhookConfiguration: %v", err)
 		}
 
-		return common.PatchSeed(r, seed, func(seed *kubermaticv1.Seed) error {
+		return common.PatchSeed(client, seed, func(seed *kubermaticv1.Seed) error {
 			kubernetes.RemoveFinalizer(seed, common.CleanupFinalizer)
 			return nil
 		})

--- a/api/pkg/controller/operator/seed/resources/kubermatic/kubermatic.go
+++ b/api/pkg/controller/operator/seed/resources/kubermatic/kubermatic.go
@@ -18,7 +18,7 @@ const (
 	cleanupContainerKey           = "cleanup-container.yaml"
 )
 
-func clusterRoleBindingName(cfg *operatorv1alpha1.KubermaticConfiguration) string {
+func ClusterRoleBindingName(cfg *operatorv1alpha1.KubermaticConfiguration) string {
 	return fmt.Sprintf("%s:%s-seed:cluster-admin", cfg.Namespace, cfg.Name)
 }
 
@@ -31,7 +31,7 @@ func ServiceAccountCreator(cfg *operatorv1alpha1.KubermaticConfiguration, seed *
 }
 
 func ClusterRoleBindingCreator(cfg *operatorv1alpha1.KubermaticConfiguration, seed *kubermaticv1.Seed) reconciling.NamedClusterRoleBindingCreatorGetter {
-	name := clusterRoleBindingName(cfg)
+	name := ClusterRoleBindingName(cfg)
 
 	return func() (string, reconciling.ClusterRoleBindingCreator) {
 		return name, func(crb *rbacv1.ClusterRoleBinding) (*rbacv1.ClusterRoleBinding, error) {

--- a/api/pkg/controller/seed-proxy/controller.go
+++ b/api/pkg/controller/seed-proxy/controller.go
@@ -1,6 +1,7 @@
 package seedproxy
 
 import (
+	"context"
 	"fmt"
 
 	"go.uber.org/zap"
@@ -78,6 +79,7 @@ const (
 // pods to allow access to monitoring applications inside the seed
 // clusters, like Prometheus and Grafana.
 func Add(
+	ctx context.Context,
 	mgr manager.Manager,
 	numWorkers int,
 	log *zap.SugaredLogger,
@@ -89,6 +91,7 @@ func Add(
 
 	reconciler := &Reconciler{
 		Client:               mgr.GetClient(),
+		ctx:                  ctx,
 		recorder:             mgr.GetEventRecorderFor(ControllerName),
 		log:                  log,
 		namespace:            namespace,

--- a/api/pkg/controller/seed-sync/controller.go
+++ b/api/pkg/controller/seed-sync/controller.go
@@ -22,6 +22,10 @@ const (
 	// ManagedByLabel is the label used to identify the resources
 	// created by this controller.
 	ManagedByLabel = "app.kubernetes.io/managed-by"
+
+	// CleanupFinalizer is put on Seed CRs to facilitate proper
+	// cleanup when a Seed is deleted.
+	CleanupFinalizer = "kubermatic.io/cleanup-seed-sync"
 )
 
 // Add creates a new Seed-Sync controller and sets up Watches

--- a/api/pkg/controller/seed-sync/controller.go
+++ b/api/pkg/controller/seed-sync/controller.go
@@ -1,6 +1,7 @@
 package seedsync
 
 import (
+	"context"
 	"fmt"
 
 	"go.uber.org/zap"
@@ -30,6 +31,7 @@ const (
 
 // Add creates a new Seed-Sync controller and sets up Watches
 func Add(
+	ctx context.Context,
 	mgr manager.Manager,
 	numWorkers int,
 	log *zap.SugaredLogger,
@@ -38,6 +40,7 @@ func Add(
 ) error {
 	reconciler := &Reconciler{
 		Client:           mgr.GetClient(),
+		ctx:              ctx,
 		recorder:         mgr.GetEventRecorderFor(ControllerName),
 		log:              log.Named(ControllerName),
 		seedClientGetter: provider.SeedClientGetterFactory(seedKubeconfigGetter),

--- a/api/pkg/controller/seed-sync/reconciler.go
+++ b/api/pkg/controller/seed-sync/reconciler.go
@@ -69,7 +69,7 @@ func (r *Reconciler) reconcile(seed *kubermaticv1.Seed, logger *zap.SugaredLogge
 	// ensure we always have a cleanup finalizer on the original
 	// Seed CR inside the master cluster
 	if err := common.PatchSeed(r.Client, seed, func(s *kubermaticv1.Seed) error {
-		kubernetes.AddFinalizer(s, common.CleanupFinalizer)
+		kubernetes.AddFinalizer(s, CleanupFinalizer)
 		return nil
 	}); err != nil {
 		return err

--- a/api/pkg/controller/seed-sync/reconciler.go
+++ b/api/pkg/controller/seed-sync/reconciler.go
@@ -3,15 +3,19 @@ package seedsync
 import (
 	"context"
 	"fmt"
+	"time"
 
 	"go.uber.org/zap"
 
+	"github.com/kubermatic/kubermatic/api/pkg/controller/operator/common"
 	kubermaticv1 "github.com/kubermatic/kubermatic/api/pkg/crd/kubermatic/v1"
+	"github.com/kubermatic/kubermatic/api/pkg/kubernetes"
 	"github.com/kubermatic/kubermatic/api/pkg/provider"
 	"github.com/kubermatic/kubermatic/api/pkg/resources/reconciling"
 
 	corev1 "k8s.io/api/core/v1"
 	kerrors "k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/util/sets"
 	"k8s.io/client-go/tools/record"
 	ctrlruntimeclient "sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
@@ -36,7 +40,6 @@ func (r *Reconciler) Reconcile(request reconcile.Request) (reconcile.Result, err
 	seed := &kubermaticv1.Seed{}
 	if err := r.Get(r.ctx, request.NamespacedName, seed); err != nil {
 		if kerrors.IsNotFound(err) {
-			logger.Warn("Seed has been deleted, skipping reconciling")
 			return reconcile.Result{}, nil
 		}
 
@@ -58,12 +61,72 @@ func (r *Reconciler) reconcile(seed *kubermaticv1.Seed, logger *zap.SugaredLogge
 		return fmt.Errorf("failed to create client for seed: %v", err)
 	}
 
+	// cleanup once a Seed was deleted in the master cluster
+	if seed.DeletionTimestamp != nil {
+		return r.cleanupDeletedSeed(seed, client, logger)
+	}
+
+	// ensure we always have a cleanup finalizer on the original
+	// Seed CR inside the master cluster
+	if err := common.PatchSeed(r.Client, seed, func(s *kubermaticv1.Seed) error {
+		kubernetes.AddFinalizer(s, common.CleanupFinalizer)
+		return nil
+	}); err != nil {
+		return err
+	}
+
 	seedCreators := []reconciling.NamedSeedCreatorGetter{
 		seedCreator(seed),
 	}
 
 	if err := reconciling.ReconcileSeeds(r.ctx, seedCreators, seed.Namespace, client); err != nil {
 		return fmt.Errorf("failed to reconcile seed: %v", err)
+	}
+
+	return nil
+}
+
+func (r *Reconciler) cleanupDeletedSeed(seedInMaster *kubermaticv1.Seed, seedClient ctrlruntimeclient.Client, logger *zap.SugaredLogger) error {
+	if sets.NewString(seedInMaster.Finalizers...).Has(CleanupFinalizer) {
+		logger.Debug("Seed was deleted, removing copy in seed cluster")
+
+		key, err := ctrlruntimeclient.ObjectKeyFromObject(seedInMaster)
+		if err != nil {
+			return fmt.Errorf("failed to create object key for Seed CR: %v", err)
+		}
+
+		// The DELETE op can block indefinitely if the Kubermatic Operator
+		// has put a finalizer on the Seed inside the seed cluster and
+		// no operator is running at the moment.
+		cleanupCtx, cancel := context.WithTimeout(r.ctx, 30*time.Second)
+		defer cancel()
+
+		seedInSeed := &kubermaticv1.Seed{}
+
+		err = seedClient.Get(cleanupCtx, key, seedInSeed)
+		if err != nil && !kerrors.IsNotFound(err) {
+			return fmt.Errorf("failed to probe for %s: %v", key, err)
+		}
+
+		// In cases where master and seed cluster are inside the same Kubernetes
+		// cluster, the Seed CR's copy is not actually a copy, but the same resource.
+		// This means that the "copy" has our CleanupFinalizer attached as well.
+		// Attempting to delete seedInMaster would therefore be blocked by
+		// our own finalizer.
+		// For this reason we check if master==seed and if so, only remove the
+		// finalizer later on.
+		if err == nil {
+			if seedInMaster.UID == seedInSeed.UID {
+				logger.Debug("Seed CR is identical to master version, not performing additional DELETE operation", "uid", seedInSeed.UID)
+			} else if err := seedClient.Delete(cleanupCtx, seedInSeed); err != nil {
+				return fmt.Errorf("failed to delete %s: %v", key, err)
+			}
+		}
+
+		return common.PatchSeed(r.Client, seedInMaster, func(s *kubermaticv1.Seed) error {
+			kubernetes.RemoveFinalizer(s, CleanupFinalizer)
+			return nil
+		})
 	}
 
 	return nil


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR uses finalizers to ensure that cluster-wide resources are removed and Seeds are cleaned up when a KubermaticConfiguration or Seed is removed.

* `KubermaticConfigurations` inside master clusters have a new finalizer from the operator so that it can delete the webhook and ClusterRoleBinding.
* `Seeds` inside the seed cluster (!) have an identical finalizer so that the seed-operator-controller can cleanup the seed cluster.
* `Seeds` inside the master cluster now also get a finalizer from the `seed-sync` controller. This ensures that this controller can propagate the deletion into the seed cluster.

The workflow for deleting a Seed is simple:

1. Delete the Seed CR inside the master cluster.

(Deleting the Seed CR inside the seed cluster will make the operator clean up the seed cluster, but since the seed-sync controller will immediately re-create the Seed CR, it's pointless unless you want to force-reconcile a seed cluster.)

It works like this for separate master/seed clusters:

1. Master-Seed CR has a seed-sync-cleanup finalizer.
2. This triggers the seed-sync controller to delete the Seed-Seed CR.
3. This triggers the operator to cleanup the seed cluster. Afterwards it removes its finalizer.
4. If this happened quicker than 30s, the Delete operation from step 2 succeeds and the seed-sync controller removes the finalizer on the Master-Seed CR. If this is slower, the controller errors out and retries later to delete again.
5. The Master-Seed is removed by the apiserver.

For shared master/seed clusters this is a bit more complex:

1. Seed CR has a seed-sync-cleanup *and* a operator-seed-cleanup finalizers.
2. Upon deletion, both controllers race to cleanup their finalizers:
   1. The seed-sync controller will fetch the Seed CR and notice that Master=Seed by comparing the UIDs. This makes it not perform an indefinitely blocking Delete op, but instead it will just remove its finalizer.
   2. The operator will simply cleanup as usual and then remove its finalizer.
3. It's not important in which order the two steps above happen. Afterwards, both finalizers are gone.
5. The Master-Seed is removed by the apiserver.

There are some known limitations:

1. Deleting the kubeconfig-secret for a Seed will make the cleanup impossible. In this case the seed-sync controllers errors indefinitely. It's assumed that cluster admins will either fix the missing kubeconfig to allow cleanup or remove the finalizer because they nuked the seed cluster already. This could be tackled by making the kubeconfig Secret *own* the Seed CR, but that seems weird and is out of scope for this PR.
2. Deleting a KubermaticConfiguration or a Kubermatic namespace will obviously kill controllers and the operator and make Seed deletion stuck. But I think the procedure to first delete all Seeds and then the KubermaticConfiguration is fine.

**Which issue(s) this PR fixes**:
Fixes #4755 

**Does this PR introduce a user-facing change?**:
```release-note
NONE
```
