### PR TITLE
add a spec field that enforces audit logging on DC level

### DIFF
--- a/api/cmd/kubermatic-api/swagger.json
+++ b/api/cmd/kubermatic-api/swagger.json
@@ -7913,6 +7913,11 @@
         "digitalocean": {
           "$ref": "#/definitions/DigitialoceanDatacenterSpec"
         },
+        "enforceAuditLogging": {
+          "description": "EnforceAuditLogging enforces audit logging on every cluster within the DC,\nignoring cluster-specific settings.",
+          "type": "boolean",
+          "x-go-name": "EnforceAuditLogging"
+        },
         "gcp": {
           "$ref": "#/definitions/GCPDatacenterSpec"
         },

--- a/api/pkg/api/v1/types.go
+++ b/api/pkg/api/v1/types.go
@@ -123,6 +123,10 @@ type DatacenterSpec struct {
 	// Deprecated. Automatically migrated to the RequiredEmailDomains field.
 	RequiredEmailDomain  string   `json:"requiredEmailDomain,omitempty"`
 	RequiredEmailDomains []string `json:"requiredEmailDomains,omitempty"`
+
+	// EnforceAuditLogging enforces audit logging on every cluster within the DC,
+	// ignoring cluster-specific settings.
+	EnforceAuditLogging bool `json:"enforceAuditLogging"`
 }
 
 // DatacenterList represents a list of datacenters

--- a/api/pkg/crd/kubermatic/v1/datacenter.go
+++ b/api/pkg/crd/kubermatic/v1/datacenter.go
@@ -108,6 +108,10 @@ type DatacenterSpec struct {
 	// RequiredEmailDomain is deprecated. Automatically migrated to the RequiredEmailDomains field.
 	RequiredEmailDomain  string   `json:"requiredEmailDomain,omitempty"`
 	RequiredEmailDomains []string `json:"requiredEmailDomains,omitempty"`
+
+	// EnforceAuditLogging enforces audit logging on every cluster within the DC,
+	// ignoring cluster-specific settings.
+	EnforceAuditLogging bool `json:"enforceAuditLogging"`
 }
 
 // ImageList defines a map of operating system and the image to use

--- a/api/pkg/handler/test/helper.go
+++ b/api/pkg/handler/test/helper.go
@@ -356,6 +356,14 @@ func buildSeeds() provider.SeedsGetter {
 								Fake: &kubermaticv1.DatacenterSpecFake{},
 							},
 						},
+						"audited-dc": {
+							Location: "Finanzamt Castle",
+							Country:  "Germany",
+							Spec: kubermaticv1.DatacenterSpec{
+								Fake:                &kubermaticv1.DatacenterSpecFake{},
+								EnforceAuditLogging: true,
+							},
+						},
 					},
 				},
 			},

--- a/api/pkg/handler/v1/cluster/cluster.go
+++ b/api/pkg/handler/v1/cluster/cluster.go
@@ -131,6 +131,14 @@ func CreateEndpoint(sshKeyProvider provider.SSHKeyProvider, projectProvider prov
 				"kubermatic.io/openshift": "true",
 			}
 		}
+
+		// Enforce audit logging
+		if dc.Spec.EnforceAuditLogging {
+			partialCluster.Spec.AuditLogging = &kubermaticv1.AuditLoggingSettings{
+				Enabled: true,
+			}
+		}
+
 		// generate the name here so that it can be used in the secretName below
 		partialCluster.Name = rand.String(10)
 
@@ -403,6 +411,13 @@ func PatchEndpoint(projectProvider provider.ProjectProvider, seedsGetter provide
 		_, dc, err := provider.DatacenterFromSeedMap(userInfo, seedsGetter, newInternalCluster.Spec.Cloud.DatacenterName)
 		if err != nil {
 			return nil, fmt.Errorf("error getting dc: %v", err)
+		}
+
+		// Enforce audit logging
+		if dc.Spec.EnforceAuditLogging {
+			newInternalCluster.Spec.AuditLogging = &kubermaticv1.AuditLoggingSettings{
+				Enabled: true,
+			}
 		}
 
 		assertedClusterProvider, ok := clusterProvider.(*kubernetesprovider.ClusterProvider)

--- a/api/pkg/handler/v1/cluster/cluster_test.go
+++ b/api/pkg/handler/v1/cluster/cluster_test.go
@@ -796,6 +796,19 @@ func TestCreateClusterEndpoint(t *testing.T) {
 			),
 			ExistingAPIUser: test.GenAPIUser(test.UserName2, test.UserEmail2),
 		},
