### PR TITLE
Allow to disable creation of certificates for IAP deployments

### DIFF
--- a/charts/iap/Chart.yaml
+++ b/charts/iap/Chart.yaml
@@ -14,7 +14,7 @@
 
 apiVersion: v1
 name: iap
-version: 3.0.3
+version: 3.1.0
 appVersion: v6.1.1
 description: A Helm chart to install OAuth2-Proxy as an identity-aware proxy.
 keywords:

--- a/charts/iap/templates/certificates.yaml
+++ b/charts/iap/templates/certificates.yaml
@@ -12,6 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+{{ if .Values.iap.certIssuer.name }}
 {{ range .Values.iap.deployments }}
 ---
 apiVersion: cert-manager.io/v1alpha2
@@ -25,4 +26,5 @@ spec:
     kind: {{ $.Values.iap.certIssuer.kind }}
   dnsNames:
   - {{ .ingress.host | trim }}
+{{ end -}}
 {{ end -}}

--- a/charts/iap/values.yaml
+++ b/charts/iap/values.yaml
@@ -109,12 +109,16 @@ iap:
     #     annotations:
     #       ingress.kubernetes.io/upstream-hash-by: "ip_hash" ## needed for prometheus federations
 
-  # the cert-manager Issuer (or ClusterIssuer) responsible for managing the certificates
+  # the cert-manager Issuer (or ClusterIssuer) responsible for managing the certificates;
+  # set this to an empty value to disable creating Certificate resources; in this case you need
+  # to manually provide the appropriate certificates
   certIssuer:
     name: letsencrypt-prod
     kind: ClusterIssuer
 
-  ## provides secret name at iap namespace for secret for a ca.crt file:
+  # provides secret name at iap namespace for secret for a ca.crt file; this is required if
+  # the OIDC provider (by default: Dex) uses a custom CA, because the oauth-proxy needs to
+  # validate the user tokens with the OIDC provider.
   #customProviderCA:
   #    secretName: ca-cert
   #    secretKey: ca.crt


### PR DESCRIPTION
**What this PR does / why we need it**:
This brings the iap Chart in-line with the Dex (oauth) chart, which already allows to disable the certificate creation. This is important for usecases where admins cannot issue certificates inside the cluster.

This is required before https://github.com/kubermatic/docs/pull/479 can be merged.

**Does this PR introduce a user-facing change?**:
```release-note
Allow to disable creation of certificates for IAP deployments
```
