### PR TITLE
Create/update credentials on update and migrations

### DIFF
--- a/api/cmd/seed-controller-manager/main.go
+++ b/api/cmd/seed-controller-manager/main.go
@@ -238,7 +238,7 @@ Please install the VerticalPodAutoscaler according to the documentation: https:/
 
 			return leaderelection.RunAsLeader(leaderCtx, log, config, mgr.GetEventRecorderFor(controllerName), electionName, func(ctx context.Context) error {
 				log.Info("Executing migrations...")
-				if err := seedmigrations.RunAll(ctrlCtx.mgr.GetConfig(), options.workerName); err != nil {
+				if err := seedmigrations.RunAll(leaderCtx, ctrlCtx.mgr.GetConfig(), options.workerName); err != nil {
 					return fmt.Errorf("failed to run migrations: %v", err)
 				}
 				log.Info("Migrations executed successfully")

--- a/api/pkg/crd/migrations/credentials_test.go
+++ b/api/pkg/crd/migrations/credentials_test.go
@@ -1,0 +1,130 @@
+package migrations
+
+import (
+	"context"
+	"testing"
+
+	kubermaticv1 "github.com/kubermatic/kubermatic/api/pkg/crd/kubermatic/v1"
+	"github.com/kubermatic/kubermatic/api/pkg/resources"
+	providerconfig "github.com/kubermatic/machine-controller/pkg/providerconfig/types"
+
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/types"
+	fakectrlruntimeclient "sigs.k8s.io/controller-runtime/pkg/client/fake"
+)
+
+func TestCreateSecretsForCredentials(t *testing.T) {
+	tests := []struct {
+		name        string
+		spec        kubermaticv1.CloudSpec
+		secretToken string
+	}{
+		{
+			name: "cluster with only value defined",
+			spec: kubermaticv1.CloudSpec{
+				Hetzner: &kubermaticv1.HetznerCloudSpec{
+					Token: "some-token",
+				},
+			},
+		},
+		{
+			name:        "cluster with only reference defined",
+			secretToken: "some-token",
+			spec: kubermaticv1.CloudSpec{
+				Hetzner: &kubermaticv1.HetznerCloudSpec{
+					CredentialsReference: &providerconfig.GlobalSecretKeySelector{
+						ObjectReference: corev1.ObjectReference{
+							Name:      "credential-hetzner-test-cluster",
+							Namespace: resources.KubermaticNamespace,
+						},
+						Key: resources.HetznerToken,
+					},
+				},
+			},
+		},
+		{
+			name:        "cluster with both reference and values defined",
+			secretToken: "some-other-token",
+			spec: kubermaticv1.CloudSpec{
+				Hetzner: &kubermaticv1.HetznerCloudSpec{
+					CredentialsReference: &providerconfig.GlobalSecretKeySelector{
+						ObjectReference: corev1.ObjectReference{
+							Name:      "credential-hetzner-test-cluster",
+							Namespace: resources.KubermaticNamespace,
+						},
+						Key: resources.HetznerToken,
+					},
+					Token: "some-token",
+				},
+			},
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			cluster := newCluster(test.spec)
+			allObjs := []runtime.Object{cluster}
+			if test.spec.Hetzner.CredentialsReference != nil {
+				allObjs = append(allObjs, newSecret(test.secretToken))
+			}
+
+			fakeClient := fakectrlruntimeclient.NewFakeClient(allObjs...)
+			ctx := &cleanupContext{
+				client: fakeClient,
+			}
+			if err := createSecretsForCredentials(cluster, ctx); err != nil {
+				t.Errorf("%s: error creating secrets for credentials: %v", test.name, err)
+			}
+
+			if cluster.Spec.Cloud.Hetzner.CredentialsReference == nil {
+				t.Errorf("%s: credentialsReference field is not set", test.name)
+			}
+			if cluster.Spec.Cloud.Hetzner.Token != "" {
+				t.Errorf("%s: token field is not cleared", test.name)
+			}
+
+			secret := &corev1.Secret{}
+			namespacedName := types.NamespacedName{Namespace: resources.KubermaticNamespace, Name: cluster.GetSecretName()}
+			if err := ctx.client.Get(context.TODO(), namespacedName, secret); err != nil {
+				t.Fatalf("%s: error getting secret %s: %v", test.name, cluster.GetSecretName(), err)
+			}
+			if secret.Data == nil {
+				t.Fatalf("%s: secret %s has empty data", test.name, cluster.GetSecretName())
+			}
+
+			token, ok := secret.Data[resources.HetznerToken]
+			if !ok {
+				t.Fatalf("%s: secret %s does not have %s key", test.name, cluster.GetSecretName(), resources.HetznerToken)
+			}
+			if string(token) != "some-token" {
+				t.Errorf("%s: expected token value in secret: \"some-token\", got: %s", test.name, string(token))
+			}
+		})
+	}
+}
+
+func newCluster(cloudSpec kubermaticv1.CloudSpec) *kubermaticv1.Cluster {
+	return &kubermaticv1.Cluster{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "test-cluster",
+		},
+		Spec: kubermaticv1.ClusterSpec{
+			Cloud: cloudSpec,
+		},
+	}
+}
+
+func newSecret(token string) *corev1.Secret {
+	return &corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "credential-hetzner-test-cluster",
+			Namespace: resources.KubermaticNamespace,
+		},
+		Type: corev1.SecretTypeOpaque,
+		Data: map[string][]byte{
+			resources.HetznerToken: []byte(token),
+		},
+	}
+}

--- a/api/pkg/crd/migrations/seed/migrations.go
+++ b/api/pkg/crd/migrations/seed/migrations.go
@@ -15,7 +15,6 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	kerrors "k8s.io/apimachinery/pkg/api/errors"
 	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/apimachinery/pkg/util/sets"
 	"k8s.io/client-go/rest"
 	"k8s.io/klog"
@@ -139,13 +138,6 @@ func setExposeStrategyIfEmpty(cluster *kubermaticv1.Cluster, cleanupContext *cle
 		if err := cleanupContext.client.Update(cleanupContext.ctx, cluster); err != nil {
 			return fmt.Errorf("failed to default exposeStrategy to NodePort for cluster %q: %v", cluster.Name, err)
 		}
-		namespacedName := types.NamespacedName{Name: cluster.Name}
-		updatedCluster := &kubermaticv1.Cluster{}
-		if err := cleanupContext.client.Get(cleanupContext.ctx, namespacedName, updatedCluster); err != nil {
-			return fmt.Errorf("failed to get cluster %q: %v", cluster.Name, err)
-		}
-
-		*cluster = *updatedCluster
 	}
 	return nil
 }
