### PR TITLE
Leaderelection: Always exit on lost leader lease

### DIFF
--- a/api/pkg/leaderelection/leaderelection.go
+++ b/api/pkg/leaderelection/leaderelection.go
@@ -58,6 +58,7 @@ func RunAsLeader(ctx context.Context, log *zap.SugaredLogger, cfg *rest.Config, 
 	if err != nil {
 		return err
 	}
+	log = log.With("leader-name", leaderName)
 
 	leaderElectionCtx, cancel := context.WithCancel(ctx)
 	defer cancel()
@@ -74,6 +75,10 @@ func RunAsLeader(ctx context.Context, log *zap.SugaredLogger, cfg *rest.Config, 
 			// Gets called when we could not renew the lease or the parent context was closed
 			log.Info("lost leader lease")
 			cancel()
+			// We will not do anything anymore at this point, so we must sure we exist here so we get restarted
+			// and it becomes visible that there is an issue. If we have any kind of bug in the cmds signal handling
+			// we may just get stuck here in a defunct state.
+			log.Fatal("Leader lease lost, exiting.")
 		},
 	}
 


### PR DESCRIPTION
**What this PR does / why we need it**:

* Makes sure that we exit on lost leader lease rather than getting stuck in a defunct state as observed in some e2e tests.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Documentation**:
<!-- Add links to the related documentation changes related to this pull request. E.g. the link to the kubermatic/docs pullrequest. -->

**Does this PR introduce a user-facing change?**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If  no release note is required, just write "NONE".
-->
```release-note
none
```
