### PR TITLE
Add iptables rule to accept traffic in the nodeports range for the CI cluster

### DIFF
--- a/api/hack/ci/ci-setup-kubermatic-in-kind.sh
+++ b/api/hack/ci/ci-setup-kubermatic-in-kind.sh
@@ -185,6 +185,10 @@ echodate "Cluster exposer is running"
 
 echodate "Setting up iptables rules for to make nodeports available"
 iptables -t nat -A PREROUTING -i eth0 -p tcp -m multiport --dports=30000:33000 -j DNAT --to-destination 172.17.0.2
+# By default all traffic gets dropped unless specified (tested with docker
+# server 18.09.1) 
+iptables -t filter -I DOCKER-USER -d 172.17.0.2/32 ! -i docker0 -o docker0 -p tcp -m multiport --dports=30000:33000 -j ACCEPT
+
 # Docker sets up a MASQUERADE rule for postrouting, so nothing to do for us
 echodate "Successfully set up iptables rules for nodeports"
 


### PR DESCRIPTION

Co-authored-by: irozzo-1A <iacopo@loodse.com>
Co-authored-by: youssefazrak <yazrak.tech@gmail.com>"

**What this PR does / why we need it**:

This PR is to fix the e2e tests after upgrading the CI cluster. In order to expose the nodeport range of the K8S clusters running in Kind we need to add an iptables rule to the Prow job container to accept the packets in the nodeport range. 

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Documentation**:
<!-- Add links to the related documentation changes related to this pull request. E.g. the link to the kubermatic/docs pullrequest. -->

**Does this PR introduce a user-facing change?**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If  no release note is required, just write "NONE".
-->
```release-note
NONE
```
