### PR TITLE
Add datastore and datastore cluster configs on cluster level

### DIFF
--- a/.prow.yaml
+++ b/.prow.yaml
@@ -1012,6 +1012,47 @@ presubmits:
           limits:
             memory: 4Gi
 
+  - name: pre-kubermatic-e2e-vsphere-coreos-1.18-datastore-cluster
+    decorate: true
+    optional: true
+    run_if_changed: "pkg/provider/cloud/vsphere"
+    clone_uri: "ssh://git@github.com/kubermatic/kubermatic.git"
+    labels:
+      preset-vsphere: "true"
+      preset-vault: "true"
+      preset-docker-pull: "true"
+      preset-docker-push: "true"
+      preset-repo-ssh: "true"
+      preset-kubeconfig-ci: "true"
+      preset-kind-volume-mounts: "true"
+    spec:
+      containers:
+        - image: quay.io/kubermatic/e2e-kind:with-conformance-tests-v1.0.17
+          env:
+            - name: KUBERMATIC_EDITION
+              value: ee
+            - name: VERSIONS_TO_TEST
+              value: "v1.18.6"
+            - name: PROVIDER
+              value: "vsphere"
+            - name: SCENARIO_OPTIONS
+              value: "datastore-cluster"
+            - name: SERVICE_ACCOUNT_KEY
+              valueFrom:
+                secretKeyRef:
+                  name: e2e-ci
+                  key: serviceAccountSigningKey
+          command:
+            - "./hack/ci/ci-kind-e2e.sh"
+          # docker-in-docker needs privileged mode
+          securityContext:
+            privileged: true
+          resources:
+            requests:
+              memory: 4Gi
+              cpu: 3.5
+            limits:
+              memory: 4Gi
   #########################################################
   # Base Openshift Tests
   #########################################################

--- a/cmd/conformance-tests/main.go
+++ b/cmd/conformance-tests/main.go
@@ -466,6 +466,7 @@ func getScenarios(opts Opts, log *zap.SugaredLogger) []testScenario {
 		opts.excludeSelector.Distributions[providerconfig.OperatingSystemCentOS] = false
 		opts.excludeSelector.Distributions[providerconfig.OperatingSystemSLES] = true
 		opts.excludeSelector.Distributions[providerconfig.OperatingSystemRHEL] = true
+		opts.excludeSelector.Distributions[providerconfig.OperatingSystemFlatcar] = true
 	}
 
 	scenarioOptions := strings.Split(opts.scenarioOptions, ",")

--- a/cmd/conformance-tests/scenarios_vsphere.go
+++ b/cmd/conformance-tests/scenarios_vsphere.go
@@ -25,12 +25,17 @@ import (
 
 // Returns a matrix of (version x operating system)
 func getVSphereScenarios(scenarioOptions []string, versions []*semver.Semver) []testScenario {
-	var customFolder bool
+	var (
+		customFolder     bool
+		datastoreCluster bool
+	)
 
 	for _, opt := range scenarioOptions {
 		switch opt {
 		case "custom-folder":
 			customFolder = true
+		case "datastore-cluster":
+			datastoreCluster = true
 		}
 	}
 
@@ -42,7 +47,8 @@ func getVSphereScenarios(scenarioOptions []string, versions []*semver.Semver) []
 			nodeOsSpec: apimodels.OperatingSystemSpec{
 				Ubuntu: &apimodels.UbuntuSpec{},
 			},
-			customFolder: customFolder,
+			customFolder:     customFolder,
+			datastoreCluster: datastoreCluster,
 		})
 		// CoreOS
 		scenarios = append(scenarios, &vSphereScenario{
@@ -53,7 +59,8 @@ func getVSphereScenarios(scenarioOptions []string, versions []*semver.Semver) []
 					DisableAutoUpdate: true,
 				},
 			},
