### PR TITLE
make promtail chart updatable

### DIFF
--- a/config/logging/promtail/Chart.yaml
+++ b/config/logging/promtail/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: "v1"
 name: promtail
-version: 0.0.3
+version: 0.1.0
 appVersion: v1.3.0
 description: "Responsible for gathering logs and sending them to Loki"
 keywords:

--- a/config/logging/promtail/templates/daemonset.yaml
+++ b/config/logging/promtail/templates/daemonset.yaml
@@ -15,8 +15,6 @@ spec:
     matchLabels:
       app.kubernetes.io/name: {{ template "promtail.name" . }}
       app.kubernetes.io/instance: '{{ .Release.Name }}'
-      app.kubernetes.io/version: '{{ .Chart.Version }}'
-      app.kubernetes.io/managed-by: helm
   updateStrategy:
     type: {{ .Values.promtail.deploymentStrategy }}
   {{- if ne .Values.promtail.deploymentStrategy "RollingUpdate" }}
@@ -27,8 +25,6 @@ spec:
       labels:
         app.kubernetes.io/name: {{ template "promtail.name" . }}
         app.kubernetes.io/instance: '{{ .Release.Name }}'
-        app.kubernetes.io/version: '{{ .Chart.Version }}'
-        app.kubernetes.io/managed-by: helm
       annotations:
         checksum/config: {{ include (print $.Template.BasePath "/configmap.yaml") . | sha256sum }}
         prometheus.io/scrape: "true"


### PR DESCRIPTION
**What this PR does / why we need it**:
Due to a mistake when defining the matchExpression, the promtail chart could never be updated when its version changed. This PR fixes that by not including the chart version in the match labels.

**Documentation**:
https://github.com/kubermatic/docs/pull/330 documents the manual upgrade step.

**Does this PR introduce a user-facing change?**:
```release-note
ACTION REQUIRED: Promtail labelling has changed, please see upgrade notes for further information.
```
