### PR TITLE
Add node-local-dns-cache to user-cluster-controller-manager

### DIFF
--- a/api/pkg/controller/operator/common/defaults.go
+++ b/api/pkg/controller/operator/common/defaults.go
@@ -746,12 +746,6 @@ items:
 - apiVersion: kubermatic.k8s.io/v1
   kind: Addon
   metadata:
-    name: nodelocal-dns-cache
-    labels:
-      addons.kubermatic.io/ensure: true
-- apiVersion: kubermatic.k8s.io/v1
-  kind: Addon
-  metadata:
     name: pod-security-policy
     labels:
       addons.kubermatic.io/ensure: true

--- a/api/pkg/controller/user-cluster-controller-manager/resources/resources/node-local-dns/configmap.go
+++ b/api/pkg/controller/user-cluster-controller-manager/resources/resources/node-local-dns/configmap.go
@@ -10,6 +10,11 @@ import (
 	corev1 "k8s.io/api/core/v1"
 )
 
+const (
+	addonManagerModeKey = "addonmanager.kubernetes.io/mode"
+	reconcilModeValue   = "Reconcile"
+)
+
 // ConfigMapCreator returns a ConfigMap containing the config for Node Local DNS cache
 func ConfigMapCreator(dnsClusterIP string) reconciling.NamedConfigMapCreatorGetter {
 	return func() (string, reconciling.ConfigMapCreator) {
@@ -17,7 +22,7 @@ func ConfigMapCreator(dnsClusterIP string) reconciling.NamedConfigMapCreatorGett
 			if cm.Labels == nil {
 				cm.Labels = map[string]string{}
 			}
-			cm.Labels["addonmanager.kubernetes.io/mode"] = "Reconcile"
+			cm.Labels[addonManagerModeKey] = reconcilModeValue
 
 			t, err := template.New("config").Parse(configTemplate)
 			if err != nil {

--- a/api/pkg/controller/user-cluster-controller-manager/resources/resources/node-local-dns/configmap.go
+++ b/api/pkg/controller/user-cluster-controller-manager/resources/resources/node-local-dns/configmap.go
@@ -12,7 +12,7 @@ import (
 
 const (
 	addonManagerModeKey = "addonmanager.kubernetes.io/mode"
-	reconcilModeValue   = "Reconcile"
+	reconcileModeValue  = "Reconcile"
 )
 
 // ConfigMapCreator returns a ConfigMap containing the config for Node Local DNS cache
@@ -22,7 +22,7 @@ func ConfigMapCreator(dnsClusterIP string) reconciling.NamedConfigMapCreatorGett
 			if cm.Labels == nil {
 				cm.Labels = map[string]string{}
 			}
-			cm.Labels[addonManagerModeKey] = reconcilModeValue
+			cm.Labels[addonManagerModeKey] = reconcileModeValue
 
 			t, err := template.New("config").Parse(configTemplate)
 			if err != nil {

--- a/api/pkg/controller/user-cluster-controller-manager/resources/resources/node-local-dns/configmap.go
+++ b/api/pkg/controller/user-cluster-controller-manager/resources/resources/node-local-dns/configmap.go
@@ -1,0 +1,92 @@
+package nodelocaldns
+
+import (
+	"bytes"
+	"html/template"
+
+	"github.com/kubermatic/kubermatic/api/pkg/resources"
+	"github.com/kubermatic/kubermatic/api/pkg/resources/reconciling"
+
+	corev1 "k8s.io/api/core/v1"
+)
+
+// ConfigMapCreator returns a ConfigMap containing the config for Node Local DNS cache
+func ConfigMapCreator(dnsClusterIP string) reconciling.NamedConfigMapCreatorGetter {
+	return func() (string, reconciling.ConfigMapCreator) {
+		return resources.NodeLocalDNSConfigMapName, func(cm *corev1.ConfigMap) (*corev1.ConfigMap, error) {
+			if cm.Labels == nil {
+				cm.Labels = map[string]string{}
+			}
+			cm.Labels["addonmanager.kubernetes.io/mode"] = "Reconcile"
+
+			t, err := template.New("config").Parse(configTemplate)
+			if err != nil {
+				return nil, err
+			}
+			configBuf := bytes.Buffer{}
+			if err := t.Execute(&configBuf, struct{ DNSClusterIP string }{dnsClusterIP}); err != nil {
+				return nil, err
+			}
+
+			if cm.Data == nil {
+				cm.Data = map[string]string{}
+			}
+
+			cm.Data["Corefile"] = configBuf.String()
+			return cm, nil
+		}
+	}
+}
+
+const (
+	configTemplate = `
+cluster.local:53 {
+    errors
+    cache {
+            success 9984 30
+            denial 9984 5
+    }
+    reload
+    loop
+    bind 169.254.20.10
+    forward . {{ .DNSClusterIP }} {
+            force_tcp
+    }
+    prometheus :9253
+    health 169.254.20.10:8080
+    }
+in-addr.arpa:53 {
+    errors
+    cache 30
+    reload
+    loop
+    bind 169.254.20.10
+    forward . {{ .DNSClusterIP }} {
+            force_tcp
+    }
+    prometheus :9253
+    }
+ip6.arpa:53 {
+    errors
+    cache 30
+    reload
+    loop
+    bind 169.254.20.10
+    forward . {{ .DNSClusterIP }} {
+            force_tcp
+    }
+    prometheus :9253
+    }
+.:53 {
+    errors
+    cache 30
+    reload
+    loop
+    bind 169.254.20.10
+    forward . /etc/resolv.conf {
+            force_tcp
+    }
+    prometheus :9253
+    }
+  `
+)

--- a/api/pkg/controller/user-cluster-controller-manager/resources/resources/node-local-dns/deamonset.go
+++ b/api/pkg/controller/user-cluster-controller-manager/resources/resources/node-local-dns/deamonset.go
@@ -77,16 +77,19 @@ func DaemonSetCreator() reconciling.NamedDaemonSetCreatorGetter {
 					Ports: []corev1.ContainerPort{
 						{
 							ContainerPort: 53,
+							HostPort:      53,
 							Name:          "dns-tcp",
 							Protocol:      corev1.ProtocolTCP,
 						},
 						{
 							ContainerPort: 53,
+							HostPort:      53,
 							Name:          "dns",
 							Protocol:      corev1.ProtocolUDP,
 						},
 						{
 							ContainerPort: 9153,
+							HostPort:      9153,
 							Name:          "metrics",
 							Protocol:      corev1.ProtocolTCP,
 						},
@@ -95,13 +98,17 @@ func DaemonSetCreator() reconciling.NamedDaemonSetCreatorGetter {
 					LivenessProbe: &corev1.Probe{
 						Handler: corev1.Handler{
 							HTTPGet: &corev1.HTTPGetAction{
-								Host: "169.254.20.10",
-								Path: "/health",
-								Port: intstr.FromInt(8080),
+								Host:   "169.254.20.10",
+								Scheme: corev1.URISchemeHTTP,
+								Path:   "/health",
+								Port:   intstr.FromInt(8080),
 							},
 						},
 						InitialDelaySeconds: 60,
 						TimeoutSeconds:      5,
+						PeriodSeconds:       10,
+						SuccessThreshold:    1,
+						FailureThreshold:    3,
 					},
 
 					SecurityContext: &corev1.SecurityContext{

--- a/api/pkg/controller/user-cluster-controller-manager/resources/resources/node-local-dns/deamonset.go
+++ b/api/pkg/controller/user-cluster-controller-manager/resources/resources/node-local-dns/deamonset.go
@@ -28,7 +28,7 @@ func DaemonSetCreator() reconciling.NamedDaemonSetCreatorGetter {
 			if ds.Labels == nil {
 				ds.Labels = labels
 			}
-			ds.Labels["addonmanager.kubernetes.io/mode"] = "Reconcile"
+			ds.Labels[addonManagerModeKey] = reconcilModeValue
 			ds.Labels["kubernetes.io/cluster-service"] = "true"
 
 			if ds.Spec.Selector == nil {

--- a/api/pkg/controller/user-cluster-controller-manager/resources/resources/node-local-dns/deamonset.go
+++ b/api/pkg/controller/user-cluster-controller-manager/resources/resources/node-local-dns/deamonset.go
@@ -1,0 +1,144 @@
+package nodelocaldns
+
+import (
+	"fmt"
+
+	"github.com/kubermatic/kubermatic/api/pkg/resources"
+	"github.com/kubermatic/kubermatic/api/pkg/resources/reconciling"
+
+	appsv1 "k8s.io/api/apps/v1"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/util/intstr"
+	"k8s.io/utils/pointer"
+)
+
+func DaemonSetCreator() reconciling.NamedDaemonSetCreatorGetter {
+	return func() (string, reconciling.DaemonSetCreator) {
+		return resources.NodeLocalDNSDaemonSetName, func(ds *appsv1.DaemonSet) (*appsv1.DaemonSet, error) {
+			sptr := intstr.FromString("10%")
+			ds.Spec.UpdateStrategy = appsv1.DaemonSetUpdateStrategy{
+				Type: appsv1.RollingUpdateDaemonSetStrategyType,
+				RollingUpdate: &appsv1.RollingUpdateDaemonSet{
+					MaxUnavailable: &sptr,
+				},
+			}
+			labels := resources.BaseAppLabels(resources.NodeLocalDNSDaemonSetName,
+				map[string]string{"app.kubernetes.io/name": resources.NodeLocalDNSDaemonSetName})
+			if ds.Labels == nil {
+				ds.Labels = labels
+			}
+			ds.Labels["addonmanager.kubernetes.io/mode"] = "Reconcile"
+			ds.Labels["kubernetes.io/cluster-service"] = "true"
+
+			if ds.Spec.Selector == nil {
+				ds.Spec.Selector = &metav1.LabelSelector{MatchLabels: labels}
+			}
+			if ds.Spec.Template.ObjectMeta.Labels == nil {
+				ds.Spec.Template.ObjectMeta.Labels = labels
+			}
+
+			ds.Spec.Template.Spec.ServiceAccountName = resources.NodeLocalDNSServiceAccountName
+			ds.Spec.Template.Spec.PriorityClassName = "system-cluster-critical"
+			ds.Spec.Template.Spec.HostNetwork = true
+			ds.Spec.Template.Spec.DNSPolicy = corev1.DNSDefault
+			ds.Spec.Template.Spec.TerminationGracePeriodSeconds = pointer.Int64Ptr(0)
+			ds.Spec.Template.Spec.Tolerations = []corev1.Toleration{
+				{
+					Key:      "CriticalAddonsOnly",
+					Operator: corev1.TolerationOpExists,
+				},
+			}
+
+			hostPathType := corev1.HostPathFileOrCreate
+			ds.Spec.Template.Spec.Containers = []corev1.Container{
+				{
+					Name:            "node-cache",
+					ImagePullPolicy: corev1.PullAlways,
+					Image:           fmt.Sprintf("%s/google_containers/k8s-dns-node-cache:1.15.7", resources.RegistryGCR),
+					Args: []string{
+						"-localip",
+						"169.254.20.10",
+						"-conf",
+						"/etc/coredns/Corefile",
+					},
+
+					VolumeMounts: []corev1.VolumeMount{
+						{
+							Name:      "xtables-lock",
+							MountPath: "/run/xtables.lock",
+						},
+						{
+							Name:      "config-volume",
+							MountPath: "/etc/coredns",
+						},
+					},
+
+					Ports: []corev1.ContainerPort{
+						{
+							ContainerPort: 53,
+							Name:          "dns-tcp",
+							Protocol:      corev1.ProtocolTCP,
+						},
+						{
+							ContainerPort: 53,
+							Name:          "dns",
+							Protocol:      corev1.ProtocolUDP,
+						},
+						{
+							ContainerPort: 9153,
+							Name:          "metrics",
+							Protocol:      corev1.ProtocolTCP,
+						},
+					},
+
+					LivenessProbe: &corev1.Probe{
+						Handler: corev1.Handler{
+							HTTPGet: &corev1.HTTPGetAction{
+								Host: "169.254.20.10",
+								Path: "/health",
+								Port: intstr.FromInt(8080),
+							},
+						},
+						InitialDelaySeconds: 60,
+						TimeoutSeconds:      5,
+					},
+
+					SecurityContext: &corev1.SecurityContext{
+						Privileged: pointer.BoolPtr(true),
+					},
+				},
+			}
+
+			ds.Spec.Template.Spec.Volumes = []corev1.Volume{
+				{
+					Name: "xtables-lock",
+					VolumeSource: corev1.VolumeSource{
+						HostPath: &corev1.HostPathVolumeSource{
+							Path: "/run/xtables.lock",
+							Type: &hostPathType,
+						},
+					},
+				},
+				{
+					Name: "config-volume",
+					VolumeSource: corev1.VolumeSource{
+						ConfigMap: &corev1.ConfigMapVolumeSource{
+							LocalObjectReference: corev1.LocalObjectReference{
+								Name: resources.NodeLocalDNSConfigMapName,
+							},
+							Items: []corev1.KeyToPath{
+								{
+									Key:  "Corefile",
+									Path: "Corefile",
+								},
+							},
+						},
+					},
+				},
+			}
+
+			return ds, nil
+		}
+	}
+}

--- a/api/pkg/controller/user-cluster-controller-manager/resources/resources/node-local-dns/deamonset.go
+++ b/api/pkg/controller/user-cluster-controller-manager/resources/resources/node-local-dns/deamonset.go
@@ -28,7 +28,7 @@ func DaemonSetCreator() reconciling.NamedDaemonSetCreatorGetter {
 			if ds.Labels == nil {
 				ds.Labels = labels
 			}
-			ds.Labels[addonManagerModeKey] = reconcilModeValue
+			ds.Labels[addonManagerModeKey] = reconcileModeValue
 			ds.Labels["kubernetes.io/cluster-service"] = "true"
 
 			if ds.Spec.Selector == nil {

--- a/api/pkg/controller/user-cluster-controller-manager/resources/resources/node-local-dns/service-account.go
+++ b/api/pkg/controller/user-cluster-controller-manager/resources/resources/node-local-dns/service-account.go
@@ -15,7 +15,7 @@ func ServiceAccountCreator() reconciling.NamedServiceAccountCreatorGetter {
 				sa.Labels = map[string]string{}
 			}
 			sa.Labels["kubernetes.io/cluster-service"] = "true"
-			sa.Labels[addonManagerModeKey] = reconcilModeValue
+			sa.Labels[addonManagerModeKey] = reconcileModeValue
 
 			return sa, nil
 		}

--- a/api/pkg/controller/user-cluster-controller-manager/resources/resources/node-local-dns/service-account.go
+++ b/api/pkg/controller/user-cluster-controller-manager/resources/resources/node-local-dns/service-account.go
@@ -1,0 +1,23 @@
+package nodelocaldns
+
+import (
+	"github.com/kubermatic/kubermatic/api/pkg/resources"
+	"github.com/kubermatic/kubermatic/api/pkg/resources/reconciling"
+
+	corev1 "k8s.io/api/core/v1"
+)
+
+// ServiceAccountCreator creates the service account for Node Local DNS cache
+func ServiceAccountCreator() reconciling.NamedServiceAccountCreatorGetter {
+	return func() (string, reconciling.ServiceAccountCreator) {
+		return resources.NodeLocalDNSServiceAccountName, func(sa *corev1.ServiceAccount) (*corev1.ServiceAccount, error) {
+			if sa.Labels == nil {
+				sa.Labels = map[string]string{}
+			}
+			sa.Labels["kubernetes.io/cluster-service"] = "true"
+			sa.Labels["addonmanager.kubernetes.io/mode"] = "Reconcile"
+
+			return sa, nil
+		}
+	}
+}

--- a/api/pkg/controller/user-cluster-controller-manager/resources/resources/node-local-dns/service-account.go
+++ b/api/pkg/controller/user-cluster-controller-manager/resources/resources/node-local-dns/service-account.go
@@ -15,7 +15,7 @@ func ServiceAccountCreator() reconciling.NamedServiceAccountCreatorGetter {
 				sa.Labels = map[string]string{}
 			}
 			sa.Labels["kubernetes.io/cluster-service"] = "true"
-			sa.Labels["addonmanager.kubernetes.io/mode"] = "Reconcile"
+			sa.Labels[addonManagerModeKey] = reconcilModeValue
 
 			return sa, nil
 		}

--- a/api/pkg/resources/resources.go
+++ b/api/pkg/resources/resources.go
@@ -470,6 +470,12 @@ const (
 	CoreDNSPodDisruptionBudgetName = "coredns"
 )
 
+const (
+	NodeLocalDNSServiceAccountName = "node-local-dns"
+	NodeLocalDNSConfigMapName      = "node-local-dns"
+	NodeLocalDNSDaemonSetName      = "node-local-dns"
+)
+
 // ECDSAKeyPair is a ECDSA x509 certifcate and private key
 type ECDSAKeyPair struct {
 	Key  *ecdsa.PrivateKey

--- a/config/kubermatic/Chart.yaml
+++ b/config/kubermatic/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: kubermatic
-version: 1.1.1
+version: 1.1.2
 appVersion: '__KUBERMATIC_TAG__'
 description: Kubermatic chart for master and/or seed clusters.
 keywords:

--- a/config/kubermatic/static/master/kubernetes-addons.yaml
+++ b/config/kubermatic/static/master/kubernetes-addons.yaml
@@ -44,12 +44,6 @@ items:
 - apiVersion: kubermatic.k8s.io/v1
   kind: Addon
   metadata:
-    name: nodelocal-dns-cache
-    labels:
-      addons.kubermatic.io/ensure: true
-- apiVersion: kubermatic.k8s.io/v1
-  kind: Addon
-  metadata:
     name: pod-security-policy
     labels:
       addons.kubermatic.io/ensure: true

--- a/docs/zz_generated.kubermaticConfiguration.yaml
+++ b/docs/zz_generated.kubermaticConfiguration.yaml
@@ -287,12 +287,6 @@ spec:
           - apiVersion: kubermatic.k8s.io/v1
             kind: Addon
             metadata:
-              name: nodelocal-dns-cache
-              labels:
-                addons.kubermatic.io/ensure: true
-          - apiVersion: kubermatic.k8s.io/v1
-            kind: Addon
-            metadata:
               name: pod-security-policy
               labels:
                 addons.kubermatic.io/ensure: true


### PR DESCRIPTION
**What this PR does / why we need it**:
Adds node-local-dns-cache to user-cluster-controller-manager
**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #3372

**Special notes for your reviewer**:
The labels set are different from the ones on the coredns resources. But, they are the same as the ones currently deployed by the addon template. Once this is merged I will update them both to standard labels. 
**Documentation**:
<!-- Add links to the related documentation changes related to this pull request. E.g. the link to the kubermatic/docs pullrequest. -->

**Does this PR introduce a user-facing change?**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If  no release note is required, just write "NONE".
-->
```release-note
local-node-dns-cache is no longer a manifest addon. 
```
