### PR TITLE
Keep most recent backup for every user cluster on deletion

### DIFF
--- a/api/cmd/s3-storeuploader/main.go
+++ b/api/cmd/s3-storeuploader/main.go
@@ -110,7 +110,7 @@ func main() {
 				bucketFlag,
 				prefixFlag,
 				maxRevisionsFlag,
-				fileFlag,
+				fileFlag, // unused but kept for BC compatibility with old cleanup scripts
 			},
 		},
 		{

--- a/api/pkg/controller/operator/common/defaults.go
+++ b/api/pkg/controller/operator/common/defaults.go
@@ -644,8 +644,12 @@ command:
 - -c
 - |
   set -euo pipefail
-  s3-storeuploader store --endpoint minio.minio.svc.cluster.local:9000 --bucket kubermatic-etcd-backups --create-bucket --prefix $CLUSTER --file /backup/snapshot.db
-  s3-storeuploader delete-old-revisions --endpoint minio.minio.svc.cluster.local:9000 --bucket kubermatic-etcd-backups --prefix $CLUSTER --file /backup/snapshot.db --max-revisions 20
+
+  endpoint=minio.minio.svc.cluster.local:9000
+  bucket=kubermatic-etcd-backups
+
+  s3-storeuploader store --file /backup/snapshot.db --endpoint "$endpoint" --bucket "$bucket" --create-bucket --prefix $CLUSTER
+  s3-storeuploader delete-old-revisions --max-revisions 20 --endpoint "$endpoint" --bucket "$bucket" --prefix $CLUSTER
 env:
 - name: ACCESS_KEY_ID
   valueFrom:
@@ -670,7 +674,15 @@ command:
 - -c
 - |
   set -euo pipefail
-  s3-storeuploader delete-all --endpoint minio.minio.svc.cluster.local:9000 --bucket kubermatic-etcd-backups --prefix $CLUSTER
+
+  endpoint=minio.minio.svc.cluster.local:9000
+  bucket=kubermatic-etcd-backups
+
+  # by default, we keep the most recent backup for every user cluster
+  s3-storeuploader delete-old-revisions --max-revisions 1 --endpoint "$endpoint" --bucket "$bucket" --prefix $CLUSTER
+
+  # alternatively, delete all backups for this cluster
+  #s3-storeuploader delete-all --endpoint "$endpoint" --bucket "$bucket" --prefix $CLUSTER
 env:
 - name: ACCESS_KEY_ID
   valueFrom:

--- a/config/kubermatic/Chart.yaml
+++ b/config/kubermatic/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: kubermatic
-version: 1.0.46
+version: 1.0.47
 appVersion: '__KUBERMATIC_TAG__'
 description: Kubermatic chart for master and/or seed clusters.
 keywords:

--- a/config/kubermatic/static/cleanup-container.yaml
+++ b/config/kubermatic/static/cleanup-container.yaml
@@ -7,7 +7,15 @@ command:
 - -c
 - |
   set -euo pipefail
-  s3-storeuploader delete-all --endpoint minio.minio.svc.cluster.local:9000 --bucket kubermatic-etcd-backups --prefix $CLUSTER
+
+  endpoint=minio.minio.svc.cluster.local:9000
+  bucket=kubermatic-etcd-backups
+
+  # by default, we keep the most recent backup for every user cluster
+  s3-storeuploader delete-old-revisions --max-revisions 1 --endpoint "$endpoint" --bucket "$bucket" --prefix $CLUSTER
+
+  # alternatively, delete all backups for this cluster
+  #s3-storeuploader delete-all --endpoint "$endpoint" --bucket "$bucket" --prefix $CLUSTER
 env:
 - name: ACCESS_KEY_ID
   valueFrom:

--- a/config/kubermatic/static/store-container.yaml
+++ b/config/kubermatic/static/store-container.yaml
@@ -7,8 +7,12 @@ command:
 - -c
 - |
   set -euo pipefail
-  s3-storeuploader store --endpoint minio.minio.svc.cluster.local:9000 --bucket kubermatic-etcd-backups --create-bucket --prefix $CLUSTER --file /backup/snapshot.db
-  s3-storeuploader delete-old-revisions --endpoint minio.minio.svc.cluster.local:9000 --bucket kubermatic-etcd-backups --prefix $CLUSTER --file /backup/snapshot.db --max-revisions 20
+
+  endpoint=minio.minio.svc.cluster.local:9000
+  bucket=kubermatic-etcd-backups
+
+  s3-storeuploader store --file /backup/snapshot.db --endpoint "$endpoint" --bucket "$bucket" --create-bucket --prefix $CLUSTER
+  s3-storeuploader delete-old-revisions --max-revisions 20 --endpoint "$endpoint" --bucket "$bucket" --prefix $CLUSTER
 env:
 - name: ACCESS_KEY_ID
   valueFrom:

--- a/docs/zz_generated.kubermaticConfiguration.yaml
+++ b/docs/zz_generated.kubermaticConfiguration.yaml
@@ -116,7 +116,15 @@ spec:
       - -c
       - |
         set -euo pipefail
-        s3-storeuploader delete-all --endpoint minio.minio.svc.cluster.local:9000 --bucket kubermatic-etcd-backups --prefix $CLUSTER
+
+        endpoint=minio.minio.svc.cluster.local:9000
+        bucket=kubermatic-etcd-backups
+
+        # by default, we keep the most recent backup for every user cluster
+        s3-storeuploader delete-old-revisions --max-revisions 1 --endpoint "$endpoint" --bucket "$bucket" --prefix $CLUSTER
+
+        # alternatively, delete all backups for this cluster
+        #s3-storeuploader delete-all --endpoint "$endpoint" --bucket "$bucket" --prefix $CLUSTER
       env:
       - name: ACCESS_KEY_ID
         valueFrom:
@@ -137,8 +145,12 @@ spec:
       - -c
       - |
         set -euo pipefail
-        s3-storeuploader store --endpoint minio.minio.svc.cluster.local:9000 --bucket kubermatic-etcd-backups --create-bucket --prefix $CLUSTER --file /backup/snapshot.db
-        s3-storeuploader delete-old-revisions --endpoint minio.minio.svc.cluster.local:9000 --bucket kubermatic-etcd-backups --prefix $CLUSTER --file /backup/snapshot.db --max-revisions 20
+
+        endpoint=minio.minio.svc.cluster.local:9000
+        bucket=kubermatic-etcd-backups
+
+        s3-storeuploader store --file /backup/snapshot.db --endpoint "$endpoint" --bucket "$bucket" --create-bucket --prefix $CLUSTER
+        s3-storeuploader delete-old-revisions --max-revisions 20 --endpoint "$endpoint" --bucket "$bucket" --prefix $CLUSTER
       env:
       - name: ACCESS_KEY_ID
         valueFrom:


### PR DESCRIPTION
**What this PR does / why we need it**:
For easier cluster recovery after a user cluster was deleted, it would be nice to still have backups. Currently we simply wipe everything, which is something cluster operators should opt-in to.

This PR makes it so that the most recent backup for a cluster is kept. And it leaves a nice example for customers who want to actually delete everything. Removing the cleanup container by default would have made it much more difficult for operators to correctly configure the cleanup.

**Does this PR introduce a user-facing change?**:
```release-note
Action required: The most recent backup for user clusters is kept when the cluster is deleted. Adjust the cleanup-container to get the old behaviour (delete all backups) back.
```
