### PR TITLE
[release/v2.14] add Kubernetes v1.17.9 to default versions and remove earlier versions of 1.17

### DIFF
--- a/.prow.yaml
+++ b/.prow.yaml
@@ -356,7 +356,7 @@ presubmits:
         - name: KUBERMATIC_EDITION
           value: ee
         - name: VERSIONS_TO_TEST
-          value: "v1.17.5"
+          value: "v1.17.9"
         - name: EXCLUDE_DISTRIBUTIONS
           value: "centos,ubuntu,flatcar,rhel"
         - name: SERVICE_ACCOUNT_KEY

--- a/api/pkg/controller/operator/common/defaults.go
+++ b/api/pkg/controller/operator/common/defaults.go
@@ -185,7 +185,7 @@ var (
 	}
 
 	DefaultKubernetesVersioning = operatorv1alpha1.KubermaticVersioningConfiguration{
-		Default: semver.MustParse("v1.17.5"),
+		Default: semver.MustParse("v1.17.9"),
 		Versions: []*semver.Version{
 			// Kubernetes 1.15
 			semver.MustParse("v1.15.5"),
@@ -197,10 +197,7 @@ var (
 			// Kubernetes 1.16
 			semver.MustParse("v1.16.13"),
 			// Kubernetes 1.17
-			semver.MustParse("v1.17.0"),
-			semver.MustParse("v1.17.2"),
-			semver.MustParse("v1.17.3"),
-			semver.MustParse("v1.17.5"),
+			semver.MustParse("v1.17.9"),
 			// Kubernetes 1.18
 			semver.MustParse("v1.18.2"),
 		},
@@ -272,9 +269,9 @@ var (
 				To:   "1.17.*",
 			},
 			{
-				// Released with broken Anago
-				From:      "1.17.1",
-				To:        "1.17.2",
+				// CVE-2020-8559
+				From:      "<= 1.17.8, >= 1.17.0",
+				To:        "1.17.9",
 				Automatic: pointer.BoolPtr(true),
 			},
 			{

--- a/config/kubermatic/Chart.yaml
+++ b/config/kubermatic/Chart.yaml
@@ -14,7 +14,7 @@
 
 apiVersion: v1
 name: kubermatic
-version: 1.1.1
+version: 1.1.2
 appVersion: '__KUBERMATIC_TAG__'
 description: Kubermatic chart for master and/or seed clusters.
 keywords:

--- a/config/kubermatic/static/master/updates.yaml
+++ b/config/kubermatic/static/master/updates.yaml
@@ -39,8 +39,8 @@ updates:
   to: 1.17.*
   type: kubernetes
 - automatic: true
-  from: 1.17.1
-  to: 1.17.2
+  from: <= 1.17.8, >= 1.17.0
+  to: 1.17.9
   type: kubernetes
 - from: 1.17.*
   to: 1.18.*

--- a/config/kubermatic/static/master/versions.yaml
+++ b/config/kubermatic/static/master/versions.yaml
@@ -15,15 +15,9 @@ versions:
   version: 1.15.11
 - type: kubernetes
   version: 1.16.13
-- type: kubernetes
-  version: 1.17.0
-- type: kubernetes
-  version: 1.17.2
-- type: kubernetes
-  version: 1.17.3
 - default: true
   type: kubernetes
-  version: 1.17.5
+  version: 1.17.9
 - type: kubernetes
   version: 1.18.2
 - type: openshift

--- a/docs/zz_generated.kubermaticConfiguration.yaml
+++ b/docs/zz_generated.kubermaticConfiguration.yaml
@@ -402,7 +402,7 @@ spec:
     # Kubernetes configures the Kubernetes versions and updates.
     kubernetes:
       # Default is the default version to offer users.
-      default: 1.17.5
+      default: 1.17.9
       # Updates is a list of available and automatic upgrades.
       # All 'to' versions must be configured in the version list for this orchestrator.
       # Each update may optionally be configured to be 'automatic: true', in which case the
@@ -448,8 +448,8 @@ spec:
       - from: 1.17.*
         to: 1.17.*
       - automatic: true
-        from: 1.17.1
-        to: 1.17.2
+        from: <= 1.17.8, >= 1.17.0
+        to: 1.17.9
       - from: 1.17.*
         to: 1.18.*
       - from: 1.18.*
@@ -463,10 +463,7 @@ spec:
       - 1.15.10
       - 1.15.11
       - 1.16.13
-      - 1.17.0
-      - 1.17.2
-      - 1.17.3
-      - 1.17.5
+      - 1.17.9
       - 1.18.2
     # Openshift configures the Openshift versions and updates.
     openshift:


### PR DESCRIPTION
**Special notes for your reviewer**:
CVE fixes

```release-note
Added Kubernetes v1.17.9, and removed v1.17.0-5
```
