### PR TITLE
Openshift controller: Test idempotency of resource reconciliation

### DIFF
--- a/api/pkg/controller/seed-controller-manager/openshift/data.go
+++ b/api/pkg/controller/seed-controller-manager/openshift/data.go
@@ -22,7 +22,6 @@ import (
 	"k8s.io/apimachinery/pkg/types"
 	certutil "k8s.io/client-go/util/cert"
 	"sigs.k8s.io/controller-runtime/pkg/client"
-	ctrlruntimeclient "sigs.k8s.io/controller-runtime/pkg/client"
 )
 
 // openshiftData implements the openshiftData interface which is
@@ -38,7 +37,6 @@ type openshiftData struct {
 	kubermaticImage                       string
 	dnatControllerImage                   string
 	supportsFailureDomainZoneAntiAffinity bool
-	userClusterClient                     func() (ctrlruntimeclient.Client, error)
 	externalURL                           string
 	seed                                  *kubermaticv1.Seed
 }

--- a/api/pkg/controller/seed-controller-manager/openshift/resources.go
+++ b/api/pkg/controller/seed-controller-manager/openshift/resources.go
@@ -1,0 +1,81 @@
+package openshift
+
+import (
+	"context"
+	"fmt"
+
+	kubermaticv1 "github.com/kubermatic/kubermatic/api/pkg/crd/kubermatic/v1"
+	"github.com/kubermatic/kubermatic/api/pkg/resources/nodeportproxy"
+
+	corev1 "k8s.io/api/core/v1"
+)
+
+func (r *Reconciler) reconcileResources(ctx context.Context, osData *openshiftData) error {
+	if err := r.services(ctx, osData); err != nil {
+		return fmt.Errorf("failed to reconcile Services: %v", err)
+	}
+
+	if err := r.address(ctx, osData.Cluster(), osData.Seed()); err != nil {
+		return fmt.Errorf("failed to reconcile the cluster address: %v", err)
+	}
+
+	if err := r.secrets(ctx, osData); err != nil {
+		return fmt.Errorf("failed to reconcile Secrets: %v", err)
+	}
+
+	if err := r.ensureServiceAccounts(ctx, osData.Cluster()); err != nil {
+		return err
+	}
+
+	if err := r.ensureRoles(ctx, osData.Cluster()); err != nil {
+		return err
+	}
+
+	if err := r.ensureRoleBindings(ctx, osData.Cluster()); err != nil {
+		return err
+	}
+
+	if err := r.statefulSets(ctx, osData); err != nil {
+		return fmt.Errorf("failed to reconcile StatefulSets: %v", err)
+	}
+
+	// Wait until the cloud provider infra is ready before attempting
+	// to render the cloud-config
+	// TODO: Model resource deployment as a DAG so we don't need hacks
+	// like this combined with tribal knowledge and "someone is noticing this
+	// isn't working correctly"
+	// https://github.com/kubermatic/kubermatic/issues/2948
+	// We can just return and don't need a RequeueAfter because the cluster object
+	// will get updated when the cloud infra health status changes
+	if osData.Cluster().Status.ExtendedHealth.CloudProviderInfrastructure != kubermaticv1.HealthStatusUp {
+		return nil
+	}
+
+	if err := r.configMaps(ctx, osData); err != nil {
+		return fmt.Errorf("failed to reconcile ConfigMaps: %v", err)
+	}
+
+	if err := r.deployments(ctx, osData); err != nil {
+		return fmt.Errorf("failed to reconcile Deployments: %v", err)
+	}
+
+	if osData.Cluster().Spec.ExposeStrategy == corev1.ServiceTypeLoadBalancer {
+		if err := nodeportproxy.EnsureResources(ctx, r.Client, osData); err != nil {
+			return fmt.Errorf("failed to ensure NodePortProxy resources: %v", err)
+		}
+	}
+
+	if err := r.cronJobs(ctx, osData); err != nil {
+		return fmt.Errorf("failed to reconcile CronJobs: %v", err)
+	}
+
+	if err := r.podDisruptionBudgets(ctx, osData); err != nil {
+		return fmt.Errorf("failed to reconcile PodDisruptionBudgets: %v", err)
+	}
+
+	if err := r.verticalPodAutoscalers(ctx, osData); err != nil {
+		return fmt.Errorf("failed to reconcile VerticalPodAutoscalers: %v", err)
+	}
+
+	return nil
+}

