### PR TITLE
Handle more flaky status codes in API e2e tests

### DIFF
--- a/pkg/test/e2e/api/runner.go
+++ b/pkg/test/e2e/api/runner.go
@@ -460,7 +460,7 @@ func (r *runner) DeleteCluster(projectID, dc, clusterID string) error {
 	r.test.Logf("Deleting cluster %s...", clusterID)
 
 	params := &project.DeleteClusterParams{ProjectID: projectID, DC: dc, ClusterID: clusterID}
-	setupParams(r.test, params, 1*time.Second, 3*time.Minute)
+	setupParams(r.test, params, 1*time.Second, 3*time.Minute, http.StatusConflict)
 
 	_, err := r.client.Project.DeleteCluster(params, r.bearerToken)
 	if err != nil {
@@ -1129,7 +1129,7 @@ func (r *runner) UpdateDC(seed, dcToUpdate string, dc *models.Datacenter) (*mode
 		DCToUpdate: dcToUpdate,
 		Seed:       seed,
 	}
-	setupParams(r.test, params, 1*time.Second, 3*time.Minute)
+	setupParams(r.test, params, 1*time.Second, 3*time.Minute, http.StatusBadRequest)
 
 	updatedDC, err := r.client.Datacenter.UpdateDC(params, r.bearerToken)
 	if err != nil {


### PR DESCRIPTION
**What this PR does / why we need it**:
The API can under load produce more temporary error codes than thought before.

**Which issue(s) this PR fixes**:
Fixes #5918, fixes #5928

**Does this PR introduce a user-facing change?**:
```release-note
NONE
```
