### PR TITLE
Use Go 1.15 for CI jobs

### DIFF
--- a/.prow.yaml
+++ b/.prow.yaml
@@ -25,7 +25,7 @@ presubmits:
       preset-goproxy: "true"
     spec:
       containers:
-      - image: golang:1.14.2
+      - image: golang:1.15.1
         command:
         - make
         args:
@@ -47,7 +47,7 @@ presubmits:
       preset-goproxy: "true"
     spec:
       containers:
-      - image: golang:1.14.2
+      - image: golang:1.15.1
         command:
         - make
         args:
@@ -301,7 +301,7 @@ presubmits:
       preset-goproxy: "true"
     spec:
       containers:
-      - image: quay.io/kubermatic/e2e-kind:with-conformance-tests-v1.0.19
+      - image: quay.io/kubermatic/e2e-kind:with-conformance-tests-v1.0.21
         env:
         - name: KUBERMATIC_EDITION
           value: ee
@@ -342,7 +342,7 @@ presubmits:
       preset-goproxy: "true"
     spec:
       containers:
-      - image: quay.io/kubermatic/e2e-kind:with-conformance-tests-v1.0.19
+      - image: quay.io/kubermatic/e2e-kind:with-conformance-tests-v1.0.21
         env:
         - name: KUBERMATIC_EDITION
           value: ee
@@ -383,7 +383,7 @@ presubmits:
       preset-goproxy: "true"
     spec:
       containers:
-      - image: quay.io/kubermatic/e2e-kind:with-conformance-tests-v1.0.19
+      - image: quay.io/kubermatic/e2e-kind:with-conformance-tests-v1.0.21
         env:
         - name: KUBERMATIC_EDITION
           value: ee
@@ -424,7 +424,7 @@ presubmits:
       preset-goproxy: "true"
     spec:
       containers:
-      - image: quay.io/kubermatic/e2e-kind:with-conformance-tests-v1.0.19
+      - image: quay.io/kubermatic/e2e-kind:with-conformance-tests-v1.0.21
         env:
         - name: KUBERMATIC_EDITION
           value: ee
@@ -465,7 +465,7 @@ presubmits:
       preset-goproxy: "true"
     spec:
       containers:
-      - image: quay.io/kubermatic/e2e-kind:with-conformance-tests-v1.0.19
+      - image: quay.io/kubermatic/e2e-kind:with-conformance-tests-v1.0.21
         env:
         - name: KUBERMATIC_EDITION
           value: "ce"
@@ -508,7 +508,7 @@ presubmits:
       preset-goproxy: "true"
     spec:
       containers:
-      - image: quay.io/kubermatic/e2e-kind:with-conformance-tests-v1.0.19
+      - image: quay.io/kubermatic/e2e-kind:with-conformance-tests-v1.0.21
         env:
         - name: KUBERMATIC_EDITION
           value: "ee"
@@ -558,7 +558,7 @@ presubmits:
       preset-goproxy: "true"
     spec:
       containers:
-      - image: quay.io/kubermatic/e2e-kind:with-conformance-tests-v1.0.19
+      - image: quay.io/kubermatic/e2e-kind:with-conformance-tests-v1.0.21
         env:
         - name: KUBERMATIC_EDITION
           value: ee
@@ -604,7 +604,7 @@ presubmits:
       preset-goproxy: "true"
     spec:
       containers:
-      - image: quay.io/kubermatic/e2e-kind:with-conformance-tests-v1.0.19
+      - image: quay.io/kubermatic/e2e-kind:with-conformance-tests-v1.0.21
         env:
         - name: KUBERMATIC_EDITION
           value: ee
@@ -647,7 +647,7 @@ presubmits:
       preset-goproxy: "true"
     spec:
       containers:
-      - image: quay.io/kubermatic/e2e-kind:with-conformance-tests-v1.0.19
+      - image: quay.io/kubermatic/e2e-kind:with-conformance-tests-v1.0.21
         env:
         - name: KUBERMATIC_EDITION
           value: ee
@@ -695,7 +695,7 @@ presubmits:
       preset-goproxy: "true"
     spec:
       containers:
-      - image: quay.io/kubermatic/e2e-kind:with-conformance-tests-v1.0.19
+      - image: quay.io/kubermatic/e2e-kind:with-conformance-tests-v1.0.21
         env:
         - name: KUBERMATIC_EDITION
           value: ee
@@ -738,7 +738,7 @@ presubmits:
       preset-goproxy: "true"
     spec:
       containers:
-      - image: quay.io/kubermatic/e2e-kind:with-conformance-tests-v1.0.19
+      - image: quay.io/kubermatic/e2e-kind:with-conformance-tests-v1.0.21
         env:
         - name: KUBERMATIC_EDITION
           value: ee
@@ -781,7 +781,7 @@ presubmits:
       preset-goproxy: "true"
     spec:
       containers:
-      - image: quay.io/kubermatic/e2e-kind:with-conformance-tests-v1.0.19
+      - image: quay.io/kubermatic/e2e-kind:with-conformance-tests-v1.0.21
         env:
         - name: KUBERMATIC_EDITION
           value: ee
@@ -824,7 +824,7 @@ presubmits:
       preset-goproxy: "true"
     spec:
       containers:
-      - image: quay.io/kubermatic/e2e-kind:with-conformance-tests-v1.0.19
+      - image: quay.io/kubermatic/e2e-kind:with-conformance-tests-v1.0.21
         env:
         - name: KUBERMATIC_EDITION
           value: ee
@@ -870,7 +870,7 @@ presubmits:
       preset-goproxy: "true"
     spec:
       containers:
-      - image: quay.io/kubermatic/e2e-kind:with-conformance-tests-v1.0.19
+      - image: quay.io/kubermatic/e2e-kind:with-conformance-tests-v1.0.21
         env:
         - name: KUBERMATIC_EDITION
           value: ee
@@ -915,7 +915,7 @@ presubmits:
       preset-goproxy: "true"
     spec:
       containers:
-      - image: quay.io/kubermatic/e2e-kind:with-conformance-tests-v1.0.19
+      - image: quay.io/kubermatic/e2e-kind:with-conformance-tests-v1.0.21
         env:
         - name: KUBERMATIC_EDITION
           value: ee
@@ -960,7 +960,7 @@ presubmits:
       preset-goproxy: "true"
     spec:
       containers:
-      - image: quay.io/kubermatic/e2e-kind:with-conformance-tests-v1.0.19
+      - image: quay.io/kubermatic/e2e-kind:with-conformance-tests-v1.0.21
         env:
         - name: KUBERMATIC_EDITION
           value: ee
@@ -1004,7 +1004,7 @@ presubmits:
       preset-goproxy: "true"
     spec:
       containers:
-      - image: quay.io/kubermatic/e2e-kind:with-conformance-tests-v1.0.19
+      - image: quay.io/kubermatic/e2e-kind:with-conformance-tests-v1.0.21
         env:
         - name: KUBERMATIC_EDITION
           value: ee
@@ -1050,7 +1050,7 @@ presubmits:
       preset-goproxy: "true"
     spec:
       containers:
-        - image: quay.io/kubermatic/e2e-kind:with-conformance-tests-v1.0.19
+        - image: quay.io/kubermatic/e2e-kind:with-conformance-tests-v1.0.21
           env:
             - name: KUBERMATIC_EDITION
               value: ee
@@ -1100,7 +1100,7 @@ presubmits:
       preset-goproxy: "true"
     spec:
       containers:
-      - image: quay.io/kubermatic/e2e-kind:with-conformance-tests-v1.0.19
+      - image: quay.io/kubermatic/e2e-kind:with-conformance-tests-v1.0.21
         env:
         - name: KUBERMATIC_EDITION
           value: ee
@@ -1146,7 +1146,7 @@ presubmits:
       preset-goproxy: "true"
     spec:
       containers:
-      - image: quay.io/kubermatic/e2e-kind:with-conformance-tests-v1.0.19
+      - image: quay.io/kubermatic/e2e-kind:with-conformance-tests-v1.0.21
         imagePullPolicy: Always
         command:
         - "./hack/ci/ci_run_api_e2e.sh"

