### PR TITLE
[release/v2.13] keep most recent backup on cluster deletion (#5262)

### DIFF
--- a/api/cmd/s3-storeuploader/main.go
+++ b/api/cmd/s3-storeuploader/main.go
@@ -110,7 +110,7 @@ func main() {
 				bucketFlag,
 				prefixFlag,
 				maxRevisionsFlag,
-				fileFlag,
+				fileFlag, // unused but kept for BC compatibility with old cleanup scripts
 			},
 		},
 		{

--- a/api/pkg/controller/operator/common/defaults.go
+++ b/api/pkg/controller/operator/common/defaults.go
@@ -346,8 +346,12 @@ command:
 - -c
 - |
   set -euo pipefail
-  s3-storeuploader store --endpoint minio.minio.svc.cluster.local:9000 --bucket kubermatic-etcd-backups --create-bucket --prefix $CLUSTER --file /backup/snapshot.db
-  s3-storeuploader delete-old-revisions --endpoint minio.minio.svc.cluster.local:9000 --bucket kubermatic-etcd-backups --prefix $CLUSTER --file /backup/snapshot.db --max-revisions 20
+
+  endpoint=minio.minio.svc.cluster.local:9000
+  bucket=kubermatic-etcd-backups
+
+  s3-storeuploader store --file /backup/snapshot.db --endpoint "$endpoint" --bucket "$bucket" --create-bucket --prefix $CLUSTER
+  s3-storeuploader delete-old-revisions --max-revisions 20 --endpoint "$endpoint" --bucket "$bucket" --prefix $CLUSTER
 env:
 - name: ACCESS_KEY_ID
   valueFrom:
@@ -372,7 +376,15 @@ command:
 - -c
 - |
   set -euo pipefail
-  s3-storeuploader delete-all --endpoint minio.minio.svc.cluster.local:9000 --bucket kubermatic-etcd-backups --prefix $CLUSTER
+
+  endpoint=minio.minio.svc.cluster.local:9000
+  bucket=kubermatic-etcd-backups
+
+  # by default, we keep the most recent backup for every user cluster
+  s3-storeuploader delete-old-revisions --max-revisions 1 --endpoint "$endpoint" --bucket "$bucket" --prefix $CLUSTER
+
+  # alternatively, delete all backups for this cluster
+  #s3-storeuploader delete-all --endpoint "$endpoint" --bucket "$bucket" --prefix $CLUSTER
 env:
 - name: ACCESS_KEY_ID
   valueFrom:

--- a/config/kubermatic/Chart.yaml
+++ b/config/kubermatic/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: kubermatic
-version: 1.0.40
+version: 1.0.41
 appVersion: '__KUBERMATIC_TAG__'
 description: Kubermatic chart for master and/or seed clusters.
 keywords:

--- a/config/kubermatic/static/backup-container.yaml
+++ b/config/kubermatic/static/backup-container.yaml
@@ -5,8 +5,12 @@ command:
 - -c
 - |
   set -euo pipefail
-  s3-storeuploader store --endpoint minio.minio.svc.cluster.local:9000 --bucket kubermatic-etcd-backups --create-bucket --prefix $CLUSTER --file /backup/snapshot.db
-  s3-storeuploader delete-old-revisions --endpoint minio.minio.svc.cluster.local:9000 --bucket kubermatic-etcd-backups --prefix $CLUSTER --file /backup/snapshot.db --max-revisions 20
+
+  endpoint=minio.minio.svc.cluster.local:9000
+  bucket=kubermatic-etcd-backups
+
+  s3-storeuploader store --file /backup/snapshot.db --endpoint "$endpoint" --bucket "$bucket" --create-bucket --prefix $CLUSTER
+  s3-storeuploader delete-old-revisions --max-revisions 20 --endpoint "$endpoint" --bucket "$bucket" --prefix $CLUSTER
 env:
 - name: ACCESS_KEY_ID
   valueFrom:

--- a/config/kubermatic/static/cleanup-container.yaml
+++ b/config/kubermatic/static/cleanup-container.yaml
@@ -5,7 +5,15 @@ command:
 - -c
 - |
   set -euo pipefail
-  s3-storeuploader delete-all --endpoint minio.minio.svc.cluster.local:9000 --bucket kubermatic-etcd-backups --prefix $CLUSTER
+
+  endpoint=minio.minio.svc.cluster.local:9000
+  bucket=kubermatic-etcd-backups
+
+  # by default, we keep the most recent backup for every user cluster
+  s3-storeuploader delete-old-revisions --max-revisions 1 --endpoint "$endpoint" --bucket "$bucket" --prefix $CLUSTER
+
+  # alternatively, delete all backups for this cluster
+  #s3-storeuploader delete-all --endpoint "$endpoint" --bucket "$bucket" --prefix $CLUSTER
 env:
 - name: ACCESS_KEY_ID
   valueFrom:

--- a/docs/zz_generated.kubermaticConfiguration.yaml
+++ b/docs/zz_generated.kubermaticConfiguration.yaml
@@ -275,7 +275,15 @@ spec:
       - -c
       - |
         set -euo pipefail
-        s3-storeuploader delete-all --endpoint minio.minio.svc.cluster.local:9000 --bucket kubermatic-etcd-backups --prefix $CLUSTER
+
+        endpoint=minio.minio.svc.cluster.local:9000
+        bucket=kubermatic-etcd-backups
+
+        # by default, we keep the most recent backup for every user cluster
+        s3-storeuploader delete-old-revisions --max-revisions 1 --endpoint "$endpoint" --bucket "$bucket" --prefix $CLUSTER
+
+        # alternatively, delete all backups for this cluster
+        #s3-storeuploader delete-all --endpoint "$endpoint" --bucket "$bucket" --prefix $CLUSTER
       env:
       - name: ACCESS_KEY_ID
         valueFrom:
@@ -296,8 +304,12 @@ spec:
       - -c
       - |
         set -euo pipefail
-        s3-storeuploader store --endpoint minio.minio.svc.cluster.local:9000 --bucket kubermatic-etcd-backups --create-bucket --prefix $CLUSTER --file /backup/snapshot.db
-        s3-storeuploader delete-old-revisions --endpoint minio.minio.svc.cluster.local:9000 --bucket kubermatic-etcd-backups --prefix $CLUSTER --file /backup/snapshot.db --max-revisions 20
+
+        endpoint=minio.minio.svc.cluster.local:9000
+        bucket=kubermatic-etcd-backups
+
+        s3-storeuploader store --file /backup/snapshot.db --endpoint "$endpoint" --bucket "$bucket" --create-bucket --prefix $CLUSTER
+        s3-storeuploader delete-old-revisions --max-revisions 20 --endpoint "$endpoint" --bucket "$bucket" --prefix $CLUSTER
       env:
       - name: ACCESS_KEY_ID
         valueFrom:


### PR DESCRIPTION
**What this PR does / why we need it**:
Backports #5262 into the 2.13 release branch.

**Does this PR introduce a user-facing change?**:
```release-note
When a user cluster is deleted, the most recent etcd backup is kept until manual cleanup.
```
