### PR TITLE
Update Grafana to 7.0.3

### DIFF
--- a/config/monitoring/grafana/Chart.yaml
+++ b/config/monitoring/grafana/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 name: grafana
-version: 1.3.1
-appVersion: 6.7.1
+version: 1.4.0
+appVersion: 7.0.3
 description: Grafana for Kubermatic
 keywords:
 - kubermatic

--- a/config/monitoring/grafana/values.yaml
+++ b/config/monitoring/grafana/values.yaml
@@ -5,13 +5,13 @@ grafana:
   replicas: 1
   image:
     repository: docker.io/grafana/grafana
-    tag: 6.7.1
+    tag: 7.0.3
   utilImage:
     repository: quay.io/kubermatic/util
     tag: 1.3.4
   pluginImage:
     repository: quay.io/kubermatic/grafana-plugins
-    tag: 1.0.0
+    tag: 1.1.0
   resources:
     requests:
       cpu: 100m
@@ -61,7 +61,7 @@ grafana:
 
       lokiServices: []
       # - loki
-      
+
       # read datasources from this path in the Helm chart; this is
       # evaluated during deployment, not during Grafana runtime!
       source: provisioning/datasources/*

--- a/containers/grafana-plugins/Dockerfile
+++ b/containers/grafana-plugins/Dockerfile
@@ -1,15 +1,15 @@
-FROM alpine:3.10
+FROM alpine:3.12
 
 RUN mkdir -p /plugins
 WORKDIR /plugins
 
-RUN wget -O- https://grafana.com/api/plugins/grafana-piechart-panel/versions/1.3.9/download | unzip - && \
+RUN wget -O- https://grafana.com/api/plugins/grafana-piechart-panel/versions/1.5.0/download | unzip - && \
     mv grafana-piechart-panel-* grafana-piechart-panel
 
-RUN wget -O- https://grafana.com/api/plugins/farski-blendstat-panel/versions/1.0.1/download | unzip - && \
+RUN wget -O- https://grafana.com/api/plugins/farski-blendstat-panel/versions/1.0.2/download | unzip - && \
     mv farski-blendstat-grafana-* farski-blendstat-panel
 
-RUN wget -O- https://grafana.com/api/plugins/michaeldmoore-multistat-panel/versions/1.2.3/download | unzip - && \
+RUN wget -O- https://grafana.com/api/plugins/michaeldmoore-multistat-panel/versions/1.3.0/download | unzip - && \
     mv michaeldmoore-michaeldmoore-multistat-panel-* michaeldmoore-multistat-panel
 
 RUN wget -O- https://grafana.com/api/plugins/vonage-status-panel/versions/1.0.9/download | unzip - && \

--- a/containers/grafana-plugins/release.sh
+++ b/containers/grafana-plugins/release.sh
@@ -2,7 +2,7 @@
 
 set -euo pipefail
 
-VERSION=1.0.0
+VERSION=1.1.0
 
 docker build --no-cache --pull -t quay.io/kubermatic/grafana-plugins:${VERSION} .
 docker push quay.io/kubermatic/grafana-plugins:${VERSION}


### PR DESCRIPTION
**What this PR does / why we need it**:
From what I could test on dev, 7.x works just fine with our existing dashboards.

**Does this PR introduce a user-facing change?**:
```release-note
Updated Grafana to 7.0.3
```
