### PR TITLE
Etcd-launcher feature flag

### DIFF
--- a/hack/verify-boilerplate.sh
+++ b/hack/verify-boilerplate.sh
@@ -26,6 +26,7 @@ boilerplate \
   -exclude pkg/controller/seed-controller-manager/addon/testdata/istio \
   -exclude hack/images/startup-script/manage-startup-script.sh \
   -exclude pkg/resources/certificates/triple/triple.go \
+  -exclude pkg/resources/etcd/testdata \
   -exclude pkg/ee
 
 echodate "Checking Kubermatic EE licenses..."

--- a/pkg/controller/seed-controller-manager/pvwatcher/pvwatcher_controller.go
+++ b/pkg/controller/seed-controller-manager/pvwatcher/pvwatcher_controller.go
@@ -111,6 +111,9 @@ func (r *Reconciler) Reconcile(request reconcile.Request) (reconcile.Result, err
 	if cluster.Labels[kubermaticv1.WorkerNameLabelKey] != r.workerName || cluster.Spec.Pause {
 		return reconcile.Result{}, nil
 	}
+	if flag := cluster.Spec.Features[kubermaticv1.ClusterFeatureEtcdLauncher]; !flag {
+		return reconcile.Result{}, nil
+	}
 	result, err := r.reconcile(ctx, log, request)
 	if err != nil {
 		log.Errorw("Reconciling failed", zap.Error(err))

--- a/pkg/controller/seed-controller-manager/pvwatcher/pvwatcher_controller.go
+++ b/pkg/controller/seed-controller-manager/pvwatcher/pvwatcher_controller.go
@@ -111,7 +111,7 @@ func (r *Reconciler) Reconcile(request reconcile.Request) (reconcile.Result, err
 	if cluster.Labels[kubermaticv1.WorkerNameLabelKey] != r.workerName || cluster.Spec.Pause {
 		return reconcile.Result{}, nil
 	}
-	if flag := cluster.Spec.Features[kubermaticv1.ClusterFeatureEtcdLauncher]; !flag {
+	if !cluster.Spec.Features[kubermaticv1.ClusterFeatureEtcdLauncher] {
 		return reconcile.Result{}, nil
 	}
 	result, err := r.reconcile(ctx, log, request)

--- a/pkg/crd/kubermatic/v1/cluster.go
+++ b/pkg/crd/kubermatic/v1/cluster.go
@@ -138,6 +138,8 @@ const (
 	// ClusterFeatureRancherIntegration enables the rancher server integration feature.
 	// It will deploy a Rancher Server Managegment plane on the seed cluster and import the user cluster into it.
 	ClusterFeatureRancherIntegration = "rancherIntegration"
+
+	ClusterFeatureEtcdLauncher = "etcdLauncher"
 )
 
 // ClusterConditionType is used to indicate the type of a cluster condition. For all condition

--- a/pkg/crd/kubermatic/v1/cluster.go
+++ b/pkg/crd/kubermatic/v1/cluster.go
@@ -139,6 +139,8 @@ const (
 	// It will deploy a Rancher Server Managegment plane on the seed cluster and import the user cluster into it.
 	ClusterFeatureRancherIntegration = "rancherIntegration"
 
+	// ClusterFeatureEtcdLauncher enables features related to the experimental etcd-launcher. This includes user-cluster
+	// etcd scaling, automatic volume recovery and new backup/restore contorllers.
 	ClusterFeatureEtcdLauncher = "etcdLauncher"
 )
 

--- a/pkg/resources/etcd/statefulset.go
+++ b/pkg/resources/etcd/statefulset.go
@@ -17,9 +17,12 @@ limitations under the License.
 package etcd
 
 import (
+	"bytes"
 	"fmt"
 	"strconv"
+	"text/template"
 
+	"github.com/Masterminds/sprig"
 	"k8c.io/kubermatic/v2/pkg/controller/master-controller-manager/rbac"
 	kubermaticv1 "k8c.io/kubermatic/v2/pkg/crd/kubermatic/v1"
 	"k8c.io/kubermatic/v2/pkg/resources"
@@ -35,6 +38,8 @@ import (
 
 const (
 	name = "etcd"
+
+	dataDir = "/var/run/etcd/pod_${POD_NAME}/"
 	// ImageTag defines the image tag to use for the etcd image
 	etcdImageTagV33 = "v3.3.18"
 	etcdImageTagV34 = "v3.4.3"
@@ -95,28 +100,42 @@ func StatefulSetCreator(data etcdStatefulSetCreatorData, enableDataCorruptionChe
 			}
 			set.Spec.Template.Spec.ServiceAccountName = rbac.EtcdLauncherServiceAccountName
 
-			set.Spec.Template.Spec.InitContainers = []corev1.Container{
-				{
-					Name:            "etcd-launcher-init",
-					Image:           data.EtcdLauncherImage() + ":" + resources.KUBERMATICCOMMIT,
-					ImagePullPolicy: corev1.PullIfNotPresent,
-					Command:         []string{"/bin/cp", "/etcd-launcher", "/opt/bin/"},
-					VolumeMounts: []corev1.VolumeMount{
-						{
-							Name:      "launcher",
-							MountPath: "/opt/bin/",
+			// luancher feature gate was added later in the process. So there is the possiblity to have some clusters with
+			// laucher enabled by default. We check here to make sure it's not going to reverted.
+			hasLauncher := false
+			for _, c := range set.Spec.Template.Spec.InitContainers {
+				if c.Name == "etcd-launcher-init" {
+					hasLauncher = true
+					break
+				}
+			}
+			if flag := data.Cluster().Spec.Features[kubermaticv1.ClusterFeatureEtcdLauncher]; flag || hasLauncher {
+				set.Spec.Template.Spec.InitContainers = []corev1.Container{
+					{
+						Name:            "etcd-launcher-init",
+						Image:           data.EtcdLauncherImage() + ":" + resources.KUBERMATICCOMMIT,
+						ImagePullPolicy: corev1.PullIfNotPresent,
+						Command:         []string{"/bin/cp", "/etcd-launcher", "/opt/bin/"},
+						VolumeMounts: []corev1.VolumeMount{
+							{
+								Name:      "launcher",
+								MountPath: "/opt/bin/",
+							},
 						},
 					},
-				},
+				}
 			}
-
+			etcdStartCmd, err := getEtcdCommand(data, data.Cluster().Name, data.Cluster().Status.NamespaceName, enableDataCorruptionChecks, hasLauncher)
+			if err != nil {
+				return nil, err
+			}
 			set.Spec.Template.Spec.Containers = []corev1.Container{
 				{
 					Name: resources.EtcdStatefulSetName,
 
 					Image:           data.ImageRegistry(resources.RegistryGCR) + "/etcd-development/etcd:" + ImageTag(data.Cluster()),
 					ImagePullPolicy: corev1.PullIfNotPresent,
-					Command:         []string{"/opt/bin/etcd-launcher"}, Args: getLauncherArgs(enableDataCorruptionChecks),
+					Command:         etcdStartCmd,
 					Env: []corev1.EnvVar{
 						{
 							Name: "POD_NAME",
@@ -339,6 +358,9 @@ func ImageTag(c *kubermaticv1.Cluster) string {
 }
 
 func computeReplicas(data etcdStatefulSetCreatorData, set *appsv1.StatefulSet) int {
+	if flag := data.Cluster().Spec.Features[kubermaticv1.ClusterFeatureEtcdLauncher]; !flag {
+		return kubermaticv1.DefaultEtcdClusterSize
+	}
 	etcdClusterSize := data.Cluster().Spec.ComponentsOverride.Etcd.ClusterSize
 	// handle existing clusters that don't have a configured size
 	if etcdClusterSize < kubermaticv1.DefaultEtcdClusterSize {
@@ -368,16 +390,82 @@ func computeReplicas(data etcdStatefulSetCreatorData, set *appsv1.StatefulSet) i
 	return replicas
 }
 
-func getLauncherArgs(enableCorruptionCheck bool) []string {
-	command := []string{"-namespace", "$(NAMESPACE)",
-		"-etcd-cluster-size", "$(ETCD_CLUSTER_SIZE)",
-		"-pod-name", "$(POD_NAME)",
-		"-pod-ip", "$(POD_IP)",
-		"-api-version", "$(ETCDCTL_API)",
-		"-token", "$(TOKEN)",
-	}
-	if enableCorruptionCheck {
-		command = append(command, "-enable-corruption-check")
-	}
-	return command
+type commandTplData struct {
+	ServiceName           string
+	Namespace             string
+	Token                 string
+	DataDir               string
+	Migrate               bool
+	EnableCorruptionCheck bool
 }
+
+func getEtcdCommand(data etcdStatefulSetCreatorData, name, namespace string, enableCorruptionCheck, hasLauncher bool) ([]string, error) {
+	if flag := data.Cluster().Spec.Features[kubermaticv1.ClusterFeatureEtcdLauncher]; flag || hasLauncher {
+		command := []string{"/opt/bin/etcd-launcher",
+			"-namespace", "$(NAMESPACE)",
+			"-etcd-cluster-size", "$(ETCD_CLUSTER_SIZE)",
+			"-pod-name", "$(POD_NAME)",
+			"-pod-ip", "$(POD_IP)",
+			"-api-version", "$(ETCDCTL_API)",
+			"-token", "$(TOKEN)"}
+		if enableCorruptionCheck {
+			command = append(command, "-enable-corruption-check")
+		}
+		return command, nil
+	}
+
+	tpl, err := template.New("base").Funcs(sprig.TxtFuncMap()).Parse(etcdStartCommandTpl)
+	if err != nil {
+		return nil, fmt.Errorf("failed to parse etcd command template: %v", err)
+	}
+
+	tplData := commandTplData{
+		ServiceName:           resources.EtcdServiceName,
+		Token:                 name,
+		Namespace:             namespace,
+		DataDir:               dataDir,
+		EnableCorruptionCheck: enableCorruptionCheck,
+	}
+
+	buf := bytes.Buffer{}
+	if err := tpl.Execute(&buf, tplData); err != nil {
+		return nil, err
+	}
+
+	return []string{
+		"/bin/sh",
+		"-ec",
+		buf.String(),
+	}, nil
+}
+
+const (
+	etcdStartCommandTpl = `export MASTER_ENDPOINT="https://etcd-0.{{ .ServiceName }}.{{ .Namespace }}.svc.cluster.local:2379"
+
+export INITIAL_STATE="new"
+export INITIAL_CLUSTER="etcd-0=http://etcd-0.{{ .ServiceName }}.{{ .Namespace }}.svc.cluster.local:2380,etcd-1=http://etcd-1.{{ .ServiceName }}.{{ .Namespace }}.svc.cluster.local:2380,etcd-2=http://etcd-2.{{ .ServiceName }}.{{ .Namespace }}.svc.cluster.local:2380"
+
+echo "initial-state: ${INITIAL_STATE}"
+echo "initial-cluster: ${INITIAL_CLUSTER}"
+
+exec /usr/local/bin/etcd \
+    --name=${POD_NAME} \
+    --data-dir="{{ .DataDir }}" \
+    --initial-cluster=${INITIAL_CLUSTER} \
+    --initial-cluster-token="{{ .Token }}" \
+    --initial-cluster-state=${INITIAL_STATE} \
+    --advertise-client-urls "https://${POD_NAME}.{{ .ServiceName }}.{{ .Namespace }}.svc.cluster.local:2379,https://${POD_IP}:2379" \
+    --listen-client-urls "https://${POD_IP}:2379,https://127.0.0.1:2379" \
+    --listen-peer-urls "http://${POD_IP}:2380" \
+    --initial-advertise-peer-urls "http://${POD_NAME}.{{ .ServiceName }}.{{ .Namespace }}.svc.cluster.local:2380" \
+    --trusted-ca-file /etc/etcd/pki/ca/ca.crt \
+    --client-cert-auth \
+    --cert-file /etc/etcd/pki/tls/etcd-tls.crt \
+    --key-file /etc/etcd/pki/tls/etcd-tls.key \
+{{- if .EnableCorruptionCheck }}
+    --experimental-initial-corrupt-check=true \
+    --experimental-corrupt-check-time=10m \
+{{- end }}
+    --auto-compaction-retention=8
+`
+)

--- a/pkg/resources/etcd/statefulset_test.go
+++ b/pkg/resources/etcd/statefulset_test.go
@@ -19,6 +19,7 @@ package etcd
 import (
 	"flag"
 	"fmt"
+	"strings"
 	"testing"
 
 	kubermaticv1 "k8c.io/kubermatic/v2/pkg/crd/kubermatic/v1"
@@ -67,7 +68,10 @@ func TestGetEtcdCommand(t *testing.T) {
 			if len(args) != test.expectedArgs {
 				t.Fatalf("got less/more arguments than expected. got %d expected %d", len(args), test.expectedArgs)
 			}
-			cmd := args[2]
+			cmd := strings.Join(args, " ")
+			if !test.launcherEnabled {
+				cmd = args[2]
+			}
 
 			testhelper.CompareOutput(t, fmt.Sprintf("etcd-command-%s", test.name), cmd, *update, ".sh")
 		})

--- a/pkg/resources/etcd/statefulset_test.go
+++ b/pkg/resources/etcd/statefulset_test.go
@@ -1,0 +1,118 @@
+/*
+Copyright 2020 The Kubermatic Kubernetes Platform contributors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package etcd
+
+import (
+	"flag"
+	"fmt"
+	"testing"
+
+	kubermaticv1 "k8c.io/kubermatic/v2/pkg/crd/kubermatic/v1"
+	"k8c.io/kubermatic/v2/pkg/semver"
+	testhelper "k8c.io/kubermatic/v2/pkg/test"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+var update = flag.Bool("update", false, "update .golden files")
+
+func TestGetEtcdCommand(t *testing.T) {
+
+	tests := []struct {
+		name                  string
+		clusterName           string
+		clusterNamespace      string
+		enableCorruptionCheck bool
+		launcherEnabled       bool
+		expectedArgs          int
+	}{
+		{
+			name:             "with-launcher",
+			clusterName:      "62m9k9tqlm",
+			clusterNamespace: "cluster-62m9k9tqlm",
+			launcherEnabled:  true,
+			expectedArgs:     13,
+		},
+		{
+			name:                  "with-corruption-flags",
+			clusterName:           "lg69pmx8wf",
+			clusterNamespace:      "cluster-lg69pmx8wf",
+			enableCorruptionCheck: true,
+			launcherEnabled:       false,
+			expectedArgs:          3,
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			args, err := getEtcdCommand(test.clusterName, test.clusterNamespace, test.enableCorruptionCheck, test.launcherEnabled)
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+
+			if len(args) != test.expectedArgs {
+				t.Fatalf("got less/more arguments than expected. got %d expected %d", len(args), test.expectedArgs)
+			}
+			cmd := args[2]
+
+			testhelper.CompareOutput(t, fmt.Sprintf("etcd-command-%s", test.name), cmd, *update, ".sh")
+		})
+	}
+}
+
+func TestGetImageTag(t *testing.T) {
+	testCases := []struct {
+		name           string
+		cluster        *kubermaticv1.Cluster
+		expectedResult string
+	}{
+		{
+			name: "Openshift",
+			cluster: &kubermaticv1.Cluster{
+				ObjectMeta: metav1.ObjectMeta{
+					Annotations: map[string]string{"kubermatic.io/openshift": "true"},
+				},
+				Spec: kubermaticv1.ClusterSpec{Version: *semver.NewSemverOrDie("4.17.18")},
+			},
+			expectedResult: etcdImageTagV33,
+		},
+		{
+			name: "Kubernetes 1.16",
+			cluster: &kubermaticv1.Cluster{
+				Spec: kubermaticv1.ClusterSpec{Version: *semver.NewSemverOrDie("1.16.0")},
+			},
+			expectedResult: etcdImageTagV33,
+		},
+		{
+			name: "Kubernetes 1.17",
+			cluster: &kubermaticv1.Cluster{
+				Spec: kubermaticv1.ClusterSpec{Version: *semver.NewSemverOrDie("1.17.0")},
+			},
+			expectedResult: etcdImageTagV34,
+		},
+	}
+
+	for idx := range testCases {
+		tc := testCases[idx]
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			if result := ImageTag(tc.cluster); result != tc.expectedResult {
+				t.Fatalf("expected result %s but got result %s", tc.expectedResult, result)
+			}
+		})
+	}
+}

--- a/pkg/resources/etcd/testdata/etcd-command-with-corruption-flags.golden.sh
+++ b/pkg/resources/etcd/testdata/etcd-command-with-corruption-flags.golden.sh
@@ -14,10 +14,8 @@
 
 export MASTER_ENDPOINT="https://etcd-0.etcd.cluster-lg69pmx8wf.svc.cluster.local:2379"
 
-
 export INITIAL_STATE="new"
 export INITIAL_CLUSTER="etcd-0=http://etcd-0.etcd.cluster-lg69pmx8wf.svc.cluster.local:2380,etcd-1=http://etcd-1.etcd.cluster-lg69pmx8wf.svc.cluster.local:2380,etcd-2=http://etcd-2.etcd.cluster-lg69pmx8wf.svc.cluster.local:2380"
-
 
 echo "initial-state: ${INITIAL_STATE}"
 echo "initial-cluster: ${INITIAL_CLUSTER}"
@@ -31,6 +29,7 @@ exec /usr/local/bin/etcd \
     --advertise-client-urls "https://${POD_NAME}.etcd.cluster-lg69pmx8wf.svc.cluster.local:2379,https://${POD_IP}:2379" \
     --listen-client-urls "https://${POD_IP}:2379,https://127.0.0.1:2379" \
     --listen-peer-urls "http://${POD_IP}:2380" \
+    --listen-metrics-urls "http://${POD_IP}:2378,http://127.0.0.1:2378" \
     --initial-advertise-peer-urls "http://${POD_NAME}.etcd.cluster-lg69pmx8wf.svc.cluster.local:2380" \
     --trusted-ca-file /etc/etcd/pki/ca/ca.crt \
     --client-cert-auth \

--- a/pkg/resources/etcd/testdata/etcd-command-with-corruption-flags.golden.sh
+++ b/pkg/resources/etcd/testdata/etcd-command-with-corruption-flags.golden.sh
@@ -1,17 +1,3 @@
-# Copyright 2020 The Kubermatic Kubernetes Platform contributors.
-#
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at
-#
-#     http://www.apache.org/licenses/LICENSE-2.0
-#
-# Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS,
-# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-# See the License for the specific language governing permissions and
-# limitations under the License.
-
 export MASTER_ENDPOINT="https://etcd-0.etcd.cluster-lg69pmx8wf.svc.cluster.local:2379"
 
 export INITIAL_STATE="new"

--- a/pkg/resources/etcd/testdata/etcd-command-with-launcher.golden.sh
+++ b/pkg/resources/etcd/testdata/etcd-command-with-launcher.golden.sh
@@ -1,1 +1,1 @@
-$(NAMESPACE)
+/opt/bin/etcd-launcher -namespace $(NAMESPACE) -etcd-cluster-size $(ETCD_CLUSTER_SIZE) -pod-name $(POD_NAME) -pod-ip $(POD_IP) -api-version $(ETCDCTL_API) -token $(TOKEN)

--- a/pkg/resources/etcd/testdata/etcd-command-with-launcher.golden.sh
+++ b/pkg/resources/etcd/testdata/etcd-command-with-launcher.golden.sh
@@ -1,0 +1,1 @@
+$(NAMESPACE)

--- a/pkg/resources/etcd/tls-serving-certificate.go
+++ b/pkg/resources/etcd/tls-serving-certificate.go
@@ -53,7 +53,7 @@ func TLSCertificateCreator(data tlsCertificateCreatorData) reconciling.NamedSecr
 				},
 			}
 			etcdClusterSize := kubermaticv1.DefaultEtcdClusterSize
-			if flag := data.Cluster().Spec.Features[kubermaticv1.ClusterFeatureEtcdLauncher]; flag {
+			if data.Cluster().Spec.Features[kubermaticv1.ClusterFeatureEtcdLauncher] {
 				etcdClusterSize = kubermaticv1.MaxEtcdClusterSize
 			}
 			// TODO: make this dynamic based on existing pod count

--- a/pkg/resources/etcd/tls-serving-certificate.go
+++ b/pkg/resources/etcd/tls-serving-certificate.go
@@ -52,8 +52,12 @@ func TLSCertificateCreator(data tlsCertificateCreatorData) reconciling.NamedSecr
 					net.ParseIP("127.0.0.1"),
 				},
 			}
+			etcdClusterSize := kubermaticv1.DefaultEtcdClusterSize
+			if flag := data.Cluster().Spec.Features[kubermaticv1.ClusterFeatureEtcdLauncher]; flag {
+				etcdClusterSize = kubermaticv1.MaxEtcdClusterSize
+			}
 			// TODO: make this dynamic based on existing pod count
-			for i := 0; i < kubermaticv1.MaxEtcdClusterSize; i++ {
+			for i := 0; i < etcdClusterSize; i++ {
 				// Member name
 				podName := fmt.Sprintf("etcd-%d", i)
 				altNames.DNSNames = append(altNames.DNSNames, podName)

--- a/pkg/resources/test/fixtures/statefulset-aws-1.16.0-etcd.yaml
+++ b/pkg/resources/test/fixtures/statefulset-aws-1.16.0-etcd.yaml
@@ -39,21 +39,34 @@ spec:
               topologyKey: kubernetes.io/hostname
             weight: 10
       containers:
-      - args:
-        - -namespace
-        - $(NAMESPACE)
-        - -etcd-cluster-size
-        - $(ETCD_CLUSTER_SIZE)
-        - -pod-name
-        - $(POD_NAME)
-        - -pod-ip
-        - $(POD_IP)
-        - -api-version
-        - $(ETCDCTL_API)
-        - -token
-        - $(TOKEN)
-        command:
-        - /opt/bin/etcd-launcher
+      - command:
+        - /bin/sh
+        - -ec
+        - |
+          export MASTER_ENDPOINT="https://etcd-0.etcd.cluster-de-test-01.svc.cluster.local:2379"
+
+          export INITIAL_STATE="new"
+          export INITIAL_CLUSTER="etcd-0=http://etcd-0.etcd.cluster-de-test-01.svc.cluster.local:2380,etcd-1=http://etcd-1.etcd.cluster-de-test-01.svc.cluster.local:2380,etcd-2=http://etcd-2.etcd.cluster-de-test-01.svc.cluster.local:2380"
+
+          echo "initial-state: ${INITIAL_STATE}"
+          echo "initial-cluster: ${INITIAL_CLUSTER}"
+
+          exec /usr/local/bin/etcd \
+              --name=${POD_NAME} \
+              --data-dir="/var/run/etcd/pod_${POD_NAME}/" \
+              --initial-cluster=${INITIAL_CLUSTER} \
+              --initial-cluster-token="de-test-01" \
+              --initial-cluster-state=${INITIAL_STATE} \
+              --advertise-client-urls "https://${POD_NAME}.etcd.cluster-de-test-01.svc.cluster.local:2379,https://${POD_IP}:2379" \
+              --listen-client-urls "https://${POD_IP}:2379,https://127.0.0.1:2379" \
+              --listen-peer-urls "http://${POD_IP}:2380" \
+              --listen-metrics-urls "http://${POD_IP}:2378,http://127.0.0.1:2378" \
+              --initial-advertise-peer-urls "http://${POD_NAME}.etcd.cluster-de-test-01.svc.cluster.local:2380" \
+              --trusted-ca-file /etc/etcd/pki/ca/ca.crt \
+              --client-cert-auth \
+              --cert-file /etc/etcd/pki/tls/etcd-tls.crt \
+              --key-file /etc/etcd/pki/tls/etcd-tls.key \
+              --auto-compaction-retention=8
         env:
         - name: POD_NAME
           valueFrom:
@@ -138,18 +151,6 @@ spec:
           name: launcher
       imagePullSecrets:
       - name: dockercfg
-      initContainers:
-      - command:
-        - /bin/cp
-        - /etcd-launcher
-        - /opt/bin/
-        image: 'quay.io/kubermatic/etcd-launcher:'
-        imagePullPolicy: IfNotPresent
-        name: etcd-launcher-init
-        resources: {}
-        volumeMounts:
-        - mountPath: /opt/bin/
-          name: launcher
       serviceAccountName: etcd-launcher
       volumes:
       - name: etcd-tls-certificate

--- a/pkg/resources/test/fixtures/statefulset-aws-1.17.0-etcd.yaml
+++ b/pkg/resources/test/fixtures/statefulset-aws-1.17.0-etcd.yaml
@@ -39,21 +39,34 @@ spec:
               topologyKey: kubernetes.io/hostname
             weight: 10
       containers:
-      - args:
-        - -namespace
-        - $(NAMESPACE)
-        - -etcd-cluster-size
-        - $(ETCD_CLUSTER_SIZE)
-        - -pod-name
-        - $(POD_NAME)
-        - -pod-ip
-        - $(POD_IP)
-        - -api-version
-        - $(ETCDCTL_API)
-        - -token
-        - $(TOKEN)
-        command:
-        - /opt/bin/etcd-launcher
+      - command:
+        - /bin/sh
+        - -ec
+        - |
+          export MASTER_ENDPOINT="https://etcd-0.etcd.cluster-de-test-01.svc.cluster.local:2379"
+
+          export INITIAL_STATE="new"
+          export INITIAL_CLUSTER="etcd-0=http://etcd-0.etcd.cluster-de-test-01.svc.cluster.local:2380,etcd-1=http://etcd-1.etcd.cluster-de-test-01.svc.cluster.local:2380,etcd-2=http://etcd-2.etcd.cluster-de-test-01.svc.cluster.local:2380"
+
+          echo "initial-state: ${INITIAL_STATE}"
+          echo "initial-cluster: ${INITIAL_CLUSTER}"
+
+          exec /usr/local/bin/etcd \
+              --name=${POD_NAME} \
+              --data-dir="/var/run/etcd/pod_${POD_NAME}/" \
+              --initial-cluster=${INITIAL_CLUSTER} \
+              --initial-cluster-token="de-test-01" \
+              --initial-cluster-state=${INITIAL_STATE} \
+              --advertise-client-urls "https://${POD_NAME}.etcd.cluster-de-test-01.svc.cluster.local:2379,https://${POD_IP}:2379" \
+              --listen-client-urls "https://${POD_IP}:2379,https://127.0.0.1:2379" \
+              --listen-peer-urls "http://${POD_IP}:2380" \
+              --listen-metrics-urls "http://${POD_IP}:2378,http://127.0.0.1:2378" \
+              --initial-advertise-peer-urls "http://${POD_NAME}.etcd.cluster-de-test-01.svc.cluster.local:2380" \
+              --trusted-ca-file /etc/etcd/pki/ca/ca.crt \
+              --client-cert-auth \
+              --cert-file /etc/etcd/pki/tls/etcd-tls.crt \
+              --key-file /etc/etcd/pki/tls/etcd-tls.key \
+              --auto-compaction-retention=8
         env:
         - name: POD_NAME
           valueFrom:
@@ -138,18 +151,6 @@ spec:
           name: launcher
       imagePullSecrets:
       - name: dockercfg
-      initContainers:
-      - command:
-        - /bin/cp
-        - /etcd-launcher
-        - /opt/bin/
-        image: 'quay.io/kubermatic/etcd-launcher:'
-        imagePullPolicy: IfNotPresent
-        name: etcd-launcher-init
-        resources: {}
-        volumeMounts:
-        - mountPath: /opt/bin/
-          name: launcher
       serviceAccountName: etcd-launcher
       volumes:
       - name: etcd-tls-certificate

--- a/pkg/resources/test/fixtures/statefulset-aws-1.18.0-etcd.yaml
+++ b/pkg/resources/test/fixtures/statefulset-aws-1.18.0-etcd.yaml
@@ -39,21 +39,34 @@ spec:
               topologyKey: kubernetes.io/hostname
             weight: 10
       containers:
-      - args:
-        - -namespace
-        - $(NAMESPACE)
-        - -etcd-cluster-size
-        - $(ETCD_CLUSTER_SIZE)
-        - -pod-name
-        - $(POD_NAME)
-        - -pod-ip
-        - $(POD_IP)
-        - -api-version
-        - $(ETCDCTL_API)
-        - -token
-        - $(TOKEN)
-        command:
-        - /opt/bin/etcd-launcher
+      - command:
+        - /bin/sh
+        - -ec
+        - |
+          export MASTER_ENDPOINT="https://etcd-0.etcd.cluster-de-test-01.svc.cluster.local:2379"
+
+          export INITIAL_STATE="new"
+          export INITIAL_CLUSTER="etcd-0=http://etcd-0.etcd.cluster-de-test-01.svc.cluster.local:2380,etcd-1=http://etcd-1.etcd.cluster-de-test-01.svc.cluster.local:2380,etcd-2=http://etcd-2.etcd.cluster-de-test-01.svc.cluster.local:2380"
+
+          echo "initial-state: ${INITIAL_STATE}"
+          echo "initial-cluster: ${INITIAL_CLUSTER}"
+
+          exec /usr/local/bin/etcd \
+              --name=${POD_NAME} \
+              --data-dir="/var/run/etcd/pod_${POD_NAME}/" \
+              --initial-cluster=${INITIAL_CLUSTER} \
+              --initial-cluster-token="de-test-01" \
+              --initial-cluster-state=${INITIAL_STATE} \
+              --advertise-client-urls "https://${POD_NAME}.etcd.cluster-de-test-01.svc.cluster.local:2379,https://${POD_IP}:2379" \
+              --listen-client-urls "https://${POD_IP}:2379,https://127.0.0.1:2379" \
+              --listen-peer-urls "http://${POD_IP}:2380" \
+              --listen-metrics-urls "http://${POD_IP}:2378,http://127.0.0.1:2378" \
+              --initial-advertise-peer-urls "http://${POD_NAME}.etcd.cluster-de-test-01.svc.cluster.local:2380" \
+              --trusted-ca-file /etc/etcd/pki/ca/ca.crt \
+              --client-cert-auth \
+              --cert-file /etc/etcd/pki/tls/etcd-tls.crt \
+              --key-file /etc/etcd/pki/tls/etcd-tls.key \
+              --auto-compaction-retention=8
         env:
         - name: POD_NAME
           valueFrom:
@@ -138,18 +151,6 @@ spec:
           name: launcher
       imagePullSecrets:
       - name: dockercfg
-      initContainers:
-      - command:
-        - /bin/cp
-        - /etcd-launcher
-        - /opt/bin/
-        image: 'quay.io/kubermatic/etcd-launcher:'
-        imagePullPolicy: IfNotPresent
-        name: etcd-launcher-init
-        resources: {}
-        volumeMounts:
-        - mountPath: /opt/bin/
-          name: launcher
       serviceAccountName: etcd-launcher
       volumes:
       - name: etcd-tls-certificate

--- a/pkg/resources/test/fixtures/statefulset-aws-1.19.0-etcd.yaml
+++ b/pkg/resources/test/fixtures/statefulset-aws-1.19.0-etcd.yaml
@@ -39,21 +39,34 @@ spec:
               topologyKey: kubernetes.io/hostname
             weight: 10
       containers:
-      - args:
-        - -namespace
-        - $(NAMESPACE)
-        - -etcd-cluster-size
-        - $(ETCD_CLUSTER_SIZE)
-        - -pod-name
-        - $(POD_NAME)
-        - -pod-ip
-        - $(POD_IP)
-        - -api-version
-        - $(ETCDCTL_API)
-        - -token
-        - $(TOKEN)
-        command:
-        - /opt/bin/etcd-launcher
+      - command:
+        - /bin/sh
+        - -ec
+        - |
+          export MASTER_ENDPOINT="https://etcd-0.etcd.cluster-de-test-01.svc.cluster.local:2379"
+
+          export INITIAL_STATE="new"
+          export INITIAL_CLUSTER="etcd-0=http://etcd-0.etcd.cluster-de-test-01.svc.cluster.local:2380,etcd-1=http://etcd-1.etcd.cluster-de-test-01.svc.cluster.local:2380,etcd-2=http://etcd-2.etcd.cluster-de-test-01.svc.cluster.local:2380"
+
+          echo "initial-state: ${INITIAL_STATE}"
+          echo "initial-cluster: ${INITIAL_CLUSTER}"
+
+          exec /usr/local/bin/etcd \
+              --name=${POD_NAME} \
+              --data-dir="/var/run/etcd/pod_${POD_NAME}/" \
+              --initial-cluster=${INITIAL_CLUSTER} \
+              --initial-cluster-token="de-test-01" \
+              --initial-cluster-state=${INITIAL_STATE} \
+              --advertise-client-urls "https://${POD_NAME}.etcd.cluster-de-test-01.svc.cluster.local:2379,https://${POD_IP}:2379" \
+              --listen-client-urls "https://${POD_IP}:2379,https://127.0.0.1:2379" \
+              --listen-peer-urls "http://${POD_IP}:2380" \
+              --listen-metrics-urls "http://${POD_IP}:2378,http://127.0.0.1:2378" \
+              --initial-advertise-peer-urls "http://${POD_NAME}.etcd.cluster-de-test-01.svc.cluster.local:2380" \
+              --trusted-ca-file /etc/etcd/pki/ca/ca.crt \
+              --client-cert-auth \
+              --cert-file /etc/etcd/pki/tls/etcd-tls.crt \
+              --key-file /etc/etcd/pki/tls/etcd-tls.key \
+              --auto-compaction-retention=8
         env:
         - name: POD_NAME
           valueFrom:
@@ -138,18 +151,6 @@ spec:
           name: launcher
       imagePullSecrets:
       - name: dockercfg
-      initContainers:
-      - command:
-        - /bin/cp
-        - /etcd-launcher
-        - /opt/bin/
-        image: 'quay.io/kubermatic/etcd-launcher:'
-        imagePullPolicy: IfNotPresent
-        name: etcd-launcher-init
-        resources: {}
-        volumeMounts:
-        - mountPath: /opt/bin/
-          name: launcher
       serviceAccountName: etcd-launcher
       volumes:
       - name: etcd-tls-certificate

--- a/pkg/resources/test/fixtures/statefulset-azure-1.16.0-etcd.yaml
+++ b/pkg/resources/test/fixtures/statefulset-azure-1.16.0-etcd.yaml
@@ -39,21 +39,34 @@ spec:
               topologyKey: kubernetes.io/hostname
             weight: 10
       containers:
-      - args:
-        - -namespace
-        - $(NAMESPACE)
-        - -etcd-cluster-size
-        - $(ETCD_CLUSTER_SIZE)
-        - -pod-name
-        - $(POD_NAME)
-        - -pod-ip
-        - $(POD_IP)
-        - -api-version
-        - $(ETCDCTL_API)
-        - -token
-        - $(TOKEN)
-        command:
-        - /opt/bin/etcd-launcher
+      - command:
+        - /bin/sh
+        - -ec
+        - |
+          export MASTER_ENDPOINT="https://etcd-0.etcd.cluster-de-test-01.svc.cluster.local:2379"
+
+          export INITIAL_STATE="new"
+          export INITIAL_CLUSTER="etcd-0=http://etcd-0.etcd.cluster-de-test-01.svc.cluster.local:2380,etcd-1=http://etcd-1.etcd.cluster-de-test-01.svc.cluster.local:2380,etcd-2=http://etcd-2.etcd.cluster-de-test-01.svc.cluster.local:2380"
+
+          echo "initial-state: ${INITIAL_STATE}"
+          echo "initial-cluster: ${INITIAL_CLUSTER}"
+
+          exec /usr/local/bin/etcd \
+              --name=${POD_NAME} \
+              --data-dir="/var/run/etcd/pod_${POD_NAME}/" \
+              --initial-cluster=${INITIAL_CLUSTER} \
+              --initial-cluster-token="de-test-01" \
+              --initial-cluster-state=${INITIAL_STATE} \
+              --advertise-client-urls "https://${POD_NAME}.etcd.cluster-de-test-01.svc.cluster.local:2379,https://${POD_IP}:2379" \
+              --listen-client-urls "https://${POD_IP}:2379,https://127.0.0.1:2379" \
+              --listen-peer-urls "http://${POD_IP}:2380" \
+              --listen-metrics-urls "http://${POD_IP}:2378,http://127.0.0.1:2378" \
+              --initial-advertise-peer-urls "http://${POD_NAME}.etcd.cluster-de-test-01.svc.cluster.local:2380" \
+              --trusted-ca-file /etc/etcd/pki/ca/ca.crt \
+              --client-cert-auth \
+              --cert-file /etc/etcd/pki/tls/etcd-tls.crt \
+              --key-file /etc/etcd/pki/tls/etcd-tls.key \
+              --auto-compaction-retention=8
         env:
         - name: POD_NAME
           valueFrom:
@@ -138,18 +151,6 @@ spec:
           name: launcher
       imagePullSecrets:
       - name: dockercfg
-      initContainers:
-      - command:
-        - /bin/cp
-        - /etcd-launcher
-        - /opt/bin/
-        image: 'quay.io/kubermatic/etcd-launcher:'
-        imagePullPolicy: IfNotPresent
-        name: etcd-launcher-init
-        resources: {}
-        volumeMounts:
-        - mountPath: /opt/bin/
-          name: launcher
       serviceAccountName: etcd-launcher
       volumes:
       - name: etcd-tls-certificate

--- a/pkg/resources/test/fixtures/statefulset-azure-1.17.0-etcd.yaml
+++ b/pkg/resources/test/fixtures/statefulset-azure-1.17.0-etcd.yaml
@@ -39,21 +39,34 @@ spec:
               topologyKey: kubernetes.io/hostname
             weight: 10
       containers:
-      - args:
-        - -namespace
-        - $(NAMESPACE)
-        - -etcd-cluster-size
-        - $(ETCD_CLUSTER_SIZE)
-        - -pod-name
-        - $(POD_NAME)
-        - -pod-ip
-        - $(POD_IP)
-        - -api-version
-        - $(ETCDCTL_API)
-        - -token
-        - $(TOKEN)
-        command:
-        - /opt/bin/etcd-launcher
+      - command:
+        - /bin/sh
+        - -ec
+        - |
+          export MASTER_ENDPOINT="https://etcd-0.etcd.cluster-de-test-01.svc.cluster.local:2379"
+
+          export INITIAL_STATE="new"
+          export INITIAL_CLUSTER="etcd-0=http://etcd-0.etcd.cluster-de-test-01.svc.cluster.local:2380,etcd-1=http://etcd-1.etcd.cluster-de-test-01.svc.cluster.local:2380,etcd-2=http://etcd-2.etcd.cluster-de-test-01.svc.cluster.local:2380"
+
+          echo "initial-state: ${INITIAL_STATE}"
+          echo "initial-cluster: ${INITIAL_CLUSTER}"
+
+          exec /usr/local/bin/etcd \
+              --name=${POD_NAME} \
+              --data-dir="/var/run/etcd/pod_${POD_NAME}/" \
+              --initial-cluster=${INITIAL_CLUSTER} \
+              --initial-cluster-token="de-test-01" \
+              --initial-cluster-state=${INITIAL_STATE} \
+              --advertise-client-urls "https://${POD_NAME}.etcd.cluster-de-test-01.svc.cluster.local:2379,https://${POD_IP}:2379" \
+              --listen-client-urls "https://${POD_IP}:2379,https://127.0.0.1:2379" \
+              --listen-peer-urls "http://${POD_IP}:2380" \
+              --listen-metrics-urls "http://${POD_IP}:2378,http://127.0.0.1:2378" \
+              --initial-advertise-peer-urls "http://${POD_NAME}.etcd.cluster-de-test-01.svc.cluster.local:2380" \
+              --trusted-ca-file /etc/etcd/pki/ca/ca.crt \
+              --client-cert-auth \
+              --cert-file /etc/etcd/pki/tls/etcd-tls.crt \
+              --key-file /etc/etcd/pki/tls/etcd-tls.key \
+              --auto-compaction-retention=8
         env:
         - name: POD_NAME
           valueFrom:
@@ -138,18 +151,6 @@ spec:
           name: launcher
       imagePullSecrets:
       - name: dockercfg
-      initContainers:
-      - command:
-        - /bin/cp
-        - /etcd-launcher
-        - /opt/bin/
-        image: 'quay.io/kubermatic/etcd-launcher:'
-        imagePullPolicy: IfNotPresent
-        name: etcd-launcher-init
-        resources: {}
-        volumeMounts:
-        - mountPath: /opt/bin/
-          name: launcher
       serviceAccountName: etcd-launcher
       volumes:
       - name: etcd-tls-certificate

--- a/pkg/resources/test/fixtures/statefulset-azure-1.18.0-etcd.yaml
+++ b/pkg/resources/test/fixtures/statefulset-azure-1.18.0-etcd.yaml
@@ -39,21 +39,34 @@ spec:
               topologyKey: kubernetes.io/hostname
             weight: 10
       containers:
-      - args:
-        - -namespace
-        - $(NAMESPACE)
-        - -etcd-cluster-size
-        - $(ETCD_CLUSTER_SIZE)
-        - -pod-name
-        - $(POD_NAME)
-        - -pod-ip
-        - $(POD_IP)
-        - -api-version
-        - $(ETCDCTL_API)
-        - -token
-        - $(TOKEN)
-        command:
-        - /opt/bin/etcd-launcher
+      - command:
+        - /bin/sh
+        - -ec
+        - |
+          export MASTER_ENDPOINT="https://etcd-0.etcd.cluster-de-test-01.svc.cluster.local:2379"
+
+          export INITIAL_STATE="new"
+          export INITIAL_CLUSTER="etcd-0=http://etcd-0.etcd.cluster-de-test-01.svc.cluster.local:2380,etcd-1=http://etcd-1.etcd.cluster-de-test-01.svc.cluster.local:2380,etcd-2=http://etcd-2.etcd.cluster-de-test-01.svc.cluster.local:2380"
+
+          echo "initial-state: ${INITIAL_STATE}"
+          echo "initial-cluster: ${INITIAL_CLUSTER}"
+
+          exec /usr/local/bin/etcd \
+              --name=${POD_NAME} \
+              --data-dir="/var/run/etcd/pod_${POD_NAME}/" \
+              --initial-cluster=${INITIAL_CLUSTER} \
+              --initial-cluster-token="de-test-01" \
+              --initial-cluster-state=${INITIAL_STATE} \
+              --advertise-client-urls "https://${POD_NAME}.etcd.cluster-de-test-01.svc.cluster.local:2379,https://${POD_IP}:2379" \
+              --listen-client-urls "https://${POD_IP}:2379,https://127.0.0.1:2379" \
+              --listen-peer-urls "http://${POD_IP}:2380" \
+              --listen-metrics-urls "http://${POD_IP}:2378,http://127.0.0.1:2378" \
+              --initial-advertise-peer-urls "http://${POD_NAME}.etcd.cluster-de-test-01.svc.cluster.local:2380" \
+              --trusted-ca-file /etc/etcd/pki/ca/ca.crt \
+              --client-cert-auth \
+              --cert-file /etc/etcd/pki/tls/etcd-tls.crt \
+              --key-file /etc/etcd/pki/tls/etcd-tls.key \
+              --auto-compaction-retention=8
         env:
         - name: POD_NAME
           valueFrom:
@@ -138,18 +151,6 @@ spec:
           name: launcher
       imagePullSecrets:
       - name: dockercfg
-      initContainers:
-      - command:
-        - /bin/cp
-        - /etcd-launcher
-        - /opt/bin/
-        image: 'quay.io/kubermatic/etcd-launcher:'
-        imagePullPolicy: IfNotPresent
-        name: etcd-launcher-init
-        resources: {}
-        volumeMounts:
-        - mountPath: /opt/bin/
-          name: launcher
       serviceAccountName: etcd-launcher
       volumes:
       - name: etcd-tls-certificate

--- a/pkg/resources/test/fixtures/statefulset-azure-1.19.0-etcd.yaml
+++ b/pkg/resources/test/fixtures/statefulset-azure-1.19.0-etcd.yaml
@@ -39,21 +39,34 @@ spec:
               topologyKey: kubernetes.io/hostname
             weight: 10
       containers:
-      - args:
-        - -namespace
-        - $(NAMESPACE)
-        - -etcd-cluster-size
-        - $(ETCD_CLUSTER_SIZE)
-        - -pod-name
-        - $(POD_NAME)
-        - -pod-ip
-        - $(POD_IP)
-        - -api-version
-        - $(ETCDCTL_API)
-        - -token
-        - $(TOKEN)
-        command:
-        - /opt/bin/etcd-launcher
+      - command:
+        - /bin/sh
+        - -ec
+        - |
+          export MASTER_ENDPOINT="https://etcd-0.etcd.cluster-de-test-01.svc.cluster.local:2379"
+
+          export INITIAL_STATE="new"
+          export INITIAL_CLUSTER="etcd-0=http://etcd-0.etcd.cluster-de-test-01.svc.cluster.local:2380,etcd-1=http://etcd-1.etcd.cluster-de-test-01.svc.cluster.local:2380,etcd-2=http://etcd-2.etcd.cluster-de-test-01.svc.cluster.local:2380"
+
+          echo "initial-state: ${INITIAL_STATE}"
+          echo "initial-cluster: ${INITIAL_CLUSTER}"
+
+          exec /usr/local/bin/etcd \
+              --name=${POD_NAME} \
+              --data-dir="/var/run/etcd/pod_${POD_NAME}/" \
+              --initial-cluster=${INITIAL_CLUSTER} \
+              --initial-cluster-token="de-test-01" \
+              --initial-cluster-state=${INITIAL_STATE} \
+              --advertise-client-urls "https://${POD_NAME}.etcd.cluster-de-test-01.svc.cluster.local:2379,https://${POD_IP}:2379" \
+              --listen-client-urls "https://${POD_IP}:2379,https://127.0.0.1:2379" \
+              --listen-peer-urls "http://${POD_IP}:2380" \
+              --listen-metrics-urls "http://${POD_IP}:2378,http://127.0.0.1:2378" \
+              --initial-advertise-peer-urls "http://${POD_NAME}.etcd.cluster-de-test-01.svc.cluster.local:2380" \
+              --trusted-ca-file /etc/etcd/pki/ca/ca.crt \
+              --client-cert-auth \
+              --cert-file /etc/etcd/pki/tls/etcd-tls.crt \
+              --key-file /etc/etcd/pki/tls/etcd-tls.key \
+              --auto-compaction-retention=8
         env:
         - name: POD_NAME
           valueFrom:
@@ -138,18 +151,6 @@ spec:
           name: launcher
       imagePullSecrets:
       - name: dockercfg
-      initContainers:
-      - command:
-        - /bin/cp
-        - /etcd-launcher
-        - /opt/bin/
-        image: 'quay.io/kubermatic/etcd-launcher:'
-        imagePullPolicy: IfNotPresent
-        name: etcd-launcher-init
-        resources: {}
-        volumeMounts:
-        - mountPath: /opt/bin/
-          name: launcher
       serviceAccountName: etcd-launcher
       volumes:
       - name: etcd-tls-certificate

--- a/pkg/resources/test/fixtures/statefulset-bringyourown-1.16.0-etcd.yaml
+++ b/pkg/resources/test/fixtures/statefulset-bringyourown-1.16.0-etcd.yaml
@@ -39,21 +39,34 @@ spec:
               topologyKey: kubernetes.io/hostname
             weight: 10
       containers:
-      - args:
-        - -namespace
-        - $(NAMESPACE)
-        - -etcd-cluster-size
-        - $(ETCD_CLUSTER_SIZE)
-        - -pod-name
-        - $(POD_NAME)
-        - -pod-ip
-        - $(POD_IP)
-        - -api-version
-        - $(ETCDCTL_API)
-        - -token
-        - $(TOKEN)
-        command:
-        - /opt/bin/etcd-launcher
+      - command:
+        - /bin/sh
+        - -ec
+        - |
+          export MASTER_ENDPOINT="https://etcd-0.etcd.cluster-de-test-01.svc.cluster.local:2379"
+
+          export INITIAL_STATE="new"
+          export INITIAL_CLUSTER="etcd-0=http://etcd-0.etcd.cluster-de-test-01.svc.cluster.local:2380,etcd-1=http://etcd-1.etcd.cluster-de-test-01.svc.cluster.local:2380,etcd-2=http://etcd-2.etcd.cluster-de-test-01.svc.cluster.local:2380"
+
+          echo "initial-state: ${INITIAL_STATE}"
+          echo "initial-cluster: ${INITIAL_CLUSTER}"
+
+          exec /usr/local/bin/etcd \
+              --name=${POD_NAME} \
+              --data-dir="/var/run/etcd/pod_${POD_NAME}/" \
+              --initial-cluster=${INITIAL_CLUSTER} \
+              --initial-cluster-token="de-test-01" \
+              --initial-cluster-state=${INITIAL_STATE} \
+              --advertise-client-urls "https://${POD_NAME}.etcd.cluster-de-test-01.svc.cluster.local:2379,https://${POD_IP}:2379" \
+              --listen-client-urls "https://${POD_IP}:2379,https://127.0.0.1:2379" \
+              --listen-peer-urls "http://${POD_IP}:2380" \
+              --listen-metrics-urls "http://${POD_IP}:2378,http://127.0.0.1:2378" \
+              --initial-advertise-peer-urls "http://${POD_NAME}.etcd.cluster-de-test-01.svc.cluster.local:2380" \
+              --trusted-ca-file /etc/etcd/pki/ca/ca.crt \
+              --client-cert-auth \
+              --cert-file /etc/etcd/pki/tls/etcd-tls.crt \
+              --key-file /etc/etcd/pki/tls/etcd-tls.key \
+              --auto-compaction-retention=8
         env:
         - name: POD_NAME
           valueFrom:
@@ -138,18 +151,6 @@ spec:
           name: launcher
       imagePullSecrets:
       - name: dockercfg
-      initContainers:
-      - command:
-        - /bin/cp
-        - /etcd-launcher
-        - /opt/bin/
-        image: 'quay.io/kubermatic/etcd-launcher:'
-        imagePullPolicy: IfNotPresent
-        name: etcd-launcher-init
-        resources: {}
-        volumeMounts:
-        - mountPath: /opt/bin/
-          name: launcher
       serviceAccountName: etcd-launcher
       volumes:
       - name: etcd-tls-certificate

--- a/pkg/resources/test/fixtures/statefulset-bringyourown-1.17.0-etcd.yaml
+++ b/pkg/resources/test/fixtures/statefulset-bringyourown-1.17.0-etcd.yaml
@@ -39,21 +39,34 @@ spec:
               topologyKey: kubernetes.io/hostname
             weight: 10
       containers:
-      - args:
-        - -namespace
-        - $(NAMESPACE)
-        - -etcd-cluster-size
-        - $(ETCD_CLUSTER_SIZE)
-        - -pod-name
-        - $(POD_NAME)
-        - -pod-ip
-        - $(POD_IP)
-        - -api-version
-        - $(ETCDCTL_API)
-        - -token
-        - $(TOKEN)
-        command:
-        - /opt/bin/etcd-launcher
+      - command:
+        - /bin/sh
+        - -ec
+        - |
+          export MASTER_ENDPOINT="https://etcd-0.etcd.cluster-de-test-01.svc.cluster.local:2379"
+
+          export INITIAL_STATE="new"
+          export INITIAL_CLUSTER="etcd-0=http://etcd-0.etcd.cluster-de-test-01.svc.cluster.local:2380,etcd-1=http://etcd-1.etcd.cluster-de-test-01.svc.cluster.local:2380,etcd-2=http://etcd-2.etcd.cluster-de-test-01.svc.cluster.local:2380"
+
+          echo "initial-state: ${INITIAL_STATE}"
+          echo "initial-cluster: ${INITIAL_CLUSTER}"
+
+          exec /usr/local/bin/etcd \
+              --name=${POD_NAME} \
+              --data-dir="/var/run/etcd/pod_${POD_NAME}/" \
+              --initial-cluster=${INITIAL_CLUSTER} \
+              --initial-cluster-token="de-test-01" \
+              --initial-cluster-state=${INITIAL_STATE} \
+              --advertise-client-urls "https://${POD_NAME}.etcd.cluster-de-test-01.svc.cluster.local:2379,https://${POD_IP}:2379" \
+              --listen-client-urls "https://${POD_IP}:2379,https://127.0.0.1:2379" \
+              --listen-peer-urls "http://${POD_IP}:2380" \
+              --listen-metrics-urls "http://${POD_IP}:2378,http://127.0.0.1:2378" \
+              --initial-advertise-peer-urls "http://${POD_NAME}.etcd.cluster-de-test-01.svc.cluster.local:2380" \
+              --trusted-ca-file /etc/etcd/pki/ca/ca.crt \
+              --client-cert-auth \
+              --cert-file /etc/etcd/pki/tls/etcd-tls.crt \
+              --key-file /etc/etcd/pki/tls/etcd-tls.key \
+              --auto-compaction-retention=8
         env:
         - name: POD_NAME
           valueFrom:
@@ -138,18 +151,6 @@ spec:
           name: launcher
       imagePullSecrets:
       - name: dockercfg
-      initContainers:
-      - command:
-        - /bin/cp
-        - /etcd-launcher
-        - /opt/bin/
-        image: 'quay.io/kubermatic/etcd-launcher:'
-        imagePullPolicy: IfNotPresent
-        name: etcd-launcher-init
-        resources: {}
-        volumeMounts:
-        - mountPath: /opt/bin/
-          name: launcher
       serviceAccountName: etcd-launcher
       volumes:
       - name: etcd-tls-certificate

--- a/pkg/resources/test/fixtures/statefulset-bringyourown-1.18.0-etcd.yaml
+++ b/pkg/resources/test/fixtures/statefulset-bringyourown-1.18.0-etcd.yaml
@@ -39,21 +39,34 @@ spec:
               topologyKey: kubernetes.io/hostname
             weight: 10
       containers:
-      - args:
-        - -namespace
-        - $(NAMESPACE)
-        - -etcd-cluster-size
-        - $(ETCD_CLUSTER_SIZE)
-        - -pod-name
-        - $(POD_NAME)
-        - -pod-ip
-        - $(POD_IP)
-        - -api-version
-        - $(ETCDCTL_API)
-        - -token
-        - $(TOKEN)
-        command:
-        - /opt/bin/etcd-launcher
+      - command:
+        - /bin/sh
+        - -ec
+        - |
+          export MASTER_ENDPOINT="https://etcd-0.etcd.cluster-de-test-01.svc.cluster.local:2379"
+
+          export INITIAL_STATE="new"
+          export INITIAL_CLUSTER="etcd-0=http://etcd-0.etcd.cluster-de-test-01.svc.cluster.local:2380,etcd-1=http://etcd-1.etcd.cluster-de-test-01.svc.cluster.local:2380,etcd-2=http://etcd-2.etcd.cluster-de-test-01.svc.cluster.local:2380"
+
+          echo "initial-state: ${INITIAL_STATE}"
+          echo "initial-cluster: ${INITIAL_CLUSTER}"
+
+          exec /usr/local/bin/etcd \
+              --name=${POD_NAME} \
+              --data-dir="/var/run/etcd/pod_${POD_NAME}/" \
+              --initial-cluster=${INITIAL_CLUSTER} \
+              --initial-cluster-token="de-test-01" \
+              --initial-cluster-state=${INITIAL_STATE} \
+              --advertise-client-urls "https://${POD_NAME}.etcd.cluster-de-test-01.svc.cluster.local:2379,https://${POD_IP}:2379" \
+              --listen-client-urls "https://${POD_IP}:2379,https://127.0.0.1:2379" \
+              --listen-peer-urls "http://${POD_IP}:2380" \
+              --listen-metrics-urls "http://${POD_IP}:2378,http://127.0.0.1:2378" \
+              --initial-advertise-peer-urls "http://${POD_NAME}.etcd.cluster-de-test-01.svc.cluster.local:2380" \
+              --trusted-ca-file /etc/etcd/pki/ca/ca.crt \
+              --client-cert-auth \
+              --cert-file /etc/etcd/pki/tls/etcd-tls.crt \
+              --key-file /etc/etcd/pki/tls/etcd-tls.key \
+              --auto-compaction-retention=8
         env:
         - name: POD_NAME
           valueFrom:
@@ -138,18 +151,6 @@ spec:
           name: launcher
       imagePullSecrets:
       - name: dockercfg
-      initContainers:
-      - command:
-        - /bin/cp
-        - /etcd-launcher
-        - /opt/bin/
-        image: 'quay.io/kubermatic/etcd-launcher:'
-        imagePullPolicy: IfNotPresent
-        name: etcd-launcher-init
-        resources: {}
-        volumeMounts:
-        - mountPath: /opt/bin/
-          name: launcher
       serviceAccountName: etcd-launcher
       volumes:
       - name: etcd-tls-certificate

--- a/pkg/resources/test/fixtures/statefulset-bringyourown-1.19.0-etcd.yaml
+++ b/pkg/resources/test/fixtures/statefulset-bringyourown-1.19.0-etcd.yaml
@@ -39,21 +39,34 @@ spec:
               topologyKey: kubernetes.io/hostname
             weight: 10
       containers:
-      - args:
-        - -namespace
-        - $(NAMESPACE)
-        - -etcd-cluster-size
-        - $(ETCD_CLUSTER_SIZE)
-        - -pod-name
-        - $(POD_NAME)
-        - -pod-ip
-        - $(POD_IP)
-        - -api-version
-        - $(ETCDCTL_API)
-        - -token
-        - $(TOKEN)
-        command:
-        - /opt/bin/etcd-launcher
+      - command:
+        - /bin/sh
+        - -ec
+        - |
+          export MASTER_ENDPOINT="https://etcd-0.etcd.cluster-de-test-01.svc.cluster.local:2379"
+
+          export INITIAL_STATE="new"
+          export INITIAL_CLUSTER="etcd-0=http://etcd-0.etcd.cluster-de-test-01.svc.cluster.local:2380,etcd-1=http://etcd-1.etcd.cluster-de-test-01.svc.cluster.local:2380,etcd-2=http://etcd-2.etcd.cluster-de-test-01.svc.cluster.local:2380"
+
+          echo "initial-state: ${INITIAL_STATE}"
+          echo "initial-cluster: ${INITIAL_CLUSTER}"
+
+          exec /usr/local/bin/etcd \
+              --name=${POD_NAME} \
+              --data-dir="/var/run/etcd/pod_${POD_NAME}/" \
+              --initial-cluster=${INITIAL_CLUSTER} \
+              --initial-cluster-token="de-test-01" \
+              --initial-cluster-state=${INITIAL_STATE} \
+              --advertise-client-urls "https://${POD_NAME}.etcd.cluster-de-test-01.svc.cluster.local:2379,https://${POD_IP}:2379" \
+              --listen-client-urls "https://${POD_IP}:2379,https://127.0.0.1:2379" \
+              --listen-peer-urls "http://${POD_IP}:2380" \
+              --listen-metrics-urls "http://${POD_IP}:2378,http://127.0.0.1:2378" \
+              --initial-advertise-peer-urls "http://${POD_NAME}.etcd.cluster-de-test-01.svc.cluster.local:2380" \
+              --trusted-ca-file /etc/etcd/pki/ca/ca.crt \
+              --client-cert-auth \
+              --cert-file /etc/etcd/pki/tls/etcd-tls.crt \
+              --key-file /etc/etcd/pki/tls/etcd-tls.key \
+              --auto-compaction-retention=8
         env:
         - name: POD_NAME
           valueFrom:
@@ -138,18 +151,6 @@ spec:
           name: launcher
       imagePullSecrets:
       - name: dockercfg
-      initContainers:
-      - command:
-        - /bin/cp
-        - /etcd-launcher
-        - /opt/bin/
-        image: 'quay.io/kubermatic/etcd-launcher:'
-        imagePullPolicy: IfNotPresent
-        name: etcd-launcher-init
-        resources: {}
-        volumeMounts:
-        - mountPath: /opt/bin/
-          name: launcher
       serviceAccountName: etcd-launcher
       volumes:
       - name: etcd-tls-certificate

--- a/pkg/resources/test/fixtures/statefulset-digitalocean-1.16.0-etcd.yaml
+++ b/pkg/resources/test/fixtures/statefulset-digitalocean-1.16.0-etcd.yaml
@@ -39,21 +39,34 @@ spec:
               topologyKey: kubernetes.io/hostname
             weight: 10
       containers:
-      - args:
-        - -namespace
-        - $(NAMESPACE)
-        - -etcd-cluster-size
-        - $(ETCD_CLUSTER_SIZE)
-        - -pod-name
-        - $(POD_NAME)
-        - -pod-ip
-        - $(POD_IP)
-        - -api-version
-        - $(ETCDCTL_API)
-        - -token
-        - $(TOKEN)
-        command:
-        - /opt/bin/etcd-launcher
+      - command:
+        - /bin/sh
+        - -ec
+        - |
+          export MASTER_ENDPOINT="https://etcd-0.etcd.cluster-de-test-01.svc.cluster.local:2379"
+
+          export INITIAL_STATE="new"
+          export INITIAL_CLUSTER="etcd-0=http://etcd-0.etcd.cluster-de-test-01.svc.cluster.local:2380,etcd-1=http://etcd-1.etcd.cluster-de-test-01.svc.cluster.local:2380,etcd-2=http://etcd-2.etcd.cluster-de-test-01.svc.cluster.local:2380"
+
+          echo "initial-state: ${INITIAL_STATE}"
+          echo "initial-cluster: ${INITIAL_CLUSTER}"
+
+          exec /usr/local/bin/etcd \
+              --name=${POD_NAME} \
+              --data-dir="/var/run/etcd/pod_${POD_NAME}/" \
+              --initial-cluster=${INITIAL_CLUSTER} \
+              --initial-cluster-token="de-test-01" \
+              --initial-cluster-state=${INITIAL_STATE} \
+              --advertise-client-urls "https://${POD_NAME}.etcd.cluster-de-test-01.svc.cluster.local:2379,https://${POD_IP}:2379" \
+              --listen-client-urls "https://${POD_IP}:2379,https://127.0.0.1:2379" \
+              --listen-peer-urls "http://${POD_IP}:2380" \
+              --listen-metrics-urls "http://${POD_IP}:2378,http://127.0.0.1:2378" \
+              --initial-advertise-peer-urls "http://${POD_NAME}.etcd.cluster-de-test-01.svc.cluster.local:2380" \
+              --trusted-ca-file /etc/etcd/pki/ca/ca.crt \
+              --client-cert-auth \
+              --cert-file /etc/etcd/pki/tls/etcd-tls.crt \
+              --key-file /etc/etcd/pki/tls/etcd-tls.key \
+              --auto-compaction-retention=8
         env:
         - name: POD_NAME
           valueFrom:
@@ -138,18 +151,6 @@ spec:
           name: launcher
       imagePullSecrets:
       - name: dockercfg
-      initContainers:
-      - command:
-        - /bin/cp
-        - /etcd-launcher
-        - /opt/bin/
-        image: 'quay.io/kubermatic/etcd-launcher:'
-        imagePullPolicy: IfNotPresent
-        name: etcd-launcher-init
-        resources: {}
-        volumeMounts:
-        - mountPath: /opt/bin/
-          name: launcher
       serviceAccountName: etcd-launcher
       volumes:
       - name: etcd-tls-certificate

--- a/pkg/resources/test/fixtures/statefulset-digitalocean-1.17.0-etcd.yaml
+++ b/pkg/resources/test/fixtures/statefulset-digitalocean-1.17.0-etcd.yaml
@@ -39,21 +39,34 @@ spec:
               topologyKey: kubernetes.io/hostname
             weight: 10
       containers:
-      - args:
-        - -namespace
-        - $(NAMESPACE)
-        - -etcd-cluster-size
-        - $(ETCD_CLUSTER_SIZE)
-        - -pod-name
-        - $(POD_NAME)
-        - -pod-ip
-        - $(POD_IP)
-        - -api-version
-        - $(ETCDCTL_API)
-        - -token
-        - $(TOKEN)
-        command:
-        - /opt/bin/etcd-launcher
+      - command:
+        - /bin/sh
+        - -ec
+        - |
+          export MASTER_ENDPOINT="https://etcd-0.etcd.cluster-de-test-01.svc.cluster.local:2379"
+
+          export INITIAL_STATE="new"
+          export INITIAL_CLUSTER="etcd-0=http://etcd-0.etcd.cluster-de-test-01.svc.cluster.local:2380,etcd-1=http://etcd-1.etcd.cluster-de-test-01.svc.cluster.local:2380,etcd-2=http://etcd-2.etcd.cluster-de-test-01.svc.cluster.local:2380"
+
+          echo "initial-state: ${INITIAL_STATE}"
+          echo "initial-cluster: ${INITIAL_CLUSTER}"
+
+          exec /usr/local/bin/etcd \
+              --name=${POD_NAME} \
+              --data-dir="/var/run/etcd/pod_${POD_NAME}/" \
+              --initial-cluster=${INITIAL_CLUSTER} \
+              --initial-cluster-token="de-test-01" \
+              --initial-cluster-state=${INITIAL_STATE} \
+              --advertise-client-urls "https://${POD_NAME}.etcd.cluster-de-test-01.svc.cluster.local:2379,https://${POD_IP}:2379" \
+              --listen-client-urls "https://${POD_IP}:2379,https://127.0.0.1:2379" \
+              --listen-peer-urls "http://${POD_IP}:2380" \
+              --listen-metrics-urls "http://${POD_IP}:2378,http://127.0.0.1:2378" \
+              --initial-advertise-peer-urls "http://${POD_NAME}.etcd.cluster-de-test-01.svc.cluster.local:2380" \
+              --trusted-ca-file /etc/etcd/pki/ca/ca.crt \
+              --client-cert-auth \
+              --cert-file /etc/etcd/pki/tls/etcd-tls.crt \
+              --key-file /etc/etcd/pki/tls/etcd-tls.key \
+              --auto-compaction-retention=8
         env:
         - name: POD_NAME
           valueFrom:
@@ -138,18 +151,6 @@ spec:
           name: launcher
       imagePullSecrets:
       - name: dockercfg
-      initContainers:
-      - command:
-        - /bin/cp
-        - /etcd-launcher
-        - /opt/bin/
-        image: 'quay.io/kubermatic/etcd-launcher:'
-        imagePullPolicy: IfNotPresent
-        name: etcd-launcher-init
-        resources: {}
-        volumeMounts:
-        - mountPath: /opt/bin/
-          name: launcher
       serviceAccountName: etcd-launcher
       volumes:
       - name: etcd-tls-certificate

--- a/pkg/resources/test/fixtures/statefulset-digitalocean-1.18.0-etcd.yaml
+++ b/pkg/resources/test/fixtures/statefulset-digitalocean-1.18.0-etcd.yaml
@@ -39,21 +39,34 @@ spec:
               topologyKey: kubernetes.io/hostname
             weight: 10
       containers:
-      - args:
-        - -namespace
-        - $(NAMESPACE)
-        - -etcd-cluster-size
-        - $(ETCD_CLUSTER_SIZE)
-        - -pod-name
-        - $(POD_NAME)
-        - -pod-ip
-        - $(POD_IP)
-        - -api-version
-        - $(ETCDCTL_API)
-        - -token
-        - $(TOKEN)
-        command:
-        - /opt/bin/etcd-launcher
+      - command:
+        - /bin/sh
+        - -ec
+        - |
+          export MASTER_ENDPOINT="https://etcd-0.etcd.cluster-de-test-01.svc.cluster.local:2379"
+
+          export INITIAL_STATE="new"
+          export INITIAL_CLUSTER="etcd-0=http://etcd-0.etcd.cluster-de-test-01.svc.cluster.local:2380,etcd-1=http://etcd-1.etcd.cluster-de-test-01.svc.cluster.local:2380,etcd-2=http://etcd-2.etcd.cluster-de-test-01.svc.cluster.local:2380"
+
+          echo "initial-state: ${INITIAL_STATE}"
+          echo "initial-cluster: ${INITIAL_CLUSTER}"
+
+          exec /usr/local/bin/etcd \
+              --name=${POD_NAME} \
+              --data-dir="/var/run/etcd/pod_${POD_NAME}/" \
+              --initial-cluster=${INITIAL_CLUSTER} \
+              --initial-cluster-token="de-test-01" \
+              --initial-cluster-state=${INITIAL_STATE} \
+              --advertise-client-urls "https://${POD_NAME}.etcd.cluster-de-test-01.svc.cluster.local:2379,https://${POD_IP}:2379" \
+              --listen-client-urls "https://${POD_IP}:2379,https://127.0.0.1:2379" \
+              --listen-peer-urls "http://${POD_IP}:2380" \
+              --listen-metrics-urls "http://${POD_IP}:2378,http://127.0.0.1:2378" \
+              --initial-advertise-peer-urls "http://${POD_NAME}.etcd.cluster-de-test-01.svc.cluster.local:2380" \
+              --trusted-ca-file /etc/etcd/pki/ca/ca.crt \
+              --client-cert-auth \
+              --cert-file /etc/etcd/pki/tls/etcd-tls.crt \
+              --key-file /etc/etcd/pki/tls/etcd-tls.key \
+              --auto-compaction-retention=8
         env:
         - name: POD_NAME
           valueFrom:
@@ -138,18 +151,6 @@ spec:
           name: launcher
       imagePullSecrets:
       - name: dockercfg
-      initContainers:
-      - command:
-        - /bin/cp
-        - /etcd-launcher
-        - /opt/bin/
-        image: 'quay.io/kubermatic/etcd-launcher:'
-        imagePullPolicy: IfNotPresent
-        name: etcd-launcher-init
-        resources: {}
-        volumeMounts:
-        - mountPath: /opt/bin/
-          name: launcher
       serviceAccountName: etcd-launcher
       volumes:
       - name: etcd-tls-certificate

--- a/pkg/resources/test/fixtures/statefulset-digitalocean-1.19.0-etcd.yaml
+++ b/pkg/resources/test/fixtures/statefulset-digitalocean-1.19.0-etcd.yaml
@@ -39,21 +39,34 @@ spec:
               topologyKey: kubernetes.io/hostname
             weight: 10
       containers:
-      - args:
-        - -namespace
-        - $(NAMESPACE)
-        - -etcd-cluster-size
-        - $(ETCD_CLUSTER_SIZE)
-        - -pod-name
-        - $(POD_NAME)
-        - -pod-ip
-        - $(POD_IP)
-        - -api-version
-        - $(ETCDCTL_API)
-        - -token
-        - $(TOKEN)
-        command:
-        - /opt/bin/etcd-launcher
+      - command:
+        - /bin/sh
+        - -ec
+        - |
+          export MASTER_ENDPOINT="https://etcd-0.etcd.cluster-de-test-01.svc.cluster.local:2379"
+
+          export INITIAL_STATE="new"
+          export INITIAL_CLUSTER="etcd-0=http://etcd-0.etcd.cluster-de-test-01.svc.cluster.local:2380,etcd-1=http://etcd-1.etcd.cluster-de-test-01.svc.cluster.local:2380,etcd-2=http://etcd-2.etcd.cluster-de-test-01.svc.cluster.local:2380"
+
+          echo "initial-state: ${INITIAL_STATE}"
+          echo "initial-cluster: ${INITIAL_CLUSTER}"
+
+          exec /usr/local/bin/etcd \
+              --name=${POD_NAME} \
+              --data-dir="/var/run/etcd/pod_${POD_NAME}/" \
+              --initial-cluster=${INITIAL_CLUSTER} \
+              --initial-cluster-token="de-test-01" \
+              --initial-cluster-state=${INITIAL_STATE} \
+              --advertise-client-urls "https://${POD_NAME}.etcd.cluster-de-test-01.svc.cluster.local:2379,https://${POD_IP}:2379" \
+              --listen-client-urls "https://${POD_IP}:2379,https://127.0.0.1:2379" \
+              --listen-peer-urls "http://${POD_IP}:2380" \
+              --listen-metrics-urls "http://${POD_IP}:2378,http://127.0.0.1:2378" \
+              --initial-advertise-peer-urls "http://${POD_NAME}.etcd.cluster-de-test-01.svc.cluster.local:2380" \
+              --trusted-ca-file /etc/etcd/pki/ca/ca.crt \
+              --client-cert-auth \
+              --cert-file /etc/etcd/pki/tls/etcd-tls.crt \
+              --key-file /etc/etcd/pki/tls/etcd-tls.key \
+              --auto-compaction-retention=8
         env:
         - name: POD_NAME
           valueFrom:
@@ -138,18 +151,6 @@ spec:
           name: launcher
       imagePullSecrets:
       - name: dockercfg
-      initContainers:
-      - command:
-        - /bin/cp
-        - /etcd-launcher
-        - /opt/bin/
-        image: 'quay.io/kubermatic/etcd-launcher:'
-        imagePullPolicy: IfNotPresent
-        name: etcd-launcher-init
-        resources: {}
-        volumeMounts:
-        - mountPath: /opt/bin/
-          name: launcher
       serviceAccountName: etcd-launcher
       volumes:
       - name: etcd-tls-certificate

--- a/pkg/resources/test/fixtures/statefulset-openstack-1.16.0-etcd.yaml
+++ b/pkg/resources/test/fixtures/statefulset-openstack-1.16.0-etcd.yaml
@@ -39,21 +39,34 @@ spec:
               topologyKey: kubernetes.io/hostname
             weight: 10
       containers:
-      - args:
-        - -namespace
-        - $(NAMESPACE)
-        - -etcd-cluster-size
-        - $(ETCD_CLUSTER_SIZE)
-        - -pod-name
-        - $(POD_NAME)
-        - -pod-ip
-        - $(POD_IP)
-        - -api-version
-        - $(ETCDCTL_API)
-        - -token
-        - $(TOKEN)
-        command:
-        - /opt/bin/etcd-launcher
+      - command:
+        - /bin/sh
+        - -ec
+        - |
+          export MASTER_ENDPOINT="https://etcd-0.etcd.cluster-de-test-01.svc.cluster.local:2379"
+
+          export INITIAL_STATE="new"
+          export INITIAL_CLUSTER="etcd-0=http://etcd-0.etcd.cluster-de-test-01.svc.cluster.local:2380,etcd-1=http://etcd-1.etcd.cluster-de-test-01.svc.cluster.local:2380,etcd-2=http://etcd-2.etcd.cluster-de-test-01.svc.cluster.local:2380"
+
+          echo "initial-state: ${INITIAL_STATE}"
+          echo "initial-cluster: ${INITIAL_CLUSTER}"
+
+          exec /usr/local/bin/etcd \
+              --name=${POD_NAME} \
+              --data-dir="/var/run/etcd/pod_${POD_NAME}/" \
+              --initial-cluster=${INITIAL_CLUSTER} \
+              --initial-cluster-token="de-test-01" \
+              --initial-cluster-state=${INITIAL_STATE} \
+              --advertise-client-urls "https://${POD_NAME}.etcd.cluster-de-test-01.svc.cluster.local:2379,https://${POD_IP}:2379" \
+              --listen-client-urls "https://${POD_IP}:2379,https://127.0.0.1:2379" \
+              --listen-peer-urls "http://${POD_IP}:2380" \
+              --listen-metrics-urls "http://${POD_IP}:2378,http://127.0.0.1:2378" \
+              --initial-advertise-peer-urls "http://${POD_NAME}.etcd.cluster-de-test-01.svc.cluster.local:2380" \
+              --trusted-ca-file /etc/etcd/pki/ca/ca.crt \
+              --client-cert-auth \
+              --cert-file /etc/etcd/pki/tls/etcd-tls.crt \
+              --key-file /etc/etcd/pki/tls/etcd-tls.key \
+              --auto-compaction-retention=8
         env:
         - name: POD_NAME
           valueFrom:
@@ -138,18 +151,6 @@ spec:
           name: launcher
       imagePullSecrets:
       - name: dockercfg
-      initContainers:
-      - command:
-        - /bin/cp
-        - /etcd-launcher
-        - /opt/bin/
-        image: 'quay.io/kubermatic/etcd-launcher:'
-        imagePullPolicy: IfNotPresent
-        name: etcd-launcher-init
-        resources: {}
-        volumeMounts:
-        - mountPath: /opt/bin/
-          name: launcher
       serviceAccountName: etcd-launcher
       volumes:
       - name: etcd-tls-certificate

--- a/pkg/resources/test/fixtures/statefulset-openstack-1.17.0-etcd.yaml
+++ b/pkg/resources/test/fixtures/statefulset-openstack-1.17.0-etcd.yaml
@@ -39,21 +39,34 @@ spec:
               topologyKey: kubernetes.io/hostname
             weight: 10
       containers:
-      - args:
-        - -namespace
-        - $(NAMESPACE)
-        - -etcd-cluster-size
-        - $(ETCD_CLUSTER_SIZE)
-        - -pod-name
-        - $(POD_NAME)
-        - -pod-ip
-        - $(POD_IP)
-        - -api-version
-        - $(ETCDCTL_API)
-        - -token
-        - $(TOKEN)
-        command:
-        - /opt/bin/etcd-launcher
+      - command:
+        - /bin/sh
+        - -ec
+        - |
+          export MASTER_ENDPOINT="https://etcd-0.etcd.cluster-de-test-01.svc.cluster.local:2379"
+
+          export INITIAL_STATE="new"
+          export INITIAL_CLUSTER="etcd-0=http://etcd-0.etcd.cluster-de-test-01.svc.cluster.local:2380,etcd-1=http://etcd-1.etcd.cluster-de-test-01.svc.cluster.local:2380,etcd-2=http://etcd-2.etcd.cluster-de-test-01.svc.cluster.local:2380"
+
+          echo "initial-state: ${INITIAL_STATE}"
+          echo "initial-cluster: ${INITIAL_CLUSTER}"
+
+          exec /usr/local/bin/etcd \
+              --name=${POD_NAME} \
+              --data-dir="/var/run/etcd/pod_${POD_NAME}/" \
+              --initial-cluster=${INITIAL_CLUSTER} \
+              --initial-cluster-token="de-test-01" \
+              --initial-cluster-state=${INITIAL_STATE} \
+              --advertise-client-urls "https://${POD_NAME}.etcd.cluster-de-test-01.svc.cluster.local:2379,https://${POD_IP}:2379" \
+              --listen-client-urls "https://${POD_IP}:2379,https://127.0.0.1:2379" \
+              --listen-peer-urls "http://${POD_IP}:2380" \
+              --listen-metrics-urls "http://${POD_IP}:2378,http://127.0.0.1:2378" \
+              --initial-advertise-peer-urls "http://${POD_NAME}.etcd.cluster-de-test-01.svc.cluster.local:2380" \
+              --trusted-ca-file /etc/etcd/pki/ca/ca.crt \
+              --client-cert-auth \
+              --cert-file /etc/etcd/pki/tls/etcd-tls.crt \
+              --key-file /etc/etcd/pki/tls/etcd-tls.key \
+              --auto-compaction-retention=8
         env:
         - name: POD_NAME
           valueFrom:
@@ -138,18 +151,6 @@ spec:
           name: launcher
       imagePullSecrets:
       - name: dockercfg
-      initContainers:
-      - command:
-        - /bin/cp
-        - /etcd-launcher
-        - /opt/bin/
-        image: 'quay.io/kubermatic/etcd-launcher:'
-        imagePullPolicy: IfNotPresent
-        name: etcd-launcher-init
-        resources: {}
-        volumeMounts:
-        - mountPath: /opt/bin/
-          name: launcher
       serviceAccountName: etcd-launcher
       volumes:
       - name: etcd-tls-certificate

--- a/pkg/resources/test/fixtures/statefulset-openstack-1.18.0-etcd.yaml
+++ b/pkg/resources/test/fixtures/statefulset-openstack-1.18.0-etcd.yaml
@@ -39,21 +39,34 @@ spec:
               topologyKey: kubernetes.io/hostname
             weight: 10
       containers:
-      - args:
-        - -namespace
-        - $(NAMESPACE)
-        - -etcd-cluster-size
-        - $(ETCD_CLUSTER_SIZE)
-        - -pod-name
-        - $(POD_NAME)
-        - -pod-ip
-        - $(POD_IP)
-        - -api-version
-        - $(ETCDCTL_API)
-        - -token
-        - $(TOKEN)
-        command:
-        - /opt/bin/etcd-launcher
+      - command:
+        - /bin/sh
+        - -ec
+        - |
+          export MASTER_ENDPOINT="https://etcd-0.etcd.cluster-de-test-01.svc.cluster.local:2379"
+
+          export INITIAL_STATE="new"
+          export INITIAL_CLUSTER="etcd-0=http://etcd-0.etcd.cluster-de-test-01.svc.cluster.local:2380,etcd-1=http://etcd-1.etcd.cluster-de-test-01.svc.cluster.local:2380,etcd-2=http://etcd-2.etcd.cluster-de-test-01.svc.cluster.local:2380"
+
+          echo "initial-state: ${INITIAL_STATE}"
+          echo "initial-cluster: ${INITIAL_CLUSTER}"
+
+          exec /usr/local/bin/etcd \
+              --name=${POD_NAME} \
+              --data-dir="/var/run/etcd/pod_${POD_NAME}/" \
+              --initial-cluster=${INITIAL_CLUSTER} \
+              --initial-cluster-token="de-test-01" \
+              --initial-cluster-state=${INITIAL_STATE} \
+              --advertise-client-urls "https://${POD_NAME}.etcd.cluster-de-test-01.svc.cluster.local:2379,https://${POD_IP}:2379" \
+              --listen-client-urls "https://${POD_IP}:2379,https://127.0.0.1:2379" \
+              --listen-peer-urls "http://${POD_IP}:2380" \
+              --listen-metrics-urls "http://${POD_IP}:2378,http://127.0.0.1:2378" \
+              --initial-advertise-peer-urls "http://${POD_NAME}.etcd.cluster-de-test-01.svc.cluster.local:2380" \
+              --trusted-ca-file /etc/etcd/pki/ca/ca.crt \
+              --client-cert-auth \
+              --cert-file /etc/etcd/pki/tls/etcd-tls.crt \
+              --key-file /etc/etcd/pki/tls/etcd-tls.key \
+              --auto-compaction-retention=8
         env:
         - name: POD_NAME
           valueFrom:
@@ -138,18 +151,6 @@ spec:
           name: launcher
       imagePullSecrets:
       - name: dockercfg
-      initContainers:
-      - command:
-        - /bin/cp
-        - /etcd-launcher
-        - /opt/bin/
-        image: 'quay.io/kubermatic/etcd-launcher:'
-        imagePullPolicy: IfNotPresent
-        name: etcd-launcher-init
-        resources: {}
-        volumeMounts:
-        - mountPath: /opt/bin/
-          name: launcher
       serviceAccountName: etcd-launcher
       volumes:
       - name: etcd-tls-certificate

--- a/pkg/resources/test/fixtures/statefulset-openstack-1.19.0-etcd.yaml
+++ b/pkg/resources/test/fixtures/statefulset-openstack-1.19.0-etcd.yaml
@@ -39,21 +39,34 @@ spec:
               topologyKey: kubernetes.io/hostname
             weight: 10
       containers:
-      - args:
-        - -namespace
-        - $(NAMESPACE)
-        - -etcd-cluster-size
-        - $(ETCD_CLUSTER_SIZE)
-        - -pod-name
-        - $(POD_NAME)
-        - -pod-ip
-        - $(POD_IP)
-        - -api-version
-        - $(ETCDCTL_API)
-        - -token
-        - $(TOKEN)
-        command:
-        - /opt/bin/etcd-launcher
+      - command:
+        - /bin/sh
+        - -ec
+        - |
+          export MASTER_ENDPOINT="https://etcd-0.etcd.cluster-de-test-01.svc.cluster.local:2379"
+
+          export INITIAL_STATE="new"
+          export INITIAL_CLUSTER="etcd-0=http://etcd-0.etcd.cluster-de-test-01.svc.cluster.local:2380,etcd-1=http://etcd-1.etcd.cluster-de-test-01.svc.cluster.local:2380,etcd-2=http://etcd-2.etcd.cluster-de-test-01.svc.cluster.local:2380"
+
+          echo "initial-state: ${INITIAL_STATE}"
+          echo "initial-cluster: ${INITIAL_CLUSTER}"
+
+          exec /usr/local/bin/etcd \
+              --name=${POD_NAME} \
+              --data-dir="/var/run/etcd/pod_${POD_NAME}/" \
+              --initial-cluster=${INITIAL_CLUSTER} \
+              --initial-cluster-token="de-test-01" \
+              --initial-cluster-state=${INITIAL_STATE} \
+              --advertise-client-urls "https://${POD_NAME}.etcd.cluster-de-test-01.svc.cluster.local:2379,https://${POD_IP}:2379" \
+              --listen-client-urls "https://${POD_IP}:2379,https://127.0.0.1:2379" \
+              --listen-peer-urls "http://${POD_IP}:2380" \
+              --listen-metrics-urls "http://${POD_IP}:2378,http://127.0.0.1:2378" \
+              --initial-advertise-peer-urls "http://${POD_NAME}.etcd.cluster-de-test-01.svc.cluster.local:2380" \
+              --trusted-ca-file /etc/etcd/pki/ca/ca.crt \
+              --client-cert-auth \
+              --cert-file /etc/etcd/pki/tls/etcd-tls.crt \
+              --key-file /etc/etcd/pki/tls/etcd-tls.key \
+              --auto-compaction-retention=8
         env:
         - name: POD_NAME
           valueFrom:
@@ -138,18 +151,6 @@ spec:
           name: launcher
       imagePullSecrets:
       - name: dockercfg
-      initContainers:
-      - command:
-        - /bin/cp
-        - /etcd-launcher
-        - /opt/bin/
-        image: 'quay.io/kubermatic/etcd-launcher:'
-        imagePullPolicy: IfNotPresent
-        name: etcd-launcher-init
-        resources: {}
-        volumeMounts:
-        - mountPath: /opt/bin/
-          name: launcher
       serviceAccountName: etcd-launcher
       volumes:
       - name: etcd-tls-certificate

--- a/pkg/resources/test/fixtures/statefulset-vsphere-1.16.0-etcd.yaml
+++ b/pkg/resources/test/fixtures/statefulset-vsphere-1.16.0-etcd.yaml
@@ -39,21 +39,34 @@ spec:
               topologyKey: kubernetes.io/hostname
             weight: 10
       containers:
-      - args:
-        - -namespace
-        - $(NAMESPACE)
-        - -etcd-cluster-size
-        - $(ETCD_CLUSTER_SIZE)
-        - -pod-name
-        - $(POD_NAME)
-        - -pod-ip
-        - $(POD_IP)
-        - -api-version
-        - $(ETCDCTL_API)
-        - -token
-        - $(TOKEN)
-        command:
-        - /opt/bin/etcd-launcher
+      - command:
+        - /bin/sh
+        - -ec
+        - |
+          export MASTER_ENDPOINT="https://etcd-0.etcd.cluster-de-test-01.svc.cluster.local:2379"
+
+          export INITIAL_STATE="new"
+          export INITIAL_CLUSTER="etcd-0=http://etcd-0.etcd.cluster-de-test-01.svc.cluster.local:2380,etcd-1=http://etcd-1.etcd.cluster-de-test-01.svc.cluster.local:2380,etcd-2=http://etcd-2.etcd.cluster-de-test-01.svc.cluster.local:2380"
+
+          echo "initial-state: ${INITIAL_STATE}"
+          echo "initial-cluster: ${INITIAL_CLUSTER}"
+
+          exec /usr/local/bin/etcd \
+              --name=${POD_NAME} \
+              --data-dir="/var/run/etcd/pod_${POD_NAME}/" \
+              --initial-cluster=${INITIAL_CLUSTER} \
+              --initial-cluster-token="de-test-01" \
+              --initial-cluster-state=${INITIAL_STATE} \
+              --advertise-client-urls "https://${POD_NAME}.etcd.cluster-de-test-01.svc.cluster.local:2379,https://${POD_IP}:2379" \
+              --listen-client-urls "https://${POD_IP}:2379,https://127.0.0.1:2379" \
+              --listen-peer-urls "http://${POD_IP}:2380" \
+              --listen-metrics-urls "http://${POD_IP}:2378,http://127.0.0.1:2378" \
+              --initial-advertise-peer-urls "http://${POD_NAME}.etcd.cluster-de-test-01.svc.cluster.local:2380" \
+              --trusted-ca-file /etc/etcd/pki/ca/ca.crt \
+              --client-cert-auth \
+              --cert-file /etc/etcd/pki/tls/etcd-tls.crt \
+              --key-file /etc/etcd/pki/tls/etcd-tls.key \
+              --auto-compaction-retention=8
         env:
         - name: POD_NAME
           valueFrom:
@@ -138,18 +151,6 @@ spec:
           name: launcher
       imagePullSecrets:
       - name: dockercfg
-      initContainers:
-      - command:
-        - /bin/cp
-        - /etcd-launcher
-        - /opt/bin/
-        image: 'quay.io/kubermatic/etcd-launcher:'
-        imagePullPolicy: IfNotPresent
-        name: etcd-launcher-init
-        resources: {}
-        volumeMounts:
-        - mountPath: /opt/bin/
-          name: launcher
       serviceAccountName: etcd-launcher
       volumes:
       - name: etcd-tls-certificate

--- a/pkg/resources/test/fixtures/statefulset-vsphere-1.17.0-etcd.yaml
+++ b/pkg/resources/test/fixtures/statefulset-vsphere-1.17.0-etcd.yaml
@@ -39,21 +39,34 @@ spec:
               topologyKey: kubernetes.io/hostname
             weight: 10
       containers:
-      - args:
-        - -namespace
-        - $(NAMESPACE)
-        - -etcd-cluster-size
-        - $(ETCD_CLUSTER_SIZE)
-        - -pod-name
-        - $(POD_NAME)
-        - -pod-ip
-        - $(POD_IP)
-        - -api-version
-        - $(ETCDCTL_API)
-        - -token
-        - $(TOKEN)
-        command:
-        - /opt/bin/etcd-launcher
+      - command:
+        - /bin/sh
+        - -ec
+        - |
+          export MASTER_ENDPOINT="https://etcd-0.etcd.cluster-de-test-01.svc.cluster.local:2379"
+
+          export INITIAL_STATE="new"
+          export INITIAL_CLUSTER="etcd-0=http://etcd-0.etcd.cluster-de-test-01.svc.cluster.local:2380,etcd-1=http://etcd-1.etcd.cluster-de-test-01.svc.cluster.local:2380,etcd-2=http://etcd-2.etcd.cluster-de-test-01.svc.cluster.local:2380"
+
+          echo "initial-state: ${INITIAL_STATE}"
+          echo "initial-cluster: ${INITIAL_CLUSTER}"
+
+          exec /usr/local/bin/etcd \
+              --name=${POD_NAME} \
+              --data-dir="/var/run/etcd/pod_${POD_NAME}/" \
+              --initial-cluster=${INITIAL_CLUSTER} \
+              --initial-cluster-token="de-test-01" \
+              --initial-cluster-state=${INITIAL_STATE} \
+              --advertise-client-urls "https://${POD_NAME}.etcd.cluster-de-test-01.svc.cluster.local:2379,https://${POD_IP}:2379" \
+              --listen-client-urls "https://${POD_IP}:2379,https://127.0.0.1:2379" \
+              --listen-peer-urls "http://${POD_IP}:2380" \
+              --listen-metrics-urls "http://${POD_IP}:2378,http://127.0.0.1:2378" \
+              --initial-advertise-peer-urls "http://${POD_NAME}.etcd.cluster-de-test-01.svc.cluster.local:2380" \
+              --trusted-ca-file /etc/etcd/pki/ca/ca.crt \
+              --client-cert-auth \
+              --cert-file /etc/etcd/pki/tls/etcd-tls.crt \
+              --key-file /etc/etcd/pki/tls/etcd-tls.key \
+              --auto-compaction-retention=8
         env:
         - name: POD_NAME
           valueFrom:
@@ -138,18 +151,6 @@ spec:
           name: launcher
       imagePullSecrets:
       - name: dockercfg
-      initContainers:
-      - command:
-        - /bin/cp
-        - /etcd-launcher
-        - /opt/bin/
-        image: 'quay.io/kubermatic/etcd-launcher:'
-        imagePullPolicy: IfNotPresent
-        name: etcd-launcher-init
-        resources: {}
-        volumeMounts:
-        - mountPath: /opt/bin/
-          name: launcher
       serviceAccountName: etcd-launcher
       volumes:
       - name: etcd-tls-certificate

--- a/pkg/resources/test/fixtures/statefulset-vsphere-1.18.0-etcd.yaml
+++ b/pkg/resources/test/fixtures/statefulset-vsphere-1.18.0-etcd.yaml
@@ -39,21 +39,34 @@ spec:
               topologyKey: kubernetes.io/hostname
             weight: 10
       containers:
-      - args:
-        - -namespace
-        - $(NAMESPACE)
-        - -etcd-cluster-size
-        - $(ETCD_CLUSTER_SIZE)
-        - -pod-name
-        - $(POD_NAME)
-        - -pod-ip
-        - $(POD_IP)
-        - -api-version
-        - $(ETCDCTL_API)
-        - -token
-        - $(TOKEN)
-        command:
-        - /opt/bin/etcd-launcher
+      - command:
+        - /bin/sh
+        - -ec
+        - |
+          export MASTER_ENDPOINT="https://etcd-0.etcd.cluster-de-test-01.svc.cluster.local:2379"
+
+          export INITIAL_STATE="new"
+          export INITIAL_CLUSTER="etcd-0=http://etcd-0.etcd.cluster-de-test-01.svc.cluster.local:2380,etcd-1=http://etcd-1.etcd.cluster-de-test-01.svc.cluster.local:2380,etcd-2=http://etcd-2.etcd.cluster-de-test-01.svc.cluster.local:2380"
+
+          echo "initial-state: ${INITIAL_STATE}"
+          echo "initial-cluster: ${INITIAL_CLUSTER}"
+
+          exec /usr/local/bin/etcd \
+              --name=${POD_NAME} \
+              --data-dir="/var/run/etcd/pod_${POD_NAME}/" \
+              --initial-cluster=${INITIAL_CLUSTER} \
+              --initial-cluster-token="de-test-01" \
+              --initial-cluster-state=${INITIAL_STATE} \
+              --advertise-client-urls "https://${POD_NAME}.etcd.cluster-de-test-01.svc.cluster.local:2379,https://${POD_IP}:2379" \
+              --listen-client-urls "https://${POD_IP}:2379,https://127.0.0.1:2379" \
+              --listen-peer-urls "http://${POD_IP}:2380" \
+              --listen-metrics-urls "http://${POD_IP}:2378,http://127.0.0.1:2378" \
+              --initial-advertise-peer-urls "http://${POD_NAME}.etcd.cluster-de-test-01.svc.cluster.local:2380" \
+              --trusted-ca-file /etc/etcd/pki/ca/ca.crt \
+              --client-cert-auth \
+              --cert-file /etc/etcd/pki/tls/etcd-tls.crt \
+              --key-file /etc/etcd/pki/tls/etcd-tls.key \
+              --auto-compaction-retention=8
         env:
         - name: POD_NAME
           valueFrom:
@@ -138,18 +151,6 @@ spec:
           name: launcher
       imagePullSecrets:
       - name: dockercfg
-      initContainers:
-      - command:
-        - /bin/cp
-        - /etcd-launcher
-        - /opt/bin/
-        image: 'quay.io/kubermatic/etcd-launcher:'
-        imagePullPolicy: IfNotPresent
-        name: etcd-launcher-init
-        resources: {}
-        volumeMounts:
-        - mountPath: /opt/bin/
-          name: launcher
       serviceAccountName: etcd-launcher
       volumes:
       - name: etcd-tls-certificate

--- a/pkg/resources/test/fixtures/statefulset-vsphere-1.19.0-etcd.yaml
+++ b/pkg/resources/test/fixtures/statefulset-vsphere-1.19.0-etcd.yaml
@@ -39,21 +39,34 @@ spec:
               topologyKey: kubernetes.io/hostname
             weight: 10
       containers:
-      - args:
-        - -namespace
-        - $(NAMESPACE)
-        - -etcd-cluster-size
-        - $(ETCD_CLUSTER_SIZE)
-        - -pod-name
-        - $(POD_NAME)
-        - -pod-ip
-        - $(POD_IP)
-        - -api-version
-        - $(ETCDCTL_API)
-        - -token
-        - $(TOKEN)
-        command:
-        - /opt/bin/etcd-launcher
+      - command:
+        - /bin/sh
+        - -ec
+        - |
+          export MASTER_ENDPOINT="https://etcd-0.etcd.cluster-de-test-01.svc.cluster.local:2379"
+
+          export INITIAL_STATE="new"
+          export INITIAL_CLUSTER="etcd-0=http://etcd-0.etcd.cluster-de-test-01.svc.cluster.local:2380,etcd-1=http://etcd-1.etcd.cluster-de-test-01.svc.cluster.local:2380,etcd-2=http://etcd-2.etcd.cluster-de-test-01.svc.cluster.local:2380"
+
+          echo "initial-state: ${INITIAL_STATE}"
+          echo "initial-cluster: ${INITIAL_CLUSTER}"
+
+          exec /usr/local/bin/etcd \
+              --name=${POD_NAME} \
+              --data-dir="/var/run/etcd/pod_${POD_NAME}/" \
+              --initial-cluster=${INITIAL_CLUSTER} \
+              --initial-cluster-token="de-test-01" \
+              --initial-cluster-state=${INITIAL_STATE} \
+              --advertise-client-urls "https://${POD_NAME}.etcd.cluster-de-test-01.svc.cluster.local:2379,https://${POD_IP}:2379" \
+              --listen-client-urls "https://${POD_IP}:2379,https://127.0.0.1:2379" \
+              --listen-peer-urls "http://${POD_IP}:2380" \
+              --listen-metrics-urls "http://${POD_IP}:2378,http://127.0.0.1:2378" \
+              --initial-advertise-peer-urls "http://${POD_NAME}.etcd.cluster-de-test-01.svc.cluster.local:2380" \
+              --trusted-ca-file /etc/etcd/pki/ca/ca.crt \
+              --client-cert-auth \
+              --cert-file /etc/etcd/pki/tls/etcd-tls.crt \
+              --key-file /etc/etcd/pki/tls/etcd-tls.key \
+              --auto-compaction-retention=8
         env:
         - name: POD_NAME
           valueFrom:
@@ -138,18 +151,6 @@ spec:
           name: launcher
       imagePullSecrets:
       - name: dockercfg
-      initContainers:
-      - command:
-        - /bin/cp
-        - /etcd-launcher
-        - /opt/bin/
-        image: 'quay.io/kubermatic/etcd-launcher:'
-        imagePullPolicy: IfNotPresent
-        name: etcd-launcher-init
-        resources: {}
-        volumeMounts:
-        - mountPath: /opt/bin/
-          name: launcher
       serviceAccountName: etcd-launcher
       volumes:
       - name: etcd-tls-certificate


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR introduces a feature flag for the etcd-launcher feature initially added in #5536. It also handles the situations where existing clusters already have the etcd-launcher enabled, to avoid breaking etcd on weekly releases upgrades.
**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Documentation**:
<!-- Add links to the related documentation changes related to this pull request. E.g. the link to the kubermatic/docs pullrequest. -->

**Does this PR introduce a user-facing change?**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If  no release note is required, just write "NONE".
-->
```release-note
Adds feature flag `etcdLauncher` around etcd-launcher.
```
