### PR TITLE
Use dedicated etcd-launcher image

### DIFF
--- a/cmd/etcd-launcher/Dockerfile
+++ b/cmd/etcd-launcher/Dockerfile
@@ -12,8 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-ARG ETCD_VERSION=v3.4.3
-FROM gcr.io/etcd-development/etcd:$ETCD_VERSION
+FROM busybox
 LABEL maintainer="support@kubermatic.com"
 
-COPY ./_build/etcd-launcher /usr/local/bin/
+COPY ./_build/etcd-launcher /

--- a/hack/ci/ci-setup-kubermatic-in-kind.sh
+++ b/hack/ci/ci-setup-kubermatic-in-kind.sh
@@ -46,13 +46,13 @@ export PATH=$PATH:/usr/local/go/bin
 export SEED_NAME=kubermatic
 
 if [[ -z ${JOB_NAME} ]]; then
-	echo "This script should only be running in a CI environment."
-	exit 1
+  echo "This script should only be running in a CI environment."
+  exit 1
 fi
 
 if [[ -z ${PROW_JOB_ID} ]]; then
-	echo "Build id env variable has to be set."
-	exit 1
+  echo "Build id env variable has to be set."
+  exit 1
 fi
 
 cd "${GOPATH}/src/github.com/kubermatic/kubermatic"
@@ -345,15 +345,11 @@ if [[ "${KUBERMATIC_SKIP_BUILDING}" = "false" ]]; then
     time retry 5 docker push "${IMAGE_NAME}"
   )
   (
-    echodate "Building etcd-launcher images"
-    TEST_NAME="Build etcd-launcher Docker images"
-
-    for ETCD_TAG in $(getEtcdTags); do
-      BASE_TAG=$(echo ${ETCD_TAG} | cut -d\. -f 1,2| tr -d .)
-      IMAGE_NAME="quay.io/kubermatic/etcd-launcher-${BASE_TAG}:${KUBERMATIC_VERSION}"
-      time retry 5 docker build --build-arg ETCD_VERSION=${ETCD_TAG} -t "${IMAGE_NAME}" -f cmd/etcd-launcher/Dockerfile .
-      time retry 5 kind load docker-image "$IMAGE_NAME" --name ${SEED_NAME}
-    done
+    echodate "Building etcd-launcher image"
+    TEST_NAME="Build etcd-launcher Docker image"
+    IMAGE_NAME="quay.io/kubermatic/etcd-launcher:${KUBERMATIC_VERSION}"
+    time retry 5 docker build -t "${IMAGE_NAME}" -f cmd/etcd-launcher/Dockerfile .
+    time retry 5 kind load docker-image "$IMAGE_NAME" --name ${SEED_NAME}
   )
 
   pushElapsed kubermatic_docker_build_duration_milliseconds $beforeDockerBuild

