### PR TITLE
Add support for custom Dex CA in kubermatic-api

### DIFF
--- a/api/cmd/kubermatic-api/main.go
+++ b/api/cmd/kubermatic-api/main.go
@@ -257,6 +257,7 @@ func createOIDCClients(options serverRunOptions) (auth.OIDCIssuerVerifier, error
 			auth.NewQueryParamBearerTokenExtractor("token"),
 		),
 		options.oidcSkipTLSVerify,
+		options.oidcCABundle,
 	)
 }
 
@@ -272,6 +273,7 @@ func createAuthClients(options serverRunOptions, prov providers) (auth.TokenVeri
 			auth.NewQueryParamBearerTokenExtractor("token"),
 		),
 		options.oidcSkipTLSVerify,
+		options.oidcCABundle,
 	)
 
 	if err != nil {

--- a/api/pkg/controller/operator/master/reconciler.go
+++ b/api/pkg/controller/operator/master/reconciler.go
@@ -191,10 +191,13 @@ func (r *Reconciler) reconcileSecrets(config *operatorv1alpha1.KubermaticConfigu
 
 	creators := []reconciling.NamedSecretCreatorGetter{
 		common.DockercfgSecretCreator(config),
-		common.DexCASecretCreator(config),
 		common.SeedWebhookServingCASecretCreator(config),
 		common.SeedWebhookServingCertSecretCreator(config, r.Client),
 		common.MasterFilesSecretCreator(config),
+	}
+
+	if config.Spec.Auth.CABundle != "" {
+		creators = append(creators, common.DexCASecretCreator(config))
 	}
 
 	if err := reconciling.ReconcileSecrets(r.ctx, creators, config.Namespace, r.Client, common.OwnershipModifierFactory(config, r.scheme)); err != nil {

--- a/api/pkg/controller/operator/seed/reconciler.go
+++ b/api/pkg/controller/operator/seed/reconciler.go
@@ -289,13 +289,16 @@ func (r *Reconciler) reconcileSecrets(cfg *operatorv1alpha1.KubermaticConfigurat
 
 	creators := []reconciling.NamedSecretCreatorGetter{
 		common.DockercfgSecretCreator(cfg),
-		common.DexCASecretCreator(cfg),
 		common.SeedWebhookServingCASecretCreator(cfg),
 		common.SeedWebhookServingCertSecretCreator(cfg, client),
 	}
 
 	if len(cfg.Spec.MasterFiles) > 0 {
 		creators = append(creators, common.MasterFilesSecretCreator(cfg))
+	}
+
+	if cfg.Spec.Auth.CABundle != "" {
+		creators = append(creators, common.DexCASecretCreator(cfg))
 	}
 
 	if err := reconciling.ReconcileSecrets(r.ctx, creators, cfg.Namespace, client, common.OwnershipModifierFactory(seed, r.scheme)); err != nil {

--- a/api/pkg/controller/operator/seed/resources/kubermatic/seed-controller-manager.go
+++ b/api/pkg/controller/operator/seed/resources/kubermatic/seed-controller-manager.go
@@ -183,26 +183,29 @@ func SeedControllerManagerDeploymentCreator(workerName string, versions common.V
 
 			if cfg.Spec.FeatureGates.Has(features.OpenIDAuthPlugin) {
 				args = append(args,
-					"-oidc-ca-file=/opt/dex-ca/caBundle.pem",
 					fmt.Sprintf("-oidc-issuer-url=%s", cfg.Spec.Auth.TokenIssuer),
 					fmt.Sprintf("-oidc-issuer-client-id=%s", cfg.Spec.Auth.IssuerClientID),
 					fmt.Sprintf("-oidc-issuer-client-secret=%s", cfg.Spec.Auth.IssuerClientSecret),
 				)
 
-				volumes = append(volumes, corev1.Volume{
-					Name: "dex-ca",
-					VolumeSource: corev1.VolumeSource{
-						Secret: &corev1.SecretVolumeSource{
-							SecretName: common.DexCASecretName,
-						},
-					},
-				})
+				if cfg.Spec.Auth.CABundle != "" {
+					args = append(args, "-oidc-ca-file=/opt/dex-ca/caBundle.pem")
 
-				volumeMounts = append(volumeMounts, corev1.VolumeMount{
-					Name:      "dex-ca",
-					MountPath: "/opt/dex-ca",
-					ReadOnly:  true,
-				})
+					volumes = append(volumes, corev1.Volume{
+						Name: "dex-ca",
+						VolumeSource: corev1.VolumeSource{
+							Secret: &corev1.SecretVolumeSource{
+								SecretName: common.DexCASecretName,
+							},
+						},
+					})
+
+					volumeMounts = append(volumeMounts, corev1.VolumeMount{
+						Name:      "dex-ca",
+						MountPath: "/opt/dex-ca",
+						ReadOnly:  true,
+					})
+				}
 			}
 
 			if len(cfg.Spec.UserCluster.Monitoring.CustomScrapingConfigs) > 0 {

--- a/api/pkg/crd/operator/v1alpha1/configuration.go
+++ b/api/pkg/crd/operator/v1alpha1/configuration.go
@@ -63,7 +63,7 @@ type KubermaticAuthConfiguration struct {
 	IssuerClientID           string `json:"issuerClientID,omitempty"`
 	IssuerClientSecret       string `json:"issuerClientSecret,omitempty"`
 	IssuerCookieKey          string `json:"issuerCookieKey,omitempty"`
-	CABundle                 string `json:"cABundle,omitempty"`
+	CABundle                 string `json:"caBundle,omitempty"`
 	ServiceAccountKey        string `json:"serviceAccountKey,omitempty"`
 	SkipTokenIssuerTLSVerify bool   `json:"skipTokenIssuerTLSVerify,omitempty"`
 }

--- a/config/kubermatic/Chart.yaml
+++ b/config/kubermatic/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: kubermatic
-version: 1.0.36
+version: 1.0.37
 appVersion: '__KUBERMATIC_TAG__'
 description: Kubermatic chart for master and/or seed clusters.
 keywords:

--- a/config/kubermatic/templates/kubermatic-api-dep.yaml
+++ b/config/kubermatic/templates/kubermatic-api-dep.yaml
@@ -54,6 +54,9 @@ spec:
         # the following flags enable oidc kubeconfig feature/endpoint
         - -feature-gates={{ .Values.kubermatic.api.featureGates }}
         {{- if regexMatch ".*OIDCKubeCfgEndpoint=true.*" (default "" .Values.kubermatic.api.featureGates) }}
+        {{- if .Values.kubermatic.auth.caBundle }}
+        - -oidc-ca-file=/opt/dex-ca/caBundle.pem
+        {{- end }}
         - -oidc-issuer-redirect-uri={{ .Values.kubermatic.auth.issuerRedirectURL }}
         - -oidc-issuer-client-id={{ .Values.kubermatic.auth.issuerClientID }}
         - -oidc-issuer-client-secret={{ .Values.kubermatic.auth.issuerClientSecret }}
@@ -89,6 +92,11 @@ spec:
             path: /api/v1/healthz
             scheme: HTTP
         volumeMounts:
+        {{- if .Values.kubermatic.auth.caBundle }}
+        - name: dex-ca
+          mountPath: "/opt/dex-ca/"
+          readOnly: true
+        {{- end }}
         - name: kubeconfig
           mountPath: "/opt/.kube/"
           readOnly: true

--- a/config/kubermatic/templates/kubermatic-controller-manager-dep.yaml
+++ b/config/kubermatic/templates/kubermatic-controller-manager-dep.yaml
@@ -89,7 +89,9 @@ spec:
         - -docker-pull-config-json-file=/opt/docker/.dockerconfigjson
         {{- if regexMatch ".*OpenIDAuthPlugin=true.*" (default "" .Values.kubermatic.controller.featureGates) }}
         # the following flags enable oidc auth plugin on kube-API servers
+        {{- if .Values.kubermatic.auth.caBundle }}
         - -oidc-ca-file=/opt/dex-ca/caBundle.pem
+        {{- end }}
         - -oidc-issuer-url={{ .Values.kubermatic.auth.tokenIssuer }}
         - -oidc-issuer-client-id={{ .Values.kubermatic.auth.issuerClientID }}
         - -oidc-issuer-client-secret={{ .Values.kubermatic.auth.issuerClientSecret }}
@@ -145,7 +147,7 @@ spec:
           containerPort: 8085
           protocol: TCP
         volumeMounts:
-        {{- if regexMatch ".*OpenIDAuthPlugin=true.*" (default "" .Values.kubermatic.controller.featureGates) }}
+        {{- if .Values.kubermatic.auth.caBundle }}
         - name: dex-ca
           mountPath: "/opt/dex-ca/"
           readOnly: true

--- a/docs/zz_generated.kubermaticConfiguration.yaml
+++ b/docs/zz_generated.kubermaticConfiguration.yaml
@@ -34,7 +34,7 @@ spec:
         memory: 512Mi
   # Auth defines keys and URLs for Dex.
   auth:
-    cABundle: ""
+    caBundle: ""
     clientID: kubermatic
     issuerClientID: kubermaticIssuer
     issuerClientSecret: ""


### PR DESCRIPTION
**What this PR does / why we need it**:
When Dex uses a custom CA, we already support telling the kubernetes-apiserver in user clusters about that. This PR makes it so that the kubermatic-api itself can also use the custom CA.

**Does this PR introduce a user-facing change?**:
```release-note
Support custom CA for OpenID provider in Kubermatic API.
```
