### PR TITLE
Don't deploy cluster-autoscaler on unsupported clusters

### DIFF
--- a/addons/cluster-autoscaler/cluster-autoscaler.yaml
+++ b/addons/cluster-autoscaler/cluster-autoscaler.yaml
@@ -20,6 +20,7 @@
 {{ $version = "v1.19.0 "}}
 {{ end }}
 
+{{ if not eq $version "UNSUPPORTED" }}
 ---
 apiVersion: v1
 kind: ServiceAccount
@@ -193,3 +194,4 @@ spec:
       tolerations:
       - effect: NoSchedule
         key: node-role.kubernetes.io/master
+{{ end }}


### PR DESCRIPTION
**What this PR does / why we need it**:

Don't deploy cluster-autoscaler on unsupported clusters.

**Does this PR introduce a user-facing change?**:
```release-note
NONE
```
