### PR TITLE
[release/v2.14] add Kubernetes v1.18.6 to default versions and remove earlier versions of 1.18

### DIFF
--- a/.prow.yaml
+++ b/.prow.yaml
@@ -395,7 +395,7 @@ presubmits:
         - name: KUBERMATIC_EDITION
           value: ee
         - name: VERSIONS_TO_TEST
-          value: "v1.18.2"
+          value: "v1.18.6"
         - name: EXCLUDE_DISTRIBUTIONS
           value: "centos,ubuntu,flatcar,rhel"
         - name: SERVICE_ACCOUNT_KEY
@@ -434,7 +434,7 @@ presubmits:
         - name: KUBERMATIC_EDITION
           value: ee
         - name: VERSIONS_TO_TEST
-          value: "v1.18.2"
+          value: "v1.18.6"
         - name: EXCLUDE_DISTRIBUTIONS
           value: "centos,ubuntu,coreos,rhel"
         - name: SERVICE_ACCOUNT_KEY
@@ -477,7 +477,7 @@ presubmits:
         - name: KUBERMATIC_EDITION
           value: ee
         - name: VERSIONS_TO_TEST
-          value: "v1.18.2"
+          value: "v1.18.6"
         - name: EXCLUDE_DISTRIBUTIONS
           value: "centos,ubuntu,flatcar,rhel"
         - name: PROVIDER
@@ -521,7 +521,7 @@ presubmits:
         - name: KUBERMATIC_EDITION
           value: ee
         - name: VERSIONS_TO_TEST
-          value: "v1.18.2"
+          value: "v1.18.6"
         - name: PROVIDER
           value: "gcp"
         - name: EXCLUDE_DISTRIBUTIONS
@@ -562,7 +562,7 @@ presubmits:
         - name: KUBERMATIC_EDITION
           value: ee
         - name: VERSIONS_TO_TEST
-          value: "v1.18.2"
+          value: "v1.18.6"
         - name: PROVIDER
           value: "gcp"
         - name: EXCLUDE_DISTRIBUTIONS
@@ -608,7 +608,7 @@ presubmits:
         - name: KUBERMATIC_EDITION
           value: ee
         - name: VERSIONS_TO_TEST
-          value: "v1.18.2"
+          value: "v1.18.6"
         - name: EXCLUDE_DISTRIBUTIONS
           value: "ubuntu,coreos,flatcar,rhel"
         - name: PROVIDER
@@ -649,7 +649,7 @@ presubmits:
         - name: KUBERMATIC_EDITION
           value: ee
         - name: VERSIONS_TO_TEST
-          value: "v1.18.2"
+          value: "v1.18.6"
         - name: PROVIDER
           value: "packet"
         - name: EXCLUDE_DISTRIBUTIONS
@@ -690,7 +690,7 @@ presubmits:
         - name: KUBERMATIC_EDITION
           value: ee
         - name: VERSIONS_TO_TEST
-          value: "v1.18.2"
+          value: "v1.18.6"
         - name: PROVIDER
           value: "kubevirt"
         - name: EXCLUDE_DISTRIBUTIONS
@@ -731,7 +731,7 @@ presubmits:
         - name: KUBERMATIC_EDITION
           value: ee
         - name: VERSIONS_TO_TEST
-          value: "v1.18.2"
+          value: "v1.18.6"
         - name: PROVIDER
           value: "hetzner"
         # Hetzner doesn't support coreos
@@ -775,7 +775,7 @@ presubmits:
         - name: KUBERMATIC_EDITION
           value: ee
         - name: VERSIONS_TO_TEST
-          value: "v1.18.2"
+          value: "v1.18.6"
         - name: PROVIDER
           value: "openstack"
         - name: EXCLUDE_DISTRIBUTIONS
@@ -818,7 +818,7 @@ presubmits:
         - name: KUBERMATIC_EDITION
           value: ee
         - name: VERSIONS_TO_TEST
-          value: "v1.18.2"
+          value: "v1.18.6"
         - name: PROVIDER
           value: "openstack"
         - name: DEFAULT_TIMEOUT_MINUTES
@@ -861,7 +861,7 @@ presubmits:
         - name: KUBERMATIC_EDITION
           value: ee
         - name: VERSIONS_TO_TEST
