### PR TITLE
Dedicated Certificates for Kubermatic/IAP

### DIFF
--- a/api/hack/ci/ci-setup-kubermatic-in-kind.sh
+++ b/api/hack/ci/ci-setup-kubermatic-in-kind.sh
@@ -327,6 +327,12 @@ function check_all_deployments_ready() {
   return 0
 }
 
+# We don't need a valid certificate (and can't even get one), but still need
+# to have the CRDs installed so we can at least create a Certificate resource.
+TEST_NAME="Deploy cert-manager CRDs"
+echodate "Deploying cert-manager CRDs"
+retry 5 kubectl apply -f config/cert-manager/templates/crd.yaml
+
 if [[ "${KUBERMATIC_USE_OPERATOR}" = "false" ]]; then
   TEST_NAME="Deploy Kubermatic"
   echodate "Deploying Kubermatic using Helm..."
@@ -373,12 +379,6 @@ if [[ "${KUBERMATIC_USE_OPERATOR}" = "false" ]]; then
     git checkout ${KUBERMATIC_VERSION}
   fi
 else
-  # Even when it does not reconcile certificates, the operator absolutely needs the
-  # cert-manager CRDs to exist.
-  TEST_NAME="Deploy cert-manager CRDs"
-  echodate "Deploying cert-manager CRDs"
-  retry 5 kubectl apply -f config/cert-manager/templates/crd.yaml
-
   TEST_NAME="Deploy Kubermatic"
   echodate "Installing Kubermatic using operator..."
 

--- a/api/hack/ci/ci-sync-charts.sh
+++ b/api/hack/ci/ci-sync-charts.sh
@@ -33,7 +33,7 @@ git config --global user.name "Prow CI Robot"
 git config --global core.sshCommand 'ssh -o CheckHostIP=no -i /ssh/id_rsa'
 ensure_github_host_pubkey
 
-export CHARTS='kubermatic cert-manager nginx-ingress-controller nodeport-proxy oauth minio iap s3-exporter'
+export CHARTS='kubermatic cert-manager certs nginx-ingress-controller nodeport-proxy oauth minio iap s3-exporter'
 export MONITORING_CHARTS='alertmanager blackbox-exporter grafana kube-state-metrics node-exporter prometheus'
 export LOGGING_CHARTS='loki promtail elasticsearch kibana fluentbit'
 export BACKUP_CHARTS='velero'

--- a/api/hack/ci/ci-sync-charts.sh
+++ b/api/hack/ci/ci-sync-charts.sh
@@ -33,7 +33,7 @@ git config --global user.name "Prow CI Robot"
 git config --global core.sshCommand 'ssh -o CheckHostIP=no -i /ssh/id_rsa'
 ensure_github_host_pubkey
 
-export CHARTS='kubermatic cert-manager certs nginx-ingress-controller nodeport-proxy oauth minio iap s3-exporter'
+export CHARTS='kubermatic cert-manager nginx-ingress-controller nodeport-proxy oauth minio iap s3-exporter'
 export MONITORING_CHARTS='alertmanager blackbox-exporter grafana kube-state-metrics node-exporter prometheus'
 export LOGGING_CHARTS='loki promtail elasticsearch kibana fluentbit'
 export BACKUP_CHARTS='velero'

--- a/api/hack/deploy.sh
+++ b/api/hack/deploy.sh
@@ -145,7 +145,6 @@ case "${DEPLOY_STACK}" in
     if [[ "${1}" = "master" ]]; then
       deploy "nginx-ingress-controller" "nginx-ingress-controller" ./config/nginx-ingress-controller/
       deploy "cert-manager" "cert-manager" ./config/cert-manager/
-      deploy "certs" "default" ./config/certs/
       deploy "oauth" "oauth" ./config/oauth/
       # We might have not configured IAP which results in nothing being deployed. This triggers https://github.com/helm/helm/issues/4295 and marks this as failed
       # We hack around this by grepping for a string that is mandatory in the values file of IAP

--- a/config/iap/Chart.yaml
+++ b/config/iap/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: iap
-version: 1.1.3
+version: 1.2.0
 appVersion: 7.0.0
 description: A Helm to install Keycloak-Gatekeeper as an identity-aware proxy.
 keywords:

--- a/config/iap/templates/certificates.yaml
+++ b/config/iap/templates/certificates.yaml
@@ -1,0 +1,14 @@
+{{- range .Values.iap.deployments }}
+---
+apiVersion: cert-manager.io/v1alpha2
+kind: Certificate
+metadata:
+  name: {{ .name }}
+spec:
+  secretName: {{ .name }}-tls
+  issuerRef:
+    name: {{ $.Values.iap.certIssuer.name }}
+    kind: {{ $.Values.iap.certIssuer.kind }}
+  dnsNames:
+  - {{ .ingress.host | trim }}
+{{- end -}}

