### PR TITLE
Allow using the operator instead of Helm for deploying Kubermatic

### DIFF
--- a/api/hack/ci/ci-deploy-dev.sh
+++ b/api/hack/ci/ci-deploy-dev.sh
@@ -19,15 +19,16 @@ retry 5 vault write \
 export VAULT_TOKEN="$(cat /tmp/vault-token-response.json| jq .auth.client_token -r)"
 export KUBECONFIG=/tmp/kubeconfig
 export VALUES_FILE=/tmp/values.yaml
+export DOCKER_CONFIG=/tmp/dockercfg
 export KUBERMATIC_CONFIG=/tmp/kubermatic.yaml
 
 # deploy to dev
 vault kv get -field=kubeconfig dev/seed-clusters/dev.kubermatic.io > ${KUBECONFIG}
 vault kv get -field=values.yaml dev/seed-clusters/dev.kubermatic.io > ${VALUES_FILE}
+vault kv get -field=.dockerconfigjson dev/seed-clusters/dev.kubermatic.io > ${DOCKER_CONFIG}
 vault kv get -field=kubermatic.yaml dev/seed-clusters/dev.kubermatic.io > ${KUBERMATIC_CONFIG}
 echodate "Successfully got secrets for dev from Vault"
 
 echodate "Deploying ${DEPLOY_STACK} stack to dev"
-TILLER_NAMESPACE=kubermatic-installer \
-  DEPLOY_KUBERMATIC_OPERATOR=true ./api/hack/deploy.sh master ${VALUES_FILE}
+TILLER_NAMESPACE=kubermatic-installer ./api/hack/deploy.sh master ${VALUES_FILE}
 echodate "Successfully deployed ${DEPLOY_STACK} stack to dev"

--- a/api/hack/deploy.sh
+++ b/api/hack/deploy.sh
@@ -23,7 +23,7 @@ fi
 DEPLOY_NODEPORT_PROXY=${DEPLOY_NODEPORT_PROXY:-true}
 DEPLOY_ALERTMANAGER=${DEPLOY_ALERTMANAGER:-true}
 DEPLOY_MINIO=${DEPLOY_MINIO:-true}
-DEPLOY_KUBERMATIC_OPERATOR=${DEPLOY_KUBERMATIC_OPERATOR:-false}
+USE_KUBERMATIC_OPERATOR=${USE_KUBERMATIC_OPERATOR:-false}
 DEPLOY_STACK=${DEPLOY_STACK:-kubermatic}
 TILLER_NAMESPACE=${TILLER_NAMESPACE:-kubermatic}
 HELM_INIT_ARGS=${HELM_INIT_ARGS:-""}
@@ -102,7 +102,7 @@ sed -i "s/__DASHBOARD_TAG__/$LATEST_DASHBOARD/g" ./config/kubermatic/*.yaml
 sed -i "s/__KUBERMATIC_TAG__/${GIT_HEAD_HASH}/g" ./config/kubermatic/*.yaml
 sed -i "s/__KUBERMATIC_TAG__/${GIT_HEAD_HASH}/g" ./config/kubermatic-operator/*.yaml
 sed -i "s/__NAMESPACE__/kubermatic/g" ./config/kubermatic-operator/*.yaml
-sed -i "s/__WORKER_NAME__/kubermatic-operator/g" ./config/kubermatic-operator/*.yaml
+sed -i "s/__WORKER_NAME__//g" ./config/kubermatic-operator/*.yaml
 sed -i "s/__KUBERMATIC_TAG__/${GIT_HEAD_HASH}/g" ./config/nodeport-proxy/*.yaml
 
 echodate "Deploying ${DEPLOY_STACK} stack..."
@@ -166,11 +166,31 @@ case "${DEPLOY_STACK}" in
     fi
 
     # Kubermatic
-    deploy "kubermatic" "kubermatic" ./config/kubermatic/
-
-    if [[ "${DEPLOY_KUBERMATIC_OPERATOR}" = true ]]; then
+    if [[ "${USE_KUBERMATIC_OPERATOR}" = true ]]; then
       echodate "Deploying Kubermatic Operator..."
-      kubectl apply -f ./config/kubermatic-operator/
+
+      DOCKER_CONFIG_SECRET="$(mktemp)"
+      cat <<EOF >$DOCKER_CONFIG_SECRET
+apiVersion: v1
+kind: Secret
+metadata:
+  name: dockercfg
+  namespace: kubermatic
+type: kubernetes.io/dockerconfigjson
+data:
+  .dockerconfigjson: "$(cat "$DOCKER_CONFIG" | base64 -w0)"
+EOF
+      retry 3 kubectl apply -f $DOCKER_CONFIG_SECRET
+      retry 3 kubectl apply -f ./config/kubermatic-operator/
+
+      # only deploy KubermaticConfigurations on masters, on seed clusters
+      # the relevant Seed CR is copied by Kubermatic itself
+      if [ -n "${KUBERMATIC_CONFIG:-}" ]; then
+        echodate "Deploying KubermaticConfiguration..."
+        retry 3 kubectl apply -f $KUBERMATIC_CONFIG
+      fi
+    else
+      deploy "kubermatic" "kubermatic" ./config/kubermatic/
     fi
     ;;
 esac

--- a/config/kubermatic-operator/deployment.yaml
+++ b/config/kubermatic-operator/deployment.yaml
@@ -21,6 +21,8 @@ spec:
         fluentbit.io/parser: json_iso
     spec:
       serviceAccountName: kubermatic-operator
+      imagePullSecrets:
+      - name: dockercfg
       containers:
       - name: operator
         image: 'quay.io/kubermatic/api:__KUBERMATIC_TAG__'


### PR DESCRIPTION
**What this PR does / why we need it**:
Until now we had the operator installed in parallel to the Helm chart, with the Helm chart being the main attraction. This PR changes the behaviour to use the operator **instead of** Helm when `USE_KUBERMATIC_OPERATOR=true` is set. The flag is not yet switched because all hell would break loose when the installation is not properly, manually prepared.

**Which issue(s) this PR fixes**:
Relates to #4728

**Does this PR introduce a user-facing change?**:
```release-note
NONE
```
