### PR TITLE
Support addons Docker image in image-loader

### DIFF
--- a/cmd/image-loader/main_test.go
+++ b/cmd/image-loader/main_test.go
@@ -44,7 +44,7 @@ func TestRetagImageForAllVersions(t *testing.T) {
 
 	imageSet := sets.NewString()
 	for _, v := range versions {
-		images, err := getImagesForVersion(context.Background(), log, v, addonPath)
+		images, err := getImagesForVersion(log, v, addonPath)
 		if err != nil {
 			t.Errorf("Error calling getImagesForVersion: %v", err)
 		}

--- a/cmd/image-loader/main_test.go
+++ b/cmd/image-loader/main_test.go
@@ -44,7 +44,7 @@ func TestRetagImageForAllVersions(t *testing.T) {
 
 	imageSet := sets.NewString()
 	for _, v := range versions {
-		images, err := getImagesForVersion(log, v, addonPath)
+		images, err := getImagesForVersion(context.Background(), log, v, addonPath)
 		if err != nil {
 			t.Errorf("Error calling getImagesForVersion: %v", err)
 		}

--- a/pkg/docker/docker.go
+++ b/pkg/docker/docker.go
@@ -30,7 +30,7 @@ import (
 
 // execCommand is an internal helper function to execute commands and log them
 func execCommand(log *zap.SugaredLogger, dryRun bool, cmd *exec.Cmd) error {
-	log = log.With(zap.String("command", strings.Join(cmd.Args, " ")))
+	log = log.With("command", strings.Join(cmd.Args, " "))
 	if dryRun {
 		log.Info("Would execute Docker command but this is a dry-run")
 		return nil
@@ -67,7 +67,7 @@ func DownloadImages(ctx context.Context, log *zap.SugaredLogger, dryRun bool, im
 
 // DownloadImage invokes the Docker CLI and pulls an image
 func DownloadImage(ctx context.Context, log *zap.SugaredLogger, dryRun bool, image string) error {
-	log = log.With(zap.String("image", image))
+	log = log.With("image", image)
 	log.Info("Downloading image...")
 
 	cmd := exec.CommandContext(ctx, "docker", "pull", image)
@@ -101,7 +101,7 @@ func RetagImages(ctx context.Context, log *zap.SugaredLogger, dryRun bool, image
 
 // RetagImage invokes the Docker CLI and tags the given image so it belongs to the given registry.
 func RetagImage(ctx context.Context, log *zap.SugaredLogger, dryRun bool, sourceImage, registry string) (string, error) {
-	log = log.With(zap.String("source-image", sourceImage))
+	log = log.With("source-image", sourceImage)
 	imageRef, err := reference.ParseNamed(sourceImage)
 	if err != nil {
 		return "", fmt.Errorf("failed to parse image: %v", err)
@@ -112,7 +112,7 @@ func RetagImage(ctx context.Context, log *zap.SugaredLogger, dryRun bool, source
 	}
 
 	targetImage := fmt.Sprintf("%s/%s:%s", registry, reference.Path(imageRef), taggedImageRef.Tag())
-	log = log.With(zap.String("target-image", targetImage))
+	log = log.With("target-image", targetImage)
 
 	log.Info("Tagging image...")
 	cmd := exec.CommandContext(ctx, "docker", "tag", sourceImage, targetImage)
@@ -142,7 +142,7 @@ func PushImages(ctx context.Context, log *zap.SugaredLogger, dryRun bool, images
 
 // PushImage invokes the Docker CLI and pushes the given image
 func PushImage(ctx context.Context, log *zap.SugaredLogger, dryRun bool, image string) error {
-	log = log.With(zap.String("image", image))
+	log = log.With("image", image)
 
 	log.Info("Pushing image...")
 	cmd := exec.CommandContext(ctx, "docker", "push", image)
@@ -153,14 +153,14 @@ func PushImage(ctx context.Context, log *zap.SugaredLogger, dryRun bool, image s
 	return nil
 }
 
-// ExtractDirectory copies the content from a directory out of the
+// Copy copies the content from a directory out of the
 // container onto the host system
-func ExtractDirectory(ctx context.Context, log *zap.SugaredLogger, image string, dst string, src string) error {
+func Copy(ctx context.Context, log *zap.SugaredLogger, image string, dst string, src string) error {
 	var err error
 
-	log = log.With(zap.String("image", image))
+	log = log.With("image", image)
 
-	log.Info("Extracting image...", "src", src, "dst", dst)
+	log.Infow("Extracting image...", "src", src, "dst", dst)
 
 	dst, err = filepath.Abs(dst)
 	if err != nil {

--- a/pkg/docker/docker.go
+++ b/pkg/docker/docker.go
@@ -21,6 +21,7 @@ import (
 	"errors"
 	"fmt"
 	"os/exec"
+	"path/filepath"
 	"strings"
 
 	"github.com/docker/distribution/reference"
@@ -146,6 +147,38 @@ func PushImage(ctx context.Context, log *zap.SugaredLogger, dryRun bool, image s
 	log.Info("Pushing image...")
 	cmd := exec.CommandContext(ctx, "docker", "push", image)
 	if err := execCommand(log, dryRun, cmd); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+// ExtractDirectory copies the content from a directory out of the
+// container onto the host system
+func ExtractDirectory(ctx context.Context, log *zap.SugaredLogger, image string, dst string, src string) error {
+	var err error
+
+	log = log.With(zap.String("image", image))
+
+	log.Info("Extracting image...", "src", src, "dst", dst)
+
+	dst, err = filepath.Abs(dst)
+	if err != nil {
+		return fmt.Errorf("failed to determine absolute path: %v", err)
+	}
+
+	mountPoint := "/kubermaticextractor"
+	args := []string{
+		"run",
+		"--rm",
+		"-v", fmt.Sprintf("%s:%s", dst, mountPoint),
+		"-w", src,
+		image,
+		"cp", "-ar", ".", mountPoint,
+	}
+
+	cmd := exec.CommandContext(ctx, "docker", args...)
+	if err := execCommand(log, false, cmd); err != nil {
 		return err
 	}
 


### PR DESCRIPTION
**What this PR does / why we need it**:
For users who do not have an addons folder locally (either because they do not develop their own addons or because they simply don't have it at hands), this PR extends our image-loader to

* determine the addon Docker image from the KubermaticConfiguration
* pull said image
* extract `/addons` onto the host system

This allows users to have the addons locally or let the image-loader take care of getting them. Very convenient!

As we do not support openshift in the image-loader, this only takes the Kubernetes addons image into account.

Docker offers the `docker cp` command, but that needs a Docker container, so I chose to keep it simple and just use `docker run`. As the addons image should always be inherited from our image, this means that we always have Alpine available.

**Does this PR introduce a user-facing change?**:
```release-note
NONE
```
