### PR TITLE
Add kube 1.17 presubmit

### DIFF
--- a/.prow.yaml
+++ b/.prow.yaml
@@ -725,7 +725,8 @@ presubmits:
 
   - name: pre-kubermatic-e2e-aws-coreos-1.16
     decorate: true
-    run_if_changed: "(api/|config/kubermatic)"
+    always_run: false
+    optional: true
     clone_uri: "ssh://git@github.com/kubermatic/kubermatic.git"
     labels:
       preset-aws: "true"
@@ -862,6 +863,45 @@ presubmits:
           value: "openstack"
         - name: DEFAULT_TIMEOUT_MINUTES
           value: "20"
+        - name: SERVICE_ACCOUNT_KEY
+          valueFrom:
+            secretKeyRef:
+              name: e2e-ci
+              key: serviceAccountSigningKey
+        command:
+        - "./api/hack/ci/ci-kind-e2e.sh"
+        # docker-in-docker needs privileged mode
+        securityContext:
+          privileged: true
+        resources:
+          requests:
+            memory: 4Gi
+            cpu: 3.5
+          limits:
+            memory: 4Gi
+
+  #########################################################
+  # e2e tests for Kubernetes 1.17
+  #########################################################
+
+  - name: pre-kubermatic-e2e-aws-coreos-1.17
+    decorate: true
+    run_if_changed: "(api/|config/kubermatic)"
+    clone_uri: "ssh://git@github.com/kubermatic/kubermatic.git"
+    labels:
+      preset-aws: "true"
+      preset-docker-pull: "true"
+      preset-docker-push: "true"
+      preset-vault: "true"
+      preset-repo-ssh: "true"
+      preset-kubeconfig-ci: "true"
+      preset-kind-volume-mounts: "true"
+    spec:
+      containers:
+      - image: quay.io/kubermatic/e2e-kind:with-conformance-tests-v1.0.14
+        env:
+        - name: VERSIONS_TO_TEST
+          value: "v1.17.0"
         - name: SERVICE_ACCOUNT_KEY
           valueFrom:
             secretKeyRef:

--- a/.prow.yaml
+++ b/.prow.yaml
@@ -294,7 +294,7 @@ presubmits:
 
   - name: pre-kubermatic-e2e-aws-coreos-1.15
     decorate: true
-    run_if_changed: "(api/|config/kubermatic)"
+    run_if_changed: "(api/|config/kubermatic|.prow.yaml)"
     clone_uri: "ssh://git@github.com/kubermatic/kubermatic.git"
     labels:
       preset-aws: "true"
@@ -886,7 +886,7 @@ presubmits:
 
   - name: pre-kubermatic-e2e-aws-coreos-1.17
     decorate: true
-    run_if_changed: "(api/|config/kubermatic)"
+    run_if_changed: "(api/|config/kubermatic|.prow.yaml)"
     clone_uri: "ssh://git@github.com/kubermatic/kubermatic.git"
     labels:
       preset-aws: "true"
@@ -925,7 +925,7 @@ presubmits:
 
   - name: pre-kubermatic-e2e-aws-openshift-4.1
     decorate: true
-    run_if_changed: "(api/|config/kubermatic)"
+    run_if_changed: "(api/|config/kubermatic|.prow.yaml)"
     clone_uri: "ssh://git@github.com/kubermatic/kubermatic.git"
     labels:
       preset-aws: "true"
@@ -1000,7 +1000,7 @@ presubmits:
   #########################################################
 
   - name: pre-kubermatic-api-e2e
-    run_if_changed: "^api/"
+    run_if_changed: "(api/|config/kubermatic|.prow.yaml)"
     decorate: true
     clone_uri: "ssh://git@github.com/kubermatic/kubermatic.git"
     labels:

--- a/api/cmd/conformance-tests/runner.go
+++ b/api/cmd/conformance-tests/runner.go
@@ -975,7 +975,7 @@ func (r *testRunner) getGinkgoRuns(
 	nodeNumberTotal := int32(r.nodeCount)
 
 	ginkgoSkipParallel := `\[Serial\]`
-	if cluster.Spec.Version.Minor() == 16 {
+	if minor := cluster.Spec.Version.Minor(); minor == 16 || minor == 17 {
 		// These require the nodes NodePort to be available from the tester, which is not the case for us.
 		// TODO: Maybe add an option to allow the NodePorts in the SecurityGroup?
 		ginkgoSkipParallel += "|Services should be able to change the type from ExternalName to NodePort|Services should be able to create a functioning NodePort service"


### PR DESCRIPTION
**What this PR does / why we need it**:

* Adds a new Kubernetes 1.17 presubmit and makes it mandatory
* Makes the existing kube 1.15 presubmit optional

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Documentation**:
<!-- Add links to the related documentation changes related to this pull request. E.g. the link to the kubermatic/docs pullrequest. -->

**Does this PR introduce a user-facing change?**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If  no release note is required, just write "NONE".
-->
```release-note
none
```
