### PR TITLE
Fix label for nodeport-proxy when deployed with the operator

### DIFF
--- a/pkg/controller/operator/seed/resources/nodeportproxy/service.go
+++ b/pkg/controller/operator/seed/resources/nodeportproxy/service.go
@@ -40,7 +40,7 @@ func ServiceCreator() reconciling.NamedServiceCreatorGetter {
 
 			s.Spec.Type = corev1.ServiceTypeLoadBalancer
 			s.Spec.Selector = map[string]string{
-				common.NameLabel: ServiceName,
+				common.NameLabel: EnvoyDeploymentName,
 			}
 
 			// Services need at least one port to be valid, so create it initially.


### PR DESCRIPTION
**What this PR does / why we need it**:
When installing Kubermatic with the operator, the nodeport-proxy is deployed with Label Selectors. 
Currently, both the deployment and the svc have different labels, leading to the non-creation of endpoints. In short, communications between the userclusters and the control planes are not possible.

**Documentation PR**
https://github.com/kubermatic/docs/pull/359

**Does this PR introduce a user-facing change?**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string “action required”.
2. If  no release note is required, just write “NONE”.
-->
```release-note
NONE
```