### PR TITLE
Support override etcd launcher image

### DIFF
--- a/docs/zz_generated.kubermaticConfiguration.yaml
+++ b/docs/zz_generated.kubermaticConfiguration.yaml
@@ -356,8 +356,12 @@ spec:
     # DisableAPIServerEndpointReconciling can be used to toggle the `--endpoint-reconciler-type` flag for
     # the Kubernetes API server.
     disableApiserverEndpointReconciling: false
-    # DNATControllerDockerRepository is the repository containing the Kubermatic user-cluster-controller-manager image.
+    # DNATControllerDockerRepository is the repository containing the
+    # dnat-controller image.
     dnatControllerDockerRepository: quay.io/kubermatic/kubeletdnat-controller
+    # EtcdLauncherDockerRepository is the repository containing the Kubermatic
+    # etcd-launcher image.
+    etcdLauncherDockerRepository: quay.io/kubermatic/etcd-launcher
     # EtcdVolumeSize configures the volume size to use for each etcd pod inside user clusters.
     etcdVolumeSize: 5Gi
     # KubermaticDockerRepository is the repository containing the Kubermatic user-cluster-controller-manager image.

--- a/pkg/controller/operator/common/defaults.go
+++ b/pkg/controller/operator/common/defaults.go
@@ -468,11 +468,15 @@ func DefaultConfiguration(config *operatorv1alpha1.KubermaticConfiguration, logg
 		return copy, err
 	}
 
-	if err := defaultDockerRepo(&copy.Spec.UserCluster.KubermaticDockerRepository, resources.DefaultKubermaticImage, "userCluster.addons.kubermaticDockerRepository", logger); err != nil {
+	if err := defaultDockerRepo(&copy.Spec.UserCluster.KubermaticDockerRepository, resources.DefaultKubermaticImage, "userCluster.kubermaticDockerRepository", logger); err != nil {
 		return copy, err
 	}
 
-	if err := defaultDockerRepo(&copy.Spec.UserCluster.DNATControllerDockerRepository, resources.DefaultDNATControllerImage, "userCluster.addons.dnatControllerDockerRepository", logger); err != nil {
+	if err := defaultDockerRepo(&copy.Spec.UserCluster.DNATControllerDockerRepository, resources.DefaultDNATControllerImage, "userCluster.dnatControllerDockerRepository", logger); err != nil {
+		return copy, err
+	}
+
+	if err := defaultDockerRepo(&copy.Spec.UserCluster.EtcdLauncherDockerRepository, resources.DefaultEtcdLauncherImage, "userCluster.etcdLauncher.DockerRepository", logger); err != nil {
 		return copy, err
 	}
 

--- a/pkg/controller/operator/seed/resources/kubermatic/seed-controller-manager.go
+++ b/pkg/controller/operator/seed/resources/kubermatic/seed-controller-manager.go
@@ -82,6 +82,7 @@ func SeedControllerManagerDeploymentCreator(workerName string, versions common.V
 				fmt.Sprintf("-worker-name=%s", workerName),
 				fmt.Sprintf("-kubermatic-image=%s", cfg.Spec.UserCluster.KubermaticDockerRepository),
 				fmt.Sprintf("-dnatcontroller-image=%s", cfg.Spec.UserCluster.DNATControllerDockerRepository),
+				fmt.Sprintf("-etcd-launcher-image=%s", cfg.Spec.UserCluster.EtcdLauncherDockerRepository),
 				fmt.Sprintf("-overwrite-registry=%s", cfg.Spec.UserCluster.OverwriteRegistry),
 				fmt.Sprintf("-apiserver-default-replicas=%d", *cfg.Spec.UserCluster.APIServerReplicas),
 				fmt.Sprintf("-controller-manager-default-replicas=%d", 1),

--- a/pkg/crd/operator/v1alpha1/configuration.go
+++ b/pkg/crd/operator/v1alpha1/configuration.go
@@ -149,8 +149,12 @@ type KubermaticSeedControllerConfiguration struct {
 type KubermaticUserClusterConfiguration struct {
 	// KubermaticDockerRepository is the repository containing the Kubermatic user-cluster-controller-manager image.
 	KubermaticDockerRepository string `json:"kubermaticDockerRepository,omitempty"`
-	// DNATControllerDockerRepository is the repository containing the Kubermatic user-cluster-controller-manager image.
+	// DNATControllerDockerRepository is the repository containing the
+	// dnat-controller image.
 	DNATControllerDockerRepository string `json:"dnatControllerDockerRepository,omitempty"`
+	// EtcdLauncherDockerRepository is the repository containing the Kubermatic
+	// etcd-launcher image.
+	EtcdLauncherDockerRepository string `json:"etcdLauncherDockerRepository,omitempty"`
 	// OverwriteRegistry specifies a custom Docker registry which will be used for all images
 	// used inside user clusters (user cluster control plane + addons). This also applies to
 	// the KubermaticDockerRepository and DNATControllerDockerRepository fields.


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR allows to configure the repository to be used for the `etcd-launcher` repository in the `KubermaticConfiguration` consistently with the other images handled by the `user-controller-manager`.
The main advantage is that PRs that build locally for testing and pushed to a private repository can be used easily.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Documentation**:
<!-- Add links to the related documentation changes related to this pull request. E.g. the link to the kubermatic/docs pullrequest. -->

**Does this PR introduce a user-facing change?**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If  no release note is required, just write "NONE".
-->
```release-note
Make etcd-launcher repository configurable in KubermaticConfiguration.
```
