### PR TITLE
[EE] Move MultiSeed behaviour into dedicated packages

### DIFF
--- a/.prow.yaml
+++ b/.prow.yaml
@@ -20,6 +20,9 @@ presubmits:
           requests:
             memory: 7Gi
             cpu: 2
+        env:
+        - name: KUBERMATIC_EDITION
+          value: ee
 
   - name: pre-kubermatic-verify
     run_if_changed: "^api/"
@@ -41,6 +44,9 @@ presubmits:
           limits:
             memory: 2.5Gi
             cpu: 1
+        env:
+        - name: KUBERMATIC_EDITION
+          value: ee
 
   - name: pre-kubermatic-verify-charts
     run_if_changed: "^config/"
@@ -58,6 +64,9 @@ presubmits:
           limits:
             memory: 256Mi
             cpu: 250m
+        env:
+        - name: KUBERMATIC_EDITION
+          value: ee
 
   - name: pre-kubermatic-verify-kubermatic-chart
     run_if_changed: "^(api|config)/"
@@ -75,6 +84,9 @@ presubmits:
           limits:
             memory: 1Gi
             cpu: 1
+        env:
+        - name: KUBERMATIC_EDITION
+          value: ee
 
   - name: pre-kubermatic-verify-grafana-dashboards
     run_if_changed: "^config/monitoring/grafana/"
@@ -92,6 +104,9 @@ presubmits:
           limits:
             memory: 128Mi
             cpu: 250m
+        env:
+        - name: KUBERMATIC_EDITION
+          value: ee
 
   - name: pre-kubermatic-verify-docs
     run_if_changed: "^(api|docs)/"
@@ -106,6 +121,9 @@ presubmits:
           requests:
             memory: 1Gi
             cpu: 1
+        env:
+        - name: KUBERMATIC_EDITION
+          value: ee
 
   - name: pre-kubermatic-lint
     run_if_changed: "^api/"
@@ -124,6 +142,9 @@ presubmits:
           requests:
             memory: 10Gi
             cpu: 3
+        env:
+        - name: KUBERMATIC_EDITION
+          value: ee
 
   - name: pre-kubermatic-dependencies
     run_if_changed: "^api/"
@@ -145,6 +166,9 @@ presubmits:
           limits:
             memory: 256Mi
             cpu: 250m
+        env:
+        - name: KUBERMATIC_EDITION
+          value: ee
 
   - name: pre-kubermatic-shellcheck
     optional: true
@@ -162,6 +186,9 @@ presubmits:
           requests:
             memory: 1Gi
             cpu: 0.5
+        env:
+        - name: KUBERMATIC_EDITION
+          value: ee
 
   - name: pre-kubermatic-license-validation
     run_if_changed: "vendor"
@@ -176,6 +203,9 @@ presubmits:
         - -C
         - api
         - license-validation
+        env:
+        - name: KUBERMATIC_EDITION
+          value: ee
 
   - name: pre-kubermatic-prometheus-rules-validation
     run_if_changed: "config/monitoring"
@@ -190,6 +220,9 @@ presubmits:
         - -C
         - config/monitoring
         - check-rules
+        env:
+        - name: KUBERMATIC_EDITION
+          value: ee
       imagePullSecrets:
       - name: quay
 
@@ -202,6 +235,9 @@ presubmits:
       - image: quay.io/kubermatic/promtool:2.7.0-3
         command:
         - "./api/hack/verify-user-cluster-prometheus-configs.sh"
+        env:
+        - name: KUBERMATIC_EDITION
+          value: ee
       imagePullSecrets:
       - name: quay
 
@@ -225,6 +261,8 @@ presubmits:
       containers:
       - image: quay.io/kubermatic/e2e-kind:with-conformance-tests-v1.0.17
         env:
+        - name: KUBERMATIC_EDITION
+          value: ee
         - name: VERSIONS_TO_TEST
           value: "v1.15.11"
         - name: EXCLUDE_DISTRIBUTIONS
@@ -262,6 +300,8 @@ presubmits:
       containers:
       - image: quay.io/kubermatic/e2e-kind:with-conformance-tests-v1.0.17
         env:
+        - name: KUBERMATIC_EDITION
+          value: ee
         - name: VERSIONS_TO_TEST
           value: "v1.16.9"
         - name: EXCLUDE_DISTRIBUTIONS
@@ -299,6 +339,8 @@ presubmits:
       containers:
       - image: quay.io/kubermatic/e2e-kind:with-conformance-tests-v1.0.17
         env:
+        - name: KUBERMATIC_EDITION
+          value: ee
         - name: VERSIONS_TO_TEST
           value: "v1.17.5"
         - name: EXCLUDE_DISTRIBUTIONS
@@ -336,6 +378,8 @@ presubmits:
       containers:
       - image: quay.io/kubermatic/e2e-kind:with-conformance-tests-v1.0.17
         env:
+        - name: KUBERMATIC_EDITION
+          value: ee
         - name: VERSIONS_TO_TEST
           value: "v1.18.2"
         - name: EXCLUDE_DISTRIBUTIONS
@@ -373,6 +417,8 @@ presubmits:
       containers:
       - image: quay.io/kubermatic/e2e-kind:with-conformance-tests-v1.0.16
         env:
+        - name: KUBERMATIC_EDITION
+          value: ee
         - name: VERSIONS_TO_TEST
           value: "v1.18.2"
         - name: EXCLUDE_DISTRIBUTIONS
@@ -414,6 +460,8 @@ presubmits:
       containers:
       - image: quay.io/kubermatic/e2e-kind:with-conformance-tests-v1.0.17
         env:
+        - name: KUBERMATIC_EDITION
+          value: ee
         - name: VERSIONS_TO_TEST
           value: "v1.18.2"
         - name: EXCLUDE_DISTRIBUTIONS
@@ -456,6 +504,8 @@ presubmits:
       containers:
       - image: quay.io/kubermatic/e2e-kind:with-conformance-tests-v1.0.17
         env:
+        - name: KUBERMATIC_EDITION
+          value: ee
         - name: VERSIONS_TO_TEST
           value: "v1.18.2"
         - name: PROVIDER
@@ -495,6 +545,8 @@ presubmits:
       containers:
       - image: quay.io/kubermatic/e2e-kind:with-conformance-tests-v1.0.17
         env:
+        - name: KUBERMATIC_EDITION
+          value: ee
         - name: VERSIONS_TO_TEST
           value: "v1.18.2"
         - name: PROVIDER
@@ -539,6 +591,8 @@ presubmits:
       containers:
       - image: quay.io/kubermatic/e2e-kind:with-conformance-tests-v1.0.17
         env:
+        - name: KUBERMATIC_EDITION
+          value: ee
         - name: VERSIONS_TO_TEST
           value: "v1.18.2"
         - name: EXCLUDE_DISTRIBUTIONS
@@ -578,6 +632,8 @@ presubmits:
       containers:
       - image: quay.io/kubermatic/e2e-kind:with-conformance-tests-v1.0.17
         env:
+        - name: KUBERMATIC_EDITION
+          value: ee
         - name: VERSIONS_TO_TEST
           value: "v1.18.2"
         - name: PROVIDER
@@ -617,6 +673,8 @@ presubmits:
       containers:
       - image: quay.io/kubermatic/e2e-kind:with-conformance-tests-v1.0.17
         env:
+        - name: KUBERMATIC_EDITION
+          value: ee
         - name: VERSIONS_TO_TEST
           value: "v1.18.2"
         - name: PROVIDER
@@ -656,6 +714,8 @@ presubmits:
       containers:
       - image: quay.io/kubermatic/e2e-kind:with-conformance-tests-v1.0.17
         env:
+        - name: KUBERMATIC_EDITION
+          value: ee
         - name: VERSIONS_TO_TEST
           value: "v1.18.2"
         - name: PROVIDER
@@ -698,6 +758,8 @@ presubmits:
       containers:
       - image: quay.io/kubermatic/e2e-kind:with-conformance-tests-v1.0.17
         env:
+        - name: KUBERMATIC_EDITION
+          value: ee
         - name: VERSIONS_TO_TEST
           value: "v1.18.2"
         - name: PROVIDER
@@ -739,6 +801,8 @@ presubmits:
       containers:
       - image: quay.io/kubermatic/e2e-kind:with-conformance-tests-v1.0.17
         env:
+        - name: KUBERMATIC_EDITION
+          value: ee
         - name: VERSIONS_TO_TEST
           value: "v1.18.2"
         - name: PROVIDER
@@ -780,6 +844,8 @@ presubmits:
       containers:
       - image: quay.io/kubermatic/e2e-kind:with-conformance-tests-v1.0.17
         env:
+        - name: KUBERMATIC_EDITION
+          value: ee
         - name: VERSIONS_TO_TEST
           value: "v1.18.2"
         - name: PROVIDER
@@ -821,6 +887,8 @@ presubmits:
       containers:
       - image: quay.io/kubermatic/e2e-kind:with-conformance-tests-v1.0.17
         env:
+        - name: KUBERMATIC_EDITION
+          value: ee
         - name: VERSIONS_TO_TEST
           value: "v1.18.2"
         - name: PROVIDER
@@ -861,6 +929,8 @@ presubmits:
       containers:
       - image: quay.io/kubermatic/e2e-kind:with-conformance-tests-v1.0.17
         env:
+        - name: KUBERMATIC_EDITION
+          value: ee
         - name: VERSIONS_TO_TEST
           value: "v1.18.2"
         - name: PROVIDER
@@ -909,6 +979,8 @@ presubmits:
       containers:
       - image: quay.io/kubermatic/e2e-kind:with-conformance-tests-v1.0.17
         env:
+        - name: KUBERMATIC_EDITION
+          value: ee
         - name: OPENSHIFT
           value: "true"
         - name: OPENSHIFT_VERSION
@@ -963,6 +1035,8 @@ presubmits:
           limits:
             memory: 6Gi
         env:
+        - name: KUBERMATIC_EDITION
+          value: ee
         - name: SERVICE_ACCOUNT_KEY
           valueFrom:
             secretKeyRef:
@@ -989,6 +1063,8 @@ presubmits:
       containers:
       - image: quay.io/kubermatic/e2e-kind:with-conformance-tests-v1.0.17
         env:
+        - name: KUBERMATIC_EDITION
+          value: ee
         - name: VERSIONS_TO_TEST
           value: "v1.18.2"
         - name: KUBERMATIC_USE_OPERATOR
@@ -1062,6 +1138,8 @@ presubmits:
         command:
         - ./api/hack/ci/ci-deploy-ci-kubermatic-io.sh
         env:
+        - name: KUBERMATIC_EDITION
+          value: ee
         - name: CANARY_DEPLOYMENT
           value: "true"
         # docker-in-docker needs privileged mode
@@ -1096,3 +1174,6 @@ presubmits:
           limits:
             memory: 6Gi
             cpu: 2
