### PR TITLE
custom default etcd replicas number for new clusters

### DIFF
--- a/charts/kubermatic/Chart.yaml
+++ b/charts/kubermatic/Chart.yaml
@@ -14,7 +14,7 @@
 
 apiVersion: v1
 name: kubermatic
-version: 1.1.12
+version: 1.1.13
 appVersion: '__KUBERMATIC_TAG__'
 description: Kubermatic chart for master and/or seed clusters.
 keywords:

--- a/charts/kubermatic/templates/kubermatic-controller-manager-dep.yaml
+++ b/charts/kubermatic/templates/kubermatic-controller-manager-dep.yaml
@@ -74,6 +74,7 @@ spec:
         - -external-url={{ .Values.kubermatic.domain }}
         - -datacenter-name={{ .Values.kubermatic.controller.datacenterName }}
         - -etcd-disk-size={{ .Values.kubermatic.etcd.diskSize }}
+        - -etcd-replicas={{ .Values.kubermatic.etcd.replicas }}
         {{- if .Values.kubermatic.datacenters }}
         - -datacenters=/opt/datacenter/datacenters.yaml
         {{- end }}

--- a/charts/kubermatic/values.yaml
+++ b/charts/kubermatic/values.yaml
@@ -78,6 +78,8 @@ kubermatic:
   etcd:
     # PV size for the etcd StatefulSet of new clusters
     diskSize: "5Gi"
+    # Number of etcd replicas for the etcd StatefulSet of new cluster (if not specified using componenetsOverride).
+    replicas: 3
 
   # the cert-manager Issuer (or ClusterIssuer) responsible for managing the certificate
   certIssuer:

--- a/cmd/image-loader/main.go
+++ b/cmd/image-loader/main.go
@@ -363,6 +363,7 @@ func getTemplateData(version *kubermaticversion.Version) (*resources.TemplateDat
 	fakeCluster.Status.NamespaceName = mockNamespaceName
 
 	fakeDynamicClient := fake.NewFakeClient(objects...)
+	fakeEtcdReplicas := kubermaticv1.DefaultEtcdClusterSize
 
 	return resources.NewTemplateData(
 		context.Background(),
@@ -388,6 +389,7 @@ func getTemplateData(version *kubermaticversion.Version) (*resources.TemplateDat
 		resources.DefaultEtcdLauncherImage,
 		resources.DefaultDNATControllerImage,
 		false,
+		fakeEtcdReplicas,
 	), nil
 }
 

--- a/cmd/seed-controller-manager/controllers.go
+++ b/cmd/seed-controller-manager/controllers.go
@@ -91,6 +91,9 @@ func createClusterComponentDefaulter(ctrlCtx *controllerContext) error {
 			Replicas: utilpointer.Int32Ptr(int32(ctrlCtx.runOptions.controllerManagerDefaultReplicas))},
 		Scheduler: kubermaticv1.DeploymentSettings{
 			Replicas: utilpointer.Int32Ptr(int32(ctrlCtx.runOptions.schedulerDefaultReplicas))},
+		Etcd: kubermaticv1.EtcdStatefulSetSettings{
+			ClusterSize: ctrlCtx.runOptions.etcdReplicas,
+		},
 	}
 	return clustercomponentdefaulter.Add(
 		context.Background(),
@@ -155,6 +158,7 @@ func createKubernetesController(ctrlCtx *controllerContext) error {
 		ctrlCtx.runOptions.nodePortRange,
 		ctrlCtx.runOptions.nodeAccessNetwork,
 		ctrlCtx.runOptions.etcdDiskSize,
+		ctrlCtx.runOptions.etcdReplicas,
 		ctrlCtx.runOptions.monitoringScrapeAnnotationPrefix,
 		ctrlCtx.runOptions.inClusterPrometheusRulesFile,
 		ctrlCtx.runOptions.inClusterPrometheusDisableDefaultRules,

--- a/cmd/seed-controller-manager/options.go
+++ b/cmd/seed-controller-manager/options.go
@@ -68,6 +68,7 @@ type controllerRunOptions struct {
 	backupContainerImage                             string
 	backupInterval                                   string
 	etcdDiskSize                                     resource.Quantity
+	etcdReplicas                                     int
 	inClusterPrometheusRulesFile                     string
 	inClusterPrometheusDisableDefaultRules           bool
 	inClusterPrometheusDisableDefaultScrapingConfigs bool
@@ -128,6 +129,7 @@ func newControllerRunOptions() (controllerRunOptions, error) {
 	flag.StringVar(&c.backupContainerImage, "backup-container-init-image", backupcontroller.DefaultBackupContainerImage, "Docker image to use for the init container in the backup job, must be an etcd v3 image. Only set this if your cluster can not use the public quay.io registry")
 	flag.StringVar(&c.backupInterval, "backup-interval", backupcontroller.DefaultBackupInterval, "Interval in which the etcd gets backed up")
 	flag.StringVar(&rawEtcdDiskSize, "etcd-disk-size", "5Gi", "Size for the etcd PV's. Only applies to new clusters.")
+	flag.IntVar(&c.etcdReplicas, "etcd-replicas", kubermaticv1.DefaultEtcdClusterSize, "Number of etcd replicas. Only applies to new clusters.")
 	flag.StringVar(&c.inClusterPrometheusRulesFile, "in-cluster-prometheus-rules-file", "", "The file containing the custom alerting rules for the prometheus running in the cluster-foo namespaces.")
 	flag.BoolVar(&c.inClusterPrometheusDisableDefaultRules, "in-cluster-prometheus-disable-default-rules", false, "A flag indicating whether the default rules for the prometheus running in the cluster-foo namespaces should be deployed.")
 	flag.StringVar(&c.dockerPullConfigJSONFile, "docker-pull-config-json-file", "config.json", "The file containing the docker auth config.")

--- a/docs/zz_generated.kubermaticConfiguration.yaml
+++ b/docs/zz_generated.kubermaticConfiguration.yaml
@@ -358,6 +358,8 @@ spec:
     disableApiserverEndpointReconciling: false
     # DNATControllerDockerRepository is the repository containing the Kubermatic user-cluster-controller-manager image.
     dnatControllerDockerRepository: quay.io/kubermatic/kubeletdnat-controller
+    # EtcdReplicas configures the number of replicas to use by default for each etcd pod inside user clusters.
+    etcdReplicas: 3
     # EtcdVolumeSize configures the volume size to use for each etcd pod inside user clusters.
     etcdVolumeSize: 5Gi
     # KubermaticDockerRepository is the repository containing the Kubermatic user-cluster-controller-manager image.

--- a/pkg/controller/operator/common/defaults.go
+++ b/pkg/controller/operator/common/defaults.go
@@ -406,6 +406,11 @@ func DefaultConfiguration(config *operatorv1alpha1.KubermaticConfiguration, logg
 		logger.Debugw("Defaulting field", "field", "userCluster.etcdVolumeSize", "value", copy.Spec.UserCluster.EtcdVolumeSize)
 	}
 
+	if copy.Spec.UserCluster.EtcdReplicas == 0 {
+		copy.Spec.UserCluster.EtcdReplicas = kubermaticv1.DefaultEtcdClusterSize
+		logger.Debugw("Defaulting field", "field", "userCluster.etcdReplicas", "value", copy.Spec.UserCluster.EtcdReplicas)
+	}
+
 	if copy.Spec.Ingress.ClassName == "" {
 		copy.Spec.Ingress.ClassName = DefaultIngressClass
 		logger.Debugw("Defaulting field", "field", "ingress.className", "value", copy.Spec.Ingress.ClassName)

--- a/pkg/controller/operator/seed/resources/kubermatic/seed-controller-manager.go
+++ b/pkg/controller/operator/seed/resources/kubermatic/seed-controller-manager.go
@@ -76,6 +76,7 @@ func SeedControllerManagerDeploymentCreator(workerName string, versions common.V
 				fmt.Sprintf("-namespace=%s", cfg.Namespace),
 				fmt.Sprintf("-external-url=%s", cfg.Spec.Ingress.Domain),
 				fmt.Sprintf("-datacenter-name=%s", seed.Name),
+				fmt.Sprintf("-etcd-replicas=%d", cfg.Spec.UserCluster.EtcdReplicas),
 				fmt.Sprintf("-etcd-disk-size=%s", cfg.Spec.UserCluster.EtcdVolumeSize),
 				fmt.Sprintf("-feature-gates=%s", common.StringifyFeatureGates(cfg)),
 				fmt.Sprintf("-nodeport-range=%s", cfg.Spec.UserCluster.NodePortRange),

--- a/pkg/controller/seed-controller-manager/clustercomponentdefaulter/clustercomponentdefaulter.go
+++ b/pkg/controller/seed-controller-manager/clustercomponentdefaulter/clustercomponentdefaulter.go
@@ -132,6 +132,9 @@ func (r *Reconciler) reconcile(log *zap.SugaredLogger, cluster *kubermaticv1.Clu
 	if targetComponentsOverride.Etcd.Resources == nil {
 		targetComponentsOverride.Etcd.Resources = r.defaults.Etcd.Resources
 	}
+	if targetComponentsOverride.Etcd.ClusterSize == 0 {
+		targetComponentsOverride.Etcd.ClusterSize = r.defaults.Etcd.ClusterSize
+	}
 	if targetComponentsOverride.Prometheus.Resources == nil {
 		targetComponentsOverride.Prometheus.Resources = r.defaults.Prometheus.Resources
 	}

--- a/pkg/controller/seed-controller-manager/kubernetes/cluster_controller.go
+++ b/pkg/controller/seed-controller-manager/kubernetes/cluster_controller.go
@@ -81,6 +81,7 @@ type Reconciler struct {
 	nodePortRange                                    string
 	nodeAccessNetwork                                string
 	etcdDiskSize                                     resource.Quantity
+	etcdReplicas                                     int
 	inClusterPrometheusRulesFile                     string
 	inClusterPrometheusDisableDefaultRules           bool
 	inClusterPrometheusDisableDefaultScrapingConfigs bool
@@ -113,6 +114,7 @@ func Add(
 	nodePortRange string,
 	nodeAccessNetwork string,
 	etcdDiskSize resource.Quantity,
+	etcdReplicas int,
 	monitoringScrapeAnnotationPrefix string,
 	inClusterPrometheusRulesFile string,
 	inClusterPrometheusDisableDefaultRules bool,
@@ -142,6 +144,7 @@ func Add(
 		nodePortRange:                          nodePortRange,
 		nodeAccessNetwork:                      nodeAccessNetwork,
 		etcdDiskSize:                           etcdDiskSize,
+		etcdReplicas:                           etcdReplicas,
 		inClusterPrometheusRulesFile:           inClusterPrometheusRulesFile,
 		inClusterPrometheusDisableDefaultRules: inClusterPrometheusDisableDefaultRules,
 		inClusterPrometheusDisableDefaultScrapingConfigs: inClusterPrometheusDisableDefaultScrapingConfigs,

--- a/pkg/controller/seed-controller-manager/kubernetes/resources.go
+++ b/pkg/controller/seed-controller-manager/kubernetes/resources.go
@@ -171,6 +171,7 @@ func (r *Reconciler) getClusterTemplateData(ctx context.Context, cluster *kuberm
 		r.etcdLauncherImage,
 		r.dnatControllerImage,
 		supportsFailureDomainZoneAntiAffinity,
+		r.etcdReplicas,
 	), nil
 }
 

--- a/pkg/controller/seed-controller-manager/monitoring/monitoring_controller.go
+++ b/pkg/controller/seed-controller-manager/monitoring/monitoring_controller.go
@@ -85,6 +85,7 @@ type Reconciler struct {
 	// example: kubermatic.io -> kubermatic.io/path,kubermatic.io/port
 	monitoringScrapeAnnotationPrefix string
 	concurrentClusterUpdates         int
+	etcdReplicas                     int
 
 	features Features
 }

--- a/pkg/controller/seed-controller-manager/monitoring/resources.go
+++ b/pkg/controller/seed-controller-manager/monitoring/resources.go
@@ -65,6 +65,7 @@ func (r *Reconciler) getClusterTemplateData(ctx context.Context, client ctrlrunt
 		"",
 		"",
 		false,
+		r.etcdReplicas,
 	), nil
 }
 

--- a/pkg/controller/seed-controller-manager/openshift/data.go
+++ b/pkg/controller/seed-controller-manager/openshift/data.go
@@ -57,6 +57,11 @@ type openshiftData struct {
 	supportsFailureDomainZoneAntiAffinity bool
 	externalURL                           string
 	seed                                  *kubermaticv1.Seed
+	etcdReplicas                          int
+}
+
+func (od *openshiftData) EtcdReplicas() int {
+	return od.etcdReplicas
 }
 
 func (od *openshiftData) DC() *kubermaticv1.Datacenter {

--- a/pkg/crd/operator/v1alpha1/configuration.go
+++ b/pkg/crd/operator/v1alpha1/configuration.go
@@ -167,6 +167,8 @@ type KubermaticUserClusterConfiguration struct {
 	DisableAPIServerEndpointReconciling bool `json:"disableApiserverEndpointReconciling,omitempty"`
 	// EtcdVolumeSize configures the volume size to use for each etcd pod inside user clusters.
 	EtcdVolumeSize string `json:"etcdVolumeSize,omitempty"`
+	// EtcdReplicas configures the number of replicas to use by default for each etcd pod inside user clusters.
+	EtcdReplicas int `json:"etcdReplicas,omitempty"`
 	// APIServerReplicas configures the replica count for the API-Server deployment inside user clusters.
 	APIServerReplicas *int32 `json:"apiserverReplicas,omitempty"`
 }

--- a/pkg/defaulting/cluster.go
+++ b/pkg/defaulting/cluster.go
@@ -31,8 +31,5 @@ func DefaultCreateClusterSpec(
 	if err := cloudProvider.DefaultCloudSpec(&spec.Cloud); err != nil {
 		return fmt.Errorf("failed to default cloud spec: %v", err)
 	}
-	if spec.ComponentsOverride.Etcd.ClusterSize == 0 {
-		spec.ComponentsOverride.Etcd.ClusterSize = kubermaticv1.DefaultEtcdClusterSize
-	}
 	return nil
 }

--- a/pkg/ee/conversion/helm.go
+++ b/pkg/ee/conversion/helm.go
@@ -95,6 +95,7 @@ type kubermaticValues struct {
 	DynamicPresets                       bool    `yaml:"dynamicPresets"`
 	Etcd                                 struct {
 		DiskSize string `yaml:"diskSize"`
+		Replicas int    `yaml:"replicas"`
 	} `yaml:"etcd"`
 	Controller struct {
 		FeatureGates   string      `yaml:"featureGates"`
@@ -453,11 +454,17 @@ func convertUserCluster(values *kubermaticValues) (*operatorv1alpha1.KubermaticU
 		return nil, fmt.Errorf("invalid apiserverDefaultReplicas: %v", err)
 	}
 
+	etcdReplicas := kubermaticv1.DefaultEtcdClusterSize
+	if values.Etcd.Replicas > 0 {
+		etcdReplicas = values.Etcd.Replicas
+	}
+
 	return &operatorv1alpha1.KubermaticUserClusterConfiguration{
 		KubermaticDockerRepository:     strIfChanged(values.KubermaticImage, resources.DefaultKubermaticImage),
 		DNATControllerDockerRepository: strIfChanged(values.DNATControllerImage, resources.DefaultDNATControllerImage),
 		NodePortRange:                  strIfChanged(values.Controller.NodeportRange, common.DefaultNodePortRange),
 		EtcdVolumeSize:                 strIfChanged(values.Etcd.DiskSize, common.DefaultEtcdVolumeSize),
+		EtcdReplicas:                   etcdReplicas,
 		OverwriteRegistry:              values.Controller.OverwriteRegistry,
 		Addons: operatorv1alpha1.KubermaticAddonsConfiguration{
 			Kubernetes: *kubernetesAddonCfg,

--- a/pkg/resources/data.go
+++ b/pkg/resources/data.go
@@ -60,6 +60,7 @@ type TemplateData struct {
 	etcdLauncherImage                                string
 	dnatControllerImage                              string
 	supportsFailureDomainZoneAntiAffinity            bool
+	etcdReplicas                                     int
 }
 
 // NewTemplateData returns an instance of TemplateData
@@ -85,7 +86,8 @@ func NewTemplateData(
 	kubermaticImage string,
 	etcdLauncherImage string,
 	dnatControllerImage string,
-	supportsFailureDomainZoneAntiAffinity bool) *TemplateData {
+	supportsFailureDomainZoneAntiAffinity bool,
+	etcdReplicas int) *TemplateData {
 	return &TemplateData{
 		ctx:                                    ctx,
 		client:                                 client,
@@ -109,6 +111,7 @@ func NewTemplateData(
 		etcdLauncherImage:                                etcdLauncherImage,
 		dnatControllerImage:                              dnatControllerImage,
 		supportsFailureDomainZoneAntiAffinity:            supportsFailureDomainZoneAntiAffinity,
+		etcdReplicas:                                     etcdReplicas,
 	}
 }
 
@@ -159,6 +162,11 @@ func (d *TemplateData) DC() *kubermaticv1.Datacenter {
 // EtcdDiskSize returns the etcd disk size
 func (d *TemplateData) EtcdDiskSize() resource.Quantity {
 	return d.etcdDiskSize
+}
+
+// EtcdReplicas returns number of etcd replicas.
+func (d *TemplateData) EtcdReplicas() int {
+	return d.etcdReplicas
 }
 
 func (d *TemplateData) EtcdLauncherImage() string {

--- a/pkg/resources/test/load_files_test.go
+++ b/pkg/resources/test/load_files_test.go
@@ -584,7 +584,9 @@ func TestLoadFiles(t *testing.T) {
 					"quay.io/kubermatic/kubermatic",
 					"quay.io/kubermatic/etcd-launcher",
 					"quay.io/kubermatic/kubeletdnat-controller",
-					false)
+					false,
+					kubermaticv1.DefaultEtcdClusterSize,
+				)
 
 				var deploymentCreators []reconciling.NamedDeploymentCreatorGetter
 				deploymentCreators = append(deploymentCreators, kubernetescontroller.GetDeploymentCreators(data, true)...)


### PR DESCRIPTION
Signed-off-by: furkhat <vailodf@gmail.com>

**What this PR does / why we need it**:

Adds `-etcd-replicas-number` option to the `seed-controller-manager` that will be used as value for`componentsOverride.etcd.clusterSize` for all new clusters.

**Special notes for your reviewer**:

Also fixed some hardcodes (go templates) that assume that there are only 3 etcd replicas.

**Documentation**:
<!-- Add links to the related documentation changes related to this pull request. E.g. the link to the kubermatic/docs pullrequest. -->
What documentation would you like me to add?

**Does this PR introduce a user-facing change?**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If  no release note is required, just write "NONE".
-->
```release-note
Add `-etcd-replicas` option to `seed-controller-manager` to customize number of etcd replicas for new clusters using `componentsOverride`
```
