### PR TITLE
Split kind/Kubermatic logic during CI

### DIFF
--- a/hack/ci/run-api-e2e.sh
+++ b/hack/ci/run-api-e2e.sh
@@ -23,6 +23,16 @@ set -euo pipefail
 cd $(dirname $0)/../..
 source hack/lib.sh
 
+TEST_NAME="Pre-warm Go build cache"
+echodate "Attempting to pre-warm Go build cache"
+
+beforeGocache=$(nowms)
+make download-gocache
+pushElapsed gocache_download_duration_milliseconds $beforeGocache
+
+export KIND_CLUSTER_NAME="${SEED_NAME:-kubermatic}"
+
+source hack/ci/setup-kind-cluster.sh
 source hack/ci/setup-kubermatic-in-kind.sh
 
 echodate "Creating UI Azure preset..."
@@ -123,7 +133,6 @@ appendTrap print_kubermatic_logs EXIT
 
 echodate "Running API E2E tests..."
 
-export KUBERMATIC_DEX_VALUES_FILE=$(realpath hack/ci/testdata/oauth_values.yaml)
 go test -tags="create,$KUBERMATIC_EDITION" -timeout 20m ./pkg/test/e2e/api -v
 go test -tags="e2e,$KUBERMATIC_EDITION" -timeout 20m ./pkg/test/e2e/api -v
 go test -tags="logout,$KUBERMATIC_EDITION" -timeout 20m ./pkg/test/e2e/api -v

--- a/hack/ci/run-conformance-tests.sh
+++ b/hack/ci/run-conformance-tests.sh
@@ -22,11 +22,6 @@ set -euo pipefail
 cd $(dirname $0)/../..
 source hack/lib.sh
 
-export WORKER_NAME="${BUILD_ID}"
-if [ "${KUBERMATIC_NO_WORKER_NAME:-}" = "true" ]; then
-  WORKER_NAME=""
-fi
-
 if [ -z "${E2E_SSH_PUBKEY:-}" ]; then
   echodate "Getting default SSH pubkey for machines from Vault"
   export VAULT_ADDR=https://vault.loodse.com/
@@ -79,7 +74,6 @@ elif [[ $provider == "alibaba" ]]; then
 fi
 
 timeout -s 9 90m ./_build/conformance-tests $EXTRA_ARGS \
-  -worker-name=$WORKER_NAME \
   -name-prefix=prow-e2e \
   -kubeconfig=$KUBECONFIG \
   -kubermatic-seed-cluster="$SEED_NAME" \

--- a/hack/ci/run-e2e-tests.sh
+++ b/hack/ci/run-e2e-tests.sh
@@ -26,6 +26,17 @@ source hack/lib.sh
 export GIT_HEAD_HASH="$(git rev-parse HEAD)"
 export KUBERMATIC_VERSION="${GIT_HEAD_HASH}"
 
+TEST_NAME="Pre-warm Go build cache"
+echodate "Attempting to pre-warm Go build cache"
+
+beforeGocache=$(nowms)
+make download-gocache
+pushElapsed gocache_download_duration_milliseconds $beforeGocache
+
+echodate "Creating kind cluster"
+export KIND_CLUSTER_NAME="${SEED_NAME:-kubermatic}"
+source hack/ci/setup-kind-cluster.sh
+
 echodate "Setting up Kubermatic in kind on revision ${KUBERMATIC_VERSION}"
 
 beforeKubermaticSetup=$(nowms)
@@ -36,7 +47,5 @@ else
 fi
 pushElapsed kind_kubermatic_setup_duration_milliseconds $beforeKubermaticSetup
 
-echodate "Done setting up Kubermatic in kind"
-
 echodate "Running conformance tests"
-KUBERMATIC_NO_WORKER_NAME=true ./hack/ci/run-conformance-tests.sh
+./hack/ci/run-conformance-tests.sh

--- a/hack/ci/setup-kind-cluster.sh
+++ b/hack/ci/setup-kind-cluster.sh
@@ -16,13 +16,8 @@ source hack/lib.sh
 
 echodate "Setting up kind cluster..."
 
-if [ -z "${JOB_NAME:-}" ]; then
+if [ -z "${JOB_NAME:-}" ] || [ -z "${PROW_JOB_ID:-}" ]; then
   echodate "This script should only be running in a CI environment."
-  exit 1
-fi
-
-if [ -z "${PROW_JOB_ID:-}" ]; then
-  echodate "Build id env variable has to be set."
   exit 1
 fi
 
