### PR TITLE
fix lb-updater using legacy CLI flags

### DIFF
--- a/config/nodeport-proxy/Chart.yaml
+++ b/config/nodeport-proxy/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: nodeport-proxy
-version: 1.5.3
+version: 1.5.4
 appVersion: __KUBERMATIC_TAG__
 description: Kubermatic nodeport-proxy
 keywords:

--- a/config/nodeport-proxy/templates/deployment.yaml
+++ b/config/nodeport-proxy/templates/deployment.yaml
@@ -123,7 +123,6 @@ spec:
         args:
         - "-lb-namespace=$(MY_NAMESPACE)"
         - "-lb-name=nodeport-lb"
-        - "-logtostderr"
         env:
         - name: MY_NAMESPACE
           valueFrom:


### PR DESCRIPTION
**What this PR does / why we need it**:
#5165 removed klog and uses Zap exclusively, so there is no `logtostderr` anymore.

**Does this PR introduce a user-facing change?**:
```release-note
NONE
```
