### PR TITLE
extend global settings for new flags

### DIFF
--- a/api/cmd/kubermatic-api/swagger.json
+++ b/api/cmd/kubermatic-api/swagger.json
@@ -10057,6 +10057,14 @@
         "displayTermsOfService": {
           "type": "boolean",
           "x-go-name": "DisplayTermsOfService"
+        },
+        "enableDashboard": {
+          "type": "boolean",
+          "x-go-name": "EnableDashboard"
+        },
+        "enableOIDCKubeconfig": {
+          "type": "boolean",
+          "x-go-name": "EnableOIDCKubeconfig"
         }
       },
       "x-go-package": "github.com/kubermatic/kubermatic/api/pkg/crd/kubermatic/v1"

--- a/api/pkg/crd/kubermatic/v1/settings.go
+++ b/api/pkg/crd/kubermatic/v1/settings.go
@@ -26,6 +26,8 @@ type SettingSpec struct {
 	DisplayDemoInfo       bool           `json:"displayDemoInfo"`
 	DisplayAPIDocs        bool           `json:"displayAPIDocs"`
 	DisplayTermsOfService bool           `json:"displayTermsOfService"`
+	EnableDashboard       bool           `json:"enableDashboard"`
+	EnableOIDCKubeconfig  bool           `json:"enableOIDCKubeconfig"`
 
 	// TODO: Datacenters, presets, user management, Google Analytics and default addons.
 }

