### PR TITLE
Make sure that the entries in nginx cm data are quoted

### DIFF
--- a/charts/nginx-ingress-controller/Chart.yaml
+++ b/charts/nginx-ingress-controller/Chart.yaml
@@ -14,7 +14,7 @@
 
 apiVersion: v1
 name: nginx-ingress-controller
-version: 1.1.6
+version: 1.1.7
 appVersion: 0.34.1
 description: nginx-ingress-controller
 keywords:

--- a/charts/nginx-ingress-controller/templates/configmaps.yaml
+++ b/charts/nginx-ingress-controller/templates/configmaps.yaml
@@ -23,5 +23,5 @@ metadata:
     app.kubernetes.io/managed-by: helm
 data:
   {{- range $key, $val := .Values.nginx.config }}
-  {{ $key }}: {{ $val }}
+  {{ $key }}: {{ quote $val }}
   {{- end }}


### PR DESCRIPTION
**What this PR does / why we need it**:
Make sure that values in the nginx chart config-map template gets quoted to avoid issues with numeric and boolean values like:

```
Error: release nginx-ingress-controller failed: ConfigMap in version "v1" cannot be handled as a ConfigMap: v1.ConfigMap.Data: ReadString: expects " or n, but found f, error found in #10 byte of ...|edirect":false},"kin|..., bigger context ...|ata":{"load-balance":"least_conn","ssl-redirect":false},"kind":"ConfigMap","metadata":{"labels":{"ap|...
``` 

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Documentation**:
<!-- Add links to the related documentation changes related to this pull request. E.g. the link to the kubermatic/docs pullrequest. -->

**Does this PR introduce a user-facing change?**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If  no release note is required, just write "NONE".
-->
```release-note
NONE
```
