### PR TITLE
fix error message for PVs on cluster deletion

### DIFF
--- a/pkg/clusterdeletion/deletion.go
+++ b/pkg/clusterdeletion/deletion.go
@@ -115,7 +115,7 @@ func (d *Deletion) cleanupInClusterResources(ctx context.Context, log *zap.Sugar
 	if shouldDeletePVs {
 		deletedSomeVolumes, err := d.cleanupVolumes(ctx, cluster)
 		if err != nil {
-			return fmt.Errorf("failed to cleanup LBs: %v", err)
+			return fmt.Errorf("failed to cleanup PVs: %v", err)
 		}
 		deletedSomeResource = deletedSomeResource || deletedSomeVolumes
 	}


### PR DESCRIPTION
We had the same LB error message in shouldDeleteLBs an shouldDeletePVs

```release-notes
NONE
```