### PR TITLE
Add Kubernetes v1.18.6 to default versions and remove earlier versions of 1.18

### DIFF
--- a/.prow.yaml
+++ b/.prow.yaml
@@ -384,7 +384,7 @@ presubmits:
         - name: KUBERMATIC_EDITION
           value: ee
         - name: VERSIONS_TO_TEST
-          value: "v1.18.2"
+          value: "v1.18.6"
         - name: EXCLUDE_DISTRIBUTIONS
           value: "centos,ubuntu,flatcar,rhel"
         - name: SERVICE_ACCOUNT_KEY
@@ -423,7 +423,7 @@ presubmits:
         - name: KUBERMATIC_EDITION
           value: ee
         - name: VERSIONS_TO_TEST
-          value: "v1.18.2"
+          value: "v1.18.6"
         - name: EXCLUDE_DISTRIBUTIONS
           value: "centos,ubuntu,coreos,rhel"
         - name: SERVICE_ACCOUNT_KEY
@@ -466,7 +466,7 @@ presubmits:
         - name: KUBERMATIC_EDITION
           value: ee
         - name: VERSIONS_TO_TEST
-          value: "v1.18.2"
+          value: "v1.18.6"
         - name: EXCLUDE_DISTRIBUTIONS
           value: "centos,ubuntu,flatcar,rhel"
         - name: PROVIDER
@@ -510,7 +510,7 @@ presubmits:
         - name: KUBERMATIC_EDITION
           value: ee
         - name: VERSIONS_TO_TEST
-          value: "v1.18.2"
+          value: "v1.18.6"
         - name: PROVIDER
           value: "gcp"
         - name: EXCLUDE_DISTRIBUTIONS
@@ -551,7 +551,7 @@ presubmits:
         - name: KUBERMATIC_EDITION
           value: ee
         - name: VERSIONS_TO_TEST
-          value: "v1.18.2"
+          value: "v1.18.6"
         - name: PROVIDER
           value: "gcp"
         - name: EXCLUDE_DISTRIBUTIONS
@@ -597,7 +597,7 @@ presubmits:
         - name: KUBERMATIC_EDITION
           value: ee
         - name: VERSIONS_TO_TEST
-          value: "v1.18.2"
+          value: "v1.18.6"
         - name: EXCLUDE_DISTRIBUTIONS
           value: "ubuntu,coreos,flatcar,rhel"
         - name: PROVIDER
@@ -638,7 +638,7 @@ presubmits:
         - name: KUBERMATIC_EDITION
           value: ee
         - name: VERSIONS_TO_TEST
-          value: "v1.18.2"
+          value: "v1.18.6"
         - name: PROVIDER
           value: "packet"
         - name: EXCLUDE_DISTRIBUTIONS
@@ -679,7 +679,7 @@ presubmits:
         - name: KUBERMATIC_EDITION
           value: ee
         - name: VERSIONS_TO_TEST
-          value: "v1.18.2"
+          value: "v1.18.6"
         - name: PROVIDER
           value: "kubevirt"
         - name: EXCLUDE_DISTRIBUTIONS
@@ -720,7 +720,7 @@ presubmits:
         - name: KUBERMATIC_EDITION
           value: ee
         - name: VERSIONS_TO_TEST
-          value: "v1.18.2"
+          value: "v1.18.6"
         - name: PROVIDER
           value: "hetzner"
         # Hetzner doesn't support coreos
@@ -764,7 +764,7 @@ presubmits:
         - name: KUBERMATIC_EDITION
           value: ee
         - name: VERSIONS_TO_TEST
-          value: "v1.18.2"
+          value: "v1.18.6"
         - name: PROVIDER
           value: "openstack"
         - name: EXCLUDE_DISTRIBUTIONS
@@ -807,7 +807,7 @@ presubmits:
         - name: KUBERMATIC_EDITION
           value: ee
         - name: VERSIONS_TO_TEST
-          value: "v1.18.2"
+          value: "v1.18.6"
         - name: PROVIDER
           value: "openstack"
         - name: DEFAULT_TIMEOUT_MINUTES
@@ -850,7 +850,7 @@ presubmits:
         - name: KUBERMATIC_EDITION
           value: ee
         - name: VERSIONS_TO_TEST
-          value: "v1.18.2"
+          value: "v1.18.6"
         - name: PROVIDER
           value: "openstack"
         - name: DEFAULT_TIMEOUT_MINUTES
