### PR TITLE
Provide quickstart infos for DNS settings in Kubermatic Installer

### DIFF
--- a/cmd/kubermatic-installer/cmd_deploy.go
+++ b/cmd/kubermatic-installer/cmd_deploy.go
@@ -281,8 +281,6 @@ func loadHelmValues(filename string) (*yamled.Document, error) {
 }
 
 func greeting() string {
-	rand.Seed(time.Now().UnixNano())
-
 	greetings := []string{
 		"Have a nice day!",
 		"Time for a break, maybe? ☺",

--- a/cmd/kubermatic-installer/main.go
+++ b/cmd/kubermatic-installer/main.go
@@ -17,7 +17,9 @@ limitations under the License.
 package main
 
 import (
+	"math/rand"
 	"os"
+	"time"
 
 	"github.com/urfave/cli"
 
@@ -40,6 +42,8 @@ var (
 )
 
 func main() {
+	rand.Seed(time.Now().UnixNano())
+
 	logger := log.NewLogrus()
 	versions := common.NewDefaultVersions()
 


### PR DESCRIPTION
**What this PR does / why we need it**:
When everything has been installed, users generally need to make sure certain DNS records have been created. The installer can determine the required settings automatically and inform the user with a nice, friendly overview.

For a basic setup with LoadBalancers that provide an IP:

![screenshot-2020-09-08-195416](https://user-images.githubusercontent.com/127499/92515724-56ef1c00-f214-11ea-87c5-3a80d86df266.png)

For non-LoadBalancer setups where nginx is deployed as a DaemonSet:

![screenshot-2020-09-08-204119](https://user-images.githubusercontent.com/127499/92515735-5a82a300-f214-11ea-9446-9ccc590193ea.png)


**Does this PR introduce a user-facing change?**:
```release-note
NONE
```
