### PR TITLE
use cluster exposer locally

### DIFF
--- a/api/pkg/test/e2e/api/cluster_rbac_test.go
+++ b/api/pkg/test/e2e/api/cluster_rbac_test.go
@@ -79,7 +79,7 @@ func TestCreateClusterRoleBinding(t *testing.T) {
 			for attempt := 1; attempt <= getMaxAttempts; attempt++ {
 				roleNameList, err = apiRunner.GetRoles(project.ID, tc.dc, cluster.ID)
 				if err != nil {
-					t.Fatalf("can not get user cluster roles due to error: %v", err)
+					t.Fatalf("can not get user cluster roles due to error: %v", GetErrorResponse(err))
 				}
 
 				if len(roleNameList) == len(tc.expectedRoleNames) {


### PR DESCRIPTION
**What this PR does / why we need it**: use cluster exposer locally for e2e tests

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

```release-note
```
