### PR TITLE
default the fieldPath of a Seed's kubeconfig objectRef to 'kubeconfig'

### DIFF
--- a/api/pkg/controller/operator/conversion/helm.go
+++ b/api/pkg/controller/operator/conversion/helm.go
@@ -279,7 +279,7 @@ func convertSeeds(values *helmValues, targetNamespace string) ([]runtime.Object,
 
 			secretName := fmt.Sprintf("kubeconfig-%s", seed.Name)
 
-			secret, err := util.CreateKubeconfigSecret(seedKubeconfig, secretName, targetNamespace)
+			secret, fieldPath, err := util.CreateKubeconfigSecret(seedKubeconfig, secretName, targetNamespace)
 			if err != nil {
 				return nil, fmt.Errorf("failed to create kubeconfig Secret for seed %s: %v", seed.Name, err)
 			}
@@ -288,6 +288,7 @@ func convertSeeds(values *helmValues, targetNamespace string) ([]runtime.Object,
 
 			seed.Spec.Kubeconfig.Name = secretName
 			seed.Spec.Kubeconfig.Namespace = targetNamespace
+			seed.Spec.Kubeconfig.FieldPath = fieldPath
 
 			result = append(result, secret)
 		}

--- a/api/pkg/crd/migrations/master/migrations.go
+++ b/api/pkg/crd/migrations/master/migrations.go
@@ -173,7 +173,7 @@ func createSeedKubeconfig(ctx context.Context, log *zap.SugaredLogger, client ct
 		return nil, fmt.Errorf("failed to create kubeconfig: %v", err)
 	}
 
-	secret, err := util.CreateKubeconfigSecret(kubeconfig, "kubeconfig-"+seed.Name, seed.Namespace)
+	secret, fieldPath, err := util.CreateKubeconfigSecret(kubeconfig, "kubeconfig-"+seed.Name, seed.Namespace)
 	if err != nil {
 		return nil, fmt.Errorf("failed to create kubeconfig Secret: %v", err)
 	}
@@ -202,6 +202,6 @@ func createSeedKubeconfig(ctx context.Context, log *zap.SugaredLogger, client ct
 		Kind:       "Secret",
 		Name:       secret.Name,
 		Namespace:  secret.Namespace,
-		FieldPath:  util.KubeconfigFieldPath,
+		FieldPath:  fieldPath,
 	}, nil
 }

--- a/api/pkg/crd/migrations/util/kubeconfig.go
+++ b/api/pkg/crd/migrations/util/kubeconfig.go
@@ -4,13 +4,11 @@ import (
 	"errors"
 	"fmt"
 
+	"github.com/kubermatic/kubermatic/api/pkg/provider"
+
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/client-go/tools/clientcmd"
 	clientcmdapi "k8s.io/client-go/tools/clientcmd/api"
-)
-
-const (
-	KubeconfigFieldPath = "kubeconfig"
 )
 
 // SingleSeedKubeconfig takes a kubeconfig and returns a new kubeconfig that only has the
@@ -47,18 +45,20 @@ func SingleSeedKubeconfig(kubeconfig *clientcmdapi.Config, seedName string) (*cl
 	return config, nil
 }
 
-func CreateKubeconfigSecret(kubeconfig *clientcmdapi.Config, name string, namespace string) (*corev1.Secret, error) {
+func CreateKubeconfigSecret(kubeconfig *clientcmdapi.Config, name string, namespace string) (*corev1.Secret, string, error) {
 	encoded, err := clientcmd.Write(*kubeconfig)
 	if err != nil {
-		return nil, fmt.Errorf("failed to serialize kubeconfig: %v", err)
+		return nil, "", fmt.Errorf("failed to serialize kubeconfig: %v", err)
 	}
+
+	fieldPath := provider.DefaultKubeconfigFieldPath
 
 	secret := &corev1.Secret{}
 	secret.Name = name
 	secret.Namespace = namespace
 	secret.Data = map[string][]byte{
-		KubeconfigFieldPath: encoded,
+		fieldPath: encoded,
 	}
 
-	return secret, nil
+	return secret, fieldPath, nil
 }

--- a/api/pkg/provider/types.go
+++ b/api/pkg/provider/types.go
@@ -43,6 +43,8 @@ const (
 
 	DefaultSSHPort     = 22
 	DefaultKubeletPort = 10250
+
+	DefaultKubeconfigFieldPath = "kubeconfig"
 )
 
 // CloudProvider declares a set of methods for interacting with a cloud provider


### PR DESCRIPTION
**What this PR does / why we need it**:
Kubeconfig Secrets have commonly a single key `kubeconfig`. Our code so far expected this to be explicitly configured in a Seed's objectRef, and failed with a bad error message when no fieldPath was set. We never noticed because we auto-migrated the datacenters.yaml and that creates a fully-spec'ed objectRef.

**Does this PR introduce a user-facing change?**:
```release-note
NONE
```
