### PR TITLE
Update coredns to v1.3.1

### DIFF
--- a/addons/dns/coredns-deployment.yaml
+++ b/addons/dns/coredns-deployment.yaml
@@ -80,7 +80,7 @@ spec:
         beta.kubernetes.io/os: linux
       containers:
       - name: coredns
-        image: '{{ Registry "docker.io" }}/coredns/coredns:1.6.7'
+        image: '{{ Registry "docker.io" }}/coredns/coredns:1.3.1'
         imagePullPolicy: IfNotPresent
         resources:
           limits:

--- a/addons/dns/coredns-deployment.yaml
+++ b/addons/dns/coredns-deployment.yaml
@@ -80,7 +80,7 @@ spec:
         beta.kubernetes.io/os: linux
       containers:
       - name: coredns
-        image: '{{ Registry "docker.io" }}/coredns/coredns:1.3.1'
+        image: '{{ Registry "docker.io" }}/coredns/coredns:1.6.7'
         imagePullPolicy: IfNotPresent
         resources:
           limits:

--- a/api/pkg/resources/dns/dns.go
+++ b/api/pkg/resources/dns/dns.go
@@ -93,7 +93,7 @@ func DeploymentCreator(data deploymentCreatorData) reconciling.NamedDeploymentCr
 				*openvpnSidecar,
 				{
 					Name:  resources.DNSResolverDeploymentName,
-					Image: data.ImageRegistry(resources.RegistryGCR) + "/google_containers/coredns:1.1.3",
+					Image: data.ImageRegistry(resources.RegistryGCR) + "/google_containers/coredns:1.6.7",
 					Args:  []string{"-conf", "/etc/coredns/Corefile"},
 					VolumeMounts: []corev1.VolumeMount{
 						{

--- a/api/pkg/resources/dns/dns.go
+++ b/api/pkg/resources/dns/dns.go
@@ -93,7 +93,7 @@ func DeploymentCreator(data deploymentCreatorData) reconciling.NamedDeploymentCr
 				*openvpnSidecar,
 				{
 					Name:  resources.DNSResolverDeploymentName,
-					Image: data.ImageRegistry(resources.RegistryGCR) + "/google_containers/coredns:1.6.7",
+					Image: data.ImageRegistry(resources.RegistryGCR) + "/google_containers/coredns:1.3.1",
 					Args:  []string{"-conf", "/etc/coredns/Corefile"},
 					VolumeMounts: []corev1.VolumeMount{
 						{

--- a/api/pkg/resources/test/fixtures/deployment-aws-1.10.0-dns-resolver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-aws-1.10.0-dns-resolver.yaml
@@ -97,7 +97,7 @@ spec:
       - args:
         - -conf
         - /etc/coredns/Corefile
-        image: gcr.io/google_containers/coredns:1.1.3
+        image: gcr.io/google_containers/coredns:1.6.7
         name: dns-resolver
         readinessProbe:
           failureThreshold: 3

--- a/api/pkg/resources/test/fixtures/deployment-aws-1.10.0-dns-resolver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-aws-1.10.0-dns-resolver.yaml
@@ -97,7 +97,7 @@ spec:
       - args:
         - -conf
         - /etc/coredns/Corefile
-        image: gcr.io/google_containers/coredns:1.6.7
+        image: gcr.io/google_containers/coredns:1.3.1
         name: dns-resolver
         readinessProbe:
           failureThreshold: 3

--- a/api/pkg/resources/test/fixtures/deployment-aws-1.10.6-dns-resolver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-aws-1.10.6-dns-resolver.yaml
@@ -97,7 +97,7 @@ spec:
       - args:
         - -conf
         - /etc/coredns/Corefile
-        image: gcr.io/google_containers/coredns:1.1.3
+        image: gcr.io/google_containers/coredns:1.6.7
         name: dns-resolver
         readinessProbe:
           failureThreshold: 3

--- a/api/pkg/resources/test/fixtures/deployment-aws-1.10.6-dns-resolver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-aws-1.10.6-dns-resolver.yaml
@@ -97,7 +97,7 @@ spec:
       - args:
         - -conf
         - /etc/coredns/Corefile
-        image: gcr.io/google_containers/coredns:1.6.7
+        image: gcr.io/google_containers/coredns:1.3.1
         name: dns-resolver
         readinessProbe:
           failureThreshold: 3

--- a/api/pkg/resources/test/fixtures/deployment-aws-1.11.0-dns-resolver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-aws-1.11.0-dns-resolver.yaml
@@ -97,7 +97,7 @@ spec:
       - args:
         - -conf
         - /etc/coredns/Corefile
-        image: gcr.io/google_containers/coredns:1.1.3
+        image: gcr.io/google_containers/coredns:1.6.7
         name: dns-resolver
         readinessProbe:
           failureThreshold: 3

--- a/api/pkg/resources/test/fixtures/deployment-aws-1.11.0-dns-resolver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-aws-1.11.0-dns-resolver.yaml
@@ -97,7 +97,7 @@ spec:
       - args:
         - -conf
         - /etc/coredns/Corefile
-        image: gcr.io/google_containers/coredns:1.6.7
+        image: gcr.io/google_containers/coredns:1.3.1
         name: dns-resolver
         readinessProbe:
           failureThreshold: 3

--- a/api/pkg/resources/test/fixtures/deployment-aws-1.11.1-dns-resolver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-aws-1.11.1-dns-resolver.yaml
@@ -97,7 +97,7 @@ spec:
       - args:
         - -conf
         - /etc/coredns/Corefile
-        image: gcr.io/google_containers/coredns:1.1.3
+        image: gcr.io/google_containers/coredns:1.6.7
         name: dns-resolver
         readinessProbe:
           failureThreshold: 3

--- a/api/pkg/resources/test/fixtures/deployment-aws-1.11.1-dns-resolver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-aws-1.11.1-dns-resolver.yaml
@@ -97,7 +97,7 @@ spec:
       - args:
         - -conf
         - /etc/coredns/Corefile
-        image: gcr.io/google_containers/coredns:1.6.7
+        image: gcr.io/google_containers/coredns:1.3.1
         name: dns-resolver
         readinessProbe:
           failureThreshold: 3

--- a/api/pkg/resources/test/fixtures/deployment-aws-1.12.0-dns-resolver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-aws-1.12.0-dns-resolver.yaml
@@ -97,7 +97,7 @@ spec:
       - args:
         - -conf
         - /etc/coredns/Corefile
-        image: gcr.io/google_containers/coredns:1.1.3
+        image: gcr.io/google_containers/coredns:1.6.7
         name: dns-resolver
         readinessProbe:
           failureThreshold: 3

--- a/api/pkg/resources/test/fixtures/deployment-aws-1.12.0-dns-resolver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-aws-1.12.0-dns-resolver.yaml
@@ -97,7 +97,7 @@ spec:
       - args:
         - -conf
         - /etc/coredns/Corefile
-        image: gcr.io/google_containers/coredns:1.6.7
+        image: gcr.io/google_containers/coredns:1.3.1
         name: dns-resolver
         readinessProbe:
           failureThreshold: 3

--- a/api/pkg/resources/test/fixtures/deployment-aws-1.13.0-dns-resolver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-aws-1.13.0-dns-resolver.yaml
@@ -97,7 +97,7 @@ spec:
       - args:
         - -conf
         - /etc/coredns/Corefile
-        image: gcr.io/google_containers/coredns:1.1.3
+        image: gcr.io/google_containers/coredns:1.6.7
         name: dns-resolver
         readinessProbe:
           failureThreshold: 3

--- a/api/pkg/resources/test/fixtures/deployment-aws-1.13.0-dns-resolver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-aws-1.13.0-dns-resolver.yaml
@@ -97,7 +97,7 @@ spec:
       - args:
         - -conf
         - /etc/coredns/Corefile
-        image: gcr.io/google_containers/coredns:1.6.7
+        image: gcr.io/google_containers/coredns:1.3.1
         name: dns-resolver
         readinessProbe:
           failureThreshold: 3

--- a/api/pkg/resources/test/fixtures/deployment-azure-1.10.0-dns-resolver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-azure-1.10.0-dns-resolver.yaml
@@ -97,7 +97,7 @@ spec:
       - args:
         - -conf
         - /etc/coredns/Corefile
-        image: gcr.io/google_containers/coredns:1.1.3
+        image: gcr.io/google_containers/coredns:1.6.7
         name: dns-resolver
         readinessProbe:
           failureThreshold: 3

--- a/api/pkg/resources/test/fixtures/deployment-azure-1.10.0-dns-resolver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-azure-1.10.0-dns-resolver.yaml
@@ -97,7 +97,7 @@ spec:
       - args:
         - -conf
         - /etc/coredns/Corefile
-        image: gcr.io/google_containers/coredns:1.6.7
+        image: gcr.io/google_containers/coredns:1.3.1
         name: dns-resolver
         readinessProbe:
           failureThreshold: 3

--- a/api/pkg/resources/test/fixtures/deployment-azure-1.10.6-dns-resolver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-azure-1.10.6-dns-resolver.yaml
@@ -97,7 +97,7 @@ spec:
       - args:
         - -conf
         - /etc/coredns/Corefile
-        image: gcr.io/google_containers/coredns:1.1.3
+        image: gcr.io/google_containers/coredns:1.6.7
         name: dns-resolver
         readinessProbe:
           failureThreshold: 3

--- a/api/pkg/resources/test/fixtures/deployment-azure-1.10.6-dns-resolver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-azure-1.10.6-dns-resolver.yaml
@@ -97,7 +97,7 @@ spec:
       - args:
         - -conf
         - /etc/coredns/Corefile
-        image: gcr.io/google_containers/coredns:1.6.7
+        image: gcr.io/google_containers/coredns:1.3.1
         name: dns-resolver
         readinessProbe:
           failureThreshold: 3

--- a/api/pkg/resources/test/fixtures/deployment-azure-1.11.0-dns-resolver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-azure-1.11.0-dns-resolver.yaml
@@ -97,7 +97,7 @@ spec:
       - args:
         - -conf
         - /etc/coredns/Corefile
-        image: gcr.io/google_containers/coredns:1.1.3
+        image: gcr.io/google_containers/coredns:1.6.7
         name: dns-resolver
         readinessProbe:
           failureThreshold: 3

--- a/api/pkg/resources/test/fixtures/deployment-azure-1.11.0-dns-resolver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-azure-1.11.0-dns-resolver.yaml
@@ -97,7 +97,7 @@ spec:
       - args:
         - -conf
         - /etc/coredns/Corefile
-        image: gcr.io/google_containers/coredns:1.6.7
+        image: gcr.io/google_containers/coredns:1.3.1
         name: dns-resolver
         readinessProbe:
           failureThreshold: 3

--- a/api/pkg/resources/test/fixtures/deployment-azure-1.11.1-dns-resolver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-azure-1.11.1-dns-resolver.yaml
@@ -97,7 +97,7 @@ spec:
       - args:
         - -conf
         - /etc/coredns/Corefile
-        image: gcr.io/google_containers/coredns:1.1.3
+        image: gcr.io/google_containers/coredns:1.6.7
         name: dns-resolver
         readinessProbe:
           failureThreshold: 3

--- a/api/pkg/resources/test/fixtures/deployment-azure-1.11.1-dns-resolver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-azure-1.11.1-dns-resolver.yaml
@@ -97,7 +97,7 @@ spec:
       - args:
         - -conf
         - /etc/coredns/Corefile
-        image: gcr.io/google_containers/coredns:1.6.7
+        image: gcr.io/google_containers/coredns:1.3.1
         name: dns-resolver
         readinessProbe:
           failureThreshold: 3

--- a/api/pkg/resources/test/fixtures/deployment-azure-1.12.0-dns-resolver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-azure-1.12.0-dns-resolver.yaml
@@ -97,7 +97,7 @@ spec:
       - args:
         - -conf
         - /etc/coredns/Corefile
-        image: gcr.io/google_containers/coredns:1.1.3
+        image: gcr.io/google_containers/coredns:1.6.7
         name: dns-resolver
         readinessProbe:
           failureThreshold: 3

--- a/api/pkg/resources/test/fixtures/deployment-azure-1.12.0-dns-resolver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-azure-1.12.0-dns-resolver.yaml
@@ -97,7 +97,7 @@ spec:
       - args:
         - -conf
         - /etc/coredns/Corefile
-        image: gcr.io/google_containers/coredns:1.6.7
+        image: gcr.io/google_containers/coredns:1.3.1
         name: dns-resolver
         readinessProbe:
           failureThreshold: 3

--- a/api/pkg/resources/test/fixtures/deployment-azure-1.13.0-dns-resolver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-azure-1.13.0-dns-resolver.yaml
@@ -97,7 +97,7 @@ spec:
       - args:
         - -conf
         - /etc/coredns/Corefile
-        image: gcr.io/google_containers/coredns:1.1.3
+        image: gcr.io/google_containers/coredns:1.6.7
         name: dns-resolver
         readinessProbe:
           failureThreshold: 3

--- a/api/pkg/resources/test/fixtures/deployment-azure-1.13.0-dns-resolver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-azure-1.13.0-dns-resolver.yaml
@@ -97,7 +97,7 @@ spec:
       - args:
         - -conf
         - /etc/coredns/Corefile
-        image: gcr.io/google_containers/coredns:1.6.7
+        image: gcr.io/google_containers/coredns:1.3.1
         name: dns-resolver
         readinessProbe:
           failureThreshold: 3

--- a/api/pkg/resources/test/fixtures/deployment-bringyourown-1.10.0-dns-resolver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-bringyourown-1.10.0-dns-resolver.yaml
@@ -97,7 +97,7 @@ spec:
       - args:
         - -conf
         - /etc/coredns/Corefile
-        image: gcr.io/google_containers/coredns:1.1.3
+        image: gcr.io/google_containers/coredns:1.6.7
         name: dns-resolver
         readinessProbe:
           failureThreshold: 3

--- a/api/pkg/resources/test/fixtures/deployment-bringyourown-1.10.0-dns-resolver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-bringyourown-1.10.0-dns-resolver.yaml
@@ -97,7 +97,7 @@ spec:
       - args:
         - -conf
         - /etc/coredns/Corefile
-        image: gcr.io/google_containers/coredns:1.6.7
+        image: gcr.io/google_containers/coredns:1.3.1
         name: dns-resolver
         readinessProbe:
           failureThreshold: 3

--- a/api/pkg/resources/test/fixtures/deployment-bringyourown-1.10.6-dns-resolver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-bringyourown-1.10.6-dns-resolver.yaml
@@ -97,7 +97,7 @@ spec:
       - args:
         - -conf
         - /etc/coredns/Corefile
-        image: gcr.io/google_containers/coredns:1.1.3
+        image: gcr.io/google_containers/coredns:1.6.7
         name: dns-resolver
         readinessProbe:
           failureThreshold: 3

--- a/api/pkg/resources/test/fixtures/deployment-bringyourown-1.10.6-dns-resolver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-bringyourown-1.10.6-dns-resolver.yaml
@@ -97,7 +97,7 @@ spec:
       - args:
         - -conf
         - /etc/coredns/Corefile
-        image: gcr.io/google_containers/coredns:1.6.7
+        image: gcr.io/google_containers/coredns:1.3.1
         name: dns-resolver
         readinessProbe:
           failureThreshold: 3

--- a/api/pkg/resources/test/fixtures/deployment-bringyourown-1.11.0-dns-resolver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-bringyourown-1.11.0-dns-resolver.yaml
@@ -97,7 +97,7 @@ spec:
       - args:
         - -conf
         - /etc/coredns/Corefile
-        image: gcr.io/google_containers/coredns:1.1.3
+        image: gcr.io/google_containers/coredns:1.6.7
         name: dns-resolver
         readinessProbe:
           failureThreshold: 3

--- a/api/pkg/resources/test/fixtures/deployment-bringyourown-1.11.0-dns-resolver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-bringyourown-1.11.0-dns-resolver.yaml
@@ -97,7 +97,7 @@ spec:
       - args:
         - -conf
         - /etc/coredns/Corefile
-        image: gcr.io/google_containers/coredns:1.6.7
+        image: gcr.io/google_containers/coredns:1.3.1
         name: dns-resolver
         readinessProbe:
           failureThreshold: 3

--- a/api/pkg/resources/test/fixtures/deployment-bringyourown-1.11.1-dns-resolver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-bringyourown-1.11.1-dns-resolver.yaml
@@ -97,7 +97,7 @@ spec:
       - args:
         - -conf
         - /etc/coredns/Corefile
-        image: gcr.io/google_containers/coredns:1.1.3
+        image: gcr.io/google_containers/coredns:1.6.7
         name: dns-resolver
         readinessProbe:
           failureThreshold: 3

--- a/api/pkg/resources/test/fixtures/deployment-bringyourown-1.11.1-dns-resolver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-bringyourown-1.11.1-dns-resolver.yaml
@@ -97,7 +97,7 @@ spec:
       - args:
         - -conf
         - /etc/coredns/Corefile
-        image: gcr.io/google_containers/coredns:1.6.7
+        image: gcr.io/google_containers/coredns:1.3.1
         name: dns-resolver
         readinessProbe:
           failureThreshold: 3

--- a/api/pkg/resources/test/fixtures/deployment-bringyourown-1.12.0-dns-resolver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-bringyourown-1.12.0-dns-resolver.yaml
@@ -97,7 +97,7 @@ spec:
       - args:
         - -conf
         - /etc/coredns/Corefile
-        image: gcr.io/google_containers/coredns:1.1.3
+        image: gcr.io/google_containers/coredns:1.6.7
         name: dns-resolver
         readinessProbe:
           failureThreshold: 3

--- a/api/pkg/resources/test/fixtures/deployment-bringyourown-1.12.0-dns-resolver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-bringyourown-1.12.0-dns-resolver.yaml
@@ -97,7 +97,7 @@ spec:
       - args:
         - -conf
         - /etc/coredns/Corefile
-        image: gcr.io/google_containers/coredns:1.6.7
+        image: gcr.io/google_containers/coredns:1.3.1
         name: dns-resolver
         readinessProbe:
           failureThreshold: 3

--- a/api/pkg/resources/test/fixtures/deployment-bringyourown-1.13.0-dns-resolver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-bringyourown-1.13.0-dns-resolver.yaml
@@ -97,7 +97,7 @@ spec:
       - args:
         - -conf
         - /etc/coredns/Corefile
-        image: gcr.io/google_containers/coredns:1.1.3
+        image: gcr.io/google_containers/coredns:1.6.7
         name: dns-resolver
         readinessProbe:
           failureThreshold: 3

--- a/api/pkg/resources/test/fixtures/deployment-bringyourown-1.13.0-dns-resolver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-bringyourown-1.13.0-dns-resolver.yaml
@@ -97,7 +97,7 @@ spec:
       - args:
         - -conf
         - /etc/coredns/Corefile
-        image: gcr.io/google_containers/coredns:1.6.7
+        image: gcr.io/google_containers/coredns:1.3.1
         name: dns-resolver
         readinessProbe:
           failureThreshold: 3

--- a/api/pkg/resources/test/fixtures/deployment-digitalocean-1.10.0-dns-resolver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-digitalocean-1.10.0-dns-resolver.yaml
@@ -97,7 +97,7 @@ spec:
       - args:
         - -conf
         - /etc/coredns/Corefile
-        image: gcr.io/google_containers/coredns:1.1.3
+        image: gcr.io/google_containers/coredns:1.6.7
         name: dns-resolver
         readinessProbe:
           failureThreshold: 3

--- a/api/pkg/resources/test/fixtures/deployment-digitalocean-1.10.0-dns-resolver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-digitalocean-1.10.0-dns-resolver.yaml
@@ -97,7 +97,7 @@ spec:
       - args:
         - -conf
         - /etc/coredns/Corefile
-        image: gcr.io/google_containers/coredns:1.6.7
+        image: gcr.io/google_containers/coredns:1.3.1
         name: dns-resolver
         readinessProbe:
           failureThreshold: 3

--- a/api/pkg/resources/test/fixtures/deployment-digitalocean-1.10.6-dns-resolver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-digitalocean-1.10.6-dns-resolver.yaml
@@ -97,7 +97,7 @@ spec:
       - args:
         - -conf
         - /etc/coredns/Corefile
-        image: gcr.io/google_containers/coredns:1.1.3
+        image: gcr.io/google_containers/coredns:1.6.7
         name: dns-resolver
         readinessProbe:
           failureThreshold: 3

--- a/api/pkg/resources/test/fixtures/deployment-digitalocean-1.10.6-dns-resolver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-digitalocean-1.10.6-dns-resolver.yaml
@@ -97,7 +97,7 @@ spec:
       - args:
         - -conf
         - /etc/coredns/Corefile
-        image: gcr.io/google_containers/coredns:1.6.7
+        image: gcr.io/google_containers/coredns:1.3.1
         name: dns-resolver
         readinessProbe:
           failureThreshold: 3

--- a/api/pkg/resources/test/fixtures/deployment-digitalocean-1.11.0-dns-resolver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-digitalocean-1.11.0-dns-resolver.yaml
@@ -97,7 +97,7 @@ spec:
       - args:
         - -conf
         - /etc/coredns/Corefile
-        image: gcr.io/google_containers/coredns:1.1.3
+        image: gcr.io/google_containers/coredns:1.6.7
         name: dns-resolver
         readinessProbe:
           failureThreshold: 3

--- a/api/pkg/resources/test/fixtures/deployment-digitalocean-1.11.0-dns-resolver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-digitalocean-1.11.0-dns-resolver.yaml
@@ -97,7 +97,7 @@ spec:
       - args:
         - -conf
         - /etc/coredns/Corefile
-        image: gcr.io/google_containers/coredns:1.6.7
+        image: gcr.io/google_containers/coredns:1.3.1
         name: dns-resolver
         readinessProbe:
           failureThreshold: 3

--- a/api/pkg/resources/test/fixtures/deployment-digitalocean-1.11.1-dns-resolver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-digitalocean-1.11.1-dns-resolver.yaml
@@ -97,7 +97,7 @@ spec:
       - args:
         - -conf
         - /etc/coredns/Corefile
-        image: gcr.io/google_containers/coredns:1.1.3
+        image: gcr.io/google_containers/coredns:1.6.7
         name: dns-resolver
         readinessProbe:
           failureThreshold: 3

--- a/api/pkg/resources/test/fixtures/deployment-digitalocean-1.11.1-dns-resolver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-digitalocean-1.11.1-dns-resolver.yaml
@@ -97,7 +97,7 @@ spec:
       - args:
         - -conf
         - /etc/coredns/Corefile
-        image: gcr.io/google_containers/coredns:1.6.7
+        image: gcr.io/google_containers/coredns:1.3.1
         name: dns-resolver
         readinessProbe:
           failureThreshold: 3

--- a/api/pkg/resources/test/fixtures/deployment-digitalocean-1.12.0-dns-resolver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-digitalocean-1.12.0-dns-resolver.yaml
@@ -97,7 +97,7 @@ spec:
       - args:
         - -conf
         - /etc/coredns/Corefile
-        image: gcr.io/google_containers/coredns:1.1.3
+        image: gcr.io/google_containers/coredns:1.6.7
         name: dns-resolver
         readinessProbe:
           failureThreshold: 3

--- a/api/pkg/resources/test/fixtures/deployment-digitalocean-1.12.0-dns-resolver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-digitalocean-1.12.0-dns-resolver.yaml
@@ -97,7 +97,7 @@ spec:
       - args:
         - -conf
         - /etc/coredns/Corefile
-        image: gcr.io/google_containers/coredns:1.6.7
+        image: gcr.io/google_containers/coredns:1.3.1
         name: dns-resolver
         readinessProbe:
           failureThreshold: 3

--- a/api/pkg/resources/test/fixtures/deployment-digitalocean-1.13.0-dns-resolver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-digitalocean-1.13.0-dns-resolver.yaml
@@ -97,7 +97,7 @@ spec:
       - args:
         - -conf
         - /etc/coredns/Corefile
-        image: gcr.io/google_containers/coredns:1.1.3
+        image: gcr.io/google_containers/coredns:1.6.7
         name: dns-resolver
         readinessProbe:
           failureThreshold: 3

--- a/api/pkg/resources/test/fixtures/deployment-digitalocean-1.13.0-dns-resolver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-digitalocean-1.13.0-dns-resolver.yaml
@@ -97,7 +97,7 @@ spec:
       - args:
         - -conf
         - /etc/coredns/Corefile
-        image: gcr.io/google_containers/coredns:1.6.7
+        image: gcr.io/google_containers/coredns:1.3.1
         name: dns-resolver
         readinessProbe:
           failureThreshold: 3

--- a/api/pkg/resources/test/fixtures/deployment-openstack-1.10.0-dns-resolver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-openstack-1.10.0-dns-resolver.yaml
@@ -97,7 +97,7 @@ spec:
       - args:
         - -conf
         - /etc/coredns/Corefile
-        image: gcr.io/google_containers/coredns:1.1.3
+        image: gcr.io/google_containers/coredns:1.6.7
         name: dns-resolver
         readinessProbe:
           failureThreshold: 3

--- a/api/pkg/resources/test/fixtures/deployment-openstack-1.10.0-dns-resolver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-openstack-1.10.0-dns-resolver.yaml
@@ -97,7 +97,7 @@ spec:
       - args:
         - -conf
         - /etc/coredns/Corefile
-        image: gcr.io/google_containers/coredns:1.6.7
+        image: gcr.io/google_containers/coredns:1.3.1
         name: dns-resolver
         readinessProbe:
           failureThreshold: 3

--- a/api/pkg/resources/test/fixtures/deployment-openstack-1.10.6-dns-resolver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-openstack-1.10.6-dns-resolver.yaml
@@ -97,7 +97,7 @@ spec:
       - args:
         - -conf
         - /etc/coredns/Corefile
-        image: gcr.io/google_containers/coredns:1.1.3
+        image: gcr.io/google_containers/coredns:1.6.7
         name: dns-resolver
         readinessProbe:
           failureThreshold: 3

--- a/api/pkg/resources/test/fixtures/deployment-openstack-1.10.6-dns-resolver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-openstack-1.10.6-dns-resolver.yaml
@@ -97,7 +97,7 @@ spec:
       - args:
         - -conf
         - /etc/coredns/Corefile
-        image: gcr.io/google_containers/coredns:1.6.7
+        image: gcr.io/google_containers/coredns:1.3.1
         name: dns-resolver
         readinessProbe:
           failureThreshold: 3

--- a/api/pkg/resources/test/fixtures/deployment-openstack-1.11.0-dns-resolver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-openstack-1.11.0-dns-resolver.yaml
@@ -97,7 +97,7 @@ spec:
       - args:
         - -conf
         - /etc/coredns/Corefile
-        image: gcr.io/google_containers/coredns:1.1.3
+        image: gcr.io/google_containers/coredns:1.6.7
         name: dns-resolver
         readinessProbe:
           failureThreshold: 3

--- a/api/pkg/resources/test/fixtures/deployment-openstack-1.11.0-dns-resolver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-openstack-1.11.0-dns-resolver.yaml
@@ -97,7 +97,7 @@ spec:
       - args:
         - -conf
         - /etc/coredns/Corefile
-        image: gcr.io/google_containers/coredns:1.6.7
+        image: gcr.io/google_containers/coredns:1.3.1
         name: dns-resolver
         readinessProbe:
           failureThreshold: 3

--- a/api/pkg/resources/test/fixtures/deployment-openstack-1.11.1-dns-resolver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-openstack-1.11.1-dns-resolver.yaml
@@ -97,7 +97,7 @@ spec:
       - args:
         - -conf
         - /etc/coredns/Corefile
-        image: gcr.io/google_containers/coredns:1.1.3
+        image: gcr.io/google_containers/coredns:1.6.7
         name: dns-resolver
         readinessProbe:
           failureThreshold: 3

--- a/api/pkg/resources/test/fixtures/deployment-openstack-1.11.1-dns-resolver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-openstack-1.11.1-dns-resolver.yaml
@@ -97,7 +97,7 @@ spec:
       - args:
         - -conf
         - /etc/coredns/Corefile
-        image: gcr.io/google_containers/coredns:1.6.7
+        image: gcr.io/google_containers/coredns:1.3.1
         name: dns-resolver
         readinessProbe:
           failureThreshold: 3

--- a/api/pkg/resources/test/fixtures/deployment-openstack-1.12.0-dns-resolver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-openstack-1.12.0-dns-resolver.yaml
@@ -97,7 +97,7 @@ spec:
       - args:
         - -conf
         - /etc/coredns/Corefile
-        image: gcr.io/google_containers/coredns:1.1.3
+        image: gcr.io/google_containers/coredns:1.6.7
         name: dns-resolver
         readinessProbe:
           failureThreshold: 3

--- a/api/pkg/resources/test/fixtures/deployment-openstack-1.12.0-dns-resolver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-openstack-1.12.0-dns-resolver.yaml
@@ -97,7 +97,7 @@ spec:
       - args:
         - -conf
         - /etc/coredns/Corefile
-        image: gcr.io/google_containers/coredns:1.6.7
+        image: gcr.io/google_containers/coredns:1.3.1
         name: dns-resolver
         readinessProbe:
           failureThreshold: 3

--- a/api/pkg/resources/test/fixtures/deployment-openstack-1.13.0-dns-resolver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-openstack-1.13.0-dns-resolver.yaml
@@ -97,7 +97,7 @@ spec:
       - args:
         - -conf
         - /etc/coredns/Corefile
-        image: gcr.io/google_containers/coredns:1.1.3
+        image: gcr.io/google_containers/coredns:1.6.7
         name: dns-resolver
         readinessProbe:
           failureThreshold: 3

--- a/api/pkg/resources/test/fixtures/deployment-openstack-1.13.0-dns-resolver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-openstack-1.13.0-dns-resolver.yaml
@@ -97,7 +97,7 @@ spec:
       - args:
         - -conf
         - /etc/coredns/Corefile
-        image: gcr.io/google_containers/coredns:1.6.7
+        image: gcr.io/google_containers/coredns:1.3.1
         name: dns-resolver
         readinessProbe:
           failureThreshold: 3

--- a/api/pkg/resources/test/fixtures/deployment-vsphere-1.10.0-dns-resolver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-vsphere-1.10.0-dns-resolver.yaml
@@ -97,7 +97,7 @@ spec:
       - args:
         - -conf
         - /etc/coredns/Corefile
-        image: gcr.io/google_containers/coredns:1.1.3
+        image: gcr.io/google_containers/coredns:1.6.7
         name: dns-resolver
         readinessProbe:
           failureThreshold: 3

--- a/api/pkg/resources/test/fixtures/deployment-vsphere-1.10.0-dns-resolver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-vsphere-1.10.0-dns-resolver.yaml
@@ -97,7 +97,7 @@ spec:
       - args:
         - -conf
         - /etc/coredns/Corefile
-        image: gcr.io/google_containers/coredns:1.6.7
+        image: gcr.io/google_containers/coredns:1.3.1
         name: dns-resolver
         readinessProbe:
           failureThreshold: 3

--- a/api/pkg/resources/test/fixtures/deployment-vsphere-1.10.6-dns-resolver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-vsphere-1.10.6-dns-resolver.yaml
@@ -97,7 +97,7 @@ spec:
       - args:
         - -conf
         - /etc/coredns/Corefile
-        image: gcr.io/google_containers/coredns:1.1.3
+        image: gcr.io/google_containers/coredns:1.6.7
         name: dns-resolver
         readinessProbe:
           failureThreshold: 3

--- a/api/pkg/resources/test/fixtures/deployment-vsphere-1.10.6-dns-resolver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-vsphere-1.10.6-dns-resolver.yaml
@@ -97,7 +97,7 @@ spec:
       - args:
         - -conf
         - /etc/coredns/Corefile
-        image: gcr.io/google_containers/coredns:1.6.7
+        image: gcr.io/google_containers/coredns:1.3.1
         name: dns-resolver
         readinessProbe:
           failureThreshold: 3

--- a/api/pkg/resources/test/fixtures/deployment-vsphere-1.11.0-dns-resolver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-vsphere-1.11.0-dns-resolver.yaml
@@ -97,7 +97,7 @@ spec:
       - args:
         - -conf
         - /etc/coredns/Corefile
-        image: gcr.io/google_containers/coredns:1.1.3
+        image: gcr.io/google_containers/coredns:1.6.7
         name: dns-resolver
         readinessProbe:
           failureThreshold: 3

--- a/api/pkg/resources/test/fixtures/deployment-vsphere-1.11.0-dns-resolver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-vsphere-1.11.0-dns-resolver.yaml
@@ -97,7 +97,7 @@ spec:
       - args:
         - -conf
         - /etc/coredns/Corefile
-        image: gcr.io/google_containers/coredns:1.6.7
+        image: gcr.io/google_containers/coredns:1.3.1
         name: dns-resolver
         readinessProbe:
           failureThreshold: 3

--- a/api/pkg/resources/test/fixtures/deployment-vsphere-1.11.1-dns-resolver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-vsphere-1.11.1-dns-resolver.yaml
@@ -97,7 +97,7 @@ spec:
       - args:
         - -conf
         - /etc/coredns/Corefile
-        image: gcr.io/google_containers/coredns:1.1.3
+        image: gcr.io/google_containers/coredns:1.6.7
         name: dns-resolver
         readinessProbe:
           failureThreshold: 3

--- a/api/pkg/resources/test/fixtures/deployment-vsphere-1.11.1-dns-resolver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-vsphere-1.11.1-dns-resolver.yaml
@@ -97,7 +97,7 @@ spec:
       - args:
         - -conf
         - /etc/coredns/Corefile
-        image: gcr.io/google_containers/coredns:1.6.7
+        image: gcr.io/google_containers/coredns:1.3.1
         name: dns-resolver
         readinessProbe:
           failureThreshold: 3

--- a/api/pkg/resources/test/fixtures/deployment-vsphere-1.12.0-dns-resolver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-vsphere-1.12.0-dns-resolver.yaml
@@ -97,7 +97,7 @@ spec:
       - args:
         - -conf
         - /etc/coredns/Corefile
-        image: gcr.io/google_containers/coredns:1.1.3
+        image: gcr.io/google_containers/coredns:1.6.7
         name: dns-resolver
         readinessProbe:
           failureThreshold: 3

--- a/api/pkg/resources/test/fixtures/deployment-vsphere-1.12.0-dns-resolver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-vsphere-1.12.0-dns-resolver.yaml
@@ -97,7 +97,7 @@ spec:
       - args:
         - -conf
         - /etc/coredns/Corefile
-        image: gcr.io/google_containers/coredns:1.6.7
+        image: gcr.io/google_containers/coredns:1.3.1
         name: dns-resolver
         readinessProbe:
           failureThreshold: 3

--- a/api/pkg/resources/test/fixtures/deployment-vsphere-1.13.0-dns-resolver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-vsphere-1.13.0-dns-resolver.yaml
@@ -97,7 +97,7 @@ spec:
       - args:
         - -conf
         - /etc/coredns/Corefile
-        image: gcr.io/google_containers/coredns:1.1.3
+        image: gcr.io/google_containers/coredns:1.6.7
         name: dns-resolver
         readinessProbe:
           failureThreshold: 3

--- a/api/pkg/resources/test/fixtures/deployment-vsphere-1.13.0-dns-resolver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-vsphere-1.13.0-dns-resolver.yaml
@@ -97,7 +97,7 @@ spec:
       - args:
         - -conf
         - /etc/coredns/Corefile
-        image: gcr.io/google_containers/coredns:1.6.7
+        image: gcr.io/google_containers/coredns:1.3.1
         name: dns-resolver
         readinessProbe:
           failureThreshold: 3


### PR DESCRIPTION
**What this PR does / why we need it**:
Updating Coredns to latest recommended version for K8s 1.15.X: Coredns v1.3.1. Current version (v1.1.3) is outdated for user-cluster.

**Documentation**:
<!-- Add links to the related documentation changes related to this pull request. E.g. the link to the kubermatic/docs pullrequest. -->
https://coredns.io/2019/01/13/coredns-1.3.1-release/

**Does this PR introduce a user-facing change?**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If  no release note is required, just write "NONE".
-->
```release-note
Update coredns to v1.3.1
```
