### PR TITLE
Fix setting overrides for kube-controller-manager in OpenShift controller

### DIFF
--- a/api/pkg/controller/seed-controller-manager/openshift/resources/kube_controller_manager.go
+++ b/api/pkg/controller/seed-controller-manager/openshift/resources/kube_controller_manager.go
@@ -295,7 +295,11 @@ func KubeControllerManagerDeploymentCreatorFactory(data kubeControllerManagerDat
 					kubeControllerManagerContainerName: defaultKubeControllerResourceRequirements.DeepCopy(),
 					openvpnSidecar.Name:                openvpnSidecar.Resources.DeepCopy(),
 				}
-				err = resources.SetResourceRequirements(dep.Spec.Template.Spec.Containers, defResourceRequirements, resources.GetOverrides(data.Cluster().Spec.ComponentsOverride), dep.Annotations)
+				overrides := map[string]*corev1.ResourceRequirements{}
+				if data.Cluster().Spec.ComponentsOverride.ControllerManager.Resources != nil {
+					overrides[kubeControllerManagerContainerName] = data.Cluster().Spec.ComponentsOverride.ControllerManager.Resources.DeepCopy()
+				}
+				err = resources.SetResourceRequirements(dep.Spec.Template.Spec.Containers, defResourceRequirements, overrides, dep.Annotations)
 				if err != nil {
 					return nil, fmt.Errorf("failed to set resource requirements: %v", err)
 				}

--- a/api/pkg/controller/seed-controller-manager/openshift/resources/kube_controller_manager.go
+++ b/api/pkg/controller/seed-controller-manager/openshift/resources/kube_controller_manager.go
@@ -265,7 +265,7 @@ func KubeControllerManagerDeploymentCreatorFactory(data kubeControllerManagerDat
 				dep.Spec.Template.Spec.Containers = []corev1.Container{
 					*openvpnSidecar,
 					{
-						Name:    kubeControllerManagerContainerName,
+						Name:    resources.ControllerManagerDeploymentName,
 						Image:   image,
 						Env:     env,
 						Command: []string{"hyperkube", kubeControllerManagerContainerName},
@@ -295,11 +295,7 @@ func KubeControllerManagerDeploymentCreatorFactory(data kubeControllerManagerDat
 					kubeControllerManagerContainerName: defaultKubeControllerResourceRequirements.DeepCopy(),
 					openvpnSidecar.Name:                openvpnSidecar.Resources.DeepCopy(),
 				}
-				overrides := map[string]*corev1.ResourceRequirements{}
-				if data.Cluster().Spec.ComponentsOverride.ControllerManager.Resources != nil {
-					overrides[kubeControllerManagerContainerName] = data.Cluster().Spec.ComponentsOverride.ControllerManager.Resources.DeepCopy()
-				}
-				err = resources.SetResourceRequirements(dep.Spec.Template.Spec.Containers, defResourceRequirements, overrides, dep.Annotations)
+				err = resources.SetResourceRequirements(dep.Spec.Template.Spec.Containers, defResourceRequirements, resources.GetOverrides(data.Cluster().Spec.ComponentsOverride), dep.Annotations)
 				if err != nil {
 					return nil, fmt.Errorf("failed to set resource requirements: %v", err)
 				}

--- a/api/pkg/controller/seed-controller-manager/openshift/resources/kube_controller_manager.go
+++ b/api/pkg/controller/seed-controller-manager/openshift/resources/kube_controller_manager.go
@@ -304,7 +304,7 @@ func KubeControllerManagerDeploymentCreatorFactory(data kubeControllerManagerDat
 					return nil, err
 				}
 				dep.Spec.Template.Labels = podLabels
-				wrappedPodSpec, err := apiserver.IsRunningWrapper(data, dep.Spec.Template.Spec, sets.NewString(kubeControllerManagerContainerName))
+				wrappedPodSpec, err := apiserver.IsRunningWrapper(data, dep.Spec.Template.Spec, sets.NewString(resources.ControllerManagerDeploymentName))
 				if err != nil {
 					return nil, fmt.Errorf("failed to add apiserver.IsRunningWrapper: %v", err)
 				}

--- a/api/pkg/controller/seed-controller-manager/openshift/resources/kube_scheduler.go
+++ b/api/pkg/controller/seed-controller-manager/openshift/resources/kube_scheduler.go
@@ -122,7 +122,7 @@ func KubeSchedulerDeploymentCreator(data openshiftData) reconciling.NamedDeploym
 			dep.Spec.Template.Spec.Containers = []corev1.Container{
 				*openvpnSidecar,
 				{
-					Name:    name,
+					Name:    resources.SchedulerDeploymentName,
 					Image:   image,
 					Command: []string{"hyperkube", "kube-scheduler"},
 					Args: []string{


### PR DESCRIPTION
**What this PR does / why we need it**:

Fix setting overrides for kube-controller-manager in OpenShift controller. This was overlooked in #4810.

**Does this PR introduce a user-facing change?**:
```release-note
NONE
```

/assign @alvaroaleman 