### PR TITLE
Use RBAC-based authorization to access Kubernetes Dashboard

### DIFF
--- a/api/pkg/provider/types.go
+++ b/api/pkg/provider/types.go
@@ -158,6 +158,10 @@ type ClusterProvider interface {
 	//
 	// Note that the client doesn't use admin account instead it authn/authz as userInfo(email, group)
 	GetClientForCustomerCluster(*UserInfo, *kubermaticv1.Cluster) (ctrlruntimeclient.Client, error)
+
+	// GetTokenForCustomerCluster returns a token for the given cluster with permissions granted to group that
+	// user belongs to.
+	GetTokenForCustomerCluster(userInfo *UserInfo, cluster *kubermaticv1.Cluster) (string, error)
 }
 
 // PrivilegedClusterProvider declares the set of methods for interacting with the seed clusters


### PR DESCRIPTION
**What this PR does / why we need it**:
Based on the user role in Kubermatic proper access will be granted in Kubernetes Dashboard.

![Zrzut ekranu z 2019-12-03 12-31-02](https://user-images.githubusercontent.com/2285385/70047993-87d95b00-15c9-11ea-801c-d1ba8ce77c31.png)

**Does this PR introduce a user-facing change?**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If  no release note is required, just write "NONE".
-->
```release-note
NONE
```
