### PR TITLE
Update usercluster metrics-server

### DIFF
--- a/api/pkg/resources/metrics-server/deployment.go
+++ b/api/pkg/resources/metrics-server/deployment.go
@@ -38,7 +38,7 @@ const (
 	ServingCertSecretName  = "metrics-server-serving-cert"
 	servingCertMountFolder = "/etc/serving-cert"
 
-	tag = "v0.3.4"
+	tag = "v0.3.6"
 )
 
 // metricsServerData is the data needed to construct the metrics-server components

--- a/api/pkg/resources/test/fixtures/deployment-aws-1.10.0-metrics-server.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-aws-1.10.0-metrics-server.yaml
@@ -51,7 +51,7 @@ spec:
         - '{"command":"/metrics-server","args":["--kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","--authentication-kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","--authorization-kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","--kubelet-port","10250","--kubelet-insecure-tls","--kubelet-preferred-address-types","ExternalIP,InternalIP","--v","1","--logtostderr","--tls-cert-file","/etc/serving-cert/serving.crt","--tls-private-key-file","/etc/serving-cert/serving.key"]}'
         command:
         - /http-prober-bin/http-prober
-        image: gcr.io/google_containers/metrics-server-amd64:v0.3.4
+        image: gcr.io/google_containers/metrics-server-amd64:v0.3.6
         name: metrics-server
         resources:
           limits:

--- a/api/pkg/resources/test/fixtures/deployment-aws-1.10.6-metrics-server.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-aws-1.10.6-metrics-server.yaml
@@ -51,7 +51,7 @@ spec:
         - '{"command":"/metrics-server","args":["--kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","--authentication-kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","--authorization-kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","--kubelet-port","10250","--kubelet-insecure-tls","--kubelet-preferred-address-types","ExternalIP,InternalIP","--v","1","--logtostderr","--tls-cert-file","/etc/serving-cert/serving.crt","--tls-private-key-file","/etc/serving-cert/serving.key"]}'
         command:
         - /http-prober-bin/http-prober
-        image: gcr.io/google_containers/metrics-server-amd64:v0.3.4
+        image: gcr.io/google_containers/metrics-server-amd64:v0.3.6
         name: metrics-server
         resources:
           limits:

--- a/api/pkg/resources/test/fixtures/deployment-aws-1.11.0-metrics-server.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-aws-1.11.0-metrics-server.yaml
@@ -51,7 +51,7 @@ spec:
         - '{"command":"/metrics-server","args":["--kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","--authentication-kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","--authorization-kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","--kubelet-port","10250","--kubelet-insecure-tls","--kubelet-preferred-address-types","ExternalIP,InternalIP","--v","1","--logtostderr","--tls-cert-file","/etc/serving-cert/serving.crt","--tls-private-key-file","/etc/serving-cert/serving.key"]}'
         command:
         - /http-prober-bin/http-prober
-        image: gcr.io/google_containers/metrics-server-amd64:v0.3.4
+        image: gcr.io/google_containers/metrics-server-amd64:v0.3.6
         name: metrics-server
         resources:
           limits:

--- a/api/pkg/resources/test/fixtures/deployment-aws-1.11.1-metrics-server.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-aws-1.11.1-metrics-server.yaml
@@ -51,7 +51,7 @@ spec:
         - '{"command":"/metrics-server","args":["--kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","--authentication-kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","--authorization-kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","--kubelet-port","10250","--kubelet-insecure-tls","--kubelet-preferred-address-types","ExternalIP,InternalIP","--v","1","--logtostderr","--tls-cert-file","/etc/serving-cert/serving.crt","--tls-private-key-file","/etc/serving-cert/serving.key"]}'
         command:
         - /http-prober-bin/http-prober
-        image: gcr.io/google_containers/metrics-server-amd64:v0.3.4
+        image: gcr.io/google_containers/metrics-server-amd64:v0.3.6
         name: metrics-server
         resources:
           limits:

