### PR TITLE
extend e2e preset test for datacenter

### DIFF
--- a/api/cmd/kubermatic-api/swagger.json
+++ b/api/cmd/kubermatic-api/swagger.json
@@ -6524,7 +6524,8 @@
           },
           {
             "type": "string",
-            "name": "Datacenter",
+            "x-go-name": "Datacenter",
+            "name": "datacenter",
             "in": "query"
           }
         ],

--- a/api/hack/ci/ci_run_api_e2e.sh
+++ b/api/hack/ci/ci_run_api_e2e.sh
@@ -46,7 +46,19 @@ spec:
   gcp:
     serviceAccount: ${GOOGLE_SERVICE_ACCOUNT}
 EOF
+cat <<EOF > preset-gcp-datacenter.yaml
+apiVersion: kubermatic.k8s.io/v1
+kind: Preset
+metadata:
+  name: e2e-gcp-datacenter
+  namespace: kubermatic
+spec:
+  gcp:
+    serviceAccount: ${GOOGLE_SERVICE_ACCOUNT}
+    datacenter: gcp-westeurope
+EOF
 retry 2 kubectl apply -f preset-gcp.yaml
+retry 2 kubectl apply -f preset-gcp-datacenter.yaml
 
 echodate "Creating UI OpenStack preset..."
 cat <<EOF > preset-openstack.yaml

--- a/api/pkg/handler/v1/presets/credentials.go
+++ b/api/pkg/handler/v1/presets/credentials.go
@@ -35,7 +35,7 @@ type providerReq struct {
 	// required: true
 	ProviderName string `json:"provider_name"`
 	// in: query
-	Datacenter string
+	Datacenter string `json:"datacenter,omitempty"`
 }
 
 // CredentialEndpoint returns custom credential list name for the provider

--- a/api/pkg/test/e2e/api/credentials_test.go
+++ b/api/pkg/test/e2e/api/credentials_test.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"net/http"
 	"net/url"
+	"sort"
 	"testing"
 	"time"
 
@@ -16,6 +17,7 @@ func TestListCredentials(t *testing.T) {
 	tests := []struct {
 		name         string
 		provider     string
+		datacenter   string
 		expectedList []string
 	}{
 		{
@@ -38,6 +40,12 @@ func TestListCredentials(t *testing.T) {
 			provider:     "gcp",
 			expectedList: []string{"e2e-gcp"},
 		},
+		{
+			name:         "test, get GCP credential names for the specific datacenter",
+			provider:     "gcp",
+			datacenter:   "gcp-westeurope",
+			expectedList: []string{"e2e-gcp", "e2e-gcp-datacenter"},
+		},
 	}
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
@@ -47,10 +55,12 @@ func TestListCredentials(t *testing.T) {
 			}
 
 			apiRunner := createRunner(masterToken, t)
-			credentialList, err := apiRunner.ListCredentials(tc.provider)
+			credentialList, err := apiRunner.ListCredentials(tc.provider, tc.datacenter)
 			if err != nil {
 				t.Fatalf("can not get credential names for provider %s: %v", tc.provider, err)
 			}
+			sort.Strings(tc.expectedList)
+			sort.Strings(credentialList)
 			if !equality.Semantic.DeepEqual(tc.expectedList, credentialList) {
 				t.Fatalf("expected: %v, got %v", tc.expectedList, credentialList)
 			}

--- a/api/pkg/test/e2e/api/gcp_test.go
+++ b/api/pkg/test/e2e/api/gcp_test.go
@@ -33,7 +33,7 @@ func TestGCPZones(t *testing.T) {
 			}
 
 			apiRunner := createRunner(masterToken, t)
-			credentialList, err := apiRunner.ListCredentials(tc.provider)
+			credentialList, err := apiRunner.ListCredentials(tc.provider, "")
 			if err != nil {
 				t.Fatalf("can not get credential names for provider %s: %v", tc.provider, err)
 			}
@@ -81,7 +81,7 @@ func TestGCPDiskTypes(t *testing.T) {
 			}
 
 			apiRunner := createRunner(masterToken, t)
-			credentialList, err := apiRunner.ListCredentials(tc.provider)
+			credentialList, err := apiRunner.ListCredentials(tc.provider, "")
 			if err != nil {
 				t.Fatalf("can not get credential names for provider %s: %v", tc.provider, err)
 			}
@@ -127,7 +127,7 @@ func TestGCPSizes(t *testing.T) {
 			}
 
 			apiRunner := createRunner(masterToken, t)
-			credentialList, err := apiRunner.ListCredentials(tc.provider)
+			credentialList, err := apiRunner.ListCredentials(tc.provider, "")
 			if err != nil {
 				t.Fatalf("can not get credential names for provider %s: %v", tc.provider, err)
 			}

--- a/api/pkg/test/e2e/api/runner.go
+++ b/api/pkg/test/e2e/api/runner.go
@@ -259,8 +259,8 @@ func convertServiceAccountToken(saToken *models.ServiceAccountToken) (*apiv1.Ser
 }
 
 // ListCredentials returns list of credential names for the provider
-func (r *runner) ListCredentials(providerName string) ([]string, error) {
-	params := &credentials.ListCredentialsParams{ProviderName: providerName}
+func (r *runner) ListCredentials(providerName, datacenter string) ([]string, error) {
+	params := &credentials.ListCredentialsParams{ProviderName: providerName, Datacenter: &datacenter}
 	params.WithTimeout(timeout)
 	credentialsResponse, err := r.client.Credentials.ListCredentials(params, r.bearerToken)
 	if err != nil {

--- a/api/pkg/test/e2e/api/utils/apiclient/client/credentials/list_credentials_parameters.go
+++ b/api/pkg/test/e2e/api/utils/apiclient/client/credentials/list_credentials_parameters.go
@@ -136,14 +136,14 @@ func (o *ListCredentialsParams) WriteToRequest(r runtime.ClientRequest, reg strf
 
 	if o.Datacenter != nil {
 
-		// query param Datacenter
+		// query param datacenter
 		var qrDatacenter string
 		if o.Datacenter != nil {
 			qrDatacenter = *o.Datacenter
 		}
 		qDatacenter := qrDatacenter
 		if qDatacenter != "" {
-			if err := r.SetQueryParam("Datacenter", qDatacenter); err != nil {
+			if err := r.SetQueryParam("datacenter", qDatacenter); err != nil {
 				return err
 			}
 		}


### PR DESCRIPTION
**What this PR does / why we need it**: extend e2e preset test for datacenter
 - fix swagger client
 - new preset with datacenter
 - new test scenario

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

```release-note
NONE
```
