### PR TITLE
Cluster deletion: Fix cleanupPVCUsingPods

### DIFF
--- a/api/pkg/clusterdeletion/volumes.go
+++ b/api/pkg/clusterdeletion/volumes.go
@@ -86,9 +86,10 @@ func (d *Deletion) cleanupPVCUsingPods(ctx context.Context, userClusterClient co
 	}
 
 	pvUsingPods := []*corev1.Pod{}
-	for _, pod := range podList.Items {
-		if podUsesPV(&pod) {
-			pvUsingPods = append(pvUsingPods, &pod)
+	for idx := range podList.Items {
+		pod := &podList.Items[idx]
+		if podUsesPV(pod) {
+			pvUsingPods = append(pvUsingPods, pod)
 		}
 	}
 


### PR DESCRIPTION
Signed-off-by: Olaf Klischat <o.klischat@syseleven.de>

**What this PR does / why we need it**:

This is a bugfix for the PVC cleanup during cluster deletion. See diff. The current master just copies successive elements of `podList.Items` to the `pod` loop variable and then adds a pointer to it to `pvUsingPods`, which ends up containing just a bunch of identical pointers to a copy of the last element of `podList.Items` rather than pointers to all the pods in `podList.Items` that use PVCs. This means that none of those pods are deleted and thus no PVCs or PVs are ever deleted either, which ends up preventing cluster deletion entirely because all the PVs and PVCs are stuck in "Terminating" indefinitely. We've seen this over the last days, with quite a lot of test clusters never being deleted.

**Does this PR introduce a user-facing change?**:

```release-note
NONE
```
