### PR TITLE
openstack cloud controller manager: use unique cluster name

### DIFF
--- a/api/pkg/resources/cloudcontroller/openstack.go
+++ b/api/pkg/resources/cloudcontroller/openstack.go
@@ -149,6 +149,7 @@ func getOSFlags(data *resources.TemplateData) []string {
 		"--v=1",
 		"--cloud-config=/etc/kubernetes/cloud/config",
 		"--cloud-provider=openstack",
+		"--cluster-name=" + data.Cluster().Name,
 	}
 	return flags
 }


### PR DESCRIPTION
Signed-off-by: Olaf Klischat <o.klischat@syseleven.de>

**What this PR does / why we need it**:

We noticed that we’re not setting the clusterName parameter for the openstack cloud controller manager, which means it’ll default to “kubernetes”. That will lead to non-unique openstack load balancer names at https://github.com/kubernetes/cloud-provider-openstack/blob/8c02748fab095675514861628ea57317bb36c263/pkg/cloudprovider/providers/openstack/openstack_loadbalancer.go#L521

This will result in a name clash if a user has more than one cluster in the same openstack tenant and then creates a loadbalancer service with the same name in the same namespace in all those clusters. Those clusters would then all try to use the same Openstack loadbalancer. This would definitely be the case for quite a few of our customers, hence this PR.

This definitely means though that for for users that use openstack and have already deployed 2.13 and created loadbalancer services, new openstack loadbalancers with new external IPs would be created for those services because of the name change. (it won’t be a problem for us because we haven’t rolled out 2.13 to production yet)

**Does this PR introduce a user-facing change?**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If  no release note is required, just write "NONE".
-->
```release-note
Set clusterName parameter in Openstack cloud controller to the Kubermatic cluster id to ensure unique names of created cloud resources like load balancers.
```
