### PR TITLE
Adding Loki to the dev cluster deployment

### DIFF
--- a/api/hack/ci/ci-deploy-dev.sh
+++ b/api/hack/ci/ci-deploy-dev.sh
@@ -29,6 +29,9 @@ vault kv get -field=.dockerconfigjson dev/seed-clusters/dev.kubermatic.io > ${DO
 vault kv get -field=kubermatic.yaml dev/seed-clusters/dev.kubermatic.io > ${KUBERMATIC_CONFIG}
 echodate "Successfully got secrets for dev from Vault"
 
+# deploy Loki as beta
+export DEPLOY_LOKI=true
+
 echodate "Deploying ${DEPLOY_STACK} stack to dev"
 TILLER_NAMESPACE=kubermatic-installer ./api/hack/deploy.sh master ${VALUES_FILE}
 echodate "Successfully deployed ${DEPLOY_STACK} stack to dev"

--- a/api/hack/deploy.sh
+++ b/api/hack/deploy.sh
@@ -23,6 +23,7 @@ fi
 DEPLOY_NODEPORT_PROXY=${DEPLOY_NODEPORT_PROXY:-true}
 DEPLOY_ALERTMANAGER=${DEPLOY_ALERTMANAGER:-true}
 DEPLOY_MINIO=${DEPLOY_MINIO:-true}
+DEPLOY_LOKI=${DEPLOY_LOKI:-false}
 USE_KUBERMATIC_OPERATOR=${USE_KUBERMATIC_OPERATOR:-false}
 DEPLOY_STACK=${DEPLOY_STACK:-kubermatic}
 TILLER_NAMESPACE=${TILLER_NAMESPACE:-kubermatic}
@@ -131,6 +132,10 @@ case "${DEPLOY_STACK}" in
     deploy "elasticsearch" "logging" ./config/logging/elasticsearch/
     deploy "fluentbit" "logging" ./config/logging/fluentbit/
     deploy "kibana" "logging" ./config/logging/kibana/
+    if [[ "${DEPLOY_LOKI}" = true ]]; then
+      deploy "loki" "logging" ./config/logging/loki/
+      deploy "promtail" "logging" ./config/logging/promtail/
+    fi
     ;;
 
   kubermatic)


### PR DESCRIPTION
**What this PR does / why we need it**:
As we are moving to the beta phase of Loki deployment, we need to install it on the dev cluster only for testing purposes.
This introduces a variable DEPLOY_LOKI set to true in the cluster where we want Loki to be deployed.

**Does this PR introduce a user-facing change?**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If  no release note is required, just write "NONE".
-->
```release-note
NONE
```
