### PR TITLE
Allow to adjust the Docker image tag for addons

### DIFF
--- a/docs/zz_generated.kubermaticConfiguration.yaml
+++ b/docs/zz_generated.kubermaticConfiguration.yaml
@@ -305,6 +305,10 @@ spec:
         # DockerRepository is the repository containing the Docker image containing
         # the possible addon manifests.
         dockerRepository: quay.io/kubermatic/addons
+        # DockerTagSuffix is appended to the tag used for referring to the addons image.
+        # If left empty, the tag will be the KKP version (e.g. "v2.15.0"), with a
+        # suffix it becomes "v2.15.0-SUFFIX".
+        dockerTagSuffix: ""
       # Openshift controls the addons for Openshift-based clusters.
       openshift:
         # Default is the list of addons to be installed by default into each cluster.
@@ -357,6 +361,10 @@ spec:
         # DockerRepository is the repository containing the Docker image containing
         # the possible addon manifests.
         dockerRepository: quay.io/kubermatic/openshift-addons
+        # DockerTagSuffix is appended to the tag used for referring to the addons image.
+        # If left empty, the tag will be the KKP version (e.g. "v2.15.0"), with a
+        # suffix it becomes "v2.15.0-SUFFIX".
+        dockerTagSuffix: ""
     # APIServerReplicas configures the replica count for the API-Server deployment inside user clusters.
     apiserverReplicas: 2
     # DisableAPIServerEndpointReconciling can be used to toggle the `--endpoint-reconciler-type` flag for

--- a/pkg/crd/operator/v1alpha1/configuration.go
+++ b/pkg/crd/operator/v1alpha1/configuration.go
@@ -216,6 +216,10 @@ type KubermaticAddonConfiguration struct {
 	// DockerRepository is the repository containing the Docker image containing
 	// the possible addon manifests.
 	DockerRepository string `json:"dockerRepository,omitempty"`
+	// DockerTagSuffix is appended to the tag used for referring to the addons image.
+	// If left empty, the tag will be the KKP version (e.g. "v2.15.0"), with a
+	// suffix it becomes "v2.15.0-SUFFIX".
+	DockerTagSuffix string `json:"dockerTagSuffix,omitempty"`
 }
 
 type KubermaticIngressConfiguration struct {


### PR DESCRIPTION
**What this PR does / why we need it**:
This is a proposal to help with the current problem surrounding addons in KKP.

It is currently very har to impossible to develop custom addons, as new Docker images cannot be easily refered to in userclusters. This is because the KKP Operator did not allow changing _any_ Docker tags, because it wants to keep its own internal migration logic simple (so it does not allow to override the KKP version). However, this had a significant fallout for the addons, where there are legitimate usecases for overriding the Docker image.

This proposal tries to combine the best of both worlds. We still want to make sure admins don't accidentally upgrade KKP and continue to use their old addons image (which would be possible if we allowed to completely override the image tag), but we also want to allow to "bump" the tag to make development easier.

To achieve this, this PR simply introduces the concept of a "version suffix" that is, if set, appended to the KKP version.

Fixes #6081 in my opinion.

**Does this PR introduce a user-facing change?**:
```release-note
Allow to customize the Docker image tag for Cluster Addons
```
