### PR TITLE
[release/v2.14] Migrate from google_containers to k8s.gcr.io Docker registry

### DIFF
--- a/api/pkg/resources/apiserver/deployment.go
+++ b/api/pkg/resources/apiserver/deployment.go
@@ -142,7 +142,7 @@ func DeploymentCreator(data *resources.TemplateData, enableOIDCAuthentication bo
 				*dnatControllerSidecar,
 				{
 					Name:    resources.ApiserverDeploymentName,
-					Image:   data.ImageRegistry(resources.RegistryGCR) + "/google_containers/hyperkube-amd64:v" + data.Cluster().Spec.Version.String(),
+					Image:   data.ImageRegistry(resources.RegistryK8SGCR) + "/hyperkube-amd64:v" + data.Cluster().Spec.Version.String(),
 					Command: []string{"/hyperkube", "kube-apiserver"},
 					Env:     envVars,
 					Args:    flags,

--- a/api/pkg/resources/controllermanager/deployment.go
+++ b/api/pkg/resources/controllermanager/deployment.go
@@ -155,7 +155,7 @@ func DeploymentCreator(data *resources.TemplateData) reconciling.NamedDeployment
 				*openvpnSidecar,
 				{
 					Name:    resources.ControllerManagerDeploymentName,
-					Image:   data.ImageRegistry(resources.RegistryGCR) + "/google_containers/hyperkube-amd64:v" + data.Cluster().Spec.Version.String(),
+					Image:   data.ImageRegistry(resources.RegistryK8SGCR) + "/hyperkube-amd64:v" + data.Cluster().Spec.Version.String(),
 					Command: []string{"/hyperkube", "kube-controller-manager"},
 					Args:    flags,
 					Env:     envVars,

--- a/api/pkg/resources/dns/dns.go
+++ b/api/pkg/resources/dns/dns.go
@@ -93,7 +93,7 @@ func DeploymentCreator(data deploymentCreatorData) reconciling.NamedDeploymentCr
 				*openvpnSidecar,
 				{
 					Name:  resources.DNSResolverDeploymentName,
-					Image: data.ImageRegistry(resources.RegistryGCR) + "/google_containers/coredns:1.3.1",
+					Image: data.ImageRegistry(resources.RegistryK8SGCR) + "/coredns:1.3.1",
 					Args:  []string{"-conf", "/etc/coredns/Corefile"},
 					VolumeMounts: []corev1.VolumeMount{
 						{

--- a/api/pkg/resources/metrics-server/deployment.go
+++ b/api/pkg/resources/metrics-server/deployment.go
@@ -102,7 +102,7 @@ func DeploymentCreator(data metricsServerData) reconciling.NamedDeploymentCreato
 			dep.Spec.Template.Spec.Containers = []corev1.Container{
 				{
 					Name:    name,
-					Image:   data.ImageRegistry(resources.RegistryGCR) + "/google_containers/metrics-server-amd64:" + tag,
+					Image:   data.ImageRegistry(resources.RegistryK8SGCR) + "/metrics-server-amd64:" + tag,
 					Command: []string{"/metrics-server"},
 					Args: []string{
 						"--kubeconfig", "/etc/kubernetes/kubeconfig/kubeconfig",

--- a/api/pkg/resources/resources.go
+++ b/api/pkg/resources/resources.go
@@ -308,6 +308,8 @@ const (
 	// EtcdClusterSize defines the size of the etcd to use
 	EtcdClusterSize = 3
 
+	// RegistryK8SGCR defines the kubernetes specific docker registry at google
+	RegistryK8SGCR = "k8s.gcr.io"
 	// RegistryGCR defines the kubernetes docker registry at google
 	RegistryGCR = "gcr.io"
 	// RegistryDocker defines the default docker.io registry

--- a/api/pkg/resources/scheduler/deployment.go
+++ b/api/pkg/resources/scheduler/deployment.go
@@ -103,7 +103,7 @@ func DeploymentCreator(data *resources.TemplateData) reconciling.NamedDeployment
 				*openvpnSidecar,
 				{
 					Name:    resources.SchedulerDeploymentName,
-					Image:   data.ImageRegistry(resources.RegistryGCR) + "/google_containers/hyperkube-amd64:v" + data.Cluster().Spec.Version.String(),
+					Image:   data.ImageRegistry(resources.RegistryK8SGCR) + "/hyperkube-amd64:v" + data.Cluster().Spec.Version.String(),
 					Command: []string{"/hyperkube", "kube-scheduler"},
 					Args:    flags,
 					VolumeMounts: []corev1.VolumeMount{

--- a/api/pkg/resources/test/fixtures/deployment-aws-1.15.0-apiserver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-aws-1.15.0-apiserver.yaml
@@ -238,7 +238,7 @@ spec:
           value: apiserver-external.cluster-de-test-01.svc.cluster.local.
         - name: no_proxy
           value: apiserver-external.cluster-de-test-01.svc.cluster.local.
-        image: gcr.io/google_containers/hyperkube-amd64:v1.15.0
+        image: k8s.gcr.io/hyperkube-amd64:v1.15.0
         livenessProbe:
           failureThreshold: 8
           httpGet:

--- a/api/pkg/resources/test/fixtures/deployment-aws-1.15.0-controller-manager.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-aws-1.15.0-controller-manager.yaml
@@ -129,7 +129,7 @@ spec:
           value: apiserver-external.cluster-de-test-01.svc.cluster.local.
         - name: no_proxy
           value: apiserver-external.cluster-de-test-01.svc.cluster.local.
-        image: gcr.io/google_containers/hyperkube-amd64:v1.15.0
+        image: k8s.gcr.io/hyperkube-amd64:v1.15.0
         livenessProbe:
           failureThreshold: 8
           httpGet:

--- a/api/pkg/resources/test/fixtures/deployment-aws-1.15.0-dns-resolver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-aws-1.15.0-dns-resolver.yaml
@@ -97,7 +97,7 @@ spec:
       - args:
         - -conf
         - /etc/coredns/Corefile
-        image: gcr.io/google_containers/coredns:1.3.1
+        image: k8s.gcr.io/coredns:1.3.1
         name: dns-resolver
         readinessProbe:
           failureThreshold: 3

--- a/api/pkg/resources/test/fixtures/deployment-aws-1.15.0-metrics-server.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-aws-1.15.0-metrics-server.yaml
@@ -51,7 +51,7 @@ spec:
         - '{"command":"/metrics-server","args":["--kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","--authentication-kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","--authorization-kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","--kubelet-port","10250","--kubelet-insecure-tls","--kubelet-preferred-address-types","ExternalIP,InternalIP","--v","1","--logtostderr","--tls-cert-file","/etc/serving-cert/serving.crt","--tls-private-key-file","/etc/serving-cert/serving.key"]}'
         command:
         - /http-prober-bin/http-prober
-        image: gcr.io/google_containers/metrics-server-amd64:v0.3.6
+        image: k8s.gcr.io/metrics-server-amd64:v0.3.6
         name: metrics-server
         resources:
           limits:

--- a/api/pkg/resources/test/fixtures/deployment-aws-1.15.0-scheduler.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-aws-1.15.0-scheduler.yaml
@@ -108,7 +108,7 @@ spec:
         - '{"command":"/hyperkube","args":["kube-scheduler","--kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","--authentication-kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","--authorization-kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","--client-ca-file","/etc/kubernetes/pki/ca/ca.crt","--port","0","--authentication-tolerate-lookup-failure","false"]}'
         command:
         - /http-prober-bin/http-prober
-        image: gcr.io/google_containers/hyperkube-amd64:v1.15.0
+        image: k8s.gcr.io/hyperkube-amd64:v1.15.0
         livenessProbe:
           failureThreshold: 8
           httpGet:

--- a/api/pkg/resources/test/fixtures/deployment-aws-1.16.0-apiserver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-aws-1.16.0-apiserver.yaml
@@ -238,7 +238,7 @@ spec:
           value: apiserver-external.cluster-de-test-01.svc.cluster.local.
         - name: no_proxy
           value: apiserver-external.cluster-de-test-01.svc.cluster.local.
-        image: gcr.io/google_containers/hyperkube-amd64:v1.16.0
+        image: k8s.gcr.io/hyperkube-amd64:v1.16.0
         livenessProbe:
           failureThreshold: 8
           httpGet:

--- a/api/pkg/resources/test/fixtures/deployment-aws-1.16.0-controller-manager.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-aws-1.16.0-controller-manager.yaml
@@ -129,7 +129,7 @@ spec:
           value: apiserver-external.cluster-de-test-01.svc.cluster.local.
         - name: no_proxy
           value: apiserver-external.cluster-de-test-01.svc.cluster.local.
-        image: gcr.io/google_containers/hyperkube-amd64:v1.16.0
+        image: k8s.gcr.io/hyperkube-amd64:v1.16.0
         livenessProbe:
           failureThreshold: 8
           httpGet:

--- a/api/pkg/resources/test/fixtures/deployment-aws-1.16.0-dns-resolver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-aws-1.16.0-dns-resolver.yaml
@@ -97,7 +97,7 @@ spec:
       - args:
         - -conf
         - /etc/coredns/Corefile
-        image: gcr.io/google_containers/coredns:1.3.1
+        image: k8s.gcr.io/coredns:1.3.1
         name: dns-resolver
         readinessProbe:
           failureThreshold: 3

--- a/api/pkg/resources/test/fixtures/deployment-aws-1.16.0-metrics-server.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-aws-1.16.0-metrics-server.yaml
@@ -51,7 +51,7 @@ spec:
         - '{"command":"/metrics-server","args":["--kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","--authentication-kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","--authorization-kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","--kubelet-port","10250","--kubelet-insecure-tls","--kubelet-preferred-address-types","ExternalIP,InternalIP","--v","1","--logtostderr","--tls-cert-file","/etc/serving-cert/serving.crt","--tls-private-key-file","/etc/serving-cert/serving.key"]}'
         command:
         - /http-prober-bin/http-prober
-        image: gcr.io/google_containers/metrics-server-amd64:v0.3.6
+        image: k8s.gcr.io/metrics-server-amd64:v0.3.6
         name: metrics-server
         resources:
           limits:

--- a/api/pkg/resources/test/fixtures/deployment-aws-1.16.0-scheduler.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-aws-1.16.0-scheduler.yaml
@@ -108,7 +108,7 @@ spec:
         - '{"command":"/hyperkube","args":["kube-scheduler","--kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","--authentication-kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","--authorization-kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","--client-ca-file","/etc/kubernetes/pki/ca/ca.crt","--port","0","--authentication-tolerate-lookup-failure","false"]}'
         command:
         - /http-prober-bin/http-prober
-        image: gcr.io/google_containers/hyperkube-amd64:v1.16.0
+        image: k8s.gcr.io/hyperkube-amd64:v1.16.0
         livenessProbe:
           failureThreshold: 8
           httpGet:

--- a/api/pkg/resources/test/fixtures/deployment-aws-1.17.0-apiserver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-aws-1.17.0-apiserver.yaml
@@ -238,7 +238,7 @@ spec:
           value: apiserver-external.cluster-de-test-01.svc.cluster.local.
         - name: no_proxy
           value: apiserver-external.cluster-de-test-01.svc.cluster.local.
-        image: gcr.io/google_containers/hyperkube-amd64:v1.17.0
+        image: k8s.gcr.io/hyperkube-amd64:v1.17.0
         livenessProbe:
           failureThreshold: 8
           httpGet:

--- a/api/pkg/resources/test/fixtures/deployment-aws-1.17.0-controller-manager.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-aws-1.17.0-controller-manager.yaml
@@ -129,7 +129,7 @@ spec:
           value: apiserver-external.cluster-de-test-01.svc.cluster.local.
         - name: no_proxy
           value: apiserver-external.cluster-de-test-01.svc.cluster.local.
-        image: gcr.io/google_containers/hyperkube-amd64:v1.17.0
+        image: k8s.gcr.io/hyperkube-amd64:v1.17.0
         livenessProbe:
           failureThreshold: 8
           httpGet:

--- a/api/pkg/resources/test/fixtures/deployment-aws-1.17.0-dns-resolver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-aws-1.17.0-dns-resolver.yaml
@@ -97,7 +97,7 @@ spec:
       - args:
         - -conf
         - /etc/coredns/Corefile
-        image: gcr.io/google_containers/coredns:1.3.1
+        image: k8s.gcr.io/coredns:1.3.1
         name: dns-resolver
         readinessProbe:
           failureThreshold: 3

--- a/api/pkg/resources/test/fixtures/deployment-aws-1.17.0-metrics-server.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-aws-1.17.0-metrics-server.yaml
@@ -51,7 +51,7 @@ spec:
         - '{"command":"/metrics-server","args":["--kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","--authentication-kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","--authorization-kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","--kubelet-port","10250","--kubelet-insecure-tls","--kubelet-preferred-address-types","ExternalIP,InternalIP","--v","1","--logtostderr","--tls-cert-file","/etc/serving-cert/serving.crt","--tls-private-key-file","/etc/serving-cert/serving.key"]}'
         command:
         - /http-prober-bin/http-prober
-        image: gcr.io/google_containers/metrics-server-amd64:v0.3.6
+        image: k8s.gcr.io/metrics-server-amd64:v0.3.6
         name: metrics-server
         resources:
           limits:

--- a/api/pkg/resources/test/fixtures/deployment-aws-1.17.0-scheduler.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-aws-1.17.0-scheduler.yaml
@@ -108,7 +108,7 @@ spec:
         - '{"command":"/hyperkube","args":["kube-scheduler","--kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","--authentication-kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","--authorization-kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","--client-ca-file","/etc/kubernetes/pki/ca/ca.crt","--port","0","--authentication-tolerate-lookup-failure","false"]}'
         command:
         - /http-prober-bin/http-prober
-        image: gcr.io/google_containers/hyperkube-amd64:v1.17.0
+        image: k8s.gcr.io/hyperkube-amd64:v1.17.0
         livenessProbe:
           failureThreshold: 8
           httpGet:

--- a/api/pkg/resources/test/fixtures/deployment-aws-1.18.0-apiserver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-aws-1.18.0-apiserver.yaml
@@ -238,7 +238,7 @@ spec:
           value: apiserver-external.cluster-de-test-01.svc.cluster.local.
         - name: no_proxy
           value: apiserver-external.cluster-de-test-01.svc.cluster.local.
-        image: gcr.io/google_containers/hyperkube-amd64:v1.18.0
+        image: k8s.gcr.io/hyperkube-amd64:v1.18.0
         livenessProbe:
           failureThreshold: 8
           httpGet:

--- a/api/pkg/resources/test/fixtures/deployment-aws-1.18.0-controller-manager.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-aws-1.18.0-controller-manager.yaml
@@ -129,7 +129,7 @@ spec:
           value: apiserver-external.cluster-de-test-01.svc.cluster.local.
         - name: no_proxy
           value: apiserver-external.cluster-de-test-01.svc.cluster.local.
-        image: gcr.io/google_containers/hyperkube-amd64:v1.18.0
+        image: k8s.gcr.io/hyperkube-amd64:v1.18.0
         livenessProbe:
           failureThreshold: 8
           httpGet:

--- a/api/pkg/resources/test/fixtures/deployment-aws-1.18.0-dns-resolver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-aws-1.18.0-dns-resolver.yaml
@@ -97,7 +97,7 @@ spec:
       - args:
         - -conf
         - /etc/coredns/Corefile
-        image: gcr.io/google_containers/coredns:1.3.1
+        image: k8s.gcr.io/coredns:1.3.1
         name: dns-resolver
         readinessProbe:
           failureThreshold: 3

--- a/api/pkg/resources/test/fixtures/deployment-aws-1.18.0-metrics-server.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-aws-1.18.0-metrics-server.yaml
@@ -51,7 +51,7 @@ spec:
         - '{"command":"/metrics-server","args":["--kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","--authentication-kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","--authorization-kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","--kubelet-port","10250","--kubelet-insecure-tls","--kubelet-preferred-address-types","ExternalIP,InternalIP","--v","1","--logtostderr","--tls-cert-file","/etc/serving-cert/serving.crt","--tls-private-key-file","/etc/serving-cert/serving.key"]}'
         command:
         - /http-prober-bin/http-prober
-        image: gcr.io/google_containers/metrics-server-amd64:v0.3.6
+        image: k8s.gcr.io/metrics-server-amd64:v0.3.6
         name: metrics-server
         resources:
           limits:

--- a/api/pkg/resources/test/fixtures/deployment-aws-1.18.0-scheduler.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-aws-1.18.0-scheduler.yaml
@@ -108,7 +108,7 @@ spec:
         - '{"command":"/hyperkube","args":["kube-scheduler","--kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","--authentication-kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","--authorization-kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","--client-ca-file","/etc/kubernetes/pki/ca/ca.crt","--port","0","--authentication-tolerate-lookup-failure","false"]}'
         command:
         - /http-prober-bin/http-prober
-        image: gcr.io/google_containers/hyperkube-amd64:v1.18.0
+        image: k8s.gcr.io/hyperkube-amd64:v1.18.0
         livenessProbe:
           failureThreshold: 8
           httpGet:

--- a/api/pkg/resources/test/fixtures/deployment-azure-1.15.0-apiserver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-azure-1.15.0-apiserver.yaml
@@ -232,7 +232,7 @@ spec:
           value: apiserver-external.cluster-de-test-01.svc.cluster.local.
         - name: no_proxy
           value: apiserver-external.cluster-de-test-01.svc.cluster.local.
-        image: gcr.io/google_containers/hyperkube-amd64:v1.15.0
+        image: k8s.gcr.io/hyperkube-amd64:v1.15.0
         livenessProbe:
           failureThreshold: 8
           httpGet:

--- a/api/pkg/resources/test/fixtures/deployment-azure-1.15.0-controller-manager.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-azure-1.15.0-controller-manager.yaml
@@ -123,7 +123,7 @@ spec:
           value: apiserver-external.cluster-de-test-01.svc.cluster.local.
         - name: no_proxy
           value: apiserver-external.cluster-de-test-01.svc.cluster.local.
-        image: gcr.io/google_containers/hyperkube-amd64:v1.15.0
+        image: k8s.gcr.io/hyperkube-amd64:v1.15.0
         livenessProbe:
           failureThreshold: 8
           httpGet:

--- a/api/pkg/resources/test/fixtures/deployment-azure-1.15.0-dns-resolver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-azure-1.15.0-dns-resolver.yaml
@@ -97,7 +97,7 @@ spec:
       - args:
         - -conf
         - /etc/coredns/Corefile
-        image: gcr.io/google_containers/coredns:1.3.1
+        image: k8s.gcr.io/coredns:1.3.1
         name: dns-resolver
         readinessProbe:
           failureThreshold: 3

--- a/api/pkg/resources/test/fixtures/deployment-azure-1.15.0-metrics-server.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-azure-1.15.0-metrics-server.yaml
@@ -51,7 +51,7 @@ spec:
         - '{"command":"/metrics-server","args":["--kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","--authentication-kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","--authorization-kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","--kubelet-port","10250","--kubelet-insecure-tls","--kubelet-preferred-address-types","ExternalIP,InternalIP","--v","1","--logtostderr","--tls-cert-file","/etc/serving-cert/serving.crt","--tls-private-key-file","/etc/serving-cert/serving.key"]}'
         command:
         - /http-prober-bin/http-prober
-        image: gcr.io/google_containers/metrics-server-amd64:v0.3.6
+        image: k8s.gcr.io/metrics-server-amd64:v0.3.6
         name: metrics-server
         resources:
           limits:

--- a/api/pkg/resources/test/fixtures/deployment-azure-1.15.0-scheduler.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-azure-1.15.0-scheduler.yaml
@@ -108,7 +108,7 @@ spec:
         - '{"command":"/hyperkube","args":["kube-scheduler","--kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","--authentication-kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","--authorization-kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","--client-ca-file","/etc/kubernetes/pki/ca/ca.crt","--port","0","--authentication-tolerate-lookup-failure","false"]}'
         command:
         - /http-prober-bin/http-prober
-        image: gcr.io/google_containers/hyperkube-amd64:v1.15.0
+        image: k8s.gcr.io/hyperkube-amd64:v1.15.0
         livenessProbe:
           failureThreshold: 8
           httpGet:

--- a/api/pkg/resources/test/fixtures/deployment-azure-1.16.0-apiserver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-azure-1.16.0-apiserver.yaml
@@ -232,7 +232,7 @@ spec:
           value: apiserver-external.cluster-de-test-01.svc.cluster.local.
         - name: no_proxy
           value: apiserver-external.cluster-de-test-01.svc.cluster.local.
-        image: gcr.io/google_containers/hyperkube-amd64:v1.16.0
+        image: k8s.gcr.io/hyperkube-amd64:v1.16.0
         livenessProbe:
           failureThreshold: 8
           httpGet:

--- a/api/pkg/resources/test/fixtures/deployment-azure-1.16.0-controller-manager.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-azure-1.16.0-controller-manager.yaml
@@ -123,7 +123,7 @@ spec:
           value: apiserver-external.cluster-de-test-01.svc.cluster.local.
         - name: no_proxy
           value: apiserver-external.cluster-de-test-01.svc.cluster.local.
-        image: gcr.io/google_containers/hyperkube-amd64:v1.16.0
+        image: k8s.gcr.io/hyperkube-amd64:v1.16.0
         livenessProbe:
           failureThreshold: 8
           httpGet:

--- a/api/pkg/resources/test/fixtures/deployment-azure-1.16.0-dns-resolver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-azure-1.16.0-dns-resolver.yaml
@@ -97,7 +97,7 @@ spec:
       - args:
         - -conf
         - /etc/coredns/Corefile
-        image: gcr.io/google_containers/coredns:1.3.1
+        image: k8s.gcr.io/coredns:1.3.1
         name: dns-resolver
         readinessProbe:
           failureThreshold: 3

--- a/api/pkg/resources/test/fixtures/deployment-azure-1.16.0-metrics-server.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-azure-1.16.0-metrics-server.yaml
@@ -51,7 +51,7 @@ spec:
         - '{"command":"/metrics-server","args":["--kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","--authentication-kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","--authorization-kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","--kubelet-port","10250","--kubelet-insecure-tls","--kubelet-preferred-address-types","ExternalIP,InternalIP","--v","1","--logtostderr","--tls-cert-file","/etc/serving-cert/serving.crt","--tls-private-key-file","/etc/serving-cert/serving.key"]}'
         command:
         - /http-prober-bin/http-prober
-        image: gcr.io/google_containers/metrics-server-amd64:v0.3.6
+        image: k8s.gcr.io/metrics-server-amd64:v0.3.6
         name: metrics-server
         resources:
           limits:

--- a/api/pkg/resources/test/fixtures/deployment-azure-1.16.0-scheduler.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-azure-1.16.0-scheduler.yaml
@@ -108,7 +108,7 @@ spec:
         - '{"command":"/hyperkube","args":["kube-scheduler","--kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","--authentication-kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","--authorization-kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","--client-ca-file","/etc/kubernetes/pki/ca/ca.crt","--port","0","--authentication-tolerate-lookup-failure","false"]}'
         command:
         - /http-prober-bin/http-prober
-        image: gcr.io/google_containers/hyperkube-amd64:v1.16.0
+        image: k8s.gcr.io/hyperkube-amd64:v1.16.0
         livenessProbe:
           failureThreshold: 8
           httpGet:

--- a/api/pkg/resources/test/fixtures/deployment-azure-1.17.0-apiserver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-azure-1.17.0-apiserver.yaml
@@ -232,7 +232,7 @@ spec:
           value: apiserver-external.cluster-de-test-01.svc.cluster.local.
         - name: no_proxy
           value: apiserver-external.cluster-de-test-01.svc.cluster.local.
-        image: gcr.io/google_containers/hyperkube-amd64:v1.17.0
+        image: k8s.gcr.io/hyperkube-amd64:v1.17.0
         livenessProbe:
           failureThreshold: 8
           httpGet:

--- a/api/pkg/resources/test/fixtures/deployment-azure-1.17.0-controller-manager.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-azure-1.17.0-controller-manager.yaml
@@ -123,7 +123,7 @@ spec:
           value: apiserver-external.cluster-de-test-01.svc.cluster.local.
         - name: no_proxy
           value: apiserver-external.cluster-de-test-01.svc.cluster.local.
-        image: gcr.io/google_containers/hyperkube-amd64:v1.17.0
+        image: k8s.gcr.io/hyperkube-amd64:v1.17.0
         livenessProbe:
           failureThreshold: 8
           httpGet:

--- a/api/pkg/resources/test/fixtures/deployment-azure-1.17.0-dns-resolver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-azure-1.17.0-dns-resolver.yaml
@@ -97,7 +97,7 @@ spec:
       - args:
         - -conf
         - /etc/coredns/Corefile
-        image: gcr.io/google_containers/coredns:1.3.1
+        image: k8s.gcr.io/coredns:1.3.1
         name: dns-resolver
         readinessProbe:
           failureThreshold: 3

--- a/api/pkg/resources/test/fixtures/deployment-azure-1.17.0-metrics-server.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-azure-1.17.0-metrics-server.yaml
@@ -51,7 +51,7 @@ spec:
         - '{"command":"/metrics-server","args":["--kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","--authentication-kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","--authorization-kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","--kubelet-port","10250","--kubelet-insecure-tls","--kubelet-preferred-address-types","ExternalIP,InternalIP","--v","1","--logtostderr","--tls-cert-file","/etc/serving-cert/serving.crt","--tls-private-key-file","/etc/serving-cert/serving.key"]}'
         command:
         - /http-prober-bin/http-prober
-        image: gcr.io/google_containers/metrics-server-amd64:v0.3.6
+        image: k8s.gcr.io/metrics-server-amd64:v0.3.6
         name: metrics-server
         resources:
           limits:

--- a/api/pkg/resources/test/fixtures/deployment-azure-1.17.0-scheduler.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-azure-1.17.0-scheduler.yaml
@@ -108,7 +108,7 @@ spec:
         - '{"command":"/hyperkube","args":["kube-scheduler","--kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","--authentication-kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","--authorization-kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","--client-ca-file","/etc/kubernetes/pki/ca/ca.crt","--port","0","--authentication-tolerate-lookup-failure","false"]}'
         command:
         - /http-prober-bin/http-prober
-        image: gcr.io/google_containers/hyperkube-amd64:v1.17.0
+        image: k8s.gcr.io/hyperkube-amd64:v1.17.0
         livenessProbe:
           failureThreshold: 8
           httpGet:

--- a/api/pkg/resources/test/fixtures/deployment-azure-1.18.0-apiserver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-azure-1.18.0-apiserver.yaml
@@ -232,7 +232,7 @@ spec:
           value: apiserver-external.cluster-de-test-01.svc.cluster.local.
         - name: no_proxy
           value: apiserver-external.cluster-de-test-01.svc.cluster.local.
-        image: gcr.io/google_containers/hyperkube-amd64:v1.18.0
+        image: k8s.gcr.io/hyperkube-amd64:v1.18.0
         livenessProbe:
           failureThreshold: 8
           httpGet:

--- a/api/pkg/resources/test/fixtures/deployment-azure-1.18.0-controller-manager.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-azure-1.18.0-controller-manager.yaml
@@ -123,7 +123,7 @@ spec:
           value: apiserver-external.cluster-de-test-01.svc.cluster.local.
         - name: no_proxy
           value: apiserver-external.cluster-de-test-01.svc.cluster.local.
-        image: gcr.io/google_containers/hyperkube-amd64:v1.18.0
+        image: k8s.gcr.io/hyperkube-amd64:v1.18.0
         livenessProbe:
           failureThreshold: 8
           httpGet:

--- a/api/pkg/resources/test/fixtures/deployment-azure-1.18.0-dns-resolver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-azure-1.18.0-dns-resolver.yaml
@@ -97,7 +97,7 @@ spec:
       - args:
         - -conf
         - /etc/coredns/Corefile
-        image: gcr.io/google_containers/coredns:1.3.1
+        image: k8s.gcr.io/coredns:1.3.1
         name: dns-resolver
         readinessProbe:
           failureThreshold: 3

--- a/api/pkg/resources/test/fixtures/deployment-azure-1.18.0-metrics-server.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-azure-1.18.0-metrics-server.yaml
@@ -51,7 +51,7 @@ spec:
         - '{"command":"/metrics-server","args":["--kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","--authentication-kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","--authorization-kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","--kubelet-port","10250","--kubelet-insecure-tls","--kubelet-preferred-address-types","ExternalIP,InternalIP","--v","1","--logtostderr","--tls-cert-file","/etc/serving-cert/serving.crt","--tls-private-key-file","/etc/serving-cert/serving.key"]}'
         command:
         - /http-prober-bin/http-prober
-        image: gcr.io/google_containers/metrics-server-amd64:v0.3.6
+        image: k8s.gcr.io/metrics-server-amd64:v0.3.6
         name: metrics-server
         resources:
           limits:

--- a/api/pkg/resources/test/fixtures/deployment-azure-1.18.0-scheduler.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-azure-1.18.0-scheduler.yaml
@@ -108,7 +108,7 @@ spec:
         - '{"command":"/hyperkube","args":["kube-scheduler","--kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","--authentication-kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","--authorization-kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","--client-ca-file","/etc/kubernetes/pki/ca/ca.crt","--port","0","--authentication-tolerate-lookup-failure","false"]}'
         command:
         - /http-prober-bin/http-prober
-        image: gcr.io/google_containers/hyperkube-amd64:v1.18.0
+        image: k8s.gcr.io/hyperkube-amd64:v1.18.0
         livenessProbe:
           failureThreshold: 8
           httpGet:

--- a/api/pkg/resources/test/fixtures/deployment-bringyourown-1.15.0-apiserver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-bringyourown-1.15.0-apiserver.yaml
@@ -228,7 +228,7 @@ spec:
           value: apiserver-external.cluster-de-test-01.svc.cluster.local.
         - name: no_proxy
           value: apiserver-external.cluster-de-test-01.svc.cluster.local.
-        image: gcr.io/google_containers/hyperkube-amd64:v1.15.0
+        image: k8s.gcr.io/hyperkube-amd64:v1.15.0
         livenessProbe:
           failureThreshold: 8
           httpGet:

--- a/api/pkg/resources/test/fixtures/deployment-bringyourown-1.15.0-controller-manager.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-bringyourown-1.15.0-controller-manager.yaml
@@ -123,7 +123,7 @@ spec:
           value: apiserver-external.cluster-de-test-01.svc.cluster.local.
         - name: no_proxy
           value: apiserver-external.cluster-de-test-01.svc.cluster.local.
-        image: gcr.io/google_containers/hyperkube-amd64:v1.15.0
+        image: k8s.gcr.io/hyperkube-amd64:v1.15.0
         livenessProbe:
           failureThreshold: 8
           httpGet:

--- a/api/pkg/resources/test/fixtures/deployment-bringyourown-1.15.0-dns-resolver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-bringyourown-1.15.0-dns-resolver.yaml
@@ -97,7 +97,7 @@ spec:
       - args:
         - -conf
         - /etc/coredns/Corefile
-        image: gcr.io/google_containers/coredns:1.3.1
+        image: k8s.gcr.io/coredns:1.3.1
         name: dns-resolver
         readinessProbe:
           failureThreshold: 3

--- a/api/pkg/resources/test/fixtures/deployment-bringyourown-1.15.0-metrics-server.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-bringyourown-1.15.0-metrics-server.yaml
@@ -51,7 +51,7 @@ spec:
         - '{"command":"/metrics-server","args":["--kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","--authentication-kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","--authorization-kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","--kubelet-port","10250","--kubelet-insecure-tls","--kubelet-preferred-address-types","ExternalIP,InternalIP","--v","1","--logtostderr","--tls-cert-file","/etc/serving-cert/serving.crt","--tls-private-key-file","/etc/serving-cert/serving.key"]}'
         command:
         - /http-prober-bin/http-prober
-        image: gcr.io/google_containers/metrics-server-amd64:v0.3.6
+        image: k8s.gcr.io/metrics-server-amd64:v0.3.6
         name: metrics-server
         resources:
           limits:

--- a/api/pkg/resources/test/fixtures/deployment-bringyourown-1.15.0-scheduler.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-bringyourown-1.15.0-scheduler.yaml
@@ -108,7 +108,7 @@ spec:
         - '{"command":"/hyperkube","args":["kube-scheduler","--kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","--authentication-kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","--authorization-kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","--client-ca-file","/etc/kubernetes/pki/ca/ca.crt","--port","0","--authentication-tolerate-lookup-failure","false"]}'
         command:
         - /http-prober-bin/http-prober
-        image: gcr.io/google_containers/hyperkube-amd64:v1.15.0
+        image: k8s.gcr.io/hyperkube-amd64:v1.15.0
         livenessProbe:
           failureThreshold: 8
           httpGet:

--- a/api/pkg/resources/test/fixtures/deployment-bringyourown-1.16.0-apiserver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-bringyourown-1.16.0-apiserver.yaml
@@ -228,7 +228,7 @@ spec:
           value: apiserver-external.cluster-de-test-01.svc.cluster.local.
         - name: no_proxy
           value: apiserver-external.cluster-de-test-01.svc.cluster.local.
-        image: gcr.io/google_containers/hyperkube-amd64:v1.16.0
+        image: k8s.gcr.io/hyperkube-amd64:v1.16.0
         livenessProbe:
           failureThreshold: 8
           httpGet:

--- a/api/pkg/resources/test/fixtures/deployment-bringyourown-1.16.0-controller-manager.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-bringyourown-1.16.0-controller-manager.yaml
@@ -123,7 +123,7 @@ spec:
           value: apiserver-external.cluster-de-test-01.svc.cluster.local.
         - name: no_proxy
           value: apiserver-external.cluster-de-test-01.svc.cluster.local.
-        image: gcr.io/google_containers/hyperkube-amd64:v1.16.0
+        image: k8s.gcr.io/hyperkube-amd64:v1.16.0
         livenessProbe:
           failureThreshold: 8
           httpGet:

--- a/api/pkg/resources/test/fixtures/deployment-bringyourown-1.16.0-dns-resolver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-bringyourown-1.16.0-dns-resolver.yaml
@@ -97,7 +97,7 @@ spec:
       - args:
         - -conf
         - /etc/coredns/Corefile
-        image: gcr.io/google_containers/coredns:1.3.1
+        image: k8s.gcr.io/coredns:1.3.1
         name: dns-resolver
         readinessProbe:
           failureThreshold: 3

--- a/api/pkg/resources/test/fixtures/deployment-bringyourown-1.16.0-metrics-server.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-bringyourown-1.16.0-metrics-server.yaml
@@ -51,7 +51,7 @@ spec:
         - '{"command":"/metrics-server","args":["--kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","--authentication-kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","--authorization-kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","--kubelet-port","10250","--kubelet-insecure-tls","--kubelet-preferred-address-types","ExternalIP,InternalIP","--v","1","--logtostderr","--tls-cert-file","/etc/serving-cert/serving.crt","--tls-private-key-file","/etc/serving-cert/serving.key"]}'
         command:
         - /http-prober-bin/http-prober
-        image: gcr.io/google_containers/metrics-server-amd64:v0.3.6
+        image: k8s.gcr.io/metrics-server-amd64:v0.3.6
         name: metrics-server
         resources:
           limits:

--- a/api/pkg/resources/test/fixtures/deployment-bringyourown-1.16.0-scheduler.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-bringyourown-1.16.0-scheduler.yaml
@@ -108,7 +108,7 @@ spec:
         - '{"command":"/hyperkube","args":["kube-scheduler","--kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","--authentication-kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","--authorization-kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","--client-ca-file","/etc/kubernetes/pki/ca/ca.crt","--port","0","--authentication-tolerate-lookup-failure","false"]}'
         command:
         - /http-prober-bin/http-prober
-        image: gcr.io/google_containers/hyperkube-amd64:v1.16.0
+        image: k8s.gcr.io/hyperkube-amd64:v1.16.0
         livenessProbe:
           failureThreshold: 8
           httpGet:

--- a/api/pkg/resources/test/fixtures/deployment-bringyourown-1.17.0-apiserver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-bringyourown-1.17.0-apiserver.yaml
@@ -228,7 +228,7 @@ spec:
           value: apiserver-external.cluster-de-test-01.svc.cluster.local.
         - name: no_proxy
           value: apiserver-external.cluster-de-test-01.svc.cluster.local.
-        image: gcr.io/google_containers/hyperkube-amd64:v1.17.0
+        image: k8s.gcr.io/hyperkube-amd64:v1.17.0
         livenessProbe:
           failureThreshold: 8
           httpGet:

--- a/api/pkg/resources/test/fixtures/deployment-bringyourown-1.17.0-controller-manager.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-bringyourown-1.17.0-controller-manager.yaml
@@ -123,7 +123,7 @@ spec:
           value: apiserver-external.cluster-de-test-01.svc.cluster.local.
         - name: no_proxy
           value: apiserver-external.cluster-de-test-01.svc.cluster.local.
-        image: gcr.io/google_containers/hyperkube-amd64:v1.17.0
+        image: k8s.gcr.io/hyperkube-amd64:v1.17.0
         livenessProbe:
           failureThreshold: 8
           httpGet:

--- a/api/pkg/resources/test/fixtures/deployment-bringyourown-1.17.0-dns-resolver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-bringyourown-1.17.0-dns-resolver.yaml
@@ -97,7 +97,7 @@ spec:
       - args:
         - -conf
         - /etc/coredns/Corefile
-        image: gcr.io/google_containers/coredns:1.3.1
+        image: k8s.gcr.io/coredns:1.3.1
         name: dns-resolver
         readinessProbe:
           failureThreshold: 3

--- a/api/pkg/resources/test/fixtures/deployment-bringyourown-1.17.0-metrics-server.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-bringyourown-1.17.0-metrics-server.yaml
@@ -51,7 +51,7 @@ spec:
         - '{"command":"/metrics-server","args":["--kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","--authentication-kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","--authorization-kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","--kubelet-port","10250","--kubelet-insecure-tls","--kubelet-preferred-address-types","ExternalIP,InternalIP","--v","1","--logtostderr","--tls-cert-file","/etc/serving-cert/serving.crt","--tls-private-key-file","/etc/serving-cert/serving.key"]}'
         command:
         - /http-prober-bin/http-prober
-        image: gcr.io/google_containers/metrics-server-amd64:v0.3.6
+        image: k8s.gcr.io/metrics-server-amd64:v0.3.6
         name: metrics-server
         resources:
           limits:

--- a/api/pkg/resources/test/fixtures/deployment-bringyourown-1.17.0-scheduler.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-bringyourown-1.17.0-scheduler.yaml
@@ -108,7 +108,7 @@ spec:
         - '{"command":"/hyperkube","args":["kube-scheduler","--kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","--authentication-kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","--authorization-kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","--client-ca-file","/etc/kubernetes/pki/ca/ca.crt","--port","0","--authentication-tolerate-lookup-failure","false"]}'
         command:
         - /http-prober-bin/http-prober
-        image: gcr.io/google_containers/hyperkube-amd64:v1.17.0
+        image: k8s.gcr.io/hyperkube-amd64:v1.17.0
         livenessProbe:
           failureThreshold: 8
           httpGet:

--- a/api/pkg/resources/test/fixtures/deployment-bringyourown-1.18.0-apiserver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-bringyourown-1.18.0-apiserver.yaml
@@ -228,7 +228,7 @@ spec:
           value: apiserver-external.cluster-de-test-01.svc.cluster.local.
         - name: no_proxy
           value: apiserver-external.cluster-de-test-01.svc.cluster.local.
-        image: gcr.io/google_containers/hyperkube-amd64:v1.18.0
+        image: k8s.gcr.io/hyperkube-amd64:v1.18.0
         livenessProbe:
           failureThreshold: 8
           httpGet:

--- a/api/pkg/resources/test/fixtures/deployment-bringyourown-1.18.0-controller-manager.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-bringyourown-1.18.0-controller-manager.yaml
@@ -123,7 +123,7 @@ spec:
           value: apiserver-external.cluster-de-test-01.svc.cluster.local.
         - name: no_proxy
           value: apiserver-external.cluster-de-test-01.svc.cluster.local.
-        image: gcr.io/google_containers/hyperkube-amd64:v1.18.0
+        image: k8s.gcr.io/hyperkube-amd64:v1.18.0
         livenessProbe:
           failureThreshold: 8
           httpGet:

--- a/api/pkg/resources/test/fixtures/deployment-bringyourown-1.18.0-dns-resolver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-bringyourown-1.18.0-dns-resolver.yaml
@@ -97,7 +97,7 @@ spec:
       - args:
         - -conf
         - /etc/coredns/Corefile
-        image: gcr.io/google_containers/coredns:1.3.1
+        image: k8s.gcr.io/coredns:1.3.1
         name: dns-resolver
         readinessProbe:
           failureThreshold: 3

--- a/api/pkg/resources/test/fixtures/deployment-bringyourown-1.18.0-metrics-server.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-bringyourown-1.18.0-metrics-server.yaml
@@ -51,7 +51,7 @@ spec:
         - '{"command":"/metrics-server","args":["--kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","--authentication-kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","--authorization-kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","--kubelet-port","10250","--kubelet-insecure-tls","--kubelet-preferred-address-types","ExternalIP,InternalIP","--v","1","--logtostderr","--tls-cert-file","/etc/serving-cert/serving.crt","--tls-private-key-file","/etc/serving-cert/serving.key"]}'
         command:
         - /http-prober-bin/http-prober
-        image: gcr.io/google_containers/metrics-server-amd64:v0.3.6
+        image: k8s.gcr.io/metrics-server-amd64:v0.3.6
         name: metrics-server
         resources:
           limits:

--- a/api/pkg/resources/test/fixtures/deployment-bringyourown-1.18.0-scheduler.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-bringyourown-1.18.0-scheduler.yaml
@@ -108,7 +108,7 @@ spec:
         - '{"command":"/hyperkube","args":["kube-scheduler","--kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","--authentication-kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","--authorization-kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","--client-ca-file","/etc/kubernetes/pki/ca/ca.crt","--port","0","--authentication-tolerate-lookup-failure","false"]}'
         command:
         - /http-prober-bin/http-prober
-        image: gcr.io/google_containers/hyperkube-amd64:v1.18.0
+        image: k8s.gcr.io/hyperkube-amd64:v1.18.0
         livenessProbe:
           failureThreshold: 8
           httpGet:

--- a/api/pkg/resources/test/fixtures/deployment-digitalocean-1.15.0-apiserver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-digitalocean-1.15.0-apiserver.yaml
@@ -228,7 +228,7 @@ spec:
           value: apiserver-external.cluster-de-test-01.svc.cluster.local.
         - name: no_proxy
           value: apiserver-external.cluster-de-test-01.svc.cluster.local.
-        image: gcr.io/google_containers/hyperkube-amd64:v1.15.0
+        image: k8s.gcr.io/hyperkube-amd64:v1.15.0
         livenessProbe:
           failureThreshold: 8
           httpGet:

--- a/api/pkg/resources/test/fixtures/deployment-digitalocean-1.15.0-controller-manager.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-digitalocean-1.15.0-controller-manager.yaml
@@ -123,7 +123,7 @@ spec:
           value: apiserver-external.cluster-de-test-01.svc.cluster.local.
         - name: no_proxy
           value: apiserver-external.cluster-de-test-01.svc.cluster.local.
-        image: gcr.io/google_containers/hyperkube-amd64:v1.15.0
+        image: k8s.gcr.io/hyperkube-amd64:v1.15.0
         livenessProbe:
           failureThreshold: 8
           httpGet:

--- a/api/pkg/resources/test/fixtures/deployment-digitalocean-1.15.0-dns-resolver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-digitalocean-1.15.0-dns-resolver.yaml
@@ -97,7 +97,7 @@ spec:
       - args:
         - -conf
         - /etc/coredns/Corefile
-        image: gcr.io/google_containers/coredns:1.3.1
+        image: k8s.gcr.io/coredns:1.3.1
         name: dns-resolver
         readinessProbe:
           failureThreshold: 3

--- a/api/pkg/resources/test/fixtures/deployment-digitalocean-1.15.0-metrics-server.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-digitalocean-1.15.0-metrics-server.yaml
@@ -51,7 +51,7 @@ spec:
         - '{"command":"/metrics-server","args":["--kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","--authentication-kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","--authorization-kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","--kubelet-port","10250","--kubelet-insecure-tls","--kubelet-preferred-address-types","ExternalIP,InternalIP","--v","1","--logtostderr","--tls-cert-file","/etc/serving-cert/serving.crt","--tls-private-key-file","/etc/serving-cert/serving.key"]}'
         command:
         - /http-prober-bin/http-prober
-        image: gcr.io/google_containers/metrics-server-amd64:v0.3.6
+        image: k8s.gcr.io/metrics-server-amd64:v0.3.6
         name: metrics-server
         resources:
           limits:

--- a/api/pkg/resources/test/fixtures/deployment-digitalocean-1.15.0-scheduler.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-digitalocean-1.15.0-scheduler.yaml
@@ -108,7 +108,7 @@ spec:
         - '{"command":"/hyperkube","args":["kube-scheduler","--kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","--authentication-kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","--authorization-kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","--client-ca-file","/etc/kubernetes/pki/ca/ca.crt","--port","0","--authentication-tolerate-lookup-failure","false"]}'
         command:
         - /http-prober-bin/http-prober
-        image: gcr.io/google_containers/hyperkube-amd64:v1.15.0
+        image: k8s.gcr.io/hyperkube-amd64:v1.15.0
         livenessProbe:
           failureThreshold: 8
           httpGet:

--- a/api/pkg/resources/test/fixtures/deployment-digitalocean-1.16.0-apiserver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-digitalocean-1.16.0-apiserver.yaml
@@ -228,7 +228,7 @@ spec:
           value: apiserver-external.cluster-de-test-01.svc.cluster.local.
         - name: no_proxy
           value: apiserver-external.cluster-de-test-01.svc.cluster.local.
-        image: gcr.io/google_containers/hyperkube-amd64:v1.16.0
+        image: k8s.gcr.io/hyperkube-amd64:v1.16.0
         livenessProbe:
           failureThreshold: 8
           httpGet:

--- a/api/pkg/resources/test/fixtures/deployment-digitalocean-1.16.0-controller-manager.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-digitalocean-1.16.0-controller-manager.yaml
@@ -123,7 +123,7 @@ spec:
           value: apiserver-external.cluster-de-test-01.svc.cluster.local.
         - name: no_proxy
           value: apiserver-external.cluster-de-test-01.svc.cluster.local.
-        image: gcr.io/google_containers/hyperkube-amd64:v1.16.0
+        image: k8s.gcr.io/hyperkube-amd64:v1.16.0
         livenessProbe:
           failureThreshold: 8
           httpGet:

--- a/api/pkg/resources/test/fixtures/deployment-digitalocean-1.16.0-dns-resolver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-digitalocean-1.16.0-dns-resolver.yaml
@@ -97,7 +97,7 @@ spec:
       - args:
         - -conf
         - /etc/coredns/Corefile
-        image: gcr.io/google_containers/coredns:1.3.1
+        image: k8s.gcr.io/coredns:1.3.1
         name: dns-resolver
         readinessProbe:
           failureThreshold: 3

--- a/api/pkg/resources/test/fixtures/deployment-digitalocean-1.16.0-metrics-server.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-digitalocean-1.16.0-metrics-server.yaml
@@ -51,7 +51,7 @@ spec:
         - '{"command":"/metrics-server","args":["--kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","--authentication-kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","--authorization-kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","--kubelet-port","10250","--kubelet-insecure-tls","--kubelet-preferred-address-types","ExternalIP,InternalIP","--v","1","--logtostderr","--tls-cert-file","/etc/serving-cert/serving.crt","--tls-private-key-file","/etc/serving-cert/serving.key"]}'
         command:
         - /http-prober-bin/http-prober
-        image: gcr.io/google_containers/metrics-server-amd64:v0.3.6
+        image: k8s.gcr.io/metrics-server-amd64:v0.3.6
         name: metrics-server
         resources:
           limits:

--- a/api/pkg/resources/test/fixtures/deployment-digitalocean-1.16.0-scheduler.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-digitalocean-1.16.0-scheduler.yaml
@@ -108,7 +108,7 @@ spec:
         - '{"command":"/hyperkube","args":["kube-scheduler","--kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","--authentication-kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","--authorization-kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","--client-ca-file","/etc/kubernetes/pki/ca/ca.crt","--port","0","--authentication-tolerate-lookup-failure","false"]}'
         command:
         - /http-prober-bin/http-prober
-        image: gcr.io/google_containers/hyperkube-amd64:v1.16.0
+        image: k8s.gcr.io/hyperkube-amd64:v1.16.0
         livenessProbe:
           failureThreshold: 8
           httpGet:

--- a/api/pkg/resources/test/fixtures/deployment-digitalocean-1.17.0-apiserver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-digitalocean-1.17.0-apiserver.yaml
@@ -228,7 +228,7 @@ spec:
           value: apiserver-external.cluster-de-test-01.svc.cluster.local.
         - name: no_proxy
           value: apiserver-external.cluster-de-test-01.svc.cluster.local.
-        image: gcr.io/google_containers/hyperkube-amd64:v1.17.0
+        image: k8s.gcr.io/hyperkube-amd64:v1.17.0
         livenessProbe:
           failureThreshold: 8
           httpGet:

--- a/api/pkg/resources/test/fixtures/deployment-digitalocean-1.17.0-controller-manager.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-digitalocean-1.17.0-controller-manager.yaml
@@ -123,7 +123,7 @@ spec:
           value: apiserver-external.cluster-de-test-01.svc.cluster.local.
         - name: no_proxy
           value: apiserver-external.cluster-de-test-01.svc.cluster.local.
-        image: gcr.io/google_containers/hyperkube-amd64:v1.17.0
+        image: k8s.gcr.io/hyperkube-amd64:v1.17.0
         livenessProbe:
           failureThreshold: 8
           httpGet:

--- a/api/pkg/resources/test/fixtures/deployment-digitalocean-1.17.0-dns-resolver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-digitalocean-1.17.0-dns-resolver.yaml
@@ -97,7 +97,7 @@ spec:
       - args:
         - -conf
         - /etc/coredns/Corefile
-        image: gcr.io/google_containers/coredns:1.3.1
+        image: k8s.gcr.io/coredns:1.3.1
         name: dns-resolver
         readinessProbe:
           failureThreshold: 3

--- a/api/pkg/resources/test/fixtures/deployment-digitalocean-1.17.0-metrics-server.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-digitalocean-1.17.0-metrics-server.yaml
@@ -51,7 +51,7 @@ spec:
         - '{"command":"/metrics-server","args":["--kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","--authentication-kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","--authorization-kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","--kubelet-port","10250","--kubelet-insecure-tls","--kubelet-preferred-address-types","ExternalIP,InternalIP","--v","1","--logtostderr","--tls-cert-file","/etc/serving-cert/serving.crt","--tls-private-key-file","/etc/serving-cert/serving.key"]}'
         command:
         - /http-prober-bin/http-prober
-        image: gcr.io/google_containers/metrics-server-amd64:v0.3.6
+        image: k8s.gcr.io/metrics-server-amd64:v0.3.6
         name: metrics-server
         resources:
           limits:

--- a/api/pkg/resources/test/fixtures/deployment-digitalocean-1.17.0-scheduler.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-digitalocean-1.17.0-scheduler.yaml
@@ -108,7 +108,7 @@ spec:
         - '{"command":"/hyperkube","args":["kube-scheduler","--kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","--authentication-kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","--authorization-kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","--client-ca-file","/etc/kubernetes/pki/ca/ca.crt","--port","0","--authentication-tolerate-lookup-failure","false"]}'
         command:
         - /http-prober-bin/http-prober
-        image: gcr.io/google_containers/hyperkube-amd64:v1.17.0
+        image: k8s.gcr.io/hyperkube-amd64:v1.17.0
         livenessProbe:
           failureThreshold: 8
           httpGet:

--- a/api/pkg/resources/test/fixtures/deployment-digitalocean-1.18.0-apiserver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-digitalocean-1.18.0-apiserver.yaml
@@ -228,7 +228,7 @@ spec:
           value: apiserver-external.cluster-de-test-01.svc.cluster.local.
         - name: no_proxy
           value: apiserver-external.cluster-de-test-01.svc.cluster.local.
-        image: gcr.io/google_containers/hyperkube-amd64:v1.18.0
+        image: k8s.gcr.io/hyperkube-amd64:v1.18.0
         livenessProbe:
           failureThreshold: 8
           httpGet:

--- a/api/pkg/resources/test/fixtures/deployment-digitalocean-1.18.0-controller-manager.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-digitalocean-1.18.0-controller-manager.yaml
@@ -123,7 +123,7 @@ spec:
           value: apiserver-external.cluster-de-test-01.svc.cluster.local.
         - name: no_proxy
           value: apiserver-external.cluster-de-test-01.svc.cluster.local.
-        image: gcr.io/google_containers/hyperkube-amd64:v1.18.0
+        image: k8s.gcr.io/hyperkube-amd64:v1.18.0
         livenessProbe:
           failureThreshold: 8
           httpGet:

--- a/api/pkg/resources/test/fixtures/deployment-digitalocean-1.18.0-dns-resolver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-digitalocean-1.18.0-dns-resolver.yaml
@@ -97,7 +97,7 @@ spec:
       - args:
         - -conf
         - /etc/coredns/Corefile
-        image: gcr.io/google_containers/coredns:1.3.1
+        image: k8s.gcr.io/coredns:1.3.1
         name: dns-resolver
         readinessProbe:
           failureThreshold: 3

--- a/api/pkg/resources/test/fixtures/deployment-digitalocean-1.18.0-metrics-server.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-digitalocean-1.18.0-metrics-server.yaml
@@ -51,7 +51,7 @@ spec:
         - '{"command":"/metrics-server","args":["--kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","--authentication-kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","--authorization-kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","--kubelet-port","10250","--kubelet-insecure-tls","--kubelet-preferred-address-types","ExternalIP,InternalIP","--v","1","--logtostderr","--tls-cert-file","/etc/serving-cert/serving.crt","--tls-private-key-file","/etc/serving-cert/serving.key"]}'
         command:
         - /http-prober-bin/http-prober
-        image: gcr.io/google_containers/metrics-server-amd64:v0.3.6
+        image: k8s.gcr.io/metrics-server-amd64:v0.3.6
         name: metrics-server
         resources:
           limits:

--- a/api/pkg/resources/test/fixtures/deployment-digitalocean-1.18.0-scheduler.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-digitalocean-1.18.0-scheduler.yaml
@@ -108,7 +108,7 @@ spec:
         - '{"command":"/hyperkube","args":["kube-scheduler","--kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","--authentication-kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","--authorization-kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","--client-ca-file","/etc/kubernetes/pki/ca/ca.crt","--port","0","--authentication-tolerate-lookup-failure","false"]}'
         command:
         - /http-prober-bin/http-prober
-        image: gcr.io/google_containers/hyperkube-amd64:v1.18.0
+        image: k8s.gcr.io/hyperkube-amd64:v1.18.0
         livenessProbe:
           failureThreshold: 8
           httpGet:

--- a/api/pkg/resources/test/fixtures/deployment-openstack-1.15.0-apiserver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-openstack-1.15.0-apiserver.yaml
@@ -232,7 +232,7 @@ spec:
           value: apiserver-external.cluster-de-test-01.svc.cluster.local.
         - name: no_proxy
           value: apiserver-external.cluster-de-test-01.svc.cluster.local.
-        image: gcr.io/google_containers/hyperkube-amd64:v1.15.0
+        image: k8s.gcr.io/hyperkube-amd64:v1.15.0
         livenessProbe:
           failureThreshold: 8
           httpGet:

--- a/api/pkg/resources/test/fixtures/deployment-openstack-1.15.0-controller-manager.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-openstack-1.15.0-controller-manager.yaml
@@ -123,7 +123,7 @@ spec:
           value: apiserver-external.cluster-de-test-01.svc.cluster.local.
         - name: no_proxy
           value: apiserver-external.cluster-de-test-01.svc.cluster.local.
-        image: gcr.io/google_containers/hyperkube-amd64:v1.15.0
+        image: k8s.gcr.io/hyperkube-amd64:v1.15.0
         livenessProbe:
           failureThreshold: 8
           httpGet:

--- a/api/pkg/resources/test/fixtures/deployment-openstack-1.15.0-dns-resolver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-openstack-1.15.0-dns-resolver.yaml
@@ -97,7 +97,7 @@ spec:
       - args:
         - -conf
         - /etc/coredns/Corefile
-        image: gcr.io/google_containers/coredns:1.3.1
+        image: k8s.gcr.io/coredns:1.3.1
         name: dns-resolver
         readinessProbe:
           failureThreshold: 3

--- a/api/pkg/resources/test/fixtures/deployment-openstack-1.15.0-metrics-server.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-openstack-1.15.0-metrics-server.yaml
@@ -51,7 +51,7 @@ spec:
         - '{"command":"/metrics-server","args":["--kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","--authentication-kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","--authorization-kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","--kubelet-port","10250","--kubelet-insecure-tls","--kubelet-preferred-address-types","ExternalIP,InternalIP","--v","1","--logtostderr","--tls-cert-file","/etc/serving-cert/serving.crt","--tls-private-key-file","/etc/serving-cert/serving.key"]}'
         command:
         - /http-prober-bin/http-prober
-        image: gcr.io/google_containers/metrics-server-amd64:v0.3.6
+        image: k8s.gcr.io/metrics-server-amd64:v0.3.6
         name: metrics-server
         resources:
           limits:

--- a/api/pkg/resources/test/fixtures/deployment-openstack-1.15.0-scheduler.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-openstack-1.15.0-scheduler.yaml
@@ -108,7 +108,7 @@ spec:
         - '{"command":"/hyperkube","args":["kube-scheduler","--kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","--authentication-kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","--authorization-kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","--client-ca-file","/etc/kubernetes/pki/ca/ca.crt","--port","0","--authentication-tolerate-lookup-failure","false"]}'
         command:
         - /http-prober-bin/http-prober
-        image: gcr.io/google_containers/hyperkube-amd64:v1.15.0
+        image: k8s.gcr.io/hyperkube-amd64:v1.15.0
         livenessProbe:
           failureThreshold: 8
           httpGet:

--- a/api/pkg/resources/test/fixtures/deployment-openstack-1.16.0-apiserver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-openstack-1.16.0-apiserver.yaml
@@ -232,7 +232,7 @@ spec:
           value: apiserver-external.cluster-de-test-01.svc.cluster.local.
         - name: no_proxy
           value: apiserver-external.cluster-de-test-01.svc.cluster.local.
-        image: gcr.io/google_containers/hyperkube-amd64:v1.16.0
+        image: k8s.gcr.io/hyperkube-amd64:v1.16.0
         livenessProbe:
           failureThreshold: 8
           httpGet:

--- a/api/pkg/resources/test/fixtures/deployment-openstack-1.16.0-controller-manager.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-openstack-1.16.0-controller-manager.yaml
@@ -123,7 +123,7 @@ spec:
           value: apiserver-external.cluster-de-test-01.svc.cluster.local.
         - name: no_proxy
           value: apiserver-external.cluster-de-test-01.svc.cluster.local.
-        image: gcr.io/google_containers/hyperkube-amd64:v1.16.0
+        image: k8s.gcr.io/hyperkube-amd64:v1.16.0
         livenessProbe:
           failureThreshold: 8
           httpGet:

--- a/api/pkg/resources/test/fixtures/deployment-openstack-1.16.0-dns-resolver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-openstack-1.16.0-dns-resolver.yaml
@@ -97,7 +97,7 @@ spec:
       - args:
         - -conf
         - /etc/coredns/Corefile
-        image: gcr.io/google_containers/coredns:1.3.1
+        image: k8s.gcr.io/coredns:1.3.1
         name: dns-resolver
         readinessProbe:
           failureThreshold: 3

--- a/api/pkg/resources/test/fixtures/deployment-openstack-1.16.0-metrics-server.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-openstack-1.16.0-metrics-server.yaml
@@ -51,7 +51,7 @@ spec:
         - '{"command":"/metrics-server","args":["--kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","--authentication-kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","--authorization-kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","--kubelet-port","10250","--kubelet-insecure-tls","--kubelet-preferred-address-types","ExternalIP,InternalIP","--v","1","--logtostderr","--tls-cert-file","/etc/serving-cert/serving.crt","--tls-private-key-file","/etc/serving-cert/serving.key"]}'
         command:
         - /http-prober-bin/http-prober
-        image: gcr.io/google_containers/metrics-server-amd64:v0.3.6
+        image: k8s.gcr.io/metrics-server-amd64:v0.3.6
         name: metrics-server
         resources:
           limits:

--- a/api/pkg/resources/test/fixtures/deployment-openstack-1.16.0-scheduler.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-openstack-1.16.0-scheduler.yaml
@@ -108,7 +108,7 @@ spec:
         - '{"command":"/hyperkube","args":["kube-scheduler","--kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","--authentication-kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","--authorization-kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","--client-ca-file","/etc/kubernetes/pki/ca/ca.crt","--port","0","--authentication-tolerate-lookup-failure","false"]}'
         command:
         - /http-prober-bin/http-prober
-        image: gcr.io/google_containers/hyperkube-amd64:v1.16.0
+        image: k8s.gcr.io/hyperkube-amd64:v1.16.0
         livenessProbe:
           failureThreshold: 8
           httpGet:

--- a/api/pkg/resources/test/fixtures/deployment-openstack-1.17.0-apiserver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-openstack-1.17.0-apiserver.yaml
@@ -232,7 +232,7 @@ spec:
           value: apiserver-external.cluster-de-test-01.svc.cluster.local.
         - name: no_proxy
           value: apiserver-external.cluster-de-test-01.svc.cluster.local.
-        image: gcr.io/google_containers/hyperkube-amd64:v1.17.0
+        image: k8s.gcr.io/hyperkube-amd64:v1.17.0
         livenessProbe:
           failureThreshold: 8
           httpGet:

--- a/api/pkg/resources/test/fixtures/deployment-openstack-1.17.0-controller-manager.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-openstack-1.17.0-controller-manager.yaml
@@ -123,7 +123,7 @@ spec:
           value: apiserver-external.cluster-de-test-01.svc.cluster.local.
         - name: no_proxy
           value: apiserver-external.cluster-de-test-01.svc.cluster.local.
-        image: gcr.io/google_containers/hyperkube-amd64:v1.17.0
+        image: k8s.gcr.io/hyperkube-amd64:v1.17.0
         livenessProbe:
           failureThreshold: 8
           httpGet:

--- a/api/pkg/resources/test/fixtures/deployment-openstack-1.17.0-dns-resolver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-openstack-1.17.0-dns-resolver.yaml
@@ -97,7 +97,7 @@ spec:
       - args:
         - -conf
         - /etc/coredns/Corefile
-        image: gcr.io/google_containers/coredns:1.3.1
+        image: k8s.gcr.io/coredns:1.3.1
         name: dns-resolver
         readinessProbe:
           failureThreshold: 3

--- a/api/pkg/resources/test/fixtures/deployment-openstack-1.17.0-metrics-server.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-openstack-1.17.0-metrics-server.yaml
@@ -51,7 +51,7 @@ spec:
         - '{"command":"/metrics-server","args":["--kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","--authentication-kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","--authorization-kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","--kubelet-port","10250","--kubelet-insecure-tls","--kubelet-preferred-address-types","ExternalIP,InternalIP","--v","1","--logtostderr","--tls-cert-file","/etc/serving-cert/serving.crt","--tls-private-key-file","/etc/serving-cert/serving.key"]}'
         command:
         - /http-prober-bin/http-prober
-        image: gcr.io/google_containers/metrics-server-amd64:v0.3.6
+        image: k8s.gcr.io/metrics-server-amd64:v0.3.6
         name: metrics-server
         resources:
           limits:

--- a/api/pkg/resources/test/fixtures/deployment-openstack-1.17.0-scheduler.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-openstack-1.17.0-scheduler.yaml
@@ -108,7 +108,7 @@ spec:
         - '{"command":"/hyperkube","args":["kube-scheduler","--kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","--authentication-kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","--authorization-kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","--client-ca-file","/etc/kubernetes/pki/ca/ca.crt","--port","0","--authentication-tolerate-lookup-failure","false"]}'
         command:
         - /http-prober-bin/http-prober
-        image: gcr.io/google_containers/hyperkube-amd64:v1.17.0
+        image: k8s.gcr.io/hyperkube-amd64:v1.17.0
         livenessProbe:
           failureThreshold: 8
           httpGet:

--- a/api/pkg/resources/test/fixtures/deployment-openstack-1.18.0-apiserver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-openstack-1.18.0-apiserver.yaml
@@ -232,7 +232,7 @@ spec:
           value: apiserver-external.cluster-de-test-01.svc.cluster.local.
         - name: no_proxy
           value: apiserver-external.cluster-de-test-01.svc.cluster.local.
-        image: gcr.io/google_containers/hyperkube-amd64:v1.18.0
+        image: k8s.gcr.io/hyperkube-amd64:v1.18.0
         livenessProbe:
           failureThreshold: 8
           httpGet:

--- a/api/pkg/resources/test/fixtures/deployment-openstack-1.18.0-controller-manager.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-openstack-1.18.0-controller-manager.yaml
@@ -123,7 +123,7 @@ spec:
           value: apiserver-external.cluster-de-test-01.svc.cluster.local.
         - name: no_proxy
           value: apiserver-external.cluster-de-test-01.svc.cluster.local.
-        image: gcr.io/google_containers/hyperkube-amd64:v1.18.0
+        image: k8s.gcr.io/hyperkube-amd64:v1.18.0
         livenessProbe:
           failureThreshold: 8
           httpGet:

--- a/api/pkg/resources/test/fixtures/deployment-openstack-1.18.0-dns-resolver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-openstack-1.18.0-dns-resolver.yaml
@@ -97,7 +97,7 @@ spec:
       - args:
         - -conf
         - /etc/coredns/Corefile
-        image: gcr.io/google_containers/coredns:1.3.1
+        image: k8s.gcr.io/coredns:1.3.1
         name: dns-resolver
         readinessProbe:
           failureThreshold: 3

--- a/api/pkg/resources/test/fixtures/deployment-openstack-1.18.0-metrics-server.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-openstack-1.18.0-metrics-server.yaml
@@ -51,7 +51,7 @@ spec:
         - '{"command":"/metrics-server","args":["--kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","--authentication-kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","--authorization-kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","--kubelet-port","10250","--kubelet-insecure-tls","--kubelet-preferred-address-types","ExternalIP,InternalIP","--v","1","--logtostderr","--tls-cert-file","/etc/serving-cert/serving.crt","--tls-private-key-file","/etc/serving-cert/serving.key"]}'
         command:
         - /http-prober-bin/http-prober
-        image: gcr.io/google_containers/metrics-server-amd64:v0.3.6
+        image: k8s.gcr.io/metrics-server-amd64:v0.3.6
         name: metrics-server
         resources:
           limits:

--- a/api/pkg/resources/test/fixtures/deployment-openstack-1.18.0-scheduler.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-openstack-1.18.0-scheduler.yaml
@@ -108,7 +108,7 @@ spec:
         - '{"command":"/hyperkube","args":["kube-scheduler","--kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","--authentication-kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","--authorization-kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","--client-ca-file","/etc/kubernetes/pki/ca/ca.crt","--port","0","--authentication-tolerate-lookup-failure","false"]}'
         command:
         - /http-prober-bin/http-prober
-        image: gcr.io/google_containers/hyperkube-amd64:v1.18.0
+        image: k8s.gcr.io/hyperkube-amd64:v1.18.0
         livenessProbe:
           failureThreshold: 8
           httpGet:

--- a/api/pkg/resources/test/fixtures/deployment-vsphere-1.15.0-apiserver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-vsphere-1.15.0-apiserver.yaml
@@ -232,7 +232,7 @@ spec:
           value: apiserver-external.cluster-de-test-01.svc.cluster.local.
         - name: no_proxy
           value: apiserver-external.cluster-de-test-01.svc.cluster.local.
-        image: gcr.io/google_containers/hyperkube-amd64:v1.15.0
+        image: k8s.gcr.io/hyperkube-amd64:v1.15.0
         livenessProbe:
           failureThreshold: 8
           httpGet:

--- a/api/pkg/resources/test/fixtures/deployment-vsphere-1.15.0-controller-manager.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-vsphere-1.15.0-controller-manager.yaml
@@ -123,7 +123,7 @@ spec:
           value: apiserver-external.cluster-de-test-01.svc.cluster.local.
         - name: no_proxy
           value: apiserver-external.cluster-de-test-01.svc.cluster.local.
-        image: gcr.io/google_containers/hyperkube-amd64:v1.15.0
+        image: k8s.gcr.io/hyperkube-amd64:v1.15.0
         livenessProbe:
           failureThreshold: 8
           httpGet:

--- a/api/pkg/resources/test/fixtures/deployment-vsphere-1.15.0-dns-resolver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-vsphere-1.15.0-dns-resolver.yaml
@@ -97,7 +97,7 @@ spec:
       - args:
         - -conf
         - /etc/coredns/Corefile
-        image: gcr.io/google_containers/coredns:1.3.1
+        image: k8s.gcr.io/coredns:1.3.1
         name: dns-resolver
         readinessProbe:
           failureThreshold: 3

--- a/api/pkg/resources/test/fixtures/deployment-vsphere-1.15.0-metrics-server.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-vsphere-1.15.0-metrics-server.yaml
@@ -51,7 +51,7 @@ spec:
         - '{"command":"/metrics-server","args":["--kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","--authentication-kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","--authorization-kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","--kubelet-port","10250","--kubelet-insecure-tls","--kubelet-preferred-address-types","ExternalIP,InternalIP","--v","1","--logtostderr","--tls-cert-file","/etc/serving-cert/serving.crt","--tls-private-key-file","/etc/serving-cert/serving.key"]}'
         command:
         - /http-prober-bin/http-prober
-        image: gcr.io/google_containers/metrics-server-amd64:v0.3.6
+        image: k8s.gcr.io/metrics-server-amd64:v0.3.6
         name: metrics-server
         resources:
           limits:

--- a/api/pkg/resources/test/fixtures/deployment-vsphere-1.15.0-scheduler.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-vsphere-1.15.0-scheduler.yaml
@@ -108,7 +108,7 @@ spec:
         - '{"command":"/hyperkube","args":["kube-scheduler","--kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","--authentication-kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","--authorization-kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","--client-ca-file","/etc/kubernetes/pki/ca/ca.crt","--port","0","--authentication-tolerate-lookup-failure","false"]}'
         command:
         - /http-prober-bin/http-prober
-        image: gcr.io/google_containers/hyperkube-amd64:v1.15.0
+        image: k8s.gcr.io/hyperkube-amd64:v1.15.0
         livenessProbe:
           failureThreshold: 8
           httpGet:

--- a/api/pkg/resources/test/fixtures/deployment-vsphere-1.16.0-apiserver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-vsphere-1.16.0-apiserver.yaml
@@ -232,7 +232,7 @@ spec:
           value: apiserver-external.cluster-de-test-01.svc.cluster.local.
         - name: no_proxy
           value: apiserver-external.cluster-de-test-01.svc.cluster.local.
-        image: gcr.io/google_containers/hyperkube-amd64:v1.16.0
+        image: k8s.gcr.io/hyperkube-amd64:v1.16.0
         livenessProbe:
           failureThreshold: 8
           httpGet:

--- a/api/pkg/resources/test/fixtures/deployment-vsphere-1.16.0-controller-manager.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-vsphere-1.16.0-controller-manager.yaml
@@ -123,7 +123,7 @@ spec:
           value: apiserver-external.cluster-de-test-01.svc.cluster.local.
         - name: no_proxy
           value: apiserver-external.cluster-de-test-01.svc.cluster.local.
-        image: gcr.io/google_containers/hyperkube-amd64:v1.16.0
+        image: k8s.gcr.io/hyperkube-amd64:v1.16.0
         livenessProbe:
           failureThreshold: 8
           httpGet:

--- a/api/pkg/resources/test/fixtures/deployment-vsphere-1.16.0-dns-resolver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-vsphere-1.16.0-dns-resolver.yaml
@@ -97,7 +97,7 @@ spec:
       - args:
         - -conf
         - /etc/coredns/Corefile
-        image: gcr.io/google_containers/coredns:1.3.1
+        image: k8s.gcr.io/coredns:1.3.1
         name: dns-resolver
         readinessProbe:
           failureThreshold: 3

--- a/api/pkg/resources/test/fixtures/deployment-vsphere-1.16.0-metrics-server.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-vsphere-1.16.0-metrics-server.yaml
@@ -51,7 +51,7 @@ spec:
         - '{"command":"/metrics-server","args":["--kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","--authentication-kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","--authorization-kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","--kubelet-port","10250","--kubelet-insecure-tls","--kubelet-preferred-address-types","ExternalIP,InternalIP","--v","1","--logtostderr","--tls-cert-file","/etc/serving-cert/serving.crt","--tls-private-key-file","/etc/serving-cert/serving.key"]}'
         command:
         - /http-prober-bin/http-prober
-        image: gcr.io/google_containers/metrics-server-amd64:v0.3.6
+        image: k8s.gcr.io/metrics-server-amd64:v0.3.6
         name: metrics-server
         resources:
           limits:

--- a/api/pkg/resources/test/fixtures/deployment-vsphere-1.16.0-scheduler.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-vsphere-1.16.0-scheduler.yaml
@@ -108,7 +108,7 @@ spec:
         - '{"command":"/hyperkube","args":["kube-scheduler","--kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","--authentication-kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","--authorization-kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","--client-ca-file","/etc/kubernetes/pki/ca/ca.crt","--port","0","--authentication-tolerate-lookup-failure","false"]}'
         command:
         - /http-prober-bin/http-prober
-        image: gcr.io/google_containers/hyperkube-amd64:v1.16.0
+        image: k8s.gcr.io/hyperkube-amd64:v1.16.0
         livenessProbe:
           failureThreshold: 8
           httpGet:

--- a/api/pkg/resources/test/fixtures/deployment-vsphere-1.17.0-apiserver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-vsphere-1.17.0-apiserver.yaml
@@ -232,7 +232,7 @@ spec:
           value: apiserver-external.cluster-de-test-01.svc.cluster.local.
         - name: no_proxy
           value: apiserver-external.cluster-de-test-01.svc.cluster.local.
-        image: gcr.io/google_containers/hyperkube-amd64:v1.17.0
+        image: k8s.gcr.io/hyperkube-amd64:v1.17.0
         livenessProbe:
           failureThreshold: 8
           httpGet:

--- a/api/pkg/resources/test/fixtures/deployment-vsphere-1.17.0-controller-manager.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-vsphere-1.17.0-controller-manager.yaml
@@ -123,7 +123,7 @@ spec:
           value: apiserver-external.cluster-de-test-01.svc.cluster.local.
         - name: no_proxy
           value: apiserver-external.cluster-de-test-01.svc.cluster.local.
-        image: gcr.io/google_containers/hyperkube-amd64:v1.17.0
+        image: k8s.gcr.io/hyperkube-amd64:v1.17.0
         livenessProbe:
           failureThreshold: 8
           httpGet:

--- a/api/pkg/resources/test/fixtures/deployment-vsphere-1.17.0-dns-resolver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-vsphere-1.17.0-dns-resolver.yaml
@@ -97,7 +97,7 @@ spec:
       - args:
         - -conf
         - /etc/coredns/Corefile
-        image: gcr.io/google_containers/coredns:1.3.1
+        image: k8s.gcr.io/coredns:1.3.1
         name: dns-resolver
         readinessProbe:
           failureThreshold: 3

--- a/api/pkg/resources/test/fixtures/deployment-vsphere-1.17.0-metrics-server.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-vsphere-1.17.0-metrics-server.yaml
@@ -51,7 +51,7 @@ spec:
         - '{"command":"/metrics-server","args":["--kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","--authentication-kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","--authorization-kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","--kubelet-port","10250","--kubelet-insecure-tls","--kubelet-preferred-address-types","ExternalIP,InternalIP","--v","1","--logtostderr","--tls-cert-file","/etc/serving-cert/serving.crt","--tls-private-key-file","/etc/serving-cert/serving.key"]}'
         command:
         - /http-prober-bin/http-prober
-        image: gcr.io/google_containers/metrics-server-amd64:v0.3.6
+        image: k8s.gcr.io/metrics-server-amd64:v0.3.6
         name: metrics-server
         resources:
           limits:

--- a/api/pkg/resources/test/fixtures/deployment-vsphere-1.17.0-scheduler.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-vsphere-1.17.0-scheduler.yaml
@@ -108,7 +108,7 @@ spec:
         - '{"command":"/hyperkube","args":["kube-scheduler","--kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","--authentication-kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","--authorization-kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","--client-ca-file","/etc/kubernetes/pki/ca/ca.crt","--port","0","--authentication-tolerate-lookup-failure","false"]}'
         command:
         - /http-prober-bin/http-prober
-        image: gcr.io/google_containers/hyperkube-amd64:v1.17.0
+        image: k8s.gcr.io/hyperkube-amd64:v1.17.0
         livenessProbe:
           failureThreshold: 8
           httpGet:

--- a/api/pkg/resources/test/fixtures/deployment-vsphere-1.18.0-apiserver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-vsphere-1.18.0-apiserver.yaml
@@ -232,7 +232,7 @@ spec:
           value: apiserver-external.cluster-de-test-01.svc.cluster.local.
         - name: no_proxy
           value: apiserver-external.cluster-de-test-01.svc.cluster.local.
-        image: gcr.io/google_containers/hyperkube-amd64:v1.18.0
+        image: k8s.gcr.io/hyperkube-amd64:v1.18.0
         livenessProbe:
           failureThreshold: 8
           httpGet:

--- a/api/pkg/resources/test/fixtures/deployment-vsphere-1.18.0-controller-manager.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-vsphere-1.18.0-controller-manager.yaml
@@ -123,7 +123,7 @@ spec:
           value: apiserver-external.cluster-de-test-01.svc.cluster.local.
         - name: no_proxy
           value: apiserver-external.cluster-de-test-01.svc.cluster.local.
-        image: gcr.io/google_containers/hyperkube-amd64:v1.18.0
+        image: k8s.gcr.io/hyperkube-amd64:v1.18.0
         livenessProbe:
           failureThreshold: 8
           httpGet:

--- a/api/pkg/resources/test/fixtures/deployment-vsphere-1.18.0-dns-resolver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-vsphere-1.18.0-dns-resolver.yaml
@@ -97,7 +97,7 @@ spec:
       - args:
         - -conf
         - /etc/coredns/Corefile
-        image: gcr.io/google_containers/coredns:1.3.1
+        image: k8s.gcr.io/coredns:1.3.1
         name: dns-resolver
         readinessProbe:
           failureThreshold: 3

--- a/api/pkg/resources/test/fixtures/deployment-vsphere-1.18.0-metrics-server.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-vsphere-1.18.0-metrics-server.yaml
@@ -51,7 +51,7 @@ spec:
         - '{"command":"/metrics-server","args":["--kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","--authentication-kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","--authorization-kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","--kubelet-port","10250","--kubelet-insecure-tls","--kubelet-preferred-address-types","ExternalIP,InternalIP","--v","1","--logtostderr","--tls-cert-file","/etc/serving-cert/serving.crt","--tls-private-key-file","/etc/serving-cert/serving.key"]}'
         command:
         - /http-prober-bin/http-prober
-        image: gcr.io/google_containers/metrics-server-amd64:v0.3.6
+        image: k8s.gcr.io/metrics-server-amd64:v0.3.6
         name: metrics-server
         resources:
           limits:

--- a/api/pkg/resources/test/fixtures/deployment-vsphere-1.18.0-scheduler.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-vsphere-1.18.0-scheduler.yaml
@@ -108,7 +108,7 @@ spec:
         - '{"command":"/hyperkube","args":["kube-scheduler","--kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","--authentication-kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","--authorization-kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","--client-ca-file","/etc/kubernetes/pki/ca/ca.crt","--port","0","--authentication-tolerate-lookup-failure","false"]}'
         command:
         - /http-prober-bin/http-prober
-        image: gcr.io/google_containers/hyperkube-amd64:v1.18.0
+        image: k8s.gcr.io/hyperkube-amd64:v1.18.0
         livenessProbe:
           failureThreshold: 8
           httpGet:


### PR DESCRIPTION
**What this PR does / why we need it**:

Migrate from `gcr.io/google_containers` registry to `k8s.gcr.io` registry. The google_containers registry is read-only for several weeks, and therefore the migration is advised.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
xref #5773 #5967
The issue will be closed once we fix it for the release/v2.13 branch as well.

**Does this PR introduce a user-facing change?**:
```release-note
Migrate from google_containers to k8s.gcr.io Docker registry
```
