### PR TITLE
Return correct CloudProviderName for GCP

### DIFF
--- a/api/pkg/resources/data.go
+++ b/api/pkg/resources/data.go
@@ -344,7 +344,9 @@ func GetKubernetesCloudProviderName(cluster *kubermaticv1.Cluster) string {
 	if cluster.Spec.Cloud.Azure != nil {
 		return "azure"
 	}
-
+	if cluster.Spec.Cloud.GCP != nil {
+		return "gce"
+	}
 	return ""
 }
 


### PR DESCRIPTION
**What this PR does / why we need it**:

Return correct CloudProviderName when using GCP provider. 

```release-note
NONE
```