### PR TITLE
use controller runtime impersonation client for member provider

### DIFF
--- a/api/pkg/handler/test/helper.go
+++ b/api/pkg/handler/test/helper.go
@@ -168,7 +168,9 @@ func initTestEndpoint(user apiv1.User, seedsGetter provider.SeedsGetter, kubeObj
 	fakeKubernetesImpersonationClient := func(impCfg restclient.ImpersonationConfig) (kubernetesclientset.Interface, error) {
 		return kubernetesClient, nil
 	}
-
+	fakeImpersonationClient := func(impCfg restclient.ImpersonationConfig) (ctrlruntimeclient.Client, error) {
+		return fakeClient, nil
+	}
 	userLister := kubermaticInformerFactory.Kubermatic().V1().Users().Lister()
 	sshKeyProvider := kubernetes.NewSSHKeyProvider(fakeKubermaticImpersonationClient, fakeClient)
 	privilegedSSHKeyProvider, err := kubernetes.NewPrivilegedSSHKeyProvider(fakeClient)
@@ -189,7 +191,7 @@ func initTestEndpoint(user apiv1.User, seedsGetter provider.SeedsGetter, kubeObj
 		return nil, nil, err
 	}
 	serviceAccountProvider := kubernetes.NewServiceAccountProvider(fakeKubermaticImpersonationClient, fakeClient, "localhost")
-	projectMemberProvider := kubernetes.NewProjectMemberProvider(fakeKubermaticImpersonationClient, fakeClient, kubernetes.IsServiceAccount)
+	projectMemberProvider := kubernetes.NewProjectMemberProvider(fakeImpersonationClient, fakeClient, kubernetes.IsServiceAccount)
 	userInfoGetter, err := provider.UserInfoGetterFactory(projectMemberProvider)
 	if err != nil {
 		return nil, nil, err

--- a/api/pkg/handler/v1/project/project_test.go
+++ b/api/pkg/handler/v1/project/project_test.go
@@ -458,8 +458,11 @@ func TestListProjectMethod(t *testing.T) {
 			fakeClient := fakectrlruntimeclient.NewFakeClientWithScheme(scheme.Scheme, tc.ExistingKubermaticObjects...)
 			kubermaticInformerFactory := kubermaticinformers.NewSharedInformerFactory(kubermaticClient, 10*time.Millisecond)
 
-			fakeImpersonationClient := func(impCfg restclient.ImpersonationConfig) (kubermaticclientv1.KubermaticV1Interface, error) {
+			fakeKubermaticImpersonationClient := func(impCfg restclient.ImpersonationConfig) (kubermaticclientv1.KubermaticV1Interface, error) {
 				return kubermaticClient.KubermaticV1(), nil
+			}
+			fakeImpersonationClient := func(impCfg restclient.ImpersonationConfig) (ctrlruntimeclient.Client, error) {
+				return fakeClient, nil
 			}
 			projectMemberProvider := kubernetes.NewProjectMemberProvider(fakeImpersonationClient, fakeClient, kubernetes.IsServiceAccount)
 			userProvider := kubernetes.NewUserProvider(fakeClient, kubernetes.IsServiceAccount)
@@ -473,7 +476,7 @@ func TestListProjectMethod(t *testing.T) {
 			kubernetesClient := fakerestclient.NewSimpleClientset([]runtime.Object{}...)
 			clusterProvider := kubernetes.NewClusterProvider(
 				&restclient.Config{},
-				fakeImpersonationClient,
+				fakeKubermaticImpersonationClient,
 				fUserClusterConnection,
 				"",
 				rbac.ExtractGroupPrefix,

--- a/api/pkg/handler/v1/user/user_test.go
+++ b/api/pkg/handler/v1/user/user_test.go
@@ -220,7 +220,7 @@ func TestGetUsersForProject(t *testing.T) {
 			res := httptest.NewRecorder()
 			kubermaticObj := []runtime.Object{}
 			kubermaticObj = append(kubermaticObj, tc.ExistingKubermaticObjs...)
-			ep, _, err := test.CreateTestEndpointAndGetClients(tc.ExistingAPIUser, nil, []runtime.Object{}, []runtime.Object{}, kubermaticObj, nil, nil, hack.NewTestRouting)
+			ep, err := test.CreateTestEndpoint(tc.ExistingAPIUser, []runtime.Object{}, kubermaticObj, nil, nil, hack.NewTestRouting)
 			if err != nil {
 				t.Fatalf("failed to create test endpoint due to %v", err)
 			}
@@ -252,15 +252,14 @@ func TestGetUsersForProject(t *testing.T) {
 func TestDeleteUserFromProject(t *testing.T) {
 	t.Parallel()
 	testcases := []struct {
-		Name                         string
-		Body                         string
-		ExpectedResponse             string
-		ExpectedBindingIDAfterDelete string
-		ProjectToSync                string
-		UserIDToDelete               string
-		HTTPStatus                   int
-		ExistingAPIUser              apiv1.User
-		ExistingKubermaticObjs       []runtime.Object
+		Name                   string
+		Body                   string
+		ExpectedResponse       string
+		ProjectToSync          string
+		UserIDToDelete         string
+		HTTPStatus             int
+		ExistingAPIUser        apiv1.User
+		ExistingKubermaticObjs []runtime.Object
 	}{
 		// scenario 1
 		{
@@ -281,10 +280,9 @@ func TestDeleteUserFromProject(t *testing.T) {
 				genUser("", "john", "john@acme.com"),
 				genDefaultUser(), /*bob*/
 			},
-			UserIDToDelete:               genDefaultUser().Name,
-			ExistingAPIUser:              *genAPIUser("john", "john@acme.com"),
-			ExpectedResponse:             `{}`,
-			ExpectedBindingIDAfterDelete: test.GenBinding("plan9-ID", "bob@acme.com", "viewers").Name,
+			UserIDToDelete:   genDefaultUser().Name,
+			ExistingAPIUser:  *genAPIUser("john", "john@acme.com"),
+			ExpectedResponse: `{}`,
 		},
 
 		// scenario 2
@@ -350,10 +348,9 @@ func TestDeleteUserFromProject(t *testing.T) {
 				genUser("", "john", "john@acme.com"),
 				genDefaultUser(), /*bob*/
 			},
-			UserIDToDelete:               genDefaultUser().Name,
-			ExistingAPIUser:              *genAPIUser("john", "john@acme.com"),
-			ExpectedResponse:             `{}`,
-			ExpectedBindingIDAfterDelete: test.GenBinding("plan9-ID", "bob@acme.com", "viewers").Name,
+			UserIDToDelete:   genDefaultUser().Name,
+			ExistingAPIUser:  *genAPIUser("john", "john@acme.com"),
+			ExpectedResponse: `{}`,
 		},
 
 		// scenario 5
@@ -376,10 +373,9 @@ func TestDeleteUserFromProject(t *testing.T) {
 				genDefaultUser(), /*bob*/
 				genDefaultAdminUser(),
 			},
-			UserIDToDelete:               genDefaultUser().Name,
-			ExistingAPIUser:              *genAPIUser("admin", "admin@acme.com"),
-			ExpectedResponse:             `{}`,
-			ExpectedBindingIDAfterDelete: test.GenBinding("plan9-ID", "bob@acme.com", "viewers").Name,
+			UserIDToDelete:   genDefaultUser().Name,
+			ExistingAPIUser:  *genAPIUser("admin", "admin@acme.com"),
+			ExpectedResponse: `{}`,
 		},
 	}
 	for _, tc := range testcases {
@@ -388,7 +384,7 @@ func TestDeleteUserFromProject(t *testing.T) {
 			res := httptest.NewRecorder()
 			kubermaticObj := []runtime.Object{}
 			kubermaticObj = append(kubermaticObj, tc.ExistingKubermaticObjs...)
-			ep, _, err := test.CreateTestEndpointAndGetClients(tc.ExistingAPIUser, nil, []runtime.Object{}, []runtime.Object{}, kubermaticObj, nil, nil, hack.NewTestRouting)
+			ep, err := test.CreateTestEndpoint(tc.ExistingAPIUser, nil, kubermaticObj, nil, nil, hack.NewTestRouting)
 			if err != nil {
 				t.Fatalf("failed to create test endpoint due to %v", err)
 			}
@@ -406,15 +402,14 @@ func TestDeleteUserFromProject(t *testing.T) {
 func TestEditUserInProject(t *testing.T) {
 	t.Parallel()
 	testcases := []struct {
-		Name                       string
-		Body                       string
-		ExpectedResponse           string
-		ExpectedBindingAfterUpdate *kubermaticapiv1.UserProjectBinding
-		ProjectToSync              string
-		UserIDToUpdate             string
-		HTTPStatus                 int
-		ExistingAPIUser            apiv1.User
-		ExistingKubermaticObjs     []runtime.Object
+		Name                   string
+		Body                   string
+		ExpectedResponse       string
+		ProjectToSync          string
+		UserIDToUpdate         string
+		HTTPStatus             int
+		ExistingAPIUser        apiv1.User
+		ExistingKubermaticObjs []runtime.Object
 	}{
 		// scenario 1
 		{
@@ -438,12 +433,6 @@ func TestEditUserInProject(t *testing.T) {
 			UserIDToUpdate:   genDefaultUser().Name,
 			ExistingAPIUser:  *genAPIUser("john", "john@acme.com"),
 			ExpectedResponse: `{"id":"405ac8384fa984f787f9486daf34d84d98f20c4d6a12e2cc4ed89be3bcb06ad6","name":"Bob","creationTimestamp":"0001-01-01T00:00:00Z","email":"bob@acme.com","projects":[{"id":"plan9-ID","group":"editors"}]}`,
-			ExpectedBindingAfterUpdate: func() *kubermaticapiv1.UserProjectBinding {
-				binding := test.GenBinding("plan9-ID", "bob@acme.com", "editors")
-				// the name of the original binding was derived from projectID, email and group
-				binding.Name = test.GenBinding("plan9-ID", "bob@acme.com", "viewers").Name
-				return binding
-			}(),
 		},
 
 		// scenario 2
@@ -537,12 +526,6 @@ func TestEditUserInProject(t *testing.T) {
 			UserIDToUpdate:   genDefaultUser().Name,
 			ExistingAPIUser:  *genAPIUser("john", "john@acme.com"),
 			ExpectedResponse: `{"id":"405ac8384fa984f787f9486daf34d84d98f20c4d6a12e2cc4ed89be3bcb06ad6","name":"Bob","creationTimestamp":"0001-01-01T00:00:00Z","email":"bob@acme.com","projects":[{"id":"plan9-ID","group":"editors"}]}`,
-			ExpectedBindingAfterUpdate: func() *kubermaticapiv1.UserProjectBinding {
-				binding := test.GenBinding("plan9-ID", "bob@acme.com", "editors")
-				// the name of the original binding was derived from projectID, email and group
-				binding.Name = test.GenBinding("plan9-ID", "bob@acme.com", "viewers").Name
-				return binding
-			}(),
 		},
 		// scenario 6
 		{
@@ -567,12 +550,6 @@ func TestEditUserInProject(t *testing.T) {
 			UserIDToUpdate:   genDefaultUser().Name,
 			ExistingAPIUser:  *genAPIUser("admin", "admin@acme.com"),
 			ExpectedResponse: `{"id":"405ac8384fa984f787f9486daf34d84d98f20c4d6a12e2cc4ed89be3bcb06ad6","name":"Bob","creationTimestamp":"0001-01-01T00:00:00Z","email":"bob@acme.com","projects":[{"id":"plan9-ID","group":"editors"}]}`,
-			ExpectedBindingAfterUpdate: func() *kubermaticapiv1.UserProjectBinding {
-				binding := test.GenBinding("plan9-ID", "bob@acme.com", "editors")
-				// the name of the original binding was derived from projectID, email and group
-				binding.Name = test.GenBinding("plan9-ID", "bob@acme.com", "viewers").Name
-				return binding
-			}(),
 		},
 	}
 	for _, tc := range testcases {
@@ -581,7 +558,7 @@ func TestEditUserInProject(t *testing.T) {
 			res := httptest.NewRecorder()
 			kubermaticObj := []runtime.Object{}
 			kubermaticObj = append(kubermaticObj, tc.ExistingKubermaticObjs...)
-			ep, _, err := test.CreateTestEndpointAndGetClients(tc.ExistingAPIUser, nil, []runtime.Object{}, []runtime.Object{}, kubermaticObj, nil, nil, hack.NewTestRouting)
+			ep, err := test.CreateTestEndpoint(tc.ExistingAPIUser, []runtime.Object{}, kubermaticObj, nil, nil, hack.NewTestRouting)
 			if err != nil {
 				t.Fatalf("failed to create test endpoint due to %v", err)
 			}
@@ -599,14 +576,13 @@ func TestEditUserInProject(t *testing.T) {
 func TestAddUserToProject(t *testing.T) {
 	t.Parallel()
 	testcases := []struct {
-		Name                           string
-		Body                           string
-		ExpectedResponse               string
-		ExpectedBindingAfterInvitation *kubermaticapiv1.UserProjectBinding
-		ProjectToSync                  string
-		HTTPStatus                     int
-		ExistingAPIUser                apiv1.User
-		ExistingKubermaticObjs         []runtime.Object
+		Name                   string
+		Body                   string
+		ExpectedResponse       string
+		ProjectToSync          string
+		HTTPStatus             int
+		ExistingAPIUser        apiv1.User
+		ExistingKubermaticObjs []runtime.Object
 	}{
 		{
 			Name:          "scenario 1: john the owner of the plan9 project invites bob to the project as an editor",
@@ -628,22 +604,6 @@ func TestAddUserToProject(t *testing.T) {
 			},
 			ExistingAPIUser:  *genAPIUser("john", "john@acme.com"),
 			ExpectedResponse: `{"id":"405ac8384fa984f787f9486daf34d84d98f20c4d6a12e2cc4ed89be3bcb06ad6","name":"Bob","creationTimestamp":"0001-01-01T00:00:00Z","email":"bob@acme.com","projects":[{"id":"plan9-ID","group":"editors"}]}`,
-			ExpectedBindingAfterInvitation: &kubermaticapiv1.UserProjectBinding{
-				ObjectMeta: metav1.ObjectMeta{
-					OwnerReferences: []metav1.OwnerReference{
-						{
-							APIVersion: kubermaticapiv1.SchemeGroupVersion.String(),
-							Kind:       kubermaticapiv1.ProjectKindName,
-							Name:       "plan9-ID",
-						},
-					},
-				},
-				Spec: kubermaticapiv1.UserProjectBindingSpec{
-					UserEmail: "bob@acme.com",
-					Group:     "editors-plan9-ID",
-					ProjectID: "plan9-ID",
-				},
-			},
 		},
 
 		{
@@ -776,22 +736,6 @@ func TestAddUserToProject(t *testing.T) {
 			},
 			ExistingAPIUser:  *genAPIUser("john", "john@acme.com"),
 			ExpectedResponse: `{"id":"405ac8384fa984f787f9486daf34d84d98f20c4d6a12e2cc4ed89be3bcb06ad6","name":"Bob","creationTimestamp":"0001-01-01T00:00:00Z","email":"bob@acme.com","projects":[{"id":"plan9-ID","group":"editors"}]}`,
-			ExpectedBindingAfterInvitation: &kubermaticapiv1.UserProjectBinding{
-				ObjectMeta: metav1.ObjectMeta{
-					OwnerReferences: []metav1.OwnerReference{
-						{
-							APIVersion: kubermaticapiv1.SchemeGroupVersion.String(),
-							Kind:       kubermaticapiv1.ProjectKindName,
-							Name:       "plan9-ID",
-						},
-					},
-				},
-				Spec: kubermaticapiv1.UserProjectBindingSpec{
-					UserEmail: "bob@acme.com",
-					Group:     "editors-plan9-ID",
-					ProjectID: "plan9-ID",
-				},
-			},
 		},
 
 		{
@@ -837,22 +781,6 @@ func TestAddUserToProject(t *testing.T) {
 			},
 			ExistingAPIUser:  *genAPIUser("admin", "admin@acme.com"),
 			ExpectedResponse: `{"id":"405ac8384fa984f787f9486daf34d84d98f20c4d6a12e2cc4ed89be3bcb06ad6","name":"Bob","creationTimestamp":"0001-01-01T00:00:00Z","email":"bob@acme.com","projects":[{"id":"plan9-ID","group":"editors"}]}`,
-			ExpectedBindingAfterInvitation: &kubermaticapiv1.UserProjectBinding{
-				ObjectMeta: metav1.ObjectMeta{
-					OwnerReferences: []metav1.OwnerReference{
-						{
-							APIVersion: kubermaticapiv1.SchemeGroupVersion.String(),
-							Kind:       kubermaticapiv1.ProjectKindName,
-							Name:       "plan9-ID",
-						},
-					},
-				},
-				Spec: kubermaticapiv1.UserProjectBindingSpec{
-					UserEmail: "bob@acme.com",
-					Group:     "editors-plan9-ID",
-					ProjectID: "plan9-ID",
-				},
-			},
 		},
 	}
 
@@ -862,7 +790,7 @@ func TestAddUserToProject(t *testing.T) {
 			res := httptest.NewRecorder()
 			kubermaticObj := []runtime.Object{}
 			kubermaticObj = append(kubermaticObj, tc.ExistingKubermaticObjs...)
-			ep, _, err := test.CreateTestEndpointAndGetClients(tc.ExistingAPIUser, nil, []runtime.Object{}, []runtime.Object{}, kubermaticObj, nil, nil, hack.NewTestRouting)
+			ep, err := test.CreateTestEndpoint(tc.ExistingAPIUser, []runtime.Object{}, kubermaticObj, nil, nil, hack.NewTestRouting)
 			if err != nil {
 				t.Fatalf("failed to create test endpoint due to %v", err)
 			}
@@ -917,7 +845,7 @@ func TestGetCurrentUser(t *testing.T) {
 		t.Run(tc.Name, func(t *testing.T) {
 			kubermaticObj := []runtime.Object{}
 			kubermaticObj = append(kubermaticObj, tc.ExistingKubermaticObjs...)
-			ep, _, err := test.CreateTestEndpointAndGetClients(tc.ExistingAPIUser, nil, []runtime.Object{}, []runtime.Object{}, kubermaticObj, nil, nil, hack.NewTestRouting)
+			ep, err := test.CreateTestEndpoint(tc.ExistingAPIUser, []runtime.Object{}, kubermaticObj, nil, nil, hack.NewTestRouting)
 			if err != nil {
 				t.Fatalf("failed to create test endpoint due to %v", err)
 			}
@@ -981,7 +909,7 @@ func TestNewUser(t *testing.T) {
 	for _, tc := range testcases {
 		t.Run(tc.Name, func(t *testing.T) {
 
-			ep, _, err := test.CreateTestEndpointAndGetClients(*tc.ExistingAPIUser, nil, []runtime.Object{}, []runtime.Object{}, tc.ExistingKubermaticObjects, nil, nil, hack.NewTestRouting)
+			ep, err := test.CreateTestEndpoint(*tc.ExistingAPIUser, []runtime.Object{}, tc.ExistingKubermaticObjects, nil, nil, hack.NewTestRouting)
 			if err != nil {
 				t.Fatalf("failed to create test endpoint due to %v", err)
 			}

--- a/api/pkg/provider/kubernetes/cluster_test.go
+++ b/api/pkg/provider/kubernetes/cluster_test.go
@@ -86,7 +86,7 @@ func TestCreateCluster(t *testing.T) {
 			}
 
 			// act
-			target := kubernetes.NewClusterProvider(&restclient.Config{}, impersonationClient.CreateFakeImpersonatedClientSet, nil, tc.workerName, nil, nil, nil, tc.shareKubeconfig)
+			target := kubernetes.NewClusterProvider(&restclient.Config{}, impersonationClient.CreateFakeKubermaticImpersonatedClientSet, nil, tc.workerName, nil, nil, nil, tc.shareKubeconfig)
 			partialCluster := &kubermaticv1.Cluster{}
 			partialCluster.Spec = *tc.spec
 			if tc.clusterType == "openshift" {

--- a/api/pkg/provider/kubernetes/member.go
+++ b/api/pkg/provider/kubernetes/member.go
@@ -18,7 +18,7 @@ import (
 )
 
 // NewProjectMemberProvider returns a project members provider
-func NewProjectMemberProvider(createMasterImpersonatedClient kubermaticImpersonationClient, clientPrivileged ctrlruntimeclient.Client, isServiceAccountFunc func(string) bool) *ProjectMemberProvider {
+func NewProjectMemberProvider(createMasterImpersonatedClient impersonationClient, clientPrivileged ctrlruntimeclient.Client, isServiceAccountFunc func(string) bool) *ProjectMemberProvider {
 	return &ProjectMemberProvider{
 		createMasterImpersonatedClient: createMasterImpersonatedClient,
 		clientPrivileged:               clientPrivileged,
@@ -31,7 +31,7 @@ var _ provider.ProjectMemberProvider = &ProjectMemberProvider{}
 // ProjectMemberProvider binds users with projects
 type ProjectMemberProvider struct {
 	// createMasterImpersonatedClient is used as a ground for impersonation
-	createMasterImpersonatedClient kubermaticImpersonationClient
+	createMasterImpersonatedClient impersonationClient
 
 	// treat clientPrivileged as a privileged user and use wisely
 	clientPrivileged ctrlruntimeclient.Client
@@ -49,11 +49,14 @@ func (p *ProjectMemberProvider) Create(userInfo *provider.UserInfo, project *kub
 
 	binding := genBinding(project, memberEmail, group)
 
-	masterImpersonatedClient, err := createKubermaticImpersonationClientWrapperFromUserInfo(userInfo, p.createMasterImpersonatedClient)
+	masterImpersonatedClient, err := createImpersonationClientWrapperFromUserInfo(userInfo, p.createMasterImpersonatedClient)
 	if err != nil {
 		return nil, err
 	}
-	return masterImpersonatedClient.UserProjectBindings().Create(binding)
+	if err := masterImpersonatedClient.Create(context.Background(), binding); err != nil {
+		return nil, err
+	}
+	return binding, nil
 }
 
 // List gets all members of the given project
@@ -84,13 +87,13 @@ func (p *ProjectMemberProvider) List(userInfo *provider.UserInfo, project *kuber
 	// After we get the list of members we try to get at least one item using unprivileged account to see if the user have read access
 	if len(projectMembers) > 0 {
 		if !options.SkipPrivilegeVerification {
-			masterImpersonatedClient, err := createKubermaticImpersonationClientWrapperFromUserInfo(userInfo, p.createMasterImpersonatedClient)
+			masterImpersonatedClient, err := createImpersonationClientWrapperFromUserInfo(userInfo, p.createMasterImpersonatedClient)
 			if err != nil {
 				return nil, err
 			}
 
 			memberToGet := projectMembers[0]
-			_, err = masterImpersonatedClient.UserProjectBindings().Get(memberToGet.Name, metav1.GetOptions{})
+			err = masterImpersonatedClient.Get(context.Background(), ctrlruntimeclient.ObjectKey{Name: memberToGet.Name}, &kubermaticapiv1.UserProjectBinding{})
 			if err != nil {
 				return nil, err
 			}
@@ -118,11 +121,11 @@ func (p *ProjectMemberProvider) List(userInfo *provider.UserInfo, project *kuber
 // Note:
 // Use List to get binding for the specific member of the given project
 func (p *ProjectMemberProvider) Delete(userInfo *provider.UserInfo, bindingName string) error {
-	masterImpersonatedClient, err := createKubermaticImpersonationClientWrapperFromUserInfo(userInfo, p.createMasterImpersonatedClient)
+	masterImpersonatedClient, err := createImpersonationClientWrapperFromUserInfo(userInfo, p.createMasterImpersonatedClient)
 	if err != nil {
 		return err
 	}
-	return masterImpersonatedClient.UserProjectBindings().Delete(bindingName, &metav1.DeleteOptions{})
+	return masterImpersonatedClient.Delete(context.Background(), &kubermaticapiv1.UserProjectBinding{ObjectMeta: metav1.ObjectMeta{Name: bindingName}})
 }
 
 // Update updates the given binding
@@ -130,11 +133,14 @@ func (p *ProjectMemberProvider) Update(userInfo *provider.UserInfo, binding *kub
 	if rbac.ExtractGroupPrefix(binding.Spec.Group) == rbac.OwnerGroupNamePrefix && !kuberneteshelper.HasFinalizer(binding, rbac.CleanupFinalizerName) {
 		kuberneteshelper.AddFinalizer(binding, rbac.CleanupFinalizerName)
 	}
-	masterImpersonatedClient, err := createKubermaticImpersonationClientWrapperFromUserInfo(userInfo, p.createMasterImpersonatedClient)
+	masterImpersonatedClient, err := createImpersonationClientWrapperFromUserInfo(userInfo, p.createMasterImpersonatedClient)
 	if err != nil {
 		return nil, err
 	}
-	return masterImpersonatedClient.UserProjectBindings().Update(binding)
+	if err := masterImpersonatedClient.Update(context.Background(), binding); err != nil {
+		return nil, err
+	}
+	return binding, nil
 }
 
 // MapUserToGroup maps the given user to a specific group of the given project

--- a/api/pkg/provider/kubernetes/member_test.go
+++ b/api/pkg/provider/kubernetes/member_test.go
@@ -6,31 +6,30 @@ import (
 
 	"github.com/go-test/deep"
 
-	kubermaticfakeclentset "github.com/kubermatic/kubermatic/api/pkg/crd/client/clientset/versioned/fake"
 	kubermaticv1 "github.com/kubermatic/kubermatic/api/pkg/crd/kubermatic/v1"
 	"github.com/kubermatic/kubermatic/api/pkg/provider"
 	"github.com/kubermatic/kubermatic/api/pkg/provider/kubernetes"
 
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/client-go/kubernetes/scheme"
+	restclient "k8s.io/client-go/rest"
+	ctrlruntimeclient "sigs.k8s.io/controller-runtime/pkg/client"
 	fakectrlruntimeclient "sigs.k8s.io/controller-runtime/pkg/client/fake"
 )
 
 func TestCreateBinding(t *testing.T) {
 	// test data
 	kubermaticObjects := []runtime.Object{}
-	impersonationClient, _, _, err := createFakeKubermaticClients(kubermaticObjects)
-	if err != nil {
-		t.Fatalf("unable to create fake clients, err = %v", err)
-	}
 	fakeClient := fakectrlruntimeclient.NewFakeClientWithScheme(scheme.Scheme, kubermaticObjects...)
 	authenticatedUser := createAuthenitactedUser()
 	existingProject := genDefaultProject()
 	memberEmail := ""
 	groupName := fmt.Sprintf("owners-%s", existingProject.Name)
-
+	fakeImpersonationClient := func(impCfg restclient.ImpersonationConfig) (ctrlruntimeclient.Client, error) {
+		return fakeClient, nil
+	}
 	// act
-	target := kubernetes.NewProjectMemberProvider(impersonationClient.CreateFakeImpersonatedClientSet, fakeClient, kubernetes.IsServiceAccount)
+	target := kubernetes.NewProjectMemberProvider(fakeImpersonationClient, fakeClient, kubernetes.IsServiceAccount)
 	result, err := target.Create(&provider.UserInfo{Email: authenticatedUser.Spec.Email, Group: fmt.Sprintf("owners-%s", existingProject.Name)}, existingProject, memberEmail, groupName)
 
 	// validate
@@ -107,12 +106,12 @@ func TestListBinding(t *testing.T) {
 			for _, sa := range tc.existingSA {
 				kubermaticObjects = append(kubermaticObjects, sa)
 			}
-			kubermaticClient := kubermaticfakeclentset.NewSimpleClientset(kubermaticObjects...)
-			impersonationClient := &fakeKubermaticImpersonationClient{kubermaticClient}
 			fakeClient := fakectrlruntimeclient.NewFakeClientWithScheme(scheme.Scheme, kubermaticObjects...)
-
+			fakeImpersonationClient := func(impCfg restclient.ImpersonationConfig) (ctrlruntimeclient.Client, error) {
+				return fakeClient, nil
+			}
 			// act
-			target := kubernetes.NewProjectMemberProvider(impersonationClient.CreateFakeImpersonatedClientSet, fakeClient, kubernetes.IsServiceAccount)
+			target := kubernetes.NewProjectMemberProvider(fakeImpersonationClient, fakeClient, kubernetes.IsServiceAccount)
 			result, err := target.List(&provider.UserInfo{Email: tc.authenticatedUser.Spec.Email, Group: fmt.Sprintf("owners-%s", tc.projectToSync.Name)}, tc.projectToSync, nil)
 
 			// validate

--- a/api/pkg/provider/kubernetes/project_test.go
+++ b/api/pkg/provider/kubernetes/project_test.go
@@ -131,7 +131,7 @@ func TestListProjects(t *testing.T) {
 			fakeClient := fakectrlruntimeclient.NewFakeClientWithScheme(scheme.Scheme, kubermaticObjects...)
 
 			// act
-			target, err := kubernetes.NewProjectProvider(impersonationClient.CreateFakeImpersonatedClientSet, fakeClient)
+			target, err := kubernetes.NewProjectProvider(impersonationClient.CreateFakeKubermaticImpersonatedClientSet, fakeClient)
 			if err != nil {
 				t.Fatal(err)
 			}

--- a/api/pkg/provider/kubernetes/sa_test.go
+++ b/api/pkg/provider/kubernetes/sa_test.go
@@ -50,7 +50,7 @@ func TestCreateServiceAccount(t *testing.T) {
 			fakeClient := fakectrlruntimeclient.NewFakeClientWithScheme(scheme.Scheme, tc.existingKubermaticObjects...)
 
 			// act
-			target := kubernetes.NewServiceAccountProvider(impersonationClient.CreateFakeImpersonatedClientSet, fakeClient, "localhost")
+			target := kubernetes.NewServiceAccountProvider(impersonationClient.CreateFakeKubermaticImpersonatedClientSet, fakeClient, "localhost")
 			if err != nil {
 				t.Fatal(err)
 			}
@@ -121,7 +121,7 @@ func TestList(t *testing.T) {
 			}
 			fakeClient := fakectrlruntimeclient.NewFakeClientWithScheme(scheme.Scheme, tc.existingKubermaticObjects...)
 			// act
-			target := kubernetes.NewServiceAccountProvider(impersonationClient.CreateFakeImpersonatedClientSet, fakeClient, "localhost")
+			target := kubernetes.NewServiceAccountProvider(impersonationClient.CreateFakeKubermaticImpersonatedClientSet, fakeClient, "localhost")
 			if err != nil {
 				t.Fatal(err)
 			}
@@ -171,7 +171,7 @@ func TestGet(t *testing.T) {
 			}
 			fakeClient := fakectrlruntimeclient.NewFakeClientWithScheme(scheme.Scheme, tc.existingKubermaticObjects...)
 			// act
-			target := kubernetes.NewServiceAccountProvider(impersonationClient.CreateFakeImpersonatedClientSet, fakeClient, "localhost")
+			target := kubernetes.NewServiceAccountProvider(impersonationClient.CreateFakeKubermaticImpersonatedClientSet, fakeClient, "localhost")
 			if err != nil {
 				t.Fatal(err)
 			}
@@ -223,7 +223,7 @@ func TestUpdate(t *testing.T) {
 			}
 			fakeClient := fakectrlruntimeclient.NewFakeClientWithScheme(scheme.Scheme, tc.existingKubermaticObjects...)
 			// act
-			target := kubernetes.NewServiceAccountProvider(impersonationClient.CreateFakeImpersonatedClientSet, fakeClient, "localhost")
+			target := kubernetes.NewServiceAccountProvider(impersonationClient.CreateFakeKubermaticImpersonatedClientSet, fakeClient, "localhost")
 			if err != nil {
 				t.Fatal(err)
 			}
@@ -275,7 +275,7 @@ func TestDelete(t *testing.T) {
 			}
 			fakeClient := fakectrlruntimeclient.NewFakeClientWithScheme(scheme.Scheme, tc.existingKubermaticObjects...)
 			// act
-			target := kubernetes.NewServiceAccountProvider(impersonationClient.CreateFakeImpersonatedClientSet, fakeClient, "localhost")
+			target := kubernetes.NewServiceAccountProvider(impersonationClient.CreateFakeKubermaticImpersonatedClientSet, fakeClient, "localhost")
 			if err != nil {
 				t.Fatal(err)
 			}

--- a/api/pkg/provider/kubernetes/util_test.go
+++ b/api/pkg/provider/kubernetes/util_test.go
@@ -68,7 +68,7 @@ type fakeKubermaticImpersonationClient struct {
 	kubermaticClent *kubermaticfakeclentset.Clientset
 }
 
-func (f *fakeKubermaticImpersonationClient) CreateFakeImpersonatedClientSet(impCfg restclient.ImpersonationConfig) (kubermaticclientv1.KubermaticV1Interface, error) {
+func (f *fakeKubermaticImpersonationClient) CreateFakeKubermaticImpersonatedClientSet(impCfg restclient.ImpersonationConfig) (kubermaticclientv1.KubermaticV1Interface, error) {
 	return f.kubermaticClent.KubermaticV1(), nil
 }
 


### PR DESCRIPTION
**What this PR does / why we need it**: use controller runtime impersonation client for member provider

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

```release-note
NONE
```