+        env:
+        - name: KUBERMATIC_EDITION
+          value: ee

--- a/api/Makefile
+++ b/api/Makefile
@@ -18,6 +18,7 @@ HAS_DEP:= $(shell command -v dep 2> /dev/null)
 HAS_GIT:= $(shell command -v git 2> /dev/null)
 BUILD_DEST?=_build
 GOTOOLFLAGS?=$(GOBUILDFLAGS) -ldflags '-w $(LDFLAGS)'
+KUBERMATIC_EDITION?=ce
 
 default: all
 
@@ -27,7 +28,7 @@ all: check vendor build test
 build: $(CMD)
 
 $(CMD): download-gocache
-	go build $(GOTOOLFLAGS) -o $(BUILD_DEST)/$@ ./cmd/$@
+	go build -tags "$(KUBERMATIC_EDITION)" $(GOTOOLFLAGS) -o $(BUILD_DEST)/$@ ./cmd/$@
 
 install:
 	go install $(GOTOOLFLAGS) ./cmd/...
@@ -43,15 +44,15 @@ download-gocache:
 	@touch download-gocache
 
 test: download-gocache
-	CGO_ENABLED=1 go test -tags=unit -race ./...
+	CGO_ENABLED=1 go test -tags "unit $(KUBERMATIC_EDITION)" -race ./...
 	@# Make sure all e2e tests compile with their individual build tag
 	@# without actually running them by using `-run` with a non-existing test.
 	@# **Imortant:** Do not replace this with one `go test` with multiple tags,
 	@# as that doesn't properly reflect if each individual tag still builds
-	go test -tags cloud -run nope ./pkg/test/e2e/api/...
-	go test -tags create -run nope ./pkg/test/e2e/api/...
-	go test -tags e2e -run nope ./pkg/test/e2e/api/...
-	go test -tags integration -run nope ./...
+	go test -tags "cloud $(KUBERMATIC_EDITION)" -run nope ./pkg/test/e2e/api/...
+	go test -tags "create $(KUBERMATIC_EDITION)" -run nope ./pkg/test/e2e/api/...
+	go test -tags "e2e $(KUBERMATIC_EDITION)" -run nope ./pkg/test/e2e/api/...
+	go test -tags "integration $(KUBERMATIC_EDITION)" -run nope ./...
 
 test-integration : CGO_ENABLED = 1
 test-integration: download-gocache
@@ -61,7 +62,7 @@ test-integration: download-gocache
 	@# * Prefixing them with `./` as thats needed by `go test` as well
 	@grep --files-with-matches --recursive --extended-regexp '\+build.+integration' cmd/ pkg/ \
 		|xargs dirname \
-		|xargs --max-args=1 -I ^ go test -tags integration  -race ./^
+		|xargs --max-args=1 -I ^ go test -tags "integration $(KUBERMATIC_EDITION)"  -race ./^
 
 test-update:
 	-go test ./... -update

--- a/api/cmd/kubermatic-api/main.go
+++ b/api/cmd/kubermatic-api/main.go
@@ -146,7 +146,7 @@ func createInitProviders(options serverRunOptions) (providers, error) {
 	if err != nil {
 		return providers{}, err
 	}
-	seedKubeconfigGetter, err := provider.SeedKubeconfigGetterFactory(context.Background(), mgr.GetClient(), options.kubeconfig, options.namespace, options.dynamicDatacenters)
+	seedKubeconfigGetter, err := provider.SeedKubeconfigGetterFactory(context.Background(), mgr.GetClient(), options.kubeconfig, options.dynamicDatacenters)
 	if err != nil {
 		return providers{}, err
 	}

--- a/api/cmd/kubermatic-operator-util/main_ce.go
+++ b/api/cmd/kubermatic-operator-util/main_ce.go
@@ -1,0 +1,11 @@
+// +build !ee
+
+package main
+
+import (
+	"github.com/urfave/cli"
+)
+
+func extraCommands() []cli.Command {
+	return nil
+}

--- a/api/cmd/kubermatic-operator-util/main_ee.go
+++ b/api/cmd/kubermatic-operator-util/main_ee.go
@@ -1,0 +1,20 @@
+// +build ee
+
+package main
+
+import (
+	"github.com/urfave/cli"
+
+	util "github.com/kubermatic/kubermatic/api/pkg/ee/cmd/kubermatic-operator-util"
+)
+
+func extraCommands() []cli.Command {
+	return []cli.Command{
+		{
+			Name:      "convert",
+			Usage:     "Convert a Helm values.yaml to a KubermaticConfiguration manifest (YAML)",
+			Action:    util.ConvertAction,
+			ArgsUsage: "VALUES_FILE",
+		},
+	}
+}

--- a/api/cmd/kubermatic-operator/main.go
+++ b/api/cmd/kubermatic-operator/main.go
@@ -100,7 +100,7 @@ func main() {
 		log.Fatalw("Failed to construct seedsGetter", zap.Error(err))
 	}
 
-	seedKubeconfigGetter, err := provider.SeedKubeconfigGetterFactory(ctx, mgr.GetClient(), "", opt.namespace, true)
+	seedKubeconfigGetter, err := provider.SeedKubeconfigGetterFactory(ctx, mgr.GetClient(), "", true)
 	if err != nil {
 		log.Fatalw("Failed to construct seedKubeconfigGetter", zap.Error(err))
 	}

--- a/api/cmd/master-controller-manager/main.go
+++ b/api/cmd/master-controller-manager/main.go
@@ -11,6 +11,7 @@ import (
 	"go.uber.org/zap"
 
 	mastermigrations "github.com/kubermatic/kubermatic/api/pkg/crd/migrations/master"
+	"github.com/kubermatic/kubermatic/api/pkg/crd/migrations/master/options"
 	"github.com/kubermatic/kubermatic/api/pkg/leaderelection"
 	kubermaticlog "github.com/kubermatic/kubermatic/api/pkg/log"
 	"github.com/kubermatic/kubermatic/api/pkg/metrics"
@@ -115,7 +116,7 @@ func main() {
 	ctrlCtx.ctx = ctx
 
 	// prepare migration options
-	migrationOptions := mastermigrations.MigrationOptions{
+	migrationOptions := options.MigrationOptions{
 		DatacentersFile:    runOpts.dcFile,
 		DynamicDatacenters: runOpts.dynamicDatacenters,
 	}

--- a/api/cmd/master-controller-manager/main.go
+++ b/api/cmd/master-controller-manager/main.go
@@ -194,7 +194,7 @@ func main() {
 		log.Fatalw("failed to construct seedsGetter", zap.Error(err))
 	}
 	ctrlCtx.seedKubeconfigGetter, err = provider.SeedKubeconfigGetterFactory(
-		ctx, mgr.GetClient(), runOpts.kubeconfig, ctrlCtx.namespace, runOpts.dynamicDatacenters)
+		ctx, mgr.GetClient(), runOpts.kubeconfig, runOpts.dynamicDatacenters)
 	if err != nil {
 		log.Fatalw("failed to construct seedKubeconfigGetter", zap.Error(err))
 	}

--- a/api/hack/ci/ci-run-lint.sh
+++ b/api/hack/ci/ci-run-lint.sh
@@ -5,7 +5,7 @@ set -euo pipefail
 lint_output="$(mktemp)"
 
 # run with concurrency=1 to lower memory usage a bit
-golangci-lint run -v --concurrency 1 --print-resources-usage 2>&1|tee $lint_output
+golangci-lint run -v --build-tags "$KUBERMATIC_EDITION" --concurrency 1 --print-resources-usage 2>&1|tee $lint_output
 
 if egrep -q 'compilation errors|Packages that do not compile' $lint_output; then
   echo "compilation error during linting"

--- a/api/hack/ci/ci-run-offline-test.sh
+++ b/api/hack/ci/ci-run-offline-test.sh
@@ -230,7 +230,7 @@ retry 3 helm upgrade --install --force --wait --timeout 300 \
   --namespace ${NAMESPACE} \
   kubermatic-${BUILD_ID} ./../config/kubermatic/
 
-go build github.com/kubermatic/kubermatic/api/cmd/conformance-tests
+go build --tags "$KUBERMATIC_EDITION" github.com/kubermatic/kubermatic/api/cmd/conformance-tests
 
 cp ${KUBECONFIG} /tmp/kubeconfig-remote
 kubectl --kubeconfig /tmp/kubeconfig-remote config set-cluster kubernetes --server=https://${KUBERNETES_CONTROLLER_ADDR}:6443;

--- a/api/hack/ci/ci-setup-kubermatic-in-kind.sh
+++ b/api/hack/ci/ci-setup-kubermatic-in-kind.sh
@@ -156,7 +156,7 @@ else
   make -C api download-gocache
   pushElapsed gocache_download_duration_milliseconds $beforeGocache
 
-  CGO_ENABLED=0 go build -v -o /tmp/clusterexposer ./api/pkg/test/clusterexposer/cmd
+  CGO_ENABLED=0 go build --tags "$KUBERMATIC_EDITION" -v -o /tmp/clusterexposer ./api/pkg/test/clusterexposer/cmd
   CGO_ENABLED=0 /tmp/clusterexposer \
     --kubeconfig-inner "$KUBECONFIG" \
     --kubeconfig-outer "/etc/kubeconfig/kubeconfig" \

--- a/api/hack/ci/ci-upload-gocache.sh
+++ b/api/hack/ci/ci-upload-gocache.sh
@@ -37,10 +37,13 @@ retry 2 make build
 
 echodate "Building tests"
 TEST_NAME="Build tests"
-retry 2 go test -tags cloud ./... -run nope
-retry 2 go test -tags create ./... -run nope
-retry 2 go test -tags e2e ./... -run nope
-retry 2 go test -tags integration ./... -run nope
+
+for edition in ee ce; do
+  retry 2 go test -tags "cloud $edition" ./... -run nope
+  retry 2 go test -tags "create $edition" ./... -run nope
+  retry 2 go test -tags "e2e $edition" ./... -run nope
+  retry 2 go test -tags "integration $edition" ./... -run nope
+done
 
 echodate "Creating gocache archive"
 TEST_NAME="Creating gocache archive"

--- a/api/hack/ci/ci_run_api_e2e.sh
+++ b/api/hack/ci/ci_run_api_e2e.sh
@@ -92,5 +92,5 @@ retry 2 kubectl apply -f user.yaml
 
 echodate "Running API E2E tests..."
 export KUBERMATIC_DEX_VALUES_FILE=$(realpath api/hack/ci/testdata/oauth_values.yaml)
-go test -tags=create -timeout 20m ./api/pkg/test/e2e/api -v
-go test -tags=e2e -timeout 20m ./api/pkg/test/e2e/api -v
+go test -tags="create $KUBERMATIC_EDITION" -timeout 20m ./api/pkg/test/e2e/api -v
+go test -tags="e2e $KUBERMATIC_EDITION" -timeout 20m ./api/pkg/test/e2e/api -v

--- a/api/pkg/controller/seed-controller-manager/kubernetes/resources.go
+++ b/api/pkg/controller/seed-controller-manager/kubernetes/resources.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"fmt"
 
-	controllerutil "github.com/kubermatic/kubermatic/api/pkg/controller/util"
 	kubermaticv1 "github.com/kubermatic/kubermatic/api/pkg/crd/kubermatic/v1"
 	"github.com/kubermatic/kubermatic/api/pkg/resources"
 	"github.com/kubermatic/kubermatic/api/pkg/resources/apiserver"
@@ -128,7 +127,7 @@ func (r *Reconciler) getClusterTemplateData(ctx context.Context, cluster *kuberm
 		return nil, fmt.Errorf("failed to get datacenter %s", cluster.Spec.Cloud.DatacenterName)
 	}
 
-	supportsFailureDomainZoneAntiAffinity, err := controllerutil.SupportsFailureDomainZoneAntiAffinity(ctx, r.Client)
+	supportsFailureDomainZoneAntiAffinity, err := resources.SupportsFailureDomainZoneAntiAffinity(ctx, r.Client)
 	if err != nil {
 		return nil, err
 	}

--- a/api/pkg/controller/seed-controller-manager/openshift/resources.go
+++ b/api/pkg/controller/seed-controller-manager/openshift/resources.go
@@ -4,8 +4,8 @@ import (
 	"context"
 	"fmt"
 
-	controllerutil "github.com/kubermatic/kubermatic/api/pkg/controller/util"
 	kubermaticv1 "github.com/kubermatic/kubermatic/api/pkg/crd/kubermatic/v1"
+	"github.com/kubermatic/kubermatic/api/pkg/resources"
 	"github.com/kubermatic/kubermatic/api/pkg/resources/nodeportproxy"
 
 	corev1 "k8s.io/api/core/v1"
@@ -22,7 +22,7 @@ func (r *Reconciler) getOSData(ctx context.Context, cluster *kubermaticv1.Cluste
 		return nil, fmt.Errorf("couldn't find dc %s", cluster.Spec.Cloud.DatacenterName)
 	}
 
-	supportsFailureDomainZoneAntiAffinity, err := controllerutil.SupportsFailureDomainZoneAntiAffinity(ctx, r.Client)
+	supportsFailureDomainZoneAntiAffinity, err := resources.SupportsFailureDomainZoneAntiAffinity(ctx, r.Client)
 	if err != nil {
 		return nil, err
 	}

--- a/api/pkg/controller/util/util.go
+++ b/api/pkg/controller/util/util.go
@@ -5,10 +5,8 @@ import (
 	"fmt"
 
 	kubermaticv1 "github.com/kubermatic/kubermatic/api/pkg/crd/kubermatic/v1"
-	"github.com/kubermatic/kubermatic/api/pkg/resources"
 
 	corev1 "k8s.io/api/core/v1"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/apimachinery/pkg/types"
 	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
@@ -94,28 +92,6 @@ func EnqueueConst(queueKey string) *handler.EnqueueRequestsFromMapFunc {
 				Namespace: "",
 			}}}
 	})}
