### PR TITLE
Create cluster role and binding for Kubernetes Dashboard metrics

### DIFF
--- a/api/pkg/controller/user-cluster-controller-manager/resources/reconciler.go
+++ b/api/pkg/controller/user-cluster-controller-manager/resources/reconciler.go
@@ -305,6 +305,10 @@ func (r *reconciler) reconcileClusterRoles(ctx context.Context) error {
 		clusterautoscaler.ClusterRoleCreator(),
 	}
 
+	if !r.openshift {
+		creators = append(creators, kubernetesdashboard.ClusterRoleCreator())
+	}
+
 	if err := reconciling.ReconcileClusterRoles(ctx, creators, "", r.Client); err != nil {
 		return fmt.Errorf("failed to reconcile ClusterRoles: %v", err)
 	}
@@ -331,6 +335,8 @@ func (r *reconciler) reconcileClusterRoleBindings(ctx context.Context) error {
 
 	if r.openshift {
 		creators = append(creators, openshift.TokenOwnerServiceAccountClusterRoleBinding)
+	} else {
+		creators = append(creators, kubernetesdashboard.ClusterRoleBindingCreator())
 	}
 
 	if err := reconciling.ReconcileClusterRoleBindings(ctx, creators, "", r.Client); err != nil {

--- a/api/pkg/controller/user-cluster-controller-manager/resources/resources/kubernetes-dashboard/clusterrolebinding.go
+++ b/api/pkg/controller/user-cluster-controller-manager/resources/resources/kubernetes-dashboard/clusterrolebinding.go
@@ -20,8 +20,9 @@ func ClusterRoleBindingCreator() reconciling.NamedClusterRoleBindingCreatorGette
 				Kind:     "ClusterRole",
 			}
 			crb.Subjects = []rbacv1.Subject{{
-				Kind: rbacv1.ServiceAccountKind,
-				Name: resources.MetricsScraperServiceAccountUsername,
+				Kind:      rbacv1.ServiceAccountKind,
+				Name:      resources.MetricsScraperServiceAccountUsername,
+				Namespace: Namespace,
 			}}
 			return crb, nil
 		}


### PR DESCRIPTION
**What this PR does / why we need it**:
As cluster role and binding that allow metrics scraper to read metrics are missing, Dashboard could not display usage graphs.

**Does this PR introduce a user-facing change?**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If  no release note is required, just write "NONE".
-->
```release-note
NONE
```
