### PR TITLE
Revert "Cleanup metrics-server for the user-cluster (#5185)"

### DIFF
--- a/addons/metrics-server/auth-delegator.yaml
+++ b/addons/metrics-server/auth-delegator.yaml
@@ -1,0 +1,13 @@
+---
+apiVersion: rbac.authorization.k8s.io/v1beta1
+kind: ClusterRoleBinding
+metadata:
+  name: metrics-server:system:auth-delegator
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: system:auth-delegator
+subjects:
+- kind: ServiceAccount
+  name: metrics-server
+  namespace: kube-system

--- a/addons/metrics-server/auth-reader.yaml
+++ b/addons/metrics-server/auth-reader.yaml
@@ -1,0 +1,14 @@
+---
+apiVersion: rbac.authorization.k8s.io/v1beta1
+kind: RoleBinding
+metadata:
+  name: metrics-server-auth-reader
+  namespace: kube-system
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: extension-apiserver-authentication-reader
+subjects:
+- kind: ServiceAccount
+  name: metrics-server
+  namespace: kube-system

--- a/addons/metrics-server/metrics-apiservice.yaml
+++ b/addons/metrics-server/metrics-apiservice.yaml
@@ -1,0 +1,14 @@
+---
+apiVersion: apiregistration.k8s.io/v1beta1
+kind: APIService
+metadata:
+  name: v1beta1.metrics.k8s.io
+spec:
+  service:
+    name: metrics-server
+    namespace: kube-system
+  group: metrics.k8s.io
+  version: v1beta1
+  insecureSkipTLSVerify: true
+  groupPriorityMinimum: 100
+  versionPriority: 100

--- a/addons/metrics-server/metrics-server-deployment.yaml
+++ b/addons/metrics-server/metrics-server-deployment.yaml
@@ -1,0 +1,40 @@
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: metrics-server
+  namespace: kube-system
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: metrics-server
+  namespace: kube-system
+  labels:
+    k8s-app: metrics-server
+spec:
+  selector:
+    matchLabels:
+      k8s-app: metrics-server
+  template:
+    metadata:
+      name: metrics-server
+      labels:
+        k8s-app: metrics-server
+    spec:
+      serviceAccountName: metrics-server
+      volumes:
+      # mount in tmp so we can safely use from-scratch images and/or read-only containers
+      - name: tmp-dir
+        emptyDir: {}
+      containers:
+      - name: metrics-server
+        image: '{{ Registry "gcr.io" }}/google_containers/metrics-server-amd64:v0.2.1'
+        command:
+        - /metrics-server
+        - '--source=kubernetes.summary_api:https://kubernetes.default.svc?kubeletHttps=true&kubeletPort=10250&insecure=true'
+        imagePullPolicy: Always
+        volumeMounts:
+        - name: tmp-dir
+          mountPath: /tmp
+

--- a/addons/metrics-server/metrics-server-service.yaml
+++ b/addons/metrics-server/metrics-server-service.yaml
@@ -1,0 +1,15 @@
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: metrics-server
+  namespace: kube-system
+  labels:
+    kubernetes.io/name: "Metrics-server"
+spec:
+  selector:
+    k8s-app: metrics-server
+  ports:
+  - port: 443
+    protocol: TCP
+    targetPort: 443

--- a/addons/metrics-server/resource-reader.yaml
+++ b/addons/metrics-server/resource-reader.yaml
@@ -1,0 +1,38 @@
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: system:metrics-server
+rules:
+- apiGroups:
+  - ""
+  resources:
+  - pods
+  - nodes
+  - nodes/stats
+  - namespaces
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - "extensions"
+  resources:
+  - deployments
+  verbs:
+  - get
+  - list
+  - watch
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: system:metrics-server
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: system:metrics-server
+subjects:
+- kind: ServiceAccount
+  name: metrics-server
+  namespace: kube-system

--- a/api/cmd/seed-controller-manager/options.go
+++ b/api/cmd/seed-controller-manager/options.go
@@ -225,6 +225,14 @@ func (o controllerRunOptions) validate() error {
 		return fmt.Errorf("failed to parse nodePortRange: %v", err)
 	}
 
+	// Validate the metrics-server addon is disabled, otherwise it creates conflicts with the resources
+	// we create for the metrics-server running in the seed and will render the latter unusable
+	for _, addon := range o.kubernetesAddons.Items {
+		if addon.Name == "metrics-server" {
+			return errors.New("the metrics-server addon must be disabled, it is now deployed inside the seed cluster")
+		}
+	}
+
 	return nil
 }
 

