### PR TITLE
Improve log flag handling

### DIFF
--- a/api/cmd/image-loader/main.go
+++ b/api/cmd/image-loader/main.go
@@ -57,24 +57,23 @@ type opts struct {
 	registry      string
 	dryRun        bool
 	addonsPath    string
-
-	debug     bool
-	logFormat string
 }
 
 func main() {
 	klog.InitFlags(nil)
+
+	logOpts := kubermaticlog.NewDefaultOptions()
+	logOpts.AddFlags(flag.CommandLine)
+
 	o := opts{}
 	flag.StringVar(&o.versionsFile, "versions", "../config/kubermatic/static/master/versions.yaml", "The versions.yaml file path")
 	flag.StringVar(&o.versionFilter, "version-filter", "", "Version constraint which can be used to filter for specific versions")
 	flag.StringVar(&o.registry, "registry", "registry.corp.local", "Address of the registry to push to")
 	flag.BoolVar(&o.dryRun, "dry-run", false, "Only print the names of found images")
 	flag.StringVar(&o.addonsPath, "addons-path", "", "Path to the folder containing the addons")
-	flag.BoolVar(&o.debug, "log-debug", false, "Enables debug logging")
-	flag.StringVar(&o.logFormat, "log-format", string(kubermaticlog.FormatJSON), "Log format. Available are: "+kubermaticlog.AvailableFormats.String())
 	flag.Parse()
 
-	log := kubermaticlog.New(o.debug, kubermaticlog.Format(o.logFormat))
+	log := kubermaticlog.New(logOpts.Debug, logOpts.Format)
 	defer func() {
 		if err := log.Sync(); err != nil {
 			fmt.Println(err)

--- a/api/cmd/kubeletdnat-controller/main.go
+++ b/api/cmd/kubeletdnat-controller/main.go
@@ -3,9 +3,7 @@ package main
 import (
 	"context"
 	"flag"
-	"fmt"
 	"net"
-	"os"
 	"time"
 
 	"go.uber.org/zap"
@@ -26,28 +24,17 @@ import (
 func main() {
 	pprofOpts := &pprof.Opts{}
 	pprofOpts.AddFlags(flag.CommandLine)
+	logOpts := kubermaticlog.NewDefaultOptions()
+	logOpts.AddFlags(flag.CommandLine)
 	klog.InitFlags(nil)
 	kubeconfigFlag := flag.String("kubeconfig", "", "Path to a kubeconfig.")
 	master := flag.String("master", "", "The address of the Kubernetes API server. Overrides any value in kubeconfig")
 	networkFlag := flag.String("node-access-network", "", "The network in CIDR notation to translate to.")
 	chainNameFlag := flag.String("chain-name", "node-access-dnat", "Name of the chain in nat table.")
 	vpnInterfaceFlag := flag.String("vpn-interface", "tun0", "Name of the vpn interface.")
-	logDebugFlag := flag.Bool("log-debug", false, "Enables debug logging")
-	logFormatFlag := flag.String("log-format", string(kubermaticlog.FormatJSON), "Log format. Available are: "+kubermaticlog.AvailableFormats.String())
-
-	logOptions := kubermaticlog.Options{
-		Debug:  *logDebugFlag,
-		Format: *logFormatFlag,
-	}
-
 	flag.Parse()
 
-	if err := logOptions.Validate(); err != nil {
-		fmt.Printf("error occurred while validating zap logger options: %v\n", err)
-		os.Exit(1)
-	}
-
-	rawLog := kubermaticlog.New(logOptions.Debug, kubermaticlog.Format(logOptions.Format))
+	rawLog := kubermaticlog.New(logOpts.Debug, logOpts.Format)
 	log := rawLog.Sugar()
 
 	_, network, err := net.ParseCIDR(*networkFlag)

--- a/api/cmd/kubermatic-api/main.go
+++ b/api/cmd/kubermatic-api/main.go
@@ -74,7 +74,7 @@ func main() {
 		fmt.Println(err)
 		os.Exit(1)
 	}
-	rawLog := kubermaticlog.New(options.log.Debug, kubermaticlog.Format(options.log.Format))
+	rawLog := kubermaticlog.New(options.log.Debug, options.log.Format)
 	log := rawLog.Sugar()
 	defer func() {
 		if err := log.Sync(); err != nil {
@@ -308,7 +308,7 @@ func createAPIHandler(options serverRunOptions, prov providers, oidcIssuerVerifi
 	serviceAccountTokenAuth := serviceaccount.JWTTokenAuthenticator([]byte(options.serviceAccountSigningKey))
 
 	r := handler.NewRouting(
-		kubermaticlog.New(options.log.Debug, kubermaticlog.Format(options.log.Format)).Sugar(),
+		kubermaticlog.New(options.log.Debug, options.log.Format).Sugar(),
 		prov.seedsGetter,
 		prov.clusterProviderGetter,
 		prov.addons,

--- a/api/cmd/kubermatic-api/options.go
+++ b/api/cmd/kubermatic-api/options.go
@@ -58,6 +58,9 @@ func newServerRunOptions() (serverRunOptions, error) {
 		rawAccessibleAddons string
 	)
 
+	s.log = kubermaticlog.NewDefaultOptions()
+	s.log.AddFlags(flag.CommandLine)
+
 	flag.StringVar(&s.listenAddress, "address", ":8080", "The address to listen on")
 	flag.StringVar(&s.kubeconfig, "kubeconfig", "", "Path to the kubeconfig.")
 	flag.StringVar(&s.internalAddr, "internal-address", "127.0.0.1:8085", "The address on which the internal handler should be exposed")
@@ -85,8 +88,6 @@ func newServerRunOptions() (serverRunOptions, error) {
 	flag.StringVar(&rawExposeStrategy, "expose-strategy", "NodePort", "The strategy to expose the controlplane with, either \"NodePort\" which creates NodePorts with a \"nodeport-proxy.k8s.io/expose: true\" annotation or \"LoadBalancer\", which creates a LoadBalancer")
 	flag.BoolVar(&s.dynamicDatacenters, "dynamic-datacenters", false, "Whether to enable dynamic datacenters")
 	flag.StringVar(&s.namespace, "namespace", "kubermatic", "The namespace kubermatic runs in, uses to determine where to look for datacenter custom resources")
-	flag.BoolVar(&s.log.Debug, "log-debug", false, "Enables debug logging")
-	flag.StringVar(&s.log.Format, "log-format", string(kubermaticlog.FormatJSON), "Log format. Available are: "+kubermaticlog.AvailableFormats.String())
 	flag.Parse()
 
 	featureGates, err := features.NewFeatures(rawFeatureGates)

--- a/api/cmd/master-controller-manager/main.go
+++ b/api/cmd/master-controller-manager/main.go
@@ -42,7 +42,6 @@ type controllerRunOptions struct {
 	masterURL          string
 	internalAddr       string
 	dynamicDatacenters bool
-	log                kubermaticlog.Options
 	seedvalidationHook seedvalidation.WebhookOpts
 
 	workerName string
@@ -68,6 +67,8 @@ func main() {
 	klog.InitFlags(nil)
 	pprofOpts := &pprof.Opts{}
 	pprofOpts.AddFlags(flag.CommandLine)
+	logOpts := kubermaticlog.NewDefaultOptions()
+	logOpts.AddFlags(flag.CommandLine)
 	runOpts.seedvalidationHook.AddFlags(flag.CommandLine)
 	flag.StringVar(&runOpts.kubeconfig, "kubeconfig", "", "Path to a kubeconfig.")
 	flag.StringVar(&runOpts.dcFile, "datacenters", "", "The datacenters.yaml file path.")
@@ -77,12 +78,10 @@ func main() {
 	flag.StringVar(&runOpts.internalAddr, "internal-address", "127.0.0.1:8085", "The address on which the /metrics endpoint will be served.")
 	flag.BoolVar(&runOpts.dynamicDatacenters, "dynamic-datacenters", false, "Whether to enable dynamic datacenters. Enabling this and defining the datcenters flag will enable the migration of the datacenters defined in datancenters.yaml to Seed custom resources.")
 	flag.StringVar(&ctrlCtx.namespace, "namespace", "kubermatic", "The namespace kubermatic runs in, uses to determine where to look for datacenter custom resources.")
-	flag.BoolVar(&runOpts.log.Debug, "log-debug", false, "Enables debug logging.")
-	flag.StringVar(&runOpts.log.Format, "log-format", string(kubermaticlog.FormatJSON), "Log format. Available are: "+kubermaticlog.AvailableFormats.String())
 	flag.Parse()
 
 	ctrlruntimelog.SetLogger(ctrlruntimelog.ZapLogger(false))
-	rawLog := kubermaticlog.New(runOpts.log.Debug, kubermaticlog.Format(runOpts.log.Format))
+	rawLog := kubermaticlog.New(logOpts.Debug, logOpts.Format)
 	log := rawLog.Sugar()
 	defer func() {
 		if err := log.Sync(); err != nil {

--- a/api/cmd/s3-exporter/main.go
+++ b/api/cmd/s3-exporter/main.go
@@ -17,7 +17,8 @@ import (
 )
 
 func main() {
-	logFormat := log.FormatJSON
+	logOpts := log.NewDefaultOptions()
+	logOpts.AddFlags(flag.CommandLine)
 
 	endpointWithProto := flag.String("endpoint", "", "The s3 endpoint, e.G. https://my-s3.com:9000")
 	accessKeyID := flag.String("access-key-id", "", "S3 Access key, defaults to the ACCESS_KEY_ID environment variable")
@@ -25,12 +26,10 @@ func main() {
 	bucket := flag.String("bucket", "kubermatic-etcd-backups", "The bucket to monitor")
 	kubeconfig := flag.String("kubeconfig", "", "Path to a kubeconfig. Only required if out-of-cluster.")
 	listenAddress := flag.String("address", ":9340", "The port to listen on")
-	debugLogging := flag.Bool("log-debug", false, "Enable more verbose logging")
-	flag.Var(&logFormat, "log-format", fmt.Sprintf("Use one of [%v] to change the log output format", log.AvailableFormats))
 	flag.Parse()
 
 	// setup logging
-	rawLog := log.New(*debugLogging, logFormat)
+	rawLog := log.New(logOpts.Debug, logOpts.Format)
 	logger := rawLog.Sugar()
 	defer func() {
 		if err := logger.Sync(); err != nil {

--- a/api/cmd/seed-controller-manager/main.go
+++ b/api/cmd/seed-controller-manager/main.go
@@ -44,6 +44,8 @@ func main() {
 	klog.InitFlags(nil)
 	pprofOpts := &pprof.Opts{}
 	pprofOpts.AddFlags(flag.CommandLine)
+	logOpts := kubermaticlog.NewDefaultOptions()
+	logOpts.AddFlags(flag.CommandLine)
 	options, err := newControllerRunOptions()
 	if err != nil {
 		fmt.Printf("Failed to create controller run options due to = %v\n", err)
@@ -54,7 +56,7 @@ func main() {
 		fmt.Println(err)
 		os.Exit(1)
 	}
-	rawLog := kubermaticlog.New(options.log.Debug, kubermaticlog.Format(options.log.Format))
+	rawLog := kubermaticlog.New(logOpts.Debug, logOpts.Format)
 	log := rawLog.Sugar().With(
 		"worker-name", options.workerName,
 	)

--- a/api/cmd/seed-controller-manager/options.go
+++ b/api/cmd/seed-controller-manager/options.go
@@ -16,7 +16,6 @@ import (
 	backupcontroller "github.com/kubermatic/kubermatic/api/pkg/controller/seed-controller-manager/backup"
 	kubermaticv1 "github.com/kubermatic/kubermatic/api/pkg/crd/kubermatic/v1"
 	"github.com/kubermatic/kubermatic/api/pkg/features"
-	kubermaticlog "github.com/kubermatic/kubermatic/api/pkg/log"
 	"github.com/kubermatic/kubermatic/api/pkg/provider"
 	"github.com/kubermatic/kubermatic/api/pkg/resources"
 	seedvalidation "github.com/kubermatic/kubermatic/api/pkg/validation/seed"
@@ -58,7 +57,6 @@ type controllerRunOptions struct {
 	inClusterPrometheusScrapingConfigsFile           string
 	monitoringScrapeAnnotationPrefix                 string
 	dockerPullConfigJSONFile                         string
-	log                                              kubermaticlog.Options
 	kubermaticImage                                  string
 	dnatControllerImage                              string
 	dynamicDatacenters                               bool
@@ -118,8 +116,6 @@ func newControllerRunOptions() (controllerRunOptions, error) {
 	flag.StringVar(&c.oidcIssuerURL, "oidc-issuer-url", "", "URL of the OpenID token issuer. Example: http://auth.int.kubermatic.io")
 	flag.StringVar(&c.oidcIssuerClientID, "oidc-issuer-client-id", "", "Issuer client ID")
 	flag.StringVar(&c.oidcIssuerClientSecret, "oidc-issuer-client-secret", "", "OpenID client secret")
-	flag.BoolVar(&c.log.Debug, "log-debug", false, "Enables debug logging")
-	flag.StringVar(&c.log.Format, "log-format", string(kubermaticlog.FormatJSON), "Log format. Available are: "+kubermaticlog.AvailableFormats.String())
 	flag.StringVar(&c.kubermaticImage, "kubermatic-image", resources.DefaultKubermaticImage, "The location from which to pull the Kubermatic image")
 	flag.StringVar(&c.dnatControllerImage, "dnatcontroller-image", resources.DefaultDNATControllerImage, "The location of the dnatcontroller-image")
 	flag.BoolVar(&c.dynamicDatacenters, "dynamic-datacenters", false, "Whether to enable dynamic datacenters")
@@ -219,10 +215,6 @@ func (o controllerRunOptions) validate() error {
 	// we create for the metrics-server running in the seed and will render the latter unusable
 	if strings.Contains(o.kubernetesAddonsList, "metrics-server") {
 		return errors.New("the metrics-server addon must be disabled, it is now deployed inside the seed cluster")
-	}
-
-	if err := o.log.Validate(); err != nil {
-		return err
 	}
 
 	return nil

--- a/api/cmd/user-ssh-keys-agent/main.go
+++ b/api/cmd/user-ssh-keys-agent/main.go
@@ -20,23 +20,12 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/manager"
 )
 
-type controllerRunOptions struct {
-	log kubermaticlog.Options
-}
-
 func main() {
-	runOp := controllerRunOptions{}
-	flag.BoolVar(&runOp.log.Debug, "log-debug", false, "Enables debug logging")
-	flag.StringVar(&runOp.log.Format, "log-format", string(kubermaticlog.FormatJSON), "Log format. Available are: "+kubermaticlog.AvailableFormats.String())
-
+	logOpts := kubermaticlog.NewDefaultOptions()
+	logOpts.AddFlags(flag.CommandLine)
 	flag.Parse()
 
-	if err := runOp.log.Validate(); err != nil {
-		fmt.Printf("error occurred while validating zap logger options: %v\n", err)
-		os.Exit(1)
-	}
-
-	rawLog := kubermaticlog.New(runOp.log.Debug, kubermaticlog.Format(runOp.log.Format))
+	rawLog := kubermaticlog.New(logOpts.Debug, logOpts.Format)
 	log := rawLog.Sugar()
 
 	cfg, err := config.GetConfig()

--- a/api/pkg/log/zap.go
+++ b/api/pkg/log/zap.go
@@ -1,6 +1,7 @@
 package log
 
 import (
+	"flag"
 	"fmt"
 	"os"
 	"strings"
@@ -22,7 +23,19 @@ type Options struct {
 	// Enable debug logs
 	Debug bool
 	// Log format (JSON or plain text)
-	Format string
+	Format Format
+}
+
+func NewDefaultOptions() Options {
+	return Options{
+		Debug:  false,
+		Format: FormatJSON,
+	}
+}
+
+func (o *Options) AddFlags(fs *flag.FlagSet) {
+	fs.BoolVar(&o.Debug, "log-debug", o.Debug, "Enables debug logging")
+	fs.Var(&o.Format, "log-format", "Log format, one of "+AvailableFormats.String())
 }
 
 func (o *Options) Validate() error {
@@ -73,9 +86,9 @@ func (f Formats) String() string {
 	return strings.TrimPrefix(s, separator)
 }
 
-func (f Formats) Contains(s string) bool {
+func (f Formats) Contains(s Format) bool {
 	for _, format := range f {
-		if s == string(format) {
+		if s == format {
 			return true
 		}
 	}

--- a/api/pkg/test/clusterexposer/cmd/main.go
+++ b/api/pkg/test/clusterexposer/cmd/main.go
@@ -86,7 +86,7 @@ func isRequired(flagName string) bool {
 }
 
 func run(cmd *cobra.Command, _ []string) error {
-	rawLog := log.New(debug, log.Format(string(log.FormatJSON)))
+	rawLog := log.New(debug, log.FormatJSON)
 	log := rawLog.Sugar()
 	outerCfg, err := clientcmd.BuildConfigFromFlags("", kubeconfigOuterFile)
 	if err != nil {


### PR DESCRIPTION
**What this PR does / why we need it**:
All controllers had their own way of handling the logging flags. Some used a string-based format, some used the dedicated `log.Format` type. Some validated the flags, some did not. Some put the log options in their logOptions struct, some kept them independent.

This PR cleans the mess up and makes sure that we always validate the logging flags. I had panics in my controller because I accidentally ran it with `-log-format=json` (lowercase was not allowed).

**Does this PR introduce a user-facing change?**:
```release-note
NONE
```
