### PR TITLE
gitignore download-gocache

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,3 +17,4 @@
 _artifacts/*
 _build
 _cache
+download-gocache


### PR DESCRIPTION
**What this PR does / why we need it**:
When bringing back the gocache, I forgot to gitignore the marker file, which made someone accidentally commit it to the repo.
This PR fixes that.

**Does this PR introduce a user-facing change?**:
```release-note
NONE
```
