### PR TITLE
extend API server for PodNodeSelector admission plugin

### DIFF
--- a/api/cmd/kubermatic-api/swagger.json
+++ b/api/cmd/kubermatic-api/swagger.json
@@ -7730,6 +7730,11 @@
         "openshift": {
           "$ref": "#/definitions/Openshift"
         },
+        "usePodNodeSelectorAdmissionPlugin": {
+          "description": "If active the PodNodeSelector admission plugin is configured at the apiserver",
+          "type": "boolean",
+          "x-go-name": "UsePodNodeSelectorAdmissionPlugin"
+        },
         "usePodSecurityPolicyAdmissionPlugin": {
           "description": "If active the PodSecurityPolicy admission plugin is configured at the apiserver",
           "type": "boolean",

--- a/api/pkg/api/v1/types.go
+++ b/api/pkg/api/v1/types.go
@@ -634,6 +634,9 @@ type ClusterSpec struct {
 	// If active the PodSecurityPolicy admission plugin is configured at the apiserver
 	UsePodSecurityPolicyAdmissionPlugin bool `json:"usePodSecurityPolicyAdmissionPlugin,omitempty"`
 
+	// If active the PodNodeSelector admission plugin is configured at the apiserver
+	UsePodNodeSelectorAdmissionPlugin bool `json:"usePodNodeSelectorAdmissionPlugin,omitempty"`
+
 	// AuditLogging
 	AuditLogging *kubermaticv1.AuditLoggingSettings `json:"auditLogging,omitempty"`
 

--- a/api/pkg/crd/kubermatic/v1/cluster.go
+++ b/api/pkg/crd/kubermatic/v1/cluster.go
@@ -102,6 +102,7 @@ type ClusterSpec struct {
 	Openshift *Openshift `json:"openshift,omitempty"`
 
 	UsePodSecurityPolicyAdmissionPlugin bool `json:"usePodSecurityPolicyAdmissionPlugin,omitempty"`
+	UsePodNodeSelectorAdmissionPlugin   bool `json:"usePodNodeSelectorAdmissionPlugin,omitempty"`
 
 	AuditLogging *AuditLoggingSettings `json:"auditLogging,omitempty"`
 }

--- a/api/pkg/handler/v1/cluster/cluster.go
+++ b/api/pkg/handler/v1/cluster/cluster.go
@@ -388,6 +388,7 @@ func PatchEndpoint(projectProvider provider.ProjectProvider, seedsGetter provide
 		newInternalCluster.Spec.Version = patchedCluster.Spec.Version
 		newInternalCluster.Spec.OIDC = patchedCluster.Spec.OIDC
 		newInternalCluster.Spec.UsePodSecurityPolicyAdmissionPlugin = patchedCluster.Spec.UsePodSecurityPolicyAdmissionPlugin
+		newInternalCluster.Spec.UsePodNodeSelectorAdmissionPlugin = patchedCluster.Spec.UsePodNodeSelectorAdmissionPlugin
 		newInternalCluster.Spec.AuditLogging = patchedCluster.Spec.AuditLogging
 		newInternalCluster.Spec.Openshift = patchedCluster.Spec.Openshift
 
@@ -707,6 +708,7 @@ func convertInternalClusterToExternal(internalCluster *kubermaticv1.Cluster, fil
 			OIDC:                                internalCluster.Spec.OIDC,
 			AuditLogging:                        internalCluster.Spec.AuditLogging,
 			UsePodSecurityPolicyAdmissionPlugin: internalCluster.Spec.UsePodSecurityPolicyAdmissionPlugin,
+			UsePodNodeSelectorAdmissionPlugin:   internalCluster.Spec.UsePodNodeSelectorAdmissionPlugin,
 		},
 		Status: apiv1.ClusterStatus{
 			Version: internalCluster.Spec.Version,

--- a/api/pkg/resources/apiserver/deployment.go
+++ b/api/pkg/resources/apiserver/deployment.go
@@ -241,6 +241,9 @@ func getApiserverFlags(data *resources.TemplateData, etcdEndpoints []string, ena
 	if data.Cluster().Spec.UsePodSecurityPolicyAdmissionPlugin {
 		admissionPlugins = append(admissionPlugins, "PodSecurityPolicy")
 	}
+	if data.Cluster().Spec.UsePodNodeSelectorAdmissionPlugin {
+		admissionPlugins = append(admissionPlugins, "PodNodeSelector")
+	}
 
 	flags := []string{
 		"--advertise-address", data.Cluster().Address.IP,

--- a/api/pkg/resources/cluster/cluster.go
+++ b/api/pkg/resources/cluster/cluster.go
@@ -21,6 +21,7 @@ func Spec(apiCluster apiv1.Cluster, dc *kubermaticv1.Datacenter, secretKeyGetter
 		OIDC:                                apiCluster.Spec.OIDC,
 		Version:                             apiCluster.Spec.Version,
 		UsePodSecurityPolicyAdmissionPlugin: apiCluster.Spec.UsePodSecurityPolicyAdmissionPlugin,
+		UsePodNodeSelectorAdmissionPlugin:   apiCluster.Spec.UsePodNodeSelectorAdmissionPlugin,
 		AuditLogging:                        apiCluster.Spec.AuditLogging,
 		Openshift:                           apiCluster.Spec.Openshift,
 	}

--- a/api/pkg/test/e2e/api/utils/apiclient/models/cluster_spec.go
+++ b/api/pkg/test/e2e/api/utils/apiclient/models/cluster_spec.go
@@ -21,6 +21,9 @@ type ClusterSpec struct {
 	// MachineNetworks optionally specifies the parameters for IPAM.
 	MachineNetworks []*MachineNetworkingConfig `json:"machineNetworks"`
 
+	// If active the PodNodeSelector admission plugin is configured at the apiserver
+	UsePodNodeSelectorAdmissionPlugin bool `json:"usePodNodeSelectorAdmissionPlugin,omitempty"`
+
 	// If active the PodSecurityPolicy admission plugin is configured at the apiserver
 	UsePodSecurityPolicyAdmissionPlugin bool `json:"usePodSecurityPolicyAdmissionPlugin,omitempty"`
 


### PR DESCRIPTION
**What this PR does / why we need it**: extend API server for PodNodeSelector admission plugin

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #5016

```release-note
extend API server for PodNodeSelector admission plugin
```
