### PR TITLE
increased the timeout on test which is flaky on CI

### DIFF
--- a/pkg/handler/websocket/user_test.go
+++ b/pkg/handler/websocket/user_test.go
@@ -91,7 +91,7 @@ func TestUserWatchEndpoint(t *testing.T) {
 
 			var wsMsg wsMessage
 			select {
-			case <-time.After(time.Second * 5):
+			case <-time.After(time.Second * 10):
 				t.Fatalf("timeout waiting for ws message")
 			case wsMsg = <-ch:
 			}
@@ -122,7 +122,7 @@ func TestUserWatchEndpoint(t *testing.T) {
 
 			// get the update notification
 			select {
-			case <-time.After(time.Second * 5):
+			case <-time.After(time.Second * 10):
 				if !tc.updateShouldTimeout {
 					t.Fatal("Watch update notification didnt arrive in time")
 				}


### PR DESCRIPTION
**What this PR does / why we need it**:
Increases the timeout for the user watch tests which is flaky on CI to see if it helps

**Does this PR introduce a user-facing change?**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If  no release note is required, just write "NONE".
-->
```release-note
NONE
```
