### PR TITLE
api/cmd/seed-controller-manager: Consistent camelCase function names

### DIFF
--- a/api/cmd/seed-controller-manager/controllers.go
+++ b/api/cmd/seed-controller-manager/controllers.go
@@ -41,7 +41,7 @@ var AllControllers = map[string]controllerCreator{
 	openshiftcontroller.ControllerName:            createOpenshiftController,
 	clustercomponentdefaulter.ControllerName:      createClusterComponentDefaulter,
 	seedresourcesuptodatecondition.ControllerName: createSeedConditionUpToDateController,
-	rancher.ControllerName:                        createrancherController,
+	rancher.ControllerName:                        createRancherController,
 }
 
 type controllerCreator func(*controllerContext) error
@@ -277,7 +277,7 @@ func createAddonInstallerController(ctrlCtx *controllerContext) error {
 		ctrlCtx.runOptions.openshiftAddons)
 }
 
-func createrancherController(ctrlCtx *controllerContext) error {
+func createRancherController(ctrlCtx *controllerContext) error {
 	return rancher.Add(
 		ctrlCtx.mgr,
 		ctrlCtx.log,


### PR DESCRIPTION
**What this PR does / why we need it**:

Rename createrancherController to createRancherController as all the
other create<X>Controller functions are named in this format as well.

We need this because we should strive for consistency in the codebase.

**Does this PR introduce a user-facing change?**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If  no release note is required, just write "NONE".
-->
```release-note
NONE
```
