### PR TITLE
Fix peerURL upgrade issues

### DIFF
--- a/cmd/etcd-launcher/main.go
+++ b/cmd/etcd-launcher/main.go
@@ -375,7 +375,7 @@ func (e *etcdCluster) isClusterMember(name string) (bool, error) {
 		if err != nil {
 			return false, err
 		}
-		// if the member is not started yet, it's name would be empty, in that case, we match for peerURL host.
+		// if the member is not started yet, its name would be empty, in that case, we match for peerURL host.
 		if member.Name == name || url.Host == fmt.Sprintf("%s.etcd.%s.svc.cluster.local:2380", e.config.podName, e.config.namespace) {
 			return true, nil
 		}
@@ -422,7 +422,7 @@ func (e *etcdCluster) isHealthyWithEndpoints(endpoints []string) (bool, error) {
 	_, err = client.Get(ctx, "healthy")
 	defer cancel()
 	if err != nil && err != rpctypes.ErrPermissionDenied {
-		// wait.Poll() doesn't retry if we err out
+		// silently swallow/drop transient errors
 		return false, nil
 	}
 	return true, nil

--- a/cmd/etcd-launcher/main.go
+++ b/cmd/etcd-launcher/main.go
@@ -130,6 +130,7 @@ func main() {
 		log.Fatalf("failed to check cluster membership: %v", err)
 	}
 	if isMemeber {
+		log.Infof("%s is a member", e.config.podName)
 		for {
 			// handle changes to peerURLs
 			if err := e.updatePeerURL(); err != nil {
@@ -215,6 +216,14 @@ func initialMemberList(n int, namespace string) []string {
 		members = append(members, fmt.Sprintf("etcd-%d=https://etcd-%d.etcd.%s.svc.cluster.local:2380", i, i, namespace))
 	}
 	return members
+}
+
+func peerURLsList(n int, namespace string) []string {
+	urls := []string{}
+	for i := 0; i < n; i++ {
+		urls = append(urls, fmt.Sprintf("etcd-%d.etcd.%s.svc.cluster.local:2380", i, namespace))
+	}
+	return urls
 }
 
 func clientEndpoints(n int, namespace string) []string {
@@ -366,7 +375,8 @@ func (e *etcdCluster) isClusterMember(name string) (bool, error) {
 		if err != nil {
 			return false, err
 		}
-		if member.Name == name && url.Host == fmt.Sprintf("%s.etcd.%s.svc.cluster.local:2380", e.config.podName, e.config.namespace) {
+		// if the member is not started yet, it's name would be empty, in that case, we match for peerURL host.
+		if member.Name == name || url.Host == fmt.Sprintf("%s.etcd.%s.svc.cluster.local:2380", e.config.podName, e.config.namespace) {
 			return true, nil
 		}
 	}
@@ -378,12 +388,18 @@ func (e *etcdCluster) containsUnwantedMembers() (bool, error) {
 	if err != nil {
 		return false, err
 	}
-	expectedMembers := initialMemberList(e.config.clusterSize, e.config.namespace)
+	expectedMembers := peerURLsList(e.config.clusterSize, e.config.namespace)
 membersLoop:
 	for _, member := range members {
 		for _, expectedMember := range expectedMembers {
-			if len(member.GetPeerURLs()) == 1 && expectedMember == (member.GetName()+"="+member.GetPeerURLs()[0]) {
-				continue membersLoop
+			if len(member.GetPeerURLs()) == 1 {
+				peerURL, err := url.Parse(member.PeerURLs[0])
+				if err != nil {
+					return false, err
+				}
+				if expectedMember == peerURL.Host {
+					continue membersLoop
+				}
 			}
 		}
 		return true, nil
@@ -406,7 +422,8 @@ func (e *etcdCluster) isHealthyWithEndpoints(endpoints []string) (bool, error) {
 	_, err = client.Get(ctx, "healthy")
 	defer cancel()
 	if err != nil && err != rpctypes.ErrPermissionDenied {
-		return false, err
+		// wait.Poll() doesn't retry if we err out
+		return false, nil
 	}
 	return true, nil
 }
@@ -447,7 +464,7 @@ func (e *etcdCluster) removeDeadMembers(log *zap.SugaredLogger) error {
 		if member.Name == e.config.podName {
 			continue
 		}
-		if err = wait.Poll(1*time.Second, 60*time.Second, func() (bool, error) {
+		if err = wait.Poll(1*time.Second, 30*time.Second, func() (bool, error) {
 			// we use the cluster FQDN endpoint url here. Using the IP endpoint will
 			// fail because the certificates don't include Pod IP addresses.
 			return e.isHealthyWithEndpoints(member.ClientURLs[len(member.ClientURLs)-1:])


### PR DESCRIPTION
**What this PR does / why we need it**:
Fix a split brain situation that happens when we update the peer url of one of the etcd cluster members. When we have 3 pods, the first pod is updated successfully. During processing the second pod, there was a window where the 3rd pod is removed from the cluster. The result is 1st pod is in the cluster, 3rd pod is out of the cluster, and 2nd pod is trying to join a cluster with broken quorum(1st pod cluster), which would fail. 

This PR fixes the the problem by only matching/removing etcd nodes based on peerurl hostname, not the full peer url. 

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Documentation**:
<!-- Add links to the related documentation changes related to this pull request. E.g. the link to the kubermatic/docs pullrequest. -->

**Does this PR introduce a user-facing change?**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If  no release note is required, just write "NONE".
-->
```release-note
NONE
```
