### PR TITLE
etcd-launcher image tag is customizable

### DIFF
--- a/cmd/seed-controller-manager/options.go
+++ b/cmd/seed-controller-manager/options.go
@@ -140,7 +140,7 @@ func newControllerRunOptions() (controllerRunOptions, error) {
 	flag.StringVar(&c.oidcIssuerClientID, "oidc-issuer-client-id", "", "Issuer client ID")
 	flag.StringVar(&c.oidcIssuerClientSecret, "oidc-issuer-client-secret", "", "OpenID client secret")
 	flag.StringVar(&c.kubermaticImage, "kubermatic-image", resources.DefaultKubermaticImage, "The location from which to pull the Kubermatic image")
-	flag.StringVar(&c.etcdLauncherImage, "etcd-launcher-image", resources.DefaultEtcdLauncherImage, "The location from which to pull the etcd launcher image")
+	flag.StringVar(&c.etcdLauncherImage, "etcd-launcher-image", resources.DefaultEtcdLauncherImage, fmt.Sprintf("The location from which to pull the etcd launcher image, if image tag is not specified tag %s is used", resources.KUBERMATICCOMMIT))
 	flag.StringVar(&c.dnatControllerImage, "dnatcontroller-image", resources.DefaultDNATControllerImage, "The location of the dnatcontroller-image")
 	flag.StringVar(&c.namespace, "namespace", "kubermatic", "The namespace kubermatic runs in, uses to determine where to look for datacenter custom resources")
 	flag.IntVar(&c.apiServerDefaultReplicas, "apiserver-default-replicas", 2, "The default number of replicas for usercluster api servers")

--- a/pkg/controller/seed-controller-manager/openshift/data.go
+++ b/pkg/controller/seed-controller-manager/openshift/data.go
@@ -238,7 +238,8 @@ func (od *openshiftData) EtcdDiskSize() resource.Quantity {
 	return od.etcdDiskSize
 }
 
-func (od *openshiftData) EtcdLauncherImage() string {
+// EtcdLauncherImage returns the etcd launcher image and tag.
+func (od *openshiftData) EtcdLauncherImage() (string, string) {
 	imageSplit := strings.Split(od.etcdLauncherImage, "/")
 	var registry, imageWithoutRegistry string
 	if len(imageSplit) != 3 {
@@ -248,7 +249,11 @@ func (od *openshiftData) EtcdLauncherImage() string {
 		registry = imageSplit[0]
 		imageWithoutRegistry = strings.Join(imageSplit[1:], "/")
 	}
-	return od.ImageRegistry(registry) + "/" + imageWithoutRegistry
+	s := strings.Split(imageWithoutRegistry, ":")
+	if len(s) == 2 {
+		return fmt.Sprint(od.ImageRegistry(registry), "/", s[0]), s[1]
+	}
+	return fmt.Sprint(od.ImageRegistry(registry), "/", imageWithoutRegistry), ""
 }
 
 // Openshift has its own DNS cache, so this is always false

--- a/pkg/resources/data.go
+++ b/pkg/resources/data.go
@@ -161,7 +161,8 @@ func (d *TemplateData) EtcdDiskSize() resource.Quantity {
 	return d.etcdDiskSize
 }
 
-func (d *TemplateData) EtcdLauncherImage() string {
+// EtcdLauncherImage returns the etcd launcher image and tag.
+func (d *TemplateData) EtcdLauncherImage() (string, string) {
 	imageSplit := strings.Split(d.etcdLauncherImage, "/")
 	var registry, imageWithoutRegistry string
 	if len(imageSplit) != 3 {
@@ -171,7 +172,11 @@ func (d *TemplateData) EtcdLauncherImage() string {
 		registry = imageSplit[0]
 		imageWithoutRegistry = strings.Join(imageSplit[1:], "/")
 	}
-	return d.ImageRegistry(registry) + "/" + imageWithoutRegistry
+	s := strings.Split(imageWithoutRegistry, ":")
+	if len(s) == 2 {
+		return fmt.Sprint(d.ImageRegistry(registry), "/", s[0]), s[1]
+	}
+	return fmt.Sprint(d.ImageRegistry(registry), "/", imageWithoutRegistry), ""
 }
 
 // MonitoringScrapeAnnotationPrefix returns the scrape annotation prefix
@@ -246,11 +251,11 @@ func (d *TemplateData) ProviderName() string {
 }
 
 // ImageRegistry returns the image registry to use or the passed in default if no override is specified
-func (d *TemplateData) ImageRegistry(defaultRegistry string) string {
+func (d *TemplateData) ImageRegistry(registry string) string {
 	if d.OverwriteRegistry != "" {
 		return d.OverwriteRegistry
 	}
-	return defaultRegistry
+	return registry
 }
 
 // GetRootCA returns the root CA of the cluster


### PR DESCRIPTION
**What this PR does / why we need it**:

Shipping new version of kubermatic will update etcd statefulsets etcd-launcher tag and they will be recreated even though new version doesn't have any updates related to etcd-launcher. For better service availability reasons we want to be able to set etcd-launcher image tag.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #5909

**Special notes for your reviewer**:

**Documentation**:
<!-- Add links to the related documentation changes related to this pull request. E.g. the link to the kubermatic/docs pullrequest. -->

**Does this PR introduce a user-facing change?**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If  no release note is required, just write "NONE".
-->
```release-note
seed-controller-manager option `etcd-launcher-image` receives tagged image
```
