### PR TITLE
Handle unready Caches

### DIFF
--- a/api/cmd/master-controller-manager/controllers.go
+++ b/api/cmd/master-controller-manager/controllers.go
@@ -6,7 +6,7 @@ import (
 
 	"go.uber.org/zap"
 
-	"github.com/kubermatic/kubermatic/api/pkg/controller/project-label-synchronizer"
+	projectlabelsynchronizer "github.com/kubermatic/kubermatic/api/pkg/controller/project-label-synchronizer"
 	"github.com/kubermatic/kubermatic/api/pkg/controller/rbac"
 	seedcontrollerlifecycle "github.com/kubermatic/kubermatic/api/pkg/controller/seed-controller-lifecycle"
 	seedproxy "github.com/kubermatic/kubermatic/api/pkg/controller/seed-proxy"
@@ -172,7 +172,7 @@ func projectLabelSynchronizerFactoryCreator(ctrlCtx *controllerContext) seedcont
 			seedManagerMap,
 			ctrlCtx.log,
 			ctrlCtx.workerCount,
-			ctrlCtx.workerNameLabelSelector)
+			ctrlCtx.workerName)
 	}
 	return func(mgr manager.Manager) (string, error) {
 		return projectlabelsynchronizer.ControllerName, factory(mgr)

--- a/api/pkg/controller/util/util.go
+++ b/api/pkg/controller/util/util.go
@@ -12,6 +12,7 @@ import (
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/apimachinery/pkg/types"
 	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
+	"sigs.k8s.io/controller-runtime/pkg/cache"
 	ctrlruntimeclient "sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/handler"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
@@ -149,4 +150,15 @@ func ConcurrencyLimitReached(ctx context.Context, client ctrlruntimeclient.Clien
 	clustersUpdatingInProgressCount := len(clusters.Items) - finishedUpdatingClustersCount
 
 	return clustersUpdatingInProgressCount >= limit, nil
+}
+
+// IsCacheNotStarted returns true if the given error is not nil and an instance of
+// cache.ErrCacheNotStarted.
+func IsCacheNotStarted(err error) bool {
+	if err == nil {
+		return false
+	}
+
+	_, ok := err.(*cache.ErrCacheNotStarted)
+	return ok
 }

--- a/api/pkg/controller/util/util.go
+++ b/api/pkg/controller/util/util.go
@@ -38,13 +38,18 @@ func EnqueueClusterForNamespacedObject(client ctrlruntimeclient.Client) *handler
 // EnqueueClusterForNamespacedObjectWithSeedName enqueues the cluster that owns a namespaced object,
 // if any. The seedName is put into the namespace field
 // It is used by various controllers to react to changes in the resources in the cluster namespace
-func EnqueueClusterForNamespacedObjectWithSeedName(client ctrlruntimeclient.Client, seedName string) *handler.EnqueueRequestsFromMapFunc {
+func EnqueueClusterForNamespacedObjectWithSeedName(client ctrlruntimeclient.Client, seedName string, clusterSelector labels.Selector) *handler.EnqueueRequestsFromMapFunc {
 	return &handler.EnqueueRequestsFromMapFunc{ToRequests: handler.ToRequestsFunc(func(a handler.MapObject) []reconcile.Request {
 		clusterList := &kubermaticv1.ClusterList{}
-		if err := client.List(context.Background(), clusterList); err != nil {
+		listOpts := &ctrlruntimeclient.ListOptions{
+			LabelSelector: clusterSelector,
+		}
+
+		if err := client.List(context.Background(), clusterList, listOpts); err != nil {
 			utilruntime.HandleError(fmt.Errorf("failed to list Clusters: %v", err))
 			return []reconcile.Request{}
 		}
+
 		for _, cluster := range clusterList.Items {
 			if cluster.Status.NamespaceName == a.Meta.GetNamespace() {
 				return []reconcile.Request{{NamespacedName: types.NamespacedName{
@@ -65,6 +70,7 @@ func EnqueueClusterScopedObjectWithSeedName(seedName string) *handler.EnqueueReq
 		if a.Meta.GetNamespace() != "" {
 			utilruntime.HandleError(fmt.Errorf("EnqueueClusterScopedObjectWithSeedName was used with namespace scoped object %s/%s of type %T", a.Meta.GetNamespace(), a.Meta.GetName(), a.Object))
 		}
+
 		return []reconcile.Request{{NamespacedName: types.NamespacedName{
 			Namespace: seedName,
 			Name:      a.Meta.GetName(),


### PR DESCRIPTION
**What this PR does / why we need it**:
Currently when the master-controller-manager starts up and acquired its leader lease, the usersshkeysyncer and projectlabelsyncer controllers will attempt to reconcile as soon as possible. This causes problems because the caches have not yet been started, so the pod is logging a bunch of serious sounding errors with stacktraces. This is especially misleading when debugging something, because you fetch the pod's logs and are greeted with many errors.

This PR extends the two controllers a bit to

1. Handle the worker-name labels as early as possible. This is not strictly required to fix the errors, but makes the controller play nicer when other Kubermatic installations are in the same cluster (as we now have due to the Operator and me testing it on dev).
2. Return the `ErrCacheNotStarted` so that we can handle it gracefully and simply retry.

**Does this PR introduce a user-facing change?**:
```release-note
NONE
```