### PR TITLE
Add env variable debug flag for hack/run* scripts

### DIFF
--- a/api/hack/run-api.sh
+++ b/api/hack/run-api.sh
@@ -8,6 +8,7 @@ set -x
 make -C $(dirname $0)/.. kubermatic-api
 
 KUBERMATIC_WORKERNAME=${KUBERMATIC_WORKERNAME:-$(uname -n)}
+KUBERMATIC_DEBUG=${KUBERMATIC_DEBUG:-true}
 
 # Please make sure to set -feature-gates=PrometheusEndpoint=true if you want to use that endpoint.
 
@@ -33,7 +34,7 @@ cd $(go env GOPATH)/src/github.com/kubermatic/kubermatic/api
   -oidc-issuer-redirect-uri="$(vault kv get -field=oidc-issuer-redirect-uri dev/seed-clusters/dev.kubermatic.io)" \
   -oidc-issuer-cookie-hash-key="$(vault kv get -field=oidc-issuer-cookie-hash-key dev/seed-clusters/dev.kubermatic.io)" \
   -service-account-signing-key="$(vault kv get -field=service-account-signing-key dev/seed-clusters/dev.kubermatic.io)" \
-  -log-debug=true \
+  -log-debug=$KUBERMATIC_DEBUG \
   -log-format=Console \
   -logtostderr \
   -v=4 $@

--- a/api/hack/run-controller.sh
+++ b/api/hack/run-controller.sh
@@ -12,6 +12,7 @@ export KUBERMATICCOMMIT="${KUBERMATICCOMMIT:-$(git rev-parse origin/master)}"
 make seed-controller-manager
 
 KUBERMATIC_WORKERNAME=${KUBERMATIC_WORKERNAME:-$(uname -n)}
+KUBERMATIC_DEBUG=${KUBERMATIC_DEBUG:-true}
 
 ./_build/seed-controller-manager \
   -dynamic-datacenters=true \
@@ -34,7 +35,7 @@ KUBERMATIC_WORKERNAME=${KUBERMATIC_WORKERNAME:-$(uname -n)}
   -oidc-issuer-client-id=$(vault kv get -field=oidc-issuer-client-id dev/seed-clusters/dev.kubermatic.io) \
   -oidc-issuer-client-secret=$(vault kv get -field=oidc-issuer-client-secret dev/seed-clusters/dev.kubermatic.io) \
   -monitoring-scrape-annotation-prefix='kubermatic.io' \
-  -log-debug=true \
+  -log-debug=$KUBERMATIC_DEBUG \
   -log-format=Console \
   -max-parallel-reconcile=10 \
   -logtostderr \

--- a/api/hack/run-master-controller-manager.sh
+++ b/api/hack/run-master-controller-manager.sh
@@ -7,6 +7,7 @@ set -o pipefail
 make -C $(dirname $0)/.. master-controller-manager
 
 KUBERMATIC_WORKERNAME=${KUBERMATIC_WORKERNAME:-$(uname -n)}
+KUBERMATIC_DEBUG=${KUBERMATIC_DEBUG:-true}
 
 cd $(go env GOPATH)/src/github.com/kubermatic/kubermatic/api
 ./_build/master-controller-manager \
@@ -14,7 +15,7 @@ cd $(go env GOPATH)/src/github.com/kubermatic/kubermatic/api
   -kubeconfig=../../secrets/seed-clusters/dev.kubermatic.io/kubeconfig \
   -internal-address=127.0.0.1:8086 \
   -worker-name="$(tr -cd '[:alnum:]' <<< $KUBERMATIC_WORKERNAME | tr '[:upper:]' '[:lower:]')" \
-  -log-debug=true \
+  -log-debug=$KUBERMATIC_DEBUG \
   -log-format=Console \
 	-logtostderr \
 	-v=4 # Log-level for the Kube dependencies. Increase up to 9 to get request-level logs.

--- a/api/hack/run-operator.sh
+++ b/api/hack/run-operator.sh
@@ -8,6 +8,7 @@ export NAMESPACE="${NAMESPACE:-}"
 
 export KUBERMATIC_WORKERNAME=${KUBERMATIC_WORKERNAME:-$(uname -n)}
 KUBERMATIC_WORKERNAME=$(tr -cd '[:alnum:]' <<< $KUBERMATIC_WORKERNAME | tr '[:upper:]' '[:lower:]')
+KUBERMATIC_DEBUG=${KUBERMATIC_DEBUG:-true}
 
 if [ -z "$NAMESPACE" ]; then
   echo "You must specify a NAMESPACE environment variable to run the operator in."
@@ -42,7 +43,7 @@ set -x
   -kubeconfig=../../secrets/seed-clusters/dev.kubermatic.io/kubeconfig \
   -namespace="$NAMESPACE" \
   -worker-name="$KUBERMATIC_WORKERNAME" \
-  -log-debug=true \
+  -log-debug=$KUBERMATIC_DEBUG \
   -log-format=Console \
   -logtostderr \
   -v=4 # Log-level for the Kube dependencies. Increase up to 9 to get request-level logs.

--- a/api/hack/run-userclustercontroller.sh
+++ b/api/hack/run-userclustercontroller.sh
@@ -7,6 +7,8 @@ set -o pipefail
 cd $(go env GOPATH)/src/github.com/kubermatic/kubermatic/api
 make user-cluster-controller-manager
 
+KUBERMATIC_DEBUG=${KUBERMATIC_DEBUG:-true}
+
 # Getting everything we need from the api
 # This script assumes you are in your cluster namespace, which you can configure via `kubectl config set-context $(kubectl config current-context) --namespace=<<cluster-namespace>>`
 NAMESPACE="${NAMESPACE:-$(kubectl config view --minify|grep namespace |awk '{ print $2 }')}"
@@ -58,7 +60,7 @@ fi
     -cluster-url=${CLUSTER_URL} \
     -version=${CLUSTER_VERSION} \
     -openshift-console-callback-uri="${CONSOLE_CALLBACK_URI}" \
-    -log-debug=true \
+    -log-debug=$KUBERMATIC_DEBUG \
     -log-format=Console \
     -logtostderr \
     -v=4 \


### PR DESCRIPTION
**What this PR does / why we need it**:
Add simple environment variable flag to enable/disable debug output for hack/run* scripts. Default behavior is still the same. 


```release-note
NONE
```
