### PR TITLE
Add seed-controller feature gate for etcd-launcher

### DIFF
--- a/cmd/seed-controller-manager/controllers.go
+++ b/cmd/seed-controller-manager/controllers.go
@@ -175,6 +175,7 @@ func createKubernetesController(ctrlCtx *controllerContext) error {
 			VPA:                          ctrlCtx.runOptions.featureGates.Enabled(features.VerticalPodAutoscaler),
 			EtcdDataCorruptionChecks:     ctrlCtx.runOptions.featureGates.Enabled(features.EtcdDataCorruptionChecks),
 			KubernetesOIDCAuthentication: ctrlCtx.runOptions.featureGates.Enabled(features.OpenIDAuthPlugin),
+			EtcdLauncher:                 ctrlCtx.runOptions.featureGates.Enabled(features.EtcdLauncher),
 		},
 	)
 }

--- a/pkg/controller/seed-controller-manager/kubernetes/cluster_controller.go
+++ b/pkg/controller/seed-controller-manager/kubernetes/cluster_controller.go
@@ -63,6 +63,7 @@ type Features struct {
 	VPA                          bool
 	EtcdDataCorruptionChecks     bool
 	KubernetesOIDCAuthentication bool
+	EtcdLauncher                 bool
 }
 
 // Reconciler is a controller which is responsible for managing clusters

--- a/pkg/controller/seed-controller-manager/kubernetes/pending.go
+++ b/pkg/controller/seed-controller-manager/kubernetes/pending.go
@@ -43,6 +43,11 @@ func (r *Reconciler) reconcileCluster(ctx context.Context, cluster *kubermaticv1
 		return nil, err
 	}
 
