### PR TITLE
Conformance tests: Give packet more time for provisioning

### DIFF
--- a/api/cmd/conformance-tests/runner.go
+++ b/api/cmd/conformance-tests/runner.go
@@ -421,6 +421,11 @@ func (r *testRunner) executeTests(
 	if cluster.Spec.Features[kubermaticv1.ClusterFeatureExternalCloudProvider] {
 		overallTimeout += 5 * time.Minute
 	}
+	// Packet is slower at provisioning the instances, presumably because those are actual
+	// physical hosts.
+	if cluster.Spec.Cloud.Packet != nil {
+		overallTimeout += 5 * time.Minute
+	}
 
 	if err := junitReporterWrapper(
 		"[Kubermatic] Wait for machines to get a node",


### PR DESCRIPTION
**What this PR does / why we need it**:

This PR gives packet five more minutes for provisioning (node creation + waiting for all usercluster pods to be ready). The rationale is that the packet job has been consistently failing waiting for the usercluster pods to get ready: https://prow.loodse.com/?job=periodic-kubermatic-e2e-packet-coreos-1.15

When creating a packet cluster manually, it takes roughly nine minutes from "pod exist" to "pod is ready", so the total timeframe of 10 minutes may be a bit small.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Documentation**:
<!-- Add links to the related documentation changes related to this pull request. E.g. the link to the kubermatic/docs pullrequest. -->

**Does this PR introduce a user-facing change?**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If  no release note is required, just write "NONE".
-->
```release-note
none
```

/test pre-kubermatic-e2e-packet-coreos-1.15