### PR TITLE
Allow disabling Certificate creation in Operator

### DIFF
--- a/docs/zz_generated.kubermaticConfiguration.yaml
+++ b/docs/zz_generated.kubermaticConfiguration.yaml
@@ -58,6 +58,8 @@ spec:
     # that will be used to acquire the certificate for the configured domain.
     # To use a namespaced Issuer, set the Kind to "Issuer" and manually create the
     # matching Issuer in Kubermatic's namespace.
+    # Setting an empty name disables the automatic creation of certificates and disables
+    # the TLS settings on the Kubermatic Ingress.
     certificateIssuer:
       # APIGroup is the group for the resource being referenced.
       # If APIGroup is not specified, the specified Kind must be in the core API group.

--- a/pkg/controller/operator/master/reconciler.go
+++ b/pkg/controller/operator/master/reconciler.go
@@ -337,6 +337,11 @@ func (r *Reconciler) reconcileCertificates(config *operatorv1alpha1.KubermaticCo
 		return nil
 	}
 
+	if config.Spec.Ingress.CertificateIssuer.Name == "" {
+		logger.Debug("Skipping Certificate creation because no certificateIssuer has been configured")
+		return nil
+	}
+
 	logger.Debug("Reconciling Certificates")
 
 	creators := []reconciling.NamedCertificateCreatorGetter{

--- a/pkg/crd/operator/v1alpha1/configuration.go
+++ b/pkg/crd/operator/v1alpha1/configuration.go
@@ -233,6 +233,8 @@ type KubermaticIngressConfiguration struct {
 	// that will be used to acquire the certificate for the configured domain.
 	// To use a namespaced Issuer, set the Kind to "Issuer" and manually create the
 	// matching Issuer in Kubermatic's namespace.
+	// Setting an empty name disables the automatic creation of certificates and disables
+	// the TLS settings on the Kubermatic Ingress.
 	CertificateIssuer corev1.TypedLocalObjectReference `json:"certificateIssuer,omitempty"`
 }
 


### PR DESCRIPTION
**What this PR does / why we need it**:
This is the operator-pendant to #5962.

**Does this PR introduce a user-facing change?**:
```release-note
Provide a way of skipping Certificate cert-manager resources.
```
