### PR TITLE
Upgrade endpoint: Fix no kind match error

### DIFF
--- a/api/pkg/handler/v1/cluster/upgrade.go
+++ b/api/pkg/handler/v1/cluster/upgrade.go
@@ -18,6 +18,7 @@ import (
 	"github.com/kubermatic/kubermatic/api/pkg/version"
 	clusterv1alpha1 "github.com/kubermatic/machine-controller/pkg/apis/cluster/v1alpha1"
 
+	"k8s.io/apimachinery/pkg/api/meta"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	ctrlruntimeclient "sigs.k8s.io/controller-runtime/pkg/client"
 )
@@ -51,6 +52,10 @@ func GetUpgradesEndpoint(updateManager common.UpdateManager, projectProvider pro
 
 		machineDeployments := &clusterv1alpha1.MachineDeploymentList{}
 		if err := client.List(ctx, machineDeployments, ctrlruntimeclient.InNamespace(metav1.NamespaceSystem)); err != nil {
+			// Happens during cluster creation when the CRD is not setup yet
+			if _, ok := err.(*meta.NoKindMatchError); ok {
+				return nil, nil
+			}
 			return nil, common.KubernetesErrorToHTTPError(err)
 		}
 


### PR DESCRIPTION
**What this PR does / why we need it**:

Fixes no kind match errors occasionally seen during cluster creation.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Documentation**:
<!-- Add links to the related documentation changes related to this pull request. E.g. the link to the kubermatic/docs pullrequest. -->

**Does this PR introduce a user-facing change?**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If  no release note is required, just write "NONE".
-->
```release-note
A bug that occasionally resulted in a `Error: no matches for kind "MachineDeployment" in version "cluster.k8s.io/v1alpha1" visible in the UI was fixed.
```

/assign @zreigz 