### PR TITLE
Operator chart

### DIFF
--- a/api/hack/ci/ci-sync-charts.sh
+++ b/api/hack/ci/ci-sync-charts.sh
@@ -157,22 +157,6 @@ EOF
 
 sed -s '$a\\n---' ${CHARTS_DIR}/kubermatic/crd/*.yaml >> ${CRDS_MANIFEST}
 
-OPERATOR_MANIFEST=${TARGET_DIR}/manifests/kubermatic-operator.yaml
-cat << EOF > ${OPERATOR_MANIFEST}
-# These manifests will install the Kubermatic Operator $PULL_BASE_REF into the 'kubermatic' namespace.
-# Please ensure to manually create a dockerconfigjson Secret in the same namespace,
-# named 'dockercfg' that contains the credentials for quay.io.
-# You also need to create the Kubermatic CRDs by applying the kubermatic-crds.yaml.
-
-EOF
-
-sed -s '$a\\n---' ${CHARTS_DIR}/kubermatic-operator/serviceaccount.yaml >> ${OPERATOR_MANIFEST}
-sed -s '$a\\n---' ${CHARTS_DIR}/kubermatic-operator/rbac.yaml >> ${OPERATOR_MANIFEST}
-cat ${CHARTS_DIR}/kubermatic-operator/deployment.yaml >> ${OPERATOR_MANIFEST}
-
-sed -i "s/__NAMESPACE__/kubermatic/g" ${OPERATOR_MANIFEST}
-sed -i "s/__WORKER_NAME__//g" ${OPERATOR_MANIFEST}
-
 # commit and push
 cd ${TARGET_DIR}
 git add .

--- a/api/hack/deploy.sh
+++ b/api/hack/deploy.sh
@@ -102,8 +102,6 @@ LATEST_DASHBOARD="$(get_latest_dashboard_hash "${PULL_BASE_REF}")"
 sed -i "s/__DASHBOARD_TAG__/$LATEST_DASHBOARD/g" ./config/kubermatic/*.yaml
 sed -i "s/__KUBERMATIC_TAG__/${GIT_HEAD_HASH}/g" ./config/kubermatic/*.yaml
 sed -i "s/__KUBERMATIC_TAG__/${GIT_HEAD_HASH}/g" ./config/kubermatic-operator/*.yaml
-sed -i "s/__NAMESPACE__/kubermatic/g" ./config/kubermatic-operator/*.yaml
-sed -i "s/__WORKER_NAME__//g" ./config/kubermatic-operator/*.yaml
 sed -i "s/__KUBERMATIC_TAG__/${GIT_HEAD_HASH}/g" ./config/nodeport-proxy/*.yaml
 
 echodate "Deploying ${DEPLOY_STACK} stack..."
@@ -175,19 +173,12 @@ case "${DEPLOY_STACK}" in
       if [[ "${1}" = "master" ]]; then
         echodate "Deploying Kubermatic Operator..."
 
-        DOCKER_CONFIG_SECRET="$(mktemp)"
-        cat <<EOF >$DOCKER_CONFIG_SECRET
-apiVersion: v1
-kind: Secret
-metadata:
-  name: dockercfg
-  namespace: kubermatic
-type: kubernetes.io/dockerconfigjson
-data:
-  .dockerconfigjson: "$(cat "$DOCKER_CONFIG" | base64 -w0)"
-EOF
-        retry 3 kubectl apply -f $DOCKER_CONFIG_SECRET
-        retry 3 kubectl apply -f ./config/kubermatic-operator/
+        retry 3 helm upgrade --install --force --wait --timeout 300 \
+          --set-string "kubermaticOperator.imagePullSecret=$DOCKER_CONFIG" \
+          --namespace kubermatic \
+          --values ${VALUES_FILE} \
+          kubermatic-operator \
+          ./config/kubermatic-operator/
 
         # only deploy KubermaticConfigurations on masters, on seed clusters
         # the relevant Seed CR is copied by Kubermatic itself

--- a/config/kubermatic-operator/Chart.yaml
+++ b/config/kubermatic-operator/Chart.yaml
@@ -1,0 +1,13 @@
+apiVersion: v1
+name: kubermatic-operator
+version: 0.1.0
+appVersion: '__KUBERMATIC_TAG__'
+description: Helm chart to install the Kubermatic Operator
+keywords:
+- kubermatic
+home: https://www.kubermatic.io/
+sources:
+- https://github.com/kubermatic/kubermatic
+maintainers:
+- name: Loodse GmbH
+  email: support@loodse.com

--- a/config/kubermatic-operator/templates/deployment.yaml
+++ b/config/kubermatic-operator/templates/deployment.yaml
@@ -4,7 +4,7 @@ metadata:
   name: kubermatic-operator
   labels:
     app.kubernetes.io/name: kubermatic-operator
-    app.kubernetes.io/version: '{{ .Chart.AppVersion }}'
+    app.kubernetes.io/version: '{{ .Values.kubermaticOperator.image.tag | default .Chart.AppVersion }}'
 spec:
   replicas: 1
   selector:

--- a/config/kubermatic-operator/templates/deployment.yaml
+++ b/config/kubermatic-operator/templates/deployment.yaml
@@ -2,10 +2,9 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: kubermatic-operator
-  namespace: '__NAMESPACE__'
   labels:
     app.kubernetes.io/name: kubermatic-operator
-    app.kubernetes.io/version: '__KUBERMATIC_TAG__'
+    app.kubernetes.io/version: '{{ .Chart.AppVersion }}'
 spec:
   replicas: 1
   selector:
@@ -25,17 +24,21 @@ spec:
       - name: dockercfg
       containers:
       - name: operator
-        image: 'quay.io/kubermatic/api:__KUBERMATIC_TAG__'
+        image: '{{ .Values.kubermaticOperator.image.repository }}:{{ .Values.kubermaticOperator.image.tag | default .Chart.AppVersion }}'
         imagePullPolicy: IfNotPresent
         command:
         - kubermatic-operator
         args:
         - -internal-address=0.0.0.0:8085
         - -namespace=$(POD_NAMESPACE)
-        - -worker-name=__WORKER_NAME__
+        {{- with .Values.kubermaticOperator.workerName }}
+        - -worker-name={{ . }}
+        {{- end }}
         - -log-format=json
+        {{- if .Values.kubermaticOperator.debug }}
         - -log-debug=true
         - -v=8
+        {{- end }}
         env:
         - name: POD_NAMESPACE
           valueFrom:
@@ -46,9 +49,4 @@ spec:
           containerPort: 8085
           protocol: TCP
         resources:
-          requests:
-            cpu: 200m
-            memory: 256Mi
-          limits:
-            cpu: 500m
-            memory: 512Mi
+{{ .Values.kubermaticOperator.resources | toYaml | indent 10 }}

--- a/config/kubermatic-operator/templates/dockercfg.yaml
+++ b/config/kubermatic-operator/templates/dockercfg.yaml
@@ -1,0 +1,9 @@
+apiVersion: v1
+kind: Secret
+metadata:
+  name: dockercfg
+  labels:
+    app.kubernetes.io/name: kubermatic-operator
+type: kubernetes.io/dockerconfigjson
+data:
+  .dockerconfigjson: {{ .Values.kubermaticOperator.imagePullSecret | b64enc | quote }}

--- a/config/kubermatic-operator/templates/rbac.yaml
+++ b/config/kubermatic-operator/templates/rbac.yaml
@@ -1,7 +1,7 @@
 kind: ClusterRoleBinding
 apiVersion: rbac.authorization.k8s.io/v1beta1
 metadata:
-  name: kubermatic-operator
+  name: kubermatic-operator-{{ .Release.Namespace }}
   labels:
     app.kubernetes.io/name: kubermatic-operator
 roleRef:
@@ -11,4 +11,4 @@ roleRef:
 subjects:
 - kind: ServiceAccount
   name: kubermatic-operator
-  namespace: '__NAMESPACE__'
+  namespace: '{{ .Release.Namespace }}'

--- a/config/kubermatic-operator/templates/serviceaccount.yaml
+++ b/config/kubermatic-operator/templates/serviceaccount.yaml
@@ -2,6 +2,5 @@ apiVersion: v1
 kind: ServiceAccount
 metadata:
   name: kubermatic-operator
-  namespace: '__NAMESPACE__'
   labels:
     app.kubernetes.io/name: kubermatic-operator

--- a/config/kubermatic-operator/values.yaml
+++ b/config/kubermatic-operator/values.yaml
@@ -1,0 +1,18 @@
+kubermaticOperator:
+  image:
+    repository: "quay.io/kubermatic/api"
+    tag: "__KUBERMATIC_TAG__"
+
+  imagePullSecret: |
+    {
+      "quay.io": {}
+    }
+
+  debug: false
+  resources:
+    requests:
+      cpu: 50m
+      memory: 128Mi
+    limits:
+      cpu: 500m
+      memory: 512Mi


### PR DESCRIPTION
**What this PR does / why we need it**:
Even though the operator takes care of setting up Kubermatic, we currently have a bunch of other dependencies for which we still use Helm. So the install procedure for customers would currently be

* install something with Helm
* install something with Helm
* install something with Helm
* do something completely different for the Kubermatic Operator

Which feels akward. This PR turns the static manifests for the operator into a very, very basic Helm chart.

**Which issue(s) this PR fixes**:
Relates to #4723 

**Does this PR introduce a user-facing change?**:
```release-note
NONE
```
