### PR TITLE
[release/v2.13] Migrate from google_containers to k8s.gcr.io Docker registry

### DIFF
--- a/addons/kube-proxy/daemonset.yaml
+++ b/addons/kube-proxy/daemonset.yaml
@@ -21,7 +21,7 @@ spec:
       priorityClassName: system-node-critical
       containers:
       - name: kube-proxy
-        image: '{{ Registry "gcr.io" }}/google_containers/hyperkube-amd64:v{{ .Cluster.Spec.Version }}'
+        image: '{{ Registry "k8s.gcr.io" }}/hyperkube-amd64:v{{ .Cluster.Spec.Version }}'
         imagePullPolicy: IfNotPresent
         command:
         - /usr/local/bin/kube-proxy

--- a/addons/metrics-server/metrics-server-deployment.yaml
+++ b/addons/metrics-server/metrics-server-deployment.yaml
@@ -29,7 +29,7 @@ spec:
         emptyDir: {}
       containers:
       - name: metrics-server
-        image: '{{ Registry "gcr.io" }}/google_containers/metrics-server-amd64:v0.2.1'
+        image: '{{ Registry "k8s.gcr.io" }}/metrics-server-amd64:v0.2.1'
         command:
         - /metrics-server
         - '--source=kubernetes.summary_api:https://kubernetes.default.svc?kubeletHttps=true&kubeletPort=10250&insecure=true'

--- a/addons/nodelocal-dns-cache/dns.yaml
+++ b/addons/nodelocal-dns-cache/dns.yaml
@@ -95,7 +95,7 @@ spec:
         operator: "Exists"
       containers:
       - name: node-cache
-        image: {{ Registry "gcr.io" }}/google_containers/k8s-dns-node-cache:1.15.7
+        image: {{ Registry "k8s.gcr.io" }}/k8s-dns-node-cache:1.15.7
         resources:
           requests:
             cpu: 25m

