### PR TITLE
Remove ci-run-minimal-conformance-tests.sh symlink

### DIFF
--- a/.prow.yaml
+++ b/.prow.yaml
@@ -269,7 +269,7 @@ presubmits:
         - name: DEFAULT_TIMEOUT_MINUTES
           value: "20"
         command:
-        - "./api/hack/ci-run-minimal-conformance-tests.sh"
+        - "./api/hack/ci/ci-run-minimal-conformance-tests.sh"
         # docker-in-docker needs privileged mode
         securityContext:
           privileged: true
@@ -339,7 +339,7 @@ presubmits:
         - name: PROVIDER
           value: "gcp"
         command:
-        - "./api/hack/ci-run-minimal-conformance-tests.sh"
+        - "./api/hack/ci/ci-run-minimal-conformance-tests.sh"
         # docker-in-docker needs privileged mode
         securityContext:
           privileged: true
@@ -373,7 +373,7 @@ presubmits:
         - name: ONLY_TEST_CREATION
           value: "true"
         command:
-        - "./api/hack/ci-run-minimal-conformance-tests.sh"
+        - "./api/hack/ci/ci-run-minimal-conformance-tests.sh"
         # docker-in-docker needs privileged mode
         securityContext:
           privileged: true
@@ -405,7 +405,7 @@ presubmits:
         - name: DEFAULT_TIMEOUT_MINUTES
           value: "20"
         command:
-        - "./api/hack/ci-run-minimal-conformance-tests.sh"
+        - "./api/hack/ci/ci-run-minimal-conformance-tests.sh"
         # docker-in-docker needs privileged mode
         securityContext:
           privileged: true
@@ -438,7 +438,7 @@ presubmits:
         - name: PROVIDER
           value: "digitalocean"
         command:
-        - "./api/hack/ci-run-minimal-conformance-tests.sh"
+        - "./api/hack/ci/ci-run-minimal-conformance-tests.sh"
         # docker-in-docker needs privileged mode
         securityContext:
           privileged: true
@@ -468,7 +468,7 @@ presubmits:
         - name: PROVIDER
           value: "packet"
         command:
-        - "./api/hack/ci-run-minimal-conformance-tests.sh"
+        - "./api/hack/ci/ci-run-minimal-conformance-tests.sh"
         # docker-in-docker needs privileged mode
         securityContext:
           privileged: true
@@ -500,7 +500,7 @@ presubmits:
         - name: EXCLUDE_DISTRIBUTIONS
           value: "ubuntu,coreos"
         command:
-        - "./api/hack/ci-run-minimal-conformance-tests.sh"
+        - "./api/hack/ci/ci-run-minimal-conformance-tests.sh"
         # docker-in-docker needs privileged mode
         securityContext:
           privileged: true
@@ -535,7 +535,7 @@ presubmits:
         - name: DEFAULT_TIMEOUT_MINUTES
           value: "20"
         command:
-        - "./api/hack/ci-run-minimal-conformance-tests.sh"
+        - "./api/hack/ci/ci-run-minimal-conformance-tests.sh"
         # docker-in-docker needs privileged mode
         securityContext:
           privileged: true
@@ -567,7 +567,7 @@ presubmits:
         - name: DEFAULT_TIMEOUT_MINUTES
           value: "20"
         command:
-        - "./api/hack/ci-run-minimal-conformance-tests.sh"
+        - "./api/hack/ci/ci-run-minimal-conformance-tests.sh"
         # docker-in-docker needs privileged mode
         securityContext:
           privileged: true
@@ -597,7 +597,7 @@ presubmits:
         - name: PROVIDER
           value: "vsphere"
         command:
-        - "./api/hack/ci-run-minimal-conformance-tests.sh"
+        - "./api/hack/ci/ci-run-minimal-conformance-tests.sh"
         # docker-in-docker needs privileged mode
         securityContext:
           privileged: true
@@ -630,7 +630,7 @@ presubmits:
         - name: SCENARIO_OPTIONS
           value: "custom-folder"
         command:
-        - "./api/hack/ci-run-minimal-conformance-tests.sh"
+        - "./api/hack/ci/ci-run-minimal-conformance-tests.sh"
         # docker-in-docker needs privileged mode
         securityContext:
           privileged: true
@@ -703,7 +703,7 @@ presubmits:
         - name: EXCLUDE_DISTRIBUTIONS
           value: "coreos,ubuntu"
         command:
-        - "./api/hack/ci-run-minimal-conformance-tests.sh"
+        - "./api/hack/ci/ci-run-minimal-conformance-tests.sh"
         # docker-in-docker needs privileged mode
         securityContext:
           privileged: true
@@ -737,7 +737,7 @@ presubmits:
         - name: EXCLUDE_DISTRIBUTIONS
           value: "coreos,centos"
         command:
-        - "./api/hack/ci-run-minimal-conformance-tests.sh"
+        - "./api/hack/ci/ci-run-minimal-conformance-tests.sh"
         # docker-in-docker needs privileged mode
         securityContext:
           privileged: true
@@ -769,7 +769,7 @@ presubmits:
         - name: DEFAULT_TIMEOUT_MINUTES
           value: "20"
         command:
-        - "./api/hack/ci-run-minimal-conformance-tests.sh"
+        - "./api/hack/ci/ci-run-minimal-conformance-tests.sh"
         # docker-in-docker needs privileged mode
         securityContext:
           privileged: true
@@ -805,7 +805,7 @@ presubmits:
         - name: OPENSHIFT_VERSION
           value: "4.1.18"
         command:
-        - "./api/hack/ci-run-minimal-conformance-tests.sh"
+        - "./api/hack/ci/ci-run-minimal-conformance-tests.sh"
         # docker-in-docker needs privileged mode
         securityContext:
           privileged: true

--- a/api/hack/ci-run-minimal-conformance-tests.sh
+++ b/api/hack/ci-run-minimal-conformance-tests.sh
@@ -1,1 +1,0 @@
-ci/ci-run-minimal-conformance-tests.sh

--- a/api/hack/ci/ci-run-kubermatic-upgrade-test.sh
+++ b/api/hack/ci/ci-run-kubermatic-upgrade-test.sh
@@ -6,9 +6,9 @@ set -euo pipefail
 # receives a SIGINT
 set -o monitor
 
-. $(dirname $0)/lib.sh
+cd $(dirname $0)
 
-cd $(go env GOPATH)/src/github.com/kubermatic/kubermatic/api/hack/ci
+. ../lib.sh
 
 export UPGRADE_TEST_BASE_HASH=${UPGRADE_TEST_BASE_HASH:-"master"}
 


### PR DESCRIPTION
**What this PR does / why we need it**:
This has confused me constantly and there is no real reason to have this backwards compatibility hack anymore.

**Does this PR introduce a user-facing change?**:
```release-note
NONE
```
