### PR TITLE
Replace presets.yaml with CRD in API e2e tests

### DIFF
--- a/api/hack/ci/ci-setup-kubermatic-in-kind.sh
+++ b/api/hack/ci/ci-setup-kubermatic-in-kind.sh
@@ -321,6 +321,7 @@ retry 3 helm upgrade --install --force --wait --timeout 300 \
   --set=kubermatic.checks.crd.disable=true \
   --set=kubermatic.datacenters='' \
   --set=kubermatic.dynamicDatacenters=true \
+  --set=kubermatic.dynamicPresets=true \
   --set=kubermatic.kubeconfig="$(cat $KUBECONFIG|sed 's/127.0.0.1.*/kubernetes.default.svc.cluster.local./'|base64 -w0)" \
   --set=kubermatic.auth.tokenIssuer=http://dex.oauth:5556/dex \
   --set=kubermatic.auth.clientID=kubermatic \

--- a/api/pkg/test/e2e/api/cluster_rbac_test.go
+++ b/api/pkg/test/e2e/api/cluster_rbac_test.go
@@ -30,7 +30,7 @@ func TestCreateClusterRoleBinding(t *testing.T) {
 			dc:                       "prow-build-cluster",
 			location:                 "do-fra1",
 			version:                  "v1.15.6",
-			credential:               "loodse",
+			credential:               "e2e-digitalocean",
 			replicas:                 1,
 			expectedRoleNames:        []string{"namespace-admin", "namespace-editor", "namespace-viewer"},
 			expectedClusterRoleNames: []string{"admin", "edit", "view"},

--- a/api/pkg/test/e2e/api/credentials_test.go
+++ b/api/pkg/test/e2e/api/credentials_test.go
@@ -21,22 +21,22 @@ func TestListCredentials(t *testing.T) {
 		{
 			name:         "test, get DigitalOcean credential names",
 			provider:     "digitalocean",
-			expectedList: []string{"loodse"},
+			expectedList: []string{"e2e-digitalocean"},
 		},
 		{
 			name:         "test, get Azure credential names",
 			provider:     "azure",
-			expectedList: []string{"loodse"},
+			expectedList: []string{"e2e-azure"},
 		},
 		{
 			name:         "test, get OpenStack credential names",
 			provider:     "openstack",
-			expectedList: []string{"loodse"},
+			expectedList: []string{"e2e-openstack"},
 		},
 		{
 			name:         "test, get GCP credential names",
 			provider:     "gcp",
-			expectedList: []string{"loodse"},
+			expectedList: []string{"e2e-gcp"},
 		},
 	}
 	for _, tc := range tests {
@@ -68,13 +68,13 @@ func TestProviderEndpointsWithCredentials(t *testing.T) {
 	}{
 		{
 			name:           "test, get DigitalOcean VM sizes",
-			credentialName: "loodse",
+			credentialName: "e2e-digitalocean",
 			path:           "api/v1/providers/digitalocean/sizes",
 			expectedCode:   http.StatusOK,
 		},
 		{
 			name:           "test, get Azure VM sizes",
-			credentialName: "loodse",
+			credentialName: "e2e-azure",
 			path:           "api/v1/providers/azure/sizes",
 			location:       "westeurope",
 			expectedCode:   http.StatusOK,

--- a/api/pkg/test/e2e/api/digitalocean_test.go
+++ b/api/pkg/test/e2e/api/digitalocean_test.go
@@ -30,7 +30,7 @@ func TestCreateDOCluster(t *testing.T) {
 			dc:         "prow-build-cluster",
 			location:   "do-fra1",
 			version:    "v1.15.6",
-			credential: "loodse",
+			credential: "e2e-digitalocean",
 			replicas:   1,
 		},
 	}
@@ -126,7 +126,7 @@ func TestDeleteClusterBeforeIsUp(t *testing.T) {
 			dc:         "prow-build-cluster",
 			location:   "do-fra1",
 			version:    "v1.15.6",
-			credential: "loodse",
+			credential: "e2e-digitalocean",
 			replicas:   1,
 		},
 	}
@@ -182,7 +182,7 @@ func TestGetClusterKubeconfig(t *testing.T) {
 			dc:           "prow-build-cluster",
 			location:     "do-fra1",
 			version:      "v1.15.6",
-			credential:   "loodse",
+			credential:   "e2e-digitalocean",
 			replicas:     1,
 			path:         "/api/v1/projects/%s/dc/%s/clusters/%s/kubeconfig",
 			expectedCode: http.StatusOK,

--- a/api/pkg/test/e2e/api/gcp_test.go
+++ b/api/pkg/test/e2e/api/gcp_test.go
@@ -20,7 +20,7 @@ func TestGCPZones(t *testing.T) {
 		{
 			name:                "test, get GCP zones",
 			provider:            "gcp",
-			expectedCredentials: []string{"loodse"},
+			expectedCredentials: []string{"e2e-gcp"},
 			datacenter:          "gcp-westeurope",
 			resultList:          []string{"europe-west3-a", "europe-west3-b", "europe-west3-c"},
 		},
@@ -68,7 +68,7 @@ func TestGCPDiskTypes(t *testing.T) {
 		{
 			name:                "test, get GCP disk types",
 			provider:            "gcp",
-			expectedCredentials: []string{"loodse"},
+			expectedCredentials: []string{"e2e-gcp"},
 			zone:                "europe-west3-c",
 			resultList:          []string{"pd-ssd", "pd-standard"},
 		},
@@ -115,7 +115,7 @@ func TestGCPSizes(t *testing.T) {
 		{
 			name:                "test, get GCP sizes",
 			provider:            "gcp",
-			expectedCredentials: []string{"loodse"},
+			expectedCredentials: []string{"e2e-gcp"},
 			zone:                "europe-west3-c",
 		},
 	}


### PR DESCRIPTION
**What this PR does / why we need it**:
This removes the presets.yaml from the e2e test and replaces it with Preset CRDs. This is needed because the Kubermatic Operator (that will soon take over the provisioning during e2e test) does not support the presets.yaml anymore.

**Does this PR introduce a user-facing change?**:
```release-note
NONE
```
