### PR TITLE
Add utility to convert Helm values.yaml to KubermaticConfiguration

### DIFF
--- a/api/cmd/kubermatic-operator-util/README.md
+++ b/api/cmd/kubermatic-operator-util/README.md
@@ -1,0 +1,4 @@
+# Kubermatic Operator Utility
+
+This apps provides additional tools for managing the Kubermatic
+Operator.

--- a/api/cmd/kubermatic-operator-util/main.go
+++ b/api/cmd/kubermatic-operator-util/main.go
@@ -1,0 +1,103 @@
+package main
+
+import (
+	"fmt"
+	"io/ioutil"
+	"os"
+
+	"github.com/urfave/cli"
+	"go.uber.org/zap"
+	"sigs.k8s.io/yaml"
+
+	"github.com/kubermatic/kubermatic/api/pkg/controller/operator/conversion"
+	operatorv1alpha1 "github.com/kubermatic/kubermatic/api/pkg/crd/operator/v1alpha1"
+	"github.com/kubermatic/kubermatic/api/pkg/log"
+)
+
+var logger *zap.SugaredLogger
+
+func main() {
+	app := cli.NewApp()
+	app.Name = "Kubermatic Operator Utility"
+	app.Version = "v1.0.0"
+
+	defaultLogFormat := log.FormatConsole
+
+	app.Flags = []cli.Flag{
+		cli.BoolFlag{
+			Name:  "log-debug",
+			Usage: "Enables more verbose logging",
+		},
+		cli.GenericFlag{
+			Name:  "log-format",
+			Value: &defaultLogFormat,
+			Usage: fmt.Sprintf("Use one of [%v] to change the log output", log.AvailableFormats),
+		},
+	}
+
+	app.Commands = []cli.Command{
+		{
+			Name:      "convert",
+			Usage:     "Convert a Helm values.yaml to a KubermaticConfiguration manifest (YAML)",
+			Action:    convertAction,
+			ArgsUsage: "VALUES_FILE",
+		},
+	}
+
+	// setup logging
+	app.Before = func(c *cli.Context) error {
+		format := c.GlobalGeneric("log-format").(*log.Format)
+		rawLog := log.New(c.GlobalBool("log-debug"), *format)
+		logger = rawLog.Sugar()
+
+		return nil
+	}
+
+	err := app.Run(os.Args)
+	// Only log failures when the logger has been setup, otherwise
+	// we know it's been a CLI parsing failure and the cli package
+	// has already output the error and printed the usage hints.
+	if err != nil && logger != nil {
+		logger.Fatalw("Failed to run command", zap.Error(err))
+	}
+}
+
+func convertAction(ctx *cli.Context) error {
+	valuesFile := ctx.Args().First()
+	if valuesFile == "" {
+		return cli.NewExitError("no values.yaml file given", 2)
+	}
+
+	var (
+		content []byte
+		err     error
+	)
+
+	if valuesFile == "-" {
+		content, err = ioutil.ReadAll(os.Stdin)
+	} else {
+		content, err = ioutil.ReadFile(valuesFile)
+	}
+	if err != nil {
+		return cli.NewExitError(fmt.Errorf("failed to read '%s': %v", valuesFile, err), 1)
+	}
+
+	config, err := conversion.HelmValuesFileToKubermaticConfiguration(content)
+	if err != nil {
+		return cli.NewExitError(err, 1)
+	}
+
+	config.APIVersion = operatorv1alpha1.SchemeGroupVersion.String()
+	config.Kind = "KubermaticConfiguration"
+	config.Name = "kubermatic"
+	config.Namespace = "kubermatic"
+
+	output, err := yaml.Marshal(config)
+	if err != nil {
+		return cli.NewExitError(err, 1)
+	}
+
+	fmt.Print(string(output))
+
+	return nil
+}

