### PR TITLE
Add support for codegen when the repository is out of GOPATH

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,10 +65,16 @@ Feedback and discussion are available on [the mailing list][11].
 ### Development environment
 
 ```bash
-mkdir -p $(go env GOPATH)/src/github.com/kubermatic
-cd $(go env GOPATH)/src/github.com/kubermatic
+mkdir -p $(go env GOPATH)/src/k8c.io
+cd $(go env GOPATH)/src/k8c.io
 git clone git@github.com:kubermatic/kubermatic
 cd kubermatic
+```
+
+Or alternatively:
+
+```bash
+go get k8c.io/kubermatic
 ```
 
 There are a couple of scripts in the `hacks` directory to aid in running the components locally
@@ -118,18 +124,21 @@ make fix
 make test
 ```
 
-#### Update dependencies
-
-Sure that you want to update? And not just install dependencies?
-
-```bash
-dep ensure -update
-```
-
 #### Update code generation
 
+Kuberneres code-generator tool does not work out of GOPATH
+[see](https://github.com/kubernetes/kubernetes/issues/86753), if you followed
+the recommendation and cloned your repository at `$(go env GOPATH)/src/k8c.io`
+you can run the following command:
+
 ```bash
-./hack/update-codegen.sh
+hack/update-codegen.sh
+```
+
+Otherwise run the following (requires Docker):
+
+```bash
+make update-codegen-in-docker
 ```
 
 ### Pull requests

--- a/hack/ci/ci-github-release.sh
+++ b/hack/ci/ci-github-release.sh
@@ -24,11 +24,6 @@ source hack/lib.sh
 
 GITHUB_TOKEN="${GITHUB_TOKEN:-$(cat /etc/github/oauth | tr -d '\n')}"
 
-# err can be used to print logs to stderr
-err(){
-  echo "E: $*" >>/dev/stderr
-}
-
 # utility function setting some curl default values for calling the github API
 # first argument is the URL, the rest of the arguments is used as curl
 # arguments.

--- a/hack/lib.sh
+++ b/hack/lib.sh
@@ -247,3 +247,14 @@ pushMetric() {
 pushElapsed() {
   pushMetric "$1" $(elapsed $2) "${3:-}" "${4:-}" "${5:-}"
 }
+
+# err print an error log to stderr
+err() {
+  echo "$(date) E: $*" >>/dev/stderr
+}
+
+# fatal can be used to print logs to stderr
+fatal() {
+  echo "$(date) F: $*" >>/dev/stderr
+  exit 1
+}

--- a/hack/update-codegen.sh
+++ b/hack/update-codegen.sh
@@ -16,8 +16,14 @@
 
 set -euo pipefail
 
-cd $(dirname $0)/..
+ROOT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )/.." >/dev/null 2>&1 && pwd )"
+WANTED_DIR="$(go env GOPATH)/src/k8c.io/kubermatic"
+cd "${ROOT_DIR}"
 source hack/lib.sh
+[[ "${ROOT_DIR}" == "${WANTED_DIR}" ]] || \
+    fatal "${BASH_SOURCE[0]} only works when repository is located at" \
+        "${WANTED_DIR} but currently it is at ${ROOT_DIR}"
+
 
 echodate "Creating vendor directory"
 go mod vendor


### PR DESCRIPTION
**What this PR does / why we need it**:
After moving to go modules we open to the possibility of cloning the kubermatic repository out of GOPATH. Unfortunately not all the tools and sctipts work well in this configuration.

An example is the k8s [code generator](https://github.com/kubernetes/code-generator) that we use in `hack/update-codegen.sh`. To mitigate this this PR introduce a new make target to run this script in Docker.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Documentation**:
<!-- Add links to the related documentation changes related to this pull request. E.g. the link to the kubermatic/docs pullrequest. -->

**Does this PR introduce a user-facing change?**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If  no release note is required, just write "NONE".
-->
```release-note
NONE
```
