### PR TITLE
update ELK stack to 6.8.5 and mark as deprecated

### DIFF
--- a/config/logging/elasticsearch/Chart.yaml
+++ b/config/logging/elasticsearch/Chart.yaml
@@ -1,8 +1,8 @@
 apiVersion: v1
 name: elasticsearch
-version: 1.0.5
-appVersion: 6.7.1
-description: Chart to deploy Elasticsearch master and data nodes.
+version: 1.0.6
+appVersion: 6.8.5
+description: "[DEPRECATED] Chart to deploy Elasticsearch master and data nodes."
 keywords:
 - kubermatic
 - logging

--- a/config/logging/elasticsearch/values.yaml
+++ b/config/logging/elasticsearch/values.yaml
@@ -2,7 +2,7 @@ logging:
   elasticsearch:
     image:
       repository: docker.elastic.co/elasticsearch/elasticsearch-oss
-      tag: "6.7.1"
+      tag: "6.8.5"
       pullPolicy: IfNotPresent
 
     cluster:

--- a/config/logging/kibana/Chart.yaml
+++ b/config/logging/kibana/Chart.yaml
@@ -1,8 +1,8 @@
 apiVersion: v1
 name: kibana
-version: 1.0.7
-appVersion: 6.7.1
-description: kibana
+version: 1.0.8
+appVersion: 6.8.5
+description: "[DEPRECATED] Kibana is a User Interface for Elasticsearch"
 keywords:
 - kubermatic
 - logging

--- a/config/logging/kibana/values.yaml
+++ b/config/logging/kibana/values.yaml
@@ -2,7 +2,7 @@ logging:
   kibana:
     image:
       repository: docker.elastic.co/kibana/kibana-oss
-      tag: "6.7.1"
+      tag: "6.8.5"
       pullPolicy: IfNotPresent
     resources:
       requests:


### PR DESCRIPTION
**What this PR does / why we need it**:
This updates the Elastic Stack to the latest 6.x version (going to 7.x requires a full cluster reboot and possibly other migration steps) and marks it as deprecated.

**Does this PR introduce a user-facing change?**:
```release-note
Update Elastic Stack to 6.8.5 and mark it as deprecated.
```