--- a/api/pkg/controller/user-cluster-controller-manager/resources/resources/metrics-server/apiservice.go
+++ b/api/pkg/controller/user-cluster-controller-manager/resources/resources/metrics-server/apiservice.go
@@ -1,0 +1,37 @@
+package metricsserver
+
+import (
+	"github.com/kubermatic/kubermatic/api/pkg/resources"
+	"github.com/kubermatic/kubermatic/api/pkg/resources/reconciling"
+	apiregistrationv1beta1 "k8s.io/kube-aggregator/pkg/apis/apiregistration/v1beta1"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+const (
+	Name = "metrics-server"
+)
+
+// APIServiceCreator returns the func to create/update the APIService used by the metrics-server
+func APIServiceCreator(caBundle []byte) reconciling.NamedAPIServiceCreatorGetter {
+	return func() (string, reconciling.APIServiceCreator) {
+		return resources.MetricsServerAPIServiceName, func(se *apiregistrationv1beta1.APIService) (*apiregistrationv1beta1.APIService, error) {
+			labels := resources.BaseAppLabels(Name, nil)
+			se.Labels = labels
+
+			if se.Spec.Service == nil {
+				se.Spec.Service = &apiregistrationv1beta1.ServiceReference{}
+			}
+			se.Spec.Service.Namespace = metav1.NamespaceSystem
+			se.Spec.Service.Name = resources.MetricsServerExternalNameServiceName
+			se.Spec.Group = "metrics.k8s.io"
+			se.Spec.Version = "v1beta1"
+			se.Spec.InsecureSkipTLSVerify = false
+			se.Spec.CABundle = caBundle
+			se.Spec.GroupPriorityMinimum = 100
+			se.Spec.VersionPriority = 100
+
+			return se, nil
+		}
+	}
+}

--- a/api/pkg/controller/user-cluster-controller-manager/resources/resources/metrics-server/clusterrole.go
+++ b/api/pkg/controller/user-cluster-controller-manager/resources/resources/metrics-server/clusterrole.go
@@ -1,0 +1,42 @@
+package metricsserver
+
+import (
+	"github.com/kubermatic/kubermatic/api/pkg/resources"
+	"github.com/kubermatic/kubermatic/api/pkg/resources/reconciling"
+
+	rbacv1 "k8s.io/api/rbac/v1"
+)
+
+// ClusterRole returns a cluster role for the metrics server
+func ClusterRoleCreator() reconciling.NamedClusterRoleCreatorGetter {
+	return func() (string, reconciling.ClusterRoleCreator) {
+		return resources.MetricsServerClusterRoleName, func(cr *rbacv1.ClusterRole) (*rbacv1.ClusterRole, error) {
+			cr.Labels = resources.BaseAppLabels(Name, nil)
+
+			cr.Rules = []rbacv1.PolicyRule{
+				{
+					APIGroups: []string{""},
+					Resources: []string{
+						"pods",
+						"nodes",
+						"nodes/stats",
+						"namespaces",
+					},
+					Verbs: []string{
+						"get",
+						"list",
+						"watch",
+					},
+				},
+				{
+					APIGroups: []string{"extensions"},
+					Resources: []string{
+						"deployments",
+					},
+					Verbs: []string{"get", "list", "watch"},
+				},
+			}
+			return cr, nil
+		}
+	}
+}

--- a/api/pkg/controller/user-cluster-controller-manager/resources/resources/metrics-server/clusterrolebinding.go
+++ b/api/pkg/controller/user-cluster-controller-manager/resources/resources/metrics-server/clusterrolebinding.go
@@ -1,0 +1,37 @@
+package metricsserver
+
+import (
+	"github.com/kubermatic/kubermatic/api/pkg/resources"
+	"github.com/kubermatic/kubermatic/api/pkg/resources/reconciling"
+
+	rbacv1 "k8s.io/api/rbac/v1"
+)
+
+// ClusterRoleBindingResourceReaderCreator returns the ClusterRoleBinding required for the metrics server to read all required resources
+func ClusterRoleBindingResourceReaderCreator() reconciling.NamedClusterRoleBindingCreatorGetter {
+	return func() (string, reconciling.ClusterRoleBindingCreator) {
+		return resources.MetricsServerResourceReaderClusterRoleBindingName, func(crb *rbacv1.ClusterRoleBinding) (*rbacv1.ClusterRoleBinding, error) {
+			crb.Labels = resources.BaseAppLabels(Name, nil)
+
+			crb.RoleRef = rbacv1.RoleRef{
+				Name:     resources.MetricsServerClusterRoleName,
+				Kind:     "ClusterRole",
+				APIGroup: rbacv1.GroupName,
+			}
+			crb.Subjects = []rbacv1.Subject{
+				{
+					Kind:     "User",
+					Name:     resources.MetricsServerCertUsername,
+					APIGroup: rbacv1.GroupName,
+				},
+			}
+			return crb, nil
+		}
+	}
+
+}
+
+// ClusterRoleBindingAuthDelegatorCreator returns the ClusterRoleBinding required for the metrics server to create token review requests
+func ClusterRoleBindingAuthDelegatorCreator() reconciling.NamedClusterRoleBindingCreatorGetter {
+	return resources.ClusterRoleBindingAuthDelegatorCreator(resources.MetricsServerCertUsername)
+}

--- a/api/pkg/controller/user-cluster-controller-manager/resources/resources/metrics-server/external-name-service.go
+++ b/api/pkg/controller/user-cluster-controller-manager/resources/resources/metrics-server/external-name-service.go
@@ -1,0 +1,26 @@
+package metricsserver
+
+import (
+	"fmt"
+
+	"github.com/kubermatic/kubermatic/api/pkg/resources"
+	"github.com/kubermatic/kubermatic/api/pkg/resources/reconciling"
+
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+// ExternalNameServiceCreator returns the function to reconcile the metrics server service
+func ExternalNameServiceCreator(namespace string) reconciling.NamedServiceCreatorGetter {
+	return func() (string, reconciling.ServiceCreator) {
+		return resources.MetricsServerExternalNameServiceName, func(se *corev1.Service) (*corev1.Service, error) {
+			se.Namespace = metav1.NamespaceSystem
+			se.Labels = resources.BaseAppLabels(Name, nil)
+
+			se.Spec.Type = corev1.ServiceTypeExternalName
+			se.Spec.ExternalName = fmt.Sprintf("%s.%s.svc.cluster.local", resources.MetricsServerServiceName, namespace)
+
+			return se, nil
+		}
+	}
+}

--- a/api/pkg/controller/user-cluster-controller-manager/resources/resources/metrics-server/rolebinding.go
+++ b/api/pkg/controller/user-cluster-controller-manager/resources/resources/metrics-server/rolebinding.go
@@ -1,0 +1,31 @@
+package metricsserver
+
+import (
+	"github.com/kubermatic/kubermatic/api/pkg/resources"
+	"github.com/kubermatic/kubermatic/api/pkg/resources/reconciling"
+
+	rbacv1 "k8s.io/api/rbac/v1"
+)
+
+// RolebindingAuthReaderCreator returns a func to create/update the RoleBinding used by the metrics-server to get access to the token subject review API
+func RolebindingAuthReaderCreator() reconciling.NamedRoleBindingCreatorGetter {
+	return func() (string, reconciling.RoleBindingCreator) {
+		return resources.MetricsServerAuthReaderRoleName, func(rb *rbacv1.RoleBinding) (*rbacv1.RoleBinding, error) {
+			rb.Labels = resources.BaseAppLabels(Name, nil)
+
+			rb.RoleRef = rbacv1.RoleRef{
+				Name:     "extension-apiserver-authentication-reader",
+				Kind:     "Role",
+				APIGroup: rbacv1.GroupName,
+			}
+			rb.Subjects = []rbacv1.Subject{
+				{
+					Kind:     "User",
+					Name:     resources.MetricsServerCertUsername,
+					APIGroup: rbacv1.GroupName,
+				},
+			}
+			return rb, nil
+		}
+	}
+}

--- a/api/pkg/handler/v1/cluster/cluster_test.go
+++ b/api/pkg/handler/v1/cluster/cluster_test.go
@@ -1889,11 +1889,11 @@ func TestGetClusterMetrics(t *testing.T) {
 			},
 			ExistingNodeMetrics: []*v1beta1.NodeMetrics{
 				{
-					ObjectMeta: metav1.ObjectMeta{Name: "venus", Namespace: "cluster-defClusterID"},
+					ObjectMeta: metav1.ObjectMeta{Name: "venus"},
 					Usage:      map[corev1.ResourceName]resource.Quantity{"cpu": cpuQuantity, "memory": memoryQuantity},
 				},
 				{
-					ObjectMeta: metav1.ObjectMeta{Name: "mars", Namespace: "cluster-defClusterID"},
+					ObjectMeta: metav1.ObjectMeta{Name: "mars"},
 					Usage:      map[corev1.ResourceName]resource.Quantity{"cpu": cpuQuantity, "memory": memoryQuantity},
 				},
 			},
@@ -1932,18 +1932,18 @@ func TestGetClusterMetrics(t *testing.T) {
 			},
 			ExistingNodeMetrics: []*v1beta1.NodeMetrics{
 				{
-					ObjectMeta: metav1.ObjectMeta{Name: "venus", Namespace: "cluster-defClusterID"},
+					ObjectMeta: metav1.ObjectMeta{Name: "venus"},
 					Usage:      map[corev1.ResourceName]resource.Quantity{"cpu": cpuQuantity, "memory": memoryQuantity},
 				},
 				{
-					ObjectMeta: metav1.ObjectMeta{Name: "mars", Namespace: "cluster-defClusterID"},
+					ObjectMeta: metav1.ObjectMeta{Name: "mars"},
 					Usage:      map[corev1.ResourceName]resource.Quantity{"cpu": cpuQuantity, "memory": memoryQuantity},
 				},
 			},
 		},
-		// scenario 3
+		// scenario 2
 		{
-			Name:             "scenario 3: the user John can not get Bob's cluster metrics",
+			Name:             "scenario 2: the user John can not get Bob's cluster metrics",
 			Body:             ``,
 			ExpectedResponse: `{"error":{"code":403,"message":"forbidden: \"john@acme.com\" doesn't belong to the given project = my-first-project-ID"}}`,
 			ClusterToGet:     test.GenDefaultCluster().Name,
@@ -1975,11 +1975,11 @@ func TestGetClusterMetrics(t *testing.T) {
 			},
 			ExistingNodeMetrics: []*v1beta1.NodeMetrics{
 				{
-					ObjectMeta: metav1.ObjectMeta{Name: "venus", Namespace: "cluster-defClusterID"},
+					ObjectMeta: metav1.ObjectMeta{Name: "venus"},
 					Usage:      map[corev1.ResourceName]resource.Quantity{"cpu": cpuQuantity, "memory": memoryQuantity},
 				},
 				{
-					ObjectMeta: metav1.ObjectMeta{Name: "mars", Namespace: "cluster-defClusterID"},
+					ObjectMeta: metav1.ObjectMeta{Name: "mars"},
 					Usage:      map[corev1.ResourceName]resource.Quantity{"cpu": cpuQuantity, "memory": memoryQuantity},
 				},
 			},

--- a/api/pkg/handler/v1/node/node_test.go
+++ b/api/pkg/handler/v1/node/node_test.go
@@ -1790,7 +1790,7 @@ func TestNodeDeploymentMetrics(t *testing.T) {
 			},
 			ExistingMetrics: []*v1beta1.NodeMetrics{
 				{
-					ObjectMeta: metav1.ObjectMeta{Name: "venus-1", Namespace: "cluster-defClusterID"},
+					ObjectMeta: metav1.ObjectMeta{Name: "venus-1"},
 					Usage:      map[corev1.ResourceName]resource.Quantity{"cpu": cpuQuantity, "memory": memoryQuantity},
 				},
 			},
@@ -1818,7 +1818,7 @@ func TestNodeDeploymentMetrics(t *testing.T) {
 			},
 			ExistingMetrics: []*v1beta1.NodeMetrics{
 				{
-					ObjectMeta: metav1.ObjectMeta{Name: "venus-1", Namespace: "cluster-defClusterID"},
+					ObjectMeta: metav1.ObjectMeta{Name: "venus-1"},
 					Usage:      map[corev1.ResourceName]resource.Quantity{"cpu": cpuQuantity, "memory": memoryQuantity},
 				},
 			},


### PR DESCRIPTION
This reverts commit 90f41f477fa20e6df08f0057cb05434783983f13.

**What this PR does / why we need it**:
Revert #5185 as it introduces issues (#5485)

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #5485 


**Does this PR introduce a user-facing change?**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If  no release note is required, just write "NONE".
-->
```release-note
NONE
```
