### PR TITLE
Fix missing project-id label on credential secrets

### DIFF
--- a/api/pkg/provider/kubernetes/credentials.go
+++ b/api/pkg/provider/kubernetes/credentials.go
@@ -66,7 +66,8 @@ func ensureCredentialSecret(ctx context.Context, seedClient ctrlruntimeclient.Cl
 				Name:      name,
 				Namespace: resources.KubermaticNamespace,
 				Labels: map[string]string{
-					"name": name,
+					"name":                         name,
+					kubermaticv1.ProjectIDLabelKey: cluster.Labels[kubermaticv1.ProjectIDLabelKey],
 				},
 			},
 			Type: corev1.SecretTypeOpaque,


### PR DESCRIPTION
**What this PR does / why we need it**:
The RBAC controller manages credential secrets, yet our code to create those never actually put the project-id label on them. This makes the controller constantly log errors like

> E0308 20:58:44.714053       1 rbac_resource_controller.go:231] Error syncing {{ v1 secrets} Secret credential-aws-sxpknsl2wx kubermatic/credential-aws-sxpknsl2wx 0xc000e99e00 0xc0047026f0}: unable to find owing project for the object name = credential-aws-sxpknsl2wx, gvr = /v1, Resource=secrets

**Does this PR introduce a user-facing change?**:
```release-note
Fixed cluster credential Secrets not being reconciled properly.
```
