### PR TITLE
[release/v2.13] add Kubernetes v1.17.9 to default versions and remove earlier versions of 1.17

### DIFF
--- a/.prow.yaml
+++ b/.prow.yaml
@@ -901,7 +901,7 @@ presubmits:
       - image: quay.io/kubermatic/e2e-kind:with-conformance-tests-v1.0.14
         env:
         - name: VERSIONS_TO_TEST
-          value: "v1.17.0"
+          value: "v1.17.9"
         - name: SERVICE_ACCOUNT_KEY
           valueFrom:
             secretKeyRef:
@@ -1062,7 +1062,7 @@ presubmits:
       - image: quay.io/kubermatic/e2e-kind:with-conformance-tests-v1.0.14
         env:
         - name: VERSIONS_TO_TEST
-          value: "v1.17.0"
+          value: "v1.17.9"
         - name: KUBERMATIC_USE_OPERATOR
           value: "true"
         - name: ONLY_TEST_CREATION

--- a/api/pkg/controller/operator/common/defaults.go
+++ b/api/pkg/controller/operator/common/defaults.go
@@ -424,11 +424,7 @@ versions:
 - version: "v1.16.13"
   default: false
 # Kubernetes 1.17
-- version: "v1.17.0"
-  default: false
-- version: "v1.17.2"
-  default: false
-- version: "v1.17.3"
+- version: "v1.17.9"
   default: false
 # OpenShift 4.1.9
 - version: "v4.1.9"
@@ -530,9 +526,9 @@ updates:
 - from: 1.17.*
   to: 1.17.*
   automatic: false
-# Released with broken Anago
-- from: 1.17.1
-  to: 1.17.2
+# CVE-2020-8559
+- from: <= 1.17.8, >= 1.17.0
+  to: 1.17.9
   automatic: true
 # Allow to next minor release
 - from: 1.16.*

--- a/config/kubermatic/Chart.yaml
+++ b/config/kubermatic/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: kubermatic
-version: 1.0.42
+version: 1.0.43
 appVersion: '__KUBERMATIC_TAG__'
 description: Kubermatic chart for master and/or seed clusters.
 keywords:

--- a/config/kubermatic/static/master/updates.yaml
+++ b/config/kubermatic/static/master/updates.yaml
@@ -87,9 +87,9 @@ updates:
 - from: 1.17.*
   to: 1.17.*
   automatic: false
-# Released with broken Anago
-- from: 1.17.1
-  to: 1.17.2
+# CVE-2020-8559
+- from: <= 1.17.8, >= 1.17.0
+  to: 1.17.9
   automatic: true
 # Allow to next minor release
 - from: 1.16.*

--- a/config/kubermatic/static/master/versions.yaml
+++ b/config/kubermatic/static/master/versions.yaml
@@ -18,11 +18,7 @@ versions:
 - version: "v1.16.13"
   default: false
 # Kubernetes 1.17
-- version: "v1.17.0"
-  default: false
-- version: "v1.17.2"
-  default: false
-- version: "v1.17.3"
+- version: "v1.17.9"
   default: false
 # OpenShift 4.1.9
 - version: "v4.1.9"

--- a/docs/zz_generated.kubermaticConfiguration.yaml
+++ b/docs/zz_generated.kubermaticConfiguration.yaml
@@ -197,9 +197,9 @@ spec:
       - from: 1.17.*
         to: 1.17.*
         automatic: false
-      # Released with broken Anago
-      - from: 1.17.1
-        to: 1.17.2
+      # CVE-2020-8559
+      - from: <= 1.17.8, >= 1.17.0
+        to: 1.17.9
         automatic: true
       # Allow to next minor release
       - from: 1.16.*
@@ -238,11 +238,7 @@ spec:
       - version: "v1.16.13"
         default: false
       # Kubernetes 1.17
-      - version: "v1.17.0"
-        default: false
-      - version: "v1.17.2"
-        default: false
-      - version: "v1.17.3"
+      - version: "v1.17.9"
         default: false
       # OpenShift 4.1.9
       - version: "v4.1.9"


### PR DESCRIPTION
**Special notes for your reviewer**:
CVE fixes

```release-note
Added Kubernetes v1.17.9, and removed v1.17.0-3
```
