### PR TITLE
restrict project creation

### DIFF
--- a/pkg/handler/v1/project/project.go
+++ b/pkg/handler/v1/project/project.go
@@ -85,7 +85,7 @@ func checkProjectRestriction(user *kubermaticapiv1.User, settings *kubermaticapi
 		return nil
 	}
 	if settings.Spec.RestrictProjectCreation {
-		return errors.New(http.StatusForbidden, "project creation restricted")
+		return errors.New(http.StatusForbidden, "project creation is restricted")
 	}
 	return nil
 }

--- a/pkg/handler/v1/project/project_test.go
+++ b/pkg/handler/v1/project/project_test.go
@@ -703,6 +703,46 @@ func TestCreateProjectEndpoint(t *testing.T) {
 			},
 			ExistingAPIUser: test.GenDefaultAPIUser(),
 		},
+
+		{
+			Name:             "scenario 5: project creation is restricted for the users",
+			Body:             fmt.Sprintf(`{"name":"%s"}`, test.GenDefaultProject().Spec.Name),
+			RewriteProjectID: false,
+			ExpectedResponse: `{"error":{"code":403,"message":"project creation restricted"}}`,
+			HTTPStatus:       http.StatusForbidden,
+			ExistingKubermaticObjects: test.GenDefaultKubermaticObjects(
+				func() *kubermaticapiv1.KubermaticSetting {
+					settings := test.GenDefaultSettings()
+					settings.Spec.RestrictProjectCreation = true
+					return settings
+				}(),
+			),
+			ExistingAPIUser: test.GenDefaultAPIUser(),
+		},
+		{
+			Name:             "scenario 6: project creation is not restricted for the admin",
+			Body:             fmt.Sprintf(`{"name":"%s"}`, test.GenDefaultProject().Spec.Name),
+			RewriteProjectID: true,
+			ExpectedResponse: `{"id":"%s","name":"my-first-project","creationTimestamp":"0001-01-01T00:00:00Z","status":"Inactive","owners":[{"name":"Bob","creationTimestamp":"0001-01-01T00:00:00Z","email":"bob@acme.com"}]}`,
+			HTTPStatus:       http.StatusCreated,
+			ExistingKubermaticObjects: []runtime.Object{
+				// add some projects
+				test.GenProject("my-first-project", kubermaticapiv1.ProjectActive, test.DefaultCreationTimestamp()),
+				test.GenProject("my-third-project", kubermaticapiv1.ProjectActive, test.DefaultCreationTimestamp().Add(2*time.Minute)),
+				// add John
+				test.GenUser("JohnID", "John", "john@acme.com"),
+				genUser("Bob", "bob@acme.com", true),
+				// make John the owner of the first project and the editor of the second
+				test.GenBinding("my-first-project-ID", "john@acme.com", "owners"),
+				test.GenBinding("my-third-project-ID", "bob@acme.com", "owners"),
+				func() *kubermaticapiv1.KubermaticSetting {
+					settings := test.GenDefaultSettings()
+					settings.Spec.RestrictProjectCreation = true
+					return settings
+				}(),
+			},
+			ExistingAPIUser: test.GenDefaultAPIUser(),
+		},
 	}
 
 	for _, tc := range testcases {

--- a/pkg/handler/v1/project/project_test.go
+++ b/pkg/handler/v1/project/project_test.go
@@ -708,7 +708,7 @@ func TestCreateProjectEndpoint(t *testing.T) {
 			Name:             "scenario 5: project creation is restricted for the users",
 			Body:             fmt.Sprintf(`{"name":"%s"}`, test.GenDefaultProject().Spec.Name),
 			RewriteProjectID: false,
-			ExpectedResponse: `{"error":{"code":403,"message":"project creation restricted"}}`,
+			ExpectedResponse: `{"error":{"code":403,"message":"project creation is restricted"}}`,
 			HTTPStatus:       http.StatusForbidden,
 			ExistingKubermaticObjects: test.GenDefaultKubermaticObjects(
 				func() *kubermaticapiv1.KubermaticSetting {


### PR DESCRIPTION
**What this PR does / why we need it**: Customer would like to be able to restrict users, including Owner, Viewer and Editor roles, from creating projects beneath groups. This would mean that only Admin users can create projects for any group. The reason for this is so that the admins can ensure that naming conventions are adhered to and project permissions are correct for each project created.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #


```release-note
Restrict project creation for nonadmin users
```
