### PR TITLE
implement Seed.Spec.NodeportProxy.Annotation syncing to created servi…

### DIFF
--- a/pkg/controller/operator/seed/reconciler.go
+++ b/pkg/controller/operator/seed/reconciler.go
@@ -517,7 +517,7 @@ func (r *Reconciler) reconcileServices(cfg *operatorv1alpha1.KubermaticConfigura
 	// remove the entire Kubermatic namespace.
 	if !seed.Spec.NodeportProxy.Disable {
 		creators = []reconciling.NamedServiceCreatorGetter{
-			nodeportproxy.ServiceCreator(),
+			nodeportproxy.ServiceCreator(seed),
 		}
 
 		if err := reconciling.ReconcileServices(r.ctx, creators, cfg.Namespace, client); err != nil {

--- a/pkg/controller/operator/seed/reconciler_test.go
+++ b/pkg/controller/operator/seed/reconciler_test.go
@@ -317,18 +317,6 @@ func TestBasicReconciling(t *testing.T) {
 
 				seedClient := reconciler.seedClients["seed-with-nodeport-proxy-annotations"]
 
-				seed := kubermaticv1.Seed{}
-				if err := seedClient.Get(reconciler.ctx, types.NamespacedName{
-					Namespace: "kubermatic",
-					Name:      "seed-with-nodeport-proxy-annotations",
-				}, &seed); err != nil {
-					return fmt.Errorf("failed to retrieve Seed: %v", err)
-				}
-
-				if !kubernetes.HasFinalizer(&seed, common.CleanupFinalizer) {
-					return fmt.Errorf("Seed copy in seed cluster does not have cleanup finalizer %q", common.CleanupFinalizer)
-				}
-
 				svc := corev1.Service{}
 				if err := seedClient.Get(reconciler.ctx, types.NamespacedName{
 					Namespace: "kubermatic",
@@ -342,7 +330,6 @@ func TestBasicReconciling(t *testing.T) {
 				}
 
 				for k, v := range allSeeds["seed-with-nodeport-proxy-annotations"].Spec.NodeportProxy.Annotations {
-					fmt.Printf("svc.Annotations[k]: %s, k: %s, v: %s", svc.Annotations[k], k, v)
 					if svc.Annotations[k] != v {
 						return fmt.Errorf("Nodeport service in seed cluster is missing configured annotation: %s: %s", k, v)
 					}


### PR DESCRIPTION
…ce in seed-controller

**What this PR does / why we need it**: title

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
~Fixes #~

**Special notes for your reviewer**: This is propably not complete since I'm still very newbie-ish with golang. Please point out incorrect or missing stuff and I'll happily fix/add it.

**Documentation**:
<!-- Add links to the related documentation changes related to this pull request. E.g. the link to the kubermatic/docs pullrequest. -->

**Does this PR introduce a user-facing change?**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If  no release note is required, just write "NONE".
-->
```release-note
bugfix: implement missing annotation syncing from nodeport settings in seed crd to the created loadbalancer service
```
