### PR TITLE
Improve release tarball script

### DIFF
--- a/charts/test/kubermatic.example.ce.yaml
+++ b/charts/test/kubermatic.example.ce.yaml
@@ -1,0 +1,50 @@
+apiVersion: operator.kubermatic.io/v1alpha1
+kind: KubermaticConfiguration
+metadata:
+  name: kubermatic
+  namespace: kubermatic
+spec:
+  # No image pull secret is required for CE, leave it empty.
+  imagePullSecret: |
+    {
+      "auths": {
+        "quay.io": {}
+      }
+    }
+
+  ingress:
+    # Domain is the base domain where the dashboard shall be available. Even with
+    # a disabled Ingress, this must always be a valid hostname.
+    # this domain must match what you configured as dex.ingress.host
+    # in the values.yaml
+    domain: cluster.example.dev
+    certificateIssuer:
+      # APIGroup is the group for the resource being referenced.
+      # If APIGroup is not specified, the specified Kind must be in the core API group.
+      # For any other third-party types, APIGroup is required.
+      apiGroup: null
+      # Kind is the type of resource being referenced
+      kind: ClusterIssuer
+      # Name is the name of resource being referenced
+      # For generating a certificate signed by a trusted root authority replace
+      # with "letsencrypt-prod".
+      name: "letsencrypt-staging"
+    className: nginx
+
+  # These secret keys configure the way components commmunicate with Dex.
+  auth:
+    clientID: kubermatic
+    issuerClientID: kubermaticIssuer
+    # When using letsencrypt-prod replace with "false"
+    skipTokenIssuerTLSVerify: true
+    tokenIssuer: https://cluster.example.dev/dex
+
+    # this must match the secret configured for the kubermatic client from
+    # the values.yaml.
+    issuerClientSecret: <dex-kubermatic-oauth-secret-here>
+
+    # these need to be randomly generated. Those can be generated on the
+    # shell using:
+    # cat /dev/urandom | tr -dc A-Za-z0-9 | head -c32
+    issuerCookieKey: <a-random-key>
+    serviceAccountKey: <another-random-key>

--- a/charts/test/kubermatic.example.ee.yaml
+++ b/charts/test/kubermatic.example.ee.yaml
@@ -1,0 +1,53 @@
+apiVersion: operator.kubermatic.io/v1alpha1
+kind: KubermaticConfiguration
+metadata:
+  name: kubermatic
+  namespace: kubermatic
+spec:
+  # insert the Docker authentication JSON provided by Loodse here
+  imagePullSecret: |
+    {
+      "auths": {
+        "quay.io": {
+          "auth": "<your-auth-token>",
+          "email": ""
+        }
+      }
+    }
+
+  ingress:
+    # Domain is the base domain where the dashboard shall be available. Even with
+    # a disabled Ingress, this must always be a valid hostname.
+    # this domain must match what you configured as dex.ingress.host
+    # in the values.yaml
+    domain: cluster.example.dev
+    certificateIssuer:
+      # APIGroup is the group for the resource being referenced.
+      # If APIGroup is not specified, the specified Kind must be in the core API group.
+      # For any other third-party types, APIGroup is required.
+      apiGroup: null
+      # Kind is the type of resource being referenced
+      kind: ClusterIssuer
+      # Name is the name of resource being referenced
+      # For generating a certificate signed by a trusted root authority replace
+      # with "letsencrypt-prod".
+      name: "letsencrypt-staging"
+    className: nginx
+
+  # These secret keys configure the way components commmunicate with Dex.
+  auth:
+    clientID: kubermatic
+    issuerClientID: kubermaticIssuer
+    # When using letsencrypt-prod replace with "false"
+    skipTokenIssuerTLSVerify: true
+    tokenIssuer: https://cluster.example.dev/dex
+
+    # this must match the secret configured for the kubermatic client from
+    # the values.yaml.
+    issuerClientSecret: <dex-kubermatic-oauth-secret-here>
+
+    # these need to be randomly generated. Those can be generated on the
+    # shell using:
+    # cat /dev/urandom | tr -dc A-Za-z0-9 | head -c32
+    issuerCookieKey: <a-random-key>
+    serviceAccountKey: <another-random-key>

--- a/charts/test/seed.example.yaml
+++ b/charts/test/seed.example.yaml
@@ -1,0 +1,36 @@
+apiVersion: v1
+kind: Secret
+metadata:
+  name: kubeconfig-cluster-example
+  namespace: kubermatic
+type: Opaque
+data:
+  kubeconfig: <base64 encoded kubeconfig>
+---
+apiVersion: kubermatic.k8s.io/v1
+kind: Seed
+metadata:
+  name: kubermatic
+  namespace: kubermatic
+spec:
+  # these two fields are only informational
+  country: FR
+  location: Paris
+
+  # List of datacenters where this seed cluster is allowed to create clusters in
+  # In this example, user cluster will be deployed in eu-central-1 on AWS.
+  datacenters:
+    aws-eu-central-1a:
+      country: DE
+      location: EU (Frankfurt)
+      spec:
+        aws:
+          images: null
+          region: eu-central-1
+        enforceAuditLogging: false
+        enforcePodSecurityPolicy: false
+
+  # reference to the kubeconfig to use when connecting to this seed cluster
+  kubeconfig:
+    name: kubeconfig-cluster-example
+    namespace: kubermatic

