### PR TITLE
Update wwhrd to 0.3 and use upstream Docker image instead

### DIFF
--- a/.prow.yaml
+++ b/.prow.yaml
@@ -196,16 +196,17 @@ presubmits:
     clone_uri: "ssh://git@github.com/kubermatic/kubermatic.git"
     spec:
       containers:
-      - image: quay.io/kubermatic/wwhrd:0.2.1-1
+      - image: frapposelli/wwhrd:v0.3.0
         command:
         - make
         args:
         - -C
         - api
         - license-validation
-        env:
-        - name: KUBERMATIC_EDITION
-          value: ee
+      resources:
+        requests:
+          memory: 512Mi
+          cpu: 1
 
   - name: pre-kubermatic-prometheus-rules-validation
     run_if_changed: "config/monitoring"

--- a/allowed_licensed.yaml
+++ b/allowed_licensed.yaml
@@ -6,25 +6,36 @@ blacklist:
 whitelist:
   - Apache-2.0
   - MIT
-  - NewBSD
-  - FreeBSD
+  - BSD-2-Clause
+  - BSD-2-Clause-FreeBSD
+  - BSD-3-Clause
   - ISC
 
 exceptions:
-  - github.com/kr/logfmt  # MIT - No separate license file included.
-  - github.com/go-openapi/inflect  # MIT - Cannot detect the license for some reason.
-  - github.com/opencontainers/go-digest # Apache 2.0 - Cannot detect the license for some reason.
+  - code.cloudfoundry.org/go-pubsub # Apache 2.0 - Cannot detect the license for some reason.
+  - code.cloudfoundry.org/go-pubsub/internal/node # Apache 2.0 - Cannot detect the license for some reason.
   - github.com/cristim/ec2-instances-info # Public domain: https://github.com/cristim/ec2-instances-info/blob/master/LICENSE.
   - github.com/cristim/ec2-instances-info/data # MIT: https://github.com/powdahound/ec2instances.info/blob/master/LICENSE.
-  - github.com/hashicorp/hcl/json/scanner # MPL-2.0 - used in transient vendor projects 
-  - github.com/hashicorp/hcl/hcl/strconv # MPL-2.0 - used in transient vendor projects 
-  - github.com/hashicorp/hcl/hcl/printer # MPL-2.0 - used in transient vendor projects 
-  - github.com/hashicorp/hcl/hcl/ast # MPL-2.0 - used in transient vendor projects 
-  - github.com/hashicorp/hcl/hcl/parser # MPL-2.0 - used in transient vendor projects 
-  - github.com/hashicorp/hcl/json/token # MPL-2.0 - used in transient vendor projects 
-  - github.com/hashicorp/golang-lru # MPL-2.0 - used in transient vendor projects 
-  - github.com/hashicorp/hcl # MPL-2.0 - used in transient vendor projects 
-  - github.com/hashicorp/hcl/hcl/scanner # MPL-2.0 - used in transient vendor projects 
-  - github.com/hashicorp/golang-lru/simplelru # MPL-2.0 - used in transient vendor projects 
-  - github.com/hashicorp/hcl/json/parser # MPL-2.0 - used in transient vendor projects 
-  - github.com/hashicorp/hcl/hcl/token # MPL-2.0 - used in transient vendor projects 
+  - github.com/davecgh/go-spew/spew # ISC - Cannot detect the license for some reason.
+  - github.com/docker/spdystream # Apache 2.0 - Detector picks up on the CC-BY-4.0 license that is only for the documentation.
+  - github.com/docker/spdystream/spdy # Apache 2.0 - Detector picks up on the CC-BY-4.0 license that is only for the documentation.
+  - github.com/ghodss/yaml # BSD-3-Clause and MIT
+  - github.com/go-openapi/inflect # MIT - Cannot detect the license for some reason.
+  - github.com/gogo/protobuf/proto # BSD-3-Clause, as is the entire repository
+  - github.com/gogo/protobuf/sortkeys # BSD-3-Clause, as is the entire repository
+  - github.com/hashicorp/golang-lru # MPL-2.0 - used in transient vendor projects
+  - github.com/hashicorp/golang-lru/simplelru # MPL-2.0 - used in transient vendor projects
+  - github.com/hashicorp/hcl # MPL-2.0 - used in transient vendor projects
+  - github.com/hashicorp/hcl/hcl/ast # MPL-2.0 - used in transient vendor projects
+  - github.com/hashicorp/hcl/hcl/parser # MPL-2.0 - used in transient vendor projects
+  - github.com/hashicorp/hcl/hcl/printer # MPL-2.0 - used in transient vendor projects
+  - github.com/hashicorp/hcl/hcl/scanner # MPL-2.0 - used in transient vendor projects
+  - github.com/hashicorp/hcl/hcl/strconv # MPL-2.0 - used in transient vendor projects
+  - github.com/hashicorp/hcl/hcl/token # MPL-2.0 - used in transient vendor projects
+  - github.com/hashicorp/hcl/json/parser # MPL-2.0 - used in transient vendor projects
+  - github.com/hashicorp/hcl/json/scanner # MPL-2.0 - used in transient vendor projects
+  - github.com/hashicorp/hcl/json/token # MPL-2.0 - used in transient vendor projects
+  - github.com/kr/logfmt # MIT - No separate license file included.
+  - github.com/opencontainers/go-digest # Apache 2.0 - Cannot detect the license for some reason.
+  - github.com/spf13/cobra # Apache 2.0 - Cannot detect the license for some reason.
+  - sigs.k8s.io/yaml # MIT - Cannot detect the license for some reason.

--- a/containers/wwhrd/Dockerfile
+++ b/containers/wwhrd/Dockerfile
@@ -1,6 +1,0 @@
-FROM golang:1.11.1
-
-RUN mkdir tmp
-RUN cd tmp && curl -L --fail https://github.com/frapposelli/wwhrd/releases/download/v0.2.1/wwhrd_0.2.1_linux_amd64.tar.gz | tar -xvz
-RUN mv tmp/wwhrd /usr/local/bin/wwhrd
-RUN rm -rf tmp

--- a/containers/wwhrd/release.sh
+++ b/containers/wwhrd/release.sh
@@ -1,9 +1,0 @@
-#!/usr/bin/env bash
-
-NUMBER=1
-VERSION=0.2.1
-
-set -euox pipefail
-
-docker build --no-cache --pull -t quay.io/kubermatic/wwhrd:${VERSION}-${NUMBER} .
-docker push quay.io/kubermatic/wwhrd:${VERSION}-${NUMBER}


### PR DESCRIPTION
**What this PR does / why we need it**:
Though not mentioned in the changelog for 0.3.0, wwhrd now uses a different license detection library and so the configuration had to be tweaked quite a bit.

**Does this PR introduce a user-facing change?**:
```release-note
NONE
```
