### PR TITLE
fix typo in Prometheus runbook

### DIFF
--- a/charts/monitoring/prometheus/Chart.yaml
+++ b/charts/monitoring/prometheus/Chart.yaml
@@ -14,7 +14,7 @@
 
 apiVersion: v1
 name: prometheus
-version: 2.2.29
+version: 2.2.30
 appVersion: v2.20.1
 description: Prometheus Monitoring for Kubernetes
 keywords:

--- a/charts/monitoring/prometheus/rules/general-prometheus.yaml
+++ b/charts/monitoring/prometheus/rules/general-prometheus.yaml
@@ -27,7 +27,7 @@ groups:
           severity: warning
       - alert: PromBadConfig
         annotations:
-          mesage: Prometheus failed to reload config.
+          message: Prometheus failed to reload config.
           runbook_url: https://docs.kubermatic.com/kubermatic/master/monitoring/runbook/#alert-prombadconfig
         expr: prometheus_config_last_reload_successful{job="prometheus"} == 0
         for: 15m

--- a/charts/monitoring/prometheus/rules/src/general/prometheus.yaml
+++ b/charts/monitoring/prometheus/rules/src/general/prometheus.yaml
@@ -29,7 +29,7 @@ groups:
 
   - alert: PromBadConfig
     annotations:
-      mesage: Prometheus failed to reload config.
+      message: Prometheus failed to reload config.
       runbook_url: https://docs.kubermatic.com/kubermatic/master/monitoring/runbook/#alert-prombadconfig
     expr: prometheus_config_last_reload_successful{job="prometheus"} == 0
     for: 15m


### PR DESCRIPTION
**What this PR does / why we need it**:
This fixes a small typo that is currently blocking PRs in our docs repo, as the spellchecker is already enabled over there.

**Does this PR introduce a user-facing change?**:
```release-note
NONE
```