--- a/api/pkg/resources/test/fixtures/deployment-aws-1.12.0-metrics-server.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-aws-1.12.0-metrics-server.yaml
@@ -51,7 +51,7 @@ spec:
         - '{"command":"/metrics-server","args":["--kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","--authentication-kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","--authorization-kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","--kubelet-port","10250","--kubelet-insecure-tls","--kubelet-preferred-address-types","ExternalIP,InternalIP","--v","1","--logtostderr","--tls-cert-file","/etc/serving-cert/serving.crt","--tls-private-key-file","/etc/serving-cert/serving.key"]}'
         command:
         - /http-prober-bin/http-prober
-        image: gcr.io/google_containers/metrics-server-amd64:v0.3.4
+        image: gcr.io/google_containers/metrics-server-amd64:v0.3.6
         name: metrics-server
         resources:
           limits:

--- a/api/pkg/resources/test/fixtures/deployment-aws-1.13.0-metrics-server.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-aws-1.13.0-metrics-server.yaml
@@ -51,7 +51,7 @@ spec:
         - '{"command":"/metrics-server","args":["--kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","--authentication-kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","--authorization-kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","--kubelet-port","10250","--kubelet-insecure-tls","--kubelet-preferred-address-types","ExternalIP,InternalIP","--v","1","--logtostderr","--tls-cert-file","/etc/serving-cert/serving.crt","--tls-private-key-file","/etc/serving-cert/serving.key"]}'
         command:
         - /http-prober-bin/http-prober
-        image: gcr.io/google_containers/metrics-server-amd64:v0.3.4
+        image: gcr.io/google_containers/metrics-server-amd64:v0.3.6
         name: metrics-server
         resources:
           limits:

--- a/api/pkg/resources/test/fixtures/deployment-azure-1.10.0-metrics-server.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-azure-1.10.0-metrics-server.yaml
@@ -51,7 +51,7 @@ spec:
         - '{"command":"/metrics-server","args":["--kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","--authentication-kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","--authorization-kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","--kubelet-port","10250","--kubelet-insecure-tls","--kubelet-preferred-address-types","ExternalIP,InternalIP","--v","1","--logtostderr","--tls-cert-file","/etc/serving-cert/serving.crt","--tls-private-key-file","/etc/serving-cert/serving.key"]}'
         command:
         - /http-prober-bin/http-prober
-        image: gcr.io/google_containers/metrics-server-amd64:v0.3.4
+        image: gcr.io/google_containers/metrics-server-amd64:v0.3.6
         name: metrics-server
         resources:
           limits:

--- a/api/pkg/resources/test/fixtures/deployment-azure-1.10.6-metrics-server.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-azure-1.10.6-metrics-server.yaml
@@ -51,7 +51,7 @@ spec:
         - '{"command":"/metrics-server","args":["--kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","--authentication-kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","--authorization-kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","--kubelet-port","10250","--kubelet-insecure-tls","--kubelet-preferred-address-types","ExternalIP,InternalIP","--v","1","--logtostderr","--tls-cert-file","/etc/serving-cert/serving.crt","--tls-private-key-file","/etc/serving-cert/serving.key"]}'
         command:
         - /http-prober-bin/http-prober
-        image: gcr.io/google_containers/metrics-server-amd64:v0.3.4
+        image: gcr.io/google_containers/metrics-server-amd64:v0.3.6
         name: metrics-server
         resources:
           limits:

--- a/api/pkg/resources/test/fixtures/deployment-azure-1.11.0-metrics-server.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-azure-1.11.0-metrics-server.yaml
@@ -51,7 +51,7 @@ spec:
         - '{"command":"/metrics-server","args":["--kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","--authentication-kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","--authorization-kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","--kubelet-port","10250","--kubelet-insecure-tls","--kubelet-preferred-address-types","ExternalIP,InternalIP","--v","1","--logtostderr","--tls-cert-file","/etc/serving-cert/serving.crt","--tls-private-key-file","/etc/serving-cert/serving.key"]}'
         command:
         - /http-prober-bin/http-prober
