### PR TITLE
ci-setup-kubermatic-in-kind.sh: checkout corresponding charts when deploying older kubermatic

### DIFF
--- a/api/hack/ci/ci-kind-e2e.sh
+++ b/api/hack/ci/ci-kind-e2e.sh
@@ -19,7 +19,7 @@ if [[ -n ${UPGRADE_TEST_BASE_HASH:-} ]]; then
 fi
 
 echodate "Running conformance tests"
-./api/hack/ci/ci-run-conformance-tester.sh
+CHARTS_VERSION="$KUBERMATIC_VERSION" ./api/hack/ci/ci-run-conformance-tester.sh
 
 # No upgradetest, just exit
 if [[ -z ${UPGRADE_TEST_BASE_HASH:-} ]]; then

--- a/api/hack/ci/ci-setup-kubermatic-in-kind.sh
+++ b/api/hack/ci/ci-setup-kubermatic-in-kind.sh
@@ -331,6 +331,11 @@ if [[ "${KUBERMATIC_USE_OPERATOR}" = "false" ]]; then
   TEST_NAME="Deploy Kubermatic"
   echodate "Deploying Kubermatic using Helm..."
 
+  OLD_HEAD="$(git rev-parse HEAD)"
+  if [[ -n ${CHARTS_VERSION:-} ]]; then
+    git checkout "$CHARTS_VERSION"
+  fi
+
   # --force is needed in case the first attempt at installing didn't succeed
   # see https://github.com/helm/helm/pull/3597
   retry 3 helm upgrade --install --force --wait --timeout 300 \
@@ -362,6 +367,9 @@ if [[ "${KUBERMATIC_USE_OPERATOR}" = "false" ]]; then
     --values ${VALUES_FILE} \
     kubermatic \
     ./config/kubermatic/
+
+  # Return repo to previous state if we checked out older charts before.
+  git checkout ${KUBERMATIC_VERSION}
 else
   # Even when it does not reconcile certificates, the operator absolutely needs the
   # cert-manager CRDs to exist.


### PR DESCRIPTION
```release-note
NONE
```
