### PR TITLE
backport nodeport-proxy fix to v2.14

### DIFF
--- a/api/pkg/controller/operator/seed/resources/nodeportproxy/service.go
+++ b/api/pkg/controller/operator/seed/resources/nodeportproxy/service.go
@@ -40,7 +40,7 @@ func ServiceCreator() reconciling.NamedServiceCreatorGetter {
 
 			s.Spec.Type = corev1.ServiceTypeLoadBalancer
 			s.Spec.Selector = map[string]string{
-				common.NameLabel: ServiceName,
+				common.NameLabel: EnvoyDeploymentName,
 			}
 
 			// Services need at least one port to be valid, so create it initially.


### PR DESCRIPTION
**What this PR does / why we need it**:
Backport https://github.com/kubermatic/kubermatic/pull/5609 to v2.14

**Does this PR introduce a user-facing change?**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If  no release note is required, just write "NONE".
-->
```release-note
NONE
```
