### PR TITLE
Make controllers not override resource requests set by VPA

### DIFF
--- a/api/pkg/controller/seed-controller-manager/openshift/resources/dns_operator.go
+++ b/api/pkg/controller/seed-controller-manager/openshift/resources/dns_operator.go
@@ -76,8 +76,13 @@ func OpenshiftDNSOperatorFactory(data openshiftData) reconciling.NamedDeployment
 					Name:      resources.InternalUserClusterAdminKubeconfigSecretName,
 					MountPath: "/etc/kubernetes/kubeconfig",
 				}},
-				Resources: *openshiftDNSOperatorResourceRequirements.DeepCopy(),
 			}}
+			err = resources.SetResourceRequirements(d.Spec.Template.Spec.Containers, map[string]*corev1.ResourceRequirements{
+				openshiftDNSOperatorContainerName: openshiftDNSOperatorResourceRequirements.DeepCopy(),
+			}, nil, d.Annotations)
+			if err != nil {
+				return nil, fmt.Errorf("failed to set resource requirements: %v", err)
+			}
 			d.Spec.Template.Spec.Volumes = []corev1.Volume{
 				{
 					// TODO: Properly limit this instead of just using cluster-admin

--- a/api/pkg/controller/seed-controller-manager/openshift/resources/dns_operator.go
+++ b/api/pkg/controller/seed-controller-manager/openshift/resources/dns_operator.go
@@ -21,14 +21,16 @@ const (
 )
 
 var (
-	openshiftDNSOperatorResourceRequirements = corev1.ResourceRequirements{
-		Requests: corev1.ResourceList{
-			corev1.ResourceMemory: resource.MustParse("50Mi"),
-			corev1.ResourceCPU:    resource.MustParse("10m"),
-		},
-		Limits: corev1.ResourceList{
-			corev1.ResourceMemory: resource.MustParse("200Mi"),
-			corev1.ResourceCPU:    resource.MustParse("100m"),
+	openshiftDNSOperatorResourceRequirements = map[string]*corev1.ResourceRequirements{
+		openshiftDNSOperatorContainerName: &corev1.ResourceRequirements{
+			Requests: corev1.ResourceList{
+				corev1.ResourceMemory: resource.MustParse("50Mi"),
+				corev1.ResourceCPU:    resource.MustParse("10m"),
+			},
+			Limits: corev1.ResourceList{
+				corev1.ResourceMemory: resource.MustParse("200Mi"),
+				corev1.ResourceCPU:    resource.MustParse("100m"),
+			},
 		},
 	}
 )
@@ -77,9 +79,7 @@ func OpenshiftDNSOperatorFactory(data openshiftData) reconciling.NamedDeployment
 					MountPath: "/etc/kubernetes/kubeconfig",
 				}},
 			}}
-			err = resources.SetResourceRequirements(d.Spec.Template.Spec.Containers, map[string]*corev1.ResourceRequirements{
-				openshiftDNSOperatorContainerName: openshiftDNSOperatorResourceRequirements.DeepCopy(),
-			}, nil, d.Annotations)
+			err = resources.SetResourceRequirements(d.Spec.Template.Spec.Containers, openshiftDNSOperatorResourceRequirements, nil, d.Annotations)
 			if err != nil {
 				return nil, fmt.Errorf("failed to set resource requirements: %v", err)
 			}

--- a/api/pkg/controller/seed-controller-manager/openshift/resources/dns_operator.go
+++ b/api/pkg/controller/seed-controller-manager/openshift/resources/dns_operator.go
@@ -22,7 +22,7 @@ const (
 
 var (
 	openshiftDNSOperatorResourceRequirements = map[string]*corev1.ResourceRequirements{
-		openshiftDNSOperatorContainerName: &corev1.ResourceRequirements{
+		openshiftDNSOperatorContainerName: {
 			Requests: corev1.ResourceList{
 				corev1.ResourceMemory: resource.MustParse("50Mi"),
 				corev1.ResourceCPU:    resource.MustParse("10m"),

--- a/api/pkg/controller/seed-controller-manager/openshift/resources/kube_apiserver_deployment.go
+++ b/api/pkg/controller/seed-controller-manager/openshift/resources/kube_apiserver_deployment.go
@@ -217,11 +217,7 @@ func APIDeploymentCreator(ctx context.Context, data openshiftData) reconciling.N
 				openvpnSidecar.Name:               openvpnSidecar.Resources.DeepCopy(),
 				dnatControllerSidecar.Name:        dnatControllerSidecar.Resources.DeepCopy(),
 			}
-			overrides := map[string]*corev1.ResourceRequirements{}
-			if data.Cluster().Spec.ComponentsOverride.Apiserver.Resources != nil {
-				overrides[resources.ApiserverDeploymentName] = data.Cluster().Spec.ComponentsOverride.Apiserver.Resources.DeepCopy()
-			}
-			err = resources.SetResourceRequirements(dep.Spec.Template.Spec.Containers, defResourceRequirements, overrides, dep.Annotations)
+			err = resources.SetResourceRequirements(dep.Spec.Template.Spec.Containers, defResourceRequirements, resources.GetOverrides(data.Cluster().Spec.ComponentsOverride), dep.Annotations)
 			if err != nil {
 				return nil, fmt.Errorf("failed to set resource requirements: %v", err)
 			}

--- a/api/pkg/controller/seed-controller-manager/openshift/resources/kube_apiserver_deployment.go
+++ b/api/pkg/controller/seed-controller-manager/openshift/resources/kube_apiserver_deployment.go
@@ -221,7 +221,10 @@ func APIDeploymentCreator(ctx context.Context, data openshiftData) reconciling.N
 			if data.Cluster().Spec.ComponentsOverride.Apiserver.Resources != nil {
 				overrides[resources.ApiserverDeploymentName] = data.Cluster().Spec.ComponentsOverride.Apiserver.Resources.DeepCopy()
 			}
-			resources.SetResourceRequirements(dep.Spec.Template.Spec.Containers, defResourceRequirements, overrides, dep.Annotations)
+			err = resources.SetResourceRequirements(dep.Spec.Template.Spec.Containers, defResourceRequirements, overrides, dep.Annotations)
+			if err != nil {
+				return nil, fmt.Errorf("failed to set resource requirements: %v", err)
+			}
 
 			dep.Spec.Template.Spec.Affinity = resources.HostnameAntiAffinity(resources.ApiserverDeploymentName, data.Cluster().Name)
 

--- a/api/pkg/controller/seed-controller-manager/openshift/resources/kube_controller_manager.go
+++ b/api/pkg/controller/seed-controller-manager/openshift/resources/kube_controller_manager.go
@@ -295,11 +295,7 @@ func KubeControllerManagerDeploymentCreatorFactory(data kubeControllerManagerDat
 					kubeControllerManagerContainerName: defaultKubeControllerResourceRequirements.DeepCopy(),
 					openvpnSidecar.Name:                openvpnSidecar.Resources.DeepCopy(),
 				}
-				overrides := map[string]*corev1.ResourceRequirements{}
-				if data.Cluster().Spec.ComponentsOverride.ControllerManager.Resources != nil {
-					overrides[kubeControllerManagerContainerName] = data.Cluster().Spec.ComponentsOverride.ControllerManager.Resources.DeepCopy()
-				}
-				err = resources.SetResourceRequirements(dep.Spec.Template.Spec.Containers, defResourceRequirements, overrides, dep.Annotations)
+				err = resources.SetResourceRequirements(dep.Spec.Template.Spec.Containers, defResourceRequirements, resources.GetOverrides(data.Cluster().Spec.ComponentsOverride), dep.Annotations)
 				if err != nil {
 					return nil, fmt.Errorf("failed to set resource requirements: %v", err)
 				}

--- a/api/pkg/controller/seed-controller-manager/openshift/resources/kube_scheduler.go
+++ b/api/pkg/controller/seed-controller-manager/openshift/resources/kube_scheduler.go
@@ -193,11 +193,7 @@ func KubeSchedulerDeploymentCreator(data openshiftData) reconciling.NamedDeploym
 				name:                defaultResourceRequirements.DeepCopy(),
 				openvpnSidecar.Name: openvpnSidecar.Resources.DeepCopy(),
 			}
-			overrides := map[string]*corev1.ResourceRequirements{}
-			if data.Cluster().Spec.ComponentsOverride.Scheduler.Resources != nil {
-				overrides[name] = data.Cluster().Spec.ComponentsOverride.Scheduler.Resources.DeepCopy()
-			}
-			err = resources.SetResourceRequirements(dep.Spec.Template.Spec.Containers, defResourceRequirements, overrides, dep.Annotations)
+			err = resources.SetResourceRequirements(dep.Spec.Template.Spec.Containers, defResourceRequirements, resources.GetOverrides(data.Cluster().Spec.ComponentsOverride), dep.Annotations)
 			if err != nil {
 				return nil, fmt.Errorf("failed to set resource requirements: %v", err)
 			}

--- a/api/pkg/controller/seed-controller-manager/openshift/resources/kube_scheduler.go
+++ b/api/pkg/controller/seed-controller-manager/openshift/resources/kube_scheduler.go
@@ -119,10 +119,6 @@ func KubeSchedulerDeploymentCreator(data openshiftData) reconciling.NamedDeploym
 
 			dep.Spec.Template.Spec.ImagePullSecrets = []corev1.LocalObjectReference{{Name: openshiftImagePullSecretName}}
 
-			resourceRequirements := defaultResourceRequirements
-			if data.Cluster().Spec.ComponentsOverride.Scheduler.Resources != nil {
-				resourceRequirements = *data.Cluster().Spec.ComponentsOverride.Scheduler.Resources
-			}
 			dep.Spec.Template.Spec.Containers = []corev1.Container{
 				*openvpnSidecar,
 				{
@@ -171,7 +167,6 @@ func KubeSchedulerDeploymentCreator(data openshiftData) reconciling.NamedDeploym
 							ReadOnly:  true,
 						},
 					},
-					Resources: resourceRequirements,
 					ReadinessProbe: &corev1.Probe{
 						Handler: corev1.Handler{
 							HTTPGet: getSchedulerHealthGetAction(),
@@ -194,7 +189,18 @@ func KubeSchedulerDeploymentCreator(data openshiftData) reconciling.NamedDeploym
 					},
 				},
 			}
-
+			defResourceRequirements := map[string]*corev1.ResourceRequirements{
+				name:                defaultResourceRequirements.DeepCopy(),
+				openvpnSidecar.Name: openvpnSidecar.Resources.DeepCopy(),
+			}
+			overrides := map[string]*corev1.ResourceRequirements{}
+			if data.Cluster().Spec.ComponentsOverride.Scheduler.Resources != nil {
+				overrides[name] = data.Cluster().Spec.ComponentsOverride.Scheduler.Resources.DeepCopy()
+			}
+			err = resources.SetResourceRequirements(dep.Spec.Template.Spec.Containers, defResourceRequirements, overrides, dep.Annotations)
+			if err != nil {
+				return nil, fmt.Errorf("failed to set resource requirements: %v", err)
+			}
 			dep.Spec.Template.Spec.Affinity = resources.HostnameAntiAffinity(name, data.Cluster().Name)
 
 			wrappedPodSpec, err := apiserver.IsRunningWrapper(data, dep.Spec.Template.Spec, sets.NewString(name))

--- a/api/pkg/controller/seed-controller-manager/openshift/resources/oauth.go
+++ b/api/pkg/controller/seed-controller-manager/openshift/resources/oauth.go
@@ -126,10 +126,12 @@ const (
 )
 
 var (
-	oauthDeploymentResourceRequirements = corev1.ResourceRequirements{
-		Requests: corev1.ResourceList{
-			corev1.ResourceCPU:    resource.MustParse("10m"),
-			corev1.ResourceMemory: resource.MustParse("50Mi"),
+	oauthDeploymentResourceRequirements = map[string]*corev1.ResourceRequirements{
+		OauthName: &corev1.ResourceRequirements{
+			Requests: corev1.ResourceList{
+				corev1.ResourceCPU:    resource.MustParse("10m"),
+				corev1.ResourceMemory: resource.MustParse("50Mi"),
+			},
 		},
 	}
 	oauthCLIConfigTemplate = template.Must(template.New("base").Funcs(sprig.TxtFuncMap()).Parse(oauthCLIConfigTemplateRaw))
@@ -419,9 +421,7 @@ func OauthDeploymentCreator(data openshiftData) reconciling.NamedDeploymentCreat
 					TimeoutSeconds:   1,
 				},
 			}}
-			err = resources.SetResourceRequirements(dep.Spec.Template.Spec.Containers, map[string]*corev1.ResourceRequirements{
-				OauthName: oauthDeploymentResourceRequirements.DeepCopy(),
-			}, nil, dep.Annotations)
+			err = resources.SetResourceRequirements(dep.Spec.Template.Spec.Containers, oauthDeploymentResourceRequirements, nil, dep.Annotations)
 			if err != nil {
 				return nil, fmt.Errorf("failed to set resource requirements: %v", err)
 			}

--- a/api/pkg/controller/seed-controller-manager/openshift/resources/oauth.go
+++ b/api/pkg/controller/seed-controller-manager/openshift/resources/oauth.go
@@ -354,6 +354,7 @@ func OauthDeploymentCreator(data openshiftData) reconciling.NamedDeploymentCreat
 					},
 				},
 			}
+
 			dep.Spec.Template.Spec.Containers = []corev1.Container{{
 				Name:  OauthName,
 				Image: image,
@@ -417,9 +418,13 @@ func OauthDeploymentCreator(data openshiftData) reconciling.NamedDeploymentCreat
 					SuccessThreshold: 1,
 					TimeoutSeconds:   1,
 				},
-				Resources: *oauthDeploymentResourceRequirements.DeepCopy(),
 			}}
