### PR TITLE
Prepare 2.15.0-rc.2 changelog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,16 +1,32 @@
 # Kubermatic 2.15
 
+## [v2.15.0-rc.2](https://github.com/kubermatic/kubermatic/releases/tag/v2.15.0-rc.2)
+
+### Misc
+
+- Add Kubernetes 1.16.15, 1.17.12, 1.19.2 ([#5927](https://github.com/kubermatic/kubermatic/issues/5927))
+- Add `operator.kubermatic.io/skip-reconciling` annotation to Seeds to allow step-by-step seed cluster upgrades ([#5883](https://github.com/kubermatic/kubermatic/issues/5883))
+- Add option to enable/disable external cluster import feature from admin settings in KKP dashboard ([#2644](https://github.com/kubermatic/dashboard/issues/2644))
+- Allow controlling external cluster functionality with global settings ([#5912](https://github.com/kubermatic/kubermatic/issues/5912))
+- Fix KKP Operator getting stuck in Kubernetes 1.18 clusters when reconciling Ingresses ([#5915](https://github.com/kubermatic/kubermatic/issues/5915))
+- Fix creation of RHEL8 machines ([#5950](https://github.com/kubermatic/kubermatic/issues/5950))
+- Fix loading of the access rights in the SSH keys view ([#2645](https://github.com/kubermatic/dashboard/issues/2645))
+- Fix cluster wizard rendering in Safari ([#2661](https://github.com/kubermatic/dashboard/issues/2661))
+
 ## [v2.15.0-rc.1](https://github.com/kubermatic/kubermatic/releases/tag/v2.15.0-rc.1)
 
 ### Supported Kubernetes Versions
 
 * 1.16.13
 * 1.16.14
+* 1.16.15
 * 1.17.9
 * 1.17.11
+* 1.17.12
 * 1.18.6
 * 1.18.8
 * 1.19.0
+* 1.19.2
 
 ### Highlights
 


### PR DESCRIPTION
**What this PR does / why we need it**:
This prepares the changelog for RC2, based on

* https://github.com/kubermatic/kubermatic/commit/7963161a42932e7ff3da17fe5052f7c36a665eaa
* https://github.com/kubermatic/dashboard/commit/57246f4273be5d839b5c543f8a867384dd04b1a2

When 2.15 is final, the changelogs for all RCs will be combined into a single 2.15.0 entry. For now we list the changes in between releases individually.

**Does this PR introduce a user-facing change?**:
```release-note
NONE
```
