### PR TITLE
cinder csi addon: use unique cluster name

### DIFF
--- a/addons/csi/controllerplugin.yaml
+++ b/addons/csi/controllerplugin.yaml
@@ -109,7 +109,7 @@ spec:
             - name: CLOUD_CONFIG
               value: /etc/config/config
             - name: CLUSTER_NAME
-              value: kubernetes
+              value: {{ .Cluster.Name }}
           imagePullPolicy: "IfNotPresent"
           volumeMounts:
             - name: socket-dir


### PR DESCRIPTION
Signed-off-by: Olaf Klischat <o.klischat@syseleven.de>

**What this PR does / why we need it**:

Similar to https://github.com/kubermatic/kubermatic/pull/5322, this PR sets the cluster name to the Kubermatic cluster id for the cinder csi addon too. I couldn't see any changes triggered by this -- the cinder volume names of created volumes are just the same as the pv names, i.e. `pvc-<uuid>`, i.e. they do not contain the cluster name, and thus this PR doesn't change those names and no new volumes are created. So this PR probably isn't that important, but it's there for consistency, and it may be possible that future versions of the cinder csi plugin use the cluster name as part of the name of some created artifacts, and then it would be beneficial to have a unique cluster names to avoid name clashes similar to the one described in https://github.com/kubermatic/kubermatic/pull/5322.

N.B. ideally we would also add the `--cluster-name=<clusterid>` option to the controller manager so it's used by the in-tree cloud providers (i.e. for existing/older clusters), but that *would* create new volumes because the volume names there are `<cluster name>-dynamic-<pv name>`, i.e. they include the cluster name. So we're not doing that.

**Does this PR introduce a user-facing change?**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If  no release note is required, just write "NONE".
-->
```release-note
Set clusterName parameter in cinder csi addon to the Kubermatic cluster id.
```