--- a/Makefile
+++ b/Makefile
@@ -35,7 +35,7 @@ LDFLAGS += -extldflags '-static' \
   -X k8c.io/kubermatic/v2/pkg/controller/operator/common.UIDOCKERTAG=$(UIDOCKERTAG)
 BUILD_DEST?=_build
 GOTOOLFLAGS?=$(GOBUILDFLAGS) -ldflags '-w $(LDFLAGS)'
-GOBUILDIMAGE?=golang:1.14.6
+GOBUILDIMAGE?=golang:1.15.1
 DOCKER_BIN := $(shell which docker)
 
 default: all

--- a/containers/integration-tests/Dockerfile
+++ b/containers/integration-tests/Dockerfile
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-FROM golang:1.14.2
+FROM golang:1.15.1
 LABEL maintainer="support@kubermatic.com"
 
 RUN os=$(go env GOOS) && \

--- a/pkg/log/logrus.go
+++ b/pkg/log/logrus.go
@@ -56,13 +56,16 @@ func (h *prefixHook) Fire(e *logrus.Entry) error {
 }
 
 func Prefix(e *logrus.Entry, prefix string) *logrus.Entry {
-	if e.Context != nil {
-		if oldPrefix := e.Context.Value(prefixKey); oldPrefix != nil {
-			prefix += oldPrefix.(string)
-		}
+	parentCtx := e.Context
+	if parentCtx == nil {
+		parentCtx = context.Background()
 	}
 
-	ctx := context.WithValue(e.Context, prefixKey, prefix)
+	if oldPrefix := parentCtx.Value(prefixKey); oldPrefix != nil {
+		prefix += oldPrefix.(string)
+	}
+
+	ctx := context.WithValue(parentCtx, prefixKey, prefix)
 
 	return e.WithContext(ctx)
 }

--- a/pkg/test/e2e/api/cluster_test.go
+++ b/pkg/test/e2e/api/cluster_test.go
@@ -41,7 +41,7 @@ func getKubernetesVersion() string {
 	if len(version) > 0 {
 		return version
 	}
-	return "v1.14.2"
+	return "v1.18.8"
 }
 
 func TestCreateAWSCluster(t *testing.T) {

--- a/pkg/validation/cluster_test.go
+++ b/pkg/validation/cluster_test.go
@@ -19,6 +19,7 @@ package validation
 import (
 	"errors"
 	"fmt"
+	"strings"
 	"testing"
 
 	kubermaticv1 "k8c.io/kubermatic/v2/pkg/crd/kubermatic/v1"
@@ -132,7 +133,7 @@ func TestValidateUpdateWindow(t *testing.T) {
 				Start:  "invalid",
 				Length: "1h",
 			},
-			err: errors.New("error parsing update window: unable to parse start: invalid time of day \"invalid\": expected integer"),
+			err: errors.New("invalid time of day"),
 		},
 		{
 			name: "invalid length",
@@ -140,14 +141,19 @@ func TestValidateUpdateWindow(t *testing.T) {
 				Start:  "Thu 04:00",
 				Length: "1",
 			},
-			err: errors.New("error parsing update window: unable to parse duration: time: missing unit in duration 1"),
+			err: errors.New("missing unit in duration"),
 		},
 	}
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
 			err := ValidateUpdateWindow(&test.updateWindow)
-			if fmt.Sprint(err) != fmt.Sprint(test.err) {
+			if (err != nil) != (test.err != nil) {
 				t.Errorf("Extected err to be %v, got %v", test.err, err)
+			}
+
+			// loosely validate the returned error message
+			if test.err != nil && !strings.Contains(err.Error(), test.err.Error()) {
+				t.Errorf("Extected err to contain \"%v\", but got \"%v\"", test.err, err)
 			}
 		})
 	}


### PR DESCRIPTION
**What this PR does / why we need it**:
Updating just because we can. This also then needs updates to the postsubmits in https://github.com/kubermatic/infra/pull/1127.

**Does this PR introduce a user-facing change?**:
```release-note
Kubermatic is built using Go 1.15.
```
