### PR TITLE
installing cri-o from rpm package

### DIFF
--- a/api/pkg/controller/operator/common/defaults.go
+++ b/api/pkg/controller/operator/common/defaults.go
@@ -291,6 +291,9 @@ var (
 		},
 	}
 
+	// DefaultOpenshiftVersioning contains the supported versions for openshift clusters. The OpenShift 4
+	// minor release is: Kubernetes minor - 12, since we only support openshift v4.1.9 and v4.1.18 only
+	// only cri-o 1.13.x is installed to the provisioned machines.
 	DefaultOpenshiftVersioning = operatorv1alpha1.KubermaticVersioningConfiguration{
 		Default: semver.MustParse("v4.1.18"),
 		Versions: []*semver.Version{

--- a/api/pkg/userdata/openshift/testdata/aws-v4.1.7.golden.yaml
+++ b/api/pkg/userdata/openshift/testdata/aws-v4.1.7.golden.yaml
@@ -13,14 +13,6 @@ write_files:
   content: |
     net.ipv4.ip_forward=1
 
-- path: "/etc/yum.repos.d/crio.repo"
-  content: |
-    [crio]
-    name=CRI-O
-    baseurl=https://cbs.centos.org/repos/paas7-crio-113-candidate/x86_64/os/
-    enabled=1
-    gpgcheck=0
-
 - path: "/opt/bin/setup"
   permissions: "0777"
   content: |
@@ -38,6 +30,8 @@ write_files:
 
     if systemctl is-active firewalld; then systemctl stop firewalld; fi;
     systemctl mask firewalld
+
+    yum install -y https://cbs.centos.org/kojifiles/packages/cri-o/1.13.11/1.el7/x86_64/cri-o-1.13.11-1.el7.x86_64.rpm
 
     # Coming from the upstream ansible playbook
     # https://github.com/openshift/openshift-ansible/blob/release-4.1/roles/openshift_node/defaults/main.yml#L19
@@ -95,8 +89,6 @@ write_files:
       container-storage-setup \
       cloud-utils-growpart \
       ceph-common \
-      cri-o \
-      cri-tools \
       podman \
       glusterfs-fuse
     podman run \

--- a/api/pkg/userdata/openshift/testdata/aws-v4.2.0.golden.yaml
+++ b/api/pkg/userdata/openshift/testdata/aws-v4.2.0.golden.yaml
@@ -13,14 +13,6 @@ write_files:
   content: |
     net.ipv4.ip_forward=1
 
-- path: "/etc/yum.repos.d/crio.repo"
-  content: |
-    [crio]
-    name=CRI-O
-    baseurl=https://cbs.centos.org/repos/paas7-crio-114-candidate/x86_64/os/
-    enabled=1
-    gpgcheck=0
-
 - path: "/opt/bin/setup"
   permissions: "0777"
   content: |
@@ -38,6 +30,8 @@ write_files:
 
     if systemctl is-active firewalld; then systemctl stop firewalld; fi;
     systemctl mask firewalld
+
+    yum install -y https://cbs.centos.org/kojifiles/packages/cri-o/1.13.11/1.el7/x86_64/cri-o-1.13.11-1.el7.x86_64.rpm
 
     # Coming from the upstream ansible playbook
     # https://github.com/openshift/openshift-ansible/blob/release-4.1/roles/openshift_node/defaults/main.yml#L19
@@ -95,8 +89,6 @@ write_files:
       container-storage-setup \
       cloud-utils-growpart \
       ceph-common \
-      cri-o \
-      cri-tools \
       podman \
       glusterfs-fuse
     podman run \

--- a/api/pkg/userdata/openshift/testdata/vsphere-v4.1.7.golden.yaml
+++ b/api/pkg/userdata/openshift/testdata/vsphere-v4.1.7.golden.yaml
@@ -16,14 +16,6 @@ write_files:
   content: |
     net.ipv4.ip_forward=1
 
-- path: "/etc/yum.repos.d/crio.repo"
-  content: |
-    [crio]
-    name=CRI-O
-    baseurl=https://cbs.centos.org/repos/paas7-crio-113-candidate/x86_64/os/
-    enabled=1
-    gpgcheck=0
-
 - path: "/opt/bin/setup"
   permissions: "0777"
   content: |
@@ -44,6 +36,8 @@ write_files:
 
     if systemctl is-active firewalld; then systemctl stop firewalld; fi;
     systemctl mask firewalld
+
+    yum install -y https://cbs.centos.org/kojifiles/packages/cri-o/1.13.11/1.el7/x86_64/cri-o-1.13.11-1.el7.x86_64.rpm
 
     # Coming from the upstream ansible playbook
     # https://github.com/openshift/openshift-ansible/blob/release-4.1/roles/openshift_node/defaults/main.yml#L19
@@ -101,8 +95,6 @@ write_files:
       container-storage-setup \
       cloud-utils-growpart \
       ceph-common \
-      cri-o \
-      cri-tools \
       podman \
       glusterfs-fuse \
       open-vm-tools


### PR DESCRIPTION
**What this PR does / why we need it**:
At the moment `cri-o` is installed in `CentOS 7` which is the only available os for the openshift clusters. `cri-o` is being installed using the package manager `yum` which that points to a repo which doesn't exist anymore(`https://cbs.centos.org/repos/paas7-crio-1%d-candidate/x86_64/os/`). and this results a failure while installing `cri-o`.

We do support( for the time being) only openshift `v4.1.x` thus installing `cri-o` from this package is enough for now  `"https://cbs.centos.org/kojifiles/packages/cri-o/1.13.11/1.el7/x86_64/cri-o-1.13.11-1.el7.x86_64.rpm"`. Once we support more openshift clusters versions we should make those packages path more configurable and dynamic based on openshift version. 

**Does this PR introduce a user-facing change?**:
No
```release-note
None
```
