### PR TITLE
remove pre-kubermatic-build job

### DIFF
--- a/.prow.yaml
+++ b/.prow.yaml
@@ -3,26 +3,6 @@ presubmits:
   # unit tests
   #########################################################
 
-  - name: pre-kubermatic-build
-    run_if_changed: "^api/"
-    decorate: true
-    clone_uri: "ssh://git@github.com/kubermatic/kubermatic.git"
-    spec:
-      containers:
-      - image: golang:1.12.12
-        command:
-        - make
-        args:
-        - -C
-        - api
-        - build
-        resources:
-          requests:
-            memory: 2Gi
-            cpu: 2
-          limits:
-            memory: 4Gi
-
   - name: pre-kubermatic-test
     run_if_changed: "^api/"
     decorate: true


### PR DESCRIPTION
**What this PR does / why we need it**:
This job does not do anything useful. We compile the code in basically all other jobs anyway. If the code is good, it will succeed. Otherwise *all* job will fail. We gain nothing from having this dedicated compile job, so good riddance.

**Does this PR introduce a user-facing change?**:
```release-note
NONE
```