@@ -59,7 +54,7 @@ cat <<EOF >>~/.bashrc
 unset KUBECONFIG
 
 cn() {
-  kubectl config set-context \$(kubectl config current-context) --namespace=\$1
+  kubectl config set-context --current --namespace=\$1
 }
 
 kubeconfig() {

--- a/hack/ci/setup-kind-cluster.sh
+++ b/hack/ci/setup-kind-cluster.sh
@@ -1,0 +1,133 @@
+# Copyright 2020 The Kubermatic Kubernetes Platform contributors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+source hack/lib.sh
+
+echodate "Setting up kind cluster..."
+
+if [ -z "${JOB_NAME:-}" ]; then
+  echodate "This script should only be running in a CI environment."
+  exit 1
+fi
+
+if [ -z "${PROW_JOB_ID:-}" ]; then
+  echodate "Build id env variable has to be set."
+  exit 1
+fi
+
+export KIND_CLUSTER_NAME="${KIND_CLUSTER_NAME:-kubermatic}"
+export KUBERMATIC_EDITION="${KUBERMATIC_EDITION:-ce}"
+
+# Start Docker daemon
+echodate "Starting Docker"
+dockerd > /tmp/docker.log 2>&1 &
+echodate "Started Docker successfully"
+
+function docker_logs {
+  if [[ $? -ne 0 ]]; then
+    echodate "Printing Docker logs"
+    cat /tmp/docker.log
+    echodate "Done printing Docker logs"
+  fi
+}
+appendTrap docker_logs EXIT
+
+# Wait for Docker to start
+echodate "Waiting for Docker"
+retry 5 docker stats --no-stream
+echodate "Docker became ready"
+
+# Prevent mtu-related timeouts
+echodate "Setting iptables rule to clamp mss to path mtu"
+iptables -t mangle -A POSTROUTING -p tcp --tcp-flags SYN,RST SYN -j TCPMSS --clamp-mss-to-pmtu
+
+# Make debugging a bit better
+echodate "Confuguring bash"
+cat <<EOF >>~/.bashrc
+# Gets set to the CI clusters kubeconfig from a preset
+unset KUBECONFIG
+
+cn() {
+  kubectl config set-context \$(kubectl config current-context) --namespace=\$1
+}
+
+kubeconfig() {
+  TMP_KUBECONFIG=\$(mktemp);
+  kubectl get secret admin-kubeconfig -o go-template='{{ index .data "kubeconfig" }}' | base64 -d > \$TMP_KUBECONFIG;
+  export KUBECONFIG=\$TMP_KUBECONFIG;
+  cn kube-system
+}
+
+# this alias makes it so that watch can be used with other aliases, like "watch k get pods"
+alias watch='watch '
+alias k=kubectl
+alias ll='ls -lh --file-type --group-directories-first'
+alias lll='ls -lahF --group-directories-first'
+source <(k completion bash )
+source <(k completion bash | sed s/kubectl/k/g)
+EOF
+
+# Load kind image
+echodate "Loading kindest image"
+docker load --input /kindest.tar
+echodate "Loaded kindest image"
+
+# Create kind cluster
+TEST_NAME="Create kind cluster"
+echodate "Creating the kind cluster"
+export KUBECONFIG=~/.kube/config
+
+beforeKindCreate=$(nowms)
+export KIND_NODE_VERSION=v1.18.2
+kind create cluster --name "$KIND_CLUSTER_NAME" --image=kindest/node:$KIND_NODE_VERSION
+pushElapsed kind_cluster_create_duration_milliseconds $beforeKindCreate "node_version=\"$KIND_NODE_VERSION\""
+
+# Start cluster exposer, which will expose services from within kind as
+# a NodePort service on the host
+echodate "Starting cluster exposer"
+
+CGO_ENABLED=0 go build --tags "$KUBERMATIC_EDITION" -v -o /tmp/clusterexposer ./pkg/test/clusterexposer/cmd
+/tmp/clusterexposer \
+  --kubeconfig-inner "$KUBECONFIG" \
+  --kubeconfig-outer "/etc/kubeconfig/kubeconfig" \
+  --build-id "$PROW_JOB_ID" &> /var/log/clusterexposer.log &
+
+function print_cluster_exposer_logs {
+  if [[ $? -ne 0 ]]; then
+    # Tolerate errors and just continue
+    set +e
+    echodate "Printing cluster exposer logs"
+    cat /var/log/clusterexposer.log
+    echodate "Done printing cluster exposer logs"
+    set -e
+  fi
+}
+appendTrap print_cluster_exposer_logs EXIT
+
+TEST_NAME="Wait for cluster exposer"
+echodate "Waiting for cluster exposer to be running"
+
+retry 5 curl -s --fail http://127.0.0.1:2047/metrics -o /dev/null
+echodate "Cluster exposer is running"
+
+echodate "Setting up iptables rules for to make nodeports available"
+KIND_NETWORK_IF=$(ip -br addr | grep -- 'br-' | cut -d' ' -f1)
+
+iptables -t nat -A PREROUTING -i eth0 -p tcp -m multiport --dports=30000:33000 -j DNAT --to-destination 172.18.0.2
+# By default all traffic gets dropped unless specified (tested with docker server 18.09.1)
+iptables -t filter -I DOCKER-USER -d 172.18.0.2/32 ! -i $KIND_NETWORK_IF -o $KIND_NETWORK_IF -p tcp -m multiport --dports=30000:33000 -j ACCEPT
+# Docker sets up a MASQUERADE rule for postrouting, so nothing to do for us
+
+echodate "Successfully set up iptables rules for nodeports"
+echodate "Kind cluster $KIND_CLUSTER_NAME using Kubernetes $KIND_NODE_VERSION is up and running."

--- a/hack/ci/setup-kubermatic-in-kind.sh
+++ b/hack/ci/setup-kubermatic-in-kind.sh
@@ -23,13 +23,8 @@
 
 source hack/lib.sh
 
-if [ -z "${JOB_NAME:-}" ]; then
-  echodate "This script should only be running in a CI environment."
-  exit 1
-fi
-
-if [ -z "${PROW_JOB_ID:-}" ]; then
-  echodate "Build id env variable has to be set."
+if [ -z "${KIND_CLUSTER_NAME:-}" ]; then
+  echodate "KIND_CLUSTER_NAME must be set by calling setup-kind-cluster.sh first."
   exit 1
 fi
 
@@ -57,126 +52,19 @@ export KUBERMATIC_OIDC_PASSWORD="password"
 # Set docker config
 echo "$IMAGE_PULL_SECRET_DATA" | base64 -d > /config.json
 
-# Start Docker daemon
-echodate "Starting Docker"
-dockerd > /tmp/docker.log 2>&1 &
-echodate "Started Docker successfully"
-
-function docker_logs {
-  if [[ $? -ne 0 ]]; then
-    echodate "Printing Docker logs"
-    cat /tmp/docker.log
-    echodate "Done printing Docker logs"
-  fi
-}
-appendTrap docker_logs EXIT
-
-# Wait for Docker to start
-echodate "Waiting for Docker"
-retry 5 docker stats --no-stream
-echodate "Docker became ready"
-
-# Load kind image
-echodate "Loading kindest image"
-docker load --input /kindest.tar
-echodate "Loaded kindest image"
-
-# Prevent mtu-related timeouts
-echodate "Setting iptables rule to clamp mss to path mtu"
-iptables -t mangle -A POSTROUTING -p tcp --tcp-flags SYN,RST SYN -j TCPMSS --clamp-mss-to-pmtu
-
-# Make debugging a bit better
-echodate "Confuguring bash"
-cat <<EOF >>~/.bashrc
-# Gets set to the CI clusters kubeconfig from a preset
-unset KUBECONFIG
-
-cn() {
-  kubectl config set-context \$(kubectl config current-context) --namespace=\$1
-}
-
-kubeconfig() {
-  TMP_KUBECONFIG=\$(mktemp);
-  kubectl get secret admin-kubeconfig -o go-template='{{ index .data "kubeconfig" }}' | base64 -d > \$TMP_KUBECONFIG;
-  export KUBECONFIG=\$TMP_KUBECONFIG;
-  cn kube-system
-}
-
-# this alias makes it so that watch can be used with other aliases, like "watch k get pods"
-alias watch='watch '
-alias k=kubectl
-alias ll='ls -lh --file-type --group-directories-first'
-alias lll='ls -lahF --group-directories-first'
-source <(k completion bash )
-source <(k completion bash | sed s/kubectl/k/g)
-EOF
-
 # The alias makes it easier to access the port-forwarded Dex inside the Kind cluster;
 # the token issuer cannot be localhost:5556, because pods inside the cluster would not
-# find Dex anymore.
-echodate "Setting dex.oauth alias in /etc/hosts"
-# The container runtime allows us to change the content but not to change the inode
-# which is what sed -i does, so write to a tempfile and write the tempfiles content back.
-temp_hosts="$(mktemp)"
-sed 's/localhost/localhost dex.oauth/' /etc/hosts > $temp_hosts
-cat $temp_hosts > /etc/hosts
-echodate "Set dex.oauth alias in /etc/hosts"
-
-# Create kind cluster
-TEST_NAME="Create kind cluster"
-echodate "Creating the kind cluster"
-export KUBECONFIG=~/.kube/config
-
-beforeKindCreate=$(nowms)
-nodeVersion=v1.18.2
-kind create cluster --name ${SEED_NAME} --image=kindest/node:$nodeVersion
-pushElapsed kind_cluster_create_duration_milliseconds $beforeKindCreate "node_version=\"$nodeVersion\""
-
-TEST_NAME="Pre-warm Go build cache"
-echodate "Attempting to pre-warm Go build cache"
-
-beforeGocache=$(nowms)
-make download-gocache
-pushElapsed gocache_download_duration_milliseconds $beforeGocache
-
-# Start cluster exposer, which will expose services from within kind as
-# a NodePort service on the host
-echodate "Starting cluster exposer"
-
-CGO_ENABLED=0 go build --tags "$KUBERMATIC_EDITION" -v -o /tmp/clusterexposer ./pkg/test/clusterexposer/cmd
-CGO_ENABLED=0 /tmp/clusterexposer \
-  --kubeconfig-inner "$KUBECONFIG" \
-  --kubeconfig-outer "/etc/kubeconfig/kubeconfig" \
-  --build-id "$PROW_JOB_ID" &> /var/log/clusterexposer.log &
-
-function print_cluster_exposer_logs {
-  if [[ $? -ne 0 ]]; then
-    # Tolerate errors and just continue
-    set +e
-    echodate "Printing cluster exposer logs"
-    cat /var/log/clusterexposer.log
-    echodate "Done printing cluster exposer logs"
-    set -e
-  fi
-}
-appendTrap print_cluster_exposer_logs EXIT
-
-TEST_NAME="Wait for cluster exposer"
-echodate "Waiting for cluster exposer to be running"
-
-retry 5 curl -s --fail http://127.0.0.1:2047/metrics -o /dev/null
-echodate "Cluster exposer is running"
-
-echodate "Setting up iptables rules for to make nodeports available"
-KIND_NETWORK_IF=$(ip -br addr | grep -- 'br-' | cut -d' ' -f1)
-
-iptables -t nat -A PREROUTING -i eth0 -p tcp -m multiport --dports=30000:33000 -j DNAT --to-destination 172.18.0.2
-# By default all traffic gets dropped unless specified (tested with docker
-# server 18.09.1)
-iptables -t filter -I DOCKER-USER -d 172.18.0.2/32 ! -i $KIND_NETWORK_IF -o $KIND_NETWORK_IF -p tcp -m multiport --dports=30000:33000 -j ACCEPT
-
-# Docker sets up a MASQUERADE rule for postrouting, so nothing to do for us
-echodate "Successfully set up iptables rules for nodeports"
+# find Dex anymore. As this script can be run multiple times in the same CI job,
+# we must make sure to only add the alias once.
+if ! grep oauth /etc/hosts > /dev/null; then
+  echodate "Setting dex.oauth alias in /etc/hosts"
+  # The container runtime allows us to change the content but not to change the inode
+  # which is what sed -i does, so write to a tempfile and write the tempfiles content back.
+  temp_hosts="$(mktemp)"
+  sed 's/localhost/localhost dex.oauth/' /etc/hosts > $temp_hosts
+  cat $temp_hosts > /etc/hosts
+  echodate "Set dex.oauth alias in /etc/hosts"
+fi
 
 # Build binaries and load the Docker images into the kind cluster
 echodate "Building binaries for $KUBERMATIC_VERSION"
@@ -193,7 +81,7 @@ beforeDockerBuild=$(nowms)
   TEST_NAME="Build Kubermatic Docker image"
   IMAGE_NAME="quay.io/kubermatic/kubermatic$REPOSUFFIX:$KUBERMATIC_VERSION"
   time retry 5 docker build -t "$IMAGE_NAME" .
-  time retry 5 kind load docker-image "$IMAGE_NAME" --name ${SEED_NAME}
+  time retry 5 kind load docker-image "$IMAGE_NAME" --name "$KIND_CLUSTER_NAME"
 )
 (
   echodate "Building addons image"
@@ -201,7 +89,7 @@ beforeDockerBuild=$(nowms)
   cd addons
   IMAGE_NAME="quay.io/kubermatic/addons:$KUBERMATIC_VERSION"
   time retry 5 docker build -t "${IMAGE_NAME}" .
-  time retry 5 kind load docker-image "$IMAGE_NAME" --name ${SEED_NAME}
+  time retry 5 kind load docker-image "$IMAGE_NAME" --name "$KIND_CLUSTER_NAME"
 )
 (
   echodate "Building openshift addons image"
@@ -209,7 +97,7 @@ beforeDockerBuild=$(nowms)
   cd openshift_addons
   IMAGE_NAME="quay.io/kubermatic/openshift-addons:$KUBERMATIC_VERSION"
   time retry 5 docker build -t "${IMAGE_NAME}" .
-  time retry 5 kind load docker-image "$IMAGE_NAME" --name ${SEED_NAME}
+  time retry 5 kind load docker-image "$IMAGE_NAME" --name "$KIND_CLUSTER_NAME"
 )
 (
   echodate "Building nodeport-proxy image"
@@ -218,7 +106,7 @@ beforeDockerBuild=$(nowms)
   make build
   IMAGE_NAME="quay.io/kubermatic/nodeport-proxy:$KUBERMATIC_VERSION"
   time retry 5 docker build -t "${IMAGE_NAME}" .
-  time retry 5 kind load docker-image "$IMAGE_NAME" --name ${SEED_NAME}
+  time retry 5 kind load docker-image "$IMAGE_NAME" --name "$KIND_CLUSTER_NAME"
 )
 (
   echodate "Building kubeletdnat-controller image"
@@ -227,7 +115,7 @@ beforeDockerBuild=$(nowms)
   make build
   IMAGE_NAME="quay.io/kubermatic/kubeletdnat-controller:$KUBERMATIC_VERSION"
   time retry 5 docker build -t "${IMAGE_NAME}" .
-  time retry 5 kind load docker-image "$IMAGE_NAME" --name ${SEED_NAME}
+  time retry 5 kind load docker-image "$IMAGE_NAME" --name "$KIND_CLUSTER_NAME"
 )
 (
   echodate "Building user-ssh-keys-agent image"
@@ -244,7 +132,7 @@ beforeDockerBuild=$(nowms)
   TEST_NAME="Build etcd-launcher Docker image"
   IMAGE_NAME="quay.io/kubermatic/etcd-launcher:${KUBERMATIC_VERSION}"
   time retry 5 docker build -t "${IMAGE_NAME}" -f cmd/etcd-launcher/Dockerfile .
-  time retry 5 kind load docker-image "$IMAGE_NAME" --name ${SEED_NAME}
+  time retry 5 kind load docker-image "$IMAGE_NAME" --name "$KIND_CLUSTER_NAME"
 )
 
 pushElapsed kubermatic_docker_build_duration_milliseconds $beforeDockerBuild
