### PR TITLE
Openshift console: Fix login

### DIFF
--- a/api/pkg/controller/user-cluster-controller-manager/openshift-seed-syncer/controller.go
+++ b/api/pkg/controller/user-cluster-controller-manager/openshift-seed-syncer/controller.go
@@ -204,7 +204,7 @@ func oauthBootstrapSecretCreatorGetter(userClusterClient ctrlruntimeclient.Clien
 			if s.Data == nil {
 				s.Data = map[string][]byte{}
 			}
-			s.Data[name] = userClusterOAuthSecret.Data[name]
+			s.Data[name] = userClusterOAuthSecret.Data[userclusteropenshiftresources.OAuthBootstrapUnencryptedKeyName]
 
 			return s, nil
 		}

--- a/api/pkg/controller/user-cluster-controller-manager/openshift-seed-syncer/controller.go
+++ b/api/pkg/controller/user-cluster-controller-manager/openshift-seed-syncer/controller.go
@@ -201,9 +201,9 @@ func oauthBootstrapSecretCreatorGetter(userClusterClient, seedClient ctrlruntime
 			if err := userClusterClient.Get(ctx, userClusterOAuthSecretName, userClusterOAuthSecret); err != nil {
 				return nil, fmt.Errorf("failed to get the %s/%s secret from the usercluster: %v", userClusterOAuthSecretName.Namespace, userClusterOAuthSecretName.Name, err)
 			}
-			encyptedValue, exists := userClusterOAuthSecret.Data[name]
+			encyptedValue, exists := userClusterOAuthSecret.Data[userclusteropenshiftresources.OAuthBootstrapEncryptedkeyName]
 			if !exists {
-				return nil, fmt.Errorf("usercluster secret has no %s key", name)
+				return nil, fmt.Errorf("usercluster secret has no %s key", userclusteropenshiftresources.OAuthBootstrapEncryptedkeyName)
 			}
 			secretKey, err := userclusteropenshiftresources.GetOAuthEncryptionKey(ctx, seedClient, seedNamespace)
 			if err != nil {

--- a/api/pkg/controller/user-cluster-controller-manager/openshift-seed-syncer/controller.go
+++ b/api/pkg/controller/user-cluster-controller-manager/openshift-seed-syncer/controller.go
@@ -204,7 +204,7 @@ func oauthBootstrapSecretCreatorGetter(userClusterClient ctrlruntimeclient.Clien
 			if s.Data == nil {
 				s.Data = map[string][]byte{}
 			}
-			s.Data[name] = userClusterOAuthSecret.Data[userclusteropenshiftresources.OAuthBootstrapUnencryptedKeyName]
+			s.Data[name] = userClusterOAuthSecret.Data[userclusteropenshiftresources.OAuthBootstrapEncryptedkeyName]
 
 			return s, nil
 		}

--- a/api/pkg/controller/user-cluster-controller-manager/resources/reconciler.go
+++ b/api/pkg/controller/user-cluster-controller-manager/resources/reconciler.go
@@ -424,7 +424,7 @@ func (r *reconciler) reconcileSecrets(ctx context.Context, data reconcileData) e
 		cloudcontroller.CloudConfig(data.cloudConfig),
 	}
 	if r.openshift {
-		creators = append(creators, openshift.OAuthBootstrapPassword)
+		creators = append(creators, openshift.OAuthBootstrapPasswordCreatorGetter(r.seedClient, r.namespace))
 		if r.cloudCredentialSecretTemplate != nil {
 			creators = append(creators, openshift.CloudCredentialSecretCreator(*r.cloudCredentialSecretTemplate))
 		}

--- a/api/pkg/controller/user-cluster-controller-manager/resources/reconciler_test.go
+++ b/api/pkg/controller/user-cluster-controller-manager/resources/reconciler_test.go
@@ -18,6 +18,7 @@ import (
 	apiextensionsv1beta1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1beta1"
 	kerrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/client-go/kubernetes/scheme"
 	apiregistrationv1beta1 "k8s.io/kube-aggregator/pkg/apis/apiregistration/v1beta1"
 	fakectrlruntimeclient "sigs.k8s.io/controller-runtime/pkg/client/fake"
@@ -95,6 +96,8 @@ func TestResourceReconciliationIdempotency(t *testing.T) {
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      resources.CASecretName,
 			Namespace: seedNamespace,
+			// Used for encrypting the OAuthBootstrapSecret, so must be set
+			UID: types.UID("567a5759-20ce-11ea-b48e-42010a9c0115"),
 		},
 		Data: getRSACAData(),
 	}

--- a/api/pkg/controller/user-cluster-controller-manager/resources/resources/openshift/secrets.go
+++ b/api/pkg/controller/user-cluster-controller-manager/resources/resources/openshift/secrets.go
@@ -159,11 +159,7 @@ func encryptedValueMatchesBcryptHash(encryptedValue, key, hash []byte) bool {
 	if err != nil {
 		return false
 	}
-	hashedValue, err := bcrypt.GenerateFromPassword(plainValue, 12)
-	if err != nil {
-		return false
-	}
-	return string(hashedValue) == string(hash)
+	return bcrypt.CompareHashAndPassword(hash, plainValue) == nil
 }
 
 func generateNewSecret() (string, error) {

--- a/api/pkg/controller/user-cluster-controller-manager/resources/resources/openshift/secrets.go
+++ b/api/pkg/controller/user-cluster-controller-manager/resources/resources/openshift/secrets.go
@@ -34,21 +34,31 @@ func RegistryServingCert(caCert *triple.KeyPair) reconciling.NamedSecretCreatorG
 		nil)
 }
 
-const OAuthBootstrapSecretName = "kubeadmin"
+const (
+	OAuthBootstrapSecretName         = "kubeadmin"
+	OAuthBootstrapUnencryptedKeyName = "raw"
+)
 
 // OAuthBootstrapPassword is the password we use to authenticate the dashboard against the OAuth
 // service. It must be created in the kube-system namespace.
 func OAuthBootstrapPassword() (string, reconciling.SecretCreator) {
 	return OAuthBootstrapSecretName, func(s *corev1.Secret) (*corev1.Secret, error) {
 
-		if s.Data == nil {
-			s.Data = map[string][]byte{}
-		}
 		// The only way this ever gets updated is if someone empties it. It won't be accepted if
 		// its creation timestamp is after kube-system namespace creation timestamp + 1h.
 		// https://github.com/openshift/origin/blob/e774f85c15aef11d76db1ffc458484867e503293/pkg/oauthserver/authenticator/password/bootstrap/bootstrap.go#L131
-		if _, exists := s.Data[OAuthBootstrapSecretName]; exists {
-			return s, nil
+		if value, exists := s.Data[OAuthBootstrapSecretName]; exists {
+			hashedPassword, err := bcrypt.GenerateFromPassword(value, 12)
+			if err != nil {
+				return nil, fmt.Errorf("failed to hash old password: %v", err)
+			}
+			if string(s.Data[OAuthBootstrapUnencryptedKeyName]) == string(hashedPassword) {
+				return s, nil
+			}
+		}
+
+		if s.Data == nil {
+			s.Data = map[string][]byte{}
 		}
 
 		rawPassword, err := generateNewSecret()
@@ -60,6 +70,8 @@ func OAuthBootstrapPassword() (string, reconciling.SecretCreator) {
 			return nil, fmt.Errorf("failed to hash password: %v", err)
 		}
 		s.Data[OAuthBootstrapSecretName] = hashedPassword
+		// We need to transport the raw value into the seed
+		s.Data[OAuthBootstrapUnencryptedKeyName] = []byte(rawPassword)
 
 		return s, nil
 	}

--- a/api/pkg/controller/user-cluster-controller-manager/resources/resources/openshift/secrets_test.go
+++ b/api/pkg/controller/user-cluster-controller-manager/resources/resources/openshift/secrets_test.go
@@ -8,7 +8,7 @@ func TestAESRoundTripping(t *testing.T) {
 	valueToEncrypt := []byte("my-very-secret-text")
 	psk := []byte("8w6xrx.89vwtn8strwcwbzt")
 
-	ciphertext, err := AESEncrypt(valueToEncrypt, psk)
+	ciphertext, err := aesEncrypt(valueToEncrypt, psk)
 	if err != nil {
 		t.Fatalf("encryption failed: %v", err)
 	}

--- a/api/pkg/controller/user-cluster-controller-manager/resources/resources/openshift/secrets_test.go
+++ b/api/pkg/controller/user-cluster-controller-manager/resources/resources/openshift/secrets_test.go
@@ -1,0 +1,23 @@
+package openshift
+
+import (
+	"testing"
+)
+
+func TestAESRoundTripping(t *testing.T) {
+	valueToEncrypt := []byte("my-very-secret-text")
+	psk := []byte("8w6xrx.89vwtn8strwcwbzt")
+
+	ciphertext, err := AESEncrypt(valueToEncrypt, psk)
+	if err != nil {
+		t.Fatalf("encryption failed: %v", err)
+	}
+	plaintext, err := AESDecrypt(ciphertext, psk)
+	if err != nil {
+		t.Fatalf("decryption failed: %v", err)
+	}
+
+	if string(valueToEncrypt) != string(plaintext) {
+		t.Fatalf("Result %q does not match initial value %q", string(valueToEncrypt), string(plaintext))
+	}
+}

--- a/api/pkg/handler/v1/openshift/openshift.go
+++ b/api/pkg/handler/v1/openshift/openshift.go
@@ -259,6 +259,7 @@ func consoleLogin(
 	oauthCode := redirectURL.Query().Get("code")
 	if oauthCode == "" {
 		common.WriteHTTPError(log, w, errors.New("did not get an OAuth code back from Openshift OAuth server"))
+		return
 	}
 	// We don't check this here again. If something is wrong with it, Openshift will complain
 	returnedOAuthState := redirectURL.Query().Get("state")

--- a/api/pkg/resources/usercluster/rbac.go
+++ b/api/pkg/resources/usercluster/rbac.go
@@ -49,6 +49,7 @@ func RoleCreator() (string, reconciling.RoleCreator) {
 				ResourceNames: []string{
 					resources.AdminKubeconfigSecretName,
 					openshiftresources.ConsoleOAuthSecretName,
+					openshiftresources.ConsoleAdminPasswordSecretName,
 				},
 				Verbs: []string{"update"},
 			},


### PR DESCRIPTION
**What this PR does / why we need it**:

When moving the management of the bootstrap secret into the usercluster controller, i started syncing the password hash rather than the password. This obviously does not work, hence this PR changes the whole thing to:

* Store the password encrypted via the UID of the CA secret that is in the seed in the usercluster secret
* Decrypt it and sync that into the seed

Fixes #4880 

~A further improvement could probably be move the reconciling of the secret inside the usercluster controller from the usercluster resource controller into the openshift-seed-syncer and then just check if the value in the seed when hashed matches whats in the usercluster. This is a bit tricky thought, as it ties the creation of two secrets together.~

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Documentation**:
<!-- Add links to the related documentation changes related to this pull request. E.g. the link to the kubermatic/docs pullrequest. -->

**Does this PR introduce a user-facing change?**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If  no release note is required, just write "NONE".
-->
```release-note
none
```
