### PR TITLE
fix codegen

### DIFF
--- a/hack/update-codegen.sh
+++ b/hack/update-codegen.sh
@@ -47,7 +47,7 @@ echodate "Generating operator:v1alpha1"
   --go-header-file /tmp/headerfile
 
 # Temporary fixes due to: https://github.com/kubernetes/kubernetes/issues/71655
-GENERIC_FILE="v2/pkg/crd/client/informers/externalversions/generic.go"
+GENERIC_FILE="pkg/crd/client/informers/externalversions/generic.go"
 sed -i s/usersshkeys/usersshkeies/g ${GENERIC_FILE}
 
 echodate "Generating deepcopy funcs for other packages"
@@ -55,11 +55,6 @@ go run k8s.io/code-generator/cmd/deepcopy-gen \
   --input-dirs k8c.io/kubermatic/v2/pkg/semver \
   -O zz_generated.deepcopy \
   --go-header-file /tmp/headerfile
-
-# move files into their correct location, generate-groups.sh does not handle
-# non-v1 module names very well
-cp -r v2/* .
-rm -rf v2/
 
 rm /tmp/headerfile
 


### PR DESCRIPTION
Signed-off-by: Olaf Klischat <olaf.klischat@gmail.com>

**What this PR does / why we need it**:

I'm not sure if I misunderstand something, but "update-codegen" (and thus also verify-codegen) fails in the current master for me, pretty obviously, with `sed: can't read v2/pkg/crd/client/informers/externalversions/generic.go: No such file or directory`. This fixes that. I'm not sure why prow on the master branch apparently doesn't run the the `pre-kubermatic-verify` job, which would trigger this.

**Does this PR introduce a user-facing change?**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If  no release note is required, just write "NONE".
-->
```release-note
NONE
```
