### PR TITLE
Add overwriteRegistry support for Openshift

### DIFF
--- a/api/codegen/openshift_versions/main.go
+++ b/api/codegen/openshift_versions/main.go
@@ -51,7 +51,7 @@ func {{ $componentName }}Image(openshiftVersion, registry string)(string, error)
 	switch openshiftVersion {
 {{- range $openshiftVersion, $componentTag := $componentTagMapping }}
 		case openshiftVersion{{ $openshiftVersion }}:
-			return OpenshiftImageWithRegistry(openshiftImage + "@{{ $componentTag }}", registry)
+			return OpenshiftImageWithRegistry(openshiftImage + "@{{ $componentTag }}", openshiftVersion, "{{index $.ImageNames $componentName }}", registry)
 {{- end }}
 		default:
 			return "", fmt.Errorf("no tag for openshiftVersion %q available", openshiftVersion)
@@ -94,6 +94,7 @@ func osDockerResolver(version string) (string, error) {
 func generateImageTagGetters(openshiftVersions []string, resolver func(string) (string, error)) ([]byte, error) {
 	// All tags contains a map of: componentName -> openshiftVerion -> DockerTag
 	allTags := map[string]map[string]string{}
+	imageNames := map[string]string{}
 	for _, openshiftVersion := range openshiftVersions {
 		rawOut, err := resolver(openshiftVersion)
 		if err != nil {
@@ -109,6 +110,7 @@ func generateImageTagGetters(openshiftVersions []string, resolver func(string) (
 			camelCasedComponentName := strcase.ToLowerCamel(component)
 			if _, ok := allTags[camelCasedComponentName]; !ok {
 				allTags[camelCasedComponentName] = map[string]string{}
+				imageNames[camelCasedComponentName] = component
 			}
 			allTags[camelCasedComponentName][sanitizeOpenshiftVersion(openshiftVersion)] = tag
 		}
@@ -116,8 +118,10 @@ func generateImageTagGetters(openshiftVersions []string, resolver func(string) (
 
 	data := struct {
 		Components map[string]map[string]string
+		ImageNames map[string]string
 	}{
 		Components: allTags,
+		ImageNames: imageNames,
 	}
 
 	buffer := bytes.NewBuffer([]byte{})

--- a/api/codegen/openshift_versions/main.go
+++ b/api/codegen/openshift_versions/main.go
@@ -47,11 +47,11 @@ import (
 
 {{- range $componentName, $componentTagMapping := .Components }}
 
-func {{ $componentName }}Image(openshiftVersion string)(string, error){
+func {{ $componentName }}Image(openshiftVersion, registry string)(string, error){
 	switch openshiftVersion {
 {{- range $openshiftVersion, $componentTag := $componentTagMapping }}
 		case openshiftVersion{{ $openshiftVersion }}:
-			return openshiftImage + "@{{ $componentTag }}", nil
+			return OpenshiftImageWithRegistry(openshiftImage + "@{{ $componentTag }}", registry)
 {{- end }}
 		default:
 			return "", fmt.Errorf("no tag for openshiftVersion %q available", openshiftVersion)

--- a/api/codegen/openshift_versions/testdata/4.1.9.golden.go
+++ b/api/codegen/openshift_versions/testdata/4.1.9.golden.go
@@ -4,172 +4,172 @@ import (
 	"fmt"
 )
 
-func cliImage(openshiftVersion string) (string, error) {
+func cliImage(openshiftVersion, registry string) (string, error) {
 	switch openshiftVersion {
 	case openshiftVersion419:
-		return openshiftImage + "@sha256:52ef9f5ade93e32f85e13bb9f588b2e126717256789023f8eb455b1147761562", nil
+		return OpenshiftImageWithRegistry(openshiftImage+"@sha256:52ef9f5ade93e32f85e13bb9f588b2e126717256789023f8eb455b1147761562", registry)
 	default:
 		return "", fmt.Errorf("no tag for openshiftVersion %q available", openshiftVersion)
 	}
 }
 
-func cloudCredentialOperatorImage(openshiftVersion string) (string, error) {
+func cloudCredentialOperatorImage(openshiftVersion, registry string) (string, error) {
 	switch openshiftVersion {
 	case openshiftVersion419:
-		return openshiftImage + "@sha256:1071e05a8fd4e13630be9097f4e412356af481af4568bf241f208e337665864f", nil
+		return OpenshiftImageWithRegistry(openshiftImage+"@sha256:1071e05a8fd4e13630be9097f4e412356af481af4568bf241f208e337665864f", registry)
 	default:
 		return "", fmt.Errorf("no tag for openshiftVersion %q available", openshiftVersion)
 	}
 }
 
-func clusterDnsOperatorImage(openshiftVersion string) (string, error) {
+func clusterDnsOperatorImage(openshiftVersion, registry string) (string, error) {
 	switch openshiftVersion {
 	case openshiftVersion419:
-		return openshiftImage + "@sha256:2aca09bcf2d705c8fe457e21507319550d4363fd07012db6403f59c314ecc7e0", nil
+		return OpenshiftImageWithRegistry(openshiftImage+"@sha256:2aca09bcf2d705c8fe457e21507319550d4363fd07012db6403f59c314ecc7e0", registry)
 	default:
 		return "", fmt.Errorf("no tag for openshiftVersion %q available", openshiftVersion)
 	}
 }
 
-func clusterImageRegistryOperatorImage(openshiftVersion string) (string, error) {
+func clusterImageRegistryOperatorImage(openshiftVersion, registry string) (string, error) {
 	switch openshiftVersion {
 	case openshiftVersion419:
-		return openshiftImage + "@sha256:2fb3e2f3eb6dbc013dcd4f7b94f9a9cff5231d1005174a030e265899160efc68", nil
+		return OpenshiftImageWithRegistry(openshiftImage+"@sha256:2fb3e2f3eb6dbc013dcd4f7b94f9a9cff5231d1005174a030e265899160efc68", registry)
 	default:
 		return "", fmt.Errorf("no tag for openshiftVersion %q available", openshiftVersion)
 	}
 }
 
-func clusterNetworkOperatorImage(openshiftVersion string) (string, error) {
+func clusterNetworkOperatorImage(openshiftVersion, registry string) (string, error) {
 	switch openshiftVersion {
 	case openshiftVersion419:
-		return openshiftImage + "@sha256:541465dbff9e28b303c533f5d86cea7a4f5ef1c920736a655380bb5b64954182", nil
+		return OpenshiftImageWithRegistry(openshiftImage+"@sha256:541465dbff9e28b303c533f5d86cea7a4f5ef1c920736a655380bb5b64954182", registry)
 	default:
 		return "", fmt.Errorf("no tag for openshiftVersion %q available", openshiftVersion)
 	}
 }
 
-func consoleImage(openshiftVersion string) (string, error) {
+func consoleImage(openshiftVersion, registry string) (string, error) {
 	switch openshiftVersion {
 	case openshiftVersion419:
-		return openshiftImage + "@sha256:9e554ac4505edd925eb73fec52e33d7418e2cfaf8058b59d8246ed478337748d", nil
+		return OpenshiftImageWithRegistry(openshiftImage+"@sha256:9e554ac4505edd925eb73fec52e33d7418e2cfaf8058b59d8246ed478337748d", registry)
 	default:
 		return "", fmt.Errorf("no tag for openshiftVersion %q available", openshiftVersion)
 	}
 }
 
-func containerNetworkingPluginsSupportedImage(openshiftVersion string) (string, error) {
+func containerNetworkingPluginsSupportedImage(openshiftVersion, registry string) (string, error) {
 	switch openshiftVersion {
 	case openshiftVersion419:
-		return openshiftImage + "@sha256:473d03cbfa265d2a6def817f8ec5bd1c6536d3e39cf8c2f8223dd41ed2bd4541", nil
+		return OpenshiftImageWithRegistry(openshiftImage+"@sha256:473d03cbfa265d2a6def817f8ec5bd1c6536d3e39cf8c2f8223dd41ed2bd4541", registry)
 	default:
 		return "", fmt.Errorf("no tag for openshiftVersion %q available", openshiftVersion)
 	}
 }
 
-func containerNetworkingPluginsUnsupportedImage(openshiftVersion string) (string, error) {
+func containerNetworkingPluginsUnsupportedImage(openshiftVersion, registry string) (string, error) {
 	switch openshiftVersion {
 	case openshiftVersion419:
-		return openshiftImage + "@sha256:d7c6701150c7ad12fc6dd26f2c6b093da5e9e3b43dea89196a77da1c6ef6904b", nil
+		return OpenshiftImageWithRegistry(openshiftImage+"@sha256:d7c6701150c7ad12fc6dd26f2c6b093da5e9e3b43dea89196a77da1c6ef6904b", registry)
 	default:
 		return "", fmt.Errorf("no tag for openshiftVersion %q available", openshiftVersion)
 	}
 }
 
-func corednsImage(openshiftVersion string) (string, error) {
+func corednsImage(openshiftVersion, registry string) (string, error) {
 	switch openshiftVersion {
 	case openshiftVersion419:
-		return openshiftImage + "@sha256:390cc1784aba986fad6315142d1d2524b2707a91eea3705d448367b51a112438", nil
+		return OpenshiftImageWithRegistry(openshiftImage+"@sha256:390cc1784aba986fad6315142d1d2524b2707a91eea3705d448367b51a112438", registry)
 	default:
 		return "", fmt.Errorf("no tag for openshiftVersion %q available", openshiftVersion)
 	}
 }
 
-func deployerImage(openshiftVersion string) (string, error) {
+func deployerImage(openshiftVersion, registry string) (string, error) {
 	switch openshiftVersion {
 	case openshiftVersion419:
-		return openshiftImage + "@sha256:8b946a142a8ba328ffe04195bb3fc4beeff26aaa4d8d0e99528340e8880eba7e", nil
+		return OpenshiftImageWithRegistry(openshiftImage+"@sha256:8b946a142a8ba328ffe04195bb3fc4beeff26aaa4d8d0e99528340e8880eba7e", registry)
 	default:
 		return "", fmt.Errorf("no tag for openshiftVersion %q available", openshiftVersion)
 	}
 }
 
-func dockerBuilderImage(openshiftVersion string) (string, error) {
+func dockerBuilderImage(openshiftVersion, registry string) (string, error) {
 	switch openshiftVersion {
 	case openshiftVersion419:
-		return openshiftImage + "@sha256:f4d2df04a0ac1b689bc275c060e5520781f48f007dabf849d92cf1519f16ea82", nil
+		return OpenshiftImageWithRegistry(openshiftImage+"@sha256:f4d2df04a0ac1b689bc275c060e5520781f48f007dabf849d92cf1519f16ea82", registry)
 	default:
 		return "", fmt.Errorf("no tag for openshiftVersion %q available", openshiftVersion)
 	}
 }
 
-func dockerRegistryImage(openshiftVersion string) (string, error) {
+func dockerRegistryImage(openshiftVersion, registry string) (string, error) {
 	switch openshiftVersion {
 	case openshiftVersion419:
-		return openshiftImage + "@sha256:5c0b76746c2f86177b5a0fdce866cf41dbb752af58b96daa8fa7b033fa2c4fc9", nil
+		return OpenshiftImageWithRegistry(openshiftImage+"@sha256:5c0b76746c2f86177b5a0fdce866cf41dbb752af58b96daa8fa7b033fa2c4fc9", registry)
 	default:
 		return "", fmt.Errorf("no tag for openshiftVersion %q available", openshiftVersion)
 	}
 }
 
-func hyperkubeImage(openshiftVersion string) (string, error) {
+func hyperkubeImage(openshiftVersion, registry string) (string, error) {
 	switch openshiftVersion {
 	case openshiftVersion419:
-		return openshiftImage + "@sha256:155ef40a64608c946ca9ca0310bbf88f5a4664b2925502b3acac86847bc158e6", nil
+		return OpenshiftImageWithRegistry(openshiftImage+"@sha256:155ef40a64608c946ca9ca0310bbf88f5a4664b2925502b3acac86847bc158e6", registry)
 	default:
 		return "", fmt.Errorf("no tag for openshiftVersion %q available", openshiftVersion)
 	}
 }
 
-func hypershiftImage(openshiftVersion string) (string, error) {
+func hypershiftImage(openshiftVersion, registry string) (string, error) {
 	switch openshiftVersion {
 	case openshiftVersion419:
-		return openshiftImage + "@sha256:86255c4efe6bbc141a0f41444f863bbd5cd832ffca21d2b737a4f9c225ed00ad", nil
+		return OpenshiftImageWithRegistry(openshiftImage+"@sha256:86255c4efe6bbc141a0f41444f863bbd5cd832ffca21d2b737a4f9c225ed00ad", registry)
 	default:
 		return "", fmt.Errorf("no tag for openshiftVersion %q available", openshiftVersion)
 	}
 }
 
-func multusCniImage(openshiftVersion string) (string, error) {
+func multusCniImage(openshiftVersion, registry string) (string, error) {
 	switch openshiftVersion {
 	case openshiftVersion419:
-		return openshiftImage + "@sha256:6766e62f61307e7c5a187f61d33b99ba90390b2f43351f591bb8da951915ce04", nil
+		return OpenshiftImageWithRegistry(openshiftImage+"@sha256:6766e62f61307e7c5a187f61d33b99ba90390b2f43351f591bb8da951915ce04", registry)
 	default:
 		return "", fmt.Errorf("no tag for openshiftVersion %q available", openshiftVersion)
 	}
 }
 
-func nodeImage(openshiftVersion string) (string, error) {
+func nodeImage(openshiftVersion, registry string) (string, error) {
 	switch openshiftVersion {
 	case openshiftVersion419:
-		return openshiftImage + "@sha256:472dd90bc413a9bcb99be23f7296763468ebbeb985c10b26d1c44c4b04f57a77", nil
+		return OpenshiftImageWithRegistry(openshiftImage+"@sha256:472dd90bc413a9bcb99be23f7296763468ebbeb985c10b26d1c44c4b04f57a77", registry)
 	default:
 		return "", fmt.Errorf("no tag for openshiftVersion %q available", openshiftVersion)
 	}
 }
 
-func ovnKubernetesImage(openshiftVersion string) (string, error) {
+func ovnKubernetesImage(openshiftVersion, registry string) (string, error) {
 	switch openshiftVersion {
 	case openshiftVersion419:
-		return openshiftImage + "@sha256:81088a1f27ff88e7e4a65dd3ca47513aad76bfbfc44af359887baa1d3fa60eba", nil
+		return OpenshiftImageWithRegistry(openshiftImage+"@sha256:81088a1f27ff88e7e4a65dd3ca47513aad76bfbfc44af359887baa1d3fa60eba", registry)
 	default:
 		return "", fmt.Errorf("no tag for openshiftVersion %q available", openshiftVersion)
 	}
 }
 
-func sriovCniImage(openshiftVersion string) (string, error) {
+func sriovCniImage(openshiftVersion, registry string) (string, error) {
 	switch openshiftVersion {
 	case openshiftVersion419:
-		return openshiftImage + "@sha256:9d332f4b42997f917fa7660d85975c579ee4abe354473acbd45fc2a093b12e3b", nil
+		return OpenshiftImageWithRegistry(openshiftImage+"@sha256:9d332f4b42997f917fa7660d85975c579ee4abe354473acbd45fc2a093b12e3b", registry)
 	default:
 		return "", fmt.Errorf("no tag for openshiftVersion %q available", openshiftVersion)
 	}
 }
 
-func sriovNetworkDevicePluginImage(openshiftVersion string) (string, error) {
+func sriovNetworkDevicePluginImage(openshiftVersion, registry string) (string, error) {
 	switch openshiftVersion {
 	case openshiftVersion419:
-		return openshiftImage + "@sha256:21c668c419662bf1a5c1f38d55f6ab20b4e22b807d076f927efb1ac954beed60", nil
+		return OpenshiftImageWithRegistry(openshiftImage+"@sha256:21c668c419662bf1a5c1f38d55f6ab20b4e22b807d076f927efb1ac954beed60", registry)
 	default:
 		return "", fmt.Errorf("no tag for openshiftVersion %q available", openshiftVersion)
 	}

--- a/api/codegen/openshift_versions/testdata/4.1.9.golden.go
+++ b/api/codegen/openshift_versions/testdata/4.1.9.golden.go
@@ -7,7 +7,7 @@ import (
 func cliImage(openshiftVersion, registry string) (string, error) {
 	switch openshiftVersion {
 	case openshiftVersion419:
-		return OpenshiftImageWithRegistry(openshiftImage+"@sha256:52ef9f5ade93e32f85e13bb9f588b2e126717256789023f8eb455b1147761562", registry)
+		return OpenshiftImageWithRegistry(openshiftImage+"@sha256:52ef9f5ade93e32f85e13bb9f588b2e126717256789023f8eb455b1147761562", openshiftVersion, "cli", registry)
 	default:
 		return "", fmt.Errorf("no tag for openshiftVersion %q available", openshiftVersion)
 	}
@@ -16,7 +16,7 @@ func cliImage(openshiftVersion, registry string) (string, error) {
 func cloudCredentialOperatorImage(openshiftVersion, registry string) (string, error) {
 	switch openshiftVersion {
 	case openshiftVersion419:
-		return OpenshiftImageWithRegistry(openshiftImage+"@sha256:1071e05a8fd4e13630be9097f4e412356af481af4568bf241f208e337665864f", registry)
+		return OpenshiftImageWithRegistry(openshiftImage+"@sha256:1071e05a8fd4e13630be9097f4e412356af481af4568bf241f208e337665864f", openshiftVersion, "cloud-credential-operator", registry)
 	default:
 		return "", fmt.Errorf("no tag for openshiftVersion %q available", openshiftVersion)
 	}
@@ -25,7 +25,7 @@ func cloudCredentialOperatorImage(openshiftVersion, registry string) (string, er
 func clusterDnsOperatorImage(openshiftVersion, registry string) (string, error) {
 	switch openshiftVersion {
 	case openshiftVersion419:
-		return OpenshiftImageWithRegistry(openshiftImage+"@sha256:2aca09bcf2d705c8fe457e21507319550d4363fd07012db6403f59c314ecc7e0", registry)
+		return OpenshiftImageWithRegistry(openshiftImage+"@sha256:2aca09bcf2d705c8fe457e21507319550d4363fd07012db6403f59c314ecc7e0", openshiftVersion, "cluster-dns-operator", registry)
 	default:
 		return "", fmt.Errorf("no tag for openshiftVersion %q available", openshiftVersion)
 	}
@@ -34,7 +34,7 @@ func clusterDnsOperatorImage(openshiftVersion, registry string) (string, error) 
 func clusterImageRegistryOperatorImage(openshiftVersion, registry string) (string, error) {
 	switch openshiftVersion {
 	case openshiftVersion419:
-		return OpenshiftImageWithRegistry(openshiftImage+"@sha256:2fb3e2f3eb6dbc013dcd4f7b94f9a9cff5231d1005174a030e265899160efc68", registry)
+		return OpenshiftImageWithRegistry(openshiftImage+"@sha256:2fb3e2f3eb6dbc013dcd4f7b94f9a9cff5231d1005174a030e265899160efc68", openshiftVersion, "cluster-image-registry-operator", registry)
 	default:
 		return "", fmt.Errorf("no tag for openshiftVersion %q available", openshiftVersion)
 	}
@@ -43,7 +43,7 @@ func clusterImageRegistryOperatorImage(openshiftVersion, registry string) (strin
 func clusterNetworkOperatorImage(openshiftVersion, registry string) (string, error) {
 	switch openshiftVersion {
 	case openshiftVersion419:
-		return OpenshiftImageWithRegistry(openshiftImage+"@sha256:541465dbff9e28b303c533f5d86cea7a4f5ef1c920736a655380bb5b64954182", registry)
+		return OpenshiftImageWithRegistry(openshiftImage+"@sha256:541465dbff9e28b303c533f5d86cea7a4f5ef1c920736a655380bb5b64954182", openshiftVersion, "cluster-network-operator", registry)
 	default:
 		return "", fmt.Errorf("no tag for openshiftVersion %q available", openshiftVersion)
 	}
@@ -52,7 +52,7 @@ func clusterNetworkOperatorImage(openshiftVersion, registry string) (string, err
 func consoleImage(openshiftVersion, registry string) (string, error) {
 	switch openshiftVersion {
 	case openshiftVersion419:
-		return OpenshiftImageWithRegistry(openshiftImage+"@sha256:9e554ac4505edd925eb73fec52e33d7418e2cfaf8058b59d8246ed478337748d", registry)
+		return OpenshiftImageWithRegistry(openshiftImage+"@sha256:9e554ac4505edd925eb73fec52e33d7418e2cfaf8058b59d8246ed478337748d", openshiftVersion, "console", registry)
 	default:
 		return "", fmt.Errorf("no tag for openshiftVersion %q available", openshiftVersion)
 	}
@@ -61,7 +61,7 @@ func consoleImage(openshiftVersion, registry string) (string, error) {
 func containerNetworkingPluginsSupportedImage(openshiftVersion, registry string) (string, error) {
 	switch openshiftVersion {
 	case openshiftVersion419:
-		return OpenshiftImageWithRegistry(openshiftImage+"@sha256:473d03cbfa265d2a6def817f8ec5bd1c6536d3e39cf8c2f8223dd41ed2bd4541", registry)
+		return OpenshiftImageWithRegistry(openshiftImage+"@sha256:473d03cbfa265d2a6def817f8ec5bd1c6536d3e39cf8c2f8223dd41ed2bd4541", openshiftVersion, "container-networking-plugins-supported", registry)
 	default:
 		return "", fmt.Errorf("no tag for openshiftVersion %q available", openshiftVersion)
 	}
@@ -70,7 +70,7 @@ func containerNetworkingPluginsSupportedImage(openshiftVersion, registry string)
 func containerNetworkingPluginsUnsupportedImage(openshiftVersion, registry string) (string, error) {
 	switch openshiftVersion {
 	case openshiftVersion419:
-		return OpenshiftImageWithRegistry(openshiftImage+"@sha256:d7c6701150c7ad12fc6dd26f2c6b093da5e9e3b43dea89196a77da1c6ef6904b", registry)
+		return OpenshiftImageWithRegistry(openshiftImage+"@sha256:d7c6701150c7ad12fc6dd26f2c6b093da5e9e3b43dea89196a77da1c6ef6904b", openshiftVersion, "container-networking-plugins-unsupported", registry)
 	default:
 		return "", fmt.Errorf("no tag for openshiftVersion %q available", openshiftVersion)
 	}
@@ -79,7 +79,7 @@ func containerNetworkingPluginsUnsupportedImage(openshiftVersion, registry strin
 func corednsImage(openshiftVersion, registry string) (string, error) {
 	switch openshiftVersion {
 	case openshiftVersion419:
-		return OpenshiftImageWithRegistry(openshiftImage+"@sha256:390cc1784aba986fad6315142d1d2524b2707a91eea3705d448367b51a112438", registry)
+		return OpenshiftImageWithRegistry(openshiftImage+"@sha256:390cc1784aba986fad6315142d1d2524b2707a91eea3705d448367b51a112438", openshiftVersion, "coredns", registry)
 	default:
 		return "", fmt.Errorf("no tag for openshiftVersion %q available", openshiftVersion)
 	}
@@ -88,7 +88,7 @@ func corednsImage(openshiftVersion, registry string) (string, error) {
 func deployerImage(openshiftVersion, registry string) (string, error) {
 	switch openshiftVersion {
 	case openshiftVersion419:
-		return OpenshiftImageWithRegistry(openshiftImage+"@sha256:8b946a142a8ba328ffe04195bb3fc4beeff26aaa4d8d0e99528340e8880eba7e", registry)
+		return OpenshiftImageWithRegistry(openshiftImage+"@sha256:8b946a142a8ba328ffe04195bb3fc4beeff26aaa4d8d0e99528340e8880eba7e", openshiftVersion, "deployer", registry)
 	default:
 		return "", fmt.Errorf("no tag for openshiftVersion %q available", openshiftVersion)
 	}
@@ -97,7 +97,7 @@ func deployerImage(openshiftVersion, registry string) (string, error) {
 func dockerBuilderImage(openshiftVersion, registry string) (string, error) {
 	switch openshiftVersion {
 	case openshiftVersion419:
-		return OpenshiftImageWithRegistry(openshiftImage+"@sha256:f4d2df04a0ac1b689bc275c060e5520781f48f007dabf849d92cf1519f16ea82", registry)
+		return OpenshiftImageWithRegistry(openshiftImage+"@sha256:f4d2df04a0ac1b689bc275c060e5520781f48f007dabf849d92cf1519f16ea82", openshiftVersion, "docker-builder", registry)
 	default:
 		return "", fmt.Errorf("no tag for openshiftVersion %q available", openshiftVersion)
 	}
@@ -106,7 +106,7 @@ func dockerBuilderImage(openshiftVersion, registry string) (string, error) {
 func dockerRegistryImage(openshiftVersion, registry string) (string, error) {
 	switch openshiftVersion {
 	case openshiftVersion419:
-		return OpenshiftImageWithRegistry(openshiftImage+"@sha256:5c0b76746c2f86177b5a0fdce866cf41dbb752af58b96daa8fa7b033fa2c4fc9", registry)
+		return OpenshiftImageWithRegistry(openshiftImage+"@sha256:5c0b76746c2f86177b5a0fdce866cf41dbb752af58b96daa8fa7b033fa2c4fc9", openshiftVersion, "docker-registry", registry)
 	default:
 		return "", fmt.Errorf("no tag for openshiftVersion %q available", openshiftVersion)
 	}
@@ -115,7 +115,7 @@ func dockerRegistryImage(openshiftVersion, registry string) (string, error) {
 func hyperkubeImage(openshiftVersion, registry string) (string, error) {
 	switch openshiftVersion {
 	case openshiftVersion419:
-		return OpenshiftImageWithRegistry(openshiftImage+"@sha256:155ef40a64608c946ca9ca0310bbf88f5a4664b2925502b3acac86847bc158e6", registry)
+		return OpenshiftImageWithRegistry(openshiftImage+"@sha256:155ef40a64608c946ca9ca0310bbf88f5a4664b2925502b3acac86847bc158e6", openshiftVersion, "hyperkube", registry)
 	default:
 		return "", fmt.Errorf("no tag for openshiftVersion %q available", openshiftVersion)
 	}
@@ -124,7 +124,7 @@ func hyperkubeImage(openshiftVersion, registry string) (string, error) {
 func hypershiftImage(openshiftVersion, registry string) (string, error) {
 	switch openshiftVersion {
 	case openshiftVersion419:
-		return OpenshiftImageWithRegistry(openshiftImage+"@sha256:86255c4efe6bbc141a0f41444f863bbd5cd832ffca21d2b737a4f9c225ed00ad", registry)
+		return OpenshiftImageWithRegistry(openshiftImage+"@sha256:86255c4efe6bbc141a0f41444f863bbd5cd832ffca21d2b737a4f9c225ed00ad", openshiftVersion, "hypershift", registry)
 	default:
 		return "", fmt.Errorf("no tag for openshiftVersion %q available", openshiftVersion)
 	}
@@ -133,7 +133,7 @@ func hypershiftImage(openshiftVersion, registry string) (string, error) {
 func multusCniImage(openshiftVersion, registry string) (string, error) {
 	switch openshiftVersion {
 	case openshiftVersion419:
-		return OpenshiftImageWithRegistry(openshiftImage+"@sha256:6766e62f61307e7c5a187f61d33b99ba90390b2f43351f591bb8da951915ce04", registry)
+		return OpenshiftImageWithRegistry(openshiftImage+"@sha256:6766e62f61307e7c5a187f61d33b99ba90390b2f43351f591bb8da951915ce04", openshiftVersion, "multus-cni", registry)
 	default:
 		return "", fmt.Errorf("no tag for openshiftVersion %q available", openshiftVersion)
 	}
@@ -142,7 +142,7 @@ func multusCniImage(openshiftVersion, registry string) (string, error) {
 func nodeImage(openshiftVersion, registry string) (string, error) {
 	switch openshiftVersion {
 	case openshiftVersion419:
-		return OpenshiftImageWithRegistry(openshiftImage+"@sha256:472dd90bc413a9bcb99be23f7296763468ebbeb985c10b26d1c44c4b04f57a77", registry)
+		return OpenshiftImageWithRegistry(openshiftImage+"@sha256:472dd90bc413a9bcb99be23f7296763468ebbeb985c10b26d1c44c4b04f57a77", openshiftVersion, "node", registry)
 	default:
 		return "", fmt.Errorf("no tag for openshiftVersion %q available", openshiftVersion)
 	}
@@ -151,7 +151,7 @@ func nodeImage(openshiftVersion, registry string) (string, error) {
 func ovnKubernetesImage(openshiftVersion, registry string) (string, error) {
 	switch openshiftVersion {
 	case openshiftVersion419:
-		return OpenshiftImageWithRegistry(openshiftImage+"@sha256:81088a1f27ff88e7e4a65dd3ca47513aad76bfbfc44af359887baa1d3fa60eba", registry)
+		return OpenshiftImageWithRegistry(openshiftImage+"@sha256:81088a1f27ff88e7e4a65dd3ca47513aad76bfbfc44af359887baa1d3fa60eba", openshiftVersion, "ovn-kubernetes", registry)
 	default:
 		return "", fmt.Errorf("no tag for openshiftVersion %q available", openshiftVersion)
 	}
@@ -160,7 +160,7 @@ func ovnKubernetesImage(openshiftVersion, registry string) (string, error) {
 func sriovCniImage(openshiftVersion, registry string) (string, error) {
 	switch openshiftVersion {
 	case openshiftVersion419:
-		return OpenshiftImageWithRegistry(openshiftImage+"@sha256:9d332f4b42997f917fa7660d85975c579ee4abe354473acbd45fc2a093b12e3b", registry)
+		return OpenshiftImageWithRegistry(openshiftImage+"@sha256:9d332f4b42997f917fa7660d85975c579ee4abe354473acbd45fc2a093b12e3b", openshiftVersion, "sriov-cni", registry)
 	default:
 		return "", fmt.Errorf("no tag for openshiftVersion %q available", openshiftVersion)
 	}
@@ -169,7 +169,7 @@ func sriovCniImage(openshiftVersion, registry string) (string, error) {
 func sriovNetworkDevicePluginImage(openshiftVersion, registry string) (string, error) {
 	switch openshiftVersion {
 	case openshiftVersion419:
-		return OpenshiftImageWithRegistry(openshiftImage+"@sha256:21c668c419662bf1a5c1f38d55f6ab20b4e22b807d076f927efb1ac954beed60", registry)
+		return OpenshiftImageWithRegistry(openshiftImage+"@sha256:21c668c419662bf1a5c1f38d55f6ab20b4e22b807d076f927efb1ac954beed60", openshiftVersion, "sriov-network-device-plugin", registry)
 	default:
 		return "", fmt.Errorf("no tag for openshiftVersion %q available", openshiftVersion)
 	}

--- a/api/pkg/controller/seed-controller-manager/openshift/openshift_controller.go
+++ b/api/pkg/controller/seed-controller-manager/openshift/openshift_controller.go
@@ -426,7 +426,7 @@ func (r *Reconciler) getAllConfigmapCreators(ctx context.Context, osData *opensh
 		openshiftresources.OpenshiftAPIServerConfigMapCreator(osData),
 		openshiftresources.OpenshiftKubeAPIServerConfigMapCreator(osData),
 		openshiftresources.KubeControllerManagerConfigMapCreatorFactory(osData),
-		openshiftresources.OpenshiftControllerManagerConfigMapCreator(osData.Cluster().Spec.Version.String()),
+		openshiftresources.OpenshiftControllerManagerConfigMapCreator(osData),
 		openvpn.ServerClientConfigsConfigMapCreator(osData),
 		openshiftresources.KubeSchedulerConfigMapCreator,
 		dns.ConfigMapCreator(osData),

--- a/api/pkg/controller/seed-controller-manager/openshift/resources/cloud_credential_operator.go
+++ b/api/pkg/controller/seed-controller-manager/openshift/resources/cloud_credential_operator.go
@@ -22,7 +22,7 @@ func CloudCredentialOperator(data openshiftData) reconciling.NamedDeploymentCrea
 	return func() (string, reconciling.DeploymentCreator) {
 		return cloudCredentialOperatorDeploymentName, func(d *appsv1.Deployment) (*appsv1.Deployment, error) {
 
-			image, err := cloudCredentialOperatorImage(data.Cluster().Spec.Version.String())
+			image, err := cloudCredentialOperatorImage(data.Cluster().Spec.Version.String(), data.ImageRegistry(""))
 			if err != nil {
 				return nil, err
 			}

--- a/api/pkg/controller/seed-controller-manager/openshift/resources/console.go
+++ b/api/pkg/controller/seed-controller-manager/openshift/resources/console.go
@@ -65,7 +65,7 @@ func ConsoleDeployment(data openshiftData) reconciling.NamedDeploymentCreatorGet
 			d.Spec.Selector = &metav1.LabelSelector{
 				MatchLabels: resources.BaseAppLabel(consoleDeploymentName, nil),
 			}
-			image, err := consoleImage(data.Cluster().Spec.Version.String())
+			image, err := consoleImage(data.Cluster().Spec.Version.String(), data.ImageRegistry(""))
 			if err != nil {
 				return nil, err
 			}

--- a/api/pkg/controller/seed-controller-manager/openshift/resources/const.go
+++ b/api/pkg/controller/seed-controller-manager/openshift/resources/const.go
@@ -6,4 +6,4 @@ const (
 	openshiftVersion4118 = "4.1.18"
 )
 
-//go:generate go run ../../../../codegen/openshift_versions/main.go
+//go:generate go run ../../../../../codegen/openshift_versions/main.go

--- a/api/pkg/controller/seed-controller-manager/openshift/resources/dns_operator.go
+++ b/api/pkg/controller/seed-controller-manager/openshift/resources/dns_operator.go
@@ -39,12 +39,12 @@ func OpenshiftDNSOperatorFactory(data openshiftData) reconciling.NamedDeployment
 	return func() (string, reconciling.DeploymentCreator) {
 		return openshiftDNSOperatorDeploymentName, func(d *appsv1.Deployment) (*appsv1.Deployment, error) {
 
-			image, err := clusterDnsOperatorImage(data.Cluster().Spec.Version.String())
+			image, err := clusterDnsOperatorImage(data.Cluster().Spec.Version.String(), data.ImageRegistry(""))
 			if err != nil {
 				return nil, err
 			}
 
-			env, err := openshiftDNSOperatorEnv(data.Cluster().Spec.Version.String())
+			env, err := openshiftDNSOperatorEnv(data)
 			if err != nil {
 				return nil, err
 			}
@@ -111,12 +111,13 @@ func OpenshiftDNSOperatorFactory(data openshiftData) reconciling.NamedDeployment
 	}
 }
 
-func openshiftDNSOperatorEnv(openshiftVersion string) ([]corev1.EnvVar, error) {
-	cliImageValue, err := cliImage(openshiftVersion)
+func openshiftDNSOperatorEnv(data openshiftData) ([]corev1.EnvVar, error) {
+	openshiftVersion := data.Cluster().Spec.Version.String()
+	cliImageValue, err := cliImage(openshiftVersion, data.ImageRegistry(""))
 	if err != nil {
 		return nil, err
 	}
-	coreDNSImageValue, err := corednsImage(openshiftVersion)
+	coreDNSImageValue, err := corednsImage(openshiftVersion, data.ImageRegistry(""))
 	if err != nil {
 		return nil, err
 	}

--- a/api/pkg/controller/seed-controller-manager/openshift/resources/kube_apiserver_deployment.go
+++ b/api/pkg/controller/seed-controller-manager/openshift/resources/kube_apiserver_deployment.go
@@ -162,7 +162,7 @@ func APIDeploymentCreator(ctx context.Context, data openshiftData) reconciling.N
 				return nil, err
 			}
 
-			image, err := hypershiftImage(data.Cluster().Spec.Version.String())
+			image, err := hypershiftImage(data.Cluster().Spec.Version.String(), data.ImageRegistry(""))
 			if err != nil {
 				return nil, err
 			}

--- a/api/pkg/controller/seed-controller-manager/openshift/resources/kube_controller_manager.go
+++ b/api/pkg/controller/seed-controller-manager/openshift/resources/kube_controller_manager.go
@@ -241,7 +241,7 @@ func KubeControllerManagerDeploymentCreatorFactory(data kubeControllerManagerDat
 					volumeMounts = append(volumeMounts, fakeVMWareUUIDMount)
 				}
 
-				image, err := hyperkubeImage(data.Cluster().Spec.Version.String())
+				image, err := hyperkubeImage(data.Cluster().Spec.Version.String(), data.ImageRegistry(""))
 				if err != nil {
 					return nil, err
 				}

--- a/api/pkg/controller/seed-controller-manager/openshift/resources/kube_scheduler.go
+++ b/api/pkg/controller/seed-controller-manager/openshift/resources/kube_scheduler.go
@@ -112,7 +112,7 @@ func KubeSchedulerDeploymentCreator(data openshiftData) reconciling.NamedDeploym
 
 			dep.Spec.Template.Spec.Volumes = volumes
 
-			image, err := hyperkubeImage(data.Cluster().Spec.Version.String())
+			image, err := hyperkubeImage(data.Cluster().Spec.Version.String(), data.ImageRegistry(""))
 			if err != nil {
 				return nil, err
 			}

--- a/api/pkg/controller/seed-controller-manager/openshift/resources/oauth.go
+++ b/api/pkg/controller/seed-controller-manager/openshift/resources/oauth.go
@@ -310,7 +310,7 @@ func OauthDeploymentCreator(data openshiftData) reconciling.NamedDeploymentCreat
 				{Name: openshiftImagePullSecretName},
 			}
 			dep.Spec.Template.Spec.AutomountServiceAccountToken = utilpointer.BoolPtr(false)
-			image, err := hypershiftImage(data.Cluster().Spec.Version.String())
+			image, err := hypershiftImage(data.Cluster().Spec.Version.String(), data.ImageRegistry(""))
 			if err != nil {
 				return nil, err
 			}

--- a/api/pkg/controller/seed-controller-manager/openshift/resources/openshift_apiserver_deployment.go
+++ b/api/pkg/controller/seed-controller-manager/openshift/resources/openshift_apiserver_deployment.go
@@ -174,7 +174,7 @@ func OpenshiftAPIServerDeploymentCreator(ctx context.Context, data openshiftData
 			}
 
 			// TODO: Make it cope with our registry overwriting
-			image, err := hypershiftImage(data.Cluster().Spec.Version.String())
+			image, err := hypershiftImage(data.Cluster().Spec.Version.String(), data.ImageRegistry(""))
 			if err != nil {
 				return nil, err
 			}

--- a/api/pkg/controller/seed-controller-manager/openshift/resources/openshift_controller_manager.go
+++ b/api/pkg/controller/seed-controller-manager/openshift/resources/openshift_controller_manager.go
@@ -61,18 +61,19 @@ servingInfo:
 `
 )
 
-func OpenshiftControllerManagerConfigMapCreator(openshiftVersion string) reconciling.NamedConfigMapCreatorGetter {
+func OpenshiftControllerManagerConfigMapCreator(data openshiftData) reconciling.NamedConfigMapCreatorGetter {
+	openshiftVersion := data.Cluster().Spec.Version.String()
 	return func() (string, reconciling.ConfigMapCreator) {
 		return openshiftControllerManagerConfigMapName, func(cm *corev1.ConfigMap) (*corev1.ConfigMap, error) {
 			if cm.Data == nil {
 				cm.Data = map[string]string{}
 			}
 
-			buildImageTemplateFormatImage, err := dockerBuilderImage(openshiftVersion)
+			buildImageTemplateFormatImage, err := dockerBuilderImage(openshiftVersion, data.ImageRegistry(""))
 			if err != nil {
 				return nil, err
 			}
-			deployerImageTemplateFormatImage, err := deployerImage(openshiftVersion)
+			deployerImageTemplateFormatImage, err := deployerImage(openshiftVersion, data.ImageRegistry(""))
 			if err != nil {
 				return nil, err
 			}
@@ -145,7 +146,7 @@ func OpenshiftControllerManagerDeploymentCreator(ctx context.Context, data opens
 
 			dep.Spec.Template.Spec.Volumes = volumes
 
-			image, err := hypershiftImage(data.Cluster().Spec.Version.String())
+			image, err := hypershiftImage(data.Cluster().Spec.Version.String(), data.ImageRegistry(""))
 			if err != nil {
 				return nil, err
 			}

--- a/api/pkg/controller/seed-controller-manager/openshift/resources/openshift_network_operator.go
+++ b/api/pkg/controller/seed-controller-manager/openshift/resources/openshift_network_operator.go
@@ -36,11 +36,11 @@ const openshiftNetworkOperatorDeploymentName = "openshift-network-operator"
 func OpenshiftNetworkOperatorCreatorFactory(data openshiftData) reconciling.NamedDeploymentCreatorGetter {
 	return func() (string, reconciling.DeploymentCreator) {
 		return openshiftNetworkOperatorDeploymentName, func(d *appsv1.Deployment) (*appsv1.Deployment, error) {
-			image, err := clusterNetworkOperatorImage(data.Cluster().Spec.Version.String())
+			image, err := clusterNetworkOperatorImage(data.Cluster().Spec.Version.String(), data.ImageRegistry(""))
 			if err != nil {
 				return nil, err
 			}
-			env, err := openshiftNetworkOperatorEnv(data.Cluster().Spec.Version.String())
+			env, err := openshiftNetworkOperatorEnv(data)
 			if err != nil {
 				return nil, err
 			}
@@ -115,36 +115,37 @@ func OpenshiftNetworkOperatorCreatorFactory(data openshiftData) reconciling.Name
 	}
 }
 
-func openshiftNetworkOperatorEnv(openshiftVersion string) ([]corev1.EnvVar, error) {
-	nodeImageValue, err := nodeImage(openshiftVersion)
+func openshiftNetworkOperatorEnv(data openshiftData) ([]corev1.EnvVar, error) {
+	openshiftVersion := data.Cluster().Spec.Version.String()
+	nodeImageValue, err := nodeImage(openshiftVersion, data.ImageRegistry(""))
 	if err != nil {
 		return nil, err
 	}
-	hypershiftImageValue, err := hypershiftImage(openshiftVersion)
+	hypershiftImageValue, err := hypershiftImage(openshiftVersion, data.ImageRegistry(""))
 	if err != nil {
 		return nil, err
 	}
-	multusCniImageValue, err := multusCniImage(openshiftVersion)
+	multusCniImageValue, err := multusCniImage(openshiftVersion, data.ImageRegistry(""))
 	if err != nil {
 		return nil, err
 	}
-	containerNetworkingPluginsSupportedImageValue, err := containerNetworkingPluginsSupportedImage(openshiftVersion)
+	containerNetworkingPluginsSupportedImageValue, err := containerNetworkingPluginsSupportedImage(openshiftVersion, data.ImageRegistry(""))
 	if err != nil {
 		return nil, err
 	}
-	containerNetworkingPluginsUnsupportedImageValue, err := containerNetworkingPluginsUnsupportedImage(openshiftVersion)
+	containerNetworkingPluginsUnsupportedImageValue, err := containerNetworkingPluginsUnsupportedImage(openshiftVersion, data.ImageRegistry(""))
 	if err != nil {
 		return nil, err
 	}
-	sriovCniImageValue, err := sriovCniImage(openshiftVersion)
+	sriovCniImageValue, err := sriovCniImage(openshiftVersion, data.ImageRegistry(""))
 	if err != nil {
 		return nil, err
 	}
-	sriovNetworkDevicePluginImageValue, err := sriovNetworkDevicePluginImage(openshiftVersion)
+	sriovNetworkDevicePluginImageValue, err := sriovNetworkDevicePluginImage(openshiftVersion, data.ImageRegistry(""))
 	if err != nil {
 		return nil, err
 	}
-	ovnKubernetesImageValue, err := ovnKubernetesImage(openshiftVersion)
+	ovnKubernetesImageValue, err := ovnKubernetesImage(openshiftVersion, data.ImageRegistry(""))
 	if err != nil {
 		return nil, err
 	}

--- a/api/pkg/controller/seed-controller-manager/openshift/resources/registry_operator.go
+++ b/api/pkg/controller/seed-controller-manager/openshift/resources/registry_operator.go
@@ -23,11 +23,11 @@ const (
 func RegistryOperatorFactory(data openshiftData) reconciling.NamedDeploymentCreatorGetter {
 	return func() (string, reconciling.DeploymentCreator) {
 		return openshiftRegistryOperatorName, func(d *appsv1.Deployment) (*appsv1.Deployment, error) {
-			image, err := clusterImageRegistryOperatorImage(data.Cluster().Spec.Version.String())
+			image, err := clusterImageRegistryOperatorImage(data.Cluster().Spec.Version.String(), data.ImageRegistry(""))
 			if err != nil {
 				return nil, err
 			}
-			env, err := registryOperatorEnv(data.Cluster().Spec.Version.String())
+			env, err := registryOperatorEnv(data)
 			if err != nil {
 				return nil, err
 			}
@@ -83,8 +83,9 @@ func RegistryOperatorFactory(data openshiftData) reconciling.NamedDeploymentCrea
 	}
 }
 
-func registryOperatorEnv(openshiftVersion string) ([]corev1.EnvVar, error) {
-	image, err := dockerRegistryImage(openshiftVersion)
+func registryOperatorEnv(data openshiftData) ([]corev1.EnvVar, error) {
+	openshiftVersion := data.Cluster().Spec.Version.String()
+	image, err := dockerRegistryImage(openshiftVersion, data.ImageRegistry(""))
 	if err != nil {
 		return nil, err
 	}

--- a/api/pkg/controller/seed-controller-manager/openshift/resources/utils.go
+++ b/api/pkg/controller/seed-controller-manager/openshift/resources/utils.go
@@ -1,0 +1,28 @@
+package resources
+
+import (
+	"fmt"
+
+	"github.com/docker/distribution/reference"
+)
+
+// OpenshiftImageWithRegistry will return docker image name for Openshift images. The function is
+// digest-aware and can be used with the overwriteRegistry option and with image-loader.
+func OpenshiftImageWithRegistry(image, registry string) (string, error) {
+	if registry == "" {
+		return image, nil
+	}
+	imageRef, err := reference.ParseNamed(image)
+	if err != nil {
+		return "", fmt.Errorf("failed to parse image: %v", err)
+	}
+	if reference.Domain(imageRef) == registry {
+		return image, nil
+	}
+	if taggedImageRef, ok := imageRef.(reference.NamedTagged); ok {
+		return fmt.Sprintf("%s/%s:%s", registry, reference.Path(imageRef), taggedImageRef.Tag()), nil
+	} else if digestedImageRef, ok := imageRef.(reference.Digested); ok {
+		return fmt.Sprintf("%s/%s:%s", registry, reference.Path(imageRef), digestedImageRef.Digest().Hex()), nil
+	}
+	return "", nil
+}

--- a/api/pkg/controller/seed-controller-manager/openshift/resources/utils_test.go
+++ b/api/pkg/controller/seed-controller-manager/openshift/resources/utils_test.go
@@ -1,0 +1,48 @@
+package resources
+
+import (
+	"testing"
+)
+
+func TestOpenshiftImageWithRegistry(t *testing.T) {
+	tests := []struct {
+		name          string
+		image         string
+		registry      string
+		expectedImage string
+	}{
+		{
+			name:          "Image with digest",
+			image:         openshiftImage + "@sha256:528f2ead3d1605bdf818579976d97df5dd86df0a2a5d80df9aa8209c82333a86",
+			registry:      "localhost:5000",
+			expectedImage: "localhost:5000/openshift-release-dev/ocp-v4.0-art-dev:528f2ead3d1605bdf818579976d97df5dd86df0a2a5d80df9aa8209c82333a86",
+		},
+		{
+			name:          "Image with normal tag",
+			image:         "quay.io/kubermatic/openshift:v4.1.18",
+			registry:      "docker.io",
+			expectedImage: "docker.io/kubermatic/openshift:v4.1.18",
+		},
+		{
+			name:          "Same registry",
+			image:         openshiftImage + "@sha256:528f2ead3d1605bdf818579976d97df5dd86df0a2a5d80df9aa8209c82333a86",
+			registry:      "quay.io",
+			expectedImage: openshiftImage + "@sha256:528f2ead3d1605bdf818579976d97df5dd86df0a2a5d80df9aa8209c82333a86",
+		},
+		{
+			name:          "Empty registry",
+			image:         openshiftImage + "@sha256:528f2ead3d1605bdf818579976d97df5dd86df0a2a5d80df9aa8209c82333a86",
+			registry:      "",
+			expectedImage: openshiftImage + "@sha256:528f2ead3d1605bdf818579976d97df5dd86df0a2a5d80df9aa8209c82333a86",
+		},
+	}
+	for _, test := range tests {
+		image, err := OpenshiftImageWithRegistry(test.image, test.registry)
+		if err != nil {
+			t.Fatalf("failed to run OpenshiftImageWithRegistry: %v", err)
+		}
+		if test.expectedImage != image {
+			t.Fatalf("Invalid Openshift image returned. Expected [%v], got [%v]", test.expectedImage, image)
+		}
+	}
+}

--- a/api/pkg/controller/seed-controller-manager/openshift/resources/utils_test.go
+++ b/api/pkg/controller/seed-controller-manager/openshift/resources/utils_test.go
@@ -4,6 +4,12 @@ import (
 	"testing"
 )
 
+const (
+	componentName = "cli"
+	version       = "4.1.18"
+	digestImage   = openshiftImage + "@sha256:528f2ead3d1605bdf818579976d97df5dd86df0a2a5d80df9aa8209c82333a86"
+)
+
 func TestOpenshiftImageWithRegistry(t *testing.T) {
 	tests := []struct {
 		name          string
@@ -13,9 +19,9 @@ func TestOpenshiftImageWithRegistry(t *testing.T) {
 	}{
 		{
 			name:          "Image with digest",
-			image:         openshiftImage + "@sha256:528f2ead3d1605bdf818579976d97df5dd86df0a2a5d80df9aa8209c82333a86",
+			image:         digestImage,
 			registry:      "localhost:5000",
-			expectedImage: "localhost:5000/openshift-release-dev/ocp-v4.0-art-dev:528f2ead3d1605bdf818579976d97df5dd86df0a2a5d80df9aa8209c82333a86",
+			expectedImage: "localhost:5000/openshift-release-dev/ocp-v4.0-art-dev:4.1.18-cli",
 		},
 		{
 			name:          "Image with normal tag",
@@ -25,19 +31,19 @@ func TestOpenshiftImageWithRegistry(t *testing.T) {
 		},
 		{
 			name:          "Same registry",
-			image:         openshiftImage + "@sha256:528f2ead3d1605bdf818579976d97df5dd86df0a2a5d80df9aa8209c82333a86",
+			image:         digestImage,
 			registry:      "quay.io",
-			expectedImage: openshiftImage + "@sha256:528f2ead3d1605bdf818579976d97df5dd86df0a2a5d80df9aa8209c82333a86",
+			expectedImage: digestImage,
 		},
 		{
 			name:          "Empty registry",
-			image:         openshiftImage + "@sha256:528f2ead3d1605bdf818579976d97df5dd86df0a2a5d80df9aa8209c82333a86",
+			image:         digestImage,
 			registry:      "",
-			expectedImage: openshiftImage + "@sha256:528f2ead3d1605bdf818579976d97df5dd86df0a2a5d80df9aa8209c82333a86",
+			expectedImage: digestImage,
 		},
 	}
 	for _, test := range tests {
-		image, err := OpenshiftImageWithRegistry(test.image, test.registry)
+		image, err := OpenshiftImageWithRegistry(test.image, componentName, version, test.registry)
 		if err != nil {
 			t.Fatalf("failed to run OpenshiftImageWithRegistry: %v", err)
 		}

--- a/api/pkg/controller/seed-controller-manager/openshift/resources/zz_generated_image_tags.go
+++ b/api/pkg/controller/seed-controller-manager/openshift/resources/zz_generated_image_tags.go
@@ -4,210 +4,210 @@ import (
 	"fmt"
 )
 
-func cliImage(openshiftVersion string) (string, error) {
+func cliImage(openshiftVersion, registry string) (string, error) {
 	switch openshiftVersion {
 	case openshiftVersion4118:
-		return openshiftImage + "@sha256:528f2ead3d1605bdf818579976d97df5dd86df0a2a5d80df9aa8209c82333a86", nil
+		return OpenshiftImageWithRegistry(openshiftImage+"@sha256:528f2ead3d1605bdf818579976d97df5dd86df0a2a5d80df9aa8209c82333a86", registry)
 	case openshiftVersion419:
-		return openshiftImage + "@sha256:52ef9f5ade93e32f85e13bb9f588b2e126717256789023f8eb455b1147761562", nil
+		return OpenshiftImageWithRegistry(openshiftImage+"@sha256:52ef9f5ade93e32f85e13bb9f588b2e126717256789023f8eb455b1147761562", registry)
 	default:
 		return "", fmt.Errorf("no tag for openshiftVersion %q available", openshiftVersion)
 	}
 }
 
-func cloudCredentialOperatorImage(openshiftVersion string) (string, error) {
+func cloudCredentialOperatorImage(openshiftVersion, registry string) (string, error) {
 	switch openshiftVersion {
 	case openshiftVersion4118:
-		return openshiftImage + "@sha256:0a0e07e408baea29d05812441657155086b7883863ce9084e4c5fcc6dbcef844", nil
+		return OpenshiftImageWithRegistry(openshiftImage+"@sha256:0a0e07e408baea29d05812441657155086b7883863ce9084e4c5fcc6dbcef844", registry)
 	case openshiftVersion419:
-		return openshiftImage + "@sha256:1071e05a8fd4e13630be9097f4e412356af481af4568bf241f208e337665864f", nil
+		return OpenshiftImageWithRegistry(openshiftImage+"@sha256:1071e05a8fd4e13630be9097f4e412356af481af4568bf241f208e337665864f", registry)
 	default:
 		return "", fmt.Errorf("no tag for openshiftVersion %q available", openshiftVersion)
 	}
 }
 
-func clusterDnsOperatorImage(openshiftVersion string) (string, error) {
+func clusterDnsOperatorImage(openshiftVersion, registry string) (string, error) {
 	switch openshiftVersion {
 	case openshiftVersion4118:
-		return openshiftImage + "@sha256:6a57cf4d52f44b3087fc91157186037975160e8e1aae8247b728eb8e744ef834", nil
+		return OpenshiftImageWithRegistry(openshiftImage+"@sha256:6a57cf4d52f44b3087fc91157186037975160e8e1aae8247b728eb8e744ef834", registry)
 	case openshiftVersion419:
-		return openshiftImage + "@sha256:2aca09bcf2d705c8fe457e21507319550d4363fd07012db6403f59c314ecc7e0", nil
+		return OpenshiftImageWithRegistry(openshiftImage+"@sha256:2aca09bcf2d705c8fe457e21507319550d4363fd07012db6403f59c314ecc7e0", registry)
 	default:
 		return "", fmt.Errorf("no tag for openshiftVersion %q available", openshiftVersion)
 	}
 }
 
-func clusterImageRegistryOperatorImage(openshiftVersion string) (string, error) {
+func clusterImageRegistryOperatorImage(openshiftVersion, registry string) (string, error) {
 	switch openshiftVersion {
 	case openshiftVersion4118:
-		return openshiftImage + "@sha256:a46baddc04f823f4c89b6ec36ca71bd3b934b57d00feaf9de85750d9f6bdd51d", nil
+		return OpenshiftImageWithRegistry(openshiftImage+"@sha256:a46baddc04f823f4c89b6ec36ca71bd3b934b57d00feaf9de85750d9f6bdd51d", registry)
 	case openshiftVersion419:
-		return openshiftImage + "@sha256:2fb3e2f3eb6dbc013dcd4f7b94f9a9cff5231d1005174a030e265899160efc68", nil
+		return OpenshiftImageWithRegistry(openshiftImage+"@sha256:2fb3e2f3eb6dbc013dcd4f7b94f9a9cff5231d1005174a030e265899160efc68", registry)
 	default:
 		return "", fmt.Errorf("no tag for openshiftVersion %q available", openshiftVersion)
 	}
 }
 
-func clusterNetworkOperatorImage(openshiftVersion string) (string, error) {
+func clusterNetworkOperatorImage(openshiftVersion, registry string) (string, error) {
 	switch openshiftVersion {
 	case openshiftVersion4118:
-		return openshiftImage + "@sha256:ddb3514fa03aa820fc0dd60875317c0f964884f5b06b0436dcefa22dce6c77d0", nil
+		return OpenshiftImageWithRegistry(openshiftImage+"@sha256:ddb3514fa03aa820fc0dd60875317c0f964884f5b06b0436dcefa22dce6c77d0", registry)
 	case openshiftVersion419:
-		return openshiftImage + "@sha256:541465dbff9e28b303c533f5d86cea7a4f5ef1c920736a655380bb5b64954182", nil
+		return OpenshiftImageWithRegistry(openshiftImage+"@sha256:541465dbff9e28b303c533f5d86cea7a4f5ef1c920736a655380bb5b64954182", registry)
 	default:
 		return "", fmt.Errorf("no tag for openshiftVersion %q available", openshiftVersion)
 	}
 }
 
-func consoleImage(openshiftVersion string) (string, error) {
+func consoleImage(openshiftVersion, registry string) (string, error) {
 	switch openshiftVersion {
 	case openshiftVersion4118:
-		return openshiftImage + "@sha256:aca4d430a0f53388614f46ce1f857f73f1c50337d8d96088356e2adfbacb6be1", nil
+		return OpenshiftImageWithRegistry(openshiftImage+"@sha256:aca4d430a0f53388614f46ce1f857f73f1c50337d8d96088356e2adfbacb6be1", registry)
 	case openshiftVersion419:
-		return openshiftImage + "@sha256:9e554ac4505edd925eb73fec52e33d7418e2cfaf8058b59d8246ed478337748d", nil
+		return OpenshiftImageWithRegistry(openshiftImage+"@sha256:9e554ac4505edd925eb73fec52e33d7418e2cfaf8058b59d8246ed478337748d", registry)
 	default:
 		return "", fmt.Errorf("no tag for openshiftVersion %q available", openshiftVersion)
 	}
 }
 
-func containerNetworkingPluginsSupportedImage(openshiftVersion string) (string, error) {
+func containerNetworkingPluginsSupportedImage(openshiftVersion, registry string) (string, error) {
 	switch openshiftVersion {
 	case openshiftVersion4118:
-		return openshiftImage + "@sha256:caf943952c2fac2718cd705ca6b682d6716add0355c07cb629b6cde0c0fa0aed", nil
+		return OpenshiftImageWithRegistry(openshiftImage+"@sha256:caf943952c2fac2718cd705ca6b682d6716add0355c07cb629b6cde0c0fa0aed", registry)
 	case openshiftVersion419:
-		return openshiftImage + "@sha256:473d03cbfa265d2a6def817f8ec5bd1c6536d3e39cf8c2f8223dd41ed2bd4541", nil
+		return OpenshiftImageWithRegistry(openshiftImage+"@sha256:473d03cbfa265d2a6def817f8ec5bd1c6536d3e39cf8c2f8223dd41ed2bd4541", registry)
 	default:
 		return "", fmt.Errorf("no tag for openshiftVersion %q available", openshiftVersion)
 	}
 }
 
-func containerNetworkingPluginsUnsupportedImage(openshiftVersion string) (string, error) {
+func containerNetworkingPluginsUnsupportedImage(openshiftVersion, registry string) (string, error) {
 	switch openshiftVersion {
 	case openshiftVersion4118:
-		return openshiftImage + "@sha256:6da503d2c0cd4c57699b6539f7bc5a1ec111a76ce966c04fac88a1026367d673", nil
+		return OpenshiftImageWithRegistry(openshiftImage+"@sha256:6da503d2c0cd4c57699b6539f7bc5a1ec111a76ce966c04fac88a1026367d673", registry)
 	case openshiftVersion419:
-		return openshiftImage + "@sha256:d7c6701150c7ad12fc6dd26f2c6b093da5e9e3b43dea89196a77da1c6ef6904b", nil
+		return OpenshiftImageWithRegistry(openshiftImage+"@sha256:d7c6701150c7ad12fc6dd26f2c6b093da5e9e3b43dea89196a77da1c6ef6904b", registry)
 	default:
 		return "", fmt.Errorf("no tag for openshiftVersion %q available", openshiftVersion)
 	}
 }
 
-func corednsImage(openshiftVersion string) (string, error) {
+func corednsImage(openshiftVersion, registry string) (string, error) {
 	switch openshiftVersion {
 	case openshiftVersion4118:
-		return openshiftImage + "@sha256:c9e82ff7f5744062c4d251ff89ef04f45d7b9dfa17ea01a1c4092c4e1fd2b541", nil
+		return OpenshiftImageWithRegistry(openshiftImage+"@sha256:c9e82ff7f5744062c4d251ff89ef04f45d7b9dfa17ea01a1c4092c4e1fd2b541", registry)
 	case openshiftVersion419:
-		return openshiftImage + "@sha256:390cc1784aba986fad6315142d1d2524b2707a91eea3705d448367b51a112438", nil
+		return OpenshiftImageWithRegistry(openshiftImage+"@sha256:390cc1784aba986fad6315142d1d2524b2707a91eea3705d448367b51a112438", registry)
 	default:
 		return "", fmt.Errorf("no tag for openshiftVersion %q available", openshiftVersion)
 	}
 }
 
-func deployerImage(openshiftVersion string) (string, error) {
+func deployerImage(openshiftVersion, registry string) (string, error) {
 	switch openshiftVersion {
 	case openshiftVersion4118:
-		return openshiftImage + "@sha256:0213a23caa39d575db4b2cb7d5adc5c907c71cf76f58ab537732509d160f80a9", nil
+		return OpenshiftImageWithRegistry(openshiftImage+"@sha256:0213a23caa39d575db4b2cb7d5adc5c907c71cf76f58ab537732509d160f80a9", registry)
 	case openshiftVersion419:
-		return openshiftImage + "@sha256:8b946a142a8ba328ffe04195bb3fc4beeff26aaa4d8d0e99528340e8880eba7e", nil
+		return OpenshiftImageWithRegistry(openshiftImage+"@sha256:8b946a142a8ba328ffe04195bb3fc4beeff26aaa4d8d0e99528340e8880eba7e", registry)
 	default:
 		return "", fmt.Errorf("no tag for openshiftVersion %q available", openshiftVersion)
 	}
 }
 
-func dockerBuilderImage(openshiftVersion string) (string, error) {
+func dockerBuilderImage(openshiftVersion, registry string) (string, error) {
 	switch openshiftVersion {
 	case openshiftVersion4118:
-		return openshiftImage + "@sha256:decbd4a5d1a1660f5cc541bfb2664a73689d6ba8215e2729111ce3d94315ccf2", nil
+		return OpenshiftImageWithRegistry(openshiftImage+"@sha256:decbd4a5d1a1660f5cc541bfb2664a73689d6ba8215e2729111ce3d94315ccf2", registry)
 	case openshiftVersion419:
-		return openshiftImage + "@sha256:f4d2df04a0ac1b689bc275c060e5520781f48f007dabf849d92cf1519f16ea82", nil
+		return OpenshiftImageWithRegistry(openshiftImage+"@sha256:f4d2df04a0ac1b689bc275c060e5520781f48f007dabf849d92cf1519f16ea82", registry)
 	default:
 		return "", fmt.Errorf("no tag for openshiftVersion %q available", openshiftVersion)
 	}
 }
 
-func dockerRegistryImage(openshiftVersion string) (string, error) {
+func dockerRegistryImage(openshiftVersion, registry string) (string, error) {
 	switch openshiftVersion {
 	case openshiftVersion4118:
-		return openshiftImage + "@sha256:171d5a868e31ebb3265dff9ca24ba5f447ac357037e781630eb21fe4aee7de27", nil
+		return OpenshiftImageWithRegistry(openshiftImage+"@sha256:171d5a868e31ebb3265dff9ca24ba5f447ac357037e781630eb21fe4aee7de27", registry)
 	case openshiftVersion419:
-		return openshiftImage + "@sha256:5c0b76746c2f86177b5a0fdce866cf41dbb752af58b96daa8fa7b033fa2c4fc9", nil
+		return OpenshiftImageWithRegistry(openshiftImage+"@sha256:5c0b76746c2f86177b5a0fdce866cf41dbb752af58b96daa8fa7b033fa2c4fc9", registry)
 	default:
 		return "", fmt.Errorf("no tag for openshiftVersion %q available", openshiftVersion)
 	}
 }
 
-func hyperkubeImage(openshiftVersion string) (string, error) {
+func hyperkubeImage(openshiftVersion, registry string) (string, error) {
 	switch openshiftVersion {
 	case openshiftVersion4118:
-		return openshiftImage + "@sha256:0d6ba37d0613ea9b0ee4a1b5b8e083f070fc8651eab09e266a50f6c66148dd72", nil
+		return OpenshiftImageWithRegistry(openshiftImage+"@sha256:0d6ba37d0613ea9b0ee4a1b5b8e083f070fc8651eab09e266a50f6c66148dd72", registry)
 	case openshiftVersion419:
-		return openshiftImage + "@sha256:155ef40a64608c946ca9ca0310bbf88f5a4664b2925502b3acac86847bc158e6", nil
+		return OpenshiftImageWithRegistry(openshiftImage+"@sha256:155ef40a64608c946ca9ca0310bbf88f5a4664b2925502b3acac86847bc158e6", registry)
 	default:
 		return "", fmt.Errorf("no tag for openshiftVersion %q available", openshiftVersion)
 	}
 }
 
-func hypershiftImage(openshiftVersion string) (string, error) {
+func hypershiftImage(openshiftVersion, registry string) (string, error) {
 	switch openshiftVersion {
 	case openshiftVersion4118:
-		return openshiftImage + "@sha256:cc170b944f9a308cee401d75ecd0e047807d66e5ada8075d7b60f1b4b6106ff7", nil
+		return OpenshiftImageWithRegistry(openshiftImage+"@sha256:cc170b944f9a308cee401d75ecd0e047807d66e5ada8075d7b60f1b4b6106ff7", registry)
 	case openshiftVersion419:
-		return openshiftImage + "@sha256:86255c4efe6bbc141a0f41444f863bbd5cd832ffca21d2b737a4f9c225ed00ad", nil
+		return OpenshiftImageWithRegistry(openshiftImage+"@sha256:86255c4efe6bbc141a0f41444f863bbd5cd832ffca21d2b737a4f9c225ed00ad", registry)
 	default:
 		return "", fmt.Errorf("no tag for openshiftVersion %q available", openshiftVersion)
 	}
 }
 
-func multusCniImage(openshiftVersion string) (string, error) {
+func multusCniImage(openshiftVersion, registry string) (string, error) {
 	switch openshiftVersion {
 	case openshiftVersion4118:
-		return openshiftImage + "@sha256:6f4ffe4653d7c2b4f04146cc34e2d2b23499361570de053f15d6f25a11e09a1e", nil
+		return OpenshiftImageWithRegistry(openshiftImage+"@sha256:6f4ffe4653d7c2b4f04146cc34e2d2b23499361570de053f15d6f25a11e09a1e", registry)
 	case openshiftVersion419:
-		return openshiftImage + "@sha256:6766e62f61307e7c5a187f61d33b99ba90390b2f43351f591bb8da951915ce04", nil
+		return OpenshiftImageWithRegistry(openshiftImage+"@sha256:6766e62f61307e7c5a187f61d33b99ba90390b2f43351f591bb8da951915ce04", registry)
 	default:
 		return "", fmt.Errorf("no tag for openshiftVersion %q available", openshiftVersion)
 	}
 }
 
-func nodeImage(openshiftVersion string) (string, error) {
+func nodeImage(openshiftVersion, registry string) (string, error) {
 	switch openshiftVersion {
 	case openshiftVersion4118:
-		return openshiftImage + "@sha256:a92e3ae780e2eb2b69f57285611143e5c44d99bafbdfa0220e2780a7e1bc46a2", nil
+		return OpenshiftImageWithRegistry(openshiftImage+"@sha256:a92e3ae780e2eb2b69f57285611143e5c44d99bafbdfa0220e2780a7e1bc46a2", registry)
 	case openshiftVersion419:
-		return openshiftImage + "@sha256:472dd90bc413a9bcb99be23f7296763468ebbeb985c10b26d1c44c4b04f57a77", nil
+		return OpenshiftImageWithRegistry(openshiftImage+"@sha256:472dd90bc413a9bcb99be23f7296763468ebbeb985c10b26d1c44c4b04f57a77", registry)
 	default:
 		return "", fmt.Errorf("no tag for openshiftVersion %q available", openshiftVersion)
 	}
 }
 
-func ovnKubernetesImage(openshiftVersion string) (string, error) {
+func ovnKubernetesImage(openshiftVersion, registry string) (string, error) {
 	switch openshiftVersion {
 	case openshiftVersion4118:
-		return openshiftImage + "@sha256:4dd49bb4921b802dfaf0ebee96682872e21c72895d57db8c3e94b03b63053942", nil
+		return OpenshiftImageWithRegistry(openshiftImage+"@sha256:4dd49bb4921b802dfaf0ebee96682872e21c72895d57db8c3e94b03b63053942", registry)
 	case openshiftVersion419:
-		return openshiftImage + "@sha256:81088a1f27ff88e7e4a65dd3ca47513aad76bfbfc44af359887baa1d3fa60eba", nil
+		return OpenshiftImageWithRegistry(openshiftImage+"@sha256:81088a1f27ff88e7e4a65dd3ca47513aad76bfbfc44af359887baa1d3fa60eba", registry)
 	default:
 		return "", fmt.Errorf("no tag for openshiftVersion %q available", openshiftVersion)
 	}
 }
 
-func sriovCniImage(openshiftVersion string) (string, error) {
+func sriovCniImage(openshiftVersion, registry string) (string, error) {
 	switch openshiftVersion {
 	case openshiftVersion4118:
-		return openshiftImage + "@sha256:1b151df2ab3f9058ea3c006101a2a28468c6d8d39e3e4b78453ae96c51c404cf", nil
+		return OpenshiftImageWithRegistry(openshiftImage+"@sha256:1b151df2ab3f9058ea3c006101a2a28468c6d8d39e3e4b78453ae96c51c404cf", registry)
 	case openshiftVersion419:
-		return openshiftImage + "@sha256:9d332f4b42997f917fa7660d85975c579ee4abe354473acbd45fc2a093b12e3b", nil
+		return OpenshiftImageWithRegistry(openshiftImage+"@sha256:9d332f4b42997f917fa7660d85975c579ee4abe354473acbd45fc2a093b12e3b", registry)
 	default:
 		return "", fmt.Errorf("no tag for openshiftVersion %q available", openshiftVersion)
 	}
 }
 
-func sriovNetworkDevicePluginImage(openshiftVersion string) (string, error) {
+func sriovNetworkDevicePluginImage(openshiftVersion, registry string) (string, error) {
 	switch openshiftVersion {
 	case openshiftVersion4118:
-		return openshiftImage + "@sha256:4493f9c75d46ecfcee81bbb0ca9c2579bac4ffb150b2255f8385eac50a885ca6", nil
+		return OpenshiftImageWithRegistry(openshiftImage+"@sha256:4493f9c75d46ecfcee81bbb0ca9c2579bac4ffb150b2255f8385eac50a885ca6", registry)
 	case openshiftVersion419:
-		return openshiftImage + "@sha256:21c668c419662bf1a5c1f38d55f6ab20b4e22b807d076f927efb1ac954beed60", nil
+		return OpenshiftImageWithRegistry(openshiftImage+"@sha256:21c668c419662bf1a5c1f38d55f6ab20b4e22b807d076f927efb1ac954beed60", registry)
 	default:
 		return "", fmt.Errorf("no tag for openshiftVersion %q available", openshiftVersion)
 	}

--- a/api/pkg/controller/seed-controller-manager/openshift/resources/zz_generated_image_tags.go
+++ b/api/pkg/controller/seed-controller-manager/openshift/resources/zz_generated_image_tags.go
@@ -7,9 +7,9 @@ import (
 func cliImage(openshiftVersion, registry string) (string, error) {
 	switch openshiftVersion {
 	case openshiftVersion4118:
-		return OpenshiftImageWithRegistry(openshiftImage+"@sha256:528f2ead3d1605bdf818579976d97df5dd86df0a2a5d80df9aa8209c82333a86", registry)
+		return OpenshiftImageWithRegistry(openshiftImage+"@sha256:528f2ead3d1605bdf818579976d97df5dd86df0a2a5d80df9aa8209c82333a86", openshiftVersion, "cli", registry)
 	case openshiftVersion419:
-		return OpenshiftImageWithRegistry(openshiftImage+"@sha256:52ef9f5ade93e32f85e13bb9f588b2e126717256789023f8eb455b1147761562", registry)
+		return OpenshiftImageWithRegistry(openshiftImage+"@sha256:52ef9f5ade93e32f85e13bb9f588b2e126717256789023f8eb455b1147761562", openshiftVersion, "cli", registry)
 	default:
 		return "", fmt.Errorf("no tag for openshiftVersion %q available", openshiftVersion)
 	}
@@ -18,9 +18,9 @@ func cliImage(openshiftVersion, registry string) (string, error) {
 func cloudCredentialOperatorImage(openshiftVersion, registry string) (string, error) {
 	switch openshiftVersion {
 	case openshiftVersion4118:
-		return OpenshiftImageWithRegistry(openshiftImage+"@sha256:0a0e07e408baea29d05812441657155086b7883863ce9084e4c5fcc6dbcef844", registry)
+		return OpenshiftImageWithRegistry(openshiftImage+"@sha256:0a0e07e408baea29d05812441657155086b7883863ce9084e4c5fcc6dbcef844", openshiftVersion, "cloud-credential-operator", registry)
 	case openshiftVersion419:
-		return OpenshiftImageWithRegistry(openshiftImage+"@sha256:1071e05a8fd4e13630be9097f4e412356af481af4568bf241f208e337665864f", registry)
+		return OpenshiftImageWithRegistry(openshiftImage+"@sha256:1071e05a8fd4e13630be9097f4e412356af481af4568bf241f208e337665864f", openshiftVersion, "cloud-credential-operator", registry)
 	default:
 		return "", fmt.Errorf("no tag for openshiftVersion %q available", openshiftVersion)
 	}
@@ -29,9 +29,9 @@ func cloudCredentialOperatorImage(openshiftVersion, registry string) (string, er
 func clusterDnsOperatorImage(openshiftVersion, registry string) (string, error) {
 	switch openshiftVersion {
 	case openshiftVersion4118:
-		return OpenshiftImageWithRegistry(openshiftImage+"@sha256:6a57cf4d52f44b3087fc91157186037975160e8e1aae8247b728eb8e744ef834", registry)
+		return OpenshiftImageWithRegistry(openshiftImage+"@sha256:6a57cf4d52f44b3087fc91157186037975160e8e1aae8247b728eb8e744ef834", openshiftVersion, "cluster-dns-operator", registry)
 	case openshiftVersion419:
-		return OpenshiftImageWithRegistry(openshiftImage+"@sha256:2aca09bcf2d705c8fe457e21507319550d4363fd07012db6403f59c314ecc7e0", registry)
+		return OpenshiftImageWithRegistry(openshiftImage+"@sha256:2aca09bcf2d705c8fe457e21507319550d4363fd07012db6403f59c314ecc7e0", openshiftVersion, "cluster-dns-operator", registry)
 	default:
 		return "", fmt.Errorf("no tag for openshiftVersion %q available", openshiftVersion)
 	}
@@ -40,9 +40,9 @@ func clusterDnsOperatorImage(openshiftVersion, registry string) (string, error) 
 func clusterImageRegistryOperatorImage(openshiftVersion, registry string) (string, error) {
 	switch openshiftVersion {
 	case openshiftVersion4118:
-		return OpenshiftImageWithRegistry(openshiftImage+"@sha256:a46baddc04f823f4c89b6ec36ca71bd3b934b57d00feaf9de85750d9f6bdd51d", registry)
+		return OpenshiftImageWithRegistry(openshiftImage+"@sha256:a46baddc04f823f4c89b6ec36ca71bd3b934b57d00feaf9de85750d9f6bdd51d", openshiftVersion, "cluster-image-registry-operator", registry)
 	case openshiftVersion419:
-		return OpenshiftImageWithRegistry(openshiftImage+"@sha256:2fb3e2f3eb6dbc013dcd4f7b94f9a9cff5231d1005174a030e265899160efc68", registry)
+		return OpenshiftImageWithRegistry(openshiftImage+"@sha256:2fb3e2f3eb6dbc013dcd4f7b94f9a9cff5231d1005174a030e265899160efc68", openshiftVersion, "cluster-image-registry-operator", registry)
 	default:
 		return "", fmt.Errorf("no tag for openshiftVersion %q available", openshiftVersion)
 	}
@@ -51,9 +51,9 @@ func clusterImageRegistryOperatorImage(openshiftVersion, registry string) (strin
 func clusterNetworkOperatorImage(openshiftVersion, registry string) (string, error) {
 	switch openshiftVersion {
 	case openshiftVersion4118:
-		return OpenshiftImageWithRegistry(openshiftImage+"@sha256:ddb3514fa03aa820fc0dd60875317c0f964884f5b06b0436dcefa22dce6c77d0", registry)
+		return OpenshiftImageWithRegistry(openshiftImage+"@sha256:ddb3514fa03aa820fc0dd60875317c0f964884f5b06b0436dcefa22dce6c77d0", openshiftVersion, "cluster-network-operator", registry)
 	case openshiftVersion419:
-		return OpenshiftImageWithRegistry(openshiftImage+"@sha256:541465dbff9e28b303c533f5d86cea7a4f5ef1c920736a655380bb5b64954182", registry)
+		return OpenshiftImageWithRegistry(openshiftImage+"@sha256:541465dbff9e28b303c533f5d86cea7a4f5ef1c920736a655380bb5b64954182", openshiftVersion, "cluster-network-operator", registry)
 	default:
 		return "", fmt.Errorf("no tag for openshiftVersion %q available", openshiftVersion)
 	}
@@ -62,9 +62,9 @@ func clusterNetworkOperatorImage(openshiftVersion, registry string) (string, err
 func consoleImage(openshiftVersion, registry string) (string, error) {
 	switch openshiftVersion {
 	case openshiftVersion4118:
-		return OpenshiftImageWithRegistry(openshiftImage+"@sha256:aca4d430a0f53388614f46ce1f857f73f1c50337d8d96088356e2adfbacb6be1", registry)
+		return OpenshiftImageWithRegistry(openshiftImage+"@sha256:aca4d430a0f53388614f46ce1f857f73f1c50337d8d96088356e2adfbacb6be1", openshiftVersion, "console", registry)
 	case openshiftVersion419:
-		return OpenshiftImageWithRegistry(openshiftImage+"@sha256:9e554ac4505edd925eb73fec52e33d7418e2cfaf8058b59d8246ed478337748d", registry)
+		return OpenshiftImageWithRegistry(openshiftImage+"@sha256:9e554ac4505edd925eb73fec52e33d7418e2cfaf8058b59d8246ed478337748d", openshiftVersion, "console", registry)
 	default:
 		return "", fmt.Errorf("no tag for openshiftVersion %q available", openshiftVersion)
 	}
@@ -73,9 +73,9 @@ func consoleImage(openshiftVersion, registry string) (string, error) {
 func containerNetworkingPluginsSupportedImage(openshiftVersion, registry string) (string, error) {
 	switch openshiftVersion {
 	case openshiftVersion4118:
-		return OpenshiftImageWithRegistry(openshiftImage+"@sha256:caf943952c2fac2718cd705ca6b682d6716add0355c07cb629b6cde0c0fa0aed", registry)
+		return OpenshiftImageWithRegistry(openshiftImage+"@sha256:caf943952c2fac2718cd705ca6b682d6716add0355c07cb629b6cde0c0fa0aed", openshiftVersion, "container-networking-plugins-supported", registry)
 	case openshiftVersion419:
-		return OpenshiftImageWithRegistry(openshiftImage+"@sha256:473d03cbfa265d2a6def817f8ec5bd1c6536d3e39cf8c2f8223dd41ed2bd4541", registry)
+		return OpenshiftImageWithRegistry(openshiftImage+"@sha256:473d03cbfa265d2a6def817f8ec5bd1c6536d3e39cf8c2f8223dd41ed2bd4541", openshiftVersion, "container-networking-plugins-supported", registry)
 	default:
 		return "", fmt.Errorf("no tag for openshiftVersion %q available", openshiftVersion)
 	}
@@ -84,9 +84,9 @@ func containerNetworkingPluginsSupportedImage(openshiftVersion, registry string)
 func containerNetworkingPluginsUnsupportedImage(openshiftVersion, registry string) (string, error) {
 	switch openshiftVersion {
 	case openshiftVersion4118:
-		return OpenshiftImageWithRegistry(openshiftImage+"@sha256:6da503d2c0cd4c57699b6539f7bc5a1ec111a76ce966c04fac88a1026367d673", registry)
+		return OpenshiftImageWithRegistry(openshiftImage+"@sha256:6da503d2c0cd4c57699b6539f7bc5a1ec111a76ce966c04fac88a1026367d673", openshiftVersion, "container-networking-plugins-unsupported", registry)
 	case openshiftVersion419:
-		return OpenshiftImageWithRegistry(openshiftImage+"@sha256:d7c6701150c7ad12fc6dd26f2c6b093da5e9e3b43dea89196a77da1c6ef6904b", registry)
+		return OpenshiftImageWithRegistry(openshiftImage+"@sha256:d7c6701150c7ad12fc6dd26f2c6b093da5e9e3b43dea89196a77da1c6ef6904b", openshiftVersion, "container-networking-plugins-unsupported", registry)
 	default:
 		return "", fmt.Errorf("no tag for openshiftVersion %q available", openshiftVersion)
 	}
@@ -95,9 +95,9 @@ func containerNetworkingPluginsUnsupportedImage(openshiftVersion, registry strin
 func corednsImage(openshiftVersion, registry string) (string, error) {
 	switch openshiftVersion {
 	case openshiftVersion4118:
-		return OpenshiftImageWithRegistry(openshiftImage+"@sha256:c9e82ff7f5744062c4d251ff89ef04f45d7b9dfa17ea01a1c4092c4e1fd2b541", registry)
+		return OpenshiftImageWithRegistry(openshiftImage+"@sha256:c9e82ff7f5744062c4d251ff89ef04f45d7b9dfa17ea01a1c4092c4e1fd2b541", openshiftVersion, "coredns", registry)
 	case openshiftVersion419:
-		return OpenshiftImageWithRegistry(openshiftImage+"@sha256:390cc1784aba986fad6315142d1d2524b2707a91eea3705d448367b51a112438", registry)
+		return OpenshiftImageWithRegistry(openshiftImage+"@sha256:390cc1784aba986fad6315142d1d2524b2707a91eea3705d448367b51a112438", openshiftVersion, "coredns", registry)
 	default:
 		return "", fmt.Errorf("no tag for openshiftVersion %q available", openshiftVersion)
 	}
@@ -106,9 +106,9 @@ func corednsImage(openshiftVersion, registry string) (string, error) {
 func deployerImage(openshiftVersion, registry string) (string, error) {
 	switch openshiftVersion {
 	case openshiftVersion4118:
-		return OpenshiftImageWithRegistry(openshiftImage+"@sha256:0213a23caa39d575db4b2cb7d5adc5c907c71cf76f58ab537732509d160f80a9", registry)
+		return OpenshiftImageWithRegistry(openshiftImage+"@sha256:0213a23caa39d575db4b2cb7d5adc5c907c71cf76f58ab537732509d160f80a9", openshiftVersion, "deployer", registry)
 	case openshiftVersion419:
-		return OpenshiftImageWithRegistry(openshiftImage+"@sha256:8b946a142a8ba328ffe04195bb3fc4beeff26aaa4d8d0e99528340e8880eba7e", registry)
+		return OpenshiftImageWithRegistry(openshiftImage+"@sha256:8b946a142a8ba328ffe04195bb3fc4beeff26aaa4d8d0e99528340e8880eba7e", openshiftVersion, "deployer", registry)
 	default:
 		return "", fmt.Errorf("no tag for openshiftVersion %q available", openshiftVersion)
 	}
@@ -117,9 +117,9 @@ func deployerImage(openshiftVersion, registry string) (string, error) {
 func dockerBuilderImage(openshiftVersion, registry string) (string, error) {
 	switch openshiftVersion {
 	case openshiftVersion4118:
-		return OpenshiftImageWithRegistry(openshiftImage+"@sha256:decbd4a5d1a1660f5cc541bfb2664a73689d6ba8215e2729111ce3d94315ccf2", registry)
+		return OpenshiftImageWithRegistry(openshiftImage+"@sha256:decbd4a5d1a1660f5cc541bfb2664a73689d6ba8215e2729111ce3d94315ccf2", openshiftVersion, "docker-builder", registry)
 	case openshiftVersion419:
-		return OpenshiftImageWithRegistry(openshiftImage+"@sha256:f4d2df04a0ac1b689bc275c060e5520781f48f007dabf849d92cf1519f16ea82", registry)
+		return OpenshiftImageWithRegistry(openshiftImage+"@sha256:f4d2df04a0ac1b689bc275c060e5520781f48f007dabf849d92cf1519f16ea82", openshiftVersion, "docker-builder", registry)
 	default:
 		return "", fmt.Errorf("no tag for openshiftVersion %q available", openshiftVersion)
 	}
@@ -128,9 +128,9 @@ func dockerBuilderImage(openshiftVersion, registry string) (string, error) {
 func dockerRegistryImage(openshiftVersion, registry string) (string, error) {
 	switch openshiftVersion {
 	case openshiftVersion4118:
-		return OpenshiftImageWithRegistry(openshiftImage+"@sha256:171d5a868e31ebb3265dff9ca24ba5f447ac357037e781630eb21fe4aee7de27", registry)
+		return OpenshiftImageWithRegistry(openshiftImage+"@sha256:171d5a868e31ebb3265dff9ca24ba5f447ac357037e781630eb21fe4aee7de27", openshiftVersion, "docker-registry", registry)
 	case openshiftVersion419:
-		return OpenshiftImageWithRegistry(openshiftImage+"@sha256:5c0b76746c2f86177b5a0fdce866cf41dbb752af58b96daa8fa7b033fa2c4fc9", registry)
+		return OpenshiftImageWithRegistry(openshiftImage+"@sha256:5c0b76746c2f86177b5a0fdce866cf41dbb752af58b96daa8fa7b033fa2c4fc9", openshiftVersion, "docker-registry", registry)
 	default:
 		return "", fmt.Errorf("no tag for openshiftVersion %q available", openshiftVersion)
 	}
@@ -139,9 +139,9 @@ func dockerRegistryImage(openshiftVersion, registry string) (string, error) {
 func hyperkubeImage(openshiftVersion, registry string) (string, error) {
 	switch openshiftVersion {
 	case openshiftVersion4118:
-		return OpenshiftImageWithRegistry(openshiftImage+"@sha256:0d6ba37d0613ea9b0ee4a1b5b8e083f070fc8651eab09e266a50f6c66148dd72", registry)
+		return OpenshiftImageWithRegistry(openshiftImage+"@sha256:0d6ba37d0613ea9b0ee4a1b5b8e083f070fc8651eab09e266a50f6c66148dd72", openshiftVersion, "hyperkube", registry)
 	case openshiftVersion419:
-		return OpenshiftImageWithRegistry(openshiftImage+"@sha256:155ef40a64608c946ca9ca0310bbf88f5a4664b2925502b3acac86847bc158e6", registry)
+		return OpenshiftImageWithRegistry(openshiftImage+"@sha256:155ef40a64608c946ca9ca0310bbf88f5a4664b2925502b3acac86847bc158e6", openshiftVersion, "hyperkube", registry)
 	default:
 		return "", fmt.Errorf("no tag for openshiftVersion %q available", openshiftVersion)
 	}
@@ -150,9 +150,9 @@ func hyperkubeImage(openshiftVersion, registry string) (string, error) {
 func hypershiftImage(openshiftVersion, registry string) (string, error) {
 	switch openshiftVersion {
 	case openshiftVersion4118:
-		return OpenshiftImageWithRegistry(openshiftImage+"@sha256:cc170b944f9a308cee401d75ecd0e047807d66e5ada8075d7b60f1b4b6106ff7", registry)
+		return OpenshiftImageWithRegistry(openshiftImage+"@sha256:cc170b944f9a308cee401d75ecd0e047807d66e5ada8075d7b60f1b4b6106ff7", openshiftVersion, "hypershift", registry)
 	case openshiftVersion419:
-		return OpenshiftImageWithRegistry(openshiftImage+"@sha256:86255c4efe6bbc141a0f41444f863bbd5cd832ffca21d2b737a4f9c225ed00ad", registry)
+		return OpenshiftImageWithRegistry(openshiftImage+"@sha256:86255c4efe6bbc141a0f41444f863bbd5cd832ffca21d2b737a4f9c225ed00ad", openshiftVersion, "hypershift", registry)
 	default:
 		return "", fmt.Errorf("no tag for openshiftVersion %q available", openshiftVersion)
 	}
@@ -161,9 +161,9 @@ func hypershiftImage(openshiftVersion, registry string) (string, error) {
 func multusCniImage(openshiftVersion, registry string) (string, error) {
 	switch openshiftVersion {
 	case openshiftVersion4118:
-		return OpenshiftImageWithRegistry(openshiftImage+"@sha256:6f4ffe4653d7c2b4f04146cc34e2d2b23499361570de053f15d6f25a11e09a1e", registry)
+		return OpenshiftImageWithRegistry(openshiftImage+"@sha256:6f4ffe4653d7c2b4f04146cc34e2d2b23499361570de053f15d6f25a11e09a1e", openshiftVersion, "multus-cni", registry)
 	case openshiftVersion419:
-		return OpenshiftImageWithRegistry(openshiftImage+"@sha256:6766e62f61307e7c5a187f61d33b99ba90390b2f43351f591bb8da951915ce04", registry)
+		return OpenshiftImageWithRegistry(openshiftImage+"@sha256:6766e62f61307e7c5a187f61d33b99ba90390b2f43351f591bb8da951915ce04", openshiftVersion, "multus-cni", registry)
 	default:
 		return "", fmt.Errorf("no tag for openshiftVersion %q available", openshiftVersion)
 	}
@@ -172,9 +172,9 @@ func multusCniImage(openshiftVersion, registry string) (string, error) {
 func nodeImage(openshiftVersion, registry string) (string, error) {
 	switch openshiftVersion {
 	case openshiftVersion4118:
-		return OpenshiftImageWithRegistry(openshiftImage+"@sha256:a92e3ae780e2eb2b69f57285611143e5c44d99bafbdfa0220e2780a7e1bc46a2", registry)
+		return OpenshiftImageWithRegistry(openshiftImage+"@sha256:a92e3ae780e2eb2b69f57285611143e5c44d99bafbdfa0220e2780a7e1bc46a2", openshiftVersion, "node", registry)
 	case openshiftVersion419:
-		return OpenshiftImageWithRegistry(openshiftImage+"@sha256:472dd90bc413a9bcb99be23f7296763468ebbeb985c10b26d1c44c4b04f57a77", registry)
+		return OpenshiftImageWithRegistry(openshiftImage+"@sha256:472dd90bc413a9bcb99be23f7296763468ebbeb985c10b26d1c44c4b04f57a77", openshiftVersion, "node", registry)
 	default:
 		return "", fmt.Errorf("no tag for openshiftVersion %q available", openshiftVersion)
 	}
@@ -183,9 +183,9 @@ func nodeImage(openshiftVersion, registry string) (string, error) {
 func ovnKubernetesImage(openshiftVersion, registry string) (string, error) {
 	switch openshiftVersion {
 	case openshiftVersion4118:
-		return OpenshiftImageWithRegistry(openshiftImage+"@sha256:4dd49bb4921b802dfaf0ebee96682872e21c72895d57db8c3e94b03b63053942", registry)
+		return OpenshiftImageWithRegistry(openshiftImage+"@sha256:4dd49bb4921b802dfaf0ebee96682872e21c72895d57db8c3e94b03b63053942", openshiftVersion, "ovn-kubernetes", registry)
 	case openshiftVersion419:
-		return OpenshiftImageWithRegistry(openshiftImage+"@sha256:81088a1f27ff88e7e4a65dd3ca47513aad76bfbfc44af359887baa1d3fa60eba", registry)
+		return OpenshiftImageWithRegistry(openshiftImage+"@sha256:81088a1f27ff88e7e4a65dd3ca47513aad76bfbfc44af359887baa1d3fa60eba", openshiftVersion, "ovn-kubernetes", registry)
 	default:
 		return "", fmt.Errorf("no tag for openshiftVersion %q available", openshiftVersion)
 	}
@@ -194,9 +194,9 @@ func ovnKubernetesImage(openshiftVersion, registry string) (string, error) {
 func sriovCniImage(openshiftVersion, registry string) (string, error) {
 	switch openshiftVersion {
 	case openshiftVersion4118:
-		return OpenshiftImageWithRegistry(openshiftImage+"@sha256:1b151df2ab3f9058ea3c006101a2a28468c6d8d39e3e4b78453ae96c51c404cf", registry)
+		return OpenshiftImageWithRegistry(openshiftImage+"@sha256:1b151df2ab3f9058ea3c006101a2a28468c6d8d39e3e4b78453ae96c51c404cf", openshiftVersion, "sriov-cni", registry)
 	case openshiftVersion419:
-		return OpenshiftImageWithRegistry(openshiftImage+"@sha256:9d332f4b42997f917fa7660d85975c579ee4abe354473acbd45fc2a093b12e3b", registry)
+		return OpenshiftImageWithRegistry(openshiftImage+"@sha256:9d332f4b42997f917fa7660d85975c579ee4abe354473acbd45fc2a093b12e3b", openshiftVersion, "sriov-cni", registry)
 	default:
 		return "", fmt.Errorf("no tag for openshiftVersion %q available", openshiftVersion)
 	}
@@ -205,9 +205,9 @@ func sriovCniImage(openshiftVersion, registry string) (string, error) {
 func sriovNetworkDevicePluginImage(openshiftVersion, registry string) (string, error) {
 	switch openshiftVersion {
 	case openshiftVersion4118:
-		return OpenshiftImageWithRegistry(openshiftImage+"@sha256:4493f9c75d46ecfcee81bbb0ca9c2579bac4ffb150b2255f8385eac50a885ca6", registry)
+		return OpenshiftImageWithRegistry(openshiftImage+"@sha256:4493f9c75d46ecfcee81bbb0ca9c2579bac4ffb150b2255f8385eac50a885ca6", openshiftVersion, "sriov-network-device-plugin", registry)
 	case openshiftVersion419:
-		return OpenshiftImageWithRegistry(openshiftImage+"@sha256:21c668c419662bf1a5c1f38d55f6ab20b4e22b807d076f927efb1ac954beed60", registry)
+		return OpenshiftImageWithRegistry(openshiftImage+"@sha256:21c668c419662bf1a5c1f38d55f6ab20b4e22b807d076f927efb1ac954beed60", openshiftVersion, "sriov-network-device-plugin", registry)
 	default:
 		return "", fmt.Errorf("no tag for openshiftVersion %q available", openshiftVersion)
 	}


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR enables Openshift resources/versions generator to use an external registry. 
**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #5059

**Special notes for your reviewer**:
Since the Openshift images use a single base image with different digests, each pointing to a layer representing the actual image used. It's not possible to "re-tag" image digests, so, as a work around, the added helper function will use the ~~digest hex as a tag~~ component name and the Openshift version as a tag. PR #5052 will use the same convention to push the images to a private registry. 
**Documentation**:
<!-- Add links to the related documentation changes related to this pull request. E.g. the link to the kubermatic/docs pullrequest. -->

**Does this PR introduce a user-facing change?**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If  no release note is required, just write "NONE".
-->
```release-note
NONE
```