-        image: gcr.io/google_containers/metrics-server-amd64:v0.3.4
+        image: gcr.io/google_containers/metrics-server-amd64:v0.3.6
         name: metrics-server
         resources:
           limits:

--- a/api/pkg/resources/test/fixtures/deployment-azure-1.11.1-metrics-server.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-azure-1.11.1-metrics-server.yaml
@@ -51,7 +51,7 @@ spec:
         - '{"command":"/metrics-server","args":["--kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","--authentication-kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","--authorization-kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","--kubelet-port","10250","--kubelet-insecure-tls","--kubelet-preferred-address-types","ExternalIP,InternalIP","--v","1","--logtostderr","--tls-cert-file","/etc/serving-cert/serving.crt","--tls-private-key-file","/etc/serving-cert/serving.key"]}'
         command:
         - /http-prober-bin/http-prober
-        image: gcr.io/google_containers/metrics-server-amd64:v0.3.4
+        image: gcr.io/google_containers/metrics-server-amd64:v0.3.6
         name: metrics-server
         resources:
           limits:

--- a/api/pkg/resources/test/fixtures/deployment-azure-1.12.0-metrics-server.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-azure-1.12.0-metrics-server.yaml
@@ -51,7 +51,7 @@ spec:
         - '{"command":"/metrics-server","args":["--kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","--authentication-kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","--authorization-kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","--kubelet-port","10250","--kubelet-insecure-tls","--kubelet-preferred-address-types","ExternalIP,InternalIP","--v","1","--logtostderr","--tls-cert-file","/etc/serving-cert/serving.crt","--tls-private-key-file","/etc/serving-cert/serving.key"]}'
         command:
         - /http-prober-bin/http-prober
-        image: gcr.io/google_containers/metrics-server-amd64:v0.3.4
+        image: gcr.io/google_containers/metrics-server-amd64:v0.3.6
         name: metrics-server
         resources:
           limits:

--- a/api/pkg/resources/test/fixtures/deployment-azure-1.13.0-metrics-server.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-azure-1.13.0-metrics-server.yaml
@@ -51,7 +51,7 @@ spec:
         - '{"command":"/metrics-server","args":["--kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","--authentication-kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","--authorization-kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","--kubelet-port","10250","--kubelet-insecure-tls","--kubelet-preferred-address-types","ExternalIP,InternalIP","--v","1","--logtostderr","--tls-cert-file","/etc/serving-cert/serving.crt","--tls-private-key-file","/etc/serving-cert/serving.key"]}'
         command:
         - /http-prober-bin/http-prober
-        image: gcr.io/google_containers/metrics-server-amd64:v0.3.4
+        image: gcr.io/google_containers/metrics-server-amd64:v0.3.6
         name: metrics-server
         resources:
           limits:

--- a/api/pkg/resources/test/fixtures/deployment-bringyourown-1.10.0-metrics-server.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-bringyourown-1.10.0-metrics-server.yaml
@@ -51,7 +51,7 @@ spec:
         - '{"command":"/metrics-server","args":["--kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","--authentication-kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","--authorization-kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","--kubelet-port","10250","--kubelet-insecure-tls","--kubelet-preferred-address-types","ExternalIP,InternalIP","--v","1","--logtostderr","--tls-cert-file","/etc/serving-cert/serving.crt","--tls-private-key-file","/etc/serving-cert/serving.key"]}'
         command:
         - /http-prober-bin/http-prober
-        image: gcr.io/google_containers/metrics-server-amd64:v0.3.4
+        image: gcr.io/google_containers/metrics-server-amd64:v0.3.6
         name: metrics-server
         resources:
           limits:

--- a/api/pkg/resources/test/fixtures/deployment-bringyourown-1.10.6-metrics-server.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-bringyourown-1.10.6-metrics-server.yaml
@@ -51,7 +51,7 @@ spec:
         - '{"command":"/metrics-server","args":["--kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","--authentication-kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","--authorization-kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","--kubelet-port","10250","--kubelet-insecure-tls","--kubelet-preferred-address-types","ExternalIP,InternalIP","--v","1","--logtostderr","--tls-cert-file","/etc/serving-cert/serving.crt","--tls-private-key-file","/etc/serving-cert/serving.key"]}'
         command:
         - /http-prober-bin/http-prober