--- a/charts/values.example.ce.yaml
+++ b/charts/values.example.ce.yaml
@@ -1,0 +1,45 @@
+# Dex Is the OpenID Provider for Kubermatic.
+dex:
+  ingress:
+    # configure your base domain, under which the Kubermatic dashboard shall be available
+    host: cluster.example.dev
+
+  clients:
+  # The "kubermatic" client is used for logging into the Kubermatic dashboard. It always
+  # needs to be configured.
+  - id: kubermatic
+    name: Kubermatic
+    # Generate a secure secret key
+    # Those can be generated on the shell using:
+    # cat /dev/urandom | tr -dc A-Za-z0-9 | head -c32
+    secret: <a-random-key>
+    RedirectURIs:
+    # ensure the URLs below use the dex.ingress.host configured above
+    - https://cluster.example.dev
+    - https://cluster.example.dev/projects
+
+  # Depending on your chosen login method, you need to configure either an OAuth provider like
+  # Google or GitHub, or configure a set of static passwords. Check the `charts/oauth/values.yaml`
+  # for an overview over all available connectors.
+
+  # For testing purposes, we configure a single static user/password combination.
+  staticPasswords:
+  - email: kubermatic@example.com
+    # bcrypt hash of the string "password", can be created using recent versions of htpasswd:
+    # `htpasswd -bnBC 10 "" PASSWORD_HERE | tr -d ':\n' | sed 's/$2y/$2a/'`
+    hash: "$2a$10$zMJhg/3axbm/m0KmoVxJiO1eO5gtNrgKDysy5GafQFrXY93OE9LsK"
+
+    # these are used within Kubermatic to identify the user
+    username: admin
+    userID: 08a8684b-db88-4b73-90a9-3cd1661f5466
+
+  # the cert-manager Issuer (or ClusterIssuer) responsible for managing the certificates
+  certIssuer:
+    # For generating a certificate signed by a trusted root authority replace
+    # with "letsencrypt-prod".
+    name: letsencrypt-staging
+    kind: ClusterIssuer
+
+minio:
+  storeSize: '500Gi'
+  storageClass: minio-hdd

--- a/charts/values.example.ee.yaml
+++ b/charts/values.example.ee.yaml
@@ -1,0 +1,57 @@
+# Dex Is the OpenID Provider for Kubermatic.
+dex:
+  ingress:
+    # configure your base domain, under which the Kubermatic dashboard shall be available
+    host: cluster.example.dev
+
+  clients:
+  # The "kubermatic" client is used for logging into the Kubermatic dashboard. It always
+  # needs to be configured.
+  - id: kubermatic
+    name: Kubermatic
+    # Generate a secure secret key
+    # Those can be generated on the shell using:
+    # cat /dev/urandom | tr -dc A-Za-z0-9 | head -c32
+    secret: <a-random-key>
+    RedirectURIs:
+    # ensure the URLs below use the dex.ingress.host configured above
+    - https://cluster.example.dev
+    - https://cluster.example.dev/projects
+
+  # Depending on your chosen login method, you need to configure either an OAuth provider like
+  # Google or GitHub, or configure a set of static passwords. Check the `charts/oauth/values.yaml`
+  # for an overview over all available connectors.
+
+  # For testing purposes, we configure a single static user/password combination.
+  staticPasswords:
+  - email: kubermatic@example.com
+    # bcrypt hash of the string "password", can be created using recent versions of htpasswd:
+    # `htpasswd -bnBC 10 "" PASSWORD_HERE | tr -d ':\n' | sed 's/$2y/$2a/'`
+    hash: "$2a$10$zMJhg/3axbm/m0KmoVxJiO1eO5gtNrgKDysy5GafQFrXY93OE9LsK"
+
+    # these are used within Kubermatic to identify the user
+    username: admin
+    userID: 08a8684b-db88-4b73-90a9-3cd1661f5466
+
+  # the cert-manager Issuer (or ClusterIssuer) responsible for managing the certificates
+  certIssuer:
+    # For generating a certificate signed by a trusted root authority replace
+    # with "letsencrypt-prod".
+    name: letsencrypt-staging
+    kind: ClusterIssuer
+
+kubermaticOperator:
+  # insert the Docker authentication JSON provided by Loodse here
+  imagePullSecret: |
+    {
+      "auths": {
+        "quay.io": {
+          "auth": "<your-auth-token>",
+          "email": ""
+        }
+      }
+    }
+
+minio:
+  storeSize: '500Gi'
+  storageClass: minio-hdd


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR brings the following improvements to the script used to generate the tarballs containing the Helm charts:
* Include example configuration files
* Removes Kubermatic README.md
* Introduce retries when doing requests to github API

This partly implements #5633. The remaining part is the integration with the CI/CD pipeline.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Documentation**:
<!-- Add links to the related documentation changes related to this pull request. E.g. the link to the kubermatic/docs pullrequest. -->

**Does this PR introduce a user-facing change?**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If  no release note is required, just write "NONE".
-->
```release-note
NONE
```
