### PR TITLE
[release/v2.12] drop EOL Kubernetes v1.14

### DIFF
--- a/config/kubermatic/Chart.yaml
+++ b/config/kubermatic/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: kubermatic
-version: 1.0.22
+version: 1.0.23
 appVersion: '__KUBERMATIC_TAG__'
 description: Kubermatic chart for master and/or seed clusters.
 keywords:

--- a/config/kubermatic/static/master/versions.yaml
+++ b/config/kubermatic/static/master/versions.yaml
@@ -1,14 +1,9 @@
 versions:
-# Kubernetes 1.14
-- version: "v1.14.8"
-  default: true
-- version: "v1.14.9"
-  default: false
 # Kubernetes 1.15
 - version: "v1.15.5"
   default: false
 - version: "v1.15.6"
-  default: false
+  default: true
 # Kubernetes 1.16
 - version: "v1.16.2"
   default: false


### PR DESCRIPTION
```release-note
End-of-Life Kubernetes v1.14 is no longer supported.
```

/assign @xrstf 