### PR TITLE
Add  Kuberentes 1.16.15, 1.17.12, 1.19.2

### DIFF
--- a/.prow.yaml
+++ b/.prow.yaml
@@ -322,7 +322,7 @@ presubmits:
         - name: KUBERMATIC_EDITION
           value: ee
         - name: VERSIONS_TO_TEST
-          value: "v1.16.14"
+          value: "v1.16.15"
         - name: EXCLUDE_DISTRIBUTIONS
           value: "centos,ubuntu,coreos,rhel"
         - name: SERVICE_ACCOUNT_KEY
@@ -363,7 +363,7 @@ presubmits:
         - name: KUBERMATIC_EDITION
           value: ee
         - name: VERSIONS_TO_TEST
-          value: "v1.17.11"
+          value: "v1.17.12"
         - name: EXCLUDE_DISTRIBUTIONS
           value: "centos,ubuntu,coreos,rhel"
         - name: SERVICE_ACCOUNT_KEY
@@ -404,7 +404,7 @@ presubmits:
         - name: KUBERMATIC_EDITION
           value: ee
         - name: VERSIONS_TO_TEST
-          value: "v1.18.8"
+          value: "v1.18.9"
         - name: EXCLUDE_DISTRIBUTIONS
           value: "centos,ubuntu,coreos,rhel"
         - name: SERVICE_ACCOUNT_KEY
@@ -445,7 +445,7 @@ presubmits:
         - name: KUBERMATIC_EDITION
           value: ee
         - name: VERSIONS_TO_TEST
-          value: "v1.19.0"
+          value: "v1.19.2"
         - name: EXCLUDE_DISTRIBUTIONS
           value: "centos,flatcar,coreos,rhel"
         - name: SERVICE_ACCOUNT_KEY
@@ -488,7 +488,7 @@ presubmits:
         - name: ONLY_TEST_CREATION
           value: "true"
         - name: VERSIONS_TO_TEST
-          value: "v1.19.0"
+          value: "v1.19.2"
         - name: EXCLUDE_DISTRIBUTIONS
           value: "centos,flatcar,coreos,rhel"
         - name: SERVICE_ACCOUNT_KEY
@@ -534,7 +534,7 @@ presubmits:
         - name: USE_LEGACY_HELM_CHART
           value: "true"
         - name: VERSIONS_TO_TEST
-          value: "v1.19.0"
+          value: "v1.19.2"
         - name: EXCLUDE_DISTRIBUTIONS
           value: "centos,flatcar,coreos,rhel"
         - name: SERVICE_ACCOUNT_KEY
@@ -579,7 +579,7 @@ presubmits:
         - name: KUBERMATIC_EDITION
           value: ee
         - name: VERSIONS_TO_TEST
-          value: "v1.19.0"
+          value: "v1.19.2"
         - name: EXCLUDE_DISTRIBUTIONS
           value: "centos,coreos,flatcar,rhel"
         - name: PROVIDER
@@ -625,7 +625,7 @@ presubmits:
         - name: KUBERMATIC_EDITION
           value: ee
         - name: VERSIONS_TO_TEST
-          value: "v1.19.0"
+          value: "v1.19.2"
         - name: PROVIDER
           value: "gcp"
         - name: EXCLUDE_DISTRIBUTIONS
@@ -668,7 +668,7 @@ presubmits:
         - name: KUBERMATIC_EDITION
           value: ee
         - name: VERSIONS_TO_TEST
-          value: "v1.19.0"
+          value: "v1.19.2"
         - name: PROVIDER
           value: "gcp"
         - name: EXCLUDE_DISTRIBUTIONS
@@ -716,7 +716,7 @@ presubmits:
         - name: KUBERMATIC_EDITION
           value: ee
         - name: VERSIONS_TO_TEST
-          value: "v1.19.0"
+          value: "v1.19.2"
         - name: EXCLUDE_DISTRIBUTIONS
           value: "ubuntu,coreos,flatcar,rhel"
         - name: PROVIDER
@@ -759,7 +759,7 @@ presubmits:
         - name: KUBERMATIC_EDITION
           value: ee
         - name: VERSIONS_TO_TEST
-          value: "v1.19.0"
+          value: "v1.19.2"
         - name: PROVIDER
           value: "packet"
         - name: EXCLUDE_DISTRIBUTIONS
@@ -802,7 +802,7 @@ presubmits:
         - name: KUBERMATIC_EDITION
           value: ee
         - name: VERSIONS_TO_TEST
-          value: "v1.19.0"
+          value: "v1.19.2"
         - name: PROVIDER
           value: "kubevirt"
         - name: EXCLUDE_DISTRIBUTIONS
@@ -845,7 +845,7 @@ presubmits:
         - name: KUBERMATIC_EDITION
           value: ee
         - name: VERSIONS_TO_TEST
-          value: "v1.19.0"
+          value: "v1.19.2"
         - name: PROVIDER
           value: "hetzner"
         # Hetzner doesn't support coreos
