### PR TITLE
Move to k8s.gcr.io Docker registry for CoreDNS, metrics-server, and NodeLocalDNSCache

### DIFF
--- a/addons/metrics-server/metrics-server-deployment.yaml
+++ b/addons/metrics-server/metrics-server-deployment.yaml
@@ -43,7 +43,7 @@ spec:
         emptyDir: {}
       containers:
       - name: metrics-server
-        image: '{{ Registry "gcr.io" }}/google_containers/metrics-server-amd64:v0.2.1'
+        image: '{{ Registry "k8s.gcr.io" }}/metrics-server-amd64:v0.2.1'
         command:
         - /metrics-server
         - '--source=kubernetes.summary_api:https://kubernetes.default.svc?kubeletHttps=true&kubeletPort=10250&insecure=true'

--- a/addons/nodelocal-dns-cache/dns.yaml
+++ b/addons/nodelocal-dns-cache/dns.yaml
@@ -109,7 +109,7 @@ spec:
         operator: "Exists"
       containers:
       - name: node-cache
-        image: {{ Registry "gcr.io" }}/google_containers/k8s-dns-node-cache:1.15.7
+        image: {{ Registry "k8s.gcr.io" }}/k8s-dns-node-cache:1.15.7
         resources:
           requests:
             cpu: 25m

