### PR TITLE
WIP - Helm 3

### DIFF
--- a/.prow.yaml
+++ b/.prow.yaml
@@ -68,7 +68,7 @@ presubmits:
     clone_uri: "ssh://git@github.com/kubermatic/kubermatic.git"
     spec:
       containers:
-      - image: quay.io/kubermatic/util:1.3.0
+      - image: quay.io/kubermatic/util:1.3.3
         command:
         - "./api/hack/verify-chart-versions.sh"
         resources:
@@ -85,7 +85,7 @@ presubmits:
     clone_uri: "ssh://git@github.com/kubermatic/kubermatic.git"
     spec:
       containers:
-      - image: quay.io/kubermatic/go-docker:12.12-1806-3
+      - image: quay.io/kubermatic/go-docker:12.12-1806-4
         command:
         - "./api/hack/verify-kubermatic-chart.sh"
         resources:
@@ -102,7 +102,7 @@ presubmits:
     clone_uri: "ssh://git@github.com/kubermatic/kubermatic.git"
     spec:
       containers:
-      - image: quay.io/kubermatic/util:1.3.0
+      - image: quay.io/kubermatic/util:1.3.3
         command:
         - "./api/hack/verify-grafana-dashboards.sh"
         resources:
@@ -119,7 +119,7 @@ presubmits:
     clone_uri: "ssh://git@github.com/kubermatic/kubermatic.git"
     spec:
       containers:
-      - image: quay.io/kubermatic/go-docker:12.12-1806-3
+      - image: quay.io/kubermatic/go-docker:12.12-1806-4
         command:
         - "./api/hack/verify-yaml-examples.sh"
         resources:
@@ -245,7 +245,7 @@ presubmits:
       preset-kind-volume-mounts: "true"
     spec:
       containers:
-      - image: quay.io/kubermatic/e2e-kind:with-conformance-tests-v1.0.14
+      - image: quay.io/kubermatic/e2e-kind:with-conformance-tests-v1.0.15
         env:
         - name: VERSIONS_TO_TEST
           value: "v1.14.9"
@@ -280,7 +280,7 @@ presubmits:
       preset-kind-volume-mounts: "true"
     spec:
       containers:
-      - image: quay.io/kubermatic/e2e-kind:with-conformance-tests-v1.0.14
+      - image: quay.io/kubermatic/e2e-kind:with-conformance-tests-v1.0.15
         env:
         - name: VERSIONS_TO_TEST
           value: "v1.14.8"
@@ -323,7 +323,7 @@ presubmits:
       preset-kind-volume-mounts: "true"
     spec:
       containers:
-      - image: quay.io/kubermatic/e2e-kind:with-conformance-tests-v1.0.14
+      - image: quay.io/kubermatic/e2e-kind:with-conformance-tests-v1.0.15
         env:
         - name: VERSIONS_TO_TEST
           value: "v1.15.6"
@@ -359,7 +359,7 @@ presubmits:
       preset-kind-volume-mounts: "true"
     spec:
       containers:
-      - image: quay.io/kubermatic/e2e-kind:with-conformance-tests-v1.0.14
+      - image: quay.io/kubermatic/e2e-kind:with-conformance-tests-v1.0.15
         env:
         - name: VERSIONS_TO_TEST
           value: "v1.15.5"
@@ -396,7 +396,7 @@ presubmits:
       preset-kind-volume-mounts: "true"
     spec:
       containers:
-      - image: quay.io/kubermatic/e2e-kind:with-conformance-tests-v1.0.14
+      - image: quay.io/kubermatic/e2e-kind:with-conformance-tests-v1.0.15
         env:
         - name: VERSIONS_TO_TEST
           value: "v1.15.5"
@@ -437,7 +437,7 @@ presubmits:
       preset-kind-volume-mounts: "true"
     spec:
       containers:
-      - image: quay.io/kubermatic/e2e-kind:with-conformance-tests-v1.0.14
+      - image: quay.io/kubermatic/e2e-kind:with-conformance-tests-v1.0.15
         env:
         - name: VERSIONS_TO_TEST
           value: "v1.15.5"
