### PR TITLE
[release/v2.12] add Kubernetes v1.16.13 to default versions and remove earlier versions of 1.16

### DIFF
--- a/.prow.yaml
+++ b/.prow.yaml
@@ -15,7 +15,7 @@ presubmits:
       - image: docker.io/kubermatic/kubernetes-test-binaries:v0.10.8
         env:
         - name: VERSIONS_TO_TEST
-          value: "v1.16.2"
+          value: "v1.16.13"
         command:
         - "./api/hack/ci-run-minimal-conformance-tests.sh"
         # docker-in-docker needs privileged mode
@@ -527,7 +527,7 @@ presubmits:
       - image: docker.io/kubermatic/kubernetes-test-binaries:v0.10.8
         env:
         - name: VERSIONS_TO_TEST
-          value: "v1.16.6"
+          value: "v1.16.13"
         - name: PROVIDER
           value: "azure"
         - name: DEFAULT_TIMEOUT_MINUTES
@@ -738,7 +738,7 @@ presubmits:
       - image: kubermatic/kubernetes-test-binaries:v0.10.8
         env:
         - name: VERSIONS_TO_TEST
-          value: "v1.16.3"
+          value: "v1.16.13"
         - name: PROVIDER
           value: "openstack"
         - name: DEFAULT_TIMEOUT_MINUTES
@@ -775,7 +775,7 @@ presubmits:
       - image: kubermatic/kubernetes-test-binaries:v0.10.8
         env:
         - name: VERSIONS_TO_TEST
-          value: "v1.16.3"
+          value: "v1.16.13"
         - name: PROVIDER
           value: "openstack"
         - name: DEFAULT_TIMEOUT_MINUTES
@@ -812,7 +812,7 @@ presubmits:
       - image: kubermatic/kubernetes-test-binaries:v0.10.8
         env:
         - name: VERSIONS_TO_TEST
-          value: "v1.16.3"
+          value: "v1.16.13"
         - name: PROVIDER
           value: "openstack"
         - name: DEFAULT_TIMEOUT_MINUTES

--- a/config/kubermatic/Chart.yaml
+++ b/config/kubermatic/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: kubermatic
-version: 1.0.25
+version: 1.0.26
 appVersion: '__KUBERMATIC_TAG__'
 description: Kubermatic chart for master and/or seed clusters.
 keywords:

--- a/config/kubermatic/static/master/updates.yaml
+++ b/config/kubermatic/static/master/updates.yaml
@@ -69,13 +69,9 @@ updates:
 - from: 1.16.*
   to: 1.16.*
   automatic: false
-# CVE-2019-11253
-- from: <= 1.16.1, >= 1.16.0
-  to: 1.16.2
-  automatic: true
-# Released with broken Anago
-- from: 1.16.5
-  to: 1.16.6
+# CVE-2019-11253, CVE-2020-8559
+- from: <= 1.16.12, >= 1.16.0
+  to: 1.16.13
   automatic: true
 # Allow to next minor release
 - from: 1.16.*

--- a/config/kubermatic/static/master/versions.yaml
+++ b/config/kubermatic/static/master/versions.yaml
@@ -11,15 +11,7 @@ versions:
 - version: "v1.15.10"
   default: true
 # Kubernetes 1.16
-- version: "v1.16.2"
-  default: false
-- version: "v1.16.3"
-  default: false
-- version: "v1.16.4"
-  default: false
-- version: "v1.16.6"
-  default: false
-- version: "v1.16.7"
+- version: "v1.16.13"
   default: false
 # OpenShift 4.1.9
 - version: "v4.1.9"


### PR DESCRIPTION
**Special notes for your reviewer**:
CVE fixes

```release-note
Added Kubernetes v1.16.13, and removed v1.16.2-7
```