@@ -252,35 +140,12 @@ echodate "Successfully built and loaded all images"
 
 # prepare to run kubermatic-installer
 KUBERMATIC_CONFIG="$(mktemp)"
-cat <<EOF >$KUBERMATIC_CONFIG
-apiVersion: operator.kubermatic.io/v1alpha1
-kind: KubermaticConfiguration
-metadata:
-  name: e2e
-  namespace: kubermatic
-spec:
-  ingress:
-    domain: ci.kubermatic.io
-    disable: true
-  imagePullSecret: |
-$(echo "$IMAGE_PULL_SECRET_DATA" | base64 -d | sed 's/^/    /')
-  userCluster:
-    apiserverReplicas: 1
-  api:
-    replicas: 1
-    debugLog: true
-  featureGates:
-    # VPA won't do anything useful due to missing Prometheus, but we can
-    # at least ensure we deploy a working set of Deployments.
-    VerticalPodAutoscaler: {}
-  ui:
-    replicas: 0
-  # Dex integration
-  auth:
-    tokenIssuer: "http://dex.oauth:5556/dex"
-    issuerRedirectURL: "http://localhost:8000"
-    serviceAccountKey: "$SERVICE_ACCOUNT_KEY"
-EOF
+IMAGE_PULL_SECRET_INLINE="$(echo "$IMAGE_PULL_SECRET_DATA" | base64 --decode | jq --compact-output --monochrome-output '.')"
+
+cp hack/ci/testdata/kubermatic.yaml $KUBERMATIC_CONFIG
+
+sed -i "s;__SERVICE_ACCOUNT_KEY__;$SERVICE_ACCOUNT_KEY;g" $KUBERMATIC_CONFIG
+sed -i "s;__IMAGE_PULL_SECRET__;$IMAGE_PULL_SECRET_INLINE;g" $KUBERMATIC_CONFIG
 
 HELM_VALUES_FILE="$(mktemp)"
 cat <<EOF >$HELM_VALUES_FILE
