### PR TITLE
fix retagging when there are no images

### DIFF
--- a/api/hack/retag-images.sh
+++ b/api/hack/retag-images.sh
@@ -28,7 +28,7 @@ function retag {
   echo "Done retagging ${IMAGE}"
 }
 
-IMAGES=$(cat /dev/stdin | grep "image: " | cut -d : -f 2,3)
+IMAGES=$(cat /dev/stdin | (grep "image: " || true) | cut -d : -f 2,3)
 for IMAGE in ${IMAGES}; do
   # Make sure we strip all quotes
   IMAGE="${IMAGE%\'}"


### PR DESCRIPTION
**What this PR does / why we need it**:
Since introducing the `set -euo pipefail`, the script fails when retagging Helm output with no Docker images in it (like our iap chart when no Deployments are configured).

**Does this PR introduce a user-facing change?**:
```release-note
NONE
```