-}
-
-// SupportsFailureDomainZoneAntiAffinity checks if there are any nodes with the
-// TopologyKeyFailureDomainZone label.
-func SupportsFailureDomainZoneAntiAffinity(ctx context.Context, client ctrlruntimeclient.Client) (bool, error) {
-	selector, err := labels.Parse(resources.TopologyKeyFailureDomainZone)
-	if err != nil {
-		return false, fmt.Errorf("failed to parse selector: %v", err)
-	}
-	opts := &ctrlruntimeclient.ListOptions{
-		LabelSelector: selector,
-		Raw: &metav1.ListOptions{
-			Limit: 1,
-		},
-	}
-
-	nodeList := &corev1.NodeList{}
-	if err := client.List(ctx, nodeList, opts); err != nil {
-		return false, fmt.Errorf("failed to list nodes having the %s label: %v", resources.TopologyKeyFailureDomainZone, err)
-	}
-
-	return len(nodeList.Items) != 0, nil
 }
 
 // ClusterAvailableForReconciling returns true if the given cluster can be reconciled. This is true if

--- a/api/pkg/crd/migrations/master/migrations_ce.go
+++ b/api/pkg/crd/migrations/master/migrations_ce.go
@@ -1,0 +1,18 @@
+// +build !ee
+
+package master
+
+import (
+	"context"
+
+	"go.uber.org/zap"
+
+	"github.com/kubermatic/kubermatic/api/pkg/crd/migrations/master/options"
+
+	ctrlruntimeclient "sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+// RunAll runs all migrations that should be run inside a master cluster.
+func RunAll(ctx context.Context, log *zap.SugaredLogger, client ctrlruntimeclient.Client, kubermaticNamespace string, opt options.MigrationOptions) error {
+	return nil
+}

--- a/api/pkg/crd/migrations/master/migrations_ee.go
+++ b/api/pkg/crd/migrations/master/migrations_ee.go
@@ -1,0 +1,19 @@
+// +build ee
+
+package master
+
+import (
+	"context"
+
+	"go.uber.org/zap"
+
+	"github.com/kubermatic/kubermatic/api/pkg/crd/migrations/master/options"
+	eemastermigrations "github.com/kubermatic/kubermatic/api/pkg/ee/crd/migrations/master"
+
+	ctrlruntimeclient "sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+// RunAll runs all migrations that should be run inside a master cluster.
+func RunAll(ctx context.Context, log *zap.SugaredLogger, client ctrlruntimeclient.Client, kubermaticNamespace string, opt options.MigrationOptions) error {
+	return eemastermigrations.RunAll(ctx, log, client, kubermaticNamespace, opt)
+}

--- a/api/pkg/crd/migrations/master/options/options.go
+++ b/api/pkg/crd/migrations/master/options/options.go
@@ -1,0 +1,21 @@
+package options
+
+import (
+	clientcmdapi "k8s.io/client-go/tools/clientcmd/api"
+)
+
+type MigrationOptions struct {
+	DatacentersFile    string
+	DynamicDatacenters bool
+	Kubeconfig         *clientcmdapi.Config
+}
+
+// MigrationEnabled returns true if at least one migration is enabled.
+func (o MigrationOptions) MigrationEnabled() bool {
+	return o.SeedMigrationEnabled()
+}
+
+// SeedMigrationEnabled returns true if the datacenters->seed migration is enabled.
+func (o MigrationOptions) SeedMigrationEnabled() bool {
+	return o.DatacentersFile != "" && o.DynamicDatacenters
+}

--- a/api/pkg/ee/cmd/kubermatic-operator-util/convert.go
+++ b/api/pkg/ee/cmd/kubermatic-operator-util/convert.go
@@ -1,0 +1,52 @@
+// +build ee
+
+package util
+
+import (
+	"fmt"
+	"io/ioutil"
+	"os"
+
+	"github.com/urfave/cli"
+
+	"github.com/kubermatic/kubermatic/api/pkg/ee/conversion"
+	yamlutil "github.com/kubermatic/kubermatic/api/pkg/util/yaml"
+)
+
+func ConvertAction(ctx *cli.Context) error {
+	valuesFile := ctx.Args().First()
+	if valuesFile == "" {
+		return cli.NewExitError("no values.yaml file given", 2)
+	}
+
+	var (
+		content []byte
+		err     error
+	)
+
+	if valuesFile == "-" {
+		content, err = ioutil.ReadAll(os.Stdin)
+	} else {
+		content, err = ioutil.ReadFile(valuesFile)
+	}
+	if err != nil {
+		return cli.NewExitError(fmt.Errorf("failed to read '%s': %v", valuesFile, err), 1)
+	}
+
+	resources, err := conversion.HelmValuesFileToCRDs(content, "kubermatic")
+	if err != nil {
+		return cli.NewExitError(err, 1)
+	}
+
+	for i, resource := range resources {
+		if err := yamlutil.Encode(resource, os.Stdout); err != nil {
+			return cli.NewExitError(fmt.Errorf("failed to create YAML: %v", err), 1)
+		}
+
+		if i < len(resources)-1 {
+			fmt.Println("\n---")
+		}
+	}
+
+	return nil
+}

--- a/api/pkg/ee/conversion/helm.go
+++ b/api/pkg/ee/conversion/helm.go
@@ -1,3 +1,5 @@
+// +build ee
+
 package conversion
 
 import (
@@ -10,8 +12,8 @@ import (
 	kubermaticv1 "github.com/kubermatic/kubermatic/api/pkg/crd/kubermatic/v1"
 	"github.com/kubermatic/kubermatic/api/pkg/crd/migrations/util"
 	operatorv1alpha1 "github.com/kubermatic/kubermatic/api/pkg/crd/operator/v1alpha1"
+	"github.com/kubermatic/kubermatic/api/pkg/ee/provider"
 	"github.com/kubermatic/kubermatic/api/pkg/features"
-	"github.com/kubermatic/kubermatic/api/pkg/provider"
 	"github.com/kubermatic/kubermatic/api/pkg/provider/kubernetes"
 	"github.com/kubermatic/kubermatic/api/pkg/resources"
 

--- a/api/pkg/ee/conversion/helm_test.go
+++ b/api/pkg/ee/conversion/helm_test.go
@@ -1,3 +1,5 @@
+// +build ee
+
 package conversion
 
 import (

--- a/api/pkg/ee/crd/migrations/master/migrations_test.go
+++ b/api/pkg/ee/crd/migrations/master/migrations_test.go
@@ -1,3 +1,5 @@
+// +build ee
+
 package master
 
 import (
@@ -8,6 +10,7 @@ import (
 	"go.uber.org/zap/zaptest"
 
 	kubermaticv1 "github.com/kubermatic/kubermatic/api/pkg/crd/kubermatic/v1"
+	"github.com/kubermatic/kubermatic/api/pkg/crd/migrations/master/options"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 	ctrlruntimeclient "sigs.k8s.io/controller-runtime/pkg/client"
@@ -58,7 +61,7 @@ func TestMigrateAllDatacenterEmailRestrictions(t *testing.T) {
 	}
 
 	client := fakectrlruntimeclient.NewFakeClient(unmigratedSeed)
-	err := migrateAllDatacenterEmailRestrictions(context.Background(), zaptest.NewLogger(t).Sugar(), client, nsName, MigrationOptions{})
+	err := migrateAllDatacenterEmailRestrictions(context.Background(), zaptest.NewLogger(t).Sugar(), client, nsName, options.MigrationOptions{})
 	assert.NoError(t, err)
 
 	key := ctrlruntimeclient.ObjectKey{
@@ -95,6 +98,6 @@ func TestMigrateAllDatacenterEmailRestrictionsInvalid(t *testing.T) {
 	}
 
 	client := fakectrlruntimeclient.NewFakeClient(unmigratedSeed)
-	err := migrateAllDatacenterEmailRestrictions(context.Background(), zaptest.NewLogger(t).Sugar(), client, nsName, MigrationOptions{})
+	err := migrateAllDatacenterEmailRestrictions(context.Background(), zaptest.NewLogger(t).Sugar(), client, nsName, options.MigrationOptions{})
 	assert.Error(t, err, "datacenter %s->%s has both `requiredEmailDomain` and `requiredEmailDomains` set", seedName, dcName)
 }

--- a/api/pkg/ee/provider/conversions.go
+++ b/api/pkg/ee/provider/conversions.go
@@ -1,0 +1,71 @@
+// +build ee
+
+package provider
+
+import (
+	"fmt"
+
+	kubermaticv1 "github.com/kubermatic/kubermatic/api/pkg/crd/kubermatic/v1"
+)
+
+// We can not convert a single DatacenterMeta as the SeedDatacenter contains its NodeDatacenter
+// which is also represented as a DatacenterMeta, hence we have to do it all at once
+// TODO: Get rid of this once we don't support datacenters.yaml anymore
+func DatacenterMetasToSeeds(dm map[string]DatacenterMeta) (map[string]*kubermaticv1.Seed, error) {
+	seeds := map[string]*kubermaticv1.Seed{}
+
+	for dcName, datacenterSpec := range dm {
+		if datacenterSpec.IsSeed && datacenterSpec.Seed != "" {
+			return nil, fmt.Errorf("datacenter %q is configured as seed but has a seed configured (%q) which is only allowed for datacenters that are not a seed", dcName, datacenterSpec.Seed)
+		}
+		if !datacenterSpec.IsSeed && datacenterSpec.Seed == "" {
+			return nil, fmt.Errorf("datacenter %q is not configured as seed but does not have a corresponding seed configured. Configuring a seed datacenter is required for all node datacenters", dcName)
+		}
+
+		if datacenterSpec.IsSeed {
+			// Keep existing map entries, because its possible that a NodeDC that uses this SeedDC
+			// came before the SeedDC in the loop
+			if seeds[dcName] == nil {
+				seeds[dcName] = &kubermaticv1.Seed{
+					Spec: kubermaticv1.SeedSpec{
+						Datacenters: map[string]kubermaticv1.Datacenter{},
+					},
+				}
+			}
+
+			seeds[dcName].Name = dcName
+			seeds[dcName].Spec.Country = datacenterSpec.Country
+			seeds[dcName].Spec.Location = datacenterSpec.Location
+			seeds[dcName].Spec.SeedDNSOverwrite = datacenterSpec.SeedDNSOverwrite
+
+			// Kubeconfig object ref is injected during the automated migration.
+		} else {
+			if _, exists := dm[datacenterSpec.Seed]; !exists {
+				return nil, fmt.Errorf("seedDatacenter %q used by node datacenter %q does not exist", datacenterSpec.Seed, dcName)
+			}
+			if !dm[datacenterSpec.Seed].IsSeed {
+				return nil, fmt.Errorf("datacenter %q referenced by node datacenter %q as its seed is not configured to be a seed",
+					datacenterSpec.Seed, dcName)
+
+			}
+			// Create entry for SeedDC if not already present
+			if seeds[datacenterSpec.Seed] == nil {
+				seeds[datacenterSpec.Seed] = &kubermaticv1.Seed{
+					Spec: kubermaticv1.SeedSpec{
+						Datacenters: map[string]kubermaticv1.Datacenter{},
+					},
+				}
+
+			}
+			seeds[datacenterSpec.Seed].Spec.Datacenters[dcName] = kubermaticv1.Datacenter{
+				Country:  datacenterSpec.Country,
+				Location: datacenterSpec.Location,
+				Node:     datacenterSpec.Node,
+				Spec:     datacenterSpec.Spec,
+			}
+
+		}
+	}
+
+	return seeds, nil
+}

--- a/api/pkg/ee/provider/conversions_test.go
+++ b/api/pkg/ee/provider/conversions_test.go
@@ -1,3 +1,5 @@
+// +build ee
+
 package provider
 
 import (

--- a/api/pkg/ee/provider/datacenter.go
+++ b/api/pkg/ee/provider/datacenter.go
@@ -10,10 +10,8 @@ import (
 	"strings"
 
 	kubermaticv1 "github.com/kubermatic/kubermatic/api/pkg/crd/kubermatic/v1"
-	kubermaticlog "github.com/kubermatic/kubermatic/api/pkg/log"
 	providertypes "github.com/kubermatic/machine-controller/pkg/providerconfig/types"
 
-	corev1 "k8s.io/api/core/v1"
 	kerrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/apimachinery/pkg/util/sets"
@@ -206,33 +204,10 @@ func SeedsGetterFactory(ctx context.Context, client ctrlruntimeclient.Client, dc
 
 type EESeedKubeconfigGetter = func(seed *kubermaticv1.Seed) (*rest.Config, error)
 
-func SeedKubeconfigGetterFactory(ctx context.Context, client ctrlruntimeclient.Client, kubeconfigFilePath, namespace string, dynamicDatacenters bool) (EESeedKubeconfigGetter, error) {
-	if dynamicDatacenters {
-		return func(seed *kubermaticv1.Seed) (*rest.Config, error) {
-			secret := &corev1.Secret{}
-			name := types.NamespacedName{
-				Namespace: seed.Spec.Kubeconfig.Namespace,
-				Name:      seed.Spec.Kubeconfig.Name,
-			}
-
-			fieldPath := seed.Spec.Kubeconfig.FieldPath
-			if len(fieldPath) == 0 {
-				fieldPath = DefaultKubeconfigFieldPath
-			}
-			if _, exists := secret.Data[fieldPath]; !exists {
-				return nil, fmt.Errorf("secret %q has no key %q", name.String(), fieldPath)
-			}
-
-			cfg, err := clientcmd.RESTConfigFromKubeConfig(secret.Data[fieldPath])
-			if err != nil {
-				return nil, fmt.Errorf("failed to load kubeconfig: %v", err)
-			}
-
-			kubermaticlog.Logger.With("seed", seed.Name).Debug("Successfully got kubeconfig")
-			return cfg, nil
-		}, nil
-	}
-
+// KubeconfigBasedSeedKubeconfigGetterFactory returns a provider.SeedKubeconfigGetter
+// compatible implementation that returns kubeconfigs based on the given master
+// --kubeconfig file, which has to contain a context for every configured seed.
+func KubeconfigBasedSeedKubeconfigGetterFactory(ctx context.Context, client ctrlruntimeclient.Client, kubeconfigFilePath string, dynamicDatacenters bool) (EESeedKubeconfigGetter, error) {
 	if kubeconfigFilePath == "" {
 		return nil, errors.New("--kubeconfig is required when --dynamic-datacenters=false")
 	}

--- a/api/pkg/ee/provider/datacenter.go
+++ b/api/pkg/ee/provider/datacenter.go
@@ -1,0 +1,255 @@
+// +build ee
+
+package provider
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"io/ioutil"
+	"strings"
+
+	kubermaticv1 "github.com/kubermatic/kubermatic/api/pkg/crd/kubermatic/v1"
+	kubermaticlog "github.com/kubermatic/kubermatic/api/pkg/log"
+	providertypes "github.com/kubermatic/machine-controller/pkg/providerconfig/types"
+
+	corev1 "k8s.io/api/core/v1"
+	kerrors "k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/apimachinery/pkg/util/sets"
+	"k8s.io/apimachinery/pkg/util/validation"
+	"k8s.io/client-go/rest"
+	"k8s.io/client-go/tools/clientcmd"
+	ctrlruntimeclient "sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/yaml"
+)
+
+var (
+	allOperatingSystems = sets.NewString()
+)
+
+func init() {
+	// build a quicker, convenient lookup mechanism
+	for _, os := range providertypes.AllOperatingSystems {
+		allOperatingSystems.Insert(string(os))
+	}
+}
+
+func validateImageList(images kubermaticv1.ImageList) error {
+	for s := range images {
+		if !allOperatingSystems.Has(string(s)) {
+			return fmt.Errorf("invalid operating system defined '%s'. Possible values: %s", s, strings.Join(allOperatingSystems.List(), ","))
+		}
+	}
+
+	return nil
+}
+
+// ValidateSeed takes a seed and returns an error if the seed's spec is invalid.
+func ValidateSeed(seed *kubermaticv1.Seed) error {
+	for name, dc := range seed.Spec.Datacenters {
+		if dc.Spec.VSphere != nil {
+			if err := validateImageList(dc.Spec.VSphere.Templates); err != nil {
+				return fmt.Errorf("invalid datacenter defined '%s': %v", name, err)
+			}
+		}
+		if dc.Spec.Openstack != nil {
+			if err := validateImageList(dc.Spec.Openstack.Images); err != nil {
+				return fmt.Errorf("invalid datacenter defined '%s': %v", name, err)
+			}
+		}
+	}
+
+	// invalid DNS overwrites can happen when a seed was freshly converted from
+	// the datacenters.yaml and has not yet been validated
+	if seed.Spec.SeedDNSOverwrite != "" {
+		if errs := validation.IsDNS1123Subdomain(seed.Spec.SeedDNSOverwrite); errs != nil {
+			return fmt.Errorf("DNS overwrite %q is not a valid DNS name: %v", seed.Spec.SeedDNSOverwrite, errs)
+		}
+	} else {
+		if errs := validation.IsDNS1123Subdomain(seed.Name); errs != nil {
+			return fmt.Errorf("seed name %q is not a valid DNS name: %v", seed.Name, errs)
+		}
+	}
+
+	return nil
+}
+
+// DatacenterMeta describes a Kubermatic datacenter.
+type DatacenterMeta struct {
+	Location         string                      `json:"location"`
+	Seed             string                      `json:"seed"`
+	Country          string                      `json:"country"`
+	Spec             kubermaticv1.DatacenterSpec `json:"spec"`
+	IsSeed           bool                        `json:"is_seed"`
+	SeedDNSOverwrite string                      `json:"seed_dns_overwrite,omitempty"`
+	Node             kubermaticv1.NodeSettings   `json:"node,omitempty"`
+}
+
+// datacentersMeta describes a number of Kubermatic datacenters.
+type datacentersMeta struct {
+	Datacenters map[string]DatacenterMeta `json:"datacenters"`
+}
+
+// LoadSeeds loads all Datacenters from the given path.
+func LoadSeeds(path string) (map[string]*kubermaticv1.Seed, error) {
+	bytes, err := ioutil.ReadFile(path)
+	if err != nil {
+		return nil, fmt.Errorf("failed to read datacenter.yaml: %v", err)
+	}
+
+	dcMetas := datacentersMeta{}
+	if err := yaml.UnmarshalStrict(bytes, &dcMetas); err != nil {
+		return nil, fmt.Errorf("failed to parse datacenters.yaml: %v", err)
+	}
+
+	seeds, err := DatacenterMetasToSeeds(dcMetas.Datacenters)
+	if err != nil {
+		return nil, fmt.Errorf("failed to convert datacenters.yaml: %v", err)
+	}
+
+	for seedName, seed := range seeds {
+		if err := ValidateSeed(seed); err != nil {
+			return nil, fmt.Errorf("failed to validate datacenters.yaml: seed %q is invalid: %v", seedName, err)
+		}
+	}
+
+	return seeds, nil
+}
+
+// LoadSeed loads an existing datacenters.yaml from disk and returns the given
+// datacenter as a seed or an error if the datacenter does not exist.
+func LoadSeed(path, datacenterName string) (*kubermaticv1.Seed, error) {
+	seeds, err := LoadSeeds(path)
+	if err != nil {
+		return nil, err
+	}
+
+	datacenter, exists := seeds[datacenterName]
+	if !exists {
+		return nil, fmt.Errorf("datacenter %q is not in datacenters.yaml", datacenterName)
+	}
+
+	return datacenter, nil
+}
+
+type EESeedGetter func() (*kubermaticv1.Seed, error)
+
+func SeedGetterFactory(ctx context.Context, client ctrlruntimeclient.Client, seedName, dcFile, namespace string, dynamicDatacenters bool) (EESeedGetter, error) {
+	if dynamicDatacenters {
+		return func() (*kubermaticv1.Seed, error) {
+			seed := &kubermaticv1.Seed{}
+			if err := client.Get(ctx, types.NamespacedName{Namespace: namespace, Name: seedName}, seed); err != nil {
+				// allow callers to handle this gracefully
+				if kerrors.IsNotFound(err) {
+					return nil, err
+				}
+				return nil, fmt.Errorf("failed to get seed %q: %v", seedName, err)
+			}
+			return seed, nil
+		}, nil
+	}
+
+	if dcFile == "" {
+		return nil, errors.New("--datacenters is required")
+	}
+	// Make sure we fail early, an error here is not recoverable
+	seed, err := LoadSeed(dcFile, seedName)
+	if err != nil {
+		return nil, err
+	}
+	return func() (*kubermaticv1.Seed, error) {
+		return seed.DeepCopy(), nil
+	}, nil
+}
+
+type EESeedsGetter func() (map[string]*kubermaticv1.Seed, error)
+
+func SeedsGetterFactory(ctx context.Context, client ctrlruntimeclient.Client, dcFile, namespace string, dynamicDatacenters bool) (EESeedsGetter, error) {
+	if dynamicDatacenters {
+		// We only have a options func for raw *metav1.ListOpts as the rbac controller currently required that
+		listOpts := &ctrlruntimeclient.ListOptions{
+			Namespace: namespace,
+		}
+
+		return func() (map[string]*kubermaticv1.Seed, error) {
+			seeds := &kubermaticv1.SeedList{}
+			if err := client.List(ctx, seeds, listOpts); err != nil {
+				return nil, fmt.Errorf("failed to list the seeds: %v", err)
+			}
+			seedMap := map[string]*kubermaticv1.Seed{}
+			for idx, seed := range seeds.Items {
+				seedMap[seed.Name] = &seeds.Items[idx]
+			}
+			return seedMap, nil
+		}, nil
+	}
+
+	if dcFile == "" {
+		return nil, errors.New("--datacenters is required")
+	}
+	// Make sure we fail early, an error here is not recoverable
+	seedMap, err := LoadSeeds(dcFile)
+	if err != nil {
+		return nil, err
+	}
+
+	return func() (map[string]*kubermaticv1.Seed, error) {
+		// copy it, just to be safe
+		mapToReturn := map[string]*kubermaticv1.Seed{}
+		for k, v := range seedMap {
+			mapToReturn[k] = v.DeepCopy()
+		}
+		return mapToReturn, nil
+	}, nil
+}
+
+type EESeedKubeconfigGetter = func(seed *kubermaticv1.Seed) (*rest.Config, error)
+
+func SeedKubeconfigGetterFactory(ctx context.Context, client ctrlruntimeclient.Client, kubeconfigFilePath, namespace string, dynamicDatacenters bool) (EESeedKubeconfigGetter, error) {
+	if dynamicDatacenters {
+		return func(seed *kubermaticv1.Seed) (*rest.Config, error) {
+			secret := &corev1.Secret{}
+			name := types.NamespacedName{
+				Namespace: seed.Spec.Kubeconfig.Namespace,
+				Name:      seed.Spec.Kubeconfig.Name,
+			}
+
+			fieldPath := seed.Spec.Kubeconfig.FieldPath
+			if len(fieldPath) == 0 {
+				fieldPath = DefaultKubeconfigFieldPath
+			}
+			if _, exists := secret.Data[fieldPath]; !exists {
+				return nil, fmt.Errorf("secret %q has no key %q", name.String(), fieldPath)
+			}
+
+			cfg, err := clientcmd.RESTConfigFromKubeConfig(secret.Data[fieldPath])
+			if err != nil {
+				return nil, fmt.Errorf("failed to load kubeconfig: %v", err)
+			}
+
+			kubermaticlog.Logger.With("seed", seed.Name).Debug("Successfully got kubeconfig")
+			return cfg, nil
+		}, nil
+	}
+
+	if kubeconfigFilePath == "" {
+		return nil, errors.New("--kubeconfig is required when --dynamic-datacenters=false")
+	}
+
+	kubeconfig, err := clientcmd.LoadFromFile(kubeconfigFilePath)
+	if err != nil {
+		return nil, fmt.Errorf("failed to read kubeconfig from %q: %v", kubeconfigFilePath, err)
+	}
+
+	return func(seed *kubermaticv1.Seed) (*rest.Config, error) {
+		if _, exists := kubeconfig.Contexts[seed.Name]; !exists {
+			return nil, fmt.Errorf("found no context with name %q in kubeconfig", seed.Name)
+		}
+		cfg, err := clientcmd.NewNonInteractiveClientConfig(*kubeconfig, seed.Name, &clientcmd.ConfigOverrides{}, nil).ClientConfig()
+		if err != nil {
+			return nil, fmt.Errorf("failed to get restConfig for seed %q: %v", seed.Name, err)
+		}
+		return cfg, nil
+	}, nil
+}

--- a/api/pkg/ee/provider/datacenter_test.go
+++ b/api/pkg/ee/provider/datacenter_test.go
@@ -1,0 +1,180 @@
+// +build ee
+
+package provider
+
+import (
+	"io/ioutil"
+	"os"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	kubermaticv1 "github.com/kubermatic/kubermatic/api/pkg/crd/kubermatic/v1"
+	providerconfig "github.com/kubermatic/machine-controller/pkg/providerconfig/types"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+func TestLoadDatacentersMeta(t *testing.T) {
+	datacentersYAML := `
+datacenters:
+#==================================
+#===============Seed===============
+#==================================
+  europe-west3-c: #Master
+    location: Frankfurt
+    country: DE
+    is_seed: true
+    spec:
+      bringyourown: {}
+#==================================
+#===========Digitalocean===========
+#==================================
+  do-ams3:
+    location: Amsterdam
+    seed: europe-west3-c
+    country: NL
+    spec:
+      digitalocean:
+        region: ams3
+#==================================
+#============OpenStack=============
+#==================================
+  auos-1:
+    location: Australia
+    seed: europe-west3-c
+    country: AU
+    spec:
+      openstack:
+        availability_zone: au1
+        region: au
+        dns_servers:
+        - "8.8.8.8"
+        - "8.8.4.4"
+        images:
+          ubuntu: "Ubuntu 18.04 LTS - 2018-08-10"
+          centos: ""
+          coreos: ""
+        enforce_floating_ip: true`
+	expectedSeeds := map[string]*kubermaticv1.Seed{
+		"europe-west3-c": {
+			ObjectMeta: metav1.ObjectMeta{
+				Name: "europe-west3-c",
+			},
+			Spec: kubermaticv1.SeedSpec{
+				Location: "Frankfurt",
+				Country:  "DE",
+				Datacenters: map[string]kubermaticv1.Datacenter{
+					"do-ams3": {
+						Location: "Amsterdam",
+						Country:  "NL",
+						Spec: kubermaticv1.DatacenterSpec{
+							Digitalocean: &kubermaticv1.DatacenterSpecDigitalocean{
+								Region: "ams3",
+							},
+						},
+					},
+					"auos-1": {
+						Location: "Australia",
+						Country:  "AU",
+						Spec: kubermaticv1.DatacenterSpec{
+							Openstack: &kubermaticv1.DatacenterSpecOpenstack{
+								AvailabilityZone: "au1",
+								Region:           "au",
+								DNSServers:       []string{"8.8.8.8", "8.8.4.4"},
+								Images: kubermaticv1.ImageList{
+									providerconfig.OperatingSystemUbuntu: "Ubuntu 18.04 LTS - 2018-08-10",
+									providerconfig.OperatingSystemCentOS: "",
+									providerconfig.OperatingSystemCoreos: "",
+								},
+								EnforceFloatingIP: true,
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+
+	file, err := ioutil.TempFile(os.TempDir(), "")
+	if !assert.NoError(t, err) {
+		t.FailNow()
+	}
+	defer os.Remove(file.Name()) // nolint: errcheck
+	defer file.Close()           // nolint: errcheck
+
+	_, err = file.WriteString(datacentersYAML)
+	assert.NoError(t, err)
+
+	err = file.Sync()
+	assert.NoError(t, err)
+
+	resultDatacenters, err := LoadSeeds(file.Name())
+	if err != nil {
+		t.Fatalf("failed to load datacenters: %v", err)
+	}
+
+	assert.Equal(t, expectedSeeds, resultDatacenters)
+}
+
+func TestMigrateDatacenters(t *testing.T) {
+	testCases := []struct {
+		name        string
+		datacenters map[string]DatacenterMeta
+		errExpected bool
+	}{
+		{
+			name: "Invalid name, error",
+			datacenters: map[string]DatacenterMeta{
+				"&invalid": {
+					IsSeed: true,
+				},
+			},
+			errExpected: true,
+		},
+		{
+			name: "Valid name succeeds",
+			datacenters: map[string]DatacenterMeta{
+				"valid": {
+					IsSeed: true,
+				},
+			},
+		},
+		{
+			name: "Invalid name, valid seed dns override",
+			datacenters: map[string]DatacenterMeta{
+				"&invalid": {
+					IsSeed:           true,
+					SeedDNSOverwrite: "valid",
+				},
+			},
+		},
+		{
+			name: "Valid name, invalid seed dns override",
+			datacenters: map[string]DatacenterMeta{
+				"valid": {
+					IsSeed:           true,
+					SeedDNSOverwrite: "&invalid",
+				},
+			},
+			errExpected: true,
+		},
+	}
+
+	for _, tc := range testCases {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			seeds, err := DatacenterMetasToSeeds(tc.datacenters)
+			if err != nil {
+				t.Fatalf("Failed to convert datacenters to seeds: %v", err)
+			}
+
+			for _, seed := range seeds {
+				if err := ValidateSeed(seed); (err != nil) != tc.errExpected {
+					t.Fatalf("Expected err: %t, but got err: %v", tc.errExpected, err)
+				}
+			}
+		})
+	}
+}

--- a/api/pkg/provider/conversions.go
+++ b/api/pkg/provider/conversions.go
@@ -9,69 +9,6 @@ import (
 	"github.com/kubermatic/kubermatic/api/pkg/util/errors"
 )
 
-// We can not convert a single DatacenterMeta as the SeedDatacenter contains its NodeDatacenter
-// which is also represented as a DatacenterMeta, hence we have to do it all at once
-// TODO: Get rid of this once we don't support datacenters.yaml anymore
-func DatacenterMetasToSeeds(dm map[string]DatacenterMeta) (map[string]*kubermaticv1.Seed, error) {
-
-	seeds := map[string]*kubermaticv1.Seed{}
-
-	for dcName, datacenterSpec := range dm {
-		if datacenterSpec.IsSeed && datacenterSpec.Seed != "" {
-			return nil, fmt.Errorf("datacenter %q is configured as seed but has a seed configured (%q) which is only allowed for datacenters that are not a seed", dcName, datacenterSpec.Seed)
-		}
-		if !datacenterSpec.IsSeed && datacenterSpec.Seed == "" {
-			return nil, fmt.Errorf("datacenter %q is not configured as seed but does not have a corresponding seed configured. Configuring a seed datacenter is required for all node datacenters", dcName)
-		}
-
-		if datacenterSpec.IsSeed {
-			// Keep existing map entries, because its possible that a NodeDC that uses this SeedDC
-			// came before the SeedDC in the loop
-			if seeds[dcName] == nil {
-				seeds[dcName] = &kubermaticv1.Seed{
-					Spec: kubermaticv1.SeedSpec{
-						Datacenters: map[string]kubermaticv1.Datacenter{},
-					},
-				}
-			}
-
-			seeds[dcName].Name = dcName
-			seeds[dcName].Spec.Country = datacenterSpec.Country
-			seeds[dcName].Spec.Location = datacenterSpec.Location
-			seeds[dcName].Spec.SeedDNSOverwrite = datacenterSpec.SeedDNSOverwrite
-
-			// Kubeconfig object ref is injected during the automated migration.
-		} else {
-			if _, exists := dm[datacenterSpec.Seed]; !exists {
-				return nil, fmt.Errorf("seedDatacenter %q used by node datacenter %q does not exist", datacenterSpec.Seed, dcName)
-			}
-			if !dm[datacenterSpec.Seed].IsSeed {
-				return nil, fmt.Errorf("datacenter %q referenced by node datacenter %q as its seed is not configured to be a seed",
-					datacenterSpec.Seed, dcName)
-
-			}
-			// Create entry for SeedDC if not already present
-			if seeds[datacenterSpec.Seed] == nil {
-				seeds[datacenterSpec.Seed] = &kubermaticv1.Seed{
-					Spec: kubermaticv1.SeedSpec{
-						Datacenters: map[string]kubermaticv1.Datacenter{},
-					},
-				}
-
-			}
-			seeds[datacenterSpec.Seed].Spec.Datacenters[dcName] = kubermaticv1.Datacenter{
-				Country:  datacenterSpec.Country,
-				Location: datacenterSpec.Location,
-				Node:     datacenterSpec.Node,
-				Spec:     datacenterSpec.Spec,
-			}
-
-		}
-	}
-
-	return seeds, nil
-}
-
 // Needed because the cloud providers are initialized once during startup and get all
 // DCs.
 // We need to change the cloud providers to by dynamically initialized when needed instead

--- a/api/pkg/provider/datacenter.go
+++ b/api/pkg/provider/datacenter.go
@@ -2,37 +2,19 @@ package provider
 
 import (
 	"context"
-	"errors"
-	"fmt"
-	"io/ioutil"
-	"strings"
 
 	kubermaticv1 "github.com/kubermatic/kubermatic/api/pkg/crd/kubermatic/v1"
-	kubermaticlog "github.com/kubermatic/kubermatic/api/pkg/log"
 	"github.com/kubermatic/kubermatic/api/pkg/util/restmapper"
-	providerconfig "github.com/kubermatic/machine-controller/pkg/providerconfig/types"
 
-	corev1 "k8s.io/api/core/v1"
-	kerrors "k8s.io/apimachinery/pkg/api/errors"
-	"k8s.io/apimachinery/pkg/types"
-	"k8s.io/apimachinery/pkg/util/sets"
-	"k8s.io/apimachinery/pkg/util/validation"
 	"k8s.io/client-go/rest"
-	"k8s.io/client-go/tools/clientcmd"
 	ctrlruntimeclient "sigs.k8s.io/controller-runtime/pkg/client"
-	"sigs.k8s.io/yaml"
 )
 
-var (
-	allOperatingSystems = sets.NewString()
+const (
+	// defaultSeedName is the name of the Seed resource that is used
+	// in the Community Edition, which is limited to a single seed.
+	defaultSeedName = "kubermatic"
 )
-
-func init() {
-	// build a quicker, convenient lookup mechanism
-	for _, os := range providerconfig.AllOperatingSystems {
-		allOperatingSystems.Insert(string(os))
-	}
-}
 
 // SeedGetter is a function to retrieve a single seed
 type SeedGetter = func() (*kubermaticv1.Seed, error)
@@ -52,104 +34,6 @@ type ClusterProviderGetter = func(seed *kubermaticv1.Seed) (ClusterProvider, err
 // AddonProviderGetterr is used to get an AddonProvider
 type AddonProviderGetter = func(seed *kubermaticv1.Seed) (AddonProvider, error)
 
-// DatacenterMeta describes a Kubermatic datacenter.
-type DatacenterMeta struct {
-	Location         string                      `json:"location"`
-	Seed             string                      `json:"seed"`
-	Country          string                      `json:"country"`
-	Spec             kubermaticv1.DatacenterSpec `json:"spec"`
-	IsSeed           bool                        `json:"is_seed"`
-	SeedDNSOverwrite string                      `json:"seed_dns_overwrite,omitempty"`
-	Node             kubermaticv1.NodeSettings   `json:"node,omitempty"`
-}
-
-// datacentersMeta describes a number of Kubermatic datacenters.
-type datacentersMeta struct {
-	Datacenters map[string]DatacenterMeta `json:"datacenters"`
-}
-
-// LoadSeeds loads all Datacenters from the given path.
-func LoadSeeds(path string) (map[string]*kubermaticv1.Seed, error) {
-	bytes, err := ioutil.ReadFile(path)
-	if err != nil {
-		return nil, fmt.Errorf("failed to read datacenter.yaml: %v", err)
-	}
-
-	dcMetas := datacentersMeta{}
-	if err := yaml.UnmarshalStrict(bytes, &dcMetas); err != nil {
-		return nil, fmt.Errorf("failed to parse datacenters.yaml: %v", err)
-	}
-
-	seeds, err := DatacenterMetasToSeeds(dcMetas.Datacenters)
-	if err != nil {
-		return nil, fmt.Errorf("failed to convert datacenters.yaml: %v", err)
-	}
-
-	for seedName, seed := range seeds {
-		if err := ValidateSeed(seed); err != nil {
-			return nil, fmt.Errorf("failed to validate datacenters.yaml: seed %q is invalid: %v", seedName, err)
-		}
-	}
-
-	return seeds, nil
-}
-
-// LoadSeed loads an existing datacenters.yaml from disk and returns the given
-// datacenter as a seed or an error if the datacenter does not exist.
-func LoadSeed(path, datacenterName string) (*kubermaticv1.Seed, error) {
-	seeds, err := LoadSeeds(path)
-	if err != nil {
-		return nil, err
-	}
-
-	datacenter, exists := seeds[datacenterName]
-	if !exists {
-		return nil, fmt.Errorf("datacenter %q is not in datacenters.yaml", datacenterName)
-	}
-
-	return datacenter, nil
-}
-
-func validateImageList(images kubermaticv1.ImageList) error {
-	for s := range images {
-		if !allOperatingSystems.Has(string(s)) {
-			return fmt.Errorf("invalid operating system defined '%s'. Possible values: %s", s, strings.Join(allOperatingSystems.List(), ","))
-		}
-	}
-
-	return nil
-}
-
-// ValidateSeed takes a seed and returns an error if the seed's spec is invalid.
-func ValidateSeed(seed *kubermaticv1.Seed) error {
-	for name, dc := range seed.Spec.Datacenters {
-		if dc.Spec.VSphere != nil {
-			if err := validateImageList(dc.Spec.VSphere.Templates); err != nil {
-				return fmt.Errorf("invalid datacenter defined '%s': %v", name, err)
-			}
-		}
-		if dc.Spec.Openstack != nil {
-			if err := validateImageList(dc.Spec.Openstack.Images); err != nil {
-				return fmt.Errorf("invalid datacenter defined '%s': %v", name, err)
-			}
-		}
-	}
-
-	// invalid DNS overwrites can happen when a seed was freshly converted from
-	// the datacenters.yaml and has not yet been validated
-	if seed.Spec.SeedDNSOverwrite != "" {
-		if errs := validation.IsDNS1123Subdomain(seed.Spec.SeedDNSOverwrite); errs != nil {
-			return fmt.Errorf("DNS overwrite %q is not a valid DNS name: %v", seed.Spec.SeedDNSOverwrite, errs)
-		}
-	} else {
-		if errs := validation.IsDNS1123Subdomain(seed.Name); errs != nil {
-			return fmt.Errorf("seed name %q is not a valid DNS name: %v", seed.Name, errs)
-		}
-	}
-
-	return nil
-}
-
 // SeedGetterFactory returns a SeedGetter. It has validation of all its arguments
 func SeedGetterFactory(ctx context.Context, client ctrlruntimeclient.Client, seedName, dcFile, namespace string, dynamicDatacenters bool) (SeedGetter, error) {
 	seedGetter, err := seedGetterFactory(ctx, client, seedName, dcFile, namespace, dynamicDatacenters)
@@ -164,35 +48,6 @@ func SeedGetterFactory(ctx context.Context, client ctrlruntimeclient.Client, see
 		seed.SetDefaults()
 		return seed, nil
 	}, nil
-}
-
-func seedGetterFactory(ctx context.Context, client ctrlruntimeclient.Client, seedName, dcFile, namespace string, dynamicDatacenters bool) (SeedGetter, error) {
-	if dynamicDatacenters {
-		return func() (*kubermaticv1.Seed, error) {
-			seed := &kubermaticv1.Seed{}
-			if err := client.Get(ctx, types.NamespacedName{Namespace: namespace, Name: seedName}, seed); err != nil {
-				// allow callers to handle this gracefully
-				if kerrors.IsNotFound(err) {
-					return nil, err
-				}
-				return nil, fmt.Errorf("failed to get seed %q: %v", seedName, err)
-			}
-			return seed, nil
-		}, nil
-	}
-
-	if dcFile == "" {
-		return nil, errors.New("--datacenters is required")
-	}
-	// Make sure we fail early, an error here is not recoverable
-	seed, err := LoadSeed(dcFile, seedName)
-	if err != nil {
-		return nil, err
-	}
-	return func() (*kubermaticv1.Seed, error) {
-		return seed.DeepCopy(), nil
-	}, nil
-
 }
 
 func SeedsGetterFactory(ctx context.Context, client ctrlruntimeclient.Client, dcFile, namespace string, dynamicDatacenters bool) (SeedsGetter, error) {
@@ -212,98 +67,8 @@ func SeedsGetterFactory(ctx context.Context, client ctrlruntimeclient.Client, dc
 	}, nil
 }
 
-func seedsGetterFactory(ctx context.Context, client ctrlruntimeclient.Client, dcFile, namespace string, dynamicDatacenters bool) (SeedsGetter, error) {
-	if dynamicDatacenters {
-		// We only have a options func for raw *metav1.ListOpts as the rbac controller currently required that
-		listOpts := &ctrlruntimeclient.ListOptions{
-			Namespace: namespace,
-		}
-
-		return func() (map[string]*kubermaticv1.Seed, error) {
-			seeds := &kubermaticv1.SeedList{}
-			if err := client.List(ctx, seeds, listOpts); err != nil {
-				return nil, fmt.Errorf("failed to list the seeds: %v", err)
-			}
-			seedMap := map[string]*kubermaticv1.Seed{}
-			for idx, seed := range seeds.Items {
-				seedMap[seed.Name] = &seeds.Items[idx]
-			}
-			return seedMap, nil
-		}, nil
-	}
-
-	if dcFile == "" {
-		return nil, errors.New("--datacenters is required")
-	}
-	// Make sure we fail early, an error here is not recoverable
-	seedMap, err := LoadSeeds(dcFile)
-	if err != nil {
-		return nil, err
-	}
-
-	return func() (map[string]*kubermaticv1.Seed, error) {
-		// copy it, just to be safe
-		mapToReturn := map[string]*kubermaticv1.Seed{}
-		for k, v := range seedMap {
-			mapToReturn[k] = v.DeepCopy()
-		}
-		return mapToReturn, nil
-	}, nil
-}
-
-func SeedKubeconfigGetterFactory(
-	ctx context.Context,
-	client ctrlruntimeclient.Client,
-	kubeconfigFilePath,
-	namespace string,
-	dynamicDatacenters bool) (SeedKubeconfigGetter, error) {
-
-	if dynamicDatacenters {
-		return func(seed *kubermaticv1.Seed) (*rest.Config, error) {
-			secret := &corev1.Secret{}
-			name := types.NamespacedName{
-				Namespace: seed.Spec.Kubeconfig.Namespace,
-				Name:      seed.Spec.Kubeconfig.Name,
-			}
-			if err := client.Get(ctx, name, secret); err != nil {
-				return nil, fmt.Errorf("failed to get kubeconfig secret %q: %v", name.String(), err)
-			}
-
-			fieldPath := seed.Spec.Kubeconfig.FieldPath
-			if len(fieldPath) == 0 {
-				fieldPath = DefaultKubeconfigFieldPath
-			}
-			if _, exists := secret.Data[fieldPath]; !exists {
-				return nil, fmt.Errorf("secret %q has no key %q", name.String(), fieldPath)
-			}
-
-			cfg, err := clientcmd.RESTConfigFromKubeConfig(secret.Data[fieldPath])
-			if err != nil {
-				return nil, fmt.Errorf("failed to load kubeconfig: %v", err)
-			}
-
-			kubermaticlog.Logger.With("seed", seed.Name).Debug("Successfully got kubeconfig")
-			return cfg, nil
-		}, nil
-	}
-
-	if kubeconfigFilePath == "" {
-		return nil, errors.New("--kubeconfig is required when --dynamic-datacenters=false")
-	}
-	kubeconfig, err := clientcmd.LoadFromFile(kubeconfigFilePath)
-	if err != nil {
-		return nil, fmt.Errorf("failed to read kubeconfig from %q: %v", kubeconfigFilePath, err)
-	}
-	return func(seed *kubermaticv1.Seed) (*rest.Config, error) {
-		if _, exists := kubeconfig.Contexts[seed.Name]; !exists {
-			return nil, fmt.Errorf("found no context with name %q in kubeconfig", seed.Name)
-		}
-		cfg, err := clientcmd.NewNonInteractiveClientConfig(*kubeconfig, seed.Name, &clientcmd.ConfigOverrides{}, nil).ClientConfig()
-		if err != nil {
-			return nil, fmt.Errorf("failed to get restConfig for seed %q: %v", seed.Name, err)
-		}
-		return cfg, nil
-	}, nil
+func SeedKubeconfigGetterFactory(ctx context.Context, client ctrlruntimeclient.Client, kubeconfigFilePath, namespace string, dynamicDatacenters bool) (SeedKubeconfigGetter, error) {
+	return seedKubeconfigGetterFactory(ctx, client, kubeconfigFilePath, namespace, dynamicDatacenters)
 }
 
 // SeedClientGetterFactory returns a SeedClientGetter. It uses a RestMapperCache to cache

--- a/api/pkg/provider/datacenter_ce.go
+++ b/api/pkg/provider/datacenter_ce.go
@@ -1,0 +1,79 @@
+// +build !ee
+
+package provider
+
+import (
+	"context"
+	"fmt"
+
+	kubermaticv1 "github.com/kubermatic/kubermatic/api/pkg/crd/kubermatic/v1"
+	kubermaticlog "github.com/kubermatic/kubermatic/api/pkg/log"
+
+	corev1 "k8s.io/api/core/v1"
+	kerrors "k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/client-go/rest"
+	"k8s.io/client-go/tools/clientcmd"
+	ctrlruntimeclient "sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+func seedGetterFactory(ctx context.Context, client ctrlruntimeclient.Client, seedName, dcFile, namespace string, dynamicDatacenters bool) (SeedGetter, error) {
+	return func() (*kubermaticv1.Seed, error) {
+		seed := &kubermaticv1.Seed{}
+		if err := client.Get(ctx, types.NamespacedName{Namespace: namespace, Name: seedName}, seed); err != nil {
+			// allow callers to handle this gracefully
+			if kerrors.IsNotFound(err) {
+				return nil, err
+			}
+
+			return nil, fmt.Errorf("failed to get seed %q: %v", seedName, err)
+		}
+
+		return seed, nil
+	}, nil
+}
+
+func seedsGetterFactory(ctx context.Context, client ctrlruntimeclient.Client, dcFile, namespace string, dynamicDatacenters bool) (SeedsGetter, error) {
+	return func() (map[string]*kubermaticv1.Seed, error) {
+		seed := &kubermaticv1.Seed{}
+		if err := client.Get(ctx, types.NamespacedName{Namespace: namespace, Name: defaultSeedName}, seed); err != nil {
+			if kerrors.IsNotFound(err) {
+				return nil, err
+			}
+
+			return nil, fmt.Errorf("failed to get seed %q: %v", defaultSeedName, err)
+		}
+
+		return map[string]*kubermaticv1.Seed{
+			defaultSeedName: seed,
+		}, nil
+	}, nil
+}
+
+func seedKubeconfigGetterFactory(ctx context.Context, client ctrlruntimeclient.Client, kubeconfigFilePath, namespace string, dynamicDatacenters bool) (SeedKubeconfigGetter, error) {
+	return func(seed *kubermaticv1.Seed) (*rest.Config, error) {
+		secret := &corev1.Secret{}
+		name := types.NamespacedName{
+			Namespace: seed.Spec.Kubeconfig.Namespace,
+			Name:      seed.Spec.Kubeconfig.Name,
+		}
+		if err := client.Get(ctx, name, secret); err != nil {
+			return nil, fmt.Errorf("failed to get kubeconfig secret %q: %v", name.String(), err)
+		}
+
+		fieldPath := seed.Spec.Kubeconfig.FieldPath
+		if len(fieldPath) == 0 {
+			fieldPath = DefaultKubeconfigFieldPath
+		}
+		if _, exists := secret.Data[fieldPath]; !exists {
+			return nil, fmt.Errorf("secret %q has no key %q", name.String(), fieldPath)
+		}
+
+		cfg, err := clientcmd.RESTConfigFromKubeConfig(secret.Data[fieldPath])
+		if err != nil {
+			return nil, fmt.Errorf("failed to load kubeconfig: %v", err)
+		}
+		kubermaticlog.Logger.With("seed", seed.Name).Debug("Successfully got kubeconfig")
+		return cfg, nil
+	}, nil
+}

--- a/api/pkg/provider/datacenter_ee.go
+++ b/api/pkg/provider/datacenter_ee.go
@@ -18,6 +18,10 @@ func seedGetterFactory(ctx context.Context, client ctrlruntimeclient.Client, see
 	return eeprovider.SeedGetterFactory(ctx, client, seedName, dcFile, namespace, dynamicDatacenters)
 }
 
-func seedKubeconfigGetterFactory(ctx context.Context, client ctrlruntimeclient.Client, kubeconfigFilePath, namespace string, dynamicDatacenters bool) (SeedKubeconfigGetter, error) {
-	return eeprovider.SeedKubeconfigGetterFactory(ctx, client, kubeconfigFilePath, namespace, dynamicDatacenters)
+func seedKubeconfigGetterFactory(ctx context.Context, client ctrlruntimeclient.Client, kubeconfigFilePath string, dynamicDatacenters bool) (SeedKubeconfigGetter, error) {
+	if dynamicDatacenters {
+		return secretBasedSeedKubeconfigGetterFactory(ctx, client)
+	}
+
+	return eeprovider.KubeconfigBasedSeedKubeconfigGetterFactory(ctx, client, kubeconfigFilePath, dynamicDatacenters)
 }

--- a/api/pkg/provider/datacenter_ee.go
+++ b/api/pkg/provider/datacenter_ee.go
@@ -1,0 +1,23 @@
+// +build ee
+
+package provider
+
+import (
+	"context"
+
+	eeprovider "github.com/kubermatic/kubermatic/api/pkg/ee/provider"
+
+	ctrlruntimeclient "sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+func seedsGetterFactory(ctx context.Context, client ctrlruntimeclient.Client, dcFile, namespace string, dynamicDatacenters bool) (SeedsGetter, error) {
+	return eeprovider.SeedsGetterFactory(ctx, client, dcFile, namespace, dynamicDatacenters)
+}
+
+func seedGetterFactory(ctx context.Context, client ctrlruntimeclient.Client, seedName, dcFile, namespace string, dynamicDatacenters bool) (SeedGetter, error) {
+	return eeprovider.SeedGetterFactory(ctx, client, seedName, dcFile, namespace, dynamicDatacenters)
+}
+
+func seedKubeconfigGetterFactory(ctx context.Context, client ctrlruntimeclient.Client, kubeconfigFilePath, namespace string, dynamicDatacenters bool) (SeedKubeconfigGetter, error) {
+	return eeprovider.SeedKubeconfigGetterFactory(ctx, client, kubeconfigFilePath, namespace, dynamicDatacenters)
+}

--- a/api/pkg/provider/datacenter_test.go
+++ b/api/pkg/provider/datacenter_test.go
@@ -2,189 +2,20 @@ package provider
 
 import (
 	"context"
-	"io/ioutil"
-	"os"
 	"testing"
 
-	"github.com/stretchr/testify/assert"
-
 	kubermaticv1 "github.com/kubermatic/kubermatic/api/pkg/crd/kubermatic/v1"
-	providerconfig "github.com/kubermatic/machine-controller/pkg/providerconfig/types"
 
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/kubernetes/scheme"
 	fakectrlruntimeclient "sigs.k8s.io/controller-runtime/pkg/client/fake"
 )
 
-func TestLoadDatacentersMeta(t *testing.T) {
-	datacentersYAML := `
-datacenters:
-#==================================
-#===============Seed===============
-#==================================
-  europe-west3-c: #Master
-    location: Frankfurt
-    country: DE
-    is_seed: true
-    spec:
-      bringyourown: {}
-#==================================
-#===========Digitalocean===========
-#==================================
-  do-ams3:
-    location: Amsterdam
-    seed: europe-west3-c
-    country: NL
-    spec:
-      digitalocean:
-        region: ams3
-#==================================
-#============OpenStack=============
-#==================================
-  auos-1:
-    location: Australia
-    seed: europe-west3-c
-    country: AU
-    spec:
-      openstack:
-        availability_zone: au1
-        region: au
-        dns_servers:
-        - "8.8.8.8"
-        - "8.8.4.4"
-        images:
-          ubuntu: "Ubuntu 18.04 LTS - 2018-08-10"
-          centos: ""
-          coreos: ""
-        enforce_floating_ip: true`
-	expectedSeeds := map[string]*kubermaticv1.Seed{
-		"europe-west3-c": {
-			ObjectMeta: metav1.ObjectMeta{
-				Name: "europe-west3-c",
-			},
-			Spec: kubermaticv1.SeedSpec{
-				Location: "Frankfurt",
-				Country:  "DE",
-				Datacenters: map[string]kubermaticv1.Datacenter{
-					"do-ams3": {
-						Location: "Amsterdam",
-						Country:  "NL",
-						Spec: kubermaticv1.DatacenterSpec{
-							Digitalocean: &kubermaticv1.DatacenterSpecDigitalocean{
-								Region: "ams3",
-							},
-						},
-					},
-					"auos-1": {
-						Location: "Australia",
-						Country:  "AU",
-						Spec: kubermaticv1.DatacenterSpec{
-							Openstack: &kubermaticv1.DatacenterSpecOpenstack{
-								AvailabilityZone: "au1",
-								Region:           "au",
-								DNSServers:       []string{"8.8.8.8", "8.8.4.4"},
-								Images: kubermaticv1.ImageList{
-									providerconfig.OperatingSystemUbuntu: "Ubuntu 18.04 LTS - 2018-08-10",
-									providerconfig.OperatingSystemCentOS: "",
-									providerconfig.OperatingSystemCoreos: "",
-								},
-								EnforceFloatingIP: true,
-							},
-						},
-					},
-				},
-			},
-		},
-	}
-
-	file, err := ioutil.TempFile(os.TempDir(), "")
-	if !assert.NoError(t, err) {
-		t.FailNow()
-	}
-	defer os.Remove(file.Name()) // nolint: errcheck
-	defer file.Close()           // nolint: errcheck
-
-	_, err = file.WriteString(datacentersYAML)
-	assert.NoError(t, err)
-
-	err = file.Sync()
-	assert.NoError(t, err)
-
-	resultDatacenters, err := LoadSeeds(file.Name())
-	if err != nil {
-		t.Fatalf("failed to load datacenters: %v", err)
-	}
-
-	assert.Equal(t, expectedSeeds, resultDatacenters)
-}
-
-func TestMigrateDatacenters(t *testing.T) {
-	testCases := []struct {
-		name        string
-		datacenters map[string]DatacenterMeta
-		errExpected bool
-	}{
-		{
-			name: "Invalid name, error",
-			datacenters: map[string]DatacenterMeta{
-				"&invalid": {
-					IsSeed: true,
-				},
-			},
-			errExpected: true,
-		},
-		{
-			name: "Valid name succeeds",
-			datacenters: map[string]DatacenterMeta{
-				"valid": {
-					IsSeed: true,
-				},
-			},
-		},
-		{
-			name: "Invalid name, valid seed dns override",
-			datacenters: map[string]DatacenterMeta{
-				"&invalid": {
-					IsSeed:           true,
-					SeedDNSOverwrite: "valid",
-				},
-			},
-		},
-		{
-			name: "Valid name, invalid seed dns override",
-			datacenters: map[string]DatacenterMeta{
-				"valid": {
-					IsSeed:           true,
-					SeedDNSOverwrite: "&invalid",
-				},
-			},
-			errExpected: true,
-		},
-	}
-
-	for _, tc := range testCases {
-		tc := tc
-		t.Run(tc.name, func(t *testing.T) {
-			t.Parallel()
-			seeds, err := DatacenterMetasToSeeds(tc.datacenters)
-			if err != nil {
-				t.Fatalf("Failed to convert datacenters to seeds: %v", err)
-			}
-
-			for _, seed := range seeds {
-				if err := ValidateSeed(seed); (err != nil) != tc.errExpected {
-					t.Fatalf("Expected err: %t, but got err: %v", tc.errExpected, err)
-				}
-			}
-		})
-	}
-}
-
 func TestSeedGetterFactorySetsDefaults(t *testing.T) {
 	t.Parallel()
 	initSeed := &kubermaticv1.Seed{
 		ObjectMeta: metav1.ObjectMeta{
-			Name:      "my-seed",
+			Name:      defaultSeedName,
 			Namespace: "my-ns",
 		},
 		Spec: kubermaticv1.SeedSpec{
@@ -196,7 +27,7 @@ func TestSeedGetterFactorySetsDefaults(t *testing.T) {
 	}
 	client := fakectrlruntimeclient.NewFakeClientWithScheme(scheme.Scheme, initSeed)
 
-	seedGetter, err := SeedGetterFactory(context.Background(), client, "my-seed", "", "my-ns", true)
+	seedGetter, err := SeedGetterFactory(context.Background(), client, defaultSeedName, "", "my-ns", true)
 	if err != nil {
 		t.Fatalf("failed getting seedGetter: %v", err)
 	}
@@ -214,7 +45,7 @@ func TestSeedsGetterFactorySetsDefaults(t *testing.T) {
 	t.Parallel()
 	initSeed := &kubermaticv1.Seed{
 		ObjectMeta: metav1.ObjectMeta{
-			Name:      "my-seed",
+			Name:      defaultSeedName,
 			Namespace: "my-ns",
 		},
 		Spec: kubermaticv1.SeedSpec{
@@ -234,10 +65,10 @@ func TestSeedsGetterFactorySetsDefaults(t *testing.T) {
 	if err != nil {
 		t.Fatalf("failed calling seedsGetter: %v", err)
 	}
-	if _, exists := seeds["my-seed"]; !exists || len(seeds) != 1 {
+	if _, exists := seeds[defaultSeedName]; !exists || len(seeds) != 1 {
 		t.Fatalf("expceted to get a map with exactly one key `my-seed`, got %v", seeds)
 	}
-	seed := seeds["my-seed"]
+	seed := seeds[defaultSeedName]
 	if seed.Spec.Datacenters["a"].Node.ProxySettings.HTTPProxy.String() != "seed-proxy" {
 		t.Errorf("expected the datacenters http proxy setting to get set but was %v",
 			seed.Spec.Datacenters["a"].Node.ProxySettings.HTTPProxy)

--- a/api/pkg/util/yaml/print.go
+++ b/api/pkg/util/yaml/print.go
@@ -1,0 +1,21 @@
+package yaml
+
+import (
+	"io"
+
+	yaml3 "gopkg.in/yaml.v3"
+
+	"k8s.io/test-infra/pkg/genyaml"
+)
+
+// Encode takes a runtime object and creates a YAML encoded version in the
+// given output. The special aspect of this function is that it does not
+// output the creationTimestamp when marshalling a syntetic resource. This
+// just makes the YAML look nicer when presented to the enduser.
+func Encode(resource interface{}, output io.Writer) error {
+	encoder := yaml3.NewEncoder(output)
+	encoder.SetIndent(2)
+
+	// genyaml is smart enough to not output a creationTimestamp when marshalling as YAML
+	return genyaml.NewCommentMap().EncodeYaml(resource, encoder)
+}


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR introduces the distinction between a *Community Edition* (ce) and an *Enterprise Edition* (ee). For this it makes use of Go build tags (`-tags ee`) to load alternative implementations during build time. By default the Kubermatic source code builds a Community Edition (typing `make` will get you a CE).

This PR also makes the multi seed implementation in Kubermatic an Enterprise feature. While most of the codebase still works based on `map[string]Seed`, the Community edition will always only work with a single seed (so `len(seedMap) == 1` everywhere). So the SeedsGetter will always return a 1-element map and the SeedGetter will always only work with a Seed named `kubermatic`. I had to make a decision as to what happens when a user is creating a second Seed resource: Prefer the first? The oldest? The largest? I settled on "In the community edition, the Seed must always be named `kubermatic`."

Restricting seeds in the datacenters.yaml however was pointless. Since the datacenters.yaml is already just a legacy feature, I decided to remove it entirely from the Community Edition.

There is still lots of leftovers (like the `-datacenters` flag, which is 100% useless in the CE) that we need to adjust later. Similarily, we have a bunch of controllers that don't use the seedsGetter/seedGetter, but rather use informers to directly watch Seed resources. These controllers also need to be looked at and maybe adjusted. We could also extend the Seed Validation Webhook to reject any Seed not named "kubermatic".

With regards to the code, this PR is not pretty. To have directory-based licensing, I needed to extract a few things into their own packages and then add even more packages to fix circular dependencies.

The environment variable `KUBERMATIC_EDITION` is used during CI to toggle what version we build. I think we will maybe have distinct jobs for CE and EE, which would just differ in this variable, but I'm not sure yet. For now the build artifacts are EE and therefore compatible with the rest of our infrastructure.

**Does this PR introduce a user-facing change?**:
```release-note
NONE
```
