### PR TITLE
[EE] Use kubermatic/api-ce repository for Community Edition

### DIFF
--- a/api/Makefile
+++ b/api/Makefile
@@ -1,5 +1,6 @@
 export CGO_ENABLED?=0
-REPO=quay.io/kubermatic/api
+KUBERMATIC_EDITION?=ce
+REPO=quay.io/kubermatic/api$(shell [ "$(KUBERMATIC_EDITION)" != "ee" ] && echo "-$(KUBERMATIC_EDITION)" )
 CMD=$(filter-out OWNERS nodeport-proxy kubeletdnat-controller, $(notdir $(wildcard ./cmd/*)))
 GOBUILDFLAGS?=-v
 GITTAG=$(shell git describe --tags --always)
@@ -18,7 +19,6 @@ HAS_DEP:= $(shell command -v dep 2> /dev/null)
 HAS_GIT:= $(shell command -v git 2> /dev/null)
 BUILD_DEST?=_build
 GOTOOLFLAGS?=$(GOBUILDFLAGS) -ldflags '-w $(LDFLAGS)'
-KUBERMATIC_EDITION?=ce
 
 default: all
 

--- a/api/cmd/kubermatic-operator/main.go
+++ b/api/cmd/kubermatic-operator/main.go
@@ -16,6 +16,7 @@ import (
 	kubermaticlog "github.com/kubermatic/kubermatic/api/pkg/log"
 	"github.com/kubermatic/kubermatic/api/pkg/pprof"
 	"github.com/kubermatic/kubermatic/api/pkg/provider"
+	"github.com/kubermatic/kubermatic/api/pkg/resources"
 	"github.com/kubermatic/kubermatic/api/pkg/signals"
 
 	certmanagerv1alpha2 "github.com/jetstack/cert-manager/pkg/apis/certmanager/v1alpha2"
@@ -71,7 +72,7 @@ func main() {
 		log.Fatal("-namespace is a mandatory flag")
 	}
 
-	log.Infow("Moin, moin, I'm the Kubermatic Operator and these are the versions I work with.", "kubermatic", common.KUBERMATICDOCKERTAG, "ui", common.UIDOCKERTAG)
+	log.With("kubermatic", common.KUBERMATICDOCKERTAG, "ui", common.UIDOCKERTAG).Infof("Moin, moin, I'm the Kubermatic %s Operator and these are the versions I work with.", resources.KubermaticEdition)
 
 	config, err := clientcmd.BuildConfigFromFlags("", opt.kubeconfig)
 	if err != nil {

--- a/api/hack/push_image.sh
+++ b/api/hack/push_image.sh
@@ -12,33 +12,38 @@ EOF
 fi
 
 cd "$(dirname "$0")/../"
+source ./hack/lib.sh
+
+REPOSUFFIX=""
+if [ "${KUBERMATIC_EDITION:-ee}" != "ee" ]; then
+  REPOSUFFIX="-$KUBERMATIC_EDITION"
+fi
 
 make build
-docker build -t quay.io/kubermatic/api:${1} .
+docker build -t quay.io/kubermatic/api${REPOSUFFIX}:${1} .
 cd cmd/nodeport-proxy && export TAG=${1} && make docker && unset TAG && cd -
 cd cmd/kubeletdnat-controller && export TAG=${1} && make docker && unset TAG && cd -
 docker build -t "quay.io/kubermatic/addons:${1}" ../addons
 docker build -t "quay.io/kubermatic/openshift-addons:${1}" ../openshift_addons
 cd cmd/user-ssh-keys-agent && export TAG=${1} && make docker && unset TAG && cd -
 
-for TAG in "$@"
-do
-    if [[ -z "$TAG" ]]; then
-      continue
-    fi
+for TAG in "$@"; do
+  if [[ -z "$TAG" ]]; then
+    continue
+  fi
 
-    echo "Tagging ${TAG}"
-    docker tag quay.io/kubermatic/api:${1} quay.io/kubermatic/api:${TAG}
-    docker tag quay.io/kubermatic/nodeport-proxy:${1} quay.io/kubermatic/nodeport-proxy:${TAG}
-    docker tag quay.io/kubermatic/kubeletdnat-controller:${1}  quay.io/kubermatic/kubeletdnat-controller:${TAG}
-    docker tag quay.io/kubermatic/addons:${1} quay.io/kubermatic/addons:${TAG}
-    docker tag quay.io/kubermatic/openshift-addons:${1} quay.io/kubermatic/openshift-addons:${TAG}
-    docker tag quay.io/kubermatic/user-ssh-keys-agent:${1} quay.io/kubermatic/user-ssh-keys-agent:${TAG}
+  echodate "Tagging ${TAG}"
+  docker tag quay.io/kubermatic/api${REPOSUFFIX}:${1} quay.io/kubermatic/api${REPOSUFFIX}:${TAG}
+  docker tag quay.io/kubermatic/nodeport-proxy:${1} quay.io/kubermatic/nodeport-proxy:${TAG}
+  docker tag quay.io/kubermatic/kubeletdnat-controller:${1}  quay.io/kubermatic/kubeletdnat-controller:${TAG}
+  docker tag quay.io/kubermatic/addons:${1} quay.io/kubermatic/addons:${TAG}
+  docker tag quay.io/kubermatic/openshift-addons:${1} quay.io/kubermatic/openshift-addons:${TAG}
+  docker tag quay.io/kubermatic/user-ssh-keys-agent:${1} quay.io/kubermatic/user-ssh-keys-agent:${TAG}
 
-    docker push quay.io/kubermatic/api:${TAG}
-    docker push quay.io/kubermatic/nodeport-proxy:${TAG}
-    docker push quay.io/kubermatic/kubeletdnat-controller:${TAG}
-    docker push quay.io/kubermatic/addons:${TAG}
-    docker push quay.io/kubermatic/openshift-addons:${TAG}
-    docker push quay.io/kubermatic/user-ssh-keys-agent:${TAG}
+  docker push quay.io/kubermatic/api${REPOSUFFIX}:${TAG}
+  docker push quay.io/kubermatic/nodeport-proxy:${TAG}
+  docker push quay.io/kubermatic/kubeletdnat-controller:${TAG}
+  docker push quay.io/kubermatic/addons:${TAG}
+  docker push quay.io/kubermatic/openshift-addons:${TAG}
+  docker push quay.io/kubermatic/user-ssh-keys-agent:${TAG}
 done

--- a/api/pkg/controller/operator/common/defaults.go
+++ b/api/pkg/controller/operator/common/defaults.go
@@ -37,7 +37,6 @@ const (
 	DefaultVPARecommenderDockerRepository         = "gcr.io/google_containers/vpa-recommender"
 	DefaultVPAUpdaterDockerRepository             = "gcr.io/google_containers/vpa-updater"
 	DefaultVPAAdmissionControllerDockerRepository = "gcr.io/google_containers/vpa-admission-controller"
-	DefaultNodeportProxyDockerRepository          = "quay.io/kubermatic/nodeport-proxy"
 	DefaultEnvoyDockerRepository                  = "docker.io/envoyproxy/envoy-alpine"
 
 	// DefaultNoProxy is a set of domains/networks that should never be

--- a/api/pkg/controller/operator/common/defaults_ce.go
+++ b/api/pkg/controller/operator/common/defaults_ce.go
@@ -1,0 +1,7 @@
+// +build !ee
+
+package common
+
+const (
+	DefaultNodeportProxyDockerRepository = "quay.io/kubermatic/nodeport-proxy"
+)

--- a/api/pkg/controller/operator/common/defaults_ee.go
+++ b/api/pkg/controller/operator/common/defaults_ee.go
@@ -1,0 +1,7 @@
+// +build ee
+
+package common
+
+const (
+	DefaultNodeportProxyDockerRepository = "quay.io/kubermatic/nodeport-proxy"
+)

--- a/api/pkg/resources/resources.go
+++ b/api/pkg/resources/resources.go
@@ -339,21 +339,6 @@ const (
 	// InternalUserClusterAdminKubeconfigCertUsername is the name of the user coming from kubeconfig cert
 	InternalUserClusterAdminKubeconfigCertUsername = "kubermatic-controllers"
 
-	// DefaultKubermaticImage defines the default Docker repository containing the Kubermatic API image.
-	DefaultKubermaticImage = "quay.io/kubermatic/api"
-
-	// DefaultDNATControllerImage defines the default Docker repository containing the DNAT controller image.
-	DefaultDNATControllerImage = "quay.io/kubermatic/kubeletdnat-controller"
-
-	// DefaultDashboardAddonImage defines the default Docker repository containing the dashboard image.
-	DefaultDashboardImage = "quay.io/kubermatic/dashboard"
-
-	// DefaultKubernetesAddonImage defines the default Docker repository containing the Kubernetes addons.
-	DefaultKubernetesAddonImage = "quay.io/kubermatic/addons"
-
-	// DefaultOpenshiftAddonImage defines the default Docker repository containing the Openshift addons.
-	DefaultOpenshiftAddonImage = "quay.io/kubermatic/openshift-addons"
-
 	// IPVSProxyMode defines the ipvs kube-proxy mode.
 	IPVSProxyMode = "ipvs"
 	// IPTablesProxyMode defines the iptables kube-proxy mode.

--- a/api/pkg/resources/resources_ce.go
+++ b/api/pkg/resources/resources_ce.go
@@ -4,4 +4,19 @@ package resources
 
 const (
 	KubermaticEdition = "Community Edition"
+
+	// DefaultKubermaticImage defines the default Docker repository containing the Kubermatic API image.
+	DefaultKubermaticImage = "quay.io/kubermatic/api-ce"
+
+	// DefaultDNATControllerImage defines the default Docker repository containing the DNAT controller image.
+	DefaultDNATControllerImage = "quay.io/kubermatic/kubeletdnat-controller"
+
+	// DefaultDashboardAddonImage defines the default Docker repository containing the dashboard image.
+	DefaultDashboardImage = "quay.io/kubermatic/dashboard-ce"
+
+	// DefaultKubernetesAddonImage defines the default Docker repository containing the Kubernetes addons.
+	DefaultKubernetesAddonImage = "quay.io/kubermatic/addons"
+
+	// DefaultOpenshiftAddonImage defines the default Docker repository containing the Openshift addons.
+	DefaultOpenshiftAddonImage = "quay.io/kubermatic/openshift-addons"
 )

--- a/api/pkg/resources/resources_ee.go
+++ b/api/pkg/resources/resources_ee.go
@@ -4,4 +4,19 @@ package resources
 
 const (
 	KubermaticEdition = "Enterprise Edition"
+
+	// DefaultKubermaticImage defines the default Docker repository containing the Kubermatic API image.
+	DefaultKubermaticImage = "quay.io/kubermatic/api"
+
+	// DefaultDNATControllerImage defines the default Docker repository containing the DNAT controller image.
+	DefaultDNATControllerImage = "quay.io/kubermatic/kubeletdnat-controller"
+
+	// DefaultDashboardAddonImage defines the default Docker repository containing the dashboard image.
+	DefaultDashboardImage = "quay.io/kubermatic/dashboard"
+
+	// DefaultKubernetesAddonImage defines the default Docker repository containing the Kubernetes addons.
+	DefaultKubernetesAddonImage = "quay.io/kubermatic/addons"
+
+	// DefaultOpenshiftAddonImage defines the default Docker repository containing the Openshift addons.
+	DefaultOpenshiftAddonImage = "quay.io/kubermatic/openshift-addons"
 )

--- a/docs/zz_generated.kubermaticConfiguration.yaml
+++ b/docs/zz_generated.kubermaticConfiguration.yaml
@@ -13,7 +13,7 @@ spec:
     # DebugLog enables more verbose logging.
     debugLog: false
     # DockerRepository is the repository containing the Kubermatic REST API image.
-    dockerRepository: quay.io/kubermatic/api
+    dockerRepository: quay.io/kubermatic/api-ce
     # PProfEndpoint controls the port the API should listen on to provide pprof
     # data. This port is never exposed from the container and only available via port-forwardings.
     pprofEndpoint: :6600
@@ -82,7 +82,7 @@ spec:
     # DebugLog enables more verbose logging.
     debugLog: false
     # DockerRepository is the repository containing the Kubermatic master-controller-manager image.
-    dockerRepository: quay.io/kubermatic/api
+    dockerRepository: quay.io/kubermatic/api-ce
     # PProfEndpoint controls the port the master-controller-manager should listen on to provide pprof
     # data. This port is never exposed from the container and only available via port-forwardings.
     pprofEndpoint: :6600
@@ -186,7 +186,7 @@ spec:
     # DebugLog enables more verbose logging.
     debugLog: false
     # DockerRepository is the repository containing the Kubermatic seed-controller-manager image.
-    dockerRepository: quay.io/kubermatic/api
+    dockerRepository: quay.io/kubermatic/api-ce
     # PProfEndpoint controls the port the seed-controller-manager should listen on to provide pprof
     # data. This port is never exposed from the container and only available via port-forwardings.
     pprofEndpoint: :6600
@@ -214,7 +214,7 @@ spec:
         "share_kubeconfig": false
       }
     # DockerRepository is the repository containing the Kubermatic dashboard image.
-    dockerRepository: quay.io/kubermatic/dashboard
+    dockerRepository: quay.io/kubermatic/dashboard-ce
     # Replicas sets the number of pod replicas for the UI deployment.
     replicas: 2
     # Resources describes the requested and maximum allowed CPU/memory usage.
@@ -367,7 +367,7 @@ spec:
     # EtcdVolumeSize configures the volume size to use for each etcd pod inside user clusters.
     etcdVolumeSize: 5Gi
     # KubermaticDockerRepository is the repository containing the Kubermatic user-cluster-controller-manager image.
-    kubermaticDockerRepository: quay.io/kubermatic/api
+    kubermaticDockerRepository: quay.io/kubermatic/api-ce
     # Monitoring can be used to fine-tune to in-cluster Prometheus.
     monitoring:
       # CustomRules can be used to inject custom recording and alerting rules. This field


### PR DESCRIPTION
**What this PR does / why we need it**:
When building a CE version of Kubermatic, the Docker images will be put into a different Docker repository. This will aid in permission management (compared to using "EE tags" only, in the same repository). To make migration for existing users easier, the existing repo is now declared to be the EE repo, and `api-ce` / `dashboard-ce` will be for the Community Edition.

This PR extends the Kubermatic Operator so it is built for either the CE or the EE variant.

**Does this PR introduce a user-facing change?**:
```release-note
NONE
```
