### PR TITLE
update runbook URLs to point to master version

### DIFF
--- a/config/monitoring/prometheus/Chart.yaml
+++ b/config/monitoring/prometheus/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: prometheus
-version: 2.2.10
+version: 2.2.11
 appVersion: v2.14.0
 description: Prometheus Monitoring for Kubernetes
 keywords:

--- a/config/monitoring/prometheus/rules/general-blackbox-exporter.yaml
+++ b/config/monitoring/prometheus/rules/general-blackbox-exporter.yaml
@@ -5,7 +5,7 @@ groups:
   - alert: HttpProbeFailed
     annotations:
       message: Probing the blackbox-exporter target {{ $labels.instance }} failed.
-      runbook_url: https://docs.kubermatic.io/monitoring/runbook/#alert-httpprobefailed
+      runbook_url: https://docs.loodse.com/kubermatic/master/monitoring/runbook/#alert-httpprobefailed
     expr: probe_success != 1
     for: 5m
     labels:
@@ -13,7 +13,7 @@ groups:
   - alert: HttpProbeSlow
     annotations:
       message: '{{ $labels.instance }} takes {{ $value }} seconds to respond.'
-      runbook_url: https://docs.kubermatic.io/monitoring/runbook/#alert-httpprobeslow
+      runbook_url: https://docs.loodse.com/kubermatic/master/monitoring/runbook/#alert-httpprobeslow
     expr: sum by (instance) (probe_http_duration_seconds) > 3
     for: 15m
     labels:
@@ -21,7 +21,7 @@ groups:
   - alert: HttpCertExpiresSoon
     annotations:
       message: The certificate for {{ $labels.instance }} expires in less than 3 days.
-      runbook_url: https://docs.kubermatic.io/monitoring/runbook/#alert-httpcertexpiressoon
+      runbook_url: https://docs.loodse.com/kubermatic/master/monitoring/runbook/#alert-httpcertexpiressoon
     expr: probe_ssl_earliest_cert_expiry - time() < 3*24*3600
     labels:
       severity: warning
@@ -29,7 +29,7 @@ groups:
     annotations:
       message: The certificate for {{ $labels.instance }} expires in less than 24
         hours.
-      runbook_url: https://docs.kubermatic.io/monitoring/runbook/#alert-httpcertexpiresverysoon
+      runbook_url: https://docs.loodse.com/kubermatic/master/monitoring/runbook/#alert-httpcertexpiresverysoon
     expr: probe_ssl_earliest_cert_expiry - time() < 24*3600
     labels:
       severity: critical

--- a/config/monitoring/prometheus/rules/general-cadvisor.yaml
+++ b/config/monitoring/prometheus/rules/general-cadvisor.yaml
@@ -5,7 +5,7 @@ groups:
   - alert: CadvisorDown
     annotations:
       message: Cadvisor has disappeared from Prometheus target discovery.
-      runbook_url: https://docs.kubermatic.io/monitoring/runbook/#alert-cadvisordown
+      runbook_url: https://docs.loodse.com/kubermatic/master/monitoring/runbook/#alert-cadvisordown
     expr: absent(up{job="cadvisor"} == 1)
     for: 15m
     labels:

--- a/config/monitoring/prometheus/rules/general-cert-manager.yaml
+++ b/config/monitoring/prometheus/rules/general-cert-manager.yaml
@@ -5,14 +5,14 @@ groups:
   - alert: CertManagerCertExpiresSoon
     annotations:
       message: The certificate {{ $labels.name }} expires in less than 3 days.
-      runbook_url: https://docs.kubermatic.io/monitoring/runbook/#alert-certmanagercertexpiressoon
+      runbook_url: https://docs.loodse.com/kubermatic/master/monitoring/runbook/#alert-certmanagercertexpiressoon
     expr: certmanager_certificate_expiration_timestamp_seconds - time() < 3*24*3600
     labels:
       severity: warning
   - alert: CertManagerCertExpiresVerySoon
     annotations:
       message: The certificate {{ $labels.name }} expires in less than 24 hours.
-      runbook_url: https://docs.kubermatic.io/monitoring/runbook/#alert-certmanagercertexpiresverysoon
+      runbook_url: https://docs.loodse.com/kubermatic/master/monitoring/runbook/#alert-certmanagercertexpiresverysoon
     expr: certmanager_certificate_expiration_timestamp_seconds - time() < 24*3600
     labels:
       severity: critical

--- a/config/monitoring/prometheus/rules/general-elasticsearch-exporter.yaml
+++ b/config/monitoring/prometheus/rules/general-elasticsearch-exporter.yaml
@@ -5,7 +5,7 @@ groups:
   - alert: ElasticsearchHeapTooHigh
     annotations:
       message: The heap usage of Elasticsearch node {{ $labels.name }} is over 90%.
-      runbook_url: https://docs.kubermatic.io/monitoring/runbook/#alert-elasticsearchheaptoohigh
+      runbook_url: https://docs.loodse.com/kubermatic/master/monitoring/runbook/#alert-elasticsearchheaptoohigh
     expr: elasticsearch_jvm_memory_used_bytes{area="heap"} / elasticsearch_jvm_memory_max_bytes{area="heap"}
       > 0.9
     for: 15m
@@ -14,7 +14,7 @@ groups:
   - alert: ElasticsearchClusterUnavailable
     annotations:
       message: The Elasticsearch cluster health endpoint does not respond to scrapes.
-      runbook_url: https://docs.kubermatic.io/monitoring/runbook/#alert-elasticsearchclusterunavailable
+      runbook_url: https://docs.loodse.com/kubermatic/master/monitoring/runbook/#alert-elasticsearchclusterunavailable
     expr: elasticsearch_cluster_health_up == 0
     for: 15m
     labels:
@@ -22,7 +22,7 @@ groups:
   - alert: ElasticsearchClusterUnhealthy
     annotations:
       message: The Elasticsearch cluster is not healthy.
-      runbook_url: https://docs.kubermatic.io/monitoring/runbook/#alert-elasticsearchclusterunhealthy
+      runbook_url: https://docs.loodse.com/kubermatic/master/monitoring/runbook/#alert-elasticsearchclusterunhealthy
     expr: elasticsearch_cluster_health_status{color="green"} == 0
     for: 15m
     labels:
@@ -30,7 +30,7 @@ groups:
   - alert: ElasticsearchUnassignedShards
     annotations:
       message: There are {{ $value }} unassigned shards in the Elasticsearch cluster.
-      runbook_url: https://docs.kubermatic.io/monitoring/runbook/#alert-elasticsearchunassignedshards
+      runbook_url: https://docs.loodse.com/kubermatic/master/monitoring/runbook/#alert-elasticsearchunassignedshards
     expr: elasticsearch_cluster_health_unassigned_shards > 0
     for: 15m
     labels:

--- a/config/monitoring/prometheus/rules/general-fluentbit.yaml
+++ b/config/monitoring/prometheus/rules/general-fluentbit.yaml
@@ -6,7 +6,7 @@ groups:
     annotations:
       message: Fluentbit pod `{{ $labels.pod }}` on `{{ $labels.node }}` is experiencing
         an elevated failed retry rate.
-      runbook_url: https://docs.kubermatic.io/monitoring/runbook/#alert-fluentbitmanyfailedretries
+      runbook_url: https://docs.loodse.com/kubermatic/master/monitoring/runbook/#alert-fluentbitmanyfailedretries
     expr: |
       sum by (namespace, pod, node) (kube_pod_info) *
         on (namespace, pod)
@@ -19,7 +19,7 @@ groups:
     annotations:
       message: Fluentbit pod `{{ $labels.pod }}` on `{{ $labels.node }}` is experiencing
         an elevated output error rate.
-      runbook_url: https://docs.kubermatic.io/monitoring/runbook/#alert-fluentbitmanyoutputerrors
+      runbook_url: https://docs.loodse.com/kubermatic/master/monitoring/runbook/#alert-fluentbitmanyoutputerrors
     expr: |
       sum by (namespace, pod, node) (kube_pod_info) *
         on (namespace, pod)
@@ -32,7 +32,7 @@ groups:
     annotations:
       message: Fluentbit pod `{{ $labels.pod }}` on `{{ $labels.node }}` has not processed
         any new logs for the last 30 minutes.
-      runbook_url: https://docs.kubermatic.io/monitoring/runbook/#alert-fluentbitnotprocessingnewlogs
+      runbook_url: https://docs.loodse.com/kubermatic/master/monitoring/runbook/#alert-fluentbitnotprocessingnewlogs
     expr: |
       sum by (namespace, pod, node) (kube_pod_info) *
         on (namespace, pod)

--- a/config/monitoring/prometheus/rules/general-helm-exporter.yaml
+++ b/config/monitoring/prometheus/rules/general-helm-exporter.yaml
@@ -7,7 +7,7 @@ groups:
       message: The Helm release `{{ $labels.release }}` (`{{ $labels.chart }}` chart
         in namespace `{{ $labels.exported_namespace }}`) in version {{ $labels.version
         }} has not been ready for more than 15 minutes.
-      runbook_url: https://docs.kubermatic.io/monitoring/runbook/#alert-helmreleasenotdeployed
+      runbook_url: https://docs.loodse.com/kubermatic/master/monitoring/runbook/#alert-helmreleasenotdeployed
     expr: helm_chart_info != 1
     for: 15m
     labels:

--- a/config/monitoring/prometheus/rules/general-kube-apiserver.yaml
+++ b/config/monitoring/prometheus/rules/general-kube-apiserver.yaml
@@ -20,7 +20,7 @@ groups:
   - alert: KubernetesApiserverDown
     annotations:
       message: KubernetesApiserver has disappeared from Prometheus target discovery.
-      runbook_url: https://docs.kubermatic.io/monitoring/runbook/#alert-kubernetesapiserverdown
+      runbook_url: https://docs.loodse.com/kubermatic/master/monitoring/runbook/#alert-kubernetesapiserverdown
     expr: absent(up{job="apiserver"} == 1)
     for: 15m
     labels:
@@ -29,7 +29,7 @@ groups:
     annotations:
       message: The API server has a 99th percentile latency of {{ $value }} seconds
         for {{ $labels.verb }} {{ $labels.resource }}.
-      runbook_url: https://docs.kubermatic.io/monitoring/runbook/#alert-kubeapilatencyhigh
+      runbook_url: https://docs.loodse.com/kubermatic/master/monitoring/runbook/#alert-kubeapilatencyhigh
     expr: cluster_quantile:apiserver_request_latencies:histogram_quantile{job="apiserver",quantile="0.99",subresource!="log",verb!~"^(?:LIST|WATCH|WATCHLIST|PROXY|CONNECT)$"}
       > 1
     for: 10m
@@ -39,7 +39,7 @@ groups:
     annotations:
       message: The API server has a 99th percentile latency of {{ $value }} seconds
         for {{ $labels.verb }} {{ $labels.resource }}.
-      runbook_url: https://docs.kubermatic.io/monitoring/runbook/#alert-kubeapilatencyhigh
+      runbook_url: https://docs.loodse.com/kubermatic/master/monitoring/runbook/#alert-kubeapilatencyhigh
     expr: cluster_quantile:apiserver_request_latencies:histogram_quantile{job="apiserver",quantile="0.99",subresource!="log",verb!~"^(?:LIST|WATCH|WATCHLIST|PROXY|CONNECT)$"}
       > 4
     for: 10m
@@ -48,7 +48,7 @@ groups:
   - alert: KubeAPIErrorsHigh
     annotations:
       message: API server is returning errors for {{ $value }}% of requests.
-      runbook_url: https://docs.kubermatic.io/monitoring/runbook/#alert-kubeapierrorshigh
+      runbook_url: https://docs.loodse.com/kubermatic/master/monitoring/runbook/#alert-kubeapierrorshigh
     expr: |
       sum(rate(apiserver_request_count{job="apiserver",code=~"^(?:5..)$"}[5m])) without(instance, pod)
         /
@@ -59,7 +59,7 @@ groups:
   - alert: KubeAPIErrorsHigh
     annotations:
       message: API server is returning errors for {{ $value }}% of requests.
-      runbook_url: https://docs.kubermatic.io/monitoring/runbook/#alert-kubeapierrorshigh
+      runbook_url: https://docs.loodse.com/kubermatic/master/monitoring/runbook/#alert-kubeapierrorshigh
     expr: |
       sum(rate(apiserver_request_count{job="apiserver",code=~"^(?:5..)$"}[5m])) without(instance, pod)
         /
@@ -71,7 +71,7 @@ groups:
     annotations:
       message: A client certificate used to authenticate to the apiserver is expiring
         in less than 7 days.
-      runbook_url: https://docs.kubermatic.io/monitoring/runbook/#alert-kubeclientcertificateexpiration
+      runbook_url: https://docs.loodse.com/kubermatic/master/monitoring/runbook/#alert-kubeclientcertificateexpiration
     expr: |
       apiserver_client_certificate_expiration_seconds_count{job="apiserver"} > 0
       and
@@ -82,7 +82,7 @@ groups:
     annotations:
       message: A client certificate used to authenticate to the apiserver is expiring
         in less than 24 hours.
