### PR TITLE
bump version of oauth2-proxy, add flag to add custom prover CA

### DIFF
--- a/charts/iap/Chart.yaml
+++ b/charts/iap/Chart.yaml
@@ -14,8 +14,8 @@
 
 apiVersion: v1
 name: iap
-version: 2.0.0
-appVersion: v6.0.0
+version: 3.0.0
+appVersion: v6.1.1
 description: A Helm chart to install OAuth2-Proxy as an identity-aware proxy.
 keywords:
 - kubermatic

--- a/charts/iap/templates/deployments.yaml
+++ b/charts/iap/templates/deployments.yaml
@@ -42,6 +42,9 @@ spec:
         imagePullPolicy: {{ $.Values.iap.image.pullPolicy }}
         args:
         - --provider=oidc
+        {{- if .Values.iap.custom_provider_ca_secret }}
+        - --provider-ca-file=/etc/ssl/certs/ca.crt
+        {{- end }}
         - --oidc-issuer-url={{ $.Values.iap.oidc_issuer_url }}
         - --http-address=0.0.0.0:{{ $.Values.iap.port }}
         - --upstream=http://{{ .upstream_service }}:{{ .upstream_port }}
@@ -76,6 +79,10 @@ spec:
         volumeMounts:
         - name: config
           mountPath: /config
+        {{- if .Values.iap.custom_provider_ca_secret }}
+        - name: ca
+          mountPath: /etc/ssl/certs               
+        {{- end }}  
       volumes:
       - name: config
         configMap:
@@ -83,6 +90,14 @@ spec:
           items:
           - key: config.yaml
             path: config.yaml
+      {{- if .Values.iap.custom_provider_ca_secret }}
+      - name: ca
+        secret:
+          secretName: {{ .Values.iap.custom_provider_ca_secret }}
+          items:
+          - key: ca.crt
+            path: ca.crt            
+      {{- end }}            
       securityContext:
         fsGroup: 65534
         runAsNonRoot: true

--- a/charts/iap/values.yaml
+++ b/charts/iap/values.yaml
@@ -15,9 +15,11 @@
 iap:
   image:
     repository: quay.io/oauth2-proxy/oauth2-proxy
-    tag: v6.0.0
+    tag: v6.1.1
     pullPolicy: IfNotPresent
 
+  # custom_provider_ca_secret: provider-ca-secret 
+  
   oidc_issuer_url: https://kubermatic.tld/dex
   port: 3000
 

--- a/charts/iap/values.yaml
+++ b/charts/iap/values.yaml
@@ -18,6 +18,7 @@ iap:
     tag: v6.1.1
     pullPolicy: IfNotPresent
 
+  # secret which holds the CA certificates that should be used when connecting to the provider  
   # custom_provider_ca_secret: provider-ca-secret 
   
   oidc_issuer_url: https://kubermatic.tld/dex


### PR DESCRIPTION
**What this PR does / why we need it**:

Customers should be able to add their custom CA.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

oauth2-proxy needs a version push to support the flag `--provider-ca-file`

**Documentation**:
https://oauth2-proxy.github.io/oauth2-proxy/configuration

**Does this PR introduce a user-facing change?**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If  no release note is required, just write "NONE".
-->
```release-note
NONE
```
