### PR TITLE
Do not consider stderr when running helm commands

### DIFF
--- a/pkg/install/helm/cli.go
+++ b/pkg/install/helm/cli.go
@@ -164,10 +164,12 @@ func (c *cli) run(namespace string, args ...string) ([]byte, error) {
 
 	c.logger.Debugf("$ KUBECONFIG=%s %s", c.kubeconfig, strings.Join(cmd.Args, " "))
 
-	stdoutStderr, err := cmd.CombinedOutput()
-	if err != nil {
-		err = errors.New(strings.TrimSpace(string(stdoutStderr)))
+	// when return code is greater than 0 the stderr is captured and included
+	// in the error, otherwise it is just ignored as it probably contains
+	// warnings.
+	out, err := cmd.Output()
+	if ee, ok := err.(*exec.ExitError); ok {
+		return out, fmt.Errorf("error occurred while executing helm command: %s", ee.Stderr)
 	}
-
-	return stdoutStderr, err
+	return out, err
 }


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR fixes a bug in the helm client that runs the helm binary. The client runs the helm binary and gets the combined output (stderr + stdout). This breaks some commands e.g. `Version()` when helm is outputting some warnings in the stderr.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Documentation**:
<!-- Add links to the related documentation changes related to this pull request. E.g. the link to the kubermatic/docs pullrequest. -->

**Does this PR introduce a user-facing change?**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If  no release note is required, just write "NONE".
-->
```release-note
NONE
```
