### PR TITLE
Normalize Prometheus scraping annotations

### DIFF
--- a/api/pkg/controller/operator/seed/resources/nodeportproxy/deployments.go
+++ b/api/pkg/controller/operator/seed/resources/nodeportproxy/deployments.go
@@ -44,10 +44,10 @@ func EnvoyDeploymentCreator(seed *kubermaticv1.Seed, versions common.Versions) r
 
 			d.Spec.Template.Labels = d.Spec.Selector.MatchLabels
 			d.Spec.Template.Annotations = map[string]string{
-				"kubermatic/scrape":       "true",
-				"kubermatic/scrape_port":  strconv.Itoa(EnvoyPort),
-				"kubermatic/metrics_path": "/stats/prometheus",
-				"fluentbit.io/parser":     "json_iso",
+				"prometheus.io/scrape":       "true",
+				"prometheus.io/scrape_port":  strconv.Itoa(EnvoyPort),
+				"prometheus.io/metrics_path": "/stats/prometheus",
+				"fluentbit.io/parser":        "json_iso",
 			}
 
 			d.Spec.Template.Spec.RestartPolicy = corev1.RestartPolicyAlways

--- a/api/pkg/controller/operator/seed/resources/nodeportproxy/deployments.go
+++ b/api/pkg/controller/operator/seed/resources/nodeportproxy/deployments.go
@@ -45,7 +45,7 @@ func EnvoyDeploymentCreator(seed *kubermaticv1.Seed, versions common.Versions) r
 			d.Spec.Template.Labels = d.Spec.Selector.MatchLabels
 			d.Spec.Template.Annotations = map[string]string{
 				"prometheus.io/scrape":       "true",
-				"prometheus.io/scrape_port":  strconv.Itoa(EnvoyPort),
+				"prometheus.io/port":         strconv.Itoa(EnvoyPort),
 				"prometheus.io/metrics_path": "/stats/prometheus",
 				"fluentbit.io/parser":        "json_iso",
 			}

--- a/config/backup/velero/Chart.yaml
+++ b/config/backup/velero/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: velero
-version: 1.3.2
+version: 1.4.1
 appVersion: v1.3.2
 description: A Helm chart for Heptio Velero
 keywords:

--- a/config/backup/velero/Chart.yaml
+++ b/config/backup/velero/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: velero
-version: 1.4.1
+version: 1.3.3
 appVersion: v1.3.2
 description: A Helm chart for Heptio Velero
 keywords:

--- a/config/backup/velero/templates/deployment.yaml
+++ b/config/backup/velero/templates/deployment.yaml
@@ -16,8 +16,9 @@ spec:
       labels:
         app.kubernetes.io/name: velero
       annotations:
-        kubermatic/scrape: "true"
-        kubermatic/scrape_port: "8085"
+        prometheus.io/scrape: "true"
+        prometheus.io/scrape_port: "8085"
+        kubermatic.io/chart: velero
 {{- with .Values.velero.podAnnotations }}
 {{ toYaml . | indent 8 }}
 {{- end }}

--- a/config/backup/velero/templates/deployment.yaml
+++ b/config/backup/velero/templates/deployment.yaml
@@ -17,7 +17,7 @@ spec:
         app.kubernetes.io/name: velero
       annotations:
         prometheus.io/scrape: "true"
-        prometheus.io/scrape_port: "8085"
+        prometheus.io/port: "8085"
         kubermatic.io/chart: velero
 {{- with .Values.velero.podAnnotations }}
 {{ toYaml . | indent 8 }}

--- a/config/cert-manager/Chart.yaml
+++ b/config/cert-manager/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: cert-manager
-version: 1.1.7
+version: 1.2.1
 appVersion: v0.13.0
 description: A Helm chart for cert-manager
 keywords:

--- a/config/cert-manager/Chart.yaml
+++ b/config/cert-manager/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: cert-manager
-version: 1.2.1
+version: 1.1.8
 appVersion: v0.13.0
 description: A Helm chart for cert-manager
 keywords:

--- a/config/cert-manager/templates/cert-manager-deployment.yaml
+++ b/config/cert-manager/templates/cert-manager-deployment.yaml
@@ -20,8 +20,9 @@ spec:
         app.kubernetes.io/name: cert-manager
         app.kubernetes.io/instance: {{ .Release.Name }}
       annotations:
-        kubermatic/scrape: 'true'
-        kubermatic/scrape_port: '9402'
+        prometheus.io/scrape: 'true'
+        prometheus.io/scrape_port: '9402'
+        kubermatic.io/chart: cert-manager
         fluentbit.io/parser: glog
     spec:
       serviceAccountName: cert-manager

--- a/config/cert-manager/templates/cert-manager-deployment.yaml
+++ b/config/cert-manager/templates/cert-manager-deployment.yaml
@@ -21,7 +21,7 @@ spec:
         app.kubernetes.io/instance: {{ .Release.Name }}
       annotations:
         prometheus.io/scrape: 'true'
-        prometheus.io/scrape_port: '9402'
+        prometheus.io/port: '9402'
         kubermatic.io/chart: cert-manager
         fluentbit.io/parser: glog
     spec:

--- a/config/kubermatic-operator/Chart.yaml
+++ b/config/kubermatic-operator/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: kubermatic-operator
-version: 0.2.0
+version: 0.2.1
 appVersion: '__KUBERMATIC_TAG__'
 description: Helm chart to install the Kubermatic Operator
 keywords:

--- a/config/kubermatic-operator/templates/deployment.yaml
+++ b/config/kubermatic-operator/templates/deployment.yaml
@@ -17,6 +17,7 @@ spec:
       annotations:
         prometheus.io/scrape: 'true'
         prometheus.io/scrape_port: '8085'
+        kubermatic.io/chart: kubermatic-operator
         fluentbit.io/parser: json_iso
     spec:
       serviceAccountName: kubermatic-operator

--- a/config/kubermatic-operator/templates/deployment.yaml
+++ b/config/kubermatic-operator/templates/deployment.yaml
@@ -16,7 +16,7 @@ spec:
         app.kubernetes.io/name: kubermatic-operator
       annotations:
         prometheus.io/scrape: 'true'
-        prometheus.io/scrape_port: '8085'
+        prometheus.io/port: '8085'
         kubermatic.io/chart: kubermatic-operator
         fluentbit.io/parser: json_iso
     spec:

