### PR TITLE
[release/v2.14] custom dex envvars

### DIFF
--- a/config/oauth/Chart.yaml
+++ b/config/oauth/Chart.yaml
@@ -14,7 +14,7 @@
 
 apiVersion: v1
 name: oauth
-version: 1.2.2
+version: 1.3.0
 appVersion: v2.22.0
 description: Dex
 keywords:

--- a/config/oauth/templates/deployment.yaml
+++ b/config/oauth/templates/deployment.yaml
@@ -36,6 +36,9 @@ spec:
       - image: {{ .Values.dex.image.repository }}:{{ .Values.dex.image.tag }}
         name: dex
         command: ["/usr/local/bin/dex", "serve", "/etc/dex/cfg/config.yaml"]
+        {{- if .Values.dex.env }}
+        env: {{ .Values.dex.env | toYaml | trim | nindent 8}}
+        {{- end }}
         ports:
         - name: https
           containerPort: 5556

--- a/config/oauth/templates/deployment.yaml
+++ b/config/oauth/templates/deployment.yaml
@@ -37,7 +37,7 @@ spec:
         name: dex
         command: ["/usr/local/bin/dex", "serve", "/etc/dex/cfg/config.yaml"]
         {{- if .Values.dex.env }}
-        env: {{ .Values.dex.env | toYaml | trim | nindent 8}}
+        env: {{ toYaml .Values.dex.env | trim | nindent 8 }}
         {{- end }}
         ports:
         - name: https

--- a/config/oauth/values.yaml
+++ b/config/oauth/values.yaml
@@ -20,6 +20,13 @@ dex:
   # this options allows setting custom envvars in the dex container
   # this list is directly handed to the container spec
   env: []
+  #  - name: HTTP_PROXY
+  #    value: "http://USER:PASSWORD@IPADDR:PORT"
+  #  - name: HTTPS_PROXY
+  #    valueFrom:
+  #     secretKeyRef:
+  #       key: HTTPS_PROXY
+  #       name: http-proxy-secret
   ingress:
     # this option is required
     host: ""

--- a/config/oauth/values.yaml
+++ b/config/oauth/values.yaml
@@ -17,6 +17,9 @@ dex:
     repository: "quay.io/dexidp/dex"
     tag: "v2.22.0"
   replicas: 2
+  # this options allows setting custom envvars in the dex container
+  # this list is directly handed to the container spec
+  env: []
   ingress:
     # this option is required
     host: ""


### PR DESCRIPTION
**What this PR does / why we need it**: backport of #5829 ; allow custom envvar definitions for dex to be passed via the oauth chart

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #5826

**Special notes for your reviewer**:

**Documentation**:
<!-- Add links to the related documentation changes related to this pull request. E.g. the link to the kubermatic/docs pullrequest. -->

**Does this PR introduce a user-facing change?**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If  no release note is required, just write "NONE".
-->
```release-note
Allow custom envvar definitions for dex to be passed via the oauth chart. values key: `dex.env`
```
