### PR TITLE
Update e2e tests to kind 0.8.1

### DIFF
--- a/.prow.yaml
+++ b/.prow.yaml
@@ -17,269 +17,269 @@ presubmits:
   # unit tests
   #########################################################
 
-  # - name: pre-kubermatic-test
-  #   run_if_changed: "^(cmd|codegen|hack|pkg)/"
-  #   decorate: true
-  #   clone_uri: "ssh://git@github.com/kubermatic/kubermatic.git"
-  #   labels:
-  #     preset-goproxy: "true"
-  #   spec:
-  #     containers:
-  #     - image: golang:1.14.2
-  #       command:
-  #       - make
-  #       args:
-  #       - test
-  #       resources:
-  #         requests:
-  #           memory: 7Gi
-  #           cpu: 2
-  #       env:
-  #       - name: KUBERMATIC_EDITION
-  #         value: ee
+  - name: pre-kubermatic-test
+    run_if_changed: "^(cmd|codegen|hack|pkg)/"
+    decorate: true
+    clone_uri: "ssh://git@github.com/kubermatic/kubermatic.git"
+    labels:
+      preset-goproxy: "true"
+    spec:
+      containers:
+      - image: golang:1.14.2
+        command:
+        - make
+        args:
+        - test
+        resources:
+          requests:
+            memory: 7Gi
+            cpu: 2
+        env:
+        - name: KUBERMATIC_EDITION
+          value: ee
 
-  # - name: pre-kubermatic-verify
-  #   run_if_changed: "^(cmd|codegen|hack|pkg)/"
-  #   decorate: true
-  #   clone_uri: "ssh://git@github.com/kubermatic/kubermatic.git"
-  #   path_alias: k8c.io/kubermatic
-  #   labels:
-  #     preset-goproxy: "true"
-  #   spec:
-  #     containers:
-  #     - image: golang:1.14.2
-  #       command:
-  #       - make
-  #       args:
-  #       - verify
-  #       resources:
-  #         requests:
-  #           memory: 1.5Gi
-  #           cpu: 1
-  #         limits:
-  #           memory: 2.5Gi
-  #           cpu: 2
-  #       env:
-  #       - name: KUBERMATIC_EDITION
-  #         value: ee
+  - name: pre-kubermatic-verify
+    run_if_changed: "^(cmd|codegen|hack|pkg)/"
+    decorate: true
+    clone_uri: "ssh://git@github.com/kubermatic/kubermatic.git"
+    path_alias: k8c.io/kubermatic
+    labels:
+      preset-goproxy: "true"
+    spec:
+      containers:
+      - image: golang:1.14.2
+        command:
+        - make
+        args:
+        - verify
+        resources:
+          requests:
+            memory: 1.5Gi
+            cpu: 1
+          limits:
+            memory: 2.5Gi
+            cpu: 2
+        env:
+        - name: KUBERMATIC_EDITION
+          value: ee
 
-  # - name: pre-kubermatic-verify-charts
-  #   run_if_changed: "^charts/"
-  #   decorate: true
-  #   clone_uri: "ssh://git@github.com/kubermatic/kubermatic.git"
-  #   labels:
-  #     preset-goproxy: "true"
-  #   spec:
-  #     containers:
-  #     - image: quay.io/kubermatic/util:1.3.5
-  #       command:
-  #       - "./hack/verify-chart-versions.sh"
-  #       resources:
-  #         requests:
-  #           memory: 128Mi
-  #           cpu: 50m
-  #         limits:
-  #           memory: 256Mi
-  #           cpu: 250m
-  #       env:
-  #       - name: KUBERMATIC_EDITION
-  #         value: ee
+  - name: pre-kubermatic-verify-charts
+    run_if_changed: "^charts/"
+    decorate: true
+    clone_uri: "ssh://git@github.com/kubermatic/kubermatic.git"
+    labels:
+      preset-goproxy: "true"
+    spec:
+      containers:
+      - image: quay.io/kubermatic/util:1.3.5
+        command:
+        - "./hack/verify-chart-versions.sh"
+        resources:
+          requests:
+            memory: 128Mi
+            cpu: 50m
+          limits:
+            memory: 256Mi
+            cpu: 250m
+        env:
+        - name: KUBERMATIC_EDITION
+          value: ee
 
-  # - name: pre-kubermatic-verify-kubermatic-chart
-  #   run_if_changed: "^(cmd|codegen|hack|pkg|charts)/"
-  #   decorate: true
-  #   clone_uri: "ssh://git@github.com/kubermatic/kubermatic.git"
-  #   labels:
-  #     preset-goproxy: "true"
-  #   spec:
-  #     containers:
-  #     - image: quay.io/kubermatic/go-docker:14.2-1806-0
-  #       command:
-  #       - "./hack/verify-kubermatic-chart.sh"
-  #       resources:
-  #         requests:
-  #           memory: 512Mi
-  #           cpu: 250m
-  #         limits:
-  #           memory: 1Gi
-  #           cpu: 1
-  #       env:
-  #       - name: KUBERMATIC_EDITION
-  #         value: ee
+  - name: pre-kubermatic-verify-kubermatic-chart
+    run_if_changed: "^(cmd|codegen|hack|pkg|charts)/"
+    decorate: true
+    clone_uri: "ssh://git@github.com/kubermatic/kubermatic.git"
+    labels:
+      preset-goproxy: "true"
+    spec:
+      containers:
+      - image: quay.io/kubermatic/go-docker:14.2-1806-0
+        command:
+        - "./hack/verify-kubermatic-chart.sh"
+        resources:
+          requests:
+            memory: 512Mi
+            cpu: 250m
+          limits:
+            memory: 1Gi
+            cpu: 1
+        env:
+        - name: KUBERMATIC_EDITION
+          value: ee
 
-  # - name: pre-kubermatic-verify-grafana-dashboards
-  #   run_if_changed: "^charts/monitoring/grafana/"
-  #   decorate: true
-  #   clone_uri: "ssh://git@github.com/kubermatic/kubermatic.git"
-  #   labels:
-  #     preset-goproxy: "true"
-  #   spec:
-  #     containers:
-  #     - image: quay.io/kubermatic/util:1.3.5
-  #       command:
-  #       - "./hack/verify-grafana-dashboards.sh"
-  #       resources:
-  #         requests:
-  #           memory: 64Mi
-  #           cpu: 50m
-  #         limits:
-  #           memory: 128Mi
-  #           cpu: 250m
-  #       env:
-  #       - name: KUBERMATIC_EDITION
-  #         value: ee
+  - name: pre-kubermatic-verify-grafana-dashboards
+    run_if_changed: "^charts/monitoring/grafana/"
+    decorate: true
+    clone_uri: "ssh://git@github.com/kubermatic/kubermatic.git"
+    labels:
+      preset-goproxy: "true"
+    spec:
+      containers:
+      - image: quay.io/kubermatic/util:1.3.5
+        command:
+        - "./hack/verify-grafana-dashboards.sh"
+        resources:
+          requests:
+            memory: 64Mi
+            cpu: 50m
+          limits:
+            memory: 128Mi
+            cpu: 250m
+        env:
+        - name: KUBERMATIC_EDITION
+          value: ee
 
-  # - name: pre-kubermatic-verify-docs
-  #   run_if_changed: "^(cmd|codegen|hack|pkg|docs)/"
-  #   decorate: true
-  #   clone_uri: "ssh://git@github.com/kubermatic/kubermatic.git"
-  #   labels:
-  #     preset-goproxy: "true"
-  #   spec:
-  #     containers:
-  #     - image: quay.io/kubermatic/go-docker:14.2-1806-0
-  #       command:
-  #       - "./hack/verify-docs.sh"
-  #       resources:
-  #         requests:
-  #           memory: 1Gi
-  #           cpu: 1
-  #       env:
-  #       - name: KUBERMATIC_EDITION
-  #         value: ee
+  - name: pre-kubermatic-verify-docs
+    run_if_changed: "^(cmd|codegen|hack|pkg|docs)/"
+    decorate: true
+    clone_uri: "ssh://git@github.com/kubermatic/kubermatic.git"
+    labels:
+      preset-goproxy: "true"
+    spec:
+      containers:
+      - image: quay.io/kubermatic/go-docker:14.2-1806-0
+        command:
+        - "./hack/verify-docs.sh"
+        resources:
+          requests:
+            memory: 1Gi
+            cpu: 1
+        env:
+        - name: KUBERMATIC_EDITION
+          value: ee
 
-  # - name: pre-kubermatic-lint
-  #   run_if_changed: "^(cmd|codegen|hack|pkg)/"
-  #   decorate: true
-  #   clone_uri: "ssh://git@github.com/kubermatic/kubermatic.git"
-  #   labels:
-  #     preset-goproxy: "true"
-  #   spec:
-  #     containers:
-  #     - image: golangci/golangci-lint:v1.23.6
-  #       command:
-  #       - make
-  #       args:
-  #       - lint
-  #       resources:
-  #         requests:
-  #           memory: 10Gi
-  #           cpu: 3
-  #       env:
-  #       - name: KUBERMATIC_EDITION
-  #         value: ee
+  - name: pre-kubermatic-lint
+    run_if_changed: "^(cmd|codegen|hack|pkg)/"
+    decorate: true
+    clone_uri: "ssh://git@github.com/kubermatic/kubermatic.git"
+    labels:
+      preset-goproxy: "true"
+    spec:
+      containers:
+      - image: golangci/golangci-lint:v1.23.6
+        command:
+        - make
+        args:
+        - lint
+        resources:
+          requests:
+            memory: 10Gi
+            cpu: 3
+        env:
+        - name: KUBERMATIC_EDITION
+          value: ee
 
-  # - name: pre-kubermatic-dependencies
-  #   run_if_changed: "^(cmd|codegen|hack|pkg|go.mod|go.sum)/"
-  #   decorate: true
-  #   clone_uri: "ssh://git@github.com/kubermatic/kubermatic.git"
-  #   labels:
-  #     preset-goproxy: "true"
-  #   spec:
-  #     containers:
-  #     - image: quay.io/kubermatic/go-docker:14.2-1806-0
-  #       command:
-  #       - make
-  #       args:
-  #       - check-dependencies
-  #       resources:
-  #         requests:
-  #           memory: 256Mi
-  #           cpu: 250m
-  #         limits:
-  #           memory: 256Mi
-  #           cpu: 250m
-  #       env:
-  #       - name: KUBERMATIC_EDITION
-  #         value: ee
+  - name: pre-kubermatic-dependencies
+    run_if_changed: "^(cmd|codegen|hack|pkg|go.mod|go.sum)/"
+    decorate: true
+    clone_uri: "ssh://git@github.com/kubermatic/kubermatic.git"
+    labels:
+      preset-goproxy: "true"
+    spec:
+      containers:
+      - image: quay.io/kubermatic/go-docker:14.2-1806-0
+        command:
+        - make
+        args:
+        - check-dependencies
+        resources:
+          requests:
+            memory: 256Mi
+            cpu: 250m
+          limits:
+            memory: 256Mi
+            cpu: 250m
+        env:
+        - name: KUBERMATIC_EDITION
+          value: ee
 
-  # - name: pre-kubermatic-shellcheck
-  #   optional: true
-  #   decorate: true
-  #   clone_uri: "ssh://git@github.com/kubermatic/kubermatic.git"
-  #   labels:
-  #     preset-goproxy: "true"
-  #   spec:
-  #     containers:
-  #     - image: koalaman/shellcheck-alpine:v0.7.0
-  #       command:
-  #       - sh
-  #       args:
-  #       - -c
-  #       - shellcheck --shell=bash $(find . -name '*.sh')
-  #       resources:
-  #         requests:
-  #           memory: 1Gi
-  #           cpu: 0.5
-  #       env:
-  #       - name: KUBERMATIC_EDITION
-  #         value: ee
+  - name: pre-kubermatic-shellcheck
+    optional: true
+    decorate: true
+    clone_uri: "ssh://git@github.com/kubermatic/kubermatic.git"
+    labels:
+      preset-goproxy: "true"
+    spec:
+      containers:
+      - image: koalaman/shellcheck-alpine:v0.7.0
+        command:
+        - sh
+        args:
+        - -c
+        - shellcheck --shell=bash $(find . -name '*.sh')
+        resources:
+          requests:
+            memory: 1Gi
+            cpu: 0.5
+        env:
+        - name: KUBERMATIC_EDITION
+          value: ee
 
-  # - name: pre-kubermatic-license-validation
-  #   run_if_changed: "^go.(mod|sum)$"
-  #   decorate: true
-  #   clone_uri: "ssh://git@github.com/kubermatic/kubermatic.git"
-  #   labels:
-  #     preset-goproxy: "true"
-  #   spec:
-  #     containers:
-  #     - image: quay.io/kubermatic/util:1.4.0
-  #       command:
-  #       - ./hack/verify-licenses.sh
-  #       resources:
-  #         requests:
-  #           memory: 512Mi
-  #           cpu: 1
+  - name: pre-kubermatic-license-validation
+    run_if_changed: "^go.(mod|sum)$"
+    decorate: true
+    clone_uri: "ssh://git@github.com/kubermatic/kubermatic.git"
+    labels:
+      preset-goproxy: "true"
+    spec:
+      containers:
+      - image: quay.io/kubermatic/util:1.4.0
+        command:
+        - ./hack/verify-licenses.sh
+        resources:
+          requests:
+            memory: 512Mi
+            cpu: 1
 
-  # - name: pre-kubermatic-verify-boilerplate
-  #   always_run: true
-  #   decorate: true
-  #   clone_uri: "ssh://git@github.com/kubermatic/kubermatic.git"
-  #   labels:
-  #     preset-goproxy: "true"
-  #   spec:
-  #     containers:
-  #     - image: quay.io/kubermatic-labs/boilerplate:v0.1.1
-  #       command:
-  #       - ./hack/verify-boilerplate.sh
-  #       resources:
-  #         requests:
-  #           memory: 256Mi
-  #           cpu: 100m
+  - name: pre-kubermatic-verify-boilerplate
+    always_run: true
+    decorate: true
+    clone_uri: "ssh://git@github.com/kubermatic/kubermatic.git"
+    labels:
+      preset-goproxy: "true"
+    spec:
+      containers:
+      - image: quay.io/kubermatic-labs/boilerplate:v0.1.1
+        command:
+        - ./hack/verify-boilerplate.sh
+        resources:
+          requests:
+            memory: 256Mi
+            cpu: 100m
 
-  # - name: pre-kubermatic-prometheus-rules-validation
-  #   run_if_changed: "charts/monitoring"
-  #   decorate: true
-  #   clone_uri: "ssh://git@github.com/kubermatic/kubermatic.git"
-  #   labels:
-  #     preset-goproxy: "true"
-  #   spec:
-  #     containers:
-  #     - image: quay.io/kubermatic/util:1.4.0
-  #       command:
-  #       - ./hack/verify-prometheus-rules.sh
-  #       env:
-  #       - name: KUBERMATIC_EDITION
-  #         value: ee
-  #     imagePullSecrets:
-  #     - name: quay
+  - name: pre-kubermatic-prometheus-rules-validation
+    run_if_changed: "charts/monitoring"
+    decorate: true
+    clone_uri: "ssh://git@github.com/kubermatic/kubermatic.git"
+    labels:
+      preset-goproxy: "true"
+    spec:
+      containers:
+      - image: quay.io/kubermatic/util:1.4.0
+        command:
+        - ./hack/verify-prometheus-rules.sh
+        env:
+        - name: KUBERMATIC_EDITION
+          value: ee
+      imagePullSecrets:
+      - name: quay
 
-  # - name: pre-kubermatic-user-cluster-prometheus-config-validation
-  #   run_if_changed: "pkg/resources/prometheus"
-  #   decorate: true
-  #   clone_uri: "ssh://git@github.com/kubermatic/kubermatic.git"
-  #   labels:
-  #     preset-goproxy: "true"
-  #   spec:
-  #     containers:
-  #     - image: quay.io/kubermatic/promtool:2.7.0-3
-  #       command:
-  #       - "./hack/verify-user-cluster-prometheus-configs.sh"
-  #       env:
-  #       - name: KUBERMATIC_EDITION
-  #         value: ee
-  #     imagePullSecrets:
-  #     - name: quay
+  - name: pre-kubermatic-user-cluster-prometheus-config-validation
+    run_if_changed: "pkg/resources/prometheus"
+    decorate: true
+    clone_uri: "ssh://git@github.com/kubermatic/kubermatic.git"
+    labels:
+      preset-goproxy: "true"
+    spec:
+      containers:
+      - image: quay.io/kubermatic/promtool:2.7.0-3
+        command:
+        - "./hack/verify-user-cluster-prometheus-configs.sh"
+        env:
+        - name: KUBERMATIC_EDITION
+          value: ee
+      imagePullSecrets:
+      - name: quay
 
   #########################################################
   # Base Kubernetes Tests (AWS, CoreOS)
@@ -301,7 +301,7 @@ presubmits:
       preset-goproxy: "true"
     spec:
       containers:
-      - image: quay.io/kubermatic/e2e-kind:with-conformance-tests-v1.0.19-xrstf1
+      - image: quay.io/kubermatic/e2e-kind:with-conformance-tests-v1.0.19
         env:
         - name: KUBERMATIC_EDITION
           value: ee
@@ -342,7 +342,7 @@ presubmits:
       preset-goproxy: "true"
     spec:
       containers:
-      - image: quay.io/kubermatic/e2e-kind:with-conformance-tests-v1.0.19-xrstf1
+      - image: quay.io/kubermatic/e2e-kind:with-conformance-tests-v1.0.19
         env:
         - name: KUBERMATIC_EDITION
           value: ee
@@ -383,7 +383,7 @@ presubmits:
       preset-goproxy: "true"
     spec:
       containers:
-      - image: quay.io/kubermatic/e2e-kind:with-conformance-tests-v1.0.19-xrstf1
+      - image: quay.io/kubermatic/e2e-kind:with-conformance-tests-v1.0.19
         env:
         - name: KUBERMATIC_EDITION
           value: ee
@@ -424,7 +424,7 @@ presubmits:
       preset-goproxy: "true"
     spec:
       containers:
-      - image: quay.io/kubermatic/e2e-kind:with-conformance-tests-v1.0.19-xrstf1
+      - image: quay.io/kubermatic/e2e-kind:with-conformance-tests-v1.0.19
         env:
         - name: KUBERMATIC_EDITION
           value: ee
@@ -465,7 +465,7 @@ presubmits:
       preset-goproxy: "true"
     spec:
       containers:
-      - image: quay.io/kubermatic/e2e-kind:with-conformance-tests-v1.0.19-xrstf1
+      - image: quay.io/kubermatic/e2e-kind:with-conformance-tests-v1.0.19
         env:
         - name: KUBERMATIC_EDITION
           value: "ce"
@@ -508,7 +508,7 @@ presubmits:
       preset-goproxy: "true"
     spec:
       containers:
-      - image: quay.io/kubermatic/e2e-kind:with-conformance-tests-v1.0.19-xrstf1
+      - image: quay.io/kubermatic/e2e-kind:with-conformance-tests-v1.0.19
         env:
         - name: KUBERMATIC_EDITION
           value: "ee"
