### PR TITLE
[vSphere] Improve datastore handling

### DIFF
--- a/.prow.yaml
+++ b/.prow.yaml
@@ -1074,6 +1074,8 @@ presubmits:
           value: "v1.19.2"
         - name: PROVIDER
           value: "vsphere"
+        - name: EXCLUDE_DISTRIBUTIONS
+          value: "centos,coreos,flatcar,rhel"
         - name: SCENARIO_OPTIONS
           value: "datastore-cluster"
         - name: SERVICE_ACCOUNT_KEY

--- a/cmd/conformance-tests/scenarios_vsphere.go
+++ b/cmd/conformance-tests/scenarios_vsphere.go
@@ -18,6 +18,7 @@ package main
 
 import (
 	"fmt"
+	"strings"
 
 	"k8c.io/kubermatic/v2/pkg/semver"
 	apimodels "k8c.io/kubermatic/v2/pkg/test/e2e/api/utils/apiclient/models"
@@ -84,7 +85,7 @@ type vSphereScenario struct {
 }
 
 func (s *vSphereScenario) Name() string {
-	return fmt.Sprintf("vsphere-%s-%s", getOSNameFromSpec(s.nodeOsSpec), s.version.String())
+	return fmt.Sprintf("vsphere-%s-%s", getOSNameFromSpec(s.nodeOsSpec), strings.Replace(s.version.String(), ".", "-", -1))
 }
 
 func (s *vSphereScenario) Cluster(secrets secrets) *apimodels.CreateClusterSpec {

--- a/cmd/kubermatic-api/swagger.json
+++ b/cmd/kubermatic-api/swagger.json
@@ -11295,7 +11295,7 @@
           "x-go-name": "Datacenter"
         },
         "datastore": {
-          "description": "The name of the default Datastore to be used for provisioning volumes\nusing storage classes/dynamic provisioning and for storing virtual\nmachine files in case no `Datastore` or `DatastoreCluster` is provided\nwith the `VSphereCloudSpec`.",
+          "description": "The default Datastore to be used for provisioning volumes using storage\nclasses/dynamic provisioning and for storing virtual machine files in\ncase no `Datastore` or `DatastoreCluster` is provided at Cluster level.",
           "type": "string",
           "x-go-name": "DefaultDatastore"
         },
@@ -14319,12 +14319,12 @@
           "$ref": "#/definitions/GlobalSecretKeySelector"
         },
         "datastore": {
-          "description": "Datastore to be used for storing virtual machines, it is mutually\nexclusive with DatastoreCluster.\n+optional",
+          "description": "Datastore to be used for storing virtual machines and as a default for\ndynamic volume provisioning, it is mutually exclusive with\nDatastoreCluster.\n+optional",
           "type": "string",
           "x-go-name": "Datastore"
         },
         "datastoreCluster": {
-          "description": "DatastoreCluster to be used for determining the Datastore for virtual\nmachines, it is mutually exclusive with Datastore.\n+optional",
+          "description": "DatastoreCluster to be used for storing virtual machines, it is mutually\nexclusive with Datastore.\n+optional",
           "type": "string",
           "x-go-name": "DatastoreCluster"
         },

--- a/docs/zz_generated.seed.yaml
+++ b/docs/zz_generated.seed.yaml
@@ -150,10 +150,9 @@ spec:
           cluster: ""
           # The name of the datacenter to use.
           datacenter: ""
-          # The name of the default Datastore to be used for provisioning volumes
-          # using storage classes/dynamic provisioning and for storing virtual
-          # machine files in case no `Datastore` or `DatastoreCluster` is provided
-          # with the `VSphereCloudSpec`.
+          # The default Datastore to be used for provisioning volumes using storage
+          # classes/dynamic provisioning and for storing virtual machine files in
+          # case no `Datastore` or `DatastoreCluster` is provided at Cluster level.
           datastore: ""
           # Endpoint URL to use, including protocol, for example "https://vcenter.example.com".
           endpoint: ""