-      runbook_url: https://docs.kubermatic.io/monitoring/runbook/#alert-kubeclientcertificateexpiration
+      runbook_url: https://docs.loodse.com/kubermatic/master/monitoring/runbook/#alert-kubeclientcertificateexpiration
     expr: |
       apiserver_client_certificate_expiration_seconds_count{job="apiserver"} > 0
       and

--- a/config/monitoring/prometheus/rules/general-kube-kubelet.yaml
+++ b/config/monitoring/prometheus/rules/general-kube-kubelet.yaml
@@ -5,7 +5,7 @@ groups:
   - alert: KubeletDown
     annotations:
       message: Kubelet has disappeared from Prometheus target discovery.
-      runbook_url: https://docs.kubermatic.io/monitoring/runbook/#alert-kubeletdown
+      runbook_url: https://docs.loodse.com/kubermatic/master/monitoring/runbook/#alert-kubeletdown
     expr: absent(up{job="kubelet"} == 1)
     for: 15m
     labels:
@@ -15,7 +15,7 @@ groups:
       message: The PersistentVolume claimed by {{ $labels.persistentvolumeclaim }}
         in namespace {{ $labels.namespace }} is only {{ printf "%0.0f" $value }}%
         free.
-      runbook_url: https://docs.kubermatic.io/monitoring/runbook/#alert-kubepersistentvolumeusagecritical
+      runbook_url: https://docs.loodse.com/kubermatic/master/monitoring/runbook/#alert-kubepersistentvolumeusagecritical
     expr: |
       100 * kubelet_volume_stats_available_bytes{job="kubelet"}
         /
@@ -29,7 +29,7 @@ groups:
       message: Based on recent sampling, the PersistentVolume claimed by {{ $labels.persistentvolumeclaim
         }} in namespace {{ $labels.namespace }} is expected to fill up within four
         days. Currently {{ $value }} bytes are available.
-      runbook_url: https://docs.kubermatic.io/monitoring/runbook/#alert-kubepersistentvolumefullinfourdays
+      runbook_url: https://docs.loodse.com/kubermatic/master/monitoring/runbook/#alert-kubepersistentvolumefullinfourdays
     expr: |
       (
         kubelet_volume_stats_used_bytes{job="kubelet"}
@@ -45,7 +45,7 @@ groups:
     annotations:
       message: Kubelet {{ $labels.instance }} is running {{ $value }} pods, close
         to the limit of 110.
-      runbook_url: https://docs.kubermatic.io/monitoring/runbook/#alert-kubelettoomanypods
+      runbook_url: https://docs.loodse.com/kubermatic/master/monitoring/runbook/#alert-kubelettoomanypods
     expr: kubelet_running_pod_count{job="kubelet"} > 110 * 0.9
     for: 15m
     labels:
@@ -54,7 +54,7 @@ groups:
     annotations:
       message: The kubelet on {{ $labels.instance }} is experiencing {{ printf "%0.0f"
         $value }}% errors.
-      runbook_url: https://docs.kubermatic.io/monitoring/runbook/#alert-kubeclienterrors
+      runbook_url: https://docs.loodse.com/kubermatic/master/monitoring/runbook/#alert-kubeclienterrors
     expr: |
       (sum(rate(rest_client_requests_total{code=~"(5..|<error>)",job="kubelet"}[5m])) by (instance)
         /
@@ -67,7 +67,7 @@ groups:
     annotations:
       message: The pod {{ $labels.namespace }}/{{ $labels.pod }} is experiencing {{
         printf "%0.0f" $value }}% errors.
-      runbook_url: https://docs.kubermatic.io/monitoring/runbook/#alert-kubeclienterrors
+      runbook_url: https://docs.loodse.com/kubermatic/master/monitoring/runbook/#alert-kubeclienterrors
     expr: |
       (sum(rate(rest_client_requests_total{code=~"(5..|<error>)",job="pods"}[5m])) by (namespace, pod)
         /
@@ -80,7 +80,7 @@ groups:
     annotations:
       message: The kubelet on {{ $labels.instance }} is having an elevated error rate
         for container runtime oprations.
-      runbook_url: https://docs.kubermatic.io/monitoring/runbook/#alert-kubeletruntimeerrors
+      runbook_url: https://docs.loodse.com/kubermatic/master/monitoring/runbook/#alert-kubeletruntimeerrors
     expr: |
       sum(rate(kubelet_runtime_operations_errors{job="kubelet"}[5m])) by (instance) > 0.1
     for: 15m
@@ -90,7 +90,7 @@ groups:
     annotations:
       message: The kubelet's cgroup manager latency on {{ $labels.instance }} has
         been elevated ({{ printf "%0.2f" $value }}ms) for more than 15 minutes.
-      runbook_url: https://docs.kubermatic.io/monitoring/runbook/#alert-kubeletcgroupmanagerlatencyhigh
+      runbook_url: https://docs.loodse.com/kubermatic/master/monitoring/runbook/#alert-kubeletcgroupmanagerlatencyhigh
     expr: |
       sum(rate(kubelet_cgroup_manager_latency_microseconds{quantile="0.9"}[5m])) by (instance) / 1000 > 1
     for: 15m
@@ -101,7 +101,7 @@ groups:
       message: The kubelet's pod worker latency for {{ $labels.operation_type }} operations
         on {{ $labels.instance }} has been elevated ({{ printf "%0.2f" $value }}ms)
         for more than 15 minutes.
-      runbook_url: https://docs.kubermatic.io/monitoring/runbook/#alert-kubeletpodworkerlatencyhigh
+      runbook_url: https://docs.loodse.com/kubermatic/master/monitoring/runbook/#alert-kubeletpodworkerlatencyhigh
     expr: |
       sum(rate(kubelet_pod_worker_latency_microseconds{quantile="0.9"}[5m])) by (instance, operation_type) / 1000 > 250
     for: 15m
@@ -111,7 +111,7 @@ groups:
     annotations:
       message: There are {{ $value }} different versions of Kubernetes components
         running.
-      runbook_url: https://docs.kubermatic.io/monitoring/runbook/#alert-kubeversionmismatch
+      runbook_url: https://docs.loodse.com/kubermatic/master/monitoring/runbook/#alert-kubeversionmismatch
     expr: count(count(kubernetes_build_info{job!="dns"}) by (gitVersion)) > 1
     for: 1h
     labels:

--- a/config/monitoring/prometheus/rules/general-kube-state-metrics.yaml
+++ b/config/monitoring/prometheus/rules/general-kube-state-metrics.yaml
@@ -52,7 +52,7 @@ groups:
   - alert: KubeStateMetricsDown
     annotations:
       message: KubeStateMetrics has disappeared from Prometheus target discovery.
-      runbook_url: https://docs.kubermatic.io/monitoring/runbook/#alert-kubestatemetricsdown
+      runbook_url: https://docs.loodse.com/kubermatic/master/monitoring/runbook/#alert-kubestatemetricsdown
     expr: absent(up{job="kube-state-metrics"} == 1)
     for: 15m
     labels:
@@ -61,7 +61,7 @@ groups:
     annotations:
       message: Pod {{ $labels.namespace }}/{{ $labels.pod }} ({{ $labels.container
         }}) is restarting {{ printf "%.2f" $value }} times / 5 minutes.
-      runbook_url: https://docs.kubermatic.io/monitoring/runbook/#alert-kubepodcrashlooping
+      runbook_url: https://docs.loodse.com/kubermatic/master/monitoring/runbook/#alert-kubepodcrashlooping
     expr: rate(kube_pod_container_status_restarts_total{job="kube-state-metrics"}[15m])
       * 60 * 5 > 0
     for: 1h
@@ -71,7 +71,7 @@ groups:
     annotations:
       message: Pod {{ $labels.namespace }}/{{ $labels.pod }} has been in a non-ready
         state for longer than an hour.
-      runbook_url: https://docs.kubermatic.io/monitoring/runbook/#alert-kubepodnotready
+      runbook_url: https://docs.loodse.com/kubermatic/master/monitoring/runbook/#alert-kubepodnotready
     expr: sum by (namespace, pod) (kube_pod_status_phase{job="kube-state-metrics",
       phase=~"Pending|Unknown"}) > 0
     for: 30m
@@ -82,7 +82,7 @@ groups:
       message: Deployment generation for {{ $labels.namespace }}/{{ $labels.deployment
         }} does not match, this indicates that the Deployment has failed but has not
         been rolled back.
-      runbook_url: https://docs.kubermatic.io/monitoring/runbook/#alert-kubedeploymentgenerationmismatch
+      runbook_url: https://docs.loodse.com/kubermatic/master/monitoring/runbook/#alert-kubedeploymentgenerationmismatch
     expr: |
       kube_deployment_status_observed_generation{job="kube-state-metrics"}
         !=
@@ -94,7 +94,7 @@ groups:
     annotations:
       message: Deployment {{ $labels.namespace }}/{{ $labels.deployment }} has not
         matched the expected number of replicas for longer than an hour.
-      runbook_url: https://docs.kubermatic.io/monitoring/runbook/#alert-kubedeploymentreplicasmismatch
+      runbook_url: https://docs.loodse.com/kubermatic/master/monitoring/runbook/#alert-kubedeploymentreplicasmismatch
     expr: |
       kube_deployment_spec_replicas{job="kube-state-metrics"}
         !=
@@ -106,7 +106,7 @@ groups:
     annotations:
       message: StatefulSet {{ $labels.namespace }}/{{ $labels.statefulset }} has not
         matched the expected number of replicas for longer than 15 minutes.
-      runbook_url: https://docs.kubermatic.io/monitoring/runbook/#alert-kubestatefulsetreplicasmismatch
+      runbook_url: https://docs.loodse.com/kubermatic/master/monitoring/runbook/#alert-kubestatefulsetreplicasmismatch
     expr: |
       kube_statefulset_status_replicas_ready{job="kube-state-metrics"}
         !=
@@ -119,7 +119,7 @@ groups:
       message: StatefulSet generation for {{ $labels.namespace }}/{{ $labels.statefulset
         }} does not match, this indicates that the StatefulSet has failed but has
         not been rolled back.
-      runbook_url: https://docs.kubermatic.io/monitoring/runbook/#alert-kubestatefulsetgenerationmismatch
+      runbook_url: https://docs.loodse.com/kubermatic/master/monitoring/runbook/#alert-kubestatefulsetgenerationmismatch
     expr: |
       kube_statefulset_status_observed_generation{job="kube-state-metrics"}
         !=
@@ -131,7 +131,7 @@ groups:
     annotations:
       message: StatefulSet {{ $labels.namespace }}/{{ $labels.statefulset }} update
         has not been rolled out.
-      runbook_url: https://docs.kubermatic.io/monitoring/runbook/#alert-kubestatefulsetupdatenotrolledout
+      runbook_url: https://docs.loodse.com/kubermatic/master/monitoring/runbook/#alert-kubestatefulsetupdatenotrolledout
     expr: |
       max without (revision) (
         kube_statefulset_status_current_revision{job="kube-state-metrics"}
@@ -151,7 +151,7 @@ groups:
     annotations:
       message: Only {{ $value }}% of the desired Pods of DaemonSet {{ $labels.namespace
         }}/{{ $labels.daemonset }} are scheduled and ready.
-      runbook_url: https://docs.kubermatic.io/monitoring/runbook/#alert-kubedaemonsetrolloutstuck
+      runbook_url: https://docs.loodse.com/kubermatic/master/monitoring/runbook/#alert-kubedaemonsetrolloutstuck
     expr: |
       kube_daemonset_status_number_ready{job="kube-state-metrics"}
         /
@@ -163,7 +163,7 @@ groups:
     annotations:
       message: '{{ $value }} Pods of DaemonSet {{ $labels.namespace }}/{{ $labels.daemonset
         }} are not scheduled.'
-      runbook_url: https://docs.kubermatic.io/monitoring/runbook/#alert-kubedaemonsetnotscheduled
+      runbook_url: https://docs.loodse.com/kubermatic/master/monitoring/runbook/#alert-kubedaemonsetnotscheduled
     expr: |
       kube_daemonset_status_desired_number_scheduled{job="kube-state-metrics"}
         -
@@ -175,7 +175,7 @@ groups:
     annotations:
       message: '{{ $value }} Pods of DaemonSet {{ $labels.namespace }}/{{ $labels.daemonset
         }} are running where they are not supposed to run.'
-      runbook_url: https://docs.kubermatic.io/monitoring/runbook/#alert-kubedaemonsetmisscheduled
+      runbook_url: https://docs.loodse.com/kubermatic/master/monitoring/runbook/#alert-kubedaemonsetmisscheduled
     expr: kube_daemonset_status_number_misscheduled{job="kube-state-metrics"} > 0
     for: 10m
     labels:
@@ -184,7 +184,7 @@ groups:
     annotations:
       message: CronJob {{ $labels.namespace }}/{{ $labels.cronjob }} is taking more
         than 1h to complete.
-      runbook_url: https://docs.kubermatic.io/monitoring/runbook/#alert-kubecronjobrunning
+      runbook_url: https://docs.loodse.com/kubermatic/master/monitoring/runbook/#alert-kubecronjobrunning
     expr: time() - kube_cronjob_next_schedule_time{job="kube-state-metrics"} > 3600
     for: 1h
     labels:
@@ -193,7 +193,7 @@ groups:
     annotations:
       message: Job {{ $labels.namespace }}/{{ $labels.job_name }} is taking more than
         one hour to complete.
