### PR TITLE
cert-manager 0.12.0

### DIFF
--- a/config/cert-manager/Chart.yaml
+++ b/config/cert-manager/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 name: cert-manager
-version: 1.1.5
-appVersion: v0.12.0-beta.1
+version: 1.1.6
+appVersion: v0.12.0
 description: A Helm chart for cert-manager
 keywords:
 - kubermatic

--- a/config/cert-manager/values.yaml
+++ b/config/cert-manager/values.yaml
@@ -10,7 +10,7 @@ certManager:
     replicas: 1
     image:
       repository: quay.io/jetstack/cert-manager-controller
-      tag: v0.12.0-beta.1
+      tag: v0.12.0
       pullPolicy: IfNotPresent
 
     resources:
@@ -40,7 +40,7 @@ certManager:
     replicas: 1
     image:
       repository: quay.io/jetstack/cert-manager-webhook
-      tag: v0.12.0-beta.1
+      tag: v0.12.0
       pullPolicy: IfNotPresent
 
     resources:
@@ -70,7 +70,7 @@ certManager:
     replicas: 1
     image:
       repository: quay.io/jetstack/cert-manager-cainjector
-      tag: v0.12.0-beta.1
+      tag: v0.12.0
       pullPolicy: IfNotPresent
 
     resources:


### PR DESCRIPTION
**What this PR does / why we need it**:
There were no changes between beta1 and final for the deployment manifests and the upstream chart. So I guess this is a safe little happy bump.

**Does this PR introduce a user-facing change?**:
```release-note
Update cert-manager to 0.12.0
```
