### PR TITLE
Update kube-state-metrics to v1.9.4

### DIFF
--- a/config/monitoring/kube-state-metrics/Chart.yaml
+++ b/config/monitoring/kube-state-metrics/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 name: kube-state-metrics
-version: 1.0.5
-appVersion: v1.8.0
+version: 1.0.6
+appVersion: v1.9.4
 description: Kube-State-Metrics for Kubermatic
 keywords:
 - kubermatic

--- a/config/monitoring/kube-state-metrics/templates/cluster-role.yaml
+++ b/config/monitoring/kube-state-metrics/templates/cluster-role.yaml
@@ -52,8 +52,18 @@ rules:
 - apiGroups: ["storage.k8s.io"]
   resources:
   - storageclasses
+  - volumeattachments
   verbs: ["list", "watch"]
 - apiGroups: ["autoscaling.k8s.io"]
   resources:
   - verticalpodautoscalers
+  verbs: ["list", "watch"]
+- apiGroups: ["networking.k8s.io"]
+  resources:
+  - networkpolicies
+  verbs: ["list", "watch"]
+- apiGroups: ["admissionregistration.k8s.io"]
+  resources:
+  - mutatingwebhookconfigurations
+  - validatingwebhookconfigurations
   verbs: ["list", "watch"]

--- a/config/monitoring/kube-state-metrics/values.yaml
+++ b/config/monitoring/kube-state-metrics/values.yaml
@@ -1,7 +1,7 @@
 kubeStateMetrics:
   image:
     repository: quay.io/coreos/kube-state-metrics
-    tag: v1.8.0
+    tag: v1.9.4
   resources:
     requests:
       cpu: 50m


### PR DESCRIPTION
**What this PR does / why we need it**:
Minor update to kube-state-metrics. Bug fixes, tweaks, and enhancements.
Also when upgrading to v1.9.x this required some changes to the cluster role file.

**Documentation**:
<!-- Add links to the related documentation changes related to this pull request. E.g. the link to the kubermatic/docs pullrequest. -->
Release note: https://github.com/kubernetes/kube-state-metrics/releases

**Does this PR introduce a user-facing change?**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If  no release note is required, just write "NONE".
-->
```release-note
Update kube-state-metrics to v1.9.4
```
