### PR TITLE
support for continuouslyReconcile during addon update

### DIFF
--- a/pkg/handler/v1/addon/addon_test.go
+++ b/pkg/handler/v1/addon/addon_test.go
@@ -581,6 +581,49 @@ func TestCreatePatchGetAddon(t *testing.T) {
 			},
 			ExistingAPIUser: test.GenAPIUser("bob", "bob@acme.com"),
 		},
+		// scenario 3
+		{
+			Name: "scenario 3: create, patch continuouslyReconcile flag, get an addon",
+			CreateBody: `{
+				"name": "addon1",
+				"spec": {
+					"variables": null
+				}
+			}`,
+			ExpectedCreateHTTPStatus: http.StatusCreated,
+			AddonToPatch:             "addon1",
+			PatchBody: `{
+				"name": "addon1",
+				"spec": {
+					"variables": {"foo": "bar"},
+                    "continuouslyReconcile": true
+				}
+			}`,
+			ExpectedPatchHTTPStatus: http.StatusOK,
+			AddonToGet:              "addon1",
+			ExpectedGetHTTPStatus:   http.StatusOK,
+			ExpectedGetResponse: apiv1.Addon{
+				ObjectMeta: apiv1.ObjectMeta{
+					ID:   "addon1",
+					Name: "addon1",
+				},
+				Spec: apiv1.AddonSpec{
+					Variables:             map[string]interface{}{"foo": "bar"},
+					ContinuouslyReconcile: true,
+				},
+			},
+			ExistingKubermaticObjs: []runtime.Object{
+				/*add projects*/
+				test.GenProject("my-first-project", kubermaticv1.ProjectActive, test.DefaultCreationTimestamp()),
+				/*add bindings*/
+				test.GenBinding("my-first-project-ID", "john@acme.com", "owners"),
+				/*add users*/
+				test.GenUser("", "john", "john@acme.com"),
+				/*add cluster*/
+				cluster,
+			},
+			ExistingAPIUser: test.GenAPIUser("john", "john@acme.com"),
+		},
 	}
 
 	for _, tc := range testcases {


### PR DESCRIPTION
**What this PR does / why we need it**: support for continuouslyReconcile flag during addon update

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #


```release-note
NONE
```
