### PR TITLE
backport do not set dynamic preset ce to v2.14

### DIFF
--- a/api/Makefile
+++ b/api/Makefile
@@ -17,6 +17,7 @@ KUBERMATIC_EDITION?=ce
 REPO=quay.io/kubermatic/kubermatic$(shell [ "$(KUBERMATIC_EDITION)" != "ce" ] && echo "-$(KUBERMATIC_EDITION)" )
 CMD=$(filter-out OWNERS nodeport-proxy kubeletdnat-controller, $(notdir $(wildcard ./cmd/*)))
 GOBUILDFLAGS?=-v
+GOOS ?= $(shell go env GOOS)
 GITTAG=$(shell git describe --tags --always)
 TAGS?=$(GITTAG)
 DOCKERTAGS=$(TAGS) latestbuild
@@ -42,7 +43,7 @@ all: check vendor build test
 build: $(CMD)
 
 $(CMD): download-gocache
-	go build -tags "$(KUBERMATIC_EDITION)" $(GOTOOLFLAGS) -o $(BUILD_DEST)/$@ ./cmd/$@
+	GOOS=$(GOOS) go build -tags "$(KUBERMATIC_EDITION)" $(GOTOOLFLAGS) -o $(BUILD_DEST)/$@ ./cmd/$@
 
 install:
 	go install $(GOTOOLFLAGS) ./cmd/...

--- a/api/cmd/kubeletdnat-controller/Makefile
+++ b/api/cmd/kubeletdnat-controller/Makefile
@@ -12,8 +12,10 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+GOOS ?= $(shell go env GOOS)
+
 build:
-	CGO_ENABLED=0 go build -o ./_build/kubeletdnat-controller .
+	GOOS=$(GOOS) CGO_ENABLED=0 go build -o ./_build/kubeletdnat-controller .
 
 docker: build
 	docker build -t quay.io/kubermatic/kubeletdnat-controller:$(TAG) .

--- a/api/cmd/kubermatic-operator/main.go
+++ b/api/cmd/kubermatic-operator/main.go
@@ -32,7 +32,6 @@ import (
 	kubermaticlog "github.com/kubermatic/kubermatic/api/pkg/log"
 	"github.com/kubermatic/kubermatic/api/pkg/pprof"
 	"github.com/kubermatic/kubermatic/api/pkg/provider"
-	"github.com/kubermatic/kubermatic/api/pkg/resources"
 	"github.com/kubermatic/kubermatic/api/pkg/signals"
 
 	certmanagerv1alpha2 "github.com/jetstack/cert-manager/pkg/apis/certmanager/v1alpha2"
@@ -88,7 +87,8 @@ func main() {
 		log.Fatal("-namespace is a mandatory flag")
 	}
 
-	log.With("kubermatic", common.KUBERMATICDOCKERTAG, "ui", common.UIDOCKERTAG).Infof("Moin, moin, I'm the Kubermatic %s Operator and these are the versions I work with.", resources.KubermaticEdition)
+	v := common.NewDefaultVersions()
+	log.With("kubermatic", v.Kubermatic, "ui", v.UI).Infof("Moin, moin, I'm the Kubermatic %s Operator and these are the versions I work with.", v.KubermaticEdition)
 
 	config, err := clientcmd.BuildConfigFromFlags("", opt.kubeconfig)
 	if err != nil {

--- a/api/cmd/nodeport-proxy/Makefile
+++ b/api/cmd/nodeport-proxy/Makefile
@@ -14,11 +14,13 @@
 
 default: test build
 
+GOOS ?= $(shell go env GOOS)
+
 lb-updater:
-	CGO_ENABLED=0 go build -o ./_build/lb-updater github.com/kubermatic/kubermatic/api/cmd/nodeport-proxy/lb-updater
+	GOOS=$(GOOS) CGO_ENABLED=0 go build -o ./_build/lb-updater github.com/kubermatic/kubermatic/api/cmd/nodeport-proxy/lb-updater
 
 envoy-manager:
-	CGO_ENABLED=0 go build -o ./_build/envoy-manager github.com/kubermatic/kubermatic/api/cmd/nodeport-proxy/envoy-manager
+	GOOS=$(GOOS) CGO_ENABLED=0 go build -o ./_build/envoy-manager github.com/kubermatic/kubermatic/api/cmd/nodeport-proxy/envoy-manager
 
 build: envoy-manager lb-updater
 

--- a/api/cmd/user-ssh-keys-agent/Makefile
+++ b/api/cmd/user-ssh-keys-agent/Makefile
@@ -12,8 +12,10 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+GOOS ?= $(shell go env GOOS)
+
 build:
-	CGO_ENABLED=0 go build -o user-ssh-keys-agent
+	GOOS=$(GOOS) CGO_ENABLED=0 go build -o user-ssh-keys-agent
 
 docker: build
 	docker build -t quay.io/kubermatic/user-ssh-keys-agent:$(TAG) .

--- a/api/pkg/controller/operator/common/versions.go
+++ b/api/pkg/controller/operator/common/versions.go
@@ -16,6 +16,10 @@ limitations under the License.
 
 package common
 
+import (
+	"github.com/kubermatic/kubermatic/api/pkg/util/edition"
+)
+
 // UIDOCKERTAG is a magic variable containing the tag / git commit hash
 // of the dashboard-v2 Docker image to deploy. It gets fed by the
 // Makefile as an ldflag.
@@ -27,17 +31,19 @@ var UIDOCKERTAG string
 var KUBERMATICDOCKERTAG string
 
 type Versions struct {
-	Kubermatic string
-	UI         string
-	VPA        string
-	Envoy      string
+	Kubermatic        string
+	UI                string
+	VPA               string
+	Envoy             string
+	KubermaticEdition edition.Type
 }
 
 func NewDefaultVersions() Versions {
 	return Versions{
-		Kubermatic: KUBERMATICDOCKERTAG,
-		UI:         UIDOCKERTAG,
-		VPA:        "0.5.0",
-		Envoy:      "v1.13.0",
+		Kubermatic:        KUBERMATICDOCKERTAG,
+		UI:                UIDOCKERTAG,
+		VPA:               "0.5.0",
+		Envoy:             "v1.13.0",
+		KubermaticEdition: edition.KubermaticEdition,
 	}
 }

--- a/api/pkg/controller/operator/master/resources/kubermatic/api.go
+++ b/api/pkg/controller/operator/master/resources/kubermatic/api.go
@@ -98,7 +98,6 @@ func APIDeploymentCreator(cfg *operatorv1alpha1.KubermaticConfiguration, workerN
 				"-logtostderr",
 				"-address=0.0.0.0:8080",
 				"-internal-address=0.0.0.0:8085",
-				"-dynamic-datacenters=true",
 				"-dynamic-presets=true",
 				"-swagger=/opt/swagger.json",
 				"-master-resources=/opt/extra-files",
@@ -114,6 +113,11 @@ func APIDeploymentCreator(cfg *operatorv1alpha1.KubermaticConfiguration, workerN
 				fmt.Sprintf("-feature-gates=%s", featureGates(cfg)),
 				fmt.Sprintf("-pprof-listen-address=%s", *cfg.Spec.API.PProfEndpoint),
 				fmt.Sprintf("-accessible-addons=%s", strings.Join(cfg.Spec.API.AccessibleAddons, ",")),
+			}
+
+			// Only EE does support dynamic-datacenters
+			if versions.KubermaticEdition.IsEE() {
+				args = append(args, "-dynamic-datacenters=true")
 			}
 
 			if cfg.Spec.API.DebugLog {

--- a/api/pkg/controller/operator/master/resources/kubermatic/master-controller-manager.go
+++ b/api/pkg/controller/operator/master/resources/kubermatic/master-controller-manager.go
@@ -73,12 +73,16 @@ func MasterControllerManagerDeploymentCreator(cfg *operatorv1alpha1.KubermaticCo
 			args := []string{
 				"-logtostderr",
 				"-internal-address=0.0.0.0:8085",
-				"-dynamic-datacenters=true",
 				"-worker-count=20",
 				fmt.Sprintf("-namespace=%s", cfg.Namespace),
 				fmt.Sprintf("-pprof-listen-address=%s", *cfg.Spec.MasterController.PProfEndpoint),
 				fmt.Sprintf("-seed-admissionwebhook-cert-file=/opt/seed-webhook-serving-cert/%s", resources.ServingCertSecretKey),
 				fmt.Sprintf("-seed-admissionwebhook-key-file=/opt/seed-webhook-serving-cert/%s", resources.ServingCertKeySecretKey),
+			}
+
+			// Only EE does support dynamic-datacenters
+			if versions.KubermaticEdition.IsEE() {
+				args = append(args, "-dynamic-datacenters=true")
 			}
 
 			if cfg.Spec.MasterController.DebugLog {

--- a/api/pkg/controller/operator/seed/resources/kubermatic/seed-controller-manager.go
+++ b/api/pkg/controller/operator/seed/resources/kubermatic/seed-controller-manager.go
@@ -64,7 +64,6 @@ func SeedControllerManagerDeploymentCreator(workerName string, versions common.V
 
 			args := []string{
 				"-logtostderr",
-				"-dynamic-datacenters=true",
 				"-internal-address=0.0.0.0:8085",
 				"-kubernetes-addons-path=/opt/addons/kubernetes",
 				"-openshift-addons-path=/opt/addons/openshift",
@@ -92,6 +91,11 @@ func SeedControllerManagerDeploymentCreator(workerName string, versions common.V
 				fmt.Sprintf("-pprof-listen-address=%s", *cfg.Spec.SeedController.PProfEndpoint),
 				fmt.Sprintf("-in-cluster-prometheus-disable-default-rules=%v", cfg.Spec.UserCluster.Monitoring.DisableDefaultRules),
 				fmt.Sprintf("-in-cluster-prometheus-disable-default-scraping-configs=%v", cfg.Spec.UserCluster.Monitoring.DisableDefaultScrapingConfigs),
+			}
+
+			// Only EE does support dynamic-datacenters
+			if versions.KubermaticEdition.IsEE() {
+				args = append(args, "-dynamic-datacenters=true")
 			}
 
 			if cfg.Spec.UserCluster.Monitoring.ScrapeAnnotationPrefix != "" {

--- a/api/pkg/resources/resources_ce.go
+++ b/api/pkg/resources/resources_ce.go
@@ -19,8 +19,6 @@ limitations under the License.
 package resources
 
 const (
-	KubermaticEdition = "Community Edition"
-
 	// DefaultKubermaticImage defines the default Docker repository containing the Kubermatic API image.
 	DefaultKubermaticImage = "quay.io/kubermatic/kubermatic"
 

--- a/api/pkg/resources/resources_ee.go
+++ b/api/pkg/resources/resources_ee.go
@@ -19,8 +19,6 @@ limitations under the License.
 package resources
 
 const (
-	KubermaticEdition = "Enterprise Edition"
-
 	// DefaultKubermaticImage defines the default Docker repository containing the Kubermatic API image.
 	DefaultKubermaticImage = "quay.io/kubermatic/kubermatic-ee"
 

--- a/api/pkg/util/edition/const_ce.go
+++ b/api/pkg/util/edition/const_ce.go
@@ -1,3 +1,5 @@
+// +build !ee
+
 /*
 Copyright 2020 The Kubermatic Kubernetes Platform contributors.
 
@@ -14,20 +16,6 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package util
+package edition
 
-import (
-	"go.uber.org/zap"
-
-	"github.com/kubermatic/kubermatic/api/pkg/resources"
-	"github.com/kubermatic/kubermatic/api/pkg/util/edition"
-)
-
-func Hello(log *zap.SugaredLogger, app string, verbose bool) {
-	log = log.With("version", resources.KUBERMATICGITTAG)
-	if verbose {
-		log = log.With("commit", resources.KUBERMATICCOMMIT)
-	}
-
-	log.Infof("Starting Kubermatic %s (%s)...", app, edition.KubermaticEdition)
-}
+const KubermaticEdition = CE

--- a/api/pkg/util/edition/const_ee.go
+++ b/api/pkg/util/edition/const_ee.go
@@ -1,3 +1,5 @@
+// +build ee
+
 /*
 Copyright 2020 The Kubermatic Kubernetes Platform contributors.
 
@@ -14,20 +16,6 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package util
+package edition
 
-import (
-	"go.uber.org/zap"
-
-	"github.com/kubermatic/kubermatic/api/pkg/resources"
-	"github.com/kubermatic/kubermatic/api/pkg/util/edition"
-)
-
-func Hello(log *zap.SugaredLogger, app string, verbose bool) {
-	log = log.With("version", resources.KUBERMATICGITTAG)
-	if verbose {
-		log = log.With("commit", resources.KUBERMATICCOMMIT)
-	}
-
-	log.Infof("Starting Kubermatic %s (%s)...", app, edition.KubermaticEdition)
-}
+const KubermaticEdition = EE

--- a/api/pkg/util/edition/types.go
+++ b/api/pkg/util/edition/types.go
@@ -13,21 +13,30 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 */
+package edition
 
-package util
+type Type int
 
-import (
-	"go.uber.org/zap"
-
-	"github.com/kubermatic/kubermatic/api/pkg/resources"
-	"github.com/kubermatic/kubermatic/api/pkg/util/edition"
+const (
+	CE Type = iota
+	EE
 )
 
-func Hello(log *zap.SugaredLogger, app string, verbose bool) {
-	log = log.With("version", resources.KUBERMATICGITTAG)
-	if verbose {
-		log = log.With("commit", resources.KUBERMATICCOMMIT)
+func (e Type) String() string {
+	switch e {
+	case CE:
+		return "Community Edition"
+	case EE:
+		return "Enterprise Edition"
+	default:
+		return ""
 	}
+}
 
-	log.Infof("Starting Kubermatic %s (%s)...", app, edition.KubermaticEdition)
+func (e Type) IsEE() bool {
+	return e == EE
+}
+
+func (e Type) IsCE() bool {
+	return e == CE
 }

--- a/api/pkg/util/edition/types_test.go
+++ b/api/pkg/util/edition/types_test.go
@@ -13,21 +13,18 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 */
-
-package util
+package edition
 
 import (
-	"go.uber.org/zap"
-
-	"github.com/kubermatic/kubermatic/api/pkg/resources"
-	"github.com/kubermatic/kubermatic/api/pkg/util/edition"
+	"fmt"
+	"testing"
 )
 
-func Hello(log *zap.SugaredLogger, app string, verbose bool) {
-	log = log.With("version", resources.KUBERMATICGITTAG)
-	if verbose {
-		log = log.With("commit", resources.KUBERMATICCOMMIT)
+func TestEditionString(t *testing.T) {
+	if got, exp := fmt.Sprintf("Edition: %s", CE), "Edition: Community Edition"; got != exp {
+		t.Errorf("Expected %s but got %s", exp, got)
 	}
-
-	log.Infof("Starting Kubermatic %s (%s)...", app, edition.KubermaticEdition)
+	if got, exp := fmt.Sprintf("Edition: %s", EE), "Edition: Enterprise Edition"; got != exp {
+		t.Errorf("Expected %s but got %s", exp, got)
+	}
 }


### PR DESCRIPTION
**What this PR does / why we need it**:
The community edition do not support dynamic-datacenter flag. This PR fixes the operator not to specify it when starting the k8c components in CE mode.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #5594

**Special notes for your reviewer**:

**Documentation**:
<!-- Add links to the related documentation changes related to this pull request. E.g. the link to the kubermatic/docs pullrequest. -->

**Does this PR introduce a user-facing change?**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If  no release note is required, just write "NONE".
-->
```release-note
Fix Kubermatic operator not to specify unsupported 'dynamic-datacenter' flag in CE mode.
```
