### PR TITLE
[release/v2.15] fix tag-check in github release script

### DIFF
--- a/hack/ci/ci-github-release.sh
+++ b/hack/ci/ci-github-release.sh
@@ -123,7 +123,7 @@ function build_installer() {
 }
 
 # ensure the tag has already been pushed
-if ! $DRY_RUN && [ -z "$(github_cli "https://api.github.com/repos/$GIT_REPO/tags" -s | jq ".[] | select(.name==\"$RELEASE_NAME\")")" ]; then
+if ! $DRY_RUN && ! github_cli "https://api.github.com/repos/$GIT_REPO/git/ref/tags/$RELEASE_NAME" --silent --fail >/dev/null; then
   echodate "Tag $RELEASE_NAME has not been pushed to $GIT_REPO yet."
   exit 1
 fi


### PR DESCRIPTION
**What this PR does / why we need it**:
This is a manual backport of #6043. It is somewhat improved though, as it removes an unneeded empty-string check and makes the logic more obvious.

**Does this PR introduce a user-facing change?**:
```release-note
NONE
```
