### PR TITLE
Add explicit context handling in conformance-tests

### DIFF
--- a/.prow.yaml
+++ b/.prow.yaml
@@ -1270,7 +1270,7 @@ presubmits:
       preset-goproxy: "true"
     spec:
       containers:
-      - image: quay.io/kubermatic/integration-tests:3-1
+      - image: quay.io/kubermatic/integration-tests:4-1
         command:
         - make
         args:

--- a/cmd/conformance-tests/cleanup.go
+++ b/cmd/conformance-tests/cleanup.go
@@ -39,12 +39,11 @@ var (
 		kubernetesdashboard.Namespace)
 )
 
-func (r *testRunner) deleteAllNonDefaultNamespaces(log *zap.SugaredLogger, client ctrlruntimeclient.Client) error {
+func (r *testRunner) deleteAllNonDefaultNamespaces(ctx context.Context, log *zap.SugaredLogger, client ctrlruntimeclient.Client) error {
 	log.Info("Removing non-default namespaces...")
 
 	return wait.Poll(r.userClusterPollInterval, r.customTestTimeout, func() (done bool, err error) {
 		namespaceList := &corev1.NamespaceList{}
-		ctx := context.Background()
 		if err := client.List(ctx, namespaceList); err != nil {
 			log.Errorw("Failed to list namespaces", zap.Error(err))
 			return false, nil

--- a/cmd/conformance-tests/scenarios_alibaba.go
+++ b/cmd/conformance-tests/scenarios_alibaba.go
@@ -75,7 +75,7 @@ func (s *alibabaScenario) Cluster(secrets secrets) *apimodels.CreateClusterSpec 
 	}
 }
 
-func (s *alibabaScenario) NodeDeployments(ctx context.Context, num int, secrets secrets) ([]apimodels.NodeDeployment, error) {
+func (s *alibabaScenario) NodeDeployments(_ context.Context, num int, secrets secrets) ([]apimodels.NodeDeployment, error) {
 	return []apimodels.NodeDeployment{
 		{
 			Spec: &apimodels.NodeDeploymentSpec{

--- a/cmd/conformance-tests/scenarios_alibaba.go
+++ b/cmd/conformance-tests/scenarios_alibaba.go
@@ -17,6 +17,7 @@ limitations under the License.
 package main
 
 import (
+	"context"
 	"fmt"
 
 	"k8c.io/kubermatic/v2/pkg/semver"
@@ -74,7 +75,7 @@ func (s *alibabaScenario) Cluster(secrets secrets) *apimodels.CreateClusterSpec 
 	}
 }
 
-func (s *alibabaScenario) NodeDeployments(num int, secrets secrets) ([]apimodels.NodeDeployment, error) {
+func (s *alibabaScenario) NodeDeployments(ctx context.Context, num int, secrets secrets) ([]apimodels.NodeDeployment, error) {
 	return []apimodels.NodeDeployment{
 		{
 			Spec: &apimodels.NodeDeploymentSpec{

--- a/cmd/conformance-tests/scenarios_aws.go
+++ b/cmd/conformance-tests/scenarios_aws.go
@@ -17,6 +17,7 @@ limitations under the License.
 package main
 
 import (
+	"context"
 	"errors"
 	"fmt"
 	"time"
@@ -100,12 +101,13 @@ func (s *awsScenario) Cluster(secrets secrets) *apimodels.CreateClusterSpec {
 	}
 }
 
-func (s *awsScenario) NodeDeployments(num int, secrets secrets) ([]apimodels.NodeDeployment, error) {
+func (s *awsScenario) NodeDeployments(ctx context.Context, num int, secrets secrets) ([]apimodels.NodeDeployment, error) {
 	instanceType := "t2.medium"
 	volumeType := "gp2"
 	volumeSize := int64(100)
 
 	listVPCParams := &awsapiclient.ListAWSVPCSParams{
+		Context:         ctx,
 		AccessKeyID:     utilpointer.StringPtr(secrets.AWS.AccessKeyID),
 		SecretAccessKey: utilpointer.StringPtr(secrets.AWS.SecretAccessKey),
 		DC:              awsDC,
@@ -128,6 +130,7 @@ func (s *awsScenario) NodeDeployments(num int, secrets secrets) ([]apimodels.Nod
 	}
 
 	listSubnetParams := &awsapiclient.ListAWSSubnetsParams{
+		Context:         ctx,
 		AccessKeyID:     utilpointer.StringPtr(secrets.AWS.AccessKeyID),
 		SecretAccessKey: utilpointer.StringPtr(secrets.AWS.SecretAccessKey),
 		DC:              awsDC,

--- a/cmd/conformance-tests/scenarios_azure.go
+++ b/cmd/conformance-tests/scenarios_azure.go
@@ -85,7 +85,7 @@ func (s *azureScenario) Cluster(secrets secrets) *apimodels.CreateClusterSpec {
 	}
 }
 
-func (s *azureScenario) NodeDeployments(ctx context.Context, num int, _ secrets) ([]apimodels.NodeDeployment, error) {
+func (s *azureScenario) NodeDeployments(_ context.Context, num int, _ secrets) ([]apimodels.NodeDeployment, error) {
 	replicas := int32(num)
 	size := "Standard_F2"
 	return []apimodels.NodeDeployment{

--- a/cmd/conformance-tests/scenarios_azure.go
+++ b/cmd/conformance-tests/scenarios_azure.go
@@ -17,6 +17,7 @@ limitations under the License.
 package main
 
 import (
+	"context"
 	"fmt"
 
 	"k8c.io/kubermatic/v2/pkg/semver"
@@ -84,7 +85,7 @@ func (s *azureScenario) Cluster(secrets secrets) *apimodels.CreateClusterSpec {
 	}
 }
 
-func (s *azureScenario) NodeDeployments(num int, _ secrets) ([]apimodels.NodeDeployment, error) {
+func (s *azureScenario) NodeDeployments(ctx context.Context, num int, _ secrets) ([]apimodels.NodeDeployment, error) {
 	replicas := int32(num)
 	size := "Standard_F2"
 	return []apimodels.NodeDeployment{

--- a/cmd/conformance-tests/scenarios_digitalocean.go
+++ b/cmd/conformance-tests/scenarios_digitalocean.go
@@ -17,6 +17,7 @@ limitations under the License.
 package main
 
 import (
+	"context"
 	"fmt"
 
 	"k8c.io/kubermatic/v2/pkg/semver"
@@ -82,7 +83,7 @@ func (s *digitaloceanScenario) Cluster(secrets secrets) *apimodels.CreateCluster
 	}
 }
 
-func (s *digitaloceanScenario) NodeDeployments(num int, _ secrets) ([]apimodels.NodeDeployment, error) {
+func (s *digitaloceanScenario) NodeDeployments(ctx context.Context, num int, _ secrets) ([]apimodels.NodeDeployment, error) {
 	replicas := int32(num)
 	size := "4gb"
 	return []apimodels.NodeDeployment{

--- a/cmd/conformance-tests/scenarios_digitalocean.go
+++ b/cmd/conformance-tests/scenarios_digitalocean.go
@@ -83,7 +83,7 @@ func (s *digitaloceanScenario) Cluster(secrets secrets) *apimodels.CreateCluster
 	}
 }
 
-func (s *digitaloceanScenario) NodeDeployments(ctx context.Context, num int, _ secrets) ([]apimodels.NodeDeployment, error) {
+func (s *digitaloceanScenario) NodeDeployments(_ context.Context, num int, _ secrets) ([]apimodels.NodeDeployment, error) {
 	replicas := int32(num)
 	size := "4gb"
 	return []apimodels.NodeDeployment{

--- a/cmd/conformance-tests/scenarios_gcp.go
+++ b/cmd/conformance-tests/scenarios_gcp.go
@@ -17,6 +17,7 @@ limitations under the License.
 package main
 
 import (
+	"context"
 	"fmt"
 	"strings"
 
@@ -85,7 +86,7 @@ func (s *gcpScenario) Cluster(secrets secrets) *apimodels.CreateClusterSpec {
 	}
 }
 
-func (s *gcpScenario) NodeDeployments(num int, secrets secrets) ([]apimodels.NodeDeployment, error) {
+func (s *gcpScenario) NodeDeployments(ctx context.Context, num int, secrets secrets) ([]apimodels.NodeDeployment, error) {
 	replicas := int32(num)
 
 	return []apimodels.NodeDeployment{

--- a/cmd/conformance-tests/scenarios_gcp.go
+++ b/cmd/conformance-tests/scenarios_gcp.go
@@ -86,7 +86,7 @@ func (s *gcpScenario) Cluster(secrets secrets) *apimodels.CreateClusterSpec {
 	}
 }
 
-func (s *gcpScenario) NodeDeployments(ctx context.Context, num int, secrets secrets) ([]apimodels.NodeDeployment, error) {
+func (s *gcpScenario) NodeDeployments(_ context.Context, num int, secrets secrets) ([]apimodels.NodeDeployment, error) {
 	replicas := int32(num)
 
 	return []apimodels.NodeDeployment{

--- a/cmd/conformance-tests/scenarios_hetzner.go
+++ b/cmd/conformance-tests/scenarios_hetzner.go
@@ -73,7 +73,7 @@ func (s *hetznerScenario) Cluster(secrets secrets) *apimodels.CreateClusterSpec 
 	}
 }
 
-func (s *hetznerScenario) NodeDeployments(ctx context.Context, num int, _ secrets) ([]apimodels.NodeDeployment, error) {
+func (s *hetznerScenario) NodeDeployments(_ context.Context, num int, _ secrets) ([]apimodels.NodeDeployment, error) {
 	replicas := int32(num)
 	nodeType := "cx31"
 

--- a/cmd/conformance-tests/scenarios_hetzner.go
+++ b/cmd/conformance-tests/scenarios_hetzner.go
@@ -17,6 +17,7 @@ limitations under the License.
 package main
 
 import (
+	"context"
 	"fmt"
 
 	"k8c.io/kubermatic/v2/pkg/semver"
@@ -72,7 +73,7 @@ func (s *hetznerScenario) Cluster(secrets secrets) *apimodels.CreateClusterSpec 
 	}
 }
 
-func (s *hetznerScenario) NodeDeployments(num int, _ secrets) ([]apimodels.NodeDeployment, error) {
+func (s *hetznerScenario) NodeDeployments(ctx context.Context, num int, _ secrets) ([]apimodels.NodeDeployment, error) {
 	replicas := int32(num)
 	nodeType := "cx31"
 

--- a/cmd/conformance-tests/scenarios_kubevirt.go
+++ b/cmd/conformance-tests/scenarios_kubevirt.go
@@ -79,7 +79,7 @@ func (s *kubevirtScenario) Cluster(secrets secrets) *apimodels.CreateClusterSpec
 	}
 }
 
-func (s *kubevirtScenario) NodeDeployments(ctx context.Context, num int, _ secrets) ([]apimodels.NodeDeployment, error) {
+func (s *kubevirtScenario) NodeDeployments(_ context.Context, num int, _ secrets) ([]apimodels.NodeDeployment, error) {
 	var sourceURL string
 
 	switch {

--- a/cmd/conformance-tests/scenarios_kubevirt.go
+++ b/cmd/conformance-tests/scenarios_kubevirt.go
@@ -17,6 +17,7 @@ limitations under the License.
 package main
 
 import (
+	"context"
 	"fmt"
 
 	"k8c.io/kubermatic/v2/pkg/semver"
@@ -78,7 +79,7 @@ func (s *kubevirtScenario) Cluster(secrets secrets) *apimodels.CreateClusterSpec
 	}
 }
 
-func (s *kubevirtScenario) NodeDeployments(num int, _ secrets) ([]apimodels.NodeDeployment, error) {
+func (s *kubevirtScenario) NodeDeployments(ctx context.Context, num int, _ secrets) ([]apimodels.NodeDeployment, error) {
 	var sourceURL string
 
 	switch {

--- a/cmd/conformance-tests/scenarios_openstack.go
+++ b/cmd/conformance-tests/scenarios_openstack.go
@@ -17,6 +17,7 @@ limitations under the License.
 package main
 
 import (
+	"context"
 	"fmt"
 
 	"k8c.io/kubermatic/v2/pkg/semver"
@@ -86,7 +87,7 @@ func (s *openStackScenario) Cluster(secrets secrets) *apimodels.CreateClusterSpe
 	}
 }
 
-func (s *openStackScenario) NodeDeployments(num int, _ secrets) ([]apimodels.NodeDeployment, error) {
+func (s *openStackScenario) NodeDeployments(ctx context.Context, num int, _ secrets) ([]apimodels.NodeDeployment, error) {
 	osName := getOSNameFromSpec(s.nodeOsSpec)
 	image := "kubermatic-e2e-" + osName
 	flavor := "m1.small"

--- a/cmd/conformance-tests/scenarios_openstack.go
+++ b/cmd/conformance-tests/scenarios_openstack.go
@@ -87,7 +87,7 @@ func (s *openStackScenario) Cluster(secrets secrets) *apimodels.CreateClusterSpe
 	}
 }
 
-func (s *openStackScenario) NodeDeployments(ctx context.Context, num int, _ secrets) ([]apimodels.NodeDeployment, error) {
+func (s *openStackScenario) NodeDeployments(_ context.Context, num int, _ secrets) ([]apimodels.NodeDeployment, error) {
 	osName := getOSNameFromSpec(s.nodeOsSpec)
 	image := "kubermatic-e2e-" + osName
 	flavor := "m1.small"

--- a/cmd/conformance-tests/scenarios_packet.go
+++ b/cmd/conformance-tests/scenarios_packet.go
@@ -17,6 +17,7 @@ limitations under the License.
 package main
 
 import (
+	"context"
 	"fmt"
 
 	"k8c.io/kubermatic/v2/pkg/semver"
@@ -83,7 +84,7 @@ func (s *packetScenario) Cluster(secrets secrets) *apimodels.CreateClusterSpec {
 	}
 }
 
-func (s *packetScenario) NodeDeployments(num int, _ secrets) ([]apimodels.NodeDeployment, error) {
+func (s *packetScenario) NodeDeployments(ctx context.Context, num int, _ secrets) ([]apimodels.NodeDeployment, error) {
 	instanceType := "t1.small.x86"
 	replicas := int32(num)
 	return []apimodels.NodeDeployment{

--- a/cmd/conformance-tests/scenarios_packet.go
+++ b/cmd/conformance-tests/scenarios_packet.go
@@ -84,7 +84,7 @@ func (s *packetScenario) Cluster(secrets secrets) *apimodels.CreateClusterSpec {
 	}
 }
 
-func (s *packetScenario) NodeDeployments(ctx context.Context, num int, _ secrets) ([]apimodels.NodeDeployment, error) {
+func (s *packetScenario) NodeDeployments(_ context.Context, num int, _ secrets) ([]apimodels.NodeDeployment, error) {
 	instanceType := "t1.small.x86"
 	replicas := int32(num)
 	return []apimodels.NodeDeployment{

--- a/cmd/conformance-tests/scenarios_vsphere.go
+++ b/cmd/conformance-tests/scenarios_vsphere.go
@@ -119,7 +119,7 @@ func (s *vSphereScenario) Cluster(secrets secrets) *apimodels.CreateClusterSpec 
 	return spec
 }
 
-func (s *vSphereScenario) NodeDeployments(ctx context.Context, num int, _ secrets) ([]apimodels.NodeDeployment, error) {
+func (s *vSphereScenario) NodeDeployments(_ context.Context, num int, _ secrets) ([]apimodels.NodeDeployment, error) {
 	osName := getOSNameFromSpec(s.nodeOsSpec)
 	replicas := int32(num)
 	return []apimodels.NodeDeployment{

--- a/cmd/conformance-tests/scenarios_vsphere.go
+++ b/cmd/conformance-tests/scenarios_vsphere.go
@@ -17,6 +17,7 @@ limitations under the License.
 package main
 
 import (
+	"context"
 	"fmt"
 	"strings"
 
@@ -118,7 +119,7 @@ func (s *vSphereScenario) Cluster(secrets secrets) *apimodels.CreateClusterSpec 
 	return spec
 }
 
-func (s *vSphereScenario) NodeDeployments(num int, _ secrets) ([]apimodels.NodeDeployment, error) {
+func (s *vSphereScenario) NodeDeployments(ctx context.Context, num int, _ secrets) ([]apimodels.NodeDeployment, error) {
 	osName := getOSNameFromSpec(s.nodeOsSpec)
 	replicas := int32(num)
 	return []apimodels.NodeDeployment{

--- a/cmd/conformance-tests/usercluster_controller_tests.go
+++ b/cmd/conformance-tests/usercluster_controller_tests.go
@@ -33,9 +33,8 @@ import (
 	ctrlruntimeclient "sigs.k8s.io/controller-runtime/pkg/client"
 )
 
-func (r *testRunner) testUserclusterControllerRBAC(log *zap.SugaredLogger, cluster *kubermaticv1.Cluster, userClusterClient, seedClusterClient ctrlruntimeclient.Client) error {
+func (r *testRunner) testUserclusterControllerRBAC(ctx context.Context, log *zap.SugaredLogger, cluster *kubermaticv1.Cluster, userClusterClient, seedClusterClient ctrlruntimeclient.Client) error {
 	log.Info("Testing user cluster RBAC controller")
-	ctx := context.Background()
 	clusterNamespace := fmt.Sprintf("cluster-%s", cluster.Name)
 
 	// check if usercluster-controller was deployed on seed cluster

--- a/hack/images/integration-tests/Dockerfile
+++ b/hack/images/integration-tests/Dockerfile
@@ -15,11 +15,14 @@
 FROM golang:1.15.1
 LABEL maintainer="support@kubermatic.com"
 
+ENV KUBEBUILDER_VERSION=2.3.1 \
+    KUBE_VERSION=v1.18.10
+
 RUN os=$(go env GOOS) && \
     arch=$(go env GOARCH) && \
-    curl --fail -sL https://go.kubebuilder.io/dl/2.2.0/${os}/${arch} | tar -xz -C /tmp/ && \
-    mv /tmp/kubebuilder_2.2.0_${os}_${arch} /usr/local/kubebuilder && \
-    curl --fail https://storage.googleapis.com/kubernetes-release/release/v1.18.6/bin/${os}/${arch}/kube-apiserver -L -o /tmp/kube-apiserver && \
+    curl --fail -sL https://go.kubebuilder.io/dl/${KUBEBUILDER_VERSION}/${os}/${arch} | tar -xz -C /tmp/ && \
+    mv /tmp/kubebuilder_${KUBEBUILDER_VERSION}_${os}_${arch} /usr/local/kubebuilder && \
+    curl --fail https://storage.googleapis.com/kubernetes-release/release/$KUBE_VERSION/bin/$os/${arch}/kube-apiserver -L -o /tmp/kube-apiserver && \
     chmod +x /tmp/kube-apiserver && \
     mv /tmp/kube-apiserver /usr/local/kubebuilder/bin/kube-apiserver && \
     echo 'export PATH=$PATH:/usr/local/kubebuilder/bin' >> ~/.bashrc

--- a/hack/images/integration-tests/release.sh
+++ b/hack/images/integration-tests/release.sh
@@ -19,7 +19,7 @@ set -euo pipefail
 cd $(dirname $0)
 
 REPOSITORY=quay.io/kubermatic/integration-tests
-VERSION=3
+VERSION=4
 BUILD_SUFFIX=1
 
 docker build --no-cache --pull -t "$REPOSITORY:$VERSION-$BUILD_SUFFIX" .

--- a/pkg/cluster/client/client.go
+++ b/pkg/cluster/client/client.go
@@ -63,9 +63,9 @@ type Provider struct {
 
 // GetAdminKubeconfig returns the admin kubeconfig for the given cluster. For internal use
 // by ourselves only.
-func (p *Provider) GetAdminKubeconfig(c *kubermaticv1.Cluster) ([]byte, error) {
+func (p *Provider) GetAdminKubeconfig(ctx context.Context, c *kubermaticv1.Cluster) ([]byte, error) {
 	s := &corev1.Secret{}
-	if err := p.seedClient.Get(context.Background(), types.NamespacedName{Namespace: c.Status.NamespaceName, Name: resources.InternalUserClusterAdminKubeconfigSecretName}, s); err != nil {
+	if err := p.seedClient.Get(ctx, types.NamespacedName{Namespace: c.Status.NamespaceName, Name: resources.InternalUserClusterAdminKubeconfigSecretName}, s); err != nil {
 		return nil, err
 	}
 	d := s.Data[resources.KubeconfigSecretKey]
@@ -100,8 +100,8 @@ func setExternalAddress(c *kubermaticv1.Cluster, config []byte) ([]byte, error) 
 type ConfigOption func(*restclient.Config) *restclient.Config
 
 // GetClientConfig returns the client config used for initiating a connection for the given cluster
-func (p *Provider) GetClientConfig(c *kubermaticv1.Cluster, options ...ConfigOption) (*restclient.Config, error) {
-	b, err := p.GetAdminKubeconfig(c)
+func (p *Provider) GetClientConfig(ctx context.Context, c *kubermaticv1.Cluster, options ...ConfigOption) (*restclient.Config, error) {
+	b, err := p.GetAdminKubeconfig(ctx, c)
 	if err != nil {
 		return nil, err
 	}
@@ -142,8 +142,8 @@ func (p *Provider) GetClientConfig(c *kubermaticv1.Cluster, options ...ConfigOpt
 }
 
 // GetClient returns a dynamic client
-func (p *Provider) GetClient(c *kubermaticv1.Cluster, options ...ConfigOption) (ctrlruntimeclient.Client, error) {
-	config, err := p.GetClientConfig(c, options...)
+func (p *Provider) GetClient(ctx context.Context, c *kubermaticv1.Cluster, options ...ConfigOption) (ctrlruntimeclient.Client, error) {
+	config, err := p.GetClientConfig(ctx, c, options...)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/controller/seed-controller-manager/addon/addon_controller_test.go
+++ b/pkg/controller/seed-controller-manager/addon/addon_controller_test.go
@@ -123,11 +123,11 @@ var (
 
 type fakeKubeconfigProvider struct{}
 
-func (f *fakeKubeconfigProvider) GetAdminKubeconfig(c *kubermaticv1.Cluster) ([]byte, error) {
+func (f *fakeKubeconfigProvider) GetAdminKubeconfig(_ context.Context, c *kubermaticv1.Cluster) ([]byte, error) {
 	return []byte("foo"), nil
 }
 
-func (f *fakeKubeconfigProvider) GetClient(c *kubermaticv1.Cluster, options ...clusterclient.ConfigOption) (ctrlruntimeclient.Client, error) {
+func (f *fakeKubeconfigProvider) GetClient(_ context.Context, c *kubermaticv1.Cluster, options ...clusterclient.ConfigOption) (ctrlruntimeclient.Client, error) {
 	return nil, errors.New("not implemented")
 }
 
@@ -206,12 +206,13 @@ func TestController_getAddonKubeDNStManifests(t *testing.T) {
 	}
 
 	log := kubermaticlog.New(true, kubermaticlog.FormatConsole).Sugar()
+	ctx := context.Background()
 
 	controller := &Reconciler{
 		kubernetesAddonDir: addonDir,
 		KubeconfigProvider: &fakeKubeconfigProvider{},
 	}
-	manifests, err := controller.getAddonManifests(log, addon, cluster)
+	manifests, err := controller.getAddonManifests(ctx, log, addon, cluster)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -229,7 +230,7 @@ func TestController_getAddonKubeDNStManifests(t *testing.T) {
 	}
 
 	cluster = setupTestCluster("172.25.0.0/16")
-	manifests, err = controller.getAddonManifests(log, addon, cluster)
+	manifests, err = controller.getAddonManifests(ctx, log, addon, cluster)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -266,7 +267,7 @@ func TestController_getAddonDeploymentManifests(t *testing.T) {
 		overwriteRegistry:  "bar.io",
 		KubeconfigProvider: &fakeKubeconfigProvider{},
 	}
-	manifests, err := controller.getAddonManifests(log, addon, cluster)
+	manifests, err := controller.getAddonManifests(context.Background(), log, addon, cluster)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -304,7 +305,7 @@ func TestController_getAddonDeploymentManifestsDefault(t *testing.T) {
 		kubernetesAddonDir: addonDir,
 		KubeconfigProvider: &fakeKubeconfigProvider{},
 	}
-	manifests, err := controller.getAddonManifests(log, addon, cluster)
+	manifests, err := controller.getAddonManifests(context.Background(), log, addon, cluster)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -348,7 +349,7 @@ func TestController_getAddonManifests(t *testing.T) {
 		kubernetesAddonDir: addonDir,
 		KubeconfigProvider: &fakeKubeconfigProvider{},
 	}
-	manifests, err := controller.getAddonManifests(log, addon, cluster)
+	manifests, err := controller.getAddonManifests(context.Background(), log, addon, cluster)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -417,7 +418,7 @@ func TestHugeManifest(t *testing.T) {
 		kubernetesAddonDir: "./testdata",
 		KubeconfigProvider: &fakeKubeconfigProvider{},
 	}
-	if _, _, _, err := r.setupManifestInteraction(log, addon, cluster); err != nil {
+	if _, _, _, err := r.setupManifestInteraction(context.Background(), log, addon, cluster); err != nil {
 		t.Fatalf("failed to setup manifest interaction: %v", err)
 	}
 }

--- a/pkg/controller/seed-controller-manager/constraint-template-controller/controller.go
+++ b/pkg/controller/seed-controller-manager/constraint-template-controller/controller.go
@@ -55,7 +55,7 @@ const (
 
 // UserClusterClientProvider provides functionality to get a user cluster client
 type UserClusterClientProvider interface {
-	GetClient(c *kubermaticv1.Cluster, options ...clusterclient.ConfigOption) (ctrlruntimeclient.Client, error)
+	GetClient(ctx context.Context, c *kubermaticv1.Cluster, options ...clusterclient.ConfigOption) (ctrlruntimeclient.Client, error)
 }
 
 type reconciler struct {
@@ -204,7 +204,7 @@ func (r *reconciler) syncAllClusters(
 			var err error
 			userClusterClient, ok := r.userClusterClients[userCluster.Name]
 			if !ok {
-				userClusterClient, err = r.userClusterClientProvider.GetClient(&userCluster)
+				userClusterClient, err = r.userClusterClientProvider.GetClient(r.ctx, &userCluster)
 				if err != nil {
 					return fmt.Errorf("error getting client for cluster %s: %w", userCluster.Spec.HumanReadableName, err)
 				}

--- a/pkg/controller/seed-controller-manager/constraint-template-controller/controller_test.go
+++ b/pkg/controller/seed-controller-manager/constraint-template-controller/controller_test.go
@@ -229,6 +229,6 @@ func newFakeClientProvider(client ctrlruntimeclient.Client) *fakeClientProvider 
 	}
 }
 
-func (f *fakeClientProvider) GetClient(c *kubermaticv1.Cluster, options ...clusterclient.ConfigOption) (ctrlruntimeclient.Client, error) {
+func (f *fakeClientProvider) GetClient(ctx context.Context, c *kubermaticv1.Cluster, options ...clusterclient.ConfigOption) (ctrlruntimeclient.Client, error) {
 	return f.client, nil
 }

--- a/pkg/controller/seed-controller-manager/initialmachinedeployment/controller.go
+++ b/pkg/controller/seed-controller-manager/initialmachinedeployment/controller.go
@@ -50,7 +50,7 @@ const (
 
 // UserClusterClientProvider provides functionality to get a user cluster client
 type UserClusterClientProvider interface {
-	GetClient(c *kubermaticv1.Cluster, options ...clusterclient.ConfigOption) (ctrlruntimeclient.Client, error)
+	GetClient(ctx context.Context, c *kubermaticv1.Cluster, options ...clusterclient.ConfigOption) (ctrlruntimeclient.Client, error)
 }
 
 type Reconciler struct {
@@ -146,7 +146,7 @@ func (r *Reconciler) reconcile(cluster *kubermaticv1.Cluster) (*reconcile.Result
 		return nil, nil
 	}
 
-	userClusterClient, err := r.userClusterConnectionProvider.GetClient(cluster)
+	userClusterClient, err := r.userClusterConnectionProvider.GetClient(r.ctx, cluster)
 	if err != nil {
 		return nil, fmt.Errorf("failed to get user cluster client: %v", err)
 	}

--- a/pkg/controller/seed-controller-manager/initialmachinedeployment/controller_test.go
+++ b/pkg/controller/seed-controller-manager/initialmachinedeployment/controller_test.go
@@ -259,6 +259,6 @@ func newFakeClientProvider(client ctrlruntimeclient.Client) *fakeClientProvider 
 	}
 }
 
-func (f *fakeClientProvider) GetClient(c *kubermaticv1.Cluster, options ...clusterclient.ConfigOption) (ctrlruntimeclient.Client, error) {
+func (f *fakeClientProvider) GetClient(ctx context.Context, c *kubermaticv1.Cluster, options ...clusterclient.ConfigOption) (ctrlruntimeclient.Client, error) {
 	return f.client, nil
 }

--- a/pkg/controller/seed-controller-manager/kubernetes/cluster_controller.go
+++ b/pkg/controller/seed-controller-manager/kubernetes/cluster_controller.go
@@ -57,7 +57,7 @@ const (
 
 // userClusterConnectionProvider offers functions to retrieve clients for the given user clusters
 type userClusterConnectionProvider interface {
-	GetClient(*kubermaticv1.Cluster, ...k8cuserclusterclient.ConfigOption) (ctrlruntimeclient.Client, error)
+	GetClient(context.Context, *kubermaticv1.Cluster, ...k8cuserclusterclient.ConfigOption) (ctrlruntimeclient.Client, error)
 }
 
 type Features struct {
@@ -262,7 +262,7 @@ func (r *Reconciler) reconcile(ctx context.Context, log *zap.SugaredLogger, clus
 
 		// Defer getting the client to make sure we only request it if we actually need it
 		userClusterClientGetter := func() (ctrlruntimeclient.Client, error) {
-			client, err := r.userClusterConnProvider.GetClient(cluster)
+			client, err := r.userClusterConnProvider.GetClient(ctx, cluster)
 			if err != nil {
 				return nil, fmt.Errorf("failed to get user cluster client: %v", err)
 			}

--- a/pkg/controller/seed-controller-manager/kubernetes/launching.go
+++ b/pkg/controller/seed-controller-manager/kubernetes/launching.go
@@ -28,7 +28,7 @@ import (
 
 // clusterIsReachable checks if the cluster is reachable via its external name
 func (r *Reconciler) clusterIsReachable(ctx context.Context, c *kubermaticv1.Cluster) (bool, error) {
-	client, err := r.userClusterConnProvider.GetClient(c)
+	client, err := r.userClusterConnProvider.GetClient(ctx, c)
 	if err != nil {
 		return false, err
 	}

--- a/pkg/controller/seed-controller-manager/monitoring/monitoring_controller.go
+++ b/pkg/controller/seed-controller-manager/monitoring/monitoring_controller.go
@@ -55,7 +55,7 @@ const (
 
 // userClusterConnectionProvider offers functions to retrieve clients for the given user clusters
 type userClusterConnectionProvider interface {
-	GetClient(*kubermaticv1.Cluster, ...k8cuserclusterclient.ConfigOption) (ctrlruntimeclient.Client, error)
+	GetClient(context.Context, *kubermaticv1.Cluster, ...k8cuserclusterclient.ConfigOption) (ctrlruntimeclient.Client, error)
 }
 
 // Features describes the enabled features for the monitoring controller

--- a/pkg/controller/seed-controller-manager/openshift/openshift_controller.go
+++ b/pkg/controller/seed-controller-manager/openshift/openshift_controller.go
@@ -237,7 +237,7 @@ func (r *Reconciler) reconcile(ctx context.Context, log *zap.SugaredLogger, clus
 
 		// Defer getting the client to make sure we only request it if we actually need it
 		userClusterClientGetter := func() (client.Client, error) {
-			userClusterClient, err := r.userClusterConnProvider.GetClient(cluster)
+			userClusterClient, err := r.userClusterConnProvider.GetClient(ctx, cluster)
 			if err != nil {
 				return nil, fmt.Errorf("failed to get user cluster client: %v", err)
 			}
@@ -306,7 +306,7 @@ func (r *Reconciler) reconcile(ctx context.Context, log *zap.SugaredLogger, clus
 
 // clusterIsReachable checks if the cluster is reachable via its external name
 func (r *Reconciler) clusterIsReachable(ctx context.Context, c *kubermaticv1.Cluster) (bool, error) {
-	client, err := r.userClusterConnProvider.GetClient(c)
+	client, err := r.userClusterConnProvider.GetClient(ctx, c)
 	if err != nil {
 		return false, err
 	}

--- a/pkg/controller/seed-controller-manager/rancher/controller.go
+++ b/pkg/controller/seed-controller-manager/rancher/controller.go
@@ -62,7 +62,7 @@ const (
 
 // KubeconfigProvider provides functionality to get a clusters admin kubeconfig
 type KubeconfigProvider interface {
-	GetAdminKubeconfig(c *kubermaticv1.Cluster) ([]byte, error)
+	GetAdminKubeconfig(ctx context.Context, c *kubermaticv1.Cluster) ([]byte, error)
 }
 
 type fileHandlingDone func()
@@ -335,7 +335,7 @@ func (r *Reconciler) applyRancherRegstrationCommand(ctx context.Context, log *za
 	if err != nil {
 		return fmt.Errorf("failed to read http response: %v", err)
 	}
-	kubeconfigFilename, kubeconfigDone, err := r.writeAdminKubeconfig(log, cluster)
+	kubeconfigFilename, kubeconfigDone, err := r.writeAdminKubeconfig(ctx, log, cluster)
 	if err != nil {
 		return fmt.Errorf("failed to write the admin kubeconfig to the local filesystem: %v", err)
 	}
@@ -353,9 +353,9 @@ func (r *Reconciler) applyRancherRegstrationCommand(ctx context.Context, log *za
 	return nil
 }
 
-func (r *Reconciler) writeAdminKubeconfig(log *zap.SugaredLogger, cluster *kubermaticv1.Cluster) (string, fileHandlingDone, error) {
+func (r *Reconciler) writeAdminKubeconfig(ctx context.Context, log *zap.SugaredLogger, cluster *kubermaticv1.Cluster) (string, fileHandlingDone, error) {
 	// Write kubeconfig to disk
-	kubeconfig, err := r.kubeconfigProvider.GetAdminKubeconfig(cluster)
+	kubeconfig, err := r.kubeconfigProvider.GetAdminKubeconfig(ctx, cluster)
 	if err != nil {
 		return "", nil, fmt.Errorf("failed to get admin kubeconfig for cluster %s: %v", cluster.Name, err)
 	}

--- a/pkg/controller/seed-controller-manager/update/update_controller.go
+++ b/pkg/controller/seed-controller-manager/update/update_controller.go
@@ -155,7 +155,7 @@ func (r *Reconciler) reconcile(ctx context.Context, cluster *kubermaticv1.Cluste
 }
 
 func (r *Reconciler) nodeUpdate(ctx context.Context, cluster *kubermaticv1.Cluster, clusterType string) error {
-	c, err := r.userClusterConnectionProvider.GetClient(cluster)
+	c, err := r.userClusterConnectionProvider.GetClient(ctx, cluster)
 	if err != nil {
 		return fmt.Errorf("failed to get usercluster client: %v", err)
 	}

--- a/pkg/handler/common/cluster.go
+++ b/pkg/handler/common/cluster.go
@@ -37,7 +37,6 @@ import (
 	kubernetesprovider "k8c.io/kubermatic/v2/pkg/provider/kubernetes"
 	"k8c.io/kubermatic/v2/pkg/resources/cloudcontroller"
 	"k8c.io/kubermatic/v2/pkg/resources/cluster"
-	kubermaticcontext "k8c.io/kubermatic/v2/pkg/util/context"
 	"k8c.io/kubermatic/v2/pkg/util/errors"
 	"k8c.io/kubermatic/v2/pkg/validation"
 

--- a/pkg/handler/common/cluster.go
+++ b/pkg/handler/common/cluster.go
@@ -486,7 +486,7 @@ func GetMetricsEndpoint(ctx context.Context, userInfoGetter provider.UserInfoGet
 		availableResources[n.Name] = n.Status.Allocatable
 	}
 
-	dynamicClient, err := clusterProvider.GetAdminClientForCustomerCluster(cluster)
+	dynamicClient, err := clusterProvider.GetAdminClientForCustomerCluster(ctx, cluster)
 	if err != nil {
 		return nil, common.KubernetesErrorToHTTPError(err)
 	}

--- a/pkg/handler/common/cluster.go
+++ b/pkg/handler/common/cluster.go
@@ -37,6 +37,7 @@ import (
 	kubernetesprovider "k8c.io/kubermatic/v2/pkg/provider/kubernetes"
 	"k8c.io/kubermatic/v2/pkg/resources/cloudcontroller"
 	"k8c.io/kubermatic/v2/pkg/resources/cluster"
+	kubermaticcontext "k8c.io/kubermatic/v2/pkg/util/context"
 	"k8c.io/kubermatic/v2/pkg/util/errors"
 	"k8c.io/kubermatic/v2/pkg/validation"
 

--- a/pkg/handler/common/machine.go
+++ b/pkg/handler/common/machine.go
@@ -404,7 +404,7 @@ func ListMachineDeploymentMetrics(ctx context.Context, userInfoGetter provider.U
 		}
 	}
 
-	dynamicCLient, err := clusterProvider.GetAdminClientForCustomerCluster(cluster)
+	dynamicCLient, err := clusterProvider.GetAdminClientForCustomerCluster(ctx, cluster)
 	if err != nil {
 		return nil, common.KubernetesErrorToHTTPError(err)
 	}
@@ -529,7 +529,7 @@ func ListMachineDeploymentNodesEvents(ctx context.Context, userInfoGetter provid
 		return nil, err
 	}
 
-	client, err := clusterProvider.GetAdminClientForCustomerCluster(cluster)
+	client, err := clusterProvider.GetAdminClientForCustomerCluster(ctx, cluster)
 	if err != nil {
 		return nil, common.KubernetesErrorToHTTPError(err)
 	}
@@ -741,7 +741,7 @@ func apiNodeStatus(status apiv1.NodeStatus, inputNode *corev1.Node, hideInitialN
 }
 
 func getNodeList(ctx context.Context, cluster *kubermaticv1.Cluster, clusterProvider provider.ClusterProvider) (*corev1.NodeList, error) {
-	client, err := clusterProvider.GetAdminClientForCustomerCluster(cluster)
+	client, err := clusterProvider.GetAdminClientForCustomerCluster(ctx, cluster)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/handler/common/role.go
+++ b/pkg/handler/common/role.go
@@ -46,7 +46,7 @@ func ListClusterRoleEndpoint(ctx context.Context, userInfoGetter provider.UserIn
 		return nil, err
 	}
 
-	client, err := clusterProvider.GetClientForCustomerCluster(userInfo, cluster)
+	client, err := clusterProvider.GetClientForCustomerCluster(ctx, userInfo, cluster)
 	if err != nil {
 		return nil, common.KubernetesErrorToHTTPError(err)
 	}
@@ -71,7 +71,7 @@ func ListClusterRoleNamesEndpoint(ctx context.Context, userInfoGetter provider.U
 		return nil, err
 	}
 
-	client, err := clusterProvider.GetClientForCustomerCluster(userInfo, cluster)
+	client, err := clusterProvider.GetClientForCustomerCluster(ctx, userInfo, cluster)
 	if err != nil {
 		return nil, common.KubernetesErrorToHTTPError(err)
 	}
@@ -102,7 +102,7 @@ func ListRoleEndpoint(ctx context.Context, userInfoGetter provider.UserInfoGette
 		return nil, err
 	}
 
-	client, err := clusterProvider.GetClientForCustomerCluster(userInfo, cluster)
+	client, err := clusterProvider.GetClientForCustomerCluster(ctx, userInfo, cluster)
 	if err != nil {
 		return nil, common.KubernetesErrorToHTTPError(err)
 	}
@@ -127,7 +127,7 @@ func ListRoleNamesEndpoint(ctx context.Context, userInfoGetter provider.UserInfo
 		return nil, err
 	}
 
-	client, err := clusterProvider.GetClientForCustomerCluster(userInfo, cluster)
+	client, err := clusterProvider.GetClientForCustomerCluster(ctx, userInfo, cluster)
 	if err != nil {
 		return nil, common.KubernetesErrorToHTTPError(err)
 	}

--- a/pkg/handler/common/upgrade.go
+++ b/pkg/handler/common/upgrade.go
@@ -106,7 +106,7 @@ func UpgradeNodeDeploymentsEndpoint(ctx context.Context, userInfoGetter provider
 		return nil, errors.NewBadRequest(err.Error())
 	}
 
-	client, err := clusterProvider.GetAdminClientForCustomerCluster(cluster)
+	client, err := clusterProvider.GetAdminClientForCustomerCluster(ctx, cluster)
 	if err != nil {
 		return nil, common.KubernetesErrorToHTTPError(err)
 	}

--- a/pkg/handler/test/helper.go
+++ b/pkg/handler/test/helper.go
@@ -503,7 +503,7 @@ type fakeUserClusterConnection struct {
 	fakeDynamicClient ctrlruntimeclient.Client
 }
 
-func (f *fakeUserClusterConnection) GetClient(_ *kubermaticv1.Cluster, _ ...k8cuserclusterclient.ConfigOption) (ctrlruntimeclient.Client, error) {
+func (f *fakeUserClusterConnection) GetClient(_ context.Context, _ *kubermaticv1.Cluster, _ ...k8cuserclusterclient.ConfigOption) (ctrlruntimeclient.Client, error) {
 	return f.fakeDynamicClient, nil
 }
 

--- a/pkg/handler/v1/cluster/role.go
+++ b/pkg/handler/v1/cluster/role.go
@@ -56,7 +56,7 @@ func CreateClusterRoleEndpoint(userInfoGetter provider.UserInfoGetter) endpoint.
 			return nil, err
 		}
 
-		client, err := clusterProvider.GetClientForCustomerCluster(userInfo, cluster)
+		client, err := clusterProvider.GetClientForCustomerCluster(ctx, userInfo, cluster)
 		if err != nil {
 			return nil, common.KubernetesErrorToHTTPError(err)
 		}
@@ -91,7 +91,7 @@ func CreateRoleEndpoint(userInfoGetter provider.UserInfoGetter) endpoint.Endpoin
 			return nil, err
 		}
 
-		client, err := clusterProvider.GetClientForCustomerCluster(userInfo, cluster)
+		client, err := clusterProvider.GetClientForCustomerCluster(ctx, userInfo, cluster)
 		if err != nil {
 			return nil, common.KubernetesErrorToHTTPError(err)
 		}
@@ -269,7 +269,7 @@ func GetClusterRoleEndpoint(userInfoGetter provider.UserInfoGetter) endpoint.End
 			return nil, err
 		}
 
-		client, err := clusterProvider.GetClientForCustomerCluster(userInfo, cluster)
+		client, err := clusterProvider.GetClientForCustomerCluster(ctx, userInfo, cluster)
 		if err != nil {
 			return nil, common.KubernetesErrorToHTTPError(err)
 		}
@@ -296,7 +296,7 @@ func GetRoleEndpoint(userInfoGetter provider.UserInfoGetter) endpoint.Endpoint {
 			return nil, err
 		}
 
-		client, err := clusterProvider.GetClientForCustomerCluster(userInfo, cluster)
+		client, err := clusterProvider.GetClientForCustomerCluster(ctx, userInfo, cluster)
 		if err != nil {
 			return nil, common.KubernetesErrorToHTTPError(err)
 		}
@@ -324,7 +324,7 @@ func DeleteClusterRoleEndpoint(userInfoGetter provider.UserInfoGetter) endpoint.
 			return nil, err
 		}
 
-		client, err := clusterProvider.GetClientForCustomerCluster(userInfo, cluster)
+		client, err := clusterProvider.GetClientForCustomerCluster(ctx, userInfo, cluster)
 		if err != nil {
 			return nil, common.KubernetesErrorToHTTPError(err)
 		}
@@ -356,7 +356,7 @@ func DeleteRoleEndpoint(userInfoGetter provider.UserInfoGetter) endpoint.Endpoin
 			return nil, err
 		}
 
-		client, err := clusterProvider.GetClientForCustomerCluster(userInfo, cluster)
+		client, err := clusterProvider.GetClientForCustomerCluster(ctx, userInfo, cluster)
 		if err != nil {
 			return nil, common.KubernetesErrorToHTTPError(err)
 		}
@@ -468,7 +468,7 @@ func PatchRoleEndpoint(userInfoGetter provider.UserInfoGetter) endpoint.Endpoint
 			return nil, err
 		}
 
-		client, err := clusterProvider.GetClientForCustomerCluster(userInfo, cluster)
+		client, err := clusterProvider.GetClientForCustomerCluster(ctx, userInfo, cluster)
 		if err != nil {
 			return nil, common.KubernetesErrorToHTTPError(err)
 		}
@@ -563,7 +563,7 @@ func PatchClusterRoleEndpoint(userInfoGetter provider.UserInfoGetter) endpoint.E
 			return nil, err
 		}
 
-		client, err := clusterProvider.GetClientForCustomerCluster(userInfo, cluster)
+		client, err := clusterProvider.GetClientForCustomerCluster(ctx, userInfo, cluster)
 		if err != nil {
 			return nil, common.KubernetesErrorToHTTPError(err)
 		}

--- a/pkg/handler/v1/common/common.go
+++ b/pkg/handler/v1/common/common.go
@@ -302,12 +302,12 @@ func GetClusterClient(ctx context.Context, userInfoGetter provider.UserInfoGette
 		return nil, fmt.Errorf("failed to get user information: %v", err)
 	}
 	if adminUserInfo.IsAdmin {
-		return clusterProvider.GetAdminClientForCustomerCluster(cluster)
+		return clusterProvider.GetAdminClientForCustomerCluster(ctx, cluster)
 	}
 
 	userInfo, err := userInfoGetter(ctx, projectID)
 	if err != nil {
 		return nil, fmt.Errorf("failed to get user information: %v", err)
 	}
-	return clusterProvider.GetClientForCustomerCluster(userInfo, cluster)
+	return clusterProvider.GetClientForCustomerCluster(ctx, userInfo, cluster)
 }

--- a/pkg/handler/v1/kubernetes-dashboard/dashboard.go
+++ b/pkg/handler/v1/kubernetes-dashboard/dashboard.go
@@ -97,7 +97,7 @@ func ProxyEndpoint(
 				return nil, nil
 			}
 
-			token, err := clusterProvider.GetTokenForCustomerCluster(userInfo, userCluster)
+			token, err := clusterProvider.GetTokenForCustomerCluster(ctx, userInfo, userCluster)
 			if err != nil {
 				common.WriteHTTPError(log, w, kubermaticerrors.New(http.StatusBadRequest, fmt.Sprintf("error getting token for user %q: %v", userInfo.Email, err)))
 				return nil, nil

--- a/pkg/handler/v1/project/project_test.go
+++ b/pkg/handler/v1/project/project_test.go
@@ -505,7 +505,7 @@ func TestListProjectMethod(t *testing.T) {
 
 			endpointFun := project.ListEndpoint(userInfoGetter, test.NewFakeProjectProvider(), test.NewFakePrivilegedProjectProvider(), projectMemberProvider, projectMemberProvider, userProvider, clusterProviderGetter, test.BuildSeeds())
 
-			ctx := context.WithValue(context.TODO(), middleware.UserCRContextKey, tc.ExistingAPIUser)
+			ctx := context.WithValue(context.Background(), middleware.UserCRContextKey, tc.ExistingAPIUser)
 
 			projectsRaw, err := endpointFun(ctx, project.ListReq{})
 			resultProjectList := make([]apiv1.Project, 0)
@@ -549,7 +549,7 @@ type fakeUserClusterConnection struct {
 	fakeDynamicClient ctrlruntimeclient.Client
 }
 
-func (f *fakeUserClusterConnection) GetClient(_ *kubermaticapiv1.Cluster, _ ...k8cuserclusterclient.ConfigOption) (ctrlruntimeclient.Client, error) {
+func (f *fakeUserClusterConnection) GetClient(_ context.Context, _ *kubermaticapiv1.Cluster, _ ...k8cuserclusterclient.ConfigOption) (ctrlruntimeclient.Client, error) {
 	return f.fakeDynamicClient, nil
 }
 

--- a/pkg/provider/kubernetes/cluster_internal_test.go
+++ b/pkg/provider/kubernetes/cluster_internal_test.go
@@ -109,6 +109,6 @@ type fakeUserClusterConnectionProvider struct {
 	client ctrlruntimeclient.Client
 }
 
-func (f *fakeUserClusterConnectionProvider) GetClient(*kubermaticv1.Cluster, ...k8cuserclusterclient.ConfigOption) (ctrlruntimeclient.Client, error) {
+func (f *fakeUserClusterConnectionProvider) GetClient(context.Context, *kubermaticv1.Cluster, ...k8cuserclusterclient.ConfigOption) (ctrlruntimeclient.Client, error) {
 	return f.client, nil
 }

--- a/pkg/provider/types.go
+++ b/pkg/provider/types.go
@@ -182,16 +182,16 @@ type ClusterProvider interface {
 	// GetAdminClientForCustomerCluster returns a client to interact with all resources in the given cluster
 	//
 	// Note that the client you will get has admin privileges
-	GetAdminClientForCustomerCluster(*kubermaticv1.Cluster) (ctrlruntimeclient.Client, error)
+	GetAdminClientForCustomerCluster(context.Context, *kubermaticv1.Cluster) (ctrlruntimeclient.Client, error)
 
 	// GetClientForCustomerCluster returns a client to interact with all resources in the given cluster
 	//
 	// Note that the client doesn't use admin account instead it authn/authz as userInfo(email, group)
-	GetClientForCustomerCluster(*UserInfo, *kubermaticv1.Cluster) (ctrlruntimeclient.Client, error)
+	GetClientForCustomerCluster(context.Context, *UserInfo, *kubermaticv1.Cluster) (ctrlruntimeclient.Client, error)
 
 	// GetTokenForCustomerCluster returns a token for the given cluster with permissions granted to group that
 	// user belongs to.
-	GetTokenForCustomerCluster(userInfo *UserInfo, cluster *kubermaticv1.Cluster) (string, error)
+	GetTokenForCustomerCluster(context.Context, *UserInfo, *kubermaticv1.Cluster) (string, error)
 
 	// IsCluster checks if cluster exist with the given name
 	IsCluster(clusterName string) bool


### PR DESCRIPTION
**What this PR does / why we need it**:
Currently our conformance-tests do not use a context consistently, making it hard to Ctrl-C it and have it properly clean up after itself. This PR improves the situation by making the context handling explicit.

**Does this PR introduce a user-facing change?**:
```release-note
NONE
```
