### PR TITLE
Turn addon.TemplateData into a stable, documented interface

### DIFF
--- a/.prow.yaml
+++ b/.prow.yaml
@@ -93,7 +93,7 @@ presubmits:
             memory: 128Mi
             cpu: 250m
 
-  - name: pre-kubermatic-verify-yaml-examples
+  - name: pre-kubermatic-verify-docs
     run_if_changed: "^(api|docs)/"
     decorate: true
     clone_uri: "ssh://git@github.com/kubermatic/kubermatic.git"
@@ -101,11 +101,11 @@ presubmits:
       containers:
       - image: quay.io/kubermatic/go-docker:12.12-1806-3
         command:
-        - "./api/hack/verify-yaml-examples.sh"
+        - "./api/hack/verify-docs.sh"
         resources:
           requests:
-            memory: 128Mi
-            cpu: 250m
+            memory: 1Gi
+            cpu: 1
 
   - name: pre-kubermatic-lint
     run_if_changed: "^api/"

--- a/addons/canal/canal.yaml
+++ b/addons/canal/canal.yaml
@@ -60,7 +60,7 @@ data:
   # Flannel network configuration. Mounted into the flannel container.
   net-conf.json: |
     {
-      "Network": "{{first .Cluster.Spec.ClusterNetwork.Pods.CIDRBlocks}}",
+      "Network": "{{ first .Cluster.Network.PodCIDRBlocks }}",
       "Backend": {
         "Type": "vxlan"
       }

--- a/addons/csi/controllerplugin-rbac.yaml
+++ b/addons/csi/controllerplugin-rbac.yaml
@@ -1,6 +1,5 @@
-{{ if (.Cluster.Spec.Features.externalCloudProvider) }}
-
-{{ if .Cluster.Spec.Cloud.Openstack }}
+{{ if .Cluster.Features.Has "externalCloudProvider" }}
+{{ if eq .Cluster.CloudProviderName "openstack" }}
 apiVersion: v1
 kind: ServiceAccount
 metadata:
@@ -26,7 +25,6 @@ rules:
   - apiGroups: ["storage.k8s.io"]
     resources: ["csinodes"]
     verbs: ["get", "list", "watch"]
-
 
 ---
 kind: ClusterRoleBinding
@@ -208,5 +206,4 @@ roleRef:
   name: external-resizer-cfg
   apiGroup: rbac.authorization.k8s.io
 {{ end }}
-
 {{ end }}

--- a/addons/csi/controllerplugin.yaml
+++ b/addons/csi/controllerplugin.yaml
@@ -1,10 +1,10 @@
-{{ if (.Cluster.Spec.Features.externalCloudProvider) }}
-{{ if .Cluster.Spec.Cloud.Openstack }}
+{{ if .Cluster.Features.Has "externalCloudProvider" }}
+{{ if eq .Cluster.CloudProviderName "openstack" }}
 {{ $version := "UNSUPPORTED" }}
-{{ if eq .MajorMinorVersion "1.16" }}
+{{ if eq .Cluster.MajorMinorVersion "1.16" }}
 {{ $version = "v1.16.0 "}}
 {{ end }}
-{{ if eq .MajorMinorVersion "1.17" }}
+{{ if eq .Cluster.MajorMinorVersion "1.17" }}
 {{ $version = "v1.17.0 "}}
 {{ end }}
 
@@ -92,7 +92,7 @@ spec:
             - name: socket-dir
               mountPath: /var/lib/csi/sockets/pluginproxy/
         - name: cinder-csi-plugin
-          image: docker.io/k8scloudprovider/cinder-csi-plugin:{{ $version}}
+          image: docker.io/k8scloudprovider/cinder-csi-plugin:{{ $version }}
           args :
             - /bin/cinder-csi-plugin
             - "--nodeid=$(NODE_ID)"

--- a/addons/csi/driver.yaml
+++ b/addons/csi/driver.yaml
@@ -1,6 +1,5 @@
-{{ if (.Cluster.Spec.Features.externalCloudProvider) }}
-
-{{ if .Cluster.Spec.Cloud.Openstack }}
+{{ if .Cluster.Features.Has "externalCloudProvider" }}
+{{ if eq .Cluster.CloudProviderName "openstack" }}
 apiVersion: storage.k8s.io/v1beta1
 kind: CSIDriver
 metadata:

--- a/addons/csi/nodeplugin-rbac.yaml
+++ b/addons/csi/nodeplugin-rbac.yaml
@@ -1,11 +1,11 @@
-{{ if (.Cluster.Spec.Features.externalCloudProvider) }}
-
-{{ if .Cluster.Spec.Cloud.Openstack }}
+{{ if .Cluster.Features.Has "externalCloudProvider" }}
+{{ if eq .Cluster.CloudProviderName "openstack" }}
 apiVersion: v1
 kind: ServiceAccount
 metadata:
   name: csi-cinder-node-sa
   namespace: kube-system
+
 ---
 kind: ClusterRole
 apiVersion: rbac.authorization.k8s.io/v1

--- a/addons/csi/nodeplugin.yaml
+++ b/addons/csi/nodeplugin.yaml
@@ -1,11 +1,11 @@
-{{ if (.Cluster.Spec.Features.externalCloudProvider) }}
+{{ if .Cluster.Features.Has "externalCloudProvider" }}
 
-{{ if .Cluster.Spec.Cloud.Openstack }}
+{{ if eq .Cluster.CloudProviderName "openstack" }}
 {{ $version := "UNSUPPORTED" }}
-{{ if eq .MajorMinorVersion "1.16" }}
+{{ if eq .Cluster.MajorMinorVersion "1.16" }}
 {{ $version = "v1.16.0 "}}
 {{ end }}
-{{ if eq .MajorMinorVersion "1.17" }}
+{{ if eq .Cluster.MajorMinorVersion "1.17" }}
 {{ $version = "v1.17.0 "}}
 {{ end }}
 
@@ -124,6 +124,7 @@ spec:
         - name: secret-cinderplugin
           secret:
             secretName: cloud-config
+
 ---
 kind: DaemonSet
 apiVersion: apps/v1
@@ -240,6 +241,7 @@ spec:
         - name: secret-cinderplugin
           secret:
             secretName: cloud-config
+
 ---
 kind: DaemonSet
 apiVersion: apps/v1

--- a/addons/default-storage-class/storage-class.yaml
+++ b/addons/default-storage-class/storage-class.yaml
@@ -1,5 +1,5 @@
 {{/* Template must only emit data in case its valid for a given provider. That way we can ensure we don't install it when not needed */}}
-{{ if .Cluster.Spec.Cloud.Azure }}
+{{ if eq .Cluster.CloudProviderName "azure" }}
 apiVersion: storage.k8s.io/v1
 kind: StorageClass
 metadata:
@@ -14,7 +14,7 @@ parameters:
   storageaccounttype: Standard_LRS
 {{ end }}
 
-{{ if .Cluster.Spec.Cloud.AWS }}
+{{ if eq .Cluster.CloudProviderName "aws" }}
 apiVersion: storage.k8s.io/v1
 kind: StorageClass
 metadata:
@@ -29,7 +29,7 @@ parameters:
 volumeBindingMode: WaitForFirstConsumer
 {{ end }}
 
-{{ if .Cluster.Spec.Cloud.VSphere }}
+{{ if eq .Cluster.CloudProviderName "vsphere" }}
 apiVersion: storage.k8s.io/v1
 kind: StorageClass
 metadata:
@@ -43,8 +43,8 @@ parameters:
   diskformat: thin
 {{ end }}
 
-{{ if .Cluster.Spec.Cloud.Openstack }}
-{{ if (.Cluster.Spec.Features.externalCloudProvider) }}
+{{ if eq .Cluster.CloudProviderName "openstack" }}
+{{ if .Cluster.Features.Has "externalCloudProvider" }}
 apiVersion: storage.k8s.io/v1
 kind: StorageClass
 metadata:
@@ -68,7 +68,7 @@ provisioner: kubernetes.io/cinder
 {{ end }}
 {{ end }}
 
-{{ if .Cluster.Spec.Cloud.GCP }}
+{{ if eq .Cluster.CloudProviderName "gcp" }}
 apiVersion: storage.k8s.io/v1
 kind: StorageClass
 metadata:
@@ -82,14 +82,14 @@ parameters:
   type: pd-ssd
 {{ end }}
 
-{{ if .Cluster.Spec.Cloud.Hetzner }}
+{{ if eq .Cluster.CloudProviderName "hetzner" }}
 apiVersion: v1
 kind: Secret
 metadata:
   name: hcloud-csi
   namespace: kube-system
 data:
-  token: {{ .Credentials.Hetzner.Token|b64enc }}
+  token: {{ .Credentials.Hetzner.Token | b64enc }}
 ---
 kind: StorageClass
 apiVersion: storage.k8s.io/v1

--- a/addons/dns/coredns-deployment.yaml
+++ b/addons/dns/coredns-deployment.yaml
@@ -16,7 +16,7 @@ metadata:
 spec:
   selector:
     k8s-app: kube-dns
-  clusterIP: {{.DNSClusterIP}}
+  clusterIP: {{ .Cluster.Network.DNSClusterIP }}
   ports:
   - name: dns
     port: 53

--- a/addons/kube-proxy/configmap.yaml
+++ b/addons/kube-proxy/configmap.yaml
@@ -15,7 +15,7 @@ data:
       contentType: application/vnd.kubernetes.protobuf
       kubeconfig: /var/lib/kube-proxy/kubeconfig.conf
       qps: 5
-    clusterCIDR: "{{ index .Cluster.Spec.ClusterNetwork.Pods.CIDRBlocks 0 }}"
+    clusterCIDR: "{{ first .Cluster.Network.PodCIDRBlocks }}"
     configSyncPeriod: 15m0s
     conntrack:
       max: null
@@ -39,7 +39,7 @@ data:
       syncPeriod: 30s
     kind: KubeProxyConfiguration
     metricsBindAddress: 127.0.0.1:10249
-    mode: {{ .Cluster.Spec.ClusterNetwork.ProxyMode }}
+    mode: {{ .Cluster.Network.ProxyMode }}
     nodePortAddresses: null
     oomScoreAdj: -999
     portRange: ""
@@ -51,7 +51,7 @@ data:
     clusters:
     - cluster:
         certificate-authority: /var/run/secrets/kubernetes.io/serviceaccount/ca.crt
-        server: {{ .Cluster.Address.URL }}
+        server: {{ .Cluster.ApiserverExternalURL }}
       name: default
     contexts:
     - context:

--- a/addons/kube-proxy/daemonset.yaml
+++ b/addons/kube-proxy/daemonset.yaml
@@ -21,7 +21,7 @@ spec:
       priorityClassName: system-node-critical
       containers:
       - name: kube-proxy
-        image: '{{ Registry "gcr.io" }}/google_containers/hyperkube-amd64:v{{ .Cluster.Spec.Version }}'
+        image: '{{ Registry "gcr.io" }}/google_containers/hyperkube-amd64:v{{ .Cluster.Version }}'
         imagePullPolicy: IfNotPresent
         command:
         - /usr/local/bin/kube-proxy

--- a/addons/kubelet-configmap/kubelet-configmap.yaml
+++ b/addons/kubelet-configmap/kubelet-configmap.yaml
@@ -9,7 +9,7 @@ data:
     certificatesDir: /etc/kubernetes/pki
     imageRepository: k8s.gcr.io
     kind: ClusterConfiguration
-    kubernetesVersion: {{ .Cluster.Spec.Version }}
+    kubernetesVersion: {{ .Cluster.Version }}
   ClusterStatus: |
     apiVersion: kubeadm.k8s.io/v1beta1
     kind: ClusterStatus
@@ -44,7 +44,7 @@ data:
     cgroupDriver: cgroupfs
     cgroupsPerQOS: true
     clusterDNS:
-    - {{.DNSResolverIP}}
+    - {{ .Cluster.Network.DNSResolverIP }}
     clusterDomain: cluster.local
     containerLogMaxFiles: 5
     containerLogMaxSize: 10Mi
@@ -121,7 +121,7 @@ data:
     cgroupDriver: cgroupfs
     cgroupsPerQOS: true
     clusterDNS:
-    - {{.DNSResolverIP}}
+    - {{ .Cluster.Network.DNSResolverIP }}
     clusterDomain: cluster.local
     containerLogMaxFiles: 5
     containerLogMaxSize: 10Mi
@@ -134,7 +134,7 @@ data:
     enforceNodeAllocatable:
     - pods
     eventBurst: 10
-    eventRecordQPS: {{if .Variables.EventRecordQPS}}{{.Variables.EventRecordQPS}}{{else}}5{{end}}
+    eventRecordQPS: {{ .Variables.EventRecordQPS | default 5 }}
     evictionHard:
       imagefs.available: 15%
       memory.available: 100Mi
@@ -154,7 +154,7 @@ data:
     iptablesMasqueradeBit: 14
     kind: KubeletConfiguration
     kubeAPIBurst: 10
-    kubeAPIQPS: {{if .Variables.KubeAPIQPS}}{{.Variables.KubeAPIQPS}}{{else}}5{{end}}
+    kubeAPIQPS: {{ .Variables.KubeAPIQPS | default 5 }}
     makeIPTablesUtilChains: true
     maxOpenFiles: 1000000
     maxPods: 110
@@ -163,7 +163,7 @@ data:
     podPidsLimit: -1
     port: 10250
     registryBurst: 10
-    registryPullQPS: {{if .Variables.RegistryPullQPS}}{{.Variables.RegistryPullQPS}}{{else}}5{{end}}
+    registryPullQPS: {{ .Variables.RegistryPullQPS | default 5 }}
     resolvConf: /etc/resolv.conf
     rotateCertificates: true
     runtimeRequestTimeout: 2m0s
@@ -198,7 +198,7 @@ data:
     cgroupDriver: cgroupfs
     cgroupsPerQOS: true
     clusterDNS:
-    - {{.DNSResolverIP}}
+    - {{ .Cluster.Network.DNSResolverIP }}
     clusterDomain: cluster.local
     containerLogMaxFiles: 5
     containerLogMaxSize: 10Mi
@@ -275,7 +275,7 @@ data:
     cgroupDriver: cgroupfs
     cgroupsPerQOS: true
     clusterDNS:
-    - {{.DNSResolverIP}}
+    - {{ .Cluster.Network.DNSResolverIP }}
     clusterDomain: cluster.local
     configMapAndSecretChangeDetectionStrategy: Watch
     containerLogMaxFiles: 5
@@ -356,7 +356,7 @@ data:
     cgroupDriver: cgroupfs
     cgroupsPerQOS: true
     clusterDNS:
-    - {{.DNSResolverIP}}
+    - {{ .Cluster.Network.DNSResolverIP }}
     clusterDomain: cluster.local
     configMapAndSecretChangeDetectionStrategy: Watch
     containerLogMaxFiles: 5
@@ -437,7 +437,7 @@ data:
     cgroupDriver: cgroupfs
     cgroupsPerQOS: true
     clusterDNS:
-    - {{.DNSResolverIP}}
+    - {{ .Cluster.Network.DNSResolverIP }}
     clusterDomain: cluster.local
     configMapAndSecretChangeDetectionStrategy: Watch
     containerLogMaxFiles: 5
@@ -518,7 +518,7 @@ data:
     cgroupDriver: cgroupfs
     cgroupsPerQOS: true
     clusterDNS:
-    - {{.DNSResolverIP}}
+    - {{ .Cluster.Network.DNSResolverIP }}
     clusterDomain: cluster.local
     configMapAndSecretChangeDetectionStrategy: Watch
     containerLogMaxFiles: 5

--- a/addons/nodelocal-dns-cache/dns.yaml
+++ b/addons/nodelocal-dns-cache/dns.yaml
@@ -25,7 +25,7 @@ data:
         reload
         loop
         bind 169.254.20.10
-        forward . {{.DNSClusterIP}} {
+        forward . {{ .Cluster.Network.DNSClusterIP }} {
                 force_tcp
         }
         prometheus :9253
@@ -37,7 +37,7 @@ data:
         reload
         loop
         bind 169.254.20.10
-        forward . {{.DNSClusterIP}} {
+        forward . {{ .Cluster.Network.DNSClusterIP }} {
                 force_tcp
         }
         prometheus :9253
@@ -48,7 +48,7 @@ data:
         reload
         loop
         bind 169.254.20.10
-        forward . {{.DNSClusterIP}} {
+        forward . {{ .Cluster.Network.DNSClusterIP }} {
                 force_tcp
         }
         prometheus :9253

--- a/addons/openvpn/openvpn-client-dep.yaml
+++ b/addons/openvpn/openvpn-client-dep.yaml
@@ -68,7 +68,7 @@ spec:
           iptables -t nat -D PREROUTING -j host_dnat || true
           iptables -t nat -D PREROUTING -j host_dnat_inactive || true
 
-          virtualnodenet='{{.Variables.NodeAccessNetwork}}'
+          virtualnodenet='{{ .Variables.NodeAccessNetwork }}'
 
           # access node list via kubectl and generate iptables rules
           # for DNAT from it.

--- a/api/Gopkg.lock
+++ b/api/Gopkg.lock
@@ -2276,6 +2276,7 @@
     "golang.org/x/crypto/ssh",
     "golang.org/x/oauth2",
     "golang.org/x/oauth2/google",
+    "golang.org/x/tools/go/packages",
     "google.golang.org/api/compute/v1",
     "google.golang.org/api/googleapi",
     "google.golang.org/grpc",

--- a/api/cmd/addon-godoc-generator/main.go
+++ b/api/cmd/addon-godoc-generator/main.go
@@ -1,0 +1,95 @@
+package main
+
+import (
+	"bytes"
+	"errors"
+	"fmt"
+	"go/ast"
+	"go/format"
+	"go/token"
+	"log"
+	"reflect"
+	"strings"
+
+	"github.com/kubermatic/kubermatic/api/pkg/addon"
+	"golang.org/x/tools/go/packages"
+)
+
+var packageCache = map[string]*packages.Package{}
+
+func main() {
+	t := addon.TemplateData{}
+	snippets := generateDocumentation([]string{}, reflect.ValueOf(t))
+
+	fmt.Println(strings.Join(snippets, "\n\n"))
+}
+
+func generateDocumentation(docs []string, v reflect.Value) []string {
+	t := v.Type()
+
+	if v.Kind() == reflect.Struct {
+		pkgName := t.PkgPath()
+		symbol := t.Name()
+
+		log.Printf("Documenting %s.%s ...", pkgName, symbol)
+
+		pkg, err := loadPackage(pkgName)
+		if err != nil {
+			log.Fatalf("Failed to load package: %v", err)
+		}
+
+		doc, err := getDocumentation(pkg, symbol)
+		if err != nil {
+			log.Fatalf("Failed to generate docs: %v", err)
+		}
+
+		docs = append(docs, doc)
+
+		for n := 0; n < v.NumField(); n++ {
+			docs = generateDocumentation(docs, v.Field(n))
+		}
+	}
+
+	return docs
+}
+
+func loadPackage(name string) (*packages.Package, error) {
+	if p, ok := packageCache[name]; ok {
+		return p, nil
+	}
+
+	cfg := packages.Config{
+		Mode: packages.NeedName | packages.NeedFiles | packages.NeedImports | packages.NeedDeps | packages.NeedTypes | packages.NeedSyntax,
+	}
+
+	pkgs, err := packages.Load(&cfg, name)
+	if err != nil {
+		return nil, err
+	}
+
+	if len(pkgs) != 1 {
+		return nil, fmt.Errorf("expected to load 1 package, but got %d", len(pkgs))
+	}
+
+	pkg := pkgs[0]
+	packageCache[name] = pkg
+
+	return pkg, nil
+}
+
+func getDocumentation(pkg *packages.Package, symbolName string) (string, error) {
+	for _, s := range pkg.Syntax {
+		for _, d := range s.Decls {
+			if genDecl, ok := d.(*ast.GenDecl); ok && genDecl.Tok == token.TYPE && len(genDecl.Specs) == 1 {
+				if typeSpec, ok := genDecl.Specs[0].(*ast.TypeSpec); ok && typeSpec.Name.String() == symbolName {
+					var buf bytes.Buffer
+					err := format.Node(&buf, pkg.Fset, genDecl)
+
+					return buf.String(), err
+				}
+			}
+		}
+	}
+
+	return "", errors.New("symbol not found")
+}

--- a/api/cmd/addon-godoc-generator/main.go
+++ b/api/cmd/addon-godoc-generator/main.go
@@ -11,8 +11,9 @@ import (
 	"reflect"
 	"strings"
 
-	"github.com/kubermatic/kubermatic/api/pkg/addon"
 	"golang.org/x/tools/go/packages"
+
+	"github.com/kubermatic/kubermatic/api/pkg/addon"
 )
 
 var packageCache = map[string]*packages.Package{}

--- a/api/cmd/image-loader/main.go
+++ b/api/cmd/image-loader/main.go
@@ -419,12 +419,14 @@ func getVersions(log *zap.Logger, versionsFile, versionFilter string) ([]*kuberm
 }
 
 func getImagesFromAddons(log *zap.Logger, addonsPath string, cluster *kubermaticv1.Cluster) ([]string, error) {
-	addonData := &addonutil.TemplateData{
-		Cluster:           cluster,
-		MajorMinorVersion: cluster.Spec.Version.MajorMinor(),
-		Addon:             &kubermaticv1.Addon{},
-		Variables:         map[string]interface{}{},
+	addon := kubermaticv1.Addon{}
+	credentials := resources.Credentials{}
+
+	addonData, err := addonutil.NewTemplateData(cluster, &addon, credentials, "", "", "", nil)
+	if err != nil {
+		return nil, fmt.Errorf("failed to create addon template data: %v", err)
 	}
+
 	infos, err := ioutil.ReadDir(addonsPath)
 	if err != nil {
 		return nil, fmt.Errorf("unable to list addons: %v", err)

--- a/api/cmd/image-loader/main.go
+++ b/api/cmd/image-loader/main.go
@@ -419,10 +419,9 @@ func getVersions(log *zap.Logger, versionsFile, versionFilter string) ([]*kuberm
 }
 
 func getImagesFromAddons(log *zap.Logger, addonsPath string, cluster *kubermaticv1.Cluster) ([]string, error) {
-	addon := kubermaticv1.Addon{}
 	credentials := resources.Credentials{}
 
-	addonData, err := addonutil.NewTemplateData(cluster, &addon, credentials, "", "", "", nil)
+	addonData, err := addonutil.NewTemplateData(cluster, credentials, "", "", "", nil)
 	if err != nil {
 		return nil, fmt.Errorf("failed to create addon template data: %v", err)
 	}

--- a/api/hack/ci/ci-update-docs.sh
+++ b/api/hack/ci/ci-update-docs.sh
@@ -22,6 +22,7 @@ cd $TARGET_DIR
 # copy interesting files over
 cp ../docs/zz_generated.seed.yaml data/seed.yaml
 cp ../docs/zz_generated.kubermaticConfiguration.yaml data/kubermaticConfiguration.yaml
+cp ../docs/zz_generated.addondata.go data/addondata.go
 
 # re-create Prometheus runbook
 make runbook

--- a/api/hack/update-docs.sh
+++ b/api/hack/update-docs.sh
@@ -4,6 +4,8 @@ set -euo pipefail
 
 cd $(dirname $0)/..
 
+go run cmd/addon-godoc-generator/main.go > ../docs/zz_generated.addondata.go
+
 dummy=kubermaticNoOmitPlease
 
 # remove omitempty tags from structs so that genyaml will not skip fields

--- a/api/hack/verify-docs.sh
+++ b/api/hack/verify-docs.sh
@@ -14,11 +14,11 @@ trap "cleanup" EXIT SIGINT
 
 cleanup
 
-echodate "Recreating example YAMLs..."
+echodate "Recreating documentation..."
 
 cp -ar docs $tmpdir
 rm -f docs/zz_generated.*.yaml
-./api/hack/update-yaml-examples.sh
+./api/hack/update-docs.sh
 diff -rdu docs $tmpdir
 
-echodate "Example YAMLs are in-sync with Go structs."
+echodate "Documentation is in-sync with Go code."

--- a/api/pkg/addon/template.go
+++ b/api/pkg/addon/template.go
@@ -126,6 +126,7 @@ type ClusterNetwork struct {
 	ProxyMode         string
 }
 
+//nolint:golint
 type AddonData struct {
 	Name      string
 	IsDefault bool

--- a/api/pkg/addon/template.go
+++ b/api/pkg/addon/template.go
@@ -23,6 +23,11 @@ import (
 	kyaml "k8s.io/apimachinery/pkg/util/yaml"
 )
 
+const (
+	ClusterTypeKubernetes = "kubernetes"
+	ClusterTypeOpenshift  = "openshift"
+)
+
 func txtFuncMap(overwriteRegistry string) template.FuncMap {
 	funcs := sprig.TxtFuncMap()
 	funcs["Registry"] = func(registry string) string {
@@ -39,19 +44,17 @@ func txtFuncMap(overwriteRegistry string) template.FuncMap {
 // read, as it does not hint at a different package anymore.
 type Credentials = resources.Credentials
 
-// TemplateData is injected into templates.
+// TemplateData is the root context injected into each addon manifest file.
 type TemplateData struct {
 	SeedName       string
 	DatacenterName string
 	Cluster        ClusterData
-	Addon          AddonData
 	Credentials    Credentials
 	Variables      map[string]interface{}
 }
 
 func NewTemplateData(
 	cluster *kubermaticv1.Cluster,
-	addon *kubermaticv1.Addon,
 	credentials resources.Credentials,
 	kubeconfig string,
 	dnsClusterIP string,
@@ -67,14 +70,17 @@ func NewTemplateData(
 		variables = make(map[string]interface{})
 	}
 
+	clusterType := ClusterTypeKubernetes
+	if cluster.IsOpenshift() {
+		clusterType = ClusterTypeOpenshift
+	}
+
 	return &TemplateData{
 		DatacenterName: cluster.Spec.Cloud.DatacenterName,
 		Variables:      variables,
-		Addon: AddonData{
-			Name:      addon.Name,
-			IsDefault: addon.Spec.IsDefault,
-		},
+		Credentials:    credentials,
 		Cluster: ClusterData{
+			Type:                 clusterType,
 			Name:                 cluster.Name,
 			HumanReadableName:    cluster.Spec.HumanReadableName,
 			Namespace:            cluster.Status.NamespaceName,
@@ -95,27 +101,50 @@ func NewTemplateData(
 				ProxyMode:         cluster.Spec.ClusterNetwork.ProxyMode,
 			},
 		},
-		Credentials: credentials,
 	}, nil
 }
 
 // ClusterData contains data related to the user cluster
 // the addon is rendered for.
 type ClusterData struct {
-	Name                 string
-	HumanReadableName    string
-	Namespace            string
-	OwnerName            string
-	OwnerEmail           string
-	Kubeconfig           string
+	// Type is either "kubernetes" or "openshift".
+	Type string
+	// Name is the auto-generated, internal cluster name, e.g. "bbc8sc24wb".
+	Name string
+	// HumanReadableName is the user-specified cluster name.
+	HumanReadableName string
+	// Namespace is the full namespace for the cluster's control plane.
+	Namespace string
+	// OwnerName is the owner's full name.
+	OwnerName string
+	// OwnerEmail is the owner's e-mail address.
+	OwnerEmail string
+	// Kubeconfig is a YAML-encoded kubeconfig with cluster-admin permissions
+	// inside the user-cluster. The kubeconfig uses the external URL to reach
+	// the apiserver.
+	Kubeconfig string
+	// ApiserverExternalURL is the full URL to the apiserver service from the
+	// outside, including protocol and port number. It does not contain any
+	// trailing slashes.
 	ApiserverExternalURL string
+	// ApiserverExternalURL is the full URL to the apiserver from within the
+	// seed cluster itself. It does not contain any trailing slashes.
 	ApiserverInternalURL string
-	AdminToken           string
-	CloudProviderName    string
-	Version              *semver.Version
-	MajorMinorVersion    string
-	Network              ClusterNetwork
-	Features             sets.String
+	// AdminToken is the cluster's admin token.
+	AdminToken string
+	// CloudProviderName is the name of the cloud provider used, one of
+	// "alibaba", "aws", "azure", "bringyourown", "digitalocean", "gcp",
+	// "hetzner", "kubevirt", "openstack", "packet", "vsphere" depending on
+	// the configured datacenters.
+	CloudProviderName string
+	// Version is the exact cluster version.
+	Version *semver.Version
+	// MajorMinorVersion is a shortcut for common testing on "Major.Minor".
+	MajorMinorVersion string
+	// Network contains DNS and CIDR settings for the cluster.
+	Network ClusterNetwork
+	// Features is a set of enabled features for this cluster.
+	Features sets.String
 }
 
 type ClusterNetwork struct {
@@ -124,12 +153,6 @@ type ClusterNetwork struct {
 	PodCIDRBlocks     []string
 	ServiceCIDRBlocks []string
 	ProxyMode         string
-}
-
-//nolint:golint
-type AddonData struct {
-	Name      string
-	IsDefault bool
 }
 
 func ParseFromFolder(log *zap.SugaredLogger, overwriteRegistry string, manifestPath string, data *TemplateData) ([]runtime.RawExtension, error) {

--- a/api/pkg/addon/template_test.go
+++ b/api/pkg/addon/template_test.go
@@ -28,10 +28,16 @@ func testRenderAddonsForOrchestrator(t *testing.T, orchestrator string) {
 
 	clusters := []kubermaticv1.Cluster{}
 	for _, filename := range clusterFiles {
-		content, _ := ioutil.ReadFile(filename)
+		content, err := ioutil.ReadFile(filename)
+		if err != nil {
+			t.Fatal(err)
+		}
 
 		cluster := kubermaticv1.Cluster{}
-		yaml.Unmarshal(content, &cluster)
+		err = yaml.Unmarshal(content, &cluster)
+		if err != nil {
+			t.Fatal(err)
+		}
 
 		clusters = append(clusters, cluster)
 	}
@@ -66,7 +72,7 @@ func testRenderAddonsForOrchestrator(t *testing.T, orchestrator string) {
 
 	for _, cluster := range clusters {
 		for _, addon := range addons {
-			data, err := NewTemplateData(&cluster, &addon, credentials, "kubeconfig", "1.2.3.4", "5.6.7.8", variables)
+			data, err := NewTemplateData(&cluster, credentials, "kubeconfig", "1.2.3.4", "5.6.7.8", variables)
 			if err != nil {
 				t.Fatalf("Rendering %s addon %s for cluster %s failed: %v", orchestrator, addon.Name, cluster.Name, err)
 			}

--- a/api/pkg/addon/template_test.go
+++ b/api/pkg/addon/template_test.go
@@ -1,0 +1,82 @@
+package addon
+
+import (
+	"fmt"
+	"io/ioutil"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"go.uber.org/zap"
+
+	kubermaticv1 "github.com/kubermatic/kubermatic/api/pkg/crd/kubermatic/v1"
+	"github.com/kubermatic/kubermatic/api/pkg/resources"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"sigs.k8s.io/yaml"
+)
+
+// TestRenderAddons ensures that all our default addon manifests render
+// properly given a variety of cluster configurations.
+func TestRenderAddons(t *testing.T) {
+	testRenderAddonsForOrchestrator(t, "kubernetes")
+	testRenderAddonsForOrchestrator(t, "openshift")
+}
+
+func testRenderAddonsForOrchestrator(t *testing.T, orchestrator string) {
+	clusterFiles, _ := filepath.Glob(fmt.Sprintf("testdata/cluster-%s-*", orchestrator))
+
+	clusters := []kubermaticv1.Cluster{}
+	for _, filename := range clusterFiles {
+		content, _ := ioutil.ReadFile(filename)
+
+		cluster := kubermaticv1.Cluster{}
+		yaml.Unmarshal(content, &cluster)
+
+		clusters = append(clusters, cluster)
+	}
+
+	addonBasePath := "../../../addons"
+	if orchestrator == "openshift" {
+		addonBasePath = "../../../openshift_addons"
+	}
+
+	addonPaths, _ := filepath.Glob(filepath.Join(addonBasePath, "*"))
+
+	addons := []kubermaticv1.Addon{}
+	for _, addonPath := range addonPaths {
+		addonPath, _ := filepath.Abs(addonPath)
+
+		if stat, err := os.Stat(addonPath); err != nil || !stat.IsDir() {
+			continue
+		}
+
+		addons = append(addons, kubermaticv1.Addon{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: filepath.Base(addonPath),
+			},
+		})
+	}
+
+	log := zap.NewNop().Sugar()
+	credentials := resources.Credentials{}
+	variables := map[string]interface{}{
+		"test": true,
+	}
+
+	for _, cluster := range clusters {
+		for _, addon := range addons {
+			data, err := NewTemplateData(&cluster, &addon, credentials, "kubeconfig", "1.2.3.4", "5.6.7.8", variables)
+			if err != nil {
+				t.Fatalf("Rendering %s addon %s for cluster %s failed: %v", orchestrator, addon.Name, cluster.Name, err)
+			}
+
+			path := filepath.Join(addonBasePath, addon.Name)
+
+			_, err = ParseFromFolder(log, "", path, data)
+			if err != nil {
+				t.Fatalf("Rendering %s addon %s for cluster %s failed: %v", orchestrator, addon.Name, cluster.Name, err)
+			}
+		}
+	}
+}

--- a/api/pkg/addon/testdata/cluster-kubernetes-aws.yaml
+++ b/api/pkg/addon/testdata/cluster-kubernetes-aws.yaml
@@ -1,0 +1,126 @@
+apiVersion: kubermatic.k8s.io/v1
+kind: Cluster
+metadata:
+  annotations:
+    kubermatic.io/aws-region: eu-central-1
+  creationTimestamp: "2020-04-01T23:13:34Z"
+  finalizers:
+  - kubermatic.io/cleanup-aws-control-plane-role
+  - kubermatic.io/cleanup-aws-instance-profile
+  - kubermatic.io/cleanup-aws-security-group
+  - kubermatic.io/cleanup-aws-tags
+  - kubermatic.io/cleanup-backups
+  - kubermatic.io/cleanup-credentials-secrets
+  - kubermatic.io/cleanup-usersshkeys-cluster-ids
+  - kubermatic.io/delete-nodes
+  labels:
+    project-id: 45gb8ln2bj
+  name: bbc8sc24wb
+address:
+  adminToken: bkvkdn.rlqcb4qfcng2mwp8
+  externalName: bbc8sc24wb.europe-west3-c.dev.kubermatic.io
+  internalURL: apiserver-external.cluster-bbc8sc24wb.svc.cluster.local.
+  ip: 35.198.93.90
+  port: 32105
+  url: https://bbc8sc24wb.europe-west3-c.dev.kubermatic.io:32105
+spec:
+  auditLogging: {}
+  cloud:
+    aws:
+      credentialsReference:
+        name: credential-aws-bbc8sc24wb
+        namespace: kubermatic
+      instanceProfileName: kubernetes-bbc8sc24wb
+      roleARN: kubernetes-bbc8sc24wb-control-plane
+      routeTableId: rtb-4009d528
+      securityGroupID: sg-0cc9d8a4d3649972f
+      vpcId: vpc-819f62e9
+    dc: aws-eu-central-1a
+  clusterNetwork:
+    dnsDomain: cluster.local
+    pods:
+      cidrBlocks:
+      - 172.25.0.0/16
+    proxyMode: ipvs
+    services:
+      cidrBlocks:
+      - 10.240.16.0/20
+  componentsOverride:
+    apiserver:
+      endpointReconcilingDisabled: false
+      replicas: 2
+    controllerManager:
+      replicas: 1
+    etcd: {}
+    prometheus: {}
+    scheduler:
+      replicas: 1
+  exposeStrategy: NodePort
+  humanReadableName: stupefied-heisenberg
+  oidc: {}
+  pause: false
+  version: 1.15.10
+status:
+  cloudMigrationRevision: 2
+  conditions:
+  - kubermatic_version: weekly-2019-46-346-g1d08a9926-1d08a9926fa112f7684b6ba692b41c81cf8a8dc1
+    lastHeartbeatTime: "2020-04-01T23:14:26Z"
+    lastTransitionTime: "2020-04-01T23:14:26Z"
+    status: "True"
+    type: AddonControllerReconciledSuccessfully
+  - kubermatic_version: weekly-2019-46-346-g1d08a9926-1d08a9926fa112f7684b6ba692b41c81cf8a8dc1
+    lastHeartbeatTime: "2020-04-01T23:19:25Z"
+    lastTransitionTime: "2020-04-01T23:19:25Z"
+    status: "True"
+    type: AddonInstallerControllerReconciledSuccessfully
+  - kubermatic_version: weekly-2019-46-346-g1d08a9926-1d08a9926fa112f7684b6ba692b41c81cf8a8dc1
+    lastHeartbeatTime: "2020-04-01T23:13:34Z"
+    status: "True"
+    type: BackupControllerReconciledSuccessfully
+  - kubermatic_version: weekly-2019-46-346-g1d08a9926-1d08a9926fa112f7684b6ba692b41c81cf8a8dc1
+    lastHeartbeatTime: "2020-04-01T23:13:48Z"
+    status: "True"
+    type: CloudControllerReconcilledSuccessfully
+  - kubermatic_version: weekly-2019-46-346-g1d08a9926-1d08a9926fa112f7684b6ba692b41c81cf8a8dc1
+    lastHeartbeatTime: "2020-04-01T23:14:20Z"
+    lastTransitionTime: "2020-04-01T23:14:20Z"
+    status: "True"
+    type: ClusterControllerReconciledSuccessfully
+  - kubermatic_version: weekly-2019-46-346-g1d08a9926-1d08a9926fa112f7684b6ba692b41c81cf8a8dc1
+    lastHeartbeatTime: "2020-04-01T23:14:49Z"
+    message: Cluster has been initialized successfully
+    status: "True"
+    type: ClusterInitialized
+  - kubermatic_version: weekly-2019-46-346-g1d08a9926-1d08a9926fa112f7684b6ba692b41c81cf8a8dc1
+    lastHeartbeatTime: "2020-04-01T23:14:20Z"
+    status: "True"
+    type: ComponentDefaulterReconciledSuccessfully
+  - kubermatic_version: weekly-2019-46-346-g1d08a9926-1d08a9926fa112f7684b6ba692b41c81cf8a8dc1
+    lastHeartbeatTime: "2020-04-01T23:14:34Z"
+    status: "True"
+    type: MonitoringControllerReconciledSuccessfully
+  - kubermatic_version: weekly-2019-46-346-g1d08a9926-1d08a9926fa112f7684b6ba692b41c81cf8a8dc1
+    lastHeartbeatTime: "2020-04-01T23:28:13Z"
+    lastTransitionTime: "2020-04-01T23:28:13Z"
+    message: Some control plane components did not finish updating
+    reason: ClusterUpdateSuccessful
+    status: "False"
+    type: SeedResourcesUpToDate
+  - kubermatic_version: weekly-2019-46-346-g1d08a9926-1d08a9926fa112f7684b6ba692b41c81cf8a8dc1
+    lastHeartbeatTime: "2020-04-01T23:19:14Z"
+    lastTransitionTime: "2020-04-01T23:19:14Z"
+    status: "True"
+    type: UpdateControllerReconciledSuccessfully
+  extendedHealth:
+    apiserver: 1
+    cloudProviderInfrastructure: 1
+    controller: 1
+    etcd: 2
+    machineController: 1
+    openvpn: 1
+    scheduler: 1
+    userClusterControllerManager: 1
+  kubermatic_version: 1d08a9926fa112f7684b6ba692b41c81cf8a8dc1
+  lastUpdated: null
+  namespaceName: cluster-bbc8sc24wb
+  userEmail: user@example.com

--- a/api/pkg/addon/testdata/cluster-kubernetes-do.yaml
+++ b/api/pkg/addon/testdata/cluster-kubernetes-do.yaml
@@ -1,0 +1,113 @@
+apiVersion: kubermatic.k8s.io/v1
+kind: Cluster
+metadata:
+  creationTimestamp: "2020-04-01T09:58:07Z"
+  finalizers:
+  - kubermatic.io/cleanup-backups
+  - kubermatic.io/cleanup-credentials-secrets
+  - kubermatic.io/cleanup-usersshkeys-cluster-ids
+  - kubermatic.io/delete-nodes
+  labels:
+    project-id: sqsbz74c2t
+  name: nmxjm7ngzw
+address:
+  adminToken: hkj6rb.fgfrf25nmvcmvzn6
+  externalName: nmxjm7ngzw.europe-west3-c.dev.kubermatic.io
+  internalURL: apiserver-external.cluster-nmxjm7ngzw.svc.cluster.local.
+  ip: 35.198.93.90
+  port: 30711
+  url: https://nmxjm7ngzw.europe-west3-c.dev.kubermatic.io:30711
+spec:
+  auditLogging: {}
+  cloud:
+    dc: do-fra1
+    digitalocean:
+      credentialsReference:
+        name: credential-digitalocean-nmxjm7ngzw
+        namespace: kubermatic
+  clusterNetwork:
+    dnsDomain: cluster.local
+    pods:
+      cidrBlocks:
+      - 172.25.0.0/16
+    proxyMode: ipvs
+    services:
+      cidrBlocks:
+      - 10.240.16.0/20
+  componentsOverride:
+    apiserver:
+      endpointReconcilingDisabled: false
+      replicas: 2
+    controllerManager:
+      replicas: 1
+    etcd: {}
+    prometheus: {}
+    scheduler:
+      replicas: 1
+  exposeStrategy: NodePort
+  humanReadableName: quizzical-poitras
+  oidc: {}
+  pause: false
+  version: 1.15.10
+status:
+  cloudMigrationRevision: 2
+  conditions:
+  - kubermatic_version: weekly-2019-46-346-g1d08a9926-1d08a9926fa112f7684b6ba692b41c81cf8a8dc1
+    lastHeartbeatTime: "2020-04-01T18:20:38Z"
+    lastTransitionTime: "2020-04-01T18:20:38Z"
+    status: "True"
+    type: AddonControllerReconciledSuccessfully
+  - kubermatic_version: weekly-2019-46-346-g1d08a9926-1d08a9926fa112f7684b6ba692b41c81cf8a8dc1
+    lastHeartbeatTime: "2020-04-01T21:49:56Z"
+    lastTransitionTime: "2020-04-01T21:49:56Z"
+    status: "True"
+    type: AddonInstallerControllerReconciledSuccessfully
+  - kubermatic_version: weekly-2019-46-346-g1d08a9926-1d08a9926fa112f7684b6ba692b41c81cf8a8dc1
+    lastHeartbeatTime: "2020-04-01T09:58:25Z"
+    status: "True"
+    type: BackupControllerReconciledSuccessfully
+  - kubermatic_version: weekly-2019-46-346-g1d08a9926-1d08a9926fa112f7684b6ba692b41c81cf8a8dc1
+    lastHeartbeatTime: "2020-04-01T09:58:08Z"
+    status: "True"
+    type: CloudControllerReconcilledSuccessfully
+  - kubermatic_version: weekly-2019-46-346-g1d08a9926-1d08a9926fa112f7684b6ba692b41c81cf8a8dc1
+    lastHeartbeatTime: "2020-04-01T09:58:25Z"
+    status: "True"
+    type: ClusterControllerReconciledSuccessfully
+  - kubermatic_version: weekly-2019-46-346-g1d08a9926-1d08a9926fa112f7684b6ba692b41c81cf8a8dc1
+    lastHeartbeatTime: "2020-04-01T09:59:42Z"
+    message: Cluster has been initialized successfully
+    status: "True"
+    type: ClusterInitialized
+  - kubermatic_version: weekly-2019-46-346-g1d08a9926-1d08a9926fa112f7684b6ba692b41c81cf8a8dc1
+    lastHeartbeatTime: "2020-04-01T09:58:26Z"
+    status: "True"
+    type: ComponentDefaulterReconciledSuccessfully
+  - kubermatic_version: weekly-2019-46-346-g1d08a9926-1d08a9926fa112f7684b6ba692b41c81cf8a8dc1
+    lastHeartbeatTime: "2020-04-01T09:59:30Z"
+    status: "True"
+    type: MonitoringControllerReconciledSuccessfully
+  - kubermatic_version: weekly-2019-46-346-g1d08a9926-1d08a9926fa112f7684b6ba692b41c81cf8a8dc1
+    lastHeartbeatTime: "2020-04-01T23:28:12Z"
+    lastTransitionTime: "2020-04-01T23:28:12Z"
+    message: Some control plane components did not finish updating
+    reason: ClusterUpdateSuccessful
+    status: "False"
+    type: SeedResourcesUpToDate
+  - kubermatic_version: weekly-2019-46-346-g1d08a9926-1d08a9926fa112f7684b6ba692b41c81cf8a8dc1
+    lastHeartbeatTime: "2020-04-01T09:58:27Z"
+    status: "True"
+    type: UpdateControllerReconciledSuccessfully
+  extendedHealth:
+    apiserver: 1
+    cloudProviderInfrastructure: 1
+    controller: 1
+    etcd: 2
+    machineController: 1
+    openvpn: 1
+    scheduler: 1
+    userClusterControllerManager: 1
+  kubermatic_version: 1d08a9926fa112f7684b6ba692b41c81cf8a8dc1
+  lastUpdated: null
+  namespaceName: cluster-nmxjm7ngzw
+  userEmail: user@example.com

--- a/api/pkg/addon/testdata/cluster-openshift-vsphere.yaml
+++ b/api/pkg/addon/testdata/cluster-openshift-vsphere.yaml
@@ -1,0 +1,130 @@
+apiVersion: kubermatic.k8s.io/v1
+kind: Cluster
+metadata:
+  annotations:
+    kubermatic.io/openshift: "true"
+  creationTimestamp: "2020-04-01T20:05:53Z"
+  finalizers:
+  - kubermatic.io/cleanup-backups
+  - kubermatic.io/cleanup-credentials-requests
+  - kubermatic.io/cleanup-credentials-secrets
+  - kubermatic.io/cleanup-image-registry-configs
+  - kubermatic.io/cleanup-usersshkeys-cluster-ids
+  - kubermatic.io/cleanup-vsphere-folder
+  - kubermatic.io/delete-nodes
+  labels:
+    project-id: 6lvrtz8qm2
+    user: exampleuser
+  name: m7x6hnnptb
+address:
+  adminToken: ""
+  externalName: m7x6hnnptb.europe-west3-c.dev.kubermatic.io
+  internalURL: apiserver-external.cluster-m7x6hnnptb.svc.cluster.local.
+  ip: 35.198.93.90
+  openshiftConsoleCallback: https://dev.kubermatic.io/api/v1/projects/6lvrtz8qm2/dc/europe-west3-c/clusters/m7x6hnnptb/openshift/console/proxy/auth/callback
+  port: 31473
+  url: https://m7x6hnnptb.europe-west3-c.dev.kubermatic.io:31473
+spec:
+  auditLogging: {}
+  cloud:
+    dc: vsphere-hamburg
+    vsphere:
+      credentialsReference:
+        name: credential-vsphere-m7x6hnnptb
+        namespace: kubermatic
+      folder: /dc-1/vm/kubermatic/m7x6hnnptb
+      infraManagementUser: {}
+      vmNetName: ""
+  clusterNetwork:
+    dnsDomain: cluster.local
+    pods:
+      cidrBlocks:
+      - 172.25.0.0/16
+    proxyMode: ""
+    services:
+      cidrBlocks:
+      - 10.240.16.0/20
+  componentsOverride:
+    apiserver:
+      endpointReconcilingDisabled: false
+      replicas: 2
+    controllerManager:
+      replicas: 1
+    etcd: {}
+    prometheus: {}
+    scheduler:
+      replicas: 1
+  exposeStrategy: NodePort
+  humanReadableName: nifty-curran
+  oidc: {}
+  openshift:
+    imagePullSecret: |
+      {
+        "auths": {}
+      }
+  pause: false
+  version: 4.3.2
+status:
+  cloudMigrationRevision: 2
+  conditions:
+  - kubermatic_version: weekly-2019-46-366-gebffe161a-f6f8d34f876c6ebd32872306f1d410118e7f29fc
+    lastHeartbeatTime: "2020-04-01T20:10:15Z"
+    lastTransitionTime: "2020-04-01T20:10:15Z"
+    status: "True"
+    type: AddonControllerReconciledSuccessfully
+  - kubermatic_version: weekly-2019-46-366-gebffe161a-f6f8d34f876c6ebd32872306f1d410118e7f29fc
+    lastHeartbeatTime: "2020-04-01T20:08:28Z"
+    lastTransitionTime: "2020-04-01T20:08:28Z"
+    status: "True"
+    type: AddonInstallerControllerReconciledSuccessfully
+  - kubermatic_version: weekly-2019-46-366-gebffe161a-f6f8d34f876c6ebd32872306f1d410118e7f29fc
+    lastHeartbeatTime: "2020-04-01T20:05:57Z"
+    status: "True"
+    type: BackupControllerReconciledSuccessfully
+  - kubermatic_version: weekly-2019-46-366-gebffe161a-f6f8d34f876c6ebd32872306f1d410118e7f29fc
+    lastHeartbeatTime: "2020-04-01T20:06:27Z"
+    status: "True"
+    type: CloudControllerReconcilledSuccessfully
+  - kubermatic_version: weekly-2019-46-366-gebffe161a-f6f8d34f876c6ebd32872306f1d410118e7f29fc
+    lastHeartbeatTime: "2020-04-01T20:12:18Z"
+    message: Cluster has been initialized successfully
+    status: "True"
+    type: ClusterInitialized
+  - kubermatic_version: weekly-2019-46-366-gebffe161a-f6f8d34f876c6ebd32872306f1d410118e7f29fc
+    lastHeartbeatTime: "2020-04-01T20:05:56Z"
+    status: "True"
+    type: ComponentDefaulterReconciledSuccessfully
+  - kubermatic_version: weekly-2019-46-366-gebffe161a-f6f8d34f876c6ebd32872306f1d410118e7f29fc
+    lastHeartbeatTime: "2020-04-01T20:11:01Z"
+    status: "True"
+    type: MonitoringControllerReconciledSuccessfully
+  - kubermatic_version: weekly-2019-46-366-gebffe161a-f6f8d34f876c6ebd32872306f1d410118e7f29fc
+    lastHeartbeatTime: "2020-04-01T20:06:25Z"
+    status: "True"
+    type: OpenshiftControllerReconciledSuccessfully
+  - kubermatic_version: weekly-2019-46-366-gebffe161a-f6f8d34f876c6ebd32872306f1d410118e7f29fc
+    lastHeartbeatTime: "2020-04-01T20:12:17Z"
+    lastTransitionTime: "2020-04-01T20:12:17Z"
+    message: All control plane components are up to date
+    reason: ClusterUpdateSuccessful
+    status: "True"
+    type: SeedResourcesUpToDate
+  - kubermatic_version: weekly-2019-46-366-gebffe161a-f6f8d34f876c6ebd32872306f1d410118e7f29fc
+    lastHeartbeatTime: "2020-04-01T20:05:58Z"
+    status: "True"
+    type: UpdateControllerReconciledSuccessfully
+  extendedHealth:
+    apiserver: 1
+    cloudProviderInfrastructure: 1
+    controller: 1
+    etcd: 1
+    machineController: 1
+    openvpn: 1
+    scheduler: 1
+    userClusterControllerManager: 1
+  inheritedLabels:
+    user: exampleuser
+  kubermatic_version: ebffe161ae0d7efa1a367b2eacd54a01b6a6843b
+  lastUpdated: null
+  namespaceName: cluster-m7x6hnnptb
+  userEmail: user@example.com

--- a/api/pkg/controller/seed-controller-manager/addon/addon_controller.go
+++ b/api/pkg/controller/seed-controller-manager/addon/addon_controller.go
@@ -297,7 +297,6 @@ func (r *Reconciler) getAddonManifests(log *zap.SugaredLogger, addon *kubermatic
 
 	data, err := addonutils.NewTemplateData(
 		cluster,
-		addon,
 		credentials,
 		string(kubeconfig),
 		clusterIP,

--- a/api/pkg/controller/seed-controller-manager/addon/addon_controller.go
+++ b/api/pkg/controller/seed-controller-manager/addon/addon_controller.go
@@ -282,28 +282,32 @@ func (r *Reconciler) getAddonManifests(log *zap.SugaredLogger, addon *kubermatic
 		return nil, fmt.Errorf("failed to get credentials: %v", err)
 	}
 
-	data := &addonutils.TemplateData{
-		Variables:         make(map[string]interface{}),
-		Cluster:           cluster,
-		Credentials:       credentials,
-		MajorMinorVersion: cluster.Spec.Version.MajorMinor(),
-		Addon:             addon,
-		Kubeconfig:        string(kubeconfig),
-		DNSClusterIP:      clusterIP,
-		DNSResolverIP:     dnsResolverIP,
-		ClusterCIDR:       cluster.Spec.ClusterNetwork.Pods.CIDRBlocks[0],
-	}
-
 	// Add addon variables if available.
+	variables := make(map[string]interface{})
+
 	if sub := r.addonVariables[addon.Spec.Name]; sub != nil {
-		data.Variables = sub.(map[string]interface{})
+		variables = sub.(map[string]interface{})
 	}
 
 	if len(addon.Spec.Variables.Raw) > 0 {
-		if err = json.Unmarshal(addon.Spec.Variables.Raw, &data.Variables); err != nil {
+		if err = json.Unmarshal(addon.Spec.Variables.Raw, &variables); err != nil {
 			return nil, err
 		}
 	}
+
+	data, err := addonutils.NewTemplateData(
+		cluster,
+		addon,
+		credentials,
+		string(kubeconfig),
+		clusterIP,
+		dnsResolverIP,
+		variables,
+	)
+	if err != nil {
+		return nil, fmt.Errorf("failed to create template data for addon manifests: %v", err)
+	}
+
 	manifestPath := path.Join(addonDir, addon.Spec.Name)
 
 	allManifests, err := addonutils.ParseFromFolder(log, r.overwriteRegistry, manifestPath, data)

--- a/api/pkg/controller/seed-controller-manager/addon/addon_controller_test.go
+++ b/api/pkg/controller/seed-controller-manager/addon/addon_controller_test.go
@@ -79,7 +79,7 @@ spec:
     spec:
       containers:
       - name: nginx
-        image: {{Registry "foo.io" }}/test:1.2.3
+        image: {{ Registry "foo.io" }}/test:1.2.3
 `
 
 	testManifestKubeDNS = `apiVersion: v1
@@ -95,8 +95,8 @@ metadata:
 spec:
   selector:
     k8s-app: kube-dns
-  clusterIP: {{.DNSClusterIP}}
-  clusterCIDR: "{{first .Cluster.Spec.ClusterNetwork.Pods.CIDRBlocks}}"
+  clusterIP: {{ .Cluster.Network.DNSClusterIP }}
+  clusterCIDR: "{{ first .Cluster.Network.PodCIDRBlocks }}"
 `
 )
 

--- a/api/pkg/resources/data.go
+++ b/api/pkg/resources/data.go
@@ -316,25 +316,23 @@ func (d *TemplateData) CloudCredentialSecretTemplate() ([]byte, error) {
 }
 
 func GetKubernetesCloudProviderName(cluster *kubermaticv1.Cluster) string {
-	if cluster.Spec.Cloud.AWS != nil {
+	switch {
+	case cluster.Spec.Cloud.AWS != nil:
 		return "aws"
-	}
-	if cluster.Spec.Cloud.Openstack != nil {
-		if flag := cluster.Spec.Features[kubermaticv1.ClusterFeatureExternalCloudProvider]; flag {
+	case cluster.Spec.Cloud.VSphere != nil:
+		return "vsphere"
+	case cluster.Spec.Cloud.Azure != nil:
+		return "azure"
+	case cluster.Spec.Cloud.GCP != nil:
+		return "gce"
+	case cluster.Spec.Cloud.Openstack != nil:
+		if cluster.Spec.Features[kubermaticv1.ClusterFeatureExternalCloudProvider] {
 			return "external"
 		}
 		return "openstack"
+	default:
+		return ""
 	}
-	if cluster.Spec.Cloud.VSphere != nil {
-		return "vsphere"
-	}
-	if cluster.Spec.Cloud.Azure != nil {
-		return "azure"
-	}
-	if cluster.Spec.Cloud.GCP != nil {
-		return "gce"
-	}
-	return ""
 }
 
 func (d *TemplateData) Seed() *kubermaticv1.Seed {

--- a/docs/zz_generated.addondata.go
+++ b/docs/zz_generated.addondata.go
@@ -1,9 +1,8 @@
-// TemplateData is injected into templates.
+// TemplateData is the root context injected into each addon manifest file.
 type TemplateData struct {
 	SeedName       string
 	DatacenterName string
 	Cluster        ClusterData
-	Addon          AddonData
 	Credentials    Credentials
 	Variables      map[string]interface{}
 }
@@ -11,20 +10,44 @@ type TemplateData struct {
 // ClusterData contains data related to the user cluster
 // the addon is rendered for.
 type ClusterData struct {
-	Name                 string
-	HumanReadableName    string
-	Namespace            string
-	OwnerName            string
-	OwnerEmail           string
-	Kubeconfig           string
+	// Type is either "kubernetes" or "openshift".
+	Type string
+	// Name is the auto-generated, internal cluster name, e.g. "bbc8sc24wb".
+	Name string
+	// HumanReadableName is the user-specified cluster name.
+	HumanReadableName string
+	// Namespace is the full namespace for the cluster's control plane.
+	Namespace string
+	// OwnerName is the owner's full name.
+	OwnerName string
+	// OwnerEmail is the owner's e-mail address.
+	OwnerEmail string
+	// Kubeconfig is a YAML-encoded kubeconfig with cluster-admin permissions
+	// inside the user-cluster. The kubeconfig uses the external URL to reach
+	// the apiserver.
+	Kubeconfig string
+	// ApiserverExternalURL is the full URL to the apiserver service from the
+	// outside, including protocol and port number. It does not contain any
+	// trailing slashes.
 	ApiserverExternalURL string
+	// ApiserverExternalURL is the full URL to the apiserver from within the
+	// seed cluster itself. It does not contain any trailing slashes.
 	ApiserverInternalURL string
-	AdminToken           string
-	CloudProviderName    string
-	Version              *semver.Version
-	MajorMinorVersion    string
-	Network              ClusterNetwork
-	Features             sets.String
+	// AdminToken is the cluster's admin token.
+	AdminToken string
+	// CloudProviderName is the name of the cloud provider used, one of
+	// "alibaba", "aws", "azure", "bringyourown", "digitalocean", "gcp",
+	// "hetzner", "kubevirt", "openstack", "packet", "vsphere" depending on
+	// the configured datacenters.
+	CloudProviderName string
+	// Version is the exact cluster version.
+	Version *semver.Version
+	// MajorMinorVersion is a shortcut for common testing on "Major.Minor".
+	MajorMinorVersion string
+	// Network contains DNS and CIDR settings for the cluster.
+	Network ClusterNetwork
+	// Features is a set of enabled features for this cluster.
+	Features sets.String
 }
 
 type ClusterNetwork struct {
@@ -33,11 +56,6 @@ type ClusterNetwork struct {
 	PodCIDRBlocks     []string
 	ServiceCIDRBlocks []string
 	ProxyMode         string
-}
-
-type AddonData struct {
-	Name      string
-	IsDefault bool
 }
 
 type Credentials struct {

--- a/docs/zz_generated.addondata.go
+++ b/docs/zz_generated.addondata.go
@@ -1,0 +1,105 @@
+// TemplateData is injected into templates.
+type TemplateData struct {
+	SeedName       string
+	DatacenterName string
+	Cluster        ClusterData
+	Addon          AddonData
+	Credentials    Credentials
+	Variables      map[string]interface{}
+}
+
+// ClusterData contains data related to the user cluster
+// the addon is rendered for.
+type ClusterData struct {
+	Name                 string
+	HumanReadableName    string
+	Namespace            string
+	OwnerName            string
+	OwnerEmail           string
+	Kubeconfig           string
+	ApiserverExternalURL string
+	ApiserverInternalURL string
+	AdminToken           string
+	CloudProviderName    string
+	Version              *semver.Version
+	MajorMinorVersion    string
+	Network              ClusterNetwork
+	Features             sets.String
+}
+
+type ClusterNetwork struct {
+	DNSClusterIP      string
+	DNSResolverIP     string
+	PodCIDRBlocks     []string
+	ServiceCIDRBlocks []string
+	ProxyMode         string
+}
+
+type AddonData struct {
+	Name      string
+	IsDefault bool
+}
+
+type Credentials struct {
+	AWS          AWSCredentials
+	Azure        AzureCredentials
+	Digitalocean DigitaloceanCredentials
+	GCP          GCPCredentials
+	Hetzner      HetznerCredentials
+	Openstack    OpenstackCredentials
+	Packet       PacketCredentials
+	Kubevirt     KubevirtCredentials
+	VSphere      VSphereCredentials
+	Alibaba      AlibabaCredentials
+}
+
+type AWSCredentials struct {
+	AccessKeyID     string
+	SecretAccessKey string
+}
+
+type AzureCredentials struct {
+	TenantID       string
+	SubscriptionID string
+	ClientID       string
+	ClientSecret   string
+}
+
+type DigitaloceanCredentials struct {
+	Token string
+}
+
+type GCPCredentials struct {
+	ServiceAccount string
+}
+
+type HetznerCredentials struct {
+	Token string
+}
+
+type OpenstackCredentials struct {
+	Username string
+	Password string
+	Tenant   string
+	TenantID string
+	Domain   string
+}
+
+type PacketCredentials struct {
+	APIKey    string
+	ProjectID string
+}
+
+type KubevirtCredentials struct {
+	KubeConfig string
+}
+
+type VSphereCredentials struct {
+	Username string
+	Password string
+}
+
+type AlibabaCredentials struct {
+	AccessKeyID     string
+	AccessKeySecret string
+}

--- a/openshift_addons/default-storage-class/storage-class.yaml
+++ b/openshift_addons/default-storage-class/storage-class.yaml
@@ -1,5 +1,5 @@
 {{/* Template must only emit data in case its valid for a given provider. That way we can ensure we don't install it when not needed */}}
-{{ if .Cluster.Spec.Cloud.Azure }}
+{{ if eq .Cluster.CloudProviderName "azure" }}
 apiVersion: storage.k8s.io/v1
 kind: StorageClass
 metadata:
@@ -14,7 +14,7 @@ parameters:
   storageaccounttype: Standard_LRS
 {{ end }}
 
-{{ if .Cluster.Spec.Cloud.AWS }}
+{{ if eq .Cluster.CloudProviderName "aws" }}
 apiVersion: storage.k8s.io/v1
 kind: StorageClass
 metadata:
@@ -29,7 +29,7 @@ parameters:
 volumeBindingMode: WaitForFirstConsumer
 {{ end }}
 
-{{ if .Cluster.Spec.Cloud.VSphere }}
+{{ if eq .Cluster.CloudProviderName "vsphere" }}
 apiVersion: storage.k8s.io/v1
 kind: StorageClass
 metadata:
@@ -43,7 +43,7 @@ parameters:
   diskformat: thin
 {{ end }}
 
-{{ if .Cluster.Spec.Cloud.Openstack }}
+{{ if eq .Cluster.CloudProviderName "openstack" }}
 apiVersion: storage.k8s.io/v1
 kind: StorageClass
 metadata:
@@ -55,7 +55,7 @@ metadata:
 provisioner: kubernetes.io/cinder
 {{ end }}
 
-{{ if .Cluster.Spec.Cloud.GCP }}
+{{ if eq .Cluster.CloudProviderName "gcp" }}
 apiVersion: storage.k8s.io/v1
 kind: StorageClass
 metadata:
@@ -69,14 +69,14 @@ parameters:
   type: pd-ssd
 {{ end }}
 
-{{ if .Cluster.Spec.Cloud.Hetzner }}
+{{ if eq .Cluster.CloudProviderName "hetzner" }}
 apiVersion: v1
 kind: Secret
 metadata:
   name: hcloud-csi
   namespace: kube-system
 data:
-  token: {{ .Credentials.Hetzner.Token|b64enc }}
+  token: {{ .Credentials.Hetzner.Token | b64enc }}
 ---
 kind: StorageClass
 apiVersion: storage.k8s.io/v1

--- a/openshift_addons/network/network.yaml
+++ b/openshift_addons/network/network.yaml
@@ -3,9 +3,9 @@ kind: Network
 metadata:
   name: cluster
 spec:
-  clusterNetwork:{{ range .Cluster.Spec.ClusterNetwork.Pods.CIDRBlocks }}
+  clusterNetwork:{{ range .Cluster.Network.PodCIDRBlocks }}
   - cidr: {{ . }}
     hostPrefix: 23{{ end }}
   networkType: OpenShiftSDN
-  serviceNetwork:{{ range .Cluster.Spec.ClusterNetwork.Services.CIDRBlocks }}
+  serviceNetwork:{{ range .Cluster.Network.ServiceCIDRBlocks }}
   - {{ . }}{{ end }}

--- a/openshift_addons/openvpn/openvpn-client-dep.yaml
+++ b/openshift_addons/openvpn/openvpn-client-dep.yaml
@@ -68,7 +68,7 @@ spec:
           iptables -t nat -D PREROUTING -j host_dnat || true
           iptables -t nat -D PREROUTING -j host_dnat_inactive || true
 
-          virtualnodenet='{{.Variables.NodeAccessNetwork}}'
+          virtualnodenet='{{ .Variables.NodeAccessNetwork }}'
 
           # access node list via kubectl and generate iptables rules
           # for DNAT from it.

--- a/openshift_addons/registry/imageregistry.yaml
+++ b/openshift_addons/registry/imageregistry.yaml
@@ -1,4 +1,4 @@
-{{ if .Cluster.Spec.Cloud.AWS }}
+{{ if eq .Cluster.CloudProviderName "aws" }}
 #apiVersion: imageregistry.operator.openshift.io/v1
 #kind: Config
 #metadata:


### PR DESCRIPTION
**What this PR does / why we need it**:
We have always offered templating in addon manifests (or at least for quite some time), yet we have never officially documented the available variables. This made the "templating interface" for addon authors needlessly hard to figure out.

This PR fixes that by generating a Go snippet for the struct that we actually inject into the Go templates. This Go snippet is generated by recursively finding all structs referenced in the `addon.TemplateData` struct.

As our CRDs are not our API and hence never considered stable, this PR changes `TemplateData` to have its very own data structure with a `NewTemplateData` mapping helper. This is similar to how we handle CRDs in our REST API.

https://github.com/loodse/docs/pull/246 contains the upgrade notes for this change.

**Does this PR introduce a user-facing change?**:
```release-note
Action required: Addon manifest templating is now a stable API, but different to the old implicit data. Custom addons might need to be adjusted.
```