-        image: gcr.io/google_containers/metrics-server-amd64:v0.3.4
+        image: gcr.io/google_containers/metrics-server-amd64:v0.3.6
         name: metrics-server
         resources:
           limits:

--- a/api/pkg/resources/test/fixtures/deployment-bringyourown-1.11.0-metrics-server.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-bringyourown-1.11.0-metrics-server.yaml
@@ -51,7 +51,7 @@ spec:
         - '{"command":"/metrics-server","args":["--kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","--authentication-kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","--authorization-kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","--kubelet-port","10250","--kubelet-insecure-tls","--kubelet-preferred-address-types","ExternalIP,InternalIP","--v","1","--logtostderr","--tls-cert-file","/etc/serving-cert/serving.crt","--tls-private-key-file","/etc/serving-cert/serving.key"]}'
         command:
         - /http-prober-bin/http-prober
-        image: gcr.io/google_containers/metrics-server-amd64:v0.3.4
+        image: gcr.io/google_containers/metrics-server-amd64:v0.3.6
         name: metrics-server
         resources:
           limits:

--- a/api/pkg/resources/test/fixtures/deployment-bringyourown-1.11.1-metrics-server.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-bringyourown-1.11.1-metrics-server.yaml
@@ -51,7 +51,7 @@ spec:
         - '{"command":"/metrics-server","args":["--kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","--authentication-kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","--authorization-kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","--kubelet-port","10250","--kubelet-insecure-tls","--kubelet-preferred-address-types","ExternalIP,InternalIP","--v","1","--logtostderr","--tls-cert-file","/etc/serving-cert/serving.crt","--tls-private-key-file","/etc/serving-cert/serving.key"]}'
         command:
         - /http-prober-bin/http-prober
-        image: gcr.io/google_containers/metrics-server-amd64:v0.3.4
+        image: gcr.io/google_containers/metrics-server-amd64:v0.3.6
         name: metrics-server
         resources:
           limits:

--- a/api/pkg/resources/test/fixtures/deployment-bringyourown-1.12.0-metrics-server.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-bringyourown-1.12.0-metrics-server.yaml
@@ -51,7 +51,7 @@ spec:
         - '{"command":"/metrics-server","args":["--kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","--authentication-kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","--authorization-kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","--kubelet-port","10250","--kubelet-insecure-tls","--kubelet-preferred-address-types","ExternalIP,InternalIP","--v","1","--logtostderr","--tls-cert-file","/etc/serving-cert/serving.crt","--tls-private-key-file","/etc/serving-cert/serving.key"]}'
         command:
         - /http-prober-bin/http-prober
-        image: gcr.io/google_containers/metrics-server-amd64:v0.3.4
+        image: gcr.io/google_containers/metrics-server-amd64:v0.3.6
         name: metrics-server
         resources:
           limits:

--- a/api/pkg/resources/test/fixtures/deployment-bringyourown-1.13.0-metrics-server.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-bringyourown-1.13.0-metrics-server.yaml
@@ -51,7 +51,7 @@ spec:
         - '{"command":"/metrics-server","args":["--kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","--authentication-kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","--authorization-kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","--kubelet-port","10250","--kubelet-insecure-tls","--kubelet-preferred-address-types","ExternalIP,InternalIP","--v","1","--logtostderr","--tls-cert-file","/etc/serving-cert/serving.crt","--tls-private-key-file","/etc/serving-cert/serving.key"]}'
         command:
         - /http-prober-bin/http-prober
-        image: gcr.io/google_containers/metrics-server-amd64:v0.3.4
+        image: gcr.io/google_containers/metrics-server-amd64:v0.3.6
         name: metrics-server
         resources:
           limits:

--- a/api/pkg/resources/test/fixtures/deployment-digitalocean-1.10.0-metrics-server.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-digitalocean-1.10.0-metrics-server.yaml
@@ -51,7 +51,7 @@ spec:
         - '{"command":"/metrics-server","args":["--kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","--authentication-kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","--authorization-kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","--kubelet-port","10250","--kubelet-insecure-tls","--kubelet-preferred-address-types","ExternalIP,InternalIP","--v","1","--logtostderr","--tls-cert-file","/etc/serving-cert/serving.crt","--tls-private-key-file","/etc/serving-cert/serving.key"]}'
         command:
         - /http-prober-bin/http-prober
-        image: gcr.io/google_containers/metrics-server-amd64:v0.3.4
+        image: gcr.io/google_containers/metrics-server-amd64:v0.3.6
         name: metrics-server
         resources:
           limits:

--- a/api/pkg/resources/test/fixtures/deployment-digitalocean-1.10.6-metrics-server.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-digitalocean-1.10.6-metrics-server.yaml
@@ -51,7 +51,7 @@ spec:
         - '{"command":"/metrics-server","args":["--kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","--authentication-kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","--authorization-kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","--kubelet-port","10250","--kubelet-insecure-tls","--kubelet-preferred-address-types","ExternalIP,InternalIP","--v","1","--logtostderr","--tls-cert-file","/etc/serving-cert/serving.crt","--tls-private-key-file","/etc/serving-cert/serving.key"]}'
         command:
         - /http-prober-bin/http-prober
-        image: gcr.io/google_containers/metrics-server-amd64:v0.3.4
+        image: gcr.io/google_containers/metrics-server-amd64:v0.3.6
         name: metrics-server
         resources:
           limits:

--- a/api/pkg/resources/test/fixtures/deployment-digitalocean-1.11.0-metrics-server.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-digitalocean-1.11.0-metrics-server.yaml
@@ -51,7 +51,7 @@ spec:
         - '{"command":"/metrics-server","args":["--kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","--authentication-kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","--authorization-kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","--kubelet-port","10250","--kubelet-insecure-tls","--kubelet-preferred-address-types","ExternalIP,InternalIP","--v","1","--logtostderr","--tls-cert-file","/etc/serving-cert/serving.crt","--tls-private-key-file","/etc/serving-cert/serving.key"]}'
         command:
         - /http-prober-bin/http-prober
-        image: gcr.io/google_containers/metrics-server-amd64:v0.3.4
+        image: gcr.io/google_containers/metrics-server-amd64:v0.3.6
         name: metrics-server
         resources:
           limits:

--- a/api/pkg/resources/test/fixtures/deployment-digitalocean-1.11.1-metrics-server.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-digitalocean-1.11.1-metrics-server.yaml
@@ -51,7 +51,7 @@ spec:
         - '{"command":"/metrics-server","args":["--kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","--authentication-kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","--authorization-kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","--kubelet-port","10250","--kubelet-insecure-tls","--kubelet-preferred-address-types","ExternalIP,InternalIP","--v","1","--logtostderr","--tls-cert-file","/etc/serving-cert/serving.crt","--tls-private-key-file","/etc/serving-cert/serving.key"]}'
         command:
         - /http-prober-bin/http-prober
-        image: gcr.io/google_containers/metrics-server-amd64:v0.3.4
+        image: gcr.io/google_containers/metrics-server-amd64:v0.3.6
         name: metrics-server
         resources:
           limits:

--- a/api/pkg/resources/test/fixtures/deployment-digitalocean-1.12.0-metrics-server.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-digitalocean-1.12.0-metrics-server.yaml
@@ -51,7 +51,7 @@ spec:
         - '{"command":"/metrics-server","args":["--kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","--authentication-kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","--authorization-kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","--kubelet-port","10250","--kubelet-insecure-tls","--kubelet-preferred-address-types","ExternalIP,InternalIP","--v","1","--logtostderr","--tls-cert-file","/etc/serving-cert/serving.crt","--tls-private-key-file","/etc/serving-cert/serving.key"]}'
         command:
         - /http-prober-bin/http-prober