--- a/pkg/controller/user-cluster-controller-manager/resources/resources/node-local-dns/deamonset.go
+++ b/pkg/controller/user-cluster-controller-manager/resources/resources/node-local-dns/deamonset.go
@@ -71,7 +71,7 @@ func DaemonSetCreator() reconciling.NamedDaemonSetCreatorGetter {
 				{
 					Name:            "node-cache",
 					ImagePullPolicy: corev1.PullAlways,
-					Image:           fmt.Sprintf("%s/google_containers/k8s-dns-node-cache:1.15.7", resources.RegistryGCR),
+					Image:           fmt.Sprintf("%s/k8s-dns-node-cache:1.15.7", resources.RegistryK8SGCR),
 					Args: []string{
 						"-localip",
 						"169.254.20.10",

--- a/pkg/resources/dns/dns.go
+++ b/pkg/resources/dns/dns.go
@@ -109,7 +109,7 @@ func DeploymentCreator(data deploymentCreatorData) reconciling.NamedDeploymentCr
 				*openvpnSidecar,
 				{
 					Name:  resources.DNSResolverDeploymentName,
-					Image: data.ImageRegistry(resources.RegistryGCR) + "/google_containers/coredns:1.3.1",
+					Image: data.ImageRegistry(resources.RegistryK8SGCR) + "/coredns:1.3.1",
 					Args:  []string{"-conf", "/etc/coredns/Corefile"},
 					VolumeMounts: []corev1.VolumeMount{
 						{

--- a/pkg/resources/metrics-server/deployment.go
+++ b/pkg/resources/metrics-server/deployment.go
@@ -118,7 +118,7 @@ func DeploymentCreator(data metricsServerData) reconciling.NamedDeploymentCreato
 			dep.Spec.Template.Spec.Containers = []corev1.Container{
 				{
 					Name:    name,
-					Image:   data.ImageRegistry(resources.RegistryGCR) + "/google_containers/metrics-server-amd64:" + tag,
+					Image:   data.ImageRegistry(resources.RegistryK8SGCR) + "/metrics-server-amd64:" + tag,
 					Command: []string{"/metrics-server"},
 					Args: []string{
 						"--kubeconfig", "/etc/kubernetes/kubeconfig/kubeconfig",

--- a/pkg/resources/test/fixtures/deployment-aws-1.16.0-dns-resolver.yaml
+++ b/pkg/resources/test/fixtures/deployment-aws-1.16.0-dns-resolver.yaml
@@ -99,7 +99,7 @@ spec:
       - args:
         - -conf
         - /etc/coredns/Corefile
-        image: gcr.io/google_containers/coredns:1.3.1
+        image: k8s.gcr.io/coredns:1.3.1
         name: dns-resolver
         readinessProbe:
           failureThreshold: 3

--- a/pkg/resources/test/fixtures/deployment-aws-1.16.0-metrics-server.yaml
+++ b/pkg/resources/test/fixtures/deployment-aws-1.16.0-metrics-server.yaml
@@ -53,7 +53,7 @@ spec:
         - '{"command":"/metrics-server","args":["--kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","--authentication-kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","--authorization-kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","--kubelet-port","10250","--kubelet-insecure-tls","--kubelet-preferred-address-types","ExternalIP,InternalIP","--v","1","--logtostderr","--tls-cert-file","/etc/serving-cert/serving.crt","--tls-private-key-file","/etc/serving-cert/serving.key"]}'
         command:
         - /http-prober-bin/http-prober
-        image: gcr.io/google_containers/metrics-server-amd64:v0.3.6
+        image: k8s.gcr.io/metrics-server-amd64:v0.3.6
         name: metrics-server
         resources:
           limits:

--- a/pkg/resources/test/fixtures/deployment-aws-1.17.0-dns-resolver.yaml
+++ b/pkg/resources/test/fixtures/deployment-aws-1.17.0-dns-resolver.yaml
@@ -99,7 +99,7 @@ spec:
       - args:
         - -conf
         - /etc/coredns/Corefile
-        image: gcr.io/google_containers/coredns:1.3.1
+        image: k8s.gcr.io/coredns:1.3.1
         name: dns-resolver
         readinessProbe:
           failureThreshold: 3

--- a/pkg/resources/test/fixtures/deployment-aws-1.17.0-metrics-server.yaml
+++ b/pkg/resources/test/fixtures/deployment-aws-1.17.0-metrics-server.yaml
@@ -53,7 +53,7 @@ spec:
         - '{"command":"/metrics-server","args":["--kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","--authentication-kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","--authorization-kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","--kubelet-port","10250","--kubelet-insecure-tls","--kubelet-preferred-address-types","ExternalIP,InternalIP","--v","1","--logtostderr","--tls-cert-file","/etc/serving-cert/serving.crt","--tls-private-key-file","/etc/serving-cert/serving.key"]}'
         command:
         - /http-prober-bin/http-prober
-        image: gcr.io/google_containers/metrics-server-amd64:v0.3.6
+        image: k8s.gcr.io/metrics-server-amd64:v0.3.6
         name: metrics-server
         resources:
           limits:

--- a/pkg/resources/test/fixtures/deployment-aws-1.18.0-dns-resolver.yaml
+++ b/pkg/resources/test/fixtures/deployment-aws-1.18.0-dns-resolver.yaml
@@ -99,7 +99,7 @@ spec:
       - args:
         - -conf
         - /etc/coredns/Corefile
-        image: gcr.io/google_containers/coredns:1.3.1
+        image: k8s.gcr.io/coredns:1.3.1
         name: dns-resolver
         readinessProbe:
           failureThreshold: 3

--- a/pkg/resources/test/fixtures/deployment-aws-1.18.0-metrics-server.yaml
+++ b/pkg/resources/test/fixtures/deployment-aws-1.18.0-metrics-server.yaml
@@ -53,7 +53,7 @@ spec:
         - '{"command":"/metrics-server","args":["--kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","--authentication-kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","--authorization-kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","--kubelet-port","10250","--kubelet-insecure-tls","--kubelet-preferred-address-types","ExternalIP,InternalIP","--v","1","--logtostderr","--tls-cert-file","/etc/serving-cert/serving.crt","--tls-private-key-file","/etc/serving-cert/serving.key"]}'
         command:
         - /http-prober-bin/http-prober
-        image: gcr.io/google_containers/metrics-server-amd64:v0.3.6
+        image: k8s.gcr.io/metrics-server-amd64:v0.3.6
         name: metrics-server
         resources:
           limits:

--- a/pkg/resources/test/fixtures/deployment-aws-1.19.0-dns-resolver.yaml
+++ b/pkg/resources/test/fixtures/deployment-aws-1.19.0-dns-resolver.yaml
@@ -99,7 +99,7 @@ spec:
       - args:
         - -conf
         - /etc/coredns/Corefile
-        image: gcr.io/google_containers/coredns:1.3.1
+        image: k8s.gcr.io/coredns:1.3.1
         name: dns-resolver
         readinessProbe:
           failureThreshold: 3

--- a/pkg/resources/test/fixtures/deployment-aws-1.19.0-metrics-server.yaml
+++ b/pkg/resources/test/fixtures/deployment-aws-1.19.0-metrics-server.yaml
@@ -53,7 +53,7 @@ spec:
         - '{"command":"/metrics-server","args":["--kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","--authentication-kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","--authorization-kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","--kubelet-port","10250","--kubelet-insecure-tls","--kubelet-preferred-address-types","ExternalIP,InternalIP","--v","1","--logtostderr","--tls-cert-file","/etc/serving-cert/serving.crt","--tls-private-key-file","/etc/serving-cert/serving.key"]}'
         command:
         - /http-prober-bin/http-prober
-        image: gcr.io/google_containers/metrics-server-amd64:v0.3.6
+        image: k8s.gcr.io/metrics-server-amd64:v0.3.6
         name: metrics-server
         resources:
           limits:

--- a/pkg/resources/test/fixtures/deployment-azure-1.16.0-dns-resolver.yaml
+++ b/pkg/resources/test/fixtures/deployment-azure-1.16.0-dns-resolver.yaml
@@ -99,7 +99,7 @@ spec:
       - args:
         - -conf
         - /etc/coredns/Corefile
-        image: gcr.io/google_containers/coredns:1.3.1
+        image: k8s.gcr.io/coredns:1.3.1
         name: dns-resolver
         readinessProbe:
           failureThreshold: 3

--- a/pkg/resources/test/fixtures/deployment-azure-1.16.0-metrics-server.yaml
+++ b/pkg/resources/test/fixtures/deployment-azure-1.16.0-metrics-server.yaml
@@ -53,7 +53,7 @@ spec:
         - '{"command":"/metrics-server","args":["--kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","--authentication-kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","--authorization-kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","--kubelet-port","10250","--kubelet-insecure-tls","--kubelet-preferred-address-types","ExternalIP,InternalIP","--v","1","--logtostderr","--tls-cert-file","/etc/serving-cert/serving.crt","--tls-private-key-file","/etc/serving-cert/serving.key"]}'
         command:
         - /http-prober-bin/http-prober
-        image: gcr.io/google_containers/metrics-server-amd64:v0.3.6
+        image: k8s.gcr.io/metrics-server-amd64:v0.3.6
         name: metrics-server
         resources:
           limits:

--- a/pkg/resources/test/fixtures/deployment-azure-1.17.0-dns-resolver.yaml
+++ b/pkg/resources/test/fixtures/deployment-azure-1.17.0-dns-resolver.yaml
@@ -99,7 +99,7 @@ spec:
       - args:
         - -conf
         - /etc/coredns/Corefile
-        image: gcr.io/google_containers/coredns:1.3.1
+        image: k8s.gcr.io/coredns:1.3.1
         name: dns-resolver
         readinessProbe:
           failureThreshold: 3

--- a/pkg/resources/test/fixtures/deployment-azure-1.17.0-metrics-server.yaml
+++ b/pkg/resources/test/fixtures/deployment-azure-1.17.0-metrics-server.yaml
@@ -53,7 +53,7 @@ spec:
         - '{"command":"/metrics-server","args":["--kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","--authentication-kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","--authorization-kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","--kubelet-port","10250","--kubelet-insecure-tls","--kubelet-preferred-address-types","ExternalIP,InternalIP","--v","1","--logtostderr","--tls-cert-file","/etc/serving-cert/serving.crt","--tls-private-key-file","/etc/serving-cert/serving.key"]}'
         command:
         - /http-prober-bin/http-prober
-        image: gcr.io/google_containers/metrics-server-amd64:v0.3.6
+        image: k8s.gcr.io/metrics-server-amd64:v0.3.6
         name: metrics-server
         resources:
           limits:

--- a/pkg/resources/test/fixtures/deployment-azure-1.18.0-dns-resolver.yaml
+++ b/pkg/resources/test/fixtures/deployment-azure-1.18.0-dns-resolver.yaml
@@ -99,7 +99,7 @@ spec:
       - args:
         - -conf
         - /etc/coredns/Corefile
-        image: gcr.io/google_containers/coredns:1.3.1
+        image: k8s.gcr.io/coredns:1.3.1
         name: dns-resolver
         readinessProbe:
           failureThreshold: 3

--- a/pkg/resources/test/fixtures/deployment-azure-1.18.0-metrics-server.yaml
+++ b/pkg/resources/test/fixtures/deployment-azure-1.18.0-metrics-server.yaml
@@ -53,7 +53,7 @@ spec:
         - '{"command":"/metrics-server","args":["--kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","--authentication-kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","--authorization-kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","--kubelet-port","10250","--kubelet-insecure-tls","--kubelet-preferred-address-types","ExternalIP,InternalIP","--v","1","--logtostderr","--tls-cert-file","/etc/serving-cert/serving.crt","--tls-private-key-file","/etc/serving-cert/serving.key"]}'
         command:
         - /http-prober-bin/http-prober
-        image: gcr.io/google_containers/metrics-server-amd64:v0.3.6
+        image: k8s.gcr.io/metrics-server-amd64:v0.3.6
         name: metrics-server
         resources:
           limits:

--- a/pkg/resources/test/fixtures/deployment-azure-1.19.0-dns-resolver.yaml
+++ b/pkg/resources/test/fixtures/deployment-azure-1.19.0-dns-resolver.yaml
@@ -99,7 +99,7 @@ spec:
       - args:
         - -conf
         - /etc/coredns/Corefile
-        image: gcr.io/google_containers/coredns:1.3.1
+        image: k8s.gcr.io/coredns:1.3.1
         name: dns-resolver
         readinessProbe:
           failureThreshold: 3

--- a/pkg/resources/test/fixtures/deployment-azure-1.19.0-metrics-server.yaml
+++ b/pkg/resources/test/fixtures/deployment-azure-1.19.0-metrics-server.yaml
@@ -53,7 +53,7 @@ spec:
         - '{"command":"/metrics-server","args":["--kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","--authentication-kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","--authorization-kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","--kubelet-port","10250","--kubelet-insecure-tls","--kubelet-preferred-address-types","ExternalIP,InternalIP","--v","1","--logtostderr","--tls-cert-file","/etc/serving-cert/serving.crt","--tls-private-key-file","/etc/serving-cert/serving.key"]}'
         command:
         - /http-prober-bin/http-prober
-        image: gcr.io/google_containers/metrics-server-amd64:v0.3.6
+        image: k8s.gcr.io/metrics-server-amd64:v0.3.6
         name: metrics-server
         resources:
           limits:

--- a/pkg/resources/test/fixtures/deployment-bringyourown-1.16.0-dns-resolver.yaml
+++ b/pkg/resources/test/fixtures/deployment-bringyourown-1.16.0-dns-resolver.yaml
@@ -99,7 +99,7 @@ spec:
       - args:
         - -conf
         - /etc/coredns/Corefile
-        image: gcr.io/google_containers/coredns:1.3.1
+        image: k8s.gcr.io/coredns:1.3.1
         name: dns-resolver
         readinessProbe:
           failureThreshold: 3

--- a/pkg/resources/test/fixtures/deployment-bringyourown-1.16.0-metrics-server.yaml
+++ b/pkg/resources/test/fixtures/deployment-bringyourown-1.16.0-metrics-server.yaml
@@ -53,7 +53,7 @@ spec:
         - '{"command":"/metrics-server","args":["--kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","--authentication-kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","--authorization-kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","--kubelet-port","10250","--kubelet-insecure-tls","--kubelet-preferred-address-types","ExternalIP,InternalIP","--v","1","--logtostderr","--tls-cert-file","/etc/serving-cert/serving.crt","--tls-private-key-file","/etc/serving-cert/serving.key"]}'
         command:
         - /http-prober-bin/http-prober
-        image: gcr.io/google_containers/metrics-server-amd64:v0.3.6
+        image: k8s.gcr.io/metrics-server-amd64:v0.3.6
         name: metrics-server
         resources:
           limits:

--- a/pkg/resources/test/fixtures/deployment-bringyourown-1.17.0-dns-resolver.yaml
+++ b/pkg/resources/test/fixtures/deployment-bringyourown-1.17.0-dns-resolver.yaml
@@ -99,7 +99,7 @@ spec:
       - args:
         - -conf
         - /etc/coredns/Corefile
-        image: gcr.io/google_containers/coredns:1.3.1
+        image: k8s.gcr.io/coredns:1.3.1
         name: dns-resolver
         readinessProbe:
           failureThreshold: 3

--- a/pkg/resources/test/fixtures/deployment-bringyourown-1.17.0-metrics-server.yaml
+++ b/pkg/resources/test/fixtures/deployment-bringyourown-1.17.0-metrics-server.yaml
@@ -53,7 +53,7 @@ spec:
         - '{"command":"/metrics-server","args":["--kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","--authentication-kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","--authorization-kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","--kubelet-port","10250","--kubelet-insecure-tls","--kubelet-preferred-address-types","ExternalIP,InternalIP","--v","1","--logtostderr","--tls-cert-file","/etc/serving-cert/serving.crt","--tls-private-key-file","/etc/serving-cert/serving.key"]}'
         command:
         - /http-prober-bin/http-prober
-        image: gcr.io/google_containers/metrics-server-amd64:v0.3.6
+        image: k8s.gcr.io/metrics-server-amd64:v0.3.6
         name: metrics-server
         resources:
           limits:

--- a/pkg/resources/test/fixtures/deployment-bringyourown-1.18.0-dns-resolver.yaml
+++ b/pkg/resources/test/fixtures/deployment-bringyourown-1.18.0-dns-resolver.yaml
@@ -99,7 +99,7 @@ spec:
       - args:
         - -conf
         - /etc/coredns/Corefile
-        image: gcr.io/google_containers/coredns:1.3.1
+        image: k8s.gcr.io/coredns:1.3.1
         name: dns-resolver
         readinessProbe:
           failureThreshold: 3

--- a/pkg/resources/test/fixtures/deployment-bringyourown-1.18.0-metrics-server.yaml
+++ b/pkg/resources/test/fixtures/deployment-bringyourown-1.18.0-metrics-server.yaml
@@ -53,7 +53,7 @@ spec:
         - '{"command":"/metrics-server","args":["--kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","--authentication-kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","--authorization-kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","--kubelet-port","10250","--kubelet-insecure-tls","--kubelet-preferred-address-types","ExternalIP,InternalIP","--v","1","--logtostderr","--tls-cert-file","/etc/serving-cert/serving.crt","--tls-private-key-file","/etc/serving-cert/serving.key"]}'
         command:
         - /http-prober-bin/http-prober
-        image: gcr.io/google_containers/metrics-server-amd64:v0.3.6
+        image: k8s.gcr.io/metrics-server-amd64:v0.3.6
         name: metrics-server
         resources:
           limits:

--- a/pkg/resources/test/fixtures/deployment-bringyourown-1.19.0-dns-resolver.yaml
+++ b/pkg/resources/test/fixtures/deployment-bringyourown-1.19.0-dns-resolver.yaml
@@ -99,7 +99,7 @@ spec:
       - args:
         - -conf
         - /etc/coredns/Corefile
-        image: gcr.io/google_containers/coredns:1.3.1
+        image: k8s.gcr.io/coredns:1.3.1
         name: dns-resolver
         readinessProbe:
           failureThreshold: 3

--- a/pkg/resources/test/fixtures/deployment-bringyourown-1.19.0-metrics-server.yaml
+++ b/pkg/resources/test/fixtures/deployment-bringyourown-1.19.0-metrics-server.yaml
@@ -53,7 +53,7 @@ spec:
         - '{"command":"/metrics-server","args":["--kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","--authentication-kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","--authorization-kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","--kubelet-port","10250","--kubelet-insecure-tls","--kubelet-preferred-address-types","ExternalIP,InternalIP","--v","1","--logtostderr","--tls-cert-file","/etc/serving-cert/serving.crt","--tls-private-key-file","/etc/serving-cert/serving.key"]}'
         command:
         - /http-prober-bin/http-prober
-        image: gcr.io/google_containers/metrics-server-amd64:v0.3.6
+        image: k8s.gcr.io/metrics-server-amd64:v0.3.6
         name: metrics-server
         resources:
           limits:

--- a/pkg/resources/test/fixtures/deployment-digitalocean-1.16.0-dns-resolver.yaml
+++ b/pkg/resources/test/fixtures/deployment-digitalocean-1.16.0-dns-resolver.yaml
@@ -99,7 +99,7 @@ spec:
       - args:
         - -conf
         - /etc/coredns/Corefile
-        image: gcr.io/google_containers/coredns:1.3.1
+        image: k8s.gcr.io/coredns:1.3.1
         name: dns-resolver
         readinessProbe:
           failureThreshold: 3

--- a/pkg/resources/test/fixtures/deployment-digitalocean-1.16.0-metrics-server.yaml
+++ b/pkg/resources/test/fixtures/deployment-digitalocean-1.16.0-metrics-server.yaml
@@ -53,7 +53,7 @@ spec:
         - '{"command":"/metrics-server","args":["--kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","--authentication-kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","--authorization-kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","--kubelet-port","10250","--kubelet-insecure-tls","--kubelet-preferred-address-types","ExternalIP,InternalIP","--v","1","--logtostderr","--tls-cert-file","/etc/serving-cert/serving.crt","--tls-private-key-file","/etc/serving-cert/serving.key"]}'
         command:
         - /http-prober-bin/http-prober
-        image: gcr.io/google_containers/metrics-server-amd64:v0.3.6
+        image: k8s.gcr.io/metrics-server-amd64:v0.3.6
         name: metrics-server
         resources:
           limits:

--- a/pkg/resources/test/fixtures/deployment-digitalocean-1.17.0-dns-resolver.yaml
+++ b/pkg/resources/test/fixtures/deployment-digitalocean-1.17.0-dns-resolver.yaml
@@ -99,7 +99,7 @@ spec:
       - args:
         - -conf
         - /etc/coredns/Corefile
-        image: gcr.io/google_containers/coredns:1.3.1
+        image: k8s.gcr.io/coredns:1.3.1
         name: dns-resolver
         readinessProbe:
           failureThreshold: 3

--- a/pkg/resources/test/fixtures/deployment-digitalocean-1.17.0-metrics-server.yaml
+++ b/pkg/resources/test/fixtures/deployment-digitalocean-1.17.0-metrics-server.yaml
@@ -53,7 +53,7 @@ spec:
         - '{"command":"/metrics-server","args":["--kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","--authentication-kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","--authorization-kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","--kubelet-port","10250","--kubelet-insecure-tls","--kubelet-preferred-address-types","ExternalIP,InternalIP","--v","1","--logtostderr","--tls-cert-file","/etc/serving-cert/serving.crt","--tls-private-key-file","/etc/serving-cert/serving.key"]}'
         command:
         - /http-prober-bin/http-prober
-        image: gcr.io/google_containers/metrics-server-amd64:v0.3.6
+        image: k8s.gcr.io/metrics-server-amd64:v0.3.6
         name: metrics-server
         resources:
           limits:

--- a/pkg/resources/test/fixtures/deployment-digitalocean-1.18.0-dns-resolver.yaml
+++ b/pkg/resources/test/fixtures/deployment-digitalocean-1.18.0-dns-resolver.yaml
@@ -99,7 +99,7 @@ spec:
       - args:
         - -conf
         - /etc/coredns/Corefile
-        image: gcr.io/google_containers/coredns:1.3.1
+        image: k8s.gcr.io/coredns:1.3.1
         name: dns-resolver
         readinessProbe:
           failureThreshold: 3

--- a/pkg/resources/test/fixtures/deployment-digitalocean-1.18.0-metrics-server.yaml
+++ b/pkg/resources/test/fixtures/deployment-digitalocean-1.18.0-metrics-server.yaml
@@ -53,7 +53,7 @@ spec:
         - '{"command":"/metrics-server","args":["--kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","--authentication-kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","--authorization-kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","--kubelet-port","10250","--kubelet-insecure-tls","--kubelet-preferred-address-types","ExternalIP,InternalIP","--v","1","--logtostderr","--tls-cert-file","/etc/serving-cert/serving.crt","--tls-private-key-file","/etc/serving-cert/serving.key"]}'
         command:
         - /http-prober-bin/http-prober
-        image: gcr.io/google_containers/metrics-server-amd64:v0.3.6
+        image: k8s.gcr.io/metrics-server-amd64:v0.3.6
         name: metrics-server
         resources:
           limits:

--- a/pkg/resources/test/fixtures/deployment-digitalocean-1.19.0-dns-resolver.yaml
+++ b/pkg/resources/test/fixtures/deployment-digitalocean-1.19.0-dns-resolver.yaml
@@ -99,7 +99,7 @@ spec:
       - args:
         - -conf
         - /etc/coredns/Corefile
-        image: gcr.io/google_containers/coredns:1.3.1
+        image: k8s.gcr.io/coredns:1.3.1
         name: dns-resolver
         readinessProbe:
           failureThreshold: 3

--- a/pkg/resources/test/fixtures/deployment-digitalocean-1.19.0-metrics-server.yaml
+++ b/pkg/resources/test/fixtures/deployment-digitalocean-1.19.0-metrics-server.yaml
@@ -53,7 +53,7 @@ spec:
         - '{"command":"/metrics-server","args":["--kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","--authentication-kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","--authorization-kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","--kubelet-port","10250","--kubelet-insecure-tls","--kubelet-preferred-address-types","ExternalIP,InternalIP","--v","1","--logtostderr","--tls-cert-file","/etc/serving-cert/serving.crt","--tls-private-key-file","/etc/serving-cert/serving.key"]}'
         command:
         - /http-prober-bin/http-prober
-        image: gcr.io/google_containers/metrics-server-amd64:v0.3.6
+        image: k8s.gcr.io/metrics-server-amd64:v0.3.6
         name: metrics-server
         resources:
           limits:

--- a/pkg/resources/test/fixtures/deployment-openstack-1.16.0-dns-resolver.yaml
+++ b/pkg/resources/test/fixtures/deployment-openstack-1.16.0-dns-resolver.yaml
@@ -99,7 +99,7 @@ spec:
       - args:
         - -conf
         - /etc/coredns/Corefile
-        image: gcr.io/google_containers/coredns:1.3.1
+        image: k8s.gcr.io/coredns:1.3.1
         name: dns-resolver
         readinessProbe:
           failureThreshold: 3

--- a/pkg/resources/test/fixtures/deployment-openstack-1.16.0-metrics-server.yaml
+++ b/pkg/resources/test/fixtures/deployment-openstack-1.16.0-metrics-server.yaml
@@ -53,7 +53,7 @@ spec:
         - '{"command":"/metrics-server","args":["--kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","--authentication-kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","--authorization-kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","--kubelet-port","10250","--kubelet-insecure-tls","--kubelet-preferred-address-types","ExternalIP,InternalIP","--v","1","--logtostderr","--tls-cert-file","/etc/serving-cert/serving.crt","--tls-private-key-file","/etc/serving-cert/serving.key"]}'
         command:
         - /http-prober-bin/http-prober
-        image: gcr.io/google_containers/metrics-server-amd64:v0.3.6
+        image: k8s.gcr.io/metrics-server-amd64:v0.3.6
         name: metrics-server
         resources:
           limits:

--- a/pkg/resources/test/fixtures/deployment-openstack-1.17.0-dns-resolver.yaml
+++ b/pkg/resources/test/fixtures/deployment-openstack-1.17.0-dns-resolver.yaml
@@ -99,7 +99,7 @@ spec:
       - args:
         - -conf
         - /etc/coredns/Corefile
-        image: gcr.io/google_containers/coredns:1.3.1
+        image: k8s.gcr.io/coredns:1.3.1
         name: dns-resolver
         readinessProbe:
           failureThreshold: 3

--- a/pkg/resources/test/fixtures/deployment-openstack-1.17.0-metrics-server.yaml
+++ b/pkg/resources/test/fixtures/deployment-openstack-1.17.0-metrics-server.yaml
@@ -53,7 +53,7 @@ spec:
         - '{"command":"/metrics-server","args":["--kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","--authentication-kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","--authorization-kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","--kubelet-port","10250","--kubelet-insecure-tls","--kubelet-preferred-address-types","ExternalIP,InternalIP","--v","1","--logtostderr","--tls-cert-file","/etc/serving-cert/serving.crt","--tls-private-key-file","/etc/serving-cert/serving.key"]}'
         command:
         - /http-prober-bin/http-prober
-        image: gcr.io/google_containers/metrics-server-amd64:v0.3.6
+        image: k8s.gcr.io/metrics-server-amd64:v0.3.6
         name: metrics-server
         resources:
           limits:

--- a/pkg/resources/test/fixtures/deployment-openstack-1.18.0-dns-resolver.yaml
+++ b/pkg/resources/test/fixtures/deployment-openstack-1.18.0-dns-resolver.yaml
@@ -99,7 +99,7 @@ spec:
       - args:
         - -conf
         - /etc/coredns/Corefile
-        image: gcr.io/google_containers/coredns:1.3.1
+        image: k8s.gcr.io/coredns:1.3.1
         name: dns-resolver
         readinessProbe:
           failureThreshold: 3

--- a/pkg/resources/test/fixtures/deployment-openstack-1.18.0-metrics-server.yaml
+++ b/pkg/resources/test/fixtures/deployment-openstack-1.18.0-metrics-server.yaml
@@ -53,7 +53,7 @@ spec:
         - '{"command":"/metrics-server","args":["--kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","--authentication-kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","--authorization-kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","--kubelet-port","10250","--kubelet-insecure-tls","--kubelet-preferred-address-types","ExternalIP,InternalIP","--v","1","--logtostderr","--tls-cert-file","/etc/serving-cert/serving.crt","--tls-private-key-file","/etc/serving-cert/serving.key"]}'
         command:
         - /http-prober-bin/http-prober
-        image: gcr.io/google_containers/metrics-server-amd64:v0.3.6
+        image: k8s.gcr.io/metrics-server-amd64:v0.3.6
         name: metrics-server
         resources:
           limits:

--- a/pkg/resources/test/fixtures/deployment-openstack-1.19.0-dns-resolver.yaml
+++ b/pkg/resources/test/fixtures/deployment-openstack-1.19.0-dns-resolver.yaml
@@ -99,7 +99,7 @@ spec:
       - args:
         - -conf
         - /etc/coredns/Corefile
-        image: gcr.io/google_containers/coredns:1.3.1
+        image: k8s.gcr.io/coredns:1.3.1
         name: dns-resolver
         readinessProbe:
           failureThreshold: 3

--- a/pkg/resources/test/fixtures/deployment-openstack-1.19.0-metrics-server.yaml
+++ b/pkg/resources/test/fixtures/deployment-openstack-1.19.0-metrics-server.yaml
@@ -53,7 +53,7 @@ spec:
         - '{"command":"/metrics-server","args":["--kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","--authentication-kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","--authorization-kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","--kubelet-port","10250","--kubelet-insecure-tls","--kubelet-preferred-address-types","ExternalIP,InternalIP","--v","1","--logtostderr","--tls-cert-file","/etc/serving-cert/serving.crt","--tls-private-key-file","/etc/serving-cert/serving.key"]}'
         command:
         - /http-prober-bin/http-prober
-        image: gcr.io/google_containers/metrics-server-amd64:v0.3.6
+        image: k8s.gcr.io/metrics-server-amd64:v0.3.6
         name: metrics-server
         resources:
           limits:

--- a/pkg/resources/test/fixtures/deployment-vsphere-1.16.0-dns-resolver.yaml
+++ b/pkg/resources/test/fixtures/deployment-vsphere-1.16.0-dns-resolver.yaml
@@ -99,7 +99,7 @@ spec:
       - args:
         - -conf
         - /etc/coredns/Corefile
-        image: gcr.io/google_containers/coredns:1.3.1
+        image: k8s.gcr.io/coredns:1.3.1
         name: dns-resolver
         readinessProbe:
           failureThreshold: 3

--- a/pkg/resources/test/fixtures/deployment-vsphere-1.16.0-metrics-server.yaml
+++ b/pkg/resources/test/fixtures/deployment-vsphere-1.16.0-metrics-server.yaml
@@ -53,7 +53,7 @@ spec:
         - '{"command":"/metrics-server","args":["--kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","--authentication-kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","--authorization-kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","--kubelet-port","10250","--kubelet-insecure-tls","--kubelet-preferred-address-types","ExternalIP,InternalIP","--v","1","--logtostderr","--tls-cert-file","/etc/serving-cert/serving.crt","--tls-private-key-file","/etc/serving-cert/serving.key"]}'
         command:
         - /http-prober-bin/http-prober
-        image: gcr.io/google_containers/metrics-server-amd64:v0.3.6
+        image: k8s.gcr.io/metrics-server-amd64:v0.3.6
         name: metrics-server
         resources:
           limits:

--- a/pkg/resources/test/fixtures/deployment-vsphere-1.17.0-dns-resolver.yaml
+++ b/pkg/resources/test/fixtures/deployment-vsphere-1.17.0-dns-resolver.yaml
@@ -99,7 +99,7 @@ spec:
       - args:
         - -conf
         - /etc/coredns/Corefile
-        image: gcr.io/google_containers/coredns:1.3.1
+        image: k8s.gcr.io/coredns:1.3.1
         name: dns-resolver
         readinessProbe:
           failureThreshold: 3

--- a/pkg/resources/test/fixtures/deployment-vsphere-1.17.0-metrics-server.yaml
+++ b/pkg/resources/test/fixtures/deployment-vsphere-1.17.0-metrics-server.yaml
@@ -53,7 +53,7 @@ spec:
         - '{"command":"/metrics-server","args":["--kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","--authentication-kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","--authorization-kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","--kubelet-port","10250","--kubelet-insecure-tls","--kubelet-preferred-address-types","ExternalIP,InternalIP","--v","1","--logtostderr","--tls-cert-file","/etc/serving-cert/serving.crt","--tls-private-key-file","/etc/serving-cert/serving.key"]}'
         command:
         - /http-prober-bin/http-prober
-        image: gcr.io/google_containers/metrics-server-amd64:v0.3.6
+        image: k8s.gcr.io/metrics-server-amd64:v0.3.6
         name: metrics-server
         resources:
           limits:

--- a/pkg/resources/test/fixtures/deployment-vsphere-1.18.0-dns-resolver.yaml
+++ b/pkg/resources/test/fixtures/deployment-vsphere-1.18.0-dns-resolver.yaml
@@ -99,7 +99,7 @@ spec:
       - args:
         - -conf
         - /etc/coredns/Corefile
-        image: gcr.io/google_containers/coredns:1.3.1
+        image: k8s.gcr.io/coredns:1.3.1
         name: dns-resolver
         readinessProbe:
           failureThreshold: 3

--- a/pkg/resources/test/fixtures/deployment-vsphere-1.18.0-metrics-server.yaml
+++ b/pkg/resources/test/fixtures/deployment-vsphere-1.18.0-metrics-server.yaml
@@ -53,7 +53,7 @@ spec:
         - '{"command":"/metrics-server","args":["--kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","--authentication-kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","--authorization-kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","--kubelet-port","10250","--kubelet-insecure-tls","--kubelet-preferred-address-types","ExternalIP,InternalIP","--v","1","--logtostderr","--tls-cert-file","/etc/serving-cert/serving.crt","--tls-private-key-file","/etc/serving-cert/serving.key"]}'
         command:
         - /http-prober-bin/http-prober
-        image: gcr.io/google_containers/metrics-server-amd64:v0.3.6
+        image: k8s.gcr.io/metrics-server-amd64:v0.3.6
         name: metrics-server
         resources:
           limits:

--- a/pkg/resources/test/fixtures/deployment-vsphere-1.19.0-dns-resolver.yaml
+++ b/pkg/resources/test/fixtures/deployment-vsphere-1.19.0-dns-resolver.yaml
@@ -99,7 +99,7 @@ spec:
       - args:
         - -conf
         - /etc/coredns/Corefile
-        image: gcr.io/google_containers/coredns:1.3.1
+        image: k8s.gcr.io/coredns:1.3.1
         name: dns-resolver
         readinessProbe:
           failureThreshold: 3

--- a/pkg/resources/test/fixtures/deployment-vsphere-1.19.0-metrics-server.yaml
+++ b/pkg/resources/test/fixtures/deployment-vsphere-1.19.0-metrics-server.yaml
@@ -53,7 +53,7 @@ spec:
         - '{"command":"/metrics-server","args":["--kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","--authentication-kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","--authorization-kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","--kubelet-port","10250","--kubelet-insecure-tls","--kubelet-preferred-address-types","ExternalIP,InternalIP","--v","1","--logtostderr","--tls-cert-file","/etc/serving-cert/serving.crt","--tls-private-key-file","/etc/serving-cert/serving.key"]}'
         command:
         - /http-prober-bin/http-prober
-        image: gcr.io/google_containers/metrics-server-amd64:v0.3.6
+        image: k8s.gcr.io/metrics-server-amd64:v0.3.6
         name: metrics-server
         resources:
           limits:


### PR DESCRIPTION
**What this PR does / why we need it**:

Use the `k8s.gcr.io` image registry whenever it's possible. This PR changes the registry for CoreDNS, metrics-server, and NodeLocalDNS.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
xref #5773

**Special notes for your reviewer**:

The following components are still using the `google_containers` registry:

* VPA (`vpa-updater`, `vpa-recommender`, `vpa-admission-controller`)
  * We're currently using VPA v0.5.0, while the `k8s.gcr.io` has images only for VPA v0.8.0 and newer
* addon-resizer (`gcr.io/google_containers/addon-resizer`)
  * I couldn't find where is this addon defined
* Heapster
  * Heapster is retired, so Heapster images will not be added to the `k8s.gcr.io` registry

**Does this PR introduce a user-facing change?**:
```release-note
Move to k8s.gcr.io Docker registry for CoreDNS, metrics-server, and NodeLocalDNSCache
```

/assign @xrstf 