### PR TITLE
Rollback Karma to v0.52

### DIFF
--- a/config/monitoring/karma/Chart.yaml
+++ b/config/monitoring/karma/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 name: karma
-version: 0.0.6
-appVersion: v0.55
+version: 0.0.5
+appVersion: v0.52
 description: Dashboard for Prometheus Alertmanager
 keywords:
 - kubermatic

--- a/config/monitoring/karma/values.yaml
+++ b/config/monitoring/karma/values.yaml
@@ -23,7 +23,7 @@ karma:
   images:
     karma:
       repository: docker.io/lmierzwa/karma
-      tag: v0.55
+      tag: v0.52
       pullPolicy: IfNotPresent
     initContainer:
       repository: quay.io/kubermatic/util


### PR DESCRIPTION
**What this PR does / why we need it**:
Rollback previous upgrade for Karma v0.55 to Karma v0.52.
At this point it seems the issue isn't coming from the upgrade as it appeared couple of hours later. Moreover a downgrade didn't solve the issue of having a crashloopbackoff pod.
I will proceed with further testing then re-write a PR for the upgrade to latest Karma version

`time="2020-02-16T20:56:47Z" level=info msg="Reading configuration file /etc/karma/karma.yaml"
{"level":"fatal","msg":"No valid Alertmanager URIs defined","time":"2020-02-16T20:56:47Z"}`

**Does this PR introduce a user-facing change?**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If  no release note is required, just write "NONE".
-->
```release-note
NONE
```
