### PR TITLE
make etcd launcher image name overridable

### DIFF
--- a/charts/kubermatic/Chart.yaml
+++ b/charts/kubermatic/Chart.yaml
@@ -14,7 +14,7 @@
 
 apiVersion: v1
 name: kubermatic
-version: 1.1.11
+version: 1.1.12
 appVersion: '__KUBERMATIC_TAG__'
 description: Kubermatic chart for master and/or seed clusters.
 keywords:

--- a/charts/kubermatic/templates/kubermatic-controller-manager-dep.yaml
+++ b/charts/kubermatic/templates/kubermatic-controller-manager-dep.yaml
@@ -132,6 +132,9 @@ spec:
         {{- if .Values.kubermatic.kubermaticImage }}
         - -kubermatic-image={{ .Values.kubermatic.kubermaticImage }}
         {{- end }}
+        {{- if .Values.kubermatic.etcdLauncherImage }}
+        - -etcd-launcher-image={{ .Values.kubermatic.etcdLauncherImage }}
+        {{- end }}
         {{- if .Values.kubermatic.dnatcontrollerImage }}
         - -dnatcontroller-image={{ .Values.kubermatic.dnatcontrollerImage  }}
         {{- end }}

--- a/charts/kubermatic/values.yaml
+++ b/charts/kubermatic/values.yaml
@@ -37,6 +37,8 @@ kubermatic:
   monitoringScrapeAnnotationPrefix: ""
   # The location from which to pull the Kubermatic docker image
   kubermaticImage: ""
+  # The location from which to pull the etcd launcher docker image
+  etcdLauncherImage: ""
   # The location from which to pull the Kubermatic dnatcontroller image
   dnatcontrollerImage: "quay.io/kubermatic/kubeletdnat-controller"
   # The strategy to expose the cluster with, either "NodePort" which creates a NodePort with a "nodeport-proxy.k8s.io/expose": "true" annotation to expose all

--- a/cmd/image-loader/main.go
+++ b/cmd/image-loader/main.go
@@ -385,6 +385,7 @@ func getTemplateData(version *kubermaticversion.Version) (*resources.TemplateDat
 		true,
 		// Since this is the image-loader we hardcode the default image for pulling.
 		resources.DefaultKubermaticImage,
+		resources.DefaultEtcdLauncherImage,
 		resources.DefaultDNATControllerImage,
 		false,
 	), nil

