### PR TITLE
Enable MultiAZ support for Openstack with a feature flag

### DIFF
--- a/api/cmd/kubermatic-api/swagger.json
+++ b/api/cmd/kubermatic-api/swagger.json
@@ -9803,6 +9803,11 @@
         "image"
       ],
       "properties": {
+        "availabilityZone": {
+          "description": "if not set, the default AZ from the Datacenter spec will be used",
+          "type": "string",
+          "x-go-name": "AvailabilityZone"
+        },
         "diskSize": {
           "description": "if set, the rootDisk will be a volume. If not, the rootDisk will be on ephemeral storage and its size will be derived from the flavor",
           "type": "integer",

--- a/api/pkg/api/v1/types.go
+++ b/api/pkg/api/v1/types.go
@@ -1042,6 +1042,9 @@ type OpenstackNodeSpec struct {
 	// if set, the rootDisk will be a volume. If not, the rootDisk will be on ephemeral storage and its size will be derived from the flavor
 	// required: false
 	RootDiskSizeGB *int `json:"diskSize"`
+	// if not set, the default AZ from the Datacenter spec will be used
+	// required: false
+	AvailabilityZone string `json:"availabilityZone"`
 }
 
 // AWSNodeSpec aws specific node settings

--- a/api/pkg/crd/kubermatic/v1/cluster.go
+++ b/api/pkg/crd/kubermatic/v1/cluster.go
@@ -117,6 +117,9 @@ const (
 	// ClusterFeatureRancherIntegration enables the rancher server integration feature.
 	// It will deploy a Rancher Server Managegment plane on the seed cluster and import the user cluster into it.
 	ClusterFeatureRancherIntegration = "rancherIntegration"
+
+	// ClusterFeatureOpenstackMultiAZ enables OpenStack multiple availability zones zupport
+	ClusterFeatureOpenstackMultiAZ = "openstackMultiAZ"
 )
 
 // ClusterConditionType is used to indicate the type of a cluster condition. For all condition

--- a/api/pkg/crd/kubermatic/v1/cluster.go
+++ b/api/pkg/crd/kubermatic/v1/cluster.go
@@ -118,7 +118,7 @@ const (
 	// It will deploy a Rancher Server Managegment plane on the seed cluster and import the user cluster into it.
 	ClusterFeatureRancherIntegration = "rancherIntegration"
 
-	// ClusterFeatureOpenstackMultiAZ enables OpenStack multiple availability zones zupport
+	// ClusterFeatureOpenstackMultiAZ enables OpenStack multiple availability zones support
 	ClusterFeatureOpenstackMultiAZ = "openstackMultiAZ"
 )
 

--- a/api/pkg/resources/machine/common.go
+++ b/api/pkg/resources/machine/common.go
@@ -180,6 +180,13 @@ func getOpenstackProviderSpec(c *kubermaticv1.Cluster, nodeSpec apiv1.NodeSpec, 
 		config.TrustDevicePath = providerconfig.ConfigVarBool{Value: *dc.Spec.Openstack.TrustDevicePath}
 	}
 
+	if multiAZ := c.Spec.Features[kubermaticv1.ClusterFeatureOpenstackMultiAZ]; multiAZ {
+		// Use the nodeDeployment spec AvailabilityZone if set, otherwise we stick to the default from the datacenter
+		if nodeSpec.Cloud.Openstack.AvailabilityZone != "" {
+			config.AvailabilityZone = providerconfig.ConfigVarString{Value: nodeSpec.Cloud.Openstack.AvailabilityZone}
+		}
+	}
+
 	config.Tags = map[string]string{}
 	for key, value := range nodeSpec.Cloud.Openstack.Tags {
 		config.Tags[key] = value

--- a/api/pkg/test/e2e/api/utils/apiclient/models/openstack_node_spec.go
+++ b/api/pkg/test/e2e/api/utils/apiclient/models/openstack_node_spec.go
@@ -16,6 +16,9 @@ import (
 // swagger:model OpenstackNodeSpec
 type OpenstackNodeSpec struct {
 
+	// if not set, the default AZ from the Datacenter spec will be used
+	AvailabilityZone string `json:"availabilityZone,omitempty"`
+
 	// instance flavor
 	// Required: true
 	Flavor *string `json:"flavor"`


### PR DESCRIPTION
**What this PR does / why we need it**:

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #4909

**Special notes for your reviewer**:
This was _not_ functionally tested because we don't currently have access to a multiAZ openstack environment. A feature flag was added to enable this later.
**Documentation**:
<!-- Add links to the related documentation changes related to this pull request. E.g. the link to the kubermatic/docs pullrequest. -->

**Does this PR introduce a user-facing change?**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If  no release note is required, just write "NONE".
-->
```release-note
NONE
```
