### PR TITLE
Bump Kubernetes Dashboard version for the user cluster.

### DIFF
--- a/api/pkg/resources/kubernetes-dashboard/deployment.go
+++ b/api/pkg/resources/kubernetes-dashboard/deployment.go
@@ -32,7 +32,7 @@ var (
 const (
 	name      = resources.KubernetesDashboardDeploymentName
 	imageName = "kubernetesui/dashboard"
-	tag       = "v2.0.0-beta4"
+	tag       = "v2.0.0-beta8"
 	// Namespace used by Dashboard to find required resources.
 	Namespace     = "kubernetes-dashboard"
 	ContainerPort = 9090

--- a/api/pkg/resources/test/fixtures/deployment-aws-1.10.0-kubernetes-dashboard.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-aws-1.10.0-kubernetes-dashboard.yaml
@@ -48,7 +48,7 @@ spec:
         - '{"command":"/dashboard","args":["--kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","--namespace","kubernetes-dashboard","--enable-insecure-login"]}'
         command:
         - /http-prober-bin/http-prober
-        image: docker.io/kubernetesui/dashboard:v2.0.0-beta4
+        image: docker.io/kubernetesui/dashboard:v2.0.0-beta8
         imagePullPolicy: IfNotPresent
         name: kubernetes-dashboard
         ports:

--- a/api/pkg/resources/test/fixtures/deployment-aws-1.10.6-kubernetes-dashboard.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-aws-1.10.6-kubernetes-dashboard.yaml
@@ -48,7 +48,7 @@ spec:
         - '{"command":"/dashboard","args":["--kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","--namespace","kubernetes-dashboard","--enable-insecure-login"]}'
         command:
         - /http-prober-bin/http-prober
-        image: docker.io/kubernetesui/dashboard:v2.0.0-beta4
+        image: docker.io/kubernetesui/dashboard:v2.0.0-beta8
         imagePullPolicy: IfNotPresent
         name: kubernetes-dashboard
         ports:

--- a/api/pkg/resources/test/fixtures/deployment-aws-1.11.0-kubernetes-dashboard.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-aws-1.11.0-kubernetes-dashboard.yaml
@@ -48,7 +48,7 @@ spec:
         - '{"command":"/dashboard","args":["--kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","--namespace","kubernetes-dashboard","--enable-insecure-login"]}'
         command:
         - /http-prober-bin/http-prober
-        image: docker.io/kubernetesui/dashboard:v2.0.0-beta4
+        image: docker.io/kubernetesui/dashboard:v2.0.0-beta8
         imagePullPolicy: IfNotPresent
         name: kubernetes-dashboard
         ports:

--- a/api/pkg/resources/test/fixtures/deployment-aws-1.11.1-kubernetes-dashboard.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-aws-1.11.1-kubernetes-dashboard.yaml
@@ -48,7 +48,7 @@ spec:
         - '{"command":"/dashboard","args":["--kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","--namespace","kubernetes-dashboard","--enable-insecure-login"]}'
         command:
         - /http-prober-bin/http-prober
-        image: docker.io/kubernetesui/dashboard:v2.0.0-beta4
+        image: docker.io/kubernetesui/dashboard:v2.0.0-beta8
         imagePullPolicy: IfNotPresent
         name: kubernetes-dashboard
         ports:

--- a/api/pkg/resources/test/fixtures/deployment-aws-1.12.0-kubernetes-dashboard.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-aws-1.12.0-kubernetes-dashboard.yaml
@@ -48,7 +48,7 @@ spec:
         - '{"command":"/dashboard","args":["--kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","--namespace","kubernetes-dashboard","--enable-insecure-login"]}'
         command:
         - /http-prober-bin/http-prober
-        image: docker.io/kubernetesui/dashboard:v2.0.0-beta4
+        image: docker.io/kubernetesui/dashboard:v2.0.0-beta8
         imagePullPolicy: IfNotPresent
         name: kubernetes-dashboard
         ports:

--- a/api/pkg/resources/test/fixtures/deployment-aws-1.13.0-kubernetes-dashboard.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-aws-1.13.0-kubernetes-dashboard.yaml
@@ -48,7 +48,7 @@ spec:
         - '{"command":"/dashboard","args":["--kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","--namespace","kubernetes-dashboard","--enable-insecure-login"]}'
         command:
         - /http-prober-bin/http-prober
-        image: docker.io/kubernetesui/dashboard:v2.0.0-beta4
+        image: docker.io/kubernetesui/dashboard:v2.0.0-beta8
         imagePullPolicy: IfNotPresent
         name: kubernetes-dashboard
         ports:

--- a/api/pkg/resources/test/fixtures/deployment-azure-1.10.0-kubernetes-dashboard.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-azure-1.10.0-kubernetes-dashboard.yaml
@@ -48,7 +48,7 @@ spec:
         - '{"command":"/dashboard","args":["--kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","--namespace","kubernetes-dashboard","--enable-insecure-login"]}'
         command:
         - /http-prober-bin/http-prober
-        image: docker.io/kubernetesui/dashboard:v2.0.0-beta4
+        image: docker.io/kubernetesui/dashboard:v2.0.0-beta8
         imagePullPolicy: IfNotPresent
         name: kubernetes-dashboard
         ports:

--- a/api/pkg/resources/test/fixtures/deployment-azure-1.10.6-kubernetes-dashboard.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-azure-1.10.6-kubernetes-dashboard.yaml
@@ -48,7 +48,7 @@ spec:
         - '{"command":"/dashboard","args":["--kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","--namespace","kubernetes-dashboard","--enable-insecure-login"]}'
         command:
         - /http-prober-bin/http-prober
-        image: docker.io/kubernetesui/dashboard:v2.0.0-beta4
+        image: docker.io/kubernetesui/dashboard:v2.0.0-beta8
         imagePullPolicy: IfNotPresent
         name: kubernetes-dashboard
         ports:

--- a/api/pkg/resources/test/fixtures/deployment-azure-1.11.0-kubernetes-dashboard.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-azure-1.11.0-kubernetes-dashboard.yaml
@@ -48,7 +48,7 @@ spec:
         - '{"command":"/dashboard","args":["--kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","--namespace","kubernetes-dashboard","--enable-insecure-login"]}'
         command:
         - /http-prober-bin/http-prober
-        image: docker.io/kubernetesui/dashboard:v2.0.0-beta4
+        image: docker.io/kubernetesui/dashboard:v2.0.0-beta8
         imagePullPolicy: IfNotPresent
         name: kubernetes-dashboard
         ports:

--- a/api/pkg/resources/test/fixtures/deployment-azure-1.11.1-kubernetes-dashboard.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-azure-1.11.1-kubernetes-dashboard.yaml
@@ -48,7 +48,7 @@ spec:
         - '{"command":"/dashboard","args":["--kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","--namespace","kubernetes-dashboard","--enable-insecure-login"]}'
         command:
         - /http-prober-bin/http-prober
-        image: docker.io/kubernetesui/dashboard:v2.0.0-beta4
+        image: docker.io/kubernetesui/dashboard:v2.0.0-beta8
         imagePullPolicy: IfNotPresent
         name: kubernetes-dashboard
         ports:

--- a/api/pkg/resources/test/fixtures/deployment-azure-1.12.0-kubernetes-dashboard.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-azure-1.12.0-kubernetes-dashboard.yaml
@@ -48,7 +48,7 @@ spec:
         - '{"command":"/dashboard","args":["--kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","--namespace","kubernetes-dashboard","--enable-insecure-login"]}'
         command:
         - /http-prober-bin/http-prober
-        image: docker.io/kubernetesui/dashboard:v2.0.0-beta4
+        image: docker.io/kubernetesui/dashboard:v2.0.0-beta8
         imagePullPolicy: IfNotPresent
         name: kubernetes-dashboard
         ports:

--- a/api/pkg/resources/test/fixtures/deployment-azure-1.13.0-kubernetes-dashboard.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-azure-1.13.0-kubernetes-dashboard.yaml
@@ -48,7 +48,7 @@ spec:
         - '{"command":"/dashboard","args":["--kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","--namespace","kubernetes-dashboard","--enable-insecure-login"]}'
         command:
         - /http-prober-bin/http-prober
-        image: docker.io/kubernetesui/dashboard:v2.0.0-beta4
+        image: docker.io/kubernetesui/dashboard:v2.0.0-beta8
         imagePullPolicy: IfNotPresent
         name: kubernetes-dashboard
         ports:

--- a/api/pkg/resources/test/fixtures/deployment-bringyourown-1.10.0-kubernetes-dashboard.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-bringyourown-1.10.0-kubernetes-dashboard.yaml
@@ -48,7 +48,7 @@ spec:
         - '{"command":"/dashboard","args":["--kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","--namespace","kubernetes-dashboard","--enable-insecure-login"]}'
         command:
         - /http-prober-bin/http-prober
-        image: docker.io/kubernetesui/dashboard:v2.0.0-beta4
+        image: docker.io/kubernetesui/dashboard:v2.0.0-beta8
         imagePullPolicy: IfNotPresent
         name: kubernetes-dashboard
         ports:

--- a/api/pkg/resources/test/fixtures/deployment-bringyourown-1.10.6-kubernetes-dashboard.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-bringyourown-1.10.6-kubernetes-dashboard.yaml
@@ -48,7 +48,7 @@ spec:
         - '{"command":"/dashboard","args":["--kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","--namespace","kubernetes-dashboard","--enable-insecure-login"]}'
         command:
         - /http-prober-bin/http-prober
-        image: docker.io/kubernetesui/dashboard:v2.0.0-beta4
+        image: docker.io/kubernetesui/dashboard:v2.0.0-beta8
         imagePullPolicy: IfNotPresent
         name: kubernetes-dashboard
         ports:

--- a/api/pkg/resources/test/fixtures/deployment-bringyourown-1.11.0-kubernetes-dashboard.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-bringyourown-1.11.0-kubernetes-dashboard.yaml
@@ -48,7 +48,7 @@ spec:
         - '{"command":"/dashboard","args":["--kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","--namespace","kubernetes-dashboard","--enable-insecure-login"]}'
         command:
         - /http-prober-bin/http-prober
-        image: docker.io/kubernetesui/dashboard:v2.0.0-beta4
+        image: docker.io/kubernetesui/dashboard:v2.0.0-beta8
         imagePullPolicy: IfNotPresent
         name: kubernetes-dashboard
         ports:

--- a/api/pkg/resources/test/fixtures/deployment-bringyourown-1.11.1-kubernetes-dashboard.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-bringyourown-1.11.1-kubernetes-dashboard.yaml
@@ -48,7 +48,7 @@ spec:
         - '{"command":"/dashboard","args":["--kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","--namespace","kubernetes-dashboard","--enable-insecure-login"]}'
         command:
         - /http-prober-bin/http-prober
-        image: docker.io/kubernetesui/dashboard:v2.0.0-beta4
+        image: docker.io/kubernetesui/dashboard:v2.0.0-beta8
         imagePullPolicy: IfNotPresent
         name: kubernetes-dashboard
         ports:

--- a/api/pkg/resources/test/fixtures/deployment-bringyourown-1.12.0-kubernetes-dashboard.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-bringyourown-1.12.0-kubernetes-dashboard.yaml
@@ -48,7 +48,7 @@ spec:
         - '{"command":"/dashboard","args":["--kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","--namespace","kubernetes-dashboard","--enable-insecure-login"]}'
         command:
         - /http-prober-bin/http-prober
-        image: docker.io/kubernetesui/dashboard:v2.0.0-beta4
+        image: docker.io/kubernetesui/dashboard:v2.0.0-beta8
         imagePullPolicy: IfNotPresent
         name: kubernetes-dashboard
         ports:

--- a/api/pkg/resources/test/fixtures/deployment-bringyourown-1.13.0-kubernetes-dashboard.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-bringyourown-1.13.0-kubernetes-dashboard.yaml
@@ -48,7 +48,7 @@ spec:
         - '{"command":"/dashboard","args":["--kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","--namespace","kubernetes-dashboard","--enable-insecure-login"]}'
         command:
         - /http-prober-bin/http-prober
-        image: docker.io/kubernetesui/dashboard:v2.0.0-beta4
+        image: docker.io/kubernetesui/dashboard:v2.0.0-beta8
         imagePullPolicy: IfNotPresent
         name: kubernetes-dashboard
         ports:

--- a/api/pkg/resources/test/fixtures/deployment-digitalocean-1.10.0-kubernetes-dashboard.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-digitalocean-1.10.0-kubernetes-dashboard.yaml
@@ -48,7 +48,7 @@ spec:
         - '{"command":"/dashboard","args":["--kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","--namespace","kubernetes-dashboard","--enable-insecure-login"]}'
         command:
         - /http-prober-bin/http-prober
-        image: docker.io/kubernetesui/dashboard:v2.0.0-beta4
+        image: docker.io/kubernetesui/dashboard:v2.0.0-beta8
         imagePullPolicy: IfNotPresent
         name: kubernetes-dashboard
         ports:

--- a/api/pkg/resources/test/fixtures/deployment-digitalocean-1.10.6-kubernetes-dashboard.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-digitalocean-1.10.6-kubernetes-dashboard.yaml
@@ -48,7 +48,7 @@ spec:
         - '{"command":"/dashboard","args":["--kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","--namespace","kubernetes-dashboard","--enable-insecure-login"]}'
         command:
         - /http-prober-bin/http-prober
-        image: docker.io/kubernetesui/dashboard:v2.0.0-beta4
+        image: docker.io/kubernetesui/dashboard:v2.0.0-beta8
         imagePullPolicy: IfNotPresent
         name: kubernetes-dashboard
         ports:

--- a/api/pkg/resources/test/fixtures/deployment-digitalocean-1.11.0-kubernetes-dashboard.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-digitalocean-1.11.0-kubernetes-dashboard.yaml
@@ -48,7 +48,7 @@ spec:
         - '{"command":"/dashboard","args":["--kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","--namespace","kubernetes-dashboard","--enable-insecure-login"]}'
         command:
         - /http-prober-bin/http-prober
-        image: docker.io/kubernetesui/dashboard:v2.0.0-beta4
+        image: docker.io/kubernetesui/dashboard:v2.0.0-beta8
         imagePullPolicy: IfNotPresent
         name: kubernetes-dashboard
         ports:

--- a/api/pkg/resources/test/fixtures/deployment-digitalocean-1.11.1-kubernetes-dashboard.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-digitalocean-1.11.1-kubernetes-dashboard.yaml
@@ -48,7 +48,7 @@ spec:
         - '{"command":"/dashboard","args":["--kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","--namespace","kubernetes-dashboard","--enable-insecure-login"]}'
         command:
         - /http-prober-bin/http-prober
-        image: docker.io/kubernetesui/dashboard:v2.0.0-beta4
+        image: docker.io/kubernetesui/dashboard:v2.0.0-beta8
         imagePullPolicy: IfNotPresent
         name: kubernetes-dashboard
         ports:

--- a/api/pkg/resources/test/fixtures/deployment-digitalocean-1.12.0-kubernetes-dashboard.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-digitalocean-1.12.0-kubernetes-dashboard.yaml
@@ -48,7 +48,7 @@ spec:
         - '{"command":"/dashboard","args":["--kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","--namespace","kubernetes-dashboard","--enable-insecure-login"]}'
         command:
         - /http-prober-bin/http-prober
-        image: docker.io/kubernetesui/dashboard:v2.0.0-beta4
+        image: docker.io/kubernetesui/dashboard:v2.0.0-beta8
         imagePullPolicy: IfNotPresent
         name: kubernetes-dashboard
         ports:

--- a/api/pkg/resources/test/fixtures/deployment-digitalocean-1.13.0-kubernetes-dashboard.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-digitalocean-1.13.0-kubernetes-dashboard.yaml
@@ -48,7 +48,7 @@ spec:
         - '{"command":"/dashboard","args":["--kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","--namespace","kubernetes-dashboard","--enable-insecure-login"]}'
         command:
         - /http-prober-bin/http-prober
-        image: docker.io/kubernetesui/dashboard:v2.0.0-beta4
+        image: docker.io/kubernetesui/dashboard:v2.0.0-beta8
         imagePullPolicy: IfNotPresent
         name: kubernetes-dashboard
         ports:

--- a/api/pkg/resources/test/fixtures/deployment-openstack-1.10.0-kubernetes-dashboard.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-openstack-1.10.0-kubernetes-dashboard.yaml
@@ -48,7 +48,7 @@ spec:
         - '{"command":"/dashboard","args":["--kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","--namespace","kubernetes-dashboard","--enable-insecure-login"]}'
         command:
         - /http-prober-bin/http-prober
-        image: docker.io/kubernetesui/dashboard:v2.0.0-beta4
+        image: docker.io/kubernetesui/dashboard:v2.0.0-beta8
         imagePullPolicy: IfNotPresent
         name: kubernetes-dashboard
         ports:

--- a/api/pkg/resources/test/fixtures/deployment-openstack-1.10.6-kubernetes-dashboard.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-openstack-1.10.6-kubernetes-dashboard.yaml
@@ -48,7 +48,7 @@ spec:
         - '{"command":"/dashboard","args":["--kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","--namespace","kubernetes-dashboard","--enable-insecure-login"]}'
         command:
         - /http-prober-bin/http-prober
-        image: docker.io/kubernetesui/dashboard:v2.0.0-beta4
+        image: docker.io/kubernetesui/dashboard:v2.0.0-beta8
         imagePullPolicy: IfNotPresent
         name: kubernetes-dashboard
         ports:

--- a/api/pkg/resources/test/fixtures/deployment-openstack-1.11.0-kubernetes-dashboard.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-openstack-1.11.0-kubernetes-dashboard.yaml
@@ -48,7 +48,7 @@ spec:
         - '{"command":"/dashboard","args":["--kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","--namespace","kubernetes-dashboard","--enable-insecure-login"]}'
         command:
         - /http-prober-bin/http-prober
-        image: docker.io/kubernetesui/dashboard:v2.0.0-beta4
+        image: docker.io/kubernetesui/dashboard:v2.0.0-beta8
         imagePullPolicy: IfNotPresent
         name: kubernetes-dashboard
         ports:

--- a/api/pkg/resources/test/fixtures/deployment-openstack-1.11.1-kubernetes-dashboard.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-openstack-1.11.1-kubernetes-dashboard.yaml
@@ -48,7 +48,7 @@ spec:
         - '{"command":"/dashboard","args":["--kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","--namespace","kubernetes-dashboard","--enable-insecure-login"]}'
         command:
         - /http-prober-bin/http-prober
-        image: docker.io/kubernetesui/dashboard:v2.0.0-beta4
+        image: docker.io/kubernetesui/dashboard:v2.0.0-beta8
         imagePullPolicy: IfNotPresent
         name: kubernetes-dashboard
         ports:

--- a/api/pkg/resources/test/fixtures/deployment-openstack-1.12.0-kubernetes-dashboard.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-openstack-1.12.0-kubernetes-dashboard.yaml
@@ -48,7 +48,7 @@ spec:
         - '{"command":"/dashboard","args":["--kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","--namespace","kubernetes-dashboard","--enable-insecure-login"]}'
         command:
         - /http-prober-bin/http-prober
-        image: docker.io/kubernetesui/dashboard:v2.0.0-beta4
+        image: docker.io/kubernetesui/dashboard:v2.0.0-beta8
         imagePullPolicy: IfNotPresent
         name: kubernetes-dashboard
         ports:

--- a/api/pkg/resources/test/fixtures/deployment-openstack-1.13.0-kubernetes-dashboard.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-openstack-1.13.0-kubernetes-dashboard.yaml
@@ -48,7 +48,7 @@ spec:
         - '{"command":"/dashboard","args":["--kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","--namespace","kubernetes-dashboard","--enable-insecure-login"]}'
         command:
         - /http-prober-bin/http-prober
-        image: docker.io/kubernetesui/dashboard:v2.0.0-beta4
+        image: docker.io/kubernetesui/dashboard:v2.0.0-beta8
         imagePullPolicy: IfNotPresent
         name: kubernetes-dashboard
         ports:

--- a/api/pkg/resources/test/fixtures/deployment-vsphere-1.10.0-kubernetes-dashboard.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-vsphere-1.10.0-kubernetes-dashboard.yaml
@@ -48,7 +48,7 @@ spec:
         - '{"command":"/dashboard","args":["--kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","--namespace","kubernetes-dashboard","--enable-insecure-login"]}'
         command:
         - /http-prober-bin/http-prober
-        image: docker.io/kubernetesui/dashboard:v2.0.0-beta4
+        image: docker.io/kubernetesui/dashboard:v2.0.0-beta8
         imagePullPolicy: IfNotPresent
         name: kubernetes-dashboard
         ports:

--- a/api/pkg/resources/test/fixtures/deployment-vsphere-1.10.6-kubernetes-dashboard.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-vsphere-1.10.6-kubernetes-dashboard.yaml
@@ -48,7 +48,7 @@ spec:
         - '{"command":"/dashboard","args":["--kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","--namespace","kubernetes-dashboard","--enable-insecure-login"]}'
         command:
         - /http-prober-bin/http-prober
-        image: docker.io/kubernetesui/dashboard:v2.0.0-beta4
+        image: docker.io/kubernetesui/dashboard:v2.0.0-beta8
         imagePullPolicy: IfNotPresent
         name: kubernetes-dashboard
         ports:

--- a/api/pkg/resources/test/fixtures/deployment-vsphere-1.11.0-kubernetes-dashboard.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-vsphere-1.11.0-kubernetes-dashboard.yaml
@@ -48,7 +48,7 @@ spec:
         - '{"command":"/dashboard","args":["--kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","--namespace","kubernetes-dashboard","--enable-insecure-login"]}'
         command:
         - /http-prober-bin/http-prober
-        image: docker.io/kubernetesui/dashboard:v2.0.0-beta4
+        image: docker.io/kubernetesui/dashboard:v2.0.0-beta8
         imagePullPolicy: IfNotPresent
         name: kubernetes-dashboard
         ports:

--- a/api/pkg/resources/test/fixtures/deployment-vsphere-1.11.1-kubernetes-dashboard.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-vsphere-1.11.1-kubernetes-dashboard.yaml
@@ -48,7 +48,7 @@ spec:
         - '{"command":"/dashboard","args":["--kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","--namespace","kubernetes-dashboard","--enable-insecure-login"]}'
         command:
         - /http-prober-bin/http-prober
-        image: docker.io/kubernetesui/dashboard:v2.0.0-beta4
+        image: docker.io/kubernetesui/dashboard:v2.0.0-beta8
         imagePullPolicy: IfNotPresent
         name: kubernetes-dashboard
         ports:

--- a/api/pkg/resources/test/fixtures/deployment-vsphere-1.12.0-kubernetes-dashboard.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-vsphere-1.12.0-kubernetes-dashboard.yaml
@@ -48,7 +48,7 @@ spec:
         - '{"command":"/dashboard","args":["--kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","--namespace","kubernetes-dashboard","--enable-insecure-login"]}'
         command:
         - /http-prober-bin/http-prober
-        image: docker.io/kubernetesui/dashboard:v2.0.0-beta4
+        image: docker.io/kubernetesui/dashboard:v2.0.0-beta8
         imagePullPolicy: IfNotPresent
         name: kubernetes-dashboard
         ports:

--- a/api/pkg/resources/test/fixtures/deployment-vsphere-1.13.0-kubernetes-dashboard.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-vsphere-1.13.0-kubernetes-dashboard.yaml
@@ -48,7 +48,7 @@ spec:
         - '{"command":"/dashboard","args":["--kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","--namespace","kubernetes-dashboard","--enable-insecure-login"]}'
         command:
         - /http-prober-bin/http-prober
-        image: docker.io/kubernetesui/dashboard:v2.0.0-beta4
+        image: docker.io/kubernetesui/dashboard:v2.0.0-beta8
         imagePullPolicy: IfNotPresent
         name: kubernetes-dashboard
         ports:


### PR DESCRIPTION
**What this PR does / why we need it**:
Bumps Kubernetes Dashboard version deployed for the user cluster to the latest beta.

**Does this PR introduce a user-facing change?**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If  no release note is required, just write "NONE".
-->
```release-note
NONE
```
