### PR TITLE
Fix OpenVPNServerDown alert when there are no user clusters

### DIFF
--- a/config/monitoring/prometheus/Chart.yaml
+++ b/config/monitoring/prometheus/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: prometheus
-version: 2.2.9
+version: 2.2.10
 appVersion: v2.14.0
 description: Prometheus Monitoring for Kubernetes
 keywords:

--- a/config/monitoring/prometheus/rules/kubermatic-seed-kubermatic.yaml
+++ b/config/monitoring/prometheus/rules/kubermatic-seed-kubermatic.yaml
@@ -42,8 +42,8 @@ groups:
     annotations:
       message: There is no healthy OpenVPN server in cluster {{ $labels.cluster }}.
       runbook_url: https://docs.kubermatic.io/monitoring/runbook/#alert-openvpnserverdown
-    expr: absent(kube_deployment_status_replicas_available{deployment="openvpn-server",cluster!=""}
-      > 0)
+    expr: absent(kube_deployment_status_replicas_available{cluster!="",deployment="openvpn-server"}
+      > 0) and count(kubermatic_cluster_info) > 0
     for: 15m
     labels:
       severity: critical

--- a/config/monitoring/prometheus/rules/src/kubermatic-seed/kubermatic.yaml
+++ b/config/monitoring/prometheus/rules/src/kubermatic-seed/kubermatic.yaml
@@ -60,7 +60,7 @@ groups:
     annotations:
       message: There is no healthy OpenVPN server in cluster {{ $labels.cluster }}.
       runbook_url: https://docs.kubermatic.io/monitoring/runbook/#alert-openvpnserverdown
-    expr: absent(kube_deployment_status_replicas_available{deployment="openvpn-server",cluster!=""} > 0)
+    expr: absent(kube_deployment_status_replicas_available{cluster!="",deployment="openvpn-server"} > 0) and count(kubermatic_cluster_info) > 0
     for: 15m
     labels:
       severity: critical


### PR DESCRIPTION
**What this PR does / why we need it**:
The alert was firing when there are no user clusters.

**Does this PR introduce a user-facing change?**:
```release-note
NONE
```
