### PR TITLE
addon controller: requeue reconciliations if customer apiserver is down

### DIFF
--- a/api/pkg/controller/seed-controller-manager/addon/addon_controller.go
+++ b/api/pkg/controller/seed-controller-manager/addon/addon_controller.go
@@ -203,8 +203,8 @@ func (r *Reconciler) Reconcile(request reconcile.Request) (reconcile.Result, err
 
 func (r *Reconciler) reconcile(ctx context.Context, log *zap.SugaredLogger, addon *kubermaticv1.Addon, cluster *kubermaticv1.Cluster) (*reconcile.Result, error) {
 	if cluster.Status.ExtendedHealth.Apiserver != kubermaticv1.HealthStatusUp {
-		log.Debug("Skipping because the API server is not running")
-		return nil, nil
+		log.Debug("API server is not running, trying again in 10 seconds")
+		return &reconcile.Result{RequeueAfter: 10 * time.Second}, nil
 	}
 
 	reqeueAfter, err := r.ensureRequiredResourceTypesExist(ctx, log, addon, cluster)


### PR DESCRIPTION
Signed-off-by: Olaf Klischat <o.klischat@syseleven.de>

**What this PR does / why we need it**:

In the current master, when the addon controller tries to reconcile an addon and sees that the customer apiserver isn't ready, the reconciliation request will be dropped, essentially as if the reconciliation had been successful. If no further reconciliation requests are ever received for that addon, e.g. because no further changes to the addon or cluster resource occur, the addon won't ever be reconciled until the controller manager is restarted. Correct me if I'm missing something. We saw this problem happen in our staging environment numerous times after the 2.13 merge, especially in integration tests where we create a cluster and install a whole bunch of addons very shortly after. The cluster’s AddonControllerReconciledSuccessfully condition ends up being set to True, but none of the addons are in fact reconciled.

This PR modifies the addon controller so that if the customer apiserver is down, addon reconciliation requests are re-queued after 10 seconds rather than dropped. I can no longer reproduce the problem with this patch in place.

```release-note
NONE
```