--- a/api/pkg/controller/seed-controller-manager/openshift/resources_test.go
+++ b/api/pkg/controller/seed-controller-manager/openshift/resources_test.go
@@ -1,3 +1,5 @@
+// +build integration
+
 package openshift
 
 import (

--- a/api/pkg/controller/seed-controller-manager/openshift/resources_test.go
+++ b/api/pkg/controller/seed-controller-manager/openshift/resources_test.go
@@ -1,0 +1,193 @@
+package openshift
+
+import (
+	"context"
+	"testing"
+
+	"github.com/kubermatic/kubermatic/api/pkg/semver"
+
+	kubermaticv1 "github.com/kubermatic/kubermatic/api/pkg/crd/kubermatic/v1"
+	kubermaticlog "github.com/kubermatic/kubermatic/api/pkg/log"
+	"github.com/kubermatic/kubermatic/api/pkg/resources"
+
+	appsv1 "k8s.io/api/apps/v1"
+	corev1 "k8s.io/api/core/v1"
+	apiextensionsv1beta1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1beta1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	autoscalingv1beta2 "k8s.io/autoscaler/vertical-pod-autoscaler/pkg/apis/autoscaling.k8s.io/v1beta2"
+	ctrlruntimeclient "sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/envtest"
+	"sigs.k8s.io/controller-runtime/pkg/manager"
+)
+
+func TestEnsureResourcesAreDeployedIdempotency(t *testing.T) {
+	kubermaticlog.Logger = kubermaticlog.New(true, kubermaticlog.FormatJSON).Sugar()
+	env := &envtest.Environment{
+		// Uncomment this to get the logs from etcd+apiserver
+		// AttachControlPlaneOutput: true,
+		KubeAPIServerFlags: []string{
+			"--etcd-servers={{ if .EtcdURL }}{{ .EtcdURL.String }}{{ end }}",
+			"--cert-dir={{ .CertDir }}",
+			"--insecure-port={{ if .URL }}{{ .URL.Port }}{{ end }}",
+			"--insecure-bind-address={{ if .URL }}{{ .URL.Hostname }}{{ end }}",
+			"--secure-port={{ if .SecurePort }}{{ .SecurePort }}{{ end }}",
+			"--admission-control=AlwaysAdmit",
+			// Upstream does not have `--allow-privileged`,
+			"--allow-privileged",
+		},
+	}
+	cfg, err := env.Start()
+	if err != nil {
+		t.Fatalf("failed to start testenv: %v", err)
+	}
+	defer func() {
+		if err := env.Stop(); err != nil {
+			t.Fatalf("failed to stop testenv: %v", err)
+		}
+	}()
+
+	mgr, err := manager.New(cfg, manager.Options{})
+	if err != nil {
+		t.Fatalf("failed to construct manager: %v", err)
+	}
+	if err := autoscalingv1beta2.AddToScheme(mgr.GetScheme()); err != nil {
+		t.Fatalf("failed to register vertical pod autoscaler resources to scheme: %v", err)
+	}
+	crdInstallOpts := envtest.CRDInstallOptions{
+		// Results in timeouts, maybe a controller-runtime bug?
+		// Paths: []string{"../../../../../config/kubermatic/crd"},
+		CRDs: []*apiextensionsv1beta1.CustomResourceDefinition{
+			{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "clusters.kubermatic.k8s.io",
+				},
+				Spec: apiextensionsv1beta1.CustomResourceDefinitionSpec{
+					Group:   "kubermatic.k8s.io",
+					Version: "v1",
+					Names: apiextensionsv1beta1.CustomResourceDefinitionNames{
+						Kind:     "Cluster",
+						ListKind: "ClusterList",
+						Plural:   "clusters",
+						Singular: "cluster",
+					},
+					Scope: apiextensionsv1beta1.ClusterScoped,
+				},
+			},
+			{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "verticalpodautoscalers.autoscaling.k8s.io",
+				},
+				Spec: apiextensionsv1beta1.CustomResourceDefinitionSpec{
+					Group:   "autoscaling.k8s.io",
+					Version: "v1beta2",
+					Names: apiextensionsv1beta1.CustomResourceDefinitionNames{
+						Kind:     "VerticalPodAutoscaler",
+						Plural:   "verticalpodautoscalers",
+						Singular: "verticalpodautoscaler",
+					},
+					Scope: apiextensionsv1beta1.NamespaceScoped,
+				},
+			},
+		},
+	}
+	if _, err := envtest.InstallCRDs(cfg, crdInstallOpts); err != nil {
+		t.Fatalf("failed install crds: %v", err)
+	}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	go func() {
+		if err := mgr.Start(ctx.Done()); err != nil {
+			t.Errorf("failed to start manager: %v", err)
+		}
+	}()
+
+	testCluster := &kubermaticv1.Cluster{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:        "test-cluster",
+			Annotations: map[string]string{"kubermatic.io/openshift": "true"},
+		},
+		Spec: kubermaticv1.ClusterSpec{
+			ExposeStrategy: corev1.ServiceTypeLoadBalancer,
+			Cloud: kubermaticv1.CloudSpec{
+				DatacenterName: "my-dc",
+			},
+			Version: *semver.NewSemverOrDie("4.1.18"),
+		},
+		Status: kubermaticv1.ClusterStatus{
+			NamespaceName: "cluster-test-cluster",
+			ExtendedHealth: kubermaticv1.ExtendedClusterHealth{
+				CloudProviderInfrastructure: kubermaticv1.HealthStatusUp,
+			},
+		},
+	}
+
+	// This is used as basis to sync the clusters address which we in turn do
+	// before creating any deployments.
+	lbService := &corev1.Service{
+		ObjectMeta: metav1.ObjectMeta{
+			Namespace: testCluster.Status.NamespaceName,
+			Name:      resources.FrontLoadBalancerServiceName,
+		},
+		Spec: corev1.ServiceSpec{
+			Type:  corev1.ServiceTypeLoadBalancer,
+			Ports: []corev1.ServicePort{{Port: 443}},
+		},
+		Status: corev1.ServiceStatus{
+			LoadBalancer: corev1.LoadBalancerStatus{
+				Ingress: []corev1.LoadBalancerIngress{{
+					IP: "1.2.3.4",
+				}},
+			},
+		},
+	}
+
+	if err := mgr.GetClient().Create(ctx, testCluster); err != nil {
+		t.Fatalf("failed to create testcluster: %v", err)
+	}
+	if err := mgr.GetClient().Create(ctx, lbService); err != nil {
+		t.Fatalf("failed to create the loadbalancer service: %v", err)
+	}
+	// Status is a subresource for services and we need the IP to be set, else
+	// the reconciliation returns early
+	if err := mgr.GetClient().Status().Update(ctx, lbService); err != nil {
+		t.Fatalf("failed to set lb service status: %v", err)
+	}
+
+	r := &Reconciler{
+		log:                  kubermaticlog.Logger,
+		Client:               mgr.GetClient(),
+		dockerPullConfigJSON: []byte("{}"),
+		nodeAccessNetwork:    kubermaticv1.DefaultNodeAccessNetwork,
+		seedGetter: func() (*kubermaticv1.Seed, error) {
+			return &kubermaticv1.Seed{
+				Spec: kubermaticv1.SeedSpec{
+					Datacenters: map[string]kubermaticv1.Datacenter{
+						testCluster.Spec.Cloud.DatacenterName: {},
+					},
+				},
+			}, nil
+		},
+	}
+
+	if err := r.networkDefaults(ctx, testCluster); err != nil {
+		t.Fatalf("failed to sync initial network default: %v", err)
+	}
+
+	if err := r.reconcileResources(ctx, testCluster); err != nil {
+		t.Fatalf("Initial resource deployment failed, this indicates that some resources are invalid. Error: %v", err)
+	}
+
+	if err := r.reconcileResources(ctx, testCluster); err != nil {
+		t.Fatalf("The second resource reconciliation failed, indicating we don't properly default some fields. Check the `Object differs from generated one` error for the object for which we timed out. Original error: %v", err)
+	}
+
+	// A very basic sanity check that we actually deployed something
+	deploymentList := &appsv1.DeploymentList{}
+	if err := mgr.GetAPIReader().List(ctx, deploymentList, ctrlruntimeclient.InNamespace(testCluster.Status.NamespaceName)); err != nil {
+		t.Fatalf("failed to list deployments: %v", err)
+	}
+	if len(deploymentList.Items) == 0 {
+		t.Error("expected to find at least one deployment, got zero")
+	}
+}

