### PR TITLE
Support KubermaticConfiguration in image-loader

### DIFF
--- a/cmd/image-loader/README.md
+++ b/cmd/image-loader/README.md
@@ -1,6 +1,10 @@
 # image-loader
 
-A little utility that downloads all required Docker images for kubermatic, retags then
-and pushes them.
+A little utility that downloads all required Docker images for KKP, retags then
+and pushes them to a local registry.
 
-Synopsis: `image-loader -logtostderr -v 2 -registry-name registry.corp.com`
+If you're using the KKP Operator and a KubermaticConfiguration, run the utility
+with `-configuration-file YOUR_FILE.yaml`, otherwise specify the path to the
+`versions.yaml` from the legacy Helm chart via `-versions-file VERSIONS.yaml`.
+
+Synopsis: `image-loader -registry registry.corp.com -configuration-file YOUR_FILE.yaml`

--- a/cmd/image-loader/main.go
+++ b/cmd/image-loader/main.go
@@ -85,7 +85,7 @@ func main() {
 
 	o := opts{}
 	flag.StringVar(&o.configurationFile, "configuration-file", "", "Path to the KubermaticConfiguration YAML file")
-	flag.StringVar(&o.versionsFile, "versions-file", "", "The versions.yaml file path (deprecated, EE-only)")
+	flag.StringVar(&o.versionsFile, "versions-file", "", "The versions.yaml file path (deprecated, EE-only, used only if no -configuration-file is given)")
 	flag.StringVar(&o.versionFilter, "version-filter", "", "Version constraint which can be used to filter for specific versions")
 	flag.StringVar(&o.registry, "registry", "", "Address of the registry to push to, for example localhost:5000")
 	flag.BoolVar(&o.dryRun, "dry-run", false, "Only print the names of found images")
@@ -99,6 +99,10 @@ func main() {
 			fmt.Println(err)
 		}
 	}()
+
+	if (o.configurationFile == "") != (o.versionsFile == "") {
+		log.Fatal("Either -configuration-file or -versions-file must be specified.")
+	}
 
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()

