### PR TITLE
begin to publish the new logging stack

### DIFF
--- a/api/hack/ci/ci-sync-charts.sh
+++ b/api/hack/ci/ci-sync-charts.sh
@@ -35,7 +35,7 @@ ensure_github_host_pubkey
 
 export CHARTS='kubermatic cert-manager certs nginx-ingress-controller nodeport-proxy oauth minio iap s3-exporter'
 export MONITORING_CHARTS='alertmanager blackbox-exporter grafana kube-state-metrics node-exporter prometheus'
-export LOGGING_CHARTS='elasticsearch kibana fluentbit'
+export LOGGING_CHARTS='loki promtail elasticsearch kibana fluentbit'
 export BACKUP_CHARTS='velero'
 export CHARTS_DIR=$(pwd)/config
 export TARGET_DIR='sync_target'


### PR DESCRIPTION
**What this PR does / why we need it**:
We already document on the master branch that Loki is replacing the ELK stack, so it's time to also publish our charts to the kubermatic-installer repo. The ELK stack charts are still published because maaaaaybe there will be a bugfix in them.

**Does this PR introduce a user-facing change?**:
```release-note
Grafana Loki replaces the ELK logging stack.
```
