### PR TITLE
Better function names for BaseAppLabel and AppClusterLabel

### DIFF
--- a/api/pkg/controller/seed-controller-manager/openshift/data.go
+++ b/api/pkg/controller/seed-controller-manager/openshift/data.go
@@ -158,7 +158,7 @@ func (od *openshiftData) GetPodTemplateLabels(appName string, volumes []corev1.V
 }
 
 func (od *openshiftData) GetPodTemplateLabelsWithContext(ctx context.Context, appName string, volumes []corev1.Volume, additionalLabels map[string]string) (map[string]string, error) {
-	podLabels := kubernetesresources.AppClusterLabel(appName, od.cluster.Name, additionalLabels)
+	podLabels := kubernetesresources.AppClusterLabels(appName, od.cluster.Name, additionalLabels)
 	for _, v := range volumes {
 		if v.VolumeSource.Secret != nil {
 			revision, err := od.secretRevision(ctx, v.VolumeSource.Secret.SecretName)

--- a/api/pkg/controller/seed-controller-manager/openshift/resources/cloud_credential_operator.go
+++ b/api/pkg/controller/seed-controller-manager/openshift/resources/cloud_credential_operator.go
@@ -28,7 +28,7 @@ func CloudCredentialOperator(data openshiftData) reconciling.NamedDeploymentCrea
 			}
 
 			d.Spec.Selector = &metav1.LabelSelector{
-				MatchLabels: resources.BaseAppLabel(cloudCredentialOperatorDeploymentName, nil),
+				MatchLabels: resources.BaseAppLabels(cloudCredentialOperatorDeploymentName, nil),
 			}
 			d.Spec.Template.Spec.ImagePullSecrets = []corev1.LocalObjectReference{
 				{Name: openshiftImagePullSecretName},

--- a/api/pkg/controller/seed-controller-manager/openshift/resources/console.go
+++ b/api/pkg/controller/seed-controller-manager/openshift/resources/console.go
@@ -63,7 +63,7 @@ func ConsoleDeployment(data openshiftData) reconciling.NamedDeploymentCreatorGet
 			d.Spec.Template.Spec.AutomountServiceAccountToken = utilpointer.BoolPtr(false)
 			d.Spec.Template.Spec.ImagePullSecrets = []corev1.LocalObjectReference{{Name: openshiftImagePullSecretName}}
 			d.Spec.Selector = &metav1.LabelSelector{
-				MatchLabels: resources.BaseAppLabel(consoleDeploymentName, nil),
+				MatchLabels: resources.BaseAppLabels(consoleDeploymentName, nil),
 			}
 			image, err := consoleImage(data.Cluster().Spec.Version.String(), data.ImageRegistry(""))
 			if err != nil {

--- a/api/pkg/controller/seed-controller-manager/openshift/resources/dns_operator.go
+++ b/api/pkg/controller/seed-controller-manager/openshift/resources/dns_operator.go
@@ -54,7 +54,7 @@ func OpenshiftDNSOperatorFactory(data openshiftData) reconciling.NamedDeployment
 			})
 
 			d.Spec.Selector = &metav1.LabelSelector{
-				MatchLabels: resources.BaseAppLabel(openshiftDNSOperatorDeploymentName, nil),
+				MatchLabels: resources.BaseAppLabels(openshiftDNSOperatorDeploymentName, nil),
 			}
 			d.Spec.Template.Spec.ImagePullSecrets = []corev1.LocalObjectReference{
 				{Name: openshiftImagePullSecretName},

--- a/api/pkg/controller/seed-controller-manager/openshift/resources/kube_apiserver_deployment.go
+++ b/api/pkg/controller/seed-controller-manager/openshift/resources/kube_apiserver_deployment.go
@@ -86,7 +86,7 @@ func APIDeploymentCreator(ctx context.Context, data openshiftData) reconciling.N
 		return resources.ApiserverDeploymentName, func(dep *appsv1.Deployment) (*appsv1.Deployment, error) {
 
 			dep.Name = resources.ApiserverDeploymentName
-			dep.Labels = resources.BaseAppLabel(legacyAppLabelValue, nil)
+			dep.Labels = resources.BaseAppLabels(legacyAppLabelValue, nil)
 
 			dep.Spec.Replicas = resources.Int32(1)
 			if data.Cluster().Spec.ComponentsOverride.Apiserver.Replicas != nil {
@@ -94,7 +94,7 @@ func APIDeploymentCreator(ctx context.Context, data openshiftData) reconciling.N
 			}
 
 			dep.Spec.Selector = &metav1.LabelSelector{
-				MatchLabels: resources.BaseAppLabel(legacyAppLabelValue, nil),
+				MatchLabels: resources.BaseAppLabels(legacyAppLabelValue, nil),
 			}
 			dep.Spec.Strategy.Type = appsv1.RollingUpdateStatefulSetStrategyType
 			dep.Spec.Strategy.RollingUpdate = &appsv1.RollingUpdateDeployment{

--- a/api/pkg/controller/seed-controller-manager/openshift/resources/kube_controller_manager.go
+++ b/api/pkg/controller/seed-controller-manager/openshift/resources/kube_controller_manager.go
@@ -191,7 +191,7 @@ func KubeControllerManagerDeploymentCreatorFactory(data kubeControllerManagerDat
 					dep.Spec.Replicas = data.Cluster().Spec.ComponentsOverride.ControllerManager.Replicas
 				}
 				dep.Spec.Selector = &metav1.LabelSelector{
-					MatchLabels: resources.BaseAppLabel(resources.ControllerManagerDeploymentName, nil),
+					MatchLabels: resources.BaseAppLabels(resources.ControllerManagerDeploymentName, nil),
 				}
 				dep.Spec.Template.Spec.ImagePullSecrets = []corev1.LocalObjectReference{
 					{Name: openshiftImagePullSecretName},

--- a/api/pkg/controller/seed-controller-manager/openshift/resources/kube_scheduler.go
+++ b/api/pkg/controller/seed-controller-manager/openshift/resources/kube_scheduler.go
@@ -70,7 +70,7 @@ func KubeSchedulerDeploymentCreator(data openshiftData) reconciling.NamedDeploym
 	return func() (string, reconciling.DeploymentCreator) {
 		return resources.SchedulerDeploymentName, func(dep *appsv1.Deployment) (*appsv1.Deployment, error) {
 			dep.Name = resources.SchedulerDeploymentName
-			dep.Labels = resources.BaseAppLabel(name, nil)
+			dep.Labels = resources.BaseAppLabels(name, nil)
 
 			dep.Spec.Replicas = resources.Int32(1)
 			if data.Cluster().Spec.ComponentsOverride.Scheduler.Replicas != nil {
@@ -78,7 +78,7 @@ func KubeSchedulerDeploymentCreator(data openshiftData) reconciling.NamedDeploym
 			}
 
 			dep.Spec.Selector = &metav1.LabelSelector{
-				MatchLabels: resources.BaseAppLabel(name, nil),
+				MatchLabels: resources.BaseAppLabels(name, nil),
 			}
 
 			dep.Spec.Template.Spec.AutomountServiceAccountToken = utilpointer.BoolPtr(false)

--- a/api/pkg/controller/seed-controller-manager/openshift/resources/oauth.go
+++ b/api/pkg/controller/seed-controller-manager/openshift/resources/oauth.go
@@ -181,7 +181,7 @@ func OauthConfigMapCreator(data openshiftData) reconciling.NamedConfigMapCreator
 func OauthServiceCreator(exposeStrategy corev1.ServiceType) reconciling.NamedServiceCreatorGetter {
 	return func() (string, reconciling.ServiceCreator) {
 		return OAuthServiceName, func(se *corev1.Service) (*corev1.Service, error) {
-			se.Labels = resources.BaseAppLabel(name, nil)
+			se.Labels = resources.BaseAppLabels(name, nil)
 
 			if se.Annotations == nil {
 				se.Annotations = map[string]string{}
@@ -302,9 +302,9 @@ func OauthDeploymentCreator(data openshiftData) reconciling.NamedDeploymentCreat
 
 			dep.Spec.Replicas = utilpointer.Int32Ptr(2)
 			dep.Spec.Selector = &metav1.LabelSelector{
-				MatchLabels: resources.BaseAppLabel(OauthName, nil),
+				MatchLabels: resources.BaseAppLabels(OauthName, nil),
 			}
-			dep.Spec.Template.Labels = resources.BaseAppLabel(OauthName, nil)
+			dep.Spec.Template.Labels = resources.BaseAppLabels(OauthName, nil)
 			dep.Spec.Template.Spec.ImagePullSecrets = []corev1.LocalObjectReference{
 				{Name: resources.ImagePullSecretName},
 				{Name: openshiftImagePullSecretName},

--- a/api/pkg/controller/seed-controller-manager/openshift/resources/openshift_apiserver_deployment.go
+++ b/api/pkg/controller/seed-controller-manager/openshift/resources/openshift_apiserver_deployment.go
@@ -44,7 +44,7 @@ func OpenshiftAPIServiceCreator() (string, reconciling.ServiceCreator) {
 			Port:       443,
 			TargetPort: intstr.FromInt(8443),
 		}}
-		svc.Spec.Selector = resources.BaseAppLabel(OpenshiftAPIServerDeploymentName, nil)
+		svc.Spec.Selector = resources.BaseAppLabels(OpenshiftAPIServerDeploymentName, nil)
 
 		return svc, nil
 	}
@@ -65,7 +65,7 @@ func OpenshiftAPIServerDeploymentCreator(ctx context.Context, data openshiftData
 				dep.Spec.Replicas = data.Cluster().Spec.ComponentsOverride.Apiserver.Replicas
 			}
 			dep.Spec.Selector = &metav1.LabelSelector{
-				MatchLabels: resources.BaseAppLabel(OpenshiftAPIServerDeploymentName, nil),
+				MatchLabels: resources.BaseAppLabels(OpenshiftAPIServerDeploymentName, nil),
 			}
 
 			dep.Spec.Strategy.Type = appsv1.RollingUpdateDeploymentStrategyType
@@ -79,7 +79,7 @@ func OpenshiftAPIServerDeploymentCreator(ctx context.Context, data openshiftData
 					IntVal: 0,
 				},
 			}
-			dep.Spec.Template.Labels = resources.BaseAppLabel(OpenshiftAPIServerDeploymentName, nil)
+			dep.Spec.Template.Labels = resources.BaseAppLabels(OpenshiftAPIServerDeploymentName, nil)
 			dep.Spec.Template.Spec.ImagePullSecrets = []corev1.LocalObjectReference{
 				{Name: resources.ImagePullSecretName},
 				{Name: openshiftImagePullSecretName},

--- a/api/pkg/controller/seed-controller-manager/openshift/resources/openshift_controller_manager.go
+++ b/api/pkg/controller/seed-controller-manager/openshift/resources/openshift_controller_manager.go
@@ -110,7 +110,7 @@ func OpenshiftControllerManagerDeploymentCreator(ctx context.Context, data opens
 	return func() (string, reconciling.DeploymentCreator) {
 		return OpenshiftControllerManagerDeploymentName, func(dep *appsv1.Deployment) (*appsv1.Deployment, error) {
 			dep.Name = resources.ControllerManagerDeploymentName
-			dep.Labels = resources.BaseAppLabel(OpenshiftControllerManagerDeploymentName, nil)
+			dep.Labels = resources.BaseAppLabels(OpenshiftControllerManagerDeploymentName, nil)
 
 			dep.Spec.Replicas = resources.Int32(1)
 			if data.Cluster().Spec.ComponentsOverride.ControllerManager.Replicas != nil {
@@ -119,7 +119,7 @@ func OpenshiftControllerManagerDeploymentCreator(ctx context.Context, data opens
 			dep.Spec.Template.Spec.AutomountServiceAccountToken = utilpointer.BoolPtr(false)
 
 			dep.Spec.Selector = &metav1.LabelSelector{
-				MatchLabels: resources.BaseAppLabel(OpenshiftControllerManagerDeploymentName, nil),
+				MatchLabels: resources.BaseAppLabels(OpenshiftControllerManagerDeploymentName, nil),
 			}
 			dep.Spec.Template.Spec.ImagePullSecrets = []corev1.LocalObjectReference{{Name: openshiftImagePullSecretName}}
 

--- a/api/pkg/controller/seed-controller-manager/openshift/resources/openshift_network_operator.go
+++ b/api/pkg/controller/seed-controller-manager/openshift/resources/openshift_network_operator.go
@@ -56,7 +56,7 @@ func OpenshiftNetworkOperatorCreatorFactory(data openshiftData) reconciling.Name
 				})
 
 			d.Spec.Selector = &metav1.LabelSelector{
-				MatchLabels: resources.BaseAppLabel(openshiftNetworkOperatorDeploymentName, nil),
+				MatchLabels: resources.BaseAppLabels(openshiftNetworkOperatorDeploymentName, nil),
 			}
 			d.Spec.Template.Spec.ImagePullSecrets = []corev1.LocalObjectReference{
 				{Name: openshiftImagePullSecretName},

--- a/api/pkg/controller/seed-controller-manager/openshift/resources/registry_operator.go
+++ b/api/pkg/controller/seed-controller-manager/openshift/resources/registry_operator.go
@@ -37,7 +37,7 @@ func RegistryOperatorFactory(data openshiftData) reconciling.NamedDeploymentCrea
 			})
 
 			d.Spec.Selector = &metav1.LabelSelector{
-				MatchLabels: resources.BaseAppLabel(openshiftRegistryOperatorName, nil),
+				MatchLabels: resources.BaseAppLabels(openshiftRegistryOperatorName, nil),
 			}
 			d.Spec.Template.Spec.ImagePullSecrets = []corev1.LocalObjectReference{
 				{Name: openshiftImagePullSecretName},

--- a/api/pkg/controller/user-cluster-controller-manager/resources/cloudcontroller/clusterrolebinding.go
+++ b/api/pkg/controller/user-cluster-controller-manager/resources/cloudcontroller/clusterrolebinding.go
@@ -10,7 +10,7 @@ import (
 func ClusterRoleBindingCreator() reconciling.NamedClusterRoleBindingCreatorGetter {
 	return func() (string, reconciling.ClusterRoleBindingCreator) {
 		return resources.CloudControllerManagerRoleBindingName, func(crb *rbacv1.ClusterRoleBinding) (*rbacv1.ClusterRoleBinding, error) {
-			crb.Labels = resources.BaseAppLabel(resources.CloudControllerManagerRoleBindingName, nil)
+			crb.Labels = resources.BaseAppLabels(resources.CloudControllerManagerRoleBindingName, nil)
 
 			crb.RoleRef = rbacv1.RoleRef{
 				// Can probably be tightened up a bit but for now I'm following the documentation.

--- a/api/pkg/controller/user-cluster-controller-manager/resources/resources/kube-state-metrics/clusterrole.go
+++ b/api/pkg/controller/user-cluster-controller-manager/resources/resources/kube-state-metrics/clusterrole.go
@@ -15,7 +15,7 @@ const (
 func ClusterRoleCreator() reconciling.NamedClusterRoleCreatorGetter {
 	return func() (string, reconciling.ClusterRoleCreator) {
 		return resources.KubeStateMetricsClusterRoleName, func(cr *rbacv1.ClusterRole) (*rbacv1.ClusterRole, error) {
-			cr.Labels = resources.BaseAppLabel(Name, nil)
+			cr.Labels = resources.BaseAppLabels(Name, nil)
 
 			cr.Rules = []rbacv1.PolicyRule{
 				{

--- a/api/pkg/controller/user-cluster-controller-manager/resources/resources/kube-state-metrics/clusterrolebinding.go
+++ b/api/pkg/controller/user-cluster-controller-manager/resources/resources/kube-state-metrics/clusterrolebinding.go
@@ -11,7 +11,7 @@ import (
 func ClusterRoleBindingCreator() reconciling.NamedClusterRoleBindingCreatorGetter {
 	return func() (string, reconciling.ClusterRoleBindingCreator) {
 		return resources.KubeStateMetricsClusterRoleBindingName, func(crb *rbacv1.ClusterRoleBinding) (*rbacv1.ClusterRoleBinding, error) {
-			crb.Labels = resources.BaseAppLabel(Name, nil)
+			crb.Labels = resources.BaseAppLabels(Name, nil)
 
 			crb.RoleRef = rbacv1.RoleRef{
 				Name:     resources.KubeStateMetricsClusterRoleName,

--- a/api/pkg/controller/user-cluster-controller-manager/resources/resources/kubernetes-dashboard/clusterrole.go
+++ b/api/pkg/controller/user-cluster-controller-manager/resources/resources/kubernetes-dashboard/clusterrole.go
@@ -11,7 +11,7 @@ import (
 func ClusterRoleCreator() reconciling.NamedClusterRoleCreatorGetter {
 	return func() (string, reconciling.ClusterRoleCreator) {
 		return resources.MetricsScraperClusterRoleName, func(cr *rbacv1.ClusterRole) (*rbacv1.ClusterRole, error) {
-			cr.Labels = resources.BaseAppLabel(scraperName, nil)
+			cr.Labels = resources.BaseAppLabels(scraperName, nil)
 
 			cr.Rules = []rbacv1.PolicyRule{
 				{

--- a/api/pkg/controller/user-cluster-controller-manager/resources/resources/kubernetes-dashboard/clusterrolebinding.go
+++ b/api/pkg/controller/user-cluster-controller-manager/resources/resources/kubernetes-dashboard/clusterrolebinding.go
@@ -12,7 +12,7 @@ import (
 func ClusterRoleBindingCreator() reconciling.NamedClusterRoleBindingCreatorGetter {
 	return func() (string, reconciling.ClusterRoleBindingCreator) {
 		return resources.MetricsScraperClusterRoleBindingName, func(crb *rbacv1.ClusterRoleBinding) (*rbacv1.ClusterRoleBinding, error) {
-			crb.Labels = resources.BaseAppLabel(scraperName, nil)
+			crb.Labels = resources.BaseAppLabels(scraperName, nil)
 
 			crb.RoleRef = rbacv1.RoleRef{
 				APIGroup: rbacv1.GroupName,

--- a/api/pkg/controller/user-cluster-controller-manager/resources/resources/kubernetes-dashboard/deployment.go
+++ b/api/pkg/controller/user-cluster-controller-manager/resources/resources/kubernetes-dashboard/deployment.go
@@ -39,14 +39,14 @@ func DeploymentCreator() reconciling.NamedDeploymentCreatorGetter {
 	return func() (string, reconciling.DeploymentCreator) {
 		return scraperName, func(dep *appsv1.Deployment) (*appsv1.Deployment, error) {
 			dep.Name = scraperName
-			dep.Labels = resources.BaseAppLabel(scraperName, nil)
+			dep.Labels = resources.BaseAppLabels(scraperName, nil)
 
 			dep.Spec.Replicas = resources.Int32(2)
 			dep.Spec.Selector = &metav1.LabelSelector{
-				MatchLabels: resources.BaseAppLabel(scraperName, nil),
+				MatchLabels: resources.BaseAppLabels(scraperName, nil),
 			}
 			dep.Spec.Template.ObjectMeta = metav1.ObjectMeta{
-				Labels: resources.BaseAppLabel(scraperName, nil),
+				Labels: resources.BaseAppLabels(scraperName, nil),
 			}
 
 			volumes := getVolumes()

--- a/api/pkg/controller/user-cluster-controller-manager/resources/resources/kubernetes-dashboard/role.go
+++ b/api/pkg/controller/user-cluster-controller-manager/resources/resources/kubernetes-dashboard/role.go
@@ -11,7 +11,7 @@ import (
 func RoleCreator() reconciling.NamedRoleCreatorGetter {
 	return func() (string, reconciling.RoleCreator) {
 		return resources.KubernetesDashboardRoleName, func(role *rbacv1.Role) (*rbacv1.Role, error) {
-			role.Labels = resources.BaseAppLabel(AppName, nil)
+			role.Labels = resources.BaseAppLabels(AppName, nil)
 			role.Rules = []rbacv1.PolicyRule{
 				{
 					APIGroups:     []string{""},

--- a/api/pkg/controller/user-cluster-controller-manager/resources/resources/kubernetes-dashboard/rolebinding.go
+++ b/api/pkg/controller/user-cluster-controller-manager/resources/resources/kubernetes-dashboard/rolebinding.go
@@ -11,7 +11,7 @@ import (
 func RoleBindingCreator() reconciling.NamedRoleBindingCreatorGetter {
 	return func() (string, reconciling.RoleBindingCreator) {
 		return resources.KubernetesDashboardRoleBindingName, func(rb *rbacv1.RoleBinding) (*rbacv1.RoleBinding, error) {
-			rb.Labels = resources.BaseAppLabel(AppName, nil)
+			rb.Labels = resources.BaseAppLabels(AppName, nil)
 			rb.RoleRef = rbacv1.RoleRef{
 				Name:     resources.KubernetesDashboardRoleName,
 				Kind:     "Role",

--- a/api/pkg/controller/user-cluster-controller-manager/resources/resources/kubernetes-dashboard/secret.go
+++ b/api/pkg/controller/user-cluster-controller-manager/resources/resources/kubernetes-dashboard/secret.go
@@ -15,7 +15,7 @@ func KeyHolderSecretCreator() reconciling.NamedSecretCreatorGetter {
 				secret.Data = map[string][]byte{}
 			}
 
-			secret.Labels = resources.BaseAppLabel(AppName, nil)
+			secret.Labels = resources.BaseAppLabels(AppName, nil)
 			return secret, nil
 		}
 	}
@@ -29,7 +29,7 @@ func CsrfTokenSecretCreator() reconciling.NamedSecretCreatorGetter {
 				secret.Data = map[string][]byte{}
 			}
 
-			secret.Labels = resources.BaseAppLabel(AppName, nil)
+			secret.Labels = resources.BaseAppLabels(AppName, nil)
 			return secret, nil
 		}
 	}

--- a/api/pkg/controller/user-cluster-controller-manager/resources/resources/kubernetes-dashboard/service.go
+++ b/api/pkg/controller/user-cluster-controller-manager/resources/resources/kubernetes-dashboard/service.go
@@ -13,8 +13,8 @@ func ServiceCreator() reconciling.NamedServiceCreatorGetter {
 	return func() (string, reconciling.ServiceCreator) {
 		return resources.MetricsScraperServiceName, func(s *corev1.Service) (*corev1.Service, error) {
 			s.Name = resources.MetricsScraperServiceName
-			s.Labels = resources.BaseAppLabel(scraperName, nil)
-			s.Spec.Selector = resources.BaseAppLabel(scraperName, nil)
+			s.Labels = resources.BaseAppLabels(scraperName, nil)
+			s.Spec.Selector = resources.BaseAppLabels(scraperName, nil)
 			s.Spec.Ports = []corev1.ServicePort{
 				{
 					Protocol:   corev1.ProtocolTCP,

--- a/api/pkg/controller/user-cluster-controller-manager/resources/resources/kubernetes-dashboard/serviceaccount.go
+++ b/api/pkg/controller/user-cluster-controller-manager/resources/resources/kubernetes-dashboard/serviceaccount.go
@@ -11,7 +11,7 @@ import (
 func ServiceAccountCreator() reconciling.NamedServiceAccountCreatorGetter {
 	return func() (string, reconciling.ServiceAccountCreator) {
 		return resources.MetricsScraperServiceAccountUsername, func(sa *corev1.ServiceAccount) (*corev1.ServiceAccount, error) {
-			sa.Labels = resources.BaseAppLabel(scraperName, nil)
+			sa.Labels = resources.BaseAppLabels(scraperName, nil)
 			sa.Name = resources.MetricsScraperServiceAccountUsername
 			return sa, nil
 		}

--- a/api/pkg/controller/user-cluster-controller-manager/resources/resources/machine-controller/cluster-info-configmap.go
+++ b/api/pkg/controller/user-cluster-controller-manager/resources/resources/machine-controller/cluster-info-configmap.go
@@ -21,7 +21,7 @@ func ClusterInfoConfigMapCreator(url string, caCert *x509.Certificate) reconcili
 				cm.Data = map[string]string{}
 			}
 
-			cm.Labels = resources.BaseAppLabel(Name, nil)
+			cm.Labels = resources.BaseAppLabels(Name, nil)
 
 			kubeconfig := clientcmdapi.Config{}
 			kubeconfig.Clusters = map[string]*clientcmdapi.Cluster{

--- a/api/pkg/controller/user-cluster-controller-manager/resources/resources/machine-controller/clusterrole.go
+++ b/api/pkg/controller/user-cluster-controller-manager/resources/resources/machine-controller/clusterrole.go
@@ -15,7 +15,7 @@ const (
 func ClusterRoleCreator() reconciling.NamedClusterRoleCreatorGetter {
 	return func() (string, reconciling.ClusterRoleCreator) {
 		return resources.MachineControllerClusterRoleName, func(cr *rbacv1.ClusterRole) (*rbacv1.ClusterRole, error) {
-			cr.Labels = resources.BaseAppLabel(Name, nil)
+			cr.Labels = resources.BaseAppLabels(Name, nil)
 
 			cr.Rules = []rbacv1.PolicyRule{
 				{

--- a/api/pkg/controller/user-cluster-controller-manager/resources/resources/machine-controller/clusterrolebinding.go
+++ b/api/pkg/controller/user-cluster-controller-manager/resources/resources/machine-controller/clusterrolebinding.go
@@ -42,7 +42,7 @@ func NodeSignerClusterRoleBindingCreator() reconciling.NamedClusterRoleBindingCr
 func createClusterRoleBindingCreator(crbSuffix, cRoleRef string, subj rbacv1.Subject) reconciling.NamedClusterRoleBindingCreatorGetter {
 	return func() (string, reconciling.ClusterRoleBindingCreator) {
 		return fmt.Sprintf("%s:%s", resources.MachineControllerClusterRoleBindingName, crbSuffix), func(crb *rbacv1.ClusterRoleBinding) (*rbacv1.ClusterRoleBinding, error) {
-			crb.Labels = resources.BaseAppLabel(Name, nil)
+			crb.Labels = resources.BaseAppLabels(Name, nil)
 
 			crb.RoleRef = rbacv1.RoleRef{
 				Name:     cRoleRef,

--- a/api/pkg/controller/user-cluster-controller-manager/resources/resources/machine-controller/role.go
+++ b/api/pkg/controller/user-cluster-controller-manager/resources/resources/machine-controller/role.go
@@ -15,7 +15,7 @@ func KubeSystemRoleCreator() reconciling.NamedRoleCreatorGetter {
 		return resources.MachineControllerRoleName, func(r *rbacv1.Role) (*rbacv1.Role, error) {
 			r.Name = resources.MachineControllerRoleName
 			r.Namespace = metav1.NamespaceSystem
-			r.Labels = resources.BaseAppLabel(machinecontroller.Name, nil)
+			r.Labels = resources.BaseAppLabels(machinecontroller.Name, nil)
 
 			r.Rules = []rbacv1.PolicyRule{
 				{
@@ -51,7 +51,7 @@ func EndpointReaderRoleCreator() reconciling.NamedRoleCreatorGetter {
 		return resources.MachineControllerRoleName, func(r *rbacv1.Role) (*rbacv1.Role, error) {
 			r.Name = resources.MachineControllerRoleName
 			r.Namespace = metav1.NamespaceDefault
-			r.Labels = resources.BaseAppLabel(machinecontroller.Name, nil)
+			r.Labels = resources.BaseAppLabels(machinecontroller.Name, nil)
 
 			r.Rules = []rbacv1.PolicyRule{
 				{
@@ -76,7 +76,7 @@ func ClusterInfoReaderRoleCreator() reconciling.NamedRoleCreatorGetter {
 		return resources.ClusterInfoReaderRoleName, func(r *rbacv1.Role) (*rbacv1.Role, error) {
 			r.Name = resources.ClusterInfoReaderRoleName
 			r.Namespace = metav1.NamespacePublic
-			r.Labels = resources.BaseAppLabel(machinecontroller.Name, nil)
+			r.Labels = resources.BaseAppLabels(machinecontroller.Name, nil)
 
 			r.Rules = []rbacv1.PolicyRule{
 				{
@@ -98,7 +98,7 @@ func KubePublicRoleCreator() reconciling.NamedRoleCreatorGetter {
 		return resources.MachineControllerRoleName, func(r *rbacv1.Role) (*rbacv1.Role, error) {
 			r.Name = resources.MachineControllerRoleName
 			r.Namespace = metav1.NamespacePublic
-			r.Labels = resources.BaseAppLabel(machinecontroller.Name, nil)
+			r.Labels = resources.BaseAppLabels(machinecontroller.Name, nil)
 
 			r.Rules = []rbacv1.PolicyRule{
 				{

--- a/api/pkg/controller/user-cluster-controller-manager/resources/resources/machine-controller/rolebinding.go
+++ b/api/pkg/controller/user-cluster-controller-manager/resources/resources/machine-controller/rolebinding.go
@@ -28,7 +28,7 @@ func KubePublicRoleBindingCreator() reconciling.NamedRoleBindingCreatorGetter {
 func RoleBindingCreator() reconciling.NamedRoleBindingCreatorGetter {
 	return func() (string, reconciling.RoleBindingCreator) {
 		return resources.MachineControllerRoleBindingName, func(rb *rbacv1.RoleBinding) (*rbacv1.RoleBinding, error) {
-			rb.Labels = resources.BaseAppLabel(machinecontroller.Name, nil)
+			rb.Labels = resources.BaseAppLabels(machinecontroller.Name, nil)
 
 			rb.RoleRef = rbacv1.RoleRef{
 				Name:     resources.MachineControllerRoleName,

--- a/api/pkg/controller/user-cluster-controller-manager/resources/resources/metrics-server/apiservice.go
+++ b/api/pkg/controller/user-cluster-controller-manager/resources/resources/metrics-server/apiservice.go
@@ -16,7 +16,7 @@ const (
 func APIServiceCreator(caBundle []byte) reconciling.NamedAPIServiceCreatorGetter {
 	return func() (string, reconciling.APIServiceCreator) {
 		return resources.MetricsServerAPIServiceName, func(se *apiregistrationv1beta1.APIService) (*apiregistrationv1beta1.APIService, error) {
-			labels := resources.BaseAppLabel(Name, nil)
+			labels := resources.BaseAppLabels(Name, nil)
 			se.Labels = labels
 
 			if se.Spec.Service == nil {

--- a/api/pkg/controller/user-cluster-controller-manager/resources/resources/metrics-server/clusterrole.go
+++ b/api/pkg/controller/user-cluster-controller-manager/resources/resources/metrics-server/clusterrole.go
@@ -11,7 +11,7 @@ import (
 func ClusterRoleCreator() reconciling.NamedClusterRoleCreatorGetter {
 	return func() (string, reconciling.ClusterRoleCreator) {
 		return resources.MetricsServerClusterRoleName, func(cr *rbacv1.ClusterRole) (*rbacv1.ClusterRole, error) {
-			cr.Labels = resources.BaseAppLabel(Name, nil)
+			cr.Labels = resources.BaseAppLabels(Name, nil)
 
 			cr.Rules = []rbacv1.PolicyRule{
 				{

--- a/api/pkg/controller/user-cluster-controller-manager/resources/resources/metrics-server/clusterrolebinding.go
+++ b/api/pkg/controller/user-cluster-controller-manager/resources/resources/metrics-server/clusterrolebinding.go
@@ -11,7 +11,7 @@ import (
 func ClusterRoleBindingResourceReaderCreator() reconciling.NamedClusterRoleBindingCreatorGetter {
 	return func() (string, reconciling.ClusterRoleBindingCreator) {
 		return resources.MetricsServerResourceReaderClusterRoleBindingName, func(crb *rbacv1.ClusterRoleBinding) (*rbacv1.ClusterRoleBinding, error) {
-			crb.Labels = resources.BaseAppLabel(Name, nil)
+			crb.Labels = resources.BaseAppLabels(Name, nil)
 
 			crb.RoleRef = rbacv1.RoleRef{
 				Name:     resources.MetricsServerClusterRoleName,

--- a/api/pkg/controller/user-cluster-controller-manager/resources/resources/metrics-server/external-name-service.go
+++ b/api/pkg/controller/user-cluster-controller-manager/resources/resources/metrics-server/external-name-service.go
@@ -15,7 +15,7 @@ func ExternalNameServiceCreator(namespace string) reconciling.NamedServiceCreato
 	return func() (string, reconciling.ServiceCreator) {
 		return resources.MetricsServerExternalNameServiceName, func(se *corev1.Service) (*corev1.Service, error) {
 			se.Namespace = metav1.NamespaceSystem
-			se.Labels = resources.BaseAppLabel(Name, nil)
+			se.Labels = resources.BaseAppLabels(Name, nil)
 
 			se.Spec.Type = corev1.ServiceTypeExternalName
 			se.Spec.ExternalName = fmt.Sprintf("%s.%s.svc.cluster.local", resources.MetricsServerServiceName, namespace)

--- a/api/pkg/controller/user-cluster-controller-manager/resources/resources/metrics-server/rolebinding.go
+++ b/api/pkg/controller/user-cluster-controller-manager/resources/resources/metrics-server/rolebinding.go
@@ -11,7 +11,7 @@ import (
 func RolebindingAuthReaderCreator() reconciling.NamedRoleBindingCreatorGetter {
 	return func() (string, reconciling.RoleBindingCreator) {
 		return resources.MetricsServerAuthReaderRoleName, func(rb *rbacv1.RoleBinding) (*rbacv1.RoleBinding, error) {
-			rb.Labels = resources.BaseAppLabel(Name, nil)
+			rb.Labels = resources.BaseAppLabels(Name, nil)
 
 			rb.RoleRef = rbacv1.RoleRef{
 				Name:     "extension-apiserver-authentication-reader",

--- a/api/pkg/controller/user-cluster-controller-manager/resources/resources/openvpn/configmap.go
+++ b/api/pkg/controller/user-cluster-controller-manager/resources/resources/openvpn/configmap.go
@@ -20,7 +20,7 @@ func ClientConfigConfigMapCreator(hostname string, serverPort int) reconciling.N
 			if cm.Data == nil {
 				cm.Data = map[string]string{}
 			}
-			cm.Labels = resources.BaseAppLabel(Name, nil)
+			cm.Labels = resources.BaseAppLabels(Name, nil)
 
 			config := fmt.Sprintf(`client
 proto tcp

--- a/api/pkg/controller/user-cluster-controller-manager/resources/resources/prometheus/clusterrole.go
+++ b/api/pkg/controller/user-cluster-controller-manager/resources/resources/prometheus/clusterrole.go
@@ -15,7 +15,7 @@ const (
 func ClusterRoleCreator() reconciling.NamedClusterRoleCreatorGetter {
 	return func() (string, reconciling.ClusterRoleCreator) {
 		return resources.PrometheusClusterRoleName, func(cr *rbacv1.ClusterRole) (*rbacv1.ClusterRole, error) {
-			cr.Labels = resources.BaseAppLabel(Name, nil)
+			cr.Labels = resources.BaseAppLabels(Name, nil)
 
 			cr.Rules = []rbacv1.PolicyRule{
 				{

--- a/api/pkg/controller/user-cluster-controller-manager/resources/resources/prometheus/clusterrolebinding.go
+++ b/api/pkg/controller/user-cluster-controller-manager/resources/resources/prometheus/clusterrolebinding.go
@@ -11,7 +11,7 @@ import (
 func ClusterRoleBindingCreator() reconciling.NamedClusterRoleBindingCreatorGetter {
 	return func() (string, reconciling.ClusterRoleBindingCreator) {
 		return resources.PrometheusClusterRoleBindingName, func(crb *rbacv1.ClusterRoleBinding) (*rbacv1.ClusterRoleBinding, error) {
-			crb.Labels = resources.BaseAppLabel(Name, nil)
+			crb.Labels = resources.BaseAppLabels(Name, nil)
 
 			crb.RoleRef = rbacv1.RoleRef{
 				Name:     resources.PrometheusClusterRoleName,

--- a/api/pkg/resources/apiserver/deployment.go
+++ b/api/pkg/resources/apiserver/deployment.go
@@ -59,7 +59,7 @@ func DeploymentCreator(data *resources.TemplateData, enableOIDCAuthentication bo
 	return func() (string, reconciling.DeploymentCreator) {
 		return resources.ApiserverDeploymentName, func(dep *appsv1.Deployment) (*appsv1.Deployment, error) {
 			dep.Name = resources.ApiserverDeploymentName
-			dep.Labels = resources.BaseAppLabel(name, nil)
+			dep.Labels = resources.BaseAppLabels(name, nil)
 
 			dep.Spec.Replicas = resources.Int32(1)
 			if data.Cluster().Spec.ComponentsOverride.Apiserver.Replicas != nil {
@@ -67,7 +67,7 @@ func DeploymentCreator(data *resources.TemplateData, enableOIDCAuthentication bo
 			}
 
 			dep.Spec.Selector = &metav1.LabelSelector{
-				MatchLabels: resources.BaseAppLabel(name, nil),
+				MatchLabels: resources.BaseAppLabels(name, nil),
 			}
 			dep.Spec.Template.Spec.ImagePullSecrets = []corev1.LocalObjectReference{{Name: resources.ImagePullSecretName}}
 

--- a/api/pkg/resources/apiserver/pdb.go
+++ b/api/pkg/resources/apiserver/pdb.go
@@ -16,7 +16,7 @@ func PodDisruptionBudgetCreator() reconciling.NamedPodDisruptionBudgetCreatorGet
 			maxUnavailable := intstr.FromInt(1)
 			pdb.Spec = policyv1beta1.PodDisruptionBudgetSpec{
 				Selector: &metav1.LabelSelector{
-					MatchLabels: resources.BaseAppLabel(name, nil),
+					MatchLabels: resources.BaseAppLabels(name, nil),
 				},
 				// we can only specify maxUnavailable as minAvailable would block in case we have replicas=1. See https://github.com/kubernetes/kubernetes/issues/66811
 				MaxUnavailable: &maxUnavailable,

--- a/api/pkg/resources/apiserver/service.go
+++ b/api/pkg/resources/apiserver/service.go
@@ -16,7 +16,7 @@ func InternalServiceCreator() reconciling.NamedServiceCreatorGetter {
 	return func() (string, reconciling.ServiceCreator) {
 		return resources.ApiserverInternalServiceName, func(se *corev1.Service) (*corev1.Service, error) {
 			se.Name = resources.ApiserverInternalServiceName
-			se.Labels = resources.BaseAppLabel(name, nil)
+			se.Labels = resources.BaseAppLabels(name, nil)
 			se.Spec.Type = corev1.ServiceTypeClusterIP
 			se.Spec.Selector = map[string]string{
 				resources.AppLabelKey: name,

--- a/api/pkg/resources/cloudconfig/configmap.go
+++ b/api/pkg/resources/cloudconfig/configmap.go
@@ -49,7 +49,7 @@ func ConfigMapCreator(data configMapCreatorData) reconciling.NamedConfigMapCreat
 				return nil, fmt.Errorf("failed to create cloud-config: %v", err)
 			}
 
-			cm.Labels = resources.BaseAppLabel(name, nil)
+			cm.Labels = resources.BaseAppLabels(name, nil)
 			cm.Data[resources.CloudConfigConfigMapKey] = cloudConfig
 			cm.Data[FakeVMWareUUIDKeyName] = fakeVMWareUUID
 

--- a/api/pkg/resources/cloudcontroller/openstack.go
+++ b/api/pkg/resources/cloudcontroller/openstack.go
@@ -36,12 +36,12 @@ func openStackDeploymentCreator(data *resources.TemplateData) reconciling.NamedD
 	return func() (string, reconciling.DeploymentCreator) {
 		return osName, func(dep *appsv1.Deployment) (*appsv1.Deployment, error) {
 			dep.Name = osName
-			dep.Labels = resources.BaseAppLabel(osName, nil)
+			dep.Labels = resources.BaseAppLabels(osName, nil)
 
 			dep.Spec.Replicas = resources.Int32(1)
 
 			dep.Spec.Selector = &metav1.LabelSelector{
-				MatchLabels: resources.BaseAppLabel(osName, nil),
+				MatchLabels: resources.BaseAppLabels(osName, nil),
 			}
 
 			dep.Spec.Template.Spec.Volumes = getOSVolumes()

--- a/api/pkg/resources/clusterautoscaler/clusterautoscaler.go
+++ b/api/pkg/resources/clusterautoscaler/clusterautoscaler.go
@@ -47,11 +47,11 @@ func DeploymentCreator(data clusterautoscalerData) reconciling.NamedDeploymentCr
 			}
 
 			dep.Name = resources.ClusterAutoscalerDeploymentName
-			dep.Labels = resources.BaseAppLabel(resources.ClusterAutoscalerDeploymentName, nil)
+			dep.Labels = resources.BaseAppLabels(resources.ClusterAutoscalerDeploymentName, nil)
 
 			dep.Spec.Replicas = resources.Int32(1)
 			dep.Spec.Selector = &metav1.LabelSelector{
-				MatchLabels: resources.BaseAppLabel(resources.ClusterAutoscalerDeploymentName, nil),
+				MatchLabels: resources.BaseAppLabels(resources.ClusterAutoscalerDeploymentName, nil),
 			}
 
 			volumes := []corev1.Volume{

--- a/api/pkg/resources/controllermanager/deployment.go
+++ b/api/pkg/resources/controllermanager/deployment.go
@@ -42,7 +42,7 @@ func DeploymentCreator(data *resources.TemplateData) reconciling.NamedDeployment
 	return func() (string, reconciling.DeploymentCreator) {
 		return resources.ControllerManagerDeploymentName, func(dep *appsv1.Deployment) (*appsv1.Deployment, error) {
 			dep.Name = resources.ControllerManagerDeploymentName
-			dep.Labels = resources.BaseAppLabel(name, nil)
+			dep.Labels = resources.BaseAppLabels(name, nil)
 
 			flags, err := getFlags(data)
 			if err != nil {
@@ -55,7 +55,7 @@ func DeploymentCreator(data *resources.TemplateData) reconciling.NamedDeployment
 			}
 
 			dep.Spec.Selector = &metav1.LabelSelector{
-				MatchLabels: resources.BaseAppLabel(name, nil),
+				MatchLabels: resources.BaseAppLabels(name, nil),
 			}
 			dep.Spec.Template.Spec.ImagePullSecrets = []corev1.LocalObjectReference{{Name: resources.ImagePullSecretName}}
 

--- a/api/pkg/resources/dns/dns.go
+++ b/api/pkg/resources/dns/dns.go
@@ -34,7 +34,7 @@ func ServiceCreator() reconciling.NamedServiceCreatorGetter {
 	return func() (string, reconciling.ServiceCreator) {
 		return resources.DNSResolverServiceName, func(se *corev1.Service) (*corev1.Service, error) {
 			se.Name = resources.DNSResolverServiceName
-			se.Spec.Selector = resources.BaseAppLabel(resources.DNSResolverDeploymentName, nil)
+			se.Spec.Selector = resources.BaseAppLabels(resources.DNSResolverDeploymentName, nil)
 			se.Spec.Ports = []corev1.ServicePort{
 				{
 					Name:       "dns",
@@ -60,11 +60,11 @@ func DeploymentCreator(data deploymentCreatorData) reconciling.NamedDeploymentCr
 	return func() (string, reconciling.DeploymentCreator) {
 		return resources.DNSResolverDeploymentName, func(dep *appsv1.Deployment) (*appsv1.Deployment, error) {
 			dep.Name = resources.DNSResolverDeploymentName
-			dep.Labels = resources.BaseAppLabel(resources.DNSResolverDeploymentName, nil)
+			dep.Labels = resources.BaseAppLabels(resources.DNSResolverDeploymentName, nil)
 			dep.Spec.Replicas = resources.Int32(2)
 
 			dep.Spec.Selector = &metav1.LabelSelector{
-				MatchLabels: resources.BaseAppLabel(resources.DNSResolverDeploymentName, nil),
+				MatchLabels: resources.BaseAppLabels(resources.DNSResolverDeploymentName, nil),
 			}
 			dep.Spec.Template.Spec.ImagePullSecrets = []corev1.LocalObjectReference{{Name: resources.ImagePullSecretName}}
 
@@ -220,7 +220,7 @@ func PodDisruptionBudgetCreator() reconciling.NamedPodDisruptionBudgetCreatorGet
 			minAvailable := intstr.FromInt(1)
 			pdb.Spec = policyv1beta1.PodDisruptionBudgetSpec{
 				Selector: &metav1.LabelSelector{
-					MatchLabels: resources.BaseAppLabel(resources.DNSResolverDeploymentName, nil),
+					MatchLabels: resources.BaseAppLabels(resources.DNSResolverDeploymentName, nil),
 				},
 				MinAvailable: &minAvailable,
 			}

--- a/api/pkg/resources/etcd/statefulset.go
+++ b/api/pkg/resources/etcd/statefulset.go
@@ -250,7 +250,7 @@ func getBasePodLabels(cluster *kubermaticv1.Cluster) map[string]string {
 	additionalLabels := map[string]string{
 		"cluster": cluster.Name,
 	}
-	return resources.BaseAppLabel(resources.EtcdStatefulSetName, additionalLabels)
+	return resources.BaseAppLabels(resources.EtcdStatefulSetName, additionalLabels)
 }
 
 type commandTplData struct {

--- a/api/pkg/resources/kubernetes-dashboard/deployment.go
+++ b/api/pkg/resources/kubernetes-dashboard/deployment.go
@@ -53,11 +53,11 @@ func DeploymentCreator(data kubernetesDashboardData) reconciling.NamedDeployment
 	return func() (string, reconciling.DeploymentCreator) {
 		return name, func(dep *appsv1.Deployment) (*appsv1.Deployment, error) {
 			dep.Name = name
-			dep.Labels = resources.BaseAppLabel(name, nil)
+			dep.Labels = resources.BaseAppLabels(name, nil)
 
 			dep.Spec.Replicas = resources.Int32(2)
 			dep.Spec.Selector = &metav1.LabelSelector{
-				MatchLabels: resources.BaseAppLabel(name, nil),
+				MatchLabels: resources.BaseAppLabels(name, nil),
 			}
 
 			volumes := getVolumes()

--- a/api/pkg/resources/kubestatemetrics/deployment.go
+++ b/api/pkg/resources/kubestatemetrics/deployment.go
@@ -40,11 +40,11 @@ func DeploymentCreator(data *resources.TemplateData) reconciling.NamedDeployment
 	return func() (string, reconciling.DeploymentCreator) {
 		return resources.KubeStateMetricsDeploymentName, func(dep *appsv1.Deployment) (*appsv1.Deployment, error) {
 			dep.Name = resources.KubeStateMetricsDeploymentName
-			dep.Labels = resources.BaseAppLabel(name, nil)
+			dep.Labels = resources.BaseAppLabels(name, nil)
 
 			dep.Spec.Replicas = resources.Int32(1)
 			dep.Spec.Selector = &metav1.LabelSelector{
-				MatchLabels: resources.BaseAppLabel(name, nil),
+				MatchLabels: resources.BaseAppLabels(name, nil),
 			}
 			dep.Spec.Template.Spec.ImagePullSecrets = []corev1.LocalObjectReference{{Name: resources.ImagePullSecretName}}
 

--- a/api/pkg/resources/machinecontroller/deployment.go
+++ b/api/pkg/resources/machinecontroller/deployment.go
@@ -79,11 +79,11 @@ func DeploymentCreatorWithoutInitWrapper(data machinecontrollerData) reconciling
 	return func() (string, reconciling.DeploymentCreator) {
 		return resources.MachineControllerDeploymentName, func(dep *appsv1.Deployment) (*appsv1.Deployment, error) {
 			dep.Name = resources.MachineControllerDeploymentName
-			dep.Labels = resources.BaseAppLabel(Name, nil)
+			dep.Labels = resources.BaseAppLabels(Name, nil)
 
 			dep.Spec.Replicas = resources.Int32(1)
 			dep.Spec.Selector = &metav1.LabelSelector{
-				MatchLabels: resources.BaseAppLabel(Name, nil),
+				MatchLabels: resources.BaseAppLabels(Name, nil),
 			}
 			dep.Spec.Template.Spec.ImagePullSecrets = []corev1.LocalObjectReference{{Name: resources.ImagePullSecretName}}
 

--- a/api/pkg/resources/machinecontroller/webhook.go
+++ b/api/pkg/resources/machinecontroller/webhook.go
@@ -38,10 +38,10 @@ func WebhookDeploymentCreator(data machinecontrollerData) reconciling.NamedDeplo
 	return func() (string, reconciling.DeploymentCreator) {
 		return resources.MachineControllerWebhookDeploymentName, func(dep *appsv1.Deployment) (*appsv1.Deployment, error) {
 			dep.Name = resources.MachineControllerWebhookDeploymentName
-			dep.Labels = resources.BaseAppLabel(resources.MachineControllerWebhookDeploymentName, nil)
+			dep.Labels = resources.BaseAppLabels(resources.MachineControllerWebhookDeploymentName, nil)
 			dep.Spec.Replicas = resources.Int32(1)
 			dep.Spec.Selector = &metav1.LabelSelector{
-				MatchLabels: resources.BaseAppLabel(resources.MachineControllerWebhookDeploymentName, nil),
+				MatchLabels: resources.BaseAppLabels(resources.MachineControllerWebhookDeploymentName, nil),
 			}
 			dep.Spec.Template.Spec.ImagePullSecrets = []corev1.LocalObjectReference{{Name: resources.ImagePullSecretName}}
 
@@ -135,7 +135,7 @@ func ServiceCreator() reconciling.NamedServiceCreatorGetter {
 	return func() (string, reconciling.ServiceCreator) {
 		return resources.MachineControllerWebhookServiceName, func(se *corev1.Service) (*corev1.Service, error) {
 			se.Name = resources.MachineControllerWebhookServiceName
-			se.Labels = resources.BaseAppLabel(resources.MachineControllerWebhookDeploymentName, nil)
+			se.Labels = resources.BaseAppLabels(resources.MachineControllerWebhookDeploymentName, nil)
 
 			se.Spec.Type = corev1.ServiceTypeClusterIP
 			se.Spec.Selector = map[string]string{

--- a/api/pkg/resources/metrics-server/deployment.go
+++ b/api/pkg/resources/metrics-server/deployment.go
@@ -69,11 +69,11 @@ func DeploymentCreator(data metricsServerData) reconciling.NamedDeploymentCreato
 	return func() (string, reconciling.DeploymentCreator) {
 		return resources.MetricsServerDeploymentName, func(dep *appsv1.Deployment) (*appsv1.Deployment, error) {
 			dep.Name = resources.MetricsServerDeploymentName
-			dep.Labels = resources.BaseAppLabel(name, nil)
+			dep.Labels = resources.BaseAppLabels(name, nil)
 
 			dep.Spec.Replicas = resources.Int32(2)
 			dep.Spec.Selector = &metav1.LabelSelector{
-				MatchLabels: resources.BaseAppLabel(name, nil),
+				MatchLabels: resources.BaseAppLabels(name, nil),
 			}
 			dep.Spec.Template.Spec.ImagePullSecrets = []corev1.LocalObjectReference{{Name: resources.ImagePullSecretName}}
 

--- a/api/pkg/resources/metrics-server/pdb.go
+++ b/api/pkg/resources/metrics-server/pdb.go
@@ -16,7 +16,7 @@ func PodDisruptionBudgetCreator() reconciling.NamedPodDisruptionBudgetCreatorGet
 			minAvailable := intstr.FromInt(1)
 			pdb.Spec = policyv1beta1.PodDisruptionBudgetSpec{
 				Selector: &metav1.LabelSelector{
-					MatchLabels: resources.BaseAppLabel(name, nil),
+					MatchLabels: resources.BaseAppLabels(name, nil),
 				},
 				MinAvailable: &minAvailable,
 			}

--- a/api/pkg/resources/metrics-server/service.go
+++ b/api/pkg/resources/metrics-server/service.go
@@ -13,7 +13,7 @@ func ServiceCreator() reconciling.NamedServiceCreatorGetter {
 	return func() (string, reconciling.ServiceCreator) {
 		return resources.MetricsServerServiceName, func(se *corev1.Service) (*corev1.Service, error) {
 			se.Name = resources.MetricsServerServiceName
-			labels := resources.BaseAppLabel(name, nil)
+			labels := resources.BaseAppLabels(name, nil)
 			se.Labels = labels
 
 			se.Spec.Selector = labels

--- a/api/pkg/resources/nodeportproxy/nodeportproxy.go
+++ b/api/pkg/resources/nodeportproxy/nodeportproxy.go
@@ -164,11 +164,11 @@ func deploymentEnvoy(image string, data nodePortProxyData) reconciling.NamedDepl
 	name := envoyAppLabelValue
 	return func() (string, reconciling.DeploymentCreator) {
 		return name, func(d *appsv1.Deployment) (*appsv1.Deployment, error) {
-			d.Labels = resources.BaseAppLabel(name, nil)
+			d.Labels = resources.BaseAppLabels(name, nil)
 			d.Spec.Replicas = resources.Int32(2)
 			d.Spec.Selector = &metav1.LabelSelector{
-				MatchLabels: resources.BaseAppLabel(name, nil)}
-			d.Spec.Template.Labels = resources.BaseAppLabel(name, nil)
+				MatchLabels: resources.BaseAppLabels(name, nil)}
+			d.Spec.Template.Labels = resources.BaseAppLabels(name, nil)
 			d.Spec.Template.Spec.ImagePullSecrets = []corev1.LocalObjectReference{
 				{Name: resources.ImagePullSecretName},
 			}
@@ -266,11 +266,11 @@ func deploymentLBUpdater(image string) reconciling.NamedDeploymentCreatorGetter 
 	name := name + "-lb-updater"
 	return func() (string, reconciling.DeploymentCreator) {
 		return name, func(d *appsv1.Deployment) (*appsv1.Deployment, error) {
-			d.Labels = resources.BaseAppLabel(name, nil)
+			d.Labels = resources.BaseAppLabels(name, nil)
 			d.Spec.Replicas = resources.Int32(1)
 			d.Spec.Selector = &metav1.LabelSelector{
-				MatchLabels: resources.BaseAppLabel(name, nil)}
-			d.Spec.Template.Labels = resources.BaseAppLabel(name, nil)
+				MatchLabels: resources.BaseAppLabels(name, nil)}
+			d.Spec.Template.Labels = resources.BaseAppLabels(name, nil)
 			d.Spec.Template.Spec.ImagePullSecrets = []corev1.LocalObjectReference{
 				{Name: resources.ImagePullSecretName},
 			}
@@ -309,7 +309,7 @@ func podDisruptionBudget() reconciling.NamedPodDisruptionBudgetCreatorGetter {
 		return name + "-envoy", func(pdb *policyv1beta1.PodDisruptionBudget) (*policyv1beta1.PodDisruptionBudget, error) {
 			pdb.Spec.MaxUnavailable = &maxUnavailable
 			pdb.Spec.Selector = &metav1.LabelSelector{
-				MatchLabels: resources.BaseAppLabel(envoyAppLabelValue, nil),
+				MatchLabels: resources.BaseAppLabels(envoyAppLabelValue, nil),
 			}
 			return pdb, nil
 		}
@@ -336,7 +336,7 @@ func FrontLoadBalancerServiceCreator() reconciling.NamedServiceCreatorGetter {
 				}
 			}
 
-			s.Spec.Selector = resources.BaseAppLabel(envoyAppLabelValue, nil)
+			s.Spec.Selector = resources.BaseAppLabels(envoyAppLabelValue, nil)
 			return s, nil
 		}
 	}

--- a/api/pkg/resources/openvpn/configmap.go
+++ b/api/pkg/resources/openvpn/configmap.go
@@ -21,7 +21,7 @@ type serverClientConfigsData interface {
 func ServerClientConfigsConfigMapCreator(data serverClientConfigsData) reconciling.NamedConfigMapCreatorGetter {
 	return func() (string, reconciling.ConfigMapCreator) {
 		return resources.OpenVPNClientConfigsConfigMapName, func(cm *corev1.ConfigMap) (*corev1.ConfigMap, error) {
-			cm.Labels = resources.BaseAppLabel(name, nil)
+			cm.Labels = resources.BaseAppLabels(name, nil)
 
 			var iroutes []string
 

--- a/api/pkg/resources/openvpn/deployment.go
+++ b/api/pkg/resources/openvpn/deployment.go
@@ -62,7 +62,7 @@ func DeploymentCreator(data openVPNDeploymentCreatorData) reconciling.NamedDeplo
 	return func() (string, reconciling.DeploymentCreator) {
 		return resources.OpenVPNServerDeploymentName, func(dep *appsv1.Deployment) (*appsv1.Deployment, error) {
 			dep.Name = resources.OpenVPNServerDeploymentName
-			dep.Labels = resources.BaseAppLabel(name, nil)
+			dep.Labels = resources.BaseAppLabels(name, nil)
 
 			dep.Spec.Replicas = resources.Int32(1)
 			dep.Spec.Selector = &metav1.LabelSelector{

--- a/api/pkg/resources/openvpn/service.go
+++ b/api/pkg/resources/openvpn/service.go
@@ -14,7 +14,7 @@ func ServiceCreator(exposeStrategy corev1.ServiceType) reconciling.NamedServiceC
 	return func() (string, reconciling.ServiceCreator) {
 		return resources.OpenVPNServerServiceName, func(se *corev1.Service) (*corev1.Service, error) {
 			se.Name = resources.OpenVPNServerServiceName
-			se.Labels = resources.BaseAppLabel(name, nil)
+			se.Labels = resources.BaseAppLabels(name, nil)
 
 			if se.Annotations == nil {
 				se.Annotations = map[string]string{}

--- a/api/pkg/resources/prometheus/configmap.go
+++ b/api/pkg/resources/prometheus/configmap.go
@@ -107,7 +107,7 @@ func ConfigMapCreator(data *resources.TemplateData) reconciling.NamedConfigMapCr
 			}
 
 			// update ConfigMap
-			cm.Labels = resources.BaseAppLabel(name, nil)
+			cm.Labels = resources.BaseAppLabels(name, nil)
 
 			if cm.Data == nil {
 				cm.Data = map[string]string{}

--- a/api/pkg/resources/prometheus/federation_service.go
+++ b/api/pkg/resources/prometheus/federation_service.go
@@ -15,7 +15,7 @@ func ServiceCreator(data *resources.TemplateData) reconciling.NamedServiceCreato
 		return name, func(se *corev1.Service) (*corev1.Service, error) {
 			se.Name = name
 			se.OwnerReferences = []metav1.OwnerReference{data.GetClusterRef()}
-			se.Labels = resources.BaseAppLabel(name, nil)
+			se.Labels = resources.BaseAppLabels(name, nil)
 			// We need to set cluster: user for the ServiceMonitor which federates metrics8
 			se.Labels["cluster"] = "user"
 

--- a/api/pkg/resources/prometheus/role.go
+++ b/api/pkg/resources/prometheus/role.go
@@ -11,7 +11,7 @@ import (
 func RoleCreator() reconciling.NamedRoleCreatorGetter {
 	return func() (string, reconciling.RoleCreator) {
 		return resources.PrometheusRoleName, func(r *rbacv1.Role) (*rbacv1.Role, error) {
-			r.Labels = resources.BaseAppLabel(name, nil)
+			r.Labels = resources.BaseAppLabels(name, nil)
 
 			r.Rules = []rbacv1.PolicyRule{
 				{

--- a/api/pkg/resources/prometheus/rolebinding.go
+++ b/api/pkg/resources/prometheus/rolebinding.go
@@ -11,7 +11,7 @@ import (
 func RoleBindingCreator(clusterNamespace string) reconciling.NamedRoleBindingCreatorGetter {
 	return func() (string, reconciling.RoleBindingCreator) {
 		return resources.PrometheusRoleBindingName, func(rb *rbacv1.RoleBinding) (*rbacv1.RoleBinding, error) {
-			rb.Labels = resources.BaseAppLabel(name, nil)
+			rb.Labels = resources.BaseAppLabels(name, nil)
 
 			rb.RoleRef = rbacv1.RoleRef{
 				Name:     resources.PrometheusRoleName,

--- a/api/pkg/resources/prometheus/statefulset.go
+++ b/api/pkg/resources/prometheus/statefulset.go
@@ -51,9 +51,9 @@ func StatefulSetCreator(data *resources.TemplateData) reconciling.NamedStatefulS
 			set.OwnerReferences = []metav1.OwnerReference{data.GetClusterRef()}
 
 			requiredBaseLabels := map[string]string{"cluster": data.Cluster().Name}
-			set.Labels = resources.BaseAppLabel(name, requiredBaseLabels)
+			set.Labels = resources.BaseAppLabels(name, requiredBaseLabels)
 			set.Spec.Selector = &metav1.LabelSelector{
-				MatchLabels: resources.BaseAppLabel(name, requiredBaseLabels),
+				MatchLabels: resources.BaseAppLabels(name, requiredBaseLabels),
 			}
 
 			set.Spec.Replicas = resources.Int32(1)

--- a/api/pkg/resources/rancherserver/service.go
+++ b/api/pkg/resources/rancherserver/service.go
@@ -14,7 +14,7 @@ func ServiceCreator(exposeStrategy corev1.ServiceType) reconciling.NamedServiceC
 	return func() (string, reconciling.ServiceCreator) {
 		return resources.RancherServerServiceName, func(s *corev1.Service) (*corev1.Service, error) {
 			s.Name = resources.RancherServerServiceName
-			s.Labels = resources.BaseAppLabel(resources.RancherStatefulSetName, nil)
+			s.Labels = resources.BaseAppLabels(resources.RancherStatefulSetName, nil)
 			if s.Annotations == nil {
 				s.Annotations = map[string]string{}
 			}
@@ -25,7 +25,7 @@ func ServiceCreator(exposeStrategy corev1.ServiceType) reconciling.NamedServiceC
 				s.Annotations[nodeportproxy.NodePortProxyExposeNamespacedAnnotationKey] = "true"
 				delete(s.Annotations, "nodeport-proxy.k8s.io/expose")
 			}
-			s.Spec.Selector = resources.BaseAppLabel(resources.RancherStatefulSetName, nil)
+			s.Spec.Selector = resources.BaseAppLabels(resources.RancherStatefulSetName, nil)
 			s.Spec.Type = corev1.ServiceTypeNodePort
 			if len(s.Spec.Ports) == 0 {
 				s.Spec.Ports = make([]corev1.ServicePort, 2)

--- a/api/pkg/resources/rancherserver/statefulset.go
+++ b/api/pkg/resources/rancherserver/statefulset.go
@@ -138,5 +138,5 @@ func getBasePodLabels(cluster *kubermaticv1.Cluster) map[string]string {
 	additionalLabels := map[string]string{
 		"cluster": cluster.Name,
 	}
-	return resources.BaseAppLabel(resources.RancherStatefulSetName, additionalLabels)
+	return resources.BaseAppLabels(resources.RancherStatefulSetName, additionalLabels)
 }

--- a/api/pkg/resources/resources.go
+++ b/api/pkg/resources/resources.go
@@ -596,8 +596,8 @@ func UserClusterDNSPolicyAndConfig(d userClusterDNSPolicyAndConfigData) (corev1.
 	}, nil
 }
 
-// BaseAppLabel returns the minimum required labels
-func BaseAppLabel(name string, additionalLabels map[string]string) map[string]string {
+// BaseAppLabels returns the minimum required labels
+func BaseAppLabels(name string, additionalLabels map[string]string) map[string]string {
 	labels := map[string]string{
 		AppLabelKey: name,
 	}
@@ -609,7 +609,7 @@ func BaseAppLabel(name string, additionalLabels map[string]string) map[string]st
 
 // AppClusterLabel returns the base app label + the cluster label. Additional labels can be included as well
 func AppClusterLabel(appName, clusterName string, additionalLabels map[string]string) map[string]string {
-	podLabels := BaseAppLabel(appName, additionalLabels)
+	podLabels := BaseAppLabels(appName, additionalLabels)
 	podLabels["cluster"] = clusterName
 
 	return podLabels

--- a/api/pkg/resources/resources.go
+++ b/api/pkg/resources/resources.go
@@ -607,8 +607,8 @@ func BaseAppLabels(name string, additionalLabels map[string]string) map[string]s
 	return labels
 }
 
-// AppClusterLabel returns the base app label + the cluster label. Additional labels can be included as well
-func AppClusterLabel(appName, clusterName string, additionalLabels map[string]string) map[string]string {
+// AppClusterLabels returns the base app label + the cluster label. Additional labels can be included as well
+func AppClusterLabels(appName, clusterName string, additionalLabels map[string]string) map[string]string {
 	podLabels := BaseAppLabels(appName, additionalLabels)
 	podLabels["cluster"] = clusterName
 
@@ -862,7 +862,7 @@ func GetPodTemplateLabels(
 	volumes []corev1.Volume,
 	additionalLabels map[string]string,
 ) (map[string]string, error) {
-	podLabels := AppClusterLabel(appName, clusterName, additionalLabels)
+	podLabels := AppClusterLabels(appName, clusterName, additionalLabels)
 
 	volumeLabels, err := VolumeRevisionLabels(ctx, client, namespace, volumes)
 	if err != nil {

--- a/api/pkg/resources/scheduler/deployment.go
+++ b/api/pkg/resources/scheduler/deployment.go
@@ -41,7 +41,7 @@ func DeploymentCreator(data *resources.TemplateData) reconciling.NamedDeployment
 	return func() (string, reconciling.DeploymentCreator) {
 		return resources.SchedulerDeploymentName, func(dep *appsv1.Deployment) (*appsv1.Deployment, error) {
 			dep.Name = resources.SchedulerDeploymentName
-			dep.Labels = resources.BaseAppLabel(name, nil)
+			dep.Labels = resources.BaseAppLabels(name, nil)
 
 			flags, err := getFlags(data.Cluster())
 			if err != nil {
@@ -54,7 +54,7 @@ func DeploymentCreator(data *resources.TemplateData) reconciling.NamedDeployment
 			}
 
 			dep.Spec.Selector = &metav1.LabelSelector{
-				MatchLabels: resources.BaseAppLabel(name, nil),
+				MatchLabels: resources.BaseAppLabels(name, nil),
 			}
 
 			volumes := getVolumes()

--- a/api/pkg/resources/usercluster/deployment.go
+++ b/api/pkg/resources/usercluster/deployment.go
@@ -54,11 +54,11 @@ func DeploymentCreator(data userclusterControllerData, openshift bool) reconcili
 	return func() (string, reconciling.DeploymentCreator) {
 		return resources.UserClusterControllerDeploymentName, func(dep *appsv1.Deployment) (*appsv1.Deployment, error) {
 			dep.Name = resources.UserClusterControllerDeploymentName
-			dep.Labels = resources.BaseAppLabel(name, nil)
+			dep.Labels = resources.BaseAppLabels(name, nil)
 
 			dep.Spec.Replicas = resources.Int32(1)
 			dep.Spec.Selector = &metav1.LabelSelector{
-				MatchLabels: resources.BaseAppLabel(name, nil),
+				MatchLabels: resources.BaseAppLabels(name, nil),
 			}
 			dep.Spec.Strategy.Type = appsv1.RollingUpdateStatefulSetStrategyType
 			dep.Spec.Strategy.RollingUpdate = &appsv1.RollingUpdateDeployment{


### PR DESCRIPTION
**What this PR does / why we need it**:

Fixes name of functions to make it more intuitive to figure out the responsibility of the function.

I ran into this issue while implementing a new controller. I had to look up the definition of this function to determine what to expect. 

**Does this PR introduce a user-facing change?**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If  no release note is required, just write "NONE".
-->
```release-note
NONE
```
