### PR TITLE
Remove default credentials from Helm charts

### DIFF
--- a/config/.gitignore
+++ b/config/.gitignore
@@ -1,6 +1,0 @@
-.idea
-*.swp
-*.swo
-kubermatic/static/kubeconfig
-kubermatic/static/datacenters.yaml
-kubermatic/static/url

--- a/config/minio/Chart.yaml
+++ b/config/minio/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: minio
-version: 1.0.13
+version: 1.0.14
 appVersion: RELEASE.2020-06-03T22-13-49Z
 description: minio
 keywords:

--- a/config/minio/values.yaml
+++ b/config/minio/values.yaml
@@ -3,9 +3,11 @@ minio:
     repository: docker.io/minio/minio
     tag: RELEASE.2020-06-03T22-13-49Z
   storeSize: 100Gi
+
+  # These settings are required. Keys must be alphanumeric.
   credentials:
-    accessKey: wtupllWfpMg414ZM5YkzZiUmgjh1vZdk
-    secretKey: r89xkN9JvHJQppb5v7SEfkNkiC1vDcMySQFKxg6uDkE3gZfCeB7ZBfECyUOTywym
+    accessKey: '' # 32 byte long
+    secretKey: '' # 64 byte long
 
   flags:
     # Set to true to enable Minio's strict S3 compatibility mode.

--- a/config/monitoring/grafana/Chart.yaml
+++ b/config/monitoring/grafana/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: grafana
-version: 1.4.0
+version: 1.4.1
 appVersion: 7.0.3
 description: Grafana for Kubermatic
 keywords:

--- a/config/monitoring/grafana/config/grafana.ini
+++ b/config/monitoring/grafana/config/grafana.ini
@@ -1,6 +1,6 @@
 [security]
-admin_password = {{ .Values.grafana.password | b64dec }}
-admin_user = {{ .Values.grafana.user | b64dec }}
+admin_password = {{ .Values.grafana.password | quote }}
+admin_user = {{ .Values.grafana.user | quote }}
 
 [auth]
 disable_login_form = {{ .Values.grafana.provisioning.configuration.disable_login_form }}

--- a/config/monitoring/grafana/values.yaml
+++ b/config/monitoring/grafana/values.yaml
@@ -1,6 +1,9 @@
 grafana:
-  user: YWRtaW4= # admin
-  password: bG9vZHNlMTIz # loodse123
+  # Admin login credentials, only relevant if the `disable_login_form` option
+  # further down is set to false. Using an identity aware proxy like
+  # Keycloak-Gatekeeper (see iap chart) is strongly recommended though.
+  user: admin
+  password: '' # generate a strong random password
 
   replicas: 1
   image:


### PR DESCRIPTION
**What this PR does / why we need it**:
Prevent accidentally insecure configurations by removing the default credentials. This gets even more important once Kubermatic is OSS. Unfortunately this requires existing installations to be manually migrated.

**Documentation**:
https://github.com/kubermatic/docs/pull/331

**Does this PR introduce a user-facing change?**:
```release-note
ACTION REQUIRED: Default credentials for Grafana/Minio have been removed. If you never configured credentials, refer to the upgrade notes.
ACTION REQUIRED: Grafana credentials in Helm values are not base64-encoded anymore.
```
