### PR TITLE
Allow access to Kubernetes Dashboard proxy based on global settings

### DIFF
--- a/api/pkg/handler/routes_v1.go
+++ b/api/pkg/handler/routes_v1.go
@@ -2999,6 +2999,7 @@ func (r Routing) kubernetesDashboardProxy() http.Handler {
 		middleware.TokenExtractor(r.tokenExtractors),
 		r.projectProvider,
 		r.userInfoGetter,
+		r.settingsProvider,
 		endpoint.Chain(
 			middleware.TokenVerifier(r.tokenVerifiers),
 			middleware.UserSaver(r.userProvider),


### PR DESCRIPTION
**What this PR does / why we need it**:
Allow access to Kubernetes Dashboard proxy based on global settings.

**Does this PR introduce a user-facing change?**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If  no release note is required, just write "NONE".
-->
```release-note
Access to Kubernetes Dashboard can be now enabled/disabled by the global settings.
```