--- a/cmd/image-loader/main.go
+++ b/cmd/image-loader/main.go
@@ -420,18 +420,7 @@ func getVersions(log *zap.SugaredLogger, config *operatorv1alpha1.KubermaticConf
 
 	if config != nil {
 		log.Debug("Loading versions")
-
-		assembleVersions := func(kind string, configuredVersions []*semver.Version) {
-			for i := range configuredVersions {
-				versions = append(versions, &kubermaticversion.Version{
-					Version: configuredVersions[i],
-					Type:    kind,
-				})
-			}
-		}
-
-		assembleVersions("kubernetes", config.Spec.Versions.Kubernetes.Versions)
-		assembleVersions("openshift", config.Spec.Versions.Openshift.Versions)
+		versions = getVersionsFromKubermaticConfiguration(config)
 	} else {
 		if versionsFile == "" {
 			return nil, errors.New("either a KubermaticConfiguration or a versions file must be specified")
@@ -464,6 +453,24 @@ func getVersions(log *zap.SugaredLogger, config *operatorv1alpha1.KubermaticConf
 	}
 
 	return filteredVersions, nil
+}
+
+func getVersionsFromKubermaticConfiguration(config *operatorv1alpha1.KubermaticConfiguration) []*kubermaticversion.Version {
+	versions := []*kubermaticversion.Version{}
+
+	assembleVersions := func(kind string, configuredVersions []*semver.Version) {
+		for i := range configuredVersions {
+			versions = append(versions, &kubermaticversion.Version{
+				Version: configuredVersions[i],
+				Type:    kind,
+			})
+		}
+	}
+
+	assembleVersions("kubernetes", config.Spec.Versions.Kubernetes.Versions)
+	assembleVersions("openshift", config.Spec.Versions.Openshift.Versions)
+
+	return versions
 }
 
 func getImagesFromAddons(log *zap.SugaredLogger, addonsPath string, cluster *kubermaticv1.Cluster) ([]string, error) {

--- a/cmd/image-loader/main.go
+++ b/cmd/image-loader/main.go
@@ -100,7 +100,7 @@ func main() {
 		}
 	}()
 
-	if (o.configurationFile == "") != (o.versionsFile == "") {
+	if (o.configurationFile == "") == (o.versionsFile == "") {
 		log.Fatal("Either -configuration-file or -versions-file must be specified.")
 	}
 

--- a/cmd/image-loader/main_test.go
+++ b/cmd/image-loader/main_test.go
@@ -20,36 +20,38 @@ import (
 	"context"
 	"testing"
 
+	"k8c.io/kubermatic/v2/pkg/controller/operator/common"
+	operatorv1alpha1 "k8c.io/kubermatic/v2/pkg/crd/operator/v1alpha1"
 	kubermaticlog "k8c.io/kubermatic/v2/pkg/log"
 	"k8c.io/kubermatic/v2/pkg/resources"
-	"k8c.io/kubermatic/v2/pkg/version"
 
 	"k8s.io/apimachinery/pkg/util/sets"
 )
 
 func TestRetagImageForAllVersions(t *testing.T) {
 	log := kubermaticlog.New(true, kubermaticlog.FormatConsole).Sugar()
-	masterResources := "../../charts/kubermatic/static/master/versions.yaml"
-	addonPath := "../../addons"
 
-	versions, err := version.LoadVersions(masterResources)
+	config, err := common.DefaultConfiguration(&operatorv1alpha1.KubermaticConfiguration{}, log)
 	if err != nil {
-		t.Errorf("Error loading versions: %v", err)
+		t.Errorf("failed to determine versions: %v", err)
 	}
+
+	versions := getVersionsFromKubermaticConfiguration(config)
+	addonPath := "../../addons"
 
 	// Cannot be set during go-test
 	resources.KUBERMATICCOMMIT = "latest"
 
 	imageSet := sets.NewString()
 	for _, v := range versions {
-		images, err := getImagesForVersion(log.Desugar(), v, addonPath)
+		images, err := getImagesForVersion(log, v, addonPath)
 		if err != nil {
 			t.Errorf("Error calling getImagesForVersion: %v", err)
 		}
 		imageSet.Insert(images...)
 	}
 
-	if err := processImages(context.Background(), log.Desugar(), true, imageSet.List(), "test-registry:5000"); err != nil {
+	if err := processImages(context.Background(), log, true, imageSet.List(), "test-registry:5000"); err != nil {
 		t.Errorf("Error calling processImages: %v", err)
 	}
 }

--- a/hack/ci/deploy-offline.sh
+++ b/hack/ci/deploy-offline.sh
@@ -101,7 +101,7 @@ docker push 127.0.0.1:5000/kubernetes-helm/tiller:${HELM_VERSION}
 cd ..
 KUBERMATICCOMMIT=${GIT_HEAD_HASH} GITTAG=${GIT_HEAD_HASH} make image-loader
 retry 6 ./_build/image-loader \
-  -versions charts/kubermatic/static/master/versions.yaml \
+  -configuration-file /dev/null \
   -addons-path addons \
   -registry 127.0.0.1:5000 \
   -log-format=Console

--- a/hack/ci/run-offline-test.sh
+++ b/hack/ci/run-offline-test.sh
@@ -165,7 +165,7 @@ done
 cd ..
 KUBERMATICCOMMIT=${GIT_HEAD_HASH} GITTAG=${GIT_HEAD_HASH} make image-loader
 ./_build/image-loader \
-  -versions charts/kubermatic/static/master/versions.yaml \
+  -configuration-file /dev/null \
   -addons-path addons \
   -registry 127.0.0.1:5000 \
   -log-format=Console

--- a/pkg/docker/docker.go
+++ b/pkg/docker/docker.go
@@ -28,7 +28,7 @@ import (
 )
 
 // execCommand is an internal helper function to execute commands and log them
-func execCommand(log *zap.Logger, dryRun bool, cmd *exec.Cmd) error {
+func execCommand(log *zap.SugaredLogger, dryRun bool, cmd *exec.Cmd) error {
 	log = log.With(zap.String("command", strings.Join(cmd.Args, " ")))
 	if dryRun {
 		log.Info("Would execute Docker command but this is a dry-run")
@@ -49,7 +49,7 @@ func execCommand(log *zap.Logger, dryRun bool, cmd *exec.Cmd) error {
 
 // DownloadImages pulls all given images using the Docker CLI
 // Invokes DownloadImage for actual pulling
-func DownloadImages(ctx context.Context, log *zap.Logger, dryRun bool, images []string) error {
+func DownloadImages(ctx context.Context, log *zap.SugaredLogger, dryRun bool, images []string) error {
 	for _, image := range images {
 		select {
 		case <-ctx.Done():
@@ -65,7 +65,7 @@ func DownloadImages(ctx context.Context, log *zap.Logger, dryRun bool, images []
 }
 
 // DownloadImage invokes the Docker CLI and pulls an image
-func DownloadImage(ctx context.Context, log *zap.Logger, dryRun bool, image string) error {
+func DownloadImage(ctx context.Context, log *zap.SugaredLogger, dryRun bool, image string) error {
 	log = log.With(zap.String("image", image))
 	log.Info("Downloading image...")
 
@@ -79,7 +79,7 @@ func DownloadImage(ctx context.Context, log *zap.Logger, dryRun bool, image stri
 
 // RetagImages invokes the Docker CLI and tags the given images so they belongs to the given registry.
 // Invokes RetagImage for actual tagging
-func RetagImages(ctx context.Context, log *zap.Logger, dryRun bool, images []string, registry string) ([]string, error) {
+func RetagImages(ctx context.Context, log *zap.SugaredLogger, dryRun bool, images []string, registry string) ([]string, error) {
 	var retaggedImages []string
 	for _, image := range images {
 		select {
@@ -99,7 +99,7 @@ func RetagImages(ctx context.Context, log *zap.Logger, dryRun bool, images []str
 }
 
 // RetagImage invokes the Docker CLI and tags the given image so it belongs to the given registry.
-func RetagImage(ctx context.Context, log *zap.Logger, dryRun bool, sourceImage, registry string) (string, error) {
+func RetagImage(ctx context.Context, log *zap.SugaredLogger, dryRun bool, sourceImage, registry string) (string, error) {
 	log = log.With(zap.String("source-image", sourceImage))
 	imageRef, err := reference.ParseNamed(sourceImage)
 	if err != nil {
@@ -124,7 +124,7 @@ func RetagImage(ctx context.Context, log *zap.Logger, dryRun bool, sourceImage, 
 
 // PushImages pushes all given images using the Docker CLI
 // Invokes PushImage for actual pushing
-func PushImages(ctx context.Context, log *zap.Logger, dryRun bool, images []string) error {
+func PushImages(ctx context.Context, log *zap.SugaredLogger, dryRun bool, images []string) error {
 	for _, image := range images {
 		select {
 		case <-ctx.Done():
@@ -140,7 +140,7 @@ func PushImages(ctx context.Context, log *zap.Logger, dryRun bool, images []stri
 }
 
 // PushImage invokes the Docker CLI and pushes the given image
-func PushImage(ctx context.Context, log *zap.Logger, dryRun bool, image string) error {
+func PushImage(ctx context.Context, log *zap.SugaredLogger, dryRun bool, image string) error {
 	log = log.With(zap.String("image", image))
 
 	log.Info("Pushing image...")


### PR DESCRIPTION
**What this PR does / why we need it**:
The image-loader did not yet help users that do not manage the versions with the old YAML file, but instead use the operator and its KubermaticConfiguration. This PR rectifies that by adding support for it. I chose not to split the image loader into CE/EE binaries just because it's so little code and simply not worth it for the time we still support the old Helm chart.

This can be tested by building the image loader (make sure to set a KUBERMATICCOMMIT to a version that has Docker images available on quay), creating an empty KubermaticConfiguration file and the running:

```
export KUBERMATICCOMMIT=4818b3906e63588c0b75a5a07f8d1a9bc95d8756
make image-loader

docker run -d -p 5000:5000 --restart=always --name registry registry:2

_build/image-loader \
  -registry localhost:5000 \
  -configuration-file test-kubermaticconfig.yaml \
  -log-debug
```

**Does this PR introduce a user-facing change?**:
```release-note
Add support for KubermaticConfiguration in image-loader utility
```
