### PR TITLE
Make nodeport-proxy compatible with the operator

### DIFF
--- a/config/nodeport-proxy/Chart.yaml
+++ b/config/nodeport-proxy/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: nodeport-proxy
-version: 1.5.1
+version: 1.5.2
 appVersion: __KUBERMATIC_TAG__
 description: Kubermatic nodeport-proxy
 keywords:

--- a/config/nodeport-proxy/templates/quay-secret.yaml
+++ b/config/nodeport-proxy/templates/quay-secret.yaml
@@ -2,6 +2,15 @@ apiVersion: v1
 kind: Secret
 metadata:
   name: quay
-data:
-  .dockerconfigjson: {{ with .Values.kubermatic }}{{ .imagePullSecretData | default "" | quote }}{{ else }}""{{ end }}
 type: kubernetes.io/dockerconfigjson
+data:
+{{- /* The pull secret inside the operator chart is not pre-base64-encoded. */ -}}
+{{- with .Values.kubermaticOperator }}
+  .dockerconfigjson: {{ .imagePullSecret | b64enc | quote }}
+{{- else }}
+{{- with .Values.kubermatic }}
+  .dockerconfigjson: {{ .imagePullSecretData | default "" | quote }}
+{{- else }}
+  .dockerconfigjson: ""
+{{- end }}
+{{- end }}


### PR DESCRIPTION
**What this PR does / why we need it**:
When using the kubermatic operator, users are no longer using the old `kubermatic` Helm chart. This means that the nodeport-proxy would not be able to find the Image Pull Secret.

This PR makes it so that the operator Helm chart is properly recognized.

**Does this PR introduce a user-facing change?**:
```release-note
NONE
```
