### PR TITLE
Update Helm-exporter to v0.4.3

### DIFF
--- a/config/monitoring/helm-exporter/Chart.yaml
+++ b/config/monitoring/helm-exporter/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 name: helm-exporter
-version: 1.0.2
-appVersion: 0.4.2
+version: 1.0.3
+appVersion: 0.4.3
 description: Exports Helm release information to Prometheus
 keywords:
 - kubermatic

--- a/config/monitoring/helm-exporter/values.yaml
+++ b/config/monitoring/helm-exporter/values.yaml
@@ -3,7 +3,7 @@ helmExporter:
   tillerNamespace: kubermatic-installer
   image:
     repository: docker.io/sstarcher/helm-exporter
-    tag: 0.4.2
+    tag: 0.4.3
     pullPolicy: IfNotPresent
   nameOverride: ''
 


### PR DESCRIPTION
**What this PR does / why we need it**:
Updating helm-exporter to 0.4.3. 
Minor upgrade with bug fixes.

**Special notes for your reviewer**:
For the moment I'm skipping 0.5.0. It isn't clear if it uses exclusively Helm v3 or if it supports both v2 and v3. Metrics from the pod are gathered but not from the tiller namespaces (it uses a new flag). 
I might open an issue directly with "helm-exporter".

**Documentation**:
<!-- Add links to the related documentation changes related to this pull request. E.g. the link to the kubermatic/docs pullrequest. -->
Release note: https://github.com/sstarcher/helm-exporter/releases

**Does this PR introduce a user-facing change?**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If  no release note is required, just write "NONE".
-->
```release-note
Update helm-exporter to v0.4.3
```
