### PR TITLE
bring back the gocache

### DIFF
--- a/hack/ci/ci-download-gocache.sh
+++ b/hack/ci/ci-download-gocache.sh
@@ -1,0 +1,76 @@
+#!/usr/bin/env bash
+
+# Copyright 2020 The Kubermatic Kubernetes Platform contributors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+set -euo pipefail
+
+# Required for signal propagation to work so
+# the cleanup trap gets executed when the script
+# receives a SIGINT
+set -o monitor
+
+# The gocache needs a matching go version to work, so append that to the name
+GO_VERSION="$(go version|awk '{ print $3 }'|sed 's/go//g')"
+
+# Make sure we never error, this is always best-effort only
+exit_gracefully() {
+  if [ $? -ne 0 ]; then
+    echodate "Encountered error when trying to download gocache"
+  fi
+  exit 0
+}
+trap exit_gracefully EXIT
+
+source $(dirname $0)/../lib.sh
+
+if [ -z "${GOCACHE_MINIO_ADDRESS:-}" ]; then
+  echodate "env var GOCACHE_MINIO_ADDRESS unset, can not download gocache"
+  exit 0
+fi
+
+GOCACHE="$(go env GOCACHE)"
+# Make sure it actually exists
+mkdir -p "${GOCACHE}"
+
+export CACHE_VERSION="${PULL_BASE_SHA:-}"
+
+# Periodics just use their head ref
+if [[ -z "${CACHE_VERSION}" ]]; then
+  CACHE_VERSION="$(git rev-parse HEAD)"
+fi
+
+if [ -z "${PULL_NUMBER:-}" ]; then
+  # Special case: This is called in a Postubmit. Go one revision back,
+  # as there can't be a cache for the current revision
+  CACHE_VERSION="$(git rev-parse ${CACHE_VERSION}~1)"
+fi
+
+ARCHIVE_NAME="${CACHE_VERSION}-${GO_VERSION}.tar"
+URL="${GOCACHE_MINIO_ADDRESS}/${ARCHIVE_NAME}"
+
+# Do not go through the retry loop when there is nothing
+if curl --head "${URL}" | grep -q 404; then
+  echodate "Remote has no gocache ${ARCHIVE_NAME}, exiting"
+  exit 0
+fi
+
+echodate "Downloading and extracting gocache"
+TEST_NAME="Download and extract gocache"
+# Passing the Headers as space-separated literals doesn't seem to work
+# in conjunction with the retry func, so we just put them in a file instead
+echo 'Content-Type: application/octet-stream' > /tmp/headers
+retry 5 curl --fail -H @/tmp/headers "${URL}" | tar -C $GOCACHE -xf -
+
+echodate "Successfully fetched gocache into $GOCACHE"

--- a/hack/ci/ci-setup-kubermatic-in-kind.sh
+++ b/hack/ci/ci-setup-kubermatic-in-kind.sh
@@ -166,6 +166,10 @@ if ls /var/log/clusterexposer.log &>/dev/null; then
 else
   echodate "Starting clusterexposer"
 
+  beforeGocache=$(nowms)
+  make download-gocache
+  pushElapsed gocache_download_duration_milliseconds $beforeGocache
+
   CGO_ENABLED=0 go build --tags "$KUBERMATIC_EDITION" -v -o /tmp/clusterexposer ./pkg/test/clusterexposer/cmd
   CGO_ENABLED=0 /tmp/clusterexposer \
     --kubeconfig-inner "$KUBECONFIG" \

--- a/hack/ci/ci-upload-gocache.sh
+++ b/hack/ci/ci-upload-gocache.sh
@@ -1,0 +1,82 @@
+#!/usr/bin/env bash
+
+# Copyright 2020 The Kubermatic Kubernetes Platform contributors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+set -euo pipefail
+
+# Required for signal propagation to work so
+# the cleanup trap gets executed when the script
+# receives a SIGINT
+set -o monitor
+
+cd $(dirname $0)/../..
+source hack/lib.sh
+
+if [ -z "${GOCACHE_MINIO_ADDRESS:-}" ]; then
+  echodate "Fatal: env var GOCACHE_MINIO_ADDRESS unset"
+  exit 1
+fi
+
+GOCACHE_DIR="$(mktemp -d)"
+export GOCACHE="${GOCACHE_DIR}"
+export GIT_HEAD_HASH="$(git rev-parse HEAD|tr -d '\n')"
+export CGO_ENABLED=0
+
+# Go does not distinguish compiled files based on
+# tags, so we cannot cache CE *and* EE.
+export KUBERMATIC_EDITION=ee
+
+echodate "Building binaries"
+
+(
+  TEST_NAME="Build Kubermatic"
+  retry 2 make build
+)
+(
+  TEST_NAME="Building Nodeport proxy"
+  cd cmd/nodeport-proxy
+  retry 2 make build
+)
+(
+  TEST_NAME="Building kubeletdnat controller"
+  cd cmd/kubeletdnat-controller
+  retry 2 make build
+)
+
+TEST_NAME="Build tests"
+echodate "Building tests"
+
+retry 2 go test ./... -run nope -tags "cloud,${KUBERMATIC_EDITION}"
+retry 2 go test ./... -run nope -tags "create,${KUBERMATIC_EDITION}"
+retry 2 go test ./... -run nope -tags "e2e,${KUBERMATIC_EDITION}"
+retry 2 go test ./... -run nope -tags "integration,${KUBERMATIC_EDITION}"
+
+TEST_NAME="Creating gocache archive"
+echodate "Creating gocache archive"
+
+ARCHIVE_FILE="/tmp/${GIT_HEAD_HASH}.tar"
+# No compression because that needs quite a bit of CPU
+retry 2 tar -C "$GOCACHE" -cf "$ARCHIVE_FILE" .
+
+TEST_NAME="Uploading gocache archive"
+echodate "Uploading gocache archive"
+
+# The gocache needs a matching go version to work, so append that to the name
+GO_VERSION="$(go version|awk '{ print $3 }'|sed 's/go//g')"
+
+# Passing the Headers as space-separated literals doesn't seem to work
+# in conjunction with the retry func, so we just put them in a file instead
+echo 'Content-Type: application/octet-stream' > /tmp/headers
+retry 2 curl --fail -T "${ARCHIVE_FILE}" -H @/tmp/headers "${GOCACHE_MINIO_ADDRESS}/${GIT_HEAD_HASH}-${GO_VERSION}.tar"


### PR DESCRIPTION
**What this PR does / why we need it**:
Athens is nice for reducing network times, but the majority of time is of course spent compiling stuff. This PR brings back the caching mechanism I replaced with Athens, thinking caching would work differently when using Go modules compared to dep. That was wrong however, `GOCACHE` is still relevant.

**Does this PR introduce a user-facing change?**:
```release-note
NONE
```