@@ -542,718 +542,718 @@ presubmits:
   # # Extended Kubernetes Tests (various cloud providers, OS)
   # #########################################################
 
-  # - name: pre-kubermatic-e2e-azure-ubuntu-1.19
-  #   decorate: true
-  #   optional: true
-  #   clone_uri: "ssh://git@github.com/kubermatic/kubermatic.git"
-  #   labels:
-  #     preset-azure: "true"
-  #     preset-vault: "true"
-  #     preset-docker-pull: "true"
-  #     preset-docker-push: "true"
-  #     preset-repo-ssh: "true"
-  #     preset-e2e-ssh: "true"
-  #     preset-kubeconfig-ci: "true"
-  #     preset-kind-volume-mounts: "true"
-  #     preset-goproxy: "true"
-  #   spec:
-  #     containers:
-  #     - image: quay.io/kubermatic/e2e-kind:with-conformance-tests-v1.0.19-xrstf1
-  #       env:
-  #       - name: KUBERMATIC_EDITION
-  #         value: ee
-  #       - name: VERSIONS_TO_TEST
-  #         value: "v1.19.0"
-  #       - name: EXCLUDE_DISTRIBUTIONS
-  #         value: "centos,coreos,flatcar,rhel"
-  #       - name: PROVIDER
-  #         value: "azure"
-  #       - name: DEFAULT_TIMEOUT_MINUTES
-  #         value: "20"
-  #       - name: SERVICE_ACCOUNT_KEY
-  #         valueFrom:
-  #           secretKeyRef:
-  #             name: e2e-ci
-  #             key: serviceAccountSigningKey
-  #       command:
-  #       - "./hack/ci/ci-kind-e2e.sh"
-  #       # docker-in-docker needs privileged mode
-  #       securityContext:
-  #         privileged: true
-  #       resources:
-  #         requests:
-  #           memory: 4Gi
-  #           cpu: 3.5
-  #         limits:
-  #           memory: 4Gi
+  - name: pre-kubermatic-e2e-azure-ubuntu-1.19
+    decorate: true
+    optional: true
+    clone_uri: "ssh://git@github.com/kubermatic/kubermatic.git"
+    labels:
+      preset-azure: "true"
+      preset-vault: "true"
+      preset-docker-pull: "true"
+      preset-docker-push: "true"
+      preset-repo-ssh: "true"
+      preset-e2e-ssh: "true"
+      preset-kubeconfig-ci: "true"
+      preset-kind-volume-mounts: "true"
+      preset-goproxy: "true"
+    spec:
+      containers:
+      - image: quay.io/kubermatic/e2e-kind:with-conformance-tests-v1.0.19
+        env:
+        - name: KUBERMATIC_EDITION
+          value: ee
+        - name: VERSIONS_TO_TEST
+          value: "v1.19.0"
+        - name: EXCLUDE_DISTRIBUTIONS
+          value: "centos,coreos,flatcar,rhel"
+        - name: PROVIDER
+          value: "azure"
+        - name: DEFAULT_TIMEOUT_MINUTES
+          value: "20"
+        - name: SERVICE_ACCOUNT_KEY
+          valueFrom:
+            secretKeyRef:
+              name: e2e-ci
+              key: serviceAccountSigningKey
+        command:
+        - "./hack/ci/ci-kind-e2e.sh"
+        # docker-in-docker needs privileged mode
+        securityContext:
+          privileged: true
+        resources:
+          requests:
+            memory: 4Gi
+            cpu: 3.5
+          limits:
+            memory: 4Gi
 
-  # - name: pre-kubermatic-e2e-gcp-ubuntu-1.19
-  #   decorate: true
-  #   always_run: false
-  #   optional: true
-  #   clone_uri: "ssh://git@github.com/kubermatic/kubermatic.git"
-  #   labels:
-  #     preset-gce: "true"
-  #     preset-vault: "true"
-  #     preset-docker-pull: "true"
-  #     preset-docker-push: "true"
-  #     preset-repo-ssh: "true"
-  #     preset-e2e-ssh: "true"
-  #     preset-kubeconfig-ci: "true"
-  #     preset-kind-volume-mounts: "true"
-  #     preset-goproxy: "true"
-  #   spec:
-  #     containers:
-  #     - image: quay.io/kubermatic/e2e-kind:with-conformance-tests-v1.0.19-xrstf1
-  #       env:
-  #       - name: KUBERMATIC_EDITION
-  #         value: ee
-  #       - name: VERSIONS_TO_TEST
-  #         value: "v1.19.0"
-  #       - name: PROVIDER
-  #         value: "gcp"
-  #       - name: EXCLUDE_DISTRIBUTIONS
-  #         value: "centos,coreos,flatcar,rhel"
-  #       - name: SERVICE_ACCOUNT_KEY
-  #         valueFrom:
-  #           secretKeyRef:
-  #             name: e2e-ci
-  #             key: serviceAccountSigningKey
-  #       command:
-  #       - "./hack/ci/ci-kind-e2e.sh"
-  #       # docker-in-docker needs privileged mode
-  #       securityContext:
-  #         privileged: true
-  #       resources:
-  #         requests:
-  #           memory: 4Gi
-  #           cpu: 3.5
-  #         limits:
-  #           memory: 4Gi
+  - name: pre-kubermatic-e2e-gcp-ubuntu-1.19
+    decorate: true
+    always_run: false
+    optional: true
+    clone_uri: "ssh://git@github.com/kubermatic/kubermatic.git"
+    labels:
+      preset-gce: "true"
+      preset-vault: "true"
+      preset-docker-pull: "true"
+      preset-docker-push: "true"
+      preset-repo-ssh: "true"
+      preset-e2e-ssh: "true"
+      preset-kubeconfig-ci: "true"
+      preset-kind-volume-mounts: "true"
+      preset-goproxy: "true"
+    spec:
+      containers:
+      - image: quay.io/kubermatic/e2e-kind:with-conformance-tests-v1.0.19
+        env:
+        - name: KUBERMATIC_EDITION
+          value: ee
+        - name: VERSIONS_TO_TEST
+          value: "v1.19.0"
+        - name: PROVIDER
+          value: "gcp"
+        - name: EXCLUDE_DISTRIBUTIONS
+          value: "centos,coreos,flatcar,rhel"
+        - name: SERVICE_ACCOUNT_KEY
+          valueFrom:
+            secretKeyRef:
+              name: e2e-ci
+              key: serviceAccountSigningKey
+        command:
+        - "./hack/ci/ci-kind-e2e.sh"
+        # docker-in-docker needs privileged mode
+        securityContext:
+          privileged: true
+        resources:
+          requests:
+            memory: 4Gi
+            cpu: 3.5
+          limits:
+            memory: 4Gi
 
-  # - name: pre-kubermatic-e2e-gcp-ubuntu-1.19-psp
-  #   decorate: true
-  #   optional: true
-  #   clone_uri: "ssh://git@github.com/kubermatic/kubermatic.git"
-  #   labels:
-  #     preset-gce: "true"
-  #     preset-vault: "true"
-  #     preset-docker-pull: "true"
-  #     preset-docker-push: "true"
-  #     preset-repo-ssh: "true"
-  #     preset-e2e-ssh: "true"
-  #     preset-kubeconfig-ci: "true"
-  #     preset-kind-volume-mounts: "true"
-  #     preset-goproxy: "true"
-  #   spec:
-  #     containers:
-  #     - image: quay.io/kubermatic/e2e-kind:with-conformance-tests-v1.0.19-xrstf1
-  #       env:
-  #       - name: KUBERMATIC_EDITION
-  #         value: ee
-  #       - name: VERSIONS_TO_TEST
-  #         value: "v1.19.0"
-  #       - name: PROVIDER
-  #         value: "gcp"
-  #       - name: EXCLUDE_DISTRIBUTIONS
-  #         value: "centos,coreos,flatcar,rhel"
-  #       - name: KUBERMATIC_PSP_ENABLED
-  #         value: "true"
-  #       - name: ONLY_TEST_CREATION
-  #         value: "true"
-  #       - name: SERVICE_ACCOUNT_KEY
-  #         valueFrom:
-  #           secretKeyRef:
-  #             name: e2e-ci
-  #             key: serviceAccountSigningKey
-  #       command:
-  #       - "./hack/ci/ci-kind-e2e.sh"
-  #       # docker-in-docker needs privileged mode
-  #       securityContext:
-  #         privileged: true
-  #       resources:
-  #         requests:
-  #           memory: 4Gi
-  #           cpu: 3.5
-  #         limits:
-  #           memory: 4Gi
+  - name: pre-kubermatic-e2e-gcp-ubuntu-1.19-psp
+    decorate: true
+    optional: true
+    clone_uri: "ssh://git@github.com/kubermatic/kubermatic.git"
+    labels:
+      preset-gce: "true"
+      preset-vault: "true"
+      preset-docker-pull: "true"
+      preset-docker-push: "true"
+      preset-repo-ssh: "true"
+      preset-e2e-ssh: "true"
+      preset-kubeconfig-ci: "true"
+      preset-kind-volume-mounts: "true"
+      preset-goproxy: "true"
+    spec:
+      containers:
+      - image: quay.io/kubermatic/e2e-kind:with-conformance-tests-v1.0.19
+        env:
+        - name: KUBERMATIC_EDITION
+          value: ee
+        - name: VERSIONS_TO_TEST
+          value: "v1.19.0"
+        - name: PROVIDER
+          value: "gcp"
+        - name: EXCLUDE_DISTRIBUTIONS
+          value: "centos,coreos,flatcar,rhel"
+        - name: KUBERMATIC_PSP_ENABLED
+          value: "true"
+        - name: ONLY_TEST_CREATION
+          value: "true"
+        - name: SERVICE_ACCOUNT_KEY
+          valueFrom:
+            secretKeyRef:
+              name: e2e-ci
+              key: serviceAccountSigningKey
+        command:
+        - "./hack/ci/ci-kind-e2e.sh"
+        # docker-in-docker needs privileged mode
+        securityContext:
+          privileged: true
+        resources:
+          requests:
+            memory: 4Gi
+            cpu: 3.5
+          limits:
+            memory: 4Gi
 
-  # - name: pre-kubermatic-e2e-do-centos-1.19
-  #   decorate: true
-  #   always_run: false
-  #   optional: true
-  #   clone_uri: "ssh://git@github.com/kubermatic/kubermatic.git"
-  #   labels:
-  #     preset-digitalocean: "true"
-  #     preset-vault: "true"
-  #     preset-docker-pull: "true"
-  #     preset-docker-push: "true"
-  #     preset-repo-ssh: "true"
-  #     preset-e2e-ssh: "true"
-  #     preset-kubeconfig-ci: "true"
-  #     preset-kind-volume-mounts: "true"
-  #     preset-goproxy: "true"
-  #   spec:
-  #     containers:
-  #     - image: quay.io/kubermatic/e2e-kind:with-conformance-tests-v1.0.19-xrstf1
-  #       env:
-  #       - name: KUBERMATIC_EDITION
-  #         value: ee
-  #       - name: VERSIONS_TO_TEST
-  #         value: "v1.19.0"
-  #       - name: EXCLUDE_DISTRIBUTIONS
-  #         value: "ubuntu,coreos,flatcar,rhel"
-  #       - name: PROVIDER
-  #         value: "digitalocean"
-  #       - name: SERVICE_ACCOUNT_KEY
-  #         valueFrom:
-  #           secretKeyRef:
-  #             name: e2e-ci
-  #             key: serviceAccountSigningKey
-  #       command:
-  #       - "./hack/ci/ci-kind-e2e.sh"
-  #       # docker-in-docker needs privileged mode
-  #       securityContext:
-  #         privileged: true
-  #       resources:
-  #         requests:
-  #           memory: 4Gi
-  #           cpu: 3.5
-  #         limits:
-  #           memory: 4Gi
+  - name: pre-kubermatic-e2e-do-centos-1.19
+    decorate: true
+    always_run: false
+    optional: true
+    clone_uri: "ssh://git@github.com/kubermatic/kubermatic.git"
+    labels:
+      preset-digitalocean: "true"
+      preset-vault: "true"
+      preset-docker-pull: "true"
+      preset-docker-push: "true"
+      preset-repo-ssh: "true"
+      preset-e2e-ssh: "true"
+      preset-kubeconfig-ci: "true"
+      preset-kind-volume-mounts: "true"
+      preset-goproxy: "true"
+    spec:
+      containers:
+      - image: quay.io/kubermatic/e2e-kind:with-conformance-tests-v1.0.19
+        env:
+        - name: KUBERMATIC_EDITION
+          value: ee
+        - name: VERSIONS_TO_TEST
+          value: "v1.19.0"
+        - name: EXCLUDE_DISTRIBUTIONS
+          value: "ubuntu,coreos,flatcar,rhel"
+        - name: PROVIDER
+          value: "digitalocean"
+        - name: SERVICE_ACCOUNT_KEY
+          valueFrom:
+            secretKeyRef:
+              name: e2e-ci
+              key: serviceAccountSigningKey
+        command:
+        - "./hack/ci/ci-kind-e2e.sh"
+        # docker-in-docker needs privileged mode
+        securityContext:
+          privileged: true
+        resources:
+          requests:
+            memory: 4Gi
+            cpu: 3.5
+          limits:
+            memory: 4Gi
 
-  # - name: pre-kubermatic-e2e-packet-ubuntu-1.19
-  #   decorate: true
-  #   optional: true
-  #   clone_uri: "ssh://git@github.com/kubermatic/kubermatic.git"
-  #   labels:
-  #     preset-packet: "true"
-  #     preset-vault: "true"
-  #     preset-docker-pull: "true"
-  #     preset-docker-push: "true"
-  #     preset-repo-ssh: "true"
-  #     preset-e2e-ssh: "true"
-  #     preset-kubeconfig-ci: "true"
-  #     preset-kind-volume-mounts: "true"
-  #     preset-goproxy: "true"
-  #   spec:
-  #     containers:
-  #     - image: quay.io/kubermatic/e2e-kind:with-conformance-tests-v1.0.19-xrstf1
-  #       env:
-  #       - name: KUBERMATIC_EDITION
-  #         value: ee
-  #       - name: VERSIONS_TO_TEST
-  #         value: "v1.19.0"
-  #       - name: PROVIDER
-  #         value: "packet"
-  #       - name: EXCLUDE_DISTRIBUTIONS
-  #         value: "centos,coreos,flatcar,rhel"
-  #       - name: SERVICE_ACCOUNT_KEY
-  #         valueFrom:
-  #           secretKeyRef:
-  #             name: e2e-ci
-  #             key: serviceAccountSigningKey
-  #       command:
-  #       - "./hack/ci/ci-kind-e2e.sh"
-  #       # docker-in-docker needs privileged mode
-  #       securityContext:
-  #         privileged: true
-  #       resources:
-  #         requests:
-  #           memory: 4Gi
-  #           cpu: 3.5
-  #         limits:
-  #           memory: 4Gi
+  - name: pre-kubermatic-e2e-packet-ubuntu-1.19
+    decorate: true
+    optional: true
+    clone_uri: "ssh://git@github.com/kubermatic/kubermatic.git"
+    labels:
+      preset-packet: "true"
+      preset-vault: "true"
+      preset-docker-pull: "true"
+      preset-docker-push: "true"
+      preset-repo-ssh: "true"
+      preset-e2e-ssh: "true"
+      preset-kubeconfig-ci: "true"
+      preset-kind-volume-mounts: "true"
+      preset-goproxy: "true"
+    spec:
+      containers:
+      - image: quay.io/kubermatic/e2e-kind:with-conformance-tests-v1.0.19
+        env:
+        - name: KUBERMATIC_EDITION
+          value: ee
+        - name: VERSIONS_TO_TEST
+          value: "v1.19.0"
+        - name: PROVIDER
+          value: "packet"
+        - name: EXCLUDE_DISTRIBUTIONS
+          value: "centos,coreos,flatcar,rhel"
+        - name: SERVICE_ACCOUNT_KEY
+          valueFrom:
+            secretKeyRef:
+              name: e2e-ci
+              key: serviceAccountSigningKey
+        command:
+        - "./hack/ci/ci-kind-e2e.sh"
+        # docker-in-docker needs privileged mode
+        securityContext:
+          privileged: true
+        resources:
+          requests:
+            memory: 4Gi
+            cpu: 3.5
+          limits:
+            memory: 4Gi
 
-  # - name: pre-kubermatic-e2e-kubevirt-centos-1.19
-  #   decorate: true
-  #   optional: true
-  #   clone_uri: "ssh://git@github.com/kubermatic/kubermatic.git"
-  #   labels:
-  #     preset-kubevirt: "true"
-  #     preset-vault: "true"
-  #     preset-docker-pull: "true"
-  #     preset-docker-push: "true"
-  #     preset-repo-ssh: "true"
-  #     preset-e2e-ssh: "true"
-  #     preset-kubeconfig-ci: "true"
-  #     preset-kind-volume-mounts: "true"
-  #     preset-goproxy: "true"
-  #   spec:
-  #     containers:
-  #     - image: quay.io/kubermatic/e2e-kind:with-conformance-tests-v1.0.19-xrstf1
-  #       env:
-  #       - name: KUBERMATIC_EDITION
-  #         value: ee
-  #       - name: VERSIONS_TO_TEST
-  #         value: "v1.19.0"
-  #       - name: PROVIDER
-  #         value: "kubevirt"
-  #       - name: EXCLUDE_DISTRIBUTIONS
-  #         value: "ubuntu,coreos,flatcar,rhel"
-  #       - name: SERVICE_ACCOUNT_KEY
-  #         valueFrom:
-  #           secretKeyRef:
-  #             name: e2e-ci
-  #             key: serviceAccountSigningKey
-  #       command:
-  #       - "./hack/ci/ci-kind-e2e.sh"
-  #       # docker-in-docker needs privileged mode
-  #       securityContext:
-  #         privileged: true
-  #       resources:
-  #         requests:
-  #           memory: 4Gi
-  #           cpu: 3.5
-  #         limits:
-  #           memory: 4Gi
+  - name: pre-kubermatic-e2e-kubevirt-centos-1.19
+    decorate: true
+    optional: true
+    clone_uri: "ssh://git@github.com/kubermatic/kubermatic.git"
+    labels:
+      preset-kubevirt: "true"
+      preset-vault: "true"
+      preset-docker-pull: "true"
+      preset-docker-push: "true"
+      preset-repo-ssh: "true"
+      preset-e2e-ssh: "true"
+      preset-kubeconfig-ci: "true"
+      preset-kind-volume-mounts: "true"
+      preset-goproxy: "true"
+    spec:
+      containers:
+      - image: quay.io/kubermatic/e2e-kind:with-conformance-tests-v1.0.19
+        env:
+        - name: KUBERMATIC_EDITION
+          value: ee
+        - name: VERSIONS_TO_TEST
+          value: "v1.19.0"
+        - name: PROVIDER
+          value: "kubevirt"
+        - name: EXCLUDE_DISTRIBUTIONS
+          value: "ubuntu,coreos,flatcar,rhel"
+        - name: SERVICE_ACCOUNT_KEY
+          valueFrom:
+            secretKeyRef:
+              name: e2e-ci
+              key: serviceAccountSigningKey
+        command:
+        - "./hack/ci/ci-kind-e2e.sh"
+        # docker-in-docker needs privileged mode
+        securityContext:
+          privileged: true
+        resources:
+          requests:
+            memory: 4Gi
+            cpu: 3.5
+          limits:
+            memory: 4Gi
 
