### PR TITLE
use EE version when deploying Operator

### DIFF
--- a/api/hack/deploy.sh
+++ b/api/hack/deploy.sh
@@ -177,6 +177,7 @@ case "${DEPLOY_STACK}" in
 
         retry 3 helm upgrade --install --force --wait --timeout 300 \
           --set-file "kubermaticOperator.imagePullSecret=$DOCKER_CONFIG" \
+          --set-file "kubermaticOperator.image.repository=quay.io/kubermatic/kubermatic-ee" \
           --namespace kubermatic \
           --values ${VALUES_FILE} \
           kubermatic-operator \


### PR DESCRIPTION
**What this PR does / why we need it**:
The *Helm Chart* is, as it is used by existing customers, pre-configured to use the Enterprise Edition. The Operator however by default uses the Community Edition, so whenever we use it for our systems, we have to manually switch to EE.

**Does this PR introduce a user-facing change?**:
```release-note
NONE
```
