### PR TITLE
do not use already mirrored values.yaml when mirroring images

### DIFF
--- a/hack/ci/deploy-offline.sh
+++ b/hack/ci/deploy-offline.sh
@@ -78,8 +78,12 @@ export GITTAG="${GIT_HEAD_HASH}"
 
 make image-loader
 
-# push all images from KKP and Helm charts to the local registry
-cat <<EOF >> ${VALUES_FILE}
+# push all images from KKP and Helm charts to the local registry;
+# do not use the VALUES_FILE for the loading process, as it already
+# overrides all the Docker images and for the image-loading we want
+# to get the _original_ image names.
+LOADER_VALUES_FILE=/tmp/loader-values.yaml
+cat <<EOF > ${LOADER_VALUES_FILE}
 kubermaticOperator:
   image:
     tag: ${GIT_HEAD_HASH}
@@ -108,7 +112,7 @@ _build/image-loader \
   -addons-path addons \
   -charts-path charts \
   -helm-binary helm3 \
-  -helm-values-file "${VALUES_FILE}" \
+  -helm-values-file "${LOADER_VALUES_FILE}" \
   -registry "${REGISTRY}" \
   -log-format=JSON
 


### PR DESCRIPTION
**What this PR does / why we need it**:
When using the same values.yaml for loading the images and then deploying the Helm charts, the loader will find images like "my.local.registry:5000/busybox", which it cannot mirror (well it can, but it would download the image from the local registry and then push it there again, a No-Operation).
This PR changes the script so that we use a vanilla values.yaml for the loader.

**Does this PR introduce a user-facing change?**:
```release-note
NONE
```
