### PR TITLE
Fix missing deployment selector

### DIFF
--- a/config/kubermatic-operator/deployment.yaml
+++ b/config/kubermatic-operator/deployment.yaml
@@ -8,6 +8,9 @@ metadata:
     app.kubernetes.io/version: '__KUBERMATIC_TAG__'
 spec:
   replicas: 1
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: kubermatic-operator
   template:
     metadata:
       labels:


### PR DESCRIPTION
**What this PR does / why we need it**:
Since appsv1 it's not allowed to skip defining the selectors.

**Does this PR introduce a user-facing change?**:
```release-note
NONE
```
