### PR TITLE
Configure dedicated Certificate for Dex Ingress

### DIFF
--- a/config/oauth/Chart.yaml
+++ b/config/oauth/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: oauth
-version: 1.0.11
+version: 1.1.0
 appVersion: v2.22.0
 description: Dex
 keywords:

--- a/config/oauth/templates/certificate.yaml
+++ b/config/oauth/templates/certificate.yaml
@@ -1,0 +1,13 @@
+{{- if ne .Values.dex.ingress.class "non-existent" }}
+apiVersion: cert-manager.io/v1alpha2
+kind: Certificate
+metadata:
+  name: dex
+spec:
+  secretName: dex-tls
+  issuerRef:
+    name: {{ .Values.dex.certIssuer.name }}
+    kind: {{ .Values.dex.certIssuer.kind }}
+  dnsNames:
+  - {{ .Values.dex.ingress.host }}
+{{- end }}

--- a/config/oauth/templates/ingress.yaml
+++ b/config/oauth/templates/ingress.yaml
@@ -7,7 +7,8 @@ metadata:
     kubernetes.io/ingress.class: "{{ .Values.dex.ingress.class }}"
 spec:
   tls:
-  - hosts:
+  - secretName: dex-tls
+    hosts:
     - {{ .Values.dex.ingress.host }}
   backend:
     serviceName: dex

--- a/config/oauth/values.yaml
+++ b/config/oauth/values.yaml
@@ -61,3 +61,8 @@ dex:
           topologyKey: kubernetes.io/hostname
         weight: 10
   tolerations: []
+
+  # the cert-manager Issuer (or ClusterIssuer) responsible for managing the certificates
+  certIssuer:
+    name: letsencrypt-prod
+    kind: ClusterIssuer


### PR DESCRIPTION
**What this PR does / why we need it**:
In #5163 we forgot that Dex also has its own Ingress and was still relying on the default cert. Even when the Kubermatic Ingress already contains a cert for a given domain, nginx in this case used the non-existing cert from the Dex Ingress for the domain.

As the two Ingresses are in different namespaces, they cannot share the same cert/secret. To keep them somewhat independent, I chose to give Dex its own certificate, so the chart simply works without weird nginx hacks and another helper chart.

This leaves us with two certificates for the same domain (as Kubermatic and Dex are in 99% of cases on the same domain), so nginx will simply choose whatever it likes best.

**Does this PR introduce a user-facing change?**:
```release-note
NONE
```
