### PR TITLE
Apply log retention policy to Loki

### DIFF
--- a/config/logging/loki/Chart.yaml
+++ b/config/logging/loki/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: "v1"
 name: loki
-version: 0.0.2
+version: 0.0.3
 appVersion: v1.3.0
 description: "Loki: like Prometheus, but for logs."
 keywords:

--- a/config/logging/loki/values.yaml
+++ b/config/logging/loki/values.yaml
@@ -47,10 +47,10 @@ loki:
       filesystem:
         directory: /data/loki/chunks
     chunk_store_config:
-      max_look_back_period: 0
+      max_look_back_period: 720h
     table_manager:
-      retention_deletes_enabled: false
-      retention_period: 0
+      retention_deletes_enabled: true
+      retention_period: 720h
   
   image:
     repository: docker.io/grafana/loki


### PR DESCRIPTION
**What this PR does / why we need it**:
Loki has been set up without a log retention policy.
Currently, the PVC is full which causes Loki server to not work properly and prevents promtail agents to connect to it.
This PR will put a 30 days log retention policy for Loki.

**Does this PR introduce a user-facing change?**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If  no release note is required, just write "NONE".
-->
```release-note
NONE
```
