### PR TITLE
[release/v2.14] Fix GitHub Release Script (#5855)

### DIFF
--- a/api/hack/ci/ci-github-release.sh
+++ b/api/hack/ci/ci-github-release.sh
@@ -67,7 +67,7 @@ function upload_archive {
     -H "Accept: application/json" \
     -H 'Content-Type: application/gzip' \
     -s --data-binary "@${file}")
-  if echo "${res}" | jq -e; then
+  if echo "${res}" | jq -e '.'; then
     # it the response contain errors
     if echo "${res}" | jq -e '.errors[0]'; then
       for err in $(echo "${res}" | jq -r '.errors[0].code'); do


### PR DESCRIPTION
**What this PR does / why we need it**:
This backports the jq fix for the github release script (#5855).

**Does this PR introduce a user-facing change?**:
```release-note
NONE
```
