### PR TITLE
addon installer controller: update existing addons if needed

### DIFF
--- a/api/pkg/controller/seed-controller-manager/addoninstaller/addoninstaller_controller.go
+++ b/api/pkg/controller/seed-controller-manager/addoninstaller/addoninstaller_controller.go
@@ -3,6 +3,7 @@ package addoninstaller
 import (
 	"context"
 	"fmt"
+	"reflect"
 	"time"
 
 	"go.uber.org/zap"
@@ -152,16 +153,29 @@ func (r *Reconciler) ensureAddons(ctx context.Context, log *zap.SugaredLogger, c
 		ensuredAddonsMap[addon.Name] = struct{}{}
 		name := types.NamespacedName{Namespace: cluster.Status.NamespaceName, Name: addon.Name}
 		addonLog := log.With("addon", name)
-		err := r.Get(ctx, name, &kubermaticv1.Addon{})
-		if err == nil {
+		existingAddon := &kubermaticv1.Addon{}
+		err := r.Get(ctx, name, existingAddon)
+		if err != nil {
+			if !kerrors.IsNotFound(err) {
+				return fmt.Errorf("failed to get addon %q: %v", addon.Name, err)
+			}
+			if err := r.createAddon(ctx, addonLog, addon, cluster); err != nil {
+				return fmt.Errorf("failed to create addon %q: %v", addon.Name, err)
+			}
+		} else {
 			addonLog.Debug("Addon already exists")
-			continue
-		}
-		if !kerrors.IsNotFound(err) {
-			return fmt.Errorf("failed to get addon %q: %v", addon.Name, err)
-		}
-		if err := r.createAddon(ctx, addonLog, addon, cluster); err != nil {
-			return fmt.Errorf("failed to create addon %q: %v", addon.Name, err)
+			if !reflect.DeepEqual(addon.Labels, existingAddon.Labels) || !reflect.DeepEqual(addon.Annotations, existingAddon.Annotations) || !reflect.DeepEqual(addon.Spec.Variables, existingAddon.Spec.Variables) || !reflect.DeepEqual(addon.Spec.RequiredResourceTypes, existingAddon.Spec.RequiredResourceTypes) {
+				updatedAddon := existingAddon.DeepCopy()
+				updatedAddon.Labels = addon.Labels
+				updatedAddon.Annotations = addon.Annotations
+				updatedAddon.Spec.Name = addon.Name
+				updatedAddon.Spec.Variables = addon.Spec.Variables
+				updatedAddon.Spec.RequiredResourceTypes = addon.Spec.RequiredResourceTypes
+				updatedAddon.Spec.IsDefault = true
+				if err := r.Patch(ctx, updatedAddon, ctrlruntimeclient.MergeFrom(existingAddon)); err != nil {
+					return fmt.Errorf("failed to update addon %q: %v", addon.Name, err)
+				}
+			}
 		}
 	}
 

--- a/api/pkg/controller/seed-controller-manager/addoninstaller/addoninstaller_controller_test.go
+++ b/api/pkg/controller/seed-controller-manager/addoninstaller/addoninstaller_controller_test.go
@@ -18,7 +18,11 @@ import (
 
 var addons = kubermaticv1.AddonList{Items: []kubermaticv1.Addon{
 	{ObjectMeta: metav1.ObjectMeta{Name: "Foo"}},
-	{ObjectMeta: metav1.ObjectMeta{Name: "Bar"}},
+	{ObjectMeta: metav1.ObjectMeta{
+		Name:        "Bar",
+		Labels:      map[string]string{"addons.kubermatic.io/ensure": "true"},
+		Annotations: map[string]string{"foo": "bar"},
+	}},
 }}
 
 func truePtr() *bool {
@@ -73,6 +77,8 @@ func TestCreateAddon(t *testing.T) {
 						Name:            "Bar",
 						Namespace:       "cluster-" + name,
 						ResourceVersion: "1",
+						Labels:          map[string]string{"addons.kubermatic.io/ensure": "true"},
+						Annotations:     map[string]string{"foo": "bar"},
 						OwnerReferences: []metav1.OwnerReference{
 							{
 								APIVersion:         "kubermatic.k8s.io/v1",
@@ -114,6 +120,159 @@ func TestCreateAddon(t *testing.T) {
 
 		t.Run(test.name, func(t *testing.T) {
 			objs := []runtime.Object{test.cluster}
+
+			client := ctrlruntimefakeclient.NewFakeClient(objs...)
+
+			reconciler := Reconciler{
+				log:              kubermaticlog.New(true, kubermaticlog.FormatConsole).Sugar(),
+				Client:           client,
+				kubernetesAddons: addons,
+			}
+
+			if _, err := reconciler.reconcile(context.Background(), reconciler.log, test.cluster); err != nil {
+				t.Fatalf("Reconciliation failed: %v", err)
+			}
+
+			for _, expectedAddon := range test.expectedClusterAddons {
+				addonFromClient := &kubermaticv1.Addon{}
+				if err := client.Get(context.Background(),
+					types.NamespacedName{Namespace: test.cluster.Status.NamespaceName, Name: expectedAddon.Name},
+					addonFromClient); err != nil {
+					t.Fatalf("Did not find expected addon %q", expectedAddon.Name)
+				}
+				if diff := deep.Equal(addonFromClient, expectedAddon); diff != nil {
+					t.Errorf("created addon is not equal to expected addon, diff: %v", diff)
+				}
+			}
+
+		})
+	}
+}
+
+func TestUpdateAddon(t *testing.T) {
+	name := "test-cluster"
+	tests := []struct {
+		name                  string
+		existingClusterAddons []*kubermaticv1.Addon
+		expectedClusterAddons []*kubermaticv1.Addon
+		cluster               *kubermaticv1.Cluster
+	}{
+		{
+			name: "successfully created one addon and updated another",
+			existingClusterAddons: []*kubermaticv1.Addon{
+				{
+					TypeMeta: metav1.TypeMeta{
+						APIVersion: "kubermatic.k8s.io/v1",
+						Kind:       "Addon",
+					},
+					ObjectMeta: metav1.ObjectMeta{
+						Name:            "Bar",
+						Namespace:       "cluster-" + name,
+						ResourceVersion: "1",
+						OwnerReferences: []metav1.OwnerReference{
+							{
+								APIVersion:         "kubermatic.k8s.io/v1",
+								Kind:               "Cluster",
+								Name:               name,
+								Controller:         truePtr(),
+								BlockOwnerDeletion: truePtr(),
+							},
+						},
+					},
+					Spec: kubermaticv1.AddonSpec{
+						Name: "Bar",
+						Cluster: corev1.ObjectReference{
+							Kind: "Cluster",
+							Name: name,
+						},
+						IsDefault: true,
+					},
+				},
+			},
+			expectedClusterAddons: []*kubermaticv1.Addon{
+				{
+					TypeMeta: metav1.TypeMeta{
+						APIVersion: "kubermatic.k8s.io/v1",
+						Kind:       "Addon",
+					},
+					ObjectMeta: metav1.ObjectMeta{
+						Name:            "Foo",
+						Namespace:       "cluster-" + name,
+						ResourceVersion: "1",
+						OwnerReferences: []metav1.OwnerReference{
+							{
+								APIVersion:         "kubermatic.k8s.io/v1",
+								Kind:               "Cluster",
+								Name:               name,
+								Controller:         truePtr(),
+								BlockOwnerDeletion: truePtr(),
+							},
+						},
+					},
+					Spec: kubermaticv1.AddonSpec{
+						Name: "Foo",
+						Cluster: corev1.ObjectReference{
+							Kind: "Cluster",
+							Name: name,
+						},
+						IsDefault: true,
+					},
+				},
+				{
+					TypeMeta: metav1.TypeMeta{
+						APIVersion: "kubermatic.k8s.io/v1",
+						Kind:       "Addon",
+					},
+					ObjectMeta: metav1.ObjectMeta{
+						Name:            "Bar",
+						Namespace:       "cluster-" + name,
+						Labels:          map[string]string{"addons.kubermatic.io/ensure": "true"},
+						Annotations:     map[string]string{"foo": "bar"},
+						ResourceVersion: "2",
+						OwnerReferences: []metav1.OwnerReference{
+							{
+								APIVersion:         "kubermatic.k8s.io/v1",
+								Kind:               "Cluster",
+								Name:               name,
+								Controller:         truePtr(),
+								BlockOwnerDeletion: truePtr(),
+							},
+						},
+					},
+					Spec: kubermaticv1.AddonSpec{
+						Name: "Bar",
+						Cluster: corev1.ObjectReference{
+							Kind: "Cluster",
+							Name: name,
+						},
+						IsDefault: true,
+					},
+				},
+			},
+			cluster: &kubermaticv1.Cluster{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: name,
+				},
+				Spec:    kubermaticv1.ClusterSpec{},
+				Address: kubermaticv1.ClusterAddress{},
+				Status: kubermaticv1.ClusterStatus{
+					ExtendedHealth: kubermaticv1.ExtendedClusterHealth{
+
+						Apiserver: kubermaticv1.HealthStatusUp,
+					},
+					NamespaceName: "cluster-" + name,
+				},
+			},
+		},
+	}
+
+	for _, test := range tests {
+
+		t.Run(test.name, func(t *testing.T) {
+			objs := []runtime.Object{test.cluster}
+			for _, a := range test.existingClusterAddons {
+				objs = append(objs, a)
+			}
 
 			client := ctrlruntimefakeclient.NewFakeClient(objs...)
 


### PR DESCRIPTION
Signed-off-by: Olaf Klischat <o.klischat@syseleven.de>

**What this PR does / why we need it**:

This extends the addon installer controller so it not only installs default addons if they don't exist, but also updates them in case the in-cluster resource isn't the same as the one from the DefaultKubernetesAddons list. This became necessary for us after https://github.com/kubermatic/kubermatic/pull/5193 and was mentioned briefly in https://github.com/kubermatic/kubermatic/pull/5193#issuecomment-630142192.

**Documentation**:
<!-- Add links to the related documentation changes related to this pull request. E.g. the link to the kubermatic/docs pullrequest. -->

**Does this PR introduce a user-facing change?**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If  no release note is required, just write "NONE".
-->
```release-note
Existing default addons will be updated if their definition is changed.
```
