### PR TITLE
Update cert-manager to 0.16.1

### DIFF
--- a/charts/cert-manager/Chart.yaml
+++ b/charts/cert-manager/Chart.yaml
@@ -14,8 +14,8 @@
 
 apiVersion: v1
 name: cert-manager
-version: 1.2.2
-appVersion: v0.15.1
+version: 1.2.3
+appVersion: v0.16.1
 description: A Helm chart for cert-manager
 keywords:
 - kubermatic

--- a/charts/cert-manager/crd/cert-manager.crds.yaml
+++ b/charts/cert-manager/crd/cert-manager.crds.yaml
@@ -23,7 +23,646 @@ metadata:
   labels:
     app: 'cert-manager'
     app.kubernetes.io/instance: 'cert-manager'
-    app.kubernetes.io/managed-by: 'Helm'
+    app.kubernetes.io/name: 'cert-manager'
+  name: certificaterequests.cert-manager.io
+spec:
+  additionalPrinterColumns:
+  - JSONPath: .status.conditions[?(@.type=="Ready")].status
+    name: Ready
+    type: string
+  - JSONPath: .spec.issuerRef.name
+    name: Issuer
+    priority: 1
+    type: string
+  - JSONPath: .status.conditions[?(@.type=="Ready")].message
+    name: Status
+    priority: 1
+    type: string
+  - JSONPath: .metadata.creationTimestamp
+    description: CreationTimestamp is a timestamp representing the server time when
+      this object was created. It is not guaranteed to be set in happens-before order
+      across separate operations. Clients may not set this value. It is represented
+      in RFC3339 form and is in UTC.
+    name: Age
+    type: date
+  group: cert-manager.io
+  names:
+    kind: CertificateRequest
+    listKind: CertificateRequestList
+    plural: certificaterequests
+    shortNames:
+    - cr
+    - crs
+    singular: certificaterequest
+  scope: Namespaced
+  subresources:
+    status: {}
+  validation:
+    openAPIV3Schema:
+      description: "A CertificateRequest is used to request a signed certificate from
+        one of the configured issuers. \n All fields within the CertificateRequest's
+        `spec` are immutable after creation. A CertificateRequest will either succeed
+        or fail, as denoted by its `status.state` field. \n A CertificateRequest is
+        a 'one-shot' resource, meaning it represents a single point in time request
+        for a certificate and cannot be re-used."
+      properties:
+        apiVersion:
+          description: 'APIVersion defines the versioned schema of this representation
+            of an object. Servers should convert recognized schemas to the latest
+            internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+          type: string
+        kind:
+          description: 'Kind is a string value representing the REST resource this
+            object represents. Servers may infer this from the endpoint the client
+            submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+          type: string
+        metadata:
+          type: object
+        spec:
+          description: Desired state of the CertificateRequest resource.
+          properties:
+            csr:
+              description: The PEM-encoded x509 certificate signing request to be
+                submitted to the CA for signing.
+              format: byte
+              type: string
+            duration:
+              description: The requested 'duration' (i.e. lifetime) of the Certificate.
+                This option may be ignored/overridden by some issuer types.
+              type: string
+            isCA:
+              description: IsCA will request to mark the certificate as valid for
+                certificate signing when submitting to the issuer. This will automatically
+                add the `cert sign` usage to the list of `usages`.
+              type: boolean
+            issuerRef:
+              description: IssuerRef is a reference to the issuer for this CertificateRequest.  If
+                the 'kind' field is not set, or set to 'Issuer', an Issuer resource
+                with the given name in the same namespace as the CertificateRequest
+                will be used.  If the 'kind' field is set to 'ClusterIssuer', a ClusterIssuer
+                with the provided name will be used. The 'name' field in this stanza
+                is required at all times. The group field refers to the API group
+                of the issuer which defaults to 'cert-manager.io' if empty.
+              properties:
+                group:
+                  description: Group of the resource being referred to.
+                  type: string
+                kind:
+                  description: Kind of the resource being referred to.
+                  type: string
+                name:
+                  description: Name of the resource being referred to.
+                  type: string
+              required:
+              - name
+              type: object
+            usages:
+              description: Usages is the set of x509 usages that are requested for
+                the certificate. Defaults to `digital signature` and `key encipherment`
+                if not specified.
+              items:
+                description: 'KeyUsage specifies valid usage contexts for keys. See:
+                  https://tools.ietf.org/html/rfc5280#section-4.2.1.3      https://tools.ietf.org/html/rfc5280#section-4.2.1.12
+                  Valid KeyUsage values are as follows: "signing", "digital signature",
+                  "content commitment", "key encipherment", "key agreement", "data
+                  encipherment", "cert sign", "crl sign", "encipher only", "decipher
+                  only", "any", "server auth", "client auth", "code signing", "email
+                  protection", "s/mime", "ipsec end system", "ipsec tunnel", "ipsec
+                  user", "timestamping", "ocsp signing", "microsoft sgc", "netscape
+                  sgc"'
+                enum:
+                - signing
+                - digital signature
+                - content commitment
+                - key encipherment
+                - key agreement
+                - data encipherment
+                - cert sign
+                - crl sign
+                - encipher only
+                - decipher only
+                - any
+                - server auth
+                - client auth
+                - code signing
+                - email protection
+                - s/mime
+                - ipsec end system
+                - ipsec tunnel
+                - ipsec user
+                - timestamping
+                - ocsp signing
+                - microsoft sgc
+                - netscape sgc
+                type: string
+              type: array
+          required:
+          - csr
+          - issuerRef
+          type: object
+        status:
+          description: Status of the CertificateRequest. This is set and managed automatically.
+          properties:
+            ca:
+              description: The PEM encoded x509 certificate of the signer, also known
+                as the CA (Certificate Authority). This is set on a best-effort basis
+                by different issuers. If not set, the CA is assumed to be unknown/not
+                available.
+              format: byte
+              type: string
+            certificate:
+              description: The PEM encoded x509 certificate resulting from the certificate
+                signing request. If not set, the CertificateRequest has either not
+                been completed or has failed. More information on failure can be found
+                by checking the `conditions` field.
+              format: byte
+              type: string
+            conditions:
+              description: List of status conditions to indicate the status of a CertificateRequest.
+                Known condition types are `Ready` and `InvalidRequest`.
+              items:
+                description: CertificateRequestCondition contains condition information
+                  for a CertificateRequest.
+                properties:
+                  lastTransitionTime:
+                    description: LastTransitionTime is the timestamp corresponding
+                      to the last status change of this condition.
+                    format: date-time
+                    type: string
+                  message:
+                    description: Message is a human readable description of the details
+                      of the last transition, complementing reason.
+                    type: string
+                  reason:
+                    description: Reason is a brief machine readable explanation for
+                      the condition's last transition.
+                    type: string
+                  status:
+                    description: Status of the condition, one of ('True', 'False',
+                      'Unknown').
+                    enum:
+                    - "True"
+                    - "False"
+                    - Unknown
+                    type: string
+                  type:
+                    description: Type of the condition, known values are ('Ready',
+                      'InvalidRequest').
+                    type: string
+                required:
+                - status
+                - type
+                type: object
+              type: array
+            failureTime:
+              description: FailureTime stores the time that this CertificateRequest
+                failed. This is used to influence garbage collection and back-off.
+              format: date-time
+              type: string
+          type: object
+  versions:
+  - name: v1alpha2
+    served: true
+    storage: true
+---
+# Source: cert-manager/templates/templates.legacy.out
+apiVersion: apiextensions.k8s.io/v1beta1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    cert-manager.io/inject-ca-from-secret: 'cert-manager/cert-manager-webhook-ca'
+  labels:
+    app: 'cert-manager'
+    app.kubernetes.io/instance: 'cert-manager'
+    app.kubernetes.io/name: 'cert-manager'
+  name: certificates.cert-manager.io
+spec:
+  additionalPrinterColumns:
+  - JSONPath: .status.conditions[?(@.type=="Ready")].status
+    name: Ready
+    type: string
+  - JSONPath: .spec.secretName
+    name: Secret
+    type: string
+  - JSONPath: .spec.issuerRef.name
+    name: Issuer
+    priority: 1
+    type: string
+  - JSONPath: .status.conditions[?(@.type=="Ready")].message
+    name: Status
+    priority: 1
+    type: string
+  - JSONPath: .metadata.creationTimestamp
+    description: CreationTimestamp is a timestamp representing the server time when
+      this object was created. It is not guaranteed to be set in happens-before order
+      across separate operations. Clients may not set this value. It is represented
+      in RFC3339 form and is in UTC.
+    name: Age
+    type: date
+  group: cert-manager.io
+  names:
+    kind: Certificate
+    listKind: CertificateList
+    plural: certificates
+    shortNames:
+    - cert
+    - certs
+    singular: certificate
+  scope: Namespaced
+  subresources:
+    status: {}
+  validation:
+    openAPIV3Schema:
+      description: "A Certificate resource should be created to ensure an up to date
+        and signed x509 certificate is stored in the Kubernetes Secret resource named
+        in `spec.secretName`. \n The stored certificate will be renewed before it
+        expires (as configured by `spec.renewBefore`)."
+      properties:
+        apiVersion:
+          description: 'APIVersion defines the versioned schema of this representation
+            of an object. Servers should convert recognized schemas to the latest
+            internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+          type: string
+        kind:
+          description: 'Kind is a string value representing the REST resource this
+            object represents. Servers may infer this from the endpoint the client
+            submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+          type: string
+        metadata:
+          type: object
+        spec:
+          description: Desired state of the Certificate resource.
+          properties:
+            commonName:
+              description: 'CommonName is a common name to be used on the Certificate.
+                The CommonName should have a length of 64 characters or fewer to avoid
+                generating invalid CSRs. This value is ignored by TLS clients when
+                any subject alt name is set. This is x509 behaviour: https://tools.ietf.org/html/rfc6125#section-6.4.4'
+              type: string
+            dnsNames:
+              description: DNSNames is a list of DNS subjectAltNames to be set on
+                the Certificate.
+              items:
+                type: string
+              type: array
+            duration:
+              description: The requested 'duration' (i.e. lifetime) of the Certificate.
+                This option may be ignored/overridden by some issuer types. If overridden
+                and `renewBefore` is greater than the actual certificate duration,
+                the certificate will be automatically renewed 2/3rds of the way through
+                the certificate's duration.
+              type: string
+            emailSANs:
+              description: EmailSANs is a list of email subjectAltNames to be set
+                on the Certificate.
+              items:
+                type: string
+              type: array
+            ipAddresses:
+              description: IPAddresses is a list of IP address subjectAltNames to
+                be set on the Certificate.
+              items:
+                type: string
+              type: array
+            isCA:
+              description: IsCA will mark this Certificate as valid for certificate
+                signing. This will automatically add the `cert sign` usage to the
+                list of `usages`.
+              type: boolean
+            issuerRef:
+              description: IssuerRef is a reference to the issuer for this certificate.
+                If the 'kind' field is not set, or set to 'Issuer', an Issuer resource
+                with the given name in the same namespace as the Certificate will
+                be used. If the 'kind' field is set to 'ClusterIssuer', a ClusterIssuer
+                with the provided name will be used. The 'name' field in this stanza
+                is required at all times.
+              properties:
+                group:
+                  description: Group of the resource being referred to.
+                  type: string
+                kind:
+                  description: Kind of the resource being referred to.
+                  type: string
+                name:
+                  description: Name of the resource being referred to.
+                  type: string
+              required:
+              - name
+              type: object
+            keyAlgorithm:
+              description: KeyAlgorithm is the private key algorithm of the corresponding
+                private key for this certificate. If provided, allowed values are
+                either "rsa" or "ecdsa" If `keyAlgorithm` is specified and `keySize`
+                is not provided, key size of 256 will be used for "ecdsa" key algorithm
+                and key size of 2048 will be used for "rsa" key algorithm.
+              enum:
+              - rsa
+              - ecdsa
+              type: string
+            keyEncoding:
+              description: KeyEncoding is the private key cryptography standards (PKCS)
+                for this certificate's private key to be encoded in. If provided,
+                allowed values are "pkcs1" and "pkcs8" standing for PKCS#1 and PKCS#8,
+                respectively. If KeyEncoding is not specified, then PKCS#1 will be
+                used by default.
+              enum:
+              - pkcs1
+              - pkcs8
+              type: string
+            keySize:
+              description: KeySize is the key bit size of the corresponding private
+                key for this certificate. If `keyAlgorithm` is set to `RSA`, valid
+                values are `2048`, `4096` or `8192`, and will default to `2048` if
+                not specified. If `keyAlgorithm` is set to `ECDSA`, valid values are
+                `256`, `384` or `521`, and will default to `256` if not specified.
+                No other values are allowed.
+              maximum: 8192
+              minimum: 0
+              type: integer
+            keystores:
+              description: Keystores configures additional keystore output formats
+                stored in the `secretName` Secret resource.
+              properties:
+                jks:
+                  description: JKS configures options for storing a JKS keystore in
+                    the `spec.secretName` Secret resource.
+                  properties:
+                    create:
+                      description: Create enables JKS keystore creation for the Certificate.
+                        If true, a file named `keystore.jks` will be created in the
+                        target Secret resource, encrypted using the password stored
+                        in `passwordSecretRef`. The keystore file will only be updated
+                        upon re-issuance.
+                      type: boolean
+                    passwordSecretRef:
+                      description: PasswordSecretRef is a reference to a key in a
+                        Secret resource containing the password used to encrypt the
+                        JKS keystore.
+                      properties:
+                        key:
+                          description: The key of the entry in the Secret resource's
+                            `data` field to be used. Some instances of this field
+                            may be defaulted, in others it may be required.
+                          type: string
+                        name:
+                          description: 'Name of the resource being referred to. More
+                            info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                          type: string
+                      required:
+                      - name
+                      type: object
+                  required:
+                  - create
+                  - passwordSecretRef
+                  type: object
+                pkcs12:
+                  description: PKCS12 configures options for storing a PKCS12 keystore
+                    in the `spec.secretName` Secret resource.
+                  properties:
+                    create:
+                      description: Create enables PKCS12 keystore creation for the
+                        Certificate. If true, a file named `keystore.p12` will be
+                        created in the target Secret resource, encrypted using the
+                        password stored in `passwordSecretRef`. The keystore file
+                        will only be updated upon re-issuance.
+                      type: boolean
+                    passwordSecretRef:
+                      description: PasswordSecretRef is a reference to a key in a
+                        Secret resource containing the password used to encrypt the
+                        PKCS12 keystore.
+                      properties:
+                        key:
+                          description: The key of the entry in the Secret resource's
+                            `data` field to be used. Some instances of this field
+                            may be defaulted, in others it may be required.
+                          type: string
+                        name:
+                          description: 'Name of the resource being referred to. More
+                            info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                          type: string
+                      required:
+                      - name
+                      type: object
+                  required:
+                  - create
+                  - passwordSecretRef
+                  type: object
+              type: object
+            organization:
+              description: Organization is a list of organizations to be used on the
+                Certificate.
+              items:
+                type: string
+              type: array
+            privateKey:
+              description: Options to control private keys used for the Certificate.
+              properties:
+                rotationPolicy:
+                  description: RotationPolicy controls how private keys should be
+                    regenerated when a re-issuance is being processed. If set to Never,
+                    a private key will only be generated if one does not already exist
+                    in the target `spec.secretName`. If one does exists but it does
+                    not have the correct algorithm or size, a warning will be raised
+                    to await user intervention. If set to Always, a private key matching
+                    the specified requirements will be generated whenever a re-issuance
+                    occurs. Default is 'Never' for backward compatibility.
+                  type: string
+              type: object
+            renewBefore:
+              description: The amount of time before the currently issued certificate's
+                `notAfter` time that cert-manager will begin to attempt to renew the
+                certificate. If this value is greater than the total duration of the
+                certificate (i.e. notAfter - notBefore), it will be automatically
+                renewed 2/3rds of the way through the certificate's duration.
+              type: string
+            secretName:
+              description: SecretName is the name of the secret resource that will
+                be automatically created and managed by this Certificate resource.
+                It will be populated with a private key and certificate, signed by
+                the denoted issuer.
+              type: string
+            subject:
+              description: Full X509 name specification (https://golang.org/pkg/crypto/x509/pkix/#Name).
+              properties:
+                countries:
+                  description: Countries to be used on the Certificate.
+                  items:
+                    type: string
+                  type: array
+                localities:
+                  description: Cities to be used on the Certificate.
+                  items:
+                    type: string
+                  type: array
+                organizationalUnits:
+                  description: Organizational Units to be used on the Certificate.
+                  items:
+                    type: string
+                  type: array
+                postalCodes:
+                  description: Postal codes to be used on the Certificate.
+                  items:
+                    type: string
+                  type: array
+                provinces:
+                  description: State/Provinces to be used on the Certificate.
+                  items:
+                    type: string
+                  type: array
+                serialNumber:
+                  description: Serial number to be used on the Certificate.
+                  type: string
+                streetAddresses:
+                  description: Street addresses to be used on the Certificate.
+                  items:
+                    type: string
+                  type: array
+              type: object
+            uriSANs:
+              description: URISANs is a list of URI subjectAltNames to be set on the
+                Certificate.
+              items:
+                type: string
+              type: array
+            usages:
+              description: Usages is the set of x509 usages that are requested for
+                the certificate. Defaults to `digital signature` and `key encipherment`
+                if not specified.
+              items:
+                description: 'KeyUsage specifies valid usage contexts for keys. See:
+                  https://tools.ietf.org/html/rfc5280#section-4.2.1.3      https://tools.ietf.org/html/rfc5280#section-4.2.1.12
+                  Valid KeyUsage values are as follows: "signing", "digital signature",
+                  "content commitment", "key encipherment", "key agreement", "data
+                  encipherment", "cert sign", "crl sign", "encipher only", "decipher
+                  only", "any", "server auth", "client auth", "code signing", "email
+                  protection", "s/mime", "ipsec end system", "ipsec tunnel", "ipsec
+                  user", "timestamping", "ocsp signing", "microsoft sgc", "netscape
+                  sgc"'
+                enum:
+                - signing
+                - digital signature
+                - content commitment
+                - key encipherment
+                - key agreement
+                - data encipherment
+                - cert sign
+                - crl sign
+                - encipher only
+                - decipher only
+                - any
+                - server auth
+                - client auth
+                - code signing
+                - email protection
+                - s/mime
+                - ipsec end system
+                - ipsec tunnel
+                - ipsec user
+                - timestamping
+                - ocsp signing
+                - microsoft sgc
+                - netscape sgc
+                type: string
+              type: array
+          required:
+          - issuerRef
+          - secretName
+          type: object
+        status:
+          description: Status of the Certificate. This is set and managed automatically.
+          properties:
+            conditions:
+              description: List of status conditions to indicate the status of certificates.
+                Known condition types are `Ready` and `Issuing`.
+              items:
+                description: CertificateCondition contains condition information for
+                  an Certificate.
+                properties:
+                  lastTransitionTime:
+                    description: LastTransitionTime is the timestamp corresponding
+                      to the last status change of this condition.
+                    format: date-time
+                    type: string
+                  message:
+                    description: Message is a human readable description of the details
+                      of the last transition, complementing reason.
+                    type: string
+                  reason:
+                    description: Reason is a brief machine readable explanation for
+                      the condition's last transition.
+                    type: string
+                  status:
+                    description: Status of the condition, one of ('True', 'False',
+                      'Unknown').
+                    enum:
+                    - "True"
+                    - "False"
+                    - Unknown
+                    type: string
+                  type:
+                    description: Type of the condition, known values are ('Ready',
+                      `Issuing`).
+                    type: string
+                required:
+                - status
+                - type
+                type: object
+              type: array
+            lastFailureTime:
+              description: LastFailureTime is the time as recorded by the Certificate
+                controller of the most recent failure to complete a CertificateRequest
+                for this Certificate resource. If set, cert-manager will not re-request
+                another Certificate until 1 hour has elapsed from this time.
+              format: date-time
+              type: string
+            nextPrivateKeySecretName:
+              description: The name of the Secret resource containing the private
+                key to be used for the next certificate iteration. The keymanager
+                controller will automatically set this field if the `Issuing` condition
+                is set to `True`. It will automatically unset this field when the
+                Issuing condition is not set or False.
+              type: string
+            notAfter:
+              description: The expiration time of the certificate stored in the secret
+                named by this resource in `spec.secretName`.
+              format: date-time
+              type: string
+            notBefore:
+              description: The time after which the certificate stored in the secret
+                named by this resource in spec.secretName is valid.
+              format: date-time
+              type: string
+            renewalTime:
+              description: RenewalTime is the time at which the certificate will be
+                next renewed. If not set, no upcoming renewal is scheduled.
+              format: date-time
+              type: string
+            revision:
+              description: "The current 'revision' of the certificate as issued. \n
+                When a CertificateRequest resource is created, it will have the `cert-manager.io/certificate-revision`
+                set to one greater than the current value of this field. \n Upon issuance,
+                this field will be set to the value of the annotation on the CertificateRequest
+                resource used to issue the certificate. \n Persisting the value on
+                the CertificateRequest resource allows the certificates controller
+                to know whether a request is part of an old issuance or if it is part
+                of the ongoing revision's issuance by checking if the revision value
+                in the annotation is greater than this field."
+              type: integer
+          type: object
+  versions:
+  - name: v1alpha2
+    served: true
+    storage: true
+---
+# Source: cert-manager/templates/templates.legacy.out
+apiVersion: apiextensions.k8s.io/v1beta1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    cert-manager.io/inject-ca-from-secret: 'cert-manager/cert-manager-webhook-ca'
+  labels:
+    app: 'cert-manager'
+    app.kubernetes.io/instance: 'cert-manager'
     app.kubernetes.io/name: 'cert-manager'
   name: challenges.acme.cert-manager.io
 spec:
@@ -91,10 +730,13 @@ spec:
                 as failed.
               properties:
                 group:
+                  description: Group of the resource being referred to.
                   type: string
                 kind:
+                  description: Kind of the resource being referred to.
                   type: string
                 name:
+                  description: Name of the resource being referred to.
                   type: string
               required:
               - name
@@ -113,20 +755,25 @@ spec:
                 be used to solve this challenge resource.
               properties:
                 dns01:
+                  description: Configures cert-manager to attempt to complete authorizations
+                    by performing the DNS01 challenge flow.
                   properties:
                     acmedns:
-                      description: ACMEIssuerDNS01ProviderAcmeDNS is a structure containing
-                        the configuration for ACME-DNS servers
+                      description: Use the 'ACME DNS' (https://github.com/joohoi/acme-dns)
+                        API to manage DNS01 challenge records.
                       properties:
                         accountSecretRef:
+                          description: A reference to a specific 'key' within a Secret
+                            resource. In some instances, `key` is a required field.
                           properties:
                             key:
-                              description: The key of the secret to select from. Must
-                                be a valid secret key.
+                              description: The key of the entry in the Secret resource's
+                                `data` field to be used. Some instances of this field
+                                may be defaulted, in others it may be required.
                               type: string
                             name:
-                              description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                TODO: Add other useful fields. apiVersion, kind, uid?'
+                              description: 'Name of the resource being referred to.
+                                More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
                               type: string
                           required:
                           - name
@@ -138,45 +785,53 @@ spec:
                       - host
                       type: object
                     akamai:
-                      description: ACMEIssuerDNS01ProviderAkamai is a structure containing
-                        the DNS configuration for Akamai DNS—Zone Record Management
-                        API
+                      description: Use the Akamai DNS zone management API to manage
+                        DNS01 challenge records.
                       properties:
                         accessTokenSecretRef:
+                          description: A reference to a specific 'key' within a Secret
+                            resource. In some instances, `key` is a required field.
                           properties:
                             key:
-                              description: The key of the secret to select from. Must
-                                be a valid secret key.
+                              description: The key of the entry in the Secret resource's
+                                `data` field to be used. Some instances of this field
+                                may be defaulted, in others it may be required.
                               type: string
                             name:
-                              description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                TODO: Add other useful fields. apiVersion, kind, uid?'
+                              description: 'Name of the resource being referred to.
+                                More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
                               type: string
                           required:
                           - name
                           type: object
                         clientSecretSecretRef:
+                          description: A reference to a specific 'key' within a Secret
+                            resource. In some instances, `key` is a required field.
                           properties:
                             key:
-                              description: The key of the secret to select from. Must
-                                be a valid secret key.
+                              description: The key of the entry in the Secret resource's
+                                `data` field to be used. Some instances of this field
+                                may be defaulted, in others it may be required.
                               type: string
                             name:
-                              description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                TODO: Add other useful fields. apiVersion, kind, uid?'
+                              description: 'Name of the resource being referred to.
+                                More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
                               type: string
                           required:
                           - name
                           type: object
                         clientTokenSecretRef:
+                          description: A reference to a specific 'key' within a Secret
+                            resource. In some instances, `key` is a required field.
                           properties:
                             key:
-                              description: The key of the secret to select from. Must
-                                be a valid secret key.
+                              description: The key of the entry in the Secret resource's
+                                `data` field to be used. Some instances of this field
+                                may be defaulted, in others it may be required.
                               type: string
                             name:
-                              description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                TODO: Add other useful fields. apiVersion, kind, uid?'
+                              description: 'Name of the resource being referred to.
+                                More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
                               type: string
                           required:
                           - name
@@ -190,8 +845,8 @@ spec:
                       - serviceConsumerDomain
                       type: object
                     azuredns:
-                      description: ACMEIssuerDNS01ProviderAzureDNS is a structure
-                        containing the configuration for Azure DNS
+                      description: Use the Microsoft Azure DNS API to manage DNS01
+                        challenge records.
                       properties:
                         clientID:
                           description: if both this and ClientSecret are left unset
@@ -202,12 +857,13 @@ spec:
                             will be used
                           properties:
                             key:
-                              description: The key of the secret to select from. Must
-                                be a valid secret key.
+                              description: The key of the entry in the Secret resource's
+                                `data` field to be used. Some instances of this field
+                                may be defaulted, in others it may be required.
                               type: string
                             name:
-                              description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                TODO: Add other useful fields. apiVersion, kind, uid?'
+                              description: 'Name of the resource being referred to.
+                                More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
                               type: string
                           required:
                           - name
@@ -234,20 +890,29 @@ spec:
                       - subscriptionID
                       type: object
                     clouddns:
-                      description: ACMEIssuerDNS01ProviderCloudDNS is a structure
-                        containing the DNS configuration for Google Cloud DNS
+                      description: Use the Google Cloud DNS API to manage DNS01 challenge
+                        records.
                       properties:
+                        hostedZoneName:
+                          description: HostedZoneName is an optional field that tells
+                            cert-manager in which Cloud DNS zone the challenge record
+                            has to be created. If left empty cert-manager will automatically
+                            choose a zone.
+                          type: string
                         project:
                           type: string
                         serviceAccountSecretRef:
+                          description: A reference to a specific 'key' within a Secret
+                            resource. In some instances, `key` is a required field.
                           properties:
                             key:
-                              description: The key of the secret to select from. Must
-                                be a valid secret key.
+                              description: The key of the entry in the Secret resource's
+                                `data` field to be used. Some instances of this field
+                                may be defaulted, in others it may be required.
                               type: string
                             name:
-                              description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                TODO: Add other useful fields. apiVersion, kind, uid?'
+                              description: 'Name of the resource being referred to.
+                                More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
                               type: string
                           required:
                           - name
@@ -256,39 +921,45 @@ spec:
                       - project
                       type: object
                     cloudflare:
-                      description: ACMEIssuerDNS01ProviderCloudflare is a structure
-                        containing the DNS configuration for Cloudflare
+                      description: Use the Cloudflare API to manage DNS01 challenge
+                        records.
                       properties:
                         apiKeySecretRef:
+                          description: 'API key to use to authenticate with Cloudflare.
+                            Note: using an API token to authenticate is now the recommended
+                            method as it allows greater control of permissions.'
                           properties:
                             key:
-                              description: The key of the secret to select from. Must
-                                be a valid secret key.
+                              description: The key of the entry in the Secret resource's
+                                `data` field to be used. Some instances of this field
+                                may be defaulted, in others it may be required.
                               type: string
                             name:
-                              description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                TODO: Add other useful fields. apiVersion, kind, uid?'
+                              description: 'Name of the resource being referred to.
+                                More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
                               type: string
                           required:
                           - name
                           type: object
                         apiTokenSecretRef:
+                          description: API token used to authenticate with Cloudflare.
                           properties:
                             key:
-                              description: The key of the secret to select from. Must
-                                be a valid secret key.
+                              description: The key of the entry in the Secret resource's
+                                `data` field to be used. Some instances of this field
+                                may be defaulted, in others it may be required.
                               type: string
                             name:
-                              description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                TODO: Add other useful fields. apiVersion, kind, uid?'
+                              description: 'Name of the resource being referred to.
+                                More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
                               type: string
                           required:
                           - name
                           type: object
                         email:
+                          description: Email of the account, only required when using
+                            API key based authentication.
                           type: string
-                      required:
-                      - email
                       type: object
                     cnameStrategy:
                       description: CNAMEStrategy configures how the DNS01 provider
@@ -298,18 +969,21 @@ spec:
                       - Follow
                       type: string
                     digitalocean:
-                      description: ACMEIssuerDNS01ProviderDigitalOcean is a structure
-                        containing the DNS configuration for DigitalOcean Domains
+                      description: Use the DigitalOcean DNS API to manage DNS01 challenge
+                        records.
                       properties:
                         tokenSecretRef:
+                          description: A reference to a specific 'key' within a Secret
+                            resource. In some instances, `key` is a required field.
                           properties:
                             key:
-                              description: The key of the secret to select from. Must
-                                be a valid secret key.
+                              description: The key of the entry in the Secret resource's
+                                `data` field to be used. Some instances of this field
+                                may be defaulted, in others it may be required.
                               type: string
                             name:
-                              description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                TODO: Add other useful fields. apiVersion, kind, uid?'
+                              description: 'Name of the resource being referred to.
+                                More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
                               type: string
                           required:
                           - name
@@ -318,8 +992,9 @@ spec:
                       - tokenSecretRef
                       type: object
                     rfc2136:
-                      description: ACMEIssuerDNS01ProviderRFC2136 is a structure containing
-                        the configuration for RFC2136 DNS
+                      description: Use RFC2136 ("Dynamic Updates in the Domain Name
+                        System") (https://datatracker.ietf.org/doc/rfc2136/) to manage
+                        DNS01 challenge records.
                       properties:
                         nameserver:
                           description: The IP address or hostname of an authoritative
@@ -344,12 +1019,13 @@ spec:
                             value. If ``tsigKeyName`` is defined, this field is required.
                           properties:
                             key:
-                              description: The key of the secret to select from. Must
-                                be a valid secret key.
+                              description: The key of the entry in the Secret resource's
+                                `data` field to be used. Some instances of this field
+                                may be defaulted, in others it may be required.
                               type: string
                             name:
-                              description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                TODO: Add other useful fields. apiVersion, kind, uid?'
+                              description: 'Name of the resource being referred to.
+                                More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
                               type: string
                           required:
                           - name
@@ -358,8 +1034,8 @@ spec:
                       - nameserver
                       type: object
                     route53:
-                      description: ACMEIssuerDNS01ProviderRoute53 is a structure containing
-                        the Route 53 configuration for AWS
+                      description: Use the AWS Route53 API to manage DNS01 challenge
+                        records.
                       properties:
                         accessKeyID:
                           description: 'The AccessKeyID is used for authentication.
@@ -387,12 +1063,13 @@ spec:
                             file or AWS Instance metadata https://docs.aws.amazon.com/sdk-for-go/v1/developer-guide/configuring-sdk.html#specifying-credentials
                           properties:
                             key:
-                              description: The key of the secret to select from. Must
-                                be a valid secret key.
+                              description: The key of the entry in the Secret resource's
+                                `data` field to be used. Some instances of this field
+                                may be defaulted, in others it may be required.
                               type: string
                             name:
-                              description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                TODO: Add other useful fields. apiVersion, kind, uid?'
+                              description: 'Name of the resource being referred to.
+                                More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
                               type: string
                           required:
                           - name
@@ -401,9 +1078,8 @@ spec:
                       - region
                       type: object
                     webhook:
-                      description: ACMEIssuerDNS01ProviderWebhook specifies configuration
-                        for a webhook DNS01 provider, including where to POST ChallengePayload
-                        resources.
+                      description: Configure an external webhook based DNS01 challenge
+                        solver to manage DNS01 challenge records.
                       properties:
                         config:
                           description: Additional configuration that should be passed
@@ -431,12 +1107,10 @@ spec:
                       type: object
                   type: object
                 http01:
-                  description: ACMEChallengeSolverHTTP01 contains configuration detailing
-                    how to solve HTTP01 challenges within a Kubernetes cluster. Typically
-                    this is accomplished through creating 'routes' of some description
-                    that configure ingress controllers to direct traffic to 'solver
-                    pods', which are responsible for responding to the ACME server's
-                    HTTP requests.
+                  description: Configures cert-manager to attempt to complete authorizations
+                    by performing the HTTP01 challenge flow. It is not possible to
+                    obtain certificates for wildcard domain names (e.g. `*.example.com`)
+                    using the HTTP01 challenge mechanism.
                   properties:
                     ingress:
                       description: The ingress based HTTP01 challenge solver will
@@ -1349,7 +2023,10 @@ spec:
                   type: object
                 selector:
                   description: Selector selects a set of DNSNames on the Certificate
-                    resource that should be solved using this challenge solver.
+                    resource that should be solved using this challenge solver. If
+                    not specified, the solver will be treated as the 'default' solver
+                    with the lowest priority, i.e. if any other solver has a more
+                    specific match, it will be used instead.
                   properties:
                     dnsNames:
                       description: List of DNSNames that this solver will be used
@@ -1388,8 +2065,11 @@ spec:
                 is the raw value returned from the ACME server.
               type: string
             type:
-              description: Type is the type of ACME challenge this resource represents,
-                e.g. "dns01" or "http01".
+              description: Type is the type of ACME challenge this resource represents.
+                One of "http-01" or "dns-01".
+              enum:
+              - http-01
+              - dns-01
               type: string
             url:
               description: URL is the URL of the ACME Challenge resource for this
@@ -1460,7 +2140,6 @@ metadata:
   labels:
     app: 'cert-manager'
     app.kubernetes.io/instance: 'cert-manager'
-    app.kubernetes.io/managed-by: 'Helm'
     app.kubernetes.io/name: 'cert-manager'
   name: clusterissuers.cert-manager.io
 spec:
@@ -1490,6 +2169,10 @@ spec:
     status: {}
   validation:
     openAPIV3Schema:
+      description: A ClusterIssuer represents a certificate issuing authority which
+        can be referenced as part of `issuerRef` fields. It is similar to an Issuer,
+        however it is cluster-scoped and therefore can be referenced by resources
+        that exist in *any* namespace, not just the same namespace as the referent.
       properties:
         apiVersion:
           description: 'APIVersion defines the versioned schema of this representation
@@ -1504,18 +2187,24 @@ spec:
         metadata:
           type: object
         spec:
-          description: IssuerSpec is the specification of an Issuer. This includes
-            any configuration required for the issuer.
+          description: Desired state of the ClusterIssuer resource.
           properties:
             acme:
-              description: ACMEIssuer contains the specification for an ACME issuer
+              description: ACME configures this issuer to communicate with a RFC8555
+                (ACME) server to obtain signed x509 certificates.
               properties:
                 email:
-                  description: Email is the email for this account
+                  description: Email is the email address to be associated with the
+                    ACME account. This field is optional, but it is strongly recommended
+                    to be set. It will be used to contact you in case of issues with
+                    your account or certificates, including expiry notification emails.
+                    This field may be updated after the account is initially registered.
                   type: string
                 externalAccountBinding:
                   description: ExternalAccountBinding is a reference to a CA external
-                    account of the ACME server.
+                    account of the ACME server. If set, upon registration cert-manager
+                    will attempt to associate the given external account credentials
+                    with the registered ACME account.
                   properties:
                     keyAlgorithm:
                       description: keyAlgorithm is the MAC key algorithm that the
@@ -1540,12 +2229,13 @@ spec:
                         encoded data.
                       properties:
                         key:
-                          description: The key of the secret to select from. Must
-                            be a valid secret key.
+                          description: The key of the entry in the Secret resource's
+                            `data` field to be used. Some instances of this field
+                            may be defaulted, in others it may be required.
                           type: string
                         name:
-                          description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                            TODO: Add other useful fields. apiVersion, kind, uid?'
+                          description: 'Name of the resource being referred to. More
+                            info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
                           type: string
                       required:
                       - name
@@ -1556,48 +2246,69 @@ spec:
                   - keySecretRef
                   type: object
                 privateKeySecretRef:
-                  description: PrivateKey is the name of a secret containing the private
-                    key for this user account.
+                  description: PrivateKey is the name of a Kubernetes Secret resource
+                    that will be used to store the automatically generated ACME account
+                    private key. Optionally, a `key` may be specified to select a
+                    specific entry within the named Secret resource. If `key` is not
+                    specified, a default of `tls.key` will be used.
                   properties:
                     key:
-                      description: The key of the secret to select from. Must be a
-                        valid secret key.
+                      description: The key of the entry in the Secret resource's `data`
+                        field to be used. Some instances of this field may be defaulted,
+                        in others it may be required.
                       type: string
                     name:
-                      description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                        TODO: Add other useful fields. apiVersion, kind, uid?'
+                      description: 'Name of the resource being referred to. More info:
+                        https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
                       type: string
                   required:
                   - name
                   type: object
                 server:
-                  description: Server is the ACME server URL
+                  description: 'Server is the URL used to access the ACME server''s
+                    ''directory'' endpoint. For example, for Let''s Encrypt''s staging
+                    endpoint, you would use: "https://acme-staging-v02.api.letsencrypt.org/directory".
+                    Only ACME v2 endpoints (i.e. RFC 8555) are supported.'
                   type: string
                 skipTLSVerify:
-                  description: If true, skip verifying the ACME server TLS certificate
+                  description: Enables or disables validation of the ACME server TLS
+                    certificate. If true, requests to the ACME server will not have
+                    their TLS certificate validated (i.e. insecure connections will
+                    be allowed). Only enable this option in development environments.
+                    The cert-manager system installed roots will be used to verify
+                    connections to the ACME server if this is false. Defaults to false.
                   type: boolean
                 solvers:
-                  description: Solvers is a list of challenge solvers that will be
-                    used to solve ACME challenges for the matching domains.
+                  description: 'Solvers is a list of challenge solvers that will be
+                    used to solve ACME challenges for the matching domains. Solver
+                    configurations must be provided in order to obtain certificates
+                    from an ACME server. For more information, see: https://cert-manager.io/docs/configuration/acme/'
                   items:
+                    description: Configures an issuer to solve challenges using the
+                      specified options. Only one of HTTP01 or DNS01 may be provided.
                     properties:
                       dns01:
+                        description: Configures cert-manager to attempt to complete
+                          authorizations by performing the DNS01 challenge flow.
                         properties:
                           acmedns:
-                            description: ACMEIssuerDNS01ProviderAcmeDNS is a structure
-                              containing the configuration for ACME-DNS servers
+                            description: Use the 'ACME DNS' (https://github.com/joohoi/acme-dns)
+                              API to manage DNS01 challenge records.
                             properties:
                               accountSecretRef:
+                                description: A reference to a specific 'key' within
+                                  a Secret resource. In some instances, `key` is a
+                                  required field.
                                 properties:
                                   key:
-                                    description: The key of the secret to select from.
-                                      Must be a valid secret key.
+                                    description: The key of the entry in the Secret
+                                      resource's `data` field to be used. Some instances
+                                      of this field may be defaulted, in others it
+                                      may be required.
                                     type: string
                                   name:
-                                    description: 'Name of the referent. More info:
-                                      https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                      TODO: Add other useful fields. apiVersion, kind,
-                                      uid?'
+                                    description: 'Name of the resource being referred
+                                      to. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
                                     type: string
                                 required:
                                 - name
@@ -1609,51 +2320,59 @@ spec:
                             - host
                             type: object
                           akamai:
-                            description: ACMEIssuerDNS01ProviderAkamai is a structure
-                              containing the DNS configuration for Akamai DNS—Zone
-                              Record Management API
+                            description: Use the Akamai DNS zone management API to
+                              manage DNS01 challenge records.
                             properties:
                               accessTokenSecretRef:
+                                description: A reference to a specific 'key' within
+                                  a Secret resource. In some instances, `key` is a
+                                  required field.
                                 properties:
                                   key:
-                                    description: The key of the secret to select from.
-                                      Must be a valid secret key.
+                                    description: The key of the entry in the Secret
+                                      resource's `data` field to be used. Some instances
+                                      of this field may be defaulted, in others it
+                                      may be required.
                                     type: string
                                   name:
-                                    description: 'Name of the referent. More info:
-                                      https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                      TODO: Add other useful fields. apiVersion, kind,
-                                      uid?'
+                                    description: 'Name of the resource being referred
+                                      to. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
                                     type: string
                                 required:
                                 - name
                                 type: object
                               clientSecretSecretRef:
+                                description: A reference to a specific 'key' within
+                                  a Secret resource. In some instances, `key` is a
+                                  required field.
                                 properties:
                                   key:
-                                    description: The key of the secret to select from.
-                                      Must be a valid secret key.
+                                    description: The key of the entry in the Secret
+                                      resource's `data` field to be used. Some instances
+                                      of this field may be defaulted, in others it
+                                      may be required.
                                     type: string
                                   name:
-                                    description: 'Name of the referent. More info:
-                                      https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                      TODO: Add other useful fields. apiVersion, kind,
-                                      uid?'
+                                    description: 'Name of the resource being referred
+                                      to. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
                                     type: string
                                 required:
                                 - name
                                 type: object
                               clientTokenSecretRef:
+                                description: A reference to a specific 'key' within
+                                  a Secret resource. In some instances, `key` is a
+                                  required field.
                                 properties:
                                   key:
-                                    description: The key of the secret to select from.
-                                      Must be a valid secret key.
+                                    description: The key of the entry in the Secret
+                                      resource's `data` field to be used. Some instances
+                                      of this field may be defaulted, in others it
+                                      may be required.
                                     type: string
                                   name:
-                                    description: 'Name of the referent. More info:
-                                      https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                      TODO: Add other useful fields. apiVersion, kind,
-                                      uid?'
+                                    description: 'Name of the resource being referred
+                                      to. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
                                     type: string
                                 required:
                                 - name
@@ -1667,8 +2386,8 @@ spec:
                             - serviceConsumerDomain
                             type: object
                           azuredns:
-                            description: ACMEIssuerDNS01ProviderAzureDNS is a structure
-                              containing the configuration for Azure DNS
+                            description: Use the Microsoft Azure DNS API to manage
+                              DNS01 challenge records.
                             properties:
                               clientID:
                                 description: if both this and ClientSecret are left
@@ -1679,14 +2398,14 @@ spec:
                                   MSI will be used
                                 properties:
                                   key:
-                                    description: The key of the secret to select from.
-                                      Must be a valid secret key.
+                                    description: The key of the entry in the Secret
+                                      resource's `data` field to be used. Some instances
+                                      of this field may be defaulted, in others it
+                                      may be required.
                                     type: string
                                   name:
-                                    description: 'Name of the referent. More info:
-                                      https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                      TODO: Add other useful fields. apiVersion, kind,
-                                      uid?'
+                                    description: 'Name of the resource being referred
+                                      to. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
                                     type: string
                                 required:
                                 - name
@@ -1713,22 +2432,31 @@ spec:
                             - subscriptionID
                             type: object
                           clouddns:
-                            description: ACMEIssuerDNS01ProviderCloudDNS is a structure
-                              containing the DNS configuration for Google Cloud DNS
+                            description: Use the Google Cloud DNS API to manage DNS01
+                              challenge records.
                             properties:
+                              hostedZoneName:
+                                description: HostedZoneName is an optional field that
+                                  tells cert-manager in which Cloud DNS zone the challenge
+                                  record has to be created. If left empty cert-manager
+                                  will automatically choose a zone.
+                                type: string
                               project:
                                 type: string
                               serviceAccountSecretRef:
+                                description: A reference to a specific 'key' within
+                                  a Secret resource. In some instances, `key` is a
+                                  required field.
                                 properties:
                                   key:
-                                    description: The key of the secret to select from.
-                                      Must be a valid secret key.
+                                    description: The key of the entry in the Secret
+                                      resource's `data` field to be used. Some instances
+                                      of this field may be defaulted, in others it
+                                      may be required.
                                     type: string
                                   name:
-                                    description: 'Name of the referent. More info:
-                                      https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                      TODO: Add other useful fields. apiVersion, kind,
-                                      uid?'
+                                    description: 'Name of the resource being referred
+                                      to. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
                                     type: string
                                 required:
                                 - name
@@ -1737,43 +2465,48 @@ spec:
                             - project
                             type: object
                           cloudflare:
-                            description: ACMEIssuerDNS01ProviderCloudflare is a structure
-                              containing the DNS configuration for Cloudflare
+                            description: Use the Cloudflare API to manage DNS01 challenge
+                              records.
                             properties:
                               apiKeySecretRef:
+                                description: 'API key to use to authenticate with
+                                  Cloudflare. Note: using an API token to authenticate
+                                  is now the recommended method as it allows greater
+                                  control of permissions.'
                                 properties:
                                   key:
-                                    description: The key of the secret to select from.
-                                      Must be a valid secret key.
+                                    description: The key of the entry in the Secret
+                                      resource's `data` field to be used. Some instances
+                                      of this field may be defaulted, in others it
+                                      may be required.
                                     type: string
                                   name:
-                                    description: 'Name of the referent. More info:
-                                      https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                      TODO: Add other useful fields. apiVersion, kind,
-                                      uid?'
+                                    description: 'Name of the resource being referred
+                                      to. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
                                     type: string
                                 required:
                                 - name
                                 type: object
                               apiTokenSecretRef:
+                                description: API token used to authenticate with Cloudflare.
                                 properties:
                                   key:
-                                    description: The key of the secret to select from.
-                                      Must be a valid secret key.
+                                    description: The key of the entry in the Secret
+                                      resource's `data` field to be used. Some instances
+                                      of this field may be defaulted, in others it
+                                      may be required.
                                     type: string
                                   name:
-                                    description: 'Name of the referent. More info:
-                                      https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                      TODO: Add other useful fields. apiVersion, kind,
-                                      uid?'
+                                    description: 'Name of the resource being referred
+                                      to. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
                                     type: string
                                 required:
                                 - name
                                 type: object
                               email:
+                                description: Email of the account, only required when
+                                  using API key based authentication.
                                 type: string
-                            required:
-                            - email
                             type: object
                           cnameStrategy:
                             description: CNAMEStrategy configures how the DNS01 provider
@@ -1783,21 +2516,23 @@ spec:
                             - Follow
                             type: string
                           digitalocean:
-                            description: ACMEIssuerDNS01ProviderDigitalOcean is a
-                              structure containing the DNS configuration for DigitalOcean
-                              Domains
+                            description: Use the DigitalOcean DNS API to manage DNS01
+                              challenge records.
                             properties:
                               tokenSecretRef:
+                                description: A reference to a specific 'key' within
+                                  a Secret resource. In some instances, `key` is a
+                                  required field.
                                 properties:
                                   key:
-                                    description: The key of the secret to select from.
-                                      Must be a valid secret key.
+                                    description: The key of the entry in the Secret
+                                      resource's `data` field to be used. Some instances
+                                      of this field may be defaulted, in others it
+                                      may be required.
                                     type: string
                                   name:
-                                    description: 'Name of the referent. More info:
-                                      https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                      TODO: Add other useful fields. apiVersion, kind,
-                                      uid?'
+                                    description: 'Name of the resource being referred
+                                      to. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
                                     type: string
                                 required:
                                 - name
@@ -1806,8 +2541,9 @@ spec:
                             - tokenSecretRef
                             type: object
                           rfc2136:
-                            description: ACMEIssuerDNS01ProviderRFC2136 is a structure
-                              containing the configuration for RFC2136 DNS
+                            description: Use RFC2136 ("Dynamic Updates in the Domain
+                              Name System") (https://datatracker.ietf.org/doc/rfc2136/)
+                              to manage DNS01 challenge records.
                             properties:
                               nameserver:
                                 description: The IP address or hostname of an authoritative
@@ -1834,14 +2570,14 @@ spec:
                                   field is required.
                                 properties:
                                   key:
-                                    description: The key of the secret to select from.
-                                      Must be a valid secret key.
+                                    description: The key of the entry in the Secret
+                                      resource's `data` field to be used. Some instances
+                                      of this field may be defaulted, in others it
+                                      may be required.
                                     type: string
                                   name:
-                                    description: 'Name of the referent. More info:
-                                      https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                      TODO: Add other useful fields. apiVersion, kind,
-                                      uid?'
+                                    description: 'Name of the resource being referred
+                                      to. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
                                     type: string
                                 required:
                                 - name
@@ -1850,8 +2586,8 @@ spec:
                             - nameserver
                             type: object
                           route53:
-                            description: ACMEIssuerDNS01ProviderRoute53 is a structure
-                              containing the Route 53 configuration for AWS
+                            description: Use the AWS Route53 API to manage DNS01 challenge
+                              records.
                             properties:
                               accessKeyID:
                                 description: 'The AccessKeyID is used for authentication.
@@ -1880,14 +2616,14 @@ spec:
                                   credentials file or AWS Instance metadata https://docs.aws.amazon.com/sdk-for-go/v1/developer-guide/configuring-sdk.html#specifying-credentials
                                 properties:
                                   key:
-                                    description: The key of the secret to select from.
-                                      Must be a valid secret key.
+                                    description: The key of the entry in the Secret
+                                      resource's `data` field to be used. Some instances
+                                      of this field may be defaulted, in others it
+                                      may be required.
                                     type: string
                                   name:
-                                    description: 'Name of the referent. More info:
-                                      https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                      TODO: Add other useful fields. apiVersion, kind,
-                                      uid?'
+                                    description: 'Name of the resource being referred
+                                      to. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
                                     type: string
                                 required:
                                 - name
@@ -1896,9 +2632,8 @@ spec:
                             - region
                             type: object
                           webhook:
-                            description: ACMEIssuerDNS01ProviderWebhook specifies
-                              configuration for a webhook DNS01 provider, including
-                              where to POST ChallengePayload resources.
+                            description: Configure an external webhook based DNS01
+                              challenge solver to manage DNS01 challenge records.
                             properties:
                               config:
                                 description: Additional configuration that should
@@ -1927,12 +2662,11 @@ spec:
                             type: object
                         type: object
                       http01:
-                        description: ACMEChallengeSolverHTTP01 contains configuration
-                          detailing how to solve HTTP01 challenges within a Kubernetes
-                          cluster. Typically this is accomplished through creating
-                          'routes' of some description that configure ingress controllers
-                          to direct traffic to 'solver pods', which are responsible
-                          for responding to the ACME server's HTTP requests.
+                        description: Configures cert-manager to attempt to complete
+                          authorizations by performing the HTTP01 challenge flow.
+                          It is not possible to obtain certificates for wildcard domain
+                          names (e.g. `*.example.com`) using the HTTP01 challenge
+                          mechanism.
                         properties:
                           ingress:
                             description: The ingress based HTTP01 challenge solver
@@ -2949,6 +3683,9 @@ spec:
                       selector:
                         description: Selector selects a set of DNSNames on the Certificate
                           resource that should be solved using this challenge solver.
+                          If not specified, the solver will be treated as the 'default'
+                          solver with the lowest priority, i.e. if any other solver
+                          has a more specific match, it will be used instead.
                         properties:
                           dnsNames:
                             description: List of DNSNames that this solver will be
@@ -2989,12 +3726,15 @@ spec:
               - server
               type: object
             ca:
+              description: CA configures this issuer to sign certificates using a
+                signing CA keypair stored in a Secret resource. This is used to build
+                internal PKIs that are managed by cert-manager.
               properties:
                 crlDistributionPoints:
                   description: The CRL distribution points is an X.509 v3 certificate
                     extension which identifies the location of the CRL from which
-                    the revocation of this certificate can be checked. If not set
-                    certificate will be issued without CDP. Values are strings.
+                    the revocation of this certificate can be checked. If not set,
+                    certificates will be issued without distribution points set.
                   items:
                     type: string
                   type: array
@@ -3006,6 +3746,8 @@ spec:
               - secretName
               type: object
             selfSigned:
+              description: SelfSigned configures this issuer to 'self sign' certificates
+                using the private key used to create the CertificateRequest object.
               properties:
                 crlDistributionPoints:
                   description: The CRL distribution points is an X.509 v3 certificate
@@ -3017,28 +3759,41 @@ spec:
                   type: array
               type: object
             vault:
+              description: Vault configures this issuer to sign certificates using
+                a HashiCorp Vault PKI backend.
               properties:
                 auth:
-                  description: Vault authentication
+                  description: Auth configures how cert-manager authenticates with
+                    the Vault server.
                   properties:
                     appRole:
-                      description: This Secret contains a AppRole and Secret
+                      description: AppRole authenticates with Vault using the App
+                        Role auth mechanism, with the role and secret stored in a
+                        Kubernetes Secret resource.
                       properties:
                         path:
-                          description: Where the authentication path is mounted in
-                            Vault.
+                          description: 'Path where the App Role authentication backend
+                            is mounted in Vault, e.g: "approle"'
                           type: string
                         roleId:
+                          description: RoleID configured in the App Role authentication
+                            backend when setting up the authentication backend in
+                            Vault.
                           type: string
                         secretRef:
+                          description: Reference to a key in a Secret that contains
+                            the App Role secret used to authenticate with Vault. The
+                            `key` field must be specified and denotes which entry
+                            within the Secret resource is used as the app role secret.
                           properties:
                             key:
-                              description: The key of the secret to select from. Must
-                                be a valid secret key.
+                              description: The key of the entry in the Secret resource's
+                                `data` field to be used. Some instances of this field
+                                may be defaulted, in others it may be required.
                               type: string
                             name:
-                              description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                TODO: Add other useful fields. apiVersion, kind, uid?'
+                              description: 'Name of the resource being referred to.
+                                More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
                               type: string
                           required:
                           - name
@@ -3049,8 +3804,9 @@ spec:
                       - secretRef
                       type: object
                     kubernetes:
-                      description: This contains a Role and Secret with a ServiceAccount
-                        token to authenticate with vault.
+                      description: Kubernetes authenticates with Vault by passing
+                        the ServiceAccount token stored in the named Secret resource
+                        to the Vault server.
                       properties:
                         mountPath:
                           description: The Vault mountPath here is the mount path
@@ -3070,12 +3826,13 @@ spec:
                             Use of 'ambient credentials' is not supported.
                           properties:
                             key:
-                              description: The key of the secret to select from. Must
-                                be a valid secret key.
+                              description: The key of the entry in the Secret resource's
+                                `data` field to be used. Some instances of this field
+                                may be defaulted, in others it may be required.
                               type: string
                             name:
-                              description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                TODO: Add other useful fields. apiVersion, kind, uid?'
+                              description: 'Name of the resource being referred to.
+                                More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
                               type: string
                           required:
                           - name
@@ -3085,32 +3842,37 @@ spec:
                       - secretRef
                       type: object
                     tokenSecretRef:
-                      description: This Secret contains the Vault token key
+                      description: TokenSecretRef authenticates with Vault by presenting
+                        a token.
                       properties:
                         key:
-                          description: The key of the secret to select from. Must
-                            be a valid secret key.
+                          description: The key of the entry in the Secret resource's
+                            `data` field to be used. Some instances of this field
+                            may be defaulted, in others it may be required.
                           type: string
                         name:
-                          description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                            TODO: Add other useful fields. apiVersion, kind, uid?'
+                          description: 'Name of the resource being referred to. More
+                            info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
                           type: string
                       required:
                       - name
                       type: object
                   type: object
                 caBundle:
-                  description: Base64 encoded CA bundle to validate Vault server certificate.
-                    Only used if the Server URL is using HTTPS protocol. This parameter
-                    is ignored for plain HTTP protocol connection. If not set the
-                    system root certificates are used to validate the TLS connection.
+                  description: PEM encoded CA bundle used to validate Vault server
+                    certificate. Only used if the Server URL is using HTTPS protocol.
+                    This parameter is ignored for plain HTTP protocol connection.
+                    If not set the system root certificates are used to validate the
+                    TLS connection.
                   format: byte
                   type: string
                 path:
-                  description: Vault URL path to the certificate role
+                  description: 'Path is the mount path of the Vault PKI backend''s
+                    `sign` endpoint, e.g: "my_pki_mount/sign/my-role-name".'
                   type: string
                 server:
-                  description: Server is the vault connection address
+                  description: 'Server is the connection address for the Vault server,
+                    e.g: "https://vault.example.com:8200".'
                   type: string
               required:
               - auth
@@ -3118,8 +3880,8 @@ spec:
               - server
               type: object
             venafi:
-              description: VenafiIssuer describes issuer configuration details for
-                Venafi Cloud.
+              description: Venafi configures this issuer to sign certificates using
+                a Venafi TPP or Venafi Cloud policy zone.
               properties:
                 cloud:
                   description: Cloud specifies the Venafi cloud configuration settings.
@@ -3130,18 +3892,20 @@ spec:
                         the Venafi Cloud API token.
                       properties:
                         key:
-                          description: The key of the secret to select from. Must
-                            be a valid secret key.
+                          description: The key of the entry in the Secret resource's
+                            `data` field to be used. Some instances of this field
+                            may be defaulted, in others it may be required.
                           type: string
                         name:
-                          description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                            TODO: Add other useful fields. apiVersion, kind, uid?'
+                          description: 'Name of the resource being referred to. More
+                            info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
                           type: string
                       required:
                       - name
                       type: object
                     url:
-                      description: URL is the base URL for Venafi Cloud
+                      description: URL is the base URL for Venafi Cloud. Defaults
+                        to "https://api.venafi.cloud/v1".
                       type: string
                   required:
                   - apiTokenSecretRef
@@ -3165,14 +3929,15 @@ spec:
                         contain two keys, 'username' and 'password'.
                       properties:
                         name:
-                          description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                            TODO: Add other useful fields. apiVersion, kind, uid?'
+                          description: 'Name of the resource being referred to. More
+                            info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
                           type: string
                       required:
                       - name
                       type: object
                     url:
-                      description: URL is the base URL for the Venafi TPP instance
+                      description: 'URL is the base URL for the vedsdk endpoint of
+                        the Venafi TPP instance, for example: "https://tpp.example.com/vedsdk".'
                       type: string
                   required:
                   - credentialsRef
@@ -3188,9 +3953,11 @@ spec:
               type: object
           type: object
         status:
-          description: IssuerStatus contains status information about an Issuer
+          description: Status of the ClusterIssuer. This is set and managed automatically.
           properties:
             acme:
+              description: ACME specific status options. This field should only be
+                set if the Issuer is configured to use an ACME server to issue certificates.
               properties:
                 lastRegisteredEmail:
                   description: LastRegisteredEmail is the email associated with the
@@ -3203,6 +3970,8 @@ spec:
                   type: string
               type: object
             conditions:
+              description: List of status conditions to indicate the status of a CertificateRequest.
+                Known condition types are `Ready`.
               items:
                 description: IssuerCondition contains condition information for an
                   Issuer.
@@ -3229,7 +3998,7 @@ spec:
                     - Unknown
                     type: string
                   type:
-                    description: Type of the condition, currently ('Ready').
+                    description: Type of the condition, known values are ('Ready').
                     type: string
                 required:
                 - status
@@ -3251,7 +4020,6 @@ metadata:
   labels:
     app: 'cert-manager'
     app.kubernetes.io/instance: 'cert-manager'
-    app.kubernetes.io/managed-by: 'Helm'
     app.kubernetes.io/name: 'cert-manager'
   name: issuers.cert-manager.io
 spec:
@@ -3281,6 +4049,9 @@ spec:
     status: {}
   validation:
     openAPIV3Schema:
+      description: An Issuer represents a certificate issuing authority which can
+        be referenced as part of `issuerRef` fields. It is scoped to a single namespace
+        and can therefore only be referenced by resources within the same namespace.
       properties:
         apiVersion:
           description: 'APIVersion defines the versioned schema of this representation
@@ -3295,18 +4066,24 @@ spec:
         metadata:
           type: object
         spec:
-          description: IssuerSpec is the specification of an Issuer. This includes
-            any configuration required for the issuer.
+          description: Desired state of the Issuer resource.
           properties:
             acme:
-              description: ACMEIssuer contains the specification for an ACME issuer
+              description: ACME configures this issuer to communicate with a RFC8555
+                (ACME) server to obtain signed x509 certificates.
               properties:
                 email:
-                  description: Email is the email for this account
+                  description: Email is the email address to be associated with the
+                    ACME account. This field is optional, but it is strongly recommended
+                    to be set. It will be used to contact you in case of issues with
+                    your account or certificates, including expiry notification emails.
+                    This field may be updated after the account is initially registered.
                   type: string
                 externalAccountBinding:
                   description: ExternalAccountBinding is a reference to a CA external
-                    account of the ACME server.
+                    account of the ACME server. If set, upon registration cert-manager
+                    will attempt to associate the given external account credentials
+                    with the registered ACME account.
                   properties:
                     keyAlgorithm:
                       description: keyAlgorithm is the MAC key algorithm that the
@@ -3331,12 +4108,13 @@ spec:
                         encoded data.
                       properties:
                         key:
-                          description: The key of the secret to select from. Must
-                            be a valid secret key.
+                          description: The key of the entry in the Secret resource's
+                            `data` field to be used. Some instances of this field
+                            may be defaulted, in others it may be required.
                           type: string
                         name:
-                          description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                            TODO: Add other useful fields. apiVersion, kind, uid?'
+                          description: 'Name of the resource being referred to. More
+                            info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
                           type: string
                       required:
                       - name
@@ -3347,48 +4125,69 @@ spec:
                   - keySecretRef
                   type: object
                 privateKeySecretRef:
-                  description: PrivateKey is the name of a secret containing the private
-                    key for this user account.
+                  description: PrivateKey is the name of a Kubernetes Secret resource
+                    that will be used to store the automatically generated ACME account
+                    private key. Optionally, a `key` may be specified to select a
+                    specific entry within the named Secret resource. If `key` is not
+                    specified, a default of `tls.key` will be used.
                   properties:
                     key:
-                      description: The key of the secret to select from. Must be a
-                        valid secret key.
+                      description: The key of the entry in the Secret resource's `data`
+                        field to be used. Some instances of this field may be defaulted,
+                        in others it may be required.
                       type: string
                     name:
-                      description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                        TODO: Add other useful fields. apiVersion, kind, uid?'
+                      description: 'Name of the resource being referred to. More info:
+                        https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
                       type: string
                   required:
                   - name
                   type: object
                 server:
-                  description: Server is the ACME server URL
+                  description: 'Server is the URL used to access the ACME server''s
+                    ''directory'' endpoint. For example, for Let''s Encrypt''s staging
+                    endpoint, you would use: "https://acme-staging-v02.api.letsencrypt.org/directory".
+                    Only ACME v2 endpoints (i.e. RFC 8555) are supported.'
                   type: string
                 skipTLSVerify:
-                  description: If true, skip verifying the ACME server TLS certificate
+                  description: Enables or disables validation of the ACME server TLS
+                    certificate. If true, requests to the ACME server will not have
+                    their TLS certificate validated (i.e. insecure connections will
+                    be allowed). Only enable this option in development environments.
+                    The cert-manager system installed roots will be used to verify
+                    connections to the ACME server if this is false. Defaults to false.
                   type: boolean
                 solvers:
-                  description: Solvers is a list of challenge solvers that will be
-                    used to solve ACME challenges for the matching domains.
+                  description: 'Solvers is a list of challenge solvers that will be
+                    used to solve ACME challenges for the matching domains. Solver
+                    configurations must be provided in order to obtain certificates
+                    from an ACME server. For more information, see: https://cert-manager.io/docs/configuration/acme/'
                   items:
+                    description: Configures an issuer to solve challenges using the
+                      specified options. Only one of HTTP01 or DNS01 may be provided.
                     properties:
                       dns01:
+                        description: Configures cert-manager to attempt to complete
+                          authorizations by performing the DNS01 challenge flow.
                         properties:
                           acmedns:
-                            description: ACMEIssuerDNS01ProviderAcmeDNS is a structure
-                              containing the configuration for ACME-DNS servers
+                            description: Use the 'ACME DNS' (https://github.com/joohoi/acme-dns)
+                              API to manage DNS01 challenge records.
                             properties:
                               accountSecretRef:
+                                description: A reference to a specific 'key' within
+                                  a Secret resource. In some instances, `key` is a
+                                  required field.
                                 properties:
                                   key:
-                                    description: The key of the secret to select from.
-                                      Must be a valid secret key.
+                                    description: The key of the entry in the Secret
+                                      resource's `data` field to be used. Some instances
+                                      of this field may be defaulted, in others it
+                                      may be required.
                                     type: string
                                   name:
-                                    description: 'Name of the referent. More info:
-                                      https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                      TODO: Add other useful fields. apiVersion, kind,
-                                      uid?'
+                                    description: 'Name of the resource being referred
+                                      to. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
                                     type: string
                                 required:
                                 - name
@@ -3400,51 +4199,59 @@ spec:
                             - host
                             type: object
                           akamai:
-                            description: ACMEIssuerDNS01ProviderAkamai is a structure
-                              containing the DNS configuration for Akamai DNS—Zone
-                              Record Management API
+                            description: Use the Akamai DNS zone management API to
+                              manage DNS01 challenge records.
                             properties:
                               accessTokenSecretRef:
+                                description: A reference to a specific 'key' within
+                                  a Secret resource. In some instances, `key` is a
+                                  required field.
                                 properties:
                                   key:
-                                    description: The key of the secret to select from.
-                                      Must be a valid secret key.
+                                    description: The key of the entry in the Secret
+                                      resource's `data` field to be used. Some instances
+                                      of this field may be defaulted, in others it
+                                      may be required.
                                     type: string
                                   name:
-                                    description: 'Name of the referent. More info:
-                                      https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                      TODO: Add other useful fields. apiVersion, kind,
-                                      uid?'
+                                    description: 'Name of the resource being referred
+                                      to. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
                                     type: string
                                 required:
                                 - name
                                 type: object
                               clientSecretSecretRef:
+                                description: A reference to a specific 'key' within
+                                  a Secret resource. In some instances, `key` is a
+                                  required field.
                                 properties:
                                   key:
-                                    description: The key of the secret to select from.
-                                      Must be a valid secret key.
+                                    description: The key of the entry in the Secret
+                                      resource's `data` field to be used. Some instances
+                                      of this field may be defaulted, in others it
+                                      may be required.
                                     type: string
                                   name:
-                                    description: 'Name of the referent. More info:
-                                      https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                      TODO: Add other useful fields. apiVersion, kind,
-                                      uid?'
+                                    description: 'Name of the resource being referred
+                                      to. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
                                     type: string
                                 required:
                                 - name
                                 type: object
                               clientTokenSecretRef:
+                                description: A reference to a specific 'key' within
+                                  a Secret resource. In some instances, `key` is a
+                                  required field.
                                 properties:
                                   key:
-                                    description: The key of the secret to select from.
-                                      Must be a valid secret key.
+                                    description: The key of the entry in the Secret
+                                      resource's `data` field to be used. Some instances
+                                      of this field may be defaulted, in others it
+                                      may be required.
                                     type: string
                                   name:
-                                    description: 'Name of the referent. More info:
-                                      https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                      TODO: Add other useful fields. apiVersion, kind,
-                                      uid?'
+                                    description: 'Name of the resource being referred
+                                      to. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
                                     type: string
                                 required:
                                 - name
@@ -3458,8 +4265,8 @@ spec:
                             - serviceConsumerDomain
                             type: object
                           azuredns:
-                            description: ACMEIssuerDNS01ProviderAzureDNS is a structure
-                              containing the configuration for Azure DNS
+                            description: Use the Microsoft Azure DNS API to manage
+                              DNS01 challenge records.
                             properties:
                               clientID:
                                 description: if both this and ClientSecret are left
@@ -3470,14 +4277,14 @@ spec:
                                   MSI will be used
                                 properties:
                                   key:
-                                    description: The key of the secret to select from.
-                                      Must be a valid secret key.
+                                    description: The key of the entry in the Secret
+                                      resource's `data` field to be used. Some instances
+                                      of this field may be defaulted, in others it
+                                      may be required.
                                     type: string
                                   name:
-                                    description: 'Name of the referent. More info:
-                                      https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                      TODO: Add other useful fields. apiVersion, kind,
-                                      uid?'
+                                    description: 'Name of the resource being referred
+                                      to. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
                                     type: string
                                 required:
                                 - name
@@ -3504,22 +4311,31 @@ spec:
                             - subscriptionID
                             type: object
                           clouddns:
-                            description: ACMEIssuerDNS01ProviderCloudDNS is a structure
-                              containing the DNS configuration for Google Cloud DNS
+                            description: Use the Google Cloud DNS API to manage DNS01
+                              challenge records.
                             properties:
+                              hostedZoneName:
+                                description: HostedZoneName is an optional field that
+                                  tells cert-manager in which Cloud DNS zone the challenge
+                                  record has to be created. If left empty cert-manager
+                                  will automatically choose a zone.
+                                type: string
                               project:
                                 type: string
                               serviceAccountSecretRef:
+                                description: A reference to a specific 'key' within
+                                  a Secret resource. In some instances, `key` is a
+                                  required field.
                                 properties:
                                   key:
-                                    description: The key of the secret to select from.
-                                      Must be a valid secret key.
+                                    description: The key of the entry in the Secret
+                                      resource's `data` field to be used. Some instances
+                                      of this field may be defaulted, in others it
+                                      may be required.
                                     type: string
                                   name:
-                                    description: 'Name of the referent. More info:
-                                      https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                      TODO: Add other useful fields. apiVersion, kind,
-                                      uid?'
+                                    description: 'Name of the resource being referred
+                                      to. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
                                     type: string
                                 required:
                                 - name
@@ -3528,43 +4344,48 @@ spec:
                             - project
                             type: object
                           cloudflare:
-                            description: ACMEIssuerDNS01ProviderCloudflare is a structure
-                              containing the DNS configuration for Cloudflare
+                            description: Use the Cloudflare API to manage DNS01 challenge
+                              records.
                             properties:
                               apiKeySecretRef:
+                                description: 'API key to use to authenticate with
+                                  Cloudflare. Note: using an API token to authenticate
+                                  is now the recommended method as it allows greater
+                                  control of permissions.'
                                 properties:
                                   key:
-                                    description: The key of the secret to select from.
-                                      Must be a valid secret key.
+                                    description: The key of the entry in the Secret
+                                      resource's `data` field to be used. Some instances
+                                      of this field may be defaulted, in others it
+                                      may be required.
                                     type: string
                                   name:
-                                    description: 'Name of the referent. More info:
-                                      https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                      TODO: Add other useful fields. apiVersion, kind,
-                                      uid?'
+                                    description: 'Name of the resource being referred
+                                      to. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
                                     type: string
                                 required:
                                 - name
                                 type: object
                               apiTokenSecretRef:
+                                description: API token used to authenticate with Cloudflare.
                                 properties:
                                   key:
-                                    description: The key of the secret to select from.
-                                      Must be a valid secret key.
+                                    description: The key of the entry in the Secret
+                                      resource's `data` field to be used. Some instances
+                                      of this field may be defaulted, in others it
+                                      may be required.
                                     type: string
                                   name:
-                                    description: 'Name of the referent. More info:
-                                      https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                      TODO: Add other useful fields. apiVersion, kind,
-                                      uid?'
+                                    description: 'Name of the resource being referred
+                                      to. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
                                     type: string
                                 required:
                                 - name
                                 type: object
                               email:
+                                description: Email of the account, only required when
+                                  using API key based authentication.
                                 type: string
-                            required:
-                            - email
                             type: object
                           cnameStrategy:
                             description: CNAMEStrategy configures how the DNS01 provider
@@ -3574,21 +4395,23 @@ spec:
                             - Follow
                             type: string
                           digitalocean:
-                            description: ACMEIssuerDNS01ProviderDigitalOcean is a
-                              structure containing the DNS configuration for DigitalOcean
-                              Domains
+                            description: Use the DigitalOcean DNS API to manage DNS01
+                              challenge records.
                             properties:
                               tokenSecretRef:
+                                description: A reference to a specific 'key' within
+                                  a Secret resource. In some instances, `key` is a
+                                  required field.
                                 properties:
                                   key:
-                                    description: The key of the secret to select from.
-                                      Must be a valid secret key.
+                                    description: The key of the entry in the Secret
+                                      resource's `data` field to be used. Some instances
+                                      of this field may be defaulted, in others it
+                                      may be required.
                                     type: string
                                   name:
-                                    description: 'Name of the referent. More info:
-                                      https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                      TODO: Add other useful fields. apiVersion, kind,
-                                      uid?'
+                                    description: 'Name of the resource being referred
+                                      to. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
                                     type: string
                                 required:
                                 - name
@@ -3597,8 +4420,9 @@ spec:
                             - tokenSecretRef
                             type: object
                           rfc2136:
-                            description: ACMEIssuerDNS01ProviderRFC2136 is a structure
-                              containing the configuration for RFC2136 DNS
+                            description: Use RFC2136 ("Dynamic Updates in the Domain
+                              Name System") (https://datatracker.ietf.org/doc/rfc2136/)
+                              to manage DNS01 challenge records.
                             properties:
                               nameserver:
                                 description: The IP address or hostname of an authoritative
@@ -3625,14 +4449,14 @@ spec:
                                   field is required.
                                 properties:
                                   key:
-                                    description: The key of the secret to select from.
-                                      Must be a valid secret key.
+                                    description: The key of the entry in the Secret
+                                      resource's `data` field to be used. Some instances
+                                      of this field may be defaulted, in others it
+                                      may be required.
                                     type: string
                                   name:
-                                    description: 'Name of the referent. More info:
-                                      https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                      TODO: Add other useful fields. apiVersion, kind,
-                                      uid?'
+                                    description: 'Name of the resource being referred
+                                      to. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
                                     type: string
                                 required:
                                 - name
@@ -3641,8 +4465,8 @@ spec:
                             - nameserver
                             type: object
                           route53:
-                            description: ACMEIssuerDNS01ProviderRoute53 is a structure
-                              containing the Route 53 configuration for AWS
+                            description: Use the AWS Route53 API to manage DNS01 challenge
+                              records.
                             properties:
                               accessKeyID:
                                 description: 'The AccessKeyID is used for authentication.
@@ -3671,14 +4495,14 @@ spec:
                                   credentials file or AWS Instance metadata https://docs.aws.amazon.com/sdk-for-go/v1/developer-guide/configuring-sdk.html#specifying-credentials
                                 properties:
                                   key:
-                                    description: The key of the secret to select from.
-                                      Must be a valid secret key.
+                                    description: The key of the entry in the Secret
+                                      resource's `data` field to be used. Some instances
+                                      of this field may be defaulted, in others it
+                                      may be required.
                                     type: string
                                   name:
-                                    description: 'Name of the referent. More info:
-                                      https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                      TODO: Add other useful fields. apiVersion, kind,
-                                      uid?'
+                                    description: 'Name of the resource being referred
+                                      to. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
                                     type: string
                                 required:
                                 - name
@@ -3687,9 +4511,8 @@ spec:
                             - region
                             type: object
                           webhook:
-                            description: ACMEIssuerDNS01ProviderWebhook specifies
-                              configuration for a webhook DNS01 provider, including
-                              where to POST ChallengePayload resources.
+                            description: Configure an external webhook based DNS01
+                              challenge solver to manage DNS01 challenge records.
                             properties:
                               config:
                                 description: Additional configuration that should
@@ -3718,12 +4541,11 @@ spec:
                             type: object
                         type: object
                       http01:
-                        description: ACMEChallengeSolverHTTP01 contains configuration
-                          detailing how to solve HTTP01 challenges within a Kubernetes
-                          cluster. Typically this is accomplished through creating
-                          'routes' of some description that configure ingress controllers
-                          to direct traffic to 'solver pods', which are responsible
-                          for responding to the ACME server's HTTP requests.
+                        description: Configures cert-manager to attempt to complete
+                          authorizations by performing the HTTP01 challenge flow.
+                          It is not possible to obtain certificates for wildcard domain
+                          names (e.g. `*.example.com`) using the HTTP01 challenge
+                          mechanism.
                         properties:
                           ingress:
                             description: The ingress based HTTP01 challenge solver
@@ -4740,6 +5562,9 @@ spec:
                       selector:
                         description: Selector selects a set of DNSNames on the Certificate
                           resource that should be solved using this challenge solver.
+                          If not specified, the solver will be treated as the 'default'
+                          solver with the lowest priority, i.e. if any other solver
+                          has a more specific match, it will be used instead.
                         properties:
                           dnsNames:
                             description: List of DNSNames that this solver will be
@@ -4780,12 +5605,15 @@ spec:
               - server
               type: object
             ca:
+              description: CA configures this issuer to sign certificates using a
+                signing CA keypair stored in a Secret resource. This is used to build
+                internal PKIs that are managed by cert-manager.
               properties:
                 crlDistributionPoints:
                   description: The CRL distribution points is an X.509 v3 certificate
                     extension which identifies the location of the CRL from which
-                    the revocation of this certificate can be checked. If not set
-                    certificate will be issued without CDP. Values are strings.
+                    the revocation of this certificate can be checked. If not set,
+                    certificates will be issued without distribution points set.
                   items:
                     type: string
                   type: array
@@ -4797,6 +5625,8 @@ spec:
               - secretName
               type: object
             selfSigned:
+              description: SelfSigned configures this issuer to 'self sign' certificates
+                using the private key used to create the CertificateRequest object.
               properties:
                 crlDistributionPoints:
                   description: The CRL distribution points is an X.509 v3 certificate
@@ -4808,28 +5638,41 @@ spec:
                   type: array
               type: object
             vault:
+              description: Vault configures this issuer to sign certificates using
+                a HashiCorp Vault PKI backend.
               properties:
                 auth:
-                  description: Vault authentication
+                  description: Auth configures how cert-manager authenticates with
+                    the Vault server.
                   properties:
                     appRole:
-                      description: This Secret contains a AppRole and Secret
+                      description: AppRole authenticates with Vault using the App
+                        Role auth mechanism, with the role and secret stored in a
+                        Kubernetes Secret resource.
                       properties:
                         path:
-                          description: Where the authentication path is mounted in
-                            Vault.
+                          description: 'Path where the App Role authentication backend
+                            is mounted in Vault, e.g: "approle"'
                           type: string
                         roleId:
+                          description: RoleID configured in the App Role authentication
+                            backend when setting up the authentication backend in
+                            Vault.
                           type: string
                         secretRef:
+                          description: Reference to a key in a Secret that contains
+                            the App Role secret used to authenticate with Vault. The
+                            `key` field must be specified and denotes which entry
+                            within the Secret resource is used as the app role secret.
                           properties:
                             key:
-                              description: The key of the secret to select from. Must
-                                be a valid secret key.
+                              description: The key of the entry in the Secret resource's
+                                `data` field to be used. Some instances of this field
+                                may be defaulted, in others it may be required.
                               type: string
                             name:
-                              description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                TODO: Add other useful fields. apiVersion, kind, uid?'
+                              description: 'Name of the resource being referred to.
+                                More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
                               type: string
                           required:
                           - name
@@ -4840,8 +5683,9 @@ spec:
                       - secretRef
                       type: object
                     kubernetes:
-                      description: This contains a Role and Secret with a ServiceAccount
-                        token to authenticate with vault.
+                      description: Kubernetes authenticates with Vault by passing
+                        the ServiceAccount token stored in the named Secret resource
+                        to the Vault server.
                       properties:
                         mountPath:
                           description: The Vault mountPath here is the mount path
@@ -4861,12 +5705,13 @@ spec:
                             Use of 'ambient credentials' is not supported.
                           properties:
                             key:
-                              description: The key of the secret to select from. Must
-                                be a valid secret key.
+                              description: The key of the entry in the Secret resource's
+                                `data` field to be used. Some instances of this field
+                                may be defaulted, in others it may be required.
                               type: string
                             name:
-                              description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                TODO: Add other useful fields. apiVersion, kind, uid?'
+                              description: 'Name of the resource being referred to.
+                                More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
                               type: string
                           required:
                           - name
@@ -4876,32 +5721,37 @@ spec:
                       - secretRef
                       type: object
                     tokenSecretRef:
-                      description: This Secret contains the Vault token key
+                      description: TokenSecretRef authenticates with Vault by presenting
+                        a token.
                       properties:
                         key:
-                          description: The key of the secret to select from. Must
-                            be a valid secret key.
+                          description: The key of the entry in the Secret resource's
+                            `data` field to be used. Some instances of this field
+                            may be defaulted, in others it may be required.
                           type: string
                         name:
-                          description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                            TODO: Add other useful fields. apiVersion, kind, uid?'
+                          description: 'Name of the resource being referred to. More
+                            info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
                           type: string
                       required:
                       - name
                       type: object
                   type: object
                 caBundle:
-                  description: Base64 encoded CA bundle to validate Vault server certificate.
-                    Only used if the Server URL is using HTTPS protocol. This parameter
-                    is ignored for plain HTTP protocol connection. If not set the
-                    system root certificates are used to validate the TLS connection.
+                  description: PEM encoded CA bundle used to validate Vault server
+                    certificate. Only used if the Server URL is using HTTPS protocol.
+                    This parameter is ignored for plain HTTP protocol connection.
+                    If not set the system root certificates are used to validate the
+                    TLS connection.
                   format: byte
                   type: string
                 path:
-                  description: Vault URL path to the certificate role
+                  description: 'Path is the mount path of the Vault PKI backend''s
+                    `sign` endpoint, e.g: "my_pki_mount/sign/my-role-name".'
                   type: string
                 server:
-                  description: Server is the vault connection address
+                  description: 'Server is the connection address for the Vault server,
+                    e.g: "https://vault.example.com:8200".'
                   type: string
               required:
               - auth
@@ -4909,8 +5759,8 @@ spec:
               - server
               type: object
             venafi:
-              description: VenafiIssuer describes issuer configuration details for
-                Venafi Cloud.
+              description: Venafi configures this issuer to sign certificates using
+                a Venafi TPP or Venafi Cloud policy zone.
               properties:
                 cloud:
                   description: Cloud specifies the Venafi cloud configuration settings.
@@ -4921,18 +5771,20 @@ spec:
                         the Venafi Cloud API token.
                       properties:
                         key:
-                          description: The key of the secret to select from. Must
-                            be a valid secret key.
+                          description: The key of the entry in the Secret resource's
+                            `data` field to be used. Some instances of this field
+                            may be defaulted, in others it may be required.
                           type: string
                         name:
-                          description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                            TODO: Add other useful fields. apiVersion, kind, uid?'
+                          description: 'Name of the resource being referred to. More
+                            info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
                           type: string
                       required:
                       - name
                       type: object
                     url:
-                      description: URL is the base URL for Venafi Cloud
+                      description: URL is the base URL for Venafi Cloud. Defaults
+                        to "https://api.venafi.cloud/v1".
                       type: string
                   required:
                   - apiTokenSecretRef
@@ -4956,14 +5808,15 @@ spec:
                         contain two keys, 'username' and 'password'.
                       properties:
                         name:
-                          description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                            TODO: Add other useful fields. apiVersion, kind, uid?'
+                          description: 'Name of the resource being referred to. More
+                            info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
                           type: string
                       required:
                       - name
                       type: object
                     url:
-                      description: URL is the base URL for the Venafi TPP instance
+                      description: 'URL is the base URL for the vedsdk endpoint of
+                        the Venafi TPP instance, for example: "https://tpp.example.com/vedsdk".'
                       type: string
                   required:
                   - credentialsRef
@@ -4979,9 +5832,11 @@ spec:
               type: object
           type: object
         status:
-          description: IssuerStatus contains status information about an Issuer
+          description: Status of the Issuer. This is set and managed automatically.
           properties:
             acme:
+              description: ACME specific status options. This field should only be
+                set if the Issuer is configured to use an ACME server to issue certificates.
               properties:
                 lastRegisteredEmail:
                   description: LastRegisteredEmail is the email associated with the
@@ -4994,6 +5849,8 @@ spec:
                   type: string
               type: object
             conditions:
+              description: List of status conditions to indicate the status of a CertificateRequest.
+                Known condition types are `Ready`.
               items:
                 description: IssuerCondition contains condition information for an
                   Issuer.
@@ -5020,7 +5877,7 @@ spec:
                     - Unknown
                     type: string
                   type:
-                    description: Type of the condition, currently ('Ready').
+                    description: Type of the condition, known values are ('Ready').
                     type: string
                 required:
                 - status
@@ -5042,7 +5899,6 @@ metadata:
   labels:
     app: 'cert-manager'
     app.kubernetes.io/instance: 'cert-manager'
-    app.kubernetes.io/managed-by: 'Helm'
     app.kubernetes.io/name: 'cert-manager'
   name: orders.acme.cert-manager.io
 spec:
@@ -5094,10 +5950,8 @@ spec:
           properties:
             commonName:
               description: CommonName is the common name as specified on the DER encoded
-                CSR. If CommonName is not specified, the first DNSName specified will
-                be used as the CommonName. At least one of CommonName or a DNSNames
-                must be set. This field must match the corresponding field on the
-                DER encoded CSR.
+                CSR. If specified, this value must also be present in `dnsNames`.
+                This field must match the corresponding field on the DER encoded CSR.
               type: string
             csr:
               description: Certificate signing request bytes in DER encoding. This
@@ -5107,10 +5961,8 @@ spec:
               type: string
             dnsNames:
               description: DNSNames is a list of DNS names that should be included
-                as part of the Order validation process. If CommonName is not specified,
-                the first DNSName specified will be used as the CommonName. At least
-                one of CommonName or a DNSNames must be set. This field must match
-                the corresponding field on the DER encoded CSR.
+                as part of the Order validation process. This field must match the
+                corresponding field on the DER encoded CSR.
               items:
                 type: string
               type: array
@@ -5122,16 +5974,20 @@ spec:
                 failed.
               properties:
                 group:
+                  description: Group of the resource being referred to.
                   type: string
                 kind:
+                  description: Kind of the resource being referred to.
                   type: string
                 name:
+                  description: Name of the resource being referred to.
                   type: string
               required:
               - name
               type: object
           required:
           - csr
+          - dnsNames
           - issuerRef
           type: object
         status:
@@ -5162,7 +6018,10 @@ spec:
                           type: string
                         type:
                           description: Type is the type of challenge being offered,
-                            e.g. http-01, dns-01
+                            e.g. 'http-01', 'dns-01', 'tls-sni-01', etc. This is the
+                            raw value retrieved from the ACME server. Only 'http-01'
+                            and 'dns-01' are supported by cert-manager, other values
+                            will be ignored.
                           type: string
                         url:
                           description: URL is the URL of this challenge. It can be
@@ -5253,596 +6112,6 @@ spec:
           type: object
       required:
       - metadata
-  versions:
-  - name: v1alpha2
-    served: true
-    storage: true
----
-# Source: cert-manager/templates/templates.legacy.out
-apiVersion: apiextensions.k8s.io/v1beta1
-kind: CustomResourceDefinition
-metadata:
-  annotations:
-    cert-manager.io/inject-ca-from-secret: 'cert-manager/cert-manager-webhook-ca'
-  labels:
-    app: 'cert-manager'
-    app.kubernetes.io/instance: 'cert-manager'
-    app.kubernetes.io/managed-by: 'Helm'
-    app.kubernetes.io/name: 'cert-manager'
-  name: certificaterequests.cert-manager.io
-spec:
-  additionalPrinterColumns:
-  - JSONPath: .status.conditions[?(@.type=="Ready")].status
-    name: Ready
-    type: string
-  - JSONPath: .spec.issuerRef.name
-    name: Issuer
-    priority: 1
-    type: string
-  - JSONPath: .status.conditions[?(@.type=="Ready")].message
-    name: Status
-    priority: 1
-    type: string
-  - JSONPath: .metadata.creationTimestamp
-    description: CreationTimestamp is a timestamp representing the server time when
-      this object was created. It is not guaranteed to be set in happens-before order
-      across separate operations. Clients may not set this value. It is represented
-      in RFC3339 form and is in UTC.
-    name: Age
-    type: date
-  group: cert-manager.io
-  names:
-    kind: CertificateRequest
-    listKind: CertificateRequestList
-    plural: certificaterequests
-    shortNames:
-    - cr
-    - crs
-    singular: certificaterequest
-  scope: Namespaced
-  subresources:
-    status: {}
-  validation:
-    openAPIV3Schema:
-      description: CertificateRequest is a type to represent a Certificate Signing
-        Request
-      properties:
-        apiVersion:
-          description: 'APIVersion defines the versioned schema of this representation
-            of an object. Servers should convert recognized schemas to the latest
-            internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
-          type: string
-        kind:
-          description: 'Kind is a string value representing the REST resource this
-            object represents. Servers may infer this from the endpoint the client
-            submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
-          type: string
-        metadata:
-          type: object
-        spec:
-          description: CertificateRequestSpec defines the desired state of CertificateRequest
-          properties:
-            csr:
-              description: Byte slice containing the PEM encoded CertificateSigningRequest
-              format: byte
-              type: string
-            duration:
-              description: Requested certificate default Duration
-              type: string
-            isCA:
-              description: IsCA will mark the resulting certificate as valid for signing.
-                This implies that the 'cert sign' usage is set
-              type: boolean
-            issuerRef:
-              description: IssuerRef is a reference to the issuer for this CertificateRequest.  If
-                the 'kind' field is not set, or set to 'Issuer', an Issuer resource
-                with the given name in the same namespace as the CertificateRequest
-                will be used.  If the 'kind' field is set to 'ClusterIssuer', a ClusterIssuer
-                with the provided name will be used. The 'name' field in this stanza
-                is required at all times. The group field refers to the API group
-                of the issuer which defaults to 'cert-manager.io' if empty.
-              properties:
-                group:
-                  type: string
-                kind:
-                  type: string
-                name:
-                  type: string
-              required:
-              - name
-              type: object
-            usages:
-              description: Usages is the set of x509 actions that are enabled for
-                a given key. Defaults are ('digital signature', 'key encipherment')
-                if empty
-              items:
-                description: 'KeyUsage specifies valid usage contexts for keys. See:
-                  https://tools.ietf.org/html/rfc5280#section-4.2.1.3      https://tools.ietf.org/html/rfc5280#section-4.2.1.12
-                  Valid KeyUsage values are as follows: "signing", "digital signature",
-                  "content commitment", "key encipherment", "key agreement", "data
-                  encipherment", "cert sign", "crl sign", "encipher only", "decipher
-                  only", "any", "server auth", "client auth", "code signing", "email
-                  protection", "s/mime", "ipsec end system", "ipsec tunnel", "ipsec
-                  user", "timestamping", "ocsp signing", "microsoft sgc", "netscape
-                  sgc"'
-                enum:
-                - signing
-                - digital signature
-                - content commitment
-                - key encipherment
-                - key agreement
-                - data encipherment
-                - cert sign
-                - crl sign
-                - encipher only
-                - decipher only
-                - any
-                - server auth
-                - client auth
-                - code signing
-                - email protection
-                - s/mime
-                - ipsec end system
-                - ipsec tunnel
-                - ipsec user
-                - timestamping
-                - ocsp signing
-                - microsoft sgc
-                - netscape sgc
-                type: string
-              type: array
-          required:
-          - csr
-          - issuerRef
-          type: object
-        status:
-          description: CertificateStatus defines the observed state of CertificateRequest
-            and resulting signed certificate.
-          properties:
-            ca:
-              description: Byte slice containing the PEM encoded certificate authority
-                of the signed certificate.
-              format: byte
-              type: string
-            certificate:
-              description: Byte slice containing a PEM encoded signed certificate
-                resulting from the given certificate signing request.
-              format: byte
-              type: string
-            conditions:
-              items:
-                description: CertificateRequestCondition contains condition information
-                  for a CertificateRequest.
-                properties:
-                  lastTransitionTime:
-                    description: LastTransitionTime is the timestamp corresponding
-                      to the last status change of this condition.
-                    format: date-time
-                    type: string
-                  message:
-                    description: Message is a human readable description of the details
-                      of the last transition, complementing reason.
-                    type: string
-                  reason:
-                    description: Reason is a brief machine readable explanation for
-                      the condition's last transition.
-                    type: string
-                  status:
-                    description: Status of the condition, one of ('True', 'False',
-                      'Unknown').
-                    enum:
-                    - "True"
-                    - "False"
-                    - Unknown
-                    type: string
-                  type:
-                    description: Type of the condition, currently ('Ready', 'InvalidRequest').
-                    type: string
-                required:
-                - status
-                - type
-                type: object
-              type: array
-            failureTime:
-              description: FailureTime stores the time that this CertificateRequest
-                failed. This is used to influence garbage collection and back-off.
-              format: date-time
-              type: string
-          type: object
-  versions:
-  - name: v1alpha2
-    served: true
-    storage: true
----
-# Source: cert-manager/templates/templates.legacy.out
-apiVersion: apiextensions.k8s.io/v1beta1
-kind: CustomResourceDefinition
-metadata:
-  annotations:
-    cert-manager.io/inject-ca-from-secret: 'cert-manager/cert-manager-webhook-ca'
-  labels:
-    app: 'cert-manager'
-    app.kubernetes.io/instance: 'cert-manager'
-    app.kubernetes.io/managed-by: 'Helm'
-    app.kubernetes.io/name: 'cert-manager'
-  name: certificates.cert-manager.io
-spec:
-  additionalPrinterColumns:
-  - JSONPath: .status.conditions[?(@.type=="Ready")].status
-    name: Ready
-    type: string
-  - JSONPath: .spec.secretName
-    name: Secret
-    type: string
-  - JSONPath: .spec.issuerRef.name
-    name: Issuer
-    priority: 1
-    type: string
-  - JSONPath: .status.conditions[?(@.type=="Ready")].message
-    name: Status
-    priority: 1
-    type: string
-  - JSONPath: .metadata.creationTimestamp
-    description: CreationTimestamp is a timestamp representing the server time when
-      this object was created. It is not guaranteed to be set in happens-before order
-      across separate operations. Clients may not set this value. It is represented
-      in RFC3339 form and is in UTC.
-    name: Age
-    type: date
-  group: cert-manager.io
-  names:
-    kind: Certificate
-    listKind: CertificateList
-    plural: certificates
-    shortNames:
-    - cert
-    - certs
-    singular: certificate
-  scope: Namespaced
-  subresources:
-    status: {}
-  validation:
-    openAPIV3Schema:
-      description: Certificate is a type to represent a Certificate from ACME
-      properties:
-        apiVersion:
-          description: 'APIVersion defines the versioned schema of this representation
-            of an object. Servers should convert recognized schemas to the latest
-            internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
-          type: string
-        kind:
-          description: 'Kind is a string value representing the REST resource this
-            object represents. Servers may infer this from the endpoint the client
-            submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
-          type: string
-        metadata:
-          type: object
-        spec:
-          description: CertificateSpec defines the desired state of Certificate. A
-            valid Certificate requires at least one of a CommonName, DNSName, or URISAN
-            to be valid.
-          properties:
-            commonName:
-              description: 'CommonName is a common name to be used on the Certificate.
-                The CommonName should have a length of 64 characters or fewer to avoid
-                generating invalid CSRs. This value is ignored by TLS clients when
-                any subject alt name is set. This is x509 behaviour: https://tools.ietf.org/html/rfc6125#section-6.4.4'
-              type: string
-            dnsNames:
-              description: DNSNames is a list of subject alt names to be used on the
-                Certificate.
-              items:
-                type: string
-              type: array
-            duration:
-              description: Certificate default Duration
-              type: string
-            emailSANs:
-              description: EmailSANs is a list of Email Subject Alternative Names
-                to be set on this Certificate.
-              items:
-                type: string
-              type: array
-            ipAddresses:
-              description: IPAddresses is a list of IP addresses to be used on the
-                Certificate
-              items:
-                type: string
-              type: array
-            isCA:
-              description: IsCA will mark this Certificate as valid for signing. This
-                implies that the 'cert sign' usage is set
-              type: boolean
-            issuerRef:
-              description: IssuerRef is a reference to the issuer for this certificate.
-                If the 'kind' field is not set, or set to 'Issuer', an Issuer resource
-                with the given name in the same namespace as the Certificate will
-                be used. If the 'kind' field is set to 'ClusterIssuer', a ClusterIssuer
-                with the provided name will be used. The 'name' field in this stanza
-                is required at all times.
-              properties:
-                group:
-                  type: string
-                kind:
-                  type: string
-                name:
-                  type: string
-              required:
-              - name
-              type: object
-            keyAlgorithm:
-              description: KeyAlgorithm is the private key algorithm of the corresponding
-                private key for this certificate. If provided, allowed values are
-                either "rsa" or "ecdsa" If KeyAlgorithm is specified and KeySize is
-                not provided, key size of 256 will be used for "ecdsa" key algorithm
-                and key size of 2048 will be used for "rsa" key algorithm.
-              enum:
-              - rsa
-              - ecdsa
-              type: string
-            keyEncoding:
-              description: KeyEncoding is the private key cryptography standards (PKCS)
-                for this certificate's private key to be encoded in. If provided,
-                allowed values are "pkcs1" and "pkcs8" standing for PKCS#1 and PKCS#8,
-                respectively. If KeyEncoding is not specified, then PKCS#1 will be
-                used by default.
-              enum:
-              - pkcs1
-              - pkcs8
-              type: string
-            keySize:
-              description: KeySize is the key bit size of the corresponding private
-                key for this certificate. If provided, value must be between 2048
-                and 8192 inclusive when KeyAlgorithm is empty or is set to "rsa",
-                and value must be one of (256, 384, 521) when KeyAlgorithm is set
-                to "ecdsa".
-              maximum: 8192
-              minimum: 0
-              type: integer
-            keystores:
-              description: Keystores configures additional keystore output formats
-                stored in the `secretName` Secret resource.
-              properties:
-                jks:
-                  description: JKS configures options for storing a JKS keystore in
-                    the `spec.secretName` Secret resource.
-                  properties:
-                    create:
-                      description: Create enables JKS keystore creation for the Certificate.
-                        If true, a file named `keystore.jks` will be created in the
-                        target Secret resource, encrypted using the password stored
-                        in `passwordSecretRef`. The keystore file will only be updated
-                        upon re-issuance.
-                      type: boolean
-                    passwordSecretRef:
-                      description: PasswordSecretRef is a reference to a key in a
-                        Secret resource containing the password used to encrypt the
-                        JKS keystore.
-                      properties:
-                        key:
-                          description: The key of the secret to select from. Must
-                            be a valid secret key.
-                          type: string
-                        name:
-                          description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                            TODO: Add other useful fields. apiVersion, kind, uid?'
-                          type: string
-                      required:
-                      - name
-                      type: object
-                  required:
-                  - create
-                  - passwordSecretRef
-                  type: object
-                pkcs12:
-                  description: PKCS12 configures options for storing a PKCS12 keystore
-                    in the `spec.secretName` Secret resource.
-                  properties:
-                    create:
-                      description: Create enables PKCS12 keystore creation for the
-                        Certificate. If true, a file named `keystore.p12` will be
-                        created in the target Secret resource, encrypted using the
-                        password stored in `passwordSecretRef`. The keystore file
-                        will only be updated upon re-issuance.
-                      type: boolean
-                    passwordSecretRef:
-                      description: PasswordSecretRef is a reference to a key in a
-                        Secret resource containing the password used to encrypt the
-                        PKCS12 keystore.
-                      properties:
-                        key:
-                          description: The key of the secret to select from. Must
-                            be a valid secret key.
-                          type: string
-                        name:
-                          description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                            TODO: Add other useful fields. apiVersion, kind, uid?'
-                          type: string
-                      required:
-                      - name
-                      type: object
-                  required:
-                  - create
-                  - passwordSecretRef
-                  type: object
-              type: object
-            organization:
-              description: Organization is the organization to be used on the Certificate
-              items:
-                type: string
-              type: array
-            privateKey:
-              description: Options to control private keys used for the Certificate.
-              properties:
-                rotationPolicy:
-                  description: RotationPolicy controls how private keys should be
-                    regenerated when a re-issuance is being processed. If set to Never,
-                    a private key will only be generated if one does not already exist
-                    in the target `spec.secretName`. If one does exists but it does
-                    not have the correct algorithm or size, a warning will be raised
-                    to await user intervention. If set to Always, a private key matching
-                    the specified requirements will be generated whenever a re-issuance
-                    occurs. Default is 'Never' for backward compatibility.
-                  type: string
-              type: object
-            renewBefore:
-              description: Certificate renew before expiration duration
-              type: string
-            secretName:
-              description: SecretName is the name of the secret resource to store
-                this secret in
-              type: string
-            subject:
-              description: Full X509 name specification (https://golang.org/pkg/crypto/x509/pkix/#Name).
-              properties:
-                countries:
-                  description: Countries to be used on the Certificate.
-                  items:
-                    type: string
-                  type: array
-                localities:
-                  description: Cities to be used on the Certificate.
-                  items:
-                    type: string
-                  type: array
-                organizationalUnits:
-                  description: Organizational Units to be used on the Certificate.
-                  items:
-                    type: string
-                  type: array
-                postalCodes:
-                  description: Postal codes to be used on the Certificate.
-                  items:
-                    type: string
-                  type: array
-                provinces:
-                  description: State/Provinces to be used on the Certificate.
-                  items:
-                    type: string
-                  type: array
-                serialNumber:
-                  description: Serial number to be used on the Certificate.
-                  type: string
-                streetAddresses:
-                  description: Street addresses to be used on the Certificate.
-                  items:
-                    type: string
-                  type: array
-              type: object
-            uriSANs:
-              description: URISANs is a list of URI Subject Alternative Names to be
-                set on this Certificate.
-              items:
-                type: string
-              type: array
-            usages:
-              description: Usages is the set of x509 actions that are enabled for
-                a given key. Defaults are ('digital signature', 'key encipherment')
-                if empty
-              items:
-                description: 'KeyUsage specifies valid usage contexts for keys. See:
-                  https://tools.ietf.org/html/rfc5280#section-4.2.1.3      https://tools.ietf.org/html/rfc5280#section-4.2.1.12
-                  Valid KeyUsage values are as follows: "signing", "digital signature",
-                  "content commitment", "key encipherment", "key agreement", "data
-                  encipherment", "cert sign", "crl sign", "encipher only", "decipher
-                  only", "any", "server auth", "client auth", "code signing", "email
-                  protection", "s/mime", "ipsec end system", "ipsec tunnel", "ipsec
-                  user", "timestamping", "ocsp signing", "microsoft sgc", "netscape
-                  sgc"'
-                enum:
-                - signing
-                - digital signature
-                - content commitment
-                - key encipherment
-                - key agreement
-                - data encipherment
-                - cert sign
-                - crl sign
-                - encipher only
-                - decipher only
-                - any
-                - server auth
-                - client auth
-                - code signing
-                - email protection
-                - s/mime
-                - ipsec end system
-                - ipsec tunnel
-                - ipsec user
-                - timestamping
-                - ocsp signing
-                - microsoft sgc
-                - netscape sgc
-                type: string
-              type: array
-          required:
-          - issuerRef
-          - secretName
-          type: object
-        status:
-          description: CertificateStatus defines the observed state of Certificate
-          properties:
-            conditions:
-              items:
-                description: CertificateCondition contains condition information for
-                  an Certificate.
-                properties:
-                  lastTransitionTime:
-                    description: LastTransitionTime is the timestamp corresponding
-                      to the last status change of this condition.
-                    format: date-time
-                    type: string
-                  message:
-                    description: Message is a human readable description of the details
-                      of the last transition, complementing reason.
-                    type: string
-                  reason:
-                    description: Reason is a brief machine readable explanation for
-                      the condition's last transition.
-                    type: string
-                  status:
-                    description: Status of the condition, one of ('True', 'False',
-                      'Unknown').
-                    enum:
-                    - "True"
-                    - "False"
-                    - Unknown
-                    type: string
-                  type:
-                    description: Type of the condition, currently ('Ready').
-                    type: string
-                required:
-                - status
-                - type
-                type: object
-              type: array
-            lastFailureTime:
-              format: date-time
-              type: string
-            nextPrivateKeySecretName:
-              description: The name of the Secret resource containing the private
-                key to be used for the next certificate iteration. The keymanager
-                controller will automatically set this field if the `Issuing` condition
-                is set to `True`. It will automatically unset this field when the
-                Issuing condition is not set or False.
-              type: string
-            notAfter:
-              description: The expiration time of the certificate stored in the secret
-                named by this resource in spec.secretName.
-              format: date-time
-              type: string
-            revision:
-              description: "The current 'revision' of the certificate as issued. \n
-                When a CertificateRequest resource is created, it will have the `cert-manager.io/certificate-revision`
-                set to one greater than the current value of this field. \n Upon issuance,
-                this field will be set to the value of the annotation on the CertificateRequest
-                resource used to issue the certificate. \n Persisting the value on
-                the CertificateRequest resource allows the certificates controller
-                to know whether a request is part of an old issuance or if it is part
-                of the ongoing revision's issuance by checking if the revision value
-                in the annotation is greater than this field."
-              type: integer
-          type: object
   versions:
   - name: v1alpha2
     served: true

--- a/charts/cert-manager/values.yaml
+++ b/charts/cert-manager/values.yaml
@@ -24,7 +24,7 @@ certManager:
     replicas: 1
     image:
       repository: quay.io/jetstack/cert-manager-controller
-      tag: v0.15.1
+      tag: v0.16.1
       pullPolicy: IfNotPresent
 
     resources:
@@ -54,7 +54,7 @@ certManager:
     replicas: 1
     image:
       repository: quay.io/jetstack/cert-manager-webhook
-      tag: v0.15.1
+      tag: v0.16.1
       pullPolicy: IfNotPresent
 
     resources:
@@ -84,7 +84,7 @@ certManager:
     replicas: 1
     image:
       repository: quay.io/jetstack/cert-manager-cainjector
-      tag: v0.15.1
+      tag: v0.16.1
       pullPolicy: IfNotPresent
 
     resources:

--- a/hack/update-cert-manager-crds.sh
+++ b/hack/update-cert-manager-crds.sh
@@ -34,5 +34,6 @@ echo "" >> $file
 set -x
 curl -sLo - $source >> $file
 
-# remove misleading label
+# remove misleading labels
 yq delete -i -d'*' $file 'metadata.labels."helm.sh/chart"'
+yq delete -i -d'*' $file 'metadata.labels."app.kubernetes.io/managed-by"'


### PR DESCRIPTION
**What this PR does / why we need it**:
This release brings lots of improvements all around and a new API version (`v1beta1`). We continue to use v1alpha2 however, as we're using the legacy CRDs for Kubernetes compatibility. With the upcoming release of cert-manager 1.0 we can maybe switch to v1beta1.

**Documentation**:
https://github.com/kubermatic/docs/pull/431

**Does this PR introduce a user-facing change?**:
```release-note
Update cert-manager to 0.16.1
```
