### PR TITLE
[release/v2.14] Allow to configure Velero plugin InitContainers (#5718)

### DIFF
--- a/config/backup/velero/Chart.yaml
+++ b/config/backup/velero/Chart.yaml
@@ -14,7 +14,7 @@
 
 apiVersion: v1
 name: velero
-version: 1.3.3
+version: 1.3.4
 appVersion: v1.3.2
 description: A Helm chart for Heptio Velero
 keywords:

--- a/config/backup/velero/templates/deployment.yaml
+++ b/config/backup/velero/templates/deployment.yaml
@@ -89,6 +89,10 @@ spec:
           protocol: TCP
         resources:
 {{ toYaml .Values.velero.resources | indent 10 }}
+      {{- if .Values.velero.initContainers }}
+      initContainers:
+{{ toYaml .Values.velero.initContainers | indent 6 }}
+      {{- end }}
       volumes:
       - name: plugins
         emptyDir: {}

--- a/config/backup/velero/values.yaml
+++ b/config/backup/velero/values.yaml
@@ -26,6 +26,30 @@ velero:
   # are automatically set via the configuration below
   serverFlags: []
 
+  # Init containers to add to the Velero deployment's pod spec.
+  # At least one plugin provider image is required.
+  initContainers:
+  # - name: velero-plugin-for-aws
+  #   image: docker.io/velero/velero-plugin-for-aws:v1.1.0
+  #   imagePullPolicy: IfNotPresent
+  #   volumeMounts:
+  #     - mountPath: /target
+  #       name: plugins
+
+  # - name: velero-plugin-for-gcp
+  #   image: docker.io/velero/velero-plugin-for-gcp:v1.1.0
+  #   imagePullPolicy: IfNotPresent
+  #   volumeMounts:
+  #     - mountPath: /target
+  #       name: plugins
+
+  # - name: velero-plugin-for-microsoft-azure
+  #   image: docker.io/velero/velero-plugin-for-microsoft-azure:v1.1.0
+  #   imagePullPolicy: IfNotPresent
+  #   volumeMounts:
+  #     - mountPath: /target
+  #       name: plugins
+
   # whether or not to create a restic daemonset
   restic:
     deploy: false


### PR DESCRIPTION
**What this PR does / why we need it**:
Backports #5718 into the 2.14 release branch.

**Does this PR introduce a user-facing change?**:
```release-note
Re-enable plugin initContainers for Velero
```
