### PR TITLE
Use in-tree clusterexposer

### DIFF
--- a/api/hack/ci/ci-setup-kubermatic-in-kind.sh
+++ b/api/hack/ci/ci-setup-kubermatic-in-kind.sh
@@ -134,8 +134,8 @@ trap print_cluster_exposer_logs EXIT
 
 TEST_NAME="Wait for cluster exposer"
 echodate "Waiting for cluster exposer to be running"
-retry 5 curl --fail http://127.0.0.1:2047/metrics \
-  |egrep -q 'rest_client_request_latency_seconds_bucket.*GET'
+
+retry 5 curl --fail http://127.0.0.1:2047/metrics
 echodate "Cluster exposer is running"
 
 echodate "Setting up iptables rules for to make nodeports available"

--- a/api/hack/ci/ci-setup-kubermatic-in-kind.sh
+++ b/api/hack/ci/ci-setup-kubermatic-in-kind.sh
@@ -390,6 +390,9 @@ function cleanup_kubermatic_clusters_in_kind {
   set +e
   # Clean up clusters
   kubectl delete cluster --all --ignore-not-found=true
+
+  # Kill all descendant processes
+  pkill -P $$
   set -e
 
   return $originalRC

--- a/api/hack/ci/ci-setup-kubermatic-in-kind.sh
+++ b/api/hack/ci/ci-setup-kubermatic-in-kind.sh
@@ -138,6 +138,9 @@ function print_cluster_exposer_logs {
   echodate "Printing clusterexposer logs"
   cat /var/log/clusterexposer.log
   echodate "Done printing clusterexposer logs"
+
+  echodate "Sleeping for debug"
+  sleep 1h
   set -e
 
   return $originalRC

--- a/api/hack/ci/ci-setup-kubermatic-in-kind.sh
+++ b/api/hack/ci/ci-setup-kubermatic-in-kind.sh
@@ -111,20 +111,8 @@ echodate "Creating the kind cluster"
 export KUBECONFIG=~/.kube/config
 kind create cluster --name ${SEED_NAME} --image=kindest/node:v1.15.6
 
-DOCKER_CONFIG=/ docker run \
-  --name controller \
-  --detach \
-  -v ${KUBECONFIG}:/inner \
-  -v /etc/kubeconfig/kubeconfig:/outer \
-  --network host \
-  --privileged \
-  quay.io/kubermatic/cluster-exposer:v1.1.0-dev-2 \
-  --kubeconfig-inner "/inner" \
-  --kubeconfig-outer "/outer" \
-  --namespace "default" \
-  --build-id "$PROW_JOB_ID"
-
 echodate "Starting clusterexposer"
+make -C api download-gocache
 CGO_ENABLED=0 go run ./api/pkg/test/clusterexposer/cmd \
   --kubeconfig-inner "$KUBECONFIG" \
   --kubeconfig-outer "/etc/kubeconfig/kubeconfig" \
@@ -138,9 +126,6 @@ function print_cluster_exposer_logs {
   echodate "Printing clusterexposer logs"
   cat /var/log/clusterexposer.log
   echodate "Done printing clusterexposer logs"
-
-  echodate "Sleeping for debug"
-  sleep 1h
   set -e
 
   return $originalRC

--- a/api/pkg/test/clusterexposer/cmd/main.go
+++ b/api/pkg/test/clusterexposer/cmd/main.go
@@ -113,7 +113,7 @@ func run(cmd *cobra.Command, _ []string) error {
 	// Create a new Cmd to provide shared dependencies and start components
 	log.Info("Setting up inner manager")
 	mgr, err := manager.New(innerCfg, manager.Options{
-		MetricsBindAddress: "2047",
+		MetricsBindAddress: "127.0.0.1:2047",
 		Port:               0,
 	})
 	if err != nil {

--- a/api/pkg/test/clusterexposer/cmd/main.go
+++ b/api/pkg/test/clusterexposer/cmd/main.go
@@ -93,6 +93,13 @@ func run(cmd *cobra.Command, _ []string) error {
 		return fmt.Errorf("unable to set up client config for outer cluster %v", err)
 	}
 
+	// Get a config to talk to the apiserver
+	innerCfg, err := clientcmd.BuildConfigFromFlags("", kubeconfigInnerFile)
+	if err != nil {
+		return fmt.Errorf("unable to set up client config for user cluster %v", err)
+
+	}
+
 	log.Info("Setting up outer manager")
 	outerManager, err := manager.New(outerCfg, manager.Options{
 		MetricsBindAddress: "0",
@@ -100,14 +107,6 @@ func run(cmd *cobra.Command, _ []string) error {
 	})
 	if err != nil {
 		return fmt.Errorf("failed to set up inner manager: %v", err)
-	}
-
-	// Get a config to talk to the apiserver
-	log.Info("setting up client for manager")
-	innerCfg, err := clientcmd.BuildConfigFromFlags("", kubeconfigInnerFile)
-	if err != nil {
-		return fmt.Errorf("unable to set up client config for user cluster %v", err)
-
 	}
 
 	// Create a new Cmd to provide shared dependencies and start components

--- a/api/pkg/test/clusterexposer/controller/const.go
+++ b/api/pkg/test/clusterexposer/controller/const.go
@@ -15,11 +15,6 @@ const (
 	DefaultPodPortForwardWaitTimeout = 60 * time.Second
 )
 
-var (
-	// Service annotations that will be added to the expose service of the outer cluster.
-	defaultServiceAnnotations = map[string]string{"nodeport-proxy.k8s.io/expose": "true"}
-)
-
 func GenerateName(base, buildID string) string {
 	return fmt.Sprintf("%s-%s-%s", base, buildID, utilrand.String(UserClusterAPIServerServiceSuffixLength))
 }

--- a/api/pkg/test/clusterexposer/controller/controller.go
+++ b/api/pkg/test/clusterexposer/controller/controller.go
@@ -132,7 +132,8 @@ func (r *reconciler) reconcile(log *zap.SugaredLogger, request reconcile.Request
 	}
 	outerService := getServiceFromServiceList(outerServices, request.NamespacedName)
 	if outerService == nil {
-		outerService, err := r.createOuterService(request.NamespacedName.String())
+		var err error
+		outerService, err = r.createOuterService(request.NamespacedName.String())
 		if err != nil {
 			return fmt.Errorf("failed to create service in outer cluster: %v", err)
 		}


### PR DESCRIPTION
**What this PR does / why we need it**:

Updates the in-tree clusterexposer to:
* Watch services in both inner and outer cluster
* Create a nodeport service in the outer cluster for each service in the inner cluster that has a `nodeport-proxy.k8s.io/expose` annotation
* Make sure that outerservice.Targetpot and innerService.Nodeport match outerService.Nodeport
* Sets an owner Ref on the outer service pointing to the test pod, so kube cleans up for us
* Update the `ci-setup-kubermatic-in-kind.sh` script to use this
* Display the logs of the clusterexposer at the end

This solves two problems:
* We need to expose more than one service for the Kubermatic tests, because they actually test if the cluster is a valid kube cluster and that includes log/exec, for which we need the openvpn
* We don't have to take care of the cleanup anymore

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Documentation**:
<!-- Add links to the related documentation changes related to this pull request. E.g. the link to the kubermatic/docs pullrequest. -->

**Does this PR introduce a user-facing change?**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If  no release note is required, just write "NONE".
-->
```release-note
none
```
