### PR TITLE
Portforwarding: Use upstream port-parsing

### DIFF
--- a/api/pkg/handler/v1/common/common.go
+++ b/api/pkg/handler/v1/common/common.go
@@ -145,12 +145,12 @@ func GetPortForwarder(
 	containerPort int) (*portforward.PortForwarder, chan struct{}, error) {
 	pod, err := GetReadyPod(coreClient.Pods(namespace), labelSelector)
 	if err != nil {
-		return nil, nil, nil, err
+		return nil, nil, err
 	}
 
 	dialer, err := getDialerForPod(pod, coreClient.RESTClient(), cfg)
 	if err != nil {
-		return nil, nil, nil, err
+		return nil, nil, err
 	}
 
 	readyChan := make(chan struct{})
@@ -158,7 +158,7 @@ func GetPortForwarder(
 	errorBuffer := bytes.NewBuffer(make([]byte, 1024))
 	portforwarder, err := portforward.NewOnAddresses(dialer, []string{"127.0.0.1"}, []string{"0:" + strconv.Itoa(containerPort)}, stopChan, readyChan, bytes.NewBuffer(make([]byte, 1024)), errorBuffer)
 	if err != nil {
-		return nil, nil, nil, fmt.Errorf("failed to create portforwarder: %v", err)
+		return nil, nil, fmt.Errorf("failed to create portforwarder: %v", err)
 	}
 
 	// Portforwarding is blocking, so we can't do it here

--- a/api/pkg/handler/v1/common/common.go
+++ b/api/pkg/handler/v1/common/common.go
@@ -143,15 +143,15 @@ func GetPortForwarder(
 	cfg *rest.Config,
 	namespace string,
 	labelSelector string,
-	containerPort int) (*portforward.PortForwarder, *bytes.Buffer, error) {
+	containerPort int) (*portforward.PortForwarder, *bytes.Buffer, chan struct{}, error) {
 	pod, err := GetReadyPod(coreClient.Pods(namespace), labelSelector)
 	if err != nil {
-		return nil, nil, err
+		return nil, nil, nil, err
 	}
 
 	dialer, err := getDialerForPod(pod, coreClient.RESTClient(), cfg)
 	if err != nil {
-		return nil, nil, err
+		return nil, nil, nil, err
 	}
 
 	readyChan := make(chan struct{})
@@ -160,11 +160,11 @@ func GetPortForwarder(
 	outBuffer := bytes.NewBuffer(make([]byte, 1024))
 	portforwarder, err := portforward.NewOnAddresses(dialer, []string{"127.0.0.1"}, []string{"0:" + strconv.Itoa(containerPort)}, stopChan, readyChan, outBuffer, errorBuffer)
 	if err != nil {
-		return nil, nil, fmt.Errorf("failed to create portforwarder: %v", err)
+		return nil, nil, nil, fmt.Errorf("failed to create portforwarder: %v", err)
 	}
 
 	// Portforwarding is blocking, so we can't do it here
-	return portforwarder, outBuffer, nil
+	return portforwarder, outBuffer, stopChan, nil
 }
 
 func getReadyPods(pods *corev1.PodList) *corev1.PodList {

--- a/api/pkg/handler/v1/kubernetes-dashboard/dashboard.go
+++ b/api/pkg/handler/v1/kubernetes-dashboard/dashboard.go
@@ -77,7 +77,7 @@ func ProxyEndpoint(
 			log = log.With("cluster", userCluster.Name)
 
 			// Ideally we would cache these to not open a port for every single request
-			portforwarder, outBuffer, closeChan, err := common.GetPortForwarder(
+			portforwarder, closeChan, err := common.GetPortForwarder(
 				clusterProvider.GetSeedClusterAdminClient().CoreV1(),
 				clusterProvider.SeedAdminConfig(),
 				userCluster.Status.NamespaceName,
@@ -94,15 +94,19 @@ func ProxyEndpoint(
 				return nil, nil
 			}
 
-			port, err := common.GetLocalPortFromPortForwardOutput(outBuffer.String())
+			ports, err := portforwarder.GetPorts()
 			if err != nil {
 				common.WriteHTTPError(log, w, fmt.Errorf("failed to get backend port: %v", err))
+				return nil, nil
+			}
+			if len(ports) != 1 {
+				common.WriteHTTPError(log, w, fmt.Errorf("didn't get exactly one port but %d", len(ports)))
 				return nil, nil
 			}
 
 			proxyURL := &url.URL{
 				Scheme: "http",
-				Host:   fmt.Sprintf("127.0.0.1:%d", port),
+				Host:   fmt.Sprintf("127.0.0.1:%d", ports[0].Local),
 			}
 
 			// Override strict CSP policy for proxy

--- a/api/pkg/handler/v1/kubernetes-dashboard/dashboard.go
+++ b/api/pkg/handler/v1/kubernetes-dashboard/dashboard.go
@@ -77,7 +77,7 @@ func ProxyEndpoint(
 			log = log.With("cluster", userCluster.Name)
 
 			// Ideally we would cache these to not open a port for every single request
-			portforwarder, outBuffer, err := common.GetPortForwarder(
+			portforwarder, outBuffer, closeChan, err := common.GetPortForwarder(
 				clusterProvider.GetSeedClusterAdminClient().CoreV1(),
 				clusterProvider.SeedAdminConfig(),
 				userCluster.Status.NamespaceName,
@@ -86,6 +86,7 @@ func ProxyEndpoint(
 			if err != nil {
 				return nil, fmt.Errorf("failed to get portforwarder for console: %v", err)
 			}
+			defer func() { close(closeChan) }()
 			defer portforwarder.Close()
 
 			if err = common.ForwardPort(log, portforwarder); err != nil {

--- a/api/pkg/handler/v1/openshift/openshift.go
+++ b/api/pkg/handler/v1/openshift/openshift.go
@@ -118,7 +118,7 @@ func ConsoleProxyEndpoint(
 			log = log.With("cluster", cluster.Name)
 
 			// Ideally we would cache these to not open a port for every single request
-			portforwarder, outBuffer, closeChan, err := common.GetPortForwarder(
+			portforwarder, closeChan, err := common.GetPortForwarder(
 				clusterProvider.GetSeedClusterAdminClient().CoreV1(),
 				clusterProvider.SeedAdminConfig(),
 				cluster.Status.NamespaceName,
@@ -136,25 +136,26 @@ func ConsoleProxyEndpoint(
 				return nil, nil
 			}
 
-			// PortForwarder does have a `GetPorts` but its plain broken in case the portforwarder picks
-			// a random port and always returns 0.
-			// TODO @alvaroaleman: Fix upstream
-			port, err := common.GetLocalPortFromPortForwardOutput(outBuffer.String())
+			ports, err := portforwarder.GetPorts()
 			if err != nil {
 				common.WriteHTTPError(log, w, fmt.Errorf("failed to get backend port: %v", err))
 				return nil, nil
 			}
-			url, err := url.Parse(fmt.Sprintf("http://127.0.0.1:%d", port))
-			if err != nil {
-				common.WriteHTTPError(log, w, fmt.Errorf("failed to parse backend url: %v", err))
+			if len(ports) != 1 {
+				common.WriteHTTPError(log, w, fmt.Errorf("didn't get exactly one port but %d", len(ports)))
 				return nil, nil
+			}
+
+			proxyURL := &url.URL{
+				Scheme: "http",
+				Host:   fmt.Sprintf("127.0.0.1:%d", ports[0].Local),
 			}
 
 			// The Openshift console needs script-src: unsafe-inline and sryle-src: unsafe-inline.
 			// The header here overwrites the setting on the main router, which is more strict.
 			w.Header().Set("Content-Security-Policy", "default-src 'self'; script-src 'self' 'unsafe-inline'; object-src 'self'; style-src 'self' 'unsafe-inline'; img-src 'self'; media-src 'self'; frame-ancestors 'self'; frame-src 'self'; connect-src 'self'")
 			// Proxy the request
-			proxy := httputil.NewSingleHostReverseProxy(url)
+			proxy := httputil.NewSingleHostReverseProxy(proxyURL)
 			proxy.ServeHTTP(w, r)
 
 			return nil, nil

--- a/api/pkg/handler/v1/openshift/openshift.go
+++ b/api/pkg/handler/v1/openshift/openshift.go
@@ -118,7 +118,7 @@ func ConsoleProxyEndpoint(
 			log = log.With("cluster", cluster.Name)
 
 			// Ideally we would cache these to not open a port for every single request
-			portforwarder, outBuffer, err := common.GetPortForwarder(
+			portforwarder, outBuffer, closeChan, err := common.GetPortForwarder(
 				clusterProvider.GetSeedClusterAdminClient().CoreV1(),
 				clusterProvider.SeedAdminConfig(),
 				cluster.Status.NamespaceName,
@@ -128,6 +128,7 @@ func ConsoleProxyEndpoint(
 			if err != nil {
 				return nil, fmt.Errorf("failed to get portforwarder for console: %v", err)
 			}
+			defer func() { close(closeChan) }()
 			defer portforwarder.Close()
 
 			if err = common.ForwardPort(log, portforwarder); err != nil {


### PR DESCRIPTION
**What this PR does / why we need it**:

We used a downstream parsing logic to extract the local ports from the portforwarder because what upstream had was broken. This got fixed in the meantime, so this PR removes the downstream logic.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Documentation**:
<!-- Add links to the related documentation changes related to this pull request. E.g. the link to the kubermatic/docs pullrequest. -->

**Does this PR introduce a user-facing change?**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If  no release note is required, just write "NONE".
-->
```release-note
none
```

/assign @floreks 