### PR TITLE
Fix vsphere/alibaba credential migration

### DIFF
--- a/api/pkg/crd/migrations/seed/migrations.go
+++ b/api/pkg/crd/migrations/seed/migrations.go
@@ -15,6 +15,7 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	kerrors "k8s.io/apimachinery/pkg/api/errors"
 	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/apimachinery/pkg/util/sets"
 	"k8s.io/client-go/rest"
 	"k8s.io/klog"
@@ -138,6 +139,13 @@ func setExposeStrategyIfEmpty(cluster *kubermaticv1.Cluster, cleanupContext *cle
 		if err := cleanupContext.client.Update(cleanupContext.ctx, cluster); err != nil {
 			return fmt.Errorf("failed to default exposeStrategy to NodePort for cluster %q: %v", cluster.Name, err)
 		}
+		namespacedName := types.NamespacedName{Name: cluster.Name}
+		updatedCluster := &kubermaticv1.Cluster{}
+		if err := cleanupContext.client.Get(cleanupContext.ctx, namespacedName, updatedCluster); err != nil {
+			return fmt.Errorf("failed to get cluster %q: %v", cluster.Name, err)
+		}
+
+		*cluster = *updatedCluster
 	}
 	return nil
 }
@@ -152,6 +160,13 @@ func setProxyModeIfEmpty(cluster *kubermaticv1.Cluster, cleanupContext *cleanupC
 		if err := cleanupContext.client.Update(cleanupContext.ctx, cluster); err != nil {
 			return fmt.Errorf("failed to default proxyMode to iptables for cluster %q: %v", cluster.Name, err)
 		}
+		namespacedName := types.NamespacedName{Name: cluster.Name}
+		updatedCluster := &kubermaticv1.Cluster{}
+		if err := cleanupContext.client.Get(cleanupContext.ctx, namespacedName, updatedCluster); err != nil {
+			return fmt.Errorf("failed to get cluster %q: %v", cluster.Name, err)
+		}
+
+		*cluster = *updatedCluster
 	}
 	return nil
 }
@@ -202,5 +217,12 @@ func createSecretsForCredentials(cluster *kubermaticv1.Cluster, cleanupContext *
 	if err := cleanupContext.client.Update(cleanupContext.ctx, cluster); err != nil {
 		return fmt.Errorf("failed to update cluster %q: %v", cluster.Name, err)
 	}
+	namespacedName := types.NamespacedName{Name: cluster.Name}
+	updatedCluster := &kubermaticv1.Cluster{}
+	if err := cleanupContext.client.Get(cleanupContext.ctx, namespacedName, updatedCluster); err != nil {
+		return fmt.Errorf("failed to get cluster %q: %v", cluster.Name, err)
+	}
+
+	*cluster = *updatedCluster
 	return nil
 }


### PR DESCRIPTION
**What this PR does / why we need it**:
The code for managing vsphere/alibaba credential secrets was not yet using the "create or update" strategy, but was always trying to create a new secret and quickly failing. This PR refactors the credential migration code a bit and fixes the issue.

**Does this PR introduce a user-facing change?**:
```release-note
NONE
```
