### PR TITLE
Add MaximumParallelReconciles option to KubermaticConfiguration

### DIFF
--- a/docs/zz_generated.kubermaticConfiguration.yaml
+++ b/docs/zz_generated.kubermaticConfiguration.yaml
@@ -189,6 +189,9 @@ spec:
     debugLog: false
     # DockerRepository is the repository containing the Kubermatic seed-controller-manager image.
     dockerRepository: quay.io/kubermatic/kubermatic
+    # MaximumParallelReconciles limits the number of cluster reconciliations
+    # that are active at any given time.
+    maximumParallelReconciles: 10
     # PProfEndpoint controls the port the seed-controller-manager should listen on to provide pprof
     # data. This port is never exposed from the container and only available via port-forwardings.
     pprofEndpoint: :6600

--- a/pkg/controller/operator/common/defaults.go
+++ b/pkg/controller/operator/common/defaults.go
@@ -54,6 +54,7 @@ const (
 	DefaultVPAUpdaterDockerRepository             = "gcr.io/google_containers/vpa-updater"
 	DefaultVPAAdmissionControllerDockerRepository = "gcr.io/google_containers/vpa-admission-controller"
 	DefaultEnvoyDockerRepository                  = "docker.io/envoyproxy/envoy-alpine"
+	DefaultMaximumParallelReconciles              = 10
 
 	// DefaultNoProxy is a set of domains/networks that should never be
 	// routed through a proxy. All user-supplied values are appended to
@@ -328,6 +329,11 @@ func DefaultConfiguration(config *operatorv1alpha1.KubermaticConfiguration, logg
 	if copy.Spec.ExposeStrategy == "" {
 		copy.Spec.ExposeStrategy = DefaultExposeStrategy
 		logger.Debugw("Defaulting field", "field", "exposeStrategy", "value", copy.Spec.ExposeStrategy)
+	}
+
+	if copy.Spec.SeedController.MaximumParallelReconciles == 0 {
+		copy.Spec.SeedController.MaximumParallelReconciles = DefaultMaximumParallelReconciles
+		logger.Debugw("Defaulting field", "field", "seedController.maximumParallelReconciles", "value", copy.Spec.SeedController.MaximumParallelReconciles)
 	}
 
 	if copy.Spec.SeedController.BackupStoreContainer == "" {

--- a/pkg/controller/operator/seed/resources/kubermatic/seed-controller-manager.go
+++ b/pkg/controller/operator/seed/resources/kubermatic/seed-controller-manager.go
@@ -81,7 +81,7 @@ func SeedControllerManagerDeploymentCreator(workerName string, versions common.V
 				fmt.Sprintf("-apiserver-default-replicas=%d", *cfg.Spec.UserCluster.APIServerReplicas),
 				fmt.Sprintf("-controller-manager-default-replicas=%d", 1),
 				fmt.Sprintf("-scheduler-default-replicas=%d", 1),
-				fmt.Sprintf("-max-parallel-reconcile=%d", 10),
+				fmt.Sprintf("-max-parallel-reconcile=%d", cfg.Spec.SeedController.MaximumParallelReconciles),
 				fmt.Sprintf("-apiserver-reconciling-disabled-by-default=%v", cfg.Spec.UserCluster.DisableAPIServerEndpointReconciling),
 				fmt.Sprintf("-pprof-listen-address=%s", *cfg.Spec.SeedController.PProfEndpoint),
 				fmt.Sprintf("-in-cluster-prometheus-disable-default-rules=%v", cfg.Spec.UserCluster.Monitoring.DisableDefaultRules),

--- a/pkg/crd/operator/v1alpha1/configuration.go
+++ b/pkg/crd/operator/v1alpha1/configuration.go
@@ -134,6 +134,9 @@ type KubermaticSeedControllerConfiguration struct {
 	BackupStoreContainer string `json:"backupStoreContainer,omitempty"`
 	// BackupCleanupContainer is the container used for removing expired backups from the storage location.
 	BackupCleanupContainer string `json:"backupCleanupContainer,omitempty"`
+	// MaximumParallelReconciles limits the number of cluster reconciliations
+	// that are active at any given time.
+	MaximumParallelReconciles int `json:"maximumParallelReconciles,omitempty"`
 	// PProfEndpoint controls the port the seed-controller-manager should listen on to provide pprof
 	// data. This port is never exposed from the container and only available via port-forwardings.
 	PProfEndpoint *string `json:"pprofEndpoint,omitempty"`


### PR DESCRIPTION
**What this PR does / why we need it**:
This adds support for the max-parallel-reconciles option of the seed-ctrlmgr to the KubermaticConfiguration CRD. Like with the old Helm chart, it defaults to 10.

**Does this PR introduce a user-facing change?**:
```release-note
Add MaximumParallelReconciles option to KubermaticConfiguration
```
