### PR TITLE
Updates for kube 1.17

### DIFF
--- a/api/pkg/resources/controllermanager/deployment.go
+++ b/api/pkg/resources/controllermanager/deployment.go
@@ -211,7 +211,7 @@ func getFlags(data *resources.TemplateData) ([]string, error) {
 	// TODO: Remove once we don't support Kube 1.10 anymore
 	// TODO: Before removing, add check that prevents upgrading to 1.12 when
 	// there is still a node < 1.11
-	if data.Cluster().Spec.Version.Semver().Minor() >= 12 {
+	if data.Cluster().Spec.Version.Semver().Minor() >= 12 && data.Cluster().Spec.Version.Semver().Minor() < 17 {
 		featureGates = append(featureGates, "ScheduleDaemonSetPods=false")
 	}
 	if len(featureGates) > 0 {

--- a/api/pkg/resources/scheduler/deployment.go
+++ b/api/pkg/resources/scheduler/deployment.go
@@ -204,7 +204,7 @@ func getFlags(cluster *kubermaticv1.Cluster) ([]string, error) {
 	// TODO: Remove once we don't support Kube 1.10 anymore
 	// TODO: Before removing, add check that prevents upgrading to 1.12 when
 	// there is still a node < 1.11
-	if cluster.Spec.Version.Semver().Minor() >= 12 {
+	if cluster.Spec.Version.Semver().Minor() >= 12 && cluster.Spec.Version.Semver().Minor() < 17 {
 		featureGates = append(featureGates, "ScheduleDaemonSetPods=false")
 	}
 

--- a/config/kubermatic/Chart.yaml
+++ b/config/kubermatic/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: kubermatic
-version: 1.0.28
+version: 1.0.29
 appVersion: '__KUBERMATIC_TAG__'
 description: Kubermatic chart for master and/or seed clusters.
 keywords:

--- a/config/kubermatic/static/master/versions.yaml
+++ b/config/kubermatic/static/master/versions.yaml
@@ -15,7 +15,7 @@ versions:
 - version: "v1.16.3"
   default: false
 # Kubernetes 1.17
-- version: "v1.17.0-rc.1"
+- version: "v1.17.0"
   default: false
 # OpenShift 4.1.9
 - version: "v4.1.9"


### PR DESCRIPTION
**What this PR does / why we need it**:

Adds kube 1.17 support on CentOS and Ubuntu. For CoreOS we need https://github.com/kubermatic/machine-controller/pull/658-

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Documentation**:
<!-- Add links to the related documentation changes related to this pull request. E.g. the link to the kubermatic/docs pullrequest. -->

**Does this PR introduce a user-facing change?**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If  no release note is required, just write "NONE".
-->
```release-note
Support for Kubernetes 1.17 was added
```

/assign @kdomanski 