### PR TITLE
update kube-state-metrics to 1.9.7

### DIFF
--- a/charts/monitoring/kube-state-metrics/Chart.yaml
+++ b/charts/monitoring/kube-state-metrics/Chart.yaml
@@ -14,8 +14,8 @@
 
 apiVersion: v1
 name: kube-state-metrics
-version: 1.0.9
-appVersion: v1.9.4
+version: 1.0.10
+appVersion: v1.9.7
 description: Kube-State-Metrics for Kubermatic
 keywords:
 - kubermatic

--- a/charts/monitoring/kube-state-metrics/values.yaml
+++ b/charts/monitoring/kube-state-metrics/values.yaml
@@ -15,7 +15,7 @@
 kubeStateMetrics:
   image:
     repository: quay.io/coreos/kube-state-metrics
-    tag: v1.9.4
+    tag: v1.9.7
   resources:
     requests:
       cpu: 50m

--- a/pkg/resources/kubestatemetrics/deployment.go
+++ b/pkg/resources/kubestatemetrics/deployment.go
@@ -48,7 +48,7 @@ var (
 
 const (
 	name    = "kube-state-metrics"
-	version = "v1.9.4"
+	version = "v1.9.7"
 )
 
 // DeploymentCreator returns the function to create and update the kube-state-metrics deployment

--- a/pkg/resources/test/fixtures/deployment-aws-1.15.0-kube-state-metrics.yaml
+++ b/pkg/resources/test/fixtures/deployment-aws-1.15.0-kube-state-metrics.yaml
@@ -36,7 +36,7 @@ spec:
         - '{"command":"/kube-state-metrics","args":["--kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","--port","8080","--telemetry-port","8081"]}'
         command:
         - /http-prober-bin/http-prober
-        image: quay.io/coreos/kube-state-metrics:v1.9.4
+        image: quay.io/coreos/kube-state-metrics:v1.9.7
         name: kube-state-metrics
         ports:
         - containerPort: 8080

--- a/pkg/resources/test/fixtures/deployment-aws-1.16.0-kube-state-metrics.yaml
+++ b/pkg/resources/test/fixtures/deployment-aws-1.16.0-kube-state-metrics.yaml
@@ -36,7 +36,7 @@ spec:
         - '{"command":"/kube-state-metrics","args":["--kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","--port","8080","--telemetry-port","8081"]}'
         command:
         - /http-prober-bin/http-prober
-        image: quay.io/coreos/kube-state-metrics:v1.9.4
+        image: quay.io/coreos/kube-state-metrics:v1.9.7
         name: kube-state-metrics
         ports:
         - containerPort: 8080

--- a/pkg/resources/test/fixtures/deployment-aws-1.17.0-kube-state-metrics.yaml
+++ b/pkg/resources/test/fixtures/deployment-aws-1.17.0-kube-state-metrics.yaml
@@ -36,7 +36,7 @@ spec:
         - '{"command":"/kube-state-metrics","args":["--kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","--port","8080","--telemetry-port","8081"]}'
         command:
         - /http-prober-bin/http-prober
-        image: quay.io/coreos/kube-state-metrics:v1.9.4
+        image: quay.io/coreos/kube-state-metrics:v1.9.7
         name: kube-state-metrics
         ports:
         - containerPort: 8080

--- a/pkg/resources/test/fixtures/deployment-aws-1.18.0-kube-state-metrics.yaml
+++ b/pkg/resources/test/fixtures/deployment-aws-1.18.0-kube-state-metrics.yaml
@@ -36,7 +36,7 @@ spec:
         - '{"command":"/kube-state-metrics","args":["--kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","--port","8080","--telemetry-port","8081"]}'
         command:
         - /http-prober-bin/http-prober
-        image: quay.io/coreos/kube-state-metrics:v1.9.4
+        image: quay.io/coreos/kube-state-metrics:v1.9.7
         name: kube-state-metrics
         ports:
         - containerPort: 8080

--- a/pkg/resources/test/fixtures/deployment-azure-1.15.0-kube-state-metrics.yaml
+++ b/pkg/resources/test/fixtures/deployment-azure-1.15.0-kube-state-metrics.yaml
@@ -36,7 +36,7 @@ spec:
         - '{"command":"/kube-state-metrics","args":["--kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","--port","8080","--telemetry-port","8081"]}'
         command:
         - /http-prober-bin/http-prober
-        image: quay.io/coreos/kube-state-metrics:v1.9.4
+        image: quay.io/coreos/kube-state-metrics:v1.9.7
         name: kube-state-metrics
         ports:
         - containerPort: 8080

--- a/pkg/resources/test/fixtures/deployment-azure-1.16.0-kube-state-metrics.yaml
+++ b/pkg/resources/test/fixtures/deployment-azure-1.16.0-kube-state-metrics.yaml
@@ -36,7 +36,7 @@ spec:
         - '{"command":"/kube-state-metrics","args":["--kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","--port","8080","--telemetry-port","8081"]}'
         command:
         - /http-prober-bin/http-prober
-        image: quay.io/coreos/kube-state-metrics:v1.9.4
+        image: quay.io/coreos/kube-state-metrics:v1.9.7
         name: kube-state-metrics
         ports:
         - containerPort: 8080

--- a/pkg/resources/test/fixtures/deployment-azure-1.17.0-kube-state-metrics.yaml
+++ b/pkg/resources/test/fixtures/deployment-azure-1.17.0-kube-state-metrics.yaml
@@ -36,7 +36,7 @@ spec:
         - '{"command":"/kube-state-metrics","args":["--kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","--port","8080","--telemetry-port","8081"]}'
         command:
         - /http-prober-bin/http-prober
-        image: quay.io/coreos/kube-state-metrics:v1.9.4
+        image: quay.io/coreos/kube-state-metrics:v1.9.7
         name: kube-state-metrics
         ports:
         - containerPort: 8080

--- a/pkg/resources/test/fixtures/deployment-azure-1.18.0-kube-state-metrics.yaml
+++ b/pkg/resources/test/fixtures/deployment-azure-1.18.0-kube-state-metrics.yaml
@@ -36,7 +36,7 @@ spec:
         - '{"command":"/kube-state-metrics","args":["--kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","--port","8080","--telemetry-port","8081"]}'
         command:
         - /http-prober-bin/http-prober
-        image: quay.io/coreos/kube-state-metrics:v1.9.4
+        image: quay.io/coreos/kube-state-metrics:v1.9.7
         name: kube-state-metrics
         ports:
         - containerPort: 8080

--- a/pkg/resources/test/fixtures/deployment-bringyourown-1.15.0-kube-state-metrics.yaml
+++ b/pkg/resources/test/fixtures/deployment-bringyourown-1.15.0-kube-state-metrics.yaml
@@ -36,7 +36,7 @@ spec:
         - '{"command":"/kube-state-metrics","args":["--kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","--port","8080","--telemetry-port","8081"]}'
         command:
         - /http-prober-bin/http-prober
-        image: quay.io/coreos/kube-state-metrics:v1.9.4
+        image: quay.io/coreos/kube-state-metrics:v1.9.7
         name: kube-state-metrics
         ports:
         - containerPort: 8080

--- a/pkg/resources/test/fixtures/deployment-bringyourown-1.16.0-kube-state-metrics.yaml
+++ b/pkg/resources/test/fixtures/deployment-bringyourown-1.16.0-kube-state-metrics.yaml
@@ -36,7 +36,7 @@ spec:
         - '{"command":"/kube-state-metrics","args":["--kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","--port","8080","--telemetry-port","8081"]}'
         command:
         - /http-prober-bin/http-prober
-        image: quay.io/coreos/kube-state-metrics:v1.9.4
+        image: quay.io/coreos/kube-state-metrics:v1.9.7
         name: kube-state-metrics
         ports:
         - containerPort: 8080

--- a/pkg/resources/test/fixtures/deployment-bringyourown-1.17.0-kube-state-metrics.yaml
+++ b/pkg/resources/test/fixtures/deployment-bringyourown-1.17.0-kube-state-metrics.yaml
@@ -36,7 +36,7 @@ spec:
         - '{"command":"/kube-state-metrics","args":["--kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","--port","8080","--telemetry-port","8081"]}'
         command:
         - /http-prober-bin/http-prober
-        image: quay.io/coreos/kube-state-metrics:v1.9.4
+        image: quay.io/coreos/kube-state-metrics:v1.9.7
         name: kube-state-metrics
         ports:
         - containerPort: 8080

--- a/pkg/resources/test/fixtures/deployment-bringyourown-1.18.0-kube-state-metrics.yaml
+++ b/pkg/resources/test/fixtures/deployment-bringyourown-1.18.0-kube-state-metrics.yaml
@@ -36,7 +36,7 @@ spec:
         - '{"command":"/kube-state-metrics","args":["--kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","--port","8080","--telemetry-port","8081"]}'
         command:
         - /http-prober-bin/http-prober
-        image: quay.io/coreos/kube-state-metrics:v1.9.4
+        image: quay.io/coreos/kube-state-metrics:v1.9.7
         name: kube-state-metrics
         ports:
         - containerPort: 8080

--- a/pkg/resources/test/fixtures/deployment-digitalocean-1.15.0-kube-state-metrics.yaml
+++ b/pkg/resources/test/fixtures/deployment-digitalocean-1.15.0-kube-state-metrics.yaml
@@ -36,7 +36,7 @@ spec:
         - '{"command":"/kube-state-metrics","args":["--kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","--port","8080","--telemetry-port","8081"]}'
         command:
         - /http-prober-bin/http-prober
-        image: quay.io/coreos/kube-state-metrics:v1.9.4
+        image: quay.io/coreos/kube-state-metrics:v1.9.7
         name: kube-state-metrics
         ports:
         - containerPort: 8080

--- a/pkg/resources/test/fixtures/deployment-digitalocean-1.16.0-kube-state-metrics.yaml
+++ b/pkg/resources/test/fixtures/deployment-digitalocean-1.16.0-kube-state-metrics.yaml
@@ -36,7 +36,7 @@ spec:
         - '{"command":"/kube-state-metrics","args":["--kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","--port","8080","--telemetry-port","8081"]}'
         command:
         - /http-prober-bin/http-prober
-        image: quay.io/coreos/kube-state-metrics:v1.9.4
+        image: quay.io/coreos/kube-state-metrics:v1.9.7
         name: kube-state-metrics
         ports:
         - containerPort: 8080

--- a/pkg/resources/test/fixtures/deployment-digitalocean-1.17.0-kube-state-metrics.yaml
+++ b/pkg/resources/test/fixtures/deployment-digitalocean-1.17.0-kube-state-metrics.yaml
@@ -36,7 +36,7 @@ spec:
         - '{"command":"/kube-state-metrics","args":["--kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","--port","8080","--telemetry-port","8081"]}'
         command:
         - /http-prober-bin/http-prober
-        image: quay.io/coreos/kube-state-metrics:v1.9.4
+        image: quay.io/coreos/kube-state-metrics:v1.9.7
         name: kube-state-metrics
         ports:
         - containerPort: 8080

--- a/pkg/resources/test/fixtures/deployment-digitalocean-1.18.0-kube-state-metrics.yaml
+++ b/pkg/resources/test/fixtures/deployment-digitalocean-1.18.0-kube-state-metrics.yaml
@@ -36,7 +36,7 @@ spec:
         - '{"command":"/kube-state-metrics","args":["--kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","--port","8080","--telemetry-port","8081"]}'
         command:
         - /http-prober-bin/http-prober
-        image: quay.io/coreos/kube-state-metrics:v1.9.4
+        image: quay.io/coreos/kube-state-metrics:v1.9.7
         name: kube-state-metrics
         ports:
         - containerPort: 8080

--- a/pkg/resources/test/fixtures/deployment-openstack-1.15.0-kube-state-metrics.yaml
+++ b/pkg/resources/test/fixtures/deployment-openstack-1.15.0-kube-state-metrics.yaml
@@ -36,7 +36,7 @@ spec:
         - '{"command":"/kube-state-metrics","args":["--kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","--port","8080","--telemetry-port","8081"]}'
         command:
         - /http-prober-bin/http-prober
-        image: quay.io/coreos/kube-state-metrics:v1.9.4
+        image: quay.io/coreos/kube-state-metrics:v1.9.7
         name: kube-state-metrics
         ports:
         - containerPort: 8080

--- a/pkg/resources/test/fixtures/deployment-openstack-1.16.0-kube-state-metrics.yaml
+++ b/pkg/resources/test/fixtures/deployment-openstack-1.16.0-kube-state-metrics.yaml
@@ -36,7 +36,7 @@ spec:
         - '{"command":"/kube-state-metrics","args":["--kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","--port","8080","--telemetry-port","8081"]}'
         command:
         - /http-prober-bin/http-prober
-        image: quay.io/coreos/kube-state-metrics:v1.9.4
+        image: quay.io/coreos/kube-state-metrics:v1.9.7
         name: kube-state-metrics
         ports:
         - containerPort: 8080

--- a/pkg/resources/test/fixtures/deployment-openstack-1.17.0-kube-state-metrics.yaml
+++ b/pkg/resources/test/fixtures/deployment-openstack-1.17.0-kube-state-metrics.yaml
@@ -36,7 +36,7 @@ spec:
         - '{"command":"/kube-state-metrics","args":["--kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","--port","8080","--telemetry-port","8081"]}'
         command:
         - /http-prober-bin/http-prober
-        image: quay.io/coreos/kube-state-metrics:v1.9.4
+        image: quay.io/coreos/kube-state-metrics:v1.9.7
         name: kube-state-metrics
         ports:
         - containerPort: 8080

--- a/pkg/resources/test/fixtures/deployment-openstack-1.18.0-kube-state-metrics.yaml
+++ b/pkg/resources/test/fixtures/deployment-openstack-1.18.0-kube-state-metrics.yaml
@@ -36,7 +36,7 @@ spec:
         - '{"command":"/kube-state-metrics","args":["--kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","--port","8080","--telemetry-port","8081"]}'
         command:
         - /http-prober-bin/http-prober
-        image: quay.io/coreos/kube-state-metrics:v1.9.4
+        image: quay.io/coreos/kube-state-metrics:v1.9.7
         name: kube-state-metrics
         ports:
         - containerPort: 8080

--- a/pkg/resources/test/fixtures/deployment-vsphere-1.15.0-kube-state-metrics.yaml
+++ b/pkg/resources/test/fixtures/deployment-vsphere-1.15.0-kube-state-metrics.yaml
@@ -36,7 +36,7 @@ spec:
         - '{"command":"/kube-state-metrics","args":["--kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","--port","8080","--telemetry-port","8081"]}'
         command:
         - /http-prober-bin/http-prober
-        image: quay.io/coreos/kube-state-metrics:v1.9.4
+        image: quay.io/coreos/kube-state-metrics:v1.9.7
         name: kube-state-metrics
         ports:
         - containerPort: 8080

--- a/pkg/resources/test/fixtures/deployment-vsphere-1.16.0-kube-state-metrics.yaml
+++ b/pkg/resources/test/fixtures/deployment-vsphere-1.16.0-kube-state-metrics.yaml
@@ -36,7 +36,7 @@ spec:
         - '{"command":"/kube-state-metrics","args":["--kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","--port","8080","--telemetry-port","8081"]}'
         command:
         - /http-prober-bin/http-prober
-        image: quay.io/coreos/kube-state-metrics:v1.9.4
+        image: quay.io/coreos/kube-state-metrics:v1.9.7
         name: kube-state-metrics
         ports:
         - containerPort: 8080

--- a/pkg/resources/test/fixtures/deployment-vsphere-1.17.0-kube-state-metrics.yaml
+++ b/pkg/resources/test/fixtures/deployment-vsphere-1.17.0-kube-state-metrics.yaml
@@ -36,7 +36,7 @@ spec:
         - '{"command":"/kube-state-metrics","args":["--kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","--port","8080","--telemetry-port","8081"]}'
         command:
         - /http-prober-bin/http-prober
-        image: quay.io/coreos/kube-state-metrics:v1.9.4
+        image: quay.io/coreos/kube-state-metrics:v1.9.7
         name: kube-state-metrics
         ports:
         - containerPort: 8080

--- a/pkg/resources/test/fixtures/deployment-vsphere-1.18.0-kube-state-metrics.yaml
+++ b/pkg/resources/test/fixtures/deployment-vsphere-1.18.0-kube-state-metrics.yaml
@@ -36,7 +36,7 @@ spec:
         - '{"command":"/kube-state-metrics","args":["--kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","--port","8080","--telemetry-port","8081"]}'
         command:
         - /http-prober-bin/http-prober
-        image: quay.io/coreos/kube-state-metrics:v1.9.4
+        image: quay.io/coreos/kube-state-metrics:v1.9.7
         name: kube-state-metrics
         ports:
         - containerPort: 8080


### PR DESCRIPTION
**What this PR does / why we need it**:

* [BUGFIX] internal/store/mutatingwebhookconfiguration.go: Switch to v1 kubernetes/kube-state-metrics#1144
* [BUGFIX] Fix VolumeAttachment API version mismatch: expected v1 but watching v1beta1 (kubernetes/kube-state-metrics#1136)
* [BUGFIX] Switch to using only v1 client of validatingwebhookconfiguration kubernetes/kube-state-metrics#1052

**Does this PR introduce a user-facing change?**:
```release-note
Update kube-state-metrics to v1.9.7
```