--- a/pkg/crd/kubermatic/v1/cluster.go
+++ b/pkg/crd/kubermatic/v1/cluster.go
@@ -471,15 +471,16 @@ type VSphereCloudSpec struct {
 	// +optional
 	Folder string `json:"folder"`
 	// If both Datastore and DatastoreCluster are not specified the virtual
-	// machines are stored in the `DefaultDatastore` specified in the
+	// machines are stored in the `DefaultDatastore` specified for the
 	// Datacenter.
 
-	// Datastore to be used for storing virtual machines, it is mutually
-	// exclusive with DatastoreCluster.
+	// Datastore to be used for storing virtual machines and as a default for
+	// dynamic volume provisioning, it is mutually exclusive with
+	// DatastoreCluster.
 	// +optional
 	Datastore string `json:"datastore,omitempty"`
-	// DatastoreCluster to be used for determining the Datastore for virtual
-	// machines, it is mutually exclusive with Datastore.
+	// DatastoreCluster to be used for storing virtual machines, it is mutually
+	// exclusive with Datastore.
 	// +optional
 	DatastoreCluster string `json:"datastoreCluster,omitempty"`
 

--- a/pkg/crd/kubermatic/v1/datacenter.go
+++ b/pkg/crd/kubermatic/v1/datacenter.go
@@ -232,10 +232,9 @@ type DatacenterSpecVSphere struct {
 	Endpoint string `json:"endpoint"`
 	// If set to true, disables the TLS certificate check against the endpoint.
 	AllowInsecure bool `json:"allow_insecure"`
-	// The name of the default Datastore to be used for provisioning volumes
-	// using storage classes/dynamic provisioning and for storing virtual
-	// machine files in case no `Datastore` or `DatastoreCluster` is provided
-	// with the `VSphereCloudSpec`.
+	// The default Datastore to be used for provisioning volumes using storage
+	// classes/dynamic provisioning and for storing virtual machine files in
+	// case no `Datastore` or `DatastoreCluster` is provided at Cluster level.
 	DefaultDatastore string `json:"datastore"`
 	// The name of the datacenter to use.
 	Datacenter string `json:"datacenter"`

--- a/pkg/resources/cloudconfig/configmap.go
+++ b/pkg/resources/cloudconfig/configmap.go
@@ -241,6 +241,14 @@ func getVsphereCloudConfig(
 	if urlPort := vspherURL.Port(); urlPort != "" {
 		port = urlPort
 	}
+	datastore := dc.Spec.VSphere.DefaultDatastore
+	// if a datastore is provided at cluster level override the default
+	// datastore provided at datacenter level.
+	// Note that in case a DatastoreCluster is provided at cluster level we
+	// still use DefaultDatastore specified at datacenter level.
+	if cluster.Spec.Cloud.VSphere.Datastore != "" {
+		datastore = cluster.Spec.Cloud.VSphere.Datastore
+	}
 	return &vsphere.CloudConfig{
 		Global: vsphere.GlobalOpts{
 			User:             credentials.VSphere.Username,
@@ -249,7 +257,7 @@ func getVsphereCloudConfig(
 			VCenterPort:      port,
 			InsecureFlag:     dc.Spec.VSphere.AllowInsecure,
 			Datacenter:       dc.Spec.VSphere.Datacenter,
-			DefaultDatastore: dc.Spec.VSphere.DefaultDatastore,
+			DefaultDatastore: datastore,
 			WorkingDir:       cluster.Name,
 		},
 		Workspace: vsphere.WorkspaceOpts{
@@ -262,7 +270,7 @@ func getVsphereCloudConfig(
 			VCenterIP:        vspherURL.Hostname(),
 			Datacenter:       dc.Spec.VSphere.Datacenter,
 			Folder:           cluster.Spec.Cloud.VSphere.Folder,
-			DefaultDatastore: dc.Spec.VSphere.DefaultDatastore,
+			DefaultDatastore: datastore,
 		},
 		Disk: vsphere.DiskOpts{
 			SCSIControllerType: "pvscsi",

--- a/pkg/resources/cloudconfig/configmap_test.go
+++ b/pkg/resources/cloudconfig/configmap_test.go
@@ -78,6 +78,33 @@ func TestGetVsphereCloudConfig(t *testing.T) {
 				return nil
 			},
 		},
+		{
+			name: "Datastore overridden at cluster level",
+			cluster: &kubermaticv1.Cluster{
+				Spec: kubermaticv1.ClusterSpec{
+					Cloud: kubermaticv1.CloudSpec{
+						VSphere: &kubermaticv1.VSphereCloudSpec{
+							Datastore: "super-cool-datastore",
+						},
+					},
+				},
+			},
+			dc: &kubermaticv1.Datacenter{
+				Spec: kubermaticv1.DatacenterSpec{
+					VSphere: &kubermaticv1.DatacenterSpecVSphere{
+						Endpoint:         "https://vsphere.com:9443",
+						DefaultDatastore: "less-cool-datastore",
+					},
+				},
+			},
+			verify: func(cc *vsphere.CloudConfig) error {
+				if cc.Workspace.DefaultDatastore != "super-cool-datastore" {
+					return fmt.Errorf("Expected default-datastore to be %q, was %q", "super-cool-datastore",
+						cc.Workspace.DefaultDatastore)
+				}
+				return nil
+			},
+		},
 	}
 
 	for idx := range testCases {

--- a/pkg/test/e2e/api/utils/apiclient/models/datacenter_spec_v_sphere.go
+++ b/pkg/test/e2e/api/utils/apiclient/models/datacenter_spec_v_sphere.go
@@ -29,10 +29,9 @@ type DatacenterSpecVSphere struct {
 	// The name of the datacenter to use.
 	Datacenter string `json:"datacenter,omitempty"`
 
-	// The name of the default Datastore to be used for provisioning volumes
-	// using storage classes/dynamic provisioning and for storing virtual
-	// machine files in case no `Datastore` or `DatastoreCluster` is provided
-	// with the `VSphereCloudSpec`.
+	// The default Datastore to be used for provisioning volumes using storage
+	// classes/dynamic provisioning and for storing virtual machine files in
+	// case no `Datastore` or `DatastoreCluster` is provided at Cluster level.
 	DefaultDatastore string `json:"datastore,omitempty"`
 
 	// Endpoint URL to use, including protocol, for example "https://vcenter.example.com".

--- a/pkg/test/e2e/api/utils/apiclient/models/v_sphere_cloud_spec.go
+++ b/pkg/test/e2e/api/utils/apiclient/models/v_sphere_cloud_spec.go
@@ -16,13 +16,14 @@ import (
 // swagger:model VSphereCloudSpec
 type VSphereCloudSpec struct {
 
-	// Datastore to be used for storing virtual machines, it is mutually
-	// exclusive with DatastoreCluster.
+	// Datastore to be used for storing virtual machines and as a default for
+	// dynamic volume provisioning, it is mutually exclusive with
+	// DatastoreCluster.
 	// +optional
 	Datastore string `json:"datastore,omitempty"`
 
-	// DatastoreCluster to be used for determining the Datastore for virtual
-	// machines, it is mutually exclusive with Datastore.
+	// DatastoreCluster to be used for storing virtual machines, it is mutually
+	// exclusive with Datastore.
 	// +optional
 	DatastoreCluster string `json:"datastoreCluster,omitempty"`
 


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR improves the following things:
- Use datastore provided at cluster level as default for volume provisioning (when present).
- Validation of vsphere cloud spec.
- Description of `datastore` field in `DatacenterSpecVSphere`.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Documentation**:
<!-- Add links to the related documentation changes related to this pull request. E.g. the link to the kubermatic/docs pullrequest. -->

**Does this PR introduce a user-facing change?**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If  no release note is required, just write "NONE".
-->
```release-note
NONE
```
