### PR TITLE
[release/v2.13] Backport image-loader Improvements (#6066, #6067)

### DIFF
--- a/api/Gopkg.lock
+++ b/api/Gopkg.lock
@@ -2300,6 +2300,7 @@
     "sigs.k8s.io/controller-runtime/pkg/log",
     "sigs.k8s.io/controller-runtime/pkg/log/zap",
     "sigs.k8s.io/controller-runtime/pkg/manager",
+    "sigs.k8s.io/controller-runtime/pkg/manager/signals",
     "sigs.k8s.io/controller-runtime/pkg/metrics",
     "sigs.k8s.io/controller-runtime/pkg/predicate",
     "sigs.k8s.io/controller-runtime/pkg/reconcile",

--- a/api/cmd/image-loader/addons.go
+++ b/api/cmd/image-loader/addons.go
@@ -1,0 +1,81 @@
+/*
+Copyright 2020 The Kubermatic Kubernetes Platform contributors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package main
+
+import (
+	"fmt"
+	"io/ioutil"
+	"path"
+
+	"go.uber.org/zap"
+
+	addonutil "github.com/kubermatic/kubermatic/api/pkg/addon"
+	kubermaticv1 "github.com/kubermatic/kubermatic/api/pkg/crd/kubermatic/v1"
+	"github.com/kubermatic/kubermatic/api/pkg/resources"
+
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/serializer/json"
+	"k8s.io/client-go/kubernetes/scheme"
+)
+
+func getImagesFromAddons(log *zap.SugaredLogger, addonsPath string, cluster *kubermaticv1.Cluster) ([]string, error) {
+	addonData := &addonutil.TemplateData{
+		Credentials: resources.Credentials{},
+		Cluster:     cluster,
+	}
+
+	infos, err := ioutil.ReadDir(addonsPath)
+	if err != nil {
+		return nil, fmt.Errorf("unable to list addons: %v", err)
+	}
+
+	serializer := json.NewSerializer(&json.SimpleMetaFactory{}, scheme.Scheme, scheme.Scheme, false)
+	var images []string
+	for _, info := range infos {
+		if !info.IsDir() {
+			continue
+		}
+		addonName := info.Name()
+		addonImages, err := getImagesFromAddon(log, path.Join(addonsPath, addonName), serializer, addonData)
+		if err != nil {
+			return nil, fmt.Errorf("failed to get images for addon %s: %v", addonName, err)
+		}
+		images = append(images, addonImages...)
+	}
+
+	return images, nil
+}
+
+func getImagesFromAddon(log *zap.SugaredLogger, addonPath string, decoder runtime.Decoder, data *addonutil.TemplateData) ([]string, error) {
+	log = log.With("addon", path.Base(addonPath))
+	log.Debug("Processing manifests...")
+
+	allManifests, err := addonutil.ParseFromFolder(log, "", addonPath, data)
+	if err != nil {
+		return nil, fmt.Errorf("failed to parse addon templates in %s: %v", addonPath, err)
+	}
+
+	var images []string
+	for _, manifest := range allManifests {
+		manifestImages, err := getImagesFromManifest(log, decoder, manifest.Raw)
+		if err != nil {
+			return nil, err
+		}
+		images = append(images, manifestImages...)
+	}
+	return images, nil
+}

--- a/api/cmd/image-loader/helm.go
+++ b/api/cmd/image-loader/helm.go
@@ -1,0 +1,123 @@
+/*
+Copyright 2020 The Kubermatic Kubernetes Platform contributors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package main
+
+import (
+	"bytes"
+	"context"
+	"fmt"
+	"os"
+	"path/filepath"
+	"sort"
+	"time"
+
+	"github.com/Masterminds/semver"
+	"github.com/sirupsen/logrus"
+	"go.uber.org/zap"
+
+	"github.com/kubermatic/kubermatic/api/pkg/install/helm"
+	yamlutil "github.com/kubermatic/kubermatic/api/pkg/util/yaml"
+
+	"k8s.io/apimachinery/pkg/runtime/serializer/json"
+	"k8s.io/client-go/kubernetes/scheme"
+)
+
+func getImagesForHelmCharts(ctx context.Context, log *zap.SugaredLogger, chartsPath string, valuesFile string, helmBinary string) ([]string, error) {
+	if info, err := os.Stat(chartsPath); err != nil || !info.IsDir() {
+		return nil, fmt.Errorf("%s is not a valid directory", chartsPath)
+	}
+
+	chartPaths, err := findHelmCharts(chartsPath)
+	if err != nil {
+		return nil, fmt.Errorf("failed to find Helm charts: %v", err)
+	}
+
+	helmClient, err := getHelmClient(helmBinary)
+	if err != nil {
+		return nil, fmt.Errorf("failed to create Helm client: %v", err)
+	}
+
+	images := []string{}
+	serializer := json.NewSerializer(&json.SimpleMetaFactory{}, scheme.Scheme, scheme.Scheme, false)
+
+	for _, chartPath := range chartPaths {
+		chartName := filepath.Base(chartPath)
+		chartLog := log.With("path", chartPath, "chart", chartName)
+
+		chartLog.Info("Rendering chart")
+
+		rendered, err := helmClient.RenderChart(mockNamespaceName, chartName, chartPath, valuesFile, nil)
+		if err != nil {
+			return nil, fmt.Errorf("failed to render Helm chart %q: %v", chartName, err)
+		}
+
+		manifests, err := yamlutil.ParseMultipleDocuments(bytes.NewReader(rendered))
+		if err != nil {
+			return nil, fmt.Errorf("failed to decode YAML: %v", err)
+		}
+
+		for _, manifest := range manifests {
+			manifestImages, err := getImagesFromManifest(log, serializer, manifest.Raw)
+			if err != nil {
+				return nil, fmt.Errorf("failed to parse manifests: %v", err)
+			}
+
+			images = append(images, manifestImages...)
+		}
+	}
+
+	return images, nil
+}
+
+func getHelmClient(binary string) (helm.Client, error) {
+	helmClient, err := helm.NewCLI(binary, "", "", 10*time.Second, logrus.New())
+	if err != nil {
+		return nil, fmt.Errorf("failed to create Helm client: %v", err)
+	}
+
+	helmVersion, err := helmClient.Version()
+	if err != nil {
+		return nil, fmt.Errorf("failed to check Helm version: %v", err)
+	}
+
+	if helmVersion.LessThan(semver.MustParse("3.0.0")) {
+		return nil, fmt.Errorf("the image-loader requires Helm 3, detected %s", helmVersion.String())
+	}
+
+	return helmClient, nil
+}
+
+// findHelmCharts walks the root directory and finds Chart.yaml files. It
+// then returns the found directory paths (without the "/Chart.yaml" filename).
+func findHelmCharts(root string) ([]string, error) {
+	charts := []string{}
+
+	err := filepath.Walk(root, func(path string, info os.FileInfo, err error) error {
+		if info.IsDir() {
+			if _, err := os.Stat(filepath.Join(path, "Chart.yaml")); err == nil {
+				charts = append(charts, path)
+				return filepath.SkipDir
+			}
+		}
+
+		return nil
+	})
+
+	sort.Strings(charts)
+
+	return charts, err
+}

--- a/api/cmd/image-loader/main.go
+++ b/api/cmd/image-loader/main.go
@@ -6,12 +6,10 @@ import (
 	"fmt"
 	"io/ioutil"
 	"os"
-	"path"
 
 	"github.com/Masterminds/semver"
 	"go.uber.org/zap"
 
-	addonutil "github.com/kubermatic/kubermatic/api/pkg/addon"
 	apiv1 "github.com/kubermatic/kubermatic/api/pkg/api/v1"
 	kubernetescontroller "github.com/kubermatic/kubermatic/api/pkg/controller/seed-controller-manager/kubernetes"
 	"github.com/kubermatic/kubermatic/api/pkg/controller/seed-controller-manager/monitoring"
@@ -37,9 +35,8 @@ import (
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/serializer/json"
 	"k8s.io/apimachinery/pkg/util/sets"
-	"k8s.io/client-go/kubernetes/scheme"
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
-	"sigs.k8s.io/controller-runtime/pkg/runtime/signals"
+	"sigs.k8s.io/controller-runtime/pkg/manager/signals"
 )
 
 const mockNamespaceName = "mock-namespace"
@@ -49,12 +46,15 @@ var (
 )
 
 type opts struct {
-	versionsFile  string
-	versionFilter string
-	registry      string
-	dryRun        bool
-	addonsPath    string
-	addonsImage   string
+	versionsFile   string
+	versionFilter  string
+	registry       string
+	dryRun         bool
+	addonsPath     string
+	addonsImage    string
+	chartsPath     string
+	helmValuesPath string
+	helmBinary     string
 }
 
 func main() {
@@ -69,6 +69,9 @@ func main() {
 	flag.BoolVar(&o.dryRun, "dry-run", false, "Only print the names of found images")
 	flag.StringVar(&o.addonsPath, "addons-path", "", "Path to a directory containing the KKP addons, if not given, falls back to -addons-image, then the Docker image configured in the KubermaticConfiguration")
 	flag.StringVar(&o.addonsImage, "addons-image", "", "Docker image containing KKP addons, if not given, falls back to the Docker image configured in the KubermaticConfiguration")
+	flag.StringVar(&o.chartsPath, "charts-path", "", "Path to the folder containing all Helm charts")
+	flag.StringVar(&o.helmValuesPath, "helm-values-file", "", "Use this values.yaml file when rendering the Helm charts (-charts-path)")
+	flag.StringVar(&o.helmBinary, "helm-binary", "helm", "Helm 3.x binary to use for rendering the charts")
 	flag.Parse()
 
 	rawLog := kubermaticlog.New(logOpts.Debug, logOpts.Format)
@@ -141,6 +144,16 @@ func main() {
 		imageSet.Insert(images...)
 	}
 
+	if o.chartsPath != "" {
+		log.Infow("Rendering Helm charts", "directory", o.chartsPath)
+
+		images, err := getImagesForHelmCharts(ctx, log, o.chartsPath, o.helmValuesPath, o.helmBinary)
+		if err != nil {
+			log.Fatal("Failed to get images", zap.Error(err))
+		}
+		imageSet.Insert(images...)
+	}
+
 	if err := processImages(ctx, log, o.dryRun, imageSet.List(), o.registry); err != nil {
 		log.Fatalw("Failed to process images", zap.Error(err))
 	}
@@ -187,7 +200,7 @@ func getImagesForVersion(log *zap.SugaredLogger, version *kubermaticversion.Vers
 		return nil, err
 	}
 
-	creatorImages, err := getImagesFromCreators(templateData)
+	creatorImages, err := getImagesFromCreators(log, templateData)
 	if err != nil {
 		return nil, fmt.Errorf("failed to get images from internal creator functions: %v", err)
 	}
@@ -202,7 +215,7 @@ func getImagesForVersion(log *zap.SugaredLogger, version *kubermaticversion.Vers
 	return images, nil
 }
 
-func getImagesFromCreators(templateData *resources.TemplateData) (images []string, err error) {
+func getImagesFromCreators(log *zap.SugaredLogger, templateData *resources.TemplateData) (images []string, err error) {
 	statefulsetCreators := kubernetescontroller.GetStatefulSetCreators(templateData, false)
 	statefulsetCreators = append(statefulsetCreators, monitoring.GetStatefulSetCreators(templateData)...)
 
@@ -460,55 +473,6 @@ func getVersions(log *zap.SugaredLogger, versionsFile, versionFilter string) ([]
 		}
 	}
 	return filteredVersions, nil
-}
-
-func getImagesFromAddons(log *zap.SugaredLogger, addonsPath string, cluster *kubermaticv1.Cluster) ([]string, error) {
-	addonData := &addonutil.TemplateData{
-		Cluster:           cluster,
-		MajorMinorVersion: cluster.Spec.Version.MajorMinor(),
-		Addon:             &kubermaticv1.Addon{},
-		Variables:         map[string]interface{}{},
-	}
-	infos, err := ioutil.ReadDir(addonsPath)
-	if err != nil {
-		return nil, fmt.Errorf("unable to list addons: %v", err)
-	}
-
-	serializer := json.NewSerializer(&json.SimpleMetaFactory{}, scheme.Scheme, scheme.Scheme, false)
-	var images []string
-	for _, info := range infos {
-		if !info.IsDir() {
-			continue
-		}
-		addonName := info.Name()
-		addonImages, err := getImagesFromAddon(log, path.Join(addonsPath, addonName), serializer, addonData)
-		if err != nil {
-			return nil, fmt.Errorf("failed to get images for addon %s: %v", addonName, err)
-		}
-		images = append(images, addonImages...)
-	}
-
-	return images, nil
-}
-
-func getImagesFromAddon(log *zap.SugaredLogger, addonPath string, decoder runtime.Decoder, data *addonutil.TemplateData) ([]string, error) {
-	log = log.With("addon", path.Base(addonPath))
-	log.Debug("Processing manifests...")
-
-	allManifests, err := addonutil.ParseFromFolder(log, "", addonPath, data)
-	if err != nil {
-		return nil, fmt.Errorf("failed to parse addon templates in %s: %v", addonPath, err)
-	}
-
-	var images []string
-	for _, manifest := range allManifests {
-		manifestImages, err := getImagesFromManifest(log, decoder, manifest.Raw)
-		if err != nil {
-			return nil, err
-		}
-		images = append(images, manifestImages...)
-	}
-	return images, nil
 }
 
 func getImagesFromManifest(log *zap.SugaredLogger, decoder runtime.Decoder, b []byte) ([]string, error) {

--- a/api/cmd/image-loader/main.go
+++ b/api/cmd/image-loader/main.go
@@ -112,13 +112,13 @@ func main() {
 			log.Warn("No KubermaticConfiguration, -addons-image or -addons-path given, cannot mirror images referenced in addons.")
 		}
 
-			tempDir, err := extractAddonsFromDockerImage(ctx, log, addonsImage)
-			if err != nil {
-				log.Fatalw("Failed to create local addons path", zap.Error(err))
-			}
-			defer os.RemoveAll(tempDir)
+		tempDir, err := extractAddonsFromDockerImage(ctx, log, addonsImage)
+		if err != nil {
+			log.Fatalw("Failed to create local addons path", zap.Error(err))
+		}
+		defer os.RemoveAll(tempDir)
 
-			o.addonsPath = tempDir
+		o.addonsPath = tempDir
 	}
 
 	// Using a set here for deduplication

--- a/api/cmd/image-loader/main_test.go
+++ b/api/cmd/image-loader/main_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"testing"
 
+	"github.com/kubermatic/kubermatic/api/pkg/controller/operator/common"
 	kubermaticlog "github.com/kubermatic/kubermatic/api/pkg/log"
 	"github.com/kubermatic/kubermatic/api/pkg/resources"
 	"github.com/kubermatic/kubermatic/api/pkg/version"
@@ -16,13 +17,15 @@ func TestRetagImageForAllVersions(t *testing.T) {
 	masterResources := "../../../config/kubermatic/static/master/versions.yaml"
 	addonPath := "../../../addons"
 
+	// Cannot be set during go-test
+	resources.KUBERMATICCOMMIT = "latest"
+	common.KUBERMATICDOCKERTAG = resources.KUBERMATICCOMMIT
+	common.UIDOCKERTAG = resources.KUBERMATICCOMMIT
+
 	versions, err := version.LoadVersions(masterResources)
 	if err != nil {
 		t.Errorf("Error loading versions: %v", err)
 	}
-
-	// Cannot be set during go-test
-	resources.KUBERMATICCOMMIT = "latest"
 
 	imageSet := sets.NewString()
 	for _, v := range versions {

--- a/api/hack/ci/ci-deploy-offline.sh
+++ b/api/hack/ci/ci-deploy-offline.sh
@@ -5,11 +5,11 @@ set -euo pipefail
 # receives a SIGINT
 set -o monitor
 
-cd "$(dirname "$0")/"
-source ./../lib.sh
+cd "$(dirname "$0")/../.."
+source hack/lib.sh
 
 # Build and push images
-./ci-push-images.sh
+./hack/ci/ci-push-images.sh
 
 echodate "Getting secrets from Vault"
 export VAULT_ADDR=https://vault.loodse.com/
@@ -18,12 +18,13 @@ export VAULT_TOKEN=$(vault write \
   role_id=${VAULT_ROLE_ID} secret_id=${VAULT_SECRET_ID} \
   | jq .auth.client_token -r)
 
-export GIT_HEAD_HASH="$(git rev-parse HEAD|tr -d '\n')"
+export GIT_HEAD_HASH="$(git rev-parse HEAD | tr -d '\n')"
 
 rm -f /tmp/id_rsa
 vault kv get -field=key dev/e2e-machine-controller-ssh-key > /tmp/id_rsa
 chmod 400 /tmp/id_rsa
 
+REGISTRY=127.0.0.1:5000
 PROXY_EXTERNAL_ADDR="$(vault kv get -field=proxy-ip dev/gcp-offline-env)"
 PROXY_INTERNAL_ADDR="$(vault kv get -field=proxy-internal-ip dev/gcp-offline-env)"
 KUBERNETES_CONTROLLER_ADDR="$(vault kv get -field=controller-ip dev/gcp-offline-env)"
@@ -36,7 +37,8 @@ vault kv get -field=kubeconfig dev/gcp-offline-env > /tmp/kubeconfig
 export KUBECONFIG="/tmp/kubeconfig"
 kubectl config set clusters.kubernetes.server https://127.0.0.1:6443
 
-ssh ${SSH_OPTS} -M -S /tmp/proxy-socket -fNT -L 5000:127.0.0.1:5000 root@${PROXY_EXTERNAL_ADDR}
+# port-forward the Docker registry and Kubernetes API
+ssh ${SSH_OPTS} -M -S /tmp/proxy-socket -fNT -L 5000:${REGISTRY} root@${PROXY_EXTERNAL_ADDR}
 ssh ${SSH_OPTS} -M -S /tmp/controller-socket -fNT -L 6443:127.0.0.1:6443 ${SSH_OPTS} \
   -o ProxyCommand="ssh ${SSH_OPTS} -W %h:%p root@${PROXY_EXTERNAL_ADDR}" \
   root@${KUBERNETES_CONTROLLER_ADDR}
@@ -48,54 +50,73 @@ function finish {
 }
 trap finish EXIT
 
-# Ensure we have pushed all images from our helm chats in the local registry
-cd ../../../config
-helm template cert-manager | ../api/hack/retag-images.sh
-helm template nginx-ingress-controller | ../api/hack/retag-images.sh
-helm template oauth | ../api/hack/retag-images.sh
-helm template iap | ../api/hack/retag-images.sh
-helm template minio | ../api/hack/retag-images.sh
-helm template s3-exporter | ../api/hack/retag-images.sh
-helm template nodeport-proxy --set=nodePortProxy.image.tag=${GIT_HEAD_HASH}	\
-	| ../api/hack/retag-images.sh
+# build the image loader
+export UIDOCKERTAG="$(get_latest_dashboard_hash "${PULL_BASE_REF}")"
+export KUBERMATICCOMMIT="${GIT_HEAD_HASH}"
+export GITTAG="${GIT_HEAD_HASH}"
 
-helm template monitoring/prometheus | ../api/hack/retag-images.sh
-helm template monitoring/node-exporter | ../api/hack/retag-images.sh
-helm template monitoring/kube-state-metrics | ../api/hack/retag-images.sh
-helm template monitoring/grafana | ../api/hack/retag-images.sh
-helm template monitoring/helm-exporter | ../api/hack/retag-images.sh
-helm template monitoring/alertmanager | ../api/hack/retag-images.sh
+make image-loader
 
-helm template logging/elasticsearch | ../api/hack/retag-images.sh
-helm template logging/fluentbit | ../api/hack/retag-images.sh
-helm template logging/kibana | ../api/hack/retag-images.sh
+# push all images from KKP and Helm charts to the local registry
+cat <<EOF >> ${VALUES_FILE}
+kubermaticOperator:
+  image:
+    tag: ${GIT_HEAD_HASH}
+  imagePullSecret: '{}'
 
-# PULL_BASE_REF is the name of the current branch in case of a post-submit
-# or the name of the base branch in case of a PR.
-LATEST_DASHBOARD="$(get_latest_dashboard_hash "${PULL_BASE_REF}")"
+nodePortProxy:
+  image:
+    tag: ${GIT_HEAD_HASH}
 
-HELM_EXTRA_ARGS="--set kubermatic.controller.image.tag=${GIT_HEAD_HASH},kubermatic.api.image.tag=${GIT_HEAD_HASH},kubermatic.masterController.image.tag=${GIT_HEAD_HASH},kubermatic.controller.addons.kubernetes.image.tag=${GIT_HEAD_HASH},kubermatic.controller.addons.openshift.image.tag=${GIT_HEAD_HASH},kubermatic.ui.image.tag=${LATEST_DASHBOARD}"
-helm template ${HELM_EXTRA_ARGS} kubermatic | ../api/hack/retag-images.sh
+iap:
+  deployments:
+    dummy:
+      name: dummy
+      client_id: dummy
+      client_secret: xxx
+      encryption_key: xxx
+      upstream_service: example.com.svc.cluster.local
+      upstream_port: 9093
+      ingress:
+        host: "dummy.example.com"
+        annotations: {}
+EOF
+
+_build/image-loader \
+  -addons-path ../addons \
+  -charts-path ../config \
+  -helm-binary helm3 \
+  -helm-values-file "${VALUES_FILE}" \
+  -registry "${REGISTRY}" \
+  -log-format=JSON
 
 # Push a tiller image
 docker pull gcr.io/kubernetes-helm/tiller:${HELM_VERSION}
-docker tag gcr.io/kubernetes-helm/tiller:${HELM_VERSION} 127.0.0.1:5000/kubernetes-helm/tiller:${HELM_VERSION}
-docker push 127.0.0.1:5000/kubernetes-helm/tiller:${HELM_VERSION}
-
-cd ../api
-KUBERMATICCOMMIT=${GIT_HEAD_HASH} GITTAG=${GIT_HEAD_HASH} make image-loader
-retry 6 ./_build/image-loader \
-  -versions ../config/kubermatic/static/master/versions.yaml \
-  -addons-path ../addons \
-  -registry 127.0.0.1:5000 \
-  -log-format=Console
+docker tag gcr.io/kubernetes-helm/tiller:${HELM_VERSION} ${REGISTRY}/kubernetes-helm/tiller:${HELM_VERSION}
+docker push ${REGISTRY}/kubernetes-helm/tiller:${HELM_VERSION}
 
 ## Deploy
 HELM_INIT_ARGS="--tiller-image ${PROXY_INTERNAL_ADDR}:5000/kubernetes-helm/tiller:${HELM_VERSION}" \
+  DEPLOY_STACK=kubermatic \
   DEPLOY_NODEPORT_PROXY=false \
+  TILLER_NAMESPACE="kube-system" \
+  ./hack/deploy.sh \
+  master \
+  ${VALUES_FILE}
+
+HELM_INIT_ARGS="--tiller-image ${PROXY_INTERNAL_ADDR}:5000/kubernetes-helm/tiller:${HELM_VERSION}" \
+  DEPLOY_STACK=monitoring \
   DEPLOY_ALERTMANAGER=false \
   TILLER_NAMESPACE="kube-system" \
   ./hack/deploy.sh \
   master \
-  ${VALUES_FILE} \
-  ${HELM_EXTRA_ARGS}
+  ${VALUES_FILE}
+
+HELM_INIT_ARGS="--tiller-image ${PROXY_INTERNAL_ADDR}:5000/kubernetes-helm/tiller:${HELM_VERSION}" \
+  DEPLOY_STACK=logging \
+  DEPLOY_LOKI=true \
+  DEPLOY_ELASTIC=false \
+  TILLER_NAMESPACE="kube-system" \
+  ./hack/deploy.sh \
+  master \
+  ${VALUES_FILE}

--- a/api/pkg/install/helm/cli.go
+++ b/api/pkg/install/helm/cli.go
@@ -1,0 +1,191 @@
+/*
+Copyright 2020 The Kubermatic Kubernetes Platform contributors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package helm
+
+import (
+	"bytes"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"os/exec"
+	"strings"
+	"time"
+
+	"github.com/Masterminds/semver"
+	"github.com/sirupsen/logrus"
+)
+
+type cli struct {
+	binary      string
+	kubeconfig  string
+	kubeContext string
+	timeout     time.Duration
+	logger      logrus.FieldLogger
+}
+
+// NewCLI returns a new Client implementation that uses a local helm
+// binary to perform chart installations.
+func NewCLI(binary string, kubeconfig string, kubeContext string, timeout time.Duration, logger logrus.FieldLogger) (Client, error) {
+	if timeout.Seconds() < 10 {
+		return nil, errors.New("timeout must be >= 10 seconds")
+	}
+
+	return &cli{
+		binary:      binary,
+		kubeconfig:  kubeconfig,
+		kubeContext: kubeContext,
+		timeout:     timeout,
+		logger:      logger,
+	}, nil
+}
+
+func (c *cli) InstallChart(namespace string, releaseName string, chartDirectory string, valuesFile string, values map[string]string, flags []string) error {
+	command := []string{
+		"upgrade",
+		"--install",
+		"--values", valuesFile,
+		"--timeout", c.timeout.String(),
+	}
+
+	command = append(command, valuesToFlags(values)...)
+	command = append(command, flags...)
+	command = append(command, releaseName, chartDirectory)
+
+	_, err := c.run(namespace, command...)
+
+	return err
+}
+
+func (c *cli) GetRelease(namespace string, name string) (*Release, error) {
+	releases, err := c.ListReleases(namespace)
+	if err != nil {
+		return nil, err
+	}
+
+	for idx, r := range releases {
+		if r.Namespace == namespace && r.Name == name {
+			return &releases[idx], nil
+		}
+	}
+
+	return nil, nil
+}
+
+func (c *cli) ListReleases(namespace string) ([]Release, error) {
+	args := []string{"list", "--all", "-o", "json"}
+	if namespace == "" {
+		args = append(args, "--all-namespaces")
+	}
+
+	output, err := c.run(namespace, args...)
+	if err != nil {
+		return nil, fmt.Errorf("failed to list releases: %v", err)
+	}
+
+	releases := []Release{}
+	if err := json.NewDecoder(bytes.NewReader(output)).Decode(&releases); err != nil {
+		return nil, fmt.Errorf("failed to parse Helm output: %v", err)
+	}
+
+	for idx, release := range releases {
+		nameParts := strings.Split(release.Chart, "-")
+		tail := nameParts[len(nameParts)-1]
+
+		version, err := semver.NewVersion(tail)
+		if err == nil {
+			releases[idx].Version = version
+		}
+
+		releases[idx].Chart = strings.Join(nameParts[:len(nameParts)-1], "-")
+	}
+
+	return releases, nil
+}
+
+func (c *cli) UninstallRelease(namespace string, name string) error {
+	_, err := c.run(namespace, "uninstall", name)
+
+	return err
+}
+
+func (c *cli) RenderChart(namespace string, releaseName string, chartDirectory string, valuesFile string, values map[string]string) ([]byte, error) {
+	command := []string{"template"}
+
+	if valuesFile != "" {
+		command = append(command, "--values", valuesFile)
+	}
+
+	command = append(command, valuesToFlags(values)...)
+	command = append(command, releaseName, chartDirectory)
+
+	return c.run(namespace, command...)
+}
+
+func (c *cli) Version() (*semver.Version, error) {
+	// add --client to gracefully handle Helm 2 (Helm 3 ignores the flag, thankfully);
+	// Helm 2 will output "<no value>", whereas Helm 3 would outright reject the
+	// Helm-2-style templating string "{{ .Client.SemVer }}"
+	output, err := c.run("", "version", "--client", "--template", "{{ .Version }}")
+	if err != nil {
+		return nil, err
+	}
+
+	out := strings.TrimSpace(string(output))
+	if out == "<no value>" {
+		out = "v2.99.99"
+	}
+
+	return semver.NewVersion(out)
+}
+
+func (c *cli) run(namespace string, args ...string) ([]byte, error) {
+	globalArgs := []string{}
+
+	if c.kubeContext != "" {
+		globalArgs = append(globalArgs, "--kube-context", c.kubeContext)
+	}
+
+	if namespace != "" {
+		globalArgs = append(globalArgs, "--namespace", namespace)
+	}
+
+	cmd := exec.Command(c.binary, append(globalArgs, args...)...)
+	cmd.Env = append(cmd.Env, "KUBECONFIG="+c.kubeconfig)
+
+	c.logger.Debugf("$ KUBECONFIG=%s %s", c.kubeconfig, strings.Join(cmd.Args, " "))
+
+	stdoutStderr, err := cmd.CombinedOutput()
+	if err != nil {
+		err = errors.New(strings.TrimSpace(string(stdoutStderr)))
+	}
+
+	return stdoutStderr, err
+}
+
+func valuesToFlags(values map[string]string) []string {
+	set := make([]string, 0)
+
+	for name, value := range values {
+		set = append(set, fmt.Sprintf("%s=%s", name, value))
+	}
+
+	if len(set) > 0 {
+		return []string{"--set", strings.Join(set, ",")}
+	}
+
+	return nil
+}

--- a/api/pkg/install/helm/interface.go
+++ b/api/pkg/install/helm/interface.go
@@ -1,0 +1,31 @@
+/*
+Copyright 2020 The Kubermatic Kubernetes Platform contributors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package helm
+
+import "github.com/Masterminds/semver"
+
+// Client describes the operations that the Helm client is providing to
+// the installer. This is the minimum set of operations required to
+// perform a Kubermatic installation.
+type Client interface {
+	Version() (*semver.Version, error)
+	InstallChart(namespace string, releaseName string, chartDirectory string, valuesFile string, values map[string]string, flags []string) error
+	GetRelease(namespace string, name string) (*Release, error)
+	ListReleases(namespace string) ([]Release, error)
+	UninstallRelease(namespace string, name string) error
+	RenderChart(namespace string, releaseName string, chartDirectory string, valuesFile string, values map[string]string) ([]byte, error)
+}

--- a/api/pkg/install/helm/status.go
+++ b/api/pkg/install/helm/status.go
@@ -1,0 +1,36 @@
+/*
+Copyright 2020 The Kubermatic Kubernetes Platform contributors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package helm
+
+type ReleaseStatus string
+
+const (
+	ReleaseCheckFailed ReleaseStatus = ""
+
+	// these constants mirror the Helm status from
+	// `helm status --help`
+
+	ReleaseStatusUnknown         ReleaseStatus = "unknown"
+	ReleaseStatusDeployed        ReleaseStatus = "deployed"
+	ReleaseStatusDeleted         ReleaseStatus = "uninstalled"
+	ReleaseStatusSuperseded      ReleaseStatus = "superseded"
+	ReleaseStatusFailed          ReleaseStatus = "failed"
+	ReleaseStatusDeleting        ReleaseStatus = "uninstalling"
+	ReleaseStatusPendingInstall  ReleaseStatus = "pending-install"
+	ReleaseStatusPendingUpgrade  ReleaseStatus = "pending-upgrade"
+	ReleaseStatusPendingRollback ReleaseStatus = "pending-rollback"
+)

--- a/api/pkg/install/helm/types.go
+++ b/api/pkg/install/helm/types.go
@@ -1,0 +1,83 @@
+/*
+Copyright 2020 The Kubermatic Kubernetes Platform contributors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package helm
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+
+	"github.com/Masterminds/semver"
+	"gopkg.in/yaml.v2"
+)
+
+type Release struct {
+	Name      string          `json:"name"`
+	Namespace string          `json:"namespace"`
+	Chart     string          `json:"chart"`
+	Revision  string          `json:"revision"`
+	Version   *semver.Version `json:"-"`
+	// AppVersion is not a semver, for example Minio has date-based versions.
+	AppVersion string        `json:"app_version"`
+	Status     ReleaseStatus `json:"status"`
+}
+
+func (r *Release) Clone() Release {
+	copy := *r
+	copy.Version = semver.MustParse(r.Version.Original())
+
+	return copy
+}
+
+type Chart struct {
+	Name       string          `yaml:"name"`
+	Version    *semver.Version `yaml:"-"`
+	VersionRaw string          `yaml:"version"`
+	// AppVersion is not a semver, for example Minio has date-based versions.
+	AppVersion string `yaml:"appVersion"`
+	Directory  string
+}
+
+func (c *Chart) Clone() Chart {
+	copy := *c
+	copy.Version = semver.MustParse(c.Version.Original())
+
+	return copy
+}
+
+func LoadChart(directory string) (*Chart, error) {
+	f, err := os.Open(filepath.Join(directory, "Chart.yaml"))
+	if err != nil {
+		return nil, fmt.Errorf("failed to open Chart.yaml: %v", err)
+	}
+	defer f.Close()
+
+	chart := &Chart{}
+	if err := yaml.NewDecoder(f).Decode(chart); err != nil {
+		return nil, fmt.Errorf("failed to read Chart.yaml: %v", err)
+	}
+
+	version, err := semver.NewVersion(chart.VersionRaw)
+	if err != nil {
+		return nil, fmt.Errorf("failed to parse version %q: %v", chart.VersionRaw, err)
+	}
+
+	chart.Version = version
+	chart.Directory = directory
+
+	return chart, nil
+}

--- a/api/pkg/util/yaml/parse.go
+++ b/api/pkg/util/yaml/parse.go
@@ -1,0 +1,62 @@
+/*
+Copyright 2020 The Kubermatic Kubernetes Platform contributors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package yaml
+
+import (
+	"bufio"
+	"bytes"
+	"fmt"
+	"io"
+
+	"k8s.io/apimachinery/pkg/runtime"
+	kyaml "k8s.io/apimachinery/pkg/util/yaml"
+)
+
+func ParseMultipleDocuments(input io.Reader) ([]runtime.RawExtension, error) {
+	reader := kyaml.NewYAMLReader(bufio.NewReader(input))
+	objects := []runtime.RawExtension{}
+
+	for {
+		b, err := reader.Read()
+		if err != nil {
+			if err == io.EOF {
+				break
+			}
+			return nil, fmt.Errorf("failed reading from YAML reader: %v", err)
+		}
+
+		b = bytes.TrimSpace(b)
+		if len(b) == 0 {
+			continue
+		}
+
+		decoder := kyaml.NewYAMLToJSONDecoder(bytes.NewBuffer(b))
+		raw := runtime.RawExtension{}
+		if err := decoder.Decode(&raw); err != nil {
+			return nil, fmt.Errorf("decoding failed: %v", err)
+		}
+
+		// skip empty documents (e.g. documents that are only comments)
+		if len(raw.Raw) == 0 {
+			continue
+		}
+
+		objects = append(objects, raw)
+	}
+
+	return objects, nil
+}

--- a/config/kubernetes-dashboard/Chart.yaml
+++ b/config/kubernetes-dashboard/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: kubernetes-dashboard
-version: 1.0.2
+version: 1.0.4
 appVersion: v2.0.0-rc3
 description: Kubernetes Dashboard
 keywords:

--- a/config/kubernetes-dashboard/templates/_helpers.tpl
+++ b/config/kubernetes-dashboard/templates/_helpers.tpl
@@ -1,11 +1,11 @@
 {{- define "dashboard-name" -}}
-{{- default printf "%s-%s" .Release.Name "dashboard" .Values.dashboard.deployment.dashboard.nameOverride -}}
+{{- default (printf "%s-%s" .Release.Name "dashboard") .Values.dashboard.deployment.dashboard.nameOverride -}}
 {{- end }}
 
 {{- define "oauth-name" -}}
-{{- default printf "%s-%s" .Release.Name "proxy" .Values.dashboard.deployment.proxy.nameOverride -}}
+{{- default (printf "%s-%s" .Release.Name "proxy") .Values.dashboard.deployment.proxy.nameOverride -}}
 {{- end }}
 
 {{- define "scraper-name" -}}
-{{- default printf "%s-%s" .Release.Name "scraper" .Values.dashboard.deployment.scraper.nameOverride -}}
+{{- default (printf "%s-%s" .Release.Name "scraper") .Values.dashboard.deployment.scraper.nameOverride -}}
 {{- end }}

--- a/config/kubernetes-dashboard/templates/dashboard-csrf-secret.yaml
+++ b/config/kubernetes-dashboard/templates/dashboard-csrf-secret.yaml
@@ -9,4 +9,4 @@ metadata:
   name: kubernetes-dashboard-csrf
 type: Opaque
 data:
-  csrf: "{{ .Values.dashboard.csrf }}"
+  csrf: {{ .Values.dashboard.csrf | b64enc | quote }}

--- a/config/kubernetes-dashboard/templates/oauth-proxy-secret.yaml
+++ b/config/kubernetes-dashboard/templates/oauth-proxy-secret.yaml
@@ -9,6 +9,6 @@ metadata:
   name: '{{ template "oauth-name" . }}-config'
 type: Opaque
 data:
-  clientID: "{{ .Values.dashboard.oidc.clientID }}"
-  clientSecret: "{{ .Values.dashboard.oidc.clientSecret }}"
-  cookieSecret: "{{ .Values.dashboard.oidc.cookieSecret }}"
+  clientID: {{ .Values.dashboard.oidc.clientID | b64enc | quote }}
+  clientSecret: {{ .Values.dashboard.oidc.clientSecret | b64enc | quote }}
+  cookieSecret: {{ .Values.dashboard.oidc.cookieSecret | b64enc | quote }}


### PR DESCRIPTION
**What this PR does / why we need it**:
This backports #6066 and #6067 into the 2.13 release. As the KKP Operator has not been released in this branch, I skipped adding support for the KubermaticConfiguration to the image-loader.

**Does this PR introduce a user-facing change?**:
```release-note
NONE
```
