### PR TITLE
do not scrape kube-state-metrics twice

### DIFF
--- a/config/monitoring/prometheus/Chart.yaml
+++ b/config/monitoring/prometheus/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: prometheus
-version: 2.2.17
+version: 2.2.18
 appVersion: v2.17.0
 description: Prometheus Monitoring for Kubernetes
 keywords:

--- a/config/monitoring/prometheus/config/scraping/pods.yaml
+++ b/config/monitoring/prometheus/config/scraping/pods.yaml
@@ -7,6 +7,12 @@ relabel_configs:
   regex: '{{ .Release.Namespace }};node-exporter'
   action: drop
 
+# drop kube-state-metrics, as we have dedicated rules to properly map all the labels
+# to their original pods
+- source_labels: [__meta_kubernetes_namespace, __meta_kubernetes_pod_label_app]
+  regex: '{{ .Release.Namespace }};kube-state-metrics'
+  action: drop
+
 # do not scrape user-cluster namespaces
 - source_labels: [__meta_kubernetes_namespace]
   regex: 'cluster-.*'


### PR DESCRIPTION
**What this PR does / why we need it**:
Since adjusting the scraping annotations, we scraped kubestate-metrics twice. This is a mistake and can make other computed metrics fail because of cardinality issues.

This PR makes it so that we continue to use the explicit scraping rule for KSM and ignore it in the regular pod scraping job.

**Does this PR introduce a user-facing change?**:
```release-note
NONE
```
