### PR TITLE
Update Logging Stack

### DIFF
--- a/charts/logging/loki/Chart.yaml
+++ b/charts/logging/loki/Chart.yaml
@@ -14,8 +14,8 @@
 
 apiVersion: "v1"
 name: loki
-version: 0.0.8
-appVersion: v1.3.0
+version: 0.0.9
+appVersion: v1.5.0
 description: "Loki: like Prometheus, but for logs."
 keywords:
 - kubermatic

--- a/charts/logging/loki/values.yaml
+++ b/charts/logging/loki/values.yaml
@@ -68,7 +68,7 @@ loki:
 
   image:
     repository: docker.io/grafana/loki
-    tag: v1.3.0
+    tag: 1.5.0
     pullPolicy: IfNotPresent
 
   ## The app name of loki clients

--- a/charts/logging/promtail/Chart.yaml
+++ b/charts/logging/promtail/Chart.yaml
@@ -14,8 +14,8 @@
 
 apiVersion: "v1"
 name: promtail
-version: 0.1.3
-appVersion: v1.3.0
+version: 0.1.4
+appVersion: v1.5.0
 description: "Responsible for gathering logs and sending them to Loki"
 keywords:
 - kubermatic

--- a/charts/logging/promtail/values.yaml
+++ b/charts/logging/promtail/values.yaml
@@ -17,7 +17,7 @@ promtail:
 
   image:
     repository: docker.io/grafana/promtail
-    tag: v1.3.0
+    tag: 1.5.0
     pullPolicy: IfNotPresent
 
   loki:


### PR DESCRIPTION
**What this PR does / why we need it**:
The most important breaking change for us is that starting with v1.4.0, Loki Docker images do not have the leading "v" in their tag name anymore. So the git tag is still "v1.4.0" (and this is what I kept the appVersion as), but the Docker tag is just "1.4.0".

**Does this PR introduce a user-facing change?**:
```release-note
Update Loki/promtail to v1.5.0
```
