### PR TITLE
register external cluster to RBAC controller

### DIFF
--- a/pkg/controller/master-controller-manager/rbac/rbac_controller_aggregator.go
+++ b/pkg/controller/master-controller-manager/rbac/rbac_controller_aggregator.go
@@ -161,7 +161,7 @@ func New(metrics *Metrics, mgr manager.Manager, seedManagerMap map[string]manage
 			kind:      "Secret",
 			namespace: "kubermatic",
 			shouldEnqueue: func(obj metav1.Object) bool {
-				// do not reconcile secrets without "sa-token" and "credential" prefix
+				// do not reconcile secrets without "sa-token", "credential" and "kubeconfig-external-cluster" prefix
 				return shouldEnqueueSecret(obj.GetName())
 			},
 		},
@@ -177,6 +177,15 @@ func New(metrics *Metrics, mgr manager.Manager, seedManagerMap map[string]manage
 				// do not reconcile resources without "serviceaccount" prefix
 				return strings.HasPrefix(obj.GetName(), "serviceaccount")
 			},
+		},
+
+		{
+			gvr: schema.GroupVersionResource{
+				Group:    kubermaticv1.GroupName,
+				Version:  kubermaticv1.GroupVersion,
+				Resource: kubermaticv1.ExternalClusterResourceName,
+			},
+			kind: kubermaticv1.ExternalClusterKind,
 		},
 	}
 
@@ -222,7 +231,7 @@ func (a *ControllerAggregator) Start(stopCh <-chan struct{}) error {
 }
 
 func shouldEnqueueSecret(name string) bool {
-	supportedPrefixes := []string{"sa-token", "credential"}
+	supportedPrefixes := []string{"sa-token", "credential", "kubeconfig-external-cluster"}
 	for _, prefix := range supportedPrefixes {
 		if strings.HasPrefix(name, prefix) {
 			return true

--- a/pkg/controller/master-controller-manager/rbac/sync_project_test.go
+++ b/pkg/controller/master-controller-manager/rbac/sync_project_test.go
@@ -462,6 +462,64 @@ func TestEnsureProjectClusterRBACRoleBindingForResources(t *testing.T) {
 				},
 			},
 		},
+
+		// scenario 3
+		{
+			name:                     "Scenario 3: Proper set of RBAC Bindings for project's ExternalCluster created on master",
+			projectToSync:            "thunderball",
+			expectedActionsForMaster: []string{"create", "create"},
+			projectResourcesToSync: []projectResource{
+				{
+					gvr: schema.GroupVersionResource{
+						Group:    kubermaticv1.GroupName,
+						Version:  kubermaticv1.GroupVersion,
+						Resource: kubermaticv1.ExternalClusterResourceName,
+					},
+					kind: kubermaticv1.ExternalClusterKind,
+				},
+			},
+			expectedClusterRoleBindingsForMaster: []*rbacv1.ClusterRoleBinding{
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:            "kubermatic:externalclusters:owners",
+						ResourceVersion: "1",
+					},
+					Subjects: []rbacv1.Subject{
+						{
+							APIGroup: rbacv1.GroupName,
+							Kind:     "Group",
+							Name:     "owners-thunderball",
+						},
+					},
+					RoleRef: rbacv1.RoleRef{
+						APIGroup: rbacv1.GroupName,
+						Kind:     "ClusterRole",
+						Name:     "kubermatic:externalclusters:owners",
+					},
+				},
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:            "kubermatic:externalclusters:editors",
+						ResourceVersion: "1",
+					},
+					Subjects: []rbacv1.Subject{
+						{
+							APIGroup: rbacv1.GroupName,
+							Kind:     "Group",
+							Name:     "editors-thunderball",
+						},
+					},
+					RoleRef: rbacv1.RoleRef{
+						APIGroup: rbacv1.GroupName,
+						Kind:     "ClusterRole",
+						Name:     "kubermatic:externalclusters:editors",
+					},
+				},
+			},
+			seedClusters:                        2,
+			expectedActionsForSeeds:             []string{"create", "create"},
+			expectedClusterRoleBindingsForSeeds: []*rbacv1.ClusterRoleBinding{},
+		},
 	}
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
@@ -1161,6 +1219,55 @@ func TestEnsureProjectClusterRBACRoleForResources(t *testing.T) {
 						{
 							APIGroups: []string{kubermaticv1.SchemeGroupVersion.Group},
 							Resources: []string{"userprojectbindings"},
+							Verbs:     []string{"create"},
+						},
+					},
+				},
+			},
+		},
+
+		// scenario 3
+		{
+			name:                     "Scenario 3: Proper set of RBAC Roles for ExternalCluster resource are created on \"master\" and seed clusters",
+			expectedActionsForMaster: []string{"create"},
+			// UserProjectBinding is a resource that is only on master cluster
+			expectedActionsForSeeds: []string{},
+			seedClusters:            2,
+			projectResourcesToSync: []projectResource{
+				{
+					gvr: schema.GroupVersionResource{
+						Group:    kubermaticv1.GroupName,
+						Version:  kubermaticv1.GroupVersion,
+						Resource: kubermaticv1.ExternalClusterResourceName,
+					},
+					kind: kubermaticv1.ExternalClusterKind,
+				},
+			},
+
+			expectedClusterRolesForMaster: []*rbacv1.ClusterRole{
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:            "kubermatic:externalclusters:owners",
+						ResourceVersion: "1",
+					},
+					Rules: []rbacv1.PolicyRule{
+						{
+							APIGroups: []string{kubermaticv1.SchemeGroupVersion.Group},
+							Resources: []string{"externalclusters"},
+							Verbs:     []string{"create"},
+						},
+					},
+				},
+
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:            "kubermatic:externalclusters:editors",
+						ResourceVersion: "1",
+					},
+					Rules: []rbacv1.PolicyRule{
+						{
+							APIGroups: []string{kubermaticv1.SchemeGroupVersion.Group},
+							Resources: []string{"externalclusters"},
 							Verbs:     []string{"create"},
 						},
 					},

