### PR TITLE
add KubermaticAddonTakesTooLongToReconcile alert

### DIFF
--- a/charts/monitoring/prometheus/Chart.yaml
+++ b/charts/monitoring/prometheus/Chart.yaml
@@ -14,7 +14,7 @@
 
 apiVersion: v1
 name: prometheus
-version: 2.2.24
+version: 2.2.25
 appVersion: v2.19.2
 description: Prometheus Monitoring for Kubernetes
 keywords:

--- a/charts/monitoring/prometheus/rules/kubermatic-seed-kubermatic.yaml
+++ b/charts/monitoring/prometheus/rules/kubermatic-seed-kubermatic.yaml
@@ -43,6 +43,17 @@ groups:
     for: 0m
     labels:
       severity: warning
+  - alert: KubermaticAddonTakesTooLongToReconcile
+    annotations:
+      message: Addon {{ $labels.addon }} in cluster {{ $labels.cluster }} has no related
+        resources created for more than 30min.
+      runbook_url: https://docs.kubermatic.com/kubermatic/master/monitoring/runbook/#alert-kubermaticaddonreconciliationtakestoolong
+    expr: kubermatic_addon_reconcile_failed * on(cluster) group_left() kubermatic_cluster_created
+      - kubermatic_addon_reconcile_failed * on(cluster) group_left() kubermatic_cluster_deleted
+      > 0
+    for: 30m
+    labels:
+      severity: warning
   - alert: KubermaticControllerManagerDown
     annotations:
       message: KubermaticControllerManager has disappeared from Prometheus target

--- a/charts/monitoring/prometheus/rules/src/kubermatic-seed/kubermatic.yaml
+++ b/charts/monitoring/prometheus/rules/src/kubermatic-seed/kubermatic.yaml
@@ -57,6 +57,21 @@ groups:
           Manually deleted resources inside of the user cluster is a common reason for failing deletions.
         - If all resources of the addon inside the user cluster have been cleaned up, remove the blocking finalizer (e.g. `cleanup-manifests`) from the addon resource.
 
+  - alert: KubermaticAddonTakesTooLongToReconcile
+    annotations:
+      message: Addon {{ $labels.addon }} in cluster {{ $labels.cluster }} has no related
+        resources created for more than 30min.
+      runbook_url: https://docs.kubermatic.com/kubermatic/master/monitoring/runbook/#alert-kubermaticaddonreconciliationtakestoolong
+    expr: kubermatic_addon_reconcile_failed * on(cluster) group_left() kubermatic_cluster_created
+      - kubermatic_addon_reconcile_failed * on(cluster) group_left() kubermatic_cluster_deleted
+      > 0
+    for: 30m
+    labels:
+      severity: warning
+    runbook:
+      steps:
+        - Check the kubermatic controller-manager's logs via `kubectl -n kubermatic logs -l 'role=controller-manager'` for errors related to reconciliation of the addon.
+
   - alert: KubermaticControllerManagerDown
     annotations:
       message: KubermaticControllerManager has disappeared from Prometheus target discovery.


### PR DESCRIPTION
**What this PR does / why we need it**:

It adds an alert that is fired if there is some problem with add-on reconciliation for over 30m.

**Documentation**:
https://github.com/kubermatic/docs/pull/383

**Does this PR introduce a user-facing change?**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If  no release note is required, just write "NONE".
-->
```release-note
add KubermaticAddonTakesTooLongToReconcile alert
```
