### PR TITLE
fluentbit - fix duplicate timestamp field error

### DIFF
--- a/config/logging/fluentbit/config/kubernetes.conf
+++ b/config/logging/fluentbit/config/kubernetes.conf
@@ -18,6 +18,7 @@
    Kube_URL            https://kubernetes.default.svc.cluster.local:443
    Merge_Log           On
    Merge_Log_Trim      On
+   Merge_Log_Key       log_processed
    K8S-Logging.Parser  On
    Annotations         Off
 

--- a/config/logging/fluentbit/config/parsers.conf
+++ b/config/logging/fluentbit/config/parsers.conf
@@ -61,6 +61,7 @@
    Format       json
    Time_Key     time
    Time_Format  %Y-%m-%dT%H:%M:%S.%L%z
+   Time_Keep    Off
 
 # containerd log format
 [PARSER]


### PR DESCRIPTION
**What this PR does / why we need it**:
At some customer installation I got the alert `FluentbitManyOutputErrors` this was caused
by the error that now duplicated timestamp field could forewarded to ES:
```
{"took":11210,"errors":true,"items":[{"index":{"_index":"logstash-2019.12.06","_type":"flb_type","_id":"79f89365-f288-7983-964f-f3def60b7d7c","_version":2,"result":"updated","_shards":{"total":2,"successful":2,"failed":0},"_seq_no":1204715,"_primary_term":5,"status":200}},{"index":{"_index":"logstash-2019.12.06","_type":"flb_type","_id":"ddf1a4ed-1efc-5a4b-195c-36a00777c449","_version":1,"result":"created","_shards":{"total":2,"successful":1,"failed":0},"_seq_no":1198719,"_primary_term":5,"status":201}},{"index":{"_index":"logstash-2019.12.06","_type":"flb_type","_id":"c05cb26d-9e70-7c59-8025-10a55a9d334a","_version":1,"result":"created","_shards":{"total":2,"successful":1,"failed":0},"_seq_no":1198720,"_primary_term":5,"status":201}},{"index":{"_index":"logstash-2019.12.06","_type":"flb_type","_id":"1be7272a-7d89-c4aa-b748-099b6d3fbc07","status":429,"error":{"type":"es_rejected_execution_exception","reason":"rejected exec
[2019/12/06 23:26:10] [error] [out_es] could not pack/validate JSON response
{"took":11102,"errors":true,"items":[{"index":{"_index":"logstash-2019.12.06","_type":"flb_type","_id":"be5fdea7-bc4c-fa81-647e-e5fb1e5916e9","status":429,"error":{"type":"es_rejected_execution_exception","reason":"rejected execution of processing of [4820][indices:data/write/bulk[s][p]]: request: BulkShardRequest [[logstash-2019.12.06][4]] containing [3] requests, target allocation id: eTdEbPvhTLiKyjtYJSmlUQ, primary term: 4 on EsThreadPoolExecutor[name = es-data-1/write, queue capacity = 200, org.elasticsearch.common.util.concurrent.EsThreadPoolExecutor@5c6e5e9a[Running, pool size = 1, active threads = 1, queued tasks = 200, completed tasks = 1322]]"}}},{"index":{"_index":"logstash-2019.12.06","_type":"flb_type","_id":"ceabfd62-70a0-7257-7f25-7ea6287dba75","_version":3,"result":"updated","_shards":{"total":2,"successful":2,"failed":0},"_seq_no":1203516,"_primary_term":5,"status":200}},{"index":{"_index":"logstash-2019.12
```

Setting the filter `Merge_Log_Key` fixed this issue, like descirbed in
https://github.com/fluent/fluent-bit/issues/628#issuecomment-518316428.
I'm not sure if we should set this in general, but wanted to provide the
fix back to you.


**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Documentation**:
<!-- Add links to the related documentation changes related to this pull request. E.g. the link to the kubermatic/docs pullrequest. -->

**Does this PR introduce a user-facing change?**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If  no release note is required, just write "NONE".
-->
```release-note
NONE
```