### PR TITLE
Fix etcd cert missing client auth

### DIFF
--- a/api/pkg/resources/etcd/tls-serving-certificate.go
+++ b/api/pkg/resources/etcd/tls-serving-certificate.go
@@ -66,7 +66,13 @@ func TLSCertificateCreator(data tlsCertificateCreatorData) reconciling.NamedSecr
 			config := certutil.Config{
 				CommonName: "etcd",
 				AltNames:   altNames,
-				Usages:     []x509.ExtKeyUsage{x509.ExtKeyUsageServerAuth},
+				Usages: []x509.ExtKeyUsage{
+					x509.ExtKeyUsageServerAuth,
+					// etcd needs even the server cert to allow client authentication, see
+					// https://github.com/openshift/kubecsr/commit/aad75d333646da657e788db93f2ff75da850b542
+					// not having it does not cause etcd to fail, but produces lots of warnings and errors
+					x509.ExtKeyUsageClientAuth,
+				},
 			}
 
 			cert, err := triple.NewSignedCert(config, key, ca.Cert, ca.Key)


### PR DESCRIPTION
**What this PR does / why we need it**:
Etcd requires the server cert to also allow client authentication. Otherwise it logs

```
2020-03-27 17:07:49.681923 I | embed: rejected connection from "127.0.0.1:53984" (error "tls: failed to verify client's certificate: x509: certificate specifies an incompatible key usage", ServerName "")
WARNING: 2020/03/27 17:07:49 grpc: addrConn.createTransport failed to connect to {127.0.0.1:2379 0  <nil>}. Err :connection error: desc = "transport: authentication handshake failed: remote error: tls: bad certificate". Reconnecting...
```

but works fine otherwise. See https://bugzilla.redhat.com/show_bug.cgi?id=1769985 for more information. Note that this does not only apply to Openshift, but Kubernetes as well.

**Does this PR introduce a user-facing change?**:
```release-note
NONE
```
