### PR TITLE
Fix bug where cluster in deletion kills controller

### DIFF
--- a/api/pkg/crd/migrations/seed/migrations.go
+++ b/api/pkg/crd/migrations/seed/migrations.go
@@ -225,6 +225,10 @@ func migrateClusterUserLabel(cluster *kubermaticv1.Cluster, cleanupContext *clea
 }
 
 func createSecretsForCredentials(cluster *kubermaticv1.Cluster, cleanupContext *cleanupContext) error {
+	if cluster.GetDeletionTimestamp() != nil {
+		return nil
+	}
+
 	if err := kubernetesprovider.CreateOrUpdateCredentialSecretForCluster(cleanupContext.ctx, cleanupContext.client, cluster); err != nil {
 		return err
 	}


### PR DESCRIPTION
**What this PR does / why we need it**:
Sometimes a cluster in deletion can kill the controller possibly
indefinitely, when it tries to add a finalizer to them.
This happens for example when a cluster is in deletion and the
SecretsCleanupFinalizer gets removed when the controller-manager
restarts for some reason.
Then it will always try to add this finalizer again and fail.

Make sure that finalizers only get added when objects are not stuck in
deletion.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Documentation**:
<!-- Add links to the related documentation changes related to this pull request. E.g. the link to the kubermatic/docs pullrequest. -->

**Does this PR introduce a user-facing change?**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If  no release note is required, just write "NONE".
-->
```release-note
NONE
```