-        image: gcr.io/google_containers/metrics-server-amd64:v0.3.4
+        image: gcr.io/google_containers/metrics-server-amd64:v0.3.6
         name: metrics-server
         resources:
           limits:

--- a/api/pkg/resources/test/fixtures/deployment-digitalocean-1.13.0-metrics-server.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-digitalocean-1.13.0-metrics-server.yaml
@@ -51,7 +51,7 @@ spec:
         - '{"command":"/metrics-server","args":["--kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","--authentication-kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","--authorization-kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","--kubelet-port","10250","--kubelet-insecure-tls","--kubelet-preferred-address-types","ExternalIP,InternalIP","--v","1","--logtostderr","--tls-cert-file","/etc/serving-cert/serving.crt","--tls-private-key-file","/etc/serving-cert/serving.key"]}'
         command:
         - /http-prober-bin/http-prober
-        image: gcr.io/google_containers/metrics-server-amd64:v0.3.4
+        image: gcr.io/google_containers/metrics-server-amd64:v0.3.6
         name: metrics-server
         resources:
           limits:

--- a/api/pkg/resources/test/fixtures/deployment-openstack-1.10.0-metrics-server.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-openstack-1.10.0-metrics-server.yaml
@@ -51,7 +51,7 @@ spec:
         - '{"command":"/metrics-server","args":["--kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","--authentication-kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","--authorization-kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","--kubelet-port","10250","--kubelet-insecure-tls","--kubelet-preferred-address-types","ExternalIP,InternalIP","--v","1","--logtostderr","--tls-cert-file","/etc/serving-cert/serving.crt","--tls-private-key-file","/etc/serving-cert/serving.key"]}'
         command:
         - /http-prober-bin/http-prober
-        image: gcr.io/google_containers/metrics-server-amd64:v0.3.4
+        image: gcr.io/google_containers/metrics-server-amd64:v0.3.6
         name: metrics-server
         resources:
           limits:

--- a/api/pkg/resources/test/fixtures/deployment-openstack-1.10.6-metrics-server.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-openstack-1.10.6-metrics-server.yaml
@@ -51,7 +51,7 @@ spec:
         - '{"command":"/metrics-server","args":["--kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","--authentication-kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","--authorization-kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","--kubelet-port","10250","--kubelet-insecure-tls","--kubelet-preferred-address-types","ExternalIP,InternalIP","--v","1","--logtostderr","--tls-cert-file","/etc/serving-cert/serving.crt","--tls-private-key-file","/etc/serving-cert/serving.key"]}'
         command:
         - /http-prober-bin/http-prober
-        image: gcr.io/google_containers/metrics-server-amd64:v0.3.4
+        image: gcr.io/google_containers/metrics-server-amd64:v0.3.6
         name: metrics-server
         resources:
           limits:

--- a/api/pkg/resources/test/fixtures/deployment-openstack-1.11.0-metrics-server.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-openstack-1.11.0-metrics-server.yaml
@@ -51,7 +51,7 @@ spec:
         - '{"command":"/metrics-server","args":["--kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","--authentication-kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","--authorization-kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","--kubelet-port","10250","--kubelet-insecure-tls","--kubelet-preferred-address-types","ExternalIP,InternalIP","--v","1","--logtostderr","--tls-cert-file","/etc/serving-cert/serving.crt","--tls-private-key-file","/etc/serving-cert/serving.key"]}'
         command:
         - /http-prober-bin/http-prober
-        image: gcr.io/google_containers/metrics-server-amd64:v0.3.4
+        image: gcr.io/google_containers/metrics-server-amd64:v0.3.6
         name: metrics-server
         resources:
           limits:

--- a/api/pkg/resources/test/fixtures/deployment-openstack-1.11.1-metrics-server.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-openstack-1.11.1-metrics-server.yaml
@@ -51,7 +51,7 @@ spec:
         - '{"command":"/metrics-server","args":["--kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","--authentication-kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","--authorization-kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","--kubelet-port","10250","--kubelet-insecure-tls","--kubelet-preferred-address-types","ExternalIP,InternalIP","--v","1","--logtostderr","--tls-cert-file","/etc/serving-cert/serving.crt","--tls-private-key-file","/etc/serving-cert/serving.key"]}'
         command:
         - /http-prober-bin/http-prober
-        image: gcr.io/google_containers/metrics-server-amd64:v0.3.4
+        image: gcr.io/google_containers/metrics-server-amd64:v0.3.6
         name: metrics-server
         resources:
           limits:

--- a/api/pkg/resources/test/fixtures/deployment-openstack-1.12.0-metrics-server.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-openstack-1.12.0-metrics-server.yaml
@@ -51,7 +51,7 @@ spec:
         - '{"command":"/metrics-server","args":["--kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","--authentication-kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","--authorization-kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","--kubelet-port","10250","--kubelet-insecure-tls","--kubelet-preferred-address-types","ExternalIP,InternalIP","--v","1","--logtostderr","--tls-cert-file","/etc/serving-cert/serving.crt","--tls-private-key-file","/etc/serving-cert/serving.key"]}'
         command:
         - /http-prober-bin/http-prober
-        image: gcr.io/google_containers/metrics-server-amd64:v0.3.4
+        image: gcr.io/google_containers/metrics-server-amd64:v0.3.6
         name: metrics-server
         resources:
           limits:

--- a/api/pkg/resources/test/fixtures/deployment-openstack-1.13.0-metrics-server.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-openstack-1.13.0-metrics-server.yaml
@@ -51,7 +51,7 @@ spec:
         - '{"command":"/metrics-server","args":["--kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","--authentication-kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","--authorization-kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","--kubelet-port","10250","--kubelet-insecure-tls","--kubelet-preferred-address-types","ExternalIP,InternalIP","--v","1","--logtostderr","--tls-cert-file","/etc/serving-cert/serving.crt","--tls-private-key-file","/etc/serving-cert/serving.key"]}'
         command:
         - /http-prober-bin/http-prober
-        image: gcr.io/google_containers/metrics-server-amd64:v0.3.4
+        image: gcr.io/google_containers/metrics-server-amd64:v0.3.6
         name: metrics-server
         resources:
           limits:

--- a/api/pkg/resources/test/fixtures/deployment-vsphere-1.10.0-metrics-server.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-vsphere-1.10.0-metrics-server.yaml
@@ -51,7 +51,7 @@ spec:
         - '{"command":"/metrics-server","args":["--kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","--authentication-kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","--authorization-kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","--kubelet-port","10250","--kubelet-insecure-tls","--kubelet-preferred-address-types","ExternalIP,InternalIP","--v","1","--logtostderr","--tls-cert-file","/etc/serving-cert/serving.crt","--tls-private-key-file","/etc/serving-cert/serving.key"]}'
         command:
         - /http-prober-bin/http-prober
-        image: gcr.io/google_containers/metrics-server-amd64:v0.3.4
+        image: gcr.io/google_containers/metrics-server-amd64:v0.3.6
         name: metrics-server
         resources:
           limits:

--- a/api/pkg/resources/test/fixtures/deployment-vsphere-1.10.6-metrics-server.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-vsphere-1.10.6-metrics-server.yaml
@@ -51,7 +51,7 @@ spec:
         - '{"command":"/metrics-server","args":["--kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","--authentication-kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","--authorization-kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","--kubelet-port","10250","--kubelet-insecure-tls","--kubelet-preferred-address-types","ExternalIP,InternalIP","--v","1","--logtostderr","--tls-cert-file","/etc/serving-cert/serving.crt","--tls-private-key-file","/etc/serving-cert/serving.key"]}'
         command:
         - /http-prober-bin/http-prober
-        image: gcr.io/google_containers/metrics-server-amd64:v0.3.4
+        image: gcr.io/google_containers/metrics-server-amd64:v0.3.6
         name: metrics-server
         resources:
           limits:

