### PR TITLE
Take into account DOCKER_REPO environment variable for image release

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -12,30 +12,30 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-export CGO_ENABLED?=0
-export GOFLAGS?=-mod=readonly -trimpath
-export GO111MODULE=on
-export KUBERMATIC_EDITION?=ce
-DOCKER_REPO?=quay.io/kubermatic
-REPO=$(DOCKER_REPO)/kubermatic$(shell [ "$(KUBERMATIC_EDITION)" != "ce" ] && echo "-$(KUBERMATIC_EDITION)" )
-CMD=$(filter-out OWNERS nodeport-proxy kubeletdnat-controller, $(notdir $(wildcard ./cmd/*)))
-GOBUILDFLAGS?=-v
-GOOS?=$(shell go env GOOS)
-GITTAG=$(shell git describe --tags --always)
-TAGS?=$(GITTAG)
-DOCKERTAGS=$(TAGS) latestbuild
+export CGO_ENABLED ?= 0
+export GOFLAGS ?= -mod=readonly -trimpath
+export GO111MODULE = on
+export KUBERMATIC_EDITION ?= ce
+DOCKER_REPO ?= quay.io/kubermatic
+REPO = $(DOCKER_REPO)/kubermatic$(shell [ "$(KUBERMATIC_EDITION)" != "ce" ] && echo "-$(KUBERMATIC_EDITION)" )
+CMD = $(filter-out OWNERS nodeport-proxy kubeletdnat-controller, $(notdir $(wildcard ./cmd/*)))
+GOBUILDFLAGS ?= -v
+GOOS ?= $(shell go env GOOS)
+GITTAG = $(shell git describe --tags --always)
+TAGS ?= $(GITTAG)
+DOCKERTAGS = $(TAGS) latestbuild
 DOCKER_BUILD_FLAG += $(foreach tag, $(DOCKERTAGS), -t $(REPO):$(tag))
-KUBERMATICCOMMIT?=$(shell git log -1 --format=%H)
-KUBERMATICDOCKERTAG?=$(KUBERMATICCOMMIT)
-UIDOCKERTAG?=NA
+KUBERMATICCOMMIT ?= $(shell git log -1 --format=%H)
+KUBERMATICDOCKERTAG ?= $(KUBERMATICCOMMIT)
+UIDOCKERTAG ?= NA
 LDFLAGS += -extldflags '-static' \
   -X k8c.io/kubermatic/v2/pkg/resources.KUBERMATICCOMMIT=$(KUBERMATICCOMMIT) \
   -X k8c.io/kubermatic/v2/pkg/resources.KUBERMATICGITTAG=$(GITTAG) \
   -X k8c.io/kubermatic/v2/pkg/controller/operator/common.KUBERMATICDOCKERTAG=$(KUBERMATICDOCKERTAG) \
   -X k8c.io/kubermatic/v2/pkg/controller/operator/common.UIDOCKERTAG=$(UIDOCKERTAG)
-BUILD_DEST?=_build
-GOTOOLFLAGS?=$(GOBUILDFLAGS) -ldflags '-w $(LDFLAGS)'
-GOBUILDIMAGE?=golang:1.15.1
+BUILD_DEST ?= _build
+GOTOOLFLAGS ?= $(GOBUILDFLAGS) -ldflags '-w $(LDFLAGS)'
+GOBUILDIMAGE ?= golang:1.15.1
 DOCKER_BIN := $(shell which docker)
 
 default: all

--- a/cmd/kubeletdnat-controller/Makefile
+++ b/cmd/kubeletdnat-controller/Makefile
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-DOCKER_REPO="quay.io/kubermatic"
+DOCKER_REPO ?= "quay.io/kubermatic"
 GOOS ?= $(shell go env GOOS)
 
 build:

--- a/cmd/nodeport-proxy/Makefile
+++ b/cmd/nodeport-proxy/Makefile
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-DOCKER_REPO="quay.io/kubermatic"
+DOCKER_REPO ?= "quay.io/kubermatic"
 GOOS ?= $(shell go env GOOS)
 
 default: test build

--- a/cmd/user-ssh-keys-agent/Makefile
+++ b/cmd/user-ssh-keys-agent/Makefile
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-DOCKER_REPO="quay.io/kubermatic"
+DOCKER_REPO ?= "quay.io/kubermatic"
 GOOS ?= $(shell go env GOOS)
 
 build:


### PR DESCRIPTION
**What this PR does / why we need it**:
Fix the `hack/release-docker-images.sh` script to take into account the `DOCKER_REPO` environment variable for all images.
The problem is that some `Makefile` assign a value to `DOCKER_REPO` variable using `=` operator thus it is not overridden by the environment variable set by the script.

References:
https://www.gnu.org/software/make/manual/html_node/Environment.html#Environment
https://www.gnu.org/software/make/manual/html_node/Setting.html

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Documentation**:
<!-- Add links to the related documentation changes related to this pull request. E.g. the link to the kubermatic/docs pullrequest. -->

**Does this PR introduce a user-facing change?**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If  no release note is required, just write "NONE".
-->
```release-note
NONE
```
