### PR TITLE
Fix pushing images for tagged releases

### DIFF
--- a/api/hack/ci/ci-push-images.sh
+++ b/api/hack/ci/ci-push-images.sh
@@ -31,8 +31,8 @@ export UIDOCKERTAG="$KUBERMATICDOCKERTAG"
 if [ -z "$GIT_HEAD_TAG" ]; then
   UIDOCKERTAG="$(get_latest_dashboard_hash "${PULL_BASE_REF}")"
 else
-  if [ -z "$(check_dashboard_tag "$GIT_HEAD_HASH")" ]; then
-    echo "Kubermatic was tagged as $GIT_HEAD_HASH, but this tag does not exist for the dashboard."
+  if [ -z "$(check_dashboard_tag "$GIT_HEAD_TAG")" ]; then
+    echo "Kubermatic was tagged as $GIT_HEAD_TAG, but this tag does not exist for the dashboard."
     echo "Please release a new version for the dashboard and re-run this job."
     exit 1
   fi


### PR DESCRIPTION
**What this PR does / why we need it**:
Seems like I made a typo when adjusting the push-images script.

**Does this PR introduce a user-facing change?**:
```release-note
NONE
```