--- a/api/pkg/handler/v1/admin/settings_test.go
+++ b/api/pkg/handler/v1/admin/settings_test.go
@@ -28,7 +28,7 @@ func TestGetGlobalSettings(t *testing.T) {
 		// scenario 1
 		{
 			name:                   "scenario 1: user gets settings first time",
-			expectedResponse:       `{"customLinks":[],"cleanupOptions":{"Enabled":false,"Enforced":false},"defaultNodeCount":10,"clusterTypeOptions":10,"displayDemoInfo":false,"displayAPIDocs":false,"displayTermsOfService":false}`,
+			expectedResponse:       `{"customLinks":[],"cleanupOptions":{"Enabled":false,"Enforced":false},"defaultNodeCount":10,"clusterTypeOptions":10,"displayDemoInfo":false,"displayAPIDocs":false,"displayTermsOfService":false,"enableDashboard":true,"enableOIDCKubeconfig":false}`,
 			httpStatus:             http.StatusOK,
 			existingKubermaticObjs: []runtime.Object{genUser("Bob", "bob@acme.com", true)},
 			existingAPIUser:        test.GenDefaultAPIUser(),
@@ -36,7 +36,7 @@ func TestGetGlobalSettings(t *testing.T) {
 		// scenario 2
 		{
 			name:             "scenario 2: user gets existing global settings",
-			expectedResponse: `{"customLinks":[{"label":"label","url":"url:label","icon":"icon","location":"EU"}],"cleanupOptions":{"Enabled":true,"Enforced":true},"defaultNodeCount":5,"clusterTypeOptions":5,"displayDemoInfo":true,"displayAPIDocs":true,"displayTermsOfService":true}`,
+			expectedResponse: `{"customLinks":[{"label":"label","url":"url:label","icon":"icon","location":"EU"}],"cleanupOptions":{"Enabled":true,"Enforced":true},"defaultNodeCount":5,"clusterTypeOptions":5,"displayDemoInfo":true,"displayAPIDocs":true,"displayTermsOfService":true,"enableDashboard":false,"enableOIDCKubeconfig":false}`,
 			httpStatus:       http.StatusOK,
 			existingKubermaticObjs: []runtime.Object{genUser("Bob", "bob@acme.com", true),
 				genDefaultGlobalSettings()},
@@ -92,7 +92,7 @@ func TestUpdateGlobalSettings(t *testing.T) {
 		{
 			name:                   "scenario 2: authorized user updates default settings",
 			body:                   `{"customLinks":[{"label":"label","url":"url:label","icon":"icon","location":"EU"}],"cleanupOptions":{"Enabled":true,"Enforced":true},"defaultNodeCount":100,"clusterTypeOptions":20,"displayDemoInfo":false,"displayAPIDocs":false,"displayTermsOfService":true}`,
-			expectedResponse:       `{"customLinks":[{"label":"label","url":"url:label","icon":"icon","location":"EU"}],"cleanupOptions":{"Enabled":true,"Enforced":true},"defaultNodeCount":100,"clusterTypeOptions":20,"displayDemoInfo":false,"displayAPIDocs":false,"displayTermsOfService":true}`,
+			expectedResponse:       `{"customLinks":[{"label":"label","url":"url:label","icon":"icon","location":"EU"}],"cleanupOptions":{"Enabled":true,"Enforced":true},"defaultNodeCount":100,"clusterTypeOptions":20,"displayDemoInfo":false,"displayAPIDocs":false,"displayTermsOfService":true,"enableDashboard":true,"enableOIDCKubeconfig":false}`,
 			httpStatus:             http.StatusOK,
 			existingKubermaticObjs: []runtime.Object{genUser("Bob", "bob@acme.com", true)},
 			existingAPIUser:        test.GenDefaultAPIUser(),
@@ -101,7 +101,7 @@ func TestUpdateGlobalSettings(t *testing.T) {
 		{
 			name:             "scenario 3: authorized user updates existing global settings",
 			body:             `{"customLinks":[],"cleanupOptions":{"Enabled":true,"Enforced":true},"defaultNodeCount":100,"clusterTypeOptions":20,"displayDemoInfo":false,"displayAPIDocs":false,"displayTermsOfService":true}`,
-			expectedResponse: `{"customLinks":[],"cleanupOptions":{"Enabled":true,"Enforced":true},"defaultNodeCount":100,"clusterTypeOptions":20,"displayDemoInfo":false,"displayAPIDocs":false,"displayTermsOfService":true}`,
+			expectedResponse: `{"customLinks":[],"cleanupOptions":{"Enabled":true,"Enforced":true},"defaultNodeCount":100,"clusterTypeOptions":20,"displayDemoInfo":false,"displayAPIDocs":false,"displayTermsOfService":true,"enableDashboard":false,"enableOIDCKubeconfig":false}`,
 			httpStatus:       http.StatusOK,
 			existingKubermaticObjs: []runtime.Object{genUser("Bob", "bob@acme.com", true),
 				genDefaultGlobalSettings()},

--- a/api/pkg/provider/kubernetes/settings.go
+++ b/api/pkg/provider/kubernetes/settings.go
@@ -61,6 +61,8 @@ func (s *SettingsProvider) createDefaultGlobalSettings() (*kubermaticv1.Kubermat
 			DisplayDemoInfo:       false,
 			DisplayAPIDocs:        false,
 			DisplayTermsOfService: false,
+			EnableDashboard:       true,
+			EnableOIDCKubeconfig:  false,
 		},
 	}
 	return s.client.KubermaticV1().KubermaticSettings().Create(defaultSettings)

--- a/api/pkg/test/e2e/api/helper.go
+++ b/api/pkg/test/e2e/api/helper.go
@@ -867,6 +867,8 @@ func convertGlobalSettings(gSettings *models.GlobalSettings) *apiv1.GlobalSettin
 		DisplayDemoInfo:       gSettings.DisplayDemoInfo,
 		DisplayAPIDocs:        gSettings.DisplayAPIDocs,
 		DisplayTermsOfService: gSettings.DisplayTermsOfService,
+		EnableOIDCKubeconfig:  gSettings.EnableOIDCKubeconfig,
+		EnableDashboard:       gSettings.EnableDashboard,
 	}
 }
 

--- a/api/pkg/test/e2e/api/settings_test.go
+++ b/api/pkg/test/e2e/api/settings_test.go
@@ -30,6 +30,8 @@ func TestGetDefaultGlobalSettings(t *testing.T) {
 				DisplayDemoInfo:       false,
 				DisplayAPIDocs:        false,
 				DisplayTermsOfService: false,
+				EnableDashboard:       true,
+				EnableOIDCKubeconfig:  false,
 			},
 		},
 	}

--- a/api/pkg/test/e2e/api/utils/apiclient/models/setting_spec.go
+++ b/api/pkg/test/e2e/api/utils/apiclient/models/setting_spec.go
@@ -31,6 +31,12 @@ type SettingSpec struct {
 	// display terms of service
 	DisplayTermsOfService bool `json:"displayTermsOfService,omitempty"`
 
+	// enable dashboard
+	EnableDashboard bool `json:"enableDashboard,omitempty"`
+
+	// enable o ID c kubeconfig
+	EnableOIDCKubeconfig bool `json:"enableOIDCKubeconfig,omitempty"`
+
 	// cleanup options
 	CleanupOptions *CleanupOptions `json:"cleanupOptions,omitempty"`
 


### PR DESCRIPTION
**What this PR does / why we need it**: extend global settings for new flags: enableDashboard, enableOIDCKubeconfig

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #4876

```release-note
NONE
```
