### PR TITLE
fix docs sync using bad directories

### DIFF
--- a/api/hack/ci/ci-update-docs.sh
+++ b/api/hack/ci/ci-update-docs.sh
@@ -20,9 +20,12 @@ git clone git@github.com:kubermatic/docs.git $TARGET_DIR
 cd $TARGET_DIR
 
 # copy interesting files over
-cp ../docs/zz_generated.seed.yaml data/seed.yaml
-cp ../docs/zz_generated.kubermaticConfiguration.yaml data/kubermaticConfiguration.yaml
-cp ../docs/zz_generated.addondata.go data/addondata.go
+mkdir -p data/kubermatic/master
+mkdir -p content/kubermatic/master/data
+
+cp ../docs/zz_generated.seed.yaml data/kubermatic/master/seed.yaml
+cp ../docs/zz_generated.kubermaticConfiguration.yaml data/kubermatic/master/kubermaticConfiguration.yaml
+cp ../docs/zz_generated.addondata.go content/kubermatic/master/data/addondata.go
 
 # re-create Prometheus runbook
 make runbook


### PR DESCRIPTION
**What this PR does / why we need it**:
Hugo cannot handle .go files in data/ and we also should make sure that our CRD examples are properly versioned. This PR adjusts the sync script to put the generated files in better locations.

https://github.com/loodse/docs/pull/296 updates the docs repo accordingly.

**Does this PR introduce a user-facing change?**:
```release-note
NONE
```