-  # - name: pre-kubermatic-e2e-hetzner-ubuntu-1.19
-  #   decorate: true
-  #   optional: true
-  #   clone_uri: "ssh://git@github.com/kubermatic/kubermatic.git"
-  #   labels:
-  #     preset-hetzner: "true"
-  #     preset-vault: "true"
-  #     preset-docker-pull: "true"
-  #     preset-docker-push: "true"
-  #     preset-repo-ssh: "true"
-  #     preset-e2e-ssh: "true"
-  #     preset-kubeconfig-ci: "true"
-  #     preset-kind-volume-mounts: "true"
-  #     preset-goproxy: "true"
-  #   spec:
-  #     containers:
-  #     - image: quay.io/kubermatic/e2e-kind:with-conformance-tests-v1.0.19-xrstf1
-  #       env:
-  #       - name: KUBERMATIC_EDITION
-  #         value: ee
-  #       - name: VERSIONS_TO_TEST
-  #         value: "v1.19.0"
-  #       - name: PROVIDER
-  #         value: "hetzner"
-  #       # Hetzner doesn't support coreos
-  #       - name: EXCLUDE_DISTRIBUTIONS
-  #         value: "centos,coreos,flatcar,rhel"
-  #       - name: DEFAULT_TIMEOUT_MINUTES
-  #         value: "20"
-  #       - name: SERVICE_ACCOUNT_KEY
-  #         valueFrom:
-  #           secretKeyRef:
-  #             name: e2e-ci
-  #             key: serviceAccountSigningKey
-  #       command:
-  #       - "./hack/ci/ci-kind-e2e.sh"
-  #       # docker-in-docker needs privileged mode
-  #       securityContext:
-  #         privileged: true
-  #       resources:
-  #         requests:
-  #           memory: 4Gi
-  #           cpu: 3.5
-  #         limits:
-  #           memory: 4Gi
+  - name: pre-kubermatic-e2e-hetzner-ubuntu-1.19
+    decorate: true
+    optional: true
+    clone_uri: "ssh://git@github.com/kubermatic/kubermatic.git"
+    labels:
+      preset-hetzner: "true"
+      preset-vault: "true"
+      preset-docker-pull: "true"
+      preset-docker-push: "true"
+      preset-repo-ssh: "true"
+      preset-e2e-ssh: "true"
+      preset-kubeconfig-ci: "true"
+      preset-kind-volume-mounts: "true"
+      preset-goproxy: "true"
+    spec:
+      containers:
+      - image: quay.io/kubermatic/e2e-kind:with-conformance-tests-v1.0.19
+        env:
+        - name: KUBERMATIC_EDITION
+          value: ee
+        - name: VERSIONS_TO_TEST
+          value: "v1.19.0"
+        - name: PROVIDER
+          value: "hetzner"
+        # Hetzner doesn't support coreos
+        - name: EXCLUDE_DISTRIBUTIONS
+          value: "centos,coreos,flatcar,rhel"
+        - name: DEFAULT_TIMEOUT_MINUTES
+          value: "20"
+        - name: SERVICE_ACCOUNT_KEY
+          valueFrom:
+            secretKeyRef:
+              name: e2e-ci
+              key: serviceAccountSigningKey
+        command:
+        - "./hack/ci/ci-kind-e2e.sh"
+        # docker-in-docker needs privileged mode
+        securityContext:
+          privileged: true
+        resources:
+          requests:
+            memory: 4Gi
+            cpu: 3.5
+          limits:
+            memory: 4Gi
 
-  # - name: pre-kubermatic-e2e-openstack-ubuntu-1.19
-  #   decorate: true
-  #   optional: true
-  #   clone_uri: "ssh://git@github.com/kubermatic/kubermatic.git"
-  #   labels:
-  #     preset-openstack: "true"
-  #     preset-vault: "true"
-  #     preset-docker-pull: "true"
-  #     preset-docker-push: "true"
-  #     preset-repo-ssh: "true"
-  #     preset-e2e-ssh: "true"
-  #     preset-kubeconfig-ci: "true"
-  #     preset-kind-volume-mounts: "true"
-  #     preset-goproxy: "true"
-  #   spec:
-  #     containers:
-  #     - image: quay.io/kubermatic/e2e-kind:with-conformance-tests-v1.0.19-xrstf1
-  #       env:
-  #       - name: KUBERMATIC_EDITION
-  #         value: ee
-  #       - name: VERSIONS_TO_TEST
-  #         value: "v1.19.0"
-  #       - name: PROVIDER
-  #         value: "openstack"
-  #       - name: EXCLUDE_DISTRIBUTIONS
-  #         value: "centos,coreos,flatcar,rhel"
-  #       - name: DEFAULT_TIMEOUT_MINUTES
-  #         value: "20"
-  #       - name: SERVICE_ACCOUNT_KEY
-  #         valueFrom:
-  #           secretKeyRef:
-  #             name: e2e-ci
-  #             key: serviceAccountSigningKey
-  #       command:
-  #       - "./hack/ci/ci-kind-e2e.sh"
-  #       # docker-in-docker needs privileged mode
-  #       securityContext:
-  #         privileged: true
-  #       resources:
-  #         requests:
-  #           memory: 4Gi
-  #           cpu: 3.5
-  #         limits:
-  #           memory: 4Gi
+  - name: pre-kubermatic-e2e-openstack-ubuntu-1.19
+    decorate: true
+    optional: true
+    clone_uri: "ssh://git@github.com/kubermatic/kubermatic.git"
+    labels:
+      preset-openstack: "true"
+      preset-vault: "true"
+      preset-docker-pull: "true"
+      preset-docker-push: "true"
+      preset-repo-ssh: "true"
+      preset-e2e-ssh: "true"
+      preset-kubeconfig-ci: "true"
+      preset-kind-volume-mounts: "true"
+      preset-goproxy: "true"
+    spec:
+      containers:
+      - image: quay.io/kubermatic/e2e-kind:with-conformance-tests-v1.0.19
+        env:
+        - name: KUBERMATIC_EDITION
+          value: ee
+        - name: VERSIONS_TO_TEST
+          value: "v1.19.0"
+        - name: PROVIDER
+          value: "openstack"
+        - name: EXCLUDE_DISTRIBUTIONS
+          value: "centos,coreos,flatcar,rhel"
+        - name: DEFAULT_TIMEOUT_MINUTES
+          value: "20"
+        - name: SERVICE_ACCOUNT_KEY
+          valueFrom:
+            secretKeyRef:
+              name: e2e-ci
+              key: serviceAccountSigningKey
+        command:
+        - "./hack/ci/ci-kind-e2e.sh"
+        # docker-in-docker needs privileged mode
+        securityContext:
+          privileged: true
+        resources:
+          requests:
+            memory: 4Gi
+            cpu: 3.5
+          limits:
+            memory: 4Gi
 
-  # - name: pre-kubermatic-e2e-openstack-centos-1.19
-  #   decorate: true
-  #   optional: true
-  #   clone_uri: "ssh://git@github.com/kubermatic/kubermatic.git"
-  #   labels:
-  #     preset-openstack: "true"
-  #     preset-vault: "true"
-  #     preset-docker-pull: "true"
-  #     preset-docker-push: "true"
-  #     preset-repo-ssh: "true"
-  #     preset-e2e-ssh: "true"
-  #     preset-kubeconfig-ci: "true"
-  #     preset-kind-volume-mounts: "true"
-  #     preset-goproxy: "true"
-  #   spec:
-  #     containers:
-  #     - image: quay.io/kubermatic/e2e-kind:with-conformance-tests-v1.0.19-xrstf1
-  #       env:
-  #       - name: KUBERMATIC_EDITION
-  #         value: ee
-  #       - name: VERSIONS_TO_TEST
-  #         value: "v1.19.0"
-  #       - name: PROVIDER
-  #         value: "openstack"
-  #       - name: DEFAULT_TIMEOUT_MINUTES
-  #         value: "20"
-  #       - name: EXCLUDE_DISTRIBUTIONS
-  #         value: "coreos,ubuntu,flatcar,rhel"
-  #       - name: SERVICE_ACCOUNT_KEY
-  #         valueFrom:
-  #           secretKeyRef:
-  #             name: e2e-ci
-  #             key: serviceAccountSigningKey
-  #       command:
-  #       - "./hack/ci/ci-kind-e2e.sh"
-  #       # docker-in-docker needs privileged mode
-  #       securityContext:
-  #         privileged: true
-  #       resources:
-  #         requests:
-  #           memory: 4Gi
-  #           cpu: 3.5
-  #         limits:
-  #           memory: 4Gi
+  - name: pre-kubermatic-e2e-openstack-centos-1.19
+    decorate: true
+    optional: true
+    clone_uri: "ssh://git@github.com/kubermatic/kubermatic.git"
+    labels:
+      preset-openstack: "true"
+      preset-vault: "true"
+      preset-docker-pull: "true"
+      preset-docker-push: "true"
+      preset-repo-ssh: "true"
+      preset-e2e-ssh: "true"
+      preset-kubeconfig-ci: "true"
+      preset-kind-volume-mounts: "true"
+      preset-goproxy: "true"
+    spec:
+      containers:
+      - image: quay.io/kubermatic/e2e-kind:with-conformance-tests-v1.0.19
+        env:
+        - name: KUBERMATIC_EDITION
+          value: ee
+        - name: VERSIONS_TO_TEST
+          value: "v1.19.0"
+        - name: PROVIDER
+          value: "openstack"
+        - name: DEFAULT_TIMEOUT_MINUTES
+          value: "20"
+        - name: EXCLUDE_DISTRIBUTIONS
+          value: "coreos,ubuntu,flatcar,rhel"
+        - name: SERVICE_ACCOUNT_KEY
+          valueFrom:
+            secretKeyRef:
+              name: e2e-ci
+              key: serviceAccountSigningKey
+        command:
+        - "./hack/ci/ci-kind-e2e.sh"
+        # docker-in-docker needs privileged mode
+        securityContext:
+          privileged: true
+        resources:
+          requests:
+            memory: 4Gi
+            cpu: 3.5
+          limits:
+            memory: 4Gi
 
-  # - name: pre-kubermatic-e2e-vsphere-ubuntu-1.19
-  #   decorate: true
-  #   run_if_changed: "pkg/provider/cloud/vsphere"
-  #   clone_uri: "ssh://git@github.com/kubermatic/kubermatic.git"
-  #   labels:
-  #     preset-vsphere: "true"
-  #     preset-vault: "true"
-  #     preset-docker-pull: "true"
-  #     preset-docker-push: "true"
-  #     preset-repo-ssh: "true"
-  #     preset-e2e-ssh: "true"
-  #     preset-kubeconfig-ci: "true"
-  #     preset-kind-volume-mounts: "true"
-  #     preset-goproxy: "true"
-  #   spec:
-  #     containers:
-  #     - image: quay.io/kubermatic/e2e-kind:with-conformance-tests-v1.0.19-xrstf1
-  #       env:
-  #       - name: KUBERMATIC_EDITION
-  #         value: ee
-  #       - name: VERSIONS_TO_TEST
-  #         value: "v1.19.0"
-  #       - name: PROVIDER
-  #         value: "vsphere"
-  #       - name: EXCLUDE_DISTRIBUTIONS
-  #         value: "centos,coreos,flatcar,rhel"
-  #       - name: SERVICE_ACCOUNT_KEY
-  #         valueFrom:
-  #           secretKeyRef:
-  #             name: e2e-ci
-  #             key: serviceAccountSigningKey
-  #       command:
-  #       - "./hack/ci/ci-kind-e2e.sh"
-  #       # docker-in-docker needs privileged mode
-  #       securityContext:
-  #         privileged: true
-  #       resources:
-  #         requests:
-  #           memory: 4Gi
-  #           cpu: 3.5
-  #         limits:
-  #           memory: 4Gi
+  - name: pre-kubermatic-e2e-vsphere-ubuntu-1.19
+    decorate: true
+    run_if_changed: "pkg/provider/cloud/vsphere"
+    clone_uri: "ssh://git@github.com/kubermatic/kubermatic.git"
+    labels:
+      preset-vsphere: "true"
+      preset-vault: "true"
+      preset-docker-pull: "true"
+      preset-docker-push: "true"
+      preset-repo-ssh: "true"
+      preset-e2e-ssh: "true"
+      preset-kubeconfig-ci: "true"
+      preset-kind-volume-mounts: "true"
+      preset-goproxy: "true"
+    spec:
+      containers:
+      - image: quay.io/kubermatic/e2e-kind:with-conformance-tests-v1.0.19
+        env:
+        - name: KUBERMATIC_EDITION
+          value: ee
+        - name: VERSIONS_TO_TEST
+          value: "v1.19.0"
+        - name: PROVIDER
+          value: "vsphere"
+        - name: EXCLUDE_DISTRIBUTIONS
+          value: "centos,coreos,flatcar,rhel"
+        - name: SERVICE_ACCOUNT_KEY
+          valueFrom:
+            secretKeyRef:
+              name: e2e-ci
+              key: serviceAccountSigningKey
+        command:
+        - "./hack/ci/ci-kind-e2e.sh"
+        # docker-in-docker needs privileged mode
+        securityContext:
+          privileged: true
+        resources:
+          requests:
+            memory: 4Gi
+            cpu: 3.5
+          limits:
+            memory: 4Gi
 
-  # - name: pre-kubermatic-e2e-vsphere-ubuntu-1.19-customfolder
-  #   decorate: true
-  #   optional: true
-  #   run_if_changed: "pkg/provider/cloud/vsphere"
-  #   clone_uri: "ssh://git@github.com/kubermatic/kubermatic.git"
-  #   labels:
-  #     preset-vsphere: "true"
-  #     preset-vault: "true"
-  #     preset-docker-pull: "true"
-  #     preset-docker-push: "true"
-  #     preset-repo-ssh: "true"
-  #     preset-e2e-ssh: "true"
-  #     preset-kubeconfig-ci: "true"
-  #     preset-kind-volume-mounts: "true"
-  #     preset-goproxy: "true"
-  #   spec:
-  #     containers:
-  #     - image: quay.io/kubermatic/e2e-kind:with-conformance-tests-v1.0.19-xrstf1
-  #       env:
-  #       - name: KUBERMATIC_EDITION
-  #         value: ee
-  #       - name: VERSIONS_TO_TEST
-  #         value: "v1.19.0"
-  #       - name: PROVIDER
-  #         value: "vsphere"
-  #       - name: EXCLUDE_DISTRIBUTIONS
-  #         value: "centos,coreos,flatcar,rhel"
-  #       - name: SCENARIO_OPTIONS
-  #         value: "custom-folder"
-  #       - name: SERVICE_ACCOUNT_KEY
-  #         valueFrom:
-  #           secretKeyRef:
-  #             name: e2e-ci
-  #             key: serviceAccountSigningKey
-  #       command:
-  #       - "./hack/ci/ci-kind-e2e.sh"
-  #       # docker-in-docker needs privileged mode
-  #       securityContext:
-  #         privileged: true
-  #       resources:
-  #         requests:
-  #           memory: 4Gi
-  #           cpu: 3.5
-  #         limits:
-  #           memory: 4Gi
+  - name: pre-kubermatic-e2e-vsphere-ubuntu-1.19-customfolder
+    decorate: true
+    optional: true
+    run_if_changed: "pkg/provider/cloud/vsphere"
+    clone_uri: "ssh://git@github.com/kubermatic/kubermatic.git"
+    labels:
+      preset-vsphere: "true"
+      preset-vault: "true"
+      preset-docker-pull: "true"
+      preset-docker-push: "true"
+      preset-repo-ssh: "true"
+      preset-e2e-ssh: "true"
+      preset-kubeconfig-ci: "true"
+      preset-kind-volume-mounts: "true"
+      preset-goproxy: "true"
+    spec:
+      containers:
+      - image: quay.io/kubermatic/e2e-kind:with-conformance-tests-v1.0.19
+        env:
+        - name: KUBERMATIC_EDITION
+          value: ee
+        - name: VERSIONS_TO_TEST
+          value: "v1.19.0"
+        - name: PROVIDER
+          value: "vsphere"
+        - name: EXCLUDE_DISTRIBUTIONS
+          value: "centos,coreos,flatcar,rhel"
+        - name: SCENARIO_OPTIONS
+          value: "custom-folder"
+        - name: SERVICE_ACCOUNT_KEY
+          valueFrom:
+            secretKeyRef:
+              name: e2e-ci
+              key: serviceAccountSigningKey
+        command:
+        - "./hack/ci/ci-kind-e2e.sh"
+        # docker-in-docker needs privileged mode
+        securityContext:
+          privileged: true
+        resources:
+          requests:
+            memory: 4Gi
+            cpu: 3.5
+          limits:
+            memory: 4Gi
 
-  # - name: pre-kubermatic-e2e-vsphere-ubuntu-1.19-datastore-cluster
-  #   decorate: true
-  #   optional: true
-  #   run_if_changed: "pkg/provider/cloud/vsphere"
-  #   clone_uri: "ssh://git@github.com/kubermatic/kubermatic.git"
-  #   labels:
-  #     preset-vsphere: "true"
-  #     preset-vault: "true"
-  #     preset-docker-pull: "true"
-  #     preset-docker-push: "true"
-  #     preset-repo-ssh: "true"
-  #     preset-e2e-ssh: "true"
-  #     preset-kubeconfig-ci: "true"
-  #     preset-kind-volume-mounts: "true"
-  #     preset-goproxy: "true"
-  #   spec:
-  #     containers:
-  #       - image: quay.io/kubermatic/e2e-kind:with-conformance-tests-v1.0.19-xrstf1
-  #         env:
-  #           - name: KUBERMATIC_EDITION
-  #             value: ee
-  #           - name: VERSIONS_TO_TEST
-  #             value: "v1.19.0"
-  #           - name: PROVIDER
-  #             value: "vsphere"
-  #           - name: SCENARIO_OPTIONS
-  #             value: "datastore-cluster"
-  #           - name: SERVICE_ACCOUNT_KEY
-  #             valueFrom:
-  #               secretKeyRef:
-  #                 name: e2e-ci
-  #                 key: serviceAccountSigningKey
-  #         command:
-  #           - "./hack/ci/ci-kind-e2e.sh"
-  #         # docker-in-docker needs privileged mode
-  #         securityContext:
-  #           privileged: true
-  #         resources:
-  #           requests:
-  #             memory: 4Gi
-  #             cpu: 3.5
-  #           limits:
-  #             memory: 4Gi
+  - name: pre-kubermatic-e2e-vsphere-ubuntu-1.19-datastore-cluster
+    decorate: true
+    optional: true
+    run_if_changed: "pkg/provider/cloud/vsphere"
+    clone_uri: "ssh://git@github.com/kubermatic/kubermatic.git"
+    labels:
+      preset-vsphere: "true"
+      preset-vault: "true"
+      preset-docker-pull: "true"
+      preset-docker-push: "true"
+      preset-repo-ssh: "true"
+      preset-e2e-ssh: "true"
+      preset-kubeconfig-ci: "true"
+      preset-kind-volume-mounts: "true"
+      preset-goproxy: "true"
+    spec:
+      containers:
+        - image: quay.io/kubermatic/e2e-kind:with-conformance-tests-v1.0.19
+          env:
+            - name: KUBERMATIC_EDITION
+              value: ee
+            - name: VERSIONS_TO_TEST
+              value: "v1.19.0"
+            - name: PROVIDER
+              value: "vsphere"
+            - name: SCENARIO_OPTIONS
+              value: "datastore-cluster"
+            - name: SERVICE_ACCOUNT_KEY
+              valueFrom:
+                secretKeyRef:
+                  name: e2e-ci
+                  key: serviceAccountSigningKey
+          command:
+            - "./hack/ci/ci-kind-e2e.sh"
+          # docker-in-docker needs privileged mode
+          securityContext:
+            privileged: true
+          resources:
+            requests:
+              memory: 4Gi
+              cpu: 3.5
+            limits:
+              memory: 4Gi
 