-      runbook_url: https://docs.kubermatic.io/monitoring/runbook/#alert-kubejobcompletion
+      runbook_url: https://docs.loodse.com/kubermatic/master/monitoring/runbook/#alert-kubejobcompletion
     expr: kube_job_spec_completions{job="kube-state-metrics"} - kube_job_status_succeeded{job="kube-state-metrics"}
       > 0
     for: 1h
@@ -202,7 +202,7 @@ groups:
   - alert: KubeJobFailed
     annotations:
       message: Job {{ $labels.namespace }}/{{ $labels.job_name }} failed to complete.
-      runbook_url: https://docs.kubermatic.io/monitoring/runbook/#alert-kubejobfailed
+      runbook_url: https://docs.loodse.com/kubermatic/master/monitoring/runbook/#alert-kubejobfailed
     expr: kube_job_status_failed{job="kube-state-metrics"} > 0
     for: 1h
     labels:
@@ -210,7 +210,7 @@ groups:
   - alert: KubeCPUOvercommit
     annotations:
       message: Cluster has overcommitted CPU resource requests for namespaces.
-      runbook_url: https://docs.kubermatic.io/monitoring/runbook/#alert-kubecpuovercommit
+      runbook_url: https://docs.loodse.com/kubermatic/master/monitoring/runbook/#alert-kubecpuovercommit
     expr: |
       sum(kube_resourcequota{job="kube-state-metrics", type="hard", resource="requests.cpu"})
         /
@@ -223,7 +223,7 @@ groups:
     annotations:
       message: Cluster has overcommitted CPU resource requests for pods and cannot
         tolerate node failure.
-      runbook_url: https://docs.kubermatic.io/monitoring/runbook/#alert-kubecpuovercommit
+      runbook_url: https://docs.loodse.com/kubermatic/master/monitoring/runbook/#alert-kubecpuovercommit
     expr: |
       sum(namespace_name:kube_pod_container_resource_requests_cpu_cores:sum)
         /
@@ -236,7 +236,7 @@ groups:
   - alert: KubeMemOvercommit
     annotations:
       message: Cluster has overcommitted memory resource requests for namespaces.
-      runbook_url: https://docs.kubermatic.io/monitoring/runbook/#alert-kubememovercommit
+      runbook_url: https://docs.loodse.com/kubermatic/master/monitoring/runbook/#alert-kubememovercommit
     expr: |
       sum(kube_resourcequota{job="kube-state-metrics", type="hard", resource="requests.memory"})
         /
@@ -249,7 +249,7 @@ groups:
     annotations:
       message: Cluster has overcommitted memory resource requests for pods and cannot
         tolerate node failure.
-      runbook_url: https://docs.kubermatic.io/monitoring/runbook/#alert-kubememovercommit
+      runbook_url: https://docs.loodse.com/kubermatic/master/monitoring/runbook/#alert-kubememovercommit
     expr: |
       sum(namespace_name:kube_pod_container_resource_requests_memory_bytes:sum)
         /
@@ -265,7 +265,7 @@ groups:
     annotations:
       message: Namespace {{ $labels.namespace }} is using {{ printf "%0.0f" $value
         }}% of its {{ $labels.resource }} quota.
-      runbook_url: https://docs.kubermatic.io/monitoring/runbook/#alert-kubequotaexceeded
+      runbook_url: https://docs.loodse.com/kubermatic/master/monitoring/runbook/#alert-kubequotaexceeded
     expr: |
       100 * kube_resourcequota{job="kube-state-metrics", type="used"}
         / ignoring(instance, job, type)
@@ -278,7 +278,7 @@ groups:
     annotations:
       message: Container {{ $labels.container }} in pod {{ $labels.namespace }}/{{
         $labels.pod }} has been OOMKilled {{ $value }} times in the last 30 minutes.
-      runbook_url: https://docs.kubermatic.io/monitoring/runbook/#alert-kubepodoomkilled
+      runbook_url: https://docs.loodse.com/kubermatic/master/monitoring/runbook/#alert-kubepodoomkilled
     expr: |
       (kube_pod_container_status_restarts_total - kube_pod_container_status_restarts_total offset 30m >= 2)
       and
@@ -289,7 +289,7 @@ groups:
   - alert: KubeNodeNotReady
     annotations:
       message: '{{ $labels.node }} has been unready for more than an hour.'
-      runbook_url: https://docs.kubermatic.io/monitoring/runbook/#alert-kubenodenotready
+      runbook_url: https://docs.loodse.com/kubermatic/master/monitoring/runbook/#alert-kubenodenotready
     expr: kube_node_status_condition{job="kube-state-metrics",condition="Ready",status="true"}
       == 0
     for: 1h

--- a/config/monitoring/prometheus/rules/general-node-exporter.yaml
+++ b/config/monitoring/prometheus/rules/general-node-exporter.yaml
@@ -156,7 +156,7 @@ groups:
     annotations:
       message: Filesystem on {{ $labels.device }} at {{ $labels.instance }} is predicted
         to run out of space within the next 24 hours.
-      runbook_url: https://docs.kubermatic.io/monitoring/runbook/#alert-nodefilesystemspacefillingup
+      runbook_url: https://docs.loodse.com/kubermatic/master/monitoring/runbook/#alert-nodefilesystemspacefillingup
     expr: |
       predict_linear(node_filesystem_avail_bytes{app="node-exporter",fstype=~"ext.|xfs"}[6h], 24*60*60) < 0
       and
@@ -170,7 +170,7 @@ groups:
     annotations:
       message: Filesystem on {{ $labels.device }} at {{ $labels.instance }} is predicted
         to run out of space within the next 4 hours.
-      runbook_url: https://docs.kubermatic.io/monitoring/runbook/#alert-nodefilesystemspacefillingup
+      runbook_url: https://docs.loodse.com/kubermatic/master/monitoring/runbook/#alert-nodefilesystemspacefillingup
     expr: |
       predict_linear(node_filesystem_avail_bytes{app="node-exporter",fstype=~"ext.|xfs"}[6h], 4*60*60) < 0
       and
@@ -184,7 +184,7 @@ groups:
     annotations:
       message: Filesystem on {{ $labels.device }} at {{ $labels.instance }} has only
         {{ $value }}% available space left.
-      runbook_url: https://docs.kubermatic.io/monitoring/runbook/#alert-nodefilesystemoutofspace
+      runbook_url: https://docs.loodse.com/kubermatic/master/monitoring/runbook/#alert-nodefilesystemoutofspace
     expr: |
       node_filesystem_avail_bytes{app="node-exporter",fstype=~"ext.|xfs"} / node_filesystem_size_bytes{app="node-exporter",fstype=~"ext.|xfs"} * 100 < 5
       and
@@ -196,7 +196,7 @@ groups:
     annotations:
       message: Filesystem on {{ $labels.device }} at {{ $labels.instance }} has only
         {{ $value }}% available space left.
-      runbook_url: https://docs.kubermatic.io/monitoring/runbook/#alert-nodefilesystemoutofspace
+      runbook_url: https://docs.loodse.com/kubermatic/master/monitoring/runbook/#alert-nodefilesystemoutofspace
     expr: |
       node_filesystem_avail_bytes{app="node-exporter",fstype=~"ext.|xfs"} / node_filesystem_size_bytes{app="node-exporter",fstype=~"ext.|xfs"} * 100 < 3
       and
@@ -208,7 +208,7 @@ groups:
     annotations:
       message: Filesystem on {{ $labels.device }} at {{ $labels.instance }} is predicted
         to run out of files within the next 24 hours.
-      runbook_url: https://docs.kubermatic.io/monitoring/runbook/#alert-nodefilesystemfilesfillingup
+      runbook_url: https://docs.loodse.com/kubermatic/master/monitoring/runbook/#alert-nodefilesystemfilesfillingup
     expr: |
       predict_linear(node_filesystem_files_free{app="node-exporter",fstype=~"ext.|xfs"}[6h], 24*60*60) < 0
       and
@@ -222,7 +222,7 @@ groups:
     annotations:
       message: Filesystem on {{ $labels.device }} at {{ $labels.instance }} is predicted
         to run out of files within the next 4 hours.
-      runbook_url: https://docs.kubermatic.io/monitoring/runbook/#alert-nodefilesystemfilesfillingup
+      runbook_url: https://docs.loodse.com/kubermatic/master/monitoring/runbook/#alert-nodefilesystemfilesfillingup
     expr: |
       predict_linear(node_filesystem_files_free{app="node-exporter",fstype=~"ext.|xfs"}[6h], 4*60*60) < 0
       and
@@ -236,7 +236,7 @@ groups:
     annotations:
       message: Filesystem on {{ $labels.device }} at {{ $labels.instance }} has only
         {{ $value }}% available inodes left.
-      runbook_url: https://docs.kubermatic.io/monitoring/runbook/#alert-nodefilesystemoutoffiles
+      runbook_url: https://docs.loodse.com/kubermatic/master/monitoring/runbook/#alert-nodefilesystemoutoffiles
     expr: |
       node_filesystem_files_free{app="node-exporter",fstype=~"ext.|xfs"} / node_filesystem_files{app="node-exporter",fstype=~"ext.|xfs"} * 100 < 5
       and
@@ -248,7 +248,7 @@ groups:
     annotations:
       message: Filesystem on {{ $labels.device }} at {{ $labels.instance }} has only
         {{ $value }}% available space left.
-      runbook_url: https://docs.kubermatic.io/monitoring/runbook/#alert-nodefilesystemoutofspace
+      runbook_url: https://docs.loodse.com/kubermatic/master/monitoring/runbook/#alert-nodefilesystemoutofspace
     expr: |
       node_filesystem_files_free{app="node-exporter",fstype=~"ext.|xfs"} / node_filesystem_files{app="node-exporter",fstype=~"ext.|xfs"} * 100 < 3
       and
@@ -260,7 +260,7 @@ groups:
     annotations:
       message: '{{ $labels.instance }} interface {{ $labels.device }} shows errors
         while receiving packets ({{ $value }} errors in two minutes).'
-      runbook_url: https://docs.kubermatic.io/monitoring/runbook/#alert-nodenetworkreceiveerrs
+      runbook_url: https://docs.loodse.com/kubermatic/master/monitoring/runbook/#alert-nodenetworkreceiveerrs
     expr: increase(node_network_receive_errs_total[2m]) > 10
     for: 1h
     labels:
@@ -269,7 +269,7 @@ groups:
     annotations:
       message: '{{ $labels.instance }} interface {{ $labels.device }} shows errors
         while transmitting packets ({{ $value }} errors in two minutes).'
-      runbook_url: https://docs.kubermatic.io/monitoring/runbook/#alert-nodenetworktransmiterrs
+      runbook_url: https://docs.loodse.com/kubermatic/master/monitoring/runbook/#alert-nodenetworktransmiterrs
     expr: increase(node_network_transmit_errs_total[2m]) > 10
     for: 1h
     labels:

--- a/config/monitoring/prometheus/rules/general-prometheus.yaml
+++ b/config/monitoring/prometheus/rules/general-prometheus.yaml
@@ -6,7 +6,7 @@ groups:
     annotations:
       message: Prometheus failed to scrape a target {{ $labels.job }} / {{ $labels.instance
         }}.
-      runbook_url: https://docs.kubermatic.io/monitoring/runbook/#alert-promscrapefailed
+      runbook_url: https://docs.loodse.com/kubermatic/master/monitoring/runbook/#alert-promscrapefailed
     expr: up != 1
     for: 15m
     labels:
@@ -14,7 +14,7 @@ groups:
   - alert: PromBadConfig
     annotations:
       mesage: Prometheus failed to reload config.
-      runbook_url: https://docs.kubermatic.io/monitoring/runbook/#alert-prombadconfig
+      runbook_url: https://docs.loodse.com/kubermatic/master/monitoring/runbook/#alert-prombadconfig
     expr: prometheus_config_last_reload_successful{job="prometheus"} == 0
     for: 15m
     labels:
@@ -22,7 +22,7 @@ groups:
   - alert: PromAlertmanagerBadConfig
     annotations:
       message: Alertmanager failed to reload config.
-      runbook_url: https://docs.kubermatic.io/monitoring/runbook/#alert-promalertmanagerbadconfig
+      runbook_url: https://docs.loodse.com/kubermatic/master/monitoring/runbook/#alert-promalertmanagerbadconfig
     expr: alertmanager_config_last_reload_successful{job="alertmanager"} == 0
     for: 10m
     labels:
@@ -30,7 +30,7 @@ groups:
   - alert: PromAlertsFailed
     annotations:
       message: Alertmanager failed to send an alert.
-      runbook_url: https://docs.kubermatic.io/monitoring/runbook/#alert-promalertsfailed
+      runbook_url: https://docs.loodse.com/kubermatic/master/monitoring/runbook/#alert-promalertsfailed
     expr: sum(increase(alertmanager_notifications_failed_total{job="alertmanager"}[5m]))
       by (namespace) > 0
     for: 5m
@@ -39,7 +39,7 @@ groups:
   - alert: PromRemoteStorageFailures
     annotations:
       message: Prometheus failed to send {{ printf "%.1f" $value }}% samples.