@@ -311,127 +176,14 @@ echodate "Finished installing Kubermatic"
 
 echodate "Installing Seed..."
 SEED_MANIFEST="$(mktemp)"
-cat <<EOF >$SEED_MANIFEST
-kind: Secret
-apiVersion: v1
-metadata:
-  name: ${SEED_NAME}-kubeconfig
-  namespace: kubermatic
-data:
-  kubeconfig: "$(cat $KUBECONFIG|sed 's/127.0.0.1.*/kubernetes.default.svc.cluster.local./'|base64 -w0)"
+SEED_KUBECONFIG="$(cat $KUBECONFIG | sed 's/127.0.0.1.*/kubernetes.default.svc.cluster.local./' | base64 -w0)"
 
----
-kind: Seed
-apiVersion: kubermatic.k8s.io/v1
-metadata:
-  name: ${SEED_NAME}
-  namespace: kubermatic
-  labels:
-    worker-name: "$BUILD_ID"
-spec:
-  country: Germany
-  location: Hamburg
-  kubeconfig:
-    name: ${SEED_NAME}-kubeconfig
-    namespace: kubermatic
-    fieldPath: kubeconfig
-  datacenters:
-    byo-kubernetes:
-      location: Frankfurt
-      country: DE
-      spec:
-         bringyourown: {}
-    alibaba-eu-central-1a:
-      location: Frankfurt
-      country: DE
-      spec:
-        alibaba:
-          region: eu-central-1
-    aws-eu-central-1a:
-      location: EU (Frankfurt)
-      country: DE
-      spec:
-        aws:
-          region: eu-central-1
-    hetzner-nbg1:
-      location: Nuremberg 1 DC 3
-      country: DE
-      spec:
-        hetzner:
-          datacenter: nbg1-dc3
-    vsphere-ger:
-      location: Hamburg
-      country: DE
-      spec:
-        vsphere:
-          endpoint: "https://vcenter.loodse.io"
-          datacenter: "dc-1"
-          datastore: "exsi-nas"
-          cluster: "cl-1"
-          root_path: "/dc-1/vm/e2e-tests"
-          templates:
-            ubuntu: "machine-controller-e2e-ubuntu"
-            centos: "machine-controller-e2e-centos"
-            coreos: "machine-controller-e2e-coreos"
-    azure-westeurope:
-      location: "Azure West europe"
-      country: NL
-      spec:
-        azure:
-          location: "westeurope"
-    gcp-westeurope:
-      location: "Europe West (Germany)"
-      country: DE
-      spec:
-        gcp:
-          region: europe-west3
-          zone_suffixes:
-          - c
-    packet-ewr1:
-      location: "Packet EWR1 (New York)"
-      country: US
-      spec:
-        packet:
-          facilities:
-          - ewr1
-    do-ams3:
-      location: Amsterdam
-      country: NL
-      spec:
-        digitalocean:
-          region: ams3
-    do-fra1:
-      location: Frankfurt
-      country: DE
-      spec:
-        digitalocean:
-          region: fra1
-    kubevirt-europe-west3-c:
-      location: Frankfurt
-      country: DE
-      spec:
-        kubevirt: {}
-    syseleven-dbl1:
-      country: DE
-      location: Syseleven - dbl1
-      spec:
-        openstack:
-          auth_url: https://api.cbk.cloud.syseleven.net:5000/v3
-          availability_zone: dbl1
-          dns_servers:
-          - 37.123.105.116
-          - 37.123.105.117
-          enforce_floating_ip: true
-          ignore_volume_az: false
-          images:
-            centos: kubermatic-e2e-centos
-            coreos: kubermatic-e2e-coreos
-            ubuntu: kubermatic-e2e-ubuntu
-          node_size_requirements:
-            minimum_memory: 0
-            minimum_vcpus: 0
-          region: dbl
-EOF
+cp hack/ci/testdata/seed.yaml $SEED_MANIFEST
+
+sed -i "s/__SEED_NAME__/$SEED_NAME/g" $SEED_MANIFEST
+sed -i "s/__BUILD_ID__/$BUILD_ID/g" $SEED_MANIFEST
+sed -i "s/__KUBECONFIG__/$SEED_KUBECONFIG/g" $SEED_MANIFEST
+
 retry 8 kubectl apply -f $SEED_MANIFEST
 echodate "Finished installing Seed"
 