--- a/config/kubermatic/Chart.yaml
+++ b/config/kubermatic/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: kubermatic
-version: 1.1.0
+version: 1.1.1
 appVersion: '__KUBERMATIC_TAG__'
 description: Kubermatic chart for master and/or seed clusters.
 keywords:

--- a/config/kubermatic/templates/kubermatic-api-dep.yaml
+++ b/config/kubermatic/templates/kubermatic-api-dep.yaml
@@ -15,12 +15,13 @@ spec:
         role: kubermatic-api
         version: v1
       annotations:
-        kubermatic/scrape: 'true'
-        kubermatic/scrape_port: '8085'
+        prometheus.io/scrape: 'true'
+        prometheus.io/scrape_port: '8085'
+        kubermatic.io/chart: kubermatic
+        fluentbit.io/parser: glog
         checksum/datecenters: {{ include (print $.Template.BasePath "/datacenter-yaml-secret.yaml") . | sha256sum }}
         checksum/kubeconfig: {{ include (print $.Template.BasePath "/kubeconfig-secret.yaml") . | sha256sum }}
         checksum/master-files: {{ include (print $.Template.BasePath "/master-files-secret.yaml") . | sha256sum }}
-        fluentbit.io/parser: glog
     spec:
       serviceAccountName: kubermatic
       containers:

--- a/config/kubermatic/templates/kubermatic-api-dep.yaml
+++ b/config/kubermatic/templates/kubermatic-api-dep.yaml
@@ -16,7 +16,7 @@ spec:
         version: v1
       annotations:
         prometheus.io/scrape: 'true'
-        prometheus.io/scrape_port: '8085'
+        prometheus.io/port: '8085'
         kubermatic.io/chart: kubermatic
         fluentbit.io/parser: glog
         checksum/datecenters: {{ include (print $.Template.BasePath "/datacenter-yaml-secret.yaml") . | sha256sum }}

--- a/config/kubermatic/templates/kubermatic-controller-manager-dep.yaml
+++ b/config/kubermatic/templates/kubermatic-controller-manager-dep.yaml
@@ -14,8 +14,10 @@ spec:
         role: controller-manager
         version: v1
       annotations:
-        kubermatic/scrape: 'true'
-        kubermatic/scrape_port: '8085'
+        prometheus.io/scrape: 'true'
+        prometheus.io/scrape_port: '8085'
+        kubermatic.io/chart: kubermatic
+        fluentbit.io/parser: glog
         checksum/tls: {{ include (print $.Template.BasePath "/seed-validating-webhook.yaml") . | sha256sum }}
         checksum/master-files: {{ include (print $.Template.BasePath "/master-files-secret.yaml") . | sha256sum }}
         checksum/datecenters: {{ include (print $.Template.BasePath "/datacenter-yaml-secret.yaml") . | sha256sum }}
@@ -27,7 +29,6 @@ spec:
         {{- if .Values.kubermatic.clusterNamespacePrometheus.scrapingConfigs }}
         checksum/prometheus-scraping-configs: {{ include (print $.Template.BasePath "/clusterns-prometheus-scraping-configs-configmap.yaml") . | sha256sum }}
         {{- end }}
-        fluentbit.io/parser: glog
     spec:
       serviceAccountName: kubermatic
       initContainers:

--- a/config/kubermatic/templates/kubermatic-controller-manager-dep.yaml
+++ b/config/kubermatic/templates/kubermatic-controller-manager-dep.yaml
@@ -15,7 +15,7 @@ spec:
         version: v1
       annotations:
         prometheus.io/scrape: 'true'
-        prometheus.io/scrape_port: '8085'
+        prometheus.io/port: '8085'
         kubermatic.io/chart: kubermatic
         fluentbit.io/parser: glog
         checksum/tls: {{ include (print $.Template.BasePath "/seed-validating-webhook.yaml") . | sha256sum }}

--- a/config/kubermatic/templates/master-controller-manager-dep.yaml
+++ b/config/kubermatic/templates/master-controller-manager-dep.yaml
@@ -15,11 +15,12 @@ spec:
       labels:
         app: master-controller
       annotations:
-        kubermatic/scrape: 'true'
-        kubermatic/scrape_port: '8085'
+        prometheus.io/scrape: 'true'
+        prometheus.io/scrape_port: '8085'
+        kubermatic.io/chart: kubermatic
+        fluentbit.io/parser: glog
         checksum/tls: {{ include (print $.Template.BasePath "/seed-validating-webhook.yaml") . | sha256sum }}
         checksum/kubeconfig: {{ include (print $.Template.BasePath "/kubeconfig-secret.yaml") . | sha256sum }}
-        fluentbit.io/parser: glog
     spec:
       containers:
       - name: master-controller

--- a/config/kubermatic/templates/master-controller-manager-dep.yaml
+++ b/config/kubermatic/templates/master-controller-manager-dep.yaml
@@ -16,7 +16,7 @@ spec:
         app: master-controller
       annotations:
         prometheus.io/scrape: 'true'
-        prometheus.io/scrape_port: '8085'
+        prometheus.io/port: '8085'
         kubermatic.io/chart: kubermatic
         fluentbit.io/parser: glog
         checksum/tls: {{ include (print $.Template.BasePath "/seed-validating-webhook.yaml") . | sha256sum }}

--- a/config/kubermatic/templates/vpa-admission-controller-deployment.yaml
+++ b/config/kubermatic/templates/vpa-admission-controller-deployment.yaml
@@ -16,6 +16,9 @@ spec:
       annotations:
         checksum/tls: {{ include (print $.Template.BasePath "/vpa-tls.yaml") . | sha256sum }}
         fluentbit.io/parser: glog
+        prometheus.io/scrape: 'true'
+        prometheus.io/scrape_port: '8944'
+        kubermatic.io/chart: kubermatic
     spec:
       serviceAccountName: vpa-admission-controller
       containers:

--- a/config/kubermatic/templates/vpa-admission-controller-deployment.yaml
+++ b/config/kubermatic/templates/vpa-admission-controller-deployment.yaml
@@ -17,7 +17,7 @@ spec:
         checksum/tls: {{ include (print $.Template.BasePath "/vpa-tls.yaml") . | sha256sum }}
         fluentbit.io/parser: glog
         prometheus.io/scrape: 'true'