-      runbook_url: https://docs.kubermatic.io/monitoring/runbook/#alert-promremotestoragefailures
+      runbook_url: https://docs.loodse.com/kubermatic/master/monitoring/runbook/#alert-promremotestoragefailures
     expr: |
       (rate(prometheus_remote_storage_failed_samples_total{job="prometheus"}[1m]) * 100)
         /
@@ -51,7 +51,7 @@ groups:
   - alert: PromRuleFailures
     annotations:
       message: Prometheus failed to evaluate {{ printf "%.1f" $value }} rules/sec.
-      runbook_url: https://docs.kubermatic.io/monitoring/runbook/#alert-promrulefailures
+      runbook_url: https://docs.loodse.com/kubermatic/master/monitoring/runbook/#alert-promrulefailures
     expr: rate(prometheus_rule_evaluation_failures_total{job="prometheus"}[1m]) >
       0
     for: 15m

--- a/config/monitoring/prometheus/rules/general-thanos.yaml
+++ b/config/monitoring/prometheus/rules/general-thanos.yaml
@@ -6,7 +6,7 @@ groups:
     annotations:
       message: The Thanos sidecar in `{{ $labels.namespace }}/{{ $labels.pod }}` is
         down.
-      runbook_url: https://docs.kubermatic.io/monitoring/runbook/#alert-thanossidecardown
+      runbook_url: https://docs.loodse.com/kubermatic/master/monitoring/runbook/#alert-thanossidecardown
     expr: thanos_sidecar_prometheus_up != 1
     for: 5m
     labels:
@@ -15,7 +15,7 @@ groups:
     annotations:
       message: The Thanos sidecar in `{{ $labels.namespace }}/{{ $labels.pod }}` didn't
         send a heartbeat in {{ $value }} seconds.
-      runbook_url: https://docs.kubermatic.io/monitoring/runbook/#alert-thanossidecardown
+      runbook_url: https://docs.loodse.com/kubermatic/master/monitoring/runbook/#alert-thanossidecardown
     expr: time() - thanos_sidecar_last_heartbeat_success_time_seconds > 60
     for: 3m
     labels:
@@ -24,7 +24,7 @@ groups:
     annotations:
       message: The Thanos compactor in `{{ $labels.namespace }}` is experiencing a
         high retry rate.
-      runbook_url: https://docs.kubermatic.io/monitoring/runbook/#alert-thanoscompactormanyretries
+      runbook_url: https://docs.loodse.com/kubermatic/master/monitoring/runbook/#alert-thanoscompactormanyretries
     expr: sum(rate(thanos_compactor_retries_total[5m])) > 0.01
     for: 10m
     labels:
@@ -33,7 +33,7 @@ groups:
     annotations:
       message: The Thanos shipper in `{{ $labels.namespace }}/{{ $labels.pod }}` is
         experiencing a high dir-sync failure rate.
-      runbook_url: https://docs.kubermatic.io/monitoring/runbook/#alert-thanosshippermanydirsyncfailures
+      runbook_url: https://docs.loodse.com/kubermatic/master/monitoring/runbook/#alert-thanosshippermanydirsyncfailures
     expr: sum(rate(thanos_shipper_dir_sync_failures_total[5m])) > 0.01
     for: 10m
     labels:
@@ -42,7 +42,7 @@ groups:
     annotations:
       message: The Thanos component in `{{ $labels.namespace }}/{{ $labels.pod }}`
         is experiencing a panic recovery rate.
-      runbook_url: https://docs.kubermatic.io/monitoring/runbook/#alert-thanosmanypanicrecoveries
+      runbook_url: https://docs.loodse.com/kubermatic/master/monitoring/runbook/#alert-thanosmanypanicrecoveries
     expr: sum(rate(thanos_grpc_req_panics_recovered_total[5m])) > 0.01
     for: 10m
     labels:
@@ -51,7 +51,7 @@ groups:
     annotations:
       message: The Thanos store in `{{ $labels.namespace }}/{{ $labels.pod }}` is
         experiencing a many failed block loads.
-      runbook_url: https://docs.kubermatic.io/monitoring/runbook/#alert-thanosmanyblockloadfailures
+      runbook_url: https://docs.loodse.com/kubermatic/master/monitoring/runbook/#alert-thanosmanyblockloadfailures
     expr: sum(rate(thanos_bucket_store_block_load_failures_total[5m])) > 0.01
     for: 10m
     labels:
@@ -60,7 +60,7 @@ groups:
     annotations:
       message: The Thanos store in `{{ $labels.namespace }}/{{ $labels.pod }}` is
         experiencing a many failed block drops.
-      runbook_url: https://docs.kubermatic.io/monitoring/runbook/#alert-thanosmanyblockdropfailures
+      runbook_url: https://docs.loodse.com/kubermatic/master/monitoring/runbook/#alert-thanosmanyblockdropfailures
     expr: sum(rate(thanos_bucket_store_block_drop_failures_total[5m])) > 0.01
     for: 10m
     labels:

--- a/config/monitoring/prometheus/rules/general-velero.yaml
+++ b/config/monitoring/prometheus/rules/general-velero.yaml
@@ -6,7 +6,7 @@ groups:
     annotations:
       message: Backup schedule {{ $labels.schedule }} has been taking more than 60min
         already.
-      runbook_url: https://docs.kubermatic.io/monitoring/runbook/#alert-velerobackuptakestoolong
+      runbook_url: https://docs.loodse.com/kubermatic/master/monitoring/runbook/#alert-velerobackuptakestoolong
     expr: (velero_backup_attempt_total - velero_backup_success_total) > 0
     for: 60m
     labels:
@@ -15,7 +15,7 @@ groups:
     annotations:
       message: There has not been a successful backup for schedule {{ $labels.schedule
         }} in the last 24 hours.
-      runbook_url: https://docs.kubermatic.io/monitoring/runbook/#alert-veleronorecentbackup
+      runbook_url: https://docs.loodse.com/kubermatic/master/monitoring/runbook/#alert-veleronorecentbackup
     expr: time() - velero_backup_last_successful_timestamp{schedule!=""} > 3600*25
     labels:
       severity: warning

--- a/config/monitoring/prometheus/rules/kubermatic-master-kubermatic.yaml
+++ b/config/monitoring/prometheus/rules/kubermatic-master-kubermatic.yaml
@@ -5,7 +5,7 @@ groups:
   - alert: KubermaticAPIDown
     annotations:
       message: KubermaticAPI has disappeared from Prometheus target discovery.
-      runbook_url: https://docs.kubermatic.io/monitoring/runbook/#alert-kubermaticapidown
+      runbook_url: https://docs.loodse.com/kubermatic/master/monitoring/runbook/#alert-kubermaticapidown
     expr: absent(up{job="pods",namespace="kubermatic",role="kubermatic-api"} == 1)
     for: 15m
     labels:
@@ -13,7 +13,7 @@ groups:
   - alert: KubermaticAPITooManyErrors
     annotations:
       message: Kubermatic API is returning a high rate of HTTP 5xx responses.
-      runbook_url: https://docs.kubermatic.io/monitoring/runbook/#alert-kubermaticapitoomanyerrors
+      runbook_url: https://docs.loodse.com/kubermatic/master/monitoring/runbook/#alert-kubermaticapitoomanyerrors
     expr: sum(rate(http_requests_total{role="kubermatic-api",code=~"5.."}[5m])) >
       0.1
     for: 15m

--- a/config/monitoring/prometheus/rules/kubermatic-seed-kubermatic.yaml
+++ b/config/monitoring/prometheus/rules/kubermatic-seed-kubermatic.yaml
@@ -6,7 +6,7 @@ groups:
     annotations:
       message: Kubermatic controller manager in {{ $labels.namespace }} is experiencing
         too many errors.
-      runbook_url: https://docs.kubermatic.io/monitoring/runbook/#alert-kubermatictoomanyunhandlederrors
+      runbook_url: https://docs.loodse.com/kubermatic/master/monitoring/runbook/#alert-kubermatictoomanyunhandlederrors
     expr: sum(rate(kubermatic_controller_manager_unhandled_errors_total[5m])) > 0.01
     for: 10m
     labels:
@@ -14,7 +14,7 @@ groups:
   - alert: KubermaticClusterDeletionTakesTooLong
     annotations:
       message: Cluster {{ $labels.cluster }} is stuck in deletion for more than 30min.
-      runbook_url: https://docs.kubermatic.io/monitoring/runbook/#alert-kubermaticclusterdeletiontakestoolong
+      runbook_url: https://docs.loodse.com/kubermatic/master/monitoring/runbook/#alert-kubermaticclusterdeletiontakestoolong
     expr: (time() - max by (cluster) (kubermatic_cluster_deleted)) > 30*60
     for: 0m
     labels:
@@ -23,7 +23,7 @@ groups:
     annotations:
       message: Addon {{ $labels.addon }} in cluster {{ $labels.cluster }} is stuck
         in deletion for more than 30min.
-      runbook_url: https://docs.kubermatic.io/monitoring/runbook/#alert-kubermaticaddondeletiontakestoolong
+      runbook_url: https://docs.loodse.com/kubermatic/master/monitoring/runbook/#alert-kubermaticaddondeletiontakestoolong
     expr: (time() - max by (cluster,addon) (kubermatic_addon_deleted)) > 30*60
     for: 0m
     labels:
@@ -32,7 +32,7 @@ groups:
     annotations:
       message: KubermaticControllerManager has disappeared from Prometheus target
         discovery.
-      runbook_url: https://docs.kubermatic.io/monitoring/runbook/#alert-kubermaticcontrollermanagerdown
+      runbook_url: https://docs.loodse.com/kubermatic/master/monitoring/runbook/#alert-kubermaticcontrollermanagerdown
     expr: absent(up{job="pods",namespace="kubermatic",role="controller-manager"} ==
       1)
     for: 15m
@@ -41,7 +41,7 @@ groups:
   - alert: OpenVPNServerDown
     annotations:
       message: There is no healthy OpenVPN server in cluster {{ $labels.cluster }}.
-      runbook_url: https://docs.kubermatic.io/monitoring/runbook/#alert-openvpnserverdown
+      runbook_url: https://docs.loodse.com/kubermatic/master/monitoring/runbook/#alert-openvpnserverdown
     expr: absent(kube_deployment_status_replicas_available{cluster!="",deployment="openvpn-server"}
       > 0) and count(kubermatic_cluster_info) > 0
     for: 15m
@@ -50,7 +50,7 @@ groups:
   - alert: UserClusterPrometheusAbsent
     annotations:
       message: There is no Prometheus in cluster {{ $labels.name }}.
