### PR TITLE
set options for the GetProject method

### DIFF
--- a/api/pkg/handler/v1/common/common.go
+++ b/api/pkg/handler/v1/common/common.go
@@ -256,7 +256,7 @@ func GetOwnersForProject(userInfo *provider.UserInfo, project *kubermaticv1.Proj
 	return projectOwners, nil
 }
 
-func GetProject(ctx context.Context, userInfoGetter provider.UserInfoGetter, projectProvider provider.ProjectProvider, privilegedProjectProvider provider.PrivilegedProjectProvider, projectID string) (*kubermaticv1.Project, error) {
+func GetProject(ctx context.Context, userInfoGetter provider.UserInfoGetter, projectProvider provider.ProjectProvider, privilegedProjectProvider provider.PrivilegedProjectProvider, projectID string, options *provider.ProjectGetOptions) (*kubermaticv1.Project, error) {
 	adminUserInfo, err := userInfoGetter(ctx, "")
 	if err != nil {
 		return nil, err
@@ -264,14 +264,14 @@ func GetProject(ctx context.Context, userInfoGetter provider.UserInfoGetter, pro
 
 	if adminUserInfo.IsAdmin {
 		// get any project for admin
-		return privilegedProjectProvider.GetUnsecured(projectID, &provider.ProjectGetOptions{IncludeUninitialized: true})
+		return privilegedProjectProvider.GetUnsecured(projectID, options)
 	}
 
 	userInfo, err := userInfoGetter(ctx, projectID)
 	if err != nil {
 		return nil, err
 	}
-	return projectProvider.Get(userInfo, projectID, &provider.ProjectGetOptions{IncludeUninitialized: true})
+	return projectProvider.Get(userInfo, projectID, options)
 }
 
 func GetClusterClient(ctx context.Context, userInfoGetter provider.UserInfoGetter, clusterProvider provider.ClusterProvider, cluster *kubermaticv1.Cluster, projectID string) (ctrlruntimeclient.Client, error) {

--- a/api/pkg/handler/v1/node/node.go
+++ b/api/pkg/handler/v1/node/node.go
@@ -78,7 +78,7 @@ func CreateNodeDeployment(sshKeyProvider provider.SSHKeyProvider, projectProvide
 		req := request.(createNodeDeploymentReq)
 		clusterProvider := ctx.Value(middleware.ClusterProviderContextKey).(provider.ClusterProvider)
 
-		project, err := common.GetProject(ctx, userInfoGetter, projectProvider, privilegedProjectProvider, req.ProjectID)
+		project, err := common.GetProject(ctx, userInfoGetter, projectProvider, privilegedProjectProvider, req.ProjectID, nil)
 		if err != nil {
 			return nil, common.KubernetesErrorToHTTPError(err)
 		}
@@ -622,7 +622,7 @@ func PatchNodeDeployment(sshKeyProvider provider.SSHKeyProvider, projectProvider
 			return nil, common.KubernetesErrorToHTTPError(err)
 		}
 
-		project, err := common.GetProject(ctx, userInfoGetter, projectProvider, privilegedProjectProvider, req.ProjectID)
+		project, err := common.GetProject(ctx, userInfoGetter, projectProvider, privilegedProjectProvider, req.ProjectID, nil)
 		if err != nil {
 			return nil, common.KubernetesErrorToHTTPError(err)
 		}

--- a/api/pkg/handler/v1/project/project.go
+++ b/api/pkg/handler/v1/project/project.go
@@ -194,7 +194,7 @@ func UpdateEndpoint(projectProvider provider.ProjectProvider, privilegedProjectP
 			return nil, errors.NewBadRequest(err.Error())
 		}
 
-		kubermaticProject, err := common.GetProject(ctx, userInfoGetter, projectProvider, privilegedProjectProvider, req.ProjectID)
+		kubermaticProject, err := common.GetProject(ctx, userInfoGetter, projectProvider, privilegedProjectProvider, req.ProjectID, nil)
 		if err != nil {
 			return nil, common.KubernetesErrorToHTTPError(err)
 		}
@@ -255,7 +255,7 @@ func GetEndpoint(projectProvider provider.ProjectProvider, privilegedProjectProv
 			return nil, common.KubernetesErrorToHTTPError(err)
 		}
 
-		kubermaticProject, err := common.GetProject(ctx, userInfoGetter, projectProvider, privilegedProjectProvider, req.ProjectID)
+		kubermaticProject, err := common.GetProject(ctx, userInfoGetter, projectProvider, privilegedProjectProvider, req.ProjectID, nil)
 		if err != nil {
 			return nil, common.KubernetesErrorToHTTPError(err)
 		}

--- a/api/pkg/handler/v1/serviceaccount/sa.go
+++ b/api/pkg/handler/v1/serviceaccount/sa.go
@@ -33,7 +33,7 @@ func CreateEndpoint(projectProvider provider.ProjectProvider, privilegedProjectP
 			return nil, errors.NewBadRequest(err.Error())
 		}
 		saFromRequest := req.Body
-		project, err := common.GetProject(ctx, userInfoGetter, projectProvider, privilegedProjectProvider, req.ProjectID)
+		project, err := common.GetProject(ctx, userInfoGetter, projectProvider, privilegedProjectProvider, req.ProjectID, nil)
 		if err != nil {
 			return nil, common.KubernetesErrorToHTTPError(err)
 		}
@@ -109,7 +109,7 @@ func ListEndpoint(projectProvider provider.ProjectProvider, privilegedProjectPro
 			return nil, errors.NewBadRequest("the name of the project cannot be empty")
 		}
 
-		project, err := common.GetProject(ctx, userInfoGetter, projectProvider, privilegedProjectProvider, req.ProjectID)
+		project, err := common.GetProject(ctx, userInfoGetter, projectProvider, privilegedProjectProvider, req.ProjectID, nil)
 		if err != nil {
 			return nil, common.KubernetesErrorToHTTPError(err)
 		}
@@ -156,7 +156,7 @@ func UpdateEndpoint(projectProvider provider.ProjectProvider, privilegedProjectP
 		}
 		saFromRequest := req.Body
 
-		project, err := common.GetProject(ctx, userInfoGetter, projectProvider, privilegedProjectProvider, req.ProjectID)
+		project, err := common.GetProject(ctx, userInfoGetter, projectProvider, privilegedProjectProvider, req.ProjectID, nil)
 		if err != nil {
 			return nil, common.KubernetesErrorToHTTPError(err)
 		}
@@ -249,7 +249,7 @@ func DeleteEndpoint(serviceAccountProvider provider.ServiceAccountProvider, priv
 		}
 
 		// check if project exist
-		project, err := common.GetProject(ctx, userInfoGetter, projectProvider, privilegedProjectProvider, req.ProjectID)
+		project, err := common.GetProject(ctx, userInfoGetter, projectProvider, privilegedProjectProvider, req.ProjectID, nil)
 		if err != nil {
 			return nil, common.KubernetesErrorToHTTPError(err)
 		}

--- a/api/pkg/handler/v1/serviceaccount/token.go
+++ b/api/pkg/handler/v1/serviceaccount/token.go
@@ -32,7 +32,7 @@ func CreateTokenEndpoint(projectProvider provider.ProjectProvider, privilegedPro
 		if err != nil {
 			return nil, errors.NewBadRequest(err.Error())
 		}
-		project, err := common.GetProject(ctx, userInfoGetter, projectProvider, privilegedProjectProvider, req.ProjectID)
+		project, err := common.GetProject(ctx, userInfoGetter, projectProvider, privilegedProjectProvider, req.ProjectID, nil)
 		if err != nil {
 			return nil, common.KubernetesErrorToHTTPError(err)
 		}
@@ -129,7 +129,7 @@ func ListTokenEndpoint(projectProvider provider.ProjectProvider, privilegedProje
 			return nil, errors.NewBadRequest(err.Error())
 		}
 
-		project, err := common.GetProject(ctx, userInfoGetter, projectProvider, privilegedProjectProvider, req.ProjectID)
+		project, err := common.GetProject(ctx, userInfoGetter, projectProvider, privilegedProjectProvider, req.ProjectID, nil)
 		if err != nil {
 			return nil, common.KubernetesErrorToHTTPError(err)
 		}
@@ -226,7 +226,7 @@ func DeleteTokenEndpoint(projectProvider provider.ProjectProvider, privilegedPro
 			return nil, errors.NewBadRequest(err.Error())
 		}
 
-		project, err := common.GetProject(ctx, userInfoGetter, projectProvider, privilegedProjectProvider, req.ProjectID)
+		project, err := common.GetProject(ctx, userInfoGetter, projectProvider, privilegedProjectProvider, req.ProjectID, nil)
 		if err != nil {
 			return nil, common.KubernetesErrorToHTTPError(err)
 		}
@@ -279,7 +279,7 @@ func updateEndpoint(ctx context.Context, projectProvider provider.ProjectProvide
 	privilegedServiceAccount provider.PrivilegedServiceAccountProvider, serviceAccountTokenProvider provider.ServiceAccountTokenProvider, privilegedServiceAccountTokenProvider provider.PrivilegedServiceAccountTokenProvider, userInfoGetter provider.UserInfoGetter, tokenGenerator serviceaccount.TokenGenerator,
 	projectID, saID, tokenID, newName string, regenerateToken bool) (*v1.Secret, error) {
 
-	project, err := common.GetProject(ctx, userInfoGetter, projectProvider, privilegedProjectProvider, projectID)
+	project, err := common.GetProject(ctx, userInfoGetter, projectProvider, privilegedProjectProvider, projectID, nil)
 	if err != nil {
 		return nil, err
 	}

--- a/api/pkg/handler/v1/ssh/ssh.go
+++ b/api/pkg/handler/v1/ssh/ssh.go
@@ -23,7 +23,7 @@ func CreateEndpoint(keyProvider provider.SSHKeyProvider, privilegedSSHKeyProvide
 			return nil, errors.NewBadRequest("invalid request")
 		}
 
-		project, err := common.GetProject(ctx, userInfoGetter, projectProvider, privilegedProjectProvider, req.ProjectID)
+		project, err := common.GetProject(ctx, userInfoGetter, projectProvider, privilegedProjectProvider, req.ProjectID, nil)
 		if err != nil {
 			return nil, common.KubernetesErrorToHTTPError(err)
 		}
@@ -77,7 +77,7 @@ func DeleteEndpoint(keyProvider provider.SSHKeyProvider, privilegedSSHKeyProvide
 		if !ok {
 			return nil, errors.NewBadRequest("invalid request")
 		}
-		project, err := common.GetProject(ctx, userInfoGetter, projectProvider, privilegedProjectProvider, req.ProjectID)
+		project, err := common.GetProject(ctx, userInfoGetter, projectProvider, privilegedProjectProvider, req.ProjectID, nil)
 		if err != nil {
 			return nil, common.KubernetesErrorToHTTPError(err)
 		}
@@ -114,7 +114,7 @@ func ListEndpoint(keyProvider provider.SSHKeyProvider, projectProvider provider.
 			return nil, errors.NewBadRequest("the name of the project to delete cannot be empty")
 		}
 
-		project, err := common.GetProject(ctx, userInfoGetter, projectProvider, privilegedProjectProvider, req.ProjectID)
+		project, err := common.GetProject(ctx, userInfoGetter, projectProvider, privilegedProjectProvider, req.ProjectID, nil)
 		if err != nil {
 			return nil, common.KubernetesErrorToHTTPError(err)
 		}

--- a/api/pkg/handler/v1/user/user.go
+++ b/api/pkg/handler/v1/user/user.go
@@ -35,7 +35,7 @@ func DeleteEndpoint(projectProvider provider.ProjectProvider, privilegedProjectP
 			return nil, k8cerrors.NewBadRequest("the user ID cannot be empty")
 		}
 
-		project, err := common.GetProject(ctx, userInfoGetter, projectProvider, privilegedProjectProvider, req.ProjectID)
+		project, err := common.GetProject(ctx, userInfoGetter, projectProvider, privilegedProjectProvider, req.ProjectID, nil)
 		if err != nil {
 			return nil, common.KubernetesErrorToHTTPError(err)
 		}
@@ -131,7 +131,7 @@ func EditEndpoint(projectProvider provider.ProjectProvider, privilegedProjectPro
 		currentMemberFromRequest := req.Body
 		projectFromRequest := currentMemberFromRequest.Projects[0]
 
-		project, err := common.GetProject(ctx, userInfoGetter, projectProvider, privilegedProjectProvider, req.ProjectID)
+		project, err := common.GetProject(ctx, userInfoGetter, projectProvider, privilegedProjectProvider, req.ProjectID, nil)
 		if err != nil {
 			return nil, common.KubernetesErrorToHTTPError(err)
 		}
@@ -194,7 +194,7 @@ func ListEndpoint(projectProvider provider.ProjectProvider, privilegedProjectPro
 			return nil, k8cerrors.NewBadRequest("the name of the project cannot be empty")
 		}
 
-		project, err := common.GetProject(ctx, userInfoGetter, projectProvider, privilegedProjectProvider, req.ProjectID)
+		project, err := common.GetProject(ctx, userInfoGetter, projectProvider, privilegedProjectProvider, req.ProjectID, nil)
 		if err != nil {
 			return nil, common.KubernetesErrorToHTTPError(err)
 		}
@@ -240,7 +240,7 @@ func AddEndpoint(projectProvider provider.ProjectProvider, privilegedProjectProv
 		} else if err != nil {
 			return nil, common.KubernetesErrorToHTTPError(err)
 		}
-		project, err := common.GetProject(ctx, userInfoGetter, projectProvider, privilegedProjectProvider, req.ProjectID)
+		project, err := common.GetProject(ctx, userInfoGetter, projectProvider, privilegedProjectProvider, req.ProjectID, nil)
 		if err != nil {
 			return nil, common.KubernetesErrorToHTTPError(err)
 		}

--- a/api/pkg/provider/kubernetes/project.go
+++ b/api/pkg/provider/kubernetes/project.go
@@ -138,6 +138,9 @@ func (p *ProjectProvider) Get(userInfo *provider.UserInfo, projectInternalName s
 	if userInfo == nil {
 		return nil, errors.New("a user is missing but required")
 	}
+	if options == nil {
+		options = &provider.ProjectGetOptions{IncludeUninitialized: true}
+	}
 	masterImpersonatedClient, err := createKubermaticImpersonationClientWrapperFromUserInfo(userInfo, p.createMasterImpersonatedClient)
 	if err != nil {
 		return nil, err
@@ -156,6 +159,9 @@ func (p *ProjectProvider) Get(userInfo *provider.UserInfo, projectInternalName s
 // GetUnsecured returns the project with the given name
 // This function is unsafe in a sense that it uses privileged account to get project with the given name
 func (p *PrivilegedProjectProvider) GetUnsecured(projectInternalName string, options *provider.ProjectGetOptions) (*kubermaticapiv1.Project, error) {
+	if options == nil {
+		options = &provider.ProjectGetOptions{IncludeUninitialized: true}
+	}
 	project, err := p.clientPrivileged.Get(projectInternalName, metav1.GetOptions{})
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
**What this PR does / why we need it**: set options for the GetProject method. Get rid of hardcoded options for this method and allow the user to set it

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

```release-note
NONE
```
