### PR TITLE
[release/v2.14] Restore Prometheus scrape annotations for operator-managed components

### DIFF
--- a/api/pkg/controller/operator/common/vpa/admissionctrl.go
+++ b/api/pkg/controller/operator/common/vpa/admissionctrl.go
@@ -51,9 +51,9 @@ func AdmissionControllerDeploymentCreator(cfg *operatorv1alpha1.KubermaticConfig
 
 			d.Spec.Template.Labels = d.Spec.Selector.MatchLabels
 			d.Spec.Template.Annotations = map[string]string{
-				"prometheus.io/scrape": "true",
-				"prometheus.io/port":   strconv.Itoa(admissionControllerPort),
-				"fluentbit.io/parser":  "glog",
+				"kubermatic/scrape":      "true",
+				"kubermatic/scrape_port": strconv.Itoa(admissionControllerPort),
+				"fluentbit.io/parser":    "glog",
 			}
 
 			d.Spec.Template.Spec.Volumes = []corev1.Volume{

--- a/api/pkg/controller/operator/common/vpa/recommender.go
+++ b/api/pkg/controller/operator/common/vpa/recommender.go
@@ -43,9 +43,9 @@ func RecommenderDeploymentCreator(cfg *operatorv1alpha1.KubermaticConfiguration,
 
 			d.Spec.Template.Labels = d.Spec.Selector.MatchLabels
 			d.Spec.Template.Annotations = map[string]string{
-				"prometheus.io/scrape": "true",
-				"prometheus.io/port":   strconv.Itoa(recommenderPort),
-				"fluentbit.io/parser":  "glog",
+				"kubermatic/scrape":      "true",
+				"kubermatic/scrape_port": strconv.Itoa(recommenderPort),
+				"fluentbit.io/parser":    "glog",
 			}
 
 			d.Spec.Template.Spec.ServiceAccountName = RecommenderName

--- a/api/pkg/controller/operator/common/vpa/updater.go
+++ b/api/pkg/controller/operator/common/vpa/updater.go
@@ -37,9 +37,9 @@ func UpdaterDeploymentCreator(cfg *operatorv1alpha1.KubermaticConfiguration, ver
 
 			d.Spec.Template.Labels = d.Spec.Selector.MatchLabels
 			d.Spec.Template.Annotations = map[string]string{
-				"prometheus.io/scrape": "true",
-				"prometheus.io/port":   strconv.Itoa(updaterPort),
-				"fluentbit.io/parser":  "glog",
+				"kubermatic/scrape":      "true",
+				"kubermatic/scrape_port": strconv.Itoa(updaterPort),
+				"fluentbit.io/parser":    "glog",
 			}
 
 			d.Spec.Template.Spec.ServiceAccountName = UpdaterName

--- a/api/pkg/controller/operator/master/resources/kubermatic/api.go
+++ b/api/pkg/controller/operator/master/resources/kubermatic/api.go
@@ -47,9 +47,9 @@ func APIDeploymentCreator(cfg *operatorv1alpha1.KubermaticConfiguration, workerN
 
 			d.Spec.Template.Labels = d.Spec.Selector.MatchLabels
 			d.Spec.Template.Annotations = map[string]string{
-				"prometheus.io/scrape": "true",
-				"prometheus.io/port":   "8085",
-				"fluentbit.io/parser":  "json_iso",
+				"kubermatic/scrape":      "true",
+				"kubermatic/scrape_port": "8085",
+				"fluentbit.io/parser":    "json_iso",
 			}
 
 			d.Spec.Template.Spec.ServiceAccountName = serviceAccountName

--- a/api/pkg/controller/operator/master/resources/kubermatic/master-controller-manager.go
+++ b/api/pkg/controller/operator/master/resources/kubermatic/master-controller-manager.go
@@ -31,9 +31,9 @@ func MasterControllerManagerDeploymentCreator(cfg *operatorv1alpha1.KubermaticCo
 
 			d.Spec.Template.Labels = d.Spec.Selector.MatchLabels
 			d.Spec.Template.Annotations = map[string]string{
-				"prometheus.io/scrape": "true",
-				"prometheus.io/port":   "8085",
-				"fluentbit.io/parser":  "json_iso",
+				"kubermatic/scrape":      "true",
+				"kubermatic/scrape_port": "8085",
+				"fluentbit.io/parser":    "json_iso",
 			}
 
 			d.Spec.Template.Spec.ServiceAccountName = serviceAccountName

--- a/api/pkg/controller/operator/seed/resources/kubermatic/seed-controller-manager.go
+++ b/api/pkg/controller/operator/seed/resources/kubermatic/seed-controller-manager.go
@@ -34,9 +34,9 @@ func SeedControllerManagerDeploymentCreator(workerName string, versions common.V
 
 			d.Spec.Template.Labels = d.Spec.Selector.MatchLabels
 			d.Spec.Template.Annotations = map[string]string{
-				"prometheus.io/scrape": "true",
-				"prometheus.io/port":   "8085",
-				"fluentbit.io/parser":  "json_iso",
+				"kubermatic/scrape":      "true",
+				"kubermatic/scrape_port": "8085",
+				"fluentbit.io/parser":    "json_iso",
 			}
 
 			d.Spec.Template.Spec.ServiceAccountName = serviceAccountName

--- a/api/pkg/controller/operator/seed/resources/nodeportproxy/deployments.go
+++ b/api/pkg/controller/operator/seed/resources/nodeportproxy/deployments.go
@@ -44,10 +44,10 @@ func EnvoyDeploymentCreator(seed *kubermaticv1.Seed, versions common.Versions) r
 
 			d.Spec.Template.Labels = d.Spec.Selector.MatchLabels
 			d.Spec.Template.Annotations = map[string]string{
-				"kubermatic/scrape":       "true",
-				"kubermatic/scrape_port":  strconv.Itoa(EnvoyPort),
-				"kubermatic/metrics_path": "/stats/prometheus",
-				"fluentbit.io/parser":     "json_iso",
+				"kubermatic/scrape":      "true",
+				"kubermatic/scrape_port": strconv.Itoa(EnvoyPort),
+				"kubermatic/metric_path": "/stats/prometheus",
+				"fluentbit.io/parser":    "json_iso",
 			}
 
 			d.Spec.Template.Spec.RestartPolicy = corev1.RestartPolicyAlways


### PR DESCRIPTION
**What this PR does / why we need it**:
The default Prometheus setup is not yet able to handle `prometheus.io/` annotations (this has only recently been done in #5498). In order to get Kubermatic back, for 2.14 we will simply use the old annotations, consistent with what the Kubermatic Helm chart does.

**Does this PR introduce a user-facing change?**:
```release-note
Fixed missing Kubermatic Prometheus metrics.
```
