### PR TITLE
Makefile improvements

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -143,6 +143,7 @@ verify:
 	./hack/verify-api-client.sh
 
 check-dependencies:
+	go mod tidy
 	go mod verify
 	git diff --exit-code
 

--- a/Makefile
+++ b/Makefile
@@ -40,7 +40,7 @@ DOCKER_BIN := $(shell which docker)
 
 default: all
 
-all: check build test
+all: build test
 
 .PHONY: $(CMD)
 build: $(CMD)

--- a/Makefile
+++ b/Makefile
@@ -54,8 +54,6 @@ install:
 showenv:
 	@go env
 
-check: lint
-
 download-gocache:
 	@./hack/ci/ci-download-gocache.sh
 	@# Prevent this from getting executed multiple times
@@ -156,4 +154,4 @@ ifndef DOCKER_BIN
 endif
 	$(DOCKER_BIN) run --rm -it -v ${PWD}:/go/src/k8c.io/kubermatic -w /go/src/k8c.io/kubermatic $(GOBUILDIMAGE) hack/update-codegen.sh
 
-.PHONY: build install test check cover docker-build docker-push run-controller-manager run-api-server run-rbac-generator test-update-fixture update-codegen-in-docker run-tests build-tests $(TARGET)
+.PHONY: build install test cover docker-build docker-push run-controller-manager run-api-server run-rbac-generator test-update-fixture update-codegen-in-docker run-tests build-tests $(TARGET)

--- a/go.mod
+++ b/go.mod
@@ -68,7 +68,6 @@ require (
 	go.etcd.io/etcd/v3 v3.3.0-rc.0.0.20200728214110-6c81b20ec8de
 	go.uber.org/zap v1.15.0
 	golang.org/x/crypto v0.0.0-20200728195943-123391ffb6de
-	golang.org/x/net v0.0.0-20200707034311-ab3426394381
 	golang.org/x/oauth2 v0.0.0-20200107190931-bf48bf16ab8d
 	golang.org/x/sys v0.0.0-20200819171115-d785dc25833f // indirect
 	golang.org/x/time v0.0.0-20200630173020-3af7569d3a1e // indirect


### PR DESCRIPTION
**What this PR does / why we need it**:

* Remove lint from make all/default target

Lint takes a lot of resources and time to finish, so we should not run
it by default. We have a dedicated lint target that can be used to
properly run it.

* Extend check-dependencies make target with go mod tidy

* Run go mod tidy

* Remove check make target

It appears that the check target is not used anywhere, so let's remove
it.

**Does this PR introduce a user-facing change?**:
```release-note
NONE
```

/assign @xrstf @kron4eg 