### PR TITLE
Add dynamic etcd cluster size for tls certificate

### DIFF
--- a/pkg/resources/etcd/statefulset.go
+++ b/pkg/resources/etcd/statefulset.go
@@ -348,11 +348,7 @@ func ImageTag(c *kubermaticv1.Cluster) string {
 }
 
 func computeReplicas(data etcdStatefulSetCreatorData, set *appsv1.StatefulSet) int {
-	etcdClusterSize := data.Cluster().Spec.ComponentsOverride.Etcd.ClusterSize
-	// handle existing clusters that don't have a configured size
-	if etcdClusterSize < kubermaticv1.DefaultEtcdClusterSize {
-		etcdClusterSize = kubermaticv1.DefaultEtcdClusterSize
-	}
+	etcdClusterSize := etcdClusterSize(data.Cluster())
 	if set.Spec.Replicas == nil { // new replicaset
 		return etcdClusterSize
 	}
@@ -384,4 +380,13 @@ func getLauncherArgs(enableCorruptionCheck bool) []string {
 		command = append(command, "-enable-corruption-check")
 	}
 	return command
+}
+
+func etcdClusterSize(data *kubermaticv1.Cluster) int {
+	etcdClusterSize := data.Spec.ComponentsOverride.Etcd.ClusterSize
+	// handle existing clusters that don't have a configured size
+	if etcdClusterSize < kubermaticv1.DefaultEtcdClusterSize {
+		etcdClusterSize = kubermaticv1.DefaultEtcdClusterSize
+	}
+	return etcdClusterSize
 }

--- a/pkg/resources/etcd/tls-serving-certificate.go
+++ b/pkg/resources/etcd/tls-serving-certificate.go
@@ -53,7 +53,8 @@ func TLSCertificateCreator(data tlsCertificateCreatorData) reconciling.NamedSecr
 				},
 			}
 
-			for i := 0; i < 3; i++ {
+			etcdClusterSize := etcdClusterSize(data.Cluster())
+			for i := 0; i < etcdClusterSize; i++ {
 				// Member name
 				podName := fmt.Sprintf("etcd-%d", i)
 				altNames.DNSNames = append(altNames.DNSNames, podName)


### PR DESCRIPTION
**What this PR does / why we need it**:
Currently when specifying a custom number of etcd replicas, the certificate won't be updated accordingly.

TLS certificate now uses dynamic etcd cluster size instead of hardcoded
number to make sure that all etcds are reachable with the certificate

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Documentation**:
<!-- Add links to the related documentation changes related to this pull request. E.g. the link to the kubermatic/docs pullrequest. -->

**Does this PR introduce a user-facing change?**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If  no release note is required, just write "NONE".
-->
```release-note
NONE
```
