### PR TITLE
Update Prometheus 2.17.1 on cluster-ns

### DIFF
--- a/api/pkg/resources/prometheus/statefulset.go
+++ b/api/pkg/resources/prometheus/statefulset.go
@@ -15,7 +15,7 @@ import (
 
 const (
 	name = "prometheus"
-	tag  = "v2.16.0"
+	tag  = "v2.17.1"
 
 	volumeConfigName = "config"
 	volumeDataName   = "data"

--- a/api/pkg/resources/test/fixtures/statefulset-aws-1.10.0-prometheus.yaml
+++ b/api/pkg/resources/test/fixtures/statefulset-aws-1.10.0-prometheus.yaml
@@ -38,7 +38,7 @@ spec:
         - --web.enable-lifecycle
         - --storage.tsdb.no-lockfile
         - --web.route-prefix=/
-        image: quay.io/prometheus/prometheus:v2.16.0
+        image: quay.io/prometheus/prometheus:v2.17.1
         livenessProbe:
           failureThreshold: 10
           httpGet:

--- a/api/pkg/resources/test/fixtures/statefulset-aws-1.10.6-prometheus.yaml
+++ b/api/pkg/resources/test/fixtures/statefulset-aws-1.10.6-prometheus.yaml
@@ -38,7 +38,7 @@ spec:
         - --web.enable-lifecycle
         - --storage.tsdb.no-lockfile
         - --web.route-prefix=/
-        image: quay.io/prometheus/prometheus:v2.16.0
+        image: quay.io/prometheus/prometheus:v2.17.1
         livenessProbe:
           failureThreshold: 10
           httpGet:

--- a/api/pkg/resources/test/fixtures/statefulset-aws-1.11.0-prometheus.yaml
+++ b/api/pkg/resources/test/fixtures/statefulset-aws-1.11.0-prometheus.yaml
@@ -38,7 +38,7 @@ spec:
         - --web.enable-lifecycle
         - --storage.tsdb.no-lockfile
         - --web.route-prefix=/
-        image: quay.io/prometheus/prometheus:v2.16.0
+        image: quay.io/prometheus/prometheus:v2.17.1
         livenessProbe:
           failureThreshold: 10
           httpGet:

--- a/api/pkg/resources/test/fixtures/statefulset-aws-1.11.1-prometheus.yaml
+++ b/api/pkg/resources/test/fixtures/statefulset-aws-1.11.1-prometheus.yaml
@@ -38,7 +38,7 @@ spec:
         - --web.enable-lifecycle
         - --storage.tsdb.no-lockfile
         - --web.route-prefix=/
-        image: quay.io/prometheus/prometheus:v2.16.0
+        image: quay.io/prometheus/prometheus:v2.17.1
         livenessProbe:
           failureThreshold: 10
           httpGet:

--- a/api/pkg/resources/test/fixtures/statefulset-aws-1.12.0-prometheus.yaml
+++ b/api/pkg/resources/test/fixtures/statefulset-aws-1.12.0-prometheus.yaml
@@ -38,7 +38,7 @@ spec:
         - --web.enable-lifecycle
         - --storage.tsdb.no-lockfile
         - --web.route-prefix=/
-        image: quay.io/prometheus/prometheus:v2.16.0
+        image: quay.io/prometheus/prometheus:v2.17.1
         livenessProbe:
           failureThreshold: 10
           httpGet:

--- a/api/pkg/resources/test/fixtures/statefulset-aws-1.13.0-prometheus.yaml
+++ b/api/pkg/resources/test/fixtures/statefulset-aws-1.13.0-prometheus.yaml
@@ -38,7 +38,7 @@ spec:
         - --web.enable-lifecycle
         - --storage.tsdb.no-lockfile
         - --web.route-prefix=/
-        image: quay.io/prometheus/prometheus:v2.16.0
+        image: quay.io/prometheus/prometheus:v2.17.1
         livenessProbe:
           failureThreshold: 10
           httpGet:

--- a/api/pkg/resources/test/fixtures/statefulset-azure-1.10.0-prometheus.yaml
+++ b/api/pkg/resources/test/fixtures/statefulset-azure-1.10.0-prometheus.yaml
@@ -38,7 +38,7 @@ spec:
         - --web.enable-lifecycle
         - --storage.tsdb.no-lockfile
         - --web.route-prefix=/
-        image: quay.io/prometheus/prometheus:v2.16.0
+        image: quay.io/prometheus/prometheus:v2.17.1
         livenessProbe:
           failureThreshold: 10
           httpGet:

--- a/api/pkg/resources/test/fixtures/statefulset-azure-1.10.6-prometheus.yaml
+++ b/api/pkg/resources/test/fixtures/statefulset-azure-1.10.6-prometheus.yaml
@@ -38,7 +38,7 @@ spec:
         - --web.enable-lifecycle
         - --storage.tsdb.no-lockfile
         - --web.route-prefix=/
-        image: quay.io/prometheus/prometheus:v2.16.0
+        image: quay.io/prometheus/prometheus:v2.17.1
         livenessProbe:
           failureThreshold: 10
           httpGet:

--- a/api/pkg/resources/test/fixtures/statefulset-azure-1.11.0-prometheus.yaml
+++ b/api/pkg/resources/test/fixtures/statefulset-azure-1.11.0-prometheus.yaml
@@ -38,7 +38,7 @@ spec:
         - --web.enable-lifecycle
         - --storage.tsdb.no-lockfile
         - --web.route-prefix=/
-        image: quay.io/prometheus/prometheus:v2.16.0
+        image: quay.io/prometheus/prometheus:v2.17.1
         livenessProbe:
           failureThreshold: 10
           httpGet:

--- a/api/pkg/resources/test/fixtures/statefulset-azure-1.11.1-prometheus.yaml
+++ b/api/pkg/resources/test/fixtures/statefulset-azure-1.11.1-prometheus.yaml
@@ -38,7 +38,7 @@ spec:
         - --web.enable-lifecycle
         - --storage.tsdb.no-lockfile
         - --web.route-prefix=/
-        image: quay.io/prometheus/prometheus:v2.16.0
+        image: quay.io/prometheus/prometheus:v2.17.1
         livenessProbe:
           failureThreshold: 10
           httpGet:

--- a/api/pkg/resources/test/fixtures/statefulset-azure-1.12.0-prometheus.yaml
+++ b/api/pkg/resources/test/fixtures/statefulset-azure-1.12.0-prometheus.yaml
@@ -38,7 +38,7 @@ spec:
         - --web.enable-lifecycle
         - --storage.tsdb.no-lockfile
         - --web.route-prefix=/
-        image: quay.io/prometheus/prometheus:v2.16.0
+        image: quay.io/prometheus/prometheus:v2.17.1
         livenessProbe:
           failureThreshold: 10
           httpGet:

--- a/api/pkg/resources/test/fixtures/statefulset-azure-1.13.0-prometheus.yaml
+++ b/api/pkg/resources/test/fixtures/statefulset-azure-1.13.0-prometheus.yaml
@@ -38,7 +38,7 @@ spec:
         - --web.enable-lifecycle
         - --storage.tsdb.no-lockfile
         - --web.route-prefix=/
-        image: quay.io/prometheus/prometheus:v2.16.0
+        image: quay.io/prometheus/prometheus:v2.17.1
         livenessProbe:
           failureThreshold: 10
           httpGet:

--- a/api/pkg/resources/test/fixtures/statefulset-bringyourown-1.10.0-prometheus.yaml
+++ b/api/pkg/resources/test/fixtures/statefulset-bringyourown-1.10.0-prometheus.yaml
@@ -38,7 +38,7 @@ spec:
         - --web.enable-lifecycle
         - --storage.tsdb.no-lockfile
         - --web.route-prefix=/
-        image: quay.io/prometheus/prometheus:v2.16.0
+        image: quay.io/prometheus/prometheus:v2.17.1
         livenessProbe:
           failureThreshold: 10
           httpGet:

--- a/api/pkg/resources/test/fixtures/statefulset-bringyourown-1.10.6-prometheus.yaml
+++ b/api/pkg/resources/test/fixtures/statefulset-bringyourown-1.10.6-prometheus.yaml
@@ -38,7 +38,7 @@ spec:
         - --web.enable-lifecycle
         - --storage.tsdb.no-lockfile
         - --web.route-prefix=/
-        image: quay.io/prometheus/prometheus:v2.16.0
+        image: quay.io/prometheus/prometheus:v2.17.1
         livenessProbe:
           failureThreshold: 10
           httpGet:

--- a/api/pkg/resources/test/fixtures/statefulset-bringyourown-1.11.0-prometheus.yaml
+++ b/api/pkg/resources/test/fixtures/statefulset-bringyourown-1.11.0-prometheus.yaml
@@ -38,7 +38,7 @@ spec:
         - --web.enable-lifecycle
         - --storage.tsdb.no-lockfile
         - --web.route-prefix=/
-        image: quay.io/prometheus/prometheus:v2.16.0
+        image: quay.io/prometheus/prometheus:v2.17.1
         livenessProbe:
           failureThreshold: 10
           httpGet:

--- a/api/pkg/resources/test/fixtures/statefulset-bringyourown-1.11.1-prometheus.yaml
+++ b/api/pkg/resources/test/fixtures/statefulset-bringyourown-1.11.1-prometheus.yaml
@@ -38,7 +38,7 @@ spec:
         - --web.enable-lifecycle
         - --storage.tsdb.no-lockfile
         - --web.route-prefix=/
-        image: quay.io/prometheus/prometheus:v2.16.0
+        image: quay.io/prometheus/prometheus:v2.17.1
         livenessProbe:
           failureThreshold: 10
           httpGet:

--- a/api/pkg/resources/test/fixtures/statefulset-bringyourown-1.12.0-prometheus.yaml
+++ b/api/pkg/resources/test/fixtures/statefulset-bringyourown-1.12.0-prometheus.yaml
@@ -38,7 +38,7 @@ spec:
         - --web.enable-lifecycle
         - --storage.tsdb.no-lockfile
         - --web.route-prefix=/
-        image: quay.io/prometheus/prometheus:v2.16.0
+        image: quay.io/prometheus/prometheus:v2.17.1
         livenessProbe:
           failureThreshold: 10
           httpGet:

--- a/api/pkg/resources/test/fixtures/statefulset-bringyourown-1.13.0-prometheus.yaml
+++ b/api/pkg/resources/test/fixtures/statefulset-bringyourown-1.13.0-prometheus.yaml
@@ -38,7 +38,7 @@ spec:
         - --web.enable-lifecycle
         - --storage.tsdb.no-lockfile
         - --web.route-prefix=/
-        image: quay.io/prometheus/prometheus:v2.16.0
+        image: quay.io/prometheus/prometheus:v2.17.1
         livenessProbe:
           failureThreshold: 10
           httpGet:

--- a/api/pkg/resources/test/fixtures/statefulset-digitalocean-1.10.0-prometheus.yaml
+++ b/api/pkg/resources/test/fixtures/statefulset-digitalocean-1.10.0-prometheus.yaml
@@ -38,7 +38,7 @@ spec:
         - --web.enable-lifecycle
         - --storage.tsdb.no-lockfile
         - --web.route-prefix=/
-        image: quay.io/prometheus/prometheus:v2.16.0
+        image: quay.io/prometheus/prometheus:v2.17.1
         livenessProbe:
           failureThreshold: 10
           httpGet:

--- a/api/pkg/resources/test/fixtures/statefulset-digitalocean-1.10.6-prometheus.yaml
+++ b/api/pkg/resources/test/fixtures/statefulset-digitalocean-1.10.6-prometheus.yaml
@@ -38,7 +38,7 @@ spec:
         - --web.enable-lifecycle
         - --storage.tsdb.no-lockfile
         - --web.route-prefix=/
-        image: quay.io/prometheus/prometheus:v2.16.0
+        image: quay.io/prometheus/prometheus:v2.17.1
         livenessProbe:
           failureThreshold: 10
           httpGet:

--- a/api/pkg/resources/test/fixtures/statefulset-digitalocean-1.11.0-prometheus.yaml
+++ b/api/pkg/resources/test/fixtures/statefulset-digitalocean-1.11.0-prometheus.yaml
@@ -38,7 +38,7 @@ spec:
         - --web.enable-lifecycle
         - --storage.tsdb.no-lockfile
         - --web.route-prefix=/
-        image: quay.io/prometheus/prometheus:v2.16.0
+        image: quay.io/prometheus/prometheus:v2.17.1
         livenessProbe:
           failureThreshold: 10
           httpGet:

--- a/api/pkg/resources/test/fixtures/statefulset-digitalocean-1.11.1-prometheus.yaml
+++ b/api/pkg/resources/test/fixtures/statefulset-digitalocean-1.11.1-prometheus.yaml
@@ -38,7 +38,7 @@ spec:
         - --web.enable-lifecycle
         - --storage.tsdb.no-lockfile
         - --web.route-prefix=/
-        image: quay.io/prometheus/prometheus:v2.16.0
+        image: quay.io/prometheus/prometheus:v2.17.1
         livenessProbe:
           failureThreshold: 10
           httpGet:

--- a/api/pkg/resources/test/fixtures/statefulset-digitalocean-1.12.0-prometheus.yaml
+++ b/api/pkg/resources/test/fixtures/statefulset-digitalocean-1.12.0-prometheus.yaml
@@ -38,7 +38,7 @@ spec:
         - --web.enable-lifecycle
         - --storage.tsdb.no-lockfile
         - --web.route-prefix=/
-        image: quay.io/prometheus/prometheus:v2.16.0
+        image: quay.io/prometheus/prometheus:v2.17.1
         livenessProbe:
           failureThreshold: 10
           httpGet:

--- a/api/pkg/resources/test/fixtures/statefulset-digitalocean-1.13.0-prometheus.yaml
+++ b/api/pkg/resources/test/fixtures/statefulset-digitalocean-1.13.0-prometheus.yaml
@@ -38,7 +38,7 @@ spec:
         - --web.enable-lifecycle
         - --storage.tsdb.no-lockfile
         - --web.route-prefix=/
-        image: quay.io/prometheus/prometheus:v2.16.0
+        image: quay.io/prometheus/prometheus:v2.17.1
         livenessProbe:
           failureThreshold: 10
           httpGet:

--- a/api/pkg/resources/test/fixtures/statefulset-openstack-1.10.0-prometheus.yaml
+++ b/api/pkg/resources/test/fixtures/statefulset-openstack-1.10.0-prometheus.yaml
@@ -38,7 +38,7 @@ spec:
         - --web.enable-lifecycle
         - --storage.tsdb.no-lockfile
         - --web.route-prefix=/
-        image: quay.io/prometheus/prometheus:v2.16.0
+        image: quay.io/prometheus/prometheus:v2.17.1
         livenessProbe:
           failureThreshold: 10
           httpGet:

--- a/api/pkg/resources/test/fixtures/statefulset-openstack-1.10.6-prometheus.yaml
+++ b/api/pkg/resources/test/fixtures/statefulset-openstack-1.10.6-prometheus.yaml
@@ -38,7 +38,7 @@ spec:
         - --web.enable-lifecycle
         - --storage.tsdb.no-lockfile
         - --web.route-prefix=/
-        image: quay.io/prometheus/prometheus:v2.16.0
+        image: quay.io/prometheus/prometheus:v2.17.1
         livenessProbe:
           failureThreshold: 10
           httpGet:

--- a/api/pkg/resources/test/fixtures/statefulset-openstack-1.11.0-prometheus.yaml
+++ b/api/pkg/resources/test/fixtures/statefulset-openstack-1.11.0-prometheus.yaml
@@ -38,7 +38,7 @@ spec:
         - --web.enable-lifecycle
         - --storage.tsdb.no-lockfile
         - --web.route-prefix=/
-        image: quay.io/prometheus/prometheus:v2.16.0
+        image: quay.io/prometheus/prometheus:v2.17.1
         livenessProbe:
           failureThreshold: 10
           httpGet:

--- a/api/pkg/resources/test/fixtures/statefulset-openstack-1.11.1-prometheus.yaml
+++ b/api/pkg/resources/test/fixtures/statefulset-openstack-1.11.1-prometheus.yaml
@@ -38,7 +38,7 @@ spec:
         - --web.enable-lifecycle
         - --storage.tsdb.no-lockfile
         - --web.route-prefix=/
-        image: quay.io/prometheus/prometheus:v2.16.0
+        image: quay.io/prometheus/prometheus:v2.17.1
         livenessProbe:
           failureThreshold: 10
           httpGet:

--- a/api/pkg/resources/test/fixtures/statefulset-openstack-1.12.0-prometheus.yaml
+++ b/api/pkg/resources/test/fixtures/statefulset-openstack-1.12.0-prometheus.yaml
@@ -38,7 +38,7 @@ spec:
         - --web.enable-lifecycle
         - --storage.tsdb.no-lockfile
         - --web.route-prefix=/
-        image: quay.io/prometheus/prometheus:v2.16.0
+        image: quay.io/prometheus/prometheus:v2.17.1
         livenessProbe:
           failureThreshold: 10
           httpGet:

--- a/api/pkg/resources/test/fixtures/statefulset-openstack-1.13.0-prometheus.yaml
+++ b/api/pkg/resources/test/fixtures/statefulset-openstack-1.13.0-prometheus.yaml
@@ -38,7 +38,7 @@ spec:
         - --web.enable-lifecycle
         - --storage.tsdb.no-lockfile
         - --web.route-prefix=/
-        image: quay.io/prometheus/prometheus:v2.16.0
+        image: quay.io/prometheus/prometheus:v2.17.1
         livenessProbe:
           failureThreshold: 10
           httpGet:

--- a/api/pkg/resources/test/fixtures/statefulset-vsphere-1.10.0-prometheus.yaml
+++ b/api/pkg/resources/test/fixtures/statefulset-vsphere-1.10.0-prometheus.yaml
@@ -38,7 +38,7 @@ spec:
         - --web.enable-lifecycle
         - --storage.tsdb.no-lockfile
         - --web.route-prefix=/
-        image: quay.io/prometheus/prometheus:v2.16.0
+        image: quay.io/prometheus/prometheus:v2.17.1
         livenessProbe:
           failureThreshold: 10
           httpGet:

--- a/api/pkg/resources/test/fixtures/statefulset-vsphere-1.10.6-prometheus.yaml
+++ b/api/pkg/resources/test/fixtures/statefulset-vsphere-1.10.6-prometheus.yaml
@@ -38,7 +38,7 @@ spec:
         - --web.enable-lifecycle
         - --storage.tsdb.no-lockfile
         - --web.route-prefix=/
-        image: quay.io/prometheus/prometheus:v2.16.0
+        image: quay.io/prometheus/prometheus:v2.17.1
         livenessProbe:
           failureThreshold: 10
           httpGet:

--- a/api/pkg/resources/test/fixtures/statefulset-vsphere-1.11.0-prometheus.yaml
+++ b/api/pkg/resources/test/fixtures/statefulset-vsphere-1.11.0-prometheus.yaml
@@ -38,7 +38,7 @@ spec:
         - --web.enable-lifecycle
         - --storage.tsdb.no-lockfile
         - --web.route-prefix=/
-        image: quay.io/prometheus/prometheus:v2.16.0
+        image: quay.io/prometheus/prometheus:v2.17.1
         livenessProbe:
           failureThreshold: 10
           httpGet:

--- a/api/pkg/resources/test/fixtures/statefulset-vsphere-1.11.1-prometheus.yaml
+++ b/api/pkg/resources/test/fixtures/statefulset-vsphere-1.11.1-prometheus.yaml
@@ -38,7 +38,7 @@ spec:
         - --web.enable-lifecycle
         - --storage.tsdb.no-lockfile
         - --web.route-prefix=/
-        image: quay.io/prometheus/prometheus:v2.16.0
+        image: quay.io/prometheus/prometheus:v2.17.1
         livenessProbe:
           failureThreshold: 10
           httpGet:

--- a/api/pkg/resources/test/fixtures/statefulset-vsphere-1.12.0-prometheus.yaml
+++ b/api/pkg/resources/test/fixtures/statefulset-vsphere-1.12.0-prometheus.yaml
@@ -38,7 +38,7 @@ spec:
         - --web.enable-lifecycle
         - --storage.tsdb.no-lockfile
         - --web.route-prefix=/
-        image: quay.io/prometheus/prometheus:v2.16.0
+        image: quay.io/prometheus/prometheus:v2.17.1
         livenessProbe:
           failureThreshold: 10
           httpGet:

--- a/api/pkg/resources/test/fixtures/statefulset-vsphere-1.13.0-prometheus.yaml
+++ b/api/pkg/resources/test/fixtures/statefulset-vsphere-1.13.0-prometheus.yaml
@@ -38,7 +38,7 @@ spec:
         - --web.enable-lifecycle
         - --storage.tsdb.no-lockfile
         - --web.route-prefix=/
-        image: quay.io/prometheus/prometheus:v2.16.0
+        image: quay.io/prometheus/prometheus:v2.17.1
         livenessProbe:
           failureThreshold: 10
           httpGet:


### PR DESCRIPTION
**What this PR does / why we need it**:
Update Prometheus to v2.17.1. on user cluster.
Minor upgrade.

**Documentation**:
<!-- Add links to the related documentation changes related to this pull request. E.g. the link to the kubermatic/docs pullrequest. -->
Release note: https://github.com/prometheus/prometheus/releases/tag/v2.17.1

**Does this PR introduce a user-facing change?**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If  no release note is required, just write "NONE".
-->
```release-note
Update Prometheus to v2.17.1 on user cluster
```