--- a/cmd/seed-controller-manager/controllers.go
+++ b/cmd/seed-controller-manager/controllers.go
@@ -129,6 +129,7 @@ func createOpenshiftController(ctrlCtx *controllerContext) error {
 		ctrlCtx.dockerPullConfigJSON,
 		ctrlCtx.runOptions.externalURL,
 		ctrlCtx.runOptions.kubermaticImage,
+		ctrlCtx.runOptions.etcdLauncherImage,
 		ctrlCtx.runOptions.dnatControllerImage,
 		openshiftcontroller.Features{
 			EtcdDataCorruptionChecks: ctrlCtx.runOptions.featureGates.Enabled(features.EtcdDataCorruptionChecks),
@@ -166,6 +167,7 @@ func createKubernetesController(ctrlCtx *controllerContext) error {
 		ctrlCtx.runOptions.oidcIssuerURL,
 		ctrlCtx.runOptions.oidcIssuerClientID,
 		ctrlCtx.runOptions.kubermaticImage,
+		ctrlCtx.runOptions.etcdLauncherImage,
 		ctrlCtx.runOptions.dnatControllerImage,
 		kubernetescontroller.Features{
 			VPA:                          ctrlCtx.runOptions.featureGates.Enabled(features.VerticalPodAutoscaler),

--- a/cmd/seed-controller-manager/options.go
+++ b/cmd/seed-controller-manager/options.go
@@ -75,6 +75,7 @@ type controllerRunOptions struct {
 	monitoringScrapeAnnotationPrefix                 string
 	dockerPullConfigJSONFile                         string
 	kubermaticImage                                  string
+	etcdLauncherImage                                string
 	dnatControllerImage                              string
 	namespace                                        string
 	apiServerDefaultReplicas                         int
@@ -138,6 +139,7 @@ func newControllerRunOptions() (controllerRunOptions, error) {
 	flag.StringVar(&c.oidcIssuerClientID, "oidc-issuer-client-id", "", "Issuer client ID")
 	flag.StringVar(&c.oidcIssuerClientSecret, "oidc-issuer-client-secret", "", "OpenID client secret")
 	flag.StringVar(&c.kubermaticImage, "kubermatic-image", resources.DefaultKubermaticImage, "The location from which to pull the Kubermatic image")
+	flag.StringVar(&c.etcdLauncherImage, "etcd-launcher-image", resources.DefaultEtcdLauncherImage, "The location from which to pull the etcd launcher image")
 	flag.StringVar(&c.dnatControllerImage, "dnatcontroller-image", resources.DefaultDNATControllerImage, "The location of the dnatcontroller-image")
 	flag.StringVar(&c.namespace, "namespace", "kubermatic", "The namespace kubermatic runs in, uses to determine where to look for datacenter custom resources")
 	flag.IntVar(&c.apiServerDefaultReplicas, "apiserver-default-replicas", 2, "The default number of replicas for usercluster api servers")

--- a/pkg/controller/seed-controller-manager/kubernetes/cluster_controller.go
+++ b/pkg/controller/seed-controller-manager/kubernetes/cluster_controller.go
@@ -89,6 +89,7 @@ type Reconciler struct {
 	dockerPullConfigJSON                             []byte
 	nodeLocalDNSCacheEnabled                         bool
 	kubermaticImage                                  string
+	etcdLauncherImage                                string
 	dnatControllerImage                              string
 	concurrentClusterUpdates                         int
 
@@ -125,6 +126,7 @@ func Add(
 	oidcIssuerURL string,
 	oidcIssuerClientID string,
 	kubermaticImage string,
+	etcdLauncherImage string,
 	dnatControllerImage string,
 	features Features) error {
 
@@ -148,6 +150,7 @@ func Add(
 		dockerPullConfigJSON:                             dockerPullConfigJSON,
 		nodeLocalDNSCacheEnabled:                         nodeLocalDNSCacheEnabled,
 		kubermaticImage:                                  kubermaticImage,
+		etcdLauncherImage:                                etcdLauncherImage,
 		dnatControllerImage:                              dnatControllerImage,
 		concurrentClusterUpdates:                         concurrentClusterUpdates,
 

--- a/pkg/controller/seed-controller-manager/kubernetes/resources.go
+++ b/pkg/controller/seed-controller-manager/kubernetes/resources.go
@@ -168,6 +168,7 @@ func (r *Reconciler) getClusterTemplateData(ctx context.Context, cluster *kuberm
 		r.oidcIssuerClientID,
 		r.nodeLocalDNSCacheEnabled,
 		r.kubermaticImage,
+		r.etcdLauncherImage,
 		r.dnatControllerImage,
 		supportsFailureDomainZoneAntiAffinity,
 	), nil

--- a/pkg/controller/seed-controller-manager/monitoring/resources.go
+++ b/pkg/controller/seed-controller-manager/monitoring/resources.go
@@ -63,6 +63,7 @@ func (r *Reconciler) getClusterTemplateData(ctx context.Context, client ctrlrunt
 		false,
 		"",
 		"",
+		"",
 		false,
 	), nil
 }

--- a/pkg/controller/seed-controller-manager/openshift/data.go
+++ b/pkg/controller/seed-controller-manager/openshift/data.go
@@ -51,6 +51,7 @@ type openshiftData struct {
 	nodeAccessNetwork                     string
 	oidc                                  OIDCConfig
 	etcdDiskSize                          resource.Quantity
+	etcdLauncherImage                     string
 	kubermaticImage                       string
 	dnatControllerImage                   string
 	supportsFailureDomainZoneAntiAffinity bool
@@ -237,6 +238,19 @@ func (od *openshiftData) EtcdDiskSize() resource.Quantity {
 	return od.etcdDiskSize
 }
 
+func (od *openshiftData) EtcdLauncherImage() string {
+	imageSplit := strings.Split(od.etcdLauncherImage, "/")
+	var registry, imageWithoutRegistry string
+	if len(imageSplit) != 3 {
+		registry = kubernetesresources.RegistryDocker
+		imageWithoutRegistry = strings.Join(imageSplit, "/")
+	} else {
+		registry = imageSplit[0]
+		imageWithoutRegistry = strings.Join(imageSplit[1:], "/")
+	}
+	return od.ImageRegistry(registry) + "/" + imageWithoutRegistry
+}
+
 // Openshift has its own DNS cache, so this is always false
 func (od *openshiftData) NodeLocalDNSCacheEnabled() bool {
 	return false
@@ -246,7 +260,7 @@ func (od *openshiftData) KubermaticAPIImage() string {
 	apiImageSplit := strings.Split(od.kubermaticImage, "/")
 	var registry, imageWithoutRegistry string
 	if len(apiImageSplit) != 3 {
-		registry = "docker.io"
+		registry = kubernetesresources.RegistryDocker
 		imageWithoutRegistry = strings.Join(apiImageSplit, "/")
 	} else {
 		registry = apiImageSplit[0]
@@ -263,7 +277,7 @@ func (od *openshiftData) DNATControllerImage() string {
 	dnatControllerImageSplit := strings.Split(od.dnatControllerImage, "/")
 	var registry, imageWithoutRegistry string
 	if len(dnatControllerImageSplit) != 3 {
-		registry = "docker.io"
+		registry = kubernetesresources.RegistryDocker
 		imageWithoutRegistry = strings.Join(dnatControllerImageSplit, "/")
 	} else {
 		registry = dnatControllerImageSplit[0]

--- a/pkg/controller/seed-controller-manager/openshift/openshift_controller.go
+++ b/pkg/controller/seed-controller-manager/openshift/openshift_controller.go
@@ -101,6 +101,7 @@ type Reconciler struct {
 	externalURL              string
 	oidc                     OIDCConfig
 	kubermaticImage          string
+	etcdLauncherImage        string
 	dnatControllerImage      string
 	features                 Features
 	concurrentClusterUpdates int
@@ -119,6 +120,7 @@ func Add(
 	dockerPullConfigJSON []byte,
 	externalURL string,
 	kubermaticImage string,
+	etcdLauncherImage string,
 	dnatControllerImage string,
 	features Features,
 	concurrentClusterUpdates int,
@@ -137,6 +139,7 @@ func Add(
 		workerName:               workerName,
 		externalURL:              externalURL,
 		kubermaticImage:          kubermaticImage,
+		etcdLauncherImage:        etcdLauncherImage,
 		dnatControllerImage:      dnatControllerImage,
 		features:                 features,
 		concurrentClusterUpdates: concurrentClusterUpdates,

--- a/pkg/controller/seed-controller-manager/openshift/resources.go
+++ b/pkg/controller/seed-controller-manager/openshift/resources.go
@@ -52,6 +52,7 @@ func (r *Reconciler) getOSData(ctx context.Context, cluster *kubermaticv1.Cluste
 		oidc:                                  r.oidc,
 		etcdDiskSize:                          r.etcdDiskSize,
 		kubermaticImage:                       r.kubermaticImage,
+		etcdLauncherImage:                     r.etcdLauncherImage,
 		dnatControllerImage:                   r.dnatControllerImage,
 		supportsFailureDomainZoneAntiAffinity: supportsFailureDomainZoneAntiAffinity,
 		externalURL:                           r.externalURL,

--- a/pkg/resources/data.go
+++ b/pkg/resources/data.go
@@ -57,6 +57,7 @@ type TemplateData struct {
 	oidcIssuerClientID                               string
 	nodeLocalDNSCacheEnabled                         bool
 	kubermaticImage                                  string
+	etcdLauncherImage                                string
 	dnatControllerImage                              string
 	supportsFailureDomainZoneAntiAffinity            bool
 }
@@ -82,6 +83,7 @@ func NewTemplateData(
 	oidcIssuerClientID string,
 	nodeLocalDNSCacheEnabled bool,
 	kubermaticImage string,
+	etcdLauncherImage string,
 	dnatControllerImage string,
 	supportsFailureDomainZoneAntiAffinity bool) *TemplateData {
 	return &TemplateData{
@@ -104,6 +106,7 @@ func NewTemplateData(
 		oidcIssuerClientID:                               oidcIssuerClientID,
 		nodeLocalDNSCacheEnabled:                         nodeLocalDNSCacheEnabled,
 		kubermaticImage:                                  kubermaticImage,
+		etcdLauncherImage:                                etcdLauncherImage,
 		dnatControllerImage:                              dnatControllerImage,
 		supportsFailureDomainZoneAntiAffinity:            supportsFailureDomainZoneAntiAffinity,
 	}
@@ -156,6 +159,19 @@ func (d *TemplateData) DC() *kubermaticv1.Datacenter {
 // EtcdDiskSize returns the etcd disk size
 func (d *TemplateData) EtcdDiskSize() resource.Quantity {
 	return d.etcdDiskSize
+}
+
+func (d *TemplateData) EtcdLauncherImage() string {
+	imageSplit := strings.Split(d.etcdLauncherImage, "/")
+	var registry, imageWithoutRegistry string
+	if len(imageSplit) != 3 {
+		registry = RegistryDocker
+		imageWithoutRegistry = strings.Join(imageSplit, "/")
+	} else {
+		registry = imageSplit[0]
+		imageWithoutRegistry = strings.Join(imageSplit[1:], "/")
+	}
+	return d.ImageRegistry(registry) + "/" + imageWithoutRegistry
 }
 
 // MonitoringScrapeAnnotationPrefix returns the scrape annotation prefix
@@ -277,7 +293,7 @@ func (d *TemplateData) KubermaticAPIImage() string {
 	apiImageSplit := strings.Split(d.kubermaticImage, "/")
 	var registry, imageWithoutRegistry string
 	if len(apiImageSplit) != 3 {
-		registry = "docker.io"
+		registry = RegistryDocker
 		imageWithoutRegistry = strings.Join(apiImageSplit, "/")
 	} else {
 		registry = apiImageSplit[0]
@@ -290,7 +306,7 @@ func (d *TemplateData) DNATControllerImage() string {
 	dnatControllerImageSplit := strings.Split(d.dnatControllerImage, "/")
 	var registry, imageWithoutRegistry string
 	if len(dnatControllerImageSplit) != 3 {
-		registry = "docker.io"
+		registry = RegistryDocker
 		imageWithoutRegistry = strings.Join(dnatControllerImageSplit, "/")
 	} else {
 		registry = dnatControllerImageSplit[0]

--- a/pkg/resources/etcd/statefulset.go
+++ b/pkg/resources/etcd/statefulset.go
@@ -61,6 +61,7 @@ type etcdStatefulSetCreatorData interface {
 	GetPodTemplateLabels(string, []corev1.Volume, map[string]string) (map[string]string, error)
 	ImageRegistry(string) string
 	EtcdDiskSize() resource.Quantity
+	EtcdLauncherImage() string
 	GetClusterRef() metav1.OwnerReference
 	SupportsFailureDomainZoneAntiAffinity() bool
 }
@@ -101,9 +102,8 @@ func StatefulSetCreator(data etcdStatefulSetCreatorData, enableDataCorruptionChe
 
 			set.Spec.Template.Spec.InitContainers = []corev1.Container{
 				{
-					Name: "etcd-launcher-init",
-
-					Image:           data.ImageRegistry(resources.RegistryQuay) + "/kubermatic/etcd-launcher:" + resources.KUBERMATICCOMMIT,
+					Name:            "etcd-launcher-init",
+					Image:           data.EtcdLauncherImage() + ":" + resources.KUBERMATICCOMMIT,
 					ImagePullPolicy: corev1.PullIfNotPresent,
 					Command:         []string{"/bin/cp", "/etcd-launcher", "/opt/bin/"},
 					VolumeMounts: []corev1.VolumeMount{

--- a/pkg/resources/resources_ce.go
+++ b/pkg/resources/resources_ce.go
@@ -22,6 +22,9 @@ const (
 	// DefaultKubermaticImage defines the default Docker repository containing the Kubermatic API image.
 	DefaultKubermaticImage = "quay.io/kubermatic/kubermatic"
 
+	// DefaultEtcdLauncherImage defines the default Docker repository containing the etcd launcher image.
+	DefaultEtcdLauncherImage = "quay.io/kubermatic/etcd-launcher"
+
 	// DefaultDNATControllerImage defines the default Docker repository containing the DNAT controller image.
 	DefaultDNATControllerImage = "quay.io/kubermatic/kubeletdnat-controller"
 

--- a/pkg/resources/resources_ee.go
+++ b/pkg/resources/resources_ee.go
@@ -22,6 +22,9 @@ const (
 	// DefaultKubermaticImage defines the default Docker repository containing the Kubermatic API image.
 	DefaultKubermaticImage = "quay.io/kubermatic/kubermatic-ee"
 
+	// DefaultEtcdLauncherImage defines the default Docker repository containing the etcd launcher image.
+	DefaultEtcdLauncherImage = "quay.io/kubermatic/etcd-launcher"
+
 	// DefaultDNATControllerImage defines the default Docker repository containing the DNAT controller image.
 	DefaultDNATControllerImage = "quay.io/kubermatic/kubeletdnat-controller"
 

--- a/pkg/resources/test/load_files_test.go
+++ b/pkg/resources/test/load_files_test.go
@@ -582,6 +582,7 @@ func TestLoadFiles(t *testing.T) {
 					"kubermaticIssuer",
 					true,
 					"quay.io/kubermatic/kubermatic",
+					"quay.io/kubermatic/etcd-launcher",
 					"quay.io/kubermatic/kubeletdnat-controller",
 					false)
 


### PR DESCRIPTION
Signed-off-by: Olaf Klischat <olaf.klischat@gmail.com>

**What this PR does / why we need it**:

This adds an option `-etcd-launcher-image` to the seed-controller-manager which lets the user set the image name for the etcd launcher initcontainer image. This is the same thing that `-kubermatic-image` does for the kubermatic api image, i.e. it allows you to pull the image from somewhere other than Kubermatic's own quay repo, which is needed if people run their own fork with KUBERMATICCOMMIT values that don't exist upstream.

**Does this PR introduce a user-facing change?**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If  no release note is required, just write "NONE".
-->
```release-note
etcd launcher image name overridable
```
