### PR TITLE
Cleanup API e2e Tests / The Unflakaning

### DIFF
--- a/.prow.yaml
+++ b/.prow.yaml
@@ -1165,7 +1165,10 @@ presubmits:
       - image: quay.io/kubermatic/e2e-kind:with-conformance-tests-v1.0.21
         imagePullPolicy: Always
         command:
-        - "./hack/ci/ci_run_api_e2e.sh"
+        - "./hack/ci/ci-run-api-e2e.sh"
+        env:
+        - name: VERSION_TO_TEST
+          value: v1.18.8
         securityContext:
           privileged: true
         resources:

--- a/go.mod
+++ b/go.mod
@@ -68,6 +68,7 @@ require (
 	go.etcd.io/etcd/v3 v3.3.0-rc.0.0.20200728214110-6c81b20ec8de
 	go.uber.org/zap v1.15.0
 	golang.org/x/crypto v0.0.0-20200728195943-123391ffb6de
+	golang.org/x/net v0.0.0-20200707034311-ab3426394381
 	golang.org/x/oauth2 v0.0.0-20200107190931-bf48bf16ab8d
 	golang.org/x/sys v0.0.0-20200819171115-d785dc25833f // indirect
 	golang.org/x/time v0.0.0-20200630173020-3af7569d3a1e // indirect

--- a/hack/ci/ci-setup-kubermatic-in-kind.sh
+++ b/hack/ci/ci-setup-kubermatic-in-kind.sh
@@ -63,13 +63,11 @@ dockerd > /tmp/docker.log 2>&1 &
 echodate "Started Docker successfully"
 
 function docker_logs {
-  originalRC=$?
-  if [[ $originalRC -ne 0 ]]; then
+  if [[ $? -ne 0 ]]; then
     echodate "Printing Docker logs"
     cat /tmp/docker.log
     echodate "Done printing Docker logs"
   fi
-  return $originalRC
 }
 appendTrap docker_logs EXIT
 
@@ -152,16 +150,14 @@ CGO_ENABLED=0 /tmp/clusterexposer \
   --build-id "$PROW_JOB_ID" &> /var/log/clusterexposer.log &
 
 function print_cluster_exposer_logs {
-  originalRC=$?
-
-  # Tolerate errors and just continue
-  set +e
-  echodate "Printing cluster exposer logs"
-  cat /var/log/clusterexposer.log
-  echodate "Done printing cluster exposer logs"
-  set -e
-
-  return $originalRC
+  if [[ $? -ne 0 ]]; then
+    # Tolerate errors and just continue
+    set +e
+    echodate "Printing cluster exposer logs"
+    cat /var/log/clusterexposer.log
+    echodate "Done printing cluster exposer logs"
+    set -e
+  fi
 }
 appendTrap print_cluster_exposer_logs EXIT
 
@@ -452,8 +448,8 @@ appendTrap cleanup_kubermatic_clusters_in_kind EXIT
 
 TEST_NAME="Expose Dex and Kubermatic API"
 echodate "Exposing Dex and Kubermatic API to localhost..."
-kubectl port-forward --address 0.0.0.0 -n oauth svc/dex 5556 &
-kubectl port-forward --address 0.0.0.0 -n kubermatic svc/kubermatic-api 8080:80 &
+kubectl port-forward --address 0.0.0.0 -n oauth svc/dex 5556 >/dev/null &
+kubectl port-forward --address 0.0.0.0 -n kubermatic svc/kubermatic-api 8080:80 >/dev/null &
 echodate "Finished exposing components"
 
 cd -

--- a/hack/ci/ci-setup-legacy-kubermatic-in-kind.sh
+++ b/hack/ci/ci-setup-legacy-kubermatic-in-kind.sh
@@ -66,13 +66,11 @@ dockerd > /tmp/docker.log 2>&1 &
 echodate "Started Docker successfully"
 
 function docker_logs {
-  originalRC=$?
-  if [[ $originalRC -ne 0 ]]; then
+  if [[ $? -ne 0 ]]; then
     echodate "Printing Docker logs"
     cat /tmp/docker.log
     echodate "Done printing Docker logs"
   fi
-  return $originalRC
 }
 appendTrap docker_logs EXIT
 
@@ -155,16 +153,14 @@ CGO_ENABLED=0 /tmp/clusterexposer \
   --build-id "$PROW_JOB_ID" &> /var/log/clusterexposer.log &
 
 function print_cluster_exposer_logs {
-  originalRC=$?
-
-  # Tolerate errors and just continue
-  set +e
-  echodate "Printing cluster exposer logs"
-  cat /var/log/clusterexposer.log
-  echodate "Done printing cluster exposer logs"
-  set -e
-
-  return $originalRC
+  if [[ $? -ne 0 ]]; then
+    # Tolerate errors and just continue
+    set +e
+    echodate "Printing cluster exposer logs"
+    cat /var/log/clusterexposer.log
+    echodate "Done printing cluster exposer logs"
+    set -e
+  fi
 }
 appendTrap print_cluster_exposer_logs EXIT
 

--- a/hack/lib.sh
+++ b/hack/lib.sh
@@ -283,8 +283,6 @@ check_all_deployments_ready() {
 }
 
 function cleanup_kubermatic_clusters_in_kind {
-  originalRC=$?
-
   # Tolerate errors and just continue
   set +e
   # Clean up clusters
@@ -295,6 +293,4 @@ function cleanup_kubermatic_clusters_in_kind {
   # Kill all descendant processes
   pkill -P $$
   set -e
-
-  return $originalRC
 }

--- a/pkg/test/e2e/api/client.go
+++ b/pkg/test/e2e/api/client.go
@@ -1,0 +1,151 @@
+/*
+Copyright 2020 The Kubermatic Kubernetes Platform contributors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package api
+
+import (
+	"bytes"
+	"context"
+	"fmt"
+	"io/ioutil"
+	"net/http"
+	"testing"
+	"time"
+
+	"k8s.io/apimachinery/pkg/util/wait"
+)
+
+type requestParameterHolder interface {
+	SetHTTPClient(*http.Client)
+}
+
+func setupParams(t *testing.T, p requestParameterHolder, interval time.Duration, timeout time.Duration, ignoredStatusCodes ...int) {
+	p.SetHTTPClient(newHTTPClient(t, interval, timeout, ignoredStatusCodes...))
+}
+
+func newHTTPClient(t *testing.T, interval time.Duration, timeout time.Duration, ignoredStatusCodes ...int) *http.Client {
+	return &http.Client{
+		Transport: &relaxedRoundtripper{
+			test:               t,
+			ignoredStatusCodes: ignoredStatusCodes,
+			interval:           interval,
+			timeout:            timeout,
+		},
+	}
+}
+
+type relaxedRoundtripper struct {
+	test               *testing.T
+	ignoredStatusCodes []int
+	interval           time.Duration
+	timeout            time.Duration
+}
+
+func (r *relaxedRoundtripper) RoundTrip(request *http.Request) (*http.Response, error) {
+	var (
+		bodyBytes []byte
+		response  *http.Response
+		lastErr   error
+	)
+
+	// clone request body
+	if request.Body != nil {
+		var err error
+
+		bodyBytes, err = ioutil.ReadAll(request.Body)
+		if err != nil {
+			return nil, fmt.Errorf("failed to read request body: %v", err)
+		}
+	}
+
+	r.test.Logf("%s %s", request.Method, request.URL.Path)
+
+	attempts := 0
+	err := wait.PollImmediate(r.interval, r.timeout, func() (bool, error) {
+		var reqErr error
+
+		attempts++
+
+		// create a fresh timeout that starts *now*
+		// NB: Do *not* cancel this context, as the context controls the
+		// request and response lifecycle. Cancelling the context here will
+		// make it impossible for the caller to read the response body.
+		// As this context times out anyway, and timing out means it closes
+		// itself, it's okay to not call cancel() here.
+		//nolint:lostcancel
+		ctx, _ := context.WithTimeout(context.Background(), apiRequestTimeout)
+
+		// replace any preexisting context with our new one
+		requestClone := request.Clone(ctx)
+
+		if bodyBytes != nil {
+			requestClone.Body = ioutil.NopCloser(bytes.NewReader(bodyBytes))
+		}
+
+		// perform request
+		//nolint:bodyclose
+		response, reqErr = http.DefaultTransport.RoundTrip(requestClone)
+
+		// swallow network errors like timeouts
+		if reqErr != nil {
+			// only record the request error if it was not the ctx being cancelled or
+			// expiring, as the lastErr is meant to give the cause for the timeout
+			if reqErr != context.DeadlineExceeded && reqErr != context.Canceled {
+				lastErr = reqErr
+			}
+
+			return false, nil
+		}
+
+		// ignore transient errors
+		if r.isTransientError(response) {
+			body, err := ioutil.ReadAll(response.Body)
+			if err != nil {
+				lastErr = fmt.Errorf("HTTP %s: (failed to read body: %v)", response.Status, err)
+			} else {
+				lastErr = fmt.Errorf("HTTP %s: %s", response.Status, string(body))
+			}
+
+			response.Body.Close()
+			return false, nil
+		}
+
+		// success!
+		return true, nil
+	})
+
+	if err != nil {
+		// because our Poll function never returns an error, err must be ErrWaitTimeout;
+		// RoundTrippers must never return a response and an error at the same time.
+		return nil, fmt.Errorf("request did not succeed after %v (%d attempts, ignoring HTTP codes %v), last error was: %v", r.timeout, attempts, r.ignoredStatusCodes, lastErr)
+	}
+
+	return response, nil
+}
+
+func (r *relaxedRoundtripper) isTransientError(response *http.Response) bool {
+	if response.StatusCode >= http.StatusInternalServerError {
+		return true
+	}
+
+	for _, code := range r.ignoredStatusCodes {
+		if code == response.StatusCode {
+			return true
+		}
+	}
+
+	return false
+}

--- a/pkg/test/e2e/api/credentials_test.go
+++ b/pkg/test/e2e/api/credentials_test.go
@@ -67,13 +67,13 @@ func TestListCredentials(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			masterToken, err := retrieveMasterToken()
 			if err != nil {
-				t.Fatalf("can not get master token due error: %v", err)
+				t.Fatalf("failed to get master token: %v", err)
 			}
 
 			apiRunner := createRunner(masterToken, t)
 			credentialList, err := apiRunner.ListCredentials(tc.provider, tc.datacenter)
 			if err != nil {
-				t.Fatalf("can not get credential names for provider %s: %v", tc.provider, err)
+				t.Fatalf("failed to get credential names for provider %s: %v", tc.provider, err)
 			}
 			sort.Strings(tc.expectedList)
 			sort.Strings(credentialList)
@@ -110,7 +110,7 @@ func TestProviderEndpointsWithCredentials(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			masterToken, err := retrieveMasterToken()
 			if err != nil {
-				t.Fatalf("can not get master token due error: %v", err)
+				t.Fatalf("failed to get master token: %v", err)
 			}
 
 			var u url.URL
@@ -120,7 +120,7 @@ func TestProviderEndpointsWithCredentials(t *testing.T) {
 
 			req, err := http.NewRequest("GET", u.String(), nil)
 			if err != nil {
-				t.Fatalf("can not make GET call due error: %v", err)
+				t.Fatalf("failed to make GET call: %v", err)
 			}
 
 			req.Header.Set("Cache-Control", "no-cache")
@@ -135,14 +135,13 @@ func TestProviderEndpointsWithCredentials(t *testing.T) {
 
 			resp, err := client.Do(req)
 			if err != nil {
-				t.Fatal("error reading response. ", err)
+				t.Fatalf("error reading response: %v", err)
 			}
 			defer resp.Body.Close()
 
 			if resp.StatusCode != tc.expectedCode {
-				t.Fatalf("expected code %d, got %d", tc.expectedCode, resp.StatusCode)
+				t.Fatalf("expected code %d, but got %d", tc.expectedCode, resp.StatusCode)
 			}
-
 		})
 	}
 }

--- a/pkg/test/e2e/api/dc_test.go
+++ b/pkg/test/e2e/api/dc_test.go
@@ -41,14 +41,14 @@ func TestListDCForProvider(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			masterToken, err := retrieveMasterToken()
 			if err != nil {
-				t.Fatalf("can not get master token due error: %v", err)
+				t.Fatalf("failed to get master token: %v", err)
 			}
 
 			apiRunner := createRunner(masterToken, t)
 
 			dcs, err := apiRunner.ListDCForProvider(tc.provider)
 			if err != nil {
-				t.Fatalf("can not get dcs list due to error: %v", GetErrorResponse(err))
+				t.Fatalf("failed to get dcs list: %v", err)
 			}
 
 			var resultNames []string
@@ -95,14 +95,14 @@ func TestGetDCForProvider(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			masterToken, err := retrieveMasterToken()
 			if err != nil {
-				t.Fatalf("can not get master token due error: %v", err)
+				t.Fatalf("failed to get master token: %v", err)
 			}
 
 			apiRunner := createRunner(masterToken, t)
 
 			dc, err := apiRunner.GetDCForProvider(tc.provider, tc.dc)
 			if err != nil {
-				t.Fatalf("can not get dc due to error: %v", GetErrorResponse(err))
+				t.Fatalf("failed to get dc: %v", err)
 			}
 
 			if !reflect.DeepEqual(tc.expected, dc) {
@@ -143,14 +143,14 @@ func TestCreateDC(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			adminMasterToken, err := retrieveAdminMasterToken()
 			if err != nil {
-				t.Fatalf("can not get admin master token due error: %v", err)
+				t.Fatalf("failed to get admin master token: %v", err)
 			}
 
 			adminAPIRunner := createRunner(adminMasterToken, t)
 
 			dc, err := adminAPIRunner.CreateDC(tc.seed, tc.dc)
 			if err != nil {
-				t.Fatalf("can not create dc due to error: %v", GetErrorResponse(err))
+				t.Fatalf("failed to create dc: %v", err)
 			}
 
 			if !reflect.DeepEqual(tc.dc, dc) {
@@ -158,9 +158,9 @@ func TestCreateDC(t *testing.T) {
 					*tc.dc.Metadata, *tc.dc.Spec, *tc.dc.Spec.Node, *dc.Metadata, *dc.Spec, *dc.Spec.Node)
 			}
 
-			_, err = adminAPIRunner.GetDCForSeedWithRetry(tc.seed, tc.dc.Metadata.Name, 5)
+			_, err = adminAPIRunner.GetDCForSeed(tc.seed, tc.dc.Metadata.Name)
 			if err != nil {
-				t.Fatalf("can not get dc due to error: %v", GetErrorResponse(err))
+				t.Fatalf("failed to get dc: %v", err)
 			}
 
 			// user can't create DC with the same name in the same seed
@@ -202,24 +202,24 @@ func TestDeleteDC(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			adminMasterToken, err := retrieveAdminMasterToken()
 			if err != nil {
-				t.Fatalf("can not get admin master token due error: %v", err)
+				t.Fatalf("failed to get admin master token: %v", err)
 			}
 
 			adminAPIRunner := createRunner(adminMasterToken, t)
 
 			_, err = adminAPIRunner.CreateDC(tc.seed, tc.dc)
 			if err != nil {
-				t.Fatalf("can not create dc due to error: %v", GetErrorResponse(err))
+				t.Fatalf("failed to create dc: %v", err)
 			}
 
-			_, err = adminAPIRunner.GetDCForSeedWithRetry(tc.seed, tc.dc.Metadata.Name, 5)
+			_, err = adminAPIRunner.GetDCForSeed(tc.seed, tc.dc.Metadata.Name)
 			if err != nil {
-				t.Fatalf("can not get dc due to error: %v", GetErrorResponse(err))
+				t.Fatalf("failed to get dc: %v", err)
 			}
 
 			err = adminAPIRunner.DeleteDC(tc.seed, tc.dc.Metadata.Name)
 			if err != nil {
-				t.Fatalf("can not delete dc due to error: %v", GetErrorResponse(err))
+				t.Fatalf("failed to delete dc: %v", err)
 			}
 		})
 	}
@@ -271,14 +271,14 @@ func TestUpdateDC(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			adminMasterToken, err := retrieveAdminMasterToken()
 			if err != nil {
-				t.Fatalf("can not get admin master token due error: %v", err)
+				t.Fatalf("failed to get admin master token: %v", err)
 			}
 
 			adminAPIRunner := createRunner(adminMasterToken, t)
 
 			dc, err := adminAPIRunner.CreateDC(tc.seed, tc.originalDC)
 			if err != nil {
-				t.Fatalf("can not create dc due to error: %v", GetErrorResponse(err))
+				t.Fatalf("failed to create dc: %v", err)
 			}
 
 			if !reflect.DeepEqual(tc.originalDC, dc) {
@@ -286,14 +286,14 @@ func TestUpdateDC(t *testing.T) {
 					*tc.originalDC.Metadata, *tc.originalDC.Spec, *tc.originalDC.Spec.Node, *dc.Metadata, *dc.Spec, *dc.Spec.Node)
 			}
 
-			_, err = adminAPIRunner.GetDCForSeedWithRetry(tc.seed, tc.originalDC.Metadata.Name, 5)
+			_, err = adminAPIRunner.GetDCForSeed(tc.seed, tc.originalDC.Metadata.Name)
 			if err != nil {
-				t.Fatalf("can not get dc due to error: %v", GetErrorResponse(err))
+				t.Fatalf("failed to get dc: %v", err)
 			}
 
 			updatedDC, err := adminAPIRunner.UpdateDC(tc.seed, tc.originalDC.Metadata.Name, tc.updatedDC)
 			if err != nil {
-				t.Fatalf("can not update dc due to error: %v", GetErrorResponse(err))
+				t.Fatalf("failed to update dc: %v", err)
 			}
 
 			if !reflect.DeepEqual(tc.updatedDC, updatedDC) {
@@ -352,14 +352,14 @@ func TestPatchDC(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			adminMasterToken, err := retrieveAdminMasterToken()
 			if err != nil {
-				t.Fatalf("can not get admin master token due error: %v", err)
+				t.Fatalf("failed to get admin master token: %v", err)
 			}
 
 			adminAPIRunner := createRunner(adminMasterToken, t)
 
 			dc, err := adminAPIRunner.CreateDC(tc.seed, tc.originalDC)
 			if err != nil {
-				t.Fatalf("can not create dc due to error: %v", GetErrorResponse(err))
+				t.Fatalf("failed to create dc: %v", err)
 			}
 
 			if !reflect.DeepEqual(tc.originalDC, dc) {
@@ -367,14 +367,14 @@ func TestPatchDC(t *testing.T) {
 					*tc.originalDC.Metadata, *tc.originalDC.Spec, *tc.originalDC.Spec.Node, *dc.Metadata, *dc.Spec, *dc.Spec.Node)
 			}
 
-			_, err = adminAPIRunner.GetDCForSeedWithRetry(tc.seed, tc.originalDC.Metadata.Name, 5)
+			_, err = adminAPIRunner.GetDCForSeed(tc.seed, tc.originalDC.Metadata.Name)
 			if err != nil {
-				t.Fatalf("can not get dc due to error: %v", GetErrorResponse(err))
+				t.Fatalf("failed to get dc: %v", err)
 			}
 
 			patchedDC, err := adminAPIRunner.PatchDC(tc.seed, tc.originalDC.Metadata.Name, tc.patch)
 			if err != nil {
-				t.Fatalf("can not patch dc due to error: %v", GetErrorResponse(err))
+				t.Fatalf("failed to patch dc: %v", err)
 			}
 
 			if !reflect.DeepEqual(tc.expectedDC, patchedDC) {
@@ -417,14 +417,14 @@ func TestGetDCForSeed(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			masterToken, err := retrieveMasterToken()
 			if err != nil {
-				t.Fatalf("can not get master token due error: %v", err)
+				t.Fatalf("failed to get master token: %v", err)
 			}
 
 			apiRunner := createRunner(masterToken, t)
 
 			dc, err := apiRunner.GetDCForSeed(tc.seed, tc.dc)
 			if err != nil {
-				t.Fatalf("can not get dc due to error: %v", GetErrorResponse(err))
+				t.Fatalf("failed to get dc: %v", err)
 			}
 
 			if !reflect.DeepEqual(tc.expected, dc) {
@@ -451,14 +451,14 @@ func TestListDCForSeed(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			masterToken, err := retrieveMasterToken()
 			if err != nil {
-				t.Fatalf("can not get master token due error: %v", err)
+				t.Fatalf("failed to get master token: %v", err)
 			}
 
 			apiRunner := createRunner(masterToken, t)
 
 			dcs, err := apiRunner.ListDCForSeed(tc.seed)
 			if err != nil {
-				t.Fatalf("can not get dcs list due to error: %v", GetErrorResponse(err))
+				t.Fatalf("failed to get dcs list: %v", err)
 			}
 
 			resultNames := make(map[string]bool)
@@ -505,14 +505,14 @@ func TestGetDC(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			masterToken, err := retrieveMasterToken()
 			if err != nil {
-				t.Fatalf("can not get master token due error: %v", err)
+				t.Fatalf("failed to get master token: %v", err)
 			}
 
 			apiRunner := createRunner(masterToken, t)
 
 			dc, err := apiRunner.GetDC(tc.dc)
 			if err != nil {
-				t.Fatalf("can not get dc due to error: %v", GetErrorResponse(err))
+				t.Fatalf("failed to get dc: %v", err)
 			}
 
 			if !reflect.DeepEqual(tc.expected, dc) {
@@ -537,14 +537,14 @@ func TestListDC(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			masterToken, err := retrieveMasterToken()
 			if err != nil {
-				t.Fatalf("can not get master token due error: %v", err)
+				t.Fatalf("failed to get master token: %v", err)
 			}
 
 			apiRunner := createRunner(masterToken, t)
 
 			dcs, err := apiRunner.ListDC()
 			if err != nil {
-				t.Fatalf("can not get dcs list due to error: %v", GetErrorResponse(err))
+				t.Fatalf("failed to get dcs list: %v", err)
 			}
 
 			resultNames := make(map[string]bool)

--- a/pkg/test/e2e/api/gcp_test.go
+++ b/pkg/test/e2e/api/gcp_test.go
@@ -46,13 +46,13 @@ func TestGCPZones(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			masterToken, err := retrieveMasterToken()
 			if err != nil {
-				t.Fatalf("can not get master token due error: %v", err)
+				t.Fatalf("failed to get master token: %v", err)
 			}
 
 			apiRunner := createRunner(masterToken, t)
 			credentialList, err := apiRunner.ListCredentials(tc.provider, "")
 			if err != nil {
-				t.Fatalf("can not get credential names for provider %s: %v", tc.provider, err)
+				t.Fatalf("failed to get credential names for provider %s: %v", tc.provider, err)
 			}
 			if !equality.Semantic.DeepEqual(tc.expectedCredentials, credentialList) {
 				t.Fatalf("expected: %v, got %v", tc.expectedCredentials, credentialList)
@@ -60,16 +60,15 @@ func TestGCPZones(t *testing.T) {
 
 			zoneList, err := apiRunner.ListGCPZones(credentialList[0], tc.datacenter)
 			if err != nil {
-				t.Fatalf("can not get zones %v", err)
+				t.Fatalf("failed to get zones %v", err)
 			}
 
 			sort.Strings(zoneList)
 			sort.Strings(tc.resultList)
 
 			if !equality.Semantic.DeepEqual(tc.resultList, zoneList) {
-				t.Fatalf("expected: %v, got %v", tc.resultList, zoneList)
+				t.Fatalf("expected: %v, but got %v", tc.resultList, zoneList)
 			}
-
 		})
 	}
 }
@@ -94,13 +93,13 @@ func TestGCPDiskTypes(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			masterToken, err := retrieveMasterToken()
 			if err != nil {
-				t.Fatalf("can not get master token due error: %v", err)
+				t.Fatalf("failed to get master token: %v", err)
 			}
 
 			apiRunner := createRunner(masterToken, t)
 			credentialList, err := apiRunner.ListCredentials(tc.provider, "")
 			if err != nil {
-				t.Fatalf("can not get credential names for provider %s: %v", tc.provider, err)
+				t.Fatalf("failed to get credential names for provider %s: %v", tc.provider, err)
 			}
 			if !equality.Semantic.DeepEqual(tc.expectedCredentials, credentialList) {
 				t.Fatalf("expected: %v, got %v", tc.expectedCredentials, credentialList)
@@ -108,15 +107,14 @@ func TestGCPDiskTypes(t *testing.T) {
 
 			diskTypeList, err := apiRunner.ListGCPDiskTypes(credentialList[0], tc.zone)
 			if err != nil {
-				t.Fatalf("can not get disk types %v", err)
+				t.Fatalf("failed to get disk types: %v", err)
 			}
 
 			expectedDiskTypeList := sets.NewString(diskTypeList...)
 
 			if !expectedDiskTypeList.HasAll(tc.resultList...) {
-				t.Fatalf("expected: %v, got %v", tc.resultList, diskTypeList)
+				t.Fatalf("expected: %v, but got %v", tc.resultList, diskTypeList)
 			}
-
 		})
 	}
 }
@@ -139,23 +137,22 @@ func TestGCPSizes(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			masterToken, err := retrieveMasterToken()
 			if err != nil {
-				t.Fatalf("can not get master token due error: %v", err)
+				t.Fatalf("failed to get master token: %v", err)
 			}
 
 			apiRunner := createRunner(masterToken, t)
 			credentialList, err := apiRunner.ListCredentials(tc.provider, "")
 			if err != nil {
-				t.Fatalf("can not get credential names for provider %s: %v", tc.provider, err)
+				t.Fatalf("failed to get credential names for provider %s: %v", tc.provider, err)
 			}
 			if !equality.Semantic.DeepEqual(tc.expectedCredentials, credentialList) {
-				t.Fatalf("expected: %v, got %v", tc.expectedCredentials, credentialList)
+				t.Fatalf("expected: %v, but got %v", tc.expectedCredentials, credentialList)
 			}
 
 			_, err = apiRunner.ListGCPSizes(credentialList[0], tc.zone)
 			if err != nil {
-				t.Fatalf("can not get sizes %v", err)
+				t.Fatalf("failed to get sizes: %v", err)
 			}
-
 		})
 	}
 }

--- a/pkg/test/e2e/api/oidc.go
+++ b/pkg/test/e2e/api/oidc.go
@@ -51,7 +51,7 @@ func retrieveMasterToken() (string, error) {
 		return "", fmt.Errorf("no Helm values.yaml specified via KUBERMATIC_DEX_VALUES_FILE env variable")
 	}
 
-	logger := log.New(true, log.FormatJSON).Sugar()
+	logger := log.New(false, log.FormatJSON).Sugar()
 
 	client, err := dex.NewClientFromHelmValues(valuesFile, "kubermatic", logger)
 	if err != nil {
@@ -82,7 +82,7 @@ func retrieveAdminMasterToken() (string, error) {
 		return "", fmt.Errorf("no Helm values.yaml specified via KUBERMATIC_DEX_VALUES_FILE env variable")
 	}
 
-	logger := log.New(true, log.FormatJSON).Sugar()
+	logger := log.New(false, log.FormatJSON).Sugar()
 
 	client, err := dex.NewClientFromHelmValues(valuesFile, "kubermatic", logger)
 	if err != nil {

--- a/pkg/test/e2e/api/ssh_test.go
+++ b/pkg/test/e2e/api/ssh_test.go
@@ -41,24 +41,23 @@ func TestCreateSSHKey(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			masterToken, err := retrieveMasterToken()
 			if err != nil {
-				t.Fatalf("can not get master token due error: %v", err)
+				t.Fatalf("failed to get master token: %v", err)
 			}
 
 			apiRunner := createRunner(masterToken, t)
 			project, err := apiRunner.CreateProject(rand.String(10))
 			if err != nil {
-				t.Fatalf("can not create project due error: %v", err)
+				t.Fatalf("failed to create project: %v", err)
 			}
-			teardown := cleanUpProject(project.ID, 1)
-			defer teardown(t)
+			defer cleanUpProject(t, project.ID)
 
 			sshKey, err := apiRunner.CreateUserSSHKey(project.ID, tc.keyName, tc.publicKey)
 			if err != nil {
-				t.Fatalf("can not get create SSH key due error: %v", err)
+				t.Fatalf("failed to get create SSH key: %v", err)
 			}
 			sshKeys, err := apiRunner.ListUserSSHKey(project.ID)
 			if err != nil {
-				t.Fatalf("can not list SSH keys due error: %v", err)
+				t.Fatalf("failed to list SSH keys: %v", err)
 			}
 			if len(sshKeys) != 1 {
 				t.Fatalf("expected one SSH key, got %d", len(sshKeys))
@@ -66,12 +65,12 @@ func TestCreateSSHKey(t *testing.T) {
 			if !reflect.DeepEqual(sshKeys[0], sshKey) {
 				t.Fatalf("expected %v, got %v", sshKey, sshKeys[0])
 			}
+
 			// user can't create SSH key with the same name
 			_, err = apiRunner.CreateUserSSHKey(project.ID, tc.keyName, tc.publicKey)
 			if err == nil {
 				t.Fatalf("expected error, shouldn't create SSH key with existing name")
 			}
-
 		})
 	}
 }
@@ -92,33 +91,31 @@ func TestDeleteSSHKey(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			masterToken, err := retrieveMasterToken()
 			if err != nil {
-				t.Fatalf("can not get master token due error: %v", err)
+				t.Fatalf("failed to get master token: %v", err)
 			}
 
 			apiRunner := createRunner(masterToken, t)
 			project, err := apiRunner.CreateProject(rand.String(10))
 			if err != nil {
-				t.Fatalf("can not create project due error: %v", err)
+				t.Fatalf("failed to create project: %v", err)
 			}
-			teardown := cleanUpProject(project.ID, 1)
-			defer teardown(t)
+			defer cleanUpProject(t, project.ID)
 
 			sshKey, err := apiRunner.CreateUserSSHKey(project.ID, tc.keyName, tc.publicKey)
 			if err != nil {
-				t.Fatalf("can not get create SSH key due error: %v", err)
+				t.Fatalf("failed to get create SSH key: %v", err)
 			}
 
 			if err := apiRunner.DeleteUserSSHKey(project.ID, sshKey.ID); err != nil {
-				t.Fatalf("can not delete SSH key due error: %v", err)
+				t.Fatalf("failed to delete SSH key: %v", err)
 			}
 			sshKeys, err := apiRunner.ListUserSSHKey(project.ID)
 			if err != nil {
-				t.Fatalf("can not list SSH keys due error: %v", err)
+				t.Fatalf("failed to list SSH keys: %v", err)
 			}
 			if len(sshKeys) != 0 {
-				t.Fatalf("found SSH key")
+				t.Fatal("found SSH key")
 			}
-
 		})
 	}
 }

--- a/pkg/test/e2e/api/util.go
+++ b/pkg/test/e2e/api/util.go
@@ -1,0 +1,112 @@
+/*
+Copyright 2020 The Kubermatic Kubernetes Platform contributors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package api
+
+import (
+	"fmt"
+	"os"
+	"testing"
+	"time"
+
+	"k8s.io/apimachinery/pkg/util/wait"
+)
+
+func getHost() string {
+	host := os.Getenv("KUBERMATIC_HOST")
+	if len(host) == 0 {
+		fmt.Println("No KUBERMATIC_HOST env variable set.")
+		os.Exit(1)
+	}
+	return host
+}
+
+func getScheme() string {
+	scheme := os.Getenv("KUBERMATIC_SCHEME")
+	if len(scheme) == 0 {
+		fmt.Println("No KUBERMATIC_SCHEME env variable set.")
+		os.Exit(1)
+	}
+	return scheme
+}
+
+func getKubernetesVersion() string {
+	version := os.Getenv("VERSION_TO_TEST")
+	if len(version) > 0 {
+		return version
+	}
+	return "v1.18.8"
+}
+
+func cleanUpProject(t *testing.T, id string) {
+	token, err := retrieveAdminMasterToken()
+	if err != nil {
+		t.Fatalf("failed to get master token: %v", err)
+	}
+
+	runner := createRunner(token, t)
+	before := time.Now()
+
+	t.Logf("Deleting project %s...", id)
+	if err := runner.DeleteProject(id); err != nil {
+		t.Fatalf("Failed to delete project: %v", err)
+	}
+
+	timeout := 3 * time.Minute
+	t.Logf("Waiting %v for project to be gone...", timeout)
+
+	err = wait.PollImmediate(time.Second, timeout, func() (bool, error) {
+		_, err := runner.GetProject(id)
+		return err != nil, nil // return true if there *was* an error, i.e. project is gone
+	})
+	if err != nil {
+		t.Fatalf("Failed to wait for project to be gone: %v", err)
+	}
+
+	t.Logf("Project deleted successfully after %v", time.Since(before))
+}
+
+func cleanUpCluster(t *testing.T, runner *runner, projectID, dc, clusterID string) {
+	before := time.Now()
+
+	t.Logf("Deleting cluster %s...", clusterID)
+	if err := runner.DeleteCluster(projectID, dc, clusterID); err != nil {
+		t.Fatalf("Failed to delete cluster: %v", err)
+	}
+
+	timeout := 3 * time.Minute
+	t.Logf("Waiting %v for cluster to be gone...", timeout)
+
+	err := wait.PollImmediate(time.Second, timeout, func() (bool, error) {
+		_, err := runner.GetCluster(projectID, dc, clusterID)
+		return err != nil, nil // return true if there *was* an error, i.e. project is gone
+	})
+	if err != nil {
+		t.Fatalf("Failed to wait for cluster to be gone: %v", err)
+	}
+
+	t.Logf("Cluster deleted successfully after %v", time.Since(before))
+}
+
+// waitFor is a convenience wrapper that makes simple, "brute force"
+// waiting loops easier to write.
+func waitFor(interval time.Duration, timeout time.Duration, callback func() bool) bool {
+	err := wait.PollImmediate(interval, timeout, func() (bool, error) {
+		return callback(), nil
+	})
+
+	return err == nil
+}


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR does a general cleanup of our API's e2e tests, triggered by the fact that they are very flaky (basically more than half of them fail). The following changes have been made:

* a custom HTTP client takes care of silently ignoring temporary network errors and unwanted HTTP status codes (e.g. 409 Conflict)
* hardcoded waitloops have been replaced with PollImmediate()
* some tests now don't create nodes anymore, in order to speed up the tests
* a lot of wait loops have been removed, as they would only hide issues
* the default k8s version has been bumped from 1.15.x to 1.8.8
* typos have been fixed
* logging has been extended a lot, so it's now much easier to follow along what tests are doing
* the tests themselves have not changed, i.e. we test the same things as before

I left a few comments explaining the highlights.

**Does this PR introduce a user-facing change?**:
```release-note
NONE
```
