### PR TITLE
seed-controller-manager: disable-leader-election option

### DIFF
--- a/cmd/seed-controller-manager/main.go
+++ b/cmd/seed-controller-manager/main.go
@@ -256,26 +256,32 @@ Please install the VerticalPodAutoscaler according to the documentation: https:/
 		leaderCtx, stopLeaderElection := context.WithCancel(rootCtx)
 		defer stopLeaderElection()
 
+		runner := func(ctx context.Context) error {
+			log.Info("Executing migrations...")
+			if err := seedmigrations.RunAll(leaderCtx, ctrlCtx.mgr.GetConfig(), options.workerName); err != nil {
+				return fmt.Errorf("failed to run migrations: %v", err)
+			}
+			log.Info("Migrations executed successfully")
+
+			log.Info("Starting the controller-manager...")
+			if err := mgr.Start(ctx.Done()); err != nil {
+				return fmt.Errorf("the controller-manager stopped with an error: %v", err)
+			}
+
+			return nil
+		}
+
 		g.Add(func() error {
+			if options.disableLeaderElection {
+				return runner(leaderCtx)
+			}
+
 			electionName := controllerName
 			if options.workerName != "" {
 				electionName += "-" + options.workerName
 			}
 
-			return leaderelection.RunAsLeader(leaderCtx, log, config, mgr.GetEventRecorderFor(controllerName), electionName, func(ctx context.Context) error {
-				log.Info("Executing migrations...")
-				if err := seedmigrations.RunAll(leaderCtx, ctrlCtx.mgr.GetConfig(), options.workerName); err != nil {
-					return fmt.Errorf("failed to run migrations: %v", err)
-				}
-				log.Info("Migrations executed successfully")
-
-				log.Info("Starting the controller-manager...")
-				if err := mgr.Start(ctx.Done()); err != nil {
-					return fmt.Errorf("the controller-manager stopped with an error: %v", err)
-				}
-
-				return nil
-			})
+			return leaderelection.RunAsLeader(leaderCtx, log, config, mgr.GetEventRecorderFor(controllerName), electionName, runner)
 		}, func(err error) {
 			stopLeaderElection()
 		})

--- a/cmd/seed-controller-manager/options.go
+++ b/cmd/seed-controller-manager/options.go
@@ -77,6 +77,7 @@ type controllerRunOptions struct {
 	kubermaticImage                                  string
 	dnatControllerImage                              string
 	namespace                                        string
+	disableLeaderElection                            bool
 	apiServerDefaultReplicas                         int
 	apiServerEndpointReconcilingDisabled             bool
 	controllerManagerDefaultReplicas                 int
@@ -140,6 +141,7 @@ func newControllerRunOptions() (controllerRunOptions, error) {
 	flag.StringVar(&c.kubermaticImage, "kubermatic-image", resources.DefaultKubermaticImage, "The location from which to pull the Kubermatic image")
 	flag.StringVar(&c.dnatControllerImage, "dnatcontroller-image", resources.DefaultDNATControllerImage, "The location of the dnatcontroller-image")
 	flag.StringVar(&c.namespace, "namespace", "kubermatic", "The namespace kubermatic runs in, uses to determine where to look for datacenter custom resources")
+	flag.BoolVar(&c.disableLeaderElection, "disable-leader-election", false, "A flag indicating whether the controller should skip the leader election. Only enable this for debugging purposes.")
 	flag.IntVar(&c.apiServerDefaultReplicas, "apiserver-default-replicas", 2, "The default number of replicas for usercluster api servers")
 	flag.BoolVar(&c.apiServerEndpointReconcilingDisabled, "apiserver-reconciling-disabled-by-default", false, "Whether to disable reconciling for the apiserver endpoints by default")
 	flag.IntVar(&c.controllerManagerDefaultReplicas, "controller-manager-default-replicas", 1, "The default number of replicas for usercluster controller managers")


### PR DESCRIPTION
Signed-off-by: Olaf Klischat <olaf.klischat@gmail.com>

**What this PR does / why we need it**:

This adds a --disable-leader-election option to the seed-controller-manager, which can be handy during debugging sessions where you don't want your worker to be cancelled by leader election losses.

```release-note
seed-controller-manager: -disable-leader-election option
```
