### PR TITLE
[release/2.14] Fix Subnetworks for GCP

### DIFF
--- a/api/pkg/handler/v1/provider/gcp.go
+++ b/api/pkg/handler/v1/provider/gcp.go
@@ -561,11 +561,9 @@ func listGCPSubnetworks(ctx context.Context, userInfo *provider.UserInfo, datace
 	err = req.Pages(ctx, func(page *compute.SubnetworkList) error {
 		for _, subnetwork := range page.Items {
 			// subnetworks.Network are a url e.g. https://www.googleapis.com/compute/v1/[...]/networks/default"
-			// we just get the name of the network, instead of the url
+			// we just get the path of the network, instead of the url
 			// therefor we can't use regular Filter function and need to check on our own
-			networkRegex := regexp.MustCompile(`^(.+\/networks\/)`)
-			network := networkRegex.ReplaceAllString(subnetwork.Network, "")
-			if network == networkName {
+			if strings.Contains(subnetwork.Network, networkName) {
 				net := apiv1.GCPSubnetwork{
 					ID:                    subnetwork.Id,
 					Name:                  subnetwork.Name,


### PR DESCRIPTION
**What this PR does / why we need it**:
Fix Subnetworks for GCP, because the network filtering was wrong.
cherry-picked from https://github.com/kubermatic/kubermatic/pull/5627

**Does this PR introduce a user-facing change?**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If  no release note is required, just write "NONE".
-->
```release-note
NONE
```
