### PR TITLE
fix GetUpgradesEndpoint to return list instead object

### DIFF
--- a/pkg/handler/v1/cluster/upgrade.go
+++ b/pkg/handler/v1/cluster/upgrade.go
@@ -76,7 +76,7 @@ func GetUpgradesEndpoint(updateManager common.UpdateManager, projectProvider pro
 			return nil, err
 		}
 
-		var upgrades []*apiv1.MasterVersion
+		upgrades := make([]*apiv1.MasterVersion, 0)
 		for _, v := range versions {
 			isRestricted := false
 			if clusterType == apiv1.KubernetesClusterType {


### PR DESCRIPTION
**What this PR does / why we need it**: fix GetUpgradesEndpoint to return a list instead of an object when the list is nil

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #5663


```release-note
NONE
```
