### PR TITLE
Add script to perform canary releases

### DIFF
--- a/hack/ci/ci-canary-github-release.sh
+++ b/hack/ci/ci-canary-github-release.sh
@@ -1,0 +1,52 @@
+#!/usr/bin/env bash
+
+# Copyright 2020 The Kubermatic Kubernetes Platform contributors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# This script is run for every commit to master and will create
+# a dummy release in a dedicated GitHub repo. The purpose is to
+# a) test that releasing code actually works, and
+# b) to provide test builds for internal purposes.
+
+set -euo pipefail
+
+cd $(dirname $0)/../..
+source hack/lib.sh
+rootdir="$(pwd)"
+
+export GIT_TAG="$(git rev-parse HEAD)"
+
+# create a nice looking, sortable, somewhat meaningful release name
+commitDate="$(git show --pretty='%ct' -s "$GIT_TAG")"
+releaseDate="$(date --date="@$commitDate" +"%H%M%S" --utc)"
+
+export RELEASE_NAME="$(git show --pretty="%cs-$releaseDate-%h" -s "$GIT_TAG")"
+export GIT_REPO="kubermatic/kubermatic-builds"
+
+# create dummy tag in $GIT_REPO
+echodate "Tagging $RELEASE_NAME in $GIT_REPO..."
+
+builds="$(mktemp -d)"
+git clone "git@github.com:$GIT_REPO.git" "$builds"
+cd "$builds"
+git tag -f -m "This is just a test version, DO NOT USE." "$RELEASE_NAME"
+git push --force origin "$RELEASE_NAME"
+
+# create the actual release
+echodate "Creating canary release..."
+
+cd "$rootdir"
+./hack/ci/ci-github-release.sh
+
+echodate "Done, find the new release at https://github.com/$GIT_REPO/releases/tag/$RELEASE_NAME"


### PR DESCRIPTION
**What this PR does / why we need it**:
This prepares a script that we will use to automatically create test releases to ensure our release pipeline works _before_ we have to tag an actual release for the public.

The release script itself is now capable of using a different release name on Github than in its own packages. This is required to have somewhat meaningful, sortable release names on GitHub, but still refer to the SHA1 hash of Kubermatic in the Helm charts.

**Does this PR introduce a user-facing change?**:
```release-note
NONE
```