@@ -477,7 +477,7 @@ presubmits:
       preset-kind-volume-mounts: "true"
     spec:
       containers:
-      - image: quay.io/kubermatic/e2e-kind:with-conformance-tests-v1.0.14
+      - image: quay.io/kubermatic/e2e-kind:with-conformance-tests-v1.0.15
         env:
         - name: VERSIONS_TO_TEST
           value: "v1.15.5"
@@ -516,7 +516,7 @@ presubmits:
       preset-kind-volume-mounts: "true"
     spec:
       containers:
-      - image: quay.io/kubermatic/e2e-kind:with-conformance-tests-v1.0.14
+      - image: quay.io/kubermatic/e2e-kind:with-conformance-tests-v1.0.15
         env:
         - name: VERSIONS_TO_TEST
           value: "v1.15.5"
@@ -553,7 +553,7 @@ presubmits:
       preset-kind-volume-mounts: "true"
     spec:
       containers:
-      - image: quay.io/kubermatic/e2e-kind:with-conformance-tests-v1.0.14
+      - image: quay.io/kubermatic/e2e-kind:with-conformance-tests-v1.0.15
         env:
         - name: VERSIONS_TO_TEST
           value: "v1.15.5"
@@ -592,7 +592,7 @@ presubmits:
       preset-kind-volume-mounts: "true"
     spec:
       containers:
-      - image: quay.io/kubermatic/e2e-kind:with-conformance-tests-v1.0.14
+      - image: quay.io/kubermatic/e2e-kind:with-conformance-tests-v1.0.15
         env:
         - name: VERSIONS_TO_TEST
           value: "v1.15.5"
@@ -634,7 +634,7 @@ presubmits:
       preset-kind-volume-mounts: "true"
     spec:
       containers:
-      - image: quay.io/kubermatic/e2e-kind:with-conformance-tests-v1.0.14
+      - image: quay.io/kubermatic/e2e-kind:with-conformance-tests-v1.0.15
         env:
         - name: VERSIONS_TO_TEST
           value: "v1.15.5"
@@ -673,7 +673,7 @@ presubmits:
       preset-kind-volume-mounts: "true"
     spec:
       containers:
-      - image: quay.io/kubermatic/e2e-kind:with-conformance-tests-v1.0.14
+      - image: quay.io/kubermatic/e2e-kind:with-conformance-tests-v1.0.15
         env:
         - name: VERSIONS_TO_TEST
           value: "v1.15.5"
@@ -711,7 +711,7 @@ presubmits:
       preset-kind-volume-mounts: "true"
     spec:
       containers:
-      - image: quay.io/kubermatic/e2e-kind:with-conformance-tests-v1.0.14
+      - image: quay.io/kubermatic/e2e-kind:with-conformance-tests-v1.0.15
         env:
         - name: VERSIONS_TO_TEST
           value: "v1.15.5"
@@ -755,7 +755,7 @@ presubmits:
       preset-kind-volume-mounts: "true"
     spec:
       containers:
-      - image: quay.io/kubermatic/e2e-kind:with-conformance-tests-v1.0.14
+      - image: quay.io/kubermatic/e2e-kind:with-conformance-tests-v1.0.15
         env:
         - name: VERSIONS_TO_TEST
           value: "v1.16.3"
@@ -790,7 +790,7 @@ presubmits:
       preset-kind-volume-mounts: "true"
     spec:
       containers:
-      - image: quay.io/kubermatic/e2e-kind:with-conformance-tests-v1.0.14
+      - image: quay.io/kubermatic/e2e-kind:with-conformance-tests-v1.0.15
         env:
         - name: VERSIONS_TO_TEST
           value: "v1.16.3"
@@ -831,7 +831,7 @@ presubmits:
       preset-kind-volume-mounts: "true"
     spec:
       containers:
