### PR TITLE
ci-push-images.sh: don't try to build any matching tag

### DIFF
--- a/api/hack/ci/ci-push-images.sh
+++ b/api/hack/ci/ci-push-images.sh
@@ -6,7 +6,7 @@ cd "$(git rev-parse --show-toplevel)"
 . ./api/hack/lib.sh
 
 GIT_HEAD_HASH="$(git rev-parse HEAD)"
-GIT_HEAD_TAG="$(git tag -l --points-at HEAD)"
+GIT_HEAD_TAG="$(git tag -l "$PULL_BASE_REF")"
 GIT_BRANCH="$(git rev-parse --abbrev-ref HEAD)"
 TAGS="$GIT_HEAD_HASH $GIT_HEAD_TAG"
 


### PR DESCRIPTION
Instead make sure that the we build tag passed by prow ref (if it's a tag).

Fixes script failure in case of multiple tags pointing to the same commit.

```release-note
NONE
```