--- a/hack/ci/setup-legacy-kubermatic-in-kind.sh
+++ b/hack/ci/setup-legacy-kubermatic-in-kind.sh
@@ -23,13 +23,8 @@
 
 source hack/lib.sh
 
-if [ -z "${JOB_NAME:-}" ]; then
-  echodate "This script should only be running in a CI environment."
-  exit 1
-fi
-
-if [ -z "${PROW_JOB_ID:-}" ]; then
-  echodate "Build id env variable has to be set."
+if [ -z "${KIND_CLUSTER_NAME:-}" ]; then
+  echodate "KIND_CLUSTER_NAME must be set by calling setup-kind-cluster.sh first."
   exit 1
 fi
 
@@ -57,126 +52,19 @@ export KUBERMATIC_OIDC_PASSWORD="password"
 # Set docker config
 echo "$IMAGE_PULL_SECRET_DATA" | base64 -d > /config.json
 
-# Start Docker daemon
-echodate "Starting Docker"
-dockerd > /tmp/docker.log 2>&1 &
-echodate "Started Docker successfully"
-
-function docker_logs {
-  if [[ $? -ne 0 ]]; then
-    echodate "Printing Docker logs"
-    cat /tmp/docker.log
-    echodate "Done printing Docker logs"
-  fi
-}
-appendTrap docker_logs EXIT
-
-# Wait for Docker to start
-echodate "Waiting for Docker"
-retry 5 docker stats --no-stream
-echodate "Docker became ready"
-
-# Load kind image
-echodate "Loading kindest image"
-docker load --input /kindest.tar
-echodate "Loaded kindest image"
-
-# Prevent mtu-related timeouts
-echodate "Setting iptables rule to clamp mss to path mtu"
-iptables -t mangle -A POSTROUTING -p tcp --tcp-flags SYN,RST SYN -j TCPMSS --clamp-mss-to-pmtu
-
-# Make debugging a bit better
-echodate "Confuguring bash"
-cat <<EOF >>~/.bashrc
-# Gets set to the CI clusters kubeconfig from a preset
-unset KUBECONFIG
-
-cn() {
-  kubectl config set-context \$(kubectl config current-context) --namespace=\$1
-}
-
-kubeconfig() {
-  TMP_KUBECONFIG=\$(mktemp);
-  kubectl get secret admin-kubeconfig -o go-template='{{ index .data "kubeconfig" }}' | base64 -d > \$TMP_KUBECONFIG;
-  export KUBECONFIG=\$TMP_KUBECONFIG;
-  cn kube-system
-}
-
-# this alias makes it so that watch can be used with other aliases, like "watch k get pods"
-alias watch='watch '
-alias k=kubectl
-alias ll='ls -lh --file-type --group-directories-first'
-alias lll='ls -lahF --group-directories-first'
-source <(k completion bash )
-source <(k completion bash | sed s/kubectl/k/g)
-EOF
-
 # The alias makes it easier to access the port-forwarded Dex inside the Kind cluster;
 # the token issuer cannot be localhost:5556, because pods inside the cluster would not
