### PR TITLE
[release/v2.14] fix typo in Prometheus runbook (#6052)

### DIFF
--- a/config/monitoring/prometheus/Chart.yaml
+++ b/config/monitoring/prometheus/Chart.yaml
@@ -14,7 +14,7 @@
 
 apiVersion: v1
 name: prometheus
-version: 2.2.19
+version: 2.2.20
 appVersion: v2.17.0
 description: Prometheus Monitoring for Kubernetes
 keywords:

--- a/config/monitoring/prometheus/rules/general-prometheus.yaml
+++ b/config/monitoring/prometheus/rules/general-prometheus.yaml
@@ -13,7 +13,7 @@ groups:
       severity: warning
   - alert: PromBadConfig
     annotations:
-      mesage: Prometheus failed to reload config.
+      message: Prometheus failed to reload config.
       runbook_url: https://docs.loodse.com/kubermatic/master/monitoring/runbook/#alert-prombadconfig
     expr: prometheus_config_last_reload_successful{job="prometheus"} == 0
     for: 15m

--- a/config/monitoring/prometheus/rules/src/general/prometheus.yaml
+++ b/config/monitoring/prometheus/rules/src/general/prometheus.yaml
@@ -29,7 +29,7 @@ groups:
 
   - alert: PromBadConfig
     annotations:
-      mesage: Prometheus failed to reload config.
+      message: Prometheus failed to reload config.
       runbook_url: https://docs.loodse.com/kubermatic/master/monitoring/runbook/#alert-prombadconfig
     expr: prometheus_config_last_reload_successful{job="prometheus"} == 0
     for: 15m


### PR DESCRIPTION
**What this PR does / why we need it**:
Backport #6052 into 2.14 branch.

**Does this PR introduce a user-facing change?**:
```release-note
NONE
```
