### PR TITLE
fix lib.sh being incompatible with Alpine's shell by just using bash

### DIFF
--- a/hack/ci/ci-sync-apiclient.sh
+++ b/hack/ci/ci-sync-apiclient.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/usr/bin/env bash
 
 # Copyright 2020 The Kubermatic Kubernetes Platform contributors.
 #
@@ -14,9 +14,10 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-set -eu
+set -euo pipefail
 
-. $(dirname $0)/../lib.sh
+cd $(dirname $0)/../..
+source hack/lib.sh
 
 URL="git@github.com:kubermatic/go-kubermatic.git"
 


### PR DESCRIPTION
**What this PR does / why we need it**:
I moved the worker-name detection into the lib.sh, but

```
worker_name() {
  tr -cd '[:alnum:]' <<< "${KUBERMATIC_WORKERNAME:-$(uname -n)}" | tr '[:upper:]' '[:lower:]'
}
```

is only bash compatible, Alpine's shell complains about the unsupported redirect. To make life easier, this PR simply switches to bash, as we do for all other scripts. The postsubmit jobs have already been updated to provide an image that has bash available (our util image).

**Does this PR introduce a user-facing change?**:
```release-note
NONE
```
