### PR TITLE
Migrate from Keycloak-Gatekeeper to OAuth2-Proxy

### DIFF
--- a/charts/iap/Chart.yaml
+++ b/charts/iap/Chart.yaml
@@ -14,14 +14,14 @@
 
 apiVersion: v1
 name: iap
-version: 1.2.3
-appVersion: 7.0.0
-description: A Helm to install Keycloak-Gatekeeper as an identity-aware proxy.
+version: 2.0.0
+appVersion: v6.0.0
+description: A Helm chart to install OAuth2-Proxy as an identity-aware proxy.
 keywords:
 - kubermatic
-- keycloak-gatekeeper
+- oauth2-proxy
 - iap
-home: https://github.com/keycloak/keycloak-gatekeeper
+home: https://github.com/oauth2-proxy/oauth2-proxy
 maintainers:
 - name: Loodse GmbH
   email: support@kubermatic.com

--- a/charts/iap/templates/configmaps.yaml
+++ b/charts/iap/templates/configmaps.yaml
@@ -21,6 +21,6 @@ metadata:
 data:
   config.yaml: |
 {{- with .config }}
-{{ toYaml . | indent 4 }}
+{{ toToml . | indent 4 }}
 {{ end }}
 {{ end }}

--- a/charts/iap/templates/deployments.yaml
+++ b/charts/iap/templates/deployments.yaml
@@ -90,7 +90,7 @@ spec:
       nodeSelector:
 {{ toYaml $.Values.iap.nodeSelector | indent 8 }}
       affinity:
-{{ (tpl (toYaml $.Values.iap.affinity) (merge $ .)) | fromYaml | toYaml | indent 8 }}
+{{ (tpl (toYaml $.Values.iap.affinity) (merge (deepCopy $) .)) | fromYaml | toYaml | indent 8 }}
       tolerations:
 {{ toYaml $.Values.iap.tolerations | indent 8 }}
 {{ end }}

--- a/charts/iap/templates/deployments.yaml
+++ b/charts/iap/templates/deployments.yaml
@@ -37,13 +37,20 @@ spec:
         checksum/secrets: {{ include (print $.Template.BasePath "/secrets.yaml") $ | sha256sum }}
     spec:
       containers:
-      - name: keycloak-gatekeeper
+      - name: oauth2-proxy
         image: "{{ $.Values.iap.image.repository }}:{{ $.Values.iap.image.tag }}"
         imagePullPolicy: {{ $.Values.iap.image.pullPolicy }}
         args:
-        - --discovery-url={{ $.Values.iap.discovery_url }}
-        - --listen=0.0.0.0:{{ $.Values.iap.port }}
-        - --upstream-url=http://{{ .upstream_service }}:{{ .upstream_port }}
+        - --provider=oidc
+        - --oidc-issuer-url={{ $.Values.iap.oidc_issuer_url }}
+        - --http-address=0.0.0.0:{{ $.Values.iap.port }}
+        - --upstream=http://{{ .upstream_service }}:{{ .upstream_port }}
+        - --cookie-name={{ .name }}_oauth2_proxy
+        - --proxy-prefix=/oauth
+        - --ping-path=/oauth/healthy
+        - --silence-ping-logging=true
+        - --reverse-proxy=true
+        - --skip-provider-button=true
         - --config=/config/config.yaml
         envFrom:
         - secretRef:
@@ -54,13 +61,13 @@ spec:
           protocol: TCP
         livenessProbe:
           httpGet:
-            path: /oauth/health
+            path: /oauth/healthy
             port: http
           initialDelaySeconds: 3
           timeoutSeconds: 2
         readinessProbe:
           httpGet:
-            path: /oauth/health
+            path: /oauth/healthy
             port: http
           initialDelaySeconds: 3
           timeoutSeconds: 2

--- a/charts/iap/templates/ingresses.yaml
+++ b/charts/iap/templates/ingresses.yaml
@@ -38,14 +38,6 @@ spec:
   - host: {{ .ingress.host | trim }}
     http:
       paths:
-      {{- $name := .name }}
-      {{- $upstream_port := .upstream_port }}
-      {{- range .passthrough }}
-      - path: "{{ . }}"
-        backend:
-          serviceName: {{ $name }}-upstream
-          servicePort: {{ $upstream_port }}
-      {{- end }}
       - path: "/"
         backend:
           serviceName: {{ .name }}-iap

