### PR TITLE
Handle warnings/errors in Helm CLI client

### DIFF
--- a/pkg/install/helm/cli.go
+++ b/pkg/install/helm/cli.go
@@ -164,10 +164,16 @@ func (c *cli) run(namespace string, args ...string) ([]byte, error) {
 
 	c.logger.Debugf("$ KUBECONFIG=%s %s", c.kubeconfig, strings.Join(cmd.Args, " "))
 
-	stdoutStderr, err := cmd.CombinedOutput()
+	stdout := &bytes.Buffer{}
+	stderr := &bytes.Buffer{}
+
+	cmd.Stdout = stdout
+	cmd.Stderr = stderr
+
+	err := cmd.Run()
 	if err != nil {
-		err = errors.New(strings.TrimSpace(string(stdoutStderr)))
+		err = errors.New(strings.TrimSpace(stderr.String()))
 	}
 
-	return stdoutStderr, err
+	return stdout.Bytes(), err
 }


### PR DESCRIPTION
**What this PR does / why we need it**:
With v3.3.2, Helm started to check the file mode for the given kubeconfig (https://github.com/helm/helm/pull/8748). If the kuebconfig is world-readable, it issues a warning on stderr. Before this PR, our Helm CLI Client just combined stdout and stderr for simplicity, but this won't work anymore.

This PR splits stdout and stderr again, fixing the version check.

**Which issue(s) this PR fixes**:
Fixes #6070

**Does this PR introduce a user-facing change?**:
```release-note
Improve Helm error handling in KKP Installer
```
