### PR TITLE
Fix typo when cleaning up AWS tags

### DIFF
--- a/api/pkg/provider/cloud/aws/provider.go
+++ b/api/pkg/provider/cloud/aws/provider.go
@@ -299,7 +299,7 @@ func removeTags(cluster *kubermaticv1.Cluster, client ec2iface.EC2API) error {
 		return fmt.Errorf("failed to list subnets: %v", err)
 	}
 
-	resourceIDs := []*string{&cluster.Spec.Cloud.AWS.SecurityGroupID, &cluster.Spec.Cloud.AWS.RouteTableID, &cluster.Spec.Cloud.AWS.SecurityGroupID}
+	resourceIDs := []*string{&cluster.Spec.Cloud.AWS.SecurityGroupID, &cluster.Spec.Cloud.AWS.RouteTableID}
 	for _, subnet := range sOut.Subnets {
 		resourceIDs = append(resourceIDs, subnet.SubnetId)
 	}


### PR DESCRIPTION
**What this PR does / why we need it**:
When Henrik originally implemented the tagging stuff in #1354, Alvaro later improved the code in #4848, but did not remove the other duplicated security group.

**Does this PR introduce a user-facing change?**:
```release-note
NONE
```
