### PR TITLE
Fix upgrade tests when upgrading from older kubermatic version

### DIFF
--- a/api/hack/ci/ci-run-conformance-tester.sh
+++ b/api/hack/ci/ci-run-conformance-tester.sh
@@ -56,6 +56,9 @@ elif [[ $provider == "kubevirt" ]]; then
   EXTRA_ARGS="-kubevirt-kubeconfig=${KUBEVIRT_E2E_TESTS_KUBECONFIG}"
 fi
 
+# TODO: Remove after 2.13 release, only needed for upgrade tests
+export NAMESPACE="${NAMESPACE:-kubermatic}"
+
 # Needed when running in kind
 which kind && EXTRA_ARGS="$EXTRA_ARGS -create-oidc-token=true"
 

--- a/api/hack/ci/ci-setup-kubermatic-in-kind.sh
+++ b/api/hack/ci/ci-setup-kubermatic-in-kind.sh
@@ -272,14 +272,18 @@ if [[ "${KUBERMATIC_SKIP_BUILDING}" = "false" ]]; then
     time retry 5 kind load docker-image "$IMAGE_NAME" --name ${SEED_NAME}
   )
   (
-    echodate "Building user-ssh-keys-agent image"
-    TEST_NAME="Build user-ssh-keys-agent Docker image"
-    cd api/cmd/user-ssh-keys-agent
-    make build
-    retry 5 docker login -u "$QUAY_IO_USERNAME" -p "$QUAY_IO_PASSWORD" quay.io
-    IMAGE_NAME=quay.io/kubermatic/user-ssh-keys-agent:$KUBERMATIC_VERSION
-    time retry 5 docker build -t "${IMAGE_NAME}" .
-    time retry 5 docker push "quay.io/kubermatic/user-ssh-keys-agent:$KUBERMATIC_VERSION"
+    # This may not exist during upgrade tests.
+    # TODO @kdomanski after 2.13 release: remove this condition
+    if [[ -e api/cmd/user-ssh-keys-agent ]]; then
+      echodate "Building user-ssh-keys-agent image"
+      TEST_NAME="Build user-ssh-keys-agent Docker image"
+      cd api/cmd/user-ssh-keys-agent
+      make build
+      retry 5 docker login -u "$QUAY_IO_USERNAME" -p "$QUAY_IO_PASSWORD" quay.io
+      IMAGE_NAME=quay.io/kubermatic/user-ssh-keys-agent:$KUBERMATIC_VERSION
+      time retry 5 docker build -t "${IMAGE_NAME}" .
+      time retry 5 docker push "quay.io/kubermatic/user-ssh-keys-agent:$KUBERMATIC_VERSION"
+    fi
   )
   git checkout ${OLD_HEAD}
   echodate "Successfully built and loaded all images"


### PR DESCRIPTION
**What this PR does / why we need it**:

When verifying the upgrade weekly presubmit in https://github.com/kubermatic/kubermatic/pull/4894 I found some compatibility issues when testing upgrades from an older (< 14d) kubermatic version, this PR fixes that.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Documentation**:
<!-- Add links to the related documentation changes related to this pull request. E.g. the link to the kubermatic/docs pullrequest. -->

**Does this PR introduce a user-facing change?**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If  no release note is required, just write "NONE".
-->
```release-note
none
```
