### PR TITLE
[release/v2.11] drop EOL Kubernetes v1.14

### DIFF
--- a/config/kubermatic/Chart.yaml
+++ b/config/kubermatic/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: kubermatic
-version: 1.0.4
+version: 1.0.5
 appVersion: '__KUBERMATIC_TAG__'
 description: Kubermatic chart for master and/or seed clusters.
 keywords:

--- a/config/kubermatic/static/master/versions.yaml
+++ b/config/kubermatic/static/master/versions.yaml
@@ -1,10 +1,7 @@
 versions:
-# Kubernetes 1.14
-- version: "v1.14.8"
-  default: true
 # Kubernetes 1.15
 - version: "v1.15.5"
-  default: false
+  default: true
 # OpenShift 3.11
 - version: "v3.11"
   default: true


### PR DESCRIPTION
```release-note
End-of-Life Kubernetes v1.14 is no longer supported.
```