--- a/api/pkg/controller/seed-controller-manager/openshift/resources_test.go
+++ b/api/pkg/controller/seed-controller-manager/openshift/resources_test.go
@@ -2,6 +2,8 @@ package openshift
 
 import (
 	"context"
+	"io/ioutil"
+	"os"
 	"testing"
 
 	"github.com/kubermatic/kubermatic/api/pkg/semver"
@@ -102,6 +104,22 @@ func TestEnsureResourcesAreDeployedIdempotency(t *testing.T) {
 		}
 	}()
 
+	oidcCATempfile, err := ioutil.TempFile("", "kubermatic-openshift-controller-test")
+	if err != nil {
+		t.Fatalf("failed to get tempfile for oidc ca: %v", err)
+	}
+	if err := oidcCATempfile.Close(); err != nil {
+		t.Errorf("failed to close OIDC ca tempfile: %v", err)
+	}
+	defer func() {
+		if err := os.Remove(oidcCATempfile.Name()); err != nil {
+			t.Errorf("failed to remove OIDC ca tempfile: %v", err)
+		}
+	}()
+	if err := ioutil.WriteFile(oidcCATempfile.Name(), oidcCA, 0644); err != nil {
+		t.Fatalf("failed to write oidcCA to tempfile: %v", err)
+	}
+
 	testCluster := &kubermaticv1.Cluster{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:        "test-cluster",
@@ -112,7 +130,8 @@ func TestEnsureResourcesAreDeployedIdempotency(t *testing.T) {
 			Cloud: kubermaticv1.CloudSpec{
 				DatacenterName: "my-dc",
 			},
-			Version: *semver.NewSemverOrDie("4.1.18"),
+			Openshift: &kubermaticv1.Openshift{ImagePullSecret: "{}"},
+			Version:   *semver.NewSemverOrDie("4.1.18"),
 		},
 		Status: kubermaticv1.ClusterStatus{
 			NamespaceName: "cluster-test-cluster",
@@ -168,6 +187,7 @@ func TestEnsureResourcesAreDeployedIdempotency(t *testing.T) {
 				},
 			}, nil
 		},
