### PR TITLE
Provide way to skip certificate CR creation

### DIFF
--- a/charts/kubermatic/Chart.yaml
+++ b/charts/kubermatic/Chart.yaml
@@ -14,7 +14,7 @@
 
 apiVersion: v1
 name: kubermatic
-version: 1.1.15
+version: 1.1.16
 appVersion: '__KUBERMATIC_TAG__'
 description: Kubermatic chart for master and/or seed clusters.
 keywords:

--- a/charts/kubermatic/templates/certificate.yaml
+++ b/charts/kubermatic/templates/certificate.yaml
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-{{ if .Values.kubermatic.isMaster }}
+{{ if and .Values.kubermatic.isMaster .Values.kubermatic.certIssuer }}
 apiVersion: cert-manager.io/v1alpha2
 kind: Certificate
 metadata:

--- a/charts/kubermatic/values.yaml
+++ b/charts/kubermatic/values.yaml
@@ -80,6 +80,9 @@ kubermatic:
     diskSize: "5Gi"
 
   # the cert-manager Issuer (or ClusterIssuer) responsible for managing the certificate
+  # If you want to deploy your own certificate without relying on cert-manager
+  # uncomment the next line and remove subsequent certIssuer configuration.
+  # certIssuer: null
   certIssuer:
     name: letsencrypt-prod
     kind: ClusterIssuer

--- a/charts/oauth/Chart.yaml
+++ b/charts/oauth/Chart.yaml
@@ -14,7 +14,7 @@
 
 apiVersion: v1
 name: oauth
-version: 1.3.0
+version: 1.3.1
 appVersion: v2.24.0
 description: Dex
 keywords:

--- a/charts/oauth/templates/certificate.yaml
+++ b/charts/oauth/templates/certificate.yaml
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-{{ if ne .Values.dex.ingress.class "non-existent" }}
+{{ if and (ne .Values.dex.ingress.class "non-existent") .Values.dex.certIssuer }}
 apiVersion: cert-manager.io/v1alpha2
 kind: Certificate
 metadata:

--- a/charts/oauth/values.yaml
+++ b/charts/oauth/values.yaml
@@ -87,6 +87,9 @@ dex:
   tolerations: []
 
   # the cert-manager Issuer (or ClusterIssuer) responsible for managing the certificates
+  # If you want to deploy your own certificate without relying on cert-manager
+  # uncomment the next line and remove subsequent certIssuer configuration.
+  # certIssuer: null
   certIssuer:
     name: letsencrypt-prod
     kind: ClusterIssuer

--- a/charts/values.example.ce.yaml
+++ b/charts/values.example.ce.yaml
@@ -48,6 +48,9 @@ dex:
     userID: 08a8684b-db88-4b73-90a9-3cd1661f5466
 
   # the cert-manager Issuer (or ClusterIssuer) responsible for managing the certificates
+  # If you want to deploy your own certificate without relying on cert-manager
+  # uncomment the next line and remove subsequent certIssuer configuration.
+  # certIssuer: null
   certIssuer:
     # For generating a certificate signed by a trusted root authority replace
     # with "letsencrypt-prod".

--- a/charts/values.example.ee.yaml
+++ b/charts/values.example.ee.yaml
@@ -48,6 +48,9 @@ dex:
     userID: 08a8684b-db88-4b73-90a9-3cd1661f5466
 
   # the cert-manager Issuer (or ClusterIssuer) responsible for managing the certificates
+  # If you want to deploy your own certificate without relying on cert-manager
+  # uncomment the next line and remove subsequent certIssuer configuration.
+  # certIssuer: null
   certIssuer:
     # For generating a certificate signed by a trusted root authority replace
     # with "letsencrypt-prod".


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR provides a way of skipping certificate creation. This is useful for users that provide their own certificate, enabling them to skip cert-manager creation.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #5554 

**Special notes for your reviewer**:
This is especially useful for migration from v2.13 to v2.14 where the Certificate CR was moved to kubermatic chart.

**Documentation**:
<!-- Add links to the related documentation changes related to this pull request. E.g. the link to the kubermatic/docs pullrequest. -->

**Does this PR introduce a user-facing change?**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If  no release note is required, just write "NONE".
-->
```release-note
Provide a way of skipping Certificate cert-manager resources.
```
