### PR TITLE
Fix user watch websocket to produce api user instead of internal kubermatic

### DIFF
--- a/pkg/handler/routes_v1_websocket.go
+++ b/pkg/handler/routes_v1_websocket.go
@@ -81,6 +81,7 @@ func getProviders(r Routing) watcher.Providers {
 		SettingsWatcher:  r.settingsWatcher,
 		UserProvider:     r.userProvider,
 		UserWatcher:      r.userWatcher,
+		MemberMapper:     r.userProjectMapper,
 	}
 }
 

--- a/pkg/handler/websocket/user_test.go
+++ b/pkg/handler/websocket/user_test.go
@@ -99,7 +99,7 @@ func TestUserWatchEndpoint(t *testing.T) {
 				t.Fatalf("error reading ws message: %v", err)
 			}
 
-			var user *v1.User
+			var user *apiv1.User
 			err = json.Unmarshal(wsMsg.p, &user)
 			if err != nil {
 				t.Fatalf("failed unmarshalling user: %v", err)
@@ -133,14 +133,14 @@ func TestUserWatchEndpoint(t *testing.T) {
 			}
 
 			if !tc.updateShouldTimeout {
-				var userUpdate *v1.User
+				var userUpdate *apiv1.User
 				err = json.Unmarshal(wsMsg.p, &userUpdate)
 				if err != nil {
 					t.Fatalf("failed unmarshalling user: %v", err)
 				}
 
-				if !reflect.DeepEqual(userUpdate.Spec.Settings, tc.userSettingsUpdate) {
-					t.Fatalf("expected settings %v, got %v", tc.userSettingsUpdate, userUpdate.Spec.Settings)
+				if !reflect.DeepEqual(userUpdate.Settings, tc.userSettingsUpdate) {
+					t.Fatalf("expected settings %v, got %v", tc.userSettingsUpdate, userUpdate.Settings)
 				}
 			}
 		})

--- a/pkg/watcher/types.go
+++ b/pkg/watcher/types.go
@@ -27,6 +27,7 @@ type Providers struct {
 	SettingsWatcher  SettingsWatcher
 	UserProvider     provider.UserProvider
 	UserWatcher      UserWatcher
+	MemberMapper     provider.ProjectMemberMapper
 }
 
 type SettingsWatcher interface {


### PR DESCRIPTION
**What this PR does / why we need it**:
Fix user watch websocket to produce api user instead of internal kubermatic

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Does this PR introduce a user-facing change?**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If  no release note is required, just write "NONE".
-->
```release-note
NONE
```
