### PR TITLE
allow custom envvar definitions for dex to be passed via the oauth chart

### DIFF
--- a/charts/oauth/Chart.yaml
+++ b/charts/oauth/Chart.yaml
@@ -14,7 +14,7 @@
 
 apiVersion: v1
 name: oauth
-version: 1.2.6
+version: 1.3.0
 appVersion: v2.24.0
 description: Dex
 keywords:

--- a/charts/oauth/templates/deployment.yaml
+++ b/charts/oauth/templates/deployment.yaml
@@ -39,6 +39,9 @@ spec:
       - image: {{ .Values.dex.image.repository }}:{{ .Values.dex.image.tag }}
         name: dex
         command: ["/usr/local/bin/dex", "serve", "/etc/dex/cfg/config.yaml"]
+        {{- if .Values.dex.env }}
+        env: {{ .Values.dex.env | toYaml | trim | nindent 8}}
+        {{- end }}
         ports:
         - name: https
           containerPort: 5556

--- a/charts/oauth/templates/deployment.yaml
+++ b/charts/oauth/templates/deployment.yaml
@@ -40,7 +40,7 @@ spec:
         name: dex
         command: ["/usr/local/bin/dex", "serve", "/etc/dex/cfg/config.yaml"]
         {{- if .Values.dex.env }}
-        env: {{ .Values.dex.env | toYaml | trim | nindent 8}}
+        env: {{ toYaml .Values.dex.env | trim | nindent 8 }}
         {{- end }}
         ports:
         - name: https

--- a/charts/oauth/values.yaml
+++ b/charts/oauth/values.yaml
@@ -20,6 +20,13 @@ dex:
   # this options allows setting custom envvars in the dex container
   # this list is directly handed to the container spec
   env: []
+  #  - name: HTTP_PROXY
+  #    value: "http://USER:PASSWORD@IPADDR:PORT"
+  #  - name: HTTPS_PROXY
+  #    valueFrom:
+  #     secretKeyRef:
+  #       key: HTTPS_PROXY
+  #       name: http-proxy-secret
   ingress:
     # this option is required
     host: ""

--- a/charts/oauth/values.yaml
+++ b/charts/oauth/values.yaml
@@ -17,6 +17,9 @@ dex:
     repository: "quay.io/dexidp/dex"
     tag: "v2.24.0"
   replicas: 2
+  # this options allows setting custom envvars in the dex container
+  # this list is directly handed to the container spec
+  env: []
   ingress:
     # this option is required
     host: ""


### PR DESCRIPTION
**What this PR does / why we need it**: allow custom envvar definitions for dex to be passed via the oauth chart 

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #5826 

**Special notes for your reviewer**:

**Documentation**:
<!-- Add links to the related documentation changes related to this pull request. E.g. the link to the kubermatic/docs pullrequest. --> not yet- only if this approach is deemed good by @irozzo-1A

**Does this PR introduce a user-facing change?**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If  no release note is required, just write "NONE".
-->
```release-note
Allow custom envvar definitions for dex to be passed via the oauth chart. values key: `dex.env`
```
