### PR TITLE
drop EOL Kubernetes v1.14

### DIFF
--- a/api/pkg/controller/operator/common/defaults.go
+++ b/api/pkg/controller/operator/common/defaults.go
@@ -392,12 +392,11 @@ const DefaultUIConfig = `
 }`
 
 const DefaultVersionsYAML = `
+# REMEMBER TO CHANGE BOTH:
+# - DefaultVersionsYAML in api/pkg/controller/operator/common/defaults.go
+# - config/kubermatic/static/master/versions.yaml
+
 versions:
-# Kubernetes 1.14
-- version: "v1.14.8"
-  default: false
-- version: "v1.14.9"
-  default: false
 # Kubernetes 1.15
 - version: "v1.15.5"
   default: false

--- a/config/kubermatic/Chart.yaml
+++ b/config/kubermatic/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: kubermatic
-version: 1.0.34
+version: 1.0.35
 appVersion: '__KUBERMATIC_TAG__'
 description: Kubermatic chart for master and/or seed clusters.
 keywords:

--- a/config/kubermatic/static/master/versions.yaml
+++ b/config/kubermatic/static/master/versions.yaml
@@ -1,9 +1,8 @@
+# REMEMBER TO CHANGE BOTH:
+# - DefaultVersionsYAML in api/pkg/controller/operator/common/defaults.go
+# - config/kubermatic/static/master/versions.yaml
+
 versions:
-# Kubernetes 1.14
-- version: "v1.14.8"
-  default: false
-- version: "v1.14.9"
-  default: false
 # Kubernetes 1.15
 - version: "v1.15.5"
   default: false

--- a/docs/zz_generated.kubermaticConfiguration.yaml
+++ b/docs/zz_generated.kubermaticConfiguration.yaml
@@ -206,12 +206,11 @@ spec:
         automatic: false
         type: openshift
     versions.yaml: |-
+      # REMEMBER TO CHANGE BOTH:
+      # - DefaultVersionsYAML in api/pkg/controller/operator/common/defaults.go
+      # - config/kubermatic/static/master/versions.yaml
+
       versions:
-      # Kubernetes 1.14
-      - version: "v1.14.8"
-        default: false
-      - version: "v1.14.9"
-        default: false
       # Kubernetes 1.15
       - version: "v1.15.5"
         default: false


### PR DESCRIPTION
```release-note
End-of-Life Kubernetes v1.14 is no longer supported.
```
