### PR TITLE
fix listing projects after project deletion

### DIFF
--- a/pkg/handler/v1/project/project.go
+++ b/pkg/handler/v1/project/project.go
@@ -167,6 +167,9 @@ func ListEndpoint(userInfoGetter provider.UserInfoGetter, projectProvider provid
 			userInfo := &provider.UserInfo{Email: mapping.Spec.UserEmail, Group: mapping.Spec.Group}
 			projectInternal, err := projectProvider.Get(userInfo, mapping.Spec.ProjectID, &provider.ProjectGetOptions{IncludeUninitialized: true})
 			if err != nil {
+				if isStatus(err, http.StatusNotFound) {
+					continue
+				}
 				// Request came from the specified user. Instead `Not found` error status the `Forbidden` is returned.
 				// Next request with privileged user checks if the project doesn't exist or some other error occurred.
 				if !isStatus(err, http.StatusForbidden) {


### PR DESCRIPTION
**What this PR does / why we need it**: getting the project list depends on user project bindings. When the project was removed binding still exists but the project is not found. This PR fix gets the project list endpoint and skips `not found` error

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

```release-note
NONE
```
