### PR TITLE
Use Operator for e2e Tests

### DIFF
--- a/.prow.yaml
+++ b/.prow.yaml
@@ -4,7 +4,7 @@ presubmits:
   #########################################################
 
   - name: pre-kubermatic-build
-    # run_if_changed: "^api/"
+    run_if_changed: "^api/"
     decorate: true
     clone_uri: "ssh://git@github.com/kubermatic/kubermatic.git"
     spec:
@@ -24,7 +24,7 @@ presubmits:
             memory: 4Gi
 
   - name: pre-kubermatic-test
-    # run_if_changed: "^api/"
+    run_if_changed: "^api/"
     decorate: true
     clone_uri: "ssh://git@github.com/kubermatic/kubermatic.git"
     spec:
@@ -42,7 +42,7 @@ presubmits:
             cpu: 2
 
   - name: pre-kubermatic-verify
-    # run_if_changed: "^api/"
+    run_if_changed: "^api/"
     decorate: true
     clone_uri: "ssh://git@github.com/kubermatic/kubermatic.git"
     spec:
@@ -63,7 +63,7 @@ presubmits:
             cpu: 1
 
   - name: pre-kubermatic-verify-charts
-    # run_if_changed: "^config/"
+    run_if_changed: "^config/"
     decorate: true
     clone_uri: "ssh://git@github.com/kubermatic/kubermatic.git"
     spec:
@@ -80,7 +80,7 @@ presubmits:
             cpu: 250m
 
   - name: pre-kubermatic-verify-grafana-dashboards
-    # run_if_changed: "^config/monitoring/grafana/"
+    run_if_changed: "^config/monitoring/grafana/"
     decorate: true
     clone_uri: "ssh://git@github.com/kubermatic/kubermatic.git"
     spec:
@@ -97,7 +97,7 @@ presubmits:
             cpu: 250m
 
   - name: pre-kubermatic-verify-yaml-examples
-    # run_if_changed: "^(api|docs)/"
+    run_if_changed: "^(api|docs)/"
     decorate: true
     clone_uri: "ssh://git@github.com/kubermatic/kubermatic.git"
     spec:
@@ -111,7 +111,7 @@ presubmits:
             cpu: 250m
 
   - name: pre-kubermatic-lint
-    # run_if_changed: "^api/"
+    run_if_changed: "^api/"
     decorate: true
     clone_uri: "ssh://git@github.com/kubermatic/kubermatic.git"
     spec:
@@ -131,7 +131,7 @@ presubmits:
             memory: 17Gi
 
   - name: pre-kubermatic-dependencies
-    # run_if_changed: "^api/"
+    run_if_changed: "^api/"
     decorate: true
     clone_uri: "ssh://git@github.com/kubermatic/kubermatic.git"
     spec:
@@ -169,7 +169,7 @@ presubmits:
             cpu: 0.5
 
   - name: pre-kubermatic-license-validation
-    # run_if_changed: "vendor"
+    run_if_changed: "vendor"
     decorate: true
     clone_uri: "ssh://git@github.com/kubermatic/kubermatic.git"
     spec:
@@ -183,7 +183,7 @@ presubmits:
         - license-validation
 
   - name: pre-kubermatic-prometheus-rules-validation
-    # run_if_changed: "config/monitoring"
+    run_if_changed: "config/monitoring"
     decorate: true
     clone_uri: "ssh://git@github.com/kubermatic/kubermatic.git"
     spec:
@@ -199,7 +199,7 @@ presubmits:
       - name: quay
 
   - name: pre-kubermatic-user-cluster-prometheus-config-validation
-    # run_if_changed: "api/pkg/resources/prometheus"
+    run_if_changed: "api/pkg/resources/prometheus"
     decorate: true
     clone_uri: "ssh://git@github.com/kubermatic/kubermatic.git"
     spec:
@@ -292,7 +292,7 @@ presubmits:
   # e2e tests for Kubernetes 1.15
   #########################################################
 
-  - name: pre-kubermatic-e2e-aws-coreos-1.15-helm
+  - name: pre-kubermatic-e2e-aws-coreos-1.15
     decorate: true
     run_if_changed: "(api/|config/kubermatic|.prow.yaml)"
     clone_uri: "ssh://git@github.com/kubermatic/kubermatic.git"
