### PR TITLE
fix retagging images for offline env

### DIFF
--- a/api/hack/retag-images.sh
+++ b/api/hack/retag-images.sh
@@ -1,32 +1,39 @@
 #!/usr/bin/env bash
+
+set -euo pipefail
+
 TARGET_REGISTRY=${TARGET_REGISTRY:-127.0.0.1:5000}
 
 function retag {
-  local IMAGE=$1
+  local IMAGE="$1"
 
   ORG="$(echo ${IMAGE} | cut -d / -f2)"
   NAME="$(echo ${IMAGE} | cut -d / -f3 | cut -d : -f1)"
   TAG="$(echo ${IMAGE} | cut -d / -f3 | cut -d : -f2)"
   TARGET_IMAGE="${TARGET_REGISTRY}/${ORG}/${NAME}:${TAG}"
-  echo "Retagging ${IMAGE} as ${TARGET_IMAGE}"
 
-  if curl -Ss --fail "http://${TARGET_REGISTRY}/v2/${ORG}/${NAME}/tags/list" | jq -e ".tags | index(\"${TAG}\")" >/dev/null; then
-    echo "Skipping image ${TARGET_IMAGE} because it already exists in the target registry"
+  echo -n "Retagging ${IMAGE} => ${TARGET_IMAGE}"
+
+  if curl -s --fail "http://${TARGET_REGISTRY}/v2/${ORG}/${NAME}/tags/list" | jq -e ".tags | index(\"${TAG}\")" >/dev/null; then
+    echo " skipping, exists already"
     return
   fi
 
-  docker pull ${IMAGE}
-  docker tag ${IMAGE} ${TARGET_IMAGE}
-  docker push ${TARGET_IMAGE}
+  echo " ..."
+
+  docker pull "${IMAGE}"
+  docker tag "${IMAGE}" "${TARGET_IMAGE}"
+  docker push "${TARGET_IMAGE}"
+
+  echo "Done retagging ${IMAGE}"
 }
 
 IMAGES=$(cat /dev/stdin | grep "image: " | cut -d : -f 2,3)
-for IMAGE in ${IMAGES}
-do
+for IMAGE in ${IMAGES}; do
   # Make sure we strip all quotes
   IMAGE="${IMAGE%\'}"
   IMAGE="${IMAGE#\'}"
   IMAGE="${IMAGE%\"}"
   IMAGE="${IMAGE#\"}"
-  retag ${IMAGE}
+  retag "${IMAGE}"
 done


### PR DESCRIPTION
**What this PR does / why we need it**:
Without pipefail, the `curl | jq` combo would never fail and we never detected that an image does not yet exist in the target registry.

**Does this PR introduce a user-facing change?**:
```release-note
NONE
```