-
+			err = resources.SetResourceRequirements(dep.Spec.Template.Spec.Containers, map[string]*corev1.ResourceRequirements{
+				OauthName: oauthDeploymentResourceRequirements.DeepCopy(),
+			}, nil, dep.Annotations)
+			if err != nil {
+				return nil, fmt.Errorf("failed to set resource requirements: %v", err)
+			}
 			dep.Spec.Template.Spec.Affinity = resources.HostnameAntiAffinity(OpenshiftAPIServerDeploymentName, data.Cluster().Name)
 			podLabels, err := data.GetPodTemplateLabels(OauthName, dep.Spec.Template.Spec.Volumes, nil)
 			if err != nil {

--- a/api/pkg/controller/seed-controller-manager/openshift/resources/oauth.go
+++ b/api/pkg/controller/seed-controller-manager/openshift/resources/oauth.go
@@ -127,7 +127,7 @@ const (
 
 var (
 	oauthDeploymentResourceRequirements = map[string]*corev1.ResourceRequirements{
-		OauthName: &corev1.ResourceRequirements{
+		OauthName: {
 			Requests: corev1.ResourceList{
 				corev1.ResourceCPU:    resource.MustParse("10m"),
 				corev1.ResourceMemory: resource.MustParse("50Mi"),

--- a/api/pkg/controller/seed-controller-manager/openshift/resources/openshift_network_operator.go
+++ b/api/pkg/controller/seed-controller-manager/openshift/resources/openshift_network_operator.go
@@ -17,14 +17,16 @@ import (
 )
 
 var (
-	openshiftNetworkOperatorResourceRequirements = corev1.ResourceRequirements{
-		Requests: corev1.ResourceList{
-			corev1.ResourceMemory: resource.MustParse("50Mi"),
-			corev1.ResourceCPU:    resource.MustParse("10m"),
-		},
-		Limits: corev1.ResourceList{
-			corev1.ResourceMemory: resource.MustParse("200Mi"),
-			corev1.ResourceCPU:    resource.MustParse("100m"),
+	openshiftNetworkOperatorResourceRequirements = map[string]*corev1.ResourceRequirements{
+		"network-operator": &corev1.ResourceRequirements{
+			Requests: corev1.ResourceList{
+				corev1.ResourceMemory: resource.MustParse("50Mi"),
+				corev1.ResourceCPU:    resource.MustParse("10m"),
+			},
+			Limits: corev1.ResourceList{
+				corev1.ResourceMemory: resource.MustParse("200Mi"),
+				corev1.ResourceCPU:    resource.MustParse("100m"),
+			},
 		},
 	}
 )
@@ -82,9 +84,7 @@ func OpenshiftNetworkOperatorCreatorFactory(data openshiftData) reconciling.Name
 					MountPath: "/etc/kubernetes/kubeconfig",
 				}},
 			}}
-			err = resources.SetResourceRequirements(d.Spec.Template.Spec.Containers, map[string]*corev1.ResourceRequirements{
-				"network-operator": openshiftNetworkOperatorResourceRequirements.DeepCopy(),
-			}, nil, d.Annotations)
+			err = resources.SetResourceRequirements(d.Spec.Template.Spec.Containers, openshiftNetworkOperatorResourceRequirements, nil, d.Annotations)
 			if err != nil {
 				return nil, fmt.Errorf("failed to set resource requirements: %v", err)
 			}

--- a/api/pkg/controller/seed-controller-manager/openshift/resources/openshift_network_operator.go
+++ b/api/pkg/controller/seed-controller-manager/openshift/resources/openshift_network_operator.go
@@ -65,6 +65,7 @@ func OpenshiftNetworkOperatorCreatorFactory(data openshiftData) reconciling.Name
 			if err != nil {
 				return nil, err
 			}
+
 			d.Spec.Template.Spec.Containers = []corev1.Container{{
 				Name:  "network-operator",
 				Image: image,
@@ -80,8 +81,13 @@ func OpenshiftNetworkOperatorCreatorFactory(data openshiftData) reconciling.Name
 					Name:      resources.InternalUserClusterAdminKubeconfigSecretName,
 					MountPath: "/etc/kubernetes/kubeconfig",
 				}},
-				Resources: *openshiftNetworkOperatorResourceRequirements.DeepCopy(),
 			}}
+			err = resources.SetResourceRequirements(d.Spec.Template.Spec.Containers, map[string]*corev1.ResourceRequirements{
+				"network-operator": openshiftNetworkOperatorResourceRequirements.DeepCopy(),
+			}, nil, d.Annotations)
+			if err != nil {
+				return nil, fmt.Errorf("failed to set resource requirements: %v", err)
+			}
 			d.Spec.Template.Spec.Volumes = []corev1.Volume{
 				{
 					Name: resources.InternalUserClusterAdminKubeconfigSecretName,

--- a/api/pkg/controller/seed-controller-manager/openshift/resources/openshift_network_operator.go
+++ b/api/pkg/controller/seed-controller-manager/openshift/resources/openshift_network_operator.go
@@ -18,7 +18,7 @@ import (
 
 var (
 	openshiftNetworkOperatorResourceRequirements = map[string]*corev1.ResourceRequirements{
-		"network-operator": &corev1.ResourceRequirements{
+		"network-operator": {
 			Requests: corev1.ResourceList{
 				corev1.ResourceMemory: resource.MustParse("50Mi"),
 				corev1.ResourceCPU:    resource.MustParse("10m"),

--- a/api/pkg/controller/user-cluster-controller-manager/resources/resources/kubernetes-dashboard/deployment.go
+++ b/api/pkg/controller/user-cluster-controller-manager/resources/resources/kubernetes-dashboard/deployment.go
@@ -15,7 +15,7 @@ import (
 
 var (
 	defaultResourceRequirements = map[string]*corev1.ResourceRequirements{
-		scraperName: &corev1.ResourceRequirements{
+		scraperName: {
 			Requests: corev1.ResourceList{
 				corev1.ResourceMemory: resource.MustParse("32Mi"),
 				corev1.ResourceCPU:    resource.MustParse("50m"),

--- a/api/pkg/controller/user-cluster-controller-manager/resources/resources/kubernetes-dashboard/deployment.go
+++ b/api/pkg/controller/user-cluster-controller-manager/resources/resources/kubernetes-dashboard/deployment.go
@@ -14,14 +14,16 @@ import (
 )
 
 var (
-	defaultResourceRequirements = corev1.ResourceRequirements{
-		Requests: corev1.ResourceList{
-			corev1.ResourceMemory: resource.MustParse("32Mi"),
-			corev1.ResourceCPU:    resource.MustParse("50m"),
-		},
-		Limits: corev1.ResourceList{
-			corev1.ResourceMemory: resource.MustParse("64Mi"),
-			corev1.ResourceCPU:    resource.MustParse("100m"),
+	defaultResourceRequirements = map[string]*corev1.ResourceRequirements{
+		scraperName: &corev1.ResourceRequirements{
+			Requests: corev1.ResourceList{
+				corev1.ResourceMemory: resource.MustParse("32Mi"),
+				corev1.ResourceCPU:    resource.MustParse("50m"),
+			},
+			Limits: corev1.ResourceList{
+				corev1.ResourceMemory: resource.MustParse("64Mi"),
+				corev1.ResourceCPU:    resource.MustParse("100m"),
+			},
 		},
 	}
 )
@@ -51,9 +53,7 @@ func DeploymentCreator() reconciling.NamedDeploymentCreatorGetter {
 			dep.Spec.Template.Spec.Volumes = volumes
 
 			dep.Spec.Template.Spec.Containers = getContainers()
-			err := resources.SetResourceRequirements(dep.Spec.Template.Spec.Containers, map[string]*corev1.ResourceRequirements{
-				scraperName: defaultResourceRequirements.DeepCopy(),
-			}, nil, dep.Annotations)
+			err := resources.SetResourceRequirements(dep.Spec.Template.Spec.Containers, defaultResourceRequirements, nil, dep.Annotations)
 			if err != nil {
 				return nil, fmt.Errorf("failed to set resource requirements: %v", err)
 			}

--- a/api/pkg/crd/kubermatic/v1/cluster.go
+++ b/api/pkg/crd/kubermatic/v1/cluster.go
@@ -269,31 +269,6 @@ type ComponentSettings struct {
 	Prometheus        StatefulSetSettings `json:"prometheus"`
 }
 
-func (cs *ComponentSettings) GetOverrides() map[string]*corev1.ResourceRequirements {
-	if cs == nil {
-		return nil
-	}
-
-	r := map[string]*corev1.ResourceRequirements{}
-	if cs.Apiserver.Resources != nil {
-		r["apiserver"] = cs.Apiserver.Resources.DeepCopy()
-	}
-	if cs.ControllerManager.Resources != nil {
-		r["controller-manager"] = cs.ControllerManager.Resources.DeepCopy()
-	}
-	if cs.Scheduler.Resources != nil {
-		r["scheduler"] = cs.Scheduler.Resources.DeepCopy()
-	}
-	if cs.Etcd.Resources != nil {
-		r["etcd"] = cs.Etcd.Resources.DeepCopy()
-	}
-	if cs.Prometheus.Resources != nil {
-		r["prometheus"] = cs.Prometheus.Resources.DeepCopy()
-	}
-
-	return r
-}
-
 type APIServerSettings struct {
 	DeploymentSettings `json:",inline"`
 

--- a/api/pkg/crd/kubermatic/v1/cluster.go
+++ b/api/pkg/crd/kubermatic/v1/cluster.go
@@ -269,6 +269,31 @@ type ComponentSettings struct {
 	Prometheus        StatefulSetSettings `json:"prometheus"`
 }
 
+func (cs *ComponentSettings) GetOverrides() map[string]*corev1.ResourceRequirements {
+	if cs == nil {
+		return nil
+	}
+
+	r := map[string]*corev1.ResourceRequirements{}
+	if cs.Apiserver.Resources != nil {
+		r["apiserver"] = cs.Apiserver.Resources.DeepCopy()
+	}
+	if cs.ControllerManager.Resources != nil {
+		r["controller-manager"] = cs.ControllerManager.Resources.DeepCopy()
+	}
+	if cs.Scheduler.Resources != nil {
+		r["scheduler"] = cs.Scheduler.Resources.DeepCopy()
+	}
+	if cs.Etcd.Resources != nil {
+		r["etcd"] = cs.Etcd.Resources.DeepCopy()
+	}
+	if cs.Prometheus.Resources != nil {
+		r["prometheus"] = cs.Prometheus.Resources.DeepCopy()
+	}
+
+	return r
+}
+
 type APIServerSettings struct {
 	DeploymentSettings `json:",inline"`
 

--- a/api/pkg/crd/kubermatic/v1/cluster.go
+++ b/api/pkg/crd/kubermatic/v1/cluster.go
@@ -31,8 +31,9 @@ const (
 )
 
 const (
-	WorkerNameLabelKey = "worker-name"
-	ProjectIDLabelKey  = "project-id"
+	WorkerNameLabelKey   = "worker-name"
+	ProjectIDLabelKey    = "project-id"
+	UpdatedByVPALabelKey = "updated-by-vpa"
 )
 
 // ProtectedClusterLabels is a set of labels that must not be set by users on clusters,

--- a/api/pkg/resources/apiserver/deployment.go
+++ b/api/pkg/resources/apiserver/deployment.go
@@ -125,11 +125,6 @@ func DeploymentCreator(data *resources.TemplateData, enableDexCA bool) reconcili
 				return nil, err
 			}
 
-			resourceRequirements := defaultResourceRequirements.DeepCopy()
-			if data.Cluster().Spec.ComponentsOverride.Apiserver.Resources != nil {
-				resourceRequirements = data.Cluster().Spec.ComponentsOverride.Apiserver.Resources
-			}
-
 			envVars, err := GetEnvVars(data)
 			if err != nil {
 				return nil, err
@@ -139,12 +134,11 @@ func DeploymentCreator(data *resources.TemplateData, enableDexCA bool) reconcili
 				*openvpnSidecar,
 				*dnatControllerSidecar,
 				{
-					Name:      name,
-					Image:     data.ImageRegistry(resources.RegistryGCR) + "/google_containers/hyperkube-amd64:v" + data.Cluster().Spec.Version.String(),
-					Command:   []string{"/hyperkube", "kube-apiserver"},
-					Env:       envVars,
-					Args:      flags,
-					Resources: *resourceRequirements,
+					Name:    name,
+					Image:   data.ImageRegistry(resources.RegistryGCR) + "/google_containers/hyperkube-amd64:v" + data.Cluster().Spec.Version.String(),
+					Command: []string{"/hyperkube", "kube-apiserver"},
+					Env:     envVars,
+					Args:    flags,
 					Ports: []corev1.ContainerPort{
 						{
 							ContainerPort: data.Cluster().Address.Port,
@@ -180,6 +174,20 @@ func DeploymentCreator(data *resources.TemplateData, enableDexCA bool) reconcili
 					},
 					VolumeMounts: getVolumeMounts(enableDexCA),
 				},
+			}
+
+			defResourceRequirements := map[string]*corev1.ResourceRequirements{
+				name:                       defaultResourceRequirements.DeepCopy(),
+				openvpnSidecar.Name:        openvpnSidecar.Resources.DeepCopy(),
+				dnatControllerSidecar.Name: dnatControllerSidecar.Resources.DeepCopy(),
+			}
+			overrides := map[string]*corev1.ResourceRequirements{}
+			if data.Cluster().Spec.ComponentsOverride.Apiserver.Resources != nil {
+				overrides[name] = data.Cluster().Spec.ComponentsOverride.Apiserver.Resources.DeepCopy()
+			}
+			err = resources.SetResourceRequirements(dep.Spec.Template.Spec.Containers, defResourceRequirements, overrides, dep.Annotations)
+			if err != nil {
+				return nil, fmt.Errorf("failed to set resource requirements: %v", err)
 			}
 
 			if data.Cluster().Spec.AuditLogging != nil && data.Cluster().Spec.AuditLogging.Enabled {

--- a/api/pkg/resources/apiserver/deployment.go
+++ b/api/pkg/resources/apiserver/deployment.go
@@ -134,7 +134,7 @@ func DeploymentCreator(data *resources.TemplateData, enableDexCA bool) reconcili
 				*openvpnSidecar,
 				*dnatControllerSidecar,
 				{
-					Name:    name,
+					Name:    resources.ApiserverDeploymentName,
 					Image:   data.ImageRegistry(resources.RegistryGCR) + "/google_containers/hyperkube-amd64:v" + data.Cluster().Spec.Version.String(),
 					Command: []string{"/hyperkube", "kube-apiserver"},
 					Env:     envVars,
@@ -181,7 +181,7 @@ func DeploymentCreator(data *resources.TemplateData, enableDexCA bool) reconcili
 				openvpnSidecar.Name:        openvpnSidecar.Resources.DeepCopy(),
 				dnatControllerSidecar.Name: dnatControllerSidecar.Resources.DeepCopy(),
 			}
-			err = resources.SetResourceRequirements(dep.Spec.Template.Spec.Containers, defResourceRequirements, data.Cluster().Spec.ComponentsOverride.GetOverrides(), dep.Annotations)
+			err = resources.SetResourceRequirements(dep.Spec.Template.Spec.Containers, defResourceRequirements, resources.GetOverrides(data.Cluster().Spec.ComponentsOverride), dep.Annotations)
 			if err != nil {
 				return nil, fmt.Errorf("failed to set resource requirements: %v", err)
 			}

--- a/api/pkg/resources/apiserver/deployment.go
+++ b/api/pkg/resources/apiserver/deployment.go
@@ -181,11 +181,7 @@ func DeploymentCreator(data *resources.TemplateData, enableDexCA bool) reconcili
 				openvpnSidecar.Name:        openvpnSidecar.Resources.DeepCopy(),
 				dnatControllerSidecar.Name: dnatControllerSidecar.Resources.DeepCopy(),
 			}
-			overrides := map[string]*corev1.ResourceRequirements{}
-			if data.Cluster().Spec.ComponentsOverride.Apiserver.Resources != nil {
-				overrides[name] = data.Cluster().Spec.ComponentsOverride.Apiserver.Resources.DeepCopy()
-			}
-			err = resources.SetResourceRequirements(dep.Spec.Template.Spec.Containers, defResourceRequirements, overrides, dep.Annotations)
+			err = resources.SetResourceRequirements(dep.Spec.Template.Spec.Containers, defResourceRequirements, data.Cluster().Spec.ComponentsOverride.GetOverrides(), dep.Annotations)
 			if err != nil {
 				return nil, fmt.Errorf("failed to set resource requirements: %v", err)
 			}

--- a/api/pkg/resources/cloudcontroller/openstack.go
+++ b/api/pkg/resources/cloudcontroller/openstack.go
@@ -95,9 +95,16 @@ func openStackDeploymentCreator(data *resources.TemplateData) reconciling.NamedD
 					Image:        data.ImageRegistry(resources.RegistryDocker) + "/k8scloudprovider/openstack-cloud-controller-manager:v" + version,
 					Command:      []string{"/bin/openstack-cloud-controller-manager"},
 					Args:         flags,
-					Resources:    osResourceRequirements,
 					VolumeMounts: osCloudProviderMounts,
 				},
+			}
+			defResourceRequirements := map[string]*corev1.ResourceRequirements{
+				osName:              osResourceRequirements.DeepCopy(),
+				openvpnSidecar.Name: openvpnSidecar.Resources.DeepCopy(),
+			}
+			err = resources.SetResourceRequirements(dep.Spec.Template.Spec.Containers, defResourceRequirements, nil, dep.Annotations)
+			if err != nil {
+				return nil, fmt.Errorf("failed to set resource requirements: %v", err)
 			}
 
 			return dep, nil

--- a/api/pkg/resources/clusterautoscaler/clusterautoscaler.go
+++ b/api/pkg/resources/clusterautoscaler/clusterautoscaler.go
@@ -18,7 +18,7 @@ import (
 
 var (
 	defaultResourceRequirements = map[string]*corev1.ResourceRequirements{
-		resources.ClusterAutoscalerDeploymentName: &corev1.ResourceRequirements{
+		resources.ClusterAutoscalerDeploymentName: {
 			Requests: corev1.ResourceList{
 				corev1.ResourceMemory: resource.MustParse("32Mi"),
 				corev1.ResourceCPU:    resource.MustParse("25m"),

--- a/api/pkg/resources/clusterautoscaler/clusterautoscaler.go
+++ b/api/pkg/resources/clusterautoscaler/clusterautoscaler.go
@@ -16,6 +16,19 @@ import (
 	"k8s.io/apimachinery/pkg/util/sets"
 )
 
+var (
+	defaultResourceRequirements = corev1.ResourceRequirements{
+		Requests: corev1.ResourceList{
+			corev1.ResourceMemory: resource.MustParse("32Mi"),
+			corev1.ResourceCPU:    resource.MustParse("25m"),
+		},
+		Limits: corev1.ResourceList{
+			corev1.ResourceMemory: resource.MustParse("64Mi"),
+			corev1.ResourceCPU:    resource.MustParse("50m"),
+		},
+	}
+)
+
 type clusterautoscalerData interface {
 	GetPodTemplateLabels(string, []corev1.Volume, map[string]string) (map[string]string, error)
 	ImageRegistry(string) string
@@ -82,18 +95,6 @@ func DeploymentCreator(data clusterautoscalerData) reconciling.NamedDeploymentCr
 						// delay:
 						// -v=4 --scale-down-delay-after-failure=1s --scale-down-delay-after-add=1s
 					},
-					// This likely won't be enough for bigger clusters, see https://github.com/kubermatic/kubermatic/issues/3568
-					// for details on how we want to fix this: https://github.com/kubermatic/kubermatic/issues/3568
-					Resources: corev1.ResourceRequirements{
-						Requests: corev1.ResourceList{
-							corev1.ResourceMemory: resource.MustParse("32Mi"),
-							corev1.ResourceCPU:    resource.MustParse("25m"),
-						},
-						Limits: corev1.ResourceList{
-							corev1.ResourceMemory: resource.MustParse("64Mi"),
-							corev1.ResourceCPU:    resource.MustParse("50m"),
-						},
-					},
 					LivenessProbe: &corev1.Probe{
 						Handler: corev1.Handler{
 							HTTPGet: &corev1.HTTPGetAction{
@@ -116,6 +117,16 @@ func DeploymentCreator(data clusterautoscalerData) reconciling.NamedDeploymentCr
 						},
 					},
 				},
+			}
+
+			// This likely won't be enough for bigger clusters, see https://github.com/kubermatic/kubermatic/issues/3568
+			// for details on how we want to fix this: https://github.com/kubermatic/kubermatic/issues/3568
+			defResourceRequirements := map[string]*corev1.ResourceRequirements{
+				resources.ClusterAutoscalerDeploymentName: defaultResourceRequirements.DeepCopy(),
+			}
+			err = resources.SetResourceRequirements(dep.Spec.Template.Spec.Containers, defResourceRequirements, nil, dep.Annotations)
+			if err != nil {
+				return nil, fmt.Errorf("failed to set resource requirements: %v", err)
 			}
 
 			wrappedPodSpec, err := apiserver.IsRunningWrapper(data, dep.Spec.Template.Spec, sets.NewString(resources.ClusterAutoscalerDeploymentName))

--- a/api/pkg/resources/clusterautoscaler/clusterautoscaler.go
+++ b/api/pkg/resources/clusterautoscaler/clusterautoscaler.go
@@ -17,14 +17,16 @@ import (
 )
 
 var (
-	defaultResourceRequirements = corev1.ResourceRequirements{
-		Requests: corev1.ResourceList{
-			corev1.ResourceMemory: resource.MustParse("32Mi"),
-			corev1.ResourceCPU:    resource.MustParse("25m"),
-		},
-		Limits: corev1.ResourceList{
-			corev1.ResourceMemory: resource.MustParse("64Mi"),
-			corev1.ResourceCPU:    resource.MustParse("50m"),
+	defaultResourceRequirements = map[string]*corev1.ResourceRequirements{
+		resources.ClusterAutoscalerDeploymentName: &corev1.ResourceRequirements{
+			Requests: corev1.ResourceList{
+				corev1.ResourceMemory: resource.MustParse("32Mi"),
+				corev1.ResourceCPU:    resource.MustParse("25m"),
+			},
+			Limits: corev1.ResourceList{
+				corev1.ResourceMemory: resource.MustParse("64Mi"),
+				corev1.ResourceCPU:    resource.MustParse("50m"),
+			},
 		},
 	}
 )
@@ -121,10 +123,7 @@ func DeploymentCreator(data clusterautoscalerData) reconciling.NamedDeploymentCr
 
 			// This likely won't be enough for bigger clusters, see https://github.com/kubermatic/kubermatic/issues/3568
 			// for details on how we want to fix this: https://github.com/kubermatic/kubermatic/issues/3568
-			defResourceRequirements := map[string]*corev1.ResourceRequirements{
-				resources.ClusterAutoscalerDeploymentName: defaultResourceRequirements.DeepCopy(),
-			}
-			err = resources.SetResourceRequirements(dep.Spec.Template.Spec.Containers, defResourceRequirements, nil, dep.Annotations)
+			err = resources.SetResourceRequirements(dep.Spec.Template.Spec.Containers, defaultResourceRequirements, nil, dep.Annotations)
 			if err != nil {
 				return nil, fmt.Errorf("failed to set resource requirements: %v", err)
 			}

--- a/api/pkg/resources/controllermanager/deployment.go
+++ b/api/pkg/resources/controllermanager/deployment.go
@@ -136,11 +136,6 @@ func DeploymentCreator(data *resources.TemplateData) reconciling.NamedDeployment
 				controllerManagerMounts = append(controllerManagerMounts, serviceAccountMount)
 			}
 
-			resourceRequirements := defaultResourceRequirements
-			if data.Cluster().Spec.ComponentsOverride.ControllerManager.Resources != nil {
-				resourceRequirements = *data.Cluster().Spec.ComponentsOverride.ControllerManager.Resources
-			}
-
 			envVars, err := GetEnvVars(data)
 			if err != nil {
 				return nil, err
@@ -149,12 +144,11 @@ func DeploymentCreator(data *resources.TemplateData) reconciling.NamedDeployment
 			dep.Spec.Template.Spec.Containers = []corev1.Container{
 				*openvpnSidecar,
 				{
-					Name:      name,
-					Image:     data.ImageRegistry(resources.RegistryGCR) + "/google_containers/hyperkube-amd64:v" + data.Cluster().Spec.Version.String(),
-					Command:   []string{"/hyperkube", "kube-controller-manager"},
-					Args:      flags,
-					Env:       envVars,
-					Resources: resourceRequirements,
+					Name:    name,
+					Image:   data.ImageRegistry(resources.RegistryGCR) + "/google_containers/hyperkube-amd64:v" + data.Cluster().Spec.Version.String(),
+					Command: []string{"/hyperkube", "kube-controller-manager"},
+					Args:    flags,
+					Env:     envVars,
 					ReadinessProbe: &corev1.Probe{
 						Handler: corev1.Handler{
 							HTTPGet: getHealthGetAction(data),
@@ -176,6 +170,18 @@ func DeploymentCreator(data *resources.TemplateData) reconciling.NamedDeployment
 					},
 					VolumeMounts: controllerManagerMounts,
 				},
+			}
+			defResourceRequirements := map[string]*corev1.ResourceRequirements{
+				name:                defaultResourceRequirements.DeepCopy(),
+				openvpnSidecar.Name: openvpnSidecar.Resources.DeepCopy(),
+			}
+			overrides := map[string]*corev1.ResourceRequirements{}
+			if data.Cluster().Spec.ComponentsOverride.ControllerManager.Resources != nil {
+				overrides[name] = data.Cluster().Spec.ComponentsOverride.ControllerManager.Resources.DeepCopy()
+			}
+			err = resources.SetResourceRequirements(dep.Spec.Template.Spec.Containers, defResourceRequirements, overrides, dep.Annotations)
+			if err != nil {
+				return nil, fmt.Errorf("failed to set resource requirements: %v", err)
 			}
 
 			dep.Spec.Template.Spec.Affinity = resources.HostnameAntiAffinity(name, data.Cluster().Name)

--- a/api/pkg/resources/controllermanager/deployment.go
+++ b/api/pkg/resources/controllermanager/deployment.go
@@ -144,7 +144,7 @@ func DeploymentCreator(data *resources.TemplateData) reconciling.NamedDeployment
 			dep.Spec.Template.Spec.Containers = []corev1.Container{
 				*openvpnSidecar,
 				{
-					Name:    name,
+					Name:    resources.ControllerManagerDeploymentName,
 					Image:   data.ImageRegistry(resources.RegistryGCR) + "/google_containers/hyperkube-amd64:v" + data.Cluster().Spec.Version.String(),
 					Command: []string{"/hyperkube", "kube-controller-manager"},
 					Args:    flags,
@@ -175,11 +175,7 @@ func DeploymentCreator(data *resources.TemplateData) reconciling.NamedDeployment
 				name:                defaultResourceRequirements.DeepCopy(),
 				openvpnSidecar.Name: openvpnSidecar.Resources.DeepCopy(),
 			}
-			overrides := map[string]*corev1.ResourceRequirements{}
-			if data.Cluster().Spec.ComponentsOverride.ControllerManager.Resources != nil {
-				overrides[name] = data.Cluster().Spec.ComponentsOverride.ControllerManager.Resources.DeepCopy()
-			}
-			err = resources.SetResourceRequirements(dep.Spec.Template.Spec.Containers, defResourceRequirements, overrides, dep.Annotations)
+			err = resources.SetResourceRequirements(dep.Spec.Template.Spec.Containers, defResourceRequirements, data.Cluster().Spec.ComponentsOverride.GetOverrides(), dep.Annotations)
 			if err != nil {
 				return nil, fmt.Errorf("failed to set resource requirements: %v", err)
 			}

--- a/api/pkg/resources/controllermanager/deployment.go
+++ b/api/pkg/resources/controllermanager/deployment.go
@@ -175,7 +175,7 @@ func DeploymentCreator(data *resources.TemplateData) reconciling.NamedDeployment
 				name:                defaultResourceRequirements.DeepCopy(),
 				openvpnSidecar.Name: openvpnSidecar.Resources.DeepCopy(),
 			}
-			err = resources.SetResourceRequirements(dep.Spec.Template.Spec.Containers, defResourceRequirements, data.Cluster().Spec.ComponentsOverride.GetOverrides(), dep.Annotations)
+			err = resources.SetResourceRequirements(dep.Spec.Template.Spec.Containers, defResourceRequirements, resources.GetOverrides(data.Cluster().Spec.ComponentsOverride), dep.Annotations)
 			if err != nil {
 				return nil, fmt.Errorf("failed to set resource requirements: %v", err)
 			}

--- a/api/pkg/resources/etcd/statefulset.go
+++ b/api/pkg/resources/etcd/statefulset.go
@@ -27,7 +27,7 @@ const (
 
 var (
 	defaultResourceRequirements = map[string]*corev1.ResourceRequirements{
-		name: &corev1.ResourceRequirements{
+		name: {
 			Requests: corev1.ResourceList{
 				corev1.ResourceMemory: resource.MustParse("256Mi"),
 				corev1.ResourceCPU:    resource.MustParse("50m"),

--- a/api/pkg/resources/etcd/statefulset.go
+++ b/api/pkg/resources/etcd/statefulset.go
@@ -171,11 +171,7 @@ func StatefulSetCreator(data etcdStatefulSetCreatorData, enableDataCorruptionChe
 					},
 				},
 			}
-			overrides := map[string]*corev1.ResourceRequirements{}
-			if data.Cluster().Spec.ComponentsOverride.Etcd.Resources != nil {
-				overrides[name] = data.Cluster().Spec.ComponentsOverride.Etcd.Resources.DeepCopy()
-			}
-			err = resources.SetResourceRequirements(set.Spec.Template.Spec.Containers, defaultResourceRequirements, overrides, set.Annotations)
+			err = resources.SetResourceRequirements(set.Spec.Template.Spec.Containers, defaultResourceRequirements, data.Cluster().Spec.ComponentsOverride.GetOverrides(), set.Annotations)
 			if err != nil {
 				return nil, fmt.Errorf("failed to set resource requirements: %v", err)
 			}

--- a/api/pkg/resources/etcd/statefulset.go
+++ b/api/pkg/resources/etcd/statefulset.go
@@ -92,7 +92,7 @@ func StatefulSetCreator(data etcdStatefulSetCreatorData, enableDataCorruptionChe
 
 			set.Spec.Template.Spec.Containers = []corev1.Container{
 				{
-					Name:    name,
+					Name:    resources.EtcdStatefulSetName,
 					Image:   data.ImageRegistry(resources.RegistryGCR) + "/etcd-development/etcd:" + ImageTag(data.Cluster()),
 					Command: etcdStartCmd,
 					Env: []corev1.EnvVar{
@@ -171,7 +171,7 @@ func StatefulSetCreator(data etcdStatefulSetCreatorData, enableDataCorruptionChe
 					},
 				},
 			}
-			err = resources.SetResourceRequirements(set.Spec.Template.Spec.Containers, defaultResourceRequirements, data.Cluster().Spec.ComponentsOverride.GetOverrides(), set.Annotations)
+			err = resources.SetResourceRequirements(set.Spec.Template.Spec.Containers, defaultResourceRequirements, resources.GetOverrides(data.Cluster().Spec.ComponentsOverride), set.Annotations)
 			if err != nil {
 				return nil, fmt.Errorf("failed to set resource requirements: %v", err)
 			}

--- a/api/pkg/resources/kubernetes-dashboard/deployment.go
+++ b/api/pkg/resources/kubernetes-dashboard/deployment.go
@@ -17,14 +17,16 @@ import (
 )
 
 var (
-	defaultResourceRequirements = corev1.ResourceRequirements{
-		Requests: corev1.ResourceList{
-			corev1.ResourceMemory: resource.MustParse("256Mi"),
-			corev1.ResourceCPU:    resource.MustParse("100m"),
-		},
-		Limits: corev1.ResourceList{
-			corev1.ResourceMemory: resource.MustParse("512Mi"),
-			corev1.ResourceCPU:    resource.MustParse("250m"),
+	defaultResourceRequirements = map[string]*corev1.ResourceRequirements{
+		resources.KubernetesDashboardDeploymentName: &corev1.ResourceRequirements{
+			Requests: corev1.ResourceList{
+				corev1.ResourceMemory: resource.MustParse("256Mi"),
+				corev1.ResourceCPU:    resource.MustParse("100m"),
+			},
+			Limits: corev1.ResourceList{
+				corev1.ResourceMemory: resource.MustParse("512Mi"),
+				corev1.ResourceCPU:    resource.MustParse("250m"),
+			},
 		},
 	}
 )
@@ -70,9 +72,7 @@ func DeploymentCreator(data kubernetesDashboardData) reconciling.NamedDeployment
 
 			dep.Spec.Template.Spec.Volumes = volumes
 			dep.Spec.Template.Spec.Containers = getContainers(data, dep.Spec.Template.Spec.Containers)
-			err = resources.SetResourceRequirements(dep.Spec.Template.Spec.Containers, map[string]*corev1.ResourceRequirements{
-				name: defaultResourceRequirements.DeepCopy(),
-			}, nil, dep.Annotations)
+			err = resources.SetResourceRequirements(dep.Spec.Template.Spec.Containers, defaultResourceRequirements, nil, dep.Annotations)
 			if err != nil {
 				return nil, fmt.Errorf("failed to set resource requirements: %v", err)
 			}

--- a/api/pkg/resources/kubernetes-dashboard/deployment.go
+++ b/api/pkg/resources/kubernetes-dashboard/deployment.go
@@ -70,6 +70,12 @@ func DeploymentCreator(data kubernetesDashboardData) reconciling.NamedDeployment
 
 			dep.Spec.Template.Spec.Volumes = volumes
 			dep.Spec.Template.Spec.Containers = getContainers(data, dep.Spec.Template.Spec.Containers)
+			err = resources.SetResourceRequirements(dep.Spec.Template.Spec.Containers, map[string]*corev1.ResourceRequirements{
+				name: defaultResourceRequirements.DeepCopy(),
+			}, nil, dep.Annotations)
+			if err != nil {
+				return nil, fmt.Errorf("failed to set resource requirements: %v", err)
+			}
 			dep.Spec.Template.Spec.Affinity = resources.HostnameAntiAffinity(name, data.Cluster().Name)
 
 			wrappedPodSpec, err := apiserver.IsRunningWrapper(data, dep.Spec.Template.Spec, sets.NewString(name))
@@ -105,7 +111,6 @@ func getContainers(data kubernetesDashboardData, existingContainers []corev1.Con
 			"--namespace", Namespace,
 			"--enable-insecure-login",
 		},
-		Resources: defaultResourceRequirements,
 		VolumeMounts: []corev1.VolumeMount{
 			{
 				Name:      resources.KubernetesDashboardKubeconfigSecretName,

--- a/api/pkg/resources/kubernetes-dashboard/deployment.go
+++ b/api/pkg/resources/kubernetes-dashboard/deployment.go
@@ -18,7 +18,7 @@ import (
 
 var (
 	defaultResourceRequirements = map[string]*corev1.ResourceRequirements{
-		resources.KubernetesDashboardDeploymentName: &corev1.ResourceRequirements{
+		resources.KubernetesDashboardDeploymentName: {
 			Requests: corev1.ResourceList{
 				corev1.ResourceMemory: resource.MustParse("256Mi"),
 				corev1.ResourceCPU:    resource.MustParse("100m"),

--- a/api/pkg/resources/kubestatemetrics/deployment.go
+++ b/api/pkg/resources/kubestatemetrics/deployment.go
@@ -17,7 +17,7 @@ import (
 
 var (
 	defaultResourceRequirements = map[string]*corev1.ResourceRequirements{
-		name: &corev1.ResourceRequirements{
+		name: {
 			Requests: corev1.ResourceList{
 				corev1.ResourceMemory: resource.MustParse("12Mi"),
 				corev1.ResourceCPU:    resource.MustParse("10m"),

--- a/api/pkg/resources/kubestatemetrics/deployment.go
+++ b/api/pkg/resources/kubestatemetrics/deployment.go
@@ -16,14 +16,16 @@ import (
 )
 
 var (
-	defaultResourceRequirements = corev1.ResourceRequirements{
-		Requests: corev1.ResourceList{
-			corev1.ResourceMemory: resource.MustParse("12Mi"),
-			corev1.ResourceCPU:    resource.MustParse("10m"),
-		},
-		Limits: corev1.ResourceList{
-			corev1.ResourceMemory: resource.MustParse("1Gi"),
-			corev1.ResourceCPU:    resource.MustParse("100m"),
+	defaultResourceRequirements = map[string]*corev1.ResourceRequirements{
+		name: &corev1.ResourceRequirements{
+			Requests: corev1.ResourceList{
+				corev1.ResourceMemory: resource.MustParse("12Mi"),
+				corev1.ResourceCPU:    resource.MustParse("10m"),
+			},
+			Limits: corev1.ResourceList{
+				corev1.ResourceMemory: resource.MustParse("1Gi"),
+				corev1.ResourceCPU:    resource.MustParse("100m"),
+			},
 		},
 	}
 )
@@ -107,9 +109,7 @@ func DeploymentCreator(data *resources.TemplateData) reconciling.NamedDeployment
 					},
 				},
 			}
-			err = resources.SetResourceRequirements(dep.Spec.Template.Spec.Containers, map[string]*corev1.ResourceRequirements{
-				name: defaultResourceRequirements.DeepCopy(),
-			}, nil, dep.Annotations)
+			err = resources.SetResourceRequirements(dep.Spec.Template.Spec.Containers, defaultResourceRequirements, nil, dep.Annotations)
 			if err != nil {
 				return nil, fmt.Errorf("failed to set resource requirements: %v", err)
 			}

--- a/api/pkg/resources/kubestatemetrics/deployment.go
+++ b/api/pkg/resources/kubestatemetrics/deployment.go
@@ -92,7 +92,6 @@ func DeploymentCreator(data *resources.TemplateData) reconciling.NamedDeployment
 							Protocol:      corev1.ProtocolTCP,
 						},
 					},
-					Resources: defaultResourceRequirements,
 					ReadinessProbe: &corev1.Probe{
 						Handler: corev1.Handler{
 							HTTPGet: &corev1.HTTPGetAction{
@@ -107,6 +106,12 @@ func DeploymentCreator(data *resources.TemplateData) reconciling.NamedDeployment
 						TimeoutSeconds:   15,
 					},
 				},
+			}
+			err = resources.SetResourceRequirements(dep.Spec.Template.Spec.Containers, map[string]*corev1.ResourceRequirements{
+				name: defaultResourceRequirements.DeepCopy(),
+			}, nil, dep.Annotations)
+			if err != nil {
+				return nil, fmt.Errorf("failed to set resource requirements: %v", err)
 			}
 
 			wrappedPodSpec, err := apiserver.IsRunningWrapper(data, dep.Spec.Template.Spec, sets.NewString(name))

--- a/api/pkg/resources/machinecontroller/deployment.go
+++ b/api/pkg/resources/machinecontroller/deployment.go
@@ -20,7 +20,7 @@ import (
 
 var (
 	controllerResourceRequirements = map[string]*corev1.ResourceRequirements{
-		Name: &corev1.ResourceRequirements{
+		Name: {
 			Requests: corev1.ResourceList{
 				corev1.ResourceMemory: resource.MustParse("32Mi"),
 				corev1.ResourceCPU:    resource.MustParse("25m"),

--- a/api/pkg/resources/machinecontroller/deployment.go
+++ b/api/pkg/resources/machinecontroller/deployment.go
@@ -126,7 +126,6 @@ func DeploymentCreatorWithoutInitWrapper(data machinecontrollerData) reconciling
 						Name:  "KUBECONFIG",
 						Value: "/etc/kubernetes/kubeconfig/kubeconfig",
 					}),
-					Resources: controllerResourceRequirements,
 					LivenessProbe: &corev1.Probe{
 						Handler: corev1.Handler{
 							HTTPGet: &corev1.HTTPGetAction{
@@ -149,6 +148,12 @@ func DeploymentCreatorWithoutInitWrapper(data machinecontrollerData) reconciling
 						},
 					},
 				},
+			}
+			err = resources.SetResourceRequirements(dep.Spec.Template.Spec.Containers, map[string]*corev1.ResourceRequirements{
+				Name: controllerResourceRequirements.DeepCopy(),
+			}, nil, dep.Annotations)
+			if err != nil {
+				return nil, fmt.Errorf("failed to set resource requirements: %v", err)
 			}
 
 			return dep, nil

--- a/api/pkg/resources/machinecontroller/deployment.go
+++ b/api/pkg/resources/machinecontroller/deployment.go
@@ -19,14 +19,16 @@ import (
 )
 
 var (
-	controllerResourceRequirements = corev1.ResourceRequirements{
-		Requests: corev1.ResourceList{
-			corev1.ResourceMemory: resource.MustParse("32Mi"),
-			corev1.ResourceCPU:    resource.MustParse("25m"),
-		},
-		Limits: corev1.ResourceList{
-			corev1.ResourceMemory: resource.MustParse("512Mi"),
-			corev1.ResourceCPU:    resource.MustParse("2"),
+	controllerResourceRequirements = map[string]*corev1.ResourceRequirements{
+		Name: &corev1.ResourceRequirements{
+			Requests: corev1.ResourceList{
+				corev1.ResourceMemory: resource.MustParse("32Mi"),
+				corev1.ResourceCPU:    resource.MustParse("25m"),
+			},
+			Limits: corev1.ResourceList{
+				corev1.ResourceMemory: resource.MustParse("512Mi"),
+				corev1.ResourceCPU:    resource.MustParse("2"),
+			},
 		},
 	}
 )
@@ -149,9 +151,7 @@ func DeploymentCreatorWithoutInitWrapper(data machinecontrollerData) reconciling
 					},
 				},
 			}
-			err = resources.SetResourceRequirements(dep.Spec.Template.Spec.Containers, map[string]*corev1.ResourceRequirements{
-				Name: controllerResourceRequirements.DeepCopy(),
-			}, nil, dep.Annotations)
+			err = resources.SetResourceRequirements(dep.Spec.Template.Spec.Containers, controllerResourceRequirements, nil, dep.Annotations)
 			if err != nil {
 				return nil, fmt.Errorf("failed to set resource requirements: %v", err)
 			}

--- a/api/pkg/resources/machinecontroller/webhook.go
+++ b/api/pkg/resources/machinecontroller/webhook.go
@@ -71,7 +71,6 @@ func WebhookDeploymentCreator(data machinecontrollerData) reconciling.NamedDeplo
 						Name:  "KUBECONFIG",
 						Value: "/etc/kubernetes/kubeconfig/kubeconfig",
 					}),
-					Resources: webhookResourceRequirements,
 					ReadinessProbe: &corev1.Probe{
 						Handler: corev1.Handler{
 							HTTPGet: &corev1.HTTPGetAction{
@@ -113,6 +112,13 @@ func WebhookDeploymentCreator(data machinecontrollerData) reconciling.NamedDeplo
 					},
 				},
 			}
+			err = resources.SetResourceRequirements(dep.Spec.Template.Spec.Containers, map[string]*corev1.ResourceRequirements{
+				Name: webhookResourceRequirements.DeepCopy(),
+			}, nil, dep.Annotations)
+			if err != nil {
+				return nil, fmt.Errorf("failed to set resource requirements: %v", err)
+			}
+
 			wrappedPodSpec, err := apiserver.IsRunningWrapper(data, dep.Spec.Template.Spec, sets.NewString(Name), "Machine,cluster.k8s.io/v1alpha1")
 			if err != nil {
 				return nil, fmt.Errorf("failed to add apiserver.IsRunningWrapper: %v", err)

--- a/api/pkg/resources/machinecontroller/webhook.go
+++ b/api/pkg/resources/machinecontroller/webhook.go
@@ -20,7 +20,7 @@ import (
 
 var (
 	webhookResourceRequirements = map[string]*corev1.ResourceRequirements{
-		Name: &corev1.ResourceRequirements{
+		Name: {
 			Requests: corev1.ResourceList{
 				corev1.ResourceMemory: resource.MustParse("32Mi"),
 				corev1.ResourceCPU:    resource.MustParse("10m"),

--- a/api/pkg/resources/machinecontroller/webhook.go
+++ b/api/pkg/resources/machinecontroller/webhook.go
@@ -19,14 +19,16 @@ import (
 )
 
 var (
-	webhookResourceRequirements = corev1.ResourceRequirements{
-		Requests: corev1.ResourceList{
-			corev1.ResourceMemory: resource.MustParse("32Mi"),
-			corev1.ResourceCPU:    resource.MustParse("10m"),
-		},
-		Limits: corev1.ResourceList{
-			corev1.ResourceMemory: resource.MustParse("512Mi"),
-			corev1.ResourceCPU:    resource.MustParse("100m"),
+	webhookResourceRequirements = map[string]*corev1.ResourceRequirements{
+		Name: &corev1.ResourceRequirements{
+			Requests: corev1.ResourceList{
+				corev1.ResourceMemory: resource.MustParse("32Mi"),
+				corev1.ResourceCPU:    resource.MustParse("10m"),
+			},
+			Limits: corev1.ResourceList{
+				corev1.ResourceMemory: resource.MustParse("512Mi"),
+				corev1.ResourceCPU:    resource.MustParse("100m"),
+			},
 		},
 	}
 )
@@ -112,9 +114,7 @@ func WebhookDeploymentCreator(data machinecontrollerData) reconciling.NamedDeplo
 					},
 				},
 			}
-			err = resources.SetResourceRequirements(dep.Spec.Template.Spec.Containers, map[string]*corev1.ResourceRequirements{
-				Name: webhookResourceRequirements.DeepCopy(),
-			}, nil, dep.Annotations)
+			err = resources.SetResourceRequirements(dep.Spec.Template.Spec.Containers, webhookResourceRequirements, nil, dep.Annotations)
 			if err != nil {
 				return nil, fmt.Errorf("failed to set resource requirements: %v", err)
 			}

--- a/api/pkg/resources/nodeportproxy/nodeportproxy.go
+++ b/api/pkg/resources/nodeportproxy/nodeportproxy.go
@@ -31,36 +31,36 @@ const (
 )
 
 var (
-	envoyManagerResourceRequirements = corev1.ResourceRequirements{
-		Requests: corev1.ResourceList{
-			corev1.ResourceCPU:    resource.MustParse("10m"),
-			corev1.ResourceMemory: resource.MustParse("32Mi"),
+	defaultResourceRequirements = map[string]*corev1.ResourceRequirements{
+		"envoy-manager": &corev1.ResourceRequirements{
+			Requests: corev1.ResourceList{
+				corev1.ResourceCPU:    resource.MustParse("10m"),
+				corev1.ResourceMemory: resource.MustParse("32Mi"),
+			},
+			Limits: corev1.ResourceList{
+				corev1.ResourceCPU:    resource.MustParse("50m"),
+				corev1.ResourceMemory: resource.MustParse("48Mi"),
+			},
 		},
-		Limits: corev1.ResourceList{
-			corev1.ResourceCPU:    resource.MustParse("50m"),
-			corev1.ResourceMemory: resource.MustParse("48Mi"),
+		"envoy": &corev1.ResourceRequirements{
+			Requests: corev1.ResourceList{
+				corev1.ResourceCPU:    resource.MustParse("50m"),
+				corev1.ResourceMemory: resource.MustParse("32Mi"),
+			},
+			Limits: corev1.ResourceList{
+				corev1.ResourceCPU:    resource.MustParse("100m"),
+				corev1.ResourceMemory: resource.MustParse("64Mi"),
+			},
 		},
-	}
-
-	envoyResourceRequirements = corev1.ResourceRequirements{
-		Requests: corev1.ResourceList{
-			corev1.ResourceCPU:    resource.MustParse("50m"),
-			corev1.ResourceMemory: resource.MustParse("32Mi"),
-		},
-		Limits: corev1.ResourceList{
-			corev1.ResourceCPU:    resource.MustParse("100m"),
-			corev1.ResourceMemory: resource.MustParse("64Mi"),
-		},
-	}
-
-	lbUpdaterResourceRequirements = corev1.ResourceRequirements{
-		Requests: corev1.ResourceList{
-			corev1.ResourceCPU:    resource.MustParse("10m"),
-			corev1.ResourceMemory: resource.MustParse("32Mi"),
-		},
-		Limits: corev1.ResourceList{
-			corev1.ResourceCPU:    resource.MustParse("50m"),
-			corev1.ResourceMemory: resource.MustParse("32Mi"),
+		"lb-updater": &corev1.ResourceRequirements{
+			Requests: corev1.ResourceList{
+				corev1.ResourceCPU:    resource.MustParse("10m"),
+				corev1.ResourceMemory: resource.MustParse("32Mi"),
+			},
+			Limits: corev1.ResourceList{
+				corev1.ResourceCPU:    resource.MustParse("50m"),
+				corev1.ResourceMemory: resource.MustParse("32Mi"),
+			},
 		},
 	}
 )
@@ -246,11 +246,7 @@ func deploymentEnvoy(image string, data nodePortProxyData) reconciling.NamedDepl
 					MountPath: "/etc/envoy",
 				}},
 			}}
-			defResourceRequirements := map[string]*corev1.ResourceRequirements{
-				"envoy-manager": envoyManagerResourceRequirements.DeepCopy(),
-				"envoy":         envoyResourceRequirements.DeepCopy(),
-			}
-			err := resources.SetResourceRequirements(d.Spec.Template.Spec.Containers, defResourceRequirements, nil, d.Annotations)
+			err := resources.SetResourceRequirements(d.Spec.Template.Spec.Containers, defaultResourceRequirements, nil, d.Annotations)
 			if err != nil {
 				return nil, fmt.Errorf("failed to set resource requirements: %v", err)
 			}
@@ -296,9 +292,7 @@ func deploymentLBUpdater(image string) reconciling.NamedDeploymentCreatorGetter 
 					}},
 				}},
 			}}
-			err := resources.SetResourceRequirements(d.Spec.Template.Spec.Containers, map[string]*corev1.ResourceRequirements{
-				"lb-updater": lbUpdaterResourceRequirements.DeepCopy(),
-			}, nil, d.Annotations)
+			err := resources.SetResourceRequirements(d.Spec.Template.Spec.Containers, defaultResourceRequirements, nil, d.Annotations)
 			if err != nil {
 				return nil, fmt.Errorf("failed to set resource requirements: %v", err)
 			}

--- a/api/pkg/resources/nodeportproxy/nodeportproxy.go
+++ b/api/pkg/resources/nodeportproxy/nodeportproxy.go
@@ -30,6 +30,41 @@ const (
 	NodePortProxyExposeNamespacedAnnotationKey = "nodeport-proxy.k8s.io/expose-namespaced"
 )
 
+var (
+	envoyManagerResourceRequirements = corev1.ResourceRequirements{
+		Requests: corev1.ResourceList{
+			corev1.ResourceCPU:    resource.MustParse("10m"),
+			corev1.ResourceMemory: resource.MustParse("32Mi"),
+		},
+		Limits: corev1.ResourceList{
+			corev1.ResourceCPU:    resource.MustParse("50m"),
+			corev1.ResourceMemory: resource.MustParse("48Mi"),
+		},
+	}
+
+	envoyResourceRequirements = corev1.ResourceRequirements{
+		Requests: corev1.ResourceList{
+			corev1.ResourceCPU:    resource.MustParse("50m"),
+			corev1.ResourceMemory: resource.MustParse("32Mi"),
+		},
+		Limits: corev1.ResourceList{
+			corev1.ResourceCPU:    resource.MustParse("100m"),
+			corev1.ResourceMemory: resource.MustParse("64Mi"),
+		},
+	}
+
+	lbUpdaterResourceRequirements = corev1.ResourceRequirements{
+		Requests: corev1.ResourceList{
+			corev1.ResourceCPU:    resource.MustParse("10m"),
+			corev1.ResourceMemory: resource.MustParse("32Mi"),
+		},
+		Limits: corev1.ResourceList{
+			corev1.ResourceCPU:    resource.MustParse("50m"),
+			corev1.ResourceMemory: resource.MustParse("32Mi"),
+		},
+	}
+)
+
 func EnsureResources(ctx context.Context, client ctrlruntimeclient.Client, data nodePortProxyData) error {
 	image := data.ImageRegistry("quay.io") + "/" + imageName + ":" + resources.KUBERMATICCOMMIT
 	namespace := data.Cluster().Status.NamespaceName
@@ -170,16 +205,7 @@ func deploymentEnvoy(image string, data nodePortProxyData) reconciling.NamedDepl
 						FieldPath: "metadata.namespace",
 					}},
 				}},
-				Resources: corev1.ResourceRequirements{
-					Requests: corev1.ResourceList{
-						corev1.ResourceCPU:    resource.MustParse("10m"),
-						corev1.ResourceMemory: resource.MustParse("32Mi"),
-					},
-					Limits: corev1.ResourceList{
-						corev1.ResourceCPU:    resource.MustParse("50m"),
-						corev1.ResourceMemory: resource.MustParse("48Mi"),
-					},
-				}}, {
+			}, {
 				Name:  "envoy",
 				Image: data.ImageRegistry("docker.io") + "/envoyproxy/envoy-alpine:v1.12.2",
 				Command: []string{
@@ -202,16 +228,6 @@ func deploymentEnvoy(image string, data nodePortProxyData) reconciling.NamedDepl
 						},
 					},
 				},
-				Resources: corev1.ResourceRequirements{
-					Requests: corev1.ResourceList{
-						corev1.ResourceCPU:    resource.MustParse("50m"),
-						corev1.ResourceMemory: resource.MustParse("32Mi"),
-					},
-					Limits: corev1.ResourceList{
-						corev1.ResourceCPU:    resource.MustParse("100m"),
-						corev1.ResourceMemory: resource.MustParse("64Mi"),
-					},
-				},
 				ReadinessProbe: &corev1.Probe{
 					FailureThreshold: 3,
 					Handler: corev1.Handler{
@@ -230,6 +246,14 @@ func deploymentEnvoy(image string, data nodePortProxyData) reconciling.NamedDepl
 					MountPath: "/etc/envoy",
 				}},
 			}}
+			defResourceRequirements := map[string]*corev1.ResourceRequirements{
+				"envoy-manager": envoyManagerResourceRequirements.DeepCopy(),
+				"envoy":         envoyResourceRequirements.DeepCopy(),
+			}
+			err := resources.SetResourceRequirements(d.Spec.Template.Spec.Containers, defResourceRequirements, nil, d.Annotations)
+			if err != nil {
+				return nil, fmt.Errorf("failed to set resource requirements: %v", err)
+			}
 			d.Spec.Template.Spec.Volumes = []corev1.Volume{{
 				Name: volumeMountNameEnvoyConfig,
 				VolumeSource: corev1.VolumeSource{
@@ -254,6 +278,7 @@ func deploymentLBUpdater(image string) reconciling.NamedDeploymentCreatorGetter 
 			d.Spec.Template.Spec.ImagePullSecrets = []corev1.LocalObjectReference{
 				{Name: resources.ImagePullSecretName},
 			}
+
 			d.Spec.Template.Spec.Containers = []corev1.Container{{
 				Name: "lb-updater",
 				Command: []string{
@@ -270,17 +295,13 @@ func deploymentLBUpdater(image string) reconciling.NamedDeploymentCreatorGetter 
 						FieldPath: "metadata.namespace",
 					}},
 				}},
-				Resources: corev1.ResourceRequirements{
-					Requests: corev1.ResourceList{
-						corev1.ResourceCPU:    resource.MustParse("10m"),
-						corev1.ResourceMemory: resource.MustParse("32Mi"),
-					},
-					Limits: corev1.ResourceList{
-						corev1.ResourceCPU:    resource.MustParse("50m"),
-						corev1.ResourceMemory: resource.MustParse("32Mi"),
-					},
-				},
 			}}
+			err := resources.SetResourceRequirements(d.Spec.Template.Spec.Containers, map[string]*corev1.ResourceRequirements{
+				"lb-updater": lbUpdaterResourceRequirements.DeepCopy(),
+			}, nil, d.Annotations)
+			if err != nil {
+				return nil, fmt.Errorf("failed to set resource requirements: %v", err)
+			}
 			d.Spec.Template.Spec.ServiceAccountName = "nodeport-proxy"
 
 			return d, nil

--- a/api/pkg/resources/nodeportproxy/nodeportproxy.go
+++ b/api/pkg/resources/nodeportproxy/nodeportproxy.go
@@ -32,7 +32,7 @@ const (
 
 var (
 	defaultResourceRequirements = map[string]*corev1.ResourceRequirements{
-		"envoy-manager": &corev1.ResourceRequirements{
+		"envoy-manager": {
 			Requests: corev1.ResourceList{
 				corev1.ResourceCPU:    resource.MustParse("10m"),
 				corev1.ResourceMemory: resource.MustParse("32Mi"),
@@ -42,7 +42,7 @@ var (
 				corev1.ResourceMemory: resource.MustParse("48Mi"),
 			},
 		},
-		"envoy": &corev1.ResourceRequirements{
+		"envoy": {
 			Requests: corev1.ResourceList{
 				corev1.ResourceCPU:    resource.MustParse("50m"),
 				corev1.ResourceMemory: resource.MustParse("32Mi"),
@@ -52,7 +52,7 @@ var (
 				corev1.ResourceMemory: resource.MustParse("64Mi"),
 			},
 		},
-		"lb-updater": &corev1.ResourceRequirements{
+		"lb-updater": {
 			Requests: corev1.ResourceList{
 				corev1.ResourceCPU:    resource.MustParse("10m"),
 				corev1.ResourceMemory: resource.MustParse("32Mi"),

--- a/api/pkg/resources/openvpn/deployment.go
+++ b/api/pkg/resources/openvpn/deployment.go
@@ -16,7 +16,7 @@ import (
 )
 
 var (
-	defaultResourceRequirements = corev1.ResourceRequirements{
+	openvpnResourceRequirements = corev1.ResourceRequirements{
 		Requests: corev1.ResourceList{
 			corev1.ResourceMemory: resource.MustParse("5Mi"),
 			corev1.ResourceCPU:    resource.MustParse("5m"),
@@ -27,14 +27,17 @@ var (
 		},
 	}
 
-	ipForwardRequirements = corev1.ResourceRequirements{
-		Requests: corev1.ResourceList{
-			corev1.ResourceMemory: resource.MustParse("16Mi"),
-			corev1.ResourceCPU:    resource.MustParse("5m"),
-		},
-		Limits: corev1.ResourceList{
-			corev1.ResourceMemory: resource.MustParse("32Mi"),
-			corev1.ResourceCPU:    resource.MustParse("10m"),
+	defaultResourceRequirements = map[string]*corev1.ResourceRequirements{
+		name: openvpnResourceRequirements.DeepCopy(),
+		"ip-fixup": &corev1.ResourceRequirements{
+			Requests: corev1.ResourceList{
+				corev1.ResourceMemory: resource.MustParse("16Mi"),
+				corev1.ResourceCPU:    resource.MustParse("5m"),
+			},
+			Limits: corev1.ResourceList{
+				corev1.ResourceMemory: resource.MustParse("32Mi"),
+				corev1.ResourceCPU:    resource.MustParse("10m"),
+			},
 		},
 	}
 )
@@ -145,7 +148,7 @@ iptables -A INPUT -i tun0 -j DROP
 						},
 						ProcMount: &procMountType,
 					},
-					Resources: defaultResourceRequirements,
+					Resources: openvpnResourceRequirements,
 				},
 			}
 
@@ -242,11 +245,7 @@ done`,
 					},
 				},
 			}
-			defResourceRequirements := map[string]*corev1.ResourceRequirements{
-				name:       defaultResourceRequirements.DeepCopy(),
-				"ip-fixup": ipForwardRequirements.DeepCopy(),
-			}
-			err = resources.SetResourceRequirements(dep.Spec.Template.Spec.Containers, defResourceRequirements, nil, dep.Annotations)
+			err = resources.SetResourceRequirements(dep.Spec.Template.Spec.Containers, defaultResourceRequirements, nil, dep.Annotations)
 			if err != nil {
 				return nil, fmt.Errorf("failed to set resource requirements: %v", err)
 			}

--- a/api/pkg/resources/openvpn/deployment.go
+++ b/api/pkg/resources/openvpn/deployment.go
@@ -29,7 +29,7 @@ var (
 
 	defaultResourceRequirements = map[string]*corev1.ResourceRequirements{
 		name: openvpnResourceRequirements.DeepCopy(),
-		"ip-fixup": &corev1.ResourceRequirements{
+		"ip-fixup": {
 			Requests: corev1.ResourceList{
 				corev1.ResourceMemory: resource.MustParse("16Mi"),
 				corev1.ResourceCPU:    resource.MustParse("5m"),

--- a/api/pkg/resources/openvpn/deployment.go
+++ b/api/pkg/resources/openvpn/deployment.go
@@ -188,7 +188,6 @@ iptables -A INPUT -i tun0 -j DROP
 						Privileged: resources.Bool(true),
 						ProcMount:  &procMountType,
 					},
-					Resources: defaultResourceRequirements,
 					ReadinessProbe: &corev1.Probe{
 						Handler: corev1.Handler{
 							Exec: &corev1.ExecAction{
@@ -241,8 +240,15 @@ done`,
 						Privileged: resources.Bool(true),
 						ProcMount:  &procMountType,
 					},
-					Resources: ipForwardRequirements,
 				},
+			}
+			defResourceRequirements := map[string]*corev1.ResourceRequirements{
+				name:       defaultResourceRequirements.DeepCopy(),
+				"ip-fixup": ipForwardRequirements.DeepCopy(),
+			}
+			err = resources.SetResourceRequirements(dep.Spec.Template.Spec.Containers, defResourceRequirements, nil, dep.Annotations)
+			if err != nil {
+				return nil, fmt.Errorf("failed to set resource requirements: %v", err)
 			}
 
 			return dep, nil

--- a/api/pkg/resources/prometheus/statefulset.go
+++ b/api/pkg/resources/prometheus/statefulset.go
@@ -152,11 +152,7 @@ func StatefulSetCreator(data *resources.TemplateData) reconciling.NamedStatefulS
 					},
 				},
 			}
-			overrides := map[string]*corev1.ResourceRequirements{}
-			if data.Cluster().Spec.ComponentsOverride.Prometheus.Resources != nil {
-				overrides[name] = data.Cluster().Spec.ComponentsOverride.Prometheus.Resources.DeepCopy()
-			}
-			err = resources.SetResourceRequirements(set.Spec.Template.Spec.Containers, defaultResourceRequirements, overrides, set.Annotations)
+			err = resources.SetResourceRequirements(set.Spec.Template.Spec.Containers, defaultResourceRequirements, data.Cluster().Spec.ComponentsOverride.GetOverrides(), set.Annotations)
 			if err != nil {
 				return nil, fmt.Errorf("failed to set resource requirements: %v", err)
 			}

--- a/api/pkg/resources/prometheus/statefulset.go
+++ b/api/pkg/resources/prometheus/statefulset.go
@@ -82,7 +82,7 @@ func StatefulSetCreator(data *resources.TemplateData) reconciling.NamedStatefulS
 
 			set.Spec.Template.Spec.Containers = []corev1.Container{
 				{
-					Name:  name,
+					Name:  resources.PrometheusStatefulSetName,
 					Image: data.ImageRegistry(resources.RegistryQuay) + "/prometheus/prometheus:" + tag,
 					Args: []string{
 						"--config.file=/etc/prometheus/config/prometheus.yaml",
@@ -152,7 +152,7 @@ func StatefulSetCreator(data *resources.TemplateData) reconciling.NamedStatefulS
 					},
 				},
 			}
-			err = resources.SetResourceRequirements(set.Spec.Template.Spec.Containers, defaultResourceRequirements, data.Cluster().Spec.ComponentsOverride.GetOverrides(), set.Annotations)
+			err = resources.SetResourceRequirements(set.Spec.Template.Spec.Containers, defaultResourceRequirements, resources.GetOverrides(data.Cluster().Spec.ComponentsOverride), set.Annotations)
 			if err != nil {
 				return nil, fmt.Errorf("failed to set resource requirements: %v", err)
 			}

--- a/api/pkg/resources/prometheus/statefulset.go
+++ b/api/pkg/resources/prometheus/statefulset.go
@@ -22,14 +22,16 @@ const (
 )
 
 var (
-	defaultResourceRequirements = corev1.ResourceRequirements{
-		Requests: corev1.ResourceList{
-			corev1.ResourceMemory: resource.MustParse("256Mi"),
-			corev1.ResourceCPU:    resource.MustParse("50m"),
-		},
-		Limits: corev1.ResourceList{
-			corev1.ResourceMemory: resource.MustParse("1Gi"),
-			corev1.ResourceCPU:    resource.MustParse("100m"),
+	defaultResourceRequirements = map[string]*corev1.ResourceRequirements{
+		name: &corev1.ResourceRequirements{
+			Requests: corev1.ResourceList{
+				corev1.ResourceMemory: resource.MustParse("256Mi"),
+				corev1.ResourceCPU:    resource.MustParse("50m"),
+			},
+			Limits: corev1.ResourceList{
+				corev1.ResourceMemory: resource.MustParse("1Gi"),
+				corev1.ResourceCPU:    resource.MustParse("100m"),
+			},
 		},
 	}
 )
@@ -150,14 +152,11 @@ func StatefulSetCreator(data *resources.TemplateData) reconciling.NamedStatefulS
 					},
 				},
 			}
-			defResourceRequirements := map[string]*corev1.ResourceRequirements{
-				name: defaultResourceRequirements.DeepCopy(),
-			}
 			overrides := map[string]*corev1.ResourceRequirements{}
 			if data.Cluster().Spec.ComponentsOverride.Prometheus.Resources != nil {
 				overrides[name] = data.Cluster().Spec.ComponentsOverride.Prometheus.Resources.DeepCopy()
 			}
-			err = resources.SetResourceRequirements(set.Spec.Template.Spec.Containers, defResourceRequirements, overrides, set.Annotations)
+			err = resources.SetResourceRequirements(set.Spec.Template.Spec.Containers, defaultResourceRequirements, overrides, set.Annotations)
 			if err != nil {
 				return nil, fmt.Errorf("failed to set resource requirements: %v", err)
 			}

--- a/api/pkg/resources/prometheus/statefulset.go
+++ b/api/pkg/resources/prometheus/statefulset.go
@@ -23,7 +23,7 @@ const (
 
 var (
 	defaultResourceRequirements = map[string]*corev1.ResourceRequirements{
-		name: &corev1.ResourceRequirements{
+		name: {
 			Requests: corev1.ResourceList{
 				corev1.ResourceMemory: resource.MustParse("256Mi"),
 				corev1.ResourceCPU:    resource.MustParse("50m"),

--- a/api/pkg/resources/resources.go
+++ b/api/pkg/resources/resources.go
@@ -940,3 +940,24 @@ func SetResourceRequirements(containers []corev1.Container, requirements, overri
 
 	return nil
 }
+
+func GetOverrides(componentSettings kubermaticv1.ComponentSettings) map[string]*corev1.ResourceRequirements {
+	r := map[string]*corev1.ResourceRequirements{}
+	if componentSettings.Apiserver.Resources != nil {
+		r[ApiserverDeploymentName] = componentSettings.Apiserver.Resources.DeepCopy()
+	}
+	if componentSettings.ControllerManager.Resources != nil {
+		r[ControllerManagerDeploymentName] = componentSettings.ControllerManager.Resources.DeepCopy()
+	}
+	if componentSettings.Scheduler.Resources != nil {
+		r[SchedulerDeploymentName] = componentSettings.Scheduler.Resources.DeepCopy()
+	}
+	if componentSettings.Etcd.Resources != nil {
+		r[EtcdStatefulSetName] = componentSettings.Etcd.Resources.DeepCopy()
+	}
+	if componentSettings.Prometheus.Resources != nil {
+		r[PrometheusStatefulSetName] = componentSettings.Prometheus.Resources.DeepCopy()
+	}
+
+	return r
+}

--- a/api/pkg/resources/resources_test.go
+++ b/api/pkg/resources/resources_test.go
@@ -3,6 +3,9 @@ package resources
 import (
 	"testing"
 
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/resource"
+
 	kubermaticv1 "github.com/kubermatic/kubermatic/api/pkg/crd/kubermatic/v1"
 )
 
@@ -76,6 +79,69 @@ func TestUserClusterDNSResolverIP(t *testing.T) {
 			if result != tc.expectedResult {
 				t.Errorf("wrong result, expected: %s, result: %s", tc.expectedResult, result)
 			}
+		})
+	}
+}
+
+func TestSetResourceRequirements(t *testing.T) {
+	defaultResourceRequirements := corev1.ResourceRequirements{
+		Requests: corev1.ResourceList{
+			corev1.ResourceMemory: resource.MustParse("64Mi"),
+			corev1.ResourceCPU:    resource.MustParse("20m"),
+		},
+		Limits: corev1.ResourceList{
+			corev1.ResourceMemory: resource.MustParse("512Mi"),
+			corev1.ResourceCPU:    resource.MustParse("1"),
+		},
+	}
+
+	tests := []struct {
+		name                 string
+		containers           []corev1.Container
+		annotations          map[string]string
+		defaultRequirements  map[string]*corev1.ResourceRequirements
+		expectedRequirements map[string]*corev1.ResourceRequirements
+	}{
+		{
+			name: "test with valid resource requirements json",
+			containers: []corev1.Container{
+				{
+					Name: "test",
+				},
+			},
+			annotations: map[string]string{
+				kubermaticv1.UpdatedByVPALabelKey: `[{"name":"test","requires":{"limits":{"cpu":"1","memory":"512Mi"},"requests":{"cpu":"20m","memory":"64Mi"}}}]`,
+			},
+			defaultRequirements: map[string]*corev1.ResourceRequirements{
+				"test": defaultResourceRequirements.DeepCopy(),
+			},
+			expectedRequirements: map[string]*corev1.ResourceRequirements{
+				"test": &corev1.ResourceRequirements{
+					Requests: corev1.ResourceList{
+						corev1.ResourceMemory: resource.MustParse("64Mi"),
+						corev1.ResourceCPU:    resource.MustParse("20m"),
+					},
+					Limits: corev1.ResourceList{
+						corev1.ResourceMemory: resource.MustParse("512Mi"),
+						corev1.ResourceCPU:    resource.MustParse("1"),
+					},
+				},
+			},
+		},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			// err := SetResourceRequirements(tc.containers, tc.defaultRequirements, tc.annotations)
+			// if err != nil {
+			// 	t.Fatalf("error: %v", err)
+			// }
+			// for _, container := range tc.containers {
+			// 	fmt.Println(container.Resources.Limits.Memory().MilliValue())
+			// 	fmt.Println(tc.expectedRequirements["test"].Limits.Memory().MilliValue())
+			// 	if !reflect.DeepEqual(container.Resources, tc.expectedRequirements) {
+			// 		t.Errorf("invalid resource requirements. expected: %#v, but got %#v", tc.expectedRequirements, container.Resources)
+			// 	}
+			// }
 		})
 	}
 }

--- a/api/pkg/resources/resources_test.go
+++ b/api/pkg/resources/resources_test.go
@@ -99,11 +99,12 @@ func TestSetResourceRequirements(t *testing.T) {
 		name                 string
 		containers           []corev1.Container
 		annotations          map[string]string
+		overrides            map[string]*corev1.ResourceRequirements
 		defaultRequirements  map[string]*corev1.ResourceRequirements
 		expectedRequirements map[string]*corev1.ResourceRequirements
 	}{
 		{
-			name: "test with valid resource requirements json",
+			name: "resource requirements set by vpa-updater",
 			containers: []corev1.Container{
 				{
 					Name: "test",
@@ -128,20 +129,401 @@ func TestSetResourceRequirements(t *testing.T) {
 				},
 			},
 		},
+		{
+			name: "resource requirements set by vpa-updater (multiple containers)",
+			containers: []corev1.Container{
+				{
+					Name: "test-1",
+				},
+				{
+					Name: "test-2",
+				},
+				{
+					Name: "test-3",
+				},
+			},
+			annotations: map[string]string{
+				kubermaticv1.UpdatedByVPALabelKey: `[{"name":"test-1","requires":{"limits":{"cpu":"100m","memory":"32Mi"},"requests":{"cpu":"10m","memory":"16Mi"}}},{"name":"test-2","requires":{"limits":{"cpu":"2","memory":"256Mi"},"requests":{"cpu":"20m","memory":"64Mi"}}},{"name":"test-3","requires":{"limits":{"cpu":"1","memory":"2Gi"},"requests":{"cpu":"500m","memory":"1Gi"}}}]`,
+			},
+			defaultRequirements: map[string]*corev1.ResourceRequirements{
+				"test-1": defaultResourceRequirements.DeepCopy(),
+				"test-2": defaultResourceRequirements.DeepCopy(),
+				"test-3": defaultResourceRequirements.DeepCopy(),
+			},
+			expectedRequirements: map[string]*corev1.ResourceRequirements{
+				"test-1": &corev1.ResourceRequirements{
+					Requests: corev1.ResourceList{
+						corev1.ResourceMemory: resource.MustParse("16Mi"),
+						corev1.ResourceCPU:    resource.MustParse("10m"),
+					},
+					Limits: corev1.ResourceList{
+						corev1.ResourceMemory: resource.MustParse("32Mi"),
+						corev1.ResourceCPU:    resource.MustParse("100m"),
+					},
+				},
+				"test-2": &corev1.ResourceRequirements{
+					Requests: corev1.ResourceList{
+						corev1.ResourceMemory: resource.MustParse("64Mi"),
+						corev1.ResourceCPU:    resource.MustParse("20m"),
+					},
+					Limits: corev1.ResourceList{
+						corev1.ResourceMemory: resource.MustParse("256Mi"),
+						corev1.ResourceCPU:    resource.MustParse("2"),
+					},
+				},
+				"test-3": &corev1.ResourceRequirements{
+					Requests: corev1.ResourceList{
+						corev1.ResourceMemory: resource.MustParse("1Gi"),
+						corev1.ResourceCPU:    resource.MustParse("500m"),
+					},
+					Limits: corev1.ResourceList{
+						corev1.ResourceMemory: resource.MustParse("2Gi"),
+						corev1.ResourceCPU:    resource.MustParse("1"),
+					},
+				},
+			},
+		},
+		{
+			name: "resource requirements set by vpa-updater (multiple containers, one not managed by vpa)",
+			containers: []corev1.Container{
+				{
+					Name: "test-1",
+				},
+				{
+					Name: "test-2",
+				},
+				{
+					Name: "test-3",
+				},
+			},
+			annotations: map[string]string{
+				kubermaticv1.UpdatedByVPALabelKey: `[{"name":"test-1","requires":{"limits":{"cpu":"100m","memory":"32Mi"},"requests":{"cpu":"10m","memory":"16Mi"}}},{"name":"test-3","requires":{"limits":{"cpu":"1","memory":"2Gi"},"requests":{"cpu":"500m","memory":"1Gi"}}}]`,
+			},
+			defaultRequirements: map[string]*corev1.ResourceRequirements{
+				"test-1": defaultResourceRequirements.DeepCopy(),
+				"test-2": defaultResourceRequirements.DeepCopy(),
+				"test-3": defaultResourceRequirements.DeepCopy(),
+			},
+			expectedRequirements: map[string]*corev1.ResourceRequirements{
+				"test-1": &corev1.ResourceRequirements{
+					Requests: corev1.ResourceList{
+						corev1.ResourceMemory: resource.MustParse("16Mi"),
+						corev1.ResourceCPU:    resource.MustParse("10m"),
+					},
+					Limits: corev1.ResourceList{
+						corev1.ResourceMemory: resource.MustParse("32Mi"),
+						corev1.ResourceCPU:    resource.MustParse("100m"),
+					},
+				},
+				"test-2": defaultResourceRequirements.DeepCopy(),
+				"test-3": &corev1.ResourceRequirements{
+					Requests: corev1.ResourceList{
+						corev1.ResourceMemory: resource.MustParse("1Gi"),
+						corev1.ResourceCPU:    resource.MustParse("500m"),
+					},
+					Limits: corev1.ResourceList{
+						corev1.ResourceMemory: resource.MustParse("2Gi"),
+						corev1.ResourceCPU:    resource.MustParse("1"),
+					},
+				},
+			},
+		},
+		{
+			name: "resource requirements set by vpa-updater (multiple containers, one using overrides)",
+			containers: []corev1.Container{
+				{
+					Name: "test-1",
+				},
+				{
+					Name: "test-2",
+				},
+				{
+					Name: "test-3",
+				},
+			},
+			annotations: map[string]string{
+				kubermaticv1.UpdatedByVPALabelKey: `[{"name":"test-1","requires":{"limits":{"cpu":"100m","memory":"32Mi"},"requests":{"cpu":"10m","memory":"16Mi"}}},{"name":"test-3","requires":{"limits":{"cpu":"1","memory":"2Gi"},"requests":{"cpu":"500m","memory":"1Gi"}}}]`,
+			},
+			overrides: map[string]*corev1.ResourceRequirements{
+				"test-2": &corev1.ResourceRequirements{
+					Requests: corev1.ResourceList{
+						corev1.ResourceMemory: resource.MustParse("512Mi"),
+						corev1.ResourceCPU:    resource.MustParse("200m"),
+					},
+					Limits: corev1.ResourceList{
+						corev1.ResourceMemory: resource.MustParse("2Gi"),
+						corev1.ResourceCPU:    resource.MustParse("3"),
+					},
+				},
+			},
+			defaultRequirements: map[string]*corev1.ResourceRequirements{
+				"test-1": defaultResourceRequirements.DeepCopy(),
+				"test-2": defaultResourceRequirements.DeepCopy(),
+				"test-3": defaultResourceRequirements.DeepCopy(),
+			},
+			expectedRequirements: map[string]*corev1.ResourceRequirements{
+				"test-1": &corev1.ResourceRequirements{
+					Requests: corev1.ResourceList{
+						corev1.ResourceMemory: resource.MustParse("16Mi"),
+						corev1.ResourceCPU:    resource.MustParse("10m"),
+					},
+					Limits: corev1.ResourceList{
+						corev1.ResourceMemory: resource.MustParse("32Mi"),
+						corev1.ResourceCPU:    resource.MustParse("100m"),
+					},
+				},
+				"test-2": &corev1.ResourceRequirements{
+					Requests: corev1.ResourceList{
+						corev1.ResourceMemory: resource.MustParse("512Mi"),
+						corev1.ResourceCPU:    resource.MustParse("200m"),
+					},
+					Limits: corev1.ResourceList{
+						corev1.ResourceMemory: resource.MustParse("2Gi"),
+						corev1.ResourceCPU:    resource.MustParse("3"),
+					},
+				},
+				"test-3": &corev1.ResourceRequirements{
+					Requests: corev1.ResourceList{
+						corev1.ResourceMemory: resource.MustParse("1Gi"),
+						corev1.ResourceCPU:    resource.MustParse("500m"),
+					},
+					Limits: corev1.ResourceList{
+						corev1.ResourceMemory: resource.MustParse("2Gi"),
+						corev1.ResourceCPU:    resource.MustParse("1"),
+					},
+				},
+			},
+		},
+		{
+			name: "resource requirements set by vpa-updater (multiple containers, one using overrides, one defaults)",
+			containers: []corev1.Container{
+				{
+					Name: "test-1",
+				},
+				{
+					Name: "test-2",
+				},
+				{
+					Name: "test-3",
+				},
+			},
+			annotations: map[string]string{
+				kubermaticv1.UpdatedByVPALabelKey: `[{"name":"test-3","requires":{"limits":{"cpu":"1","memory":"2Gi"},"requests":{"cpu":"500m","memory":"1Gi"}}}]`,
+			},
+			overrides: map[string]*corev1.ResourceRequirements{
+				"test-2": &corev1.ResourceRequirements{
+					Requests: corev1.ResourceList{
+						corev1.ResourceMemory: resource.MustParse("512Mi"),
+						corev1.ResourceCPU:    resource.MustParse("200m"),
+					},
+					Limits: corev1.ResourceList{
+						corev1.ResourceMemory: resource.MustParse("2Gi"),
+						corev1.ResourceCPU:    resource.MustParse("3"),
+					},
+				},
+			},
+			defaultRequirements: map[string]*corev1.ResourceRequirements{
+				"test-1": defaultResourceRequirements.DeepCopy(),
+				"test-2": defaultResourceRequirements.DeepCopy(),
+				"test-3": defaultResourceRequirements.DeepCopy(),
+			},
+			expectedRequirements: map[string]*corev1.ResourceRequirements{
+				"test-1": defaultResourceRequirements.DeepCopy(),
+				"test-2": &corev1.ResourceRequirements{
+					Requests: corev1.ResourceList{
+						corev1.ResourceMemory: resource.MustParse("512Mi"),
+						corev1.ResourceCPU:    resource.MustParse("200m"),
+					},
+					Limits: corev1.ResourceList{
+						corev1.ResourceMemory: resource.MustParse("2Gi"),
+						corev1.ResourceCPU:    resource.MustParse("3"),
+					},
+				},
+				"test-3": &corev1.ResourceRequirements{
+					Requests: corev1.ResourceList{
+						corev1.ResourceMemory: resource.MustParse("1Gi"),
+						corev1.ResourceCPU:    resource.MustParse("500m"),
+					},
+					Limits: corev1.ResourceList{
+						corev1.ResourceMemory: resource.MustParse("2Gi"),
+						corev1.ResourceCPU:    resource.MustParse("1"),
+					},
+				},
+			},
+		},
+		{
+			name: "empty vpa label (expected to take defaults)",
+			containers: []corev1.Container{
+				{
+					Name: "test-1",
+				},
+			},
+			annotations: map[string]string{
+				kubermaticv1.UpdatedByVPALabelKey: "",
+			},
+			defaultRequirements: map[string]*corev1.ResourceRequirements{
+				"test-1": defaultResourceRequirements.DeepCopy(),
+			},
+			expectedRequirements: map[string]*corev1.ResourceRequirements{
+				"test-1": defaultResourceRequirements.DeepCopy(),
+			},
+		},
+		{
+			name: "no vpa label (expected to take defaults)",
+			containers: []corev1.Container{
+				{
+					Name: "test-1",
+				},
+			},
+			annotations: map[string]string{},
+			defaultRequirements: map[string]*corev1.ResourceRequirements{
+				"test-1": defaultResourceRequirements.DeepCopy(),
+			},
+			expectedRequirements: map[string]*corev1.ResourceRequirements{
+				"test-1": defaultResourceRequirements.DeepCopy(),
+			},
+		},
+		{
+			name: "two containers, no vpa label, both containers with overrides",
+			containers: []corev1.Container{
+				{
+					Name: "test-1",
+				},
+				{
+					Name: "test-2",
+				},
+			},
+			annotations: map[string]string{},
+			overrides: map[string]*corev1.ResourceRequirements{
+				"test-1": &corev1.ResourceRequirements{
+					Requests: corev1.ResourceList{
+						corev1.ResourceMemory: resource.MustParse("16Mi"),
+						corev1.ResourceCPU:    resource.MustParse("10m"),
+					},
+					Limits: corev1.ResourceList{
+						corev1.ResourceMemory: resource.MustParse("32Mi"),
+						corev1.ResourceCPU:    resource.MustParse("100m"),
+					},
+				},
+				"test-2": &corev1.ResourceRequirements{
+					Requests: corev1.ResourceList{
+						corev1.ResourceMemory: resource.MustParse("1Gi"),
+						corev1.ResourceCPU:    resource.MustParse("500m"),
+					},
+					Limits: corev1.ResourceList{
+						corev1.ResourceMemory: resource.MustParse("2Gi"),
+						corev1.ResourceCPU:    resource.MustParse("1"),
+					},
+				},
+			},
+			defaultRequirements: map[string]*corev1.ResourceRequirements{
+				"test-1": defaultResourceRequirements.DeepCopy(),
+				"test-2": defaultResourceRequirements.DeepCopy(),
+			},
+			expectedRequirements: map[string]*corev1.ResourceRequirements{
+				"test-1": &corev1.ResourceRequirements{
+					Requests: corev1.ResourceList{
+						corev1.ResourceMemory: resource.MustParse("16Mi"),
+						corev1.ResourceCPU:    resource.MustParse("10m"),
+					},
+					Limits: corev1.ResourceList{
+						corev1.ResourceMemory: resource.MustParse("32Mi"),
+						corev1.ResourceCPU:    resource.MustParse("100m"),
+					},
+				},
+				"test-2": &corev1.ResourceRequirements{
+					Requests: corev1.ResourceList{
+						corev1.ResourceMemory: resource.MustParse("1Gi"),
+						corev1.ResourceCPU:    resource.MustParse("500m"),
+					},
+					Limits: corev1.ResourceList{
+						corev1.ResourceMemory: resource.MustParse("2Gi"),
+						corev1.ResourceCPU:    resource.MustParse("1"),
+					},
+				},
+			},
+		},
+		{
+			name: "one container, no vpa label, only cpu requirements set",
+			containers: []corev1.Container{
+				{
+					Name: "test-1",
+				},
+			},
+			annotations: map[string]string{},
+			defaultRequirements: map[string]*corev1.ResourceRequirements{
+				"test-1": &corev1.ResourceRequirements{
+					Requests: corev1.ResourceList{
+						corev1.ResourceCPU: resource.MustParse("100m"),
+					},
+					Limits: corev1.ResourceList{
+						corev1.ResourceCPU: resource.MustParse("200m"),
+					},
+				},
+			},
+			expectedRequirements: map[string]*corev1.ResourceRequirements{
+				"test-1": &corev1.ResourceRequirements{
+					Requests: corev1.ResourceList{
+						corev1.ResourceCPU: resource.MustParse("100m"),
+					},
+					Limits: corev1.ResourceList{
+						corev1.ResourceCPU: resource.MustParse("200m"),
+					},
+				},
+			},
+		},
+		{
+			name: "one container, no vpa label, no resource requirements",
+			containers: []corev1.Container{
+				{
+					Name: "test-1",
+				},
+			},
+			annotations: map[string]string{},
+			defaultRequirements: map[string]*corev1.ResourceRequirements{
+				"test-1": &corev1.ResourceRequirements{},
+			},
+			expectedRequirements: map[string]*corev1.ResourceRequirements{
+				"test-1": &corev1.ResourceRequirements{},
+			},
+		},
+		{
+			name: "default requirements containing more containers then expected",
+			containers: []corev1.Container{
+				{
+					Name: "test-2",
+				},
+			},
+			annotations: map[string]string{},
+			defaultRequirements: map[string]*corev1.ResourceRequirements{
+				"test-1": defaultResourceRequirements.DeepCopy(),
+				"test-2": defaultResourceRequirements.DeepCopy(),
+			},
+			expectedRequirements: map[string]*corev1.ResourceRequirements{
+				"test-2": defaultResourceRequirements.DeepCopy(),
+			},
+		},
 	}
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
-			// err := SetResourceRequirements(tc.containers, tc.defaultRequirements, tc.annotations)
-			// if err != nil {
-			// 	t.Fatalf("error: %v", err)
-			// }
-			// for _, container := range tc.containers {
-			// 	fmt.Println(container.Resources.Limits.Memory().MilliValue())
-			// 	fmt.Println(tc.expectedRequirements["test"].Limits.Memory().MilliValue())
-			// 	if !reflect.DeepEqual(container.Resources, tc.expectedRequirements) {
-			// 		t.Errorf("invalid resource requirements. expected: %#v, but got %#v", tc.expectedRequirements, container.Resources)
-			// 	}
-			// }
+			err := SetResourceRequirements(tc.containers, tc.defaultRequirements, tc.overrides, tc.annotations)
+			if err != nil {
+				t.Fatalf("error: %v", err)
+			}
+			for _, container := range tc.containers {
+				if tc.expectedRequirements[container.Name].Requests.Cpu() != nil && !container.Resources.Requests.Cpu().Equal(*tc.expectedRequirements[container.Name].Requests.Cpu()) {
+					t.Errorf("invalid resource requirements: expected requested cpu %v, but got %v", container.Resources.Requests.Cpu(), tc.expectedRequirements[container.Name].Requests.Cpu())
+				}
+				if tc.expectedRequirements[container.Name].Requests.Memory() != nil && !container.Resources.Requests.Memory().Equal(*tc.expectedRequirements[container.Name].Requests.Memory()) {
+					t.Errorf("invalid resource requirements: expected requested memory %v, but got %v", container.Resources.Requests.Memory(), tc.expectedRequirements[container.Name].Requests.Memory())
+				}
+				if tc.expectedRequirements[container.Name].Limits.Cpu() != nil && !container.Resources.Limits.Cpu().Equal(*tc.expectedRequirements[container.Name].Limits.Cpu()) {
+					t.Errorf("invalid resource requirements: expected cpu limit %v, but got %v", container.Resources.Requests.Cpu(), tc.expectedRequirements[container.Name].Requests.Cpu())
+				}
+				if tc.expectedRequirements[container.Name].Limits.Memory() != nil && !container.Resources.Limits.Memory().Equal(*tc.expectedRequirements[container.Name].Limits.Memory()) {
+					t.Errorf("invalid resource requirements: expected memory limit %v, but got %v", container.Resources.Limits.Memory(), tc.expectedRequirements[container.Name].Limits.Memory())
+				}
+			}
 		})
 	}
 }

--- a/api/pkg/resources/resources_test.go
+++ b/api/pkg/resources/resources_test.go
@@ -117,7 +117,7 @@ func TestSetResourceRequirements(t *testing.T) {
 				"test": defaultResourceRequirements.DeepCopy(),
 			},
 			expectedRequirements: map[string]*corev1.ResourceRequirements{
-				"test": &corev1.ResourceRequirements{
+				"test": {
 					Requests: corev1.ResourceList{
 						corev1.ResourceMemory: resource.MustParse("64Mi"),
 						corev1.ResourceCPU:    resource.MustParse("20m"),
@@ -151,7 +151,7 @@ func TestSetResourceRequirements(t *testing.T) {
 				"test-3": defaultResourceRequirements.DeepCopy(),
 			},
 			expectedRequirements: map[string]*corev1.ResourceRequirements{
-				"test-1": &corev1.ResourceRequirements{
+				"test-1": {
 					Requests: corev1.ResourceList{
 						corev1.ResourceMemory: resource.MustParse("16Mi"),
 						corev1.ResourceCPU:    resource.MustParse("10m"),
@@ -161,7 +161,7 @@ func TestSetResourceRequirements(t *testing.T) {
 						corev1.ResourceCPU:    resource.MustParse("100m"),
 					},
 				},
-				"test-2": &corev1.ResourceRequirements{
+				"test-2": {
 					Requests: corev1.ResourceList{
 						corev1.ResourceMemory: resource.MustParse("64Mi"),
 						corev1.ResourceCPU:    resource.MustParse("20m"),
@@ -171,7 +171,7 @@ func TestSetResourceRequirements(t *testing.T) {
 						corev1.ResourceCPU:    resource.MustParse("2"),
 					},
 				},
-				"test-3": &corev1.ResourceRequirements{
+				"test-3": {
 					Requests: corev1.ResourceList{
 						corev1.ResourceMemory: resource.MustParse("1Gi"),
 						corev1.ResourceCPU:    resource.MustParse("500m"),
@@ -205,7 +205,7 @@ func TestSetResourceRequirements(t *testing.T) {
 				"test-3": defaultResourceRequirements.DeepCopy(),
 			},
 			expectedRequirements: map[string]*corev1.ResourceRequirements{
-				"test-1": &corev1.ResourceRequirements{
+				"test-1": {
 					Requests: corev1.ResourceList{
 						corev1.ResourceMemory: resource.MustParse("16Mi"),
 						corev1.ResourceCPU:    resource.MustParse("10m"),
@@ -216,7 +216,7 @@ func TestSetResourceRequirements(t *testing.T) {
 					},
 				},
 				"test-2": defaultResourceRequirements.DeepCopy(),
-				"test-3": &corev1.ResourceRequirements{
+				"test-3": {
 					Requests: corev1.ResourceList{
 						corev1.ResourceMemory: resource.MustParse("1Gi"),
 						corev1.ResourceCPU:    resource.MustParse("500m"),
@@ -245,7 +245,7 @@ func TestSetResourceRequirements(t *testing.T) {
 				kubermaticv1.UpdatedByVPALabelKey: `[{"name":"test-1","requires":{"limits":{"cpu":"100m","memory":"32Mi"},"requests":{"cpu":"10m","memory":"16Mi"}}},{"name":"test-3","requires":{"limits":{"cpu":"1","memory":"2Gi"},"requests":{"cpu":"500m","memory":"1Gi"}}}]`,
 			},
 			overrides: map[string]*corev1.ResourceRequirements{
-				"test-2": &corev1.ResourceRequirements{
+				"test-2": {
 					Requests: corev1.ResourceList{
 						corev1.ResourceMemory: resource.MustParse("512Mi"),
 						corev1.ResourceCPU:    resource.MustParse("200m"),
@@ -262,7 +262,7 @@ func TestSetResourceRequirements(t *testing.T) {
 				"test-3": defaultResourceRequirements.DeepCopy(),
 			},
 			expectedRequirements: map[string]*corev1.ResourceRequirements{
-				"test-1": &corev1.ResourceRequirements{
+				"test-1": {
 					Requests: corev1.ResourceList{
 						corev1.ResourceMemory: resource.MustParse("16Mi"),
 						corev1.ResourceCPU:    resource.MustParse("10m"),
@@ -272,7 +272,7 @@ func TestSetResourceRequirements(t *testing.T) {
 						corev1.ResourceCPU:    resource.MustParse("100m"),
 					},
 				},
-				"test-2": &corev1.ResourceRequirements{
+				"test-2": {
 					Requests: corev1.ResourceList{
 						corev1.ResourceMemory: resource.MustParse("512Mi"),
 						corev1.ResourceCPU:    resource.MustParse("200m"),
@@ -282,7 +282,7 @@ func TestSetResourceRequirements(t *testing.T) {
 						corev1.ResourceCPU:    resource.MustParse("3"),
 					},
 				},
-				"test-3": &corev1.ResourceRequirements{
+				"test-3": {
 					Requests: corev1.ResourceList{
 						corev1.ResourceMemory: resource.MustParse("1Gi"),
 						corev1.ResourceCPU:    resource.MustParse("500m"),
@@ -311,7 +311,7 @@ func TestSetResourceRequirements(t *testing.T) {
 				kubermaticv1.UpdatedByVPALabelKey: `[{"name":"test-3","requires":{"limits":{"cpu":"1","memory":"2Gi"},"requests":{"cpu":"500m","memory":"1Gi"}}}]`,
 			},
 			overrides: map[string]*corev1.ResourceRequirements{
-				"test-2": &corev1.ResourceRequirements{
+				"test-2": {
 					Requests: corev1.ResourceList{
 						corev1.ResourceMemory: resource.MustParse("512Mi"),
 						corev1.ResourceCPU:    resource.MustParse("200m"),
@@ -329,7 +329,7 @@ func TestSetResourceRequirements(t *testing.T) {
 			},
 			expectedRequirements: map[string]*corev1.ResourceRequirements{
 				"test-1": defaultResourceRequirements.DeepCopy(),
-				"test-2": &corev1.ResourceRequirements{
+				"test-2": {
 					Requests: corev1.ResourceList{
 						corev1.ResourceMemory: resource.MustParse("512Mi"),
 						corev1.ResourceCPU:    resource.MustParse("200m"),
@@ -339,7 +339,7 @@ func TestSetResourceRequirements(t *testing.T) {
 						corev1.ResourceCPU:    resource.MustParse("3"),
 					},
 				},
-				"test-3": &corev1.ResourceRequirements{
+				"test-3": {
 					Requests: corev1.ResourceList{
 						corev1.ResourceMemory: resource.MustParse("1Gi"),
 						corev1.ResourceCPU:    resource.MustParse("500m"),
@@ -395,7 +395,7 @@ func TestSetResourceRequirements(t *testing.T) {
 			},
 			annotations: map[string]string{},
 			overrides: map[string]*corev1.ResourceRequirements{
-				"test-1": &corev1.ResourceRequirements{
+				"test-1": {
 					Requests: corev1.ResourceList{
 						corev1.ResourceMemory: resource.MustParse("16Mi"),
 						corev1.ResourceCPU:    resource.MustParse("10m"),
@@ -405,7 +405,7 @@ func TestSetResourceRequirements(t *testing.T) {
 						corev1.ResourceCPU:    resource.MustParse("100m"),
 					},
 				},
-				"test-2": &corev1.ResourceRequirements{
+				"test-2": {
 					Requests: corev1.ResourceList{
 						corev1.ResourceMemory: resource.MustParse("1Gi"),
 						corev1.ResourceCPU:    resource.MustParse("500m"),
@@ -421,7 +421,7 @@ func TestSetResourceRequirements(t *testing.T) {
 				"test-2": defaultResourceRequirements.DeepCopy(),
 			},
 			expectedRequirements: map[string]*corev1.ResourceRequirements{
-				"test-1": &corev1.ResourceRequirements{
+				"test-1": {
 					Requests: corev1.ResourceList{
 						corev1.ResourceMemory: resource.MustParse("16Mi"),
 						corev1.ResourceCPU:    resource.MustParse("10m"),
@@ -431,7 +431,7 @@ func TestSetResourceRequirements(t *testing.T) {
 						corev1.ResourceCPU:    resource.MustParse("100m"),
 					},
 				},
-				"test-2": &corev1.ResourceRequirements{
+				"test-2": {
 					Requests: corev1.ResourceList{
 						corev1.ResourceMemory: resource.MustParse("1Gi"),
 						corev1.ResourceCPU:    resource.MustParse("500m"),
@@ -452,7 +452,7 @@ func TestSetResourceRequirements(t *testing.T) {
 			},
 			annotations: map[string]string{},
 			defaultRequirements: map[string]*corev1.ResourceRequirements{
-				"test-1": &corev1.ResourceRequirements{
+				"test-1": {
 					Requests: corev1.ResourceList{
 						corev1.ResourceCPU: resource.MustParse("100m"),
 					},
@@ -462,7 +462,7 @@ func TestSetResourceRequirements(t *testing.T) {
 				},
 			},
 			expectedRequirements: map[string]*corev1.ResourceRequirements{
-				"test-1": &corev1.ResourceRequirements{
+				"test-1": {
 					Requests: corev1.ResourceList{
 						corev1.ResourceCPU: resource.MustParse("100m"),
 					},
@@ -481,10 +481,10 @@ func TestSetResourceRequirements(t *testing.T) {
 			},
 			annotations: map[string]string{},
 			defaultRequirements: map[string]*corev1.ResourceRequirements{
-				"test-1": &corev1.ResourceRequirements{},
+				"test-1": {},
 			},
 			expectedRequirements: map[string]*corev1.ResourceRequirements{
-				"test-1": &corev1.ResourceRequirements{},
+				"test-1": {},
 			},
 		},
 		{

--- a/api/pkg/resources/scheduler/deployment.go
+++ b/api/pkg/resources/scheduler/deployment.go
@@ -127,11 +127,7 @@ func DeploymentCreator(data *resources.TemplateData) reconciling.NamedDeployment
 				name:                defaultResourceRequirements.DeepCopy(),
 				openvpnSidecar.Name: openvpnSidecar.Resources.DeepCopy(),
 			}
-			overrides := map[string]*corev1.ResourceRequirements{}
-			if data.Cluster().Spec.ComponentsOverride.Scheduler.Resources != nil {
-				overrides[name] = data.Cluster().Spec.ComponentsOverride.Scheduler.Resources.DeepCopy()
-			}
-			err = resources.SetResourceRequirements(dep.Spec.Template.Spec.Containers, defResourceRequirements, overrides, dep.Annotations)
+			err = resources.SetResourceRequirements(dep.Spec.Template.Spec.Containers, defResourceRequirements, data.Cluster().Spec.ComponentsOverride.GetOverrides(), dep.Annotations)
 			if err != nil {
 				return nil, fmt.Errorf("failed to set resource requirements: %v", err)
 			}

--- a/api/pkg/resources/scheduler/deployment.go
+++ b/api/pkg/resources/scheduler/deployment.go
@@ -86,7 +86,7 @@ func DeploymentCreator(data *resources.TemplateData) reconciling.NamedDeployment
 			dep.Spec.Template.Spec.Containers = []corev1.Container{
 				*openvpnSidecar,
 				{
-					Name:    name,
+					Name:    resources.SchedulerDeploymentName,
 					Image:   data.ImageRegistry(resources.RegistryGCR) + "/google_containers/hyperkube-amd64:v" + data.Cluster().Spec.Version.String(),
 					Command: []string{"/hyperkube", "kube-scheduler"},
 					Args:    flags,
@@ -127,7 +127,7 @@ func DeploymentCreator(data *resources.TemplateData) reconciling.NamedDeployment
 				name:                defaultResourceRequirements.DeepCopy(),
 				openvpnSidecar.Name: openvpnSidecar.Resources.DeepCopy(),
 			}
-			err = resources.SetResourceRequirements(dep.Spec.Template.Spec.Containers, defResourceRequirements, data.Cluster().Spec.ComponentsOverride.GetOverrides(), dep.Annotations)
+			err = resources.SetResourceRequirements(dep.Spec.Template.Spec.Containers, defResourceRequirements, resources.GetOverrides(data.Cluster().Spec.ComponentsOverride), dep.Annotations)
 			if err != nil {
 				return nil, fmt.Errorf("failed to set resource requirements: %v", err)
 			}

--- a/api/pkg/resources/usercluster/deployment.go
+++ b/api/pkg/resources/usercluster/deployment.go
@@ -20,7 +20,7 @@ import (
 
 var (
 	defaultResourceRequirements = map[string]*corev1.ResourceRequirements{
-		name: &corev1.ResourceRequirements{
+		name: {
 			Requests: corev1.ResourceList{
 				corev1.ResourceMemory: resource.MustParse("32Mi"),
 				corev1.ResourceCPU:    resource.MustParse("25m"),

--- a/api/pkg/resources/usercluster/deployment.go
+++ b/api/pkg/resources/usercluster/deployment.go
@@ -145,7 +145,6 @@ func DeploymentCreator(data userclusterControllerData, openshift bool) reconcili
 							},
 						},
 					},
-					Resources: defaultResourceRequirements,
 					ReadinessProbe: &corev1.Probe{
 						Handler: corev1.Handler{
 							HTTPGet: &corev1.HTTPGetAction{
@@ -167,6 +166,12 @@ func DeploymentCreator(data userclusterControllerData, openshift bool) reconcili
 						},
 					},
 				},
+			}
+			err = resources.SetResourceRequirements(dep.Spec.Template.Spec.Containers, map[string]*corev1.ResourceRequirements{
+				name: defaultResourceRequirements.DeepCopy(),
+			}, nil, dep.Annotations)
+			if err != nil {
+				return nil, fmt.Errorf("failed to set resource requirements: %v", err)
 			}
 			dep.Spec.Template.Spec.ServiceAccountName = serviceAccountName
 

--- a/api/pkg/resources/usercluster/deployment.go
+++ b/api/pkg/resources/usercluster/deployment.go
@@ -19,14 +19,16 @@ import (
 )
 
 var (
-	defaultResourceRequirements = corev1.ResourceRequirements{
-		Requests: corev1.ResourceList{
-			corev1.ResourceMemory: resource.MustParse("32Mi"),
-			corev1.ResourceCPU:    resource.MustParse("25m"),
-		},
-		Limits: corev1.ResourceList{
-			corev1.ResourceMemory: resource.MustParse("512Mi"),
-			corev1.ResourceCPU:    resource.MustParse("500m"),
+	defaultResourceRequirements = map[string]*corev1.ResourceRequirements{
+		name: &corev1.ResourceRequirements{
+			Requests: corev1.ResourceList{
+				corev1.ResourceMemory: resource.MustParse("32Mi"),
+				corev1.ResourceCPU:    resource.MustParse("25m"),
+			},
+			Limits: corev1.ResourceList{
+				corev1.ResourceMemory: resource.MustParse("512Mi"),
+				corev1.ResourceCPU:    resource.MustParse("500m"),
+			},
 		},
 	}
 )
@@ -167,9 +169,7 @@ func DeploymentCreator(data userclusterControllerData, openshift bool) reconcili
 					},
 				},
 			}
-			err = resources.SetResourceRequirements(dep.Spec.Template.Spec.Containers, map[string]*corev1.ResourceRequirements{
-				name: defaultResourceRequirements.DeepCopy(),
-			}, nil, dep.Annotations)
+			err = resources.SetResourceRequirements(dep.Spec.Template.Spec.Containers, defaultResourceRequirements, nil, dep.Annotations)
 			if err != nil {
 				return nil, fmt.Errorf("failed to set resource requirements: %v", err)
 			}


### PR DESCRIPTION
**What this PR does / why we need it**:

Relevant to the upcoming `vpa-updater` controller (#4763).

This PR ensures that controllers will not override the resource requests set by `vpa-updater`. This is done by checking is there the annotation set by `vpa-updater`.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Relevant to #4763 #3213

**Does this PR introduce a user-facing change?**:
```release-note
NONE
```

/assign @alvaroaleman 