@@ -160,13 +152,6 @@ func setProxyModeIfEmpty(cluster *kubermaticv1.Cluster, cleanupContext *cleanupC
 		if err := cleanupContext.client.Update(cleanupContext.ctx, cluster); err != nil {
 			return fmt.Errorf("failed to default proxyMode to iptables for cluster %q: %v", cluster.Name, err)
 		}
-		namespacedName := types.NamespacedName{Name: cluster.Name}
-		updatedCluster := &kubermaticv1.Cluster{}
-		if err := cleanupContext.client.Get(cleanupContext.ctx, namespacedName, updatedCluster); err != nil {
-			return fmt.Errorf("failed to get cluster %q: %v", cluster.Name, err)
-		}
-
-		*cluster = *updatedCluster
 	}
 	return nil
 }
@@ -204,13 +189,6 @@ func migrateClusterUserLabel(cluster *kubermaticv1.Cluster, cleanupContext *clea
 		if err := cleanupContext.client.Update(cleanupContext.ctx, cluster); err != nil {
 			return fmt.Errorf("failed to update cluster %q: %v", cluster.Name, err)
 		}
-		namespacedName := types.NamespacedName{Name: cluster.Name}
-		updatedCluster := &kubermaticv1.Cluster{}
-		if err := cleanupContext.client.Get(cleanupContext.ctx, namespacedName, updatedCluster); err != nil {
-			return fmt.Errorf("failed to get cluster %q: %v", cluster.Name, err)
-		}
-
-		*cluster = *updatedCluster
 	}
 	return nil
 }
@@ -224,12 +202,5 @@ func createSecretsForCredentials(cluster *kubermaticv1.Cluster, cleanupContext *
 	if err := cleanupContext.client.Update(cleanupContext.ctx, cluster); err != nil {
 		return fmt.Errorf("failed to update cluster %q: %v", cluster.Name, err)
 	}
-	namespacedName := types.NamespacedName{Name: cluster.Name}
-	updatedCluster := &kubermaticv1.Cluster{}
-	if err := cleanupContext.client.Get(cleanupContext.ctx, namespacedName, updatedCluster); err != nil {
-		return fmt.Errorf("failed to get cluster %q: %v", cluster.Name, err)
-	}
-
-	*cluster = *updatedCluster
 	return nil
 }

--- a/api/pkg/crd/migrations/seed/migrations_test.go
+++ b/api/pkg/crd/migrations/seed/migrations_test.go
@@ -72,10 +72,11 @@ func TestCreateSecretsForCredentials(t *testing.T) {
 			}
 
 			fakeClient := fakectrlruntimeclient.NewFakeClientWithScheme(scheme.Scheme, allObjs...)
