### PR TITLE
add token blacklist for the user

### DIFF
--- a/api/pkg/crd/kubermatic/v1/user.go
+++ b/api/pkg/crd/kubermatic/v1/user.go
@@ -17,6 +17,9 @@ limitations under the License.
 package v1
 
 import (
+	"fmt"
+
+	providerconfig "github.com/kubermatic/machine-controller/pkg/providerconfig/types"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
@@ -42,11 +45,12 @@ type User struct {
 
 // UserSpec specifies a user
 type UserSpec struct {
-	ID       string        `json:"id"`
-	Name     string        `json:"name"`
-	Email    string        `json:"email"`
-	IsAdmin  bool          `json:"admin"`
-	Settings *UserSettings `json:"settings,omitempty"`
+	ID                      string                                  `json:"id"`
+	Name                    string                                  `json:"name"`
+	Email                   string                                  `json:"email"`
+	IsAdmin                 bool                                    `json:"admin"`
+	Settings                *UserSettings                           `json:"settings,omitempty"`
+	TokenBlackListReference *providerconfig.GlobalSecretKeySelector `json:"tokenBlackListReference,omitempty"`
 }
 
 // UserSettings represent an user settings
@@ -74,4 +78,8 @@ type UserList struct {
 type ProjectGroup struct {
 	Name  string `json:"name"`
 	Group string `json:"group"`
+}
+
+func (u *User) GetTokenBlackListSecretName() string {
+	return fmt.Sprintf("token-blacklist-%s", u.Name)
 }

--- a/api/pkg/crd/kubermatic/v1/zz_generated.deepcopy.go
+++ b/api/pkg/crd/kubermatic/v1/zz_generated.deepcopy.go
@@ -2468,6 +2468,11 @@ func (in *UserSpec) DeepCopyInto(out *UserSpec) {
 		*out = new(UserSettings)
 		**out = **in
 	}
+	if in.TokenBlackListReference != nil {
+		in, out := &in.TokenBlackListReference, &out.TokenBlackListReference
+		*out = new(types.GlobalSecretKeySelector)
+		**out = **in
+	}
 	return
 }
 


### PR DESCRIPTION
**What this PR does / why we need it**: token blacklist secret holds the authorization bearer tokens which were invalidated during logout operation. It enforces a new login to get API access

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

```release-note
NONE
```
