### PR TITLE
Fix node-exporter addon being impossible to scrape

### DIFF
--- a/addons/node-exporter/daemonset-proxy.yaml
+++ b/addons/node-exporter/daemonset-proxy.yaml
@@ -1,0 +1,70 @@
+{{- $port := .Variables.port | default 49100 -}}
+apiVersion: apps/v1
+kind: DaemonSet
+metadata:
+  name: node-exporter-proxy
+  namespace: kube-system
+  labels:
+    addonmanager.kubernetes.io/mode: Reconcile
+    app.kubernetes.io/name: node-exporter-proxy
+    app.kubernetes.io/version: v0.18.0
+spec:
+  updateStrategy:
+    type: RollingUpdate
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: node-exporter-proxy
+  template:
+    metadata:
+{{- with .ScrapeAnnotationPrefix }}
+      annotations:
+        {{ . }}/path: /metrics
+        {{ . }}/port: "{{ $port }}"
+{{- end }}
+      labels:
+        app.kubernetes.io/name: node-exporter-proxy
+    spec:
+      containers:
+      - name: socat
+        image: '{{ Registry "docker.io" }}/alpine/socat:1.7.3.4-r0'
+        imagePullPolicy: IfNotPresent
+        command: [/bin/sh]
+        args:
+        - -c
+        - |
+          set -e
+
+          socket=/shared/node-exporter-socket
+          if [ ! -S "$socket" ]; then
+            echo "Socket $socket has not yet been opened, exiting."
+            exit 1
+          fi
+
+          socat -d -d TCP4-LISTEN:{{ $port }},fork,reuseaddr UNIX:$socket
+        resources:
+          requests:
+            cpu: 10m
+            memory: 24Mi
+          limits:
+            cpu: 100m
+            memory: 48Mi
+        ports:
+        - containerPort: {{ $port }}
+          hostPort: {{ $port }}
+          name: http
+        volumeMounts:
+        - name: shared
+          mountPath: /shared
+          mountPropagation: HostToContainer
+      tolerations:
+      - effect: NoExecute
+        operator: Exists
+      - effect: NoSchedule
+        operator: Exists
+      volumes:
+      - name: shared
+        hostPath:
+          path: /tmp
+      securityContext:
+        runAsNonRoot: true
+        runAsUser: 65534

--- a/addons/node-exporter/daemonset.yaml
+++ b/addons/node-exporter/daemonset.yaml
@@ -1,3 +1,4 @@
+{{- $port := .Variables.port | default 49100 -}}
 apiVersion: apps/v1
 kind: DaemonSet
 metadata:
@@ -15,7 +16,6 @@ spec:
       app.kubernetes.io/name: node-exporter
   template:
     metadata:
-      name: node-exporter
       labels:
         app.kubernetes.io/name: node-exporter
     spec:
@@ -29,7 +29,7 @@ spec:
         - '--path.procfs=/host/proc'
         - '--path.sysfs=/host/sys'
         - '--path.rootfs=/host/root'
-        - '--web.listen-address=127.0.0.1:9100'
+        - '--web.listen-address=127.0.0.1:{{ $port }}'
         resources:
           requests:
             cpu: 10m
@@ -48,31 +48,28 @@ spec:
           readOnly: true
           mountPath: /host/root
           mountPropagation: HostToContainer
-
-      - name: kube-rbac-proxy
-        image: '{{ Registry "quay.io" }}/coreos/kube-rbac-proxy:v0.4.1'
+      - name: socat
+        image: '{{ Registry "docker.io" }}/alpine/socat:1.7.3.4-r0'
+        imagePullPolicy: IfNotPresent
+        command: [/bin/sh]
         args:
-        - '--logtostderr'
-        - '--secure-listen-address=$(IP):9100'
-        - '--tls-cipher-suites=TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256,TLS_RSA_WITH_AES_128_CBC_SHA256,TLS_ECDHE_ECDSA_WITH_AES_128_CBC_SHA256,TLS_ECDHE_RSA_WITH_AES_128_CBC_SHA256'
-        - '--upstream=http://127.0.0.1:9100/'
-        env:
-        - name: IP
-          valueFrom:
-            fieldRef:
-              fieldPath: status.podIP
-        ports:
-        - containerPort: 9100
-          hostPort: 9100
-          name: https
-        resources:
-          requests:
-            cpu: 10m
-            memory: 24Mi
-          limits:
-            cpu: 20m
-            memory: 48Mi
+        - -c
+        - |
+          set -e
 
+          socket=/shared/node-exporter-socket
+          rm -f $socket
+
+          socat -d -d UNIX-LISTEN:$socket,fork,reuseaddr TCP4:127.0.0.1:{{ $port }}
+        requests:
+          cpu: 10m
+          memory: 24Mi
+        limits:
+          cpu: 100m
+          memory: 48Mi
+        volumeMounts:
+        - name: shared
+          mountPath: /shared
       tolerations:
       - effect: NoExecute
         operator: Exists
