### PR TITLE
add GNU tar to util image, bump dependencies

### DIFF
--- a/.prow.yaml
+++ b/.prow.yaml
@@ -64,7 +64,7 @@ presubmits:
     clone_uri: "ssh://git@github.com/kubermatic/kubermatic.git"
     spec:
       containers:
-      - image: quay.io/kubermatic/util:1.3.0
+      - image: quay.io/kubermatic/util:1.3.5
         command:
         - "./hack/verify-chart-versions.sh"
         resources:
@@ -104,7 +104,7 @@ presubmits:
     clone_uri: "ssh://git@github.com/kubermatic/kubermatic.git"
     spec:
       containers:
-      - image: quay.io/kubermatic/util:1.3.0
+      - image: quay.io/kubermatic/util:1.3.5
         command:
         - "./hack/verify-grafana-dashboards.sh"
         resources:

--- a/charts/kubermatic/Chart.yaml
+++ b/charts/kubermatic/Chart.yaml
@@ -14,7 +14,7 @@
 
 apiVersion: v1
 name: kubermatic
-version: 1.1.8
+version: 1.1.9
 appVersion: '__KUBERMATIC_TAG__'
 description: Kubermatic chart for master and/or seed clusters.
 keywords:

--- a/charts/kubermatic/values.yaml
+++ b/charts/kubermatic/values.yaml
@@ -71,7 +71,7 @@ kubermatic:
       helmVersion: "v2.11.0"
       image:
         repository: "quay.io/kubermatic/util"
-        tag: "1.3.4"
+        tag: "1.3.5"
 
   etcd:
     # PV size for the etcd StatefulSet of new clusters

--- a/charts/logging/kibana/Chart.yaml
+++ b/charts/logging/kibana/Chart.yaml
@@ -14,7 +14,7 @@
 
 apiVersion: v1
 name: kibana
-version: 1.0.11
+version: 1.0.12
 appVersion: 6.8.5
 description: "[DEPRECATED] Kibana is a User Interface for Elasticsearch"
 keywords:

--- a/charts/logging/kibana/values.yaml
+++ b/charts/logging/kibana/values.yaml
@@ -30,7 +30,7 @@ logging:
     setupContainer:
       image:
         repository: quay.io/kubermatic/util
-        tag: 1.3.4
+        tag: 1.3.5
         pullPolicy: IfNotPresent
       resources:
         requests:

--- a/charts/minio/Chart.yaml
+++ b/charts/minio/Chart.yaml
@@ -14,7 +14,7 @@
 
 apiVersion: v1
 name: minio
-version: 1.0.15
+version: 1.0.16
 appVersion: RELEASE.2020-06-03T22-13-49Z
 description: minio
 keywords:

--- a/charts/minio/values.yaml
+++ b/charts/minio/values.yaml
@@ -35,7 +35,7 @@ minio:
     enabled: true
     image:
       repository: quay.io/kubermatic/util
-      tag: 1.3.4
+      tag: 1.3.5
 
   # If your cluster does not have a default storage class,
   # you can specify the class to use for Minio. Note that

--- a/charts/monitoring/alertmanager/Chart.yaml
+++ b/charts/monitoring/alertmanager/Chart.yaml
@@ -14,7 +14,7 @@
 
 apiVersion: v1
 name: alertmanager
-version: 2.0.10
+version: 2.0.11
 appVersion: v0.20.0
 description: Alertmanager for Kubermatic
 keywords:

--- a/charts/monitoring/alertmanager/values.yaml
+++ b/charts/monitoring/alertmanager/values.yaml
@@ -104,4 +104,4 @@ alertmanager:
     enabled: false
     image:
       repository: quay.io/kubermatic/util
-      tag: 1.3.4
+      tag: 1.3.5

--- a/charts/monitoring/grafana/Chart.yaml
+++ b/charts/monitoring/grafana/Chart.yaml
@@ -14,7 +14,7 @@
 
 apiVersion: v1
 name: grafana
-version: 1.4.2
+version: 1.4.3
 appVersion: 7.0.3
 description: Grafana for Kubermatic
 keywords:

--- a/charts/monitoring/grafana/values.yaml
+++ b/charts/monitoring/grafana/values.yaml
@@ -25,7 +25,7 @@ grafana:
     tag: 7.0.3
   utilImage:
     repository: quay.io/kubermatic/util
-    tag: 1.3.4
+    tag: 1.3.5
   pluginImage:
     repository: quay.io/kubermatic/grafana-plugins
     tag: 1.1.0

--- a/charts/monitoring/karma/Chart.yaml
+++ b/charts/monitoring/karma/Chart.yaml
@@ -14,7 +14,7 @@
 
 apiVersion: v1
 name: karma
-version: 0.0.9
+version: 0.0.10
 appVersion: v0.55
 description: Dashboard for Prometheus Alertmanager
 keywords:

--- a/charts/monitoring/karma/values.yaml
+++ b/charts/monitoring/karma/values.yaml
@@ -41,7 +41,7 @@ karma:
       pullPolicy: IfNotPresent
     initContainer:
       repository: quay.io/kubermatic/util
