### PR TITLE
fix s3 secrect location

### DIFF
--- a/charts/minio/Chart.yaml
+++ b/charts/minio/Chart.yaml
@@ -14,7 +14,7 @@
 
 apiVersion: v1
 name: minio
-version: 1.0.15
+version: 1.0.16
 appVersion: RELEASE.2020-06-03T22-13-49Z
 description: minio
 keywords:

--- a/charts/minio/templates/secret-kube-system.yaml
+++ b/charts/minio/templates/secret-kube-system.yaml
@@ -16,7 +16,7 @@ apiVersion: v1
 kind: Secret
 metadata:
   name: s3-credentials
-  namespace: kube-system
+  namespace: {{ .Values.s3Exporter.namespace}}
 type: Opaque
 data:
   ACCESS_KEY_ID: "{{ .Values.minio.credentials.accessKey | b64enc }}"

--- a/charts/minio/values.yaml
+++ b/charts/minio/values.yaml
@@ -62,3 +62,7 @@ minio:
   nodeSelector: {}
   affinity: {}
   tolerations: []
+
+s3Exporter:
+  # namespace to store the secret for s3-exporter chart
+  namespace: s3-exporter

--- a/charts/s3-exporter/Chart.yaml
+++ b/charts/s3-exporter/Chart.yaml
@@ -14,7 +14,7 @@
 
 apiVersion: v1
 name: s3-exporter
-version: 1.1.3
+version: 1.1.4
 appVersion: v0.4
 keywords:
 - kubermatic

--- a/charts/s3-exporter/templates/clusterrole.yaml
+++ b/charts/s3-exporter/templates/clusterrole.yaml
@@ -16,6 +16,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
   name: {{ .Release.Namespace }}:s3exporter:clusters:reader
+  namespace: {{ .Values.s3Exporter.namespace}}
 rules:
 - apiGroups:
   - kubermatic.k8s.io

--- a/charts/s3-exporter/templates/clusterrolebinding.yaml
+++ b/charts/s3-exporter/templates/clusterrolebinding.yaml
@@ -16,6 +16,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
   name: {{ .Release.Namespace }}:s3exporter:clusters:reader
+  namespace: {{ .Values.s3Exporter.namespace}}
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole

--- a/charts/s3-exporter/templates/deployment.yaml
+++ b/charts/s3-exporter/templates/deployment.yaml
@@ -16,7 +16,7 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: s3-exporter
-  namespace: {{ .Release.Namespace }}
+  namespace: {{ .Values.s3Exporter.namespace}}
 spec:
   replicas: 2
   selector:

--- a/charts/s3-exporter/templates/serviceaccount.yaml
+++ b/charts/s3-exporter/templates/serviceaccount.yaml
@@ -16,4 +16,4 @@ apiVersion: v1
 kind: ServiceAccount
 metadata:
   name: s3-exporter
-  namespace: {{ .Release.Namespace }}
+  namespace: {{ .Values.s3Exporter.namespace}}

--- a/charts/s3-exporter/values.yaml
+++ b/charts/s3-exporter/values.yaml
@@ -13,6 +13,7 @@
 # limitations under the License.
 
 s3Exporter:
+  namespace: s3-exporter
   image:
     repository: quay.io/kubermatic/s3-exporter
     tag: v0.4


### PR DESCRIPTION
**What this PR does / why we need it**:

To ensure that the secrect of the minio S3 location is stored into the namespace of the `s3-exporter` chart the namespace have been defined as helm value. According to https://github.com/kubermatic/docs/blob/master/content/kubermatic/master/installation/add_seed_cluster/_index.en.md#2-install-kubermatic-dependencies the target namespace is `s3-exporter` what have defined as default.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Documentation**:
<!-- Add links to the related documentation changes related to this pull request. E.g. the link to the kubermatic/docs pullrequest. -->
**Does this PR introduce a user-facing change?**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If  no release note is required, just write "NONE".
-->
```release-note
NONE
```