### PR TITLE
Fix incorrect error handling in collectAddon function

### DIFF
--- a/pkg/collectors/addon.go
+++ b/pkg/collectors/addon.go
@@ -83,6 +83,7 @@ func (cc AddonCollector) Collect(ch chan<- prometheus.Metric) {
 func (cc *AddonCollector) collectAddon(ch chan<- prometheus.Metric, addon *kubermaticv1.Addon) {
 	if len(addon.OwnerReferences) < 1 || addon.OwnerReferences[0].Kind != kubermaticv1.ClusterKindName {
 		utilruntime.HandleError(fmt.Errorf("No owning cluster for addon %v/%v", addon.Namespace, addon.Name))
+		return
 	}
 
 	clusterName := addon.OwnerReferences[0].Name


### PR DESCRIPTION
**What this PR does / why we need it**:
There is a return statement missing, when handling a broken or missing ownerReference in the collectAddon function.
Without this, the controller will print an error message and panic.

**Special notes for your reviewer**:

**Documentation**:
<!-- Add links to the related documentation changes related to this pull request. E.g. the link to the kubermatic/docs pullrequest. -->

**Does this PR introduce a user-facing change?**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If  no release note is required, just write "NONE".
-->
```release-note
NONE
```
