### PR TITLE
[EE] switch Docker repository logic for Kubermatic

### DIFF
--- a/api/Makefile
+++ b/api/Makefile
@@ -1,6 +1,6 @@
 export CGO_ENABLED?=0
 KUBERMATIC_EDITION?=ce
-REPO=quay.io/kubermatic/api$(shell [ "$(KUBERMATIC_EDITION)" != "ee" ] && echo "-$(KUBERMATIC_EDITION)" )
+REPO=quay.io/kubermatic/kubermatic$(shell [ "$(KUBERMATIC_EDITION)" != "ce" ] && echo "-$(KUBERMATIC_EDITION)" )
 CMD=$(filter-out OWNERS nodeport-proxy kubeletdnat-controller, $(notdir $(wildcard ./cmd/*)))
 GOBUILDFLAGS?=-v
 GITTAG=$(shell git describe --tags --always)

--- a/api/hack/ci/ci-run-offline-test.sh
+++ b/api/hack/ci/ci-run-offline-test.sh
@@ -117,7 +117,7 @@ echodate "Sucessfully finished building and pushing quay images"
 cd ./../../../config
 HELM_EXTRA_ARGS="--set kubermatic.controller.image.tag=${GIT_HEAD_HASH},kubermatic.api.image.tag=${GIT_HEAD_HASH},kubermatic.masterController.image.tag=${GIT_HEAD_HASH}"
 # We must not pull those images from remote. We build them on the fly
-helm template ${HELM_EXTRA_ARGS} kubermatic | grep -v quay.io/kubermatic/api |../api/hack/retag-images.sh
+helm template ${HELM_EXTRA_ARGS} kubermatic | grep -v quay.io/kubermatic/kubermatic |../api/hack/retag-images.sh
 
 # Push a tiller image
 docker pull gcr.io/kubernetes-helm/tiller:${HELM_VERSION}

--- a/api/hack/ci/ci-setup-kubermatic-in-kind.sh
+++ b/api/hack/ci/ci-setup-kubermatic-in-kind.sh
@@ -252,6 +252,11 @@ echodate "Deploying Kubermatic CRDs"
 
 retry 5 kubectl apply -f config/kubermatic/crd
 
+REPOSUFFIX=""
+if [ "$KUBERMATIC_EDITION" != "ce" ]; then
+  REPOSUFFIX="-$KUBERMATIC_EDITION"
+fi
+
 if [[ "${KUBERMATIC_SKIP_BUILDING}" = "false" ]]; then
   # Build kubermatic binaries and push the image
   OLD_HEAD="$(git rev-parse HEAD)"
@@ -270,7 +275,7 @@ if [[ "${KUBERMATIC_SKIP_BUILDING}" = "false" ]]; then
     echodate "Building docker image"
     TEST_NAME="Build Kubermatic Docker image"
     cd api
-    IMAGE_NAME="quay.io/kubermatic/api:$KUBERMATIC_VERSION"
+    IMAGE_NAME="quay.io/kubermatic/kubermatic$REPOSUFFIX:$KUBERMATIC_VERSION"
     time retry 5 docker build -t "$IMAGE_NAME" .
     time retry 5 kind load docker-image "$IMAGE_NAME" --name ${SEED_NAME}
   )
@@ -374,10 +379,16 @@ if [[ "${KUBERMATIC_USE_OPERATOR}" = "false" ]]; then
   beforeDeployment=$(nowms)
 
   # --force is needed in case the first attempt at installing didn't succeed
-  # see https://github.com/helm/helm/pull/3597
+  # see https://github.com/helm/helm/pull/3597;
+  # we always override the quay repositories so we don't have to care if the
+  # Helm chart is made for CE or EE
   retry 3 helm upgrade --install --force --wait --timeout 300 \
     --set=kubermatic.isMaster=true \
     --set=kubermatic.imagePullSecretData=$IMAGE_PULL_SECRET_DATA \
+    --set-string=kubermatic.controller.image.repository="quay.io/kubermatic/kubermatic$REPOSUFFIX" \
+    --set-string=kubermatic.masterController.image.repository="quay.io/kubermatic/kubermatic$REPOSUFFIX" \
+    --set-string=kubermatic.api.image.repository="quay.io/kubermatic/kubermatic$REPOSUFFIX" \
+    --set-string=kubermatic.ui.image.repository="quay.io/kubermatic/dashboard$REPOSUFFIX" \
     --set-string=kubermatic.controller.addons.kubernetes.image.tag="$KUBERMATIC_VERSION" \
     --set-string=kubermatic.controller.image.tag="$KUBERMATIC_VERSION" \
     --set-string=kubermatic.controller.addons.openshift.image.tag="$KUBERMATIC_VERSION" \
@@ -421,6 +432,7 @@ else
   # see https://github.com/helm/helm/pull/3597
   retry 3 helm upgrade --install --force --wait --timeout 300 \
     --set-file "kubermaticOperator.imagePullSecret=/config.json" \
+    --set-string "kubermaticOperator.image.repository=quay.io/kubermatic/kubermatic$REPOSUFFIX" \
     --set-string "kubermaticOperator.image.tag=$KUBERMATIC_VERSION" \
     --namespace kubermatic \
     --values ${VALUES_FILE} \
@@ -428,6 +440,9 @@ else
     ./config/kubermatic-operator/
 
   echodate "Kubermatic Operator is ready."
+
+  # No need to override any Docker repositories here, as the operator
+  # is already pinned to CE or EE and has the proper default values on board.
 
   KUBERMATIC_CONFIG="$(mktemp)"
   cat <<EOF >$KUBERMATIC_CONFIG

--- a/api/hack/push_image.sh
+++ b/api/hack/push_image.sh
@@ -15,17 +15,24 @@ cd "$(dirname "$0")/../"
 source ./hack/lib.sh
 
 REPOSUFFIX=""
-if [ "${KUBERMATIC_EDITION:-ee}" != "ee" ]; then
+KUBERMATIC_EDITION="${KUBERMATIC_EDITION:-ee}"
+
+if [ "$KUBERMATIC_EDITION" != "ce" ]; then
   REPOSUFFIX="-$KUBERMATIC_EDITION"
 fi
 
 make build
-docker build -t quay.io/kubermatic/api${REPOSUFFIX}:${1} .
+docker build -t quay.io/kubermatic/kubermatic${REPOSUFFIX}:${1} .
 cd cmd/nodeport-proxy && export TAG=${1} && make docker && unset TAG && cd -
 cd cmd/kubeletdnat-controller && export TAG=${1} && make docker && unset TAG && cd -
 docker build -t "quay.io/kubermatic/addons:${1}" ../addons
 docker build -t "quay.io/kubermatic/openshift-addons:${1}" ../openshift_addons
 cd cmd/user-ssh-keys-agent && export TAG=${1} && make docker && unset TAG && cd -
+
+# keep a mirror of the EE version in the old repo
+if [ "$KUBERMATIC_EDITION" == "ee" ]; then
+  docker tag quay.io/kubermatic/kubermatic${REPOSUFFIX}:${1} quay.io/kubermatic/api:${1}
+fi
 
 for TAG in "$@"; do
   if [[ -z "$TAG" ]]; then
@@ -33,17 +40,22 @@ for TAG in "$@"; do
   fi
 
   echodate "Tagging ${TAG}"
-  docker tag quay.io/kubermatic/api${REPOSUFFIX}:${1} quay.io/kubermatic/api${REPOSUFFIX}:${TAG}
+  docker tag quay.io/kubermatic/kubermatic${REPOSUFFIX}:${1} quay.io/kubermatic/kubermatic${REPOSUFFIX}:${TAG}
   docker tag quay.io/kubermatic/nodeport-proxy:${1} quay.io/kubermatic/nodeport-proxy:${TAG}
   docker tag quay.io/kubermatic/kubeletdnat-controller:${1}  quay.io/kubermatic/kubeletdnat-controller:${TAG}
   docker tag quay.io/kubermatic/addons:${1} quay.io/kubermatic/addons:${TAG}
   docker tag quay.io/kubermatic/openshift-addons:${1} quay.io/kubermatic/openshift-addons:${TAG}
   docker tag quay.io/kubermatic/user-ssh-keys-agent:${1} quay.io/kubermatic/user-ssh-keys-agent:${TAG}
 
-  docker push quay.io/kubermatic/api${REPOSUFFIX}:${TAG}
+  docker push quay.io/kubermatic/kubermatic${REPOSUFFIX}:${TAG}
   docker push quay.io/kubermatic/nodeport-proxy:${TAG}
   docker push quay.io/kubermatic/kubeletdnat-controller:${TAG}
   docker push quay.io/kubermatic/addons:${TAG}
   docker push quay.io/kubermatic/openshift-addons:${TAG}
   docker push quay.io/kubermatic/user-ssh-keys-agent:${TAG}
+
+  if [ "$KUBERMATIC_EDITION" == "ee" ]; then
+    docker tag quay.io/kubermatic/api:${1} quay.io/kubermatic/api:${TAG}
+    docker push quay.io/kubermatic/api:${TAG}
+  fi
 done

--- a/api/pkg/resources/resources_ce.go
+++ b/api/pkg/resources/resources_ce.go
@@ -6,13 +6,13 @@ const (
 	KubermaticEdition = "Community Edition"
 
 	// DefaultKubermaticImage defines the default Docker repository containing the Kubermatic API image.
-	DefaultKubermaticImage = "quay.io/kubermatic/api-ce"
+	DefaultKubermaticImage = "quay.io/kubermatic/kubermatic"
 
 	// DefaultDNATControllerImage defines the default Docker repository containing the DNAT controller image.
 	DefaultDNATControllerImage = "quay.io/kubermatic/kubeletdnat-controller"
 
 	// DefaultDashboardAddonImage defines the default Docker repository containing the dashboard image.
-	DefaultDashboardImage = "quay.io/kubermatic/dashboard-ce"
+	DefaultDashboardImage = "quay.io/kubermatic/dashboard"
 
 	// DefaultKubernetesAddonImage defines the default Docker repository containing the Kubernetes addons.
 	DefaultKubernetesAddonImage = "quay.io/kubermatic/addons"

--- a/api/pkg/resources/resources_ee.go
+++ b/api/pkg/resources/resources_ee.go
@@ -6,13 +6,13 @@ const (
 	KubermaticEdition = "Enterprise Edition"
 
 	// DefaultKubermaticImage defines the default Docker repository containing the Kubermatic API image.
-	DefaultKubermaticImage = "quay.io/kubermatic/api"
+	DefaultKubermaticImage = "quay.io/kubermatic/kubermatic-ee"
 
 	// DefaultDNATControllerImage defines the default Docker repository containing the DNAT controller image.
 	DefaultDNATControllerImage = "quay.io/kubermatic/kubeletdnat-controller"
 
 	// DefaultDashboardAddonImage defines the default Docker repository containing the dashboard image.
-	DefaultDashboardImage = "quay.io/kubermatic/dashboard"
+	DefaultDashboardImage = "quay.io/kubermatic/dashboard-ee"
 
 	// DefaultKubernetesAddonImage defines the default Docker repository containing the Kubernetes addons.
 	DefaultKubernetesAddonImage = "quay.io/kubermatic/addons"

--- a/api/pkg/resources/test/fixtures/deployment-aws-1.15.0-usercluster-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-aws-1.15.0-usercluster-controller.yaml
@@ -46,7 +46,7 @@ spec:
             fieldRef:
               apiVersion: v1
               fieldPath: metadata.namespace
-        image: 'quay.io/kubermatic/api:'
+        image: 'quay.io/kubermatic/kubermatic:'
         name: usercluster-controller
         readinessProbe:
           failureThreshold: 5

--- a/api/pkg/resources/test/fixtures/deployment-aws-1.16.0-usercluster-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-aws-1.16.0-usercluster-controller.yaml
@@ -46,7 +46,7 @@ spec:
             fieldRef:
               apiVersion: v1
               fieldPath: metadata.namespace
-        image: 'quay.io/kubermatic/api:'
+        image: 'quay.io/kubermatic/kubermatic:'
         name: usercluster-controller
         readinessProbe:
           failureThreshold: 5

--- a/api/pkg/resources/test/fixtures/deployment-aws-1.17.0-usercluster-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-aws-1.17.0-usercluster-controller.yaml
@@ -46,7 +46,7 @@ spec:
             fieldRef:
               apiVersion: v1
               fieldPath: metadata.namespace
-        image: 'quay.io/kubermatic/api:'
+        image: 'quay.io/kubermatic/kubermatic:'
         name: usercluster-controller
         readinessProbe:
           failureThreshold: 5

--- a/api/pkg/resources/test/fixtures/deployment-aws-1.18.0-usercluster-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-aws-1.18.0-usercluster-controller.yaml
@@ -46,7 +46,7 @@ spec:
             fieldRef:
               apiVersion: v1
               fieldPath: metadata.namespace
-        image: 'quay.io/kubermatic/api:'
+        image: 'quay.io/kubermatic/kubermatic:'
         name: usercluster-controller
         readinessProbe:
           failureThreshold: 5

--- a/api/pkg/resources/test/fixtures/deployment-azure-1.15.0-usercluster-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-azure-1.15.0-usercluster-controller.yaml
@@ -46,7 +46,7 @@ spec:
             fieldRef:
               apiVersion: v1
               fieldPath: metadata.namespace
-        image: 'quay.io/kubermatic/api:'
+        image: 'quay.io/kubermatic/kubermatic:'
         name: usercluster-controller
         readinessProbe:
           failureThreshold: 5

--- a/api/pkg/resources/test/fixtures/deployment-azure-1.16.0-usercluster-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-azure-1.16.0-usercluster-controller.yaml
@@ -46,7 +46,7 @@ spec:
             fieldRef:
               apiVersion: v1
               fieldPath: metadata.namespace
-        image: 'quay.io/kubermatic/api:'
+        image: 'quay.io/kubermatic/kubermatic:'
         name: usercluster-controller
         readinessProbe:
           failureThreshold: 5

--- a/api/pkg/resources/test/fixtures/deployment-azure-1.17.0-usercluster-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-azure-1.17.0-usercluster-controller.yaml
@@ -46,7 +46,7 @@ spec:
             fieldRef:
               apiVersion: v1
               fieldPath: metadata.namespace
-        image: 'quay.io/kubermatic/api:'
+        image: 'quay.io/kubermatic/kubermatic:'
         name: usercluster-controller
         readinessProbe:
           failureThreshold: 5

--- a/api/pkg/resources/test/fixtures/deployment-azure-1.18.0-usercluster-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-azure-1.18.0-usercluster-controller.yaml
@@ -46,7 +46,7 @@ spec:
             fieldRef:
               apiVersion: v1
               fieldPath: metadata.namespace
-        image: 'quay.io/kubermatic/api:'
+        image: 'quay.io/kubermatic/kubermatic:'
         name: usercluster-controller
         readinessProbe:
           failureThreshold: 5

--- a/api/pkg/resources/test/fixtures/deployment-bringyourown-1.15.0-usercluster-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-bringyourown-1.15.0-usercluster-controller.yaml
@@ -46,7 +46,7 @@ spec:
             fieldRef:
               apiVersion: v1
               fieldPath: metadata.namespace
-        image: 'quay.io/kubermatic/api:'
+        image: 'quay.io/kubermatic/kubermatic:'
         name: usercluster-controller
         readinessProbe:
           failureThreshold: 5

--- a/api/pkg/resources/test/fixtures/deployment-bringyourown-1.16.0-usercluster-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-bringyourown-1.16.0-usercluster-controller.yaml
@@ -46,7 +46,7 @@ spec:
             fieldRef:
               apiVersion: v1
               fieldPath: metadata.namespace
-        image: 'quay.io/kubermatic/api:'
+        image: 'quay.io/kubermatic/kubermatic:'
         name: usercluster-controller
         readinessProbe:
           failureThreshold: 5

--- a/api/pkg/resources/test/fixtures/deployment-bringyourown-1.17.0-usercluster-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-bringyourown-1.17.0-usercluster-controller.yaml
@@ -46,7 +46,7 @@ spec:
             fieldRef:
               apiVersion: v1
               fieldPath: metadata.namespace
-        image: 'quay.io/kubermatic/api:'
+        image: 'quay.io/kubermatic/kubermatic:'
         name: usercluster-controller
         readinessProbe:
           failureThreshold: 5

--- a/api/pkg/resources/test/fixtures/deployment-bringyourown-1.18.0-usercluster-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-bringyourown-1.18.0-usercluster-controller.yaml
@@ -46,7 +46,7 @@ spec:
             fieldRef:
               apiVersion: v1
               fieldPath: metadata.namespace
-        image: 'quay.io/kubermatic/api:'
+        image: 'quay.io/kubermatic/kubermatic:'
         name: usercluster-controller
         readinessProbe:
           failureThreshold: 5

--- a/api/pkg/resources/test/fixtures/deployment-digitalocean-1.15.0-usercluster-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-digitalocean-1.15.0-usercluster-controller.yaml
@@ -46,7 +46,7 @@ spec:
             fieldRef:
               apiVersion: v1
               fieldPath: metadata.namespace
-        image: 'quay.io/kubermatic/api:'
+        image: 'quay.io/kubermatic/kubermatic:'
         name: usercluster-controller
         readinessProbe:
           failureThreshold: 5

--- a/api/pkg/resources/test/fixtures/deployment-digitalocean-1.16.0-usercluster-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-digitalocean-1.16.0-usercluster-controller.yaml
@@ -46,7 +46,7 @@ spec:
             fieldRef:
               apiVersion: v1
               fieldPath: metadata.namespace
-        image: 'quay.io/kubermatic/api:'
+        image: 'quay.io/kubermatic/kubermatic:'
         name: usercluster-controller
         readinessProbe:
           failureThreshold: 5

--- a/api/pkg/resources/test/fixtures/deployment-digitalocean-1.17.0-usercluster-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-digitalocean-1.17.0-usercluster-controller.yaml
@@ -46,7 +46,7 @@ spec:
             fieldRef:
               apiVersion: v1
               fieldPath: metadata.namespace
-        image: 'quay.io/kubermatic/api:'
+        image: 'quay.io/kubermatic/kubermatic:'
         name: usercluster-controller
         readinessProbe:
           failureThreshold: 5

--- a/api/pkg/resources/test/fixtures/deployment-digitalocean-1.18.0-usercluster-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-digitalocean-1.18.0-usercluster-controller.yaml
@@ -46,7 +46,7 @@ spec:
             fieldRef:
               apiVersion: v1
               fieldPath: metadata.namespace
-        image: 'quay.io/kubermatic/api:'
+        image: 'quay.io/kubermatic/kubermatic:'
         name: usercluster-controller
         readinessProbe:
           failureThreshold: 5

--- a/api/pkg/resources/test/fixtures/deployment-openstack-1.15.0-usercluster-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-openstack-1.15.0-usercluster-controller.yaml
@@ -46,7 +46,7 @@ spec:
             fieldRef:
               apiVersion: v1
               fieldPath: metadata.namespace
-        image: 'quay.io/kubermatic/api:'
+        image: 'quay.io/kubermatic/kubermatic:'
         name: usercluster-controller
         readinessProbe:
           failureThreshold: 5

--- a/api/pkg/resources/test/fixtures/deployment-openstack-1.16.0-usercluster-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-openstack-1.16.0-usercluster-controller.yaml
@@ -46,7 +46,7 @@ spec:
             fieldRef:
               apiVersion: v1
               fieldPath: metadata.namespace
-        image: 'quay.io/kubermatic/api:'
+        image: 'quay.io/kubermatic/kubermatic:'
         name: usercluster-controller
         readinessProbe:
           failureThreshold: 5

--- a/api/pkg/resources/test/fixtures/deployment-openstack-1.17.0-usercluster-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-openstack-1.17.0-usercluster-controller.yaml
@@ -46,7 +46,7 @@ spec:
             fieldRef:
               apiVersion: v1
               fieldPath: metadata.namespace
-        image: 'quay.io/kubermatic/api:'
+        image: 'quay.io/kubermatic/kubermatic:'
         name: usercluster-controller
         readinessProbe:
           failureThreshold: 5

--- a/api/pkg/resources/test/fixtures/deployment-openstack-1.18.0-usercluster-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-openstack-1.18.0-usercluster-controller.yaml
@@ -46,7 +46,7 @@ spec:
             fieldRef:
               apiVersion: v1
               fieldPath: metadata.namespace
-        image: 'quay.io/kubermatic/api:'
+        image: 'quay.io/kubermatic/kubermatic:'
         name: usercluster-controller
         readinessProbe:
           failureThreshold: 5

--- a/api/pkg/resources/test/fixtures/deployment-vsphere-1.15.0-usercluster-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-vsphere-1.15.0-usercluster-controller.yaml
@@ -46,7 +46,7 @@ spec:
             fieldRef:
               apiVersion: v1
               fieldPath: metadata.namespace
-        image: 'quay.io/kubermatic/api:'
+        image: 'quay.io/kubermatic/kubermatic:'
         name: usercluster-controller
         readinessProbe:
           failureThreshold: 5

--- a/api/pkg/resources/test/fixtures/deployment-vsphere-1.16.0-usercluster-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-vsphere-1.16.0-usercluster-controller.yaml
@@ -46,7 +46,7 @@ spec:
             fieldRef:
               apiVersion: v1
               fieldPath: metadata.namespace
-        image: 'quay.io/kubermatic/api:'
+        image: 'quay.io/kubermatic/kubermatic:'
         name: usercluster-controller
         readinessProbe:
           failureThreshold: 5

--- a/api/pkg/resources/test/fixtures/deployment-vsphere-1.17.0-usercluster-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-vsphere-1.17.0-usercluster-controller.yaml
@@ -46,7 +46,7 @@ spec:
             fieldRef:
               apiVersion: v1
               fieldPath: metadata.namespace
-        image: 'quay.io/kubermatic/api:'
+        image: 'quay.io/kubermatic/kubermatic:'
         name: usercluster-controller
         readinessProbe:
           failureThreshold: 5

--- a/api/pkg/resources/test/fixtures/deployment-vsphere-1.18.0-usercluster-controller.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-vsphere-1.18.0-usercluster-controller.yaml
@@ -46,7 +46,7 @@ spec:
             fieldRef:
               apiVersion: v1
               fieldPath: metadata.namespace
-        image: 'quay.io/kubermatic/api:'
+        image: 'quay.io/kubermatic/kubermatic:'
         name: usercluster-controller
         readinessProbe:
           failureThreshold: 5

--- a/api/pkg/resources/test/load_files_test.go
+++ b/api/pkg/resources/test/load_files_test.go
@@ -563,7 +563,7 @@ func TestLoadFiles(t *testing.T) {
 					"https://dev.kubermatic.io/dex",
 					"kubermaticIssuer",
 					true,
-					"quay.io/kubermatic/api",
+					"quay.io/kubermatic/kubermatic",
 					"quay.io/kubermatic/kubeletdnat-controller",
 					false)
 

--- a/config/kubermatic-operator/Chart.yaml
+++ b/config/kubermatic-operator/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: kubermatic-operator
-version: 0.1.0
+version: 0.2.0
 appVersion: '__KUBERMATIC_TAG__'
 description: Helm chart to install the Kubermatic Operator
 keywords:

--- a/config/kubermatic-operator/values.yaml
+++ b/config/kubermatic-operator/values.yaml
@@ -1,6 +1,6 @@
 kubermaticOperator:
   image:
-    repository: "quay.io/kubermatic/api"
+    repository: "quay.io/kubermatic/kubermatic"
     tag: "__KUBERMATIC_TAG__"
 
   imagePullSecret: |

--- a/config/kubermatic/Chart.yaml
+++ b/config/kubermatic/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: kubermatic
-version: 1.0.53
+version: 1.1.0
 appVersion: '__KUBERMATIC_TAG__'
 description: Kubermatic chart for master and/or seed clusters.
 keywords:

--- a/config/kubermatic/values.yaml
+++ b/config/kubermatic/values.yaml
@@ -84,7 +84,7 @@ kubermatic:
     nodeportRange: "30000-32767"
     replicas: 2
     image:
-      repository: "quay.io/kubermatic/api"
+      repository: "quay.io/kubermatic/kubermatic-ee"
       tag: "__KUBERMATIC_TAG__"
       pullPolicy: "IfNotPresent"
     pprofEndpoint: ":6600"
@@ -145,7 +145,7 @@ kubermatic:
     # The default list is taken from static/master/accessible-addons.yaml if the list below is null.
     accessibleAddons: null
     image:
-      repository: "quay.io/kubermatic/api"
+      repository: "quay.io/kubermatic/kubermatic-ee"
       tag: "__KUBERMATIC_TAG__"
       pullPolicy: "IfNotPresent"
     resources:
@@ -228,7 +228,7 @@ kubermatic:
   masterController:
     replicas: 1
     image:
-      repository: quay.io/kubermatic/api
+      repository: quay.io/kubermatic/kubermatic-ee
       tag: "__KUBERMATIC_TAG__"
       pullPolicy: IfNotPresent
     resources:

--- a/config/kubermatic/values.yaml
+++ b/config/kubermatic/values.yaml
@@ -184,7 +184,7 @@ kubermatic:
   ui:
     replicas: 2
     image:
-      repository: "quay.io/kubermatic/dashboard"
+      repository: "quay.io/kubermatic/dashboard-ee"
       tag: "__DASHBOARD_TAG__"
       pullPolicy: "IfNotPresent"
     # Config options for the dashboard, a JSON document. If this is not set, the

--- a/docs/zz_generated.kubermaticConfiguration.yaml
+++ b/docs/zz_generated.kubermaticConfiguration.yaml
@@ -13,7 +13,7 @@ spec:
     # DebugLog enables more verbose logging.
     debugLog: false
     # DockerRepository is the repository containing the Kubermatic REST API image.
-    dockerRepository: quay.io/kubermatic/api-ce
+    dockerRepository: quay.io/kubermatic/kubermatic
     # PProfEndpoint controls the port the API should listen on to provide pprof
     # data. This port is never exposed from the container and only available via port-forwardings.
     pprofEndpoint: :6600
@@ -82,7 +82,7 @@ spec:
     # DebugLog enables more verbose logging.
     debugLog: false
     # DockerRepository is the repository containing the Kubermatic master-controller-manager image.
-    dockerRepository: quay.io/kubermatic/api-ce
+    dockerRepository: quay.io/kubermatic/kubermatic
     # PProfEndpoint controls the port the master-controller-manager should listen on to provide pprof
     # data. This port is never exposed from the container and only available via port-forwardings.
     pprofEndpoint: :6600
@@ -186,7 +186,7 @@ spec:
     # DebugLog enables more verbose logging.
     debugLog: false
     # DockerRepository is the repository containing the Kubermatic seed-controller-manager image.
-    dockerRepository: quay.io/kubermatic/api-ce
+    dockerRepository: quay.io/kubermatic/kubermatic
     # PProfEndpoint controls the port the seed-controller-manager should listen on to provide pprof
     # data. This port is never exposed from the container and only available via port-forwardings.
     pprofEndpoint: :6600
@@ -214,7 +214,7 @@ spec:
         "share_kubeconfig": false
       }
     # DockerRepository is the repository containing the Kubermatic dashboard image.
-    dockerRepository: quay.io/kubermatic/dashboard-ce
+    dockerRepository: quay.io/kubermatic/dashboard
     # Replicas sets the number of pod replicas for the UI deployment.
     replicas: 2
     # Resources describes the requested and maximum allowed CPU/memory usage.
@@ -367,7 +367,7 @@ spec:
     # EtcdVolumeSize configures the volume size to use for each etcd pod inside user clusters.
     etcdVolumeSize: 5Gi
     # KubermaticDockerRepository is the repository containing the Kubermatic user-cluster-controller-manager image.
-    kubermaticDockerRepository: quay.io/kubermatic/api-ce
+    kubermaticDockerRepository: quay.io/kubermatic/kubermatic
     # Monitoring can be used to fine-tune to in-cluster Prometheus.
     monitoring:
       # CustomRules can be used to inject custom recording and alerting rules. This field


### PR DESCRIPTION
**What this PR does / why we need it**:
We decided to take the opportunity to rename our default Docker repository to `kubermatic` (from `api`).

**Does this PR introduce a user-facing change?**:
```release-note
NONE
```
