### PR TITLE
update machine-controller to v1.10.2

### DIFF
--- a/api/Gopkg.lock
+++ b/api/Gopkg.lock
@@ -868,8 +868,8 @@
     "pkg/userdata/ubuntu",
   ]
   pruneopts = "NUT"
-  revision = "1be5bfa34fe38142a8df7acd6696df2585fa4761"
-  version = "v1.10.1"
+  revision = "04c3f2ab0fe688858b8ac124ce17cf686cd6d9c7"
+  version = "v1.10.2"
 
 [[projects]]
   digest = "1:0dbba7d4d4f3eeb01acd81af338ff4a3c4b0bb814d87368ea536e616f383240d"

--- a/api/Gopkg.toml
+++ b/api/Gopkg.toml
@@ -121,7 +121,7 @@ required = [
 
 [[constraint]]
   name = "github.com/kubermatic/machine-controller"
-	version = "v1.10.1"
+	version = "v1.10.2"
 
 [[override]]
   name = "sigs.k8s.io/controller-runtime"

--- a/api/pkg/resources/machinecontroller/deployment.go
+++ b/api/pkg/resources/machinecontroller/deployment.go
@@ -37,7 +37,7 @@ var (
 const (
 	Name = "machine-controller"
 
-	tag = "v1.10.1"
+	tag = "v1.10.2"
 
 	NodeLocalDNSCacheAddress = "169.254.20.10"
 )

--- a/api/pkg/resources/test/fixtures/deployment-aws-1.10.0-machine-controller-webhook.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-aws-1.10.0-machine-controller-webhook.yaml
@@ -54,7 +54,7 @@ spec:
           value: apiserver-external.cluster-de-test-01.svc.cluster.local.
         - name: KUBECONFIG
           value: /etc/kubernetes/kubeconfig/kubeconfig
-        image: docker.io/kubermatic/machine-controller:v1.10.1
+        image: docker.io/kubermatic/machine-controller:v1.10.2
         livenessProbe:
           failureThreshold: 8
           httpGet:

--- a/api/pkg/resources/test/fixtures/deployment-aws-1.10.0-machine-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-aws-1.10.0-machine-controller.yaml
@@ -57,7 +57,7 @@ spec:
           value: apiserver-external.cluster-de-test-01.svc.cluster.local.
         - name: KUBECONFIG
           value: /etc/kubernetes/kubeconfig/kubeconfig
-        image: docker.io/kubermatic/machine-controller:v1.10.1
+        image: docker.io/kubermatic/machine-controller:v1.10.2
         livenessProbe:
           failureThreshold: 3
           httpGet:

--- a/api/pkg/resources/test/fixtures/deployment-aws-1.10.6-machine-controller-webhook.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-aws-1.10.6-machine-controller-webhook.yaml
@@ -54,7 +54,7 @@ spec:
           value: apiserver-external.cluster-de-test-01.svc.cluster.local.
         - name: KUBECONFIG
           value: /etc/kubernetes/kubeconfig/kubeconfig
-        image: docker.io/kubermatic/machine-controller:v1.10.1
+        image: docker.io/kubermatic/machine-controller:v1.10.2
         livenessProbe:
           failureThreshold: 8
           httpGet:

--- a/api/pkg/resources/test/fixtures/deployment-aws-1.10.6-machine-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-aws-1.10.6-machine-controller.yaml
@@ -57,7 +57,7 @@ spec:
           value: apiserver-external.cluster-de-test-01.svc.cluster.local.
         - name: KUBECONFIG
           value: /etc/kubernetes/kubeconfig/kubeconfig
-        image: docker.io/kubermatic/machine-controller:v1.10.1
+        image: docker.io/kubermatic/machine-controller:v1.10.2
         livenessProbe:
           failureThreshold: 3
           httpGet:

--- a/api/pkg/resources/test/fixtures/deployment-aws-1.11.0-machine-controller-webhook.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-aws-1.11.0-machine-controller-webhook.yaml
@@ -54,7 +54,7 @@ spec:
           value: apiserver-external.cluster-de-test-01.svc.cluster.local.
         - name: KUBECONFIG
           value: /etc/kubernetes/kubeconfig/kubeconfig
-        image: docker.io/kubermatic/machine-controller:v1.10.1
+        image: docker.io/kubermatic/machine-controller:v1.10.2
         livenessProbe:
           failureThreshold: 8
           httpGet:

--- a/api/pkg/resources/test/fixtures/deployment-aws-1.11.0-machine-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-aws-1.11.0-machine-controller.yaml
@@ -57,7 +57,7 @@ spec:
           value: apiserver-external.cluster-de-test-01.svc.cluster.local.
         - name: KUBECONFIG
           value: /etc/kubernetes/kubeconfig/kubeconfig
-        image: docker.io/kubermatic/machine-controller:v1.10.1
+        image: docker.io/kubermatic/machine-controller:v1.10.2
         livenessProbe:
           failureThreshold: 3
           httpGet:

--- a/api/pkg/resources/test/fixtures/deployment-aws-1.11.1-machine-controller-webhook.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-aws-1.11.1-machine-controller-webhook.yaml
@@ -54,7 +54,7 @@ spec:
           value: apiserver-external.cluster-de-test-01.svc.cluster.local.
         - name: KUBECONFIG
           value: /etc/kubernetes/kubeconfig/kubeconfig
-        image: docker.io/kubermatic/machine-controller:v1.10.1
+        image: docker.io/kubermatic/machine-controller:v1.10.2
         livenessProbe:
           failureThreshold: 8
           httpGet:

--- a/api/pkg/resources/test/fixtures/deployment-aws-1.11.1-machine-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-aws-1.11.1-machine-controller.yaml
@@ -57,7 +57,7 @@ spec:
           value: apiserver-external.cluster-de-test-01.svc.cluster.local.
         - name: KUBECONFIG
           value: /etc/kubernetes/kubeconfig/kubeconfig
-        image: docker.io/kubermatic/machine-controller:v1.10.1
+        image: docker.io/kubermatic/machine-controller:v1.10.2
         livenessProbe:
           failureThreshold: 3
           httpGet:

--- a/api/pkg/resources/test/fixtures/deployment-aws-1.12.0-machine-controller-webhook.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-aws-1.12.0-machine-controller-webhook.yaml
@@ -54,7 +54,7 @@ spec:
           value: apiserver-external.cluster-de-test-01.svc.cluster.local.
         - name: KUBECONFIG
           value: /etc/kubernetes/kubeconfig/kubeconfig
-        image: docker.io/kubermatic/machine-controller:v1.10.1
+        image: docker.io/kubermatic/machine-controller:v1.10.2
         livenessProbe:
           failureThreshold: 8
           httpGet:

--- a/api/pkg/resources/test/fixtures/deployment-aws-1.12.0-machine-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-aws-1.12.0-machine-controller.yaml
@@ -57,7 +57,7 @@ spec:
           value: apiserver-external.cluster-de-test-01.svc.cluster.local.
         - name: KUBECONFIG
           value: /etc/kubernetes/kubeconfig/kubeconfig
-        image: docker.io/kubermatic/machine-controller:v1.10.1
+        image: docker.io/kubermatic/machine-controller:v1.10.2
         livenessProbe:
           failureThreshold: 3
           httpGet:

--- a/api/pkg/resources/test/fixtures/deployment-aws-1.13.0-machine-controller-webhook.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-aws-1.13.0-machine-controller-webhook.yaml
@@ -54,7 +54,7 @@ spec:
           value: apiserver-external.cluster-de-test-01.svc.cluster.local.
         - name: KUBECONFIG
           value: /etc/kubernetes/kubeconfig/kubeconfig
-        image: docker.io/kubermatic/machine-controller:v1.10.1
+        image: docker.io/kubermatic/machine-controller:v1.10.2
         livenessProbe:
           failureThreshold: 8
           httpGet:

--- a/api/pkg/resources/test/fixtures/deployment-aws-1.13.0-machine-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-aws-1.13.0-machine-controller.yaml
@@ -57,7 +57,7 @@ spec:
           value: apiserver-external.cluster-de-test-01.svc.cluster.local.
         - name: KUBECONFIG
           value: /etc/kubernetes/kubeconfig/kubeconfig
-        image: docker.io/kubermatic/machine-controller:v1.10.1
+        image: docker.io/kubermatic/machine-controller:v1.10.2
         livenessProbe:
           failureThreshold: 3
           httpGet:

--- a/api/pkg/resources/test/fixtures/deployment-azure-1.10.0-machine-controller-webhook.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-azure-1.10.0-machine-controller-webhook.yaml
@@ -58,7 +58,7 @@ spec:
           value: apiserver-external.cluster-de-test-01.svc.cluster.local.
         - name: KUBECONFIG
           value: /etc/kubernetes/kubeconfig/kubeconfig
-        image: docker.io/kubermatic/machine-controller:v1.10.1
+        image: docker.io/kubermatic/machine-controller:v1.10.2
         livenessProbe:
           failureThreshold: 8
           httpGet:

--- a/api/pkg/resources/test/fixtures/deployment-azure-1.10.0-machine-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-azure-1.10.0-machine-controller.yaml
@@ -61,7 +61,7 @@ spec:
           value: apiserver-external.cluster-de-test-01.svc.cluster.local.
         - name: KUBECONFIG
           value: /etc/kubernetes/kubeconfig/kubeconfig
-        image: docker.io/kubermatic/machine-controller:v1.10.1
+        image: docker.io/kubermatic/machine-controller:v1.10.2
         livenessProbe:
           failureThreshold: 3
           httpGet:

--- a/api/pkg/resources/test/fixtures/deployment-azure-1.10.6-machine-controller-webhook.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-azure-1.10.6-machine-controller-webhook.yaml
@@ -58,7 +58,7 @@ spec:
           value: apiserver-external.cluster-de-test-01.svc.cluster.local.
         - name: KUBECONFIG
           value: /etc/kubernetes/kubeconfig/kubeconfig
-        image: docker.io/kubermatic/machine-controller:v1.10.1
+        image: docker.io/kubermatic/machine-controller:v1.10.2
         livenessProbe:
           failureThreshold: 8
           httpGet:

--- a/api/pkg/resources/test/fixtures/deployment-azure-1.10.6-machine-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-azure-1.10.6-machine-controller.yaml
@@ -61,7 +61,7 @@ spec:
           value: apiserver-external.cluster-de-test-01.svc.cluster.local.
         - name: KUBECONFIG
           value: /etc/kubernetes/kubeconfig/kubeconfig
-        image: docker.io/kubermatic/machine-controller:v1.10.1
+        image: docker.io/kubermatic/machine-controller:v1.10.2
         livenessProbe:
           failureThreshold: 3
           httpGet:

--- a/api/pkg/resources/test/fixtures/deployment-azure-1.11.0-machine-controller-webhook.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-azure-1.11.0-machine-controller-webhook.yaml
@@ -58,7 +58,7 @@ spec:
           value: apiserver-external.cluster-de-test-01.svc.cluster.local.
         - name: KUBECONFIG
           value: /etc/kubernetes/kubeconfig/kubeconfig
-        image: docker.io/kubermatic/machine-controller:v1.10.1
+        image: docker.io/kubermatic/machine-controller:v1.10.2
         livenessProbe:
           failureThreshold: 8
           httpGet:

--- a/api/pkg/resources/test/fixtures/deployment-azure-1.11.0-machine-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-azure-1.11.0-machine-controller.yaml
@@ -61,7 +61,7 @@ spec:
           value: apiserver-external.cluster-de-test-01.svc.cluster.local.
         - name: KUBECONFIG
           value: /etc/kubernetes/kubeconfig/kubeconfig
-        image: docker.io/kubermatic/machine-controller:v1.10.1
+        image: docker.io/kubermatic/machine-controller:v1.10.2
         livenessProbe:
           failureThreshold: 3
           httpGet:

--- a/api/pkg/resources/test/fixtures/deployment-azure-1.11.1-machine-controller-webhook.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-azure-1.11.1-machine-controller-webhook.yaml
@@ -58,7 +58,7 @@ spec:
           value: apiserver-external.cluster-de-test-01.svc.cluster.local.
         - name: KUBECONFIG
           value: /etc/kubernetes/kubeconfig/kubeconfig
-        image: docker.io/kubermatic/machine-controller:v1.10.1
+        image: docker.io/kubermatic/machine-controller:v1.10.2
         livenessProbe:
           failureThreshold: 8
           httpGet:

--- a/api/pkg/resources/test/fixtures/deployment-azure-1.11.1-machine-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-azure-1.11.1-machine-controller.yaml
@@ -61,7 +61,7 @@ spec:
           value: apiserver-external.cluster-de-test-01.svc.cluster.local.
         - name: KUBECONFIG
           value: /etc/kubernetes/kubeconfig/kubeconfig
-        image: docker.io/kubermatic/machine-controller:v1.10.1
+        image: docker.io/kubermatic/machine-controller:v1.10.2
         livenessProbe:
           failureThreshold: 3
           httpGet:

--- a/api/pkg/resources/test/fixtures/deployment-azure-1.12.0-machine-controller-webhook.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-azure-1.12.0-machine-controller-webhook.yaml
@@ -58,7 +58,7 @@ spec:
           value: apiserver-external.cluster-de-test-01.svc.cluster.local.
         - name: KUBECONFIG
           value: /etc/kubernetes/kubeconfig/kubeconfig
-        image: docker.io/kubermatic/machine-controller:v1.10.1
+        image: docker.io/kubermatic/machine-controller:v1.10.2
         livenessProbe:
           failureThreshold: 8
           httpGet:

--- a/api/pkg/resources/test/fixtures/deployment-azure-1.12.0-machine-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-azure-1.12.0-machine-controller.yaml
@@ -61,7 +61,7 @@ spec:
           value: apiserver-external.cluster-de-test-01.svc.cluster.local.
         - name: KUBECONFIG
           value: /etc/kubernetes/kubeconfig/kubeconfig
-        image: docker.io/kubermatic/machine-controller:v1.10.1
+        image: docker.io/kubermatic/machine-controller:v1.10.2
         livenessProbe:
           failureThreshold: 3
           httpGet:

--- a/api/pkg/resources/test/fixtures/deployment-azure-1.13.0-machine-controller-webhook.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-azure-1.13.0-machine-controller-webhook.yaml
@@ -58,7 +58,7 @@ spec:
           value: apiserver-external.cluster-de-test-01.svc.cluster.local.
         - name: KUBECONFIG
           value: /etc/kubernetes/kubeconfig/kubeconfig
-        image: docker.io/kubermatic/machine-controller:v1.10.1
+        image: docker.io/kubermatic/machine-controller:v1.10.2
         livenessProbe:
           failureThreshold: 8
           httpGet:

--- a/api/pkg/resources/test/fixtures/deployment-azure-1.13.0-machine-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-azure-1.13.0-machine-controller.yaml
@@ -61,7 +61,7 @@ spec:
           value: apiserver-external.cluster-de-test-01.svc.cluster.local.
         - name: KUBECONFIG
           value: /etc/kubernetes/kubeconfig/kubeconfig
-        image: docker.io/kubermatic/machine-controller:v1.10.1
+        image: docker.io/kubermatic/machine-controller:v1.10.2
         livenessProbe:
           failureThreshold: 3
           httpGet:

--- a/api/pkg/resources/test/fixtures/deployment-bringyourown-1.10.0-machine-controller-webhook.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-bringyourown-1.10.0-machine-controller-webhook.yaml
@@ -50,7 +50,7 @@ spec:
           value: apiserver-external.cluster-de-test-01.svc.cluster.local.
         - name: KUBECONFIG
           value: /etc/kubernetes/kubeconfig/kubeconfig
-        image: docker.io/kubermatic/machine-controller:v1.10.1
+        image: docker.io/kubermatic/machine-controller:v1.10.2
         livenessProbe:
           failureThreshold: 8
           httpGet:

--- a/api/pkg/resources/test/fixtures/deployment-bringyourown-1.10.0-machine-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-bringyourown-1.10.0-machine-controller.yaml
@@ -53,7 +53,7 @@ spec:
           value: apiserver-external.cluster-de-test-01.svc.cluster.local.
         - name: KUBECONFIG
           value: /etc/kubernetes/kubeconfig/kubeconfig
-        image: docker.io/kubermatic/machine-controller:v1.10.1
+        image: docker.io/kubermatic/machine-controller:v1.10.2
         livenessProbe:
           failureThreshold: 3
           httpGet:

--- a/api/pkg/resources/test/fixtures/deployment-bringyourown-1.10.6-machine-controller-webhook.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-bringyourown-1.10.6-machine-controller-webhook.yaml
@@ -50,7 +50,7 @@ spec:
           value: apiserver-external.cluster-de-test-01.svc.cluster.local.
         - name: KUBECONFIG
           value: /etc/kubernetes/kubeconfig/kubeconfig
-        image: docker.io/kubermatic/machine-controller:v1.10.1
+        image: docker.io/kubermatic/machine-controller:v1.10.2
         livenessProbe:
           failureThreshold: 8
           httpGet:

--- a/api/pkg/resources/test/fixtures/deployment-bringyourown-1.10.6-machine-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-bringyourown-1.10.6-machine-controller.yaml
@@ -53,7 +53,7 @@ spec:
           value: apiserver-external.cluster-de-test-01.svc.cluster.local.
         - name: KUBECONFIG
           value: /etc/kubernetes/kubeconfig/kubeconfig
-        image: docker.io/kubermatic/machine-controller:v1.10.1
+        image: docker.io/kubermatic/machine-controller:v1.10.2
         livenessProbe:
           failureThreshold: 3
           httpGet:

--- a/api/pkg/resources/test/fixtures/deployment-bringyourown-1.11.0-machine-controller-webhook.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-bringyourown-1.11.0-machine-controller-webhook.yaml
@@ -50,7 +50,7 @@ spec:
           value: apiserver-external.cluster-de-test-01.svc.cluster.local.
         - name: KUBECONFIG
           value: /etc/kubernetes/kubeconfig/kubeconfig
-        image: docker.io/kubermatic/machine-controller:v1.10.1
+        image: docker.io/kubermatic/machine-controller:v1.10.2
         livenessProbe:
           failureThreshold: 8
           httpGet:

--- a/api/pkg/resources/test/fixtures/deployment-bringyourown-1.11.0-machine-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-bringyourown-1.11.0-machine-controller.yaml
@@ -53,7 +53,7 @@ spec:
           value: apiserver-external.cluster-de-test-01.svc.cluster.local.
         - name: KUBECONFIG
           value: /etc/kubernetes/kubeconfig/kubeconfig
-        image: docker.io/kubermatic/machine-controller:v1.10.1
+        image: docker.io/kubermatic/machine-controller:v1.10.2
         livenessProbe:
           failureThreshold: 3
           httpGet:

--- a/api/pkg/resources/test/fixtures/deployment-bringyourown-1.11.1-machine-controller-webhook.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-bringyourown-1.11.1-machine-controller-webhook.yaml
@@ -50,7 +50,7 @@ spec:
           value: apiserver-external.cluster-de-test-01.svc.cluster.local.
         - name: KUBECONFIG
           value: /etc/kubernetes/kubeconfig/kubeconfig
-        image: docker.io/kubermatic/machine-controller:v1.10.1
+        image: docker.io/kubermatic/machine-controller:v1.10.2
         livenessProbe:
           failureThreshold: 8
           httpGet:

--- a/api/pkg/resources/test/fixtures/deployment-bringyourown-1.11.1-machine-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-bringyourown-1.11.1-machine-controller.yaml
@@ -53,7 +53,7 @@ spec:
           value: apiserver-external.cluster-de-test-01.svc.cluster.local.
         - name: KUBECONFIG
           value: /etc/kubernetes/kubeconfig/kubeconfig
-        image: docker.io/kubermatic/machine-controller:v1.10.1
+        image: docker.io/kubermatic/machine-controller:v1.10.2
         livenessProbe:
           failureThreshold: 3
           httpGet:

--- a/api/pkg/resources/test/fixtures/deployment-bringyourown-1.12.0-machine-controller-webhook.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-bringyourown-1.12.0-machine-controller-webhook.yaml
@@ -50,7 +50,7 @@ spec:
           value: apiserver-external.cluster-de-test-01.svc.cluster.local.
         - name: KUBECONFIG
           value: /etc/kubernetes/kubeconfig/kubeconfig
-        image: docker.io/kubermatic/machine-controller:v1.10.1
+        image: docker.io/kubermatic/machine-controller:v1.10.2
         livenessProbe:
           failureThreshold: 8
           httpGet:

--- a/api/pkg/resources/test/fixtures/deployment-bringyourown-1.12.0-machine-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-bringyourown-1.12.0-machine-controller.yaml
@@ -53,7 +53,7 @@ spec:
           value: apiserver-external.cluster-de-test-01.svc.cluster.local.
         - name: KUBECONFIG
           value: /etc/kubernetes/kubeconfig/kubeconfig
-        image: docker.io/kubermatic/machine-controller:v1.10.1
+        image: docker.io/kubermatic/machine-controller:v1.10.2
         livenessProbe:
           failureThreshold: 3
           httpGet:

--- a/api/pkg/resources/test/fixtures/deployment-bringyourown-1.13.0-machine-controller-webhook.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-bringyourown-1.13.0-machine-controller-webhook.yaml
@@ -50,7 +50,7 @@ spec:
           value: apiserver-external.cluster-de-test-01.svc.cluster.local.
         - name: KUBECONFIG
           value: /etc/kubernetes/kubeconfig/kubeconfig
-        image: docker.io/kubermatic/machine-controller:v1.10.1
+        image: docker.io/kubermatic/machine-controller:v1.10.2
         livenessProbe:
           failureThreshold: 8
           httpGet:

--- a/api/pkg/resources/test/fixtures/deployment-bringyourown-1.13.0-machine-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-bringyourown-1.13.0-machine-controller.yaml
@@ -53,7 +53,7 @@ spec:
           value: apiserver-external.cluster-de-test-01.svc.cluster.local.
         - name: KUBECONFIG
           value: /etc/kubernetes/kubeconfig/kubeconfig
-        image: docker.io/kubermatic/machine-controller:v1.10.1
+        image: docker.io/kubermatic/machine-controller:v1.10.2
         livenessProbe:
           failureThreshold: 3
           httpGet:

--- a/api/pkg/resources/test/fixtures/deployment-digitalocean-1.10.0-machine-controller-webhook.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-digitalocean-1.10.0-machine-controller-webhook.yaml
@@ -52,7 +52,7 @@ spec:
           value: apiserver-external.cluster-de-test-01.svc.cluster.local.
         - name: KUBECONFIG
           value: /etc/kubernetes/kubeconfig/kubeconfig
-        image: docker.io/kubermatic/machine-controller:v1.10.1
+        image: docker.io/kubermatic/machine-controller:v1.10.2
         livenessProbe:
           failureThreshold: 8
           httpGet:

--- a/api/pkg/resources/test/fixtures/deployment-digitalocean-1.10.0-machine-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-digitalocean-1.10.0-machine-controller.yaml
@@ -55,7 +55,7 @@ spec:
           value: apiserver-external.cluster-de-test-01.svc.cluster.local.
         - name: KUBECONFIG
           value: /etc/kubernetes/kubeconfig/kubeconfig
-        image: docker.io/kubermatic/machine-controller:v1.10.1
+        image: docker.io/kubermatic/machine-controller:v1.10.2
         livenessProbe:
           failureThreshold: 3
           httpGet:

--- a/api/pkg/resources/test/fixtures/deployment-digitalocean-1.10.6-machine-controller-webhook.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-digitalocean-1.10.6-machine-controller-webhook.yaml
@@ -52,7 +52,7 @@ spec:
           value: apiserver-external.cluster-de-test-01.svc.cluster.local.
         - name: KUBECONFIG
           value: /etc/kubernetes/kubeconfig/kubeconfig
-        image: docker.io/kubermatic/machine-controller:v1.10.1
+        image: docker.io/kubermatic/machine-controller:v1.10.2
         livenessProbe:
           failureThreshold: 8
           httpGet:

--- a/api/pkg/resources/test/fixtures/deployment-digitalocean-1.10.6-machine-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-digitalocean-1.10.6-machine-controller.yaml
@@ -55,7 +55,7 @@ spec:
           value: apiserver-external.cluster-de-test-01.svc.cluster.local.
         - name: KUBECONFIG
           value: /etc/kubernetes/kubeconfig/kubeconfig
-        image: docker.io/kubermatic/machine-controller:v1.10.1
+        image: docker.io/kubermatic/machine-controller:v1.10.2
         livenessProbe:
           failureThreshold: 3
           httpGet:

--- a/api/pkg/resources/test/fixtures/deployment-digitalocean-1.11.0-machine-controller-webhook.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-digitalocean-1.11.0-machine-controller-webhook.yaml
@@ -52,7 +52,7 @@ spec:
           value: apiserver-external.cluster-de-test-01.svc.cluster.local.
         - name: KUBECONFIG
           value: /etc/kubernetes/kubeconfig/kubeconfig
-        image: docker.io/kubermatic/machine-controller:v1.10.1
+        image: docker.io/kubermatic/machine-controller:v1.10.2
         livenessProbe:
           failureThreshold: 8
           httpGet:

--- a/api/pkg/resources/test/fixtures/deployment-digitalocean-1.11.0-machine-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-digitalocean-1.11.0-machine-controller.yaml
@@ -55,7 +55,7 @@ spec:
           value: apiserver-external.cluster-de-test-01.svc.cluster.local.
         - name: KUBECONFIG
           value: /etc/kubernetes/kubeconfig/kubeconfig
-        image: docker.io/kubermatic/machine-controller:v1.10.1
+        image: docker.io/kubermatic/machine-controller:v1.10.2
         livenessProbe:
           failureThreshold: 3
           httpGet:

--- a/api/pkg/resources/test/fixtures/deployment-digitalocean-1.11.1-machine-controller-webhook.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-digitalocean-1.11.1-machine-controller-webhook.yaml
@@ -52,7 +52,7 @@ spec:
           value: apiserver-external.cluster-de-test-01.svc.cluster.local.
         - name: KUBECONFIG
           value: /etc/kubernetes/kubeconfig/kubeconfig
-        image: docker.io/kubermatic/machine-controller:v1.10.1
+        image: docker.io/kubermatic/machine-controller:v1.10.2
         livenessProbe:
           failureThreshold: 8
           httpGet:

--- a/api/pkg/resources/test/fixtures/deployment-digitalocean-1.11.1-machine-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-digitalocean-1.11.1-machine-controller.yaml
@@ -55,7 +55,7 @@ spec:
           value: apiserver-external.cluster-de-test-01.svc.cluster.local.
         - name: KUBECONFIG
           value: /etc/kubernetes/kubeconfig/kubeconfig
-        image: docker.io/kubermatic/machine-controller:v1.10.1
+        image: docker.io/kubermatic/machine-controller:v1.10.2
         livenessProbe:
           failureThreshold: 3
           httpGet:

--- a/api/pkg/resources/test/fixtures/deployment-digitalocean-1.12.0-machine-controller-webhook.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-digitalocean-1.12.0-machine-controller-webhook.yaml
@@ -52,7 +52,7 @@ spec:
           value: apiserver-external.cluster-de-test-01.svc.cluster.local.
         - name: KUBECONFIG
           value: /etc/kubernetes/kubeconfig/kubeconfig
-        image: docker.io/kubermatic/machine-controller:v1.10.1
+        image: docker.io/kubermatic/machine-controller:v1.10.2
         livenessProbe:
           failureThreshold: 8
           httpGet:

--- a/api/pkg/resources/test/fixtures/deployment-digitalocean-1.12.0-machine-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-digitalocean-1.12.0-machine-controller.yaml
@@ -55,7 +55,7 @@ spec:
           value: apiserver-external.cluster-de-test-01.svc.cluster.local.
         - name: KUBECONFIG
           value: /etc/kubernetes/kubeconfig/kubeconfig
-        image: docker.io/kubermatic/machine-controller:v1.10.1
+        image: docker.io/kubermatic/machine-controller:v1.10.2
         livenessProbe:
           failureThreshold: 3
           httpGet:

--- a/api/pkg/resources/test/fixtures/deployment-digitalocean-1.13.0-machine-controller-webhook.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-digitalocean-1.13.0-machine-controller-webhook.yaml
@@ -52,7 +52,7 @@ spec:
           value: apiserver-external.cluster-de-test-01.svc.cluster.local.
         - name: KUBECONFIG
           value: /etc/kubernetes/kubeconfig/kubeconfig
-        image: docker.io/kubermatic/machine-controller:v1.10.1
+        image: docker.io/kubermatic/machine-controller:v1.10.2
         livenessProbe:
           failureThreshold: 8
           httpGet:

--- a/api/pkg/resources/test/fixtures/deployment-digitalocean-1.13.0-machine-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-digitalocean-1.13.0-machine-controller.yaml
@@ -55,7 +55,7 @@ spec:
           value: apiserver-external.cluster-de-test-01.svc.cluster.local.
         - name: KUBECONFIG
           value: /etc/kubernetes/kubeconfig/kubeconfig
-        image: docker.io/kubermatic/machine-controller:v1.10.1
+        image: docker.io/kubermatic/machine-controller:v1.10.2
         livenessProbe:
           failureThreshold: 3
           httpGet:

--- a/api/pkg/resources/test/fixtures/deployment-openstack-1.10.0-machine-controller-webhook.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-openstack-1.10.0-machine-controller-webhook.yaml
@@ -61,7 +61,7 @@ spec:
           value: apiserver-external.cluster-de-test-01.svc.cluster.local.
         - name: KUBECONFIG
           value: /etc/kubernetes/kubeconfig/kubeconfig
-        image: docker.io/kubermatic/machine-controller:v1.10.1
+        image: docker.io/kubermatic/machine-controller:v1.10.2
         livenessProbe:
           failureThreshold: 8
           httpGet:

--- a/api/pkg/resources/test/fixtures/deployment-openstack-1.10.0-machine-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-openstack-1.10.0-machine-controller.yaml
@@ -64,7 +64,7 @@ spec:
           value: apiserver-external.cluster-de-test-01.svc.cluster.local.
         - name: KUBECONFIG
           value: /etc/kubernetes/kubeconfig/kubeconfig
-        image: docker.io/kubermatic/machine-controller:v1.10.1
+        image: docker.io/kubermatic/machine-controller:v1.10.2
         livenessProbe:
           failureThreshold: 3
           httpGet:

--- a/api/pkg/resources/test/fixtures/deployment-openstack-1.10.6-machine-controller-webhook.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-openstack-1.10.6-machine-controller-webhook.yaml
@@ -61,7 +61,7 @@ spec:
           value: apiserver-external.cluster-de-test-01.svc.cluster.local.
         - name: KUBECONFIG
           value: /etc/kubernetes/kubeconfig/kubeconfig
-        image: docker.io/kubermatic/machine-controller:v1.10.1
+        image: docker.io/kubermatic/machine-controller:v1.10.2
         livenessProbe:
           failureThreshold: 8
           httpGet:

--- a/api/pkg/resources/test/fixtures/deployment-openstack-1.10.6-machine-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-openstack-1.10.6-machine-controller.yaml
@@ -64,7 +64,7 @@ spec:
           value: apiserver-external.cluster-de-test-01.svc.cluster.local.
         - name: KUBECONFIG
           value: /etc/kubernetes/kubeconfig/kubeconfig
-        image: docker.io/kubermatic/machine-controller:v1.10.1
+        image: docker.io/kubermatic/machine-controller:v1.10.2
         livenessProbe:
           failureThreshold: 3
           httpGet:

--- a/api/pkg/resources/test/fixtures/deployment-openstack-1.11.0-machine-controller-webhook.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-openstack-1.11.0-machine-controller-webhook.yaml
@@ -61,7 +61,7 @@ spec:
           value: apiserver-external.cluster-de-test-01.svc.cluster.local.
         - name: KUBECONFIG
           value: /etc/kubernetes/kubeconfig/kubeconfig
-        image: docker.io/kubermatic/machine-controller:v1.10.1
+        image: docker.io/kubermatic/machine-controller:v1.10.2
         livenessProbe:
           failureThreshold: 8
           httpGet:

--- a/api/pkg/resources/test/fixtures/deployment-openstack-1.11.0-machine-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-openstack-1.11.0-machine-controller.yaml
@@ -64,7 +64,7 @@ spec:
           value: apiserver-external.cluster-de-test-01.svc.cluster.local.
         - name: KUBECONFIG
           value: /etc/kubernetes/kubeconfig/kubeconfig
-        image: docker.io/kubermatic/machine-controller:v1.10.1
+        image: docker.io/kubermatic/machine-controller:v1.10.2
         livenessProbe:
           failureThreshold: 3
           httpGet:

--- a/api/pkg/resources/test/fixtures/deployment-openstack-1.11.1-machine-controller-webhook.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-openstack-1.11.1-machine-controller-webhook.yaml
@@ -61,7 +61,7 @@ spec:
           value: apiserver-external.cluster-de-test-01.svc.cluster.local.
         - name: KUBECONFIG
           value: /etc/kubernetes/kubeconfig/kubeconfig
-        image: docker.io/kubermatic/machine-controller:v1.10.1
+        image: docker.io/kubermatic/machine-controller:v1.10.2
         livenessProbe:
           failureThreshold: 8
           httpGet:

--- a/api/pkg/resources/test/fixtures/deployment-openstack-1.11.1-machine-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-openstack-1.11.1-machine-controller.yaml
@@ -64,7 +64,7 @@ spec:
           value: apiserver-external.cluster-de-test-01.svc.cluster.local.
         - name: KUBECONFIG
           value: /etc/kubernetes/kubeconfig/kubeconfig
-        image: docker.io/kubermatic/machine-controller:v1.10.1
+        image: docker.io/kubermatic/machine-controller:v1.10.2
         livenessProbe:
           failureThreshold: 3
           httpGet:

--- a/api/pkg/resources/test/fixtures/deployment-openstack-1.12.0-machine-controller-webhook.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-openstack-1.12.0-machine-controller-webhook.yaml
@@ -61,7 +61,7 @@ spec:
           value: apiserver-external.cluster-de-test-01.svc.cluster.local.
         - name: KUBECONFIG
           value: /etc/kubernetes/kubeconfig/kubeconfig
-        image: docker.io/kubermatic/machine-controller:v1.10.1
+        image: docker.io/kubermatic/machine-controller:v1.10.2
         livenessProbe:
           failureThreshold: 8
           httpGet:

--- a/api/pkg/resources/test/fixtures/deployment-openstack-1.12.0-machine-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-openstack-1.12.0-machine-controller.yaml
@@ -64,7 +64,7 @@ spec:
           value: apiserver-external.cluster-de-test-01.svc.cluster.local.
         - name: KUBECONFIG
           value: /etc/kubernetes/kubeconfig/kubeconfig
-        image: docker.io/kubermatic/machine-controller:v1.10.1
+        image: docker.io/kubermatic/machine-controller:v1.10.2
         livenessProbe:
           failureThreshold: 3
           httpGet:

--- a/api/pkg/resources/test/fixtures/deployment-openstack-1.13.0-machine-controller-webhook.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-openstack-1.13.0-machine-controller-webhook.yaml
@@ -61,7 +61,7 @@ spec:
           value: apiserver-external.cluster-de-test-01.svc.cluster.local.
         - name: KUBECONFIG
           value: /etc/kubernetes/kubeconfig/kubeconfig
-        image: docker.io/kubermatic/machine-controller:v1.10.1
+        image: docker.io/kubermatic/machine-controller:v1.10.2
         livenessProbe:
           failureThreshold: 8
           httpGet:

--- a/api/pkg/resources/test/fixtures/deployment-openstack-1.13.0-machine-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-openstack-1.13.0-machine-controller.yaml
@@ -64,7 +64,7 @@ spec:
           value: apiserver-external.cluster-de-test-01.svc.cluster.local.
         - name: KUBECONFIG
           value: /etc/kubernetes/kubeconfig/kubeconfig
-        image: docker.io/kubermatic/machine-controller:v1.10.1
+        image: docker.io/kubermatic/machine-controller:v1.10.2
         livenessProbe:
           failureThreshold: 3
           httpGet:

--- a/api/pkg/resources/test/fixtures/deployment-vsphere-1.10.0-machine-controller-webhook.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-vsphere-1.10.0-machine-controller-webhook.yaml
@@ -56,7 +56,7 @@ spec:
           value: apiserver-external.cluster-de-test-01.svc.cluster.local.
         - name: KUBECONFIG
           value: /etc/kubernetes/kubeconfig/kubeconfig
-        image: docker.io/kubermatic/machine-controller:v1.10.1
+        image: docker.io/kubermatic/machine-controller:v1.10.2
         livenessProbe:
           failureThreshold: 8
           httpGet:

--- a/api/pkg/resources/test/fixtures/deployment-vsphere-1.10.0-machine-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-vsphere-1.10.0-machine-controller.yaml
@@ -59,7 +59,7 @@ spec:
           value: apiserver-external.cluster-de-test-01.svc.cluster.local.
         - name: KUBECONFIG
           value: /etc/kubernetes/kubeconfig/kubeconfig
-        image: docker.io/kubermatic/machine-controller:v1.10.1
+        image: docker.io/kubermatic/machine-controller:v1.10.2
         livenessProbe:
           failureThreshold: 3
           httpGet:

--- a/api/pkg/resources/test/fixtures/deployment-vsphere-1.10.6-machine-controller-webhook.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-vsphere-1.10.6-machine-controller-webhook.yaml
@@ -56,7 +56,7 @@ spec:
           value: apiserver-external.cluster-de-test-01.svc.cluster.local.
         - name: KUBECONFIG
           value: /etc/kubernetes/kubeconfig/kubeconfig
-        image: docker.io/kubermatic/machine-controller:v1.10.1
+        image: docker.io/kubermatic/machine-controller:v1.10.2
         livenessProbe:
           failureThreshold: 8
           httpGet:

--- a/api/pkg/resources/test/fixtures/deployment-vsphere-1.10.6-machine-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-vsphere-1.10.6-machine-controller.yaml
@@ -59,7 +59,7 @@ spec:
           value: apiserver-external.cluster-de-test-01.svc.cluster.local.
         - name: KUBECONFIG
           value: /etc/kubernetes/kubeconfig/kubeconfig
-        image: docker.io/kubermatic/machine-controller:v1.10.1
+        image: docker.io/kubermatic/machine-controller:v1.10.2
         livenessProbe:
           failureThreshold: 3
           httpGet:

--- a/api/pkg/resources/test/fixtures/deployment-vsphere-1.11.0-machine-controller-webhook.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-vsphere-1.11.0-machine-controller-webhook.yaml
@@ -56,7 +56,7 @@ spec:
           value: apiserver-external.cluster-de-test-01.svc.cluster.local.
         - name: KUBECONFIG
           value: /etc/kubernetes/kubeconfig/kubeconfig
-        image: docker.io/kubermatic/machine-controller:v1.10.1
+        image: docker.io/kubermatic/machine-controller:v1.10.2
         livenessProbe:
           failureThreshold: 8
           httpGet:

--- a/api/pkg/resources/test/fixtures/deployment-vsphere-1.11.0-machine-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-vsphere-1.11.0-machine-controller.yaml
@@ -59,7 +59,7 @@ spec:
           value: apiserver-external.cluster-de-test-01.svc.cluster.local.
         - name: KUBECONFIG
           value: /etc/kubernetes/kubeconfig/kubeconfig
-        image: docker.io/kubermatic/machine-controller:v1.10.1
+        image: docker.io/kubermatic/machine-controller:v1.10.2
         livenessProbe:
           failureThreshold: 3
           httpGet:

--- a/api/pkg/resources/test/fixtures/deployment-vsphere-1.11.1-machine-controller-webhook.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-vsphere-1.11.1-machine-controller-webhook.yaml
@@ -56,7 +56,7 @@ spec:
           value: apiserver-external.cluster-de-test-01.svc.cluster.local.
         - name: KUBECONFIG
           value: /etc/kubernetes/kubeconfig/kubeconfig
-        image: docker.io/kubermatic/machine-controller:v1.10.1
+        image: docker.io/kubermatic/machine-controller:v1.10.2
         livenessProbe:
           failureThreshold: 8
           httpGet:

--- a/api/pkg/resources/test/fixtures/deployment-vsphere-1.11.1-machine-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-vsphere-1.11.1-machine-controller.yaml
@@ -59,7 +59,7 @@ spec:
           value: apiserver-external.cluster-de-test-01.svc.cluster.local.
         - name: KUBECONFIG
           value: /etc/kubernetes/kubeconfig/kubeconfig
-        image: docker.io/kubermatic/machine-controller:v1.10.1
+        image: docker.io/kubermatic/machine-controller:v1.10.2
         livenessProbe:
           failureThreshold: 3
           httpGet:

--- a/api/pkg/resources/test/fixtures/deployment-vsphere-1.12.0-machine-controller-webhook.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-vsphere-1.12.0-machine-controller-webhook.yaml
@@ -56,7 +56,7 @@ spec:
           value: apiserver-external.cluster-de-test-01.svc.cluster.local.
         - name: KUBECONFIG
           value: /etc/kubernetes/kubeconfig/kubeconfig
-        image: docker.io/kubermatic/machine-controller:v1.10.1
+        image: docker.io/kubermatic/machine-controller:v1.10.2
         livenessProbe:
           failureThreshold: 8
           httpGet:

--- a/api/pkg/resources/test/fixtures/deployment-vsphere-1.12.0-machine-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-vsphere-1.12.0-machine-controller.yaml
@@ -59,7 +59,7 @@ spec:
           value: apiserver-external.cluster-de-test-01.svc.cluster.local.
         - name: KUBECONFIG
           value: /etc/kubernetes/kubeconfig/kubeconfig
-        image: docker.io/kubermatic/machine-controller:v1.10.1
+        image: docker.io/kubermatic/machine-controller:v1.10.2
         livenessProbe:
           failureThreshold: 3
           httpGet:

--- a/api/pkg/resources/test/fixtures/deployment-vsphere-1.13.0-machine-controller-webhook.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-vsphere-1.13.0-machine-controller-webhook.yaml
@@ -56,7 +56,7 @@ spec:
           value: apiserver-external.cluster-de-test-01.svc.cluster.local.
         - name: KUBECONFIG
           value: /etc/kubernetes/kubeconfig/kubeconfig
-        image: docker.io/kubermatic/machine-controller:v1.10.1
+        image: docker.io/kubermatic/machine-controller:v1.10.2
         livenessProbe:
           failureThreshold: 8
           httpGet:

--- a/api/pkg/resources/test/fixtures/deployment-vsphere-1.13.0-machine-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-vsphere-1.13.0-machine-controller.yaml
@@ -59,7 +59,7 @@ spec:
           value: apiserver-external.cluster-de-test-01.svc.cluster.local.
         - name: KUBECONFIG
           value: /etc/kubernetes/kubeconfig/kubeconfig
-        image: docker.io/kubermatic/machine-controller:v1.10.1
+        image: docker.io/kubermatic/machine-controller:v1.10.2
         livenessProbe:
           failureThreshold: 3
           httpGet:


### PR DESCRIPTION
**What this PR does / why we need it**:
This brings us the urgently needed Digitalocean fix.

**Does this PR introduce a user-facing change?**:
```release-note
Update machine-controller to v1.10.2.
```
