### PR TITLE
Backup hourly ClusterResources and all Namespaces

### DIFF
--- a/config/backup/velero/Chart.yaml
+++ b/config/backup/velero/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: velero
-version: 1.3.0
+version: 1.3.2
 appVersion: v1.3.2
 description: A Helm chart for Heptio Velero
 keywords:

--- a/config/backup/velero/schedules/hourly-cluster.yaml
+++ b/config/backup/velero/schedules/hourly-cluster.yaml
@@ -1,0 +1,12 @@
+apiVersion: velero.io/v1
+kind: Schedule
+metadata:
+  name: hourly-cluster
+spec:
+  schedule: 0 * * * *
+  template:
+    includeClusterResources: true
+    includedNamespaces:
+    - '*'
+    snapshotVolumes: false
+    ttl: 168h # 7 days  


### PR DESCRIPTION
**Documentation**: tbd
<!-- Add links to the related documentation changes related to this pull request. E.g. the link to the kubermatic/docs pullrequest. -->

**Does this PR introduce a user-facing change?**:
```release-note
Create an hourly schedule Velero backup for all namespaces and cluster resources
```