-      - image: quay.io/kubermatic/e2e-kind:with-conformance-tests-v1.0.14
+      - image: quay.io/kubermatic/e2e-kind:with-conformance-tests-v1.0.15
         env:
         - name: VERSIONS_TO_TEST
           value: "v1.16.3"
@@ -872,7 +872,7 @@ presubmits:
       preset-kind-volume-mounts: "true"
     spec:
       containers:
-      - image: quay.io/kubermatic/e2e-kind:with-conformance-tests-v1.0.14
+      - image: quay.io/kubermatic/e2e-kind:with-conformance-tests-v1.0.15
         env:
         - name: VERSIONS_TO_TEST
           value: "v1.16.3"
@@ -915,7 +915,7 @@ presubmits:
       preset-kind-volume-mounts: "true"
     spec:
       containers:
-      - image: quay.io/kubermatic/e2e-kind:with-conformance-tests-v1.0.14
+      - image: quay.io/kubermatic/e2e-kind:with-conformance-tests-v1.0.15
         env:
         - name: VERSIONS_TO_TEST
           value: "v1.17.0"
@@ -956,7 +956,7 @@ presubmits:
       preset-kind-volume-mounts: "true"
     spec:
       containers:
-      - image: quay.io/kubermatic/e2e-kind:with-conformance-tests-v1.0.14
+      - image: quay.io/kubermatic/e2e-kind:with-conformance-tests-v1.0.15
         env:
         - name: OPENSHIFT
           value: "true"
@@ -998,7 +998,7 @@ presubmits:
       preset-kind-volume-mounts: "true"
     spec:
       containers:
-      - image: quay.io/kubermatic/e2e-kind:with-conformance-tests-v1.0.14
+      - image: quay.io/kubermatic/e2e-kind:with-conformance-tests-v1.0.15
         env:
         - name: VERSIONS_TO_TEST
           value: "v1.15.6"
@@ -1039,7 +1039,7 @@ presubmits:
       preset-vault: "true"
     spec:
       containers:
-      - image: quay.io/kubermatic/e2e-kind:with-conformance-tests-v1.0.14
+      - image: quay.io/kubermatic/e2e-kind:with-conformance-tests-v1.0.15
         imagePullPolicy: Always
         command:
         - "./api/hack/ci/ci_run_api_e2e.sh"
@@ -1076,7 +1076,7 @@ presubmits:
       preset-kind-volume-mounts: "true"
     spec:
       containers:
-      - image: quay.io/kubermatic/e2e-kind:with-conformance-tests-v1.0.14
+      - image: quay.io/kubermatic/e2e-kind:with-conformance-tests-v1.0.15
         env:
         - name: VERSIONS_TO_TEST
           value: "v1.17.0"
@@ -1115,7 +1115,7 @@ presubmits:
       preset-repo-ssh: "true"
     spec:
       containers:
-      - image: quay.io/kubermatic/go-docker:12.12-1806-3
+      - image: quay.io/kubermatic/go-docker:12.12-1806-4
         command:
         - "./api/hack/ci/ci-run-offline-test.sh"
         # docker-in-docker needs privileged mode
@@ -1147,7 +1147,7 @@ presubmits:
       preset-repo-ssh: "true"
     spec:
       containers:
-      - image: quay.io/kubermatic/go-docker:12.12-1806-3
+      - image: quay.io/kubermatic/go-docker:12.12-1806-4
         command:
         - ./api/hack/ci/ci-deploy-ci-kubermatic-io.sh
         env:

--- a/api/hack/ci/ci-setup-kubermatic-in-kind.sh
+++ b/api/hack/ci/ci-setup-kubermatic-in-kind.sh
@@ -180,8 +180,8 @@ iptables -t nat -A PREROUTING -i eth0 -p tcp -m multiport --dports=30000:33000 -
 # Docker sets up a MASQUERADE rule for postrouting, so nothing to do for us
 echodate "Successfully set up iptables rules for nodeports"
 
