### PR TITLE
Fix for panic when user/settings watch connection closes

### DIFF
--- a/pkg/handler/websocket/common.go
+++ b/pkg/handler/websocket/common.go
@@ -23,7 +23,7 @@ import (
 )
 
 // writes close control message to the websocket connection. Same as the default websocket close handler.
-func writeCloseMessage(ws *websocket.Conn, code int) {
+func writeCloseMessage(ws *websocket.Conn, code int) error {
 	message := websocket.FormatCloseMessage(code, "")
-	_ = ws.WriteControl(websocket.CloseMessage, message, time.Now().Add(time.Second))
+	return ws.WriteControl(websocket.CloseMessage, message, time.Now().Add(time.Second))
 }

--- a/pkg/handler/websocket/common.go
+++ b/pkg/handler/websocket/common.go
@@ -1,0 +1,29 @@
+/*
+Copyright 2020 The Kubermatic Kubernetes Platform contributors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package websocket
+
+import (
+	"time"
+
+	"github.com/gorilla/websocket"
+)
+
+// writes close control message to the websocket connection. Same as the default websocket close handler.
+func writeCloseMessage(ws *websocket.Conn, code int) {
+	message := websocket.FormatCloseMessage(code, "")
+	_ = ws.WriteControl(websocket.CloseMessage, message, time.Now().Add(time.Second))
+}

--- a/pkg/handler/websocket/settings.go
+++ b/pkg/handler/websocket/settings.go
@@ -80,6 +80,7 @@ func WriteSettings(providers watcher.Providers, ws *websocket.Conn) {
 
 	ws.SetCloseHandler(func(code int, text string) error {
 		unSub()
-		return ws.CloseHandler()(code, text)
+		writeCloseMessage(ws, code)
+		return nil
 	})
 }

--- a/pkg/handler/websocket/settings.go
+++ b/pkg/handler/websocket/settings.go
@@ -80,7 +80,6 @@ func WriteSettings(providers watcher.Providers, ws *websocket.Conn) {
 
 	ws.SetCloseHandler(func(code int, text string) error {
 		unSub()
-		writeCloseMessage(ws, code)
-		return nil
+		return writeCloseMessage(ws, code)
 	})
 }

--- a/pkg/handler/websocket/user.go
+++ b/pkg/handler/websocket/user.go
@@ -18,6 +18,7 @@ package websocket
 
 import (
 	"encoding/json"
+
 	apiv1 "github.com/kubermatic/kubermatic/pkg/api/v1"
 	v1 "github.com/kubermatic/kubermatic/pkg/crd/kubermatic/v1"
 	"github.com/kubermatic/kubermatic/pkg/log"
@@ -98,6 +99,7 @@ func WriteUser(providers watcher.Providers, ws *websocket.Conn, userEmail string
 
 	ws.SetCloseHandler(func(code int, text string) error {
 		unSub()
-		return ws.CloseHandler()(code, text)
+		writeCloseMessage(ws, code)
+		return nil
 	})
 }

--- a/pkg/handler/websocket/user.go
+++ b/pkg/handler/websocket/user.go
@@ -99,7 +99,6 @@ func WriteUser(providers watcher.Providers, ws *websocket.Conn, userEmail string
 
 	ws.SetCloseHandler(func(code int, text string) error {
 		unSub()
-		writeCloseMessage(ws, code)
-		return nil
+		return writeCloseMessage(ws, code)
 	})
 }


### PR DESCRIPTION
**What this PR does / why we need it**:
fix for the panic that happens on user/settings watch connection close

**Does this PR introduce a user-facing change?**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If  no release note is required, just write "NONE".
-->
```release-note
NONE
```
