### PR TITLE
Use Loki stack instead of Elastic Stack on offline-env

### DIFF
--- a/api/hack/ci/ci-deploy-offline.sh
+++ b/api/hack/ci/ci-deploy-offline.sh
@@ -56,8 +56,8 @@ helm template oauth | ../api/hack/retag-images.sh
 helm template iap | ../api/hack/retag-images.sh
 helm template minio | ../api/hack/retag-images.sh
 helm template s3-exporter | ../api/hack/retag-images.sh
-helm template nodeport-proxy --set=nodePortProxy.image.tag=${GIT_HEAD_HASH}	\
-	| ../api/hack/retag-images.sh
+helm template nodeport-proxy --set=nodePortProxy.image.tag=${GIT_HEAD_HASH} \
+  ../api/hack/retag-images.sh
 
 helm template monitoring/prometheus | ../api/hack/retag-images.sh
 helm template monitoring/node-exporter | ../api/hack/retag-images.sh
@@ -66,9 +66,8 @@ helm template monitoring/grafana | ../api/hack/retag-images.sh
 helm template monitoring/helm-exporter | ../api/hack/retag-images.sh
 helm template monitoring/alertmanager | ../api/hack/retag-images.sh
 
-helm template logging/elasticsearch | ../api/hack/retag-images.sh
-helm template logging/fluentbit | ../api/hack/retag-images.sh
-helm template logging/kibana | ../api/hack/retag-images.sh
+helm template logging/promtail | ../api/hack/retag-images.sh
+helm template logging/loki | ../api/hack/retag-images.sh
 
 # PULL_BASE_REF is the name of the current branch in case of a post-submit
 # or the name of the base branch in case of a PR.
@@ -92,8 +91,27 @@ retry 6 ./_build/image-loader \
 
 ## Deploy
 HELM_INIT_ARGS="--tiller-image ${PROXY_INTERNAL_ADDR}:5000/kubernetes-helm/tiller:${HELM_VERSION}" \
+  DEPLOY_STACK=kubermatic \
   DEPLOY_NODEPORT_PROXY=false \
+  TILLER_NAMESPACE="kube-system" \
+  ./hack/deploy.sh \
+  master \
+  ${VALUES_FILE} \
+  ${HELM_EXTRA_ARGS}
+
+HELM_INIT_ARGS="--tiller-image ${PROXY_INTERNAL_ADDR}:5000/kubernetes-helm/tiller:${HELM_VERSION}" \
+  DEPLOY_STACK=monitoring \
   DEPLOY_ALERTMANAGER=false \
+  TILLER_NAMESPACE="kube-system" \
+  ./hack/deploy.sh \
+  master \
+  ${VALUES_FILE} \
+  ${HELM_EXTRA_ARGS}
+
+HELM_INIT_ARGS="--tiller-image ${PROXY_INTERNAL_ADDR}:5000/kubernetes-helm/tiller:${HELM_VERSION}" \
+  DEPLOY_STACK=logging \
+  DEPLOY_LOKI=true \
+  DEPLOY_ELASTIC=false \
   TILLER_NAMESPACE="kube-system" \
   ./hack/deploy.sh \
   master \

--- a/api/hack/deploy.sh
+++ b/api/hack/deploy.sh
@@ -24,6 +24,7 @@ DEPLOY_NODEPORT_PROXY=${DEPLOY_NODEPORT_PROXY:-true}
 DEPLOY_ALERTMANAGER=${DEPLOY_ALERTMANAGER:-true}
 DEPLOY_MINIO=${DEPLOY_MINIO:-true}
 DEPLOY_LOKI=${DEPLOY_LOKI:-false}
+DEPLOY_ELASTIC=${DEPLOY_ELASTIC:-true}
 USE_KUBERMATIC_OPERATOR=${USE_KUBERMATIC_OPERATOR:-false}
 DEPLOY_STACK=${DEPLOY_STACK:-kubermatic}
 TILLER_NAMESPACE=${TILLER_NAMESPACE:-kubermatic}
@@ -118,9 +119,11 @@ case "${DEPLOY_STACK}" in
 
   logging)
     initTiller
-    deploy "elasticsearch" "logging" ./config/logging/elasticsearch/
-    deploy "fluentbit" "logging" ./config/logging/fluentbit/
-    deploy "kibana" "logging" ./config/logging/kibana/
+    if [[ "${DEPLOY_ELASTIC}" = true ]]; then
+      deploy "elasticsearch" "logging" ./config/logging/elasticsearch/
+      deploy "fluentbit" "logging" ./config/logging/fluentbit/
+      deploy "kibana" "logging" ./config/logging/kibana/
+    fi
     if [[ "${DEPLOY_LOKI}" = true ]]; then
       deploy "loki" "logging" ./config/logging/loki/
       deploy "promtail" "logging" ./config/logging/promtail/


### PR DESCRIPTION
**What this PR does / why we need it**:
We want to scale down the offline environment and for this purpose we decided that running Loki instead of the Elastic stack allows us to use smaller instances. This PR makes it so that the offline deployment actually updates the monitoring/logging stacks.

**Does this PR introduce a user-facing change?**:
```release-note
NONE
```