### PR TITLE
Make caBundle available to kubermatic-api when it is configured but n…

### DIFF
--- a/charts/kubermatic/Chart.yaml
+++ b/charts/kubermatic/Chart.yaml
@@ -14,7 +14,7 @@
 
 apiVersion: v1
 name: kubermatic
-version: 1.1.16
+version: 1.1.17
 appVersion: '__KUBERMATIC_TAG__'
 description: Kubermatic chart for master and/or seed clusters.
 keywords:

--- a/charts/kubermatic/templates/kubermatic-api-dep.yaml
+++ b/charts/kubermatic/templates/kubermatic-api-dep.yaml
@@ -71,11 +71,11 @@ spec:
         - -accessible-addons={{- (.Files.Get "static/master/accessible-addons.yaml" | fromYaml).addons | join "," }}
         {{- end }}
         - -feature-gates={{ .Values.kubermatic.api.featureGates }}
-        # the following flags enable oidc kubeconfig feature/endpoint
-        {{- if regexMatch ".*OIDCKubeCfgEndpoint=true.*" (default "" .Values.kubermatic.api.featureGates) }}
         {{- if .Values.kubermatic.auth.caBundle }}
         - -oidc-ca-file=/opt/dex-ca/caBundle.pem
         {{- end }}
+        # the following flags enable oidc kubeconfig feature/endpoint
+        {{- if regexMatch ".*OIDCKubeCfgEndpoint=true.*" (default "" .Values.kubermatic.api.featureGates) }}
         - -oidc-issuer-redirect-uri={{ .Values.kubermatic.auth.issuerRedirectURL }}
         - -oidc-issuer-client-id={{ .Values.kubermatic.auth.issuerClientID }}
         - -oidc-issuer-client-secret={{ .Values.kubermatic.auth.issuerClientSecret }}

--- a/pkg/controller/operator/master/resources/kubermatic/api.go
+++ b/pkg/controller/operator/master/resources/kubermatic/api.go
@@ -121,6 +121,25 @@ func APIDeploymentCreator(cfg *operatorv1alpha1.KubermaticConfiguration, workerN
 				args = append(args, "-v=2")
 			}
 
+			if cfg.Spec.Auth.CABundle != "" {
+				args = append(args, "-oidc-ca-file=/opt/dex-ca/caBundle.pem")
+
+				volumes = append(volumes, corev1.Volume{
+					Name: "dex-ca",
+					VolumeSource: corev1.VolumeSource{
+						Secret: &corev1.SecretVolumeSource{
+							SecretName: common.DexCASecretName,
+						},
+					},
+				})
+
+				volumeMounts = append(volumeMounts, corev1.VolumeMount{
+					Name:      "dex-ca",
+					MountPath: "/opt/dex-ca",
+					ReadOnly:  true,
+				})
+			}
+
 			if cfg.Spec.FeatureGates.Has(features.OIDCKubeCfgEndpoint) {
 				args = append(
 					args,
@@ -129,25 +148,6 @@ func APIDeploymentCreator(cfg *operatorv1alpha1.KubermaticConfiguration, workerN
 					fmt.Sprintf("-oidc-issuer-client-secret=%s", cfg.Spec.Auth.IssuerClientSecret),
 					fmt.Sprintf("-oidc-issuer-cookie-hash-key=%s", cfg.Spec.Auth.IssuerCookieKey),
 				)
-
-				if cfg.Spec.Auth.CABundle != "" {
-					args = append(args, "-oidc-ca-file=/opt/dex-ca/caBundle.pem")
-
-					volumes = append(volumes, corev1.Volume{
-						Name: "dex-ca",
-						VolumeSource: corev1.VolumeSource{
-							Secret: &corev1.SecretVolumeSource{
-								SecretName: common.DexCASecretName,
-							},
-						},
-					})
-
-					volumeMounts = append(volumeMounts, corev1.VolumeMount{
-						Name:      "dex-ca",
-						MountPath: "/opt/dex-ca",
-						ReadOnly:  true,
-					})
-				}
 			}
 
 			if workerName != "" {


### PR DESCRIPTION
**What this PR does / why we need it**: Make caBundle available to kubermatic-api when it is configured but no OIDCKubeCfgEndpoint feature-flag is set.

This enables users to use a custom root CA for dex.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Documentation**:
<!-- Add links to the related documentation changes related to this pull request. E.g. the link to the kubermatic/docs pullrequest. -->

**Does this PR introduce a user-facing change?**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If  no release note is required, just write "NONE".
-->
```release-note
Always mount CABundle for Dex into the kubermatic-api, even when `OIDCKubeCfgEndpoint` is disabled.
```