-# find Dex anymore.
-echodate "Setting dex.oauth alias in /etc/hosts"
-# The container runtime allows us to change the content but not to change the inode
-# which is what sed -i does, so write to a tempfile and write the tempfiles content back.
-temp_hosts="$(mktemp)"
-sed 's/localhost/localhost dex.oauth/' /etc/hosts > $temp_hosts
-cat $temp_hosts > /etc/hosts
-echodate "Set dex.oauth alias in /etc/hosts"
-
-# Create kind cluster
-TEST_NAME="Create kind cluster"
-echodate "Creating the kind cluster"
-export KUBECONFIG=~/.kube/config
-
-beforeKindCreate=$(nowms)
-nodeVersion=v1.18.2
-kind create cluster --name ${SEED_NAME} --image=kindest/node:$nodeVersion
-pushElapsed kind_cluster_create_duration_milliseconds $beforeKindCreate "node_version=\"$nodeVersion\""
-
-TEST_NAME="Pre-warm Go build cache"
-echodate "Attempting to pre-warm Go build cache"
-
-beforeGocache=$(nowms)
-make download-gocache
-pushElapsed gocache_download_duration_milliseconds $beforeGocache
-
-# Start cluster exposer, which will expose services from within kind as
-# a NodePort service on the host
-echodate "Starting cluster exposer"
-
-CGO_ENABLED=0 go build --tags "$KUBERMATIC_EDITION" -v -o /tmp/clusterexposer ./pkg/test/clusterexposer/cmd
-CGO_ENABLED=0 /tmp/clusterexposer \
-  --kubeconfig-inner "$KUBECONFIG" \
-  --kubeconfig-outer "/etc/kubeconfig/kubeconfig" \
-  --build-id "$PROW_JOB_ID" &> /var/log/clusterexposer.log &
-
-function print_cluster_exposer_logs {
-  if [[ $? -ne 0 ]]; then
-    # Tolerate errors and just continue
-    set +e
-    echodate "Printing cluster exposer logs"
-    cat /var/log/clusterexposer.log
-    echodate "Done printing cluster exposer logs"
-    set -e
-  fi
-}
-appendTrap print_cluster_exposer_logs EXIT
-
-TEST_NAME="Wait for cluster exposer"
-echodate "Waiting for cluster exposer to be running"
-
-retry 5 curl -s --fail http://127.0.0.1:2047/metrics -o /dev/null
-echodate "Cluster exposer is running"
-
-echodate "Setting up iptables rules for to make nodeports available"
-KIND_NETWORK_IF=$(ip -br addr | grep -- 'br-' | cut -d' ' -f1)
-
-iptables -t nat -A PREROUTING -i eth0 -p tcp -m multiport --dports=30000:33000 -j DNAT --to-destination 172.18.0.2
-# By default all traffic gets dropped unless specified (tested with docker
-# server 18.09.1)
-iptables -t filter -I DOCKER-USER -d 172.18.0.2/32 ! -i $KIND_NETWORK_IF -o $KIND_NETWORK_IF -p tcp -m multiport --dports=30000:33000 -j ACCEPT
-
-# Docker sets up a MASQUERADE rule for postrouting, so nothing to do for us
-echodate "Successfully set up iptables rules for nodeports"
+# find Dex anymore. As this script can be run multiple times in the same CI job,
+# we must make sure to only add the alias once.
+if ! grep oauth /etc/hosts > /dev/null; then
+  echodate "Setting dex.oauth alias in /etc/hosts"
+  # The container runtime allows us to change the content but not to change the inode
+  # which is what sed -i does, so write to a tempfile and write the tempfiles content back.
+  temp_hosts="$(mktemp)"
+  sed 's/localhost/localhost dex.oauth/' /etc/hosts > $temp_hosts
+  cat $temp_hosts > /etc/hosts
+  echodate "Set dex.oauth alias in /etc/hosts"
+fi
 
 echodate "Creating StorageClass kubermatic-fast "
 TEST_NAME="Create StorageClass kubermatic-fast"
@@ -211,7 +99,7 @@ beforeDockerBuild=$(nowms)
   TEST_NAME="Build Kubermatic Docker image"
   IMAGE_NAME="quay.io/kubermatic/kubermatic$REPOSUFFIX:$KUBERMATIC_VERSION"
   time retry 5 docker build -t "$IMAGE_NAME" .
-  time retry 5 kind load docker-image "$IMAGE_NAME" --name ${SEED_NAME}
+  time retry 5 kind load docker-image "$IMAGE_NAME" --name "$KIND_CLUSTER_NAME"
 )
 (
   echodate "Building addons image"
@@ -219,7 +107,7 @@ beforeDockerBuild=$(nowms)
   cd addons
   IMAGE_NAME="quay.io/kubermatic/addons:$KUBERMATIC_VERSION"
   time retry 5 docker build -t "${IMAGE_NAME}" .
-  time retry 5 kind load docker-image "$IMAGE_NAME" --name ${SEED_NAME}
+  time retry 5 kind load docker-image "$IMAGE_NAME" --name "$KIND_CLUSTER_NAME"
 )
 (
   echodate "Building openshift addons image"
@@ -227,7 +115,7 @@ beforeDockerBuild=$(nowms)
   cd openshift_addons
   IMAGE_NAME="quay.io/kubermatic/openshift-addons:$KUBERMATIC_VERSION"
   time retry 5 docker build -t "${IMAGE_NAME}" .
-  time retry 5 kind load docker-image "$IMAGE_NAME" --name ${SEED_NAME}
+  time retry 5 kind load docker-image "$IMAGE_NAME" --name "$KIND_CLUSTER_NAME"
 )
 (
   echodate "Building kubeletdnat-controller image"
@@ -236,7 +124,7 @@ beforeDockerBuild=$(nowms)
   make build
   IMAGE_NAME="quay.io/kubermatic/kubeletdnat-controller:$KUBERMATIC_VERSION"
   time retry 5 docker build -t "${IMAGE_NAME}" .
-  time retry 5 kind load docker-image "$IMAGE_NAME" --name ${SEED_NAME}
+  time retry 5 kind load docker-image "$IMAGE_NAME" --name "$KIND_CLUSTER_NAME"
 )
 (
   echodate "Building user-ssh-keys-agent image"
@@ -253,7 +141,7 @@ beforeDockerBuild=$(nowms)
   TEST_NAME="Build etcd-launcher Docker image"
   IMAGE_NAME="quay.io/kubermatic/etcd-launcher:${KUBERMATIC_VERSION}"
   time retry 5 docker build -t "${IMAGE_NAME}" -f cmd/etcd-launcher/Dockerfile .
-  time retry 5 kind load docker-image "$IMAGE_NAME" --name ${SEED_NAME}
+  time retry 5 kind load docker-image "$IMAGE_NAME" --name "$KIND_CLUSTER_NAME"
 )
 
 pushElapsed kubermatic_docker_build_duration_milliseconds $beforeDockerBuild
@@ -271,6 +159,8 @@ echodate "Deploying Kubermatic using Helm..."
 
 beforeDeployment=$(nowms)
 
+SEED_KUBECONFIG="$(cat $KUBECONFIG | sed 's/127.0.0.1.*/kubernetes.default.svc.cluster.local./' | base64 -w0)"
+
 # we always override the quay repositories so we don't have to care if the
 # Helm chart is made for CE or EE
 retry 3 kubectl create ns kubermatic
@@ -286,7 +176,7 @@ retry 3 helm3 --namespace kubermatic install --atomic --timeout 5m \
   --set-string=kubermatic.controller.image.tag="$KUBERMATIC_VERSION" \
   --set-string=kubermatic.controller.addons.openshift.image.tag="$KUBERMATIC_VERSION" \
   --set-string=kubermatic.api.image.tag="$KUBERMATIC_VERSION" \