-        prometheus.io/scrape_port: '8944'
+        prometheus.io/port: '8944'
         kubermatic.io/chart: kubermatic
     spec:
       serviceAccountName: vpa-admission-controller

--- a/config/kubermatic/templates/vpa-recommender-deployment.yaml
+++ b/config/kubermatic/templates/vpa-recommender-deployment.yaml
@@ -23,7 +23,7 @@ spec:
       annotations:
         fluentbit.io/parser: glog
         prometheus.io/scrape: 'true'
-        prometheus.io/scrape_port: '8942'
+        prometheus.io/port: '8942'
         kubermatic.io/chart: kubermatic
     spec:
       serviceAccountName: vpa-recommender

--- a/config/kubermatic/templates/vpa-recommender-deployment.yaml
+++ b/config/kubermatic/templates/vpa-recommender-deployment.yaml
@@ -22,8 +22,9 @@ spec:
         app: vpa-recommender
       annotations:
         fluentbit.io/parser: glog
-        kubermatic/scrape: 'true'
-        kubermatic/scrape_port: '8942'
+        prometheus.io/scrape: 'true'
+        prometheus.io/scrape_port: '8942'
+        kubermatic.io/chart: kubermatic
     spec:
       serviceAccountName: vpa-recommender
       containers:

--- a/config/kubermatic/templates/vpa-updater-deployment.yaml
+++ b/config/kubermatic/templates/vpa-updater-deployment.yaml
@@ -22,6 +22,10 @@ spec:
         app: vpa-updater
       annotations:
         fluentbit.io/parser: glog
+        # updater should provider metrics, but currently does not
+        # prometheus.io/scrape: 'true'
+        # prometheus.io/scrape_port: '8943'
+        kubermatic.io/chart: kubermatic
     spec:
       serviceAccountName: vpa-updater
       containers:

--- a/config/kubermatic/templates/vpa-updater-deployment.yaml
+++ b/config/kubermatic/templates/vpa-updater-deployment.yaml
@@ -22,7 +22,7 @@ spec:
         app: vpa-updater
       annotations:
         fluentbit.io/parser: glog
-        # updater should provider metrics, but currently does not
+        # updater should provide metrics, but currently does not
         # prometheus.io/scrape: 'true'
         # prometheus.io/port: '8943'
         kubermatic.io/chart: kubermatic

--- a/config/kubermatic/templates/vpa-updater-deployment.yaml
+++ b/config/kubermatic/templates/vpa-updater-deployment.yaml
@@ -24,7 +24,7 @@ spec:
         fluentbit.io/parser: glog
         # updater should provider metrics, but currently does not
         # prometheus.io/scrape: 'true'
-        # prometheus.io/scrape_port: '8943'
+        # prometheus.io/port: '8943'
         kubermatic.io/chart: kubermatic
     spec:
       serviceAccountName: vpa-updater

--- a/config/kubernetes-dashboard/Chart.yaml
+++ b/config/kubernetes-dashboard/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: kubernetes-dashboard
-version: 1.0.3
+version: 1.0.4
 appVersion: v2.0.0
 description: Kubernetes Dashboard
 keywords:

--- a/config/kubernetes-dashboard/templates/dashboard-deployment.yaml
+++ b/config/kubernetes-dashboard/templates/dashboard-deployment.yaml
@@ -25,7 +25,7 @@ spec:
         app.kubernetes.io/managed-by: helm
       annotations:
         prometheus.io/scrape: 'true'
-        prometheus.io/scrape_port: '9090'
+        prometheus.io/port: '9090'
         kubermatic.io/chart: kubernetes-dashboard
     spec:
       containers:

--- a/config/kubernetes-dashboard/templates/dashboard-deployment.yaml
+++ b/config/kubernetes-dashboard/templates/dashboard-deployment.yaml
@@ -23,6 +23,10 @@ spec:
         app.kubernetes.io/instance: {{ .Release.Name }}
         app.kubernetes.io/version: '{{ .Chart.Version }}'
         app.kubernetes.io/managed-by: helm
+      annotations:
+        prometheus.io/scrape: 'true'
+        prometheus.io/scrape_port: '9090'
+        kubermatic.io/chart: kubernetes-dashboard
     spec:
       containers:
         - name: kubernetes-dashboard

--- a/config/logging/elasticsearch/Chart.yaml
+++ b/config/logging/elasticsearch/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: elasticsearch
-version: 1.0.6
+version: 1.0.7
 appVersion: 6.8.5
 description: "[DEPRECATED] Chart to deploy Elasticsearch master and data nodes."
 keywords:

--- a/config/logging/elasticsearch/templates/exporter-deployment.yaml
+++ b/config/logging/elasticsearch/templates/exporter-deployment.yaml
@@ -17,8 +17,9 @@ spec:
       labels:
         app: elasticsearch-exporter
       annotations:
-        kubermatic/scrape: "true"
-        kubermatic/scrape_port: "9114"
+        prometheus.io/scrape: "true"
+        prometheus.io/scrape_port: "9114"
+        kubermatic.io/chart: elasticsearch
     spec:
       containers:
       - name: exporter

--- a/config/logging/elasticsearch/templates/exporter-deployment.yaml
+++ b/config/logging/elasticsearch/templates/exporter-deployment.yaml
@@ -18,7 +18,7 @@ spec:
         app: elasticsearch-exporter
       annotations:
         prometheus.io/scrape: "true"
-        prometheus.io/scrape_port: "9114"
+        prometheus.io/port: "9114"
         kubermatic.io/chart: elasticsearch
     spec:
       containers:

--- a/config/logging/fluentbit/Chart.yaml
+++ b/config/logging/fluentbit/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: fluentbit
-version: 1.5.1
+version: 1.5.2
 appVersion: 1.2.2
 description: Helm chart to install fluent-bit as a log shipper DaemonSet.
 keywords:

--- a/config/logging/fluentbit/templates/daemonset.yaml
+++ b/config/logging/fluentbit/templates/daemonset.yaml
@@ -27,7 +27,7 @@ spec:
         kubernetes.io/cluster-service: "true"
       annotations:
         prometheus.io/scrape: "true"
