### PR TITLE
Update node-exporter to 1.0.1

### DIFF
--- a/addons/node-exporter/daemonset.yaml
+++ b/addons/node-exporter/daemonset.yaml
@@ -20,7 +20,7 @@ metadata:
   labels:
     addonmanager.kubernetes.io/mode: Reconcile
     app.kubernetes.io/name: node-exporter
-    app.kubernetes.io/version: v0.18.0
+    app.kubernetes.io/version: v1.0.1
 spec:
   updateStrategy:
     type: RollingUpdate
@@ -64,7 +64,7 @@ spec:
           mountPropagation: HostToContainer
 
       - name: kube-rbac-proxy
-        image: '{{ Registry "quay.io" }}/coreos/kube-rbac-proxy:v0.4.1'
+        image: '{{ Registry "quay.io" }}/brancz/kube-rbac-proxy:v0.6.0'
         args:
         - '--logtostderr'
         - '--secure-listen-address=$(IP):9100'

--- a/charts/monitoring/node-exporter/Chart.yaml
+++ b/charts/monitoring/node-exporter/Chart.yaml
@@ -14,8 +14,8 @@
 
 apiVersion: v1
 name: node-exporter
-version: 1.0.5
-appVersion: v0.18.1
+version: 1.1.0
+appVersion: v1.0.1
 description: Prometheus Node Exporter for Kubermatic
 keywords:
 - kubermatic

--- a/charts/monitoring/node-exporter/values.yaml
+++ b/charts/monitoring/node-exporter/values.yaml
@@ -15,7 +15,7 @@
 nodeExporter:
   image:
     repository: quay.io/prometheus/node-exporter
-    tag: v0.18.1
+    tag: v1.0.1
   resources:
     requests:
       cpu: 50m
@@ -26,8 +26,8 @@ nodeExporter:
 
   rbacProxy:
     image:
-      repository: quay.io/coreos/kube-rbac-proxy
-      tag: v0.4.1
+      repository: quay.io/brancz/kube-rbac-proxy
+      tag: v0.6.0
     resources:
       requests:
         cpu: 50m


### PR DESCRIPTION
**What this PR does / why we need it**:
Lots of improvements and no breaking changes for us.

The quay.io repository for the rbac-proxy does not seem to be updated properly, as 0.6.0 is not available there. This is why I changed to the ... new? repository.

**Does this PR introduce a user-facing change?**:
```release-note
Update node-exporter to 1.0.1, including the usercluster addon
```