+		oidc: OIDCConfig{CAFile: oidcCATempfile.Name()},
 	}
 
 	if err := r.networkDefaults(ctx, testCluster); err != nil {
@@ -191,3 +211,37 @@ func TestEnsureResourcesAreDeployedIdempotency(t *testing.T) {
 		t.Error("expected to find at least one deployment, got zero")
 	}
 }
+
+var oidcCA = []byte(`
+-----BEGIN CERTIFICATE-----
+MIIFazCCA1OgAwIBAgIRAIIQz7DSQONZRGPgu2OCiwAwDQYJKoZIhvcNAQELBQAw
+TzELMAkGA1UEBhMCVVMxKTAnBgNVBAoTIEludGVybmV0IFNlY3VyaXR5IFJlc2Vh
+cmNoIEdyb3VwMRUwEwYDVQQDEwxJU1JHIFJvb3QgWDEwHhcNMTUwNjA0MTEwNDM4
+WhcNMzUwNjA0MTEwNDM4WjBPMQswCQYDVQQGEwJVUzEpMCcGA1UEChMgSW50ZXJu
+ZXQgU2VjdXJpdHkgUmVzZWFyY2ggR3JvdXAxFTATBgNVBAMTDElTUkcgUm9vdCBY
+MTCCAiIwDQYJKoZIhvcNAQEBBQADggIPADCCAgoCggIBAK3oJHP0FDfzm54rVygc
+h77ct984kIxuPOZXoHj3dcKi/vVqbvYATyjb3miGbESTtrFj/RQSa78f0uoxmyF+
+0TM8ukj13Xnfs7j/EvEhmkvBioZxaUpmZmyPfjxwv60pIgbz5MDmgK7iS4+3mX6U
+A5/TR5d8mUgjU+g4rk8Kb4Mu0UlXjIB0ttov0DiNewNwIRt18jA8+o+u3dpjq+sW
+T8KOEUt+zwvo/7V3LvSye0rgTBIlDHCNAymg4VMk7BPZ7hm/ELNKjD+Jo2FR3qyH
+B5T0Y3HsLuJvW5iB4YlcNHlsdu87kGJ55tukmi8mxdAQ4Q7e2RCOFvu396j3x+UC
+B5iPNgiV5+I3lg02dZ77DnKxHZu8A/lJBdiB3QW0KtZB6awBdpUKD9jf1b0SHzUv
+KBds0pjBqAlkd25HN7rOrFleaJ1/ctaJxQZBKT5ZPt0m9STJEadao0xAH0ahmbWn
+OlFuhjuefXKnEgV4We0+UXgVCwOPjdAvBbI+e0ocS3MFEvzG6uBQE3xDk3SzynTn
+jh8BCNAw1FtxNrQHusEwMFxIt4I7mKZ9YIqioymCzLq9gwQbooMDQaHWBfEbwrbw
+qHyGO0aoSCqI3Haadr8faqU9GY/rOPNk3sgrDQoo//fb4hVC1CLQJ13hef4Y53CI
+rU7m2Ys6xt0nUW7/vGT1M0NPAgMBAAGjQjBAMA4GA1UdDwEB/wQEAwIBBjAPBgNV
+HRMBAf8EBTADAQH/MB0GA1UdDgQWBBR5tFnme7bl5AFzgAiIyBpY9umbbjANBgkq
+hkiG9w0BAQsFAAOCAgEAVR9YqbyyqFDQDLHYGmkgJykIrGF1XIpu+ILlaS/V9lZL
+ubhzEFnTIZd+50xx+7LSYK05qAvqFyFWhfFQDlnrzuBZ6brJFe+GnY+EgPbk6ZGQ
+3BebYhtF8GaV0nxvwuo77x/Py9auJ/GpsMiu/X1+mvoiBOv/2X/qkSsisRcOj/KK
+NFtY2PwByVS5uCbMiogziUwthDyC3+6WVwW6LLv3xLfHTjuCvjHIInNzktHCgKQ5
+ORAzI4JMPJ+GslWYHb4phowim57iaztXOoJwTdwJx4nLCgdNbOhdjsnvzqvHu7Ur
+TkXWStAmzOVyyghqpZXjFaH3pO3JLF+l+/+sKAIuvtd7u+Nxe5AW0wdeRlN8NwdC
+jNPElpzVmbUq4JUagEiuTDkHzsxHpFKVK7q4+63SM1N95R1NbdWhscdCb+ZAJzVc
+oyi3B43njTOQ5yOf+1CceWxG1bQVs5ZufpsMljq4Ui0/1lvh+wjChP4kqKOJ2qxq
+4RgqsahDYVvTH9w7jXbyLeiNdd8XM2w9U/t7y0Ff/9yi0GE44Za4rF2LN9d11TPA
+mRGunUHBcnWEvgJBQl9nJEiU0Zsnvgc/ubhPgXRR4Xq37Z0j4r7g1SgEEzwxA57d
+emyPxgcYxn/eR44/KJ4EBs+lVDR3veyJm+kXQ99b21/+jh5Xos1AnX5iItreGCc=
+-----END CERTIFICATE-----
+`)

