### PR TITLE
add continuouslyReconcile flag for addons

### DIFF
--- a/cmd/kubermatic-api/swagger.json
+++ b/cmd/kubermatic-api/swagger.json
@@ -9373,6 +9373,11 @@
       "description": "AddonSpec addon specification",
       "type": "object",
       "properties": {
+        "continuouslyReconcile": {
+          "description": "ContinuouslyReconcile indicates that the addon cannot be deleted or modified outside of the UI after installation",
+          "type": "boolean",
+          "x-go-name": "ContinuouslyReconcile"
+        },
         "isDefault": {
           "description": "IsDefault indicates whether the addon is default",
           "type": "boolean",

--- a/pkg/api/v1/types.go
+++ b/pkg/api/v1/types.go
@@ -945,6 +945,8 @@ type AddonSpec struct {
 	Variables map[string]interface{} `json:"variables,omitempty"`
 	// IsDefault indicates whether the addon is default
 	IsDefault bool `json:"isDefault,omitempty"`
+	// ContinuouslyReconcile indicates that the addon cannot be deleted or modified outside of the UI after installation
+	ContinuouslyReconcile bool `json:"continuouslyReconcile,omitempty"`
 }
 
 // AddonConfig represents a addon configuration

--- a/pkg/handler/v1/addon/addon_test.go
+++ b/pkg/handler/v1/addon/addon_test.go
@@ -417,6 +417,38 @@ func TestCreateAddon(t *testing.T) {
 			},
 			ExistingAPIUser: test.GenAPIUser("bob", "bob@acme.com"),
 		},
+		// scenario 4
+		{
+			Name: "scenario 4: create an addon with continuouslyReconcile flag",
+			Body: `{
+				"name": "addon1",
+				"spec": {
+					"variables": null,
+					"continuouslyReconcile": true
+				}
+			}`,
+			ExpectedResponse: apiv1.Addon{
+				ObjectMeta: apiv1.ObjectMeta{
+					ID:   "addon1",
+					Name: "addon1",
+				},
+				Spec: apiv1.AddonSpec{
+					ContinuouslyReconcile: true,
+				},
+			},
+			ExpectedHTTPStatus: http.StatusCreated,
+			ExistingKubermaticObjs: []runtime.Object{
+				/*add projects*/
+				test.GenProject("my-first-project", kubermaticv1.ProjectActive, test.DefaultCreationTimestamp()),
+				/*add bindings*/
+				test.GenBinding("my-first-project-ID", "john@acme.com", "owners"),
+				/*add users*/
+				test.GenUser("", "john", "john@acme.com"),
+				/*add cluster*/
+				cluster,
+			},
+			ExistingAPIUser: test.GenAPIUser("john", "john@acme.com"),
+		},
 	}
 
 	for _, tc := range testcases {

--- a/pkg/provider/types.go
+++ b/pkg/provider/types.go
@@ -630,7 +630,7 @@ type EventRecorderProvider interface {
 // AddonProvider declares the set of methods for interacting with addons
 type AddonProvider interface {
 	// New creates a new addon in the given cluster
-	New(userInfo *UserInfo, cluster *kubermaticv1.Cluster, addonName string, variables *runtime.RawExtension) (*kubermaticv1.Addon, error)
+	New(userInfo *UserInfo, cluster *kubermaticv1.Cluster, addonName string, variables *runtime.RawExtension, labels map[string]string) (*kubermaticv1.Addon, error)
 
 	// List gets all addons that belong to the given cluster
 	// If you want to filter the result please take a look at ClusterListOptions
@@ -658,7 +658,7 @@ type PrivilegedAddonProvider interface {
 	//
 	// Note that this function:
 	// is unsafe in a sense that it uses privileged account to create the resource
-	NewUnsecured(cluster *kubermaticv1.Cluster, addonName string, variables *runtime.RawExtension) (*kubermaticv1.Addon, error)
+	NewUnsecured(cluster *kubermaticv1.Cluster, addonName string, variables *runtime.RawExtension, labels map[string]string) (*kubermaticv1.Addon, error)
 
 	// GetUnsecured returns the given addon
 	//

--- a/pkg/test/e2e/api/utils/apiclient/models/addon_spec.go
+++ b/pkg/test/e2e/api/utils/apiclient/models/addon_spec.go
@@ -15,6 +15,9 @@ import (
 // swagger:model AddonSpec
 type AddonSpec struct {
 
+	// ContinuouslyReconcile indicates that the addon cannot be deleted or modified outside of the UI after installation
+	ContinuouslyReconcile bool `json:"continuouslyReconcile,omitempty"`
+
 	// IsDefault indicates whether the addon is default
 	IsDefault bool `json:"isDefault,omitempty"`
 


### PR DESCRIPTION
**What this PR does / why we need it**: add API option to set the `addons.kubermatic.io/ensure` label for accessible addons.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #5672

```release-note
NONE
```
