### PR TITLE
Update Thanos to 0.10.1

### DIFF
--- a/config/monitoring/prometheus/Chart.yaml
+++ b/config/monitoring/prometheus/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: prometheus
-version: 2.2.8
+version: 2.2.9
 appVersion: v2.14.0
 description: Prometheus Monitoring for Kubernetes
 keywords:

--- a/config/monitoring/prometheus/templates/thanos-ui-deployment.yaml
+++ b/config/monitoring/prometheus/templates/thanos-ui-deployment.yaml
@@ -33,7 +33,7 @@ spec:
         - --objstore.config-file=/etc/thanos/objstore.yaml
         ports:
         - name: http
-          containerPort: 8080
+          containerPort: 10902
         volumeMounts:
         - name: thanos
           mountPath: /etc/thanos

--- a/config/monitoring/prometheus/templates/thanos-ui-service.yaml
+++ b/config/monitoring/prometheus/templates/thanos-ui-service.yaml
@@ -11,7 +11,7 @@ metadata:
 spec:
   ports:
   - name: http
-    port: 8080
+    port: 10902
     targetPort: http
   selector:
     app.kubernetes.io/name: thanos-ui

--- a/config/monitoring/prometheus/values.yaml
+++ b/config/monitoring/prometheus/values.yaml
@@ -121,7 +121,7 @@ prometheus:
     enabled: false
     image:
       repository: quay.io/thanos/thanos
-      tag: v0.8.1
+      tag: v0.10.1
 
     store:
       replicas: 2
@@ -245,7 +245,13 @@ prometheus:
           cpu: 300m
           memory: 1Gi
     thanosStore:
-      resources: {}
+      resources:
+        requests:
+          cpu: 250m
+          memory: 1536Mi
+        limits:
+          cpu: 1
+          memory: 3Gi
     thanosQuery:
       resources:
         requests:
@@ -258,10 +264,10 @@ prometheus:
       resources:
         requests:
           cpu: 500m
-          memory: 4Gi
+          memory: 2Gi
         limits:
           cpu: 2
-          memory: 8Gi
+          memory: 4Gi
     thanosUI:
       resources:
         requests:


### PR DESCRIPTION
**What this PR does / why we need it**:
Thanos 0.10 promises lower resource requirements and other nicities. The UI component now also beings to emitting metrics, so the bad scrape annotations from before now actually work.

**Does this PR introduce a user-facing change?**:
```release-note
Update Thanos to 0.10.1
```
