### PR TITLE
Openstack: include distributed routers in existing router search

### DIFF
--- a/api/pkg/provider/cloud/openstack/helper.go
+++ b/api/pkg/provider/cloud/openstack/helper.go
@@ -448,7 +448,7 @@ func getRouterIDForSubnet(netClient *gophercloud.ServiceClient, subnetID, networ
 	}
 
 	for _, port := range ports {
-		if port.DeviceOwner == "network:router_interface" {
+		if port.DeviceOwner == "network:router_interface" || port.DeviceOwner == "network:router_interface_distributed" {
 			// Check IP for the interface & check if the IP belongs to the subnet
 			for _, ip := range port.FixedIPs {
 				if ip.SubnetID == subnetID {


### PR DESCRIPTION
When we crate a cluster in an existing subnet, the code looks for
existing routers to which the subnet is connected.

Before this commit we only look for 'network:router_interface'. On some
installations the routers are network:router_interface_distributed.

As a result, Kubermatic user to report no routers found and attempted to
create a new router for the subnet, which is not allowed.

```release-note
Openstack: fixed a bug preventing the usage of pre-existing subnets connected to distributed routers
```
