### PR TITLE
Remove empty Docker secret for Kubermatic Operator CE Helm chart

### DIFF
--- a/charts/kubermatic-operator/Chart.yaml
+++ b/charts/kubermatic-operator/Chart.yaml
@@ -14,7 +14,7 @@
 
 apiVersion: v1
 name: kubermatic-operator
-version: 0.2.3
+version: 0.2.4
 appVersion: '__KUBERMATIC_TAG__'
 description: Helm chart to install the Kubermatic Operator
 keywords:

--- a/charts/kubermatic-operator/templates/dockercfg.yaml
+++ b/charts/kubermatic-operator/templates/dockercfg.yaml
@@ -12,6 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+{{- if .Values.kubermaticOperator.imagePullSecret }}
 apiVersion: v1
 kind: Secret
 metadata:
@@ -21,3 +22,4 @@ metadata:
 type: kubernetes.io/dockerconfigjson
 data:
   .dockerconfigjson: {{ .Values.kubermaticOperator.imagePullSecret | b64enc | quote }}
+{{- end }}


### PR DESCRIPTION
**What this PR does / why we need it**:
Currently when installing Kubermatic Operator CE Helm chart, it is needed to have a Docker secret.
This quick fix introduce a condition: if the Docker secret is not specified in the value file then the `dockercfg.yaml` doesn't get created.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #5600 

**Does this PR introduce a user-facing change?**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If  no release note is required, just write "NONE".
-->
```release-note
NONE
```
