### PR TITLE
deploy Kubermatic Operator in parallel on dev

### DIFF
--- a/api/hack/ci/ci-deploy-dev.sh
+++ b/api/hack/ci/ci-deploy-dev.sh
@@ -19,12 +19,15 @@ retry 5 vault write \
 export VAULT_TOKEN="$(cat /tmp/vault-token-response.json| jq .auth.client_token -r)"
 export KUBECONFIG=/tmp/kubeconfig
 export VALUES_FILE=/tmp/values.yaml
+export KUBERMATIC_CONFIG=/tmp/kubermatic.yaml
 
 # deploy to dev
 vault kv get -field=kubeconfig dev/seed-clusters/dev.kubermatic.io > ${KUBECONFIG}
 vault kv get -field=values.yaml dev/seed-clusters/dev.kubermatic.io > ${VALUES_FILE}
+vault kv get -field=kubermatic.yaml dev/seed-clusters/dev.kubermatic.io > ${KUBERMATIC_CONFIG}
 echodate "Successfully got secrets for dev from Vault"
 
 echodate "Deploying ${DEPLOY_STACK} stack to dev"
-TILLER_NAMESPACE=kubermatic-installer ./api/hack/deploy.sh master ${VALUES_FILE}
+TILLER_NAMESPACE=kubermatic-installer \
+  DEPLOY_KUBERMATIC_OPERATOR=true ./api/hack/deploy.sh master ${VALUES_FILE}
 echodate "Successfully deployed ${DEPLOY_STACK} stack to dev"

--- a/api/hack/deploy.sh
+++ b/api/hack/deploy.sh
@@ -23,6 +23,7 @@ fi
 DEPLOY_NODEPORT_PROXY=${DEPLOY_NODEPORT_PROXY:-true}
 DEPLOY_ALERTMANAGER=${DEPLOY_ALERTMANAGER:-true}
 DEPLOY_MINIO=${DEPLOY_MINIO:-true}
+DEPLOY_KUBERMATIC_OPERATOR=${DEPLOY_KUBERMATIC_OPERATOR:-false}
 DEPLOY_STACK=${DEPLOY_STACK:-kubermatic}
 TILLER_NAMESPACE=${TILLER_NAMESPACE:-kubermatic}
 HELM_INIT_ARGS=${HELM_INIT_ARGS:-""}
@@ -164,10 +165,10 @@ case "${DEPLOY_STACK}" in
 
     # Kubermatic
     deploy "kubermatic" "kubermatic" ./config/kubermatic/
-    ;;
 
-  kubermatic-operator)
-    kubectl create namespace kubermatic-operator || true
-    kubectl apply -f ./config/kubermatic-operator/
+    if [[ "${DEPLOY_KUBERMATIC_OPERATOR}" = true ]]; then
+      echodate "Deploying Kubermatic Operator..."
+      kubectl apply -f ./config/kubermatic-operator/
+    fi
     ;;
 esac

--- a/config/kubermatic-operator/deployment.yaml
+++ b/config/kubermatic-operator/deployment.yaml
@@ -15,7 +15,7 @@ spec:
       annotations:
         prometheus.io/scrape: 'true'
         prometheus.io/scrape_port: '8085'
-        fluentbit.io/parser: json
+        fluentbit.io/parser: json_iso
     spec:
       serviceAccountName: kubermatic-operator
       containers:
@@ -28,6 +28,7 @@ spec:
         - -internal-address=0.0.0.0:8085
         - -namespace=$(POD_NAMESPACE)
         - -log-format=json
+        - -worker-name=kubermatic-operator
         env:
         - name: POD_NAMESPACE
           valueFrom:


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR extends the deployment script to deploy the Kubermatic Operator in parallel to the original Helm chart on dev. This is a first step towards removing the Helm chart entirely.

The Operator-managed Kubermatic installation will have a worker-name assigned, so it should not interfere with the "main" Kubermatic installation.

**Which issue(s) this PR fixes**:
Relates to #4728

**Does this PR introduce a user-facing change?**:
```release-note
NONE
```