-  # #########################################################
-  # # Base Openshift Tests
-  # #########################################################
+  #########################################################
+  # Base Openshift Tests
+  #########################################################
 
-  # - name: pre-kubermatic-e2e-aws-openshift-4.1
-  #   decorate: true
-  #   optional: true
-  #   run_if_changed: "openshift_addons/"
-  #   clone_uri: "ssh://git@github.com/kubermatic/kubermatic.git"
-  #   labels:
-  #     preset-aws: "true"
-  #     preset-openshift-pull-secret: "true"
-  #     preset-vault: "true"
-  #     preset-docker-push: "true"
-  #     preset-docker-pull: "true"
-  #     preset-oidc: "true"
-  #     preset-repo-ssh: "true"
-  #     preset-e2e-ssh: "true"
-  #     preset-kubeconfig-ci: "true"
-  #     preset-kind-volume-mounts: "true"
-  #     preset-goproxy: "true"
-  #   spec:
-  #     containers:
-  #     - image: quay.io/kubermatic/e2e-kind:with-conformance-tests-v1.0.19-xrstf1
-  #       env:
-  #       - name: KUBERMATIC_EDITION
-  #         value: ee
-  #       - name: OPENSHIFT
-  #         value: "true"
-  #       - name: OPENSHIFT_VERSION
-  #         value: "4.1.18"
-  #       - name: SERVICE_ACCOUNT_KEY
-  #         valueFrom:
-  #           secretKeyRef:
-  #             name: e2e-ci
-  #             key: serviceAccountSigningKey
-  #       command:
-  #       - "./hack/ci/ci-kind-e2e.sh"
-  #       # docker-in-docker needs privileged mode
-  #       securityContext:
-  #         privileged: true
-  #       resources:
-  #         requests:
-  #           memory: 4Gi
-  #           cpu: 3.5
-  #         limits:
-  #           memory: 4Gi
+  - name: pre-kubermatic-e2e-aws-openshift-4.1
+    decorate: true
+    optional: true
+    run_if_changed: "openshift_addons/"
+    clone_uri: "ssh://git@github.com/kubermatic/kubermatic.git"
+    labels:
+      preset-aws: "true"
+      preset-openshift-pull-secret: "true"
+      preset-vault: "true"
+      preset-docker-push: "true"
+      preset-docker-pull: "true"
+      preset-oidc: "true"
+      preset-repo-ssh: "true"
+      preset-e2e-ssh: "true"
+      preset-kubeconfig-ci: "true"
+      preset-kind-volume-mounts: "true"
+      preset-goproxy: "true"
+    spec:
+      containers:
+      - image: quay.io/kubermatic/e2e-kind:with-conformance-tests-v1.0.19
+        env:
+        - name: KUBERMATIC_EDITION
+          value: ee
+        - name: OPENSHIFT
+          value: "true"
+        - name: OPENSHIFT_VERSION
+          value: "4.1.18"
+        - name: SERVICE_ACCOUNT_KEY
+          valueFrom:
+            secretKeyRef:
+              name: e2e-ci
+              key: serviceAccountSigningKey
+        command:
+        - "./hack/ci/ci-kind-e2e.sh"
+        # docker-in-docker needs privileged mode
+        securityContext:
+          privileged: true
+        resources:
+          requests:
+            memory: 4Gi
+            cpu: 3.5
+          limits:
+            memory: 4Gi
 
-  # #########################################################
-  # # REST API e2e tests
-  # #########################################################
+  #########################################################
+  # REST API e2e tests
+  #########################################################
 
-  # - name: pre-kubermatic-api-e2e
-  #   run_if_changed: "(cmd/|codegen/|hack/|pkg/|charts/kubermatic|.prow.yaml)"
-  #   decorate: true
-  #   clone_uri: "ssh://git@github.com/kubermatic/kubermatic.git"
-  #   labels:
-  #     preset-digitalocean: "true"
-  #     preset-openstack: "true"
-  #     preset-azure: "true"
-  #     preset-kubeconfig-ci: "true"
-  #     preset-docker-pull: "true"
-  #     preset-docker-push: "true"
-  #     preset-gce: "true"
-  #     preset-kind-volume-mounts: "true"
-  #     preset-vault: "true"
-  #     preset-goproxy: "true"
-  #   spec:
-  #     containers:
-  #     - image: quay.io/kubermatic/e2e-kind:with-conformance-tests-v1.0.19-xrstf1
-  #       imagePullPolicy: Always
-  #       command:
-  #       - "./hack/ci/ci_run_api_e2e.sh"
-  #       securityContext:
-  #         privileged: true
-  #       resources:
-  #         requests:
-  #           memory: 4Gi
-  #           cpu: 2
-  #         limits:
-  #           memory: 6Gi
-  #       env:
-  #       - name: KUBERMATIC_EDITION
-  #         value: ee
-  #       - name: SERVICE_ACCOUNT_KEY
-  #         valueFrom:
-  #           secretKeyRef:
-  #             name: e2e-ci
-  #             key: serviceAccountSigningKey
+  - name: pre-kubermatic-api-e2e
+    run_if_changed: "(cmd/|codegen/|hack/|pkg/|charts/kubermatic|.prow.yaml)"
+    decorate: true
+    clone_uri: "ssh://git@github.com/kubermatic/kubermatic.git"
+    labels:
+      preset-digitalocean: "true"
+      preset-openstack: "true"
+      preset-azure: "true"
+      preset-kubeconfig-ci: "true"
+      preset-docker-pull: "true"
+      preset-docker-push: "true"
+      preset-gce: "true"
+      preset-kind-volume-mounts: "true"
+      preset-vault: "true"
+      preset-goproxy: "true"
+    spec:
+      containers:
+      - image: quay.io/kubermatic/e2e-kind:with-conformance-tests-v1.0.19
+        imagePullPolicy: Always
+        command:
+        - "./hack/ci/ci_run_api_e2e.sh"
+        securityContext:
+          privileged: true
+        resources:
+          requests:
+            memory: 4Gi
+            cpu: 2
+          limits:
+            memory: 6Gi
+        env:
+        - name: KUBERMATIC_EDITION
+          value: ee
+        - name: SERVICE_ACCOUNT_KEY
+          valueFrom:
+            secretKeyRef:
+              name: e2e-ci
+              key: serviceAccountSigningKey
 
-  # #########################################################
-  # # misc
-  # #########################################################
+  #########################################################
+  # misc
+  #########################################################
 
-  # - name: pre-kubermatic-e2e-gcp-offline
-  #   decorate: true
-  #   clone_uri: "ssh://git@github.com/kubermatic/kubermatic.git"
-  #   labels:
-  #     preset-gce: "true"
-  #     preset-vault: "true"
-  #     preset-docker-push: "true"
-  #     preset-repo-ssh: "true"
-  #     preset-goproxy: "true"
-  #   spec:
-  #     containers:
-  #     - image: quay.io/kubermatic/go-docker:14.2-1806-0
-  #       command:
-  #       - "./hack/ci/ci-run-offline-test.sh"
-  #       # docker-in-docker needs privileged mode
-  #       securityContext:
-  #         privileged: true
-  #       resources:
-  #         requests:
-  #           memory: 2.5Gi
-  #           cpu: 500m
-  #         limits:
-  #           memory: 4Gi
-  #           cpu: 2
+  - name: pre-kubermatic-e2e-gcp-offline
+    decorate: true
+    clone_uri: "ssh://git@github.com/kubermatic/kubermatic.git"
+    labels:
+      preset-gce: "true"
+      preset-vault: "true"
+      preset-docker-push: "true"
+      preset-repo-ssh: "true"
+      preset-goproxy: "true"
+    spec:
+      containers:
+      - image: quay.io/kubermatic/go-docker:14.2-1806-0
+        command:
+        - "./hack/ci/ci-run-offline-test.sh"
+        # docker-in-docker needs privileged mode
+        securityContext:
+          privileged: true
+        resources:
+          requests:
+            memory: 2.5Gi
+            cpu: 500m
+          limits:
+            memory: 4Gi
+            cpu: 2
 
-  # - name: pre-kubermatic-canary-deployment-ci-kubermatic-io
-  #   max_concurrency: 1
-  #   decorate: true
-  #   # * hack: Contains all the deployment scripting
-  #   # * charts/kubermatic: Contains the chart
-  #   # * pkg/crd/kubermatic/v1: Contains the Seed and Datacenter types, if
-  #   #   this gets out of sync with whats in the secrets repo, we fail because we use
-  #   #   yaml.UnmarshalStrict
-  #   run_if_changed: "(hack|charts/kubermatic|pkg/crd/kubermatic/v1)"
-  #   clone_uri: "ssh://git@github.com/kubermatic/kubermatic.git"
-  #   branches:
-  #   - ^master$
-  #   labels:
-  #     preset-docker-push: "true"
-  #     preset-vault: "true"
-  #     preset-repo-ssh: "true"
-  #     preset-goproxy: "true"
-  #   spec:
-  #     containers:
-  #     - image: quay.io/kubermatic/go-docker:14.2-1806-0
-  #       command:
-  #       - ./hack/ci/ci-deploy-ci-kubermatic-io.sh
-  #       env:
-  #       - name: KUBERMATIC_EDITION
-  #         value: ee
-  #       - name: CANARY_DEPLOYMENT
-  #         value: "true"
-  #       # docker-in-docker needs privileged mode
-  #       securityContext:
-  #         privileged: true
-  #       resources:
-  #         requests:
-  #           cpu: 1
-  #           memory: 1Gi
-  #         limits:
-  #           memory: 3Gi
+  - name: pre-kubermatic-canary-deployment-ci-kubermatic-io
+    max_concurrency: 1
+    decorate: true
+    # * hack: Contains all the deployment scripting
+    # * charts/kubermatic: Contains the chart
+    # * pkg/crd/kubermatic/v1: Contains the Seed and Datacenter types, if
+    #   this gets out of sync with whats in the secrets repo, we fail because we use
+    #   yaml.UnmarshalStrict
+    run_if_changed: "(hack|charts/kubermatic|pkg/crd/kubermatic/v1)"
+    clone_uri: "ssh://git@github.com/kubermatic/kubermatic.git"
+    branches:
+    - ^master$
+    labels:
+      preset-docker-push: "true"
+      preset-vault: "true"
+      preset-repo-ssh: "true"
+      preset-goproxy: "true"
+    spec:
+      containers:
+      - image: quay.io/kubermatic/go-docker:14.2-1806-0
+        command:
+        - ./hack/ci/ci-deploy-ci-kubermatic-io.sh
+        env:
+        - name: KUBERMATIC_EDITION
+          value: ee
+        - name: CANARY_DEPLOYMENT
+          value: "true"
+        # docker-in-docker needs privileged mode
+        securityContext:
+          privileged: true
+        resources:
+          requests:
+            cpu: 1
+            memory: 1Gi
+          limits:
+            memory: 3Gi
 
-  # - name: pre-kubermatic-test-integration
-  #   run_if_changed: "^(cmd|codegen|hack|pkg)/"
-  #   decorate: true
-  #   clone_uri: "ssh://git@github.com/kubermatic/kubermatic.git"
-  #   labels:
-  #     preset-vsphere: "true"
-  #     preset-goproxy: "true"
-  #   spec:
-  #     containers:
-  #     - image: quay.io/kubermatic/integration-tests:3-1
-  #       command:
-  #       - make
-  #       args:
-  #       - test-integration
-  #       resources:
-  #         requests:
-  #           memory: 4Gi
-  #           cpu: 2
-  #         limits:
-  #           memory: 6Gi
-  #           cpu: 2
-  #       env:
-  #       - name: KUBERMATIC_EDITION
-  #         value: ee
+  - name: pre-kubermatic-test-integration
+    run_if_changed: "^(cmd|codegen|hack|pkg)/"
+    decorate: true
+    clone_uri: "ssh://git@github.com/kubermatic/kubermatic.git"
+    labels:
+      preset-vsphere: "true"
+      preset-goproxy: "true"
+    spec:
+      containers:
+      - image: quay.io/kubermatic/integration-tests:3-1
+        command:
+        - make
+        args:
+        - test-integration
+        resources:
+          requests:
+            memory: 4Gi
+            cpu: 2
+          limits:
+            memory: 6Gi
+            cpu: 2
+        env:
+        - name: KUBERMATIC_EDITION
+          value: ee

--- a/.prow.yaml
+++ b/.prow.yaml
@@ -301,7 +301,7 @@ presubmits:
       preset-goproxy: "true"
     spec:
       containers:
-      - image: quay.io/kubermatic/e2e-kind:with-conformance-tests-v1.0.18
+      - image: quay.io/kubermatic/e2e-kind:with-conformance-tests-v1.0.19-xrstf1
         env:
         - name: KUBERMATIC_EDITION
           value: ee
@@ -342,7 +342,7 @@ presubmits:
       preset-goproxy: "true"
     spec:
       containers:
-      - image: quay.io/kubermatic/e2e-kind:with-conformance-tests-v1.0.18
+      - image: quay.io/kubermatic/e2e-kind:with-conformance-tests-v1.0.19-xrstf1
         env:
         - name: KUBERMATIC_EDITION
           value: ee
@@ -383,7 +383,7 @@ presubmits:
       preset-goproxy: "true"
     spec:
       containers:
-      - image: quay.io/kubermatic/e2e-kind:with-conformance-tests-v1.0.18
+      - image: quay.io/kubermatic/e2e-kind:with-conformance-tests-v1.0.19-xrstf1
         env:
         - name: KUBERMATIC_EDITION
           value: ee
@@ -424,7 +424,7 @@ presubmits:
       preset-goproxy: "true"
     spec:
       containers:
-      - image: quay.io/kubermatic/e2e-kind:with-conformance-tests-v1.0.18
+      - image: quay.io/kubermatic/e2e-kind:with-conformance-tests-v1.0.19-xrstf1
         env:
         - name: KUBERMATIC_EDITION
           value: ee
@@ -465,7 +465,7 @@ presubmits:
       preset-goproxy: "true"
     spec:
       containers:
-      - image: quay.io/kubermatic/e2e-kind:with-conformance-tests-v1.0.18
+      - image: quay.io/kubermatic/e2e-kind:with-conformance-tests-v1.0.19-xrstf1
         env:
         - name: KUBERMATIC_EDITION
           value: "ce"
@@ -508,7 +508,7 @@ presubmits:
       preset-goproxy: "true"
     spec:
       containers:
-      - image: quay.io/kubermatic/e2e-kind:with-conformance-tests-v1.0.18
+      - image: quay.io/kubermatic/e2e-kind:with-conformance-tests-v1.0.19-xrstf1
         env:
         - name: KUBERMATIC_EDITION
           value: "ee"
@@ -558,7 +558,7 @@ presubmits:
       preset-goproxy: "true"
     spec:
       containers:
-      - image: quay.io/kubermatic/e2e-kind:with-conformance-tests-v1.0.18
+      - image: quay.io/kubermatic/e2e-kind:with-conformance-tests-v1.0.19-xrstf1
         env:
         - name: KUBERMATIC_EDITION
           value: ee
@@ -604,7 +604,7 @@ presubmits:
       preset-goproxy: "true"
     spec:
       containers:
-      - image: quay.io/kubermatic/e2e-kind:with-conformance-tests-v1.0.18
+      - image: quay.io/kubermatic/e2e-kind:with-conformance-tests-v1.0.19-xrstf1
         env:
         - name: KUBERMATIC_EDITION
           value: ee
@@ -647,7 +647,7 @@ presubmits:
       preset-goproxy: "true"
     spec:
       containers:
-      - image: quay.io/kubermatic/e2e-kind:with-conformance-tests-v1.0.18
+      - image: quay.io/kubermatic/e2e-kind:with-conformance-tests-v1.0.19-xrstf1
         env:
         - name: KUBERMATIC_EDITION
           value: ee
@@ -695,7 +695,7 @@ presubmits:
       preset-goproxy: "true"
     spec:
       containers:
-      - image: quay.io/kubermatic/e2e-kind:with-conformance-tests-v1.0.18
+      - image: quay.io/kubermatic/e2e-kind:with-conformance-tests-v1.0.19-xrstf1
         env:
         - name: KUBERMATIC_EDITION
           value: ee
@@ -738,7 +738,7 @@ presubmits:
       preset-goproxy: "true"
     spec:
       containers:
-      - image: quay.io/kubermatic/e2e-kind:with-conformance-tests-v1.0.18
+      - image: quay.io/kubermatic/e2e-kind:with-conformance-tests-v1.0.19-xrstf1
         env:
         - name: KUBERMATIC_EDITION
           value: ee
@@ -781,7 +781,7 @@ presubmits:
       preset-goproxy: "true"
     spec:
       containers:
-      - image: quay.io/kubermatic/e2e-kind:with-conformance-tests-v1.0.18
+      - image: quay.io/kubermatic/e2e-kind:with-conformance-tests-v1.0.19-xrstf1
         env:
         - name: KUBERMATIC_EDITION
           value: ee
@@ -824,7 +824,7 @@ presubmits:
       preset-goproxy: "true"
     spec:
       containers:
-      - image: quay.io/kubermatic/e2e-kind:with-conformance-tests-v1.0.18
+      - image: quay.io/kubermatic/e2e-kind:with-conformance-tests-v1.0.19-xrstf1
         env:
         - name: KUBERMATIC_EDITION
           value: ee
@@ -870,7 +870,7 @@ presubmits:
       preset-goproxy: "true"
     spec:
       containers:
-      - image: quay.io/kubermatic/e2e-kind:with-conformance-tests-v1.0.18
+      - image: quay.io/kubermatic/e2e-kind:with-conformance-tests-v1.0.19-xrstf1
         env:
         - name: KUBERMATIC_EDITION
           value: ee
@@ -915,7 +915,7 @@ presubmits:
       preset-goproxy: "true"
     spec:
       containers:
-      - image: quay.io/kubermatic/e2e-kind:with-conformance-tests-v1.0.18
+      - image: quay.io/kubermatic/e2e-kind:with-conformance-tests-v1.0.19-xrstf1
         env:
         - name: KUBERMATIC_EDITION
           value: ee
@@ -960,7 +960,7 @@ presubmits:
       preset-goproxy: "true"
     spec:
       containers:
-      - image: quay.io/kubermatic/e2e-kind:with-conformance-tests-v1.0.18
+      - image: quay.io/kubermatic/e2e-kind:with-conformance-tests-v1.0.19-xrstf1
         env:
         - name: KUBERMATIC_EDITION
           value: ee
@@ -1004,7 +1004,7 @@ presubmits:
       preset-goproxy: "true"
     spec:
       containers:
-      - image: quay.io/kubermatic/e2e-kind:with-conformance-tests-v1.0.18
+      - image: quay.io/kubermatic/e2e-kind:with-conformance-tests-v1.0.19-xrstf1
         env:
         - name: KUBERMATIC_EDITION
           value: ee
@@ -1050,7 +1050,7 @@ presubmits:
       preset-goproxy: "true"
     spec:
       containers:
-        - image: quay.io/kubermatic/e2e-kind:with-conformance-tests-v1.0.18
+        - image: quay.io/kubermatic/e2e-kind:with-conformance-tests-v1.0.19-xrstf1
           env:
             - name: KUBERMATIC_EDITION
               value: ee
@@ -1100,7 +1100,7 @@ presubmits:
       preset-goproxy: "true"
     spec:
       containers:
-      - image: quay.io/kubermatic/e2e-kind:with-conformance-tests-v1.0.18
+      - image: quay.io/kubermatic/e2e-kind:with-conformance-tests-v1.0.19-xrstf1
         env:
         - name: KUBERMATIC_EDITION
           value: ee
@@ -1146,7 +1146,7 @@ presubmits:
       preset-goproxy: "true"
     spec:
       containers:
-      - image: quay.io/kubermatic/e2e-kind:with-conformance-tests-v1.0.18
+      - image: quay.io/kubermatic/e2e-kind:with-conformance-tests-v1.0.19-xrstf1
         imagePullPolicy: Always
         command:
         - "./hack/ci/ci_run_api_e2e.sh"

--- a/.prow.yaml
+++ b/.prow.yaml
@@ -17,269 +17,269 @@ presubmits:
   # unit tests
   #########################################################
 
-  - name: pre-kubermatic-test
-    run_if_changed: "^(cmd|codegen|hack|pkg)/"
-    decorate: true
-    clone_uri: "ssh://git@github.com/kubermatic/kubermatic.git"
-    labels:
-      preset-goproxy: "true"
-    spec:
-      containers:
-      - image: golang:1.14.2
-        command:
-        - make
-        args:
-        - test
-        resources:
-          requests:
-            memory: 7Gi
-            cpu: 2
-        env:
-        - name: KUBERMATIC_EDITION
-          value: ee
+  # - name: pre-kubermatic-test
+  #   run_if_changed: "^(cmd|codegen|hack|pkg)/"
+  #   decorate: true
+  #   clone_uri: "ssh://git@github.com/kubermatic/kubermatic.git"
+  #   labels:
+  #     preset-goproxy: "true"
+  #   spec:
+  #     containers:
+  #     - image: golang:1.14.2
+  #       command:
+  #       - make
+  #       args:
+  #       - test
+  #       resources:
+  #         requests:
+  #           memory: 7Gi
+  #           cpu: 2
+  #       env:
+  #       - name: KUBERMATIC_EDITION
+  #         value: ee
 
-  - name: pre-kubermatic-verify
-    run_if_changed: "^(cmd|codegen|hack|pkg)/"
-    decorate: true
-    clone_uri: "ssh://git@github.com/kubermatic/kubermatic.git"
-    path_alias: k8c.io/kubermatic
-    labels:
-      preset-goproxy: "true"
-    spec:
-      containers:
-      - image: golang:1.14.2
-        command:
-        - make
-        args:
-        - verify
-        resources:
-          requests:
-            memory: 1.5Gi
-            cpu: 1
-          limits:
-            memory: 2.5Gi
-            cpu: 2
-        env:
-        - name: KUBERMATIC_EDITION
-          value: ee
+  # - name: pre-kubermatic-verify
+  #   run_if_changed: "^(cmd|codegen|hack|pkg)/"
+  #   decorate: true
+  #   clone_uri: "ssh://git@github.com/kubermatic/kubermatic.git"
+  #   path_alias: k8c.io/kubermatic
+  #   labels:
+  #     preset-goproxy: "true"
+  #   spec:
+  #     containers:
+  #     - image: golang:1.14.2
+  #       command:
+  #       - make
+  #       args:
+  #       - verify
+  #       resources:
+  #         requests:
+  #           memory: 1.5Gi
+  #           cpu: 1
+  #         limits:
+  #           memory: 2.5Gi
+  #           cpu: 2
+  #       env:
+  #       - name: KUBERMATIC_EDITION
+  #         value: ee
 
-  - name: pre-kubermatic-verify-charts
-    run_if_changed: "^charts/"
-    decorate: true
-    clone_uri: "ssh://git@github.com/kubermatic/kubermatic.git"
-    labels:
-      preset-goproxy: "true"
-    spec:
-      containers:
-      - image: quay.io/kubermatic/util:1.3.5
-        command:
-        - "./hack/verify-chart-versions.sh"
-        resources:
-          requests:
-            memory: 128Mi
-            cpu: 50m
-          limits:
-            memory: 256Mi
-            cpu: 250m
-        env:
-        - name: KUBERMATIC_EDITION
-          value: ee
+  # - name: pre-kubermatic-verify-charts
+  #   run_if_changed: "^charts/"
+  #   decorate: true
+  #   clone_uri: "ssh://git@github.com/kubermatic/kubermatic.git"
+  #   labels:
+  #     preset-goproxy: "true"
+  #   spec:
+  #     containers:
+  #     - image: quay.io/kubermatic/util:1.3.5
+  #       command:
+  #       - "./hack/verify-chart-versions.sh"
+  #       resources:
+  #         requests:
+  #           memory: 128Mi
+  #           cpu: 50m
+  #         limits:
+  #           memory: 256Mi
+  #           cpu: 250m
+  #       env:
+  #       - name: KUBERMATIC_EDITION
+  #         value: ee
 
-  - name: pre-kubermatic-verify-kubermatic-chart
-    run_if_changed: "^(cmd|codegen|hack|pkg|charts)/"
-    decorate: true
-    clone_uri: "ssh://git@github.com/kubermatic/kubermatic.git"
-    labels:
-      preset-goproxy: "true"
-    spec:
-      containers:
-      - image: quay.io/kubermatic/go-docker:14.2-1806-0
-        command:
-        - "./hack/verify-kubermatic-chart.sh"
-        resources:
-          requests:
-            memory: 512Mi
-            cpu: 250m
-          limits:
-            memory: 1Gi
-            cpu: 1
-        env:
-        - name: KUBERMATIC_EDITION
-          value: ee
+  # - name: pre-kubermatic-verify-kubermatic-chart
+  #   run_if_changed: "^(cmd|codegen|hack|pkg|charts)/"
+  #   decorate: true
+  #   clone_uri: "ssh://git@github.com/kubermatic/kubermatic.git"
+  #   labels:
+  #     preset-goproxy: "true"
+  #   spec:
+  #     containers:
+  #     - image: quay.io/kubermatic/go-docker:14.2-1806-0
+  #       command:
+  #       - "./hack/verify-kubermatic-chart.sh"
+  #       resources:
+  #         requests:
+  #           memory: 512Mi
+  #           cpu: 250m
+  #         limits:
+  #           memory: 1Gi
+  #           cpu: 1
+  #       env:
+  #       - name: KUBERMATIC_EDITION
+  #         value: ee
 
-  - name: pre-kubermatic-verify-grafana-dashboards
-    run_if_changed: "^charts/monitoring/grafana/"
-    decorate: true
-    clone_uri: "ssh://git@github.com/kubermatic/kubermatic.git"
-    labels:
-      preset-goproxy: "true"
-    spec:
-      containers:
-      - image: quay.io/kubermatic/util:1.3.5
-        command:
-        - "./hack/verify-grafana-dashboards.sh"
-        resources:
-          requests:
-            memory: 64Mi
-            cpu: 50m
-          limits:
-            memory: 128Mi
-            cpu: 250m
-        env:
-        - name: KUBERMATIC_EDITION
-          value: ee
+  # - name: pre-kubermatic-verify-grafana-dashboards
+  #   run_if_changed: "^charts/monitoring/grafana/"
+  #   decorate: true
+  #   clone_uri: "ssh://git@github.com/kubermatic/kubermatic.git"
+  #   labels:
+  #     preset-goproxy: "true"
+  #   spec:
+  #     containers:
+  #     - image: quay.io/kubermatic/util:1.3.5
+  #       command:
+  #       - "./hack/verify-grafana-dashboards.sh"
+  #       resources:
+  #         requests:
+  #           memory: 64Mi
+  #           cpu: 50m
+  #         limits:
+  #           memory: 128Mi
+  #           cpu: 250m
+  #       env:
+  #       - name: KUBERMATIC_EDITION
+  #         value: ee
 
-  - name: pre-kubermatic-verify-docs
-    run_if_changed: "^(cmd|codegen|hack|pkg|docs)/"
-    decorate: true
-    clone_uri: "ssh://git@github.com/kubermatic/kubermatic.git"
-    labels:
-      preset-goproxy: "true"
-    spec:
-      containers:
-      - image: quay.io/kubermatic/go-docker:14.2-1806-0
-        command:
-        - "./hack/verify-docs.sh"
-        resources:
-          requests:
-            memory: 1Gi
-            cpu: 1
-        env:
-        - name: KUBERMATIC_EDITION
-          value: ee
+  # - name: pre-kubermatic-verify-docs
+  #   run_if_changed: "^(cmd|codegen|hack|pkg|docs)/"
+  #   decorate: true
+  #   clone_uri: "ssh://git@github.com/kubermatic/kubermatic.git"
+  #   labels:
+  #     preset-goproxy: "true"
+  #   spec:
+  #     containers:
+  #     - image: quay.io/kubermatic/go-docker:14.2-1806-0
+  #       command:
+  #       - "./hack/verify-docs.sh"
+  #       resources:
+  #         requests:
+  #           memory: 1Gi
+  #           cpu: 1
+  #       env:
+  #       - name: KUBERMATIC_EDITION
+  #         value: ee
 
-  - name: pre-kubermatic-lint
-    run_if_changed: "^(cmd|codegen|hack|pkg)/"
-    decorate: true
-    clone_uri: "ssh://git@github.com/kubermatic/kubermatic.git"
-    labels:
-      preset-goproxy: "true"
-    spec:
-      containers:
-      - image: golangci/golangci-lint:v1.23.6
-        command:
-        - make
-        args:
-        - lint
-        resources:
-          requests:
-            memory: 10Gi
-            cpu: 3
-        env:
-        - name: KUBERMATIC_EDITION
-          value: ee
+  # - name: pre-kubermatic-lint
+  #   run_if_changed: "^(cmd|codegen|hack|pkg)/"
+  #   decorate: true
+  #   clone_uri: "ssh://git@github.com/kubermatic/kubermatic.git"
+  #   labels:
+  #     preset-goproxy: "true"
+  #   spec:
+  #     containers:
+  #     - image: golangci/golangci-lint:v1.23.6
+  #       command:
+  #       - make
+  #       args:
+  #       - lint
+  #       resources:
+  #         requests:
+  #           memory: 10Gi
+  #           cpu: 3
+  #       env:
+  #       - name: KUBERMATIC_EDITION
+  #         value: ee
 
-  - name: pre-kubermatic-dependencies
-    run_if_changed: "^(cmd|codegen|hack|pkg|go.mod|go.sum)/"
-    decorate: true
-    clone_uri: "ssh://git@github.com/kubermatic/kubermatic.git"
-    labels:
-      preset-goproxy: "true"
-    spec:
-      containers:
-      - image: quay.io/kubermatic/go-docker:14.2-1806-0
-        command:
-        - make
-        args:
-        - check-dependencies
-        resources:
-          requests:
-            memory: 256Mi
-            cpu: 250m
-          limits:
-            memory: 256Mi
-            cpu: 250m
-        env:
-        - name: KUBERMATIC_EDITION
-          value: ee
+  # - name: pre-kubermatic-dependencies
+  #   run_if_changed: "^(cmd|codegen|hack|pkg|go.mod|go.sum)/"
+  #   decorate: true
+  #   clone_uri: "ssh://git@github.com/kubermatic/kubermatic.git"
+  #   labels:
+  #     preset-goproxy: "true"
+  #   spec:
+  #     containers:
+  #     - image: quay.io/kubermatic/go-docker:14.2-1806-0
+  #       command:
+  #       - make
+  #       args:
+  #       - check-dependencies
+  #       resources:
+  #         requests:
+  #           memory: 256Mi
+  #           cpu: 250m
+  #         limits:
+  #           memory: 256Mi
+  #           cpu: 250m
+  #       env:
+  #       - name: KUBERMATIC_EDITION
+  #         value: ee
 
-  - name: pre-kubermatic-shellcheck
-    optional: true
-    decorate: true
-    clone_uri: "ssh://git@github.com/kubermatic/kubermatic.git"
-    labels:
-      preset-goproxy: "true"
-    spec:
-      containers:
-      - image: koalaman/shellcheck-alpine:v0.7.0
-        command:
-        - sh
-        args:
-        - -c
-        - shellcheck --shell=bash $(find . -name '*.sh')
-        resources:
-          requests:
-            memory: 1Gi
-            cpu: 0.5
-        env:
-        - name: KUBERMATIC_EDITION
-          value: ee
+  # - name: pre-kubermatic-shellcheck
+  #   optional: true
+  #   decorate: true
+  #   clone_uri: "ssh://git@github.com/kubermatic/kubermatic.git"
+  #   labels:
+  #     preset-goproxy: "true"
+  #   spec:
+  #     containers:
+  #     - image: koalaman/shellcheck-alpine:v0.7.0
+  #       command:
+  #       - sh
+  #       args:
+  #       - -c
+  #       - shellcheck --shell=bash $(find . -name '*.sh')
+  #       resources:
+  #         requests:
+  #           memory: 1Gi
+  #           cpu: 0.5
+  #       env:
+  #       - name: KUBERMATIC_EDITION
+  #         value: ee
 
-  - name: pre-kubermatic-license-validation
-    run_if_changed: "^go.(mod|sum)$"
-    decorate: true
-    clone_uri: "ssh://git@github.com/kubermatic/kubermatic.git"
-    labels:
-      preset-goproxy: "true"
-    spec:
-      containers:
-      - image: quay.io/kubermatic/util:1.4.0
-        command:
-        - ./hack/verify-licenses.sh
-        resources:
-          requests:
-            memory: 512Mi
-            cpu: 1
+  # - name: pre-kubermatic-license-validation
+  #   run_if_changed: "^go.(mod|sum)$"
+  #   decorate: true
+  #   clone_uri: "ssh://git@github.com/kubermatic/kubermatic.git"
+  #   labels:
+  #     preset-goproxy: "true"
+  #   spec:
+  #     containers:
+  #     - image: quay.io/kubermatic/util:1.4.0
+  #       command:
+  #       - ./hack/verify-licenses.sh
+  #       resources:
+  #         requests:
+  #           memory: 512Mi
+  #           cpu: 1
 
-  - name: pre-kubermatic-verify-boilerplate
-    always_run: true
-    decorate: true
-    clone_uri: "ssh://git@github.com/kubermatic/kubermatic.git"
-    labels:
-      preset-goproxy: "true"
-    spec:
-      containers:
-      - image: quay.io/kubermatic-labs/boilerplate:v0.1.1
-        command:
-        - ./hack/verify-boilerplate.sh
-        resources:
-          requests:
-            memory: 256Mi
-            cpu: 100m
+  # - name: pre-kubermatic-verify-boilerplate
+  #   always_run: true
+  #   decorate: true
+  #   clone_uri: "ssh://git@github.com/kubermatic/kubermatic.git"
+  #   labels:
+  #     preset-goproxy: "true"
+  #   spec:
+  #     containers:
+  #     - image: quay.io/kubermatic-labs/boilerplate:v0.1.1
+  #       command:
+  #       - ./hack/verify-boilerplate.sh
+  #       resources:
+  #         requests:
+  #           memory: 256Mi
+  #           cpu: 100m
 
-  - name: pre-kubermatic-prometheus-rules-validation
-    run_if_changed: "charts/monitoring"
-    decorate: true
-    clone_uri: "ssh://git@github.com/kubermatic/kubermatic.git"
-    labels:
-      preset-goproxy: "true"
-    spec:
-      containers:
-      - image: quay.io/kubermatic/util:1.4.0
-        command:
-        - ./hack/verify-prometheus-rules.sh
-        env:
-        - name: KUBERMATIC_EDITION
-          value: ee
-      imagePullSecrets:
-      - name: quay
+  # - name: pre-kubermatic-prometheus-rules-validation
+  #   run_if_changed: "charts/monitoring"
+  #   decorate: true
+  #   clone_uri: "ssh://git@github.com/kubermatic/kubermatic.git"
+  #   labels:
+  #     preset-goproxy: "true"
+  #   spec:
+  #     containers:
+  #     - image: quay.io/kubermatic/util:1.4.0
+  #       command:
+  #       - ./hack/verify-prometheus-rules.sh
+  #       env:
+  #       - name: KUBERMATIC_EDITION
+  #         value: ee
+  #     imagePullSecrets:
+  #     - name: quay
 
-  - name: pre-kubermatic-user-cluster-prometheus-config-validation
-    run_if_changed: "pkg/resources/prometheus"
-    decorate: true
-    clone_uri: "ssh://git@github.com/kubermatic/kubermatic.git"
-    labels:
-      preset-goproxy: "true"
-    spec:
-      containers:
-      - image: quay.io/kubermatic/promtool:2.7.0-3
-        command:
-        - "./hack/verify-user-cluster-prometheus-configs.sh"
-        env:
-        - name: KUBERMATIC_EDITION
-          value: ee
-      imagePullSecrets:
-      - name: quay
+  # - name: pre-kubermatic-user-cluster-prometheus-config-validation
+  #   run_if_changed: "pkg/resources/prometheus"
+  #   decorate: true
+  #   clone_uri: "ssh://git@github.com/kubermatic/kubermatic.git"
+  #   labels:
+  #     preset-goproxy: "true"
+  #   spec:
+  #     containers:
+  #     - image: quay.io/kubermatic/promtool:2.7.0-3
+  #       command:
+  #       - "./hack/verify-user-cluster-prometheus-configs.sh"
+  #       env:
+  #       - name: KUBERMATIC_EDITION
+  #         value: ee
+  #     imagePullSecrets:
+  #     - name: quay
 
   #########################################################
   # Base Kubernetes Tests (AWS, CoreOS)
@@ -542,718 +542,718 @@ presubmits:
   # # Extended Kubernetes Tests (various cloud providers, OS)
   # #########################################################
 
