### PR TITLE
Add support for creating rbac bindings to group subjects

### DIFF
--- a/api/cmd/kubermatic-api/swagger.json
+++ b/api/cmd/kubermatic-api/swagger.json
@@ -8406,6 +8406,10 @@
       "description": "ClusterRoleUser defines associated user with cluster role",
       "type": "object",
       "properties": {
+        "group": {
+          "type": "string",
+          "x-go-name": "Group"
+        },
         "userEmail": {
           "type": "string",
           "x-go-name": "UserEmail"
@@ -11302,6 +11306,10 @@
       "description": "RoleUser defines associated user with role",
       "type": "object",
       "properties": {
+        "group": {
+          "type": "string",
+          "x-go-name": "Group"
+        },
         "userEmail": {
           "type": "string",
           "x-go-name": "UserEmail"

--- a/api/pkg/api/v1/types.go
+++ b/api/pkg/api/v1/types.go
@@ -1365,12 +1365,14 @@ type ClusterRoleName struct {
 // swagger:model RoleUser
 type RoleUser struct {
 	UserEmail string `json:"userEmail"`
+	Group     string `json:"group"`
 }
 
 // ClusterRoleUser defines associated user with cluster role
 // swagger:model ClusterRoleUser
 type ClusterRoleUser struct {
 	UserEmail string `json:"userEmail"`
+	Group     string `json:"group"`
 }
 
 // Role defines RBAC role for the user cluster

--- a/api/pkg/handler/v1/cluster/binding_test.go
+++ b/api/pkg/handler/v1/cluster/binding_test.go
@@ -307,7 +307,7 @@ func TestListRoleBinding(t *testing.T) {
 	}{
 		{
 			name:             "scenario 1: list bindings",
-			expectedResponse: `[{"namespace":"default","subjects":[{"kind":"User","name":"test-1@example.com"}],"roleRefName":"role-1"},{"namespace":"default","subjects":[{"kind":"User","name":"test-2@example.com"},{"kind":"Group","name":"test"}],"roleRefName":"role-2"},{"namespace":"test","subjects":[{"kind":"User","name":"test-10@example.com"},{"kind":"Group","name":"test"}],"roleRefName":"role-10"}]`,
+			expectedResponse: `[{"namespace":"default","subjects":[{"kind":"User","name":"test-1@example.com"}],"roleRefName":"role-1"},{"namespace":"default","subjects":[{"kind":"User","name":"test-2@example.com"}],"roleRefName":"role-2"},{"namespace":"default","subjects":[{"kind":"Group","name":"test"}],"roleRefName":"role-2"},{"namespace":"test","subjects":[{"kind":"User","name":"test-10@example.com"}],"roleRefName":"role-10"},{"namespace":"test","subjects":[{"kind":"Group","name":"test"}],"roleRefName":"role-10"}]`,
 			clusterToGet:     test.GenDefaultCluster().Name,
 			httpStatus:       http.StatusOK,
 			existingKubermaticObjs: test.GenDefaultKubermaticObjects(
@@ -587,7 +587,7 @@ func TestBindUserToClusterRole(t *testing.T) {
 			),
 			existingKubernrtesObjs: []runtime.Object{
 				genDefaultClusterRole("role-1"),
-				genDefaultGroupClusterRoleBinding("test", "role-1", "group"),
+				genDefaultGroupClusterRoleBinding("test", "role-1", "test"),
 			},
 			existingAPIUser: test.GenDefaultAPIUser(),
 		},
@@ -710,7 +710,7 @@ func TestListClusterRoleBinding(t *testing.T) {
 		// scenario 1
 		{
 			name:             "scenario 1: list cluster role bindings",
-			expectedResponse: `[{"subjects":[{"kind":"User","name":"test-1"}],"roleRefName":"role-1"},{"subjects":[{"kind":"User","name":"test-2"}],"roleRefName":"role-1"},{"subjects":[{"kind":"User","name":"test-3"},{"subjects":[{"kind":"Group","name":"test-4"}],"roleRefName":"role-2"}]`,
+			expectedResponse: `[{"subjects":[{"kind":"User","name":"test-1"}],"roleRefName":"role-1"},{"subjects":[{"kind":"User","name":"test-2"}],"roleRefName":"role-1"},{"subjects":[{"kind":"User","name":"test-3"}],"roleRefName":"role-2"},{"subjects":[{"kind":"Group","name":"test-4"}],"roleRefName":"role-2"}]`,
 			clusterToGet:     test.GenDefaultCluster().Name,
 			httpStatus:       http.StatusOK,
 			existingKubermaticObjs: test.GenDefaultKubermaticObjects(

--- a/api/pkg/test/e2e/api/utils/apiclient/models/cluster_role_user.go
+++ b/api/pkg/test/e2e/api/utils/apiclient/models/cluster_role_user.go
@@ -14,6 +14,9 @@ import (
 // swagger:model ClusterRoleUser
 type ClusterRoleUser struct {
 
+	// group
+	Group string `json:"group,omitempty"`
+
 	// user email
 	UserEmail string `json:"userEmail,omitempty"`
 }

--- a/api/pkg/test/e2e/api/utils/apiclient/models/role_user.go
+++ b/api/pkg/test/e2e/api/utils/apiclient/models/role_user.go
@@ -14,6 +14,9 @@ import (
 // swagger:model RoleUser
 type RoleUser struct {
 
+	// group
+	Group string `json:"group,omitempty"`
+
 	// user email
 	UserEmail string `json:"userEmail,omitempty"`
 }


### PR DESCRIPTION
**What this PR does / why we need it**:
Add support for creating rbac bindings to group subjects. Before only user subjects were supported.

**Special notes for your reviewer**:
When this is merged, we can also create a PR for the dashboard changes.

**Does this PR introduce a user-facing change?**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If  no release note is required, just write "NONE".
-->
```release-note
Add support for creating rbac bindings to group subjects
```
