### PR TITLE
Add dev-only flag to override UI version in KubermaticConfiguration

### DIFF
--- a/api/pkg/controller/operator/master/resources/kubermatic/ui.go
+++ b/api/pkg/controller/operator/master/resources/kubermatic/ui.go
@@ -39,10 +39,15 @@ func UIDeploymentCreator(cfg *operatorv1alpha1.KubermaticConfiguration, versions
 				RunAsUser:    pointer.Int64Ptr(65534),
 			}
 
+			tag := versions.UI
+			if cfg.Spec.UI.DockerTag != "" {
+				tag = cfg.Spec.UI.DockerTag
+			}
+
 			d.Spec.Template.Spec.Containers = []corev1.Container{
 				{
 					Name:  "webserver",
-					Image: cfg.Spec.UI.DockerRepository + ":" + versions.UI,
+					Image: cfg.Spec.UI.DockerRepository + ":" + tag,
 					Ports: []corev1.ContainerPort{
 						{
 							Name:          "http",

--- a/api/pkg/crd/operator/v1alpha1/configuration.go
+++ b/api/pkg/crd/operator/v1alpha1/configuration.go
@@ -93,6 +93,9 @@ type KubermaticAPIConfiguration struct {
 type KubermaticUIConfiguration struct {
 	// DockerRepository is the repository containing the Kubermatic dashboard image.
 	DockerRepository string `json:"dockerRepository,omitempty"`
+	// DockerTag is used to overwrite the dashboard Docker image tag and is only for development
+	// purposes. This field must not be set in production environments.
+	DockerTag string `json:"dockerTag,omitempty,omitgenyaml"`
 	// Config sets flags for various dashboard features.
 	Config string `json:"config,omitempty"`
 	// Resources describes the requested and maximum allowed CPU/memory usage.


### PR DESCRIPTION
**What this PR does / why we need it**:
We need a way to consistently update the dashboard version for cases when the UI was updated, yet no new operator has been built yet.

**Does this PR introduce a user-facing change?**:
```release-note
NONE
```
