### PR TITLE
Update Loki to 1.6.1

### DIFF
--- a/charts/logging/loki/Chart.yaml
+++ b/charts/logging/loki/Chart.yaml
@@ -14,8 +14,8 @@
 
 apiVersion: "v1"
 name: loki
-version: 0.0.9
-appVersion: v1.5.0
+version: 0.0.10
+appVersion: v1.6.1
 description: "Loki: like Prometheus, but for logs."
 keywords:
 - kubermatic

--- a/charts/logging/loki/values.yaml
+++ b/charts/logging/loki/values.yaml
@@ -68,7 +68,7 @@ loki:
 
   image:
     repository: docker.io/grafana/loki
-    tag: 1.5.0
+    tag: 1.6.1
     pullPolicy: IfNotPresent
 
   ## The app name of loki clients

--- a/charts/logging/promtail/Chart.yaml
+++ b/charts/logging/promtail/Chart.yaml
@@ -14,8 +14,8 @@
 
 apiVersion: "v1"
 name: promtail
-version: 0.1.5
-appVersion: v1.5.0
+version: 0.1.6
+appVersion: v1.6.1
 description: "Responsible for gathering logs and sending them to Loki"
 keywords:
 - kubermatic

--- a/charts/logging/promtail/values.yaml
+++ b/charts/logging/promtail/values.yaml
@@ -17,7 +17,7 @@ promtail:
 
   image:
     repository: docker.io/grafana/promtail
-    tag: 1.5.0
+    tag: 1.6.1
     pullPolicy: IfNotPresent
 
   loki:


### PR DESCRIPTION
**What this PR does / why we need it**:
Lots of improvements all around and we're (from looking at testing on dev) are not affected by the few manual upgrade steps between 1.5 and 1.6.

**Does this PR introduce a user-facing change?**:
```release-note
Update Grafan Loki to 1.6.1
```
