### PR TITLE
Update label usage for cAdvisor metrics

### DIFF
--- a/config/monitoring/grafana/Chart.yaml
+++ b/config/monitoring/grafana/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: grafana
-version: 1.2.9
+version: 1.2.10
 appVersion: 6.5.2
 description: Grafana for Kubermatic
 keywords:

--- a/config/monitoring/grafana/dashboards/go/processes.json
+++ b/config/monitoring/grafana/dashboards/go/processes.json
@@ -57,7 +57,7 @@
           "refId": "A"
         },
         {
-          "expr": "avg(container_memory_rss{namespace=\"$namespace\",pod_name=\"$pod\",container_name=~\"$container\"})",
+          "expr": "avg(container_memory_rss{namespace=\"$namespace\",pod=\"$pod\",container=~\"$container\"})",
           "format": "time_series",
           "intervalFactor": 1,
           "legendFormat": "container rss",

--- a/config/monitoring/grafana/dashboards/kubernetes/node-namespaces.json
+++ b/config/monitoring/grafana/dashboards/kubernetes/node-namespaces.json
@@ -76,7 +76,7 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "sum by (namespace) (container_memory_rss{kubernetes_io_hostname=\"$hostname\",job=\"cadvisor\",container_name!=\"\",namespace!=\"\",namespace!~\"^$exclude.*\"})",
+          "expr": "sum by (namespace) (container_memory_rss{kubernetes_io_hostname=\"$hostname\",job=\"cadvisor\",container!=\"\",namespace!=\"\",namespace!~\"^$exclude.*\"})",
           "format": "time_series",
           "intervalFactor": 1,
           "legendFormat": "{{ namespace }}",

--- a/config/monitoring/grafana/dashboards/kubernetes/pods.json
+++ b/config/monitoring/grafana/dashboards/kubernetes/pods.json
@@ -50,7 +50,7 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "sum (container_memory_usage_bytes{job=\"cadvisor\", namespace=\"$namespace\", pod_name=\"$pod\", container_name!=\"POD\", image!=\"\"})",
+          "expr": "sum (container_memory_usage_bytes{job=\"cadvisor\", namespace=\"$namespace\", pod=\"$pod\", container!=\"POD\", image!=\"\"})",
           "format": "time_series",
           "intervalFactor": 2,
           "legendFormat": "Current Usage",
@@ -153,10 +153,10 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "sum by(container_name) (container_memory_usage_bytes{job=\"cadvisor\", namespace=\"$namespace\", pod_name=\"$pod\", container_name=~\"$container\", container_name!=\"POD\"})",
+          "expr": "sum by(container) (container_memory_usage_bytes{job=\"cadvisor\", namespace=\"$namespace\", pod=\"$pod\", container=~\"$container\", container!=\"POD\"})",
           "format": "time_series",
           "intervalFactor": 2,
-          "legendFormat": "Current: {{ container_name }}",
+          "legendFormat": "Current: {{ container }}",
           "refId": "A"
         },
         {
@@ -257,10 +257,10 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "sum by (container_name) (rate(container_cpu_usage_seconds_total{job=\"cadvisor\", image!=\"\",container_name!=\"POD\",pod_name=\"$pod\"}[1m]))",
+          "expr": "sum by (container) (rate(container_cpu_usage_seconds_total{job=\"cadvisor\", image!=\"\",container!=\"POD\",pod=\"$pod\"}[1m]))",
           "format": "time_series",
           "intervalFactor": 2,
-          "legendFormat": "{{ container_name }}",
+          "legendFormat": "{{ container }}",
           "refId": "A"
         }
       ],
@@ -347,7 +347,7 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "rate(container_network_receive_bytes_total{job=\"cadvisor\", namespace=\"$namespace\", pod_name=\"$pod\"}[1m])",
+          "expr": "rate(container_network_receive_bytes_total{job=\"cadvisor\", namespace=\"$namespace\", pod=\"$pod\"}[1m])",
           "format": "time_series",
           "intervalFactor": 2,
           "legendFormat": "bytes",

--- a/config/monitoring/grafana/dashboards/kubernetes/resources-cluster.json
+++ b/config/monitoring/grafana/dashboards/kubernetes/resources-cluster.json
@@ -914,7 +914,7 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "sum(namespace_pod_name_container_name:container_cpu_usage_seconds_total:sum_rate) by (namespace)",
+          "expr": "sum(namespace_pod_container:container_cpu_usage_seconds_total:sum_rate) by (namespace)",
           "format": "time_series",
           "intervalFactor": 2,
           "legendFormat": "{{namespace}}",
