### PR TITLE
publish kubermatic-operator chart in installer repo

### DIFF
--- a/api/hack/ci/ci-sync-charts.sh
+++ b/api/hack/ci/ci-sync-charts.sh
@@ -56,7 +56,7 @@ git config --global user.name "Prow CI Robot"
 git config --global core.sshCommand 'ssh -o CheckHostIP=no -i /ssh/id_rsa'
 ensure_github_host_pubkey
 
-export CHARTS='kubermatic cert-manager certs nginx-ingress-controller nodeport-proxy oauth minio iap s3-exporter'
+export CHARTS='kubermatic kubermatic-operator cert-manager certs nginx-ingress-controller nodeport-proxy oauth minio iap s3-exporter'
 export MONITORING_CHARTS='alertmanager blackbox-exporter grafana kube-state-metrics node-exporter prometheus'
 export LOGGING_CHARTS='loki promtail elasticsearch kibana fluentbit'
 export BACKUP_CHARTS='velero'


### PR DESCRIPTION
**What this PR does / why we need it**:
Just for completeness, it makes sense to have the operator chart be synced as well. We use and recommend it for new installations already.

**Does this PR introduce a user-facing change?**:
```release-note
NONE
```
