### PR TITLE
seed kube-state-metrics: K8s 1.16 compatibility

### DIFF
--- a/config/monitoring/kube-state-metrics/templates/role.yaml
+++ b/config/monitoring/kube-state-metrics/templates/role.yaml
@@ -7,7 +7,7 @@ rules:
   resources:
   - pods
   verbs: ["get"]
-- apiGroups: ["extensions"]
+- apiGroups: ["apps","extensions"]
   resources:
   - deployments
   resourceNames: ["kube-state-metrics"]

--- a/config/monitoring/kube-state-metrics/values.yaml
+++ b/config/monitoring/kube-state-metrics/values.yaml
@@ -13,7 +13,7 @@ kubeStateMetrics:
   resizer:
     image:
       repository: gcr.io/google_containers/addon-resizer
-      tag: '1.8.4' # is still the recommended version
+      tag: '1.8.8' # needed for K8s >= 1.16 because of https://github.com/kubernetes/autoscaler/issues/2803
     resources:
       requests:
         cpu: 50m


### PR DESCRIPTION
Signed-off-by: Olaf Klischat <o.klischat@syseleven.de>

**What this PR does / why we need it**:

We use K8s 1.17 in the seed clusters, and I needed this one to make the seed kube-state-metrics including the resizer sidecar work.

```release-note
Seed kube-state-metrics support for K8s 1.16 and higher
```