### PR TITLE
Fix retention policy for Loki

### DIFF
--- a/config/logging/loki/Chart.yaml
+++ b/config/logging/loki/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: "v1"
 name: loki
-version: 0.0.3
+version: 0.0.4
 appVersion: v1.3.0
 description: "Loki: like Prometheus, but for logs."
 keywords:

--- a/config/logging/loki/values.yaml
+++ b/config/logging/loki/values.yaml
@@ -29,7 +29,7 @@ loki:
     limits_config:
       enforce_metric_name: false
       reject_old_samples: true
-      reject_old_samples_max_age: 168h
+      reject_old_samples_max_age: 144h
     schema_config:
       configs:
       - from: 2018-04-15
@@ -38,7 +38,7 @@ loki:
         schema: v9
         index:
           prefix: index_
-          period: 168h
+          period: 144h
     server:
       http_listen_port: 3100
     storage_config:


### PR DESCRIPTION
**What this PR does / why we need it**:
Fix the new retention policy that has been applied to Loki.
Default values were used but they don't verify the condition of 

> retention period should now be a multiple of periodic table duration

This lead to a failure in initializing the table-manager and causing the Loki server to go into crashloopbackoff.
Periodic table retention has been set to now 6 days (144h) and most importantly it verifies the above condition.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #5189

**Documentation**:
<!-- Add links to the related documentation changes related to this pull request. E.g. the link to the kubermatic/docs pullrequest. -->

**Does this PR introduce a user-facing change?**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If  no release note is required, just write "NONE".
-->
```release-note
NONE
```
