### PR TITLE
Fix license validation job

### DIFF
--- a/.prow.yaml
+++ b/.prow.yaml
@@ -210,17 +210,13 @@ presubmits:
     clone_uri: "ssh://git@github.com/kubermatic/kubermatic.git"
     spec:
       containers:
-      - image: frapposelli/wwhrd:v0.3.0
+      - image: quay.io/kubermatic/wwhrd:0.3.0-0
         command:
-        - make
-        args:
-        - -C
-        - api
-        - license-validation
-      resources:
-        requests:
-          memory: 512Mi
-          cpu: 1
+        - ./api/hack/verify-licenses.sh
+        resources:
+          requests:
+            memory: 512Mi
+            cpu: 1
 
   - name: pre-kubermatic-prometheus-rules-validation
     run_if_changed: "config/monitoring"

--- a/api/Makefile
+++ b/api/Makefile
@@ -1,4 +1,4 @@
-# Copyright YEAR The Kubermatic Kubernetes Platform contributors.
+# Copyright 2020 The Kubermatic Kubernetes Platform contributors.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -139,9 +139,6 @@ check-dependencies:
 	dep version || go get -u github.com/golang/dep/cmd/dep
 	dep check
 	git diff --exit-code
-
-license-validation:
-	wwhrd check -f ../allowed_licensed.yaml
 
 gen-api-client:
 	./hack/gen-api-client.sh

--- a/api/hack/verify-licenses.sh
+++ b/api/hack/verify-licenses.sh
@@ -1,0 +1,23 @@
+#!/usr/bin/env sh
+
+# Copyright 2020 The Kubermatic Kubernetes Platform contributors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+set -eu
+
+cd $(dirname $0)/..
+. hack/lib.sh
+
+echodate "Checking licenses..."
+wwhrd check -f ../allowed_licensed.yaml

--- a/containers/wwhrd/Dockerfile
+++ b/containers/wwhrd/Dockerfile
@@ -1,0 +1,25 @@
+# Copyright 2020 The Kubermatic Kubernetes Platform contributors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+FROM alpine:3.12 AS builder
+
+RUN apk update
+RUN apk add curl
+RUN cd tmp && curl -L --fail https://github.com/frapposelli/wwhrd/releases/download/v0.3.0/wwhrd_0.3.0_linux_amd64.tar.gz | tar -xvz
+RUN /tmp/wwhrd -v
+
+FROM alpine:3.12
+
+COPY --from=builder /tmp/wwhrd /usr/local/bin/
+ENTRYPOINT ["wwhrd"]

--- a/containers/wwhrd/release.sh
+++ b/containers/wwhrd/release.sh
@@ -1,0 +1,23 @@
+#!/usr/bin/env bash
+
+# Copyright 2020 The Kubermatic Kubernetes Platform contributors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+NUMBER=0
+VERSION=0.3.0
+
+set -euox pipefail
+
+docker build --no-cache --pull -t quay.io/kubermatic/wwhrd:${VERSION}-${NUMBER} .
+docker push quay.io/kubermatic/wwhrd:${VERSION}-${NUMBER}


### PR DESCRIPTION
**What this PR does / why we need it**:
upstream wwhrd image does not contain make. And without even being able to `cd` into the `api` directory, we would have to hardcode a workingDir for the container, which could interfere with Prow doing its magic to setup the test container.

This PR therefore brings back our own custom wwhrd image, based on Alpine. It's a full 5MB larger than the upstream image, yet is a billion times easier to use. Worth it.

**Does this PR introduce a user-facing change?**:
```release-note
NONE
```
