### PR TITLE
Backport fix seed validation to 2.14

### DIFF
--- a/api/pkg/provider/datacenter.go
+++ b/api/pkg/provider/datacenter.go
@@ -33,9 +33,9 @@ import (
 )
 
 const (
-	// defaultSeedName is the name of the Seed resource that is used
+	// DefaultSeedName is the name of the Seed resource that is used
 	// in the Community Edition, which is limited to a single seed.
-	defaultSeedName = "kubermatic"
+	DefaultSeedName = "kubermatic"
 )
 
 // SeedGetter is a function to retrieve a single seed
@@ -78,18 +78,18 @@ func SeedGetterFactory(ctx context.Context, client ctrlruntimeclient.Client, see
 func SeedsGetterFactory(ctx context.Context, client ctrlruntimeclient.Client, namespace string) (SeedsGetter, error) {
 	return func() (map[string]*kubermaticv1.Seed, error) {
 		seed := &kubermaticv1.Seed{}
-		if err := client.Get(ctx, types.NamespacedName{Namespace: namespace, Name: defaultSeedName}, seed); err != nil {
+		if err := client.Get(ctx, types.NamespacedName{Namespace: namespace, Name: DefaultSeedName}, seed); err != nil {
 			if kerrors.IsNotFound(err) {
 				return nil, err
 			}
 
-			return nil, fmt.Errorf("failed to get seed %q: %v", defaultSeedName, err)
+			return nil, fmt.Errorf("failed to get seed %q: %v", DefaultSeedName, err)
 		}
 
 		seed.SetDefaults()
 
 		return map[string]*kubermaticv1.Seed{
-			defaultSeedName: seed,
+			DefaultSeedName: seed,
 		}, nil
 	}, nil
 }

--- a/api/pkg/provider/datacenter_test.go
+++ b/api/pkg/provider/datacenter_test.go
@@ -31,7 +31,7 @@ func TestSeedGetterFactorySetsDefaults(t *testing.T) {
 	t.Parallel()
 	initSeed := &kubermaticv1.Seed{
 		ObjectMeta: metav1.ObjectMeta{
-			Name:      defaultSeedName,
+			Name:      DefaultSeedName,
 			Namespace: "my-ns",
 		},
 		Spec: kubermaticv1.SeedSpec{
@@ -43,7 +43,7 @@ func TestSeedGetterFactorySetsDefaults(t *testing.T) {
 	}
 	client := fakectrlruntimeclient.NewFakeClientWithScheme(scheme.Scheme, initSeed)
 
-	seedGetter, err := SeedGetterFactory(context.Background(), client, defaultSeedName, "my-ns")
+	seedGetter, err := SeedGetterFactory(context.Background(), client, DefaultSeedName, "my-ns")
 	if err != nil {
 		t.Fatalf("failed getting seedGetter: %v", err)
 	}
@@ -61,7 +61,7 @@ func TestSeedsGetterFactorySetsDefaults(t *testing.T) {
 	t.Parallel()
 	initSeed := &kubermaticv1.Seed{
 		ObjectMeta: metav1.ObjectMeta{
-			Name:      defaultSeedName,
+			Name:      DefaultSeedName,
 			Namespace: "my-ns",
 		},
 		Spec: kubermaticv1.SeedSpec{
@@ -81,10 +81,10 @@ func TestSeedsGetterFactorySetsDefaults(t *testing.T) {
 	if err != nil {
 		t.Fatalf("failed calling seedsGetter: %v", err)
 	}
-	if _, exists := seeds[defaultSeedName]; !exists || len(seeds) != 1 {
+	if _, exists := seeds[DefaultSeedName]; !exists || len(seeds) != 1 {
 		t.Fatalf("expceted to get a map with exactly one key `my-seed`, got %v", seeds)
 	}
-	seed := seeds[defaultSeedName]
+	seed := seeds[DefaultSeedName]
 	if seed.Spec.Datacenters["a"].Node.ProxySettings.HTTPProxy.String() != "seed-proxy" {
 		t.Errorf("expected the datacenters http proxy setting to get set but was %v",
 			seed.Spec.Datacenters["a"].Node.ProxySettings.HTTPProxy)

--- a/api/pkg/validation/seed/seed_test.go
+++ b/api/pkg/validation/seed/seed_test.go
@@ -17,10 +17,15 @@ limitations under the License.
 package seed
 
 import (
+	"context"
+	"errors"
+	"strings"
 	"testing"
 
 	kubermaticv1 "github.com/kubermatic/kubermatic/api/pkg/crd/kubermatic/v1"
+	"github.com/kubermatic/kubermatic/api/pkg/provider"
 
+	admissionv1beta1 "k8s.io/api/admission/v1beta1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/client-go/kubernetes/scheme"
@@ -410,11 +415,11 @@ func TestValidate(t *testing.T) {
 
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
-			sv := &seedValidator{
+			sv := &Validator{
 				listOpts: &ctrlruntimeclient.ListOptions{},
 			}
 
-			err := sv.validate(tc.seedToValidate,
+			err := sv.validate(context.Background(), tc.seedToValidate,
 				fakectrlruntimeclient.NewFakeClientWithScheme(scheme.Scheme, tc.existingClusters...),
 				tc.existingSeeds, tc.isDelete)
 
@@ -424,4 +429,148 @@ func TestValidate(t *testing.T) {
 		})
 	}
 
+}
+
+func TestSingleSeedValidateFunc(t *testing.T) {
+	tests := []struct {
+		name      string
+		namespace string
+		seed      *kubermaticv1.Seed
+		op        admissionv1beta1.Operation
+		wantErr   bool
+	}{
+		{
+			name:      "Matching name and namespace",
+			namespace: "kubermatic",
+			seed: &kubermaticv1.Seed{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      provider.DefaultSeedName,
+					Namespace: "kubermatic",
+				},
+			},
+			op:      admissionv1beta1.Create,
+			wantErr: false,
+		},
+		{
+			name:      "Non Matching namespace",
+			namespace: "kubermatic",
+			seed: &kubermaticv1.Seed{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      provider.DefaultSeedName,
+					Namespace: "kube-system",
+				},
+			},
+			op:      admissionv1beta1.Create,
+			wantErr: true,
+		},
+		{
+			name:      "Non Matching name",
+			namespace: "kubermatic",
+			seed: &kubermaticv1.Seed{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "my-seed",
+					Namespace: "kubermatic",
+				},
+			},
+			op:      admissionv1beta1.Create,
+			wantErr: true,
+		},
+		{
+			name:      "my-seed",
+			namespace: "kubermatic",
+			seed: &kubermaticv1.Seed{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "custom-seed",
+					Namespace: "kube-system",
+				},
+			},
+			op:      admissionv1beta1.Delete,
+			wantErr: false,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := SingleSeedValidateFunc(tt.namespace)(context.Background(), tt.seed, tt.op); (got == nil) == tt.wantErr {
+				t.Errorf("Expected validation error = %v, but got: %v", tt.wantErr, got)
+			}
+		})
+	}
+}
+
+func TestCombineSeedValidateFuncs(t *testing.T) {
+	tests := []struct {
+		name              string
+		validationResults string
+		wantErr           bool
+		expSuccess        int
+		expFailures       int
+	}{
+		{
+			name:              "Multiple succeeding validations",
+			validationResults: "S -> S -> S -> S",
+			wantErr:           false,
+			expSuccess:        4,
+		},
+		{
+			name:              "Last validation fails",
+			validationResults: "S -> S -> S -> S -> F",
+			wantErr:           true,
+			expSuccess:        4,
+		},
+		{
+			name:              "Last validation fails",
+			validationResults: "S -> S -> F -> S -> S",
+			wantErr:           true,
+			expSuccess:        2,
+		},
+		{
+			name:              "First validation fails",
+			validationResults: "F -> S -> S -> S -> S",
+			wantErr:           true,
+			expSuccess:        0,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			tv := &TestValidator{}
+			if got := CombineSeedValidateFuncs(tv.GetValidateFuncs(tt.validationResults)...)(context.Background(), &kubermaticv1.Seed{}, admissionv1beta1.Create); (got == nil) == tt.wantErr {
+				t.Errorf("Expected validation error = %v, but got: %v", tt.wantErr, got)
+			}
+			if exp, got := tt.expSuccess, tv.successCounter; exp != got {
+				t.Errorf("Expected %d success, but got: %v", exp, got)
+			}
+		})
+	}
+}
+
+type TestValidator struct {
+	successCounter int
+}
+
+func (t *TestValidator) ValidationSuccess(ctx context.Context, seed *kubermaticv1.Seed, op admissionv1beta1.Operation) error {
+	t.successCounter++
+	return nil
+}
+
+func (t *TestValidator) ValidationFailure(ctx context.Context, seed *kubermaticv1.Seed, op admissionv1beta1.Operation) error {
+	return errors.New("Validation failed")
+}
+
+// GetValidateFuncs returns a slice of ValidateFunc respecting the given
+// pattern where "S" stands for Success and "F" for failure. Those symbols are
+// separated by " -> ".
+// e.g. "S -> S -> F" will return the following sequence:
+// []SeedValidateFunc{t.ValidationSuccess, t.ValidationSuccess, t.ValidationFailure}
+func (t *TestValidator) GetValidateFuncs(pattern string) []ValidateFunc {
+	seq := strings.Split(pattern, "->")
+	var funcs []ValidateFunc
+	for _, s := range seq {
+		switch strings.ToUpper(strings.Trim(s, " ")) {
+		case "F":
+			funcs = append(funcs, t.ValidationFailure)
+		case "S":
+			funcs = append(funcs, t.ValidationSuccess)
+		}
+	}
+	return funcs
 }


### PR DESCRIPTION
**What this PR does / why we need it**:
At the moment it is not possible to create Seed resources in CE mode, as the validation is broken.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #5601

**Special notes for your reviewer**:

**Documentation**:
<!-- Add links to the related documentation changes related to this pull request. E.g. the link to the kubermatic/docs pullrequest. -->

**Does this PR introduce a user-facing change?**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If  no release note is required, just write "NONE".
-->
```release-note
Fix Seed validation for Community Edition.
```
