### PR TITLE
Improve image push script for local usage

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -14,10 +14,11 @@
 
 export CGO_ENABLED?=0
 export KUBERMATIC_EDITION?=ce
-REPO=quay.io/kubermatic/kubermatic$(shell [ "$(KUBERMATIC_EDITION)" != "ce" ] && echo "-$(KUBERMATIC_EDITION)" )
+DOCKER_REPO?=quay.io/kubermatic
+REPO=$(DOCKER_REPO)/kubermatic$(shell [ "$(KUBERMATIC_EDITION)" != "ce" ] && echo "-$(KUBERMATIC_EDITION)" )
 CMD=$(filter-out OWNERS nodeport-proxy kubeletdnat-controller, $(notdir $(wildcard ./cmd/*)))
 GOBUILDFLAGS?=-v
-GOOS ?= $(shell go env GOOS)
+GOOS?=$(shell go env GOOS)
 GITTAG=$(shell git describe --tags --always)
 TAGS?=$(GITTAG)
 DOCKERTAGS=$(TAGS) latestbuild

--- a/cmd/user-ssh-keys-agent/Dockerfile
+++ b/cmd/user-ssh-keys-agent/Dockerfile
@@ -15,6 +15,6 @@
 FROM alpine:3.10
 LABEL maintainer="support@kubermatic.com"
 
-COPY ./user-ssh-keys-agent /usr/local/bin/user-ssh-keys-agent
+COPY ./_build/user-ssh-keys-agent /usr/local/bin/user-ssh-keys-agent
 
 ENTRYPOINT ["/usr/local/bin/user-ssh-keys-agent"]

--- a/cmd/user-ssh-keys-agent/Makefile
+++ b/cmd/user-ssh-keys-agent/Makefile
@@ -16,7 +16,7 @@ DOCKER_REPO="quay.io/kubermatic"
 GOOS ?= $(shell go env GOOS)
 
 build:
-	GOOS=$(GOOS) CGO_ENABLED=0 go build -o user-ssh-keys-agent
+	GOOS=$(GOOS) CGO_ENABLED=0 go build -o ./_build/user-ssh-keys-agent
 
 docker: build
 	docker build -t $(DOCKER_REPO)/user-ssh-keys-agent:$(TAG) .


### PR DESCRIPTION
**What this PR does / why we need it**:
In order to do some manual tests before integrating some changes it can be useful to build locally the Docker images and push them to a local repository. This PR enhance the `hack/push_image.sh` script to cross compile the binaries used to build the images targeting `linux` by default even when the script is run from another OS.


**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Documentation**:
<!-- Add links to the related documentation changes related to this pull request. E.g. the link to the kubermatic/docs pullrequest. -->

**Does this PR introduce a user-facing change?**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If  no release note is required, just write "NONE".
-->
```release-note
NONE
```
