### PR TITLE
fix RBAC Binding for OIDC kubeconfig

### DIFF
--- a/pkg/controller/user-cluster-controller-manager/cluster-role-labeler/cluster_role_labeler.go
+++ b/pkg/controller/user-cluster-controller-manager/cluster-role-labeler/cluster_role_labeler.go
@@ -66,7 +66,7 @@ func Add(ctx context.Context, log *zap.SugaredLogger, mgr manager.Manager) error
 	}
 
 	// Watch for changes to ClusterRoles
-	if err = c.Watch(&source.Kind{Type: &rbacv1.ClusterRole{}}, &handler.EnqueueRequestForObject{}, predicateutil.ByName("admin", "view", "edit")); err != nil {
+	if err = c.Watch(&source.Kind{Type: &rbacv1.ClusterRole{}}, &handler.EnqueueRequestForObject{}, predicateutil.ByName("cluster-admin", "view", "edit")); err != nil {
 		return fmt.Errorf("failed to establish watch for the ClusterRoles %v", err)
 	}
 

--- a/pkg/controller/user-cluster-controller-manager/owner-binding-creator/owner_binding_creator.go
+++ b/pkg/controller/user-cluster-controller-manager/owner-binding-creator/owner_binding_creator.go
@@ -123,10 +123,10 @@ func (r *reconciler) reconcile(log *zap.SugaredLogger, clusterRoleName string) e
 				Name:     clusterRoleName,
 			},
 		}
-		// Bind user who created the cluster to the `admin` ClusterRole.
+		// Bind user who created the cluster to the `cluster-admin` ClusterRole.
 		// Add cluster owner only once when binding doesn't exist yet.
 		// Later the user can remove/add subjects from the binding using the API.
-		if clusterRoleName == "admin" {
+		if clusterRoleName == "cluster-admin" {
 			crb.Subjects = []rbacv1.Subject{
 				{
 					Kind:     rbacv1.UserKind,

--- a/pkg/controller/user-cluster-controller-manager/owner-binding-creator/owner_binding_creator_test.go
+++ b/pkg/controller/user-cluster-controller-manager/owner-binding-creator/owner_binding_creator_test.go
@@ -49,10 +49,10 @@ func TestReconcile(t *testing.T) {
 		{
 			name: "role binding created with cluster owner subject",
 			clusterRole: &rbacv1.ClusterRole{ObjectMeta: metav1.ObjectMeta{
-				Name:   "admin",
+				Name:   "cluster-admin",
 				Labels: map[string]string{cluster.UserClusterComponentKey: cluster.UserClusterRoleComponentValue},
 			}},
-			requestName: "admin",
+			requestName: "cluster-admin",
 			ownerEmail:  "test@test.com",
 			expectedBinding: rbacv1.ClusterRoleBinding{
 				ObjectMeta: metav1.ObjectMeta{
@@ -62,7 +62,7 @@ func TestReconcile(t *testing.T) {
 				RoleRef: rbacv1.RoleRef{
 					APIGroup: rbacv1.GroupName,
 					Kind:     "ClusterRole",
-					Name:     "admin",
+					Name:     "cluster-admin",
 				},
 				Subjects: []rbacv1.Subject{
 					{

--- a/pkg/test/e2e/api/cluster_rbac_test.go
+++ b/pkg/test/e2e/api/cluster_rbac_test.go
@@ -48,7 +48,7 @@ func TestCreateClusterRoleBinding(t *testing.T) {
 			credential:               "e2e-digitalocean",
 			replicas:                 0,
 			expectedRoleNames:        []string{"namespace-admin", "namespace-editor", "namespace-viewer"},
-			expectedClusterRoleNames: []string{"admin", "edit", "view"},
+			expectedClusterRoleNames: []string{"cluster-admin", "edit", "view"},
 		},
 	}
 	for _, tc := range tests {


### PR DESCRIPTION
**What this PR does / why we need it**: the admin RBAC binding for OIDC kubeconfig has too few permissions. Use the cluster-admin role as a default for the admin.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #6011


```release-note
NONE
```
