### PR TITLE
[release/v2.14] fix tag-check in github release

### DIFF
--- a/api/hack/ci/ci-github-release.sh
+++ b/api/hack/ci/ci-github-release.sh
@@ -95,7 +95,7 @@ repo="${repo:-kubermatic/kubermatic}"
 auth="Authorization: token $GITHUB_TOKEN"
 
 # ensure the tag has already been pushed
-if [ -z "$(github_cli "https://api.github.com/repos/$repo/tags" -s | jq ".[] | select(.name==\"$tag\")")" ]; then
+if ! github_cli "https://api.github.com/repos/$repo/git/ref/tags/$tag" --silent --fail >/dev/null; then
   echodate "Tag $tag has not been pushed to $repo yet."
   exit 1
 fi


### PR DESCRIPTION
**What this PR does / why we need it**:
This backports an improved version of #6043 into the 2.14 branch.

**Does this PR introduce a user-facing change?**:
```release-note
NONE
```
