### PR TITLE
skipping flaky user watch test until solution is found

### DIFF
--- a/pkg/handler/websocket/user_test.go
+++ b/pkg/handler/websocket/user_test.go
@@ -36,6 +36,7 @@ import (
 )
 
 func TestUserWatchEndpoint(t *testing.T) {
+	t.Skip("skipping until the reason for flakiness is found")
 	t.Parallel()
 	testcases := []struct {
 		name                string


### PR DESCRIPTION
**What this PR does / why we need it**:
Skips flaky user watch test until solution is found.


**Does this PR introduce a user-facing change?**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If  no release note is required, just write "NONE".
-->
```release-note
NONE
```
