### PR TITLE
Disable controller-runtime default metrics server

### DIFF
--- a/api/cmd/master-controller-manager/main.go
+++ b/api/cmd/master-controller-manager/main.go
@@ -166,7 +166,8 @@ func main() {
 	}
 
 	mgr, err := manager.New(cfg, manager.Options{
-		MetricsBindAddress: "",
+		// disable default metrics server. We start ours later.
+		MetricsBindAddress: "0",
 		// inject the handcrafted cache into the manager
 		NewCache: func(config *rest.Config, opts ctrlruntimecache.Options) (ctrlruntimecache.Cache, error) {
 			return &unstartableCache{cache}, nil


### PR DESCRIPTION
**What this PR does / why we need it**:
Contorller-runtime starts it's own metrics server by default. The default port for this server is `8080` which conflicts with the API port if both ran in the same network space. This should be only the case on a developer box. Since we start our "own" metrics server anyway, with a specific bind address, we should disable this one.
**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Documentation**:
<!-- Add links to the related documentation changes related to this pull request. E.g. the link to the kubermatic/docs pullrequest. -->

**Does this PR introduce a user-facing change?**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If  no release note is required, just write "NONE".
-->
```release-note
NONE
```
