### PR TITLE
[release/v2.13] add Kubernetes v1.16.13 to default versions and remove earlier versions of 1.16

### DIFF
--- a/.prow.yaml
+++ b/.prow.yaml
@@ -741,7 +741,7 @@ presubmits:
       - image: quay.io/kubermatic/e2e-kind:with-conformance-tests-v1.0.14
         env:
         - name: VERSIONS_TO_TEST
-          value: "v1.16.3"
+          value: "v1.16.13"
         - name: SERVICE_ACCOUNT_KEY
           valueFrom:
             secretKeyRef:
@@ -776,7 +776,7 @@ presubmits:
       - image: quay.io/kubermatic/e2e-kind:with-conformance-tests-v1.0.14
         env:
         - name: VERSIONS_TO_TEST
-          value: "v1.16.3"
+          value: "v1.16.13"
         - name: PROVIDER
           value: "openstack"
         - name: DEFAULT_TIMEOUT_MINUTES
@@ -817,7 +817,7 @@ presubmits:
       - image: quay.io/kubermatic/e2e-kind:with-conformance-tests-v1.0.14
         env:
         - name: VERSIONS_TO_TEST
-          value: "v1.16.3"
+          value: "v1.16.13"
         - name: PROVIDER
           value: "openstack"
         - name: DEFAULT_TIMEOUT_MINUTES
@@ -858,7 +858,7 @@ presubmits:
       - image: quay.io/kubermatic/e2e-kind:with-conformance-tests-v1.0.14
         env:
         - name: VERSIONS_TO_TEST
-          value: "v1.16.3"
+          value: "v1.16.13"
         - name: PROVIDER
           value: "openstack"
         - name: DEFAULT_TIMEOUT_MINUTES

--- a/api/pkg/controller/operator/common/defaults.go
+++ b/api/pkg/controller/operator/common/defaults.go
@@ -421,15 +421,7 @@ versions:
 - version: "v1.15.10"
   default: true
 # Kubernetes 1.16
-- version: "v1.16.2"
-  default: false
-- version: "v1.16.3"
-  default: false
-- version: "v1.16.4"
-  default: false
-- version: "v1.16.6"
-  default: false
-- version: "v1.16.7"
+- version: "v1.16.13"
   default: false
 # Kubernetes 1.17
 - version: "v1.17.0"
@@ -524,13 +516,9 @@ updates:
 - from: 1.16.*
   to: 1.16.*
   automatic: false
-# CVE-2019-11253
-- from: <= 1.16.1, >= 1.16.0
-  to: 1.16.2
-  automatic: true
-# Released with broken Anago
-- from: 1.16.5
-  to: 1.16.6
+# CVE-2019-11253, CVE-2020-8559
+- from: <= 1.16.12, >= 1.16.0
+  to: 1.16.13
   automatic: true
 # Allow to next minor release
 - from: 1.16.*

--- a/config/kubermatic/Chart.yaml
+++ b/config/kubermatic/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: kubermatic
-version: 1.0.41
+version: 1.0.42
 appVersion: '__KUBERMATIC_TAG__'
 description: Kubermatic chart for master and/or seed clusters.
 keywords:

--- a/config/kubermatic/static/master/updates.yaml
+++ b/config/kubermatic/static/master/updates.yaml
@@ -73,13 +73,9 @@ updates:
 - from: 1.16.*
   to: 1.16.*
   automatic: false
-# CVE-2019-11253
-- from: <= 1.16.1, >= 1.16.0
-  to: 1.16.2
-  automatic: true
-# Released with broken Anago
-- from: 1.16.5
-  to: 1.16.6
+# CVE-2019-11253, CVE-2020-8559
+- from: <= 1.16.12, >= 1.16.0
+  to: 1.16.13
   automatic: true
 # Allow to next minor release
 - from: 1.16.*

--- a/config/kubermatic/static/master/versions.yaml
+++ b/config/kubermatic/static/master/versions.yaml
@@ -15,15 +15,7 @@ versions:
 - version: "v1.15.10"
   default: true
 # Kubernetes 1.16
-- version: "v1.16.2"
-  default: false
-- version: "v1.16.3"
-  default: false
-- version: "v1.16.4"
-  default: false
-- version: "v1.16.6"
-  default: false
-- version: "v1.16.7"
+- version: "v1.16.13"
   default: false
 # Kubernetes 1.17
 - version: "v1.17.0"

--- a/docs/zz_generated.kubermaticConfiguration.yaml
+++ b/docs/zz_generated.kubermaticConfiguration.yaml
@@ -183,13 +183,9 @@ spec:
       - from: 1.16.*
         to: 1.16.*
         automatic: false
-      # CVE-2019-11253
-      - from: <= 1.16.1, >= 1.16.0
-        to: 1.16.2
-        automatic: true
-      # Released with broken Anago
-      - from: 1.16.5
-        to: 1.16.6
+      # CVE-2019-11253, CVE-2020-8559
+      - from: <= 1.16.12, >= 1.16.0
+        to: 1.16.13
         automatic: true
       # Allow to next minor release
       - from: 1.16.*
@@ -239,15 +235,7 @@ spec:
       - version: "v1.15.10"
         default: true
       # Kubernetes 1.16
-      - version: "v1.16.2"
-        default: false
-      - version: "v1.16.3"
-        default: false
-      - version: "v1.16.4"
-        default: false
-      - version: "v1.16.6"
-        default: false
-      - version: "v1.16.7"
+      - version: "v1.16.13"
         default: false
       # Kubernetes 1.17
       - version: "v1.17.0"


### PR DESCRIPTION
**Special notes for your reviewer**:
CVE fixes

-->
```release-note
Added Kubernetes v1.16.13, and removed v1.16.2-7
```