--- a/charts/iap/templates/secrets.yaml
+++ b/charts/iap/templates/secrets.yaml
@@ -20,7 +20,7 @@ metadata:
   name: iap-{{ .name }}-secret
 type: Opaque
 data:
-  PROXY_CLIENT_ID: {{ .client_id | b64enc }}
-  PROXY_CLIENT_SECRET: {{ .client_secret | b64enc }}
-  PROXY_ENCRYPTION_KEY: {{ .encryption_key | b64enc }}
+  OAUTH2_PROXY_CLIENT_ID: {{ .client_id | b64enc }}
+  OAUTH2_PROXY_CLIENT_SECRET: {{ .client_secret | b64enc }}
+  OAUTH2_PROXY_COOKIE_SECRET: {{ .encryption_key | b64enc }}
 {{ end }}

--- a/charts/iap/values.yaml
+++ b/charts/iap/values.yaml
@@ -13,6 +13,14 @@
 # limitations under the License.
 
 iap:
+  image:
+    repository: quay.io/oauth2-proxy/oauth2-proxy
+    tag: v6.0.0
+    pullPolicy: IfNotPresent
+
+  oidc_issuer_url: https://kubermatic.tld/dex
+  port: 3000
+
   # replicas per deployment; you can set this explicitly per deployment
   # to override this
   replicas: 2
@@ -20,87 +28,85 @@ iap:
   deployments:
     # alertmanager:
     #   name: alertmanager
-    #   replicas: 2 #
+    #   replicas: 3
     #   client_id: alertmanager
     #   client_secret: xxx
     #   encryption_key: xxx
-    #   config: ## see https://www.keycloak.org/docs/latest/securing_apps/index.html#example-usage-and-configuration
-    #   ## example configuration allowing access only to the mygroup from mygithuborg organization
-    #     scopes:
-    #     - "groups"
-    #     resources:
-    #     - uri: "/*"
-    #       groups:
-    #       - "mygithuborg:mygroup"
+    #   config: ## see https://github.com/oauth2-proxy/oauth2-proxy/blob/master/docs/configuration/configuration.md
+    #     scope: "groups openid email"
+    #     email_domains:
+    #       - '*'
+    #     ## example configuration allowing access only to the mygroup from mygithuborg organization
+    #     github_org: mygithuborg
+    #     github_team: mygroup
+    #     ## do not route health endpoint through the proxy
+    #     skip_auth_regex:
+    #       - '/-/healthy'
     #   upstream_service: alertmanager.monitoring.svc.cluster.local
     #   upstream_port: 9093
     #   ingress:
     #     host: "alertmanager.kubermatic.tld"
-    #     annotations: {}
-    #   # List of URL prefixes for which nginx should be configured to route requests
-    #   # directly to the upstream service instead of to the Keycloak Proxy;
-    #   # this can be useful for health check which should not generate load on the
-    #   # identity aware proxy (Dex for example creates AuthRequest CRDs for each
-    #   # opened session).
-    #   # Be careful to not accidentally expose a health endpoint that in case of errors
-    #   # or bad configuration can respond with confidential data (error messages,
-    #   # stack traces, configuration, ...).
-    #   passthrough:
-    #   - /-/healthy # exposes nothing
+    #     annotations: {}1
+    #
     # grafana:
     #   name: grafana
     #   client_id: grafana
     #   client_secret: xxx
     #   encryption_key: xxx
-    #   config: ## see https://www.keycloak.org/docs/latest/securing_apps/index.html#example-usage-and-configuration
-    #     enable-authorization-header: false
+    #   config: ## see https://github.com/oauth2-proxy/oauth2-proxy/blob/master/docs/configuration/configuration.md
+    #     scope: "groups openid email"
+    #     email_domains:
+    #       - '*'
+    #     ## do not route health endpoint through the proxy
+    #     skip_auth_regex:
+    #       - '/api/health'
     #   upstream_service: grafana.monitoring.svc.cluster.local
     #   upstream_port: 3000
     #   ingress:
     #     host: "grafana.kubermatic.tld"
     #     annotations: {}
