### PR TITLE
cluster controller: make sure the cluster health status is always synced

### DIFF
--- a/api/pkg/controller/seed-controller-manager/kubernetes/cluster_controller.go
+++ b/api/pkg/controller/seed-controller-manager/kubernetes/cluster_controller.go
@@ -227,6 +227,11 @@ func (r *Reconciler) Reconcile(request reconcile.Request) (reconcile.Result, err
 }
 
 func (r *Reconciler) reconcile(ctx context.Context, log *zap.SugaredLogger, cluster *kubermaticv1.Cluster) (*reconcile.Result, error) {
+	// synchronize cluster.status.health for Kubernetes clusters
+	if err := r.syncHealth(ctx, cluster); err != nil {
+		return nil, err
+	}
+
 	if cluster.DeletionTimestamp != nil {
 		log.Debug("Cleaning up cluster")
 

--- a/api/pkg/controller/seed-controller-manager/kubernetes/pending.go
+++ b/api/pkg/controller/seed-controller-manager/kubernetes/pending.go
@@ -32,11 +32,6 @@ func (r *Reconciler) reconcileCluster(ctx context.Context, cluster *kubermaticv1
 		return nil, err
 	}
 
-	// synchronize cluster.status.health for Kubernetes clusters
-	if err := r.syncHealth(ctx, cluster); err != nil {
-		return nil, err
-	}
-
 	if cluster.Status.ExtendedHealth.Apiserver == kubermaticv1.HealthStatusUp {
 		// Controlling of user-cluster resources
 		reachable, err := r.clusterIsReachable(ctx, cluster)


### PR DESCRIPTION
Signed-off-by: Olaf Klischat <o.klischat@syseleven.de>

**What this PR does / why we need it**:

I recently had the case that a cluster was stuck in deletion indefinitely because the apiserver was marked as "provisioning" (2) in the cluster's .status.extendedHealth, and that never gets updated for clusters with deletionTimestamp set. This PR moves the synchronization of .status.extendedHealth to the beginning of the reconciliation loop, where it'll always be executed no matter what. Is this OK or am I overlooking something here?

**Does this PR introduce a user-facing change?**:
```release-note
NONE
```
