### PR TITLE
add an API field to switch on dynamic kubelet config

### DIFF
--- a/api/cmd/kubermatic-api/swagger.json
+++ b/api/cmd/kubermatic-api/swagger.json
@@ -8941,6 +8941,10 @@
         "template"
       ],
       "properties": {
+        "dynamicConfig": {
+          "type": "boolean",
+          "x-go-name": "DynamicConfig"
+        },
         "paused": {
           "type": "boolean",
           "x-go-name": "Paused"

--- a/api/pkg/api/v1/types.go
+++ b/api/pkg/api/v1/types.go
@@ -1189,6 +1189,8 @@ type NodeDeploymentSpec struct {
 	Template NodeSpec `json:"template"`
 	// required: false
 	Paused *bool `json:"paused,omitempty"`
+	// required: false
+	DynamicConfig *bool `json:"dynamicConfig,omitempty"`
 }
 
 // Event is a report of an event somewhere in the cluster.

--- a/api/pkg/handler/test/helper.go
+++ b/api/pkg/handler/test/helper.go
@@ -671,8 +671,19 @@ func GenTestMachine(name, rawProviderSpec string, labels map[string]string, owne
 	}
 }
 
-func GenTestMachineDeployment(name, rawProviderSpec string, selector map[string]string) *clusterv1alpha1.MachineDeployment {
+func GenTestMachineDeployment(name, rawProviderSpec string, selector map[string]string, dynamicConfig bool) *clusterv1alpha1.MachineDeployment {
 	var replicas int32 = 1
+
+	var configSource *corev1.NodeConfigSource
+	if dynamicConfig {
+		configSource = &corev1.NodeConfigSource{
+			ConfigMap: &corev1.ConfigMapNodeConfigSource{
+				Namespace:        "kube-system",
+				KubeletConfigKey: "kubelet",
+				Name:             "config-kubelet-9.9",
+			},
+		}
+	}
 	return &clusterv1alpha1.MachineDeployment{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      name,
@@ -696,6 +707,7 @@ func GenTestMachineDeployment(name, rawProviderSpec string, selector map[string]
 					Versions: clusterv1alpha1.MachineVersionInfo{
 						Kubelet: "v9.9.9",
 					},
+					ConfigSource: configSource,
 				},
 			},
 		},

--- a/api/pkg/handler/v1/cluster/upgrade_test.go
+++ b/api/pkg/handler/v1/cluster/upgrade_test.go
@@ -94,7 +94,7 @@ func TestGetClusterUpgrades(t *testing.T) {
 			existingKubermaticObjs: test.GenDefaultKubermaticObjects(),
 			existingMachineDeployments: func() []*clusterv1alpha1.MachineDeployment {
 				mds := make([]*clusterv1alpha1.MachineDeployment, 0, 1)
-				mdWithOldKubelet := test.GenTestMachineDeployment("venus", `{"cloudProvider":"digitalocean","cloudProviderSpec":{"token":"dummy-token","region":"fra1","size":"2GB"}, "operatingSystem":"ubuntu", "operatingSystemSpec":{"distUpgradeOnBoot":true}}`, nil)
+				mdWithOldKubelet := test.GenTestMachineDeployment("venus", `{"cloudProvider":"digitalocean","cloudProviderSpec":{"token":"dummy-token","region":"fra1","size":"2GB"}, "operatingSystem":"ubuntu", "operatingSystemSpec":{"distUpgradeOnBoot":true}}`, nil, false)
 				mdWithOldKubelet.Spec.Template.Spec.Versions.Kubelet = "v1.4.0"
 				mds = append(mds, mdWithOldKubelet)
 				return mds
@@ -351,8 +351,8 @@ func TestUpgradeClusterNodeDeployments(t *testing.T) {
 			}()),
 			ExistingAPIUser: test.GenDefaultAPIUser(),
 			ExistingMachineDeployments: []runtime.Object{
-				test.GenTestMachineDeployment("venus", `{"cloudProvider":"digitalocean","cloudProviderSpec":{"token":"dummy-token","region":"fra1","size":"2GB"}, "operatingSystem":"ubuntu", "operatingSystemSpec":{"distUpgradeOnBoot":true}}`, nil),
-				test.GenTestMachineDeployment("mars", `{"cloudProvider":"aws","cloudProviderSpec":{"token":"dummy-token","region":"eu-central-1","availabilityZone":"eu-central-1a","vpcId":"vpc-819f62e9","subnetId":"subnet-2bff4f43","instanceType":"t2.micro","diskSize":50}, "operatingSystem":"ubuntu", "operatingSystemSpec":{"distUpgradeOnBoot":false}}`, nil),
+				test.GenTestMachineDeployment("venus", `{"cloudProvider":"digitalocean","cloudProviderSpec":{"token":"dummy-token","region":"fra1","size":"2GB"}, "operatingSystem":"ubuntu", "operatingSystemSpec":{"distUpgradeOnBoot":true}}`, nil, false),
+				test.GenTestMachineDeployment("mars", `{"cloudProvider":"aws","cloudProviderSpec":{"token":"dummy-token","region":"eu-central-1","availabilityZone":"eu-central-1a","vpcId":"vpc-819f62e9","subnetId":"subnet-2bff4f43","instanceType":"t2.micro","diskSize":50}, "operatingSystem":"ubuntu", "operatingSystemSpec":{"distUpgradeOnBoot":false}}`, nil, false),
 			},
 		},
 		{
@@ -368,8 +368,8 @@ func TestUpgradeClusterNodeDeployments(t *testing.T) {
 				return cluster
 			}()), ExistingAPIUser: test.GenDefaultAPIUser(),
 			ExistingMachineDeployments: []runtime.Object{
-				test.GenTestMachineDeployment("venus", `{"cloudProvider":"digitalocean","cloudProviderSpec":{"token":"dummy-token","region":"fra1","size":"2GB"}, "operatingSystem":"ubuntu", "operatingSystemSpec":{"distUpgradeOnBoot":true}}`, nil),
-				test.GenTestMachineDeployment("mars", `{"cloudProvider":"aws","cloudProviderSpec":{"token":"dummy-token","region":"eu-central-1","availabilityZone":"eu-central-1a","vpcId":"vpc-819f62e9","subnetId":"subnet-2bff4f43","instanceType":"t2.micro","diskSize":50}, "operatingSystem":"ubuntu", "operatingSystemSpec":{"distUpgradeOnBoot":false}}`, nil),
+				test.GenTestMachineDeployment("venus", `{"cloudProvider":"digitalocean","cloudProviderSpec":{"token":"dummy-token","region":"fra1","size":"2GB"}, "operatingSystem":"ubuntu", "operatingSystemSpec":{"distUpgradeOnBoot":true}}`, nil, false),
+				test.GenTestMachineDeployment("mars", `{"cloudProvider":"aws","cloudProviderSpec":{"token":"dummy-token","region":"eu-central-1","availabilityZone":"eu-central-1a","vpcId":"vpc-819f62e9","subnetId":"subnet-2bff4f43","instanceType":"t2.micro","diskSize":50}, "operatingSystem":"ubuntu", "operatingSystemSpec":{"distUpgradeOnBoot":false}}`, nil, false),
 			},
 		},
 	}

