### PR TITLE
Update Dex to v0.24.0

### DIFF
--- a/config/oauth/Chart.yaml
+++ b/config/oauth/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 name: oauth
-version: 1.2.1
-appVersion: v2.22.0
+version: 1.2.2
+appVersion: v2.24.0
 description: Dex
 keywords:
 - kubermatic

--- a/config/oauth/values.yaml
+++ b/config/oauth/values.yaml
@@ -1,7 +1,7 @@
 dex:
   image:
     repository: "quay.io/dexidp/dex"
-    tag: "v2.22.0"
+    tag: "v2.24.0"
   replicas: 2
   ingress:
     # this option is required


### PR DESCRIPTION
**What this PR does / why we need it**:
Nothing interesting to see here. No migration steps mentioned on https://github.com/dexidp/dex/releases

**Does this PR introduce a user-facing change?**:
```release-note
Update Dex to v0.24.0
```
