### PR TITLE
Use go 12.12 for all presubmits

### DIFF
--- a/.prow.yaml
+++ b/.prow.yaml
@@ -102,7 +102,7 @@ presubmits:
     clone_uri: "ssh://git@github.com/kubermatic/kubermatic.git"
     spec:
       containers:
-      - image: quay.io/kubermatic/go-docker:13.3-1806-2
+      - image: quay.io/kubermatic/go-docker:12.12-1806-3
         command:
         - "./api/hack/verify-yaml-examples.sh"
         resources:
@@ -1055,7 +1055,7 @@ presubmits:
       preset-repo-ssh: "true"
     spec:
       containers:
-      - image: quay.io/kubermatic/go-docker:13.3-1806-2
+      - image: quay.io/kubermatic/go-docker:12.12-1806-3
         command:
         - "./api/hack/ci/ci-run-offline-test.sh"
         # docker-in-docker needs privileged mode
@@ -1085,7 +1085,7 @@ presubmits:
       preset-repo-ssh: "true"
     spec:
       containers:
-      - image: quay.io/kubermatic/go-docker:13.3-1806-2
+      - image: quay.io/kubermatic/go-docker:12.12-1806-3
         command:
         - ./api/hack/ci/ci-deploy-ci-kubermatic-io.sh
         env:

--- a/api/hack/ci/ci-push-images.sh
+++ b/api/hack/ci/ci-push-images.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/bash
 
 set -eu
 cd "$(git rev-parse --show-toplevel)"


### PR DESCRIPTION
**What this PR does / why we need it**:

Changes all presubmit jobs to use an image with go 12.12, allowing them to use the gocache and hence drastically reducing their build time. This should be especially benefial for the ci-canary-deploy-kubermatic-ci-io job, who at times needed 20 minutes until the docker images were built.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Documentation**:
<!-- Add links to the related documentation changes related to this pull request. E.g. the link to the kubermatic/docs pullrequest. -->

**Does this PR introduce a user-facing change?**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If  no release note is required, just write "NONE".
-->
```release-note
none
```