-  --set=kubermatic.controller.datacenterName="${SEED_NAME}" \
+  --set=kubermatic.controller.datacenterName="$SEED_NAME" \
   --set=kubermatic.api.replicas=1 \
   --set-string=kubermatic.masterController.image.tag="$KUBERMATIC_VERSION" \
   --set-string=kubermatic.ui.image.tag=latest \
@@ -296,7 +186,7 @@ retry 3 helm3 --namespace kubermatic install --atomic --timeout 5m \
   --set=kubermatic.datacenters='' \
   --set=kubermatic.dynamicDatacenters=true \
   --set=kubermatic.dynamicPresets=true \
-  --set=kubermatic.kubeconfig="$(cat $KUBECONFIG|sed 's/127.0.0.1.*/kubernetes.default.svc.cluster.local./'|base64 -w0)" \
+  --set=kubermatic.kubeconfig="$SEED_KUBECONFIG" \
   --set=kubermatic.auth.tokenIssuer=http://dex.oauth:5556/dex \
   --set=kubermatic.auth.clientID=kubermatic \
   --set=kubermatic.auth.serviceAccountKey=$SERVICE_ACCOUNT_KEY \
@@ -311,127 +201,13 @@ echodate "Finished installing Kubermatic"
 
 echodate "Installing Seed..."
 SEED_MANIFEST="$(mktemp)"
-cat <<EOF >$SEED_MANIFEST
-kind: Secret
-apiVersion: v1
-metadata:
-  name: ${SEED_NAME}-kubeconfig
-  namespace: kubermatic
-data:
-  kubeconfig: "$(cat $KUBECONFIG|sed 's/127.0.0.1.*/kubernetes.default.svc.cluster.local./'|base64 -w0)"
 
----
-kind: Seed
-apiVersion: kubermatic.k8s.io/v1
-metadata:
-  name: ${SEED_NAME}
-  namespace: kubermatic
-  labels:
-    worker-name: "$BUILD_ID"
-spec:
-  country: Germany
-  location: Hamburg
-  kubeconfig:
-    name: ${SEED_NAME}-kubeconfig
-    namespace: kubermatic
-    fieldPath: kubeconfig
-  datacenters:
-    byo-kubernetes:
-      location: Frankfurt
-      country: DE
-      spec:
-         bringyourown: {}
-    alibaba-eu-central-1a:
-      location: Frankfurt
-      country: DE
-      spec:
-        alibaba:
-          region: eu-central-1
-    aws-eu-central-1a:
-      location: EU (Frankfurt)
-      country: DE
-      spec:
-        aws:
-          region: eu-central-1
-    hetzner-nbg1:
-      location: Nuremberg 1 DC 3
-      country: DE
-      spec:
-        hetzner:
-          datacenter: nbg1-dc3
-    vsphere-ger:
-      location: Hamburg
-      country: DE
-      spec:
-        vsphere:
-          endpoint: "https://vcenter.loodse.io"
-          datacenter: "dc-1"
-          datastore: "exsi-nas"
-          cluster: "cl-1"
-          root_path: "/dc-1/vm/e2e-tests"
-          templates:
-            ubuntu: "machine-controller-e2e-ubuntu"
-            centos: "machine-controller-e2e-centos"
-            coreos: "machine-controller-e2e-coreos"
-    azure-westeurope:
-      location: "Azure West europe"
-      country: NL
-      spec:
-        azure:
-          location: "westeurope"
-    gcp-westeurope:
-      location: "Europe West (Germany)"
-      country: DE
-      spec:
-        gcp:
-          region: europe-west3
-          zone_suffixes:
-          - c
-    packet-ewr1:
-      location: "Packet EWR1 (New York)"
-      country: US
-      spec:
-        packet:
-          facilities:
-          - ewr1
-    do-ams3:
-      location: Amsterdam
-      country: NL
-      spec:
-        digitalocean:
-          region: ams3
-    do-fra1:
-      location: Frankfurt
-      country: DE
-      spec:
-        digitalocean:
-          region: fra1
-    kubevirt-europe-west3-c:
-      location: Frankfurt
-      country: DE
-      spec:
-        kubevirt: {}
-    syseleven-dbl1:
-      country: DE
-      location: Syseleven - dbl1
-      spec:
-        openstack:
-          auth_url: https://api.cbk.cloud.syseleven.net:5000/v3
-          availability_zone: dbl1
-          dns_servers:
-          - 37.123.105.116
-          - 37.123.105.117
-          enforce_floating_ip: true
-          ignore_volume_az: false
-          images:
-            centos: kubermatic-e2e-centos
-            coreos: kubermatic-e2e-coreos
-            ubuntu: kubermatic-e2e-ubuntu
-          node_size_requirements:
-            minimum_memory: 0
-            minimum_vcpus: 0
-          region: dbl
-EOF
+cp hack/ci/testdata/seed.yaml $SEED_MANIFEST
+
+sed -i "s/__SEED_NAME__/$SEED_NAME/g" $SEED_MANIFEST
+sed -i "s/__BUILD_ID__/$BUILD_ID/g" $SEED_MANIFEST
+sed -i "s/__KUBECONFIG__/$SEED_KUBECONFIG/g" $SEED_MANIFEST
+
 retry 8 kubectl apply -f $SEED_MANIFEST
 echodate "Finished installing Seed"
 

--- a/hack/ci/testdata/kubermatic.yaml
+++ b/hack/ci/testdata/kubermatic.yaml
@@ -1,0 +1,40 @@
+# Copyright 2020 The Kubermatic Kubernetes Platform contributors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+apiVersion: operator.kubermatic.io/v1alpha1
+kind: KubermaticConfiguration
+metadata:
+  name: e2e
+  namespace: kubermatic
+spec:
+  ingress:
+    domain: ci.kubermatic.io
+    disable: true
+  imagePullSecret: '__IMAGE_PULL_SECRET__'
+  userCluster:
+    apiserverReplicas: 1
+  api:
+    replicas: 1
+    debugLog: true
+  featureGates:
+    # VPA won't do anything useful due to missing Prometheus, but we can
+    # at least ensure we deploy a working set of Deployments.
+    VerticalPodAutoscaler: {}
+  ui:
+    replicas: 0
+  # Dex integration
+  auth:
+    tokenIssuer: "http://dex.oauth:5556/dex"
+    issuerRedirectURL: "http://localhost:8000"
+    serviceAccountKey: "__SERVICE_ACCOUNT_KEY__"