--- a/api/pkg/controller/operator/common/defaults.go
+++ b/api/pkg/controller/operator/common/defaults.go
@@ -17,20 +17,21 @@ import (
 )
 
 const (
-	defaultPProfEndpoint               = ":6600"
-	defaultNodePortRange               = "30000-32767"
-	defaultEtcdVolumeSize              = "5Gi"
-	defaultAuthClientID                = "kubermatic"
-	defaultIngressClass                = "nginx"
-	defaultAPIReplicas                 = 2
-	defaultUIReplicas                  = 1
-	defaultSeedControllerMgrReplicas   = 2
-	defaultMasterControllerMgrReplicas = 2
-	defaultAPIServerReplicas           = 2
+	DefaultPProfEndpoint               = ":6600"
+	DefaultNodePortRange               = "30000-32767"
+	DefaultEtcdVolumeSize              = "5Gi"
+	DefaultAuthClientID                = "kubermatic"
+	DefaultIngressClass                = "nginx"
+	DefaultAPIReplicas                 = 2
+	DefaultUIReplicas                  = 2
+	DefaultSeedControllerMgrReplicas   = 2
+	DefaultMasterControllerMgrReplicas = 2
+	DefaultAPIServerReplicas           = 2
+	DefaultExposeStrategy              = operatorv1alpha1.NodePortStrategy
 )
 
 var (
-	kubernetesDefaultAddons = []string{
+	KubernetesDefaultAddons = []string{
 		"canal",
 		"csi",
 		"dns",
@@ -44,11 +45,11 @@ var (
 		"logrotate",
 	}
 
-	defaultAccessibleAddons = []string{
+	DefaultAccessibleAddons = []string{
 		"node-exporter",
 	}
 
-	defaultUIResources = corev1.ResourceRequirements{
+	DefaultUIResources = corev1.ResourceRequirements{
 		Requests: corev1.ResourceList{
 			corev1.ResourceCPU:    resource.MustParse("100m"),
 			corev1.ResourceMemory: resource.MustParse("64Mi"),
@@ -59,7 +60,7 @@ var (
 		},
 	}
 
-	defaultAPIResources = corev1.ResourceRequirements{
+	DefaultAPIResources = corev1.ResourceRequirements{
 		Requests: corev1.ResourceList{
 			corev1.ResourceCPU:    resource.MustParse("100m"),
 			corev1.ResourceMemory: resource.MustParse("512Mi"),
@@ -70,7 +71,7 @@ var (
 		},
 	}
 
-	defaultMasterControllerMgrResources = corev1.ResourceRequirements{
+	DefaultMasterControllerMgrResources = corev1.ResourceRequirements{
 		Requests: corev1.ResourceList{
 			corev1.ResourceCPU:    resource.MustParse("50m"),
 			corev1.ResourceMemory: resource.MustParse("128Mi"),
@@ -81,7 +82,7 @@ var (
 		},
 	}
 
-	defaultSeedControllerMgrResources = corev1.ResourceRequirements{
+	DefaultSeedControllerMgrResources = corev1.ResourceRequirements{
 		Requests: corev1.ResourceList{
 			corev1.ResourceCPU:    resource.MustParse("200m"),
 			corev1.ResourceMemory: resource.MustParse("512Mi"),
@@ -99,82 +100,82 @@ func DefaultConfiguration(config *operatorv1alpha1.KubermaticConfiguration, logg
 	copy := config.DeepCopy()
 
 	if copy.Spec.ExposeStrategy == "" {
-		copy.Spec.ExposeStrategy = operatorv1alpha1.NodePortStrategy
+		copy.Spec.ExposeStrategy = DefaultExposeStrategy
 		logger.Debugw("Defaulting field", "field", "exposeStrategy", "value", copy.Spec.ExposeStrategy)
 	}
 
 	if copy.Spec.SeedController.BackupStoreContainer == "" {
-		copy.Spec.SeedController.BackupStoreContainer = strings.TrimSpace(defaultBackupStoreContainer)
+		copy.Spec.SeedController.BackupStoreContainer = strings.TrimSpace(DefaultBackupStoreContainer)
 		logger.Debugw("Defaulting field", "field", "seedController.backupStoreContainer")
 	}
 
 	if copy.Spec.SeedController.BackupCleanupContainer == "" {
-		copy.Spec.SeedController.BackupCleanupContainer = strings.TrimSpace(defaultBackupCleanupContainer)
+		copy.Spec.SeedController.BackupCleanupContainer = strings.TrimSpace(DefaultBackupCleanupContainer)
 		logger.Debugw("Defaulting field", "field", "seedController.backupCleanupContainer")
 	}
 
 	if copy.Spec.SeedController.Replicas == nil {
-		copy.Spec.SeedController.Replicas = pointer.Int32Ptr(defaultSeedControllerMgrReplicas)
+		copy.Spec.SeedController.Replicas = pointer.Int32Ptr(DefaultSeedControllerMgrReplicas)
 		logger.Debugw("Defaulting field", "field", "seedController.replicas", "value", *copy.Spec.SeedController.Replicas)
 	}
 
 	if copy.Spec.API.PProfEndpoint == nil {
-		copy.Spec.API.PProfEndpoint = pointer.StringPtr(defaultPProfEndpoint)
+		copy.Spec.API.PProfEndpoint = pointer.StringPtr(DefaultPProfEndpoint)
 		logger.Debugw("Defaulting field", "field", "api.pprofEndpoint", "value", *copy.Spec.API.PProfEndpoint)
 	}
 
 	if copy.Spec.SeedController.PProfEndpoint == nil {
-		copy.Spec.SeedController.PProfEndpoint = pointer.StringPtr(defaultPProfEndpoint)
+		copy.Spec.SeedController.PProfEndpoint = pointer.StringPtr(DefaultPProfEndpoint)
 		logger.Debugw("Defaulting field", "field", "seedController.pprofEndpoint", "value", *copy.Spec.SeedController.PProfEndpoint)
 	}
 
 	if copy.Spec.MasterController.PProfEndpoint == nil {
-		copy.Spec.MasterController.PProfEndpoint = pointer.StringPtr(defaultPProfEndpoint)
+		copy.Spec.MasterController.PProfEndpoint = pointer.StringPtr(DefaultPProfEndpoint)
 		logger.Debugw("Defaulting field", "field", "masterController.pprofEndpoint", "value", *copy.Spec.MasterController.PProfEndpoint)
 	}
 
 	if copy.Spec.MasterController.Replicas == nil {
-		copy.Spec.MasterController.Replicas = pointer.Int32Ptr(defaultMasterControllerMgrReplicas)
+		copy.Spec.MasterController.Replicas = pointer.Int32Ptr(DefaultMasterControllerMgrReplicas)
 		logger.Debugw("Defaulting field", "field", "masterController.replicas", "value", *copy.Spec.MasterController.Replicas)
 	}
 
 	if len(copy.Spec.UserCluster.Addons.Kubernetes.Default) == 0 && copy.Spec.UserCluster.Addons.Kubernetes.DefaultManifests == "" {
-		copy.Spec.UserCluster.Addons.Kubernetes.Default = kubernetesDefaultAddons
+		copy.Spec.UserCluster.Addons.Kubernetes.Default = KubernetesDefaultAddons
 		logger.Debugw("Defaulting field", "field", "userCluster.addons.kubernetes.default", "value", copy.Spec.UserCluster.Addons.Kubernetes.Default)
 	}
 
 	if len(copy.Spec.UserCluster.Addons.Openshift.Default) == 0 && copy.Spec.UserCluster.Addons.Openshift.DefaultManifests == "" {
-		copy.Spec.UserCluster.Addons.Openshift.DefaultManifests = strings.TrimSpace(defaultOpenshiftAddons)
+		copy.Spec.UserCluster.Addons.Openshift.DefaultManifests = strings.TrimSpace(DefaultOpenshiftAddons)
 		logger.Debugw("Defaulting field", "field", "userCluster.Addons.Openshift.DefaultManifests")
 	}
 
 	if copy.Spec.UserCluster.APIServerReplicas == nil {
-		copy.Spec.UserCluster.APIServerReplicas = pointer.Int32Ptr(defaultAPIServerReplicas)
+		copy.Spec.UserCluster.APIServerReplicas = pointer.Int32Ptr(DefaultAPIServerReplicas)
 		logger.Debugw("Defaulting field", "field", "userCluster.apiserverReplicas", "value", *copy.Spec.UserCluster.APIServerReplicas)
 	}
 
 	if len(copy.Spec.API.AccessibleAddons) == 0 {
-		copy.Spec.API.AccessibleAddons = defaultAccessibleAddons
+		copy.Spec.API.AccessibleAddons = DefaultAccessibleAddons
 		logger.Debugw("Defaulting field", "field", "api.accessibleAddons", "value", copy.Spec.API.AccessibleAddons)
 	}
 
 	if copy.Spec.API.Replicas == nil {
-		copy.Spec.API.Replicas = pointer.Int32Ptr(defaultAPIReplicas)
+		copy.Spec.API.Replicas = pointer.Int32Ptr(DefaultAPIReplicas)
 		logger.Debugw("Defaulting field", "field", "api.replicas", "value", *copy.Spec.API.Replicas)
 	}
 
 	if copy.Spec.UserCluster.NodePortRange == "" {
-		copy.Spec.UserCluster.NodePortRange = defaultNodePortRange
+		copy.Spec.UserCluster.NodePortRange = DefaultNodePortRange
 		logger.Debugw("Defaulting field", "field", "userCluster.nodePortRange", "value", copy.Spec.UserCluster.NodePortRange)
 	}
 
 	if copy.Spec.UserCluster.EtcdVolumeSize == "" {
-		copy.Spec.UserCluster.EtcdVolumeSize = defaultEtcdVolumeSize
+		copy.Spec.UserCluster.EtcdVolumeSize = DefaultEtcdVolumeSize
 		logger.Debugw("Defaulting field", "field", "userCluster.etcdVolumeSize", "value", copy.Spec.UserCluster.EtcdVolumeSize)
 	}
 
 	if copy.Spec.Ingress.ClassName == "" {
-		copy.Spec.Ingress.ClassName = defaultIngressClass
+		copy.Spec.Ingress.ClassName = DefaultIngressClass
 		logger.Debugw("Defaulting field", "field", "ingress.className", "value", copy.Spec.Ingress.ClassName)
 	}
 
@@ -187,12 +188,12 @@ func DefaultConfiguration(config *operatorv1alpha1.KubermaticConfiguration, logg
 	}
 
 	if copy.Spec.UI.Config == "" {
-		copy.Spec.UI.Config = strings.TrimSpace(defaultUIConfig)
+		copy.Spec.UI.Config = strings.TrimSpace(DefaultUIConfig)
 		logger.Debugw("Defaulting field", "field", "ui.config", "value", copy.Spec.UI.Config)
 	}
 
 	if copy.Spec.UI.Replicas == nil {
-		copy.Spec.UI.Replicas = pointer.Int32Ptr(defaultUIReplicas)
+		copy.Spec.UI.Replicas = pointer.Int32Ptr(DefaultUIReplicas)
 		logger.Debugw("Defaulting field", "field", "ui.replicas", "value", *copy.Spec.UI.Replicas)
 	}
 
@@ -201,19 +202,19 @@ func DefaultConfiguration(config *operatorv1alpha1.KubermaticConfiguration, logg
 	}
 
 	if copy.Spec.MasterFiles["versions.yaml"] == "" {
-		copy.Spec.MasterFiles["versions.yaml"] = strings.TrimSpace(defaultVersionsYAML)
+		copy.Spec.MasterFiles["versions.yaml"] = strings.TrimSpace(DefaultVersionsYAML)
 		logger.Debugw("Defaulting field", "field", "masterFiles.'versions.yaml'")
 	}
 
 	if copy.Spec.MasterFiles["updates.yaml"] == "" {
-		copy.Spec.MasterFiles["updates.yaml"] = strings.TrimSpace(defaultUpdatesYAML)
+		copy.Spec.MasterFiles["updates.yaml"] = strings.TrimSpace(DefaultUpdatesYAML)
 		logger.Debugw("Defaulting field", "field", "masterFiles.'updates.yaml'")
 	}
 
 	auth := copy.Spec.Auth
 
 	if auth.ClientID == "" {
-		auth.ClientID = defaultAuthClientID
+		auth.ClientID = DefaultAuthClientID
 		logger.Debugw("Defaulting field", "field", "auth.clientID", "value", auth.ClientID)
 	}
 
@@ -266,19 +267,19 @@ func DefaultConfiguration(config *operatorv1alpha1.KubermaticConfiguration, logg
 		return copy, err
 	}
 
-	if err := defaultResources(&copy.Spec.UI.Resources, defaultUIResources, "ui.resources", logger); err != nil {
+	if err := defaultResources(&copy.Spec.UI.Resources, DefaultUIResources, "ui.resources", logger); err != nil {
 		return copy, err
 	}
 
-	if err := defaultResources(&copy.Spec.API.Resources, defaultAPIResources, "api.resources", logger); err != nil {
+	if err := defaultResources(&copy.Spec.API.Resources, DefaultAPIResources, "api.resources", logger); err != nil {
 		return copy, err
 	}
 
-	if err := defaultResources(&copy.Spec.SeedController.Resources, defaultSeedControllerMgrResources, "seedController.resources", logger); err != nil {
+	if err := defaultResources(&copy.Spec.SeedController.Resources, DefaultSeedControllerMgrResources, "seedController.resources", logger); err != nil {
 		return copy, err
 	}
 
-	if err := defaultResources(&copy.Spec.MasterController.Resources, defaultMasterControllerMgrResources, "masterController.resources", logger); err != nil {
+	if err := defaultResources(&copy.Spec.MasterController.Resources, DefaultMasterControllerMgrResources, "masterController.resources", logger); err != nil {
 		return copy, err
 	}
 
@@ -337,7 +338,7 @@ func defaultResourceList(list *corev1.ResourceList, defaults corev1.ResourceList
 	return nil
 }
 
-const defaultBackupStoreContainer = `
+const DefaultBackupStoreContainer = `
 name: store-container
 image: quay.io/kubermatic/s3-storer:v0.1.4
 command:
@@ -363,7 +364,7 @@ volumeMounts:
   mountPath: /backup
 `
 
-const defaultBackupCleanupContainer = `
+const DefaultBackupCleanupContainer = `
 name: cleanup-container
 image: quay.io/kubermatic/s3-storer:v0.1.4
 command:
@@ -385,12 +386,12 @@ env:
       key: SECRET_ACCESS_KEY
 `
 
-const defaultUIConfig = `
+const DefaultUIConfig = `
 {
   "share_kubeconfig": false
 }`
 
-const defaultVersionsYAML = `
+const DefaultVersionsYAML = `
 versions:
 # Kubernetes 1.14
 - version: "v1.14.8"
@@ -420,7 +421,7 @@ versions:
   type: "openshift"
 `
 
-const defaultUpdatesYAML = `
+const DefaultUpdatesYAML = `
 ### Updates file
 #
 # Contains a list of allowed updated
@@ -520,7 +521,7 @@ updates:
   type: openshift
 `
 
-const defaultOpenshiftAddons = `
+const DefaultOpenshiftAddons = `
 apiVersion: v1
 kind: List
 items:

--- a/api/pkg/controller/operator/common/defaults_test.go
+++ b/api/pkg/controller/operator/common/defaults_test.go
@@ -45,7 +45,7 @@ func TestKubernetesDefaultAddonsMatchesChart(t *testing.T) {
 	if err != nil {
 		t.Fatalf("jsonpathValueFromChart: %v", err)
 	}
-	expected := fmt.Sprintf("%v", kubernetesDefaultAddons)
+	expected := fmt.Sprintf("%v", KubernetesDefaultAddons)
 	actual := fmt.Sprintf("%v", fromChart)
 	if actual != expected {
 		t.Errorf("kubernetes default addons in the chart (%s) do not match operator defaults (%s)", actual, expected)
@@ -59,7 +59,7 @@ func TestDefaultAccessibleAddonsMatchChart(t *testing.T) {
 		t.Fatalf("jsonpathValueFromChart: %v", err)
 	}
 
-	expected := fmt.Sprintf("%v", defaultAccessibleAddons)
+	expected := fmt.Sprintf("%v", DefaultAccessibleAddons)
 	actual := fmt.Sprintf("%v", fromChart)
 	if actual != expected {
 		t.Errorf("defaultAccessibleAddons from chart (%s) do not match operator defaults (%s)", actual, expected)
@@ -72,7 +72,7 @@ func TestDefaultBackupStoreContainerMatchesChart(t *testing.T) {
 	if err != nil {
 		t.Fatalf("failed to read backupstorecontainer from disk: %v", err)
 	}
-	if diff := getStringDiff(string(fromChart), defaultBackupStoreContainer); diff != nil {
+	if diff := getStringDiff(string(fromChart), DefaultBackupStoreContainer); diff != nil {
 		t.Errorf("backupcontainer from chart does not match default from operator, diff: %v", diff)
 	}
 }
@@ -83,7 +83,7 @@ func TestDefaultBackupCleanupContainerMatchesChart(t *testing.T) {
 	if err != nil {
 		t.Fatalf("failed to read backupcleanupcontainer from disk: %v", err)
 	}
-	if diff := getStringDiff(string(fromChart), defaultBackupCleanupContainer); diff != nil {
+	if diff := getStringDiff(string(fromChart), DefaultBackupCleanupContainer); diff != nil {
 		t.Errorf("backupcontainer from chart does not match default from operator, diff: %v", diff)
 	}
 }
@@ -94,7 +94,7 @@ func TestDefaultUIConfigMatchesChart(t *testing.T) {
 	if err != nil {
 		t.Fatalf("jsonpathValueFromChart: %v", err)
 	}
-	if diff := getStringDiff(fmt.Sprintf("%v", fromChart), defaultUIConfig); diff != nil {
+	if diff := getStringDiff(fmt.Sprintf("%v", fromChart), DefaultUIConfig); diff != nil {
 		t.Errorf("defaultUIConfig from chart does not match default from operator, diff: %v", err)
 	}
 }
@@ -105,7 +105,7 @@ func TestDefaultVersionsYAMLMatchesChart(t *testing.T) {
 	if err != nil {
 		t.Fatalf("failed to read versions from disk: %v", err)
 	}
-	if diff := getStringDiff(string(fromChart), defaultVersionsYAML); diff != nil {
+	if diff := getStringDiff(string(fromChart), DefaultVersionsYAML); diff != nil {
 		t.Errorf("versions.yaml from chart does not match default from operator, diff: %v", diff)
 	}
 }
@@ -116,7 +116,7 @@ func TestDefaultUpdatesYAMLMatchesChart(t *testing.T) {
 	if err != nil {
 		t.Fatalf("failed to read versions from disk: %v", err)
 	}
-	if diff := getStringDiff(string(fromChart), defaultUpdatesYAML); diff != nil {
+	if diff := getStringDiff(string(fromChart), DefaultUpdatesYAML); diff != nil {
 		t.Errorf("updates.yaml from chart does not match default from operator, diff: %v", diff)
 	}
 }
@@ -127,7 +127,7 @@ func TestDefaultOpenshiftAddonsMatchesChart(t *testing.T) {
 	if err != nil {
 		t.Fatalf("failed to read versions from disk: %v", err)
 	}
-	if diff := getStringDiff(string(fromChart), defaultOpenshiftAddons); diff != nil {
+	if diff := getStringDiff(string(fromChart), DefaultOpenshiftAddons); diff != nil {
 		t.Errorf("openshift-addons.yaml from chart does not match default from operator, diff: %v", diff)
 	}
 }

--- a/api/pkg/controller/operator/conversion/helm.go
+++ b/api/pkg/controller/operator/conversion/helm.go
@@ -1,0 +1,454 @@
+package conversion
+
+import (
+	"encoding/base64"
+	"fmt"
+	"strconv"
+	"strings"
+
+	"github.com/kubermatic/kubermatic/api/pkg/controller/operator/common"
+	operatorv1alpha1 "github.com/kubermatic/kubermatic/api/pkg/crd/operator/v1alpha1"
+	"github.com/kubermatic/kubermatic/api/pkg/features"
+	"github.com/kubermatic/kubermatic/api/pkg/resources"
+
+	certmanagerv1alpha2 "github.com/jetstack/cert-manager/pkg/apis/certmanager/v1alpha2"
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/util/sets"
+	"k8s.io/utils/pointer"
+	"sigs.k8s.io/yaml"
+)
+
+type dockerImage struct {
+	Repository string `yaml:"repository"`
+	Tag        string `yaml:"tag"`
+	PullPolicy string `yaml:"pullPolicy"`
+}
+
+type addonValues struct {
+	DefaultAddons     []string    `yaml:"defaultAddons"`
+	DefaultAddonsFile string      `yaml:"defaultAddonsFile"`
+	Image             dockerImage `yaml:"image"`
+}
+
+type helmValues struct {
+	Kubermatic kubermaticValues `yaml:"kubermatic"`
+}
+
+type kubermaticValues struct {
+	ImagePullSecretData string `yaml:"imagePullSecretData"`
+	Auth                struct {
+		ClientID                 string `yaml:"clientID"`
+		TokenIssuer              string `yaml:"tokenIssuer"`
+		IssuerRedirectURL        string `yaml:"issuerRedirectURL"`
+		IssuerClientID           string `yaml:"issuerClientID"`
+		IssuerClientSecret       string `yaml:"issuerClientSecret"`
+		IssuerCookieKey          string `yaml:"issuerCookieKey"`
+		CABundle                 string `yaml:"caBundle"`
+		SkipTokenIssuerTLSVerify string `yaml:"skipTokenIssuerTLSVerify"`
+		ServiceAccountKey        string `yaml:"serviceAccountKey"`
+	} `yaml:"auth"`
+	Datacenters                          string  `yaml:"datacenters"`
+	Domain                               string  `yaml:"domain"`
+	Kubeconfig                           string  `yaml:"kubeconfig"`
+	MonitoringScrapeAnnotationPrefix     string  `yaml:"monitoringScrapeAnnotationPrefix"`
+	KubermaticImage                      string  `yaml:"kubermaticImage"`
+	DNATControllerImage                  string  `yaml:"dnatControllerImage"`
+	ExposeStrategy                       string  `yaml:"exposeStrategy"`
+	Presets                              string  `yaml:"presets"`
+	APIServerDefaultReplicas             *string `yaml:"apiserverDefaultReplicas"`
+	ControllerManagerDefaultReplicas     *string `yaml:"controllerManagerDefaultReplicas"`
+	SchedulerDefaultReplicas             *string `yaml:"schedulerDefaultReplicas"`
+	MaxParallelReconcile                 string  `yaml:"maxParallelReconcile"`
+	APIServerEndpointReconcilingDisabled bool    `yaml:"apiserverEndpointReconcilingDisabled"`
+	DynamicDatacenters                   bool    `yaml:"dynamicDatacenters"`
+	DynamicPresets                       bool    `yaml:"dynamicPresets"`
+	Etcd                                 struct {
+		DiskSize string `yaml:"diskSize"`
+	} `yaml:"etcd"`
+	Controller struct {
+		FeatureGates   string      `yaml:"featureGates"`
+		DatacenterName string      `yaml:"datacenterName"`
+		NodeportRange  string      `yaml:"nodeportRange"`
+		Replicas       *string     `yaml:"replicas"`
+		Image          dockerImage `yaml:"image"`
+		PProfEndpoint  string      `yaml:"pprofEndpoint"`
+		Addons         struct {
+			Kubernetes addonValues `yaml:"kubernetes"`
+			Openshift  addonValues `yaml:"openshift"`
+		} `yaml:"addons"`
+		OverwriteRegistry string                      `yaml:"overwriteRegistry"`
+		WorkerCount       int                         `yaml:"workerCount"`
+		Resources         corev1.ResourceRequirements `yaml:"resources"`
+	} `yaml:"controller"`
+	API struct {
+		FeatureGates     string                      `yaml:"featureGates"`
+		Replicas         *string                     `yaml:"replicas"`
+		AccessibleAddons []string                    `yaml:"accessibleAddons"`
+		Image            dockerImage                 `yaml:"image"`
+		PProfEndpoint    string                      `yaml:"pprofEndpoint"`
+		Resources        corev1.ResourceRequirements `yaml:"resources"`
+	} `yaml:"api"`
+	UI struct {
+		Replicas  *string                     `yaml:"replicas"`
+		Image     dockerImage                 `yaml:"image"`
+		Config    string                      `yaml:"config"`
+		Resources corev1.ResourceRequirements `yaml:"resources"`
+	} `yaml:"ui"`
+	MasterController struct {
+		Replicas      *string                     `yaml:"replicas"`
+		Image         dockerImage                 `yaml:"image"`
+		DebugLog      bool                        `yaml:"debugLog"`
+		PProfEndpoint string                      `yaml:"pprofEndpoint"`
+		WorkerCount   int                         `yaml:"workerCount"`
+		Resources     corev1.ResourceRequirements `yaml:"resources"`
+	} `yaml:"masterController"`
+	StoreContainer             string `yaml:"storeContainer"`
+	CleanupContainer           string `yaml:"cleanupContainer"`
+	ClusterNamespacePrometheus struct {
+		DisableDefaultScrapingConfigs bool          `yaml:"disableDefaultScrapingConfigs"`
+		ScrapingConfigs               []interface{} `yaml:"scrapingConfigs"`
+		DisableDefaultRules           bool          `yaml:"disableDefaultRules"`
+		Rules                         interface{}   `yaml:"rules"`
+	} `yaml:"clusterNamespacePrometheus"`
+}
+
+func HelmValuesFileToKubermaticConfiguration(yamlContent []byte) (*operatorv1alpha1.KubermaticConfiguration, error) {
+	values := helmValues{}
+	if err := yaml.Unmarshal(yamlContent, &values); err != nil {
+		return nil, fmt.Errorf("failed to decode file: %v", err)
+	}
+
+	config := operatorv1alpha1.KubermaticConfiguration{}
+	config.Spec.Ingress.Domain = values.Kubermatic.Domain
+
+	// This is not actually the default, but anyone running our current stack has the
+	// most recent cert-manager chart installed, which provides this ClusterIssuer by
+	// default.
+	config.Spec.Ingress.CertificateIssuer.Name = "letsencrypt-prod"
+	config.Spec.Ingress.CertificateIssuer.Kind = certmanagerv1alpha2.ClusterIssuerKind
+
+	if values.Kubermatic.ExposeStrategy != "" && values.Kubermatic.ExposeStrategy != string(common.DefaultExposeStrategy) {
+		allowed := sets.NewString(string(operatorv1alpha1.NodePortStrategy), string(operatorv1alpha1.LoadBalancerStrategy))
+
+		if !allowed.Has(values.Kubermatic.ExposeStrategy) {
+			return nil, fmt.Errorf("invalid expose strategy '%s', choose one of %v", values.Kubermatic.ExposeStrategy, allowed.List())
+		}
+
+		config.Spec.ExposeStrategy = operatorv1alpha1.ExposeStrategy(values.Kubermatic.ExposeStrategy)
+	}
+
+	pullSecret, err := base64.StdEncoding.DecodeString(values.Kubermatic.ImagePullSecretData)
+	if err != nil {
+		return &config, fmt.Errorf("invalid imagePullSecretData: %v", err)
+	}
+	config.Spec.ImagePullSecret = string(pullSecret)
+
+	auth, err := convertAuth(&values.Kubermatic)
+	if err != nil {
+		return &config, fmt.Errorf("invalid auth section: %v", err)
+	}
+	config.Spec.Auth = *auth
+
+	featureGates, err := convertFeatureGates(&values.Kubermatic)
+	if err != nil {
+		return &config, fmt.Errorf("invalid feature gates: %v", err)
+	}
+	config.Spec.FeatureGates = featureGates
+
+	api, err := convertAPI(&values.Kubermatic)
+	if err != nil {
+		return &config, fmt.Errorf("invalid API section: %v", err)
+	}
+	config.Spec.API = *api
+
+	seedController, err := convertSeedController(&values.Kubermatic)
+	if err != nil {
+		return &config, fmt.Errorf("invalid seedController section: %v", err)
+	}
+	config.Spec.SeedController = *seedController
+
+	userCluster, err := convertUserCluster(&values.Kubermatic)
+	if err != nil {
+		// the "seedController" in the error msg is not a typo
+		return &config, fmt.Errorf("invalid seedController section: %v", err)
+	}
+	config.Spec.UserCluster = *userCluster
+
+	masterController, err := convertMasterController(&values.Kubermatic)
+	if err != nil {
+		return &config, fmt.Errorf("invalid masterController section: %v", err)
+	}
+	config.Spec.MasterController = *masterController
+
+	ui, err := convertUI(&values.Kubermatic)
+	if err != nil {
+		return &config, fmt.Errorf("invalid UI section: %v", err)
+	}
+	config.Spec.UI = *ui
+
+	return &config, nil
+}
+
+func convertAuth(values *kubermaticValues) (*operatorv1alpha1.KubermaticAuthConfiguration, error) {
+	effectiveClientID := values.Auth.ClientID
+	if effectiveClientID == "" {
+		effectiveClientID = common.DefaultAuthClientID
+	}
+
+	caBundle, err := base64.StdEncoding.DecodeString(values.Auth.CABundle)
+	if err != nil {
+		return nil, fmt.Errorf("invalid CA bundle: %v", err)
+	}
+
+	return &operatorv1alpha1.KubermaticAuthConfiguration{
+		ClientID:                 strIfChanged(values.Auth.ClientID, common.DefaultAuthClientID),
+		TokenIssuer:              strIfChanged(values.Auth.TokenIssuer, fmt.Sprintf("https://%s/dex", values.Domain)),
+		IssuerClientID:           strIfChanged(values.Auth.IssuerClientID, fmt.Sprintf("%sIssuer", effectiveClientID)),
+		IssuerRedirectURL:        strIfChanged(values.Auth.IssuerRedirectURL, fmt.Sprintf("https://%s/api/v1/kubeconfig", values.Domain)),
+		IssuerClientSecret:       values.Auth.IssuerClientSecret,
+		IssuerCookieKey:          values.Auth.IssuerCookieKey,
+		CABundle:                 string(caBundle),
+		SkipTokenIssuerTLSVerify: values.Auth.SkipTokenIssuerTLSVerify == "true",
+		ServiceAccountKey:        values.Auth.ServiceAccountKey,
+	}, nil
+}
+
+func convertAPI(values *kubermaticValues) (*operatorv1alpha1.KubermaticAPIConfiguration, error) {
+	replicas, err := getReplicas(values.API.Replicas, common.DefaultAPIReplicas)
+	if err != nil {
+		return nil, fmt.Errorf("invalid replicas: %v", err)
+	}
+
+	return &operatorv1alpha1.KubermaticAPIConfiguration{
+		DockerRepository: strIfChanged(values.API.Image.Repository, resources.DefaultKubermaticImage),
+		AccessibleAddons: values.API.AccessibleAddons,
+		PProfEndpoint:    getPProfEndpoint(values.API.PProfEndpoint),
+		Replicas:         replicas,
+		Resources:        convertResources(values.API.Resources, common.DefaultAPIResources),
+	}, nil
+}
+
+func convertSeedController(values *kubermaticValues) (*operatorv1alpha1.KubermaticSeedControllerConfiguration, error) {
+	replicas, err := getReplicas(values.Controller.Replicas, common.DefaultSeedControllerMgrReplicas)
+	if err != nil {
+		return nil, fmt.Errorf("invalid replicas: %v", err)
+	}
+
+	storeContainer := strings.TrimSpace(values.StoreContainer)
+	if storeContainer == strings.TrimSpace(common.DefaultBackupStoreContainer) {
+		storeContainer = ""
+	}
+
+	cleanupContainer := strings.TrimSpace(values.CleanupContainer)
+	if cleanupContainer == strings.TrimSpace(common.DefaultBackupCleanupContainer) {
+		cleanupContainer = ""
+	}
+
+	return &operatorv1alpha1.KubermaticSeedControllerConfiguration{
+		DockerRepository:       strIfChanged(values.Controller.Image.Repository, resources.DefaultKubermaticImage),
+		BackupStoreContainer:   storeContainer,
+		BackupCleanupContainer: cleanupContainer,
+		PProfEndpoint:          getPProfEndpoint(values.Controller.PProfEndpoint),
+		Replicas:               replicas,
+		Resources:              convertResources(values.Controller.Resources, common.DefaultSeedControllerMgrResources),
+	}, nil
+}
+
+func convertUserCluster(values *kubermaticValues) (*operatorv1alpha1.KubermaticUserClusterConfiguration, error) {
+	kubernetesAddonCfg, err := convertAddonConfig(&values.Controller.Addons.Kubernetes, common.KubernetesAddonsFileName, resources.DefaultKubernetesAddonImage)
+	if err != nil {
+		return nil, fmt.Errorf("invalid kubernetes addons: %v", err)
+	}
+
+	openshiftAddonCfg, err := convertAddonConfig(&values.Controller.Addons.Openshift, common.OpenshiftAddonsFileName, resources.DefaultOpenshiftAddonImage)
+	if err != nil {
+		return nil, fmt.Errorf("invalid openshift addons: %v", err)
+	}
+
+	customRules := ""
+	if values.ClusterNamespacePrometheus.Rules != nil {
+		encoded, err := yaml.Marshal(values.ClusterNamespacePrometheus.Rules)
+		if err != nil {
+			return nil, fmt.Errorf("failed to encode custom Prometheus rules as YAML: %v", err)
+		}
+
+		customRules = string(encoded)
+	}
+
+	customScrapingConfigs := ""
+	if values.ClusterNamespacePrometheus.ScrapingConfigs != nil {
+		encoded, err := yaml.Marshal(values.ClusterNamespacePrometheus.ScrapingConfigs)
+		if err != nil {
+			return nil, fmt.Errorf("failed to encode custom Prometheus scraping configs as YAML: %v", err)
+		}
+
+		customScrapingConfigs = string(encoded)
+	}
+
+	apiserverReplicas, err := getReplicas(values.APIServerDefaultReplicas, common.DefaultAPIServerReplicas)
+	if err != nil {
+		return nil, fmt.Errorf("invalid apiserverDefaultReplicas: %v", err)
+	}
+
+	return &operatorv1alpha1.KubermaticUserClusterConfiguration{
+		KubermaticDockerRepository:     strIfChanged(values.KubermaticImage, resources.DefaultKubermaticImage),
+		DNATControllerDockerRepository: strIfChanged(values.DNATControllerImage, resources.DefaultDNATControllerImage),
+		NodePortRange:                  strIfChanged(values.Controller.NodeportRange, common.DefaultNodePortRange),
+		EtcdVolumeSize:                 strIfChanged(values.Etcd.DiskSize, common.DefaultEtcdVolumeSize),
+		OverwriteRegistry:              values.Controller.OverwriteRegistry,
+		Addons: operatorv1alpha1.KubermaticAddonsConfiguration{
+			Kubernetes: *kubernetesAddonCfg,
+			Openshift:  *openshiftAddonCfg,
+		},
+		Monitoring: operatorv1alpha1.KubermaticUserClusterMonitoringConfiguration{
+			ScrapeAnnotationPrefix:        values.MonitoringScrapeAnnotationPrefix,
+			DisableDefaultRules:           values.ClusterNamespacePrometheus.DisableDefaultRules,
+			DisableDefaultScrapingConfigs: values.ClusterNamespacePrometheus.DisableDefaultScrapingConfigs,
+			CustomRules:                   customRules,
+			CustomScrapingConfigs:         customScrapingConfigs,
+		},
+		DisableAPIServerEndpointReconciling: values.APIServerEndpointReconcilingDisabled,
+		APIServerReplicas:                   apiserverReplicas,
+	}, nil
+}
+
+func convertAddonConfig(values *addonValues, defaultManifestFile string, defaultRepo string) (*operatorv1alpha1.KubermaticAddonConfiguration, error) {
+	if len(values.DefaultAddons) > 0 && values.DefaultAddonsFile != "" {
+		return nil, fmt.Errorf("both defaultAddons and defaultAddonsFile are configured, but they are mutually exclusive")
+	}
+
+	defaultManifests := ""
+	if values.DefaultAddonsFile != "" && values.DefaultAddonsFile != defaultManifestFile {
+		defaultManifests = fmt.Sprintf("!! insert the contents of %s here !!", values.DefaultAddonsFile)
+	}
+
+	return &operatorv1alpha1.KubermaticAddonConfiguration{
+		DockerRepository: strIfChanged(values.Image.Repository, defaultRepo),
+		Default:          values.DefaultAddons,
+		DefaultManifests: defaultManifests,
+	}, nil
+}
+
+func convertMasterController(values *kubermaticValues) (*operatorv1alpha1.KubermaticMasterControllerConfiguration, error) {
+	replicas, err := getReplicas(values.MasterController.Replicas, common.DefaultMasterControllerMgrReplicas)
+	if err != nil {
+		return nil, fmt.Errorf("invalid replicas: %v", err)
+	}
+
+	return &operatorv1alpha1.KubermaticMasterControllerConfiguration{
+		DockerRepository: strIfChanged(values.MasterController.Image.Repository, resources.DefaultKubermaticImage),
+		PProfEndpoint:    getPProfEndpoint(values.MasterController.PProfEndpoint),
+		Replicas:         replicas,
+		Resources:        convertResources(values.MasterController.Resources, common.DefaultMasterControllerMgrResources),
+	}, nil
+}
+
+func convertUI(values *kubermaticValues) (*operatorv1alpha1.KubermaticUIConfiguration, error) {
+	replicas, err := getReplicas(values.UI.Replicas, common.DefaultUIReplicas)
+	if err != nil {
+		return nil, fmt.Errorf("invalid replicas: %v", err)
+	}
+
+	return &operatorv1alpha1.KubermaticUIConfiguration{
+		DockerRepository: strIfChanged(values.UI.Image.Repository, resources.DefaultDashboardImage),
+		Config:           values.UI.Config,
+		Replicas:         replicas,
+		Resources:        convertResources(values.UI.Resources, common.DefaultUIResources),
+	}, nil
+}
+
+func convertResources(values corev1.ResourceRequirements, defaults corev1.ResourceRequirements) corev1.ResourceRequirements {
+	result := corev1.ResourceRequirements{}
+
+	for _, r := range []corev1.ResourceName{corev1.ResourceMemory, corev1.ResourceCPU} {
+		specified, exists := values.Requests[r]
+		if exists {
+			defaulted, exists := defaults.Requests[r]
+			if !exists || specified.Cmp(defaulted) != 0 {
+				if result.Requests == nil {
+					result.Requests = corev1.ResourceList{}
+				}
+				result.Requests[r] = specified
+			}
+		}
+
+		specified, exists = values.Limits[r]
+		if exists {
+			defaulted, exists := defaults.Limits[r]
+			if !exists || specified.Cmp(defaulted) != 0 {
+				if result.Limits == nil {
+					result.Limits = corev1.ResourceList{}
+				}
+				result.Limits[r] = specified
+			}
+		}
+	}
+
+	return result
+}
+
+func convertFeatureGates(values *kubermaticValues) (sets.String, error) {
+	set := sets.NewString()
+
+	for _, gates := range []string{values.API.FeatureGates, values.Controller.FeatureGates} {
+		features, err := features.NewFeatures(gates)
+		if err != nil {
+			return set, fmt.Errorf("failed to parse feature gates: %v", err)
+		}
+
+		for feature, enabled := range features {
+			if enabled {
+				set.Insert(feature)
+			}
+		}
+	}
+
+	return set, nil
+}
+
+func strIfChanged(value string, defaultValue string) string {
+	if value == defaultValue {
+		return ""
+	}
+
+	return value
+}
+
+func getReplicas(yamlValue *string, defaultValue int) (*int32, error) {
+	if yamlValue == nil || *yamlValue == "" {
+		return nil, nil
+	}
+
+	parsed, err := numericValue(*yamlValue)
+	if err != nil {
+		return nil, fmt.Errorf("invalid numeric value: %v", err)
+	}
+
+	if parsed != defaultValue {
+		return pointer.Int32Ptr(int32(parsed)), nil
+	}
+
+	return nil, nil
+}
+
+func getPProfEndpoint(yamlValue string) *string {
+	if yamlValue == "" || yamlValue == common.DefaultPProfEndpoint {
+		return nil
+	}
+
+	return pointer.StringPtr(yamlValue)
+}
+
+func numericValue(value interface{}) (int, error) {
+	switch t := value.(type) {
+	case int:
+		return t, nil
+
+	case string:
+		parsed, err := strconv.ParseInt(t, 10, 32)
+		return int(parsed), err
+
+	default:
+		return 0, fmt.Errorf("cannot parse '%v' (%T) as an integer", t, t)
+	}
+}

--- a/api/pkg/controller/operator/conversion/helm_test.go
+++ b/api/pkg/controller/operator/conversion/helm_test.go
@@ -1,0 +1,234 @@
+package conversion
+
+import (
+	"fmt"
+	"strings"
+	"testing"
+
+	"github.com/kubermatic/kubermatic/api/pkg/controller/operator/common"
+	operatorv1alpha1 "github.com/kubermatic/kubermatic/api/pkg/crd/operator/v1alpha1"
+
+	"k8s.io/apimachinery/pkg/api/equality"
+	"k8s.io/apimachinery/pkg/util/diff"
+	"k8s.io/utils/pointer"
+	"sigs.k8s.io/yaml"
+)
+
+func parseYAML(t *testing.T, content string) helmValues {
+	values := helmValues{}
+	if err := yaml.Unmarshal([]byte(strings.TrimSpace(content)), &values); err != nil {
+		t.Fatalf("Failed to parse YAML: %v", err)
+	}
+
+	return values
+}
+
+func TestParsingReplicas(t *testing.T) {
+	defaultReplicas := 42
+	testcases := []struct {
+		yaml     string
+		expected *int32
+	}{
+		{
+			yaml:     `kubermatic: {}`,
+			expected: nil,
+		},
+		{
+			yaml:     `kubermatic: { api: { replicas: 0 } }`,
+			expected: pointer.Int32Ptr(0),
+		},
+		{
+			yaml:     `kubermatic: { api: { replicas: 7 } }`,
+			expected: pointer.Int32Ptr(7),
+		},
+		{
+			yaml:     `kubermatic: { api: { replicas: "7" } }`,
+			expected: pointer.Int32Ptr(7),
+		},
+	}
+
+	for idx, testcase := range testcases {
+		values := parseYAML(t, testcase.yaml)
+
+		replicas, err := getReplicas(values.Kubermatic.API.Replicas, defaultReplicas)
+		if err != nil {
+			t.Errorf("Test case %d failed, failed to determine replicas: %v", idx+1, err)
+			continue
+		}
+
+		switch {
+		case replicas == nil && testcase.expected == nil:
+			break
+		case replicas == nil:
+			t.Errorf("Test case %d failed, expected %v but got %v replicas.", idx+1, *testcase.expected, replicas)
+		case testcase.expected == nil:
+			t.Errorf("Test case %d failed, expected %v but got %v replicas.", idx+1, testcase.expected, *replicas)
+		case *replicas != *testcase.expected:
+			t.Errorf("Test case %d failed, expected %v but got %v replicas.", idx+1, *testcase.expected, *replicas)
+		}
+	}
+}
+
+func TestConvertAuth(t *testing.T) {
+	testcases := []struct {
+		yaml     string
+		expected *operatorv1alpha1.KubermaticAuthConfiguration
+	}{
+		{
+			yaml:     `kubermatic: {}`,
+			expected: &operatorv1alpha1.KubermaticAuthConfiguration{},
+		},
+		{
+			yaml: `kubermatic: { auth: { clientID: foo } }`,
+			expected: &operatorv1alpha1.KubermaticAuthConfiguration{
+				ClientID: "foo",
+			},
+		},
+		{
+			yaml:     fmt.Sprintf(`kubermatic: { auth: { clientID: "%s" } }`, common.DefaultAuthClientID),
+			expected: &operatorv1alpha1.KubermaticAuthConfiguration{},
+		},
+		{
+			yaml:     `kubermatic: { domain: "example.com", auth: { tokenIssuer: "https://example.com/dex" } }`,
+			expected: &operatorv1alpha1.KubermaticAuthConfiguration{},
+		},
+		{
+			yaml: `kubermatic: { auth: { clientID: "foo", issuerClientID: "fooIssuer" } }`,
+			expected: &operatorv1alpha1.KubermaticAuthConfiguration{
+				ClientID: "foo",
+			},
+		},
+		{
+			yaml: `kubermatic: { auth: { clientID: "foo", issuerClientID: "bar" } }`,
+			expected: &operatorv1alpha1.KubermaticAuthConfiguration{
+				ClientID:       "foo",
+				IssuerClientID: "bar",
+			},
+		},
+		{
+			yaml: `kubermatic: { domain: "example.com", auth: { tokenIssuer: "https://example.com/some/other/url" } }`,
+			expected: &operatorv1alpha1.KubermaticAuthConfiguration{
+				TokenIssuer: "https://example.com/some/other/url",
+			},
+		},
+		{
+			yaml: `kubermatic: { auth: { caBundle: "aGVsbG8gd29ybGQ=" } }`,
+			expected: &operatorv1alpha1.KubermaticAuthConfiguration{
+				CABundle: "hello world",
+			},
+		},
+		{
+			yaml: `kubermatic: { auth: { skipTokenIssuerTLSVerify: "false" } }`,
+			expected: &operatorv1alpha1.KubermaticAuthConfiguration{
+				SkipTokenIssuerTLSVerify: false,
+			},
+		},
+		{
+			yaml: `kubermatic: { auth: { skipTokenIssuerTLSVerify: "nope" } }`,
+			expected: &operatorv1alpha1.KubermaticAuthConfiguration{
+				SkipTokenIssuerTLSVerify: false,
+			},
+		},
+		{
+			yaml: `kubermatic: { auth: { skipTokenIssuerTLSVerify: "true" } }`,
+			expected: &operatorv1alpha1.KubermaticAuthConfiguration{
+				SkipTokenIssuerTLSVerify: true,
+			},
+		},
+	}
+
+	for idx, testcase := range testcases {
+		values := parseYAML(t, testcase.yaml)
+
+		config, err := convertAuth(&values.Kubermatic)
+		if err != nil {
+			t.Errorf("Test case %d failed, failed to convert: %v", idx+1, err)
+			continue
+		}
+
+		if !equality.Semantic.DeepEqual(config, testcase.expected) {
+			t.Errorf("Test case %d failed:\n%v", idx+1, diff.ObjectDiff(testcase.expected, config))
+		}
+	}
+}
+
+func TestConvertAPI(t *testing.T) {
+	testcases := []struct {
+		yaml     string
+		expected *operatorv1alpha1.KubermaticAPIConfiguration
+	}{
+		{
+			yaml:     `kubermatic: {}`,
+			expected: &operatorv1alpha1.KubermaticAPIConfiguration{},
+		},
+		{
+			yaml: `kubermatic: { api: { accessibleAddons: [a, b, c] } }`,
+			expected: &operatorv1alpha1.KubermaticAPIConfiguration{
+				AccessibleAddons: []string{"a", "b", "c"},
+			},
+		},
+		{
+			yaml: `kubermatic: { api: { pprofEndpoint: ":8888" } }`,
+			expected: &operatorv1alpha1.KubermaticAPIConfiguration{
+				PProfEndpoint: pointer.StringPtr(":8888"),
+			},
+		},
+		{
+			yaml:     fmt.Sprintf(`kubermatic: { api: { pprofEndpoint: "%s" } }`, common.DefaultPProfEndpoint),
+			expected: &operatorv1alpha1.KubermaticAPIConfiguration{},
+		},
+	}
+
+	for idx, testcase := range testcases {
+		values := parseYAML(t, testcase.yaml)
+
+		config, err := convertAPI(&values.Kubermatic)
+		if err != nil {
+			t.Errorf("Test case %d failed, failed to convert: %v", idx+1, err)
+			continue
+		}
+
+		if !equality.Semantic.DeepEqual(config, testcase.expected) {
+			t.Errorf("Test case %d failed:\n%v", idx+1, diff.ObjectDiff(testcase.expected, config))
+		}
+	}
+}
+
+func TestConvertPrometheus(t *testing.T) {
+	testcases := []struct {
+		yaml     string
+		expected *operatorv1alpha1.KubermaticUserClusterMonitoringConfiguration
+	}{
+		{
+			yaml:     `kubermatic: {}`,
+			expected: &operatorv1alpha1.KubermaticUserClusterMonitoringConfiguration{},
+		},
+		{
+			yaml: `kubermatic: { monitoringScrapeAnnotationPrefix: "foo" }`,
+			expected: &operatorv1alpha1.KubermaticUserClusterMonitoringConfiguration{
+				ScrapeAnnotationPrefix: "foo",
+			},
+		},
+		{
+			yaml: `kubermatic: { clusterNamespacePrometheus: { scrapingConfigs: [a, b, c], rules: { groups: [] } } }`,
+			expected: &operatorv1alpha1.KubermaticUserClusterMonitoringConfiguration{
+				CustomScrapingConfigs: "- a\n- b\n- c\n",
+				CustomRules:           "groups: []\n",
+			},
+		},
+	}
+
+	for idx, testcase := range testcases {
+		values := parseYAML(t, testcase.yaml)
+
+		config, err := convertUserCluster(&values.Kubermatic)
+		if err != nil {
+			t.Errorf("Test case %d failed, failed to convert: %v", idx+1, err)
+			continue
+		}
+
+		if !equality.Semantic.DeepEqual(&config.Monitoring, testcase.expected) {
+			t.Errorf("Test case %d failed:\n%v", idx+1, diff.ObjectDiff(testcase.expected, config.Monitoring))
+		}
+	}
+}

--- a/docs/zz_generated.kubermaticConfiguration.yaml
+++ b/docs/zz_generated.kubermaticConfiguration.yaml
@@ -314,7 +314,7 @@ spec:
     # DockerRepository is the repository containing the Kubermatic dashboard image.
     dockerRepository: quay.io/kubermatic/ui-v2
     # Replicas sets the number of pod replicas for the UI deployment.
-    replicas: 1
+    replicas: 2
     # Resources describes the requested and maximum allowed CPU/memory usage.
     resources:
       # Limits describes the maximum amount of compute resources allowed.


### PR DESCRIPTION
**What this PR does / why we need it**:
We shuffled quite a few settings around when designing the KubermaticConfiguration CRD. To make it easier for customers to migrate to the operator, we should also offer a tool to convert their existing configuration. This PR adds such a utility.

The code has been put into a dedicated binary so that we can ship it individually and in order to not make the existing operator binary more complicated by introducing a CLI framework.

The conversion makes great effort to not output default values, in order to create a minimal KubermaticConfiguration. This helps as it does not hardcode (possibly soon outdated) default values and prevents misconfiguration. It also makes it easier to either use the customer's values.yaml (with only their adjustments) or the merged Helm values (e.g. by taking the values from Tiller's ConfigMap for the Kubermatic release), as default values are consistently filtered out.

**Which issue(s) this PR fixes**:
Part of #4723 

**Does this PR introduce a user-facing change?**:
```release-note
NONE
```
