### PR TITLE
fix tag-check in github release script

### DIFF
--- a/hack/ci/github-release.sh
+++ b/hack/ci/github-release.sh
@@ -140,7 +140,7 @@ function build_installer() {
 }
 
 # ensure the tag has already been pushed
-if ! $DRY_RUN && [ -z "$(github_cli "https://api.github.com/repos/$GIT_REPO/tags" --silent | jq ".[] | select(.name==\"$RELEASE_NAME\")")" ]; then
+if ! $DRY_RUN && [ -z "$(github_cli "https://api.github.com/repos/$GIT_REPO/git/ref/tags/$RELEASE_NAME" --silent --fail)" ]; then
   echodate "Tag $RELEASE_NAME has not been pushed to $GIT_REPO yet."
   exit 1
 fi


### PR DESCRIPTION
**What this PR does / why we need it**:
Previously, we only checked the first N tags, so the logic often seemingly randomly failed. This PR improves that by just checking the tag directly. Nicely enough, the Github API does _not_ perform a prefix check, so checking for `v2.15.0` will not match an existing `v2.15.0-rc.1`.

**Does this PR introduce a user-facing change?**:
```release-note
NONE
```
