### PR TITLE
Dex 2.21.0

### DIFF
--- a/config/oauth/Chart.yaml
+++ b/config/oauth/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 name: oauth
-version: 1.0.8
-appVersion: v2.19.0
+version: 1.0.9
+appVersion: v2.21.0
 description: Dex
 keywords:
 - kubermatic

--- a/config/oauth/values.yaml
+++ b/config/oauth/values.yaml
@@ -1,7 +1,7 @@
 dex:
   image:
     repository: "quay.io/dexidp/dex"
-    tag: "v2.19.0"
+    tag: "v2.21.0"
   replicas: 2
   ingress:
     host: ""


### PR DESCRIPTION
**What this PR does / why we need it**:
Nothing too fancy here, but maybe https://github.com/dexidp/dex/pull/1185 would be helpful so we don't have to rely on Github orgs anymore?

**Does this PR introduce a user-facing change?**:
```release-note
Update Dex to v2.12.0
```
