### PR TITLE
Update Dashboard dependencies to use dashboard-ee by default

### DIFF
--- a/api/pkg/resources/resources_ce.go
+++ b/api/pkg/resources/resources_ce.go
@@ -12,7 +12,7 @@ const (
 	DefaultDNATControllerImage = "quay.io/kubermatic/kubeletdnat-controller"
 
 	// DefaultDashboardAddonImage defines the default Docker repository containing the dashboard image.
-	DefaultDashboardImage = "quay.io/kubermatic/dashboard-ce"
+	DefaultDashboardImage = "quay.io/kubermatic/dashboard"
 
 	// DefaultKubernetesAddonImage defines the default Docker repository containing the Kubernetes addons.
 	DefaultKubernetesAddonImage = "quay.io/kubermatic/addons"

--- a/api/pkg/resources/resources_ee.go
+++ b/api/pkg/resources/resources_ee.go
@@ -12,7 +12,7 @@ const (
 	DefaultDNATControllerImage = "quay.io/kubermatic/kubeletdnat-controller"
 
 	// DefaultDashboardAddonImage defines the default Docker repository containing the dashboard image.
-	DefaultDashboardImage = "quay.io/kubermatic/dashboard"
+	DefaultDashboardImage = "quay.io/kubermatic/dashboard-ee"
 
 	// DefaultKubernetesAddonImage defines the default Docker repository containing the Kubernetes addons.
 	DefaultKubernetesAddonImage = "quay.io/kubermatic/addons"

--- a/config/kubermatic/Chart.yaml
+++ b/config/kubermatic/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: kubermatic
-version: 1.0.53
+version: 1.0.54
 appVersion: '__KUBERMATIC_TAG__'
 description: Kubermatic chart for master and/or seed clusters.
 keywords:

--- a/config/kubermatic/values.yaml
+++ b/config/kubermatic/values.yaml
@@ -184,7 +184,7 @@ kubermatic:
   ui:
     replicas: 2
     image:
-      repository: "quay.io/kubermatic/dashboard"
+      repository: "quay.io/kubermatic/dashboard-ee"
       tag: "__DASHBOARD_TAG__"
       pullPolicy: "IfNotPresent"
     # Config options for the dashboard, a JSON document. If this is not set, the

--- a/docs/zz_generated.kubermaticConfiguration.yaml
+++ b/docs/zz_generated.kubermaticConfiguration.yaml
@@ -214,7 +214,7 @@ spec:
         "share_kubeconfig": false
       }
     # DockerRepository is the repository containing the Kubermatic dashboard image.
-    dockerRepository: quay.io/kubermatic/dashboard-ce
+    dockerRepository: quay.io/kubermatic/dashboard
     # Replicas sets the number of pod replicas for the UI deployment.
     replicas: 2
     # Resources describes the requested and maximum allowed CPU/memory usage.


### PR DESCRIPTION
**What this PR does / why we need it**:
As `dashboard` image is no longer considered EE, I have updated the code to use `dashboard-ee` instead.

**Does this PR introduce a user-facing change?**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If  no release note is required, just write "NONE".
-->
```release-note
NONE
```