@@ -310,43 +310,6 @@ presubmits:
         env:
         - name: VERSIONS_TO_TEST
           value: "v1.15.6"
-        - name: SERVICE_ACCOUNT_KEY
-          valueFrom:
-            secretKeyRef:
-              name: e2e-ci
-              key: serviceAccountSigningKey
-        command:
-        - "./api/hack/ci/ci-kind-e2e.sh"
-        # docker-in-docker needs privileged mode
-        securityContext:
-          privileged: true
-        resources:
-          requests:
-            memory: 4Gi
-            cpu: 3.5
-          limits:
-            memory: 4Gi
-
-  - name: pre-kubermatic-e2e-aws-coreos-1.15-operator
-    decorate: true
-    run_if_changed: "(api/|config/kubermatic|.prow.yaml)"
-    clone_uri: "ssh://git@github.com/kubermatic/kubermatic.git"
-    labels:
-      preset-aws: "true"
-      preset-docker-pull: "true"
-      preset-docker-push: "true"
-      preset-vault: "true"
-      preset-repo-ssh: "true"
-      preset-kubeconfig-ci: "true"
-      preset-kind-volume-mounts: "true"
-    spec:
-      containers:
-      - image: quay.io/kubermatic/e2e-kind:with-conformance-tests-v1.0.14
-        env:
-        - name: VERSIONS_TO_TEST
-          value: "v1.15.6"
-        - name: KUBERMATIC_USE_OPERATOR
-          value: "true"
         - name: SERVICE_ACCOUNT_KEY
           valueFrom:
             secretKeyRef:
@@ -681,7 +644,7 @@ presubmits:
 
   - name: pre-kubermatic-e2e-vsphere-coreos-1.15
     decorate: true
-    # run_if_changed: "api/pkg/provider/cloud/vsphere"
+    run_if_changed: "api/pkg/provider/cloud/vsphere"
     clone_uri: "ssh://git@github.com/kubermatic/kubermatic.git"
     labels:
       preset-vsphere: "true"
@@ -719,7 +682,7 @@ presubmits:
   - name: pre-kubermatic-e2e-vsphere-coreos-1.15-customfolder
     decorate: true
     optional: true
-    # run_if_changed: "api/pkg/provider/cloud/vsphere"
+    run_if_changed: "api/pkg/provider/cloud/vsphere"
     clone_uri: "ssh://git@github.com/kubermatic/kubermatic.git"
     labels:
       preset-vsphere: "true"
@@ -923,7 +886,7 @@ presubmits:
 
   - name: pre-kubermatic-e2e-aws-coreos-1.17
     decorate: true
-    # run_if_changed: "(api/|config/kubermatic|.prow.yaml)"
+    run_if_changed: "(api/|config/kubermatic|.prow.yaml)"
     clone_uri: "ssh://git@github.com/kubermatic/kubermatic.git"
     labels:
       preset-aws: "true"
@@ -962,7 +925,7 @@ presubmits:
 
   - name: pre-kubermatic-e2e-aws-openshift-4.1
     decorate: true
-    # run_if_changed: "(api/|config/kubermatic|.prow.yaml)"
+    run_if_changed: "(api/|config/kubermatic|.prow.yaml)"
     clone_uri: "ssh://git@github.com/kubermatic/kubermatic.git"
     labels:
       preset-aws: "true"
@@ -1043,7 +1006,7 @@ presubmits:
   # API e2e tests
   #########################################################
 
-  - name: pre-kubermatic-api-e2e-helm
+  - name: pre-kubermatic-api-e2e
     run_if_changed: "(api/|config/kubermatic|.prow.yaml)"
     decorate: true
     clone_uri: "ssh://git@github.com/kubermatic/kubermatic.git"
@@ -1078,42 +1041,48 @@ presubmits:
               name: e2e-ci
               key: serviceAccountSigningKey
 
-  - name: pre-kubermatic-api-e2e-operator
-    run_if_changed: "(api/|config/kubermatic|.prow.yaml)"
+  #########################################################
+  # test Kubermatic Operator
+  #########################################################
+
+  - name: pre-kubermatic-e2e-operator
     decorate: true
