### PR TITLE
Makefile: better support for compiling with debug symbols

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -33,8 +33,9 @@ LDFLAGS += -extldflags '-static' \
   -X k8c.io/kubermatic/v2/pkg/resources.KUBERMATICGITTAG=$(GITTAG) \
   -X k8c.io/kubermatic/v2/pkg/controller/operator/common.KUBERMATICDOCKERTAG=$(KUBERMATICDOCKERTAG) \
   -X k8c.io/kubermatic/v2/pkg/controller/operator/common.UIDOCKERTAG=$(UIDOCKERTAG)
+LDFLAGS_EXTRA=-w
 BUILD_DEST ?= _build
-GOTOOLFLAGS ?= $(GOBUILDFLAGS) -ldflags '-w $(LDFLAGS)'
+GOTOOLFLAGS ?= $(GOBUILDFLAGS) -ldflags '$(LDFLAGS_EXTRA) $(LDFLAGS)' $(GOTOOLFLAGS_EXTRA)
 GOBUILDIMAGE ?= golang:1.15.1
 DOCKER_BIN := $(shell which docker)
 


### PR DESCRIPTION
Signed-off-by: Olaf Klischat <olaf.klischat@gmail.com>

**What this PR does / why we need it**:

This is a 2-line patch to the Makefile that splits the GOTOOLFLAGS and LDFLAGS variables up so that it becomes easier to change parts of them without having to redefine the whole GOTOOLFLAGS (which is all flags passed to the compiler, including linker arguments). Specifically, this makes it easier to compile all binaries with debugging symbols enabled. In the current master, the -w option (which removes debugging symbols) is hardcoded into GOTOOLFLAGS, so you'd have to redefine the whole variable, which would be very repetitive, just to remove that one flag. The PR moves the -w into a variable LDFLAGS_EXTRA that can be redefined separately. The PR also add a variable GOTOOLFLAGS_EXTRA (empty by default) which contains additional arguments to be added to GOTOOLFLAGS.

With this PR, compiling with debug symbols works like this:

`make GOTOOLFLAGS_EXTRA="-gcflags='all=-N -l'" LDFLAGS_EXTRA="" seed-controller-manager`

If you don't set these two variables, the resulting flags variables and thus the resulting compiler invocation will not be changed, i.e. will be identical to the upstream master. So the PR should retain full backwards compatibility with all CIs and other make-invoking scripts that may exist anywhere.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Documentation**:
<!-- Add links to the related documentation changes related to this pull request. E.g. the link to the kubermatic/docs pullrequest. -->

**Does this PR introduce a user-facing change?**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If  no release note is required, just write "NONE".
-->
```release-note
Makefile: better support for compiling with debug symbols
```
