### PR TITLE
Fix operator cleanup watches

### DIFF
--- a/api/pkg/controller/seed-sync/reconciler_test.go
+++ b/api/pkg/controller/seed-sync/reconciler_test.go
@@ -103,7 +103,7 @@ func TestReconcilingSeed(t *testing.T) {
 				},
 			}
 
-			if err := reconciler.reconcile(test.input, log); err != nil {
+			if err := reconciler.reconcile(test.input, seedClient, log); err != nil {
 				t.Fatalf("reconciling failed: %v", err)
 			}
 


### PR DESCRIPTION
**What this PR does / why we need it**:
The operator had some missing watches, so it did not notice all changes to Seeds in all clusters. This PR fixes the missing watches. It also fixes the actual cleanup procedure, where my old code was under the assumption that a .Delete() call would *block* until all finalizers are gone, which is not the case. For this reason we now have this wait loop.

**Which issue(s) this PR fixes**:
Relates to #4755

**Does this PR introduce a user-facing change?**:
```release-note
NONE
```