--- a/pkg/controller/master-controller-manager/rbac/sync_resource_test.go
+++ b/pkg/controller/master-controller-manager/rbac/sync_resource_test.go
@@ -512,6 +512,183 @@ func TestSyncProjectResourcesClusterWide(t *testing.T) {
 				},
 			},
 		},
+
+		// scenario 5
+		{
+			name:            "scenario 5: a proper set of RBAC Role/Binding is generated for an external cluster",
+			expectedActions: []string{"create", "create", "create", "create", "create", "create"},
+
+			dependantToSync: &resourceToProcess{
+				gvr: schema.GroupVersionResource{
+					Group:    kubermaticv1.SchemeGroupVersion.Group,
+					Version:  kubermaticv1.SchemeGroupVersion.Version,
+					Resource: kubermaticv1.ExternalClusterResourceName,
+				},
+				kind: kubermaticv1.ExternalClusterKind,
+				metaObject: &kubermaticv1.ExternalCluster{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "abcd",
+						UID:  types.UID("abcdID"),
+						OwnerReferences: []metav1.OwnerReference{
+							{
+								APIVersion: kubermaticv1.SchemeGroupVersion.String(),
+								Kind:       kubermaticv1.ProjectKindName,
+								Name:       "thunderball",
+								UID:        "thunderballID",
+							},
+						},
+					},
+					Spec: kubermaticv1.ExternalClusterSpec{},
+				},
+			},
+
+			expectedClusterRoles: []*rbacv1.ClusterRole{
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "kubermatic:externalcluster-abcd:owners-thunderball",
+						OwnerReferences: []metav1.OwnerReference{
+							{
+								APIVersion: kubermaticv1.SchemeGroupVersion.String(),
+								Kind:       kubermaticv1.ExternalClusterKind,
+								Name:       "abcd",
+								UID:        "abcdID", // set manually
+							},
+						},
+					},
+					Rules: []rbacv1.PolicyRule{
+						{
+							APIGroups:     []string{kubermaticv1.SchemeGroupVersion.Group},
+							Resources:     []string{kubermaticv1.ExternalClusterResourceName},
+							ResourceNames: []string{"abcd"},
+							Verbs:         []string{"get", "update", "delete"},
+						},
+					},
+				},
+
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "kubermatic:externalcluster-abcd:editors-thunderball",
+						OwnerReferences: []metav1.OwnerReference{
+							{
+								APIVersion: kubermaticv1.SchemeGroupVersion.String(),
+								Kind:       kubermaticv1.ExternalClusterKind,
+								Name:       "abcd",
+								UID:        "abcdID", // set manually
+							},
+						},
+					},
+					Rules: []rbacv1.PolicyRule{
+						{
+							APIGroups:     []string{kubermaticv1.SchemeGroupVersion.Group},
+							Resources:     []string{kubermaticv1.ExternalClusterResourceName},
+							ResourceNames: []string{"abcd"},
+							Verbs:         []string{"get", "update", "delete"},
+						},
+					},
+				},
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "kubermatic:externalcluster-abcd:viewers-thunderball",
+						OwnerReferences: []metav1.OwnerReference{
+							{
+								APIVersion: kubermaticv1.SchemeGroupVersion.String(),
+								Kind:       kubermaticv1.ExternalClusterKind,
+								Name:       "abcd",
+								UID:        "abcdID", // set manually
+							},
+						},
+					},
+					Rules: []rbacv1.PolicyRule{
+						{
+							APIGroups:     []string{kubermaticv1.SchemeGroupVersion.Group},
+							Resources:     []string{kubermaticv1.ExternalClusterResourceName},
+							ResourceNames: []string{"abcd"},
+							Verbs:         []string{"get"},
+						},
+					},
+				},
+			},
+
+			expectedClusterRoleBindings: []*rbacv1.ClusterRoleBinding{
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "kubermatic:externalcluster-abcd:owners-thunderball",
+						OwnerReferences: []metav1.OwnerReference{
+							{
+								APIVersion: kubermaticv1.SchemeGroupVersion.String(),
+								Kind:       kubermaticv1.ExternalClusterKind,
+								Name:       "abcd",
+								UID:        "abcdID", // set manually
+							},
+						},
+					},
+					Subjects: []rbacv1.Subject{
+						{
+							APIGroup: rbacv1.GroupName,
+							Kind:     "Group",
+							Name:     "owners-thunderball",
+						},
+					},
+					RoleRef: rbacv1.RoleRef{
+						APIGroup: rbacv1.GroupName,
+						Kind:     "ClusterRole",
+						Name:     "kubermatic:externalcluster-abcd:owners-thunderball",
+					},
+				},
+
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "kubermatic:externalcluster-abcd:editors-thunderball",
+						OwnerReferences: []metav1.OwnerReference{
+							{
+								APIVersion: kubermaticv1.SchemeGroupVersion.String(),
+								Kind:       kubermaticv1.ExternalClusterKind,
+								Name:       "abcd",
+								UID:        "abcdID", // set manually
+							},
+						},
+					},
+					Subjects: []rbacv1.Subject{
+						{
+							APIGroup: rbacv1.GroupName,
+							Kind:     "Group",
+							Name:     "editors-thunderball",
+						},
+					},
+					RoleRef: rbacv1.RoleRef{
+						APIGroup: rbacv1.GroupName,
+						Kind:     "ClusterRole",
+						Name:     "kubermatic:externalcluster-abcd:editors-thunderball",
+					},
+				},
+
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "kubermatic:externalcluster-abcd:viewers-thunderball",
+						OwnerReferences: []metav1.OwnerReference{
+							{
+								APIVersion: kubermaticv1.SchemeGroupVersion.String(),
+								Kind:       kubermaticv1.ExternalClusterKind,
+								Name:       "abcd",
+								UID:        "abcdID", // set manually
+							},
+						},
+					},
+					Subjects: []rbacv1.Subject{
+						{
+							APIGroup: rbacv1.GroupName,
+							Kind:     "Group",
+							Name:     "viewers-thunderball",
+						},
+					},
+					RoleRef: rbacv1.RoleRef{
+						APIGroup: rbacv1.GroupName,
+						Kind:     "ClusterRole",
+						Name:     "kubermatic:externalcluster-abcd:viewers-thunderball",
+					},
+				},
+			},
+		},
 	}
 
 	for _, test := range tests {

--- a/pkg/crd/kubermatic/v1/external_cluster.go
+++ b/pkg/crd/kubermatic/v1/external_cluster.go
@@ -23,6 +23,15 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
+const (
+
+	// ExternalClusterResourceName represents "Resource" defined in Kubernetes
+	ExternalClusterResourceName = "externalclusters"
+
+	// ExternalClusterKind represents "Kind" defined in Kubernetes
+	ExternalClusterKind = "ExternalCluster"
+)
+
 //+genclient
 //+genclient:nonNamespaced
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object


### PR DESCRIPTION
**What this PR does / why we need it**: register external cluster to RBAC controller. It generates a proper set of RBAC Role/Binding for this resource.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #5714

```release-note
Add ExternalCuster to RBAC controller to generate a proper set of RBAC Role/Binding
```
