### PR TITLE
Update Grafana to 7.1.5

### DIFF
--- a/charts/monitoring/grafana/Chart.yaml
+++ b/charts/monitoring/grafana/Chart.yaml
@@ -14,8 +14,8 @@
 
 apiVersion: v1
 name: grafana
-version: 1.4.5
-appVersion: 7.0.3
+version: 1.4.6
+appVersion: 7.1.5
 description: Grafana for Kubermatic
 keywords:
 - kubermatic

--- a/charts/monitoring/grafana/values.yaml
+++ b/charts/monitoring/grafana/values.yaml
@@ -22,7 +22,7 @@ grafana:
   replicas: 1
   image:
     repository: docker.io/grafana/grafana
-    tag: 7.0.3
+    tag: 7.1.5
   utilImage:
     repository: quay.io/kubermatic/util
     tag: 1.3.5


### PR DESCRIPTION
**What this PR does / why we need it**:
https://grafana.com/blog/2020/07/17/grafana-v7.1-released-new-features-for-influxdb-and-elasticsearch-data-sources-table-panel-transformations-and-more/

**Does this PR introduce a user-facing change?**:
```release-note
Update Grafana to 7.1.5
```
