### PR TITLE
Fallback to in-tree cloud provider for OTC

### DIFF
--- a/pkg/handler/common/cluster.go
+++ b/pkg/handler/common/cluster.go
@@ -164,7 +164,7 @@ func CreateEndpoint(ctx context.Context, projectID string, body apiv1.CreateClus
 	// generate the name here so that it can be used in the secretName below
 	partialCluster.Name = rand.String(10)
 
-	if cloudcontroller.ExternalCloudControllerFeatureSupported(partialCluster) {
+	if cloudcontroller.ExternalCloudControllerFeatureSupported(dc, partialCluster) {
 		partialCluster.Spec.Features = map[string]bool{kubermaticv1.ClusterFeatureExternalCloudProvider: true}
 	}
 

--- a/pkg/resources/cloudcontroller/openstack.go
+++ b/pkg/resources/cloudcontroller/openstack.go
@@ -18,6 +18,7 @@ package cloudcontroller
 
 import (
 	"fmt"
+	"net/url"
 
 	kubermaticv1 "k8c.io/kubermatic/v2/pkg/crd/kubermatic/v1"
 	"k8c.io/kubermatic/v2/pkg/resources"
@@ -183,11 +184,36 @@ func getOSVersion(version semver.Semver) (string, error) {
 }
 
 // ExternalCloudControllerFeatureSupported checks if the
-func ExternalCloudControllerFeatureSupported(cluster *kubermaticv1.Cluster) bool {
+func ExternalCloudControllerFeatureSupported(dc *kubermaticv1.Datacenter, cluster *kubermaticv1.Cluster) bool {
 	if cluster.Spec.Cloud.Openstack == nil {
 		return false
 	}
+	// When using OpenStack external CCM with Open Telekom Cloud the creation
+	// of LBs fail as documented in the issue below:
+	// https://github.com/kubernetes/cloud-provider-openstack/issues/960
+	// Falling back to the in-tree CloudProvider mitigates the problem, even if
+	// not all features are expected to work properly (e.g.
+	// `manage-security-groups` should be set to false in cloud config, see
+	// https://kubernetes.io/docs/concepts/cluster-administration/cloud-providers/#load-balancer
+	// for more details).
+	//
+	// TODO(irozzo) This is a dirty hack to temporarily support OTC using
+	// Openstack provider, remove this when dedicated OTC support is
+	// introduced in Kubermatic.
+	if dc.Spec.Openstack != nil && isOTC(dc.Spec.Openstack) {
+		return false
+	}
 	return OpenStackCloudControllerSupported(cluster.Spec.Version)
+}
+
+// isOTC returns `true` if the OpenStack Datacenter uses OTC (i.e.
+// Open Telekom Cloud), `false` otherwise.
+func isOTC(dc *kubermaticv1.DatacenterSpecOpenstack) bool {
+	u, err := url.Parse(dc.AuthURL)
+	if err != nil {
+		return false
+	}
+	return u.Host == "iam.eu-de.otc.t-systems.com"
 }
 
 // OpenStackCloudControllerSupported checks if this version of Kubernetes is supported

--- a/pkg/resources/cloudcontroller/openstack_test.go
+++ b/pkg/resources/cloudcontroller/openstack_test.go
@@ -1,0 +1,69 @@
+/*
+Copyright 2020 The Kubermatic Kubernetes Platform contributors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package cloudcontroller
+
+import (
+	"testing"
+
+	kubermaticv1 "k8c.io/kubermatic/v2/pkg/crd/kubermatic/v1"
+)
+
+func TestIsOTC(t *testing.T) {
+	tests := []struct {
+		name    string
+		authURL string
+		want    bool
+	}{
+		{
+			name:    "Nominal",
+			authURL: "https://iam.eu-de.otc.t-systems.com/v3",
+			want:    true,
+		},
+		{
+			name:    "Same host",
+			authURL: "http://iam.eu-de.otc.t-systems.com/v2.0",
+			want:    true,
+		},
+		{
+			name:    "Trailing slash",
+			authURL: "https://iam.eu-de.otc.t-systems.com/v3/",
+			want:    true,
+		},
+		{
+			name:    "Same host",
+			authURL: "https://iam.eu-de.otc.t-systems.com:5000/v3",
+			want:    false,
+		},
+		{
+			name:    "IP",
+			authURL: "http://192.168.2.1:5000/v2.0",
+			want:    false,
+		},
+		{
+			name:    "Other provider",
+			authURL: "http://identity.provider.org/v3",
+			want:    false,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := isOTC(&kubermaticv1.DatacenterSpecOpenstack{AuthURL: tt.authURL}); got != tt.want {
+				t.Errorf("isOTC() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
**What this PR does / why we need it**:
When using OpenStack provider with Open Telekom Cloud we have to fallback to the in-tree cloud provider, otherwise services of type LoadBalancer do not work properly due to:

https://github.com/kubernetes/cloud-provider-openstack/issues/960

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:
This is a temporary solution and should be removed when/if OTC will have a dedicated K8C provider.

**Documentation**:
<!-- Add links to the related documentation changes related to this pull request. E.g. the link to the kubermatic/docs pullrequest. -->

**Does this PR introduce a user-facing change?**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If  no release note is required, just write "NONE".
-->
```release-note
Fallback to in-tree cloud provider when OpenStack provider is used with Open Telekom Cloud
```
