### PR TITLE
add pod and node depoyment metrics e2e

### DIFF
--- a/api/cmd/conformance-tests/main.go
+++ b/api/cmd/conformance-tests/main.go
@@ -56,6 +56,7 @@ import (
 	"k8s.io/client-go/kubernetes/scheme"
 	"k8s.io/client-go/rest"
 	"k8s.io/client-go/tools/clientcmd"
+	metricsv1beta1 "k8s.io/metrics/pkg/apis/metrics/v1beta1"
 	ctrlruntimeclient "sigs.k8s.io/controller-runtime/pkg/client"
 )
 
@@ -409,6 +410,10 @@ func main() {
 
 	if err := clusterv1alpha1.SchemeBuilder.AddToScheme(scheme.Scheme); err != nil {
 		log.Fatalw("Failed to add clusterv1alpha1 to scheme", zap.Error(err))
+	}
+
+	if err := metricsv1beta1.SchemeBuilder.AddToScheme(scheme.Scheme); err != nil {
+		log.Fatalw("Failed to add metrics v1beta1 to scheme", zap.Error(err))
 	}
 
 	seedClusterClient, err := ctrlruntimeclient.New(config, ctrlruntimeclient.Options{})

--- a/api/cmd/conformance-tests/runner.go
+++ b/api/cmd/conformance-tests/runner.go
@@ -732,6 +732,16 @@ func (r *testRunner) testCluster(
 		log.Errorf("Failed to verify that prometheus metrics are available: %v", err)
 	}
 
+	// Do pod and node metrics availability test - with retries
+	if err := junitReporterWrapper(
+		"[Kubermatic] Test pod and node metrics availability", report, func() error {
+			return retryNAttempts(maxTestAttempts, func(attempt int) error {
+				return r.testUserClusterPodAndNodeMetrics(log, cluster, userClusterClient)
+			})
+		}); err != nil {
+		log.Errorf("Failed to verify that pod and node metrics are available: %v", err)
+	}
+
 	return nil
 }
 


### PR DESCRIPTION
**What this PR does / why we need it**:
Adds pod and node deployment metrics e2e. It will help us with early identification of metrics-server issues.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #5518 

**Does this PR introduce a user-facing change?**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If  no release note is required, just write "NONE".
-->
```release-note
NONE
```
