### PR TITLE
Fix FluentbitManyRetries error being too sensitive

### DIFF
--- a/config/monitoring/prometheus/Chart.yaml
+++ b/config/monitoring/prometheus/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: prometheus
-version: 2.2.6
+version: 2.2.7
 appVersion: v2.14.0
 description: Prometheus Monitoring for Kubernetes
 keywords:

--- a/config/monitoring/prometheus/rules/general-fluentbit.yaml
+++ b/config/monitoring/prometheus/rules/general-fluentbit.yaml
@@ -2,16 +2,16 @@
 groups:
 - name: fluentbit
   rules:
-  - alert: FluentbitManyRetries
+  - alert: FluentbitManyFailedRetries
     annotations:
       message: Fluentbit pod `{{ $labels.pod }}` on `{{ $labels.node }}` is experiencing
-        an elevated retry rate.
-      runbook_url: https://docs.kubermatic.io/monitoring/runbook/#alert-fluentbitmanyretries
+        an elevated failed retry rate.
+      runbook_url: https://docs.kubermatic.io/monitoring/runbook/#alert-fluentbitmanyfailedretries
     expr: |
       sum by (namespace, pod, node) (kube_pod_info) *
         on (namespace, pod)
         group_right (node)
-        rate(fluentbit_output_retries_total[1m]) > 0
+        rate(fluentbit_output_retries_failed_total[1m]) > 0
     for: 10m
     labels:
       severity: warning

--- a/config/monitoring/prometheus/rules/src/general/fluentbit.yaml
+++ b/config/monitoring/prometheus/rules/src/general/fluentbit.yaml
@@ -1,15 +1,15 @@
 groups:
 - name: fluentbit
   rules:
-  - alert: FluentbitManyRetries
+  - alert: FluentbitManyFailedRetries
     annotations:
-      message: Fluentbit pod `{{ $labels.pod }}` on `{{ $labels.node }}` is experiencing an elevated retry rate.
-      runbook_url: https://docs.kubermatic.io/monitoring/runbook/#alert-fluentbitmanyretries
+      message: Fluentbit pod `{{ $labels.pod }}` on `{{ $labels.node }}` is experiencing an elevated failed retry rate.
+      runbook_url: https://docs.kubermatic.io/monitoring/runbook/#alert-fluentbitmanyfailedretries
     expr: |
       sum by (namespace, pod, node) (kube_pod_info) *
         on (namespace, pod)
         group_right (node)
-        rate(fluentbit_output_retries_total[1m]) > 0
+        rate(fluentbit_output_retries_failed_total[1m]) > 0
     for: 10m
     labels:
       severity: warning
@@ -17,6 +17,8 @@ groups:
       steps:
       - Ensure the target Elasticsearch cluster is healthy and accepts new documents (in certain
         conditions Elasticsearch clusters become read-only).
+      - Ensure that `Retry_Limit` is not set to `False` (infinite) to prevent unprocessable logs
+        from stopping the ingestion of new logs.
 
   - alert: FluentbitManyOutputErrors
     annotations:
@@ -34,6 +36,8 @@ groups:
       steps:
       - Ensure the target Elasticsearch cluster is healthy and accepts new documents (in certain
         conditions Elasticsearch clusters become read-only).
+      - Ensure that `Retry_Limit` is not set to `False` (infinite) to prevent unprocessable logs
+        from stopping the ingestion of new logs.
 
   - alert: FluentbitNotProcessingNewLogs
     annotations:


### PR DESCRIPTION
**What this PR does / why we need it**:
Retries are a normal part of fluent-bit's scheduler operations and do not necessarily indicate a problem worth alerting about. Even on nodes that are pretty much idle fluent-bit seems to retry stuff internally without reason. The debug logging shows clearly that all Elasticsearch requests succeed and nothing on any level except debug is logged at all.

**Does this PR introduce a user-facing change?**:
```release-note
Fix FluentbitManyRetries Prometheus alert being too sensitive to harmless backpressure.
```
