### PR TITLE
Fix ci-download-gocache for periodics

### DIFF
--- a/api/hack/ci/ci-download-gocache.sh
+++ b/api/hack/ci/ci-download-gocache.sh
@@ -30,6 +30,10 @@ GOCACHE=$(go env GOCACHE)
 # Make sure it actually exists
 mkdir -p $GOCACHE
 
+# Periodics just use their head ref
+if [[ -z "${PULL_BASE_SHA:-}" ]]; then
+  export CACHE_VERSION="$(git rev-parse HEAD)"
+fi
 CACHE_VERSION="${CACHE_VERSION:-${PULL_BASE_SHA}}"
 if [ -z ${PULL_NUMBER:-} ]; then
   # Special case: This is called in a Postubmit. Go one revision back,


### PR DESCRIPTION
**What this PR does / why we need it**:

Those do not have the `PULL_BASE_SHA` var available, hence this always fails, see e.G. https://prow.loodse.com/view/gcs/prow-data/logs/periodic-kubermatic-e2e-vsphere-coreos-1.15/1205291561135378433

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Documentation**:
<!-- Add links to the related documentation changes related to this pull request. E.g. the link to the kubermatic/docs pullrequest. -->

**Does this PR introduce a user-facing change?**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If  no release note is required, just write "NONE".
-->
```release-note
none
```