-        prometheus.io/scrape_port: "2020"
+        prometheus.io/port: "2020"
         prometheus.io/metric_path: /api/v1/metrics/prometheus
         kubermatic.io/chart: fluentbit
         checksum/config: '{{ include (print $.Template.BasePath "/configmap.yaml") . | sha256sum }}'

--- a/config/logging/fluentbit/templates/daemonset.yaml
+++ b/config/logging/fluentbit/templates/daemonset.yaml
@@ -28,7 +28,7 @@ spec:
       annotations:
         prometheus.io/scrape: "true"
         prometheus.io/port: "2020"
-        prometheus.io/metric_path: /api/v1/metrics/prometheus
+        prometheus.io/metrics_path: /api/v1/metrics/prometheus
         kubermatic.io/chart: fluentbit
         checksum/config: '{{ include (print $.Template.BasePath "/configmap.yaml") . | sha256sum }}'
     spec:

--- a/config/logging/fluentbit/templates/daemonset.yaml
+++ b/config/logging/fluentbit/templates/daemonset.yaml
@@ -26,9 +26,10 @@ spec:
         version: v1
         kubernetes.io/cluster-service: "true"
       annotations:
-        kubermatic/metric_path: /api/v1/metrics/prometheus
-        kubermatic/scrape: "true"
-        kubermatic/scrape_port: "2020"
+        prometheus.io/scrape: "true"
+        prometheus.io/scrape_port: "2020"
+        prometheus.io/metric_path: /api/v1/metrics/prometheus
+        kubermatic.io/chart: fluentbit
         checksum/config: '{{ include (print $.Template.BasePath "/configmap.yaml") . | sha256sum }}'
     spec:
       serviceAccountName: fluent-bit

--- a/config/logging/loki/Chart.yaml
+++ b/config/logging/loki/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: "v1"
 name: loki
-version: 0.0.5
+version: 0.0.6
 appVersion: v1.3.0
 description: "Loki: like Prometheus, but for logs."
 keywords:

--- a/config/logging/loki/templates/statefulset.yaml
+++ b/config/logging/loki/templates/statefulset.yaml
@@ -31,6 +31,7 @@ spec:
         checksum/config: {{ include (print $.Template.BasePath "/secret.yaml") . | sha256sum }}
         prometheus.io/scrape: "true"
         prometheus.io/port: "http-metrics"
+        kubermatic.io/chart: loki
     spec:
       serviceAccountName: {{ template "loki.serviceAccountName" . }}
       securityContext:
@@ -38,7 +39,7 @@ spec:
         runAsGroup: 10001
         runAsNonRoot: true
         runAsUser: 10001
-      initContainers: [] 
+      initContainers: []
       containers:
         - name: {{ .Chart.Name }}
           image: "{{ .Values.loki.image.repository }}:{{ .Values.loki.image.tag }}"

--- a/config/logging/promtail/Chart.yaml
+++ b/config/logging/promtail/Chart.yaml
@@ -1,13 +1,13 @@
 apiVersion: "v1"
 name: promtail
-version: 0.0.2
+version: 0.0.3
 appVersion: v1.3.0
 description: "Responsible for gathering logs and sending them to Loki"
 keywords:
 - kubermatic
 - logging
 - grafana
-- loki 
+- loki
 - promtail
 home: https://grafana.com/loki
 sources:

--- a/config/logging/promtail/templates/daemonset.yaml
+++ b/config/logging/promtail/templates/daemonset.yaml
@@ -33,6 +33,7 @@ spec:
         checksum/config: {{ include (print $.Template.BasePath "/configmap.yaml") . | sha256sum }}
         prometheus.io/scrape: "true"
         prometheus.io/port: "http-metrics"
+        kubermatic.io/chart: promtail
     spec:
       serviceAccountName: {{ template "promtail.serviceAccountName" . }}
     {{- if .Values.promtail.priorityClassName }}

--- a/config/minio/Chart.yaml
+++ b/config/minio/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: minio
-version: 1.0.11
+version: 1.0.12
 appVersion: RELEASE.2019-10-12T01-39-57Z
 description: minio
 keywords:

--- a/config/minio/templates/deployment.yaml
+++ b/config/minio/templates/deployment.yaml
@@ -15,7 +15,7 @@ spec:
       annotations:
         prometheus.io/scrape: "true"
         prometheus.io/port: "9000"
-        prometheus.io/metric_path: /minio/prometheus/metrics
+        prometheus.io/metrics_path: /minio/prometheus/metrics
         kubermatic.io/chart: minio
         {{- if .Values.minio.backup.enabled }}
         backup.velero.io/backup-volumes: minio-backup

--- a/config/minio/templates/deployment.yaml
+++ b/config/minio/templates/deployment.yaml
@@ -14,7 +14,7 @@ spec:
         app: minio
       annotations:
         prometheus.io/scrape: "true"
-        prometheus.io/scrape_port: "9000"
+        prometheus.io/port: "9000"
         prometheus.io/metric_path: /minio/prometheus/metrics
         kubermatic.io/chart: minio
         {{- if .Values.minio.backup.enabled }}

--- a/config/minio/templates/deployment.yaml
+++ b/config/minio/templates/deployment.yaml
@@ -13,9 +13,10 @@ spec:
       labels:
         app: minio
       annotations:
-        kubermatic/scrape: "true"
-        kubermatic/scrape_port: "9000"
-        kubermatic/metric_path: /minio/prometheus/metrics
+        prometheus.io/scrape: "true"
+        prometheus.io/scrape_port: "9000"
+        prometheus.io/metric_path: /minio/prometheus/metrics
+        kubermatic.io/chart: minio
         {{- if .Values.minio.backup.enabled }}
         backup.velero.io/backup-volumes: minio-backup
         pre.hook.backup.velero.io/container: backup

--- a/config/monitoring/blackbox-exporter/Chart.yaml
+++ b/config/monitoring/blackbox-exporter/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: blackbox-exporter
-version: 1.0.3
+version: 1.0.4
 appVersion: v0.16.0
 description: Deploys the Prometheus Blackbox Exporter
 keywords:

--- a/config/monitoring/blackbox-exporter/templates/deployment.yaml
+++ b/config/monitoring/blackbox-exporter/templates/deployment.yaml
@@ -14,8 +14,9 @@ spec:
       labels:
         app: blackbox-exporter
       annotations:
-        kubermatic/scrape: "true"
-        kubermatic/scrape_port: "9115"
+        prometheus.io/scrape: "true"
+        prometheus.io/scrape_port: "9115"
+        kubermatic.io/chart: blackbox-exporter
         checksum/config: {{ include (print $.Template.BasePath "/configmap.yaml") . | sha256sum }}
     spec:
       containers:

--- a/config/monitoring/blackbox-exporter/templates/deployment.yaml
+++ b/config/monitoring/blackbox-exporter/templates/deployment.yaml
@@ -15,7 +15,7 @@ spec:
         app: blackbox-exporter
       annotations:
         prometheus.io/scrape: "true"
-        prometheus.io/scrape_port: "9115"
+        prometheus.io/port: "9115"
         kubermatic.io/chart: blackbox-exporter
         checksum/config: {{ include (print $.Template.BasePath "/configmap.yaml") . | sha256sum }}
     spec:

--- a/config/monitoring/helm-exporter/Chart.yaml
+++ b/config/monitoring/helm-exporter/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: helm-exporter
-version: 1.0.3
+version: 1.0.4
 appVersion: 0.4.3
 description: Exports Helm release information to Prometheus
 keywords:

--- a/config/monitoring/helm-exporter/templates/deployment.yaml
+++ b/config/monitoring/helm-exporter/templates/deployment.yaml
@@ -18,8 +18,9 @@ spec:
         app.kubernetes.io/name: '{{ .Chart.Name }}'
         app.kubernetes.io/instance: '{{ template "name" . }}'
       annotations:
-        kubermatic/scrape: 'true'
-        kubermatic/scrape_port: '9571'
+        prometheus.io/scrape: 'true'
+        prometheus.io/scrape_port: '9571'
+        kubermatic.io/chart: helm-exporter
     spec:
       containers:
       - name: '{{ .Chart.Name }}'

--- a/config/monitoring/helm-exporter/templates/deployment.yaml
+++ b/config/monitoring/helm-exporter/templates/deployment.yaml
@@ -19,7 +19,7 @@ spec:
         app.kubernetes.io/instance: '{{ template "name" . }}'
       annotations:
         prometheus.io/scrape: 'true'
-        prometheus.io/scrape_port: '9571'
+        prometheus.io/port: '9571'
         kubermatic.io/chart: helm-exporter
     spec:
       containers:

--- a/config/monitoring/kube-state-metrics/Chart.yaml
+++ b/config/monitoring/kube-state-metrics/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: kube-state-metrics
-version: 1.0.6
+version: 1.0.7
 appVersion: v1.9.4
 description: Kube-State-Metrics for Kubermatic
 keywords:

--- a/config/monitoring/kube-state-metrics/templates/deployment.yaml
+++ b/config/monitoring/kube-state-metrics/templates/deployment.yaml
@@ -13,7 +13,7 @@ spec:
         app: kube-state-metrics
       annotations:
         prometheus.io/scrape: 'true'
-        prometheus.io/scrape_port: '8080'
+        prometheus.io/port: '8080'
         kubermatic.io/chart: kube-state-metrics
         fluentbit.io/parser: glog
     spec:

--- a/config/monitoring/kube-state-metrics/templates/deployment.yaml
+++ b/config/monitoring/kube-state-metrics/templates/deployment.yaml
@@ -12,6 +12,9 @@ spec:
       labels:
         app: kube-state-metrics
       annotations:
+        prometheus.io/scrape: 'true'
+        prometheus.io/scrape_port: '8080'
+        kubermatic.io/chart: kube-state-metrics
         fluentbit.io/parser: glog
     spec:
       serviceAccountName: kube-state-metrics

--- a/config/monitoring/node-exporter/Chart.yaml
+++ b/config/monitoring/node-exporter/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: node-exporter
-version: 1.0.2
+version: 1.0.3
 appVersion: v0.18.1
 description: Prometheus Node Exporter for Kubermatic
 keywords:

--- a/config/monitoring/node-exporter/templates/daemonset.yaml
+++ b/config/monitoring/node-exporter/templates/daemonset.yaml
@@ -18,8 +18,9 @@ spec:
       labels:
         app: node-exporter
       annotations:
-        kubermatic/scrape: 'true'
-        kubermatic/scrape_port: '9100'
+        prometheus.io/scrape: 'true'
+        prometheus.io/scrape_port: '9100'
+        kubermatic.io/chart: node-exporter
     spec:
       hostNetwork: true
       hostPID: true

--- a/config/monitoring/node-exporter/templates/daemonset.yaml
+++ b/config/monitoring/node-exporter/templates/daemonset.yaml
@@ -19,7 +19,7 @@ spec:
         app: node-exporter
       annotations:
         prometheus.io/scrape: 'true'
-        prometheus.io/scrape_port: '9100'
+        prometheus.io/port: '9100'
         kubermatic.io/chart: node-exporter
     spec:
       hostNetwork: true

--- a/config/monitoring/prometheus/Chart.yaml
+++ b/config/monitoring/prometheus/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: prometheus
-version: 2.2.16
+version: 2.2.17
 appVersion: v2.17.0
 description: Prometheus Monitoring for Kubernetes
 keywords:

--- a/config/monitoring/prometheus/config/scraping/clusters.yaml
+++ b/config/monitoring/prometheus/config/scraping/clusters.yaml
@@ -8,11 +8,6 @@ scheme: http
 kubernetes_sd_configs:
 - role: endpoints
 relabel_configs:
-# drop everything within e2e test clusters
-- source_labels: [__meta_kubernetes_namespace]
-  separator: ;
-  regex: .*prow-e2e-.*
-  action: drop
 - source_labels: [__meta_kubernetes_service_label_cluster]
   separator: ;
   regex: user

--- a/config/monitoring/prometheus/config/scraping/node-exporter.yaml
+++ b/config/monitoring/prometheus/config/scraping/node-exporter.yaml
@@ -11,14 +11,14 @@ relabel_configs:
 - source_labels: [__meta_kubernetes_namespace, __meta_kubernetes_pod_label_app]
   regex: '{{ .Release.Namespace }};node-exporter'
   action: keep
