### PR TITLE
don't create cluster role binding for API cluster roles

### DIFF
--- a/api/pkg/handler/v1/cluster/binding_test.go
+++ b/api/pkg/handler/v1/cluster/binding_test.go
@@ -300,12 +300,12 @@ func TestBindUserToClusterRole(t *testing.T) {
 	}{
 		// scenario 1
 		{
-			name:             "scenario 1: bind user to role-1",
+			name:             "scenario 1: bind user to role-1, when cluster role binding doesn't exist",
 			roleName:         "role-1",
 			body:             `{"userEmail":"test@example.com"}`,
-			expectedResponse: `{"subjects":[{"kind":"User","apiGroup":"rbac.authorization.k8s.io","name":"test@example.com"}],"roleRefName":"role-1"}`,
+			expectedResponse: `{"error":{"code":500,"message":"the cluster role binding not found"}}`,
 			clusterToGet:     test.GenDefaultCluster().Name,
-			httpStatus:       http.StatusOK,
+			httpStatus:       http.StatusInternalServerError,
 			existingKubermaticObjs: test.GenDefaultKubermaticObjects(
 				test.GenDefaultCluster(),
 			),


### PR DESCRIPTION
**What this PR does / why we need it**: remove adding Cluster Role Binding if it doesn't exist. Right now there is a ownerbindingcreator controller to handle this. It creates bindings for all cluster roles with special label `component=userClusterRole` (predefines cluster roles accessible only via the API)
 
**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

```release-note
NONE
```
