### PR TITLE
Extend sync-charts to provide helmless static manifests

### DIFF
--- a/config/kubermatic/Chart.yaml
+++ b/config/kubermatic/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: kubermatic
-version: 1.0.41
+version: 1.0.42
 appVersion: '__KUBERMATIC_TAG__'
 description: Kubermatic chart for master and/or seed clusters.
 keywords:

--- a/config/kubermatic/crd/crd-vpa.yaml
+++ b/config/kubermatic/crd/crd-vpa.yaml
@@ -1,4 +1,3 @@
----
 apiVersion: apiextensions.k8s.io/v1beta1
 kind: CustomResourceDefinition
 metadata:


### PR DESCRIPTION
**What this PR does / why we need it**:
It's tedious to assemble all the files a customer needs to install Kubermatic. This PR makes it easier by concatenating the CRD and Operator manifests into single files in the kubermatic-installer repo. This way we can document the installation as "run `kubectl apply` twice pls".

**Does this PR introduce a user-facing change?**:
```release-note
NONE
```
