### PR TITLE
restore f8598963e (make openshift tests optional)

### DIFF
--- a/.prow.yaml
+++ b/.prow.yaml
@@ -835,7 +835,8 @@ presubmits:
 
   - name: pre-kubermatic-e2e-aws-openshift-4.1
     decorate: true
-    run_if_changed: "(api/|config/kubermatic|openshift_addons/|.prow.yaml)"
+    optional: true
+    run_if_changed: "openshift_addons/"
     clone_uri: "ssh://git@github.com/kubermatic/kubermatic.git"
     labels:
       preset-aws: "true"


### PR DESCRIPTION
**What this PR does / why we need it**:
The change from #5335 got somehow lost in #5325, even though I thought I carefully rebased and was aware of the change. In contrast to the original PR, I chose to still at least run the tests by default when the openshift addons changed.

**Does this PR introduce a user-facing change?**:
```release-note
NONE
```