-          value: "v1.18.2"
+          value: "v1.18.6"
         - name: PROVIDER
           value: "openstack"
         - name: DEFAULT_TIMEOUT_MINUTES
@@ -904,7 +904,7 @@ presubmits:
         - name: KUBERMATIC_EDITION
           value: ee
         - name: VERSIONS_TO_TEST
-          value: "v1.18.2"
+          value: "v1.18.6"
         - name: PROVIDER
           value: "vsphere"
         - name: EXCLUDE_DISTRIBUTIONS
@@ -946,7 +946,7 @@ presubmits:
         - name: KUBERMATIC_EDITION
           value: ee
         - name: VERSIONS_TO_TEST
-          value: "v1.18.2"
+          value: "v1.18.6"
         - name: PROVIDER
           value: "vsphere"
         - name: EXCLUDE_DISTRIBUTIONS
@@ -1082,7 +1082,7 @@ presubmits:
         - name: EXCLUDE_DISTRIBUTIONS
           value: ubuntu,centos,sles,rhel,flatcar
         - name: VERSIONS_TO_TEST
-          value: "v1.18.2"
+          value: "v1.18.6"
         - name: KUBERMATIC_USE_OPERATOR
           value: "true"
         - name: ONLY_TEST_CREATION

--- a/api/pkg/controller/operator/common/defaults.go
+++ b/api/pkg/controller/operator/common/defaults.go
@@ -199,7 +199,7 @@ var (
 			// Kubernetes 1.17
 			semver.MustParse("v1.17.9"),
 			// Kubernetes 1.18
-			semver.MustParse("v1.18.2"),
+			semver.MustParse("v1.18.6"),
 		},
 		Updates: []operatorv1alpha1.Update{
 			// ======= 1.14 =======
@@ -285,6 +285,14 @@ var (
 				// Allow to change to any patch version
 				From: "1.18.*",
 				To:   "1.18.*",
+			},
+			{
+				// CVE-2020-8559
+				// Releases from 1.18.0 to 1.18.2 also do not work with CentOS7
+				// https://github.com/kubernetes/kubernetes/pull/90678
+				From:      "<= 1.18.5, >= 1.18.0",
+				To:        "1.18.6",
+				Automatic: pointer.BoolPtr(true),
 			},
 		},
 	}

--- a/config/kubermatic/Chart.yaml
+++ b/config/kubermatic/Chart.yaml
@@ -14,7 +14,7 @@
 
 apiVersion: v1
 name: kubermatic
-version: 1.1.2
+version: 1.1.3
 appVersion: '__KUBERMATIC_TAG__'
 description: Kubermatic chart for master and/or seed clusters.
 keywords:

--- a/config/kubermatic/static/master/updates.yaml
+++ b/config/kubermatic/static/master/updates.yaml
@@ -48,6 +48,10 @@ updates:
 - from: 1.18.*
   to: 1.18.*
   type: kubernetes
+- automatic: true
+  from: <= 1.18.5, >= 1.18.0
+  to: 1.18.6
+  type: kubernetes
 - from: 4.1.*
   to: 4.1.*
   type: openshift

--- a/config/kubermatic/static/master/versions.yaml
+++ b/config/kubermatic/static/master/versions.yaml
@@ -19,7 +19,7 @@ versions:
   type: kubernetes
   version: 1.17.9
 - type: kubernetes
-  version: 1.18.2
+  version: 1.18.6
 - type: openshift
   version: 4.1.9
 - default: true

--- a/docs/zz_generated.kubermaticConfiguration.yaml
+++ b/docs/zz_generated.kubermaticConfiguration.yaml
@@ -454,6 +454,9 @@ spec:
         to: 1.18.*
       - from: 1.18.*
         to: 1.18.*
+      - automatic: true
+        from: <= 1.18.5, >= 1.18.0
+        to: 1.18.6
       # Versions lists the available versions.
       versions:
       - 1.15.5
@@ -464,7 +467,7 @@ spec:
       - 1.15.11
       - 1.16.13
       - 1.17.9
-      - 1.18.2
+      - 1.18.6
     # Openshift configures the Openshift versions and updates.
     openshift:
       # Default is the default version to offer users.


### PR DESCRIPTION

```release-note
Added Kubernetes v1.18.6, and removed v1.18.2
```