@@ -891,7 +891,7 @@ presubmits:
         - name: KUBERMATIC_EDITION
           value: ee
         - name: VERSIONS_TO_TEST
-          value: "v1.19.0"
+          value: "v1.19.2"
         - name: PROVIDER
           value: "openstack"
         - name: EXCLUDE_DISTRIBUTIONS
@@ -936,7 +936,7 @@ presubmits:
         - name: KUBERMATIC_EDITION
           value: ee
         - name: VERSIONS_TO_TEST
-          value: "v1.19.0"
+          value: "v1.19.2"
         - name: PROVIDER
           value: "openstack"
         - name: DEFAULT_TIMEOUT_MINUTES
@@ -981,7 +981,7 @@ presubmits:
         - name: KUBERMATIC_EDITION
           value: ee
         - name: VERSIONS_TO_TEST
-          value: "v1.19.0"
+          value: "v1.19.2"
         - name: PROVIDER
           value: "vsphere"
         - name: EXCLUDE_DISTRIBUTIONS
@@ -1025,7 +1025,7 @@ presubmits:
         - name: KUBERMATIC_EDITION
           value: ee
         - name: VERSIONS_TO_TEST
-          value: "v1.19.0"
+          value: "v1.19.2"
         - name: PROVIDER
           value: "vsphere"
         - name: EXCLUDE_DISTRIBUTIONS
@@ -1066,32 +1066,32 @@ presubmits:
       preset-goproxy: "true"
     spec:
       containers:
-        - image: quay.io/kubermatic/e2e-kind:with-conformance-tests-v1.0.21
-          env:
-            - name: KUBERMATIC_EDITION
-              value: ee
-            - name: VERSIONS_TO_TEST
-              value: "v1.19.0"
-            - name: PROVIDER
-              value: "vsphere"
-            - name: SCENARIO_OPTIONS
-              value: "datastore-cluster"
-            - name: SERVICE_ACCOUNT_KEY
-              valueFrom:
-                secretKeyRef:
-                  name: e2e-ci
-                  key: serviceAccountSigningKey
-          command:
-            - "./hack/ci/ci-kind-e2e.sh"
-          # docker-in-docker needs privileged mode
-          securityContext:
-            privileged: true
-          resources:
-            requests:
-              memory: 4Gi
-              cpu: 3.5
-            limits:
-              memory: 4Gi
+      - image: quay.io/kubermatic/e2e-kind:with-conformance-tests-v1.0.21
+        env:
+        - name: KUBERMATIC_EDITION
+          value: ee
+        - name: VERSIONS_TO_TEST
+          value: "v1.19.2"
+        - name: PROVIDER
+          value: "vsphere"
+        - name: SCENARIO_OPTIONS
+          value: "datastore-cluster"
+        - name: SERVICE_ACCOUNT_KEY
+          valueFrom:
+            secretKeyRef:
+              name: e2e-ci
+              key: serviceAccountSigningKey
+        command:
+        - "./hack/ci/ci-kind-e2e.sh"
+        # docker-in-docker needs privileged mode
+        securityContext:
+          privileged: true
+        resources:
+          requests:
+            memory: 4Gi
+            cpu: 3.5
+          limits:
+            memory: 4Gi
 
   #########################################################
   # Base Openshift Tests
@@ -1168,7 +1168,7 @@ presubmits:
         - "./hack/ci/ci-run-api-e2e.sh"
         env:
         - name: VERSION_TO_TEST
-          value: v1.18.8
+          value: v1.18.9
         securityContext:
           privileged: true
         resources:

--- a/.prow.yaml
+++ b/.prow.yaml
@@ -404,7 +404,7 @@ presubmits:
         - name: KUBERMATIC_EDITION
           value: ee
         - name: VERSIONS_TO_TEST
-          value: "v1.18.9"
+          value: "v1.18.8"
         - name: EXCLUDE_DISTRIBUTIONS
           value: "centos,ubuntu,coreos,rhel"
         - name: SERVICE_ACCOUNT_KEY
@@ -1168,7 +1168,7 @@ presubmits:
         - "./hack/ci/ci-run-api-e2e.sh"
         env:
         - name: VERSION_TO_TEST
-          value: v1.18.9
+          value: v1.18.8
         securityContext:
           privileged: true
         resources:

--- a/charts/kubermatic/Chart.yaml
+++ b/charts/kubermatic/Chart.yaml
@@ -14,7 +14,7 @@
 
 apiVersion: v1
 name: kubermatic
-version: 1.1.14
+version: 1.1.15
 appVersion: '__KUBERMATIC_TAG__'
 description: Kubermatic chart for master and/or seed clusters.
 keywords:

--- a/charts/kubermatic/static/master/versions.yaml
+++ b/charts/kubermatic/static/master/versions.yaml
@@ -15,11 +15,9 @@ versions:
   version: 1.17.12
 - type: kubernetes
   version: 1.18.6
-- type: kubernetes
-  version: 1.18.8
 - default: true
   type: kubernetes