-- source_labels: [__meta_kubernetes_pod_annotation_kubermatic_scrape]
+- source_labels: [__meta_kubernetes_pod_annotation_prometheus_io_scrape]
   action: keep
   regex: true
-- source_labels: [__meta_kubernetes_pod_annotation_kubermatic_metric_path]
+- source_labels: [__meta_kubernetes_pod_annotation_prometheus_io_metrics_path]
   action: replace
   target_label: __metrics_path__
   regex: (.+)
-- source_labels: [__address__, __meta_kubernetes_pod_annotation_kubermatic_scrape_port]
+- source_labels: [__address__, __meta_kubernetes_pod_annotation_prometheus_io_port]
   action: replace
   regex: ([^:]+)(?::\d+)?;(\d+)
   replacement: $1:$2

--- a/config/monitoring/prometheus/config/scraping/node-exporter.yaml
+++ b/config/monitoring/prometheus/config/scraping/node-exporter.yaml
@@ -11,18 +11,25 @@ relabel_configs:
 - source_labels: [__meta_kubernetes_namespace, __meta_kubernetes_pod_label_app]
   regex: '{{ .Release.Namespace }};node-exporter'
   action: keep
-- source_labels: [__meta_kubernetes_pod_annotation_prometheus_io_scrape]
+
+# only keep pods labelled with special annotations;
+# "kubermatic/" is supported for legacy reasons
+- source_labels: [__meta_kubernetes_pod_annotation_kubermatic_scrape, __meta_kubernetes_pod_annotation_prometheus_io_scrape]
+  regex: '.*true.*'
   action: keep
-  regex: true
-- source_labels: [__meta_kubernetes_pod_annotation_prometheus_io_metrics_path]
+
+# allow to overwrite the scrape port
+- source_labels: [__address__, __meta_kubernetes_pod_annotation_kubermatic_scrape_port] # deprecated
   action: replace
-  target_label: __metrics_path__
-  regex: (.+)
-- source_labels: [__address__, __meta_kubernetes_pod_annotation_prometheus_io_port]
-  action: replace
-  regex: ([^:]+)(?::\d+)?;(\d+)
+  regex: '^([^:]+)(?::\d+)?;(\d+)$'
   replacement: $1:$2
   target_label: __address__
+- source_labels: [__address__, __meta_kubernetes_pod_annotation_prometheus_io_port]
+  action: replace
+  regex: '^([^:]+)(?::\d+)?;(\d+)$'
+  replacement: $1:$2
+  target_label: __address__
+
 - action: labelmap
   regex: __meta_kubernetes_pod_label_(.+)
 - source_labels: [__meta_kubernetes_namespace]

--- a/config/monitoring/prometheus/config/scraping/pods.yaml
+++ b/config/monitoring/prometheus/config/scraping/pods.yaml
@@ -2,26 +2,50 @@ job_name: 'pods'
 kubernetes_sd_configs:
 - role: pod
 relabel_configs:
-# drop everything within test clusters
-- source_labels: [__meta_kubernetes_namespace]
-  regex: prow-kubermatic-.*
-  action: drop
 # drop node-exporters, as they need HTTPS scraping with credentials
 - source_labels: [__meta_kubernetes_namespace, __meta_kubernetes_pod_label_app]
   regex: '{{ .Release.Namespace }};node-exporter'
   action: drop
-- source_labels: [__meta_kubernetes_pod_annotation_kubermatic_scrape]
+
+# do not scrape user-cluster namespaces
+- source_labels: [__meta_kubernetes_namespace]
+  regex: 'cluster-.*'
+  action: drop
+
+# only keep pods labelled with special annotations;
+# "kubermatic/" is supported for legacy reasons
+- source_labels: [__meta_kubernetes_pod_annotation_kubermatic_scrape, __meta_kubernetes_pod_annotation_prometheus_io_scrape]
+  regex: '.*true.*'
   action: keep
-  regex: true
+
+# allow to overwrite the metrics URL
+- source_labels: [__meta_kubernetes_pod_annotation_prometheus_io_metric_path]
+  action: replace
+  target_label: __metrics_path__
+  regex: (.+)
 - source_labels: [__meta_kubernetes_pod_annotation_kubermatic_metric_path]
   action: replace
   target_label: __metrics_path__
   regex: (.+)
-- source_labels: [__address__, __meta_kubernetes_pod_annotation_kubermatic_scrape_port]
+
+# Allow to overwrite the scrape port
+- source_labels: [__address__, __meta_kubernetes_pod_annotation_kubermatic_scrape_port] # deprecated names
   action: replace
-  regex: ([^:]+)(?::\d+)?;(\d+)
+  regex: '^([^:]+)(?::\d+)?;(\d+)$'
   replacement: $1:$2
   target_label: __address__
+- source_labels: [__address__, __meta_kubernetes_pod_annotation_prometheus_io_scrape_port] # deprecated names
+  action: replace
+  regex: '^([^:]+)(?::\d+)?;(\d+)$'
+  replacement: $1:$2
+  target_label: __address__
+- source_labels: [__address__, __meta_kubernetes_pod_annotation_prometheus_io_port]
+  action: replace
+  regex: '^([^:]+)(?::\d+)?;(\d+)$'
+  replacement: $1:$2
+  target_label: __address__
+
+# refine labels further
 - action: labelmap
   regex: __meta_kubernetes_pod_label_(.+)
 - source_labels: [__meta_kubernetes_namespace]
@@ -34,7 +58,9 @@ relabel_configs:
   target_label: pod
   replacement: $1
   action: replace
+
 metric_relabel_configs:
+# turn namespace into a nice cluster ID label
 - source_labels: [namespace]
   regex: cluster-([a-z0-9]+)
   target_label: cluster

--- a/config/monitoring/prometheus/config/scraping/pods.yaml
+++ b/config/monitoring/prometheus/config/scraping/pods.yaml
@@ -32,7 +32,7 @@ relabel_configs:
   target_label: __metrics_path__
   regex: (.+)
 
-# Allow to overwrite the scrape port
+# allow to overwrite the scrape port
 - source_labels: [__address__, __meta_kubernetes_pod_annotation_kubermatic_scrape_port] # deprecated
   action: replace
   regex: '^([^:]+)(?::\d+)?;(\d+)$'

