### PR TITLE
move cmd/util to pkg/util/cli

### DIFF
--- a/cmd/conformance-tests/main.go
+++ b/cmd/conformance-tests/main.go
@@ -38,7 +38,6 @@ import (
 
 	clusterv1alpha1 "github.com/kubermatic/machine-controller/pkg/apis/cluster/v1alpha1"
 	providerconfig "github.com/kubermatic/machine-controller/pkg/providerconfig/types"
-	cmdutil "k8c.io/kubermatic/v2/cmd/util"
 	clusterclient "k8c.io/kubermatic/v2/pkg/cluster/client"
 	kubermaticv1 "k8c.io/kubermatic/v2/pkg/crd/kubermatic/v1"
 	kubermaticlog "k8c.io/kubermatic/v2/pkg/log"
@@ -50,6 +49,7 @@ import (
 	"k8c.io/kubermatic/v2/pkg/test/e2e/api/utils/apiclient/client/project"
 	"k8c.io/kubermatic/v2/pkg/test/e2e/api/utils/apiclient/models"
 	"k8c.io/kubermatic/v2/pkg/test/e2e/api/utils/dex"
+	"k8c.io/kubermatic/v2/pkg/util/cli"
 
 	"k8s.io/apimachinery/pkg/util/sets"
 	"k8s.io/apimachinery/pkg/util/wait"
@@ -186,7 +186,7 @@ func main() {
 		}
 	}()
 
-	cmdutil.Hello(log, "Conformance Tests", true)
+	cli.Hello(log, "Conformance Tests", true)
 
 	// user.Current does not work in Alpine
 	pubkeyPath := path.Join(os.Getenv("HOME"), ".ssh/id_rsa.pub")

--- a/cmd/kubeletdnat-controller/main.go
+++ b/cmd/kubeletdnat-controller/main.go
@@ -24,10 +24,10 @@ import (
 
 	"go.uber.org/zap"
 
-	cmdutil "k8c.io/kubermatic/v2/cmd/util"
 	"k8c.io/kubermatic/v2/pkg/controller/kubeletdnat"
 	kubermaticlog "k8c.io/kubermatic/v2/pkg/log"
 	"k8c.io/kubermatic/v2/pkg/pprof"
+	"k8c.io/kubermatic/v2/pkg/util/cli"
 
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/util/wait"
@@ -54,7 +54,7 @@ func main() {
 	rawLog := kubermaticlog.New(logOpts.Debug, logOpts.Format)
 	log := rawLog.Sugar()
 
-	cmdutil.Hello(log, "Kubelet DNAT-Controller", logOpts.Debug)
+	cli.Hello(log, "Kubelet DNAT-Controller", logOpts.Debug)
 
 	_, network, err := net.ParseCIDR(*networkFlag)
 	if err != nil {

--- a/cmd/kubermatic-api/main.go
+++ b/cmd/kubermatic-api/main.go
@@ -50,7 +50,6 @@ import (
 
 	clusterv1alpha1 "github.com/kubermatic/machine-controller/pkg/apis/cluster/v1alpha1"
 
-	cmdutil "k8c.io/kubermatic/v2/cmd/util"
 	"k8c.io/kubermatic/v2/pkg/cluster/client"
 	"k8c.io/kubermatic/v2/pkg/controller/master-controller-manager/rbac"
 	kubermaticclientset "k8c.io/kubermatic/v2/pkg/crd/client/clientset/versioned"
@@ -67,6 +66,7 @@ import (
 	"k8c.io/kubermatic/v2/pkg/provider"
 	kubernetesprovider "k8c.io/kubermatic/v2/pkg/provider/kubernetes"
 	"k8c.io/kubermatic/v2/pkg/serviceaccount"
+	"k8c.io/kubermatic/v2/pkg/util/cli"
 	"k8c.io/kubermatic/v2/pkg/version"
 	kuberneteswatcher "k8c.io/kubermatic/v2/pkg/watcher/kubernetes"
 
@@ -103,7 +103,7 @@ func main() {
 	}()
 	kubermaticlog.Logger = log
 
-	cmdutil.Hello(log, "API", options.log.Debug)
+	cli.Hello(log, "API", options.log.Debug)
 
 	if err := clusterv1alpha1.AddToScheme(scheme.Scheme); err != nil {
 		kubermaticlog.Logger.Fatalw("failed to register scheme", zap.Stringer("api", clusterv1alpha1.SchemeGroupVersion), zap.Error(err))

--- a/cmd/master-controller-manager/main.go
+++ b/cmd/master-controller-manager/main.go
@@ -24,12 +24,12 @@ import (
 	"github.com/prometheus/client_golang/prometheus"
 	"go.uber.org/zap"
 
-	cmdutil "k8c.io/kubermatic/v2/cmd/util"
 	kubermaticlog "k8c.io/kubermatic/v2/pkg/log"
 	"k8c.io/kubermatic/v2/pkg/metrics"
 	metricserver "k8c.io/kubermatic/v2/pkg/metrics/server"
 	"k8c.io/kubermatic/v2/pkg/pprof"
 	"k8c.io/kubermatic/v2/pkg/provider"
+	"k8c.io/kubermatic/v2/pkg/util/cli"
 	"k8c.io/kubermatic/v2/pkg/util/workerlabel"
 	seedvalidation "k8c.io/kubermatic/v2/pkg/validation/seed"
 
@@ -101,7 +101,7 @@ func main() {
 	ctrlCtx.log = log
 	ctrlCtx.workerName = runOpts.workerName
 
-	cmdutil.Hello(log, "Master Controller-Manager", logOpts.Debug)
+	cli.Hello(log, "Master Controller-Manager", logOpts.Debug)
 
 	// TODO remove label selector when everything is migrated to controller-runtime
 	selector, err := workerlabel.LabelSelector(runOpts.workerName)

--- a/cmd/nodeport-proxy/envoy-manager/main.go
+++ b/cmd/nodeport-proxy/envoy-manager/main.go
@@ -31,9 +31,9 @@ import (
 	envoycache "github.com/envoyproxy/go-control-plane/pkg/cache"
 	xds "github.com/envoyproxy/go-control-plane/pkg/server"
 
-	cmdutil "k8c.io/kubermatic/v2/cmd/util"
 	controllerutil "k8c.io/kubermatic/v2/pkg/controller/util"
 	kubermaticlog "k8c.io/kubermatic/v2/pkg/log"
+	"k8c.io/kubermatic/v2/pkg/util/cli"
 
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/runtime"
@@ -88,7 +88,7 @@ func main() {
 		}
 	}()
 
-	cmdutil.Hello(log, "Envoy-Manager", logOpts.Debug)
+	cli.Hello(log, "Envoy-Manager", logOpts.Debug)
 	log.Infow("Starting the server...", "address", listenAddress)
 
 	snapshotCache := envoycache.NewSnapshotCache(true, hasher{}, log.With("component", "envoycache"))

--- a/cmd/nodeport-proxy/lb-updater/main.go
+++ b/cmd/nodeport-proxy/lb-updater/main.go
@@ -26,9 +26,9 @@ import (
 	"github.com/go-test/deep"
 	"go.uber.org/zap"
 
-	cmdutil "k8c.io/kubermatic/v2/cmd/util"
 	controllerutil "k8c.io/kubermatic/v2/pkg/controller/util"
 	kubermaticlog "k8c.io/kubermatic/v2/pkg/log"
+	"k8c.io/kubermatic/v2/pkg/util/cli"
 
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/equality"
@@ -83,7 +83,7 @@ func main() {
 		}
 	}()
 
-	cmdutil.Hello(log, "LoadBalancer Updater", logOpts.Debug)
+	cli.Hello(log, "LoadBalancer Updater", logOpts.Debug)
 
 	config, err := ctrlruntimeconfig.GetConfig()
 	if err != nil {

--- a/cmd/seed-controller-manager/main.go
+++ b/cmd/seed-controller-manager/main.go
@@ -29,7 +29,6 @@ import (
 	"go.uber.org/zap"
 
 	clusterv1alpha1 "github.com/kubermatic/machine-controller/pkg/apis/cluster/v1alpha1"
-	cmdutil "k8c.io/kubermatic/v2/cmd/util"
 	"k8c.io/kubermatic/v2/pkg/cluster/client"
 	"k8c.io/kubermatic/v2/pkg/collectors"
 	kubermaticv1 "k8c.io/kubermatic/v2/pkg/crd/kubermatic/v1"
@@ -37,6 +36,7 @@ import (
 	"k8c.io/kubermatic/v2/pkg/metrics"
 	metricserver "k8c.io/kubermatic/v2/pkg/metrics/server"
 	"k8c.io/kubermatic/v2/pkg/pprof"
+	"k8c.io/kubermatic/v2/pkg/util/cli"
 	"k8c.io/kubermatic/v2/pkg/util/restmapper"
 	seedvalidation "k8c.io/kubermatic/v2/pkg/validation/seed"
 	ctrl "sigs.k8s.io/controller-runtime"
@@ -81,7 +81,7 @@ func main() {
 		}
 	}()
 
-	cmdutil.Hello(log, "Seed Controller-Manager", logOpts.Debug)
+	cli.Hello(log, "Seed Controller-Manager", logOpts.Debug)
 
 	// Set the logger used by sigs.k8s.io/controller-runtime
 	ctrlruntimelog.Log = ctrlruntimelog.NewDelegatingLogger(zapr.NewLogger(rawLog).WithName("controller_runtime"))

--- a/cmd/user-cluster-controller-manager/main.go
+++ b/cmd/user-cluster-controller-manager/main.go
@@ -32,7 +32,6 @@ import (
 	"go.uber.org/zap"
 
 	clusterv1alpha1 "github.com/kubermatic/machine-controller/pkg/apis/cluster/v1alpha1"
-	cmdutil "k8c.io/kubermatic/v2/cmd/util"
 	clusterrolelabeler "k8c.io/kubermatic/v2/pkg/controller/user-cluster-controller-manager/cluster-role-labeler"
 	containerlinux "k8c.io/kubermatic/v2/pkg/controller/user-cluster-controller-manager/container-linux"
 	"k8c.io/kubermatic/v2/pkg/controller/user-cluster-controller-manager/ipam"
@@ -49,6 +48,7 @@ import (
 	kubermaticlog "k8c.io/kubermatic/v2/pkg/log"
 	"k8c.io/kubermatic/v2/pkg/pprof"
 	"k8c.io/kubermatic/v2/pkg/resources/reconciling"
+	"k8c.io/kubermatic/v2/pkg/util/cli"
 
 	corev1 "k8s.io/api/core/v1"
 	apiextensionsv1beta1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1beta1"
@@ -117,7 +117,7 @@ func main() {
 	rawLog := kubermaticlog.New(logOpts.Debug, logOpts.Format)
 	log := rawLog.Sugar()
 
-	cmdutil.Hello(log, "User-Cluster Controller-Manager", logOpts.Debug)
+	cli.Hello(log, "User-Cluster Controller-Manager", logOpts.Debug)
 
 	if runOp.ownerEmail == "" {
 		log.Fatal("-owner-email must be set")

--- a/cmd/user-ssh-keys-agent/main.go
+++ b/cmd/user-ssh-keys-agent/main.go
@@ -27,9 +27,9 @@ import (
 	"github.com/go-logr/zapr"
 	"go.uber.org/zap"
 
-	cmdutil "k8c.io/kubermatic/v2/cmd/util"
 	usersshkeys "k8c.io/kubermatic/v2/pkg/controller/usersshkeysagent"
 	kubermaticlog "k8c.io/kubermatic/v2/pkg/log"
+	"k8c.io/kubermatic/v2/pkg/util/cli"
 
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"sigs.k8s.io/controller-runtime/pkg/client/config"
@@ -45,7 +45,7 @@ func main() {
 	rawLog := kubermaticlog.New(logOpts.Debug, logOpts.Format)
 	log := rawLog.Sugar()
 
-	cmdutil.Hello(log, "User SSH-Key Agent", logOpts.Debug)
+	cli.Hello(log, "User SSH-Key Agent", logOpts.Debug)
 
 	cfg, err := config.GetConfig()
 	if err != nil {

--- a/pkg/util/cli/hello.go
+++ b/pkg/util/cli/hello.go
@@ -14,7 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package util
+package cli
 
 import (
 	"go.uber.org/zap"


### PR DESCRIPTION
**What this PR does / why we need it**:
It was a bad decision to put the utility functions in cmd/util, as this produced a useless file in _build/util and is misleading. This PR rectifies that mistake by moving the helper package to pkg/util/cli.

**Does this PR introduce a user-facing change?**:
```release-note
NONE
```
