### PR TITLE
[release/v2.14] Finish migration to the k8s.gcr.io Docker registry

### DIFF
--- a/addons/kube-proxy/daemonset.yaml
+++ b/addons/kube-proxy/daemonset.yaml
@@ -35,7 +35,7 @@ spec:
       priorityClassName: system-node-critical
       containers:
       - name: kube-proxy
-        image: '{{ Registry "gcr.io" }}/google_containers/hyperkube-amd64:v{{ .Cluster.Version }}'
+        image: '{{ Registry "k8s.gcr.io" }}/hyperkube-amd64:v{{ .Cluster.Version }}'
         imagePullPolicy: IfNotPresent
         command:
         - /usr/local/bin/kube-proxy

--- a/addons/metrics-server/metrics-server-deployment.yaml
+++ b/addons/metrics-server/metrics-server-deployment.yaml
@@ -43,7 +43,7 @@ spec:
         emptyDir: {}
       containers:
       - name: metrics-server
-        image: '{{ Registry "gcr.io" }}/google_containers/metrics-server-amd64:v0.2.1'
+        image: '{{ Registry "k8s.gcr.io" }}/metrics-server-amd64:v0.2.1'
         command:
         - /metrics-server
         - '--source=kubernetes.summary_api:https://kubernetes.default.svc?kubeletHttps=true&kubeletPort=10250&insecure=true'

--- a/addons/nodelocal-dns-cache/dns.yaml
+++ b/addons/nodelocal-dns-cache/dns.yaml
@@ -109,7 +109,7 @@ spec:
         operator: "Exists"
       containers:
       - name: node-cache
-        image: {{ Registry "gcr.io" }}/google_containers/k8s-dns-node-cache:1.15.7
+        image: {{ Registry "k8s.gcr.io" }}/k8s-dns-node-cache:1.15.7
         resources:
           requests:
             cpu: 25m


### PR DESCRIPTION
**What this PR does / why we need it**:

We've migrated to the `k8s.gcr.io` registry in #5986, but there are some references that have been forgotten. This PR replaces the remaining references to the `google_containers` registry. This PR is supposed to keep the `release/v2.14` branch in sync with the master and `release/v2.15` branches.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
xref #5773 #5967

**Does this PR introduce a user-facing change?**:
```release-note
NONE
```

/assign @xrstf @irozzo-1A 