-      tag: 1.3.4
+      tag: 1.3.5
       pullPolicy: IfNotPresent
   resources:
     karma:

--- a/charts/monitoring/prometheus/Chart.yaml
+++ b/charts/monitoring/prometheus/Chart.yaml
@@ -14,7 +14,7 @@
 
 apiVersion: v1
 name: prometheus
-version: 2.2.20
+version: 2.2.21
 appVersion: v2.17.0
 description: Prometheus Monitoring for Kubernetes
 keywords:

--- a/charts/monitoring/prometheus/values.yaml
+++ b/charts/monitoring/prometheus/values.yaml
@@ -45,7 +45,7 @@ prometheus:
     enabled: true
     image:
       repository: quay.io/kubermatic/util
-      tag: 1.3.4
+      tag: 1.3.5
     timeout: 60m
 
   # Specify additional external labels which will be added to all
@@ -215,7 +215,7 @@ prometheus:
     enabled: false
     image:
       repository: quay.io/kubermatic/util
-      tag: 1.3.4
+      tag: 1.3.5
 
   containers:
     prometheus:

--- a/containers/util/Dockerfile
+++ b/containers/util/Dockerfile
@@ -12,13 +12,13 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-FROM alpine:3.11
+FROM alpine:3.12
 
-ENV MC_VERSION=RELEASE.2020-05-16T01-44-37Z \
-    KUBECTL_VERSION=v1.17.5 \
-    HELM_VERSION=v2.16.7 \
-    VAULT_VERSION=1.3.5 \
-    YQ_VERSION=3.3.0
+ENV MC_VERSION=RELEASE.2020-07-17T02-52-20Z \
+    KUBECTL_VERSION=v1.18.6 \
+    HELM_VERSION=v2.16.9 \
+    VAULT_VERSION=1.4.3 \
+    YQ_VERSION=3.3.2
 
 RUN apk add --no-cache -U \
     bash \
@@ -33,7 +33,8 @@ RUN apk add --no-cache -U \
     openssh-client \
     rsync \
     socat \
-    unzip
+    unzip \
+    tar
 
 RUN curl -Lo /usr/bin/yq https://github.com/mikefarah/yq/releases/download/${YQ_VERSION}/yq_linux_amd64 && \
     chmod +x /usr/bin/yq && \

--- a/containers/util/release.sh
+++ b/containers/util/release.sh
@@ -14,10 +14,13 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+set -euo pipefail
+
 SUFFIX=""
-VERSION=1.3.4
+VERSION=1.3.5
 
-set -euox pipefail
+cd $(dirname $0)
 
+set -x
 docker build --no-cache --pull -t quay.io/kubermatic/util:${VERSION}${SUFFIX} .
 docker push quay.io/kubermatic/util:${VERSION}${SUFFIX}

--- a/hack/ci/ci-github-release.sh
+++ b/hack/ci/ci-github-release.sh
@@ -135,7 +135,7 @@ sed -i "s/__KUBERMATIC_TAG__/$tag/g" charts/kubermatic-operator/*.yaml
 echodate "Uploading kubermatic CE archive..."
 
 archive="kubermatic-ce-$tag.tar.gz"
-# Gnu tar is required
+# GNU tar is required
 tar czf "$archive" \
   --transform='flags=r;s|charts/values.example.ce.yaml|examples/values.example.yaml|' \
   --transform='flags=r;s|charts/test/|examples/|' \
@@ -167,7 +167,7 @@ echodate "Uploading kubermatic EE archive..."
 yq w -i charts/kubermatic-operator/values.yaml 'kubermaticOperator.image.repository' 'quay.io/kubermatic/kubermatic-ee'
 
 archive="kubermatic-ee-$tag.tar.gz"
-# Gnu tar is required
+# GNU tar is required
 tar czf "$archive" \
   --transform='flags=r;s|charts/values.example.ee.yaml|examples/values.example.yaml|' \
   --transform='flags=r;s|charts/test/|examples/|' \

--- a/pkg/controller/master-controller-manager/seed-proxy/resources.go
+++ b/pkg/controller/master-controller-manager/seed-proxy/resources.go
@@ -228,7 +228,7 @@ func masterDeploymentCreator(seed *kubermaticv1.Seed, secret *corev1.Secret) rec
 			d.Spec.Template.Spec.Containers = []corev1.Container{
 				{
 					Name:    "proxy",
-					Image:   "quay.io/kubermatic/util:1.3.4",
+					Image:   "quay.io/kubermatic/util:1.3.5",
 					Command: []string{"/bin/bash"},
 					Args:    []string{"-c", strings.TrimSpace(proxyScript)},
 					Env: []corev1.EnvVar{


### PR DESCRIPTION
**What this PR does / why we need it**:
GNU tar is required for `--transform` to work. This PR therefore adds GNU tar and bumps the other tools in the util image as well.

**Does this PR introduce a user-facing change?**:
```release-note
NONE
```
