### PR TITLE
Seed components: Check if cluster is up by using HealthStatusUp

### DIFF
--- a/api/pkg/controller/seed-controller-manager/addon/addon_controller.go
+++ b/api/pkg/controller/seed-controller-manager/addon/addon_controller.go
@@ -221,8 +221,7 @@ func (r *Reconciler) reconcile(ctx context.Context, log *zap.SugaredLogger, addo
 		return nil, fmt.Errorf("failed to ensure that the isDefault field is up to date in the addon: %v", err)
 	}
 
-	// When the apiserver is not healthy, we must skip it
-	if kubermaticv1.HealthStatusDown == cluster.Status.ExtendedHealth.Apiserver {
+	if cluster.Status.ExtendedHealth.Apiserver != kubermaticv1.HealthStatusUp {
 		log.Debug("Skipping because the API server is not running")
 		return nil, nil
 	}

--- a/api/pkg/controller/seed-controller-manager/addoninstaller/addoninstaller_controller.go
+++ b/api/pkg/controller/seed-controller-manager/addoninstaller/addoninstaller_controller.go
@@ -127,7 +127,7 @@ func (r *Reconciler) reconcile(ctx context.Context, log *zap.SugaredLogger, clus
 	// This controller handles Kubernetes & OpenShift cluster.
 	// Based on the type we install different default addons
 	var addonsToInstall []string
-	if cluster.Annotations["kubermatic.io/openshift"] != "" {
+	if cluster.IsOpenshift() {
 		log = log.With("clustertype", "openshift")
 		addonsToInstall = r.openshiftAddons
 	} else {
@@ -137,7 +137,7 @@ func (r *Reconciler) reconcile(ctx context.Context, log *zap.SugaredLogger, clus
 
 	// Wait until the Apiserver is running to ensure the namespace exists at least.
 	// Just checking for cluster.status.namespaceName is not enough as it gets set before the namespace exists
-	if kubermaticv1.HealthStatusDown == cluster.Status.ExtendedHealth.Apiserver {
+	if cluster.Status.ExtendedHealth.Apiserver != kubermaticv1.HealthStatusUp {
 		log.Debug("Skipping because the API server is not running")
 		return &reconcile.Result{RequeueAfter: 1 * time.Second}, nil
 	}

--- a/api/pkg/controller/seed-controller-manager/backup/backup_controller.go
+++ b/api/pkg/controller/seed-controller-manager/backup/backup_controller.go
@@ -251,8 +251,7 @@ func (r *Reconciler) reconcile(ctx context.Context, log *zap.SugaredLogger, clus
 		return nil
 	}
 
-	// Wait until we have a running etcd
-	if kubermaticv1.HealthStatusDown == cluster.Status.ExtendedHealth.Etcd {
+	if cluster.Status.ExtendedHealth.Etcd != kubermaticv1.HealthStatusUp {
 		log.Debug("Skipping because the cluster has no running etcd yet")
 		return nil
 	}

--- a/api/pkg/controller/seed-controller-manager/kubernetes/pending.go
+++ b/api/pkg/controller/seed-controller-manager/kubernetes/pending.go
@@ -37,7 +37,7 @@ func (r *Reconciler) reconcileCluster(ctx context.Context, cluster *kubermaticv1
 		return nil, err
 	}
 
-	if cluster.Status.ExtendedHealth.Apiserver != kubermaticv1.HealthStatusDown {
+	if cluster.Status.ExtendedHealth.Apiserver == kubermaticv1.HealthStatusUp {
 		// Controlling of user-cluster resources
 		reachable, err := r.clusterIsReachable(ctx, cluster)
 		if err != nil {

--- a/api/pkg/controller/seed-controller-manager/openshift/openshift_controller.go
+++ b/api/pkg/controller/seed-controller-manager/openshift/openshift_controller.go
@@ -247,7 +247,7 @@ func (r *Reconciler) reconcile(ctx context.Context, log *zap.SugaredLogger, clus
 		return nil, fmt.Errorf("failed to sync health: %v", err)
 	}
 
-	if kubermaticv1.HealthStatusDown == cluster.Status.ExtendedHealth.Apiserver {
+	if cluster.Status.ExtendedHealth.Apiserver != kubermaticv1.HealthStatusUp {
 		// We have to wait for the APIServer to not be completely down. Changes for it
 		// will trigger us, so we can just return here.
 		return nil, nil


### PR DESCRIPTION
**What this PR does / why we need it**:

We changed the health status to be `Provisioning` for as long as the cluster hasn't been ready once and is not fully ready. This breaks our current assumption of "If its not down its up" which leads to a lot of error on initial cluster creation. This PR fixes that by checking for "up" instead.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Documentation**:
<!-- Add links to the related documentation changes related to this pull request. E.g. the link to the kubermatic/docs pullrequest. -->

**Does this PR introduce a user-facing change?**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If  no release note is required, just write "NONE".
-->
```release-note
none
```
