### PR TITLE
Fix gocache accidentally interpreting random headers as HTTP 404

### DIFF
--- a/hack/ci/ci-download-gocache.sh
+++ b/hack/ci/ci-download-gocache.sh
@@ -61,7 +61,7 @@ ARCHIVE_NAME="${CACHE_VERSION}-${GO_VERSION}.tar"
 URL="${GOCACHE_MINIO_ADDRESS}/${ARCHIVE_NAME}"
 
 # Do not go through the retry loop when there is nothing
-if curl --head "${URL}" | grep -q 404; then
+if ! curl --head --silent --fail "${URL}" > /dev/null; then
   echodate "Remote has no gocache ${ARCHIVE_NAME}, exiting"
   exit 0
 fi


### PR DESCRIPTION
**What this PR does / why we need it**:
Checking if *any* HTTP header contains the string "404" is a bit too broad and can lead to these false negatives:

```
curl --head http://127.0.0.1:9000/gocache/2f34c05fc4338242eb5f5413232b668f3f924714-1.15.1.tar | grep 404
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed
  0 1339M    0     0    0     0      0      0 --:--:-- --:--:-- --:--:--     0
Content-Length: 1404815360
```

This PR makes the existence check more robust.

**Does this PR introduce a user-facing change?**:
```release-note
NONE
```