--- a/hack/lib.sh
+++ b/hack/lib.sh
@@ -247,7 +247,3 @@ pushMetric() {
 pushElapsed() {
   pushMetric "$1" $(elapsed $2) "${3:-}" "${4:-}" "${5:-}"
 }
-
-getEtcdTags() {
-  echo $(git grep -h etcdImageTag $(go env GOPATH)/src/github.com/kubermatic/kubermatic/pkg/resources/etcd/statefulset.go | grep -v return | cut -d\  -f 3| tr -d "\"" | xargs echo -n)
-}

--- a/pkg/resources/test/fixtures/statefulset-aws-1.15.0-etcd.yaml
+++ b/pkg/resources/test/fixtures/statefulset-aws-1.15.0-etcd.yaml
@@ -55,7 +55,7 @@ spec:
         - -initial-state
         - $(INITIAL_STATE)
         command:
-        - /usr/local/bin/etcd-launcher
+        - /opt/bin/etcd-launcher
         env:
         - name: POD_NAME
           valueFrom:
@@ -88,7 +88,7 @@ spec:
           value: /etc/etcd/pki/client/apiserver-etcd-client.key
         - name: INITIAL_STATE
           value: new
-        image: 'quay.io/kubermatic/etcd-launcher-v33:'
+        image: gcr.io/etcd-development/etcd:v3.3.18
         imagePullPolicy: IfNotPresent
         livenessProbe:
           failureThreshold: 3
@@ -138,8 +138,22 @@ spec:
         - mountPath: /etc/etcd/pki/client
           name: apiserver-etcd-client-certificate
           readOnly: true
+        - mountPath: /opt/bin/
+          name: launcher
       imagePullSecrets:
       - name: dockercfg
+      initContainers:
+      - command:
+        - /bin/cp
+        - /etcd-launcher
+        - /opt/bin/
+        image: 'quay.io/kubermatic/etcd-launcher:'
+        imagePullPolicy: IfNotPresent
+        name: etcd-launcher-init
+        resources: {}
+        volumeMounts:
+        - mountPath: /opt/bin/
+          name: launcher
       volumes:
       - name: etcd-tls-certificate
         secret:
@@ -153,6 +167,8 @@ spec:
       - name: apiserver-etcd-client-certificate
         secret:
           secretName: apiserver-etcd-client-certificate
+      - emptyDir: {}
+        name: launcher
   updateStrategy:
     type: RollingUpdate
   volumeClaimTemplates:

--- a/pkg/resources/test/fixtures/statefulset-aws-1.16.0-etcd.yaml
+++ b/pkg/resources/test/fixtures/statefulset-aws-1.16.0-etcd.yaml
@@ -55,7 +55,7 @@ spec:
         - -initial-state
         - $(INITIAL_STATE)
         command:
-        - /usr/local/bin/etcd-launcher
+        - /opt/bin/etcd-launcher
         env:
         - name: POD_NAME
           valueFrom:
@@ -88,7 +88,7 @@ spec:
           value: /etc/etcd/pki/client/apiserver-etcd-client.key
         - name: INITIAL_STATE
           value: new
-        image: 'quay.io/kubermatic/etcd-launcher-v33:'
+        image: gcr.io/etcd-development/etcd:v3.3.18
         imagePullPolicy: IfNotPresent
         livenessProbe:
           failureThreshold: 3
@@ -138,8 +138,22 @@ spec:
         - mountPath: /etc/etcd/pki/client
           name: apiserver-etcd-client-certificate
           readOnly: true
+        - mountPath: /opt/bin/
+          name: launcher
       imagePullSecrets:
       - name: dockercfg
+      initContainers:
+      - command:
+        - /bin/cp
+        - /etcd-launcher
+        - /opt/bin/
+        image: 'quay.io/kubermatic/etcd-launcher:'
+        imagePullPolicy: IfNotPresent
+        name: etcd-launcher-init
+        resources: {}
+        volumeMounts:
+        - mountPath: /opt/bin/
+          name: launcher
       volumes:
       - name: etcd-tls-certificate
         secret:
@@ -153,6 +167,8 @@ spec:
       - name: apiserver-etcd-client-certificate
         secret:
           secretName: apiserver-etcd-client-certificate
+      - emptyDir: {}
+        name: launcher
   updateStrategy:
     type: RollingUpdate
   volumeClaimTemplates:

--- a/pkg/resources/test/fixtures/statefulset-aws-1.17.0-etcd.yaml
+++ b/pkg/resources/test/fixtures/statefulset-aws-1.17.0-etcd.yaml
@@ -55,7 +55,7 @@ spec:
         - -initial-state
         - $(INITIAL_STATE)
         command:
-        - /usr/local/bin/etcd-launcher
+        - /opt/bin/etcd-launcher
         env:
         - name: POD_NAME
           valueFrom:
@@ -88,7 +88,7 @@ spec:
           value: /etc/etcd/pki/client/apiserver-etcd-client.key
         - name: INITIAL_STATE
           value: new
-        image: 'quay.io/kubermatic/etcd-launcher-v34:'
+        image: gcr.io/etcd-development/etcd:v3.4.3
         imagePullPolicy: IfNotPresent
         livenessProbe:
           failureThreshold: 3
@@ -138,8 +138,22 @@ spec:
         - mountPath: /etc/etcd/pki/client
           name: apiserver-etcd-client-certificate
           readOnly: true
+        - mountPath: /opt/bin/
+          name: launcher
       imagePullSecrets:
       - name: dockercfg
+      initContainers:
+      - command:
+        - /bin/cp
+        - /etcd-launcher
+        - /opt/bin/
+        image: 'quay.io/kubermatic/etcd-launcher:'
+        imagePullPolicy: IfNotPresent
+        name: etcd-launcher-init
+        resources: {}
+        volumeMounts:
+        - mountPath: /opt/bin/
+          name: launcher
       volumes:
       - name: etcd-tls-certificate
         secret:
@@ -153,6 +167,8 @@ spec:
       - name: apiserver-etcd-client-certificate
         secret:
           secretName: apiserver-etcd-client-certificate
+      - emptyDir: {}
+        name: launcher
   updateStrategy:
     type: RollingUpdate
   volumeClaimTemplates:

--- a/pkg/resources/test/fixtures/statefulset-aws-1.18.0-etcd.yaml
+++ b/pkg/resources/test/fixtures/statefulset-aws-1.18.0-etcd.yaml
@@ -55,7 +55,7 @@ spec:
         - -initial-state
         - $(INITIAL_STATE)
         command:
-        - /usr/local/bin/etcd-launcher
+        - /opt/bin/etcd-launcher
         env:
         - name: POD_NAME
           valueFrom:
@@ -88,7 +88,7 @@ spec:
           value: /etc/etcd/pki/client/apiserver-etcd-client.key
         - name: INITIAL_STATE
           value: new
-        image: 'quay.io/kubermatic/etcd-launcher-v34:'
+        image: gcr.io/etcd-development/etcd:v3.4.3
         imagePullPolicy: IfNotPresent
         livenessProbe:
           failureThreshold: 3
@@ -138,8 +138,22 @@ spec:
         - mountPath: /etc/etcd/pki/client
           name: apiserver-etcd-client-certificate
           readOnly: true
+        - mountPath: /opt/bin/
+          name: launcher
       imagePullSecrets:
       - name: dockercfg
+      initContainers:
+      - command:
+        - /bin/cp
+        - /etcd-launcher
+        - /opt/bin/
+        image: 'quay.io/kubermatic/etcd-launcher:'
+        imagePullPolicy: IfNotPresent
+        name: etcd-launcher-init
+        resources: {}
+        volumeMounts:
+        - mountPath: /opt/bin/
+          name: launcher
       volumes:
       - name: etcd-tls-certificate
         secret:
@@ -153,6 +167,8 @@ spec:
       - name: apiserver-etcd-client-certificate
         secret:
           secretName: apiserver-etcd-client-certificate
+      - emptyDir: {}
+        name: launcher
   updateStrategy:
     type: RollingUpdate
   volumeClaimTemplates:

--- a/pkg/resources/test/fixtures/statefulset-azure-1.15.0-etcd.yaml
+++ b/pkg/resources/test/fixtures/statefulset-azure-1.15.0-etcd.yaml
@@ -55,7 +55,7 @@ spec:
         - -initial-state
         - $(INITIAL_STATE)
         command:
-        - /usr/local/bin/etcd-launcher
+        - /opt/bin/etcd-launcher
         env:
         - name: POD_NAME
           valueFrom:
@@ -88,7 +88,7 @@ spec:
           value: /etc/etcd/pki/client/apiserver-etcd-client.key
         - name: INITIAL_STATE
           value: new
-        image: 'quay.io/kubermatic/etcd-launcher-v33:'
+        image: gcr.io/etcd-development/etcd:v3.3.18
         imagePullPolicy: IfNotPresent
         livenessProbe:
           failureThreshold: 3
@@ -138,8 +138,22 @@ spec:
         - mountPath: /etc/etcd/pki/client
           name: apiserver-etcd-client-certificate
           readOnly: true
+        - mountPath: /opt/bin/
+          name: launcher
       imagePullSecrets:
       - name: dockercfg
+      initContainers:
+      - command:
+        - /bin/cp
+        - /etcd-launcher
+        - /opt/bin/
+        image: 'quay.io/kubermatic/etcd-launcher:'
+        imagePullPolicy: IfNotPresent
+        name: etcd-launcher-init
+        resources: {}
+        volumeMounts:
+        - mountPath: /opt/bin/
+          name: launcher
       volumes:
       - name: etcd-tls-certificate
         secret:
@@ -153,6 +167,8 @@ spec:
       - name: apiserver-etcd-client-certificate
         secret:
           secretName: apiserver-etcd-client-certificate
+      - emptyDir: {}
+        name: launcher
   updateStrategy:
     type: RollingUpdate
   volumeClaimTemplates:

--- a/pkg/resources/test/fixtures/statefulset-azure-1.16.0-etcd.yaml
+++ b/pkg/resources/test/fixtures/statefulset-azure-1.16.0-etcd.yaml
@@ -55,7 +55,7 @@ spec:
         - -initial-state
         - $(INITIAL_STATE)
         command:
-        - /usr/local/bin/etcd-launcher
+        - /opt/bin/etcd-launcher
         env:
         - name: POD_NAME
           valueFrom:
@@ -88,7 +88,7 @@ spec:
           value: /etc/etcd/pki/client/apiserver-etcd-client.key
         - name: INITIAL_STATE
           value: new
-        image: 'quay.io/kubermatic/etcd-launcher-v33:'
+        image: gcr.io/etcd-development/etcd:v3.3.18
         imagePullPolicy: IfNotPresent
         livenessProbe:
           failureThreshold: 3
@@ -138,8 +138,22 @@ spec:
         - mountPath: /etc/etcd/pki/client
           name: apiserver-etcd-client-certificate
           readOnly: true
+        - mountPath: /opt/bin/
+          name: launcher
       imagePullSecrets:
       - name: dockercfg
+      initContainers:
+      - command:
+        - /bin/cp
+        - /etcd-launcher
+        - /opt/bin/
+        image: 'quay.io/kubermatic/etcd-launcher:'
+        imagePullPolicy: IfNotPresent
+        name: etcd-launcher-init
+        resources: {}
+        volumeMounts:
+        - mountPath: /opt/bin/
+          name: launcher
       volumes:
       - name: etcd-tls-certificate
         secret:
@@ -153,6 +167,8 @@ spec:
       - name: apiserver-etcd-client-certificate
         secret:
           secretName: apiserver-etcd-client-certificate
+      - emptyDir: {}
+        name: launcher
   updateStrategy:
     type: RollingUpdate
   volumeClaimTemplates:

--- a/pkg/resources/test/fixtures/statefulset-azure-1.17.0-etcd.yaml
+++ b/pkg/resources/test/fixtures/statefulset-azure-1.17.0-etcd.yaml
@@ -55,7 +55,7 @@ spec:
         - -initial-state
         - $(INITIAL_STATE)
         command:
-        - /usr/local/bin/etcd-launcher
+        - /opt/bin/etcd-launcher
         env:
         - name: POD_NAME
           valueFrom:
@@ -88,7 +88,7 @@ spec:
           value: /etc/etcd/pki/client/apiserver-etcd-client.key
         - name: INITIAL_STATE
           value: new
-        image: 'quay.io/kubermatic/etcd-launcher-v34:'
+        image: gcr.io/etcd-development/etcd:v3.4.3
         imagePullPolicy: IfNotPresent
         livenessProbe:
           failureThreshold: 3
@@ -138,8 +138,22 @@ spec:
         - mountPath: /etc/etcd/pki/client
           name: apiserver-etcd-client-certificate
           readOnly: true
+        - mountPath: /opt/bin/
+          name: launcher
       imagePullSecrets:
       - name: dockercfg
+      initContainers:
+      - command:
+        - /bin/cp
+        - /etcd-launcher
+        - /opt/bin/
+        image: 'quay.io/kubermatic/etcd-launcher:'
+        imagePullPolicy: IfNotPresent
+        name: etcd-launcher-init
+        resources: {}
+        volumeMounts:
+        - mountPath: /opt/bin/
+          name: launcher
       volumes:
       - name: etcd-tls-certificate
         secret:
@@ -153,6 +167,8 @@ spec:
       - name: apiserver-etcd-client-certificate
         secret:
           secretName: apiserver-etcd-client-certificate
+      - emptyDir: {}
+        name: launcher
   updateStrategy:
     type: RollingUpdate
   volumeClaimTemplates:

--- a/pkg/resources/test/fixtures/statefulset-azure-1.18.0-etcd.yaml
+++ b/pkg/resources/test/fixtures/statefulset-azure-1.18.0-etcd.yaml
@@ -55,7 +55,7 @@ spec:
         - -initial-state
         - $(INITIAL_STATE)
         command:
-        - /usr/local/bin/etcd-launcher
+        - /opt/bin/etcd-launcher
         env:
         - name: POD_NAME
           valueFrom:
@@ -88,7 +88,7 @@ spec:
           value: /etc/etcd/pki/client/apiserver-etcd-client.key
         - name: INITIAL_STATE
           value: new
-        image: 'quay.io/kubermatic/etcd-launcher-v34:'
+        image: gcr.io/etcd-development/etcd:v3.4.3
         imagePullPolicy: IfNotPresent
         livenessProbe:
           failureThreshold: 3
@@ -138,8 +138,22 @@ spec:
         - mountPath: /etc/etcd/pki/client
           name: apiserver-etcd-client-certificate
           readOnly: true
+        - mountPath: /opt/bin/
+          name: launcher
       imagePullSecrets:
       - name: dockercfg
+      initContainers:
+      - command:
+        - /bin/cp
+        - /etcd-launcher
+        - /opt/bin/
+        image: 'quay.io/kubermatic/etcd-launcher:'
+        imagePullPolicy: IfNotPresent
+        name: etcd-launcher-init
+        resources: {}
+        volumeMounts:
+        - mountPath: /opt/bin/
+          name: launcher
       volumes:
       - name: etcd-tls-certificate
         secret:
@@ -153,6 +167,8 @@ spec:
       - name: apiserver-etcd-client-certificate
         secret:
           secretName: apiserver-etcd-client-certificate
+      - emptyDir: {}
+        name: launcher
   updateStrategy:
     type: RollingUpdate
   volumeClaimTemplates:

--- a/pkg/resources/test/fixtures/statefulset-bringyourown-1.15.0-etcd.yaml
+++ b/pkg/resources/test/fixtures/statefulset-bringyourown-1.15.0-etcd.yaml
@@ -55,7 +55,7 @@ spec:
         - -initial-state
         - $(INITIAL_STATE)
         command:
-        - /usr/local/bin/etcd-launcher
+        - /opt/bin/etcd-launcher
         env:
         - name: POD_NAME
           valueFrom:
@@ -88,7 +88,7 @@ spec:
           value: /etc/etcd/pki/client/apiserver-etcd-client.key
         - name: INITIAL_STATE
           value: new
-        image: 'quay.io/kubermatic/etcd-launcher-v33:'
+        image: gcr.io/etcd-development/etcd:v3.3.18
         imagePullPolicy: IfNotPresent
         livenessProbe:
           failureThreshold: 3
@@ -138,8 +138,22 @@ spec:
         - mountPath: /etc/etcd/pki/client
           name: apiserver-etcd-client-certificate
           readOnly: true
+        - mountPath: /opt/bin/
+          name: launcher
       imagePullSecrets:
       - name: dockercfg
+      initContainers:
+      - command:
+        - /bin/cp
+        - /etcd-launcher
+        - /opt/bin/
+        image: 'quay.io/kubermatic/etcd-launcher:'
+        imagePullPolicy: IfNotPresent
+        name: etcd-launcher-init
+        resources: {}
+        volumeMounts:
+        - mountPath: /opt/bin/
+          name: launcher
       volumes:
       - name: etcd-tls-certificate
         secret:
@@ -153,6 +167,8 @@ spec:
       - name: apiserver-etcd-client-certificate
         secret:
           secretName: apiserver-etcd-client-certificate
+      - emptyDir: {}
+        name: launcher
   updateStrategy:
     type: RollingUpdate
   volumeClaimTemplates:

--- a/pkg/resources/test/fixtures/statefulset-bringyourown-1.16.0-etcd.yaml
+++ b/pkg/resources/test/fixtures/statefulset-bringyourown-1.16.0-etcd.yaml
@@ -55,7 +55,7 @@ spec:
         - -initial-state
         - $(INITIAL_STATE)
         command:
-        - /usr/local/bin/etcd-launcher
+        - /opt/bin/etcd-launcher
         env:
         - name: POD_NAME
           valueFrom:
@@ -88,7 +88,7 @@ spec:
           value: /etc/etcd/pki/client/apiserver-etcd-client.key
         - name: INITIAL_STATE
           value: new
-        image: 'quay.io/kubermatic/etcd-launcher-v33:'
+        image: gcr.io/etcd-development/etcd:v3.3.18
         imagePullPolicy: IfNotPresent
         livenessProbe:
           failureThreshold: 3
@@ -138,8 +138,22 @@ spec:
         - mountPath: /etc/etcd/pki/client
           name: apiserver-etcd-client-certificate
           readOnly: true
+        - mountPath: /opt/bin/
+          name: launcher
       imagePullSecrets:
       - name: dockercfg
+      initContainers:
+      - command:
+        - /bin/cp
+        - /etcd-launcher
+        - /opt/bin/
+        image: 'quay.io/kubermatic/etcd-launcher:'
+        imagePullPolicy: IfNotPresent
+        name: etcd-launcher-init
+        resources: {}
+        volumeMounts:
+        - mountPath: /opt/bin/
+          name: launcher
       volumes:
       - name: etcd-tls-certificate
         secret:
@@ -153,6 +167,8 @@ spec:
       - name: apiserver-etcd-client-certificate
         secret:
           secretName: apiserver-etcd-client-certificate
+      - emptyDir: {}
+        name: launcher
   updateStrategy:
     type: RollingUpdate
   volumeClaimTemplates:

--- a/pkg/resources/test/fixtures/statefulset-bringyourown-1.17.0-etcd.yaml
+++ b/pkg/resources/test/fixtures/statefulset-bringyourown-1.17.0-etcd.yaml
@@ -55,7 +55,7 @@ spec:
         - -initial-state
         - $(INITIAL_STATE)
         command:
-        - /usr/local/bin/etcd-launcher
+        - /opt/bin/etcd-launcher
         env:
         - name: POD_NAME
           valueFrom:
@@ -88,7 +88,7 @@ spec:
           value: /etc/etcd/pki/client/apiserver-etcd-client.key
         - name: INITIAL_STATE
           value: new
-        image: 'quay.io/kubermatic/etcd-launcher-v34:'
+        image: gcr.io/etcd-development/etcd:v3.4.3
         imagePullPolicy: IfNotPresent
         livenessProbe:
           failureThreshold: 3
@@ -138,8 +138,22 @@ spec:
         - mountPath: /etc/etcd/pki/client
           name: apiserver-etcd-client-certificate
           readOnly: true
+        - mountPath: /opt/bin/
+          name: launcher
       imagePullSecrets:
       - name: dockercfg
+      initContainers:
+      - command:
+        - /bin/cp
+        - /etcd-launcher
+        - /opt/bin/
+        image: 'quay.io/kubermatic/etcd-launcher:'
+        imagePullPolicy: IfNotPresent
+        name: etcd-launcher-init
+        resources: {}
+        volumeMounts:
+        - mountPath: /opt/bin/
+          name: launcher
       volumes:
       - name: etcd-tls-certificate
         secret:
@@ -153,6 +167,8 @@ spec:
       - name: apiserver-etcd-client-certificate
         secret:
           secretName: apiserver-etcd-client-certificate
+      - emptyDir: {}
+        name: launcher
   updateStrategy:
     type: RollingUpdate
   volumeClaimTemplates:

--- a/pkg/resources/test/fixtures/statefulset-bringyourown-1.18.0-etcd.yaml
+++ b/pkg/resources/test/fixtures/statefulset-bringyourown-1.18.0-etcd.yaml
@@ -55,7 +55,7 @@ spec:
         - -initial-state
         - $(INITIAL_STATE)
         command:
-        - /usr/local/bin/etcd-launcher
+        - /opt/bin/etcd-launcher
         env:
         - name: POD_NAME
           valueFrom:
@@ -88,7 +88,7 @@ spec:
           value: /etc/etcd/pki/client/apiserver-etcd-client.key
         - name: INITIAL_STATE
           value: new
-        image: 'quay.io/kubermatic/etcd-launcher-v34:'
+        image: gcr.io/etcd-development/etcd:v3.4.3
         imagePullPolicy: IfNotPresent
         livenessProbe:
           failureThreshold: 3
@@ -138,8 +138,22 @@ spec:
         - mountPath: /etc/etcd/pki/client
           name: apiserver-etcd-client-certificate
           readOnly: true
+        - mountPath: /opt/bin/
+          name: launcher
       imagePullSecrets:
       - name: dockercfg
+      initContainers:
+      - command:
+        - /bin/cp
+        - /etcd-launcher
+        - /opt/bin/
+        image: 'quay.io/kubermatic/etcd-launcher:'
+        imagePullPolicy: IfNotPresent
+        name: etcd-launcher-init
+        resources: {}
+        volumeMounts:
+        - mountPath: /opt/bin/
+          name: launcher
       volumes:
       - name: etcd-tls-certificate
         secret:
@@ -153,6 +167,8 @@ spec:
       - name: apiserver-etcd-client-certificate
         secret:
           secretName: apiserver-etcd-client-certificate
+      - emptyDir: {}
+        name: launcher
   updateStrategy:
     type: RollingUpdate
   volumeClaimTemplates:

--- a/pkg/resources/test/fixtures/statefulset-digitalocean-1.15.0-etcd.yaml
+++ b/pkg/resources/test/fixtures/statefulset-digitalocean-1.15.0-etcd.yaml
@@ -55,7 +55,7 @@ spec:
         - -initial-state
         - $(INITIAL_STATE)
         command:
-        - /usr/local/bin/etcd-launcher
+        - /opt/bin/etcd-launcher
         env:
         - name: POD_NAME
           valueFrom:
@@ -88,7 +88,7 @@ spec:
           value: /etc/etcd/pki/client/apiserver-etcd-client.key
         - name: INITIAL_STATE
           value: new
-        image: 'quay.io/kubermatic/etcd-launcher-v33:'
+        image: gcr.io/etcd-development/etcd:v3.3.18
         imagePullPolicy: IfNotPresent
         livenessProbe:
           failureThreshold: 3
@@ -138,8 +138,22 @@ spec:
         - mountPath: /etc/etcd/pki/client
           name: apiserver-etcd-client-certificate
           readOnly: true
+        - mountPath: /opt/bin/
+          name: launcher
       imagePullSecrets:
       - name: dockercfg
+      initContainers:
+      - command:
+        - /bin/cp
+        - /etcd-launcher
+        - /opt/bin/
+        image: 'quay.io/kubermatic/etcd-launcher:'
+        imagePullPolicy: IfNotPresent
+        name: etcd-launcher-init
+        resources: {}
+        volumeMounts:
+        - mountPath: /opt/bin/
+          name: launcher
       volumes:
       - name: etcd-tls-certificate
         secret:
@@ -153,6 +167,8 @@ spec:
       - name: apiserver-etcd-client-certificate
         secret:
           secretName: apiserver-etcd-client-certificate
+      - emptyDir: {}
+        name: launcher
   updateStrategy:
     type: RollingUpdate
   volumeClaimTemplates:

--- a/pkg/resources/test/fixtures/statefulset-digitalocean-1.16.0-etcd.yaml
+++ b/pkg/resources/test/fixtures/statefulset-digitalocean-1.16.0-etcd.yaml
@@ -55,7 +55,7 @@ spec:
         - -initial-state
         - $(INITIAL_STATE)
         command:
-        - /usr/local/bin/etcd-launcher
+        - /opt/bin/etcd-launcher
         env:
         - name: POD_NAME
           valueFrom:
@@ -88,7 +88,7 @@ spec:
           value: /etc/etcd/pki/client/apiserver-etcd-client.key
         - name: INITIAL_STATE
           value: new
-        image: 'quay.io/kubermatic/etcd-launcher-v33:'
+        image: gcr.io/etcd-development/etcd:v3.3.18
         imagePullPolicy: IfNotPresent
         livenessProbe:
           failureThreshold: 3
@@ -138,8 +138,22 @@ spec:
         - mountPath: /etc/etcd/pki/client
           name: apiserver-etcd-client-certificate
           readOnly: true
+        - mountPath: /opt/bin/
+          name: launcher
       imagePullSecrets:
       - name: dockercfg
+      initContainers:
+      - command:
+        - /bin/cp
+        - /etcd-launcher
+        - /opt/bin/
+        image: 'quay.io/kubermatic/etcd-launcher:'
+        imagePullPolicy: IfNotPresent
+        name: etcd-launcher-init
+        resources: {}
+        volumeMounts:
+        - mountPath: /opt/bin/
+          name: launcher
       volumes:
       - name: etcd-tls-certificate
         secret:
@@ -153,6 +167,8 @@ spec:
       - name: apiserver-etcd-client-certificate
         secret:
           secretName: apiserver-etcd-client-certificate
+      - emptyDir: {}
+        name: launcher
   updateStrategy:
     type: RollingUpdate
   volumeClaimTemplates:

--- a/pkg/resources/test/fixtures/statefulset-digitalocean-1.17.0-etcd.yaml
+++ b/pkg/resources/test/fixtures/statefulset-digitalocean-1.17.0-etcd.yaml
@@ -55,7 +55,7 @@ spec:
         - -initial-state
         - $(INITIAL_STATE)
         command:
-        - /usr/local/bin/etcd-launcher
+        - /opt/bin/etcd-launcher
         env:
         - name: POD_NAME
           valueFrom:
@@ -88,7 +88,7 @@ spec:
           value: /etc/etcd/pki/client/apiserver-etcd-client.key
         - name: INITIAL_STATE
           value: new
-        image: 'quay.io/kubermatic/etcd-launcher-v34:'
+        image: gcr.io/etcd-development/etcd:v3.4.3
         imagePullPolicy: IfNotPresent
         livenessProbe:
           failureThreshold: 3
@@ -138,8 +138,22 @@ spec:
         - mountPath: /etc/etcd/pki/client
           name: apiserver-etcd-client-certificate
           readOnly: true
+        - mountPath: /opt/bin/
+          name: launcher
       imagePullSecrets:
       - name: dockercfg
+      initContainers:
+      - command:
+        - /bin/cp
+        - /etcd-launcher
+        - /opt/bin/
+        image: 'quay.io/kubermatic/etcd-launcher:'
+        imagePullPolicy: IfNotPresent
+        name: etcd-launcher-init
+        resources: {}
+        volumeMounts:
+        - mountPath: /opt/bin/
+          name: launcher
       volumes:
       - name: etcd-tls-certificate
         secret:
@@ -153,6 +167,8 @@ spec:
       - name: apiserver-etcd-client-certificate
         secret:
           secretName: apiserver-etcd-client-certificate
+      - emptyDir: {}
+        name: launcher
   updateStrategy:
     type: RollingUpdate
   volumeClaimTemplates:

--- a/pkg/resources/test/fixtures/statefulset-digitalocean-1.18.0-etcd.yaml
+++ b/pkg/resources/test/fixtures/statefulset-digitalocean-1.18.0-etcd.yaml
@@ -55,7 +55,7 @@ spec:
         - -initial-state
         - $(INITIAL_STATE)
         command:
-        - /usr/local/bin/etcd-launcher
+        - /opt/bin/etcd-launcher
         env:
         - name: POD_NAME
           valueFrom:
@@ -88,7 +88,7 @@ spec:
           value: /etc/etcd/pki/client/apiserver-etcd-client.key
         - name: INITIAL_STATE
           value: new
-        image: 'quay.io/kubermatic/etcd-launcher-v34:'
+        image: gcr.io/etcd-development/etcd:v3.4.3
         imagePullPolicy: IfNotPresent
         livenessProbe:
           failureThreshold: 3
@@ -138,8 +138,22 @@ spec:
         - mountPath: /etc/etcd/pki/client
           name: apiserver-etcd-client-certificate
           readOnly: true
+        - mountPath: /opt/bin/
+          name: launcher
       imagePullSecrets:
       - name: dockercfg
+      initContainers:
+      - command:
+        - /bin/cp
+        - /etcd-launcher
+        - /opt/bin/
+        image: 'quay.io/kubermatic/etcd-launcher:'
+        imagePullPolicy: IfNotPresent
+        name: etcd-launcher-init
+        resources: {}
+        volumeMounts:
+        - mountPath: /opt/bin/
+          name: launcher
       volumes:
       - name: etcd-tls-certificate
         secret:
@@ -153,6 +167,8 @@ spec:
       - name: apiserver-etcd-client-certificate
         secret:
           secretName: apiserver-etcd-client-certificate
+      - emptyDir: {}
+        name: launcher
   updateStrategy:
     type: RollingUpdate
   volumeClaimTemplates:

--- a/pkg/resources/test/fixtures/statefulset-openstack-1.15.0-etcd.yaml
+++ b/pkg/resources/test/fixtures/statefulset-openstack-1.15.0-etcd.yaml
@@ -55,7 +55,7 @@ spec:
         - -initial-state
         - $(INITIAL_STATE)
         command:
-        - /usr/local/bin/etcd-launcher
+        - /opt/bin/etcd-launcher
         env:
         - name: POD_NAME
           valueFrom:
@@ -88,7 +88,7 @@ spec:
           value: /etc/etcd/pki/client/apiserver-etcd-client.key
         - name: INITIAL_STATE
           value: new
-        image: 'quay.io/kubermatic/etcd-launcher-v33:'
+        image: gcr.io/etcd-development/etcd:v3.3.18
         imagePullPolicy: IfNotPresent
         livenessProbe:
           failureThreshold: 3
@@ -138,8 +138,22 @@ spec:
         - mountPath: /etc/etcd/pki/client
           name: apiserver-etcd-client-certificate
           readOnly: true
+        - mountPath: /opt/bin/
+          name: launcher
       imagePullSecrets:
       - name: dockercfg
+      initContainers:
+      - command:
+        - /bin/cp
+        - /etcd-launcher
+        - /opt/bin/
+        image: 'quay.io/kubermatic/etcd-launcher:'
+        imagePullPolicy: IfNotPresent
+        name: etcd-launcher-init
+        resources: {}
+        volumeMounts:
+        - mountPath: /opt/bin/
+          name: launcher
       volumes:
       - name: etcd-tls-certificate
         secret:
@@ -153,6 +167,8 @@ spec:
       - name: apiserver-etcd-client-certificate
         secret:
           secretName: apiserver-etcd-client-certificate
+      - emptyDir: {}
+        name: launcher
   updateStrategy:
     type: RollingUpdate
   volumeClaimTemplates:

--- a/pkg/resources/test/fixtures/statefulset-openstack-1.16.0-etcd.yaml
+++ b/pkg/resources/test/fixtures/statefulset-openstack-1.16.0-etcd.yaml
@@ -55,7 +55,7 @@ spec:
         - -initial-state
         - $(INITIAL_STATE)
         command:
-        - /usr/local/bin/etcd-launcher
+        - /opt/bin/etcd-launcher
         env:
         - name: POD_NAME
           valueFrom:
@@ -88,7 +88,7 @@ spec:
           value: /etc/etcd/pki/client/apiserver-etcd-client.key
         - name: INITIAL_STATE
           value: new
-        image: 'quay.io/kubermatic/etcd-launcher-v33:'
+        image: gcr.io/etcd-development/etcd:v3.3.18
         imagePullPolicy: IfNotPresent
         livenessProbe:
           failureThreshold: 3
@@ -138,8 +138,22 @@ spec:
         - mountPath: /etc/etcd/pki/client
           name: apiserver-etcd-client-certificate
           readOnly: true
+        - mountPath: /opt/bin/
+          name: launcher
       imagePullSecrets:
       - name: dockercfg
+      initContainers:
+      - command:
+        - /bin/cp
+        - /etcd-launcher
+        - /opt/bin/
+        image: 'quay.io/kubermatic/etcd-launcher:'
+        imagePullPolicy: IfNotPresent
+        name: etcd-launcher-init
+        resources: {}
+        volumeMounts:
+        - mountPath: /opt/bin/
+          name: launcher
       volumes:
       - name: etcd-tls-certificate
         secret:
@@ -153,6 +167,8 @@ spec:
       - name: apiserver-etcd-client-certificate
         secret:
           secretName: apiserver-etcd-client-certificate
+      - emptyDir: {}
+        name: launcher
   updateStrategy:
     type: RollingUpdate
   volumeClaimTemplates:

--- a/pkg/resources/test/fixtures/statefulset-openstack-1.17.0-etcd.yaml
+++ b/pkg/resources/test/fixtures/statefulset-openstack-1.17.0-etcd.yaml
@@ -55,7 +55,7 @@ spec:
         - -initial-state
         - $(INITIAL_STATE)
         command:
-        - /usr/local/bin/etcd-launcher
+        - /opt/bin/etcd-launcher
         env:
         - name: POD_NAME
           valueFrom:
@@ -88,7 +88,7 @@ spec:
           value: /etc/etcd/pki/client/apiserver-etcd-client.key
         - name: INITIAL_STATE
           value: new
-        image: 'quay.io/kubermatic/etcd-launcher-v34:'
+        image: gcr.io/etcd-development/etcd:v3.4.3
         imagePullPolicy: IfNotPresent
         livenessProbe:
           failureThreshold: 3
@@ -138,8 +138,22 @@ spec:
         - mountPath: /etc/etcd/pki/client
           name: apiserver-etcd-client-certificate
           readOnly: true
+        - mountPath: /opt/bin/
+          name: launcher
       imagePullSecrets:
       - name: dockercfg
+      initContainers:
+      - command:
+        - /bin/cp
+        - /etcd-launcher
+        - /opt/bin/
+        image: 'quay.io/kubermatic/etcd-launcher:'
+        imagePullPolicy: IfNotPresent
+        name: etcd-launcher-init
+        resources: {}
+        volumeMounts:
+        - mountPath: /opt/bin/
+          name: launcher
       volumes:
       - name: etcd-tls-certificate
         secret:
@@ -153,6 +167,8 @@ spec:
       - name: apiserver-etcd-client-certificate
         secret:
           secretName: apiserver-etcd-client-certificate
+      - emptyDir: {}
+        name: launcher
   updateStrategy:
     type: RollingUpdate
   volumeClaimTemplates:

--- a/pkg/resources/test/fixtures/statefulset-openstack-1.18.0-etcd.yaml
+++ b/pkg/resources/test/fixtures/statefulset-openstack-1.18.0-etcd.yaml
@@ -55,7 +55,7 @@ spec:
         - -initial-state
         - $(INITIAL_STATE)
         command:
-        - /usr/local/bin/etcd-launcher
+        - /opt/bin/etcd-launcher
         env:
         - name: POD_NAME
           valueFrom:
@@ -88,7 +88,7 @@ spec:
           value: /etc/etcd/pki/client/apiserver-etcd-client.key
         - name: INITIAL_STATE
           value: new
-        image: 'quay.io/kubermatic/etcd-launcher-v34:'
+        image: gcr.io/etcd-development/etcd:v3.4.3
         imagePullPolicy: IfNotPresent
         livenessProbe:
           failureThreshold: 3
@@ -138,8 +138,22 @@ spec:
         - mountPath: /etc/etcd/pki/client
           name: apiserver-etcd-client-certificate
           readOnly: true
+        - mountPath: /opt/bin/
+          name: launcher
       imagePullSecrets:
       - name: dockercfg
+      initContainers:
+      - command:
+        - /bin/cp
+        - /etcd-launcher
+        - /opt/bin/
+        image: 'quay.io/kubermatic/etcd-launcher:'
+        imagePullPolicy: IfNotPresent
+        name: etcd-launcher-init
+        resources: {}
+        volumeMounts:
+        - mountPath: /opt/bin/
+          name: launcher
       volumes:
       - name: etcd-tls-certificate
         secret:
@@ -153,6 +167,8 @@ spec:
       - name: apiserver-etcd-client-certificate
         secret:
           secretName: apiserver-etcd-client-certificate
+      - emptyDir: {}
+        name: launcher
   updateStrategy:
     type: RollingUpdate
   volumeClaimTemplates:

--- a/pkg/resources/test/fixtures/statefulset-vsphere-1.15.0-etcd.yaml
+++ b/pkg/resources/test/fixtures/statefulset-vsphere-1.15.0-etcd.yaml
@@ -55,7 +55,7 @@ spec:
         - -initial-state
         - $(INITIAL_STATE)
         command:
-        - /usr/local/bin/etcd-launcher
+        - /opt/bin/etcd-launcher
         env:
         - name: POD_NAME
           valueFrom:
@@ -88,7 +88,7 @@ spec:
           value: /etc/etcd/pki/client/apiserver-etcd-client.key
         - name: INITIAL_STATE
           value: new
-        image: 'quay.io/kubermatic/etcd-launcher-v33:'
+        image: gcr.io/etcd-development/etcd:v3.3.18
         imagePullPolicy: IfNotPresent
         livenessProbe:
           failureThreshold: 3
@@ -138,8 +138,22 @@ spec:
         - mountPath: /etc/etcd/pki/client
           name: apiserver-etcd-client-certificate
           readOnly: true
+        - mountPath: /opt/bin/
+          name: launcher
       imagePullSecrets:
       - name: dockercfg
+      initContainers:
+      - command:
+        - /bin/cp
+        - /etcd-launcher
+        - /opt/bin/
+        image: 'quay.io/kubermatic/etcd-launcher:'
+        imagePullPolicy: IfNotPresent
+        name: etcd-launcher-init
+        resources: {}
+        volumeMounts:
+        - mountPath: /opt/bin/
+          name: launcher
       volumes:
       - name: etcd-tls-certificate
         secret:
@@ -153,6 +167,8 @@ spec:
       - name: apiserver-etcd-client-certificate
         secret:
           secretName: apiserver-etcd-client-certificate
+      - emptyDir: {}
+        name: launcher
   updateStrategy:
     type: RollingUpdate
   volumeClaimTemplates:

--- a/pkg/resources/test/fixtures/statefulset-vsphere-1.16.0-etcd.yaml
+++ b/pkg/resources/test/fixtures/statefulset-vsphere-1.16.0-etcd.yaml
@@ -55,7 +55,7 @@ spec:
         - -initial-state
         - $(INITIAL_STATE)
         command:
-        - /usr/local/bin/etcd-launcher
+        - /opt/bin/etcd-launcher
         env:
         - name: POD_NAME
           valueFrom:
@@ -88,7 +88,7 @@ spec:
           value: /etc/etcd/pki/client/apiserver-etcd-client.key
         - name: INITIAL_STATE
           value: new
-        image: 'quay.io/kubermatic/etcd-launcher-v33:'
+        image: gcr.io/etcd-development/etcd:v3.3.18
         imagePullPolicy: IfNotPresent
         livenessProbe:
           failureThreshold: 3
@@ -138,8 +138,22 @@ spec:
         - mountPath: /etc/etcd/pki/client
           name: apiserver-etcd-client-certificate
           readOnly: true
+        - mountPath: /opt/bin/
+          name: launcher
       imagePullSecrets:
       - name: dockercfg
+      initContainers:
+      - command:
+        - /bin/cp
+        - /etcd-launcher
+        - /opt/bin/
+        image: 'quay.io/kubermatic/etcd-launcher:'
+        imagePullPolicy: IfNotPresent
+        name: etcd-launcher-init
+        resources: {}
+        volumeMounts:
+        - mountPath: /opt/bin/
+          name: launcher
       volumes:
       - name: etcd-tls-certificate
         secret:
@@ -153,6 +167,8 @@ spec:
       - name: apiserver-etcd-client-certificate
         secret:
           secretName: apiserver-etcd-client-certificate
+      - emptyDir: {}
+        name: launcher
   updateStrategy:
     type: RollingUpdate
   volumeClaimTemplates:

--- a/pkg/resources/test/fixtures/statefulset-vsphere-1.17.0-etcd.yaml
+++ b/pkg/resources/test/fixtures/statefulset-vsphere-1.17.0-etcd.yaml
@@ -55,7 +55,7 @@ spec:
         - -initial-state
         - $(INITIAL_STATE)
         command:
-        - /usr/local/bin/etcd-launcher
+        - /opt/bin/etcd-launcher
         env:
         - name: POD_NAME
           valueFrom:
@@ -88,7 +88,7 @@ spec:
           value: /etc/etcd/pki/client/apiserver-etcd-client.key
         - name: INITIAL_STATE
           value: new
-        image: 'quay.io/kubermatic/etcd-launcher-v34:'
+        image: gcr.io/etcd-development/etcd:v3.4.3
         imagePullPolicy: IfNotPresent
         livenessProbe:
           failureThreshold: 3
@@ -138,8 +138,22 @@ spec:
         - mountPath: /etc/etcd/pki/client
           name: apiserver-etcd-client-certificate
           readOnly: true
+        - mountPath: /opt/bin/
+          name: launcher
       imagePullSecrets:
       - name: dockercfg
+      initContainers:
+      - command:
+        - /bin/cp
+        - /etcd-launcher
+        - /opt/bin/
+        image: 'quay.io/kubermatic/etcd-launcher:'
+        imagePullPolicy: IfNotPresent
+        name: etcd-launcher-init
+        resources: {}
+        volumeMounts:
+        - mountPath: /opt/bin/
+          name: launcher
       volumes:
       - name: etcd-tls-certificate
         secret:
@@ -153,6 +167,8 @@ spec:
       - name: apiserver-etcd-client-certificate
         secret:
           secretName: apiserver-etcd-client-certificate
+      - emptyDir: {}
+        name: launcher
   updateStrategy:
     type: RollingUpdate
   volumeClaimTemplates:

--- a/pkg/resources/test/fixtures/statefulset-vsphere-1.18.0-etcd.yaml
+++ b/pkg/resources/test/fixtures/statefulset-vsphere-1.18.0-etcd.yaml
@@ -55,7 +55,7 @@ spec:
         - -initial-state
         - $(INITIAL_STATE)
         command:
-        - /usr/local/bin/etcd-launcher
+        - /opt/bin/etcd-launcher
         env:
         - name: POD_NAME
           valueFrom:
@@ -88,7 +88,7 @@ spec:
           value: /etc/etcd/pki/client/apiserver-etcd-client.key
         - name: INITIAL_STATE
           value: new
-        image: 'quay.io/kubermatic/etcd-launcher-v34:'
+        image: gcr.io/etcd-development/etcd:v3.4.3
         imagePullPolicy: IfNotPresent
         livenessProbe:
           failureThreshold: 3
@@ -138,8 +138,22 @@ spec:
         - mountPath: /etc/etcd/pki/client
           name: apiserver-etcd-client-certificate
           readOnly: true
+        - mountPath: /opt/bin/
+          name: launcher
       imagePullSecrets:
       - name: dockercfg
+      initContainers:
+      - command:
+        - /bin/cp
+        - /etcd-launcher
+        - /opt/bin/
+        image: 'quay.io/kubermatic/etcd-launcher:'
+        imagePullPolicy: IfNotPresent
+        name: etcd-launcher-init
+        resources: {}
+        volumeMounts:
+        - mountPath: /opt/bin/
+          name: launcher
       volumes:
       - name: etcd-tls-certificate
         secret:
@@ -153,6 +167,8 @@ spec:
       - name: apiserver-etcd-client-certificate
         secret:
           secretName: apiserver-etcd-client-certificate
+      - emptyDir: {}
+        name: launcher
   updateStrategy:
     type: RollingUpdate
   volumeClaimTemplates:


### PR DESCRIPTION
**What this PR does / why we need it**:
Initially, etcd-launcher was added to the main etcd image. Since we support two versions of etcd, we had to support two versions of the launcher image. This complected things, so are going to use a single launcher image that adds the binary to the main etcd image at runtime via an initcontainer. This should make development and testing much easier.
**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Documentation**:
<!-- Add links to the related documentation changes related to this pull request. E.g. the link to the kubermatic/docs pullrequest. -->

**Does this PR introduce a user-facing change?**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If  no release note is required, just write "NONE".
-->
```release-note
NONE
```
