### PR TITLE
Improve global settings WebSocket

### DIFF
--- a/api/pkg/handler/routes_v1_websocket.go
+++ b/api/pkg/handler/routes_v1_websocket.go
@@ -46,9 +46,7 @@ func getHandler(writer WebsocketWriter, providers watcher.Providers, routing Rou
 
 		ws, err := upgrader.Upgrade(w, req, nil)
 		if err != nil {
-			if _, ok := err.(websocket.HandshakeError); !ok {
-				log.Logger.Debug(err)
-			}
+			log.Logger.Debug(err)
 			return
 		}
 
@@ -101,11 +99,10 @@ func requestLoggingReader(websocket *websocket.Conn) {
 		}
 	}()
 
-	websocket.SetReadLimit(512)
-
 	for {
 		_, message, err := websocket.ReadMessage()
 		if err != nil {
+			log.Logger.Debug(err)
 			break
 		}
 

--- a/api/pkg/handler/routes_v1_websocket.go
+++ b/api/pkg/handler/routes_v1_websocket.go
@@ -5,7 +5,6 @@ import (
 	"net"
 	"net/http"
 	"net/url"
-	"unicode/utf8"
 
 	"github.com/kubermatic/kubermatic/api/pkg/api/v1"
 	"github.com/kubermatic/kubermatic/api/pkg/handler/auth"
@@ -33,47 +32,21 @@ var upgrader = websocket.Upgrader{
 			return false
 		}
 
-		if equalASCIIFold(u.Host, r.Host) {
+		if u.Host == r.Host {
 			return true
 		}
 
-		// Following checks are custom, the ones above come from gorilla/websocket default check.
-		// The target is to allow all request coming from the same host, no matter from which port.
 		host, _, err := net.SplitHostPort(r.Host)
 		if err != nil {
 			return false
 		}
 
-		if equalASCIIFold(u.Hostname(), host) {
+		if u.Hostname() == host {
 			return true
 		}
 
 		return false
 	},
-}
-
-// equalASCIIFold returns true if s is equal to t with ASCII case folding as
-// defined in RFC 4790. Method is taken from gorilla/websocket.
-func equalASCIIFold(s, t string) bool {
-	for s != "" && t != "" {
-		sr, size := utf8.DecodeRuneInString(s)
-		s = s[size:]
-		tr, size := utf8.DecodeRuneInString(t)
-		t = t[size:]
-		if sr == tr {
-			continue
-		}
-		if 'A' <= sr && sr <= 'Z' {
-			sr = sr + 'a' - 'A'
-		}
-		if 'A' <= tr && tr <= 'Z' {
-			tr = tr + 'a' - 'A'
-		}
-		if sr != tr {
-			return false
-		}
-	}
-	return s == t
 }
 
 type WebsocketWriter func(providers watcher.Providers, ws *websocket.Conn)

--- a/api/pkg/handler/websocket/settings.go
+++ b/api/pkg/handler/websocket/settings.go
@@ -2,6 +2,7 @@ package websocket
 
 import (
 	"encoding/json"
+
 	api "github.com/kubermatic/kubermatic/api/pkg/api/v1"
 	"github.com/kubermatic/kubermatic/api/pkg/crd/kubermatic/v1"
 	"github.com/kubermatic/kubermatic/api/pkg/log"

--- a/api/pkg/handler/websocket/settings.go
+++ b/api/pkg/handler/websocket/settings.go
@@ -2,7 +2,8 @@ package websocket
 
 import (
 	"encoding/json"
-
+	api "github.com/kubermatic/kubermatic/api/pkg/api/v1"
+	"github.com/kubermatic/kubermatic/api/pkg/crd/kubermatic/v1"
 	"github.com/kubermatic/kubermatic/api/pkg/log"
 	"github.com/kubermatic/kubermatic/api/pkg/watcher"
 
@@ -16,7 +17,7 @@ func WriteSettings(providers watcher.Providers, ws *websocket.Conn) {
 		return
 	}
 
-	initialResponse, err := json.Marshal(initialSettings)
+	initialResponse, err := json.Marshal(api.GlobalSettings(initialSettings.Spec))
 	if err != nil {
 		log.Logger.Debug(err)
 		return
@@ -28,10 +29,29 @@ func WriteSettings(providers watcher.Providers, ws *websocket.Conn) {
 	}
 
 	providers.SettingsWatcher.Subscribe(func(settings interface{}) {
-		response, err := json.Marshal(settings)
-		if err != nil {
-			log.Logger.Debug(err)
-			return
+		var response []byte
+		if settings != nil {
+			var externalSettings api.GlobalSettings
+			internalSettings, ok := settings.(*v1.KubermaticSetting)
+			if ok {
+				externalSettings = api.GlobalSettings(internalSettings.Spec)
+			} else {
+				log.Logger.Debug("cannot convert settings: %v", settings)
+			}
+
+			response, err = json.Marshal(externalSettings)
+			if err != nil {
+				log.Logger.Debug(err)
+				return
+			}
+		} else {
+			// Explicitly set null response instead returning defaulted global settings structure.
+			// It allows clients to distinct null response and default or empty global settings structure.
+			response, err = json.Marshal(nil)
+			if err != nil {
+				log.Logger.Debug(err)
+				return
+			}
 		}
 
 		if err := ws.WriteMessage(websocket.TextMessage, response); err != nil {


### PR DESCRIPTION
**What this PR does / why we need it**: 
- Adds keep-alive mechanism for settings watcher. It is required as I have noticed that from time to time it is failing. We need to restart it each time it fails. WebSocket connection will be restarted by the client, so this should be fine.
- Exposes only external objects in the WebSocket.
- Implements `CheckOrigin` method. Used a default method extended by an allowance for requests coming from same host but different port.
- Use combined token extractor to extract auth token from header, cookie or query param. 

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:

**Special notes for your reviewer**:

**Documentation**:
<!-- Add links to the related documentation changes related to this pull request. E.g. the link to the kubermatic/docs pullrequest. -->

**Does this PR introduce a user-facing change?**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If  no release note is required, just write "NONE".
-->
```release-note
NONE
```
