### PR TITLE
do not let a single bad Seed prevent listing clusters

### DIFF
--- a/api/cmd/kubermatic-api/main.go
+++ b/api/cmd/kubermatic-api/main.go
@@ -183,7 +183,6 @@ func createInitProviders(options serverRunOptions) (providers, error) {
 		for _, seed := range seeds {
 			if _, err := clusterProviderGetter(seed); err != nil {
 				kubermaticlog.Logger.Infow("failed to get clusterProvider when trying to warm up restMapper cache", zap.Error(err), "seed", seed.Name)
-				continue
 			}
 		}
 	}()

--- a/api/pkg/handler/v1/cluster/cluster.go
+++ b/api/pkg/handler/v1/cluster/cluster.go
@@ -454,9 +454,11 @@ func ListAllEndpoint(projectProvider provider.ProjectProvider, seedsGetter provi
 		}
 
 		for _, seed := range seeds {
+			// if a Seed is bad, do not forward that error to the user, but only log
 			clusterProvider, err := clusterProviderGetter(seed)
 			if err != nil {
-				return nil, common.KubernetesErrorToHTTPError(err)
+				klog.Errorf("failed to create cluster provider for seed %s: %v", seed.Name, err)
+				continue
 			}
 			apiClusters, err := getClusters(clusterProvider, userInfo, projectProvider, req.ProjectID)
 			if err != nil {


### PR DESCRIPTION
**What this PR does / why we need it**:
When a Seed went down, the endpoint for listing clusters in a project would return a HTTP 500 and prevent clusters in other seeds from being listed. This PR changes the behaviour to log-only, like we do in the API's main.go already.

**Which issue(s) this PR fixes**:
Fixes #4950

**Does this PR introduce a user-facing change?**:
```release-note
Fixed a bug that prevented clusters in working seeds from being listed in the dashboard if any other seed was unreachable.
```
