### PR TITLE
Share seed managers across controllers in seed-controller-lifecycle

### DIFF
--- a/api/cmd/kubermatic-operator/main.go
+++ b/api/cmd/kubermatic-operator/main.go
@@ -37,6 +37,8 @@ type controllerRunOptions struct {
 }
 
 func main() {
+	ctx := context.Background()
+
 	klog.InitFlags(nil)
 	pprofOpts := &pprof.Opts{}
 	pprofOpts.AddFlags(flag.CommandLine)
@@ -92,8 +94,6 @@ func main() {
 		log.Fatalw("Failed to register scheme", zap.Stringer("api", certmanagerv1alpha2.SchemeGroupVersion), zap.Error(err))
 	}
 
-	ctx, cancel := context.WithCancel(context.Background())
-	defer cancel()
 
 	seedsGetter, err := provider.SeedsGetterFactory(ctx, mgr.GetClient(), "", opt.namespace, true)
 	if err != nil {
@@ -109,7 +109,7 @@ func main() {
 		log.Fatalw("Failed to add operator-master controller", zap.Error(err))
 	}
 
-	seedOperatorControllerFactory := func(mgr manager.Manager, seedManagerMap map[string]manager.Manager) (string, error) {
+	seedOperatorControllerFactory := func(ctx context.Context, mgr manager.Manager, seedManagerMap map[string]manager.Manager) (string, error) {
 		return seedctrl.ControllerName, seedctrl.Add(
 			ctx,
 			log,

--- a/api/cmd/kubermatic-operator/main.go
+++ b/api/cmd/kubermatic-operator/main.go
@@ -94,7 +94,6 @@ func main() {
 		log.Fatalw("Failed to register scheme", zap.Stringer("api", certmanagerv1alpha2.SchemeGroupVersion), zap.Error(err))
 	}
 
-
 	seedsGetter, err := provider.SeedsGetterFactory(ctx, mgr.GetClient(), "", opt.namespace, true)
 	if err != nil {
 		log.Fatalw("Failed to construct seedsGetter", zap.Error(err))

--- a/api/cmd/master-controller-manager/controllers.go
+++ b/api/cmd/master-controller-manager/controllers.go
@@ -4,8 +4,6 @@ import (
 	"fmt"
 	"time"
 
-	"go.uber.org/zap"
-
 	projectlabelsynchronizer "github.com/kubermatic/kubermatic/api/pkg/controller/project-label-synchronizer"
 	"github.com/kubermatic/kubermatic/api/pkg/controller/rbac"
 	seedcontrollerlifecycle "github.com/kubermatic/kubermatic/api/pkg/controller/seed-controller-lifecycle"
@@ -21,7 +19,6 @@ import (
 	"github.com/prometheus/client_golang/prometheus"
 
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/apimachinery/pkg/util/sets"
 	"k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/rest"
 	"sigs.k8s.io/controller-runtime/pkg/manager"
@@ -71,71 +68,32 @@ func rbacControllerFactoryCreator(
 	workerCount int,
 	selectorOps func(*metav1.ListOptions),
 ) seedcontrollerlifecycle.ControllerFactory {
-
+	// register metrics
 	rbacMetrics := rbac.NewMetrics()
-	seedKubeconfigRetrievalSuccessMetric := prometheus.NewGaugeVec(prometheus.GaugeOpts{
-		Namespace: "kubermatic",
-		Subsystem: "master_controller_manager",
-		Name:      "seed_kubeconfig_retrieval_success",
-		Help:      "Indicates if retrieving the kubeconfig for the given seed was successful",
-	}, []string{"seed"})
-	// GaugeVec doesn't have a func to only keep metrics with a given label value, it only
-	// has a func to delete metrics with a given label value. Hence we have to track ourselves
-	// which label values get removed
-	seedsWithMetrics := sets.NewString()
-	prometheus.MustRegister(rbacMetrics.Workers, seedKubeconfigRetrievalSuccessMetric)
+	prometheus.MustRegister(rbacMetrics.Workers)
 
-	factory := func(mgr manager.Manager) error {
-		seeds, err := seedsGetter()
-		if err != nil {
-			return fmt.Errorf("failed to get seeds: %v", err)
-		}
+	return func(mgr manager.Manager, seedManagerMap map[string]manager.Manager) (string, error) {
 		masterClusterProvider, err := rbacClusterProvider(mastercfg, "master", true, selectorOps)
 		if err != nil {
-			return fmt.Errorf("failed to create master rbac provider: %v", err)
+			return "", fmt.Errorf("failed to create master rbac provider: %v", err)
 		}
+
 		allClusterProviders := []*rbac.ClusterProvider{masterClusterProvider}
 
-		newSeedsWithMetrics := sets.NewString()
-		for _, seed := range seeds {
-			kubeConfig, err := seedKubeconfigGetter(seed)
+		for seedName, seedMgr := range seedManagerMap {
+			clusterProvider, err := rbacClusterProvider(seedMgr.GetConfig(), seedName, false, selectorOps)
 			if err != nil {
-				kubermaticlog.Logger.With("error", err).With("seed", seed.Name).Error("error getting kubeconfig")
-				// Dont let a single broken kubeconfig break the whole controller creation
-				seedKubeconfigRetrievalSuccessMetric.WithLabelValues(seed.Name).Set(0)
-				continue
-			}
-			seedKubeconfigRetrievalSuccessMetric.WithLabelValues(seed.Name).Set(1)
-			clusterProvider, err := rbacClusterProvider(kubeConfig, seed.Name, false, selectorOps)
-			if err != nil {
-				return fmt.Errorf("failed to create rbac provider for seed %q: %v", seed.Name, err)
+				return "", fmt.Errorf("failed to create rbac provider for seed %q: %v", seedName, err)
 			}
 			allClusterProviders = append(allClusterProviders, clusterProvider)
 		}
-		removedSeeds := sets.NewString(seedsWithMetrics.List()...)
-		removedSeeds.Delete(newSeedsWithMetrics.List()...)
-		_ = seedKubeconfigRetrievalSuccessMetric.DeleteLabelValues(removedSeeds.List()...)
-		seedsWithMetrics = newSeedsWithMetrics
 
 		ctrl, err := rbac.New(rbacMetrics, allClusterProviders, workerCount)
 		if err != nil {
-			return fmt.Errorf("failed to create rbac controller: %v", err)
+			return "", fmt.Errorf("failed to create rbac controller: %v", err)
 		}
 
-		return mgr.Add(manager.RunnableFunc(func(stopCh <-chan struct{}) error {
-			// This is an implementation of sigs.k8s.io/controller-runtime/pkg/manager.Runnable
-			// It wraps the actual controllers implementation to make sure informers are started first
-			for _, clusterProvider := range allClusterProviders {
-				clusterProvider.StartInformers(stopCh)
-				if err := clusterProvider.WaitForCachesToSync(stopCh); err != nil {
-					return fmt.Errorf("RBAC controller failed to sync cache: %v", err)
-				}
-			}
-			return ctrl.Start(stopCh)
-		}))
-	}
-	return func(mgr manager.Manager) (string, error) {
-		return "rbac-controller", factory(mgr)
+		return "rbac-controller", mgr.Add(ctrl)
 	}
 }
 
@@ -160,33 +118,21 @@ func rbacClusterProvider(cfg *rest.Config, name string, master bool, labelSelect
 }
 
 func projectLabelSynchronizerFactoryCreator(ctrlCtx *controllerContext) seedcontrollerlifecycle.ControllerFactory {
-	factory := func(mgr manager.Manager) error {
-		seedManagerMap, err := createSeedManagers("project-label-synchronizer-factory", ctrlCtx, mgr)
-		if err != nil {
-			return fmt.Errorf("failed build seeds managers: %v", err)
-		}
-
-		return projectlabelsynchronizer.Add(
+	return func(masterMgr manager.Manager, seedManagerMap map[string]manager.Manager) (string, error) {
+		return projectlabelsynchronizer.ControllerName, projectlabelsynchronizer.Add(
 			ctrlCtx.ctx,
-			mgr,
+			masterMgr,
 			seedManagerMap,
 			ctrlCtx.log,
 			ctrlCtx.workerCount,
-			ctrlCtx.workerName)
-	}
-	return func(mgr manager.Manager) (string, error) {
-		return projectlabelsynchronizer.ControllerName, factory(mgr)
+			ctrlCtx.workerName,
+		)
 	}
 }
 
 func userSSHKeysSynchronizerFactoryCreator(ctrlCtx *controllerContext) seedcontrollerlifecycle.ControllerFactory {
-	factory := func(mgr manager.Manager) error {
-		seedManagerMap, err := createSeedManagers("usersshkeys-synchronizer-factory", ctrlCtx, mgr)
-		if err != nil {
-			return fmt.Errorf("failed build seeds managers: %v", err)
-		}
-
-		return usersshkeyssynchronizer.Add(
+	return func(mgr manager.Manager, seedManagerMap map[string]manager.Manager) (string, error) {
+		return usersshkeyssynchronizer.ControllerName, usersshkeyssynchronizer.Add(
 			ctrlCtx.ctx,
 			mgr,
 			seedManagerMap,
@@ -195,41 +141,4 @@ func userSSHKeysSynchronizerFactoryCreator(ctrlCtx *controllerContext) seedcontr
 			ctrlCtx.workerCount,
 		)
 	}
-	return func(mgr manager.Manager) (string, error) {
-		return usersshkeyssynchronizer.ControllerName, factory(mgr)
-	}
-}
-
-func createSeedManagers(name string, ctrlCtx *controllerContext, mgr manager.Manager) (map[string]manager.Manager, error) {
-	log := ctrlCtx.log.Named(name)
-	seeds, err := ctrlCtx.seedsGetter()
-	if err != nil {
-		log.Errorw("Failed to get seeds", zap.Error(err))
-		return nil, fmt.Errorf("failed to get seeds: %v", err)
-	}
-
-	seedManagerMap := make(map[string]manager.Manager, len(seeds))
-	for seedName, seed := range seeds {
-		log := ctrlCtx.log.With("seed", seed.Name)
-		kubeconfig, err := ctrlCtx.seedKubeconfigGetter(seed)
-		if err != nil {
-			log.Errorw("Failed to get kubeconfig for seed", zap.Error(err))
-			// Don't let one defunct seed break everything. We have a metric for this
-			// in the rbac controller factory, so just log it here
-			continue
-		}
-		seedMgr, err := manager.New(kubeconfig, manager.Options{
-			MetricsBindAddress: "0",
-		})
-		if err != nil {
-			log.Errorw("Failed to construct mgr for seed", zap.Error(err))
-			continue
-		}
-		seedManagerMap[seedName] = seedMgr
-		if err := mgr.Add(seedMgr); err != nil {
-			return nil, fmt.Errorf("failed to add controller manager for seed %q to mgr: %v", seedName, err)
-		}
-	}
-
-	return seedManagerMap, nil
 }

--- a/api/cmd/master-controller-manager/controllers.go
+++ b/api/cmd/master-controller-manager/controllers.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"context"
 	"fmt"
 	"time"
 
@@ -72,7 +73,7 @@ func rbacControllerFactoryCreator(
 	rbacMetrics := rbac.NewMetrics()
 	prometheus.MustRegister(rbacMetrics.Workers)
 
-	return func(mgr manager.Manager, seedManagerMap map[string]manager.Manager) (string, error) {
+	return func(ctx context.Context, mgr manager.Manager, seedManagerMap map[string]manager.Manager) (string, error) {
 		masterClusterProvider, err := rbacClusterProvider(mastercfg, "master", true, selectorOps)
 		if err != nil {
 			return "", fmt.Errorf("failed to create master rbac provider: %v", err)
@@ -118,9 +119,9 @@ func rbacClusterProvider(cfg *rest.Config, name string, master bool, labelSelect
 }
 
 func projectLabelSynchronizerFactoryCreator(ctrlCtx *controllerContext) seedcontrollerlifecycle.ControllerFactory {
-	return func(masterMgr manager.Manager, seedManagerMap map[string]manager.Manager) (string, error) {
+	return func(ctx context.Context, masterMgr manager.Manager, seedManagerMap map[string]manager.Manager) (string, error) {
 		return projectlabelsynchronizer.ControllerName, projectlabelsynchronizer.Add(
-			ctrlCtx.ctx,
+			ctx,
 			masterMgr,
 			seedManagerMap,
 			ctrlCtx.log,
@@ -131,9 +132,9 @@ func projectLabelSynchronizerFactoryCreator(ctrlCtx *controllerContext) seedcont
 }
 
 func userSSHKeysSynchronizerFactoryCreator(ctrlCtx *controllerContext) seedcontrollerlifecycle.ControllerFactory {
-	return func(mgr manager.Manager, seedManagerMap map[string]manager.Manager) (string, error) {
+	return func(ctx context.Context, mgr manager.Manager, seedManagerMap map[string]manager.Manager) (string, error) {
 		return usersshkeyssynchronizer.ControllerName, usersshkeyssynchronizer.Add(
-			ctrlCtx.ctx,
+			ctx,
 			mgr,
 			seedManagerMap,
 			ctrlCtx.log,

--- a/api/cmd/master-controller-manager/controllers.go
+++ b/api/cmd/master-controller-manager/controllers.go
@@ -69,7 +69,6 @@ func rbacControllerFactoryCreator(
 	workerCount int,
 	selectorOps func(*metav1.ListOptions),
 ) seedcontrollerlifecycle.ControllerFactory {
-	// register metrics
 	rbacMetrics := rbac.NewMetrics()
 	prometheus.MustRegister(rbacMetrics.Workers)
 

--- a/api/pkg/controller/seed-controller-lifecycle/seed_controller_lifecycle.go
+++ b/api/pkg/controller/seed-controller-lifecycle/seed_controller_lifecycle.go
@@ -11,9 +11,11 @@ import (
 	predicateutil "github.com/kubermatic/kubermatic/api/pkg/controller/util/predicate"
 	kubermaticv1 "github.com/kubermatic/kubermatic/api/pkg/crd/kubermatic/v1"
 	"github.com/kubermatic/kubermatic/api/pkg/provider"
+	"github.com/prometheus/client_golang/prometheus"
 
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/util/sets"
 	"k8s.io/client-go/rest"
 	"sigs.k8s.io/controller-runtime/pkg/cache"
 	ctrlruntimeclient "sigs.k8s.io/controller-runtime/pkg/client"
@@ -30,6 +32,19 @@ const (
 	// We must only enqueue this one key
 	queueKey = ControllerName
 )
+
+var (
+	seedKubeconfigRetrievalSuccessMetric = prometheus.NewGaugeVec(prometheus.GaugeOpts{
+		Namespace: "kubermatic",
+		Subsystem: "master_controller_manager",
+		Name:      "seed_kubeconfig_retrieval_success",
+		Help:      "Indicates if retrieving the kubeconfig for the given seed was successful",
+	}, []string{"seed"})
+)
+
+func init() {
+	prometheus.MustRegister(seedKubeconfigRetrievalSuccessMetric)
+}
 
 type Reconciler struct {
 	ctx                  context.Context
@@ -53,7 +68,7 @@ type managerInstance struct {
 }
 
 // ControllerFactory is a function to create a new controller instance
-type ControllerFactory func(manager.Manager) (controllerName string, err error)
+type ControllerFactory func(manager.Manager, map[string]manager.Manager) (controllerName string, err error)
 
 func Add(
 	ctx context.Context,
@@ -64,7 +79,6 @@ func Add(
 	seedKubeconfigGetter provider.SeedKubeconfigGetter,
 	controllerFactories ...ControllerFactory,
 ) error {
-
 	reconciler := &Reconciler{
 		ctx:                  ctx,
 		masterKubeCfg:        mgr.GetConfig(),
@@ -125,9 +139,20 @@ func (r *Reconciler) reconcile() error {
 		if err != nil {
 			// Don't let a single broken kubeconfig break everything.
 			r.log.Errorw("failed to get kubeconfig", "seed", seed.Name, zap.Error(err))
+			seedKubeconfigRetrievalSuccessMetric.WithLabelValues(seed.Name).Set(0)
 			continue
 		}
+
 		seedKubeconfigMap[seed.Name] = *cfg
+		seedKubeconfigRetrievalSuccessMetric.WithLabelValues(seed.Name).Set(1)
+	}
+
+	// delete label combinations for non-existing seeds
+	if r.activeManager != nil {
+		removedSeeds := sets.StringKeySet(r.activeManager.config).Difference(sets.StringKeySet(seedKubeconfigMap))
+		for _, seedName := range removedSeeds.List() {
+			seedKubeconfigRetrievalSuccessMetric.DeleteLabelValues(seedName)
+		}
 	}
 
 	if r.activeManager != nil && r.activeManager.running && reflect.DeepEqual(r.activeManager.config, seedKubeconfigMap) {
@@ -135,11 +160,11 @@ func (r *Reconciler) reconcile() error {
 		return nil
 	}
 
-	// We let a controller manager run the controllers for us.
+	// We let a master controller manager run the controllers for us.
 	mgr, err := manager.New(r.masterKubeCfg, manager.Options{
 		LeaderElection:     false,
 		MetricsBindAddress: "0",
-		// Avoid duplicating caches or client for master cluster, as its static.
+		// Avoid duplicating caches or client for master cluster, as it's static.
 		NewCache: func(_ *rest.Config, _ cache.Options) (cache.Cache, error) {
 			return r.masterCache, nil
 		},
@@ -148,11 +173,17 @@ func (r *Reconciler) reconcile() error {
 		},
 	})
 	if err != nil {
-		return fmt.Errorf("failed to create controller manager: %v", err)
+		return fmt.Errorf("failed to create master controller manager: %v", err)
+	}
+
+	// create one manager per seed, so that all controllers share the same caches
+	seedManagers, err := r.createSeedManagers(mgr, seeds, seedKubeconfigMap)
+	if err != nil {
+		return fmt.Errorf("failed to create managers for all seeds: %v", err)
 	}
 
 	for _, factory := range r.controllerFactories {
-		controllerName, err := factory(mgr)
+		controllerName, err := factory(mgr, seedManagers)
 		if err != nil {
 			return fmt.Errorf("failed to construct controller %s: %v", controllerName, err)
 		}
@@ -181,5 +212,32 @@ func (r *Reconciler) reconcile() error {
 	}()
 
 	r.activeManager = mi
+
 	return nil
+}
+
+func (r *Reconciler) createSeedManagers(masterMgr manager.Manager, seeds map[string]*kubermaticv1.Seed, kubeconfigs map[string]rest.Config) (map[string]manager.Manager, error) {
+	seedManagers := make(map[string]manager.Manager, len(seeds))
+
+	for seedName, seed := range seeds {
+		kubeconfig, exists := kubeconfigs[seedName]
+		if !exists {
+			continue // we already warned earlier about the inability to retrieve the kubeconfig
+		}
+
+		log := r.log.With("seed", seed.Name)
+
+		seedMgr, err := manager.New(&kubeconfig, manager.Options{MetricsBindAddress: "0"})
+		if err != nil {
+			log.Errorw("Failed to construct manager for seed", zap.Error(err))
+			continue
+		}
+
+		seedManagers[seedName] = seedMgr
+		if err := masterMgr.Add(seedMgr); err != nil {
+			return nil, fmt.Errorf("failed to add controller manager for seed %q to master manager: %v", seedName, err)
+		}
+	}
+
+	return seedManagers, nil
 }

--- a/api/pkg/controller/seed-controller-lifecycle/seed_controller_lifecycle.go
+++ b/api/pkg/controller/seed-controller-lifecycle/seed_controller_lifecycle.go
@@ -203,6 +203,7 @@ func (r *Reconciler) reconcile() error {
 	for _, factory := range r.controllerFactories {
 		controllerName, err := factory(ctrlCtx, mgr, seedManagers)
 		if err != nil {
+			cancelCtrlCtx()
 			return fmt.Errorf("failed to construct controller %s: %v", controllerName, err)
 		}
 	}


### PR DESCRIPTION
**What this PR does / why we need it**:
This prepares a set of managers to be used by all controllers, with the purpose of improving performance and reducing memory usage. It also makes constructing controllers for the seed-lifecycle much easier. We also now give all controllers a shared context and cancel this context when we teardown the controllers again.

As a bonus this now also both fixes the seedKubeconfigSuccess metric and makes it work across all controllers.

**Does this PR introduce a user-facing change?**:
```release-note
NONE
```
