### PR TITLE
add Kubernetes v1.17.9 to default versions and remove earlier versions of 1.17

### DIFF
--- a/.prow.yaml
+++ b/.prow.yaml
@@ -345,7 +345,7 @@ presubmits:
         - name: KUBERMATIC_EDITION
           value: ee
         - name: VERSIONS_TO_TEST
-          value: "v1.17.5"
+          value: "v1.17.9"
         - name: EXCLUDE_DISTRIBUTIONS
           value: "centos,ubuntu,flatcar,rhel"
         - name: SERVICE_ACCOUNT_KEY

--- a/charts/kubermatic/Chart.yaml
+++ b/charts/kubermatic/Chart.yaml
@@ -14,7 +14,7 @@
 
 apiVersion: v1
 name: kubermatic
-version: 1.1.6
+version: 1.1.7
 appVersion: '__KUBERMATIC_TAG__'
 description: Kubermatic chart for master and/or seed clusters.
 keywords:

--- a/charts/kubermatic/static/master/updates.yaml
+++ b/charts/kubermatic/static/master/updates.yaml
@@ -32,10 +32,6 @@ updates:
   from: <= 1.16.12, >= 1.16.0
   to: 1.16.13
   type: kubernetes
-- automatic: true
-  from: 1.16.5
-  to: 1.16.6
-  type: kubernetes
 - from: 1.16.*
   to: 1.17.*
   type: kubernetes
@@ -43,8 +39,8 @@ updates:
   to: 1.17.*
   type: kubernetes
 - automatic: true
-  from: 1.17.1
-  to: 1.17.2
+  from: <= 1.17.8, >= 1.17.0
+  to: 1.17.9
   type: kubernetes
 - from: 1.17.*
   to: 1.18.*

--- a/charts/kubermatic/static/master/versions.yaml
+++ b/charts/kubermatic/static/master/versions.yaml
@@ -17,15 +17,9 @@ versions:
   version: 1.15.12
 - type: kubernetes
   version: 1.16.13
-- type: kubernetes
-  version: 1.17.0
-- type: kubernetes
-  version: 1.17.2
-- type: kubernetes
-  version: 1.17.3
 - default: true
   type: kubernetes
-  version: 1.17.5
+  version: 1.17.9
 - type: kubernetes
   version: 1.18.2
 - type: openshift

--- a/docs/zz_generated.kubermaticConfiguration.yaml
+++ b/docs/zz_generated.kubermaticConfiguration.yaml
@@ -391,7 +391,7 @@ spec:
     # Kubernetes configures the Kubernetes versions and updates.
     kubernetes:
       # Default is the default version to offer users.
-      default: 1.17.5
+      default: 1.17.9
       # Updates is a list of available and automatic upgrades.
       # All 'to' versions must be configured in the version list for this orchestrator.
       # Each update may optionally be configured to be 'automatic: true', in which case the
@@ -432,16 +432,13 @@ spec:
       - automatic: true
         from: <= 1.16.12, >= 1.16.0
         to: 1.16.13
-      - automatic: true
-        from: 1.16.5
-        to: 1.16.6
       - from: 1.16.*
         to: 1.17.*
       - from: 1.17.*
         to: 1.17.*
       - automatic: true
-        from: 1.17.1
-        to: 1.17.2
+        from: <= 1.17.8, >= 1.17.0
+        to: 1.17.9
       - from: 1.17.*
         to: 1.18.*
       - from: 1.18.*
@@ -456,10 +453,7 @@ spec:
       - 1.15.11
       - 1.15.12
       - 1.16.13
-      - 1.17.0
-      - 1.17.2
-      - 1.17.3
-      - 1.17.5
+      - 1.17.9
       - 1.18.2
     # Openshift configures the Openshift versions and updates.
     openshift:

--- a/pkg/controller/operator/common/defaults.go
+++ b/pkg/controller/operator/common/defaults.go
@@ -186,7 +186,7 @@ var (
 	}
 
 	DefaultKubernetesVersioning = operatorv1alpha1.KubermaticVersioningConfiguration{
-		Default: semver.MustParse("v1.17.5"),
+		Default: semver.MustParse("v1.17.9"),
 		Versions: []*semver.Version{
 			// Kubernetes 1.15
 			semver.MustParse("v1.15.5"),
@@ -199,10 +199,7 @@ var (
 			// Kubernetes 1.16
 			semver.MustParse("v1.16.13"),
 			// Kubernetes 1.17
-			semver.MustParse("v1.17.0"),
-			semver.MustParse("v1.17.2"),
-			semver.MustParse("v1.17.3"),
-			semver.MustParse("v1.17.5"),
+			semver.MustParse("v1.17.9"),
 			// Kubernetes 1.18
 			semver.MustParse("v1.18.2"),
 		},
@@ -262,12 +259,6 @@ var (
 				Automatic: pointer.BoolPtr(true),
 			},
 			{
-				// Released with broken Anago
-				From:      "1.16.5",
-				To:        "1.16.6",
-				Automatic: pointer.BoolPtr(true),
-			},
-			{
 				// Allow to next minor release
 				From: "1.16.*",
 				To:   "1.17.*",
@@ -280,9 +271,9 @@ var (
 				To:   "1.17.*",
 			},
 			{
-				// Released with broken Anago
-				From:      "1.17.1",
-				To:        "1.17.2",
+				// CVE-2020-8559
+				From:      "<= 1.17.8, >= 1.17.0",
+				To:        "1.17.9",
 				Automatic: pointer.BoolPtr(true),
 			},
 			{


### PR DESCRIPTION
**Special notes for your reviewer**:
CVE fixes

```release-note
Added Kubernetes v1.17.9, and removed v1.17.5
```
