### PR TITLE
Fix addons installation

### DIFF
--- a/pkg/controller/seed-controller-manager/addon/addon_controller.go
+++ b/pkg/controller/seed-controller-manager/addon/addon_controller.go
@@ -273,7 +273,7 @@ func (r *Reconciler) reconcile(ctx context.Context, log *zap.SugaredLogger, addo
 		return nil, fmt.Errorf("failed to deploy the addon manifests into the cluster: %v", err)
 	}
 	if err := r.ensureFinalizerIsSet(ctx, addon); err != nil {
-		return nil, fmt.Errorf("failed to ensure that the cleanup finalizer existis on the addon: %v", err)
+		return nil, fmt.Errorf("failed to ensure that the cleanup finalizer exists on the addon: %v", err)
 	}
 	if err := r.ensureResourcesCreatedConditionIsSet(ctx, addon); err != nil {
 		return nil, fmt.Errorf("failed to set add ResourcesCreated Condition: %v", err)

--- a/pkg/controller/seed-controller-manager/addoninstaller/addoninstaller_controller_test.go
+++ b/pkg/controller/seed-controller-manager/addoninstaller/addoninstaller_controller_test.go
@@ -280,6 +280,116 @@ func TestUpdateAddon(t *testing.T) {
 				},
 			},
 		},
+		{
+			name: "successfully created two addons and deleted one",
+			existingClusterAddons: []*kubermaticv1.Addon{
+				{
+					TypeMeta: metav1.TypeMeta{
+						APIVersion: "kubermatic.k8s.io/v1",
+						Kind:       "Addon",
+					},
+					ObjectMeta: metav1.ObjectMeta{
+						Name:            "to-be-deleted",
+						Namespace:       "cluster-" + name,
+						ResourceVersion: "1",
+						OwnerReferences: []metav1.OwnerReference{
+							{
+								APIVersion:         "kubermatic.k8s.io/v1",
+								Kind:               "Cluster",
+								Name:               name,
+								Controller:         truePtr(),
+								BlockOwnerDeletion: truePtr(),
+							},
+						},
+					},
+					Spec: kubermaticv1.AddonSpec{
+						Name: "ToBeDeleted",
+						Cluster: corev1.ObjectReference{
+							Kind: "Cluster",
+							Name: name,
+						},
+						IsDefault: true,
+					},
+				},
+			},
+			expectedClusterAddons: []*kubermaticv1.Addon{
+				{
+					TypeMeta: metav1.TypeMeta{
+						APIVersion: "kubermatic.k8s.io/v1",
+						Kind:       "Addon",
+					},
+					ObjectMeta: metav1.ObjectMeta{
+						Name:            "Foo",
+						Namespace:       "cluster-" + name,
+						ResourceVersion: "1",
+						OwnerReferences: []metav1.OwnerReference{
+							{
+								APIVersion:         "kubermatic.k8s.io/v1",
+								Kind:               "Cluster",
+								Name:               name,
+								Controller:         truePtr(),
+								BlockOwnerDeletion: truePtr(),
+							},
+						},
+					},
+					Spec: kubermaticv1.AddonSpec{
+						Name: "Foo",
+						Cluster: corev1.ObjectReference{
+							Kind: "Cluster",
+							Name: name,
+						},
+						IsDefault: true,
+					},
+				},
+				{
+					TypeMeta: metav1.TypeMeta{
+						APIVersion: "kubermatic.k8s.io/v1",
+						Kind:       "Addon",
+					},
+					ObjectMeta: metav1.ObjectMeta{
+						Name:            "Bar",
+						Namespace:       "cluster-" + name,
+						Labels:          map[string]string{"addons.kubermatic.io/ensure": "true"},
+						Annotations:     map[string]string{"foo": "bar"},
+						ResourceVersion: "1",
+						OwnerReferences: []metav1.OwnerReference{
+							{
+								APIVersion:         "kubermatic.k8s.io/v1",
+								Kind:               "Cluster",
+								Name:               name,
+								Controller:         truePtr(),
+								BlockOwnerDeletion: truePtr(),
+							},
+						},
+					},
+					Spec: kubermaticv1.AddonSpec{
+						Name: "Bar",
+						Cluster: corev1.ObjectReference{
+							Kind: "Cluster",
+							Name: name,
+						},
+						IsDefault: true,
+					},
+				},
+			},
+			cluster: &kubermaticv1.Cluster{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: name,
+				},
+				Spec:    kubermaticv1.ClusterSpec{},
+				Address: kubermaticv1.ClusterAddress{},
+				Status: kubermaticv1.ClusterStatus{
+					ExtendedHealth: kubermaticv1.ExtendedClusterHealth{
+
+						Apiserver: kubermaticv1.HealthStatusUp,
+					},
+					NamespaceName: "cluster-" + name,
+				},
+			},
+		},
+		//TODO(irozzo) Add test to ensure that user added addons are not
+		//deleted when the following is merged:
+		// https://github.com/kubernetes-sigs/controller-runtime/pull/800
 	}
 
 	for _, test := range tests {


### PR DESCRIPTION
**What this PR does / why we need it**:
The _addoninstaller_controller_ is created with a pre-determined list of add-ons that are mandatory and ensured in every user cluster, those are defined as `default` add-ons.
#5370 introduced some logic to delete the add-ons that do not belong to such list for migration purposes. The problem is that it did not take into account optional addons that may be installed by user cluster administrators that also get erroneously removed. This PR fixes the issue.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #5528 

**Special notes for your reviewer**:

**Documentation**:
<!-- Add links to the related documentation changes related to this pull request. E.g. the link to the kubermatic/docs pullrequest. -->

**Does this PR introduce a user-facing change?**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If  no release note is required, just write "NONE".
-->
```release-note
NONE
```
