### PR TITLE
Restore nginx's publish-service feature

### DIFF
--- a/config/nginx-ingress-controller/Chart.yaml
+++ b/config/nginx-ingress-controller/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: nginx-ingress-controller
-version: 1.0.5
+version: 1.0.6
 appVersion: 0.25.1
 description: nginx-ingress-controller
 keywords:

--- a/config/nginx-ingress-controller/templates/nginx-ds-dep.yaml
+++ b/config/nginx-ingress-controller/templates/nginx-ds-dep.yaml
@@ -44,6 +44,9 @@ spec:
         - --configmap=$(POD_NAMESPACE)/nginx-configuration
         - --ingress-class=nginx
         - --annotations-prefix=ingress.kubernetes.io
+        {{- if not .Values.nginx.hostNetwork }}
+        - --publish-service=$(POD_NAMESPACE)/nginx-ingress-controller
+        {{- end }}
         {{- range .Values.nginx.extraArgs }}
         - {{ . | quote }}
         {{- end }}


### PR DESCRIPTION
**What this PR does / why we need it**:
The flag was removed in #4688, reason was:

> The publish-service stuff has been removed. We don't use it and if someone wants to use it, they can easily get it back via extraArgs.

However this was me not actually understanding what the flag does, plus the fact that was simply wrong. The flag toggles a feature in nginx-ingress-controller that will mirror the service's endpoint to the Ingresses covered by that service. So when you have a LoadBalancer on AWS, that LoadBalancer service gets an external address like `abe0ad665e5aa426598c16b0d26598a9-592030229.eu-central-1.elb.amazonaws.com`. nginx will now copy this into the Ingress object, so that `kubectl get ingress` will show the LoadBalancer that handles the Ingress. Quite nifty and IMHO simple and easy enough that we should include it by default.

We just had it configured to a non-existing service. This PR fixes that.

**Does this PR introduce a user-facing change?**:
```release-note
Restore nginx-ingress-controller --publish-service functionality.
```