-  version: 1.18.9
+  version: 1.18.8
 - type: kubernetes
   version: 1.19.0
 - type: kubernetes

--- a/charts/kubermatic/static/master/versions.yaml
+++ b/charts/kubermatic/static/master/versions.yaml
@@ -6,16 +6,24 @@ versions:
 - type: kubernetes
   version: 1.16.14
 - type: kubernetes
+  version: 1.16.15
+- type: kubernetes
   version: 1.17.9
 - type: kubernetes
   version: 1.17.11
 - type: kubernetes
+  version: 1.17.12
+- type: kubernetes
   version: 1.18.6
+- type: kubernetes
+  version: 1.18.8
 - default: true
   type: kubernetes
-  version: 1.18.8
+  version: 1.18.9
 - type: kubernetes
   version: 1.19.0
+- type: kubernetes
+  version: 1.19.2
 - type: openshift
   version: 4.1.9
 - default: true

--- a/docs/zz_generated.kubermaticConfiguration.yaml
+++ b/docs/zz_generated.kubermaticConfiguration.yaml
@@ -395,7 +395,7 @@ spec:
     # Kubernetes configures the Kubernetes versions and updates.
     kubernetes:
       # Default is the default version to offer users.
-      default: 1.18.9
+      default: 1.18.8
       # Updates is a list of available and automatic upgrades.
       # All 'to' versions must be configured in the version list for this orchestrator.
       # Each update may optionally be configured to be 'automatic: true', in which case the
@@ -457,7 +457,6 @@ spec:
         - 1.17.12
         - 1.18.6
         - 1.18.8
-        - 1.18.9
         - 1.19.0
         - 1.19.2
     # Openshift configures the Openshift versions and updates.

--- a/docs/zz_generated.kubermaticConfiguration.yaml
+++ b/docs/zz_generated.kubermaticConfiguration.yaml
@@ -395,7 +395,7 @@ spec:
     # Kubernetes configures the Kubernetes versions and updates.
     kubernetes:
       # Default is the default version to offer users.
-      default: 1.18.8
+      default: 1.18.9
       # Updates is a list of available and automatic upgrades.
       # All 'to' versions must be configured in the version list for this orchestrator.
       # Each update may optionally be configured to be 'automatic: true', in which case the
@@ -451,11 +451,15 @@ spec:
       versions:
         - 1.16.13
         - 1.16.14
+        - 1.16.15
         - 1.17.9
         - 1.17.11
+        - 1.17.12
         - 1.18.6
         - 1.18.8
+        - 1.18.9
         - 1.19.0
+        - 1.19.2
     # Openshift configures the Openshift versions and updates.
     openshift:
       # Default is the default version to offer users.

--- a/pkg/controller/operator/common/defaults.go
+++ b/pkg/controller/operator/common/defaults.go
@@ -186,7 +186,7 @@ var (
 	}
 
 	DefaultKubernetesVersioning = operatorv1alpha1.KubermaticVersioningConfiguration{
-		Default: semver.MustParse("v1.18.9"),
+		Default: semver.MustParse("v1.18.8"),
 		Versions: []*semver.Version{
 			// Kubernetes 1.16
 			semver.MustParse("v1.16.13"),
@@ -199,7 +199,6 @@ var (
 			// Kubernetes 1.18
 			semver.MustParse("v1.18.6"),
 			semver.MustParse("v1.18.8"),
-			semver.MustParse("v1.18.9"),
 			// Kubernetes 1.19
 			semver.MustParse("v1.19.0"),
 			semver.MustParse("v1.19.2"),

--- a/pkg/controller/operator/common/defaults.go
+++ b/pkg/controller/operator/common/defaults.go
@@ -186,19 +186,23 @@ var (
 	}
 
 	DefaultKubernetesVersioning = operatorv1alpha1.KubermaticVersioningConfiguration{
-		Default: semver.MustParse("v1.18.8"),
+		Default: semver.MustParse("v1.18.9"),
 		Versions: []*semver.Version{
 			// Kubernetes 1.16
 			semver.MustParse("v1.16.13"),
 			semver.MustParse("v1.16.14"),
+			semver.MustParse("v1.16.15"),
 			// Kubernetes 1.17
 			semver.MustParse("v1.17.9"),
 			semver.MustParse("v1.17.11"),
+			semver.MustParse("v1.17.12"),
 			// Kubernetes 1.18
 			semver.MustParse("v1.18.6"),
 			semver.MustParse("v1.18.8"),
+			semver.MustParse("v1.18.9"),
 			// Kubernetes 1.19
 			semver.MustParse("v1.19.0"),
+			semver.MustParse("v1.19.2"),
 		},
 		Updates: []operatorv1alpha1.Update{
 			// ======= 1.15 =======


### PR DESCRIPTION
**What this PR does / why we need it**:
This just bumps the supported Kubernetes versions. 1.18.9 is left out because there is no image on quay.io for it [yet?].

**Does this PR introduce a user-facing change?**:
```release-note
Add Kuberentes 1.16.15, 1.17.12, 1.19.2
```
