### PR TITLE
increase resources for canary-ci-deployment job

### DIFF
--- a/.prow.yaml
+++ b/.prow.yaml
@@ -1138,11 +1138,10 @@ presubmits:
           privileged: true
         resources:
           requests:
-            cpu: 500m
+            cpu: 1
             memory: 1Gi
           limits:
-            cpu: 1
-            memory: 2Gi
+            memory: 3Gi
 
   - name: pre-kubermatic-test-integration
     run_if_changed: "^api/"


### PR DESCRIPTION
**What this PR does / why we need it**:
Kubermatic grew over the last few months and the 2GB memory limit for compiling is simply not enough anymore.

Previously, basically all jobs died:

![screenshot-2020-03-13-130550](https://user-images.githubusercontent.com/127499/76619821-1005bf80-652c-11ea-96b0-41896c5d18bd.png)

This is a typical run of this job if it was not OOMkilled:

![screenshot-2020-03-13-131033](https://user-images.githubusercontent.com/127499/76619853-21e76280-652c-11ea-8284-d1a62a2b8ae0.png)

**Does this PR introduce a user-facing change?**:
```release-note
NONE
```
