### PR TITLE
Do not try to restore repo to older version when not building Kubermatic

### DIFF
--- a/api/hack/ci/ci-setup-kubermatic-in-kind.sh
+++ b/api/hack/ci/ci-setup-kubermatic-in-kind.sh
@@ -369,7 +369,9 @@ if [[ "${KUBERMATIC_USE_OPERATOR}" = "false" ]]; then
     ./config/kubermatic/
 
   # Return repo to previous state if we checked out older charts before.
-  git checkout ${KUBERMATIC_VERSION}
+  if [[ "${KUBERMATIC_SKIP_BUILDING}" = "false" ]]; then
+    git checkout ${KUBERMATIC_VERSION}
+  fi
 else
   # Even when it does not reconcile certificates, the operator absolutely needs the
   # cert-manager CRDs to exist.


### PR DESCRIPTION
**What this PR does / why we need it**:
Kubermatic Dashboard e2e error with:
```bash
error: pathspec 'latest' did not match any file(s) known to git.
```

As we use `KUBERMATIC_VERSION=latest`, we cannot checkout such branch as it will not exist.

**Does this PR introduce a user-facing change?**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If  no release note is required, just write "NONE".
-->
```release-note
NONE
```