@@ -893,7 +893,7 @@ presubmits:
         - name: KUBERMATIC_EDITION
           value: ee
         - name: VERSIONS_TO_TEST
-          value: "v1.18.2"
+          value: "v1.18.6"
         - name: PROVIDER
           value: "vsphere"
         - name: EXCLUDE_DISTRIBUTIONS
@@ -935,7 +935,7 @@ presubmits:
         - name: KUBERMATIC_EDITION
           value: ee
         - name: VERSIONS_TO_TEST
-          value: "v1.18.2"
+          value: "v1.18.6"
         - name: PROVIDER
           value: "vsphere"
         - name: EXCLUDE_DISTRIBUTIONS
@@ -1071,7 +1071,7 @@ presubmits:
         - name: EXCLUDE_DISTRIBUTIONS
           value: ubuntu,centos,sles,rhel,flatcar
         - name: VERSIONS_TO_TEST
-          value: "v1.18.2"
+          value: "v1.18.6"
         - name: KUBERMATIC_USE_OPERATOR
           value: "true"
         - name: ONLY_TEST_CREATION

--- a/charts/kubermatic/Chart.yaml
+++ b/charts/kubermatic/Chart.yaml
@@ -14,7 +14,7 @@
 
 apiVersion: v1
 name: kubermatic
-version: 1.1.7
+version: 1.1.8
 appVersion: '__KUBERMATIC_TAG__'
 description: Kubermatic chart for master and/or seed clusters.
 keywords:

--- a/charts/kubermatic/static/master/updates.yaml
+++ b/charts/kubermatic/static/master/updates.yaml
@@ -48,6 +48,10 @@ updates:
 - from: 1.18.*
   to: 1.18.*
   type: kubernetes
+- automatic: true
+  from: <= 1.18.5, >= 1.18.0
+  to: 1.18.6
+  type: kubernetes
 - from: 4.1.*
   to: 4.1.*
   type: openshift

--- a/charts/kubermatic/static/master/versions.yaml
+++ b/charts/kubermatic/static/master/versions.yaml
@@ -21,7 +21,7 @@ versions:
   type: kubernetes
   version: 1.17.9
 - type: kubernetes
-  version: 1.18.2
+  version: 1.18.6
 - type: openshift
   version: 4.1.9
 - default: true

--- a/docs/zz_generated.kubermaticConfiguration.yaml
+++ b/docs/zz_generated.kubermaticConfiguration.yaml
@@ -443,6 +443,9 @@ spec:
         to: 1.18.*
       - from: 1.18.*
         to: 1.18.*
+      - automatic: true
+        from: <= 1.18.5, >= 1.18.0
+        to: 1.18.6
       # Versions lists the available versions.
       versions:
       - 1.15.5
@@ -454,7 +457,7 @@ spec:
       - 1.15.12
       - 1.16.13
       - 1.17.9
-      - 1.18.2
+      - 1.18.6
     # Openshift configures the Openshift versions and updates.
     openshift:
       # Default is the default version to offer users.

--- a/pkg/controller/operator/common/defaults.go
+++ b/pkg/controller/operator/common/defaults.go
@@ -201,7 +201,7 @@ var (
 			// Kubernetes 1.17
 			semver.MustParse("v1.17.9"),
 			// Kubernetes 1.18
-			semver.MustParse("v1.18.2"),
+			semver.MustParse("v1.18.6"),
 		},
 		Updates: []operatorv1alpha1.Update{
 			// ======= 1.14 =======
@@ -287,6 +287,14 @@ var (
 				// Allow to change to any patch version
 				From: "1.18.*",
 				To:   "1.18.*",
+			},
+			{
+				// CVE-2020-8559
+				// Releases from 1.18.0 to 1.18.2 also do not work with CentOS7
+				// https://github.com/kubernetes/kubernetes/pull/90678
+				From:      "<= 1.18.5, >= 1.18.0",
+				To:        "1.18.6",
+				Automatic: pointer.BoolPtr(true),
 			},
 		},
 	}


### PR DESCRIPTION
**What this PR does / why we need it**:
`kube-proxy` versions 1.18.0, 1.18.1 and 1.18.2 are impacted by a bug impacting CentOS7.

See: https://github.com/kubermatic/machine-controller/issues/795

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Documentation**:
<!-- Add links to the related documentation changes related to this pull request. E.g. the link to the kubermatic/docs pullrequest. -->

**Does this PR introduce a user-facing change?**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If  no release note is required, just write "NONE".
-->
```release-note
NONE
```
