### PR TITLE
added user watch endpoint

### DIFF
--- a/cmd/kubermatic-api/options.go
+++ b/cmd/kubermatic-api/options.go
@@ -198,4 +198,5 @@ type providers struct {
 	presetProvider                        provider.PresetProvider
 	admissionPluginProvider               provider.AdmissionPluginsProvider
 	settingsWatcher                       watcher.SettingsWatcher
+	userWatcher                           watcher.UserWatcher
 }

--- a/pkg/handler/routing.go
+++ b/pkg/handler/routing.go
@@ -72,6 +72,7 @@ type Routing struct {
 	adminProvider                         provider.AdminProvider
 	admissionPluginProvider               provider.AdmissionPluginsProvider
 	settingsWatcher                       watcher.SettingsWatcher
+	userWatcher                           watcher.UserWatcher
 }
 
 // NewRouting creates a new Routing.
@@ -110,6 +111,7 @@ func NewRouting(
 	adminProvider provider.AdminProvider,
 	admissionPluginProvider provider.AdmissionPluginsProvider,
 	settingsWatcher watcher.SettingsWatcher,
+	userWatcher watcher.UserWatcher,
 ) Routing {
 	return Routing{
 		log:                                   logger,
@@ -147,6 +149,7 @@ func NewRouting(
 		adminProvider:                         adminProvider,
 		admissionPluginProvider:               admissionPluginProvider,
 		settingsWatcher:                       settingsWatcher,
+		userWatcher:                           userWatcher,
 	}
 }
 

--- a/pkg/handler/test/hack/hack.go
+++ b/pkg/handler/test/hack/hack.go
@@ -71,7 +71,8 @@ func NewTestRouting(
 	eventRecorderProvider provider.EventRecorderProvider,
 	presetsProvider provider.PresetProvider,
 	admissionPluginProvider provider.AdmissionPluginsProvider,
-	settingsWatcher watcher.SettingsWatcher) http.Handler {
+	settingsWatcher watcher.SettingsWatcher,
+	userWatcher watcher.UserWatcher) http.Handler {
 
 	updateManager := version.New(versions, updates)
 	r := handler.NewRouting(
@@ -109,6 +110,7 @@ func NewTestRouting(
 		adminProvider,
 		admissionPluginProvider,
 		settingsWatcher,
+		userWatcher,
 	)
 
 	mainRouter := mux.NewRouter()
@@ -121,6 +123,7 @@ func NewTestRouting(
 		mainRouter,
 	)
 	r.RegisterV1Admin(v1Router)
+	r.RegisterV1Websocket(v1Router)
 	return mainRouter
 }
 

--- a/pkg/handler/test/helper.go
+++ b/pkg/handler/test/helper.go
@@ -162,7 +162,8 @@ type newRoutingFunc func(
 	eventRecorderProvider provider.EventRecorderProvider,
 	presetsProvider provider.PresetProvider,
 	admissionPluginProvider provider.AdmissionPluginsProvider,
-	settingsWatcher watcher.SettingsWatcher) http.Handler
+	settingsWatcher watcher.SettingsWatcher,
+	userWatcher watcher.UserWatcher) http.Handler
 
 func initTestEndpoint(user apiv1.User, seedsGetter provider.SeedsGetter, kubeObjects, machineObjects, kubermaticObjects []runtime.Object, versions []*version.Version, updates []*version.Update, routingFunc newRoutingFunc) (http.Handler, *ClientsSets, error) {
 	if seedsGetter == nil {
@@ -183,7 +184,7 @@ func initTestEndpoint(user apiv1.User, seedsGetter provider.SeedsGetter, kubeObj
 	if err != nil {
 		return nil, nil, err
 	}
-	userProvider := kubernetes.NewUserProvider(fakeClient, kubernetes.IsServiceAccount)
+	userProvider := kubernetes.NewUserProvider(fakeClient, kubernetes.IsServiceAccount, kubermaticClient)
 	adminProvider := kubernetes.NewAdminProvider(fakeClient)
 	settingsProvider := kubernetes.NewSettingsProvider(kubermaticClient, fakeClient)
 	addonConfigProvider := kubernetes.NewAddonConfigProvider(fakeClient)
@@ -287,6 +288,11 @@ func initTestEndpoint(user apiv1.User, seedsGetter provider.SeedsGetter, kubeObj
 		return nil, nil, err
 	}
 
+	userWatcher, err := kuberneteswatcher.NewUserWatcher(userProvider)
+	if err != nil {
+		return nil, nil, err
+	}
+
 	// Disable the metrics endpoint in tests
 	var prometheusClient prometheusapi.Client
 
@@ -323,6 +329,7 @@ func initTestEndpoint(user apiv1.User, seedsGetter provider.SeedsGetter, kubeObj
 		credentialsManager,
 		admissionPluginProvider,
 		settingsWatcher,
+		userWatcher,
 	)
 
 	return mainRouter, &ClientsSets{kubermaticClient, fakeClient, kubernetesClient, tokenAuth, tokenGenerator}, nil

--- a/pkg/handler/v1/project/project_test.go
+++ b/pkg/handler/v1/project/project_test.go
@@ -29,6 +29,7 @@ import (
 	apiv1 "github.com/kubermatic/kubermatic/pkg/api/v1"
 	k8cuserclusterclient "github.com/kubermatic/kubermatic/pkg/cluster/client"
 	"github.com/kubermatic/kubermatic/pkg/controller/master-controller-manager/rbac"
+	kubermaticfakeclentset "github.com/kubermatic/kubermatic/pkg/crd/client/clientset/versioned/fake"
 	kubermaticapiv1 "github.com/kubermatic/kubermatic/pkg/crd/kubermatic/v1"
 	"github.com/kubermatic/kubermatic/pkg/handler/middleware"
 	"github.com/kubermatic/kubermatic/pkg/handler/test"
@@ -465,13 +466,13 @@ func TestListProjectMethod(t *testing.T) {
 
 	for _, tc := range testcases {
 		t.Run(tc.Name, func(t *testing.T) {
-
+			kubermaticClient := kubermaticfakeclentset.NewSimpleClientset()
 			fakeClient := fakectrlruntimeclient.NewFakeClientWithScheme(scheme.Scheme, tc.ExistingKubermaticObjects...)
 			fakeImpersonationClient := func(impCfg restclient.ImpersonationConfig) (ctrlruntimeclient.Client, error) {
 				return fakeClient, nil
 			}
 			projectMemberProvider := kubernetes.NewProjectMemberProvider(fakeImpersonationClient, fakeClient, kubernetes.IsServiceAccount)
-			userProvider := kubernetes.NewUserProvider(fakeClient, kubernetes.IsServiceAccount)
+			userProvider := kubernetes.NewUserProvider(fakeClient, kubernetes.IsServiceAccount, kubermaticClient)
 
 			userInfoGetter, err := provider.UserInfoGetterFactory(projectMemberProvider)
 			if err != nil {

--- a/pkg/handler/websocket/user.go
+++ b/pkg/handler/websocket/user.go
@@ -1,0 +1,83 @@
+/*
+Copyright 2020 The Kubermatic Kubernetes Platform contributors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package websocket
+
+import (
+	"encoding/json"
+
+	v1 "github.com/kubermatic/kubermatic/pkg/crd/kubermatic/v1"
+	"github.com/kubermatic/kubermatic/pkg/log"
+	"github.com/kubermatic/kubermatic/pkg/watcher"
+
+	"code.cloudfoundry.org/go-pubsub"
+	"github.com/gorilla/websocket"
+)
+
+func WriteUser(providers watcher.Providers, ws *websocket.Conn, userEmail string) {
+	initialUser, err := providers.UserProvider.UserByEmail(userEmail)
+	if err != nil {
+		log.Logger.Debug(err)
+		return
+	}
+
+	initialResponse, err := json.Marshal(initialUser)
+	if err != nil {
+		log.Logger.Debug(err)
+		return
+	}
+
+	if err := ws.WriteMessage(websocket.TextMessage, initialResponse); err != nil {
+		log.Logger.Debug(err)
+		return
+	}
+
+	hashID, err := providers.UserWatcher.CalculateHash(userEmail)
+	if err != nil {
+		log.Logger.Debug(err)
+		return
+	}
+
+	providers.UserWatcher.Subscribe(func(rawUser interface{}) {
+		var response []byte
+		if rawUser != nil {
+			user, ok := rawUser.(*v1.User)
+			if !ok {
+				log.Logger.Warn("cannot convert user for user watch: %v", rawUser)
+				return
+			}
+
+			response, err = json.Marshal(user)
+			if err != nil {
+				log.Logger.Debug(err)
+				return
+			}
+		} else {
+			// Explicitly set null response instead returning defaulted user structure.
+			// It allows clients to distinct null response and default or empty user.
+			response, err = json.Marshal(nil)
+			if err != nil {
+				log.Logger.Debug(err)
+				return
+			}
+		}
+
+		if err := ws.WriteMessage(websocket.TextMessage, response); err != nil {
+			log.Logger.Debug(err)
+			return
+		}
+	}, pubsub.WithPath([]uint64{hashID}))
+}

--- a/pkg/handler/websocket/user_test.go
+++ b/pkg/handler/websocket/user_test.go
@@ -1,0 +1,181 @@
+/*
+Copyright 2020 The Kubermatic Kubernetes Platform contributors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package websocket_test
+
+import (
+	"encoding/json"
+	"fmt"
+	"net/http/httptest"
+	"reflect"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/gorilla/websocket"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+
+	apiv1 "github.com/kubermatic/kubermatic/pkg/api/v1"
+	v1 "github.com/kubermatic/kubermatic/pkg/crd/kubermatic/v1"
+	"github.com/kubermatic/kubermatic/pkg/handler/test"
+	"github.com/kubermatic/kubermatic/pkg/handler/test/hack"
+)
+
+func TestUserWatchEndpoint(t *testing.T) {
+	t.Parallel()
+	testcases := []struct {
+		name                string
+		userToUpdate        string
+		userSettingsUpdate  *v1.UserSettings
+		userUpdate          *apiv1.User
+		existingAPIUser     *apiv1.User
+		existingUsers       []*apiv1.User
+		updateShouldTimeout bool
+	}{
+		{
+			name:         "should be able to watch and notice user setting change on its own user",
+			userToUpdate: test.GenDefaultAPIUser().Name,
+			userSettingsUpdate: &v1.UserSettings{
+				CollapseSidenav: true,
+			},
+			existingAPIUser:     test.GenDefaultAPIUser(),
+			existingUsers:       []*apiv1.User{test.GenDefaultAPIUser(), test.GenAPIUser("john", "john@acme.com")},
+			updateShouldTimeout: false,
+		},
+		{
+			name:         "should be able to watch and but not notice the user setting change on a different user",
+			userToUpdate: test.GenAPIUser("john", "john@acme.com").Name,
+			userSettingsUpdate: &v1.UserSettings{
+				CollapseSidenav: true,
+			},
+			existingAPIUser:     test.GenDefaultAPIUser(),
+			existingUsers:       []*apiv1.User{test.GenDefaultAPIUser(), test.GenAPIUser("john", "john@acme.com")},
+			updateShouldTimeout: true,
+		},
+	}
+	for _, tc := range testcases {
+		t.Run(tc.name, func(t *testing.T) {
+			var runtimeObjectUsers []runtime.Object
+			for _, user := range tc.existingUsers {
+				runtimeObjectUsers = append(runtimeObjectUsers, test.APIUserToKubermaticUser(*user))
+			}
+
+			ep, cli, err := test.CreateTestEndpointAndGetClients(*tc.existingAPIUser, nil, []runtime.Object{}, nil,
+				runtimeObjectUsers, nil, nil, hack.NewTestRouting)
+			if err != nil {
+				t.Fatalf("failed to create test endpoint due to %v", err)
+			}
+			server := httptest.NewServer(ep)
+			defer server.Close()
+
+			// setup ws client
+			wsURL := "ws" + strings.TrimPrefix(server.URL, "http") + "/api/v1/ws/me"
+			ch, err := createWSClient(wsURL)
+			if err != nil {
+				t.Fatalf("failed to initialize websocket client: %v", err)
+			}
+
+			var wsMsg wsMessage
+			select {
+			case <-time.After(time.Second * 2):
+				t.Fatalf("timeout waiting for ws message")
+			case wsMsg = <-ch:
+			}
+			if wsMsg.err != nil {
+				t.Fatalf("error reading ws message: %v", err)
+			}
+
+			var user *v1.User
+			err = json.Unmarshal(wsMsg.p, &user)
+			if err != nil {
+				t.Fatalf("failed unmarshalling user: %v", err)
+			}
+			if user.Name != tc.existingAPIUser.Name {
+				t.Fatalf("got wrong initial user from watch, expected: %s, got %s", tc.existingAPIUser.Name, user.Name)
+			}
+
+			// Update user to get watch notification
+			userToUpdate, err := cli.FakeKubermaticClient.KubermaticV1().Users().Get(tc.userToUpdate, metav1.GetOptions{})
+			if err != nil {
+				t.Fatalf("error getting user to update: %v", err)
+			}
+			userToUpdate.Spec.Settings = tc.userSettingsUpdate
+
+			_, err = cli.FakeKubermaticClient.KubermaticV1().Users().Update(userToUpdate)
+			if err != nil {
+				t.Fatalf("error updating user: %v", err)
+			}
+
+			// get the update notification
+			select {
+			case <-time.After(time.Second * 2):
+				if !tc.updateShouldTimeout {
+					t.Fatal("Watch update notification didnt arrive in time")
+				}
+			case wsMsg = <-ch:
+			}
+			if wsMsg.err != nil {
+				t.Fatalf("error reading ws message: %v", err)
+			}
+
+			if !tc.updateShouldTimeout {
+				var userUpdate *v1.User
+				err = json.Unmarshal(wsMsg.p, &userUpdate)
+				if err != nil {
+					t.Fatalf("failed unmarshalling user: %v", err)
+				}
+
+				if !reflect.DeepEqual(userUpdate.Spec.Settings, tc.userSettingsUpdate) {
+					t.Fatalf("expected settings %v, got %v", tc.userSettingsUpdate, userUpdate.Spec.Settings)
+				}
+			}
+		})
+	}
+}
+
+type wsMessage struct {
+	messageType int
+	p           []byte
+	err         error
+}
+
+func createWSClient(url string) (chan wsMessage, error) {
+	ws, _, err := websocket.DefaultDialer.Dial(url, nil)
+	if err != nil {
+		return nil, fmt.Errorf("failed to initialize websocket dialer: %v", err)
+	}
+
+	ch := make(chan wsMessage, 5)
+
+	go func() {
+		for {
+			t, p, err := ws.ReadMessage()
+			ch <- wsMessage{
+				messageType: t,
+				p:           p,
+				err:         err,
+			}
+			if err != nil {
+				close(ch)
+				ws.Close()
+				break
+			}
+		}
+	}()
+
+	return ch, nil
+}

--- a/pkg/handler/websocket/user_test.go
+++ b/pkg/handler/websocket/user_test.go
@@ -91,7 +91,7 @@ func TestUserWatchEndpoint(t *testing.T) {
 
 			var wsMsg wsMessage
 			select {
-			case <-time.After(time.Second * 2):
+			case <-time.After(time.Second * 5):
 				t.Fatalf("timeout waiting for ws message")
 			case wsMsg = <-ch:
 			}
@@ -122,7 +122,7 @@ func TestUserWatchEndpoint(t *testing.T) {
 
 			// get the update notification
 			select {
-			case <-time.After(time.Second * 2):
+			case <-time.After(time.Second * 5):
 				if !tc.updateShouldTimeout {
 					t.Fatal("Watch update notification didnt arrive in time")
 				}

--- a/pkg/provider/kubernetes/user_test.go
+++ b/pkg/provider/kubernetes/user_test.go
@@ -24,6 +24,7 @@ import (
 	"github.com/stretchr/testify/assert"
 
 	apiv1 "github.com/kubermatic/kubermatic/pkg/api/v1"
+	kubermaticfakeclentset "github.com/kubermatic/kubermatic/pkg/crd/client/clientset/versioned/fake"
 	kubermaticapiv1 "github.com/kubermatic/kubermatic/pkg/crd/kubermatic/v1"
 	"github.com/kubermatic/kubermatic/pkg/handler/test"
 	"github.com/kubermatic/kubermatic/pkg/provider/kubernetes"
@@ -120,9 +121,10 @@ func TestAddUserTokenToBlacklist(t *testing.T) {
 			existingObj := []runtime.Object{}
 			existingObj = append(existingObj, tc.existingObjs...)
 			fakeClient := fakectrlruntimeclient.NewFakeClientWithScheme(scheme.Scheme, existingObj...)
+			kubermaticClient := kubermaticfakeclentset.NewSimpleClientset()
 
 			// act
-			target := kubernetes.NewUserProvider(fakeClient, nil)
+			target := kubernetes.NewUserProvider(fakeClient, nil, kubermaticClient)
 			if err := target.AddUserTokenToBlacklist(tc.existingUser, tc.token, tc.expiry); err != nil {
 				t.Fatal(err)
 			}

--- a/pkg/provider/types.go
+++ b/pkg/provider/types.go
@@ -283,6 +283,7 @@ type UserProvider interface {
 	UserByID(id string) (*kubermaticv1.User, error)
 	AddUserTokenToBlacklist(user *kubermaticv1.User, token string, expiry apiv1.Time) error
 	GetUserBlacklistTokens(user *kubermaticv1.User) ([]string, error)
+	WatchUser() (watch.Interface, error)
 }
 
 // PrivilegedProjectProvider declares the set of method for interacting with kubermatic's project and uses privileged account for it

--- a/pkg/watcher/kubernetes/user.go
+++ b/pkg/watcher/kubernetes/user.go
@@ -1,0 +1,106 @@
+/*
+Copyright 2020 The Kubermatic Kubernetes Platform contributors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package kubernetes
+
+import (
+	"hash/fnv"
+	"reflect"
+
+	"code.cloudfoundry.org/go-pubsub"
+	"k8s.io/apimachinery/pkg/watch"
+
+	v1 "github.com/kubermatic/kubermatic/pkg/crd/kubermatic/v1"
+	"github.com/kubermatic/kubermatic/pkg/log"
+	"github.com/kubermatic/kubermatic/pkg/provider"
+)
+
+// UserWatcher watches user and notifies its subscribers about any changes.
+type UserWatcher struct {
+	provider  provider.UserProvider
+	watcher   watch.Interface
+	publisher *pubsub.PubSub
+}
+
+// UserWatcher returns a new resource watcher.
+func NewUserWatcher(provider provider.UserProvider) (*UserWatcher, error) {
+	watcher, err := provider.WatchUser()
+	if err != nil {
+		return nil, err
+	}
+
+	w := &UserWatcher{
+		provider:  provider,
+		watcher:   watcher,
+		publisher: pubsub.New(),
+	}
+
+	go w.run()
+	return w, nil
+}
+
+// run and publish information about user updates. Watch will restart itself if any error occurs.
+func (watcher *UserWatcher) run() {
+	defer func() {
+		log.Logger.Debug("restarting user watcher")
+		watcher.watcher.Stop()
+		watcher.watcher = nil
+		watcher.run()
+	}()
+
+	if watcher.watcher == nil {
+		var err error
+		if watcher.watcher, err = watcher.provider.WatchUser(); err != nil {
+			log.Logger.Debug("could not recreate user watcher")
+			return
+		}
+	}
+
+	for event := range watcher.watcher.ResultChan() {
+		user, ok := event.Object.(*v1.User)
+		if !ok {
+			log.Logger.Debugf("expected user got %s", reflect.TypeOf(event.Object))
+		}
+
+		if user != nil {
+			idHash, err := watcher.CalculateHash(user.Spec.Email)
+			if err != nil {
+				log.Logger.Warnf("Error calculating user hash for user watch pubsub: %v", err)
+				continue
+			}
+
+			if event.Type == watch.Added || event.Type == watch.Modified {
+				watcher.publisher.Publish(user, pubsub.LinearTreeTraverser([]uint64{idHash}))
+			} else if event.Type == watch.Deleted {
+				watcher.publisher.Publish(nil, pubsub.LinearTreeTraverser([]uint64{idHash}))
+			}
+		}
+	}
+}
+
+func (watcher *UserWatcher) CalculateHash(id string) (uint64, error) {
+	h := fnv.New64()
+	_, err := h.Write([]byte(id))
+	if err != nil {
+		return 0, err
+	}
+	return h.Sum64(), err
+}
+
+// Subscribe allows to register subscription handler which will be invoked on each user change.
+func (watcher *UserWatcher) Subscribe(subscription pubsub.Subscription, opts ...pubsub.SubscribeOption) {
+	watcher.publisher.Subscribe(subscription, opts...)
+}

--- a/pkg/watcher/kubernetes/user_test.go
+++ b/pkg/watcher/kubernetes/user_test.go
@@ -1,0 +1,69 @@
+/*
+Copyright 2020 The Kubermatic Kubernetes Platform contributors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package kubernetes
+
+import (
+	"testing"
+
+	kubermaticfakeclentset "github.com/kubermatic/kubermatic/pkg/crd/client/clientset/versioned/fake"
+	"github.com/kubermatic/kubermatic/pkg/provider/kubernetes"
+
+	"code.cloudfoundry.org/go-pubsub"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/client-go/kubernetes/scheme"
+	fakectrlruntimeclient "sigs.k8s.io/controller-runtime/pkg/client/fake"
+)
+
+func TestNewUserWatcher(t *testing.T) {
+	kubermaticClient := kubermaticfakeclentset.NewSimpleClientset()
+	runtimeClient := fakectrlruntimeclient.NewFakeClientWithScheme(scheme.Scheme, []runtime.Object{}...)
+	userProvider := kubernetes.NewUserProvider(runtimeClient, nil, kubermaticClient)
+	userWatcher, err := NewUserWatcher(userProvider)
+	if err != nil {
+		t.Fatal("cannot create user watcher")
+	}
+
+	counter := 0
+	userWatcher.Subscribe(func(d interface{}) {
+		counter++
+	}, pubsub.WithPath([]uint64{'a'}))
+
+	if counter != 0 {
+		t.Fatal("counter should be set to 0 before any data is published")
+	}
+
+	userWatcher.publisher.Publish("test-data", pubsub.LinearTreeTraverser([]uint64{'a'}))
+
+	if counter != 1 {
+		t.Fatal("counter should be set to 1 after the data is published")
+	}
+
+	var data interface{}
+	userWatcher.Subscribe(func(d interface{}) {
+		data = d
+	}, pubsub.WithPath([]uint64{'b'}))
+
+	userWatcher.publisher.Publish("test-data-1", pubsub.LinearTreeTraverser([]uint64{'b'}))
+
+	if data != "test-data-1" {
+		t.Fatal("data should be correctly read in the subscription")
+	}
+
+	if counter != 1 {
+		t.Fatal("counter should be set to 1 after the data is published to `b` subscriber")
+	}
+}

--- a/pkg/watcher/types.go
+++ b/pkg/watcher/types.go
@@ -25,8 +25,15 @@ import (
 type Providers struct {
 	SettingsProvider provider.SettingsProvider
 	SettingsWatcher  SettingsWatcher
+	UserProvider     provider.UserProvider
+	UserWatcher      UserWatcher
 }
 
 type SettingsWatcher interface {
 	Subscribe(subscription pubsub.Subscription)
+}
+
+type UserWatcher interface {
+	Subscribe(subscription pubsub.Subscription, opts ...pubsub.SubscribeOption)
+	CalculateHash(id string) (uint64, error)
 }


### PR DESCRIPTION
**What this PR does / why we need it**:
adds a user watch websocket endpoint. Primarily it will be used by the UI to catch the user settings changes and apply them. 

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #5564 


**Does this PR introduce a user-facing change?**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If  no release note is required, just write "NONE".
-->
```release-note
added a websocket user self-watch endpoint 
```
