### PR TITLE
fix producer and consumer mismatch

### DIFF
--- a/cmd/kubermatic-api/swagger.json
+++ b/cmd/kubermatic-api/swagger.json
@@ -2456,7 +2456,8 @@
     "/api/v1/projects/{project_id}/dc/{dc}/clusters/{cluster_id}/kubeconfig": {
       "get": {
         "produces": [
-          "application/yaml"
+          "application/yaml",
+          "application/json"
         ],
         "tags": [
           "project"

--- a/pkg/handler/routes_v1.go
+++ b/pkg/handler/routes_v1.go
@@ -1909,6 +1909,7 @@ func (r Routing) getClusterEvents() http.Handler {
 //
 //     Produces:
 //     - application/yaml
+//	   - application/json
 //
 //     Responses:
 //       default: errorResponse

--- a/pkg/test/e2e/api/utils/apiclient/client/project/project_client.go
+++ b/pkg/test/e2e/api/utils/apiclient/client/project/project_client.go
@@ -1036,7 +1036,7 @@ func (a *Client) GetClusterKubeconfig(params *GetClusterKubeconfigParams, authIn
 		ID:                 "getClusterKubeconfig",
 		Method:             "GET",
 		PathPattern:        "/api/v1/projects/{project_id}/dc/{dc}/clusters/{cluster_id}/kubeconfig",
-		ProducesMediaTypes: []string{"application/yaml"},
+		ProducesMediaTypes: []string{"application/json", "application/yaml"},
 		ConsumesMediaTypes: []string{"application/json"},
 		Schemes:            []string{"https"},
 		Params:             params,


### PR DESCRIPTION
Signed-off-by: furkhat <vailodf@gmail.com>

**What this PR does / why we need it**:

When using generated api client, function for getting cluster's kubeconfig won't work. This is due to producer (`application/yaml`) and consumer (`application/json`) mismatch.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes Blocks download kubeconfig feature of terraform-provider-kubermatic

**Does this PR introduce a user-facing change?**:
```release-note
NONE
```