### PR TITLE
Fix prometheus alertmanager queries for KubeClientCertificateExpiration

### DIFF
--- a/charts/monitoring/prometheus/Chart.yaml
+++ b/charts/monitoring/prometheus/Chart.yaml
@@ -14,7 +14,7 @@
 
 apiVersion: v1
 name: prometheus
-version: 2.2.25
+version: 2.2.26
 appVersion: v2.19.2
 description: Prometheus Monitoring for Kubernetes
 keywords:

--- a/charts/monitoring/prometheus/rules/general-kube-apiserver.yaml
+++ b/charts/monitoring/prometheus/rules/general-kube-apiserver.yaml
@@ -93,7 +93,7 @@ groups:
     expr: |
       apiserver_client_certificate_expiration_seconds_count{job="apiserver"} > 0
       and
-      histogram_quantile(0.01, sum by (job, le) (rate(apiserver_client_certificate_expiration_seconds_bucket{job="apiserver"}[5m]))) < 604800
+      histogram_quantile(0.01, sum by (job, instance, le) (rate(apiserver_client_certificate_expiration_seconds_bucket{job="apiserver"}[5m]))) < 604800
     labels:
       severity: warning
   - alert: KubeClientCertificateExpiration
@@ -104,6 +104,6 @@ groups:
     expr: |
       apiserver_client_certificate_expiration_seconds_count{job="apiserver"} > 0
       and
-      histogram_quantile(0.01, sum by (job, le) (rate(apiserver_client_certificate_expiration_seconds_bucket{job="apiserver"}[5m]))) < 86400
+      histogram_quantile(0.01, sum by (job, instance, le) (rate(apiserver_client_certificate_expiration_seconds_bucket{job="apiserver"}[5m]))) < 86400
     labels:
       severity: critical

--- a/charts/monitoring/prometheus/rules/src/general/kube-apiserver.yaml
+++ b/charts/monitoring/prometheus/rules/src/general/kube-apiserver.yaml
@@ -99,7 +99,7 @@ groups:
     expr: |
       apiserver_client_certificate_expiration_seconds_count{job="apiserver"} > 0
       and
-      histogram_quantile(0.01, sum by (job, le) (rate(apiserver_client_certificate_expiration_seconds_bucket{job="apiserver"}[5m]))) < 604800
+      histogram_quantile(0.01, sum by (job, instance, le) (rate(apiserver_client_certificate_expiration_seconds_bucket{job="apiserver"}[5m]))) < 604800
     labels:
       severity: warning
     runbook:
@@ -115,7 +115,7 @@ groups:
     expr: |
       apiserver_client_certificate_expiration_seconds_count{job="apiserver"} > 0
       and
-      histogram_quantile(0.01, sum by (job, le) (rate(apiserver_client_certificate_expiration_seconds_bucket{job="apiserver"}[5m]))) < 86400
+      histogram_quantile(0.01, sum by (job, instance, le) (rate(apiserver_client_certificate_expiration_seconds_bucket{job="apiserver"}[5m]))) < 86400
     labels:
       severity: critical
     runbook:


### PR DESCRIPTION
**What this PR does / why we need it**:
In the alert-manager config there is a problem where

`apiserver_client_certificate_expiration_seconds_count{job="apiserver"} > 0`
and
`histogram_quantile(0.01, sum by (job, le) (rate(apiserver_client_certificate_expiration_seconds_bucket{job="apiserver"} [5m]))) < 604800`
are joined together by `and`.

However the first portion contains a label `instance` while the second
portion of the query does a `sum(` doesn't include the `instance` label
and therefore prometheus cannot join together those two queries.

This patch adds the instance label to the histogram query in order to
make this alert work.
This can cause an production outage, since you wont be alerted
on a expiring certificate in time.

The current query is this:
![Screenshot 2020-07-23 at 11 19 42](https://user-images.githubusercontent.com/1952599/88270766-74087380-ccd6-11ea-964e-2789ebade587.png)

While the query submitted in this PR is this:
![Screenshot 2020-07-23 at 11 16 18](https://user-images.githubusercontent.com/1952599/88270774-75d23700-ccd6-11ea-8ce5-94136e2e8ddf.png)


**Which issue(s) this PR fixes** *
No issue opened on the Kubermatic repository

**Special notes for your reviewer**:
None

**Documentation**:
None

**Does this PR introduce a user-facing change?**:
```release-note
Fixing the KubeClientCertificateExpiration Prometheus Alert which did not alert in for expiring certificates
```