-  - name: pre-kubermatic-e2e-azure-ubuntu-1.19
-    decorate: true
-    optional: true
-    clone_uri: "ssh://git@github.com/kubermatic/kubermatic.git"
-    labels:
-      preset-azure: "true"
-      preset-vault: "true"
-      preset-docker-pull: "true"
-      preset-docker-push: "true"
-      preset-repo-ssh: "true"
-      preset-e2e-ssh: "true"
-      preset-kubeconfig-ci: "true"
-      preset-kind-volume-mounts: "true"
-      preset-goproxy: "true"
-    spec:
-      containers:
-      - image: quay.io/kubermatic/e2e-kind:with-conformance-tests-v1.0.19-xrstf1
-        env:
-        - name: KUBERMATIC_EDITION
-          value: ee
-        - name: VERSIONS_TO_TEST
-          value: "v1.19.0"
-        - name: EXCLUDE_DISTRIBUTIONS
-          value: "centos,coreos,flatcar,rhel"
-        - name: PROVIDER
-          value: "azure"
-        - name: DEFAULT_TIMEOUT_MINUTES
-          value: "20"
-        - name: SERVICE_ACCOUNT_KEY
-          valueFrom:
-            secretKeyRef:
-              name: e2e-ci
-              key: serviceAccountSigningKey
-        command:
-        - "./hack/ci/ci-kind-e2e.sh"
-        # docker-in-docker needs privileged mode
-        securityContext:
-          privileged: true
-        resources:
-          requests:
-            memory: 4Gi
-            cpu: 3.5
-          limits:
-            memory: 4Gi
+  # - name: pre-kubermatic-e2e-azure-ubuntu-1.19
+  #   decorate: true
+  #   optional: true
+  #   clone_uri: "ssh://git@github.com/kubermatic/kubermatic.git"
+  #   labels:
+  #     preset-azure: "true"
+  #     preset-vault: "true"
+  #     preset-docker-pull: "true"
+  #     preset-docker-push: "true"
+  #     preset-repo-ssh: "true"
+  #     preset-e2e-ssh: "true"
+  #     preset-kubeconfig-ci: "true"
+  #     preset-kind-volume-mounts: "true"
+  #     preset-goproxy: "true"
+  #   spec:
+  #     containers:
+  #     - image: quay.io/kubermatic/e2e-kind:with-conformance-tests-v1.0.19-xrstf1
+  #       env:
+  #       - name: KUBERMATIC_EDITION
+  #         value: ee
+  #       - name: VERSIONS_TO_TEST
+  #         value: "v1.19.0"
+  #       - name: EXCLUDE_DISTRIBUTIONS
+  #         value: "centos,coreos,flatcar,rhel"
+  #       - name: PROVIDER
+  #         value: "azure"
+  #       - name: DEFAULT_TIMEOUT_MINUTES
+  #         value: "20"
+  #       - name: SERVICE_ACCOUNT_KEY
+  #         valueFrom:
+  #           secretKeyRef:
+  #             name: e2e-ci
+  #             key: serviceAccountSigningKey
+  #       command:
+  #       - "./hack/ci/ci-kind-e2e.sh"
+  #       # docker-in-docker needs privileged mode
+  #       securityContext:
+  #         privileged: true
+  #       resources:
+  #         requests:
+  #           memory: 4Gi
+  #           cpu: 3.5
+  #         limits:
+  #           memory: 4Gi
 
-  - name: pre-kubermatic-e2e-gcp-ubuntu-1.19
-    decorate: true
-    always_run: false
-    optional: true
-    clone_uri: "ssh://git@github.com/kubermatic/kubermatic.git"
-    labels:
-      preset-gce: "true"
-      preset-vault: "true"
-      preset-docker-pull: "true"
-      preset-docker-push: "true"
-      preset-repo-ssh: "true"
-      preset-e2e-ssh: "true"
-      preset-kubeconfig-ci: "true"
-      preset-kind-volume-mounts: "true"
-      preset-goproxy: "true"
-    spec:
-      containers:
-      - image: quay.io/kubermatic/e2e-kind:with-conformance-tests-v1.0.19-xrstf1
-        env:
-        - name: KUBERMATIC_EDITION
-          value: ee
-        - name: VERSIONS_TO_TEST
-          value: "v1.19.0"
-        - name: PROVIDER
-          value: "gcp"
-        - name: EXCLUDE_DISTRIBUTIONS
-          value: "centos,coreos,flatcar,rhel"
-        - name: SERVICE_ACCOUNT_KEY
-          valueFrom:
-            secretKeyRef:
-              name: e2e-ci
-              key: serviceAccountSigningKey
-        command:
-        - "./hack/ci/ci-kind-e2e.sh"
-        # docker-in-docker needs privileged mode
-        securityContext:
-          privileged: true
-        resources:
-          requests:
-            memory: 4Gi
-            cpu: 3.5
-          limits:
-            memory: 4Gi
+  # - name: pre-kubermatic-e2e-gcp-ubuntu-1.19
+  #   decorate: true
+  #   always_run: false
+  #   optional: true
+  #   clone_uri: "ssh://git@github.com/kubermatic/kubermatic.git"
+  #   labels:
+  #     preset-gce: "true"
+  #     preset-vault: "true"
+  #     preset-docker-pull: "true"
+  #     preset-docker-push: "true"
+  #     preset-repo-ssh: "true"
+  #     preset-e2e-ssh: "true"
+  #     preset-kubeconfig-ci: "true"
+  #     preset-kind-volume-mounts: "true"
+  #     preset-goproxy: "true"
+  #   spec:
+  #     containers:
+  #     - image: quay.io/kubermatic/e2e-kind:with-conformance-tests-v1.0.19-xrstf1
+  #       env:
+  #       - name: KUBERMATIC_EDITION
+  #         value: ee
+  #       - name: VERSIONS_TO_TEST
+  #         value: "v1.19.0"
+  #       - name: PROVIDER
+  #         value: "gcp"
+  #       - name: EXCLUDE_DISTRIBUTIONS
+  #         value: "centos,coreos,flatcar,rhel"
+  #       - name: SERVICE_ACCOUNT_KEY
+  #         valueFrom:
+  #           secretKeyRef:
+  #             name: e2e-ci
+  #             key: serviceAccountSigningKey
+  #       command:
+  #       - "./hack/ci/ci-kind-e2e.sh"
+  #       # docker-in-docker needs privileged mode
+  #       securityContext:
+  #         privileged: true
+  #       resources:
+  #         requests:
+  #           memory: 4Gi
+  #           cpu: 3.5
+  #         limits:
+  #           memory: 4Gi
 
-  - name: pre-kubermatic-e2e-gcp-ubuntu-1.19-psp
-    decorate: true
-    optional: true
-    clone_uri: "ssh://git@github.com/kubermatic/kubermatic.git"
-    labels:
-      preset-gce: "true"
-      preset-vault: "true"
-      preset-docker-pull: "true"
-      preset-docker-push: "true"
-      preset-repo-ssh: "true"
-      preset-e2e-ssh: "true"
-      preset-kubeconfig-ci: "true"
-      preset-kind-volume-mounts: "true"
-      preset-goproxy: "true"
-    spec:
-      containers:
-      - image: quay.io/kubermatic/e2e-kind:with-conformance-tests-v1.0.19-xrstf1
-        env:
-        - name: KUBERMATIC_EDITION
-          value: ee
-        - name: VERSIONS_TO_TEST
-          value: "v1.19.0"
-        - name: PROVIDER
-          value: "gcp"
-        - name: EXCLUDE_DISTRIBUTIONS
-          value: "centos,coreos,flatcar,rhel"
-        - name: KUBERMATIC_PSP_ENABLED
-          value: "true"
-        - name: ONLY_TEST_CREATION
-          value: "true"
-        - name: SERVICE_ACCOUNT_KEY
-          valueFrom:
-            secretKeyRef:
-              name: e2e-ci
-              key: serviceAccountSigningKey
-        command:
-        - "./hack/ci/ci-kind-e2e.sh"
-        # docker-in-docker needs privileged mode
-        securityContext:
-          privileged: true
-        resources:
-          requests:
-            memory: 4Gi
-            cpu: 3.5
-          limits:
-            memory: 4Gi
+  # - name: pre-kubermatic-e2e-gcp-ubuntu-1.19-psp
+  #   decorate: true
+  #   optional: true
+  #   clone_uri: "ssh://git@github.com/kubermatic/kubermatic.git"
+  #   labels:
+  #     preset-gce: "true"
+  #     preset-vault: "true"
+  #     preset-docker-pull: "true"
+  #     preset-docker-push: "true"
+  #     preset-repo-ssh: "true"
+  #     preset-e2e-ssh: "true"
+  #     preset-kubeconfig-ci: "true"
+  #     preset-kind-volume-mounts: "true"
+  #     preset-goproxy: "true"
+  #   spec:
+  #     containers:
+  #     - image: quay.io/kubermatic/e2e-kind:with-conformance-tests-v1.0.19-xrstf1
+  #       env:
+  #       - name: KUBERMATIC_EDITION
+  #         value: ee
+  #       - name: VERSIONS_TO_TEST
+  #         value: "v1.19.0"
+  #       - name: PROVIDER
+  #         value: "gcp"
+  #       - name: EXCLUDE_DISTRIBUTIONS
+  #         value: "centos,coreos,flatcar,rhel"
+  #       - name: KUBERMATIC_PSP_ENABLED
+  #         value: "true"
+  #       - name: ONLY_TEST_CREATION
+  #         value: "true"
+  #       - name: SERVICE_ACCOUNT_KEY
+  #         valueFrom:
+  #           secretKeyRef:
+  #             name: e2e-ci
+  #             key: serviceAccountSigningKey
+  #       command:
+  #       - "./hack/ci/ci-kind-e2e.sh"
+  #       # docker-in-docker needs privileged mode
+  #       securityContext:
+  #         privileged: true
+  #       resources:
+  #         requests:
+  #           memory: 4Gi
+  #           cpu: 3.5
+  #         limits:
+  #           memory: 4Gi
 
-  - name: pre-kubermatic-e2e-do-centos-1.19
-    decorate: true
-    always_run: false
-    optional: true
-    clone_uri: "ssh://git@github.com/kubermatic/kubermatic.git"
-    labels:
-      preset-digitalocean: "true"
-      preset-vault: "true"
-      preset-docker-pull: "true"
-      preset-docker-push: "true"
-      preset-repo-ssh: "true"
-      preset-e2e-ssh: "true"
-      preset-kubeconfig-ci: "true"
-      preset-kind-volume-mounts: "true"
-      preset-goproxy: "true"
-    spec:
-      containers:
-      - image: quay.io/kubermatic/e2e-kind:with-conformance-tests-v1.0.19-xrstf1
-        env:
-        - name: KUBERMATIC_EDITION
-          value: ee
-        - name: VERSIONS_TO_TEST
-          value: "v1.19.0"
-        - name: EXCLUDE_DISTRIBUTIONS
-          value: "ubuntu,coreos,flatcar,rhel"
-        - name: PROVIDER
-          value: "digitalocean"
-        - name: SERVICE_ACCOUNT_KEY
-          valueFrom:
-            secretKeyRef:
-              name: e2e-ci
-              key: serviceAccountSigningKey
-        command:
-        - "./hack/ci/ci-kind-e2e.sh"
-        # docker-in-docker needs privileged mode
-        securityContext:
-          privileged: true
-        resources:
-          requests:
-            memory: 4Gi
-            cpu: 3.5
-          limits:
-            memory: 4Gi
+  # - name: pre-kubermatic-e2e-do-centos-1.19
+  #   decorate: true
+  #   always_run: false
+  #   optional: true
+  #   clone_uri: "ssh://git@github.com/kubermatic/kubermatic.git"
+  #   labels:
+  #     preset-digitalocean: "true"
+  #     preset-vault: "true"
+  #     preset-docker-pull: "true"
+  #     preset-docker-push: "true"
+  #     preset-repo-ssh: "true"
+  #     preset-e2e-ssh: "true"
+  #     preset-kubeconfig-ci: "true"
+  #     preset-kind-volume-mounts: "true"
+  #     preset-goproxy: "true"
+  #   spec:
+  #     containers:
+  #     - image: quay.io/kubermatic/e2e-kind:with-conformance-tests-v1.0.19-xrstf1
+  #       env:
+  #       - name: KUBERMATIC_EDITION
+  #         value: ee
+  #       - name: VERSIONS_TO_TEST
+  #         value: "v1.19.0"
+  #       - name: EXCLUDE_DISTRIBUTIONS
+  #         value: "ubuntu,coreos,flatcar,rhel"
+  #       - name: PROVIDER
+  #         value: "digitalocean"
+  #       - name: SERVICE_ACCOUNT_KEY
+  #         valueFrom:
+  #           secretKeyRef:
+  #             name: e2e-ci
+  #             key: serviceAccountSigningKey
+  #       command:
+  #       - "./hack/ci/ci-kind-e2e.sh"
+  #       # docker-in-docker needs privileged mode
+  #       securityContext:
+  #         privileged: true
+  #       resources:
+  #         requests:
+  #           memory: 4Gi
+  #           cpu: 3.5
+  #         limits:
+  #           memory: 4Gi
 
-  - name: pre-kubermatic-e2e-packet-ubuntu-1.19
-    decorate: true
-    optional: true
-    clone_uri: "ssh://git@github.com/kubermatic/kubermatic.git"
-    labels:
-      preset-packet: "true"
-      preset-vault: "true"
-      preset-docker-pull: "true"
-      preset-docker-push: "true"
-      preset-repo-ssh: "true"
-      preset-e2e-ssh: "true"
-      preset-kubeconfig-ci: "true"
-      preset-kind-volume-mounts: "true"
-      preset-goproxy: "true"
-    spec:
-      containers:
-      - image: quay.io/kubermatic/e2e-kind:with-conformance-tests-v1.0.19-xrstf1
-        env:
-        - name: KUBERMATIC_EDITION
-          value: ee
-        - name: VERSIONS_TO_TEST
-          value: "v1.19.0"
-        - name: PROVIDER
-          value: "packet"
-        - name: EXCLUDE_DISTRIBUTIONS
-          value: "centos,coreos,flatcar,rhel"
-        - name: SERVICE_ACCOUNT_KEY
-          valueFrom:
-            secretKeyRef:
-              name: e2e-ci
-              key: serviceAccountSigningKey
-        command:
-        - "./hack/ci/ci-kind-e2e.sh"
-        # docker-in-docker needs privileged mode
-        securityContext:
-          privileged: true
-        resources:
-          requests:
-            memory: 4Gi
-            cpu: 3.5
-          limits:
-            memory: 4Gi
+  # - name: pre-kubermatic-e2e-packet-ubuntu-1.19
+  #   decorate: true
+  #   optional: true
+  #   clone_uri: "ssh://git@github.com/kubermatic/kubermatic.git"
+  #   labels:
+  #     preset-packet: "true"
+  #     preset-vault: "true"
+  #     preset-docker-pull: "true"
+  #     preset-docker-push: "true"
+  #     preset-repo-ssh: "true"
+  #     preset-e2e-ssh: "true"
+  #     preset-kubeconfig-ci: "true"
+  #     preset-kind-volume-mounts: "true"
+  #     preset-goproxy: "true"
+  #   spec:
+  #     containers:
+  #     - image: quay.io/kubermatic/e2e-kind:with-conformance-tests-v1.0.19-xrstf1
+  #       env:
+  #       - name: KUBERMATIC_EDITION
+  #         value: ee
+  #       - name: VERSIONS_TO_TEST
+  #         value: "v1.19.0"
+  #       - name: PROVIDER
+  #         value: "packet"
+  #       - name: EXCLUDE_DISTRIBUTIONS
+  #         value: "centos,coreos,flatcar,rhel"
+  #       - name: SERVICE_ACCOUNT_KEY
+  #         valueFrom:
+  #           secretKeyRef:
+  #             name: e2e-ci
+  #             key: serviceAccountSigningKey
+  #       command:
+  #       - "./hack/ci/ci-kind-e2e.sh"
+  #       # docker-in-docker needs privileged mode
+  #       securityContext:
+  #         privileged: true
+  #       resources:
+  #         requests:
+  #           memory: 4Gi
+  #           cpu: 3.5
+  #         limits:
+  #           memory: 4Gi
 
-  - name: pre-kubermatic-e2e-kubevirt-centos-1.19
-    decorate: true
-    optional: true
-    clone_uri: "ssh://git@github.com/kubermatic/kubermatic.git"
-    labels:
-      preset-kubevirt: "true"
-      preset-vault: "true"
-      preset-docker-pull: "true"
-      preset-docker-push: "true"
-      preset-repo-ssh: "true"
-      preset-e2e-ssh: "true"
-      preset-kubeconfig-ci: "true"
-      preset-kind-volume-mounts: "true"
-      preset-goproxy: "true"
-    spec:
-      containers:
-      - image: quay.io/kubermatic/e2e-kind:with-conformance-tests-v1.0.19-xrstf1
-        env:
-        - name: KUBERMATIC_EDITION
-          value: ee
-        - name: VERSIONS_TO_TEST
-          value: "v1.19.0"
-        - name: PROVIDER
-          value: "kubevirt"
-        - name: EXCLUDE_DISTRIBUTIONS
-          value: "ubuntu,coreos,flatcar,rhel"
-        - name: SERVICE_ACCOUNT_KEY
-          valueFrom:
-            secretKeyRef:
-              name: e2e-ci
-              key: serviceAccountSigningKey
-        command:
-        - "./hack/ci/ci-kind-e2e.sh"
-        # docker-in-docker needs privileged mode
-        securityContext:
-          privileged: true
-        resources:
-          requests:
-            memory: 4Gi
-            cpu: 3.5
-          limits:
-            memory: 4Gi
+  # - name: pre-kubermatic-e2e-kubevirt-centos-1.19
+  #   decorate: true
+  #   optional: true
+  #   clone_uri: "ssh://git@github.com/kubermatic/kubermatic.git"
+  #   labels:
+  #     preset-kubevirt: "true"
+  #     preset-vault: "true"
+  #     preset-docker-pull: "true"
+  #     preset-docker-push: "true"
+  #     preset-repo-ssh: "true"
+  #     preset-e2e-ssh: "true"
+  #     preset-kubeconfig-ci: "true"
+  #     preset-kind-volume-mounts: "true"
+  #     preset-goproxy: "true"
+  #   spec:
+  #     containers:
+  #     - image: quay.io/kubermatic/e2e-kind:with-conformance-tests-v1.0.19-xrstf1
+  #       env:
+  #       - name: KUBERMATIC_EDITION
+  #         value: ee
+  #       - name: VERSIONS_TO_TEST
+  #         value: "v1.19.0"
+  #       - name: PROVIDER
+  #         value: "kubevirt"
+  #       - name: EXCLUDE_DISTRIBUTIONS
+  #         value: "ubuntu,coreos,flatcar,rhel"
+  #       - name: SERVICE_ACCOUNT_KEY
+  #         valueFrom:
+  #           secretKeyRef:
+  #             name: e2e-ci
+  #             key: serviceAccountSigningKey
+  #       command:
+  #       - "./hack/ci/ci-kind-e2e.sh"
+  #       # docker-in-docker needs privileged mode
+  #       securityContext:
+  #         privileged: true
+  #       resources:
+  #         requests:
+  #           memory: 4Gi
+  #           cpu: 3.5
+  #         limits:
+  #           memory: 4Gi
 
