### PR TITLE
Do not tag :latest when doing canary deployments in presubmits

### DIFF
--- a/api/hack/ci/ci-push-images.sh
+++ b/api/hack/ci/ci-push-images.sh
@@ -7,8 +7,13 @@ cd "$(git rev-parse --show-toplevel)"
 
 GIT_HEAD_HASH="$(git rev-parse HEAD)"
 GIT_HEAD_TAG="$(git tag -l --points-at HEAD)"
-# FIXME: use `latest` only on the master branch
-TAGS="$GIT_HEAD_HASH $GIT_HEAD_TAG latest"
+TAGS="$GIT_HEAD_HASH $GIT_HEAD_TAG"
+
+# we only want to create the "latest" tag if we're building
+# the master branch and it's not a canary deployment
+if [ -z "${CANARY_DEPLOYMENT:-}" ] && [ "$(git rev-parse --abbrev-ref HEAD)" == "master" ]; then
+  TAGS="$TAGS latest"
+fi
 
 apt install time -y
 


### PR DESCRIPTION
**What this PR does / why we need it**:
Some PRs cause a canary deployment and we accidentally always tag a "latest" Docker image, probably because of the assumption that the `ci-push-images.sh` is only ever used in postsubmits. This means that the "latest" tag is more or less random and this causes all sorts of random test failures in the dashboard repo (and of course can cause major issues if a customer ever wanted to live dangerously and run "latest").

This PR simply disable the "latest" tag if the script is called in a canary presubmit.

**Does this PR introduce a user-facing change?**:
```release-note
NONE
```
