### PR TITLE
Don't test AWS-only metrics in e2e tests

### DIFF
--- a/api/cmd/conformance-tests/custom_tests.go
+++ b/api/cmd/conformance-tests/custom_tests.go
@@ -350,7 +350,7 @@ func (r *testRunner) testUserClusterMetrics(log *zap.SugaredLogger, cluster *kub
 
 		if !fetchedMetricsSet.HasAll("machine_controller_machines", "kubelet_runtime_operations_latency_microseconds_count",
 			"replicaset_controller_rate_limiter_use", "workqueue_retries_total", "ssh_tunnel_open_count", "scheduler_e2e_scheduling_duration_seconds_count",
-			"kube_daemonset_labels", "etcd_disk_backend_defrag_duration_seconds_sum", "cloudprovider_aws_api_request_duration_seconds_sum") {
+			"kube_daemonset_labels", "etcd_disk_backend_defrag_duration_seconds_sum") {
 			return errors.New("failed to get all expected metrics")
 		}
 


### PR DESCRIPTION
**What this PR does / why we need it**:
The recent adition of the e2e tests for user-cluster metrics only worked for AWS-based tests, so tests for all other cloud providers in our periodics fail now.

**Does this PR introduce a user-facing change?**:
```release-note
NONE
```
