### PR TITLE
Operator: Fix addon defaulting

### DIFF
--- a/api/pkg/controller/operator/common/defaults.go
+++ b/api/pkg/controller/operator/common/defaults.go
@@ -129,7 +129,7 @@ func DefaultConfiguration(config *operatorv1alpha1.KubermaticConfiguration, logg
 
 	if len(copy.Spec.UserCluster.Addons.Openshift.Default) == 0 && copy.Spec.UserCluster.Addons.Openshift.DefaultManifests == "" {
 		copy.Spec.UserCluster.Addons.Openshift.DefaultManifests = strings.TrimSpace(defaultOpenshiftAddons)
-		logger.Debugw("Defaulting field", "field", "usercluster.Addons.Openshift.DefaultManifests")
+		logger.Debugw("Defaulting field", "field", "userCluster.Addons.Openshift.DefaultManifests")
 	}
 
 	if len(copy.Spec.API.AccessibleAddons) == 0 {

--- a/api/pkg/controller/operator/common/defaults.go
+++ b/api/pkg/controller/operator/common/defaults.go
@@ -38,16 +38,6 @@ var (
 		"logrotate",
 	}
 
-	openshiftDefaultAddons = []string{
-		"crd",
-		"openvpn",
-		"rbac",
-		"network",
-		"default-storage-class",
-		"registry",
-		"logrotate",
-	}
-
 	defaultAccessibleAddons = []string{
 		"node-exporter",
 	}
@@ -132,14 +122,14 @@ func DefaultConfiguration(config *operatorv1alpha1.KubermaticConfiguration, logg
 		logger.Debugw("Defaulting field", "field", "masterController.pprofEndpoint", "value", *copy.Spec.MasterController.PProfEndpoint)
 	}
 
-	if len(copy.Spec.UserCluster.Addons.Kubernetes.Default) == 0 {
+	if len(copy.Spec.UserCluster.Addons.Kubernetes.Default) == 0 && copy.Spec.UserCluster.Addons.Kubernetes.DefaultManifests == "" {
 		copy.Spec.UserCluster.Addons.Kubernetes.Default = kubernetesDefaultAddons
 		logger.Debugw("Defaulting field", "field", "userCluster.addons.kubernetes.default", "value", copy.Spec.UserCluster.Addons.Kubernetes.Default)
 	}
 
-	if len(copy.Spec.UserCluster.Addons.Openshift.Default) == 0 {
-		copy.Spec.UserCluster.Addons.Openshift.Default = openshiftDefaultAddons
-		logger.Debugw("Defaulting field", "field", "userCluster.addons.openshift.default", "value", copy.Spec.UserCluster.Addons.Openshift.Default)
+	if len(copy.Spec.UserCluster.Addons.Openshift.Default) == 0 && copy.Spec.UserCluster.Addons.Openshift.DefaultManifests == "" {
+		copy.Spec.UserCluster.Addons.Openshift.DefaultManifests = strings.TrimSpace(defaultOpenshiftAddons)
+		logger.Debugw("Defaulting field", "field", "usercluster.Addons.Openshift.DefaultManifests")
 	}
 
 	if len(copy.Spec.API.AccessibleAddons) == 0 {
@@ -187,11 +177,6 @@ func DefaultConfiguration(config *operatorv1alpha1.KubermaticConfiguration, logg
 	if copy.Spec.MasterFiles["updates.yaml"] == "" {
 		copy.Spec.MasterFiles["updates.yaml"] = strings.TrimSpace(defaultUpdatesYAML)
 		logger.Debugw("Defaulting field", "field", "masterFiles.'updates.yaml'")
-	}
-
-	if copy.Spec.MasterFiles["openshift-addons.yaml"] == "" {
-		copy.Spec.MasterFiles["openshift-addons.yaml"] = strings.TrimSpace(defaultOpenshiftAddons)
-		logger.Debugw("Defaulting field", "field", "masterFiles.'openshift-addons.yaml'")
 	}
 
 	auth := copy.Spec.Auth

--- a/api/pkg/controller/operator/common/resources.go
+++ b/api/pkg/controller/operator/common/resources.go
@@ -30,6 +30,13 @@ const (
 	// VersionLabel is the label containing the application's version.
 	VersionLabel = "app.kubernetes.io/version"
 
+	// OpenshiftAddonsFileName is the name of the openshift addons manifest file
+	// in the master files.
+	OpenshiftAddonsFileName = "openshift-addons.yaml"
+	// KubernetesAddonsFileName is the name of the kubernetes addons manifest file
+	// in the master files.
+	KubernetesAddonsFileName = "kubernetes-addons.yaml"
+
 	DockercfgSecretName                   = "dockercfg"
 	DexCASecretName                       = "dex-ca"
 	MasterFilesSecretName                 = "extra-files"
@@ -81,9 +88,15 @@ func DexCASecretCreator(cfg *operatorv1alpha1.KubermaticConfiguration) reconcili
 }
 
 func MasterFilesSecretCreator(cfg *operatorv1alpha1.KubermaticConfiguration) reconciling.NamedSecretCreatorGetter {
+	data := map[string]string{}
+	for key, val := range cfg.Spec.MasterFiles {
+		data[key] = val
+	}
+	data[OpenshiftAddonsFileName] = cfg.Spec.UserCluster.Addons.Openshift.DefaultManifests
+	data[KubernetesAddonsFileName] = cfg.Spec.UserCluster.Addons.Kubernetes.DefaultManifests
 	return func() (string, reconciling.SecretCreator) {
 		return MasterFilesSecretName, func(s *corev1.Secret) (*corev1.Secret, error) {
-			return createSecretData(s, cfg.Spec.MasterFiles), nil
+			return createSecretData(s, data), nil
 		}
 	}
 }

--- a/api/pkg/crd/operator/v1alpha1/configuration.go
+++ b/api/pkg/crd/operator/v1alpha1/configuration.go
@@ -171,7 +171,11 @@ type KubermaticUserClusterMonitoringConfiguration struct {
 // KubermaticAddonConfiguration describes the addons for a given cluster runtime.
 type KubermaticAddonConfiguration struct {
 	// Default is the list of addons to be installed by default into each cluster.
+	// Mutually exclusive with "defaultManifests".
 	Default []string `json:"default,omitempty"`
+	// DefaultManifests is a list of addon manifests to install into all clusters.
+	// Mutually exclusive with "default".
+	DefaultManifests string `json:"defaultManifests,omitempty"`
 	// DockerRepository is the repository containing the Docker image containing
 	// the possible addon manifests.
 	DockerRepository string `json:"dockerRepository,omitempty"`

--- a/docs/zz_generated.kubermaticConfiguration.yaml
+++ b/docs/zz_generated.kubermaticConfiguration.yaml
@@ -93,48 +93,6 @@ spec:
         memory: 128Mi
   # MasterFiles is a map of additional files to mount into each master component.
   masterFiles:
-    openshift-addons.yaml: |-
-      apiVersion: v1
-      kind: List
-      items:
-      - apiVersion: kubermatic.k8s.io/v1
-        kind: Addon
-        metadata:
-        name: crd
-      - apiVersion: kubermatic.k8s.io/v1
-        kind: Addon
-        metadata:
-        name: default-storage-class
-      - apiVersion: kubermatic.k8s.io/v1
-        kind: Addon
-        metadata:
-        name: logrotate
-      - apiVersion: kubermatic.k8s.io/v1
-        kind: Addon
-        metadata:
-        name: network
-        spec:
-        requiredResourceTypes:
-        - Group: config.openshift.io
-          Kind: Network
-          Version: v1
-      - apiVersion: kubermatic.k8s.io/v1
-        kind: Addon
-        metadata:
-        name: openvpn
-      - apiVersion: kubermatic.k8s.io/v1
-        kind: Addon
-        metadata:
-        name: rbac
-      - apiVersion: kubermatic.k8s.io/v1
-        kind: Addon
-        metadata:
-        name: registry
-        spec:
-        requiredResourceTypes:
-        - Group: cloudcredential.openshift.io
-          Kind: CredentialsRequest
-          Version: v1
     updates.yaml: |-
       ### Updates file
       #
@@ -364,6 +322,7 @@ spec:
       # Kubernetes controls the addons for Kubernetes-based clusters.
       kubernetes:
         # Default is the list of addons to be installed by default into each cluster.
+        # Mutually exclusive with "defaultManifests".
         default:
           - canal
           - csi
@@ -376,20 +335,61 @@ spec:
           - nodelocal-dns-cache
           - pod-security-policy
           - logrotate
+        # DefaultManifests is a list of addon manifests to install into all clusters.
+        # Mutually exclusive with "default".
+        defaultManifests: ""
         # DockerRepository is the repository containing the Docker image containing
         # the possible addon manifests.
         dockerRepository: quay.io/kubermatic/addons
       # Openshift controls the addons for Openshift-based clusters.
       openshift:
         # Default is the list of addons to be installed by default into each cluster.
-        default:
-          - crd
-          - openvpn
-          - rbac
-          - network
-          - default-storage-class
-          - registry
-          - logrotate
+        # Mutually exclusive with "defaultManifests".
+        default: null
+        # DefaultManifests is a list of addon manifests to install into all clusters.
+        # Mutually exclusive with "default".
+        defaultManifests: |-
+          apiVersion: v1
+          kind: List
+          items:
+          - apiVersion: kubermatic.k8s.io/v1
+            kind: Addon
+            metadata:
+            name: crd
+          - apiVersion: kubermatic.k8s.io/v1
+            kind: Addon
+            metadata:
+            name: default-storage-class
+          - apiVersion: kubermatic.k8s.io/v1
+            kind: Addon
+            metadata:
+            name: logrotate
+          - apiVersion: kubermatic.k8s.io/v1
+            kind: Addon
+            metadata:
+            name: network
+            spec:
+            requiredResourceTypes:
+            - Group: config.openshift.io
+              Kind: Network
+              Version: v1
+          - apiVersion: kubermatic.k8s.io/v1
+            kind: Addon
+            metadata:
+            name: openvpn
+          - apiVersion: kubermatic.k8s.io/v1
+            kind: Addon
+            metadata:
+            name: rbac
+          - apiVersion: kubermatic.k8s.io/v1
+            kind: Addon
+            metadata:
+            name: registry
+            spec:
+            requiredResourceTypes:
+            - Group: cloudcredential.openshift.io
+              Kind: CredentialsRequest
+              Version: v1
         # DockerRepository is the repository containing the Docker image containing
         # the possible addon manifests.
         dockerRepository: quay.io/kubermatic/openshift-addons


### PR DESCRIPTION
**What this PR does / why we need it**:

In #4913 the operator was hardcoded to use addon manifests configured via the master files and ignore the `Spec.UserCluster.Addons.Openshift.Default` setting.

This PR makes it correctly set either of the two and only default if both are unset. Also, the setting was moved from the master files map into the `KubermaticAddonConfiguration` and the controller was updated to also use either of the two for Kubernetes.
**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Documentation**:
<!-- Add links to the related documentation changes related to this pull request. E.g. the link to the kubermatic/docs pullrequest. -->

**Does this PR introduce a user-facing change?**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If  no release note is required, just write "NONE".
-->
```release-note
none
```