+    run_if_changed: "(api/|config/kubermatic|.prow.yaml)"
     clone_uri: "ssh://git@github.com/kubermatic/kubermatic.git"
     labels:
-      preset-digitalocean: "true"
-      preset-openstack: "true"
-      preset-azure: "true"
-      preset-kubeconfig-ci: "true"
+      preset-aws: "true"
       preset-docker-pull: "true"
       preset-docker-push: "true"
-      preset-gce: "true"
-      preset-kind-volume-mounts: "true"
       preset-vault: "true"
+      preset-repo-ssh: "true"
+      preset-kubeconfig-ci: "true"
+      preset-kind-volume-mounts: "true"
     spec:
       containers:
       - image: quay.io/kubermatic/e2e-kind:with-conformance-tests-v1.0.14
-        imagePullPolicy: Always
-        command:
-        - "./api/hack/ci/ci_run_api_e2e.sh"
-        securityContext:
-          privileged: true
-        resources:
-          requests:
-            memory: 4Gi
-            cpu: 2
-          limits:
-            memory: 6Gi
         env:
+        - name: VERSIONS_TO_TEST
+          value: "v1.17.0"
+        - name: KUBERMATIC_USE_OPERATOR
+          value: "true"
+        - name: ONLY_TEST_CREATION
+          value: "true"
         - name: SERVICE_ACCOUNT_KEY
           valueFrom:
             secretKeyRef:
               name: e2e-ci
               key: serviceAccountSigningKey
-        - name: KUBERMATIC_USE_OPERATOR
-          value: "true"
+        command:
+        - "./api/hack/ci/ci-kind-e2e.sh"
+        # docker-in-docker needs privileged mode
+        securityContext:
+          privileged: true
+        resources:
+          requests:
+            memory: 4Gi
+            cpu: 3.5
+          limits:
+            memory: 4Gi
 
   #########################################################
   # misc
@@ -1151,7 +1120,7 @@ presubmits:
     # * api/pkg/crd/kubermatic/v1: Contains the Seed and Datacenter types, if
     #   this gets out of sync with whats in the secrets repo, we fail because we use
     #   yaml.UnmarshalStrict
-    # run_if_changed: "(api/hack|config/kubermatic|api/pkg/crd/kubermatic/v1)"
+    run_if_changed: "(api/hack|config/kubermatic|api/pkg/crd/kubermatic/v1)"
     clone_uri: "ssh://git@github.com/kubermatic/kubermatic.git"
     labels:
       preset-docker-push: "true"
@@ -1177,7 +1146,7 @@ presubmits:
             memory: 2Gi
 
   - name: pre-kubermatic-test-integration
-    # run_if_changed: "^api/"
+    run_if_changed: "^api/"
     decorate: true
     clone_uri: "ssh://git@github.com/kubermatic/kubermatic.git"
     labels:

--- a/.prow.yaml
+++ b/.prow.yaml
@@ -4,7 +4,7 @@ presubmits:
   #########################################################
 
   - name: pre-kubermatic-build
-    run_if_changed: "^api/"
+    # run_if_changed: "^api/"
     decorate: true
     clone_uri: "ssh://git@github.com/kubermatic/kubermatic.git"
     spec:
@@ -24,7 +24,7 @@ presubmits:
             memory: 4Gi
 
   - name: pre-kubermatic-test
-    run_if_changed: "^api/"
+    # run_if_changed: "^api/"
     decorate: true
     clone_uri: "ssh://git@github.com/kubermatic/kubermatic.git"
     spec:
@@ -42,7 +42,7 @@ presubmits:
             cpu: 2
 
   - name: pre-kubermatic-verify
-    run_if_changed: "^api/"
+    # run_if_changed: "^api/"
     decorate: true
     clone_uri: "ssh://git@github.com/kubermatic/kubermatic.git"
     spec:
@@ -63,7 +63,7 @@ presubmits:
             cpu: 1
 
   - name: pre-kubermatic-verify-charts
-    run_if_changed: "^config/"
+    # run_if_changed: "^config/"
     decorate: true
     clone_uri: "ssh://git@github.com/kubermatic/kubermatic.git"
     spec:
@@ -80,7 +80,7 @@ presubmits:
             cpu: 250m
 
   - name: pre-kubermatic-verify-grafana-dashboards
-    run_if_changed: "^config/monitoring/grafana/"
+    # run_if_changed: "^config/monitoring/grafana/"
     decorate: true
     clone_uri: "ssh://git@github.com/kubermatic/kubermatic.git"
     spec:
@@ -97,7 +97,7 @@ presubmits:
             cpu: 250m
 
   - name: pre-kubermatic-verify-yaml-examples
-    run_if_changed: "^(api|docs)/"
+    # run_if_changed: "^(api|docs)/"
     decorate: true
     clone_uri: "ssh://git@github.com/kubermatic/kubermatic.git"
     spec:
@@ -111,7 +111,7 @@ presubmits:
             cpu: 250m
 
   - name: pre-kubermatic-lint
-    run_if_changed: "^api/"
+    # run_if_changed: "^api/"
     decorate: true
     clone_uri: "ssh://git@github.com/kubermatic/kubermatic.git"
     spec:
@@ -131,7 +131,7 @@ presubmits:
             memory: 17Gi
 
   - name: pre-kubermatic-dependencies
-    run_if_changed: "^api/"
+    # run_if_changed: "^api/"
     decorate: true
     clone_uri: "ssh://git@github.com/kubermatic/kubermatic.git"
     spec:
@@ -169,7 +169,7 @@ presubmits:
             cpu: 0.5
 
   - name: pre-kubermatic-license-validation
-    run_if_changed: "vendor"
+    # run_if_changed: "vendor"
     decorate: true
     clone_uri: "ssh://git@github.com/kubermatic/kubermatic.git"
     spec:
@@ -183,7 +183,7 @@ presubmits:
         - license-validation
 
   - name: pre-kubermatic-prometheus-rules-validation
-    run_if_changed: "config/monitoring"
+    # run_if_changed: "config/monitoring"
     decorate: true
     clone_uri: "ssh://git@github.com/kubermatic/kubermatic.git"
     spec:
@@ -199,7 +199,7 @@ presubmits:
       - name: quay
 
   - name: pre-kubermatic-user-cluster-prometheus-config-validation
-    run_if_changed: "api/pkg/resources/prometheus"
+    # run_if_changed: "api/pkg/resources/prometheus"
     decorate: true
     clone_uri: "ssh://git@github.com/kubermatic/kubermatic.git"
     spec:
@@ -292,7 +292,7 @@ presubmits:
   # e2e tests for Kubernetes 1.15
   #########################################################
 
-  - name: pre-kubermatic-e2e-aws-coreos-1.15
+  - name: pre-kubermatic-e2e-aws-coreos-1.15-helm
     decorate: true
     run_if_changed: "(api/|config/kubermatic|.prow.yaml)"
     clone_uri: "ssh://git@github.com/kubermatic/kubermatic.git"
@@ -310,6 +310,43 @@ presubmits:
         env:
         - name: VERSIONS_TO_TEST
           value: "v1.15.6"
+        - name: SERVICE_ACCOUNT_KEY
+          valueFrom:
+            secretKeyRef:
+              name: e2e-ci
+              key: serviceAccountSigningKey
+        command:
+        - "./api/hack/ci/ci-kind-e2e.sh"
+        # docker-in-docker needs privileged mode
+        securityContext:
+          privileged: true
+        resources:
+          requests:
+            memory: 4Gi
+            cpu: 3.5
+          limits:
+            memory: 4Gi
+
+  - name: pre-kubermatic-e2e-aws-coreos-1.15-operator
+    decorate: true
+    run_if_changed: "(api/|config/kubermatic|.prow.yaml)"
+    clone_uri: "ssh://git@github.com/kubermatic/kubermatic.git"
+    labels:
+      preset-aws: "true"
+      preset-docker-pull: "true"
+      preset-docker-push: "true"
+      preset-vault: "true"
+      preset-repo-ssh: "true"
+      preset-kubeconfig-ci: "true"
+      preset-kind-volume-mounts: "true"
+    spec:
+      containers:
+      - image: quay.io/kubermatic/e2e-kind:with-conformance-tests-v1.0.14
+        env:
+        - name: VERSIONS_TO_TEST
+          value: "v1.15.6"
+        - name: KUBERMATIC_USE_OPERATOR
+          value: "true"
         - name: SERVICE_ACCOUNT_KEY
           valueFrom:
             secretKeyRef:
@@ -644,7 +681,7 @@ presubmits:
 
   - name: pre-kubermatic-e2e-vsphere-coreos-1.15
     decorate: true
-    run_if_changed: "api/pkg/provider/cloud/vsphere"
+    # run_if_changed: "api/pkg/provider/cloud/vsphere"
     clone_uri: "ssh://git@github.com/kubermatic/kubermatic.git"
     labels:
       preset-vsphere: "true"
@@ -682,7 +719,7 @@ presubmits:
   - name: pre-kubermatic-e2e-vsphere-coreos-1.15-customfolder
     decorate: true
     optional: true
-    run_if_changed: "api/pkg/provider/cloud/vsphere"
+    # run_if_changed: "api/pkg/provider/cloud/vsphere"
     clone_uri: "ssh://git@github.com/kubermatic/kubermatic.git"
     labels:
       preset-vsphere: "true"
@@ -886,7 +923,7 @@ presubmits:
 
   - name: pre-kubermatic-e2e-aws-coreos-1.17
     decorate: true
-    run_if_changed: "(api/|config/kubermatic|.prow.yaml)"
+    # run_if_changed: "(api/|config/kubermatic|.prow.yaml)"
     clone_uri: "ssh://git@github.com/kubermatic/kubermatic.git"
     labels:
       preset-aws: "true"
@@ -925,7 +962,7 @@ presubmits:
 
   - name: pre-kubermatic-e2e-aws-openshift-4.1
     decorate: true
-    run_if_changed: "(api/|config/kubermatic|.prow.yaml)"
+    # run_if_changed: "(api/|config/kubermatic|.prow.yaml)"
     clone_uri: "ssh://git@github.com/kubermatic/kubermatic.git"
     labels:
       preset-aws: "true"
@@ -1006,7 +1043,7 @@ presubmits:
   # API e2e tests
   #########################################################
 
-  - name: pre-kubermatic-api-e2e
+  - name: pre-kubermatic-api-e2e-helm
     run_if_changed: "(api/|config/kubermatic|.prow.yaml)"
     decorate: true
     clone_uri: "ssh://git@github.com/kubermatic/kubermatic.git"
@@ -1040,6 +1077,43 @@ presubmits:
             secretKeyRef:
               name: e2e-ci
               key: serviceAccountSigningKey
+
+  - name: pre-kubermatic-api-e2e-operator
+    run_if_changed: "(api/|config/kubermatic|.prow.yaml)"
+    decorate: true
+    clone_uri: "ssh://git@github.com/kubermatic/kubermatic.git"
+    labels:
+      preset-digitalocean: "true"
+      preset-openstack: "true"
+      preset-azure: "true"
+      preset-kubeconfig-ci: "true"
+      preset-docker-pull: "true"
+      preset-docker-push: "true"
+      preset-gce: "true"
+      preset-kind-volume-mounts: "true"
+      preset-vault: "true"
+    spec:
+      containers:
+      - image: quay.io/kubermatic/e2e-kind:with-conformance-tests-v1.0.14
+        imagePullPolicy: Always
+        command:
+        - "./api/hack/ci/ci_run_api_e2e.sh"
+        securityContext:
+          privileged: true
+        resources:
+          requests:
+            memory: 4Gi
+            cpu: 2
+          limits:
+            memory: 6Gi
+        env:
+        - name: SERVICE_ACCOUNT_KEY
+          valueFrom:
+            secretKeyRef:
+              name: e2e-ci
+              key: serviceAccountSigningKey
+        - name: KUBERMATIC_USE_OPERATOR
+          value: "true"
 
   #########################################################
   # misc
@@ -1077,7 +1151,7 @@ presubmits:
     # * api/pkg/crd/kubermatic/v1: Contains the Seed and Datacenter types, if
     #   this gets out of sync with whats in the secrets repo, we fail because we use
     #   yaml.UnmarshalStrict
