### PR TITLE
Allow to configure Velero plugin InitContainers

### DIFF
--- a/charts/backup/velero/Chart.yaml
+++ b/charts/backup/velero/Chart.yaml
@@ -14,7 +14,7 @@
 
 apiVersion: v1
 name: velero
-version: 1.4.1
+version: 1.4.2
 appVersion: v1.4.0
 description: A Helm chart for Heptio Velero
 keywords:

--- a/charts/backup/velero/templates/deployment.yaml
+++ b/charts/backup/velero/templates/deployment.yaml
@@ -90,6 +90,10 @@ spec:
           protocol: TCP
         resources:
 {{ toYaml .Values.velero.resources | indent 10 }}
+      {{- if .Values.velero.initContainers }}
+      initContainers:
+{{ toYaml .Values.velero.initContainers | indent 6 }}
+      {{- end }}
       volumes:
       - name: plugins
         emptyDir: {}

--- a/charts/backup/velero/values.yaml
+++ b/charts/backup/velero/values.yaml
@@ -26,6 +26,30 @@ velero:
   # are automatically set via the configuration below
   serverFlags: []
 
+  # Init containers to add to the Velero deployment's pod spec.
+  # At least one plugin provider image is required.
+  initContainers:
+  # - name: velero-plugin-for-aws
+  #   image: docker.io/velero/velero-plugin-for-aws:v1.1.0
+  #   imagePullPolicy: IfNotPresent
+  #   volumeMounts:
+  #     - mountPath: /target
+  #       name: plugins
+
+  # - name: velero-plugin-for-gcp
+  #   image: docker.io/velero/velero-plugin-for-gcp:v1.1.0
+  #   imagePullPolicy: IfNotPresent
+  #   volumeMounts:
+  #     - mountPath: /target
+  #       name: plugins
+
+  # - name: velero-plugin-for-microsoft-azure
+  #   image: docker.io/velero/velero-plugin-for-microsoft-azure:v1.1.0
+  #   imagePullPolicy: IfNotPresent
+  #   volumeMounts:
+  #     - mountPath: /target
+  #       name: plugins
+
   # whether or not to create a restic daemonset
   restic:
     deploy: false


### PR DESCRIPTION
**What this PR does / why we need it**:
When updating Velero to 1.2, we nuked the possibility to define the cloud provider plugin. Since 1.2, it's required to manually install plugins, e.g. via init containers. This PR makes it possible again for users to configure their plugins.

Enabling all three makes Velero log

```
time="2020-07-29T11:39:43Z" level=info msg="registering plugin" command=/plugins/velero-plugin-for-aws kind=VolumeSnapshotter logSource="pkg/plugin/clientmgmt/registry.go:100" name=velero.io/aws
time="2020-07-29T11:39:43Z" level=info msg="registering plugin" command=/plugins/velero-plugin-for-aws kind=ObjectStore logSource="pkg/plugin/clientmgmt/registry.go:100" name=velero.io/aws
time="2020-07-29T11:39:43Z" level=info msg="registering plugin" command=/plugins/velero-plugin-for-gcp kind=VolumeSnapshotter logSource="pkg/plugin/clientmgmt/registry.go:100" name=velero.io/gcp
time="2020-07-29T11:39:43Z" level=info msg="registering plugin" command=/plugins/velero-plugin-for-gcp kind=ObjectStore logSource="pkg/plugin/clientmgmt/registry.go:100" name=velero.io/gcp
time="2020-07-29T11:39:43Z" level=info msg="registering plugin" command=/plugins/velero-plugin-for-microsoft-azure kind=VolumeSnapshotter logSource="pkg/plugin/clientmgmt/registry.go:100" name=velero.io/azure
time="2020-07-29T11:39:43Z" level=info msg="registering plugin" command=/plugins/velero-plugin-for-microsoft-azure kind=ObjectStore logSource="pkg/plugin/clientmgmt/registry.go:100" name=velero.io/azure
```

**Does this PR introduce a user-facing change?**:
```release-note
Re-enable plugin initContainers for Velero
```
