### PR TITLE
[release/v2.14] Make sure that tag placeholder is replaced for all charts when preparing release tarball

### DIFF
--- a/api/hack/ci/ci-github-release.sh
+++ b/api/hack/ci/ci-github-release.sh
@@ -128,9 +128,8 @@ fi
 releaseID=$(echo "$releasedata" | jq -r '.id')
 
 # prepare source for archiving
-sed -i "s/__DASHBOARD_TAG__/$tag/g" config/kubermatic/*.yaml
-sed -i "s/__KUBERMATIC_TAG__/$tag/g" config/kubermatic/*.yaml
-sed -i "s/__KUBERMATIC_TAG__/$tag/g" config/kubermatic-operator/*.yaml
+sed -i "s/__DASHBOARD_TAG__/$tag/g" config/*/*.yaml
+sed -i "s/__KUBERMATIC_TAG__/$tag/g" config/*/*.yaml
 
 echodate "Uploading kubermatic CE archive..."
 


### PR DESCRIPTION
**What this PR does / why we need it**:
This makes sure that `__KUBERMATIC_TAG__` and `__DASHBOARD_TAG__` are replaced for all charts. Currently it is not the case for nodeport proxy chart.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Documentation**:
<!-- Add links to the related documentation changes related to this pull request. E.g. the link to the kubermatic/docs pullrequest. -->

**Does this PR introduce a user-facing change?**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If  no release note is required, just write "NONE".
-->
```release-note
NONE
```