--- a/api/pkg/resources/apiserver/deployment.go
+++ b/api/pkg/resources/apiserver/deployment.go
@@ -135,7 +135,7 @@ func DeploymentCreator(data *resources.TemplateData, enableDexCA bool) reconcili
 				*dnatControllerSidecar,
 				{
 					Name:    resources.ApiserverDeploymentName,
-					Image:   data.ImageRegistry(resources.RegistryGCR) + "/google_containers/hyperkube-amd64:v" + data.Cluster().Spec.Version.String(),
+					Image:   data.ImageRegistry(resources.RegistryK8SGCR) + "/hyperkube-amd64:v" + data.Cluster().Spec.Version.String(),
 					Command: []string{"/hyperkube", "kube-apiserver"},
 					Env:     envVars,
 					Args:    flags,

--- a/api/pkg/resources/controllermanager/deployment.go
+++ b/api/pkg/resources/controllermanager/deployment.go
@@ -145,7 +145,7 @@ func DeploymentCreator(data *resources.TemplateData) reconciling.NamedDeployment
 				*openvpnSidecar,
 				{
 					Name:    resources.ControllerManagerDeploymentName,
-					Image:   data.ImageRegistry(resources.RegistryGCR) + "/google_containers/hyperkube-amd64:v" + data.Cluster().Spec.Version.String(),
+					Image:   data.ImageRegistry(resources.RegistryK8SGCR) + "/hyperkube-amd64:v" + data.Cluster().Spec.Version.String(),
 					Command: []string{"/hyperkube", "kube-controller-manager"},
 					Args:    flags,
 					Env:     envVars,

--- a/api/pkg/resources/dns/dns.go
+++ b/api/pkg/resources/dns/dns.go
@@ -93,7 +93,7 @@ func DeploymentCreator(data deploymentCreatorData) reconciling.NamedDeploymentCr
 				*openvpnSidecar,
 				{
 					Name:  resources.DNSResolverDeploymentName,
-					Image: data.ImageRegistry(resources.RegistryGCR) + "/google_containers/coredns:1.1.3",
+					Image: data.ImageRegistry(resources.RegistryK8SGCR) + "/coredns:1.1.3",
 					Args:  []string{"-conf", "/etc/coredns/Corefile"},
 					VolumeMounts: []corev1.VolumeMount{
 						{

--- a/api/pkg/resources/metrics-server/deployment.go
+++ b/api/pkg/resources/metrics-server/deployment.go
@@ -102,7 +102,7 @@ func DeploymentCreator(data metricsServerData) reconciling.NamedDeploymentCreato
 			dep.Spec.Template.Spec.Containers = []corev1.Container{
 				{
 					Name:    name,
-					Image:   data.ImageRegistry(resources.RegistryGCR) + "/google_containers/metrics-server-amd64:" + tag,
+					Image:   data.ImageRegistry(resources.RegistryK8SGCR) + "/metrics-server-amd64:" + tag,
 					Command: []string{"/metrics-server"},
 					Args: []string{
 						"--kubeconfig", "/etc/kubernetes/kubeconfig/kubeconfig",

--- a/api/pkg/resources/resources.go
+++ b/api/pkg/resources/resources.go
@@ -307,6 +307,8 @@ const (
 	// EtcdClusterSize defines the size of the etcd to use
 	EtcdClusterSize = 3
 
+	// RegistryK8SGCR defines the kubernetes specific docker registry at google
+	RegistryK8SGCR = "k8s.gcr.io"
 	// RegistryGCR defines the kubernetes docker registry at google
 	RegistryGCR = "gcr.io"
 	// RegistryDocker defines the default docker.io registry

--- a/api/pkg/resources/scheduler/deployment.go
+++ b/api/pkg/resources/scheduler/deployment.go
@@ -87,7 +87,7 @@ func DeploymentCreator(data *resources.TemplateData) reconciling.NamedDeployment
 				*openvpnSidecar,
 				{
 					Name:    resources.SchedulerDeploymentName,
-					Image:   data.ImageRegistry(resources.RegistryGCR) + "/google_containers/hyperkube-amd64:v" + data.Cluster().Spec.Version.String(),
+					Image:   data.ImageRegistry(resources.RegistryK8SGCR) + "/hyperkube-amd64:v" + data.Cluster().Spec.Version.String(),
 					Command: []string{"/hyperkube", "kube-scheduler"},
 					Args:    flags,
 					VolumeMounts: []corev1.VolumeMount{

--- a/api/pkg/resources/test/fixtures/deployment-aws-1.10.0-apiserver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-aws-1.10.0-apiserver.yaml
@@ -240,7 +240,7 @@ spec:
           value: apiserver-external.cluster-de-test-01.svc.cluster.local.
         - name: no_proxy
           value: apiserver-external.cluster-de-test-01.svc.cluster.local.
-        image: gcr.io/google_containers/hyperkube-amd64:v1.10.0
+        image: k8s.gcr.io/hyperkube-amd64:v1.10.0
         livenessProbe:
           failureThreshold: 8
           httpGet:

--- a/api/pkg/resources/test/fixtures/deployment-aws-1.10.0-controller-manager.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-aws-1.10.0-controller-manager.yaml
@@ -129,7 +129,7 @@ spec:
           value: apiserver-external.cluster-de-test-01.svc.cluster.local.
         - name: no_proxy
           value: apiserver-external.cluster-de-test-01.svc.cluster.local.
-        image: gcr.io/google_containers/hyperkube-amd64:v1.10.0
+        image: k8s.gcr.io/hyperkube-amd64:v1.10.0
         livenessProbe:
           failureThreshold: 8
           httpGet:

--- a/api/pkg/resources/test/fixtures/deployment-aws-1.10.0-dns-resolver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-aws-1.10.0-dns-resolver.yaml
@@ -97,7 +97,7 @@ spec:
       - args:
         - -conf
         - /etc/coredns/Corefile
-        image: gcr.io/google_containers/coredns:1.1.3
+        image: k8s.gcr.io/coredns:1.1.3
         name: dns-resolver
         readinessProbe:
           failureThreshold: 3

--- a/api/pkg/resources/test/fixtures/deployment-aws-1.10.0-metrics-server.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-aws-1.10.0-metrics-server.yaml
@@ -51,7 +51,7 @@ spec:
         - '{"command":"/metrics-server","args":["--kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","--authentication-kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","--authorization-kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","--kubelet-port","10250","--kubelet-insecure-tls","--kubelet-preferred-address-types","ExternalIP,InternalIP","--v","1","--logtostderr","--tls-cert-file","/etc/serving-cert/serving.crt","--tls-private-key-file","/etc/serving-cert/serving.key"]}'
         command:
         - /http-prober-bin/http-prober
-        image: gcr.io/google_containers/metrics-server-amd64:v0.3.4
+        image: k8s.gcr.io/metrics-server-amd64:v0.3.4
         name: metrics-server
         resources:
           limits:

--- a/api/pkg/resources/test/fixtures/deployment-aws-1.10.0-scheduler.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-aws-1.10.0-scheduler.yaml
@@ -108,7 +108,7 @@ spec:
         - '{"command":"/hyperkube","args":["kube-scheduler","--kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig"]}'
         command:
         - /http-prober-bin/http-prober
-        image: gcr.io/google_containers/hyperkube-amd64:v1.10.0
+        image: k8s.gcr.io/hyperkube-amd64:v1.10.0
         livenessProbe:
           failureThreshold: 8
           httpGet:

--- a/api/pkg/resources/test/fixtures/deployment-aws-1.10.6-apiserver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-aws-1.10.6-apiserver.yaml
@@ -240,7 +240,7 @@ spec:
           value: apiserver-external.cluster-de-test-01.svc.cluster.local.
         - name: no_proxy
           value: apiserver-external.cluster-de-test-01.svc.cluster.local.
-        image: gcr.io/google_containers/hyperkube-amd64:v1.10.6
+        image: k8s.gcr.io/hyperkube-amd64:v1.10.6
         livenessProbe:
           failureThreshold: 8
           httpGet:

--- a/api/pkg/resources/test/fixtures/deployment-aws-1.10.6-controller-manager.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-aws-1.10.6-controller-manager.yaml
@@ -129,7 +129,7 @@ spec:
           value: apiserver-external.cluster-de-test-01.svc.cluster.local.
         - name: no_proxy
           value: apiserver-external.cluster-de-test-01.svc.cluster.local.
-        image: gcr.io/google_containers/hyperkube-amd64:v1.10.6
+        image: k8s.gcr.io/hyperkube-amd64:v1.10.6
         livenessProbe:
           failureThreshold: 8
           httpGet:

--- a/api/pkg/resources/test/fixtures/deployment-aws-1.10.6-dns-resolver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-aws-1.10.6-dns-resolver.yaml
@@ -97,7 +97,7 @@ spec:
       - args:
         - -conf
         - /etc/coredns/Corefile
-        image: gcr.io/google_containers/coredns:1.1.3
+        image: k8s.gcr.io/coredns:1.1.3
         name: dns-resolver
         readinessProbe:
           failureThreshold: 3

--- a/api/pkg/resources/test/fixtures/deployment-aws-1.10.6-metrics-server.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-aws-1.10.6-metrics-server.yaml
@@ -51,7 +51,7 @@ spec:
         - '{"command":"/metrics-server","args":["--kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","--authentication-kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","--authorization-kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","--kubelet-port","10250","--kubelet-insecure-tls","--kubelet-preferred-address-types","ExternalIP,InternalIP","--v","1","--logtostderr","--tls-cert-file","/etc/serving-cert/serving.crt","--tls-private-key-file","/etc/serving-cert/serving.key"]}'
         command:
         - /http-prober-bin/http-prober
-        image: gcr.io/google_containers/metrics-server-amd64:v0.3.4
+        image: k8s.gcr.io/metrics-server-amd64:v0.3.4
         name: metrics-server
         resources:
           limits:

--- a/api/pkg/resources/test/fixtures/deployment-aws-1.10.6-scheduler.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-aws-1.10.6-scheduler.yaml
@@ -108,7 +108,7 @@ spec:
         - '{"command":"/hyperkube","args":["kube-scheduler","--kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig"]}'
         command:
         - /http-prober-bin/http-prober
-        image: gcr.io/google_containers/hyperkube-amd64:v1.10.6
+        image: k8s.gcr.io/hyperkube-amd64:v1.10.6
         livenessProbe:
           failureThreshold: 8
           httpGet:

--- a/api/pkg/resources/test/fixtures/deployment-aws-1.11.0-apiserver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-aws-1.11.0-apiserver.yaml
@@ -238,7 +238,7 @@ spec:
           value: apiserver-external.cluster-de-test-01.svc.cluster.local.
         - name: no_proxy
           value: apiserver-external.cluster-de-test-01.svc.cluster.local.
-        image: gcr.io/google_containers/hyperkube-amd64:v1.11.0
+        image: k8s.gcr.io/hyperkube-amd64:v1.11.0
         livenessProbe:
           failureThreshold: 8
           httpGet:

--- a/api/pkg/resources/test/fixtures/deployment-aws-1.11.0-controller-manager.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-aws-1.11.0-controller-manager.yaml
@@ -129,7 +129,7 @@ spec:
           value: apiserver-external.cluster-de-test-01.svc.cluster.local.
         - name: no_proxy
           value: apiserver-external.cluster-de-test-01.svc.cluster.local.
-        image: gcr.io/google_containers/hyperkube-amd64:v1.11.0
+        image: k8s.gcr.io/hyperkube-amd64:v1.11.0
         livenessProbe:
           failureThreshold: 8
           httpGet:

--- a/api/pkg/resources/test/fixtures/deployment-aws-1.11.0-dns-resolver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-aws-1.11.0-dns-resolver.yaml
@@ -97,7 +97,7 @@ spec:
       - args:
         - -conf
         - /etc/coredns/Corefile
-        image: gcr.io/google_containers/coredns:1.1.3
+        image: k8s.gcr.io/coredns:1.1.3
         name: dns-resolver
         readinessProbe:
           failureThreshold: 3

--- a/api/pkg/resources/test/fixtures/deployment-aws-1.11.0-metrics-server.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-aws-1.11.0-metrics-server.yaml
@@ -51,7 +51,7 @@ spec:
         - '{"command":"/metrics-server","args":["--kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","--authentication-kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","--authorization-kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","--kubelet-port","10250","--kubelet-insecure-tls","--kubelet-preferred-address-types","ExternalIP,InternalIP","--v","1","--logtostderr","--tls-cert-file","/etc/serving-cert/serving.crt","--tls-private-key-file","/etc/serving-cert/serving.key"]}'
         command:
         - /http-prober-bin/http-prober
-        image: gcr.io/google_containers/metrics-server-amd64:v0.3.4
+        image: k8s.gcr.io/metrics-server-amd64:v0.3.4
         name: metrics-server
         resources:
           limits:

--- a/api/pkg/resources/test/fixtures/deployment-aws-1.11.0-scheduler.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-aws-1.11.0-scheduler.yaml
@@ -108,7 +108,7 @@ spec:
         - '{"command":"/hyperkube","args":["kube-scheduler","--kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig"]}'
         command:
         - /http-prober-bin/http-prober
-        image: gcr.io/google_containers/hyperkube-amd64:v1.11.0
+        image: k8s.gcr.io/hyperkube-amd64:v1.11.0
         livenessProbe:
           failureThreshold: 8
           httpGet:

--- a/api/pkg/resources/test/fixtures/deployment-aws-1.11.1-apiserver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-aws-1.11.1-apiserver.yaml
@@ -238,7 +238,7 @@ spec:
           value: apiserver-external.cluster-de-test-01.svc.cluster.local.
         - name: no_proxy
           value: apiserver-external.cluster-de-test-01.svc.cluster.local.
-        image: gcr.io/google_containers/hyperkube-amd64:v1.11.1
+        image: k8s.gcr.io/hyperkube-amd64:v1.11.1
         livenessProbe:
           failureThreshold: 8
           httpGet:

--- a/api/pkg/resources/test/fixtures/deployment-aws-1.11.1-controller-manager.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-aws-1.11.1-controller-manager.yaml
@@ -129,7 +129,7 @@ spec:
           value: apiserver-external.cluster-de-test-01.svc.cluster.local.
         - name: no_proxy
           value: apiserver-external.cluster-de-test-01.svc.cluster.local.
-        image: gcr.io/google_containers/hyperkube-amd64:v1.11.1
+        image: k8s.gcr.io/hyperkube-amd64:v1.11.1
         livenessProbe:
           failureThreshold: 8
           httpGet:

--- a/api/pkg/resources/test/fixtures/deployment-aws-1.11.1-dns-resolver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-aws-1.11.1-dns-resolver.yaml
@@ -97,7 +97,7 @@ spec:
       - args:
         - -conf
         - /etc/coredns/Corefile
-        image: gcr.io/google_containers/coredns:1.1.3
+        image: k8s.gcr.io/coredns:1.1.3
         name: dns-resolver
         readinessProbe:
           failureThreshold: 3

--- a/api/pkg/resources/test/fixtures/deployment-aws-1.11.1-metrics-server.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-aws-1.11.1-metrics-server.yaml
@@ -51,7 +51,7 @@ spec:
         - '{"command":"/metrics-server","args":["--kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","--authentication-kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","--authorization-kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","--kubelet-port","10250","--kubelet-insecure-tls","--kubelet-preferred-address-types","ExternalIP,InternalIP","--v","1","--logtostderr","--tls-cert-file","/etc/serving-cert/serving.crt","--tls-private-key-file","/etc/serving-cert/serving.key"]}'
         command:
         - /http-prober-bin/http-prober
-        image: gcr.io/google_containers/metrics-server-amd64:v0.3.4
+        image: k8s.gcr.io/metrics-server-amd64:v0.3.4
         name: metrics-server
         resources:
           limits:

--- a/api/pkg/resources/test/fixtures/deployment-aws-1.11.1-scheduler.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-aws-1.11.1-scheduler.yaml
@@ -108,7 +108,7 @@ spec:
         - '{"command":"/hyperkube","args":["kube-scheduler","--kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig"]}'
         command:
         - /http-prober-bin/http-prober
-        image: gcr.io/google_containers/hyperkube-amd64:v1.11.1
+        image: k8s.gcr.io/hyperkube-amd64:v1.11.1
         livenessProbe:
           failureThreshold: 8
           httpGet:

--- a/api/pkg/resources/test/fixtures/deployment-aws-1.12.0-apiserver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-aws-1.12.0-apiserver.yaml
@@ -238,7 +238,7 @@ spec:
           value: apiserver-external.cluster-de-test-01.svc.cluster.local.
         - name: no_proxy
           value: apiserver-external.cluster-de-test-01.svc.cluster.local.
-        image: gcr.io/google_containers/hyperkube-amd64:v1.12.0
+        image: k8s.gcr.io/hyperkube-amd64:v1.12.0
         livenessProbe:
           failureThreshold: 8
           httpGet:

--- a/api/pkg/resources/test/fixtures/deployment-aws-1.12.0-controller-manager.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-aws-1.12.0-controller-manager.yaml
@@ -129,7 +129,7 @@ spec:
           value: apiserver-external.cluster-de-test-01.svc.cluster.local.
         - name: no_proxy
           value: apiserver-external.cluster-de-test-01.svc.cluster.local.
-        image: gcr.io/google_containers/hyperkube-amd64:v1.12.0
+        image: k8s.gcr.io/hyperkube-amd64:v1.12.0
         livenessProbe:
           failureThreshold: 8
           httpGet:

--- a/api/pkg/resources/test/fixtures/deployment-aws-1.12.0-dns-resolver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-aws-1.12.0-dns-resolver.yaml
@@ -97,7 +97,7 @@ spec:
       - args:
         - -conf
         - /etc/coredns/Corefile
-        image: gcr.io/google_containers/coredns:1.1.3
+        image: k8s.gcr.io/coredns:1.1.3
         name: dns-resolver
         readinessProbe:
           failureThreshold: 3

--- a/api/pkg/resources/test/fixtures/deployment-aws-1.12.0-metrics-server.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-aws-1.12.0-metrics-server.yaml
@@ -51,7 +51,7 @@ spec:
         - '{"command":"/metrics-server","args":["--kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","--authentication-kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","--authorization-kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","--kubelet-port","10250","--kubelet-insecure-tls","--kubelet-preferred-address-types","ExternalIP,InternalIP","--v","1","--logtostderr","--tls-cert-file","/etc/serving-cert/serving.crt","--tls-private-key-file","/etc/serving-cert/serving.key"]}'
         command:
         - /http-prober-bin/http-prober
-        image: gcr.io/google_containers/metrics-server-amd64:v0.3.4
+        image: k8s.gcr.io/metrics-server-amd64:v0.3.4
         name: metrics-server
         resources:
           limits:

--- a/api/pkg/resources/test/fixtures/deployment-aws-1.12.0-scheduler.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-aws-1.12.0-scheduler.yaml
@@ -108,7 +108,7 @@ spec:
         - '{"command":"/hyperkube","args":["kube-scheduler","--kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","--feature-gates","ScheduleDaemonSetPods=false"]}'
         command:
         - /http-prober-bin/http-prober
-        image: gcr.io/google_containers/hyperkube-amd64:v1.12.0
+        image: k8s.gcr.io/hyperkube-amd64:v1.12.0
         livenessProbe:
           failureThreshold: 8
           httpGet:

--- a/api/pkg/resources/test/fixtures/deployment-aws-1.13.0-apiserver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-aws-1.13.0-apiserver.yaml
@@ -238,7 +238,7 @@ spec:
           value: apiserver-external.cluster-de-test-01.svc.cluster.local.
         - name: no_proxy
           value: apiserver-external.cluster-de-test-01.svc.cluster.local.
-        image: gcr.io/google_containers/hyperkube-amd64:v1.13.0
+        image: k8s.gcr.io/hyperkube-amd64:v1.13.0
         livenessProbe:
           failureThreshold: 8
           httpGet:

--- a/api/pkg/resources/test/fixtures/deployment-aws-1.13.0-controller-manager.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-aws-1.13.0-controller-manager.yaml
@@ -129,7 +129,7 @@ spec:
           value: apiserver-external.cluster-de-test-01.svc.cluster.local.
         - name: no_proxy
           value: apiserver-external.cluster-de-test-01.svc.cluster.local.
-        image: gcr.io/google_containers/hyperkube-amd64:v1.13.0
+        image: k8s.gcr.io/hyperkube-amd64:v1.13.0
         livenessProbe:
           failureThreshold: 8
           httpGet:

--- a/api/pkg/resources/test/fixtures/deployment-aws-1.13.0-dns-resolver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-aws-1.13.0-dns-resolver.yaml
@@ -97,7 +97,7 @@ spec:
       - args:
         - -conf
         - /etc/coredns/Corefile
-        image: gcr.io/google_containers/coredns:1.1.3
+        image: k8s.gcr.io/coredns:1.1.3
         name: dns-resolver
         readinessProbe:
           failureThreshold: 3

--- a/api/pkg/resources/test/fixtures/deployment-aws-1.13.0-metrics-server.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-aws-1.13.0-metrics-server.yaml
@@ -51,7 +51,7 @@ spec:
         - '{"command":"/metrics-server","args":["--kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","--authentication-kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","--authorization-kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","--kubelet-port","10250","--kubelet-insecure-tls","--kubelet-preferred-address-types","ExternalIP,InternalIP","--v","1","--logtostderr","--tls-cert-file","/etc/serving-cert/serving.crt","--tls-private-key-file","/etc/serving-cert/serving.key"]}'
         command:
         - /http-prober-bin/http-prober
-        image: gcr.io/google_containers/metrics-server-amd64:v0.3.4
+        image: k8s.gcr.io/metrics-server-amd64:v0.3.4
         name: metrics-server
         resources:
           limits:

--- a/api/pkg/resources/test/fixtures/deployment-aws-1.13.0-scheduler.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-aws-1.13.0-scheduler.yaml
@@ -108,7 +108,7 @@ spec:
         - '{"command":"/hyperkube","args":["kube-scheduler","--kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","--authentication-kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","--authorization-kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","--client-ca-file","/etc/kubernetes/pki/ca/ca.crt","--port","0","--feature-gates","ScheduleDaemonSetPods=false"]}'
         command:
         - /http-prober-bin/http-prober
-        image: gcr.io/google_containers/hyperkube-amd64:v1.13.0
+        image: k8s.gcr.io/hyperkube-amd64:v1.13.0
         livenessProbe:
           failureThreshold: 8
           httpGet:

--- a/api/pkg/resources/test/fixtures/deployment-azure-1.10.0-apiserver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-azure-1.10.0-apiserver.yaml
@@ -234,7 +234,7 @@ spec:
           value: apiserver-external.cluster-de-test-01.svc.cluster.local.
         - name: no_proxy
           value: apiserver-external.cluster-de-test-01.svc.cluster.local.
-        image: gcr.io/google_containers/hyperkube-amd64:v1.10.0
+        image: k8s.gcr.io/hyperkube-amd64:v1.10.0
         livenessProbe:
           failureThreshold: 8
           httpGet:

--- a/api/pkg/resources/test/fixtures/deployment-azure-1.10.0-controller-manager.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-azure-1.10.0-controller-manager.yaml
@@ -123,7 +123,7 @@ spec:
           value: apiserver-external.cluster-de-test-01.svc.cluster.local.
         - name: no_proxy
           value: apiserver-external.cluster-de-test-01.svc.cluster.local.
-        image: gcr.io/google_containers/hyperkube-amd64:v1.10.0
+        image: k8s.gcr.io/hyperkube-amd64:v1.10.0
         livenessProbe:
           failureThreshold: 8
           httpGet:

--- a/api/pkg/resources/test/fixtures/deployment-azure-1.10.0-dns-resolver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-azure-1.10.0-dns-resolver.yaml
@@ -97,7 +97,7 @@ spec:
       - args:
         - -conf
         - /etc/coredns/Corefile
-        image: gcr.io/google_containers/coredns:1.1.3
+        image: k8s.gcr.io/coredns:1.1.3
         name: dns-resolver
         readinessProbe:
           failureThreshold: 3

--- a/api/pkg/resources/test/fixtures/deployment-azure-1.10.0-metrics-server.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-azure-1.10.0-metrics-server.yaml
@@ -51,7 +51,7 @@ spec:
         - '{"command":"/metrics-server","args":["--kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","--authentication-kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","--authorization-kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","--kubelet-port","10250","--kubelet-insecure-tls","--kubelet-preferred-address-types","ExternalIP,InternalIP","--v","1","--logtostderr","--tls-cert-file","/etc/serving-cert/serving.crt","--tls-private-key-file","/etc/serving-cert/serving.key"]}'
         command:
         - /http-prober-bin/http-prober
-        image: gcr.io/google_containers/metrics-server-amd64:v0.3.4
+        image: k8s.gcr.io/metrics-server-amd64:v0.3.4
         name: metrics-server
         resources:
           limits:

--- a/api/pkg/resources/test/fixtures/deployment-azure-1.10.0-scheduler.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-azure-1.10.0-scheduler.yaml
@@ -108,7 +108,7 @@ spec:
         - '{"command":"/hyperkube","args":["kube-scheduler","--kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig"]}'
         command:
         - /http-prober-bin/http-prober
-        image: gcr.io/google_containers/hyperkube-amd64:v1.10.0
+        image: k8s.gcr.io/hyperkube-amd64:v1.10.0
         livenessProbe:
           failureThreshold: 8
           httpGet:

--- a/api/pkg/resources/test/fixtures/deployment-azure-1.10.6-apiserver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-azure-1.10.6-apiserver.yaml
@@ -234,7 +234,7 @@ spec:
           value: apiserver-external.cluster-de-test-01.svc.cluster.local.
         - name: no_proxy
           value: apiserver-external.cluster-de-test-01.svc.cluster.local.
-        image: gcr.io/google_containers/hyperkube-amd64:v1.10.6
+        image: k8s.gcr.io/hyperkube-amd64:v1.10.6
         livenessProbe:
           failureThreshold: 8
           httpGet:

--- a/api/pkg/resources/test/fixtures/deployment-azure-1.10.6-controller-manager.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-azure-1.10.6-controller-manager.yaml
@@ -123,7 +123,7 @@ spec:
           value: apiserver-external.cluster-de-test-01.svc.cluster.local.
         - name: no_proxy
           value: apiserver-external.cluster-de-test-01.svc.cluster.local.
-        image: gcr.io/google_containers/hyperkube-amd64:v1.10.6
+        image: k8s.gcr.io/hyperkube-amd64:v1.10.6
         livenessProbe:
           failureThreshold: 8
           httpGet:

--- a/api/pkg/resources/test/fixtures/deployment-azure-1.10.6-dns-resolver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-azure-1.10.6-dns-resolver.yaml
@@ -97,7 +97,7 @@ spec:
       - args:
         - -conf
         - /etc/coredns/Corefile
-        image: gcr.io/google_containers/coredns:1.1.3
+        image: k8s.gcr.io/coredns:1.1.3
         name: dns-resolver
         readinessProbe:
           failureThreshold: 3

--- a/api/pkg/resources/test/fixtures/deployment-azure-1.10.6-metrics-server.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-azure-1.10.6-metrics-server.yaml
@@ -51,7 +51,7 @@ spec:
         - '{"command":"/metrics-server","args":["--kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","--authentication-kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","--authorization-kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","--kubelet-port","10250","--kubelet-insecure-tls","--kubelet-preferred-address-types","ExternalIP,InternalIP","--v","1","--logtostderr","--tls-cert-file","/etc/serving-cert/serving.crt","--tls-private-key-file","/etc/serving-cert/serving.key"]}'
         command:
         - /http-prober-bin/http-prober
-        image: gcr.io/google_containers/metrics-server-amd64:v0.3.4
+        image: k8s.gcr.io/metrics-server-amd64:v0.3.4
         name: metrics-server
         resources:
           limits:

--- a/api/pkg/resources/test/fixtures/deployment-azure-1.10.6-scheduler.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-azure-1.10.6-scheduler.yaml
@@ -108,7 +108,7 @@ spec:
         - '{"command":"/hyperkube","args":["kube-scheduler","--kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig"]}'
         command:
         - /http-prober-bin/http-prober
-        image: gcr.io/google_containers/hyperkube-amd64:v1.10.6
+        image: k8s.gcr.io/hyperkube-amd64:v1.10.6
         livenessProbe:
           failureThreshold: 8
           httpGet:

--- a/api/pkg/resources/test/fixtures/deployment-azure-1.11.0-apiserver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-azure-1.11.0-apiserver.yaml
@@ -232,7 +232,7 @@ spec:
           value: apiserver-external.cluster-de-test-01.svc.cluster.local.
         - name: no_proxy
           value: apiserver-external.cluster-de-test-01.svc.cluster.local.
-        image: gcr.io/google_containers/hyperkube-amd64:v1.11.0
+        image: k8s.gcr.io/hyperkube-amd64:v1.11.0
         livenessProbe:
           failureThreshold: 8
           httpGet:

--- a/api/pkg/resources/test/fixtures/deployment-azure-1.11.0-controller-manager.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-azure-1.11.0-controller-manager.yaml
@@ -123,7 +123,7 @@ spec:
           value: apiserver-external.cluster-de-test-01.svc.cluster.local.
         - name: no_proxy
           value: apiserver-external.cluster-de-test-01.svc.cluster.local.
-        image: gcr.io/google_containers/hyperkube-amd64:v1.11.0
+        image: k8s.gcr.io/hyperkube-amd64:v1.11.0
         livenessProbe:
           failureThreshold: 8
           httpGet:

--- a/api/pkg/resources/test/fixtures/deployment-azure-1.11.0-dns-resolver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-azure-1.11.0-dns-resolver.yaml
@@ -97,7 +97,7 @@ spec:
       - args:
         - -conf
         - /etc/coredns/Corefile
-        image: gcr.io/google_containers/coredns:1.1.3
+        image: k8s.gcr.io/coredns:1.1.3
         name: dns-resolver
         readinessProbe:
           failureThreshold: 3

--- a/api/pkg/resources/test/fixtures/deployment-azure-1.11.0-metrics-server.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-azure-1.11.0-metrics-server.yaml
@@ -51,7 +51,7 @@ spec:
         - '{"command":"/metrics-server","args":["--kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","--authentication-kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","--authorization-kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","--kubelet-port","10250","--kubelet-insecure-tls","--kubelet-preferred-address-types","ExternalIP,InternalIP","--v","1","--logtostderr","--tls-cert-file","/etc/serving-cert/serving.crt","--tls-private-key-file","/etc/serving-cert/serving.key"]}'
         command:
         - /http-prober-bin/http-prober
-        image: gcr.io/google_containers/metrics-server-amd64:v0.3.4
+        image: k8s.gcr.io/metrics-server-amd64:v0.3.4
         name: metrics-server
         resources:
           limits:

--- a/api/pkg/resources/test/fixtures/deployment-azure-1.11.0-scheduler.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-azure-1.11.0-scheduler.yaml
@@ -108,7 +108,7 @@ spec:
         - '{"command":"/hyperkube","args":["kube-scheduler","--kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig"]}'
         command:
         - /http-prober-bin/http-prober
-        image: gcr.io/google_containers/hyperkube-amd64:v1.11.0
+        image: k8s.gcr.io/hyperkube-amd64:v1.11.0
         livenessProbe:
           failureThreshold: 8
           httpGet:

--- a/api/pkg/resources/test/fixtures/deployment-azure-1.11.1-apiserver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-azure-1.11.1-apiserver.yaml
@@ -232,7 +232,7 @@ spec:
           value: apiserver-external.cluster-de-test-01.svc.cluster.local.
         - name: no_proxy
           value: apiserver-external.cluster-de-test-01.svc.cluster.local.
-        image: gcr.io/google_containers/hyperkube-amd64:v1.11.1
+        image: k8s.gcr.io/hyperkube-amd64:v1.11.1
         livenessProbe:
           failureThreshold: 8
           httpGet:

--- a/api/pkg/resources/test/fixtures/deployment-azure-1.11.1-controller-manager.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-azure-1.11.1-controller-manager.yaml
@@ -123,7 +123,7 @@ spec:
           value: apiserver-external.cluster-de-test-01.svc.cluster.local.
         - name: no_proxy
           value: apiserver-external.cluster-de-test-01.svc.cluster.local.
-        image: gcr.io/google_containers/hyperkube-amd64:v1.11.1
+        image: k8s.gcr.io/hyperkube-amd64:v1.11.1
         livenessProbe:
           failureThreshold: 8
           httpGet:

--- a/api/pkg/resources/test/fixtures/deployment-azure-1.11.1-dns-resolver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-azure-1.11.1-dns-resolver.yaml
@@ -97,7 +97,7 @@ spec:
       - args:
         - -conf
         - /etc/coredns/Corefile
-        image: gcr.io/google_containers/coredns:1.1.3
+        image: k8s.gcr.io/coredns:1.1.3
         name: dns-resolver
         readinessProbe:
           failureThreshold: 3

--- a/api/pkg/resources/test/fixtures/deployment-azure-1.11.1-metrics-server.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-azure-1.11.1-metrics-server.yaml
@@ -51,7 +51,7 @@ spec:
         - '{"command":"/metrics-server","args":["--kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","--authentication-kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","--authorization-kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","--kubelet-port","10250","--kubelet-insecure-tls","--kubelet-preferred-address-types","ExternalIP,InternalIP","--v","1","--logtostderr","--tls-cert-file","/etc/serving-cert/serving.crt","--tls-private-key-file","/etc/serving-cert/serving.key"]}'
         command:
         - /http-prober-bin/http-prober
-        image: gcr.io/google_containers/metrics-server-amd64:v0.3.4
+        image: k8s.gcr.io/metrics-server-amd64:v0.3.4
         name: metrics-server
         resources:
           limits:

--- a/api/pkg/resources/test/fixtures/deployment-azure-1.11.1-scheduler.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-azure-1.11.1-scheduler.yaml
@@ -108,7 +108,7 @@ spec:
         - '{"command":"/hyperkube","args":["kube-scheduler","--kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig"]}'
         command:
         - /http-prober-bin/http-prober
-        image: gcr.io/google_containers/hyperkube-amd64:v1.11.1
+        image: k8s.gcr.io/hyperkube-amd64:v1.11.1
         livenessProbe:
           failureThreshold: 8
           httpGet:

--- a/api/pkg/resources/test/fixtures/deployment-azure-1.12.0-apiserver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-azure-1.12.0-apiserver.yaml
@@ -232,7 +232,7 @@ spec:
           value: apiserver-external.cluster-de-test-01.svc.cluster.local.
         - name: no_proxy
           value: apiserver-external.cluster-de-test-01.svc.cluster.local.
-        image: gcr.io/google_containers/hyperkube-amd64:v1.12.0
+        image: k8s.gcr.io/hyperkube-amd64:v1.12.0
         livenessProbe:
           failureThreshold: 8
           httpGet:

--- a/api/pkg/resources/test/fixtures/deployment-azure-1.12.0-controller-manager.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-azure-1.12.0-controller-manager.yaml
@@ -123,7 +123,7 @@ spec:
           value: apiserver-external.cluster-de-test-01.svc.cluster.local.
         - name: no_proxy
           value: apiserver-external.cluster-de-test-01.svc.cluster.local.
-        image: gcr.io/google_containers/hyperkube-amd64:v1.12.0
+        image: k8s.gcr.io/hyperkube-amd64:v1.12.0
         livenessProbe:
           failureThreshold: 8
           httpGet:

--- a/api/pkg/resources/test/fixtures/deployment-azure-1.12.0-dns-resolver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-azure-1.12.0-dns-resolver.yaml
@@ -97,7 +97,7 @@ spec:
       - args:
         - -conf
         - /etc/coredns/Corefile
-        image: gcr.io/google_containers/coredns:1.1.3
+        image: k8s.gcr.io/coredns:1.1.3
         name: dns-resolver
         readinessProbe:
           failureThreshold: 3

--- a/api/pkg/resources/test/fixtures/deployment-azure-1.12.0-metrics-server.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-azure-1.12.0-metrics-server.yaml
@@ -51,7 +51,7 @@ spec:
         - '{"command":"/metrics-server","args":["--kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","--authentication-kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","--authorization-kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","--kubelet-port","10250","--kubelet-insecure-tls","--kubelet-preferred-address-types","ExternalIP,InternalIP","--v","1","--logtostderr","--tls-cert-file","/etc/serving-cert/serving.crt","--tls-private-key-file","/etc/serving-cert/serving.key"]}'
         command:
         - /http-prober-bin/http-prober
-        image: gcr.io/google_containers/metrics-server-amd64:v0.3.4
+        image: k8s.gcr.io/metrics-server-amd64:v0.3.4
         name: metrics-server
         resources:
           limits:

--- a/api/pkg/resources/test/fixtures/deployment-azure-1.12.0-scheduler.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-azure-1.12.0-scheduler.yaml
@@ -108,7 +108,7 @@ spec:
         - '{"command":"/hyperkube","args":["kube-scheduler","--kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","--feature-gates","ScheduleDaemonSetPods=false"]}'
         command:
         - /http-prober-bin/http-prober
-        image: gcr.io/google_containers/hyperkube-amd64:v1.12.0
+        image: k8s.gcr.io/hyperkube-amd64:v1.12.0
         livenessProbe:
           failureThreshold: 8
           httpGet:

--- a/api/pkg/resources/test/fixtures/deployment-azure-1.13.0-apiserver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-azure-1.13.0-apiserver.yaml
@@ -232,7 +232,7 @@ spec:
           value: apiserver-external.cluster-de-test-01.svc.cluster.local.
         - name: no_proxy
           value: apiserver-external.cluster-de-test-01.svc.cluster.local.
-        image: gcr.io/google_containers/hyperkube-amd64:v1.13.0
+        image: k8s.gcr.io/hyperkube-amd64:v1.13.0
         livenessProbe:
           failureThreshold: 8
           httpGet:

--- a/api/pkg/resources/test/fixtures/deployment-azure-1.13.0-controller-manager.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-azure-1.13.0-controller-manager.yaml
@@ -123,7 +123,7 @@ spec:
           value: apiserver-external.cluster-de-test-01.svc.cluster.local.
         - name: no_proxy
           value: apiserver-external.cluster-de-test-01.svc.cluster.local.
-        image: gcr.io/google_containers/hyperkube-amd64:v1.13.0
+        image: k8s.gcr.io/hyperkube-amd64:v1.13.0
         livenessProbe:
           failureThreshold: 8
           httpGet:

--- a/api/pkg/resources/test/fixtures/deployment-azure-1.13.0-dns-resolver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-azure-1.13.0-dns-resolver.yaml
@@ -97,7 +97,7 @@ spec:
       - args:
         - -conf
         - /etc/coredns/Corefile
-        image: gcr.io/google_containers/coredns:1.1.3
+        image: k8s.gcr.io/coredns:1.1.3
         name: dns-resolver
         readinessProbe:
           failureThreshold: 3

--- a/api/pkg/resources/test/fixtures/deployment-azure-1.13.0-metrics-server.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-azure-1.13.0-metrics-server.yaml
@@ -51,7 +51,7 @@ spec:
         - '{"command":"/metrics-server","args":["--kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","--authentication-kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","--authorization-kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","--kubelet-port","10250","--kubelet-insecure-tls","--kubelet-preferred-address-types","ExternalIP,InternalIP","--v","1","--logtostderr","--tls-cert-file","/etc/serving-cert/serving.crt","--tls-private-key-file","/etc/serving-cert/serving.key"]}'
         command:
         - /http-prober-bin/http-prober
-        image: gcr.io/google_containers/metrics-server-amd64:v0.3.4
+        image: k8s.gcr.io/metrics-server-amd64:v0.3.4
         name: metrics-server
         resources:
           limits:

--- a/api/pkg/resources/test/fixtures/deployment-azure-1.13.0-scheduler.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-azure-1.13.0-scheduler.yaml
@@ -108,7 +108,7 @@ spec:
         - '{"command":"/hyperkube","args":["kube-scheduler","--kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","--authentication-kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","--authorization-kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","--client-ca-file","/etc/kubernetes/pki/ca/ca.crt","--port","0","--feature-gates","ScheduleDaemonSetPods=false"]}'
         command:
         - /http-prober-bin/http-prober
-        image: gcr.io/google_containers/hyperkube-amd64:v1.13.0
+        image: k8s.gcr.io/hyperkube-amd64:v1.13.0
         livenessProbe:
           failureThreshold: 8
           httpGet:

--- a/api/pkg/resources/test/fixtures/deployment-bringyourown-1.10.0-apiserver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-bringyourown-1.10.0-apiserver.yaml
@@ -230,7 +230,7 @@ spec:
           value: apiserver-external.cluster-de-test-01.svc.cluster.local.
         - name: no_proxy
           value: apiserver-external.cluster-de-test-01.svc.cluster.local.
-        image: gcr.io/google_containers/hyperkube-amd64:v1.10.0
+        image: k8s.gcr.io/hyperkube-amd64:v1.10.0
         livenessProbe:
           failureThreshold: 8
           httpGet:

--- a/api/pkg/resources/test/fixtures/deployment-bringyourown-1.10.0-controller-manager.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-bringyourown-1.10.0-controller-manager.yaml
@@ -123,7 +123,7 @@ spec:
           value: apiserver-external.cluster-de-test-01.svc.cluster.local.
         - name: no_proxy
           value: apiserver-external.cluster-de-test-01.svc.cluster.local.
-        image: gcr.io/google_containers/hyperkube-amd64:v1.10.0
+        image: k8s.gcr.io/hyperkube-amd64:v1.10.0
         livenessProbe:
           failureThreshold: 8
           httpGet:

--- a/api/pkg/resources/test/fixtures/deployment-bringyourown-1.10.0-dns-resolver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-bringyourown-1.10.0-dns-resolver.yaml
@@ -97,7 +97,7 @@ spec:
       - args:
         - -conf
         - /etc/coredns/Corefile
-        image: gcr.io/google_containers/coredns:1.1.3
+        image: k8s.gcr.io/coredns:1.1.3
         name: dns-resolver
         readinessProbe:
           failureThreshold: 3

--- a/api/pkg/resources/test/fixtures/deployment-bringyourown-1.10.0-metrics-server.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-bringyourown-1.10.0-metrics-server.yaml
@@ -51,7 +51,7 @@ spec:
         - '{"command":"/metrics-server","args":["--kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","--authentication-kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","--authorization-kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","--kubelet-port","10250","--kubelet-insecure-tls","--kubelet-preferred-address-types","ExternalIP,InternalIP","--v","1","--logtostderr","--tls-cert-file","/etc/serving-cert/serving.crt","--tls-private-key-file","/etc/serving-cert/serving.key"]}'
         command:
         - /http-prober-bin/http-prober
-        image: gcr.io/google_containers/metrics-server-amd64:v0.3.4
+        image: k8s.gcr.io/metrics-server-amd64:v0.3.4
         name: metrics-server
         resources:
           limits:

--- a/api/pkg/resources/test/fixtures/deployment-bringyourown-1.10.0-scheduler.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-bringyourown-1.10.0-scheduler.yaml
@@ -108,7 +108,7 @@ spec:
         - '{"command":"/hyperkube","args":["kube-scheduler","--kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig"]}'
         command:
         - /http-prober-bin/http-prober
-        image: gcr.io/google_containers/hyperkube-amd64:v1.10.0
+        image: k8s.gcr.io/hyperkube-amd64:v1.10.0
         livenessProbe:
           failureThreshold: 8
           httpGet:

--- a/api/pkg/resources/test/fixtures/deployment-bringyourown-1.10.6-apiserver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-bringyourown-1.10.6-apiserver.yaml
@@ -230,7 +230,7 @@ spec:
           value: apiserver-external.cluster-de-test-01.svc.cluster.local.
         - name: no_proxy
           value: apiserver-external.cluster-de-test-01.svc.cluster.local.
-        image: gcr.io/google_containers/hyperkube-amd64:v1.10.6
+        image: k8s.gcr.io/hyperkube-amd64:v1.10.6
         livenessProbe:
           failureThreshold: 8
           httpGet:

--- a/api/pkg/resources/test/fixtures/deployment-bringyourown-1.10.6-controller-manager.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-bringyourown-1.10.6-controller-manager.yaml
@@ -123,7 +123,7 @@ spec:
           value: apiserver-external.cluster-de-test-01.svc.cluster.local.
         - name: no_proxy
           value: apiserver-external.cluster-de-test-01.svc.cluster.local.
-        image: gcr.io/google_containers/hyperkube-amd64:v1.10.6
+        image: k8s.gcr.io/hyperkube-amd64:v1.10.6
         livenessProbe:
           failureThreshold: 8
           httpGet:

--- a/api/pkg/resources/test/fixtures/deployment-bringyourown-1.10.6-dns-resolver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-bringyourown-1.10.6-dns-resolver.yaml
@@ -97,7 +97,7 @@ spec:
       - args:
         - -conf
         - /etc/coredns/Corefile
-        image: gcr.io/google_containers/coredns:1.1.3
+        image: k8s.gcr.io/coredns:1.1.3
         name: dns-resolver
         readinessProbe:
           failureThreshold: 3

--- a/api/pkg/resources/test/fixtures/deployment-bringyourown-1.10.6-metrics-server.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-bringyourown-1.10.6-metrics-server.yaml
@@ -51,7 +51,7 @@ spec:
         - '{"command":"/metrics-server","args":["--kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","--authentication-kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","--authorization-kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","--kubelet-port","10250","--kubelet-insecure-tls","--kubelet-preferred-address-types","ExternalIP,InternalIP","--v","1","--logtostderr","--tls-cert-file","/etc/serving-cert/serving.crt","--tls-private-key-file","/etc/serving-cert/serving.key"]}'
         command:
         - /http-prober-bin/http-prober
-        image: gcr.io/google_containers/metrics-server-amd64:v0.3.4
+        image: k8s.gcr.io/metrics-server-amd64:v0.3.4
         name: metrics-server
         resources:
           limits:

--- a/api/pkg/resources/test/fixtures/deployment-bringyourown-1.10.6-scheduler.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-bringyourown-1.10.6-scheduler.yaml
@@ -108,7 +108,7 @@ spec:
         - '{"command":"/hyperkube","args":["kube-scheduler","--kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig"]}'
         command:
         - /http-prober-bin/http-prober
-        image: gcr.io/google_containers/hyperkube-amd64:v1.10.6
+        image: k8s.gcr.io/hyperkube-amd64:v1.10.6
         livenessProbe:
           failureThreshold: 8
           httpGet:

--- a/api/pkg/resources/test/fixtures/deployment-bringyourown-1.11.0-apiserver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-bringyourown-1.11.0-apiserver.yaml
@@ -228,7 +228,7 @@ spec:
           value: apiserver-external.cluster-de-test-01.svc.cluster.local.
         - name: no_proxy
           value: apiserver-external.cluster-de-test-01.svc.cluster.local.
-        image: gcr.io/google_containers/hyperkube-amd64:v1.11.0
+        image: k8s.gcr.io/hyperkube-amd64:v1.11.0
         livenessProbe:
           failureThreshold: 8
           httpGet:

--- a/api/pkg/resources/test/fixtures/deployment-bringyourown-1.11.0-controller-manager.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-bringyourown-1.11.0-controller-manager.yaml
@@ -123,7 +123,7 @@ spec:
           value: apiserver-external.cluster-de-test-01.svc.cluster.local.
         - name: no_proxy
           value: apiserver-external.cluster-de-test-01.svc.cluster.local.
-        image: gcr.io/google_containers/hyperkube-amd64:v1.11.0
+        image: k8s.gcr.io/hyperkube-amd64:v1.11.0
         livenessProbe:
           failureThreshold: 8
           httpGet:

--- a/api/pkg/resources/test/fixtures/deployment-bringyourown-1.11.0-dns-resolver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-bringyourown-1.11.0-dns-resolver.yaml
@@ -97,7 +97,7 @@ spec:
       - args:
         - -conf
         - /etc/coredns/Corefile
-        image: gcr.io/google_containers/coredns:1.1.3
+        image: k8s.gcr.io/coredns:1.1.3
         name: dns-resolver
         readinessProbe:
           failureThreshold: 3

--- a/api/pkg/resources/test/fixtures/deployment-bringyourown-1.11.0-metrics-server.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-bringyourown-1.11.0-metrics-server.yaml
@@ -51,7 +51,7 @@ spec:
         - '{"command":"/metrics-server","args":["--kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","--authentication-kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","--authorization-kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","--kubelet-port","10250","--kubelet-insecure-tls","--kubelet-preferred-address-types","ExternalIP,InternalIP","--v","1","--logtostderr","--tls-cert-file","/etc/serving-cert/serving.crt","--tls-private-key-file","/etc/serving-cert/serving.key"]}'
         command:
         - /http-prober-bin/http-prober
-        image: gcr.io/google_containers/metrics-server-amd64:v0.3.4
+        image: k8s.gcr.io/metrics-server-amd64:v0.3.4
         name: metrics-server
         resources:
           limits:

--- a/api/pkg/resources/test/fixtures/deployment-bringyourown-1.11.0-scheduler.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-bringyourown-1.11.0-scheduler.yaml
@@ -108,7 +108,7 @@ spec:
         - '{"command":"/hyperkube","args":["kube-scheduler","--kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig"]}'
         command:
         - /http-prober-bin/http-prober
-        image: gcr.io/google_containers/hyperkube-amd64:v1.11.0
+        image: k8s.gcr.io/hyperkube-amd64:v1.11.0
         livenessProbe:
           failureThreshold: 8
           httpGet:

--- a/api/pkg/resources/test/fixtures/deployment-bringyourown-1.11.1-apiserver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-bringyourown-1.11.1-apiserver.yaml
@@ -228,7 +228,7 @@ spec:
           value: apiserver-external.cluster-de-test-01.svc.cluster.local.
         - name: no_proxy
           value: apiserver-external.cluster-de-test-01.svc.cluster.local.
-        image: gcr.io/google_containers/hyperkube-amd64:v1.11.1
+        image: k8s.gcr.io/hyperkube-amd64:v1.11.1
         livenessProbe:
           failureThreshold: 8
           httpGet:

--- a/api/pkg/resources/test/fixtures/deployment-bringyourown-1.11.1-controller-manager.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-bringyourown-1.11.1-controller-manager.yaml
@@ -123,7 +123,7 @@ spec:
           value: apiserver-external.cluster-de-test-01.svc.cluster.local.
         - name: no_proxy
           value: apiserver-external.cluster-de-test-01.svc.cluster.local.
-        image: gcr.io/google_containers/hyperkube-amd64:v1.11.1
+        image: k8s.gcr.io/hyperkube-amd64:v1.11.1
         livenessProbe:
           failureThreshold: 8
           httpGet:

--- a/api/pkg/resources/test/fixtures/deployment-bringyourown-1.11.1-dns-resolver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-bringyourown-1.11.1-dns-resolver.yaml
@@ -97,7 +97,7 @@ spec:
       - args:
         - -conf
         - /etc/coredns/Corefile
-        image: gcr.io/google_containers/coredns:1.1.3
+        image: k8s.gcr.io/coredns:1.1.3
         name: dns-resolver
         readinessProbe:
           failureThreshold: 3

--- a/api/pkg/resources/test/fixtures/deployment-bringyourown-1.11.1-metrics-server.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-bringyourown-1.11.1-metrics-server.yaml
@@ -51,7 +51,7 @@ spec:
         - '{"command":"/metrics-server","args":["--kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","--authentication-kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","--authorization-kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","--kubelet-port","10250","--kubelet-insecure-tls","--kubelet-preferred-address-types","ExternalIP,InternalIP","--v","1","--logtostderr","--tls-cert-file","/etc/serving-cert/serving.crt","--tls-private-key-file","/etc/serving-cert/serving.key"]}'
         command:
         - /http-prober-bin/http-prober
-        image: gcr.io/google_containers/metrics-server-amd64:v0.3.4
+        image: k8s.gcr.io/metrics-server-amd64:v0.3.4
         name: metrics-server
         resources:
           limits:

--- a/api/pkg/resources/test/fixtures/deployment-bringyourown-1.11.1-scheduler.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-bringyourown-1.11.1-scheduler.yaml
@@ -108,7 +108,7 @@ spec:
         - '{"command":"/hyperkube","args":["kube-scheduler","--kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig"]}'
         command:
         - /http-prober-bin/http-prober
-        image: gcr.io/google_containers/hyperkube-amd64:v1.11.1
+        image: k8s.gcr.io/hyperkube-amd64:v1.11.1
         livenessProbe:
           failureThreshold: 8
           httpGet:

--- a/api/pkg/resources/test/fixtures/deployment-bringyourown-1.12.0-apiserver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-bringyourown-1.12.0-apiserver.yaml
@@ -228,7 +228,7 @@ spec:
           value: apiserver-external.cluster-de-test-01.svc.cluster.local.
         - name: no_proxy
           value: apiserver-external.cluster-de-test-01.svc.cluster.local.
-        image: gcr.io/google_containers/hyperkube-amd64:v1.12.0
+        image: k8s.gcr.io/hyperkube-amd64:v1.12.0
         livenessProbe:
           failureThreshold: 8
           httpGet:

--- a/api/pkg/resources/test/fixtures/deployment-bringyourown-1.12.0-controller-manager.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-bringyourown-1.12.0-controller-manager.yaml
@@ -123,7 +123,7 @@ spec:
           value: apiserver-external.cluster-de-test-01.svc.cluster.local.
         - name: no_proxy
           value: apiserver-external.cluster-de-test-01.svc.cluster.local.
-        image: gcr.io/google_containers/hyperkube-amd64:v1.12.0
+        image: k8s.gcr.io/hyperkube-amd64:v1.12.0
         livenessProbe:
           failureThreshold: 8
           httpGet:

--- a/api/pkg/resources/test/fixtures/deployment-bringyourown-1.12.0-dns-resolver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-bringyourown-1.12.0-dns-resolver.yaml
@@ -97,7 +97,7 @@ spec:
       - args:
         - -conf
         - /etc/coredns/Corefile
-        image: gcr.io/google_containers/coredns:1.1.3
+        image: k8s.gcr.io/coredns:1.1.3
         name: dns-resolver
         readinessProbe:
           failureThreshold: 3

--- a/api/pkg/resources/test/fixtures/deployment-bringyourown-1.12.0-metrics-server.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-bringyourown-1.12.0-metrics-server.yaml
@@ -51,7 +51,7 @@ spec:
         - '{"command":"/metrics-server","args":["--kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","--authentication-kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","--authorization-kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","--kubelet-port","10250","--kubelet-insecure-tls","--kubelet-preferred-address-types","ExternalIP,InternalIP","--v","1","--logtostderr","--tls-cert-file","/etc/serving-cert/serving.crt","--tls-private-key-file","/etc/serving-cert/serving.key"]}'
         command:
         - /http-prober-bin/http-prober
-        image: gcr.io/google_containers/metrics-server-amd64:v0.3.4
+        image: k8s.gcr.io/metrics-server-amd64:v0.3.4
         name: metrics-server
         resources:
           limits:

--- a/api/pkg/resources/test/fixtures/deployment-bringyourown-1.12.0-scheduler.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-bringyourown-1.12.0-scheduler.yaml
@@ -108,7 +108,7 @@ spec:
         - '{"command":"/hyperkube","args":["kube-scheduler","--kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","--feature-gates","ScheduleDaemonSetPods=false"]}'
         command:
         - /http-prober-bin/http-prober
-        image: gcr.io/google_containers/hyperkube-amd64:v1.12.0
+        image: k8s.gcr.io/hyperkube-amd64:v1.12.0
         livenessProbe:
           failureThreshold: 8
           httpGet:

--- a/api/pkg/resources/test/fixtures/deployment-bringyourown-1.13.0-apiserver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-bringyourown-1.13.0-apiserver.yaml
@@ -228,7 +228,7 @@ spec:
           value: apiserver-external.cluster-de-test-01.svc.cluster.local.
         - name: no_proxy
           value: apiserver-external.cluster-de-test-01.svc.cluster.local.
-        image: gcr.io/google_containers/hyperkube-amd64:v1.13.0
+        image: k8s.gcr.io/hyperkube-amd64:v1.13.0
         livenessProbe:
           failureThreshold: 8
           httpGet:

--- a/api/pkg/resources/test/fixtures/deployment-bringyourown-1.13.0-controller-manager.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-bringyourown-1.13.0-controller-manager.yaml
@@ -123,7 +123,7 @@ spec:
           value: apiserver-external.cluster-de-test-01.svc.cluster.local.
         - name: no_proxy
           value: apiserver-external.cluster-de-test-01.svc.cluster.local.
-        image: gcr.io/google_containers/hyperkube-amd64:v1.13.0
+        image: k8s.gcr.io/hyperkube-amd64:v1.13.0
         livenessProbe:
           failureThreshold: 8
           httpGet:

--- a/api/pkg/resources/test/fixtures/deployment-bringyourown-1.13.0-dns-resolver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-bringyourown-1.13.0-dns-resolver.yaml
@@ -97,7 +97,7 @@ spec:
       - args:
         - -conf
         - /etc/coredns/Corefile
-        image: gcr.io/google_containers/coredns:1.1.3
+        image: k8s.gcr.io/coredns:1.1.3
         name: dns-resolver
         readinessProbe:
           failureThreshold: 3

--- a/api/pkg/resources/test/fixtures/deployment-bringyourown-1.13.0-metrics-server.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-bringyourown-1.13.0-metrics-server.yaml
@@ -51,7 +51,7 @@ spec:
         - '{"command":"/metrics-server","args":["--kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","--authentication-kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","--authorization-kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","--kubelet-port","10250","--kubelet-insecure-tls","--kubelet-preferred-address-types","ExternalIP,InternalIP","--v","1","--logtostderr","--tls-cert-file","/etc/serving-cert/serving.crt","--tls-private-key-file","/etc/serving-cert/serving.key"]}'
         command:
         - /http-prober-bin/http-prober
-        image: gcr.io/google_containers/metrics-server-amd64:v0.3.4
+        image: k8s.gcr.io/metrics-server-amd64:v0.3.4
         name: metrics-server
         resources:
           limits:

--- a/api/pkg/resources/test/fixtures/deployment-bringyourown-1.13.0-scheduler.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-bringyourown-1.13.0-scheduler.yaml
@@ -108,7 +108,7 @@ spec:
         - '{"command":"/hyperkube","args":["kube-scheduler","--kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","--authentication-kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","--authorization-kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","--client-ca-file","/etc/kubernetes/pki/ca/ca.crt","--port","0","--feature-gates","ScheduleDaemonSetPods=false"]}'
         command:
         - /http-prober-bin/http-prober
-        image: gcr.io/google_containers/hyperkube-amd64:v1.13.0
+        image: k8s.gcr.io/hyperkube-amd64:v1.13.0
         livenessProbe:
           failureThreshold: 8
           httpGet:

--- a/api/pkg/resources/test/fixtures/deployment-digitalocean-1.10.0-apiserver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-digitalocean-1.10.0-apiserver.yaml
@@ -230,7 +230,7 @@ spec:
           value: apiserver-external.cluster-de-test-01.svc.cluster.local.
         - name: no_proxy
           value: apiserver-external.cluster-de-test-01.svc.cluster.local.
-        image: gcr.io/google_containers/hyperkube-amd64:v1.10.0
+        image: k8s.gcr.io/hyperkube-amd64:v1.10.0
         livenessProbe:
           failureThreshold: 8
           httpGet:

--- a/api/pkg/resources/test/fixtures/deployment-digitalocean-1.10.0-controller-manager.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-digitalocean-1.10.0-controller-manager.yaml
@@ -123,7 +123,7 @@ spec:
           value: apiserver-external.cluster-de-test-01.svc.cluster.local.
         - name: no_proxy
           value: apiserver-external.cluster-de-test-01.svc.cluster.local.
-        image: gcr.io/google_containers/hyperkube-amd64:v1.10.0
+        image: k8s.gcr.io/hyperkube-amd64:v1.10.0
         livenessProbe:
           failureThreshold: 8
           httpGet:

--- a/api/pkg/resources/test/fixtures/deployment-digitalocean-1.10.0-dns-resolver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-digitalocean-1.10.0-dns-resolver.yaml
@@ -97,7 +97,7 @@ spec:
       - args:
         - -conf
         - /etc/coredns/Corefile
-        image: gcr.io/google_containers/coredns:1.1.3
+        image: k8s.gcr.io/coredns:1.1.3
         name: dns-resolver
         readinessProbe:
           failureThreshold: 3

--- a/api/pkg/resources/test/fixtures/deployment-digitalocean-1.10.0-metrics-server.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-digitalocean-1.10.0-metrics-server.yaml
@@ -51,7 +51,7 @@ spec:
         - '{"command":"/metrics-server","args":["--kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","--authentication-kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","--authorization-kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","--kubelet-port","10250","--kubelet-insecure-tls","--kubelet-preferred-address-types","ExternalIP,InternalIP","--v","1","--logtostderr","--tls-cert-file","/etc/serving-cert/serving.crt","--tls-private-key-file","/etc/serving-cert/serving.key"]}'
         command:
         - /http-prober-bin/http-prober
-        image: gcr.io/google_containers/metrics-server-amd64:v0.3.4
+        image: k8s.gcr.io/metrics-server-amd64:v0.3.4
         name: metrics-server
         resources:
           limits:

--- a/api/pkg/resources/test/fixtures/deployment-digitalocean-1.10.0-scheduler.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-digitalocean-1.10.0-scheduler.yaml
@@ -108,7 +108,7 @@ spec:
         - '{"command":"/hyperkube","args":["kube-scheduler","--kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig"]}'
         command:
         - /http-prober-bin/http-prober
-        image: gcr.io/google_containers/hyperkube-amd64:v1.10.0
+        image: k8s.gcr.io/hyperkube-amd64:v1.10.0
         livenessProbe:
           failureThreshold: 8
           httpGet:

--- a/api/pkg/resources/test/fixtures/deployment-digitalocean-1.10.6-apiserver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-digitalocean-1.10.6-apiserver.yaml
@@ -230,7 +230,7 @@ spec:
           value: apiserver-external.cluster-de-test-01.svc.cluster.local.
         - name: no_proxy
           value: apiserver-external.cluster-de-test-01.svc.cluster.local.
-        image: gcr.io/google_containers/hyperkube-amd64:v1.10.6
+        image: k8s.gcr.io/hyperkube-amd64:v1.10.6
         livenessProbe:
           failureThreshold: 8
           httpGet:

--- a/api/pkg/resources/test/fixtures/deployment-digitalocean-1.10.6-controller-manager.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-digitalocean-1.10.6-controller-manager.yaml
@@ -123,7 +123,7 @@ spec:
           value: apiserver-external.cluster-de-test-01.svc.cluster.local.
         - name: no_proxy
           value: apiserver-external.cluster-de-test-01.svc.cluster.local.
-        image: gcr.io/google_containers/hyperkube-amd64:v1.10.6
+        image: k8s.gcr.io/hyperkube-amd64:v1.10.6
         livenessProbe:
           failureThreshold: 8
           httpGet:

--- a/api/pkg/resources/test/fixtures/deployment-digitalocean-1.10.6-dns-resolver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-digitalocean-1.10.6-dns-resolver.yaml
@@ -97,7 +97,7 @@ spec:
       - args:
         - -conf
         - /etc/coredns/Corefile
-        image: gcr.io/google_containers/coredns:1.1.3
+        image: k8s.gcr.io/coredns:1.1.3
         name: dns-resolver
         readinessProbe:
           failureThreshold: 3

--- a/api/pkg/resources/test/fixtures/deployment-digitalocean-1.10.6-metrics-server.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-digitalocean-1.10.6-metrics-server.yaml
@@ -51,7 +51,7 @@ spec:
         - '{"command":"/metrics-server","args":["--kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","--authentication-kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","--authorization-kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","--kubelet-port","10250","--kubelet-insecure-tls","--kubelet-preferred-address-types","ExternalIP,InternalIP","--v","1","--logtostderr","--tls-cert-file","/etc/serving-cert/serving.crt","--tls-private-key-file","/etc/serving-cert/serving.key"]}'
         command:
         - /http-prober-bin/http-prober
-        image: gcr.io/google_containers/metrics-server-amd64:v0.3.4
+        image: k8s.gcr.io/metrics-server-amd64:v0.3.4
         name: metrics-server
         resources:
           limits:

--- a/api/pkg/resources/test/fixtures/deployment-digitalocean-1.10.6-scheduler.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-digitalocean-1.10.6-scheduler.yaml
@@ -108,7 +108,7 @@ spec:
         - '{"command":"/hyperkube","args":["kube-scheduler","--kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig"]}'
         command:
         - /http-prober-bin/http-prober
-        image: gcr.io/google_containers/hyperkube-amd64:v1.10.6
+        image: k8s.gcr.io/hyperkube-amd64:v1.10.6
         livenessProbe:
           failureThreshold: 8
           httpGet:

--- a/api/pkg/resources/test/fixtures/deployment-digitalocean-1.11.0-apiserver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-digitalocean-1.11.0-apiserver.yaml
@@ -228,7 +228,7 @@ spec:
           value: apiserver-external.cluster-de-test-01.svc.cluster.local.
         - name: no_proxy
           value: apiserver-external.cluster-de-test-01.svc.cluster.local.
-        image: gcr.io/google_containers/hyperkube-amd64:v1.11.0
+        image: k8s.gcr.io/hyperkube-amd64:v1.11.0
         livenessProbe:
           failureThreshold: 8
           httpGet:

--- a/api/pkg/resources/test/fixtures/deployment-digitalocean-1.11.0-controller-manager.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-digitalocean-1.11.0-controller-manager.yaml
@@ -123,7 +123,7 @@ spec:
           value: apiserver-external.cluster-de-test-01.svc.cluster.local.
         - name: no_proxy
           value: apiserver-external.cluster-de-test-01.svc.cluster.local.
-        image: gcr.io/google_containers/hyperkube-amd64:v1.11.0
+        image: k8s.gcr.io/hyperkube-amd64:v1.11.0
         livenessProbe:
           failureThreshold: 8
           httpGet:

--- a/api/pkg/resources/test/fixtures/deployment-digitalocean-1.11.0-dns-resolver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-digitalocean-1.11.0-dns-resolver.yaml
@@ -97,7 +97,7 @@ spec:
       - args:
         - -conf
         - /etc/coredns/Corefile
-        image: gcr.io/google_containers/coredns:1.1.3
+        image: k8s.gcr.io/coredns:1.1.3
         name: dns-resolver
         readinessProbe:
           failureThreshold: 3

--- a/api/pkg/resources/test/fixtures/deployment-digitalocean-1.11.0-metrics-server.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-digitalocean-1.11.0-metrics-server.yaml
@@ -51,7 +51,7 @@ spec:
         - '{"command":"/metrics-server","args":["--kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","--authentication-kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","--authorization-kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","--kubelet-port","10250","--kubelet-insecure-tls","--kubelet-preferred-address-types","ExternalIP,InternalIP","--v","1","--logtostderr","--tls-cert-file","/etc/serving-cert/serving.crt","--tls-private-key-file","/etc/serving-cert/serving.key"]}'
         command:
         - /http-prober-bin/http-prober
-        image: gcr.io/google_containers/metrics-server-amd64:v0.3.4
+        image: k8s.gcr.io/metrics-server-amd64:v0.3.4
         name: metrics-server
         resources:
           limits:

--- a/api/pkg/resources/test/fixtures/deployment-digitalocean-1.11.0-scheduler.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-digitalocean-1.11.0-scheduler.yaml
@@ -108,7 +108,7 @@ spec:
         - '{"command":"/hyperkube","args":["kube-scheduler","--kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig"]}'
         command:
         - /http-prober-bin/http-prober
-        image: gcr.io/google_containers/hyperkube-amd64:v1.11.0
+        image: k8s.gcr.io/hyperkube-amd64:v1.11.0
         livenessProbe:
           failureThreshold: 8
           httpGet:

--- a/api/pkg/resources/test/fixtures/deployment-digitalocean-1.11.1-apiserver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-digitalocean-1.11.1-apiserver.yaml
@@ -228,7 +228,7 @@ spec:
           value: apiserver-external.cluster-de-test-01.svc.cluster.local.
         - name: no_proxy
           value: apiserver-external.cluster-de-test-01.svc.cluster.local.
-        image: gcr.io/google_containers/hyperkube-amd64:v1.11.1
+        image: k8s.gcr.io/hyperkube-amd64:v1.11.1
         livenessProbe:
           failureThreshold: 8
           httpGet:

--- a/api/pkg/resources/test/fixtures/deployment-digitalocean-1.11.1-controller-manager.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-digitalocean-1.11.1-controller-manager.yaml
@@ -123,7 +123,7 @@ spec:
           value: apiserver-external.cluster-de-test-01.svc.cluster.local.
         - name: no_proxy
           value: apiserver-external.cluster-de-test-01.svc.cluster.local.
-        image: gcr.io/google_containers/hyperkube-amd64:v1.11.1
+        image: k8s.gcr.io/hyperkube-amd64:v1.11.1
         livenessProbe:
           failureThreshold: 8
           httpGet:

--- a/api/pkg/resources/test/fixtures/deployment-digitalocean-1.11.1-dns-resolver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-digitalocean-1.11.1-dns-resolver.yaml
@@ -97,7 +97,7 @@ spec:
       - args:
         - -conf
         - /etc/coredns/Corefile
-        image: gcr.io/google_containers/coredns:1.1.3
+        image: k8s.gcr.io/coredns:1.1.3
         name: dns-resolver
         readinessProbe:
           failureThreshold: 3

--- a/api/pkg/resources/test/fixtures/deployment-digitalocean-1.11.1-metrics-server.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-digitalocean-1.11.1-metrics-server.yaml
@@ -51,7 +51,7 @@ spec:
         - '{"command":"/metrics-server","args":["--kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","--authentication-kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","--authorization-kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","--kubelet-port","10250","--kubelet-insecure-tls","--kubelet-preferred-address-types","ExternalIP,InternalIP","--v","1","--logtostderr","--tls-cert-file","/etc/serving-cert/serving.crt","--tls-private-key-file","/etc/serving-cert/serving.key"]}'
         command:
         - /http-prober-bin/http-prober
-        image: gcr.io/google_containers/metrics-server-amd64:v0.3.4
+        image: k8s.gcr.io/metrics-server-amd64:v0.3.4
         name: metrics-server
         resources:
           limits:

--- a/api/pkg/resources/test/fixtures/deployment-digitalocean-1.11.1-scheduler.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-digitalocean-1.11.1-scheduler.yaml
@@ -108,7 +108,7 @@ spec:
         - '{"command":"/hyperkube","args":["kube-scheduler","--kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig"]}'
         command:
         - /http-prober-bin/http-prober
-        image: gcr.io/google_containers/hyperkube-amd64:v1.11.1
+        image: k8s.gcr.io/hyperkube-amd64:v1.11.1
         livenessProbe:
           failureThreshold: 8
           httpGet:

--- a/api/pkg/resources/test/fixtures/deployment-digitalocean-1.12.0-apiserver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-digitalocean-1.12.0-apiserver.yaml
@@ -228,7 +228,7 @@ spec:
           value: apiserver-external.cluster-de-test-01.svc.cluster.local.
         - name: no_proxy
           value: apiserver-external.cluster-de-test-01.svc.cluster.local.
-        image: gcr.io/google_containers/hyperkube-amd64:v1.12.0
+        image: k8s.gcr.io/hyperkube-amd64:v1.12.0
         livenessProbe:
           failureThreshold: 8
           httpGet:

--- a/api/pkg/resources/test/fixtures/deployment-digitalocean-1.12.0-controller-manager.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-digitalocean-1.12.0-controller-manager.yaml
@@ -123,7 +123,7 @@ spec:
           value: apiserver-external.cluster-de-test-01.svc.cluster.local.
         - name: no_proxy
           value: apiserver-external.cluster-de-test-01.svc.cluster.local.
-        image: gcr.io/google_containers/hyperkube-amd64:v1.12.0
+        image: k8s.gcr.io/hyperkube-amd64:v1.12.0
         livenessProbe:
           failureThreshold: 8
           httpGet:

--- a/api/pkg/resources/test/fixtures/deployment-digitalocean-1.12.0-dns-resolver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-digitalocean-1.12.0-dns-resolver.yaml
@@ -97,7 +97,7 @@ spec:
       - args:
         - -conf
         - /etc/coredns/Corefile
-        image: gcr.io/google_containers/coredns:1.1.3
+        image: k8s.gcr.io/coredns:1.1.3
         name: dns-resolver
         readinessProbe:
           failureThreshold: 3

--- a/api/pkg/resources/test/fixtures/deployment-digitalocean-1.12.0-metrics-server.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-digitalocean-1.12.0-metrics-server.yaml
@@ -51,7 +51,7 @@ spec:
         - '{"command":"/metrics-server","args":["--kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","--authentication-kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","--authorization-kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","--kubelet-port","10250","--kubelet-insecure-tls","--kubelet-preferred-address-types","ExternalIP,InternalIP","--v","1","--logtostderr","--tls-cert-file","/etc/serving-cert/serving.crt","--tls-private-key-file","/etc/serving-cert/serving.key"]}'
         command:
         - /http-prober-bin/http-prober
-        image: gcr.io/google_containers/metrics-server-amd64:v0.3.4
+        image: k8s.gcr.io/metrics-server-amd64:v0.3.4
         name: metrics-server
         resources:
           limits:

--- a/api/pkg/resources/test/fixtures/deployment-digitalocean-1.12.0-scheduler.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-digitalocean-1.12.0-scheduler.yaml
@@ -108,7 +108,7 @@ spec:
         - '{"command":"/hyperkube","args":["kube-scheduler","--kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","--feature-gates","ScheduleDaemonSetPods=false"]}'
         command:
         - /http-prober-bin/http-prober
-        image: gcr.io/google_containers/hyperkube-amd64:v1.12.0
+        image: k8s.gcr.io/hyperkube-amd64:v1.12.0
         livenessProbe:
           failureThreshold: 8
           httpGet:

--- a/api/pkg/resources/test/fixtures/deployment-digitalocean-1.13.0-apiserver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-digitalocean-1.13.0-apiserver.yaml
@@ -228,7 +228,7 @@ spec:
           value: apiserver-external.cluster-de-test-01.svc.cluster.local.
         - name: no_proxy
           value: apiserver-external.cluster-de-test-01.svc.cluster.local.
-        image: gcr.io/google_containers/hyperkube-amd64:v1.13.0
+        image: k8s.gcr.io/hyperkube-amd64:v1.13.0
         livenessProbe:
           failureThreshold: 8
           httpGet:

--- a/api/pkg/resources/test/fixtures/deployment-digitalocean-1.13.0-controller-manager.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-digitalocean-1.13.0-controller-manager.yaml
@@ -123,7 +123,7 @@ spec:
           value: apiserver-external.cluster-de-test-01.svc.cluster.local.
         - name: no_proxy
           value: apiserver-external.cluster-de-test-01.svc.cluster.local.
-        image: gcr.io/google_containers/hyperkube-amd64:v1.13.0
+        image: k8s.gcr.io/hyperkube-amd64:v1.13.0
         livenessProbe:
           failureThreshold: 8
           httpGet:

--- a/api/pkg/resources/test/fixtures/deployment-digitalocean-1.13.0-dns-resolver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-digitalocean-1.13.0-dns-resolver.yaml
@@ -97,7 +97,7 @@ spec:
       - args:
         - -conf
         - /etc/coredns/Corefile
-        image: gcr.io/google_containers/coredns:1.1.3
+        image: k8s.gcr.io/coredns:1.1.3
         name: dns-resolver
         readinessProbe:
           failureThreshold: 3

--- a/api/pkg/resources/test/fixtures/deployment-digitalocean-1.13.0-metrics-server.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-digitalocean-1.13.0-metrics-server.yaml
@@ -51,7 +51,7 @@ spec:
         - '{"command":"/metrics-server","args":["--kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","--authentication-kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","--authorization-kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","--kubelet-port","10250","--kubelet-insecure-tls","--kubelet-preferred-address-types","ExternalIP,InternalIP","--v","1","--logtostderr","--tls-cert-file","/etc/serving-cert/serving.crt","--tls-private-key-file","/etc/serving-cert/serving.key"]}'
         command:
         - /http-prober-bin/http-prober
-        image: gcr.io/google_containers/metrics-server-amd64:v0.3.4
+        image: k8s.gcr.io/metrics-server-amd64:v0.3.4
         name: metrics-server
         resources:
           limits:

--- a/api/pkg/resources/test/fixtures/deployment-digitalocean-1.13.0-scheduler.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-digitalocean-1.13.0-scheduler.yaml
@@ -108,7 +108,7 @@ spec:
         - '{"command":"/hyperkube","args":["kube-scheduler","--kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","--authentication-kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","--authorization-kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","--client-ca-file","/etc/kubernetes/pki/ca/ca.crt","--port","0","--feature-gates","ScheduleDaemonSetPods=false"]}'
         command:
         - /http-prober-bin/http-prober
-        image: gcr.io/google_containers/hyperkube-amd64:v1.13.0
+        image: k8s.gcr.io/hyperkube-amd64:v1.13.0
         livenessProbe:
           failureThreshold: 8
           httpGet:

--- a/api/pkg/resources/test/fixtures/deployment-openstack-1.10.0-apiserver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-openstack-1.10.0-apiserver.yaml
@@ -234,7 +234,7 @@ spec:
           value: apiserver-external.cluster-de-test-01.svc.cluster.local.
         - name: no_proxy
           value: apiserver-external.cluster-de-test-01.svc.cluster.local.
-        image: gcr.io/google_containers/hyperkube-amd64:v1.10.0
+        image: k8s.gcr.io/hyperkube-amd64:v1.10.0
         livenessProbe:
           failureThreshold: 8
           httpGet:

--- a/api/pkg/resources/test/fixtures/deployment-openstack-1.10.0-controller-manager.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-openstack-1.10.0-controller-manager.yaml
@@ -123,7 +123,7 @@ spec:
           value: apiserver-external.cluster-de-test-01.svc.cluster.local.
         - name: no_proxy
           value: apiserver-external.cluster-de-test-01.svc.cluster.local.
-        image: gcr.io/google_containers/hyperkube-amd64:v1.10.0
+        image: k8s.gcr.io/hyperkube-amd64:v1.10.0
         livenessProbe:
           failureThreshold: 8
           httpGet:

--- a/api/pkg/resources/test/fixtures/deployment-openstack-1.10.0-dns-resolver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-openstack-1.10.0-dns-resolver.yaml
@@ -97,7 +97,7 @@ spec:
       - args:
         - -conf
         - /etc/coredns/Corefile
-        image: gcr.io/google_containers/coredns:1.1.3
+        image: k8s.gcr.io/coredns:1.1.3
         name: dns-resolver
         readinessProbe:
           failureThreshold: 3

--- a/api/pkg/resources/test/fixtures/deployment-openstack-1.10.0-metrics-server.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-openstack-1.10.0-metrics-server.yaml
@@ -51,7 +51,7 @@ spec:
         - '{"command":"/metrics-server","args":["--kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","--authentication-kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","--authorization-kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","--kubelet-port","10250","--kubelet-insecure-tls","--kubelet-preferred-address-types","ExternalIP,InternalIP","--v","1","--logtostderr","--tls-cert-file","/etc/serving-cert/serving.crt","--tls-private-key-file","/etc/serving-cert/serving.key"]}'
         command:
         - /http-prober-bin/http-prober
-        image: gcr.io/google_containers/metrics-server-amd64:v0.3.4
+        image: k8s.gcr.io/metrics-server-amd64:v0.3.4
         name: metrics-server
         resources:
           limits:

--- a/api/pkg/resources/test/fixtures/deployment-openstack-1.10.0-scheduler.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-openstack-1.10.0-scheduler.yaml
@@ -108,7 +108,7 @@ spec:
         - '{"command":"/hyperkube","args":["kube-scheduler","--kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig"]}'
         command:
         - /http-prober-bin/http-prober
-        image: gcr.io/google_containers/hyperkube-amd64:v1.10.0
+        image: k8s.gcr.io/hyperkube-amd64:v1.10.0
         livenessProbe:
           failureThreshold: 8
           httpGet:

--- a/api/pkg/resources/test/fixtures/deployment-openstack-1.10.6-apiserver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-openstack-1.10.6-apiserver.yaml
@@ -234,7 +234,7 @@ spec:
           value: apiserver-external.cluster-de-test-01.svc.cluster.local.
         - name: no_proxy
           value: apiserver-external.cluster-de-test-01.svc.cluster.local.
-        image: gcr.io/google_containers/hyperkube-amd64:v1.10.6
+        image: k8s.gcr.io/hyperkube-amd64:v1.10.6
         livenessProbe:
           failureThreshold: 8
           httpGet:

--- a/api/pkg/resources/test/fixtures/deployment-openstack-1.10.6-controller-manager.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-openstack-1.10.6-controller-manager.yaml
@@ -123,7 +123,7 @@ spec:
           value: apiserver-external.cluster-de-test-01.svc.cluster.local.
         - name: no_proxy
           value: apiserver-external.cluster-de-test-01.svc.cluster.local.
-        image: gcr.io/google_containers/hyperkube-amd64:v1.10.6
+        image: k8s.gcr.io/hyperkube-amd64:v1.10.6
         livenessProbe:
           failureThreshold: 8
           httpGet:

--- a/api/pkg/resources/test/fixtures/deployment-openstack-1.10.6-dns-resolver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-openstack-1.10.6-dns-resolver.yaml
@@ -97,7 +97,7 @@ spec:
       - args:
         - -conf
         - /etc/coredns/Corefile
-        image: gcr.io/google_containers/coredns:1.1.3
+        image: k8s.gcr.io/coredns:1.1.3
         name: dns-resolver
         readinessProbe:
           failureThreshold: 3

--- a/api/pkg/resources/test/fixtures/deployment-openstack-1.10.6-metrics-server.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-openstack-1.10.6-metrics-server.yaml
@@ -51,7 +51,7 @@ spec:
         - '{"command":"/metrics-server","args":["--kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","--authentication-kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","--authorization-kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","--kubelet-port","10250","--kubelet-insecure-tls","--kubelet-preferred-address-types","ExternalIP,InternalIP","--v","1","--logtostderr","--tls-cert-file","/etc/serving-cert/serving.crt","--tls-private-key-file","/etc/serving-cert/serving.key"]}'
         command:
         - /http-prober-bin/http-prober
-        image: gcr.io/google_containers/metrics-server-amd64:v0.3.4
+        image: k8s.gcr.io/metrics-server-amd64:v0.3.4
         name: metrics-server
         resources:
           limits:

--- a/api/pkg/resources/test/fixtures/deployment-openstack-1.10.6-scheduler.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-openstack-1.10.6-scheduler.yaml
@@ -108,7 +108,7 @@ spec:
         - '{"command":"/hyperkube","args":["kube-scheduler","--kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig"]}'
         command:
         - /http-prober-bin/http-prober
-        image: gcr.io/google_containers/hyperkube-amd64:v1.10.6
+        image: k8s.gcr.io/hyperkube-amd64:v1.10.6
         livenessProbe:
           failureThreshold: 8
           httpGet:

--- a/api/pkg/resources/test/fixtures/deployment-openstack-1.11.0-apiserver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-openstack-1.11.0-apiserver.yaml
@@ -232,7 +232,7 @@ spec:
           value: apiserver-external.cluster-de-test-01.svc.cluster.local.
         - name: no_proxy
           value: apiserver-external.cluster-de-test-01.svc.cluster.local.
-        image: gcr.io/google_containers/hyperkube-amd64:v1.11.0
+        image: k8s.gcr.io/hyperkube-amd64:v1.11.0
         livenessProbe:
           failureThreshold: 8
           httpGet:

--- a/api/pkg/resources/test/fixtures/deployment-openstack-1.11.0-controller-manager.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-openstack-1.11.0-controller-manager.yaml
@@ -123,7 +123,7 @@ spec:
           value: apiserver-external.cluster-de-test-01.svc.cluster.local.
         - name: no_proxy
           value: apiserver-external.cluster-de-test-01.svc.cluster.local.
-        image: gcr.io/google_containers/hyperkube-amd64:v1.11.0
+        image: k8s.gcr.io/hyperkube-amd64:v1.11.0
         livenessProbe:
           failureThreshold: 8
           httpGet:

--- a/api/pkg/resources/test/fixtures/deployment-openstack-1.11.0-dns-resolver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-openstack-1.11.0-dns-resolver.yaml
@@ -97,7 +97,7 @@ spec:
       - args:
         - -conf
         - /etc/coredns/Corefile
-        image: gcr.io/google_containers/coredns:1.1.3
+        image: k8s.gcr.io/coredns:1.1.3
         name: dns-resolver
         readinessProbe:
           failureThreshold: 3

--- a/api/pkg/resources/test/fixtures/deployment-openstack-1.11.0-metrics-server.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-openstack-1.11.0-metrics-server.yaml
@@ -51,7 +51,7 @@ spec:
         - '{"command":"/metrics-server","args":["--kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","--authentication-kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","--authorization-kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","--kubelet-port","10250","--kubelet-insecure-tls","--kubelet-preferred-address-types","ExternalIP,InternalIP","--v","1","--logtostderr","--tls-cert-file","/etc/serving-cert/serving.crt","--tls-private-key-file","/etc/serving-cert/serving.key"]}'
         command:
         - /http-prober-bin/http-prober
-        image: gcr.io/google_containers/metrics-server-amd64:v0.3.4
+        image: k8s.gcr.io/metrics-server-amd64:v0.3.4
         name: metrics-server
         resources:
           limits:

--- a/api/pkg/resources/test/fixtures/deployment-openstack-1.11.0-scheduler.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-openstack-1.11.0-scheduler.yaml
@@ -108,7 +108,7 @@ spec:
         - '{"command":"/hyperkube","args":["kube-scheduler","--kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig"]}'
         command:
         - /http-prober-bin/http-prober
-        image: gcr.io/google_containers/hyperkube-amd64:v1.11.0
+        image: k8s.gcr.io/hyperkube-amd64:v1.11.0
         livenessProbe:
           failureThreshold: 8
           httpGet:

--- a/api/pkg/resources/test/fixtures/deployment-openstack-1.11.1-apiserver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-openstack-1.11.1-apiserver.yaml
@@ -232,7 +232,7 @@ spec:
           value: apiserver-external.cluster-de-test-01.svc.cluster.local.
         - name: no_proxy
           value: apiserver-external.cluster-de-test-01.svc.cluster.local.
-        image: gcr.io/google_containers/hyperkube-amd64:v1.11.1
+        image: k8s.gcr.io/hyperkube-amd64:v1.11.1
         livenessProbe:
           failureThreshold: 8
           httpGet:

--- a/api/pkg/resources/test/fixtures/deployment-openstack-1.11.1-controller-manager.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-openstack-1.11.1-controller-manager.yaml
@@ -123,7 +123,7 @@ spec:
           value: apiserver-external.cluster-de-test-01.svc.cluster.local.
         - name: no_proxy
           value: apiserver-external.cluster-de-test-01.svc.cluster.local.
-        image: gcr.io/google_containers/hyperkube-amd64:v1.11.1
+        image: k8s.gcr.io/hyperkube-amd64:v1.11.1
         livenessProbe:
           failureThreshold: 8
           httpGet:

--- a/api/pkg/resources/test/fixtures/deployment-openstack-1.11.1-dns-resolver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-openstack-1.11.1-dns-resolver.yaml
@@ -97,7 +97,7 @@ spec:
       - args:
         - -conf
         - /etc/coredns/Corefile
-        image: gcr.io/google_containers/coredns:1.1.3
+        image: k8s.gcr.io/coredns:1.1.3
         name: dns-resolver
         readinessProbe:
           failureThreshold: 3

--- a/api/pkg/resources/test/fixtures/deployment-openstack-1.11.1-metrics-server.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-openstack-1.11.1-metrics-server.yaml
@@ -51,7 +51,7 @@ spec:
         - '{"command":"/metrics-server","args":["--kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","--authentication-kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","--authorization-kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","--kubelet-port","10250","--kubelet-insecure-tls","--kubelet-preferred-address-types","ExternalIP,InternalIP","--v","1","--logtostderr","--tls-cert-file","/etc/serving-cert/serving.crt","--tls-private-key-file","/etc/serving-cert/serving.key"]}'
         command:
         - /http-prober-bin/http-prober
-        image: gcr.io/google_containers/metrics-server-amd64:v0.3.4
+        image: k8s.gcr.io/metrics-server-amd64:v0.3.4
         name: metrics-server
         resources:
           limits:

--- a/api/pkg/resources/test/fixtures/deployment-openstack-1.11.1-scheduler.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-openstack-1.11.1-scheduler.yaml
@@ -108,7 +108,7 @@ spec:
         - '{"command":"/hyperkube","args":["kube-scheduler","--kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig"]}'
         command:
         - /http-prober-bin/http-prober
-        image: gcr.io/google_containers/hyperkube-amd64:v1.11.1
+        image: k8s.gcr.io/hyperkube-amd64:v1.11.1
         livenessProbe:
           failureThreshold: 8
           httpGet:

--- a/api/pkg/resources/test/fixtures/deployment-openstack-1.12.0-apiserver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-openstack-1.12.0-apiserver.yaml
@@ -232,7 +232,7 @@ spec:
           value: apiserver-external.cluster-de-test-01.svc.cluster.local.
         - name: no_proxy
           value: apiserver-external.cluster-de-test-01.svc.cluster.local.
-        image: gcr.io/google_containers/hyperkube-amd64:v1.12.0
+        image: k8s.gcr.io/hyperkube-amd64:v1.12.0
         livenessProbe:
           failureThreshold: 8
           httpGet:

--- a/api/pkg/resources/test/fixtures/deployment-openstack-1.12.0-controller-manager.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-openstack-1.12.0-controller-manager.yaml
@@ -123,7 +123,7 @@ spec:
           value: apiserver-external.cluster-de-test-01.svc.cluster.local.
         - name: no_proxy
           value: apiserver-external.cluster-de-test-01.svc.cluster.local.
-        image: gcr.io/google_containers/hyperkube-amd64:v1.12.0
+        image: k8s.gcr.io/hyperkube-amd64:v1.12.0
         livenessProbe:
           failureThreshold: 8
           httpGet:

--- a/api/pkg/resources/test/fixtures/deployment-openstack-1.12.0-dns-resolver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-openstack-1.12.0-dns-resolver.yaml
@@ -97,7 +97,7 @@ spec:
       - args:
         - -conf
         - /etc/coredns/Corefile
-        image: gcr.io/google_containers/coredns:1.1.3
+        image: k8s.gcr.io/coredns:1.1.3
         name: dns-resolver
         readinessProbe:
           failureThreshold: 3

--- a/api/pkg/resources/test/fixtures/deployment-openstack-1.12.0-metrics-server.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-openstack-1.12.0-metrics-server.yaml
@@ -51,7 +51,7 @@ spec:
         - '{"command":"/metrics-server","args":["--kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","--authentication-kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","--authorization-kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","--kubelet-port","10250","--kubelet-insecure-tls","--kubelet-preferred-address-types","ExternalIP,InternalIP","--v","1","--logtostderr","--tls-cert-file","/etc/serving-cert/serving.crt","--tls-private-key-file","/etc/serving-cert/serving.key"]}'
         command:
         - /http-prober-bin/http-prober
-        image: gcr.io/google_containers/metrics-server-amd64:v0.3.4
+        image: k8s.gcr.io/metrics-server-amd64:v0.3.4
         name: metrics-server
         resources:
           limits:

--- a/api/pkg/resources/test/fixtures/deployment-openstack-1.12.0-scheduler.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-openstack-1.12.0-scheduler.yaml
@@ -108,7 +108,7 @@ spec:
         - '{"command":"/hyperkube","args":["kube-scheduler","--kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","--feature-gates","ScheduleDaemonSetPods=false"]}'
         command:
         - /http-prober-bin/http-prober
-        image: gcr.io/google_containers/hyperkube-amd64:v1.12.0
+        image: k8s.gcr.io/hyperkube-amd64:v1.12.0
         livenessProbe:
           failureThreshold: 8
           httpGet:

--- a/api/pkg/resources/test/fixtures/deployment-openstack-1.13.0-apiserver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-openstack-1.13.0-apiserver.yaml
@@ -232,7 +232,7 @@ spec:
           value: apiserver-external.cluster-de-test-01.svc.cluster.local.
         - name: no_proxy
           value: apiserver-external.cluster-de-test-01.svc.cluster.local.
-        image: gcr.io/google_containers/hyperkube-amd64:v1.13.0
+        image: k8s.gcr.io/hyperkube-amd64:v1.13.0
         livenessProbe:
           failureThreshold: 8
           httpGet:

--- a/api/pkg/resources/test/fixtures/deployment-openstack-1.13.0-controller-manager.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-openstack-1.13.0-controller-manager.yaml
@@ -123,7 +123,7 @@ spec:
           value: apiserver-external.cluster-de-test-01.svc.cluster.local.
         - name: no_proxy
           value: apiserver-external.cluster-de-test-01.svc.cluster.local.
-        image: gcr.io/google_containers/hyperkube-amd64:v1.13.0
+        image: k8s.gcr.io/hyperkube-amd64:v1.13.0
         livenessProbe:
           failureThreshold: 8
           httpGet:

--- a/api/pkg/resources/test/fixtures/deployment-openstack-1.13.0-dns-resolver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-openstack-1.13.0-dns-resolver.yaml
@@ -97,7 +97,7 @@ spec:
       - args:
         - -conf
         - /etc/coredns/Corefile
-        image: gcr.io/google_containers/coredns:1.1.3
+        image: k8s.gcr.io/coredns:1.1.3
         name: dns-resolver
         readinessProbe:
           failureThreshold: 3

--- a/api/pkg/resources/test/fixtures/deployment-openstack-1.13.0-metrics-server.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-openstack-1.13.0-metrics-server.yaml
@@ -51,7 +51,7 @@ spec:
         - '{"command":"/metrics-server","args":["--kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","--authentication-kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","--authorization-kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","--kubelet-port","10250","--kubelet-insecure-tls","--kubelet-preferred-address-types","ExternalIP,InternalIP","--v","1","--logtostderr","--tls-cert-file","/etc/serving-cert/serving.crt","--tls-private-key-file","/etc/serving-cert/serving.key"]}'
         command:
         - /http-prober-bin/http-prober
-        image: gcr.io/google_containers/metrics-server-amd64:v0.3.4
+        image: k8s.gcr.io/metrics-server-amd64:v0.3.4
         name: metrics-server
         resources:
           limits:

--- a/api/pkg/resources/test/fixtures/deployment-openstack-1.13.0-scheduler.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-openstack-1.13.0-scheduler.yaml
@@ -108,7 +108,7 @@ spec:
         - '{"command":"/hyperkube","args":["kube-scheduler","--kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","--authentication-kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","--authorization-kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","--client-ca-file","/etc/kubernetes/pki/ca/ca.crt","--port","0","--feature-gates","ScheduleDaemonSetPods=false"]}'
         command:
         - /http-prober-bin/http-prober
-        image: gcr.io/google_containers/hyperkube-amd64:v1.13.0
+        image: k8s.gcr.io/hyperkube-amd64:v1.13.0
         livenessProbe:
           failureThreshold: 8
           httpGet:

--- a/api/pkg/resources/test/fixtures/deployment-vsphere-1.10.0-apiserver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-vsphere-1.10.0-apiserver.yaml
@@ -234,7 +234,7 @@ spec:
           value: apiserver-external.cluster-de-test-01.svc.cluster.local.
         - name: no_proxy
           value: apiserver-external.cluster-de-test-01.svc.cluster.local.
-        image: gcr.io/google_containers/hyperkube-amd64:v1.10.0
+        image: k8s.gcr.io/hyperkube-amd64:v1.10.0
         livenessProbe:
           failureThreshold: 8
           httpGet:

--- a/api/pkg/resources/test/fixtures/deployment-vsphere-1.10.0-controller-manager.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-vsphere-1.10.0-controller-manager.yaml
@@ -123,7 +123,7 @@ spec:
           value: apiserver-external.cluster-de-test-01.svc.cluster.local.
         - name: no_proxy
           value: apiserver-external.cluster-de-test-01.svc.cluster.local.
-        image: gcr.io/google_containers/hyperkube-amd64:v1.10.0
+        image: k8s.gcr.io/hyperkube-amd64:v1.10.0
         livenessProbe:
           failureThreshold: 8
           httpGet:

--- a/api/pkg/resources/test/fixtures/deployment-vsphere-1.10.0-dns-resolver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-vsphere-1.10.0-dns-resolver.yaml
@@ -97,7 +97,7 @@ spec:
       - args:
         - -conf
         - /etc/coredns/Corefile
-        image: gcr.io/google_containers/coredns:1.1.3
+        image: k8s.gcr.io/coredns:1.1.3
         name: dns-resolver
         readinessProbe:
           failureThreshold: 3

--- a/api/pkg/resources/test/fixtures/deployment-vsphere-1.10.0-metrics-server.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-vsphere-1.10.0-metrics-server.yaml
@@ -51,7 +51,7 @@ spec:
         - '{"command":"/metrics-server","args":["--kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","--authentication-kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","--authorization-kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","--kubelet-port","10250","--kubelet-insecure-tls","--kubelet-preferred-address-types","ExternalIP,InternalIP","--v","1","--logtostderr","--tls-cert-file","/etc/serving-cert/serving.crt","--tls-private-key-file","/etc/serving-cert/serving.key"]}'
         command:
         - /http-prober-bin/http-prober
-        image: gcr.io/google_containers/metrics-server-amd64:v0.3.4
+        image: k8s.gcr.io/metrics-server-amd64:v0.3.4
         name: metrics-server
         resources:
           limits:

--- a/api/pkg/resources/test/fixtures/deployment-vsphere-1.10.0-scheduler.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-vsphere-1.10.0-scheduler.yaml
@@ -108,7 +108,7 @@ spec:
         - '{"command":"/hyperkube","args":["kube-scheduler","--kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig"]}'
         command:
         - /http-prober-bin/http-prober
-        image: gcr.io/google_containers/hyperkube-amd64:v1.10.0
+        image: k8s.gcr.io/hyperkube-amd64:v1.10.0
         livenessProbe:
           failureThreshold: 8
           httpGet:

--- a/api/pkg/resources/test/fixtures/deployment-vsphere-1.10.6-apiserver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-vsphere-1.10.6-apiserver.yaml
@@ -234,7 +234,7 @@ spec:
           value: apiserver-external.cluster-de-test-01.svc.cluster.local.
         - name: no_proxy
           value: apiserver-external.cluster-de-test-01.svc.cluster.local.
-        image: gcr.io/google_containers/hyperkube-amd64:v1.10.6
+        image: k8s.gcr.io/hyperkube-amd64:v1.10.6
         livenessProbe:
           failureThreshold: 8
           httpGet:

--- a/api/pkg/resources/test/fixtures/deployment-vsphere-1.10.6-controller-manager.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-vsphere-1.10.6-controller-manager.yaml
@@ -123,7 +123,7 @@ spec:
           value: apiserver-external.cluster-de-test-01.svc.cluster.local.
         - name: no_proxy
           value: apiserver-external.cluster-de-test-01.svc.cluster.local.
-        image: gcr.io/google_containers/hyperkube-amd64:v1.10.6
+        image: k8s.gcr.io/hyperkube-amd64:v1.10.6
         livenessProbe:
           failureThreshold: 8
           httpGet:

--- a/api/pkg/resources/test/fixtures/deployment-vsphere-1.10.6-dns-resolver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-vsphere-1.10.6-dns-resolver.yaml
@@ -97,7 +97,7 @@ spec:
       - args:
         - -conf
         - /etc/coredns/Corefile
-        image: gcr.io/google_containers/coredns:1.1.3
+        image: k8s.gcr.io/coredns:1.1.3
         name: dns-resolver
         readinessProbe:
           failureThreshold: 3

--- a/api/pkg/resources/test/fixtures/deployment-vsphere-1.10.6-metrics-server.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-vsphere-1.10.6-metrics-server.yaml
@@ -51,7 +51,7 @@ spec:
         - '{"command":"/metrics-server","args":["--kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","--authentication-kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","--authorization-kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","--kubelet-port","10250","--kubelet-insecure-tls","--kubelet-preferred-address-types","ExternalIP,InternalIP","--v","1","--logtostderr","--tls-cert-file","/etc/serving-cert/serving.crt","--tls-private-key-file","/etc/serving-cert/serving.key"]}'
         command:
         - /http-prober-bin/http-prober
-        image: gcr.io/google_containers/metrics-server-amd64:v0.3.4
+        image: k8s.gcr.io/metrics-server-amd64:v0.3.4
         name: metrics-server
         resources:
           limits:

--- a/api/pkg/resources/test/fixtures/deployment-vsphere-1.10.6-scheduler.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-vsphere-1.10.6-scheduler.yaml
@@ -108,7 +108,7 @@ spec:
         - '{"command":"/hyperkube","args":["kube-scheduler","--kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig"]}'
         command:
         - /http-prober-bin/http-prober
-        image: gcr.io/google_containers/hyperkube-amd64:v1.10.6
+        image: k8s.gcr.io/hyperkube-amd64:v1.10.6
         livenessProbe:
           failureThreshold: 8
           httpGet:

--- a/api/pkg/resources/test/fixtures/deployment-vsphere-1.11.0-apiserver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-vsphere-1.11.0-apiserver.yaml
@@ -232,7 +232,7 @@ spec:
           value: apiserver-external.cluster-de-test-01.svc.cluster.local.
         - name: no_proxy
           value: apiserver-external.cluster-de-test-01.svc.cluster.local.
-        image: gcr.io/google_containers/hyperkube-amd64:v1.11.0
+        image: k8s.gcr.io/hyperkube-amd64:v1.11.0
         livenessProbe:
           failureThreshold: 8
           httpGet:

--- a/api/pkg/resources/test/fixtures/deployment-vsphere-1.11.0-controller-manager.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-vsphere-1.11.0-controller-manager.yaml
@@ -123,7 +123,7 @@ spec:
           value: apiserver-external.cluster-de-test-01.svc.cluster.local.
         - name: no_proxy
           value: apiserver-external.cluster-de-test-01.svc.cluster.local.
-        image: gcr.io/google_containers/hyperkube-amd64:v1.11.0
+        image: k8s.gcr.io/hyperkube-amd64:v1.11.0
         livenessProbe:
           failureThreshold: 8
           httpGet:

--- a/api/pkg/resources/test/fixtures/deployment-vsphere-1.11.0-dns-resolver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-vsphere-1.11.0-dns-resolver.yaml
@@ -97,7 +97,7 @@ spec:
       - args:
         - -conf
         - /etc/coredns/Corefile
-        image: gcr.io/google_containers/coredns:1.1.3
+        image: k8s.gcr.io/coredns:1.1.3
         name: dns-resolver
         readinessProbe:
           failureThreshold: 3

--- a/api/pkg/resources/test/fixtures/deployment-vsphere-1.11.0-metrics-server.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-vsphere-1.11.0-metrics-server.yaml
@@ -51,7 +51,7 @@ spec:
         - '{"command":"/metrics-server","args":["--kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","--authentication-kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","--authorization-kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","--kubelet-port","10250","--kubelet-insecure-tls","--kubelet-preferred-address-types","ExternalIP,InternalIP","--v","1","--logtostderr","--tls-cert-file","/etc/serving-cert/serving.crt","--tls-private-key-file","/etc/serving-cert/serving.key"]}'
         command:
         - /http-prober-bin/http-prober
-        image: gcr.io/google_containers/metrics-server-amd64:v0.3.4
+        image: k8s.gcr.io/metrics-server-amd64:v0.3.4
         name: metrics-server
         resources:
           limits:

--- a/api/pkg/resources/test/fixtures/deployment-vsphere-1.11.0-scheduler.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-vsphere-1.11.0-scheduler.yaml
@@ -108,7 +108,7 @@ spec:
         - '{"command":"/hyperkube","args":["kube-scheduler","--kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig"]}'
         command:
         - /http-prober-bin/http-prober
-        image: gcr.io/google_containers/hyperkube-amd64:v1.11.0
+        image: k8s.gcr.io/hyperkube-amd64:v1.11.0
         livenessProbe:
           failureThreshold: 8
           httpGet:

--- a/api/pkg/resources/test/fixtures/deployment-vsphere-1.11.1-apiserver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-vsphere-1.11.1-apiserver.yaml
@@ -232,7 +232,7 @@ spec:
           value: apiserver-external.cluster-de-test-01.svc.cluster.local.
         - name: no_proxy
           value: apiserver-external.cluster-de-test-01.svc.cluster.local.
-        image: gcr.io/google_containers/hyperkube-amd64:v1.11.1
+        image: k8s.gcr.io/hyperkube-amd64:v1.11.1
         livenessProbe:
           failureThreshold: 8
           httpGet:

--- a/api/pkg/resources/test/fixtures/deployment-vsphere-1.11.1-controller-manager.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-vsphere-1.11.1-controller-manager.yaml
@@ -123,7 +123,7 @@ spec:
           value: apiserver-external.cluster-de-test-01.svc.cluster.local.
         - name: no_proxy
           value: apiserver-external.cluster-de-test-01.svc.cluster.local.
-        image: gcr.io/google_containers/hyperkube-amd64:v1.11.1
+        image: k8s.gcr.io/hyperkube-amd64:v1.11.1
         livenessProbe:
           failureThreshold: 8
           httpGet:

--- a/api/pkg/resources/test/fixtures/deployment-vsphere-1.11.1-dns-resolver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-vsphere-1.11.1-dns-resolver.yaml
@@ -97,7 +97,7 @@ spec:
       - args:
         - -conf
         - /etc/coredns/Corefile
-        image: gcr.io/google_containers/coredns:1.1.3
+        image: k8s.gcr.io/coredns:1.1.3
         name: dns-resolver
         readinessProbe:
           failureThreshold: 3

--- a/api/pkg/resources/test/fixtures/deployment-vsphere-1.11.1-metrics-server.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-vsphere-1.11.1-metrics-server.yaml
@@ -51,7 +51,7 @@ spec:
         - '{"command":"/metrics-server","args":["--kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","--authentication-kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","--authorization-kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","--kubelet-port","10250","--kubelet-insecure-tls","--kubelet-preferred-address-types","ExternalIP,InternalIP","--v","1","--logtostderr","--tls-cert-file","/etc/serving-cert/serving.crt","--tls-private-key-file","/etc/serving-cert/serving.key"]}'
         command:
         - /http-prober-bin/http-prober
-        image: gcr.io/google_containers/metrics-server-amd64:v0.3.4
+        image: k8s.gcr.io/metrics-server-amd64:v0.3.4
         name: metrics-server
         resources:
           limits:

--- a/api/pkg/resources/test/fixtures/deployment-vsphere-1.11.1-scheduler.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-vsphere-1.11.1-scheduler.yaml
@@ -108,7 +108,7 @@ spec:
         - '{"command":"/hyperkube","args":["kube-scheduler","--kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig"]}'
         command:
         - /http-prober-bin/http-prober
-        image: gcr.io/google_containers/hyperkube-amd64:v1.11.1
+        image: k8s.gcr.io/hyperkube-amd64:v1.11.1
         livenessProbe:
           failureThreshold: 8
           httpGet:

--- a/api/pkg/resources/test/fixtures/deployment-vsphere-1.12.0-apiserver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-vsphere-1.12.0-apiserver.yaml
@@ -232,7 +232,7 @@ spec:
           value: apiserver-external.cluster-de-test-01.svc.cluster.local.
         - name: no_proxy
           value: apiserver-external.cluster-de-test-01.svc.cluster.local.
-        image: gcr.io/google_containers/hyperkube-amd64:v1.12.0
+        image: k8s.gcr.io/hyperkube-amd64:v1.12.0
         livenessProbe:
           failureThreshold: 8
           httpGet:

--- a/api/pkg/resources/test/fixtures/deployment-vsphere-1.12.0-controller-manager.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-vsphere-1.12.0-controller-manager.yaml
@@ -123,7 +123,7 @@ spec:
           value: apiserver-external.cluster-de-test-01.svc.cluster.local.
         - name: no_proxy
           value: apiserver-external.cluster-de-test-01.svc.cluster.local.
-        image: gcr.io/google_containers/hyperkube-amd64:v1.12.0
+        image: k8s.gcr.io/hyperkube-amd64:v1.12.0
         livenessProbe:
           failureThreshold: 8
           httpGet:

--- a/api/pkg/resources/test/fixtures/deployment-vsphere-1.12.0-dns-resolver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-vsphere-1.12.0-dns-resolver.yaml
@@ -97,7 +97,7 @@ spec:
       - args:
         - -conf
         - /etc/coredns/Corefile
-        image: gcr.io/google_containers/coredns:1.1.3
+        image: k8s.gcr.io/coredns:1.1.3
         name: dns-resolver
         readinessProbe:
           failureThreshold: 3

--- a/api/pkg/resources/test/fixtures/deployment-vsphere-1.12.0-metrics-server.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-vsphere-1.12.0-metrics-server.yaml
@@ -51,7 +51,7 @@ spec:
         - '{"command":"/metrics-server","args":["--kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","--authentication-kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","--authorization-kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","--kubelet-port","10250","--kubelet-insecure-tls","--kubelet-preferred-address-types","ExternalIP,InternalIP","--v","1","--logtostderr","--tls-cert-file","/etc/serving-cert/serving.crt","--tls-private-key-file","/etc/serving-cert/serving.key"]}'
         command:
         - /http-prober-bin/http-prober
-        image: gcr.io/google_containers/metrics-server-amd64:v0.3.4
+        image: k8s.gcr.io/metrics-server-amd64:v0.3.4
         name: metrics-server
         resources:
           limits:

--- a/api/pkg/resources/test/fixtures/deployment-vsphere-1.12.0-scheduler.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-vsphere-1.12.0-scheduler.yaml
@@ -108,7 +108,7 @@ spec:
         - '{"command":"/hyperkube","args":["kube-scheduler","--kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","--feature-gates","ScheduleDaemonSetPods=false"]}'
         command:
         - /http-prober-bin/http-prober
-        image: gcr.io/google_containers/hyperkube-amd64:v1.12.0
+        image: k8s.gcr.io/hyperkube-amd64:v1.12.0
         livenessProbe:
           failureThreshold: 8
           httpGet:

--- a/api/pkg/resources/test/fixtures/deployment-vsphere-1.13.0-apiserver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-vsphere-1.13.0-apiserver.yaml
@@ -232,7 +232,7 @@ spec:
           value: apiserver-external.cluster-de-test-01.svc.cluster.local.
         - name: no_proxy
           value: apiserver-external.cluster-de-test-01.svc.cluster.local.
-        image: gcr.io/google_containers/hyperkube-amd64:v1.13.0
+        image: k8s.gcr.io/hyperkube-amd64:v1.13.0
         livenessProbe:
           failureThreshold: 8
           httpGet:

--- a/api/pkg/resources/test/fixtures/deployment-vsphere-1.13.0-controller-manager.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-vsphere-1.13.0-controller-manager.yaml
@@ -123,7 +123,7 @@ spec:
           value: apiserver-external.cluster-de-test-01.svc.cluster.local.
         - name: no_proxy
           value: apiserver-external.cluster-de-test-01.svc.cluster.local.
-        image: gcr.io/google_containers/hyperkube-amd64:v1.13.0
+        image: k8s.gcr.io/hyperkube-amd64:v1.13.0
         livenessProbe:
           failureThreshold: 8
           httpGet:

--- a/api/pkg/resources/test/fixtures/deployment-vsphere-1.13.0-dns-resolver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-vsphere-1.13.0-dns-resolver.yaml
@@ -97,7 +97,7 @@ spec:
       - args:
         - -conf
         - /etc/coredns/Corefile
-        image: gcr.io/google_containers/coredns:1.1.3
+        image: k8s.gcr.io/coredns:1.1.3
         name: dns-resolver
         readinessProbe:
           failureThreshold: 3

--- a/api/pkg/resources/test/fixtures/deployment-vsphere-1.13.0-metrics-server.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-vsphere-1.13.0-metrics-server.yaml
@@ -51,7 +51,7 @@ spec:
         - '{"command":"/metrics-server","args":["--kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","--authentication-kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","--authorization-kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","--kubelet-port","10250","--kubelet-insecure-tls","--kubelet-preferred-address-types","ExternalIP,InternalIP","--v","1","--logtostderr","--tls-cert-file","/etc/serving-cert/serving.crt","--tls-private-key-file","/etc/serving-cert/serving.key"]}'
         command:
         - /http-prober-bin/http-prober
-        image: gcr.io/google_containers/metrics-server-amd64:v0.3.4
+        image: k8s.gcr.io/metrics-server-amd64:v0.3.4
         name: metrics-server
         resources:
           limits:

--- a/api/pkg/resources/test/fixtures/deployment-vsphere-1.13.0-scheduler.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-vsphere-1.13.0-scheduler.yaml
@@ -108,7 +108,7 @@ spec:
         - '{"command":"/hyperkube","args":["kube-scheduler","--kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","--authentication-kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","--authorization-kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","--client-ca-file","/etc/kubernetes/pki/ca/ca.crt","--port","0","--feature-gates","ScheduleDaemonSetPods=false"]}'
         command:
         - /http-prober-bin/http-prober
-        image: gcr.io/google_containers/hyperkube-amd64:v1.13.0
+        image: k8s.gcr.io/hyperkube-amd64:v1.13.0
         livenessProbe:
           failureThreshold: 8
           httpGet:

--- a/config/kubermatic/Chart.yaml
+++ b/config/kubermatic/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: kubermatic
-version: 1.0.43
+version: 1.0.44
 appVersion: '__KUBERMATIC_TAG__'
 description: Kubermatic chart for master and/or seed clusters.
 keywords:

--- a/config/kubermatic/values.yaml
+++ b/config/kubermatic/values.yaml
@@ -326,7 +326,7 @@ kubermatic:
   vpa:
     updater:
       image:
-        repository: gcr.io/google_containers/vpa-updater
+        repository: k8s.gcr.io/vpa-updater
         tag: 0.5.0
       resources:
         requests:
@@ -341,7 +341,7 @@ kubermatic:
 
     recommender:
       image:
-        repository: gcr.io/google_containers/vpa-recommender
+        repository: k8s.gcr.io/vpa-recommender
         tag: 0.5.0
       resources:
         requests:
@@ -356,7 +356,7 @@ kubermatic:
 
     admissioncontroller:
       image:
-        repository: gcr.io/google_containers/vpa-admission-controller
+        repository: k8s.gcr.io/vpa-admission-controller
         tag: 0.5.0
       resources:
         requests:

--- a/config/monitoring/kube-state-metrics/Chart.yaml
+++ b/config/monitoring/kube-state-metrics/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: kube-state-metrics
-version: 1.0.5
+version: 1.0.6
 appVersion: v1.8.0
 description: Kube-State-Metrics for Kubermatic
 keywords:

--- a/config/monitoring/kube-state-metrics/values.yaml
+++ b/config/monitoring/kube-state-metrics/values.yaml
@@ -12,7 +12,7 @@ kubeStateMetrics:
 
   resizer:
     image:
-      repository: gcr.io/google_containers/addon-resizer
+      repository: k8s.gcr.io/addon-resizer
       tag: '1.8.4' # is still the recommended version
     resources:
       requests:


### PR DESCRIPTION
**What this PR does / why we need it**:

Manual cherry-pick of #5986 to the `release/v2.13` branch, including updates to addons.

Migrate from `gcr.io/google_containers` registry to `k8s.gcr.io` registry. The google_containers registry is read-only for several weeks, and therefore the migration is advised.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
xref #5773 #5967 

**Special notes for your reviewer**:

Currently, only the following files are specifying `google_containers`:

* `addons/heapster/heapster-controller.yaml` (the project is retired)
* `api/vendor/k8s.io/api/core/v1/types.go`
* `api/vendor/k8s.io/api/core/v1/types_swagger_doc_generated.go`
* `api/cmd/node-resource-documenter/documenter_test.go`
* `config/test/guestbook-full-example.yaml`

Those files don't seem important for the migration, so I didn't change them.

**Does this PR introduce a user-facing change?**:
```release-note
Migrate from google_containers to k8s.gcr.io Docker registry
```

/assign @xrstf @irozzo-1A 