### PR TITLE
Fix bad dockercfg Secret

### DIFF
--- a/api/hack/deploy.sh
+++ b/api/hack/deploy.sh
@@ -174,7 +174,7 @@ case "${DEPLOY_STACK}" in
         echodate "Deploying Kubermatic Operator..."
 
         retry 3 helm upgrade --install --force --wait --timeout 300 \
-          --set-string "kubermaticOperator.imagePullSecret=$DOCKER_CONFIG" \
+          --set-file "kubermaticOperator.imagePullSecret=$DOCKER_CONFIG" \
           --namespace kubermatic \
           --values ${VALUES_FILE} \
           kubermatic-operator \


### PR DESCRIPTION
**What this PR does / why we need it**:
This fixes the broken operator deployment.

**Does this PR introduce a user-facing change?**:
```release-note
NONE
```