-      runbook_url: https://docs.kubermatic.io/monitoring/runbook/#alert-userclusterprometheusdisappeared
+      runbook_url: https://docs.loodse.com/kubermatic/master/monitoring/runbook/#alert-userclusterprometheusdisappeared
     expr: |
       (
         kubermatic_cluster_info * on (name) group_left

--- a/config/monitoring/prometheus/rules/managed-kube-controller-manager.yaml
+++ b/config/monitoring/prometheus/rules/managed-kube-controller-manager.yaml
@@ -12,7 +12,7 @@ groups:
   - alert: KubeControllerManagerDown
     annotations:
       message: No healthy controller-manager pods exist inside the cluster.
-      runbook_url: https://docs.kubermatic.io/monitoring/runbook/#alert-kubecontrollermanagerdown
+      runbook_url: https://docs.loodse.com/kubermatic/master/monitoring/runbook/#alert-kubecontrollermanagerdown
     expr: absent(:ready_kube_controller_managers:sum) or :ready_kube_controller_managers:sum
       == 0
     for: 10m

--- a/config/monitoring/prometheus/rules/managed-kube-scheduler.yaml
+++ b/config/monitoring/prometheus/rules/managed-kube-scheduler.yaml
@@ -12,7 +12,7 @@ groups:
   - alert: KubeSchedulerDown
     annotations:
       message: No healthy scheduler pods exist inside the cluster.
-      runbook_url: https://docs.kubermatic.io/monitoring/runbook/#alert-kubeschedulerdown
+      runbook_url: https://docs.loodse.com/kubermatic/master/monitoring/runbook/#alert-kubeschedulerdown
     expr: absent(:ready_kube_schedulers:sum) or :ready_kube_schedulers:sum == 0
     for: 10m
     labels:

--- a/config/monitoring/prometheus/rules/src/general/blackbox-exporter.yaml
+++ b/config/monitoring/prometheus/rules/src/general/blackbox-exporter.yaml
@@ -4,7 +4,7 @@ groups:
   - alert: HttpProbeFailed
     annotations:
       message: Probing the blackbox-exporter target {{ $labels.instance }} failed.
-      runbook_url: https://docs.kubermatic.io/monitoring/runbook/#alert-httpprobefailed
+      runbook_url: https://docs.loodse.com/kubermatic/master/monitoring/runbook/#alert-httpprobefailed
     expr: probe_success != 1
     for: 5m
     labels:
@@ -13,7 +13,7 @@ groups:
   - alert: HttpProbeSlow
     annotations:
       message: '{{ $labels.instance }} takes {{ $value }} seconds to respond.'
-      runbook_url: https://docs.kubermatic.io/monitoring/runbook/#alert-httpprobeslow
+      runbook_url: https://docs.loodse.com/kubermatic/master/monitoring/runbook/#alert-httpprobeslow
     expr: sum by (instance) (probe_http_duration_seconds) > 3
     for: 15m
     labels:
@@ -26,7 +26,7 @@ groups:
   - alert: HttpCertExpiresSoon
     annotations:
       message: The certificate for {{ $labels.instance }} expires in less than 3 days.
-      runbook_url: https://docs.kubermatic.io/monitoring/runbook/#alert-httpcertexpiressoon
+      runbook_url: https://docs.loodse.com/kubermatic/master/monitoring/runbook/#alert-httpcertexpiressoon
     expr: probe_ssl_earliest_cert_expiry - time() < 3*24*3600
     labels:
       severity: warning
@@ -34,7 +34,7 @@ groups:
   - alert: HttpCertExpiresVerySoon
     annotations:
       message: The certificate for {{ $labels.instance }} expires in less than 24 hours.
-      runbook_url: https://docs.kubermatic.io/monitoring/runbook/#alert-httpcertexpiresverysoon
+      runbook_url: https://docs.loodse.com/kubermatic/master/monitoring/runbook/#alert-httpcertexpiresverysoon
     expr: probe_ssl_earliest_cert_expiry - time() < 24*3600
     labels:
       severity: critical

--- a/config/monitoring/prometheus/rules/src/general/cadvisor.yaml
+++ b/config/monitoring/prometheus/rules/src/general/cadvisor.yaml
@@ -4,7 +4,7 @@ groups:
   - alert: CadvisorDown
     annotations:
       message: Cadvisor has disappeared from Prometheus target discovery.
-      runbook_url: https://docs.kubermatic.io/monitoring/runbook/#alert-cadvisordown
+      runbook_url: https://docs.loodse.com/kubermatic/master/monitoring/runbook/#alert-cadvisordown
     expr: absent(up{job="cadvisor"} == 1)
     for: 15m
     labels:
@@ -15,7 +15,7 @@ groups:
   # - alert: CPUThrottlingHigh
   #   annotations:
   #     message: '{{ printf "%0.0f" $value }}% throttling of CPU in namespace {{ $labels.namespace }} for {{ $labels.container }}.'
-  #     runbook_url: https://docs.kubermatic.io/monitoring/runbook/#alert-cputhrottlinghigh
+  #     runbook_url: https://docs.loodse.com/kubermatic/master/monitoring/runbook/#alert-cputhrottlinghigh
   #   expr: |
   #     100 * sum(increase(container_cpu_cfs_throttled_periods_total[5m])) by (container, pod, namespace)
   #       /

--- a/config/monitoring/prometheus/rules/src/general/cert-manager.yaml
+++ b/config/monitoring/prometheus/rules/src/general/cert-manager.yaml
@@ -4,7 +4,7 @@ groups:
   - alert: CertManagerCertExpiresSoon
     annotations:
       message: The certificate {{ $labels.name }} expires in less than 3 days.
-      runbook_url: https://docs.kubermatic.io/monitoring/runbook/#alert-certmanagercertexpiressoon
+      runbook_url: https://docs.loodse.com/kubermatic/master/monitoring/runbook/#alert-certmanagercertexpiressoon
     expr: certmanager_certificate_expiration_timestamp_seconds - time() < 3*24*3600
     labels:
       severity: warning
@@ -12,7 +12,7 @@ groups:
   - alert: CertManagerCertExpiresVerySoon
     annotations:
       message: The certificate {{ $labels.name }} expires in less than 24 hours.
-      runbook_url: https://docs.kubermatic.io/monitoring/runbook/#alert-certmanagercertexpiresverysoon
+      runbook_url: https://docs.loodse.com/kubermatic/master/monitoring/runbook/#alert-certmanagercertexpiresverysoon
     expr: certmanager_certificate_expiration_timestamp_seconds - time() < 24*3600
     labels:
       severity: critical

--- a/config/monitoring/prometheus/rules/src/general/elasticsearch-exporter.yaml
+++ b/config/monitoring/prometheus/rules/src/general/elasticsearch-exporter.yaml
@@ -4,7 +4,7 @@ groups:
   - alert: ElasticsearchHeapTooHigh
     annotations:
       message: The heap usage of Elasticsearch node {{ $labels.name }} is over 90%.
-      runbook_url: https://docs.kubermatic.io/monitoring/runbook/#alert-elasticsearchheaptoohigh
+      runbook_url: https://docs.loodse.com/kubermatic/master/monitoring/runbook/#alert-elasticsearchheaptoohigh
     expr: elasticsearch_jvm_memory_used_bytes{area="heap"} / elasticsearch_jvm_memory_max_bytes{area="heap"} > 0.9
     for: 15m
     labels:
@@ -17,7 +17,7 @@ groups:
   - alert: ElasticsearchClusterUnavailable
     annotations:
       message: The Elasticsearch cluster health endpoint does not respond to scrapes.
-      runbook_url: https://docs.kubermatic.io/monitoring/runbook/#alert-elasticsearchclusterunavailable
+      runbook_url: https://docs.loodse.com/kubermatic/master/monitoring/runbook/#alert-elasticsearchclusterunavailable
     expr: elasticsearch_cluster_health_up == 0
     for: 15m
     labels:
@@ -26,7 +26,7 @@ groups:
   - alert: ElasticsearchClusterUnhealthy
     annotations:
       message: The Elasticsearch cluster is not healthy.
-      runbook_url: https://docs.kubermatic.io/monitoring/runbook/#alert-elasticsearchclusterunhealthy
+      runbook_url: https://docs.loodse.com/kubermatic/master/monitoring/runbook/#alert-elasticsearchclusterunhealthy
     expr: elasticsearch_cluster_health_status{color="green"} == 0
     for: 15m
     labels:
@@ -35,7 +35,7 @@ groups:
   - alert: ElasticsearchUnassignedShards
     annotations:
       message: There are {{ $value }} unassigned shards in the Elasticsearch cluster.
-      runbook_url: https://docs.kubermatic.io/monitoring/runbook/#alert-elasticsearchunassignedshards
+      runbook_url: https://docs.loodse.com/kubermatic/master/monitoring/runbook/#alert-elasticsearchunassignedshards
     expr: elasticsearch_cluster_health_unassigned_shards > 0
     for: 15m
     labels:

--- a/config/monitoring/prometheus/rules/src/general/fluentbit.yaml
+++ b/config/monitoring/prometheus/rules/src/general/fluentbit.yaml
@@ -4,7 +4,7 @@ groups:
   - alert: FluentbitManyFailedRetries
     annotations:
       message: Fluentbit pod `{{ $labels.pod }}` on `{{ $labels.node }}` is experiencing an elevated failed retry rate.
-      runbook_url: https://docs.kubermatic.io/monitoring/runbook/#alert-fluentbitmanyfailedretries
+      runbook_url: https://docs.loodse.com/kubermatic/master/monitoring/runbook/#alert-fluentbitmanyfailedretries
     expr: |
       sum by (namespace, pod, node) (kube_pod_info) *
         on (namespace, pod)
@@ -23,7 +23,7 @@ groups:
   - alert: FluentbitManyOutputErrors
     annotations:
       message: Fluentbit pod `{{ $labels.pod }}` on `{{ $labels.node }}` is experiencing an elevated output error rate.
-      runbook_url: https://docs.kubermatic.io/monitoring/runbook/#alert-fluentbitmanyoutputerrors
+      runbook_url: https://docs.loodse.com/kubermatic/master/monitoring/runbook/#alert-fluentbitmanyoutputerrors
     expr: |
       sum by (namespace, pod, node) (kube_pod_info) *
         on (namespace, pod)
@@ -42,7 +42,7 @@ groups:
   - alert: FluentbitNotProcessingNewLogs
     annotations:
       message: Fluentbit pod `{{ $labels.pod }}` on `{{ $labels.node }}` has not processed any new logs for the last 30 minutes.
-      runbook_url: https://docs.kubermatic.io/monitoring/runbook/#alert-fluentbitnotprocessingnewlogs
+      runbook_url: https://docs.loodse.com/kubermatic/master/monitoring/runbook/#alert-fluentbitnotprocessingnewlogs
     expr: |
       sum by (namespace, pod, node) (kube_pod_info) *
         on (namespace, pod)

--- a/config/monitoring/prometheus/rules/src/general/helm-exporter.yaml
+++ b/config/monitoring/prometheus/rules/src/general/helm-exporter.yaml
@@ -6,7 +6,7 @@ groups:
       message:
         The Helm release `{{ $labels.release }}` (`{{ $labels.chart }}` chart in namespace `{{ $labels.exported_namespace }}`)
         in version {{ $labels.version }} has not been ready for more than 15 minutes.
-      runbook_url: https://docs.kubermatic.io/monitoring/runbook/#alert-helmreleasenotdeployed
+      runbook_url: https://docs.loodse.com/kubermatic/master/monitoring/runbook/#alert-helmreleasenotdeployed
     expr: helm_chart_info != 1
     for: 15m
     labels:

--- a/config/monitoring/prometheus/rules/src/general/kube-apiserver.yaml
+++ b/config/monitoring/prometheus/rules/src/general/kube-apiserver.yaml
@@ -26,7 +26,7 @@ groups:
   - alert: KubernetesApiserverDown
     annotations:
       message: KubernetesApiserver has disappeared from Prometheus target discovery.
-      runbook_url: https://docs.kubermatic.io/monitoring/runbook/#alert-kubernetesapiserverdown
+      runbook_url: https://docs.loodse.com/kubermatic/master/monitoring/runbook/#alert-kubernetesapiserverdown
     expr: absent(up{job="apiserver"} == 1)
     for: 15m
     labels:
@@ -37,7 +37,7 @@ groups:
       message:
         The API server has a 99th percentile latency of {{ $value }} seconds
         for {{ $labels.verb }} {{ $labels.resource }}.
-      runbook_url: https://docs.kubermatic.io/monitoring/runbook/#alert-kubeapilatencyhigh
+      runbook_url: https://docs.loodse.com/kubermatic/master/monitoring/runbook/#alert-kubeapilatencyhigh
     expr: cluster_quantile:apiserver_request_latencies:histogram_quantile{job="apiserver",quantile="0.99",subresource!="log",verb!~"^(?:LIST|WATCH|WATCHLIST|PROXY|CONNECT)$"} > 1
     for: 10m
     labels:
@@ -48,7 +48,7 @@ groups:
       message:
         The API server has a 99th percentile latency of {{ $value }} seconds
         for {{ $labels.verb }} {{ $labels.resource }}.
-      runbook_url: https://docs.kubermatic.io/monitoring/runbook/#alert-kubeapilatencyhigh
+      runbook_url: https://docs.loodse.com/kubermatic/master/monitoring/runbook/#alert-kubeapilatencyhigh
     expr: cluster_quantile:apiserver_request_latencies:histogram_quantile{job="apiserver",quantile="0.99",subresource!="log",verb!~"^(?:LIST|WATCH|WATCHLIST|PROXY|CONNECT)$"} > 4
     for: 10m
     labels:
@@ -57,7 +57,7 @@ groups:
   - alert: KubeAPIErrorsHigh
     annotations:
       message: API server is returning errors for {{ $value }}% of requests.
-      runbook_url: https://docs.kubermatic.io/monitoring/runbook/#alert-kubeapierrorshigh
+      runbook_url: https://docs.loodse.com/kubermatic/master/monitoring/runbook/#alert-kubeapierrorshigh
     expr: |
       sum(rate(apiserver_request_count{job="apiserver",code=~"^(?:5..)$"}[5m])) without(instance, pod)
         /
@@ -69,7 +69,7 @@ groups:
   - alert: KubeAPIErrorsHigh
     annotations:
       message: API server is returning errors for {{ $value }}% of requests.
-      runbook_url: https://docs.kubermatic.io/monitoring/runbook/#alert-kubeapierrorshigh
+      runbook_url: https://docs.loodse.com/kubermatic/master/monitoring/runbook/#alert-kubeapierrorshigh
     expr: |
       sum(rate(apiserver_request_count{job="apiserver",code=~"^(?:5..)$"}[5m])) without(instance, pod)
         /
@@ -81,7 +81,7 @@ groups:
   - alert: KubeClientCertificateExpiration
     annotations:
       message: A client certificate used to authenticate to the apiserver is expiring in less than 7 days.
-      runbook_url: https://docs.kubermatic.io/monitoring/runbook/#alert-kubeclientcertificateexpiration
+      runbook_url: https://docs.loodse.com/kubermatic/master/monitoring/runbook/#alert-kubeclientcertificateexpiration
     expr: |
       apiserver_client_certificate_expiration_seconds_count{job="apiserver"} > 0
       and
@@ -97,7 +97,7 @@ groups:
   - alert: KubeClientCertificateExpiration
     annotations:
       message: A client certificate used to authenticate to the apiserver is expiring in less than 24 hours.
-      runbook_url: https://docs.kubermatic.io/monitoring/runbook/#alert-kubeclientcertificateexpiration
+      runbook_url: https://docs.loodse.com/kubermatic/master/monitoring/runbook/#alert-kubeclientcertificateexpiration
     expr: |
       apiserver_client_certificate_expiration_seconds_count{job="apiserver"} > 0
       and

--- a/config/monitoring/prometheus/rules/src/general/kube-kubelet.yaml
+++ b/config/monitoring/prometheus/rules/src/general/kube-kubelet.yaml
@@ -4,7 +4,7 @@ groups:
   - alert: KubeletDown
     annotations:
       message: Kubelet has disappeared from Prometheus target discovery.
-      runbook_url: https://docs.kubermatic.io/monitoring/runbook/#alert-kubeletdown
+      runbook_url: https://docs.loodse.com/kubermatic/master/monitoring/runbook/#alert-kubeletdown
     expr: absent(up{job="kubelet"} == 1)
     for: 15m
     labels:
@@ -15,7 +15,7 @@ groups:
       message:
         The PersistentVolume claimed by {{ $labels.persistentvolumeclaim }} in namespace
         {{ $labels.namespace }} is only {{ printf "%0.0f" $value }}% free.
-      runbook_url: https://docs.kubermatic.io/monitoring/runbook/#alert-kubepersistentvolumeusagecritical
+      runbook_url: https://docs.loodse.com/kubermatic/master/monitoring/runbook/#alert-kubepersistentvolumeusagecritical
     expr: |
       100 * kubelet_volume_stats_available_bytes{job="kubelet"}
         /
@@ -31,7 +31,7 @@ groups:
         Based on recent sampling, the PersistentVolume claimed by {{ $labels.persistentvolumeclaim }}
         in namespace {{ $labels.namespace }} is expected to fill up within four days.
         Currently {{ $value }} bytes are available.
-      runbook_url: https://docs.kubermatic.io/monitoring/runbook/#alert-kubepersistentvolumefullinfourdays
+      runbook_url: https://docs.loodse.com/kubermatic/master/monitoring/runbook/#alert-kubepersistentvolumefullinfourdays
     expr: |
       (
         kubelet_volume_stats_used_bytes{job="kubelet"}
@@ -47,7 +47,7 @@ groups:
   - alert: KubeletTooManyPods
     annotations:
       message: Kubelet {{ $labels.instance }} is running {{ $value }} pods, close to the limit of 110.
-      runbook_url: https://docs.kubermatic.io/monitoring/runbook/#alert-kubelettoomanypods
+      runbook_url: https://docs.loodse.com/kubermatic/master/monitoring/runbook/#alert-kubelettoomanypods
     expr: kubelet_running_pod_count{job="kubelet"} > 110 * 0.9
     for: 15m
     labels:
@@ -57,7 +57,7 @@ groups:
     annotations:
       message:
         The kubelet on {{ $labels.instance }} is experiencing {{ printf "%0.0f" $value }}% errors.
-      runbook_url: https://docs.kubermatic.io/monitoring/runbook/#alert-kubeclienterrors
+      runbook_url: https://docs.loodse.com/kubermatic/master/monitoring/runbook/#alert-kubeclienterrors
     expr: |
       (sum(rate(rest_client_requests_total{code=~"(5..|<error>)",job="kubelet"}[5m])) by (instance)
         /
@@ -72,7 +72,7 @@ groups:
     annotations:
       message:
         The pod {{ $labels.namespace }}/{{ $labels.pod }} is experiencing {{ printf "%0.0f" $value }}% errors.
-      runbook_url: https://docs.kubermatic.io/monitoring/runbook/#alert-kubeclienterrors
+      runbook_url: https://docs.loodse.com/kubermatic/master/monitoring/runbook/#alert-kubeclienterrors
     expr: |
       (sum(rate(rest_client_requests_total{code=~"(5..|<error>)",job="pods"}[5m])) by (namespace, pod)
         /
@@ -86,7 +86,7 @@ groups:
     annotations:
       message:
         The kubelet on {{ $labels.instance }} is having an elevated error rate for container runtime oprations.
-      runbook_url: https://docs.kubermatic.io/monitoring/runbook/#alert-kubeletruntimeerrors
+      runbook_url: https://docs.loodse.com/kubermatic/master/monitoring/runbook/#alert-kubeletruntimeerrors
     expr: |
       sum(rate(kubelet_runtime_operations_errors{job="kubelet"}[5m])) by (instance) > 0.1
     for: 15m
@@ -97,7 +97,7 @@ groups:
     annotations:
       message:
         The kubelet's cgroup manager latency on {{ $labels.instance }} has been elevated ({{ printf "%0.2f" $value }}ms) for more than 15 minutes.
-      runbook_url: https://docs.kubermatic.io/monitoring/runbook/#alert-kubeletcgroupmanagerlatencyhigh
+      runbook_url: https://docs.loodse.com/kubermatic/master/monitoring/runbook/#alert-kubeletcgroupmanagerlatencyhigh
     expr: |
       sum(rate(kubelet_cgroup_manager_latency_microseconds{quantile="0.9"}[5m])) by (instance) / 1000 > 1
     for: 15m
@@ -108,7 +108,7 @@ groups:
     annotations:
       message:
         The kubelet's pod worker latency for {{ $labels.operation_type }} operations on {{ $labels.instance }} has been elevated ({{ printf "%0.2f" $value }}ms) for more than 15 minutes.
-      runbook_url: https://docs.kubermatic.io/monitoring/runbook/#alert-kubeletpodworkerlatencyhigh
+      runbook_url: https://docs.loodse.com/kubermatic/master/monitoring/runbook/#alert-kubeletpodworkerlatencyhigh
     expr: |
       sum(rate(kubelet_pod_worker_latency_microseconds{quantile="0.9"}[5m])) by (instance, operation_type) / 1000 > 250
     for: 15m
@@ -118,7 +118,7 @@ groups:
   - alert: KubeVersionMismatch
     annotations:
       message: There are {{ $value }} different versions of Kubernetes components running.
-      runbook_url: https://docs.kubermatic.io/monitoring/runbook/#alert-kubeversionmismatch
+      runbook_url: https://docs.loodse.com/kubermatic/master/monitoring/runbook/#alert-kubeversionmismatch
     expr: count(count(kubernetes_build_info{job!="dns"}) by (gitVersion)) > 1
     for: 1h
     labels:

--- a/config/monitoring/prometheus/rules/src/general/kube-state-metrics.yaml
+++ b/config/monitoring/prometheus/rules/src/general/kube-state-metrics.yaml
@@ -64,7 +64,7 @@ groups:
   - alert: KubeStateMetricsDown
     annotations:
       message: KubeStateMetrics has disappeared from Prometheus target discovery.
-      runbook_url: https://docs.kubermatic.io/monitoring/runbook/#alert-kubestatemetricsdown
+      runbook_url: https://docs.loodse.com/kubermatic/master/monitoring/runbook/#alert-kubestatemetricsdown
     expr: absent(up{job="kube-state-metrics"} == 1)
     for: 15m
     labels:
@@ -75,7 +75,7 @@ groups:
       message:
         Pod {{ $labels.namespace }}/{{ $labels.pod }} ({{ $labels.container }}) is restarting
         {{ printf "%.2f" $value }} times / 5 minutes.
-      runbook_url: https://docs.kubermatic.io/monitoring/runbook/#alert-kubepodcrashlooping
+      runbook_url: https://docs.loodse.com/kubermatic/master/monitoring/runbook/#alert-kubepodcrashlooping
     expr: rate(kube_pod_container_status_restarts_total{job="kube-state-metrics"}[15m]) * 60 * 5 > 0
     for: 1h
     labels:
@@ -87,7 +87,7 @@ groups:
   - alert: KubePodNotReady
     annotations:
       message: Pod {{ $labels.namespace }}/{{ $labels.pod }} has been in a non-ready state for longer than an hour.
-      runbook_url: https://docs.kubermatic.io/monitoring/runbook/#alert-kubepodnotready
+      runbook_url: https://docs.loodse.com/kubermatic/master/monitoring/runbook/#alert-kubepodnotready
     expr: sum by (namespace, pod) (kube_pod_status_phase{job="kube-state-metrics", phase=~"Pending|Unknown"}) > 0
     for: 30m
     labels:
@@ -101,7 +101,7 @@ groups:
       message:
         Deployment generation for {{ $labels.namespace }}/{{ $labels.deployment }} does not match,
         this indicates that the Deployment has failed but has not been rolled back.
-      runbook_url: https://docs.kubermatic.io/monitoring/runbook/#alert-kubedeploymentgenerationmismatch
+      runbook_url: https://docs.loodse.com/kubermatic/master/monitoring/runbook/#alert-kubedeploymentgenerationmismatch
     expr: |
       kube_deployment_status_observed_generation{job="kube-state-metrics"}
         !=
@@ -115,7 +115,7 @@ groups:
       message:
         Deployment {{ $labels.namespace }}/{{ $labels.deployment }} has not matched the expected
         number of replicas for longer than an hour.
-      runbook_url: https://docs.kubermatic.io/monitoring/runbook/#alert-kubedeploymentreplicasmismatch
+      runbook_url: https://docs.loodse.com/kubermatic/master/monitoring/runbook/#alert-kubedeploymentreplicasmismatch
     expr: |
       kube_deployment_spec_replicas{job="kube-state-metrics"}
         !=
@@ -129,7 +129,7 @@ groups:
       message:
         StatefulSet {{ $labels.namespace }}/{{ $labels.statefulset }} has not matched the expected
         number of replicas for longer than 15 minutes.
-      runbook_url: https://docs.kubermatic.io/monitoring/runbook/#alert-kubestatefulsetreplicasmismatch
+      runbook_url: https://docs.loodse.com/kubermatic/master/monitoring/runbook/#alert-kubestatefulsetreplicasmismatch
     expr: |
       kube_statefulset_status_replicas_ready{job="kube-state-metrics"}
         !=
@@ -143,7 +143,7 @@ groups:
       message:
         StatefulSet generation for {{ $labels.namespace }}/{{ $labels.statefulset }} does not match,
         this indicates that the StatefulSet has failed but has not been rolled back.
-      runbook_url: https://docs.kubermatic.io/monitoring/runbook/#alert-kubestatefulsetgenerationmismatch
+      runbook_url: https://docs.loodse.com/kubermatic/master/monitoring/runbook/#alert-kubestatefulsetgenerationmismatch
     expr: |
       kube_statefulset_status_observed_generation{job="kube-state-metrics"}
         !=
@@ -155,7 +155,7 @@ groups:
   - alert: KubeStatefulSetUpdateNotRolledOut
     annotations:
       message: StatefulSet {{ $labels.namespace }}/{{ $labels.statefulset }} update has not been rolled out.
-      runbook_url: https://docs.kubermatic.io/monitoring/runbook/#alert-kubestatefulsetupdatenotrolledout
+      runbook_url: https://docs.loodse.com/kubermatic/master/monitoring/runbook/#alert-kubestatefulsetupdatenotrolledout
     expr: |
       max without (revision) (
         kube_statefulset_status_current_revision{job="kube-state-metrics"}
@@ -177,7 +177,7 @@ groups:
       message:
         Only {{ $value }}% of the desired Pods of DaemonSet {{ $labels.namespace }}/{{ $labels.daemonset }}
         are scheduled and ready.
-      runbook_url: https://docs.kubermatic.io/monitoring/runbook/#alert-kubedaemonsetrolloutstuck
+      runbook_url: https://docs.loodse.com/kubermatic/master/monitoring/runbook/#alert-kubedaemonsetrolloutstuck
     expr: |
       kube_daemonset_status_number_ready{job="kube-state-metrics"}
         /
@@ -189,7 +189,7 @@ groups:
   - alert: KubeDaemonSetNotScheduled
     annotations:
       message: '{{ $value }} Pods of DaemonSet {{ $labels.namespace }}/{{ $labels.daemonset }} are not scheduled.'
-      runbook_url: https://docs.kubermatic.io/monitoring/runbook/#alert-kubedaemonsetnotscheduled
+      runbook_url: https://docs.loodse.com/kubermatic/master/monitoring/runbook/#alert-kubedaemonsetnotscheduled
     expr: |
       kube_daemonset_status_desired_number_scheduled{job="kube-state-metrics"}
         -
@@ -201,7 +201,7 @@ groups:
   - alert: KubeDaemonSetMisScheduled
     annotations:
       message: '{{ $value }} Pods of DaemonSet {{ $labels.namespace }}/{{ $labels.daemonset }} are running where they are not supposed to run.'
-      runbook_url: https://docs.kubermatic.io/monitoring/runbook/#alert-kubedaemonsetmisscheduled
+      runbook_url: https://docs.loodse.com/kubermatic/master/monitoring/runbook/#alert-kubedaemonsetmisscheduled
     expr: kube_daemonset_status_number_misscheduled{job="kube-state-metrics"} > 0
     for: 10m
     labels:
@@ -210,7 +210,7 @@ groups:
   - alert: KubeCronJobRunning
     annotations:
       message: CronJob {{ $labels.namespace }}/{{ $labels.cronjob }} is taking more than 1h to complete.
-      runbook_url: https://docs.kubermatic.io/monitoring/runbook/#alert-kubecronjobrunning
+      runbook_url: https://docs.loodse.com/kubermatic/master/monitoring/runbook/#alert-kubecronjobrunning
     expr: time() - kube_cronjob_next_schedule_time{job="kube-state-metrics"} > 3600
     for: 1h
     labels:
@@ -219,7 +219,7 @@ groups:
   - alert: KubeJobCompletion
     annotations:
       message: Job {{ $labels.namespace }}/{{ $labels.job_name }} is taking more than one hour to complete.
-      runbook_url: https://docs.kubermatic.io/monitoring/runbook/#alert-kubejobcompletion
+      runbook_url: https://docs.loodse.com/kubermatic/master/monitoring/runbook/#alert-kubejobcompletion
     expr: kube_job_spec_completions{job="kube-state-metrics"} - kube_job_status_succeeded{job="kube-state-metrics"} > 0
     for: 1h
     labels:
@@ -228,7 +228,7 @@ groups:
   - alert: KubeJobFailed
     annotations:
       message: Job {{ $labels.namespace }}/{{ $labels.job_name }} failed to complete.
-      runbook_url: https://docs.kubermatic.io/monitoring/runbook/#alert-kubejobfailed
+      runbook_url: https://docs.loodse.com/kubermatic/master/monitoring/runbook/#alert-kubejobfailed
     expr: kube_job_status_failed{job="kube-state-metrics"} > 0
     for: 1h
     labels:
@@ -237,7 +237,7 @@ groups:
   - alert: KubeCPUOvercommit
     annotations:
       message: Cluster has overcommitted CPU resource requests for namespaces.
-      runbook_url: https://docs.kubermatic.io/monitoring/runbook/#alert-kubecpuovercommit
+      runbook_url: https://docs.loodse.com/kubermatic/master/monitoring/runbook/#alert-kubecpuovercommit
     expr: |
       sum(kube_resourcequota{job="kube-state-metrics", type="hard", resource="requests.cpu"})
         /
@@ -250,7 +250,7 @@ groups:
   - alert: KubeCPUOvercommit
     annotations:
       message: Cluster has overcommitted CPU resource requests for pods and cannot tolerate node failure.
-      runbook_url: https://docs.kubermatic.io/monitoring/runbook/#alert-kubecpuovercommit
+      runbook_url: https://docs.loodse.com/kubermatic/master/monitoring/runbook/#alert-kubecpuovercommit
     expr: |
       sum(namespace_name:kube_pod_container_resource_requests_cpu_cores:sum)
         /
@@ -264,7 +264,7 @@ groups:
   - alert: KubeMemOvercommit
     annotations:
       message: Cluster has overcommitted memory resource requests for namespaces.
-      runbook_url: https://docs.kubermatic.io/monitoring/runbook/#alert-kubememovercommit
+      runbook_url: https://docs.loodse.com/kubermatic/master/monitoring/runbook/#alert-kubememovercommit
     expr: |
       sum(kube_resourcequota{job="kube-state-metrics", type="hard", resource="requests.memory"})
         /
@@ -277,7 +277,7 @@ groups:
   - alert: KubeMemOvercommit
     annotations:
       message: Cluster has overcommitted memory resource requests for pods and cannot tolerate node failure.
-      runbook_url: https://docs.kubermatic.io/monitoring/runbook/#alert-kubememovercommit
+      runbook_url: https://docs.loodse.com/kubermatic/master/monitoring/runbook/#alert-kubememovercommit
     expr: |
       sum(namespace_name:kube_pod_container_resource_requests_memory_bytes:sum)
         /
@@ -293,7 +293,7 @@ groups:
   - alert: KubeQuotaExceeded
     annotations:
       message: Namespace {{ $labels.namespace }} is using {{ printf "%0.0f" $value }}% of its {{ $labels.resource }} quota.
-      runbook_url: https://docs.kubermatic.io/monitoring/runbook/#alert-kubequotaexceeded
+      runbook_url: https://docs.loodse.com/kubermatic/master/monitoring/runbook/#alert-kubequotaexceeded
     expr: |
       100 * kube_resourcequota{job="kube-state-metrics", type="used"}
         / ignoring(instance, job, type)
@@ -308,7 +308,7 @@ groups:
       message:
         Container {{ $labels.container }} in pod {{ $labels.namespace }}/{{ $labels.pod }}
         has been OOMKilled {{ $value }} times in the last 30 minutes.
-      runbook_url: https://docs.kubermatic.io/monitoring/runbook/#alert-kubepodoomkilled
+      runbook_url: https://docs.loodse.com/kubermatic/master/monitoring/runbook/#alert-kubepodoomkilled
     expr: |
       (kube_pod_container_status_restarts_total - kube_pod_container_status_restarts_total offset 30m >= 2)
       and
@@ -320,7 +320,7 @@ groups:
   - alert: KubeNodeNotReady
     annotations:
       message: '{{ $labels.node }} has been unready for more than an hour.'
-      runbook_url: https://docs.kubermatic.io/monitoring/runbook/#alert-kubenodenotready
+      runbook_url: https://docs.loodse.com/kubermatic/master/monitoring/runbook/#alert-kubenodenotready
     expr: kube_node_status_condition{job="kube-state-metrics",condition="Ready",status="true"} == 0
     for: 1h
     labels:

--- a/config/monitoring/prometheus/rules/src/general/node-exporter.yaml
+++ b/config/monitoring/prometheus/rules/src/general/node-exporter.yaml
@@ -185,7 +185,7 @@ groups:
       message:
         Filesystem on {{ $labels.device }} at {{ $labels.instance }} is predicted
         to run out of space within the next 24 hours.
-      runbook_url: https://docs.kubermatic.io/monitoring/runbook/#alert-nodefilesystemspacefillingup
+      runbook_url: https://docs.loodse.com/kubermatic/master/monitoring/runbook/#alert-nodefilesystemspacefillingup
     expr: |
       predict_linear(node_filesystem_avail_bytes{app="node-exporter",fstype=~"ext.|xfs"}[6h], 24*60*60) < 0
       and
@@ -201,7 +201,7 @@ groups:
       message:
         Filesystem on {{ $labels.device }} at {{ $labels.instance }} is predicted
         to run out of space within the next 4 hours.
-      runbook_url: https://docs.kubermatic.io/monitoring/runbook/#alert-nodefilesystemspacefillingup
+      runbook_url: https://docs.loodse.com/kubermatic/master/monitoring/runbook/#alert-nodefilesystemspacefillingup
     expr: |
       predict_linear(node_filesystem_avail_bytes{app="node-exporter",fstype=~"ext.|xfs"}[6h], 4*60*60) < 0
       and
@@ -217,7 +217,7 @@ groups:
       message:
         Filesystem on {{ $labels.device }} at {{ $labels.instance }} has only
         {{ $value }}% available space left.
-      runbook_url: https://docs.kubermatic.io/monitoring/runbook/#alert-nodefilesystemoutofspace
+      runbook_url: https://docs.loodse.com/kubermatic/master/monitoring/runbook/#alert-nodefilesystemoutofspace
     expr: |
       node_filesystem_avail_bytes{app="node-exporter",fstype=~"ext.|xfs"} / node_filesystem_size_bytes{app="node-exporter",fstype=~"ext.|xfs"} * 100 < 5
       and
@@ -231,7 +231,7 @@ groups:
       message:
         Filesystem on {{ $labels.device }} at {{ $labels.instance }} has only
         {{ $value }}% available space left.
-      runbook_url: https://docs.kubermatic.io/monitoring/runbook/#alert-nodefilesystemoutofspace
+      runbook_url: https://docs.loodse.com/kubermatic/master/monitoring/runbook/#alert-nodefilesystemoutofspace
     expr: |
       node_filesystem_avail_bytes{app="node-exporter",fstype=~"ext.|xfs"} / node_filesystem_size_bytes{app="node-exporter",fstype=~"ext.|xfs"} * 100 < 3
       and
@@ -245,7 +245,7 @@ groups:
       message:
         Filesystem on {{ $labels.device }} at {{ $labels.instance }} is predicted
         to run out of files within the next 24 hours.
-      runbook_url: https://docs.kubermatic.io/monitoring/runbook/#alert-nodefilesystemfilesfillingup
+      runbook_url: https://docs.loodse.com/kubermatic/master/monitoring/runbook/#alert-nodefilesystemfilesfillingup
     expr: |
       predict_linear(node_filesystem_files_free{app="node-exporter",fstype=~"ext.|xfs"}[6h], 24*60*60) < 0
       and
@@ -261,7 +261,7 @@ groups:
       message:
         Filesystem on {{ $labels.device }} at {{ $labels.instance }} is predicted
         to run out of files within the next 4 hours.
-      runbook_url: https://docs.kubermatic.io/monitoring/runbook/#alert-nodefilesystemfilesfillingup
+      runbook_url: https://docs.loodse.com/kubermatic/master/monitoring/runbook/#alert-nodefilesystemfilesfillingup
     expr: |
       predict_linear(node_filesystem_files_free{app="node-exporter",fstype=~"ext.|xfs"}[6h], 4*60*60) < 0
       and
@@ -277,7 +277,7 @@ groups:
       message:
         Filesystem on {{ $labels.device }} at {{ $labels.instance }} has only
         {{ $value }}% available inodes left.
-      runbook_url: https://docs.kubermatic.io/monitoring/runbook/#alert-nodefilesystemoutoffiles
+      runbook_url: https://docs.loodse.com/kubermatic/master/monitoring/runbook/#alert-nodefilesystemoutoffiles
     expr: |
       node_filesystem_files_free{app="node-exporter",fstype=~"ext.|xfs"} / node_filesystem_files{app="node-exporter",fstype=~"ext.|xfs"} * 100 < 5
       and
@@ -291,7 +291,7 @@ groups:
       message:
         Filesystem on {{ $labels.device }} at {{ $labels.instance }} has only
         {{ $value }}% available space left.
-      runbook_url: https://docs.kubermatic.io/monitoring/runbook/#alert-nodefilesystemoutofspace
+      runbook_url: https://docs.loodse.com/kubermatic/master/monitoring/runbook/#alert-nodefilesystemoutofspace
     expr: |
       node_filesystem_files_free{app="node-exporter",fstype=~"ext.|xfs"} / node_filesystem_files{app="node-exporter",fstype=~"ext.|xfs"} * 100 < 3
       and
@@ -305,7 +305,7 @@ groups:
       message:
         '{{ $labels.instance }} interface {{ $labels.device }} shows errors
         while receiving packets ({{ $value }} errors in two minutes).'
-      runbook_url: https://docs.kubermatic.io/monitoring/runbook/#alert-nodenetworkreceiveerrs
+      runbook_url: https://docs.loodse.com/kubermatic/master/monitoring/runbook/#alert-nodenetworkreceiveerrs
     expr: increase(node_network_receive_errs_total[2m]) > 10
     for: 1h
     labels:
@@ -316,7 +316,7 @@ groups:
       message:
         '{{ $labels.instance }} interface {{ $labels.device }} shows errors
         while transmitting packets ({{ $value }} errors in two minutes).'
-      runbook_url: https://docs.kubermatic.io/monitoring/runbook/#alert-nodenetworktransmiterrs
+      runbook_url: https://docs.loodse.com/kubermatic/master/monitoring/runbook/#alert-nodenetworktransmiterrs
     expr: increase(node_network_transmit_errs_total[2m]) > 10
     for: 1h
     labels:

--- a/config/monitoring/prometheus/rules/src/general/prometheus.yaml
+++ b/config/monitoring/prometheus/rules/src/general/prometheus.yaml
@@ -4,7 +4,7 @@ groups:
   - alert: PromScrapeFailed
     annotations:
       message: Prometheus failed to scrape a target {{ $labels.job }} / {{ $labels.instance }}.
-      runbook_url: https://docs.kubermatic.io/monitoring/runbook/#alert-promscrapefailed
+      runbook_url: https://docs.loodse.com/kubermatic/master/monitoring/runbook/#alert-promscrapefailed
     expr: up != 1
     for: 15m
     labels:
@@ -16,7 +16,7 @@ groups:
   - alert: PromBadConfig
     annotations:
       mesage: Prometheus failed to reload config.
-      runbook_url: https://docs.kubermatic.io/monitoring/runbook/#alert-prombadconfig
+      runbook_url: https://docs.loodse.com/kubermatic/master/monitoring/runbook/#alert-prombadconfig
     expr: prometheus_config_last_reload_successful{job="prometheus"} == 0
     for: 15m
     labels:
@@ -29,7 +29,7 @@ groups:
   - alert: PromAlertmanagerBadConfig
     annotations:
       message: Alertmanager failed to reload config.
-      runbook_url: https://docs.kubermatic.io/monitoring/runbook/#alert-promalertmanagerbadconfig
+      runbook_url: https://docs.loodse.com/kubermatic/master/monitoring/runbook/#alert-promalertmanagerbadconfig
     expr: alertmanager_config_last_reload_successful{job="alertmanager"} == 0
     for: 10m
     labels:
@@ -42,7 +42,7 @@ groups:
   - alert: PromAlertsFailed
     annotations:
       message: Alertmanager failed to send an alert.
-      runbook_url: https://docs.kubermatic.io/monitoring/runbook/#alert-promalertsfailed
+      runbook_url: https://docs.loodse.com/kubermatic/master/monitoring/runbook/#alert-promalertsfailed
     expr: sum(increase(alertmanager_notifications_failed_total{job="alertmanager"}[5m])) by (namespace) > 0
     for: 5m
     labels:
@@ -55,7 +55,7 @@ groups:
   - alert: PromRemoteStorageFailures
     annotations:
       message: Prometheus failed to send {{ printf "%.1f" $value }}% samples.
-      runbook_url: https://docs.kubermatic.io/monitoring/runbook/#alert-promremotestoragefailures
+      runbook_url: https://docs.loodse.com/kubermatic/master/monitoring/runbook/#alert-promremotestoragefailures
     expr: |
       (rate(prometheus_remote_storage_failed_samples_total{job="prometheus"}[1m]) * 100)
         /
@@ -72,7 +72,7 @@ groups:
   - alert: PromRuleFailures
     annotations:
       message: Prometheus failed to evaluate {{ printf "%.1f" $value }} rules/sec.
-      runbook_url: https://docs.kubermatic.io/monitoring/runbook/#alert-promrulefailures
+      runbook_url: https://docs.loodse.com/kubermatic/master/monitoring/runbook/#alert-promrulefailures
     expr: rate(prometheus_rule_evaluation_failures_total{job="prometheus"}[1m]) > 0
     for: 15m
     labels:

--- a/config/monitoring/prometheus/rules/src/general/thanos.yaml
+++ b/config/monitoring/prometheus/rules/src/general/thanos.yaml
@@ -4,7 +4,7 @@ groups:
   - alert: ThanosSidecarDown
     annotations:
       message: The Thanos sidecar in `{{ $labels.namespace }}/{{ $labels.pod }}` is down.
-      runbook_url: https://docs.kubermatic.io/monitoring/runbook/#alert-thanossidecardown
+      runbook_url: https://docs.loodse.com/kubermatic/master/monitoring/runbook/#alert-thanossidecardown
     expr: thanos_sidecar_prometheus_up != 1
     for: 5m
     labels:
@@ -13,7 +13,7 @@ groups:
   - alert: ThanosSidecarNoHeartbeat
     annotations:
       message: The Thanos sidecar in `{{ $labels.namespace }}/{{ $labels.pod }}` didn't send a heartbeat in {{ $value }} seconds.
-      runbook_url: https://docs.kubermatic.io/monitoring/runbook/#alert-thanossidecardown
+      runbook_url: https://docs.loodse.com/kubermatic/master/monitoring/runbook/#alert-thanossidecardown
     expr: time() - thanos_sidecar_last_heartbeat_success_time_seconds > 60
     for: 3m
     labels:
@@ -22,7 +22,7 @@ groups:
   - alert: ThanosCompactorManyRetries
     annotations:
       message: The Thanos compactor in `{{ $labels.namespace }}` is experiencing a high retry rate.
-      runbook_url: https://docs.kubermatic.io/monitoring/runbook/#alert-thanoscompactormanyretries
+      runbook_url: https://docs.loodse.com/kubermatic/master/monitoring/runbook/#alert-thanoscompactormanyretries
     expr: sum(rate(thanos_compactor_retries_total[5m])) > 0.01
     for: 10m
     labels:
@@ -34,7 +34,7 @@ groups:
   - alert: ThanosShipperManyDirSyncFailures
     annotations:
       message: The Thanos shipper in `{{ $labels.namespace }}/{{ $labels.pod }}` is experiencing a high dir-sync failure rate.
-      runbook_url: https://docs.kubermatic.io/monitoring/runbook/#alert-thanosshippermanydirsyncfailures
+      runbook_url: https://docs.loodse.com/kubermatic/master/monitoring/runbook/#alert-thanosshippermanydirsyncfailures
     expr: sum(rate(thanos_shipper_dir_sync_failures_total[5m])) > 0.01
     for: 10m
     labels:
@@ -46,7 +46,7 @@ groups:
   - alert: ThanosManyPanicRecoveries
     annotations:
       message: The Thanos component in `{{ $labels.namespace }}/{{ $labels.pod }}` is experiencing a panic recovery rate.
-      runbook_url: https://docs.kubermatic.io/monitoring/runbook/#alert-thanosmanypanicrecoveries
+      runbook_url: https://docs.loodse.com/kubermatic/master/monitoring/runbook/#alert-thanosmanypanicrecoveries
     expr: sum(rate(thanos_grpc_req_panics_recovered_total[5m])) > 0.01
     for: 10m
     labels:
@@ -55,7 +55,7 @@ groups:
   - alert: ThanosManyBlockLoadFailures
     annotations:
       message: The Thanos store in `{{ $labels.namespace }}/{{ $labels.pod }}` is experiencing a many failed block loads.
-      runbook_url: https://docs.kubermatic.io/monitoring/runbook/#alert-thanosmanyblockloadfailures
+      runbook_url: https://docs.loodse.com/kubermatic/master/monitoring/runbook/#alert-thanosmanyblockloadfailures
     expr: sum(rate(thanos_bucket_store_block_load_failures_total[5m])) > 0.01
     for: 10m
     labels:
@@ -64,7 +64,7 @@ groups:
   - alert: ThanosManyBlockDropFailures
     annotations:
       message: The Thanos store in `{{ $labels.namespace }}/{{ $labels.pod }}` is experiencing a many failed block drops.
-      runbook_url: https://docs.kubermatic.io/monitoring/runbook/#alert-thanosmanyblockdropfailures
+      runbook_url: https://docs.loodse.com/kubermatic/master/monitoring/runbook/#alert-thanosmanyblockdropfailures
     expr: sum(rate(thanos_bucket_store_block_drop_failures_total[5m])) > 0.01
     for: 10m
     labels:

--- a/config/monitoring/prometheus/rules/src/general/velero.yaml
+++ b/config/monitoring/prometheus/rules/src/general/velero.yaml
@@ -4,7 +4,7 @@ groups:
   - alert: VeleroBackupTakesTooLong
     annotations:
       message: Backup schedule {{ $labels.schedule }} has been taking more than 60min already.
-      runbook_url: https://docs.kubermatic.io/monitoring/runbook/#alert-velerobackuptakestoolong
+      runbook_url: https://docs.loodse.com/kubermatic/master/monitoring/runbook/#alert-velerobackuptakestoolong
     expr: (velero_backup_attempt_total - velero_backup_success_total) > 0
     for: 60m
     labels:
@@ -18,7 +18,7 @@ groups:
   - alert: VeleroNoRecentBackup
     annotations:
       message: There has not been a successful backup for schedule {{ $labels.schedule }} in the last 24 hours.
-      runbook_url: https://docs.kubermatic.io/monitoring/runbook/#alert-veleronorecentbackup
+      runbook_url: https://docs.loodse.com/kubermatic/master/monitoring/runbook/#alert-veleronorecentbackup
     expr: time() - velero_backup_last_successful_timestamp{schedule!=""} > 3600*25
     labels:
       severity: warning

--- a/config/monitoring/prometheus/rules/src/kubermatic-master/kubermatic.yaml
+++ b/config/monitoring/prometheus/rules/src/kubermatic-master/kubermatic.yaml
@@ -4,7 +4,7 @@ groups:
   - alert: KubermaticAPIDown
     annotations:
       message: KubermaticAPI has disappeared from Prometheus target discovery.
-      runbook_url: https://docs.kubermatic.io/monitoring/runbook/#alert-kubermaticapidown
+      runbook_url: https://docs.loodse.com/kubermatic/master/monitoring/runbook/#alert-kubermaticapidown
     expr: absent(up{job="pods",namespace="kubermatic",role="kubermatic-api"} == 1)
     for: 15m
     labels:
@@ -17,7 +17,7 @@ groups:
   - alert: KubermaticAPITooManyErrors
     annotations:
       message: Kubermatic API is returning a high rate of HTTP 5xx responses.
-      runbook_url: https://docs.kubermatic.io/monitoring/runbook/#alert-kubermaticapitoomanyerrors
+      runbook_url: https://docs.loodse.com/kubermatic/master/monitoring/runbook/#alert-kubermaticapitoomanyerrors
     expr: sum(rate(http_requests_total{role="kubermatic-api",code=~"5.."}[5m])) > 0.1
     for: 15m
     labels:

--- a/config/monitoring/prometheus/rules/src/kubermatic-seed/kubermatic.yaml
+++ b/config/monitoring/prometheus/rules/src/kubermatic-seed/kubermatic.yaml
@@ -4,7 +4,7 @@ groups:
   - alert: KubermaticTooManyUnhandledErrors
     annotations:
       message: Kubermatic controller manager in {{ $labels.namespace }} is experiencing too many errors.
-      runbook_url: https://docs.kubermatic.io/monitoring/runbook/#alert-kubermatictoomanyunhandlederrors
+      runbook_url: https://docs.loodse.com/kubermatic/master/monitoring/runbook/#alert-kubermatictoomanyunhandlederrors
     expr: sum(rate(kubermatic_controller_manager_unhandled_errors_total[5m])) > 0.01
     for: 10m
     labels:
@@ -16,7 +16,7 @@ groups:
   - alert: KubermaticClusterDeletionTakesTooLong
     annotations:
       message: Cluster {{ $labels.cluster }} is stuck in deletion for more than 30min.
-      runbook_url: https://docs.kubermatic.io/monitoring/runbook/#alert-kubermaticclusterdeletiontakestoolong
+      runbook_url: https://docs.loodse.com/kubermatic/master/monitoring/runbook/#alert-kubermaticclusterdeletiontakestoolong
     expr: (time() - max by (cluster) (kubermatic_cluster_deleted)) > 30*60
     for: 0m
     labels:
@@ -32,7 +32,7 @@ groups:
   - alert: KubermaticAddonDeletionTakesTooLong
     annotations:
       message: Addon {{ $labels.addon }} in cluster {{ $labels.cluster }} is stuck in deletion for more than 30min.
-      runbook_url: https://docs.kubermatic.io/monitoring/runbook/#alert-kubermaticaddondeletiontakestoolong
+      runbook_url: https://docs.loodse.com/kubermatic/master/monitoring/runbook/#alert-kubermaticaddondeletiontakestoolong
     expr: (time() - max by (cluster,addon) (kubermatic_addon_deleted)) > 30*60
     for: 0m
     labels:
@@ -46,7 +46,7 @@ groups:
   - alert: KubermaticControllerManagerDown
     annotations:
       message: KubermaticControllerManager has disappeared from Prometheus target discovery.
-      runbook_url: https://docs.kubermatic.io/monitoring/runbook/#alert-kubermaticcontrollermanagerdown
+      runbook_url: https://docs.loodse.com/kubermatic/master/monitoring/runbook/#alert-kubermaticcontrollermanagerdown
     expr: absent(up{job="pods",namespace="kubermatic",role="controller-manager"} == 1)
     for: 15m
     labels:
@@ -59,7 +59,7 @@ groups:
   - alert: OpenVPNServerDown
     annotations:
       message: There is no healthy OpenVPN server in cluster {{ $labels.cluster }}.
-      runbook_url: https://docs.kubermatic.io/monitoring/runbook/#alert-openvpnserverdown
+      runbook_url: https://docs.loodse.com/kubermatic/master/monitoring/runbook/#alert-openvpnserverdown
     expr: absent(kube_deployment_status_replicas_available{cluster!="",deployment="openvpn-server"} > 0) and count(kubermatic_cluster_info) > 0
     for: 15m
     labels:
@@ -68,7 +68,7 @@ groups:
   - alert: UserClusterPrometheusAbsent
     annotations:
       message: There is no Prometheus in cluster {{ $labels.name }}.
-      runbook_url: https://docs.kubermatic.io/monitoring/runbook/#alert-userclusterprometheusdisappeared
+      runbook_url: https://docs.loodse.com/kubermatic/master/monitoring/runbook/#alert-userclusterprometheusdisappeared
     expr: |
       (
         kubermatic_cluster_info * on (name) group_left

--- a/config/monitoring/prometheus/rules/src/managed/kube-controller-manager.yaml
+++ b/config/monitoring/prometheus/rules/src/managed/kube-controller-manager.yaml
@@ -12,7 +12,7 @@ groups:
   - alert: KubeControllerManagerDown
     annotations:
       message: No healthy controller-manager pods exist inside the cluster.
-      runbook_url: https://docs.kubermatic.io/monitoring/runbook/#alert-kubecontrollermanagerdown
+      runbook_url: https://docs.loodse.com/kubermatic/master/monitoring/runbook/#alert-kubecontrollermanagerdown
     expr: absent(:ready_kube_controller_managers:sum) or :ready_kube_controller_managers:sum == 0
     for: 10m
     labels:

--- a/config/monitoring/prometheus/rules/src/managed/kube-scheduler.yaml
+++ b/config/monitoring/prometheus/rules/src/managed/kube-scheduler.yaml
@@ -12,7 +12,7 @@ groups:
   - alert: KubeSchedulerDown
     annotations:
       message: No healthy scheduler pods exist inside the cluster.
-      runbook_url: https://docs.kubermatic.io/monitoring/runbook/#alert-kubeschedulerdown
+      runbook_url: https://docs.loodse.com/kubermatic/master/monitoring/runbook/#alert-kubeschedulerdown
     expr: absent(:ready_kube_schedulers:sum) or :ready_kube_schedulers:sum == 0
     for: 10m
     labels:


### PR DESCRIPTION
**What this PR does / why we need it**:
Since the documentation got restructured, we need to adjust the links. A super duper version would create links matching to the Kubermatic version, but this should be good enough(tm) for now.

**Which issue(s) this PR fixes**:
Fixes #4828 and #4840

**Does this PR introduce a user-facing change?**:
```release-note
NONE
```
