### PR TITLE
Fix path changing in e2e tests

### DIFF
--- a/hack/ci/run-api-e2e.sh
+++ b/hack/ci/run-api-e2e.sh
@@ -21,9 +21,9 @@
 set -euo pipefail
 
 cd $(dirname $0)/../..
-source ./hack/lib.sh
+source hack/lib.sh
 
-source ./hack/ci/setup-kubermatic-in-kind.sh
+source hack/ci/setup-kubermatic-in-kind.sh
 
 echodate "Creating UI Azure preset..."
 cat <<EOF > preset-azure.yaml

--- a/hack/ci/setup-kubermatic-in-kind.sh
+++ b/hack/ci/setup-kubermatic-in-kind.sh
@@ -21,7 +21,6 @@
 ### This script should be sourced, not called, so callers get the variables
 ### it sets.
 
-cd $(dirname $0)/../..
 source hack/lib.sh
 
 if [ -z "${JOB_NAME:-}" ]; then

--- a/hack/ci/setup-legacy-kubermatic-in-kind.sh
+++ b/hack/ci/setup-legacy-kubermatic-in-kind.sh
@@ -21,7 +21,6 @@
 ### This script should be sourced, not called, so callers get the variables
 ### it sets.
 
-cd $(dirname $0)/../..
 source hack/lib.sh
 
 if [ -z "${JOB_NAME:-}" ]; then


### PR DESCRIPTION
**What this PR does / why we need it**:
Back in the old days, we always ran our test scripts with `./hack/ci/....`. Since we removed the `ci-` prefix, the new jobs do a `cd hack/ci; ./run-....`o, so the dirname() is now `.` and not `hack/ci/` anymore. This then confused the setup scripts, which tried to perform a relativ path change and ended up outside of the repository.

This PR fixes that by simply making it so that the sourced scripts do not `cd` anymore.

**Does this PR introduce a user-facing change?**:
```release-note
NONE
```
