### PR TITLE
use runtime controller client for PrivilegedProjectProvider

### DIFF
--- a/api/cmd/kubermatic-api/main.go
+++ b/api/cmd/kubermatic-api/main.go
@@ -206,12 +206,12 @@ func createInitProviders(options serverRunOptions) (providers, error) {
 	}
 	serviceAccountProvider := kubernetesprovider.NewServiceAccountProvider(defaultKubermaticImpersonationClient.CreateImpersonatedKubermaticClientSet, userMasterLister, options.domain)
 	projectMemberProvider := kubernetesprovider.NewProjectMemberProvider(defaultKubermaticImpersonationClient.CreateImpersonatedKubermaticClientSet, kubermaticMasterInformerFactory.Kubermatic().V1().UserProjectBindings().Lister(), userMasterLister, kubernetesprovider.IsServiceAccount)
-	projectProvider, err := kubernetesprovider.NewProjectProvider(defaultKubermaticImpersonationClient.CreateImpersonatedKubermaticClientSet, kubermaticMasterInformerFactory.Kubermatic().V1().Projects().Lister())
+	projectProvider, err := kubernetesprovider.NewProjectProvider(defaultKubermaticImpersonationClient.CreateImpersonatedKubermaticClientSet, mgr.GetClient())
 	if err != nil {
 		return providers{}, fmt.Errorf("failed to create project provider due to %v", err)
 	}
 
-	privilegedProjectProvider, err := kubernetesprovider.NewPrivilegedProjectProvider(defaultKubermaticImpersonationClient.CreateImpersonatedKubermaticClientSet)
+	privilegedProjectProvider, err := kubernetesprovider.NewPrivilegedProjectProvider(mgr.GetClient())
 	if err != nil {
 		return providers{}, fmt.Errorf("failed to create privileged project provider due to %v", err)
 	}

