### PR TITLE
Shrink down Docker image size

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-# Copyright YEAR The Kubermatic Kubernetes Platform contributors.
+# Copyright 2020 The Kubermatic Kubernetes Platform contributors.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -12,14 +12,26 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-FROM alpine:3.10
-LABEL maintainer="support@loodse.com"
+FROM alpine:3.12
+LABEL maintainer="support@kubermatic.com"
 
-ADD https://storage.googleapis.com/kubernetes-release/release/v1.17.3/bin/linux/amd64/kubectl /usr/local/bin/kubectl
+ADD https://storage.googleapis.com/kubernetes-release/release/v1.18.5/bin/linux/amd64/kubectl /usr/local/bin/kubectl
+
 # We need the ca-certs so they api doesn't crash because it can't verify the certificate of Dex
 RUN chmod +x /usr/local/bin/kubectl && apk add ca-certificates
 
-COPY ./_build/* /usr/local/bin/
+# Do not needless copy all binaries into the image.
+COPY ./_build/image-loader \
+     ./_build/kubermatic-api \
+     ./_build/kubermatic-operator \
+     ./_build/kubermatic-operator-util \
+     ./_build/master-controller-manager \
+     ./_build/owner-remover \
+     ./_build/seed-controller-manager \
+     ./_build/user-cluster-controller-manager \
+     ./_build/userdata-openshift \
+     /usr/local/bin/
+
 COPY ./cmd/kubermatic-api/swagger.json /opt/swagger.json
 
 USER nobody

--- a/Makefile
+++ b/Makefile
@@ -13,7 +13,7 @@
 # limitations under the License.
 
 export CGO_ENABLED?=0
-KUBERMATIC_EDITION?=ce
+export KUBERMATIC_EDITION?=ce
 REPO=quay.io/kubermatic/kubermatic$(shell [ "$(KUBERMATIC_EDITION)" != "ce" ] && echo "-$(KUBERMATIC_EDITION)" )
 CMD=$(filter-out OWNERS nodeport-proxy kubeletdnat-controller, $(notdir $(wildcard ./cmd/*)))
 GOBUILDFLAGS?=-v


### PR DESCRIPTION
**What this PR does / why we need it**:
We should not publish helper tools in our official Docker images. It makes them seem to be officially supported tools. Likewise, removing a few binaries from the Docker image shrunk it down from 850 to 600 MiB on my machine. Quite a bit!

The change to the Makefile snuck in because just typing `make` breaks as the `ci-lint.sh` cannot handle the variable not being defined. Exporting it from the Makefile is the easiest workaorund.

**Does this PR introduce a user-facing change?**:
```release-note
Docker image size was reduced by removing development binaries.
```
