### PR TITLE
fix owning project not being set on credential secrets

### DIFF
--- a/pkg/handler/common/cluster.go
+++ b/pkg/handler/common/cluster.go
@@ -133,6 +133,12 @@ func CreateEndpoint(ctx context.Context, projectID string, body apiv1.CreateClus
 	}
 	partialCluster := &kubermaticv1.Cluster{}
 	partialCluster.Labels = body.Cluster.Labels
+	if partialCluster.Labels == nil {
+		partialCluster.Labels = make(map[string]string)
+	}
+	// Owning project ID must be set early, because it will be inherited by some child objects,
+	// for example the credentials secret.
+	partialCluster.Labels[kubermaticv1.ProjectIDLabelKey] = projectID
 	partialCluster.Spec = *spec
 	if body.Cluster.Type == "openshift" {
 		if body.Cluster.Spec.Openshift == nil || body.Cluster.Spec.Openshift.ImagePullSecret == "" {


### PR DESCRIPTION
Currently when the a credentials secret is being created, it receives the "owning project ID label" from the parent cluster which is passed into the `CreateOrUpdateCredentialSecretForCluster`. However, during a new cluster creation we pass a partial cluster there, which doesn't have this label set.

Result?
```
E0812 15:06:32.194559       1 rbac_resource_controller.go:262] Error syncing {{ v1 secrets} Secret credential-openstack-v2x4s8mhqr kubermatic/credential-openstack-v2x4s8mhqr 0xc000180d80 0xc000d98ab0}: unable to find owning project for the object name = credential-openstack-v2x4s8mhqr, gvr = /v1, Resource=secrets
```

```release-note
NONE
```
