### PR TITLE
Apply the Kubermatic Operator Helm change to 2.14

### DIFF
--- a/config/kubermatic-operator/Chart.yaml
+++ b/config/kubermatic-operator/Chart.yaml
@@ -14,7 +14,7 @@
 
 apiVersion: v1
 name: kubermatic-operator
-version: 0.2.0
+version: 0.2.1
 appVersion: '__KUBERMATIC_TAG__'
 description: Helm chart to install the Kubermatic Operator
 keywords:

--- a/config/kubermatic-operator/templates/dockercfg.yaml
+++ b/config/kubermatic-operator/templates/dockercfg.yaml
@@ -12,6 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+{{- if .Values.kubermaticOperator.imagePullSecret }}
 apiVersion: v1
 kind: Secret
 metadata:
@@ -21,3 +22,4 @@ metadata:
 type: kubernetes.io/dockerconfigjson
 data:
   .dockerconfigjson: {{ .Values.kubermaticOperator.imagePullSecret | b64enc | quote }}
+{{- end }}


### PR DESCRIPTION
**What this PR does / why we need it**:
Backport #5610 to 2.14

**Does this PR introduce a user-facing change?**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If  no release note is required, just write "NONE".
-->
```release-note
NONE
```
