### PR TITLE
Fix GitHub Release Script

### DIFF
--- a/hack/ci/ci-github-release.sh
+++ b/hack/ci/ci-github-release.sh
@@ -103,7 +103,7 @@ function tar_to_zip() {
   rm -- "$archive"
 
   archive="$(echo "$archive" | sed 's/.tar.gz/.zip/')"
-  (cd "$tmpdir"; zip -r "$archive" .)
+  (cd "$tmpdir"; zip -rq "$archive" .)
   rm -rf -- "$tmpdir"
 
   echo "$archive"

--- a/hack/ci/ci-github-release.sh
+++ b/hack/ci/ci-github-release.sh
@@ -73,7 +73,8 @@ function upload_archive {
     -H "Accept: application/json" \
     -H 'Content-Type: application/gzip' \
     -s --data-binary "@$file")
-  if echo "$res" | jq -e; then
+
+  if echo "$res" | jq -e '.'; then
     # if the response contain errors
     if echo "$res" | jq -e '.errors[0]'; then
       for err in $(echo "$res" | jq -r '.errors[0].code'); do
@@ -82,12 +83,12 @@ function upload_archive {
         # match.
         [[ "$err" == "already_exists" ]] && return 0
       done
-      err "Response contains unexpected errors: $res"
+      echodate "Response contains unexpected errors: $res"
       return 1
     fi
     return 0
   else
-    err "Response did not contain valid JSON: $res"
+    echodate "Response did not contain valid JSON: $res"
     return 1
   fi
 }


### PR DESCRIPTION
**What this PR does / why we need it**:
* outputting more than the filename in tar_to_zip breaks the script obviously
* jq requires a path when the container has no TTY attached

**Does this PR introduce a user-facing change?**:
```release-note
NONE
```