--- a/config/monitoring/prometheus/config/scraping/pods.yaml
+++ b/config/monitoring/prometheus/config/scraping/pods.yaml
@@ -19,22 +19,26 @@ relabel_configs:
   action: keep
 
 # allow to overwrite the metrics URL
-- source_labels: [__meta_kubernetes_pod_annotation_prometheus_io_metric_path]
+- source_labels: [__meta_kubernetes_pod_annotation_prometheus_io_metrics_path]
   action: replace
   target_label: __metrics_path__
   regex: (.+)
-- source_labels: [__meta_kubernetes_pod_annotation_kubermatic_metric_path]
+- source_labels: [__meta_kubernetes_pod_annotation_kubermatic_metrics_path] # deprecated
+  action: replace
+  target_label: __metrics_path__
+  regex: (.+)
+- source_labels: [__meta_kubernetes_pod_annotation_kubermatic_metric_path] # deprecated typo
   action: replace
   target_label: __metrics_path__
   regex: (.+)
 
 # Allow to overwrite the scrape port
-- source_labels: [__address__, __meta_kubernetes_pod_annotation_kubermatic_scrape_port] # deprecated names
+- source_labels: [__address__, __meta_kubernetes_pod_annotation_kubermatic_scrape_port] # deprecated
   action: replace
   regex: '^([^:]+)(?::\d+)?;(\d+)$'
   replacement: $1:$2
   target_label: __address__
-- source_labels: [__address__, __meta_kubernetes_pod_annotation_prometheus_io_scrape_port] # deprecated names
+- source_labels: [__address__, __meta_kubernetes_pod_annotation_prometheus_io_scrape_port] # deprecated variant
   action: replace
   regex: '^([^:]+)(?::\d+)?;(\d+)$'
   replacement: $1:$2

--- a/config/monitoring/prometheus/templates/statefulset.yaml
+++ b/config/monitoring/prometheus/templates/statefulset.yaml
@@ -22,8 +22,9 @@ spec:
         thanos.io/store-api: 'true'
         {{- end }}
       annotations:
-        kubermatic/scrape: 'true'
-        kubermatic/scrape_port: '9090'
+        prometheus.io/scrape: 'true'
+        prometheus.io/scrape_port: '9090'
+        kubermatic.io/chart: prometheus
         {{- if .Values.prometheus.backup.enabled }}
         backup.velero.io/backup-volumes: backup
         pre.hook.backup.velero.io/container: backup

--- a/config/monitoring/prometheus/templates/statefulset.yaml
+++ b/config/monitoring/prometheus/templates/statefulset.yaml
@@ -23,7 +23,7 @@ spec:
         {{- end }}
       annotations:
         prometheus.io/scrape: 'true'
-        prometheus.io/scrape_port: '9090'
+        prometheus.io/port: '9090'
         kubermatic.io/chart: prometheus
         {{- if .Values.prometheus.backup.enabled }}
         backup.velero.io/backup-volumes: backup

--- a/config/monitoring/prometheus/templates/thanos-compact-deployment.yaml
+++ b/config/monitoring/prometheus/templates/thanos-compact-deployment.yaml
@@ -21,7 +21,7 @@ spec:
         app.kubernetes.io/instance: {{ template "name" . }}
       annotations:
         prometheus.io/scrape: 'true'
-        prometheus.io/scrape_port: '10902'
+        prometheus.io/port: '10902'
         kubermatic.io/chart: prometheus
     spec:
       containers:

--- a/config/monitoring/prometheus/templates/thanos-compact-deployment.yaml
+++ b/config/monitoring/prometheus/templates/thanos-compact-deployment.yaml
@@ -20,8 +20,9 @@ spec:
         app.kubernetes.io/name: thanos-compact
         app.kubernetes.io/instance: {{ template "name" . }}
       annotations:
-        kubermatic/scrape: 'true'
-        kubermatic/scrape_port: '10902'
+        prometheus.io/scrape: 'true'
+        prometheus.io/scrape_port: '10902'
+        kubermatic.io/chart: prometheus
     spec:
       containers:
       - name: thanos

--- a/config/monitoring/prometheus/templates/thanos-query-deployment.yaml
+++ b/config/monitoring/prometheus/templates/thanos-query-deployment.yaml
@@ -21,7 +21,7 @@ spec:
         app.kubernetes.io/instance: {{ template "name" . }}
       annotations:
         prometheus.io/scrape: 'true'
-        prometheus.io/scrape_port: '10902'
+        prometheus.io/port: '10902'
         kubermatic.io/chart: prometheus
     spec:
       containers:

--- a/config/monitoring/prometheus/templates/thanos-query-deployment.yaml
+++ b/config/monitoring/prometheus/templates/thanos-query-deployment.yaml
@@ -20,8 +20,9 @@ spec:
         app.kubernetes.io/name: thanos-query
         app.kubernetes.io/instance: {{ template "name" . }}
       annotations:
-        kubermatic/scrape: 'true'
-        kubermatic/scrape_port: '10902'
+        prometheus.io/scrape: 'true'
+        prometheus.io/scrape_port: '10902'
+        kubermatic.io/chart: prometheus
     spec:
       containers:
       - name: thanos

--- a/config/monitoring/prometheus/templates/thanos-store-deployment.yaml
+++ b/config/monitoring/prometheus/templates/thanos-store-deployment.yaml
@@ -21,8 +21,9 @@ spec:
         app.kubernetes.io/instance: {{ template "name" . }}
         thanos.io/store-api: 'true'
       annotations:
-        kubermatic/scrape: 'true'
-        kubermatic/scrape_port: '10902'
+        prometheus.io/scrape: 'true'
+        prometheus.io/scrape_port: '10902'
+        kubermatic.io/chart: prometheus
     spec:
       containers:
       - name: thanos

--- a/config/monitoring/prometheus/templates/thanos-store-deployment.yaml
+++ b/config/monitoring/prometheus/templates/thanos-store-deployment.yaml
@@ -22,7 +22,7 @@ spec:
         thanos.io/store-api: 'true'
       annotations:
         prometheus.io/scrape: 'true'
-        prometheus.io/scrape_port: '10902'
+        prometheus.io/port: '10902'
         kubermatic.io/chart: prometheus
     spec:
       containers:

--- a/config/monitoring/prometheus/templates/thanos-ui-deployment.yaml
+++ b/config/monitoring/prometheus/templates/thanos-ui-deployment.yaml
@@ -21,7 +21,7 @@ spec:
         app.kubernetes.io/instance: {{ template "name" . }}
       annotations:
         prometheus.io/scrape: 'true'
-        prometheus.io/scrape_port: '10902'
+        prometheus.io/port: '10902'
         kubermatic.io/chart: prometheus
     spec:
       containers:

--- a/config/monitoring/prometheus/templates/thanos-ui-deployment.yaml
+++ b/config/monitoring/prometheus/templates/thanos-ui-deployment.yaml
@@ -20,8 +20,9 @@ spec:
         app.kubernetes.io/name: thanos-ui
         app.kubernetes.io/instance: {{ template "name" . }}
       annotations:
-        kubermatic/scrape: 'true'
-        kubermatic/scrape_port: '10902'
+        prometheus.io/scrape: 'true'
+        prometheus.io/scrape_port: '10902'
+        kubermatic.io/chart: prometheus
     spec:
       containers:
       - name: thanos

--- a/config/oauth/Chart.yaml
+++ b/config/oauth/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: oauth
-version: 1.2.0
+version: 1.2.1
 appVersion: v2.22.0
 description: Dex
 keywords:

--- a/config/oauth/templates/configmap.yaml
+++ b/config/oauth/templates/configmap.yaml
@@ -17,6 +17,8 @@ data:
         inCluster: true
     web:
       http: 0.0.0.0:5556
+    telemetry:
+      http: 0.0.0.0:5558
     # this is a requirement for static passwords, so we just enable it by default
     enablePasswordDB: true
 {{ if .Values.dex.expiry }}

--- a/config/oauth/templates/deployment.yaml
+++ b/config/oauth/templates/deployment.yaml
@@ -14,6 +14,9 @@ spec:
       labels:
         app: dex
       annotations:
+        prometheus.io/scrape: 'true'
+        prometheus.io/scrape_port: '5558'
+        kubermatic.io/chart: oauth
         checksum/config: {{ include (print $.Template.BasePath "/configmap.yaml") . | sha256sum }}
         checksum/secrets: {{ include (print $.Template.BasePath "/secrets.yaml") . | sha256sum }}
     spec:
@@ -25,6 +28,8 @@ spec:
         ports:
         - name: https
           containerPort: 5556
+        - name: telemetry
+          containerPort: 5558
         volumeMounts:
         - name: config
           mountPath: /etc/dex/cfg

--- a/config/oauth/templates/deployment.yaml
+++ b/config/oauth/templates/deployment.yaml
@@ -15,7 +15,7 @@ spec:
         app: dex
       annotations:
         prometheus.io/scrape: 'true'
-        prometheus.io/scrape_port: '5558'
+        prometheus.io/port: '5558'
         kubermatic.io/chart: oauth
         checksum/config: {{ include (print $.Template.BasePath "/configmap.yaml") . | sha256sum }}
         checksum/secrets: {{ include (print $.Template.BasePath "/secrets.yaml") . | sha256sum }}

--- a/config/s3-exporter/Chart.yaml
+++ b/config/s3-exporter/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: s3-exporter
-version: 1.1.1
+version: 1.1.2
 appVersion: v0.4
 keywords:
 - kubermatic

--- a/config/s3-exporter/templates/deployment.yaml
+++ b/config/s3-exporter/templates/deployment.yaml
@@ -13,8 +13,9 @@ spec:
       labels:
         app: s3-exporter
       annotations:
-        kubermatic/scrape: 'true'
-        kubermatic/scrape_port: '9340'
+        prometheus.io/scrape: 'true'
+        prometheus.io/scrape_port: '9340'
+        kubermatic.io/chart: s3-exporter
         fluentbit.io/parser: json_iso
     spec:
       serviceAccountName: s3-exporter

--- a/config/s3-exporter/templates/deployment.yaml
+++ b/config/s3-exporter/templates/deployment.yaml
@@ -14,7 +14,7 @@ spec:
         app: s3-exporter
       annotations:
         prometheus.io/scrape: 'true'
-        prometheus.io/scrape_port: '9340'
+        prometheus.io/port: '9340'
         kubermatic.io/chart: s3-exporter
         fluentbit.io/parser: json_iso
     spec:


### PR DESCRIPTION
**What this PR does / why we need it**:
Historically we have been using `kubermatic/scrape` to annotations to mark pods for scraping. This was mostly done, IIRC, to prevent Prometheus from sccraping the entire seed cluster.

Over time, the monitoring stack has evolved and contains more metrics and dashboards for other components. There are now a number of reasons to use a more standard `prometheus.io/` prefix:

* It makes Kubermatic be one component in the cluster.
* Other monitoring solutions can easily find Kubermatic scrape targets.
* We already use `prometheus.io/` as the prefix inside the user-cluster Prometheus.
* We use `fluentbit.io/parser` for the parser name, not `kubermatic/fluentbit-parser`.

This PR therefore changes the prefix everywhere *but* the nginx-ingress and nodeport-proxy, to prevent re-deployments and LoadBalancer changes. The PR also

* normalizes `metric_path` to `metrics_path`,
* normalizes `scrape_port` to `port`,
* adds a new `kubermatic.io/chart` annotation to pods managed by Helm charts, in case we ever want to specifically target a certain chart by its name (or all pods just having this annotation),
* adjusts the scraping rules in Prometheus to handle both old and new annotations, so the rollout can happen over time.

I tested this on dev (Prometheus only, i.e. all other charts still use their original annotations) and the changes scraping rules match a broader, i.e. more complete set of pods (52 instead of 47). Node-exporter were also still matched and since rules/annotation for user-cluster components have not been touched, I didn't test it.

Currently, without this PR, the scraping of Kubermatic components is broken when using the Operator, because the Operator acciden^Wbravely already uses the new annotations. I will create a dedicated PR for the 2.14 release branch to just add the old annotations, which is much safer for an existing release.

**Documentation**:
<!-- Add links to the related documentation changes related to this pull request. E.g. the link to the kubermatic/docs pullrequest. -->
TODO

**Does this PR introduce a user-facing change?**:
```release-note
Prometheus scraping annotations have been normalized to use `prometheus.io/` as their prefix. Old annotations (`kubermatic/`) are still supported, but deprecated.
```