### PR TITLE
Enable dynamic presets in API run script

### DIFF
--- a/api/hack/run-api.sh
+++ b/api/hack/run-api.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 set -o errexit
 set -o nounset
@@ -19,7 +19,7 @@ cd $(go env GOPATH)/src/github.com/kubermatic/kubermatic/api
 ./_build/kubermatic-api \
   -kubeconfig=../../secrets/seed-clusters/dev.kubermatic.io/kubeconfig \
   -dynamic-datacenters=true \
-  -presets=../../secrets/seed-clusters/dev.kubermatic.io/presets.yaml \
+  -dynamic-presets=true \
   -versions=../config/kubermatic/static/master/versions.yaml \
   -updates=../config/kubermatic/static/master/updates.yaml \
   -master-resources=../config/kubermatic/static/master \

--- a/api/hack/run-controller.sh
+++ b/api/hack/run-controller.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 set -o errexit
 set -o nounset
@@ -13,6 +13,7 @@ make seed-controller-manager
 
 KUBERMATIC_WORKERNAME=${KUBERMATIC_WORKERNAME:-$(uname -n)}
 KUBERMATIC_DEBUG=${KUBERMATIC_DEBUG:-true}
+PPROF_PORT=${PPROF_PORT:-6600}
 
 ./_build/seed-controller-manager \
   -dynamic-datacenters=true \
@@ -38,5 +39,6 @@ KUBERMATIC_DEBUG=${KUBERMATIC_DEBUG:-true}
   -log-debug=$KUBERMATIC_DEBUG \
   -log-format=Console \
   -max-parallel-reconcile=10 \
+  -pprof-listen-address=":${PPROF_PORT}" \
   -logtostderr \
   -v=4 # Log-level for the Kube dependencies. Increase up to 9 to get request-level logs.

--- a/docs/dev-getting-started.md
+++ b/docs/dev-getting-started.md
@@ -12,7 +12,6 @@ The basic steps to get started on this are these:
 * Start all the components via the respective scripts. All of them are blocking so it is suggested to start a termial instance for each:
     * API: `$(go env GOPATH)/src/github.com/kubermatic/kubermatic/api/hack/run-api.sh`
     * Dashboard: `$(go env GOPATH)/src/github.com/kubermatic/dashboard-v2/hack/run-local-dashboard.sh`
-    * RBAC-Controller: `$(go env GOPATH)/src/github.com/kubermatic/kubermatic/api/hack/run-rbac-generator.sh`
     * Controller-Manager: `$(go env GOPATH)/src/github.com/kubermatic/kubermatic/api/hack/run-controller.sh`
 
 Now you can visit http://localhost:8000 in your webbrowser, log in and create a cluster at a provider of your choice. The result can then be viewed by looking into the respective seed cluster:


### PR DESCRIPTION
- Add dynamic-presets flag to `run-api.sh`.
- Makes PPROF port overridable for `run-controller.sh`.

```release-note
NONE
```