-    #   passthrough:
-    #   - /api/health # exposes Grafana version and Git hash
+    #
     # kibana:
     #   name: kibana
     #   client_id: kibana
     #   client_secret: xxx
     #   encryption_key: xxx
-    #   config: {} ## see https://www.keycloak.org/docs/latest/securing_apps/index.html#example-usage-and-configuration
+    #   config: ## see https://github.com/oauth2-proxy/oauth2-proxy/blob/master/docs/configuration/configuration.md
+    #     scope: "groups openid email"
+    #     email_domains:
+    #       - '*'
+    #     ## do not route health endpoint through the proxy
+    #     skip_auth_regex:
+    #       - '/ui/favicons/favicon.ico'
     #   upstream_service: kibana.logging.svc.cluster.local
     #   upstream_port: 5601
     #   ingress:
     #     host: "kibana.kubermatic.tld"
     #     annotations: {}
-    #   passthrough:
-    #   - /ui/favicons/favicon.ico # exposes nothing
+    #
     # prometheus:
     #   name: prometheus
     #   client_id: prometheus
     #   client_secret: xxx
     #   encryption_key: xxx
-    #   config: {} ## see https://www.keycloak.org/docs/latest/securing_apps/index.html#example-usage-and-configuration
+    #   config: ## see https://github.com/oauth2-proxy/oauth2-proxy/blob/master/docs/configuration/configuration.md
+    #     scope: "groups openid email"
+    #     email_domains:
+    #       - '*'
+    #     ## do not route health endpoint through the proxy
+    #     skip_auth_regex:
+    #       - '/-/healthy'
     #   upstream_service: prometheus.monitoring.svc.cluster.local
     #   upstream_port: 9090
     #   ingress:
     #     host: "prometheus.kubermatic.tld"
     #     annotations:
     #       ingress.kubernetes.io/upstream-hash-by: "ip_hash" ## needed for prometheus federations
-    #   passthrough:
-    #   - /-/healthy # exposes nothing
 
   # the cert-manager Issuer (or ClusterIssuer) responsible for managing the certificates
   certIssuer:
     name: letsencrypt-prod
     kind: ClusterIssuer
-
-  discovery_url: https://kubermatic.tld/dex/.well-known/openid-configuration
-  port: 3000
-
-  image:
-    repository: docker.io/keycloak/keycloak-gatekeeper
-    tag: 7.0.0
-    pullPolicy: IfNotPresent
 
   resources:
     requests:

--- a/charts/iap/values.yaml
+++ b/charts/iap/values.yaml
@@ -60,6 +60,9 @@ iap:
     #     ## do not route health endpoint through the proxy
     #     skip_auth_regex:
     #       - '/api/health'
+    #     ## auto-register users based on their email address
+    #     ## Grafana is configured to look for the X-Forwarded-Email header
+    #     pass_user_headers: true
     #   upstream_service: grafana.monitoring.svc.cluster.local
     #   upstream_port: 3000
     #   ingress:

--- a/charts/monitoring/grafana/Chart.yaml
+++ b/charts/monitoring/grafana/Chart.yaml
@@ -14,7 +14,7 @@
 
 apiVersion: v1
 name: grafana
-version: 1.4.4
+version: 1.4.5
 appVersion: 7.0.3
 description: Grafana for Kubermatic
 keywords:

--- a/charts/monitoring/grafana/config/grafana.ini
+++ b/charts/monitoring/grafana/config/grafana.ini
@@ -10,7 +10,7 @@ enabled = false
 
 [auth.proxy]
 enabled = true
-header_name = X-Auth-Username
+header_name = X-Forwarded-Email
 header_property = username
 auto_sign_up = true
 


### PR DESCRIPTION
**What this PR does / why we need it**:
Keycloak-Gatekeeper has been moved to https://github.com/louketo/louketo-proxy, which was then shortly thereafter also [declared dead](https://github.com/louketo/louketo-proxy/issues/683) and users are advised to migrate to https://github.com/oauth2-proxy/oauth2-proxy -- this PR accomplishes that.

Most of the configuration options are compatible, but with different names, so a manual migration step is absolutely required.

**Documentation**:
https://github.com/kubermatic/docs/pull/432

**Does this PR introduce a user-facing change?**:
```release-note
Replaced deprecated Keycloak-Gatekeeper with OAuth2-Proxy
```
