### PR TITLE
Use etcd v3.4 for Kube 1.17+

### DIFF
--- a/api/cmd/image-loader/main.go
+++ b/api/cmd/image-loader/main.go
@@ -12,7 +12,6 @@ import (
 
 	addonutil "github.com/kubermatic/kubermatic/api/pkg/addon"
 	apiv1 "github.com/kubermatic/kubermatic/api/pkg/api/v1"
-	backupcontroller "github.com/kubermatic/kubermatic/api/pkg/controller/seed-controller-manager/backup"
 	kubernetescontroller "github.com/kubermatic/kubermatic/api/pkg/controller/seed-controller-manager/kubernetes"
 	"github.com/kubermatic/kubermatic/api/pkg/controller/seed-controller-manager/monitoring"
 	containerlinux "github.com/kubermatic/kubermatic/api/pkg/controller/user-cluster-controller-manager/container-linux"
@@ -46,9 +45,7 @@ import (
 const mockNamespaceName = "mock-namespace"
 
 var (
-	staticImages = []string{
-		backupcontroller.DefaultBackupContainerImage,
-	}
+	staticImages = []string{}
 )
 
 type opts struct {

--- a/api/pkg/controller/seed-controller-manager/backup/backup_controller_test.go
+++ b/api/pkg/controller/seed-controller-manager/backup/backup_controller_test.go
@@ -8,6 +8,7 @@ import (
 	kubermaticlog "github.com/kubermatic/kubermatic/api/pkg/log"
 	"github.com/kubermatic/kubermatic/api/pkg/resources"
 	"github.com/kubermatic/kubermatic/api/pkg/resources/certificates/triple"
+	"github.com/kubermatic/kubermatic/api/pkg/semver"
 
 	batchv1beta1 "k8s.io/api/batch/v1beta1"
 	corev1 "k8s.io/api/core/v1"
@@ -32,6 +33,9 @@ func TestEnsureBackupCronJob(t *testing.T) {
 	cluster := &kubermaticv1.Cluster{
 		ObjectMeta: metav1.ObjectMeta{
 			Name: "test-cluster",
+		},
+		Spec: kubermaticv1.ClusterSpec{
+			Version: *semver.NewSemverOrDie("1.16.3"),
 		},
 		Status: kubermaticv1.ClusterStatus{
 			NamespaceName: "testnamespace",

--- a/api/pkg/resources/etcd/cronjob.go
+++ b/api/pkg/resources/etcd/cronjob.go
@@ -42,7 +42,7 @@ func CronJobCreator(data cronJobCreatorData) reconciling.NamedCronJobCreatorGett
 			job.Spec.JobTemplate.Spec.Template.Spec.Containers = []corev1.Container{
 				{
 					Name:    "defragger",
-					Image:   data.ImageRegistry(resources.RegistryGCR) + "/etcd-development/etcd:" + ImageTag,
+					Image:   data.ImageRegistry(resources.RegistryGCR) + "/etcd-development/etcd:" + ImageTag(data.Cluster()),
 					Command: command,
 					VolumeMounts: []corev1.VolumeMount{
 						{

--- a/api/pkg/resources/etcd/etcdrunning/etcdrunning.go
+++ b/api/pkg/resources/etcd/etcdrunning/etcdrunning.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"strings"
 
+	kubermaticv1 "github.com/kubermatic/kubermatic/api/pkg/crd/kubermatic/v1"
 	"github.com/kubermatic/kubermatic/api/pkg/resources"
 	"github.com/kubermatic/kubermatic/api/pkg/resources/etcd"
 
@@ -12,12 +13,13 @@ import (
 
 type etcdRunningData interface {
 	ImageRegistry(defaultRegistry string) string
+	Cluster() *kubermaticv1.Cluster
 }
 
 func Container(etcdEndpoints []string, data etcdRunningData) corev1.Container {
 	return corev1.Container{
 		Name:  "etcd-running",
-		Image: data.ImageRegistry(resources.RegistryGCR) + "/etcd-development/etcd:" + etcd.ImageTag,
+		Image: data.ImageRegistry(resources.RegistryGCR) + "/etcd-development/etcd:" + etcd.ImageTag(data.Cluster()),
 		Command: []string{
 			"/bin/sh",
 			"-ec",

--- a/api/pkg/resources/etcd/statefulset_test.go
+++ b/api/pkg/resources/etcd/statefulset_test.go
@@ -5,7 +5,11 @@ import (
 	"fmt"
 	"testing"
 
+	kubermaticv1 "github.com/kubermatic/kubermatic/api/pkg/crd/kubermatic/v1"
+	"github.com/kubermatic/kubermatic/api/pkg/semver"
 	testhelper "github.com/kubermatic/kubermatic/api/pkg/test"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
 var update = flag.Bool("update", false, "update .golden files")
@@ -53,6 +57,49 @@ func TestGetEtcdCommand(t *testing.T) {
 			cmd := args[2]
 
 			testhelper.CompareOutput(t, fmt.Sprintf("etcd-command-%s", test.name), cmd, *update, ".sh")
+		})
+	}
+}
+
+func TestGetImageTag(t *testing.T) {
+	testCases := []struct {
+		name           string
+		cluster        *kubermaticv1.Cluster
+		expectedResult string
+	}{
+		{
+			name: "Openshift",
+			cluster: &kubermaticv1.Cluster{
+				ObjectMeta: metav1.ObjectMeta{
+					Annotations: map[string]string{"kubermatic.io/openshift": "true"},
+				},
+				Spec: kubermaticv1.ClusterSpec{Version: *semver.NewSemverOrDie("4.17.18")},
+			},
+			expectedResult: imageTagV33,
+		},
+		{
+			name: "Kubernetes 1.16",
+			cluster: &kubermaticv1.Cluster{
+				Spec: kubermaticv1.ClusterSpec{Version: *semver.NewSemverOrDie("1.16.0")},
+			},
+			expectedResult: imageTagV33,
+		},
+		{
+			name: "Kubernetes 1.17",
+			cluster: &kubermaticv1.Cluster{
+				Spec: kubermaticv1.ClusterSpec{Version: *semver.NewSemverOrDie("1.17.0")},
+			},
+			expectedResult: imageTagV34,
+		},
+	}
+
+	for idx := range testCases {
+		tc := testCases[idx]
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			if result := ImageTag(tc.cluster); result != tc.expectedResult {
+				t.Fatalf("expected result %s but got result %s", tc.expectedResult, result)
+			}
 		})
 	}
 }

--- a/api/pkg/resources/test/fixtures/cronjob-aws-1.10.0-etcd-defragger.yaml
+++ b/api/pkg/resources/test/fixtures/cronjob-aws-1.10.0-etcd-defragger.yaml
@@ -44,7 +44,7 @@ spec:
                   echo "$node is not healthy, skipping defrag."
                 fi
               done
-            image: gcr.io/etcd-development/etcd:v3.3.15
+            image: gcr.io/etcd-development/etcd:v3.3.18
             name: defragger
             resources: {}
             volumeMounts:

--- a/api/pkg/resources/test/fixtures/cronjob-aws-1.10.6-etcd-defragger.yaml
+++ b/api/pkg/resources/test/fixtures/cronjob-aws-1.10.6-etcd-defragger.yaml
@@ -44,7 +44,7 @@ spec:
                   echo "$node is not healthy, skipping defrag."
                 fi
               done
-            image: gcr.io/etcd-development/etcd:v3.3.15
+            image: gcr.io/etcd-development/etcd:v3.3.18
             name: defragger
             resources: {}
             volumeMounts:

--- a/api/pkg/resources/test/fixtures/cronjob-aws-1.11.0-etcd-defragger.yaml
+++ b/api/pkg/resources/test/fixtures/cronjob-aws-1.11.0-etcd-defragger.yaml
@@ -44,7 +44,7 @@ spec:
                   echo "$node is not healthy, skipping defrag."
                 fi
               done
-            image: gcr.io/etcd-development/etcd:v3.3.15
+            image: gcr.io/etcd-development/etcd:v3.3.18
             name: defragger
             resources: {}
             volumeMounts:

--- a/api/pkg/resources/test/fixtures/cronjob-aws-1.11.1-etcd-defragger.yaml
+++ b/api/pkg/resources/test/fixtures/cronjob-aws-1.11.1-etcd-defragger.yaml
@@ -44,7 +44,7 @@ spec:
                   echo "$node is not healthy, skipping defrag."
                 fi
               done
-            image: gcr.io/etcd-development/etcd:v3.3.15
+            image: gcr.io/etcd-development/etcd:v3.3.18
             name: defragger
             resources: {}
             volumeMounts:

--- a/api/pkg/resources/test/fixtures/cronjob-aws-1.12.0-etcd-defragger.yaml
+++ b/api/pkg/resources/test/fixtures/cronjob-aws-1.12.0-etcd-defragger.yaml
@@ -44,7 +44,7 @@ spec:
                   echo "$node is not healthy, skipping defrag."
                 fi
               done
-            image: gcr.io/etcd-development/etcd:v3.3.15
+            image: gcr.io/etcd-development/etcd:v3.3.18
             name: defragger
             resources: {}
             volumeMounts:

--- a/api/pkg/resources/test/fixtures/cronjob-aws-1.13.0-etcd-defragger.yaml
+++ b/api/pkg/resources/test/fixtures/cronjob-aws-1.13.0-etcd-defragger.yaml
@@ -44,7 +44,7 @@ spec:
                   echo "$node is not healthy, skipping defrag."
                 fi
               done
-            image: gcr.io/etcd-development/etcd:v3.3.15
+            image: gcr.io/etcd-development/etcd:v3.3.18
             name: defragger
             resources: {}
             volumeMounts:

--- a/api/pkg/resources/test/fixtures/cronjob-azure-1.10.0-etcd-defragger.yaml
+++ b/api/pkg/resources/test/fixtures/cronjob-azure-1.10.0-etcd-defragger.yaml
@@ -44,7 +44,7 @@ spec:
                   echo "$node is not healthy, skipping defrag."
                 fi
               done
-            image: gcr.io/etcd-development/etcd:v3.3.15
+            image: gcr.io/etcd-development/etcd:v3.3.18
             name: defragger
             resources: {}
             volumeMounts:

--- a/api/pkg/resources/test/fixtures/cronjob-azure-1.10.6-etcd-defragger.yaml
+++ b/api/pkg/resources/test/fixtures/cronjob-azure-1.10.6-etcd-defragger.yaml
@@ -44,7 +44,7 @@ spec:
                   echo "$node is not healthy, skipping defrag."
                 fi
               done
-            image: gcr.io/etcd-development/etcd:v3.3.15
+            image: gcr.io/etcd-development/etcd:v3.3.18
             name: defragger
             resources: {}
             volumeMounts:

--- a/api/pkg/resources/test/fixtures/cronjob-azure-1.11.0-etcd-defragger.yaml
+++ b/api/pkg/resources/test/fixtures/cronjob-azure-1.11.0-etcd-defragger.yaml
@@ -44,7 +44,7 @@ spec:
                   echo "$node is not healthy, skipping defrag."
                 fi
               done
-            image: gcr.io/etcd-development/etcd:v3.3.15
+            image: gcr.io/etcd-development/etcd:v3.3.18
             name: defragger
             resources: {}
             volumeMounts:

--- a/api/pkg/resources/test/fixtures/cronjob-azure-1.11.1-etcd-defragger.yaml
+++ b/api/pkg/resources/test/fixtures/cronjob-azure-1.11.1-etcd-defragger.yaml
@@ -44,7 +44,7 @@ spec:
                   echo "$node is not healthy, skipping defrag."
                 fi
               done
-            image: gcr.io/etcd-development/etcd:v3.3.15
+            image: gcr.io/etcd-development/etcd:v3.3.18
             name: defragger
             resources: {}
             volumeMounts:

--- a/api/pkg/resources/test/fixtures/cronjob-azure-1.12.0-etcd-defragger.yaml
+++ b/api/pkg/resources/test/fixtures/cronjob-azure-1.12.0-etcd-defragger.yaml
@@ -44,7 +44,7 @@ spec:
                   echo "$node is not healthy, skipping defrag."
                 fi
               done
-            image: gcr.io/etcd-development/etcd:v3.3.15
+            image: gcr.io/etcd-development/etcd:v3.3.18
             name: defragger
             resources: {}
             volumeMounts:

--- a/api/pkg/resources/test/fixtures/cronjob-azure-1.13.0-etcd-defragger.yaml
+++ b/api/pkg/resources/test/fixtures/cronjob-azure-1.13.0-etcd-defragger.yaml
@@ -44,7 +44,7 @@ spec:
                   echo "$node is not healthy, skipping defrag."
                 fi
               done
-            image: gcr.io/etcd-development/etcd:v3.3.15
+            image: gcr.io/etcd-development/etcd:v3.3.18
             name: defragger
             resources: {}
             volumeMounts:

--- a/api/pkg/resources/test/fixtures/cronjob-bringyourown-1.10.0-etcd-defragger.yaml
+++ b/api/pkg/resources/test/fixtures/cronjob-bringyourown-1.10.0-etcd-defragger.yaml
@@ -44,7 +44,7 @@ spec:
                   echo "$node is not healthy, skipping defrag."
                 fi
               done
-            image: gcr.io/etcd-development/etcd:v3.3.15
+            image: gcr.io/etcd-development/etcd:v3.3.18
             name: defragger
             resources: {}
             volumeMounts:

--- a/api/pkg/resources/test/fixtures/cronjob-bringyourown-1.10.6-etcd-defragger.yaml
+++ b/api/pkg/resources/test/fixtures/cronjob-bringyourown-1.10.6-etcd-defragger.yaml
@@ -44,7 +44,7 @@ spec:
                   echo "$node is not healthy, skipping defrag."
                 fi
               done
-            image: gcr.io/etcd-development/etcd:v3.3.15
+            image: gcr.io/etcd-development/etcd:v3.3.18
             name: defragger
             resources: {}
             volumeMounts:

--- a/api/pkg/resources/test/fixtures/cronjob-bringyourown-1.11.0-etcd-defragger.yaml
+++ b/api/pkg/resources/test/fixtures/cronjob-bringyourown-1.11.0-etcd-defragger.yaml
@@ -44,7 +44,7 @@ spec:
                   echo "$node is not healthy, skipping defrag."
                 fi
               done
-            image: gcr.io/etcd-development/etcd:v3.3.15
+            image: gcr.io/etcd-development/etcd:v3.3.18
             name: defragger
             resources: {}
             volumeMounts:

--- a/api/pkg/resources/test/fixtures/cronjob-bringyourown-1.11.1-etcd-defragger.yaml
+++ b/api/pkg/resources/test/fixtures/cronjob-bringyourown-1.11.1-etcd-defragger.yaml
@@ -44,7 +44,7 @@ spec:
                   echo "$node is not healthy, skipping defrag."
                 fi
               done
-            image: gcr.io/etcd-development/etcd:v3.3.15
+            image: gcr.io/etcd-development/etcd:v3.3.18
             name: defragger
             resources: {}
             volumeMounts:

--- a/api/pkg/resources/test/fixtures/cronjob-bringyourown-1.12.0-etcd-defragger.yaml
+++ b/api/pkg/resources/test/fixtures/cronjob-bringyourown-1.12.0-etcd-defragger.yaml
@@ -44,7 +44,7 @@ spec:
                   echo "$node is not healthy, skipping defrag."
                 fi
               done
-            image: gcr.io/etcd-development/etcd:v3.3.15
+            image: gcr.io/etcd-development/etcd:v3.3.18
             name: defragger
             resources: {}
             volumeMounts:

--- a/api/pkg/resources/test/fixtures/cronjob-bringyourown-1.13.0-etcd-defragger.yaml
+++ b/api/pkg/resources/test/fixtures/cronjob-bringyourown-1.13.0-etcd-defragger.yaml
@@ -44,7 +44,7 @@ spec:
                   echo "$node is not healthy, skipping defrag."
                 fi
               done
-            image: gcr.io/etcd-development/etcd:v3.3.15
+            image: gcr.io/etcd-development/etcd:v3.3.18
             name: defragger
             resources: {}
             volumeMounts:

--- a/api/pkg/resources/test/fixtures/cronjob-digitalocean-1.10.0-etcd-defragger.yaml
+++ b/api/pkg/resources/test/fixtures/cronjob-digitalocean-1.10.0-etcd-defragger.yaml
@@ -44,7 +44,7 @@ spec:
                   echo "$node is not healthy, skipping defrag."
                 fi
               done
-            image: gcr.io/etcd-development/etcd:v3.3.15
+            image: gcr.io/etcd-development/etcd:v3.3.18
             name: defragger
             resources: {}
             volumeMounts:

--- a/api/pkg/resources/test/fixtures/cronjob-digitalocean-1.10.6-etcd-defragger.yaml
+++ b/api/pkg/resources/test/fixtures/cronjob-digitalocean-1.10.6-etcd-defragger.yaml
@@ -44,7 +44,7 @@ spec:
                   echo "$node is not healthy, skipping defrag."
                 fi
               done
-            image: gcr.io/etcd-development/etcd:v3.3.15
+            image: gcr.io/etcd-development/etcd:v3.3.18
             name: defragger
             resources: {}
             volumeMounts:

--- a/api/pkg/resources/test/fixtures/cronjob-digitalocean-1.11.0-etcd-defragger.yaml
+++ b/api/pkg/resources/test/fixtures/cronjob-digitalocean-1.11.0-etcd-defragger.yaml
@@ -44,7 +44,7 @@ spec:
                   echo "$node is not healthy, skipping defrag."
                 fi
               done
-            image: gcr.io/etcd-development/etcd:v3.3.15
+            image: gcr.io/etcd-development/etcd:v3.3.18
             name: defragger
             resources: {}
             volumeMounts:

--- a/api/pkg/resources/test/fixtures/cronjob-digitalocean-1.11.1-etcd-defragger.yaml
+++ b/api/pkg/resources/test/fixtures/cronjob-digitalocean-1.11.1-etcd-defragger.yaml
@@ -44,7 +44,7 @@ spec:
                   echo "$node is not healthy, skipping defrag."
                 fi
               done
-            image: gcr.io/etcd-development/etcd:v3.3.15
+            image: gcr.io/etcd-development/etcd:v3.3.18
             name: defragger
             resources: {}
             volumeMounts:

--- a/api/pkg/resources/test/fixtures/cronjob-digitalocean-1.12.0-etcd-defragger.yaml
+++ b/api/pkg/resources/test/fixtures/cronjob-digitalocean-1.12.0-etcd-defragger.yaml
@@ -44,7 +44,7 @@ spec:
                   echo "$node is not healthy, skipping defrag."
                 fi
               done
-            image: gcr.io/etcd-development/etcd:v3.3.15
+            image: gcr.io/etcd-development/etcd:v3.3.18
             name: defragger
             resources: {}
             volumeMounts:

--- a/api/pkg/resources/test/fixtures/cronjob-digitalocean-1.13.0-etcd-defragger.yaml
+++ b/api/pkg/resources/test/fixtures/cronjob-digitalocean-1.13.0-etcd-defragger.yaml
@@ -44,7 +44,7 @@ spec:
                   echo "$node is not healthy, skipping defrag."
                 fi
               done
-            image: gcr.io/etcd-development/etcd:v3.3.15
+            image: gcr.io/etcd-development/etcd:v3.3.18
             name: defragger
             resources: {}
             volumeMounts:

--- a/api/pkg/resources/test/fixtures/cronjob-openstack-1.10.0-etcd-defragger.yaml
+++ b/api/pkg/resources/test/fixtures/cronjob-openstack-1.10.0-etcd-defragger.yaml
@@ -44,7 +44,7 @@ spec:
                   echo "$node is not healthy, skipping defrag."
                 fi
               done
-            image: gcr.io/etcd-development/etcd:v3.3.15
+            image: gcr.io/etcd-development/etcd:v3.3.18
             name: defragger
             resources: {}
             volumeMounts:

--- a/api/pkg/resources/test/fixtures/cronjob-openstack-1.10.6-etcd-defragger.yaml
+++ b/api/pkg/resources/test/fixtures/cronjob-openstack-1.10.6-etcd-defragger.yaml
@@ -44,7 +44,7 @@ spec:
                   echo "$node is not healthy, skipping defrag."
                 fi
               done
-            image: gcr.io/etcd-development/etcd:v3.3.15
+            image: gcr.io/etcd-development/etcd:v3.3.18
             name: defragger
             resources: {}
             volumeMounts:

--- a/api/pkg/resources/test/fixtures/cronjob-openstack-1.11.0-etcd-defragger.yaml
+++ b/api/pkg/resources/test/fixtures/cronjob-openstack-1.11.0-etcd-defragger.yaml
@@ -44,7 +44,7 @@ spec:
                   echo "$node is not healthy, skipping defrag."
                 fi
               done
-            image: gcr.io/etcd-development/etcd:v3.3.15
+            image: gcr.io/etcd-development/etcd:v3.3.18
             name: defragger
             resources: {}
             volumeMounts:

--- a/api/pkg/resources/test/fixtures/cronjob-openstack-1.11.1-etcd-defragger.yaml
+++ b/api/pkg/resources/test/fixtures/cronjob-openstack-1.11.1-etcd-defragger.yaml
@@ -44,7 +44,7 @@ spec:
                   echo "$node is not healthy, skipping defrag."
                 fi
               done
-            image: gcr.io/etcd-development/etcd:v3.3.15
+            image: gcr.io/etcd-development/etcd:v3.3.18
             name: defragger
             resources: {}
             volumeMounts:

--- a/api/pkg/resources/test/fixtures/cronjob-openstack-1.12.0-etcd-defragger.yaml
+++ b/api/pkg/resources/test/fixtures/cronjob-openstack-1.12.0-etcd-defragger.yaml
@@ -44,7 +44,7 @@ spec:
                   echo "$node is not healthy, skipping defrag."
                 fi
               done
-            image: gcr.io/etcd-development/etcd:v3.3.15
+            image: gcr.io/etcd-development/etcd:v3.3.18
             name: defragger
             resources: {}
             volumeMounts:

--- a/api/pkg/resources/test/fixtures/cronjob-openstack-1.13.0-etcd-defragger.yaml
+++ b/api/pkg/resources/test/fixtures/cronjob-openstack-1.13.0-etcd-defragger.yaml
@@ -44,7 +44,7 @@ spec:
                   echo "$node is not healthy, skipping defrag."
                 fi
               done
-            image: gcr.io/etcd-development/etcd:v3.3.15
+            image: gcr.io/etcd-development/etcd:v3.3.18
             name: defragger
             resources: {}
             volumeMounts:

--- a/api/pkg/resources/test/fixtures/cronjob-vsphere-1.10.0-etcd-defragger.yaml
+++ b/api/pkg/resources/test/fixtures/cronjob-vsphere-1.10.0-etcd-defragger.yaml
@@ -44,7 +44,7 @@ spec:
                   echo "$node is not healthy, skipping defrag."
                 fi
               done
-            image: gcr.io/etcd-development/etcd:v3.3.15
+            image: gcr.io/etcd-development/etcd:v3.3.18
             name: defragger
             resources: {}
             volumeMounts:

--- a/api/pkg/resources/test/fixtures/cronjob-vsphere-1.10.6-etcd-defragger.yaml
+++ b/api/pkg/resources/test/fixtures/cronjob-vsphere-1.10.6-etcd-defragger.yaml
@@ -44,7 +44,7 @@ spec:
                   echo "$node is not healthy, skipping defrag."
                 fi
               done
-            image: gcr.io/etcd-development/etcd:v3.3.15
+            image: gcr.io/etcd-development/etcd:v3.3.18
             name: defragger
             resources: {}
             volumeMounts:

--- a/api/pkg/resources/test/fixtures/cronjob-vsphere-1.11.0-etcd-defragger.yaml
+++ b/api/pkg/resources/test/fixtures/cronjob-vsphere-1.11.0-etcd-defragger.yaml
@@ -44,7 +44,7 @@ spec:
                   echo "$node is not healthy, skipping defrag."
                 fi
               done
-            image: gcr.io/etcd-development/etcd:v3.3.15
+            image: gcr.io/etcd-development/etcd:v3.3.18
             name: defragger
             resources: {}
             volumeMounts:

--- a/api/pkg/resources/test/fixtures/cronjob-vsphere-1.11.1-etcd-defragger.yaml
+++ b/api/pkg/resources/test/fixtures/cronjob-vsphere-1.11.1-etcd-defragger.yaml
@@ -44,7 +44,7 @@ spec:
                   echo "$node is not healthy, skipping defrag."
                 fi
               done
-            image: gcr.io/etcd-development/etcd:v3.3.15
+            image: gcr.io/etcd-development/etcd:v3.3.18
             name: defragger
             resources: {}
             volumeMounts:

--- a/api/pkg/resources/test/fixtures/cronjob-vsphere-1.12.0-etcd-defragger.yaml
+++ b/api/pkg/resources/test/fixtures/cronjob-vsphere-1.12.0-etcd-defragger.yaml
@@ -44,7 +44,7 @@ spec:
                   echo "$node is not healthy, skipping defrag."
                 fi
               done
-            image: gcr.io/etcd-development/etcd:v3.3.15
+            image: gcr.io/etcd-development/etcd:v3.3.18
             name: defragger
             resources: {}
             volumeMounts:

--- a/api/pkg/resources/test/fixtures/cronjob-vsphere-1.13.0-etcd-defragger.yaml
+++ b/api/pkg/resources/test/fixtures/cronjob-vsphere-1.13.0-etcd-defragger.yaml
@@ -44,7 +44,7 @@ spec:
                   echo "$node is not healthy, skipping defrag."
                 fi
               done
-            image: gcr.io/etcd-development/etcd:v3.3.15
+            image: gcr.io/etcd-development/etcd:v3.3.18
             name: defragger
             resources: {}
             volumeMounts:

--- a/api/pkg/resources/test/fixtures/deployment-aws-1.10.0-apiserver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-aws-1.10.0-apiserver.yaml
@@ -329,7 +329,7 @@ spec:
           --dial-timeout=2s --endpoints='https://etcd-0.etcd.cluster-de-test-01.svc.cluster.local.:2379,https://etcd-1.etcd.cluster-de-test-01.svc.cluster.local.:2379,https://etcd-2.etcd.cluster-de-test-01.svc.cluster.local.:2379'
           put kubermatic/quorum-check something; do echo waiting for etcd; sleep 2;
           done;
-        image: gcr.io/etcd-development/etcd:v3.3.15
+        image: gcr.io/etcd-development/etcd:v3.3.18
         name: etcd-running
         resources: {}
         volumeMounts:

--- a/api/pkg/resources/test/fixtures/deployment-aws-1.10.6-apiserver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-aws-1.10.6-apiserver.yaml
@@ -329,7 +329,7 @@ spec:
           --dial-timeout=2s --endpoints='https://etcd-0.etcd.cluster-de-test-01.svc.cluster.local.:2379,https://etcd-1.etcd.cluster-de-test-01.svc.cluster.local.:2379,https://etcd-2.etcd.cluster-de-test-01.svc.cluster.local.:2379'
           put kubermatic/quorum-check something; do echo waiting for etcd; sleep 2;
           done;
-        image: gcr.io/etcd-development/etcd:v3.3.15
+        image: gcr.io/etcd-development/etcd:v3.3.18
         name: etcd-running
         resources: {}
         volumeMounts:

--- a/api/pkg/resources/test/fixtures/deployment-aws-1.11.0-apiserver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-aws-1.11.0-apiserver.yaml
@@ -327,7 +327,7 @@ spec:
           --dial-timeout=2s --endpoints='https://etcd-0.etcd.cluster-de-test-01.svc.cluster.local.:2379,https://etcd-1.etcd.cluster-de-test-01.svc.cluster.local.:2379,https://etcd-2.etcd.cluster-de-test-01.svc.cluster.local.:2379'
           put kubermatic/quorum-check something; do echo waiting for etcd; sleep 2;
           done;
-        image: gcr.io/etcd-development/etcd:v3.3.15
+        image: gcr.io/etcd-development/etcd:v3.3.18
         name: etcd-running
         resources: {}
         volumeMounts:

--- a/api/pkg/resources/test/fixtures/deployment-aws-1.11.1-apiserver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-aws-1.11.1-apiserver.yaml
@@ -327,7 +327,7 @@ spec:
           --dial-timeout=2s --endpoints='https://etcd-0.etcd.cluster-de-test-01.svc.cluster.local.:2379,https://etcd-1.etcd.cluster-de-test-01.svc.cluster.local.:2379,https://etcd-2.etcd.cluster-de-test-01.svc.cluster.local.:2379'
           put kubermatic/quorum-check something; do echo waiting for etcd; sleep 2;
           done;
-        image: gcr.io/etcd-development/etcd:v3.3.15
+        image: gcr.io/etcd-development/etcd:v3.3.18
         name: etcd-running
         resources: {}
         volumeMounts:

--- a/api/pkg/resources/test/fixtures/deployment-aws-1.12.0-apiserver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-aws-1.12.0-apiserver.yaml
@@ -327,7 +327,7 @@ spec:
           --dial-timeout=2s --endpoints='https://etcd-0.etcd.cluster-de-test-01.svc.cluster.local.:2379,https://etcd-1.etcd.cluster-de-test-01.svc.cluster.local.:2379,https://etcd-2.etcd.cluster-de-test-01.svc.cluster.local.:2379'
           put kubermatic/quorum-check something; do echo waiting for etcd; sleep 2;
           done;
-        image: gcr.io/etcd-development/etcd:v3.3.15
+        image: gcr.io/etcd-development/etcd:v3.3.18
         name: etcd-running
         resources: {}
         volumeMounts:

--- a/api/pkg/resources/test/fixtures/deployment-aws-1.13.0-apiserver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-aws-1.13.0-apiserver.yaml
@@ -327,7 +327,7 @@ spec:
           --dial-timeout=2s --endpoints='https://etcd-0.etcd.cluster-de-test-01.svc.cluster.local.:2379,https://etcd-1.etcd.cluster-de-test-01.svc.cluster.local.:2379,https://etcd-2.etcd.cluster-de-test-01.svc.cluster.local.:2379'
           put kubermatic/quorum-check something; do echo waiting for etcd; sleep 2;
           done;
-        image: gcr.io/etcd-development/etcd:v3.3.15
+        image: gcr.io/etcd-development/etcd:v3.3.18
         name: etcd-running
         resources: {}
         volumeMounts:

--- a/api/pkg/resources/test/fixtures/deployment-azure-1.10.0-apiserver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-azure-1.10.0-apiserver.yaml
@@ -323,7 +323,7 @@ spec:
           --dial-timeout=2s --endpoints='https://etcd-0.etcd.cluster-de-test-01.svc.cluster.local.:2379,https://etcd-1.etcd.cluster-de-test-01.svc.cluster.local.:2379,https://etcd-2.etcd.cluster-de-test-01.svc.cluster.local.:2379'
           put kubermatic/quorum-check something; do echo waiting for etcd; sleep 2;
           done;
-        image: gcr.io/etcd-development/etcd:v3.3.15
+        image: gcr.io/etcd-development/etcd:v3.3.18
         name: etcd-running
         resources: {}
         volumeMounts:

--- a/api/pkg/resources/test/fixtures/deployment-azure-1.10.6-apiserver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-azure-1.10.6-apiserver.yaml
@@ -323,7 +323,7 @@ spec:
           --dial-timeout=2s --endpoints='https://etcd-0.etcd.cluster-de-test-01.svc.cluster.local.:2379,https://etcd-1.etcd.cluster-de-test-01.svc.cluster.local.:2379,https://etcd-2.etcd.cluster-de-test-01.svc.cluster.local.:2379'
           put kubermatic/quorum-check something; do echo waiting for etcd; sleep 2;
           done;
-        image: gcr.io/etcd-development/etcd:v3.3.15
+        image: gcr.io/etcd-development/etcd:v3.3.18
         name: etcd-running
         resources: {}
         volumeMounts:

--- a/api/pkg/resources/test/fixtures/deployment-azure-1.11.0-apiserver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-azure-1.11.0-apiserver.yaml
@@ -321,7 +321,7 @@ spec:
           --dial-timeout=2s --endpoints='https://etcd-0.etcd.cluster-de-test-01.svc.cluster.local.:2379,https://etcd-1.etcd.cluster-de-test-01.svc.cluster.local.:2379,https://etcd-2.etcd.cluster-de-test-01.svc.cluster.local.:2379'
           put kubermatic/quorum-check something; do echo waiting for etcd; sleep 2;
           done;
-        image: gcr.io/etcd-development/etcd:v3.3.15
+        image: gcr.io/etcd-development/etcd:v3.3.18
         name: etcd-running
         resources: {}
         volumeMounts:

--- a/api/pkg/resources/test/fixtures/deployment-azure-1.11.1-apiserver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-azure-1.11.1-apiserver.yaml
@@ -321,7 +321,7 @@ spec:
           --dial-timeout=2s --endpoints='https://etcd-0.etcd.cluster-de-test-01.svc.cluster.local.:2379,https://etcd-1.etcd.cluster-de-test-01.svc.cluster.local.:2379,https://etcd-2.etcd.cluster-de-test-01.svc.cluster.local.:2379'
           put kubermatic/quorum-check something; do echo waiting for etcd; sleep 2;
           done;
-        image: gcr.io/etcd-development/etcd:v3.3.15
+        image: gcr.io/etcd-development/etcd:v3.3.18
         name: etcd-running
         resources: {}
         volumeMounts:

--- a/api/pkg/resources/test/fixtures/deployment-azure-1.12.0-apiserver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-azure-1.12.0-apiserver.yaml
@@ -321,7 +321,7 @@ spec:
           --dial-timeout=2s --endpoints='https://etcd-0.etcd.cluster-de-test-01.svc.cluster.local.:2379,https://etcd-1.etcd.cluster-de-test-01.svc.cluster.local.:2379,https://etcd-2.etcd.cluster-de-test-01.svc.cluster.local.:2379'
           put kubermatic/quorum-check something; do echo waiting for etcd; sleep 2;
           done;
-        image: gcr.io/etcd-development/etcd:v3.3.15
+        image: gcr.io/etcd-development/etcd:v3.3.18
         name: etcd-running
         resources: {}
         volumeMounts:

--- a/api/pkg/resources/test/fixtures/deployment-azure-1.13.0-apiserver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-azure-1.13.0-apiserver.yaml
@@ -321,7 +321,7 @@ spec:
           --dial-timeout=2s --endpoints='https://etcd-0.etcd.cluster-de-test-01.svc.cluster.local.:2379,https://etcd-1.etcd.cluster-de-test-01.svc.cluster.local.:2379,https://etcd-2.etcd.cluster-de-test-01.svc.cluster.local.:2379'
           put kubermatic/quorum-check something; do echo waiting for etcd; sleep 2;
           done;
-        image: gcr.io/etcd-development/etcd:v3.3.15
+        image: gcr.io/etcd-development/etcd:v3.3.18
         name: etcd-running
         resources: {}
         volumeMounts:

--- a/api/pkg/resources/test/fixtures/deployment-bringyourown-1.10.0-apiserver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-bringyourown-1.10.0-apiserver.yaml
@@ -319,7 +319,7 @@ spec:
           --dial-timeout=2s --endpoints='https://etcd-0.etcd.cluster-de-test-01.svc.cluster.local.:2379,https://etcd-1.etcd.cluster-de-test-01.svc.cluster.local.:2379,https://etcd-2.etcd.cluster-de-test-01.svc.cluster.local.:2379'
           put kubermatic/quorum-check something; do echo waiting for etcd; sleep 2;
           done;
-        image: gcr.io/etcd-development/etcd:v3.3.15
+        image: gcr.io/etcd-development/etcd:v3.3.18
         name: etcd-running
         resources: {}
         volumeMounts:

--- a/api/pkg/resources/test/fixtures/deployment-bringyourown-1.10.6-apiserver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-bringyourown-1.10.6-apiserver.yaml
@@ -319,7 +319,7 @@ spec:
           --dial-timeout=2s --endpoints='https://etcd-0.etcd.cluster-de-test-01.svc.cluster.local.:2379,https://etcd-1.etcd.cluster-de-test-01.svc.cluster.local.:2379,https://etcd-2.etcd.cluster-de-test-01.svc.cluster.local.:2379'
           put kubermatic/quorum-check something; do echo waiting for etcd; sleep 2;
           done;
-        image: gcr.io/etcd-development/etcd:v3.3.15
+        image: gcr.io/etcd-development/etcd:v3.3.18
         name: etcd-running
         resources: {}
         volumeMounts:

--- a/api/pkg/resources/test/fixtures/deployment-bringyourown-1.11.0-apiserver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-bringyourown-1.11.0-apiserver.yaml
@@ -317,7 +317,7 @@ spec:
           --dial-timeout=2s --endpoints='https://etcd-0.etcd.cluster-de-test-01.svc.cluster.local.:2379,https://etcd-1.etcd.cluster-de-test-01.svc.cluster.local.:2379,https://etcd-2.etcd.cluster-de-test-01.svc.cluster.local.:2379'
           put kubermatic/quorum-check something; do echo waiting for etcd; sleep 2;
           done;
-        image: gcr.io/etcd-development/etcd:v3.3.15
+        image: gcr.io/etcd-development/etcd:v3.3.18
         name: etcd-running
         resources: {}
         volumeMounts:

--- a/api/pkg/resources/test/fixtures/deployment-bringyourown-1.11.1-apiserver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-bringyourown-1.11.1-apiserver.yaml
@@ -317,7 +317,7 @@ spec:
           --dial-timeout=2s --endpoints='https://etcd-0.etcd.cluster-de-test-01.svc.cluster.local.:2379,https://etcd-1.etcd.cluster-de-test-01.svc.cluster.local.:2379,https://etcd-2.etcd.cluster-de-test-01.svc.cluster.local.:2379'
           put kubermatic/quorum-check something; do echo waiting for etcd; sleep 2;
           done;
-        image: gcr.io/etcd-development/etcd:v3.3.15
+        image: gcr.io/etcd-development/etcd:v3.3.18
         name: etcd-running
         resources: {}
         volumeMounts:

--- a/api/pkg/resources/test/fixtures/deployment-bringyourown-1.12.0-apiserver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-bringyourown-1.12.0-apiserver.yaml
@@ -317,7 +317,7 @@ spec:
           --dial-timeout=2s --endpoints='https://etcd-0.etcd.cluster-de-test-01.svc.cluster.local.:2379,https://etcd-1.etcd.cluster-de-test-01.svc.cluster.local.:2379,https://etcd-2.etcd.cluster-de-test-01.svc.cluster.local.:2379'
           put kubermatic/quorum-check something; do echo waiting for etcd; sleep 2;
           done;
-        image: gcr.io/etcd-development/etcd:v3.3.15
+        image: gcr.io/etcd-development/etcd:v3.3.18
         name: etcd-running
         resources: {}
         volumeMounts:

--- a/api/pkg/resources/test/fixtures/deployment-bringyourown-1.13.0-apiserver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-bringyourown-1.13.0-apiserver.yaml
@@ -317,7 +317,7 @@ spec:
           --dial-timeout=2s --endpoints='https://etcd-0.etcd.cluster-de-test-01.svc.cluster.local.:2379,https://etcd-1.etcd.cluster-de-test-01.svc.cluster.local.:2379,https://etcd-2.etcd.cluster-de-test-01.svc.cluster.local.:2379'
           put kubermatic/quorum-check something; do echo waiting for etcd; sleep 2;
           done;
-        image: gcr.io/etcd-development/etcd:v3.3.15
+        image: gcr.io/etcd-development/etcd:v3.3.18
         name: etcd-running
         resources: {}
         volumeMounts:

--- a/api/pkg/resources/test/fixtures/deployment-digitalocean-1.10.0-apiserver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-digitalocean-1.10.0-apiserver.yaml
@@ -319,7 +319,7 @@ spec:
           --dial-timeout=2s --endpoints='https://etcd-0.etcd.cluster-de-test-01.svc.cluster.local.:2379,https://etcd-1.etcd.cluster-de-test-01.svc.cluster.local.:2379,https://etcd-2.etcd.cluster-de-test-01.svc.cluster.local.:2379'
           put kubermatic/quorum-check something; do echo waiting for etcd; sleep 2;
           done;
-        image: gcr.io/etcd-development/etcd:v3.3.15
+        image: gcr.io/etcd-development/etcd:v3.3.18
         name: etcd-running
         resources: {}
         volumeMounts:

--- a/api/pkg/resources/test/fixtures/deployment-digitalocean-1.10.6-apiserver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-digitalocean-1.10.6-apiserver.yaml
@@ -319,7 +319,7 @@ spec:
           --dial-timeout=2s --endpoints='https://etcd-0.etcd.cluster-de-test-01.svc.cluster.local.:2379,https://etcd-1.etcd.cluster-de-test-01.svc.cluster.local.:2379,https://etcd-2.etcd.cluster-de-test-01.svc.cluster.local.:2379'
           put kubermatic/quorum-check something; do echo waiting for etcd; sleep 2;
           done;
-        image: gcr.io/etcd-development/etcd:v3.3.15
+        image: gcr.io/etcd-development/etcd:v3.3.18
         name: etcd-running
         resources: {}
         volumeMounts:

--- a/api/pkg/resources/test/fixtures/deployment-digitalocean-1.11.0-apiserver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-digitalocean-1.11.0-apiserver.yaml
@@ -317,7 +317,7 @@ spec:
           --dial-timeout=2s --endpoints='https://etcd-0.etcd.cluster-de-test-01.svc.cluster.local.:2379,https://etcd-1.etcd.cluster-de-test-01.svc.cluster.local.:2379,https://etcd-2.etcd.cluster-de-test-01.svc.cluster.local.:2379'
           put kubermatic/quorum-check something; do echo waiting for etcd; sleep 2;
           done;
-        image: gcr.io/etcd-development/etcd:v3.3.15
+        image: gcr.io/etcd-development/etcd:v3.3.18
         name: etcd-running
         resources: {}
         volumeMounts:

--- a/api/pkg/resources/test/fixtures/deployment-digitalocean-1.11.1-apiserver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-digitalocean-1.11.1-apiserver.yaml
@@ -317,7 +317,7 @@ spec:
           --dial-timeout=2s --endpoints='https://etcd-0.etcd.cluster-de-test-01.svc.cluster.local.:2379,https://etcd-1.etcd.cluster-de-test-01.svc.cluster.local.:2379,https://etcd-2.etcd.cluster-de-test-01.svc.cluster.local.:2379'
           put kubermatic/quorum-check something; do echo waiting for etcd; sleep 2;
           done;
-        image: gcr.io/etcd-development/etcd:v3.3.15
+        image: gcr.io/etcd-development/etcd:v3.3.18
         name: etcd-running
         resources: {}
         volumeMounts:

--- a/api/pkg/resources/test/fixtures/deployment-digitalocean-1.12.0-apiserver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-digitalocean-1.12.0-apiserver.yaml
@@ -317,7 +317,7 @@ spec:
           --dial-timeout=2s --endpoints='https://etcd-0.etcd.cluster-de-test-01.svc.cluster.local.:2379,https://etcd-1.etcd.cluster-de-test-01.svc.cluster.local.:2379,https://etcd-2.etcd.cluster-de-test-01.svc.cluster.local.:2379'
           put kubermatic/quorum-check something; do echo waiting for etcd; sleep 2;
           done;
-        image: gcr.io/etcd-development/etcd:v3.3.15
+        image: gcr.io/etcd-development/etcd:v3.3.18
         name: etcd-running
         resources: {}
         volumeMounts:

--- a/api/pkg/resources/test/fixtures/deployment-digitalocean-1.13.0-apiserver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-digitalocean-1.13.0-apiserver.yaml
@@ -317,7 +317,7 @@ spec:
           --dial-timeout=2s --endpoints='https://etcd-0.etcd.cluster-de-test-01.svc.cluster.local.:2379,https://etcd-1.etcd.cluster-de-test-01.svc.cluster.local.:2379,https://etcd-2.etcd.cluster-de-test-01.svc.cluster.local.:2379'
           put kubermatic/quorum-check something; do echo waiting for etcd; sleep 2;
           done;
-        image: gcr.io/etcd-development/etcd:v3.3.15
+        image: gcr.io/etcd-development/etcd:v3.3.18
         name: etcd-running
         resources: {}
         volumeMounts:

--- a/api/pkg/resources/test/fixtures/deployment-openstack-1.10.0-apiserver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-openstack-1.10.0-apiserver.yaml
@@ -323,7 +323,7 @@ spec:
           --dial-timeout=2s --endpoints='https://etcd-0.etcd.cluster-de-test-01.svc.cluster.local.:2379,https://etcd-1.etcd.cluster-de-test-01.svc.cluster.local.:2379,https://etcd-2.etcd.cluster-de-test-01.svc.cluster.local.:2379'
           put kubermatic/quorum-check something; do echo waiting for etcd; sleep 2;
           done;
-        image: gcr.io/etcd-development/etcd:v3.3.15
+        image: gcr.io/etcd-development/etcd:v3.3.18
         name: etcd-running
         resources: {}
         volumeMounts:

--- a/api/pkg/resources/test/fixtures/deployment-openstack-1.10.6-apiserver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-openstack-1.10.6-apiserver.yaml
@@ -323,7 +323,7 @@ spec:
           --dial-timeout=2s --endpoints='https://etcd-0.etcd.cluster-de-test-01.svc.cluster.local.:2379,https://etcd-1.etcd.cluster-de-test-01.svc.cluster.local.:2379,https://etcd-2.etcd.cluster-de-test-01.svc.cluster.local.:2379'
           put kubermatic/quorum-check something; do echo waiting for etcd; sleep 2;
           done;
-        image: gcr.io/etcd-development/etcd:v3.3.15
+        image: gcr.io/etcd-development/etcd:v3.3.18
         name: etcd-running
         resources: {}
         volumeMounts:

--- a/api/pkg/resources/test/fixtures/deployment-openstack-1.11.0-apiserver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-openstack-1.11.0-apiserver.yaml
@@ -321,7 +321,7 @@ spec:
           --dial-timeout=2s --endpoints='https://etcd-0.etcd.cluster-de-test-01.svc.cluster.local.:2379,https://etcd-1.etcd.cluster-de-test-01.svc.cluster.local.:2379,https://etcd-2.etcd.cluster-de-test-01.svc.cluster.local.:2379'
           put kubermatic/quorum-check something; do echo waiting for etcd; sleep 2;
           done;
-        image: gcr.io/etcd-development/etcd:v3.3.15
+        image: gcr.io/etcd-development/etcd:v3.3.18
         name: etcd-running
         resources: {}
         volumeMounts:

--- a/api/pkg/resources/test/fixtures/deployment-openstack-1.11.1-apiserver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-openstack-1.11.1-apiserver.yaml
@@ -321,7 +321,7 @@ spec:
           --dial-timeout=2s --endpoints='https://etcd-0.etcd.cluster-de-test-01.svc.cluster.local.:2379,https://etcd-1.etcd.cluster-de-test-01.svc.cluster.local.:2379,https://etcd-2.etcd.cluster-de-test-01.svc.cluster.local.:2379'
           put kubermatic/quorum-check something; do echo waiting for etcd; sleep 2;
           done;
-        image: gcr.io/etcd-development/etcd:v3.3.15
+        image: gcr.io/etcd-development/etcd:v3.3.18
         name: etcd-running
         resources: {}
         volumeMounts:

--- a/api/pkg/resources/test/fixtures/deployment-openstack-1.12.0-apiserver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-openstack-1.12.0-apiserver.yaml
@@ -321,7 +321,7 @@ spec:
           --dial-timeout=2s --endpoints='https://etcd-0.etcd.cluster-de-test-01.svc.cluster.local.:2379,https://etcd-1.etcd.cluster-de-test-01.svc.cluster.local.:2379,https://etcd-2.etcd.cluster-de-test-01.svc.cluster.local.:2379'
           put kubermatic/quorum-check something; do echo waiting for etcd; sleep 2;
           done;
-        image: gcr.io/etcd-development/etcd:v3.3.15
+        image: gcr.io/etcd-development/etcd:v3.3.18
         name: etcd-running
         resources: {}
         volumeMounts:

--- a/api/pkg/resources/test/fixtures/deployment-openstack-1.13.0-apiserver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-openstack-1.13.0-apiserver.yaml
@@ -321,7 +321,7 @@ spec:
           --dial-timeout=2s --endpoints='https://etcd-0.etcd.cluster-de-test-01.svc.cluster.local.:2379,https://etcd-1.etcd.cluster-de-test-01.svc.cluster.local.:2379,https://etcd-2.etcd.cluster-de-test-01.svc.cluster.local.:2379'
           put kubermatic/quorum-check something; do echo waiting for etcd; sleep 2;
           done;
-        image: gcr.io/etcd-development/etcd:v3.3.15
+        image: gcr.io/etcd-development/etcd:v3.3.18
         name: etcd-running
         resources: {}
         volumeMounts:

--- a/api/pkg/resources/test/fixtures/deployment-vsphere-1.10.0-apiserver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-vsphere-1.10.0-apiserver.yaml
@@ -323,7 +323,7 @@ spec:
           --dial-timeout=2s --endpoints='https://etcd-0.etcd.cluster-de-test-01.svc.cluster.local.:2379,https://etcd-1.etcd.cluster-de-test-01.svc.cluster.local.:2379,https://etcd-2.etcd.cluster-de-test-01.svc.cluster.local.:2379'
           put kubermatic/quorum-check something; do echo waiting for etcd; sleep 2;
           done;
-        image: gcr.io/etcd-development/etcd:v3.3.15
+        image: gcr.io/etcd-development/etcd:v3.3.18
         name: etcd-running
         resources: {}
         volumeMounts:

--- a/api/pkg/resources/test/fixtures/deployment-vsphere-1.10.6-apiserver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-vsphere-1.10.6-apiserver.yaml
@@ -323,7 +323,7 @@ spec:
           --dial-timeout=2s --endpoints='https://etcd-0.etcd.cluster-de-test-01.svc.cluster.local.:2379,https://etcd-1.etcd.cluster-de-test-01.svc.cluster.local.:2379,https://etcd-2.etcd.cluster-de-test-01.svc.cluster.local.:2379'
           put kubermatic/quorum-check something; do echo waiting for etcd; sleep 2;
           done;
-        image: gcr.io/etcd-development/etcd:v3.3.15
+        image: gcr.io/etcd-development/etcd:v3.3.18
         name: etcd-running
         resources: {}
         volumeMounts:

--- a/api/pkg/resources/test/fixtures/deployment-vsphere-1.11.0-apiserver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-vsphere-1.11.0-apiserver.yaml
@@ -321,7 +321,7 @@ spec:
           --dial-timeout=2s --endpoints='https://etcd-0.etcd.cluster-de-test-01.svc.cluster.local.:2379,https://etcd-1.etcd.cluster-de-test-01.svc.cluster.local.:2379,https://etcd-2.etcd.cluster-de-test-01.svc.cluster.local.:2379'
           put kubermatic/quorum-check something; do echo waiting for etcd; sleep 2;
           done;
-        image: gcr.io/etcd-development/etcd:v3.3.15
+        image: gcr.io/etcd-development/etcd:v3.3.18
         name: etcd-running
         resources: {}
         volumeMounts:

--- a/api/pkg/resources/test/fixtures/deployment-vsphere-1.11.1-apiserver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-vsphere-1.11.1-apiserver.yaml
@@ -321,7 +321,7 @@ spec:
           --dial-timeout=2s --endpoints='https://etcd-0.etcd.cluster-de-test-01.svc.cluster.local.:2379,https://etcd-1.etcd.cluster-de-test-01.svc.cluster.local.:2379,https://etcd-2.etcd.cluster-de-test-01.svc.cluster.local.:2379'
           put kubermatic/quorum-check something; do echo waiting for etcd; sleep 2;
           done;
-        image: gcr.io/etcd-development/etcd:v3.3.15
+        image: gcr.io/etcd-development/etcd:v3.3.18
         name: etcd-running
         resources: {}
         volumeMounts:

--- a/api/pkg/resources/test/fixtures/deployment-vsphere-1.12.0-apiserver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-vsphere-1.12.0-apiserver.yaml
@@ -321,7 +321,7 @@ spec:
           --dial-timeout=2s --endpoints='https://etcd-0.etcd.cluster-de-test-01.svc.cluster.local.:2379,https://etcd-1.etcd.cluster-de-test-01.svc.cluster.local.:2379,https://etcd-2.etcd.cluster-de-test-01.svc.cluster.local.:2379'
           put kubermatic/quorum-check something; do echo waiting for etcd; sleep 2;
           done;
-        image: gcr.io/etcd-development/etcd:v3.3.15
+        image: gcr.io/etcd-development/etcd:v3.3.18
         name: etcd-running
         resources: {}
         volumeMounts:

--- a/api/pkg/resources/test/fixtures/deployment-vsphere-1.13.0-apiserver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-vsphere-1.13.0-apiserver.yaml
@@ -321,7 +321,7 @@ spec:
           --dial-timeout=2s --endpoints='https://etcd-0.etcd.cluster-de-test-01.svc.cluster.local.:2379,https://etcd-1.etcd.cluster-de-test-01.svc.cluster.local.:2379,https://etcd-2.etcd.cluster-de-test-01.svc.cluster.local.:2379'
           put kubermatic/quorum-check something; do echo waiting for etcd; sleep 2;
           done;
-        image: gcr.io/etcd-development/etcd:v3.3.15
+        image: gcr.io/etcd-development/etcd:v3.3.18
         name: etcd-running
         resources: {}
         volumeMounts:

--- a/api/pkg/resources/test/fixtures/statefulset-aws-1.10.0-etcd.yaml
+++ b/api/pkg/resources/test/fixtures/statefulset-aws-1.10.0-etcd.yaml
@@ -79,7 +79,7 @@ spec:
               fieldPath: status.podIP
         - name: ETCDCTL_API
           value: "3"
-        image: gcr.io/etcd-development/etcd:v3.3.15
+        image: gcr.io/etcd-development/etcd:v3.3.18
         name: etcd
         ports:
         - containerPort: 2379

--- a/api/pkg/resources/test/fixtures/statefulset-aws-1.10.6-etcd.yaml
+++ b/api/pkg/resources/test/fixtures/statefulset-aws-1.10.6-etcd.yaml
@@ -79,7 +79,7 @@ spec:
               fieldPath: status.podIP
         - name: ETCDCTL_API
           value: "3"
-        image: gcr.io/etcd-development/etcd:v3.3.15
+        image: gcr.io/etcd-development/etcd:v3.3.18
         name: etcd
         ports:
         - containerPort: 2379

--- a/api/pkg/resources/test/fixtures/statefulset-aws-1.11.0-etcd.yaml
+++ b/api/pkg/resources/test/fixtures/statefulset-aws-1.11.0-etcd.yaml
@@ -79,7 +79,7 @@ spec:
               fieldPath: status.podIP
         - name: ETCDCTL_API
           value: "3"
-        image: gcr.io/etcd-development/etcd:v3.3.15
+        image: gcr.io/etcd-development/etcd:v3.3.18
         name: etcd
         ports:
         - containerPort: 2379

--- a/api/pkg/resources/test/fixtures/statefulset-aws-1.11.1-etcd.yaml
+++ b/api/pkg/resources/test/fixtures/statefulset-aws-1.11.1-etcd.yaml
@@ -79,7 +79,7 @@ spec:
               fieldPath: status.podIP
         - name: ETCDCTL_API
           value: "3"
-        image: gcr.io/etcd-development/etcd:v3.3.15
+        image: gcr.io/etcd-development/etcd:v3.3.18
         name: etcd
         ports:
         - containerPort: 2379

--- a/api/pkg/resources/test/fixtures/statefulset-aws-1.12.0-etcd.yaml
+++ b/api/pkg/resources/test/fixtures/statefulset-aws-1.12.0-etcd.yaml
@@ -79,7 +79,7 @@ spec:
               fieldPath: status.podIP
         - name: ETCDCTL_API
           value: "3"
-        image: gcr.io/etcd-development/etcd:v3.3.15
+        image: gcr.io/etcd-development/etcd:v3.3.18
         name: etcd
         ports:
         - containerPort: 2379

--- a/api/pkg/resources/test/fixtures/statefulset-aws-1.13.0-etcd.yaml
+++ b/api/pkg/resources/test/fixtures/statefulset-aws-1.13.0-etcd.yaml
@@ -79,7 +79,7 @@ spec:
               fieldPath: status.podIP
         - name: ETCDCTL_API
           value: "3"
-        image: gcr.io/etcd-development/etcd:v3.3.15
+        image: gcr.io/etcd-development/etcd:v3.3.18
         name: etcd
         ports:
         - containerPort: 2379

--- a/api/pkg/resources/test/fixtures/statefulset-azure-1.10.0-etcd.yaml
+++ b/api/pkg/resources/test/fixtures/statefulset-azure-1.10.0-etcd.yaml
@@ -79,7 +79,7 @@ spec:
               fieldPath: status.podIP
         - name: ETCDCTL_API
           value: "3"
-        image: gcr.io/etcd-development/etcd:v3.3.15
+        image: gcr.io/etcd-development/etcd:v3.3.18
         name: etcd
         ports:
         - containerPort: 2379

--- a/api/pkg/resources/test/fixtures/statefulset-azure-1.10.6-etcd.yaml
+++ b/api/pkg/resources/test/fixtures/statefulset-azure-1.10.6-etcd.yaml
@@ -79,7 +79,7 @@ spec:
               fieldPath: status.podIP
         - name: ETCDCTL_API
           value: "3"
-        image: gcr.io/etcd-development/etcd:v3.3.15
+        image: gcr.io/etcd-development/etcd:v3.3.18
         name: etcd
         ports:
         - containerPort: 2379

--- a/api/pkg/resources/test/fixtures/statefulset-azure-1.11.0-etcd.yaml
+++ b/api/pkg/resources/test/fixtures/statefulset-azure-1.11.0-etcd.yaml
@@ -79,7 +79,7 @@ spec:
               fieldPath: status.podIP
         - name: ETCDCTL_API
           value: "3"
-        image: gcr.io/etcd-development/etcd:v3.3.15
+        image: gcr.io/etcd-development/etcd:v3.3.18
         name: etcd
         ports:
         - containerPort: 2379

--- a/api/pkg/resources/test/fixtures/statefulset-azure-1.11.1-etcd.yaml
+++ b/api/pkg/resources/test/fixtures/statefulset-azure-1.11.1-etcd.yaml
@@ -79,7 +79,7 @@ spec:
               fieldPath: status.podIP
         - name: ETCDCTL_API
           value: "3"
-        image: gcr.io/etcd-development/etcd:v3.3.15
+        image: gcr.io/etcd-development/etcd:v3.3.18
         name: etcd
         ports:
         - containerPort: 2379

--- a/api/pkg/resources/test/fixtures/statefulset-azure-1.12.0-etcd.yaml
+++ b/api/pkg/resources/test/fixtures/statefulset-azure-1.12.0-etcd.yaml
@@ -79,7 +79,7 @@ spec:
               fieldPath: status.podIP
         - name: ETCDCTL_API
           value: "3"
-        image: gcr.io/etcd-development/etcd:v3.3.15
+        image: gcr.io/etcd-development/etcd:v3.3.18
         name: etcd
         ports:
         - containerPort: 2379

--- a/api/pkg/resources/test/fixtures/statefulset-azure-1.13.0-etcd.yaml
+++ b/api/pkg/resources/test/fixtures/statefulset-azure-1.13.0-etcd.yaml
@@ -79,7 +79,7 @@ spec:
               fieldPath: status.podIP
         - name: ETCDCTL_API
           value: "3"
-        image: gcr.io/etcd-development/etcd:v3.3.15
+        image: gcr.io/etcd-development/etcd:v3.3.18
         name: etcd
         ports:
         - containerPort: 2379

--- a/api/pkg/resources/test/fixtures/statefulset-bringyourown-1.10.0-etcd.yaml
+++ b/api/pkg/resources/test/fixtures/statefulset-bringyourown-1.10.0-etcd.yaml
@@ -79,7 +79,7 @@ spec:
               fieldPath: status.podIP
         - name: ETCDCTL_API
           value: "3"
-        image: gcr.io/etcd-development/etcd:v3.3.15
+        image: gcr.io/etcd-development/etcd:v3.3.18
         name: etcd
         ports:
         - containerPort: 2379

--- a/api/pkg/resources/test/fixtures/statefulset-bringyourown-1.10.6-etcd.yaml
+++ b/api/pkg/resources/test/fixtures/statefulset-bringyourown-1.10.6-etcd.yaml
@@ -79,7 +79,7 @@ spec:
               fieldPath: status.podIP
         - name: ETCDCTL_API
           value: "3"
-        image: gcr.io/etcd-development/etcd:v3.3.15
+        image: gcr.io/etcd-development/etcd:v3.3.18
         name: etcd
         ports:
         - containerPort: 2379

--- a/api/pkg/resources/test/fixtures/statefulset-bringyourown-1.11.0-etcd.yaml
+++ b/api/pkg/resources/test/fixtures/statefulset-bringyourown-1.11.0-etcd.yaml
@@ -79,7 +79,7 @@ spec:
               fieldPath: status.podIP
         - name: ETCDCTL_API
           value: "3"
-        image: gcr.io/etcd-development/etcd:v3.3.15
+        image: gcr.io/etcd-development/etcd:v3.3.18
         name: etcd
         ports:
         - containerPort: 2379

--- a/api/pkg/resources/test/fixtures/statefulset-bringyourown-1.11.1-etcd.yaml
+++ b/api/pkg/resources/test/fixtures/statefulset-bringyourown-1.11.1-etcd.yaml
@@ -79,7 +79,7 @@ spec:
               fieldPath: status.podIP
         - name: ETCDCTL_API
           value: "3"
-        image: gcr.io/etcd-development/etcd:v3.3.15
+        image: gcr.io/etcd-development/etcd:v3.3.18
         name: etcd
         ports:
         - containerPort: 2379

--- a/api/pkg/resources/test/fixtures/statefulset-bringyourown-1.12.0-etcd.yaml
+++ b/api/pkg/resources/test/fixtures/statefulset-bringyourown-1.12.0-etcd.yaml
@@ -79,7 +79,7 @@ spec:
               fieldPath: status.podIP
         - name: ETCDCTL_API
           value: "3"
-        image: gcr.io/etcd-development/etcd:v3.3.15
+        image: gcr.io/etcd-development/etcd:v3.3.18
         name: etcd
         ports:
         - containerPort: 2379

--- a/api/pkg/resources/test/fixtures/statefulset-bringyourown-1.13.0-etcd.yaml
+++ b/api/pkg/resources/test/fixtures/statefulset-bringyourown-1.13.0-etcd.yaml
@@ -79,7 +79,7 @@ spec:
               fieldPath: status.podIP
         - name: ETCDCTL_API
           value: "3"
-        image: gcr.io/etcd-development/etcd:v3.3.15
+        image: gcr.io/etcd-development/etcd:v3.3.18
         name: etcd
         ports:
         - containerPort: 2379

--- a/api/pkg/resources/test/fixtures/statefulset-digitalocean-1.10.0-etcd.yaml
+++ b/api/pkg/resources/test/fixtures/statefulset-digitalocean-1.10.0-etcd.yaml
@@ -79,7 +79,7 @@ spec:
               fieldPath: status.podIP
         - name: ETCDCTL_API
           value: "3"
-        image: gcr.io/etcd-development/etcd:v3.3.15
+        image: gcr.io/etcd-development/etcd:v3.3.18
         name: etcd
         ports:
         - containerPort: 2379

--- a/api/pkg/resources/test/fixtures/statefulset-digitalocean-1.10.6-etcd.yaml
+++ b/api/pkg/resources/test/fixtures/statefulset-digitalocean-1.10.6-etcd.yaml
@@ -79,7 +79,7 @@ spec:
               fieldPath: status.podIP
         - name: ETCDCTL_API
           value: "3"
-        image: gcr.io/etcd-development/etcd:v3.3.15
+        image: gcr.io/etcd-development/etcd:v3.3.18
         name: etcd
         ports:
         - containerPort: 2379

--- a/api/pkg/resources/test/fixtures/statefulset-digitalocean-1.11.0-etcd.yaml
+++ b/api/pkg/resources/test/fixtures/statefulset-digitalocean-1.11.0-etcd.yaml
@@ -79,7 +79,7 @@ spec:
               fieldPath: status.podIP
         - name: ETCDCTL_API
           value: "3"
-        image: gcr.io/etcd-development/etcd:v3.3.15
+        image: gcr.io/etcd-development/etcd:v3.3.18
         name: etcd
         ports:
         - containerPort: 2379

--- a/api/pkg/resources/test/fixtures/statefulset-digitalocean-1.11.1-etcd.yaml
+++ b/api/pkg/resources/test/fixtures/statefulset-digitalocean-1.11.1-etcd.yaml
@@ -79,7 +79,7 @@ spec:
               fieldPath: status.podIP
         - name: ETCDCTL_API
           value: "3"
-        image: gcr.io/etcd-development/etcd:v3.3.15
+        image: gcr.io/etcd-development/etcd:v3.3.18
         name: etcd
         ports:
         - containerPort: 2379

--- a/api/pkg/resources/test/fixtures/statefulset-digitalocean-1.12.0-etcd.yaml
+++ b/api/pkg/resources/test/fixtures/statefulset-digitalocean-1.12.0-etcd.yaml
@@ -79,7 +79,7 @@ spec:
               fieldPath: status.podIP
         - name: ETCDCTL_API
           value: "3"
-        image: gcr.io/etcd-development/etcd:v3.3.15
+        image: gcr.io/etcd-development/etcd:v3.3.18
         name: etcd
         ports:
         - containerPort: 2379

--- a/api/pkg/resources/test/fixtures/statefulset-digitalocean-1.13.0-etcd.yaml
+++ b/api/pkg/resources/test/fixtures/statefulset-digitalocean-1.13.0-etcd.yaml
@@ -79,7 +79,7 @@ spec:
               fieldPath: status.podIP
         - name: ETCDCTL_API
           value: "3"
-        image: gcr.io/etcd-development/etcd:v3.3.15
+        image: gcr.io/etcd-development/etcd:v3.3.18
         name: etcd
         ports:
         - containerPort: 2379

--- a/api/pkg/resources/test/fixtures/statefulset-openstack-1.10.0-etcd.yaml
+++ b/api/pkg/resources/test/fixtures/statefulset-openstack-1.10.0-etcd.yaml
@@ -79,7 +79,7 @@ spec:
               fieldPath: status.podIP
         - name: ETCDCTL_API
           value: "3"
-        image: gcr.io/etcd-development/etcd:v3.3.15
+        image: gcr.io/etcd-development/etcd:v3.3.18
         name: etcd
         ports:
         - containerPort: 2379

--- a/api/pkg/resources/test/fixtures/statefulset-openstack-1.10.6-etcd.yaml
+++ b/api/pkg/resources/test/fixtures/statefulset-openstack-1.10.6-etcd.yaml
@@ -79,7 +79,7 @@ spec:
               fieldPath: status.podIP
         - name: ETCDCTL_API
           value: "3"
-        image: gcr.io/etcd-development/etcd:v3.3.15
+        image: gcr.io/etcd-development/etcd:v3.3.18
         name: etcd
         ports:
         - containerPort: 2379

--- a/api/pkg/resources/test/fixtures/statefulset-openstack-1.11.0-etcd.yaml
+++ b/api/pkg/resources/test/fixtures/statefulset-openstack-1.11.0-etcd.yaml
@@ -79,7 +79,7 @@ spec:
               fieldPath: status.podIP
         - name: ETCDCTL_API
           value: "3"
-        image: gcr.io/etcd-development/etcd:v3.3.15
+        image: gcr.io/etcd-development/etcd:v3.3.18
         name: etcd
         ports:
         - containerPort: 2379

--- a/api/pkg/resources/test/fixtures/statefulset-openstack-1.11.1-etcd.yaml
+++ b/api/pkg/resources/test/fixtures/statefulset-openstack-1.11.1-etcd.yaml
@@ -79,7 +79,7 @@ spec:
               fieldPath: status.podIP
         - name: ETCDCTL_API
           value: "3"
-        image: gcr.io/etcd-development/etcd:v3.3.15
+        image: gcr.io/etcd-development/etcd:v3.3.18
         name: etcd
         ports:
         - containerPort: 2379

--- a/api/pkg/resources/test/fixtures/statefulset-openstack-1.12.0-etcd.yaml
+++ b/api/pkg/resources/test/fixtures/statefulset-openstack-1.12.0-etcd.yaml
@@ -79,7 +79,7 @@ spec:
               fieldPath: status.podIP
         - name: ETCDCTL_API
           value: "3"
-        image: gcr.io/etcd-development/etcd:v3.3.15
+        image: gcr.io/etcd-development/etcd:v3.3.18
         name: etcd
         ports:
         - containerPort: 2379

--- a/api/pkg/resources/test/fixtures/statefulset-openstack-1.13.0-etcd.yaml
+++ b/api/pkg/resources/test/fixtures/statefulset-openstack-1.13.0-etcd.yaml
@@ -79,7 +79,7 @@ spec:
               fieldPath: status.podIP
         - name: ETCDCTL_API
           value: "3"
-        image: gcr.io/etcd-development/etcd:v3.3.15
+        image: gcr.io/etcd-development/etcd:v3.3.18
         name: etcd
         ports:
         - containerPort: 2379

--- a/api/pkg/resources/test/fixtures/statefulset-vsphere-1.10.0-etcd.yaml
+++ b/api/pkg/resources/test/fixtures/statefulset-vsphere-1.10.0-etcd.yaml
@@ -79,7 +79,7 @@ spec:
               fieldPath: status.podIP
         - name: ETCDCTL_API
           value: "3"
-        image: gcr.io/etcd-development/etcd:v3.3.15
+        image: gcr.io/etcd-development/etcd:v3.3.18
         name: etcd
         ports:
         - containerPort: 2379

--- a/api/pkg/resources/test/fixtures/statefulset-vsphere-1.10.6-etcd.yaml
+++ b/api/pkg/resources/test/fixtures/statefulset-vsphere-1.10.6-etcd.yaml
@@ -79,7 +79,7 @@ spec:
               fieldPath: status.podIP
         - name: ETCDCTL_API
           value: "3"
-        image: gcr.io/etcd-development/etcd:v3.3.15
+        image: gcr.io/etcd-development/etcd:v3.3.18
         name: etcd
         ports:
         - containerPort: 2379

--- a/api/pkg/resources/test/fixtures/statefulset-vsphere-1.11.0-etcd.yaml
+++ b/api/pkg/resources/test/fixtures/statefulset-vsphere-1.11.0-etcd.yaml
@@ -79,7 +79,7 @@ spec:
               fieldPath: status.podIP
         - name: ETCDCTL_API
           value: "3"
-        image: gcr.io/etcd-development/etcd:v3.3.15
+        image: gcr.io/etcd-development/etcd:v3.3.18
         name: etcd
         ports:
         - containerPort: 2379

--- a/api/pkg/resources/test/fixtures/statefulset-vsphere-1.11.1-etcd.yaml
+++ b/api/pkg/resources/test/fixtures/statefulset-vsphere-1.11.1-etcd.yaml
@@ -79,7 +79,7 @@ spec:
               fieldPath: status.podIP
         - name: ETCDCTL_API
           value: "3"
-        image: gcr.io/etcd-development/etcd:v3.3.15
+        image: gcr.io/etcd-development/etcd:v3.3.18
         name: etcd
         ports:
         - containerPort: 2379

--- a/api/pkg/resources/test/fixtures/statefulset-vsphere-1.12.0-etcd.yaml
+++ b/api/pkg/resources/test/fixtures/statefulset-vsphere-1.12.0-etcd.yaml
@@ -79,7 +79,7 @@ spec:
               fieldPath: status.podIP
         - name: ETCDCTL_API
           value: "3"
-        image: gcr.io/etcd-development/etcd:v3.3.15
+        image: gcr.io/etcd-development/etcd:v3.3.18
         name: etcd
         ports:
         - containerPort: 2379

--- a/api/pkg/resources/test/fixtures/statefulset-vsphere-1.13.0-etcd.yaml
+++ b/api/pkg/resources/test/fixtures/statefulset-vsphere-1.13.0-etcd.yaml
@@ -79,7 +79,7 @@ spec:
               fieldPath: status.podIP
         - name: ETCDCTL_API
           value: "3"
-        image: gcr.io/etcd-development/etcd:v3.3.15
+        image: gcr.io/etcd-development/etcd:v3.3.18
         name: etcd
         ports:
         - containerPort: 2379


### PR DESCRIPTION
**What this PR does / why we need it**:

* Upgrades etcd to 3.4 for Kube 1.17+ clusters
* Changes the backup cronjob to also work with the new etcd version

I have manually checked that:
* Upgrading etcd works
* The backup job works for both etcd 3.4 and 3.3
* The defragger job works for both etcd 3.4 and 3.3

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Documentation**:
<!-- Add links to the related documentation changes related to this pull request. E.g. the link to the kubermatic/docs pullrequest. -->

**Does this PR introduce a user-facing change?**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If  no release note is required, just write "NONE".
-->
```release-note
Etcd was upgraded to 3.4 for 1.17+ clusters
```

/CC @shahbazn