### PR TITLE
ensure the node-labeler controller uses consistent labels

### DIFF
--- a/api/pkg/controller/user-cluster-controller-manager/node-labeler/node_labeleler.go
+++ b/api/pkg/controller/user-cluster-controller-manager/node-labeler/node_labeleler.go
@@ -125,23 +125,36 @@ func (r *reconciler) reconcile(log *zap.SugaredLogger, node *corev1.Node) error 
 }
 
 func applyDistributionLabel(log *zap.SugaredLogger, node *corev1.Node) (changed bool, err error) {
-	osImage := strings.ToLower(node.Status.NodeInfo.OSImage)
+	osImage := node.Status.NodeInfo.OSImage
 
-	var wantValue string
-	for k, v := range api.OSLabelMatchValues {
-		if strings.Contains(osImage, v) {
-			wantValue = k
-		}
-	}
-	if wantValue == "" {
-		return false, fmt.Errorf("Could not detect distribution from image name %q", osImage)
+	wantedLabel := findDistributionLabel(node.Status.NodeInfo.OSImage)
+	if wantedLabel == "" {
+		return false, fmt.Errorf("could not detect distribution from image name %q", osImage)
 	}
 
-	if node.Labels[api.DistributionLabelKey] == wantValue {
+	if node.Labels[api.DistributionLabelKey] == wantedLabel {
 		return false, nil
 	}
 
-	node.Labels[api.DistributionLabelKey] = wantValue
-	log.Debugw("Setting label", "label-key", api.DistributionLabelKey, "old-label-value", node.Labels[api.DistributionLabelKey], "new-label-value", wantValue)
+	node.Labels[api.DistributionLabelKey] = wantedLabel
+	log.Debugw("Setting label", "label-key", api.DistributionLabelKey, "old-label-value", node.Labels[api.DistributionLabelKey], "new-label-value", wantedLabel)
 	return true, nil
+}
+
+// findDistributionLabel finds the best label value for a given
+// OS image string. It returns the longest match to ensure consistent
+// results.
+func findDistributionLabel(osImage string) string {
+	osImage = strings.ToLower(osImage)
+
+	matchedLabel := ""
+	matchedValue := ""
+	for k, v := range api.OSLabelMatchValues {
+		if strings.Contains(osImage, v) && len(v) > len(matchedValue) {
+			matchedLabel = k
+			matchedValue = v
+		}
+	}
+
+	return matchedLabel
 }


### PR DESCRIPTION
**What this PR does / why we need it**:
Depending on the map iteration order, the node labeler controller labelled "flatcar container linux" systems sometimes as "container linux" because of its substring matching. To make the logic consistent, we now only consider the longest label match.

This should make e2e tests much less flaky.

**Does this PR introduce a user-facing change?**:
```release-note
Fix nodes sometimes not having the correct distribution label applied.
```
