### PR TITLE
Fix comment on cluster field of vSphere datacenter spec

### DIFF
--- a/cmd/kubermatic-api/swagger.json
+++ b/cmd/kubermatic-api/swagger.json
@@ -10562,7 +10562,7 @@
           "x-go-name": "AllowInsecure"
         },
         "cluster": {
-          "description": "The name of the Kubernetes cluster to use.",
+          "description": "Optional: The name of the vSphere cluster to use.\nCluster is deprecated and may be removed in future releases as it is\ncurrently ignored.\nThe cluster hosting the VMs will be the same VM used as a template is\nlocated.",
           "type": "string",
           "x-go-name": "Cluster"
         },

--- a/docs/zz_generated.seed.yaml
+++ b/docs/zz_generated.seed.yaml
@@ -142,7 +142,11 @@ spec:
         vsphere:
           # If set to true, disables the TLS certificate check against the endpoint.
           allow_insecure: false
-          # The name of the Kubernetes cluster to use.
+          # Optional: The name of the vSphere cluster to use.
+          # Cluster is deprecated and may be removed in future releases as it is
+          # currently ignored.
+          # The cluster hosting the VMs will be the same VM used as a template is
+          # located.
           cluster: ""
           # The name of the datacenter to use.
           datacenter: ""
@@ -164,8 +168,9 @@ spec:
           # "/datacenter-1/vm/all-kubermatic-vms-in-here") and defaults to the root VM
           # folder: "/datacenter-1/vm"
           root_path: ""
-          # A list of templates to use for a given operating system. You must define at
-          # least one template.
+          # A list of VM templates to use for a given operating system. You must
+          # define at least one template.
+          # See: https://github.com/kubermatic/machine-controller/blob/master/docs/vsphere.md#template-vms-preparation
           templates:
             centos: ""
             coreos: ""

--- a/pkg/crd/kubermatic/v1/datacenter.go
+++ b/pkg/crd/kubermatic/v1/datacenter.go
@@ -239,15 +239,20 @@ type DatacenterSpecVSphere struct {
 	DefaultDatastore string `json:"datastore"`
 	// The name of the datacenter to use.
 	Datacenter string `json:"datacenter"`
-	// The name of the Kubernetes cluster to use.
+	// Optional: The name of the vSphere cluster to use.
+	// Cluster is deprecated and may be removed in future releases as it is
+	// currently ignored.
+	// The cluster hosting the VMs will be the same VM used as a template is
+	// located.
 	Cluster string `json:"cluster"`
 	// Optional: The root path for cluster specific VM folders. Each cluster gets its own
 	// folder below the root folder. Must be the FQDN (for example
 	// "/datacenter-1/vm/all-kubermatic-vms-in-here") and defaults to the root VM
 	// folder: "/datacenter-1/vm"
 	RootPath string `json:"root_path"`
-	// A list of templates to use for a given operating system. You must define at
-	// least one template.
+	// A list of VM templates to use for a given operating system. You must
+	// define at least one template.
+	// See: https://github.com/kubermatic/machine-controller/blob/master/docs/vsphere.md#template-vms-preparation
 	Templates ImageList `json:"templates"`
 
 	// Optional: Infra management user is the user that will be used for everything

--- a/pkg/test/e2e/api/utils/apiclient/models/datacenter_spec_v_sphere.go
+++ b/pkg/test/e2e/api/utils/apiclient/models/datacenter_spec_v_sphere.go
@@ -19,7 +19,11 @@ type DatacenterSpecVSphere struct {
 	// If set to true, disables the TLS certificate check against the endpoint.
 	AllowInsecure bool `json:"allow_insecure,omitempty"`
 
-	// The name of the Kubernetes cluster to use.
+	// Optional: The name of the vSphere cluster to use.
+	// Cluster is deprecated and may be removed in future releases as it is
+	// currently ignored.
+	// The cluster hosting the VMs will be the same VM used as a template is
+	// located.
 	Cluster string `json:"cluster,omitempty"`
 
 	// The name of the datacenter to use.


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR fixes the comment on the `Cluster` field in `DatacenterSpecVSphere` that wrongly states it refers to the Kubernates cluster. In addition it specifies that this field is optional, and what is more important completely ignored.

See: https://github.com/kubermatic/machine-controller/pull/726#issuecomment-611449844

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Documentation**:
<!-- Add links to the related documentation changes related to this pull request. E.g. the link to the kubermatic/docs pullrequest. -->

**Does this PR introduce a user-facing change?**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If  no release note is required, just write "NONE".
-->
```release-note
Make 'cluster' field in vSphere datacenter spec optional.
```
