### PR TITLE
[release/v2.13] cleanup image-loader (#6063)

### DIFF
--- a/api/cmd/image-loader/README.md
+++ b/api/cmd/image-loader/README.md
@@ -1,6 +1,6 @@
 # image-loader
 
-A little utility that downloads all required Docker images for kubermatic, retags then
-and pushes them.
+A little utility that downloads all required Docker images for KKP, retags them
+and pushes them to a local registry.
 
-Synopsis: `image-loader -logtostderr -v 2 -registry-name registry.corp.com`
+Synopsis: `image-loader -registry-name registry.corp.com -versions-file VERSIONS.yaml`

--- a/api/cmd/image-loader/main_test.go
+++ b/api/cmd/image-loader/main_test.go
@@ -26,14 +26,14 @@ func TestRetagImageForAllVersions(t *testing.T) {
 
 	imageSet := sets.NewString()
 	for _, v := range versions {
-		images, err := getImagesForVersion(log.Desugar(), v, addonPath)
+		images, err := getImagesForVersion(log, v, addonPath)
 		if err != nil {
 			t.Errorf("Error calling getImagesForVersion: %v", err)
 		}
 		imageSet.Insert(images...)
 	}
 
-	if err := processImages(context.Background(), log.Desugar(), true, imageSet.List(), "test-registry:5000"); err != nil {
+	if err := processImages(context.Background(), log, true, imageSet.List(), "test-registry:5000"); err != nil {
 		t.Errorf("Error calling processImages: %v", err)
 	}
 }

--- a/api/pkg/docker/docker.go
+++ b/api/pkg/docker/docker.go
@@ -12,8 +12,8 @@ import (
 )
 
 // execCommand is an internal helper function to execute commands and log them
-func execCommand(log *zap.Logger, dryRun bool, cmd *exec.Cmd) error {
-	log = log.With(zap.String("command", strings.Join(cmd.Args, " ")))
+func execCommand(log *zap.SugaredLogger, dryRun bool, cmd *exec.Cmd) error {
+	log = log.With("command", strings.Join(cmd.Args, " "))
 	if dryRun {
 		log.Info("Would execute Docker command but this is a dry-run")
 		return nil
@@ -33,7 +33,7 @@ func execCommand(log *zap.Logger, dryRun bool, cmd *exec.Cmd) error {
 
 // DownloadImages pulls all given images using the Docker CLI
 // Invokes DownloadImage for actual pulling
-func DownloadImages(ctx context.Context, log *zap.Logger, dryRun bool, images []string) error {
+func DownloadImages(ctx context.Context, log *zap.SugaredLogger, dryRun bool, images []string) error {
 	for _, image := range images {
 		select {
 		case <-ctx.Done():
@@ -49,8 +49,8 @@ func DownloadImages(ctx context.Context, log *zap.Logger, dryRun bool, images []
 }
 
 // DownloadImage invokes the Docker CLI and pulls an image
-func DownloadImage(ctx context.Context, log *zap.Logger, dryRun bool, image string) error {
-	log = log.With(zap.String("image", image))
+func DownloadImage(ctx context.Context, log *zap.SugaredLogger, dryRun bool, image string) error {
+	log = log.With("image", image)
 	log.Info("Downloading image...")
 
 	cmd := exec.CommandContext(ctx, "docker", "pull", image)
@@ -63,7 +63,7 @@ func DownloadImage(ctx context.Context, log *zap.Logger, dryRun bool, image stri
 
 // RetagImages invokes the Docker CLI and tags the given images so they belongs to the given registry.
 // Invokes RetagImage for actual tagging
-func RetagImages(ctx context.Context, log *zap.Logger, dryRun bool, images []string, registry string) ([]string, error) {
+func RetagImages(ctx context.Context, log *zap.SugaredLogger, dryRun bool, images []string, registry string) ([]string, error) {
 	var retaggedImages []string
 	for _, image := range images {
 		select {
@@ -83,8 +83,8 @@ func RetagImages(ctx context.Context, log *zap.Logger, dryRun bool, images []str
 }
 
 // RetagImage invokes the Docker CLI and tags the given image so it belongs to the given registry.
-func RetagImage(ctx context.Context, log *zap.Logger, dryRun bool, sourceImage, registry string) (string, error) {
-	log = log.With(zap.String("source-image", sourceImage))
+func RetagImage(ctx context.Context, log *zap.SugaredLogger, dryRun bool, sourceImage, registry string) (string, error) {
+	log = log.With("source-image", sourceImage)
 	imageRef, err := reference.ParseNamed(sourceImage)
 	if err != nil {
 		return "", fmt.Errorf("failed to parse image: %v", err)
@@ -95,7 +95,7 @@ func RetagImage(ctx context.Context, log *zap.Logger, dryRun bool, sourceImage, 
 	}
 
 	targetImage := fmt.Sprintf("%s/%s:%s", registry, reference.Path(imageRef), taggedImageRef.Tag())
-	log = log.With(zap.String("target-image", targetImage))
+	log = log.With("target-image", targetImage)
 
 	log.Info("Tagging image...")
 	cmd := exec.CommandContext(ctx, "docker", "tag", sourceImage, targetImage)
@@ -108,7 +108,7 @@ func RetagImage(ctx context.Context, log *zap.Logger, dryRun bool, sourceImage, 
 
 // PushImages pushes all given images using the Docker CLI
 // Invokes PushImage for actual pushing
-func PushImages(ctx context.Context, log *zap.Logger, dryRun bool, images []string) error {
+func PushImages(ctx context.Context, log *zap.SugaredLogger, dryRun bool, images []string) error {
 	for _, image := range images {
 		select {
 		case <-ctx.Done():
@@ -124,8 +124,8 @@ func PushImages(ctx context.Context, log *zap.Logger, dryRun bool, images []stri
 }
 
 // PushImage invokes the Docker CLI and pushes the given image
-func PushImage(ctx context.Context, log *zap.Logger, dryRun bool, image string) error {
-	log = log.With(zap.String("image", image))
+func PushImage(ctx context.Context, log *zap.SugaredLogger, dryRun bool, image string) error {
+	log = log.With("image", image)
 
 	log.Info("Pushing image...")
 	cmd := exec.CommandContext(ctx, "docker", "push", image)


### PR DESCRIPTION
**What this PR does / why we need it**:
This backports the relevant parts from #6063 into the 2.13 release. This release does not yet support the Operator, so the backport only contains the other minor cleanup things, to make the other backports easier.

**Does this PR introduce a user-facing change?**:
```release-note
NONE
```
