### PR TITLE
Fix CI offline deployment

### DIFF
--- a/charts/iap/Chart.yaml
+++ b/charts/iap/Chart.yaml
@@ -14,7 +14,7 @@
 
 apiVersion: v1
 name: iap
-version: 3.0.2
+version: 3.0.3
 appVersion: v6.1.1
 description: A Helm chart to install OAuth2-Proxy as an identity-aware proxy.
 keywords:

--- a/charts/iap/values.yaml
+++ b/charts/iap/values.yaml
@@ -18,9 +18,9 @@ iap:
     tag: v6.1.1
     pullPolicy: IfNotPresent
 
-  # secret which holds the CA certificates that should be used when connecting to the provider  
-  # custom_provider_ca_secret: provider-ca-secret 
-  
+  # secret which holds the CA certificates that should be used when connecting to the provider
+  # custom_provider_ca_secret: provider-ca-secret
+
   oidc_issuer_url: https://kubermatic.tld/dex
   port: 3000
 
@@ -49,7 +49,7 @@ iap:
     #   upstream_port: 9093
     #   ingress:
     #     host: "alertmanager.kubermatic.tld"
-    #     annotations: {}1
+    #     annotations: {}
     #
     # grafana:
     #   name: grafana

--- a/cmd/image-loader/main.go
+++ b/cmd/image-loader/main.go
@@ -193,7 +193,7 @@ func main() {
 
 		images, err := getImagesForHelmCharts(ctx, log, kubermaticConfig, o.chartsPath, o.helmValuesPath, o.helmBinary)
 		if err != nil {
-			log.Fatal("Failed to get images", zap.Error(err))
+			log.Fatalw("Failed to get images", zap.Error(err))
 		}
 		imageSet.Insert(images...)
 	}
@@ -512,7 +512,7 @@ func getVersions(log *zap.SugaredLogger, config *operatorv1alpha1.KubermaticConf
 
 		var err error
 
-		log.Debug("Loading versions", "file", versionsFile)
+		log.Debugw("Loading versions", "file", versionsFile)
 		versions, err = kubermaticversion.LoadVersions(versionsFile)
 		if err != nil {
 			return nil, err

--- a/hack/ci/deploy-offline.sh
+++ b/hack/ci/deploy-offline.sh
@@ -83,9 +83,24 @@ cat <<EOF >> ${VALUES_FILE}
 kubermaticOperator:
   image:
     tag: ${GIT_HEAD_HASH}
+  imagePullSecret: '{}'
+
 nodePortProxy:
   image:
     tag: ${GIT_HEAD_HASH}
+
+iap:
+  deployments:
+    dummy:
+      name: dummy
+      client_id: dummy
+      client_secret: xxx
+      encryption_key: xxx
+      upstream_service: example.com.svc.cluster.local
+      upstream_port: 9093
+      ingress:
+        host: "dummy.example.com"
+        annotations: {}
 EOF
 
 _build/image-loader \


### PR DESCRIPTION
**What this PR does / why we need it**:
The ol' nodeport-proxy Chart still requires some valid imagepullsecret to render the chart. This PR fixes the missing dummy value and also configures a dummy IAP, because the oauth-proxy Docker image is important to have.

**Does this PR introduce a user-facing change?**:
```release-note
NONE
```
