### PR TITLE
Backport fix seed validation flackiness to 2.14

### DIFF
--- a/api/pkg/controller/operator/common/defaults.go
+++ b/api/pkg/controller/operator/common/defaults.go
@@ -46,8 +46,8 @@ const (
 	DefaultIngressClass                           = "nginx"
 	DefaultAPIReplicas                            = 2
 	DefaultUIReplicas                             = 2
-	DefaultSeedControllerMgrReplicas              = 2
-	DefaultMasterControllerMgrReplicas            = 2
+	DefaultSeedControllerMgrReplicas              = 1
+	DefaultMasterControllerMgrReplicas            = 1
 	DefaultAPIServerReplicas                      = 2
 	DefaultExposeStrategy                         = operatorv1alpha1.NodePortStrategy
 	DefaultVPARecommenderDockerRepository         = "gcr.io/google_containers/vpa-recommender"

--- a/docs/zz_generated.kubermaticConfiguration.yaml
+++ b/docs/zz_generated.kubermaticConfiguration.yaml
@@ -90,7 +90,7 @@ spec:
       # DryRun makes the migrator only log the actions it would take.
       dryRun: false
     # Replicas sets the number of pod replicas for the master-controller-manager.
-    replicas: 2
+    replicas: 1
     # Resources describes the requested and maximum allowed CPU/memory usage.
     resources:
       # Limits describes the maximum amount of compute resources allowed.
@@ -190,7 +190,7 @@ spec:
     # data. This port is never exposed from the container and only available via port-forwardings.
     pprofEndpoint: :6600
     # Replicas sets the number of pod replicas for the seed-controller-manager.
-    replicas: 2
+    replicas: 1
     # Resources describes the requested and maximum allowed CPU/memory usage.
     resources:
       # Limits describes the maximum amount of compute resources allowed.


### PR DESCRIPTION
**What this PR does / why we need it**:
At the moment it is not possible to create Seed resources in CE mode, as the validation is broken.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes: #5601

**Special notes for your reviewer**:

**Documentation**:
<!-- Add links to the related documentation changes related to this pull request. E.g. the link to the kubermatic/docs pullrequest. -->

**Does this PR introduce a user-facing change?**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If  no release note is required, just write "NONE".
-->
```release-note
Fix Seed validation for Community Edition.
```
