### PR TITLE
make kubernetes cluster type as default

### DIFF
--- a/api/pkg/handler/test/helper.go
+++ b/api/pkg/handler/test/helper.go
@@ -917,3 +917,25 @@ func GenDefaultPreset() *kubermaticv1.Preset {
 		},
 	}
 }
+
+func GenDefaultSettings() *kubermaticv1.KubermaticSetting {
+	return &kubermaticv1.KubermaticSetting{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: kubermaticv1.GlobalSettingsName,
+		},
+		Spec: kubermaticv1.SettingSpec{
+			CustomLinks: []kubermaticv1.CustomLink{},
+			CleanupOptions: kubermaticv1.CleanupOptions{
+				Enabled:  false,
+				Enforced: false,
+			},
+			DefaultNodeCount:      10,
+			ClusterTypeOptions:    kubermaticv1.ClusterTypeAll,
+			DisplayDemoInfo:       false,
+			DisplayAPIDocs:        false,
+			DisplayTermsOfService: false,
+			EnableDashboard:       true,
+			EnableOIDCKubeconfig:  false,
+		},
+	}
+}

--- a/api/pkg/handler/v1/admin/settings_test.go
+++ b/api/pkg/handler/v1/admin/settings_test.go
@@ -28,7 +28,7 @@ func TestGetGlobalSettings(t *testing.T) {
 		// scenario 1
 		{
 			name:                   "scenario 1: user gets settings first time",
-			expectedResponse:       `{"customLinks":[],"cleanupOptions":{"Enabled":false,"Enforced":false},"defaultNodeCount":10,"clusterTypeOptions":0,"displayDemoInfo":false,"displayAPIDocs":false,"displayTermsOfService":false,"enableDashboard":true,"enableOIDCKubeconfig":false}`,
+			expectedResponse:       `{"customLinks":[],"cleanupOptions":{"Enabled":false,"Enforced":false},"defaultNodeCount":10,"clusterTypeOptions":1,"displayDemoInfo":false,"displayAPIDocs":false,"displayTermsOfService":false,"enableDashboard":true,"enableOIDCKubeconfig":false}`,
 			httpStatus:             http.StatusOK,
 			existingKubermaticObjs: []runtime.Object{genUser("Bob", "bob@acme.com", true)},
 			existingAPIUser:        test.GenDefaultAPIUser(),

--- a/api/pkg/handler/v1/cluster/cluster_test.go
+++ b/api/pkg/handler/v1/cluster/cluster_test.go
@@ -966,7 +966,7 @@ func TestCreateClusterEndpoint(t *testing.T) {
 			RewriteClusterID:       true,
 			HTTPStatus:             http.StatusCreated,
 			ProjectToSync:          test.GenDefaultProject().Name,
-			ExistingKubermaticObjs: test.GenDefaultKubermaticObjects(),
+			ExistingKubermaticObjs: test.GenDefaultKubermaticObjects(test.GenDefaultSettings()),
 			ExistingAPIUser:        test.GenDefaultAPIUser(),
 		},
 		// scenario 6
@@ -977,7 +977,7 @@ func TestCreateClusterEndpoint(t *testing.T) {
 			RewriteClusterID:       true,
 			HTTPStatus:             http.StatusCreated,
 			ProjectToSync:          test.GenDefaultProject().Name,
-			ExistingKubermaticObjs: test.GenDefaultKubermaticObjects(),
+			ExistingKubermaticObjs: test.GenDefaultKubermaticObjects(test.GenDefaultSettings()),
 			ExistingAPIUser:        test.GenDefaultAPIUser(),
 		},
 		// scenario 7
@@ -987,7 +987,7 @@ func TestCreateClusterEndpoint(t *testing.T) {
 			ExpectedResponse:       `{"error":{"code":400,"message":"invalid credentials: missing preset 'default' for the user 'bob@acme.com'"}}`,
 			HTTPStatus:             http.StatusBadRequest,
 			ProjectToSync:          test.GenDefaultProject().Name,
-			ExistingKubermaticObjs: test.GenDefaultKubermaticObjects(),
+			ExistingKubermaticObjs: test.GenDefaultKubermaticObjects(test.GenDefaultSettings()),
 			ExistingAPIUser:        test.GenDefaultAPIUser(),
 		},
 		{
@@ -996,7 +996,7 @@ func TestCreateClusterEndpoint(t *testing.T) {
 			ExpectedResponse:       `{"error":{"code":400,"message":"openshift clusters must be configured with an imagePullSecret"}}`,
 			HTTPStatus:             http.StatusBadRequest,
 			ProjectToSync:          test.GenDefaultProject().Name,
-			ExistingKubermaticObjs: test.GenDefaultKubermaticObjects(),
+			ExistingKubermaticObjs: test.GenDefaultKubermaticObjects(test.GenDefaultSettings()),
 			ExistingAPIUser:        test.GenDefaultAPIUser(),
 		},
 		{

--- a/api/pkg/provider/kubernetes/settings.go
+++ b/api/pkg/provider/kubernetes/settings.go
@@ -2,7 +2,6 @@ package kubernetes
 
 import (
 	"fmt"
-	"k8s.io/apimachinery/pkg/watch"
 
 	kubermaticclientset "github.com/kubermatic/kubermatic/api/pkg/crd/client/clientset/versioned"
 	kubermaticv1lister "github.com/kubermatic/kubermatic/api/pkg/crd/client/listers/kubermatic/v1"
@@ -12,6 +11,7 @@ import (
 	kerrors "k8s.io/apimachinery/pkg/api/errors"
 	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/apimachinery/pkg/watch"
 )
 
 // UserProvider manages user resources
@@ -62,7 +62,7 @@ func (s *SettingsProvider) createDefaultGlobalSettings() (*kubermaticv1.Kubermat
 				Enforced: false,
 			},
 			DefaultNodeCount:      10,
-			ClusterTypeOptions:    kubermaticv1.ClusterTypeAll,
+			ClusterTypeOptions:    kubermaticv1.ClusterTypeKubernetes,
 			DisplayDemoInfo:       false,
 			DisplayAPIDocs:        false,
 			DisplayTermsOfService: false,

--- a/api/pkg/test/e2e/api/settings_test.go
+++ b/api/pkg/test/e2e/api/settings_test.go
@@ -26,7 +26,7 @@ func TestGetDefaultGlobalSettings(t *testing.T) {
 					Enforced: false,
 				},
 				DefaultNodeCount:      10,
-				ClusterTypeOptions:    kubermaticv1.ClusterTypeAll,
+				ClusterTypeOptions:    kubermaticv1.ClusterTypeKubernetes,
 				DisplayDemoInfo:       false,
 				DisplayAPIDocs:        false,
 				DisplayTermsOfService: false,


### PR DESCRIPTION
**What this PR does / why we need it**: make Kubernetes cluster type as default

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #5438

```release-note
NONE
```
