### PR TITLE
add changelog for 2.13.9

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -351,6 +351,15 @@
 
 # Kubermatic 2.13
 
+## [v2.13.9](https://github.com/kubermatic/kubermatic/releases/tag/v2.13.9)
+
+### Misc
+
+- Add a configuration flag for seed-controller-manager to enforce default addons on userclusters. Disabled by default ([#5987](https://github.com/kubermatic/kubermatic/issues/5987))
+
+
+
+
 ## v2.13.8
 
 ### Bugfixes


### PR DESCRIPTION
**What this PR does / why we need it**:
This prepares a new 2.13.9 KKP release, based on

* https://github.com/kubermatic/kubermatic/commit/f0aabde0d27b86cccece582cdf2353f38b03c8e0
* https://github.com/kubermatic/dashboard/commit/d09bc531619d5351e54b40b4ac27d580032ee326 (same as 2.13.8)

**Does this PR introduce a user-facing change?**:
```release-note
NONE
```
