### PR TITLE
Correctly close port-forwarders

### DIFF
--- a/api/pkg/handler/v1/common/common.go
+++ b/api/pkg/handler/v1/common/common.go
@@ -143,15 +143,15 @@ func GetPortForwarder(
 	cfg *rest.Config,
 	namespace string,
 	labelSelector string,
-	containerPort int) (*portforward.PortForwarder, *bytes.Buffer, error) {
+	containerPort int) (*portforward.PortForwarder, *bytes.Buffer, chan struct{}, error) {
 	pod, err := GetReadyPod(coreClient.Pods(namespace), labelSelector)
 	if err != nil {
-		return nil, nil, err
+		return nil, nil, nil, err
 	}
 
 	dialer, err := getDialerForPod(pod, coreClient.RESTClient(), cfg)
 	if err != nil {
-		return nil, nil, err
+		return nil, nil, nil, err
 	}
 
 	readyChan := make(chan struct{})
@@ -160,11 +160,11 @@ func GetPortForwarder(
 	outBuffer := bytes.NewBuffer(make([]byte, 1024))
 	portforwarder, err := portforward.NewOnAddresses(dialer, []string{"127.0.0.1"}, []string{"0:" + strconv.Itoa(containerPort)}, stopChan, readyChan, outBuffer, errorBuffer)
 	if err != nil {
-		return nil, nil, fmt.Errorf("failed to create portforwarder: %v", err)
+		return nil, nil, nil, fmt.Errorf("failed to create portforwarder: %v", err)
 	}
 
 	// Portforwarding is blocking, so we can't do it here
-	return portforwarder, outBuffer, nil
+	return portforwarder, outBuffer, stopChan, nil
 }
 
 func getReadyPods(pods *corev1.PodList) *corev1.PodList {

--- a/api/pkg/handler/v1/kubernetes-dashboard/dashboard.go
+++ b/api/pkg/handler/v1/kubernetes-dashboard/dashboard.go
@@ -77,7 +77,7 @@ func ProxyEndpoint(
 			log = log.With("cluster", userCluster.Name)
 
 			// Ideally we would cache these to not open a port for every single request
-			portforwarder, outBuffer, err := common.GetPortForwarder(
+			portforwarder, outBuffer, closeChan, err := common.GetPortForwarder(
 				clusterProvider.GetSeedClusterAdminClient().CoreV1(),
 				clusterProvider.SeedAdminConfig(),
 				userCluster.Status.NamespaceName,
@@ -86,6 +86,7 @@ func ProxyEndpoint(
 			if err != nil {
 				return nil, fmt.Errorf("failed to get portforwarder for console: %v", err)
 			}
+			defer func() { close(closeChan) }()
 			defer portforwarder.Close()
 
 			if err = common.ForwardPort(log, portforwarder); err != nil {

--- a/api/pkg/handler/v1/kubernetes-dashboard/dashboard.go
+++ b/api/pkg/handler/v1/kubernetes-dashboard/dashboard.go
@@ -86,8 +86,10 @@ func ProxyEndpoint(
 			if err != nil {
 				return nil, fmt.Errorf("failed to get portforwarder for console: %v", err)
 			}
-			defer func() { close(closeChan) }()
-			defer portforwarder.Close()
+			defer func() {
+				portforwarder.Close()
+				close(closeChan)
+			}()
 
 			if err = common.ForwardPort(log, portforwarder); err != nil {
 				common.WriteHTTPError(log, w, err)

--- a/api/pkg/handler/v1/openshift/openshift.go
+++ b/api/pkg/handler/v1/openshift/openshift.go
@@ -118,7 +118,7 @@ func ConsoleProxyEndpoint(
 			log = log.With("cluster", cluster.Name)
 
 			// Ideally we would cache these to not open a port for every single request
-			portforwarder, outBuffer, err := common.GetPortForwarder(
+			portforwarder, outBuffer, closeChan, err := common.GetPortForwarder(
 				clusterProvider.GetSeedClusterAdminClient().CoreV1(),
 				clusterProvider.SeedAdminConfig(),
 				cluster.Status.NamespaceName,
@@ -128,6 +128,7 @@ func ConsoleProxyEndpoint(
 			if err != nil {
 				return nil, fmt.Errorf("failed to get portforwarder for console: %v", err)
 			}
+			defer func() { close(closeChan) }()
 			defer portforwarder.Close()
 
 			if err = common.ForwardPort(log, portforwarder); err != nil {

--- a/api/pkg/handler/v1/openshift/openshift.go
+++ b/api/pkg/handler/v1/openshift/openshift.go
@@ -128,8 +128,10 @@ func ConsoleProxyEndpoint(
 			if err != nil {
 				return nil, fmt.Errorf("failed to get portforwarder for console: %v", err)
 			}
-			defer func() { close(closeChan) }()
-			defer portforwarder.Close()
+			defer func() {
+				portforwarder.Close()
+				close(closeChan)
+			}()
 
 			if err = common.ForwardPort(log, portforwarder); err != nil {
 				common.WriteHTTPError(log, w, err)


### PR DESCRIPTION
**What this PR does / why we need it**:

So far, we close the individual listeners in the portforwarding but not the underlying spdy connection to the kubelet, resulting in memory leaking.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #4862

**Special notes for your reviewer**:

**Documentation**:
<!-- Add links to the related documentation changes related to this pull request. E.g. the link to the kubermatic/docs pullrequest. -->

**Does this PR introduce a user-facing change?**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If  no release note is required, just write "NONE".
-->
```release-note
A memory leak in the port-forwarding of the Kubernetes dashboard and Openshift console endpoints was fixed
```
