### PR TITLE
Remove hard dependency on cert-manager from Operator

### DIFF
--- a/cmd/kubermatic-installer/cmd_deploy.go
+++ b/cmd/kubermatic-installer/cmd_deploy.go
@@ -35,7 +35,6 @@ import (
 	"k8c.io/kubermatic/v2/pkg/resources"
 	"k8c.io/kubermatic/v2/pkg/util/edition"
 
-	certmanagerv1alpha2 "github.com/jetstack/cert-manager/pkg/apis/certmanager/v1alpha2"
 	apiextensionsv1beta1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1beta1"
 	"k8s.io/apimachinery/pkg/util/wait"
 	ctrlruntimeconfig "sigs.k8s.io/controller-runtime/pkg/client/config"
@@ -217,10 +216,6 @@ func DeployAction(logger *logrus.Logger) cli.ActionFunc {
 		}
 
 		if err := operatorv1alpha1.AddToScheme(mgr.GetScheme()); err != nil {
-			return fmt.Errorf("failed to add scheme: %v", err)
-		}
-
-		if err := certmanagerv1alpha2.AddToScheme(mgr.GetScheme()); err != nil {
 			return fmt.Errorf("failed to add scheme: %v", err)
 		}
 

--- a/cmd/kubermatic-operator/main.go
+++ b/cmd/kubermatic-operator/main.go
@@ -34,7 +34,6 @@ import (
 	"k8c.io/kubermatic/v2/pkg/provider"
 	"k8c.io/kubermatic/v2/pkg/signals"
 
-	certmanagerv1alpha2 "github.com/jetstack/cert-manager/pkg/apis/certmanager/v1alpha2"
 	"k8s.io/klog"
 	ctrl "sigs.k8s.io/controller-runtime"
 	ctrllog "sigs.k8s.io/controller-runtime/pkg/log"
@@ -105,10 +104,6 @@ func main() {
 
 	if err := operatorv1alpha1.AddToScheme(mgr.GetScheme()); err != nil {
 		log.Fatalw("Failed to register scheme", zap.Stringer("api", operatorv1alpha1.SchemeGroupVersion), zap.Error(err))
-	}
-
-	if err := certmanagerv1alpha2.AddToScheme(mgr.GetScheme()); err != nil {
-		log.Fatalw("Failed to register scheme", zap.Stringer("api", certmanagerv1alpha2.SchemeGroupVersion), zap.Error(err))
 	}
 
 	seedsGetter, err := seedsGetterFactory(ctx, mgr.GetClient(), opt)

--- a/pkg/controller/operator/master/controller.go
+++ b/pkg/controller/operator/master/controller.go
@@ -26,7 +26,6 @@ import (
 	predicateutil "k8c.io/kubermatic/v2/pkg/controller/util/predicate"
 	operatorv1alpha1 "k8c.io/kubermatic/v2/pkg/crd/operator/v1alpha1"
 
-	certmanagerv1alpha2 "github.com/jetstack/cert-manager/pkg/apis/certmanager/v1alpha2"
 	admissionregistrationv1beta1 "k8s.io/api/admissionregistration/v1beta1"
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
@@ -129,7 +128,6 @@ func Add(
 		&corev1.ServiceAccount{},
 		&extensionsv1beta1.Ingress{},
 		&policyv1beta1.PodDisruptionBudget{},
-		&certmanagerv1alpha2.Certificate{},
 	}
 
 	for _, t := range namespacedTypesToWatch {

--- a/pkg/controller/operator/master/reconciler.go
+++ b/pkg/controller/operator/master/reconciler.go
@@ -138,10 +138,6 @@ func (r *Reconciler) reconcile(config *operatorv1alpha1.KubermaticConfiguration,
 		return err
 	}
 
-	if err := r.reconcileCertificates(config, logger); err != nil {
-		return err
-	}
-
 	if err := r.reconcileAdmissionWebhooks(config, logger); err != nil {
 		return err
 	}
@@ -326,30 +322,6 @@ func (r *Reconciler) reconcileIngresses(config *operatorv1alpha1.KubermaticConfi
 
 	if err := reconciling.ReconcileIngresses(r.ctx, creators, config.Namespace, r.Client, common.OwnershipModifierFactory(config, r.scheme)); err != nil {
 		return fmt.Errorf("failed to reconcile Ingresses: %v", err)
-	}
-
-	return nil
-}
-
-func (r *Reconciler) reconcileCertificates(config *operatorv1alpha1.KubermaticConfiguration, logger *zap.SugaredLogger) error {
-	if config.Spec.Ingress.Disable {
-		logger.Debug("Skipping Certificate creation because Ingress creation is disabled")
-		return nil
-	}
-
-	if config.Spec.Ingress.CertificateIssuer.Name == "" {
-		logger.Debug("Skipping Certificate creation because no certificateIssuer has been configured")
-		return nil
-	}
-
-	logger.Debug("Reconciling Certificates")
-
-	creators := []reconciling.NamedCertificateCreatorGetter{
-		kubermatic.CertificateCreator(config),
-	}
-
-	if err := reconciling.ReconcileCertificates(r.ctx, creators, config.Namespace, r.Client, common.OwnershipModifierFactory(config, r.scheme)); err != nil {
-		return fmt.Errorf("failed to reconcile Certificates: %v", err)
 	}
 
 	return nil

--- a/pkg/controller/operator/master/resources/kubermatic/common.go
+++ b/pkg/controller/operator/master/resources/kubermatic/common.go
@@ -17,7 +17,6 @@ limitations under the License.
 package kubermatic
 
 import (
-	"errors"
 	"fmt"
 
 	operatorv1alpha1 "k8c.io/kubermatic/v2/pkg/crd/operator/v1alpha1"
@@ -38,7 +37,6 @@ const (
 	uiDeploymentName      = "kubermatic-dashboard"
 	apiServiceName        = "kubermatic-api"
 	uiServiceName         = "kubermatic-dashboard"
-	certificateName       = "kubermatic"
 	certificateSecretName = "kubermatic-tls"
 )
 
@@ -100,9 +98,23 @@ func IngressCreator(cfg *operatorv1alpha1.KubermaticConfiguration) reconciling.N
 			}
 			i.Annotations["kubernetes.io/ingress.class"] = cfg.Spec.Ingress.ClassName
 
-			// If a Certificate is being issued, reference it,
-			// otherwise leave any possible customization intact.
-			if cfg.Spec.Ingress.CertificateIssuer.Name != "" {
+			// If a Certificate is being issued, configure cert-manager by
+			// setting up the required annoations.
+			issuer := cfg.Spec.Ingress.CertificateIssuer
+
+			if issuer.Name != "" {
+				delete(i.Annotations, certmanagerv1alpha2.IngressIssuerNameAnnotationKey)
+				delete(i.Annotations, certmanagerv1alpha2.IngressClusterIssuerNameAnnotationKey)
+
+				switch issuer.Kind {
+				case certmanagerv1alpha2.IssuerKind:
+					i.Annotations[certmanagerv1alpha2.IngressIssuerNameAnnotationKey] = issuer.Name
+				case certmanagerv1alpha2.ClusterIssuerKind:
+					i.Annotations[certmanagerv1alpha2.IngressClusterIssuerNameAnnotationKey] = issuer.Name
+				default:
+					return nil, fmt.Errorf("unknown Certificate Issuer Kind %q configured", issuer.Kind)
+				}
+
 				i.Spec.TLS = []extensionsv1beta1.IngressTLS{
 					{
 						Hosts:      []string{cfg.Spec.Ingress.Domain},
@@ -159,29 +171,6 @@ func IngressCreator(cfg *operatorv1alpha1.KubermaticConfiguration) reconciling.N
 			}
 
 			return i, nil
-		}
-	}
-}
-
-func CertificateCreator(cfg *operatorv1alpha1.KubermaticConfiguration) reconciling.NamedCertificateCreatorGetter {
-	return func() (string, reconciling.CertificateCreator) {
-		return certificateName, func(c *certmanagerv1alpha2.Certificate) (*certmanagerv1alpha2.Certificate, error) {
-			name := cfg.Spec.Ingress.CertificateIssuer.Name
-			if name == "" {
-				return nil, errors.New("no certificateIssuer configured in KubermaticConfiguration, this creator should not have been called")
-			}
-
-			c.Spec.IssuerRef.Name = name
-			c.Spec.IssuerRef.Kind = cfg.Spec.Ingress.CertificateIssuer.Kind
-
-			if group := cfg.Spec.Ingress.CertificateIssuer.APIGroup; group != nil {
-				c.Spec.IssuerRef.Group = *group
-			}
-
-			c.Spec.SecretName = certificateSecretName
-			c.Spec.DNSNames = []string{cfg.Spec.Ingress.Domain}
-
-			return c, nil
 		}
 	}
 }

--- a/pkg/install/stack/kubermatic/stack.go
+++ b/pkg/install/stack/kubermatic/stack.go
@@ -174,6 +174,12 @@ func deployNginxIngressController(ctx context.Context, logger *logrus.Entry, kub
 func deployCertManager(ctx context.Context, logger *logrus.Entry, kubeClient ctrlruntimeclient.Client, helmClient helm.Client, opt Options) error {
 	logger.Info("📦 Deploying cert-manager…")
 	sublogger := log.Prefix(logger, "   ")
+
+	if opt.KubermaticConfiguration.Spec.Ingress.CertificateIssuer.Name == "" {
+		sublogger.Info("No CertificateIssuer configured in KubermaticConfiguration, skipping.")
+		return nil
+	}
+
 	chartDir := filepath.Join(opt.ChartsDirectory, "cert-manager")
 
 	chart, err := helm.LoadChart(chartDir)

--- a/pkg/install/stack/kubermatic/validation.go
+++ b/pkg/install/stack/kubermatic/validation.go
@@ -58,10 +58,6 @@ func validateKubermaticConfiguration(config *operatorv1alpha1.KubermaticConfigur
 		if config.Spec.Ingress.Domain == "" {
 			failures = append(failures, errors.New("spec.ingress.domain cannot be left empty"))
 		}
-
-		if config.Spec.Ingress.CertificateIssuer.Name == "" {
-			failures = append(failures, errors.New("spec.ingress.certificateIssuer.name cannot be left empty"))
-		}
 	}
 
 	failures = validateRandomSecret(config, config.Spec.Auth.ServiceAccountKey, "spec.auth.serviceAccountKey", failures)


### PR DESCRIPTION
**What this PR does / why we need it**:
This somehow got lost when doing #5969 and #5962. This PR makes cert-manager optional for the Operator (though certificates are still required for KKP to work properly).

This not just removes a dependency from our codebase (one less scheme to load), but also gives users more freedom to manage the certificates on their own in the Ingresses.

**Does this PR introduce a user-facing change?**:
```release-note
Operator does not require cert-manager to be installed; certificates are configured via Ingress annotations instead.
```
