### PR TITLE
Only check dashboard-repo during deployments if it's really needed

### DIFF
--- a/api/hack/deploy.sh
+++ b/api/hack/deploy.sh
@@ -95,15 +95,6 @@ function initTiller() {
   unset TEST_NAME
 }
 
-# PULL_BASE_REF is the name of the current branch in case of a post-submit
-# or the name of the base branch in case of a PR.
-LATEST_DASHBOARD="$(get_latest_dashboard_hash "${PULL_BASE_REF}")"
-
-sed -i "s/__DASHBOARD_TAG__/$LATEST_DASHBOARD/g" ./config/kubermatic/*.yaml
-sed -i "s/__KUBERMATIC_TAG__/${GIT_HEAD_HASH}/g" ./config/kubermatic/*.yaml
-sed -i "s/__KUBERMATIC_TAG__/${GIT_HEAD_HASH}/g" ./config/kubermatic-operator/*.yaml
-sed -i "s/__KUBERMATIC_TAG__/${GIT_HEAD_HASH}/g" ./config/nodeport-proxy/*.yaml
-
 echodate "Deploying ${DEPLOY_STACK} stack..."
 case "${DEPLOY_STACK}" in
   monitoring)
@@ -141,6 +132,15 @@ case "${DEPLOY_STACK}" in
 
     echodate "Deploying the CRD's..."
     retry 5 kubectl apply -f ./config/kubermatic/crd/
+
+    # PULL_BASE_REF is the name of the current branch in case of a post-submit
+    # or the name of the base branch in case of a PR.
+    LATEST_DASHBOARD="$(get_latest_dashboard_hash "${PULL_BASE_REF}")"
+
+    sed -i "s/__DASHBOARD_TAG__/$LATEST_DASHBOARD/g" ./config/kubermatic/*.yaml
+    sed -i "s/__KUBERMATIC_TAG__/${GIT_HEAD_HASH}/g" ./config/kubermatic/*.yaml
+    sed -i "s/__KUBERMATIC_TAG__/${GIT_HEAD_HASH}/g" ./config/kubermatic-operator/*.yaml
+    sed -i "s/__KUBERMATIC_TAG__/${GIT_HEAD_HASH}/g" ./config/nodeport-proxy/*.yaml
 
     if [[ "${1}" = "master" ]]; then
       deploy "nginx-ingress-controller" "nginx-ingress-controller" ./config/nginx-ingress-controller/


### PR DESCRIPTION
**What this PR does / why we need it**:
The deployment jobs for the monitoring/logging stacks print errors because they have no SSH credentials to clone the dashboard repo. Instead of giving them the key, it should simply not be required to get the dashboard version unless we're actually deploying the Kubermatic stack.

Errors are like so:

```
[2020-03-13T14:45:10+00:00] Successfully got secrets for dev from Vault
[2020-03-13T14:45:10+00:00] Deploying monitoring stack to dev
 [*] Adding Github's SSH host key to known hosts
Warning: Identity file /ssh/id_rsa not accessible: No such file or directory.
git@github.com: Permission denied (publickey).
fatal: Could not read from remote repository.

Please make sure you have the correct access rights
and the repository exists.
Retry 1/5 exited 128, retrying in 1 seconds...
Warning: Identity file /ssh/id_rsa not accessible: No such file or directory.
git@github.com: Permission denied (publickey).
fatal: Could not read from remote repository.

Please make sure you have the correct access rights
and the repository exists.
Retry 2/5 exited 128, retrying in 2 seconds...
Warning: Identity file /ssh/id_rsa not accessible: No such file or directory.
git@github.com: Permission denied (publickey).
fatal: Could not read from remote repository.

Please make sure you have the correct access rights
and the repository exists.
Retry 3/5 exited 128, retrying in 4 seconds...
Warning: Identity file /ssh/id_rsa not accessible: No such file or directory.
git@github.com: Permission denied (publickey).
fatal: Could not read from remote repository.

Please make sure you have the correct access rights
and the repository exists.
Retry 4/5 exited 128, retrying in 8 seconds...
Warning: Identity file /ssh/id_rsa not accessible: No such file or directory.
git@github.com: Permission denied (publickey).
fatal: Could not read from remote repository.

Please make sure you have the correct access rights
and the repository exists.
Retry 5/5 exited 128, no more retries left.
[2020-03-13T14:45:29+00:00] The latest dashboard hash for master is 
[2020-03-13T14:45:29+00:00] Deploying monitoring stack...
```

**Does this PR introduce a user-facing change?**:
```release-note
NONE
```
