### PR TITLE
build etcd-launcher during e2e tests

### DIFF
--- a/api/hack/lib.sh
+++ b/api/hack/lib.sh
@@ -245,5 +245,5 @@ pushElapsed() {
 }
 
 getEtcdTags() {
-  echo $(git grep -h etcdImageTag pkg/resources/etcd/statefulset.go | grep -v return |cut -d\  -f 3| tr -d "\"" | xargs echo -n)
+  echo $(git grep -h etcdImageTag $(go env GOPATH)/src/github.com/kubermatic/kubermatic/api/pkg/resources/etcd/statefulset.go | grep -v return | cut -d\  -f 3| tr -d "\"" | xargs echo -n)
 }


### PR DESCRIPTION
**What this PR does / why we need it**:
In https://github.com/kubermatic/kubermatic/pull/5536 we introduced a new Docker image, but forgot to build it during e2e tests.

**Does this PR introduce a user-facing change?**:
```release-note
NONE
```