--- a/api/pkg/resources/resources.go
+++ b/api/pkg/resources/resources.go
@@ -7,6 +7,7 @@ import (
 	"crypto/x509"
 	"errors"
 	"fmt"
+	"io/ioutil"
 	"net"
 	"time"
 
@@ -730,24 +731,12 @@ func getClusterCAFromLister(ctx context.Context, namespace, name string, client 
 
 // GetDexCAFromFile returns the Dex CA from the lister
 func GetDexCAFromFile(caBundleFilePath string) ([]*x509.Certificate, error) {
-
-	f, err := os.Open(caBundleFilePath)
+	rawData, err := ioutil.ReadFile(caBundleFilePath)
 	if err != nil {
-		return nil, fmt.Errorf("got an invalid CA bundle file %v", err)
-	}
-	defer func() {
-		err := f.Close()
-		if err != nil {
-			klog.Fatal(err)
-		}
-	}()
-
-	bytes, err := ioutil.ReadAll(bufio.NewReader(f))
-	if err != nil {
-		return nil, err
+		return nil, fmt.Errorf("failed to read CA bundle file %q: %v", caBundleFilePath, err)
 	}
 
-	dexCACerts, err := certutil.ParseCertsPEM(bytes)
+	dexCACerts, err := certutil.ParseCertsPEM(rawData)
 	if err != nil {
 		return nil, fmt.Errorf("got an invalid cert: %v", err)
 	}

--- a/api/pkg/resources/resources.go
+++ b/api/pkg/resources/resources.go
@@ -1,16 +1,13 @@
 package resources
 
 import (
-	"bufio"
 	"context"
 	"crypto/ecdsa"
 	"crypto/rsa"
 	"crypto/x509"
 	"errors"
 	"fmt"
-	"io/ioutil"
 	"net"
-	"os"
 	"time"
 
 	"github.com/kubermatic/kubermatic/api/pkg/semver"


### PR DESCRIPTION
**What this PR does / why we need it**:

Towards #2342 this PR adds an integration test to the openshift controller if its resource reconciliation is idempotent and succeeds. In order to make this testable, some smaller refactorings were needed.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Documentation**:
<!-- Add links to the related documentation changes related to this pull request. E.g. the link to the kubermatic/docs pullrequest. -->

**Does this PR introduce a user-facing change?**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If  no release note is required, just write "NONE".
-->
```release-note
none
```
