### PR TITLE
Update openvpn container to v2.4.8

### DIFF
--- a/addons/openvpn/openvpn-client-dep.yaml
+++ b/addons/openvpn/openvpn-client-dep.yaml
@@ -18,7 +18,7 @@ spec:
       serviceAccountName: vpn-client
       containers:
       - name: openvpn-client
-        image: '{{ Registry "quay.io" }}/kubermatic/openvpn:v0.6-dev'
+        image: '{{ Registry "quay.io" }}/kubermatic/openvpn:2.4.8'
         command: ["/usr/sbin/openvpn"]
         args: ["--config", "/etc/openvpn/config/config"]
         resources:
@@ -57,7 +57,7 @@ spec:
           name: openvpn-client-certificates
           readOnly: true
       - name: dnat-controller
-        image: '{{ Registry "quay.io" }}/kubermatic/openvpn:v0.6-dev'
+        image: '{{ Registry "quay.io" }}/kubermatic/openvpn:2.4.8'
         command:
         - bash
         - -ec

--- a/addons/openvpn/openvpn-client-dep.yaml
+++ b/addons/openvpn/openvpn-client-dep.yaml
@@ -18,7 +18,7 @@ spec:
       serviceAccountName: vpn-client
       containers:
       - name: openvpn-client
-        image: '{{ Registry "quay.io" }}/kubermatic/openvpn:v0.5'
+        image: '{{ Registry "quay.io" }}/kubermatic/openvpn:v0.6-dev'
         command: ["/usr/sbin/openvpn"]
         args: ["--config", "/etc/openvpn/config/config"]
         resources:
@@ -57,7 +57,7 @@ spec:
           name: openvpn-client-certificates
           readOnly: true
       - name: dnat-controller
-        image: '{{ Registry "quay.io" }}/kubermatic/openvpn:v0.5'
+        image: '{{ Registry "quay.io" }}/kubermatic/openvpn:v0.6-dev'
         command:
         - bash
         - -ec

--- a/addons/openvpn/openvpn-client-dep.yaml
+++ b/addons/openvpn/openvpn-client-dep.yaml
@@ -18,7 +18,7 @@ spec:
       serviceAccountName: vpn-client
       containers:
       - name: openvpn-client
-        image: '{{ Registry "quay.io" }}/kubermatic/openvpn:2.4.8'
+        image: '{{ Registry "quay.io" }}/kubermatic/openvpn:v2.4.8-r1'
         command: ["/usr/sbin/openvpn"]
         args: ["--config", "/etc/openvpn/config/config"]
         resources:
@@ -57,7 +57,7 @@ spec:
           name: openvpn-client-certificates
           readOnly: true
       - name: dnat-controller
-        image: '{{ Registry "quay.io" }}/kubermatic/openvpn:2.4.8'
+        image: '{{ Registry "quay.io" }}/kubermatic/openvpn:v2.4.8-r1'
         command:
         - bash
         - -ec

--- a/api/pkg/resources/openvpn/deployment.go
+++ b/api/pkg/resources/openvpn/deployment.go
@@ -132,7 +132,7 @@ func DeploymentCreator(data openVPNDeploymentCreatorData) reconciling.NamedDeplo
 			dep.Spec.Template.Spec.InitContainers = []corev1.Container{
 				{
 					Name:    "iptables-init",
-					Image:   data.ImageRegistry(resources.RegistryQuay) + "/kubermatic/openvpn:v0.6-dev",
+					Image:   data.ImageRegistry(resources.RegistryQuay) + "/kubermatic/openvpn:2.4.8",
 					Command: []string{"/bin/bash"},
 					Args: []string{
 						"-c", `# do not give a 10.20.0.0/24 route to clients (nodes) but
@@ -188,7 +188,7 @@ iptables -A INPUT -i tun0 -j DROP
 			dep.Spec.Template.Spec.Containers = []corev1.Container{
 				{
 					Name:    name,
-					Image:   data.ImageRegistry(resources.RegistryQuay) + "/kubermatic/openvpn:v0.6-dev",
+					Image:   data.ImageRegistry(resources.RegistryQuay) + "/kubermatic/openvpn:2.4.8",
 					Command: []string{"/usr/sbin/openvpn"},
 					Args:    vpnArgs,
 					Ports: []corev1.ContainerPort{
@@ -241,7 +241,7 @@ iptables -A INPUT -i tun0 -j DROP
 				},
 				{
 					Name:    "ip-fixup",
-					Image:   data.ImageRegistry(resources.RegistryQuay) + "/kubermatic/openvpn:v0.6-dev",
+					Image:   data.ImageRegistry(resources.RegistryQuay) + "/kubermatic/openvpn:2.4.8",
 					Command: []string{"/bin/bash"},
 					Args: []string{
 						"-c",

--- a/api/pkg/resources/openvpn/deployment.go
+++ b/api/pkg/resources/openvpn/deployment.go
@@ -132,7 +132,7 @@ func DeploymentCreator(data openVPNDeploymentCreatorData) reconciling.NamedDeplo
 			dep.Spec.Template.Spec.InitContainers = []corev1.Container{
 				{
 					Name:    "iptables-init",
-					Image:   data.ImageRegistry(resources.RegistryQuay) + "/kubermatic/openvpn:v0.5",
+					Image:   data.ImageRegistry(resources.RegistryQuay) + "/kubermatic/openvpn:v0.6-dev",
 					Command: []string{"/bin/bash"},
 					Args: []string{
 						"-c", `# do not give a 10.20.0.0/24 route to clients (nodes) but
@@ -188,7 +188,7 @@ iptables -A INPUT -i tun0 -j DROP
 			dep.Spec.Template.Spec.Containers = []corev1.Container{
 				{
 					Name:    name,
-					Image:   data.ImageRegistry(resources.RegistryQuay) + "/kubermatic/openvpn:v0.5",
+					Image:   data.ImageRegistry(resources.RegistryQuay) + "/kubermatic/openvpn:v0.6-dev",
 					Command: []string{"/usr/sbin/openvpn"},
 					Args:    vpnArgs,
 					Ports: []corev1.ContainerPort{
@@ -241,7 +241,7 @@ iptables -A INPUT -i tun0 -j DROP
 				},
 				{
 					Name:    "ip-fixup",
-					Image:   data.ImageRegistry(resources.RegistryQuay) + "/kubermatic/openvpn:v0.5",
+					Image:   data.ImageRegistry(resources.RegistryQuay) + "/kubermatic/openvpn:v0.6-dev",
 					Command: []string{"/bin/bash"},
 					Args: []string{
 						"-c",

--- a/api/pkg/resources/openvpn/deployment.go
+++ b/api/pkg/resources/openvpn/deployment.go
@@ -132,7 +132,7 @@ func DeploymentCreator(data openVPNDeploymentCreatorData) reconciling.NamedDeplo
 			dep.Spec.Template.Spec.InitContainers = []corev1.Container{
 				{
 					Name:    "iptables-init",
-					Image:   data.ImageRegistry(resources.RegistryQuay) + "/kubermatic/openvpn:2.4.8",
+					Image:   data.ImageRegistry(resources.RegistryQuay) + "/kubermatic/openvpn:v2.4.8-r1",
 					Command: []string{"/bin/bash"},
 					Args: []string{
 						"-c", `# do not give a 10.20.0.0/24 route to clients (nodes) but
@@ -188,7 +188,7 @@ iptables -A INPUT -i tun0 -j DROP
 			dep.Spec.Template.Spec.Containers = []corev1.Container{
 				{
 					Name:    name,
-					Image:   data.ImageRegistry(resources.RegistryQuay) + "/kubermatic/openvpn:2.4.8",
+					Image:   data.ImageRegistry(resources.RegistryQuay) + "/kubermatic/openvpn:v2.4.8-r1",
 					Command: []string{"/usr/sbin/openvpn"},
 					Args:    vpnArgs,
 					Ports: []corev1.ContainerPort{
@@ -241,7 +241,7 @@ iptables -A INPUT -i tun0 -j DROP
 				},
 				{
 					Name:    "ip-fixup",
-					Image:   data.ImageRegistry(resources.RegistryQuay) + "/kubermatic/openvpn:2.4.8",
+					Image:   data.ImageRegistry(resources.RegistryQuay) + "/kubermatic/openvpn:v2.4.8-r1",
 					Command: []string{"/bin/bash"},
 					Args: []string{
 						"-c",

--- a/api/pkg/resources/test/fixtures/deployment-aws-1.10.0-apiserver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-aws-1.10.0-apiserver.yaml
@@ -89,7 +89,7 @@ spec:
         - /dev/stdout
         command:
         - /usr/sbin/openvpn
-        image: quay.io/kubermatic/openvpn:v0.6-dev
+        image: quay.io/kubermatic/openvpn:2.4.8
         name: openvpn-client
         resources:
           limits:

--- a/api/pkg/resources/test/fixtures/deployment-aws-1.10.0-apiserver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-aws-1.10.0-apiserver.yaml
@@ -89,7 +89,7 @@ spec:
         - /dev/stdout
         command:
         - /usr/sbin/openvpn
-        image: quay.io/kubermatic/openvpn:2.4.8
+        image: quay.io/kubermatic/openvpn:v2.4.8-r1
         name: openvpn-client
         resources:
           limits:

--- a/api/pkg/resources/test/fixtures/deployment-aws-1.10.0-apiserver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-aws-1.10.0-apiserver.yaml
@@ -89,7 +89,7 @@ spec:
         - /dev/stdout
         command:
         - /usr/sbin/openvpn
-        image: quay.io/kubermatic/openvpn:v0.5
+        image: quay.io/kubermatic/openvpn:v0.6-dev
         name: openvpn-client
         resources:
           limits:

--- a/api/pkg/resources/test/fixtures/deployment-aws-1.10.0-controller-manager.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-aws-1.10.0-controller-manager.yaml
@@ -81,7 +81,7 @@ spec:
         - /dev/stdout
         command:
         - /usr/sbin/openvpn
-        image: quay.io/kubermatic/openvpn:v0.6-dev
+        image: quay.io/kubermatic/openvpn:2.4.8
         name: openvpn-client
         resources:
           limits:

--- a/api/pkg/resources/test/fixtures/deployment-aws-1.10.0-controller-manager.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-aws-1.10.0-controller-manager.yaml
@@ -81,7 +81,7 @@ spec:
         - /dev/stdout
         command:
         - /usr/sbin/openvpn
-        image: quay.io/kubermatic/openvpn:v0.5
+        image: quay.io/kubermatic/openvpn:v0.6-dev
         name: openvpn-client
         resources:
           limits:

--- a/api/pkg/resources/test/fixtures/deployment-aws-1.10.0-controller-manager.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-aws-1.10.0-controller-manager.yaml
@@ -81,7 +81,7 @@ spec:
         - /dev/stdout
         command:
         - /usr/sbin/openvpn
-        image: quay.io/kubermatic/openvpn:2.4.8
+        image: quay.io/kubermatic/openvpn:v2.4.8-r1
         name: openvpn-client
         resources:
           limits:

--- a/api/pkg/resources/test/fixtures/deployment-aws-1.10.0-dns-resolver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-aws-1.10.0-dns-resolver.yaml
@@ -79,7 +79,7 @@ spec:
         - /dev/stdout
         command:
         - /usr/sbin/openvpn
-        image: quay.io/kubermatic/openvpn:2.4.8
+        image: quay.io/kubermatic/openvpn:v2.4.8-r1
         name: openvpn-client
         resources:
           limits:

--- a/api/pkg/resources/test/fixtures/deployment-aws-1.10.0-dns-resolver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-aws-1.10.0-dns-resolver.yaml
@@ -79,7 +79,7 @@ spec:
         - /dev/stdout
         command:
         - /usr/sbin/openvpn
-        image: quay.io/kubermatic/openvpn:v0.5
+        image: quay.io/kubermatic/openvpn:v0.6-dev
         name: openvpn-client
         resources:
           limits:

--- a/api/pkg/resources/test/fixtures/deployment-aws-1.10.0-dns-resolver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-aws-1.10.0-dns-resolver.yaml
@@ -79,7 +79,7 @@ spec:
         - /dev/stdout
         command:
         - /usr/sbin/openvpn
-        image: quay.io/kubermatic/openvpn:v0.6-dev
+        image: quay.io/kubermatic/openvpn:2.4.8
         name: openvpn-client
         resources:
           limits:

--- a/api/pkg/resources/test/fixtures/deployment-aws-1.10.0-metrics-server.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-aws-1.10.0-metrics-server.yaml
@@ -108,7 +108,7 @@ spec:
         - /dev/stdout
         command:
         - /usr/sbin/openvpn
-        image: quay.io/kubermatic/openvpn:2.4.8
+        image: quay.io/kubermatic/openvpn:v2.4.8-r1
         name: openvpn-client
         resources:
           limits:

--- a/api/pkg/resources/test/fixtures/deployment-aws-1.10.0-metrics-server.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-aws-1.10.0-metrics-server.yaml
@@ -108,7 +108,7 @@ spec:
         - /dev/stdout
         command:
         - /usr/sbin/openvpn
-        image: quay.io/kubermatic/openvpn:v0.5
+        image: quay.io/kubermatic/openvpn:v0.6-dev
         name: openvpn-client
         resources:
           limits:

--- a/api/pkg/resources/test/fixtures/deployment-aws-1.10.0-metrics-server.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-aws-1.10.0-metrics-server.yaml
@@ -108,7 +108,7 @@ spec:
         - /dev/stdout
         command:
         - /usr/sbin/openvpn
-        image: quay.io/kubermatic/openvpn:v0.6-dev
+        image: quay.io/kubermatic/openvpn:2.4.8
         name: openvpn-client
         resources:
           limits:

--- a/api/pkg/resources/test/fixtures/deployment-aws-1.10.0-openvpn-server.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-aws-1.10.0-openvpn-server.yaml
@@ -86,7 +86,7 @@ spec:
         - 255.255.255.0
         command:
         - /usr/sbin/openvpn
-        image: quay.io/kubermatic/openvpn:v0.6-dev
+        image: quay.io/kubermatic/openvpn:2.4.8
         name: openvpn-server
         ports:
         - containerPort: 1194
@@ -135,7 +135,7 @@ spec:
           done
         command:
         - /bin/bash
-        image: quay.io/kubermatic/openvpn:v0.6-dev
+        image: quay.io/kubermatic/openvpn:2.4.8
         name: ip-fixup
         resources:
           limits:
@@ -189,7 +189,7 @@ spec:
           iptables -A INPUT -i tun0 -j DROP
         command:
         - /bin/bash
-        image: quay.io/kubermatic/openvpn:v0.6-dev
+        image: quay.io/kubermatic/openvpn:2.4.8
         name: iptables-init
         resources:
           limits:

--- a/api/pkg/resources/test/fixtures/deployment-aws-1.10.0-openvpn-server.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-aws-1.10.0-openvpn-server.yaml
@@ -86,7 +86,7 @@ spec:
         - 255.255.255.0
         command:
         - /usr/sbin/openvpn
-        image: quay.io/kubermatic/openvpn:2.4.8
+        image: quay.io/kubermatic/openvpn:v2.4.8-r1
         name: openvpn-server
         ports:
         - containerPort: 1194
@@ -135,7 +135,7 @@ spec:
           done
         command:
         - /bin/bash
-        image: quay.io/kubermatic/openvpn:2.4.8
+        image: quay.io/kubermatic/openvpn:v2.4.8-r1
         name: ip-fixup
         resources:
           limits:
@@ -189,7 +189,7 @@ spec:
           iptables -A INPUT -i tun0 -j DROP
         command:
         - /bin/bash
-        image: quay.io/kubermatic/openvpn:2.4.8
+        image: quay.io/kubermatic/openvpn:v2.4.8-r1
         name: iptables-init
         resources:
           limits:

--- a/api/pkg/resources/test/fixtures/deployment-aws-1.10.0-openvpn-server.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-aws-1.10.0-openvpn-server.yaml
@@ -86,7 +86,7 @@ spec:
         - 255.255.255.0
         command:
         - /usr/sbin/openvpn
-        image: quay.io/kubermatic/openvpn:v0.5
+        image: quay.io/kubermatic/openvpn:v0.6-dev
         name: openvpn-server
         ports:
         - containerPort: 1194
@@ -135,7 +135,7 @@ spec:
           done
         command:
         - /bin/bash
-        image: quay.io/kubermatic/openvpn:v0.5
+        image: quay.io/kubermatic/openvpn:v0.6-dev
         name: ip-fixup
         resources:
           limits:
@@ -189,7 +189,7 @@ spec:
           iptables -A INPUT -i tun0 -j DROP
         command:
         - /bin/bash
-        image: quay.io/kubermatic/openvpn:v0.5
+        image: quay.io/kubermatic/openvpn:v0.6-dev
         name: iptables-init
         resources:
           limits:

--- a/api/pkg/resources/test/fixtures/deployment-aws-1.10.0-scheduler.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-aws-1.10.0-scheduler.yaml
@@ -79,7 +79,7 @@ spec:
         - /dev/stdout
         command:
         - /usr/sbin/openvpn
-        image: quay.io/kubermatic/openvpn:2.4.8
+        image: quay.io/kubermatic/openvpn:v2.4.8-r1
         name: openvpn-client
         resources:
           limits:

--- a/api/pkg/resources/test/fixtures/deployment-aws-1.10.0-scheduler.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-aws-1.10.0-scheduler.yaml
@@ -79,7 +79,7 @@ spec:
         - /dev/stdout
         command:
         - /usr/sbin/openvpn
-        image: quay.io/kubermatic/openvpn:v0.5
+        image: quay.io/kubermatic/openvpn:v0.6-dev
         name: openvpn-client
         resources:
           limits:

--- a/api/pkg/resources/test/fixtures/deployment-aws-1.10.0-scheduler.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-aws-1.10.0-scheduler.yaml
@@ -79,7 +79,7 @@ spec:
         - /dev/stdout
         command:
         - /usr/sbin/openvpn
-        image: quay.io/kubermatic/openvpn:v0.6-dev
+        image: quay.io/kubermatic/openvpn:2.4.8
         name: openvpn-client
         resources:
           limits:

--- a/api/pkg/resources/test/fixtures/deployment-aws-1.10.6-apiserver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-aws-1.10.6-apiserver.yaml
@@ -89,7 +89,7 @@ spec:
         - /dev/stdout
         command:
         - /usr/sbin/openvpn
-        image: quay.io/kubermatic/openvpn:v0.6-dev
+        image: quay.io/kubermatic/openvpn:2.4.8
         name: openvpn-client
         resources:
           limits:

--- a/api/pkg/resources/test/fixtures/deployment-aws-1.10.6-apiserver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-aws-1.10.6-apiserver.yaml
@@ -89,7 +89,7 @@ spec:
         - /dev/stdout
         command:
         - /usr/sbin/openvpn
-        image: quay.io/kubermatic/openvpn:2.4.8
+        image: quay.io/kubermatic/openvpn:v2.4.8-r1
         name: openvpn-client
         resources:
           limits:

--- a/api/pkg/resources/test/fixtures/deployment-aws-1.10.6-apiserver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-aws-1.10.6-apiserver.yaml
@@ -89,7 +89,7 @@ spec:
         - /dev/stdout
         command:
         - /usr/sbin/openvpn
-        image: quay.io/kubermatic/openvpn:v0.5
+        image: quay.io/kubermatic/openvpn:v0.6-dev
         name: openvpn-client
         resources:
           limits:

--- a/api/pkg/resources/test/fixtures/deployment-aws-1.10.6-controller-manager.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-aws-1.10.6-controller-manager.yaml
@@ -81,7 +81,7 @@ spec:
         - /dev/stdout
         command:
         - /usr/sbin/openvpn
-        image: quay.io/kubermatic/openvpn:v0.6-dev
+        image: quay.io/kubermatic/openvpn:2.4.8
         name: openvpn-client
         resources:
           limits:

--- a/api/pkg/resources/test/fixtures/deployment-aws-1.10.6-controller-manager.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-aws-1.10.6-controller-manager.yaml
@@ -81,7 +81,7 @@ spec:
         - /dev/stdout
         command:
         - /usr/sbin/openvpn
-        image: quay.io/kubermatic/openvpn:v0.5
+        image: quay.io/kubermatic/openvpn:v0.6-dev
         name: openvpn-client
         resources:
           limits:

--- a/api/pkg/resources/test/fixtures/deployment-aws-1.10.6-controller-manager.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-aws-1.10.6-controller-manager.yaml
@@ -81,7 +81,7 @@ spec:
         - /dev/stdout
         command:
         - /usr/sbin/openvpn
-        image: quay.io/kubermatic/openvpn:2.4.8
+        image: quay.io/kubermatic/openvpn:v2.4.8-r1
         name: openvpn-client
         resources:
           limits:

--- a/api/pkg/resources/test/fixtures/deployment-aws-1.10.6-dns-resolver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-aws-1.10.6-dns-resolver.yaml
@@ -79,7 +79,7 @@ spec:
         - /dev/stdout
         command:
         - /usr/sbin/openvpn
-        image: quay.io/kubermatic/openvpn:2.4.8
+        image: quay.io/kubermatic/openvpn:v2.4.8-r1
         name: openvpn-client
         resources:
           limits:

--- a/api/pkg/resources/test/fixtures/deployment-aws-1.10.6-dns-resolver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-aws-1.10.6-dns-resolver.yaml
@@ -79,7 +79,7 @@ spec:
         - /dev/stdout
         command:
         - /usr/sbin/openvpn
-        image: quay.io/kubermatic/openvpn:v0.5
+        image: quay.io/kubermatic/openvpn:v0.6-dev
         name: openvpn-client
         resources:
           limits:

--- a/api/pkg/resources/test/fixtures/deployment-aws-1.10.6-dns-resolver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-aws-1.10.6-dns-resolver.yaml
@@ -79,7 +79,7 @@ spec:
         - /dev/stdout
         command:
         - /usr/sbin/openvpn
-        image: quay.io/kubermatic/openvpn:v0.6-dev
+        image: quay.io/kubermatic/openvpn:2.4.8
         name: openvpn-client
         resources:
           limits:

--- a/api/pkg/resources/test/fixtures/deployment-aws-1.10.6-metrics-server.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-aws-1.10.6-metrics-server.yaml
@@ -108,7 +108,7 @@ spec:
         - /dev/stdout
         command:
         - /usr/sbin/openvpn
-        image: quay.io/kubermatic/openvpn:2.4.8
+        image: quay.io/kubermatic/openvpn:v2.4.8-r1
         name: openvpn-client
         resources:
           limits:

--- a/api/pkg/resources/test/fixtures/deployment-aws-1.10.6-metrics-server.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-aws-1.10.6-metrics-server.yaml
@@ -108,7 +108,7 @@ spec:
         - /dev/stdout
         command:
         - /usr/sbin/openvpn
-        image: quay.io/kubermatic/openvpn:v0.5
+        image: quay.io/kubermatic/openvpn:v0.6-dev
         name: openvpn-client
         resources:
           limits:

--- a/api/pkg/resources/test/fixtures/deployment-aws-1.10.6-metrics-server.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-aws-1.10.6-metrics-server.yaml
@@ -108,7 +108,7 @@ spec:
         - /dev/stdout
         command:
         - /usr/sbin/openvpn
-        image: quay.io/kubermatic/openvpn:v0.6-dev
+        image: quay.io/kubermatic/openvpn:2.4.8
         name: openvpn-client
         resources:
           limits:

--- a/api/pkg/resources/test/fixtures/deployment-aws-1.10.6-openvpn-server.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-aws-1.10.6-openvpn-server.yaml
@@ -86,7 +86,7 @@ spec:
         - 255.255.255.0
         command:
         - /usr/sbin/openvpn
-        image: quay.io/kubermatic/openvpn:v0.6-dev
+        image: quay.io/kubermatic/openvpn:2.4.8
         name: openvpn-server
         ports:
         - containerPort: 1194
@@ -135,7 +135,7 @@ spec:
           done
         command:
         - /bin/bash
-        image: quay.io/kubermatic/openvpn:v0.6-dev
+        image: quay.io/kubermatic/openvpn:2.4.8
         name: ip-fixup
         resources:
           limits:
@@ -189,7 +189,7 @@ spec:
           iptables -A INPUT -i tun0 -j DROP
         command:
         - /bin/bash
-        image: quay.io/kubermatic/openvpn:v0.6-dev
+        image: quay.io/kubermatic/openvpn:2.4.8
         name: iptables-init
         resources:
           limits:

--- a/api/pkg/resources/test/fixtures/deployment-aws-1.10.6-openvpn-server.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-aws-1.10.6-openvpn-server.yaml
@@ -86,7 +86,7 @@ spec:
         - 255.255.255.0
         command:
         - /usr/sbin/openvpn
-        image: quay.io/kubermatic/openvpn:2.4.8
+        image: quay.io/kubermatic/openvpn:v2.4.8-r1
         name: openvpn-server
         ports:
         - containerPort: 1194
@@ -135,7 +135,7 @@ spec:
           done
         command:
         - /bin/bash
-        image: quay.io/kubermatic/openvpn:2.4.8
+        image: quay.io/kubermatic/openvpn:v2.4.8-r1
         name: ip-fixup
         resources:
           limits:
@@ -189,7 +189,7 @@ spec:
           iptables -A INPUT -i tun0 -j DROP
         command:
         - /bin/bash
-        image: quay.io/kubermatic/openvpn:2.4.8
+        image: quay.io/kubermatic/openvpn:v2.4.8-r1
         name: iptables-init
         resources:
           limits:

--- a/api/pkg/resources/test/fixtures/deployment-aws-1.10.6-openvpn-server.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-aws-1.10.6-openvpn-server.yaml
@@ -86,7 +86,7 @@ spec:
         - 255.255.255.0
         command:
         - /usr/sbin/openvpn
-        image: quay.io/kubermatic/openvpn:v0.5
+        image: quay.io/kubermatic/openvpn:v0.6-dev
         name: openvpn-server
         ports:
         - containerPort: 1194
@@ -135,7 +135,7 @@ spec:
           done
         command:
         - /bin/bash
-        image: quay.io/kubermatic/openvpn:v0.5
+        image: quay.io/kubermatic/openvpn:v0.6-dev
         name: ip-fixup
         resources:
           limits:
@@ -189,7 +189,7 @@ spec:
           iptables -A INPUT -i tun0 -j DROP
         command:
         - /bin/bash
-        image: quay.io/kubermatic/openvpn:v0.5
+        image: quay.io/kubermatic/openvpn:v0.6-dev
         name: iptables-init
         resources:
           limits:

--- a/api/pkg/resources/test/fixtures/deployment-aws-1.10.6-scheduler.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-aws-1.10.6-scheduler.yaml
@@ -79,7 +79,7 @@ spec:
         - /dev/stdout
         command:
         - /usr/sbin/openvpn
-        image: quay.io/kubermatic/openvpn:2.4.8
+        image: quay.io/kubermatic/openvpn:v2.4.8-r1
         name: openvpn-client
         resources:
           limits:

--- a/api/pkg/resources/test/fixtures/deployment-aws-1.10.6-scheduler.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-aws-1.10.6-scheduler.yaml
@@ -79,7 +79,7 @@ spec:
         - /dev/stdout
         command:
         - /usr/sbin/openvpn
-        image: quay.io/kubermatic/openvpn:v0.5
+        image: quay.io/kubermatic/openvpn:v0.6-dev
         name: openvpn-client
         resources:
           limits:

--- a/api/pkg/resources/test/fixtures/deployment-aws-1.10.6-scheduler.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-aws-1.10.6-scheduler.yaml
@@ -79,7 +79,7 @@ spec:
         - /dev/stdout
         command:
         - /usr/sbin/openvpn
-        image: quay.io/kubermatic/openvpn:v0.6-dev
+        image: quay.io/kubermatic/openvpn:2.4.8
         name: openvpn-client
         resources:
           limits:

--- a/api/pkg/resources/test/fixtures/deployment-aws-1.11.0-apiserver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-aws-1.11.0-apiserver.yaml
@@ -89,7 +89,7 @@ spec:
         - /dev/stdout
         command:
         - /usr/sbin/openvpn
-        image: quay.io/kubermatic/openvpn:v0.6-dev
+        image: quay.io/kubermatic/openvpn:2.4.8
         name: openvpn-client
         resources:
           limits:

--- a/api/pkg/resources/test/fixtures/deployment-aws-1.11.0-apiserver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-aws-1.11.0-apiserver.yaml
@@ -89,7 +89,7 @@ spec:
         - /dev/stdout
         command:
         - /usr/sbin/openvpn
-        image: quay.io/kubermatic/openvpn:2.4.8
+        image: quay.io/kubermatic/openvpn:v2.4.8-r1
         name: openvpn-client
         resources:
           limits:

--- a/api/pkg/resources/test/fixtures/deployment-aws-1.11.0-apiserver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-aws-1.11.0-apiserver.yaml
@@ -89,7 +89,7 @@ spec:
         - /dev/stdout
         command:
         - /usr/sbin/openvpn
-        image: quay.io/kubermatic/openvpn:v0.5
+        image: quay.io/kubermatic/openvpn:v0.6-dev
         name: openvpn-client
         resources:
           limits:

--- a/api/pkg/resources/test/fixtures/deployment-aws-1.11.0-controller-manager.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-aws-1.11.0-controller-manager.yaml
@@ -81,7 +81,7 @@ spec:
         - /dev/stdout
         command:
         - /usr/sbin/openvpn
-        image: quay.io/kubermatic/openvpn:v0.6-dev
+        image: quay.io/kubermatic/openvpn:2.4.8
         name: openvpn-client
         resources:
           limits:

--- a/api/pkg/resources/test/fixtures/deployment-aws-1.11.0-controller-manager.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-aws-1.11.0-controller-manager.yaml
@@ -81,7 +81,7 @@ spec:
         - /dev/stdout
         command:
         - /usr/sbin/openvpn
-        image: quay.io/kubermatic/openvpn:v0.5
+        image: quay.io/kubermatic/openvpn:v0.6-dev
         name: openvpn-client
         resources:
           limits:

--- a/api/pkg/resources/test/fixtures/deployment-aws-1.11.0-controller-manager.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-aws-1.11.0-controller-manager.yaml
@@ -81,7 +81,7 @@ spec:
         - /dev/stdout
         command:
         - /usr/sbin/openvpn
-        image: quay.io/kubermatic/openvpn:2.4.8
+        image: quay.io/kubermatic/openvpn:v2.4.8-r1
         name: openvpn-client
         resources:
           limits:

--- a/api/pkg/resources/test/fixtures/deployment-aws-1.11.0-dns-resolver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-aws-1.11.0-dns-resolver.yaml
@@ -79,7 +79,7 @@ spec:
         - /dev/stdout
         command:
         - /usr/sbin/openvpn
-        image: quay.io/kubermatic/openvpn:2.4.8
+        image: quay.io/kubermatic/openvpn:v2.4.8-r1
         name: openvpn-client
         resources:
           limits:

--- a/api/pkg/resources/test/fixtures/deployment-aws-1.11.0-dns-resolver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-aws-1.11.0-dns-resolver.yaml
@@ -79,7 +79,7 @@ spec:
         - /dev/stdout
         command:
         - /usr/sbin/openvpn
-        image: quay.io/kubermatic/openvpn:v0.5
+        image: quay.io/kubermatic/openvpn:v0.6-dev
         name: openvpn-client
         resources:
           limits:

--- a/api/pkg/resources/test/fixtures/deployment-aws-1.11.0-dns-resolver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-aws-1.11.0-dns-resolver.yaml
@@ -79,7 +79,7 @@ spec:
         - /dev/stdout
         command:
         - /usr/sbin/openvpn
-        image: quay.io/kubermatic/openvpn:v0.6-dev
+        image: quay.io/kubermatic/openvpn:2.4.8
         name: openvpn-client
         resources:
           limits:

--- a/api/pkg/resources/test/fixtures/deployment-aws-1.11.0-metrics-server.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-aws-1.11.0-metrics-server.yaml
@@ -108,7 +108,7 @@ spec:
         - /dev/stdout
         command:
         - /usr/sbin/openvpn
-        image: quay.io/kubermatic/openvpn:2.4.8
+        image: quay.io/kubermatic/openvpn:v2.4.8-r1
         name: openvpn-client
         resources:
           limits:

--- a/api/pkg/resources/test/fixtures/deployment-aws-1.11.0-metrics-server.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-aws-1.11.0-metrics-server.yaml
@@ -108,7 +108,7 @@ spec:
         - /dev/stdout
         command:
         - /usr/sbin/openvpn
-        image: quay.io/kubermatic/openvpn:v0.5
+        image: quay.io/kubermatic/openvpn:v0.6-dev
         name: openvpn-client
         resources:
           limits:

--- a/api/pkg/resources/test/fixtures/deployment-aws-1.11.0-metrics-server.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-aws-1.11.0-metrics-server.yaml
@@ -108,7 +108,7 @@ spec:
         - /dev/stdout
         command:
         - /usr/sbin/openvpn
-        image: quay.io/kubermatic/openvpn:v0.6-dev
+        image: quay.io/kubermatic/openvpn:2.4.8
         name: openvpn-client
         resources:
           limits:

--- a/api/pkg/resources/test/fixtures/deployment-aws-1.11.0-openvpn-server.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-aws-1.11.0-openvpn-server.yaml
@@ -86,7 +86,7 @@ spec:
         - 255.255.255.0
         command:
         - /usr/sbin/openvpn
-        image: quay.io/kubermatic/openvpn:v0.6-dev
+        image: quay.io/kubermatic/openvpn:2.4.8
         name: openvpn-server
         ports:
         - containerPort: 1194
@@ -135,7 +135,7 @@ spec:
           done
         command:
         - /bin/bash
-        image: quay.io/kubermatic/openvpn:v0.6-dev
+        image: quay.io/kubermatic/openvpn:2.4.8
         name: ip-fixup
         resources:
           limits:
@@ -189,7 +189,7 @@ spec:
           iptables -A INPUT -i tun0 -j DROP
         command:
         - /bin/bash
-        image: quay.io/kubermatic/openvpn:v0.6-dev
+        image: quay.io/kubermatic/openvpn:2.4.8
         name: iptables-init
         resources:
           limits:

--- a/api/pkg/resources/test/fixtures/deployment-aws-1.11.0-openvpn-server.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-aws-1.11.0-openvpn-server.yaml
@@ -86,7 +86,7 @@ spec:
         - 255.255.255.0
         command:
         - /usr/sbin/openvpn
-        image: quay.io/kubermatic/openvpn:2.4.8
+        image: quay.io/kubermatic/openvpn:v2.4.8-r1
         name: openvpn-server
         ports:
         - containerPort: 1194
@@ -135,7 +135,7 @@ spec:
           done
         command:
         - /bin/bash
-        image: quay.io/kubermatic/openvpn:2.4.8
+        image: quay.io/kubermatic/openvpn:v2.4.8-r1
         name: ip-fixup
         resources:
           limits:
@@ -189,7 +189,7 @@ spec:
           iptables -A INPUT -i tun0 -j DROP
         command:
         - /bin/bash
-        image: quay.io/kubermatic/openvpn:2.4.8
+        image: quay.io/kubermatic/openvpn:v2.4.8-r1
         name: iptables-init
         resources:
           limits:

--- a/api/pkg/resources/test/fixtures/deployment-aws-1.11.0-openvpn-server.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-aws-1.11.0-openvpn-server.yaml
@@ -86,7 +86,7 @@ spec:
         - 255.255.255.0
         command:
         - /usr/sbin/openvpn
-        image: quay.io/kubermatic/openvpn:v0.5
+        image: quay.io/kubermatic/openvpn:v0.6-dev
         name: openvpn-server
         ports:
         - containerPort: 1194
@@ -135,7 +135,7 @@ spec:
           done
         command:
         - /bin/bash
-        image: quay.io/kubermatic/openvpn:v0.5
+        image: quay.io/kubermatic/openvpn:v0.6-dev
         name: ip-fixup
         resources:
           limits:
@@ -189,7 +189,7 @@ spec:
           iptables -A INPUT -i tun0 -j DROP
         command:
         - /bin/bash
-        image: quay.io/kubermatic/openvpn:v0.5
+        image: quay.io/kubermatic/openvpn:v0.6-dev
         name: iptables-init
         resources:
           limits:

--- a/api/pkg/resources/test/fixtures/deployment-aws-1.11.0-scheduler.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-aws-1.11.0-scheduler.yaml
@@ -79,7 +79,7 @@ spec:
         - /dev/stdout
         command:
         - /usr/sbin/openvpn
-        image: quay.io/kubermatic/openvpn:2.4.8
+        image: quay.io/kubermatic/openvpn:v2.4.8-r1
         name: openvpn-client
         resources:
           limits:

--- a/api/pkg/resources/test/fixtures/deployment-aws-1.11.0-scheduler.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-aws-1.11.0-scheduler.yaml
@@ -79,7 +79,7 @@ spec:
         - /dev/stdout
         command:
         - /usr/sbin/openvpn
-        image: quay.io/kubermatic/openvpn:v0.5
+        image: quay.io/kubermatic/openvpn:v0.6-dev
         name: openvpn-client
         resources:
           limits:

--- a/api/pkg/resources/test/fixtures/deployment-aws-1.11.0-scheduler.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-aws-1.11.0-scheduler.yaml
@@ -79,7 +79,7 @@ spec:
         - /dev/stdout
         command:
         - /usr/sbin/openvpn
-        image: quay.io/kubermatic/openvpn:v0.6-dev
+        image: quay.io/kubermatic/openvpn:2.4.8
         name: openvpn-client
         resources:
           limits:

--- a/api/pkg/resources/test/fixtures/deployment-aws-1.11.1-apiserver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-aws-1.11.1-apiserver.yaml
@@ -89,7 +89,7 @@ spec:
         - /dev/stdout
         command:
         - /usr/sbin/openvpn
-        image: quay.io/kubermatic/openvpn:v0.6-dev
+        image: quay.io/kubermatic/openvpn:2.4.8
         name: openvpn-client
         resources:
           limits:

--- a/api/pkg/resources/test/fixtures/deployment-aws-1.11.1-apiserver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-aws-1.11.1-apiserver.yaml
@@ -89,7 +89,7 @@ spec:
         - /dev/stdout
         command:
         - /usr/sbin/openvpn
-        image: quay.io/kubermatic/openvpn:2.4.8
+        image: quay.io/kubermatic/openvpn:v2.4.8-r1
         name: openvpn-client
         resources:
           limits:

--- a/api/pkg/resources/test/fixtures/deployment-aws-1.11.1-apiserver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-aws-1.11.1-apiserver.yaml
@@ -89,7 +89,7 @@ spec:
         - /dev/stdout
         command:
         - /usr/sbin/openvpn
-        image: quay.io/kubermatic/openvpn:v0.5
+        image: quay.io/kubermatic/openvpn:v0.6-dev
         name: openvpn-client
         resources:
           limits:

--- a/api/pkg/resources/test/fixtures/deployment-aws-1.11.1-controller-manager.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-aws-1.11.1-controller-manager.yaml
@@ -81,7 +81,7 @@ spec:
         - /dev/stdout
         command:
         - /usr/sbin/openvpn
-        image: quay.io/kubermatic/openvpn:v0.6-dev
+        image: quay.io/kubermatic/openvpn:2.4.8
         name: openvpn-client
         resources:
           limits:

--- a/api/pkg/resources/test/fixtures/deployment-aws-1.11.1-controller-manager.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-aws-1.11.1-controller-manager.yaml
@@ -81,7 +81,7 @@ spec:
         - /dev/stdout
         command:
         - /usr/sbin/openvpn
-        image: quay.io/kubermatic/openvpn:v0.5
+        image: quay.io/kubermatic/openvpn:v0.6-dev
         name: openvpn-client
         resources:
           limits:

--- a/api/pkg/resources/test/fixtures/deployment-aws-1.11.1-controller-manager.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-aws-1.11.1-controller-manager.yaml
@@ -81,7 +81,7 @@ spec:
         - /dev/stdout
         command:
         - /usr/sbin/openvpn
-        image: quay.io/kubermatic/openvpn:2.4.8
+        image: quay.io/kubermatic/openvpn:v2.4.8-r1
         name: openvpn-client
         resources:
           limits:

--- a/api/pkg/resources/test/fixtures/deployment-aws-1.11.1-dns-resolver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-aws-1.11.1-dns-resolver.yaml
@@ -79,7 +79,7 @@ spec:
         - /dev/stdout
         command:
         - /usr/sbin/openvpn
-        image: quay.io/kubermatic/openvpn:2.4.8
+        image: quay.io/kubermatic/openvpn:v2.4.8-r1
         name: openvpn-client
         resources:
           limits:

--- a/api/pkg/resources/test/fixtures/deployment-aws-1.11.1-dns-resolver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-aws-1.11.1-dns-resolver.yaml
@@ -79,7 +79,7 @@ spec:
         - /dev/stdout
         command:
         - /usr/sbin/openvpn
-        image: quay.io/kubermatic/openvpn:v0.5
+        image: quay.io/kubermatic/openvpn:v0.6-dev
         name: openvpn-client
         resources:
           limits:

--- a/api/pkg/resources/test/fixtures/deployment-aws-1.11.1-dns-resolver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-aws-1.11.1-dns-resolver.yaml
@@ -79,7 +79,7 @@ spec:
         - /dev/stdout
         command:
         - /usr/sbin/openvpn
-        image: quay.io/kubermatic/openvpn:v0.6-dev
+        image: quay.io/kubermatic/openvpn:2.4.8
         name: openvpn-client
         resources:
           limits:

--- a/api/pkg/resources/test/fixtures/deployment-aws-1.11.1-metrics-server.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-aws-1.11.1-metrics-server.yaml
@@ -108,7 +108,7 @@ spec:
         - /dev/stdout
         command:
         - /usr/sbin/openvpn
-        image: quay.io/kubermatic/openvpn:2.4.8
+        image: quay.io/kubermatic/openvpn:v2.4.8-r1
         name: openvpn-client
         resources:
           limits:

--- a/api/pkg/resources/test/fixtures/deployment-aws-1.11.1-metrics-server.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-aws-1.11.1-metrics-server.yaml
@@ -108,7 +108,7 @@ spec:
         - /dev/stdout
         command:
         - /usr/sbin/openvpn
-        image: quay.io/kubermatic/openvpn:v0.5
+        image: quay.io/kubermatic/openvpn:v0.6-dev
         name: openvpn-client
         resources:
           limits:

--- a/api/pkg/resources/test/fixtures/deployment-aws-1.11.1-metrics-server.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-aws-1.11.1-metrics-server.yaml
@@ -108,7 +108,7 @@ spec:
         - /dev/stdout
         command:
         - /usr/sbin/openvpn
-        image: quay.io/kubermatic/openvpn:v0.6-dev
+        image: quay.io/kubermatic/openvpn:2.4.8
         name: openvpn-client
         resources:
           limits:

--- a/api/pkg/resources/test/fixtures/deployment-aws-1.11.1-openvpn-server.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-aws-1.11.1-openvpn-server.yaml
@@ -86,7 +86,7 @@ spec:
         - 255.255.255.0
         command:
         - /usr/sbin/openvpn
-        image: quay.io/kubermatic/openvpn:v0.6-dev
+        image: quay.io/kubermatic/openvpn:2.4.8
         name: openvpn-server
         ports:
         - containerPort: 1194
@@ -135,7 +135,7 @@ spec:
           done
         command:
         - /bin/bash
-        image: quay.io/kubermatic/openvpn:v0.6-dev
+        image: quay.io/kubermatic/openvpn:2.4.8
         name: ip-fixup
         resources:
           limits:
@@ -189,7 +189,7 @@ spec:
           iptables -A INPUT -i tun0 -j DROP
         command:
         - /bin/bash
-        image: quay.io/kubermatic/openvpn:v0.6-dev
+        image: quay.io/kubermatic/openvpn:2.4.8
         name: iptables-init
         resources:
           limits:

--- a/api/pkg/resources/test/fixtures/deployment-aws-1.11.1-openvpn-server.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-aws-1.11.1-openvpn-server.yaml
@@ -86,7 +86,7 @@ spec:
         - 255.255.255.0
         command:
         - /usr/sbin/openvpn
-        image: quay.io/kubermatic/openvpn:2.4.8
+        image: quay.io/kubermatic/openvpn:v2.4.8-r1
         name: openvpn-server
         ports:
         - containerPort: 1194
@@ -135,7 +135,7 @@ spec:
           done
         command:
         - /bin/bash
-        image: quay.io/kubermatic/openvpn:2.4.8
+        image: quay.io/kubermatic/openvpn:v2.4.8-r1
         name: ip-fixup
         resources:
           limits:
@@ -189,7 +189,7 @@ spec:
           iptables -A INPUT -i tun0 -j DROP
         command:
         - /bin/bash
-        image: quay.io/kubermatic/openvpn:2.4.8
+        image: quay.io/kubermatic/openvpn:v2.4.8-r1
         name: iptables-init
         resources:
           limits:

--- a/api/pkg/resources/test/fixtures/deployment-aws-1.11.1-openvpn-server.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-aws-1.11.1-openvpn-server.yaml
@@ -86,7 +86,7 @@ spec:
         - 255.255.255.0
         command:
         - /usr/sbin/openvpn
-        image: quay.io/kubermatic/openvpn:v0.5
+        image: quay.io/kubermatic/openvpn:v0.6-dev
         name: openvpn-server
         ports:
         - containerPort: 1194
@@ -135,7 +135,7 @@ spec:
           done
         command:
         - /bin/bash
-        image: quay.io/kubermatic/openvpn:v0.5
+        image: quay.io/kubermatic/openvpn:v0.6-dev
         name: ip-fixup
         resources:
           limits:
@@ -189,7 +189,7 @@ spec:
           iptables -A INPUT -i tun0 -j DROP
         command:
         - /bin/bash
-        image: quay.io/kubermatic/openvpn:v0.5
+        image: quay.io/kubermatic/openvpn:v0.6-dev
         name: iptables-init
         resources:
           limits:

--- a/api/pkg/resources/test/fixtures/deployment-aws-1.11.1-scheduler.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-aws-1.11.1-scheduler.yaml
@@ -79,7 +79,7 @@ spec:
         - /dev/stdout
         command:
         - /usr/sbin/openvpn
-        image: quay.io/kubermatic/openvpn:2.4.8
+        image: quay.io/kubermatic/openvpn:v2.4.8-r1
         name: openvpn-client
         resources:
           limits:

--- a/api/pkg/resources/test/fixtures/deployment-aws-1.11.1-scheduler.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-aws-1.11.1-scheduler.yaml
@@ -79,7 +79,7 @@ spec:
         - /dev/stdout
         command:
         - /usr/sbin/openvpn
-        image: quay.io/kubermatic/openvpn:v0.5
+        image: quay.io/kubermatic/openvpn:v0.6-dev
         name: openvpn-client
         resources:
           limits:

--- a/api/pkg/resources/test/fixtures/deployment-aws-1.11.1-scheduler.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-aws-1.11.1-scheduler.yaml
@@ -79,7 +79,7 @@ spec:
         - /dev/stdout
         command:
         - /usr/sbin/openvpn
-        image: quay.io/kubermatic/openvpn:v0.6-dev
+        image: quay.io/kubermatic/openvpn:2.4.8
         name: openvpn-client
         resources:
           limits:

--- a/api/pkg/resources/test/fixtures/deployment-aws-1.12.0-apiserver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-aws-1.12.0-apiserver.yaml
@@ -89,7 +89,7 @@ spec:
         - /dev/stdout
         command:
         - /usr/sbin/openvpn
-        image: quay.io/kubermatic/openvpn:v0.6-dev
+        image: quay.io/kubermatic/openvpn:2.4.8
         name: openvpn-client
         resources:
           limits:

--- a/api/pkg/resources/test/fixtures/deployment-aws-1.12.0-apiserver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-aws-1.12.0-apiserver.yaml
@@ -89,7 +89,7 @@ spec:
         - /dev/stdout
         command:
         - /usr/sbin/openvpn
-        image: quay.io/kubermatic/openvpn:2.4.8
+        image: quay.io/kubermatic/openvpn:v2.4.8-r1
         name: openvpn-client
         resources:
           limits:

--- a/api/pkg/resources/test/fixtures/deployment-aws-1.12.0-apiserver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-aws-1.12.0-apiserver.yaml
@@ -89,7 +89,7 @@ spec:
         - /dev/stdout
         command:
         - /usr/sbin/openvpn
-        image: quay.io/kubermatic/openvpn:v0.5
+        image: quay.io/kubermatic/openvpn:v0.6-dev
         name: openvpn-client
         resources:
           limits:

--- a/api/pkg/resources/test/fixtures/deployment-aws-1.12.0-controller-manager.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-aws-1.12.0-controller-manager.yaml
@@ -81,7 +81,7 @@ spec:
         - /dev/stdout
         command:
         - /usr/sbin/openvpn
-        image: quay.io/kubermatic/openvpn:v0.6-dev
+        image: quay.io/kubermatic/openvpn:2.4.8
         name: openvpn-client
         resources:
           limits:

--- a/api/pkg/resources/test/fixtures/deployment-aws-1.12.0-controller-manager.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-aws-1.12.0-controller-manager.yaml
@@ -81,7 +81,7 @@ spec:
         - /dev/stdout
         command:
         - /usr/sbin/openvpn
-        image: quay.io/kubermatic/openvpn:v0.5
+        image: quay.io/kubermatic/openvpn:v0.6-dev
         name: openvpn-client
         resources:
           limits:

--- a/api/pkg/resources/test/fixtures/deployment-aws-1.12.0-controller-manager.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-aws-1.12.0-controller-manager.yaml
@@ -81,7 +81,7 @@ spec:
         - /dev/stdout
         command:
         - /usr/sbin/openvpn
-        image: quay.io/kubermatic/openvpn:2.4.8
+        image: quay.io/kubermatic/openvpn:v2.4.8-r1
         name: openvpn-client
         resources:
           limits:

--- a/api/pkg/resources/test/fixtures/deployment-aws-1.12.0-dns-resolver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-aws-1.12.0-dns-resolver.yaml
@@ -79,7 +79,7 @@ spec:
         - /dev/stdout
         command:
         - /usr/sbin/openvpn
-        image: quay.io/kubermatic/openvpn:2.4.8
+        image: quay.io/kubermatic/openvpn:v2.4.8-r1
         name: openvpn-client
         resources:
           limits:

--- a/api/pkg/resources/test/fixtures/deployment-aws-1.12.0-dns-resolver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-aws-1.12.0-dns-resolver.yaml
@@ -79,7 +79,7 @@ spec:
         - /dev/stdout
         command:
         - /usr/sbin/openvpn
-        image: quay.io/kubermatic/openvpn:v0.5
+        image: quay.io/kubermatic/openvpn:v0.6-dev
         name: openvpn-client
         resources:
           limits:

--- a/api/pkg/resources/test/fixtures/deployment-aws-1.12.0-dns-resolver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-aws-1.12.0-dns-resolver.yaml
@@ -79,7 +79,7 @@ spec:
         - /dev/stdout
         command:
         - /usr/sbin/openvpn
-        image: quay.io/kubermatic/openvpn:v0.6-dev
+        image: quay.io/kubermatic/openvpn:2.4.8
         name: openvpn-client
         resources:
           limits:

--- a/api/pkg/resources/test/fixtures/deployment-aws-1.12.0-metrics-server.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-aws-1.12.0-metrics-server.yaml
@@ -108,7 +108,7 @@ spec:
         - /dev/stdout
         command:
         - /usr/sbin/openvpn
-        image: quay.io/kubermatic/openvpn:2.4.8
+        image: quay.io/kubermatic/openvpn:v2.4.8-r1
         name: openvpn-client
         resources:
           limits:

--- a/api/pkg/resources/test/fixtures/deployment-aws-1.12.0-metrics-server.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-aws-1.12.0-metrics-server.yaml
@@ -108,7 +108,7 @@ spec:
         - /dev/stdout
         command:
         - /usr/sbin/openvpn
-        image: quay.io/kubermatic/openvpn:v0.5
+        image: quay.io/kubermatic/openvpn:v0.6-dev
         name: openvpn-client
         resources:
           limits:

--- a/api/pkg/resources/test/fixtures/deployment-aws-1.12.0-metrics-server.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-aws-1.12.0-metrics-server.yaml
@@ -108,7 +108,7 @@ spec:
         - /dev/stdout
         command:
         - /usr/sbin/openvpn
-        image: quay.io/kubermatic/openvpn:v0.6-dev
+        image: quay.io/kubermatic/openvpn:2.4.8
         name: openvpn-client
         resources:
           limits:

--- a/api/pkg/resources/test/fixtures/deployment-aws-1.12.0-openvpn-server.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-aws-1.12.0-openvpn-server.yaml
@@ -86,7 +86,7 @@ spec:
         - 255.255.255.0
         command:
         - /usr/sbin/openvpn
-        image: quay.io/kubermatic/openvpn:v0.6-dev
+        image: quay.io/kubermatic/openvpn:2.4.8
         name: openvpn-server
         ports:
         - containerPort: 1194
@@ -135,7 +135,7 @@ spec:
           done
         command:
         - /bin/bash
-        image: quay.io/kubermatic/openvpn:v0.6-dev
+        image: quay.io/kubermatic/openvpn:2.4.8
         name: ip-fixup
         resources:
           limits:
@@ -189,7 +189,7 @@ spec:
           iptables -A INPUT -i tun0 -j DROP
         command:
         - /bin/bash
-        image: quay.io/kubermatic/openvpn:v0.6-dev
+        image: quay.io/kubermatic/openvpn:2.4.8
         name: iptables-init
         resources:
           limits:

--- a/api/pkg/resources/test/fixtures/deployment-aws-1.12.0-openvpn-server.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-aws-1.12.0-openvpn-server.yaml
@@ -86,7 +86,7 @@ spec:
         - 255.255.255.0
         command:
         - /usr/sbin/openvpn
-        image: quay.io/kubermatic/openvpn:2.4.8
+        image: quay.io/kubermatic/openvpn:v2.4.8-r1
         name: openvpn-server
         ports:
         - containerPort: 1194
@@ -135,7 +135,7 @@ spec:
           done
         command:
         - /bin/bash
-        image: quay.io/kubermatic/openvpn:2.4.8
+        image: quay.io/kubermatic/openvpn:v2.4.8-r1
         name: ip-fixup
         resources:
           limits:
@@ -189,7 +189,7 @@ spec:
           iptables -A INPUT -i tun0 -j DROP
         command:
         - /bin/bash
-        image: quay.io/kubermatic/openvpn:2.4.8
+        image: quay.io/kubermatic/openvpn:v2.4.8-r1
         name: iptables-init
         resources:
           limits:

--- a/api/pkg/resources/test/fixtures/deployment-aws-1.12.0-openvpn-server.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-aws-1.12.0-openvpn-server.yaml
@@ -86,7 +86,7 @@ spec:
         - 255.255.255.0
         command:
         - /usr/sbin/openvpn
-        image: quay.io/kubermatic/openvpn:v0.5
+        image: quay.io/kubermatic/openvpn:v0.6-dev
         name: openvpn-server
         ports:
         - containerPort: 1194
@@ -135,7 +135,7 @@ spec:
           done
         command:
         - /bin/bash
-        image: quay.io/kubermatic/openvpn:v0.5
+        image: quay.io/kubermatic/openvpn:v0.6-dev
         name: ip-fixup
         resources:
           limits:
@@ -189,7 +189,7 @@ spec:
           iptables -A INPUT -i tun0 -j DROP
         command:
         - /bin/bash
-        image: quay.io/kubermatic/openvpn:v0.5
+        image: quay.io/kubermatic/openvpn:v0.6-dev
         name: iptables-init
         resources:
           limits:

--- a/api/pkg/resources/test/fixtures/deployment-aws-1.12.0-scheduler.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-aws-1.12.0-scheduler.yaml
@@ -79,7 +79,7 @@ spec:
         - /dev/stdout
         command:
         - /usr/sbin/openvpn
-        image: quay.io/kubermatic/openvpn:2.4.8
+        image: quay.io/kubermatic/openvpn:v2.4.8-r1
         name: openvpn-client
         resources:
           limits:

--- a/api/pkg/resources/test/fixtures/deployment-aws-1.12.0-scheduler.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-aws-1.12.0-scheduler.yaml
@@ -79,7 +79,7 @@ spec:
         - /dev/stdout
         command:
         - /usr/sbin/openvpn
-        image: quay.io/kubermatic/openvpn:v0.5
+        image: quay.io/kubermatic/openvpn:v0.6-dev
         name: openvpn-client
         resources:
           limits:

--- a/api/pkg/resources/test/fixtures/deployment-aws-1.12.0-scheduler.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-aws-1.12.0-scheduler.yaml
@@ -79,7 +79,7 @@ spec:
         - /dev/stdout
         command:
         - /usr/sbin/openvpn
-        image: quay.io/kubermatic/openvpn:v0.6-dev
+        image: quay.io/kubermatic/openvpn:2.4.8
         name: openvpn-client
         resources:
           limits:

--- a/api/pkg/resources/test/fixtures/deployment-aws-1.13.0-apiserver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-aws-1.13.0-apiserver.yaml
@@ -89,7 +89,7 @@ spec:
         - /dev/stdout
         command:
         - /usr/sbin/openvpn
-        image: quay.io/kubermatic/openvpn:v0.6-dev
+        image: quay.io/kubermatic/openvpn:2.4.8
         name: openvpn-client
         resources:
           limits:

--- a/api/pkg/resources/test/fixtures/deployment-aws-1.13.0-apiserver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-aws-1.13.0-apiserver.yaml
@@ -89,7 +89,7 @@ spec:
         - /dev/stdout
         command:
         - /usr/sbin/openvpn
-        image: quay.io/kubermatic/openvpn:2.4.8
+        image: quay.io/kubermatic/openvpn:v2.4.8-r1
         name: openvpn-client
         resources:
           limits:

--- a/api/pkg/resources/test/fixtures/deployment-aws-1.13.0-apiserver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-aws-1.13.0-apiserver.yaml
@@ -89,7 +89,7 @@ spec:
         - /dev/stdout
         command:
         - /usr/sbin/openvpn
-        image: quay.io/kubermatic/openvpn:v0.5
+        image: quay.io/kubermatic/openvpn:v0.6-dev
         name: openvpn-client
         resources:
           limits:

--- a/api/pkg/resources/test/fixtures/deployment-aws-1.13.0-controller-manager.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-aws-1.13.0-controller-manager.yaml
@@ -81,7 +81,7 @@ spec:
         - /dev/stdout
         command:
         - /usr/sbin/openvpn
-        image: quay.io/kubermatic/openvpn:v0.6-dev
+        image: quay.io/kubermatic/openvpn:2.4.8
         name: openvpn-client
         resources:
           limits:

--- a/api/pkg/resources/test/fixtures/deployment-aws-1.13.0-controller-manager.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-aws-1.13.0-controller-manager.yaml
@@ -81,7 +81,7 @@ spec:
         - /dev/stdout
         command:
         - /usr/sbin/openvpn
-        image: quay.io/kubermatic/openvpn:v0.5
+        image: quay.io/kubermatic/openvpn:v0.6-dev
         name: openvpn-client
         resources:
           limits:

--- a/api/pkg/resources/test/fixtures/deployment-aws-1.13.0-controller-manager.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-aws-1.13.0-controller-manager.yaml
@@ -81,7 +81,7 @@ spec:
         - /dev/stdout
         command:
         - /usr/sbin/openvpn
-        image: quay.io/kubermatic/openvpn:2.4.8
+        image: quay.io/kubermatic/openvpn:v2.4.8-r1
         name: openvpn-client
         resources:
           limits:

--- a/api/pkg/resources/test/fixtures/deployment-aws-1.13.0-dns-resolver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-aws-1.13.0-dns-resolver.yaml
@@ -79,7 +79,7 @@ spec:
         - /dev/stdout
         command:
         - /usr/sbin/openvpn
-        image: quay.io/kubermatic/openvpn:2.4.8
+        image: quay.io/kubermatic/openvpn:v2.4.8-r1
         name: openvpn-client
         resources:
           limits:

--- a/api/pkg/resources/test/fixtures/deployment-aws-1.13.0-dns-resolver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-aws-1.13.0-dns-resolver.yaml
@@ -79,7 +79,7 @@ spec:
         - /dev/stdout
         command:
         - /usr/sbin/openvpn
-        image: quay.io/kubermatic/openvpn:v0.5
+        image: quay.io/kubermatic/openvpn:v0.6-dev
         name: openvpn-client
         resources:
           limits:

--- a/api/pkg/resources/test/fixtures/deployment-aws-1.13.0-dns-resolver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-aws-1.13.0-dns-resolver.yaml
@@ -79,7 +79,7 @@ spec:
         - /dev/stdout
         command:
         - /usr/sbin/openvpn
-        image: quay.io/kubermatic/openvpn:v0.6-dev
+        image: quay.io/kubermatic/openvpn:2.4.8
         name: openvpn-client
         resources:
           limits:

--- a/api/pkg/resources/test/fixtures/deployment-aws-1.13.0-metrics-server.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-aws-1.13.0-metrics-server.yaml
@@ -108,7 +108,7 @@ spec:
         - /dev/stdout
         command:
         - /usr/sbin/openvpn
-        image: quay.io/kubermatic/openvpn:2.4.8
+        image: quay.io/kubermatic/openvpn:v2.4.8-r1
         name: openvpn-client
         resources:
           limits:

--- a/api/pkg/resources/test/fixtures/deployment-aws-1.13.0-metrics-server.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-aws-1.13.0-metrics-server.yaml
@@ -108,7 +108,7 @@ spec:
         - /dev/stdout
         command:
         - /usr/sbin/openvpn
-        image: quay.io/kubermatic/openvpn:v0.5
+        image: quay.io/kubermatic/openvpn:v0.6-dev
         name: openvpn-client
         resources:
           limits:

--- a/api/pkg/resources/test/fixtures/deployment-aws-1.13.0-metrics-server.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-aws-1.13.0-metrics-server.yaml
@@ -108,7 +108,7 @@ spec:
         - /dev/stdout
         command:
         - /usr/sbin/openvpn
-        image: quay.io/kubermatic/openvpn:v0.6-dev
+        image: quay.io/kubermatic/openvpn:2.4.8
         name: openvpn-client
         resources:
           limits:

--- a/api/pkg/resources/test/fixtures/deployment-aws-1.13.0-openvpn-server.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-aws-1.13.0-openvpn-server.yaml
@@ -86,7 +86,7 @@ spec:
         - 255.255.255.0
         command:
         - /usr/sbin/openvpn
-        image: quay.io/kubermatic/openvpn:v0.6-dev
+        image: quay.io/kubermatic/openvpn:2.4.8
         name: openvpn-server
         ports:
         - containerPort: 1194
@@ -135,7 +135,7 @@ spec:
           done
         command:
         - /bin/bash
-        image: quay.io/kubermatic/openvpn:v0.6-dev
+        image: quay.io/kubermatic/openvpn:2.4.8
         name: ip-fixup
         resources:
           limits:
@@ -189,7 +189,7 @@ spec:
           iptables -A INPUT -i tun0 -j DROP
         command:
         - /bin/bash
-        image: quay.io/kubermatic/openvpn:v0.6-dev
+        image: quay.io/kubermatic/openvpn:2.4.8
         name: iptables-init
         resources:
           limits:

--- a/api/pkg/resources/test/fixtures/deployment-aws-1.13.0-openvpn-server.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-aws-1.13.0-openvpn-server.yaml
@@ -86,7 +86,7 @@ spec:
         - 255.255.255.0
         command:
         - /usr/sbin/openvpn
-        image: quay.io/kubermatic/openvpn:2.4.8
+        image: quay.io/kubermatic/openvpn:v2.4.8-r1
         name: openvpn-server
         ports:
         - containerPort: 1194
@@ -135,7 +135,7 @@ spec:
           done
         command:
         - /bin/bash
-        image: quay.io/kubermatic/openvpn:2.4.8
+        image: quay.io/kubermatic/openvpn:v2.4.8-r1
         name: ip-fixup
         resources:
           limits:
@@ -189,7 +189,7 @@ spec:
           iptables -A INPUT -i tun0 -j DROP
         command:
         - /bin/bash
-        image: quay.io/kubermatic/openvpn:2.4.8
+        image: quay.io/kubermatic/openvpn:v2.4.8-r1
         name: iptables-init
         resources:
           limits:

--- a/api/pkg/resources/test/fixtures/deployment-aws-1.13.0-openvpn-server.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-aws-1.13.0-openvpn-server.yaml
@@ -86,7 +86,7 @@ spec:
         - 255.255.255.0
         command:
         - /usr/sbin/openvpn
-        image: quay.io/kubermatic/openvpn:v0.5
+        image: quay.io/kubermatic/openvpn:v0.6-dev
         name: openvpn-server
         ports:
         - containerPort: 1194
@@ -135,7 +135,7 @@ spec:
           done
         command:
         - /bin/bash
-        image: quay.io/kubermatic/openvpn:v0.5
+        image: quay.io/kubermatic/openvpn:v0.6-dev
         name: ip-fixup
         resources:
           limits:
@@ -189,7 +189,7 @@ spec:
           iptables -A INPUT -i tun0 -j DROP
         command:
         - /bin/bash
-        image: quay.io/kubermatic/openvpn:v0.5
+        image: quay.io/kubermatic/openvpn:v0.6-dev
         name: iptables-init
         resources:
           limits:

--- a/api/pkg/resources/test/fixtures/deployment-aws-1.13.0-scheduler.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-aws-1.13.0-scheduler.yaml
@@ -79,7 +79,7 @@ spec:
         - /dev/stdout
         command:
         - /usr/sbin/openvpn
-        image: quay.io/kubermatic/openvpn:2.4.8
+        image: quay.io/kubermatic/openvpn:v2.4.8-r1
         name: openvpn-client
         resources:
           limits:

--- a/api/pkg/resources/test/fixtures/deployment-aws-1.13.0-scheduler.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-aws-1.13.0-scheduler.yaml
@@ -79,7 +79,7 @@ spec:
         - /dev/stdout
         command:
         - /usr/sbin/openvpn
-        image: quay.io/kubermatic/openvpn:v0.5
+        image: quay.io/kubermatic/openvpn:v0.6-dev
         name: openvpn-client
         resources:
           limits:

--- a/api/pkg/resources/test/fixtures/deployment-aws-1.13.0-scheduler.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-aws-1.13.0-scheduler.yaml
@@ -79,7 +79,7 @@ spec:
         - /dev/stdout
         command:
         - /usr/sbin/openvpn
-        image: quay.io/kubermatic/openvpn:v0.6-dev
+        image: quay.io/kubermatic/openvpn:2.4.8
         name: openvpn-client
         resources:
           limits:

--- a/api/pkg/resources/test/fixtures/deployment-azure-1.10.0-apiserver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-azure-1.10.0-apiserver.yaml
@@ -89,7 +89,7 @@ spec:
         - /dev/stdout
         command:
         - /usr/sbin/openvpn
-        image: quay.io/kubermatic/openvpn:v0.6-dev
+        image: quay.io/kubermatic/openvpn:2.4.8
         name: openvpn-client
         resources:
           limits:

--- a/api/pkg/resources/test/fixtures/deployment-azure-1.10.0-apiserver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-azure-1.10.0-apiserver.yaml
@@ -89,7 +89,7 @@ spec:
         - /dev/stdout
         command:
         - /usr/sbin/openvpn
-        image: quay.io/kubermatic/openvpn:2.4.8
+        image: quay.io/kubermatic/openvpn:v2.4.8-r1
         name: openvpn-client
         resources:
           limits:

--- a/api/pkg/resources/test/fixtures/deployment-azure-1.10.0-apiserver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-azure-1.10.0-apiserver.yaml
@@ -89,7 +89,7 @@ spec:
         - /dev/stdout
         command:
         - /usr/sbin/openvpn
-        image: quay.io/kubermatic/openvpn:v0.5
+        image: quay.io/kubermatic/openvpn:v0.6-dev
         name: openvpn-client
         resources:
           limits:

--- a/api/pkg/resources/test/fixtures/deployment-azure-1.10.0-controller-manager.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-azure-1.10.0-controller-manager.yaml
@@ -81,7 +81,7 @@ spec:
         - /dev/stdout
         command:
         - /usr/sbin/openvpn
-        image: quay.io/kubermatic/openvpn:v0.6-dev
+        image: quay.io/kubermatic/openvpn:2.4.8
         name: openvpn-client
         resources:
           limits:

--- a/api/pkg/resources/test/fixtures/deployment-azure-1.10.0-controller-manager.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-azure-1.10.0-controller-manager.yaml
@@ -81,7 +81,7 @@ spec:
         - /dev/stdout
         command:
         - /usr/sbin/openvpn
-        image: quay.io/kubermatic/openvpn:v0.5
+        image: quay.io/kubermatic/openvpn:v0.6-dev
         name: openvpn-client
         resources:
           limits:

--- a/api/pkg/resources/test/fixtures/deployment-azure-1.10.0-controller-manager.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-azure-1.10.0-controller-manager.yaml
@@ -81,7 +81,7 @@ spec:
         - /dev/stdout
         command:
         - /usr/sbin/openvpn
-        image: quay.io/kubermatic/openvpn:2.4.8
+        image: quay.io/kubermatic/openvpn:v2.4.8-r1
         name: openvpn-client
         resources:
           limits:

--- a/api/pkg/resources/test/fixtures/deployment-azure-1.10.0-dns-resolver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-azure-1.10.0-dns-resolver.yaml
@@ -79,7 +79,7 @@ spec:
         - /dev/stdout
         command:
         - /usr/sbin/openvpn
-        image: quay.io/kubermatic/openvpn:2.4.8
+        image: quay.io/kubermatic/openvpn:v2.4.8-r1
         name: openvpn-client
         resources:
           limits:

--- a/api/pkg/resources/test/fixtures/deployment-azure-1.10.0-dns-resolver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-azure-1.10.0-dns-resolver.yaml
@@ -79,7 +79,7 @@ spec:
         - /dev/stdout
         command:
         - /usr/sbin/openvpn
-        image: quay.io/kubermatic/openvpn:v0.5
+        image: quay.io/kubermatic/openvpn:v0.6-dev
         name: openvpn-client
         resources:
           limits:

--- a/api/pkg/resources/test/fixtures/deployment-azure-1.10.0-dns-resolver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-azure-1.10.0-dns-resolver.yaml
@@ -79,7 +79,7 @@ spec:
         - /dev/stdout
         command:
         - /usr/sbin/openvpn
-        image: quay.io/kubermatic/openvpn:v0.6-dev
+        image: quay.io/kubermatic/openvpn:2.4.8
         name: openvpn-client
         resources:
           limits:

--- a/api/pkg/resources/test/fixtures/deployment-azure-1.10.0-metrics-server.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-azure-1.10.0-metrics-server.yaml
@@ -108,7 +108,7 @@ spec:
         - /dev/stdout
         command:
         - /usr/sbin/openvpn
-        image: quay.io/kubermatic/openvpn:2.4.8
+        image: quay.io/kubermatic/openvpn:v2.4.8-r1
         name: openvpn-client
         resources:
           limits:

--- a/api/pkg/resources/test/fixtures/deployment-azure-1.10.0-metrics-server.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-azure-1.10.0-metrics-server.yaml
@@ -108,7 +108,7 @@ spec:
         - /dev/stdout
         command:
         - /usr/sbin/openvpn
-        image: quay.io/kubermatic/openvpn:v0.5
+        image: quay.io/kubermatic/openvpn:v0.6-dev
         name: openvpn-client
         resources:
           limits:

--- a/api/pkg/resources/test/fixtures/deployment-azure-1.10.0-metrics-server.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-azure-1.10.0-metrics-server.yaml
@@ -108,7 +108,7 @@ spec:
         - /dev/stdout
         command:
         - /usr/sbin/openvpn
-        image: quay.io/kubermatic/openvpn:v0.6-dev
+        image: quay.io/kubermatic/openvpn:2.4.8
         name: openvpn-client
         resources:
           limits:

--- a/api/pkg/resources/test/fixtures/deployment-azure-1.10.0-openvpn-server.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-azure-1.10.0-openvpn-server.yaml
@@ -86,7 +86,7 @@ spec:
         - 255.255.255.0
         command:
         - /usr/sbin/openvpn
-        image: quay.io/kubermatic/openvpn:v0.6-dev
+        image: quay.io/kubermatic/openvpn:2.4.8
         name: openvpn-server
         ports:
         - containerPort: 1194
@@ -135,7 +135,7 @@ spec:
           done
         command:
         - /bin/bash
-        image: quay.io/kubermatic/openvpn:v0.6-dev
+        image: quay.io/kubermatic/openvpn:2.4.8
         name: ip-fixup
         resources:
           limits:
@@ -189,7 +189,7 @@ spec:
           iptables -A INPUT -i tun0 -j DROP
         command:
         - /bin/bash
-        image: quay.io/kubermatic/openvpn:v0.6-dev
+        image: quay.io/kubermatic/openvpn:2.4.8
         name: iptables-init
         resources:
           limits:

--- a/api/pkg/resources/test/fixtures/deployment-azure-1.10.0-openvpn-server.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-azure-1.10.0-openvpn-server.yaml
@@ -86,7 +86,7 @@ spec:
         - 255.255.255.0
         command:
         - /usr/sbin/openvpn
-        image: quay.io/kubermatic/openvpn:2.4.8
+        image: quay.io/kubermatic/openvpn:v2.4.8-r1
         name: openvpn-server
         ports:
         - containerPort: 1194
@@ -135,7 +135,7 @@ spec:
           done
         command:
         - /bin/bash
-        image: quay.io/kubermatic/openvpn:2.4.8
+        image: quay.io/kubermatic/openvpn:v2.4.8-r1
         name: ip-fixup
         resources:
           limits:
@@ -189,7 +189,7 @@ spec:
           iptables -A INPUT -i tun0 -j DROP
         command:
         - /bin/bash
-        image: quay.io/kubermatic/openvpn:2.4.8
+        image: quay.io/kubermatic/openvpn:v2.4.8-r1
         name: iptables-init
         resources:
           limits:

--- a/api/pkg/resources/test/fixtures/deployment-azure-1.10.0-openvpn-server.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-azure-1.10.0-openvpn-server.yaml
@@ -86,7 +86,7 @@ spec:
         - 255.255.255.0
         command:
         - /usr/sbin/openvpn
-        image: quay.io/kubermatic/openvpn:v0.5
+        image: quay.io/kubermatic/openvpn:v0.6-dev
         name: openvpn-server
         ports:
         - containerPort: 1194
@@ -135,7 +135,7 @@ spec:
           done
         command:
         - /bin/bash
-        image: quay.io/kubermatic/openvpn:v0.5
+        image: quay.io/kubermatic/openvpn:v0.6-dev
         name: ip-fixup
         resources:
           limits:
@@ -189,7 +189,7 @@ spec:
           iptables -A INPUT -i tun0 -j DROP
         command:
         - /bin/bash
-        image: quay.io/kubermatic/openvpn:v0.5
+        image: quay.io/kubermatic/openvpn:v0.6-dev
         name: iptables-init
         resources:
           limits:

--- a/api/pkg/resources/test/fixtures/deployment-azure-1.10.0-scheduler.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-azure-1.10.0-scheduler.yaml
@@ -79,7 +79,7 @@ spec:
         - /dev/stdout
         command:
         - /usr/sbin/openvpn
-        image: quay.io/kubermatic/openvpn:2.4.8
+        image: quay.io/kubermatic/openvpn:v2.4.8-r1
         name: openvpn-client
         resources:
           limits:

--- a/api/pkg/resources/test/fixtures/deployment-azure-1.10.0-scheduler.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-azure-1.10.0-scheduler.yaml
@@ -79,7 +79,7 @@ spec:
         - /dev/stdout
         command:
         - /usr/sbin/openvpn
-        image: quay.io/kubermatic/openvpn:v0.5
+        image: quay.io/kubermatic/openvpn:v0.6-dev
         name: openvpn-client
         resources:
           limits:

--- a/api/pkg/resources/test/fixtures/deployment-azure-1.10.0-scheduler.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-azure-1.10.0-scheduler.yaml
@@ -79,7 +79,7 @@ spec:
         - /dev/stdout
         command:
         - /usr/sbin/openvpn
-        image: quay.io/kubermatic/openvpn:v0.6-dev
+        image: quay.io/kubermatic/openvpn:2.4.8
         name: openvpn-client
         resources:
           limits:

--- a/api/pkg/resources/test/fixtures/deployment-azure-1.10.6-apiserver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-azure-1.10.6-apiserver.yaml
@@ -89,7 +89,7 @@ spec:
         - /dev/stdout
         command:
         - /usr/sbin/openvpn
-        image: quay.io/kubermatic/openvpn:v0.6-dev
+        image: quay.io/kubermatic/openvpn:2.4.8
         name: openvpn-client
         resources:
           limits:

--- a/api/pkg/resources/test/fixtures/deployment-azure-1.10.6-apiserver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-azure-1.10.6-apiserver.yaml
@@ -89,7 +89,7 @@ spec:
         - /dev/stdout
         command:
         - /usr/sbin/openvpn
-        image: quay.io/kubermatic/openvpn:2.4.8
+        image: quay.io/kubermatic/openvpn:v2.4.8-r1
         name: openvpn-client
         resources:
           limits:

--- a/api/pkg/resources/test/fixtures/deployment-azure-1.10.6-apiserver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-azure-1.10.6-apiserver.yaml
@@ -89,7 +89,7 @@ spec:
         - /dev/stdout
         command:
         - /usr/sbin/openvpn
-        image: quay.io/kubermatic/openvpn:v0.5
+        image: quay.io/kubermatic/openvpn:v0.6-dev
         name: openvpn-client
         resources:
           limits:

--- a/api/pkg/resources/test/fixtures/deployment-azure-1.10.6-controller-manager.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-azure-1.10.6-controller-manager.yaml
@@ -81,7 +81,7 @@ spec:
         - /dev/stdout
         command:
         - /usr/sbin/openvpn
-        image: quay.io/kubermatic/openvpn:v0.6-dev
+        image: quay.io/kubermatic/openvpn:2.4.8
         name: openvpn-client
         resources:
           limits:

--- a/api/pkg/resources/test/fixtures/deployment-azure-1.10.6-controller-manager.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-azure-1.10.6-controller-manager.yaml
@@ -81,7 +81,7 @@ spec:
         - /dev/stdout
         command:
         - /usr/sbin/openvpn
-        image: quay.io/kubermatic/openvpn:v0.5
+        image: quay.io/kubermatic/openvpn:v0.6-dev
         name: openvpn-client
         resources:
           limits:

--- a/api/pkg/resources/test/fixtures/deployment-azure-1.10.6-controller-manager.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-azure-1.10.6-controller-manager.yaml
@@ -81,7 +81,7 @@ spec:
         - /dev/stdout
         command:
         - /usr/sbin/openvpn
-        image: quay.io/kubermatic/openvpn:2.4.8
+        image: quay.io/kubermatic/openvpn:v2.4.8-r1
         name: openvpn-client
         resources:
           limits:

--- a/api/pkg/resources/test/fixtures/deployment-azure-1.10.6-dns-resolver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-azure-1.10.6-dns-resolver.yaml
@@ -79,7 +79,7 @@ spec:
         - /dev/stdout
         command:
         - /usr/sbin/openvpn
-        image: quay.io/kubermatic/openvpn:2.4.8
+        image: quay.io/kubermatic/openvpn:v2.4.8-r1
         name: openvpn-client
         resources:
           limits:

--- a/api/pkg/resources/test/fixtures/deployment-azure-1.10.6-dns-resolver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-azure-1.10.6-dns-resolver.yaml
@@ -79,7 +79,7 @@ spec:
         - /dev/stdout
         command:
         - /usr/sbin/openvpn
-        image: quay.io/kubermatic/openvpn:v0.5
+        image: quay.io/kubermatic/openvpn:v0.6-dev
         name: openvpn-client
         resources:
           limits:

--- a/api/pkg/resources/test/fixtures/deployment-azure-1.10.6-dns-resolver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-azure-1.10.6-dns-resolver.yaml
@@ -79,7 +79,7 @@ spec:
         - /dev/stdout
         command:
         - /usr/sbin/openvpn
-        image: quay.io/kubermatic/openvpn:v0.6-dev
+        image: quay.io/kubermatic/openvpn:2.4.8
         name: openvpn-client
         resources:
           limits:

--- a/api/pkg/resources/test/fixtures/deployment-azure-1.10.6-metrics-server.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-azure-1.10.6-metrics-server.yaml
@@ -108,7 +108,7 @@ spec:
         - /dev/stdout
         command:
         - /usr/sbin/openvpn
-        image: quay.io/kubermatic/openvpn:2.4.8
+        image: quay.io/kubermatic/openvpn:v2.4.8-r1
         name: openvpn-client
         resources:
           limits:

--- a/api/pkg/resources/test/fixtures/deployment-azure-1.10.6-metrics-server.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-azure-1.10.6-metrics-server.yaml
@@ -108,7 +108,7 @@ spec:
         - /dev/stdout
         command:
         - /usr/sbin/openvpn
-        image: quay.io/kubermatic/openvpn:v0.5
+        image: quay.io/kubermatic/openvpn:v0.6-dev
         name: openvpn-client
         resources:
           limits:

--- a/api/pkg/resources/test/fixtures/deployment-azure-1.10.6-metrics-server.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-azure-1.10.6-metrics-server.yaml
@@ -108,7 +108,7 @@ spec:
         - /dev/stdout
         command:
         - /usr/sbin/openvpn
-        image: quay.io/kubermatic/openvpn:v0.6-dev
+        image: quay.io/kubermatic/openvpn:2.4.8
         name: openvpn-client
         resources:
           limits:

--- a/api/pkg/resources/test/fixtures/deployment-azure-1.10.6-openvpn-server.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-azure-1.10.6-openvpn-server.yaml
@@ -86,7 +86,7 @@ spec:
         - 255.255.255.0
         command:
         - /usr/sbin/openvpn
-        image: quay.io/kubermatic/openvpn:v0.6-dev
+        image: quay.io/kubermatic/openvpn:2.4.8
         name: openvpn-server
         ports:
         - containerPort: 1194
@@ -135,7 +135,7 @@ spec:
           done
         command:
         - /bin/bash
-        image: quay.io/kubermatic/openvpn:v0.6-dev
+        image: quay.io/kubermatic/openvpn:2.4.8
         name: ip-fixup
         resources:
           limits:
@@ -189,7 +189,7 @@ spec:
           iptables -A INPUT -i tun0 -j DROP
         command:
         - /bin/bash
-        image: quay.io/kubermatic/openvpn:v0.6-dev
+        image: quay.io/kubermatic/openvpn:2.4.8
         name: iptables-init
         resources:
           limits:

--- a/api/pkg/resources/test/fixtures/deployment-azure-1.10.6-openvpn-server.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-azure-1.10.6-openvpn-server.yaml
@@ -86,7 +86,7 @@ spec:
         - 255.255.255.0
         command:
         - /usr/sbin/openvpn
-        image: quay.io/kubermatic/openvpn:2.4.8
+        image: quay.io/kubermatic/openvpn:v2.4.8-r1
         name: openvpn-server
         ports:
         - containerPort: 1194
@@ -135,7 +135,7 @@ spec:
           done
         command:
         - /bin/bash
-        image: quay.io/kubermatic/openvpn:2.4.8
+        image: quay.io/kubermatic/openvpn:v2.4.8-r1
         name: ip-fixup
         resources:
           limits:
@@ -189,7 +189,7 @@ spec:
           iptables -A INPUT -i tun0 -j DROP
         command:
         - /bin/bash
-        image: quay.io/kubermatic/openvpn:2.4.8
+        image: quay.io/kubermatic/openvpn:v2.4.8-r1
         name: iptables-init
         resources:
           limits:

--- a/api/pkg/resources/test/fixtures/deployment-azure-1.10.6-openvpn-server.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-azure-1.10.6-openvpn-server.yaml
@@ -86,7 +86,7 @@ spec:
         - 255.255.255.0
         command:
         - /usr/sbin/openvpn
-        image: quay.io/kubermatic/openvpn:v0.5
+        image: quay.io/kubermatic/openvpn:v0.6-dev
         name: openvpn-server
         ports:
         - containerPort: 1194
@@ -135,7 +135,7 @@ spec:
           done
         command:
         - /bin/bash
-        image: quay.io/kubermatic/openvpn:v0.5
+        image: quay.io/kubermatic/openvpn:v0.6-dev
         name: ip-fixup
         resources:
           limits:
@@ -189,7 +189,7 @@ spec:
           iptables -A INPUT -i tun0 -j DROP
         command:
         - /bin/bash
-        image: quay.io/kubermatic/openvpn:v0.5
+        image: quay.io/kubermatic/openvpn:v0.6-dev
         name: iptables-init
         resources:
           limits:

--- a/api/pkg/resources/test/fixtures/deployment-azure-1.10.6-scheduler.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-azure-1.10.6-scheduler.yaml
@@ -79,7 +79,7 @@ spec:
         - /dev/stdout
         command:
         - /usr/sbin/openvpn
-        image: quay.io/kubermatic/openvpn:2.4.8
+        image: quay.io/kubermatic/openvpn:v2.4.8-r1
         name: openvpn-client
         resources:
           limits:

--- a/api/pkg/resources/test/fixtures/deployment-azure-1.10.6-scheduler.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-azure-1.10.6-scheduler.yaml
@@ -79,7 +79,7 @@ spec:
         - /dev/stdout
         command:
         - /usr/sbin/openvpn
-        image: quay.io/kubermatic/openvpn:v0.5
+        image: quay.io/kubermatic/openvpn:v0.6-dev
         name: openvpn-client
         resources:
           limits:

--- a/api/pkg/resources/test/fixtures/deployment-azure-1.10.6-scheduler.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-azure-1.10.6-scheduler.yaml
@@ -79,7 +79,7 @@ spec:
         - /dev/stdout
         command:
         - /usr/sbin/openvpn
-        image: quay.io/kubermatic/openvpn:v0.6-dev
+        image: quay.io/kubermatic/openvpn:2.4.8
         name: openvpn-client
         resources:
           limits:

--- a/api/pkg/resources/test/fixtures/deployment-azure-1.11.0-apiserver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-azure-1.11.0-apiserver.yaml
@@ -89,7 +89,7 @@ spec:
         - /dev/stdout
         command:
         - /usr/sbin/openvpn
-        image: quay.io/kubermatic/openvpn:v0.6-dev
+        image: quay.io/kubermatic/openvpn:2.4.8
         name: openvpn-client
         resources:
           limits:

--- a/api/pkg/resources/test/fixtures/deployment-azure-1.11.0-apiserver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-azure-1.11.0-apiserver.yaml
@@ -89,7 +89,7 @@ spec:
         - /dev/stdout
         command:
         - /usr/sbin/openvpn
-        image: quay.io/kubermatic/openvpn:2.4.8
+        image: quay.io/kubermatic/openvpn:v2.4.8-r1
         name: openvpn-client
         resources:
           limits:

--- a/api/pkg/resources/test/fixtures/deployment-azure-1.11.0-apiserver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-azure-1.11.0-apiserver.yaml
@@ -89,7 +89,7 @@ spec:
         - /dev/stdout
         command:
         - /usr/sbin/openvpn
-        image: quay.io/kubermatic/openvpn:v0.5
+        image: quay.io/kubermatic/openvpn:v0.6-dev
         name: openvpn-client
         resources:
           limits:

--- a/api/pkg/resources/test/fixtures/deployment-azure-1.11.0-controller-manager.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-azure-1.11.0-controller-manager.yaml
@@ -81,7 +81,7 @@ spec:
         - /dev/stdout
         command:
         - /usr/sbin/openvpn
-        image: quay.io/kubermatic/openvpn:v0.6-dev
+        image: quay.io/kubermatic/openvpn:2.4.8
         name: openvpn-client
         resources:
           limits:

--- a/api/pkg/resources/test/fixtures/deployment-azure-1.11.0-controller-manager.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-azure-1.11.0-controller-manager.yaml
@@ -81,7 +81,7 @@ spec:
         - /dev/stdout
         command:
         - /usr/sbin/openvpn
-        image: quay.io/kubermatic/openvpn:v0.5
+        image: quay.io/kubermatic/openvpn:v0.6-dev
         name: openvpn-client
         resources:
           limits:

--- a/api/pkg/resources/test/fixtures/deployment-azure-1.11.0-controller-manager.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-azure-1.11.0-controller-manager.yaml
@@ -81,7 +81,7 @@ spec:
         - /dev/stdout
         command:
         - /usr/sbin/openvpn
-        image: quay.io/kubermatic/openvpn:2.4.8
+        image: quay.io/kubermatic/openvpn:v2.4.8-r1
         name: openvpn-client
         resources:
           limits:

--- a/api/pkg/resources/test/fixtures/deployment-azure-1.11.0-dns-resolver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-azure-1.11.0-dns-resolver.yaml
@@ -79,7 +79,7 @@ spec:
         - /dev/stdout
         command:
         - /usr/sbin/openvpn
-        image: quay.io/kubermatic/openvpn:2.4.8
+        image: quay.io/kubermatic/openvpn:v2.4.8-r1
         name: openvpn-client
         resources:
           limits:

--- a/api/pkg/resources/test/fixtures/deployment-azure-1.11.0-dns-resolver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-azure-1.11.0-dns-resolver.yaml
@@ -79,7 +79,7 @@ spec:
         - /dev/stdout
         command:
         - /usr/sbin/openvpn
-        image: quay.io/kubermatic/openvpn:v0.5
+        image: quay.io/kubermatic/openvpn:v0.6-dev
         name: openvpn-client
         resources:
           limits:

--- a/api/pkg/resources/test/fixtures/deployment-azure-1.11.0-dns-resolver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-azure-1.11.0-dns-resolver.yaml
@@ -79,7 +79,7 @@ spec:
         - /dev/stdout
         command:
         - /usr/sbin/openvpn
-        image: quay.io/kubermatic/openvpn:v0.6-dev
+        image: quay.io/kubermatic/openvpn:2.4.8
         name: openvpn-client
         resources:
           limits:

--- a/api/pkg/resources/test/fixtures/deployment-azure-1.11.0-metrics-server.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-azure-1.11.0-metrics-server.yaml
@@ -108,7 +108,7 @@ spec:
         - /dev/stdout
         command:
         - /usr/sbin/openvpn
-        image: quay.io/kubermatic/openvpn:2.4.8
+        image: quay.io/kubermatic/openvpn:v2.4.8-r1
         name: openvpn-client
         resources:
           limits:

--- a/api/pkg/resources/test/fixtures/deployment-azure-1.11.0-metrics-server.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-azure-1.11.0-metrics-server.yaml
@@ -108,7 +108,7 @@ spec:
         - /dev/stdout
         command:
         - /usr/sbin/openvpn
-        image: quay.io/kubermatic/openvpn:v0.5
+        image: quay.io/kubermatic/openvpn:v0.6-dev
         name: openvpn-client
         resources:
           limits:

--- a/api/pkg/resources/test/fixtures/deployment-azure-1.11.0-metrics-server.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-azure-1.11.0-metrics-server.yaml
@@ -108,7 +108,7 @@ spec:
         - /dev/stdout
         command:
         - /usr/sbin/openvpn
-        image: quay.io/kubermatic/openvpn:v0.6-dev
+        image: quay.io/kubermatic/openvpn:2.4.8
         name: openvpn-client
         resources:
           limits:

--- a/api/pkg/resources/test/fixtures/deployment-azure-1.11.0-openvpn-server.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-azure-1.11.0-openvpn-server.yaml
@@ -86,7 +86,7 @@ spec:
         - 255.255.255.0
         command:
         - /usr/sbin/openvpn
-        image: quay.io/kubermatic/openvpn:v0.6-dev
+        image: quay.io/kubermatic/openvpn:2.4.8
         name: openvpn-server
         ports:
         - containerPort: 1194
@@ -135,7 +135,7 @@ spec:
           done
         command:
         - /bin/bash
-        image: quay.io/kubermatic/openvpn:v0.6-dev
+        image: quay.io/kubermatic/openvpn:2.4.8
         name: ip-fixup
         resources:
           limits:
@@ -189,7 +189,7 @@ spec:
           iptables -A INPUT -i tun0 -j DROP
         command:
         - /bin/bash
-        image: quay.io/kubermatic/openvpn:v0.6-dev
+        image: quay.io/kubermatic/openvpn:2.4.8
         name: iptables-init
         resources:
           limits:

--- a/api/pkg/resources/test/fixtures/deployment-azure-1.11.0-openvpn-server.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-azure-1.11.0-openvpn-server.yaml
@@ -86,7 +86,7 @@ spec:
         - 255.255.255.0
         command:
         - /usr/sbin/openvpn
-        image: quay.io/kubermatic/openvpn:2.4.8
+        image: quay.io/kubermatic/openvpn:v2.4.8-r1
         name: openvpn-server
         ports:
         - containerPort: 1194
@@ -135,7 +135,7 @@ spec:
           done
         command:
         - /bin/bash
-        image: quay.io/kubermatic/openvpn:2.4.8
+        image: quay.io/kubermatic/openvpn:v2.4.8-r1
         name: ip-fixup
         resources:
           limits:
@@ -189,7 +189,7 @@ spec:
           iptables -A INPUT -i tun0 -j DROP
         command:
         - /bin/bash
-        image: quay.io/kubermatic/openvpn:2.4.8
+        image: quay.io/kubermatic/openvpn:v2.4.8-r1
         name: iptables-init
         resources:
           limits:

--- a/api/pkg/resources/test/fixtures/deployment-azure-1.11.0-openvpn-server.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-azure-1.11.0-openvpn-server.yaml
@@ -86,7 +86,7 @@ spec:
         - 255.255.255.0
         command:
         - /usr/sbin/openvpn
-        image: quay.io/kubermatic/openvpn:v0.5
+        image: quay.io/kubermatic/openvpn:v0.6-dev
         name: openvpn-server
         ports:
         - containerPort: 1194
@@ -135,7 +135,7 @@ spec:
           done
         command:
         - /bin/bash
-        image: quay.io/kubermatic/openvpn:v0.5
+        image: quay.io/kubermatic/openvpn:v0.6-dev
         name: ip-fixup
         resources:
           limits:
@@ -189,7 +189,7 @@ spec:
           iptables -A INPUT -i tun0 -j DROP
         command:
         - /bin/bash
-        image: quay.io/kubermatic/openvpn:v0.5
+        image: quay.io/kubermatic/openvpn:v0.6-dev
         name: iptables-init
         resources:
           limits:

--- a/api/pkg/resources/test/fixtures/deployment-azure-1.11.0-scheduler.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-azure-1.11.0-scheduler.yaml
@@ -79,7 +79,7 @@ spec:
         - /dev/stdout
         command:
         - /usr/sbin/openvpn
-        image: quay.io/kubermatic/openvpn:2.4.8
+        image: quay.io/kubermatic/openvpn:v2.4.8-r1
         name: openvpn-client
         resources:
           limits:

--- a/api/pkg/resources/test/fixtures/deployment-azure-1.11.0-scheduler.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-azure-1.11.0-scheduler.yaml
@@ -79,7 +79,7 @@ spec:
         - /dev/stdout
         command:
         - /usr/sbin/openvpn
-        image: quay.io/kubermatic/openvpn:v0.5
+        image: quay.io/kubermatic/openvpn:v0.6-dev
         name: openvpn-client
         resources:
           limits:

--- a/api/pkg/resources/test/fixtures/deployment-azure-1.11.0-scheduler.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-azure-1.11.0-scheduler.yaml
@@ -79,7 +79,7 @@ spec:
         - /dev/stdout
         command:
         - /usr/sbin/openvpn
-        image: quay.io/kubermatic/openvpn:v0.6-dev
+        image: quay.io/kubermatic/openvpn:2.4.8
         name: openvpn-client
         resources:
           limits:

--- a/api/pkg/resources/test/fixtures/deployment-azure-1.11.1-apiserver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-azure-1.11.1-apiserver.yaml
@@ -89,7 +89,7 @@ spec:
         - /dev/stdout
         command:
         - /usr/sbin/openvpn
-        image: quay.io/kubermatic/openvpn:v0.6-dev
+        image: quay.io/kubermatic/openvpn:2.4.8
         name: openvpn-client
         resources:
           limits:

--- a/api/pkg/resources/test/fixtures/deployment-azure-1.11.1-apiserver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-azure-1.11.1-apiserver.yaml
@@ -89,7 +89,7 @@ spec:
         - /dev/stdout
         command:
         - /usr/sbin/openvpn
-        image: quay.io/kubermatic/openvpn:2.4.8
+        image: quay.io/kubermatic/openvpn:v2.4.8-r1
         name: openvpn-client
         resources:
           limits:

--- a/api/pkg/resources/test/fixtures/deployment-azure-1.11.1-apiserver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-azure-1.11.1-apiserver.yaml
@@ -89,7 +89,7 @@ spec:
         - /dev/stdout
         command:
         - /usr/sbin/openvpn
-        image: quay.io/kubermatic/openvpn:v0.5
+        image: quay.io/kubermatic/openvpn:v0.6-dev
         name: openvpn-client
         resources:
           limits:

--- a/api/pkg/resources/test/fixtures/deployment-azure-1.11.1-controller-manager.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-azure-1.11.1-controller-manager.yaml
@@ -81,7 +81,7 @@ spec:
         - /dev/stdout
         command:
         - /usr/sbin/openvpn
-        image: quay.io/kubermatic/openvpn:v0.6-dev
+        image: quay.io/kubermatic/openvpn:2.4.8
         name: openvpn-client
         resources:
           limits:

--- a/api/pkg/resources/test/fixtures/deployment-azure-1.11.1-controller-manager.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-azure-1.11.1-controller-manager.yaml
@@ -81,7 +81,7 @@ spec:
         - /dev/stdout
         command:
         - /usr/sbin/openvpn
-        image: quay.io/kubermatic/openvpn:v0.5
+        image: quay.io/kubermatic/openvpn:v0.6-dev
         name: openvpn-client
         resources:
           limits:

--- a/api/pkg/resources/test/fixtures/deployment-azure-1.11.1-controller-manager.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-azure-1.11.1-controller-manager.yaml
@@ -81,7 +81,7 @@ spec:
         - /dev/stdout
         command:
         - /usr/sbin/openvpn
-        image: quay.io/kubermatic/openvpn:2.4.8
+        image: quay.io/kubermatic/openvpn:v2.4.8-r1
         name: openvpn-client
         resources:
           limits:

--- a/api/pkg/resources/test/fixtures/deployment-azure-1.11.1-dns-resolver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-azure-1.11.1-dns-resolver.yaml
@@ -79,7 +79,7 @@ spec:
         - /dev/stdout
         command:
         - /usr/sbin/openvpn
-        image: quay.io/kubermatic/openvpn:2.4.8
+        image: quay.io/kubermatic/openvpn:v2.4.8-r1
         name: openvpn-client
         resources:
           limits:

--- a/api/pkg/resources/test/fixtures/deployment-azure-1.11.1-dns-resolver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-azure-1.11.1-dns-resolver.yaml
@@ -79,7 +79,7 @@ spec:
         - /dev/stdout
         command:
         - /usr/sbin/openvpn
-        image: quay.io/kubermatic/openvpn:v0.5
+        image: quay.io/kubermatic/openvpn:v0.6-dev
         name: openvpn-client
         resources:
           limits:

--- a/api/pkg/resources/test/fixtures/deployment-azure-1.11.1-dns-resolver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-azure-1.11.1-dns-resolver.yaml
@@ -79,7 +79,7 @@ spec:
         - /dev/stdout
         command:
         - /usr/sbin/openvpn
-        image: quay.io/kubermatic/openvpn:v0.6-dev
+        image: quay.io/kubermatic/openvpn:2.4.8
         name: openvpn-client
         resources:
           limits:

--- a/api/pkg/resources/test/fixtures/deployment-azure-1.11.1-metrics-server.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-azure-1.11.1-metrics-server.yaml
@@ -108,7 +108,7 @@ spec:
         - /dev/stdout
         command:
         - /usr/sbin/openvpn
-        image: quay.io/kubermatic/openvpn:2.4.8
+        image: quay.io/kubermatic/openvpn:v2.4.8-r1
         name: openvpn-client
         resources:
           limits:

--- a/api/pkg/resources/test/fixtures/deployment-azure-1.11.1-metrics-server.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-azure-1.11.1-metrics-server.yaml
@@ -108,7 +108,7 @@ spec:
         - /dev/stdout
         command:
         - /usr/sbin/openvpn
-        image: quay.io/kubermatic/openvpn:v0.5
+        image: quay.io/kubermatic/openvpn:v0.6-dev
         name: openvpn-client
         resources:
           limits:

--- a/api/pkg/resources/test/fixtures/deployment-azure-1.11.1-metrics-server.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-azure-1.11.1-metrics-server.yaml
@@ -108,7 +108,7 @@ spec:
         - /dev/stdout
         command:
         - /usr/sbin/openvpn
-        image: quay.io/kubermatic/openvpn:v0.6-dev
+        image: quay.io/kubermatic/openvpn:2.4.8
         name: openvpn-client
         resources:
           limits:

--- a/api/pkg/resources/test/fixtures/deployment-azure-1.11.1-openvpn-server.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-azure-1.11.1-openvpn-server.yaml
@@ -86,7 +86,7 @@ spec:
         - 255.255.255.0
         command:
         - /usr/sbin/openvpn
-        image: quay.io/kubermatic/openvpn:v0.6-dev
+        image: quay.io/kubermatic/openvpn:2.4.8
         name: openvpn-server
         ports:
         - containerPort: 1194
@@ -135,7 +135,7 @@ spec:
           done
         command:
         - /bin/bash
-        image: quay.io/kubermatic/openvpn:v0.6-dev
+        image: quay.io/kubermatic/openvpn:2.4.8
         name: ip-fixup
         resources:
           limits:
@@ -189,7 +189,7 @@ spec:
           iptables -A INPUT -i tun0 -j DROP
         command:
         - /bin/bash
-        image: quay.io/kubermatic/openvpn:v0.6-dev
+        image: quay.io/kubermatic/openvpn:2.4.8
         name: iptables-init
         resources:
           limits:

--- a/api/pkg/resources/test/fixtures/deployment-azure-1.11.1-openvpn-server.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-azure-1.11.1-openvpn-server.yaml
@@ -86,7 +86,7 @@ spec:
         - 255.255.255.0
         command:
         - /usr/sbin/openvpn
-        image: quay.io/kubermatic/openvpn:2.4.8
+        image: quay.io/kubermatic/openvpn:v2.4.8-r1
         name: openvpn-server
         ports:
         - containerPort: 1194
@@ -135,7 +135,7 @@ spec:
           done
         command:
         - /bin/bash
-        image: quay.io/kubermatic/openvpn:2.4.8
+        image: quay.io/kubermatic/openvpn:v2.4.8-r1
         name: ip-fixup
         resources:
           limits:
@@ -189,7 +189,7 @@ spec:
           iptables -A INPUT -i tun0 -j DROP
         command:
         - /bin/bash
-        image: quay.io/kubermatic/openvpn:2.4.8
+        image: quay.io/kubermatic/openvpn:v2.4.8-r1
         name: iptables-init
         resources:
           limits:

--- a/api/pkg/resources/test/fixtures/deployment-azure-1.11.1-openvpn-server.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-azure-1.11.1-openvpn-server.yaml
@@ -86,7 +86,7 @@ spec:
         - 255.255.255.0
         command:
         - /usr/sbin/openvpn
-        image: quay.io/kubermatic/openvpn:v0.5
+        image: quay.io/kubermatic/openvpn:v0.6-dev
         name: openvpn-server
         ports:
         - containerPort: 1194
@@ -135,7 +135,7 @@ spec:
           done
         command:
         - /bin/bash
-        image: quay.io/kubermatic/openvpn:v0.5
+        image: quay.io/kubermatic/openvpn:v0.6-dev
         name: ip-fixup
         resources:
           limits:
@@ -189,7 +189,7 @@ spec:
           iptables -A INPUT -i tun0 -j DROP
         command:
         - /bin/bash
-        image: quay.io/kubermatic/openvpn:v0.5
+        image: quay.io/kubermatic/openvpn:v0.6-dev
         name: iptables-init
         resources:
           limits:

--- a/api/pkg/resources/test/fixtures/deployment-azure-1.11.1-scheduler.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-azure-1.11.1-scheduler.yaml
@@ -79,7 +79,7 @@ spec:
         - /dev/stdout
         command:
         - /usr/sbin/openvpn
-        image: quay.io/kubermatic/openvpn:2.4.8
+        image: quay.io/kubermatic/openvpn:v2.4.8-r1
         name: openvpn-client
         resources:
           limits:

--- a/api/pkg/resources/test/fixtures/deployment-azure-1.11.1-scheduler.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-azure-1.11.1-scheduler.yaml
@@ -79,7 +79,7 @@ spec:
         - /dev/stdout
         command:
         - /usr/sbin/openvpn
-        image: quay.io/kubermatic/openvpn:v0.5
+        image: quay.io/kubermatic/openvpn:v0.6-dev
         name: openvpn-client
         resources:
           limits:

--- a/api/pkg/resources/test/fixtures/deployment-azure-1.11.1-scheduler.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-azure-1.11.1-scheduler.yaml
@@ -79,7 +79,7 @@ spec:
         - /dev/stdout
         command:
         - /usr/sbin/openvpn
-        image: quay.io/kubermatic/openvpn:v0.6-dev
+        image: quay.io/kubermatic/openvpn:2.4.8
         name: openvpn-client
         resources:
           limits:

--- a/api/pkg/resources/test/fixtures/deployment-azure-1.12.0-apiserver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-azure-1.12.0-apiserver.yaml
@@ -89,7 +89,7 @@ spec:
         - /dev/stdout
         command:
         - /usr/sbin/openvpn
-        image: quay.io/kubermatic/openvpn:v0.6-dev
+        image: quay.io/kubermatic/openvpn:2.4.8
         name: openvpn-client
         resources:
           limits:

--- a/api/pkg/resources/test/fixtures/deployment-azure-1.12.0-apiserver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-azure-1.12.0-apiserver.yaml
@@ -89,7 +89,7 @@ spec:
         - /dev/stdout
         command:
         - /usr/sbin/openvpn
-        image: quay.io/kubermatic/openvpn:2.4.8
+        image: quay.io/kubermatic/openvpn:v2.4.8-r1
         name: openvpn-client
         resources:
           limits:

--- a/api/pkg/resources/test/fixtures/deployment-azure-1.12.0-apiserver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-azure-1.12.0-apiserver.yaml
@@ -89,7 +89,7 @@ spec:
         - /dev/stdout
         command:
         - /usr/sbin/openvpn
-        image: quay.io/kubermatic/openvpn:v0.5
+        image: quay.io/kubermatic/openvpn:v0.6-dev
         name: openvpn-client
         resources:
           limits:

--- a/api/pkg/resources/test/fixtures/deployment-azure-1.12.0-controller-manager.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-azure-1.12.0-controller-manager.yaml
@@ -81,7 +81,7 @@ spec:
         - /dev/stdout
         command:
         - /usr/sbin/openvpn
-        image: quay.io/kubermatic/openvpn:v0.6-dev
+        image: quay.io/kubermatic/openvpn:2.4.8
         name: openvpn-client
         resources:
           limits:

--- a/api/pkg/resources/test/fixtures/deployment-azure-1.12.0-controller-manager.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-azure-1.12.0-controller-manager.yaml
@@ -81,7 +81,7 @@ spec:
         - /dev/stdout
         command:
         - /usr/sbin/openvpn
-        image: quay.io/kubermatic/openvpn:v0.5
+        image: quay.io/kubermatic/openvpn:v0.6-dev
         name: openvpn-client
         resources:
           limits:

--- a/api/pkg/resources/test/fixtures/deployment-azure-1.12.0-controller-manager.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-azure-1.12.0-controller-manager.yaml
@@ -81,7 +81,7 @@ spec:
         - /dev/stdout
         command:
         - /usr/sbin/openvpn
-        image: quay.io/kubermatic/openvpn:2.4.8
+        image: quay.io/kubermatic/openvpn:v2.4.8-r1
         name: openvpn-client
         resources:
           limits:

--- a/api/pkg/resources/test/fixtures/deployment-azure-1.12.0-dns-resolver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-azure-1.12.0-dns-resolver.yaml
@@ -79,7 +79,7 @@ spec:
         - /dev/stdout
         command:
         - /usr/sbin/openvpn
-        image: quay.io/kubermatic/openvpn:2.4.8
+        image: quay.io/kubermatic/openvpn:v2.4.8-r1
         name: openvpn-client
         resources:
           limits:

--- a/api/pkg/resources/test/fixtures/deployment-azure-1.12.0-dns-resolver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-azure-1.12.0-dns-resolver.yaml
@@ -79,7 +79,7 @@ spec:
         - /dev/stdout
         command:
         - /usr/sbin/openvpn
-        image: quay.io/kubermatic/openvpn:v0.5
+        image: quay.io/kubermatic/openvpn:v0.6-dev
         name: openvpn-client
         resources:
           limits:

--- a/api/pkg/resources/test/fixtures/deployment-azure-1.12.0-dns-resolver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-azure-1.12.0-dns-resolver.yaml
@@ -79,7 +79,7 @@ spec:
         - /dev/stdout
         command:
         - /usr/sbin/openvpn
-        image: quay.io/kubermatic/openvpn:v0.6-dev
+        image: quay.io/kubermatic/openvpn:2.4.8
         name: openvpn-client
         resources:
           limits:

--- a/api/pkg/resources/test/fixtures/deployment-azure-1.12.0-metrics-server.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-azure-1.12.0-metrics-server.yaml
@@ -108,7 +108,7 @@ spec:
         - /dev/stdout
         command:
         - /usr/sbin/openvpn
-        image: quay.io/kubermatic/openvpn:2.4.8
+        image: quay.io/kubermatic/openvpn:v2.4.8-r1
         name: openvpn-client
         resources:
           limits:

--- a/api/pkg/resources/test/fixtures/deployment-azure-1.12.0-metrics-server.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-azure-1.12.0-metrics-server.yaml
@@ -108,7 +108,7 @@ spec:
         - /dev/stdout
         command:
         - /usr/sbin/openvpn
-        image: quay.io/kubermatic/openvpn:v0.5
+        image: quay.io/kubermatic/openvpn:v0.6-dev
         name: openvpn-client
         resources:
           limits:

--- a/api/pkg/resources/test/fixtures/deployment-azure-1.12.0-metrics-server.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-azure-1.12.0-metrics-server.yaml
@@ -108,7 +108,7 @@ spec:
         - /dev/stdout
         command:
         - /usr/sbin/openvpn
-        image: quay.io/kubermatic/openvpn:v0.6-dev
+        image: quay.io/kubermatic/openvpn:2.4.8
         name: openvpn-client
         resources:
           limits:

--- a/api/pkg/resources/test/fixtures/deployment-azure-1.12.0-openvpn-server.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-azure-1.12.0-openvpn-server.yaml
@@ -86,7 +86,7 @@ spec:
         - 255.255.255.0
         command:
         - /usr/sbin/openvpn
-        image: quay.io/kubermatic/openvpn:v0.6-dev
+        image: quay.io/kubermatic/openvpn:2.4.8
         name: openvpn-server
         ports:
         - containerPort: 1194
@@ -135,7 +135,7 @@ spec:
           done
         command:
         - /bin/bash
-        image: quay.io/kubermatic/openvpn:v0.6-dev
+        image: quay.io/kubermatic/openvpn:2.4.8
         name: ip-fixup
         resources:
           limits:
@@ -189,7 +189,7 @@ spec:
           iptables -A INPUT -i tun0 -j DROP
         command:
         - /bin/bash
-        image: quay.io/kubermatic/openvpn:v0.6-dev
+        image: quay.io/kubermatic/openvpn:2.4.8
         name: iptables-init
         resources:
           limits:

--- a/api/pkg/resources/test/fixtures/deployment-azure-1.12.0-openvpn-server.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-azure-1.12.0-openvpn-server.yaml
@@ -86,7 +86,7 @@ spec:
         - 255.255.255.0
         command:
         - /usr/sbin/openvpn
-        image: quay.io/kubermatic/openvpn:2.4.8
+        image: quay.io/kubermatic/openvpn:v2.4.8-r1
         name: openvpn-server
         ports:
         - containerPort: 1194
@@ -135,7 +135,7 @@ spec:
           done
         command:
         - /bin/bash
-        image: quay.io/kubermatic/openvpn:2.4.8
+        image: quay.io/kubermatic/openvpn:v2.4.8-r1
         name: ip-fixup
         resources:
           limits:
@@ -189,7 +189,7 @@ spec:
           iptables -A INPUT -i tun0 -j DROP
         command:
         - /bin/bash
-        image: quay.io/kubermatic/openvpn:2.4.8
+        image: quay.io/kubermatic/openvpn:v2.4.8-r1
         name: iptables-init
         resources:
           limits:

--- a/api/pkg/resources/test/fixtures/deployment-azure-1.12.0-openvpn-server.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-azure-1.12.0-openvpn-server.yaml
@@ -86,7 +86,7 @@ spec:
         - 255.255.255.0
         command:
         - /usr/sbin/openvpn
-        image: quay.io/kubermatic/openvpn:v0.5
+        image: quay.io/kubermatic/openvpn:v0.6-dev
         name: openvpn-server
         ports:
         - containerPort: 1194
@@ -135,7 +135,7 @@ spec:
           done
         command:
         - /bin/bash
-        image: quay.io/kubermatic/openvpn:v0.5
+        image: quay.io/kubermatic/openvpn:v0.6-dev
         name: ip-fixup
         resources:
           limits:
@@ -189,7 +189,7 @@ spec:
           iptables -A INPUT -i tun0 -j DROP
         command:
         - /bin/bash
-        image: quay.io/kubermatic/openvpn:v0.5
+        image: quay.io/kubermatic/openvpn:v0.6-dev
         name: iptables-init
         resources:
           limits:

--- a/api/pkg/resources/test/fixtures/deployment-azure-1.12.0-scheduler.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-azure-1.12.0-scheduler.yaml
@@ -79,7 +79,7 @@ spec:
         - /dev/stdout
         command:
         - /usr/sbin/openvpn
-        image: quay.io/kubermatic/openvpn:2.4.8
+        image: quay.io/kubermatic/openvpn:v2.4.8-r1
         name: openvpn-client
         resources:
           limits:

--- a/api/pkg/resources/test/fixtures/deployment-azure-1.12.0-scheduler.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-azure-1.12.0-scheduler.yaml
@@ -79,7 +79,7 @@ spec:
         - /dev/stdout
         command:
         - /usr/sbin/openvpn
-        image: quay.io/kubermatic/openvpn:v0.5
+        image: quay.io/kubermatic/openvpn:v0.6-dev
         name: openvpn-client
         resources:
           limits:

--- a/api/pkg/resources/test/fixtures/deployment-azure-1.12.0-scheduler.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-azure-1.12.0-scheduler.yaml
@@ -79,7 +79,7 @@ spec:
         - /dev/stdout
         command:
         - /usr/sbin/openvpn
-        image: quay.io/kubermatic/openvpn:v0.6-dev
+        image: quay.io/kubermatic/openvpn:2.4.8
         name: openvpn-client
         resources:
           limits:

--- a/api/pkg/resources/test/fixtures/deployment-azure-1.13.0-apiserver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-azure-1.13.0-apiserver.yaml
@@ -89,7 +89,7 @@ spec:
         - /dev/stdout
         command:
         - /usr/sbin/openvpn
-        image: quay.io/kubermatic/openvpn:v0.6-dev
+        image: quay.io/kubermatic/openvpn:2.4.8
         name: openvpn-client
         resources:
           limits:

--- a/api/pkg/resources/test/fixtures/deployment-azure-1.13.0-apiserver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-azure-1.13.0-apiserver.yaml
@@ -89,7 +89,7 @@ spec:
         - /dev/stdout
         command:
         - /usr/sbin/openvpn
-        image: quay.io/kubermatic/openvpn:2.4.8
+        image: quay.io/kubermatic/openvpn:v2.4.8-r1
         name: openvpn-client
         resources:
           limits:

--- a/api/pkg/resources/test/fixtures/deployment-azure-1.13.0-apiserver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-azure-1.13.0-apiserver.yaml
@@ -89,7 +89,7 @@ spec:
         - /dev/stdout
         command:
         - /usr/sbin/openvpn
-        image: quay.io/kubermatic/openvpn:v0.5
+        image: quay.io/kubermatic/openvpn:v0.6-dev
         name: openvpn-client
         resources:
           limits:

--- a/api/pkg/resources/test/fixtures/deployment-azure-1.13.0-controller-manager.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-azure-1.13.0-controller-manager.yaml
@@ -81,7 +81,7 @@ spec:
         - /dev/stdout
         command:
         - /usr/sbin/openvpn
-        image: quay.io/kubermatic/openvpn:v0.6-dev
+        image: quay.io/kubermatic/openvpn:2.4.8
         name: openvpn-client
         resources:
           limits:

--- a/api/pkg/resources/test/fixtures/deployment-azure-1.13.0-controller-manager.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-azure-1.13.0-controller-manager.yaml
@@ -81,7 +81,7 @@ spec:
         - /dev/stdout
         command:
         - /usr/sbin/openvpn
-        image: quay.io/kubermatic/openvpn:v0.5
+        image: quay.io/kubermatic/openvpn:v0.6-dev
         name: openvpn-client
         resources:
           limits:

--- a/api/pkg/resources/test/fixtures/deployment-azure-1.13.0-controller-manager.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-azure-1.13.0-controller-manager.yaml
@@ -81,7 +81,7 @@ spec:
         - /dev/stdout
         command:
         - /usr/sbin/openvpn
-        image: quay.io/kubermatic/openvpn:2.4.8
+        image: quay.io/kubermatic/openvpn:v2.4.8-r1
         name: openvpn-client
         resources:
           limits:

--- a/api/pkg/resources/test/fixtures/deployment-azure-1.13.0-dns-resolver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-azure-1.13.0-dns-resolver.yaml
@@ -79,7 +79,7 @@ spec:
         - /dev/stdout
         command:
         - /usr/sbin/openvpn
-        image: quay.io/kubermatic/openvpn:2.4.8
+        image: quay.io/kubermatic/openvpn:v2.4.8-r1
         name: openvpn-client
         resources:
           limits:

--- a/api/pkg/resources/test/fixtures/deployment-azure-1.13.0-dns-resolver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-azure-1.13.0-dns-resolver.yaml
@@ -79,7 +79,7 @@ spec:
         - /dev/stdout
         command:
         - /usr/sbin/openvpn
-        image: quay.io/kubermatic/openvpn:v0.5
+        image: quay.io/kubermatic/openvpn:v0.6-dev
         name: openvpn-client
         resources:
           limits:

--- a/api/pkg/resources/test/fixtures/deployment-azure-1.13.0-dns-resolver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-azure-1.13.0-dns-resolver.yaml
@@ -79,7 +79,7 @@ spec:
         - /dev/stdout
         command:
         - /usr/sbin/openvpn
-        image: quay.io/kubermatic/openvpn:v0.6-dev
+        image: quay.io/kubermatic/openvpn:2.4.8
         name: openvpn-client
         resources:
           limits:

--- a/api/pkg/resources/test/fixtures/deployment-azure-1.13.0-metrics-server.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-azure-1.13.0-metrics-server.yaml
@@ -108,7 +108,7 @@ spec:
         - /dev/stdout
         command:
         - /usr/sbin/openvpn
-        image: quay.io/kubermatic/openvpn:2.4.8
+        image: quay.io/kubermatic/openvpn:v2.4.8-r1
         name: openvpn-client
         resources:
           limits:

--- a/api/pkg/resources/test/fixtures/deployment-azure-1.13.0-metrics-server.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-azure-1.13.0-metrics-server.yaml
@@ -108,7 +108,7 @@ spec:
         - /dev/stdout
         command:
         - /usr/sbin/openvpn
-        image: quay.io/kubermatic/openvpn:v0.5
+        image: quay.io/kubermatic/openvpn:v0.6-dev
         name: openvpn-client
         resources:
           limits:

--- a/api/pkg/resources/test/fixtures/deployment-azure-1.13.0-metrics-server.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-azure-1.13.0-metrics-server.yaml
@@ -108,7 +108,7 @@ spec:
         - /dev/stdout
         command:
         - /usr/sbin/openvpn
-        image: quay.io/kubermatic/openvpn:v0.6-dev
+        image: quay.io/kubermatic/openvpn:2.4.8
         name: openvpn-client
         resources:
           limits:

--- a/api/pkg/resources/test/fixtures/deployment-azure-1.13.0-openvpn-server.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-azure-1.13.0-openvpn-server.yaml
@@ -86,7 +86,7 @@ spec:
         - 255.255.255.0
         command:
         - /usr/sbin/openvpn
-        image: quay.io/kubermatic/openvpn:v0.6-dev
+        image: quay.io/kubermatic/openvpn:2.4.8
         name: openvpn-server
         ports:
         - containerPort: 1194
@@ -135,7 +135,7 @@ spec:
           done
         command:
         - /bin/bash
-        image: quay.io/kubermatic/openvpn:v0.6-dev
+        image: quay.io/kubermatic/openvpn:2.4.8
         name: ip-fixup
         resources:
           limits:
@@ -189,7 +189,7 @@ spec:
           iptables -A INPUT -i tun0 -j DROP
         command:
         - /bin/bash
-        image: quay.io/kubermatic/openvpn:v0.6-dev
+        image: quay.io/kubermatic/openvpn:2.4.8
         name: iptables-init
         resources:
           limits:

--- a/api/pkg/resources/test/fixtures/deployment-azure-1.13.0-openvpn-server.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-azure-1.13.0-openvpn-server.yaml
@@ -86,7 +86,7 @@ spec:
         - 255.255.255.0
         command:
         - /usr/sbin/openvpn
-        image: quay.io/kubermatic/openvpn:2.4.8
+        image: quay.io/kubermatic/openvpn:v2.4.8-r1
         name: openvpn-server
         ports:
         - containerPort: 1194
@@ -135,7 +135,7 @@ spec:
           done
         command:
         - /bin/bash
-        image: quay.io/kubermatic/openvpn:2.4.8
+        image: quay.io/kubermatic/openvpn:v2.4.8-r1
         name: ip-fixup
         resources:
           limits:
@@ -189,7 +189,7 @@ spec:
           iptables -A INPUT -i tun0 -j DROP
         command:
         - /bin/bash
-        image: quay.io/kubermatic/openvpn:2.4.8
+        image: quay.io/kubermatic/openvpn:v2.4.8-r1
         name: iptables-init
         resources:
           limits:

--- a/api/pkg/resources/test/fixtures/deployment-azure-1.13.0-openvpn-server.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-azure-1.13.0-openvpn-server.yaml
@@ -86,7 +86,7 @@ spec:
         - 255.255.255.0
         command:
         - /usr/sbin/openvpn
-        image: quay.io/kubermatic/openvpn:v0.5
+        image: quay.io/kubermatic/openvpn:v0.6-dev
         name: openvpn-server
         ports:
         - containerPort: 1194
@@ -135,7 +135,7 @@ spec:
           done
         command:
         - /bin/bash
-        image: quay.io/kubermatic/openvpn:v0.5
+        image: quay.io/kubermatic/openvpn:v0.6-dev
         name: ip-fixup
         resources:
           limits:
@@ -189,7 +189,7 @@ spec:
           iptables -A INPUT -i tun0 -j DROP
         command:
         - /bin/bash
-        image: quay.io/kubermatic/openvpn:v0.5
+        image: quay.io/kubermatic/openvpn:v0.6-dev
         name: iptables-init
         resources:
           limits:

--- a/api/pkg/resources/test/fixtures/deployment-azure-1.13.0-scheduler.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-azure-1.13.0-scheduler.yaml
@@ -79,7 +79,7 @@ spec:
         - /dev/stdout
         command:
         - /usr/sbin/openvpn
-        image: quay.io/kubermatic/openvpn:2.4.8
+        image: quay.io/kubermatic/openvpn:v2.4.8-r1
         name: openvpn-client
         resources:
           limits:

--- a/api/pkg/resources/test/fixtures/deployment-azure-1.13.0-scheduler.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-azure-1.13.0-scheduler.yaml
@@ -79,7 +79,7 @@ spec:
         - /dev/stdout
         command:
         - /usr/sbin/openvpn
-        image: quay.io/kubermatic/openvpn:v0.5
+        image: quay.io/kubermatic/openvpn:v0.6-dev
         name: openvpn-client
         resources:
           limits:

--- a/api/pkg/resources/test/fixtures/deployment-azure-1.13.0-scheduler.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-azure-1.13.0-scheduler.yaml
@@ -79,7 +79,7 @@ spec:
         - /dev/stdout
         command:
         - /usr/sbin/openvpn
-        image: quay.io/kubermatic/openvpn:v0.6-dev
+        image: quay.io/kubermatic/openvpn:2.4.8
         name: openvpn-client
         resources:
           limits:

--- a/api/pkg/resources/test/fixtures/deployment-bringyourown-1.10.0-apiserver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-bringyourown-1.10.0-apiserver.yaml
@@ -89,7 +89,7 @@ spec:
         - /dev/stdout
         command:
         - /usr/sbin/openvpn
-        image: quay.io/kubermatic/openvpn:v0.6-dev
+        image: quay.io/kubermatic/openvpn:2.4.8
         name: openvpn-client
         resources:
           limits:

--- a/api/pkg/resources/test/fixtures/deployment-bringyourown-1.10.0-apiserver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-bringyourown-1.10.0-apiserver.yaml
@@ -89,7 +89,7 @@ spec:
         - /dev/stdout
         command:
         - /usr/sbin/openvpn
-        image: quay.io/kubermatic/openvpn:2.4.8
+        image: quay.io/kubermatic/openvpn:v2.4.8-r1
         name: openvpn-client
         resources:
           limits:

--- a/api/pkg/resources/test/fixtures/deployment-bringyourown-1.10.0-apiserver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-bringyourown-1.10.0-apiserver.yaml
@@ -89,7 +89,7 @@ spec:
         - /dev/stdout
         command:
         - /usr/sbin/openvpn
-        image: quay.io/kubermatic/openvpn:v0.5
+        image: quay.io/kubermatic/openvpn:v0.6-dev
         name: openvpn-client
         resources:
           limits:

--- a/api/pkg/resources/test/fixtures/deployment-bringyourown-1.10.0-controller-manager.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-bringyourown-1.10.0-controller-manager.yaml
@@ -81,7 +81,7 @@ spec:
         - /dev/stdout
         command:
         - /usr/sbin/openvpn
-        image: quay.io/kubermatic/openvpn:v0.6-dev
+        image: quay.io/kubermatic/openvpn:2.4.8
         name: openvpn-client
         resources:
           limits:

--- a/api/pkg/resources/test/fixtures/deployment-bringyourown-1.10.0-controller-manager.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-bringyourown-1.10.0-controller-manager.yaml
@@ -81,7 +81,7 @@ spec:
         - /dev/stdout
         command:
         - /usr/sbin/openvpn
-        image: quay.io/kubermatic/openvpn:v0.5
+        image: quay.io/kubermatic/openvpn:v0.6-dev
         name: openvpn-client
         resources:
           limits:

--- a/api/pkg/resources/test/fixtures/deployment-bringyourown-1.10.0-controller-manager.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-bringyourown-1.10.0-controller-manager.yaml
@@ -81,7 +81,7 @@ spec:
         - /dev/stdout
         command:
         - /usr/sbin/openvpn
-        image: quay.io/kubermatic/openvpn:2.4.8
+        image: quay.io/kubermatic/openvpn:v2.4.8-r1
         name: openvpn-client
         resources:
           limits:

--- a/api/pkg/resources/test/fixtures/deployment-bringyourown-1.10.0-dns-resolver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-bringyourown-1.10.0-dns-resolver.yaml
@@ -79,7 +79,7 @@ spec:
         - /dev/stdout
         command:
         - /usr/sbin/openvpn
-        image: quay.io/kubermatic/openvpn:2.4.8
+        image: quay.io/kubermatic/openvpn:v2.4.8-r1
         name: openvpn-client
         resources:
           limits:

--- a/api/pkg/resources/test/fixtures/deployment-bringyourown-1.10.0-dns-resolver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-bringyourown-1.10.0-dns-resolver.yaml
@@ -79,7 +79,7 @@ spec:
         - /dev/stdout
         command:
         - /usr/sbin/openvpn
-        image: quay.io/kubermatic/openvpn:v0.5
+        image: quay.io/kubermatic/openvpn:v0.6-dev
         name: openvpn-client
         resources:
           limits:

--- a/api/pkg/resources/test/fixtures/deployment-bringyourown-1.10.0-dns-resolver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-bringyourown-1.10.0-dns-resolver.yaml
@@ -79,7 +79,7 @@ spec:
         - /dev/stdout
         command:
         - /usr/sbin/openvpn
-        image: quay.io/kubermatic/openvpn:v0.6-dev
+        image: quay.io/kubermatic/openvpn:2.4.8
         name: openvpn-client
         resources:
           limits:

--- a/api/pkg/resources/test/fixtures/deployment-bringyourown-1.10.0-metrics-server.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-bringyourown-1.10.0-metrics-server.yaml
@@ -108,7 +108,7 @@ spec:
         - /dev/stdout
         command:
         - /usr/sbin/openvpn
-        image: quay.io/kubermatic/openvpn:2.4.8
+        image: quay.io/kubermatic/openvpn:v2.4.8-r1
         name: openvpn-client
         resources:
           limits:

--- a/api/pkg/resources/test/fixtures/deployment-bringyourown-1.10.0-metrics-server.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-bringyourown-1.10.0-metrics-server.yaml
@@ -108,7 +108,7 @@ spec:
         - /dev/stdout
         command:
         - /usr/sbin/openvpn
-        image: quay.io/kubermatic/openvpn:v0.5
+        image: quay.io/kubermatic/openvpn:v0.6-dev
         name: openvpn-client
         resources:
           limits:

--- a/api/pkg/resources/test/fixtures/deployment-bringyourown-1.10.0-metrics-server.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-bringyourown-1.10.0-metrics-server.yaml
@@ -108,7 +108,7 @@ spec:
         - /dev/stdout
         command:
         - /usr/sbin/openvpn
-        image: quay.io/kubermatic/openvpn:v0.6-dev
+        image: quay.io/kubermatic/openvpn:2.4.8
         name: openvpn-client
         resources:
           limits:

--- a/api/pkg/resources/test/fixtures/deployment-bringyourown-1.10.0-openvpn-server.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-bringyourown-1.10.0-openvpn-server.yaml
@@ -86,7 +86,7 @@ spec:
         - 255.255.255.0
         command:
         - /usr/sbin/openvpn
-        image: quay.io/kubermatic/openvpn:v0.6-dev
+        image: quay.io/kubermatic/openvpn:2.4.8
         name: openvpn-server
         ports:
         - containerPort: 1194
@@ -135,7 +135,7 @@ spec:
           done
         command:
         - /bin/bash
-        image: quay.io/kubermatic/openvpn:v0.6-dev
+        image: quay.io/kubermatic/openvpn:2.4.8
         name: ip-fixup
         resources:
           limits:
@@ -189,7 +189,7 @@ spec:
           iptables -A INPUT -i tun0 -j DROP
         command:
         - /bin/bash
-        image: quay.io/kubermatic/openvpn:v0.6-dev
+        image: quay.io/kubermatic/openvpn:2.4.8
         name: iptables-init
         resources:
           limits:

--- a/api/pkg/resources/test/fixtures/deployment-bringyourown-1.10.0-openvpn-server.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-bringyourown-1.10.0-openvpn-server.yaml
@@ -86,7 +86,7 @@ spec:
         - 255.255.255.0
         command:
         - /usr/sbin/openvpn
-        image: quay.io/kubermatic/openvpn:2.4.8
+        image: quay.io/kubermatic/openvpn:v2.4.8-r1
         name: openvpn-server
         ports:
         - containerPort: 1194
@@ -135,7 +135,7 @@ spec:
           done
         command:
         - /bin/bash
-        image: quay.io/kubermatic/openvpn:2.4.8
+        image: quay.io/kubermatic/openvpn:v2.4.8-r1
         name: ip-fixup
         resources:
           limits:
@@ -189,7 +189,7 @@ spec:
           iptables -A INPUT -i tun0 -j DROP
         command:
         - /bin/bash
-        image: quay.io/kubermatic/openvpn:2.4.8
+        image: quay.io/kubermatic/openvpn:v2.4.8-r1
         name: iptables-init
         resources:
           limits:

--- a/api/pkg/resources/test/fixtures/deployment-bringyourown-1.10.0-openvpn-server.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-bringyourown-1.10.0-openvpn-server.yaml
@@ -86,7 +86,7 @@ spec:
         - 255.255.255.0
         command:
         - /usr/sbin/openvpn
-        image: quay.io/kubermatic/openvpn:v0.5
+        image: quay.io/kubermatic/openvpn:v0.6-dev
         name: openvpn-server
         ports:
         - containerPort: 1194
@@ -135,7 +135,7 @@ spec:
           done
         command:
         - /bin/bash
-        image: quay.io/kubermatic/openvpn:v0.5
+        image: quay.io/kubermatic/openvpn:v0.6-dev
         name: ip-fixup
         resources:
           limits:
@@ -189,7 +189,7 @@ spec:
           iptables -A INPUT -i tun0 -j DROP
         command:
         - /bin/bash
-        image: quay.io/kubermatic/openvpn:v0.5
+        image: quay.io/kubermatic/openvpn:v0.6-dev
         name: iptables-init
         resources:
           limits:

--- a/api/pkg/resources/test/fixtures/deployment-bringyourown-1.10.0-scheduler.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-bringyourown-1.10.0-scheduler.yaml
@@ -79,7 +79,7 @@ spec:
         - /dev/stdout
         command:
         - /usr/sbin/openvpn
-        image: quay.io/kubermatic/openvpn:2.4.8
+        image: quay.io/kubermatic/openvpn:v2.4.8-r1
         name: openvpn-client
         resources:
           limits:

--- a/api/pkg/resources/test/fixtures/deployment-bringyourown-1.10.0-scheduler.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-bringyourown-1.10.0-scheduler.yaml
@@ -79,7 +79,7 @@ spec:
         - /dev/stdout
         command:
         - /usr/sbin/openvpn
-        image: quay.io/kubermatic/openvpn:v0.5
+        image: quay.io/kubermatic/openvpn:v0.6-dev
         name: openvpn-client
         resources:
           limits:

--- a/api/pkg/resources/test/fixtures/deployment-bringyourown-1.10.0-scheduler.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-bringyourown-1.10.0-scheduler.yaml
@@ -79,7 +79,7 @@ spec:
         - /dev/stdout
         command:
         - /usr/sbin/openvpn
-        image: quay.io/kubermatic/openvpn:v0.6-dev
+        image: quay.io/kubermatic/openvpn:2.4.8
         name: openvpn-client
         resources:
           limits:

--- a/api/pkg/resources/test/fixtures/deployment-bringyourown-1.10.6-apiserver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-bringyourown-1.10.6-apiserver.yaml
@@ -89,7 +89,7 @@ spec:
         - /dev/stdout
         command:
         - /usr/sbin/openvpn
-        image: quay.io/kubermatic/openvpn:v0.6-dev
+        image: quay.io/kubermatic/openvpn:2.4.8
         name: openvpn-client
         resources:
           limits:

--- a/api/pkg/resources/test/fixtures/deployment-bringyourown-1.10.6-apiserver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-bringyourown-1.10.6-apiserver.yaml
@@ -89,7 +89,7 @@ spec:
         - /dev/stdout
         command:
         - /usr/sbin/openvpn
-        image: quay.io/kubermatic/openvpn:2.4.8
+        image: quay.io/kubermatic/openvpn:v2.4.8-r1
         name: openvpn-client
         resources:
           limits:

--- a/api/pkg/resources/test/fixtures/deployment-bringyourown-1.10.6-apiserver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-bringyourown-1.10.6-apiserver.yaml
@@ -89,7 +89,7 @@ spec:
         - /dev/stdout
         command:
         - /usr/sbin/openvpn
-        image: quay.io/kubermatic/openvpn:v0.5
+        image: quay.io/kubermatic/openvpn:v0.6-dev
         name: openvpn-client
         resources:
           limits:

--- a/api/pkg/resources/test/fixtures/deployment-bringyourown-1.10.6-controller-manager.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-bringyourown-1.10.6-controller-manager.yaml
@@ -81,7 +81,7 @@ spec:
         - /dev/stdout
         command:
         - /usr/sbin/openvpn
-        image: quay.io/kubermatic/openvpn:v0.6-dev
+        image: quay.io/kubermatic/openvpn:2.4.8
         name: openvpn-client
         resources:
           limits:

--- a/api/pkg/resources/test/fixtures/deployment-bringyourown-1.10.6-controller-manager.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-bringyourown-1.10.6-controller-manager.yaml
@@ -81,7 +81,7 @@ spec:
         - /dev/stdout
         command:
         - /usr/sbin/openvpn
-        image: quay.io/kubermatic/openvpn:v0.5
+        image: quay.io/kubermatic/openvpn:v0.6-dev
         name: openvpn-client
         resources:
           limits:

--- a/api/pkg/resources/test/fixtures/deployment-bringyourown-1.10.6-controller-manager.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-bringyourown-1.10.6-controller-manager.yaml
@@ -81,7 +81,7 @@ spec:
         - /dev/stdout
         command:
         - /usr/sbin/openvpn
-        image: quay.io/kubermatic/openvpn:2.4.8
+        image: quay.io/kubermatic/openvpn:v2.4.8-r1
         name: openvpn-client
         resources:
           limits:

--- a/api/pkg/resources/test/fixtures/deployment-bringyourown-1.10.6-dns-resolver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-bringyourown-1.10.6-dns-resolver.yaml
@@ -79,7 +79,7 @@ spec:
         - /dev/stdout
         command:
         - /usr/sbin/openvpn
-        image: quay.io/kubermatic/openvpn:2.4.8
+        image: quay.io/kubermatic/openvpn:v2.4.8-r1
         name: openvpn-client
         resources:
           limits:

--- a/api/pkg/resources/test/fixtures/deployment-bringyourown-1.10.6-dns-resolver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-bringyourown-1.10.6-dns-resolver.yaml
@@ -79,7 +79,7 @@ spec:
         - /dev/stdout
         command:
         - /usr/sbin/openvpn
-        image: quay.io/kubermatic/openvpn:v0.5
+        image: quay.io/kubermatic/openvpn:v0.6-dev
         name: openvpn-client
         resources:
           limits:

--- a/api/pkg/resources/test/fixtures/deployment-bringyourown-1.10.6-dns-resolver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-bringyourown-1.10.6-dns-resolver.yaml
@@ -79,7 +79,7 @@ spec:
         - /dev/stdout
         command:
         - /usr/sbin/openvpn
-        image: quay.io/kubermatic/openvpn:v0.6-dev
+        image: quay.io/kubermatic/openvpn:2.4.8
         name: openvpn-client
         resources:
           limits:

--- a/api/pkg/resources/test/fixtures/deployment-bringyourown-1.10.6-metrics-server.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-bringyourown-1.10.6-metrics-server.yaml
@@ -108,7 +108,7 @@ spec:
         - /dev/stdout
         command:
         - /usr/sbin/openvpn
-        image: quay.io/kubermatic/openvpn:2.4.8
+        image: quay.io/kubermatic/openvpn:v2.4.8-r1
         name: openvpn-client
         resources:
           limits:

--- a/api/pkg/resources/test/fixtures/deployment-bringyourown-1.10.6-metrics-server.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-bringyourown-1.10.6-metrics-server.yaml
@@ -108,7 +108,7 @@ spec:
         - /dev/stdout
         command:
         - /usr/sbin/openvpn
-        image: quay.io/kubermatic/openvpn:v0.5
+        image: quay.io/kubermatic/openvpn:v0.6-dev
         name: openvpn-client
         resources:
           limits:

--- a/api/pkg/resources/test/fixtures/deployment-bringyourown-1.10.6-metrics-server.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-bringyourown-1.10.6-metrics-server.yaml
@@ -108,7 +108,7 @@ spec:
         - /dev/stdout
         command:
         - /usr/sbin/openvpn
-        image: quay.io/kubermatic/openvpn:v0.6-dev
+        image: quay.io/kubermatic/openvpn:2.4.8
         name: openvpn-client
         resources:
           limits:

--- a/api/pkg/resources/test/fixtures/deployment-bringyourown-1.10.6-openvpn-server.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-bringyourown-1.10.6-openvpn-server.yaml
@@ -86,7 +86,7 @@ spec:
         - 255.255.255.0
         command:
         - /usr/sbin/openvpn
-        image: quay.io/kubermatic/openvpn:v0.6-dev
+        image: quay.io/kubermatic/openvpn:2.4.8
         name: openvpn-server
         ports:
         - containerPort: 1194
@@ -135,7 +135,7 @@ spec:
           done
         command:
         - /bin/bash
-        image: quay.io/kubermatic/openvpn:v0.6-dev
+        image: quay.io/kubermatic/openvpn:2.4.8
         name: ip-fixup
         resources:
           limits:
@@ -189,7 +189,7 @@ spec:
           iptables -A INPUT -i tun0 -j DROP
         command:
         - /bin/bash
-        image: quay.io/kubermatic/openvpn:v0.6-dev
+        image: quay.io/kubermatic/openvpn:2.4.8
         name: iptables-init
         resources:
           limits:

--- a/api/pkg/resources/test/fixtures/deployment-bringyourown-1.10.6-openvpn-server.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-bringyourown-1.10.6-openvpn-server.yaml
@@ -86,7 +86,7 @@ spec:
         - 255.255.255.0
         command:
         - /usr/sbin/openvpn
-        image: quay.io/kubermatic/openvpn:2.4.8
+        image: quay.io/kubermatic/openvpn:v2.4.8-r1
         name: openvpn-server
         ports:
         - containerPort: 1194
@@ -135,7 +135,7 @@ spec:
           done
         command:
         - /bin/bash
-        image: quay.io/kubermatic/openvpn:2.4.8
+        image: quay.io/kubermatic/openvpn:v2.4.8-r1
         name: ip-fixup
         resources:
           limits:
@@ -189,7 +189,7 @@ spec:
           iptables -A INPUT -i tun0 -j DROP
         command:
         - /bin/bash
-        image: quay.io/kubermatic/openvpn:2.4.8
+        image: quay.io/kubermatic/openvpn:v2.4.8-r1
         name: iptables-init
         resources:
           limits:

--- a/api/pkg/resources/test/fixtures/deployment-bringyourown-1.10.6-openvpn-server.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-bringyourown-1.10.6-openvpn-server.yaml
@@ -86,7 +86,7 @@ spec:
         - 255.255.255.0
         command:
         - /usr/sbin/openvpn
-        image: quay.io/kubermatic/openvpn:v0.5
+        image: quay.io/kubermatic/openvpn:v0.6-dev
         name: openvpn-server
         ports:
         - containerPort: 1194
@@ -135,7 +135,7 @@ spec:
           done
         command:
         - /bin/bash
-        image: quay.io/kubermatic/openvpn:v0.5
+        image: quay.io/kubermatic/openvpn:v0.6-dev
         name: ip-fixup
         resources:
           limits:
@@ -189,7 +189,7 @@ spec:
           iptables -A INPUT -i tun0 -j DROP
         command:
         - /bin/bash
-        image: quay.io/kubermatic/openvpn:v0.5
+        image: quay.io/kubermatic/openvpn:v0.6-dev
         name: iptables-init
         resources:
           limits:

--- a/api/pkg/resources/test/fixtures/deployment-bringyourown-1.10.6-scheduler.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-bringyourown-1.10.6-scheduler.yaml
@@ -79,7 +79,7 @@ spec:
         - /dev/stdout
         command:
         - /usr/sbin/openvpn
-        image: quay.io/kubermatic/openvpn:2.4.8
+        image: quay.io/kubermatic/openvpn:v2.4.8-r1
         name: openvpn-client
         resources:
           limits:

--- a/api/pkg/resources/test/fixtures/deployment-bringyourown-1.10.6-scheduler.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-bringyourown-1.10.6-scheduler.yaml
@@ -79,7 +79,7 @@ spec:
         - /dev/stdout
         command:
         - /usr/sbin/openvpn
-        image: quay.io/kubermatic/openvpn:v0.5
+        image: quay.io/kubermatic/openvpn:v0.6-dev
         name: openvpn-client
         resources:
           limits:

--- a/api/pkg/resources/test/fixtures/deployment-bringyourown-1.10.6-scheduler.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-bringyourown-1.10.6-scheduler.yaml
@@ -79,7 +79,7 @@ spec:
         - /dev/stdout
         command:
         - /usr/sbin/openvpn
-        image: quay.io/kubermatic/openvpn:v0.6-dev
+        image: quay.io/kubermatic/openvpn:2.4.8
         name: openvpn-client
         resources:
           limits:

--- a/api/pkg/resources/test/fixtures/deployment-bringyourown-1.11.0-apiserver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-bringyourown-1.11.0-apiserver.yaml
@@ -89,7 +89,7 @@ spec:
         - /dev/stdout
         command:
         - /usr/sbin/openvpn
-        image: quay.io/kubermatic/openvpn:v0.6-dev
+        image: quay.io/kubermatic/openvpn:2.4.8
         name: openvpn-client
         resources:
           limits:

--- a/api/pkg/resources/test/fixtures/deployment-bringyourown-1.11.0-apiserver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-bringyourown-1.11.0-apiserver.yaml
@@ -89,7 +89,7 @@ spec:
         - /dev/stdout
         command:
         - /usr/sbin/openvpn
-        image: quay.io/kubermatic/openvpn:2.4.8
+        image: quay.io/kubermatic/openvpn:v2.4.8-r1
         name: openvpn-client
         resources:
           limits:

--- a/api/pkg/resources/test/fixtures/deployment-bringyourown-1.11.0-apiserver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-bringyourown-1.11.0-apiserver.yaml
@@ -89,7 +89,7 @@ spec:
         - /dev/stdout
         command:
         - /usr/sbin/openvpn
-        image: quay.io/kubermatic/openvpn:v0.5
+        image: quay.io/kubermatic/openvpn:v0.6-dev
         name: openvpn-client
         resources:
           limits:

--- a/api/pkg/resources/test/fixtures/deployment-bringyourown-1.11.0-controller-manager.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-bringyourown-1.11.0-controller-manager.yaml
@@ -81,7 +81,7 @@ spec:
         - /dev/stdout
         command:
         - /usr/sbin/openvpn
-        image: quay.io/kubermatic/openvpn:v0.6-dev
+        image: quay.io/kubermatic/openvpn:2.4.8
         name: openvpn-client
         resources:
           limits:

--- a/api/pkg/resources/test/fixtures/deployment-bringyourown-1.11.0-controller-manager.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-bringyourown-1.11.0-controller-manager.yaml
@@ -81,7 +81,7 @@ spec:
         - /dev/stdout
         command:
         - /usr/sbin/openvpn
-        image: quay.io/kubermatic/openvpn:v0.5
+        image: quay.io/kubermatic/openvpn:v0.6-dev
         name: openvpn-client
         resources:
           limits:

--- a/api/pkg/resources/test/fixtures/deployment-bringyourown-1.11.0-controller-manager.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-bringyourown-1.11.0-controller-manager.yaml
@@ -81,7 +81,7 @@ spec:
         - /dev/stdout
         command:
         - /usr/sbin/openvpn
-        image: quay.io/kubermatic/openvpn:2.4.8
+        image: quay.io/kubermatic/openvpn:v2.4.8-r1
         name: openvpn-client
         resources:
           limits:

--- a/api/pkg/resources/test/fixtures/deployment-bringyourown-1.11.0-dns-resolver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-bringyourown-1.11.0-dns-resolver.yaml
@@ -79,7 +79,7 @@ spec:
         - /dev/stdout
         command:
         - /usr/sbin/openvpn
-        image: quay.io/kubermatic/openvpn:2.4.8
+        image: quay.io/kubermatic/openvpn:v2.4.8-r1
         name: openvpn-client
         resources:
           limits:

--- a/api/pkg/resources/test/fixtures/deployment-bringyourown-1.11.0-dns-resolver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-bringyourown-1.11.0-dns-resolver.yaml
@@ -79,7 +79,7 @@ spec:
         - /dev/stdout
         command:
         - /usr/sbin/openvpn
-        image: quay.io/kubermatic/openvpn:v0.5
+        image: quay.io/kubermatic/openvpn:v0.6-dev
         name: openvpn-client
         resources:
           limits:

--- a/api/pkg/resources/test/fixtures/deployment-bringyourown-1.11.0-dns-resolver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-bringyourown-1.11.0-dns-resolver.yaml
@@ -79,7 +79,7 @@ spec:
         - /dev/stdout
         command:
         - /usr/sbin/openvpn
-        image: quay.io/kubermatic/openvpn:v0.6-dev
+        image: quay.io/kubermatic/openvpn:2.4.8
         name: openvpn-client
         resources:
           limits:

--- a/api/pkg/resources/test/fixtures/deployment-bringyourown-1.11.0-metrics-server.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-bringyourown-1.11.0-metrics-server.yaml
@@ -108,7 +108,7 @@ spec:
         - /dev/stdout
         command:
         - /usr/sbin/openvpn
-        image: quay.io/kubermatic/openvpn:2.4.8
+        image: quay.io/kubermatic/openvpn:v2.4.8-r1
         name: openvpn-client
         resources:
           limits:

--- a/api/pkg/resources/test/fixtures/deployment-bringyourown-1.11.0-metrics-server.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-bringyourown-1.11.0-metrics-server.yaml
@@ -108,7 +108,7 @@ spec:
         - /dev/stdout
         command:
         - /usr/sbin/openvpn
-        image: quay.io/kubermatic/openvpn:v0.5
+        image: quay.io/kubermatic/openvpn:v0.6-dev
         name: openvpn-client
         resources:
           limits:

--- a/api/pkg/resources/test/fixtures/deployment-bringyourown-1.11.0-metrics-server.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-bringyourown-1.11.0-metrics-server.yaml
@@ -108,7 +108,7 @@ spec:
         - /dev/stdout
         command:
         - /usr/sbin/openvpn
-        image: quay.io/kubermatic/openvpn:v0.6-dev
+        image: quay.io/kubermatic/openvpn:2.4.8
         name: openvpn-client
         resources:
           limits:

--- a/api/pkg/resources/test/fixtures/deployment-bringyourown-1.11.0-openvpn-server.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-bringyourown-1.11.0-openvpn-server.yaml
@@ -86,7 +86,7 @@ spec:
         - 255.255.255.0
         command:
         - /usr/sbin/openvpn
-        image: quay.io/kubermatic/openvpn:v0.6-dev
+        image: quay.io/kubermatic/openvpn:2.4.8
         name: openvpn-server
         ports:
         - containerPort: 1194
@@ -135,7 +135,7 @@ spec:
           done
         command:
         - /bin/bash
-        image: quay.io/kubermatic/openvpn:v0.6-dev
+        image: quay.io/kubermatic/openvpn:2.4.8
         name: ip-fixup
         resources:
           limits:
@@ -189,7 +189,7 @@ spec:
           iptables -A INPUT -i tun0 -j DROP
         command:
         - /bin/bash
-        image: quay.io/kubermatic/openvpn:v0.6-dev
+        image: quay.io/kubermatic/openvpn:2.4.8
         name: iptables-init
         resources:
           limits:

--- a/api/pkg/resources/test/fixtures/deployment-bringyourown-1.11.0-openvpn-server.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-bringyourown-1.11.0-openvpn-server.yaml
@@ -86,7 +86,7 @@ spec:
         - 255.255.255.0
         command:
         - /usr/sbin/openvpn
-        image: quay.io/kubermatic/openvpn:2.4.8
+        image: quay.io/kubermatic/openvpn:v2.4.8-r1
         name: openvpn-server
         ports:
         - containerPort: 1194
@@ -135,7 +135,7 @@ spec:
           done
         command:
         - /bin/bash
-        image: quay.io/kubermatic/openvpn:2.4.8
+        image: quay.io/kubermatic/openvpn:v2.4.8-r1
         name: ip-fixup
         resources:
           limits:
@@ -189,7 +189,7 @@ spec:
           iptables -A INPUT -i tun0 -j DROP
         command:
         - /bin/bash
-        image: quay.io/kubermatic/openvpn:2.4.8
+        image: quay.io/kubermatic/openvpn:v2.4.8-r1
         name: iptables-init
         resources:
           limits:

--- a/api/pkg/resources/test/fixtures/deployment-bringyourown-1.11.0-openvpn-server.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-bringyourown-1.11.0-openvpn-server.yaml
@@ -86,7 +86,7 @@ spec:
         - 255.255.255.0
         command:
         - /usr/sbin/openvpn
-        image: quay.io/kubermatic/openvpn:v0.5
+        image: quay.io/kubermatic/openvpn:v0.6-dev
         name: openvpn-server
         ports:
         - containerPort: 1194
@@ -135,7 +135,7 @@ spec:
           done
         command:
         - /bin/bash
-        image: quay.io/kubermatic/openvpn:v0.5
+        image: quay.io/kubermatic/openvpn:v0.6-dev
         name: ip-fixup
         resources:
           limits:
@@ -189,7 +189,7 @@ spec:
           iptables -A INPUT -i tun0 -j DROP
         command:
         - /bin/bash
-        image: quay.io/kubermatic/openvpn:v0.5
+        image: quay.io/kubermatic/openvpn:v0.6-dev
         name: iptables-init
         resources:
           limits:

--- a/api/pkg/resources/test/fixtures/deployment-bringyourown-1.11.0-scheduler.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-bringyourown-1.11.0-scheduler.yaml
@@ -79,7 +79,7 @@ spec:
         - /dev/stdout
         command:
         - /usr/sbin/openvpn
-        image: quay.io/kubermatic/openvpn:2.4.8
+        image: quay.io/kubermatic/openvpn:v2.4.8-r1
         name: openvpn-client
         resources:
           limits:

--- a/api/pkg/resources/test/fixtures/deployment-bringyourown-1.11.0-scheduler.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-bringyourown-1.11.0-scheduler.yaml
@@ -79,7 +79,7 @@ spec:
         - /dev/stdout
         command:
         - /usr/sbin/openvpn
-        image: quay.io/kubermatic/openvpn:v0.5
+        image: quay.io/kubermatic/openvpn:v0.6-dev
         name: openvpn-client
         resources:
           limits:

--- a/api/pkg/resources/test/fixtures/deployment-bringyourown-1.11.0-scheduler.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-bringyourown-1.11.0-scheduler.yaml
@@ -79,7 +79,7 @@ spec:
         - /dev/stdout
         command:
         - /usr/sbin/openvpn
-        image: quay.io/kubermatic/openvpn:v0.6-dev
+        image: quay.io/kubermatic/openvpn:2.4.8
         name: openvpn-client
         resources:
           limits:

--- a/api/pkg/resources/test/fixtures/deployment-bringyourown-1.11.1-apiserver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-bringyourown-1.11.1-apiserver.yaml
@@ -89,7 +89,7 @@ spec:
         - /dev/stdout
         command:
         - /usr/sbin/openvpn
-        image: quay.io/kubermatic/openvpn:v0.6-dev
+        image: quay.io/kubermatic/openvpn:2.4.8
         name: openvpn-client
         resources:
           limits:

--- a/api/pkg/resources/test/fixtures/deployment-bringyourown-1.11.1-apiserver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-bringyourown-1.11.1-apiserver.yaml
@@ -89,7 +89,7 @@ spec:
         - /dev/stdout
         command:
         - /usr/sbin/openvpn
-        image: quay.io/kubermatic/openvpn:2.4.8
+        image: quay.io/kubermatic/openvpn:v2.4.8-r1
         name: openvpn-client
         resources:
           limits:

--- a/api/pkg/resources/test/fixtures/deployment-bringyourown-1.11.1-apiserver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-bringyourown-1.11.1-apiserver.yaml
@@ -89,7 +89,7 @@ spec:
         - /dev/stdout
         command:
         - /usr/sbin/openvpn
-        image: quay.io/kubermatic/openvpn:v0.5
+        image: quay.io/kubermatic/openvpn:v0.6-dev
         name: openvpn-client
         resources:
           limits:

--- a/api/pkg/resources/test/fixtures/deployment-bringyourown-1.11.1-controller-manager.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-bringyourown-1.11.1-controller-manager.yaml
@@ -81,7 +81,7 @@ spec:
         - /dev/stdout
         command:
         - /usr/sbin/openvpn
-        image: quay.io/kubermatic/openvpn:v0.6-dev
+        image: quay.io/kubermatic/openvpn:2.4.8
         name: openvpn-client
         resources:
           limits:

--- a/api/pkg/resources/test/fixtures/deployment-bringyourown-1.11.1-controller-manager.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-bringyourown-1.11.1-controller-manager.yaml
@@ -81,7 +81,7 @@ spec:
         - /dev/stdout
         command:
         - /usr/sbin/openvpn
-        image: quay.io/kubermatic/openvpn:v0.5
+        image: quay.io/kubermatic/openvpn:v0.6-dev
         name: openvpn-client
         resources:
           limits:

--- a/api/pkg/resources/test/fixtures/deployment-bringyourown-1.11.1-controller-manager.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-bringyourown-1.11.1-controller-manager.yaml
@@ -81,7 +81,7 @@ spec:
         - /dev/stdout
         command:
         - /usr/sbin/openvpn
-        image: quay.io/kubermatic/openvpn:2.4.8
+        image: quay.io/kubermatic/openvpn:v2.4.8-r1
         name: openvpn-client
         resources:
           limits:

--- a/api/pkg/resources/test/fixtures/deployment-bringyourown-1.11.1-dns-resolver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-bringyourown-1.11.1-dns-resolver.yaml
@@ -79,7 +79,7 @@ spec:
         - /dev/stdout
         command:
         - /usr/sbin/openvpn
-        image: quay.io/kubermatic/openvpn:2.4.8
+        image: quay.io/kubermatic/openvpn:v2.4.8-r1
         name: openvpn-client
         resources:
           limits:

--- a/api/pkg/resources/test/fixtures/deployment-bringyourown-1.11.1-dns-resolver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-bringyourown-1.11.1-dns-resolver.yaml
@@ -79,7 +79,7 @@ spec:
         - /dev/stdout
         command:
         - /usr/sbin/openvpn
-        image: quay.io/kubermatic/openvpn:v0.5
+        image: quay.io/kubermatic/openvpn:v0.6-dev
         name: openvpn-client
         resources:
           limits:

--- a/api/pkg/resources/test/fixtures/deployment-bringyourown-1.11.1-dns-resolver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-bringyourown-1.11.1-dns-resolver.yaml
@@ -79,7 +79,7 @@ spec:
         - /dev/stdout
         command:
         - /usr/sbin/openvpn
-        image: quay.io/kubermatic/openvpn:v0.6-dev
+        image: quay.io/kubermatic/openvpn:2.4.8
         name: openvpn-client
         resources:
           limits:

--- a/api/pkg/resources/test/fixtures/deployment-bringyourown-1.11.1-metrics-server.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-bringyourown-1.11.1-metrics-server.yaml
@@ -108,7 +108,7 @@ spec:
         - /dev/stdout
         command:
         - /usr/sbin/openvpn
-        image: quay.io/kubermatic/openvpn:2.4.8
+        image: quay.io/kubermatic/openvpn:v2.4.8-r1
         name: openvpn-client
         resources:
           limits:

--- a/api/pkg/resources/test/fixtures/deployment-bringyourown-1.11.1-metrics-server.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-bringyourown-1.11.1-metrics-server.yaml
@@ -108,7 +108,7 @@ spec:
         - /dev/stdout
         command:
         - /usr/sbin/openvpn
-        image: quay.io/kubermatic/openvpn:v0.5
+        image: quay.io/kubermatic/openvpn:v0.6-dev
         name: openvpn-client
         resources:
           limits:

--- a/api/pkg/resources/test/fixtures/deployment-bringyourown-1.11.1-metrics-server.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-bringyourown-1.11.1-metrics-server.yaml
@@ -108,7 +108,7 @@ spec:
         - /dev/stdout
         command:
         - /usr/sbin/openvpn
-        image: quay.io/kubermatic/openvpn:v0.6-dev
+        image: quay.io/kubermatic/openvpn:2.4.8
         name: openvpn-client
         resources:
           limits:

--- a/api/pkg/resources/test/fixtures/deployment-bringyourown-1.11.1-openvpn-server.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-bringyourown-1.11.1-openvpn-server.yaml
@@ -86,7 +86,7 @@ spec:
         - 255.255.255.0
         command:
         - /usr/sbin/openvpn
-        image: quay.io/kubermatic/openvpn:v0.6-dev
+        image: quay.io/kubermatic/openvpn:2.4.8
         name: openvpn-server
         ports:
         - containerPort: 1194
@@ -135,7 +135,7 @@ spec:
           done
         command:
         - /bin/bash
-        image: quay.io/kubermatic/openvpn:v0.6-dev
+        image: quay.io/kubermatic/openvpn:2.4.8
         name: ip-fixup
         resources:
           limits:
@@ -189,7 +189,7 @@ spec:
           iptables -A INPUT -i tun0 -j DROP
         command:
         - /bin/bash
-        image: quay.io/kubermatic/openvpn:v0.6-dev
+        image: quay.io/kubermatic/openvpn:2.4.8
         name: iptables-init
         resources:
           limits:

--- a/api/pkg/resources/test/fixtures/deployment-bringyourown-1.11.1-openvpn-server.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-bringyourown-1.11.1-openvpn-server.yaml
@@ -86,7 +86,7 @@ spec:
         - 255.255.255.0
         command:
         - /usr/sbin/openvpn
-        image: quay.io/kubermatic/openvpn:2.4.8
+        image: quay.io/kubermatic/openvpn:v2.4.8-r1
         name: openvpn-server
         ports:
         - containerPort: 1194
@@ -135,7 +135,7 @@ spec:
           done
         command:
         - /bin/bash
-        image: quay.io/kubermatic/openvpn:2.4.8
+        image: quay.io/kubermatic/openvpn:v2.4.8-r1
         name: ip-fixup
         resources:
           limits:
@@ -189,7 +189,7 @@ spec:
           iptables -A INPUT -i tun0 -j DROP
         command:
         - /bin/bash
-        image: quay.io/kubermatic/openvpn:2.4.8
+        image: quay.io/kubermatic/openvpn:v2.4.8-r1
         name: iptables-init
         resources:
           limits:

--- a/api/pkg/resources/test/fixtures/deployment-bringyourown-1.11.1-openvpn-server.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-bringyourown-1.11.1-openvpn-server.yaml
@@ -86,7 +86,7 @@ spec:
         - 255.255.255.0
         command:
         - /usr/sbin/openvpn
-        image: quay.io/kubermatic/openvpn:v0.5
+        image: quay.io/kubermatic/openvpn:v0.6-dev
         name: openvpn-server
         ports:
         - containerPort: 1194
@@ -135,7 +135,7 @@ spec:
           done
         command:
         - /bin/bash
-        image: quay.io/kubermatic/openvpn:v0.5
+        image: quay.io/kubermatic/openvpn:v0.6-dev
         name: ip-fixup
         resources:
           limits:
@@ -189,7 +189,7 @@ spec:
           iptables -A INPUT -i tun0 -j DROP
         command:
         - /bin/bash
-        image: quay.io/kubermatic/openvpn:v0.5
+        image: quay.io/kubermatic/openvpn:v0.6-dev
         name: iptables-init
         resources:
           limits:

--- a/api/pkg/resources/test/fixtures/deployment-bringyourown-1.11.1-scheduler.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-bringyourown-1.11.1-scheduler.yaml
@@ -79,7 +79,7 @@ spec:
         - /dev/stdout
         command:
         - /usr/sbin/openvpn
-        image: quay.io/kubermatic/openvpn:2.4.8
+        image: quay.io/kubermatic/openvpn:v2.4.8-r1
         name: openvpn-client
         resources:
           limits:

--- a/api/pkg/resources/test/fixtures/deployment-bringyourown-1.11.1-scheduler.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-bringyourown-1.11.1-scheduler.yaml
@@ -79,7 +79,7 @@ spec:
         - /dev/stdout
         command:
         - /usr/sbin/openvpn
-        image: quay.io/kubermatic/openvpn:v0.5
+        image: quay.io/kubermatic/openvpn:v0.6-dev
         name: openvpn-client
         resources:
           limits:

--- a/api/pkg/resources/test/fixtures/deployment-bringyourown-1.11.1-scheduler.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-bringyourown-1.11.1-scheduler.yaml
@@ -79,7 +79,7 @@ spec:
         - /dev/stdout
         command:
         - /usr/sbin/openvpn
-        image: quay.io/kubermatic/openvpn:v0.6-dev
+        image: quay.io/kubermatic/openvpn:2.4.8
         name: openvpn-client
         resources:
           limits:

--- a/api/pkg/resources/test/fixtures/deployment-bringyourown-1.12.0-apiserver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-bringyourown-1.12.0-apiserver.yaml
@@ -89,7 +89,7 @@ spec:
         - /dev/stdout
         command:
         - /usr/sbin/openvpn
-        image: quay.io/kubermatic/openvpn:v0.6-dev
+        image: quay.io/kubermatic/openvpn:2.4.8
         name: openvpn-client
         resources:
           limits:

--- a/api/pkg/resources/test/fixtures/deployment-bringyourown-1.12.0-apiserver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-bringyourown-1.12.0-apiserver.yaml
@@ -89,7 +89,7 @@ spec:
         - /dev/stdout
         command:
         - /usr/sbin/openvpn
-        image: quay.io/kubermatic/openvpn:2.4.8
+        image: quay.io/kubermatic/openvpn:v2.4.8-r1
         name: openvpn-client
         resources:
           limits:

--- a/api/pkg/resources/test/fixtures/deployment-bringyourown-1.12.0-apiserver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-bringyourown-1.12.0-apiserver.yaml
@@ -89,7 +89,7 @@ spec:
         - /dev/stdout
         command:
         - /usr/sbin/openvpn
-        image: quay.io/kubermatic/openvpn:v0.5
+        image: quay.io/kubermatic/openvpn:v0.6-dev
         name: openvpn-client
         resources:
           limits:

--- a/api/pkg/resources/test/fixtures/deployment-bringyourown-1.12.0-controller-manager.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-bringyourown-1.12.0-controller-manager.yaml
@@ -81,7 +81,7 @@ spec:
         - /dev/stdout
         command:
         - /usr/sbin/openvpn
-        image: quay.io/kubermatic/openvpn:v0.6-dev
+        image: quay.io/kubermatic/openvpn:2.4.8
         name: openvpn-client
         resources:
           limits:

--- a/api/pkg/resources/test/fixtures/deployment-bringyourown-1.12.0-controller-manager.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-bringyourown-1.12.0-controller-manager.yaml
@@ -81,7 +81,7 @@ spec:
         - /dev/stdout
         command:
         - /usr/sbin/openvpn
-        image: quay.io/kubermatic/openvpn:v0.5
+        image: quay.io/kubermatic/openvpn:v0.6-dev
         name: openvpn-client
         resources:
           limits:

--- a/api/pkg/resources/test/fixtures/deployment-bringyourown-1.12.0-controller-manager.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-bringyourown-1.12.0-controller-manager.yaml
@@ -81,7 +81,7 @@ spec:
         - /dev/stdout
         command:
         - /usr/sbin/openvpn
-        image: quay.io/kubermatic/openvpn:2.4.8
+        image: quay.io/kubermatic/openvpn:v2.4.8-r1
         name: openvpn-client
         resources:
           limits:

--- a/api/pkg/resources/test/fixtures/deployment-bringyourown-1.12.0-dns-resolver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-bringyourown-1.12.0-dns-resolver.yaml
@@ -79,7 +79,7 @@ spec:
         - /dev/stdout
         command:
         - /usr/sbin/openvpn
-        image: quay.io/kubermatic/openvpn:2.4.8
+        image: quay.io/kubermatic/openvpn:v2.4.8-r1
         name: openvpn-client
         resources:
           limits:

--- a/api/pkg/resources/test/fixtures/deployment-bringyourown-1.12.0-dns-resolver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-bringyourown-1.12.0-dns-resolver.yaml
@@ -79,7 +79,7 @@ spec:
         - /dev/stdout
         command:
         - /usr/sbin/openvpn
-        image: quay.io/kubermatic/openvpn:v0.5
+        image: quay.io/kubermatic/openvpn:v0.6-dev
         name: openvpn-client
         resources:
           limits:

--- a/api/pkg/resources/test/fixtures/deployment-bringyourown-1.12.0-dns-resolver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-bringyourown-1.12.0-dns-resolver.yaml
@@ -79,7 +79,7 @@ spec:
         - /dev/stdout
         command:
         - /usr/sbin/openvpn
-        image: quay.io/kubermatic/openvpn:v0.6-dev
+        image: quay.io/kubermatic/openvpn:2.4.8
         name: openvpn-client
         resources:
           limits:

--- a/api/pkg/resources/test/fixtures/deployment-bringyourown-1.12.0-metrics-server.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-bringyourown-1.12.0-metrics-server.yaml
@@ -108,7 +108,7 @@ spec:
         - /dev/stdout
         command:
         - /usr/sbin/openvpn
-        image: quay.io/kubermatic/openvpn:2.4.8
+        image: quay.io/kubermatic/openvpn:v2.4.8-r1
         name: openvpn-client
         resources:
           limits:

--- a/api/pkg/resources/test/fixtures/deployment-bringyourown-1.12.0-metrics-server.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-bringyourown-1.12.0-metrics-server.yaml
@@ -108,7 +108,7 @@ spec:
         - /dev/stdout
         command:
         - /usr/sbin/openvpn
-        image: quay.io/kubermatic/openvpn:v0.5
+        image: quay.io/kubermatic/openvpn:v0.6-dev
         name: openvpn-client
         resources:
           limits:

--- a/api/pkg/resources/test/fixtures/deployment-bringyourown-1.12.0-metrics-server.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-bringyourown-1.12.0-metrics-server.yaml
@@ -108,7 +108,7 @@ spec:
         - /dev/stdout
         command:
         - /usr/sbin/openvpn
-        image: quay.io/kubermatic/openvpn:v0.6-dev
+        image: quay.io/kubermatic/openvpn:2.4.8
         name: openvpn-client
         resources:
           limits:

--- a/api/pkg/resources/test/fixtures/deployment-bringyourown-1.12.0-openvpn-server.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-bringyourown-1.12.0-openvpn-server.yaml
@@ -86,7 +86,7 @@ spec:
         - 255.255.255.0
         command:
         - /usr/sbin/openvpn
-        image: quay.io/kubermatic/openvpn:v0.6-dev
+        image: quay.io/kubermatic/openvpn:2.4.8
         name: openvpn-server
         ports:
         - containerPort: 1194
@@ -135,7 +135,7 @@ spec:
           done
         command:
         - /bin/bash
-        image: quay.io/kubermatic/openvpn:v0.6-dev
+        image: quay.io/kubermatic/openvpn:2.4.8
         name: ip-fixup
         resources:
           limits:
@@ -189,7 +189,7 @@ spec:
           iptables -A INPUT -i tun0 -j DROP
         command:
         - /bin/bash
-        image: quay.io/kubermatic/openvpn:v0.6-dev
+        image: quay.io/kubermatic/openvpn:2.4.8
         name: iptables-init
         resources:
           limits:

--- a/api/pkg/resources/test/fixtures/deployment-bringyourown-1.12.0-openvpn-server.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-bringyourown-1.12.0-openvpn-server.yaml
@@ -86,7 +86,7 @@ spec:
         - 255.255.255.0
         command:
         - /usr/sbin/openvpn
-        image: quay.io/kubermatic/openvpn:2.4.8
+        image: quay.io/kubermatic/openvpn:v2.4.8-r1
         name: openvpn-server
         ports:
         - containerPort: 1194
@@ -135,7 +135,7 @@ spec:
           done
         command:
         - /bin/bash
-        image: quay.io/kubermatic/openvpn:2.4.8
+        image: quay.io/kubermatic/openvpn:v2.4.8-r1
         name: ip-fixup
         resources:
           limits:
@@ -189,7 +189,7 @@ spec:
           iptables -A INPUT -i tun0 -j DROP
         command:
         - /bin/bash
-        image: quay.io/kubermatic/openvpn:2.4.8
+        image: quay.io/kubermatic/openvpn:v2.4.8-r1
         name: iptables-init
         resources:
           limits:

--- a/api/pkg/resources/test/fixtures/deployment-bringyourown-1.12.0-openvpn-server.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-bringyourown-1.12.0-openvpn-server.yaml
@@ -86,7 +86,7 @@ spec:
         - 255.255.255.0
         command:
         - /usr/sbin/openvpn
-        image: quay.io/kubermatic/openvpn:v0.5
+        image: quay.io/kubermatic/openvpn:v0.6-dev
         name: openvpn-server
         ports:
         - containerPort: 1194
@@ -135,7 +135,7 @@ spec:
           done
         command:
         - /bin/bash
-        image: quay.io/kubermatic/openvpn:v0.5
+        image: quay.io/kubermatic/openvpn:v0.6-dev
         name: ip-fixup
         resources:
           limits:
@@ -189,7 +189,7 @@ spec:
           iptables -A INPUT -i tun0 -j DROP
         command:
         - /bin/bash
-        image: quay.io/kubermatic/openvpn:v0.5
+        image: quay.io/kubermatic/openvpn:v0.6-dev
         name: iptables-init
         resources:
           limits:

--- a/api/pkg/resources/test/fixtures/deployment-bringyourown-1.12.0-scheduler.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-bringyourown-1.12.0-scheduler.yaml
@@ -79,7 +79,7 @@ spec:
         - /dev/stdout
         command:
         - /usr/sbin/openvpn
-        image: quay.io/kubermatic/openvpn:2.4.8
+        image: quay.io/kubermatic/openvpn:v2.4.8-r1
         name: openvpn-client
         resources:
           limits:

--- a/api/pkg/resources/test/fixtures/deployment-bringyourown-1.12.0-scheduler.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-bringyourown-1.12.0-scheduler.yaml
@@ -79,7 +79,7 @@ spec:
         - /dev/stdout
         command:
         - /usr/sbin/openvpn
-        image: quay.io/kubermatic/openvpn:v0.5
+        image: quay.io/kubermatic/openvpn:v0.6-dev
         name: openvpn-client
         resources:
           limits:

--- a/api/pkg/resources/test/fixtures/deployment-bringyourown-1.12.0-scheduler.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-bringyourown-1.12.0-scheduler.yaml
@@ -79,7 +79,7 @@ spec:
         - /dev/stdout
         command:
         - /usr/sbin/openvpn
-        image: quay.io/kubermatic/openvpn:v0.6-dev
+        image: quay.io/kubermatic/openvpn:2.4.8
         name: openvpn-client
         resources:
           limits:

--- a/api/pkg/resources/test/fixtures/deployment-bringyourown-1.13.0-apiserver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-bringyourown-1.13.0-apiserver.yaml
@@ -89,7 +89,7 @@ spec:
         - /dev/stdout
         command:
         - /usr/sbin/openvpn
-        image: quay.io/kubermatic/openvpn:v0.6-dev
+        image: quay.io/kubermatic/openvpn:2.4.8
         name: openvpn-client
         resources:
           limits:

--- a/api/pkg/resources/test/fixtures/deployment-bringyourown-1.13.0-apiserver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-bringyourown-1.13.0-apiserver.yaml
@@ -89,7 +89,7 @@ spec:
         - /dev/stdout
         command:
         - /usr/sbin/openvpn
-        image: quay.io/kubermatic/openvpn:2.4.8
+        image: quay.io/kubermatic/openvpn:v2.4.8-r1
         name: openvpn-client
         resources:
           limits:

--- a/api/pkg/resources/test/fixtures/deployment-bringyourown-1.13.0-apiserver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-bringyourown-1.13.0-apiserver.yaml
@@ -89,7 +89,7 @@ spec:
         - /dev/stdout
         command:
         - /usr/sbin/openvpn
-        image: quay.io/kubermatic/openvpn:v0.5
+        image: quay.io/kubermatic/openvpn:v0.6-dev
         name: openvpn-client
         resources:
           limits:

--- a/api/pkg/resources/test/fixtures/deployment-bringyourown-1.13.0-controller-manager.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-bringyourown-1.13.0-controller-manager.yaml
@@ -81,7 +81,7 @@ spec:
         - /dev/stdout
         command:
         - /usr/sbin/openvpn
-        image: quay.io/kubermatic/openvpn:v0.6-dev
+        image: quay.io/kubermatic/openvpn:2.4.8
         name: openvpn-client
         resources:
           limits:

--- a/api/pkg/resources/test/fixtures/deployment-bringyourown-1.13.0-controller-manager.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-bringyourown-1.13.0-controller-manager.yaml
@@ -81,7 +81,7 @@ spec:
         - /dev/stdout
         command:
         - /usr/sbin/openvpn
-        image: quay.io/kubermatic/openvpn:v0.5
+        image: quay.io/kubermatic/openvpn:v0.6-dev
         name: openvpn-client
         resources:
           limits:

--- a/api/pkg/resources/test/fixtures/deployment-bringyourown-1.13.0-controller-manager.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-bringyourown-1.13.0-controller-manager.yaml
@@ -81,7 +81,7 @@ spec:
         - /dev/stdout
         command:
         - /usr/sbin/openvpn
-        image: quay.io/kubermatic/openvpn:2.4.8
+        image: quay.io/kubermatic/openvpn:v2.4.8-r1
         name: openvpn-client
         resources:
           limits:

--- a/api/pkg/resources/test/fixtures/deployment-bringyourown-1.13.0-dns-resolver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-bringyourown-1.13.0-dns-resolver.yaml
@@ -79,7 +79,7 @@ spec:
         - /dev/stdout
         command:
         - /usr/sbin/openvpn
-        image: quay.io/kubermatic/openvpn:2.4.8
+        image: quay.io/kubermatic/openvpn:v2.4.8-r1
         name: openvpn-client
         resources:
           limits:

--- a/api/pkg/resources/test/fixtures/deployment-bringyourown-1.13.0-dns-resolver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-bringyourown-1.13.0-dns-resolver.yaml
@@ -79,7 +79,7 @@ spec:
         - /dev/stdout
         command:
         - /usr/sbin/openvpn
-        image: quay.io/kubermatic/openvpn:v0.5
+        image: quay.io/kubermatic/openvpn:v0.6-dev
         name: openvpn-client
         resources:
           limits:

--- a/api/pkg/resources/test/fixtures/deployment-bringyourown-1.13.0-dns-resolver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-bringyourown-1.13.0-dns-resolver.yaml
@@ -79,7 +79,7 @@ spec:
         - /dev/stdout
         command:
         - /usr/sbin/openvpn
-        image: quay.io/kubermatic/openvpn:v0.6-dev
+        image: quay.io/kubermatic/openvpn:2.4.8
         name: openvpn-client
         resources:
           limits:

--- a/api/pkg/resources/test/fixtures/deployment-bringyourown-1.13.0-metrics-server.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-bringyourown-1.13.0-metrics-server.yaml
@@ -108,7 +108,7 @@ spec:
         - /dev/stdout
         command:
         - /usr/sbin/openvpn
-        image: quay.io/kubermatic/openvpn:2.4.8
+        image: quay.io/kubermatic/openvpn:v2.4.8-r1
         name: openvpn-client
         resources:
           limits:

--- a/api/pkg/resources/test/fixtures/deployment-bringyourown-1.13.0-metrics-server.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-bringyourown-1.13.0-metrics-server.yaml
@@ -108,7 +108,7 @@ spec:
         - /dev/stdout
         command:
         - /usr/sbin/openvpn
-        image: quay.io/kubermatic/openvpn:v0.5
+        image: quay.io/kubermatic/openvpn:v0.6-dev
         name: openvpn-client
         resources:
           limits:

--- a/api/pkg/resources/test/fixtures/deployment-bringyourown-1.13.0-metrics-server.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-bringyourown-1.13.0-metrics-server.yaml
@@ -108,7 +108,7 @@ spec:
         - /dev/stdout
         command:
         - /usr/sbin/openvpn
-        image: quay.io/kubermatic/openvpn:v0.6-dev
+        image: quay.io/kubermatic/openvpn:2.4.8
         name: openvpn-client
         resources:
           limits:

--- a/api/pkg/resources/test/fixtures/deployment-bringyourown-1.13.0-openvpn-server.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-bringyourown-1.13.0-openvpn-server.yaml
@@ -86,7 +86,7 @@ spec:
         - 255.255.255.0
         command:
         - /usr/sbin/openvpn
-        image: quay.io/kubermatic/openvpn:v0.6-dev
+        image: quay.io/kubermatic/openvpn:2.4.8
         name: openvpn-server
         ports:
         - containerPort: 1194
@@ -135,7 +135,7 @@ spec:
           done
         command:
         - /bin/bash
-        image: quay.io/kubermatic/openvpn:v0.6-dev
+        image: quay.io/kubermatic/openvpn:2.4.8
         name: ip-fixup
         resources:
           limits:
@@ -189,7 +189,7 @@ spec:
           iptables -A INPUT -i tun0 -j DROP
         command:
         - /bin/bash
-        image: quay.io/kubermatic/openvpn:v0.6-dev
+        image: quay.io/kubermatic/openvpn:2.4.8
         name: iptables-init
         resources:
           limits:

--- a/api/pkg/resources/test/fixtures/deployment-bringyourown-1.13.0-openvpn-server.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-bringyourown-1.13.0-openvpn-server.yaml
@@ -86,7 +86,7 @@ spec:
         - 255.255.255.0
         command:
         - /usr/sbin/openvpn
-        image: quay.io/kubermatic/openvpn:2.4.8
+        image: quay.io/kubermatic/openvpn:v2.4.8-r1
         name: openvpn-server
         ports:
         - containerPort: 1194
@@ -135,7 +135,7 @@ spec:
           done
         command:
         - /bin/bash
-        image: quay.io/kubermatic/openvpn:2.4.8
+        image: quay.io/kubermatic/openvpn:v2.4.8-r1
         name: ip-fixup
         resources:
           limits:
@@ -189,7 +189,7 @@ spec:
           iptables -A INPUT -i tun0 -j DROP
         command:
         - /bin/bash
-        image: quay.io/kubermatic/openvpn:2.4.8
+        image: quay.io/kubermatic/openvpn:v2.4.8-r1
         name: iptables-init
         resources:
           limits:

--- a/api/pkg/resources/test/fixtures/deployment-bringyourown-1.13.0-openvpn-server.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-bringyourown-1.13.0-openvpn-server.yaml
@@ -86,7 +86,7 @@ spec:
         - 255.255.255.0
         command:
         - /usr/sbin/openvpn
-        image: quay.io/kubermatic/openvpn:v0.5
+        image: quay.io/kubermatic/openvpn:v0.6-dev
         name: openvpn-server
         ports:
         - containerPort: 1194
@@ -135,7 +135,7 @@ spec:
           done
         command:
         - /bin/bash
-        image: quay.io/kubermatic/openvpn:v0.5
+        image: quay.io/kubermatic/openvpn:v0.6-dev
         name: ip-fixup
         resources:
           limits:
@@ -189,7 +189,7 @@ spec:
           iptables -A INPUT -i tun0 -j DROP
         command:
         - /bin/bash
-        image: quay.io/kubermatic/openvpn:v0.5
+        image: quay.io/kubermatic/openvpn:v0.6-dev
         name: iptables-init
         resources:
           limits:

--- a/api/pkg/resources/test/fixtures/deployment-bringyourown-1.13.0-scheduler.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-bringyourown-1.13.0-scheduler.yaml
@@ -79,7 +79,7 @@ spec:
         - /dev/stdout
         command:
         - /usr/sbin/openvpn
-        image: quay.io/kubermatic/openvpn:2.4.8
+        image: quay.io/kubermatic/openvpn:v2.4.8-r1
         name: openvpn-client
         resources:
           limits:

--- a/api/pkg/resources/test/fixtures/deployment-bringyourown-1.13.0-scheduler.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-bringyourown-1.13.0-scheduler.yaml
@@ -79,7 +79,7 @@ spec:
         - /dev/stdout
         command:
         - /usr/sbin/openvpn
-        image: quay.io/kubermatic/openvpn:v0.5
+        image: quay.io/kubermatic/openvpn:v0.6-dev
         name: openvpn-client
         resources:
           limits:

--- a/api/pkg/resources/test/fixtures/deployment-bringyourown-1.13.0-scheduler.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-bringyourown-1.13.0-scheduler.yaml
@@ -79,7 +79,7 @@ spec:
         - /dev/stdout
         command:
         - /usr/sbin/openvpn
-        image: quay.io/kubermatic/openvpn:v0.6-dev
+        image: quay.io/kubermatic/openvpn:2.4.8
         name: openvpn-client
         resources:
           limits:

--- a/api/pkg/resources/test/fixtures/deployment-digitalocean-1.10.0-apiserver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-digitalocean-1.10.0-apiserver.yaml
@@ -89,7 +89,7 @@ spec:
         - /dev/stdout
         command:
         - /usr/sbin/openvpn
-        image: quay.io/kubermatic/openvpn:v0.6-dev
+        image: quay.io/kubermatic/openvpn:2.4.8
         name: openvpn-client
         resources:
           limits:

--- a/api/pkg/resources/test/fixtures/deployment-digitalocean-1.10.0-apiserver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-digitalocean-1.10.0-apiserver.yaml
@@ -89,7 +89,7 @@ spec:
         - /dev/stdout
         command:
         - /usr/sbin/openvpn
-        image: quay.io/kubermatic/openvpn:2.4.8
+        image: quay.io/kubermatic/openvpn:v2.4.8-r1
         name: openvpn-client
         resources:
           limits:

--- a/api/pkg/resources/test/fixtures/deployment-digitalocean-1.10.0-apiserver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-digitalocean-1.10.0-apiserver.yaml
@@ -89,7 +89,7 @@ spec:
         - /dev/stdout
         command:
         - /usr/sbin/openvpn
-        image: quay.io/kubermatic/openvpn:v0.5
+        image: quay.io/kubermatic/openvpn:v0.6-dev
         name: openvpn-client
         resources:
           limits:

--- a/api/pkg/resources/test/fixtures/deployment-digitalocean-1.10.0-controller-manager.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-digitalocean-1.10.0-controller-manager.yaml
@@ -81,7 +81,7 @@ spec:
         - /dev/stdout
         command:
         - /usr/sbin/openvpn
-        image: quay.io/kubermatic/openvpn:v0.6-dev
+        image: quay.io/kubermatic/openvpn:2.4.8
         name: openvpn-client
         resources:
           limits:

--- a/api/pkg/resources/test/fixtures/deployment-digitalocean-1.10.0-controller-manager.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-digitalocean-1.10.0-controller-manager.yaml
@@ -81,7 +81,7 @@ spec:
         - /dev/stdout
         command:
         - /usr/sbin/openvpn
-        image: quay.io/kubermatic/openvpn:v0.5
+        image: quay.io/kubermatic/openvpn:v0.6-dev
         name: openvpn-client
         resources:
           limits:

--- a/api/pkg/resources/test/fixtures/deployment-digitalocean-1.10.0-controller-manager.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-digitalocean-1.10.0-controller-manager.yaml
@@ -81,7 +81,7 @@ spec:
         - /dev/stdout
         command:
         - /usr/sbin/openvpn
-        image: quay.io/kubermatic/openvpn:2.4.8
+        image: quay.io/kubermatic/openvpn:v2.4.8-r1
         name: openvpn-client
         resources:
           limits:

--- a/api/pkg/resources/test/fixtures/deployment-digitalocean-1.10.0-dns-resolver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-digitalocean-1.10.0-dns-resolver.yaml
@@ -79,7 +79,7 @@ spec:
         - /dev/stdout
         command:
         - /usr/sbin/openvpn
-        image: quay.io/kubermatic/openvpn:2.4.8
+        image: quay.io/kubermatic/openvpn:v2.4.8-r1
         name: openvpn-client
         resources:
           limits:

--- a/api/pkg/resources/test/fixtures/deployment-digitalocean-1.10.0-dns-resolver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-digitalocean-1.10.0-dns-resolver.yaml
@@ -79,7 +79,7 @@ spec:
         - /dev/stdout
         command:
         - /usr/sbin/openvpn
-        image: quay.io/kubermatic/openvpn:v0.5
+        image: quay.io/kubermatic/openvpn:v0.6-dev
         name: openvpn-client
         resources:
           limits:

--- a/api/pkg/resources/test/fixtures/deployment-digitalocean-1.10.0-dns-resolver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-digitalocean-1.10.0-dns-resolver.yaml
@@ -79,7 +79,7 @@ spec:
         - /dev/stdout
         command:
         - /usr/sbin/openvpn
-        image: quay.io/kubermatic/openvpn:v0.6-dev
+        image: quay.io/kubermatic/openvpn:2.4.8
         name: openvpn-client
         resources:
           limits:

--- a/api/pkg/resources/test/fixtures/deployment-digitalocean-1.10.0-metrics-server.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-digitalocean-1.10.0-metrics-server.yaml
@@ -108,7 +108,7 @@ spec:
         - /dev/stdout
         command:
         - /usr/sbin/openvpn
-        image: quay.io/kubermatic/openvpn:2.4.8
+        image: quay.io/kubermatic/openvpn:v2.4.8-r1
         name: openvpn-client
         resources:
           limits:

--- a/api/pkg/resources/test/fixtures/deployment-digitalocean-1.10.0-metrics-server.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-digitalocean-1.10.0-metrics-server.yaml
@@ -108,7 +108,7 @@ spec:
         - /dev/stdout
         command:
         - /usr/sbin/openvpn
-        image: quay.io/kubermatic/openvpn:v0.5
+        image: quay.io/kubermatic/openvpn:v0.6-dev
         name: openvpn-client
         resources:
           limits:

--- a/api/pkg/resources/test/fixtures/deployment-digitalocean-1.10.0-metrics-server.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-digitalocean-1.10.0-metrics-server.yaml
@@ -108,7 +108,7 @@ spec:
         - /dev/stdout
         command:
         - /usr/sbin/openvpn
-        image: quay.io/kubermatic/openvpn:v0.6-dev
+        image: quay.io/kubermatic/openvpn:2.4.8
         name: openvpn-client
         resources:
           limits:

--- a/api/pkg/resources/test/fixtures/deployment-digitalocean-1.10.0-openvpn-server.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-digitalocean-1.10.0-openvpn-server.yaml
@@ -86,7 +86,7 @@ spec:
         - 255.255.255.0
         command:
         - /usr/sbin/openvpn
-        image: quay.io/kubermatic/openvpn:v0.6-dev
+        image: quay.io/kubermatic/openvpn:2.4.8
         name: openvpn-server
         ports:
         - containerPort: 1194
@@ -135,7 +135,7 @@ spec:
           done
         command:
         - /bin/bash
-        image: quay.io/kubermatic/openvpn:v0.6-dev
+        image: quay.io/kubermatic/openvpn:2.4.8
         name: ip-fixup
         resources:
           limits:
@@ -189,7 +189,7 @@ spec:
           iptables -A INPUT -i tun0 -j DROP
         command:
         - /bin/bash
-        image: quay.io/kubermatic/openvpn:v0.6-dev
+        image: quay.io/kubermatic/openvpn:2.4.8
         name: iptables-init
         resources:
           limits:

--- a/api/pkg/resources/test/fixtures/deployment-digitalocean-1.10.0-openvpn-server.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-digitalocean-1.10.0-openvpn-server.yaml
@@ -86,7 +86,7 @@ spec:
         - 255.255.255.0
         command:
         - /usr/sbin/openvpn
-        image: quay.io/kubermatic/openvpn:2.4.8
+        image: quay.io/kubermatic/openvpn:v2.4.8-r1
         name: openvpn-server
         ports:
         - containerPort: 1194
@@ -135,7 +135,7 @@ spec:
           done
         command:
         - /bin/bash
-        image: quay.io/kubermatic/openvpn:2.4.8
+        image: quay.io/kubermatic/openvpn:v2.4.8-r1
         name: ip-fixup
         resources:
           limits:
@@ -189,7 +189,7 @@ spec:
           iptables -A INPUT -i tun0 -j DROP
         command:
         - /bin/bash
-        image: quay.io/kubermatic/openvpn:2.4.8
+        image: quay.io/kubermatic/openvpn:v2.4.8-r1
         name: iptables-init
         resources:
           limits:

--- a/api/pkg/resources/test/fixtures/deployment-digitalocean-1.10.0-openvpn-server.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-digitalocean-1.10.0-openvpn-server.yaml
@@ -86,7 +86,7 @@ spec:
         - 255.255.255.0
         command:
         - /usr/sbin/openvpn
-        image: quay.io/kubermatic/openvpn:v0.5
+        image: quay.io/kubermatic/openvpn:v0.6-dev
         name: openvpn-server
         ports:
         - containerPort: 1194
@@ -135,7 +135,7 @@ spec:
           done
         command:
         - /bin/bash
-        image: quay.io/kubermatic/openvpn:v0.5
+        image: quay.io/kubermatic/openvpn:v0.6-dev
         name: ip-fixup
         resources:
           limits:
@@ -189,7 +189,7 @@ spec:
           iptables -A INPUT -i tun0 -j DROP
         command:
         - /bin/bash
-        image: quay.io/kubermatic/openvpn:v0.5
+        image: quay.io/kubermatic/openvpn:v0.6-dev
         name: iptables-init
         resources:
           limits:

--- a/api/pkg/resources/test/fixtures/deployment-digitalocean-1.10.0-scheduler.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-digitalocean-1.10.0-scheduler.yaml
@@ -79,7 +79,7 @@ spec:
         - /dev/stdout
         command:
         - /usr/sbin/openvpn
-        image: quay.io/kubermatic/openvpn:2.4.8
+        image: quay.io/kubermatic/openvpn:v2.4.8-r1
         name: openvpn-client
         resources:
           limits:

--- a/api/pkg/resources/test/fixtures/deployment-digitalocean-1.10.0-scheduler.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-digitalocean-1.10.0-scheduler.yaml
@@ -79,7 +79,7 @@ spec:
         - /dev/stdout
         command:
         - /usr/sbin/openvpn
-        image: quay.io/kubermatic/openvpn:v0.5
+        image: quay.io/kubermatic/openvpn:v0.6-dev
         name: openvpn-client
         resources:
           limits:

--- a/api/pkg/resources/test/fixtures/deployment-digitalocean-1.10.0-scheduler.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-digitalocean-1.10.0-scheduler.yaml
@@ -79,7 +79,7 @@ spec:
         - /dev/stdout
         command:
         - /usr/sbin/openvpn
-        image: quay.io/kubermatic/openvpn:v0.6-dev
+        image: quay.io/kubermatic/openvpn:2.4.8
         name: openvpn-client
         resources:
           limits:

--- a/api/pkg/resources/test/fixtures/deployment-digitalocean-1.10.6-apiserver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-digitalocean-1.10.6-apiserver.yaml
@@ -89,7 +89,7 @@ spec:
         - /dev/stdout
         command:
         - /usr/sbin/openvpn
-        image: quay.io/kubermatic/openvpn:v0.6-dev
+        image: quay.io/kubermatic/openvpn:2.4.8
         name: openvpn-client
         resources:
           limits:

--- a/api/pkg/resources/test/fixtures/deployment-digitalocean-1.10.6-apiserver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-digitalocean-1.10.6-apiserver.yaml
@@ -89,7 +89,7 @@ spec:
         - /dev/stdout
         command:
         - /usr/sbin/openvpn
-        image: quay.io/kubermatic/openvpn:2.4.8
+        image: quay.io/kubermatic/openvpn:v2.4.8-r1
         name: openvpn-client
         resources:
           limits:

--- a/api/pkg/resources/test/fixtures/deployment-digitalocean-1.10.6-apiserver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-digitalocean-1.10.6-apiserver.yaml
@@ -89,7 +89,7 @@ spec:
         - /dev/stdout
         command:
         - /usr/sbin/openvpn
-        image: quay.io/kubermatic/openvpn:v0.5
+        image: quay.io/kubermatic/openvpn:v0.6-dev
         name: openvpn-client
         resources:
           limits:

--- a/api/pkg/resources/test/fixtures/deployment-digitalocean-1.10.6-controller-manager.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-digitalocean-1.10.6-controller-manager.yaml
@@ -81,7 +81,7 @@ spec:
         - /dev/stdout
         command:
         - /usr/sbin/openvpn
-        image: quay.io/kubermatic/openvpn:v0.6-dev
+        image: quay.io/kubermatic/openvpn:2.4.8
         name: openvpn-client
         resources:
           limits:

--- a/api/pkg/resources/test/fixtures/deployment-digitalocean-1.10.6-controller-manager.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-digitalocean-1.10.6-controller-manager.yaml
@@ -81,7 +81,7 @@ spec:
         - /dev/stdout
         command:
         - /usr/sbin/openvpn
-        image: quay.io/kubermatic/openvpn:v0.5
+        image: quay.io/kubermatic/openvpn:v0.6-dev
         name: openvpn-client
         resources:
           limits:

--- a/api/pkg/resources/test/fixtures/deployment-digitalocean-1.10.6-controller-manager.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-digitalocean-1.10.6-controller-manager.yaml
@@ -81,7 +81,7 @@ spec:
         - /dev/stdout
         command:
         - /usr/sbin/openvpn
-        image: quay.io/kubermatic/openvpn:2.4.8
+        image: quay.io/kubermatic/openvpn:v2.4.8-r1
         name: openvpn-client
         resources:
           limits:

--- a/api/pkg/resources/test/fixtures/deployment-digitalocean-1.10.6-dns-resolver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-digitalocean-1.10.6-dns-resolver.yaml
@@ -79,7 +79,7 @@ spec:
         - /dev/stdout
         command:
         - /usr/sbin/openvpn
-        image: quay.io/kubermatic/openvpn:2.4.8
+        image: quay.io/kubermatic/openvpn:v2.4.8-r1
         name: openvpn-client
         resources:
           limits:

--- a/api/pkg/resources/test/fixtures/deployment-digitalocean-1.10.6-dns-resolver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-digitalocean-1.10.6-dns-resolver.yaml
@@ -79,7 +79,7 @@ spec:
         - /dev/stdout
         command:
         - /usr/sbin/openvpn
-        image: quay.io/kubermatic/openvpn:v0.5
+        image: quay.io/kubermatic/openvpn:v0.6-dev
         name: openvpn-client
         resources:
           limits:

--- a/api/pkg/resources/test/fixtures/deployment-digitalocean-1.10.6-dns-resolver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-digitalocean-1.10.6-dns-resolver.yaml
@@ -79,7 +79,7 @@ spec:
         - /dev/stdout
         command:
         - /usr/sbin/openvpn
-        image: quay.io/kubermatic/openvpn:v0.6-dev
+        image: quay.io/kubermatic/openvpn:2.4.8
         name: openvpn-client
         resources:
           limits:

--- a/api/pkg/resources/test/fixtures/deployment-digitalocean-1.10.6-metrics-server.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-digitalocean-1.10.6-metrics-server.yaml
@@ -108,7 +108,7 @@ spec:
         - /dev/stdout
         command:
         - /usr/sbin/openvpn
-        image: quay.io/kubermatic/openvpn:2.4.8
+        image: quay.io/kubermatic/openvpn:v2.4.8-r1
         name: openvpn-client
         resources:
           limits:

--- a/api/pkg/resources/test/fixtures/deployment-digitalocean-1.10.6-metrics-server.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-digitalocean-1.10.6-metrics-server.yaml
@@ -108,7 +108,7 @@ spec:
         - /dev/stdout
         command:
         - /usr/sbin/openvpn
-        image: quay.io/kubermatic/openvpn:v0.5
+        image: quay.io/kubermatic/openvpn:v0.6-dev
         name: openvpn-client
         resources:
           limits:

--- a/api/pkg/resources/test/fixtures/deployment-digitalocean-1.10.6-metrics-server.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-digitalocean-1.10.6-metrics-server.yaml
@@ -108,7 +108,7 @@ spec:
         - /dev/stdout
         command:
         - /usr/sbin/openvpn
-        image: quay.io/kubermatic/openvpn:v0.6-dev
+        image: quay.io/kubermatic/openvpn:2.4.8
         name: openvpn-client
         resources:
           limits:

--- a/api/pkg/resources/test/fixtures/deployment-digitalocean-1.10.6-openvpn-server.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-digitalocean-1.10.6-openvpn-server.yaml
@@ -86,7 +86,7 @@ spec:
         - 255.255.255.0
         command:
         - /usr/sbin/openvpn
-        image: quay.io/kubermatic/openvpn:v0.6-dev
+        image: quay.io/kubermatic/openvpn:2.4.8
         name: openvpn-server
         ports:
         - containerPort: 1194
@@ -135,7 +135,7 @@ spec:
           done
         command:
         - /bin/bash
-        image: quay.io/kubermatic/openvpn:v0.6-dev
+        image: quay.io/kubermatic/openvpn:2.4.8
         name: ip-fixup
         resources:
           limits:
@@ -189,7 +189,7 @@ spec:
           iptables -A INPUT -i tun0 -j DROP
         command:
         - /bin/bash
-        image: quay.io/kubermatic/openvpn:v0.6-dev
+        image: quay.io/kubermatic/openvpn:2.4.8
         name: iptables-init
         resources:
           limits:

--- a/api/pkg/resources/test/fixtures/deployment-digitalocean-1.10.6-openvpn-server.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-digitalocean-1.10.6-openvpn-server.yaml
@@ -86,7 +86,7 @@ spec:
         - 255.255.255.0
         command:
         - /usr/sbin/openvpn
-        image: quay.io/kubermatic/openvpn:2.4.8
+        image: quay.io/kubermatic/openvpn:v2.4.8-r1
         name: openvpn-server
         ports:
         - containerPort: 1194
@@ -135,7 +135,7 @@ spec:
           done
         command:
         - /bin/bash
-        image: quay.io/kubermatic/openvpn:2.4.8
+        image: quay.io/kubermatic/openvpn:v2.4.8-r1
         name: ip-fixup
         resources:
           limits:
@@ -189,7 +189,7 @@ spec:
           iptables -A INPUT -i tun0 -j DROP
         command:
         - /bin/bash
-        image: quay.io/kubermatic/openvpn:2.4.8
+        image: quay.io/kubermatic/openvpn:v2.4.8-r1
         name: iptables-init
         resources:
           limits:

--- a/api/pkg/resources/test/fixtures/deployment-digitalocean-1.10.6-openvpn-server.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-digitalocean-1.10.6-openvpn-server.yaml
@@ -86,7 +86,7 @@ spec:
         - 255.255.255.0
         command:
         - /usr/sbin/openvpn
-        image: quay.io/kubermatic/openvpn:v0.5
+        image: quay.io/kubermatic/openvpn:v0.6-dev
         name: openvpn-server
         ports:
         - containerPort: 1194
@@ -135,7 +135,7 @@ spec:
           done
         command:
         - /bin/bash
-        image: quay.io/kubermatic/openvpn:v0.5
+        image: quay.io/kubermatic/openvpn:v0.6-dev
         name: ip-fixup
         resources:
           limits:
@@ -189,7 +189,7 @@ spec:
           iptables -A INPUT -i tun0 -j DROP
         command:
         - /bin/bash
-        image: quay.io/kubermatic/openvpn:v0.5
+        image: quay.io/kubermatic/openvpn:v0.6-dev
         name: iptables-init
         resources:
           limits:

--- a/api/pkg/resources/test/fixtures/deployment-digitalocean-1.10.6-scheduler.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-digitalocean-1.10.6-scheduler.yaml
@@ -79,7 +79,7 @@ spec:
         - /dev/stdout
         command:
         - /usr/sbin/openvpn
-        image: quay.io/kubermatic/openvpn:2.4.8
+        image: quay.io/kubermatic/openvpn:v2.4.8-r1
         name: openvpn-client
         resources:
           limits:

--- a/api/pkg/resources/test/fixtures/deployment-digitalocean-1.10.6-scheduler.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-digitalocean-1.10.6-scheduler.yaml
@@ -79,7 +79,7 @@ spec:
         - /dev/stdout
         command:
         - /usr/sbin/openvpn
-        image: quay.io/kubermatic/openvpn:v0.5
+        image: quay.io/kubermatic/openvpn:v0.6-dev
         name: openvpn-client
         resources:
           limits:

--- a/api/pkg/resources/test/fixtures/deployment-digitalocean-1.10.6-scheduler.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-digitalocean-1.10.6-scheduler.yaml
@@ -79,7 +79,7 @@ spec:
         - /dev/stdout
         command:
         - /usr/sbin/openvpn
-        image: quay.io/kubermatic/openvpn:v0.6-dev
+        image: quay.io/kubermatic/openvpn:2.4.8
         name: openvpn-client
         resources:
           limits:

--- a/api/pkg/resources/test/fixtures/deployment-digitalocean-1.11.0-apiserver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-digitalocean-1.11.0-apiserver.yaml
@@ -89,7 +89,7 @@ spec:
         - /dev/stdout
         command:
         - /usr/sbin/openvpn
-        image: quay.io/kubermatic/openvpn:v0.6-dev
+        image: quay.io/kubermatic/openvpn:2.4.8
         name: openvpn-client
         resources:
           limits:

--- a/api/pkg/resources/test/fixtures/deployment-digitalocean-1.11.0-apiserver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-digitalocean-1.11.0-apiserver.yaml
@@ -89,7 +89,7 @@ spec:
         - /dev/stdout
         command:
         - /usr/sbin/openvpn
-        image: quay.io/kubermatic/openvpn:2.4.8
+        image: quay.io/kubermatic/openvpn:v2.4.8-r1
         name: openvpn-client
         resources:
           limits:

--- a/api/pkg/resources/test/fixtures/deployment-digitalocean-1.11.0-apiserver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-digitalocean-1.11.0-apiserver.yaml
@@ -89,7 +89,7 @@ spec:
         - /dev/stdout
         command:
         - /usr/sbin/openvpn
-        image: quay.io/kubermatic/openvpn:v0.5
+        image: quay.io/kubermatic/openvpn:v0.6-dev
         name: openvpn-client
         resources:
           limits:

--- a/api/pkg/resources/test/fixtures/deployment-digitalocean-1.11.0-controller-manager.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-digitalocean-1.11.0-controller-manager.yaml
@@ -81,7 +81,7 @@ spec:
         - /dev/stdout
         command:
         - /usr/sbin/openvpn
-        image: quay.io/kubermatic/openvpn:v0.6-dev
+        image: quay.io/kubermatic/openvpn:2.4.8
         name: openvpn-client
         resources:
           limits:

--- a/api/pkg/resources/test/fixtures/deployment-digitalocean-1.11.0-controller-manager.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-digitalocean-1.11.0-controller-manager.yaml
@@ -81,7 +81,7 @@ spec:
         - /dev/stdout
         command:
         - /usr/sbin/openvpn
-        image: quay.io/kubermatic/openvpn:v0.5
+        image: quay.io/kubermatic/openvpn:v0.6-dev
         name: openvpn-client
         resources:
           limits:

--- a/api/pkg/resources/test/fixtures/deployment-digitalocean-1.11.0-controller-manager.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-digitalocean-1.11.0-controller-manager.yaml
@@ -81,7 +81,7 @@ spec:
         - /dev/stdout
         command:
         - /usr/sbin/openvpn
-        image: quay.io/kubermatic/openvpn:2.4.8
+        image: quay.io/kubermatic/openvpn:v2.4.8-r1
         name: openvpn-client
         resources:
           limits:

--- a/api/pkg/resources/test/fixtures/deployment-digitalocean-1.11.0-dns-resolver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-digitalocean-1.11.0-dns-resolver.yaml
@@ -79,7 +79,7 @@ spec:
         - /dev/stdout
         command:
         - /usr/sbin/openvpn
-        image: quay.io/kubermatic/openvpn:2.4.8
+        image: quay.io/kubermatic/openvpn:v2.4.8-r1
         name: openvpn-client
         resources:
           limits:

--- a/api/pkg/resources/test/fixtures/deployment-digitalocean-1.11.0-dns-resolver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-digitalocean-1.11.0-dns-resolver.yaml
@@ -79,7 +79,7 @@ spec:
         - /dev/stdout
         command:
         - /usr/sbin/openvpn
-        image: quay.io/kubermatic/openvpn:v0.5
+        image: quay.io/kubermatic/openvpn:v0.6-dev
         name: openvpn-client
         resources:
           limits:

--- a/api/pkg/resources/test/fixtures/deployment-digitalocean-1.11.0-dns-resolver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-digitalocean-1.11.0-dns-resolver.yaml
@@ -79,7 +79,7 @@ spec:
         - /dev/stdout
         command:
         - /usr/sbin/openvpn
-        image: quay.io/kubermatic/openvpn:v0.6-dev
+        image: quay.io/kubermatic/openvpn:2.4.8
         name: openvpn-client
         resources:
           limits:

--- a/api/pkg/resources/test/fixtures/deployment-digitalocean-1.11.0-metrics-server.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-digitalocean-1.11.0-metrics-server.yaml
@@ -108,7 +108,7 @@ spec:
         - /dev/stdout
         command:
         - /usr/sbin/openvpn
-        image: quay.io/kubermatic/openvpn:2.4.8
+        image: quay.io/kubermatic/openvpn:v2.4.8-r1
         name: openvpn-client
         resources:
           limits:

--- a/api/pkg/resources/test/fixtures/deployment-digitalocean-1.11.0-metrics-server.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-digitalocean-1.11.0-metrics-server.yaml
@@ -108,7 +108,7 @@ spec:
         - /dev/stdout
         command:
         - /usr/sbin/openvpn
-        image: quay.io/kubermatic/openvpn:v0.5
+        image: quay.io/kubermatic/openvpn:v0.6-dev
         name: openvpn-client
         resources:
           limits:

--- a/api/pkg/resources/test/fixtures/deployment-digitalocean-1.11.0-metrics-server.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-digitalocean-1.11.0-metrics-server.yaml
@@ -108,7 +108,7 @@ spec:
         - /dev/stdout
         command:
         - /usr/sbin/openvpn
-        image: quay.io/kubermatic/openvpn:v0.6-dev
+        image: quay.io/kubermatic/openvpn:2.4.8
         name: openvpn-client
         resources:
           limits:

--- a/api/pkg/resources/test/fixtures/deployment-digitalocean-1.11.0-openvpn-server.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-digitalocean-1.11.0-openvpn-server.yaml
@@ -86,7 +86,7 @@ spec:
         - 255.255.255.0
         command:
         - /usr/sbin/openvpn
-        image: quay.io/kubermatic/openvpn:v0.6-dev
+        image: quay.io/kubermatic/openvpn:2.4.8
         name: openvpn-server
         ports:
         - containerPort: 1194
@@ -135,7 +135,7 @@ spec:
           done
         command:
         - /bin/bash
-        image: quay.io/kubermatic/openvpn:v0.6-dev
+        image: quay.io/kubermatic/openvpn:2.4.8
         name: ip-fixup
         resources:
           limits:
@@ -189,7 +189,7 @@ spec:
           iptables -A INPUT -i tun0 -j DROP
         command:
         - /bin/bash
-        image: quay.io/kubermatic/openvpn:v0.6-dev
+        image: quay.io/kubermatic/openvpn:2.4.8
         name: iptables-init
         resources:
           limits:

--- a/api/pkg/resources/test/fixtures/deployment-digitalocean-1.11.0-openvpn-server.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-digitalocean-1.11.0-openvpn-server.yaml
@@ -86,7 +86,7 @@ spec:
         - 255.255.255.0
         command:
         - /usr/sbin/openvpn
-        image: quay.io/kubermatic/openvpn:2.4.8
+        image: quay.io/kubermatic/openvpn:v2.4.8-r1
         name: openvpn-server
         ports:
         - containerPort: 1194
@@ -135,7 +135,7 @@ spec:
           done
         command:
         - /bin/bash
-        image: quay.io/kubermatic/openvpn:2.4.8
+        image: quay.io/kubermatic/openvpn:v2.4.8-r1
         name: ip-fixup
         resources:
           limits:
@@ -189,7 +189,7 @@ spec:
           iptables -A INPUT -i tun0 -j DROP
         command:
         - /bin/bash
-        image: quay.io/kubermatic/openvpn:2.4.8
+        image: quay.io/kubermatic/openvpn:v2.4.8-r1
         name: iptables-init
         resources:
           limits:

--- a/api/pkg/resources/test/fixtures/deployment-digitalocean-1.11.0-openvpn-server.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-digitalocean-1.11.0-openvpn-server.yaml
@@ -86,7 +86,7 @@ spec:
         - 255.255.255.0
         command:
         - /usr/sbin/openvpn
-        image: quay.io/kubermatic/openvpn:v0.5
+        image: quay.io/kubermatic/openvpn:v0.6-dev
         name: openvpn-server
         ports:
         - containerPort: 1194
@@ -135,7 +135,7 @@ spec:
           done
         command:
         - /bin/bash
-        image: quay.io/kubermatic/openvpn:v0.5
+        image: quay.io/kubermatic/openvpn:v0.6-dev
         name: ip-fixup
         resources:
           limits:
@@ -189,7 +189,7 @@ spec:
           iptables -A INPUT -i tun0 -j DROP
         command:
         - /bin/bash
-        image: quay.io/kubermatic/openvpn:v0.5
+        image: quay.io/kubermatic/openvpn:v0.6-dev
         name: iptables-init
         resources:
           limits:

--- a/api/pkg/resources/test/fixtures/deployment-digitalocean-1.11.0-scheduler.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-digitalocean-1.11.0-scheduler.yaml
@@ -79,7 +79,7 @@ spec:
         - /dev/stdout
         command:
         - /usr/sbin/openvpn
-        image: quay.io/kubermatic/openvpn:2.4.8
+        image: quay.io/kubermatic/openvpn:v2.4.8-r1
         name: openvpn-client
         resources:
           limits:

--- a/api/pkg/resources/test/fixtures/deployment-digitalocean-1.11.0-scheduler.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-digitalocean-1.11.0-scheduler.yaml
@@ -79,7 +79,7 @@ spec:
         - /dev/stdout
         command:
         - /usr/sbin/openvpn
-        image: quay.io/kubermatic/openvpn:v0.5
+        image: quay.io/kubermatic/openvpn:v0.6-dev
         name: openvpn-client
         resources:
           limits:

--- a/api/pkg/resources/test/fixtures/deployment-digitalocean-1.11.0-scheduler.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-digitalocean-1.11.0-scheduler.yaml
@@ -79,7 +79,7 @@ spec:
         - /dev/stdout
         command:
         - /usr/sbin/openvpn
-        image: quay.io/kubermatic/openvpn:v0.6-dev
+        image: quay.io/kubermatic/openvpn:2.4.8
         name: openvpn-client
         resources:
           limits:

--- a/api/pkg/resources/test/fixtures/deployment-digitalocean-1.11.1-apiserver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-digitalocean-1.11.1-apiserver.yaml
@@ -89,7 +89,7 @@ spec:
         - /dev/stdout
         command:
         - /usr/sbin/openvpn
-        image: quay.io/kubermatic/openvpn:v0.6-dev
+        image: quay.io/kubermatic/openvpn:2.4.8
         name: openvpn-client
         resources:
           limits:

--- a/api/pkg/resources/test/fixtures/deployment-digitalocean-1.11.1-apiserver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-digitalocean-1.11.1-apiserver.yaml
@@ -89,7 +89,7 @@ spec:
         - /dev/stdout
         command:
         - /usr/sbin/openvpn
-        image: quay.io/kubermatic/openvpn:2.4.8
+        image: quay.io/kubermatic/openvpn:v2.4.8-r1
         name: openvpn-client
         resources:
           limits:

--- a/api/pkg/resources/test/fixtures/deployment-digitalocean-1.11.1-apiserver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-digitalocean-1.11.1-apiserver.yaml
@@ -89,7 +89,7 @@ spec:
         - /dev/stdout
         command:
         - /usr/sbin/openvpn
-        image: quay.io/kubermatic/openvpn:v0.5
+        image: quay.io/kubermatic/openvpn:v0.6-dev
         name: openvpn-client
         resources:
           limits:

--- a/api/pkg/resources/test/fixtures/deployment-digitalocean-1.11.1-controller-manager.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-digitalocean-1.11.1-controller-manager.yaml
@@ -81,7 +81,7 @@ spec:
         - /dev/stdout
         command:
         - /usr/sbin/openvpn
-        image: quay.io/kubermatic/openvpn:v0.6-dev
+        image: quay.io/kubermatic/openvpn:2.4.8
         name: openvpn-client
         resources:
           limits:

--- a/api/pkg/resources/test/fixtures/deployment-digitalocean-1.11.1-controller-manager.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-digitalocean-1.11.1-controller-manager.yaml
@@ -81,7 +81,7 @@ spec:
         - /dev/stdout
         command:
         - /usr/sbin/openvpn
-        image: quay.io/kubermatic/openvpn:v0.5
+        image: quay.io/kubermatic/openvpn:v0.6-dev
         name: openvpn-client
         resources:
           limits:

--- a/api/pkg/resources/test/fixtures/deployment-digitalocean-1.11.1-controller-manager.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-digitalocean-1.11.1-controller-manager.yaml
@@ -81,7 +81,7 @@ spec:
         - /dev/stdout
         command:
         - /usr/sbin/openvpn
-        image: quay.io/kubermatic/openvpn:2.4.8
+        image: quay.io/kubermatic/openvpn:v2.4.8-r1
         name: openvpn-client
         resources:
           limits:

--- a/api/pkg/resources/test/fixtures/deployment-digitalocean-1.11.1-dns-resolver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-digitalocean-1.11.1-dns-resolver.yaml
@@ -79,7 +79,7 @@ spec:
         - /dev/stdout
         command:
         - /usr/sbin/openvpn
-        image: quay.io/kubermatic/openvpn:2.4.8
+        image: quay.io/kubermatic/openvpn:v2.4.8-r1
         name: openvpn-client
         resources:
           limits:

--- a/api/pkg/resources/test/fixtures/deployment-digitalocean-1.11.1-dns-resolver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-digitalocean-1.11.1-dns-resolver.yaml
@@ -79,7 +79,7 @@ spec:
         - /dev/stdout
         command:
         - /usr/sbin/openvpn
-        image: quay.io/kubermatic/openvpn:v0.5
+        image: quay.io/kubermatic/openvpn:v0.6-dev
         name: openvpn-client
         resources:
           limits:

--- a/api/pkg/resources/test/fixtures/deployment-digitalocean-1.11.1-dns-resolver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-digitalocean-1.11.1-dns-resolver.yaml
@@ -79,7 +79,7 @@ spec:
         - /dev/stdout
         command:
         - /usr/sbin/openvpn
-        image: quay.io/kubermatic/openvpn:v0.6-dev
+        image: quay.io/kubermatic/openvpn:2.4.8
         name: openvpn-client
         resources:
           limits:

--- a/api/pkg/resources/test/fixtures/deployment-digitalocean-1.11.1-metrics-server.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-digitalocean-1.11.1-metrics-server.yaml
@@ -108,7 +108,7 @@ spec:
         - /dev/stdout
         command:
         - /usr/sbin/openvpn
-        image: quay.io/kubermatic/openvpn:2.4.8
+        image: quay.io/kubermatic/openvpn:v2.4.8-r1
         name: openvpn-client
         resources:
           limits:

--- a/api/pkg/resources/test/fixtures/deployment-digitalocean-1.11.1-metrics-server.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-digitalocean-1.11.1-metrics-server.yaml
@@ -108,7 +108,7 @@ spec:
         - /dev/stdout
         command:
         - /usr/sbin/openvpn
-        image: quay.io/kubermatic/openvpn:v0.5
+        image: quay.io/kubermatic/openvpn:v0.6-dev
         name: openvpn-client
         resources:
           limits:

--- a/api/pkg/resources/test/fixtures/deployment-digitalocean-1.11.1-metrics-server.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-digitalocean-1.11.1-metrics-server.yaml
@@ -108,7 +108,7 @@ spec:
         - /dev/stdout
         command:
         - /usr/sbin/openvpn
-        image: quay.io/kubermatic/openvpn:v0.6-dev
+        image: quay.io/kubermatic/openvpn:2.4.8
         name: openvpn-client
         resources:
           limits:

--- a/api/pkg/resources/test/fixtures/deployment-digitalocean-1.11.1-openvpn-server.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-digitalocean-1.11.1-openvpn-server.yaml
@@ -86,7 +86,7 @@ spec:
         - 255.255.255.0
         command:
         - /usr/sbin/openvpn
-        image: quay.io/kubermatic/openvpn:v0.6-dev
+        image: quay.io/kubermatic/openvpn:2.4.8
         name: openvpn-server
         ports:
         - containerPort: 1194
@@ -135,7 +135,7 @@ spec:
           done
         command:
         - /bin/bash
-        image: quay.io/kubermatic/openvpn:v0.6-dev
+        image: quay.io/kubermatic/openvpn:2.4.8
         name: ip-fixup
         resources:
           limits:
@@ -189,7 +189,7 @@ spec:
           iptables -A INPUT -i tun0 -j DROP
         command:
         - /bin/bash
-        image: quay.io/kubermatic/openvpn:v0.6-dev
+        image: quay.io/kubermatic/openvpn:2.4.8
         name: iptables-init
         resources:
           limits:

--- a/api/pkg/resources/test/fixtures/deployment-digitalocean-1.11.1-openvpn-server.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-digitalocean-1.11.1-openvpn-server.yaml
@@ -86,7 +86,7 @@ spec:
         - 255.255.255.0
         command:
         - /usr/sbin/openvpn
-        image: quay.io/kubermatic/openvpn:2.4.8
+        image: quay.io/kubermatic/openvpn:v2.4.8-r1
         name: openvpn-server
         ports:
         - containerPort: 1194
@@ -135,7 +135,7 @@ spec:
           done
         command:
         - /bin/bash
-        image: quay.io/kubermatic/openvpn:2.4.8
+        image: quay.io/kubermatic/openvpn:v2.4.8-r1
         name: ip-fixup
         resources:
           limits:
@@ -189,7 +189,7 @@ spec:
           iptables -A INPUT -i tun0 -j DROP
         command:
         - /bin/bash
-        image: quay.io/kubermatic/openvpn:2.4.8
+        image: quay.io/kubermatic/openvpn:v2.4.8-r1
         name: iptables-init
         resources:
           limits:

--- a/api/pkg/resources/test/fixtures/deployment-digitalocean-1.11.1-openvpn-server.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-digitalocean-1.11.1-openvpn-server.yaml
@@ -86,7 +86,7 @@ spec:
         - 255.255.255.0
         command:
         - /usr/sbin/openvpn
-        image: quay.io/kubermatic/openvpn:v0.5
+        image: quay.io/kubermatic/openvpn:v0.6-dev
         name: openvpn-server
         ports:
         - containerPort: 1194
@@ -135,7 +135,7 @@ spec:
           done
         command:
         - /bin/bash
-        image: quay.io/kubermatic/openvpn:v0.5
+        image: quay.io/kubermatic/openvpn:v0.6-dev
         name: ip-fixup
         resources:
           limits:
@@ -189,7 +189,7 @@ spec:
           iptables -A INPUT -i tun0 -j DROP
         command:
         - /bin/bash
-        image: quay.io/kubermatic/openvpn:v0.5
+        image: quay.io/kubermatic/openvpn:v0.6-dev
         name: iptables-init
         resources:
           limits:

--- a/api/pkg/resources/test/fixtures/deployment-digitalocean-1.11.1-scheduler.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-digitalocean-1.11.1-scheduler.yaml
@@ -79,7 +79,7 @@ spec:
         - /dev/stdout
         command:
         - /usr/sbin/openvpn
-        image: quay.io/kubermatic/openvpn:2.4.8
+        image: quay.io/kubermatic/openvpn:v2.4.8-r1
         name: openvpn-client
         resources:
           limits:

--- a/api/pkg/resources/test/fixtures/deployment-digitalocean-1.11.1-scheduler.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-digitalocean-1.11.1-scheduler.yaml
@@ -79,7 +79,7 @@ spec:
         - /dev/stdout
         command:
         - /usr/sbin/openvpn
-        image: quay.io/kubermatic/openvpn:v0.5
+        image: quay.io/kubermatic/openvpn:v0.6-dev
         name: openvpn-client
         resources:
           limits:

--- a/api/pkg/resources/test/fixtures/deployment-digitalocean-1.11.1-scheduler.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-digitalocean-1.11.1-scheduler.yaml
@@ -79,7 +79,7 @@ spec:
         - /dev/stdout
         command:
         - /usr/sbin/openvpn
-        image: quay.io/kubermatic/openvpn:v0.6-dev
+        image: quay.io/kubermatic/openvpn:2.4.8
         name: openvpn-client
         resources:
           limits:

--- a/api/pkg/resources/test/fixtures/deployment-digitalocean-1.12.0-apiserver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-digitalocean-1.12.0-apiserver.yaml
@@ -89,7 +89,7 @@ spec:
         - /dev/stdout
         command:
         - /usr/sbin/openvpn
-        image: quay.io/kubermatic/openvpn:v0.6-dev
+        image: quay.io/kubermatic/openvpn:2.4.8
         name: openvpn-client
         resources:
           limits:

--- a/api/pkg/resources/test/fixtures/deployment-digitalocean-1.12.0-apiserver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-digitalocean-1.12.0-apiserver.yaml
@@ -89,7 +89,7 @@ spec:
         - /dev/stdout
         command:
         - /usr/sbin/openvpn
-        image: quay.io/kubermatic/openvpn:2.4.8
+        image: quay.io/kubermatic/openvpn:v2.4.8-r1
         name: openvpn-client
         resources:
           limits:

--- a/api/pkg/resources/test/fixtures/deployment-digitalocean-1.12.0-apiserver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-digitalocean-1.12.0-apiserver.yaml
@@ -89,7 +89,7 @@ spec:
         - /dev/stdout
         command:
         - /usr/sbin/openvpn
-        image: quay.io/kubermatic/openvpn:v0.5
+        image: quay.io/kubermatic/openvpn:v0.6-dev
         name: openvpn-client
         resources:
           limits:

--- a/api/pkg/resources/test/fixtures/deployment-digitalocean-1.12.0-controller-manager.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-digitalocean-1.12.0-controller-manager.yaml
@@ -81,7 +81,7 @@ spec:
         - /dev/stdout
         command:
         - /usr/sbin/openvpn
-        image: quay.io/kubermatic/openvpn:v0.6-dev
+        image: quay.io/kubermatic/openvpn:2.4.8
         name: openvpn-client
         resources:
           limits:

--- a/api/pkg/resources/test/fixtures/deployment-digitalocean-1.12.0-controller-manager.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-digitalocean-1.12.0-controller-manager.yaml
@@ -81,7 +81,7 @@ spec:
         - /dev/stdout
         command:
         - /usr/sbin/openvpn
-        image: quay.io/kubermatic/openvpn:v0.5
+        image: quay.io/kubermatic/openvpn:v0.6-dev
         name: openvpn-client
         resources:
           limits:

--- a/api/pkg/resources/test/fixtures/deployment-digitalocean-1.12.0-controller-manager.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-digitalocean-1.12.0-controller-manager.yaml
@@ -81,7 +81,7 @@ spec:
         - /dev/stdout
         command:
         - /usr/sbin/openvpn
-        image: quay.io/kubermatic/openvpn:2.4.8
+        image: quay.io/kubermatic/openvpn:v2.4.8-r1
         name: openvpn-client
         resources:
           limits:

--- a/api/pkg/resources/test/fixtures/deployment-digitalocean-1.12.0-dns-resolver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-digitalocean-1.12.0-dns-resolver.yaml
@@ -79,7 +79,7 @@ spec:
         - /dev/stdout
         command:
         - /usr/sbin/openvpn
-        image: quay.io/kubermatic/openvpn:2.4.8
+        image: quay.io/kubermatic/openvpn:v2.4.8-r1
         name: openvpn-client
         resources:
           limits:

--- a/api/pkg/resources/test/fixtures/deployment-digitalocean-1.12.0-dns-resolver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-digitalocean-1.12.0-dns-resolver.yaml
@@ -79,7 +79,7 @@ spec:
         - /dev/stdout
         command:
         - /usr/sbin/openvpn
-        image: quay.io/kubermatic/openvpn:v0.5
+        image: quay.io/kubermatic/openvpn:v0.6-dev
         name: openvpn-client
         resources:
           limits:

--- a/api/pkg/resources/test/fixtures/deployment-digitalocean-1.12.0-dns-resolver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-digitalocean-1.12.0-dns-resolver.yaml
@@ -79,7 +79,7 @@ spec:
         - /dev/stdout
         command:
         - /usr/sbin/openvpn
-        image: quay.io/kubermatic/openvpn:v0.6-dev
+        image: quay.io/kubermatic/openvpn:2.4.8
         name: openvpn-client
         resources:
           limits:

--- a/api/pkg/resources/test/fixtures/deployment-digitalocean-1.12.0-metrics-server.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-digitalocean-1.12.0-metrics-server.yaml
@@ -108,7 +108,7 @@ spec:
         - /dev/stdout
         command:
         - /usr/sbin/openvpn
-        image: quay.io/kubermatic/openvpn:2.4.8
+        image: quay.io/kubermatic/openvpn:v2.4.8-r1
         name: openvpn-client
         resources:
           limits:

--- a/api/pkg/resources/test/fixtures/deployment-digitalocean-1.12.0-metrics-server.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-digitalocean-1.12.0-metrics-server.yaml
@@ -108,7 +108,7 @@ spec:
         - /dev/stdout
         command:
         - /usr/sbin/openvpn
-        image: quay.io/kubermatic/openvpn:v0.5
+        image: quay.io/kubermatic/openvpn:v0.6-dev
         name: openvpn-client
         resources:
           limits:

--- a/api/pkg/resources/test/fixtures/deployment-digitalocean-1.12.0-metrics-server.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-digitalocean-1.12.0-metrics-server.yaml
@@ -108,7 +108,7 @@ spec:
         - /dev/stdout
         command:
         - /usr/sbin/openvpn
-        image: quay.io/kubermatic/openvpn:v0.6-dev
+        image: quay.io/kubermatic/openvpn:2.4.8
         name: openvpn-client
         resources:
           limits:

--- a/api/pkg/resources/test/fixtures/deployment-digitalocean-1.12.0-openvpn-server.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-digitalocean-1.12.0-openvpn-server.yaml
@@ -86,7 +86,7 @@ spec:
         - 255.255.255.0
         command:
         - /usr/sbin/openvpn
-        image: quay.io/kubermatic/openvpn:v0.6-dev
+        image: quay.io/kubermatic/openvpn:2.4.8
         name: openvpn-server
         ports:
         - containerPort: 1194
@@ -135,7 +135,7 @@ spec:
           done
         command:
         - /bin/bash
-        image: quay.io/kubermatic/openvpn:v0.6-dev
+        image: quay.io/kubermatic/openvpn:2.4.8
         name: ip-fixup
         resources:
           limits:
@@ -189,7 +189,7 @@ spec:
           iptables -A INPUT -i tun0 -j DROP
         command:
         - /bin/bash
-        image: quay.io/kubermatic/openvpn:v0.6-dev
+        image: quay.io/kubermatic/openvpn:2.4.8
         name: iptables-init
         resources:
           limits:

--- a/api/pkg/resources/test/fixtures/deployment-digitalocean-1.12.0-openvpn-server.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-digitalocean-1.12.0-openvpn-server.yaml
@@ -86,7 +86,7 @@ spec:
         - 255.255.255.0
         command:
         - /usr/sbin/openvpn
-        image: quay.io/kubermatic/openvpn:2.4.8
+        image: quay.io/kubermatic/openvpn:v2.4.8-r1
         name: openvpn-server
         ports:
         - containerPort: 1194
@@ -135,7 +135,7 @@ spec:
           done
         command:
         - /bin/bash
-        image: quay.io/kubermatic/openvpn:2.4.8
+        image: quay.io/kubermatic/openvpn:v2.4.8-r1
         name: ip-fixup
         resources:
           limits:
@@ -189,7 +189,7 @@ spec:
           iptables -A INPUT -i tun0 -j DROP
         command:
         - /bin/bash
-        image: quay.io/kubermatic/openvpn:2.4.8
+        image: quay.io/kubermatic/openvpn:v2.4.8-r1
         name: iptables-init
         resources:
           limits:

--- a/api/pkg/resources/test/fixtures/deployment-digitalocean-1.12.0-openvpn-server.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-digitalocean-1.12.0-openvpn-server.yaml
@@ -86,7 +86,7 @@ spec:
         - 255.255.255.0
         command:
         - /usr/sbin/openvpn
-        image: quay.io/kubermatic/openvpn:v0.5
+        image: quay.io/kubermatic/openvpn:v0.6-dev
         name: openvpn-server
         ports:
         - containerPort: 1194
@@ -135,7 +135,7 @@ spec:
           done
         command:
         - /bin/bash
-        image: quay.io/kubermatic/openvpn:v0.5
+        image: quay.io/kubermatic/openvpn:v0.6-dev
         name: ip-fixup
         resources:
           limits:
@@ -189,7 +189,7 @@ spec:
           iptables -A INPUT -i tun0 -j DROP
         command:
         - /bin/bash
-        image: quay.io/kubermatic/openvpn:v0.5
+        image: quay.io/kubermatic/openvpn:v0.6-dev
         name: iptables-init
         resources:
           limits:

--- a/api/pkg/resources/test/fixtures/deployment-digitalocean-1.12.0-scheduler.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-digitalocean-1.12.0-scheduler.yaml
@@ -79,7 +79,7 @@ spec:
         - /dev/stdout
         command:
         - /usr/sbin/openvpn
-        image: quay.io/kubermatic/openvpn:2.4.8
+        image: quay.io/kubermatic/openvpn:v2.4.8-r1
         name: openvpn-client
         resources:
           limits:

--- a/api/pkg/resources/test/fixtures/deployment-digitalocean-1.12.0-scheduler.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-digitalocean-1.12.0-scheduler.yaml
@@ -79,7 +79,7 @@ spec:
         - /dev/stdout
         command:
         - /usr/sbin/openvpn
-        image: quay.io/kubermatic/openvpn:v0.5
+        image: quay.io/kubermatic/openvpn:v0.6-dev
         name: openvpn-client
         resources:
           limits:

--- a/api/pkg/resources/test/fixtures/deployment-digitalocean-1.12.0-scheduler.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-digitalocean-1.12.0-scheduler.yaml
@@ -79,7 +79,7 @@ spec:
         - /dev/stdout
         command:
         - /usr/sbin/openvpn
-        image: quay.io/kubermatic/openvpn:v0.6-dev
+        image: quay.io/kubermatic/openvpn:2.4.8
         name: openvpn-client
         resources:
           limits:

--- a/api/pkg/resources/test/fixtures/deployment-digitalocean-1.13.0-apiserver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-digitalocean-1.13.0-apiserver.yaml
@@ -89,7 +89,7 @@ spec:
         - /dev/stdout
         command:
         - /usr/sbin/openvpn
-        image: quay.io/kubermatic/openvpn:v0.6-dev
+        image: quay.io/kubermatic/openvpn:2.4.8
         name: openvpn-client
         resources:
           limits:

--- a/api/pkg/resources/test/fixtures/deployment-digitalocean-1.13.0-apiserver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-digitalocean-1.13.0-apiserver.yaml
@@ -89,7 +89,7 @@ spec:
         - /dev/stdout
         command:
         - /usr/sbin/openvpn
-        image: quay.io/kubermatic/openvpn:2.4.8
+        image: quay.io/kubermatic/openvpn:v2.4.8-r1
         name: openvpn-client
         resources:
           limits:

--- a/api/pkg/resources/test/fixtures/deployment-digitalocean-1.13.0-apiserver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-digitalocean-1.13.0-apiserver.yaml
@@ -89,7 +89,7 @@ spec:
         - /dev/stdout
         command:
         - /usr/sbin/openvpn
-        image: quay.io/kubermatic/openvpn:v0.5
+        image: quay.io/kubermatic/openvpn:v0.6-dev
         name: openvpn-client
         resources:
           limits:

--- a/api/pkg/resources/test/fixtures/deployment-digitalocean-1.13.0-controller-manager.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-digitalocean-1.13.0-controller-manager.yaml
@@ -81,7 +81,7 @@ spec:
         - /dev/stdout
         command:
         - /usr/sbin/openvpn
-        image: quay.io/kubermatic/openvpn:v0.6-dev
+        image: quay.io/kubermatic/openvpn:2.4.8
         name: openvpn-client
         resources:
           limits:

--- a/api/pkg/resources/test/fixtures/deployment-digitalocean-1.13.0-controller-manager.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-digitalocean-1.13.0-controller-manager.yaml
@@ -81,7 +81,7 @@ spec:
         - /dev/stdout
         command:
         - /usr/sbin/openvpn
-        image: quay.io/kubermatic/openvpn:v0.5
+        image: quay.io/kubermatic/openvpn:v0.6-dev
         name: openvpn-client
         resources:
           limits:

--- a/api/pkg/resources/test/fixtures/deployment-digitalocean-1.13.0-controller-manager.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-digitalocean-1.13.0-controller-manager.yaml
@@ -81,7 +81,7 @@ spec:
         - /dev/stdout
         command:
         - /usr/sbin/openvpn
-        image: quay.io/kubermatic/openvpn:2.4.8
+        image: quay.io/kubermatic/openvpn:v2.4.8-r1
         name: openvpn-client
         resources:
           limits:

--- a/api/pkg/resources/test/fixtures/deployment-digitalocean-1.13.0-dns-resolver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-digitalocean-1.13.0-dns-resolver.yaml
@@ -79,7 +79,7 @@ spec:
         - /dev/stdout
         command:
         - /usr/sbin/openvpn
-        image: quay.io/kubermatic/openvpn:2.4.8
+        image: quay.io/kubermatic/openvpn:v2.4.8-r1
         name: openvpn-client
         resources:
           limits:

--- a/api/pkg/resources/test/fixtures/deployment-digitalocean-1.13.0-dns-resolver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-digitalocean-1.13.0-dns-resolver.yaml
@@ -79,7 +79,7 @@ spec:
         - /dev/stdout
         command:
         - /usr/sbin/openvpn
-        image: quay.io/kubermatic/openvpn:v0.5
+        image: quay.io/kubermatic/openvpn:v0.6-dev
         name: openvpn-client
         resources:
           limits:

--- a/api/pkg/resources/test/fixtures/deployment-digitalocean-1.13.0-dns-resolver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-digitalocean-1.13.0-dns-resolver.yaml
@@ -79,7 +79,7 @@ spec:
         - /dev/stdout
         command:
         - /usr/sbin/openvpn
-        image: quay.io/kubermatic/openvpn:v0.6-dev
+        image: quay.io/kubermatic/openvpn:2.4.8
         name: openvpn-client
         resources:
           limits:

--- a/api/pkg/resources/test/fixtures/deployment-digitalocean-1.13.0-metrics-server.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-digitalocean-1.13.0-metrics-server.yaml
@@ -108,7 +108,7 @@ spec:
         - /dev/stdout
         command:
         - /usr/sbin/openvpn
-        image: quay.io/kubermatic/openvpn:2.4.8
+        image: quay.io/kubermatic/openvpn:v2.4.8-r1
         name: openvpn-client
         resources:
           limits:

--- a/api/pkg/resources/test/fixtures/deployment-digitalocean-1.13.0-metrics-server.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-digitalocean-1.13.0-metrics-server.yaml
@@ -108,7 +108,7 @@ spec:
         - /dev/stdout
         command:
         - /usr/sbin/openvpn
-        image: quay.io/kubermatic/openvpn:v0.5
+        image: quay.io/kubermatic/openvpn:v0.6-dev
         name: openvpn-client
         resources:
           limits:

--- a/api/pkg/resources/test/fixtures/deployment-digitalocean-1.13.0-metrics-server.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-digitalocean-1.13.0-metrics-server.yaml
@@ -108,7 +108,7 @@ spec:
         - /dev/stdout
         command:
         - /usr/sbin/openvpn
-        image: quay.io/kubermatic/openvpn:v0.6-dev
+        image: quay.io/kubermatic/openvpn:2.4.8
         name: openvpn-client
         resources:
           limits:

--- a/api/pkg/resources/test/fixtures/deployment-digitalocean-1.13.0-openvpn-server.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-digitalocean-1.13.0-openvpn-server.yaml
@@ -86,7 +86,7 @@ spec:
         - 255.255.255.0
         command:
         - /usr/sbin/openvpn
-        image: quay.io/kubermatic/openvpn:v0.6-dev
+        image: quay.io/kubermatic/openvpn:2.4.8
         name: openvpn-server
         ports:
         - containerPort: 1194
@@ -135,7 +135,7 @@ spec:
           done
         command:
         - /bin/bash
-        image: quay.io/kubermatic/openvpn:v0.6-dev
+        image: quay.io/kubermatic/openvpn:2.4.8
         name: ip-fixup
         resources:
           limits:
@@ -189,7 +189,7 @@ spec:
           iptables -A INPUT -i tun0 -j DROP
         command:
         - /bin/bash
-        image: quay.io/kubermatic/openvpn:v0.6-dev
+        image: quay.io/kubermatic/openvpn:2.4.8
         name: iptables-init
         resources:
           limits:

--- a/api/pkg/resources/test/fixtures/deployment-digitalocean-1.13.0-openvpn-server.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-digitalocean-1.13.0-openvpn-server.yaml
@@ -86,7 +86,7 @@ spec:
         - 255.255.255.0
         command:
         - /usr/sbin/openvpn
-        image: quay.io/kubermatic/openvpn:2.4.8
+        image: quay.io/kubermatic/openvpn:v2.4.8-r1
         name: openvpn-server
         ports:
         - containerPort: 1194
@@ -135,7 +135,7 @@ spec:
           done
         command:
         - /bin/bash
-        image: quay.io/kubermatic/openvpn:2.4.8
+        image: quay.io/kubermatic/openvpn:v2.4.8-r1
         name: ip-fixup
         resources:
           limits:
@@ -189,7 +189,7 @@ spec:
           iptables -A INPUT -i tun0 -j DROP
         command:
         - /bin/bash
-        image: quay.io/kubermatic/openvpn:2.4.8
+        image: quay.io/kubermatic/openvpn:v2.4.8-r1
         name: iptables-init
         resources:
           limits:

--- a/api/pkg/resources/test/fixtures/deployment-digitalocean-1.13.0-openvpn-server.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-digitalocean-1.13.0-openvpn-server.yaml
@@ -86,7 +86,7 @@ spec:
         - 255.255.255.0
         command:
         - /usr/sbin/openvpn
-        image: quay.io/kubermatic/openvpn:v0.5
+        image: quay.io/kubermatic/openvpn:v0.6-dev
         name: openvpn-server
         ports:
         - containerPort: 1194
@@ -135,7 +135,7 @@ spec:
           done
         command:
         - /bin/bash
-        image: quay.io/kubermatic/openvpn:v0.5
+        image: quay.io/kubermatic/openvpn:v0.6-dev
         name: ip-fixup
         resources:
           limits:
@@ -189,7 +189,7 @@ spec:
           iptables -A INPUT -i tun0 -j DROP
         command:
         - /bin/bash
-        image: quay.io/kubermatic/openvpn:v0.5
+        image: quay.io/kubermatic/openvpn:v0.6-dev
         name: iptables-init
         resources:
           limits:

--- a/api/pkg/resources/test/fixtures/deployment-digitalocean-1.13.0-scheduler.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-digitalocean-1.13.0-scheduler.yaml
@@ -79,7 +79,7 @@ spec:
         - /dev/stdout
         command:
         - /usr/sbin/openvpn
-        image: quay.io/kubermatic/openvpn:2.4.8
+        image: quay.io/kubermatic/openvpn:v2.4.8-r1
         name: openvpn-client
         resources:
           limits:

--- a/api/pkg/resources/test/fixtures/deployment-digitalocean-1.13.0-scheduler.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-digitalocean-1.13.0-scheduler.yaml
@@ -79,7 +79,7 @@ spec:
         - /dev/stdout
         command:
         - /usr/sbin/openvpn
-        image: quay.io/kubermatic/openvpn:v0.5
+        image: quay.io/kubermatic/openvpn:v0.6-dev
         name: openvpn-client
         resources:
           limits:

--- a/api/pkg/resources/test/fixtures/deployment-digitalocean-1.13.0-scheduler.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-digitalocean-1.13.0-scheduler.yaml
@@ -79,7 +79,7 @@ spec:
         - /dev/stdout
         command:
         - /usr/sbin/openvpn
-        image: quay.io/kubermatic/openvpn:v0.6-dev
+        image: quay.io/kubermatic/openvpn:2.4.8
         name: openvpn-client
         resources:
           limits:

--- a/api/pkg/resources/test/fixtures/deployment-openstack-1.10.0-apiserver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-openstack-1.10.0-apiserver.yaml
@@ -89,7 +89,7 @@ spec:
         - /dev/stdout
         command:
         - /usr/sbin/openvpn
-        image: quay.io/kubermatic/openvpn:v0.6-dev
+        image: quay.io/kubermatic/openvpn:2.4.8
         name: openvpn-client
         resources:
           limits:

--- a/api/pkg/resources/test/fixtures/deployment-openstack-1.10.0-apiserver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-openstack-1.10.0-apiserver.yaml
@@ -89,7 +89,7 @@ spec:
         - /dev/stdout
         command:
         - /usr/sbin/openvpn
-        image: quay.io/kubermatic/openvpn:2.4.8
+        image: quay.io/kubermatic/openvpn:v2.4.8-r1
         name: openvpn-client
         resources:
           limits:

--- a/api/pkg/resources/test/fixtures/deployment-openstack-1.10.0-apiserver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-openstack-1.10.0-apiserver.yaml
@@ -89,7 +89,7 @@ spec:
         - /dev/stdout
         command:
         - /usr/sbin/openvpn
-        image: quay.io/kubermatic/openvpn:v0.5
+        image: quay.io/kubermatic/openvpn:v0.6-dev
         name: openvpn-client
         resources:
           limits:

--- a/api/pkg/resources/test/fixtures/deployment-openstack-1.10.0-controller-manager.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-openstack-1.10.0-controller-manager.yaml
@@ -81,7 +81,7 @@ spec:
         - /dev/stdout
         command:
         - /usr/sbin/openvpn
-        image: quay.io/kubermatic/openvpn:v0.6-dev
+        image: quay.io/kubermatic/openvpn:2.4.8
         name: openvpn-client
         resources:
           limits:

--- a/api/pkg/resources/test/fixtures/deployment-openstack-1.10.0-controller-manager.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-openstack-1.10.0-controller-manager.yaml
@@ -81,7 +81,7 @@ spec:
         - /dev/stdout
         command:
         - /usr/sbin/openvpn
-        image: quay.io/kubermatic/openvpn:v0.5
+        image: quay.io/kubermatic/openvpn:v0.6-dev
         name: openvpn-client
         resources:
           limits:

--- a/api/pkg/resources/test/fixtures/deployment-openstack-1.10.0-controller-manager.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-openstack-1.10.0-controller-manager.yaml
@@ -81,7 +81,7 @@ spec:
         - /dev/stdout
         command:
         - /usr/sbin/openvpn
-        image: quay.io/kubermatic/openvpn:2.4.8
+        image: quay.io/kubermatic/openvpn:v2.4.8-r1
         name: openvpn-client
         resources:
           limits:

--- a/api/pkg/resources/test/fixtures/deployment-openstack-1.10.0-dns-resolver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-openstack-1.10.0-dns-resolver.yaml
@@ -79,7 +79,7 @@ spec:
         - /dev/stdout
         command:
         - /usr/sbin/openvpn
-        image: quay.io/kubermatic/openvpn:2.4.8
+        image: quay.io/kubermatic/openvpn:v2.4.8-r1
         name: openvpn-client
         resources:
           limits:

--- a/api/pkg/resources/test/fixtures/deployment-openstack-1.10.0-dns-resolver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-openstack-1.10.0-dns-resolver.yaml
@@ -79,7 +79,7 @@ spec:
         - /dev/stdout
         command:
         - /usr/sbin/openvpn
-        image: quay.io/kubermatic/openvpn:v0.5
+        image: quay.io/kubermatic/openvpn:v0.6-dev
         name: openvpn-client
         resources:
           limits:

--- a/api/pkg/resources/test/fixtures/deployment-openstack-1.10.0-dns-resolver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-openstack-1.10.0-dns-resolver.yaml
@@ -79,7 +79,7 @@ spec:
         - /dev/stdout
         command:
         - /usr/sbin/openvpn
-        image: quay.io/kubermatic/openvpn:v0.6-dev
+        image: quay.io/kubermatic/openvpn:2.4.8
         name: openvpn-client
         resources:
           limits:

--- a/api/pkg/resources/test/fixtures/deployment-openstack-1.10.0-metrics-server.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-openstack-1.10.0-metrics-server.yaml
@@ -108,7 +108,7 @@ spec:
         - /dev/stdout
         command:
         - /usr/sbin/openvpn
-        image: quay.io/kubermatic/openvpn:2.4.8
+        image: quay.io/kubermatic/openvpn:v2.4.8-r1
         name: openvpn-client
         resources:
           limits:

--- a/api/pkg/resources/test/fixtures/deployment-openstack-1.10.0-metrics-server.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-openstack-1.10.0-metrics-server.yaml
@@ -108,7 +108,7 @@ spec:
         - /dev/stdout
         command:
         - /usr/sbin/openvpn
-        image: quay.io/kubermatic/openvpn:v0.5
+        image: quay.io/kubermatic/openvpn:v0.6-dev
         name: openvpn-client
         resources:
           limits:

--- a/api/pkg/resources/test/fixtures/deployment-openstack-1.10.0-metrics-server.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-openstack-1.10.0-metrics-server.yaml
@@ -108,7 +108,7 @@ spec:
         - /dev/stdout
         command:
         - /usr/sbin/openvpn
-        image: quay.io/kubermatic/openvpn:v0.6-dev
+        image: quay.io/kubermatic/openvpn:2.4.8
         name: openvpn-client
         resources:
           limits:

--- a/api/pkg/resources/test/fixtures/deployment-openstack-1.10.0-openvpn-server.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-openstack-1.10.0-openvpn-server.yaml
@@ -86,7 +86,7 @@ spec:
         - 255.255.255.0
         command:
         - /usr/sbin/openvpn
-        image: quay.io/kubermatic/openvpn:v0.6-dev
+        image: quay.io/kubermatic/openvpn:2.4.8
         name: openvpn-server
         ports:
         - containerPort: 1194
@@ -135,7 +135,7 @@ spec:
           done
         command:
         - /bin/bash
-        image: quay.io/kubermatic/openvpn:v0.6-dev
+        image: quay.io/kubermatic/openvpn:2.4.8
         name: ip-fixup
         resources:
           limits:
@@ -189,7 +189,7 @@ spec:
           iptables -A INPUT -i tun0 -j DROP
         command:
         - /bin/bash
-        image: quay.io/kubermatic/openvpn:v0.6-dev
+        image: quay.io/kubermatic/openvpn:2.4.8
         name: iptables-init
         resources:
           limits:

--- a/api/pkg/resources/test/fixtures/deployment-openstack-1.10.0-openvpn-server.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-openstack-1.10.0-openvpn-server.yaml
@@ -86,7 +86,7 @@ spec:
         - 255.255.255.0
         command:
         - /usr/sbin/openvpn
-        image: quay.io/kubermatic/openvpn:2.4.8
+        image: quay.io/kubermatic/openvpn:v2.4.8-r1
         name: openvpn-server
         ports:
         - containerPort: 1194
@@ -135,7 +135,7 @@ spec:
           done
         command:
         - /bin/bash
-        image: quay.io/kubermatic/openvpn:2.4.8
+        image: quay.io/kubermatic/openvpn:v2.4.8-r1
         name: ip-fixup
         resources:
           limits:
@@ -189,7 +189,7 @@ spec:
           iptables -A INPUT -i tun0 -j DROP
         command:
         - /bin/bash
-        image: quay.io/kubermatic/openvpn:2.4.8
+        image: quay.io/kubermatic/openvpn:v2.4.8-r1
         name: iptables-init
         resources:
           limits:

--- a/api/pkg/resources/test/fixtures/deployment-openstack-1.10.0-openvpn-server.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-openstack-1.10.0-openvpn-server.yaml
@@ -86,7 +86,7 @@ spec:
         - 255.255.255.0
         command:
         - /usr/sbin/openvpn
-        image: quay.io/kubermatic/openvpn:v0.5
+        image: quay.io/kubermatic/openvpn:v0.6-dev
         name: openvpn-server
         ports:
         - containerPort: 1194
@@ -135,7 +135,7 @@ spec:
           done
         command:
         - /bin/bash
-        image: quay.io/kubermatic/openvpn:v0.5
+        image: quay.io/kubermatic/openvpn:v0.6-dev
         name: ip-fixup
         resources:
           limits:
@@ -189,7 +189,7 @@ spec:
           iptables -A INPUT -i tun0 -j DROP
         command:
         - /bin/bash
-        image: quay.io/kubermatic/openvpn:v0.5
+        image: quay.io/kubermatic/openvpn:v0.6-dev
         name: iptables-init
         resources:
           limits:

--- a/api/pkg/resources/test/fixtures/deployment-openstack-1.10.0-scheduler.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-openstack-1.10.0-scheduler.yaml
@@ -79,7 +79,7 @@ spec:
         - /dev/stdout
         command:
         - /usr/sbin/openvpn
-        image: quay.io/kubermatic/openvpn:2.4.8
+        image: quay.io/kubermatic/openvpn:v2.4.8-r1
         name: openvpn-client
         resources:
           limits:

--- a/api/pkg/resources/test/fixtures/deployment-openstack-1.10.0-scheduler.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-openstack-1.10.0-scheduler.yaml
@@ -79,7 +79,7 @@ spec:
         - /dev/stdout
         command:
         - /usr/sbin/openvpn
-        image: quay.io/kubermatic/openvpn:v0.5
+        image: quay.io/kubermatic/openvpn:v0.6-dev
         name: openvpn-client
         resources:
           limits:

--- a/api/pkg/resources/test/fixtures/deployment-openstack-1.10.0-scheduler.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-openstack-1.10.0-scheduler.yaml
@@ -79,7 +79,7 @@ spec:
         - /dev/stdout
         command:
         - /usr/sbin/openvpn
-        image: quay.io/kubermatic/openvpn:v0.6-dev
+        image: quay.io/kubermatic/openvpn:2.4.8
         name: openvpn-client
         resources:
           limits:

--- a/api/pkg/resources/test/fixtures/deployment-openstack-1.10.6-apiserver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-openstack-1.10.6-apiserver.yaml
@@ -89,7 +89,7 @@ spec:
         - /dev/stdout
         command:
         - /usr/sbin/openvpn
-        image: quay.io/kubermatic/openvpn:v0.6-dev
+        image: quay.io/kubermatic/openvpn:2.4.8
         name: openvpn-client
         resources:
           limits:

--- a/api/pkg/resources/test/fixtures/deployment-openstack-1.10.6-apiserver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-openstack-1.10.6-apiserver.yaml
@@ -89,7 +89,7 @@ spec:
         - /dev/stdout
         command:
         - /usr/sbin/openvpn
-        image: quay.io/kubermatic/openvpn:2.4.8
+        image: quay.io/kubermatic/openvpn:v2.4.8-r1
         name: openvpn-client
         resources:
           limits:

--- a/api/pkg/resources/test/fixtures/deployment-openstack-1.10.6-apiserver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-openstack-1.10.6-apiserver.yaml
@@ -89,7 +89,7 @@ spec:
         - /dev/stdout
         command:
         - /usr/sbin/openvpn
-        image: quay.io/kubermatic/openvpn:v0.5
+        image: quay.io/kubermatic/openvpn:v0.6-dev
         name: openvpn-client
         resources:
           limits:

--- a/api/pkg/resources/test/fixtures/deployment-openstack-1.10.6-controller-manager.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-openstack-1.10.6-controller-manager.yaml
@@ -81,7 +81,7 @@ spec:
         - /dev/stdout
         command:
         - /usr/sbin/openvpn
-        image: quay.io/kubermatic/openvpn:v0.6-dev
+        image: quay.io/kubermatic/openvpn:2.4.8
         name: openvpn-client
         resources:
           limits:

--- a/api/pkg/resources/test/fixtures/deployment-openstack-1.10.6-controller-manager.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-openstack-1.10.6-controller-manager.yaml
@@ -81,7 +81,7 @@ spec:
         - /dev/stdout
         command:
         - /usr/sbin/openvpn
-        image: quay.io/kubermatic/openvpn:v0.5
+        image: quay.io/kubermatic/openvpn:v0.6-dev
         name: openvpn-client
         resources:
           limits:

--- a/api/pkg/resources/test/fixtures/deployment-openstack-1.10.6-controller-manager.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-openstack-1.10.6-controller-manager.yaml
@@ -81,7 +81,7 @@ spec:
         - /dev/stdout
         command:
         - /usr/sbin/openvpn
-        image: quay.io/kubermatic/openvpn:2.4.8
+        image: quay.io/kubermatic/openvpn:v2.4.8-r1
         name: openvpn-client
         resources:
           limits:

--- a/api/pkg/resources/test/fixtures/deployment-openstack-1.10.6-dns-resolver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-openstack-1.10.6-dns-resolver.yaml
@@ -79,7 +79,7 @@ spec:
         - /dev/stdout
         command:
         - /usr/sbin/openvpn
-        image: quay.io/kubermatic/openvpn:2.4.8
+        image: quay.io/kubermatic/openvpn:v2.4.8-r1
         name: openvpn-client
         resources:
           limits:

--- a/api/pkg/resources/test/fixtures/deployment-openstack-1.10.6-dns-resolver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-openstack-1.10.6-dns-resolver.yaml
@@ -79,7 +79,7 @@ spec:
         - /dev/stdout
         command:
         - /usr/sbin/openvpn
-        image: quay.io/kubermatic/openvpn:v0.5
+        image: quay.io/kubermatic/openvpn:v0.6-dev
         name: openvpn-client
         resources:
           limits:

--- a/api/pkg/resources/test/fixtures/deployment-openstack-1.10.6-dns-resolver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-openstack-1.10.6-dns-resolver.yaml
@@ -79,7 +79,7 @@ spec:
         - /dev/stdout
         command:
         - /usr/sbin/openvpn
-        image: quay.io/kubermatic/openvpn:v0.6-dev
+        image: quay.io/kubermatic/openvpn:2.4.8
         name: openvpn-client
         resources:
           limits:

--- a/api/pkg/resources/test/fixtures/deployment-openstack-1.10.6-metrics-server.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-openstack-1.10.6-metrics-server.yaml
@@ -108,7 +108,7 @@ spec:
         - /dev/stdout
         command:
         - /usr/sbin/openvpn
-        image: quay.io/kubermatic/openvpn:2.4.8
+        image: quay.io/kubermatic/openvpn:v2.4.8-r1
         name: openvpn-client
         resources:
           limits:

--- a/api/pkg/resources/test/fixtures/deployment-openstack-1.10.6-metrics-server.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-openstack-1.10.6-metrics-server.yaml
@@ -108,7 +108,7 @@ spec:
         - /dev/stdout
         command:
         - /usr/sbin/openvpn
-        image: quay.io/kubermatic/openvpn:v0.5
+        image: quay.io/kubermatic/openvpn:v0.6-dev
         name: openvpn-client
         resources:
           limits:

--- a/api/pkg/resources/test/fixtures/deployment-openstack-1.10.6-metrics-server.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-openstack-1.10.6-metrics-server.yaml
@@ -108,7 +108,7 @@ spec:
         - /dev/stdout
         command:
         - /usr/sbin/openvpn
-        image: quay.io/kubermatic/openvpn:v0.6-dev
+        image: quay.io/kubermatic/openvpn:2.4.8
         name: openvpn-client
         resources:
           limits:

--- a/api/pkg/resources/test/fixtures/deployment-openstack-1.10.6-openvpn-server.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-openstack-1.10.6-openvpn-server.yaml
@@ -86,7 +86,7 @@ spec:
         - 255.255.255.0
         command:
         - /usr/sbin/openvpn
-        image: quay.io/kubermatic/openvpn:v0.6-dev
+        image: quay.io/kubermatic/openvpn:2.4.8
         name: openvpn-server
         ports:
         - containerPort: 1194
@@ -135,7 +135,7 @@ spec:
           done
         command:
         - /bin/bash
-        image: quay.io/kubermatic/openvpn:v0.6-dev
+        image: quay.io/kubermatic/openvpn:2.4.8
         name: ip-fixup
         resources:
           limits:
@@ -189,7 +189,7 @@ spec:
           iptables -A INPUT -i tun0 -j DROP
         command:
         - /bin/bash
-        image: quay.io/kubermatic/openvpn:v0.6-dev
+        image: quay.io/kubermatic/openvpn:2.4.8
         name: iptables-init
         resources:
           limits:

--- a/api/pkg/resources/test/fixtures/deployment-openstack-1.10.6-openvpn-server.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-openstack-1.10.6-openvpn-server.yaml
@@ -86,7 +86,7 @@ spec:
         - 255.255.255.0
         command:
         - /usr/sbin/openvpn
-        image: quay.io/kubermatic/openvpn:2.4.8
+        image: quay.io/kubermatic/openvpn:v2.4.8-r1
         name: openvpn-server
         ports:
         - containerPort: 1194
@@ -135,7 +135,7 @@ spec:
           done
         command:
         - /bin/bash
-        image: quay.io/kubermatic/openvpn:2.4.8
+        image: quay.io/kubermatic/openvpn:v2.4.8-r1
         name: ip-fixup
         resources:
           limits:
@@ -189,7 +189,7 @@ spec:
           iptables -A INPUT -i tun0 -j DROP
         command:
         - /bin/bash
-        image: quay.io/kubermatic/openvpn:2.4.8
+        image: quay.io/kubermatic/openvpn:v2.4.8-r1
         name: iptables-init
         resources:
           limits:

--- a/api/pkg/resources/test/fixtures/deployment-openstack-1.10.6-openvpn-server.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-openstack-1.10.6-openvpn-server.yaml
@@ -86,7 +86,7 @@ spec:
         - 255.255.255.0
         command:
         - /usr/sbin/openvpn
-        image: quay.io/kubermatic/openvpn:v0.5
+        image: quay.io/kubermatic/openvpn:v0.6-dev
         name: openvpn-server
         ports:
         - containerPort: 1194
@@ -135,7 +135,7 @@ spec:
           done
         command:
         - /bin/bash
-        image: quay.io/kubermatic/openvpn:v0.5
+        image: quay.io/kubermatic/openvpn:v0.6-dev
         name: ip-fixup
         resources:
           limits:
@@ -189,7 +189,7 @@ spec:
           iptables -A INPUT -i tun0 -j DROP
         command:
         - /bin/bash
-        image: quay.io/kubermatic/openvpn:v0.5
+        image: quay.io/kubermatic/openvpn:v0.6-dev
         name: iptables-init
         resources:
           limits:

--- a/api/pkg/resources/test/fixtures/deployment-openstack-1.10.6-scheduler.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-openstack-1.10.6-scheduler.yaml
@@ -79,7 +79,7 @@ spec:
         - /dev/stdout
         command:
         - /usr/sbin/openvpn
-        image: quay.io/kubermatic/openvpn:2.4.8
+        image: quay.io/kubermatic/openvpn:v2.4.8-r1
         name: openvpn-client
         resources:
           limits:

--- a/api/pkg/resources/test/fixtures/deployment-openstack-1.10.6-scheduler.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-openstack-1.10.6-scheduler.yaml
@@ -79,7 +79,7 @@ spec:
         - /dev/stdout
         command:
         - /usr/sbin/openvpn
-        image: quay.io/kubermatic/openvpn:v0.5
+        image: quay.io/kubermatic/openvpn:v0.6-dev
         name: openvpn-client
         resources:
           limits:

--- a/api/pkg/resources/test/fixtures/deployment-openstack-1.10.6-scheduler.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-openstack-1.10.6-scheduler.yaml
@@ -79,7 +79,7 @@ spec:
         - /dev/stdout
         command:
         - /usr/sbin/openvpn
-        image: quay.io/kubermatic/openvpn:v0.6-dev
+        image: quay.io/kubermatic/openvpn:2.4.8
         name: openvpn-client
         resources:
           limits:

--- a/api/pkg/resources/test/fixtures/deployment-openstack-1.11.0-apiserver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-openstack-1.11.0-apiserver.yaml
@@ -89,7 +89,7 @@ spec:
         - /dev/stdout
         command:
         - /usr/sbin/openvpn
-        image: quay.io/kubermatic/openvpn:v0.6-dev
+        image: quay.io/kubermatic/openvpn:2.4.8
         name: openvpn-client
         resources:
           limits:

--- a/api/pkg/resources/test/fixtures/deployment-openstack-1.11.0-apiserver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-openstack-1.11.0-apiserver.yaml
@@ -89,7 +89,7 @@ spec:
         - /dev/stdout
         command:
         - /usr/sbin/openvpn
-        image: quay.io/kubermatic/openvpn:2.4.8
+        image: quay.io/kubermatic/openvpn:v2.4.8-r1
         name: openvpn-client
         resources:
           limits:

--- a/api/pkg/resources/test/fixtures/deployment-openstack-1.11.0-apiserver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-openstack-1.11.0-apiserver.yaml
@@ -89,7 +89,7 @@ spec:
         - /dev/stdout
         command:
         - /usr/sbin/openvpn
-        image: quay.io/kubermatic/openvpn:v0.5
+        image: quay.io/kubermatic/openvpn:v0.6-dev
         name: openvpn-client
         resources:
           limits:

--- a/api/pkg/resources/test/fixtures/deployment-openstack-1.11.0-controller-manager.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-openstack-1.11.0-controller-manager.yaml
@@ -81,7 +81,7 @@ spec:
         - /dev/stdout
         command:
         - /usr/sbin/openvpn
-        image: quay.io/kubermatic/openvpn:v0.6-dev
+        image: quay.io/kubermatic/openvpn:2.4.8
         name: openvpn-client
         resources:
           limits:

--- a/api/pkg/resources/test/fixtures/deployment-openstack-1.11.0-controller-manager.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-openstack-1.11.0-controller-manager.yaml
@@ -81,7 +81,7 @@ spec:
         - /dev/stdout
         command:
         - /usr/sbin/openvpn
-        image: quay.io/kubermatic/openvpn:v0.5
+        image: quay.io/kubermatic/openvpn:v0.6-dev
         name: openvpn-client
         resources:
           limits:

--- a/api/pkg/resources/test/fixtures/deployment-openstack-1.11.0-controller-manager.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-openstack-1.11.0-controller-manager.yaml
@@ -81,7 +81,7 @@ spec:
         - /dev/stdout
         command:
         - /usr/sbin/openvpn
-        image: quay.io/kubermatic/openvpn:2.4.8
+        image: quay.io/kubermatic/openvpn:v2.4.8-r1
         name: openvpn-client
         resources:
           limits:

--- a/api/pkg/resources/test/fixtures/deployment-openstack-1.11.0-dns-resolver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-openstack-1.11.0-dns-resolver.yaml
@@ -79,7 +79,7 @@ spec:
         - /dev/stdout
         command:
         - /usr/sbin/openvpn
-        image: quay.io/kubermatic/openvpn:2.4.8
+        image: quay.io/kubermatic/openvpn:v2.4.8-r1
         name: openvpn-client
         resources:
           limits:

--- a/api/pkg/resources/test/fixtures/deployment-openstack-1.11.0-dns-resolver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-openstack-1.11.0-dns-resolver.yaml
@@ -79,7 +79,7 @@ spec:
         - /dev/stdout
         command:
         - /usr/sbin/openvpn
-        image: quay.io/kubermatic/openvpn:v0.5
+        image: quay.io/kubermatic/openvpn:v0.6-dev
         name: openvpn-client
         resources:
           limits:

--- a/api/pkg/resources/test/fixtures/deployment-openstack-1.11.0-dns-resolver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-openstack-1.11.0-dns-resolver.yaml
@@ -79,7 +79,7 @@ spec:
         - /dev/stdout
         command:
         - /usr/sbin/openvpn
-        image: quay.io/kubermatic/openvpn:v0.6-dev
+        image: quay.io/kubermatic/openvpn:2.4.8
         name: openvpn-client
         resources:
           limits:

--- a/api/pkg/resources/test/fixtures/deployment-openstack-1.11.0-metrics-server.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-openstack-1.11.0-metrics-server.yaml
@@ -108,7 +108,7 @@ spec:
         - /dev/stdout
         command:
         - /usr/sbin/openvpn
-        image: quay.io/kubermatic/openvpn:2.4.8
+        image: quay.io/kubermatic/openvpn:v2.4.8-r1
         name: openvpn-client
         resources:
           limits:

--- a/api/pkg/resources/test/fixtures/deployment-openstack-1.11.0-metrics-server.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-openstack-1.11.0-metrics-server.yaml
@@ -108,7 +108,7 @@ spec:
         - /dev/stdout
         command:
         - /usr/sbin/openvpn
-        image: quay.io/kubermatic/openvpn:v0.5
+        image: quay.io/kubermatic/openvpn:v0.6-dev
         name: openvpn-client
         resources:
           limits:

--- a/api/pkg/resources/test/fixtures/deployment-openstack-1.11.0-metrics-server.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-openstack-1.11.0-metrics-server.yaml
@@ -108,7 +108,7 @@ spec:
         - /dev/stdout
         command:
         - /usr/sbin/openvpn
-        image: quay.io/kubermatic/openvpn:v0.6-dev
+        image: quay.io/kubermatic/openvpn:2.4.8
         name: openvpn-client
         resources:
           limits:

--- a/api/pkg/resources/test/fixtures/deployment-openstack-1.11.0-openvpn-server.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-openstack-1.11.0-openvpn-server.yaml
@@ -86,7 +86,7 @@ spec:
         - 255.255.255.0
         command:
         - /usr/sbin/openvpn
-        image: quay.io/kubermatic/openvpn:v0.6-dev
+        image: quay.io/kubermatic/openvpn:2.4.8
         name: openvpn-server
         ports:
         - containerPort: 1194
@@ -135,7 +135,7 @@ spec:
           done
         command:
         - /bin/bash
-        image: quay.io/kubermatic/openvpn:v0.6-dev
+        image: quay.io/kubermatic/openvpn:2.4.8
         name: ip-fixup
         resources:
           limits:
@@ -189,7 +189,7 @@ spec:
           iptables -A INPUT -i tun0 -j DROP
         command:
         - /bin/bash
-        image: quay.io/kubermatic/openvpn:v0.6-dev
+        image: quay.io/kubermatic/openvpn:2.4.8
         name: iptables-init
         resources:
           limits:

--- a/api/pkg/resources/test/fixtures/deployment-openstack-1.11.0-openvpn-server.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-openstack-1.11.0-openvpn-server.yaml
@@ -86,7 +86,7 @@ spec:
         - 255.255.255.0
         command:
         - /usr/sbin/openvpn
-        image: quay.io/kubermatic/openvpn:2.4.8
+        image: quay.io/kubermatic/openvpn:v2.4.8-r1
         name: openvpn-server
         ports:
         - containerPort: 1194
@@ -135,7 +135,7 @@ spec:
           done
         command:
         - /bin/bash
-        image: quay.io/kubermatic/openvpn:2.4.8
+        image: quay.io/kubermatic/openvpn:v2.4.8-r1
         name: ip-fixup
         resources:
           limits:
@@ -189,7 +189,7 @@ spec:
           iptables -A INPUT -i tun0 -j DROP
         command:
         - /bin/bash
-        image: quay.io/kubermatic/openvpn:2.4.8
+        image: quay.io/kubermatic/openvpn:v2.4.8-r1
         name: iptables-init
         resources:
           limits:

--- a/api/pkg/resources/test/fixtures/deployment-openstack-1.11.0-openvpn-server.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-openstack-1.11.0-openvpn-server.yaml
@@ -86,7 +86,7 @@ spec:
         - 255.255.255.0
         command:
         - /usr/sbin/openvpn
-        image: quay.io/kubermatic/openvpn:v0.5
+        image: quay.io/kubermatic/openvpn:v0.6-dev
         name: openvpn-server
         ports:
         - containerPort: 1194
@@ -135,7 +135,7 @@ spec:
           done
         command:
         - /bin/bash
-        image: quay.io/kubermatic/openvpn:v0.5
+        image: quay.io/kubermatic/openvpn:v0.6-dev
         name: ip-fixup
         resources:
           limits:
@@ -189,7 +189,7 @@ spec:
           iptables -A INPUT -i tun0 -j DROP
         command:
         - /bin/bash
-        image: quay.io/kubermatic/openvpn:v0.5
+        image: quay.io/kubermatic/openvpn:v0.6-dev
         name: iptables-init
         resources:
           limits:

--- a/api/pkg/resources/test/fixtures/deployment-openstack-1.11.0-scheduler.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-openstack-1.11.0-scheduler.yaml
@@ -79,7 +79,7 @@ spec:
         - /dev/stdout
         command:
         - /usr/sbin/openvpn
-        image: quay.io/kubermatic/openvpn:2.4.8
+        image: quay.io/kubermatic/openvpn:v2.4.8-r1
         name: openvpn-client
         resources:
           limits:

--- a/api/pkg/resources/test/fixtures/deployment-openstack-1.11.0-scheduler.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-openstack-1.11.0-scheduler.yaml
@@ -79,7 +79,7 @@ spec:
         - /dev/stdout
         command:
         - /usr/sbin/openvpn
-        image: quay.io/kubermatic/openvpn:v0.5
+        image: quay.io/kubermatic/openvpn:v0.6-dev
         name: openvpn-client
         resources:
           limits:

--- a/api/pkg/resources/test/fixtures/deployment-openstack-1.11.0-scheduler.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-openstack-1.11.0-scheduler.yaml
@@ -79,7 +79,7 @@ spec:
         - /dev/stdout
         command:
         - /usr/sbin/openvpn
-        image: quay.io/kubermatic/openvpn:v0.6-dev
+        image: quay.io/kubermatic/openvpn:2.4.8
         name: openvpn-client
         resources:
           limits:

--- a/api/pkg/resources/test/fixtures/deployment-openstack-1.11.1-apiserver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-openstack-1.11.1-apiserver.yaml
@@ -89,7 +89,7 @@ spec:
         - /dev/stdout
         command:
         - /usr/sbin/openvpn
-        image: quay.io/kubermatic/openvpn:v0.6-dev
+        image: quay.io/kubermatic/openvpn:2.4.8
         name: openvpn-client
         resources:
           limits:

--- a/api/pkg/resources/test/fixtures/deployment-openstack-1.11.1-apiserver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-openstack-1.11.1-apiserver.yaml
@@ -89,7 +89,7 @@ spec:
         - /dev/stdout
         command:
         - /usr/sbin/openvpn
-        image: quay.io/kubermatic/openvpn:2.4.8
+        image: quay.io/kubermatic/openvpn:v2.4.8-r1
         name: openvpn-client
         resources:
           limits:

--- a/api/pkg/resources/test/fixtures/deployment-openstack-1.11.1-apiserver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-openstack-1.11.1-apiserver.yaml
@@ -89,7 +89,7 @@ spec:
         - /dev/stdout
         command:
         - /usr/sbin/openvpn
-        image: quay.io/kubermatic/openvpn:v0.5
+        image: quay.io/kubermatic/openvpn:v0.6-dev
         name: openvpn-client
         resources:
           limits:

--- a/api/pkg/resources/test/fixtures/deployment-openstack-1.11.1-controller-manager.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-openstack-1.11.1-controller-manager.yaml
@@ -81,7 +81,7 @@ spec:
         - /dev/stdout
         command:
         - /usr/sbin/openvpn
-        image: quay.io/kubermatic/openvpn:v0.6-dev
+        image: quay.io/kubermatic/openvpn:2.4.8
         name: openvpn-client
         resources:
           limits:

--- a/api/pkg/resources/test/fixtures/deployment-openstack-1.11.1-controller-manager.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-openstack-1.11.1-controller-manager.yaml
@@ -81,7 +81,7 @@ spec:
         - /dev/stdout
         command:
         - /usr/sbin/openvpn
-        image: quay.io/kubermatic/openvpn:v0.5
+        image: quay.io/kubermatic/openvpn:v0.6-dev
         name: openvpn-client
         resources:
           limits:

--- a/api/pkg/resources/test/fixtures/deployment-openstack-1.11.1-controller-manager.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-openstack-1.11.1-controller-manager.yaml
@@ -81,7 +81,7 @@ spec:
         - /dev/stdout
         command:
         - /usr/sbin/openvpn
-        image: quay.io/kubermatic/openvpn:2.4.8
+        image: quay.io/kubermatic/openvpn:v2.4.8-r1
         name: openvpn-client
         resources:
           limits:

--- a/api/pkg/resources/test/fixtures/deployment-openstack-1.11.1-dns-resolver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-openstack-1.11.1-dns-resolver.yaml
@@ -79,7 +79,7 @@ spec:
         - /dev/stdout
         command:
         - /usr/sbin/openvpn
-        image: quay.io/kubermatic/openvpn:2.4.8
+        image: quay.io/kubermatic/openvpn:v2.4.8-r1
         name: openvpn-client
         resources:
           limits:

--- a/api/pkg/resources/test/fixtures/deployment-openstack-1.11.1-dns-resolver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-openstack-1.11.1-dns-resolver.yaml
@@ -79,7 +79,7 @@ spec:
         - /dev/stdout
         command:
         - /usr/sbin/openvpn
-        image: quay.io/kubermatic/openvpn:v0.5
+        image: quay.io/kubermatic/openvpn:v0.6-dev
         name: openvpn-client
         resources:
           limits:

--- a/api/pkg/resources/test/fixtures/deployment-openstack-1.11.1-dns-resolver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-openstack-1.11.1-dns-resolver.yaml
@@ -79,7 +79,7 @@ spec:
         - /dev/stdout
         command:
         - /usr/sbin/openvpn
-        image: quay.io/kubermatic/openvpn:v0.6-dev
+        image: quay.io/kubermatic/openvpn:2.4.8
         name: openvpn-client
         resources:
           limits:

--- a/api/pkg/resources/test/fixtures/deployment-openstack-1.11.1-metrics-server.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-openstack-1.11.1-metrics-server.yaml
@@ -108,7 +108,7 @@ spec:
         - /dev/stdout
         command:
         - /usr/sbin/openvpn
-        image: quay.io/kubermatic/openvpn:2.4.8
+        image: quay.io/kubermatic/openvpn:v2.4.8-r1
         name: openvpn-client
         resources:
           limits:

--- a/api/pkg/resources/test/fixtures/deployment-openstack-1.11.1-metrics-server.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-openstack-1.11.1-metrics-server.yaml
@@ -108,7 +108,7 @@ spec:
         - /dev/stdout
         command:
         - /usr/sbin/openvpn
-        image: quay.io/kubermatic/openvpn:v0.5
+        image: quay.io/kubermatic/openvpn:v0.6-dev
         name: openvpn-client
         resources:
           limits:

--- a/api/pkg/resources/test/fixtures/deployment-openstack-1.11.1-metrics-server.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-openstack-1.11.1-metrics-server.yaml
@@ -108,7 +108,7 @@ spec:
         - /dev/stdout
         command:
         - /usr/sbin/openvpn
-        image: quay.io/kubermatic/openvpn:v0.6-dev
+        image: quay.io/kubermatic/openvpn:2.4.8
         name: openvpn-client
         resources:
           limits:

--- a/api/pkg/resources/test/fixtures/deployment-openstack-1.11.1-openvpn-server.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-openstack-1.11.1-openvpn-server.yaml
@@ -86,7 +86,7 @@ spec:
         - 255.255.255.0
         command:
         - /usr/sbin/openvpn
-        image: quay.io/kubermatic/openvpn:v0.6-dev
+        image: quay.io/kubermatic/openvpn:2.4.8
         name: openvpn-server
         ports:
         - containerPort: 1194
@@ -135,7 +135,7 @@ spec:
           done
         command:
         - /bin/bash
-        image: quay.io/kubermatic/openvpn:v0.6-dev
+        image: quay.io/kubermatic/openvpn:2.4.8
         name: ip-fixup
         resources:
           limits:
@@ -189,7 +189,7 @@ spec:
           iptables -A INPUT -i tun0 -j DROP
         command:
         - /bin/bash
-        image: quay.io/kubermatic/openvpn:v0.6-dev
+        image: quay.io/kubermatic/openvpn:2.4.8
         name: iptables-init
         resources:
           limits:

--- a/api/pkg/resources/test/fixtures/deployment-openstack-1.11.1-openvpn-server.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-openstack-1.11.1-openvpn-server.yaml
@@ -86,7 +86,7 @@ spec:
         - 255.255.255.0
         command:
         - /usr/sbin/openvpn
-        image: quay.io/kubermatic/openvpn:2.4.8
+        image: quay.io/kubermatic/openvpn:v2.4.8-r1
         name: openvpn-server
         ports:
         - containerPort: 1194
@@ -135,7 +135,7 @@ spec:
           done
         command:
         - /bin/bash
-        image: quay.io/kubermatic/openvpn:2.4.8
+        image: quay.io/kubermatic/openvpn:v2.4.8-r1
         name: ip-fixup
         resources:
           limits:
@@ -189,7 +189,7 @@ spec:
           iptables -A INPUT -i tun0 -j DROP
         command:
         - /bin/bash
-        image: quay.io/kubermatic/openvpn:2.4.8
+        image: quay.io/kubermatic/openvpn:v2.4.8-r1
         name: iptables-init
         resources:
           limits:

--- a/api/pkg/resources/test/fixtures/deployment-openstack-1.11.1-openvpn-server.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-openstack-1.11.1-openvpn-server.yaml
@@ -86,7 +86,7 @@ spec:
         - 255.255.255.0
         command:
         - /usr/sbin/openvpn
-        image: quay.io/kubermatic/openvpn:v0.5
+        image: quay.io/kubermatic/openvpn:v0.6-dev
         name: openvpn-server
         ports:
         - containerPort: 1194
@@ -135,7 +135,7 @@ spec:
           done
         command:
         - /bin/bash
-        image: quay.io/kubermatic/openvpn:v0.5
+        image: quay.io/kubermatic/openvpn:v0.6-dev
         name: ip-fixup
         resources:
           limits:
@@ -189,7 +189,7 @@ spec:
           iptables -A INPUT -i tun0 -j DROP
         command:
         - /bin/bash
-        image: quay.io/kubermatic/openvpn:v0.5
+        image: quay.io/kubermatic/openvpn:v0.6-dev
         name: iptables-init
         resources:
           limits:

--- a/api/pkg/resources/test/fixtures/deployment-openstack-1.11.1-scheduler.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-openstack-1.11.1-scheduler.yaml
@@ -79,7 +79,7 @@ spec:
         - /dev/stdout
         command:
         - /usr/sbin/openvpn
-        image: quay.io/kubermatic/openvpn:2.4.8
+        image: quay.io/kubermatic/openvpn:v2.4.8-r1
         name: openvpn-client
         resources:
           limits:

--- a/api/pkg/resources/test/fixtures/deployment-openstack-1.11.1-scheduler.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-openstack-1.11.1-scheduler.yaml
@@ -79,7 +79,7 @@ spec:
         - /dev/stdout
         command:
         - /usr/sbin/openvpn
-        image: quay.io/kubermatic/openvpn:v0.5
+        image: quay.io/kubermatic/openvpn:v0.6-dev
         name: openvpn-client
         resources:
           limits:

--- a/api/pkg/resources/test/fixtures/deployment-openstack-1.11.1-scheduler.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-openstack-1.11.1-scheduler.yaml
@@ -79,7 +79,7 @@ spec:
         - /dev/stdout
         command:
         - /usr/sbin/openvpn
-        image: quay.io/kubermatic/openvpn:v0.6-dev
+        image: quay.io/kubermatic/openvpn:2.4.8
         name: openvpn-client
         resources:
           limits:

--- a/api/pkg/resources/test/fixtures/deployment-openstack-1.12.0-apiserver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-openstack-1.12.0-apiserver.yaml
@@ -89,7 +89,7 @@ spec:
         - /dev/stdout
         command:
         - /usr/sbin/openvpn
-        image: quay.io/kubermatic/openvpn:v0.6-dev
+        image: quay.io/kubermatic/openvpn:2.4.8
         name: openvpn-client
         resources:
           limits:

--- a/api/pkg/resources/test/fixtures/deployment-openstack-1.12.0-apiserver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-openstack-1.12.0-apiserver.yaml
@@ -89,7 +89,7 @@ spec:
         - /dev/stdout
         command:
         - /usr/sbin/openvpn
-        image: quay.io/kubermatic/openvpn:2.4.8
+        image: quay.io/kubermatic/openvpn:v2.4.8-r1
         name: openvpn-client
         resources:
           limits:

--- a/api/pkg/resources/test/fixtures/deployment-openstack-1.12.0-apiserver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-openstack-1.12.0-apiserver.yaml
@@ -89,7 +89,7 @@ spec:
         - /dev/stdout
         command:
         - /usr/sbin/openvpn
-        image: quay.io/kubermatic/openvpn:v0.5
+        image: quay.io/kubermatic/openvpn:v0.6-dev
         name: openvpn-client
         resources:
           limits:

--- a/api/pkg/resources/test/fixtures/deployment-openstack-1.12.0-controller-manager.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-openstack-1.12.0-controller-manager.yaml
@@ -81,7 +81,7 @@ spec:
         - /dev/stdout
         command:
         - /usr/sbin/openvpn
-        image: quay.io/kubermatic/openvpn:v0.6-dev
+        image: quay.io/kubermatic/openvpn:2.4.8
         name: openvpn-client
         resources:
           limits:

--- a/api/pkg/resources/test/fixtures/deployment-openstack-1.12.0-controller-manager.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-openstack-1.12.0-controller-manager.yaml
@@ -81,7 +81,7 @@ spec:
         - /dev/stdout
         command:
         - /usr/sbin/openvpn
-        image: quay.io/kubermatic/openvpn:v0.5
+        image: quay.io/kubermatic/openvpn:v0.6-dev
         name: openvpn-client
         resources:
           limits:

--- a/api/pkg/resources/test/fixtures/deployment-openstack-1.12.0-controller-manager.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-openstack-1.12.0-controller-manager.yaml
@@ -81,7 +81,7 @@ spec:
         - /dev/stdout
         command:
         - /usr/sbin/openvpn
-        image: quay.io/kubermatic/openvpn:2.4.8
+        image: quay.io/kubermatic/openvpn:v2.4.8-r1
         name: openvpn-client
         resources:
           limits:

--- a/api/pkg/resources/test/fixtures/deployment-openstack-1.12.0-dns-resolver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-openstack-1.12.0-dns-resolver.yaml
@@ -79,7 +79,7 @@ spec:
         - /dev/stdout
         command:
         - /usr/sbin/openvpn
-        image: quay.io/kubermatic/openvpn:2.4.8
+        image: quay.io/kubermatic/openvpn:v2.4.8-r1
         name: openvpn-client
         resources:
           limits:

--- a/api/pkg/resources/test/fixtures/deployment-openstack-1.12.0-dns-resolver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-openstack-1.12.0-dns-resolver.yaml
@@ -79,7 +79,7 @@ spec:
         - /dev/stdout
         command:
         - /usr/sbin/openvpn
-        image: quay.io/kubermatic/openvpn:v0.5
+        image: quay.io/kubermatic/openvpn:v0.6-dev
         name: openvpn-client
         resources:
           limits:

--- a/api/pkg/resources/test/fixtures/deployment-openstack-1.12.0-dns-resolver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-openstack-1.12.0-dns-resolver.yaml
@@ -79,7 +79,7 @@ spec:
         - /dev/stdout
         command:
         - /usr/sbin/openvpn
-        image: quay.io/kubermatic/openvpn:v0.6-dev
+        image: quay.io/kubermatic/openvpn:2.4.8
         name: openvpn-client
         resources:
           limits:

--- a/api/pkg/resources/test/fixtures/deployment-openstack-1.12.0-metrics-server.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-openstack-1.12.0-metrics-server.yaml
@@ -108,7 +108,7 @@ spec:
         - /dev/stdout
         command:
         - /usr/sbin/openvpn
-        image: quay.io/kubermatic/openvpn:2.4.8
+        image: quay.io/kubermatic/openvpn:v2.4.8-r1
         name: openvpn-client
         resources:
           limits:

--- a/api/pkg/resources/test/fixtures/deployment-openstack-1.12.0-metrics-server.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-openstack-1.12.0-metrics-server.yaml
@@ -108,7 +108,7 @@ spec:
         - /dev/stdout
         command:
         - /usr/sbin/openvpn
-        image: quay.io/kubermatic/openvpn:v0.5
+        image: quay.io/kubermatic/openvpn:v0.6-dev
         name: openvpn-client
         resources:
           limits:

--- a/api/pkg/resources/test/fixtures/deployment-openstack-1.12.0-metrics-server.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-openstack-1.12.0-metrics-server.yaml
@@ -108,7 +108,7 @@ spec:
         - /dev/stdout
         command:
         - /usr/sbin/openvpn
-        image: quay.io/kubermatic/openvpn:v0.6-dev
+        image: quay.io/kubermatic/openvpn:2.4.8
         name: openvpn-client
         resources:
           limits:

--- a/api/pkg/resources/test/fixtures/deployment-openstack-1.12.0-openvpn-server.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-openstack-1.12.0-openvpn-server.yaml
@@ -86,7 +86,7 @@ spec:
         - 255.255.255.0
         command:
         - /usr/sbin/openvpn
-        image: quay.io/kubermatic/openvpn:v0.6-dev
+        image: quay.io/kubermatic/openvpn:2.4.8
         name: openvpn-server
         ports:
         - containerPort: 1194
@@ -135,7 +135,7 @@ spec:
           done
         command:
         - /bin/bash
-        image: quay.io/kubermatic/openvpn:v0.6-dev
+        image: quay.io/kubermatic/openvpn:2.4.8
         name: ip-fixup
         resources:
           limits:
@@ -189,7 +189,7 @@ spec:
           iptables -A INPUT -i tun0 -j DROP
         command:
         - /bin/bash
-        image: quay.io/kubermatic/openvpn:v0.6-dev
+        image: quay.io/kubermatic/openvpn:2.4.8
         name: iptables-init
         resources:
           limits:

--- a/api/pkg/resources/test/fixtures/deployment-openstack-1.12.0-openvpn-server.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-openstack-1.12.0-openvpn-server.yaml
@@ -86,7 +86,7 @@ spec:
         - 255.255.255.0
         command:
         - /usr/sbin/openvpn
-        image: quay.io/kubermatic/openvpn:2.4.8
+        image: quay.io/kubermatic/openvpn:v2.4.8-r1
         name: openvpn-server
         ports:
         - containerPort: 1194
@@ -135,7 +135,7 @@ spec:
           done
         command:
         - /bin/bash
-        image: quay.io/kubermatic/openvpn:2.4.8
+        image: quay.io/kubermatic/openvpn:v2.4.8-r1
         name: ip-fixup
         resources:
           limits:
@@ -189,7 +189,7 @@ spec:
           iptables -A INPUT -i tun0 -j DROP
         command:
         - /bin/bash
-        image: quay.io/kubermatic/openvpn:2.4.8
+        image: quay.io/kubermatic/openvpn:v2.4.8-r1
         name: iptables-init
         resources:
           limits:

--- a/api/pkg/resources/test/fixtures/deployment-openstack-1.12.0-openvpn-server.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-openstack-1.12.0-openvpn-server.yaml
@@ -86,7 +86,7 @@ spec:
         - 255.255.255.0
         command:
         - /usr/sbin/openvpn
-        image: quay.io/kubermatic/openvpn:v0.5
+        image: quay.io/kubermatic/openvpn:v0.6-dev
         name: openvpn-server
         ports:
         - containerPort: 1194
@@ -135,7 +135,7 @@ spec:
           done
         command:
         - /bin/bash
-        image: quay.io/kubermatic/openvpn:v0.5
+        image: quay.io/kubermatic/openvpn:v0.6-dev
         name: ip-fixup
         resources:
           limits:
@@ -189,7 +189,7 @@ spec:
           iptables -A INPUT -i tun0 -j DROP
         command:
         - /bin/bash
-        image: quay.io/kubermatic/openvpn:v0.5
+        image: quay.io/kubermatic/openvpn:v0.6-dev
         name: iptables-init
         resources:
           limits:

--- a/api/pkg/resources/test/fixtures/deployment-openstack-1.12.0-scheduler.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-openstack-1.12.0-scheduler.yaml
@@ -79,7 +79,7 @@ spec:
         - /dev/stdout
         command:
         - /usr/sbin/openvpn
-        image: quay.io/kubermatic/openvpn:2.4.8
+        image: quay.io/kubermatic/openvpn:v2.4.8-r1
         name: openvpn-client
         resources:
           limits:

--- a/api/pkg/resources/test/fixtures/deployment-openstack-1.12.0-scheduler.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-openstack-1.12.0-scheduler.yaml
@@ -79,7 +79,7 @@ spec:
         - /dev/stdout
         command:
         - /usr/sbin/openvpn
-        image: quay.io/kubermatic/openvpn:v0.5
+        image: quay.io/kubermatic/openvpn:v0.6-dev
         name: openvpn-client
         resources:
           limits:

--- a/api/pkg/resources/test/fixtures/deployment-openstack-1.12.0-scheduler.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-openstack-1.12.0-scheduler.yaml
@@ -79,7 +79,7 @@ spec:
         - /dev/stdout
         command:
         - /usr/sbin/openvpn
-        image: quay.io/kubermatic/openvpn:v0.6-dev
+        image: quay.io/kubermatic/openvpn:2.4.8
         name: openvpn-client
         resources:
           limits:

--- a/api/pkg/resources/test/fixtures/deployment-openstack-1.13.0-apiserver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-openstack-1.13.0-apiserver.yaml
@@ -89,7 +89,7 @@ spec:
         - /dev/stdout
         command:
         - /usr/sbin/openvpn
-        image: quay.io/kubermatic/openvpn:v0.6-dev
+        image: quay.io/kubermatic/openvpn:2.4.8
         name: openvpn-client
         resources:
           limits:

--- a/api/pkg/resources/test/fixtures/deployment-openstack-1.13.0-apiserver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-openstack-1.13.0-apiserver.yaml
@@ -89,7 +89,7 @@ spec:
         - /dev/stdout
         command:
         - /usr/sbin/openvpn
-        image: quay.io/kubermatic/openvpn:2.4.8
+        image: quay.io/kubermatic/openvpn:v2.4.8-r1
         name: openvpn-client
         resources:
           limits:

--- a/api/pkg/resources/test/fixtures/deployment-openstack-1.13.0-apiserver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-openstack-1.13.0-apiserver.yaml
@@ -89,7 +89,7 @@ spec:
         - /dev/stdout
         command:
         - /usr/sbin/openvpn
-        image: quay.io/kubermatic/openvpn:v0.5
+        image: quay.io/kubermatic/openvpn:v0.6-dev
         name: openvpn-client
         resources:
           limits:

--- a/api/pkg/resources/test/fixtures/deployment-openstack-1.13.0-controller-manager.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-openstack-1.13.0-controller-manager.yaml
@@ -81,7 +81,7 @@ spec:
         - /dev/stdout
         command:
         - /usr/sbin/openvpn
-        image: quay.io/kubermatic/openvpn:v0.6-dev
+        image: quay.io/kubermatic/openvpn:2.4.8
         name: openvpn-client
         resources:
           limits:

--- a/api/pkg/resources/test/fixtures/deployment-openstack-1.13.0-controller-manager.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-openstack-1.13.0-controller-manager.yaml
@@ -81,7 +81,7 @@ spec:
         - /dev/stdout
         command:
         - /usr/sbin/openvpn
-        image: quay.io/kubermatic/openvpn:v0.5
+        image: quay.io/kubermatic/openvpn:v0.6-dev
         name: openvpn-client
         resources:
           limits:

--- a/api/pkg/resources/test/fixtures/deployment-openstack-1.13.0-controller-manager.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-openstack-1.13.0-controller-manager.yaml
@@ -81,7 +81,7 @@ spec:
         - /dev/stdout
         command:
         - /usr/sbin/openvpn
-        image: quay.io/kubermatic/openvpn:2.4.8
+        image: quay.io/kubermatic/openvpn:v2.4.8-r1
         name: openvpn-client
         resources:
           limits:

--- a/api/pkg/resources/test/fixtures/deployment-openstack-1.13.0-dns-resolver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-openstack-1.13.0-dns-resolver.yaml
@@ -79,7 +79,7 @@ spec:
         - /dev/stdout
         command:
         - /usr/sbin/openvpn
-        image: quay.io/kubermatic/openvpn:2.4.8
+        image: quay.io/kubermatic/openvpn:v2.4.8-r1
         name: openvpn-client
         resources:
           limits:

--- a/api/pkg/resources/test/fixtures/deployment-openstack-1.13.0-dns-resolver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-openstack-1.13.0-dns-resolver.yaml
@@ -79,7 +79,7 @@ spec:
         - /dev/stdout
         command:
         - /usr/sbin/openvpn
-        image: quay.io/kubermatic/openvpn:v0.5
+        image: quay.io/kubermatic/openvpn:v0.6-dev
         name: openvpn-client
         resources:
           limits:

--- a/api/pkg/resources/test/fixtures/deployment-openstack-1.13.0-dns-resolver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-openstack-1.13.0-dns-resolver.yaml
@@ -79,7 +79,7 @@ spec:
         - /dev/stdout
         command:
         - /usr/sbin/openvpn
-        image: quay.io/kubermatic/openvpn:v0.6-dev
+        image: quay.io/kubermatic/openvpn:2.4.8
         name: openvpn-client
         resources:
           limits:

--- a/api/pkg/resources/test/fixtures/deployment-openstack-1.13.0-metrics-server.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-openstack-1.13.0-metrics-server.yaml
@@ -108,7 +108,7 @@ spec:
         - /dev/stdout
         command:
         - /usr/sbin/openvpn
-        image: quay.io/kubermatic/openvpn:2.4.8
+        image: quay.io/kubermatic/openvpn:v2.4.8-r1
         name: openvpn-client
         resources:
           limits:

--- a/api/pkg/resources/test/fixtures/deployment-openstack-1.13.0-metrics-server.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-openstack-1.13.0-metrics-server.yaml
@@ -108,7 +108,7 @@ spec:
         - /dev/stdout
         command:
         - /usr/sbin/openvpn
-        image: quay.io/kubermatic/openvpn:v0.5
+        image: quay.io/kubermatic/openvpn:v0.6-dev
         name: openvpn-client
         resources:
           limits:

--- a/api/pkg/resources/test/fixtures/deployment-openstack-1.13.0-metrics-server.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-openstack-1.13.0-metrics-server.yaml
@@ -108,7 +108,7 @@ spec:
         - /dev/stdout
         command:
         - /usr/sbin/openvpn
-        image: quay.io/kubermatic/openvpn:v0.6-dev
+        image: quay.io/kubermatic/openvpn:2.4.8
         name: openvpn-client
         resources:
           limits:

--- a/api/pkg/resources/test/fixtures/deployment-openstack-1.13.0-openvpn-server.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-openstack-1.13.0-openvpn-server.yaml
@@ -86,7 +86,7 @@ spec:
         - 255.255.255.0
         command:
         - /usr/sbin/openvpn
-        image: quay.io/kubermatic/openvpn:v0.6-dev
+        image: quay.io/kubermatic/openvpn:2.4.8
         name: openvpn-server
         ports:
         - containerPort: 1194
@@ -135,7 +135,7 @@ spec:
           done
         command:
         - /bin/bash
-        image: quay.io/kubermatic/openvpn:v0.6-dev
+        image: quay.io/kubermatic/openvpn:2.4.8
         name: ip-fixup
         resources:
           limits:
@@ -189,7 +189,7 @@ spec:
           iptables -A INPUT -i tun0 -j DROP
         command:
         - /bin/bash
-        image: quay.io/kubermatic/openvpn:v0.6-dev
+        image: quay.io/kubermatic/openvpn:2.4.8
         name: iptables-init
         resources:
           limits:

--- a/api/pkg/resources/test/fixtures/deployment-openstack-1.13.0-openvpn-server.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-openstack-1.13.0-openvpn-server.yaml
@@ -86,7 +86,7 @@ spec:
         - 255.255.255.0
         command:
         - /usr/sbin/openvpn
-        image: quay.io/kubermatic/openvpn:2.4.8
+        image: quay.io/kubermatic/openvpn:v2.4.8-r1
         name: openvpn-server
         ports:
         - containerPort: 1194
@@ -135,7 +135,7 @@ spec:
           done
         command:
         - /bin/bash
-        image: quay.io/kubermatic/openvpn:2.4.8
+        image: quay.io/kubermatic/openvpn:v2.4.8-r1
         name: ip-fixup
         resources:
           limits:
@@ -189,7 +189,7 @@ spec:
           iptables -A INPUT -i tun0 -j DROP
         command:
         - /bin/bash
-        image: quay.io/kubermatic/openvpn:2.4.8
+        image: quay.io/kubermatic/openvpn:v2.4.8-r1
         name: iptables-init
         resources:
           limits:

--- a/api/pkg/resources/test/fixtures/deployment-openstack-1.13.0-openvpn-server.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-openstack-1.13.0-openvpn-server.yaml
@@ -86,7 +86,7 @@ spec:
         - 255.255.255.0
         command:
         - /usr/sbin/openvpn
-        image: quay.io/kubermatic/openvpn:v0.5
+        image: quay.io/kubermatic/openvpn:v0.6-dev
         name: openvpn-server
         ports:
         - containerPort: 1194
@@ -135,7 +135,7 @@ spec:
           done
         command:
         - /bin/bash
-        image: quay.io/kubermatic/openvpn:v0.5
+        image: quay.io/kubermatic/openvpn:v0.6-dev
         name: ip-fixup
         resources:
           limits:
@@ -189,7 +189,7 @@ spec:
           iptables -A INPUT -i tun0 -j DROP
         command:
         - /bin/bash
-        image: quay.io/kubermatic/openvpn:v0.5
+        image: quay.io/kubermatic/openvpn:v0.6-dev
         name: iptables-init
         resources:
           limits:

--- a/api/pkg/resources/test/fixtures/deployment-openstack-1.13.0-scheduler.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-openstack-1.13.0-scheduler.yaml
@@ -79,7 +79,7 @@ spec:
         - /dev/stdout
         command:
         - /usr/sbin/openvpn
-        image: quay.io/kubermatic/openvpn:2.4.8
+        image: quay.io/kubermatic/openvpn:v2.4.8-r1
         name: openvpn-client
         resources:
           limits:

--- a/api/pkg/resources/test/fixtures/deployment-openstack-1.13.0-scheduler.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-openstack-1.13.0-scheduler.yaml
@@ -79,7 +79,7 @@ spec:
         - /dev/stdout
         command:
         - /usr/sbin/openvpn
-        image: quay.io/kubermatic/openvpn:v0.5
+        image: quay.io/kubermatic/openvpn:v0.6-dev
         name: openvpn-client
         resources:
           limits:

--- a/api/pkg/resources/test/fixtures/deployment-openstack-1.13.0-scheduler.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-openstack-1.13.0-scheduler.yaml
@@ -79,7 +79,7 @@ spec:
         - /dev/stdout
         command:
         - /usr/sbin/openvpn
-        image: quay.io/kubermatic/openvpn:v0.6-dev
+        image: quay.io/kubermatic/openvpn:2.4.8
         name: openvpn-client
         resources:
           limits:

--- a/api/pkg/resources/test/fixtures/deployment-vsphere-1.10.0-apiserver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-vsphere-1.10.0-apiserver.yaml
@@ -89,7 +89,7 @@ spec:
         - /dev/stdout
         command:
         - /usr/sbin/openvpn
-        image: quay.io/kubermatic/openvpn:v0.6-dev
+        image: quay.io/kubermatic/openvpn:2.4.8
         name: openvpn-client
         resources:
           limits:

--- a/api/pkg/resources/test/fixtures/deployment-vsphere-1.10.0-apiserver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-vsphere-1.10.0-apiserver.yaml
@@ -89,7 +89,7 @@ spec:
         - /dev/stdout
         command:
         - /usr/sbin/openvpn
-        image: quay.io/kubermatic/openvpn:2.4.8
+        image: quay.io/kubermatic/openvpn:v2.4.8-r1
         name: openvpn-client
         resources:
           limits:

--- a/api/pkg/resources/test/fixtures/deployment-vsphere-1.10.0-apiserver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-vsphere-1.10.0-apiserver.yaml
@@ -89,7 +89,7 @@ spec:
         - /dev/stdout
         command:
         - /usr/sbin/openvpn
-        image: quay.io/kubermatic/openvpn:v0.5
+        image: quay.io/kubermatic/openvpn:v0.6-dev
         name: openvpn-client
         resources:
           limits:

--- a/api/pkg/resources/test/fixtures/deployment-vsphere-1.10.0-controller-manager.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-vsphere-1.10.0-controller-manager.yaml
@@ -81,7 +81,7 @@ spec:
         - /dev/stdout
         command:
         - /usr/sbin/openvpn
-        image: quay.io/kubermatic/openvpn:v0.6-dev
+        image: quay.io/kubermatic/openvpn:2.4.8
         name: openvpn-client
         resources:
           limits:

--- a/api/pkg/resources/test/fixtures/deployment-vsphere-1.10.0-controller-manager.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-vsphere-1.10.0-controller-manager.yaml
@@ -81,7 +81,7 @@ spec:
         - /dev/stdout
         command:
         - /usr/sbin/openvpn
-        image: quay.io/kubermatic/openvpn:v0.5
+        image: quay.io/kubermatic/openvpn:v0.6-dev
         name: openvpn-client
         resources:
           limits:

--- a/api/pkg/resources/test/fixtures/deployment-vsphere-1.10.0-controller-manager.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-vsphere-1.10.0-controller-manager.yaml
@@ -81,7 +81,7 @@ spec:
         - /dev/stdout
         command:
         - /usr/sbin/openvpn
-        image: quay.io/kubermatic/openvpn:2.4.8
+        image: quay.io/kubermatic/openvpn:v2.4.8-r1
         name: openvpn-client
         resources:
           limits:

--- a/api/pkg/resources/test/fixtures/deployment-vsphere-1.10.0-dns-resolver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-vsphere-1.10.0-dns-resolver.yaml
@@ -79,7 +79,7 @@ spec:
         - /dev/stdout
         command:
         - /usr/sbin/openvpn
-        image: quay.io/kubermatic/openvpn:2.4.8
+        image: quay.io/kubermatic/openvpn:v2.4.8-r1
         name: openvpn-client
         resources:
           limits:

--- a/api/pkg/resources/test/fixtures/deployment-vsphere-1.10.0-dns-resolver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-vsphere-1.10.0-dns-resolver.yaml
@@ -79,7 +79,7 @@ spec:
         - /dev/stdout
         command:
         - /usr/sbin/openvpn
-        image: quay.io/kubermatic/openvpn:v0.5
+        image: quay.io/kubermatic/openvpn:v0.6-dev
         name: openvpn-client
         resources:
           limits:

--- a/api/pkg/resources/test/fixtures/deployment-vsphere-1.10.0-dns-resolver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-vsphere-1.10.0-dns-resolver.yaml
@@ -79,7 +79,7 @@ spec:
         - /dev/stdout
         command:
         - /usr/sbin/openvpn
-        image: quay.io/kubermatic/openvpn:v0.6-dev
+        image: quay.io/kubermatic/openvpn:2.4.8
         name: openvpn-client
         resources:
           limits:

--- a/api/pkg/resources/test/fixtures/deployment-vsphere-1.10.0-metrics-server.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-vsphere-1.10.0-metrics-server.yaml
@@ -108,7 +108,7 @@ spec:
         - /dev/stdout
         command:
         - /usr/sbin/openvpn
-        image: quay.io/kubermatic/openvpn:2.4.8
+        image: quay.io/kubermatic/openvpn:v2.4.8-r1
         name: openvpn-client
         resources:
           limits:

--- a/api/pkg/resources/test/fixtures/deployment-vsphere-1.10.0-metrics-server.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-vsphere-1.10.0-metrics-server.yaml
@@ -108,7 +108,7 @@ spec:
         - /dev/stdout
         command:
         - /usr/sbin/openvpn
-        image: quay.io/kubermatic/openvpn:v0.5
+        image: quay.io/kubermatic/openvpn:v0.6-dev
         name: openvpn-client
         resources:
           limits:

--- a/api/pkg/resources/test/fixtures/deployment-vsphere-1.10.0-metrics-server.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-vsphere-1.10.0-metrics-server.yaml
@@ -108,7 +108,7 @@ spec:
         - /dev/stdout
         command:
         - /usr/sbin/openvpn
-        image: quay.io/kubermatic/openvpn:v0.6-dev
+        image: quay.io/kubermatic/openvpn:2.4.8
         name: openvpn-client
         resources:
           limits:

--- a/api/pkg/resources/test/fixtures/deployment-vsphere-1.10.0-openvpn-server.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-vsphere-1.10.0-openvpn-server.yaml
@@ -86,7 +86,7 @@ spec:
         - 255.255.255.0
         command:
         - /usr/sbin/openvpn
-        image: quay.io/kubermatic/openvpn:v0.6-dev
+        image: quay.io/kubermatic/openvpn:2.4.8
         name: openvpn-server
         ports:
         - containerPort: 1194
@@ -135,7 +135,7 @@ spec:
           done
         command:
         - /bin/bash
-        image: quay.io/kubermatic/openvpn:v0.6-dev
+        image: quay.io/kubermatic/openvpn:2.4.8
         name: ip-fixup
         resources:
           limits:
@@ -189,7 +189,7 @@ spec:
           iptables -A INPUT -i tun0 -j DROP
         command:
         - /bin/bash
-        image: quay.io/kubermatic/openvpn:v0.6-dev
+        image: quay.io/kubermatic/openvpn:2.4.8
         name: iptables-init
         resources:
           limits:

--- a/api/pkg/resources/test/fixtures/deployment-vsphere-1.10.0-openvpn-server.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-vsphere-1.10.0-openvpn-server.yaml
@@ -86,7 +86,7 @@ spec:
         - 255.255.255.0
         command:
         - /usr/sbin/openvpn
-        image: quay.io/kubermatic/openvpn:2.4.8
+        image: quay.io/kubermatic/openvpn:v2.4.8-r1
         name: openvpn-server
         ports:
         - containerPort: 1194
@@ -135,7 +135,7 @@ spec:
           done
         command:
         - /bin/bash
-        image: quay.io/kubermatic/openvpn:2.4.8
+        image: quay.io/kubermatic/openvpn:v2.4.8-r1
         name: ip-fixup
         resources:
           limits:
@@ -189,7 +189,7 @@ spec:
           iptables -A INPUT -i tun0 -j DROP
         command:
         - /bin/bash
-        image: quay.io/kubermatic/openvpn:2.4.8
+        image: quay.io/kubermatic/openvpn:v2.4.8-r1
         name: iptables-init
         resources:
           limits:

--- a/api/pkg/resources/test/fixtures/deployment-vsphere-1.10.0-openvpn-server.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-vsphere-1.10.0-openvpn-server.yaml
@@ -86,7 +86,7 @@ spec:
         - 255.255.255.0
         command:
         - /usr/sbin/openvpn
-        image: quay.io/kubermatic/openvpn:v0.5
+        image: quay.io/kubermatic/openvpn:v0.6-dev
         name: openvpn-server
         ports:
         - containerPort: 1194
@@ -135,7 +135,7 @@ spec:
           done
         command:
         - /bin/bash
-        image: quay.io/kubermatic/openvpn:v0.5
+        image: quay.io/kubermatic/openvpn:v0.6-dev
         name: ip-fixup
         resources:
           limits:
@@ -189,7 +189,7 @@ spec:
           iptables -A INPUT -i tun0 -j DROP
         command:
         - /bin/bash
-        image: quay.io/kubermatic/openvpn:v0.5
+        image: quay.io/kubermatic/openvpn:v0.6-dev
         name: iptables-init
         resources:
           limits:

--- a/api/pkg/resources/test/fixtures/deployment-vsphere-1.10.0-scheduler.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-vsphere-1.10.0-scheduler.yaml
@@ -79,7 +79,7 @@ spec:
         - /dev/stdout
         command:
         - /usr/sbin/openvpn
-        image: quay.io/kubermatic/openvpn:2.4.8
+        image: quay.io/kubermatic/openvpn:v2.4.8-r1
         name: openvpn-client
         resources:
           limits:

--- a/api/pkg/resources/test/fixtures/deployment-vsphere-1.10.0-scheduler.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-vsphere-1.10.0-scheduler.yaml
@@ -79,7 +79,7 @@ spec:
         - /dev/stdout
         command:
         - /usr/sbin/openvpn
-        image: quay.io/kubermatic/openvpn:v0.5
+        image: quay.io/kubermatic/openvpn:v0.6-dev
         name: openvpn-client
         resources:
           limits:

--- a/api/pkg/resources/test/fixtures/deployment-vsphere-1.10.0-scheduler.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-vsphere-1.10.0-scheduler.yaml
@@ -79,7 +79,7 @@ spec:
         - /dev/stdout
         command:
         - /usr/sbin/openvpn
-        image: quay.io/kubermatic/openvpn:v0.6-dev
+        image: quay.io/kubermatic/openvpn:2.4.8
         name: openvpn-client
         resources:
           limits:

--- a/api/pkg/resources/test/fixtures/deployment-vsphere-1.10.6-apiserver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-vsphere-1.10.6-apiserver.yaml
@@ -89,7 +89,7 @@ spec:
         - /dev/stdout
         command:
         - /usr/sbin/openvpn
-        image: quay.io/kubermatic/openvpn:v0.6-dev
+        image: quay.io/kubermatic/openvpn:2.4.8
         name: openvpn-client
         resources:
           limits:

--- a/api/pkg/resources/test/fixtures/deployment-vsphere-1.10.6-apiserver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-vsphere-1.10.6-apiserver.yaml
@@ -89,7 +89,7 @@ spec:
         - /dev/stdout
         command:
         - /usr/sbin/openvpn
-        image: quay.io/kubermatic/openvpn:2.4.8
+        image: quay.io/kubermatic/openvpn:v2.4.8-r1
         name: openvpn-client
         resources:
           limits:

--- a/api/pkg/resources/test/fixtures/deployment-vsphere-1.10.6-apiserver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-vsphere-1.10.6-apiserver.yaml
@@ -89,7 +89,7 @@ spec:
         - /dev/stdout
         command:
         - /usr/sbin/openvpn
-        image: quay.io/kubermatic/openvpn:v0.5
+        image: quay.io/kubermatic/openvpn:v0.6-dev
         name: openvpn-client
         resources:
           limits:

--- a/api/pkg/resources/test/fixtures/deployment-vsphere-1.10.6-controller-manager.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-vsphere-1.10.6-controller-manager.yaml
@@ -81,7 +81,7 @@ spec:
         - /dev/stdout
         command:
         - /usr/sbin/openvpn
-        image: quay.io/kubermatic/openvpn:v0.6-dev
+        image: quay.io/kubermatic/openvpn:2.4.8
         name: openvpn-client
         resources:
           limits:

--- a/api/pkg/resources/test/fixtures/deployment-vsphere-1.10.6-controller-manager.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-vsphere-1.10.6-controller-manager.yaml
@@ -81,7 +81,7 @@ spec:
         - /dev/stdout
         command:
         - /usr/sbin/openvpn
-        image: quay.io/kubermatic/openvpn:v0.5
+        image: quay.io/kubermatic/openvpn:v0.6-dev
         name: openvpn-client
         resources:
           limits:

--- a/api/pkg/resources/test/fixtures/deployment-vsphere-1.10.6-controller-manager.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-vsphere-1.10.6-controller-manager.yaml
@@ -81,7 +81,7 @@ spec:
         - /dev/stdout
         command:
         - /usr/sbin/openvpn
-        image: quay.io/kubermatic/openvpn:2.4.8
+        image: quay.io/kubermatic/openvpn:v2.4.8-r1
         name: openvpn-client
         resources:
           limits:

--- a/api/pkg/resources/test/fixtures/deployment-vsphere-1.10.6-dns-resolver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-vsphere-1.10.6-dns-resolver.yaml
@@ -79,7 +79,7 @@ spec:
         - /dev/stdout
         command:
         - /usr/sbin/openvpn
-        image: quay.io/kubermatic/openvpn:2.4.8
+        image: quay.io/kubermatic/openvpn:v2.4.8-r1
         name: openvpn-client
         resources:
           limits:

--- a/api/pkg/resources/test/fixtures/deployment-vsphere-1.10.6-dns-resolver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-vsphere-1.10.6-dns-resolver.yaml
@@ -79,7 +79,7 @@ spec:
         - /dev/stdout
         command:
         - /usr/sbin/openvpn
-        image: quay.io/kubermatic/openvpn:v0.5
+        image: quay.io/kubermatic/openvpn:v0.6-dev
         name: openvpn-client
         resources:
           limits:

--- a/api/pkg/resources/test/fixtures/deployment-vsphere-1.10.6-dns-resolver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-vsphere-1.10.6-dns-resolver.yaml
@@ -79,7 +79,7 @@ spec:
         - /dev/stdout
         command:
         - /usr/sbin/openvpn
-        image: quay.io/kubermatic/openvpn:v0.6-dev
+        image: quay.io/kubermatic/openvpn:2.4.8
         name: openvpn-client
         resources:
           limits:

--- a/api/pkg/resources/test/fixtures/deployment-vsphere-1.10.6-metrics-server.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-vsphere-1.10.6-metrics-server.yaml
@@ -108,7 +108,7 @@ spec:
         - /dev/stdout
         command:
         - /usr/sbin/openvpn
-        image: quay.io/kubermatic/openvpn:2.4.8
+        image: quay.io/kubermatic/openvpn:v2.4.8-r1
         name: openvpn-client
         resources:
           limits:

--- a/api/pkg/resources/test/fixtures/deployment-vsphere-1.10.6-metrics-server.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-vsphere-1.10.6-metrics-server.yaml
@@ -108,7 +108,7 @@ spec:
         - /dev/stdout
         command:
         - /usr/sbin/openvpn
-        image: quay.io/kubermatic/openvpn:v0.5
+        image: quay.io/kubermatic/openvpn:v0.6-dev
         name: openvpn-client
         resources:
           limits:

--- a/api/pkg/resources/test/fixtures/deployment-vsphere-1.10.6-metrics-server.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-vsphere-1.10.6-metrics-server.yaml
@@ -108,7 +108,7 @@ spec:
         - /dev/stdout
         command:
         - /usr/sbin/openvpn
-        image: quay.io/kubermatic/openvpn:v0.6-dev
+        image: quay.io/kubermatic/openvpn:2.4.8
         name: openvpn-client
         resources:
           limits:

--- a/api/pkg/resources/test/fixtures/deployment-vsphere-1.10.6-openvpn-server.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-vsphere-1.10.6-openvpn-server.yaml
@@ -86,7 +86,7 @@ spec:
         - 255.255.255.0
         command:
         - /usr/sbin/openvpn
-        image: quay.io/kubermatic/openvpn:v0.6-dev
+        image: quay.io/kubermatic/openvpn:2.4.8
         name: openvpn-server
         ports:
         - containerPort: 1194
@@ -135,7 +135,7 @@ spec:
           done
         command:
         - /bin/bash
-        image: quay.io/kubermatic/openvpn:v0.6-dev
+        image: quay.io/kubermatic/openvpn:2.4.8
         name: ip-fixup
         resources:
           limits:
@@ -189,7 +189,7 @@ spec:
           iptables -A INPUT -i tun0 -j DROP
         command:
         - /bin/bash
-        image: quay.io/kubermatic/openvpn:v0.6-dev
+        image: quay.io/kubermatic/openvpn:2.4.8
         name: iptables-init
         resources:
           limits:

--- a/api/pkg/resources/test/fixtures/deployment-vsphere-1.10.6-openvpn-server.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-vsphere-1.10.6-openvpn-server.yaml
@@ -86,7 +86,7 @@ spec:
         - 255.255.255.0
         command:
         - /usr/sbin/openvpn
-        image: quay.io/kubermatic/openvpn:2.4.8
+        image: quay.io/kubermatic/openvpn:v2.4.8-r1
         name: openvpn-server
         ports:
         - containerPort: 1194
@@ -135,7 +135,7 @@ spec:
           done
         command:
         - /bin/bash
-        image: quay.io/kubermatic/openvpn:2.4.8
+        image: quay.io/kubermatic/openvpn:v2.4.8-r1
         name: ip-fixup
         resources:
           limits:
@@ -189,7 +189,7 @@ spec:
           iptables -A INPUT -i tun0 -j DROP
         command:
         - /bin/bash
-        image: quay.io/kubermatic/openvpn:2.4.8
+        image: quay.io/kubermatic/openvpn:v2.4.8-r1
         name: iptables-init
         resources:
           limits:

--- a/api/pkg/resources/test/fixtures/deployment-vsphere-1.10.6-openvpn-server.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-vsphere-1.10.6-openvpn-server.yaml
@@ -86,7 +86,7 @@ spec:
         - 255.255.255.0
         command:
         - /usr/sbin/openvpn
-        image: quay.io/kubermatic/openvpn:v0.5
+        image: quay.io/kubermatic/openvpn:v0.6-dev
         name: openvpn-server
         ports:
         - containerPort: 1194
@@ -135,7 +135,7 @@ spec:
           done
         command:
         - /bin/bash
-        image: quay.io/kubermatic/openvpn:v0.5
+        image: quay.io/kubermatic/openvpn:v0.6-dev
         name: ip-fixup
         resources:
           limits:
@@ -189,7 +189,7 @@ spec:
           iptables -A INPUT -i tun0 -j DROP
         command:
         - /bin/bash
-        image: quay.io/kubermatic/openvpn:v0.5
+        image: quay.io/kubermatic/openvpn:v0.6-dev
         name: iptables-init
         resources:
           limits:

--- a/api/pkg/resources/test/fixtures/deployment-vsphere-1.10.6-scheduler.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-vsphere-1.10.6-scheduler.yaml
@@ -79,7 +79,7 @@ spec:
         - /dev/stdout
         command:
         - /usr/sbin/openvpn
-        image: quay.io/kubermatic/openvpn:2.4.8
+        image: quay.io/kubermatic/openvpn:v2.4.8-r1
         name: openvpn-client
         resources:
           limits:

--- a/api/pkg/resources/test/fixtures/deployment-vsphere-1.10.6-scheduler.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-vsphere-1.10.6-scheduler.yaml
@@ -79,7 +79,7 @@ spec:
         - /dev/stdout
         command:
         - /usr/sbin/openvpn
-        image: quay.io/kubermatic/openvpn:v0.5
+        image: quay.io/kubermatic/openvpn:v0.6-dev
         name: openvpn-client
         resources:
           limits:

--- a/api/pkg/resources/test/fixtures/deployment-vsphere-1.10.6-scheduler.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-vsphere-1.10.6-scheduler.yaml
@@ -79,7 +79,7 @@ spec:
         - /dev/stdout
         command:
         - /usr/sbin/openvpn
-        image: quay.io/kubermatic/openvpn:v0.6-dev
+        image: quay.io/kubermatic/openvpn:2.4.8
         name: openvpn-client
         resources:
           limits:

--- a/api/pkg/resources/test/fixtures/deployment-vsphere-1.11.0-apiserver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-vsphere-1.11.0-apiserver.yaml
@@ -89,7 +89,7 @@ spec:
         - /dev/stdout
         command:
         - /usr/sbin/openvpn
-        image: quay.io/kubermatic/openvpn:v0.6-dev
+        image: quay.io/kubermatic/openvpn:2.4.8
         name: openvpn-client
         resources:
           limits:

--- a/api/pkg/resources/test/fixtures/deployment-vsphere-1.11.0-apiserver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-vsphere-1.11.0-apiserver.yaml
@@ -89,7 +89,7 @@ spec:
         - /dev/stdout
         command:
         - /usr/sbin/openvpn
-        image: quay.io/kubermatic/openvpn:2.4.8
+        image: quay.io/kubermatic/openvpn:v2.4.8-r1
         name: openvpn-client
         resources:
           limits:

--- a/api/pkg/resources/test/fixtures/deployment-vsphere-1.11.0-apiserver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-vsphere-1.11.0-apiserver.yaml
@@ -89,7 +89,7 @@ spec:
         - /dev/stdout
         command:
         - /usr/sbin/openvpn
-        image: quay.io/kubermatic/openvpn:v0.5
+        image: quay.io/kubermatic/openvpn:v0.6-dev
         name: openvpn-client
         resources:
           limits:

--- a/api/pkg/resources/test/fixtures/deployment-vsphere-1.11.0-controller-manager.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-vsphere-1.11.0-controller-manager.yaml
@@ -81,7 +81,7 @@ spec:
         - /dev/stdout
         command:
         - /usr/sbin/openvpn
-        image: quay.io/kubermatic/openvpn:v0.6-dev
+        image: quay.io/kubermatic/openvpn:2.4.8
         name: openvpn-client
         resources:
           limits:

--- a/api/pkg/resources/test/fixtures/deployment-vsphere-1.11.0-controller-manager.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-vsphere-1.11.0-controller-manager.yaml
@@ -81,7 +81,7 @@ spec:
         - /dev/stdout
         command:
         - /usr/sbin/openvpn
-        image: quay.io/kubermatic/openvpn:v0.5
+        image: quay.io/kubermatic/openvpn:v0.6-dev
         name: openvpn-client
         resources:
           limits:

--- a/api/pkg/resources/test/fixtures/deployment-vsphere-1.11.0-controller-manager.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-vsphere-1.11.0-controller-manager.yaml
@@ -81,7 +81,7 @@ spec:
         - /dev/stdout
         command:
         - /usr/sbin/openvpn
-        image: quay.io/kubermatic/openvpn:2.4.8
+        image: quay.io/kubermatic/openvpn:v2.4.8-r1
         name: openvpn-client
         resources:
           limits:

--- a/api/pkg/resources/test/fixtures/deployment-vsphere-1.11.0-dns-resolver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-vsphere-1.11.0-dns-resolver.yaml
@@ -79,7 +79,7 @@ spec:
         - /dev/stdout
         command:
         - /usr/sbin/openvpn
-        image: quay.io/kubermatic/openvpn:2.4.8
+        image: quay.io/kubermatic/openvpn:v2.4.8-r1
         name: openvpn-client
         resources:
           limits:

--- a/api/pkg/resources/test/fixtures/deployment-vsphere-1.11.0-dns-resolver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-vsphere-1.11.0-dns-resolver.yaml
@@ -79,7 +79,7 @@ spec:
         - /dev/stdout
         command:
         - /usr/sbin/openvpn
-        image: quay.io/kubermatic/openvpn:v0.5
+        image: quay.io/kubermatic/openvpn:v0.6-dev
         name: openvpn-client
         resources:
           limits:

--- a/api/pkg/resources/test/fixtures/deployment-vsphere-1.11.0-dns-resolver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-vsphere-1.11.0-dns-resolver.yaml
@@ -79,7 +79,7 @@ spec:
         - /dev/stdout
         command:
         - /usr/sbin/openvpn
-        image: quay.io/kubermatic/openvpn:v0.6-dev
+        image: quay.io/kubermatic/openvpn:2.4.8
         name: openvpn-client
         resources:
           limits:

--- a/api/pkg/resources/test/fixtures/deployment-vsphere-1.11.0-metrics-server.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-vsphere-1.11.0-metrics-server.yaml
@@ -108,7 +108,7 @@ spec:
         - /dev/stdout
         command:
         - /usr/sbin/openvpn
-        image: quay.io/kubermatic/openvpn:2.4.8
+        image: quay.io/kubermatic/openvpn:v2.4.8-r1
         name: openvpn-client
         resources:
           limits:

--- a/api/pkg/resources/test/fixtures/deployment-vsphere-1.11.0-metrics-server.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-vsphere-1.11.0-metrics-server.yaml
@@ -108,7 +108,7 @@ spec:
         - /dev/stdout
         command:
         - /usr/sbin/openvpn
-        image: quay.io/kubermatic/openvpn:v0.5
+        image: quay.io/kubermatic/openvpn:v0.6-dev
         name: openvpn-client
         resources:
           limits:

--- a/api/pkg/resources/test/fixtures/deployment-vsphere-1.11.0-metrics-server.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-vsphere-1.11.0-metrics-server.yaml
@@ -108,7 +108,7 @@ spec:
         - /dev/stdout
         command:
         - /usr/sbin/openvpn
-        image: quay.io/kubermatic/openvpn:v0.6-dev
+        image: quay.io/kubermatic/openvpn:2.4.8
         name: openvpn-client
         resources:
           limits:

--- a/api/pkg/resources/test/fixtures/deployment-vsphere-1.11.0-openvpn-server.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-vsphere-1.11.0-openvpn-server.yaml
@@ -86,7 +86,7 @@ spec:
         - 255.255.255.0
         command:
         - /usr/sbin/openvpn
-        image: quay.io/kubermatic/openvpn:v0.6-dev
+        image: quay.io/kubermatic/openvpn:2.4.8
         name: openvpn-server
         ports:
         - containerPort: 1194
@@ -135,7 +135,7 @@ spec:
           done
         command:
         - /bin/bash
-        image: quay.io/kubermatic/openvpn:v0.6-dev
+        image: quay.io/kubermatic/openvpn:2.4.8
         name: ip-fixup
         resources:
           limits:
@@ -189,7 +189,7 @@ spec:
           iptables -A INPUT -i tun0 -j DROP
         command:
         - /bin/bash
-        image: quay.io/kubermatic/openvpn:v0.6-dev
+        image: quay.io/kubermatic/openvpn:2.4.8
         name: iptables-init
         resources:
           limits:

--- a/api/pkg/resources/test/fixtures/deployment-vsphere-1.11.0-openvpn-server.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-vsphere-1.11.0-openvpn-server.yaml
@@ -86,7 +86,7 @@ spec:
         - 255.255.255.0
         command:
         - /usr/sbin/openvpn
-        image: quay.io/kubermatic/openvpn:2.4.8
+        image: quay.io/kubermatic/openvpn:v2.4.8-r1
         name: openvpn-server
         ports:
         - containerPort: 1194
@@ -135,7 +135,7 @@ spec:
           done
         command:
         - /bin/bash
-        image: quay.io/kubermatic/openvpn:2.4.8
+        image: quay.io/kubermatic/openvpn:v2.4.8-r1
         name: ip-fixup
         resources:
           limits:
@@ -189,7 +189,7 @@ spec:
           iptables -A INPUT -i tun0 -j DROP
         command:
         - /bin/bash
-        image: quay.io/kubermatic/openvpn:2.4.8
+        image: quay.io/kubermatic/openvpn:v2.4.8-r1
         name: iptables-init
         resources:
           limits:

--- a/api/pkg/resources/test/fixtures/deployment-vsphere-1.11.0-openvpn-server.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-vsphere-1.11.0-openvpn-server.yaml
@@ -86,7 +86,7 @@ spec:
         - 255.255.255.0
         command:
         - /usr/sbin/openvpn
-        image: quay.io/kubermatic/openvpn:v0.5
+        image: quay.io/kubermatic/openvpn:v0.6-dev
         name: openvpn-server
         ports:
         - containerPort: 1194
@@ -135,7 +135,7 @@ spec:
           done
         command:
         - /bin/bash
-        image: quay.io/kubermatic/openvpn:v0.5
+        image: quay.io/kubermatic/openvpn:v0.6-dev
         name: ip-fixup
         resources:
           limits:
@@ -189,7 +189,7 @@ spec:
           iptables -A INPUT -i tun0 -j DROP
         command:
         - /bin/bash
-        image: quay.io/kubermatic/openvpn:v0.5
+        image: quay.io/kubermatic/openvpn:v0.6-dev
         name: iptables-init
         resources:
           limits:

--- a/api/pkg/resources/test/fixtures/deployment-vsphere-1.11.0-scheduler.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-vsphere-1.11.0-scheduler.yaml
@@ -79,7 +79,7 @@ spec:
         - /dev/stdout
         command:
         - /usr/sbin/openvpn
-        image: quay.io/kubermatic/openvpn:2.4.8
+        image: quay.io/kubermatic/openvpn:v2.4.8-r1
         name: openvpn-client
         resources:
           limits:

--- a/api/pkg/resources/test/fixtures/deployment-vsphere-1.11.0-scheduler.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-vsphere-1.11.0-scheduler.yaml
@@ -79,7 +79,7 @@ spec:
         - /dev/stdout
         command:
         - /usr/sbin/openvpn
-        image: quay.io/kubermatic/openvpn:v0.5
+        image: quay.io/kubermatic/openvpn:v0.6-dev
         name: openvpn-client
         resources:
           limits:

--- a/api/pkg/resources/test/fixtures/deployment-vsphere-1.11.0-scheduler.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-vsphere-1.11.0-scheduler.yaml
@@ -79,7 +79,7 @@ spec:
         - /dev/stdout
         command:
         - /usr/sbin/openvpn
-        image: quay.io/kubermatic/openvpn:v0.6-dev
+        image: quay.io/kubermatic/openvpn:2.4.8
         name: openvpn-client
         resources:
           limits:

--- a/api/pkg/resources/test/fixtures/deployment-vsphere-1.11.1-apiserver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-vsphere-1.11.1-apiserver.yaml
@@ -89,7 +89,7 @@ spec:
         - /dev/stdout
         command:
         - /usr/sbin/openvpn
-        image: quay.io/kubermatic/openvpn:v0.6-dev
+        image: quay.io/kubermatic/openvpn:2.4.8
         name: openvpn-client
         resources:
           limits:

--- a/api/pkg/resources/test/fixtures/deployment-vsphere-1.11.1-apiserver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-vsphere-1.11.1-apiserver.yaml
@@ -89,7 +89,7 @@ spec:
         - /dev/stdout
         command:
         - /usr/sbin/openvpn
-        image: quay.io/kubermatic/openvpn:2.4.8
+        image: quay.io/kubermatic/openvpn:v2.4.8-r1
         name: openvpn-client
         resources:
           limits:

--- a/api/pkg/resources/test/fixtures/deployment-vsphere-1.11.1-apiserver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-vsphere-1.11.1-apiserver.yaml
@@ -89,7 +89,7 @@ spec:
         - /dev/stdout
         command:
         - /usr/sbin/openvpn
-        image: quay.io/kubermatic/openvpn:v0.5
+        image: quay.io/kubermatic/openvpn:v0.6-dev
         name: openvpn-client
         resources:
           limits:

--- a/api/pkg/resources/test/fixtures/deployment-vsphere-1.11.1-controller-manager.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-vsphere-1.11.1-controller-manager.yaml
@@ -81,7 +81,7 @@ spec:
         - /dev/stdout
         command:
         - /usr/sbin/openvpn
-        image: quay.io/kubermatic/openvpn:v0.6-dev
+        image: quay.io/kubermatic/openvpn:2.4.8
         name: openvpn-client
         resources:
           limits:

--- a/api/pkg/resources/test/fixtures/deployment-vsphere-1.11.1-controller-manager.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-vsphere-1.11.1-controller-manager.yaml
@@ -81,7 +81,7 @@ spec:
         - /dev/stdout
         command:
         - /usr/sbin/openvpn
-        image: quay.io/kubermatic/openvpn:v0.5
+        image: quay.io/kubermatic/openvpn:v0.6-dev
         name: openvpn-client
         resources:
           limits:

--- a/api/pkg/resources/test/fixtures/deployment-vsphere-1.11.1-controller-manager.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-vsphere-1.11.1-controller-manager.yaml
@@ -81,7 +81,7 @@ spec:
         - /dev/stdout
         command:
         - /usr/sbin/openvpn
-        image: quay.io/kubermatic/openvpn:2.4.8
+        image: quay.io/kubermatic/openvpn:v2.4.8-r1
         name: openvpn-client
         resources:
           limits:

--- a/api/pkg/resources/test/fixtures/deployment-vsphere-1.11.1-dns-resolver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-vsphere-1.11.1-dns-resolver.yaml
@@ -79,7 +79,7 @@ spec:
         - /dev/stdout
         command:
         - /usr/sbin/openvpn
-        image: quay.io/kubermatic/openvpn:2.4.8
+        image: quay.io/kubermatic/openvpn:v2.4.8-r1
         name: openvpn-client
         resources:
           limits:

--- a/api/pkg/resources/test/fixtures/deployment-vsphere-1.11.1-dns-resolver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-vsphere-1.11.1-dns-resolver.yaml
@@ -79,7 +79,7 @@ spec:
         - /dev/stdout
         command:
         - /usr/sbin/openvpn
-        image: quay.io/kubermatic/openvpn:v0.5
+        image: quay.io/kubermatic/openvpn:v0.6-dev
         name: openvpn-client
         resources:
           limits:

--- a/api/pkg/resources/test/fixtures/deployment-vsphere-1.11.1-dns-resolver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-vsphere-1.11.1-dns-resolver.yaml
@@ -79,7 +79,7 @@ spec:
         - /dev/stdout
         command:
         - /usr/sbin/openvpn
-        image: quay.io/kubermatic/openvpn:v0.6-dev
+        image: quay.io/kubermatic/openvpn:2.4.8
         name: openvpn-client
         resources:
           limits:

--- a/api/pkg/resources/test/fixtures/deployment-vsphere-1.11.1-metrics-server.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-vsphere-1.11.1-metrics-server.yaml
@@ -108,7 +108,7 @@ spec:
         - /dev/stdout
         command:
         - /usr/sbin/openvpn
-        image: quay.io/kubermatic/openvpn:2.4.8
+        image: quay.io/kubermatic/openvpn:v2.4.8-r1
         name: openvpn-client
         resources:
           limits:

--- a/api/pkg/resources/test/fixtures/deployment-vsphere-1.11.1-metrics-server.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-vsphere-1.11.1-metrics-server.yaml
@@ -108,7 +108,7 @@ spec:
         - /dev/stdout
         command:
         - /usr/sbin/openvpn
-        image: quay.io/kubermatic/openvpn:v0.5
+        image: quay.io/kubermatic/openvpn:v0.6-dev
         name: openvpn-client
         resources:
           limits:

--- a/api/pkg/resources/test/fixtures/deployment-vsphere-1.11.1-metrics-server.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-vsphere-1.11.1-metrics-server.yaml
@@ -108,7 +108,7 @@ spec:
         - /dev/stdout
         command:
         - /usr/sbin/openvpn
-        image: quay.io/kubermatic/openvpn:v0.6-dev
+        image: quay.io/kubermatic/openvpn:2.4.8
         name: openvpn-client
         resources:
           limits:

--- a/api/pkg/resources/test/fixtures/deployment-vsphere-1.11.1-openvpn-server.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-vsphere-1.11.1-openvpn-server.yaml
@@ -86,7 +86,7 @@ spec:
         - 255.255.255.0
         command:
         - /usr/sbin/openvpn
-        image: quay.io/kubermatic/openvpn:v0.6-dev
+        image: quay.io/kubermatic/openvpn:2.4.8
         name: openvpn-server
         ports:
         - containerPort: 1194
@@ -135,7 +135,7 @@ spec:
           done
         command:
         - /bin/bash
-        image: quay.io/kubermatic/openvpn:v0.6-dev
+        image: quay.io/kubermatic/openvpn:2.4.8
         name: ip-fixup
         resources:
           limits:
@@ -189,7 +189,7 @@ spec:
           iptables -A INPUT -i tun0 -j DROP
         command:
         - /bin/bash
-        image: quay.io/kubermatic/openvpn:v0.6-dev
+        image: quay.io/kubermatic/openvpn:2.4.8
         name: iptables-init
         resources:
           limits:

--- a/api/pkg/resources/test/fixtures/deployment-vsphere-1.11.1-openvpn-server.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-vsphere-1.11.1-openvpn-server.yaml
@@ -86,7 +86,7 @@ spec:
         - 255.255.255.0
         command:
         - /usr/sbin/openvpn
-        image: quay.io/kubermatic/openvpn:2.4.8
+        image: quay.io/kubermatic/openvpn:v2.4.8-r1
         name: openvpn-server
         ports:
         - containerPort: 1194
@@ -135,7 +135,7 @@ spec:
           done
         command:
         - /bin/bash
-        image: quay.io/kubermatic/openvpn:2.4.8
+        image: quay.io/kubermatic/openvpn:v2.4.8-r1
         name: ip-fixup
         resources:
           limits:
@@ -189,7 +189,7 @@ spec:
           iptables -A INPUT -i tun0 -j DROP
         command:
         - /bin/bash
-        image: quay.io/kubermatic/openvpn:2.4.8
+        image: quay.io/kubermatic/openvpn:v2.4.8-r1
         name: iptables-init
         resources:
           limits:

--- a/api/pkg/resources/test/fixtures/deployment-vsphere-1.11.1-openvpn-server.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-vsphere-1.11.1-openvpn-server.yaml
@@ -86,7 +86,7 @@ spec:
         - 255.255.255.0
         command:
         - /usr/sbin/openvpn
-        image: quay.io/kubermatic/openvpn:v0.5
+        image: quay.io/kubermatic/openvpn:v0.6-dev
         name: openvpn-server
         ports:
         - containerPort: 1194
@@ -135,7 +135,7 @@ spec:
           done
         command:
         - /bin/bash
-        image: quay.io/kubermatic/openvpn:v0.5
+        image: quay.io/kubermatic/openvpn:v0.6-dev
         name: ip-fixup
         resources:
           limits:
@@ -189,7 +189,7 @@ spec:
           iptables -A INPUT -i tun0 -j DROP
         command:
         - /bin/bash
-        image: quay.io/kubermatic/openvpn:v0.5
+        image: quay.io/kubermatic/openvpn:v0.6-dev
         name: iptables-init
         resources:
           limits:

--- a/api/pkg/resources/test/fixtures/deployment-vsphere-1.11.1-scheduler.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-vsphere-1.11.1-scheduler.yaml
@@ -79,7 +79,7 @@ spec:
         - /dev/stdout
         command:
         - /usr/sbin/openvpn
-        image: quay.io/kubermatic/openvpn:2.4.8
+        image: quay.io/kubermatic/openvpn:v2.4.8-r1
         name: openvpn-client
         resources:
           limits:

--- a/api/pkg/resources/test/fixtures/deployment-vsphere-1.11.1-scheduler.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-vsphere-1.11.1-scheduler.yaml
@@ -79,7 +79,7 @@ spec:
         - /dev/stdout
         command:
         - /usr/sbin/openvpn
-        image: quay.io/kubermatic/openvpn:v0.5
+        image: quay.io/kubermatic/openvpn:v0.6-dev
         name: openvpn-client
         resources:
           limits:

--- a/api/pkg/resources/test/fixtures/deployment-vsphere-1.11.1-scheduler.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-vsphere-1.11.1-scheduler.yaml
@@ -79,7 +79,7 @@ spec:
         - /dev/stdout
         command:
         - /usr/sbin/openvpn
-        image: quay.io/kubermatic/openvpn:v0.6-dev
+        image: quay.io/kubermatic/openvpn:2.4.8
         name: openvpn-client
         resources:
           limits:

--- a/api/pkg/resources/test/fixtures/deployment-vsphere-1.12.0-apiserver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-vsphere-1.12.0-apiserver.yaml
@@ -89,7 +89,7 @@ spec:
         - /dev/stdout
         command:
         - /usr/sbin/openvpn
-        image: quay.io/kubermatic/openvpn:v0.6-dev
+        image: quay.io/kubermatic/openvpn:2.4.8
         name: openvpn-client
         resources:
           limits:

--- a/api/pkg/resources/test/fixtures/deployment-vsphere-1.12.0-apiserver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-vsphere-1.12.0-apiserver.yaml
@@ -89,7 +89,7 @@ spec:
         - /dev/stdout
         command:
         - /usr/sbin/openvpn
-        image: quay.io/kubermatic/openvpn:2.4.8
+        image: quay.io/kubermatic/openvpn:v2.4.8-r1
         name: openvpn-client
         resources:
           limits:

--- a/api/pkg/resources/test/fixtures/deployment-vsphere-1.12.0-apiserver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-vsphere-1.12.0-apiserver.yaml
@@ -89,7 +89,7 @@ spec:
         - /dev/stdout
         command:
         - /usr/sbin/openvpn
-        image: quay.io/kubermatic/openvpn:v0.5
+        image: quay.io/kubermatic/openvpn:v0.6-dev
         name: openvpn-client
         resources:
           limits:

--- a/api/pkg/resources/test/fixtures/deployment-vsphere-1.12.0-controller-manager.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-vsphere-1.12.0-controller-manager.yaml
@@ -81,7 +81,7 @@ spec:
         - /dev/stdout
         command:
         - /usr/sbin/openvpn
-        image: quay.io/kubermatic/openvpn:v0.6-dev
+        image: quay.io/kubermatic/openvpn:2.4.8
         name: openvpn-client
         resources:
           limits:

--- a/api/pkg/resources/test/fixtures/deployment-vsphere-1.12.0-controller-manager.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-vsphere-1.12.0-controller-manager.yaml
@@ -81,7 +81,7 @@ spec:
         - /dev/stdout
         command:
         - /usr/sbin/openvpn
-        image: quay.io/kubermatic/openvpn:v0.5
+        image: quay.io/kubermatic/openvpn:v0.6-dev
         name: openvpn-client
         resources:
           limits:

--- a/api/pkg/resources/test/fixtures/deployment-vsphere-1.12.0-controller-manager.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-vsphere-1.12.0-controller-manager.yaml
@@ -81,7 +81,7 @@ spec:
         - /dev/stdout
         command:
         - /usr/sbin/openvpn
-        image: quay.io/kubermatic/openvpn:2.4.8
+        image: quay.io/kubermatic/openvpn:v2.4.8-r1
         name: openvpn-client
         resources:
           limits:

--- a/api/pkg/resources/test/fixtures/deployment-vsphere-1.12.0-dns-resolver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-vsphere-1.12.0-dns-resolver.yaml
@@ -79,7 +79,7 @@ spec:
         - /dev/stdout
         command:
         - /usr/sbin/openvpn
-        image: quay.io/kubermatic/openvpn:2.4.8
+        image: quay.io/kubermatic/openvpn:v2.4.8-r1
         name: openvpn-client
         resources:
           limits:

--- a/api/pkg/resources/test/fixtures/deployment-vsphere-1.12.0-dns-resolver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-vsphere-1.12.0-dns-resolver.yaml
@@ -79,7 +79,7 @@ spec:
         - /dev/stdout
         command:
         - /usr/sbin/openvpn
-        image: quay.io/kubermatic/openvpn:v0.5
+        image: quay.io/kubermatic/openvpn:v0.6-dev
         name: openvpn-client
         resources:
           limits:

--- a/api/pkg/resources/test/fixtures/deployment-vsphere-1.12.0-dns-resolver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-vsphere-1.12.0-dns-resolver.yaml
@@ -79,7 +79,7 @@ spec:
         - /dev/stdout
         command:
         - /usr/sbin/openvpn
-        image: quay.io/kubermatic/openvpn:v0.6-dev
+        image: quay.io/kubermatic/openvpn:2.4.8
         name: openvpn-client
         resources:
           limits:

--- a/api/pkg/resources/test/fixtures/deployment-vsphere-1.12.0-metrics-server.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-vsphere-1.12.0-metrics-server.yaml
@@ -108,7 +108,7 @@ spec:
         - /dev/stdout
         command:
         - /usr/sbin/openvpn
-        image: quay.io/kubermatic/openvpn:2.4.8
+        image: quay.io/kubermatic/openvpn:v2.4.8-r1
         name: openvpn-client
         resources:
           limits:

--- a/api/pkg/resources/test/fixtures/deployment-vsphere-1.12.0-metrics-server.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-vsphere-1.12.0-metrics-server.yaml
@@ -108,7 +108,7 @@ spec:
         - /dev/stdout
         command:
         - /usr/sbin/openvpn
-        image: quay.io/kubermatic/openvpn:v0.5
+        image: quay.io/kubermatic/openvpn:v0.6-dev
         name: openvpn-client
         resources:
           limits:

--- a/api/pkg/resources/test/fixtures/deployment-vsphere-1.12.0-metrics-server.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-vsphere-1.12.0-metrics-server.yaml
@@ -108,7 +108,7 @@ spec:
         - /dev/stdout
         command:
         - /usr/sbin/openvpn
-        image: quay.io/kubermatic/openvpn:v0.6-dev
+        image: quay.io/kubermatic/openvpn:2.4.8
         name: openvpn-client
         resources:
           limits:

--- a/api/pkg/resources/test/fixtures/deployment-vsphere-1.12.0-openvpn-server.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-vsphere-1.12.0-openvpn-server.yaml
@@ -86,7 +86,7 @@ spec:
         - 255.255.255.0
         command:
         - /usr/sbin/openvpn
-        image: quay.io/kubermatic/openvpn:v0.6-dev
+        image: quay.io/kubermatic/openvpn:2.4.8
         name: openvpn-server
         ports:
         - containerPort: 1194
@@ -135,7 +135,7 @@ spec:
           done
         command:
         - /bin/bash
-        image: quay.io/kubermatic/openvpn:v0.6-dev
+        image: quay.io/kubermatic/openvpn:2.4.8
         name: ip-fixup
         resources:
           limits:
@@ -189,7 +189,7 @@ spec:
           iptables -A INPUT -i tun0 -j DROP
         command:
         - /bin/bash
-        image: quay.io/kubermatic/openvpn:v0.6-dev
+        image: quay.io/kubermatic/openvpn:2.4.8
         name: iptables-init
         resources:
           limits:

--- a/api/pkg/resources/test/fixtures/deployment-vsphere-1.12.0-openvpn-server.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-vsphere-1.12.0-openvpn-server.yaml
@@ -86,7 +86,7 @@ spec:
         - 255.255.255.0
         command:
         - /usr/sbin/openvpn
-        image: quay.io/kubermatic/openvpn:2.4.8
+        image: quay.io/kubermatic/openvpn:v2.4.8-r1
         name: openvpn-server
         ports:
         - containerPort: 1194
@@ -135,7 +135,7 @@ spec:
           done
         command:
         - /bin/bash
-        image: quay.io/kubermatic/openvpn:2.4.8
+        image: quay.io/kubermatic/openvpn:v2.4.8-r1
         name: ip-fixup
         resources:
           limits:
@@ -189,7 +189,7 @@ spec:
           iptables -A INPUT -i tun0 -j DROP
         command:
         - /bin/bash
-        image: quay.io/kubermatic/openvpn:2.4.8
+        image: quay.io/kubermatic/openvpn:v2.4.8-r1
         name: iptables-init
         resources:
           limits:

--- a/api/pkg/resources/test/fixtures/deployment-vsphere-1.12.0-openvpn-server.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-vsphere-1.12.0-openvpn-server.yaml
@@ -86,7 +86,7 @@ spec:
         - 255.255.255.0
         command:
         - /usr/sbin/openvpn
-        image: quay.io/kubermatic/openvpn:v0.5
+        image: quay.io/kubermatic/openvpn:v0.6-dev
         name: openvpn-server
         ports:
         - containerPort: 1194
@@ -135,7 +135,7 @@ spec:
           done
         command:
         - /bin/bash
-        image: quay.io/kubermatic/openvpn:v0.5
+        image: quay.io/kubermatic/openvpn:v0.6-dev
         name: ip-fixup
         resources:
           limits:
@@ -189,7 +189,7 @@ spec:
           iptables -A INPUT -i tun0 -j DROP
         command:
         - /bin/bash
-        image: quay.io/kubermatic/openvpn:v0.5
+        image: quay.io/kubermatic/openvpn:v0.6-dev
         name: iptables-init
         resources:
           limits:

--- a/api/pkg/resources/test/fixtures/deployment-vsphere-1.12.0-scheduler.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-vsphere-1.12.0-scheduler.yaml
@@ -79,7 +79,7 @@ spec:
         - /dev/stdout
         command:
         - /usr/sbin/openvpn
-        image: quay.io/kubermatic/openvpn:2.4.8
+        image: quay.io/kubermatic/openvpn:v2.4.8-r1
         name: openvpn-client
         resources:
           limits:

--- a/api/pkg/resources/test/fixtures/deployment-vsphere-1.12.0-scheduler.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-vsphere-1.12.0-scheduler.yaml
@@ -79,7 +79,7 @@ spec:
         - /dev/stdout
         command:
         - /usr/sbin/openvpn
-        image: quay.io/kubermatic/openvpn:v0.5
+        image: quay.io/kubermatic/openvpn:v0.6-dev
         name: openvpn-client
         resources:
           limits:

--- a/api/pkg/resources/test/fixtures/deployment-vsphere-1.12.0-scheduler.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-vsphere-1.12.0-scheduler.yaml
@@ -79,7 +79,7 @@ spec:
         - /dev/stdout
         command:
         - /usr/sbin/openvpn
-        image: quay.io/kubermatic/openvpn:v0.6-dev
+        image: quay.io/kubermatic/openvpn:2.4.8
         name: openvpn-client
         resources:
           limits:

--- a/api/pkg/resources/test/fixtures/deployment-vsphere-1.13.0-apiserver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-vsphere-1.13.0-apiserver.yaml
@@ -89,7 +89,7 @@ spec:
         - /dev/stdout
         command:
         - /usr/sbin/openvpn
-        image: quay.io/kubermatic/openvpn:v0.6-dev
+        image: quay.io/kubermatic/openvpn:2.4.8
         name: openvpn-client
         resources:
           limits:

--- a/api/pkg/resources/test/fixtures/deployment-vsphere-1.13.0-apiserver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-vsphere-1.13.0-apiserver.yaml
@@ -89,7 +89,7 @@ spec:
         - /dev/stdout
         command:
         - /usr/sbin/openvpn
-        image: quay.io/kubermatic/openvpn:2.4.8
+        image: quay.io/kubermatic/openvpn:v2.4.8-r1
         name: openvpn-client
         resources:
           limits:

--- a/api/pkg/resources/test/fixtures/deployment-vsphere-1.13.0-apiserver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-vsphere-1.13.0-apiserver.yaml
@@ -89,7 +89,7 @@ spec:
         - /dev/stdout
         command:
         - /usr/sbin/openvpn
-        image: quay.io/kubermatic/openvpn:v0.5
+        image: quay.io/kubermatic/openvpn:v0.6-dev
         name: openvpn-client
         resources:
           limits:

--- a/api/pkg/resources/test/fixtures/deployment-vsphere-1.13.0-controller-manager.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-vsphere-1.13.0-controller-manager.yaml
@@ -81,7 +81,7 @@ spec:
         - /dev/stdout
         command:
         - /usr/sbin/openvpn
-        image: quay.io/kubermatic/openvpn:v0.6-dev
+        image: quay.io/kubermatic/openvpn:2.4.8
         name: openvpn-client
         resources:
           limits:

--- a/api/pkg/resources/test/fixtures/deployment-vsphere-1.13.0-controller-manager.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-vsphere-1.13.0-controller-manager.yaml
@@ -81,7 +81,7 @@ spec:
         - /dev/stdout
         command:
         - /usr/sbin/openvpn
-        image: quay.io/kubermatic/openvpn:v0.5
+        image: quay.io/kubermatic/openvpn:v0.6-dev
         name: openvpn-client
         resources:
           limits:

--- a/api/pkg/resources/test/fixtures/deployment-vsphere-1.13.0-controller-manager.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-vsphere-1.13.0-controller-manager.yaml
@@ -81,7 +81,7 @@ spec:
         - /dev/stdout
         command:
         - /usr/sbin/openvpn
-        image: quay.io/kubermatic/openvpn:2.4.8
+        image: quay.io/kubermatic/openvpn:v2.4.8-r1
         name: openvpn-client
         resources:
           limits:

--- a/api/pkg/resources/test/fixtures/deployment-vsphere-1.13.0-dns-resolver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-vsphere-1.13.0-dns-resolver.yaml
@@ -79,7 +79,7 @@ spec:
         - /dev/stdout
         command:
         - /usr/sbin/openvpn
-        image: quay.io/kubermatic/openvpn:2.4.8
+        image: quay.io/kubermatic/openvpn:v2.4.8-r1
         name: openvpn-client
         resources:
           limits:

--- a/api/pkg/resources/test/fixtures/deployment-vsphere-1.13.0-dns-resolver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-vsphere-1.13.0-dns-resolver.yaml
@@ -79,7 +79,7 @@ spec:
         - /dev/stdout
         command:
         - /usr/sbin/openvpn
-        image: quay.io/kubermatic/openvpn:v0.5
+        image: quay.io/kubermatic/openvpn:v0.6-dev
         name: openvpn-client
         resources:
           limits:

--- a/api/pkg/resources/test/fixtures/deployment-vsphere-1.13.0-dns-resolver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-vsphere-1.13.0-dns-resolver.yaml
@@ -79,7 +79,7 @@ spec:
         - /dev/stdout
         command:
         - /usr/sbin/openvpn
-        image: quay.io/kubermatic/openvpn:v0.6-dev
+        image: quay.io/kubermatic/openvpn:2.4.8
         name: openvpn-client
         resources:
           limits:

--- a/api/pkg/resources/test/fixtures/deployment-vsphere-1.13.0-metrics-server.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-vsphere-1.13.0-metrics-server.yaml
@@ -108,7 +108,7 @@ spec:
         - /dev/stdout
         command:
         - /usr/sbin/openvpn
-        image: quay.io/kubermatic/openvpn:2.4.8
+        image: quay.io/kubermatic/openvpn:v2.4.8-r1
         name: openvpn-client
         resources:
           limits:

--- a/api/pkg/resources/test/fixtures/deployment-vsphere-1.13.0-metrics-server.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-vsphere-1.13.0-metrics-server.yaml
@@ -108,7 +108,7 @@ spec:
         - /dev/stdout
         command:
         - /usr/sbin/openvpn
-        image: quay.io/kubermatic/openvpn:v0.5
+        image: quay.io/kubermatic/openvpn:v0.6-dev
         name: openvpn-client
         resources:
           limits:

--- a/api/pkg/resources/test/fixtures/deployment-vsphere-1.13.0-metrics-server.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-vsphere-1.13.0-metrics-server.yaml
@@ -108,7 +108,7 @@ spec:
         - /dev/stdout
         command:
         - /usr/sbin/openvpn
-        image: quay.io/kubermatic/openvpn:v0.6-dev
+        image: quay.io/kubermatic/openvpn:2.4.8
         name: openvpn-client
         resources:
           limits:

--- a/api/pkg/resources/test/fixtures/deployment-vsphere-1.13.0-openvpn-server.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-vsphere-1.13.0-openvpn-server.yaml
@@ -86,7 +86,7 @@ spec:
         - 255.255.255.0
         command:
         - /usr/sbin/openvpn
-        image: quay.io/kubermatic/openvpn:v0.6-dev
+        image: quay.io/kubermatic/openvpn:2.4.8
         name: openvpn-server
         ports:
         - containerPort: 1194
@@ -135,7 +135,7 @@ spec:
           done
         command:
         - /bin/bash
-        image: quay.io/kubermatic/openvpn:v0.6-dev
+        image: quay.io/kubermatic/openvpn:2.4.8
         name: ip-fixup
         resources:
           limits:
@@ -189,7 +189,7 @@ spec:
           iptables -A INPUT -i tun0 -j DROP
         command:
         - /bin/bash
-        image: quay.io/kubermatic/openvpn:v0.6-dev
+        image: quay.io/kubermatic/openvpn:2.4.8
         name: iptables-init
         resources:
           limits:

--- a/api/pkg/resources/test/fixtures/deployment-vsphere-1.13.0-openvpn-server.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-vsphere-1.13.0-openvpn-server.yaml
@@ -86,7 +86,7 @@ spec:
         - 255.255.255.0
         command:
         - /usr/sbin/openvpn
-        image: quay.io/kubermatic/openvpn:2.4.8
+        image: quay.io/kubermatic/openvpn:v2.4.8-r1
         name: openvpn-server
         ports:
         - containerPort: 1194
@@ -135,7 +135,7 @@ spec:
           done
         command:
         - /bin/bash
-        image: quay.io/kubermatic/openvpn:2.4.8
+        image: quay.io/kubermatic/openvpn:v2.4.8-r1
         name: ip-fixup
         resources:
           limits:
@@ -189,7 +189,7 @@ spec:
           iptables -A INPUT -i tun0 -j DROP
         command:
         - /bin/bash
-        image: quay.io/kubermatic/openvpn:2.4.8
+        image: quay.io/kubermatic/openvpn:v2.4.8-r1
         name: iptables-init
         resources:
           limits:

--- a/api/pkg/resources/test/fixtures/deployment-vsphere-1.13.0-openvpn-server.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-vsphere-1.13.0-openvpn-server.yaml
@@ -86,7 +86,7 @@ spec:
         - 255.255.255.0
         command:
         - /usr/sbin/openvpn
-        image: quay.io/kubermatic/openvpn:v0.5
+        image: quay.io/kubermatic/openvpn:v0.6-dev
         name: openvpn-server
         ports:
         - containerPort: 1194
@@ -135,7 +135,7 @@ spec:
           done
         command:
         - /bin/bash
-        image: quay.io/kubermatic/openvpn:v0.5
+        image: quay.io/kubermatic/openvpn:v0.6-dev
         name: ip-fixup
         resources:
           limits:
@@ -189,7 +189,7 @@ spec:
           iptables -A INPUT -i tun0 -j DROP
         command:
         - /bin/bash
-        image: quay.io/kubermatic/openvpn:v0.5
+        image: quay.io/kubermatic/openvpn:v0.6-dev
         name: iptables-init
         resources:
           limits:

--- a/api/pkg/resources/test/fixtures/deployment-vsphere-1.13.0-scheduler.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-vsphere-1.13.0-scheduler.yaml
@@ -79,7 +79,7 @@ spec:
         - /dev/stdout
         command:
         - /usr/sbin/openvpn
-        image: quay.io/kubermatic/openvpn:2.4.8
+        image: quay.io/kubermatic/openvpn:v2.4.8-r1
         name: openvpn-client
         resources:
           limits:

--- a/api/pkg/resources/test/fixtures/deployment-vsphere-1.13.0-scheduler.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-vsphere-1.13.0-scheduler.yaml
@@ -79,7 +79,7 @@ spec:
         - /dev/stdout
         command:
         - /usr/sbin/openvpn
-        image: quay.io/kubermatic/openvpn:v0.5
+        image: quay.io/kubermatic/openvpn:v0.6-dev
         name: openvpn-client
         resources:
           limits:

--- a/api/pkg/resources/test/fixtures/deployment-vsphere-1.13.0-scheduler.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-vsphere-1.13.0-scheduler.yaml
@@ -79,7 +79,7 @@ spec:
         - /dev/stdout
         command:
         - /usr/sbin/openvpn
-        image: quay.io/kubermatic/openvpn:v0.6-dev
+        image: quay.io/kubermatic/openvpn:2.4.8
         name: openvpn-client
         resources:
           limits:

--- a/api/pkg/resources/vpnsidecar/openvpnClient.go
+++ b/api/pkg/resources/vpnsidecar/openvpnClient.go
@@ -34,7 +34,7 @@ type openvpnData interface {
 func OpenVPNSidecarContainer(data openvpnData, name string) (*corev1.Container, error) {
 	return &corev1.Container{
 		Name:    name,
-		Image:   data.ImageRegistry(resources.RegistryQuay) + "/kubermatic/openvpn:v0.5",
+		Image:   data.ImageRegistry(resources.RegistryQuay) + "/kubermatic/openvpn:v0.6-dev",
 		Command: []string{"/usr/sbin/openvpn"},
 		Args: []string{
 			"--client",

--- a/api/pkg/resources/vpnsidecar/openvpnClient.go
+++ b/api/pkg/resources/vpnsidecar/openvpnClient.go
@@ -34,7 +34,7 @@ type openvpnData interface {
 func OpenVPNSidecarContainer(data openvpnData, name string) (*corev1.Container, error) {
 	return &corev1.Container{
 		Name:    name,
-		Image:   data.ImageRegistry(resources.RegistryQuay) + "/kubermatic/openvpn:2.4.8",
+		Image:   data.ImageRegistry(resources.RegistryQuay) + "/kubermatic/openvpn:v2.4.8-r1",
 		Command: []string{"/usr/sbin/openvpn"},
 		Args: []string{
 			"--client",

--- a/api/pkg/resources/vpnsidecar/openvpnClient.go
+++ b/api/pkg/resources/vpnsidecar/openvpnClient.go
@@ -34,7 +34,7 @@ type openvpnData interface {
 func OpenVPNSidecarContainer(data openvpnData, name string) (*corev1.Container, error) {
 	return &corev1.Container{
 		Name:    name,
-		Image:   data.ImageRegistry(resources.RegistryQuay) + "/kubermatic/openvpn:v0.6-dev",
+		Image:   data.ImageRegistry(resources.RegistryQuay) + "/kubermatic/openvpn:2.4.8",
 		Command: []string{"/usr/sbin/openvpn"},
 		Args: []string{
 			"--client",

--- a/containers/openvpn/Dockerfile
+++ b/containers/openvpn/Dockerfile
@@ -1,4 +1,4 @@
-FROM alpine:3.9
+FROM alpine:3.11
 LABEL maintainer="support@loodse.com"
 
 RUN apk add -U \

--- a/containers/openvpn/Dockerfile
+++ b/containers/openvpn/Dockerfile
@@ -8,7 +8,7 @@ RUN apk add -U \
 	iptables \
 	jq \
 	openssl \
-	openvpn \
+	openvpn=2.4.8-r1 \
 	--no-cache
 
 # add kubectl

--- a/containers/openvpn/Dockerfile
+++ b/containers/openvpn/Dockerfile
@@ -1,4 +1,5 @@
 FROM alpine:3.11
+ARG OPENVPN_VERSION
 LABEL maintainer="support@loodse.com"
 
 RUN apk add -U \
@@ -8,7 +9,7 @@ RUN apk add -U \
 	iptables \
 	jq \
 	openssl \
-	openvpn=2.4.8-r1 \
+	openvpn=$OPENVPN_VERSION \
 	--no-cache
 
 # add kubectl

--- a/containers/openvpn/release.sh
+++ b/containers/openvpn/release.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 
-ver=v0.5
+ver=v0.6
 
 set -euox pipefail
 

--- a/containers/openvpn/release.sh
+++ b/containers/openvpn/release.sh
@@ -1,8 +1,8 @@
 #!/usr/bin/env bash
 
-ver=v2.4.8
+ver=2.4.8-r1
 
 set -euox pipefail
 
-docker build --no-cache --pull -t quay.io/kubermatic/openvpn:$ver .
-docker push quay.io/kubermatic/openvpn:$ver
+docker build --build-arg OPENVPN_VERSION=${ver} --no-cache --pull -t quay.io/kubermatic/openvpn:v${ver} .
+docker push quay.io/kubermatic/openvpn:v${ver}

--- a/containers/openvpn/release.sh
+++ b/containers/openvpn/release.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 
-ver=v0.6
+ver=v0.6-dev
 
 set -euox pipefail
 

--- a/containers/openvpn/release.sh
+++ b/containers/openvpn/release.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 
-ver=v0.6-dev
+ver=v2.4.8
 
 set -euox pipefail
 

--- a/openshift_addons/openvpn/openvpn-client-dep.yaml
+++ b/openshift_addons/openvpn/openvpn-client-dep.yaml
@@ -18,7 +18,7 @@ spec:
       serviceAccountName: vpn-client
       containers:
       - name: openvpn-client
-        image: '{{ Registry "quay.io" }}/kubermatic/openvpn:v0.6-dev'
+        image: '{{ Registry "quay.io" }}/kubermatic/openvpn:2.4.8'
         command: ["/usr/sbin/openvpn"]
         args: ["--config", "/etc/openvpn/config/config"]
         resources:
@@ -57,7 +57,7 @@ spec:
           name: openvpn-client-certificates
           readOnly: true
       - name: dnat-controller
-        image: '{{ Registry "quay.io" }}/kubermatic/openvpn:v0.6-dev'
+        image: '{{ Registry "quay.io" }}/kubermatic/openvpn:2.4.8'
         command:
         - bash
         - -ec

--- a/openshift_addons/openvpn/openvpn-client-dep.yaml
+++ b/openshift_addons/openvpn/openvpn-client-dep.yaml
@@ -18,7 +18,7 @@ spec:
       serviceAccountName: vpn-client
       containers:
       - name: openvpn-client
-        image: '{{ Registry "quay.io" }}/kubermatic/openvpn:v0.5'
+        image: '{{ Registry "quay.io" }}/kubermatic/openvpn:v0.6-dev'
         command: ["/usr/sbin/openvpn"]
         args: ["--config", "/etc/openvpn/config/config"]
         resources:
@@ -57,7 +57,7 @@ spec:
           name: openvpn-client-certificates
           readOnly: true
       - name: dnat-controller
-        image: '{{ Registry "quay.io" }}/kubermatic/openvpn:v0.5'
+        image: '{{ Registry "quay.io" }}/kubermatic/openvpn:v0.6-dev'
         command:
         - bash
         - -ec

--- a/openshift_addons/openvpn/openvpn-client-dep.yaml
+++ b/openshift_addons/openvpn/openvpn-client-dep.yaml
@@ -18,7 +18,7 @@ spec:
       serviceAccountName: vpn-client
       containers:
       - name: openvpn-client
-        image: '{{ Registry "quay.io" }}/kubermatic/openvpn:2.4.8'
+        image: '{{ Registry "quay.io" }}/kubermatic/openvpn:v2.4.8-r1'
         command: ["/usr/sbin/openvpn"]
         args: ["--config", "/etc/openvpn/config/config"]
         resources:
@@ -57,7 +57,7 @@ spec:
           name: openvpn-client-certificates
           readOnly: true
       - name: dnat-controller
-        image: '{{ Registry "quay.io" }}/kubermatic/openvpn:2.4.8'
+        image: '{{ Registry "quay.io" }}/kubermatic/openvpn:v2.4.8-r1'
         command:
         - bash
         - -ec

--- a/openshift_addons/release.sh
+++ b/openshift_addons/release.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 
 set -ex
-export TAG=v0.10-dev
+export TAG=v0.9
 
 docker build -t quay.io/kubermatic/openshift-addons:${TAG} .
 docker push quay.io/kubermatic/openshift-addons:${TAG}

--- a/openshift_addons/release.sh
+++ b/openshift_addons/release.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 
 set -ex
-export TAG=v0.9
+export TAG=v0.10-dev
 
 docker build -t quay.io/kubermatic/openshift-addons:${TAG} .
 docker push quay.io/kubermatic/openshift-addons:${TAG}


### PR DESCRIPTION
**What this PR does / why we need it**:
Openvpn update to v2.4.8. Security fixes, improvements etc.

This will update:
_ Openvpn for the user-clusters (control plane side and on worker nodes)
_ vpnsidecar
_ openshift addons

**Documentation**:
<!-- Add links to the related documentation changes related to this pull request. E.g. the link to the kubermatic/docs pullrequest. -->
Release note: 
- https://github.com/OpenVPN/openvpn/releases/tag/v2.4.8
- https://github.com/OpenVPN/openvpn/releases/tag/v2.4.7


**Does this PR introduce a user-facing change?**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If  no release note is required, just write "NONE".
-->
```release-note
Update openvpn to 2.4.8
```
