### PR TITLE
fix typo in github release script

### DIFF
--- a/hack/ci/github-release.sh
+++ b/hack/ci/github-release.sh
@@ -146,7 +146,7 @@ function build_tools() {
   fi
 }
 
-function upload_archive() {
+function ship_archive() {
   local archive="$1"
   local buildTarget="$2"
 
@@ -257,7 +257,7 @@ for buildTarget in $RELEASE_PLATFORMS; do
     LICENSE \
     CHANGELOG.md
 
-  upload_archive "$archive" "$buildTarget"
+  ship_archive "$archive" "$buildTarget"
 
   echodate "Compiling EE installer ($buildTarget)..."
   KUBERMATIC_EDITION=ee build_installer
@@ -295,7 +295,7 @@ for buildTarget in $RELEASE_PLATFORMS; do
     pkg/ee/LICENSE \
     CHANGELOG.md
 
-  upload_archive "$archive" "$buildTarget"
+  ship_archive "$archive" "$buildTarget"
 
   # tools do not have CE/EE dependencies, so it's enough to build
   # one archive per build target
@@ -311,7 +311,7 @@ for buildTarget in $RELEASE_PLATFORMS; do
     _build/image-loader* \
     LICENSE
 
-  upload_archive "$archive" "$buildTarget"
+  ship_archive "$archive" "$buildTarget"
 done
 
 echodate "Done."


### PR DESCRIPTION
**What this PR does / why we need it**:
I accidentally overwrote `upload_archive`. I should have gone with my initial name.

**Does this PR introduce a user-facing change?**:
```release-note
NONE
```