--- a/hack/ci/testdata/seed.yaml
+++ b/hack/ci/testdata/seed.yaml
@@ -1,0 +1,133 @@
+# Copyright 2020 The Kubermatic Kubernetes Platform contributors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+kind: Secret
+apiVersion: v1
+metadata:
+  name: "__SEED_NAME__-kubeconfig"
+  namespace: kubermatic
+data:
+  kubeconfig: "__KUBECONFIG__"
+
+---
+kind: Seed
+apiVersion: kubermatic.k8s.io/v1
+metadata:
+  name: "__SEED_NAME__"
+  namespace: kubermatic
+  labels:
+    worker-name: "__BUILD_ID__"
+spec:
+  country: Germany
+  location: Hamburg
+  kubeconfig:
+    name: "__SEED_NAME__-kubeconfig"
+    namespace: kubermatic
+    fieldPath: kubeconfig
+  datacenters:
+    byo-kubernetes:
+      location: Frankfurt
+      country: DE
+      spec:
+         bringyourown: {}
+    alibaba-eu-central-1a:
+      location: Frankfurt
+      country: DE
+      spec:
+        alibaba:
+          region: eu-central-1
+    aws-eu-central-1a:
+      location: EU (Frankfurt)
+      country: DE
+      spec:
+        aws:
+          region: eu-central-1
+    hetzner-nbg1:
+      location: Nuremberg 1 DC 3
+      country: DE
+      spec:
+        hetzner:
+          datacenter: nbg1-dc3
+    vsphere-ger:
+      location: Hamburg
+      country: DE
+      spec:
+        vsphere:
+          endpoint: "https://vcenter.loodse.io"
+          datacenter: "dc-1"
+          datastore: "exsi-nas"
+          cluster: "cl-1"
+          root_path: "/dc-1/vm/e2e-tests"
+          templates:
+            ubuntu: "machine-controller-e2e-ubuntu"
+            centos: "machine-controller-e2e-centos"
+            coreos: "machine-controller-e2e-coreos"
+    azure-westeurope:
+      location: "Azure West europe"
+      country: NL
+      spec:
+        azure:
+          location: "westeurope"
+    gcp-westeurope:
+      location: "Europe West (Germany)"
+      country: DE
+      spec:
+        gcp:
+          region: europe-west3
+          zone_suffixes:
+          - c
+    packet-ewr1:
+      location: "Packet EWR1 (New York)"
+      country: US
+      spec:
+        packet:
+          facilities:
+          - ewr1
+    do-ams3:
+      location: Amsterdam
+      country: NL
+      spec:
+        digitalocean:
+          region: ams3
+    do-fra1:
+      location: Frankfurt
+      country: DE
+      spec:
+        digitalocean:
+          region: fra1
+    kubevirt-europe-west3-c:
+      location: Frankfurt
+      country: DE
+      spec:
+        kubevirt: {}
+    syseleven-dbl1:
+      country: DE
+      location: Syseleven - dbl1
+      spec:
+        openstack:
+          auth_url: https://api.cbk.cloud.syseleven.net:5000/v3
+          availability_zone: dbl1
+          dns_servers:
+          - 37.123.105.116
+          - 37.123.105.117
+          enforce_floating_ip: true
+          ignore_volume_az: false
+          images:
+            centos: kubermatic-e2e-centos
+            coreos: kubermatic-e2e-coreos
+            ubuntu: kubermatic-e2e-ubuntu
+          node_size_requirements:
+            minimum_memory: 0
+            minimum_vcpus: 0
+          region: dbl

--- a/hack/run-user-cluster-controller-manager.sh
+++ b/hack/run-user-cluster-controller-manager.sh
@@ -25,7 +25,7 @@ echodate "Compiling user-cluster-controller-manager..."
 make user-cluster-controller-manager
 
 # Getting everything we need from the api
-# This script assumes you are in your cluster namespace, which you can configure via `kubectl config set-context $(kubectl config current-context) --namespace=<<cluster-namespace>>`
+# This script assumes you are in your cluster namespace, which you can configure via `kubectl config set-context --current --namespace=<<cluster-namespace>>`
 NAMESPACE="${NAMESPACE:-$(kubectl config view --minify | grep namespace |awk '{ print $2 }')}"
 CLUSTER_NAME="$(echo $NAMESPACE | sed 's/cluster-//')"
 CLUSTER_RAW="$(kubectl get cluster $CLUSTER_NAME -o json)"


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR is a first step towards bringing back the upgrade tests (KKP upgrades that is, not usercluster upgrades). These tests were removed a year back or so because the way we built them was severely limiting our ability to improve the product and lead to tons of BC hacks all over the place.

Now that we have a fancy installer and operator, it's time to bring these tests back and make sure that the installer can do what it promises. This will then replace the canary-ci-deployment tests, which currently test that our Helm charts are upgradable without problems. The problem with the canary job are many however: there can be only 1 job at any time, it depends on Kubermatic infrastructure and it does not test anyhting that is actually of importance.

The general test outline I aim for is this:

1. Setup a kind cluster.
2. Find the last stable KKP release, `git checkout` to that revision and then install KKP into the kind cluster. This of course requires that the release version also already has the installer (because otherwise we couldn't test the installer, as all our other code uses Helm 2, but the installer uses Helm 3). Instead of git-checkout and compiling, we could soon also just download the release archive from github. :-D
3. Wait for the old KKP installation to be complete.
4. Checkout HEAD of the Pull Request again, recompile installer.
5. Run the new installer and let it upgrade the KKP setup.
6. Wait for all Deployments to have finished rolling out.

This PR is a preparation for step 2, to ensure that we have a simple script that can just setup Kubermatic without also setting up Kind/clusterexposer. That's why this PR splits the `setup-kubermatic-in-kind` script into two, one just for kind and one just for KKP. To make it simpler, the large inline YAML documents for Seed/KubermaticConfiguration have been extracted as well.

**Does this PR introduce a user-facing change?**:
```release-note
NONE
```
