### PR TITLE
Add Helm Support to image-loader

### DIFF
--- a/charts/kubernetes-dashboard/Chart.yaml
+++ b/charts/kubernetes-dashboard/Chart.yaml
@@ -14,7 +14,7 @@
 
 apiVersion: v1
 name: kubernetes-dashboard
-version: 1.0.6
+version: 1.0.7
 appVersion: v2.0.0
 description: Kubernetes Dashboard
 keywords:

--- a/charts/kubernetes-dashboard/templates/_helpers.tpl
+++ b/charts/kubernetes-dashboard/templates/_helpers.tpl
@@ -1,11 +1,11 @@
 {{- define "dashboard-name" -}}
-{{- default printf "%s-%s" .Release.Name "dashboard" .Values.dashboard.deployment.dashboard.nameOverride -}}
+{{- default (printf "%s-%s" .Release.Name "dashboard") .Values.dashboard.deployment.dashboard.nameOverride -}}
 {{- end }}
 
 {{- define "oauth-name" -}}
-{{- default printf "%s-%s" .Release.Name "proxy" .Values.dashboard.deployment.proxy.nameOverride -}}
+{{- default (printf "%s-%s" .Release.Name "proxy") .Values.dashboard.deployment.proxy.nameOverride -}}
 {{- end }}
 
 {{- define "scraper-name" -}}
-{{- default printf "%s-%s" .Release.Name "scraper" .Values.dashboard.deployment.scraper.nameOverride -}}
+{{- default (printf "%s-%s" .Release.Name "scraper") .Values.dashboard.deployment.scraper.nameOverride -}}
 {{- end }}

--- a/charts/kubernetes-dashboard/templates/dashboard-csrf-secret.yaml
+++ b/charts/kubernetes-dashboard/templates/dashboard-csrf-secret.yaml
@@ -23,4 +23,4 @@ metadata:
   name: kubernetes-dashboard-csrf
 type: Opaque
 data:
-  csrf: "{{ .Values.dashboard.csrf }}"
+  csrf: {{ .Values.dashboard.csrf | b64enc | quote }}

--- a/charts/kubernetes-dashboard/templates/oauth-proxy-secret.yaml
+++ b/charts/kubernetes-dashboard/templates/oauth-proxy-secret.yaml
@@ -23,6 +23,6 @@ metadata:
   name: '{{ template "oauth-name" . }}-config'
 type: Opaque
 data:
-  clientID: "{{ .Values.dashboard.oidc.clientID }}"
-  clientSecret: "{{ .Values.dashboard.oidc.clientSecret }}"
-  cookieSecret: "{{ .Values.dashboard.oidc.cookieSecret }}"
+  clientID: {{ .Values.dashboard.oidc.clientID | b64enc | quote }}
+  clientSecret: {{ .Values.dashboard.oidc.clientSecret | b64enc | quote }}
+  cookieSecret: {{ .Values.dashboard.oidc.cookieSecret | b64enc | quote }}

