### PR TITLE
WIP - Fix node-exporter scraping 

### DIFF
--- a/addons/node-exporter/daemonset.yaml
+++ b/addons/node-exporter/daemonset.yaml
@@ -49,30 +49,29 @@ spec:
           mountPath: /host/root
           mountPropagation: HostToContainer
 
-      - name: kube-rbac-proxy
-        image: '{{ Registry "quay.io" }}/coreos/kube-rbac-proxy:v0.4.1'
-        args:
-        - '--logtostderr'
-        - '--secure-listen-address=$(IP):9100'
-        - '--tls-cipher-suites=TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256,TLS_RSA_WITH_AES_128_CBC_SHA256,TLS_ECDHE_ECDSA_WITH_AES_128_CBC_SHA256,TLS_ECDHE_RSA_WITH_AES_128_CBC_SHA256'
-        - '--upstream=http://127.0.0.1:9100/'
-        env:
-        - name: IP
-          valueFrom:
-            fieldRef:
-              fieldPath: status.podIP
-        ports:
-        - containerPort: 9100
-          hostPort: 9100
-          name: https
-        resources:
-          requests:
-            cpu: 10m
-            memory: 24Mi
-          limits:
-            cpu: 20m
-            memory: 48Mi
-
+      - command:
+        - bash
+        - -c
+        - |
+          while sleep 15; do
+            echo 1 > /proc/sys/net/ipv4/conf/all/route_localnet
+            iptables -t nat -C PREROUTING -p tcp --dport 9100 -j DNAT --to 127.0.0.1:9100
+            STATUS=$?
+            if [ $STATUS -ne 0 ]; then
+              iptables -t nat -A PREROUTING -p tcp --dport 9100 -j DNAT --to 127.0.0.1:9100
+              echo "Rule added"
+            fi
+          done
+        image: quay.io/kubermatic/openvpn:v2.4.8-r1
+        imagePullPolicy: IfNotPresent
+        name: dnat-controller-9100
+        resources: {}
+        securityContext:
+          capabilities:
+            add:
+            - NET_ADMIN
+        terminationMessagePath: /dev/termination-log
+        terminationMessagePolicy: File
       tolerations:
       - effect: NoExecute
         operator: Exists
@@ -88,6 +87,4 @@ spec:
       - name: root
         hostPath:
           path: /
-      securityContext:
-        runAsNonRoot: true
-        runAsUser: 65534
+      securityContext: {}


### PR DESCRIPTION
**What this PR does / why we need it**:
Fix node-exporter scraping. At the moment no scraping from the control plane is working. This is supposed to work thanks to the apiserver proxy feature and the current VPN tunnel.

As discussed with Christoph, this is another PR for the issue but tackling it in a different way:
Same VPN tunnels will be used and traffic coming out of the openvpn-client in the user-cluster will be DNATed to the localhost. This is done using a sidecar container. 

kube-rbac-proxy will be removed as it is not needed anymore.
This is still WIP and requires preferably additional security on the iptables rule (-i interface or -s IP). For the control-plane part: Prometheus pod modified to scrape directly the node-exporter using a VPN tunnel.


**Does this PR introduce a user-facing change?**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If  no release note is required, just write "NONE".
-->
```release-note
NONE
```