--- a/config/iap/templates/ingresses.yaml
+++ b/config/iap/templates/ingresses.yaml
@@ -14,7 +14,8 @@ metadata:
 {{- end }}
 spec:
   tls:
-  - hosts:
+  - secretName: {{ .name }}-tls
+    hosts:
     - {{ .ingress.host | trim }}
   backend:
     serviceName: {{ .name }}-iap

--- a/config/iap/values.yaml
+++ b/config/iap/values.yaml
@@ -74,6 +74,11 @@ iap:
     #   passthrough:
     #   - /-/healthy # exposes nothing
 
+  # the cert-manager Issuer (or ClusterIssuer) responsible for managing the certificates
+  certIssuer:
+    name: letsencrypt-prod
+    kind: ClusterIssuer
+
   discovery_url: https://kubermatic.tld/dex/.well-known/openid-configuration
   port: 3000
 

--- a/config/kubermatic/Chart.yaml
+++ b/config/kubermatic/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: kubermatic
-version: 1.0.45
+version: 1.0.46
 appVersion: '__KUBERMATIC_TAG__'
 description: Kubermatic chart for master and/or seed clusters.
 keywords:

--- a/config/kubermatic/templates/certificate.yaml
+++ b/config/kubermatic/templates/certificate.yaml
@@ -1,0 +1,13 @@
+{{ if .Values.kubermatic.isMaster }}
+apiVersion: cert-manager.io/v1alpha2
+kind: Certificate
+metadata:
+  name: kubermatic
+spec:
+  secretName: kubermatic-tls
+  issuerRef:
+    name: {{ .Values.kubermatic.certIssuer.name }}
+    kind: {{ .Values.kubermatic.certIssuer.kind }}
+  dnsNames:
+  - {{ .Values.kubermatic.domain }}
+{{ end }}

--- a/config/kubermatic/templates/ingress.yaml
+++ b/config/kubermatic/templates/ingress.yaml
@@ -7,7 +7,8 @@ metadata:
     kubernetes.io/ingress.class: {{ (default "nginx" .Values.kubermatic.ingressClass) }}
 spec:
   tls:
-  - hosts:
+  - secretName: kubermatic-tls
+    hosts:
     - {{ .Values.kubermatic.domain }}
   backend:
     serviceName: kubermatic-ui

--- a/config/kubermatic/values.yaml
+++ b/config/kubermatic/values.yaml
@@ -63,6 +63,11 @@ kubermatic:
     # PV size for the etcd StatefulSet of new clusters
     diskSize: "5Gi"
 
+  # the cert-manager Issuer (or ClusterIssuer) responsible for managing the certificate
+  certIssuer:
+    name: letsencrypt-prod
+    kind: ClusterIssuer
+
   controller:
     # Available feature gates:
     # - OpenIDAuthPlugin

--- a/config/nginx-ingress-controller/Chart.yaml
+++ b/config/nginx-ingress-controller/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: nginx-ingress-controller
-version: 1.1.1
+version: 1.1.2
 appVersion: 0.29.0
 description: nginx-ingress-controller
 keywords:

--- a/config/nginx-ingress-controller/values.yaml
+++ b/config/nginx-ingress-controller/values.yaml
@@ -7,8 +7,7 @@ nginx:
     tag: 0.29.0
   config: {}
 #   load-balance: "least_conn"
-  extraArgs:
-  - '--default-ssl-certificate=default/kubermatic-tls-certificates'
+  extraArgs: []
   resources:
     requests:
       cpu: 50m


### PR DESCRIPTION
**What this PR does / why we need it**:
So far we had a big "catch all" `certs` chart that just created one big cert and we hoped that it always contains all relevant domains. This was weird to manage (adding a new IAP meant re-deploying the certs chart) and weird to understand ("Kubermatic uses HTTPS, but the Ingress says nothing about what cert? Where does it come from?" -- until you find out about the certs chart).

This PR removes the catch-all-cert and instead makes the kubermatic/iap charts create dedicated certificates for each ingress/domain. The `certs` chart is therefore not needed anymore.

The cert-manager in Kubermatic 2.13 is already configured to create a ClusterIssuer for Let's Encrypt and we moved the DNS stuff already over to the cert-manager as well. It should be safe to update.

**Documentation:**
https://github.com/loodse/docs/pull/248

**Does this PR introduce a user-facing change?**:
```release-note
TLS certificates for Kubermatic/IAP are now not managed by a shared `certs` chart anymore, but handled individually for each Ingress.
```
