### PR TITLE
Flatcar update operator support

### DIFF
--- a/cmd/user-cluster-controller-manager/main.go
+++ b/cmd/user-cluster-controller-manager/main.go
@@ -34,6 +34,7 @@ import (
 	clusterv1alpha1 "github.com/kubermatic/machine-controller/pkg/apis/cluster/v1alpha1"
 	clusterrolelabeler "k8c.io/kubermatic/v2/pkg/controller/user-cluster-controller-manager/cluster-role-labeler"
 	containerlinux "k8c.io/kubermatic/v2/pkg/controller/user-cluster-controller-manager/container-linux"
+	"k8c.io/kubermatic/v2/pkg/controller/user-cluster-controller-manager/flatcar"
 	"k8c.io/kubermatic/v2/pkg/controller/user-cluster-controller-manager/ipam"
 	nodelabeler "k8c.io/kubermatic/v2/pkg/controller/user-cluster-controller-manager/node-labeler"
 	"k8c.io/kubermatic/v2/pkg/controller/user-cluster-controller-manager/nodecsrapprover"
@@ -287,6 +288,11 @@ func main() {
 		log.Fatalw("Failed to register the ContainerLinux controller", zap.Error(err))
 	}
 	log.Info("Registered ContainerLinux controller")
+
+	if err := flatcar.Add(mgr, runOp.overwriteRegistry, updateWindow); err != nil {
+		log.Fatalw("Failed to register the Flatcar controller", zap.Error(err))
+	}
+	log.Info("Registered Flatcar controller")
 
 	if err := nodelabeler.Add(ctx, log, mgr, nodeLabels); err != nil {
 		log.Fatalw("Failed to register nodelabel controller", zap.Error(err))

--- a/pkg/controller/user-cluster-controller-manager/flatcar/doc.go
+++ b/pkg/controller/user-cluster-controller-manager/flatcar/doc.go
@@ -1,0 +1,21 @@
+/*
+Copyright 2020 The Kubermatic Kubernetes Platform contributors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+/*
+Package flatcar linux contains the flatcar linux controller that is responsible for deploying the
+[Flatcar Linux Update Operator](https://github.com/kinvolk/flatcar-linux-update-operator) operator and DaemonSet
+*/
+package flatcar

--- a/pkg/controller/user-cluster-controller-manager/flatcar/flatcar_controller.go
+++ b/pkg/controller/user-cluster-controller-manager/flatcar/flatcar_controller.go
@@ -19,10 +19,10 @@ package flatcar
 import (
 	"context"
 	"fmt"
-	controllerutil "k8c.io/kubermatic/v2/pkg/controller/util"
 
 	"k8c.io/kubermatic/v2/pkg/controller/user-cluster-controller-manager/flatcar/resources"
 	nodelabelerapi "k8c.io/kubermatic/v2/pkg/controller/user-cluster-controller-manager/node-labeler/api"
+	controllerutil "k8c.io/kubermatic/v2/pkg/controller/util"
 	predicateutil "k8c.io/kubermatic/v2/pkg/controller/util/predicate"
 	kubermaticv1 "k8c.io/kubermatic/v2/pkg/crd/kubermatic/v1"
 	"k8c.io/kubermatic/v2/pkg/resources/reconciling"

--- a/pkg/controller/user-cluster-controller-manager/flatcar/flatcar_controller.go
+++ b/pkg/controller/user-cluster-controller-manager/flatcar/flatcar_controller.go
@@ -1,0 +1,144 @@
+/*
+Copyright 2020 The Kubermatic Kubernetes Platform contributors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package flatcar
+
+import (
+	"context"
+	"fmt"
+
+	"k8c.io/kubermatic/v2/pkg/controller/user-cluster-controller-manager/flatcar/resources"
+	nodelabelerapi "k8c.io/kubermatic/v2/pkg/controller/user-cluster-controller-manager/node-labeler/api"
+	predicateutil "k8c.io/kubermatic/v2/pkg/controller/util/predicate"
+	kubermaticv1 "k8c.io/kubermatic/v2/pkg/crd/kubermatic/v1"
+	"k8c.io/kubermatic/v2/pkg/resources/reconciling"
+
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	ctrlruntimeclient "sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/controller"
+	"sigs.k8s.io/controller-runtime/pkg/handler"
+	"sigs.k8s.io/controller-runtime/pkg/manager"
+	"sigs.k8s.io/controller-runtime/pkg/reconcile"
+	"sigs.k8s.io/controller-runtime/pkg/source"
+)
+
+const (
+	ControllerName = "kubermatic_flatcar_controller"
+)
+
+type Reconciler struct {
+	ctrlruntimeclient.Client
+	overwriteRegistry string
+	updateWindow      kubermaticv1.UpdateWindow
+}
+
+func Add(mgr manager.Manager, overwriteRegistry string, updateWindow kubermaticv1.UpdateWindow) error {
+
+	reconciler := &Reconciler{
+		Client:            mgr.GetClient(),
+		overwriteRegistry: overwriteRegistry,
+		updateWindow:      updateWindow,
+	}
+
+	ctrlOptions := controller.Options{
+		Reconciler: reconciler,
+		// Only use 1 worker to prevent concurrent operator deployments
+		MaxConcurrentReconciles: 1,
+	}
+	c, err := controller.New(ControllerName, mgr, ctrlOptions)
+	if err != nil {
+		return err
+	}
+
+	predicates := predicateutil.Factory(func(m metav1.Object, _ runtime.Object) bool {
+		return m.GetLabels()[nodelabelerapi.DistributionLabelKey] == nodelabelerapi.FlatcarLabelValue
+	})
+	return c.Watch(&source.Kind{Type: &corev1.Node{}}, &handler.EnqueueRequestForObject{}, predicates)
+}
+
+func (r *Reconciler) Reconcile(_ reconcile.Request) (reconcile.Result, error) {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	if err := r.reconcileUpdateOperatorResources(ctx); err != nil {
+		return reconcile.Result{}, fmt.Errorf("failed to reconcile the UpdateOperator resources: %v", err)
+	}
+
+	return reconcile.Result{}, nil
+}
+
+// reconcileUpdateOperatorResources deploys the FlatcarUpdateOperator
+// https://github.com/kinvolk/flatcar-linux-update-operator
+func (r *Reconciler) reconcileUpdateOperatorResources(ctx context.Context) error {
+	saCreators := []reconciling.NamedServiceAccountCreatorGetter{
+		resources.OperatorServiceAccountCreator(),
+		resources.AgentServiceAccountCreator(),
+	}
+	if err := reconciling.ReconcileServiceAccounts(ctx, saCreators, metav1.NamespaceSystem, r.Client); err != nil {
+		return fmt.Errorf("failed to reconcile the ServiceAccounts: %v", err)
+	}
+
+	crCreators := []reconciling.NamedClusterRoleCreatorGetter{
+		resources.OperatorClusterRoleCreator(),
+		resources.AgentClusterRoleCreator(),
+	}
+	if err := reconciling.ReconcileClusterRoles(ctx, crCreators, metav1.NamespaceNone, r.Client); err != nil {
+		return fmt.Errorf("failed to reconcile the ClusterRoles: %v", err)
+	}
+
+	crbCreators := []reconciling.NamedClusterRoleBindingCreatorGetter{
+		resources.OperatorClusterRoleBindingCreator(),
+		resources.AgentClusterRoleBindingCreator(),
+	}
+	if err := reconciling.ReconcileClusterRoleBindings(ctx, crbCreators, metav1.NamespaceNone, r.Client); err != nil {
+		return fmt.Errorf("failed to reconcile the ClusterRoleBindings: %v", err)
+	}
+
+	depCreators := getDeploymentCreators(r.overwriteRegistry, r.updateWindow)
+	if err := reconciling.ReconcileDeployments(ctx, depCreators, metav1.NamespaceSystem, r.Client); err != nil {
+		return fmt.Errorf("failed to reconcile the Deployments: %v", err)
+	}
+
+	dsCreators := getDaemonSetCreators(r.overwriteRegistry)
+	if err := reconciling.ReconcileDaemonSets(ctx, dsCreators, metav1.NamespaceSystem, r.Client); err != nil {
+		return fmt.Errorf("failed to reconcile the DaemonSet: %v", err)
+	}
+
+	return nil
+}
+
+func getRegistryDefaultFunc(overwriteRegistry string) func(defaultRegistry string) string {
+	return func(defaultRegistry string) string {
+		if overwriteRegistry != "" {
+			return overwriteRegistry
+		}
+		return defaultRegistry
+	}
+}
+
+func getDeploymentCreators(overwriteRegistry string, updateWindow kubermaticv1.UpdateWindow) []reconciling.NamedDeploymentCreatorGetter {
+	return []reconciling.NamedDeploymentCreatorGetter{
+		resources.OperatorDeploymentCreator(getRegistryDefaultFunc(overwriteRegistry), updateWindow),
+	}
+}
+
+func getDaemonSetCreators(overwriteRegistry string) []reconciling.NamedDaemonSetCreatorGetter {
+	return []reconciling.NamedDaemonSetCreatorGetter{
+		resources.AgentDaemonSetCreator(getRegistryDefaultFunc(overwriteRegistry)),
+	}
+}

--- a/pkg/controller/user-cluster-controller-manager/flatcar/resources/clusterrole.go
+++ b/pkg/controller/user-cluster-controller-manager/flatcar/resources/clusterrole.go
@@ -1,0 +1,154 @@
+/*
+Copyright 2020 The Kubermatic Kubernetes Platform contributors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package resources
+
+import (
+	"k8c.io/kubermatic/v2/pkg/resources/reconciling"
+
+	rbacv1 "k8s.io/api/rbac/v1"
+)
+
+const (
+	OperatorClusterRoleName = "flatcar-linux-update-operator"
+	AgentClusterRoleName    = "flatcar-linux-update-agent"
+)
+
+func OperatorClusterRoleCreator() reconciling.NamedClusterRoleCreatorGetter {
+	return func() (string, reconciling.ClusterRoleCreator) {
+		return OperatorClusterRoleName, func(cr *rbacv1.ClusterRole) (*rbacv1.ClusterRole, error) {
+			cr.Rules = []rbacv1.PolicyRule{
+				{
+					APIGroups: []string{""},
+					Resources: []string{"nodes"},
+					Verbs: []string{
+						"get",
+						"list",
+						"watch",
+						"update",
+					},
+				},
+				{
+					APIGroups: []string{""},
+					Resources: []string{"configmaps"},
+					Verbs: []string{
+						"create",
+						"get",
+						"update",
+						"list",
+						"watch",
+					},
+				},
+				{
+					APIGroups: []string{""},
+					Resources: []string{"events"},
+					Verbs: []string{
+						"create",
+						"watch",
+					},
+				},
+				{
+					APIGroups: []string{""},
+					Resources: []string{"pods"},
+					Verbs: []string{
+						"get",
+						"list",
+						"delete",
+					},
+				},
+				{
+					APIGroups: []string{"apps"},
+					Resources: []string{"daemonsets"},
+					Verbs: []string{
+						"get",
+					},
+				},
+				{
+					APIGroups:     []string{"policy"},
+					ResourceNames: []string{"flatcar-linux-update-operator"},
+					Resources:     []string{"podsecuritypolicies"},
+					Verbs: []string{
+						"use",
+					},
+				},
+			}
+			return cr, nil
+		}
+	}
+}
+
+func AgentClusterRoleCreator() reconciling.NamedClusterRoleCreatorGetter {
+	return func() (string, reconciling.ClusterRoleCreator) {
+		return AgentClusterRoleName, func(cr *rbacv1.ClusterRole) (*rbacv1.ClusterRole, error) {
+			cr.Rules = []rbacv1.PolicyRule{
+				{
+					APIGroups: []string{""},
+					Resources: []string{"nodes"},
+					Verbs: []string{
+						"get",
+						"list",
+						"watch",
+						"update",
+					},
+				},
+				{
+					APIGroups: []string{""},
+					Resources: []string{"configmaps"},
+					Verbs: []string{
+						"create",
+						"get",
+						"update",
+						"list",
+						"watch",
+					},
+				},
+				{
+					APIGroups: []string{""},
+					Resources: []string{"events"},
+					Verbs: []string{
+						"create",
+						"watch",
+					},
+				},
+				{
+					APIGroups: []string{""},
+					Resources: []string{"pods"},
+					Verbs: []string{
+						"get",
+						"list",
+						"delete",
+					},
+				},
+				{
+					APIGroups: []string{"apps"},
+					Resources: []string{"daemonsets"},
+					Verbs: []string{
+						"get",
+					},
+				},
+				{
+					APIGroups:     []string{"policy"},
+					ResourceNames: []string{"flatcar-linux-update-agentß"},
+					Resources:     []string{"podsecuritypolicies"},
+					Verbs: []string{
+						"use",
+					},
+				},
+			}
+			return cr, nil
+		}
+	}
+}

--- a/pkg/controller/user-cluster-controller-manager/flatcar/resources/clusterrolebinding.go
+++ b/pkg/controller/user-cluster-controller-manager/flatcar/resources/clusterrolebinding.go
@@ -1,0 +1,69 @@
+/*
+Copyright 2020 The Kubermatic Kubernetes Platform contributors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package resources
+
+import (
+	"k8c.io/kubermatic/v2/pkg/resources/reconciling"
+
+	rbacv1 "k8s.io/api/rbac/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+const (
+	OperatorClusterRoleBindingName = "flatcar-linux-update-operator"
+	AgentClusterRoleBindingName    = "flatcar-linux-update-agent"
+)
+
+func OperatorClusterRoleBindingCreator() reconciling.NamedClusterRoleBindingCreatorGetter {
+	return func() (string, reconciling.ClusterRoleBindingCreator) {
+		return OperatorClusterRoleBindingName, func(crb *rbacv1.ClusterRoleBinding) (*rbacv1.ClusterRoleBinding, error) {
+			crb.RoleRef = rbacv1.RoleRef{
+				APIGroup: rbacv1.GroupName,
+				Kind:     "ClusterRole",
+				Name:     OperatorClusterRoleName,
+			}
+			crb.Subjects = []rbacv1.Subject{
+				{
+					Kind:      "ServiceAccount",
+					Name:      OperatorServiceAccountName,
+					Namespace: metav1.NamespaceSystem,
+				},
+			}
+			return crb, nil
+		}
+	}
+}
+
+func AgentClusterRoleBindingCreator() reconciling.NamedClusterRoleBindingCreatorGetter {
+	return func() (string, reconciling.ClusterRoleBindingCreator) {
+		return AgentClusterRoleBindingName, func(crb *rbacv1.ClusterRoleBinding) (*rbacv1.ClusterRoleBinding, error) {
+			crb.RoleRef = rbacv1.RoleRef{
+				APIGroup: rbacv1.GroupName,
+				Kind:     "ClusterRole",
+				Name:     AgentClusterRoleName,
+			}
+			crb.Subjects = []rbacv1.Subject{
+				{
+					Kind:      "ServiceAccount",
+					Name:      AgentServiceAccountName,
+					Namespace: metav1.NamespaceSystem,
+				},
+			}
+			return crb, nil
+		}
+	}
+}

--- a/pkg/controller/user-cluster-controller-manager/flatcar/resources/serviceaccount.go
+++ b/pkg/controller/user-cluster-controller-manager/flatcar/resources/serviceaccount.go
@@ -1,0 +1,44 @@
+/*
+Copyright 2020 The Kubermatic Kubernetes Platform contributors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package resources
+
+import (
+	"k8c.io/kubermatic/v2/pkg/resources/reconciling"
+
+	corev1 "k8s.io/api/core/v1"
+)
+
+const (
+	OperatorServiceAccountName = "flatcar-linux-update-operator-sa"
+	AgentServiceAccountName    = "flatcar-linux-update-agent"
+)
+
+func OperatorServiceAccountCreator() reconciling.NamedServiceAccountCreatorGetter {
+	return func() (string, reconciling.ServiceAccountCreator) {
+		return OperatorServiceAccountName, func(sa *corev1.ServiceAccount) (*corev1.ServiceAccount, error) {
+			return sa, nil
+		}
+	}
+}
+
+func AgentServiceAccountCreator() reconciling.NamedServiceAccountCreatorGetter {
+	return func() (string, reconciling.ServiceAccountCreator) {
+		return AgentServiceAccountName, func(sa *corev1.ServiceAccount) (*corev1.ServiceAccount, error) {
+			return sa, nil
+		}
+	}
+}

--- a/pkg/controller/user-cluster-controller-manager/flatcar/resources/update_agent.go
+++ b/pkg/controller/user-cluster-controller-manager/flatcar/resources/update_agent.go
@@ -37,6 +37,8 @@ var (
 )
 
 func AgentDaemonSetCreator(getRegistry GetImageRegistry) reconciling.NamedDaemonSetCreatorGetter {
+	var userCore int64 = 500 // UID of the flatcar admin user 'core'
+
 	return func() (string, reconciling.DaemonSetCreator) {
 		return AgentDaemonSetName, func(ds *appsv1.DaemonSet) (*appsv1.DaemonSet, error) {
 			ds.Spec.UpdateStrategy = appsv1.DaemonSetUpdateStrategy{
@@ -61,6 +63,9 @@ func AgentDaemonSetCreator(getRegistry GetImageRegistry) reconciling.NamedDaemon
 					Name:    "update-agent",
 					Image:   getRegistry(resources.RegistryQuay) + "/kinvolk/flatcar-linux-update-operator:v0.7.3",
 					Command: []string{"/bin/update-agent"},
+					SecurityContext: &corev1.SecurityContext{
+						RunAsUser: &userCore,
+					},
 					Env: []corev1.EnvVar{
 						{
 							Name: "UPDATE_AGENT_NODE",

--- a/pkg/controller/user-cluster-controller-manager/flatcar/resources/update_agent.go
+++ b/pkg/controller/user-cluster-controller-manager/flatcar/resources/update_agent.go
@@ -46,7 +46,7 @@ func AgentDaemonSetCreator(getRegistry GetImageRegistry) reconciling.NamedDaemon
 				},
 			}
 
-			labels := map[string]string{"app": AgentDaemonSetName}
+			labels := map[string]string{"app.kubernetes.io/name": AgentDaemonSetName}
 
 			ds.Spec.Selector = &metav1.LabelSelector{MatchLabels: labels}
 			ds.Spec.Template.ObjectMeta.Labels = labels

--- a/pkg/controller/user-cluster-controller-manager/flatcar/resources/update_agent.go
+++ b/pkg/controller/user-cluster-controller-manager/flatcar/resources/update_agent.go
@@ -47,6 +47,7 @@ func AgentDaemonSetCreator(getRegistry GetImageRegistry) reconciling.NamedDaemon
 			}
 
 			labels := map[string]string{"app": AgentDaemonSetName}
+
 			ds.Spec.Selector = &metav1.LabelSelector{MatchLabels: labels}
 			ds.Spec.Template.ObjectMeta.Labels = labels
 

--- a/pkg/controller/user-cluster-controller-manager/flatcar/resources/update_agent.go
+++ b/pkg/controller/user-cluster-controller-manager/flatcar/resources/update_agent.go
@@ -1,0 +1,157 @@
+/*
+Copyright 2020 The Kubermatic Kubernetes Platform contributors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package resources
+
+import (
+	nodelabelerapi "k8c.io/kubermatic/v2/pkg/controller/user-cluster-controller-manager/node-labeler/api"
+	"k8c.io/kubermatic/v2/pkg/resources"
+	"k8c.io/kubermatic/v2/pkg/resources/reconciling"
+
+	appsv1 "k8s.io/api/apps/v1"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/util/intstr"
+)
+
+const (
+	AgentDaemonSetName = "flatcar-linux-update-agent"
+)
+
+var (
+	daemonSetMaxUnavailable = intstr.FromInt(1)
+	hostPathType            = corev1.HostPathUnset
+)
+
+func AgentDaemonSetCreator(getRegistry GetImageRegistry) reconciling.NamedDaemonSetCreatorGetter {
+	return func() (string, reconciling.DaemonSetCreator) {
+		return AgentDaemonSetName, func(ds *appsv1.DaemonSet) (*appsv1.DaemonSet, error) {
+			ds.Spec.UpdateStrategy = appsv1.DaemonSetUpdateStrategy{
+				Type: appsv1.RollingUpdateDaemonSetStrategyType,
+				RollingUpdate: &appsv1.RollingUpdateDaemonSet{
+					MaxUnavailable: &daemonSetMaxUnavailable,
+				},
+			}
+
+			labels := map[string]string{"app": AgentDaemonSetName}
+			ds.Spec.Selector = &metav1.LabelSelector{MatchLabels: labels}
+			ds.Spec.Template.ObjectMeta.Labels = labels
+
+			// The agent should only run on Flatcar nodes
+			ds.Spec.Template.Spec.NodeSelector = map[string]string{nodelabelerapi.DistributionLabelKey: nodelabelerapi.FlatcarLabelValue}
+
+			ds.Spec.Template.Spec.ServiceAccountName = AgentServiceAccountName
+
+			ds.Spec.Template.Spec.Containers = []corev1.Container{
+				{
+					Name:    "update-agent",
+					Image:   getRegistry(resources.RegistryQuay) + "/kinvolk/flatcar-linux-update-operator:v0.7.3",
+					Command: []string{"/bin/update-agent"},
+					Env: []corev1.EnvVar{
+						{
+							Name: "UPDATE_AGENT_NODE",
+							ValueFrom: &corev1.EnvVarSource{
+								FieldRef: &corev1.ObjectFieldSelector{
+									APIVersion: "v1",
+									FieldPath:  "spec.nodeName",
+								},
+							},
+						},
+						{
+							Name: "POD_NAMESPACE",
+							ValueFrom: &corev1.EnvVarSource{
+								FieldRef: &corev1.ObjectFieldSelector{
+									APIVersion: "v1",
+									FieldPath:  "metadata.namespace",
+								},
+							},
+						},
+					},
+					VolumeMounts: []corev1.VolumeMount{
+						{
+							Name:      "var-run-dbus",
+							MountPath: "/var/run/dbus",
+						},
+						{
+							Name:      "etc-flatcar",
+							MountPath: "/etc/flatcar",
+						},
+						{
+							Name:      "usr-share-flatcar",
+							MountPath: "/usr/share/flatcar",
+						},
+						{
+							Name:      "etc-os-release",
+							MountPath: "/etc/os-release",
+						},
+					},
+				},
+			}
+
+			ds.Spec.Template.Spec.Tolerations = []corev1.Toleration{
+				{
+					Effect:   corev1.TaintEffectNoSchedule,
+					Operator: corev1.TolerationOpExists,
+				},
+				{
+					Effect:   corev1.TaintEffectNoExecute,
+					Operator: corev1.TolerationOpExists,
+				},
+			}
+
+			ds.Spec.Template.Spec.Volumes = []corev1.Volume{
+				{
+					Name: "var-run-dbus",
+					VolumeSource: corev1.VolumeSource{
+						HostPath: &corev1.HostPathVolumeSource{
+							Path: "/var/run/dbus",
+							Type: &hostPathType,
+						},
+					},
+				},
+				{
+					Name: "etc-flatcar",
+					VolumeSource: corev1.VolumeSource{
+						HostPath: &corev1.HostPathVolumeSource{
+							Path: "/etc/flatcar",
+							Type: &hostPathType,
+						},
+					},
+				},
+				{
+					Name: "usr-share-flatcar",
+					VolumeSource: corev1.VolumeSource{
+						HostPath: &corev1.HostPathVolumeSource{
+							Path: "/usr/share/flatcar",
+							Type: &hostPathType,
+						},
+					},
+				},
+				{
+					Name: "etc-os-release",
+					VolumeSource: corev1.VolumeSource{
+						HostPath: &corev1.HostPathVolumeSource{
+							Path: "/etc/os-release",
+							Type: &hostPathType,
+						},
+					},
+				},
+			}
+
+			return ds, nil
+		}
+	}
+}

--- a/pkg/controller/user-cluster-controller-manager/flatcar/resources/update_operator.go
+++ b/pkg/controller/user-cluster-controller-manager/flatcar/resources/update_operator.go
@@ -1,0 +1,113 @@
+/*
+Copyright 2020 The Kubermatic Kubernetes Platform contributors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package resources
+
+import (
+	nodelabelerapi "k8c.io/kubermatic/v2/pkg/controller/user-cluster-controller-manager/node-labeler/api"
+	kubermaticv1 "k8c.io/kubermatic/v2/pkg/crd/kubermatic/v1"
+	"k8c.io/kubermatic/v2/pkg/resources"
+	"k8c.io/kubermatic/v2/pkg/resources/reconciling"
+
+	appsv1 "k8s.io/api/apps/v1"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/util/intstr"
+)
+
+const (
+	OperatorDeploymentName = "flatcar-linux-update-operator"
+)
+
+var (
+	deploymentReplicas       int32 = 1
+	deploymentMaxSurge             = intstr.FromInt(1)
+	deploymentMaxUnavailable       = intstr.FromString("25%")
+)
+
+type GetImageRegistry func(reg string) string
+
+func OperatorDeploymentCreator(getRegistry GetImageRegistry, updateWindow kubermaticv1.UpdateWindow) reconciling.NamedDeploymentCreatorGetter {
+	return func() (string, reconciling.DeploymentCreator) {
+		return OperatorDeploymentName, func(dep *appsv1.Deployment) (*appsv1.Deployment, error) {
+			dep.Spec.Replicas = &deploymentReplicas
+
+			dep.Spec.Strategy = appsv1.DeploymentStrategy{
+				Type: appsv1.RollingUpdateDeploymentStrategyType,
+				RollingUpdate: &appsv1.RollingUpdateDeployment{
+					MaxSurge:       &deploymentMaxSurge,
+					MaxUnavailable: &deploymentMaxUnavailable,
+				},
+			}
+
+			labels := map[string]string{"app": OperatorDeploymentName}
+			dep.Spec.Selector = &metav1.LabelSelector{MatchLabels: labels}
+			dep.Spec.Template.ObjectMeta.Labels = labels
+			dep.Spec.Template.Spec.ServiceAccountName = OperatorServiceAccountName
+
+			// The operator should only run on Flatcar nodes
+			dep.Spec.Template.Spec.NodeSelector = map[string]string{nodelabelerapi.DistributionLabelKey: nodelabelerapi.FlatcarLabelValue}
+
+			env := []corev1.EnvVar{
+				{
+					Name: "POD_NAMESPACE",
+					ValueFrom: &corev1.EnvVarSource{
+						FieldRef: &corev1.ObjectFieldSelector{
+							APIVersion: "v1",
+							FieldPath:  "metadata.namespace",
+						},
+					},
+				},
+			}
+
+			if updateWindow.Start != "" {
+				env = append(env, corev1.EnvVar{
+					Name:  "UPDATE_OPERATOR_REBOOT_WINDOW_START",
+					Value: updateWindow.Start,
+				})
+			}
+
+			if updateWindow.Length != "" {
+				env = append(env, corev1.EnvVar{
+					Name:  "UPDATE_OPERATOR_REBOOT_WINDOW_LENGTH",
+					Value: updateWindow.Length,
+				})
+			}
+
+			dep.Spec.Template.Spec.Containers = []corev1.Container{
+				{
+					Name:    "update-operator",
+					Image:   getRegistry(resources.RegistryQuay) + "/kinvolk/flatcar-linux-update-operator:v0.7.3",
+					Command: []string{"/bin/update-operator"},
+					Env:     env,
+				},
+			}
+
+			dep.Spec.Template.Spec.Tolerations = []corev1.Toleration{
+				{
+					Effect:   corev1.TaintEffectNoSchedule,
+					Operator: corev1.TolerationOpExists,
+				},
+				{
+					Effect:   corev1.TaintEffectNoExecute,
+					Operator: corev1.TolerationOpExists,
+				},
+			}
+
+			return dep, nil
+		}
+	}
+}

--- a/pkg/controller/user-cluster-controller-manager/flatcar/resources/update_operator.go
+++ b/pkg/controller/user-cluster-controller-manager/flatcar/resources/update_operator.go
@@ -53,7 +53,8 @@ func OperatorDeploymentCreator(getRegistry GetImageRegistry, updateWindow kuberm
 				},
 			}
 
-			labels := map[string]string{"app": OperatorDeploymentName}
+			labels := map[string]string{"app.kubernetes.io/name": OperatorDeploymentName}
+
 			dep.Spec.Selector = &metav1.LabelSelector{MatchLabels: labels}
 			dep.Spec.Template.ObjectMeta.Labels = labels
 			dep.Spec.Template.Spec.ServiceAccountName = OperatorServiceAccountName


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR adds support for the flatcar linux update operator. 

**Which issue(s) this PR fixes**
Fixes #5622

**Special notes for your reviewer**:
* This PR is based on the existing operator for [Container Linux](https://github.com/kubermatic/kubermatic/tree/master/pkg/controller/user-cluster-controller-manager/container-linux) and the [flatcar update operator example deployment](https://github.com/kinvolk/flatcar-linux-update-operator/tree/master/examples/deploy).
* The 'resource' package contains a lot of duplicated definitions for the operator and agent respectively. Those could easily be deduplicated. But as a consequence the resource definitions would not mirror the ones from the example deployment as nicely. For me both approaches are valid. I leave it up to the reviewer, whether deduplication is preferred over the current solution.

**Documentation**:
* [Flatcar Linux Update Operator](https://github.com/kinvolk/flatcar-linux-update-operator#flatcar-linux-update-operator)

**Does this PR introduce a user-facing change?**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If  no release note is required, just write "NONE".
-->
```release-note
NONE
```
