### PR TITLE
Add path to gcp subnetworks

### DIFF
--- a/cmd/kubermatic-api/swagger.json
+++ b/cmd/kubermatic-api/swagger.json
@@ -10471,6 +10471,10 @@
           "type": "string",
           "x-go-name": "Network"
         },
+        "path": {
+          "type": "string",
+          "x-go-name": "Path"
+        },
         "privateIpGoogleAccess": {
           "type": "boolean",
           "x-go-name": "PrivateIPGoogleAccess"

--- a/pkg/api/v1/types.go
+++ b/pkg/api/v1/types.go
@@ -281,6 +281,7 @@ type GCPSubnetwork struct {
 	SelfLink              string `json:"selfLink"`
 	PrivateIPGoogleAccess bool   `json:"privateIpGoogleAccess"`
 	Kind                  string `json:"kind"`
+	Path                  string `json:"path"`
 }
 
 // DigitaloceanSizeList represents a object of digitalocean sizes.

--- a/pkg/handler/v1/provider/gcp.go
+++ b/pkg/handler/v1/provider/gcp.go
@@ -575,11 +575,13 @@ func listGCPSubnetworks(ctx context.Context, userInfo *provider.UserInfo, datace
 
 	req := computeService.Subnetworks.List(project, datacenter.Spec.GCP.Region)
 	err = req.Pages(ctx, func(page *compute.SubnetworkList) error {
+		subnetworkRegex := regexp.MustCompile(`(projects\/.+)$`)
 		for _, subnetwork := range page.Items {
 			// subnetworks.Network are a url e.g. https://www.googleapis.com/compute/v1/[...]/networks/default"
 			// we just get the path of the network, instead of the url
 			// therefor we can't use regular Filter function and need to check on our own
 			if strings.Contains(subnetwork.Network, networkName) {
+				subnetworkPath := subnetworkRegex.FindString(subnetwork.SelfLink)
 				net := apiv1.GCPSubnetwork{
 					ID:                    subnetwork.Id,
 					Name:                  subnetwork.Name,
@@ -590,6 +592,7 @@ func listGCPSubnetworks(ctx context.Context, userInfo *provider.UserInfo, datace
 					SelfLink:              subnetwork.SelfLink,
 					PrivateIPGoogleAccess: subnetwork.PrivateIpGoogleAccess,
 					Kind:                  subnetwork.Kind,
+					Path:                  subnetworkPath,
 				}
 
 				subnetworks = append(subnetworks, net)

--- a/pkg/test/e2e/api/utils/apiclient/models/g_c_p_subnetwork.go
+++ b/pkg/test/e2e/api/utils/apiclient/models/g_c_p_subnetwork.go
@@ -33,6 +33,9 @@ type GCPSubnetwork struct {
 	// network
 	Network string `json:"network,omitempty"`
 
+	// path
+	Path string `json:"path,omitempty"`
+
 	// private IP google access
 	PrivateIPGoogleAccess bool `json:"privateIpGoogleAccess,omitempty"`
 


### PR DESCRIPTION
**What this PR does / why we need it**:
Add new field `path` to gcp subnetworks, as it is the needed value for cluster creation

**Special notes for your reviewer**:
/

**Does this PR introduce a user-facing change?**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If  no release note is required, just write "NONE".
-->
```release-note
NONE
```
