### PR TITLE
machine-controller v1.14.0

### DIFF
--- a/api/pkg/resources/machinecontroller/deployment.go
+++ b/api/pkg/resources/machinecontroller/deployment.go
@@ -37,7 +37,7 @@ var (
 const (
 	Name = "machine-controller"
 
-	tag = "v1.13.2"
+	tag = "v1.14.0"
 
 	NodeLocalDNSCacheAddress = "169.254.20.10"
 )

--- a/api/pkg/resources/test/fixtures/deployment-aws-1.15.0-machine-controller-webhook.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-aws-1.15.0-machine-controller-webhook.yaml
@@ -54,7 +54,7 @@ spec:
           value: apiserver-external.cluster-de-test-01.svc.cluster.local.
         - name: KUBECONFIG
           value: /etc/kubernetes/kubeconfig/kubeconfig
-        image: docker.io/kubermatic/machine-controller:v1.13.2
+        image: docker.io/kubermatic/machine-controller:v1.14.0
         livenessProbe:
           failureThreshold: 8
           httpGet:

--- a/api/pkg/resources/test/fixtures/deployment-aws-1.15.0-machine-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-aws-1.15.0-machine-controller.yaml
@@ -57,7 +57,7 @@ spec:
           value: apiserver-external.cluster-de-test-01.svc.cluster.local.
         - name: KUBECONFIG
           value: /etc/kubernetes/kubeconfig/kubeconfig
-        image: docker.io/kubermatic/machine-controller:v1.13.2
+        image: docker.io/kubermatic/machine-controller:v1.14.0
         livenessProbe:
           failureThreshold: 3
           httpGet:

--- a/api/pkg/resources/test/fixtures/deployment-aws-1.16.0-machine-controller-webhook.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-aws-1.16.0-machine-controller-webhook.yaml
@@ -54,7 +54,7 @@ spec:
           value: apiserver-external.cluster-de-test-01.svc.cluster.local.
         - name: KUBECONFIG
           value: /etc/kubernetes/kubeconfig/kubeconfig
-        image: docker.io/kubermatic/machine-controller:v1.13.2
+        image: docker.io/kubermatic/machine-controller:v1.14.0
         livenessProbe:
           failureThreshold: 8
           httpGet:

--- a/api/pkg/resources/test/fixtures/deployment-aws-1.16.0-machine-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-aws-1.16.0-machine-controller.yaml
@@ -57,7 +57,7 @@ spec:
           value: apiserver-external.cluster-de-test-01.svc.cluster.local.
         - name: KUBECONFIG
           value: /etc/kubernetes/kubeconfig/kubeconfig
-        image: docker.io/kubermatic/machine-controller:v1.13.2
+        image: docker.io/kubermatic/machine-controller:v1.14.0
         livenessProbe:
           failureThreshold: 3
           httpGet:

--- a/api/pkg/resources/test/fixtures/deployment-aws-1.17.0-machine-controller-webhook.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-aws-1.17.0-machine-controller-webhook.yaml
@@ -54,7 +54,7 @@ spec:
           value: apiserver-external.cluster-de-test-01.svc.cluster.local.
         - name: KUBECONFIG
           value: /etc/kubernetes/kubeconfig/kubeconfig
-        image: docker.io/kubermatic/machine-controller:v1.13.2
+        image: docker.io/kubermatic/machine-controller:v1.14.0
         livenessProbe:
           failureThreshold: 8
           httpGet:

--- a/api/pkg/resources/test/fixtures/deployment-aws-1.17.0-machine-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-aws-1.17.0-machine-controller.yaml
@@ -57,7 +57,7 @@ spec:
           value: apiserver-external.cluster-de-test-01.svc.cluster.local.
         - name: KUBECONFIG
           value: /etc/kubernetes/kubeconfig/kubeconfig
-        image: docker.io/kubermatic/machine-controller:v1.13.2
+        image: docker.io/kubermatic/machine-controller:v1.14.0
         livenessProbe:
           failureThreshold: 3
           httpGet:

--- a/api/pkg/resources/test/fixtures/deployment-aws-1.18.0-machine-controller-webhook.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-aws-1.18.0-machine-controller-webhook.yaml
@@ -54,7 +54,7 @@ spec:
           value: apiserver-external.cluster-de-test-01.svc.cluster.local.
         - name: KUBECONFIG
           value: /etc/kubernetes/kubeconfig/kubeconfig
-        image: docker.io/kubermatic/machine-controller:v1.13.2
+        image: docker.io/kubermatic/machine-controller:v1.14.0
         livenessProbe:
           failureThreshold: 8
           httpGet:

--- a/api/pkg/resources/test/fixtures/deployment-aws-1.18.0-machine-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-aws-1.18.0-machine-controller.yaml
@@ -57,7 +57,7 @@ spec:
           value: apiserver-external.cluster-de-test-01.svc.cluster.local.
         - name: KUBECONFIG
           value: /etc/kubernetes/kubeconfig/kubeconfig
-        image: docker.io/kubermatic/machine-controller:v1.13.2
+        image: docker.io/kubermatic/machine-controller:v1.14.0
         livenessProbe:
           failureThreshold: 3
           httpGet:

--- a/api/pkg/resources/test/fixtures/deployment-azure-1.15.0-machine-controller-webhook.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-azure-1.15.0-machine-controller-webhook.yaml
@@ -58,7 +58,7 @@ spec:
           value: apiserver-external.cluster-de-test-01.svc.cluster.local.
         - name: KUBECONFIG
           value: /etc/kubernetes/kubeconfig/kubeconfig
-        image: docker.io/kubermatic/machine-controller:v1.13.2
+        image: docker.io/kubermatic/machine-controller:v1.14.0
         livenessProbe:
           failureThreshold: 8
           httpGet:

--- a/api/pkg/resources/test/fixtures/deployment-azure-1.15.0-machine-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-azure-1.15.0-machine-controller.yaml
@@ -61,7 +61,7 @@ spec:
           value: apiserver-external.cluster-de-test-01.svc.cluster.local.
         - name: KUBECONFIG
           value: /etc/kubernetes/kubeconfig/kubeconfig
-        image: docker.io/kubermatic/machine-controller:v1.13.2
+        image: docker.io/kubermatic/machine-controller:v1.14.0
         livenessProbe:
           failureThreshold: 3
           httpGet:

--- a/api/pkg/resources/test/fixtures/deployment-azure-1.16.0-machine-controller-webhook.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-azure-1.16.0-machine-controller-webhook.yaml
@@ -58,7 +58,7 @@ spec:
           value: apiserver-external.cluster-de-test-01.svc.cluster.local.
         - name: KUBECONFIG
           value: /etc/kubernetes/kubeconfig/kubeconfig
-        image: docker.io/kubermatic/machine-controller:v1.13.2
+        image: docker.io/kubermatic/machine-controller:v1.14.0
         livenessProbe:
           failureThreshold: 8
           httpGet:

--- a/api/pkg/resources/test/fixtures/deployment-azure-1.16.0-machine-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-azure-1.16.0-machine-controller.yaml
@@ -61,7 +61,7 @@ spec:
           value: apiserver-external.cluster-de-test-01.svc.cluster.local.
         - name: KUBECONFIG
           value: /etc/kubernetes/kubeconfig/kubeconfig
-        image: docker.io/kubermatic/machine-controller:v1.13.2
+        image: docker.io/kubermatic/machine-controller:v1.14.0
         livenessProbe:
           failureThreshold: 3
           httpGet:

--- a/api/pkg/resources/test/fixtures/deployment-azure-1.17.0-machine-controller-webhook.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-azure-1.17.0-machine-controller-webhook.yaml
@@ -58,7 +58,7 @@ spec:
           value: apiserver-external.cluster-de-test-01.svc.cluster.local.
         - name: KUBECONFIG
           value: /etc/kubernetes/kubeconfig/kubeconfig
-        image: docker.io/kubermatic/machine-controller:v1.13.2
+        image: docker.io/kubermatic/machine-controller:v1.14.0
         livenessProbe:
           failureThreshold: 8
           httpGet:

--- a/api/pkg/resources/test/fixtures/deployment-azure-1.17.0-machine-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-azure-1.17.0-machine-controller.yaml
@@ -61,7 +61,7 @@ spec:
           value: apiserver-external.cluster-de-test-01.svc.cluster.local.
         - name: KUBECONFIG
           value: /etc/kubernetes/kubeconfig/kubeconfig
-        image: docker.io/kubermatic/machine-controller:v1.13.2
+        image: docker.io/kubermatic/machine-controller:v1.14.0
         livenessProbe:
           failureThreshold: 3
           httpGet:

--- a/api/pkg/resources/test/fixtures/deployment-azure-1.18.0-machine-controller-webhook.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-azure-1.18.0-machine-controller-webhook.yaml
@@ -58,7 +58,7 @@ spec:
           value: apiserver-external.cluster-de-test-01.svc.cluster.local.
         - name: KUBECONFIG
           value: /etc/kubernetes/kubeconfig/kubeconfig
-        image: docker.io/kubermatic/machine-controller:v1.13.2
+        image: docker.io/kubermatic/machine-controller:v1.14.0
         livenessProbe:
           failureThreshold: 8
           httpGet:

--- a/api/pkg/resources/test/fixtures/deployment-azure-1.18.0-machine-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-azure-1.18.0-machine-controller.yaml
@@ -61,7 +61,7 @@ spec:
           value: apiserver-external.cluster-de-test-01.svc.cluster.local.
         - name: KUBECONFIG
           value: /etc/kubernetes/kubeconfig/kubeconfig
-        image: docker.io/kubermatic/machine-controller:v1.13.2
+        image: docker.io/kubermatic/machine-controller:v1.14.0
         livenessProbe:
           failureThreshold: 3
           httpGet:

--- a/api/pkg/resources/test/fixtures/deployment-bringyourown-1.15.0-machine-controller-webhook.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-bringyourown-1.15.0-machine-controller-webhook.yaml
@@ -50,7 +50,7 @@ spec:
           value: apiserver-external.cluster-de-test-01.svc.cluster.local.
         - name: KUBECONFIG
           value: /etc/kubernetes/kubeconfig/kubeconfig
-        image: docker.io/kubermatic/machine-controller:v1.13.2
+        image: docker.io/kubermatic/machine-controller:v1.14.0
         livenessProbe:
           failureThreshold: 8
           httpGet:

--- a/api/pkg/resources/test/fixtures/deployment-bringyourown-1.15.0-machine-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-bringyourown-1.15.0-machine-controller.yaml
@@ -53,7 +53,7 @@ spec:
           value: apiserver-external.cluster-de-test-01.svc.cluster.local.
         - name: KUBECONFIG
           value: /etc/kubernetes/kubeconfig/kubeconfig
-        image: docker.io/kubermatic/machine-controller:v1.13.2
+        image: docker.io/kubermatic/machine-controller:v1.14.0
         livenessProbe:
           failureThreshold: 3
           httpGet:

--- a/api/pkg/resources/test/fixtures/deployment-bringyourown-1.16.0-machine-controller-webhook.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-bringyourown-1.16.0-machine-controller-webhook.yaml
@@ -50,7 +50,7 @@ spec:
           value: apiserver-external.cluster-de-test-01.svc.cluster.local.
         - name: KUBECONFIG
           value: /etc/kubernetes/kubeconfig/kubeconfig
-        image: docker.io/kubermatic/machine-controller:v1.13.2
+        image: docker.io/kubermatic/machine-controller:v1.14.0
         livenessProbe:
           failureThreshold: 8
           httpGet:

--- a/api/pkg/resources/test/fixtures/deployment-bringyourown-1.16.0-machine-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-bringyourown-1.16.0-machine-controller.yaml
@@ -53,7 +53,7 @@ spec:
           value: apiserver-external.cluster-de-test-01.svc.cluster.local.
         - name: KUBECONFIG
           value: /etc/kubernetes/kubeconfig/kubeconfig
-        image: docker.io/kubermatic/machine-controller:v1.13.2
+        image: docker.io/kubermatic/machine-controller:v1.14.0
         livenessProbe:
           failureThreshold: 3
           httpGet:

--- a/api/pkg/resources/test/fixtures/deployment-bringyourown-1.17.0-machine-controller-webhook.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-bringyourown-1.17.0-machine-controller-webhook.yaml
@@ -50,7 +50,7 @@ spec:
           value: apiserver-external.cluster-de-test-01.svc.cluster.local.
         - name: KUBECONFIG
           value: /etc/kubernetes/kubeconfig/kubeconfig
-        image: docker.io/kubermatic/machine-controller:v1.13.2
+        image: docker.io/kubermatic/machine-controller:v1.14.0
         livenessProbe:
           failureThreshold: 8
           httpGet:

--- a/api/pkg/resources/test/fixtures/deployment-bringyourown-1.17.0-machine-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-bringyourown-1.17.0-machine-controller.yaml
@@ -53,7 +53,7 @@ spec:
           value: apiserver-external.cluster-de-test-01.svc.cluster.local.
         - name: KUBECONFIG
           value: /etc/kubernetes/kubeconfig/kubeconfig
-        image: docker.io/kubermatic/machine-controller:v1.13.2
+        image: docker.io/kubermatic/machine-controller:v1.14.0
         livenessProbe:
           failureThreshold: 3
           httpGet:

--- a/api/pkg/resources/test/fixtures/deployment-bringyourown-1.18.0-machine-controller-webhook.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-bringyourown-1.18.0-machine-controller-webhook.yaml
@@ -50,7 +50,7 @@ spec:
           value: apiserver-external.cluster-de-test-01.svc.cluster.local.
         - name: KUBECONFIG
           value: /etc/kubernetes/kubeconfig/kubeconfig
-        image: docker.io/kubermatic/machine-controller:v1.13.2
+        image: docker.io/kubermatic/machine-controller:v1.14.0
         livenessProbe:
           failureThreshold: 8
           httpGet:

--- a/api/pkg/resources/test/fixtures/deployment-bringyourown-1.18.0-machine-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-bringyourown-1.18.0-machine-controller.yaml
@@ -53,7 +53,7 @@ spec:
           value: apiserver-external.cluster-de-test-01.svc.cluster.local.
         - name: KUBECONFIG
           value: /etc/kubernetes/kubeconfig/kubeconfig
-        image: docker.io/kubermatic/machine-controller:v1.13.2
+        image: docker.io/kubermatic/machine-controller:v1.14.0
         livenessProbe:
           failureThreshold: 3
           httpGet:

--- a/api/pkg/resources/test/fixtures/deployment-digitalocean-1.15.0-machine-controller-webhook.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-digitalocean-1.15.0-machine-controller-webhook.yaml
@@ -52,7 +52,7 @@ spec:
           value: apiserver-external.cluster-de-test-01.svc.cluster.local.
         - name: KUBECONFIG
           value: /etc/kubernetes/kubeconfig/kubeconfig
-        image: docker.io/kubermatic/machine-controller:v1.13.2
+        image: docker.io/kubermatic/machine-controller:v1.14.0
         livenessProbe:
           failureThreshold: 8
           httpGet:

--- a/api/pkg/resources/test/fixtures/deployment-digitalocean-1.15.0-machine-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-digitalocean-1.15.0-machine-controller.yaml
@@ -55,7 +55,7 @@ spec:
           value: apiserver-external.cluster-de-test-01.svc.cluster.local.
         - name: KUBECONFIG
           value: /etc/kubernetes/kubeconfig/kubeconfig
-        image: docker.io/kubermatic/machine-controller:v1.13.2
+        image: docker.io/kubermatic/machine-controller:v1.14.0
         livenessProbe:
           failureThreshold: 3
           httpGet:

--- a/api/pkg/resources/test/fixtures/deployment-digitalocean-1.16.0-machine-controller-webhook.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-digitalocean-1.16.0-machine-controller-webhook.yaml
@@ -52,7 +52,7 @@ spec:
           value: apiserver-external.cluster-de-test-01.svc.cluster.local.
         - name: KUBECONFIG
           value: /etc/kubernetes/kubeconfig/kubeconfig
-        image: docker.io/kubermatic/machine-controller:v1.13.2
+        image: docker.io/kubermatic/machine-controller:v1.14.0
         livenessProbe:
           failureThreshold: 8
           httpGet:

--- a/api/pkg/resources/test/fixtures/deployment-digitalocean-1.16.0-machine-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-digitalocean-1.16.0-machine-controller.yaml
@@ -55,7 +55,7 @@ spec:
           value: apiserver-external.cluster-de-test-01.svc.cluster.local.
         - name: KUBECONFIG
           value: /etc/kubernetes/kubeconfig/kubeconfig
-        image: docker.io/kubermatic/machine-controller:v1.13.2
+        image: docker.io/kubermatic/machine-controller:v1.14.0
         livenessProbe:
           failureThreshold: 3
           httpGet:

--- a/api/pkg/resources/test/fixtures/deployment-digitalocean-1.17.0-machine-controller-webhook.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-digitalocean-1.17.0-machine-controller-webhook.yaml
@@ -52,7 +52,7 @@ spec:
           value: apiserver-external.cluster-de-test-01.svc.cluster.local.
         - name: KUBECONFIG
           value: /etc/kubernetes/kubeconfig/kubeconfig
-        image: docker.io/kubermatic/machine-controller:v1.13.2
+        image: docker.io/kubermatic/machine-controller:v1.14.0
         livenessProbe:
           failureThreshold: 8
           httpGet:

--- a/api/pkg/resources/test/fixtures/deployment-digitalocean-1.17.0-machine-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-digitalocean-1.17.0-machine-controller.yaml
@@ -55,7 +55,7 @@ spec:
           value: apiserver-external.cluster-de-test-01.svc.cluster.local.
         - name: KUBECONFIG
           value: /etc/kubernetes/kubeconfig/kubeconfig
-        image: docker.io/kubermatic/machine-controller:v1.13.2
+        image: docker.io/kubermatic/machine-controller:v1.14.0
         livenessProbe:
           failureThreshold: 3
           httpGet:

--- a/api/pkg/resources/test/fixtures/deployment-digitalocean-1.18.0-machine-controller-webhook.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-digitalocean-1.18.0-machine-controller-webhook.yaml
@@ -52,7 +52,7 @@ spec:
           value: apiserver-external.cluster-de-test-01.svc.cluster.local.
         - name: KUBECONFIG
           value: /etc/kubernetes/kubeconfig/kubeconfig
-        image: docker.io/kubermatic/machine-controller:v1.13.2
+        image: docker.io/kubermatic/machine-controller:v1.14.0
         livenessProbe:
           failureThreshold: 8
           httpGet:

--- a/api/pkg/resources/test/fixtures/deployment-digitalocean-1.18.0-machine-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-digitalocean-1.18.0-machine-controller.yaml
@@ -55,7 +55,7 @@ spec:
           value: apiserver-external.cluster-de-test-01.svc.cluster.local.
         - name: KUBECONFIG
           value: /etc/kubernetes/kubeconfig/kubeconfig
-        image: docker.io/kubermatic/machine-controller:v1.13.2
+        image: docker.io/kubermatic/machine-controller:v1.14.0
         livenessProbe:
           failureThreshold: 3
           httpGet:

--- a/api/pkg/resources/test/fixtures/deployment-openstack-1.15.0-machine-controller-webhook.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-openstack-1.15.0-machine-controller-webhook.yaml
@@ -61,7 +61,7 @@ spec:
           value: apiserver-external.cluster-de-test-01.svc.cluster.local.
         - name: KUBECONFIG
           value: /etc/kubernetes/kubeconfig/kubeconfig
-        image: docker.io/kubermatic/machine-controller:v1.13.2
+        image: docker.io/kubermatic/machine-controller:v1.14.0
         livenessProbe:
           failureThreshold: 8
           httpGet:

--- a/api/pkg/resources/test/fixtures/deployment-openstack-1.15.0-machine-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-openstack-1.15.0-machine-controller.yaml
@@ -64,7 +64,7 @@ spec:
           value: apiserver-external.cluster-de-test-01.svc.cluster.local.
         - name: KUBECONFIG
           value: /etc/kubernetes/kubeconfig/kubeconfig
-        image: docker.io/kubermatic/machine-controller:v1.13.2
+        image: docker.io/kubermatic/machine-controller:v1.14.0
         livenessProbe:
           failureThreshold: 3
           httpGet:

--- a/api/pkg/resources/test/fixtures/deployment-openstack-1.16.0-machine-controller-webhook.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-openstack-1.16.0-machine-controller-webhook.yaml
@@ -61,7 +61,7 @@ spec:
           value: apiserver-external.cluster-de-test-01.svc.cluster.local.
         - name: KUBECONFIG
           value: /etc/kubernetes/kubeconfig/kubeconfig
-        image: docker.io/kubermatic/machine-controller:v1.13.2
+        image: docker.io/kubermatic/machine-controller:v1.14.0
         livenessProbe:
           failureThreshold: 8
           httpGet:

--- a/api/pkg/resources/test/fixtures/deployment-openstack-1.16.0-machine-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-openstack-1.16.0-machine-controller.yaml
@@ -64,7 +64,7 @@ spec:
           value: apiserver-external.cluster-de-test-01.svc.cluster.local.
         - name: KUBECONFIG
           value: /etc/kubernetes/kubeconfig/kubeconfig
-        image: docker.io/kubermatic/machine-controller:v1.13.2
+        image: docker.io/kubermatic/machine-controller:v1.14.0
         livenessProbe:
           failureThreshold: 3
           httpGet:

--- a/api/pkg/resources/test/fixtures/deployment-openstack-1.17.0-machine-controller-webhook.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-openstack-1.17.0-machine-controller-webhook.yaml
@@ -61,7 +61,7 @@ spec:
           value: apiserver-external.cluster-de-test-01.svc.cluster.local.
         - name: KUBECONFIG
           value: /etc/kubernetes/kubeconfig/kubeconfig
-        image: docker.io/kubermatic/machine-controller:v1.13.2
+        image: docker.io/kubermatic/machine-controller:v1.14.0
         livenessProbe:
           failureThreshold: 8
           httpGet:

--- a/api/pkg/resources/test/fixtures/deployment-openstack-1.17.0-machine-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-openstack-1.17.0-machine-controller.yaml
@@ -64,7 +64,7 @@ spec:
           value: apiserver-external.cluster-de-test-01.svc.cluster.local.
         - name: KUBECONFIG
           value: /etc/kubernetes/kubeconfig/kubeconfig
-        image: docker.io/kubermatic/machine-controller:v1.13.2
+        image: docker.io/kubermatic/machine-controller:v1.14.0
         livenessProbe:
           failureThreshold: 3
           httpGet:

--- a/api/pkg/resources/test/fixtures/deployment-openstack-1.18.0-machine-controller-webhook.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-openstack-1.18.0-machine-controller-webhook.yaml
@@ -61,7 +61,7 @@ spec:
           value: apiserver-external.cluster-de-test-01.svc.cluster.local.
         - name: KUBECONFIG
           value: /etc/kubernetes/kubeconfig/kubeconfig
-        image: docker.io/kubermatic/machine-controller:v1.13.2
+        image: docker.io/kubermatic/machine-controller:v1.14.0
         livenessProbe:
           failureThreshold: 8
           httpGet:

--- a/api/pkg/resources/test/fixtures/deployment-openstack-1.18.0-machine-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-openstack-1.18.0-machine-controller.yaml
@@ -64,7 +64,7 @@ spec:
           value: apiserver-external.cluster-de-test-01.svc.cluster.local.
         - name: KUBECONFIG
           value: /etc/kubernetes/kubeconfig/kubeconfig
-        image: docker.io/kubermatic/machine-controller:v1.13.2
+        image: docker.io/kubermatic/machine-controller:v1.14.0
         livenessProbe:
           failureThreshold: 3
           httpGet:

--- a/api/pkg/resources/test/fixtures/deployment-vsphere-1.15.0-machine-controller-webhook.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-vsphere-1.15.0-machine-controller-webhook.yaml
@@ -56,7 +56,7 @@ spec:
           value: apiserver-external.cluster-de-test-01.svc.cluster.local.
         - name: KUBECONFIG
           value: /etc/kubernetes/kubeconfig/kubeconfig
-        image: docker.io/kubermatic/machine-controller:v1.13.2
+        image: docker.io/kubermatic/machine-controller:v1.14.0
         livenessProbe:
           failureThreshold: 8
           httpGet:

--- a/api/pkg/resources/test/fixtures/deployment-vsphere-1.15.0-machine-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-vsphere-1.15.0-machine-controller.yaml
@@ -59,7 +59,7 @@ spec:
           value: apiserver-external.cluster-de-test-01.svc.cluster.local.
         - name: KUBECONFIG
           value: /etc/kubernetes/kubeconfig/kubeconfig
-        image: docker.io/kubermatic/machine-controller:v1.13.2
+        image: docker.io/kubermatic/machine-controller:v1.14.0
         livenessProbe:
           failureThreshold: 3
           httpGet:

--- a/api/pkg/resources/test/fixtures/deployment-vsphere-1.16.0-machine-controller-webhook.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-vsphere-1.16.0-machine-controller-webhook.yaml
@@ -56,7 +56,7 @@ spec:
           value: apiserver-external.cluster-de-test-01.svc.cluster.local.
         - name: KUBECONFIG
           value: /etc/kubernetes/kubeconfig/kubeconfig
-        image: docker.io/kubermatic/machine-controller:v1.13.2
+        image: docker.io/kubermatic/machine-controller:v1.14.0
         livenessProbe:
           failureThreshold: 8
           httpGet:

--- a/api/pkg/resources/test/fixtures/deployment-vsphere-1.16.0-machine-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-vsphere-1.16.0-machine-controller.yaml
@@ -59,7 +59,7 @@ spec:
           value: apiserver-external.cluster-de-test-01.svc.cluster.local.
         - name: KUBECONFIG
           value: /etc/kubernetes/kubeconfig/kubeconfig
-        image: docker.io/kubermatic/machine-controller:v1.13.2
+        image: docker.io/kubermatic/machine-controller:v1.14.0
         livenessProbe:
           failureThreshold: 3
           httpGet:

--- a/api/pkg/resources/test/fixtures/deployment-vsphere-1.17.0-machine-controller-webhook.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-vsphere-1.17.0-machine-controller-webhook.yaml
@@ -56,7 +56,7 @@ spec:
           value: apiserver-external.cluster-de-test-01.svc.cluster.local.
         - name: KUBECONFIG
           value: /etc/kubernetes/kubeconfig/kubeconfig
-        image: docker.io/kubermatic/machine-controller:v1.13.2
+        image: docker.io/kubermatic/machine-controller:v1.14.0
         livenessProbe:
           failureThreshold: 8
           httpGet:

--- a/api/pkg/resources/test/fixtures/deployment-vsphere-1.17.0-machine-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-vsphere-1.17.0-machine-controller.yaml
@@ -59,7 +59,7 @@ spec:
           value: apiserver-external.cluster-de-test-01.svc.cluster.local.
         - name: KUBECONFIG
           value: /etc/kubernetes/kubeconfig/kubeconfig
-        image: docker.io/kubermatic/machine-controller:v1.13.2
+        image: docker.io/kubermatic/machine-controller:v1.14.0
         livenessProbe:
           failureThreshold: 3
           httpGet:

--- a/api/pkg/resources/test/fixtures/deployment-vsphere-1.18.0-machine-controller-webhook.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-vsphere-1.18.0-machine-controller-webhook.yaml
@@ -56,7 +56,7 @@ spec:
           value: apiserver-external.cluster-de-test-01.svc.cluster.local.
         - name: KUBECONFIG
           value: /etc/kubernetes/kubeconfig/kubeconfig
-        image: docker.io/kubermatic/machine-controller:v1.13.2
+        image: docker.io/kubermatic/machine-controller:v1.14.0
         livenessProbe:
           failureThreshold: 8
           httpGet:

--- a/api/pkg/resources/test/fixtures/deployment-vsphere-1.18.0-machine-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-vsphere-1.18.0-machine-controller.yaml
@@ -59,7 +59,7 @@ spec:
           value: apiserver-external.cluster-de-test-01.svc.cluster.local.
         - name: KUBECONFIG
           value: /etc/kubernetes/kubeconfig/kubeconfig
-        image: docker.io/kubermatic/machine-controller:v1.13.2
+        image: docker.io/kubermatic/machine-controller:v1.14.0
         livenessProbe:
           failureThreshold: 3
           httpGet:


### PR DESCRIPTION
**What this PR does / why we need it**:
To fix docker-ce/docker-ce-cli version skew

```release-note
upgraded machine-controller v1.14.0
```