-			customFolder: customFolder,
+			customFolder:     customFolder,
+			datastoreCluster: datastoreCluster,
 		})
 		// CentOS
 		scenarios = append(scenarios, &vSphereScenario{
@@ -61,7 +68,8 @@ func getVSphereScenarios(scenarioOptions []string, versions []*semver.Semver) []
 			nodeOsSpec: apimodels.OperatingSystemSpec{
 				Centos: &apimodels.CentOSSpec{},
 			},
-			customFolder: customFolder,
+			customFolder:     customFolder,
+			datastoreCluster: datastoreCluster,
 		})
 	}
 
@@ -69,9 +77,10 @@ func getVSphereScenarios(scenarioOptions []string, versions []*semver.Semver) []
 }
 
 type vSphereScenario struct {
-	version      *semver.Semver
-	nodeOsSpec   apimodels.OperatingSystemSpec
-	customFolder bool
+	version          *semver.Semver
+	nodeOsSpec       apimodels.OperatingSystemSpec
+	customFolder     bool
+	datastoreCluster bool
 }
 
 func (s *vSphereScenario) Name() string {
@@ -86,8 +95,9 @@ func (s *vSphereScenario) Cluster(secrets secrets) *apimodels.CreateClusterSpec 
 				Cloud: &apimodels.CloudSpec{
 					DatacenterName: "vsphere-ger",
 					Vsphere: &apimodels.VSphereCloudSpec{
-						Username: secrets.VSphere.Username,
-						Password: secrets.VSphere.Password,
+						Username:  secrets.VSphere.Username,
+						Password:  secrets.VSphere.Password,
+						Datastore: "exsi-nas",
 					},
 				},
 				Version: s.version.String(),
@@ -97,6 +107,11 @@ func (s *vSphereScenario) Cluster(secrets secrets) *apimodels.CreateClusterSpec 
 
 	if s.customFolder {
 		spec.Cluster.Spec.Cloud.Vsphere.Folder = "/dc-1/vm/e2e-tests/custom_folder_test"
+	}
+
+	if s.datastoreCluster {
+		spec.Cluster.Spec.Cloud.Vsphere.DatastoreCluster = "dsc-1"
+		spec.Cluster.Spec.Cloud.Vsphere.Datastore = ""
 	}
 
 	return spec

--- a/cmd/kubermatic-api/swagger.json
+++ b/cmd/kubermatic-api/swagger.json
@@ -10164,9 +10164,9 @@
           "x-go-name": "Datacenter"
         },
         "datastore": {
-          "description": "The name of the datastore to use.",
+          "description": "The name of the default Datastore to be used for provisioning volumes\nusing storage classes/dynamic provisioning and for storing virtual\nmachine files in case no `Datastore` or `DatastoreCluster` is provided\nwith the `VSphereCloudSpec`.",
           "type": "string",
-          "x-go-name": "Datastore"
+          "x-go-name": "DefaultDatastore"
         },
         "endpoint": {
           "description": "Endpoint URL to use, including protocol, for example \"https://vcenter.example.com\".",
@@ -12963,7 +12963,18 @@
         "credentialsReference": {
           "$ref": "#/definitions/GlobalSecretKeySelector"
         },
+        "datastore": {
+          "description": "Datastore to be used for storing virtual machines, it is mutually\nexclusive with DatastoreCluster.\n+optional",
+          "type": "string",
+          "x-go-name": "Datastore"
+        },
+        "datastoreCluster": {
+          "description": "DatastoreCluster to be used for determining the Datastore for virtual\nmachines, it is mutually exclusive with Datastore.\n+optional",
+          "type": "string",
+          "x-go-name": "DatastoreCluster"
+        },
         "folder": {
+          "description": "Folder is the folder to be used to group the provisioned virtual\nmachines.\n+optional",
           "type": "string",
           "x-go-name": "Folder"
         },
@@ -12971,14 +12982,17 @@
           "$ref": "#/definitions/VSphereCredentials"
         },
         "password": {
+          "description": "Password is the vSphere user password.\n+optional",
           "type": "string",
           "x-go-name": "Password"
         },
         "username": {
+          "description": "Username is the vSphere user name.\n+optional",
           "type": "string",
           "x-go-name": "Username"
         },
         "vmNetName": {
+          "description": "VMNetName is the name of the vSphere network.",
           "type": "string",
           "x-go-name": "VMNetName"
         }

