### PR TITLE
Loki grafana

### DIFF
--- a/config/monitoring/grafana/Chart.yaml
+++ b/config/monitoring/grafana/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: grafana
-version: 1.2.8
+version: 1.2.9
 appVersion: 6.5.2
 description: Grafana for Kubermatic
 keywords:

--- a/config/monitoring/grafana/provisioning/datasources/loki.yaml
+++ b/config/monitoring/grafana/provisioning/datasources/loki.yaml
@@ -19,4 +19,4 @@ datasources:
   url: 'http://{{ $name }}.{{ $ns }}.svc.cluster.local:{{ $port }}'
   version: 1
   editable: false
-{{ end }
+{{ end }}

--- a/config/monitoring/grafana/provisioning/datasources/loki.yaml
+++ b/config/monitoring/grafana/provisioning/datasources/loki.yaml
@@ -1,0 +1,22 @@
+apiVersion: 1
+datasources:
+{{ range .Values.grafana.provisioning.datasources.lokiServices }}
+{{ $name := . }}
+{{ $ns := "logging" }}
+{{ $port := "3100" }}
+{{ if (contains ":" $name) }}
+{{ $port = (split ":" $name)._1 }}
+{{ $name = (split ":" $name)._0 }}
+{{ end }}
+{{ if (contains "." $name) }}
+{{ $ns = (split "." $name)._1 }}
+{{ $name = (split "." $name)._0 }}
+{{ end }}
+- name: {{ $name }}
+  type: loki
+  access: proxy
+  org_id: 1
+  url: 'http://{{ $name }}.{{ $ns }}.svc.cluster.local:{{ $port }}'
+  version: 1
+  editable: false
+{{ end }

--- a/config/monitoring/grafana/values.yaml
+++ b/config/monitoring/grafana/values.yaml
@@ -59,6 +59,8 @@ grafana:
       - prometheus
       # - prometheus-thanos-query:10902
 
+      lokiServices:
+      - loki
       # read datasources from this path in the Helm chart; this is
       # evaluated during deployment, not during Grafana runtime!
       source: provisioning/datasources/*

--- a/config/monitoring/grafana/values.yaml
+++ b/config/monitoring/grafana/values.yaml
@@ -59,8 +59,8 @@ grafana:
       - prometheus
       # - prometheus-thanos-query:10902
 
-      lokiServices:
-      - loki
+      lokiServices: []
+      # - loki
       
       # read datasources from this path in the Helm chart; this is
       # evaluated during deployment, not during Grafana runtime!

--- a/config/monitoring/grafana/values.yaml
+++ b/config/monitoring/grafana/values.yaml
@@ -61,6 +61,7 @@ grafana:
 
       lokiServices:
       - loki
+      
       # read datasources from this path in the Helm chart; this is
       # evaluated during deployment, not during Grafana runtime!
       source: provisioning/datasources/*


### PR DESCRIPTION
**What this PR does / why we need it**:
Implementation of Loki: Loki needs to be added as a datasource in Grafana.
This modifies the currents helm chart for Grafana and creates the Loki datasource yaml file and let Grafana loads it on startup.


**Does this PR introduce a user-facing change?**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
