### PR TITLE
make canary release compatible with jq 1.5

### DIFF
--- a/hack/ci/github-release.sh
+++ b/hack/ci/github-release.sh
@@ -79,7 +79,7 @@ function create_release {
        --arg name "$name" \
        --arg prerelease "$prerelease" \
        --arg body "$body" \
-       '$ARGS.named'
+       '{"tag_name":$tag_name,"name":$name,"prerelease":$prerelease,"body":$body}'
   )"
 
   github_cli \


### PR DESCRIPTION
**What this PR does / why we need it**:
Pretty much what it says on the tin. `$ARGS` is a 1.6+ thing.

**Does this PR introduce a user-facing change?**:
```release-note
NONE
```
