### PR TITLE
Fix possible service IP collision for kube-dns

### DIFF
--- a/api/pkg/controller/master-controller-manager/rbac/sync_resource_test.go
+++ b/api/pkg/controller/master-controller-manager/rbac/sync_resource_test.go
@@ -36,7 +36,7 @@ func TestSyncProjectResourcesClusterWide(t *testing.T) {
 		// scenario 1
 		{
 			name:            "scenario 1: a proper set of RBAC Role/Binding is generated for a cluster",
-			expectedActions: []string{"create", "create", "create", "create", "create", "create", "get", "create", "get", "create", "get", "create", "get", "create", "get", "create", "get", "create"},
+			expectedActions: []string{"create", "create", "create", "create", "create", "create", "get", "create", "get", "create", "get", "create", "get", "create", "get", "create", "get", "create", "create", "create"},
 
 			dependantToSync: &resourceToProcess{
 				gvr: schema.GroupVersionResource{

--- a/api/pkg/controller/user-cluster-controller-manager/resources/resources/kubernetes-dashboard/service.go
+++ b/api/pkg/controller/user-cluster-controller-manager/resources/resources/kubernetes-dashboard/service.go
@@ -56,7 +56,7 @@ func getMetricsScraperServiceIP(clusterCIDRBlocks []string) (string, error) {
 
 	ip[len(ip)-1] = ip[len(ip)-1] + byte((rand.Intn(200) + 20))
 	if !ipnet.Contains(ip) { // highly unlikely, but checking anyway.
-		return "", fmt.Errorf("failed to get a valid service IP, retrying..")
+		return "", fmt.Errorf("failed to get a valid service IP")
 	}
 
 	return ip.String(), nil

--- a/api/pkg/controller/user-cluster-controller-manager/resources/resources/kubernetes-dashboard/service.go
+++ b/api/pkg/controller/user-cluster-controller-manager/resources/resources/kubernetes-dashboard/service.go
@@ -1,6 +1,12 @@
 package kubernetesdashboard
 
 import (
+	"errors"
+	"fmt"
+	"math/rand"
+	"net"
+	"time"
+
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/util/intstr"
 
@@ -9,7 +15,7 @@ import (
 )
 
 // ServiceCreator creates the service for the dashboard-metrics-scraper
-func ServiceCreator() reconciling.NamedServiceCreatorGetter {
+func ServiceCreator(cidrBlocks []string) reconciling.NamedServiceCreatorGetter {
 	return func() (string, reconciling.ServiceCreator) {
 		return resources.MetricsScraperServiceName, func(s *corev1.Service) (*corev1.Service, error) {
 			s.Name = resources.MetricsScraperServiceName
@@ -22,7 +28,36 @@ func ServiceCreator() reconciling.NamedServiceCreatorGetter {
 					TargetPort: intstr.FromInt(8000),
 				},
 			}
+			if s.Spec.ClusterIP == "" {
+				clusterIP, err := getMetricsScraperServiceIP(cidrBlocks)
+				if err != nil {
+					return nil, err
+				}
+				s.Spec.ClusterIP = clusterIP
+			}
 			return s, nil
 		}
 	}
+}
+
+// To avoid IP collision with the kube-dns service(https://github.com/kubermatic/kubermatic/issues/5232), we ensure that the IP used for this service is from a range outside the expected IP for the kube-dns service.
+func getMetricsScraperServiceIP(clusterCIDRBlocks []string) (string, error) {
+	rand.Seed(time.Now().UnixNano())
+	if len(clusterCIDRBlocks) == 0 {
+		return "", errors.New("failed to get metrics scarapper service IP: no service cidr defined")
+	}
+
+	block := clusterCIDRBlocks[0]
+	_, ipnet, err := net.ParseCIDR(block)
+	if err != nil {
+		return "", fmt.Errorf("failed to get metrics scarapper service IP: invalid service cidr %s", block)
+	}
+	ip := ipnet.IP
+
+	ip[len(ip)-1] = ip[len(ip)-1] + byte((rand.Intn(200) + 20))
+	if !ipnet.Contains(ip) { // highly unlikely, but checking anyway.
+		return "", fmt.Errorf("failed to get a valid service IP, retrying..")
+	}
+
+	return ip.String(), nil
 }


### PR DESCRIPTION
**What this PR does / why we need it**:

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #5232

**Special notes for your reviewer**:
It seems the first 3 services created in `kube-system` are `kubeapi`, `dashboard-metrics-scraper` and `kube-dns`. So, `dashboard-metrics-scraper` is only one likely to beat `kube-dns` to that particular IP.
This best way I figured to fix this is to also set the IP for `dashboard-metrics-scraper` but make sure it's not conflicting with the `kube-dns` IP. Theoretically, there is a possibility that this might conflict with an existing service IP, but it's very unlikely since this is the second service created on the user cluster.
**Documentation**:
<!-- Add links to the related documentation changes related to this pull request. E.g. the link to the kubermatic/docs pullrequest. -->

**Does this PR introduce a user-facing change?**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If  no release note is required, just write "NONE".
-->
```release-note
NONE
```
