### PR TITLE
Expose Grafana setting `viewers_can_edit` to helm chart (no ticket)

### DIFF
--- a/config/monitoring/grafana/Chart.yaml
+++ b/config/monitoring/grafana/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: grafana
-version: 1.2.13
+version: 1.3.0
 appVersion: 6.7.1
 description: Grafana for Kubermatic
 keywords:

--- a/config/monitoring/grafana/config/grafana.ini
+++ b/config/monitoring/grafana/config/grafana.ini
@@ -14,7 +14,8 @@ header_name = X-Auth-Username
 header_property = username
 auto_sign_up = true
 
-{{ with .Values.grafana.provisioning.configuration.auto_assign_org_role }}
 [users]
+viewers_can_edit = {{ .Values.grafana.provisioning.configuration.viewers_can_edit }}
+{{- with .Values.grafana.provisioning.configuration.auto_assign_org_role }}
 auto_assign_org_role = {{ . }}
-{{ end }}
+{{- end }}

--- a/config/monitoring/grafana/config/grafana.ini
+++ b/config/monitoring/grafana/config/grafana.ini
@@ -16,6 +16,4 @@ auto_sign_up = true
 
 [users]
 viewers_can_edit = {{ .Values.grafana.provisioning.configuration.viewers_can_edit }}
-{{- with .Values.grafana.provisioning.configuration.auto_assign_org_role }}
-auto_assign_org_role = {{ . }}
-{{- end }}
+auto_assign_org_role = {{ .Values.grafana.provisioning.configuration.auto_assign_org_role }}

--- a/config/monitoring/grafana/values.yaml
+++ b/config/monitoring/grafana/values.yaml
@@ -95,6 +95,13 @@ grafana:
       # credentials defined above.
       disable_login_form: true
 
+      # Set this to true to allow Viewers to
+      # edit existing dashboards and explore datasources.
+      # Viewers will still not be able to save these changes back
+      # but they will be able to see other metrics than exposed by
+      # the dashboards.
+      viewers_can_edit: false
+
   # If you manage your dashboards via your own configmaps,
   # you can add them here to have them automatically be
   # mounted in Grafana. For each volume, specify either a


### PR DESCRIPTION
* add grafana.provisioning.configuration.viewers_can_edit to grafana's values.yaml
* change grafana.ini to expose flag setting to grafana

**What this PR does / why we need it**: Let `Viewers` explore loki logs without removing the source-of-truth for grafana dashboard configuration.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Documentation**:
<!-- Add links to the related documentation changes related to this pull request. E.g. the link to the kubermatic/docs pullrequest. -->

**Does this PR introduce a user-facing change?**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If  no release note is required, just write "NONE".
-->
```release-note
NONE
```