+		{
+			Name:             "scenario 11: create a cluster in audit-logging-enforced datacenter, without explicitly enabling audit logging",
+			Body:             `{"cluster":{"name":"keen-snyder","spec":{"version":"1.9.7","cloud":{"fake":{"token":"dummy_token"},"dc":"audited-dc"}}}}`,
+			ExpectedResponse: `{"id":"%s","name":"keen-snyder","creationTimestamp":"0001-01-01T00:00:00Z","type":"kubernetes","spec":{"cloud":{"dc":"audited-dc","fake":{}},"version":"1.9.7","oidc":{},"auditLogging":{"enabled":true}},"status":{"version":"1.9.7","url":""}}`,
+			RewriteClusterID: true,
+			HTTPStatus:       http.StatusCreated,
+			ProjectToSync:    test.GenDefaultProject().Name,
+			ExistingKubermaticObjs: test.GenDefaultKubermaticObjects(
+				test.GenUser(test.UserID2, test.UserName2, test.UserEmail2),
+				test.GenBinding(test.GenDefaultProject().Name, test.UserEmail2, "editors"),
+			),
+			ExistingAPIUser: test.GenAPIUser(test.UserName2, test.UserEmail2),
+		},
 	}
 
 	for _, tc := range testcases {

--- a/api/pkg/handler/v1/dc/datacenter.go
+++ b/api/pkg/handler/v1/dc/datacenter.go
@@ -231,6 +231,7 @@ func apiSpec(dc *kubermaticv1.Datacenter) (*apiv1.DatacenterSpec, error) {
 
 	spec.RequiredEmailDomain = dc.Spec.RequiredEmailDomain
 	spec.RequiredEmailDomains = dc.Spec.RequiredEmailDomains
+	spec.EnforceAuditLogging = dc.Spec.EnforceAuditLogging
 
 	return spec, nil
 }

--- a/api/pkg/handler/v1/dc/datacenter_test.go
+++ b/api/pkg/handler/v1/dc/datacenter_test.go
@@ -27,7 +27,7 @@ func TestDatacentersEndpoint(t *testing.T) {
 		t.Fatalf("Expected route to return code 200, got %d: %s", res.Code, res.Body.String())
 	}
 
-	test.CompareWithResult(t, res, ` [{"metadata":{"name":"fake-dc","resourceVersion":"1"},"spec":{"seed":"us-central1","country":"Germany","location":"Henriks basement","provider":"fake"}},{"metadata":{"name":"private-do1","resourceVersion":"1"},"spec":{"seed":"us-central1","country":"NL","location":"US ","provider":"digitalocean","digitalocean":{"region":"ams2"}}},{"metadata":{"name":"regular-do1","resourceVersion":"1"},"spec":{"seed":"us-central1","country":"NL","location":"Amsterdam","provider":"digitalocean","digitalocean":{"region":"ams2"}}},{"metadata":{"name":"us-central1","resourceVersion":"1"},"spec":{"seed":""},"seed":true}]
+	test.CompareWithResult(t, res, ` [{"metadata":{"name":"audited-dc","resourceVersion":"1"},"spec":{"seed":"us-central1","country":"Germany","location":"Finanzamt Castle","provider":"fake","enforceAuditLogging":true}},{"metadata":{"name":"fake-dc","resourceVersion":"1"},"spec":{"seed":"us-central1","country":"Germany","location":"Henriks basement","provider":"fake","enforceAuditLogging":false}},{"metadata":{"name":"private-do1","resourceVersion":"1"},"spec":{"seed":"us-central1","country":"NL","location":"US ","provider":"digitalocean","digitalocean":{"region":"ams2"},"enforceAuditLogging":false}},{"metadata":{"name":"regular-do1","resourceVersion":"1"},"spec":{"seed":"us-central1","country":"NL","location":"Amsterdam","provider":"digitalocean","digitalocean":{"region":"ams2"},"enforceAuditLogging":false}},{"metadata":{"name":"us-central1","resourceVersion":"1"},"spec":{"seed":"","enforceAuditLogging":false},"seed":true}]
 `)
 }
 
@@ -104,7 +104,7 @@ func TestDatacenterEndpointFilteredByEmail(t *testing.T) {
 			t.Fatalf("Expected route to return code 200, got %d: %s", res.Code, res.Body.String())
 		}
 
-		test.CompareWithResult(t, res, `{"metadata":{"name":"restricted-fake-dc","resourceVersion":"1"},"spec":{"seed":"us-central1","country":"NL","location":"Amsterdam","provider":"fake","requiredEmailDomain":"example.com"}}`)
+		test.CompareWithResult(t, res, `{"metadata":{"name":"restricted-fake-dc","resourceVersion":"1"},"spec":{"seed":"us-central1","country":"NL","location":"Amsterdam","provider":"fake","requiredEmailDomain":"example.com","enforceAuditLogging":false}}`)
 	}
 }
 
@@ -124,7 +124,7 @@ func TestDatacenterEndpointAdmin(t *testing.T) {
 		t.Fatalf("Expected route to return code 200, got %d: %s", res.Code, res.Body.String())
 	}
 
-	test.CompareWithResult(t, res, `{"metadata":{"name":"private-do1","resourceVersion":"1"},"spec":{"seed":"us-central1","country":"NL","location":"US ","provider":"digitalocean","digitalocean":{"region":"ams2"}}}`)
+	test.CompareWithResult(t, res, `{"metadata":{"name":"private-do1","resourceVersion":"1"},"spec":{"seed":"us-central1","country":"NL","location":"US ","provider":"digitalocean","digitalocean":{"region":"ams2"},"enforceAuditLogging":false}}`)
 
 }
 
@@ -144,5 +144,5 @@ func TestDatacenterEndpointFound(t *testing.T) {
 		t.Fatalf("Expected route to return code 200, got %d: %s", res.Code, res.Body.String())
 	}
 
-	test.CompareWithResult(t, res, `{"metadata":{"name":"regular-do1","resourceVersion":"1"},"spec":{"seed":"us-central1","country":"NL","location":"Amsterdam","provider":"digitalocean","digitalocean":{"region":"ams2"}}}`)
+	test.CompareWithResult(t, res, `{"metadata":{"name":"regular-do1","resourceVersion":"1"},"spec":{"seed":"us-central1","country":"NL","location":"Amsterdam","provider":"digitalocean","digitalocean":{"region":"ams2"},"enforceAuditLogging":false}}`)
 }

--- a/api/pkg/test/e2e/api/utils/apiclient/models/datacenter_spec.go
+++ b/api/pkg/test/e2e/api/utils/apiclient/models/datacenter_spec.go
@@ -19,6 +19,10 @@ type DatacenterSpec struct {
 	// country
 	Country string `json:"country,omitempty"`
 
+	// EnforceAuditLogging enforces audit logging on every cluster within the DC,
+	// ignoring cluster-specific settings.
+	EnforceAuditLogging bool `json:"enforceAuditLogging,omitempty"`
+
 	// location
 	Location string `json:"location,omitempty"`
 

--- a/docs/zz_generated.seed.yaml
+++ b/docs/zz_generated.seed.yaml
@@ -66,6 +66,9 @@ spec:
           # Datacenter location, e.g. "ams3". A list of existing datacenters can be found
           # at https://www.digitalocean.com/docs/platform/availability-matrix/
           region: ""
+        # EnforceAuditLogging enforces audit logging on every cluster within the DC,
+        # ignoring cluster-specific settings.
+        enforceAuditLogging: false
         gcp:
           # Region to use, for example "europe-west3", for a full list of regions see
           # https://cloud.google.com/compute/docs/regions-zones/


### PR DESCRIPTION
Fixes #4298

```release-note
Audit logging can now be enforced in all clusters within a Datacenter.
```
