### PR TITLE
add 2.14.7 changelog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -151,6 +151,21 @@
 
 # Kubermatic 2.14
 
+## [v2.14.7](https://github.com/kubermatic/kubermatic/releases/tag/v2.14.7)
+
+This release includes an important change to the Docker registry used for fetching the Kubernetes control plane
+components. The change will require that all user-clusters reconcile their control planes, which can cause
+significant load on the seed clusters. Refer to the
+[general upgrade guidelines](https://docs.kubermatic.com/kubermatic/master/upgrading/guidelines/) for more
+information on how to limit the impact of such changes during KKP upgrades.
+
+### Misc
+
+- ACTION REQUIRED: Migrate from google_containers to k8s.gcr.io Docker registry ([#5986](https://github.com/kubermatic/kubermatic/issues/5986))
+
+
+
+
 ## v2.14.6
 
 ### Bugfixes


### PR DESCRIPTION
**What this PR does / why we need it**:
This prepares a new release based on

* https://github.com/kubermatic/kubermatic/commit/b7ee18793b01b183488621ac230a0a32f023805a
* https://github.com/kubermatic/dashboard/commit/257d81ce36aba1dc3f209bd845f0ea43d898bdbe (same as 2.14.6)

**Does this PR introduce a user-facing change?**:
```release-note
NONE
```
