### PR TITLE
enabling node csr approver for kubernetes clusters

### DIFF
--- a/api/Gopkg.lock
+++ b/api/Gopkg.lock
@@ -2258,6 +2258,7 @@
     "k8s.io/client-go/kubernetes/fake",
     "k8s.io/client-go/kubernetes/scheme",
     "k8s.io/client-go/kubernetes/typed/certificates/v1beta1",
+    "k8s.io/client-go/kubernetes/typed/certificates/v1beta1/fake",
     "k8s.io/client-go/kubernetes/typed/core/v1",
     "k8s.io/client-go/listers/core/v1",
     "k8s.io/client-go/listers/rbac/v1",

--- a/api/cmd/user-cluster-controller-manager/main.go
+++ b/api/cmd/user-cluster-controller-manager/main.go
@@ -229,14 +229,16 @@ func main() {
 	}
 	log.Info("Registered user RBAC controller")
 
+	if err := nodecsrapprover.Add(mgr, 4, cfg, log); err != nil {
+		log.Fatalw("Failed to add nodecsrapprover controller", zap.Error(err))
+	}
+	log.Info("Registered nodecsrapprover controller")
+
 	if runOp.openshift {
-		if err := nodecsrapprover.Add(mgr, 4, cfg, log); err != nil {
-			log.Fatalw("Failed to add nodecsrapprover controller", zap.Error(err))
-		}
 		if err := openshiftmasternodelabeler.Add(context.Background(), kubermaticlog.Logger, mgr); err != nil {
 			log.Fatalw("Failed to add openshiftmasternodelabeler controller", zap.Error(err))
 		}
-		log.Info("Registered nodecsrapprover controller")
+		log.Info("Registered openshiftmasternodelabeler controller")
 
 		if err := openshiftseedsyncer.Add(log, mgr, seedMgr, runOp.clusterURL, runOp.namespace); err != nil {
 			log.Fatalw("Failed to register the openshiftseedsyncer", zap.Error(err))

--- a/api/pkg/controller/user-cluster-controller-manager/nodecsrapprover/node_csr_approver_test.go
+++ b/api/pkg/controller/user-cluster-controller-manager/nodecsrapprover/node_csr_approver_test.go
@@ -1,0 +1,91 @@
+package nodecsrapprover
+
+import (
+	"context"
+	"sync"
+	"testing"
+
+	kubermaticlog "github.com/kubermatic/kubermatic/api/pkg/log"
+
+	certificatesv1beta1 "k8s.io/api/certificates/v1beta1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/client-go/kubernetes/typed/certificates/v1beta1/fake"
+	fakeclienttest "k8s.io/client-go/testing"
+
+	k8sclientfake "sigs.k8s.io/controller-runtime/pkg/client/fake"
+	"sigs.k8s.io/controller-runtime/pkg/reconcile"
+)
+
+func TestReconciler_Reconcile(t *testing.T) {
+	reaction := &fakeApproveReaction{}
+	simpleReactor := &fakeclienttest.SimpleReactor{
+		Verb:     "*",
+		Resource: "*",
+		Reaction: reaction.approveReaction,
+	}
+	testCases := []struct {
+		name       string
+		reconciler reconciler
+	}{
+		{
+			name: "test approving a created certificate",
+			reconciler: reconciler{
+				log: kubermaticlog.New(true, kubermaticlog.FormatConsole).Sugar(),
+				Client: k8sclientfake.NewFakeClient(&certificatesv1beta1.CertificateSigningRequest{
+					ObjectMeta: metav1.ObjectMeta{
+						ResourceVersion: "123456",
+						Name:            "csr",
+						Namespace:       metav1.NamespaceSystem,
+					},
+					Spec: certificatesv1beta1.CertificateSigningRequestSpec{
+						Request: []byte("LS0tLS1CRUdJTiBDRVJUSUZJQ0FURSBSRVFVRVNULS0tLS0KTUlJQkdUQ0J2d0lCQURCZE1SVXdFd1lEVlFRS0V3eHplWE4wWlcwNmJtOWtaWE14UkRCQ0JnTlZCQU1UTzNONQpjM1JsYlRwdWIyUmxPbWRyWlMxcmRXSmxjbTFoZEdsakxXUmxkaTF3Y21WbGJYUnBZbXhsTFdKcFp5MWpZbVEyCk9EWmpaQzAxTkRsek1Ga3dFd1lIS29aSXpqMENBUVlJS29aSXpqMERBUWNEUWdBRWtDb2xGU24rZU10NDgxaWcKSmZUa3JjVmg1RGRhNnczZWkyYnBuMXgrRE9lc0VmdWR1Q3hLOWgyazN2L0RFb0J3eUpRNzF0RW5JbSs5UG04Lwp6dkcwa2FBQU1Bb0dDQ3FHU000OUJBTUNBMGtBTUVZQ0lRRGpSbjJJSjNNU2NKRXNSc3VHSTgyOFBvTW1TaWNuCkRqcjhKNWZ3QkxIeUxnSWhBTW9SY3FBREFYOTJHK0VhTGg5N1Q3NUo4em5mSUlVTE5ReW9OeTZVTUN5SgotLS0tLUVORCBDRVJUSUZJQ0FURSBSRVFVRVNULS0tLS0K"),
+						Usages: []certificatesv1beta1.KeyUsage{
+							certificatesv1beta1.UsageDigitalSignature,
+							certificatesv1beta1.UsageKeyEncipherment,
+							certificatesv1beta1.UsageServerAuth,
+						},
+						Username: "test-user",
+						Groups: []string{
+							"system:nodes",
+						},
+					},
+				}),
+				certClient: &fake.FakeCertificateSigningRequests{
+					Fake: &fake.FakeCertificatesV1beta1{
+						Fake: &fakeclienttest.Fake{
+							RWMutex:       sync.RWMutex{},
+							ReactionChain: []fakeclienttest.Reactor{simpleReactor},
+						},
+					},
+				},
+			},
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			ctx := context.Background()
+			if err := tc.reconciler.reconcile(ctx, reconcile.Request{
+				NamespacedName: types.NamespacedName{Name: "csr", Namespace: metav1.NamespaceSystem}}); err != nil {
+				t.Fatalf("failed executing test: %v", err)
+			}
+
+			for _, cond := range reaction.expectedCSR.Status.Conditions {
+				if cond.Type != certificatesv1beta1.CertificateApproved {
+					t.Fatalf("failed updating csr condition")
+				}
+			}
+		})
+	}
+}
+
+type fakeApproveReaction struct {
+	expectedCSR *certificatesv1beta1.CertificateSigningRequest
+}
+
+func (f *fakeApproveReaction) approveReaction(action fakeclienttest.Action) (bool, runtime.Object, error) {
+	f.expectedCSR = action.(fakeclienttest.UpdateActionImpl).Object.(*certificatesv1beta1.CertificateSigningRequest)
+	return true, f.expectedCSR, nil
+}


### PR DESCRIPTION
**What this PR does / why we need it**:
Enabling the nodecsrapprover controller for kubernetes cluster so The kubelet serving certificate is validated by apiserver.

**Which issue(s) this PR fixes**
Fixes #4301

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
No

```release-note
NONE
```