-  - name: pre-kubermatic-e2e-hetzner-ubuntu-1.19
-    decorate: true
-    optional: true
-    clone_uri: "ssh://git@github.com/kubermatic/kubermatic.git"
-    labels:
-      preset-hetzner: "true"
-      preset-vault: "true"
-      preset-docker-pull: "true"
-      preset-docker-push: "true"
-      preset-repo-ssh: "true"
-      preset-e2e-ssh: "true"
-      preset-kubeconfig-ci: "true"
-      preset-kind-volume-mounts: "true"
-      preset-goproxy: "true"
-    spec:
-      containers:
-      - image: quay.io/kubermatic/e2e-kind:with-conformance-tests-v1.0.19-xrstf1
-        env:
-        - name: KUBERMATIC_EDITION
-          value: ee
-        - name: VERSIONS_TO_TEST
-          value: "v1.19.0"
-        - name: PROVIDER
-          value: "hetzner"
-        # Hetzner doesn't support coreos
-        - name: EXCLUDE_DISTRIBUTIONS
-          value: "centos,coreos,flatcar,rhel"
-        - name: DEFAULT_TIMEOUT_MINUTES
-          value: "20"
-        - name: SERVICE_ACCOUNT_KEY
-          valueFrom:
-            secretKeyRef:
-              name: e2e-ci
-              key: serviceAccountSigningKey
-        command:
-        - "./hack/ci/ci-kind-e2e.sh"
-        # docker-in-docker needs privileged mode
-        securityContext:
-          privileged: true
-        resources:
-          requests:
-            memory: 4Gi
-            cpu: 3.5
-          limits:
-            memory: 4Gi
+  # - name: pre-kubermatic-e2e-hetzner-ubuntu-1.19
+  #   decorate: true
+  #   optional: true
+  #   clone_uri: "ssh://git@github.com/kubermatic/kubermatic.git"
+  #   labels:
+  #     preset-hetzner: "true"
+  #     preset-vault: "true"
+  #     preset-docker-pull: "true"
+  #     preset-docker-push: "true"
+  #     preset-repo-ssh: "true"
+  #     preset-e2e-ssh: "true"
+  #     preset-kubeconfig-ci: "true"
+  #     preset-kind-volume-mounts: "true"
+  #     preset-goproxy: "true"
+  #   spec:
+  #     containers:
+  #     - image: quay.io/kubermatic/e2e-kind:with-conformance-tests-v1.0.19-xrstf1
+  #       env:
+  #       - name: KUBERMATIC_EDITION
+  #         value: ee
+  #       - name: VERSIONS_TO_TEST
+  #         value: "v1.19.0"
+  #       - name: PROVIDER
+  #         value: "hetzner"
+  #       # Hetzner doesn't support coreos
+  #       - name: EXCLUDE_DISTRIBUTIONS
+  #         value: "centos,coreos,flatcar,rhel"
+  #       - name: DEFAULT_TIMEOUT_MINUTES
+  #         value: "20"
+  #       - name: SERVICE_ACCOUNT_KEY
+  #         valueFrom:
+  #           secretKeyRef:
+  #             name: e2e-ci
+  #             key: serviceAccountSigningKey
+  #       command:
+  #       - "./hack/ci/ci-kind-e2e.sh"
+  #       # docker-in-docker needs privileged mode
+  #       securityContext:
+  #         privileged: true
+  #       resources:
+  #         requests:
+  #           memory: 4Gi
+  #           cpu: 3.5
+  #         limits:
+  #           memory: 4Gi
 
-  - name: pre-kubermatic-e2e-openstack-ubuntu-1.19
-    decorate: true
-    optional: true
-    clone_uri: "ssh://git@github.com/kubermatic/kubermatic.git"
-    labels:
-      preset-openstack: "true"
-      preset-vault: "true"
-      preset-docker-pull: "true"
-      preset-docker-push: "true"
-      preset-repo-ssh: "true"
-      preset-e2e-ssh: "true"
-      preset-kubeconfig-ci: "true"
-      preset-kind-volume-mounts: "true"
-      preset-goproxy: "true"
-    spec:
-      containers:
-      - image: quay.io/kubermatic/e2e-kind:with-conformance-tests-v1.0.19-xrstf1
-        env:
-        - name: KUBERMATIC_EDITION
-          value: ee
-        - name: VERSIONS_TO_TEST
-          value: "v1.19.0"
-        - name: PROVIDER
-          value: "openstack"
-        - name: EXCLUDE_DISTRIBUTIONS
-          value: "centos,coreos,flatcar,rhel"
-        - name: DEFAULT_TIMEOUT_MINUTES
-          value: "20"
-        - name: SERVICE_ACCOUNT_KEY
-          valueFrom:
-            secretKeyRef:
-              name: e2e-ci
-              key: serviceAccountSigningKey
-        command:
-        - "./hack/ci/ci-kind-e2e.sh"
-        # docker-in-docker needs privileged mode
-        securityContext:
-          privileged: true
-        resources:
-          requests:
-            memory: 4Gi
-            cpu: 3.5
-          limits:
-            memory: 4Gi
+  # - name: pre-kubermatic-e2e-openstack-ubuntu-1.19
+  #   decorate: true
+  #   optional: true
+  #   clone_uri: "ssh://git@github.com/kubermatic/kubermatic.git"
+  #   labels:
+  #     preset-openstack: "true"
+  #     preset-vault: "true"
+  #     preset-docker-pull: "true"
+  #     preset-docker-push: "true"
+  #     preset-repo-ssh: "true"
+  #     preset-e2e-ssh: "true"
+  #     preset-kubeconfig-ci: "true"
+  #     preset-kind-volume-mounts: "true"
+  #     preset-goproxy: "true"
+  #   spec:
+  #     containers:
+  #     - image: quay.io/kubermatic/e2e-kind:with-conformance-tests-v1.0.19-xrstf1
+  #       env:
+  #       - name: KUBERMATIC_EDITION
+  #         value: ee
+  #       - name: VERSIONS_TO_TEST
+  #         value: "v1.19.0"
+  #       - name: PROVIDER
+  #         value: "openstack"
+  #       - name: EXCLUDE_DISTRIBUTIONS
+  #         value: "centos,coreos,flatcar,rhel"
+  #       - name: DEFAULT_TIMEOUT_MINUTES
+  #         value: "20"
+  #       - name: SERVICE_ACCOUNT_KEY
+  #         valueFrom:
+  #           secretKeyRef:
+  #             name: e2e-ci
+  #             key: serviceAccountSigningKey
+  #       command:
+  #       - "./hack/ci/ci-kind-e2e.sh"
+  #       # docker-in-docker needs privileged mode
+  #       securityContext:
+  #         privileged: true
+  #       resources:
+  #         requests:
+  #           memory: 4Gi
+  #           cpu: 3.5
+  #         limits:
+  #           memory: 4Gi
 
-  - name: pre-kubermatic-e2e-openstack-centos-1.19
-    decorate: true
-    optional: true
-    clone_uri: "ssh://git@github.com/kubermatic/kubermatic.git"
-    labels:
-      preset-openstack: "true"
-      preset-vault: "true"
-      preset-docker-pull: "true"
-      preset-docker-push: "true"
-      preset-repo-ssh: "true"
-      preset-e2e-ssh: "true"
-      preset-kubeconfig-ci: "true"
-      preset-kind-volume-mounts: "true"
-      preset-goproxy: "true"
-    spec:
-      containers:
-      - image: quay.io/kubermatic/e2e-kind:with-conformance-tests-v1.0.19-xrstf1
-        env:
-        - name: KUBERMATIC_EDITION
-          value: ee
-        - name: VERSIONS_TO_TEST
-          value: "v1.19.0"
-        - name: PROVIDER
-          value: "openstack"
-        - name: DEFAULT_TIMEOUT_MINUTES
-          value: "20"
-        - name: EXCLUDE_DISTRIBUTIONS
-          value: "coreos,ubuntu,flatcar,rhel"
-        - name: SERVICE_ACCOUNT_KEY
-          valueFrom:
-            secretKeyRef:
-              name: e2e-ci
-              key: serviceAccountSigningKey
-        command:
-        - "./hack/ci/ci-kind-e2e.sh"
-        # docker-in-docker needs privileged mode
-        securityContext:
-          privileged: true
-        resources:
-          requests:
-            memory: 4Gi
-            cpu: 3.5
-          limits:
-            memory: 4Gi
+  # - name: pre-kubermatic-e2e-openstack-centos-1.19
+  #   decorate: true
+  #   optional: true
+  #   clone_uri: "ssh://git@github.com/kubermatic/kubermatic.git"
+  #   labels:
+  #     preset-openstack: "true"
+  #     preset-vault: "true"
+  #     preset-docker-pull: "true"
+  #     preset-docker-push: "true"
+  #     preset-repo-ssh: "true"
+  #     preset-e2e-ssh: "true"
+  #     preset-kubeconfig-ci: "true"
+  #     preset-kind-volume-mounts: "true"
+  #     preset-goproxy: "true"
+  #   spec:
+  #     containers:
+  #     - image: quay.io/kubermatic/e2e-kind:with-conformance-tests-v1.0.19-xrstf1
+  #       env:
+  #       - name: KUBERMATIC_EDITION
+  #         value: ee
+  #       - name: VERSIONS_TO_TEST
+  #         value: "v1.19.0"
+  #       - name: PROVIDER
+  #         value: "openstack"
+  #       - name: DEFAULT_TIMEOUT_MINUTES
+  #         value: "20"
+  #       - name: EXCLUDE_DISTRIBUTIONS
+  #         value: "coreos,ubuntu,flatcar,rhel"
+  #       - name: SERVICE_ACCOUNT_KEY
+  #         valueFrom:
+  #           secretKeyRef:
+  #             name: e2e-ci
+  #             key: serviceAccountSigningKey
+  #       command:
+  #       - "./hack/ci/ci-kind-e2e.sh"
+  #       # docker-in-docker needs privileged mode
+  #       securityContext:
+  #         privileged: true
+  #       resources:
+  #         requests:
+  #           memory: 4Gi
+  #           cpu: 3.5
+  #         limits:
+  #           memory: 4Gi
 
-  - name: pre-kubermatic-e2e-vsphere-ubuntu-1.19
-    decorate: true
-    run_if_changed: "pkg/provider/cloud/vsphere"
-    clone_uri: "ssh://git@github.com/kubermatic/kubermatic.git"
-    labels:
-      preset-vsphere: "true"
-      preset-vault: "true"
-      preset-docker-pull: "true"
-      preset-docker-push: "true"
-      preset-repo-ssh: "true"
-      preset-e2e-ssh: "true"
-      preset-kubeconfig-ci: "true"
-      preset-kind-volume-mounts: "true"
-      preset-goproxy: "true"
-    spec:
-      containers:
-      - image: quay.io/kubermatic/e2e-kind:with-conformance-tests-v1.0.19-xrstf1
-        env:
-        - name: KUBERMATIC_EDITION
-          value: ee
-        - name: VERSIONS_TO_TEST
-          value: "v1.19.0"
-        - name: PROVIDER
-          value: "vsphere"
-        - name: EXCLUDE_DISTRIBUTIONS
-          value: "centos,coreos,flatcar,rhel"
-        - name: SERVICE_ACCOUNT_KEY
-          valueFrom:
-            secretKeyRef:
-              name: e2e-ci
-              key: serviceAccountSigningKey
-        command:
-        - "./hack/ci/ci-kind-e2e.sh"
-        # docker-in-docker needs privileged mode
-        securityContext:
-          privileged: true
-        resources:
-          requests:
-            memory: 4Gi
-            cpu: 3.5
-          limits:
-            memory: 4Gi
+  # - name: pre-kubermatic-e2e-vsphere-ubuntu-1.19
+  #   decorate: true
+  #   run_if_changed: "pkg/provider/cloud/vsphere"
+  #   clone_uri: "ssh://git@github.com/kubermatic/kubermatic.git"
+  #   labels:
+  #     preset-vsphere: "true"
+  #     preset-vault: "true"
+  #     preset-docker-pull: "true"
+  #     preset-docker-push: "true"
+  #     preset-repo-ssh: "true"
+  #     preset-e2e-ssh: "true"
+  #     preset-kubeconfig-ci: "true"
+  #     preset-kind-volume-mounts: "true"
+  #     preset-goproxy: "true"
+  #   spec:
+  #     containers:
+  #     - image: quay.io/kubermatic/e2e-kind:with-conformance-tests-v1.0.19-xrstf1
+  #       env:
+  #       - name: KUBERMATIC_EDITION
+  #         value: ee
+  #       - name: VERSIONS_TO_TEST
+  #         value: "v1.19.0"
+  #       - name: PROVIDER
+  #         value: "vsphere"
+  #       - name: EXCLUDE_DISTRIBUTIONS
+  #         value: "centos,coreos,flatcar,rhel"
+  #       - name: SERVICE_ACCOUNT_KEY
+  #         valueFrom:
+  #           secretKeyRef:
+  #             name: e2e-ci
+  #             key: serviceAccountSigningKey
+  #       command:
+  #       - "./hack/ci/ci-kind-e2e.sh"
+  #       # docker-in-docker needs privileged mode
+  #       securityContext:
+  #         privileged: true
+  #       resources:
+  #         requests:
+  #           memory: 4Gi
+  #           cpu: 3.5
+  #         limits:
+  #           memory: 4Gi
 
-  - name: pre-kubermatic-e2e-vsphere-ubuntu-1.19-customfolder
-    decorate: true
-    optional: true
-    run_if_changed: "pkg/provider/cloud/vsphere"
-    clone_uri: "ssh://git@github.com/kubermatic/kubermatic.git"
-    labels:
-      preset-vsphere: "true"
-      preset-vault: "true"
-      preset-docker-pull: "true"
-      preset-docker-push: "true"
-      preset-repo-ssh: "true"
-      preset-e2e-ssh: "true"
-      preset-kubeconfig-ci: "true"
-      preset-kind-volume-mounts: "true"
-      preset-goproxy: "true"
-    spec:
-      containers:
-      - image: quay.io/kubermatic/e2e-kind:with-conformance-tests-v1.0.19-xrstf1
-        env:
-        - name: KUBERMATIC_EDITION
-          value: ee
-        - name: VERSIONS_TO_TEST
-          value: "v1.19.0"
-        - name: PROVIDER
-          value: "vsphere"
-        - name: EXCLUDE_DISTRIBUTIONS
-          value: "centos,coreos,flatcar,rhel"
-        - name: SCENARIO_OPTIONS
-          value: "custom-folder"
-        - name: SERVICE_ACCOUNT_KEY
-          valueFrom:
-            secretKeyRef:
-              name: e2e-ci
-              key: serviceAccountSigningKey
-        command:
-        - "./hack/ci/ci-kind-e2e.sh"
-        # docker-in-docker needs privileged mode
-        securityContext:
-          privileged: true
-        resources:
-          requests:
-            memory: 4Gi
-            cpu: 3.5
-          limits:
-            memory: 4Gi
+  # - name: pre-kubermatic-e2e-vsphere-ubuntu-1.19-customfolder
+  #   decorate: true
+  #   optional: true
+  #   run_if_changed: "pkg/provider/cloud/vsphere"
+  #   clone_uri: "ssh://git@github.com/kubermatic/kubermatic.git"
+  #   labels:
+  #     preset-vsphere: "true"
+  #     preset-vault: "true"
+  #     preset-docker-pull: "true"
+  #     preset-docker-push: "true"
+  #     preset-repo-ssh: "true"
+  #     preset-e2e-ssh: "true"
+  #     preset-kubeconfig-ci: "true"
+  #     preset-kind-volume-mounts: "true"
+  #     preset-goproxy: "true"
+  #   spec:
+  #     containers:
+  #     - image: quay.io/kubermatic/e2e-kind:with-conformance-tests-v1.0.19-xrstf1
+  #       env:
+  #       - name: KUBERMATIC_EDITION
+  #         value: ee
+  #       - name: VERSIONS_TO_TEST
+  #         value: "v1.19.0"
+  #       - name: PROVIDER
+  #         value: "vsphere"
+  #       - name: EXCLUDE_DISTRIBUTIONS
+  #         value: "centos,coreos,flatcar,rhel"
+  #       - name: SCENARIO_OPTIONS
+  #         value: "custom-folder"
+  #       - name: SERVICE_ACCOUNT_KEY
+  #         valueFrom:
+  #           secretKeyRef:
+  #             name: e2e-ci
+  #             key: serviceAccountSigningKey
+  #       command:
+  #       - "./hack/ci/ci-kind-e2e.sh"
+  #       # docker-in-docker needs privileged mode
+  #       securityContext:
+  #         privileged: true
+  #       resources:
+  #         requests:
+  #           memory: 4Gi
+  #           cpu: 3.5
+  #         limits:
+  #           memory: 4Gi
 
-  - name: pre-kubermatic-e2e-vsphere-ubuntu-1.19-datastore-cluster
-    decorate: true
-    optional: true
-    run_if_changed: "pkg/provider/cloud/vsphere"
-    clone_uri: "ssh://git@github.com/kubermatic/kubermatic.git"
-    labels:
-      preset-vsphere: "true"
-      preset-vault: "true"
-      preset-docker-pull: "true"
-      preset-docker-push: "true"
-      preset-repo-ssh: "true"
-      preset-e2e-ssh: "true"
-      preset-kubeconfig-ci: "true"
-      preset-kind-volume-mounts: "true"
-      preset-goproxy: "true"
-    spec:
-      containers:
-        - image: quay.io/kubermatic/e2e-kind:with-conformance-tests-v1.0.19-xrstf1
-          env:
-            - name: KUBERMATIC_EDITION
-              value: ee
-            - name: VERSIONS_TO_TEST
-              value: "v1.19.0"
-            - name: PROVIDER
-              value: "vsphere"
-            - name: SCENARIO_OPTIONS
-              value: "datastore-cluster"
-            - name: SERVICE_ACCOUNT_KEY
-              valueFrom:
-                secretKeyRef:
-                  name: e2e-ci
-                  key: serviceAccountSigningKey
-          command:
-            - "./hack/ci/ci-kind-e2e.sh"
-          # docker-in-docker needs privileged mode
-          securityContext:
-            privileged: true
-          resources:
-            requests:
-              memory: 4Gi
-              cpu: 3.5
-            limits:
-              memory: 4Gi
+  # - name: pre-kubermatic-e2e-vsphere-ubuntu-1.19-datastore-cluster
+  #   decorate: true
+  #   optional: true
+  #   run_if_changed: "pkg/provider/cloud/vsphere"
+  #   clone_uri: "ssh://git@github.com/kubermatic/kubermatic.git"
+  #   labels:
+  #     preset-vsphere: "true"
+  #     preset-vault: "true"
+  #     preset-docker-pull: "true"
+  #     preset-docker-push: "true"
+  #     preset-repo-ssh: "true"
+  #     preset-e2e-ssh: "true"
+  #     preset-kubeconfig-ci: "true"
+  #     preset-kind-volume-mounts: "true"
+  #     preset-goproxy: "true"
+  #   spec:
+  #     containers:
+  #       - image: quay.io/kubermatic/e2e-kind:with-conformance-tests-v1.0.19-xrstf1
+  #         env:
+  #           - name: KUBERMATIC_EDITION
+  #             value: ee
+  #           - name: VERSIONS_TO_TEST
+  #             value: "v1.19.0"
+  #           - name: PROVIDER
+  #             value: "vsphere"
+  #           - name: SCENARIO_OPTIONS
+  #             value: "datastore-cluster"
+  #           - name: SERVICE_ACCOUNT_KEY
+  #             valueFrom:
+  #               secretKeyRef:
+  #                 name: e2e-ci
+  #                 key: serviceAccountSigningKey
+  #         command:
+  #           - "./hack/ci/ci-kind-e2e.sh"
+  #         # docker-in-docker needs privileged mode
+  #         securityContext:
+  #           privileged: true
+  #         resources:
+  #           requests:
+  #             memory: 4Gi
+  #             cpu: 3.5
+  #           limits:
+  #             memory: 4Gi
 