-    run_if_changed: "(api/hack|config/kubermatic|api/pkg/crd/kubermatic/v1)"
+    # run_if_changed: "(api/hack|config/kubermatic|api/pkg/crd/kubermatic/v1)"
     clone_uri: "ssh://git@github.com/kubermatic/kubermatic.git"
     labels:
       preset-docker-push: "true"
@@ -1103,7 +1177,7 @@ presubmits:
             memory: 2Gi
 
   - name: pre-kubermatic-test-integration
-    run_if_changed: "^api/"
+    # run_if_changed: "^api/"
     decorate: true
     clone_uri: "ssh://git@github.com/kubermatic/kubermatic.git"
     labels:

--- a/api/hack/deploy.sh
+++ b/api/hack/deploy.sh
@@ -101,6 +101,8 @@ LATEST_DASHBOARD="$(get_latest_dashboard_hash "${PULL_BASE_REF}")"
 sed -i "s/__DASHBOARD_TAG__/$LATEST_DASHBOARD/g" ./config/kubermatic/*.yaml
 sed -i "s/__KUBERMATIC_TAG__/${GIT_HEAD_HASH}/g" ./config/kubermatic/*.yaml
 sed -i "s/__KUBERMATIC_TAG__/${GIT_HEAD_HASH}/g" ./config/kubermatic-operator/*.yaml
+sed -i "s/__NAMESPACE__/kubermatic/g" ./config/kubermatic-operator/*.yaml
+sed -i "s/__WORKER_NAME__/kubermatic-operator/g" ./config/kubermatic-operator/*.yaml
 sed -i "s/__KUBERMATIC_TAG__/${GIT_HEAD_HASH}/g" ./config/nodeport-proxy/*.yaml
 
 echodate "Deploying ${DEPLOY_STACK} stack..."

--- a/api/hack/lib.sh
+++ b/api/hack/lib.sh
@@ -37,7 +37,7 @@ actual_retry() {
 }
 
 echodate() {
-  echo "$(date -Is)" "$@"
+  echo "[$(date -Is)]" "$@"
 }
 
 write_junit() {

--- a/config/kubermatic-operator/deployment.yaml
+++ b/config/kubermatic-operator/deployment.yaml
@@ -2,7 +2,7 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: kubermatic-operator
-  namespace: kubermatic-operator
+  namespace: '__NAMESPACE__'
   labels:
     app.kubernetes.io/name: kubermatic-operator
     app.kubernetes.io/version: '__KUBERMATIC_TAG__'
@@ -30,8 +30,10 @@ spec:
         args:
         - -internal-address=0.0.0.0:8085
         - -namespace=$(POD_NAMESPACE)
+        - -worker-name=__WORKER_NAME__
         - -log-format=json
-        - -worker-name=kubermatic-operator
+        - -log-debug=true
+        - -v=8
         env:
         - name: POD_NAMESPACE
           valueFrom:

--- a/config/kubermatic-operator/rbac.yaml
+++ b/config/kubermatic-operator/rbac.yaml
@@ -11,4 +11,4 @@ roleRef:
 subjects:
 - kind: ServiceAccount
   name: kubermatic-operator
-  namespace: kubermatic-operator
+  namespace: '__NAMESPACE__'

--- a/config/kubermatic-operator/serviceaccount.yaml
+++ b/config/kubermatic-operator/serviceaccount.yaml
@@ -2,6 +2,6 @@ apiVersion: v1
 kind: ServiceAccount
 metadata:
   name: kubermatic-operator
-  namespace: kubermatic-operator
+  namespace: '__NAMESPACE__'
   labels:
     app.kubernetes.io/name: kubermatic-operator


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR extends our e2e tests to be able to deploy Kubermatic either using the Helm chart or the new Kubermatic Operator. A new environment variable, `KUBERMATIC_USE_OPERATOR` toggles between the two. We support both for e2e tests because we still support the Helm chart for existing customers.

**Which issue(s) this PR fixes**:
Fixes #4727

**Does this PR introduce a user-facing change?**:
```release-note
NONE
```