--- a/api/pkg/resources/test/fixtures/deployment-vsphere-1.11.0-metrics-server.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-vsphere-1.11.0-metrics-server.yaml
@@ -51,7 +51,7 @@ spec:
         - '{"command":"/metrics-server","args":["--kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","--authentication-kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","--authorization-kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","--kubelet-port","10250","--kubelet-insecure-tls","--kubelet-preferred-address-types","ExternalIP,InternalIP","--v","1","--logtostderr","--tls-cert-file","/etc/serving-cert/serving.crt","--tls-private-key-file","/etc/serving-cert/serving.key"]}'
         command:
         - /http-prober-bin/http-prober
-        image: gcr.io/google_containers/metrics-server-amd64:v0.3.4
+        image: gcr.io/google_containers/metrics-server-amd64:v0.3.6
         name: metrics-server
         resources:
           limits:

--- a/api/pkg/resources/test/fixtures/deployment-vsphere-1.11.1-metrics-server.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-vsphere-1.11.1-metrics-server.yaml
@@ -51,7 +51,7 @@ spec:
         - '{"command":"/metrics-server","args":["--kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","--authentication-kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","--authorization-kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","--kubelet-port","10250","--kubelet-insecure-tls","--kubelet-preferred-address-types","ExternalIP,InternalIP","--v","1","--logtostderr","--tls-cert-file","/etc/serving-cert/serving.crt","--tls-private-key-file","/etc/serving-cert/serving.key"]}'
         command:
         - /http-prober-bin/http-prober
-        image: gcr.io/google_containers/metrics-server-amd64:v0.3.4
+        image: gcr.io/google_containers/metrics-server-amd64:v0.3.6
         name: metrics-server
         resources:
           limits:

--- a/api/pkg/resources/test/fixtures/deployment-vsphere-1.12.0-metrics-server.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-vsphere-1.12.0-metrics-server.yaml
@@ -51,7 +51,7 @@ spec:
         - '{"command":"/metrics-server","args":["--kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","--authentication-kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","--authorization-kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","--kubelet-port","10250","--kubelet-insecure-tls","--kubelet-preferred-address-types","ExternalIP,InternalIP","--v","1","--logtostderr","--tls-cert-file","/etc/serving-cert/serving.crt","--tls-private-key-file","/etc/serving-cert/serving.key"]}'
         command:
         - /http-prober-bin/http-prober
-        image: gcr.io/google_containers/metrics-server-amd64:v0.3.4
+        image: gcr.io/google_containers/metrics-server-amd64:v0.3.6
         name: metrics-server
         resources:
           limits:

--- a/api/pkg/resources/test/fixtures/deployment-vsphere-1.13.0-metrics-server.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-vsphere-1.13.0-metrics-server.yaml
@@ -51,7 +51,7 @@ spec:
         - '{"command":"/metrics-server","args":["--kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","--authentication-kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","--authorization-kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","--kubelet-port","10250","--kubelet-insecure-tls","--kubelet-preferred-address-types","ExternalIP,InternalIP","--v","1","--logtostderr","--tls-cert-file","/etc/serving-cert/serving.crt","--tls-private-key-file","/etc/serving-cert/serving.key"]}'
         command:
         - /http-prober-bin/http-prober
-        image: gcr.io/google_containers/metrics-server-amd64:v0.3.4
+        image: gcr.io/google_containers/metrics-server-amd64:v0.3.6
         name: metrics-server
         resources:
           limits:


### PR DESCRIPTION
**What this PR does / why we need it**:
Upgrade metrics-server to the latest v0.3.6.
Minor upgrade.

**Documentation**:
<!-- Add links to the related documentation changes related to this pull request. E.g. the link to the kubermatic/docs pullrequest. -->
Release note: https://github.com/kubernetes-sigs/metrics-server/releases

**Does this PR introduce a user-facing change?**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If  no release note is required, just write "NONE".
-->
```release-note
Update metrics-server to v0.3.6
```
