### PR TITLE
[WIP][release/v2.14] Tolerate legacy registry for k8s control plane components

### DIFF
--- a/api/pkg/controller/seed-controller-manager/openshift/resources/dns_operator.go
+++ b/api/pkg/controller/seed-controller-manager/openshift/resources/dns_operator.go
@@ -127,6 +127,7 @@ func OpenshiftDNSOperatorFactory(data openshiftData) reconciling.NamedDeployment
 	}
 }
 
+//nolint:interfacer
 func openshiftDNSOperatorEnv(data openshiftData) ([]corev1.EnvVar, error) {
 	openshiftVersion := data.Cluster().Spec.Version.String()
 	cliImageValue, err := cliImage(openshiftVersion, data.ImageRegistry(""))

--- a/api/pkg/controller/seed-controller-manager/openshift/resources/openshift_controller_manager.go
+++ b/api/pkg/controller/seed-controller-manager/openshift/resources/openshift_controller_manager.go
@@ -77,6 +77,7 @@ servingInfo:
 `
 )
 
+//nolint:interfacer
 func OpenshiftControllerManagerConfigMapCreator(data openshiftData) reconciling.NamedConfigMapCreatorGetter {
 	openshiftVersion := data.Cluster().Spec.Version.String()
 	return func() (string, reconciling.ConfigMapCreator) {

--- a/api/pkg/controller/seed-controller-manager/openshift/resources/openshift_network_operator.go
+++ b/api/pkg/controller/seed-controller-manager/openshift/resources/openshift_network_operator.go
@@ -131,6 +131,7 @@ func OpenshiftNetworkOperatorCreatorFactory(data openshiftData) reconciling.Name
 	}
 }
 
+//nolint:interfacer
 func openshiftNetworkOperatorEnv(data openshiftData) ([]corev1.EnvVar, error) {
 	openshiftVersion := data.Cluster().Spec.Version.String()
 	nodeImageValue, err := nodeImage(openshiftVersion, data.ImageRegistry(""))

--- a/api/pkg/controller/seed-controller-manager/openshift/resources/registry_operator.go
+++ b/api/pkg/controller/seed-controller-manager/openshift/resources/registry_operator.go
@@ -99,6 +99,7 @@ func RegistryOperatorFactory(data openshiftData) reconciling.NamedDeploymentCrea
 	}
 }
 
+//nolint:interfacer
 func registryOperatorEnv(data openshiftData) ([]corev1.EnvVar, error) {
 	openshiftVersion := data.Cluster().Spec.Version.String()
 	image, err := dockerRegistryImage(openshiftVersion, data.ImageRegistry(""))

--- a/api/pkg/resources/apiserver/deployment.go
+++ b/api/pkg/resources/apiserver/deployment.go
@@ -153,12 +153,18 @@ func DeploymentCreator(data *resources.TemplateData, enableOIDCAuthentication bo
 				return nil, err
 			}
 
+			image, err := resources.Hyperkube.Image(data,
+				resources.ContainersList(dep.Spec.Template.Spec.Containers).GetImage(resources.ApiserverDeploymentName))
+			if err != nil {
+				return nil, fmt.Errorf("failed to get hyperkube image: %v", err)
+			}
+
 			dep.Spec.Template.Spec.Containers = []corev1.Container{
 				*openvpnSidecar,
 				*dnatControllerSidecar,
 				{
 					Name:    resources.ApiserverDeploymentName,
-					Image:   data.ImageRegistry(resources.RegistryK8SGCR) + "/hyperkube-amd64:v" + data.Cluster().Spec.Version.String(),
+					Image:   image,
 					Command: []string{"/hyperkube", "kube-apiserver"},
 					Env:     envVars,
 					Args:    flags,

--- a/api/pkg/resources/controllermanager/deployment.go
+++ b/api/pkg/resources/controllermanager/deployment.go
@@ -167,11 +167,17 @@ func DeploymentCreator(data *resources.TemplateData) reconciling.NamedDeployment
 				Port:   intstr.FromInt(10257),
 			}
 
+			image, err := resources.Hyperkube.Image(data,
+				resources.ContainersList(dep.Spec.Template.Spec.Containers).GetImage(resources.ControllerManagerDeploymentName))
+			if err != nil {
+				return nil, fmt.Errorf("failed to get hyperkube image: %v", err)
+			}
+
 			dep.Spec.Template.Spec.Containers = []corev1.Container{
 				*openvpnSidecar,
 				{
 					Name:    resources.ControllerManagerDeploymentName,
-					Image:   data.ImageRegistry(resources.RegistryK8SGCR) + "/hyperkube-amd64:v" + data.Cluster().Spec.Version.String(),
+					Image:   image,
 					Command: []string{"/hyperkube", "kube-controller-manager"},
 					Args:    flags,
 					Env:     envVars,

--- a/api/pkg/resources/dns/dns.go
+++ b/api/pkg/resources/dns/dns.go
@@ -105,11 +105,17 @@ func DeploymentCreator(data deploymentCreatorData) reconciling.NamedDeploymentCr
 				return nil, fmt.Errorf("failed to get openvpn sidecar for dns resolver: %v", err)
 			}
 
+			image, err := resources.CoreDNS.Image(data,
+				resources.ContainersList(dep.Spec.Template.Spec.Containers).GetImage(resources.DNSResolverDeploymentName))
+			if err != nil {
+				return nil, fmt.Errorf("failed to get coredns image: %v", err)
+			}
+
 			dep.Spec.Template.Spec.Containers = []corev1.Container{
 				*openvpnSidecar,
 				{
 					Name:  resources.DNSResolverDeploymentName,
-					Image: data.ImageRegistry(resources.RegistryK8SGCR) + "/coredns:1.3.1",
+					Image: image,
 					Args:  []string{"-conf", "/etc/coredns/Corefile"},
 					VolumeMounts: []corev1.VolumeMount{
 						{

--- a/api/pkg/resources/metrics-server/deployment.go
+++ b/api/pkg/resources/metrics-server/deployment.go
@@ -53,8 +53,6 @@ const (
 	// serving cert.
 	ServingCertSecretName  = "metrics-server-serving-cert"
 	servingCertMountFolder = "/etc/serving-cert"
-
-	tag = "v0.3.6"
 )
 
 // metricsServerData is the data needed to construct the metrics-server components
@@ -115,10 +113,16 @@ func DeploymentCreator(data metricsServerData) reconciling.NamedDeploymentCreato
 				return nil, fmt.Errorf("failed to get dnat-controller sidecar: %v", err)
 			}
 
+			image, err := resources.MetricsServer.Image(data,
+				resources.ContainersList(dep.Spec.Template.Spec.Containers).GetImage(name))
+			if err != nil {
+				return nil, fmt.Errorf("failed to get metricsserver image: %v", err)
+			}
+
 			dep.Spec.Template.Spec.Containers = []corev1.Container{
 				{
 					Name:    name,
-					Image:   data.ImageRegistry(resources.RegistryK8SGCR) + "/metrics-server-amd64:" + tag,
+					Image:   image,
 					Command: []string{"/metrics-server"},
 					Args: []string{
 						"--kubeconfig", "/etc/kubernetes/kubeconfig/kubeconfig",


### PR DESCRIPTION
**What this PR does / why we need it**:
The goal of this PR is to avoid rolling out all control plane components in seed clusters when k8c patch version is upgraded due to #5986.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Documentation**:
<!-- Add links to the related documentation changes related to this pull request. E.g. the link to the kubermatic/docs pullrequest. -->

**Does this PR introduce a user-facing change?**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If  no release note is required, just write "NONE".
-->
```release-note
NONE
```
