### PR TITLE
Update cert-manager to v0.13.0

### DIFF
--- a/config/cert-manager/Chart.yaml
+++ b/config/cert-manager/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 name: cert-manager
-version: 1.1.6
-appVersion: v0.12.0
+version: 1.1.7
+appVersion: v0.13.0
 description: A Helm chart for cert-manager
 keywords:
 - kubermatic

--- a/config/cert-manager/values.yaml
+++ b/config/cert-manager/values.yaml
@@ -10,7 +10,7 @@ certManager:
     replicas: 1
     image:
       repository: quay.io/jetstack/cert-manager-controller
-      tag: v0.12.0
+      tag: v0.13.0
       pullPolicy: IfNotPresent
 
     resources:
@@ -40,7 +40,7 @@ certManager:
     replicas: 1
     image:
       repository: quay.io/jetstack/cert-manager-webhook
-      tag: v0.12.0
+      tag: v0.13.0
       pullPolicy: IfNotPresent
 
     resources:
@@ -70,7 +70,7 @@ certManager:
     replicas: 1
     image:
       repository: quay.io/jetstack/cert-manager-cainjector
-      tag: v0.12.0
+      tag: v0.13.0
       pullPolicy: IfNotPresent
 
     resources:


### PR DESCRIPTION
**What this PR does / why we need it**:
This minor upgrade from 0.12.0 to 0.13.0 contains bug-fixes.
No major changes between the two versions so it is a rather safe upgrade.

**Documentation**:
<!-- Add links to the related documentation changes related to this pull request. E.g. the link to the kubermatic/docs pullrequest. -->
Full release note: https://github.com/jetstack/cert-manager/releases/tag/v0.13.0

**Does this PR introduce a user-facing change?**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If  no release note is required, just write "NONE".
-->
```release-note 
Update cert-manager to 0.13.0
```
