### PR TITLE
fix componentsOverride affecting default values when reconciling clusters

### DIFF
--- a/pkg/resources/resources.go
+++ b/pkg/resources/resources.go
@@ -941,7 +941,13 @@ func GetHTTPProxyEnvVarsFromSeed(seed *kubermaticv1.Seed, inClusterAPIServerURL 
 // SetResourceRequirements sets resource requirements on provided slice of containers.
 // The highest priority has requirements provided using overrides, then requirements provided by the vpa-updater
 // (if VPA is enabled), and at the end provided default requirements for a given resource.
-func SetResourceRequirements(containers []corev1.Container, requirements, overrides map[string]*corev1.ResourceRequirements, annotations map[string]string) error {
+func SetResourceRequirements(containers []corev1.Container, defaultRequirements, overrides map[string]*corev1.ResourceRequirements, annotations map[string]string) error {
+	// do not accidentally modify the map of default requirements
+	requirements := map[string]*corev1.ResourceRequirements{}
+	for k, v := range defaultRequirements {
+		requirements[k] = v.DeepCopy()
+	}
+
 	val, ok := annotations[kubermaticv1.UpdatedByVPALabelKey]
 	if ok && val != "" {
 		var req []Requirements
@@ -954,7 +960,7 @@ func SetResourceRequirements(containers []corev1.Container, requirements, overri
 		}
 	}
 	for k, v := range overrides {
-		requirements[k] = v
+		requirements[k] = v.DeepCopy()
 	}
 
 	for i := range containers {


### PR DESCRIPTION
**What this PR does / why we need it**:
`resources.SetResourceRequirements()` accidentally modified the given default requirements, which lead to more or less random effects on other clusters, depending on the reconciling order.

This seems to have been introduced in December 2019 via #4810, so 2.13+ version are affected.

**Which issue(s) this PR fixes**:
Fixes #5654

**Does this PR introduce a user-facing change?**:
```release-note
Fix componentsOverride of a cluster affecting other clusters.
```
