### PR TITLE
do not deploy nodeport-proxy chart on dev anymore

### DIFF
--- a/hack/ci/ci-deploy-dev-asia.sh
+++ b/hack/ci/ci-deploy-dev-asia.sh
@@ -21,6 +21,7 @@ source ./hack/lib.sh
 
 export DEPLOY_STACK=${DEPLOY_STACK:-kubermatic}
 export GIT_HEAD_HASH="$(git rev-parse HEAD|tr -d '\n')"
+export DEPLOY_NODEPORT_PROXY=false
 
 if [[ "${DEPLOY_STACK}" == "kubermatic" ]]; then
   ./hack/ci/ci-push-images.sh

--- a/hack/ci/ci-deploy-dev.sh
+++ b/hack/ci/ci-deploy-dev.sh
@@ -47,6 +47,7 @@ echodate "Successfully got secrets for dev from Vault"
 
 # deploy Loki as beta
 export DEPLOY_LOKI=true
+export DEPLOY_NODEPORT_PROXY=false
 
 echodate "Deploying ${DEPLOY_STACK} stack to dev"
 TILLER_NAMESPACE=kubermatic-installer ./hack/deploy.sh master ${VALUES_FILE}

--- a/pkg/resources/address/address_test.go
+++ b/pkg/resources/address/address_test.go
@@ -38,7 +38,7 @@ const (
 	fakeClusterNamespaceName = "cluster-ns"
 	// This must be the A record for *.europe-west3c.dev.kubermatic.io and
 	// *.alias-europe-west3-c.dev.kubermatic.io
-	externalIP = "35.198.93.90"
+	externalIP = "34.89.181.151"
 	// Henrik created 2 dns entries for dns-test @ OVH.com. dns-test.kubermatic.io points to:
 	// - 192.168.1.1
 	// - 192.168.1.2


### PR DESCRIPTION
**What this PR does / why we need it**:
It's time we finally make the switch to the operator-managed nodeport-proxy. This PR makes it so that dev/dev-asia do not have the old chart deployed to them anymore, so we can begin to cleanup these clusters.

**Does this PR introduce a user-facing change?**:
```release-note
NONE
```
