### PR TITLE
replace employee email addresses in Dockerfiles

### DIFF
--- a/addons/Dockerfile
+++ b/addons/Dockerfile
@@ -1,5 +1,4 @@
-FROM alpine:3.9
-
-LABEL maintainer "henrik@loodse.com"
+FROM alpine:3.10
+LABEL maintainer="support@loodse.com"
 
 ADD ./ /addons/

--- a/api/Dockerfile
+++ b/api/Dockerfile
@@ -1,6 +1,5 @@
 FROM alpine:3.10
-
-LABEL maintainer="sebastian@loodse.com"
+LABEL maintainer="support@loodse.com"
 
 ADD https://storage.googleapis.com/kubernetes-release/release/v1.14.5/bin/linux/amd64/kubectl /usr/local/bin/kubectl
 # We need the ca-certs so they api doesn't crash because it can't verify the certificate of Dex

--- a/api/cmd/http-prober/Dockerfile
+++ b/api/cmd/http-prober/Dockerfile
@@ -1,4 +1,4 @@
 FROM alpine:3.10
-LABEL maintainer "dev@loodse.com"
+LABEL maintainer="support@loodse.com"
 
 COPY ./http-prober /usr/local/bin/

--- a/api/cmd/kubeletdnat-controller/Dockerfile
+++ b/api/cmd/kubeletdnat-controller/Dockerfile
@@ -1,4 +1,5 @@
 FROM alpine:3.10
+LABEL maintainer="support@loodse.com"
 
 RUN apk add -u iptables
 COPY ./_build/kubeletdnat-controller /usr/local/bin/kubeletdnat-controller

--- a/api/cmd/nodeport-proxy/Dockerfile
+++ b/api/cmd/nodeport-proxy/Dockerfile
@@ -1,4 +1,5 @@
 FROM alpine:latest
+LABEL maintainer="support@loodse.com"
 
 ADD ./_build/lb-updater /
 ADD ./_build/envoy-manager /

--- a/api/cmd/s3-exporter/Dockerfile
+++ b/api/cmd/s3-exporter/Dockerfile
@@ -1,4 +1,5 @@
 FROM alpine:3.10
+LABEL maintainer="support@loodse.com"
 
 RUN apk add --no-cache ca-certificates
 

--- a/api/cmd/s3-storeuploader/Dockerfile
+++ b/api/cmd/s3-storeuploader/Dockerfile
@@ -1,8 +1,6 @@
-FROM alpine:3.7
-
-LABEL maintainer "henrik@loodse.com"
+FROM alpine:3.10
+LABEL maintainer="support@loodse.com"
 
 RUN apk add --no-cache ca-certificates
 
 COPY ./s3-storeuploader /usr/local/bin/
-

--- a/api/cmd/user-ssh-keys-agent/Dockerfile
+++ b/api/cmd/user-ssh-keys-agent/Dockerfile
@@ -1,4 +1,5 @@
 FROM alpine:3.10
+LABEL maintainer="support@loodse.com"
 
 COPY ./user-ssh-keys-agent /usr/local/bin/user-ssh-keys-agent
 

--- a/containers/openvpn/Dockerfile
+++ b/containers/openvpn/Dockerfile
@@ -1,5 +1,5 @@
 FROM alpine:3.9
-LABEL maintainer="tobias.hintze@loodse.com"
+LABEL maintainer="support@loodse.com"
 
 RUN apk add -U \
 	bash \

--- a/openshift_addons/Dockerfile
+++ b/openshift_addons/Dockerfile
@@ -1,5 +1,4 @@
-FROM alpine:3.9
-
-LABEL maintainer "alvaro@loodse.com"
+FROM alpine:3.10
+LABEL maintainer="support@loodse.com"
 
 ADD ./ /addons/


### PR DESCRIPTION
**What this PR does / why we need it**:
Employees come and go, and just like with our Helm charts we should use a generic maintainer label for our Docker images.

**Does this PR introduce a user-facing change?**:
```release-note
NONE
```