--- a/docs/zz_generated.seed.yaml
+++ b/docs/zz_generated.seed.yaml
@@ -146,7 +146,10 @@ spec:
           cluster: ""
           # The name of the datacenter to use.
           datacenter: ""
-          # The name of the datastore to use.
+          # The name of the default Datastore to be used for provisioning volumes
+          # using storage classes/dynamic provisioning and for storing virtual
+          # machine files in case no `Datastore` or `DatastoreCluster` is provided
+          # with the `VSphereCloudSpec`.
           datastore: ""
           # Endpoint URL to use, including protocol, for example "https://vcenter.example.com".
           endpoint: ""

--- a/pkg/api/v1/types_test.go
+++ b/pkg/api/v1/types_test.go
@@ -110,6 +110,7 @@ func TestNewClusterSpec_MarshalJSON(t *testing.T) {
 							Password: valueToBeFiltered,
 						},
 						VMNetName: "vmNetName",
+						Datastore: "testDataStore",
 					},
 				},
 			},

--- a/pkg/crd/kubermatic/v1/cluster.go
+++ b/pkg/crd/kubermatic/v1/cluster.go
@@ -444,10 +444,30 @@ type VSphereCredentials struct {
 type VSphereCloudSpec struct {
 	CredentialsReference *providerconfig.GlobalSecretKeySelector `json:"credentialsReference,omitempty"`
 
-	Username  string `json:"username,omitempty"`
-	Password  string `json:"password,omitempty"`
+	// Username is the vSphere user name.
+	// +optional
+	Username string `json:"username"`
+	// Password is the vSphere user password.
+	// +optional
+	Password string `json:"password"`
+	// VMNetName is the name of the vSphere network.
 	VMNetName string `json:"vmNetName"`
-	Folder    string `json:"folder,omitempty"`
+	// Folder is the folder to be used to group the provisioned virtual
+	// machines.
+	// +optional
+	Folder string `json:"folder"`
+	// If both Datastore and DatastoreCluster are not specified the virtual
+	// machines are stored in the `DefaultDatastore` specified in the
+	// Datacenter.
+
+	// Datastore to be used for storing virtual machines, it is mutually
+	// exclusive with DatastoreCluster.
+	// +optional
+	Datastore string `json:"datastore,omitempty"`
+	// DatastoreCluster to be used for determining the Datastore for virtual
+	// machines, it is mutually exclusive with Datastore.
+	// +optional
+	DatastoreCluster string `json:"datastoreCluster,omitempty"`
 
 	// This user will be used for everything except cloud provider functionality
 	InfraManagementUser VSphereCredentials `json:"infraManagementUser"`

--- a/pkg/crd/kubermatic/v1/datacenter.go
+++ b/pkg/crd/kubermatic/v1/datacenter.go
@@ -229,8 +229,11 @@ type DatacenterSpecVSphere struct {
 	Endpoint string `json:"endpoint"`
 	// If set to true, disables the TLS certificate check against the endpoint.
 	AllowInsecure bool `json:"allow_insecure"`
-	// The name of the datastore to use.
-	Datastore string `json:"datastore"`
+	// The name of the default Datastore to be used for provisioning volumes
+	// using storage classes/dynamic provisioning and for storing virtual
+	// machine files in case no `Datastore` or `DatastoreCluster` is provided
+	// with the `VSphereCloudSpec`.
+	DefaultDatastore string `json:"datastore"`
 	// The name of the datacenter to use.
 	Datacenter string `json:"datacenter"`
 	// The name of the Kubernetes cluster to use.

--- a/pkg/crd/kubermatic/v1/preset.go
+++ b/pkg/crd/kubermatic/v1/preset.go
@@ -95,9 +95,10 @@ type VSphere struct {
 	Username string `json:"username"`
 	Password string `json:"password"`
 
-	VMNetName string `json:"vmNetName,omitempty"`
-
-	Datacenter string `json:"datacenter,omitempty"`
+	VMNetName        string `json:"vmNetName,omitempty"`
+	Datastore        string `json:"datastore,omitempty"`
+	DatastoreCluster string `json:"datastoreCluster,omitempty"`
+	Datacenter       string `json:"datacenter,omitempty"`
 }
 
 type AWS struct {

--- a/pkg/handler/v1/provider/vsphere_test.go
+++ b/pkg/handler/v1/provider/vsphere_test.go
@@ -125,12 +125,12 @@ func (v *vSphereMock) buildVSphereDatacenter() provider.SeedsGetter {
 							Country:  "Moon States",
 							Spec: kubermaticv1.DatacenterSpec{
 								VSphere: &kubermaticv1.DatacenterSpecVSphere{
-									Endpoint:      v.server.Server.URL,
-									AllowInsecure: true,
-									Datastore:     "LocalDS_0",
-									Datacenter:    "ha-datacenter",
-									Cluster:       "localhost.localdomain",
-									RootPath:      "/ha-datacenter/vm/",
+									Endpoint:         v.server.Server.URL,
+									AllowInsecure:    true,
+									DefaultDatastore: "LocalDS_0",
+									Datacenter:       "ha-datacenter",
+									Cluster:          "localhost.localdomain",
+									RootPath:         "/ha-datacenter/vm/",
 								},
 							},
 						},

--- a/pkg/provider/cloud/vsphere/provider.go
+++ b/pkg/provider/cloud/vsphere/provider.go
@@ -216,6 +216,10 @@ func (v *Provider) ValidateCloudSpec(spec kubermaticv1.CloudSpec) error {
 		return err
 	}
 
+	if spec.VSphere.DatastoreCluster != "" && spec.VSphere.Datastore != "" {
+		return errors.New("either datastore or datastore cluster can be selected")
+	}
+
 	session, err := newSession(context.TODO(), v.dc, username, password)
 	if err != nil {
 		return fmt.Errorf("failed to create vCenter session: %v", err)

--- a/pkg/provider/kubernetes/preset.go
+++ b/pkg/provider/kubernetes/preset.go
@@ -377,6 +377,8 @@ func (m *PresetsProvider) setVsphereCredentials(userInfo *provider.UserInfo, pre
 	cloud.VSphere.Username = credentials.Username
 
 	cloud.VSphere.VMNetName = credentials.VMNetName
+	cloud.VSphere.Datastore = credentials.Datastore
+	cloud.VSphere.DatastoreCluster = credentials.DatastoreCluster
 	return &cloud, nil
 
 }

--- a/pkg/resources/cloudconfig/configmap.go
+++ b/pkg/resources/cloudconfig/configmap.go
@@ -249,7 +249,7 @@ func getVsphereCloudConfig(
 			VCenterPort:      port,
 			InsecureFlag:     dc.Spec.VSphere.AllowInsecure,
 			Datacenter:       dc.Spec.VSphere.Datacenter,
-			DefaultDatastore: dc.Spec.VSphere.Datastore,
+			DefaultDatastore: dc.Spec.VSphere.DefaultDatastore,
 			WorkingDir:       cluster.Name,
 		},
 		Workspace: vsphere.WorkspaceOpts{
@@ -262,7 +262,7 @@ func getVsphereCloudConfig(
 			VCenterIP:        vspherURL.Hostname(),
 			Datacenter:       dc.Spec.VSphere.Datacenter,
 			Folder:           cluster.Spec.Cloud.VSphere.Folder,
-			DefaultDatastore: dc.Spec.VSphere.Datastore,
+			DefaultDatastore: dc.Spec.VSphere.DefaultDatastore,
 		},
 		Disk: vsphere.DiskOpts{
 			SCSIControllerType: "pvscsi",

--- a/pkg/resources/machine/common_test.go
+++ b/pkg/resources/machine/common_test.go
@@ -1,0 +1,135 @@
+/*
+Copyright 2020 The Kubermatic Kubernetes Platform contributors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package machine
+
+import (
+	"encoding/json"
+	"testing"
+
+	apiv1 "github.com/kubermatic/kubermatic/pkg/api/v1"
+	kubermaticv1 "github.com/kubermatic/kubermatic/pkg/crd/kubermatic/v1"
+	vsphere "github.com/kubermatic/machine-controller/pkg/cloudprovider/provider/vsphere/types"
+	providerconfigtypes "github.com/kubermatic/machine-controller/pkg/providerconfig/types"
+)
+
+func TestGetVSphereProviderSpec(t *testing.T) {
+	tests := []struct {
+		name        string
+		cluster     *kubermaticv1.Cluster
+		nodeSpec    apiv1.NodeSpec
+		dc          *kubermaticv1.Datacenter
+		wantRawConf vsphere.RawConfig
+		wantErr     bool
+	}{
+		{
+			name: "Datastore",
+			nodeSpec: apiv1.NodeSpec{
+				Cloud: apiv1.NodeCloudSpec{
+					VSphere: &apiv1.VSphereNodeSpec{},
+				},
+			},
+			cluster: &kubermaticv1.Cluster{
+				Spec: kubermaticv1.ClusterSpec{
+					Cloud: kubermaticv1.CloudSpec{
+						VSphere: &kubermaticv1.VSphereCloudSpec{},
+					},
+				},
+			},
+			dc: &kubermaticv1.Datacenter{
+				Spec: kubermaticv1.DatacenterSpec{
+					VSphere: &kubermaticv1.DatacenterSpecVSphere{
+						DefaultDatastore: "default-datastore",
+					},
+				},
+			},
+			wantRawConf: vsphere.RawConfig{
+				Datastore: providerconfigtypes.ConfigVarString{Value: "default-datastore"},
+			},
+		},
+		{
+			name: "Default datastore",
+			nodeSpec: apiv1.NodeSpec{
+				Cloud: apiv1.NodeCloudSpec{
+					VSphere: &apiv1.VSphereNodeSpec{},
+				},
+			},
+			cluster: &kubermaticv1.Cluster{
+				Spec: kubermaticv1.ClusterSpec{
+					Cloud: kubermaticv1.CloudSpec{
+						VSphere: &kubermaticv1.VSphereCloudSpec{
+							Datastore: "my-datastore",
+						},
+					},
+				},
+			},
+			dc: &kubermaticv1.Datacenter{
+				Spec: kubermaticv1.DatacenterSpec{
+					VSphere: &kubermaticv1.DatacenterSpecVSphere{
+						DefaultDatastore: "default-datastore",
+					},
+				},
+			},
+			wantRawConf: vsphere.RawConfig{
+				Datastore: providerconfigtypes.ConfigVarString{Value: "my-datastore"},
+			},
+		},
+		{
+			name: "Datastore cluster",
+			nodeSpec: apiv1.NodeSpec{
+				Cloud: apiv1.NodeCloudSpec{
+					VSphere: &apiv1.VSphereNodeSpec{},
+				},
+			},
+			cluster: &kubermaticv1.Cluster{
+				Spec: kubermaticv1.ClusterSpec{
+					Cloud: kubermaticv1.CloudSpec{
+						VSphere: &kubermaticv1.VSphereCloudSpec{
+							Datastore: "my-datastore-cluster",
+						},
+					},
+				},
+			},
+			dc: &kubermaticv1.Datacenter{
+				Spec: kubermaticv1.DatacenterSpec{
+					VSphere: &kubermaticv1.DatacenterSpecVSphere{
+						DefaultDatastore: "default-datastore",
+					},
+				},
+			},
+			wantRawConf: vsphere.RawConfig{
+				Datastore: providerconfigtypes.ConfigVarString{Value: "my-datastore-cluster"},
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := getVSphereProviderSpec(tt.cluster, tt.nodeSpec, tt.dc)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("getVSphereProviderSpec() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+			gotRawConf := vsphere.RawConfig{}
+			err = json.Unmarshal(got.Raw, &gotRawConf)
+			if err != nil {
+				t.Fatalf("error occurred whil unmarshaling raw config: %v", err)
+			}
+			if gotRawConf != tt.wantRawConf {
+				t.Errorf("getVSphereProviderSpec() = %+v, want %+v", gotRawConf, tt.wantRawConf)
+			}
+		})
+	}
+}

--- a/pkg/resources/test/load_files_test.go
+++ b/pkg/resources/test/load_files_test.go
@@ -177,12 +177,12 @@ func TestLoadFiles(t *testing.T) {
 				Location: "az-location",
 			},
 			VSphere: &kubermaticv1.DatacenterSpecVSphere{
-				Endpoint:      "https://vs-endpoint.io",
-				AllowInsecure: false,
-				Datastore:     "vs-datastore",
-				Datacenter:    "vs-datacenter",
-				Cluster:       "vs-cluster",
-				RootPath:      "vs-cluster",
+				Endpoint:         "https://vs-endpoint.io",
+				AllowInsecure:    false,
+				DefaultDatastore: "vs-datastore",
+				Datacenter:       "vs-datacenter",
+				Cluster:          "vs-cluster",
+				RootPath:         "vs-cluster",
 			},
 			AWS: &kubermaticv1.DatacenterSpecAWS{
 				Images: kubermaticv1.ImageList{

--- a/pkg/test/e2e/api/utils/apiclient/models/datacenter_spec_v_sphere.go
+++ b/pkg/test/e2e/api/utils/apiclient/models/datacenter_spec_v_sphere.go
@@ -25,8 +25,11 @@ type DatacenterSpecVSphere struct {
 	// The name of the datacenter to use.
 	Datacenter string `json:"datacenter,omitempty"`
 
-	// The name of the datastore to use.
-	Datastore string `json:"datastore,omitempty"`
+	// The name of the default Datastore to be used for provisioning volumes
+	// using storage classes/dynamic provisioning and for storing virtual
+	// machine files in case no `Datastore` or `DatastoreCluster` is provided
+	// with the `VSphereCloudSpec`.
+	DefaultDatastore string `json:"datastore,omitempty"`
 
 	// Endpoint URL to use, including protocol, for example "https://vcenter.example.com".
 	Endpoint string `json:"endpoint,omitempty"`

--- a/pkg/test/e2e/api/utils/apiclient/models/v_sphere_cloud_spec.go
+++ b/pkg/test/e2e/api/utils/apiclient/models/v_sphere_cloud_spec.go
@@ -16,16 +16,30 @@ import (
 // swagger:model VSphereCloudSpec
 type VSphereCloudSpec struct {
 
-	// folder
+	// Datastore to be used for storing virtual machines, it is mutually
+	// exclusive with DatastoreCluster.
+	// +optional
+	Datastore string `json:"datastore,omitempty"`
+
+	// DatastoreCluster to be used for determining the Datastore for virtual
+	// machines, it is mutually exclusive with Datastore.
+	// +optional
+	DatastoreCluster string `json:"datastoreCluster,omitempty"`
+
+	// Folder is the folder to be used to group the provisioned virtual
+	// machines.
+	// +optional
 	Folder string `json:"folder,omitempty"`
 
-	// password
+	// Password is the vSphere user password.
+	// +optional
 	Password string `json:"password,omitempty"`
 
-	// username
+	// Username is the vSphere user name.
+	// +optional
 	Username string `json:"username,omitempty"`
 
-	// VM net name
+	// VMNetName is the name of the vSphere network.
 	VMNetName string `json:"vmNetName,omitempty"`
 
 	// credentials reference


### PR DESCRIPTION
**What this PR does / why we need it**:
We added support for datastore clusters in machine controller. Now MachineDeployments for vSphere can specify a datastoreCluster instead of a datastore in the cloudProviderSpec. The goal of this PR is to wire this functionality to Kubermatic. Meaning that the datastoreCluster should be supported in the vSphere cluster spec. 

**Which issue(s) this PR fixes**
Fixes kubermatic/kubermatic#5136

**Does this PR introduce a user-facing change?**:
This PR should also be reflected by adding two new fields in Kubermatic UI where the user should specify whether to use a datastore cluster or simply a specific datastore.

```release-note
Supporting datastore cluster and default datastore in Kubermatic  
```
