### PR TITLE
[release/v2.12] add .prow.yaml

### DIFF
--- a/.prow.yaml
+++ b/.prow.yaml
@@ -1,0 +1,900 @@
+presubmits:
+  - name: pre-kubermatic-e2e-aws-coreos-1.16
+    decorate: true
+    clone_uri: "ssh://git@github.com/kubermatic/kubermatic.git"
+    skip_branches:
+    - master
+    - weekly
+    labels:
+      preset-aws: "true"
+      preset-vault: "true"
+      preset-docker-push: "true"
+      preset-repo-ssh: "true"
+    spec:
+      containers:
+      - image: docker.io/kubermatic/kubernetes-test-binaries:v0.10.8
+        env:
+        - name: VERSIONS_TO_TEST
+          value: "v1.16.2"
+        command:
+        - "./api/hack/ci-run-minimal-conformance-tests.sh"
+        # docker-in-docker needs privileged mode
+        securityContext:
+          privileged: true
+        resources:
+          requests:
+            memory: 2.5Gi
+            cpu: 500m
+          limits:
+            memory: 4Gi
+            cpu: 2
+
+  - name: pre-kubermatic-e2e-do-centos-1.15
+    decorate: true
+    always_run: false
+    optional: true
+    clone_uri: "ssh://git@github.com/kubermatic/kubermatic.git"
+    skip_branches:
+    - release/v2.9
+    - master
+    - weekly
+    labels:
+      preset-digitalocean: "true"
+      preset-vault: "true"
+      preset-docker-push: "true"
+      preset-repo-ssh: "true"
+    spec:
+      containers:
+      - image: docker.io/kubermatic/kubernetes-test-binaries:v0.10.8
+        env:
+        - name: VERSIONS_TO_TEST
+          value: "v1.15.5"
+        - name: EXCLUDE_DISTRIBUTIONS
+          value: "ubuntu,coreos"
+        - name: PROVIDER
+          value: "digitalocean"
+        command:
+        - "./api/hack/ci-run-minimal-conformance-tests.sh"
+        # docker-in-docker needs privileged mode
+        securityContext:
+          privileged: true
+        resources:
+          requests:
+            memory: 2.5Gi
+            cpu: 500m
+          limits:
+            memory: 4Gi
+            cpu: 2
+
+  - name: pre-kubermatic-e2e-upgrade-weekly
+    decorate: true
+    always_run: true
+    optional: false
+    clone_uri: "ssh://git@github.com/kubermatic/kubermatic.git"
+    branches:
+      - weekly
+    labels:
+      preset-aws: "true"
+      preset-vault: "true"
+      preset-docker-pull: "true"
+      preset-docker-push: "true"
+      preset-repo-ssh: "true"
+      preset-kubeconfig-ci: "true"
+      preset-kind-volume-mounts: "true"
+    spec:
+      containers:
+      - image: quay.io/kubermatic/e2e-kind:with-conformance-tests-v1.0.15
+        env:
+        - name: VERSIONS_TO_TEST
+          value: "v1.15.6"
+        - name: UPGRADE_TEST_BASE_HASH
+          value: weekly
+        - name: SERVICE_ACCOUNT_KEY
+          valueFrom:
+            secretKeyRef:
+              name: e2e-ci
+              key: serviceAccountSigningKey
+        command:
+        - ./api/hack/run-kubermatic-kind-upgrade-test.sh
+        # docker-in-docker needs privileged mode
+        securityContext:
+          privileged: true
+        resources:
+          requests:
+            memory: 4Gi
+            cpu: 3.5
+          limits:
+            memory: 4Gi
+
+  - name: pre-kubermatic-api-e2e
+    run_if_changed: "^api/"
+    decorate: true
+    clone_uri: "ssh://git@github.com/kubermatic/kubermatic.git"
+    skip_branches:
+    - release/v2.11
+    # This test has been superseded in v2.13. By the time v2.15 is out, v2.12 will be EOL and the test can be removed entirely.
+    - release/v2.13
+    - release/v2.14
+    - release/v2.15
+    - master
+    - weekly
+    labels:
+      preset-digitalocean: "true"
+      preset-openstack: "true"
+      preset-azure: "true"
+      preset-kubeconfig-ci: "true"
+      preset-docker-pull: "true"
+      preset-gce: "true"
+    spec:
+      # DNS configuration allows inner cluster to access the internet.
+      dnsPolicy: "None"
+      dnsConfig:
+        nameservers:
+          - 1.1.1.1 # Cloudflare DNS servers
+          - 1.0.0.1
+      containers:
+        - image: quay.io/kubermatic/e2e-kind:v1.0.15
+          imagePullPolicy: Always
+          command:
+            - "./api/hack/ci/ci_run_api_e2e.sh"
+          volumeMounts:
+            - name: modules
+              mountPath: /lib/modules
+            - name: cgroup
+              mountPath: /sys/fs/cgroup
+          securityContext:
+            privileged: true
+          resources:
+            requests:
+              memory: 4Gi
+              cpu: 2
+            limits:
+              memory: 6Gi
+              cpu: 3.5
+          env:
+            - name: SERVICE_ACCOUNT_KEY
+              valueFrom:
+                secretKeyRef:
+                  name: e2e-ci
+                  key: serviceAccountSigningKey
+      # Those volumes are required by inner docker instance to properly start the k8s cluster inside the pod.
+      volumes:
+        - name: modules
+          hostPath:
+            path: /lib/modules
+            type: Directory
+        - name: cgroup
+          hostPath:
+            path: /sys/fs/cgroup
+            type: Directory
+
+  - name: pre-kubermatic-build
+    run_if_changed: "^api/"
+    decorate: true
+    clone_uri: "ssh://git@github.com/kubermatic/kubermatic.git"
+    skip_branches:
+    - master
+    - weekly
+    spec:
+      containers:
+      - image: golang:1.12.12
+        command:
+        - make
+        args:
+        - -C
+        - api
+        - build
+        resources:
+          requests:
+            memory: 2Gi
+            cpu: 2
+          limits:
+            memory: 4Gi
+
+  - name: pre-kubermatic-test
+    run_if_changed: "^api/"
+    decorate: true
+    clone_uri: "ssh://git@github.com/kubermatic/kubermatic.git"
+    skip_branches:
+    - master
+    - weekly
+    spec:
+      containers:
+      - image: golang:1.12.12
+        command:
+        - make
+        args:
+        - -C
+        - api
+        - test
+        resources:
+          requests:
+            memory: 7Gi
+            cpu: 2
+
+  - name: pre-kubermatic-verify
+    run_if_changed: "^api/"
+    decorate: true
+    clone_uri: "ssh://git@github.com/kubermatic/kubermatic.git"
+    skip_branches:
+    - master
+    - weekly
+    spec:
+      containers:
+      - image: golang:1.12.12
+        command:
+        - make
+        args:
+        - -C
+        - api
+        - verify
+        resources:
+          requests:
+            memory: 1.5Gi
+            cpu: 500m
+          limits:
+            memory: 2.5Gi
+            cpu: 1
+
+  - name: pre-kubermatic-verify-charts
+    run_if_changed: "^config/"
+    decorate: true
+    clone_uri: "ssh://git@github.com/kubermatic/kubermatic.git"
+    skip_branches:
+    - master
+    - weekly
+    spec:
+      containers:
+      - image: quay.io/kubermatic/util:1.3.0
+        command:
+        - "./api/hack/verify-chart-versions.sh"
+        resources:
+          requests:
+            memory: 128Mi
+            cpu: 50m
+          limits:
+            memory: 256Mi
+            cpu: 250m
+
+  - name: pre-kubermatic-verify-grafana-dashboards
+    run_if_changed: "^config/monitoring/grafana/"
+    decorate: true
+    clone_uri: "ssh://git@github.com/kubermatic/kubermatic.git"
+    skip_branches:
+    - master
+    - weekly
+    spec:
+      containers:
+      - image: quay.io/kubermatic/util:1.3.0
+        command:
+        - "./api/hack/verify-grafana-dashboards.sh"
+        resources:
+          requests:
+            memory: 64Mi
+            cpu: 50m
+          limits:
+            memory: 128Mi
+            cpu: 250m
+
+  - name: pre-kubermatic-verify-yaml-examples
+    run_if_changed: "^(api|docs)/"
+    decorate: true
+    clone_uri: "ssh://git@github.com/kubermatic/kubermatic.git"
+    skip_branches:
+    - master
+    - weekly
+    spec:
+      containers:
+      - image: quay.io/kubermatic/go-docker:12.9-1806-0
+        command:
+        - "./api/hack/verify-yaml-examples.sh"
+        resources:
+          requests:
+            memory: 128Mi
+            cpu: 250m
+
+  - name: pre-kubermatic-lint
+    run_if_changed: "^api/"
+    decorate: true
+    clone_uri: "ssh://git@github.com/kubermatic/kubermatic.git"
+    skip_branches:
+    - master
+    - weekly
+    spec:
+      containers:
+      - image: golangci/golangci-lint:v1.17.1
+        command:
+        - make
+        args:
+        - -C
+        - api
+        - lint
+        resources:
+          requests:
+            memory: 17Gi
+            cpu: 3
+          limits:
+            memory: 17Gi
+
+  - name: pre-kubermatic-dependencies
+    run_if_changed: "^api/"
+    decorate: true
+    clone_uri: "ssh://git@github.com/kubermatic/kubermatic.git"
+    skip_branches:
+    - master
+    - weekly
+    spec:
+      containers:
+      - image: quay.io/kubermatic/dep:0.5.4-2
+        command:
+        - make
+        args:
+        - -C
+        - api
+        - check-dependencies
+        resources:
+          requests:
+            memory: 256Mi
+            cpu: 250m
+          limits:
+            memory: 256Mi
+            cpu: 250m
+
+  - name: pre-kubermatic-shellcheck
+    optional: true
+    decorate: true
+    clone_uri: "ssh://git@github.com/kubermatic/kubermatic.git"
+    skip_branches:
+    - master
+    - weekly
+    spec:
+      containers:
+      - image: koalaman/shellcheck-alpine:v0.7.0
+        command:
+        - sh
+        args:
+        - -c
+        - shellcheck --shell=bash $(find . -name '*.sh')
+        resources:
+          requests:
+            memory: 1Gi
+            cpu: 0.5
+
+  - name: pre-kubermatic-license-validation
+    run_if_changed: "vendor"
+    decorate: true
+    clone_uri: "ssh://git@github.com/kubermatic/kubermatic.git"
+    skip_branches:
+    - master
+    - weekly
+    spec:
+      containers:
+      - image: quay.io/kubermatic/wwhrd:0.2.1-1
+        command:
+        - make
+        args:
+        - -C
+        - api
+        - license-validation
+
+  - name: pre-kubermatic-prometheus-rules-validation
+    run_if_changed: "config/monitoring"
+    decorate: true
+    clone_uri: "ssh://git@github.com/kubermatic/kubermatic.git"
+    skip_branches:
+    - master
+    - weekly
+    spec:
+      containers:
+      - image: quay.io/kubermatic/promtool:2.7.0-3
+        command:
+        - make
+        args:
+        - -C
+        - config/monitoring
+        - check-rules
+      imagePullSecrets:
+      - name: quay
+
+  - name: pre-kubermatic-user-cluster-prometheus-config-validation
+    run_if_changed: "api/pkg/resources/prometheus"
+    decorate: true
+    clone_uri: "ssh://git@github.com/kubermatic/kubermatic.git"
+    skip_branches:
+    - master
+    - weekly
+    spec:
+      containers:
+      - image: quay.io/kubermatic/promtool:2.7.0-3
+        command:
+        - "./api/hack/verify-user-cluster-prometheus-configs.sh"
+      imagePullSecrets:
+      - name: quay
+
+  - name: pre-kubermatic-e2e-gcp-coreos-1.15
+    decorate: true
+    always_run: false
+    optional: true
+    clone_uri: "ssh://git@github.com/kubermatic/kubermatic.git"
+    skip_branches:
+    - release/v2.9
+    - master
+    - weekly
+    labels:
+      preset-gce: "true"
+      preset-vault: "true"
+      preset-docker-push: "true"
+      preset-repo-ssh: "true"
+    spec:
+      containers:
+      - image: docker.io/kubermatic/kubernetes-test-binaries:v0.10.8
+        env:
+        - name: VERSIONS_TO_TEST
+          value: "v1.15.5"
+        - name: PROVIDER
+          value: "gcp"
+        command:
+        - "./api/hack/ci-run-minimal-conformance-tests.sh"
+        # docker-in-docker needs privileged mode
+        securityContext:
+          privileged: true
+        resources:
+          requests:
+            memory: 2.5Gi
+            cpu: 500m
+          limits:
+            memory: 4Gi
+            cpu: 2
+
+  - name: pre-kubermatic-e2e-aws-coreos-1.15
+    decorate: true
+    run_if_changed: "(api/|config/kubermatic)"
+    clone_uri: "ssh://git@github.com/kubermatic/kubermatic.git"
+    skip_branches:
+    - release/v2.9
+    - release/v2.10
+    # This test has been superseded in v2.13. By the time v2.15 is out, v2.12 will be EOL and the test can be removed entirely.
+    - release/v2.13
+    - release/v2.14
+    - release/v2.15
+    - master
+    - weekly
+    labels:
+      preset-aws: "true"
+      preset-vault: "true"
+      preset-docker-push: "true"
+      preset-repo-ssh: "true"
+    spec:
+      containers:
+      - image: docker.io/kubermatic/kubernetes-test-binaries:v0.10.8
+        env:
+        - name: VERSIONS_TO_TEST
+          value: "v1.15.5"
+        command:
+        - "./api/hack/ci-run-minimal-conformance-tests.sh"
+        # docker-in-docker needs privileged mode
+        securityContext:
+          privileged: true
+        resources:
+          requests:
+            memory: 2.5Gi
+            cpu: 500m
+          limits:
+            memory: 4Gi
+            cpu: 2
+
+  - name: pre-kubermatic-e2e-gcp-offline
+    decorate: true
+    clone_uri: "ssh://git@github.com/kubermatic/kubermatic.git"
+    skip_branches:
+    - master
+    - weekly
+    labels:
+      preset-gce: "true"
+      preset-vault: "true"
+      preset-docker-push: "true"
+      preset-repo-ssh: "true"
+    spec:
+      containers:
+      - image: quay.io/kubermatic/go-docker:12.9-1806-0
+        command:
+          - "./api/hack/ci/ci-run-offline-test.sh"
+        # docker-in-docker needs privileged mode
+        securityContext:
+          privileged: true
+        resources:
+          requests:
+            memory: 2.5Gi
+            cpu: 500m
+          limits:
+            memory: 4Gi
+            cpu: 2
+
+  - name: pre-kubermatic-e2e-azure-coreos-1.16
+    decorate: true
+    optional: true
+    clone_uri: "ssh://git@github.com/kubermatic/kubermatic.git"
+    skip_branches:
+    - master
+    - weekly
+    labels:
+      preset-azure: "true"
+      preset-vault: "true"
+      preset-docker-push: "true"
+      preset-repo-ssh: "true"
+    spec:
+      containers:
+      - image: docker.io/kubermatic/kubernetes-test-binaries:v0.10.8
+        env:
+        - name: VERSIONS_TO_TEST
+          value: "v1.16.6"
+        - name: PROVIDER
+          value: "azure"
+        - name: DEFAULT_TIMEOUT_MINUTES
+          value: "20"
+        command:
+        - "./api/hack/ci-run-minimal-conformance-tests.sh"
+        # docker-in-docker needs privileged mode
+        securityContext:
+          privileged: true
+        resources:
+          requests:
+            memory: 2.5Gi
+            cpu: 500m
+          limits:
+            memory: 4Gi
+            cpu: 2
+
+  - name: pre-kubermatic-e2e-azure-coreos-1.15
+    decorate: true
+    optional: true
+    clone_uri: "ssh://git@github.com/kubermatic/kubermatic.git"
+    skip_branches:
+    - master
+    - weekly
+    labels:
+      preset-azure: "true"
+      preset-vault: "true"
+      preset-docker-push: "true"
+      preset-repo-ssh: "true"
+    spec:
+      containers:
+      - image: docker.io/kubermatic/kubernetes-test-binaries:v0.10.8
+        env:
+        - name: VERSIONS_TO_TEST
+          value: "v1.15.5"
+        - name: PROVIDER
+          value: "azure"
+        - name: DEFAULT_TIMEOUT_MINUTES
+          value: "20"
+        command:
+        - "./api/hack/ci-run-minimal-conformance-tests.sh"
+        # docker-in-docker needs privileged mode
+        securityContext:
+          privileged: true
+        resources:
+          requests:
+            memory: 2.5Gi
+            cpu: 500m
+          limits:
+            memory: 4Gi
+            cpu: 2
+
+  - name: pre-kubermatic-e2e-packet-coreos-1.15
+    decorate: true
+    optional: true
+    clone_uri: "ssh://git@github.com/kubermatic/kubermatic.git"
+    skip_branches:
+    - master
+    - weekly
+    labels:
+      preset-packet: "true"
+      preset-vault: "true"
+      preset-docker-push: "true"
+      preset-repo-ssh: "true"
+    spec:
+      containers:
+      - image: kubermatic/kubernetes-test-binaries:v0.10.8
+        env:
+        - name: VERSIONS_TO_TEST
+          value: "v1.15.5"
+        - name: PROVIDER
+          value: "packet"
+        command:
+        - "./api/hack/ci-run-minimal-conformance-tests.sh"
+        # docker-in-docker needs privileged mode
+        securityContext:
+          privileged: true
+        resources:
+          requests:
+            memory: 2Gi
+            cpu: 500m
+          limits:
+            memory: 4Gi
+            cpu: 2
+
+  - name: pre-kubermatic-e2e-kubevirt-centos-1.15
+    decorate: true
+    optional: true
+    clone_uri: "ssh://git@github.com/kubermatic/kubermatic.git"
+    skip_branches:
+    - master
+    - weekly
+    labels:
+      preset-kubevirt: "true"
+      preset-vault: "true"
+      preset-docker-push: "true"
+      preset-repo-ssh: "true"
+    spec:
+      containers:
+        - image: kubermatic/kubernetes-test-binaries:v0.10.8
+          env:
+            - name: VERSIONS_TO_TEST
+              value: "v1.15.5"
+            - name: PROVIDER
+              value: "kubevirt"
+            - name: EXCLUDE_DISTRIBUTIONS
+              value: "ubuntu,coreos"
+          command:
+            - "./api/hack/ci-run-minimal-conformance-tests.sh"
+          # docker-in-docker needs privileged mode
+          securityContext:
+            privileged: true
+          resources:
+            requests:
+              memory: 2Gi
+              cpu: 500m
+            limits:
+              memory: 4Gi
+              cpu: 2
+
+  - name: pre-kubermatic-e2e-hetzner-ubuntu-1.15
+    decorate: true
+    optional: true
+    clone_uri: "ssh://git@github.com/kubermatic/kubermatic.git"
+    skip_branches:
+    - master
+    - weekly
+    labels:
+      preset-hetzner: "true"
+      preset-vault: "true"
+      preset-docker-push: "true"
+      preset-repo-ssh: "true"
+    spec:
+      containers:
+      - image: kubermatic/kubernetes-test-binaries:v0.10.8
+        env:
+        - name: VERSIONS_TO_TEST
+          value: "v1.15.5"
+        - name: PROVIDER
+          value: "hetzner"
+        # Hetzner doesn't support coreos
+        - name: EXCLUDE_DISTRIBUTIONS
+          value: "centos,coreos"
+        - name: DEFAULT_TIMEOUT_MINUTES
+          value: "20"
+        command:
+        - "./api/hack/ci-run-minimal-conformance-tests.sh"
+        # docker-in-docker needs privileged mode
+        securityContext:
+          privileged: true
+        resources:
+          requests:
+            memory: 2Gi
+            cpu: 500m
+          limits:
+            memory: 4Gi
+            cpu: 2
+
+  - name: pre-kubermatic-e2e-openstack-coreos-1.15
+    decorate: true
+    optional: true
+    clone_uri: "ssh://git@github.com/kubermatic/kubermatic.git"
+    skip_branches:
+    - master
+    - weekly
+    labels:
+      preset-openstack: "true"
+      preset-vault: "true"
+      preset-docker-push: "true"
+      preset-repo-ssh: "true"
+    spec:
+      containers:
+      - image: kubermatic/kubernetes-test-binaries:v0.10.8
+        env:
+        - name: VERSIONS_TO_TEST
+          value: "v1.15.5"
+        - name: PROVIDER
+          value: "openstack"
+        - name: DEFAULT_TIMEOUT_MINUTES
+          value: "20"
+        command:
+        - "./api/hack/ci-run-minimal-conformance-tests.sh"
+        # docker-in-docker needs privileged mode
+        securityContext:
+          privileged: true
+        resources:
+          requests:
+            memory: 2Gi
+            cpu: 500m
+          limits:
+            memory: 4Gi
+            cpu: 2
+
+  - name: pre-kubermatic-e2e-openstack-centos-1.16
+    decorate: true
+    optional: true
+    clone_uri: "ssh://git@github.com/kubermatic/kubermatic.git"
+    skip_branches:
+    - master
+    - weekly
+    labels:
+      preset-openstack: "true"
+      preset-vault: "true"
+      preset-docker-push: "true"
+      preset-repo-ssh: "true"
+    spec:
+      containers:
+      - image: kubermatic/kubernetes-test-binaries:v0.10.8
+        env:
+        - name: VERSIONS_TO_TEST
+          value: "v1.16.3"
+        - name: PROVIDER
+          value: "openstack"
+        - name: DEFAULT_TIMEOUT_MINUTES
+          value: "20"
+        - name: EXCLUDE_DISTRIBUTIONS
+          value: "coreos,ubuntu"
+        command:
+        - "./api/hack/ci-run-minimal-conformance-tests.sh"
+        # docker-in-docker needs privileged mode
+        securityContext:
+          privileged: true
+        resources:
+          requests:
+            memory: 2Gi
+            cpu: 500m
+          limits:
+            memory: 4Gi
+            cpu: 2
+
+  - name: pre-kubermatic-e2e-openstack-ubuntu-1.16
+    decorate: true
+    optional: true
+    clone_uri: "ssh://git@github.com/kubermatic/kubermatic.git"
+    skip_branches:
+    - master
+    - weekly
+    labels:
+      preset-openstack: "true"
+      preset-vault: "true"
+      preset-docker-push: "true"
+      preset-repo-ssh: "true"
+    spec:
+      containers:
+      - image: kubermatic/kubernetes-test-binaries:v0.10.8
+        env:
+        - name: VERSIONS_TO_TEST
+          value: "v1.16.3"
+        - name: PROVIDER
+          value: "openstack"
+        - name: DEFAULT_TIMEOUT_MINUTES
+          value: "20"
+        - name: EXCLUDE_DISTRIBUTIONS
+          value: "coreos,centos"
+        command:
+        - "./api/hack/ci-run-minimal-conformance-tests.sh"
+        # docker-in-docker needs privileged mode
+        securityContext:
+          privileged: true
+        resources:
+          requests:
+            memory: 2Gi
+            cpu: 500m
+          limits:
+            memory: 4Gi
+            cpu: 2
+
+  - name: pre-kubermatic-e2e-openstack-coreos-1.16
+    decorate: true
+    optional: true
+    clone_uri: "ssh://git@github.com/kubermatic/kubermatic.git"
+    skip_branches:
+    - master
+    - weekly
+    labels:
+      preset-openstack: "true"
+      preset-vault: "true"
+      preset-docker-push: "true"
+      preset-repo-ssh: "true"
+    spec:
+      containers:
+      - image: kubermatic/kubernetes-test-binaries:v0.10.8
+        env:
+        - name: VERSIONS_TO_TEST
+          value: "v1.16.3"
+        - name: PROVIDER
+          value: "openstack"
+        - name: DEFAULT_TIMEOUT_MINUTES
+          value: "20"
+        command:
+        - "./api/hack/ci-run-minimal-conformance-tests.sh"
+        # docker-in-docker needs privileged mode
+        securityContext:
+          privileged: true
+        resources:
+          requests:
+            memory: 2Gi
+            cpu: 500m
+          limits:
+            memory: 4Gi
+            cpu: 2
+
+  - name: pre-kubermatic-e2e-vsphere-coreos-1.15
+    decorate: true
+    run_if_changed: "api/pkg/provider/cloud/vsphere"
+    clone_uri: "ssh://git@github.com/kubermatic/kubermatic.git"
+    skip_branches:
+    - master
+    - weekly
+    labels:
+      preset-vsphere: "true"
+      preset-vault: "true"
+      preset-docker-push: "true"
+      preset-repo-ssh: "true"
+    spec:
+      containers:
+      - image: kubermatic/kubernetes-test-binaries:v0.10.8
+        env:
+        - name: VERSIONS_TO_TEST
+          value: "v1.15.5"
+        - name: PROVIDER
+          value: "vsphere"
+        command:
+        - "./api/hack/ci-run-minimal-conformance-tests.sh"
+        # docker-in-docker needs privileged mode
+        securityContext:
+          privileged: true
+        resources:
+          requests:
+            memory: 2Gi
+            cpu: 500m
+          limits:
+            memory: 4Gi
+            cpu: 2
+
+  - name: pre-kubermatic-e2e-vsphere-coreos-1.15-customfolder
+    decorate: true
+    optional: true
+    run_if_changed: "api/pkg/provider/cloud/vsphere"
+    clone_uri: "ssh://git@github.com/kubermatic/kubermatic.git"
+    skip_branches:
+    - master
+    - weekly
+    labels:
+      preset-vsphere: "true"
+      preset-vault: "true"
+      preset-docker-push: "true"
+      preset-repo-ssh: "true"
+    spec:
+      containers:
+      - image: kubermatic/kubernetes-test-binaries:v0.10.8
+        env:
+        - name: VERSIONS_TO_TEST
+          value: "v1.15.5"
+        - name: PROVIDER
+          value: "vsphere"
+        - name: SCENARIO_OPTIONS
+          value: "custom-folder"
+        command:
+        - "./api/hack/ci-run-minimal-conformance-tests.sh"
+        # docker-in-docker needs privileged mode
+        securityContext:
+          privileged: true
+        resources:
+          requests:
+            memory: 2Gi
+            cpu: 500m
+          limits:
+            memory: 4Gi
+            cpu: 2


### PR DESCRIPTION
**What this PR does / why we need it**:
This creates a copy of our presubmits from the infra repo, because we want to get rid of the centrally managed presubmits.

I removed the following jobs from the .prow.yaml:

* `pull-kubermatic-e2e-upgrade-2.11-2.12`
* `pull-kubermatic-api-e2e-2.11`

I also had to rename all jobs and change their prefix from `pull-` to `pre-`, so that there are no naming conflicts with the presubmits from the infra repo.

**Does this PR introduce a user-facing change?**:
```release-note
NONE
```
