### PR TITLE
Make ImagePullSecret optional

### DIFF
--- a/charts/kubermatic-operator/Chart.yaml
+++ b/charts/kubermatic-operator/Chart.yaml
@@ -14,7 +14,7 @@
 
 apiVersion: v1
 name: kubermatic-operator
-version: 0.2.5
+version: 0.2.6
 appVersion: '__KUBERMATIC_TAG__'
 description: Helm chart to install the Kubermatic Operator
 keywords:

--- a/charts/kubermatic-operator/templates/deployment.yaml
+++ b/charts/kubermatic-operator/templates/deployment.yaml
@@ -35,8 +35,10 @@ spec:
         fluentbit.io/parser: json_iso
     spec:
       serviceAccountName: kubermatic-operator
+      {{- if .Values.kubermaticOperator.imagePullSecret }}
       imagePullSecrets:
       - name: dockercfg
+      {{- end }}
       containers:
       - name: operator
         image: '{{ .Values.kubermaticOperator.image.repository }}:{{ .Values.kubermaticOperator.image.tag | default .Chart.AppVersion }}'

--- a/charts/kubermatic-operator/templates/dockercfg.yaml
+++ b/charts/kubermatic-operator/templates/dockercfg.yaml
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-{{- if .Values.kubermaticOperator.imagePullSecret }}
+{{ with .Values.kubermaticOperator.imagePullSecret }}
 apiVersion: v1
 kind: Secret
 metadata:
@@ -21,5 +21,5 @@ metadata:
     app.kubernetes.io/name: kubermatic-operator
 type: kubernetes.io/dockerconfigjson
 data:
-  .dockerconfigjson: {{ .Values.kubermaticOperator.imagePullSecret | b64enc | quote }}
-{{- end }}
+  .dockerconfigjson: {{ . | b64enc | quote }}
+{{ end }}

--- a/charts/kubermatic-operator/values.yaml
+++ b/charts/kubermatic-operator/values.yaml
@@ -17,10 +17,9 @@ kubermaticOperator:
     repository: "quay.io/kubermatic/kubermatic"
     tag: "__KUBERMATIC_TAG__"
 
-  imagePullSecret: |
-    {
-      "quay.io": {}
-    }
+  # For Enterprise Editions, configure the Docker Pull Secret as a JSON string here.
+  imagePullSecret: ''
+  # imagePullSecret: '{"quay.io":...}'
 
   debug: false
   resources:

--- a/docs/zz_generated.kubermaticConfiguration.yaml
+++ b/docs/zz_generated.kubermaticConfiguration.yaml
@@ -51,7 +51,7 @@ spec:
   # FeatureGates are used to optionally enable certain features.
   featureGates: {}
   # ImagePullSecret is used to authenticate against Docker registries.
-  imagePullSecret: ""
+  imagePullSecret: '{}'
   # Ingress contains settings for making the API and UI accessible remotely.
   ingress:
     # CertificateIssuer is the name of a cert-manager Issuer or ClusterIssuer (default)

--- a/hack/ci/ci-setup-kubermatic-in-kind.sh
+++ b/hack/ci/ci-setup-kubermatic-in-kind.sh
@@ -54,9 +54,6 @@ export KUBERMATIC_DEX_VALUES_FILE=$(realpath hack/ci/testdata/oauth_values.yaml)
 export KUBERMATIC_OIDC_LOGIN="roxy@loodse.com"
 export KUBERMATIC_OIDC_PASSWORD="password"
 
-# Set docker config
-echo "$IMAGE_PULL_SECRET_DATA" | base64 -d > /config.json
-
 # Start Docker daemon
 echodate "Starting Docker"
 dockerd > /tmp/docker.log 2>&1 &
@@ -263,11 +260,14 @@ metadata:
   name: e2e
   namespace: kubermatic
 spec:
+  # the actual value is not important in e2e tests,
+  # as all images are already loaded into the kind cluster;
+  # but a non-empty value must be provided for testing the
+  # EE version of the operator
+  imagePullSecret: '{}'
   ingress:
     domain: ci.kubermatic.io
     disable: true
-  imagePullSecret: |
-$(echo "$IMAGE_PULL_SECRET_DATA" | base64 -d | sed 's/^/    /')
   userCluster:
     apiserverReplicas: 1
   api:

--- a/pkg/controller/operator/common/defaults.go
+++ b/pkg/controller/operator/common/defaults.go
@@ -322,6 +322,14 @@ func DefaultConfiguration(config *operatorv1alpha1.KubermaticConfiguration, logg
 
 	copy := config.DeepCopy()
 
+	if copy.Spec.ImagePullSecret == "" {
+		// This ensures that the created dockercfg Secrets later will contain valid JSON
+		// and that we do not have to make a distinction between unset, empty and full
+		// Docker Pull Secret; instead we *always* create a dockercfg Secret and reference
+		// it everywhere.
+		copy.Spec.ImagePullSecret = "{}"
+	}
+
 	if copy.Spec.ExposeStrategy == "" {
 		copy.Spec.ExposeStrategy = DefaultExposeStrategy
 		logger.Debugw("Defaulting field", "field", "exposeStrategy", "value", copy.Spec.ExposeStrategy)

--- a/pkg/resources/resources.go
+++ b/pkg/resources/resources.go
@@ -65,6 +65,16 @@ const (
 const APIServerSecurePort = 6443
 
 const (
+	// DefaultKubermaticCEImage defines the default Docker repository containing the Kubermatic CE API image.
+	DefaultKubermaticCEImage = "quay.io/kubermatic/kubermatic"
+	// DefaultKubermaticCEImage defines the default Docker repository containing the Kubermatic EE API image.
+	DefaultKubermaticEEImage = "quay.io/kubermatic/kubermatic-ee"
+
+	// DefaultDashboardCEImage defines the default Docker repository containing the dashboard CE API image.
+	DefaultDashboardCEImage = "quay.io/kubermatic/dashboard"
+	// DefaultDashboardEEImage defines the default Docker repository containing the dashboard EE API image.
+	DefaultDashboardEEImage = "quay.io/kubermatic/dashboard-ee"
+
 	// ApiserverDeploymentName is the name of the apiserver deployment
 	ApiserverDeploymentName = "apiserver"
 	//ControllerManagerDeploymentName is the name for the controller manager deployment

--- a/pkg/resources/resources.go
+++ b/pkg/resources/resources.go
@@ -70,9 +70,9 @@ const (
 	// DefaultKubermaticCEImage defines the default Docker repository containing the Kubermatic EE API image.
 	DefaultKubermaticEEImage = "quay.io/kubermatic/kubermatic-ee"
 
-	// DefaultDashboardCEImage defines the default Docker repository containing the dashboard CE API image.
+	// DefaultDashboardCEImage defines the default Docker repository containing the dashboard CE image.
 	DefaultDashboardCEImage = "quay.io/kubermatic/dashboard"
-	// DefaultDashboardEEImage defines the default Docker repository containing the dashboard EE API image.
+	// DefaultDashboardEEImage defines the default Docker repository containing the dashboard EE image.
 	DefaultDashboardEEImage = "quay.io/kubermatic/dashboard-ee"
 
 	// ApiserverDeploymentName is the name of the apiserver deployment

--- a/pkg/resources/resources_ce.go
+++ b/pkg/resources/resources_ce.go
@@ -20,7 +20,7 @@ package resources
 
 const (
 	// DefaultKubermaticImage defines the default Docker repository containing the Kubermatic API image.
-	DefaultKubermaticImage = "quay.io/kubermatic/kubermatic"
+	DefaultKubermaticImage = DefaultKubermaticCEImage
 
 	// DefaultEtcdLauncherImage defines the default Docker repository containing the etcd launcher image.
 	DefaultEtcdLauncherImage = "quay.io/kubermatic/etcd-launcher"
@@ -29,7 +29,7 @@ const (
 	DefaultDNATControllerImage = "quay.io/kubermatic/kubeletdnat-controller"
 
 	// DefaultDashboardAddonImage defines the default Docker repository containing the dashboard image.
-	DefaultDashboardImage = "quay.io/kubermatic/dashboard"
+	DefaultDashboardImage = DefaultDashboardCEImage
 
 	// DefaultKubernetesAddonImage defines the default Docker repository containing the Kubernetes addons.
 	DefaultKubernetesAddonImage = "quay.io/kubermatic/addons"

--- a/pkg/resources/resources_ee.go
+++ b/pkg/resources/resources_ee.go
@@ -20,7 +20,7 @@ package resources
 
 const (
 	// DefaultKubermaticImage defines the default Docker repository containing the Kubermatic API image.
-	DefaultKubermaticImage = "quay.io/kubermatic/kubermatic-ee"
+	DefaultKubermaticImage = DefaultKubermaticEEImage
 
 	// DefaultEtcdLauncherImage defines the default Docker repository containing the etcd launcher image.
 	DefaultEtcdLauncherImage = "quay.io/kubermatic/etcd-launcher"
@@ -29,7 +29,7 @@ const (
 	DefaultDNATControllerImage = "quay.io/kubermatic/kubeletdnat-controller"
 
 	// DefaultDashboardAddonImage defines the default Docker repository containing the dashboard image.
-	DefaultDashboardImage = "quay.io/kubermatic/dashboard-ee"
+	DefaultDashboardImage = DefaultDashboardEEImage
 
 	// DefaultKubernetesAddonImage defines the default Docker repository containing the Kubernetes addons.
 	DefaultKubernetesAddonImage = "quay.io/kubermatic/addons"


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR makes configuring the imagepullsecret always optional.

* For CE-based setups, there is no special secret required because all Docker images are public.
* For EE-based setups, a Secret is required *unless* the admin chose to mirror the images in a local Registry mirror, so we cannot be 100% sure that for EE a Secret is required.
* To make misconfiguration a tiny bit harder, the installer now checks the Docker repository used and if it's the EE repo, it will require a Docker Pull Secret (it can be empty, the installer will not validate it _that_ deeply).

**Which issue(s) this PR fixes**:
Fixes #5694

**Does this PR introduce a user-facing change?**:
```release-note
NONE
```
