### PR TITLE
Validate serviceAccountKey in the installer

### DIFF
--- a/pkg/install/stack/kubermatic/validation.go
+++ b/pkg/install/stack/kubermatic/validation.go
@@ -26,6 +26,7 @@ import (
 
 	operatorv1alpha1 "k8c.io/kubermatic/v2/pkg/crd/operator/v1alpha1"
 	"k8c.io/kubermatic/v2/pkg/features"
+	"k8c.io/kubermatic/v2/pkg/serviceaccount"
 	"k8c.io/kubermatic/v2/pkg/util/yamled"
 )
 
@@ -61,6 +62,10 @@ func validateKubermaticConfiguration(config *operatorv1alpha1.KubermaticConfigur
 	}
 
 	failures = validateRandomSecret(config, config.Spec.Auth.ServiceAccountKey, "spec.auth.serviceAccountKey", failures)
+
+	if err := serviceaccount.ValidateKey([]byte(config.Spec.Auth.ServiceAccountKey)); err != nil {
+		failures = append(failures, fmt.Errorf("spec.auth.serviceAccountKey is invalid: %v", err))
+	}
 
 	if config.Spec.FeatureGates.Has(features.OIDCKubeCfgEndpoint) {
 		failures = validateRandomSecret(config, config.Spec.Auth.IssuerClientSecret, "spec.auth.issuerClientSecret", failures)


### PR DESCRIPTION
**What this PR does / why we need it**:
The Kubermatic API crashloops whenever the key is shorter than 32 bytes.

**Does this PR introduce a user-facing change?**:
```release-note
NONE
```