-  #########################################################
-  # Base Openshift Tests
-  #########################################################
+  # #########################################################
+  # # Base Openshift Tests
+  # #########################################################
 
-  - name: pre-kubermatic-e2e-aws-openshift-4.1
-    decorate: true
-    optional: true
-    run_if_changed: "openshift_addons/"
-    clone_uri: "ssh://git@github.com/kubermatic/kubermatic.git"
-    labels:
-      preset-aws: "true"
-      preset-openshift-pull-secret: "true"
-      preset-vault: "true"
-      preset-docker-push: "true"
-      preset-docker-pull: "true"
-      preset-oidc: "true"
-      preset-repo-ssh: "true"
-      preset-e2e-ssh: "true"
-      preset-kubeconfig-ci: "true"
-      preset-kind-volume-mounts: "true"
-      preset-goproxy: "true"
-    spec:
-      containers:
-      - image: quay.io/kubermatic/e2e-kind:with-conformance-tests-v1.0.19-xrstf1
-        env:
-        - name: KUBERMATIC_EDITION
-          value: ee
-        - name: OPENSHIFT
-          value: "true"
-        - name: OPENSHIFT_VERSION
-          value: "4.1.18"
-        - name: SERVICE_ACCOUNT_KEY
-          valueFrom:
-            secretKeyRef:
-              name: e2e-ci
-              key: serviceAccountSigningKey
-        command:
-        - "./hack/ci/ci-kind-e2e.sh"
-        # docker-in-docker needs privileged mode
-        securityContext:
-          privileged: true
-        resources:
-          requests:
-            memory: 4Gi
-            cpu: 3.5
-          limits:
-            memory: 4Gi
+  # - name: pre-kubermatic-e2e-aws-openshift-4.1
+  #   decorate: true
+  #   optional: true
+  #   run_if_changed: "openshift_addons/"
+  #   clone_uri: "ssh://git@github.com/kubermatic/kubermatic.git"
+  #   labels:
+  #     preset-aws: "true"
+  #     preset-openshift-pull-secret: "true"
+  #     preset-vault: "true"
+  #     preset-docker-push: "true"
+  #     preset-docker-pull: "true"
+  #     preset-oidc: "true"
+  #     preset-repo-ssh: "true"
+  #     preset-e2e-ssh: "true"
+  #     preset-kubeconfig-ci: "true"
+  #     preset-kind-volume-mounts: "true"
+  #     preset-goproxy: "true"
+  #   spec:
+  #     containers:
+  #     - image: quay.io/kubermatic/e2e-kind:with-conformance-tests-v1.0.19-xrstf1
+  #       env:
+  #       - name: KUBERMATIC_EDITION
+  #         value: ee
+  #       - name: OPENSHIFT
+  #         value: "true"
+  #       - name: OPENSHIFT_VERSION
+  #         value: "4.1.18"
+  #       - name: SERVICE_ACCOUNT_KEY
+  #         valueFrom:
+  #           secretKeyRef:
+  #             name: e2e-ci
+  #             key: serviceAccountSigningKey
+  #       command:
+  #       - "./hack/ci/ci-kind-e2e.sh"
+  #       # docker-in-docker needs privileged mode
+  #       securityContext:
+  #         privileged: true
+  #       resources:
+  #         requests:
+  #           memory: 4Gi
+  #           cpu: 3.5
+  #         limits:
+  #           memory: 4Gi
 
-  #########################################################
-  # REST API e2e tests
-  #########################################################
+  # #########################################################
+  # # REST API e2e tests
+  # #########################################################
 
-  - name: pre-kubermatic-api-e2e
-    run_if_changed: "(cmd/|codegen/|hack/|pkg/|charts/kubermatic|.prow.yaml)"
-    decorate: true
-    clone_uri: "ssh://git@github.com/kubermatic/kubermatic.git"
-    labels:
-      preset-digitalocean: "true"
-      preset-openstack: "true"
-      preset-azure: "true"
-      preset-kubeconfig-ci: "true"
-      preset-docker-pull: "true"
-      preset-docker-push: "true"
-      preset-gce: "true"
-      preset-kind-volume-mounts: "true"
-      preset-vault: "true"
-      preset-goproxy: "true"
-    spec:
-      containers:
-      - image: quay.io/kubermatic/e2e-kind:with-conformance-tests-v1.0.19-xrstf1
-        imagePullPolicy: Always
-        command:
-        - "./hack/ci/ci_run_api_e2e.sh"
-        securityContext:
-          privileged: true
-        resources:
-          requests:
-            memory: 4Gi
-            cpu: 2
-          limits:
-            memory: 6Gi
-        env:
-        - name: KUBERMATIC_EDITION
-          value: ee
-        - name: SERVICE_ACCOUNT_KEY
-          valueFrom:
-            secretKeyRef:
-              name: e2e-ci
-              key: serviceAccountSigningKey
+  # - name: pre-kubermatic-api-e2e
+  #   run_if_changed: "(cmd/|codegen/|hack/|pkg/|charts/kubermatic|.prow.yaml)"
+  #   decorate: true
+  #   clone_uri: "ssh://git@github.com/kubermatic/kubermatic.git"
+  #   labels:
+  #     preset-digitalocean: "true"
+  #     preset-openstack: "true"
+  #     preset-azure: "true"
+  #     preset-kubeconfig-ci: "true"
+  #     preset-docker-pull: "true"
+  #     preset-docker-push: "true"
+  #     preset-gce: "true"
+  #     preset-kind-volume-mounts: "true"
+  #     preset-vault: "true"
+  #     preset-goproxy: "true"
+  #   spec:
+  #     containers:
+  #     - image: quay.io/kubermatic/e2e-kind:with-conformance-tests-v1.0.19-xrstf1
+  #       imagePullPolicy: Always
+  #       command:
+  #       - "./hack/ci/ci_run_api_e2e.sh"
+  #       securityContext:
+  #         privileged: true
+  #       resources:
+  #         requests:
+  #           memory: 4Gi
+  #           cpu: 2
+  #         limits:
+  #           memory: 6Gi
+  #       env:
+  #       - name: KUBERMATIC_EDITION
+  #         value: ee
+  #       - name: SERVICE_ACCOUNT_KEY
+  #         valueFrom:
+  #           secretKeyRef:
+  #             name: e2e-ci
+  #             key: serviceAccountSigningKey
 
-  #########################################################
-  # misc
-  #########################################################
+  # #########################################################
+  # # misc
+  # #########################################################
 
-  - name: pre-kubermatic-e2e-gcp-offline
-    decorate: true
-    clone_uri: "ssh://git@github.com/kubermatic/kubermatic.git"
-    labels:
-      preset-gce: "true"
-      preset-vault: "true"
-      preset-docker-push: "true"
-      preset-repo-ssh: "true"
-      preset-goproxy: "true"
-    spec:
-      containers:
-      - image: quay.io/kubermatic/go-docker:14.2-1806-0
-        command:
-        - "./hack/ci/ci-run-offline-test.sh"
-        # docker-in-docker needs privileged mode
-        securityContext:
-          privileged: true
-        resources:
-          requests:
-            memory: 2.5Gi
-            cpu: 500m
-          limits:
-            memory: 4Gi
-            cpu: 2
+  # - name: pre-kubermatic-e2e-gcp-offline
+  #   decorate: true
+  #   clone_uri: "ssh://git@github.com/kubermatic/kubermatic.git"
+  #   labels:
+  #     preset-gce: "true"
+  #     preset-vault: "true"
+  #     preset-docker-push: "true"
+  #     preset-repo-ssh: "true"
+  #     preset-goproxy: "true"
+  #   spec:
+  #     containers:
+  #     - image: quay.io/kubermatic/go-docker:14.2-1806-0
+  #       command:
+  #       - "./hack/ci/ci-run-offline-test.sh"
+  #       # docker-in-docker needs privileged mode
+  #       securityContext:
+  #         privileged: true
+  #       resources:
+  #         requests:
+  #           memory: 2.5Gi
+  #           cpu: 500m
+  #         limits:
+  #           memory: 4Gi
+  #           cpu: 2
 
-  - name: pre-kubermatic-canary-deployment-ci-kubermatic-io
-    max_concurrency: 1
-    decorate: true
-    # * hack: Contains all the deployment scripting
-    # * charts/kubermatic: Contains the chart
-    # * pkg/crd/kubermatic/v1: Contains the Seed and Datacenter types, if
-    #   this gets out of sync with whats in the secrets repo, we fail because we use
-    #   yaml.UnmarshalStrict
-    run_if_changed: "(hack|charts/kubermatic|pkg/crd/kubermatic/v1)"
-    clone_uri: "ssh://git@github.com/kubermatic/kubermatic.git"
-    branches:
-    - ^master$
-    labels:
-      preset-docker-push: "true"
-      preset-vault: "true"
-      preset-repo-ssh: "true"
-      preset-goproxy: "true"
-    spec:
-      containers:
-      - image: quay.io/kubermatic/go-docker:14.2-1806-0
-        command:
-        - ./hack/ci/ci-deploy-ci-kubermatic-io.sh
-        env:
-        - name: KUBERMATIC_EDITION
-          value: ee
-        - name: CANARY_DEPLOYMENT
-          value: "true"
-        # docker-in-docker needs privileged mode
-        securityContext:
-          privileged: true
-        resources:
-          requests:
-            cpu: 1
-            memory: 1Gi
-          limits:
-            memory: 3Gi
+  # - name: pre-kubermatic-canary-deployment-ci-kubermatic-io
+  #   max_concurrency: 1
+  #   decorate: true
+  #   # * hack: Contains all the deployment scripting
+  #   # * charts/kubermatic: Contains the chart
+  #   # * pkg/crd/kubermatic/v1: Contains the Seed and Datacenter types, if
+  #   #   this gets out of sync with whats in the secrets repo, we fail because we use
+  #   #   yaml.UnmarshalStrict
+  #   run_if_changed: "(hack|charts/kubermatic|pkg/crd/kubermatic/v1)"
+  #   clone_uri: "ssh://git@github.com/kubermatic/kubermatic.git"
+  #   branches:
+  #   - ^master$
+  #   labels:
+  #     preset-docker-push: "true"
+  #     preset-vault: "true"
+  #     preset-repo-ssh: "true"
+  #     preset-goproxy: "true"
+  #   spec:
+  #     containers:
+  #     - image: quay.io/kubermatic/go-docker:14.2-1806-0
+  #       command:
+  #       - ./hack/ci/ci-deploy-ci-kubermatic-io.sh
+  #       env:
+  #       - name: KUBERMATIC_EDITION
+  #         value: ee
+  #       - name: CANARY_DEPLOYMENT
+  #         value: "true"
+  #       # docker-in-docker needs privileged mode
+  #       securityContext:
+  #         privileged: true
+  #       resources:
+  #         requests:
+  #           cpu: 1
+  #           memory: 1Gi
+  #         limits:
+  #           memory: 3Gi
 
-  - name: pre-kubermatic-test-integration
-    run_if_changed: "^(cmd|codegen|hack|pkg)/"
-    decorate: true
-    clone_uri: "ssh://git@github.com/kubermatic/kubermatic.git"
-    labels:
-      preset-vsphere: "true"
-      preset-goproxy: "true"
-    spec:
-      containers:
-      - image: quay.io/kubermatic/integration-tests:3-1
-        command:
-        - make
-        args:
-        - test-integration
-        resources:
-          requests:
-            memory: 4Gi
-            cpu: 2
-          limits:
-            memory: 6Gi
-            cpu: 2
-        env:
-        - name: KUBERMATIC_EDITION
-          value: ee
+  # - name: pre-kubermatic-test-integration
+  #   run_if_changed: "^(cmd|codegen|hack|pkg)/"
+  #   decorate: true
+  #   clone_uri: "ssh://git@github.com/kubermatic/kubermatic.git"
+  #   labels:
+  #     preset-vsphere: "true"
+  #     preset-goproxy: "true"
+  #   spec:
+  #     containers:
+  #     - image: quay.io/kubermatic/integration-tests:3-1
+  #       command:
+  #       - make
+  #       args:
+  #       - test-integration
+  #       resources:
+  #         requests:
+  #           memory: 4Gi
+  #           cpu: 2
+  #         limits:
+  #           memory: 6Gi
+  #           cpu: 2
+  #       env:
+  #       - name: KUBERMATIC_EDITION
+  #         value: ee

--- a/hack/ci/ci-setup-kubermatic-in-kind.sh
+++ b/hack/ci/ci-setup-kubermatic-in-kind.sh
@@ -172,10 +172,12 @@ retry 5 curl -s --fail http://127.0.0.1:2047/metrics -o /dev/null
 echodate "Cluster exposer is running"
 
 echodate "Setting up iptables rules for to make nodeports available"
+KIND_NETWORK_IF=$(ip -br addr | grep -- 'br-' | cut -d' ' -f1)
+
 iptables -t nat -A PREROUTING -i eth0 -p tcp -m multiport --dports=30000:33000 -j DNAT --to-destination 172.18.0.2
 # By default all traffic gets dropped unless specified (tested with docker
 # server 18.09.1)
-iptables -t filter -I DOCKER-USER -d 172.18.0.2/32 ! -i docker0 -o docker0 -p tcp -m multiport --dports=30000:33000 -j ACCEPT
+iptables -t filter -I DOCKER-USER -d 172.18.0.2/32 ! -i $KIND_NETWORK_IF -o $KIND_NETWORK_IF -p tcp -m multiport --dports=30000:33000 -j ACCEPT
 
 # Docker sets up a MASQUERADE rule for postrouting, so nothing to do for us
 echodate "Successfully set up iptables rules for nodeports"

--- a/hack/ci/ci-setup-kubermatic-in-kind.sh
+++ b/hack/ci/ci-setup-kubermatic-in-kind.sh
@@ -172,10 +172,10 @@ retry 5 curl -s --fail http://127.0.0.1:2047/metrics -o /dev/null
 echodate "Cluster exposer is running"
 
 echodate "Setting up iptables rules for to make nodeports available"
-iptables -t nat -A PREROUTING -i eth0 -p tcp -m multiport --dports=30000:33000 -j DNAT --to-destination 172.17.0.2
+iptables -t nat -A PREROUTING -i eth0 -p tcp -m multiport --dports=30000:33000 -j DNAT --to-destination 172.18.0.2
 # By default all traffic gets dropped unless specified (tested with docker
 # server 18.09.1)
-iptables -t filter -I DOCKER-USER -d 172.17.0.2/32 ! -i docker0 -o docker0 -p tcp -m multiport --dports=30000:33000 -j ACCEPT
+iptables -t filter -I DOCKER-USER -d 172.18.0.2/32 ! -i docker0 -o docker0 -p tcp -m multiport --dports=30000:33000 -j ACCEPT
 
 # Docker sets up a MASQUERADE rule for postrouting, so nothing to do for us
 echodate "Successfully set up iptables rules for nodeports"

--- a/hack/ci/ci-setup-kubermatic-in-kind.sh
+++ b/hack/ci/ci-setup-kubermatic-in-kind.sh
@@ -130,7 +130,7 @@ echodate "Creating the kind cluster"
 export KUBECONFIG=~/.kube/config
 
 beforeKindCreate=$(nowms)
-nodeVersion=v1.15.6
+nodeVersion=v1.18.2
 kind create cluster --name ${SEED_NAME} --image=kindest/node:$nodeVersion
 pushElapsed kind_cluster_create_duration_milliseconds $beforeKindCreate "node_version=\"$nodeVersion\""
 

--- a/hack/ci/ci-setup-legacy-kubermatic-in-kind.sh
+++ b/hack/ci/ci-setup-legacy-kubermatic-in-kind.sh
@@ -175,10 +175,12 @@ retry 5 curl -s --fail http://127.0.0.1:2047/metrics -o /dev/null
 echodate "Cluster exposer is running"
 
 echodate "Setting up iptables rules for to make nodeports available"
-iptables -t nat -A PREROUTING -i eth0 -p tcp -m multiport --dports=30000:33000 -j DNAT --to-destination 172.17.0.2
+KIND_NETWORK_IF=$(ip -br addr | grep -- 'br-' | cut -d' ' -f1)
+
+iptables -t nat -A PREROUTING -i eth0 -p tcp -m multiport --dports=30000:33000 -j DNAT --to-destination 172.18.0.2
 # By default all traffic gets dropped unless specified (tested with docker
 # server 18.09.1)
-iptables -t filter -I DOCKER-USER -d 172.17.0.2/32 ! -i docker0 -o docker0 -p tcp -m multiport --dports=30000:33000 -j ACCEPT
+iptables -t filter -I DOCKER-USER -d 172.18.0.2/32 ! -i $KIND_NETWORK_IF -o $KIND_NETWORK_IF -p tcp -m multiport --dports=30000:33000 -j ACCEPT
 
 # Docker sets up a MASQUERADE rule for postrouting, so nothing to do for us
 echodate "Successfully set up iptables rules for nodeports"

--- a/hack/ci/ci-setup-legacy-kubermatic-in-kind.sh
+++ b/hack/ci/ci-setup-legacy-kubermatic-in-kind.sh
@@ -133,7 +133,7 @@ echodate "Creating the kind cluster"
 export KUBECONFIG=~/.kube/config
 
 beforeKindCreate=$(nowms)
-nodeVersion=v1.15.6
+nodeVersion=v1.18.2
 kind create cluster --name ${SEED_NAME} --image=kindest/node:$nodeVersion
 pushElapsed kind_cluster_create_duration_milliseconds $beforeKindCreate "node_version=\"$nodeVersion\""
 


### PR DESCRIPTION
**What this PR does / why we need it**:
This updates kind. Kind now has its own Docker network, so the iptables stuff had to be adjusted to dynamically find the correct bridge interface.

**Does this PR introduce a user-facing change?**:
```release-note
NONE
```
