### PR TITLE
[release/v2.14] Make unit-test independent from actual DNS resolution

### DIFF
--- a/api/pkg/controller/seed-controller-manager/kubernetes/address.go
+++ b/api/pkg/controller/seed-controller-manager/kubernetes/address.go
@@ -41,7 +41,12 @@ func (r *Reconciler) syncAddress(ctx context.Context, log *zap.SugaredLogger, cl
 		r.log.Infow("Created admin token for cluster", "cluster", cluster.Name)
 	}
 
-	modifiers, err := address.SyncClusterAddress(ctx, log, cluster, r.Client, r.externalURL, seed)
+	modifiers, err := address.NewModifiersBuilder(log).
+		Cluster(cluster).
+		Client(r.Client).
+		ExternalURL(r.externalURL).
+		Seed(seed).
+		Build(ctx)
 	if err != nil {
 		return err
 	}

--- a/api/pkg/controller/seed-controller-manager/openshift/openshift_controller.go
+++ b/api/pkg/controller/seed-controller-manager/openshift/openshift_controller.go
@@ -587,7 +587,12 @@ func (r *Reconciler) ensureNamespace(ctx context.Context, c *kubermaticv1.Cluste
 }
 
 func (r *Reconciler) address(ctx context.Context, cluster *kubermaticv1.Cluster, seed *kubermaticv1.Seed) error {
-	modifiers, err := address.SyncClusterAddress(ctx, r.log.With("cluster", cluster.Name), cluster, r.Client, r.externalURL, seed)
+	modifiers, err := address.NewModifiersBuilder(r.log.With("cluster", cluster.Name)).
+		Cluster(cluster).
+		Client(r.Client).
+		ExternalURL(r.externalURL).
+		Seed(seed).
+		Build(ctx)
 	if err != nil {
 		return err
 	}

--- a/api/pkg/resources/address/address.go
+++ b/api/pkg/resources/address/address.go
@@ -18,6 +18,7 @@ package address
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"net"
 
@@ -32,24 +33,72 @@ import (
 	ctrlruntimeclient "sigs.k8s.io/controller-runtime/pkg/client"
 )
 
-func SyncClusterAddress(ctx context.Context,
-	log *zap.SugaredLogger,
-	cluster *kubermaticv1.Cluster,
-	client ctrlruntimeclient.Client,
-	externalURL string,
-	seed *kubermaticv1.Seed) ([]func(*kubermaticv1.Cluster), error) {
-	var modifiers []func(*kubermaticv1.Cluster)
+type lookupFunction func(host string) ([]net.IP, error)
 
-	subdomain := seed.Name
-	if seed.Spec.SeedDNSOverwrite != "" {
-		subdomain = seed.Spec.SeedDNSOverwrite
+type ModifiersBuilder struct {
+	log         *zap.SugaredLogger
+	client      ctrlruntimeclient.Client
+	cluster     *kubermaticv1.Cluster
+	seed        *kubermaticv1.Seed
+	externalURL string
+	// used to ease unit tests
+	lookupFunction lookupFunction
+}
+
+func NewModifiersBuilder(log *zap.SugaredLogger) *ModifiersBuilder {
+	return &ModifiersBuilder{
+		log:            log,
+		lookupFunction: net.LookupIP,
+	}
+}
+
+func (m *ModifiersBuilder) Client(c ctrlruntimeclient.Client) *ModifiersBuilder {
+	m.client = c
+	return m
+}
+
+func (m *ModifiersBuilder) Cluster(c *kubermaticv1.Cluster) *ModifiersBuilder {
+	m.cluster = c
+	return m
+}
+
+func (m *ModifiersBuilder) Seed(s *kubermaticv1.Seed) *ModifiersBuilder {
+	m.seed = s
+	return m
+}
+
+func (m *ModifiersBuilder) ExternalURL(e string) *ModifiersBuilder {
+	m.externalURL = e
+	return m
+}
+
+func (m *ModifiersBuilder) lookupFunc(l lookupFunction) *ModifiersBuilder {
+	m.lookupFunction = l
+	return m
+}
+
+func (m *ModifiersBuilder) Build(ctx context.Context) ([]func(*kubermaticv1.Cluster), error) {
+	var modifiers []func(*kubermaticv1.Cluster)
+	if m.seed == nil {
+		return modifiers, errors.New("providing seed is mandatory for building address modifiers")
+	}
+	if m.cluster == nil {
+		return modifiers, errors.New("providing cluster is mandatory for building address modifiers")
+	}
+	if m.client == nil {
+		return modifiers, errors.New("providing client is mandatory for building address modifiers")
+	}
+
+	subdomain := m.seed.Name
+	if m.seed.Spec.SeedDNSOverwrite != "" {
+		subdomain = m.seed.Spec.SeedDNSOverwrite
 	}
 
 	frontProxyLoadBalancerServiceIP := ""
-	if cluster.Spec.ExposeStrategy == corev1.ServiceTypeLoadBalancer {
+	if m.cluster.Spec.ExposeStrategy == corev1.ServiceTypeLoadBalancer {
 		frontProxyLoadBalancerService := &corev1.Service{}
-		nn := types.NamespacedName{Namespace: cluster.Status.NamespaceName, Name: resources.FrontLoadBalancerServiceName}
-		if err := client.Get(ctx, nn, frontProxyLoadBalancerService); err != nil {
+		nn := types.NamespacedName{Namespace: m.cluster.Status.NamespaceName, Name: resources.FrontLoadBalancerServiceName}
+		if err := m.client.Get(ctx, nn, frontProxyLoadBalancerService); err != nil {
 			return nil, fmt.Errorf("failed to get the front-loadbalancer service: %v", err)
 		}
 		// Use this as default in case the implementation doesn't populate the status
@@ -64,50 +113,50 @@ func SyncClusterAddress(ctx context.Context,
 
 	// External Name
 	externalName := ""
-	if cluster.Spec.ExposeStrategy == corev1.ServiceTypeLoadBalancer {
+	if m.cluster.Spec.ExposeStrategy == corev1.ServiceTypeLoadBalancer {
 		externalName = frontProxyLoadBalancerServiceIP
 	} else {
-		externalName = fmt.Sprintf("%s.%s.%s", cluster.Name, subdomain, externalURL)
+		externalName = fmt.Sprintf("%s.%s.%s", m.cluster.Name, subdomain, m.externalURL)
 	}
 
-	if cluster.Address.ExternalName != externalName {
+	if m.cluster.Address.ExternalName != externalName {
 		modifiers = append(modifiers, func(c *kubermaticv1.Cluster) {
 			c.Address.ExternalName = externalName
 		})
-		log.Debugw("Set external name for cluster", "externalName", externalName)
+		m.log.Debugw("Set external name for cluster", "externalName", externalName)
 	}
 
 	// Internal name
-	internalName := fmt.Sprintf("%s.%s.svc.cluster.local.", resources.ApiserverExternalServiceName, cluster.Status.NamespaceName)
-	if cluster.Address.InternalName != internalName {
+	internalName := fmt.Sprintf("%s.%s.svc.cluster.local.", resources.ApiserverExternalServiceName, m.cluster.Status.NamespaceName)
+	if m.cluster.Address.InternalName != internalName {
 		modifiers = append(modifiers, func(c *kubermaticv1.Cluster) {
 			c.Address.InternalName = internalName
 		})
-		log.Debugw("Set internal name for cluster", "internalName", internalName)
+		m.log.Debugw("Set internal name for cluster", "internalName", internalName)
 	}
 
 	// IP
 	ip := ""
-	if cluster.Spec.ExposeStrategy == corev1.ServiceTypeLoadBalancer {
+	if m.cluster.Spec.ExposeStrategy == corev1.ServiceTypeLoadBalancer {
 		ip = frontProxyLoadBalancerServiceIP
 	} else {
 		var err error
 		// Always lookup IP address, in case it changes (IP's on AWS LB's change)
-		ip, err = getExternalIPv4(log, externalName)
+		ip, err = m.getExternalIPv4(externalName)
 		if err != nil {
 			return nil, err
 		}
 	}
-	if cluster.Address.IP != ip {
+	if m.cluster.Address.IP != ip {
 		modifiers = append(modifiers, func(c *kubermaticv1.Cluster) {
 			c.Address.IP = ip
 		})
-		log.Debugw("Set IP for cluster", "ip", ip)
+		m.log.Debugw("Set IP for cluster", "ip", ip)
 	}
 
 	service := &corev1.Service{}
-	serviceKey := types.NamespacedName{Namespace: cluster.Status.NamespaceName, Name: resources.ApiserverExternalServiceName}
-	if err := client.Get(ctx, serviceKey, service); err != nil {
+	serviceKey := types.NamespacedName{Namespace: m.cluster.Status.NamespaceName, Name: resources.ApiserverExternalServiceName}
+	if err := m.client.Get(ctx, serviceKey, service); err != nil {
 		return nil, err
 	}
 	if len(service.Spec.Ports) < 1 {
@@ -116,26 +165,26 @@ func SyncClusterAddress(ctx context.Context,
 
 	// Port
 	port := service.Spec.Ports[0].NodePort
-	if cluster.Address.Port != port {
+	if m.cluster.Address.Port != port {
 		modifiers = append(modifiers, func(c *kubermaticv1.Cluster) {
 			c.Address.Port = port
 		})
-		log.Debugw("Set port for cluster", "port", port)
+		m.log.Debugw("Set port for cluster", "port", port)
 	}
 
 	// URL
 	url := fmt.Sprintf("https://%s:%d", externalName, port)
-	if cluster.Address.URL != url {
+	if m.cluster.Address.URL != url {
 		modifiers = append(modifiers, func(c *kubermaticv1.Cluster) {
 			c.Address.URL = url
 		})
-		log.Debugw("Set URL for cluster", "url", url)
+		m.log.Debugw("Set URL for cluster", "url", url)
 	}
 
-	if cluster.IsOpenshift() {
+	if m.cluster.IsOpenshift() {
 		openshiftConsoleCallBackURL := fmt.Sprintf("https://%s/api/v1/projects/%s/dc/%s/clusters/%s/openshift/console/proxy/auth/callback",
-			externalURL, cluster.Labels[kubermaticv1.ProjectIDLabelKey], seed.Name, cluster.Name)
-		if cluster.Address.OpenshiftConsoleCallBack != openshiftConsoleCallBackURL {
+			m.externalURL, m.cluster.Labels[kubermaticv1.ProjectIDLabelKey], m.seed.Name, m.cluster.Name)
+		if m.cluster.Address.OpenshiftConsoleCallBack != openshiftConsoleCallBackURL {
 			modifiers = append(modifiers, func(c *kubermaticv1.Cluster) {
 				c.Address.OpenshiftConsoleCallBack = openshiftConsoleCallBackURL
 			})
@@ -145,8 +194,8 @@ func SyncClusterAddress(ctx context.Context,
 	return modifiers, nil
 }
 
-func getExternalIPv4(log *zap.SugaredLogger, hostname string) (string, error) {
-	resolvedIPs, err := net.LookupIP(hostname)
+func (m *ModifiersBuilder) getExternalIPv4(hostname string) (string, error) {
+	resolvedIPs, err := m.lookupFunction(hostname)
 	if err != nil {
 		return "", fmt.Errorf("failed to lookup ip for %s: %v", hostname, err)
 	}
@@ -163,7 +212,7 @@ func getExternalIPv4(log *zap.SugaredLogger, hostname string) (string, error) {
 
 	//Just one ipv4
 	if len(ips) > 1 {
-		log.Debugw("Lookup returned multiple ipv4 addresses. Picking the first one after sorting", "hostname", hostname, "foundAddresses", ips, "pickedAddress", ips[0])
+		m.log.Debugw("Lookup returned multiple ipv4 addresses. Picking the first one after sorting", "hostname", hostname, "foundAddresses", ips, "pickedAddress", ips[0])
 	}
 	return ips[0], nil
 }

--- a/api/pkg/resources/address/address_test.go
+++ b/api/pkg/resources/address/address_test.go
@@ -19,6 +19,7 @@ package address
 import (
 	"context"
 	"fmt"
+	"net"
 	"testing"
 
 	kubermaticv1 "github.com/kubermatic/kubermatic/api/pkg/crd/kubermatic/v1"
@@ -36,18 +37,27 @@ const (
 	fakeDCName               = "europe-west3-c"
 	fakeExternalURL          = "dev.kubermatic.io"
 	fakeClusterNamespaceName = "cluster-ns"
-	// This must be the A record for *.europe-west3c.dev.kubermatic.io and
-	// *.alias-europe-west3-c.dev.kubermatic.io
-	externalIP = "35.198.93.90"
-	// Henrik created 2 dns entries for dns-test @ OVH.com. dns-test.kubermatic.io points to:
-	// - 192.168.1.1
-	// - 192.168.1.2
-	// - 2001:16B8:6844:D700:A1B9:D94B:FDC3:1C33
-	testDomain = "dns-test.kubermatic.io"
+	externalIP               = "34.89.181.151"
+	testDomain               = "dns-test.kubermatic.io"
 )
 
+func testLookupFunction(host string) ([]net.IP, error) {
+	switch host {
+	case testDomain:
+		return []net.IP{net.IPv4(192, 168, 1, 1), net.IPv4(192, 168, 1, 2)}, nil
+	case "fake-cluster.europe-west3-c.dev.kubermatic.io":
+		fallthrough
+	case "fake-cluster.alias-europe-west3-c.dev.kubermatic.io":
+		return []net.IP{net.IPv4(34, 89, 181, 151)}, nil
+	default:
+		return []net.IP{}, nil
+	}
+}
+
 func TestGetExternalIPv4(t *testing.T) {
-	ip, err := getExternalIPv4(kubermaticlog.Logger, testDomain)
+	ip, err := NewModifiersBuilder(kubermaticlog.Logger).
+		lookupFunc(testLookupFunction).
+		getExternalIPv4(testDomain)
 	if err != nil {
 		t.Fatalf("failed to get the external IPv4 address for %s: %v", testDomain, err)
 	}
@@ -195,8 +205,13 @@ func TestSyncClusterAddress(t *testing.T) {
 				},
 			}
 
-			modifiers, err := SyncClusterAddress(context.Background(), kubermaticlog.Logger,
-				cluster, client, fakeExternalURL, seed)
+			modifiers, err := NewModifiersBuilder(kubermaticlog.Logger).
+				Client(client).
+				Cluster(cluster).
+				Seed(seed).
+				ExternalURL(fakeExternalURL).
+				lookupFunc(testLookupFunction).
+				Build(context.Background())
 			if err != nil {
 				if tc.errExpected {
 					return


### PR DESCRIPTION
**What this PR does / why we need it**:
Backport of #5919 to branch release/v2.14.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Documentation**:
<!-- Add links to the related documentation changes related to this pull request. E.g. the link to the kubermatic/docs pullrequest. -->

**Does this PR introduce a user-facing change?**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If  no release note is required, just write "NONE".
-->
```release-note
NONE
```
