### PR TITLE
fix typo in prometheus chart

### DIFF
--- a/config/monitoring/prometheus/Chart.yaml
+++ b/config/monitoring/prometheus/Chart.yaml
@@ -14,7 +14,7 @@
 
 apiVersion: v1
 name: prometheus
-version: 2.2.19
+version: 2.2.20
 appVersion: v2.17.0
 description: Prometheus Monitoring for Kubernetes
 keywords:

--- a/config/monitoring/prometheus/templates/thanos-secret.yaml
+++ b/config/monitoring/prometheus/templates/thanos-secret.yaml
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
- if .Values.prometheus.thanos.enabled }}
+{{ if .Values.prometheus.thanos.enabled }}
 apiVersion: v1
 kind: Secret
 metadata:


### PR DESCRIPTION
**What this PR does / why we need it**:
I made a typo when adding the license comment.

**Does this PR introduce a user-facing change?**:
```release-note
NONE
```
