### PR TITLE
Fix deleting addons from clusters

### DIFF
--- a/api/pkg/controller/seed-controller-manager/addon/addon_controller.go
+++ b/api/pkg/controller/seed-controller-manager/addon/addon_controller.go
@@ -538,5 +538,5 @@ func (r *Reconciler) ensureRequiredResourceTypesExist(ctx context.Context, log *
 }
 
 func deleteCommand(ctx context.Context, kubeconfigFilename, manifestFilename string) *exec.Cmd {
-	return exec.CommandContext(ctx, "kubectl", "--kubeconfig", kubeconfigFilename, "delete", "-f", manifestFilename, "--ignore-not-found", "true")
+	return exec.CommandContext(ctx, "kubectl", "--kubeconfig", kubeconfigFilename, "delete", "-f", manifestFilename, "--ignore-not-found")
 }


### PR DESCRIPTION
**What this PR does / why we need it**:
This fixes the kubectl call to delete an addon manifest.

**Which issue(s) this PR fixes**:
Fixes #4850

**Does this PR introduce a user-facing change?**:
```release-note
Fixed deleting user-selectable addons from clusters.
```