+	// Apply etcdLauncher flag
+	if err := r.ensureEtcdLauncherFeatureFlag(ctx, cluster); err != nil {
+		return nil, err
+	}
+
 	// Deploy & Update master components for Kubernetes
 	if err := r.ensureResourcesAreDeployed(ctx, cluster); err != nil {
 		return nil, err
@@ -110,6 +115,22 @@ func (r *Reconciler) ensureClusterNetworkDefaults(ctx context.Context, cluster *
 	return r.updateCluster(ctx, cluster, func(c *kubermaticv1.Cluster) {
 		for _, modify := range modifiers {
 			modify(c)
+		}
+	})
+}
+
+// ensureEtcdLauncherFeatureFlag will apply seed controller etcdLauncher setting on the cluster level
+func (r *Reconciler) ensureEtcdLauncherFeatureFlag(ctx context.Context, cluster *kubermaticv1.Cluster) error {
+	return r.updateCluster(ctx, cluster, func(c *kubermaticv1.Cluster) {
+		if r.features.EtcdLauncher { // enabled at the controller level
+			// we only modify the cluster feature flag if it's not explicitly set, regardless if the value
+			_, set := c.Spec.Features[kubermaticv1.ClusterFeatureEtcdLauncher]
+			if !set {
+				if c.Spec.Features == nil {
+					c.Spec.Features = make(map[string]bool)
+				}
+				c.Spec.Features[kubermaticv1.ClusterFeatureEtcdLauncher] = true
+			}
 		}
 	})
 }

--- a/pkg/controller/seed-controller-manager/kubernetes/pending.go
+++ b/pkg/controller/seed-controller-manager/kubernetes/pending.go
@@ -123,9 +123,8 @@ func (r *Reconciler) ensureClusterNetworkDefaults(ctx context.Context, cluster *
 func (r *Reconciler) ensureEtcdLauncherFeatureFlag(ctx context.Context, cluster *kubermaticv1.Cluster) error {
 	return r.updateCluster(ctx, cluster, func(c *kubermaticv1.Cluster) {
 		if r.features.EtcdLauncher { // enabled at the controller level
-			// we only modify the cluster feature flag if it's not explicitly set, regardless if the value
-			_, set := c.Spec.Features[kubermaticv1.ClusterFeatureEtcdLauncher]
-			if !set {
+			// we only modify the cluster feature flag if it's not explicitly set, regardless of the value
+			if _, set := c.Spec.Features[kubermaticv1.ClusterFeatureEtcdLauncher]; !set {
 				if c.Spec.Features == nil {
 					c.Spec.Features = make(map[string]bool)
 				}

--- a/pkg/controller/seed-controller-manager/kubernetes/pending_test.go
+++ b/pkg/controller/seed-controller-manager/kubernetes/pending_test.go
@@ -1,0 +1,139 @@
+// +build integration
+
+/*
+Copyright 2020 The Kubermatic Kubernetes Platform contributors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package kubernetes
+
+import (
+	"context"
+	"testing"
+
+	kubermaticv1 "k8c.io/kubermatic/v2/pkg/crd/kubermatic/v1"
+	kubermaticlog "k8c.io/kubermatic/v2/pkg/log"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	"sigs.k8s.io/controller-runtime/pkg/envtest"
+	"sigs.k8s.io/controller-runtime/pkg/manager"
+)
+
+func TestEnsureEtcdLauncherFeatureFlag(t *testing.T) {
+	tests := []struct {
+		name                 string
+		clusterFeatures      map[string]bool
+		seedEtcdLauncher     bool
+		expectedEtcdLauncher bool
+	}{
+		{
+			name:                 "Seed feature gate enabled, cluster has no feature flag",
+			clusterFeatures:      nil, // no features set
+			seedEtcdLauncher:     true,
+			expectedEtcdLauncher: true,
+		},
+		{
+			name: "Seed feature gate enabled, cluster explicitly set to false",
+			clusterFeatures: map[string]bool{
+				kubermaticv1.ClusterFeatureEtcdLauncher: false,
+			},
+			seedEtcdLauncher:     true,
+			expectedEtcdLauncher: false,
+		},
+		{
+			name: "Seed feature gate disabled, cluster explicitly set to true",
+			clusterFeatures: map[string]bool{
+				kubermaticv1.ClusterFeatureEtcdLauncher: true,
+			},
+			seedEtcdLauncher:     false,
+			expectedEtcdLauncher: true,
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			kubermaticlog.Logger = kubermaticlog.New(true, kubermaticlog.FormatJSON).Sugar()
+			env := &envtest.Environment{
+				// Uncomment this to get the logs from etcd+apiserver
+				// AttachControlPlaneOutput: true,
+				KubeAPIServerFlags: []string{
+					"--etcd-servers={{ if .EtcdURL }}{{ .EtcdURL.String }}{{ end }}",
+					"--cert-dir={{ .CertDir }}",
+					"--insecure-port={{ if .URL }}{{ .URL.Port }}{{ end }}",
+					"--insecure-bind-address={{ if .URL }}{{ .URL.Hostname }}{{ end }}",
+					"--secure-port={{ if .SecurePort }}{{ .SecurePort }}{{ end }}",
+					"--admission-control=AlwaysAdmit",
+					// Upstream does not have `--allow-privileged`,
+					"--allow-privileged",
+				},
+			}
+			cfg, err := env.Start()
+			if err != nil {
+				t.Fatalf("failed to start testenv: %v", err)
+			}
+			defer func() {
+				if err := env.Stop(); err != nil {
+					t.Fatalf("failed to stop testenv: %v", err)
+				}
+			}()
+
+			mgr, err := manager.New(cfg, manager.Options{})
+			if err != nil {
+				t.Fatalf("failed to construct manager: %v", err)
+			}
+
+			crdInstallOpts := envtest.CRDInstallOptions{
+				Paths:              []string{"../../../../charts/kubermatic/crd"},
+				ErrorIfPathMissing: true,
+			}
+			if _, err := envtest.InstallCRDs(cfg, crdInstallOpts); err != nil {
+				t.Fatalf("failed install crds: %v", err)
+			}
+
+			ctx, cancel := context.WithCancel(context.Background())
+			defer cancel()
+			go func() {
+				if err := mgr.Start(ctx.Done()); err != nil {
+					t.Errorf("failed to start manager: %v", err)
+				}
+			}()
+
+			cluster := &kubermaticv1.Cluster{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "test-cluster",
+				},
+				Spec: kubermaticv1.ClusterSpec{
+					Features: test.clusterFeatures,
+				},
+			}
+			if err := mgr.GetClient().Create(ctx, cluster); err != nil {
+				t.Fatalf("failed to create testcluster: %v", err)
+			}
+
+			r := &Reconciler{
+				Client: mgr.GetClient(),
+				features: Features{
+					EtcdLauncher: test.seedEtcdLauncher,
+				},
+			}
+			if err := r.ensureEtcdLauncherFeatureFlag(ctx, cluster); err != nil {
+				t.Fatal(err)
+			}
+			if cluster.Spec.Features != nil && cluster.Spec.Features[kubermaticv1.ClusterFeatureEtcdLauncher] != test.expectedEtcdLauncher {
+				t.Errorf("expected clsuter flag to be %v , got %v instead", test.expectedEtcdLauncher, cluster.Spec.Features[kubermaticv1.ClusterFeatureEtcdLauncher])
+			}
+		})
+	}
+
+}

--- a/pkg/features/features.go
+++ b/pkg/features/features.go
@@ -41,6 +41,10 @@ const (
 	// --experimental-initial-corrupt-check=true +
 	// --experimental-corrupt-check-time=10m
 	EtcdDataCorruptionChecks = "EtcdDataCorruptionChecks"
+
+	// EtcdLauncher if enabled will apply the cluster level etcd-launcher feature flag on all clusters,
+	// unless it's explicitly disabled on the cluster level
+	EtcdLauncher = "EtcdLauncher"
 )
 
 // FeatureGate is map of key=value pairs that enables/disables various features.

--- a/pkg/features/features.go
+++ b/pkg/features/features.go
@@ -43,7 +43,7 @@ const (
 	EtcdDataCorruptionChecks = "EtcdDataCorruptionChecks"
 
 	// EtcdLauncher if enabled will apply the cluster level etcd-launcher feature flag on all clusters,
-	// unless it's explicitly disabled on the cluster level
+	// unless it's explicitly disabled at the cluster level
 	EtcdLauncher = "EtcdLauncher"
 )
 


### PR DESCRIPTION
**What this PR does / why we need it**:
Adds a feature gate for etcd-launcher in seed-controller. If the flag is enabled all user clusters will have the cluster level feature flag automatically enabled, except user clusters where the cluster level feature flags is explicitly disabled.
**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #5992

**Special notes for your reviewer**:

**Documentation**:
<!-- Add links to the related documentation changes related to this pull request. E.g. the link to the kubermatic/docs pullrequest. -->

**Does this PR introduce a user-facing change?**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If  no release note is required, just write "NONE".
-->
```release-note
Adds a new feature gate to the seed-controller to enable etcd-launcher for all user clusters.
```
