### PR TITLE
Update Prometheus to 2.20.1

### DIFF
--- a/charts/monitoring/prometheus/Chart.yaml
+++ b/charts/monitoring/prometheus/Chart.yaml
@@ -14,8 +14,8 @@
 
 apiVersion: v1
 name: prometheus
-version: 2.2.26
-appVersion: v2.19.2
+version: 2.2.27
+appVersion: v2.20.1
 description: Prometheus Monitoring for Kubernetes
 keywords:
 - kubermatic

--- a/charts/monitoring/prometheus/values.yaml
+++ b/charts/monitoring/prometheus/values.yaml
@@ -15,7 +15,7 @@
 prometheus:
   image:
     repository: quay.io/prometheus/prometheus
-    tag: v2.19.2
+    tag: v2.20.1
     pullPolicy: IfNotPresent
 
   host: ''
@@ -24,11 +24,7 @@ prometheus:
 
   tsdb:
     retentionTime: 15d
-
-    # This is not yet considered a truly stable
-    # feature by the Prometheus developers, see
-    # https://github.com/prometheus/tsdb/pull/609
-    compressWAL: false
+    compressWAL: true
 
   configReloaderImage:
     repository: docker.io/jimmidyson/configmap-reload

--- a/pkg/resources/prometheus/statefulset.go
+++ b/pkg/resources/prometheus/statefulset.go
@@ -31,7 +31,7 @@ import (
 
 const (
 	name = "prometheus"
-	tag  = "v2.19.2"
+	tag  = "v2.20.1"
 
 	volumeConfigName = "config"
 	volumeDataName   = "data"

--- a/pkg/resources/test/fixtures/statefulset-aws-1.15.0-prometheus.yaml
+++ b/pkg/resources/test/fixtures/statefulset-aws-1.15.0-prometheus.yaml
@@ -40,7 +40,7 @@ spec:
         - --web.enable-lifecycle
         - --storage.tsdb.no-lockfile
         - --web.route-prefix=/
-        image: quay.io/prometheus/prometheus:v2.19.2
+        image: quay.io/prometheus/prometheus:v2.20.1
         livenessProbe:
           failureThreshold: 10
           httpGet:

--- a/pkg/resources/test/fixtures/statefulset-aws-1.16.0-prometheus.yaml
+++ b/pkg/resources/test/fixtures/statefulset-aws-1.16.0-prometheus.yaml
@@ -40,7 +40,7 @@ spec:
         - --web.enable-lifecycle
         - --storage.tsdb.no-lockfile
         - --web.route-prefix=/
-        image: quay.io/prometheus/prometheus:v2.19.2
+        image: quay.io/prometheus/prometheus:v2.20.1
         livenessProbe:
           failureThreshold: 10
           httpGet:

--- a/pkg/resources/test/fixtures/statefulset-aws-1.17.0-prometheus.yaml
+++ b/pkg/resources/test/fixtures/statefulset-aws-1.17.0-prometheus.yaml
@@ -40,7 +40,7 @@ spec:
         - --web.enable-lifecycle
         - --storage.tsdb.no-lockfile
         - --web.route-prefix=/
-        image: quay.io/prometheus/prometheus:v2.19.2
+        image: quay.io/prometheus/prometheus:v2.20.1
         livenessProbe:
           failureThreshold: 10
           httpGet:

--- a/pkg/resources/test/fixtures/statefulset-aws-1.18.0-prometheus.yaml
+++ b/pkg/resources/test/fixtures/statefulset-aws-1.18.0-prometheus.yaml
@@ -40,7 +40,7 @@ spec:
         - --web.enable-lifecycle
         - --storage.tsdb.no-lockfile
         - --web.route-prefix=/
-        image: quay.io/prometheus/prometheus:v2.19.2
+        image: quay.io/prometheus/prometheus:v2.20.1
         livenessProbe:
           failureThreshold: 10
           httpGet:

--- a/pkg/resources/test/fixtures/statefulset-azure-1.15.0-prometheus.yaml
+++ b/pkg/resources/test/fixtures/statefulset-azure-1.15.0-prometheus.yaml
@@ -40,7 +40,7 @@ spec:
         - --web.enable-lifecycle
         - --storage.tsdb.no-lockfile
         - --web.route-prefix=/
-        image: quay.io/prometheus/prometheus:v2.19.2
+        image: quay.io/prometheus/prometheus:v2.20.1
         livenessProbe:
           failureThreshold: 10
           httpGet:

--- a/pkg/resources/test/fixtures/statefulset-azure-1.16.0-prometheus.yaml
+++ b/pkg/resources/test/fixtures/statefulset-azure-1.16.0-prometheus.yaml
@@ -40,7 +40,7 @@ spec:
         - --web.enable-lifecycle
         - --storage.tsdb.no-lockfile
         - --web.route-prefix=/
-        image: quay.io/prometheus/prometheus:v2.19.2
+        image: quay.io/prometheus/prometheus:v2.20.1
         livenessProbe:
           failureThreshold: 10
           httpGet:

--- a/pkg/resources/test/fixtures/statefulset-azure-1.17.0-prometheus.yaml
+++ b/pkg/resources/test/fixtures/statefulset-azure-1.17.0-prometheus.yaml
@@ -40,7 +40,7 @@ spec:
         - --web.enable-lifecycle
         - --storage.tsdb.no-lockfile
         - --web.route-prefix=/
-        image: quay.io/prometheus/prometheus:v2.19.2
+        image: quay.io/prometheus/prometheus:v2.20.1
         livenessProbe:
           failureThreshold: 10
           httpGet:

--- a/pkg/resources/test/fixtures/statefulset-azure-1.18.0-prometheus.yaml
+++ b/pkg/resources/test/fixtures/statefulset-azure-1.18.0-prometheus.yaml
@@ -40,7 +40,7 @@ spec:
         - --web.enable-lifecycle
         - --storage.tsdb.no-lockfile
         - --web.route-prefix=/
-        image: quay.io/prometheus/prometheus:v2.19.2
+        image: quay.io/prometheus/prometheus:v2.20.1
         livenessProbe:
           failureThreshold: 10
           httpGet:

--- a/pkg/resources/test/fixtures/statefulset-bringyourown-1.15.0-prometheus.yaml
+++ b/pkg/resources/test/fixtures/statefulset-bringyourown-1.15.0-prometheus.yaml
@@ -40,7 +40,7 @@ spec:
         - --web.enable-lifecycle
         - --storage.tsdb.no-lockfile
         - --web.route-prefix=/
-        image: quay.io/prometheus/prometheus:v2.19.2
+        image: quay.io/prometheus/prometheus:v2.20.1
         livenessProbe:
           failureThreshold: 10
           httpGet:

--- a/pkg/resources/test/fixtures/statefulset-bringyourown-1.16.0-prometheus.yaml
+++ b/pkg/resources/test/fixtures/statefulset-bringyourown-1.16.0-prometheus.yaml
@@ -40,7 +40,7 @@ spec:
         - --web.enable-lifecycle
         - --storage.tsdb.no-lockfile
         - --web.route-prefix=/
-        image: quay.io/prometheus/prometheus:v2.19.2
+        image: quay.io/prometheus/prometheus:v2.20.1
         livenessProbe:
           failureThreshold: 10
           httpGet:

--- a/pkg/resources/test/fixtures/statefulset-bringyourown-1.17.0-prometheus.yaml
+++ b/pkg/resources/test/fixtures/statefulset-bringyourown-1.17.0-prometheus.yaml
@@ -40,7 +40,7 @@ spec:
         - --web.enable-lifecycle
         - --storage.tsdb.no-lockfile
         - --web.route-prefix=/
-        image: quay.io/prometheus/prometheus:v2.19.2
+        image: quay.io/prometheus/prometheus:v2.20.1
         livenessProbe:
           failureThreshold: 10
           httpGet:

--- a/pkg/resources/test/fixtures/statefulset-bringyourown-1.18.0-prometheus.yaml
+++ b/pkg/resources/test/fixtures/statefulset-bringyourown-1.18.0-prometheus.yaml
@@ -40,7 +40,7 @@ spec:
         - --web.enable-lifecycle
         - --storage.tsdb.no-lockfile
         - --web.route-prefix=/
-        image: quay.io/prometheus/prometheus:v2.19.2
+        image: quay.io/prometheus/prometheus:v2.20.1
         livenessProbe:
           failureThreshold: 10
           httpGet:

--- a/pkg/resources/test/fixtures/statefulset-digitalocean-1.15.0-prometheus.yaml
+++ b/pkg/resources/test/fixtures/statefulset-digitalocean-1.15.0-prometheus.yaml
@@ -40,7 +40,7 @@ spec:
         - --web.enable-lifecycle
         - --storage.tsdb.no-lockfile
         - --web.route-prefix=/
-        image: quay.io/prometheus/prometheus:v2.19.2
+        image: quay.io/prometheus/prometheus:v2.20.1
         livenessProbe:
           failureThreshold: 10
           httpGet:

--- a/pkg/resources/test/fixtures/statefulset-digitalocean-1.16.0-prometheus.yaml
+++ b/pkg/resources/test/fixtures/statefulset-digitalocean-1.16.0-prometheus.yaml
@@ -40,7 +40,7 @@ spec:
         - --web.enable-lifecycle
         - --storage.tsdb.no-lockfile
         - --web.route-prefix=/
-        image: quay.io/prometheus/prometheus:v2.19.2
+        image: quay.io/prometheus/prometheus:v2.20.1
         livenessProbe:
           failureThreshold: 10
           httpGet:

--- a/pkg/resources/test/fixtures/statefulset-digitalocean-1.17.0-prometheus.yaml
+++ b/pkg/resources/test/fixtures/statefulset-digitalocean-1.17.0-prometheus.yaml
@@ -40,7 +40,7 @@ spec:
         - --web.enable-lifecycle
         - --storage.tsdb.no-lockfile
         - --web.route-prefix=/
-        image: quay.io/prometheus/prometheus:v2.19.2
+        image: quay.io/prometheus/prometheus:v2.20.1
         livenessProbe:
           failureThreshold: 10
           httpGet:

--- a/pkg/resources/test/fixtures/statefulset-digitalocean-1.18.0-prometheus.yaml
+++ b/pkg/resources/test/fixtures/statefulset-digitalocean-1.18.0-prometheus.yaml
@@ -40,7 +40,7 @@ spec:
         - --web.enable-lifecycle
         - --storage.tsdb.no-lockfile
         - --web.route-prefix=/
-        image: quay.io/prometheus/prometheus:v2.19.2
+        image: quay.io/prometheus/prometheus:v2.20.1
         livenessProbe:
           failureThreshold: 10
           httpGet:

--- a/pkg/resources/test/fixtures/statefulset-openstack-1.15.0-prometheus.yaml
+++ b/pkg/resources/test/fixtures/statefulset-openstack-1.15.0-prometheus.yaml
@@ -40,7 +40,7 @@ spec:
         - --web.enable-lifecycle
         - --storage.tsdb.no-lockfile
         - --web.route-prefix=/
-        image: quay.io/prometheus/prometheus:v2.19.2
+        image: quay.io/prometheus/prometheus:v2.20.1
         livenessProbe:
           failureThreshold: 10
           httpGet:

--- a/pkg/resources/test/fixtures/statefulset-openstack-1.16.0-prometheus.yaml
+++ b/pkg/resources/test/fixtures/statefulset-openstack-1.16.0-prometheus.yaml
@@ -40,7 +40,7 @@ spec:
         - --web.enable-lifecycle
         - --storage.tsdb.no-lockfile
         - --web.route-prefix=/
-        image: quay.io/prometheus/prometheus:v2.19.2
+        image: quay.io/prometheus/prometheus:v2.20.1
         livenessProbe:
           failureThreshold: 10
           httpGet:

--- a/pkg/resources/test/fixtures/statefulset-openstack-1.17.0-prometheus.yaml
+++ b/pkg/resources/test/fixtures/statefulset-openstack-1.17.0-prometheus.yaml
@@ -40,7 +40,7 @@ spec:
         - --web.enable-lifecycle
         - --storage.tsdb.no-lockfile
         - --web.route-prefix=/
-        image: quay.io/prometheus/prometheus:v2.19.2
+        image: quay.io/prometheus/prometheus:v2.20.1
         livenessProbe:
           failureThreshold: 10
           httpGet:

--- a/pkg/resources/test/fixtures/statefulset-openstack-1.18.0-prometheus.yaml
+++ b/pkg/resources/test/fixtures/statefulset-openstack-1.18.0-prometheus.yaml
@@ -40,7 +40,7 @@ spec:
         - --web.enable-lifecycle
         - --storage.tsdb.no-lockfile
         - --web.route-prefix=/
-        image: quay.io/prometheus/prometheus:v2.19.2
+        image: quay.io/prometheus/prometheus:v2.20.1
         livenessProbe:
           failureThreshold: 10
           httpGet:

--- a/pkg/resources/test/fixtures/statefulset-vsphere-1.15.0-prometheus.yaml
+++ b/pkg/resources/test/fixtures/statefulset-vsphere-1.15.0-prometheus.yaml
@@ -40,7 +40,7 @@ spec:
         - --web.enable-lifecycle
         - --storage.tsdb.no-lockfile
         - --web.route-prefix=/
-        image: quay.io/prometheus/prometheus:v2.19.2
+        image: quay.io/prometheus/prometheus:v2.20.1
         livenessProbe:
           failureThreshold: 10
           httpGet:

--- a/pkg/resources/test/fixtures/statefulset-vsphere-1.16.0-prometheus.yaml
+++ b/pkg/resources/test/fixtures/statefulset-vsphere-1.16.0-prometheus.yaml
@@ -40,7 +40,7 @@ spec:
         - --web.enable-lifecycle
         - --storage.tsdb.no-lockfile
         - --web.route-prefix=/
-        image: quay.io/prometheus/prometheus:v2.19.2
+        image: quay.io/prometheus/prometheus:v2.20.1
         livenessProbe:
           failureThreshold: 10
           httpGet:

--- a/pkg/resources/test/fixtures/statefulset-vsphere-1.17.0-prometheus.yaml
+++ b/pkg/resources/test/fixtures/statefulset-vsphere-1.17.0-prometheus.yaml
@@ -40,7 +40,7 @@ spec:
         - --web.enable-lifecycle
         - --storage.tsdb.no-lockfile
         - --web.route-prefix=/
-        image: quay.io/prometheus/prometheus:v2.19.2
+        image: quay.io/prometheus/prometheus:v2.20.1
         livenessProbe:
           failureThreshold: 10
           httpGet:

--- a/pkg/resources/test/fixtures/statefulset-vsphere-1.18.0-prometheus.yaml
+++ b/pkg/resources/test/fixtures/statefulset-vsphere-1.18.0-prometheus.yaml
@@ -40,7 +40,7 @@ spec:
         - --web.enable-lifecycle
         - --storage.tsdb.no-lockfile
         - --web.route-prefix=/
-        image: quay.io/prometheus/prometheus:v2.19.2
+        image: quay.io/prometheus/prometheus:v2.20.1
         livenessProbe:
           failureThreshold: 10
           httpGet:


### PR DESCRIPTION
**What this PR does / why we need it**:
Biggest change is that WAL compression is now enabled by default in upstream, so we follow their recommendation.

**Documentation**:
https://github.com/kubermatic/docs/pull/434

**Does this PR introduce a user-facing change?**:
```release-note
ACTION REQUIRED: Update Prometheus to 2.20.1, enabled WAL compression by default
```
