### PR TITLE
Fix canary release

### DIFF
--- a/hack/ci/ci-canary-github-release.sh
+++ b/hack/ci/ci-canary-github-release.sh
@@ -27,11 +27,16 @@ rootdir="$(pwd)"
 
 export GIT_TAG="$(git rev-parse HEAD)"
 
+git config --global user.email "dev@kubermatic.com"
+git config --global user.name "Prow CI Robot"
+git config --global core.sshCommand 'ssh -o CheckHostIP=no -i /ssh/id_rsa'
+ensure_github_host_pubkey
+
 # create a nice looking, sortable, somewhat meaningful release name
 commitDate="$(git show --pretty='%ct' -s "$GIT_TAG")"
-releaseDate="$(date --date="@$commitDate" +"%H%M%S" --utc)"
+releaseDate="$(date --date="@$commitDate" +"%Y-%m-%d-%H%M%S" --utc)"
 
-export RELEASE_NAME="$(git show --pretty="%cs-$releaseDate-%h" -s "$GIT_TAG")"
+export RELEASE_NAME="$releaseDate-$(git rev-parse --short "$GIT_TAG")"
 export GIT_REPO="kubermatic/kubermatic-builds"
 
 # create dummy tag in $GIT_REPO

--- a/hack/ci/ci-github-release.sh
+++ b/hack/ci/ci-github-release.sh
@@ -35,7 +35,7 @@ export GIT_HEAD="${GIT_HEAD:-$(git rev-parse HEAD)}"
 export GIT_REPO="${GIT_REPO:-kubermatic/kubermatic}"
 export RELEASE_PLATFORMS="${RELEASE_PLATFORMS:-linux-amd64 darwin-amd64 windows-amd64}"
 
-# RELEASE_NAME allos to customize the tag that is used to create the
+# RELEASE_NAME allows to customize the tag that is used to create the
 # Github release for, while the Helm charts and things will still
 # point to GIT_TAG
 export RELEASE_NAME="${RELEASE_NAME:-$GIT_TAG}"


### PR DESCRIPTION
**What this PR does / why we need it**:
Our Docker images's git does not know %cs yet, so this PR makes the date handling a bit better. And it fixes the `allos` typo.

**Does this PR introduce a user-facing change?**:
```release-note
NONE
```
