### PR TITLE
Fix misdetecting tags when retagging images

### DIFF
--- a/api/hack/retag-images.sh
+++ b/api/hack/retag-images.sh
@@ -8,9 +8,9 @@ function retag {
   NAME="$(echo ${IMAGE} | cut -d / -f3 | cut -d : -f1)"
   TAG="$(echo ${IMAGE} | cut -d / -f3 | cut -d : -f2)"
   TARGET_IMAGE="${TARGET_REGISTRY}/${ORG}/${NAME}:${TAG}"
-  echo "Retagging ${IMAGE} to ${TARGET_IMAGE}"
+  echo "Retagging ${IMAGE} as ${TARGET_IMAGE}"
 
-  if curl -Ss --fail "http://${TARGET_REGISTRY}/v2/${ORG}/${NAME}/tags/list"|grep -q ${TAG}; then
+  if curl -Ss --fail "http://${TARGET_REGISTRY}/v2/${ORG}/${NAME}/tags/list" | jq -e ".tags | index(\"${TAG}\")" >/dev/null; then
     echo "Skipping image ${TARGET_IMAGE} because it already exists in the target registry"
     return
   fi


### PR DESCRIPTION
**What this PR does / why we need it**:
When doing https://github.com/kubermatic/kubermatic/pull/4857, the tag changed from `v0.12.0-beta` to `v0.12.0`. The retag-images.sh script accidentally mismatched this when checking the offline proxy host's local registry, so it would not push the image there and the deployment fails.

**Does this PR introduce a user-facing change?**:
```release-note
NONE
```