-			ctx := &cleanupContext{
+			cleanupContext := &cleanupContext{
 				client: fakeClient,
+				ctx:    context.TODO(),
 			}
-			if err := createSecretsForCredentials(cluster, ctx); err != nil {
+			if err := createSecretsForCredentials(cluster, cleanupContext); err != nil {
 				t.Errorf("%s: error creating secrets for credentials: %v", test.name, err)
 			}
 
@@ -88,7 +89,7 @@ func TestCreateSecretsForCredentials(t *testing.T) {
 
 			secret := &corev1.Secret{}
 			namespacedName := types.NamespacedName{Namespace: resources.KubermaticNamespace, Name: cluster.GetSecretName()}
-			if err := ctx.client.Get(context.TODO(), namespacedName, secret); err != nil {
+			if err := cleanupContext.client.Get(cleanupContext.ctx, namespacedName, secret); err != nil {
 				t.Fatalf("%s: error getting secret %s: %v", test.name, cluster.GetSecretName(), err)
 			}
 			if secret.Data == nil {

--- a/api/pkg/crd/migrations/seed/migrations_test.go
+++ b/api/pkg/crd/migrations/seed/migrations_test.go
@@ -1,4 +1,4 @@
-package migrations
+package seed
 
 import (
 	"context"
@@ -12,6 +12,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/client-go/kubernetes/scheme"
 	fakectrlruntimeclient "sigs.k8s.io/controller-runtime/pkg/client/fake"
 )
 
@@ -70,7 +71,7 @@ func TestCreateSecretsForCredentials(t *testing.T) {
 				allObjs = append(allObjs, newSecret(test.secretToken))
 			}
 
-			fakeClient := fakectrlruntimeclient.NewFakeClient(allObjs...)
+			fakeClient := fakectrlruntimeclient.NewFakeClientWithScheme(scheme.Scheme, allObjs...)
 			ctx := &cleanupContext{
 				client: fakeClient,
 			}

--- a/api/pkg/handler/routes_v1.go
+++ b/api/pkg/handler/routes_v1.go
@@ -1443,6 +1443,7 @@ func (r Routing) patchCluster() http.Handler {
 			middleware.TokenVerifier(r.tokenVerifiers),
 			middleware.UserSaver(r.userProvider),
 			middleware.SetClusterProvider(r.clusterProviderGetter, r.seedsGetter),
+			middleware.SetPrivilegedClusterProvider(r.clusterProviderGetter, r.seedsGetter),
 		)(cluster.PatchEndpoint(r.projectProvider, r.seedsGetter, r.userInfoGetter)),
 		cluster.DecodePatchReq,
 		encodeJSON,

--- a/api/pkg/handler/v1/cluster/cluster.go
+++ b/api/pkg/handler/v1/cluster/cluster.go
@@ -146,7 +146,7 @@ func CreateEndpoint(sshKeyProvider provider.SSHKeyProvider, projectProvider prov
 			partialCluster.Spec.Features = map[string]bool{kubermaticv1.ClusterFeatureExternalCloudProvider: true}
 		}
 
-		if err := kubernetesprovider.CreateCredentialSecretForCluster(ctx, privilegedClusterProvider.GetSeedClusterAdminRuntimeClient(), partialCluster, req.ProjectID); err != nil {
+		if err := kubernetesprovider.CreateOrUpdateCredentialSecretForCluster(ctx, privilegedClusterProvider.GetSeedClusterAdminRuntimeClient(), partialCluster); err != nil {
 			return nil, err
 		}
 		kuberneteshelper.AddFinalizer(partialCluster, apiv1.CredentialsSecretsCleanupFinalizer)
@@ -345,6 +345,7 @@ func PatchEndpoint(projectProvider provider.ProjectProvider, seedsGetter provide
 	return func(ctx context.Context, request interface{}) (interface{}, error) {
 		req := request.(PatchReq)
 		clusterProvider := ctx.Value(middleware.ClusterProviderContextKey).(provider.ClusterProvider)
+		privilegedClusterProvider := ctx.Value(middleware.PrivilegedClusterProviderContextKey).(provider.PrivilegedClusterProvider)
 		userInfo, err := userInfoGetter(ctx, req.ProjectID)
 		if err != nil {
 			return nil, errors.New(http.StatusInternalServerError, "no userInfo in request")
@@ -412,6 +413,10 @@ func PatchEndpoint(projectProvider provider.ProjectProvider, seedsGetter provide
 		_, dc, err := provider.DatacenterFromSeedMap(userInfo, seedsGetter, newInternalCluster.Spec.Cloud.DatacenterName)
 		if err != nil {
 			return nil, fmt.Errorf("error getting dc: %v", err)
+		}
+
+		if err := kubernetesprovider.CreateOrUpdateCredentialSecretForCluster(ctx, privilegedClusterProvider.GetSeedClusterAdminRuntimeClient(), newInternalCluster); err != nil {
+			return nil, err
 		}
 
 		// Enforce audit logging

--- a/api/pkg/provider/kubernetes/credentials.go
+++ b/api/pkg/provider/kubernetes/credentials.go
@@ -43,7 +43,7 @@ func CreateOrUpdateCredentialSecretForCluster(ctx context.Context, seedClient ct
 		return createVSphereSecret(ctx, seedClient, cluster)
 	}
 	if cluster.Spec.Cloud.Alibaba != nil {
-		return createAlibabaSecret(ctx, seedClient, cluster, projectID)
+		return createAlibabaSecret(ctx, seedClient, cluster)
 	}
 	return nil
 }
@@ -674,7 +674,7 @@ func createVSphereSecret(ctx context.Context, seedClient ctrlruntimeclient.Clien
 	return nil
 }
 
-func createAlibabaSecret(ctx context.Context, seedClient ctrlruntimeclient.Client, cluster *kubermaticv1.Cluster, projectID string) error {
+func createAlibabaSecret(ctx context.Context, seedClient ctrlruntimeclient.Client, cluster *kubermaticv1.Cluster) error {
 	// create secret for storing credentials
 	name := cluster.GetSecretName()
 	secret := &corev1.Secret{
@@ -682,8 +682,7 @@ func createAlibabaSecret(ctx context.Context, seedClient ctrlruntimeclient.Clien
 			Name:      name,
 			Namespace: resources.KubermaticNamespace,
 			Labels: map[string]string{
-				kubermaticv1.ProjectIDLabelKey: projectID,
-				"name":                         name,
+				"name": name,
 			},
 		},
 		Type: corev1.SecretTypeOpaque,

--- a/api/pkg/provider/kubernetes/credentials.go
+++ b/api/pkg/provider/kubernetes/credentials.go
@@ -9,37 +9,38 @@ import (
 
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
 	ctrlruntimeclient "sigs.k8s.io/controller-runtime/pkg/client"
 )
 
 // CreateCredentialSecretForCluster creates a new secret for a credential
-func CreateCredentialSecretForCluster(ctx context.Context, seedClient ctrlruntimeclient.Client, cluster *kubermaticv1.Cluster, projectID string) error {
+func CreateOrUpdateCredentialSecretForCluster(ctx context.Context, seedClient ctrlruntimeclient.Client, cluster *kubermaticv1.Cluster) error {
 	if cluster.Spec.Cloud.AWS != nil {
-		return createAWSSecret(ctx, seedClient, cluster, projectID)
+		return createOrUpdateAWSSecret(ctx, seedClient, cluster)
 	}
 	if cluster.Spec.Cloud.Azure != nil {
-		return createAzureSecret(ctx, seedClient, cluster, projectID)
+		return createOrUpdateAzureSecret(ctx, seedClient, cluster)
 	}
 	if cluster.Spec.Cloud.Digitalocean != nil {
-		return createDigitaloceanSecret(ctx, seedClient, cluster, projectID)
+		return createOrUpdateDigitaloceanSecret(ctx, seedClient, cluster)
 	}
 	if cluster.Spec.Cloud.GCP != nil {
-		return createGCPSecret(ctx, seedClient, cluster, projectID)
+		return createOrUpdateGCPSecret(ctx, seedClient, cluster)
 	}
 	if cluster.Spec.Cloud.Hetzner != nil {
-		return createHetznerSecret(ctx, seedClient, cluster, projectID)
+		return createOrUpdateHetznerSecret(ctx, seedClient, cluster)
 	}
 	if cluster.Spec.Cloud.Openstack != nil {
-		return createOpenstackSecret(ctx, seedClient, cluster, projectID)
+		return createOrUpdateOpenstackSecret(ctx, seedClient, cluster)
 	}
 	if cluster.Spec.Cloud.Packet != nil {
-		return createPacketSecret(ctx, seedClient, cluster, projectID)
+		return createOrUpdatePacketSecret(ctx, seedClient, cluster)
 	}
 	if cluster.Spec.Cloud.Kubevirt != nil {
-		return createKubevirtSecret(ctx, seedClient, cluster, projectID)
+		return createOrUpdateKubevirtSecret(ctx, seedClient, cluster)
 	}
 	if cluster.Spec.Cloud.VSphere != nil {
-		return createVSphereSecret(ctx, seedClient, cluster, projectID)
+		return createVSphereSecret(ctx, seedClient, cluster)
 	}
 	if cluster.Spec.Cloud.Alibaba != nil {
 		return createAlibabaSecret(ctx, seedClient, cluster, projectID)
@@ -47,308 +48,592 @@ func CreateCredentialSecretForCluster(ctx context.Context, seedClient ctrlruntim
 	return nil
 }
 
-func createAWSSecret(ctx context.Context, seedClient ctrlruntimeclient.Client, cluster *kubermaticv1.Cluster, projectID string) error {
-	// create secret for storing credentials
-	name := cluster.GetSecretName()
-	secret := &corev1.Secret{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:      name,
-			Namespace: resources.KubermaticNamespace,
-			Labels: map[string]string{
-				kubermaticv1.ProjectIDLabelKey: projectID,
-				"name":                         name,
+func createOrUpdateAWSSecret(ctx context.Context, seedClient ctrlruntimeclient.Client, cluster *kubermaticv1.Cluster) error {
+	spec := cluster.Spec.Cloud.AWS
+	referenceDefined := spec.CredentialsReference != nil && spec.CredentialsReference.Name != ""
+	valuesDefined := spec.AccessKeyID != "" || spec.SecretAccessKey != ""
+
+	if !referenceDefined && valuesDefined {
+		name := cluster.GetSecretName()
+		secret := &corev1.Secret{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      name,
+				Namespace: resources.KubermaticNamespace,
+				Labels: map[string]string{
+					"name": name,
+				},
 			},
-		},
-		Type: corev1.SecretTypeOpaque,
-		Data: map[string][]byte{
-			resources.AWSAccessKeyID:     []byte(cluster.Spec.Cloud.AWS.AccessKeyID),
-			resources.AWSSecretAccessKey: []byte(cluster.Spec.Cloud.AWS.SecretAccessKey),
-		},
+			Type: corev1.SecretTypeOpaque,
+			Data: map[string][]byte{
+				resources.AWSAccessKeyID:     []byte(spec.AccessKeyID),
+				resources.AWSSecretAccessKey: []byte(spec.SecretAccessKey),
+			},
+		}
+
+		if err := seedClient.Create(ctx, secret); err != nil {
+			return err
+		}
+
+		// add secret key selectors to cluster object
+		cluster.Spec.Cloud.AWS.CredentialsReference = &providerconfig.GlobalSecretKeySelector{
+			ObjectReference: corev1.ObjectReference{
+				Name:      cluster.GetSecretName(),
+				Namespace: resources.KubermaticNamespace,
+			},
+		}
 	}
 
-	if err := seedClient.Create(ctx, secret); err != nil {
-		return err
+	if referenceDefined && valuesDefined {
+		namespacedName := types.NamespacedName{Namespace: resources.KubermaticNamespace, Name: cluster.GetSecretName()}
+		existingSecret := &corev1.Secret{}
+		if err := seedClient.Get(ctx, namespacedName, existingSecret); err != nil {
+			return err
+		}
+
+		var updateNeeded bool
+		if existingSecret.Data != nil {
+			if accessKeyID, ok := existingSecret.Data[resources.AWSAccessKeyID]; ok {
+				if string(accessKeyID) != spec.AccessKeyID {
+					existingSecret.Data[resources.AWSAccessKeyID] = []byte(spec.AccessKeyID)
+					updateNeeded = true
+				}
+			}
+			if secretAccessKey, ok := existingSecret.Data[resources.AWSSecretAccessKey]; ok {
+				if string(secretAccessKey) != spec.SecretAccessKey {
+					existingSecret.Data[resources.AWSSecretAccessKey] = []byte(spec.SecretAccessKey)
+					updateNeeded = true
+				}
+			}
+		}
+		if updateNeeded {
+			if err := seedClient.Update(ctx, existingSecret); err != nil {
+				return err
+			}
+		}
 	}
 
-	// add secret key selectors to cluster object
-	cluster.Spec.Cloud.AWS.CredentialsReference = &providerconfig.GlobalSecretKeySelector{
-		ObjectReference: corev1.ObjectReference{
-			Name:      secret.Name,
-			Namespace: secret.Namespace,
-		},
+	if valuesDefined {
+		cluster.Spec.Cloud.AWS.AccessKeyID = ""
+		cluster.Spec.Cloud.AWS.SecretAccessKey = ""
 	}
-
-	// remove credentials from cluster object
-	cluster.Spec.Cloud.AWS.AccessKeyID = ""
-	cluster.Spec.Cloud.AWS.SecretAccessKey = ""
 
 	return nil
 }
 
-func createAzureSecret(ctx context.Context, seedClient ctrlruntimeclient.Client, cluster *kubermaticv1.Cluster, projectID string) error {
-	name := cluster.GetSecretName()
-	secret := &corev1.Secret{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:      name,
-			Namespace: resources.KubermaticNamespace,
-			Labels: map[string]string{
-				kubermaticv1.ProjectIDLabelKey: projectID,
-				"name":                         name,
+func createOrUpdateAzureSecret(ctx context.Context, seedClient ctrlruntimeclient.Client, cluster *kubermaticv1.Cluster) error {
+	spec := cluster.Spec.Cloud.Azure
+	referenceDefined := spec.CredentialsReference != nil && spec.CredentialsReference.Name != ""
+	valuesDefined := spec.TenantID != "" || spec.SubscriptionID != "" || spec.ClientID != "" || spec.ClientSecret != ""
+
+	if !referenceDefined && valuesDefined {
+		name := cluster.GetSecretName()
+		secret := &corev1.Secret{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      name,
+				Namespace: resources.KubermaticNamespace,
+				Labels: map[string]string{
+					"name": name,
+				},
 			},
-		},
-		Type: corev1.SecretTypeOpaque,
-		Data: map[string][]byte{
-			resources.AzureTenantID:       []byte(cluster.Spec.Cloud.Azure.TenantID),
-			resources.AzureSubscriptionID: []byte(cluster.Spec.Cloud.Azure.SubscriptionID),
-			resources.AzureClientID:       []byte(cluster.Spec.Cloud.Azure.ClientID),
-			resources.AzureClientSecret:   []byte(cluster.Spec.Cloud.Azure.ClientSecret),
-		},
+			Type: corev1.SecretTypeOpaque,
+			Data: map[string][]byte{
+				resources.AzureTenantID:       []byte(spec.TenantID),
+				resources.AzureSubscriptionID: []byte(spec.SubscriptionID),
+				resources.AzureClientID:       []byte(spec.ClientID),
+				resources.AzureClientSecret:   []byte(spec.ClientSecret),
+			},
+		}
+
+		if err := seedClient.Create(ctx, secret); err != nil {
+			return err
+		}
+
+		// add secret key selectors to cluster object
+		cluster.Spec.Cloud.Azure.CredentialsReference = &providerconfig.GlobalSecretKeySelector{
+			ObjectReference: corev1.ObjectReference{
+				Name:      cluster.GetSecretName(),
+				Namespace: resources.KubermaticNamespace,
+			},
+		}
 	}
 
-	if err := seedClient.Create(ctx, secret); err != nil {
-		return err
+	if referenceDefined && valuesDefined {
+		namespacedName := types.NamespacedName{Namespace: resources.KubermaticNamespace, Name: cluster.GetSecretName()}
+		existingSecret := &corev1.Secret{}
+		if err := seedClient.Get(ctx, namespacedName, existingSecret); err != nil {
+			return err
+		}
+
+		var updateNeeded bool
+		if existingSecret.Data != nil {
+			if tenantID, ok := existingSecret.Data[resources.AzureTenantID]; ok {
+				if string(tenantID) != spec.TenantID {
+					existingSecret.Data[resources.AzureTenantID] = []byte(spec.TenantID)
+					updateNeeded = true
+				}
+			}
+			if subscriptionID, ok := existingSecret.Data[resources.AzureSubscriptionID]; ok {
+				if string(subscriptionID) != spec.SubscriptionID {
+					existingSecret.Data[resources.AzureSubscriptionID] = []byte(spec.SubscriptionID)
+					updateNeeded = true
+				}
+			}
+			if clientID, ok := existingSecret.Data[resources.AzureClientID]; ok {
+				if string(clientID) != spec.ClientID {
+					existingSecret.Data[resources.AzureClientID] = []byte(spec.ClientID)
+					updateNeeded = true
+				}
+			}
+			if clientSecret, ok := existingSecret.Data[resources.AzureClientSecret]; ok {
+				if string(clientSecret) != spec.ClientSecret {
+					existingSecret.Data[resources.AzureClientSecret] = []byte(spec.ClientSecret)
+					updateNeeded = true
+				}
+			}
+		}
+		if updateNeeded {
+			if err := seedClient.Update(ctx, existingSecret); err != nil {
+				return err
+			}
+		}
 	}
 
-	// add secret key selectors to cluster object
-	cluster.Spec.Cloud.Azure.CredentialsReference = &providerconfig.GlobalSecretKeySelector{
-		ObjectReference: corev1.ObjectReference{
-			Name:      secret.Name,
-			Namespace: secret.Namespace,
-		},
+	if valuesDefined {
+		cluster.Spec.Cloud.Azure.TenantID = ""
+		cluster.Spec.Cloud.Azure.SubscriptionID = ""
+		cluster.Spec.Cloud.Azure.ClientID = ""
+		cluster.Spec.Cloud.Azure.ClientSecret = ""
 	}
-
-	// remove credentials from cluster object
-	cluster.Spec.Cloud.Azure.TenantID = ""
-	cluster.Spec.Cloud.Azure.SubscriptionID = ""
-	cluster.Spec.Cloud.Azure.ClientID = ""
-	cluster.Spec.Cloud.Azure.ClientSecret = ""
 
 	return nil
 }
 
-func createDigitaloceanSecret(ctx context.Context, seedClient ctrlruntimeclient.Client, cluster *kubermaticv1.Cluster, projectID string) error {
-	name := cluster.GetSecretName()
-	secret := &corev1.Secret{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:      name,
-			Namespace: resources.KubermaticNamespace,
-			Labels: map[string]string{
-				kubermaticv1.ProjectIDLabelKey: projectID,
-				"name":                         name,
+func createOrUpdateDigitaloceanSecret(ctx context.Context, seedClient ctrlruntimeclient.Client, cluster *kubermaticv1.Cluster) error {
+	spec := cluster.Spec.Cloud.Digitalocean
+	referenceDefined := spec.CredentialsReference != nil && spec.CredentialsReference.Name != ""
+	valuesDefined := spec.Token != ""
+
+	if !referenceDefined && valuesDefined {
+		name := cluster.GetSecretName()
+		secret := &corev1.Secret{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      name,
+				Namespace: resources.KubermaticNamespace,
+				Labels: map[string]string{
+					"name": name,
+				},
 			},
-		},
-		Type: corev1.SecretTypeOpaque,
-		Data: map[string][]byte{
-			resources.DigitaloceanToken: []byte(cluster.Spec.Cloud.Digitalocean.Token),
-		},
+			Type: corev1.SecretTypeOpaque,
+			Data: map[string][]byte{
+				resources.DigitaloceanToken: []byte(spec.Token),
+			},
+		}
+
+		if err := seedClient.Create(ctx, secret); err != nil {
+			return err
+		}
+
+		// add secret key selectors to cluster object
+		cluster.Spec.Cloud.Digitalocean.CredentialsReference = &providerconfig.GlobalSecretKeySelector{
+			ObjectReference: corev1.ObjectReference{
+				Name:      cluster.GetSecretName(),
+				Namespace: resources.KubermaticNamespace,
+			},
+		}
 	}
 
-	if err := seedClient.Create(ctx, secret); err != nil {
-		return err
+	if referenceDefined && valuesDefined {
+		namespacedName := types.NamespacedName{Namespace: resources.KubermaticNamespace, Name: cluster.GetSecretName()}
+		existingSecret := &corev1.Secret{}
+		if err := seedClient.Get(ctx, namespacedName, existingSecret); err != nil {
+			return err
+		}
+
+		var updateNeeded bool
+		if existingSecret.Data != nil {
+			if token, ok := existingSecret.Data[resources.DigitaloceanToken]; ok {
+				if string(token) != spec.Token {
+					existingSecret.Data[resources.DigitaloceanToken] = []byte(spec.Token)
+					updateNeeded = true
+				}
+			}
+		}
+
+		if updateNeeded {
+			if err := seedClient.Update(ctx, existingSecret); err != nil {
+				return err
+			}
+		}
 	}
 
-	// add secret key selectors to cluster object
-	cluster.Spec.Cloud.Digitalocean.CredentialsReference = &providerconfig.GlobalSecretKeySelector{
-		ObjectReference: corev1.ObjectReference{
-			Name:      secret.Name,
-			Namespace: secret.Namespace,
-		},
+	if valuesDefined {
+		cluster.Spec.Cloud.Digitalocean.Token = ""
 	}
-
-	// remove credentials from cluster object
-	cluster.Spec.Cloud.Digitalocean.Token = ""
 
 	return nil
 }
 
-func createGCPSecret(ctx context.Context, seedClient ctrlruntimeclient.Client, cluster *kubermaticv1.Cluster, projectID string) error {
-	name := cluster.GetSecretName()
-	secret := &corev1.Secret{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:      name,
-			Namespace: resources.KubermaticNamespace,
-			Labels: map[string]string{
-				kubermaticv1.ProjectIDLabelKey: projectID,
-				"name":                         name,
+func createOrUpdateGCPSecret(ctx context.Context, seedClient ctrlruntimeclient.Client, cluster *kubermaticv1.Cluster) error {
+	spec := cluster.Spec.Cloud.GCP
+	referenceDefined := spec.CredentialsReference != nil && spec.CredentialsReference.Name != ""
+	valuesDefined := spec.ServiceAccount != ""
+
+	if !referenceDefined && valuesDefined {
+		name := cluster.GetSecretName()
+		secret := &corev1.Secret{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      name,
+				Namespace: resources.KubermaticNamespace,
+				Labels: map[string]string{
+					"name": name,
+				},
 			},
-		},
-		Type: corev1.SecretTypeOpaque,
-		Data: map[string][]byte{
-			resources.GCPServiceAccount: []byte(cluster.Spec.Cloud.GCP.ServiceAccount),
-		},
+			Type: corev1.SecretTypeOpaque,
+			Data: map[string][]byte{
+				resources.GCPServiceAccount: []byte(spec.ServiceAccount),
+			},
+		}
+
+		if err := seedClient.Create(ctx, secret); err != nil {
+			return err
+		}
+
+		cluster.Spec.Cloud.GCP.CredentialsReference = &providerconfig.GlobalSecretKeySelector{
+			ObjectReference: corev1.ObjectReference{
+				Name:      cluster.GetSecretName(),
+				Namespace: resources.KubermaticNamespace,
+			},
+		}
 	}
 
-	if err := seedClient.Create(ctx, secret); err != nil {
-		return err
+	if referenceDefined && valuesDefined {
+		namespacedName := types.NamespacedName{Namespace: resources.KubermaticNamespace, Name: cluster.GetSecretName()}
+		existingSecret := &corev1.Secret{}
+		if err := seedClient.Get(ctx, namespacedName, existingSecret); err != nil {
+			return err
+		}
+
+		var updateNeeded bool
+		if existingSecret.Data != nil {
+			if sa, ok := existingSecret.Data[resources.GCPServiceAccount]; ok {
+				if string(sa) != spec.ServiceAccount {
+					existingSecret.Data[resources.GCPServiceAccount] = []byte(spec.ServiceAccount)
+					updateNeeded = true
+				}
+			}
+		}
+
+		if updateNeeded {
+			if err := seedClient.Update(ctx, existingSecret); err != nil {
+				return err
+			}
+		}
 	}
 
-	// add secret key selectors to cluster object
-	cluster.Spec.Cloud.GCP.CredentialsReference = &providerconfig.GlobalSecretKeySelector{
-		ObjectReference: corev1.ObjectReference{
-			Name:      secret.Name,
-			Namespace: secret.Namespace,
-		},
+	if valuesDefined {
+		cluster.Spec.Cloud.GCP.ServiceAccount = ""
 	}
-
-	// remove credentials from cluster object
-	cluster.Spec.Cloud.GCP.ServiceAccount = ""
 
 	return nil
 }
 
-func createHetznerSecret(ctx context.Context, seedClient ctrlruntimeclient.Client, cluster *kubermaticv1.Cluster, projectID string) error {
-	name := cluster.GetSecretName()
-	secret := &corev1.Secret{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:      name,
-			Namespace: resources.KubermaticNamespace,
-			Labels: map[string]string{
-				kubermaticv1.ProjectIDLabelKey: projectID,
-				"name":                         name,
+func createOrUpdateHetznerSecret(ctx context.Context, seedClient ctrlruntimeclient.Client, cluster *kubermaticv1.Cluster) error {
+	spec := cluster.Spec.Cloud.Hetzner
+	referenceDefined := spec.CredentialsReference != nil && spec.CredentialsReference.Name != ""
+	valuesDefined := spec.Token != ""
+
+	if !referenceDefined && valuesDefined {
+		name := cluster.GetSecretName()
+		secret := &corev1.Secret{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      name,
+				Namespace: resources.KubermaticNamespace,
+				Labels: map[string]string{
+					"name": name,
+				},
 			},
-		},
-		Type: corev1.SecretTypeOpaque,
-		Data: map[string][]byte{
-			resources.HetznerToken: []byte(cluster.Spec.Cloud.Hetzner.Token),
-		},
+			Type: corev1.SecretTypeOpaque,
+			Data: map[string][]byte{
+				resources.HetznerToken: []byte(spec.Token),
+			},
+		}
+
+		if err := seedClient.Create(ctx, secret); err != nil {
+			return err
+		}
+
+		cluster.Spec.Cloud.Hetzner.CredentialsReference = &providerconfig.GlobalSecretKeySelector{
+			ObjectReference: corev1.ObjectReference{
+				Name:      cluster.GetSecretName(),
+				Namespace: resources.KubermaticNamespace,
+			},
+		}
 	}
 
-	if err := seedClient.Create(ctx, secret); err != nil {
-		return err
+	if referenceDefined && valuesDefined {
+		namespacedName := types.NamespacedName{Namespace: resources.KubermaticNamespace, Name: cluster.GetSecretName()}
+		existingSecret := &corev1.Secret{}
+		if err := seedClient.Get(ctx, namespacedName, existingSecret); err != nil {
+			return err
+		}
+
+		var updateNeeded bool
+		if existingSecret.Data != nil {
+			if token, ok := existingSecret.Data[resources.HetznerToken]; ok {
+				if string(token) != spec.Token {
+					existingSecret.Data[resources.HetznerToken] = []byte(spec.Token)
+					updateNeeded = true
+				}
+			}
+		}
+
+		if updateNeeded {
+			if err := seedClient.Update(ctx, existingSecret); err != nil {
+				return err
+			}
+		}
 	}
 
-	// add secret key selectors to cluster object
-	cluster.Spec.Cloud.Hetzner.CredentialsReference = &providerconfig.GlobalSecretKeySelector{
-		ObjectReference: corev1.ObjectReference{
-			Name:      secret.Name,
-			Namespace: secret.Namespace,
-		},
+	if valuesDefined {
+		cluster.Spec.Cloud.Hetzner.Token = ""
 	}
-
-	// remove credentials from cluster object
-	cluster.Spec.Cloud.Hetzner.Token = ""
 
 	return nil
 }
 
-func createOpenstackSecret(ctx context.Context, seedClient ctrlruntimeclient.Client, cluster *kubermaticv1.Cluster, projectID string) error {
-	name := cluster.GetSecretName()
-	secret := &corev1.Secret{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:      name,
-			Namespace: resources.KubermaticNamespace,
-			Labels: map[string]string{
-				kubermaticv1.ProjectIDLabelKey: projectID,
-				"name":                         name,
+func createOrUpdateOpenstackSecret(ctx context.Context, seedClient ctrlruntimeclient.Client, cluster *kubermaticv1.Cluster) error {
+	spec := cluster.Spec.Cloud.Openstack
+	referenceDefined := spec.CredentialsReference != nil && spec.CredentialsReference.Name != ""
+	valuesDefined := spec.Username != "" || spec.Password != "" || spec.Tenant != "" || spec.TenantID != "" || spec.Domain != ""
+
+	if !referenceDefined && valuesDefined {
+		name := cluster.GetSecretName()
+		secret := &corev1.Secret{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      name,
+				Namespace: resources.KubermaticNamespace,
+				Labels: map[string]string{
+					"name": name,
+				},
 			},
-		},
-		Type: corev1.SecretTypeOpaque,
-		Data: map[string][]byte{
-			resources.OpenstackUsername: []byte(cluster.Spec.Cloud.Openstack.Username),
-			resources.OpenstackPassword: []byte(cluster.Spec.Cloud.Openstack.Password),
-			resources.OpenstackTenant:   []byte(cluster.Spec.Cloud.Openstack.Tenant),
-			resources.OpenstackTenantID: []byte(cluster.Spec.Cloud.Openstack.TenantID),
-			resources.OpenstackDomain:   []byte(cluster.Spec.Cloud.Openstack.Domain),
-		},
+			Type: corev1.SecretTypeOpaque,
+			Data: map[string][]byte{
+				resources.OpenstackUsername: []byte(spec.Username),
+				resources.OpenstackPassword: []byte(spec.Password),
+				resources.OpenstackTenant:   []byte(spec.Tenant),
+				resources.OpenstackTenantID: []byte(spec.TenantID),
+				resources.OpenstackDomain:   []byte(spec.Domain),
+			},
+		}
+
+		if err := seedClient.Create(ctx, secret); err != nil {
+			return err
+		}
+
+		// add secret key selectors to cluster object
+		cluster.Spec.Cloud.Openstack.CredentialsReference = &providerconfig.GlobalSecretKeySelector{
+			ObjectReference: corev1.ObjectReference{
+				Name:      cluster.GetSecretName(),
+				Namespace: resources.KubermaticNamespace,
+			},
+		}
 	}
 
-	if err := seedClient.Create(ctx, secret); err != nil {
-		return err
+	if referenceDefined && valuesDefined {
+		namespacedName := types.NamespacedName{Namespace: resources.KubermaticNamespace, Name: cluster.GetSecretName()}
+		existingSecret := &corev1.Secret{}
+		if err := seedClient.Get(ctx, namespacedName, existingSecret); err != nil {
+			return err
+		}
+
+		var updateNeeded bool
+		if existingSecret.Data != nil {
+			if username, ok := existingSecret.Data[resources.OpenstackUsername]; ok {
+				if string(username) != spec.Username {
+					existingSecret.Data[resources.OpenstackUsername] = []byte(spec.Username)
+					updateNeeded = true
+				}
+			}
+			if password, ok := existingSecret.Data[resources.OpenstackPassword]; ok {
+				if string(password) != spec.Password {
+					existingSecret.Data[resources.OpenstackPassword] = []byte(spec.Password)
+					updateNeeded = true
+				}
+			}
+			if tenant, ok := existingSecret.Data[resources.OpenstackTenant]; ok {
+				if string(tenant) != spec.Tenant {
+					existingSecret.Data[resources.OpenstackTenant] = []byte(spec.Tenant)
+					updateNeeded = true
+				}
+			}
+			if tenantID, ok := existingSecret.Data[resources.OpenstackTenantID]; ok {
+				if string(tenantID) != spec.TenantID {
+					existingSecret.Data[resources.OpenstackTenantID] = []byte(spec.TenantID)
+					updateNeeded = true
+				}
+			}
+			if domain, ok := existingSecret.Data[resources.OpenstackDomain]; ok {
+				if string(domain) != spec.Domain {
+					existingSecret.Data[resources.OpenstackDomain] = []byte(spec.Domain)
+					updateNeeded = true
+				}
+			}
+		}
+		if updateNeeded {
+			if err := seedClient.Update(ctx, existingSecret); err != nil {
+				return err
+			}
+		}
 	}
 
-	// add secret key selectors to cluster object
-	cluster.Spec.Cloud.Openstack.CredentialsReference = &providerconfig.GlobalSecretKeySelector{
-		ObjectReference: corev1.ObjectReference{
-			Name:      secret.Name,
-			Namespace: secret.Namespace,
-		},
+	if valuesDefined {
+		cluster.Spec.Cloud.Openstack.Username = ""
+		cluster.Spec.Cloud.Openstack.Password = ""
+		cluster.Spec.Cloud.Openstack.Tenant = ""
+		cluster.Spec.Cloud.Openstack.TenantID = ""
+		cluster.Spec.Cloud.Openstack.Domain = ""
 	}
-
-	// remove credentials from cluster object
-	cluster.Spec.Cloud.Openstack.Username = ""
-	cluster.Spec.Cloud.Openstack.Password = ""
-	cluster.Spec.Cloud.Openstack.Tenant = ""
-	cluster.Spec.Cloud.Openstack.TenantID = ""
-	cluster.Spec.Cloud.Openstack.Domain = ""
 
 	return nil
 }
 
-func createPacketSecret(ctx context.Context, seedClient ctrlruntimeclient.Client, cluster *kubermaticv1.Cluster, projectID string) error {
-	// create secret for storing credentials
-	name := cluster.GetSecretName()
-	secret := &corev1.Secret{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:      name,
-			Namespace: resources.KubermaticNamespace,
-			Labels: map[string]string{
-				kubermaticv1.ProjectIDLabelKey: projectID,
-				"name":                         name,
+func createOrUpdatePacketSecret(ctx context.Context, seedClient ctrlruntimeclient.Client, cluster *kubermaticv1.Cluster) error {
+	spec := cluster.Spec.Cloud.Packet
+	referenceDefined := spec.CredentialsReference != nil && spec.CredentialsReference.Name != ""
+	valuesDefined := spec.APIKey != "" || spec.ProjectID != ""
+
+	if !referenceDefined && valuesDefined {
+		name := cluster.GetSecretName()
+		secret := &corev1.Secret{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      name,
+				Namespace: resources.KubermaticNamespace,
+				Labels: map[string]string{
+					"name": name,
+				},
 			},
-		},
-		Type: corev1.SecretTypeOpaque,
-		Data: map[string][]byte{
-			resources.PacketAPIKey:    []byte(cluster.Spec.Cloud.Packet.APIKey),
-			resources.PacketProjectID: []byte(cluster.Spec.Cloud.Packet.ProjectID),
-		},
+			Type: corev1.SecretTypeOpaque,
+			Data: map[string][]byte{
+				resources.PacketAPIKey:    []byte(spec.APIKey),
+				resources.PacketProjectID: []byte(spec.ProjectID),
+			},
+		}
+
+		if err := seedClient.Create(ctx, secret); err != nil {
+			return err
+		}
+
+		// add secret key selectors to cluster object
+		cluster.Spec.Cloud.Packet.CredentialsReference = &providerconfig.GlobalSecretKeySelector{
+			ObjectReference: corev1.ObjectReference{
+				Name:      cluster.GetSecretName(),
+				Namespace: resources.KubermaticNamespace,
+			},
+		}
 	}
 
-	if err := seedClient.Create(ctx, secret); err != nil {
-		return err
+	if referenceDefined && valuesDefined {
+		namespacedName := types.NamespacedName{Namespace: resources.KubermaticNamespace, Name: cluster.GetSecretName()}
+		existingSecret := &corev1.Secret{}
+		if err := seedClient.Get(ctx, namespacedName, existingSecret); err != nil {
+			return err
+		}
+
+		var updateNeeded bool
+		if existingSecret.Data != nil {
+			if apiKey, ok := existingSecret.Data[resources.PacketAPIKey]; ok {
+				if string(apiKey) != spec.APIKey {
+					existingSecret.Data[resources.PacketAPIKey] = []byte(spec.APIKey)
+					updateNeeded = true
+				}
+			}
+			if projectID, ok := existingSecret.Data[resources.PacketProjectID]; ok {
+				if string(projectID) != spec.ProjectID {
+					existingSecret.Data[resources.PacketProjectID] = []byte(spec.ProjectID)
+					updateNeeded = true
+				}
+			}
+		}
+		if updateNeeded {
+			if err := seedClient.Update(ctx, existingSecret); err != nil {
+				return err
+			}
+		}
 	}
 
-	// add secret key selectors to cluster object
-	cluster.Spec.Cloud.Packet.CredentialsReference = &providerconfig.GlobalSecretKeySelector{
-		ObjectReference: corev1.ObjectReference{
-			Name:      secret.Name,
-			Namespace: secret.Namespace,
-		},
+	if valuesDefined {
+		cluster.Spec.Cloud.Packet.APIKey = ""
+		cluster.Spec.Cloud.Packet.ProjectID = ""
 	}
-
-	// remove credentials from cluster object
-	cluster.Spec.Cloud.Packet.APIKey = ""
-	cluster.Spec.Cloud.Packet.ProjectID = ""
 
 	return nil
 }
 
-func createKubevirtSecret(ctx context.Context, seedClient ctrlruntimeclient.Client, cluster *kubermaticv1.Cluster, projectID string) error {
-	// create secret for storing credentials
-	name := cluster.GetSecretName()
-	secret := &corev1.Secret{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:      name,
-			Namespace: resources.KubermaticNamespace,
-			Labels: map[string]string{
-				kubermaticv1.ProjectIDLabelKey: projectID,
-				"name":                         name,
+func createOrUpdateKubevirtSecret(ctx context.Context, seedClient ctrlruntimeclient.Client, cluster *kubermaticv1.Cluster) error {
+	spec := cluster.Spec.Cloud.Kubevirt
+	referenceDefined := spec.CredentialsReference != nil && spec.CredentialsReference.Name != ""
+	valuesDefined := spec.Kubeconfig != ""
+
+	if !referenceDefined && valuesDefined {
+		name := cluster.GetSecretName()
+		secret := &corev1.Secret{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      name,
+				Namespace: resources.KubermaticNamespace,
+				Labels: map[string]string{
+					"name": name,
+				},
 			},
-		},
-		Type: corev1.SecretTypeOpaque,
-		Data: map[string][]byte{
-			resources.KubevirtKubeConfig: []byte(cluster.Spec.Cloud.Kubevirt.Kubeconfig),
-		},
+			Type: corev1.SecretTypeOpaque,
+			Data: map[string][]byte{
+				resources.KubevirtKubeConfig: []byte(spec.Kubeconfig),
+			},
+		}
+
+		if err := seedClient.Create(ctx, secret); err != nil {
+			return err
+		}
+
+		// add secret key selectors to cluster object
+		cluster.Spec.Cloud.Kubevirt.CredentialsReference = &providerconfig.GlobalSecretKeySelector{
+			ObjectReference: corev1.ObjectReference{
+				Name:      cluster.GetSecretName(),
+				Namespace: resources.KubermaticNamespace,
+			},
+		}
 	}
 
-	if err := seedClient.Create(ctx, secret); err != nil {
-		return err
+	if referenceDefined && valuesDefined {
+		namespacedName := types.NamespacedName{Namespace: resources.KubermaticNamespace, Name: cluster.GetSecretName()}
+		existingSecret := &corev1.Secret{}
+		if err := seedClient.Get(ctx, namespacedName, existingSecret); err != nil {
+			return err
+		}
+
+		var updateNeeded bool
+		if existingSecret.Data != nil {
+			if kubeconfig, ok := existingSecret.Data[resources.KubevirtKubeConfig]; ok {
+				if string(kubeconfig) != spec.Kubeconfig {
+					existingSecret.Data[resources.KubevirtKubeConfig] = []byte(spec.Kubeconfig)
+					updateNeeded = true
+				}
+			}
+		}
+		if updateNeeded {
+			if err := seedClient.Update(ctx, existingSecret); err != nil {
+				return err
+			}
+		}
 	}
 
-	// add secret key selectors to cluster object
-	cluster.Spec.Cloud.Kubevirt.CredentialsReference = &providerconfig.GlobalSecretKeySelector{
-		ObjectReference: corev1.ObjectReference{
-			Name:      secret.Name,
-			Namespace: secret.Namespace,
-		},
+	if valuesDefined {
+		cluster.Spec.Cloud.Kubevirt.Kubeconfig = ""
 	}
-
-	// remove credentials from cluster object
-	cluster.Spec.Cloud.Kubevirt.Kubeconfig = ""
 
 	return nil
 }
 
-func createVSphereSecret(ctx context.Context, seedClient ctrlruntimeclient.Client, cluster *kubermaticv1.Cluster, projectID string) error {
+func createVSphereSecret(ctx context.Context, seedClient ctrlruntimeclient.Client, cluster *kubermaticv1.Cluster) error {
 	spec := cluster.Spec.Cloud.VSphere
 	name := cluster.GetSecretName()
 	secret := &corev1.Secret{
@@ -356,8 +641,7 @@ func createVSphereSecret(ctx context.Context, seedClient ctrlruntimeclient.Clien
 			Name:      name,
 			Namespace: resources.KubermaticNamespace,
 			Labels: map[string]string{
-				kubermaticv1.ProjectIDLabelKey: projectID,
-				"name":                         name,
+				"name": name,
 			},
 		},
 		Type: corev1.SecretTypeOpaque,


### PR DESCRIPTION
**What this PR does / why we need it**:
 - Removes the projectID label during secret creation since that label isn't used anywhere.
 - Adds logic to update credentials in PatchEndpoint.
 - Adds code to create/update credentials for migration. This also changes the migration-related code to use controller-runtime.
 - Adds unit test for credentials for migration.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #4552


```release-note
NONE
```
