### PR TITLE
unsubscribe the pubsub on user watch websocket close

### DIFF
--- a/pkg/handler/websocket/user_test.go
+++ b/pkg/handler/websocket/user_test.go
@@ -110,6 +110,10 @@ func TestUserWatchEndpoint(t *testing.T) {
 			}
 
 			// Update user to get watch notification
+			// Sleep for just a bit so the subscription gets set up in the api server. This is due to a race condition
+			// can happen when there are changes to the watched user right after the ws connection is established.
+			// Without this the test is flaky.
+			time.Sleep(time.Second)
 			userToUpdate, err := cli.FakeKubermaticClient.KubermaticV1().Users().Get(tc.userToUpdate, metav1.GetOptions{})
 			if err != nil {
 				t.Fatalf("error getting user to update: %v", err)

--- a/pkg/watcher/kubernetes/settings.go
+++ b/pkg/watcher/kubernetes/settings.go
@@ -85,6 +85,6 @@ func (watcher *SettingsWatcher) run() {
 }
 
 // Subscribe allows to register subscription handler which will be invoked on each settings change.
-func (watcher *SettingsWatcher) Subscribe(subscription pubsub.Subscription) {
-	watcher.publisher.Subscribe(subscription)
+func (watcher *SettingsWatcher) Subscribe(subscription pubsub.Subscription) pubsub.Unsubscriber {
+	return watcher.publisher.Subscribe(subscription)
 }

--- a/pkg/watcher/kubernetes/user.go
+++ b/pkg/watcher/kubernetes/user.go
@@ -101,6 +101,6 @@ func (watcher *UserWatcher) CalculateHash(id string) (uint64, error) {
 }
 
 // Subscribe allows to register subscription handler which will be invoked on each user change.
-func (watcher *UserWatcher) Subscribe(subscription pubsub.Subscription, opts ...pubsub.SubscribeOption) {
-	watcher.publisher.Subscribe(subscription, opts...)
+func (watcher *UserWatcher) Subscribe(subscription pubsub.Subscription, opts ...pubsub.SubscribeOption) pubsub.Unsubscriber {
+	return watcher.publisher.Subscribe(subscription, opts...)
 }

--- a/pkg/watcher/types.go
+++ b/pkg/watcher/types.go
@@ -31,10 +31,10 @@ type Providers struct {
 }
 
 type SettingsWatcher interface {
-	Subscribe(subscription pubsub.Subscription)
+	Subscribe(subscription pubsub.Subscription) pubsub.Unsubscriber
 }
 
 type UserWatcher interface {
-	Subscribe(subscription pubsub.Subscription, opts ...pubsub.SubscribeOption)
+	Subscribe(subscription pubsub.Subscription, opts ...pubsub.SubscribeOption) pubsub.Unsubscriber
 	CalculateHash(id string) (uint64, error)
 }


### PR DESCRIPTION
**What this PR does / why we need it**:
Unsubscribes the pubsub user watch for user which websocket connection is closed.

**Does this PR introduce a user-facing change?**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If  no release note is required, just write "NONE".
-->
```release-note
NONE
```
