### PR TITLE
Allow remote host connections to websocket

### DIFF
--- a/api/pkg/handler/routes_v1_websocket.go
+++ b/api/pkg/handler/routes_v1_websocket.go
@@ -19,6 +19,9 @@ import (
 var upgrader = websocket.Upgrader{
 	ReadBufferSize:  1024,
 	WriteBufferSize: 1024,
+	CheckOrigin: func(r *http.Request) bool {
+		return true
+	},
 }
 
 type WebsocketWriter func(providers watcher.Providers, ws *websocket.Conn)


### PR DESCRIPTION
**What this PR does / why we need it**: At the moment connections from different origin are automatically blocked by the websocket. This will change the default behaviour. More info: https://godoc.org/github.com/gorilla/websocket#hdr-Origin_Considerations

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:

**Special notes for your reviewer**:

**Documentation**:
<!-- Add links to the related documentation changes related to this pull request. E.g. the link to the kubermatic/docs pullrequest. -->

**Does this PR introduce a user-facing change?**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If  no release note is required, just write "NONE".
-->
```release-note
NONE
```
