### PR TITLE
operator-e2e-test: don't test both flatcar and coreos

### DIFF
--- a/.prow.yaml
+++ b/.prow.yaml
@@ -1065,6 +1065,8 @@ presubmits:
         env:
         - name: KUBERMATIC_EDITION
           value: ee
+        - name: EXCLUDE_DISTRIBUTIONS
+          value: ubuntu,centos,sles,rhel,flatcar
         - name: VERSIONS_TO_TEST
           value: "v1.18.2"
         - name: KUBERMATIC_USE_OPERATOR


### PR DESCRIPTION
**What this PR does / why we need it**:
Because the `EXCLUDE_DISTRIBUTIONS` is not set for this job, it uses the default value from `ci-run-conformance-tester.sh` which results in both CoreOS and Flatcar being tested.
Effectively running two tests in parallel massively increases the probability of failure due to timeouts etc.

```release-note
NONE
```
