### PR TITLE
Fix GitHub release again

### DIFF
--- a/hack/ci/github-release.sh
+++ b/hack/ci/github-release.sh
@@ -77,7 +77,7 @@ function create_release {
     jq --null-input \
        --arg tag_name "$tag" \
        --arg name "$name" \
-       --arg prerelease "$prerelease" \
+       --argjson prerelease "$prerelease" \
        --arg body "$body" \
        '{"tag_name":$tag_name,"name":$name,"prerelease":$prerelease,"body":$body}'
   )"


### PR DESCRIPTION
**What this PR does / why we need it**:
Booleans should stay booleans.

**Does this PR introduce a user-facing change?**:
```release-note
NONE
```