@@ -88,6 +85,9 @@ spec:
       - name: root
         hostPath:
           path: /
+      - name: shared
+        hostPath:
+          path: /tmp
       securityContext:
         runAsNonRoot: true
         runAsUser: 65534

--- a/api/cmd/seed-controller-manager/controllers.go
+++ b/api/cmd/seed-controller-manager/controllers.go
@@ -259,6 +259,7 @@ func createAddonController(ctrlCtx *controllerContext) error {
 				"NodeAccessNetwork": ctrlCtx.runOptions.nodeAccessNetwork,
 			},
 		},
+		ctrlCtx.runOptions.monitoringScrapeAnnotationPrefix,
 		ctrlCtx.runOptions.kubernetesAddonsPath,
 		ctrlCtx.runOptions.openshiftAddonsPath,
 		ctrlCtx.runOptions.overwriteRegistry,

--- a/api/cmd/seed-controller-manager/options.go
+++ b/api/cmd/seed-controller-manager/options.go
@@ -116,7 +116,7 @@ func newControllerRunOptions() (controllerRunOptions, error) {
 	flag.StringVar(&c.dockerPullConfigJSONFile, "docker-pull-config-json-file", "config.json", "The file containing the docker auth config.")
 	flag.BoolVar(&c.inClusterPrometheusDisableDefaultScrapingConfigs, "in-cluster-prometheus-disable-default-scraping-configs", false, "A flag indicating whether the default scraping configs for the prometheus running in the cluster-foo namespaces should be deployed.")
 	flag.StringVar(&c.inClusterPrometheusScrapingConfigsFile, "in-cluster-prometheus-scraping-configs-file", "", "The file containing the custom scraping configs for the prometheus running in the cluster-foo namespaces.")
-	flag.StringVar(&c.monitoringScrapeAnnotationPrefix, "monitoring-scrape-annotation-prefix", "monitoring.kubermatic.io", "The prefix for monitoring annotations in the user cluster. Default: monitoring.kubermatic.io -> monitoring.kubermatic.io/port, monitoring.kubermatic.io/path")
+	flag.StringVar(&c.monitoringScrapeAnnotationPrefix, "monitoring-scrape-annotation-prefix", "", "The prefix for monitoring annotations ({prefix}/port and {prefix}/path) in the user cluster.")
 	flag.StringVar(&rawFeatureGates, "feature-gates", "", "A set of key=value pairs that describe feature gates for various features.")
 	flag.StringVar(&c.oidcCAFile, "oidc-ca-file", "", "The path to the certificate for the CA that signed your identity provider’s web certificate.")
 	flag.StringVar(&c.oidcIssuerURL, "oidc-issuer-url", "", "URL of the OpenID token issuer. Example: http://auth.int.kubermatic.io")

--- a/api/pkg/addon/template.go
+++ b/api/pkg/addon/template.go
@@ -33,15 +33,16 @@ func txtFuncMap(overwriteRegistry string) template.FuncMap {
 }
 
 type TemplateData struct {
-	Addon             *kubermaticv1.Addon
-	Kubeconfig        string
-	MajorMinorVersion string
-	Cluster           *kubermaticv1.Cluster
-	Credentials       resources.Credentials
-	Variables         map[string]interface{}
-	DNSClusterIP      string
-	DNSResolverIP     string
-	ClusterCIDR       string
+	Addon                  *kubermaticv1.Addon
+	Kubeconfig             string
+	MajorMinorVersion      string
+	Cluster                *kubermaticv1.Cluster
+	Credentials            resources.Credentials
+	Variables              map[string]interface{}
+	DNSClusterIP           string
+	DNSResolverIP          string
+	ClusterCIDR            string
+	ScrapeAnnotationPrefix string
 }
 
 func ParseFromFolder(log *zap.SugaredLogger, overwriteRegistry string, manifestPath string, data *TemplateData) ([]runtime.RawExtension, error) {

--- a/config/kubermatic/Chart.yaml
+++ b/config/kubermatic/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: kubermatic
-version: 1.0.46
+version: 1.0.47
 appVersion: '__KUBERMATIC_TAG__'
 description: Kubermatic chart for master and/or seed clusters.
 keywords:

--- a/config/kubermatic/values.yaml
+++ b/config/kubermatic/values.yaml
@@ -19,7 +19,7 @@ kubermatic:
   domain: ""
   # base64 encoded kubeconfig which gives admin access to all seed clusters
   kubeconfig: ""
-  # The prefix for monitoring annotations in the user cluster. Default: monitoring.kubermatic.io -> monitoring.kubermatic.io/scrape, monitoring.kubermatic.io/path
+  # The prefix for monitoring annotations in the user cluster. For example: monitoring.kubermatic.io -> monitoring.kubermatic.io/scrape, monitoring.kubermatic.io/path
   monitoringScrapeAnnotationPrefix: ""
   # The location from which to pull the Kubermatic docker image
   kubermaticImage: ""


### PR DESCRIPTION
**What this PR does / why we need it**:
Up until now it was pretty much impossible to configure Prometheus to scrape the node-exporter addon in user clusters. This PR fixes that. For those interested, the failed attempts are described below the release notes.

## Foreword

The most important piece of knowledge here is that the node-exporter **runs in the host network.** This puts it (and its pod IP) outside the Pod IP range of the user cluster and therefore outside of the VPN.

Old solution: In order to not make the node-exporter available on all interfaces of a node (and hence make it public, unless someone put firewall rules into place), we make the exporter run on `127.0.0.1:9100` and then have a *kube-rbac-proxy* sidecar which binds on the pod IP (this can be an internal or external IP, dependending on the cloud provider), checks credentials and then forwards to the upstream node-exporter on `127.0.0.1`.

## Solution: Escape host network via UNIX sockets

The kube-rbac-proxy is gone entirely. Instead the node-exporter pod now has a socat sidecar, which listens on a socket on the host and forwards traffic to the node-exporter. A second DaemonSet runs another socat proxy, but this time taking Prometheus scrape requests and forwarding them to the local socket. This removes the need to find the neighboring pod, as the proxy simply uses whatever is present on the host's disk.

## Addon Configuration

This PR also extends the addon configuration so that the scrape annotation prefix is available for templating in addon manifests. This makes it so that cluster operators can configure the prefix once and have the addons be reconciled properly.

In order to not leak our Product name, we have to revert the default value for the flag to an empty string.

The node-exporter addon now expects a `port` variable and defaults to a **non-default** port for the exporter. This makes it so that customers can install their own node-exporter without conflicting with the addon.

## Security Considerations

This PR makes a socket available on every node, under which anyone can reach the node-exporter. I don't think this makes it less secure: If you can read the socket file, you could also just talk to port 9100 locally.

## Backwards Compatibility

The default port for node-exporters changed from 9100 to 49100. Given that nobody so far could feasably have scraped it, I don't think we need to classify this as "breaking change". The new port should hopefully be safer and cluster operators can override it by setting the variable for each user-cluster manually.

The changed default value for the scrape annotation however is breaking, but I think it's okay to document that customers need to set `kubermatic.monitoringScrapeAnnotationPrefix=whatever.they.like` when updating.

**Does this PR introduce a user-facing change?**:
```release-note
The node-exporter addon gets automatically scraped when installed into user clusters.
Action required: default scrape annotation prefix default value was removed.
```

### Further Reading: Solution Finding

#### Attempt 1: Scrape Pod via kube-apiserver proxy.

The obvious approach and what we already do for all other pods in the user-cluster (if they have the special scraping prefix annotation). This makes Prometheus send the scraping request to the kube-apiserver, which proxies it to the pod.

I tried

* `/api/v1/namespaces/kube-system/pods/node-exporter-xyz:9100/proxy` (sic)
* `/api/v1/namespaces/kube-system/pods/node-exporter-xyz:9100/proxy/metrics`
* `/api/v1/namespaces/kube-system/pods/https:node-exporter-xyz:9100/proxy/metrics`

All ended up in a timeout. Even if this worked, the credentials are not forwarded by the kube-apiserver, so the bearer token would be received by kube-rbac-proxy anyway.

#### Attempt 2: Scrape Nodes via kube-apiserver proxy.

Same as before, but doing Prometheus service discovery on nodes instead of pods. I tried

* `/api/v1/nodes/<ip>:9100/proxy/metrics`
* `/api/v1/nodes/https:<ip>:9100/proxy/metrics`
* `/api/v1/nodes/<hostname>:9100/proxy/metrics`
* `/api/v1/nodes/https:<hostname>:9100/proxy/metrics`

All failed.

#### Attempt 3: Scrape the node directly

This fails because

* we might have firewall rules in place that prevent access to the nodes
* we never know if a node IP is internal or external
* internal node IPs are not reachable via VPN

#### Attempt 4: Remove kube-rbac-proxy, bind to private IP

This would make the node-exporter bind to the node's internal IP instead of localhost. Not all cloud providers provide internal IPs, so this is out. It would also not solve the issue of reaching the node in the first place (see attempt 3).

#### Attempt 5: Run a kubectl-proxy sidecar container

This sidecar cannot run in the node-exporter pod, because it would not solve anything attempt 4 would not have solved (removing authentication). So the "sidecar" would be a "sidecar pod", i.e. a second DaemonSet. The problem then is that the pod needs to find its neighboring node-exporter pod. This is simple with kubectl and jq, but we need to do this in a public Docker image, because due to whitelabelling we cannot create a quay.io/kubermatic/... helper image with the required tools. Good luck finding good kubectl+jq images out there.