--- a/api/pkg/handler/test/helper.go
+++ b/api/pkg/handler/test/helper.go
@@ -221,11 +221,11 @@ func initTestEndpoint(user apiv1.User, seedsGetter provider.SeedsGetter, kubeObj
 	tokenExtractors := auth.NewTokenExtractorPlugins(extractors)
 	fakeOIDCClient := NewFakeOIDCClient(user)
 
-	projectProvider, err := kubernetes.NewProjectProvider(fakeKubermaticImpersonationClient, kubermaticInformerFactory.Kubermatic().V1().Projects().Lister())
+	projectProvider, err := kubernetes.NewProjectProvider(fakeKubermaticImpersonationClient, fakeClient)
 	if err != nil {
 		return nil, nil, err
 	}
-	privilegedProjectProvider, err := kubernetes.NewPrivilegedProjectProvider(fakeKubermaticImpersonationClient)
+	privilegedProjectProvider, err := kubernetes.NewPrivilegedProjectProvider(fakeClient)
 	if err != nil {
 		return nil, nil, err
 	}

--- a/api/pkg/provider/kubernetes/project.go
+++ b/api/pkg/provider/kubernetes/project.go
@@ -1,23 +1,23 @@
 package kubernetes
 
 import (
+	"context"
 	"errors"
 
 	kubermaticclientv1 "github.com/kubermatic/kubermatic/api/pkg/crd/client/clientset/versioned/typed/kubermatic/v1"
-	kubermaticv1lister "github.com/kubermatic/kubermatic/api/pkg/crd/client/listers/kubermatic/v1"
 	kubermaticapiv1 "github.com/kubermatic/kubermatic/api/pkg/crd/kubermatic/v1"
 	"github.com/kubermatic/kubermatic/api/pkg/handler/v1/label"
 	"github.com/kubermatic/kubermatic/api/pkg/provider"
 
 	kerrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/apimachinery/pkg/util/rand"
 	restclient "k8s.io/client-go/rest"
+	ctrlruntimeclient "sigs.k8s.io/controller-runtime/pkg/client"
 )
 
 // NewProjectProvider returns a project provider
-func NewProjectProvider(createMasterImpersonatedClient kubermaticImpersonationClient, projectLister kubermaticv1lister.ProjectLister) (*ProjectProvider, error) {
+func NewProjectProvider(createMasterImpersonatedClient kubermaticImpersonationClient, client ctrlruntimeclient.Client) (*ProjectProvider, error) {
 	kubermaticClient, err := createMasterImpersonatedClient(restclient.ImpersonationConfig{})
 	if err != nil {
 		return nil, err
@@ -26,19 +26,14 @@ func NewProjectProvider(createMasterImpersonatedClient kubermaticImpersonationCl
 	return &ProjectProvider{
 		createMasterImpersonatedClient: createMasterImpersonatedClient,
 		clientPrivileged:               kubermaticClient.Projects(),
-		projectLister:                  projectLister,
+		runtimeClient:                  client,
 	}, nil
 }
 
 // NewPrivilegedProjectProvider returns a privileged project provider
-func NewPrivilegedProjectProvider(createMasterImpersonatedClient kubermaticImpersonationClient) (*PrivilegedProjectProvider, error) {
-	kubermaticClient, err := createMasterImpersonatedClient(restclient.ImpersonationConfig{})
-	if err != nil {
-		return nil, err
-	}
-
+func NewPrivilegedProjectProvider(client ctrlruntimeclient.Client) (*PrivilegedProjectProvider, error) {
 	return &PrivilegedProjectProvider{
-		clientPrivileged: kubermaticClient.Projects(),
+		clientPrivileged: client,
 	}, nil
 }
 
@@ -50,14 +45,14 @@ type ProjectProvider struct {
 	// treat clientPrivileged as a privileged user and use wisely
 	clientPrivileged kubermaticclientv1.ProjectInterface
 
-	// projectLister local cache that stores projects objects
-	projectLister kubermaticv1lister.ProjectLister
+	// runtimeClient privileged client
+	runtimeClient ctrlruntimeclient.Client
 }
 
 // PrivilegedProjectProvider represents a data structure that knows how to manage projects in a privileged way
 type PrivilegedProjectProvider struct {
 	// treat clientPrivileged as a privileged user and use wisely
-	clientPrivileged kubermaticclientv1.ProjectInterface
+	clientPrivileged ctrlruntimeclient.Client
 }
 
 // New creates a brand new project in the system with the given name
@@ -162,8 +157,8 @@ func (p *PrivilegedProjectProvider) GetUnsecured(projectInternalName string, opt
 	if options == nil {
 		options = &provider.ProjectGetOptions{IncludeUninitialized: true}
 	}
-	project, err := p.clientPrivileged.Get(projectInternalName, metav1.GetOptions{})
-	if err != nil {
+	project := &kubermaticapiv1.Project{}
+	if err := p.clientPrivileged.Get(context.Background(), ctrlruntimeclient.ObjectKey{Name: projectInternalName}, project); err != nil {
 		return nil, err
 	}
 	if !options.IncludeUninitialized && project.Status.Phase != kubermaticapiv1.ProjectActive {
@@ -178,22 +173,25 @@ func (p *PrivilegedProjectProvider) GetUnsecured(projectInternalName string, opt
 // Note:
 // Before deletion project's status.phase is set to ProjectTerminating
 func (p *PrivilegedProjectProvider) DeleteUnsecured(projectInternalName string) error {
-	existingProject, err := p.clientPrivileged.Get(projectInternalName, metav1.GetOptions{})
-	if err != nil {
+	existingProject := &kubermaticapiv1.Project{}
+	if err := p.clientPrivileged.Get(context.Background(), ctrlruntimeclient.ObjectKey{Name: projectInternalName}, existingProject); err != nil {
 		return err
 	}
 	existingProject.Status.Phase = kubermaticapiv1.ProjectTerminating
-	if _, err := p.clientPrivileged.Update(existingProject); err != nil {
+	if err := p.clientPrivileged.Update(context.Background(), existingProject); err != nil {
 		return err
 	}
 
-	return p.clientPrivileged.Delete(projectInternalName, &metav1.DeleteOptions{})
+	return p.clientPrivileged.Delete(context.Background(), existingProject)
 }
 
 // UpdateUnsecured update a specific project and returns the updated project
 // This function is unsafe in a sense that it uses privileged account to update the project
 func (p *PrivilegedProjectProvider) UpdateUnsecured(project *kubermaticapiv1.Project) (*kubermaticapiv1.Project, error) {
-	return p.clientPrivileged.Update(project)
+	if err := p.clientPrivileged.Update(context.Background(), project); err != nil {
+		return nil, err
+	}
+	return project, nil
 }
 
 // List gets a list of projects, by default it returns all resources.
@@ -204,13 +202,13 @@ func (p *ProjectProvider) List(options *provider.ProjectListOptions) ([]*kuberma
 	if options == nil {
 		options = &provider.ProjectListOptions{}
 	}
-	projects, err := p.projectLister.List(labels.Everything())
-	if err != nil {
+	projects := &kubermaticapiv1.ProjectList{}
+	if err := p.runtimeClient.List(context.Background(), projects); err != nil {
 		return nil, err
 	}
 
-	ret := []*kubermaticapiv1.Project{}
-	for _, project := range projects {
+	var ret []*kubermaticapiv1.Project
+	for _, project := range projects.Items {
 		if len(options.ProjectName) > 0 && project.Spec.Name != options.ProjectName {
 			continue
 		}

--- a/api/pkg/provider/kubernetes/project_test.go
+++ b/api/pkg/provider/kubernetes/project_test.go
@@ -5,7 +5,6 @@ import (
 
 	"github.com/go-test/deep"
 
-	kubermaticv1lister "github.com/kubermatic/kubermatic/api/pkg/crd/client/listers/kubermatic/v1"
 	kubermaticv1 "github.com/kubermatic/kubermatic/api/pkg/crd/kubermatic/v1"
 	"github.com/kubermatic/kubermatic/api/pkg/provider"
 	"github.com/kubermatic/kubermatic/api/pkg/provider/kubernetes"
@@ -14,6 +13,8 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/client-go/kubernetes/scheme"
+	fakectrlruntimeclient "sigs.k8s.io/controller-runtime/pkg/client/fake"
 )
 
 func TestListProjects(t *testing.T) {
@@ -123,14 +124,14 @@ func TestListProjects(t *testing.T) {
 				kubermaticObjects = append(kubermaticObjects, binding)
 			}
 
-			impersonationClient, _, indexer, err := createFakeKubermaticClients(kubermaticObjects)
+			impersonationClient, _, _, err := createFakeKubermaticClients(kubermaticObjects)
 			if err != nil {
 				t.Fatalf("unable to create fake clients, err = %v", err)
 			}
-			projectLister := kubermaticv1lister.NewProjectLister(indexer)
+			fakeClient := fakectrlruntimeclient.NewFakeClientWithScheme(scheme.Scheme, kubermaticObjects...)
 
 			// act
-			target, err := kubernetes.NewProjectProvider(impersonationClient.CreateFakeImpersonatedClientSet, projectLister)
+			target, err := kubernetes.NewProjectProvider(impersonationClient.CreateFakeImpersonatedClientSet, fakeClient)
 			if err != nil {
 				t.Fatal(err)
 			}
@@ -203,13 +204,10 @@ func TestGetUnsecuredProjects(t *testing.T) {
 				kubermaticObjects = append(kubermaticObjects, binding)
 			}
 
-			impersonationClient, _, _, err := createFakeKubermaticClients(kubermaticObjects)
-			if err != nil {
-				t.Fatalf("unable to create fake clients, err = %v", err)
-			}
+			fakeClient := fakectrlruntimeclient.NewFakeClientWithScheme(scheme.Scheme, kubermaticObjects...)
 
 			// act
-			target, err := kubernetes.NewPrivilegedProjectProvider(impersonationClient.CreateFakeImpersonatedClientSet)
+			target, err := kubernetes.NewPrivilegedProjectProvider(fakeClient)
 			if err != nil {
 				t.Fatal(err)
 			}

--- a/api/pkg/provider/kubernetes/util_test.go
+++ b/api/pkg/provider/kubernetes/util_test.go
@@ -177,6 +177,10 @@ func genDefaultUser() *kubermaticv1.User {
 // genProject generates new empty project
 func genProject(name, phase string, creationTime time.Time, oRef ...metav1.OwnerReference) *kubermaticv1.Project {
 	return &kubermaticv1.Project{
+		TypeMeta: metav1.TypeMeta{
+			Kind:       "Project",
+			APIVersion: "kubermatic.k8s.io/v1",
+		},
 		ObjectMeta: metav1.ObjectMeta{
 			Name:              fmt.Sprintf("%s-%s", name, "ID"),
 			CreationTimestamp: metav1.NewTime(creationTime),


### PR DESCRIPTION
**What this PR does / why we need it**: Update `pkg/provider/kubernetes/project.go` to use runtime client for PrivilegedProjectProvider

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #5415

```release-note
NONE
```