--- a/api/pkg/handler/v1/node/node.go
+++ b/api/pkg/handler/v1/node/node.go
@@ -171,6 +171,8 @@ func outputMachineDeployment(md *clusterv1alpha1.MachineDeployment) (*apiv1.Node
 		}
 	}
 
+	hasDynamicConfig := md.Spec.Template.Spec.ConfigSource != nil
+
 	return &apiv1.NodeDeployment{
 		ObjectMeta: apiv1.ObjectMeta{
 			ID:                md.Name,
@@ -189,7 +191,8 @@ func outputMachineDeployment(md *clusterv1alpha1.MachineDeployment) (*apiv1.Node
 				OperatingSystem: *operatingSystemSpec,
 				Cloud:           *cloudSpec,
 			},
-			Paused: &md.Spec.Paused,
+			Paused:        &md.Spec.Paused,
+			DynamicConfig: &hasDynamicConfig,
 		},
 		Status: md.Status,
 	}, nil

--- a/api/pkg/handler/v1/provider/aws_test.go
+++ b/api/pkg/handler/v1/provider/aws_test.go
@@ -81,8 +81,8 @@ func TestSetDefaultSubnet(t *testing.T) {
 			},
 			machineDeployments: &clusterv1alpha1.MachineDeploymentList{
 				Items: []clusterv1alpha1.MachineDeployment{
-					*test.GenTestMachineDeployment("md-1-b", `{"cloudProvider":"aws","cloudProviderSpec":{"token":"dummy-token","region":"eu-central-1","availabilityZone":"eu-central-1b","vpcId":"vpc-819f62e9","subnetId":"subnet-2bff4f43","instanceType":"t2.micro","diskSize":50}, "operatingSystem":"ubuntu", "operatingSystemSpec":{"distUpgradeOnBoot":false}}`, nil),
-					*test.GenTestMachineDeployment("md-1-c", `{"cloudProvider":"aws","cloudProviderSpec":{"token":"dummy-token","region":"eu-central-1","availabilityZone":"eu-central-1c","vpcId":"vpc-819f62e9","subnetId":"subnet-2bff4f43","instanceType":"t2.micro","diskSize":50}, "operatingSystem":"ubuntu", "operatingSystemSpec":{"distUpgradeOnBoot":false}}`, nil),
+					*test.GenTestMachineDeployment("md-1-b", `{"cloudProvider":"aws","cloudProviderSpec":{"token":"dummy-token","region":"eu-central-1","availabilityZone":"eu-central-1b","vpcId":"vpc-819f62e9","subnetId":"subnet-2bff4f43","instanceType":"t2.micro","diskSize":50}, "operatingSystem":"ubuntu", "operatingSystemSpec":{"distUpgradeOnBoot":false}}`, nil, false),
+					*test.GenTestMachineDeployment("md-1-c", `{"cloudProvider":"aws","cloudProviderSpec":{"token":"dummy-token","region":"eu-central-1","availabilityZone":"eu-central-1c","vpcId":"vpc-819f62e9","subnetId":"subnet-2bff4f43","instanceType":"t2.micro","diskSize":50}, "operatingSystem":"ubuntu", "operatingSystemSpec":{"distUpgradeOnBoot":false}}`, nil, false),
 				},
 			},
 			expectedResult: apiv1.AWSSubnetList{
@@ -124,8 +124,8 @@ func TestSetDefaultSubnet(t *testing.T) {
 			},
 			machineDeployments: &clusterv1alpha1.MachineDeploymentList{
 				Items: []clusterv1alpha1.MachineDeployment{
-					*test.GenTestMachineDeployment("md-1-a", `{"cloudProvider":"aws","cloudProviderSpec":{"token":"dummy-token","region":"eu-central-1","availabilityZone":"eu-central-1a","vpcId":"vpc-819f62e9","subnetId":"subnet-2bff4f43","instanceType":"t2.micro","diskSize":50}, "operatingSystem":"ubuntu", "operatingSystemSpec":{"distUpgradeOnBoot":false}}`, nil),
-					*test.GenTestMachineDeployment("md-1-b", `{"cloudProvider":"aws","cloudProviderSpec":{"token":"dummy-token","region":"eu-central-1","availabilityZone":"eu-central-1b","vpcId":"vpc-819f62e9","subnetId":"subnet-2bff4f43","instanceType":"t2.micro","diskSize":50}, "operatingSystem":"ubuntu", "operatingSystemSpec":{"distUpgradeOnBoot":false}}`, nil),
+					*test.GenTestMachineDeployment("md-1-a", `{"cloudProvider":"aws","cloudProviderSpec":{"token":"dummy-token","region":"eu-central-1","availabilityZone":"eu-central-1a","vpcId":"vpc-819f62e9","subnetId":"subnet-2bff4f43","instanceType":"t2.micro","diskSize":50}, "operatingSystem":"ubuntu", "operatingSystemSpec":{"distUpgradeOnBoot":false}}`, nil, false),
+					*test.GenTestMachineDeployment("md-1-b", `{"cloudProvider":"aws","cloudProviderSpec":{"token":"dummy-token","region":"eu-central-1","availabilityZone":"eu-central-1b","vpcId":"vpc-819f62e9","subnetId":"subnet-2bff4f43","instanceType":"t2.micro","diskSize":50}, "operatingSystem":"ubuntu", "operatingSystemSpec":{"distUpgradeOnBoot":false}}`, nil, false),
 				},
 			},
 			expectedResult: apiv1.AWSSubnetList{
@@ -167,9 +167,9 @@ func TestSetDefaultSubnet(t *testing.T) {
 			},
 			machineDeployments: &clusterv1alpha1.MachineDeploymentList{
 				Items: []clusterv1alpha1.MachineDeployment{
-					*test.GenTestMachineDeployment("md-1-a", `{"cloudProvider":"aws","cloudProviderSpec":{"token":"dummy-token","region":"eu-central-1","availabilityZone":"eu-central-1a","vpcId":"vpc-819f62e9","subnetId":"subnet-2bff4f43","instanceType":"t2.micro","diskSize":50}, "operatingSystem":"ubuntu", "operatingSystemSpec":{"distUpgradeOnBoot":false}}`, nil),
-					*test.GenTestMachineDeployment("md-1-b", `{"cloudProvider":"aws","cloudProviderSpec":{"token":"dummy-token","region":"eu-central-1","availabilityZone":"eu-central-1b","vpcId":"vpc-819f62e9","subnetId":"subnet-2bff4f43","instanceType":"t2.micro","diskSize":50}, "operatingSystem":"ubuntu", "operatingSystemSpec":{"distUpgradeOnBoot":false}}`, nil),
-					*test.GenTestMachineDeployment("md-1-c", `{"cloudProvider":"aws","cloudProviderSpec":{"token":"dummy-token","region":"eu-central-1","availabilityZone":"eu-central-1c","vpcId":"vpc-819f62e9","subnetId":"subnet-2bff4f43","instanceType":"t2.micro","diskSize":50}, "operatingSystem":"ubuntu", "operatingSystemSpec":{"distUpgradeOnBoot":false}}`, nil),
+					*test.GenTestMachineDeployment("md-1-a", `{"cloudProvider":"aws","cloudProviderSpec":{"token":"dummy-token","region":"eu-central-1","availabilityZone":"eu-central-1a","vpcId":"vpc-819f62e9","subnetId":"subnet-2bff4f43","instanceType":"t2.micro","diskSize":50}, "operatingSystem":"ubuntu", "operatingSystemSpec":{"distUpgradeOnBoot":false}}`, nil, false),
+					*test.GenTestMachineDeployment("md-1-b", `{"cloudProvider":"aws","cloudProviderSpec":{"token":"dummy-token","region":"eu-central-1","availabilityZone":"eu-central-1b","vpcId":"vpc-819f62e9","subnetId":"subnet-2bff4f43","instanceType":"t2.micro","diskSize":50}, "operatingSystem":"ubuntu", "operatingSystemSpec":{"distUpgradeOnBoot":false}}`, nil, false),
+					*test.GenTestMachineDeployment("md-1-c", `{"cloudProvider":"aws","cloudProviderSpec":{"token":"dummy-token","region":"eu-central-1","availabilityZone":"eu-central-1c","vpcId":"vpc-819f62e9","subnetId":"subnet-2bff4f43","instanceType":"t2.micro","diskSize":50}, "operatingSystem":"ubuntu", "operatingSystemSpec":{"distUpgradeOnBoot":false}}`, nil, false),
 				},
 			},
 			expectedResult: apiv1.AWSSubnetList{
@@ -195,9 +195,9 @@ func TestSetDefaultSubnet(t *testing.T) {
 			subnets: apiv1.AWSSubnetList{},
 			machineDeployments: &clusterv1alpha1.MachineDeploymentList{
 				Items: []clusterv1alpha1.MachineDeployment{
-					*test.GenTestMachineDeployment("md-1-a", `{"cloudProvider":"aws","cloudProviderSpec":{"token":"dummy-token","region":"eu-central-1","availabilityZone":"eu-central-1a","vpcId":"vpc-819f62e9","subnetId":"subnet-2bff4f43","instanceType":"t2.micro","diskSize":50}, "operatingSystem":"ubuntu", "operatingSystemSpec":{"distUpgradeOnBoot":false}}`, nil),
-					*test.GenTestMachineDeployment("md-1-b", `{"cloudProvider":"aws","cloudProviderSpec":{"token":"dummy-token","region":"eu-central-1","availabilityZone":"eu-central-1b","vpcId":"vpc-819f62e9","subnetId":"subnet-2bff4f43","instanceType":"t2.micro","diskSize":50}, "operatingSystem":"ubuntu", "operatingSystemSpec":{"distUpgradeOnBoot":false}}`, nil),
-					*test.GenTestMachineDeployment("md-1-c", `{"cloudProvider":"aws","cloudProviderSpec":{"token":"dummy-token","region":"eu-central-1","availabilityZone":"eu-central-1c","vpcId":"vpc-819f62e9","subnetId":"subnet-2bff4f43","instanceType":"t2.micro","diskSize":50}, "operatingSystem":"ubuntu", "operatingSystemSpec":{"distUpgradeOnBoot":false}}`, nil),
+					*test.GenTestMachineDeployment("md-1-a", `{"cloudProvider":"aws","cloudProviderSpec":{"token":"dummy-token","region":"eu-central-1","availabilityZone":"eu-central-1a","vpcId":"vpc-819f62e9","subnetId":"subnet-2bff4f43","instanceType":"t2.micro","diskSize":50}, "operatingSystem":"ubuntu", "operatingSystemSpec":{"distUpgradeOnBoot":false}}`, nil, false),
+					*test.GenTestMachineDeployment("md-1-b", `{"cloudProvider":"aws","cloudProviderSpec":{"token":"dummy-token","region":"eu-central-1","availabilityZone":"eu-central-1b","vpcId":"vpc-819f62e9","subnetId":"subnet-2bff4f43","instanceType":"t2.micro","diskSize":50}, "operatingSystem":"ubuntu", "operatingSystemSpec":{"distUpgradeOnBoot":false}}`, nil, false),
+					*test.GenTestMachineDeployment("md-1-c", `{"cloudProvider":"aws","cloudProviderSpec":{"token":"dummy-token","region":"eu-central-1","availabilityZone":"eu-central-1c","vpcId":"vpc-819f62e9","subnetId":"subnet-2bff4f43","instanceType":"t2.micro","diskSize":50}, "operatingSystem":"ubuntu", "operatingSystemSpec":{"distUpgradeOnBoot":false}}`, nil, false),
 				},
 			},
 			expectedError: "the subnet list can not be empty",

--- a/api/pkg/resources/machine/machinedeployment.go
+++ b/api/pkg/resources/machine/machinedeployment.go
@@ -69,6 +69,21 @@ func Deployment(c *kubermaticv1.Cluster, nd *apiv1.NodeDeployment, dc *kubermati
 
 	md.Spec.Template.Spec.Versions.Kubelet = nd.Spec.Template.Versions.Kubelet
 
+	if nd.Spec.DynamicConfig != nil && *nd.Spec.DynamicConfig {
+		kubeletVersion, err := semver.NewVersion(nd.Spec.Template.Versions.Kubelet)
+		if err != nil {
+			return nil, fmt.Errorf("failed to parse kubelet version: %v", err)
+		}
+
+		md.Spec.Template.Spec.ConfigSource = &corev1.NodeConfigSource{
+			ConfigMap: &corev1.ConfigMapNodeConfigSource{
+				Namespace:        "kube-system",
+				Name:             fmt.Sprintf("kubelet-config-%d.%d", kubeletVersion.Major(), kubeletVersion.Minor()),
+				KubeletConfigKey: "kubelet",
+			},
+		}
+	}
+
 	if len(c.Spec.MachineNetworks) > 0 {
 		// TODO(mrIncompetent): Rename this finalizer to not contain the word "kubermatic" (For whitelabeling purpose)
 		md.Spec.Template.Annotations = map[string]string{

--- a/api/pkg/test/e2e/api/utils/apiclient/models/node_deployment_spec.go
+++ b/api/pkg/test/e2e/api/utils/apiclient/models/node_deployment_spec.go
@@ -17,6 +17,9 @@ import (
 // swagger:model NodeDeploymentSpec
 type NodeDeploymentSpec struct {
 
+	// dynamic config
+	DynamicConfig bool `json:"dynamicConfig,omitempty"`
+
 	// paused
 	Paused bool `json:"paused,omitempty"`
 


### PR DESCRIPTION
**What this PR does / why we need it**:
An intermediate step towards #3494 . Dynamic kubelet config is experimental, so let's still make it optional.

```release-note
MachineDeployments can now be configured to enable dynamic kubelet config
```