-echodate "Creating kubermatic-fast storageclass"
 TEST_NAME="Create kubermatic-fast storageclass"
+echodate "Creating kubermatic-fast storageclass"
 retry 5 kubectl get storageclasses.storage.k8s.io standard -o json \
   |jq 'del(.metadata)|.metadata.name = "kubermatic-fast"'\
   |kubectl apply -f -
@@ -227,7 +227,7 @@ echodate "Deploying Dex"
 
 export KUBERMATIC_DEX_VALUES_FILE=$(realpath api/hack/ci/testdata/oauth_values.yaml)
 
-if kubectl get namespace oauth; then
+if kubectl get namespace oauth >/dev/null 2>&1; then
   echodate "Dex already deployed"
 else
   retry 5 helm install --wait --timeout 180 \

--- a/api/pkg/controller/master-controller-manager/seed-proxy/resources.go
+++ b/api/pkg/controller/master-controller-manager/seed-proxy/resources.go
@@ -212,7 +212,7 @@ func masterDeploymentCreator(seed *kubermaticv1.Seed, secret *corev1.Secret) rec
 			d.Spec.Template.Spec.Containers = []corev1.Container{
 				{
 					Name:    "proxy",
-					Image:   "quay.io/kubermatic/util:1.3.2",
+					Image:   "quay.io/kubermatic/util:1.3.3",
 					Command: []string{"/bin/bash"},
 					Args:    []string{"-c", strings.TrimSpace(proxyScript)},
 					Env: []corev1.EnvVar{

--- a/config/README.md
+++ b/config/README.md
@@ -224,7 +224,7 @@ kubectl create -f installer/serviceaccount.yaml
 kubectl create -f installer/clusterrolebinding.yaml
 # values.yaml is the file you created during the step above
 kubectl -n kubermatic-installer create secret generic values --from-file=values.yaml
-#Create the docker secret - needs to have read access to kubermatic/installer 
+#Create the docker secret - needs to have read access to kubermatic/installer
 kubectl  -n kubermatic-installer create secret docker-registry dockercfg --docker-username='' --docker-password='' --docker-email=''
 kubectl  -n kubermatic-installer create secret docker-registry quay --docker-username='' --docker-password='' --docker-email=''
 # Create and run the installer job
@@ -236,7 +236,7 @@ kubectl create -f install-job.yaml
 
 ### Create DNS entry for your domain
 Go to https://www.ovh.ie/ and add a dns entry for the dashboard:
-- $DOMAIN  
+- $DOMAIN
 
 The external ip for the DNS entry can be fetched via
 ```bash
@@ -245,7 +245,7 @@ kubectl -n ingress-nginx describe service nginx-ingress-controller | grep "LoadB
 
 Go to https://www.ovh.ie/ and add a dns entry for the nodeport-exposer:
 $DATACENTER=us-central1
-- *.$DATACENTER.$DOMAIN  =  *.us-central1.dev.kubermatic.io  
+- *.$DATACENTER.$DOMAIN  =  *.us-central1.dev.kubermatic.io
 
 The external ip for the DNS entry can be fetched via
 ```bash
@@ -256,7 +256,7 @@ kubectl -n nodeport-exposer describe service nodeport-exposer | grep "LoadBalanc
 [2]: https://kubernetes.io/docs/tasks/access-application-cluster/configure-access-multiple-clusters/
 [3]: ../docs/datacenters.md
 [4]: installer/README.md
-[5]: https://github.com/kubernetes/helm
+[5]: https://github.com/helm/helm
 [6]: https://github.com/kubermatic/secrets
 [7]: https://github.com/kubermatic/kubermatic/blob/master/config/storage/templates/_helpers.tpl
 [8]: https://kubernetes.io/docs/concepts/storage/storage-classes/

--- a/config/kubermatic/Chart.yaml
+++ b/config/kubermatic/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: kubermatic
-version: 1.0.43
+version: 1.0.44
 appVersion: '__KUBERMATIC_TAG__'
 description: Kubermatic chart for master and/or seed clusters.
 keywords:

--- a/config/kubermatic/values.yaml
+++ b/config/kubermatic/values.yaml
@@ -57,7 +57,7 @@ kubermatic:
       helmVersion: "v2.11.0"
       image:
         repository: "quay.io/kubermatic/util"
-        tag: "1.3.2"
+        tag: "1.3.3"
 
   etcd:
     # PV size for the etcd StatefulSet of new clusters

--- a/config/logging/kibana/Chart.yaml
+++ b/config/logging/kibana/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: kibana
-version: 1.0.8
+version: 1.0.9
 appVersion: 6.8.5
 description: "[DEPRECATED] Kibana is a User Interface for Elasticsearch"
 keywords:

--- a/config/logging/kibana/values.yaml
+++ b/config/logging/kibana/values.yaml
@@ -16,7 +16,7 @@ logging:
     setupContainer:
       image:
         repository: quay.io/kubermatic/util
-        tag: 1.3.2
+        tag: 1.3.3
         pullPolicy: IfNotPresent
       resources:
         requests:

--- a/config/minio/Chart.yaml
+++ b/config/minio/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: minio
-version: 1.0.9
+version: 1.0.10
 appVersion: RELEASE.2019-10-12T01-39-57Z
 description: minio
 keywords:

--- a/config/minio/values.yaml
+++ b/config/minio/values.yaml
@@ -19,7 +19,7 @@ minio:
     enabled: true
     image:
       repository: quay.io/kubermatic/util
-      tag: 1.3.2
+      tag: 1.3.3
 
   # If your cluster does not have a default storage class,
   # you can specify the class to use for Minio. Note that

--- a/config/monitoring/alertmanager/Chart.yaml
+++ b/config/monitoring/alertmanager/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: alertmanager
-version: 2.0.7
+version: 2.0.8
 appVersion: v0.20.0
 description: Alertmanager for Kubermatic
 keywords:

--- a/config/monitoring/alertmanager/values.yaml
+++ b/config/monitoring/alertmanager/values.yaml
@@ -90,4 +90,4 @@ alertmanager:
     enabled: false
     image:
       repository: quay.io/kubermatic/util
-      tag: 1.3.2
+      tag: 1.3.3

--- a/config/monitoring/grafana/Chart.yaml
+++ b/config/monitoring/grafana/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: grafana
-version: 1.2.10
+version: 1.2.11
 appVersion: 6.5.2
 description: Grafana for Kubermatic
 keywords:

--- a/config/monitoring/grafana/values.yaml
+++ b/config/monitoring/grafana/values.yaml
@@ -8,7 +8,7 @@ grafana:
     tag: 6.5.2
   utilImage:
     repository: quay.io/kubermatic/util
-    tag: 1.3.2
+    tag: 1.3.3
   pluginImage:
     repository: quay.io/kubermatic/grafana-plugins
     tag: 1.0.0
@@ -61,7 +61,7 @@ grafana:
 
       lokiServices: []
       # - loki
-      
+
       # read datasources from this path in the Helm chart; this is
       # evaluated during deployment, not during Grafana runtime!
       source: provisioning/datasources/*

--- a/config/monitoring/karma/Chart.yaml
+++ b/config/monitoring/karma/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: karma
-version: 0.0.6
+version: 0.0.7
 appVersion: v0.55
 description: Dashboard for Prometheus Alertmanager
 keywords:

--- a/config/monitoring/karma/values.yaml
+++ b/config/monitoring/karma/values.yaml
@@ -27,7 +27,7 @@ karma:
       pullPolicy: IfNotPresent
     initContainer:
       repository: quay.io/kubermatic/util
-      tag: 1.3.2
+      tag: 1.3.3
       pullPolicy: IfNotPresent
   resources:
     karma:

--- a/config/monitoring/prometheus/Chart.yaml
+++ b/config/monitoring/prometheus/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: prometheus
-version: 2.2.11
+version: 2.2.12
 appVersion: v2.14.0
 description: Prometheus Monitoring for Kubernetes
 keywords:

--- a/config/monitoring/prometheus/rules/src/general/helm-exporter.yaml
+++ b/config/monitoring/prometheus/rules/src/general/helm-exporter.yaml
@@ -13,7 +13,7 @@ groups:
       severity: warning
     runbook:
       steps:
-      - Check the installed Helm releases via `helm --tiller-namespace kubermtic-installer ls`.
+      - Check the installed Helm releases via `helm --all-namespaces ls` (Helm 3) or `helm --tiller-namespace kubermatic-installer ls` (Helm 2).
       - If all releases are status `DEPLOYED`, make sure the helme-exporter is looking at the correct Tiller by checking
         the `values.yaml` flag `helmExporter.tillerNamespace`.
       - If Helm cannot repair the chart automatically, delete/purge the chart (`helm delete --purge [RELEASE]`) and

--- a/config/monitoring/prometheus/values.yaml
+++ b/config/monitoring/prometheus/values.yaml
@@ -31,7 +31,7 @@ prometheus:
     enabled: true
     image:
       repository: quay.io/kubermatic/util
-      tag: 1.3.2
+      tag: 1.3.3
     timeout: 60m
 
   # Specify additional external labels which will be added to all
@@ -201,7 +201,7 @@ prometheus:
     enabled: false
     image:
       repository: quay.io/kubermatic/util
-      tag: 1.3.2
+      tag: 1.3.3
 
   containers:
     prometheus:

--- a/containers/util/Dockerfile
+++ b/containers/util/Dockerfile
@@ -2,7 +2,8 @@ FROM alpine:3.10
 
 ENV MC_VERSION=RELEASE.2019-09-20T00-09-55Z \
     KUBECTL_VERSION=v1.16.2 \
-    HELM_VERSION=v2.16.1 \
+    HELM2_VERSION=v2.16.1 \
+    HELM3_VERSION=v3.1.0 \
     VAULT_VERSION=1.2.3 \
     YQ_VERSION=2.4.0
 
@@ -33,10 +34,16 @@ RUN curl -Lo /usr/bin/kubectl https://storage.googleapis.com/kubernetes-release/
     chmod +x /usr/bin/kubectl && \
     kubectl version --short --client
 
-RUN curl -L https://storage.googleapis.com/kubernetes-helm/helm-${HELM_VERSION}-linux-amd64.tar.gz | tar -xvz && \
-    mv linux-amd64/helm /usr/bin/helm && \
+RUN curl -L https://get.helm.sh/helm-${HELM2_VERSION}-linux-amd64.tar.gz | tar -xvz && \
+    mv linux-amd64/helm /usr/bin/helm2 && \
+    ln -s /usr/bin/helm2 /usr/bin/helm && \
     rm -rf linux-amd64 && \
-    helm version --client --short
+    helm2 version --short --client
+
+RUN curl -L https://get.helm.sh/helm-${HELM3_VERSION}-linux-amd64.tar.gz | tar -xvz && \
+    mv linux-amd64/helm /usr/bin/helm3 && \
+    rm -rf linux-amd64 && \
+    helm3 version --short
 
 RUN curl -Lo vault.zip https://releases.hashicorp.com/vault/${VAULT_VERSION}/vault_${VAULT_VERSION}_linux_amd64.zip && \
     unzip vault.zip && \

--- a/containers/util/release.sh
+++ b/containers/util/release.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 
 SUFFIX=""
-VERSION=1.3.2
+VERSION=1.3.3
 
 set -euox pipefail
 


### PR DESCRIPTION
**What this PR does / why we need it**:
This prepares all Docker images to contain Helm 3 in addition to Helm 2. It also configures the Prow jobs to use these new images and gives the deploy.sh the ability to use Helm 3.

This should prepare us for next steps in the Helm3 migration.

Requires kubermatic/infra#909.

**Does this PR introduce a user-facing change?**:
```release-note
NONE
```
