### PR TITLE
fix blackbox exporter module http version syntax

### DIFF
--- a/charts/monitoring/blackbox-exporter/Chart.yaml
+++ b/charts/monitoring/blackbox-exporter/Chart.yaml
@@ -14,7 +14,7 @@
 
 apiVersion: v1
 name: blackbox-exporter
-version: 1.0.7
+version: 1.0.8
 appVersion: v0.17.0
 description: Deploys the Prometheus Blackbox Exporter
 keywords:

--- a/charts/monitoring/blackbox-exporter/values.yaml
+++ b/charts/monitoring/blackbox-exporter/values.yaml
@@ -47,6 +47,6 @@ blackboxExporter:
       timeout: 5s
       http:
         method: GET
-        valid_http_versions: ["HTTP/1.1", "HTTP/2"]
+        valid_http_versions: ["HTTP/1.1", "HTTP/2.0"]
         fail_if_not_ssl: true
         preferred_ip_protocol: "ip4"


### PR DESCRIPTION
Signed-off-by: Felix Wiedmann <privat@felixwiedmann.de>

**What this PR does / why we need it**:
This PR fixes the defined https_2xx module syntax of the blackbox exporter chart due to upgrade to release 0.17.0.
Here you can find more details in the upstream repo: https://github.com/prometheus/blackbox_exporter/issues/691

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Documentation**:
<!-- Add links to the related documentation changes related to this pull request. E.g. the link to the kubermatic/docs pullrequest. -->

**Does this PR introduce a user-facing change?**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If  no release note is required, just write "NONE".
-->
```release-note
NONE
```