@@ -1131,7 +1131,7 @@
       ],
       "targets": [
         {
-          "expr": "sum(namespace_pod_name_container_name:container_cpu_usage_seconds_total:sum_rate) by (namespace)",
+          "expr": "sum(namespace_pod_container:container_cpu_usage_seconds_total:sum_rate) by (namespace)",
           "format": "table",
           "instant": true,
           "intervalFactor": 2,
@@ -1149,7 +1149,7 @@
           "step": 10
         },
         {
-          "expr": "sum(namespace_pod_name_container_name:container_cpu_usage_seconds_total:sum_rate) by (namespace) / sum(kube_pod_container_resource_requests_cpu_cores) by (namespace)",
+          "expr": "sum(namespace_pod_container:container_cpu_usage_seconds_total:sum_rate) by (namespace) / sum(kube_pod_container_resource_requests_cpu_cores) by (namespace)",
           "format": "table",
           "instant": true,
           "intervalFactor": 2,
@@ -1167,7 +1167,7 @@
           "step": 10
         },
         {
-          "expr": "sum(namespace_pod_name_container_name:container_cpu_usage_seconds_total:sum_rate) by (namespace) / sum(kube_pod_container_resource_limits_cpu_cores) by (namespace)",
+          "expr": "sum(namespace_pod_container:container_cpu_usage_seconds_total:sum_rate) by (namespace) / sum(kube_pod_container_resource_limits_cpu_cores) by (namespace)",
           "format": "table",
           "instant": true,
           "intervalFactor": 2,
@@ -1267,7 +1267,7 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "sum(container_memory_rss{job=\"cadvisor\",container_name!=\"\"}) by (namespace)",
+          "expr": "sum(container_memory_rss{job=\"cadvisor\",container!=\"\"}) by (namespace)",
           "format": "time_series",
           "intervalFactor": 2,
           "legendFormat": "{{namespace}}",
@@ -1482,7 +1482,7 @@
       ],
       "targets": [
         {
-          "expr": "sum(container_memory_rss{job=\"cadvisor\",container_name!=\"\"}) by (namespace)",
+          "expr": "sum(container_memory_rss{job=\"cadvisor\",container!=\"\"}) by (namespace)",
           "format": "table",
           "instant": true,
           "intervalFactor": 2,
@@ -1500,7 +1500,7 @@
           "step": 10
         },
         {
-          "expr": "sum(container_memory_rss{job=\"cadvisor\",container_name!=\"\"}) by (namespace) / sum(kube_pod_container_resource_requests_memory_bytes) by (namespace)",
+          "expr": "sum(container_memory_rss{job=\"cadvisor\",container!=\"\"}) by (namespace) / sum(kube_pod_container_resource_requests_memory_bytes) by (namespace)",
           "format": "table",
           "instant": true,
           "intervalFactor": 2,
@@ -1518,7 +1518,7 @@
           "step": 10
         },
         {
-          "expr": "sum(container_memory_rss{job=\"cadvisor\",container_name!=\"\"}) by (namespace) / sum(kube_pod_container_resource_limits_memory_bytes) by (namespace)",
+          "expr": "sum(container_memory_rss{job=\"cadvisor\",container!=\"\"}) by (namespace) / sum(kube_pod_container_resource_limits_memory_bytes) by (namespace)",
           "format": "table",
           "instant": true,
           "intervalFactor": 2,

--- a/config/monitoring/grafana/dashboards/kubernetes/resources-namespace.json
+++ b/config/monitoring/grafana/dashboards/kubernetes/resources-namespace.json
@@ -60,10 +60,10 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "sum(namespace_pod_name_container_name:container_cpu_usage_seconds_total:sum_rate{namespace=\"$namespace\"}) by (pod_name)",
+          "expr": "sum(namespace_pod_container:container_cpu_usage_seconds_total:sum_rate{namespace=\"$namespace\"}) by (pod)",
           "format": "time_series",
           "intervalFactor": 2,
-          "legendFormat": "{{pod_name}}",
+          "legendFormat": "{{pod}}",
           "legendLink": null,
           "refId": "A",
           "step": 10
@@ -275,7 +275,7 @@
       ],
       "targets": [
         {
-          "expr": "sum(label_replace(namespace_pod_name_container_name:container_cpu_usage_seconds_total:sum_rate{namespace=\"$namespace\"}, \"pod\", \"$1\", \"pod_name\", \"(.*)\")) by (pod)",
+          "expr": "sum(namespace_pod_container:container_cpu_usage_seconds_total:sum_rate{namespace=\"$namespace\"}) by (pod)",
           "format": "table",
           "instant": true,
           "intervalFactor": 2,
@@ -293,7 +293,7 @@
           "step": 10
         },
         {
-          "expr": "sum(label_replace(namespace_pod_name_container_name:container_cpu_usage_seconds_total:sum_rate{namespace=\"$namespace\"}, \"pod\", \"$1\", \"pod_name\", \"(.*)\")) by (pod) / sum(kube_pod_container_resource_requests_cpu_cores{namespace=\"$namespace\"}) by (pod)",
+          "expr": "sum(namespace_pod_container:container_cpu_usage_seconds_total:sum_rate{namespace=\"$namespace\"}) by (pod) / sum(kube_pod_container_resource_requests_cpu_cores{namespace=\"$namespace\"}) by (pod)",
           "format": "table",
           "instant": true,
           "intervalFactor": 2,
@@ -311,7 +311,7 @@
           "step": 10
         },
         {
-          "expr": "sum(label_replace(namespace_pod_name_container_name:container_cpu_usage_seconds_total:sum_rate{namespace=\"$namespace\"}, \"pod\", \"$1\", \"pod_name\", \"(.*)\")) by (pod) / sum(kube_pod_container_resource_limits_cpu_cores{namespace=\"$namespace\"}) by (pod)",
+          "expr": "sum(namespace_pod_container:container_cpu_usage_seconds_total:sum_rate{namespace=\"$namespace\"}) by (pod) / sum(kube_pod_container_resource_limits_cpu_cores{namespace=\"$namespace\"}) by (pod)",
           "format": "table",
           "instant": true,
           "intervalFactor": 2,
@@ -411,10 +411,10 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "sum(container_memory_usage_bytes{job=\"cadvisor\",namespace=\"$namespace\", container_name!=\"\"}) by (pod_name)",
+          "expr": "sum(container_memory_usage_bytes{job=\"cadvisor\",namespace=\"$namespace\", container!=\"\"}) by (pod)",
           "format": "time_series",
           "intervalFactor": 2,
-          "legendFormat": "{{pod_name}}",
+          "legendFormat": "{{pod}}",
           "legendLink": null,
           "refId": "A",
           "step": 10
@@ -668,7 +668,7 @@
       ],
       "targets": [
         {
-          "expr": "sum(label_replace(container_memory_usage_bytes{job=\"cadvisor\",namespace=\"$namespace\",container_name!=\"\"}, \"pod\", \"$1\", \"pod_name\", \"(.*)\")) by (pod)",
+          "expr": "sum(container_memory_usage_bytes{job=\"cadvisor\",namespace=\"$namespace\",container!=\"\"}) by (pod)",
           "format": "table",
           "instant": true,
           "intervalFactor": 2,
@@ -686,7 +686,7 @@
           "step": 10
         },
         {
-          "expr": "sum(label_replace(container_memory_usage_bytes{job=\"cadvisor\",namespace=\"$namespace\",container_name!=\"\"}, \"pod\", \"$1\", \"pod_name\", \"(.*)\")) by (pod) / sum(kube_pod_container_resource_requests_memory_bytes{namespace=\"$namespace\"}) by (pod)",
+          "expr": "sum(container_memory_usage_bytes{job=\"cadvisor\",namespace=\"$namespace\",container!=\"\"}) by (pod) / sum(kube_pod_container_resource_requests_memory_bytes{namespace=\"$namespace\"}) by (pod)",
           "format": "table",
           "instant": true,
           "intervalFactor": 2,
@@ -704,7 +704,7 @@
           "step": 10
         },
         {
-          "expr": "sum(label_replace(container_memory_usage_bytes{job=\"cadvisor\",namespace=\"$namespace\",container_name!=\"\"}, \"pod\", \"$1\", \"pod_name\", \"(.*)\")) by (pod) / sum(kube_pod_container_resource_limits_memory_bytes{namespace=\"$namespace\"}) by (pod)",
+          "expr": "sum(container_memory_usage_bytes{job=\"cadvisor\",namespace=\"$namespace\",container!=\"\"}) by (pod) / sum(kube_pod_container_resource_limits_memory_bytes{namespace=\"$namespace\"}) by (pod)",
           "format": "table",
           "instant": true,
           "intervalFactor": 2,
@@ -713,7 +713,7 @@
           "step": 10
         },
         {
-          "expr": "sum(label_replace(container_memory_rss{job=\"cadvisor\",namespace=\"$namespace\",container_name!=\"\"}, \"pod\", \"$1\", \"pod_name\", \"(.*)\")) by (pod)",
+          "expr": "sum(container_memory_rss{job=\"cadvisor\",namespace=\"$namespace\",container!=\"\"}) by (pod)",
           "format": "table",
           "instant": true,
           "intervalFactor": 2,
@@ -722,7 +722,7 @@
           "step": 10
         },
         {
-          "expr": "sum(label_replace(container_memory_cache{job=\"cadvisor\",namespace=\"$namespace\",container_name!=\"\"}, \"pod\", \"$1\", \"pod_name\", \"(.*)\")) by (pod)",
+          "expr": "sum(container_memory_cache{job=\"cadvisor\",namespace=\"$namespace\",container!=\"\"}) by (pod)",
           "format": "table",
           "instant": true,
           "intervalFactor": 2,
@@ -731,7 +731,7 @@
           "step": 10
         },
         {
-          "expr": "sum(label_replace(container_memory_swap{job=\"cadvisor\",namespace=\"$namespace\",container_name!=\"\"}, \"pod\", \"$1\", \"pod_name\", \"(.*)\")) by (pod)",
+          "expr": "sum(container_memory_swap{job=\"cadvisor\",namespace=\"$namespace\",container!=\"\"}) by (pod)",
           "format": "table",
           "instant": true,
           "intervalFactor": 2,

--- a/config/monitoring/grafana/dashboards/kubernetes/resources-pod.json
+++ b/config/monitoring/grafana/dashboards/kubernetes/resources-pod.json
@@ -297,11 +297,11 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "sum(namespace_pod_name_container_name:container_cpu_usage_seconds_total:sum_rate{namespace=\"$namespace\", pod_name=\"$pod\", container_name!=\"POD\"}) by (container_name)",
+          "expr": "sum(namespace_pod_container:container_cpu_usage_seconds_total:sum_rate{namespace=\"$namespace\", pod=\"$pod\", container!=\"POD\"}) by (container)",
           "format": "time_series",
           "instant": false,
           "intervalFactor": 2,
-          "legendFormat": "{{ container_name }}",
+          "legendFormat": "{{ container }}",
           "legendLink": null,
           "refId": "A",
           "step": 10
@@ -513,7 +513,7 @@
       ],
       "targets": [
         {
-          "expr": "sum(label_replace(namespace_pod_name_container_name:container_cpu_usage_seconds_total:sum_rate{namespace=\"$namespace\", pod_name=\"$pod\", container_name!=\"POD\"}, \"container\", \"$1\", \"container_name\", \"(.*)\")) by (container)",
+          "expr": "sum(namespace_pod_container:container_cpu_usage_seconds_total:sum_rate{namespace=\"$namespace\", pod=\"$pod\", container!=\"POD\"}) by (container)",
           "format": "table",
           "instant": true,
           "intervalFactor": 2,
@@ -531,7 +531,7 @@
           "step": 10
         },
         {
-          "expr": "sum(label_replace(namespace_pod_name_container_name:container_cpu_usage_seconds_total:sum_rate{namespace=\"$namespace\", pod_name=\"$pod\"}, \"container\", \"$1\", \"container_name\", \"(.*)\")) by (container) / sum(kube_pod_container_resource_requests_cpu_cores{namespace=\"$namespace\", pod=\"$pod\"}) by (container)",
+          "expr": "sum(namespace_pod_container:container_cpu_usage_seconds_total:sum_rate{namespace=\"$namespace\", pod=\"$pod\"}) by (container) / sum(kube_pod_container_resource_requests_cpu_cores{namespace=\"$namespace\", pod=\"$pod\"}) by (container)",
           "format": "table",
           "instant": true,
           "intervalFactor": 2,
@@ -549,7 +549,7 @@
           "step": 10
         },
         {
-          "expr": "sum(label_replace(namespace_pod_name_container_name:container_cpu_usage_seconds_total:sum_rate{namespace=\"$namespace\", pod_name=\"$pod\"}, \"container\", \"$1\", \"container_name\", \"(.*)\")) by (container) / sum(kube_pod_container_resource_limits_cpu_cores{namespace=\"$namespace\", pod=\"$pod\"}) by (container)",
+          "expr": "sum(namespace_pod_container:container_cpu_usage_seconds_total:sum_rate{namespace=\"$namespace\", pod=\"$pod\"}) by (container) / sum(kube_pod_container_resource_limits_cpu_cores{namespace=\"$namespace\", pod=\"$pod\"}) by (container)",
           "format": "table",
           "instant": true,
           "intervalFactor": 2,
@@ -649,28 +649,28 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "sum(container_memory_rss{namespace=\"$namespace\", pod_name=\"$pod\", container_name!=\"POD\", container_name!=\"\"}) by (container_name)",
+          "expr": "sum(container_memory_rss{namespace=\"$namespace\", pod=\"$pod\", container!=\"POD\", container!=\"\"}) by (container)",
           "format": "time_series",
           "intervalFactor": 2,
-          "legendFormat": "{{ container_name }} (RSS)",
+          "legendFormat": "{{ container }} (RSS)",
           "legendLink": null,
           "refId": "A",
           "step": 10
         },
         {
-          "expr": "sum(container_memory_cache{namespace=\"$namespace\", pod_name=\"$pod\", container_name!=\"POD\", container_name!=\"\"}) by (container_name)",
+          "expr": "sum(container_memory_cache{namespace=\"$namespace\", pod=\"$pod\", container!=\"POD\", container!=\"\"}) by (container)",
           "format": "time_series",
           "intervalFactor": 2,
-          "legendFormat": "{{ container_name }} (Cache)",
+          "legendFormat": "{{ container }} (Cache)",
           "legendLink": null,
           "refId": "B",
           "step": 10
         },
         {
-          "expr": "sum(container_memory_swap{namespace=\"$namespace\", pod_name=\"$pod\", container_name!=\"POD\", container_name!=\"\"}) by (container_name)",
+          "expr": "sum(container_memory_swap{namespace=\"$namespace\", pod=\"$pod\", container!=\"POD\", container!=\"\"}) by (container)",
           "format": "time_series",
           "intervalFactor": 2,
-          "legendFormat": "{{ container_name }} (Swap)",
+          "legendFormat": "{{ container }} (Swap)",
           "legendLink": null,
           "refId": "C",
           "step": 10
@@ -924,7 +924,7 @@
       ],
       "targets": [
         {
-          "expr": "sum(label_replace(container_memory_usage_bytes{namespace=\"$namespace\", pod_name=\"$pod\", container_name!=\"POD\", container_name!=\"\"}, \"container\", \"$1\", \"container_name\", \"(.*)\")) by (container)",
+          "expr": "sum(container_memory_usage_bytes{namespace=\"$namespace\", pod=\"$pod\", container!=\"POD\", container!=\"\"}) by (container)",
           "format": "table",
           "instant": true,
           "intervalFactor": 2,
@@ -942,7 +942,7 @@
           "step": 10
         },
         {
-          "expr": "sum(label_replace(container_memory_usage_bytes{namespace=\"$namespace\", pod_name=\"$pod\"}, \"container\", \"$1\", \"container_name\", \"(.*)\")) by (container) / sum(kube_pod_container_resource_requests_memory_bytes{namespace=\"$namespace\", pod=\"$pod\"}) by (container)",
+          "expr": "sum(container_memory_usage_bytes{namespace=\"$namespace\", pod=\"$pod\"}) by (container) / sum(kube_pod_container_resource_requests_memory_bytes{namespace=\"$namespace\", pod=\"$pod\"}) by (container)",
           "format": "table",
           "instant": true,
           "intervalFactor": 2,
@@ -960,7 +960,7 @@
           "step": 10
         },
         {
-          "expr": "sum(label_replace(container_memory_usage_bytes{namespace=\"$namespace\", pod_name=\"$pod\", container_name!=\"\"}, \"container\", \"$1\", \"container_name\", \"(.*)\")) by (container) / sum(kube_pod_container_resource_limits_memory_bytes{namespace=\"$namespace\", pod=\"$pod\"}) by (container)",
+          "expr": "sum(container_memory_usage_bytes{namespace=\"$namespace\", pod=\"$pod\", container!=\"\"}) by (container) / sum(kube_pod_container_resource_limits_memory_bytes{namespace=\"$namespace\", pod=\"$pod\"}) by (container)",
           "format": "table",
           "instant": true,
           "intervalFactor": 2,
@@ -969,7 +969,7 @@
           "step": 10
         },
         {
-          "expr": "sum(label_replace(container_memory_rss{namespace=\"$namespace\", pod_name=\"$pod\", container_name != \"\", container_name != \"POD\"}, \"container\", \"$1\", \"container_name\", \"(.*)\")) by (container)",
+          "expr": "sum(container_memory_rss{namespace=\"$namespace\", pod=\"$pod\", container != \"\", container != \"POD\"}) by (container)",
           "format": "table",
           "instant": true,
           "intervalFactor": 2,
@@ -978,7 +978,7 @@
           "step": 10
         },
         {
-          "expr": "sum(label_replace(container_memory_cache{namespace=\"$namespace\", pod_name=\"$pod\", container_name != \"\", container_name != \"POD\"}, \"container\", \"$1\", \"container_name\", \"(.*)\")) by (container)",
+          "expr": "sum(container_memory_cache{namespace=\"$namespace\", pod=\"$pod\", container != \"\", container != \"POD\"}) by (container)",
           "format": "table",
           "instant": true,
           "intervalFactor": 2,
@@ -987,7 +987,7 @@
           "step": 10
         },
         {
-          "expr": "sum(label_replace(container_memory_swap{namespace=\"$namespace\", pod_name=\"$pod\", container_name != \"\", container_name != \"POD\"}, \"container\", \"$1\", \"container_name\", \"(.*)\")) by (container)",
+          "expr": "sum(container_memory_swap{namespace=\"$namespace\", pod=\"$pod\", container != \"\", container != \"POD\"}) by (container)",
           "format": "table",
           "instant": true,
           "intervalFactor": 2,

--- a/config/monitoring/grafana/dashboards/kubernetes/statefulset.json
+++ b/config/monitoring/grafana/dashboards/kubernetes/statefulset.json
@@ -69,7 +69,7 @@
       "tableColumn": "",
       "targets": [
         {
-          "expr": "sum(rate(container_cpu_usage_seconds_total{job=\"cadvisor\", namespace=\"$namespace\", pod_name=~\"$statefulset.*\", container_name!=\"\"}[3m]))",
+          "expr": "sum(rate(container_cpu_usage_seconds_total{job=\"cadvisor\", namespace=\"$namespace\", pod=~\"$statefulset.*\", container!=\"\"}[3m]))",
           "format": "time_series",
           "intervalFactor": 2,
           "legendFormat": "",
@@ -152,7 +152,7 @@
       "tableColumn": "",
       "targets": [
         {
-          "expr": "sum(container_memory_usage_bytes{job=\"cadvisor\", namespace=\"$namespace\", pod_name=~\"$statefulset.*\", container_name!=\"\"}) / 1024^3",
+          "expr": "sum(container_memory_usage_bytes{job=\"cadvisor\", namespace=\"$namespace\", pod=~\"$statefulset.*\", container!=\"\"}) / 1024^3",
           "format": "time_series",
           "intervalFactor": 2,
           "legendFormat": "",
@@ -235,7 +235,7 @@
       "tableColumn": "",
       "targets": [
         {
-          "expr": "sum(rate(container_network_transmit_bytes_total{job=\"cadvisor\", namespace=\"$namespace\", pod_name=~\"$statefulset.*\", container_name!=\"\"}[3m])) + sum(rate(container_network_receive_bytes_total{namespace=\"$namespace\",pod_name=~\"$statefulset.*\"}[3m]))",
+          "expr": "sum(rate(container_network_transmit_bytes_total{job=\"cadvisor\", namespace=\"$namespace\", pod=~\"$statefulset.*\", container!=\"\"}[3m])) + sum(rate(container_network_receive_bytes_total{namespace=\"$namespace\",pod=~\"$statefulset.*\"}[3m]))",
           "format": "time_series",
           "intervalFactor": 2,
           "legendFormat": "",

--- a/config/monitoring/prometheus/Chart.yaml
+++ b/config/monitoring/prometheus/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: prometheus
-version: 2.2.5
+version: 2.2.6
 appVersion: v2.14.0
 description: Prometheus Monitoring for Kubernetes
 keywords:

--- a/config/monitoring/prometheus/rules/general-kube-state-metrics.yaml
+++ b/config/monitoring/prometheus/rules/general-kube-state-metrics.yaml
@@ -6,47 +6,47 @@ groups:
       sum(min(kube_pod_info) by (node))
     record: ':kube_pod_info_node_count:'
   - expr: |
-      max(label_replace(kube_pod_info{job="kube-state-metrics"}, "pod", "$1", "pod", "(.*)")) by (node, namespace, pod)
+      max(kube_pod_info{job="kube-state-metrics"}) by (node, namespace, pod)
     record: 'node_namespace_pod:kube_pod_info:'
   - expr: |
-      sum(rate(container_cpu_usage_seconds_total{job="cadvisor", image!="", container_name!=""}[5m])) by (namespace)
+      sum(rate(container_cpu_usage_seconds_total{job="cadvisor", image!="", container!=""}[5m])) by (namespace)
     record: namespace:container_cpu_usage_seconds_total:sum_rate
   - expr: |
-      sum by (namespace, pod_name, container_name) (
-        rate(container_cpu_usage_seconds_total{job="cadvisor", image!="", container_name!=""}[5m])
+      sum by (namespace, pod, container) (
+        rate(container_cpu_usage_seconds_total{job="cadvisor", image!="", container!=""}[5m])
       )
-    record: namespace_pod_name_container_name:container_cpu_usage_seconds_total:sum_rate
+    record: namespace_pod_container:container_cpu_usage_seconds_total:sum_rate
   - expr: |
       sum by (namespace) (
-        container_memory_usage_bytes{job="cadvisor", image!="", container_name!=""}
+        container_memory_usage_bytes{job="cadvisor", image!="", container!=""}
       )
     record: namespace:container_memory_usage_bytes:sum
   - expr: |
       sum by (namespace, label_name) (
-          sum(rate(container_cpu_usage_seconds_total{job="cadvisor", image!="", container_name!=""}[5m])) by (namespace, pod_name)
-        * on (namespace, pod_name) group_left(label_name)
-          label_replace(kube_pod_labels{job="kube-state-metrics"}, "pod_name", "$1", "pod", "(.*)")
+          sum(rate(container_cpu_usage_seconds_total{job="cadvisor", image!="", container!=""}[5m])) by (namespace, pod)
+        * on (namespace, pod) group_left (label_name)
+          kube_pod_labels{job="kube-state-metrics"}
       )
     record: namespace_name:container_cpu_usage_seconds_total:sum_rate
   - expr: |
       sum by (namespace, label_name) (
-          sum(container_memory_usage_bytes{job="cadvisor",image!="", container_name!=""}) by (pod_name, namespace)
-        * on (namespace, pod_name) group_left(label_name)
-          label_replace(kube_pod_labels{job="kube-state-metrics"}, "pod_name", "$1", "pod", "(.*)")
+          sum(container_memory_usage_bytes{job="cadvisor",image!="", container!=""}) by (pod, namespace)
+        * on (namespace, pod) group_left (label_name)
+          kube_pod_labels{job="kube-state-metrics"}
       )
     record: namespace_name:container_memory_usage_bytes:sum
   - expr: |
       sum by (namespace, label_name) (
           sum(kube_pod_container_resource_requests_memory_bytes{job="kube-state-metrics"}) by (namespace, pod)
-        * on (namespace, pod) group_left(label_name)
-          label_replace(kube_pod_labels{job="kube-state-metrics"}, "pod_name", "$1", "pod", "(.*)")
+        * on (namespace, pod) group_left (label_name)
+          kube_pod_labels{job="kube-state-metrics"}
       )
     record: namespace_name:kube_pod_container_resource_requests_memory_bytes:sum
   - expr: |
       sum by (namespace, label_name) (
           sum(kube_pod_container_resource_requests_cpu_cores{job="kube-state-metrics"} and on(pod) kube_pod_status_scheduled{condition="true"}) by (namespace, pod)
-        * on (namespace, pod) group_left(label_name)
-          label_replace(kube_pod_labels{job="kube-state-metrics"}, "pod_name", "$1", "pod", "(.*)")
+        * on (namespace, pod) group_left (label_name)
+          kube_pod_labels{job="kube-state-metrics"}
       )
     record: namespace_name:kube_pod_container_resource_requests_cpu_cores:sum
   - alert: KubeStateMetricsDown

--- a/config/monitoring/prometheus/rules/general-vertical-pod-autoscaler.yaml
+++ b/config/monitoring/prometheus/rules/general-vertical-pod-autoscaler.yaml
@@ -4,13 +4,13 @@ groups:
   rules:
   - expr: |
       label_replace(
-        sum(container_cpu_usage_seconds_total{job="cadvisor", pod_name=~".+", name!="POD", name!=""}) by (pod_name, namespace, name),
+        sum(container_cpu_usage_seconds_total{job="cadvisor", pod=~".+", name!="POD", name!=""}) by (pod, namespace, name),
         "job", "cadvisor-vpa", "", ""
       )
     record: container_cpu_usage_seconds_total
   - expr: |
       label_replace(
-        sum(container_memory_usage_bytes{job="cadvisor", pod_name=~".+", name!="POD", name!=""}) by (pod_name, namespace, name),
+        sum(container_memory_usage_bytes{job="cadvisor", pod=~".+", name!="POD", name!=""}) by (pod, namespace, name),
         "job", "cadvisor-vpa", "", ""
       )
     record: container_memory_usage_bytes

--- a/config/monitoring/prometheus/rules/src/general/cadvisor.yaml
+++ b/config/monitoring/prometheus/rules/src/general/cadvisor.yaml
@@ -14,12 +14,12 @@ groups:
 
   # - alert: CPUThrottlingHigh
   #   annotations:
-  #     message: '{{ printf "%0.0f" $value }}% throttling of CPU in namespace {{ $labels.namespace }} for {{ $labels.container_name }}.'
+  #     message: '{{ printf "%0.0f" $value }}% throttling of CPU in namespace {{ $labels.namespace }} for {{ $labels.container }}.'
   #     runbook_url: https://docs.kubermatic.io/monitoring/runbook/#alert-cputhrottlinghigh
   #   expr: |
-  #     100 * sum(increase(container_cpu_cfs_throttled_periods_total[5m])) by (container_name, pod_name, namespace)
+  #     100 * sum(increase(container_cpu_cfs_throttled_periods_total[5m])) by (container, pod, namespace)
   #       /
-  #     sum(increase(container_cpu_cfs_periods_total[5m])) by (container_name, pod_name, namespace)
+  #     sum(increase(container_cpu_cfs_periods_total[5m])) by (container, pod, namespace)
   #       > 25
   #   for: 15m
   #   labels:

--- a/config/monitoring/prometheus/rules/src/general/kube-state-metrics.yaml
+++ b/config/monitoring/prometheus/rules/src/general/kube-state-metrics.yaml
@@ -7,54 +7,54 @@ groups:
 
   - record: 'node_namespace_pod:kube_pod_info:'
     expr: |
-      max(label_replace(kube_pod_info{job="kube-state-metrics"}, "pod", "$1", "pod", "(.*)")) by (node, namespace, pod)
+      max(kube_pod_info{job="kube-state-metrics"}) by (node, namespace, pod)
 
   - record: namespace:container_cpu_usage_seconds_total:sum_rate
     expr: |
-      sum(rate(container_cpu_usage_seconds_total{job="cadvisor", image!="", container_name!=""}[5m])) by (namespace)
+      sum(rate(container_cpu_usage_seconds_total{job="cadvisor", image!="", container!=""}[5m])) by (namespace)
 
-  - record: namespace_pod_name_container_name:container_cpu_usage_seconds_total:sum_rate
+  - record: namespace_pod_container:container_cpu_usage_seconds_total:sum_rate
     expr: |
-      sum by (namespace, pod_name, container_name) (
-        rate(container_cpu_usage_seconds_total{job="cadvisor", image!="", container_name!=""}[5m])
+      sum by (namespace, pod, container) (
+        rate(container_cpu_usage_seconds_total{job="cadvisor", image!="", container!=""}[5m])
       )
 
   - record: namespace:container_memory_usage_bytes:sum
     expr: |
       sum by (namespace) (
-        container_memory_usage_bytes{job="cadvisor", image!="", container_name!=""}
+        container_memory_usage_bytes{job="cadvisor", image!="", container!=""}
       )
 
   - record: namespace_name:container_cpu_usage_seconds_total:sum_rate
     expr: |
       sum by (namespace, label_name) (
-          sum(rate(container_cpu_usage_seconds_total{job="cadvisor", image!="", container_name!=""}[5m])) by (namespace, pod_name)
-        * on (namespace, pod_name) group_left(label_name)
-          label_replace(kube_pod_labels{job="kube-state-metrics"}, "pod_name", "$1", "pod", "(.*)")
+          sum(rate(container_cpu_usage_seconds_total{job="cadvisor", image!="", container!=""}[5m])) by (namespace, pod)
+        * on (namespace, pod) group_left (label_name)
+          kube_pod_labels{job="kube-state-metrics"}
       )
 
   - record: namespace_name:container_memory_usage_bytes:sum
     expr: |
       sum by (namespace, label_name) (
-          sum(container_memory_usage_bytes{job="cadvisor",image!="", container_name!=""}) by (pod_name, namespace)
-        * on (namespace, pod_name) group_left(label_name)
-          label_replace(kube_pod_labels{job="kube-state-metrics"}, "pod_name", "$1", "pod", "(.*)")
+          sum(container_memory_usage_bytes{job="cadvisor",image!="", container!=""}) by (pod, namespace)
+        * on (namespace, pod) group_left (label_name)
+          kube_pod_labels{job="kube-state-metrics"}
       )
 
   - record: namespace_name:kube_pod_container_resource_requests_memory_bytes:sum
     expr: |
       sum by (namespace, label_name) (
           sum(kube_pod_container_resource_requests_memory_bytes{job="kube-state-metrics"}) by (namespace, pod)
-        * on (namespace, pod) group_left(label_name)
-          label_replace(kube_pod_labels{job="kube-state-metrics"}, "pod_name", "$1", "pod", "(.*)")
+        * on (namespace, pod) group_left (label_name)
+          kube_pod_labels{job="kube-state-metrics"}
       )
 
   - record: namespace_name:kube_pod_container_resource_requests_cpu_cores:sum
     expr: |
       sum by (namespace, label_name) (
           sum(kube_pod_container_resource_requests_cpu_cores{job="kube-state-metrics"} and on(pod) kube_pod_status_scheduled{condition="true"}) by (namespace, pod)
-        * on (namespace, pod) group_left(label_name)
-          label_replace(kube_pod_labels{job="kube-state-metrics"}, "pod_name", "$1", "pod", "(.*)")
+        * on (namespace, pod) group_left (label_name)
+          kube_pod_labels{job="kube-state-metrics"}
       )
 
   ############################################################

--- a/config/monitoring/prometheus/rules/src/general/vertical-pod-autoscaler.yaml
+++ b/config/monitoring/prometheus/rules/src/general/vertical-pod-autoscaler.yaml
@@ -4,20 +4,20 @@ groups:
 
   # These rules provide metrics to be consumed by Kubernetes' VPA. The VPA only needs a tiny fraction
   # of the labels available on the container_* metrics, so we reduce them with the inner query to
-  # only contain pod_name, namespace and name.
+  # only contain pod name, namespace and name.
   # Because the VPA does not allow to change the metric name it queries, but only the job selector,
   # we "cheat" by re-using the same metric name and injecting a custom job ("cadvisor-vpa") label.
 
   - record: container_cpu_usage_seconds_total
     expr: |
       label_replace(
-        sum(container_cpu_usage_seconds_total{job="cadvisor", pod_name=~".+", name!="POD", name!=""}) by (pod_name, namespace, name),
+        sum(container_cpu_usage_seconds_total{job="cadvisor", pod=~".+", name!="POD", name!=""}) by (pod, namespace, name),
         "job", "cadvisor-vpa", "", ""
       )
 
   - record: container_memory_usage_bytes
     expr: |
       label_replace(
-        sum(container_memory_usage_bytes{job="cadvisor", pod_name=~".+", name!="POD", name!=""}) by (pod_name, namespace, name),
+        sum(container_memory_usage_bytes{job="cadvisor", pod=~".+", name!="POD", name!=""}) by (pod, namespace, name),
         "job", "cadvisor-vpa", "", ""
       )


### PR DESCRIPTION
**What this PR does / why we need it**:
In Kubernetes 1.14 the label names `pod_name` and `container_name` in cAdvisor metrics [have been renamed to `pod` and `container`](https://github.com/kubernetes/kubernetes/pull/69099). The old labels were still available until they were [removed in 1.16](https://github.com/kubernetes/kubernetes/pull/80376).

This PR updates all of our Prometheus/Grafana stuff to work exclusively with the new label names (`pod` and `container`). Support for 1.14 has recently been dropped in #4987.

**Does this PR introduce a user-facing change?**:
```release-note
NONE
```