--- a/cmd/image-loader/addons.go
+++ b/cmd/image-loader/addons.go
@@ -1,0 +1,83 @@
+/*
+Copyright 2020 The Kubermatic Kubernetes Platform contributors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package main
+
+import (
+	"fmt"
+	"io/ioutil"
+	"path"
+
+	"go.uber.org/zap"
+
+	addonutil "k8c.io/kubermatic/v2/pkg/addon"
+	kubermaticv1 "k8c.io/kubermatic/v2/pkg/crd/kubermatic/v1"
+	"k8c.io/kubermatic/v2/pkg/resources"
+
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/serializer/json"
+	"k8s.io/client-go/kubernetes/scheme"
+)
+
+func getImagesFromAddons(log *zap.SugaredLogger, addonsPath string, cluster *kubermaticv1.Cluster) ([]string, error) {
+	credentials := resources.Credentials{}
+
+	addonData, err := addonutil.NewTemplateData(cluster, credentials, "", "", "", nil)
+	if err != nil {
+		return nil, fmt.Errorf("failed to create addon template data: %v", err)
+	}
+
+	infos, err := ioutil.ReadDir(addonsPath)
+	if err != nil {
+		return nil, fmt.Errorf("unable to list addons: %v", err)
+	}
+
+	serializer := json.NewSerializer(&json.SimpleMetaFactory{}, scheme.Scheme, scheme.Scheme, false)
+	var images []string
+	for _, info := range infos {
+		if !info.IsDir() {
+			continue
+		}
+		addonName := info.Name()
+		addonImages, err := getImagesFromAddon(log, path.Join(addonsPath, addonName), serializer, addonData)
+		if err != nil {
+			return nil, fmt.Errorf("failed to get images for addon %s: %v", addonName, err)
+		}
+		images = append(images, addonImages...)
+	}
+
+	return images, nil
+}
+
+func getImagesFromAddon(log *zap.SugaredLogger, addonPath string, decoder runtime.Decoder, data *addonutil.TemplateData) ([]string, error) {
+	log = log.With(zap.String("addon", path.Base(addonPath)))
+	log.Debug("Processing manifests...")
+
+	allManifests, err := addonutil.ParseFromFolder(log, "", addonPath, data)
+	if err != nil {
+		return nil, fmt.Errorf("failed to parse addon templates in %s: %v", addonPath, err)
+	}
+
+	var images []string
+	for _, manifest := range allManifests {
+		manifestImages, err := getImagesFromManifest(log, decoder, manifest.Raw)
+		if err != nil {
+			return nil, err
+		}
+		images = append(images, manifestImages...)
+	}
+	return images, nil
+}

--- a/cmd/image-loader/helm.go
+++ b/cmd/image-loader/helm.go
@@ -1,0 +1,132 @@
+/*
+Copyright 2020 The Kubermatic Kubernetes Platform contributors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package main
+
+import (
+	"bytes"
+	"context"
+	"fmt"
+	"os"
+	"path/filepath"
+	"sort"
+	"time"
+
+	"github.com/Masterminds/semver"
+	"github.com/sirupsen/logrus"
+	"go.uber.org/zap"
+
+	operatorv1alpha1 "k8c.io/kubermatic/v2/pkg/crd/operator/v1alpha1"
+	"k8c.io/kubermatic/v2/pkg/install/helm"
+	yamlutil "k8c.io/kubermatic/v2/pkg/util/yaml"
+
+	"k8s.io/apimachinery/pkg/runtime/serializer/json"
+	"k8s.io/client-go/kubernetes/scheme"
+)
+
+func getImagesForHelmCharts(ctx context.Context, log *zap.SugaredLogger, config *operatorv1alpha1.KubermaticConfiguration, chartsPath string, valuesFile string, helmBinary string) ([]string, error) {
+	if info, err := os.Stat(chartsPath); err != nil || !info.IsDir() {
+		return nil, fmt.Errorf("%s is not a valid directory", chartsPath)
+	}
+
+	chartPaths, err := findHelmCharts(chartsPath)
+	if err != nil {
+		return nil, fmt.Errorf("failed to find Helm charts: %v", err)
+	}
+
+	helmClient, err := getHelmClient(helmBinary)
+	if err != nil {
+		return nil, fmt.Errorf("failed to create Helm client: %v", err)
+	}
+
+	images := []string{}
+	serializer := json.NewSerializer(&json.SimpleMetaFactory{}, scheme.Scheme, scheme.Scheme, false)
+
+	for _, chartPath := range chartPaths {
+		chartName := filepath.Base(chartPath)
+		chartLog := log.With("path", chartPath, "chart", chartName)
+
+		// do not render the Kubermatic chart again, if a Kubermatic configuration
+		// is given; in this case, the operator is used and we determine the images
+		// used via the static creators in Go code.
+		if config != nil && chartName == "kubermatic" {
+			chartLog.Info("Skipping chart because KubermaticConfiguration was given")
+			continue
+		}
+
+		chartLog.Info("Rendering chart")
+
+		rendered, err := helmClient.RenderChart(mockNamespaceName, chartName, chartPath, valuesFile, nil)
+		if err != nil {
+			return nil, fmt.Errorf("failed to render Helm chart %q: %v", chartName, err)
+		}
+
+		manifests, err := yamlutil.ParseMultipleDocuments(bytes.NewReader(rendered))
+		if err != nil {
+			return nil, fmt.Errorf("failed to decode YAML: %v", err)
+		}
+
+		for _, manifest := range manifests {
+			manifestImages, err := getImagesFromManifest(log, serializer, manifest.Raw)
+			if err != nil {
+				return nil, fmt.Errorf("failed to parse manifests: %v", err)
+			}
+
+			images = append(images, manifestImages...)
+		}
+	}
+
+	return images, nil
+}
+
+func getHelmClient(binary string) (helm.Client, error) {
+	helmClient, err := helm.NewCLI(binary, "", "", 10*time.Second, logrus.New())
+	if err != nil {
+		return nil, fmt.Errorf("failed to create Helm client: %v", err)
+	}
+
+	helmVersion, err := helmClient.Version()
+	if err != nil {
+		return nil, fmt.Errorf("failed to check Helm version: %v", err)
+	}
+
+	if helmVersion.LessThan(semver.MustParse("3.0.0")) {
+		return nil, fmt.Errorf("the image-loader requires Helm 3, detected %s", helmVersion.String())
+	}
+
+	return helmClient, nil
+}
+
+// findHelmCharts walks the root directory and finds Chart.yaml files. It
+// then returns the found directory paths (without the "/Chart.yaml" filename).
+func findHelmCharts(root string) ([]string, error) {
+	charts := []string{}
+
+	err := filepath.Walk(root, func(path string, info os.FileInfo, err error) error {
+		if info.IsDir() {
+			if _, err := os.Stat(filepath.Join(path, "Chart.yaml")); err == nil {
+				charts = append(charts, path)
+				return filepath.SkipDir
+			}
+		}
+
+		return nil
+	})
+
+	sort.Strings(charts)
+
+	return charts, err
+}

--- a/cmd/image-loader/main.go
+++ b/cmd/image-loader/main.go
@@ -242,7 +242,7 @@ func getImagesForVersion(log *zap.SugaredLogger, version *kubermaticversion.Vers
 		return nil, err
 	}
 
-	creatorImages, err := getImagesFromCreators(templateData, config)
+	creatorImages, err := getImagesFromCreators(log, templateData, config)
 	if err != nil {
 		return nil, fmt.Errorf("failed to get images from internal creator functions: %v", err)
 	}
@@ -257,9 +257,13 @@ func getImagesForVersion(log *zap.SugaredLogger, version *kubermaticversion.Vers
 	return images, nil
 }
 
-func getImagesFromCreators(templateData *resources.TemplateData, config *operatorv1alpha1.KubermaticConfiguration) (images []string, err error) {
+func getImagesFromCreators(log *zap.SugaredLogger, templateData *resources.TemplateData, config *operatorv1alpha1.KubermaticConfiguration) (images []string, err error) {
 	v := common.NewDefaultVersions()
-	seed := &kubermaticv1.Seed{}
+
+	seed, err := common.DefaultSeed(&kubermaticv1.Seed{}, log)
+	if err != nil {
+		return nil, fmt.Errorf("failed to default Seed: %v", err)
+	}
 
 	statefulsetCreators := kubernetescontroller.GetStatefulSetCreators(templateData, false)
 	statefulsetCreators = append(statefulsetCreators, monitoring.GetStatefulSetCreators(templateData)...)

--- a/cmd/image-loader/main.go
+++ b/cmd/image-loader/main.go
@@ -21,6 +21,8 @@ import (
 	"errors"
 	"flag"
 	"fmt"
+	"io/ioutil"
+	"os"
 
 	"github.com/Masterminds/semver"
 	"go.uber.org/zap"

--- a/cmd/image-loader/main_test.go
+++ b/cmd/image-loader/main_test.go
@@ -31,6 +31,11 @@ import (
 func TestRetagImageForAllVersions(t *testing.T) {
 	log := kubermaticlog.New(true, kubermaticlog.FormatConsole).Sugar()
 
+	// Cannot be set during go-test
+	resources.KUBERMATICCOMMIT = "latest"
+	common.KUBERMATICDOCKERTAG = resources.KUBERMATICCOMMIT
+	common.UIDOCKERTAG = resources.KUBERMATICCOMMIT
+
 	config, err := common.DefaultConfiguration(&operatorv1alpha1.KubermaticConfiguration{}, log)
 	if err != nil {
 		t.Errorf("failed to determine versions: %v", err)
@@ -38,9 +43,6 @@ func TestRetagImageForAllVersions(t *testing.T) {
 
 	versions := getVersionsFromKubermaticConfiguration(config)
 	addonPath := "../../addons"
-
-	// Cannot be set during go-test
-	resources.KUBERMATICCOMMIT = "latest"
 
 	imageSet := sets.NewString()
 	for _, v := range versions {

--- a/cmd/image-loader/main_test.go
+++ b/cmd/image-loader/main_test.go
@@ -44,7 +44,7 @@ func TestRetagImageForAllVersions(t *testing.T) {
 
 	imageSet := sets.NewString()
 	for _, v := range versions {
-		images, err := getImagesForVersion(log, v, addonPath)
+		images, err := getImagesForVersion(log, v, config, addonPath)
 		if err != nil {
 			t.Errorf("Error calling getImagesForVersion: %v", err)
 		}

--- a/cmd/image-loader/operator.go
+++ b/cmd/image-loader/operator.go
@@ -1,0 +1,69 @@
+/*
+Copyright 2020 The Kubermatic Kubernetes Platform contributors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package main
+
+import (
+	"fmt"
+	"io/ioutil"
+
+	"github.com/Masterminds/semver"
+	"go.uber.org/zap"
+	"gopkg.in/yaml.v2"
+
+	"k8c.io/kubermatic/v2/pkg/controller/operator/common"
+	operatorv1alpha1 "k8c.io/kubermatic/v2/pkg/crd/operator/v1alpha1"
+	kubermaticversion "k8c.io/kubermatic/v2/pkg/version"
+)
+
+func loadKubermaticConfiguration(log *zap.SugaredLogger, filename string) (*operatorv1alpha1.KubermaticConfiguration, error) {
+	log.Infow("Loading KubermaticConfiguration", "file", filename)
+
+	content, err := ioutil.ReadFile(filename)
+	if err != nil {
+		return nil, fmt.Errorf("failed to read file: %v", err)
+	}
+
+	config := &operatorv1alpha1.KubermaticConfiguration{}
+	if err := yaml.Unmarshal(content, &config); err != nil {
+		return nil, fmt.Errorf("failed to parse file as YAML: %v", err)
+	}
+
+	defaulted, err := common.DefaultConfiguration(config, log)
+	if err != nil {
+		return nil, fmt.Errorf("failed to process: %v", err)
+	}
+
+	return defaulted, nil
+}
+
+func getVersionsFromKubermaticConfiguration(config *operatorv1alpha1.KubermaticConfiguration) []*kubermaticversion.Version {
+	versions := []*kubermaticversion.Version{}
+
+	assembleVersions := func(kind string, configuredVersions []*semver.Version) {
+		for i := range configuredVersions {
+			versions = append(versions, &kubermaticversion.Version{
+				Version: configuredVersions[i],
+				Type:    kind,
+			})
+		}
+	}
+
+	assembleVersions("kubernetes", config.Spec.Versions.Kubernetes.Versions)
+	assembleVersions("openshift", config.Spec.Versions.Openshift.Versions)
+
+	return versions
+}

--- a/hack/ci/deploy-offline.sh
+++ b/hack/ci/deploy-offline.sh
@@ -56,7 +56,7 @@ export KUBECONFIG="/tmp/kubeconfig"
 kubectl config set clusters.kubernetes.server https://127.0.0.1:6443
 
 # port-forward the Docker registry and Kubernetes API
-ssh ${SSH_OPTS} -M -S /tmp/proxy-socket -fNT -L 5000:${REGISTRY}:5000 root@${PROXY_EXTERNAL_ADDR}
+ssh ${SSH_OPTS} -M -S /tmp/proxy-socket -fNT -L 5000:${REGISTRY} root@${PROXY_EXTERNAL_ADDR}
 ssh ${SSH_OPTS} -M -S /tmp/controller-socket -fNT -L 6443:127.0.0.1:6443 ${SSH_OPTS} \
   -o ProxyCommand="ssh ${SSH_OPTS} -W %h:%p root@${PROXY_EXTERNAL_ADDR}" \
   root@${KUBERNETES_CONTROLLER_ADDR}

--- a/hack/ci/deploy-offline.sh
+++ b/hack/ci/deploy-offline.sh
@@ -23,11 +23,11 @@ set -euo pipefail
 # receives a SIGINT
 set -o monitor
 
-cd "$(dirname "$0")/"
-source ../lib.sh
+cd "$(dirname "$0")/../.."
+source hack/lib.sh
 
 # Build and push images
-./push-images.sh
+./hack/ci/push-images.sh
 
 echodate "Getting secrets from Vault"
 export VAULT_ADDR=https://vault.loodse.com/
@@ -36,12 +36,13 @@ export VAULT_TOKEN=$(vault write \
   role_id=${VAULT_ROLE_ID} secret_id=${VAULT_SECRET_ID} \
   | jq .auth.client_token -r)
 
-export GIT_HEAD_HASH="$(git rev-parse HEAD|tr -d '\n')"
+export GIT_HEAD_HASH="$(git rev-parse HEAD | tr -d '\n')"
 
 rm -f /tmp/id_rsa
 vault kv get -field=key dev/e2e-machine-controller-ssh-key > /tmp/id_rsa
 chmod 400 /tmp/id_rsa
 
+REGISTRY=127.0.0.1:5000
 PROXY_EXTERNAL_ADDR="$(vault kv get -field=proxy-ip dev/gcp-offline-env)"
 PROXY_INTERNAL_ADDR="$(vault kv get -field=proxy-internal-ip dev/gcp-offline-env)"
 KUBERNETES_CONTROLLER_ADDR="$(vault kv get -field=controller-ip dev/gcp-offline-env)"
@@ -54,7 +55,8 @@ vault kv get -field=kubeconfig dev/gcp-offline-env > /tmp/kubeconfig
 export KUBECONFIG="/tmp/kubeconfig"
 kubectl config set clusters.kubernetes.server https://127.0.0.1:6443
 
-ssh ${SSH_OPTS} -M -S /tmp/proxy-socket -fNT -L 5000:127.0.0.1:5000 root@${PROXY_EXTERNAL_ADDR}
+# port-forward the Docker registry and Kubernetes API
+ssh ${SSH_OPTS} -M -S /tmp/proxy-socket -fNT -L 5000:${REGISTRY}:5000 root@${PROXY_EXTERNAL_ADDR}
 ssh ${SSH_OPTS} -M -S /tmp/controller-socket -fNT -L 6443:127.0.0.1:6443 ${SSH_OPTS} \
   -o ProxyCommand="ssh ${SSH_OPTS} -W %h:%p root@${PROXY_EXTERNAL_ADDR}" \
   root@${KUBERNETES_CONTROLLER_ADDR}
@@ -66,55 +68,48 @@ function finish {
 }
 trap finish EXIT
 
-# Ensure we have pushed all images from our helm chats in the local registry
-cd ../../charts
-helm template cert-manager | ../hack/retag-images.sh
-helm template nginx-ingress-controller | ../hack/retag-images.sh
-helm template oauth | ../hack/retag-images.sh
-helm template iap | ../hack/retag-images.sh
-helm template minio | ../hack/retag-images.sh
-helm template s3-exporter | ../hack/retag-images.sh
-helm template nodeport-proxy --set=nodePortProxy.image.tag=${GIT_HEAD_HASH} | ../hack/retag-images.sh
-
-helm template monitoring/prometheus | ../hack/retag-images.sh
-helm template monitoring/node-exporter | ../hack/retag-images.sh
-helm template monitoring/kube-state-metrics | ../hack/retag-images.sh
-helm template monitoring/grafana | ../hack/retag-images.sh
-helm template monitoring/helm-exporter | ../hack/retag-images.sh
-helm template monitoring/alertmanager | ../hack/retag-images.sh
-
-helm template logging/promtail | ../hack/retag-images.sh
-helm template logging/loki | ../hack/retag-images.sh
+# build the image loader
 
 # PULL_BASE_REF is the name of the current branch in case of a post-submit
 # or the name of the base branch in case of a PR.
-LATEST_DASHBOARD="$(get_latest_dashboard_hash "${PULL_BASE_REF}")"
+export UIDOCKERTAG="$(get_latest_dashboard_hash "${PULL_BASE_REF}")"
+export KUBERMATICCOMMIT="${GIT_HEAD_HASH}"
+export GITTAG="${GIT_HEAD_HASH}"
 
-HELM_EXTRA_ARGS="--set kubermatic.controller.image.tag=${GIT_HEAD_HASH},kubermatic.api.image.tag=${GIT_HEAD_HASH},kubermatic.masterController.image.tag=${GIT_HEAD_HASH},kubermatic.controller.addons.kubernetes.image.tag=${GIT_HEAD_HASH},kubermatic.controller.addons.openshift.image.tag=${GIT_HEAD_HASH},kubermatic.ui.image.tag=${LATEST_DASHBOARD}"
-helm template ${HELM_EXTRA_ARGS} kubermatic | ../hack/retag-images.sh
+make image-loader
+
+# push all images from KKP and Helm charts to the local registry
+cat <<EOF >> ${VALUES_FILE}
+kubermaticOperator:
+  image:
+    tag: ${GIT_HEAD_HASH}
+nodePortProxy:
+  image:
+    tag: ${GIT_HEAD_HASH}
+EOF
+
+_build/image-loader \
+  -configuration-file /dev/null \
+  -addons-path addons \
+  -charts-path charts \
+  -helm-binary helm3 \
+  -helm-values-file "${VALUES_FILE}" \
+  -registry "${REGISTRY}" \
+  -log-format=JSON
 
 # Push a tiller image
 docker pull gcr.io/kubernetes-helm/tiller:${HELM_VERSION}
-docker tag gcr.io/kubernetes-helm/tiller:${HELM_VERSION} 127.0.0.1:5000/kubernetes-helm/tiller:${HELM_VERSION}
-docker push 127.0.0.1:5000/kubernetes-helm/tiller:${HELM_VERSION}
+docker tag gcr.io/kubernetes-helm/tiller:${HELM_VERSION} ${REGISTRY}/kubernetes-helm/tiller:${HELM_VERSION}
+docker push ${REGISTRY}/kubernetes-helm/tiller:${HELM_VERSION}
 
-cd ..
-KUBERMATICCOMMIT=${GIT_HEAD_HASH} GITTAG=${GIT_HEAD_HASH} make image-loader
-retry 6 ./_build/image-loader \
-  -configuration-file /dev/null \
-  -addons-path addons \
-  -registry 127.0.0.1:5000 \
-  -log-format=Console
-
-## Deploy
+# Deploy
 HELM_INIT_ARGS="--tiller-image ${PROXY_INTERNAL_ADDR}:5000/kubernetes-helm/tiller:${HELM_VERSION}" \
   DEPLOY_STACK=kubermatic \
   DEPLOY_NODEPORT_PROXY=false \
   TILLER_NAMESPACE="kube-system" \
   ./hack/ci/deploy.sh \
   master \
-  ${VALUES_FILE} \
-  ${HELM_EXTRA_ARGS}
+  ${VALUES_FILE}
 
 HELM_INIT_ARGS="--tiller-image ${PROXY_INTERNAL_ADDR}:5000/kubernetes-helm/tiller:${HELM_VERSION}" \
   DEPLOY_STACK=monitoring \
@@ -122,8 +117,7 @@ HELM_INIT_ARGS="--tiller-image ${PROXY_INTERNAL_ADDR}:5000/kubernetes-helm/tille
   TILLER_NAMESPACE="kube-system" \
   ./hack/ci/deploy.sh \
   master \
-  ${VALUES_FILE} \
-  ${HELM_EXTRA_ARGS}
+  ${VALUES_FILE}
 
 HELM_INIT_ARGS="--tiller-image ${PROXY_INTERNAL_ADDR}:5000/kubernetes-helm/tiller:${HELM_VERSION}" \
   DEPLOY_STACK=logging \
@@ -132,5 +126,4 @@ HELM_INIT_ARGS="--tiller-image ${PROXY_INTERNAL_ADDR}:5000/kubernetes-helm/tille
   TILLER_NAMESPACE="kube-system" \
   ./hack/ci/deploy.sh \
   master \
-  ${VALUES_FILE} \
-  ${HELM_EXTRA_ARGS}
+  ${VALUES_FILE}

--- a/pkg/install/helm/cli.go
+++ b/pkg/install/helm/cli.go
@@ -61,16 +61,7 @@ func (c *cli) InstallChart(namespace string, releaseName string, chartDirectory 
 		"--timeout", c.timeout.String(),
 	}
 
-	set := make([]string, 0)
-
-	for name, value := range values {
-		set = append(set, fmt.Sprintf("%s=%s", name, value))
-	}
-
-	if len(set) > 0 {
-		command = append(command, "--set", strings.Join(set, ","))
-	}
-
+	command = append(command, valuesToFlags(values)...)
 	command = append(command, flags...)
 	command = append(command, releaseName, chartDirectory)
 
@@ -131,6 +122,19 @@ func (c *cli) UninstallRelease(namespace string, name string) error {
 	return err
 }
 
+func (c *cli) RenderChart(namespace string, releaseName string, chartDirectory string, valuesFile string, values map[string]string) ([]byte, error) {
+	command := []string{"template"}
+
+	if valuesFile != "" {
+		command = append(command, "--values", valuesFile)
+	}
+
+	command = append(command, valuesToFlags(values)...)
+	command = append(command, releaseName, chartDirectory)
+
+	return c.run(namespace, command...)
+}
+
 func (c *cli) Version() (*semver.Version, error) {
 	// add --client to gracefully handle Helm 2 (Helm 3 ignores the flag, thankfully);
 	// Helm 2 will output "<no value>", whereas Helm 3 would outright reject the
@@ -170,4 +174,18 @@ func (c *cli) run(namespace string, args ...string) ([]byte, error) {
 	}
 
 	return stdoutStderr, err
+}
+
+func valuesToFlags(values map[string]string) []string {
+	set := make([]string, 0)
+
+	for name, value := range values {
+		set = append(set, fmt.Sprintf("%s=%s", name, value))
+	}
+
+	if len(set) > 0 {
+		return []string{"--set", strings.Join(set, ",")}
+	}
+
+	return nil
 }

--- a/pkg/install/helm/cli.go
+++ b/pkg/install/helm/cli.go
@@ -177,7 +177,7 @@ func (c *cli) run(namespace string, args ...string) ([]byte, error) {
 }
 
 func valuesToFlags(values map[string]string) []string {
-	set := make([]string, 0)
+	set := make([]string, 0, len(values))
 
 	for name, value := range values {
 		set = append(set, fmt.Sprintf("%s=%s", name, value))

--- a/pkg/install/helm/interface.go
+++ b/pkg/install/helm/interface.go
@@ -23,8 +23,9 @@ import "github.com/Masterminds/semver"
 // perform a Kubermatic installation.
 type Client interface {
 	Version() (*semver.Version, error)
-	InstallChart(namespace string, releaseName string, chartDirectory, valuesFile string, values map[string]string, flags []string) error
+	InstallChart(namespace string, releaseName string, chartDirectory string, valuesFile string, values map[string]string, flags []string) error
 	GetRelease(namespace string, name string) (*Release, error)
 	ListReleases(namespace string) ([]Release, error)
 	UninstallRelease(namespace string, name string) error
+	RenderChart(namespace string, releaseName string, chartDirectory string, valuesFile string, values map[string]string) ([]byte, error)
 }

--- a/pkg/util/yaml/parse.go
+++ b/pkg/util/yaml/parse.go
@@ -1,0 +1,62 @@
+/*
+Copyright 2020 The Kubermatic Kubernetes Platform contributors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package yaml
+
+import (
+	"bufio"
+	"bytes"
+	"fmt"
+	"io"
+
+	"k8s.io/apimachinery/pkg/runtime"
+	kyaml "k8s.io/apimachinery/pkg/util/yaml"
+)
+
+func ParseMultipleDocuments(input io.Reader) ([]runtime.RawExtension, error) {
+	reader := kyaml.NewYAMLReader(bufio.NewReader(input))
+	objects := []runtime.RawExtension{}
+
+	for {
+		b, err := reader.Read()
+		if err != nil {
+			if err == io.EOF {
+				break
+			}
+			return nil, fmt.Errorf("failed reading from YAML reader: %v", err)
+		}
+
+		b = bytes.TrimSpace(b)
+		if len(b) == 0 {
+			continue
+		}
+
+		decoder := kyaml.NewYAMLToJSONDecoder(bytes.NewBuffer(b))
+		raw := runtime.RawExtension{}
+		if err := decoder.Decode(&raw); err != nil {
+			return nil, fmt.Errorf("decoding failed: %v", err)
+		}
+
+		// skip empty documents (e.g. documents that are only comments)
+		if len(raw.Raw) == 0 {
+			continue
+		}
+
+		objects = append(objects, raw)
+	}
+
+	return objects, nil
+}


### PR DESCRIPTION
**What this PR does / why we need it**:
Previously, we had a shell script to run `helm template [chart] | ./retag-images.sh`. This script would then sed/grep for anything that looks like `image: ....` and return it.

This PR moves this logic into the image-loader. As we already have a neat little Helm client for the installer, it's easy to just extend it to allow rendering Helm charts.

For addons we already have a logic that would parse the output (YAML), read it into []runtime.RawExtension and then look for PodSpecs in a type-safe manner. This is now reused for handling the Helm output as well, making it much, MUCH safer.

This now reduces the work for users who want to mirror KKP to just running the image-loader (and having Helm 3 installed on their system).

The fixes for the kubernetes-dashboard are just here because the image-loader parses _all_ charts and this chart was simply broken. It will soon be moved out of this repository anyway and is currently not used anywhere, so this can be disregarded in this PR.

**Does this PR introduce a user-facing change?**:
```release-note
NONE
```
