### PR TITLE
Add Kubernetes 1.20

### DIFF
--- a/.prow.yaml
+++ b/.prow.yaml
@@ -306,7 +306,7 @@ presubmits:
       preset-goproxy: "true"
     spec:
       containers:
-      - image: quay.io/kubermatic/e2e-kind:with-conformance-tests-v1.0.22
+      - image: quay.io/kubermatic/e2e-kind:with-conformance-tests-v1.0.23
         command:
         - ./hack/ci/test-github-release.sh
         resources:
@@ -334,12 +334,12 @@ presubmits:
       preset-goproxy: "true"
     spec:
       containers:
-      - image: quay.io/kubermatic/e2e-kind:with-conformance-tests-v1.0.22
+      - image: quay.io/kubermatic/e2e-kind:with-conformance-tests-v1.0.23
         env:
         - name: KUBERMATIC_EDITION
           value: ee
         - name: VERSIONS_TO_TEST
-          value: "v1.17.13"
+          value: "v1.17.16"
         - name: DISTRIBUTIONS
           value: flatcar
         - name: SERVICE_ACCOUNT_KEY
@@ -375,12 +375,12 @@ presubmits:
       preset-goproxy: "true"
     spec:
       containers:
-      - image: quay.io/kubermatic/e2e-kind:with-conformance-tests-v1.0.22
+      - image: quay.io/kubermatic/e2e-kind:with-conformance-tests-v1.0.23
         env:
         - name: KUBERMATIC_EDITION
           value: ee
         - name: VERSIONS_TO_TEST
-          value: "v1.18.10"
+          value: "v1.18.14"
         - name: DISTRIBUTIONS
           value: flatcar
         - name: SERVICE_ACCOUNT_KEY
@@ -441,7 +441,7 @@ presubmits:
           limits:
             memory: 4Gi
 
-  - name: pre-kubermatic-e2e-aws-ubuntu-1.19-ce
+  - name: pre-kubermatic-e2e-aws-ubuntu-1.20
     decorate: true
     run_if_changed: "(cmd/|codegen/|hack/|pkg/|charts/kubermatic|addons/|.prow.yaml)"
     clone_uri: "ssh://git@github.com/kubermatic/kubermatic.git"
@@ -457,14 +457,12 @@ presubmits:
       preset-goproxy: "true"
     spec:
       containers:
-      - image: quay.io/kubermatic/e2e-kind:with-conformance-tests-v1.0.22
+      - image: quay.io/kubermatic/e2e-kind:with-conformance-tests-v1.0.23
         env:
         - name: KUBERMATIC_EDITION
-          value: "ce"
-        - name: ONLY_TEST_CREATION
-          value: "true"
+          value: ee
         - name: VERSIONS_TO_TEST
-          value: "v1.19.3"
+          value: "v1.20.2"
         - name: DISTRIBUTIONS
           value: ubuntu
         - name: SERVICE_ACCOUNT_KEY
@@ -484,7 +482,7 @@ presubmits:
           limits:
             memory: 4Gi
 
-  - name: pre-kubermatic-e2e-aws-ubuntu-1.19-legacy
+  - name: pre-kubermatic-e2e-aws-ubuntu-1.20-ce
     decorate: true
     run_if_changed: "(cmd/|codegen/|hack/|pkg/|charts/kubermatic|addons/|.prow.yaml)"
     clone_uri: "ssh://git@github.com/kubermatic/kubermatic.git"
@@ -500,7 +498,50 @@ presubmits:
       preset-goproxy: "true"
     spec:
       containers:
-      - image: quay.io/kubermatic/e2e-kind:with-conformance-tests-v1.0.22
+      - image: quay.io/kubermatic/e2e-kind:with-conformance-tests-v1.0.23
+        env:
+        - name: KUBERMATIC_EDITION
+          value: "ce"
+        - name: ONLY_TEST_CREATION
+          value: "true"
+        - name: VERSIONS_TO_TEST
+          value: "v1.20.2"
+        - name: DISTRIBUTIONS
+          value: ubuntu
+        - name: SERVICE_ACCOUNT_KEY
+          valueFrom:
+            secretKeyRef:
+              name: e2e-ci
+              key: serviceAccountSigningKey
+        command:
+        - "./hack/ci/run-e2e-tests.sh"
+        # docker-in-docker needs privileged mode
+        securityContext:
+          privileged: true
+        resources:
+          requests:
+            memory: 4Gi
+            cpu: 3.5
+          limits:
+            memory: 4Gi
+
+  - name: pre-kubermatic-e2e-aws-ubuntu-1.20-legacy
+    decorate: true
+    run_if_changed: "(cmd/|codegen/|hack/|pkg/|charts/kubermatic|addons/|.prow.yaml)"
+    clone_uri: "ssh://git@github.com/kubermatic/kubermatic.git"
+    labels:
+      preset-aws: "true"
+      preset-docker-pull: "true"
+      preset-docker-push: "true"
+      preset-vault: "true"
+      preset-repo-ssh: "true"
+      preset-e2e-ssh: "true"
+      preset-kubeconfig-ci: "true"
+      preset-kind-volume-mounts: "true"
+      preset-goproxy: "true"
+    spec:
+      containers:
+      - image: quay.io/kubermatic/e2e-kind:with-conformance-tests-v1.0.23
         env:
         - name: KUBERMATIC_EDITION
           value: "ee"
@@ -510,7 +551,7 @@ presubmits:
         - name: USE_LEGACY_HELM_CHART
           value: "true"
         - name: VERSIONS_TO_TEST
-          value: "v1.19.3"
+          value: "v1.20.2"
         - name: DISTRIBUTIONS
           value: ubuntu
         - name: SERVICE_ACCOUNT_KEY
@@ -534,7 +575,7 @@ presubmits:
   # # Extended Kubernetes Tests (various cloud providers, OS)
   # #########################################################
 
-  - name: pre-kubermatic-e2e-azure-ubuntu-1.19
+  - name: pre-kubermatic-e2e-azure-ubuntu-1.20
     decorate: true
     optional: true
     clone_uri: "ssh://git@github.com/kubermatic/kubermatic.git"
@@ -550,12 +591,12 @@ presubmits:
       preset-goproxy: "true"
     spec:
       containers:
-      - image: quay.io/kubermatic/e2e-kind:with-conformance-tests-v1.0.22
+      - image: quay.io/kubermatic/e2e-kind:with-conformance-tests-v1.0.23
         env:
         - name: KUBERMATIC_EDITION
           value: ee
         - name: VERSIONS_TO_TEST
-          value: "v1.19.3"
+          value: "v1.20.2"
         - name: DISTRIBUTIONS
           value: ubuntu
         - name: PROVIDER
@@ -579,7 +620,7 @@ presubmits:
           limits:
             memory: 4Gi
 
-  - name: pre-kubermatic-e2e-gcp-ubuntu-1.19
+  - name: pre-kubermatic-e2e-gcp-ubuntu-1.20
     decorate: true
     always_run: false
     optional: true
@@ -596,12 +637,12 @@ presubmits:
       preset-goproxy: "true"
     spec:
       containers:
-      - image: quay.io/kubermatic/e2e-kind:with-conformance-tests-v1.0.22
+      - image: quay.io/kubermatic/e2e-kind:with-conformance-tests-v1.0.23
         env:
         - name: KUBERMATIC_EDITION
           value: ee
         - name: VERSIONS_TO_TEST
-          value: "v1.19.3"
+          value: "v1.20.2"
         - name: PROVIDER
           value: "gcp"
         - name: DISTRIBUTIONS
@@ -623,7 +664,7 @@ presubmits:
           limits:
             memory: 4Gi
 
-  - name: pre-kubermatic-e2e-gcp-ubuntu-1.19-psp
+  - name: pre-kubermatic-e2e-gcp-ubuntu-1.20-psp
     decorate: true
     optional: true
     clone_uri: "ssh://git@github.com/kubermatic/kubermatic.git"
@@ -639,12 +680,12 @@ presubmits:
       preset-goproxy: "true"
     spec:
       containers:
-      - image: quay.io/kubermatic/e2e-kind:with-conformance-tests-v1.0.22
+      - image: quay.io/kubermatic/e2e-kind:with-conformance-tests-v1.0.23
         env:
         - name: KUBERMATIC_EDITION
           value: ee
         - name: VERSIONS_TO_TEST
-          value: "v1.19.3"
+          value: "v1.20.2"
         - name: PROVIDER
           value: "gcp"
         - name: DISTRIBUTIONS
@@ -670,7 +711,7 @@ presubmits:
           limits:
             memory: 4Gi
 
-  - name: pre-kubermatic-e2e-do-centos-1.19
+  - name: pre-kubermatic-e2e-do-centos-1.20
     decorate: true
     always_run: false
     optional: true
@@ -687,12 +728,12 @@ presubmits:
       preset-goproxy: "true"
     spec:
       containers:
-      - image: quay.io/kubermatic/e2e-kind:with-conformance-tests-v1.0.22
+      - image: quay.io/kubermatic/e2e-kind:with-conformance-tests-v1.0.23
         env:
         - name: KUBERMATIC_EDITION
           value: ee
         - name: VERSIONS_TO_TEST
-          value: "v1.19.3"
+          value: "v1.20.2"
         - name: DISTRIBUTIONS
           value: centos
         - name: PROVIDER
@@ -714,7 +755,7 @@ presubmits:
           limits:
             memory: 4Gi
 
-  - name: pre-kubermatic-e2e-packet-ubuntu-1.19
+  - name: pre-kubermatic-e2e-packet-ubuntu-1.20
     decorate: true
     optional: true
     clone_uri: "ssh://git@github.com/kubermatic/kubermatic.git"
@@ -730,12 +771,12 @@ presubmits:
       preset-goproxy: "true"
     spec:
       containers:
-      - image: quay.io/kubermatic/e2e-kind:with-conformance-tests-v1.0.22
+      - image: quay.io/kubermatic/e2e-kind:with-conformance-tests-v1.0.23
         env:
         - name: KUBERMATIC_EDITION
           value: ee
         - name: VERSIONS_TO_TEST
-          value: "v1.19.3"
+          value: "v1.20.2"
         - name: PROVIDER
           value: "packet"
         - name: DISTRIBUTIONS
@@ -757,7 +798,7 @@ presubmits:
           limits:
             memory: 4Gi
 
-  - name: pre-kubermatic-e2e-kubevirt-centos-1.19
+  - name: pre-kubermatic-e2e-kubevirt-centos-1.20
     decorate: true
     optional: true
     clone_uri: "ssh://git@github.com/kubermatic/kubermatic.git"
@@ -773,12 +814,12 @@ presubmits:
       preset-goproxy: "true"
     spec:
       containers:
-      - image: quay.io/kubermatic/e2e-kind:with-conformance-tests-v1.0.22
+      - image: quay.io/kubermatic/e2e-kind:with-conformance-tests-v1.0.23
         env:
         - name: KUBERMATIC_EDITION
           value: ee
         - name: VERSIONS_TO_TEST
-          value: "v1.19.3"
+          value: "v1.20.2"
         - name: PROVIDER
           value: "kubevirt"
         - name: DISTRIBUTIONS
@@ -800,7 +841,7 @@ presubmits:
           limits:
             memory: 4Gi
 
-  - name: pre-kubermatic-e2e-hetzner-ubuntu-1.19
+  - name: pre-kubermatic-e2e-hetzner-ubuntu-1.20
     decorate: true
     optional: true
     clone_uri: "ssh://git@github.com/kubermatic/kubermatic.git"
@@ -816,12 +857,12 @@ presubmits:
       preset-goproxy: "true"
     spec:
       containers:
-      - image: quay.io/kubermatic/e2e-kind:with-conformance-tests-v1.0.22
+      - image: quay.io/kubermatic/e2e-kind:with-conformance-tests-v1.0.23
         env:
         - name: KUBERMATIC_EDITION
           value: ee
         - name: VERSIONS_TO_TEST
-          value: "v1.19.3"
+          value: "v1.20.2"
         - name: PROVIDER
           value: "hetzner"
         - name: DISTRIBUTIONS
@@ -845,7 +886,7 @@ presubmits:
           limits:
             memory: 4Gi
 
-  - name: pre-kubermatic-e2e-openstack-ubuntu-1.19
+  - name: pre-kubermatic-e2e-openstack-ubuntu-1.20
     decorate: true
     optional: true
     clone_uri: "ssh://git@github.com/kubermatic/kubermatic.git"
@@ -861,12 +902,12 @@ presubmits:
       preset-goproxy: "true"
     spec:
       containers:
-      - image: quay.io/kubermatic/e2e-kind:with-conformance-tests-v1.0.22
+      - image: quay.io/kubermatic/e2e-kind:with-conformance-tests-v1.0.23
         env:
         - name: KUBERMATIC_EDITION
           value: ee
         - name: VERSIONS_TO_TEST
-          value: "v1.19.3"
+          value: "v1.20.2"
         - name: PROVIDER
           value: "openstack"
         - name: DISTRIBUTIONS
@@ -890,7 +931,7 @@ presubmits:
           limits:
             memory: 4Gi
 
-  - name: pre-kubermatic-e2e-openstack-centos-1.19
+  - name: pre-kubermatic-e2e-openstack-centos-1.20
     decorate: true
     optional: true
     clone_uri: "ssh://git@github.com/kubermatic/kubermatic.git"
@@ -906,12 +947,12 @@ presubmits:
       preset-goproxy: "true"
     spec:
       containers:
-      - image: quay.io/kubermatic/e2e-kind:with-conformance-tests-v1.0.22
+      - image: quay.io/kubermatic/e2e-kind:with-conformance-tests-v1.0.23
         env:
         - name: KUBERMATIC_EDITION
           value: ee
         - name: VERSIONS_TO_TEST
-          value: "v1.19.3"
+          value: "v1.20.2"
         - name: PROVIDER
           value: "openstack"
         - name: DEFAULT_TIMEOUT_MINUTES
@@ -935,7 +976,7 @@ presubmits:
           limits:
             memory: 4Gi
 
-  - name: pre-kubermatic-e2e-vsphere-ubuntu-1.19
+  - name: pre-kubermatic-e2e-vsphere-ubuntu-1.20
     decorate: true
     run_if_changed: "pkg/provider/cloud/vsphere"
     clone_uri: "ssh://git@github.com/kubermatic/kubermatic.git"
@@ -951,12 +992,12 @@ presubmits:
       preset-goproxy: "true"
     spec:
       containers:
-      - image: quay.io/kubermatic/e2e-kind:with-conformance-tests-v1.0.22
+      - image: quay.io/kubermatic/e2e-kind:with-conformance-tests-v1.0.23
         env:
         - name: KUBERMATIC_EDITION
           value: ee
         - name: VERSIONS_TO_TEST
-          value: "v1.19.3"
+          value: "v1.20.2"
         - name: PROVIDER
           value: "vsphere"
         - name: DISTRIBUTIONS
@@ -978,7 +1019,7 @@ presubmits:
           limits:
             memory: 4Gi
 
-  - name: pre-kubermatic-e2e-vsphere-ubuntu-1.19-customfolder
+  - name: pre-kubermatic-e2e-vsphere-ubuntu-1.20-customfolder
     decorate: true
     optional: true
     run_if_changed: "pkg/provider/cloud/vsphere"
@@ -995,12 +1036,12 @@ presubmits:
       preset-goproxy: "true"
     spec:
       containers:
-      - image: quay.io/kubermatic/e2e-kind:with-conformance-tests-v1.0.22
+      - image: quay.io/kubermatic/e2e-kind:with-conformance-tests-v1.0.23
         env:
         - name: KUBERMATIC_EDITION
           value: ee
         - name: VERSIONS_TO_TEST
-          value: "v1.19.3"
+          value: "v1.20.2"
         - name: PROVIDER
           value: "vsphere"
         - name: DISTRIBUTIONS
@@ -1024,7 +1065,7 @@ presubmits:
           limits:
             memory: 4Gi
 
-  - name: pre-kubermatic-e2e-vsphere-ubuntu-1.19-datastore-cluster
+  - name: pre-kubermatic-e2e-vsphere-ubuntu-1.20-datastore-cluster
     decorate: true
     optional: true
     run_if_changed: "pkg/provider/cloud/vsphere"
@@ -1041,12 +1082,12 @@ presubmits:
       preset-goproxy: "true"
     spec:
       containers:
-      - image: quay.io/kubermatic/e2e-kind:with-conformance-tests-v1.0.22
+      - image: quay.io/kubermatic/e2e-kind:with-conformance-tests-v1.0.23
         env:
         - name: KUBERMATIC_EDITION
           value: ee
         - name: VERSIONS_TO_TEST
-          value: "v1.19.3"
+          value: "v1.20.2"
         - name: PROVIDER
           value: "vsphere"
         - name: DISTRIBUTIONS
@@ -1092,7 +1133,7 @@ presubmits:
       preset-goproxy: "true"
     spec:
       containers:
-      - image: quay.io/kubermatic/e2e-kind:with-conformance-tests-v1.0.22
+      - image: quay.io/kubermatic/e2e-kind:with-conformance-tests-v1.0.23
         env:
         - name: KUBERMATIC_EDITION
           value: ee
@@ -1138,7 +1179,7 @@ presubmits:
       preset-goproxy: "true"
     spec:
       containers:
-      - image: quay.io/kubermatic/e2e-kind:with-conformance-tests-v1.0.22
+      - image: quay.io/kubermatic/e2e-kind:with-conformance-tests-v1.0.23
         imagePullPolicy: Always
         command:
         - "./hack/ci/run-api-e2e.sh"
@@ -1180,12 +1221,19 @@ presubmits:
       preset-goproxy: "true"
     spec:
       containers:
-      - image: quay.io/kubermatic/e2e-kind:with-conformance-tests-v1.0.22
+      - image: quay.io/kubermatic/e2e-kind:with-conformance-tests-v1.0.23
         command:
         - "./hack/ci/run-etcd-launcher-tests.sh"
         env:
         - name: VERSION_TO_TEST
-          value: v1.18.10
+          value: v1.20.2
+        - name: KUBERMATIC_EDITION
+          value: ee
+        - name: SERVICE_ACCOUNT_KEY
+          valueFrom:
+            secretKeyRef:
+              name: e2e-ci
+              key: serviceAccountSigningKey
         securityContext:
           privileged: true
         resources:
@@ -1194,14 +1242,6 @@ presubmits:
             cpu: 2
           limits:
             memory: 6Gi
-        env:
-        - name: KUBERMATIC_EDITION
-          value: ee
-        - name: SERVICE_ACCOUNT_KEY
-          valueFrom:
-            secretKeyRef:
-              name: e2e-ci
-              key: serviceAccountSigningKey
 
   #########################################################
   # NodePort Proxy e2e tests
@@ -1218,7 +1258,7 @@ presubmits:
       preset-goproxy: "true"
     spec:
       containers:
-      - image: quay.io/kubermatic/e2e-kind:with-conformance-tests-v1.0.22
+      - image: quay.io/kubermatic/e2e-kind:with-conformance-tests-v1.0.23
         imagePullPolicy: Always
         command:
         - make
@@ -1226,7 +1266,7 @@ presubmits:
         - run-nodeport-proxy-e2e-test-in-kind
         env:
         - name: KIND_NODE_VERSION
-          value: v1.18.2
+          value: v1.19.1
         securityContext:
           privileged: true
         resources:

--- a/addons/csi/controllerplugin.yaml
+++ b/addons/csi/controllerplugin.yaml
@@ -25,6 +25,9 @@
 {{ if eq .Cluster.MajorMinorVersion "1.19" }}
 {{ $version = "v1.19.0 "}}
 {{ end }}
+{{ if eq .Cluster.MajorMinorVersion "1.20" }}
+{{ $version = "v1.20.0 "}}
+{{ end }}
 
 kind: Service
 apiVersion: v1

--- a/addons/csi/nodeplugin.yaml
+++ b/addons/csi/nodeplugin.yaml
@@ -25,6 +25,9 @@
 {{ if eq .Cluster.MajorMinorVersion "1.19" }}
 {{ $version = "v1.19.0 "}}
 {{ end }}
+{{ if eq .Cluster.MajorMinorVersion "1.20" }}
+{{ $version = "v1.20.0 "}}
+{{ end }}
 
 kind: DaemonSet
 apiVersion: apps/v1

--- a/addons/kubelet-configmap/kubelet-configmap.yaml
+++ b/addons/kubelet-configmap/kubelet-configmap.yaml
@@ -356,3 +356,84 @@ data:
     streamingConnectionIdleTimeout: 4h0m0s
     syncFrequency: 1m0s
     volumeStatsAggPeriod: 1m0s
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: kubelet-config-1.20
+  namespace: kube-system
+data:
+  kubelet: |
+    address: 0.0.0.0
+    apiVersion: kubelet.config.k8s.io/v1beta1
+    authentication:
+      anonymous:
+        enabled: false
+      webhook:
+        cacheTTL: 2m0s
+        enabled: true
+      x509:
+        clientCAFile: /etc/kubernetes/pki/ca.crt
+    authorization:
+      mode: Webhook
+      webhook:
+        cacheAuthorizedTTL: 5m0s
+        cacheUnauthorizedTTL: 30s
+    cgroupDriver: cgroupfs
+    cgroupsPerQOS: true
+    clusterDNS:
+    - {{ .Cluster.Network.DNSResolverIP }}
+    clusterDomain: cluster.local
+    configMapAndSecretChangeDetectionStrategy: Watch
+    containerLogMaxFiles: 5
+    containerLogMaxSize: 10Mi
+    contentType: application/vnd.kubernetes.protobuf
+    cpuCFSQuota: true
+    cpuCFSQuotaPeriod: 100ms
+    cpuManagerPolicy: none
+    cpuManagerReconcilePeriod: 10s
+    enableControllerAttachDetach: true
+    enableDebuggingHandlers: true
+    enforceNodeAllocatable:
+    - pods
+    eventBurst: 10
+    eventRecordQPS: 5
+    evictionHard:
+      imagefs.available: 15%
+      memory.available: 100Mi
+      nodefs.available: 10%
+      nodefs.inodesFree: 5%
+    evictionPressureTransitionPeriod: 5m0s
+    failSwapOn: true
+    fileCheckFrequency: 20s
+    hairpinMode: promiscuous-bridge
+    healthzBindAddress: 127.0.0.1
+    healthzPort: 10248
+    httpCheckFrequency: 20s
+    imageGCHighThresholdPercent: 85
+    imageGCLowThresholdPercent: 80
+    imageMinimumGCAge: 2m0s
+    iptablesDropBit: 15
+    iptablesMasqueradeBit: 14
+    kind: KubeletConfiguration
+    kubeAPIBurst: 10
+    kubeAPIQPS: 5
+    makeIPTablesUtilChains: true
+    maxOpenFiles: 1000000
+    maxPods: 110
+    nodeLeaseDurationSeconds: 40
+    nodeStatusReportFrequency: 1m0s
+    nodeStatusUpdateFrequency: 10s
+    oomScoreAdj: -999
+    podPidsLimit: -1
+    port: 10250
+    registryBurst: 10
+    registryPullQPS: 5
+    resolvConf: /etc/resolv.conf
+    rotateCertificates: true
+    runtimeRequestTimeout: 2m0s
+    serializeImagePulls: true
+    staticPodPath: /etc/kubernetes/manifests
+    streamingConnectionIdleTimeout: 4h0m0s
+    syncFrequency: 1m0s
+    volumeStatsAggPeriod: 1m0s

--- a/addons/rbac/allow-kubeadm-join-configmap.yaml
+++ b/addons/rbac/allow-kubeadm-join-configmap.yaml
@@ -24,6 +24,7 @@ rules:
   - kubelet-config-1.17
   - kubelet-config-1.18
   - kubelet-config-1.19
+  - kubelet-config-1.20
   - kube-proxy
   - kubeadm-config
   resources:

--- a/charts/kubermatic/Chart.yaml
+++ b/charts/kubermatic/Chart.yaml
@@ -14,7 +14,7 @@
 
 apiVersion: v1
 name: kubermatic
-version: 1.1.27
+version: 1.1.28
 appVersion: '__KUBERMATIC_TAG__'
 description: Kubermatic chart for master and/or seed clusters.
 keywords:

--- a/charts/kubermatic/static/master/updates.yaml
+++ b/charts/kubermatic/static/master/updates.yaml
@@ -38,6 +38,12 @@ updates:
 - from: 1.19.*
   to: 1.19.*
   type: kubernetes
+- from: 1.19.*
+  to: 1.20.*
+  type: kubernetes
+- from: 1.20.*
+  to: 1.20.*
+  type: kubernetes
 - from: 4.1.*
   to: 4.1.*
   type: openshift

--- a/charts/kubermatic/static/master/versions.yaml
+++ b/charts/kubermatic/static/master/versions.yaml
@@ -10,18 +10,24 @@ versions:
 - type: kubernetes
   version: 1.17.13
 - type: kubernetes
+  version: 1.17.16
+- type: kubernetes
   version: 1.18.6
 - type: kubernetes
   version: 1.18.8
-- default: true
-  type: kubernetes
+- type: kubernetes
   version: 1.18.10
+- type: kubernetes
+  version: 1.18.14
 - type: kubernetes
   version: 1.19.0
 - type: kubernetes
   version: 1.19.2
-- type: kubernetes
+- default: true
+  type: kubernetes
   version: 1.19.3
+- type: kubernetes
+  version: 1.20.2
 - type: openshift
   version: 4.1.9
 - default: true

--- a/cmd/conformance-tests/runner.go
+++ b/cmd/conformance-tests/runner.go
@@ -1158,7 +1158,7 @@ func (r *testRunner) getGinkgoRuns(
 	nodeNumberTotal := int32(r.nodeCount)
 
 	ginkgoSkipParallel := `\[Serial\]`
-	if minor := cluster.Spec.Version.Minor(); minor >= 16 && minor <= 19 {
+	if minor := cluster.Spec.Version.Minor(); minor >= 16 && minor <= 20 {
 		// These require the nodes NodePort to be available from the tester, which is not the case for us.
 		// TODO: Maybe add an option to allow the NodePorts in the SecurityGroup?
 		ginkgoSkipParallel = strings.Join([]string{

--- a/docs/zz_generated.kubermaticConfiguration.yaml
+++ b/docs/zz_generated.kubermaticConfiguration.yaml
@@ -409,7 +409,7 @@ spec:
     # Kubernetes configures the Kubernetes versions and updates.
     kubernetes:
       # Default is the default version to offer users.
-      default: 1.18.10
+      default: 1.19.3
       # Updates is a list of available and automatic upgrades.
       # All 'to' versions must be configured in the version list for this orchestrator.
       # Each update may optionally be configured to be 'automatic: true', in which case the
@@ -453,18 +453,25 @@ spec:
           to: 1.19.*
         - from: 1.19.*
           to: 1.19.*
+        - from: 1.19.*
+          to: 1.20.*
+        - from: 1.20.*
+          to: 1.20.*
       # Versions lists the available versions.
       versions:
         - 1.17.9
         - 1.17.11
         - 1.17.12
         - 1.17.13
+        - 1.17.16
         - 1.18.6
         - 1.18.8
         - 1.18.10
+        - 1.18.14
         - 1.19.0
         - 1.19.2
         - 1.19.3
+        - 1.20.2
     # Openshift configures the Openshift versions and updates.
     openshift:
       # Default is the default version to offer users.

--- a/pkg/controller/operator/common/defaults.go
+++ b/pkg/controller/operator/common/defaults.go
@@ -188,21 +188,25 @@ var (
 	}
 
 	DefaultKubernetesVersioning = operatorv1alpha1.KubermaticVersioningConfiguration{
-		Default: semver.MustParse("v1.18.10"),
+		Default: semver.MustParse("v1.19.3"),
 		Versions: []*semver.Version{
 			// Kubernetes 1.17
 			semver.MustParse("v1.17.9"),
 			semver.MustParse("v1.17.11"),
 			semver.MustParse("v1.17.12"),
 			semver.MustParse("v1.17.13"),
+			semver.MustParse("v1.17.16"),
 			// Kubernetes 1.18
 			semver.MustParse("v1.18.6"),
 			semver.MustParse("v1.18.8"),
 			semver.MustParse("v1.18.10"),
+			semver.MustParse("v1.18.14"),
 			// Kubernetes 1.19
 			semver.MustParse("v1.19.0"),
 			semver.MustParse("v1.19.2"),
 			semver.MustParse("v1.19.3"),
+			// Kubernetes 1.20
+			semver.MustParse("v1.20.2"),
 		},
 		Updates: []operatorv1alpha1.Update{
 			{
@@ -273,6 +277,18 @@ var (
 				// Allow to change to any patch version
 				From: "1.19.*",
 				To:   "1.19.*",
+			},
+			{
+				// Allow to next minor release
+				From: "1.19.*",
+				To:   "1.20.*",
+			},
+
+			// ======= 1.20 =======
+			{
+				// Allow to change to any patch version
+				From: "1.20.*",
+				To:   "1.20.*",
 			},
 		},
 	}

--- a/pkg/resources/test/fixtures/configmap-aws-1.20.0-adm-control.yaml
+++ b/pkg/resources/test/fixtures/configmap-aws-1.20.0-adm-control.yaml
@@ -1,0 +1,8 @@
+# This file has been generated, DO NOT EDIT.
+
+data:
+  admission-control.yaml: |
+    kind: AdmissionConfiguration
+    apiVersion: apiserver.config.k8s.io/v1
+metadata:
+  creationTimestamp: null

--- a/pkg/resources/test/fixtures/configmap-aws-1.20.0-audit-config.yaml
+++ b/pkg/resources/test/fixtures/configmap-aws-1.20.0-audit-config.yaml
@@ -1,0 +1,10 @@
+# This file has been generated, DO NOT EDIT.
+
+data:
+  policy.yaml: |
+    apiVersion: audit.k8s.io/v1
+    kind: Policy
+    rules:
+    - level: Metadata
+metadata:
+  creationTimestamp: null

--- a/pkg/resources/test/fixtures/configmap-aws-1.20.0-cloud-config.yaml
+++ b/pkg/resources/test/fixtures/configmap-aws-1.20.0-cloud-config.yaml
@@ -1,0 +1,19 @@
+# This file has been generated, DO NOT EDIT.
+
+data:
+  config: |
+    [global]
+    Zone="us-central1x"
+    VPC="aws-vpn-id"
+    SubnetID=""
+    RouteTableID="aws-route-table-id"
+    RoleARN="aws-role-arn"
+    KubernetesClusterID="de-test-01"
+    DisableSecurityGroupIngress=false
+    ElbSecurityGroup=""
+    DisableStrictZoneCheck=true
+  fakeVmwareUUID: VMware-42 00 00 00 00 00 00 00-00 00 00 00 00 00 00 00
+metadata:
+  creationTimestamp: null
+  labels:
+    app: cloud-config

--- a/pkg/resources/test/fixtures/configmap-aws-1.20.0-dns-resolver.yaml
+++ b/pkg/resources/test/fixtures/configmap-aws-1.20.0-dns-resolver.yaml
@@ -1,0 +1,21 @@
+# This file has been generated, DO NOT EDIT.
+
+data:
+  Corefile: |2
+
+    cluster-de-test-01.svc.cluster.local. {
+        forward . /etc/resolv.conf
+        errors
+    }
+    cluster.local {
+        forward . 10.240.16.10
+        errors
+    }
+    . {
+      forward . /etc/resolv.conf
+      errors
+      health
+      prometheus 0.0.0.0:9253
+    }
+metadata:
+  creationTimestamp: null

--- a/pkg/resources/test/fixtures/configmap-aws-1.20.0-openvpn-client-configs.yaml
+++ b/pkg/resources/test/fixtures/configmap-aws-1.20.0-openvpn-client-configs.yaml
@@ -1,0 +1,11 @@
+# This file has been generated, DO NOT EDIT.
+
+data:
+  user-cluster-client: |
+    iroute 172.25.0.0 255.255.0.0
+    iroute 10.240.16.0 255.255.240.0
+    iroute 192.0.2.0 255.255.255.0
+metadata:
+  creationTimestamp: null
+  labels:
+    app: openvpn-server

--- a/pkg/resources/test/fixtures/configmap-aws-1.20.0-prometheus.yaml
+++ b/pkg/resources/test/fixtures/configmap-aws-1.20.0-prometheus.yaml
@@ -1,0 +1,623 @@
+# This file has been generated, DO NOT EDIT.
+
+data:
+  prometheus.yaml: |
+    global:
+      evaluation_interval: 30s
+      scrape_interval: 30s
+      external_labels:
+        cluster: "de-test-01"
+        seed_cluster: "testdc"
+
+    rule_files:
+    - "/etc/prometheus/config/rules*.yaml"
+
+    alerting:
+      alertmanagers:
+      - dns_sd_configs:
+        # configure the Seed's alertmanager for the user cluster
+        - names:
+          - 'alertmanager.monitoring.svc.cluster.local'
+          type: A
+          port: 9093
+
+    scrape_configs:
+    #######################################################################
+    # These rules will scrape pods running inside the seed cluster.
+
+    # scrape the etcd pods
+    - job_name: etcd
+      scheme: https
+      tls_config:
+        ca_file: /etc/etcd/pki/client/ca.crt
+        cert_file: /etc/etcd/pki/client/apiserver-etcd-client.crt
+        key_file: /etc/etcd/pki/client/apiserver-etcd-client.key
+
+      static_configs:
+      - targets:
+        - 'etcd-0.etcd.cluster-de-test-01.svc.cluster.local:2379'
+        - 'etcd-1.etcd.cluster-de-test-01.svc.cluster.local:2379'
+        - 'etcd-2.etcd.cluster-de-test-01.svc.cluster.local:2379'
+
+      relabel_configs:
+      - source_labels: [__address__]
+        regex: (etcd-\d+).+
+        action: replace
+        replacement: $1
+        target_label: instance
+
+    # scrape the cluster's control plane (apiserver, controller-manager, scheduler)
+    - job_name: kubernetes-control-plane
+      scheme: https
+      tls_config:
+        ca_file: /etc/kubernetes/ca.crt
+        cert_file: /etc/kubernetes/prometheus-client.crt
+        key_file: /etc/kubernetes/prometheus-client.key
+        # insecure_skip_verify is needed because the apiservers certificate
+        # does not contain a common name for the pod's ip address
+        insecure_skip_verify: true
+
+      kubernetes_sd_configs:
+      - role: pod
+        namespaces:
+          names:
+          - "cluster-de-test-01"
+
+      relabel_configs:
+      - source_labels: [__meta_kubernetes_pod_annotation_prometheus_io_scrape_with_kube_cert]
+        action: keep
+        regex: true
+      - source_labels: [__meta_kubernetes_pod_annotation_prometheus_io_path]
+        action: replace
+        target_label: __metrics_path__
+        regex: (.+)
+      - source_labels: [__address__, __meta_kubernetes_pod_annotation_prometheus_io_port]
+        action: replace
+        regex: ([^:]+)(?::\d+)?;(\d+)
+        replacement: $1:$2
+        target_label: __address__
+      - source_labels: [__meta_kubernetes_namespace]
+        action: replace
+        target_label: namespace
+      - source_labels: [__meta_kubernetes_pod_name]
+        action: replace
+        target_label: pod
+      - source_labels: [__meta_kubernetes_pod_label_app]
+        action: replace
+        target_label: job
+
+      # drop very expensive apiserver metrics
+      metric_relabel_configs:
+      - source_labels: [__name__]
+        regex: 'apiserver_request_(duration|latencies)_.*'
+        action: drop
+      - source_labels: [__name__]
+        regex: 'apiserver_response_sizes_.*'
+        action: drop
+
+    # scrape other cluster control plane components, like kube-state-metrics, DNS resolver,
+    # machine-controller etcd.
+    - job_name: control-plane-pods
+      kubernetes_sd_configs:
+      - role: pod
+        namespaces:
+          names:
+          - "cluster-de-test-01"
+
+      relabel_configs:
+      - source_labels: [__meta_kubernetes_pod_label_app, __meta_kubernetes_pod_container_init]
+        regex: "kube-state-metrics;true"
+        action: drop
+      - source_labels: [__meta_kubernetes_pod_annotation_prometheus_io_scrape]
+        action: keep
+        regex: true
+      - source_labels: [__meta_kubernetes_pod_annotation_prometheus_io_path]
+        action: replace
+        target_label: __metrics_path__
+        regex: (.+)
+      - source_labels: [__address__, __meta_kubernetes_pod_annotation_prometheus_io_port]
+        action: replace
+        regex: ([^:]+)(?::\d+)?;(\d+)
+        replacement: $1:$2
+        target_label: __address__
+      - source_labels: [__meta_kubernetes_pod_label_role, __meta_kubernetes_pod_label_app]
+        action: replace
+        target_label: job
+        separator: ''
+      - source_labels: [__meta_kubernetes_namespace]
+        action: replace
+        target_label: namespace
+      - source_labels: [__meta_kubernetes_pod_name]
+        action: replace
+        target_label: pod
+
+    #######################################################################
+    # These rules will scrape pods running inside the user cluster itself.
+
+    # scrape node metrics
+    - job_name: nodes
+      scheme: https
+      tls_config:
+        ca_file: /etc/kubernetes/ca.crt
+        cert_file: /etc/kubernetes/prometheus-client.crt
+        key_file: /etc/kubernetes/prometheus-client.key
+
+      kubernetes_sd_configs:
+      - role: node
+        api_server: 'https://apiserver-external.cluster-de-test-01.svc.cluster.local.'
+        tls_config:
+          ca_file: /etc/kubernetes/ca.crt
+          cert_file: /etc/kubernetes/prometheus-client.crt
+          key_file: /etc/kubernetes/prometheus-client.key
+
+      relabel_configs:
+      - action: labelmap
+        regex: __meta_kubernetes_node_label_(.+)
+      - target_label: __address__
+        replacement: 'apiserver-external.cluster-de-test-01.svc.cluster.local.'
+      - source_labels: [__meta_kubernetes_node_name]
+        regex: (.+)
+        target_label: __metrics_path__
+        replacement: /api/v1/nodes/${1}/proxy/metrics
+
+    # scrape node cadvisor
+    - job_name: cadvisor
+      scheme: https
+      tls_config:
+        ca_file: /etc/kubernetes/ca.crt
+        cert_file: /etc/kubernetes/prometheus-client.crt
+        key_file: /etc/kubernetes/prometheus-client.key
+
+      kubernetes_sd_configs:
+      - role: node
+        api_server: 'https://apiserver-external.cluster-de-test-01.svc.cluster.local.'
+        tls_config:
+          ca_file: /etc/kubernetes/ca.crt
+          cert_file: /etc/kubernetes/prometheus-client.crt
+          key_file: /etc/kubernetes/prometheus-client.key
+
+      relabel_configs:
+      - action: labelmap
+        regex: __meta_kubernetes_node_label_(.+)
+      - target_label: __address__
+        replacement: 'apiserver-external.cluster-de-test-01.svc.cluster.local.'
+      - source_labels: [__meta_kubernetes_node_name]
+        regex: (.+)
+        target_label: __metrics_path__
+        replacement: /api/v1/nodes/${1}/proxy/metrics/cadvisor
+
+    # scrape pods inside the user cluster with a special annotation
+    - job_name: 'user-cluster-pods'
+      scheme: https
+      tls_config:
+        ca_file: /etc/kubernetes/ca.crt
+        cert_file: /etc/kubernetes/prometheus-client.crt
+        key_file: /etc/kubernetes/prometheus-client.key
+
+      kubernetes_sd_configs:
+      - role: pod
+        api_server: 'https://apiserver-external.cluster-de-test-01.svc.cluster.local.'
+        tls_config:
+          ca_file: /etc/kubernetes/ca.crt
+          cert_file: /etc/kubernetes/prometheus-client.crt
+          key_file: /etc/kubernetes/prometheus-client.key
+
+      relabel_configs:
+      - source_labels: [__meta_kubernetes_pod_annotation_kubermatic_io_monitoring_port]
+        action: keep
+        regex: \d+
+      - source_labels: [__meta_kubernetes_pod_annotation_kubermatic_io_monitoring_path]
+        regex: (.+)
+        action: replace
+        target_label: __metrics_path__
+      - source_labels: [__meta_kubernetes_namespace, __meta_kubernetes_pod_name, __meta_kubernetes_pod_annotation_kubermatic_io_monitoring_port, __metrics_path__]
+        action: replace
+        regex: (.*);(.*);(.*);(.*)
+        target_label: __metrics_path__
+        replacement: /api/v1/namespaces/${1}/pods/${2}:${3}/proxy${4}
+      - target_label: __address__
+        replacement: 'apiserver-external.cluster-de-test-01.svc.cluster.local.'
+      - source_labels: [__meta_kubernetes_namespace]
+        action: replace
+        target_label: namespace
+      - source_labels: [__meta_kubernetes_pod_name]
+        action: replace
+        target_label: pod
+    #######################################################################
+    # custom scraping configurations
+
+    - job_name: custom-test-config
+      scheme: https
+      metrics_path: '/metrics'
+      static_configs:
+      - targets:
+        - 'foo.bar:12345'
+  rules.yaml: |
+    groups:
+    - name: kubermatic.goprocess
+      rules:
+      - record: job:process_resident_memory_bytes:clone
+        expr: process_resident_memory_bytes
+        labels:
+          kubermatic: federate
+
+      - record: job:process_cpu_seconds_total:rate5m
+        expr: rate(process_cpu_seconds_total[5m])
+        labels:
+          kubermatic: federate
+
+      - record: job:process_open_fds:clone
+        expr: process_open_fds
+        labels:
+          kubermatic: federate
+
+    - name: kubermatic.machine_controller
+      rules:
+      - record: job:machine_controller_errors_total:rate5m
+        expr: rate(machine_controller_errors_total[5m])
+        labels:
+          kubermatic: federate
+
+      - alert: KubernetesAdmissionWebhookHighRejectionRate
+        annotations:
+          message: '{{ $labels.operation }} requests for Machine objects are failing (Admission) with a high rate. Consider checking the affected objects'
+        expr: rate(apiserver_admission_webhook_admission_latencies_seconds_count{name="machine-controller.kubermatic.io-machines",rejected="true"}[5m]) > 0.01
+        for: 5m
+        labels:
+          severity: warning
+
+    - name: kubermatic.etcd
+      rules:
+      - record: job:etcd_server_has_leader:sum
+        expr: sum(etcd_server_has_leader)
+        labels:
+          kubermatic: federate
+
+      - record: job:etcd_disk_wal_fsync_duration_seconds_bucket:99percentile
+        expr: histogram_quantile(0.99, sum(rate(etcd_disk_wal_fsync_duration_seconds_bucket[5m])) by (instance, le))
+        labels:
+          kubermatic: federate
+
+      - record: job:etcd_disk_backend_commit_duration_seconds_bucket:99percentile
+        expr: histogram_quantile(0.99, sum(rate(etcd_disk_backend_commit_duration_seconds_bucket[5m])) by (instance, le))
+        labels:
+          kubermatic: federate
+
+      - record: job:etcd_debugging_mvcc_db_total_size_in_bytes:clone
+        expr: etcd_debugging_mvcc_db_total_size_in_bytes
+        labels:
+          kubermatic: federate
+
+      - record: job:etcd_network_client_grpc_received_bytes_total:rate5m
+        expr: rate(etcd_network_client_grpc_received_bytes_total[5m])
+        labels:
+          kubermatic: federate
+
+      - record: job:etcd_network_client_grpc_sent_bytes_total:rate5m
+        expr: rate(etcd_network_client_grpc_sent_bytes_total[5m])
+        labels:
+          kubermatic: federate
+
+      - record: job:etcd_network_peer_received_bytes_total:rate5msum
+        expr: sum(rate(etcd_network_peer_received_bytes_total[5m])) by (instance)
+        labels:
+          kubermatic: federate
+
+      - record: job:etcd_network_peer_sent_bytes_total:rate5msum
+        expr: sum(rate(etcd_network_peer_sent_bytes_total[5m])) by (instance)
+        labels:
+          kubermatic: federate
+
+      - record: job:etcd_server_proposals_failed_total:rate5msum
+        expr: sum(rate(etcd_server_proposals_failed_total[5m]))
+        labels:
+          kubermatic: federate
+
+      - record: job:etcd_server_proposals_pending:sum
+        expr: sum(etcd_server_proposals_pending)
+        labels:
+          kubermatic: federate
+
+      - record: job:etcd_server_proposals_committed_total:rate5msum
+        expr: sum(rate(etcd_server_proposals_committed_total[5m]))
+        labels:
+          kubermatic: federate
+
+      - record: job:etcd_server_proposals_applied_total:rate5msum
+        expr: sum(rate(etcd_server_proposals_applied_total[5m]))
+        labels:
+          kubermatic: federate
+
+      - record: job:etcd_server_leader_changes_seen_total:changes1d
+        expr: changes(etcd_server_leader_changes_seen_total[1d])
+        labels:
+          kubermatic: federate
+
+      - record: job:etcd_debugging_mvcc_delete_total:rate5m
+        expr: rate(etcd_debugging_mvcc_delete_total[5m])
+        labels:
+          kubermatic: federate
+
+      - record: job:etcd_debugging_mvcc_put_total:rate5m
+        expr: rate(etcd_debugging_mvcc_put_total[5m])
+        labels:
+          kubermatic: federate
+
+      - record: job:etcd_debugging_mvcc_range_total:rate5m
+        expr: rate(etcd_debugging_mvcc_range_total[5m])
+        labels:
+          kubermatic: federate
+
+      - record: job:etcd_debugging_mvcc_watcher_total:rate5m
+        expr: rate(etcd_debugging_mvcc_watcher_total[5m])
+        labels:
+          kubermatic: federate
+
+      - record: job:etcd_debugging_mvcc_txn_total:rate5m
+        expr: rate(etcd_debugging_mvcc_txn_total[5m])
+        labels:
+          kubermatic: federate
+
+      - record: job:etcd_debugging_mvcc_keys_total:clone
+        expr: etcd_debugging_mvcc_keys_total
+        labels:
+          kubermatic: federate
+
+      - record: job:etcd_debugging_store_reads_total:rate5m
+        expr: rate(etcd_debugging_store_reads_total[5m])
+        labels:
+          kubermatic: federate
+
+      - record: job:etcd_debugging_store_writes_total:rate5m
+        expr: rate(etcd_debugging_store_writes_total[5m])
+        labels:
+          kubermatic: federate
+
+      - record: job:etcd_debugging_store_expires_total:rate5m
+        expr: rate(etcd_debugging_store_expires_total[5m])
+        labels:
+          kubermatic: federate
+
+    - name: machine-controller
+      rules:
+      - alert: MachineControllerTooManyErrors
+        annotations:
+          message: Machine Controller in {{ $labels.namespace }} has too many errors in its loop.
+        expr: |
+          sum(rate(machine_controller_errors_total[5m])) by (namespace) > 0.01
+        for: 20m
+        labels:
+          severity: warning
+
+      - alert: MachineControllerMachineDeletionTakesTooLong
+        annotations:
+          message: Machine {{ $labels.machine }} of cluster {{ $labels.cluster }} is stuck in deletion for more than 30min.
+        expr: (time() - machine_controller_machine_deleted) > 30*60
+        for: 0m
+        labels:
+          severity: warning
+
+      - alert: AWSInstanceCountTooHigh
+        annotations:
+          message: '{{ $labels.machine }} has more than one instance at AWS'
+        expr: machine_controller_aws_instances_for_machine > 1
+        for: 30m
+        labels:
+          severity: warning
+
+      - record: job:machine_controller_errors_total:rate5m
+        expr: rate(machine_controller_errors_total[5m])
+        labels:
+          kubermatic: federate
+
+      - record: job:machine_controller_workers:sum
+        expr: sum(machine_controller_workers)
+        labels:
+          kubermatic: federate
+
+      - record: job:machine_controller_machines:sum
+        expr: sum(machine_controller_machines)
+        labels:
+          kubermatic: federate
+
+    - name: etcd
+      rules:
+      - alert: EtcdInsufficientMembers
+        annotations:
+          message: 'Etcd cluster "{{ $labels.job }}": insufficient members ({{ $value }}).'
+        expr: |
+          sum(up{job="etcd"} == bool 1) by (job) < ((count(up{job="etcd"}) by (job) + 1) / 2)
+        for: 15m
+        labels:
+          severity: critical
+
+      - alert: EtcdNoLeader
+        annotations:
+          message: 'Etcd cluster "{{ $labels.job }}": member {{ $labels.instance }} has no leader.'
+        expr: |
+          etcd_server_has_leader{job="etcd"} == 0
+        for: 15m
+        labels:
+          severity: critical
+
+      - alert: EtcdHighNumberOfLeaderChanges
+        annotations:
+          message: 'Etcd cluster "{{ $labels.job }}": instance {{ $labels.instance }} has seen {{ $value }} leader changes within the last hour.'
+        expr: |
+          rate(etcd_server_leader_changes_seen_total{job="etcd"}[15m]) > 3
+        for: 15m
+        labels:
+          severity: warning
+
+      - alert: EtcdGRPCRequestsSlow
+        annotations:
+          message: 'Etcd cluster "{{ $labels.job }}": gRPC requests to {{ $labels.grpc_method }} are taking {{ $value }}s on etcd instance {{ $labels.instance }}.'
+        expr: |
+          histogram_quantile(0.99, sum(rate(grpc_server_handling_seconds_bucket{job="etcd", grpc_type="unary"}[5m])) by (job, instance, grpc_service, grpc_method, le))
+          > 0.15
+        for: 10m
+        labels:
+          severity: critical
+
+      - alert: EtcdMemberCommunicationSlow
+        annotations:
+          message: 'Etcd cluster "{{ $labels.job }}": member communication with {{ $labels.To }} is taking {{ $value }}s on etcd instance {{ $labels.instance }}.'
+        expr: |
+          histogram_quantile(0.99, rate(etcd_network_peer_round_trip_time_seconds_bucket{job="etcd"}[5m]))
+          > 0.15
+        for: 10m
+        labels:
+          severity: warning
+
+      - alert: EtcdHighNumberOfFailedProposals
+        annotations:
+          message: 'Etcd cluster "{{ $labels.job }}": {{ $value }} proposal failures within the last hour on etcd instance {{ $labels.instance }}.'
+        expr: |
+          rate(etcd_server_proposals_failed_total{job="etcd"}[15m]) > 5
+        for: 15m
+        labels:
+          severity: warning
+
+      - alert: EtcdHighFsyncDurations
+        annotations:
+          message: 'Etcd cluster "{{ $labels.job }}": 99th percentile fync durations are {{ $value }}s on etcd instance {{ $labels.instance }}.'
+        expr: |
+          histogram_quantile(0.99, rate(etcd_disk_wal_fsync_duration_seconds_bucket{job="etcd"}[5m]))
+          > 0.5
+        for: 10m
+        labels:
+          severity: warning
+
+      - alert: EtcdHighCommitDurations
+        annotations:
+          message: 'Etcd cluster "{{ $labels.job }}": 99th percentile commit durations {{ $value }}s on etcd instance {{ $labels.instance }}.'
+        expr: |
+          histogram_quantile(0.99, rate(etcd_disk_backend_commit_duration_seconds_bucket{job="etcd"}[5m]))
+          > 0.25
+        for: 10m
+        labels:
+          severity: warning
+
+    - name: process.filedescriptors
+      rules:
+      - expr: process_open_fds / process_max_fds
+        record: instance:fd_utilization
+
+      - alert: FdExhaustionClose
+        annotations:
+          message: '{{ $labels.job }} instance {{ $labels.instance }} will exhaust its file descriptors soon'
+        expr: |
+          predict_linear(instance:fd_utilization[1h], 3600 * 4) > 1
+        for: 10m
+        labels:
+          severity: warning
+
+      - alert: FdExhaustionClose
+        annotations:
+          message: '{{ $labels.job }} instance {{ $labels.instance }} will exhaust its file descriptors soon'
+        expr: |
+          predict_linear(instance:fd_utilization[10m], 3600) > 1
+        for: 10m
+        labels:
+          severity: critical
+
+    - name: kubernetes-absent
+      rules:
+      - alert: KubernetesApiserverDown
+        annotations:
+          message: Kubernetes apiserver has disappeared from Prometheus target discovery.
+        expr: absent(up{job="apiserver"} == 1)
+        for: 15m
+        labels:
+          severity: critical
+
+      - alert: KubernetesControllerManagerDown
+        annotations:
+          message: Kubernetes controller-manager has disappeared from Prometheus target discovery.
+        expr: absent(up{job="controller-manager"} == 1) and absent(up{job="openshift-controller-manager"} == 1)
+        for: 15m
+        labels:
+          severity: critical
+
+      - alert: KubernetesSchedulerDown
+        annotations:
+          message: Kubernetes scheduler has disappeared from Prometheus target discovery.
+        expr: absent(up{job="scheduler"} == 1) and absent(up{job="openshift-controller-manager"} == 1)
+        for: 15m
+        labels:
+          severity: critical
+
+      - alert: MachineControllerDown
+        annotations:
+          message: Machine controller has disappeared from Prometheus target discovery.
+        expr: absent(up{job="machine-controller"} == 1)
+        for: 15m
+        labels:
+          severity: critical
+
+      - alert: UserClusterControllerDown
+        annotations:
+          message: User Cluster Controller has disappeared from Prometheus target discovery.
+        expr: absent(up{job="usercluster-controller"} == 1)
+        for: 15m
+        labels:
+          severity: critical
+
+      - alert: KubeStateMetricsDown
+        annotations:
+          message: Kube-state-metrics has disappeared from Prometheus target discovery.
+        expr: absent(up{job="kube-state-metrics"} == 1)
+        for: 15m
+        labels:
+          severity: warning
+
+      - alert: EtcdDown
+        annotations:
+          message: Etcd has disappeared from Prometheus target discovery.
+        expr: absent(up{job="etcd"} == 1)
+        for: 15m
+        labels:
+          severity: critical
+
+      # This is triggered if the cluster does have nodes, but the cadvisor could
+      # not successfully be scraped for whatever reason. An absent() on cadvisor
+      # metrics is not a good alert because clusters could simply have no nodes
+      # and hence no cadvisors.
+      - alert: CAdvisorDown
+        annotations:
+          message: cAdvisor on {{ $labels.kubernetes_io_hostname }} could not be scraped.
+        expr: up{job="cadvisor"} == 0
+        for: 15m
+        labels:
+          severity: warning
+
+      # This functions similarly to the cadvisor alert above.
+      - alert: KubernetesNodeDown
+        annotations:
+          message: The kubelet on {{ $labels.kubernetes_io_hostname }} could not be scraped.
+        expr: up{job="kubernetes-nodes"} == 0
+        for: 15m
+        labels:
+          severity: warning
+
+      - alert: DNSResolverDown
+        annotations:
+          message: DNS resolver has disappeared from Prometheus target discovery.
+        expr: absent(up{job="dns-resolver"} == 1)
+        for: 15m
+        labels:
+          severity: warning
+
+    - name: kubernetes-nodes
+      rules:
+      - alert: KubernetesNodeNotReady
+        annotations:
+          message: '{{ $labels.node }} has been unready for more than an hour.'
+        expr: kube_node_status_condition{condition="Ready",status="true"} == 0
+        for: 30m
+        labels:
+          severity: warning
+metadata:
+  creationTimestamp: null
+  labels:
+    app: prometheus

--- a/pkg/resources/test/fixtures/configmap-azure-1.20.0-adm-control.yaml
+++ b/pkg/resources/test/fixtures/configmap-azure-1.20.0-adm-control.yaml
@@ -1,0 +1,8 @@
+# This file has been generated, DO NOT EDIT.
+
+data:
+  admission-control.yaml: |
+    kind: AdmissionConfiguration
+    apiVersion: apiserver.config.k8s.io/v1
+metadata:
+  creationTimestamp: null

--- a/pkg/resources/test/fixtures/configmap-azure-1.20.0-audit-config.yaml
+++ b/pkg/resources/test/fixtures/configmap-azure-1.20.0-audit-config.yaml
@@ -1,0 +1,10 @@
+# This file has been generated, DO NOT EDIT.
+
+data:
+  policy.yaml: |
+    apiVersion: audit.k8s.io/v1
+    kind: Policy
+    rules:
+    - level: Metadata
+metadata:
+  creationTimestamp: null

--- a/pkg/resources/test/fixtures/configmap-azure-1.20.0-cloud-config.yaml
+++ b/pkg/resources/test/fixtures/configmap-azure-1.20.0-cloud-config.yaml
@@ -1,0 +1,9 @@
+# This file has been generated, DO NOT EDIT.
+
+data:
+  config: '{"cloud":"AZUREPUBLICCLOUD","tenantId":"az-tenant-id","subscriptionId":"az-subscription-id","aadClientId":"az-client-id","aadClientSecret":"az-client-secret","resourceGroup":"az-res-group","location":"az-location","vnetName":"az-vnet-name","subnetName":"az-subnet-name","routeTableName":"az-route-table-name","securityGroupName":"az-sec-group","primaryAvailabilitySetName":"az-availability-set","vnetResourceGroup":"az-res-group","useInstanceMetadata":false}'
+  fakeVmwareUUID: VMware-42 00 00 00 00 00 00 00-00 00 00 00 00 00 00 00
+metadata:
+  creationTimestamp: null
+  labels:
+    app: cloud-config

--- a/pkg/resources/test/fixtures/configmap-azure-1.20.0-dns-resolver.yaml
+++ b/pkg/resources/test/fixtures/configmap-azure-1.20.0-dns-resolver.yaml
@@ -1,0 +1,21 @@
+# This file has been generated, DO NOT EDIT.
+
+data:
+  Corefile: |2
+
+    cluster-de-test-01.svc.cluster.local. {
+        forward . /etc/resolv.conf
+        errors
+    }
+    cluster.local {
+        forward . 10.240.16.10
+        errors
+    }
+    . {
+      forward . /etc/resolv.conf
+      errors
+      health
+      prometheus 0.0.0.0:9253
+    }
+metadata:
+  creationTimestamp: null

--- a/pkg/resources/test/fixtures/configmap-azure-1.20.0-openvpn-client-configs.yaml
+++ b/pkg/resources/test/fixtures/configmap-azure-1.20.0-openvpn-client-configs.yaml
@@ -1,0 +1,11 @@
+# This file has been generated, DO NOT EDIT.
+
+data:
+  user-cluster-client: |
+    iroute 172.25.0.0 255.255.0.0
+    iroute 10.240.16.0 255.255.240.0
+    iroute 192.0.2.0 255.255.255.0
+metadata:
+  creationTimestamp: null
+  labels:
+    app: openvpn-server

--- a/pkg/resources/test/fixtures/configmap-azure-1.20.0-prometheus.yaml
+++ b/pkg/resources/test/fixtures/configmap-azure-1.20.0-prometheus.yaml
@@ -1,0 +1,623 @@
+# This file has been generated, DO NOT EDIT.
+
+data:
+  prometheus.yaml: |
+    global:
+      evaluation_interval: 30s
+      scrape_interval: 30s
+      external_labels:
+        cluster: "de-test-01"
+        seed_cluster: "testdc"
+
+    rule_files:
+    - "/etc/prometheus/config/rules*.yaml"
+
+    alerting:
+      alertmanagers:
+      - dns_sd_configs:
+        # configure the Seed's alertmanager for the user cluster
+        - names:
+          - 'alertmanager.monitoring.svc.cluster.local'
+          type: A
+          port: 9093
+
+    scrape_configs:
+    #######################################################################
+    # These rules will scrape pods running inside the seed cluster.
+
+    # scrape the etcd pods
+    - job_name: etcd
+      scheme: https
+      tls_config:
+        ca_file: /etc/etcd/pki/client/ca.crt
+        cert_file: /etc/etcd/pki/client/apiserver-etcd-client.crt
+        key_file: /etc/etcd/pki/client/apiserver-etcd-client.key
+
+      static_configs:
+      - targets:
+        - 'etcd-0.etcd.cluster-de-test-01.svc.cluster.local:2379'
+        - 'etcd-1.etcd.cluster-de-test-01.svc.cluster.local:2379'
+        - 'etcd-2.etcd.cluster-de-test-01.svc.cluster.local:2379'
+
+      relabel_configs:
+      - source_labels: [__address__]
+        regex: (etcd-\d+).+
+        action: replace
+        replacement: $1
+        target_label: instance
+
+    # scrape the cluster's control plane (apiserver, controller-manager, scheduler)
+    - job_name: kubernetes-control-plane
+      scheme: https
+      tls_config:
+        ca_file: /etc/kubernetes/ca.crt
+        cert_file: /etc/kubernetes/prometheus-client.crt
+        key_file: /etc/kubernetes/prometheus-client.key
+        # insecure_skip_verify is needed because the apiservers certificate
+        # does not contain a common name for the pod's ip address
+        insecure_skip_verify: true
+
+      kubernetes_sd_configs:
+      - role: pod
+        namespaces:
+          names:
+          - "cluster-de-test-01"
+
+      relabel_configs:
+      - source_labels: [__meta_kubernetes_pod_annotation_prometheus_io_scrape_with_kube_cert]
+        action: keep
+        regex: true
+      - source_labels: [__meta_kubernetes_pod_annotation_prometheus_io_path]
+        action: replace
+        target_label: __metrics_path__
+        regex: (.+)
+      - source_labels: [__address__, __meta_kubernetes_pod_annotation_prometheus_io_port]
+        action: replace
+        regex: ([^:]+)(?::\d+)?;(\d+)
+        replacement: $1:$2
+        target_label: __address__
+      - source_labels: [__meta_kubernetes_namespace]
+        action: replace
+        target_label: namespace
+      - source_labels: [__meta_kubernetes_pod_name]
+        action: replace
+        target_label: pod
+      - source_labels: [__meta_kubernetes_pod_label_app]
+        action: replace
+        target_label: job
+
+      # drop very expensive apiserver metrics
+      metric_relabel_configs:
+      - source_labels: [__name__]
+        regex: 'apiserver_request_(duration|latencies)_.*'
+        action: drop
+      - source_labels: [__name__]
+        regex: 'apiserver_response_sizes_.*'
+        action: drop
+
+    # scrape other cluster control plane components, like kube-state-metrics, DNS resolver,
+    # machine-controller etcd.
+    - job_name: control-plane-pods
+      kubernetes_sd_configs:
+      - role: pod
+        namespaces:
+          names:
+          - "cluster-de-test-01"
+
+      relabel_configs:
+      - source_labels: [__meta_kubernetes_pod_label_app, __meta_kubernetes_pod_container_init]
+        regex: "kube-state-metrics;true"
+        action: drop
+      - source_labels: [__meta_kubernetes_pod_annotation_prometheus_io_scrape]
+        action: keep
+        regex: true
+      - source_labels: [__meta_kubernetes_pod_annotation_prometheus_io_path]
+        action: replace
+        target_label: __metrics_path__
+        regex: (.+)
+      - source_labels: [__address__, __meta_kubernetes_pod_annotation_prometheus_io_port]
+        action: replace
+        regex: ([^:]+)(?::\d+)?;(\d+)
+        replacement: $1:$2
+        target_label: __address__
+      - source_labels: [__meta_kubernetes_pod_label_role, __meta_kubernetes_pod_label_app]
+        action: replace
+        target_label: job
+        separator: ''
+      - source_labels: [__meta_kubernetes_namespace]
+        action: replace
+        target_label: namespace
+      - source_labels: [__meta_kubernetes_pod_name]
+        action: replace
+        target_label: pod
+
+    #######################################################################
+    # These rules will scrape pods running inside the user cluster itself.
+
+    # scrape node metrics
+    - job_name: nodes
+      scheme: https
+      tls_config:
+        ca_file: /etc/kubernetes/ca.crt
+        cert_file: /etc/kubernetes/prometheus-client.crt
+        key_file: /etc/kubernetes/prometheus-client.key
+
+      kubernetes_sd_configs:
+      - role: node
+        api_server: 'https://apiserver-external.cluster-de-test-01.svc.cluster.local.'
+        tls_config:
+          ca_file: /etc/kubernetes/ca.crt
+          cert_file: /etc/kubernetes/prometheus-client.crt
+          key_file: /etc/kubernetes/prometheus-client.key
+
+      relabel_configs:
+      - action: labelmap
+        regex: __meta_kubernetes_node_label_(.+)
+      - target_label: __address__
+        replacement: 'apiserver-external.cluster-de-test-01.svc.cluster.local.'
+      - source_labels: [__meta_kubernetes_node_name]
+        regex: (.+)
+        target_label: __metrics_path__
+        replacement: /api/v1/nodes/${1}/proxy/metrics
+
+    # scrape node cadvisor
+    - job_name: cadvisor
+      scheme: https
+      tls_config:
+        ca_file: /etc/kubernetes/ca.crt
+        cert_file: /etc/kubernetes/prometheus-client.crt
+        key_file: /etc/kubernetes/prometheus-client.key
+
+      kubernetes_sd_configs:
+      - role: node
+        api_server: 'https://apiserver-external.cluster-de-test-01.svc.cluster.local.'
+        tls_config:
+          ca_file: /etc/kubernetes/ca.crt
+          cert_file: /etc/kubernetes/prometheus-client.crt
+          key_file: /etc/kubernetes/prometheus-client.key
+
+      relabel_configs:
+      - action: labelmap
+        regex: __meta_kubernetes_node_label_(.+)
+      - target_label: __address__
+        replacement: 'apiserver-external.cluster-de-test-01.svc.cluster.local.'
+      - source_labels: [__meta_kubernetes_node_name]
+        regex: (.+)
+        target_label: __metrics_path__
+        replacement: /api/v1/nodes/${1}/proxy/metrics/cadvisor
+
+    # scrape pods inside the user cluster with a special annotation
+    - job_name: 'user-cluster-pods'
+      scheme: https
+      tls_config:
+        ca_file: /etc/kubernetes/ca.crt
+        cert_file: /etc/kubernetes/prometheus-client.crt
+        key_file: /etc/kubernetes/prometheus-client.key
+
+      kubernetes_sd_configs:
+      - role: pod
+        api_server: 'https://apiserver-external.cluster-de-test-01.svc.cluster.local.'
+        tls_config:
+          ca_file: /etc/kubernetes/ca.crt
+          cert_file: /etc/kubernetes/prometheus-client.crt
+          key_file: /etc/kubernetes/prometheus-client.key
+
+      relabel_configs:
+      - source_labels: [__meta_kubernetes_pod_annotation_kubermatic_io_monitoring_port]
+        action: keep
+        regex: \d+
+      - source_labels: [__meta_kubernetes_pod_annotation_kubermatic_io_monitoring_path]
+        regex: (.+)
+        action: replace
+        target_label: __metrics_path__
+      - source_labels: [__meta_kubernetes_namespace, __meta_kubernetes_pod_name, __meta_kubernetes_pod_annotation_kubermatic_io_monitoring_port, __metrics_path__]
+        action: replace
+        regex: (.*);(.*);(.*);(.*)
+        target_label: __metrics_path__
+        replacement: /api/v1/namespaces/${1}/pods/${2}:${3}/proxy${4}
+      - target_label: __address__
+        replacement: 'apiserver-external.cluster-de-test-01.svc.cluster.local.'
+      - source_labels: [__meta_kubernetes_namespace]
+        action: replace
+        target_label: namespace
+      - source_labels: [__meta_kubernetes_pod_name]
+        action: replace
+        target_label: pod
+    #######################################################################
+    # custom scraping configurations
+
+    - job_name: custom-test-config
+      scheme: https
+      metrics_path: '/metrics'
+      static_configs:
+      - targets:
+        - 'foo.bar:12345'
+  rules.yaml: |
+    groups:
+    - name: kubermatic.goprocess
+      rules:
+      - record: job:process_resident_memory_bytes:clone
+        expr: process_resident_memory_bytes
+        labels:
+          kubermatic: federate
+
+      - record: job:process_cpu_seconds_total:rate5m
+        expr: rate(process_cpu_seconds_total[5m])
+        labels:
+          kubermatic: federate
+
+      - record: job:process_open_fds:clone
+        expr: process_open_fds
+        labels:
+          kubermatic: federate
+
+    - name: kubermatic.machine_controller
+      rules:
+      - record: job:machine_controller_errors_total:rate5m
+        expr: rate(machine_controller_errors_total[5m])
+        labels:
+          kubermatic: federate
+
+      - alert: KubernetesAdmissionWebhookHighRejectionRate
+        annotations:
+          message: '{{ $labels.operation }} requests for Machine objects are failing (Admission) with a high rate. Consider checking the affected objects'
+        expr: rate(apiserver_admission_webhook_admission_latencies_seconds_count{name="machine-controller.kubermatic.io-machines",rejected="true"}[5m]) > 0.01
+        for: 5m
+        labels:
+          severity: warning
+
+    - name: kubermatic.etcd
+      rules:
+      - record: job:etcd_server_has_leader:sum
+        expr: sum(etcd_server_has_leader)
+        labels:
+          kubermatic: federate
+
+      - record: job:etcd_disk_wal_fsync_duration_seconds_bucket:99percentile
+        expr: histogram_quantile(0.99, sum(rate(etcd_disk_wal_fsync_duration_seconds_bucket[5m])) by (instance, le))
+        labels:
+          kubermatic: federate
+
+      - record: job:etcd_disk_backend_commit_duration_seconds_bucket:99percentile
+        expr: histogram_quantile(0.99, sum(rate(etcd_disk_backend_commit_duration_seconds_bucket[5m])) by (instance, le))
+        labels:
+          kubermatic: federate
+
+      - record: job:etcd_debugging_mvcc_db_total_size_in_bytes:clone
+        expr: etcd_debugging_mvcc_db_total_size_in_bytes
+        labels:
+          kubermatic: federate
+
+      - record: job:etcd_network_client_grpc_received_bytes_total:rate5m
+        expr: rate(etcd_network_client_grpc_received_bytes_total[5m])
+        labels:
+          kubermatic: federate
+
+      - record: job:etcd_network_client_grpc_sent_bytes_total:rate5m
+        expr: rate(etcd_network_client_grpc_sent_bytes_total[5m])
+        labels:
+          kubermatic: federate
+
+      - record: job:etcd_network_peer_received_bytes_total:rate5msum
+        expr: sum(rate(etcd_network_peer_received_bytes_total[5m])) by (instance)
+        labels:
+          kubermatic: federate
+
+      - record: job:etcd_network_peer_sent_bytes_total:rate5msum
+        expr: sum(rate(etcd_network_peer_sent_bytes_total[5m])) by (instance)
+        labels:
+          kubermatic: federate
+
+      - record: job:etcd_server_proposals_failed_total:rate5msum
+        expr: sum(rate(etcd_server_proposals_failed_total[5m]))
+        labels:
+          kubermatic: federate
+
+      - record: job:etcd_server_proposals_pending:sum
+        expr: sum(etcd_server_proposals_pending)
+        labels:
+          kubermatic: federate
+
+      - record: job:etcd_server_proposals_committed_total:rate5msum
+        expr: sum(rate(etcd_server_proposals_committed_total[5m]))
+        labels:
+          kubermatic: federate
+
+      - record: job:etcd_server_proposals_applied_total:rate5msum
+        expr: sum(rate(etcd_server_proposals_applied_total[5m]))
+        labels:
+          kubermatic: federate
+
+      - record: job:etcd_server_leader_changes_seen_total:changes1d
+        expr: changes(etcd_server_leader_changes_seen_total[1d])
+        labels:
+          kubermatic: federate
+
+      - record: job:etcd_debugging_mvcc_delete_total:rate5m
+        expr: rate(etcd_debugging_mvcc_delete_total[5m])
+        labels:
+          kubermatic: federate
+
+      - record: job:etcd_debugging_mvcc_put_total:rate5m
+        expr: rate(etcd_debugging_mvcc_put_total[5m])
+        labels:
+          kubermatic: federate
+
+      - record: job:etcd_debugging_mvcc_range_total:rate5m
+        expr: rate(etcd_debugging_mvcc_range_total[5m])
+        labels:
+          kubermatic: federate
+
+      - record: job:etcd_debugging_mvcc_watcher_total:rate5m
+        expr: rate(etcd_debugging_mvcc_watcher_total[5m])
+        labels:
+          kubermatic: federate
+
+      - record: job:etcd_debugging_mvcc_txn_total:rate5m
+        expr: rate(etcd_debugging_mvcc_txn_total[5m])
+        labels:
+          kubermatic: federate
+
+      - record: job:etcd_debugging_mvcc_keys_total:clone
+        expr: etcd_debugging_mvcc_keys_total
+        labels:
+          kubermatic: federate
+
+      - record: job:etcd_debugging_store_reads_total:rate5m
+        expr: rate(etcd_debugging_store_reads_total[5m])
+        labels:
+          kubermatic: federate
+
+      - record: job:etcd_debugging_store_writes_total:rate5m
+        expr: rate(etcd_debugging_store_writes_total[5m])
+        labels:
+          kubermatic: federate
+
+      - record: job:etcd_debugging_store_expires_total:rate5m
+        expr: rate(etcd_debugging_store_expires_total[5m])
+        labels:
+          kubermatic: federate
+
+    - name: machine-controller
+      rules:
+      - alert: MachineControllerTooManyErrors
+        annotations:
+          message: Machine Controller in {{ $labels.namespace }} has too many errors in its loop.
+        expr: |
+          sum(rate(machine_controller_errors_total[5m])) by (namespace) > 0.01
+        for: 20m
+        labels:
+          severity: warning
+
+      - alert: MachineControllerMachineDeletionTakesTooLong
+        annotations:
+          message: Machine {{ $labels.machine }} of cluster {{ $labels.cluster }} is stuck in deletion for more than 30min.
+        expr: (time() - machine_controller_machine_deleted) > 30*60
+        for: 0m
+        labels:
+          severity: warning
+
+      - alert: AWSInstanceCountTooHigh
+        annotations:
+          message: '{{ $labels.machine }} has more than one instance at AWS'
+        expr: machine_controller_aws_instances_for_machine > 1
+        for: 30m
+        labels:
+          severity: warning
+
+      - record: job:machine_controller_errors_total:rate5m
+        expr: rate(machine_controller_errors_total[5m])
+        labels:
+          kubermatic: federate
+
+      - record: job:machine_controller_workers:sum
+        expr: sum(machine_controller_workers)
+        labels:
+          kubermatic: federate
+
+      - record: job:machine_controller_machines:sum
+        expr: sum(machine_controller_machines)
+        labels:
+          kubermatic: federate
+
+    - name: etcd
+      rules:
+      - alert: EtcdInsufficientMembers
+        annotations:
+          message: 'Etcd cluster "{{ $labels.job }}": insufficient members ({{ $value }}).'
+        expr: |
+          sum(up{job="etcd"} == bool 1) by (job) < ((count(up{job="etcd"}) by (job) + 1) / 2)
+        for: 15m
+        labels:
+          severity: critical
+
+      - alert: EtcdNoLeader
+        annotations:
+          message: 'Etcd cluster "{{ $labels.job }}": member {{ $labels.instance }} has no leader.'
+        expr: |
+          etcd_server_has_leader{job="etcd"} == 0
+        for: 15m
+        labels:
+          severity: critical
+
+      - alert: EtcdHighNumberOfLeaderChanges
+        annotations:
+          message: 'Etcd cluster "{{ $labels.job }}": instance {{ $labels.instance }} has seen {{ $value }} leader changes within the last hour.'
+        expr: |
+          rate(etcd_server_leader_changes_seen_total{job="etcd"}[15m]) > 3
+        for: 15m
+        labels:
+          severity: warning
+
+      - alert: EtcdGRPCRequestsSlow
+        annotations:
+          message: 'Etcd cluster "{{ $labels.job }}": gRPC requests to {{ $labels.grpc_method }} are taking {{ $value }}s on etcd instance {{ $labels.instance }}.'
+        expr: |
+          histogram_quantile(0.99, sum(rate(grpc_server_handling_seconds_bucket{job="etcd", grpc_type="unary"}[5m])) by (job, instance, grpc_service, grpc_method, le))
+          > 0.15
+        for: 10m
+        labels:
+          severity: critical
+
+      - alert: EtcdMemberCommunicationSlow
+        annotations:
+          message: 'Etcd cluster "{{ $labels.job }}": member communication with {{ $labels.To }} is taking {{ $value }}s on etcd instance {{ $labels.instance }}.'
+        expr: |
+          histogram_quantile(0.99, rate(etcd_network_peer_round_trip_time_seconds_bucket{job="etcd"}[5m]))
+          > 0.15
+        for: 10m
+        labels:
+          severity: warning
+
+      - alert: EtcdHighNumberOfFailedProposals
+        annotations:
+          message: 'Etcd cluster "{{ $labels.job }}": {{ $value }} proposal failures within the last hour on etcd instance {{ $labels.instance }}.'
+        expr: |
+          rate(etcd_server_proposals_failed_total{job="etcd"}[15m]) > 5
+        for: 15m
+        labels:
+          severity: warning
+
+      - alert: EtcdHighFsyncDurations
+        annotations:
+          message: 'Etcd cluster "{{ $labels.job }}": 99th percentile fync durations are {{ $value }}s on etcd instance {{ $labels.instance }}.'
+        expr: |
+          histogram_quantile(0.99, rate(etcd_disk_wal_fsync_duration_seconds_bucket{job="etcd"}[5m]))
+          > 0.5
+        for: 10m
+        labels:
+          severity: warning
+
+      - alert: EtcdHighCommitDurations
+        annotations:
+          message: 'Etcd cluster "{{ $labels.job }}": 99th percentile commit durations {{ $value }}s on etcd instance {{ $labels.instance }}.'
+        expr: |
+          histogram_quantile(0.99, rate(etcd_disk_backend_commit_duration_seconds_bucket{job="etcd"}[5m]))
+          > 0.25
+        for: 10m
+        labels:
+          severity: warning
+
+    - name: process.filedescriptors
+      rules:
+      - expr: process_open_fds / process_max_fds
+        record: instance:fd_utilization
+
+      - alert: FdExhaustionClose
+        annotations:
+          message: '{{ $labels.job }} instance {{ $labels.instance }} will exhaust its file descriptors soon'
+        expr: |
+          predict_linear(instance:fd_utilization[1h], 3600 * 4) > 1
+        for: 10m
+        labels:
+          severity: warning
+
+      - alert: FdExhaustionClose
+        annotations:
+          message: '{{ $labels.job }} instance {{ $labels.instance }} will exhaust its file descriptors soon'
+        expr: |
+          predict_linear(instance:fd_utilization[10m], 3600) > 1
+        for: 10m
+        labels:
+          severity: critical
+
+    - name: kubernetes-absent
+      rules:
+      - alert: KubernetesApiserverDown
+        annotations:
+          message: Kubernetes apiserver has disappeared from Prometheus target discovery.
+        expr: absent(up{job="apiserver"} == 1)
+        for: 15m
+        labels:
+          severity: critical
+
+      - alert: KubernetesControllerManagerDown
+        annotations:
+          message: Kubernetes controller-manager has disappeared from Prometheus target discovery.
+        expr: absent(up{job="controller-manager"} == 1) and absent(up{job="openshift-controller-manager"} == 1)
+        for: 15m
+        labels:
+          severity: critical
+
+      - alert: KubernetesSchedulerDown
+        annotations:
+          message: Kubernetes scheduler has disappeared from Prometheus target discovery.
+        expr: absent(up{job="scheduler"} == 1) and absent(up{job="openshift-controller-manager"} == 1)
+        for: 15m
+        labels:
+          severity: critical
+
+      - alert: MachineControllerDown
+        annotations:
+          message: Machine controller has disappeared from Prometheus target discovery.
+        expr: absent(up{job="machine-controller"} == 1)
+        for: 15m
+        labels:
+          severity: critical
+
+      - alert: UserClusterControllerDown
+        annotations:
+          message: User Cluster Controller has disappeared from Prometheus target discovery.
+        expr: absent(up{job="usercluster-controller"} == 1)
+        for: 15m
+        labels:
+          severity: critical
+
+      - alert: KubeStateMetricsDown
+        annotations:
+          message: Kube-state-metrics has disappeared from Prometheus target discovery.
+        expr: absent(up{job="kube-state-metrics"} == 1)
+        for: 15m
+        labels:
+          severity: warning
+
+      - alert: EtcdDown
+        annotations:
+          message: Etcd has disappeared from Prometheus target discovery.
+        expr: absent(up{job="etcd"} == 1)
+        for: 15m
+        labels:
+          severity: critical
+
+      # This is triggered if the cluster does have nodes, but the cadvisor could
+      # not successfully be scraped for whatever reason. An absent() on cadvisor
+      # metrics is not a good alert because clusters could simply have no nodes
+      # and hence no cadvisors.
+      - alert: CAdvisorDown
+        annotations:
+          message: cAdvisor on {{ $labels.kubernetes_io_hostname }} could not be scraped.
+        expr: up{job="cadvisor"} == 0
+        for: 15m
+        labels:
+          severity: warning
+
+      # This functions similarly to the cadvisor alert above.
+      - alert: KubernetesNodeDown
+        annotations:
+          message: The kubelet on {{ $labels.kubernetes_io_hostname }} could not be scraped.
+        expr: up{job="kubernetes-nodes"} == 0
+        for: 15m
+        labels:
+          severity: warning
+
+      - alert: DNSResolverDown
+        annotations:
+          message: DNS resolver has disappeared from Prometheus target discovery.
+        expr: absent(up{job="dns-resolver"} == 1)
+        for: 15m
+        labels:
+          severity: warning
+
+    - name: kubernetes-nodes
+      rules:
+      - alert: KubernetesNodeNotReady
+        annotations:
+          message: '{{ $labels.node }} has been unready for more than an hour.'
+        expr: kube_node_status_condition{condition="Ready",status="true"} == 0
+        for: 30m
+        labels:
+          severity: warning
+metadata:
+  creationTimestamp: null
+  labels:
+    app: prometheus

--- a/pkg/resources/test/fixtures/configmap-bringyourown-1.20.0-adm-control.yaml
+++ b/pkg/resources/test/fixtures/configmap-bringyourown-1.20.0-adm-control.yaml
@@ -1,0 +1,8 @@
+# This file has been generated, DO NOT EDIT.
+
+data:
+  admission-control.yaml: |
+    kind: AdmissionConfiguration
+    apiVersion: apiserver.config.k8s.io/v1
+metadata:
+  creationTimestamp: null

--- a/pkg/resources/test/fixtures/configmap-bringyourown-1.20.0-audit-config.yaml
+++ b/pkg/resources/test/fixtures/configmap-bringyourown-1.20.0-audit-config.yaml
@@ -1,0 +1,10 @@
+# This file has been generated, DO NOT EDIT.
+
+data:
+  policy.yaml: |
+    apiVersion: audit.k8s.io/v1
+    kind: Policy
+    rules:
+    - level: Metadata
+metadata:
+  creationTimestamp: null

--- a/pkg/resources/test/fixtures/configmap-bringyourown-1.20.0-cloud-config.yaml
+++ b/pkg/resources/test/fixtures/configmap-bringyourown-1.20.0-cloud-config.yaml
@@ -1,0 +1,9 @@
+# This file has been generated, DO NOT EDIT.
+
+data:
+  config: ""
+  fakeVmwareUUID: VMware-42 00 00 00 00 00 00 00-00 00 00 00 00 00 00 00
+metadata:
+  creationTimestamp: null
+  labels:
+    app: cloud-config

--- a/pkg/resources/test/fixtures/configmap-bringyourown-1.20.0-dns-resolver.yaml
+++ b/pkg/resources/test/fixtures/configmap-bringyourown-1.20.0-dns-resolver.yaml
@@ -1,0 +1,21 @@
+# This file has been generated, DO NOT EDIT.
+
+data:
+  Corefile: |2
+
+    cluster-de-test-01.svc.cluster.local. {
+        forward . /etc/resolv.conf
+        errors
+    }
+    cluster.local {
+        forward . 10.240.16.10
+        errors
+    }
+    . {
+      forward . /etc/resolv.conf
+      errors
+      health
+      prometheus 0.0.0.0:9253
+    }
+metadata:
+  creationTimestamp: null

--- a/pkg/resources/test/fixtures/configmap-bringyourown-1.20.0-openvpn-client-configs.yaml
+++ b/pkg/resources/test/fixtures/configmap-bringyourown-1.20.0-openvpn-client-configs.yaml
@@ -1,0 +1,11 @@
+# This file has been generated, DO NOT EDIT.
+
+data:
+  user-cluster-client: |
+    iroute 172.25.0.0 255.255.0.0
+    iroute 10.240.16.0 255.255.240.0
+    iroute 192.0.2.0 255.255.255.0
+metadata:
+  creationTimestamp: null
+  labels:
+    app: openvpn-server

--- a/pkg/resources/test/fixtures/configmap-bringyourown-1.20.0-prometheus.yaml
+++ b/pkg/resources/test/fixtures/configmap-bringyourown-1.20.0-prometheus.yaml
@@ -1,0 +1,623 @@
+# This file has been generated, DO NOT EDIT.
+
+data:
+  prometheus.yaml: |
+    global:
+      evaluation_interval: 30s
+      scrape_interval: 30s
+      external_labels:
+        cluster: "de-test-01"
+        seed_cluster: "testdc"
+
+    rule_files:
+    - "/etc/prometheus/config/rules*.yaml"
+
+    alerting:
+      alertmanagers:
+      - dns_sd_configs:
+        # configure the Seed's alertmanager for the user cluster
+        - names:
+          - 'alertmanager.monitoring.svc.cluster.local'
+          type: A
+          port: 9093
+
+    scrape_configs:
+    #######################################################################
+    # These rules will scrape pods running inside the seed cluster.
+
+    # scrape the etcd pods
+    - job_name: etcd
+      scheme: https
+      tls_config:
+        ca_file: /etc/etcd/pki/client/ca.crt
+        cert_file: /etc/etcd/pki/client/apiserver-etcd-client.crt
+        key_file: /etc/etcd/pki/client/apiserver-etcd-client.key
+
+      static_configs:
+      - targets:
+        - 'etcd-0.etcd.cluster-de-test-01.svc.cluster.local:2379'
+        - 'etcd-1.etcd.cluster-de-test-01.svc.cluster.local:2379'
+        - 'etcd-2.etcd.cluster-de-test-01.svc.cluster.local:2379'
+
+      relabel_configs:
+      - source_labels: [__address__]
+        regex: (etcd-\d+).+
+        action: replace
+        replacement: $1
+        target_label: instance
+
+    # scrape the cluster's control plane (apiserver, controller-manager, scheduler)
+    - job_name: kubernetes-control-plane
+      scheme: https
+      tls_config:
+        ca_file: /etc/kubernetes/ca.crt
+        cert_file: /etc/kubernetes/prometheus-client.crt
+        key_file: /etc/kubernetes/prometheus-client.key
+        # insecure_skip_verify is needed because the apiservers certificate
+        # does not contain a common name for the pod's ip address
+        insecure_skip_verify: true
+
+      kubernetes_sd_configs:
+      - role: pod
+        namespaces:
+          names:
+          - "cluster-de-test-01"
+
+      relabel_configs:
+      - source_labels: [__meta_kubernetes_pod_annotation_prometheus_io_scrape_with_kube_cert]
+        action: keep
+        regex: true
+      - source_labels: [__meta_kubernetes_pod_annotation_prometheus_io_path]
+        action: replace
+        target_label: __metrics_path__
+        regex: (.+)
+      - source_labels: [__address__, __meta_kubernetes_pod_annotation_prometheus_io_port]
+        action: replace
+        regex: ([^:]+)(?::\d+)?;(\d+)
+        replacement: $1:$2
+        target_label: __address__
+      - source_labels: [__meta_kubernetes_namespace]
+        action: replace
+        target_label: namespace
+      - source_labels: [__meta_kubernetes_pod_name]
+        action: replace
+        target_label: pod
+      - source_labels: [__meta_kubernetes_pod_label_app]
+        action: replace
+        target_label: job
+
+      # drop very expensive apiserver metrics
+      metric_relabel_configs:
+      - source_labels: [__name__]
+        regex: 'apiserver_request_(duration|latencies)_.*'
+        action: drop
+      - source_labels: [__name__]
+        regex: 'apiserver_response_sizes_.*'
+        action: drop
+
+    # scrape other cluster control plane components, like kube-state-metrics, DNS resolver,
+    # machine-controller etcd.
+    - job_name: control-plane-pods
+      kubernetes_sd_configs:
+      - role: pod
+        namespaces:
+          names:
+          - "cluster-de-test-01"
+
+      relabel_configs:
+      - source_labels: [__meta_kubernetes_pod_label_app, __meta_kubernetes_pod_container_init]
+        regex: "kube-state-metrics;true"
+        action: drop
+      - source_labels: [__meta_kubernetes_pod_annotation_prometheus_io_scrape]
+        action: keep
+        regex: true
+      - source_labels: [__meta_kubernetes_pod_annotation_prometheus_io_path]
+        action: replace
+        target_label: __metrics_path__
+        regex: (.+)
+      - source_labels: [__address__, __meta_kubernetes_pod_annotation_prometheus_io_port]
+        action: replace
+        regex: ([^:]+)(?::\d+)?;(\d+)
+        replacement: $1:$2
+        target_label: __address__
+      - source_labels: [__meta_kubernetes_pod_label_role, __meta_kubernetes_pod_label_app]
+        action: replace
+        target_label: job
+        separator: ''
+      - source_labels: [__meta_kubernetes_namespace]
+        action: replace
+        target_label: namespace
+      - source_labels: [__meta_kubernetes_pod_name]
+        action: replace
+        target_label: pod
+
+    #######################################################################
+    # These rules will scrape pods running inside the user cluster itself.
+
+    # scrape node metrics
+    - job_name: nodes
+      scheme: https
+      tls_config:
+        ca_file: /etc/kubernetes/ca.crt
+        cert_file: /etc/kubernetes/prometheus-client.crt
+        key_file: /etc/kubernetes/prometheus-client.key
+
+      kubernetes_sd_configs:
+      - role: node
+        api_server: 'https://apiserver-external.cluster-de-test-01.svc.cluster.local.'
+        tls_config:
+          ca_file: /etc/kubernetes/ca.crt
+          cert_file: /etc/kubernetes/prometheus-client.crt
+          key_file: /etc/kubernetes/prometheus-client.key
+
+      relabel_configs:
+      - action: labelmap
+        regex: __meta_kubernetes_node_label_(.+)
+      - target_label: __address__
+        replacement: 'apiserver-external.cluster-de-test-01.svc.cluster.local.'
+      - source_labels: [__meta_kubernetes_node_name]
+        regex: (.+)
+        target_label: __metrics_path__
+        replacement: /api/v1/nodes/${1}/proxy/metrics
+
+    # scrape node cadvisor
+    - job_name: cadvisor
+      scheme: https
+      tls_config:
+        ca_file: /etc/kubernetes/ca.crt
+        cert_file: /etc/kubernetes/prometheus-client.crt
+        key_file: /etc/kubernetes/prometheus-client.key
+
+      kubernetes_sd_configs:
+      - role: node
+        api_server: 'https://apiserver-external.cluster-de-test-01.svc.cluster.local.'
+        tls_config:
+          ca_file: /etc/kubernetes/ca.crt
+          cert_file: /etc/kubernetes/prometheus-client.crt
+          key_file: /etc/kubernetes/prometheus-client.key
+
+      relabel_configs:
+      - action: labelmap
+        regex: __meta_kubernetes_node_label_(.+)
+      - target_label: __address__
+        replacement: 'apiserver-external.cluster-de-test-01.svc.cluster.local.'
+      - source_labels: [__meta_kubernetes_node_name]
+        regex: (.+)
+        target_label: __metrics_path__
+        replacement: /api/v1/nodes/${1}/proxy/metrics/cadvisor
+
+    # scrape pods inside the user cluster with a special annotation
+    - job_name: 'user-cluster-pods'
+      scheme: https
+      tls_config:
+        ca_file: /etc/kubernetes/ca.crt
+        cert_file: /etc/kubernetes/prometheus-client.crt
+        key_file: /etc/kubernetes/prometheus-client.key
+
+      kubernetes_sd_configs:
+      - role: pod
+        api_server: 'https://apiserver-external.cluster-de-test-01.svc.cluster.local.'
+        tls_config:
+          ca_file: /etc/kubernetes/ca.crt
+          cert_file: /etc/kubernetes/prometheus-client.crt
+          key_file: /etc/kubernetes/prometheus-client.key
+
+      relabel_configs:
+      - source_labels: [__meta_kubernetes_pod_annotation_kubermatic_io_monitoring_port]
+        action: keep
+        regex: \d+
+      - source_labels: [__meta_kubernetes_pod_annotation_kubermatic_io_monitoring_path]
+        regex: (.+)
+        action: replace
+        target_label: __metrics_path__
+      - source_labels: [__meta_kubernetes_namespace, __meta_kubernetes_pod_name, __meta_kubernetes_pod_annotation_kubermatic_io_monitoring_port, __metrics_path__]
+        action: replace
+        regex: (.*);(.*);(.*);(.*)
+        target_label: __metrics_path__
+        replacement: /api/v1/namespaces/${1}/pods/${2}:${3}/proxy${4}
+      - target_label: __address__
+        replacement: 'apiserver-external.cluster-de-test-01.svc.cluster.local.'
+      - source_labels: [__meta_kubernetes_namespace]
+        action: replace
+        target_label: namespace
+      - source_labels: [__meta_kubernetes_pod_name]
+        action: replace
+        target_label: pod
+    #######################################################################
+    # custom scraping configurations
+
+    - job_name: custom-test-config
+      scheme: https
+      metrics_path: '/metrics'
+      static_configs:
+      - targets:
+        - 'foo.bar:12345'
+  rules.yaml: |
+    groups:
+    - name: kubermatic.goprocess
+      rules:
+      - record: job:process_resident_memory_bytes:clone
+        expr: process_resident_memory_bytes
+        labels:
+          kubermatic: federate
+
+      - record: job:process_cpu_seconds_total:rate5m
+        expr: rate(process_cpu_seconds_total[5m])
+        labels:
+          kubermatic: federate
+
+      - record: job:process_open_fds:clone
+        expr: process_open_fds
+        labels:
+          kubermatic: federate
+
+    - name: kubermatic.machine_controller
+      rules:
+      - record: job:machine_controller_errors_total:rate5m
+        expr: rate(machine_controller_errors_total[5m])
+        labels:
+          kubermatic: federate
+
+      - alert: KubernetesAdmissionWebhookHighRejectionRate
+        annotations:
+          message: '{{ $labels.operation }} requests for Machine objects are failing (Admission) with a high rate. Consider checking the affected objects'
+        expr: rate(apiserver_admission_webhook_admission_latencies_seconds_count{name="machine-controller.kubermatic.io-machines",rejected="true"}[5m]) > 0.01
+        for: 5m
+        labels:
+          severity: warning
+
+    - name: kubermatic.etcd
+      rules:
+      - record: job:etcd_server_has_leader:sum
+        expr: sum(etcd_server_has_leader)
+        labels:
+          kubermatic: federate
+
+      - record: job:etcd_disk_wal_fsync_duration_seconds_bucket:99percentile
+        expr: histogram_quantile(0.99, sum(rate(etcd_disk_wal_fsync_duration_seconds_bucket[5m])) by (instance, le))
+        labels:
+          kubermatic: federate
+
+      - record: job:etcd_disk_backend_commit_duration_seconds_bucket:99percentile
+        expr: histogram_quantile(0.99, sum(rate(etcd_disk_backend_commit_duration_seconds_bucket[5m])) by (instance, le))
+        labels:
+          kubermatic: federate
+
+      - record: job:etcd_debugging_mvcc_db_total_size_in_bytes:clone
+        expr: etcd_debugging_mvcc_db_total_size_in_bytes
+        labels:
+          kubermatic: federate
+
+      - record: job:etcd_network_client_grpc_received_bytes_total:rate5m
+        expr: rate(etcd_network_client_grpc_received_bytes_total[5m])
+        labels:
+          kubermatic: federate
+
+      - record: job:etcd_network_client_grpc_sent_bytes_total:rate5m
+        expr: rate(etcd_network_client_grpc_sent_bytes_total[5m])
+        labels:
+          kubermatic: federate
+
+      - record: job:etcd_network_peer_received_bytes_total:rate5msum
+        expr: sum(rate(etcd_network_peer_received_bytes_total[5m])) by (instance)
+        labels:
+          kubermatic: federate
+
+      - record: job:etcd_network_peer_sent_bytes_total:rate5msum
+        expr: sum(rate(etcd_network_peer_sent_bytes_total[5m])) by (instance)
+        labels:
+          kubermatic: federate
+
+      - record: job:etcd_server_proposals_failed_total:rate5msum
+        expr: sum(rate(etcd_server_proposals_failed_total[5m]))
+        labels:
+          kubermatic: federate
+
+      - record: job:etcd_server_proposals_pending:sum
+        expr: sum(etcd_server_proposals_pending)
+        labels:
+          kubermatic: federate
+
+      - record: job:etcd_server_proposals_committed_total:rate5msum
+        expr: sum(rate(etcd_server_proposals_committed_total[5m]))
+        labels:
+          kubermatic: federate
+
+      - record: job:etcd_server_proposals_applied_total:rate5msum
+        expr: sum(rate(etcd_server_proposals_applied_total[5m]))
+        labels:
+          kubermatic: federate
+
+      - record: job:etcd_server_leader_changes_seen_total:changes1d
+        expr: changes(etcd_server_leader_changes_seen_total[1d])
+        labels:
+          kubermatic: federate
+
+      - record: job:etcd_debugging_mvcc_delete_total:rate5m
+        expr: rate(etcd_debugging_mvcc_delete_total[5m])
+        labels:
+          kubermatic: federate
+
+      - record: job:etcd_debugging_mvcc_put_total:rate5m
+        expr: rate(etcd_debugging_mvcc_put_total[5m])
+        labels:
+          kubermatic: federate
+
+      - record: job:etcd_debugging_mvcc_range_total:rate5m
+        expr: rate(etcd_debugging_mvcc_range_total[5m])
+        labels:
+          kubermatic: federate
+
+      - record: job:etcd_debugging_mvcc_watcher_total:rate5m
+        expr: rate(etcd_debugging_mvcc_watcher_total[5m])
+        labels:
+          kubermatic: federate
+
+      - record: job:etcd_debugging_mvcc_txn_total:rate5m
+        expr: rate(etcd_debugging_mvcc_txn_total[5m])
+        labels:
+          kubermatic: federate
+
+      - record: job:etcd_debugging_mvcc_keys_total:clone
+        expr: etcd_debugging_mvcc_keys_total
+        labels:
+          kubermatic: federate
+
+      - record: job:etcd_debugging_store_reads_total:rate5m
+        expr: rate(etcd_debugging_store_reads_total[5m])
+        labels:
+          kubermatic: federate
+
+      - record: job:etcd_debugging_store_writes_total:rate5m
+        expr: rate(etcd_debugging_store_writes_total[5m])
+        labels:
+          kubermatic: federate
+
+      - record: job:etcd_debugging_store_expires_total:rate5m
+        expr: rate(etcd_debugging_store_expires_total[5m])
+        labels:
+          kubermatic: federate
+
+    - name: machine-controller
+      rules:
+      - alert: MachineControllerTooManyErrors
+        annotations:
+          message: Machine Controller in {{ $labels.namespace }} has too many errors in its loop.
+        expr: |
+          sum(rate(machine_controller_errors_total[5m])) by (namespace) > 0.01
+        for: 20m
+        labels:
+          severity: warning
+
+      - alert: MachineControllerMachineDeletionTakesTooLong
+        annotations:
+          message: Machine {{ $labels.machine }} of cluster {{ $labels.cluster }} is stuck in deletion for more than 30min.
+        expr: (time() - machine_controller_machine_deleted) > 30*60
+        for: 0m
+        labels:
+          severity: warning
+
+      - alert: AWSInstanceCountTooHigh
+        annotations:
+          message: '{{ $labels.machine }} has more than one instance at AWS'
+        expr: machine_controller_aws_instances_for_machine > 1
+        for: 30m
+        labels:
+          severity: warning
+
+      - record: job:machine_controller_errors_total:rate5m
+        expr: rate(machine_controller_errors_total[5m])
+        labels:
+          kubermatic: federate
+
+      - record: job:machine_controller_workers:sum
+        expr: sum(machine_controller_workers)
+        labels:
+          kubermatic: federate
+
+      - record: job:machine_controller_machines:sum
+        expr: sum(machine_controller_machines)
+        labels:
+          kubermatic: federate
+
+    - name: etcd
+      rules:
+      - alert: EtcdInsufficientMembers
+        annotations:
+          message: 'Etcd cluster "{{ $labels.job }}": insufficient members ({{ $value }}).'
+        expr: |
+          sum(up{job="etcd"} == bool 1) by (job) < ((count(up{job="etcd"}) by (job) + 1) / 2)
+        for: 15m
+        labels:
+          severity: critical
+
+      - alert: EtcdNoLeader
+        annotations:
+          message: 'Etcd cluster "{{ $labels.job }}": member {{ $labels.instance }} has no leader.'
+        expr: |
+          etcd_server_has_leader{job="etcd"} == 0
+        for: 15m
+        labels:
+          severity: critical
+
+      - alert: EtcdHighNumberOfLeaderChanges
+        annotations:
+          message: 'Etcd cluster "{{ $labels.job }}": instance {{ $labels.instance }} has seen {{ $value }} leader changes within the last hour.'
+        expr: |
+          rate(etcd_server_leader_changes_seen_total{job="etcd"}[15m]) > 3
+        for: 15m
+        labels:
+          severity: warning
+
+      - alert: EtcdGRPCRequestsSlow
+        annotations:
+          message: 'Etcd cluster "{{ $labels.job }}": gRPC requests to {{ $labels.grpc_method }} are taking {{ $value }}s on etcd instance {{ $labels.instance }}.'
+        expr: |
+          histogram_quantile(0.99, sum(rate(grpc_server_handling_seconds_bucket{job="etcd", grpc_type="unary"}[5m])) by (job, instance, grpc_service, grpc_method, le))
+          > 0.15
+        for: 10m
+        labels:
+          severity: critical
+
+      - alert: EtcdMemberCommunicationSlow
+        annotations:
+          message: 'Etcd cluster "{{ $labels.job }}": member communication with {{ $labels.To }} is taking {{ $value }}s on etcd instance {{ $labels.instance }}.'
+        expr: |
+          histogram_quantile(0.99, rate(etcd_network_peer_round_trip_time_seconds_bucket{job="etcd"}[5m]))
+          > 0.15
+        for: 10m
+        labels:
+          severity: warning
+
+      - alert: EtcdHighNumberOfFailedProposals
+        annotations:
+          message: 'Etcd cluster "{{ $labels.job }}": {{ $value }} proposal failures within the last hour on etcd instance {{ $labels.instance }}.'
+        expr: |
+          rate(etcd_server_proposals_failed_total{job="etcd"}[15m]) > 5
+        for: 15m
+        labels:
+          severity: warning
+
+      - alert: EtcdHighFsyncDurations
+        annotations:
+          message: 'Etcd cluster "{{ $labels.job }}": 99th percentile fync durations are {{ $value }}s on etcd instance {{ $labels.instance }}.'
+        expr: |
+          histogram_quantile(0.99, rate(etcd_disk_wal_fsync_duration_seconds_bucket{job="etcd"}[5m]))
+          > 0.5
+        for: 10m
+        labels:
+          severity: warning
+
+      - alert: EtcdHighCommitDurations
+        annotations:
+          message: 'Etcd cluster "{{ $labels.job }}": 99th percentile commit durations {{ $value }}s on etcd instance {{ $labels.instance }}.'
+        expr: |
+          histogram_quantile(0.99, rate(etcd_disk_backend_commit_duration_seconds_bucket{job="etcd"}[5m]))
+          > 0.25
+        for: 10m
+        labels:
+          severity: warning
+
+    - name: process.filedescriptors
+      rules:
+      - expr: process_open_fds / process_max_fds
+        record: instance:fd_utilization
+
+      - alert: FdExhaustionClose
+        annotations:
+          message: '{{ $labels.job }} instance {{ $labels.instance }} will exhaust its file descriptors soon'
+        expr: |
+          predict_linear(instance:fd_utilization[1h], 3600 * 4) > 1
+        for: 10m
+        labels:
+          severity: warning
+
+      - alert: FdExhaustionClose
+        annotations:
+          message: '{{ $labels.job }} instance {{ $labels.instance }} will exhaust its file descriptors soon'
+        expr: |
+          predict_linear(instance:fd_utilization[10m], 3600) > 1
+        for: 10m
+        labels:
+          severity: critical
+
+    - name: kubernetes-absent
+      rules:
+      - alert: KubernetesApiserverDown
+        annotations:
+          message: Kubernetes apiserver has disappeared from Prometheus target discovery.
+        expr: absent(up{job="apiserver"} == 1)
+        for: 15m
+        labels:
+          severity: critical
+
+      - alert: KubernetesControllerManagerDown
+        annotations:
+          message: Kubernetes controller-manager has disappeared from Prometheus target discovery.
+        expr: absent(up{job="controller-manager"} == 1) and absent(up{job="openshift-controller-manager"} == 1)
+        for: 15m
+        labels:
+          severity: critical
+
+      - alert: KubernetesSchedulerDown
+        annotations:
+          message: Kubernetes scheduler has disappeared from Prometheus target discovery.
+        expr: absent(up{job="scheduler"} == 1) and absent(up{job="openshift-controller-manager"} == 1)
+        for: 15m
+        labels:
+          severity: critical
+
+      - alert: MachineControllerDown
+        annotations:
+          message: Machine controller has disappeared from Prometheus target discovery.
+        expr: absent(up{job="machine-controller"} == 1)
+        for: 15m
+        labels:
+          severity: critical
+
+      - alert: UserClusterControllerDown
+        annotations:
+          message: User Cluster Controller has disappeared from Prometheus target discovery.
+        expr: absent(up{job="usercluster-controller"} == 1)
+        for: 15m
+        labels:
+          severity: critical
+
+      - alert: KubeStateMetricsDown
+        annotations:
+          message: Kube-state-metrics has disappeared from Prometheus target discovery.
+        expr: absent(up{job="kube-state-metrics"} == 1)
+        for: 15m
+        labels:
+          severity: warning
+
+      - alert: EtcdDown
+        annotations:
+          message: Etcd has disappeared from Prometheus target discovery.
+        expr: absent(up{job="etcd"} == 1)
+        for: 15m
+        labels:
+          severity: critical
+
+      # This is triggered if the cluster does have nodes, but the cadvisor could
+      # not successfully be scraped for whatever reason. An absent() on cadvisor
+      # metrics is not a good alert because clusters could simply have no nodes
+      # and hence no cadvisors.
+      - alert: CAdvisorDown
+        annotations:
+          message: cAdvisor on {{ $labels.kubernetes_io_hostname }} could not be scraped.
+        expr: up{job="cadvisor"} == 0
+        for: 15m
+        labels:
+          severity: warning
+
+      # This functions similarly to the cadvisor alert above.
+      - alert: KubernetesNodeDown
+        annotations:
+          message: The kubelet on {{ $labels.kubernetes_io_hostname }} could not be scraped.
+        expr: up{job="kubernetes-nodes"} == 0
+        for: 15m
+        labels:
+          severity: warning
+
+      - alert: DNSResolverDown
+        annotations:
+          message: DNS resolver has disappeared from Prometheus target discovery.
+        expr: absent(up{job="dns-resolver"} == 1)
+        for: 15m
+        labels:
+          severity: warning
+
+    - name: kubernetes-nodes
+      rules:
+      - alert: KubernetesNodeNotReady
+        annotations:
+          message: '{{ $labels.node }} has been unready for more than an hour.'
+        expr: kube_node_status_condition{condition="Ready",status="true"} == 0
+        for: 30m
+        labels:
+          severity: warning
+metadata:
+  creationTimestamp: null
+  labels:
+    app: prometheus

--- a/pkg/resources/test/fixtures/configmap-digitalocean-1.20.0-adm-control.yaml
+++ b/pkg/resources/test/fixtures/configmap-digitalocean-1.20.0-adm-control.yaml
@@ -1,0 +1,8 @@
+# This file has been generated, DO NOT EDIT.
+
+data:
+  admission-control.yaml: |
+    kind: AdmissionConfiguration
+    apiVersion: apiserver.config.k8s.io/v1
+metadata:
+  creationTimestamp: null

--- a/pkg/resources/test/fixtures/configmap-digitalocean-1.20.0-audit-config.yaml
+++ b/pkg/resources/test/fixtures/configmap-digitalocean-1.20.0-audit-config.yaml
@@ -1,0 +1,10 @@
+# This file has been generated, DO NOT EDIT.
+
+data:
+  policy.yaml: |
+    apiVersion: audit.k8s.io/v1
+    kind: Policy
+    rules:
+    - level: Metadata
+metadata:
+  creationTimestamp: null

--- a/pkg/resources/test/fixtures/configmap-digitalocean-1.20.0-cloud-config.yaml
+++ b/pkg/resources/test/fixtures/configmap-digitalocean-1.20.0-cloud-config.yaml
@@ -1,0 +1,9 @@
+# This file has been generated, DO NOT EDIT.
+
+data:
+  config: ""
+  fakeVmwareUUID: VMware-42 00 00 00 00 00 00 00-00 00 00 00 00 00 00 00
+metadata:
+  creationTimestamp: null
+  labels:
+    app: cloud-config

--- a/pkg/resources/test/fixtures/configmap-digitalocean-1.20.0-dns-resolver.yaml
+++ b/pkg/resources/test/fixtures/configmap-digitalocean-1.20.0-dns-resolver.yaml
@@ -1,0 +1,21 @@
+# This file has been generated, DO NOT EDIT.
+
+data:
+  Corefile: |2
+
+    cluster-de-test-01.svc.cluster.local. {
+        forward . /etc/resolv.conf
+        errors
+    }
+    cluster.local {
+        forward . 10.240.16.10
+        errors
+    }
+    . {
+      forward . /etc/resolv.conf
+      errors
+      health
+      prometheus 0.0.0.0:9253
+    }
+metadata:
+  creationTimestamp: null

--- a/pkg/resources/test/fixtures/configmap-digitalocean-1.20.0-openvpn-client-configs.yaml
+++ b/pkg/resources/test/fixtures/configmap-digitalocean-1.20.0-openvpn-client-configs.yaml
@@ -1,0 +1,11 @@
+# This file has been generated, DO NOT EDIT.
+
+data:
+  user-cluster-client: |
+    iroute 172.25.0.0 255.255.0.0
+    iroute 10.240.16.0 255.255.240.0
+    iroute 192.0.2.0 255.255.255.0
+metadata:
+  creationTimestamp: null
+  labels:
+    app: openvpn-server

--- a/pkg/resources/test/fixtures/configmap-digitalocean-1.20.0-prometheus.yaml
+++ b/pkg/resources/test/fixtures/configmap-digitalocean-1.20.0-prometheus.yaml
@@ -1,0 +1,623 @@
+# This file has been generated, DO NOT EDIT.
+
+data:
+  prometheus.yaml: |
+    global:
+      evaluation_interval: 30s
+      scrape_interval: 30s
+      external_labels:
+        cluster: "de-test-01"
+        seed_cluster: "testdc"
+
+    rule_files:
+    - "/etc/prometheus/config/rules*.yaml"
+
+    alerting:
+      alertmanagers:
+      - dns_sd_configs:
+        # configure the Seed's alertmanager for the user cluster
+        - names:
+          - 'alertmanager.monitoring.svc.cluster.local'
+          type: A
+          port: 9093
+
+    scrape_configs:
+    #######################################################################
+    # These rules will scrape pods running inside the seed cluster.
+
+    # scrape the etcd pods
+    - job_name: etcd
+      scheme: https
+      tls_config:
+        ca_file: /etc/etcd/pki/client/ca.crt
+        cert_file: /etc/etcd/pki/client/apiserver-etcd-client.crt
+        key_file: /etc/etcd/pki/client/apiserver-etcd-client.key
+
+      static_configs:
+      - targets:
+        - 'etcd-0.etcd.cluster-de-test-01.svc.cluster.local:2379'
+        - 'etcd-1.etcd.cluster-de-test-01.svc.cluster.local:2379'
+        - 'etcd-2.etcd.cluster-de-test-01.svc.cluster.local:2379'
+
+      relabel_configs:
+      - source_labels: [__address__]
+        regex: (etcd-\d+).+
+        action: replace
+        replacement: $1
+        target_label: instance
+
+    # scrape the cluster's control plane (apiserver, controller-manager, scheduler)
+    - job_name: kubernetes-control-plane
+      scheme: https
+      tls_config:
+        ca_file: /etc/kubernetes/ca.crt
+        cert_file: /etc/kubernetes/prometheus-client.crt
+        key_file: /etc/kubernetes/prometheus-client.key
+        # insecure_skip_verify is needed because the apiservers certificate
+        # does not contain a common name for the pod's ip address
+        insecure_skip_verify: true
+
+      kubernetes_sd_configs:
+      - role: pod
+        namespaces:
+          names:
+          - "cluster-de-test-01"
+
+      relabel_configs:
+      - source_labels: [__meta_kubernetes_pod_annotation_prometheus_io_scrape_with_kube_cert]
+        action: keep
+        regex: true
+      - source_labels: [__meta_kubernetes_pod_annotation_prometheus_io_path]
+        action: replace
+        target_label: __metrics_path__
+        regex: (.+)
+      - source_labels: [__address__, __meta_kubernetes_pod_annotation_prometheus_io_port]
+        action: replace
+        regex: ([^:]+)(?::\d+)?;(\d+)
+        replacement: $1:$2
+        target_label: __address__
+      - source_labels: [__meta_kubernetes_namespace]
+        action: replace
+        target_label: namespace
+      - source_labels: [__meta_kubernetes_pod_name]
+        action: replace
+        target_label: pod
+      - source_labels: [__meta_kubernetes_pod_label_app]
+        action: replace
+        target_label: job
+
+      # drop very expensive apiserver metrics
+      metric_relabel_configs:
+      - source_labels: [__name__]
+        regex: 'apiserver_request_(duration|latencies)_.*'
+        action: drop
+      - source_labels: [__name__]
+        regex: 'apiserver_response_sizes_.*'
+        action: drop
+
+    # scrape other cluster control plane components, like kube-state-metrics, DNS resolver,
+    # machine-controller etcd.
+    - job_name: control-plane-pods
+      kubernetes_sd_configs:
+      - role: pod
+        namespaces:
+          names:
+          - "cluster-de-test-01"
+
+      relabel_configs:
+      - source_labels: [__meta_kubernetes_pod_label_app, __meta_kubernetes_pod_container_init]
+        regex: "kube-state-metrics;true"
+        action: drop
+      - source_labels: [__meta_kubernetes_pod_annotation_prometheus_io_scrape]
+        action: keep
+        regex: true
+      - source_labels: [__meta_kubernetes_pod_annotation_prometheus_io_path]
+        action: replace
+        target_label: __metrics_path__
+        regex: (.+)
+      - source_labels: [__address__, __meta_kubernetes_pod_annotation_prometheus_io_port]
+        action: replace
+        regex: ([^:]+)(?::\d+)?;(\d+)
+        replacement: $1:$2
+        target_label: __address__
+      - source_labels: [__meta_kubernetes_pod_label_role, __meta_kubernetes_pod_label_app]
+        action: replace
+        target_label: job
+        separator: ''
+      - source_labels: [__meta_kubernetes_namespace]
+        action: replace
+        target_label: namespace
+      - source_labels: [__meta_kubernetes_pod_name]
+        action: replace
+        target_label: pod
+
+    #######################################################################
+    # These rules will scrape pods running inside the user cluster itself.
+
+    # scrape node metrics
+    - job_name: nodes
+      scheme: https
+      tls_config:
+        ca_file: /etc/kubernetes/ca.crt
+        cert_file: /etc/kubernetes/prometheus-client.crt
+        key_file: /etc/kubernetes/prometheus-client.key
+
+      kubernetes_sd_configs:
+      - role: node
+        api_server: 'https://apiserver-external.cluster-de-test-01.svc.cluster.local.'
+        tls_config:
+          ca_file: /etc/kubernetes/ca.crt
+          cert_file: /etc/kubernetes/prometheus-client.crt
+          key_file: /etc/kubernetes/prometheus-client.key
+
+      relabel_configs:
+      - action: labelmap
+        regex: __meta_kubernetes_node_label_(.+)
+      - target_label: __address__
+        replacement: 'apiserver-external.cluster-de-test-01.svc.cluster.local.'
+      - source_labels: [__meta_kubernetes_node_name]
+        regex: (.+)
+        target_label: __metrics_path__
+        replacement: /api/v1/nodes/${1}/proxy/metrics
+
+    # scrape node cadvisor
+    - job_name: cadvisor
+      scheme: https
+      tls_config:
+        ca_file: /etc/kubernetes/ca.crt
+        cert_file: /etc/kubernetes/prometheus-client.crt
+        key_file: /etc/kubernetes/prometheus-client.key
+
+      kubernetes_sd_configs:
+      - role: node
+        api_server: 'https://apiserver-external.cluster-de-test-01.svc.cluster.local.'
+        tls_config:
+          ca_file: /etc/kubernetes/ca.crt
+          cert_file: /etc/kubernetes/prometheus-client.crt
+          key_file: /etc/kubernetes/prometheus-client.key
+
+      relabel_configs:
+      - action: labelmap
+        regex: __meta_kubernetes_node_label_(.+)
+      - target_label: __address__
+        replacement: 'apiserver-external.cluster-de-test-01.svc.cluster.local.'
+      - source_labels: [__meta_kubernetes_node_name]
+        regex: (.+)
+        target_label: __metrics_path__
+        replacement: /api/v1/nodes/${1}/proxy/metrics/cadvisor
+
+    # scrape pods inside the user cluster with a special annotation
+    - job_name: 'user-cluster-pods'
+      scheme: https
+      tls_config:
+        ca_file: /etc/kubernetes/ca.crt
+        cert_file: /etc/kubernetes/prometheus-client.crt
+        key_file: /etc/kubernetes/prometheus-client.key
+
+      kubernetes_sd_configs:
+      - role: pod
+        api_server: 'https://apiserver-external.cluster-de-test-01.svc.cluster.local.'
+        tls_config:
+          ca_file: /etc/kubernetes/ca.crt
+          cert_file: /etc/kubernetes/prometheus-client.crt
+          key_file: /etc/kubernetes/prometheus-client.key
+
+      relabel_configs:
+      - source_labels: [__meta_kubernetes_pod_annotation_kubermatic_io_monitoring_port]
+        action: keep
+        regex: \d+
+      - source_labels: [__meta_kubernetes_pod_annotation_kubermatic_io_monitoring_path]
+        regex: (.+)
+        action: replace
+        target_label: __metrics_path__
+      - source_labels: [__meta_kubernetes_namespace, __meta_kubernetes_pod_name, __meta_kubernetes_pod_annotation_kubermatic_io_monitoring_port, __metrics_path__]
+        action: replace
+        regex: (.*);(.*);(.*);(.*)
+        target_label: __metrics_path__
+        replacement: /api/v1/namespaces/${1}/pods/${2}:${3}/proxy${4}
+      - target_label: __address__
+        replacement: 'apiserver-external.cluster-de-test-01.svc.cluster.local.'
+      - source_labels: [__meta_kubernetes_namespace]
+        action: replace
+        target_label: namespace
+      - source_labels: [__meta_kubernetes_pod_name]
+        action: replace
+        target_label: pod
+    #######################################################################
+    # custom scraping configurations
+
+    - job_name: custom-test-config
+      scheme: https
+      metrics_path: '/metrics'
+      static_configs:
+      - targets:
+        - 'foo.bar:12345'
+  rules.yaml: |
+    groups:
+    - name: kubermatic.goprocess
+      rules:
+      - record: job:process_resident_memory_bytes:clone
+        expr: process_resident_memory_bytes
+        labels:
+          kubermatic: federate
+
+      - record: job:process_cpu_seconds_total:rate5m
+        expr: rate(process_cpu_seconds_total[5m])
+        labels:
+          kubermatic: federate
+
+      - record: job:process_open_fds:clone
+        expr: process_open_fds
+        labels:
+          kubermatic: federate
+
+    - name: kubermatic.machine_controller
+      rules:
+      - record: job:machine_controller_errors_total:rate5m
+        expr: rate(machine_controller_errors_total[5m])
+        labels:
+          kubermatic: federate
+
+      - alert: KubernetesAdmissionWebhookHighRejectionRate
+        annotations:
+          message: '{{ $labels.operation }} requests for Machine objects are failing (Admission) with a high rate. Consider checking the affected objects'
+        expr: rate(apiserver_admission_webhook_admission_latencies_seconds_count{name="machine-controller.kubermatic.io-machines",rejected="true"}[5m]) > 0.01
+        for: 5m
+        labels:
+          severity: warning
+
+    - name: kubermatic.etcd
+      rules:
+      - record: job:etcd_server_has_leader:sum
+        expr: sum(etcd_server_has_leader)
+        labels:
+          kubermatic: federate
+
+      - record: job:etcd_disk_wal_fsync_duration_seconds_bucket:99percentile
+        expr: histogram_quantile(0.99, sum(rate(etcd_disk_wal_fsync_duration_seconds_bucket[5m])) by (instance, le))
+        labels:
+          kubermatic: federate
+
+      - record: job:etcd_disk_backend_commit_duration_seconds_bucket:99percentile
+        expr: histogram_quantile(0.99, sum(rate(etcd_disk_backend_commit_duration_seconds_bucket[5m])) by (instance, le))
+        labels:
+          kubermatic: federate
+
+      - record: job:etcd_debugging_mvcc_db_total_size_in_bytes:clone
+        expr: etcd_debugging_mvcc_db_total_size_in_bytes
+        labels:
+          kubermatic: federate
+
+      - record: job:etcd_network_client_grpc_received_bytes_total:rate5m
+        expr: rate(etcd_network_client_grpc_received_bytes_total[5m])
+        labels:
+          kubermatic: federate
+
+      - record: job:etcd_network_client_grpc_sent_bytes_total:rate5m
+        expr: rate(etcd_network_client_grpc_sent_bytes_total[5m])
+        labels:
+          kubermatic: federate
+
+      - record: job:etcd_network_peer_received_bytes_total:rate5msum
+        expr: sum(rate(etcd_network_peer_received_bytes_total[5m])) by (instance)
+        labels:
+          kubermatic: federate
+
+      - record: job:etcd_network_peer_sent_bytes_total:rate5msum
+        expr: sum(rate(etcd_network_peer_sent_bytes_total[5m])) by (instance)
+        labels:
+          kubermatic: federate
+
+      - record: job:etcd_server_proposals_failed_total:rate5msum
+        expr: sum(rate(etcd_server_proposals_failed_total[5m]))
+        labels:
+          kubermatic: federate
+
+      - record: job:etcd_server_proposals_pending:sum
+        expr: sum(etcd_server_proposals_pending)
+        labels:
+          kubermatic: federate
+
+      - record: job:etcd_server_proposals_committed_total:rate5msum
+        expr: sum(rate(etcd_server_proposals_committed_total[5m]))
+        labels:
+          kubermatic: federate
+
+      - record: job:etcd_server_proposals_applied_total:rate5msum
+        expr: sum(rate(etcd_server_proposals_applied_total[5m]))
+        labels:
+          kubermatic: federate
+
+      - record: job:etcd_server_leader_changes_seen_total:changes1d
+        expr: changes(etcd_server_leader_changes_seen_total[1d])
+        labels:
+          kubermatic: federate
+
+      - record: job:etcd_debugging_mvcc_delete_total:rate5m
+        expr: rate(etcd_debugging_mvcc_delete_total[5m])
+        labels:
+          kubermatic: federate
+
+      - record: job:etcd_debugging_mvcc_put_total:rate5m
+        expr: rate(etcd_debugging_mvcc_put_total[5m])
+        labels:
+          kubermatic: federate
+
+      - record: job:etcd_debugging_mvcc_range_total:rate5m
+        expr: rate(etcd_debugging_mvcc_range_total[5m])
+        labels:
+          kubermatic: federate
+
+      - record: job:etcd_debugging_mvcc_watcher_total:rate5m
+        expr: rate(etcd_debugging_mvcc_watcher_total[5m])
+        labels:
+          kubermatic: federate
+
+      - record: job:etcd_debugging_mvcc_txn_total:rate5m
+        expr: rate(etcd_debugging_mvcc_txn_total[5m])
+        labels:
+          kubermatic: federate
+
+      - record: job:etcd_debugging_mvcc_keys_total:clone
+        expr: etcd_debugging_mvcc_keys_total
+        labels:
+          kubermatic: federate
+
+      - record: job:etcd_debugging_store_reads_total:rate5m
+        expr: rate(etcd_debugging_store_reads_total[5m])
+        labels:
+          kubermatic: federate
+
+      - record: job:etcd_debugging_store_writes_total:rate5m
+        expr: rate(etcd_debugging_store_writes_total[5m])
+        labels:
+          kubermatic: federate
+
+      - record: job:etcd_debugging_store_expires_total:rate5m
+        expr: rate(etcd_debugging_store_expires_total[5m])
+        labels:
+          kubermatic: federate
+
+    - name: machine-controller
+      rules:
+      - alert: MachineControllerTooManyErrors
+        annotations:
+          message: Machine Controller in {{ $labels.namespace }} has too many errors in its loop.
+        expr: |
+          sum(rate(machine_controller_errors_total[5m])) by (namespace) > 0.01
+        for: 20m
+        labels:
+          severity: warning
+
+      - alert: MachineControllerMachineDeletionTakesTooLong
+        annotations:
+          message: Machine {{ $labels.machine }} of cluster {{ $labels.cluster }} is stuck in deletion for more than 30min.
+        expr: (time() - machine_controller_machine_deleted) > 30*60
+        for: 0m
+        labels:
+          severity: warning
+
+      - alert: AWSInstanceCountTooHigh
+        annotations:
+          message: '{{ $labels.machine }} has more than one instance at AWS'
+        expr: machine_controller_aws_instances_for_machine > 1
+        for: 30m
+        labels:
+          severity: warning
+
+      - record: job:machine_controller_errors_total:rate5m
+        expr: rate(machine_controller_errors_total[5m])
+        labels:
+          kubermatic: federate
+
+      - record: job:machine_controller_workers:sum
+        expr: sum(machine_controller_workers)
+        labels:
+          kubermatic: federate
+
+      - record: job:machine_controller_machines:sum
+        expr: sum(machine_controller_machines)
+        labels:
+          kubermatic: federate
+
+    - name: etcd
+      rules:
+      - alert: EtcdInsufficientMembers
+        annotations:
+          message: 'Etcd cluster "{{ $labels.job }}": insufficient members ({{ $value }}).'
+        expr: |
+          sum(up{job="etcd"} == bool 1) by (job) < ((count(up{job="etcd"}) by (job) + 1) / 2)
+        for: 15m
+        labels:
+          severity: critical
+
+      - alert: EtcdNoLeader
+        annotations:
+          message: 'Etcd cluster "{{ $labels.job }}": member {{ $labels.instance }} has no leader.'
+        expr: |
+          etcd_server_has_leader{job="etcd"} == 0
+        for: 15m
+        labels:
+          severity: critical
+
+      - alert: EtcdHighNumberOfLeaderChanges
+        annotations:
+          message: 'Etcd cluster "{{ $labels.job }}": instance {{ $labels.instance }} has seen {{ $value }} leader changes within the last hour.'
+        expr: |
+          rate(etcd_server_leader_changes_seen_total{job="etcd"}[15m]) > 3
+        for: 15m
+        labels:
+          severity: warning
+
+      - alert: EtcdGRPCRequestsSlow
+        annotations:
+          message: 'Etcd cluster "{{ $labels.job }}": gRPC requests to {{ $labels.grpc_method }} are taking {{ $value }}s on etcd instance {{ $labels.instance }}.'
+        expr: |
+          histogram_quantile(0.99, sum(rate(grpc_server_handling_seconds_bucket{job="etcd", grpc_type="unary"}[5m])) by (job, instance, grpc_service, grpc_method, le))
+          > 0.15
+        for: 10m
+        labels:
+          severity: critical
+
+      - alert: EtcdMemberCommunicationSlow
+        annotations:
+          message: 'Etcd cluster "{{ $labels.job }}": member communication with {{ $labels.To }} is taking {{ $value }}s on etcd instance {{ $labels.instance }}.'
+        expr: |
+          histogram_quantile(0.99, rate(etcd_network_peer_round_trip_time_seconds_bucket{job="etcd"}[5m]))
+          > 0.15
+        for: 10m
+        labels:
+          severity: warning
+
+      - alert: EtcdHighNumberOfFailedProposals
+        annotations:
+          message: 'Etcd cluster "{{ $labels.job }}": {{ $value }} proposal failures within the last hour on etcd instance {{ $labels.instance }}.'
+        expr: |
+          rate(etcd_server_proposals_failed_total{job="etcd"}[15m]) > 5
+        for: 15m
+        labels:
+          severity: warning
+
+      - alert: EtcdHighFsyncDurations
+        annotations:
+          message: 'Etcd cluster "{{ $labels.job }}": 99th percentile fync durations are {{ $value }}s on etcd instance {{ $labels.instance }}.'
+        expr: |
+          histogram_quantile(0.99, rate(etcd_disk_wal_fsync_duration_seconds_bucket{job="etcd"}[5m]))
+          > 0.5
+        for: 10m
+        labels:
+          severity: warning
+
+      - alert: EtcdHighCommitDurations
+        annotations:
+          message: 'Etcd cluster "{{ $labels.job }}": 99th percentile commit durations {{ $value }}s on etcd instance {{ $labels.instance }}.'
+        expr: |
+          histogram_quantile(0.99, rate(etcd_disk_backend_commit_duration_seconds_bucket{job="etcd"}[5m]))
+          > 0.25
+        for: 10m
+        labels:
+          severity: warning
+
+    - name: process.filedescriptors
+      rules:
+      - expr: process_open_fds / process_max_fds
+        record: instance:fd_utilization
+
+      - alert: FdExhaustionClose
+        annotations:
+          message: '{{ $labels.job }} instance {{ $labels.instance }} will exhaust its file descriptors soon'
+        expr: |
+          predict_linear(instance:fd_utilization[1h], 3600 * 4) > 1
+        for: 10m
+        labels:
+          severity: warning
+
+      - alert: FdExhaustionClose
+        annotations:
+          message: '{{ $labels.job }} instance {{ $labels.instance }} will exhaust its file descriptors soon'
+        expr: |
+          predict_linear(instance:fd_utilization[10m], 3600) > 1
+        for: 10m
+        labels:
+          severity: critical
+
+    - name: kubernetes-absent
+      rules:
+      - alert: KubernetesApiserverDown
+        annotations:
+          message: Kubernetes apiserver has disappeared from Prometheus target discovery.
+        expr: absent(up{job="apiserver"} == 1)
+        for: 15m
+        labels:
+          severity: critical
+
+      - alert: KubernetesControllerManagerDown
+        annotations:
+          message: Kubernetes controller-manager has disappeared from Prometheus target discovery.
+        expr: absent(up{job="controller-manager"} == 1) and absent(up{job="openshift-controller-manager"} == 1)
+        for: 15m
+        labels:
+          severity: critical
+
+      - alert: KubernetesSchedulerDown
+        annotations:
+          message: Kubernetes scheduler has disappeared from Prometheus target discovery.
+        expr: absent(up{job="scheduler"} == 1) and absent(up{job="openshift-controller-manager"} == 1)
+        for: 15m
+        labels:
+          severity: critical
+
+      - alert: MachineControllerDown
+        annotations:
+          message: Machine controller has disappeared from Prometheus target discovery.
+        expr: absent(up{job="machine-controller"} == 1)
+        for: 15m
+        labels:
+          severity: critical
+
+      - alert: UserClusterControllerDown
+        annotations:
+          message: User Cluster Controller has disappeared from Prometheus target discovery.
+        expr: absent(up{job="usercluster-controller"} == 1)
+        for: 15m
+        labels:
+          severity: critical
+
+      - alert: KubeStateMetricsDown
+        annotations:
+          message: Kube-state-metrics has disappeared from Prometheus target discovery.
+        expr: absent(up{job="kube-state-metrics"} == 1)
+        for: 15m
+        labels:
+          severity: warning
+
+      - alert: EtcdDown
+        annotations:
+          message: Etcd has disappeared from Prometheus target discovery.
+        expr: absent(up{job="etcd"} == 1)
+        for: 15m
+        labels:
+          severity: critical
+
+      # This is triggered if the cluster does have nodes, but the cadvisor could
+      # not successfully be scraped for whatever reason. An absent() on cadvisor
+      # metrics is not a good alert because clusters could simply have no nodes
+      # and hence no cadvisors.
+      - alert: CAdvisorDown
+        annotations:
+          message: cAdvisor on {{ $labels.kubernetes_io_hostname }} could not be scraped.
+        expr: up{job="cadvisor"} == 0
+        for: 15m
+        labels:
+          severity: warning
+
+      # This functions similarly to the cadvisor alert above.
+      - alert: KubernetesNodeDown
+        annotations:
+          message: The kubelet on {{ $labels.kubernetes_io_hostname }} could not be scraped.
+        expr: up{job="kubernetes-nodes"} == 0
+        for: 15m
+        labels:
+          severity: warning
+
+      - alert: DNSResolverDown
+        annotations:
+          message: DNS resolver has disappeared from Prometheus target discovery.
+        expr: absent(up{job="dns-resolver"} == 1)
+        for: 15m
+        labels:
+          severity: warning
+
+    - name: kubernetes-nodes
+      rules:
+      - alert: KubernetesNodeNotReady
+        annotations:
+          message: '{{ $labels.node }} has been unready for more than an hour.'
+        expr: kube_node_status_condition{condition="Ready",status="true"} == 0
+        for: 30m
+        labels:
+          severity: warning
+metadata:
+  creationTimestamp: null
+  labels:
+    app: prometheus

--- a/pkg/resources/test/fixtures/configmap-openstack-1.20.0-adm-control.yaml
+++ b/pkg/resources/test/fixtures/configmap-openstack-1.20.0-adm-control.yaml
@@ -1,0 +1,8 @@
+# This file has been generated, DO NOT EDIT.
+
+data:
+  admission-control.yaml: |
+    kind: AdmissionConfiguration
+    apiVersion: apiserver.config.k8s.io/v1
+metadata:
+  creationTimestamp: null

--- a/pkg/resources/test/fixtures/configmap-openstack-1.20.0-audit-config.yaml
+++ b/pkg/resources/test/fixtures/configmap-openstack-1.20.0-audit-config.yaml
@@ -1,0 +1,10 @@
+# This file has been generated, DO NOT EDIT.
+
+data:
+  policy.yaml: |
+    apiVersion: audit.k8s.io/v1
+    kind: Policy
+    rules:
+    - level: Metadata
+metadata:
+  creationTimestamp: null

--- a/pkg/resources/test/fixtures/configmap-openstack-1.20.0-cloud-config.yaml
+++ b/pkg/resources/test/fixtures/configmap-openstack-1.20.0-cloud-config.yaml
@@ -1,0 +1,30 @@
+# This file has been generated, DO NOT EDIT.
+
+data:
+  config: |
+    [Global]
+    auth-url    = "https://example.com:8000/v3"
+    username    = "openstack-username"
+    password    = "openstack-password"
+    tenant-name = "openstack-tenant"
+    tenant-id   = ""
+    domain-name = "openstack-domain"
+    region      = "cbk"
+
+    [LoadBalancer]
+    lb-version = "v2"
+    subnet-id = ""
+    floating-network-id = ""
+    lb-method = "ROUND_ROBIN"
+    lb-provider = ""
+    manage-security-groups = true
+
+    [BlockStorage]
+    ignore-volume-az  = true
+    trust-device-path = false
+    bs-version        = "auto"
+  fakeVmwareUUID: VMware-42 00 00 00 00 00 00 00-00 00 00 00 00 00 00 00
+metadata:
+  creationTimestamp: null
+  labels:
+    app: cloud-config

--- a/pkg/resources/test/fixtures/configmap-openstack-1.20.0-dns-resolver.yaml
+++ b/pkg/resources/test/fixtures/configmap-openstack-1.20.0-dns-resolver.yaml
@@ -1,0 +1,21 @@
+# This file has been generated, DO NOT EDIT.
+
+data:
+  Corefile: |2
+
+    cluster-de-test-01.svc.cluster.local. {
+        forward . /etc/resolv.conf
+        errors
+    }
+    cluster.local {
+        forward . 10.240.16.10
+        errors
+    }
+    . {
+      forward . /etc/resolv.conf
+      errors
+      health
+      prometheus 0.0.0.0:9253
+    }
+metadata:
+  creationTimestamp: null

--- a/pkg/resources/test/fixtures/configmap-openstack-1.20.0-openvpn-client-configs.yaml
+++ b/pkg/resources/test/fixtures/configmap-openstack-1.20.0-openvpn-client-configs.yaml
@@ -1,0 +1,11 @@
+# This file has been generated, DO NOT EDIT.
+
+data:
+  user-cluster-client: |
+    iroute 172.25.0.0 255.255.0.0
+    iroute 10.240.16.0 255.255.240.0
+    iroute 192.0.2.0 255.255.255.0
+metadata:
+  creationTimestamp: null
+  labels:
+    app: openvpn-server

--- a/pkg/resources/test/fixtures/configmap-openstack-1.20.0-prometheus.yaml
+++ b/pkg/resources/test/fixtures/configmap-openstack-1.20.0-prometheus.yaml
@@ -1,0 +1,623 @@
+# This file has been generated, DO NOT EDIT.
+
+data:
+  prometheus.yaml: |
+    global:
+      evaluation_interval: 30s
+      scrape_interval: 30s
+      external_labels:
+        cluster: "de-test-01"
+        seed_cluster: "testdc"
+
+    rule_files:
+    - "/etc/prometheus/config/rules*.yaml"
+
+    alerting:
+      alertmanagers:
+      - dns_sd_configs:
+        # configure the Seed's alertmanager for the user cluster
+        - names:
+          - 'alertmanager.monitoring.svc.cluster.local'
+          type: A
+          port: 9093
+
+    scrape_configs:
+    #######################################################################
+    # These rules will scrape pods running inside the seed cluster.
+
+    # scrape the etcd pods
+    - job_name: etcd
+      scheme: https
+      tls_config:
+        ca_file: /etc/etcd/pki/client/ca.crt
+        cert_file: /etc/etcd/pki/client/apiserver-etcd-client.crt
+        key_file: /etc/etcd/pki/client/apiserver-etcd-client.key
+
+      static_configs:
+      - targets:
+        - 'etcd-0.etcd.cluster-de-test-01.svc.cluster.local:2379'
+        - 'etcd-1.etcd.cluster-de-test-01.svc.cluster.local:2379'
+        - 'etcd-2.etcd.cluster-de-test-01.svc.cluster.local:2379'
+
+      relabel_configs:
+      - source_labels: [__address__]
+        regex: (etcd-\d+).+
+        action: replace
+        replacement: $1
+        target_label: instance
+
+    # scrape the cluster's control plane (apiserver, controller-manager, scheduler)
+    - job_name: kubernetes-control-plane
+      scheme: https
+      tls_config:
+        ca_file: /etc/kubernetes/ca.crt
+        cert_file: /etc/kubernetes/prometheus-client.crt
+        key_file: /etc/kubernetes/prometheus-client.key
+        # insecure_skip_verify is needed because the apiservers certificate
+        # does not contain a common name for the pod's ip address
+        insecure_skip_verify: true
+
+      kubernetes_sd_configs:
+      - role: pod
+        namespaces:
+          names:
+          - "cluster-de-test-01"
+
+      relabel_configs:
+      - source_labels: [__meta_kubernetes_pod_annotation_prometheus_io_scrape_with_kube_cert]
+        action: keep
+        regex: true
+      - source_labels: [__meta_kubernetes_pod_annotation_prometheus_io_path]
+        action: replace
+        target_label: __metrics_path__
+        regex: (.+)
+      - source_labels: [__address__, __meta_kubernetes_pod_annotation_prometheus_io_port]
+        action: replace
+        regex: ([^:]+)(?::\d+)?;(\d+)
+        replacement: $1:$2
+        target_label: __address__
+      - source_labels: [__meta_kubernetes_namespace]
+        action: replace
+        target_label: namespace
+      - source_labels: [__meta_kubernetes_pod_name]
+        action: replace
+        target_label: pod
+      - source_labels: [__meta_kubernetes_pod_label_app]
+        action: replace
+        target_label: job
+
+      # drop very expensive apiserver metrics
+      metric_relabel_configs:
+      - source_labels: [__name__]
+        regex: 'apiserver_request_(duration|latencies)_.*'
+        action: drop
+      - source_labels: [__name__]
+        regex: 'apiserver_response_sizes_.*'
+        action: drop
+
+    # scrape other cluster control plane components, like kube-state-metrics, DNS resolver,
+    # machine-controller etcd.
+    - job_name: control-plane-pods
+      kubernetes_sd_configs:
+      - role: pod
+        namespaces:
+          names:
+          - "cluster-de-test-01"
+
+      relabel_configs:
+      - source_labels: [__meta_kubernetes_pod_label_app, __meta_kubernetes_pod_container_init]
+        regex: "kube-state-metrics;true"
+        action: drop
+      - source_labels: [__meta_kubernetes_pod_annotation_prometheus_io_scrape]
+        action: keep
+        regex: true
+      - source_labels: [__meta_kubernetes_pod_annotation_prometheus_io_path]
+        action: replace
+        target_label: __metrics_path__
+        regex: (.+)
+      - source_labels: [__address__, __meta_kubernetes_pod_annotation_prometheus_io_port]
+        action: replace
+        regex: ([^:]+)(?::\d+)?;(\d+)
+        replacement: $1:$2
+        target_label: __address__
+      - source_labels: [__meta_kubernetes_pod_label_role, __meta_kubernetes_pod_label_app]
+        action: replace
+        target_label: job
+        separator: ''
+      - source_labels: [__meta_kubernetes_namespace]
+        action: replace
+        target_label: namespace
+      - source_labels: [__meta_kubernetes_pod_name]
+        action: replace
+        target_label: pod
+
+    #######################################################################
+    # These rules will scrape pods running inside the user cluster itself.
+
+    # scrape node metrics
+    - job_name: nodes
+      scheme: https
+      tls_config:
+        ca_file: /etc/kubernetes/ca.crt
+        cert_file: /etc/kubernetes/prometheus-client.crt
+        key_file: /etc/kubernetes/prometheus-client.key
+
+      kubernetes_sd_configs:
+      - role: node
+        api_server: 'https://apiserver-external.cluster-de-test-01.svc.cluster.local.'
+        tls_config:
+          ca_file: /etc/kubernetes/ca.crt
+          cert_file: /etc/kubernetes/prometheus-client.crt
+          key_file: /etc/kubernetes/prometheus-client.key
+
+      relabel_configs:
+      - action: labelmap
+        regex: __meta_kubernetes_node_label_(.+)
+      - target_label: __address__
+        replacement: 'apiserver-external.cluster-de-test-01.svc.cluster.local.'
+      - source_labels: [__meta_kubernetes_node_name]
+        regex: (.+)
+        target_label: __metrics_path__
+        replacement: /api/v1/nodes/${1}/proxy/metrics
+
+    # scrape node cadvisor
+    - job_name: cadvisor
+      scheme: https
+      tls_config:
+        ca_file: /etc/kubernetes/ca.crt
+        cert_file: /etc/kubernetes/prometheus-client.crt
+        key_file: /etc/kubernetes/prometheus-client.key
+
+      kubernetes_sd_configs:
+      - role: node
+        api_server: 'https://apiserver-external.cluster-de-test-01.svc.cluster.local.'
+        tls_config:
+          ca_file: /etc/kubernetes/ca.crt
+          cert_file: /etc/kubernetes/prometheus-client.crt
+          key_file: /etc/kubernetes/prometheus-client.key
+
+      relabel_configs:
+      - action: labelmap
+        regex: __meta_kubernetes_node_label_(.+)
+      - target_label: __address__
+        replacement: 'apiserver-external.cluster-de-test-01.svc.cluster.local.'
+      - source_labels: [__meta_kubernetes_node_name]
+        regex: (.+)
+        target_label: __metrics_path__
+        replacement: /api/v1/nodes/${1}/proxy/metrics/cadvisor
+
+    # scrape pods inside the user cluster with a special annotation
+    - job_name: 'user-cluster-pods'
+      scheme: https
+      tls_config:
+        ca_file: /etc/kubernetes/ca.crt
+        cert_file: /etc/kubernetes/prometheus-client.crt
+        key_file: /etc/kubernetes/prometheus-client.key
+
+      kubernetes_sd_configs:
+      - role: pod
+        api_server: 'https://apiserver-external.cluster-de-test-01.svc.cluster.local.'
+        tls_config:
+          ca_file: /etc/kubernetes/ca.crt
+          cert_file: /etc/kubernetes/prometheus-client.crt
+          key_file: /etc/kubernetes/prometheus-client.key
+
+      relabel_configs:
+      - source_labels: [__meta_kubernetes_pod_annotation_kubermatic_io_monitoring_port]
+        action: keep
+        regex: \d+
+      - source_labels: [__meta_kubernetes_pod_annotation_kubermatic_io_monitoring_path]
+        regex: (.+)
+        action: replace
+        target_label: __metrics_path__
+      - source_labels: [__meta_kubernetes_namespace, __meta_kubernetes_pod_name, __meta_kubernetes_pod_annotation_kubermatic_io_monitoring_port, __metrics_path__]
+        action: replace
+        regex: (.*);(.*);(.*);(.*)
+        target_label: __metrics_path__
+        replacement: /api/v1/namespaces/${1}/pods/${2}:${3}/proxy${4}
+      - target_label: __address__
+        replacement: 'apiserver-external.cluster-de-test-01.svc.cluster.local.'
+      - source_labels: [__meta_kubernetes_namespace]
+        action: replace
+        target_label: namespace
+      - source_labels: [__meta_kubernetes_pod_name]
+        action: replace
+        target_label: pod
+    #######################################################################
+    # custom scraping configurations
+
+    - job_name: custom-test-config
+      scheme: https
+      metrics_path: '/metrics'
+      static_configs:
+      - targets:
+        - 'foo.bar:12345'
+  rules.yaml: |
+    groups:
+    - name: kubermatic.goprocess
+      rules:
+      - record: job:process_resident_memory_bytes:clone
+        expr: process_resident_memory_bytes
+        labels:
+          kubermatic: federate
+
+      - record: job:process_cpu_seconds_total:rate5m
+        expr: rate(process_cpu_seconds_total[5m])
+        labels:
+          kubermatic: federate
+
+      - record: job:process_open_fds:clone
+        expr: process_open_fds
+        labels:
+          kubermatic: federate
+
+    - name: kubermatic.machine_controller
+      rules:
+      - record: job:machine_controller_errors_total:rate5m
+        expr: rate(machine_controller_errors_total[5m])
+        labels:
+          kubermatic: federate
+
+      - alert: KubernetesAdmissionWebhookHighRejectionRate
+        annotations:
+          message: '{{ $labels.operation }} requests for Machine objects are failing (Admission) with a high rate. Consider checking the affected objects'
+        expr: rate(apiserver_admission_webhook_admission_latencies_seconds_count{name="machine-controller.kubermatic.io-machines",rejected="true"}[5m]) > 0.01
+        for: 5m
+        labels:
+          severity: warning
+
+    - name: kubermatic.etcd
+      rules:
+      - record: job:etcd_server_has_leader:sum
+        expr: sum(etcd_server_has_leader)
+        labels:
+          kubermatic: federate
+
+      - record: job:etcd_disk_wal_fsync_duration_seconds_bucket:99percentile
+        expr: histogram_quantile(0.99, sum(rate(etcd_disk_wal_fsync_duration_seconds_bucket[5m])) by (instance, le))
+        labels:
+          kubermatic: federate
+
+      - record: job:etcd_disk_backend_commit_duration_seconds_bucket:99percentile
+        expr: histogram_quantile(0.99, sum(rate(etcd_disk_backend_commit_duration_seconds_bucket[5m])) by (instance, le))
+        labels:
+          kubermatic: federate
+
+      - record: job:etcd_debugging_mvcc_db_total_size_in_bytes:clone
+        expr: etcd_debugging_mvcc_db_total_size_in_bytes
+        labels:
+          kubermatic: federate
+
+      - record: job:etcd_network_client_grpc_received_bytes_total:rate5m
+        expr: rate(etcd_network_client_grpc_received_bytes_total[5m])
+        labels:
+          kubermatic: federate
+
+      - record: job:etcd_network_client_grpc_sent_bytes_total:rate5m
+        expr: rate(etcd_network_client_grpc_sent_bytes_total[5m])
+        labels:
+          kubermatic: federate
+
+      - record: job:etcd_network_peer_received_bytes_total:rate5msum
+        expr: sum(rate(etcd_network_peer_received_bytes_total[5m])) by (instance)
+        labels:
+          kubermatic: federate
+
+      - record: job:etcd_network_peer_sent_bytes_total:rate5msum
+        expr: sum(rate(etcd_network_peer_sent_bytes_total[5m])) by (instance)
+        labels:
+          kubermatic: federate
+
+      - record: job:etcd_server_proposals_failed_total:rate5msum
+        expr: sum(rate(etcd_server_proposals_failed_total[5m]))
+        labels:
+          kubermatic: federate
+
+      - record: job:etcd_server_proposals_pending:sum
+        expr: sum(etcd_server_proposals_pending)
+        labels:
+          kubermatic: federate
+
+      - record: job:etcd_server_proposals_committed_total:rate5msum
+        expr: sum(rate(etcd_server_proposals_committed_total[5m]))
+        labels:
+          kubermatic: federate
+
+      - record: job:etcd_server_proposals_applied_total:rate5msum
+        expr: sum(rate(etcd_server_proposals_applied_total[5m]))
+        labels:
+          kubermatic: federate
+
+      - record: job:etcd_server_leader_changes_seen_total:changes1d
+        expr: changes(etcd_server_leader_changes_seen_total[1d])
+        labels:
+          kubermatic: federate
+
+      - record: job:etcd_debugging_mvcc_delete_total:rate5m
+        expr: rate(etcd_debugging_mvcc_delete_total[5m])
+        labels:
+          kubermatic: federate
+
+      - record: job:etcd_debugging_mvcc_put_total:rate5m
+        expr: rate(etcd_debugging_mvcc_put_total[5m])
+        labels:
+          kubermatic: federate
+
+      - record: job:etcd_debugging_mvcc_range_total:rate5m
+        expr: rate(etcd_debugging_mvcc_range_total[5m])
+        labels:
+          kubermatic: federate
+
+      - record: job:etcd_debugging_mvcc_watcher_total:rate5m
+        expr: rate(etcd_debugging_mvcc_watcher_total[5m])
+        labels:
+          kubermatic: federate
+
+      - record: job:etcd_debugging_mvcc_txn_total:rate5m
+        expr: rate(etcd_debugging_mvcc_txn_total[5m])
+        labels:
+          kubermatic: federate
+
+      - record: job:etcd_debugging_mvcc_keys_total:clone
+        expr: etcd_debugging_mvcc_keys_total
+        labels:
+          kubermatic: federate
+
+      - record: job:etcd_debugging_store_reads_total:rate5m
+        expr: rate(etcd_debugging_store_reads_total[5m])
+        labels:
+          kubermatic: federate
+
+      - record: job:etcd_debugging_store_writes_total:rate5m
+        expr: rate(etcd_debugging_store_writes_total[5m])
+        labels:
+          kubermatic: federate
+
+      - record: job:etcd_debugging_store_expires_total:rate5m
+        expr: rate(etcd_debugging_store_expires_total[5m])
+        labels:
+          kubermatic: federate
+
+    - name: machine-controller
+      rules:
+      - alert: MachineControllerTooManyErrors
+        annotations:
+          message: Machine Controller in {{ $labels.namespace }} has too many errors in its loop.
+        expr: |
+          sum(rate(machine_controller_errors_total[5m])) by (namespace) > 0.01
+        for: 20m
+        labels:
+          severity: warning
+
+      - alert: MachineControllerMachineDeletionTakesTooLong
+        annotations:
+          message: Machine {{ $labels.machine }} of cluster {{ $labels.cluster }} is stuck in deletion for more than 30min.
+        expr: (time() - machine_controller_machine_deleted) > 30*60
+        for: 0m
+        labels:
+          severity: warning
+
+      - alert: AWSInstanceCountTooHigh
+        annotations:
+          message: '{{ $labels.machine }} has more than one instance at AWS'
+        expr: machine_controller_aws_instances_for_machine > 1
+        for: 30m
+        labels:
+          severity: warning
+
+      - record: job:machine_controller_errors_total:rate5m
+        expr: rate(machine_controller_errors_total[5m])
+        labels:
+          kubermatic: federate
+
+      - record: job:machine_controller_workers:sum
+        expr: sum(machine_controller_workers)
+        labels:
+          kubermatic: federate
+
+      - record: job:machine_controller_machines:sum
+        expr: sum(machine_controller_machines)
+        labels:
+          kubermatic: federate
+
+    - name: etcd
+      rules:
+      - alert: EtcdInsufficientMembers
+        annotations:
+          message: 'Etcd cluster "{{ $labels.job }}": insufficient members ({{ $value }}).'
+        expr: |
+          sum(up{job="etcd"} == bool 1) by (job) < ((count(up{job="etcd"}) by (job) + 1) / 2)
+        for: 15m
+        labels:
+          severity: critical
+
+      - alert: EtcdNoLeader
+        annotations:
+          message: 'Etcd cluster "{{ $labels.job }}": member {{ $labels.instance }} has no leader.'
+        expr: |
+          etcd_server_has_leader{job="etcd"} == 0
+        for: 15m
+        labels:
+          severity: critical
+
+      - alert: EtcdHighNumberOfLeaderChanges
+        annotations:
+          message: 'Etcd cluster "{{ $labels.job }}": instance {{ $labels.instance }} has seen {{ $value }} leader changes within the last hour.'
+        expr: |
+          rate(etcd_server_leader_changes_seen_total{job="etcd"}[15m]) > 3
+        for: 15m
+        labels:
+          severity: warning
+
+      - alert: EtcdGRPCRequestsSlow
+        annotations:
+          message: 'Etcd cluster "{{ $labels.job }}": gRPC requests to {{ $labels.grpc_method }} are taking {{ $value }}s on etcd instance {{ $labels.instance }}.'
+        expr: |
+          histogram_quantile(0.99, sum(rate(grpc_server_handling_seconds_bucket{job="etcd", grpc_type="unary"}[5m])) by (job, instance, grpc_service, grpc_method, le))
+          > 0.15
+        for: 10m
+        labels:
+          severity: critical
+
+      - alert: EtcdMemberCommunicationSlow
+        annotations:
+          message: 'Etcd cluster "{{ $labels.job }}": member communication with {{ $labels.To }} is taking {{ $value }}s on etcd instance {{ $labels.instance }}.'
+        expr: |
+          histogram_quantile(0.99, rate(etcd_network_peer_round_trip_time_seconds_bucket{job="etcd"}[5m]))
+          > 0.15
+        for: 10m
+        labels:
+          severity: warning
+
+      - alert: EtcdHighNumberOfFailedProposals
+        annotations:
+          message: 'Etcd cluster "{{ $labels.job }}": {{ $value }} proposal failures within the last hour on etcd instance {{ $labels.instance }}.'
+        expr: |
+          rate(etcd_server_proposals_failed_total{job="etcd"}[15m]) > 5
+        for: 15m
+        labels:
+          severity: warning
+
+      - alert: EtcdHighFsyncDurations
+        annotations:
+          message: 'Etcd cluster "{{ $labels.job }}": 99th percentile fync durations are {{ $value }}s on etcd instance {{ $labels.instance }}.'
+        expr: |
+          histogram_quantile(0.99, rate(etcd_disk_wal_fsync_duration_seconds_bucket{job="etcd"}[5m]))
+          > 0.5
+        for: 10m
+        labels:
+          severity: warning
+
+      - alert: EtcdHighCommitDurations
+        annotations:
+          message: 'Etcd cluster "{{ $labels.job }}": 99th percentile commit durations {{ $value }}s on etcd instance {{ $labels.instance }}.'
+        expr: |
+          histogram_quantile(0.99, rate(etcd_disk_backend_commit_duration_seconds_bucket{job="etcd"}[5m]))
+          > 0.25
+        for: 10m
+        labels:
+          severity: warning
+
+    - name: process.filedescriptors
+      rules:
+      - expr: process_open_fds / process_max_fds
+        record: instance:fd_utilization
+
+      - alert: FdExhaustionClose
+        annotations:
+          message: '{{ $labels.job }} instance {{ $labels.instance }} will exhaust its file descriptors soon'
+        expr: |
+          predict_linear(instance:fd_utilization[1h], 3600 * 4) > 1
+        for: 10m
+        labels:
+          severity: warning
+
+      - alert: FdExhaustionClose
+        annotations:
+          message: '{{ $labels.job }} instance {{ $labels.instance }} will exhaust its file descriptors soon'
+        expr: |
+          predict_linear(instance:fd_utilization[10m], 3600) > 1
+        for: 10m
+        labels:
+          severity: critical
+
+    - name: kubernetes-absent
+      rules:
+      - alert: KubernetesApiserverDown
+        annotations:
+          message: Kubernetes apiserver has disappeared from Prometheus target discovery.
+        expr: absent(up{job="apiserver"} == 1)
+        for: 15m
+        labels:
+          severity: critical
+
+      - alert: KubernetesControllerManagerDown
+        annotations:
+          message: Kubernetes controller-manager has disappeared from Prometheus target discovery.
+        expr: absent(up{job="controller-manager"} == 1) and absent(up{job="openshift-controller-manager"} == 1)
+        for: 15m
+        labels:
+          severity: critical
+
+      - alert: KubernetesSchedulerDown
+        annotations:
+          message: Kubernetes scheduler has disappeared from Prometheus target discovery.
+        expr: absent(up{job="scheduler"} == 1) and absent(up{job="openshift-controller-manager"} == 1)
+        for: 15m
+        labels:
+          severity: critical
+
+      - alert: MachineControllerDown
+        annotations:
+          message: Machine controller has disappeared from Prometheus target discovery.
+        expr: absent(up{job="machine-controller"} == 1)
+        for: 15m
+        labels:
+          severity: critical
+
+      - alert: UserClusterControllerDown
+        annotations:
+          message: User Cluster Controller has disappeared from Prometheus target discovery.
+        expr: absent(up{job="usercluster-controller"} == 1)
+        for: 15m
+        labels:
+          severity: critical
+
+      - alert: KubeStateMetricsDown
+        annotations:
+          message: Kube-state-metrics has disappeared from Prometheus target discovery.
+        expr: absent(up{job="kube-state-metrics"} == 1)
+        for: 15m
+        labels:
+          severity: warning
+
+      - alert: EtcdDown
+        annotations:
+          message: Etcd has disappeared from Prometheus target discovery.
+        expr: absent(up{job="etcd"} == 1)
+        for: 15m
+        labels:
+          severity: critical
+
+      # This is triggered if the cluster does have nodes, but the cadvisor could
+      # not successfully be scraped for whatever reason. An absent() on cadvisor
+      # metrics is not a good alert because clusters could simply have no nodes
+      # and hence no cadvisors.
+      - alert: CAdvisorDown
+        annotations:
+          message: cAdvisor on {{ $labels.kubernetes_io_hostname }} could not be scraped.
+        expr: up{job="cadvisor"} == 0
+        for: 15m
+        labels:
+          severity: warning
+
+      # This functions similarly to the cadvisor alert above.
+      - alert: KubernetesNodeDown
+        annotations:
+          message: The kubelet on {{ $labels.kubernetes_io_hostname }} could not be scraped.
+        expr: up{job="kubernetes-nodes"} == 0
+        for: 15m
+        labels:
+          severity: warning
+
+      - alert: DNSResolverDown
+        annotations:
+          message: DNS resolver has disappeared from Prometheus target discovery.
+        expr: absent(up{job="dns-resolver"} == 1)
+        for: 15m
+        labels:
+          severity: warning
+
+    - name: kubernetes-nodes
+      rules:
+      - alert: KubernetesNodeNotReady
+        annotations:
+          message: '{{ $labels.node }} has been unready for more than an hour.'
+        expr: kube_node_status_condition{condition="Ready",status="true"} == 0
+        for: 30m
+        labels:
+          severity: warning
+metadata:
+  creationTimestamp: null
+  labels:
+    app: prometheus

--- a/pkg/resources/test/fixtures/configmap-vsphere-1.20.0-adm-control.yaml
+++ b/pkg/resources/test/fixtures/configmap-vsphere-1.20.0-adm-control.yaml
@@ -1,0 +1,8 @@
+# This file has been generated, DO NOT EDIT.
+
+data:
+  admission-control.yaml: |
+    kind: AdmissionConfiguration
+    apiVersion: apiserver.config.k8s.io/v1
+metadata:
+  creationTimestamp: null

--- a/pkg/resources/test/fixtures/configmap-vsphere-1.20.0-audit-config.yaml
+++ b/pkg/resources/test/fixtures/configmap-vsphere-1.20.0-audit-config.yaml
@@ -1,0 +1,10 @@
+# This file has been generated, DO NOT EDIT.
+
+data:
+  policy.yaml: |
+    apiVersion: audit.k8s.io/v1
+    kind: Policy
+    rules:
+    - level: Metadata
+metadata:
+  creationTimestamp: null

--- a/pkg/resources/test/fixtures/configmap-vsphere-1.20.0-cloud-config.yaml
+++ b/pkg/resources/test/fixtures/configmap-vsphere-1.20.0-cloud-config.yaml
@@ -1,0 +1,30 @@
+# This file has been generated, DO NOT EDIT.
+
+data:
+  config: |+
+    [Global]
+    user              = "vs-username"
+    password          = "vs-password"
+    port              = "443"
+    insecure-flag     = false
+    working-dir       = "de-test-01"
+    datacenter        = "vs-datacenter"
+    datastore         = "vs-datastore"
+    server            = "vs-endpoint.io"
+
+    [Disk]
+    scsicontrollertype = "pvscsi"
+
+    [Workspace]
+    server            = "vs-endpoint.io"
+    datacenter        = "vs-datacenter"
+    folder            = ""
+    default-datastore = "vs-datastore"
+    resourcepool-path = ""
+
+
+  fakeVmwareUUID: VMware-42 00 00 00 00 00 00 00-00 00 00 00 00 00 00 00
+metadata:
+  creationTimestamp: null
+  labels:
+    app: cloud-config

--- a/pkg/resources/test/fixtures/configmap-vsphere-1.20.0-dns-resolver.yaml
+++ b/pkg/resources/test/fixtures/configmap-vsphere-1.20.0-dns-resolver.yaml
@@ -1,0 +1,21 @@
+# This file has been generated, DO NOT EDIT.
+
+data:
+  Corefile: |2
+
+    cluster-de-test-01.svc.cluster.local. {
+        forward . /etc/resolv.conf
+        errors
+    }
+    cluster.local {
+        forward . 10.240.16.10
+        errors
+    }
+    . {
+      forward . /etc/resolv.conf
+      errors
+      health
+      prometheus 0.0.0.0:9253
+    }
+metadata:
+  creationTimestamp: null

--- a/pkg/resources/test/fixtures/configmap-vsphere-1.20.0-openvpn-client-configs.yaml
+++ b/pkg/resources/test/fixtures/configmap-vsphere-1.20.0-openvpn-client-configs.yaml
@@ -1,0 +1,11 @@
+# This file has been generated, DO NOT EDIT.
+
+data:
+  user-cluster-client: |
+    iroute 172.25.0.0 255.255.0.0
+    iroute 10.240.16.0 255.255.240.0
+    iroute 192.0.2.0 255.255.255.0
+metadata:
+  creationTimestamp: null
+  labels:
+    app: openvpn-server

--- a/pkg/resources/test/fixtures/configmap-vsphere-1.20.0-prometheus.yaml
+++ b/pkg/resources/test/fixtures/configmap-vsphere-1.20.0-prometheus.yaml
@@ -1,0 +1,623 @@
+# This file has been generated, DO NOT EDIT.
+
+data:
+  prometheus.yaml: |
+    global:
+      evaluation_interval: 30s
+      scrape_interval: 30s
+      external_labels:
+        cluster: "de-test-01"
+        seed_cluster: "testdc"
+
+    rule_files:
+    - "/etc/prometheus/config/rules*.yaml"
+
+    alerting:
+      alertmanagers:
+      - dns_sd_configs:
+        # configure the Seed's alertmanager for the user cluster
+        - names:
+          - 'alertmanager.monitoring.svc.cluster.local'
+          type: A
+          port: 9093
+
+    scrape_configs:
+    #######################################################################
+    # These rules will scrape pods running inside the seed cluster.
+
+    # scrape the etcd pods
+    - job_name: etcd
+      scheme: https
+      tls_config:
+        ca_file: /etc/etcd/pki/client/ca.crt
+        cert_file: /etc/etcd/pki/client/apiserver-etcd-client.crt
+        key_file: /etc/etcd/pki/client/apiserver-etcd-client.key
+
+      static_configs:
+      - targets:
+        - 'etcd-0.etcd.cluster-de-test-01.svc.cluster.local:2379'
+        - 'etcd-1.etcd.cluster-de-test-01.svc.cluster.local:2379'
+        - 'etcd-2.etcd.cluster-de-test-01.svc.cluster.local:2379'
+
+      relabel_configs:
+      - source_labels: [__address__]
+        regex: (etcd-\d+).+
+        action: replace
+        replacement: $1
+        target_label: instance
+
+    # scrape the cluster's control plane (apiserver, controller-manager, scheduler)
+    - job_name: kubernetes-control-plane
+      scheme: https
+      tls_config:
+        ca_file: /etc/kubernetes/ca.crt
+        cert_file: /etc/kubernetes/prometheus-client.crt
+        key_file: /etc/kubernetes/prometheus-client.key
+        # insecure_skip_verify is needed because the apiservers certificate
+        # does not contain a common name for the pod's ip address
+        insecure_skip_verify: true
+
+      kubernetes_sd_configs:
+      - role: pod
+        namespaces:
+          names:
+          - "cluster-de-test-01"
+
+      relabel_configs:
+      - source_labels: [__meta_kubernetes_pod_annotation_prometheus_io_scrape_with_kube_cert]
+        action: keep
+        regex: true
+      - source_labels: [__meta_kubernetes_pod_annotation_prometheus_io_path]
+        action: replace
+        target_label: __metrics_path__
+        regex: (.+)
+      - source_labels: [__address__, __meta_kubernetes_pod_annotation_prometheus_io_port]
+        action: replace
+        regex: ([^:]+)(?::\d+)?;(\d+)
+        replacement: $1:$2
+        target_label: __address__
+      - source_labels: [__meta_kubernetes_namespace]
+        action: replace
+        target_label: namespace
+      - source_labels: [__meta_kubernetes_pod_name]
+        action: replace
+        target_label: pod
+      - source_labels: [__meta_kubernetes_pod_label_app]
+        action: replace
+        target_label: job
+
+      # drop very expensive apiserver metrics
+      metric_relabel_configs:
+      - source_labels: [__name__]
+        regex: 'apiserver_request_(duration|latencies)_.*'
+        action: drop
+      - source_labels: [__name__]
+        regex: 'apiserver_response_sizes_.*'
+        action: drop
+
+    # scrape other cluster control plane components, like kube-state-metrics, DNS resolver,
+    # machine-controller etcd.
+    - job_name: control-plane-pods
+      kubernetes_sd_configs:
+      - role: pod
+        namespaces:
+          names:
+          - "cluster-de-test-01"
+
+      relabel_configs:
+      - source_labels: [__meta_kubernetes_pod_label_app, __meta_kubernetes_pod_container_init]
+        regex: "kube-state-metrics;true"
+        action: drop
+      - source_labels: [__meta_kubernetes_pod_annotation_prometheus_io_scrape]
+        action: keep
+        regex: true
+      - source_labels: [__meta_kubernetes_pod_annotation_prometheus_io_path]
+        action: replace
+        target_label: __metrics_path__
+        regex: (.+)
+      - source_labels: [__address__, __meta_kubernetes_pod_annotation_prometheus_io_port]
+        action: replace
+        regex: ([^:]+)(?::\d+)?;(\d+)
+        replacement: $1:$2
+        target_label: __address__
+      - source_labels: [__meta_kubernetes_pod_label_role, __meta_kubernetes_pod_label_app]
+        action: replace
+        target_label: job
+        separator: ''
+      - source_labels: [__meta_kubernetes_namespace]
+        action: replace
+        target_label: namespace
+      - source_labels: [__meta_kubernetes_pod_name]
+        action: replace
+        target_label: pod
+
+    #######################################################################
+    # These rules will scrape pods running inside the user cluster itself.
+
+    # scrape node metrics
+    - job_name: nodes
+      scheme: https
+      tls_config:
+        ca_file: /etc/kubernetes/ca.crt
+        cert_file: /etc/kubernetes/prometheus-client.crt
+        key_file: /etc/kubernetes/prometheus-client.key
+
+      kubernetes_sd_configs:
+      - role: node
+        api_server: 'https://apiserver-external.cluster-de-test-01.svc.cluster.local.'
+        tls_config:
+          ca_file: /etc/kubernetes/ca.crt
+          cert_file: /etc/kubernetes/prometheus-client.crt
+          key_file: /etc/kubernetes/prometheus-client.key
+
+      relabel_configs:
+      - action: labelmap
+        regex: __meta_kubernetes_node_label_(.+)
+      - target_label: __address__
+        replacement: 'apiserver-external.cluster-de-test-01.svc.cluster.local.'
+      - source_labels: [__meta_kubernetes_node_name]
+        regex: (.+)
+        target_label: __metrics_path__
+        replacement: /api/v1/nodes/${1}/proxy/metrics
+
+    # scrape node cadvisor
+    - job_name: cadvisor
+      scheme: https
+      tls_config:
+        ca_file: /etc/kubernetes/ca.crt
+        cert_file: /etc/kubernetes/prometheus-client.crt
+        key_file: /etc/kubernetes/prometheus-client.key
+
+      kubernetes_sd_configs:
+      - role: node
+        api_server: 'https://apiserver-external.cluster-de-test-01.svc.cluster.local.'
+        tls_config:
+          ca_file: /etc/kubernetes/ca.crt
+          cert_file: /etc/kubernetes/prometheus-client.crt
+          key_file: /etc/kubernetes/prometheus-client.key
+
+      relabel_configs:
+      - action: labelmap
+        regex: __meta_kubernetes_node_label_(.+)
+      - target_label: __address__
+        replacement: 'apiserver-external.cluster-de-test-01.svc.cluster.local.'
+      - source_labels: [__meta_kubernetes_node_name]
+        regex: (.+)
+        target_label: __metrics_path__
+        replacement: /api/v1/nodes/${1}/proxy/metrics/cadvisor
+
+    # scrape pods inside the user cluster with a special annotation
+    - job_name: 'user-cluster-pods'
+      scheme: https
+      tls_config:
+        ca_file: /etc/kubernetes/ca.crt
+        cert_file: /etc/kubernetes/prometheus-client.crt
+        key_file: /etc/kubernetes/prometheus-client.key
+
+      kubernetes_sd_configs:
+      - role: pod
+        api_server: 'https://apiserver-external.cluster-de-test-01.svc.cluster.local.'
+        tls_config:
+          ca_file: /etc/kubernetes/ca.crt
+          cert_file: /etc/kubernetes/prometheus-client.crt
+          key_file: /etc/kubernetes/prometheus-client.key
+
+      relabel_configs:
+      - source_labels: [__meta_kubernetes_pod_annotation_kubermatic_io_monitoring_port]
+        action: keep
+        regex: \d+
+      - source_labels: [__meta_kubernetes_pod_annotation_kubermatic_io_monitoring_path]
+        regex: (.+)
+        action: replace
+        target_label: __metrics_path__
+      - source_labels: [__meta_kubernetes_namespace, __meta_kubernetes_pod_name, __meta_kubernetes_pod_annotation_kubermatic_io_monitoring_port, __metrics_path__]
+        action: replace
+        regex: (.*);(.*);(.*);(.*)
+        target_label: __metrics_path__
+        replacement: /api/v1/namespaces/${1}/pods/${2}:${3}/proxy${4}
+      - target_label: __address__
+        replacement: 'apiserver-external.cluster-de-test-01.svc.cluster.local.'
+      - source_labels: [__meta_kubernetes_namespace]
+        action: replace
+        target_label: namespace
+      - source_labels: [__meta_kubernetes_pod_name]
+        action: replace
+        target_label: pod
+    #######################################################################
+    # custom scraping configurations
+
+    - job_name: custom-test-config
+      scheme: https
+      metrics_path: '/metrics'
+      static_configs:
+      - targets:
+        - 'foo.bar:12345'
+  rules.yaml: |
+    groups:
+    - name: kubermatic.goprocess
+      rules:
+      - record: job:process_resident_memory_bytes:clone
+        expr: process_resident_memory_bytes
+        labels:
+          kubermatic: federate
+
+      - record: job:process_cpu_seconds_total:rate5m
+        expr: rate(process_cpu_seconds_total[5m])
+        labels:
+          kubermatic: federate
+
+      - record: job:process_open_fds:clone
+        expr: process_open_fds
+        labels:
+          kubermatic: federate
+
+    - name: kubermatic.machine_controller
+      rules:
+      - record: job:machine_controller_errors_total:rate5m
+        expr: rate(machine_controller_errors_total[5m])
+        labels:
+          kubermatic: federate
+
+      - alert: KubernetesAdmissionWebhookHighRejectionRate
+        annotations:
+          message: '{{ $labels.operation }} requests for Machine objects are failing (Admission) with a high rate. Consider checking the affected objects'
+        expr: rate(apiserver_admission_webhook_admission_latencies_seconds_count{name="machine-controller.kubermatic.io-machines",rejected="true"}[5m]) > 0.01
+        for: 5m
+        labels:
+          severity: warning
+
+    - name: kubermatic.etcd
+      rules:
+      - record: job:etcd_server_has_leader:sum
+        expr: sum(etcd_server_has_leader)
+        labels:
+          kubermatic: federate
+
+      - record: job:etcd_disk_wal_fsync_duration_seconds_bucket:99percentile
+        expr: histogram_quantile(0.99, sum(rate(etcd_disk_wal_fsync_duration_seconds_bucket[5m])) by (instance, le))
+        labels:
+          kubermatic: federate
+
+      - record: job:etcd_disk_backend_commit_duration_seconds_bucket:99percentile
+        expr: histogram_quantile(0.99, sum(rate(etcd_disk_backend_commit_duration_seconds_bucket[5m])) by (instance, le))
+        labels:
+          kubermatic: federate
+
+      - record: job:etcd_debugging_mvcc_db_total_size_in_bytes:clone
+        expr: etcd_debugging_mvcc_db_total_size_in_bytes
+        labels:
+          kubermatic: federate
+
+      - record: job:etcd_network_client_grpc_received_bytes_total:rate5m
+        expr: rate(etcd_network_client_grpc_received_bytes_total[5m])
+        labels:
+          kubermatic: federate
+
+      - record: job:etcd_network_client_grpc_sent_bytes_total:rate5m
+        expr: rate(etcd_network_client_grpc_sent_bytes_total[5m])
+        labels:
+          kubermatic: federate
+
+      - record: job:etcd_network_peer_received_bytes_total:rate5msum
+        expr: sum(rate(etcd_network_peer_received_bytes_total[5m])) by (instance)
+        labels:
+          kubermatic: federate
+
+      - record: job:etcd_network_peer_sent_bytes_total:rate5msum
+        expr: sum(rate(etcd_network_peer_sent_bytes_total[5m])) by (instance)
+        labels:
+          kubermatic: federate
+
+      - record: job:etcd_server_proposals_failed_total:rate5msum
+        expr: sum(rate(etcd_server_proposals_failed_total[5m]))
+        labels:
+          kubermatic: federate
+
+      - record: job:etcd_server_proposals_pending:sum
+        expr: sum(etcd_server_proposals_pending)
+        labels:
+          kubermatic: federate
+
+      - record: job:etcd_server_proposals_committed_total:rate5msum
+        expr: sum(rate(etcd_server_proposals_committed_total[5m]))
+        labels:
+          kubermatic: federate
+
+      - record: job:etcd_server_proposals_applied_total:rate5msum
+        expr: sum(rate(etcd_server_proposals_applied_total[5m]))
+        labels:
+          kubermatic: federate
+
+      - record: job:etcd_server_leader_changes_seen_total:changes1d
+        expr: changes(etcd_server_leader_changes_seen_total[1d])
+        labels:
+          kubermatic: federate
+
+      - record: job:etcd_debugging_mvcc_delete_total:rate5m
+        expr: rate(etcd_debugging_mvcc_delete_total[5m])
+        labels:
+          kubermatic: federate
+
+      - record: job:etcd_debugging_mvcc_put_total:rate5m
+        expr: rate(etcd_debugging_mvcc_put_total[5m])
+        labels:
+          kubermatic: federate
+
+      - record: job:etcd_debugging_mvcc_range_total:rate5m
+        expr: rate(etcd_debugging_mvcc_range_total[5m])
+        labels:
+          kubermatic: federate
+
+      - record: job:etcd_debugging_mvcc_watcher_total:rate5m
+        expr: rate(etcd_debugging_mvcc_watcher_total[5m])
+        labels:
+          kubermatic: federate
+
+      - record: job:etcd_debugging_mvcc_txn_total:rate5m
+        expr: rate(etcd_debugging_mvcc_txn_total[5m])
+        labels:
+          kubermatic: federate
+
+      - record: job:etcd_debugging_mvcc_keys_total:clone
+        expr: etcd_debugging_mvcc_keys_total
+        labels:
+          kubermatic: federate
+
+      - record: job:etcd_debugging_store_reads_total:rate5m
+        expr: rate(etcd_debugging_store_reads_total[5m])
+        labels:
+          kubermatic: federate
+
+      - record: job:etcd_debugging_store_writes_total:rate5m
+        expr: rate(etcd_debugging_store_writes_total[5m])
+        labels:
+          kubermatic: federate
+
+      - record: job:etcd_debugging_store_expires_total:rate5m
+        expr: rate(etcd_debugging_store_expires_total[5m])
+        labels:
+          kubermatic: federate
+
+    - name: machine-controller
+      rules:
+      - alert: MachineControllerTooManyErrors
+        annotations:
+          message: Machine Controller in {{ $labels.namespace }} has too many errors in its loop.
+        expr: |
+          sum(rate(machine_controller_errors_total[5m])) by (namespace) > 0.01
+        for: 20m
+        labels:
+          severity: warning
+
+      - alert: MachineControllerMachineDeletionTakesTooLong
+        annotations:
+          message: Machine {{ $labels.machine }} of cluster {{ $labels.cluster }} is stuck in deletion for more than 30min.
+        expr: (time() - machine_controller_machine_deleted) > 30*60
+        for: 0m
+        labels:
+          severity: warning
+
+      - alert: AWSInstanceCountTooHigh
+        annotations:
+          message: '{{ $labels.machine }} has more than one instance at AWS'
+        expr: machine_controller_aws_instances_for_machine > 1
+        for: 30m
+        labels:
+          severity: warning
+
+      - record: job:machine_controller_errors_total:rate5m
+        expr: rate(machine_controller_errors_total[5m])
+        labels:
+          kubermatic: federate
+
+      - record: job:machine_controller_workers:sum
+        expr: sum(machine_controller_workers)
+        labels:
+          kubermatic: federate
+
+      - record: job:machine_controller_machines:sum
+        expr: sum(machine_controller_machines)
+        labels:
+          kubermatic: federate
+
+    - name: etcd
+      rules:
+      - alert: EtcdInsufficientMembers
+        annotations:
+          message: 'Etcd cluster "{{ $labels.job }}": insufficient members ({{ $value }}).'
+        expr: |
+          sum(up{job="etcd"} == bool 1) by (job) < ((count(up{job="etcd"}) by (job) + 1) / 2)
+        for: 15m
+        labels:
+          severity: critical
+
+      - alert: EtcdNoLeader
+        annotations:
+          message: 'Etcd cluster "{{ $labels.job }}": member {{ $labels.instance }} has no leader.'
+        expr: |
+          etcd_server_has_leader{job="etcd"} == 0
+        for: 15m
+        labels:
+          severity: critical
+
+      - alert: EtcdHighNumberOfLeaderChanges
+        annotations:
+          message: 'Etcd cluster "{{ $labels.job }}": instance {{ $labels.instance }} has seen {{ $value }} leader changes within the last hour.'
+        expr: |
+          rate(etcd_server_leader_changes_seen_total{job="etcd"}[15m]) > 3
+        for: 15m
+        labels:
+          severity: warning
+
+      - alert: EtcdGRPCRequestsSlow
+        annotations:
+          message: 'Etcd cluster "{{ $labels.job }}": gRPC requests to {{ $labels.grpc_method }} are taking {{ $value }}s on etcd instance {{ $labels.instance }}.'
+        expr: |
+          histogram_quantile(0.99, sum(rate(grpc_server_handling_seconds_bucket{job="etcd", grpc_type="unary"}[5m])) by (job, instance, grpc_service, grpc_method, le))
+          > 0.15
+        for: 10m
+        labels:
+          severity: critical
+
+      - alert: EtcdMemberCommunicationSlow
+        annotations:
+          message: 'Etcd cluster "{{ $labels.job }}": member communication with {{ $labels.To }} is taking {{ $value }}s on etcd instance {{ $labels.instance }}.'
+        expr: |
+          histogram_quantile(0.99, rate(etcd_network_peer_round_trip_time_seconds_bucket{job="etcd"}[5m]))
+          > 0.15
+        for: 10m
+        labels:
+          severity: warning
+
+      - alert: EtcdHighNumberOfFailedProposals
+        annotations:
+          message: 'Etcd cluster "{{ $labels.job }}": {{ $value }} proposal failures within the last hour on etcd instance {{ $labels.instance }}.'
+        expr: |
+          rate(etcd_server_proposals_failed_total{job="etcd"}[15m]) > 5
+        for: 15m
+        labels:
+          severity: warning
+
+      - alert: EtcdHighFsyncDurations
+        annotations:
+          message: 'Etcd cluster "{{ $labels.job }}": 99th percentile fync durations are {{ $value }}s on etcd instance {{ $labels.instance }}.'
+        expr: |
+          histogram_quantile(0.99, rate(etcd_disk_wal_fsync_duration_seconds_bucket{job="etcd"}[5m]))
+          > 0.5
+        for: 10m
+        labels:
+          severity: warning
+
+      - alert: EtcdHighCommitDurations
+        annotations:
+          message: 'Etcd cluster "{{ $labels.job }}": 99th percentile commit durations {{ $value }}s on etcd instance {{ $labels.instance }}.'
+        expr: |
+          histogram_quantile(0.99, rate(etcd_disk_backend_commit_duration_seconds_bucket{job="etcd"}[5m]))
+          > 0.25
+        for: 10m
+        labels:
+          severity: warning
+
+    - name: process.filedescriptors
+      rules:
+      - expr: process_open_fds / process_max_fds
+        record: instance:fd_utilization
+
+      - alert: FdExhaustionClose
+        annotations:
+          message: '{{ $labels.job }} instance {{ $labels.instance }} will exhaust its file descriptors soon'
+        expr: |
+          predict_linear(instance:fd_utilization[1h], 3600 * 4) > 1
+        for: 10m
+        labels:
+          severity: warning
+
+      - alert: FdExhaustionClose
+        annotations:
+          message: '{{ $labels.job }} instance {{ $labels.instance }} will exhaust its file descriptors soon'
+        expr: |
+          predict_linear(instance:fd_utilization[10m], 3600) > 1
+        for: 10m
+        labels:
+          severity: critical
+
+    - name: kubernetes-absent
+      rules:
+      - alert: KubernetesApiserverDown
+        annotations:
+          message: Kubernetes apiserver has disappeared from Prometheus target discovery.
+        expr: absent(up{job="apiserver"} == 1)
+        for: 15m
+        labels:
+          severity: critical
+
+      - alert: KubernetesControllerManagerDown
+        annotations:
+          message: Kubernetes controller-manager has disappeared from Prometheus target discovery.
+        expr: absent(up{job="controller-manager"} == 1) and absent(up{job="openshift-controller-manager"} == 1)
+        for: 15m
+        labels:
+          severity: critical
+
+      - alert: KubernetesSchedulerDown
+        annotations:
+          message: Kubernetes scheduler has disappeared from Prometheus target discovery.
+        expr: absent(up{job="scheduler"} == 1) and absent(up{job="openshift-controller-manager"} == 1)
+        for: 15m
+        labels:
+          severity: critical
+
+      - alert: MachineControllerDown
+        annotations:
+          message: Machine controller has disappeared from Prometheus target discovery.
+        expr: absent(up{job="machine-controller"} == 1)
+        for: 15m
+        labels:
+          severity: critical
+
+      - alert: UserClusterControllerDown
+        annotations:
+          message: User Cluster Controller has disappeared from Prometheus target discovery.
+        expr: absent(up{job="usercluster-controller"} == 1)
+        for: 15m
+        labels:
+          severity: critical
+
+      - alert: KubeStateMetricsDown
+        annotations:
+          message: Kube-state-metrics has disappeared from Prometheus target discovery.
+        expr: absent(up{job="kube-state-metrics"} == 1)
+        for: 15m
+        labels:
+          severity: warning
+
+      - alert: EtcdDown
+        annotations:
+          message: Etcd has disappeared from Prometheus target discovery.
+        expr: absent(up{job="etcd"} == 1)
+        for: 15m
+        labels:
+          severity: critical
+
+      # This is triggered if the cluster does have nodes, but the cadvisor could
+      # not successfully be scraped for whatever reason. An absent() on cadvisor
+      # metrics is not a good alert because clusters could simply have no nodes
+      # and hence no cadvisors.
+      - alert: CAdvisorDown
+        annotations:
+          message: cAdvisor on {{ $labels.kubernetes_io_hostname }} could not be scraped.
+        expr: up{job="cadvisor"} == 0
+        for: 15m
+        labels:
+          severity: warning
+
+      # This functions similarly to the cadvisor alert above.
+      - alert: KubernetesNodeDown
+        annotations:
+          message: The kubelet on {{ $labels.kubernetes_io_hostname }} could not be scraped.
+        expr: up{job="kubernetes-nodes"} == 0
+        for: 15m
+        labels:
+          severity: warning
+
+      - alert: DNSResolverDown
+        annotations:
+          message: DNS resolver has disappeared from Prometheus target discovery.
+        expr: absent(up{job="dns-resolver"} == 1)
+        for: 15m
+        labels:
+          severity: warning
+
+    - name: kubernetes-nodes
+      rules:
+      - alert: KubernetesNodeNotReady
+        annotations:
+          message: '{{ $labels.node }} has been unready for more than an hour.'
+        expr: kube_node_status_condition{condition="Ready",status="true"} == 0
+        for: 30m
+        labels:
+          severity: warning
+metadata:
+  creationTimestamp: null
+  labels:
+    app: prometheus

--- a/pkg/resources/test/fixtures/cronjob-aws-1.20.0-etcd-defragger.yaml
+++ b/pkg/resources/test/fixtures/cronjob-aws-1.20.0-etcd-defragger.yaml
@@ -1,0 +1,65 @@
+# This file has been generated, DO NOT EDIT.
+
+metadata:
+  creationTimestamp: null
+  name: etcd-defragger
+  ownerReferences:
+  - apiVersion: kubermatic.k8s.io/v1
+    blockOwnerDeletion: true
+    controller: true
+    kind: Cluster
+    name: de-test-01
+    uid: "1234567890"
+spec:
+  concurrencyPolicy: Forbid
+  jobTemplate:
+    metadata:
+      creationTimestamp: null
+    spec:
+      template:
+        metadata:
+          creationTimestamp: null
+        spec:
+          containers:
+          - command:
+            - /bin/sh
+            - -ec
+            - |-
+              etcdctl() {
+              ETCDCTL_API=3 /usr/local/bin/etcdctl \
+                --command-timeout=60s \
+                --endpoints https://$1.etcd.cluster-de-test-01.svc.cluster.local.:2379 \
+                --cacert /etc/etcd/pki/client/ca.crt \
+                --cert /etc/etcd/pki/client/apiserver-etcd-client.crt \
+                --key /etc/etcd/pki/client/apiserver-etcd-client.key \
+                $2
+              }
+
+              for node in etcd-0 etcd-1 etcd-2; do
+                etcdctl $node "endpoint health"
+
+                if [ $? -eq 0 ]; then
+                  echo "Defragmenting $node..."
+                  etcdctl $node defrag
+                  sleep 30
+                else
+                  echo "$node is not healthy, skipping defrag."
+                fi
+              done
+            image: gcr.io/etcd-development/etcd:v3.4.3
+            name: defragger
+            resources: {}
+            volumeMounts:
+            - mountPath: /etc/etcd/pki/client
+              name: apiserver-etcd-client-certificate
+              readOnly: true
+          imagePullSecrets:
+          - name: dockercfg
+          restartPolicy: OnFailure
+          volumes:
+          - name: apiserver-etcd-client-certificate
+            secret:
+              secretName: apiserver-etcd-client-certificate
+  schedule: '@every 3h'
+  successfulJobsHistoryLimit: 0
+status: {}

--- a/pkg/resources/test/fixtures/cronjob-azure-1.20.0-etcd-defragger.yaml
+++ b/pkg/resources/test/fixtures/cronjob-azure-1.20.0-etcd-defragger.yaml
@@ -1,0 +1,65 @@
+# This file has been generated, DO NOT EDIT.
+
+metadata:
+  creationTimestamp: null
+  name: etcd-defragger
+  ownerReferences:
+  - apiVersion: kubermatic.k8s.io/v1
+    blockOwnerDeletion: true
+    controller: true
+    kind: Cluster
+    name: de-test-01
+    uid: "1234567890"
+spec:
+  concurrencyPolicy: Forbid
+  jobTemplate:
+    metadata:
+      creationTimestamp: null
+    spec:
+      template:
+        metadata:
+          creationTimestamp: null
+        spec:
+          containers:
+          - command:
+            - /bin/sh
+            - -ec
+            - |-
+              etcdctl() {
+              ETCDCTL_API=3 /usr/local/bin/etcdctl \
+                --command-timeout=60s \
+                --endpoints https://$1.etcd.cluster-de-test-01.svc.cluster.local.:2379 \
+                --cacert /etc/etcd/pki/client/ca.crt \
+                --cert /etc/etcd/pki/client/apiserver-etcd-client.crt \
+                --key /etc/etcd/pki/client/apiserver-etcd-client.key \
+                $2
+              }
+
+              for node in etcd-0 etcd-1 etcd-2; do
+                etcdctl $node "endpoint health"
+
+                if [ $? -eq 0 ]; then
+                  echo "Defragmenting $node..."
+                  etcdctl $node defrag
+                  sleep 30
+                else
+                  echo "$node is not healthy, skipping defrag."
+                fi
+              done
+            image: gcr.io/etcd-development/etcd:v3.4.3
+            name: defragger
+            resources: {}
+            volumeMounts:
+            - mountPath: /etc/etcd/pki/client
+              name: apiserver-etcd-client-certificate
+              readOnly: true
+          imagePullSecrets:
+          - name: dockercfg
+          restartPolicy: OnFailure
+          volumes:
+          - name: apiserver-etcd-client-certificate
+            secret:
+              secretName: apiserver-etcd-client-certificate
+  schedule: '@every 3h'
+  successfulJobsHistoryLimit: 0
+status: {}

--- a/pkg/resources/test/fixtures/cronjob-bringyourown-1.20.0-etcd-defragger.yaml
+++ b/pkg/resources/test/fixtures/cronjob-bringyourown-1.20.0-etcd-defragger.yaml
@@ -1,0 +1,65 @@
+# This file has been generated, DO NOT EDIT.
+
+metadata:
+  creationTimestamp: null
+  name: etcd-defragger
+  ownerReferences:
+  - apiVersion: kubermatic.k8s.io/v1
+    blockOwnerDeletion: true
+    controller: true
+    kind: Cluster
+    name: de-test-01
+    uid: "1234567890"
+spec:
+  concurrencyPolicy: Forbid
+  jobTemplate:
+    metadata:
+      creationTimestamp: null
+    spec:
+      template:
+        metadata:
+          creationTimestamp: null
+        spec:
+          containers:
+          - command:
+            - /bin/sh
+            - -ec
+            - |-
+              etcdctl() {
+              ETCDCTL_API=3 /usr/local/bin/etcdctl \
+                --command-timeout=60s \
+                --endpoints https://$1.etcd.cluster-de-test-01.svc.cluster.local.:2379 \
+                --cacert /etc/etcd/pki/client/ca.crt \
+                --cert /etc/etcd/pki/client/apiserver-etcd-client.crt \
+                --key /etc/etcd/pki/client/apiserver-etcd-client.key \
+                $2
+              }
+
+              for node in etcd-0 etcd-1 etcd-2; do
+                etcdctl $node "endpoint health"
+
+                if [ $? -eq 0 ]; then
+                  echo "Defragmenting $node..."
+                  etcdctl $node defrag
+                  sleep 30
+                else
+                  echo "$node is not healthy, skipping defrag."
+                fi
+              done
+            image: gcr.io/etcd-development/etcd:v3.4.3
+            name: defragger
+            resources: {}
+            volumeMounts:
+            - mountPath: /etc/etcd/pki/client
+              name: apiserver-etcd-client-certificate
+              readOnly: true
+          imagePullSecrets:
+          - name: dockercfg
+          restartPolicy: OnFailure
+          volumes:
+          - name: apiserver-etcd-client-certificate
+            secret:
+              secretName: apiserver-etcd-client-certificate
+  schedule: '@every 3h'
+  successfulJobsHistoryLimit: 0
+status: {}

--- a/pkg/resources/test/fixtures/cronjob-digitalocean-1.20.0-etcd-defragger.yaml
+++ b/pkg/resources/test/fixtures/cronjob-digitalocean-1.20.0-etcd-defragger.yaml
@@ -1,0 +1,65 @@
+# This file has been generated, DO NOT EDIT.
+
+metadata:
+  creationTimestamp: null
+  name: etcd-defragger
+  ownerReferences:
+  - apiVersion: kubermatic.k8s.io/v1
+    blockOwnerDeletion: true
+    controller: true
+    kind: Cluster
+    name: de-test-01
+    uid: "1234567890"
+spec:
+  concurrencyPolicy: Forbid
+  jobTemplate:
+    metadata:
+      creationTimestamp: null
+    spec:
+      template:
+        metadata:
+          creationTimestamp: null
+        spec:
+          containers:
+          - command:
+            - /bin/sh
+            - -ec
+            - |-
+              etcdctl() {
+              ETCDCTL_API=3 /usr/local/bin/etcdctl \
+                --command-timeout=60s \
+                --endpoints https://$1.etcd.cluster-de-test-01.svc.cluster.local.:2379 \
+                --cacert /etc/etcd/pki/client/ca.crt \
+                --cert /etc/etcd/pki/client/apiserver-etcd-client.crt \
+                --key /etc/etcd/pki/client/apiserver-etcd-client.key \
+                $2
+              }
+
+              for node in etcd-0 etcd-1 etcd-2; do
+                etcdctl $node "endpoint health"
+
+                if [ $? -eq 0 ]; then
+                  echo "Defragmenting $node..."
+                  etcdctl $node defrag
+                  sleep 30
+                else
+                  echo "$node is not healthy, skipping defrag."
+                fi
+              done
+            image: gcr.io/etcd-development/etcd:v3.4.3
+            name: defragger
+            resources: {}
+            volumeMounts:
+            - mountPath: /etc/etcd/pki/client
+              name: apiserver-etcd-client-certificate
+              readOnly: true
+          imagePullSecrets:
+          - name: dockercfg
+          restartPolicy: OnFailure
+          volumes:
+          - name: apiserver-etcd-client-certificate
+            secret:
+              secretName: apiserver-etcd-client-certificate
+  schedule: '@every 3h'
+  successfulJobsHistoryLimit: 0
+status: {}

--- a/pkg/resources/test/fixtures/cronjob-openstack-1.20.0-etcd-defragger.yaml
+++ b/pkg/resources/test/fixtures/cronjob-openstack-1.20.0-etcd-defragger.yaml
@@ -1,0 +1,65 @@
+# This file has been generated, DO NOT EDIT.
+
+metadata:
+  creationTimestamp: null
+  name: etcd-defragger
+  ownerReferences:
+  - apiVersion: kubermatic.k8s.io/v1
+    blockOwnerDeletion: true
+    controller: true
+    kind: Cluster
+    name: de-test-01
+    uid: "1234567890"
+spec:
+  concurrencyPolicy: Forbid
+  jobTemplate:
+    metadata:
+      creationTimestamp: null
+    spec:
+      template:
+        metadata:
+          creationTimestamp: null
+        spec:
+          containers:
+          - command:
+            - /bin/sh
+            - -ec
+            - |-
+              etcdctl() {
+              ETCDCTL_API=3 /usr/local/bin/etcdctl \
+                --command-timeout=60s \
+                --endpoints https://$1.etcd.cluster-de-test-01.svc.cluster.local.:2379 \
+                --cacert /etc/etcd/pki/client/ca.crt \
+                --cert /etc/etcd/pki/client/apiserver-etcd-client.crt \
+                --key /etc/etcd/pki/client/apiserver-etcd-client.key \
+                $2
+              }
+
+              for node in etcd-0 etcd-1 etcd-2; do
+                etcdctl $node "endpoint health"
+
+                if [ $? -eq 0 ]; then
+                  echo "Defragmenting $node..."
+                  etcdctl $node defrag
+                  sleep 30
+                else
+                  echo "$node is not healthy, skipping defrag."
+                fi
+              done
+            image: gcr.io/etcd-development/etcd:v3.4.3
+            name: defragger
+            resources: {}
+            volumeMounts:
+            - mountPath: /etc/etcd/pki/client
+              name: apiserver-etcd-client-certificate
+              readOnly: true
+          imagePullSecrets:
+          - name: dockercfg
+          restartPolicy: OnFailure
+          volumes:
+          - name: apiserver-etcd-client-certificate
+            secret:
+              secretName: apiserver-etcd-client-certificate
+  schedule: '@every 3h'
+  successfulJobsHistoryLimit: 0
+status: {}

--- a/pkg/resources/test/fixtures/cronjob-vsphere-1.20.0-etcd-defragger.yaml
+++ b/pkg/resources/test/fixtures/cronjob-vsphere-1.20.0-etcd-defragger.yaml
@@ -1,0 +1,65 @@
+# This file has been generated, DO NOT EDIT.
+
+metadata:
+  creationTimestamp: null
+  name: etcd-defragger
+  ownerReferences:
+  - apiVersion: kubermatic.k8s.io/v1
+    blockOwnerDeletion: true
+    controller: true
+    kind: Cluster
+    name: de-test-01
+    uid: "1234567890"
+spec:
+  concurrencyPolicy: Forbid
+  jobTemplate:
+    metadata:
+      creationTimestamp: null
+    spec:
+      template:
+        metadata:
+          creationTimestamp: null
+        spec:
+          containers:
+          - command:
+            - /bin/sh
+            - -ec
+            - |-
+              etcdctl() {
+              ETCDCTL_API=3 /usr/local/bin/etcdctl \
+                --command-timeout=60s \
+                --endpoints https://$1.etcd.cluster-de-test-01.svc.cluster.local.:2379 \
+                --cacert /etc/etcd/pki/client/ca.crt \
+                --cert /etc/etcd/pki/client/apiserver-etcd-client.crt \
+                --key /etc/etcd/pki/client/apiserver-etcd-client.key \
+                $2
+              }
+
+              for node in etcd-0 etcd-1 etcd-2; do
+                etcdctl $node "endpoint health"
+
+                if [ $? -eq 0 ]; then
+                  echo "Defragmenting $node..."
+                  etcdctl $node defrag
+                  sleep 30
+                else
+                  echo "$node is not healthy, skipping defrag."
+                fi
+              done
+            image: gcr.io/etcd-development/etcd:v3.4.3
+            name: defragger
+            resources: {}
+            volumeMounts:
+            - mountPath: /etc/etcd/pki/client
+              name: apiserver-etcd-client-certificate
+              readOnly: true
+          imagePullSecrets:
+          - name: dockercfg
+          restartPolicy: OnFailure
+          volumes:
+          - name: apiserver-etcd-client-certificate
+            secret:
+              secretName: apiserver-etcd-client-certificate
+  schedule: '@every 3h'
+  successfulJobsHistoryLimit: 0
+status: {}

--- a/pkg/resources/test/fixtures/deployment-aws-1.17.0-apiserver.yaml
+++ b/pkg/resources/test/fixtures/deployment-aws-1.17.0-apiserver.yaml
@@ -202,12 +202,12 @@ spec:
         - X-Remote-Group
         - --requestheader-username-headers
         - X-Remote-User
+        - --service-account-issuer
+        - https://jh8j81chn.europe-west3-c.dev.kubermatic.io:30000
         - --service-account-signing-key-file
         - /etc/kubernetes/service-account-key/sa.key
-        - --service-account-issuer
-        - kubernetes.default.svc
         - --api-audiences
-        - kubernetes.default.svc
+        - https://jh8j81chn.europe-west3-c.dev.kubermatic.io:30000
         - --kubelet-preferred-address-types
         - ExternalIP,InternalIP
         - --cloud-provider

--- a/pkg/resources/test/fixtures/deployment-aws-1.17.0-usercluster-controller.yaml
+++ b/pkg/resources/test/fixtures/deployment-aws-1.17.0-usercluster-controller.yaml
@@ -39,7 +39,7 @@ spec:
         - -timeout
         - "1"
         - -command
-        - '{"command":"/usr/local/bin/user-cluster-controller-manager","args":["-kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","-metrics-listen-address","0.0.0.0:8085","-health-listen-address","0.0.0.0:8086","-namespace","$(NAMESPACE)","-cluster-url","","-dns-cluster-ip","10.240.16.10","-openvpn-server-port","30003","-overwrite-registry","","-openshift=false","-version","1.17.0","-cloud-provider-name","aws","-owner-email","","-opa-integration=false","--ipam-controller-network","192.168.1.1/24,192.168.1.1,8.8.8.8","-node-labels","{\"my-label\":\"my-value\"}"]}'
+        - '{"command":"/usr/local/bin/user-cluster-controller-manager","args":["-kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","-metrics-listen-address","0.0.0.0:8085","-health-listen-address","0.0.0.0:8086","-namespace","$(NAMESPACE)","-cluster-url","https://jh8j81chn.europe-west3-c.dev.kubermatic.io:30000","-dns-cluster-ip","10.240.16.10","-openvpn-server-port","30003","-overwrite-registry","","-openshift=false","-version","1.17.0","-cloud-provider-name","aws","-owner-email","","-opa-integration=false","--ipam-controller-network","192.168.1.1/24,192.168.1.1,8.8.8.8","-node-labels","{\"my-label\":\"my-value\"}"]}'
         command:
         - /http-prober-bin/http-prober
         env:

--- a/pkg/resources/test/fixtures/deployment-aws-1.18.0-apiserver.yaml
+++ b/pkg/resources/test/fixtures/deployment-aws-1.18.0-apiserver.yaml
@@ -202,12 +202,12 @@ spec:
         - X-Remote-Group
         - --requestheader-username-headers
         - X-Remote-User
+        - --service-account-issuer
+        - https://jh8j81chn.europe-west3-c.dev.kubermatic.io:30000
         - --service-account-signing-key-file
         - /etc/kubernetes/service-account-key/sa.key
-        - --service-account-issuer
-        - kubernetes.default.svc
         - --api-audiences
-        - kubernetes.default.svc
+        - https://jh8j81chn.europe-west3-c.dev.kubermatic.io:30000
         - --kubelet-preferred-address-types
         - ExternalIP,InternalIP
         - --cloud-provider

--- a/pkg/resources/test/fixtures/deployment-aws-1.18.0-usercluster-controller.yaml
+++ b/pkg/resources/test/fixtures/deployment-aws-1.18.0-usercluster-controller.yaml
@@ -39,7 +39,7 @@ spec:
         - -timeout
         - "1"
         - -command
-        - '{"command":"/usr/local/bin/user-cluster-controller-manager","args":["-kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","-metrics-listen-address","0.0.0.0:8085","-health-listen-address","0.0.0.0:8086","-namespace","$(NAMESPACE)","-cluster-url","","-dns-cluster-ip","10.240.16.10","-openvpn-server-port","30003","-overwrite-registry","","-openshift=false","-version","1.18.0","-cloud-provider-name","aws","-owner-email","","-opa-integration=false","--ipam-controller-network","192.168.1.1/24,192.168.1.1,8.8.8.8","-node-labels","{\"my-label\":\"my-value\"}"]}'
+        - '{"command":"/usr/local/bin/user-cluster-controller-manager","args":["-kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","-metrics-listen-address","0.0.0.0:8085","-health-listen-address","0.0.0.0:8086","-namespace","$(NAMESPACE)","-cluster-url","https://jh8j81chn.europe-west3-c.dev.kubermatic.io:30000","-dns-cluster-ip","10.240.16.10","-openvpn-server-port","30003","-overwrite-registry","","-openshift=false","-version","1.18.0","-cloud-provider-name","aws","-owner-email","","-opa-integration=false","--ipam-controller-network","192.168.1.1/24,192.168.1.1,8.8.8.8","-node-labels","{\"my-label\":\"my-value\"}"]}'
         command:
         - /http-prober-bin/http-prober
         env:

--- a/pkg/resources/test/fixtures/deployment-aws-1.19.0-apiserver.yaml
+++ b/pkg/resources/test/fixtures/deployment-aws-1.19.0-apiserver.yaml
@@ -202,12 +202,12 @@ spec:
         - X-Remote-Group
         - --requestheader-username-headers
         - X-Remote-User
+        - --service-account-issuer
+        - https://jh8j81chn.europe-west3-c.dev.kubermatic.io:30000
         - --service-account-signing-key-file
         - /etc/kubernetes/service-account-key/sa.key
-        - --service-account-issuer
-        - kubernetes.default.svc
         - --api-audiences
-        - kubernetes.default.svc
+        - https://jh8j81chn.europe-west3-c.dev.kubermatic.io:30000
         - --kubelet-preferred-address-types
         - ExternalIP,InternalIP
         - --cloud-provider

--- a/pkg/resources/test/fixtures/deployment-aws-1.19.0-usercluster-controller.yaml
+++ b/pkg/resources/test/fixtures/deployment-aws-1.19.0-usercluster-controller.yaml
@@ -39,7 +39,7 @@ spec:
         - -timeout
         - "1"
         - -command
-        - '{"command":"/usr/local/bin/user-cluster-controller-manager","args":["-kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","-metrics-listen-address","0.0.0.0:8085","-health-listen-address","0.0.0.0:8086","-namespace","$(NAMESPACE)","-cluster-url","","-dns-cluster-ip","10.240.16.10","-openvpn-server-port","30003","-overwrite-registry","","-openshift=false","-version","1.19.0","-cloud-provider-name","aws","-owner-email","","-opa-integration=false","--ipam-controller-network","192.168.1.1/24,192.168.1.1,8.8.8.8","-node-labels","{\"my-label\":\"my-value\"}"]}'
+        - '{"command":"/usr/local/bin/user-cluster-controller-manager","args":["-kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","-metrics-listen-address","0.0.0.0:8085","-health-listen-address","0.0.0.0:8086","-namespace","$(NAMESPACE)","-cluster-url","https://jh8j81chn.europe-west3-c.dev.kubermatic.io:30000","-dns-cluster-ip","10.240.16.10","-openvpn-server-port","30003","-overwrite-registry","","-openshift=false","-version","1.19.0","-cloud-provider-name","aws","-owner-email","","-opa-integration=false","--ipam-controller-network","192.168.1.1/24,192.168.1.1,8.8.8.8","-node-labels","{\"my-label\":\"my-value\"}"]}'
         command:
         - /http-prober-bin/http-prober
         env:

--- a/pkg/resources/test/fixtures/deployment-aws-1.20.0-apiserver.yaml
+++ b/pkg/resources/test/fixtures/deployment-aws-1.20.0-apiserver.yaml
@@ -1,0 +1,412 @@
+# This file has been generated, DO NOT EDIT.
+
+metadata:
+  creationTimestamp: null
+  labels:
+    app: apiserver
+  name: apiserver
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: apiserver
+  strategy: {}
+  template:
+    metadata:
+      annotations:
+        prometheus.io/path: /metrics
+        prometheus.io/port: "30000"
+        prometheus.io/scrape_with_kube_cert: "true"
+      creationTimestamp: null
+      labels:
+        adm-control-configmap-revision: "123456"
+        apiserver-etcd-client-certificate-secret-revision: "123456"
+        apiserver-proxy-client-certificate-secret-revision: "123456"
+        apiserver-tls-secret-revision: "123456"
+        app: apiserver
+        audit-config-configmap-revision: "123456"
+        ca-secret-revision: "123456"
+        cloud-config-configmap-revision: "123456"
+        cluster: de-test-01
+        dex-ca-secret-revision: "123456"
+        front-proxy-ca-secret-revision: "123456"
+        kubelet-client-certificates-secret-revision: "123456"
+        kubeletdnatcontroller-kubeconfig-secret-revision: "123456"
+        openvpn-client-certificates-secret-revision: "123456"
+        service-account-key-secret-revision: "123456"
+        tokens-secret-revision: "123456"
+    spec:
+      affinity:
+        podAntiAffinity:
+          preferredDuringSchedulingIgnoredDuringExecution:
+          - podAffinityTerm:
+              labelSelector:
+                matchLabels:
+                  app: apiserver
+                  cluster: de-test-01
+              topologyKey: kubernetes.io/hostname
+            weight: 100
+          - podAffinityTerm:
+              labelSelector:
+                matchLabels:
+                  app: apiserver
+              topologyKey: kubernetes.io/hostname
+            weight: 10
+      containers:
+      - args:
+        - --client
+        - --proto
+        - tcp
+        - --dev
+        - tun
+        - --auth-nocache
+        - --remote
+        - openvpn-server.cluster-de-test-01.svc.cluster.local.
+        - "1194"
+        - --nobind
+        - --connect-timeout
+        - "5"
+        - --connect-retry
+        - "1"
+        - --ca
+        - /etc/openvpn/pki/client/ca.crt
+        - --cert
+        - /etc/openvpn/pki/client/client.crt
+        - --key
+        - /etc/openvpn/pki/client/client.key
+        - --remote-cert-tls
+        - server
+        - --link-mtu
+        - "1432"
+        - --cipher
+        - AES-256-GCM
+        - --auth
+        - SHA1
+        - --keysize
+        - "256"
+        - --script-security
+        - "2"
+        - --status
+        - /run/openvpn-status
+        - --log
+        - /dev/stdout
+        command:
+        - /usr/sbin/openvpn
+        image: quay.io/kubermatic/openvpn:v2.4.8-r1
+        name: openvpn-client
+        resources:
+          limits:
+            cpu: 100m
+            memory: 32Mi
+          requests:
+            cpu: 5m
+            memory: 5Mi
+        securityContext:
+          privileged: true
+        volumeMounts:
+        - mountPath: /etc/openvpn/pki/client
+          name: openvpn-client-certificates
+          readOnly: true
+      - args:
+        - -kubeconfig
+        - /etc/kubernetes/kubeconfig/kubeconfig
+        - -node-access-network
+        - 192.0.2.0/24
+        - -master
+        - https://127.0.0.1:30000
+        command:
+        - /usr/local/bin/kubeletdnat-controller
+        image: quay.io/kubermatic/kubeletdnat-controller:v0.0.0-test
+        name: dnat-controller
+        resources:
+          limits:
+            cpu: 100m
+            memory: 512Mi
+          requests:
+            cpu: 5m
+            memory: 16Mi
+        securityContext:
+          capabilities:
+            add:
+            - NET_ADMIN
+          procMount: Default
+          runAsUser: 0
+        volumeMounts:
+        - mountPath: /etc/kubernetes/kubeconfig
+          name: kubeletdnatcontroller-kubeconfig
+          readOnly: true
+      - args:
+        - --advertise-address
+        - 35.198.93.90
+        - --secure-port
+        - "30000"
+        - --kubernetes-service-node-port
+        - "30000"
+        - --etcd-servers
+        - https://etcd-0.etcd.cluster-de-test-01.svc.cluster.local.:2379,https://etcd-1.etcd.cluster-de-test-01.svc.cluster.local.:2379,https://etcd-2.etcd.cluster-de-test-01.svc.cluster.local.:2379
+        - --etcd-cafile
+        - /etc/etcd/pki/client/ca.crt
+        - --etcd-certfile
+        - /etc/etcd/pki/client/apiserver-etcd-client.crt
+        - --etcd-keyfile
+        - /etc/etcd/pki/client/apiserver-etcd-client.key
+        - --storage-backend
+        - etcd3
+        - --enable-admission-plugins
+        - DefaultStorageClass,DefaultTolerationSeconds,LimitRanger,MutatingAdmissionWebhook,NamespaceLifecycle,Priority,ResourceQuota,ServiceAccount,ValidatingAdmissionWebhook
+        - --admission-control-config-file
+        - /etc/kubernetes/adm-control/admission-control.yaml
+        - --authorization-mode
+        - Node,RBAC
+        - --external-hostname
+        - jh8j81chn.europe-west3-c.dev.kubermatic.io
+        - --token-auth-file
+        - /etc/kubernetes/tokens/tokens.csv
+        - --enable-bootstrap-token-auth
+        - --service-account-key-file
+        - /etc/kubernetes/service-account-key/sa.key
+        - --service-cluster-ip-range
+        - 10.240.16.0/20
+        - --service-node-port-range
+        - 30000-32767
+        - --allow-privileged
+        - --audit-log-maxage
+        - "30"
+        - --audit-log-maxbackup
+        - "3"
+        - --audit-log-maxsize
+        - "100"
+        - --audit-log-path
+        - /var/log/kubernetes/audit/audit.log
+        - --tls-cert-file
+        - /etc/kubernetes/tls/apiserver-tls.crt
+        - --tls-private-key-file
+        - /etc/kubernetes/tls/apiserver-tls.key
+        - --proxy-client-cert-file
+        - /etc/kubernetes/pki/front-proxy/client/apiserver-proxy-client.crt
+        - --proxy-client-key-file
+        - /etc/kubernetes/pki/front-proxy/client/apiserver-proxy-client.key
+        - --client-ca-file
+        - /etc/kubernetes/pki/ca/ca.crt
+        - --kubelet-client-certificate
+        - /etc/kubernetes/kubelet/kubelet-client.crt
+        - --kubelet-client-key
+        - /etc/kubernetes/kubelet/kubelet-client.key
+        - --requestheader-client-ca-file
+        - /etc/kubernetes/pki/front-proxy/ca/ca.crt
+        - --requestheader-allowed-names
+        - apiserver-aggregator
+        - --requestheader-extra-headers-prefix
+        - X-Remote-Extra-
+        - --requestheader-group-headers
+        - X-Remote-Group
+        - --requestheader-username-headers
+        - X-Remote-User
+        - --service-account-issuer
+        - https://jh8j81chn.europe-west3-c.dev.kubermatic.io:30000
+        - --service-account-signing-key-file
+        - /etc/kubernetes/service-account-key/sa.key
+        - --api-audiences
+        - https://jh8j81chn.europe-west3-c.dev.kubermatic.io:30000
+        - --kubelet-preferred-address-types
+        - ExternalIP,InternalIP
+        - --cloud-provider
+        - aws
+        - --cloud-config
+        - /etc/kubernetes/cloud/config
+        - --oidc-issuer-url
+        - https://dev.kubermatic.io/dex
+        - --oidc-client-id
+        - kubermaticIssuer
+        - --oidc-username-claim
+        - email
+        - --oidc-groups-prefix
+        - 'oidc:'
+        - --oidc-groups-claim
+        - groups
+        - --oidc-ca-file
+        - /etc/kubernetes/dex/ca/caBundle.pem
+        command:
+        - /usr/local/bin/kube-apiserver
+        env:
+        - name: AWS_ACCESS_KEY_ID
+          value: aws-access-key-id
+        - name: AWS_SECRET_ACCESS_KEY
+          value: aws-secret-access-key
+        - name: AWS_VPC_ID
+          value: aws-vpn-id
+        - name: HTTP_PROXY
+          value: http://my-corp
+        - name: HTTPS_PROXY
+          value: http://my-corp
+        - name: http_proxy
+          value: http://my-corp
+        - name: https_proxy
+          value: http://my-corp
+        - name: NO_PROXY
+          value: apiserver-external.cluster-de-test-01.svc.cluster.local.
+        - name: no_proxy
+          value: apiserver-external.cluster-de-test-01.svc.cluster.local.
+        image: k8s.gcr.io/kube-apiserver:v1.20.0
+        livenessProbe:
+          failureThreshold: 8
+          httpGet:
+            path: /healthz
+            port: 30000
+            scheme: HTTPS
+          initialDelaySeconds: 15
+          periodSeconds: 10
+          successThreshold: 1
+          timeoutSeconds: 15
+        name: apiserver
+        ports:
+        - containerPort: 30000
+          protocol: TCP
+        readinessProbe:
+          failureThreshold: 3
+          httpGet:
+            path: /healthz
+            port: 30000
+            scheme: HTTPS
+          periodSeconds: 5
+          successThreshold: 1
+          timeoutSeconds: 15
+        resources:
+          limits:
+            cpu: "2"
+            memory: 4Gi
+          requests:
+            cpu: 100m
+            memory: 256Mi
+        volumeMounts:
+        - mountPath: /etc/kubernetes/tls
+          name: apiserver-tls
+          readOnly: true
+        - mountPath: /etc/kubernetes/tokens
+          name: tokens
+          readOnly: true
+        - mountPath: /etc/kubernetes/kubelet
+          name: kubelet-client-certificates
+          readOnly: true
+        - mountPath: /etc/kubernetes/pki/ca
+          name: ca
+          readOnly: true
+        - mountPath: /etc/kubernetes/service-account-key
+          name: service-account-key
+          readOnly: true
+        - mountPath: /etc/kubernetes/cloud
+          name: cloud-config
+          readOnly: true
+        - mountPath: /etc/etcd/pki/client
+          name: apiserver-etcd-client-certificate
+          readOnly: true
+        - mountPath: /etc/kubernetes/pki/front-proxy/client
+          name: apiserver-proxy-client-certificate
+          readOnly: true
+        - mountPath: /etc/kubernetes/pki/front-proxy/ca
+          name: front-proxy-ca
+          readOnly: true
+        - mountPath: /etc/kubernetes/audit
+          name: audit-config
+          readOnly: true
+        - mountPath: /var/log/kubernetes/audit
+          name: audit-log
+        - mountPath: /etc/kubernetes/adm-control
+          name: adm-control
+          readOnly: true
+        - mountPath: /etc/ssl/certs
+          name: ca-certs
+          readOnly: true
+        - mountPath: /usr/share/ca-certificates
+          name: usr-share-ca-certificates
+          readOnly: true
+        - mountPath: /etc/kubernetes/dex/ca
+          name: dex-ca
+          readOnly: true
+      dnsConfig:
+        nameservers:
+        - 192.0.2.14
+        options:
+        - name: ndots
+          value: "5"
+        searches:
+        - kube-system.svc.cluster.local
+        - svc.cluster.local
+        - cluster.local
+      dnsPolicy: None
+      imagePullSecrets:
+      - name: dockercfg
+      initContainers:
+      - command:
+        - /bin/sh
+        - -ec
+        - until ETCDCTL_API=3 /usr/local/bin/etcdctl --cacert=/etc/etcd/pki/client/ca.crt
+          --cert=/etc/etcd/pki/client/apiserver-etcd-client.crt --key=/etc/etcd/pki/client/apiserver-etcd-client.key
+          --dial-timeout=2s --endpoints='https://etcd-0.etcd.cluster-de-test-01.svc.cluster.local.:2379,https://etcd-1.etcd.cluster-de-test-01.svc.cluster.local.:2379,https://etcd-2.etcd.cluster-de-test-01.svc.cluster.local.:2379'
+          put kubermatic/quorum-check something; do echo waiting for etcd; sleep 2;
+          done;
+        image: gcr.io/etcd-development/etcd:v3.4.3
+        name: etcd-running
+        resources: {}
+        volumeMounts:
+        - mountPath: /etc/etcd/pki/client
+          name: apiserver-etcd-client-certificate
+          readOnly: true
+      volumes:
+      - name: apiserver-tls
+        secret:
+          secretName: apiserver-tls
+      - name: tokens
+        secret:
+          secretName: tokens
+      - name: openvpn-client-certificates
+        secret:
+          secretName: openvpn-client-certificates
+      - name: kubelet-client-certificates
+        secret:
+          secretName: kubelet-client-certificates
+      - name: ca
+        secret:
+          items:
+          - key: ca.crt
+            path: ca.crt
+          secretName: ca
+      - name: service-account-key
+        secret:
+          secretName: service-account-key
+      - configMap:
+          name: cloud-config
+        name: cloud-config
+      - name: apiserver-etcd-client-certificate
+        secret:
+          secretName: apiserver-etcd-client-certificate
+      - name: apiserver-proxy-client-certificate
+        secret:
+          secretName: apiserver-proxy-client-certificate
+      - name: front-proxy-ca
+        secret:
+          secretName: front-proxy-ca
+      - name: kubeletdnatcontroller-kubeconfig
+        secret:
+          secretName: kubeletdnatcontroller-kubeconfig
+      - configMap:
+          name: audit-config
+          optional: false
+        name: audit-config
+      - emptyDir: {}
+        name: audit-log
+      - configMap:
+          name: adm-control
+        name: adm-control
+      - hostPath:
+          path: /etc/ssl/certs
+          type: DirectoryOrCreate
+        name: ca-certs
+      - hostPath:
+          path: /usr/share/ca-certificates
+          type: DirectoryOrCreate
+        name: usr-share-ca-certificates
+      - name: dex-ca
+        secret:
+          secretName: dex-ca
+status: {}

--- a/pkg/resources/test/fixtures/deployment-aws-1.20.0-controller-manager.yaml
+++ b/pkg/resources/test/fixtures/deployment-aws-1.20.0-controller-manager.yaml
@@ -1,0 +1,233 @@
+# This file has been generated, DO NOT EDIT.
+
+metadata:
+  creationTimestamp: null
+  labels:
+    app: controller-manager
+  name: controller-manager
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: controller-manager
+  strategy: {}
+  template:
+    metadata:
+      annotations:
+        prometheus.io/path: /metrics
+        prometheus.io/port: "10257"
+        prometheus.io/scrape_with_kube_cert: "true"
+      creationTimestamp: null
+      labels:
+        app: controller-manager
+        ca-secret-revision: "123456"
+        cloud-config-configmap-revision: "123456"
+        cluster: de-test-01
+        controllermanager-kubeconfig-secret-revision: "123456"
+        openvpn-client-certificates-secret-revision: "123456"
+        service-account-key-secret-revision: "123456"
+    spec:
+      affinity:
+        podAntiAffinity:
+          preferredDuringSchedulingIgnoredDuringExecution:
+          - podAffinityTerm:
+              labelSelector:
+                matchLabels:
+                  app: controller-manager
+                  cluster: de-test-01
+              topologyKey: kubernetes.io/hostname
+            weight: 100
+          - podAffinityTerm:
+              labelSelector:
+                matchLabels:
+                  app: controller-manager
+              topologyKey: kubernetes.io/hostname
+            weight: 10
+      containers:
+      - args:
+        - --client
+        - --proto
+        - tcp
+        - --dev
+        - tun
+        - --auth-nocache
+        - --remote
+        - openvpn-server.cluster-de-test-01.svc.cluster.local.
+        - "1194"
+        - --nobind
+        - --connect-timeout
+        - "5"
+        - --connect-retry
+        - "1"
+        - --ca
+        - /etc/openvpn/pki/client/ca.crt
+        - --cert
+        - /etc/openvpn/pki/client/client.crt
+        - --key
+        - /etc/openvpn/pki/client/client.key
+        - --remote-cert-tls
+        - server
+        - --link-mtu
+        - "1432"
+        - --cipher
+        - AES-256-GCM
+        - --auth
+        - SHA1
+        - --keysize
+        - "256"
+        - --script-security
+        - "2"
+        - --status
+        - /run/openvpn-status
+        - --log
+        - /dev/stdout
+        command:
+        - /usr/sbin/openvpn
+        image: quay.io/kubermatic/openvpn:v2.4.8-r1
+        name: openvpn-client
+        resources:
+          limits:
+            cpu: 100m
+            memory: 32Mi
+          requests:
+            cpu: 5m
+            memory: 5Mi
+        securityContext:
+          privileged: true
+        volumeMounts:
+        - mountPath: /etc/openvpn/pki/client
+          name: openvpn-client-certificates
+          readOnly: true
+      - args:
+        - -endpoint
+        - https://apiserver-external.cluster-de-test-01.svc.cluster.local./healthz
+        - -insecure
+        - -retries
+        - "100"
+        - -retry-wait
+        - "2"
+        - -timeout
+        - "1"
+        - -command
+        - '{"command":"/usr/local/bin/kube-controller-manager","args":["--kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","--service-account-private-key-file","/etc/kubernetes/service-account-key/sa.key","--root-ca-file","/etc/kubernetes/pki/ca/ca.crt","--cluster-signing-cert-file","/etc/kubernetes/pki/ca/ca.crt","--cluster-signing-key-file","/etc/kubernetes/pki/ca/ca.key","--cluster-cidr","172.25.0.0/16","--allocate-node-cidrs","--controllers","*,bootstrapsigner,tokencleaner","--use-service-account-credentials","--feature-gates","RotateKubeletClientCertificate=true,RotateKubeletServerCertificate=true","--cloud-provider","aws","--cloud-config","/etc/kubernetes/cloud/config","--configure-cloud-routes=false","--authentication-kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","--client-ca-file","/etc/kubernetes/pki/ca/ca.crt","--authentication-kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","--authorization-kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","--port","0"]}'
+        command:
+        - /http-prober-bin/http-prober
+        env:
+        - name: AWS_ACCESS_KEY_ID
+          value: aws-access-key-id
+        - name: AWS_SECRET_ACCESS_KEY
+          value: aws-secret-access-key
+        - name: AWS_VPC_ID
+          value: aws-vpn-id
+        - name: HTTP_PROXY
+          value: http://my-corp
+        - name: HTTPS_PROXY
+          value: http://my-corp
+        - name: http_proxy
+          value: http://my-corp
+        - name: https_proxy
+          value: http://my-corp
+        - name: NO_PROXY
+          value: apiserver-external.cluster-de-test-01.svc.cluster.local.
+        - name: no_proxy
+          value: apiserver-external.cluster-de-test-01.svc.cluster.local.
+        image: k8s.gcr.io/kube-controller-manager:v1.20.0
+        livenessProbe:
+          failureThreshold: 8
+          httpGet:
+            path: /healthz
+            port: 10257
+            scheme: HTTPS
+          initialDelaySeconds: 15
+          periodSeconds: 10
+          successThreshold: 1
+          timeoutSeconds: 15
+        name: controller-manager
+        readinessProbe:
+          failureThreshold: 3
+          httpGet:
+            path: /healthz
+            port: 10257
+            scheme: HTTPS
+          periodSeconds: 10
+          successThreshold: 1
+          timeoutSeconds: 15
+        resources:
+          limits:
+            cpu: "2"
+            memory: 2Gi
+          requests:
+            cpu: 100m
+            memory: 100Mi
+        volumeMounts:
+        - mountPath: /etc/kubernetes/pki/ca
+          name: ca
+          readOnly: true
+        - mountPath: /etc/kubernetes/service-account-key
+          name: service-account-key
+          readOnly: true
+        - mountPath: /etc/kubernetes/cloud
+          name: cloud-config
+          readOnly: true
+        - mountPath: /etc/kubernetes/kubeconfig
+          name: controllermanager-kubeconfig
+          readOnly: true
+        - mountPath: /etc/ssl/certs
+          name: ca-certs
+          readOnly: true
+        - mountPath: /usr/share/ca-certificates
+          name: usr-share-ca-certificates
+          readOnly: true
+        - mountPath: /http-prober-bin
+          name: http-prober-bin
+      dnsConfig:
+        nameservers:
+        - 192.0.2.14
+        options:
+        - name: ndots
+          value: "5"
+        searches:
+        - kube-system.svc.cluster.local
+        - svc.cluster.local
+        - cluster.local
+      dnsPolicy: None
+      imagePullSecrets:
+      - name: dockercfg
+      initContainers:
+      - command:
+        - /bin/cp
+        - /usr/local/bin/http-prober
+        - /http-prober-bin/http-prober
+        image: quay.io/kubermatic/http-prober:v0.3.1
+        name: copy-http-prober
+        resources: {}
+        volumeMounts:
+        - mountPath: /http-prober-bin
+          name: http-prober-bin
+      volumes:
+      - name: ca
+        secret:
+          secretName: ca
+      - name: service-account-key
+        secret:
+          secretName: service-account-key
+      - configMap:
+          name: cloud-config
+        name: cloud-config
+      - name: openvpn-client-certificates
+        secret:
+          secretName: openvpn-client-certificates
+      - name: controllermanager-kubeconfig
+        secret:
+          secretName: controllermanager-kubeconfig
+      - hostPath:
+          path: /etc/ssl/certs
+          type: DirectoryOrCreate
+        name: ca-certs
+      - hostPath:
+          path: /usr/share/ca-certificates
+          type: DirectoryOrCreate
+        name: usr-share-ca-certificates
+      - emptyDir: {}
+        name: http-prober-bin
+status: {}

--- a/pkg/resources/test/fixtures/deployment-aws-1.20.0-dns-resolver.yaml
+++ b/pkg/resources/test/fixtures/deployment-aws-1.20.0-dns-resolver.yaml
@@ -1,0 +1,140 @@
+# This file has been generated, DO NOT EDIT.
+
+metadata:
+  creationTimestamp: null
+  labels:
+    app: dns-resolver
+  name: dns-resolver
+spec:
+  replicas: 2
+  selector:
+    matchLabels:
+      app: dns-resolver
+  strategy: {}
+  template:
+    metadata:
+      annotations:
+        prometheus.io/path: /metrics
+        prometheus.io/port: "9253"
+        prometheus.io/scrape: "true"
+      creationTimestamp: null
+      labels:
+        app: dns-resolver
+        ca-secret-revision: "123456"
+        cluster: de-test-01
+        dns-resolver-configmap-revision: "123456"
+        openvpn-client-certificates-secret-revision: "123456"
+    spec:
+      affinity:
+        podAntiAffinity:
+          preferredDuringSchedulingIgnoredDuringExecution:
+          - podAffinityTerm:
+              labelSelector:
+                matchLabels:
+                  app: dns-resolver
+                  cluster: de-test-01
+              topologyKey: kubernetes.io/hostname
+            weight: 100
+          - podAffinityTerm:
+              labelSelector:
+                matchLabels:
+                  app: dns-resolver
+              topologyKey: kubernetes.io/hostname
+            weight: 10
+      containers:
+      - args:
+        - --client
+        - --proto
+        - tcp
+        - --dev
+        - tun
+        - --auth-nocache
+        - --remote
+        - openvpn-server.cluster-de-test-01.svc.cluster.local.
+        - "1194"
+        - --nobind
+        - --connect-timeout
+        - "5"
+        - --connect-retry
+        - "1"
+        - --ca
+        - /etc/openvpn/pki/client/ca.crt
+        - --cert
+        - /etc/openvpn/pki/client/client.crt
+        - --key
+        - /etc/openvpn/pki/client/client.key
+        - --remote-cert-tls
+        - server
+        - --link-mtu
+        - "1432"
+        - --cipher
+        - AES-256-GCM
+        - --auth
+        - SHA1
+        - --keysize
+        - "256"
+        - --script-security
+        - "2"
+        - --status
+        - /run/openvpn-status
+        - --log
+        - /dev/stdout
+        command:
+        - /usr/sbin/openvpn
+        image: quay.io/kubermatic/openvpn:v2.4.8-r1
+        name: openvpn-client
+        resources:
+          limits:
+            cpu: 100m
+            memory: 32Mi
+          requests:
+            cpu: 5m
+            memory: 5Mi
+        securityContext:
+          privileged: true
+        volumeMounts:
+        - mountPath: /etc/openvpn/pki/client
+          name: openvpn-client-certificates
+          readOnly: true
+      - args:
+        - -conf
+        - /etc/coredns/Corefile
+        image: k8s.gcr.io/coredns:1.3.1
+        name: dns-resolver
+        readinessProbe:
+          failureThreshold: 3
+          httpGet:
+            path: /health
+            port: 8080
+            scheme: HTTP
+          initialDelaySeconds: 2
+          periodSeconds: 10
+          successThreshold: 1
+          timeoutSeconds: 15
+        resources:
+          limits:
+            cpu: 100m
+            memory: 128Mi
+          requests:
+            cpu: 5m
+            memory: 20Mi
+        volumeMounts:
+        - mountPath: /etc/coredns
+          name: dns-resolver
+          readOnly: true
+      imagePullSecrets:
+      - name: dockercfg
+      volumes:
+      - configMap:
+          name: dns-resolver
+        name: dns-resolver
+      - name: openvpn-client-certificates
+        secret:
+          secretName: openvpn-client-certificates
+      - name: ca
+        secret:
+          items:
+          - key: ca.crt
+            path: ca.crt
+          secretName: ca
+status: {}

--- a/pkg/resources/test/fixtures/deployment-aws-1.20.0-kube-state-metrics.yaml
+++ b/pkg/resources/test/fixtures/deployment-aws-1.20.0-kube-state-metrics.yaml
@@ -1,0 +1,89 @@
+# This file has been generated, DO NOT EDIT.
+
+metadata:
+  creationTimestamp: null
+  labels:
+    app: kube-state-metrics
+  name: kube-state-metrics
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: kube-state-metrics
+  strategy: {}
+  template:
+    metadata:
+      annotations:
+        prometheus.io/scrape: "true"
+      creationTimestamp: null
+      labels:
+        app: kube-state-metrics
+        cluster: de-test-01
+        kube-state-metrics-kubeconfig-secret-revision: "123456"
+    spec:
+      containers:
+      - args:
+        - -endpoint
+        - https://apiserver-external.cluster-de-test-01.svc.cluster.local./healthz
+        - -insecure
+        - -retries
+        - "100"
+        - -retry-wait
+        - "2"
+        - -timeout
+        - "1"
+        - -command
+        - '{"command":"/kube-state-metrics","args":["--kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","--port","8080","--telemetry-port","8081"]}'
+        command:
+        - /http-prober-bin/http-prober
+        image: quay.io/coreos/kube-state-metrics:v1.9.7
+        name: kube-state-metrics
+        ports:
+        - containerPort: 8080
+          name: metrics
+          protocol: TCP
+        - containerPort: 8081
+          name: telemetry
+          protocol: TCP
+        readinessProbe:
+          failureThreshold: 3
+          httpGet:
+            path: /healthz
+            port: 8080
+            scheme: HTTP
+          periodSeconds: 10
+          successThreshold: 1
+          timeoutSeconds: 15
+        resources:
+          limits:
+            cpu: 100m
+            memory: 1Gi
+          requests:
+            cpu: 10m
+            memory: 12Mi
+        volumeMounts:
+        - mountPath: /etc/kubernetes/kubeconfig
+          name: kube-state-metrics-kubeconfig
+          readOnly: true
+        - mountPath: /http-prober-bin
+          name: http-prober-bin
+      imagePullSecrets:
+      - name: dockercfg
+      initContainers:
+      - command:
+        - /bin/cp
+        - /usr/local/bin/http-prober
+        - /http-prober-bin/http-prober
+        image: quay.io/kubermatic/http-prober:v0.3.1
+        name: copy-http-prober
+        resources: {}
+        volumeMounts:
+        - mountPath: /http-prober-bin
+          name: http-prober-bin
+      volumes:
+      - name: kube-state-metrics-kubeconfig
+        secret:
+          secretName: kube-state-metrics-kubeconfig
+      - emptyDir: {}
+        name: http-prober-bin
+status: {}

--- a/pkg/resources/test/fixtures/deployment-aws-1.20.0-kubernetes-dashboard.yaml
+++ b/pkg/resources/test/fixtures/deployment-aws-1.20.0-kubernetes-dashboard.yaml
@@ -1,0 +1,97 @@
+# This file has been generated, DO NOT EDIT.
+
+metadata:
+  creationTimestamp: null
+  labels:
+    app: kubernetes-dashboard
+  name: kubernetes-dashboard
+spec:
+  replicas: 2
+  selector:
+    matchLabels:
+      app: kubernetes-dashboard
+  strategy: {}
+  template:
+    metadata:
+      creationTimestamp: null
+      labels:
+        app: kubernetes-dashboard
+        cluster: de-test-01
+        kubernetes-dashboard-kubeconfig-secret-revision: "123456"
+    spec:
+      affinity:
+        podAntiAffinity:
+          preferredDuringSchedulingIgnoredDuringExecution:
+          - podAffinityTerm:
+              labelSelector:
+                matchLabels:
+                  app: kubernetes-dashboard
+                  cluster: de-test-01
+              topologyKey: kubernetes.io/hostname
+            weight: 100
+          - podAffinityTerm:
+              labelSelector:
+                matchLabels:
+                  app: kubernetes-dashboard
+              topologyKey: kubernetes.io/hostname
+            weight: 10
+      containers:
+      - args:
+        - -endpoint
+        - https://apiserver-external.cluster-de-test-01.svc.cluster.local./healthz
+        - -insecure
+        - -retries
+        - "100"
+        - -retry-wait
+        - "2"
+        - -timeout
+        - "1"
+        - -command
+        - '{"command":"/dashboard","args":["--kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","--namespace","kubernetes-dashboard","--enable-insecure-login"]}'
+        command:
+        - /http-prober-bin/http-prober
+        image: docker.io/kubernetesui/dashboard:v2.0.4
+        imagePullPolicy: IfNotPresent
+        name: kubernetes-dashboard
+        ports:
+        - containerPort: 9090
+          protocol: TCP
+        resources:
+          limits:
+            cpu: 250m
+            memory: 512Mi
+          requests:
+            cpu: 100m
+            memory: 256Mi
+        securityContext:
+          allowPrivilegeEscalation: false
+          readOnlyRootFilesystem: true
+          runAsUser: 1001
+        volumeMounts:
+        - mountPath: /etc/kubernetes/kubeconfig
+          name: kubernetes-dashboard-kubeconfig
+          readOnly: true
+        - mountPath: /tmp
+          name: tmp-volume
+        - mountPath: /http-prober-bin
+          name: http-prober-bin
+      initContainers:
+      - command:
+        - /bin/cp
+        - /usr/local/bin/http-prober
+        - /http-prober-bin/http-prober
+        image: quay.io/kubermatic/http-prober:v0.3.1
+        name: copy-http-prober
+        resources: {}
+        volumeMounts:
+        - mountPath: /http-prober-bin
+          name: http-prober-bin
+      volumes:
+      - name: kubernetes-dashboard-kubeconfig
+        secret:
+          secretName: kubernetes-dashboard-kubeconfig
+      - emptyDir: {}
+        name: tmp-volume
+      - emptyDir: {}
+        name: http-prober-bin
+status: {}

--- a/pkg/resources/test/fixtures/deployment-aws-1.20.0-machine-controller-webhook.yaml
+++ b/pkg/resources/test/fixtures/deployment-aws-1.20.0-machine-controller-webhook.yaml
@@ -1,0 +1,118 @@
+# This file has been generated, DO NOT EDIT.
+
+metadata:
+  creationTimestamp: null
+  labels:
+    app: machine-controller-webhook
+  name: machine-controller-webhook
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: machine-controller-webhook
+  strategy: {}
+  template:
+    metadata:
+      creationTimestamp: null
+      labels:
+        app: machine-controller-webhook
+        cluster: de-test-01
+        machinecontroller-kubeconfig-secret-revision: "123456"
+        machinecontroller-webhook-serving-cert-secret-revision: "123456"
+    spec:
+      containers:
+      - args:
+        - -endpoint
+        - https://apiserver-external.cluster-de-test-01.svc.cluster.local./healthz
+        - -insecure
+        - -retries
+        - "100"
+        - -retry-wait
+        - "2"
+        - -timeout
+        - "1"
+        - -command
+        - '{"command":"/usr/local/bin/webhook","args":["-kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","-logtostderr","-v","4","-listen-address","0.0.0.0:9876"]}'
+        - --crd-to-wait-for
+        - Machine,cluster.k8s.io/v1alpha1
+        command:
+        - /http-prober-bin/http-prober
+        env:
+        - name: AWS_ACCESS_KEY_ID
+          value: aws-access-key-id
+        - name: AWS_SECRET_ACCESS_KEY
+          value: aws-secret-access-key
+        - name: HTTP_PROXY
+          value: http://my-corp
+        - name: HTTPS_PROXY
+          value: http://my-corp
+        - name: http_proxy
+          value: http://my-corp
+        - name: https_proxy
+          value: http://my-corp
+        - name: NO_PROXY
+          value: apiserver-external.cluster-de-test-01.svc.cluster.local.
+        - name: no_proxy
+          value: apiserver-external.cluster-de-test-01.svc.cluster.local.
+        - name: KUBECONFIG
+          value: /etc/kubernetes/kubeconfig/kubeconfig
+        image: docker.io/kubermatic/machine-controller:v1.23.1
+        livenessProbe:
+          failureThreshold: 8
+          httpGet:
+            path: /healthz
+            port: 9876
+            scheme: HTTPS
+          initialDelaySeconds: 15
+          periodSeconds: 10
+          successThreshold: 1
+          timeoutSeconds: 15
+        name: machine-controller
+        readinessProbe:
+          failureThreshold: 3
+          httpGet:
+            path: /healthz
+            port: 9876
+            scheme: HTTPS
+          periodSeconds: 10
+          successThreshold: 1
+          timeoutSeconds: 15
+        resources:
+          limits:
+            cpu: 100m
+            memory: 512Mi
+          requests:
+            cpu: 10m
+            memory: 32Mi
+        volumeMounts:
+        - mountPath: /etc/kubernetes/kubeconfig
+          name: machinecontroller-kubeconfig
+          readOnly: true
+        - mountPath: /tmp/cert
+          name: machinecontroller-webhook-serving-cert
+          readOnly: true
+        - mountPath: /http-prober-bin
+          name: http-prober-bin
+      imagePullSecrets:
+      - name: dockercfg
+      initContainers:
+      - command:
+        - /bin/cp
+        - /usr/local/bin/http-prober
+        - /http-prober-bin/http-prober
+        image: quay.io/kubermatic/http-prober:v0.3.1
+        name: copy-http-prober
+        resources: {}
+        volumeMounts:
+        - mountPath: /http-prober-bin
+          name: http-prober-bin
+      volumes:
+      - name: machinecontroller-kubeconfig
+        secret:
+          secretName: machinecontroller-kubeconfig
+      - name: machinecontroller-webhook-serving-cert
+        secret:
+          secretName: machinecontroller-webhook-serving-cert
+      - emptyDir: {}
+        name: http-prober-bin
+status: {}

--- a/pkg/resources/test/fixtures/deployment-aws-1.20.0-machine-controller.yaml
+++ b/pkg/resources/test/fixtures/deployment-aws-1.20.0-machine-controller.yaml
@@ -1,0 +1,106 @@
+# This file has been generated, DO NOT EDIT.
+
+metadata:
+  creationTimestamp: null
+  labels:
+    app: machine-controller
+  name: machine-controller
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: machine-controller
+  strategy: {}
+  template:
+    metadata:
+      annotations:
+        prometheus.io/path: /metrics
+        prometheus.io/port: "8080"
+        prometheus.io/scrape: "true"
+      creationTimestamp: null
+      labels:
+        app: machine-controller
+        cluster: de-test-01
+        machinecontroller-kubeconfig-secret-revision: "123456"
+    spec:
+      containers:
+      - args:
+        - -endpoint
+        - https://apiserver-external.cluster-de-test-01.svc.cluster.local./healthz
+        - -insecure
+        - -retries
+        - "100"
+        - -retry-wait
+        - "2"
+        - -timeout
+        - "1"
+        - -command
+        - '{"command":"/usr/local/bin/machine-controller","args":["-kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","-logtostderr","-v","4","-cluster-dns","169.254.20.10","-health-probe-address","0.0.0.0:8085","-metrics-address","0.0.0.0:8080"]}'
+        - --crd-to-wait-for
+        - Machine,cluster.k8s.io/v1alpha1
+        command:
+        - /http-prober-bin/http-prober
+        env:
+        - name: AWS_ACCESS_KEY_ID
+          value: aws-access-key-id
+        - name: AWS_SECRET_ACCESS_KEY
+          value: aws-secret-access-key
+        - name: HTTP_PROXY
+          value: http://my-corp
+        - name: HTTPS_PROXY
+          value: http://my-corp
+        - name: http_proxy
+          value: http://my-corp
+        - name: https_proxy
+          value: http://my-corp
+        - name: NO_PROXY
+          value: apiserver-external.cluster-de-test-01.svc.cluster.local.
+        - name: no_proxy
+          value: apiserver-external.cluster-de-test-01.svc.cluster.local.
+        - name: KUBECONFIG
+          value: /etc/kubernetes/kubeconfig/kubeconfig
+        image: docker.io/kubermatic/machine-controller:v1.23.1
+        livenessProbe:
+          failureThreshold: 3
+          httpGet:
+            path: /readyz
+            port: 8085
+            scheme: HTTP
+          initialDelaySeconds: 15
+          periodSeconds: 10
+          successThreshold: 1
+          timeoutSeconds: 15
+        name: machine-controller
+        resources:
+          limits:
+            cpu: "2"
+            memory: 512Mi
+          requests:
+            cpu: 25m
+            memory: 32Mi
+        volumeMounts:
+        - mountPath: /etc/kubernetes/kubeconfig
+          name: machinecontroller-kubeconfig
+          readOnly: true
+        - mountPath: /http-prober-bin
+          name: http-prober-bin
+      imagePullSecrets:
+      - name: dockercfg
+      initContainers:
+      - command:
+        - /bin/cp
+        - /usr/local/bin/http-prober
+        - /http-prober-bin/http-prober
+        image: quay.io/kubermatic/http-prober:v0.3.1
+        name: copy-http-prober
+        resources: {}
+        volumeMounts:
+        - mountPath: /http-prober-bin
+          name: http-prober-bin
+      volumes:
+      - name: machinecontroller-kubeconfig
+        secret:
+          secretName: machinecontroller-kubeconfig
+      - emptyDir: {}
+        name: http-prober-bin
+status: {}

--- a/pkg/resources/test/fixtures/deployment-aws-1.20.0-metrics-server.yaml
+++ b/pkg/resources/test/fixtures/deployment-aws-1.20.0-metrics-server.yaml
@@ -1,0 +1,182 @@
+# This file has been generated, DO NOT EDIT.
+
+metadata:
+  creationTimestamp: null
+  labels:
+    app: metrics-server
+  name: metrics-server
+spec:
+  replicas: 2
+  selector:
+    matchLabels:
+      app: metrics-server
+  strategy: {}
+  template:
+    metadata:
+      creationTimestamp: null
+      labels:
+        app: metrics-server
+        cluster: de-test-01
+        kubeletdnatcontroller-kubeconfig-secret-revision: "123456"
+        metrics-server-secret-revision: "123456"
+        metrics-server-serving-cert-secret-revision: "123456"
+        openvpn-client-certificates-secret-revision: "123456"
+    spec:
+      affinity:
+        podAntiAffinity:
+          preferredDuringSchedulingIgnoredDuringExecution:
+          - podAffinityTerm:
+              labelSelector:
+                matchLabels:
+                  app: metrics-server
+                  cluster: de-test-01
+              topologyKey: kubernetes.io/hostname
+            weight: 100
+          - podAffinityTerm:
+              labelSelector:
+                matchLabels:
+                  app: metrics-server
+              topologyKey: kubernetes.io/hostname
+            weight: 10
+      containers:
+      - args:
+        - -endpoint
+        - https://apiserver-external.cluster-de-test-01.svc.cluster.local./healthz
+        - -insecure
+        - -retries
+        - "100"
+        - -retry-wait
+        - "2"
+        - -timeout
+        - "1"
+        - -command
+        - '{"command":"/metrics-server","args":["--kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","--authentication-kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","--authorization-kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","--kubelet-port","10250","--kubelet-insecure-tls","--kubelet-preferred-address-types","ExternalIP,InternalIP","--v","1","--logtostderr","--tls-cert-file","/etc/serving-cert/serving.crt","--tls-private-key-file","/etc/serving-cert/serving.key"]}'
+        command:
+        - /http-prober-bin/http-prober
+        image: k8s.gcr.io/metrics-server-amd64:v0.3.6
+        name: metrics-server
+        resources:
+          limits:
+            cpu: 150m
+            memory: 512Mi
+          requests:
+            cpu: 25m
+            memory: 32Mi
+        volumeMounts:
+        - mountPath: /etc/kubernetes/kubeconfig
+          name: metrics-server
+          readOnly: true
+        - mountPath: /etc/serving-cert
+          name: metrics-server-serving-cert
+          readOnly: true
+        - mountPath: /http-prober-bin
+          name: http-prober-bin
+      - args:
+        - --client
+        - --proto
+        - tcp
+        - --dev
+        - tun
+        - --auth-nocache
+        - --remote
+        - openvpn-server.cluster-de-test-01.svc.cluster.local.
+        - "1194"
+        - --nobind
+        - --connect-timeout
+        - "5"
+        - --connect-retry
+        - "1"
+        - --ca
+        - /etc/openvpn/pki/client/ca.crt
+        - --cert
+        - /etc/openvpn/pki/client/client.crt
+        - --key
+        - /etc/openvpn/pki/client/client.key
+        - --remote-cert-tls
+        - server
+        - --link-mtu
+        - "1432"
+        - --cipher
+        - AES-256-GCM
+        - --auth
+        - SHA1
+        - --keysize
+        - "256"
+        - --script-security
+        - "2"
+        - --status
+        - /run/openvpn-status
+        - --log
+        - /dev/stdout
+        command:
+        - /usr/sbin/openvpn
+        image: quay.io/kubermatic/openvpn:v2.4.8-r1
+        name: openvpn-client
+        resources:
+          limits:
+            cpu: 100m
+            memory: 32Mi
+          requests:
+            cpu: 5m
+            memory: 5Mi
+        securityContext:
+          privileged: true
+        volumeMounts:
+        - mountPath: /etc/openvpn/pki/client
+          name: openvpn-client-certificates
+          readOnly: true
+      - args:
+        - -kubeconfig
+        - /etc/kubernetes/kubeconfig/kubeconfig
+        - -node-access-network
+        - 192.0.2.0/24
+        command:
+        - /usr/local/bin/kubeletdnat-controller
+        image: quay.io/kubermatic/kubeletdnat-controller:v0.0.0-test
+        name: dnat-controller
+        resources:
+          limits:
+            cpu: 100m
+            memory: 512Mi
+          requests:
+            cpu: 5m
+            memory: 16Mi
+        securityContext:
+          capabilities:
+            add:
+            - NET_ADMIN
+          procMount: Default
+          runAsUser: 0
+        volumeMounts:
+        - mountPath: /etc/kubernetes/kubeconfig
+          name: kubeletdnatcontroller-kubeconfig
+          readOnly: true
+      imagePullSecrets:
+      - name: dockercfg
+      initContainers:
+      - command:
+        - /bin/cp
+        - /usr/local/bin/http-prober
+        - /http-prober-bin/http-prober
+        image: quay.io/kubermatic/http-prober:v0.3.1
+        name: copy-http-prober
+        resources: {}
+        volumeMounts:
+        - mountPath: /http-prober-bin
+          name: http-prober-bin
+      volumes:
+      - name: metrics-server
+        secret:
+          secretName: metrics-server
+      - name: openvpn-client-certificates
+        secret:
+          secretName: openvpn-client-certificates
+      - name: kubeletdnatcontroller-kubeconfig
+        secret:
+          secretName: kubeletdnatcontroller-kubeconfig
+      - name: metrics-server-serving-cert
+        secret:
+          secretName: metrics-server-serving-cert
+      - emptyDir: {}
+        name: http-prober-bin
+status: {}

--- a/pkg/resources/test/fixtures/deployment-aws-1.20.0-openvpn-server.yaml
+++ b/pkg/resources/test/fixtures/deployment-aws-1.20.0-openvpn-server.yaml
@@ -1,0 +1,223 @@
+# This file has been generated, DO NOT EDIT.
+
+metadata:
+  creationTimestamp: null
+  labels:
+    app: openvpn-server
+  name: openvpn-server
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: openvpn-server
+  strategy:
+    rollingUpdate:
+      maxSurge: 1
+      maxUnavailable: 1
+    type: RollingUpdate
+  template:
+    metadata:
+      annotations:
+        prometheus.io/path: /metrics
+        prometheus.io/port: "9176"
+        prometheus.io/scrape: "true"
+      creationTimestamp: null
+      labels:
+        app: openvpn-server
+        cluster: de-test-01
+        openvpn-ca-secret-revision: "123456"
+        openvpn-client-configs-configmap-revision: "123456"
+        openvpn-server-certificates-secret-revision: "123456"
+    spec:
+      containers:
+      - args:
+        - --proto
+        - tcp
+        - --dev
+        - tun
+        - --mode
+        - server
+        - --lport
+        - "1194"
+        - --server
+        - 10.20.0.0
+        - 255.255.255.0
+        - --ca
+        - /etc/kubernetes/pki/ca/ca.crt
+        - --cert
+        - /etc/openvpn/pki/server/server.crt
+        - --key
+        - /etc/openvpn/pki/server/server.key
+        - --dh
+        - none
+        - --duplicate-cn
+        - --client-config-dir
+        - /etc/openvpn/clients
+        - --status
+        - /run/openvpn/openvpn-status
+        - --status-version
+        - "3"
+        - --cipher
+        - AES-256-GCM
+        - --auth
+        - SHA1
+        - --keysize
+        - "256"
+        - --script-security
+        - "2"
+        - --ping
+        - "5"
+        - --verb
+        - "3"
+        - --log
+        - /dev/stdout
+        - --push
+        - route 172.25.0.0 255.255.0.0
+        - --route
+        - 172.25.0.0
+        - 255.255.0.0
+        - --push
+        - route 10.240.16.0 255.255.240.0
+        - --route
+        - 10.240.16.0
+        - 255.255.240.0
+        - --push
+        - route 192.0.2.0 255.255.255.0
+        - --route
+        - 192.0.2.0
+        - 255.255.255.0
+        command:
+        - /usr/sbin/openvpn
+        image: quay.io/kubermatic/openvpn:v2.4.8-r1
+        name: openvpn-server
+        ports:
+        - containerPort: 1194
+          protocol: TCP
+        readinessProbe:
+          exec:
+            command:
+            - test
+            - -s
+            - /run/openvpn/openvpn-status
+          failureThreshold: 3
+          initialDelaySeconds: 5
+          periodSeconds: 5
+          successThreshold: 1
+          timeoutSeconds: 1
+        resources:
+          limits:
+            cpu: 100m
+            memory: 20Mi
+          requests:
+            cpu: 5m
+            memory: 5Mi
+        securityContext:
+          privileged: true
+          procMount: Default
+        volumeMounts:
+        - mountPath: /etc/openvpn/pki/server
+          name: openvpn-server-certificates
+          readOnly: true
+        - mountPath: /etc/kubernetes/pki/ca
+          name: ca
+          readOnly: true
+        - mountPath: /etc/openvpn/clients
+          name: openvpn-client-configs
+          readOnly: true
+        - mountPath: /run/openvpn
+          name: openvpn-status
+      - args:
+        - -c
+        - |-
+          while true; do sysctl -w net.ipv4.ip_forward=1;
+            if ! iptables -t mangle -C INPUT -p tcp --tcp-flags SYN,RST SYN --dport 1194 -j TCPMSS --set-mss 1300 &>/dev/null; then
+             iptables -t mangle -A INPUT -p tcp --tcp-flags SYN,RST SYN --dport 1194 -j TCPMSS --set-mss 1300
+            fi
+            sleep 30;
+          done
+        command:
+        - /bin/bash
+        image: quay.io/kubermatic/openvpn:v2.4.8-r1
+        name: ip-fixup
+        resources:
+          limits:
+            cpu: 10m
+            memory: 32Mi
+          requests:
+            cpu: 5m
+            memory: 16Mi
+        securityContext:
+          privileged: true
+          procMount: Default
+      - args:
+        - -openvpn.status_paths
+        - /run/openvpn/openvpn-status
+        command:
+        - /bin/openvpn_exporter
+        image: docker.io/kumina/openvpn-exporter:v0.2.2
+        name: openvpn-exporter
+        ports:
+        - containerPort: 9176
+          protocol: TCP
+        resources:
+          limits:
+            cpu: 100m
+            memory: 20Mi
+          requests:
+            cpu: 5m
+            memory: 5Mi
+        volumeMounts:
+        - mountPath: /run/openvpn
+          name: openvpn-status
+      imagePullSecrets:
+      - name: dockercfg
+      initContainers:
+      - args:
+        - -c
+        - |
+          # do not give a 10.20.0.0/24 route to clients (nodes) but
+          # masquerade to openvpn-server's IP instead:
+          iptables -t nat -A POSTROUTING -o tun0 -s 10.20.0.0/24 -j MASQUERADE
+
+          # Only allow outbound traffic to services, pods, nodes
+          iptables -P FORWARD DROP
+          iptables -A FORWARD -m state --state ESTABLISHED,RELATED -j ACCEPT
+          iptables -A FORWARD -i tun0 -o tun0 -s 10.20.0.0/24 -d 172.25.0.0/16 -j ACCEPT
+          iptables -A FORWARD -i tun0 -o tun0 -s 10.20.0.0/24 -d 10.240.16.0/20 -j ACCEPT
+          iptables -A FORWARD -i tun0 -o tun0 -s 10.20.0.0/24 -d 192.0.2.0/24 -j ACCEPT
+
+          iptables -A INPUT -m state --state ESTABLISHED,RELATED -j ACCEPT
+          iptables -A INPUT -i tun0 -p icmp -j ACCEPT
+          iptables -A INPUT -i tun0 -j DROP
+        command:
+        - /bin/bash
+        image: quay.io/kubermatic/openvpn:v2.4.8-r1
+        name: iptables-init
+        resources:
+          limits:
+            cpu: 100m
+            memory: 20Mi
+          requests:
+            cpu: 5m
+            memory: 5Mi
+        securityContext:
+          capabilities:
+            add:
+            - NET_ADMIN
+          procMount: Default
+      volumes:
+      - name: ca
+        secret:
+          items:
+          - key: ca.crt
+            path: ca.crt
+          secretName: openvpn-ca
+      - name: openvpn-server-certificates
+        secret:
+          secretName: openvpn-server-certificates
+      - configMap:
+          name: openvpn-client-configs
+        name: openvpn-client-configs
+      - emptyDir: {}
+        name: openvpn-status
+status: {}

--- a/pkg/resources/test/fixtures/deployment-aws-1.20.0-scheduler.yaml
+++ b/pkg/resources/test/fixtures/deployment-aws-1.20.0-scheduler.yaml
@@ -1,0 +1,203 @@
+# This file has been generated, DO NOT EDIT.
+
+metadata:
+  creationTimestamp: null
+  labels:
+    app: scheduler
+  name: scheduler
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: scheduler
+  strategy: {}
+  template:
+    metadata:
+      annotations:
+        prometheus.io/path: /metrics
+        prometheus.io/port: "10259"
+        prometheus.io/scrape_with_kube_cert: "true"
+      creationTimestamp: null
+      labels:
+        app: scheduler
+        ca-secret-revision: "123456"
+        cluster: de-test-01
+        openvpn-client-certificates-secret-revision: "123456"
+        scheduler-kubeconfig-secret-revision: "123456"
+    spec:
+      affinity:
+        podAntiAffinity:
+          preferredDuringSchedulingIgnoredDuringExecution:
+          - podAffinityTerm:
+              labelSelector:
+                matchLabels:
+                  app: scheduler
+                  cluster: de-test-01
+              topologyKey: kubernetes.io/hostname
+            weight: 100
+          - podAffinityTerm:
+              labelSelector:
+                matchLabels:
+                  app: scheduler
+              topologyKey: kubernetes.io/hostname
+            weight: 10
+      containers:
+      - args:
+        - --client
+        - --proto
+        - tcp
+        - --dev
+        - tun
+        - --auth-nocache
+        - --remote
+        - openvpn-server.cluster-de-test-01.svc.cluster.local.
+        - "1194"
+        - --nobind
+        - --connect-timeout
+        - "5"
+        - --connect-retry
+        - "1"
+        - --ca
+        - /etc/openvpn/pki/client/ca.crt
+        - --cert
+        - /etc/openvpn/pki/client/client.crt
+        - --key
+        - /etc/openvpn/pki/client/client.key
+        - --remote-cert-tls
+        - server
+        - --link-mtu
+        - "1432"
+        - --cipher
+        - AES-256-GCM
+        - --auth
+        - SHA1
+        - --keysize
+        - "256"
+        - --script-security
+        - "2"
+        - --status
+        - /run/openvpn-status
+        - --log
+        - /dev/stdout
+        command:
+        - /usr/sbin/openvpn
+        image: quay.io/kubermatic/openvpn:v2.4.8-r1
+        name: openvpn-client
+        resources:
+          limits:
+            cpu: 100m
+            memory: 32Mi
+          requests:
+            cpu: 5m
+            memory: 5Mi
+        securityContext:
+          privileged: true
+        volumeMounts:
+        - mountPath: /etc/openvpn/pki/client
+          name: openvpn-client-certificates
+          readOnly: true
+      - args:
+        - -endpoint
+        - https://apiserver-external.cluster-de-test-01.svc.cluster.local./healthz
+        - -insecure
+        - -retries
+        - "100"
+        - -retry-wait
+        - "2"
+        - -timeout
+        - "1"
+        - -command
+        - '{"command":"/usr/local/bin/kube-scheduler","args":["--kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","--authentication-kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","--authorization-kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","--client-ca-file","/etc/kubernetes/pki/ca/ca.crt","--port","0"]}'
+        command:
+        - /http-prober-bin/http-prober
+        image: k8s.gcr.io/kube-scheduler:v1.20.0
+        livenessProbe:
+          failureThreshold: 8
+          httpGet:
+            path: /healthz
+            port: 10259
+            scheme: HTTPS
+          initialDelaySeconds: 15
+          periodSeconds: 10
+          successThreshold: 1
+          timeoutSeconds: 15
+        name: scheduler
+        readinessProbe:
+          failureThreshold: 3
+          httpGet:
+            path: /healthz
+            port: 10259
+            scheme: HTTPS
+          periodSeconds: 10
+          successThreshold: 1
+          timeoutSeconds: 15
+        resources:
+          limits:
+            cpu: "1"
+            memory: 512Mi
+          requests:
+            cpu: 20m
+            memory: 64Mi
+        volumeMounts:
+        - mountPath: /etc/kubernetes/kubeconfig
+          name: scheduler-kubeconfig
+          readOnly: true
+        - mountPath: /etc/kubernetes/pki/ca
+          name: ca
+          readOnly: true
+        - mountPath: /etc/ssl/certs
+          name: ca-certs
+          readOnly: true
+        - mountPath: /usr/share/ca-certificates
+          name: usr-share-ca-certificates
+          readOnly: true
+        - mountPath: /http-prober-bin
+          name: http-prober-bin
+      dnsConfig:
+        nameservers:
+        - 192.0.2.14
+        options:
+        - name: ndots
+          value: "5"
+        searches:
+        - kube-system.svc.cluster.local
+        - svc.cluster.local
+        - cluster.local
+      dnsPolicy: None
+      imagePullSecrets:
+      - name: dockercfg
+      initContainers:
+      - command:
+        - /bin/cp
+        - /usr/local/bin/http-prober
+        - /http-prober-bin/http-prober
+        image: quay.io/kubermatic/http-prober:v0.3.1
+        name: copy-http-prober
+        resources: {}
+        volumeMounts:
+        - mountPath: /http-prober-bin
+          name: http-prober-bin
+      volumes:
+      - name: openvpn-client-certificates
+        secret:
+          secretName: openvpn-client-certificates
+      - name: ca
+        secret:
+          items:
+          - key: ca.crt
+            path: ca.crt
+          secretName: ca
+      - name: scheduler-kubeconfig
+        secret:
+          secretName: scheduler-kubeconfig
+      - hostPath:
+          path: /etc/ssl/certs
+          type: DirectoryOrCreate
+        name: ca-certs
+      - hostPath:
+          path: /usr/share/ca-certificates
+          type: DirectoryOrCreate
+        name: usr-share-ca-certificates
+      - emptyDir: {}
+        name: http-prober-bin
+status: {}

--- a/pkg/resources/test/fixtures/deployment-aws-1.20.0-usercluster-controller.yaml
+++ b/pkg/resources/test/fixtures/deployment-aws-1.20.0-usercluster-controller.yaml
@@ -1,0 +1,95 @@
+# This file has been generated, DO NOT EDIT.
+
+metadata:
+  creationTimestamp: null
+  labels:
+    app: usercluster-controller
+  name: usercluster-controller
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: usercluster-controller
+  strategy:
+    rollingUpdate:
+      maxSurge: 1
+      maxUnavailable: 1
+    type: RollingUpdate
+  template:
+    metadata:
+      annotations:
+        prometheus.io/path: /metrics
+        prometheus.io/port: "8085"
+        prometheus.io/scrape: "true"
+      creationTimestamp: null
+      labels:
+        app: usercluster-controller
+        cluster: de-test-01
+        internal-admin-kubeconfig-secret-revision: "123456"
+    spec:
+      containers:
+      - args:
+        - -endpoint
+        - https://apiserver-external.cluster-de-test-01.svc.cluster.local./healthz
+        - -insecure
+        - -retries
+        - "100"
+        - -retry-wait
+        - "2"
+        - -timeout
+        - "1"
+        - -command
+        - '{"command":"/usr/local/bin/user-cluster-controller-manager","args":["-kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","-metrics-listen-address","0.0.0.0:8085","-health-listen-address","0.0.0.0:8086","-namespace","$(NAMESPACE)","-cluster-url","https://jh8j81chn.europe-west3-c.dev.kubermatic.io:30000","-dns-cluster-ip","10.240.16.10","-openvpn-server-port","30003","-overwrite-registry","","-openshift=false","-version","1.20.0","-cloud-provider-name","aws","-owner-email","","-opa-integration=false","--ipam-controller-network","192.168.1.1/24,192.168.1.1,8.8.8.8","-node-labels","{\"my-label\":\"my-value\"}"]}'
+        command:
+        - /http-prober-bin/http-prober
+        env:
+        - name: NAMESPACE
+          valueFrom:
+            fieldRef:
+              apiVersion: v1
+              fieldPath: metadata.namespace
+        image: quay.io/kubermatic/kubermatic:v0.0.0-test
+        name: usercluster-controller
+        readinessProbe:
+          failureThreshold: 5
+          httpGet:
+            path: /ready
+            port: 8086
+            scheme: HTTP
+          periodSeconds: 5
+          successThreshold: 1
+          timeoutSeconds: 15
+        resources:
+          limits:
+            cpu: 500m
+            memory: 512Mi
+          requests:
+            cpu: 25m
+            memory: 32Mi
+        volumeMounts:
+        - mountPath: /etc/kubernetes/kubeconfig
+          name: internal-admin-kubeconfig
+          readOnly: true
+        - mountPath: /http-prober-bin
+          name: http-prober-bin
+      imagePullSecrets:
+      - name: dockercfg
+      initContainers:
+      - command:
+        - /bin/cp
+        - /usr/local/bin/http-prober
+        - /http-prober-bin/http-prober
+        image: quay.io/kubermatic/http-prober:v0.3.1
+        name: copy-http-prober
+        resources: {}
+        volumeMounts:
+        - mountPath: /http-prober-bin
+          name: http-prober-bin
+      serviceAccountName: kubermatic-usercluster-controller-manager
+      volumes:
+      - name: internal-admin-kubeconfig
+        secret:
+          secretName: internal-admin-kubeconfig
+      - emptyDir: {}
+        name: http-prober-bin
+status: {}

--- a/pkg/resources/test/fixtures/deployment-azure-1.17.0-apiserver.yaml
+++ b/pkg/resources/test/fixtures/deployment-azure-1.17.0-apiserver.yaml
@@ -202,12 +202,12 @@ spec:
         - X-Remote-Group
         - --requestheader-username-headers
         - X-Remote-User
+        - --service-account-issuer
+        - https://jh8j81chn.europe-west3-c.dev.kubermatic.io:30000
         - --service-account-signing-key-file
         - /etc/kubernetes/service-account-key/sa.key
-        - --service-account-issuer
-        - kubernetes.default.svc
         - --api-audiences
-        - kubernetes.default.svc
+        - https://jh8j81chn.europe-west3-c.dev.kubermatic.io:30000
         - --kubelet-preferred-address-types
         - ExternalIP,InternalIP
         - --cloud-provider

--- a/pkg/resources/test/fixtures/deployment-azure-1.17.0-usercluster-controller.yaml
+++ b/pkg/resources/test/fixtures/deployment-azure-1.17.0-usercluster-controller.yaml
@@ -39,7 +39,7 @@ spec:
         - -timeout
         - "1"
         - -command
-        - '{"command":"/usr/local/bin/user-cluster-controller-manager","args":["-kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","-metrics-listen-address","0.0.0.0:8085","-health-listen-address","0.0.0.0:8086","-namespace","$(NAMESPACE)","-cluster-url","","-dns-cluster-ip","10.240.16.10","-openvpn-server-port","30003","-overwrite-registry","","-openshift=false","-version","1.17.0","-cloud-provider-name","azure","-owner-email","","-opa-integration=false","--ipam-controller-network","192.168.1.1/24,192.168.1.1,8.8.8.8","-node-labels","{\"my-label\":\"my-value\"}"]}'
+        - '{"command":"/usr/local/bin/user-cluster-controller-manager","args":["-kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","-metrics-listen-address","0.0.0.0:8085","-health-listen-address","0.0.0.0:8086","-namespace","$(NAMESPACE)","-cluster-url","https://jh8j81chn.europe-west3-c.dev.kubermatic.io:30000","-dns-cluster-ip","10.240.16.10","-openvpn-server-port","30003","-overwrite-registry","","-openshift=false","-version","1.17.0","-cloud-provider-name","azure","-owner-email","","-opa-integration=false","--ipam-controller-network","192.168.1.1/24,192.168.1.1,8.8.8.8","-node-labels","{\"my-label\":\"my-value\"}"]}'
         command:
         - /http-prober-bin/http-prober
         env:

--- a/pkg/resources/test/fixtures/deployment-azure-1.18.0-apiserver.yaml
+++ b/pkg/resources/test/fixtures/deployment-azure-1.18.0-apiserver.yaml
@@ -202,12 +202,12 @@ spec:
         - X-Remote-Group
         - --requestheader-username-headers
         - X-Remote-User
+        - --service-account-issuer
+        - https://jh8j81chn.europe-west3-c.dev.kubermatic.io:30000
         - --service-account-signing-key-file
         - /etc/kubernetes/service-account-key/sa.key
-        - --service-account-issuer
-        - kubernetes.default.svc
         - --api-audiences
-        - kubernetes.default.svc
+        - https://jh8j81chn.europe-west3-c.dev.kubermatic.io:30000
         - --kubelet-preferred-address-types
         - ExternalIP,InternalIP
         - --cloud-provider

--- a/pkg/resources/test/fixtures/deployment-azure-1.18.0-usercluster-controller.yaml
+++ b/pkg/resources/test/fixtures/deployment-azure-1.18.0-usercluster-controller.yaml
@@ -39,7 +39,7 @@ spec:
         - -timeout
         - "1"
         - -command
-        - '{"command":"/usr/local/bin/user-cluster-controller-manager","args":["-kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","-metrics-listen-address","0.0.0.0:8085","-health-listen-address","0.0.0.0:8086","-namespace","$(NAMESPACE)","-cluster-url","","-dns-cluster-ip","10.240.16.10","-openvpn-server-port","30003","-overwrite-registry","","-openshift=false","-version","1.18.0","-cloud-provider-name","azure","-owner-email","","-opa-integration=false","--ipam-controller-network","192.168.1.1/24,192.168.1.1,8.8.8.8","-node-labels","{\"my-label\":\"my-value\"}"]}'
+        - '{"command":"/usr/local/bin/user-cluster-controller-manager","args":["-kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","-metrics-listen-address","0.0.0.0:8085","-health-listen-address","0.0.0.0:8086","-namespace","$(NAMESPACE)","-cluster-url","https://jh8j81chn.europe-west3-c.dev.kubermatic.io:30000","-dns-cluster-ip","10.240.16.10","-openvpn-server-port","30003","-overwrite-registry","","-openshift=false","-version","1.18.0","-cloud-provider-name","azure","-owner-email","","-opa-integration=false","--ipam-controller-network","192.168.1.1/24,192.168.1.1,8.8.8.8","-node-labels","{\"my-label\":\"my-value\"}"]}'
         command:
         - /http-prober-bin/http-prober
         env:

--- a/pkg/resources/test/fixtures/deployment-azure-1.19.0-apiserver.yaml
+++ b/pkg/resources/test/fixtures/deployment-azure-1.19.0-apiserver.yaml
@@ -202,12 +202,12 @@ spec:
         - X-Remote-Group
         - --requestheader-username-headers
         - X-Remote-User
+        - --service-account-issuer
+        - https://jh8j81chn.europe-west3-c.dev.kubermatic.io:30000
         - --service-account-signing-key-file
         - /etc/kubernetes/service-account-key/sa.key
-        - --service-account-issuer
-        - kubernetes.default.svc
         - --api-audiences
-        - kubernetes.default.svc
+        - https://jh8j81chn.europe-west3-c.dev.kubermatic.io:30000
         - --kubelet-preferred-address-types
         - ExternalIP,InternalIP
         - --cloud-provider

--- a/pkg/resources/test/fixtures/deployment-azure-1.19.0-usercluster-controller.yaml
+++ b/pkg/resources/test/fixtures/deployment-azure-1.19.0-usercluster-controller.yaml
@@ -39,7 +39,7 @@ spec:
         - -timeout
         - "1"
         - -command
-        - '{"command":"/usr/local/bin/user-cluster-controller-manager","args":["-kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","-metrics-listen-address","0.0.0.0:8085","-health-listen-address","0.0.0.0:8086","-namespace","$(NAMESPACE)","-cluster-url","","-dns-cluster-ip","10.240.16.10","-openvpn-server-port","30003","-overwrite-registry","","-openshift=false","-version","1.19.0","-cloud-provider-name","azure","-owner-email","","-opa-integration=false","--ipam-controller-network","192.168.1.1/24,192.168.1.1,8.8.8.8","-node-labels","{\"my-label\":\"my-value\"}"]}'
+        - '{"command":"/usr/local/bin/user-cluster-controller-manager","args":["-kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","-metrics-listen-address","0.0.0.0:8085","-health-listen-address","0.0.0.0:8086","-namespace","$(NAMESPACE)","-cluster-url","https://jh8j81chn.europe-west3-c.dev.kubermatic.io:30000","-dns-cluster-ip","10.240.16.10","-openvpn-server-port","30003","-overwrite-registry","","-openshift=false","-version","1.19.0","-cloud-provider-name","azure","-owner-email","","-opa-integration=false","--ipam-controller-network","192.168.1.1/24,192.168.1.1,8.8.8.8","-node-labels","{\"my-label\":\"my-value\"}"]}'
         command:
         - /http-prober-bin/http-prober
         env:

--- a/pkg/resources/test/fixtures/deployment-azure-1.20.0-apiserver.yaml
+++ b/pkg/resources/test/fixtures/deployment-azure-1.20.0-apiserver.yaml
@@ -1,0 +1,406 @@
+# This file has been generated, DO NOT EDIT.
+
+metadata:
+  creationTimestamp: null
+  labels:
+    app: apiserver
+  name: apiserver
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: apiserver
+  strategy: {}
+  template:
+    metadata:
+      annotations:
+        prometheus.io/path: /metrics
+        prometheus.io/port: "30000"
+        prometheus.io/scrape_with_kube_cert: "true"
+      creationTimestamp: null
+      labels:
+        adm-control-configmap-revision: "123456"
+        apiserver-etcd-client-certificate-secret-revision: "123456"
+        apiserver-proxy-client-certificate-secret-revision: "123456"
+        apiserver-tls-secret-revision: "123456"
+        app: apiserver
+        audit-config-configmap-revision: "123456"
+        ca-secret-revision: "123456"
+        cloud-config-configmap-revision: "123456"
+        cluster: de-test-01
+        dex-ca-secret-revision: "123456"
+        front-proxy-ca-secret-revision: "123456"
+        kubelet-client-certificates-secret-revision: "123456"
+        kubeletdnatcontroller-kubeconfig-secret-revision: "123456"
+        openvpn-client-certificates-secret-revision: "123456"
+        service-account-key-secret-revision: "123456"
+        tokens-secret-revision: "123456"
+    spec:
+      affinity:
+        podAntiAffinity:
+          preferredDuringSchedulingIgnoredDuringExecution:
+          - podAffinityTerm:
+              labelSelector:
+                matchLabels:
+                  app: apiserver
+                  cluster: de-test-01
+              topologyKey: kubernetes.io/hostname
+            weight: 100
+          - podAffinityTerm:
+              labelSelector:
+                matchLabels:
+                  app: apiserver
+              topologyKey: kubernetes.io/hostname
+            weight: 10
+      containers:
+      - args:
+        - --client
+        - --proto
+        - tcp
+        - --dev
+        - tun
+        - --auth-nocache
+        - --remote
+        - openvpn-server.cluster-de-test-01.svc.cluster.local.
+        - "1194"
+        - --nobind
+        - --connect-timeout
+        - "5"
+        - --connect-retry
+        - "1"
+        - --ca
+        - /etc/openvpn/pki/client/ca.crt
+        - --cert
+        - /etc/openvpn/pki/client/client.crt
+        - --key
+        - /etc/openvpn/pki/client/client.key
+        - --remote-cert-tls
+        - server
+        - --link-mtu
+        - "1432"
+        - --cipher
+        - AES-256-GCM
+        - --auth
+        - SHA1
+        - --keysize
+        - "256"
+        - --script-security
+        - "2"
+        - --status
+        - /run/openvpn-status
+        - --log
+        - /dev/stdout
+        command:
+        - /usr/sbin/openvpn
+        image: quay.io/kubermatic/openvpn:v2.4.8-r1
+        name: openvpn-client
+        resources:
+          limits:
+            cpu: 100m
+            memory: 32Mi
+          requests:
+            cpu: 5m
+            memory: 5Mi
+        securityContext:
+          privileged: true
+        volumeMounts:
+        - mountPath: /etc/openvpn/pki/client
+          name: openvpn-client-certificates
+          readOnly: true
+      - args:
+        - -kubeconfig
+        - /etc/kubernetes/kubeconfig/kubeconfig
+        - -node-access-network
+        - 192.0.2.0/24
+        - -master
+        - https://127.0.0.1:30000
+        command:
+        - /usr/local/bin/kubeletdnat-controller
+        image: quay.io/kubermatic/kubeletdnat-controller:v0.0.0-test
+        name: dnat-controller
+        resources:
+          limits:
+            cpu: 100m
+            memory: 512Mi
+          requests:
+            cpu: 5m
+            memory: 16Mi
+        securityContext:
+          capabilities:
+            add:
+            - NET_ADMIN
+          procMount: Default
+          runAsUser: 0
+        volumeMounts:
+        - mountPath: /etc/kubernetes/kubeconfig
+          name: kubeletdnatcontroller-kubeconfig
+          readOnly: true
+      - args:
+        - --advertise-address
+        - 35.198.93.90
+        - --secure-port
+        - "30000"
+        - --kubernetes-service-node-port
+        - "30000"
+        - --etcd-servers
+        - https://etcd-0.etcd.cluster-de-test-01.svc.cluster.local.:2379,https://etcd-1.etcd.cluster-de-test-01.svc.cluster.local.:2379,https://etcd-2.etcd.cluster-de-test-01.svc.cluster.local.:2379
+        - --etcd-cafile
+        - /etc/etcd/pki/client/ca.crt
+        - --etcd-certfile
+        - /etc/etcd/pki/client/apiserver-etcd-client.crt
+        - --etcd-keyfile
+        - /etc/etcd/pki/client/apiserver-etcd-client.key
+        - --storage-backend
+        - etcd3
+        - --enable-admission-plugins
+        - DefaultStorageClass,DefaultTolerationSeconds,LimitRanger,MutatingAdmissionWebhook,NamespaceLifecycle,Priority,ResourceQuota,ServiceAccount,ValidatingAdmissionWebhook
+        - --admission-control-config-file
+        - /etc/kubernetes/adm-control/admission-control.yaml
+        - --authorization-mode
+        - Node,RBAC
+        - --external-hostname
+        - jh8j81chn.europe-west3-c.dev.kubermatic.io
+        - --token-auth-file
+        - /etc/kubernetes/tokens/tokens.csv
+        - --enable-bootstrap-token-auth
+        - --service-account-key-file
+        - /etc/kubernetes/service-account-key/sa.key
+        - --service-cluster-ip-range
+        - 10.240.16.0/20
+        - --service-node-port-range
+        - 30000-32767
+        - --allow-privileged
+        - --audit-log-maxage
+        - "30"
+        - --audit-log-maxbackup
+        - "3"
+        - --audit-log-maxsize
+        - "100"
+        - --audit-log-path
+        - /var/log/kubernetes/audit/audit.log
+        - --tls-cert-file
+        - /etc/kubernetes/tls/apiserver-tls.crt
+        - --tls-private-key-file
+        - /etc/kubernetes/tls/apiserver-tls.key
+        - --proxy-client-cert-file
+        - /etc/kubernetes/pki/front-proxy/client/apiserver-proxy-client.crt
+        - --proxy-client-key-file
+        - /etc/kubernetes/pki/front-proxy/client/apiserver-proxy-client.key
+        - --client-ca-file
+        - /etc/kubernetes/pki/ca/ca.crt
+        - --kubelet-client-certificate
+        - /etc/kubernetes/kubelet/kubelet-client.crt
+        - --kubelet-client-key
+        - /etc/kubernetes/kubelet/kubelet-client.key
+        - --requestheader-client-ca-file
+        - /etc/kubernetes/pki/front-proxy/ca/ca.crt
+        - --requestheader-allowed-names
+        - apiserver-aggregator
+        - --requestheader-extra-headers-prefix
+        - X-Remote-Extra-
+        - --requestheader-group-headers
+        - X-Remote-Group
+        - --requestheader-username-headers
+        - X-Remote-User
+        - --service-account-issuer
+        - https://jh8j81chn.europe-west3-c.dev.kubermatic.io:30000
+        - --service-account-signing-key-file
+        - /etc/kubernetes/service-account-key/sa.key
+        - --api-audiences
+        - https://jh8j81chn.europe-west3-c.dev.kubermatic.io:30000
+        - --kubelet-preferred-address-types
+        - ExternalIP,InternalIP
+        - --cloud-provider
+        - azure
+        - --cloud-config
+        - /etc/kubernetes/cloud/config
+        - --oidc-issuer-url
+        - https://dev.kubermatic.io/dex
+        - --oidc-client-id
+        - kubermaticIssuer
+        - --oidc-username-claim
+        - email
+        - --oidc-groups-prefix
+        - 'oidc:'
+        - --oidc-groups-claim
+        - groups
+        - --oidc-ca-file
+        - /etc/kubernetes/dex/ca/caBundle.pem
+        command:
+        - /usr/local/bin/kube-apiserver
+        env:
+        - name: HTTP_PROXY
+          value: http://my-corp
+        - name: HTTPS_PROXY
+          value: http://my-corp
+        - name: http_proxy
+          value: http://my-corp
+        - name: https_proxy
+          value: http://my-corp
+        - name: NO_PROXY
+          value: apiserver-external.cluster-de-test-01.svc.cluster.local.
+        - name: no_proxy
+          value: apiserver-external.cluster-de-test-01.svc.cluster.local.
+        image: k8s.gcr.io/kube-apiserver:v1.20.0
+        livenessProbe:
+          failureThreshold: 8
+          httpGet:
+            path: /healthz
+            port: 30000
+            scheme: HTTPS
+          initialDelaySeconds: 15
+          periodSeconds: 10
+          successThreshold: 1
+          timeoutSeconds: 15
+        name: apiserver
+        ports:
+        - containerPort: 30000
+          protocol: TCP
+        readinessProbe:
+          failureThreshold: 3
+          httpGet:
+            path: /healthz
+            port: 30000
+            scheme: HTTPS
+          periodSeconds: 5
+          successThreshold: 1
+          timeoutSeconds: 15
+        resources:
+          limits:
+            cpu: "2"
+            memory: 4Gi
+          requests:
+            cpu: 100m
+            memory: 256Mi
+        volumeMounts:
+        - mountPath: /etc/kubernetes/tls
+          name: apiserver-tls
+          readOnly: true
+        - mountPath: /etc/kubernetes/tokens
+          name: tokens
+          readOnly: true
+        - mountPath: /etc/kubernetes/kubelet
+          name: kubelet-client-certificates
+          readOnly: true
+        - mountPath: /etc/kubernetes/pki/ca
+          name: ca
+          readOnly: true
+        - mountPath: /etc/kubernetes/service-account-key
+          name: service-account-key
+          readOnly: true
+        - mountPath: /etc/kubernetes/cloud
+          name: cloud-config
+          readOnly: true
+        - mountPath: /etc/etcd/pki/client
+          name: apiserver-etcd-client-certificate
+          readOnly: true
+        - mountPath: /etc/kubernetes/pki/front-proxy/client
+          name: apiserver-proxy-client-certificate
+          readOnly: true
+        - mountPath: /etc/kubernetes/pki/front-proxy/ca
+          name: front-proxy-ca
+          readOnly: true
+        - mountPath: /etc/kubernetes/audit
+          name: audit-config
+          readOnly: true
+        - mountPath: /var/log/kubernetes/audit
+          name: audit-log
+        - mountPath: /etc/kubernetes/adm-control
+          name: adm-control
+          readOnly: true
+        - mountPath: /etc/ssl/certs
+          name: ca-certs
+          readOnly: true
+        - mountPath: /usr/share/ca-certificates
+          name: usr-share-ca-certificates
+          readOnly: true
+        - mountPath: /etc/kubernetes/dex/ca
+          name: dex-ca
+          readOnly: true
+      dnsConfig:
+        nameservers:
+        - 192.0.2.14
+        options:
+        - name: ndots
+          value: "5"
+        searches:
+        - kube-system.svc.cluster.local
+        - svc.cluster.local
+        - cluster.local
+      dnsPolicy: None
+      imagePullSecrets:
+      - name: dockercfg
+      initContainers:
+      - command:
+        - /bin/sh
+        - -ec
+        - until ETCDCTL_API=3 /usr/local/bin/etcdctl --cacert=/etc/etcd/pki/client/ca.crt
+          --cert=/etc/etcd/pki/client/apiserver-etcd-client.crt --key=/etc/etcd/pki/client/apiserver-etcd-client.key
+          --dial-timeout=2s --endpoints='https://etcd-0.etcd.cluster-de-test-01.svc.cluster.local.:2379,https://etcd-1.etcd.cluster-de-test-01.svc.cluster.local.:2379,https://etcd-2.etcd.cluster-de-test-01.svc.cluster.local.:2379'
+          put kubermatic/quorum-check something; do echo waiting for etcd; sleep 2;
+          done;
+        image: gcr.io/etcd-development/etcd:v3.4.3
+        name: etcd-running
+        resources: {}
+        volumeMounts:
+        - mountPath: /etc/etcd/pki/client
+          name: apiserver-etcd-client-certificate
+          readOnly: true
+      volumes:
+      - name: apiserver-tls
+        secret:
+          secretName: apiserver-tls
+      - name: tokens
+        secret:
+          secretName: tokens
+      - name: openvpn-client-certificates
+        secret:
+          secretName: openvpn-client-certificates
+      - name: kubelet-client-certificates
+        secret:
+          secretName: kubelet-client-certificates
+      - name: ca
+        secret:
+          items:
+          - key: ca.crt
+            path: ca.crt
+          secretName: ca
+      - name: service-account-key
+        secret:
+          secretName: service-account-key
+      - configMap:
+          name: cloud-config
+        name: cloud-config
+      - name: apiserver-etcd-client-certificate
+        secret:
+          secretName: apiserver-etcd-client-certificate
+      - name: apiserver-proxy-client-certificate
+        secret:
+          secretName: apiserver-proxy-client-certificate
+      - name: front-proxy-ca
+        secret:
+          secretName: front-proxy-ca
+      - name: kubeletdnatcontroller-kubeconfig
+        secret:
+          secretName: kubeletdnatcontroller-kubeconfig
+      - configMap:
+          name: audit-config
+          optional: false
+        name: audit-config
+      - emptyDir: {}
+        name: audit-log
+      - configMap:
+          name: adm-control
+        name: adm-control
+      - hostPath:
+          path: /etc/ssl/certs
+          type: DirectoryOrCreate
+        name: ca-certs
+      - hostPath:
+          path: /usr/share/ca-certificates
+          type: DirectoryOrCreate
+        name: usr-share-ca-certificates
+      - name: dex-ca
+        secret:
+          secretName: dex-ca
+status: {}

--- a/pkg/resources/test/fixtures/deployment-azure-1.20.0-controller-manager.yaml
+++ b/pkg/resources/test/fixtures/deployment-azure-1.20.0-controller-manager.yaml
@@ -1,0 +1,227 @@
+# This file has been generated, DO NOT EDIT.
+
+metadata:
+  creationTimestamp: null
+  labels:
+    app: controller-manager
+  name: controller-manager
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: controller-manager
+  strategy: {}
+  template:
+    metadata:
+      annotations:
+        prometheus.io/path: /metrics
+        prometheus.io/port: "10257"
+        prometheus.io/scrape_with_kube_cert: "true"
+      creationTimestamp: null
+      labels:
+        app: controller-manager
+        ca-secret-revision: "123456"
+        cloud-config-configmap-revision: "123456"
+        cluster: de-test-01
+        controllermanager-kubeconfig-secret-revision: "123456"
+        openvpn-client-certificates-secret-revision: "123456"
+        service-account-key-secret-revision: "123456"
+    spec:
+      affinity:
+        podAntiAffinity:
+          preferredDuringSchedulingIgnoredDuringExecution:
+          - podAffinityTerm:
+              labelSelector:
+                matchLabels:
+                  app: controller-manager
+                  cluster: de-test-01
+              topologyKey: kubernetes.io/hostname
+            weight: 100
+          - podAffinityTerm:
+              labelSelector:
+                matchLabels:
+                  app: controller-manager
+              topologyKey: kubernetes.io/hostname
+            weight: 10
+      containers:
+      - args:
+        - --client
+        - --proto
+        - tcp
+        - --dev
+        - tun
+        - --auth-nocache
+        - --remote
+        - openvpn-server.cluster-de-test-01.svc.cluster.local.
+        - "1194"
+        - --nobind
+        - --connect-timeout
+        - "5"
+        - --connect-retry
+        - "1"
+        - --ca
+        - /etc/openvpn/pki/client/ca.crt
+        - --cert
+        - /etc/openvpn/pki/client/client.crt
+        - --key
+        - /etc/openvpn/pki/client/client.key
+        - --remote-cert-tls
+        - server
+        - --link-mtu
+        - "1432"
+        - --cipher
+        - AES-256-GCM
+        - --auth
+        - SHA1
+        - --keysize
+        - "256"
+        - --script-security
+        - "2"
+        - --status
+        - /run/openvpn-status
+        - --log
+        - /dev/stdout
+        command:
+        - /usr/sbin/openvpn
+        image: quay.io/kubermatic/openvpn:v2.4.8-r1
+        name: openvpn-client
+        resources:
+          limits:
+            cpu: 100m
+            memory: 32Mi
+          requests:
+            cpu: 5m
+            memory: 5Mi
+        securityContext:
+          privileged: true
+        volumeMounts:
+        - mountPath: /etc/openvpn/pki/client
+          name: openvpn-client-certificates
+          readOnly: true
+      - args:
+        - -endpoint
+        - https://apiserver-external.cluster-de-test-01.svc.cluster.local./healthz
+        - -insecure
+        - -retries
+        - "100"
+        - -retry-wait
+        - "2"
+        - -timeout
+        - "1"
+        - -command
+        - '{"command":"/usr/local/bin/kube-controller-manager","args":["--kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","--service-account-private-key-file","/etc/kubernetes/service-account-key/sa.key","--root-ca-file","/etc/kubernetes/pki/ca/ca.crt","--cluster-signing-cert-file","/etc/kubernetes/pki/ca/ca.crt","--cluster-signing-key-file","/etc/kubernetes/pki/ca/ca.key","--cluster-cidr","172.25.0.0/16","--allocate-node-cidrs","--controllers","*,bootstrapsigner,tokencleaner","--use-service-account-credentials","--feature-gates","RotateKubeletClientCertificate=true,RotateKubeletServerCertificate=true","--cloud-provider","azure","--cloud-config","/etc/kubernetes/cloud/config","--cluster-name","de-test-01","--configure-cloud-routes=false","--authentication-kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","--client-ca-file","/etc/kubernetes/pki/ca/ca.crt","--authentication-kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","--authorization-kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","--port","0"]}'
+        command:
+        - /http-prober-bin/http-prober
+        env:
+        - name: HTTP_PROXY
+          value: http://my-corp
+        - name: HTTPS_PROXY
+          value: http://my-corp
+        - name: http_proxy
+          value: http://my-corp
+        - name: https_proxy
+          value: http://my-corp
+        - name: NO_PROXY
+          value: apiserver-external.cluster-de-test-01.svc.cluster.local.
+        - name: no_proxy
+          value: apiserver-external.cluster-de-test-01.svc.cluster.local.
+        image: k8s.gcr.io/kube-controller-manager:v1.20.0
+        livenessProbe:
+          failureThreshold: 8
+          httpGet:
+            path: /healthz
+            port: 10257
+            scheme: HTTPS
+          initialDelaySeconds: 15
+          periodSeconds: 10
+          successThreshold: 1
+          timeoutSeconds: 15
+        name: controller-manager
+        readinessProbe:
+          failureThreshold: 3
+          httpGet:
+            path: /healthz
+            port: 10257
+            scheme: HTTPS
+          periodSeconds: 10
+          successThreshold: 1
+          timeoutSeconds: 15
+        resources:
+          limits:
+            cpu: "2"
+            memory: 2Gi
+          requests:
+            cpu: 100m
+            memory: 100Mi
+        volumeMounts:
+        - mountPath: /etc/kubernetes/pki/ca
+          name: ca
+          readOnly: true
+        - mountPath: /etc/kubernetes/service-account-key
+          name: service-account-key
+          readOnly: true
+        - mountPath: /etc/kubernetes/cloud
+          name: cloud-config
+          readOnly: true
+        - mountPath: /etc/kubernetes/kubeconfig
+          name: controllermanager-kubeconfig
+          readOnly: true
+        - mountPath: /etc/ssl/certs
+          name: ca-certs
+          readOnly: true
+        - mountPath: /usr/share/ca-certificates
+          name: usr-share-ca-certificates
+          readOnly: true
+        - mountPath: /http-prober-bin
+          name: http-prober-bin
+      dnsConfig:
+        nameservers:
+        - 192.0.2.14
+        options:
+        - name: ndots
+          value: "5"
+        searches:
+        - kube-system.svc.cluster.local
+        - svc.cluster.local
+        - cluster.local
+      dnsPolicy: None
+      imagePullSecrets:
+      - name: dockercfg
+      initContainers:
+      - command:
+        - /bin/cp
+        - /usr/local/bin/http-prober
+        - /http-prober-bin/http-prober
+        image: quay.io/kubermatic/http-prober:v0.3.1
+        name: copy-http-prober
+        resources: {}
+        volumeMounts:
+        - mountPath: /http-prober-bin
+          name: http-prober-bin
+      volumes:
+      - name: ca
+        secret:
+          secretName: ca
+      - name: service-account-key
+        secret:
+          secretName: service-account-key
+      - configMap:
+          name: cloud-config
+        name: cloud-config
+      - name: openvpn-client-certificates
+        secret:
+          secretName: openvpn-client-certificates
+      - name: controllermanager-kubeconfig
+        secret:
+          secretName: controllermanager-kubeconfig
+      - hostPath:
+          path: /etc/ssl/certs
+          type: DirectoryOrCreate
+        name: ca-certs
+      - hostPath:
+          path: /usr/share/ca-certificates
+          type: DirectoryOrCreate
+        name: usr-share-ca-certificates
+      - emptyDir: {}
+        name: http-prober-bin
+status: {}

--- a/pkg/resources/test/fixtures/deployment-azure-1.20.0-dns-resolver.yaml
+++ b/pkg/resources/test/fixtures/deployment-azure-1.20.0-dns-resolver.yaml
@@ -1,0 +1,140 @@
+# This file has been generated, DO NOT EDIT.
+
+metadata:
+  creationTimestamp: null
+  labels:
+    app: dns-resolver
+  name: dns-resolver
+spec:
+  replicas: 2
+  selector:
+    matchLabels:
+      app: dns-resolver
+  strategy: {}
+  template:
+    metadata:
+      annotations:
+        prometheus.io/path: /metrics
+        prometheus.io/port: "9253"
+        prometheus.io/scrape: "true"
+      creationTimestamp: null
+      labels:
+        app: dns-resolver
+        ca-secret-revision: "123456"
+        cluster: de-test-01
+        dns-resolver-configmap-revision: "123456"
+        openvpn-client-certificates-secret-revision: "123456"
+    spec:
+      affinity:
+        podAntiAffinity:
+          preferredDuringSchedulingIgnoredDuringExecution:
+          - podAffinityTerm:
+              labelSelector:
+                matchLabels:
+                  app: dns-resolver
+                  cluster: de-test-01
+              topologyKey: kubernetes.io/hostname
+            weight: 100
+          - podAffinityTerm:
+              labelSelector:
+                matchLabels:
+                  app: dns-resolver
+              topologyKey: kubernetes.io/hostname
+            weight: 10
+      containers:
+      - args:
+        - --client
+        - --proto
+        - tcp
+        - --dev
+        - tun
+        - --auth-nocache
+        - --remote
+        - openvpn-server.cluster-de-test-01.svc.cluster.local.
+        - "1194"
+        - --nobind
+        - --connect-timeout
+        - "5"
+        - --connect-retry
+        - "1"
+        - --ca
+        - /etc/openvpn/pki/client/ca.crt
+        - --cert
+        - /etc/openvpn/pki/client/client.crt
+        - --key
+        - /etc/openvpn/pki/client/client.key
+        - --remote-cert-tls
+        - server
+        - --link-mtu
+        - "1432"
+        - --cipher
+        - AES-256-GCM
+        - --auth
+        - SHA1
+        - --keysize
+        - "256"
+        - --script-security
+        - "2"
+        - --status
+        - /run/openvpn-status
+        - --log
+        - /dev/stdout
+        command:
+        - /usr/sbin/openvpn
+        image: quay.io/kubermatic/openvpn:v2.4.8-r1
+        name: openvpn-client
+        resources:
+          limits:
+            cpu: 100m
+            memory: 32Mi
+          requests:
+            cpu: 5m
+            memory: 5Mi
+        securityContext:
+          privileged: true
+        volumeMounts:
+        - mountPath: /etc/openvpn/pki/client
+          name: openvpn-client-certificates
+          readOnly: true
+      - args:
+        - -conf
+        - /etc/coredns/Corefile
+        image: k8s.gcr.io/coredns:1.3.1
+        name: dns-resolver
+        readinessProbe:
+          failureThreshold: 3
+          httpGet:
+            path: /health
+            port: 8080
+            scheme: HTTP
+          initialDelaySeconds: 2
+          periodSeconds: 10
+          successThreshold: 1
+          timeoutSeconds: 15
+        resources:
+          limits:
+            cpu: 100m
+            memory: 128Mi
+          requests:
+            cpu: 5m
+            memory: 20Mi
+        volumeMounts:
+        - mountPath: /etc/coredns
+          name: dns-resolver
+          readOnly: true
+      imagePullSecrets:
+      - name: dockercfg
+      volumes:
+      - configMap:
+          name: dns-resolver
+        name: dns-resolver
+      - name: openvpn-client-certificates
+        secret:
+          secretName: openvpn-client-certificates
+      - name: ca
+        secret:
+          items:
+          - key: ca.crt
+            path: ca.crt
+          secretName: ca
+status: {}

--- a/pkg/resources/test/fixtures/deployment-azure-1.20.0-kube-state-metrics.yaml
+++ b/pkg/resources/test/fixtures/deployment-azure-1.20.0-kube-state-metrics.yaml
@@ -1,0 +1,89 @@
+# This file has been generated, DO NOT EDIT.
+
+metadata:
+  creationTimestamp: null
+  labels:
+    app: kube-state-metrics
+  name: kube-state-metrics
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: kube-state-metrics
+  strategy: {}
+  template:
+    metadata:
+      annotations:
+        prometheus.io/scrape: "true"
+      creationTimestamp: null
+      labels:
+        app: kube-state-metrics
+        cluster: de-test-01
+        kube-state-metrics-kubeconfig-secret-revision: "123456"
+    spec:
+      containers:
+      - args:
+        - -endpoint
+        - https://apiserver-external.cluster-de-test-01.svc.cluster.local./healthz
+        - -insecure
+        - -retries
+        - "100"
+        - -retry-wait
+        - "2"
+        - -timeout
+        - "1"
+        - -command
+        - '{"command":"/kube-state-metrics","args":["--kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","--port","8080","--telemetry-port","8081"]}'
+        command:
+        - /http-prober-bin/http-prober
+        image: quay.io/coreos/kube-state-metrics:v1.9.7
+        name: kube-state-metrics
+        ports:
+        - containerPort: 8080
+          name: metrics
+          protocol: TCP
+        - containerPort: 8081
+          name: telemetry
+          protocol: TCP
+        readinessProbe:
+          failureThreshold: 3
+          httpGet:
+            path: /healthz
+            port: 8080
+            scheme: HTTP
+          periodSeconds: 10
+          successThreshold: 1
+          timeoutSeconds: 15
+        resources:
+          limits:
+            cpu: 100m
+            memory: 1Gi
+          requests:
+            cpu: 10m
+            memory: 12Mi
+        volumeMounts:
+        - mountPath: /etc/kubernetes/kubeconfig
+          name: kube-state-metrics-kubeconfig
+          readOnly: true
+        - mountPath: /http-prober-bin
+          name: http-prober-bin
+      imagePullSecrets:
+      - name: dockercfg
+      initContainers:
+      - command:
+        - /bin/cp
+        - /usr/local/bin/http-prober
+        - /http-prober-bin/http-prober
+        image: quay.io/kubermatic/http-prober:v0.3.1
+        name: copy-http-prober
+        resources: {}
+        volumeMounts:
+        - mountPath: /http-prober-bin
+          name: http-prober-bin
+      volumes:
+      - name: kube-state-metrics-kubeconfig
+        secret:
+          secretName: kube-state-metrics-kubeconfig
+      - emptyDir: {}
+        name: http-prober-bin
+status: {}

--- a/pkg/resources/test/fixtures/deployment-azure-1.20.0-kubernetes-dashboard.yaml
+++ b/pkg/resources/test/fixtures/deployment-azure-1.20.0-kubernetes-dashboard.yaml
@@ -1,0 +1,97 @@
+# This file has been generated, DO NOT EDIT.
+
+metadata:
+  creationTimestamp: null
+  labels:
+    app: kubernetes-dashboard
+  name: kubernetes-dashboard
+spec:
+  replicas: 2
+  selector:
+    matchLabels:
+      app: kubernetes-dashboard
+  strategy: {}
+  template:
+    metadata:
+      creationTimestamp: null
+      labels:
+        app: kubernetes-dashboard
+        cluster: de-test-01
+        kubernetes-dashboard-kubeconfig-secret-revision: "123456"
+    spec:
+      affinity:
+        podAntiAffinity:
+          preferredDuringSchedulingIgnoredDuringExecution:
+          - podAffinityTerm:
+              labelSelector:
+                matchLabels:
+                  app: kubernetes-dashboard
+                  cluster: de-test-01
+              topologyKey: kubernetes.io/hostname
+            weight: 100
+          - podAffinityTerm:
+              labelSelector:
+                matchLabels:
+                  app: kubernetes-dashboard
+              topologyKey: kubernetes.io/hostname
+            weight: 10
+      containers:
+      - args:
+        - -endpoint
+        - https://apiserver-external.cluster-de-test-01.svc.cluster.local./healthz
+        - -insecure
+        - -retries
+        - "100"
+        - -retry-wait
+        - "2"
+        - -timeout
+        - "1"
+        - -command
+        - '{"command":"/dashboard","args":["--kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","--namespace","kubernetes-dashboard","--enable-insecure-login"]}'
+        command:
+        - /http-prober-bin/http-prober
+        image: docker.io/kubernetesui/dashboard:v2.0.4
+        imagePullPolicy: IfNotPresent
+        name: kubernetes-dashboard
+        ports:
+        - containerPort: 9090
+          protocol: TCP
+        resources:
+          limits:
+            cpu: 250m
+            memory: 512Mi
+          requests:
+            cpu: 100m
+            memory: 256Mi
+        securityContext:
+          allowPrivilegeEscalation: false
+          readOnlyRootFilesystem: true
+          runAsUser: 1001
+        volumeMounts:
+        - mountPath: /etc/kubernetes/kubeconfig
+          name: kubernetes-dashboard-kubeconfig
+          readOnly: true
+        - mountPath: /tmp
+          name: tmp-volume
+        - mountPath: /http-prober-bin
+          name: http-prober-bin
+      initContainers:
+      - command:
+        - /bin/cp
+        - /usr/local/bin/http-prober
+        - /http-prober-bin/http-prober
+        image: quay.io/kubermatic/http-prober:v0.3.1
+        name: copy-http-prober
+        resources: {}
+        volumeMounts:
+        - mountPath: /http-prober-bin
+          name: http-prober-bin
+      volumes:
+      - name: kubernetes-dashboard-kubeconfig
+        secret:
+          secretName: kubernetes-dashboard-kubeconfig
+      - emptyDir: {}
+        name: tmp-volume
+      - emptyDir: {}
+        name: http-prober-bin
+status: {}

--- a/pkg/resources/test/fixtures/deployment-azure-1.20.0-machine-controller-webhook.yaml
+++ b/pkg/resources/test/fixtures/deployment-azure-1.20.0-machine-controller-webhook.yaml
@@ -1,0 +1,122 @@
+# This file has been generated, DO NOT EDIT.
+
+metadata:
+  creationTimestamp: null
+  labels:
+    app: machine-controller-webhook
+  name: machine-controller-webhook
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: machine-controller-webhook
+  strategy: {}
+  template:
+    metadata:
+      creationTimestamp: null
+      labels:
+        app: machine-controller-webhook
+        cluster: de-test-01
+        machinecontroller-kubeconfig-secret-revision: "123456"
+        machinecontroller-webhook-serving-cert-secret-revision: "123456"
+    spec:
+      containers:
+      - args:
+        - -endpoint
+        - https://apiserver-external.cluster-de-test-01.svc.cluster.local./healthz
+        - -insecure
+        - -retries
+        - "100"
+        - -retry-wait
+        - "2"
+        - -timeout
+        - "1"
+        - -command
+        - '{"command":"/usr/local/bin/webhook","args":["-kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","-logtostderr","-v","4","-listen-address","0.0.0.0:9876"]}'
+        - --crd-to-wait-for
+        - Machine,cluster.k8s.io/v1alpha1
+        command:
+        - /http-prober-bin/http-prober
+        env:
+        - name: AZURE_CLIENT_ID
+          value: az-client-id
+        - name: AZURE_CLIENT_SECRET
+          value: az-client-secret
+        - name: AZURE_TENANT_ID
+          value: az-tenant-id
+        - name: AZURE_SUBSCRIPTION_ID
+          value: az-subscription-id
+        - name: HTTP_PROXY
+          value: http://my-corp
+        - name: HTTPS_PROXY
+          value: http://my-corp
+        - name: http_proxy
+          value: http://my-corp
+        - name: https_proxy
+          value: http://my-corp
+        - name: NO_PROXY
+          value: apiserver-external.cluster-de-test-01.svc.cluster.local.
+        - name: no_proxy
+          value: apiserver-external.cluster-de-test-01.svc.cluster.local.
+        - name: KUBECONFIG
+          value: /etc/kubernetes/kubeconfig/kubeconfig
+        image: docker.io/kubermatic/machine-controller:v1.23.1
+        livenessProbe:
+          failureThreshold: 8
+          httpGet:
+            path: /healthz
+            port: 9876
+            scheme: HTTPS
+          initialDelaySeconds: 15
+          periodSeconds: 10
+          successThreshold: 1
+          timeoutSeconds: 15
+        name: machine-controller
+        readinessProbe:
+          failureThreshold: 3
+          httpGet:
+            path: /healthz
+            port: 9876
+            scheme: HTTPS
+          periodSeconds: 10
+          successThreshold: 1
+          timeoutSeconds: 15
+        resources:
+          limits:
+            cpu: 100m
+            memory: 512Mi
+          requests:
+            cpu: 10m
+            memory: 32Mi
+        volumeMounts:
+        - mountPath: /etc/kubernetes/kubeconfig
+          name: machinecontroller-kubeconfig
+          readOnly: true
+        - mountPath: /tmp/cert
+          name: machinecontroller-webhook-serving-cert
+          readOnly: true
+        - mountPath: /http-prober-bin
+          name: http-prober-bin
+      imagePullSecrets:
+      - name: dockercfg
+      initContainers:
+      - command:
+        - /bin/cp
+        - /usr/local/bin/http-prober
+        - /http-prober-bin/http-prober
+        image: quay.io/kubermatic/http-prober:v0.3.1
+        name: copy-http-prober
+        resources: {}
+        volumeMounts:
+        - mountPath: /http-prober-bin
+          name: http-prober-bin
+      volumes:
+      - name: machinecontroller-kubeconfig
+        secret:
+          secretName: machinecontroller-kubeconfig
+      - name: machinecontroller-webhook-serving-cert
+        secret:
+          secretName: machinecontroller-webhook-serving-cert
+      - emptyDir: {}
+        name: http-prober-bin
+status: {}

--- a/pkg/resources/test/fixtures/deployment-azure-1.20.0-machine-controller.yaml
+++ b/pkg/resources/test/fixtures/deployment-azure-1.20.0-machine-controller.yaml
@@ -1,0 +1,110 @@
+# This file has been generated, DO NOT EDIT.
+
+metadata:
+  creationTimestamp: null
+  labels:
+    app: machine-controller
+  name: machine-controller
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: machine-controller
+  strategy: {}
+  template:
+    metadata:
+      annotations:
+        prometheus.io/path: /metrics
+        prometheus.io/port: "8080"
+        prometheus.io/scrape: "true"
+      creationTimestamp: null
+      labels:
+        app: machine-controller
+        cluster: de-test-01
+        machinecontroller-kubeconfig-secret-revision: "123456"
+    spec:
+      containers:
+      - args:
+        - -endpoint
+        - https://apiserver-external.cluster-de-test-01.svc.cluster.local./healthz
+        - -insecure
+        - -retries
+        - "100"
+        - -retry-wait
+        - "2"
+        - -timeout
+        - "1"
+        - -command
+        - '{"command":"/usr/local/bin/machine-controller","args":["-kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","-logtostderr","-v","4","-cluster-dns","169.254.20.10","-health-probe-address","0.0.0.0:8085","-metrics-address","0.0.0.0:8080"]}'
+        - --crd-to-wait-for
+        - Machine,cluster.k8s.io/v1alpha1
+        command:
+        - /http-prober-bin/http-prober
+        env:
+        - name: AZURE_CLIENT_ID
+          value: az-client-id
+        - name: AZURE_CLIENT_SECRET
+          value: az-client-secret
+        - name: AZURE_TENANT_ID
+          value: az-tenant-id
+        - name: AZURE_SUBSCRIPTION_ID
+          value: az-subscription-id
+        - name: HTTP_PROXY
+          value: http://my-corp
+        - name: HTTPS_PROXY
+          value: http://my-corp
+        - name: http_proxy
+          value: http://my-corp
+        - name: https_proxy
+          value: http://my-corp
+        - name: NO_PROXY
+          value: apiserver-external.cluster-de-test-01.svc.cluster.local.
+        - name: no_proxy
+          value: apiserver-external.cluster-de-test-01.svc.cluster.local.
+        - name: KUBECONFIG
+          value: /etc/kubernetes/kubeconfig/kubeconfig
+        image: docker.io/kubermatic/machine-controller:v1.23.1
+        livenessProbe:
+          failureThreshold: 3
+          httpGet:
+            path: /readyz
+            port: 8085
+            scheme: HTTP
+          initialDelaySeconds: 15
+          periodSeconds: 10
+          successThreshold: 1
+          timeoutSeconds: 15
+        name: machine-controller
+        resources:
+          limits:
+            cpu: "2"
+            memory: 512Mi
+          requests:
+            cpu: 25m
+            memory: 32Mi
+        volumeMounts:
+        - mountPath: /etc/kubernetes/kubeconfig
+          name: machinecontroller-kubeconfig
+          readOnly: true
+        - mountPath: /http-prober-bin
+          name: http-prober-bin
+      imagePullSecrets:
+      - name: dockercfg
+      initContainers:
+      - command:
+        - /bin/cp
+        - /usr/local/bin/http-prober
+        - /http-prober-bin/http-prober
+        image: quay.io/kubermatic/http-prober:v0.3.1
+        name: copy-http-prober
+        resources: {}
+        volumeMounts:
+        - mountPath: /http-prober-bin
+          name: http-prober-bin
+      volumes:
+      - name: machinecontroller-kubeconfig
+        secret:
+          secretName: machinecontroller-kubeconfig
+      - emptyDir: {}
+        name: http-prober-bin
+status: {}

--- a/pkg/resources/test/fixtures/deployment-azure-1.20.0-metrics-server.yaml
+++ b/pkg/resources/test/fixtures/deployment-azure-1.20.0-metrics-server.yaml
@@ -1,0 +1,182 @@
+# This file has been generated, DO NOT EDIT.
+
+metadata:
+  creationTimestamp: null
+  labels:
+    app: metrics-server
+  name: metrics-server
+spec:
+  replicas: 2
+  selector:
+    matchLabels:
+      app: metrics-server
+  strategy: {}
+  template:
+    metadata:
+      creationTimestamp: null
+      labels:
+        app: metrics-server
+        cluster: de-test-01
+        kubeletdnatcontroller-kubeconfig-secret-revision: "123456"
+        metrics-server-secret-revision: "123456"
+        metrics-server-serving-cert-secret-revision: "123456"
+        openvpn-client-certificates-secret-revision: "123456"
+    spec:
+      affinity:
+        podAntiAffinity:
+          preferredDuringSchedulingIgnoredDuringExecution:
+          - podAffinityTerm:
+              labelSelector:
+                matchLabels:
+                  app: metrics-server
+                  cluster: de-test-01
+              topologyKey: kubernetes.io/hostname
+            weight: 100
+          - podAffinityTerm:
+              labelSelector:
+                matchLabels:
+                  app: metrics-server
+              topologyKey: kubernetes.io/hostname
+            weight: 10
+      containers:
+      - args:
+        - -endpoint
+        - https://apiserver-external.cluster-de-test-01.svc.cluster.local./healthz
+        - -insecure
+        - -retries
+        - "100"
+        - -retry-wait
+        - "2"
+        - -timeout
+        - "1"
+        - -command
+        - '{"command":"/metrics-server","args":["--kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","--authentication-kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","--authorization-kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","--kubelet-port","10250","--kubelet-insecure-tls","--kubelet-preferred-address-types","ExternalIP,InternalIP","--v","1","--logtostderr","--tls-cert-file","/etc/serving-cert/serving.crt","--tls-private-key-file","/etc/serving-cert/serving.key"]}'
+        command:
+        - /http-prober-bin/http-prober
+        image: k8s.gcr.io/metrics-server-amd64:v0.3.6
+        name: metrics-server
+        resources:
+          limits:
+            cpu: 150m
+            memory: 512Mi
+          requests:
+            cpu: 25m
+            memory: 32Mi
+        volumeMounts:
+        - mountPath: /etc/kubernetes/kubeconfig
+          name: metrics-server
+          readOnly: true
+        - mountPath: /etc/serving-cert
+          name: metrics-server-serving-cert
+          readOnly: true
+        - mountPath: /http-prober-bin
+          name: http-prober-bin
+      - args:
+        - --client
+        - --proto
+        - tcp
+        - --dev
+        - tun
+        - --auth-nocache
+        - --remote
+        - openvpn-server.cluster-de-test-01.svc.cluster.local.
+        - "1194"
+        - --nobind
+        - --connect-timeout
+        - "5"
+        - --connect-retry
+        - "1"
+        - --ca
+        - /etc/openvpn/pki/client/ca.crt
+        - --cert
+        - /etc/openvpn/pki/client/client.crt
+        - --key
+        - /etc/openvpn/pki/client/client.key
+        - --remote-cert-tls
+        - server
+        - --link-mtu
+        - "1432"
+        - --cipher
+        - AES-256-GCM
+        - --auth
+        - SHA1
+        - --keysize
+        - "256"
+        - --script-security
+        - "2"
+        - --status
+        - /run/openvpn-status
+        - --log
+        - /dev/stdout
+        command:
+        - /usr/sbin/openvpn
+        image: quay.io/kubermatic/openvpn:v2.4.8-r1
+        name: openvpn-client
+        resources:
+          limits:
+            cpu: 100m
+            memory: 32Mi
+          requests:
+            cpu: 5m
+            memory: 5Mi
+        securityContext:
+          privileged: true
+        volumeMounts:
+        - mountPath: /etc/openvpn/pki/client
+          name: openvpn-client-certificates
+          readOnly: true
+      - args:
+        - -kubeconfig
+        - /etc/kubernetes/kubeconfig/kubeconfig
+        - -node-access-network
+        - 192.0.2.0/24
+        command:
+        - /usr/local/bin/kubeletdnat-controller
+        image: quay.io/kubermatic/kubeletdnat-controller:v0.0.0-test
+        name: dnat-controller
+        resources:
+          limits:
+            cpu: 100m
+            memory: 512Mi
+          requests:
+            cpu: 5m
+            memory: 16Mi
+        securityContext:
+          capabilities:
+            add:
+            - NET_ADMIN
+          procMount: Default
+          runAsUser: 0
+        volumeMounts:
+        - mountPath: /etc/kubernetes/kubeconfig
+          name: kubeletdnatcontroller-kubeconfig
+          readOnly: true
+      imagePullSecrets:
+      - name: dockercfg
+      initContainers:
+      - command:
+        - /bin/cp
+        - /usr/local/bin/http-prober
+        - /http-prober-bin/http-prober
+        image: quay.io/kubermatic/http-prober:v0.3.1
+        name: copy-http-prober
+        resources: {}
+        volumeMounts:
+        - mountPath: /http-prober-bin
+          name: http-prober-bin
+      volumes:
+      - name: metrics-server
+        secret:
+          secretName: metrics-server
+      - name: openvpn-client-certificates
+        secret:
+          secretName: openvpn-client-certificates
+      - name: kubeletdnatcontroller-kubeconfig
+        secret:
+          secretName: kubeletdnatcontroller-kubeconfig
+      - name: metrics-server-serving-cert
+        secret:
+          secretName: metrics-server-serving-cert
+      - emptyDir: {}
+        name: http-prober-bin
+status: {}

--- a/pkg/resources/test/fixtures/deployment-azure-1.20.0-openvpn-server.yaml
+++ b/pkg/resources/test/fixtures/deployment-azure-1.20.0-openvpn-server.yaml
@@ -1,0 +1,223 @@
+# This file has been generated, DO NOT EDIT.
+
+metadata:
+  creationTimestamp: null
+  labels:
+    app: openvpn-server
+  name: openvpn-server
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: openvpn-server
+  strategy:
+    rollingUpdate:
+      maxSurge: 1
+      maxUnavailable: 1
+    type: RollingUpdate
+  template:
+    metadata:
+      annotations:
+        prometheus.io/path: /metrics
+        prometheus.io/port: "9176"
+        prometheus.io/scrape: "true"
+      creationTimestamp: null
+      labels:
+        app: openvpn-server
+        cluster: de-test-01
+        openvpn-ca-secret-revision: "123456"
+        openvpn-client-configs-configmap-revision: "123456"
+        openvpn-server-certificates-secret-revision: "123456"
+    spec:
+      containers:
+      - args:
+        - --proto
+        - tcp
+        - --dev
+        - tun
+        - --mode
+        - server
+        - --lport
+        - "1194"
+        - --server
+        - 10.20.0.0
+        - 255.255.255.0
+        - --ca
+        - /etc/kubernetes/pki/ca/ca.crt
+        - --cert
+        - /etc/openvpn/pki/server/server.crt
+        - --key
+        - /etc/openvpn/pki/server/server.key
+        - --dh
+        - none
+        - --duplicate-cn
+        - --client-config-dir
+        - /etc/openvpn/clients
+        - --status
+        - /run/openvpn/openvpn-status
+        - --status-version
+        - "3"
+        - --cipher
+        - AES-256-GCM
+        - --auth
+        - SHA1
+        - --keysize
+        - "256"
+        - --script-security
+        - "2"
+        - --ping
+        - "5"
+        - --verb
+        - "3"
+        - --log
+        - /dev/stdout
+        - --push
+        - route 172.25.0.0 255.255.0.0
+        - --route
+        - 172.25.0.0
+        - 255.255.0.0
+        - --push
+        - route 10.240.16.0 255.255.240.0
+        - --route
+        - 10.240.16.0
+        - 255.255.240.0
+        - --push
+        - route 192.0.2.0 255.255.255.0
+        - --route
+        - 192.0.2.0
+        - 255.255.255.0
+        command:
+        - /usr/sbin/openvpn
+        image: quay.io/kubermatic/openvpn:v2.4.8-r1
+        name: openvpn-server
+        ports:
+        - containerPort: 1194
+          protocol: TCP
+        readinessProbe:
+          exec:
+            command:
+            - test
+            - -s
+            - /run/openvpn/openvpn-status
+          failureThreshold: 3
+          initialDelaySeconds: 5
+          periodSeconds: 5
+          successThreshold: 1
+          timeoutSeconds: 1
+        resources:
+          limits:
+            cpu: 100m
+            memory: 20Mi
+          requests:
+            cpu: 5m
+            memory: 5Mi
+        securityContext:
+          privileged: true
+          procMount: Default
+        volumeMounts:
+        - mountPath: /etc/openvpn/pki/server
+          name: openvpn-server-certificates
+          readOnly: true
+        - mountPath: /etc/kubernetes/pki/ca
+          name: ca
+          readOnly: true
+        - mountPath: /etc/openvpn/clients
+          name: openvpn-client-configs
+          readOnly: true
+        - mountPath: /run/openvpn
+          name: openvpn-status
+      - args:
+        - -c
+        - |-
+          while true; do sysctl -w net.ipv4.ip_forward=1;
+            if ! iptables -t mangle -C INPUT -p tcp --tcp-flags SYN,RST SYN --dport 1194 -j TCPMSS --set-mss 1300 &>/dev/null; then
+             iptables -t mangle -A INPUT -p tcp --tcp-flags SYN,RST SYN --dport 1194 -j TCPMSS --set-mss 1300
+            fi
+            sleep 30;
+          done
+        command:
+        - /bin/bash
+        image: quay.io/kubermatic/openvpn:v2.4.8-r1
+        name: ip-fixup
+        resources:
+          limits:
+            cpu: 10m
+            memory: 32Mi
+          requests:
+            cpu: 5m
+            memory: 16Mi
+        securityContext:
+          privileged: true
+          procMount: Default
+      - args:
+        - -openvpn.status_paths
+        - /run/openvpn/openvpn-status
+        command:
+        - /bin/openvpn_exporter
+        image: docker.io/kumina/openvpn-exporter:v0.2.2
+        name: openvpn-exporter
+        ports:
+        - containerPort: 9176
+          protocol: TCP
+        resources:
+          limits:
+            cpu: 100m
+            memory: 20Mi
+          requests:
+            cpu: 5m
+            memory: 5Mi
+        volumeMounts:
+        - mountPath: /run/openvpn
+          name: openvpn-status
+      imagePullSecrets:
+      - name: dockercfg
+      initContainers:
+      - args:
+        - -c
+        - |
+          # do not give a 10.20.0.0/24 route to clients (nodes) but
+          # masquerade to openvpn-server's IP instead:
+          iptables -t nat -A POSTROUTING -o tun0 -s 10.20.0.0/24 -j MASQUERADE
+
+          # Only allow outbound traffic to services, pods, nodes
+          iptables -P FORWARD DROP
+          iptables -A FORWARD -m state --state ESTABLISHED,RELATED -j ACCEPT
+          iptables -A FORWARD -i tun0 -o tun0 -s 10.20.0.0/24 -d 172.25.0.0/16 -j ACCEPT
+          iptables -A FORWARD -i tun0 -o tun0 -s 10.20.0.0/24 -d 10.240.16.0/20 -j ACCEPT
+          iptables -A FORWARD -i tun0 -o tun0 -s 10.20.0.0/24 -d 192.0.2.0/24 -j ACCEPT
+
+          iptables -A INPUT -m state --state ESTABLISHED,RELATED -j ACCEPT
+          iptables -A INPUT -i tun0 -p icmp -j ACCEPT
+          iptables -A INPUT -i tun0 -j DROP
+        command:
+        - /bin/bash
+        image: quay.io/kubermatic/openvpn:v2.4.8-r1
+        name: iptables-init
+        resources:
+          limits:
+            cpu: 100m
+            memory: 20Mi
+          requests:
+            cpu: 5m
+            memory: 5Mi
+        securityContext:
+          capabilities:
+            add:
+            - NET_ADMIN
+          procMount: Default
+      volumes:
+      - name: ca
+        secret:
+          items:
+          - key: ca.crt
+            path: ca.crt
+          secretName: openvpn-ca
+      - name: openvpn-server-certificates
+        secret:
+          secretName: openvpn-server-certificates
+      - configMap:
+          name: openvpn-client-configs
+        name: openvpn-client-configs
+      - emptyDir: {}
+        name: openvpn-status
+status: {}

--- a/pkg/resources/test/fixtures/deployment-azure-1.20.0-scheduler.yaml
+++ b/pkg/resources/test/fixtures/deployment-azure-1.20.0-scheduler.yaml
@@ -1,0 +1,203 @@
+# This file has been generated, DO NOT EDIT.
+
+metadata:
+  creationTimestamp: null
+  labels:
+    app: scheduler
+  name: scheduler
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: scheduler
+  strategy: {}
+  template:
+    metadata:
+      annotations:
+        prometheus.io/path: /metrics
+        prometheus.io/port: "10259"
+        prometheus.io/scrape_with_kube_cert: "true"
+      creationTimestamp: null
+      labels:
+        app: scheduler
+        ca-secret-revision: "123456"
+        cluster: de-test-01
+        openvpn-client-certificates-secret-revision: "123456"
+        scheduler-kubeconfig-secret-revision: "123456"
+    spec:
+      affinity:
+        podAntiAffinity:
+          preferredDuringSchedulingIgnoredDuringExecution:
+          - podAffinityTerm:
+              labelSelector:
+                matchLabels:
+                  app: scheduler
+                  cluster: de-test-01
+              topologyKey: kubernetes.io/hostname
+            weight: 100
+          - podAffinityTerm:
+              labelSelector:
+                matchLabels:
+                  app: scheduler
+              topologyKey: kubernetes.io/hostname
+            weight: 10
+      containers:
+      - args:
+        - --client
+        - --proto
+        - tcp
+        - --dev
+        - tun
+        - --auth-nocache
+        - --remote
+        - openvpn-server.cluster-de-test-01.svc.cluster.local.
+        - "1194"
+        - --nobind
+        - --connect-timeout
+        - "5"
+        - --connect-retry
+        - "1"
+        - --ca
+        - /etc/openvpn/pki/client/ca.crt
+        - --cert
+        - /etc/openvpn/pki/client/client.crt
+        - --key
+        - /etc/openvpn/pki/client/client.key
+        - --remote-cert-tls
+        - server
+        - --link-mtu
+        - "1432"
+        - --cipher
+        - AES-256-GCM
+        - --auth
+        - SHA1
+        - --keysize
+        - "256"
+        - --script-security
+        - "2"
+        - --status
+        - /run/openvpn-status
+        - --log
+        - /dev/stdout
+        command:
+        - /usr/sbin/openvpn
+        image: quay.io/kubermatic/openvpn:v2.4.8-r1
+        name: openvpn-client
+        resources:
+          limits:
+            cpu: 100m
+            memory: 32Mi
+          requests:
+            cpu: 5m
+            memory: 5Mi
+        securityContext:
+          privileged: true
+        volumeMounts:
+        - mountPath: /etc/openvpn/pki/client
+          name: openvpn-client-certificates
+          readOnly: true
+      - args:
+        - -endpoint
+        - https://apiserver-external.cluster-de-test-01.svc.cluster.local./healthz
+        - -insecure
+        - -retries
+        - "100"
+        - -retry-wait
+        - "2"
+        - -timeout
+        - "1"
+        - -command
+        - '{"command":"/usr/local/bin/kube-scheduler","args":["--kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","--authentication-kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","--authorization-kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","--client-ca-file","/etc/kubernetes/pki/ca/ca.crt","--port","0"]}'
+        command:
+        - /http-prober-bin/http-prober
+        image: k8s.gcr.io/kube-scheduler:v1.20.0
+        livenessProbe:
+          failureThreshold: 8
+          httpGet:
+            path: /healthz
+            port: 10259
+            scheme: HTTPS
+          initialDelaySeconds: 15
+          periodSeconds: 10
+          successThreshold: 1
+          timeoutSeconds: 15
+        name: scheduler
+        readinessProbe:
+          failureThreshold: 3
+          httpGet:
+            path: /healthz
+            port: 10259
+            scheme: HTTPS
+          periodSeconds: 10
+          successThreshold: 1
+          timeoutSeconds: 15
+        resources:
+          limits:
+            cpu: "1"
+            memory: 512Mi
+          requests:
+            cpu: 20m
+            memory: 64Mi
+        volumeMounts:
+        - mountPath: /etc/kubernetes/kubeconfig
+          name: scheduler-kubeconfig
+          readOnly: true
+        - mountPath: /etc/kubernetes/pki/ca
+          name: ca
+          readOnly: true
+        - mountPath: /etc/ssl/certs
+          name: ca-certs
+          readOnly: true
+        - mountPath: /usr/share/ca-certificates
+          name: usr-share-ca-certificates
+          readOnly: true
+        - mountPath: /http-prober-bin
+          name: http-prober-bin
+      dnsConfig:
+        nameservers:
+        - 192.0.2.14
+        options:
+        - name: ndots
+          value: "5"
+        searches:
+        - kube-system.svc.cluster.local
+        - svc.cluster.local
+        - cluster.local
+      dnsPolicy: None
+      imagePullSecrets:
+      - name: dockercfg
+      initContainers:
+      - command:
+        - /bin/cp
+        - /usr/local/bin/http-prober
+        - /http-prober-bin/http-prober
+        image: quay.io/kubermatic/http-prober:v0.3.1
+        name: copy-http-prober
+        resources: {}
+        volumeMounts:
+        - mountPath: /http-prober-bin
+          name: http-prober-bin
+      volumes:
+      - name: openvpn-client-certificates
+        secret:
+          secretName: openvpn-client-certificates
+      - name: ca
+        secret:
+          items:
+          - key: ca.crt
+            path: ca.crt
+          secretName: ca
+      - name: scheduler-kubeconfig
+        secret:
+          secretName: scheduler-kubeconfig
+      - hostPath:
+          path: /etc/ssl/certs
+          type: DirectoryOrCreate
+        name: ca-certs
+      - hostPath:
+          path: /usr/share/ca-certificates
+          type: DirectoryOrCreate
+        name: usr-share-ca-certificates
+      - emptyDir: {}
+        name: http-prober-bin
+status: {}

--- a/pkg/resources/test/fixtures/deployment-azure-1.20.0-usercluster-controller.yaml
+++ b/pkg/resources/test/fixtures/deployment-azure-1.20.0-usercluster-controller.yaml
@@ -1,0 +1,95 @@
+# This file has been generated, DO NOT EDIT.
+
+metadata:
+  creationTimestamp: null
+  labels:
+    app: usercluster-controller
+  name: usercluster-controller
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: usercluster-controller
+  strategy:
+    rollingUpdate:
+      maxSurge: 1
+      maxUnavailable: 1
+    type: RollingUpdate
+  template:
+    metadata:
+      annotations:
+        prometheus.io/path: /metrics
+        prometheus.io/port: "8085"
+        prometheus.io/scrape: "true"
+      creationTimestamp: null
+      labels:
+        app: usercluster-controller
+        cluster: de-test-01
+        internal-admin-kubeconfig-secret-revision: "123456"
+    spec:
+      containers:
+      - args:
+        - -endpoint
+        - https://apiserver-external.cluster-de-test-01.svc.cluster.local./healthz
+        - -insecure
+        - -retries
+        - "100"
+        - -retry-wait
+        - "2"
+        - -timeout
+        - "1"
+        - -command
+        - '{"command":"/usr/local/bin/user-cluster-controller-manager","args":["-kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","-metrics-listen-address","0.0.0.0:8085","-health-listen-address","0.0.0.0:8086","-namespace","$(NAMESPACE)","-cluster-url","https://jh8j81chn.europe-west3-c.dev.kubermatic.io:30000","-dns-cluster-ip","10.240.16.10","-openvpn-server-port","30003","-overwrite-registry","","-openshift=false","-version","1.20.0","-cloud-provider-name","azure","-owner-email","","-opa-integration=false","--ipam-controller-network","192.168.1.1/24,192.168.1.1,8.8.8.8","-node-labels","{\"my-label\":\"my-value\"}"]}'
+        command:
+        - /http-prober-bin/http-prober
+        env:
+        - name: NAMESPACE
+          valueFrom:
+            fieldRef:
+              apiVersion: v1
+              fieldPath: metadata.namespace
+        image: quay.io/kubermatic/kubermatic:v0.0.0-test
+        name: usercluster-controller
+        readinessProbe:
+          failureThreshold: 5
+          httpGet:
+            path: /ready
+            port: 8086
+            scheme: HTTP
+          periodSeconds: 5
+          successThreshold: 1
+          timeoutSeconds: 15
+        resources:
+          limits:
+            cpu: 500m
+            memory: 512Mi
+          requests:
+            cpu: 25m
+            memory: 32Mi
+        volumeMounts:
+        - mountPath: /etc/kubernetes/kubeconfig
+          name: internal-admin-kubeconfig
+          readOnly: true
+        - mountPath: /http-prober-bin
+          name: http-prober-bin
+      imagePullSecrets:
+      - name: dockercfg
+      initContainers:
+      - command:
+        - /bin/cp
+        - /usr/local/bin/http-prober
+        - /http-prober-bin/http-prober
+        image: quay.io/kubermatic/http-prober:v0.3.1
+        name: copy-http-prober
+        resources: {}
+        volumeMounts:
+        - mountPath: /http-prober-bin
+          name: http-prober-bin
+      serviceAccountName: kubermatic-usercluster-controller-manager
+      volumes:
+      - name: internal-admin-kubeconfig
+        secret:
+          secretName: internal-admin-kubeconfig
+      - emptyDir: {}
+        name: http-prober-bin
+status: {}

--- a/pkg/resources/test/fixtures/deployment-bringyourown-1.17.0-apiserver.yaml
+++ b/pkg/resources/test/fixtures/deployment-bringyourown-1.17.0-apiserver.yaml
@@ -202,12 +202,12 @@ spec:
         - X-Remote-Group
         - --requestheader-username-headers
         - X-Remote-User
+        - --service-account-issuer
+        - https://jh8j81chn.europe-west3-c.dev.kubermatic.io:30000
         - --service-account-signing-key-file
         - /etc/kubernetes/service-account-key/sa.key
-        - --service-account-issuer
-        - kubernetes.default.svc
         - --api-audiences
-        - kubernetes.default.svc
+        - https://jh8j81chn.europe-west3-c.dev.kubermatic.io:30000
         - --kubelet-preferred-address-types
         - ExternalIP,InternalIP
         - --oidc-issuer-url

--- a/pkg/resources/test/fixtures/deployment-bringyourown-1.17.0-usercluster-controller.yaml
+++ b/pkg/resources/test/fixtures/deployment-bringyourown-1.17.0-usercluster-controller.yaml
@@ -39,7 +39,7 @@ spec:
         - -timeout
         - "1"
         - -command
-        - '{"command":"/usr/local/bin/user-cluster-controller-manager","args":["-kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","-metrics-listen-address","0.0.0.0:8085","-health-listen-address","0.0.0.0:8086","-namespace","$(NAMESPACE)","-cluster-url","","-dns-cluster-ip","10.240.16.10","-openvpn-server-port","30003","-overwrite-registry","","-openshift=false","-version","1.17.0","-cloud-provider-name","","-owner-email","","-opa-integration=false","--ipam-controller-network","192.168.1.1/24,192.168.1.1,8.8.8.8","-node-labels","{\"my-label\":\"my-value\"}"]}'
+        - '{"command":"/usr/local/bin/user-cluster-controller-manager","args":["-kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","-metrics-listen-address","0.0.0.0:8085","-health-listen-address","0.0.0.0:8086","-namespace","$(NAMESPACE)","-cluster-url","https://jh8j81chn.europe-west3-c.dev.kubermatic.io:30000","-dns-cluster-ip","10.240.16.10","-openvpn-server-port","30003","-overwrite-registry","","-openshift=false","-version","1.17.0","-cloud-provider-name","","-owner-email","","-opa-integration=false","--ipam-controller-network","192.168.1.1/24,192.168.1.1,8.8.8.8","-node-labels","{\"my-label\":\"my-value\"}"]}'
         command:
         - /http-prober-bin/http-prober
         env:

--- a/pkg/resources/test/fixtures/deployment-bringyourown-1.18.0-apiserver.yaml
+++ b/pkg/resources/test/fixtures/deployment-bringyourown-1.18.0-apiserver.yaml
@@ -202,12 +202,12 @@ spec:
         - X-Remote-Group
         - --requestheader-username-headers
         - X-Remote-User
+        - --service-account-issuer
+        - https://jh8j81chn.europe-west3-c.dev.kubermatic.io:30000
         - --service-account-signing-key-file
         - /etc/kubernetes/service-account-key/sa.key
-        - --service-account-issuer
-        - kubernetes.default.svc
         - --api-audiences
-        - kubernetes.default.svc
+        - https://jh8j81chn.europe-west3-c.dev.kubermatic.io:30000
         - --kubelet-preferred-address-types
         - ExternalIP,InternalIP
         - --oidc-issuer-url

--- a/pkg/resources/test/fixtures/deployment-bringyourown-1.18.0-usercluster-controller.yaml
+++ b/pkg/resources/test/fixtures/deployment-bringyourown-1.18.0-usercluster-controller.yaml
@@ -39,7 +39,7 @@ spec:
         - -timeout
         - "1"
         - -command
-        - '{"command":"/usr/local/bin/user-cluster-controller-manager","args":["-kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","-metrics-listen-address","0.0.0.0:8085","-health-listen-address","0.0.0.0:8086","-namespace","$(NAMESPACE)","-cluster-url","","-dns-cluster-ip","10.240.16.10","-openvpn-server-port","30003","-overwrite-registry","","-openshift=false","-version","1.18.0","-cloud-provider-name","","-owner-email","","-opa-integration=false","--ipam-controller-network","192.168.1.1/24,192.168.1.1,8.8.8.8","-node-labels","{\"my-label\":\"my-value\"}"]}'
+        - '{"command":"/usr/local/bin/user-cluster-controller-manager","args":["-kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","-metrics-listen-address","0.0.0.0:8085","-health-listen-address","0.0.0.0:8086","-namespace","$(NAMESPACE)","-cluster-url","https://jh8j81chn.europe-west3-c.dev.kubermatic.io:30000","-dns-cluster-ip","10.240.16.10","-openvpn-server-port","30003","-overwrite-registry","","-openshift=false","-version","1.18.0","-cloud-provider-name","","-owner-email","","-opa-integration=false","--ipam-controller-network","192.168.1.1/24,192.168.1.1,8.8.8.8","-node-labels","{\"my-label\":\"my-value\"}"]}'
         command:
         - /http-prober-bin/http-prober
         env:

--- a/pkg/resources/test/fixtures/deployment-bringyourown-1.19.0-apiserver.yaml
+++ b/pkg/resources/test/fixtures/deployment-bringyourown-1.19.0-apiserver.yaml
@@ -202,12 +202,12 @@ spec:
         - X-Remote-Group
         - --requestheader-username-headers
         - X-Remote-User
+        - --service-account-issuer
+        - https://jh8j81chn.europe-west3-c.dev.kubermatic.io:30000
         - --service-account-signing-key-file
         - /etc/kubernetes/service-account-key/sa.key
-        - --service-account-issuer
-        - kubernetes.default.svc
         - --api-audiences
-        - kubernetes.default.svc
+        - https://jh8j81chn.europe-west3-c.dev.kubermatic.io:30000
         - --kubelet-preferred-address-types
         - ExternalIP,InternalIP
         - --oidc-issuer-url

--- a/pkg/resources/test/fixtures/deployment-bringyourown-1.19.0-usercluster-controller.yaml
+++ b/pkg/resources/test/fixtures/deployment-bringyourown-1.19.0-usercluster-controller.yaml
@@ -39,7 +39,7 @@ spec:
         - -timeout
         - "1"
         - -command
-        - '{"command":"/usr/local/bin/user-cluster-controller-manager","args":["-kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","-metrics-listen-address","0.0.0.0:8085","-health-listen-address","0.0.0.0:8086","-namespace","$(NAMESPACE)","-cluster-url","","-dns-cluster-ip","10.240.16.10","-openvpn-server-port","30003","-overwrite-registry","","-openshift=false","-version","1.19.0","-cloud-provider-name","","-owner-email","","-opa-integration=false","--ipam-controller-network","192.168.1.1/24,192.168.1.1,8.8.8.8","-node-labels","{\"my-label\":\"my-value\"}"]}'
+        - '{"command":"/usr/local/bin/user-cluster-controller-manager","args":["-kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","-metrics-listen-address","0.0.0.0:8085","-health-listen-address","0.0.0.0:8086","-namespace","$(NAMESPACE)","-cluster-url","https://jh8j81chn.europe-west3-c.dev.kubermatic.io:30000","-dns-cluster-ip","10.240.16.10","-openvpn-server-port","30003","-overwrite-registry","","-openshift=false","-version","1.19.0","-cloud-provider-name","","-owner-email","","-opa-integration=false","--ipam-controller-network","192.168.1.1/24,192.168.1.1,8.8.8.8","-node-labels","{\"my-label\":\"my-value\"}"]}'
         command:
         - /http-prober-bin/http-prober
         env:

--- a/pkg/resources/test/fixtures/deployment-bringyourown-1.20.0-apiserver.yaml
+++ b/pkg/resources/test/fixtures/deployment-bringyourown-1.20.0-apiserver.yaml
@@ -1,0 +1,402 @@
+# This file has been generated, DO NOT EDIT.
+
+metadata:
+  creationTimestamp: null
+  labels:
+    app: apiserver
+  name: apiserver
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: apiserver
+  strategy: {}
+  template:
+    metadata:
+      annotations:
+        prometheus.io/path: /metrics
+        prometheus.io/port: "30000"
+        prometheus.io/scrape_with_kube_cert: "true"
+      creationTimestamp: null
+      labels:
+        adm-control-configmap-revision: "123456"
+        apiserver-etcd-client-certificate-secret-revision: "123456"
+        apiserver-proxy-client-certificate-secret-revision: "123456"
+        apiserver-tls-secret-revision: "123456"
+        app: apiserver
+        audit-config-configmap-revision: "123456"
+        ca-secret-revision: "123456"
+        cloud-config-configmap-revision: "123456"
+        cluster: de-test-01
+        dex-ca-secret-revision: "123456"
+        front-proxy-ca-secret-revision: "123456"
+        kubelet-client-certificates-secret-revision: "123456"
+        kubeletdnatcontroller-kubeconfig-secret-revision: "123456"
+        openvpn-client-certificates-secret-revision: "123456"
+        service-account-key-secret-revision: "123456"
+        tokens-secret-revision: "123456"
+    spec:
+      affinity:
+        podAntiAffinity:
+          preferredDuringSchedulingIgnoredDuringExecution:
+          - podAffinityTerm:
+              labelSelector:
+                matchLabels:
+                  app: apiserver
+                  cluster: de-test-01
+              topologyKey: kubernetes.io/hostname
+            weight: 100
+          - podAffinityTerm:
+              labelSelector:
+                matchLabels:
+                  app: apiserver
+              topologyKey: kubernetes.io/hostname
+            weight: 10
+      containers:
+      - args:
+        - --client
+        - --proto
+        - tcp
+        - --dev
+        - tun
+        - --auth-nocache
+        - --remote
+        - openvpn-server.cluster-de-test-01.svc.cluster.local.
+        - "1194"
+        - --nobind
+        - --connect-timeout
+        - "5"
+        - --connect-retry
+        - "1"
+        - --ca
+        - /etc/openvpn/pki/client/ca.crt
+        - --cert
+        - /etc/openvpn/pki/client/client.crt
+        - --key
+        - /etc/openvpn/pki/client/client.key
+        - --remote-cert-tls
+        - server
+        - --link-mtu
+        - "1432"
+        - --cipher
+        - AES-256-GCM
+        - --auth
+        - SHA1
+        - --keysize
+        - "256"
+        - --script-security
+        - "2"
+        - --status
+        - /run/openvpn-status
+        - --log
+        - /dev/stdout
+        command:
+        - /usr/sbin/openvpn
+        image: quay.io/kubermatic/openvpn:v2.4.8-r1
+        name: openvpn-client
+        resources:
+          limits:
+            cpu: 100m
+            memory: 32Mi
+          requests:
+            cpu: 5m
+            memory: 5Mi
+        securityContext:
+          privileged: true
+        volumeMounts:
+        - mountPath: /etc/openvpn/pki/client
+          name: openvpn-client-certificates
+          readOnly: true
+      - args:
+        - -kubeconfig
+        - /etc/kubernetes/kubeconfig/kubeconfig
+        - -node-access-network
+        - 192.0.2.0/24
+        - -master
+        - https://127.0.0.1:30000
+        command:
+        - /usr/local/bin/kubeletdnat-controller
+        image: quay.io/kubermatic/kubeletdnat-controller:v0.0.0-test
+        name: dnat-controller
+        resources:
+          limits:
+            cpu: 100m
+            memory: 512Mi
+          requests:
+            cpu: 5m
+            memory: 16Mi
+        securityContext:
+          capabilities:
+            add:
+            - NET_ADMIN
+          procMount: Default
+          runAsUser: 0
+        volumeMounts:
+        - mountPath: /etc/kubernetes/kubeconfig
+          name: kubeletdnatcontroller-kubeconfig
+          readOnly: true
+      - args:
+        - --advertise-address
+        - 35.198.93.90
+        - --secure-port
+        - "30000"
+        - --kubernetes-service-node-port
+        - "30000"
+        - --etcd-servers
+        - https://etcd-0.etcd.cluster-de-test-01.svc.cluster.local.:2379,https://etcd-1.etcd.cluster-de-test-01.svc.cluster.local.:2379,https://etcd-2.etcd.cluster-de-test-01.svc.cluster.local.:2379
+        - --etcd-cafile
+        - /etc/etcd/pki/client/ca.crt
+        - --etcd-certfile
+        - /etc/etcd/pki/client/apiserver-etcd-client.crt
+        - --etcd-keyfile
+        - /etc/etcd/pki/client/apiserver-etcd-client.key
+        - --storage-backend
+        - etcd3
+        - --enable-admission-plugins
+        - DefaultStorageClass,DefaultTolerationSeconds,LimitRanger,MutatingAdmissionWebhook,NamespaceLifecycle,Priority,ResourceQuota,ServiceAccount,ValidatingAdmissionWebhook
+        - --admission-control-config-file
+        - /etc/kubernetes/adm-control/admission-control.yaml
+        - --authorization-mode
+        - Node,RBAC
+        - --external-hostname
+        - jh8j81chn.europe-west3-c.dev.kubermatic.io
+        - --token-auth-file
+        - /etc/kubernetes/tokens/tokens.csv
+        - --enable-bootstrap-token-auth
+        - --service-account-key-file
+        - /etc/kubernetes/service-account-key/sa.key
+        - --service-cluster-ip-range
+        - 10.240.16.0/20
+        - --service-node-port-range
+        - 30000-32767
+        - --allow-privileged
+        - --audit-log-maxage
+        - "30"
+        - --audit-log-maxbackup
+        - "3"
+        - --audit-log-maxsize
+        - "100"
+        - --audit-log-path
+        - /var/log/kubernetes/audit/audit.log
+        - --tls-cert-file
+        - /etc/kubernetes/tls/apiserver-tls.crt
+        - --tls-private-key-file
+        - /etc/kubernetes/tls/apiserver-tls.key
+        - --proxy-client-cert-file
+        - /etc/kubernetes/pki/front-proxy/client/apiserver-proxy-client.crt
+        - --proxy-client-key-file
+        - /etc/kubernetes/pki/front-proxy/client/apiserver-proxy-client.key
+        - --client-ca-file
+        - /etc/kubernetes/pki/ca/ca.crt
+        - --kubelet-client-certificate
+        - /etc/kubernetes/kubelet/kubelet-client.crt
+        - --kubelet-client-key
+        - /etc/kubernetes/kubelet/kubelet-client.key
+        - --requestheader-client-ca-file
+        - /etc/kubernetes/pki/front-proxy/ca/ca.crt
+        - --requestheader-allowed-names
+        - apiserver-aggregator
+        - --requestheader-extra-headers-prefix
+        - X-Remote-Extra-
+        - --requestheader-group-headers
+        - X-Remote-Group
+        - --requestheader-username-headers
+        - X-Remote-User
+        - --service-account-issuer
+        - https://jh8j81chn.europe-west3-c.dev.kubermatic.io:30000
+        - --service-account-signing-key-file
+        - /etc/kubernetes/service-account-key/sa.key
+        - --api-audiences
+        - https://jh8j81chn.europe-west3-c.dev.kubermatic.io:30000
+        - --kubelet-preferred-address-types
+        - ExternalIP,InternalIP
+        - --oidc-issuer-url
+        - https://dev.kubermatic.io/dex
+        - --oidc-client-id
+        - kubermaticIssuer
+        - --oidc-username-claim
+        - email
+        - --oidc-groups-prefix
+        - 'oidc:'
+        - --oidc-groups-claim
+        - groups
+        - --oidc-ca-file
+        - /etc/kubernetes/dex/ca/caBundle.pem
+        command:
+        - /usr/local/bin/kube-apiserver
+        env:
+        - name: HTTP_PROXY
+          value: http://my-corp
+        - name: HTTPS_PROXY
+          value: http://my-corp
+        - name: http_proxy
+          value: http://my-corp
+        - name: https_proxy
+          value: http://my-corp
+        - name: NO_PROXY
+          value: apiserver-external.cluster-de-test-01.svc.cluster.local.
+        - name: no_proxy
+          value: apiserver-external.cluster-de-test-01.svc.cluster.local.
+        image: k8s.gcr.io/kube-apiserver:v1.20.0
+        livenessProbe:
+          failureThreshold: 8
+          httpGet:
+            path: /healthz
+            port: 30000
+            scheme: HTTPS
+          initialDelaySeconds: 15
+          periodSeconds: 10
+          successThreshold: 1
+          timeoutSeconds: 15
+        name: apiserver
+        ports:
+        - containerPort: 30000
+          protocol: TCP
+        readinessProbe:
+          failureThreshold: 3
+          httpGet:
+            path: /healthz
+            port: 30000
+            scheme: HTTPS
+          periodSeconds: 5
+          successThreshold: 1
+          timeoutSeconds: 15
+        resources:
+          limits:
+            cpu: "2"
+            memory: 4Gi
+          requests:
+            cpu: 100m
+            memory: 256Mi
+        volumeMounts:
+        - mountPath: /etc/kubernetes/tls
+          name: apiserver-tls
+          readOnly: true
+        - mountPath: /etc/kubernetes/tokens
+          name: tokens
+          readOnly: true
+        - mountPath: /etc/kubernetes/kubelet
+          name: kubelet-client-certificates
+          readOnly: true
+        - mountPath: /etc/kubernetes/pki/ca
+          name: ca
+          readOnly: true
+        - mountPath: /etc/kubernetes/service-account-key
+          name: service-account-key
+          readOnly: true
+        - mountPath: /etc/kubernetes/cloud
+          name: cloud-config
+          readOnly: true
+        - mountPath: /etc/etcd/pki/client
+          name: apiserver-etcd-client-certificate
+          readOnly: true
+        - mountPath: /etc/kubernetes/pki/front-proxy/client
+          name: apiserver-proxy-client-certificate
+          readOnly: true
+        - mountPath: /etc/kubernetes/pki/front-proxy/ca
+          name: front-proxy-ca
+          readOnly: true
+        - mountPath: /etc/kubernetes/audit
+          name: audit-config
+          readOnly: true
+        - mountPath: /var/log/kubernetes/audit
+          name: audit-log
+        - mountPath: /etc/kubernetes/adm-control
+          name: adm-control
+          readOnly: true
+        - mountPath: /etc/ssl/certs
+          name: ca-certs
+          readOnly: true
+        - mountPath: /usr/share/ca-certificates
+          name: usr-share-ca-certificates
+          readOnly: true
+        - mountPath: /etc/kubernetes/dex/ca
+          name: dex-ca
+          readOnly: true
+      dnsConfig:
+        nameservers:
+        - 192.0.2.14
+        options:
+        - name: ndots
+          value: "5"
+        searches:
+        - kube-system.svc.cluster.local
+        - svc.cluster.local
+        - cluster.local
+      dnsPolicy: None
+      imagePullSecrets:
+      - name: dockercfg
+      initContainers:
+      - command:
+        - /bin/sh
+        - -ec
+        - until ETCDCTL_API=3 /usr/local/bin/etcdctl --cacert=/etc/etcd/pki/client/ca.crt
+          --cert=/etc/etcd/pki/client/apiserver-etcd-client.crt --key=/etc/etcd/pki/client/apiserver-etcd-client.key
+          --dial-timeout=2s --endpoints='https://etcd-0.etcd.cluster-de-test-01.svc.cluster.local.:2379,https://etcd-1.etcd.cluster-de-test-01.svc.cluster.local.:2379,https://etcd-2.etcd.cluster-de-test-01.svc.cluster.local.:2379'
+          put kubermatic/quorum-check something; do echo waiting for etcd; sleep 2;
+          done;
+        image: gcr.io/etcd-development/etcd:v3.4.3
+        name: etcd-running
+        resources: {}
+        volumeMounts:
+        - mountPath: /etc/etcd/pki/client
+          name: apiserver-etcd-client-certificate
+          readOnly: true
+      volumes:
+      - name: apiserver-tls
+        secret:
+          secretName: apiserver-tls
+      - name: tokens
+        secret:
+          secretName: tokens
+      - name: openvpn-client-certificates
+        secret:
+          secretName: openvpn-client-certificates
+      - name: kubelet-client-certificates
+        secret:
+          secretName: kubelet-client-certificates
+      - name: ca
+        secret:
+          items:
+          - key: ca.crt
+            path: ca.crt
+          secretName: ca
+      - name: service-account-key
+        secret:
+          secretName: service-account-key
+      - configMap:
+          name: cloud-config
+        name: cloud-config
+      - name: apiserver-etcd-client-certificate
+        secret:
+          secretName: apiserver-etcd-client-certificate
+      - name: apiserver-proxy-client-certificate
+        secret:
+          secretName: apiserver-proxy-client-certificate
+      - name: front-proxy-ca
+        secret:
+          secretName: front-proxy-ca
+      - name: kubeletdnatcontroller-kubeconfig
+        secret:
+          secretName: kubeletdnatcontroller-kubeconfig
+      - configMap:
+          name: audit-config
+          optional: false
+        name: audit-config
+      - emptyDir: {}
+        name: audit-log
+      - configMap:
+          name: adm-control
+        name: adm-control
+      - hostPath:
+          path: /etc/ssl/certs
+          type: DirectoryOrCreate
+        name: ca-certs
+      - hostPath:
+          path: /usr/share/ca-certificates
+          type: DirectoryOrCreate
+        name: usr-share-ca-certificates
+      - name: dex-ca
+        secret:
+          secretName: dex-ca
+status: {}

--- a/pkg/resources/test/fixtures/deployment-bringyourown-1.20.0-controller-manager.yaml
+++ b/pkg/resources/test/fixtures/deployment-bringyourown-1.20.0-controller-manager.yaml
@@ -1,0 +1,227 @@
+# This file has been generated, DO NOT EDIT.
+
+metadata:
+  creationTimestamp: null
+  labels:
+    app: controller-manager
+  name: controller-manager
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: controller-manager
+  strategy: {}
+  template:
+    metadata:
+      annotations:
+        prometheus.io/path: /metrics
+        prometheus.io/port: "10257"
+        prometheus.io/scrape_with_kube_cert: "true"
+      creationTimestamp: null
+      labels:
+        app: controller-manager
+        ca-secret-revision: "123456"
+        cloud-config-configmap-revision: "123456"
+        cluster: de-test-01
+        controllermanager-kubeconfig-secret-revision: "123456"
+        openvpn-client-certificates-secret-revision: "123456"
+        service-account-key-secret-revision: "123456"
+    spec:
+      affinity:
+        podAntiAffinity:
+          preferredDuringSchedulingIgnoredDuringExecution:
+          - podAffinityTerm:
+              labelSelector:
+                matchLabels:
+                  app: controller-manager
+                  cluster: de-test-01
+              topologyKey: kubernetes.io/hostname
+            weight: 100
+          - podAffinityTerm:
+              labelSelector:
+                matchLabels:
+                  app: controller-manager
+              topologyKey: kubernetes.io/hostname
+            weight: 10
+      containers:
+      - args:
+        - --client
+        - --proto
+        - tcp
+        - --dev
+        - tun
+        - --auth-nocache
+        - --remote
+        - openvpn-server.cluster-de-test-01.svc.cluster.local.
+        - "1194"
+        - --nobind
+        - --connect-timeout
+        - "5"
+        - --connect-retry
+        - "1"
+        - --ca
+        - /etc/openvpn/pki/client/ca.crt
+        - --cert
+        - /etc/openvpn/pki/client/client.crt
+        - --key
+        - /etc/openvpn/pki/client/client.key
+        - --remote-cert-tls
+        - server
+        - --link-mtu
+        - "1432"
+        - --cipher
+        - AES-256-GCM
+        - --auth
+        - SHA1
+        - --keysize
+        - "256"
+        - --script-security
+        - "2"
+        - --status
+        - /run/openvpn-status
+        - --log
+        - /dev/stdout
+        command:
+        - /usr/sbin/openvpn
+        image: quay.io/kubermatic/openvpn:v2.4.8-r1
+        name: openvpn-client
+        resources:
+          limits:
+            cpu: 100m
+            memory: 32Mi
+          requests:
+            cpu: 5m
+            memory: 5Mi
+        securityContext:
+          privileged: true
+        volumeMounts:
+        - mountPath: /etc/openvpn/pki/client
+          name: openvpn-client-certificates
+          readOnly: true
+      - args:
+        - -endpoint
+        - https://apiserver-external.cluster-de-test-01.svc.cluster.local./healthz
+        - -insecure
+        - -retries
+        - "100"
+        - -retry-wait
+        - "2"
+        - -timeout
+        - "1"
+        - -command
+        - '{"command":"/usr/local/bin/kube-controller-manager","args":["--kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","--service-account-private-key-file","/etc/kubernetes/service-account-key/sa.key","--root-ca-file","/etc/kubernetes/pki/ca/ca.crt","--cluster-signing-cert-file","/etc/kubernetes/pki/ca/ca.crt","--cluster-signing-key-file","/etc/kubernetes/pki/ca/ca.key","--cluster-cidr","172.25.0.0/16","--allocate-node-cidrs","--controllers","*,bootstrapsigner,tokencleaner","--use-service-account-credentials","--feature-gates","RotateKubeletClientCertificate=true,RotateKubeletServerCertificate=true","--authentication-kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","--client-ca-file","/etc/kubernetes/pki/ca/ca.crt","--authentication-kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","--authorization-kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","--port","0"]}'
+        command:
+        - /http-prober-bin/http-prober
+        env:
+        - name: HTTP_PROXY
+          value: http://my-corp
+        - name: HTTPS_PROXY
+          value: http://my-corp
+        - name: http_proxy
+          value: http://my-corp
+        - name: https_proxy
+          value: http://my-corp
+        - name: NO_PROXY
+          value: apiserver-external.cluster-de-test-01.svc.cluster.local.
+        - name: no_proxy
+          value: apiserver-external.cluster-de-test-01.svc.cluster.local.
+        image: k8s.gcr.io/kube-controller-manager:v1.20.0
+        livenessProbe:
+          failureThreshold: 8
+          httpGet:
+            path: /healthz
+            port: 10257
+            scheme: HTTPS
+          initialDelaySeconds: 15
+          periodSeconds: 10
+          successThreshold: 1
+          timeoutSeconds: 15
+        name: controller-manager
+        readinessProbe:
+          failureThreshold: 3
+          httpGet:
+            path: /healthz
+            port: 10257
+            scheme: HTTPS
+          periodSeconds: 10
+          successThreshold: 1
+          timeoutSeconds: 15
+        resources:
+          limits:
+            cpu: "2"
+            memory: 2Gi
+          requests:
+            cpu: 100m
+            memory: 100Mi
+        volumeMounts:
+        - mountPath: /etc/kubernetes/pki/ca
+          name: ca
+          readOnly: true
+        - mountPath: /etc/kubernetes/service-account-key
+          name: service-account-key
+          readOnly: true
+        - mountPath: /etc/kubernetes/cloud
+          name: cloud-config
+          readOnly: true
+        - mountPath: /etc/kubernetes/kubeconfig
+          name: controllermanager-kubeconfig
+          readOnly: true
+        - mountPath: /etc/ssl/certs
+          name: ca-certs
+          readOnly: true
+        - mountPath: /usr/share/ca-certificates
+          name: usr-share-ca-certificates
+          readOnly: true
+        - mountPath: /http-prober-bin
+          name: http-prober-bin
+      dnsConfig:
+        nameservers:
+        - 192.0.2.14
+        options:
+        - name: ndots
+          value: "5"
+        searches:
+        - kube-system.svc.cluster.local
+        - svc.cluster.local
+        - cluster.local
+      dnsPolicy: None
+      imagePullSecrets:
+      - name: dockercfg
+      initContainers:
+      - command:
+        - /bin/cp
+        - /usr/local/bin/http-prober
+        - /http-prober-bin/http-prober
+        image: quay.io/kubermatic/http-prober:v0.3.1
+        name: copy-http-prober
+        resources: {}
+        volumeMounts:
+        - mountPath: /http-prober-bin
+          name: http-prober-bin
+      volumes:
+      - name: ca
+        secret:
+          secretName: ca
+      - name: service-account-key
+        secret:
+          secretName: service-account-key
+      - configMap:
+          name: cloud-config
+        name: cloud-config
+      - name: openvpn-client-certificates
+        secret:
+          secretName: openvpn-client-certificates
+      - name: controllermanager-kubeconfig
+        secret:
+          secretName: controllermanager-kubeconfig
+      - hostPath:
+          path: /etc/ssl/certs
+          type: DirectoryOrCreate
+        name: ca-certs
+      - hostPath:
+          path: /usr/share/ca-certificates
+          type: DirectoryOrCreate
+        name: usr-share-ca-certificates
+      - emptyDir: {}
+        name: http-prober-bin
+status: {}

--- a/pkg/resources/test/fixtures/deployment-bringyourown-1.20.0-dns-resolver.yaml
+++ b/pkg/resources/test/fixtures/deployment-bringyourown-1.20.0-dns-resolver.yaml
@@ -1,0 +1,140 @@
+# This file has been generated, DO NOT EDIT.
+
+metadata:
+  creationTimestamp: null
+  labels:
+    app: dns-resolver
+  name: dns-resolver
+spec:
+  replicas: 2
+  selector:
+    matchLabels:
+      app: dns-resolver
+  strategy: {}
+  template:
+    metadata:
+      annotations:
+        prometheus.io/path: /metrics
+        prometheus.io/port: "9253"
+        prometheus.io/scrape: "true"
+      creationTimestamp: null
+      labels:
+        app: dns-resolver
+        ca-secret-revision: "123456"
+        cluster: de-test-01
+        dns-resolver-configmap-revision: "123456"
+        openvpn-client-certificates-secret-revision: "123456"
+    spec:
+      affinity:
+        podAntiAffinity:
+          preferredDuringSchedulingIgnoredDuringExecution:
+          - podAffinityTerm:
+              labelSelector:
+                matchLabels:
+                  app: dns-resolver
+                  cluster: de-test-01
+              topologyKey: kubernetes.io/hostname
+            weight: 100
+          - podAffinityTerm:
+              labelSelector:
+                matchLabels:
+                  app: dns-resolver
+              topologyKey: kubernetes.io/hostname
+            weight: 10
+      containers:
+      - args:
+        - --client
+        - --proto
+        - tcp
+        - --dev
+        - tun
+        - --auth-nocache
+        - --remote
+        - openvpn-server.cluster-de-test-01.svc.cluster.local.
+        - "1194"
+        - --nobind
+        - --connect-timeout
+        - "5"
+        - --connect-retry
+        - "1"
+        - --ca
+        - /etc/openvpn/pki/client/ca.crt
+        - --cert
+        - /etc/openvpn/pki/client/client.crt
+        - --key
+        - /etc/openvpn/pki/client/client.key
+        - --remote-cert-tls
+        - server
+        - --link-mtu
+        - "1432"
+        - --cipher
+        - AES-256-GCM
+        - --auth
+        - SHA1
+        - --keysize
+        - "256"
+        - --script-security
+        - "2"
+        - --status
+        - /run/openvpn-status
+        - --log
+        - /dev/stdout
+        command:
+        - /usr/sbin/openvpn
+        image: quay.io/kubermatic/openvpn:v2.4.8-r1
+        name: openvpn-client
+        resources:
+          limits:
+            cpu: 100m
+            memory: 32Mi
+          requests:
+            cpu: 5m
+            memory: 5Mi
+        securityContext:
+          privileged: true
+        volumeMounts:
+        - mountPath: /etc/openvpn/pki/client
+          name: openvpn-client-certificates
+          readOnly: true
+      - args:
+        - -conf
+        - /etc/coredns/Corefile
+        image: k8s.gcr.io/coredns:1.3.1
+        name: dns-resolver
+        readinessProbe:
+          failureThreshold: 3
+          httpGet:
+            path: /health
+            port: 8080
+            scheme: HTTP
+          initialDelaySeconds: 2
+          periodSeconds: 10
+          successThreshold: 1
+          timeoutSeconds: 15
+        resources:
+          limits:
+            cpu: 100m
+            memory: 128Mi
+          requests:
+            cpu: 5m
+            memory: 20Mi
+        volumeMounts:
+        - mountPath: /etc/coredns
+          name: dns-resolver
+          readOnly: true
+      imagePullSecrets:
+      - name: dockercfg
+      volumes:
+      - configMap:
+          name: dns-resolver
+        name: dns-resolver
+      - name: openvpn-client-certificates
+        secret:
+          secretName: openvpn-client-certificates
+      - name: ca
+        secret:
+          items:
+          - key: ca.crt
+            path: ca.crt
+          secretName: ca
+status: {}

--- a/pkg/resources/test/fixtures/deployment-bringyourown-1.20.0-kube-state-metrics.yaml
+++ b/pkg/resources/test/fixtures/deployment-bringyourown-1.20.0-kube-state-metrics.yaml
@@ -1,0 +1,89 @@
+# This file has been generated, DO NOT EDIT.
+
+metadata:
+  creationTimestamp: null
+  labels:
+    app: kube-state-metrics
+  name: kube-state-metrics
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: kube-state-metrics
+  strategy: {}
+  template:
+    metadata:
+      annotations:
+        prometheus.io/scrape: "true"
+      creationTimestamp: null
+      labels:
+        app: kube-state-metrics
+        cluster: de-test-01
+        kube-state-metrics-kubeconfig-secret-revision: "123456"
+    spec:
+      containers:
+      - args:
+        - -endpoint
+        - https://apiserver-external.cluster-de-test-01.svc.cluster.local./healthz
+        - -insecure
+        - -retries
+        - "100"
+        - -retry-wait
+        - "2"
+        - -timeout
+        - "1"
+        - -command
+        - '{"command":"/kube-state-metrics","args":["--kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","--port","8080","--telemetry-port","8081"]}'
+        command:
+        - /http-prober-bin/http-prober
+        image: quay.io/coreos/kube-state-metrics:v1.9.7
+        name: kube-state-metrics
+        ports:
+        - containerPort: 8080
+          name: metrics
+          protocol: TCP
+        - containerPort: 8081
+          name: telemetry
+          protocol: TCP
+        readinessProbe:
+          failureThreshold: 3
+          httpGet:
+            path: /healthz
+            port: 8080
+            scheme: HTTP
+          periodSeconds: 10
+          successThreshold: 1
+          timeoutSeconds: 15
+        resources:
+          limits:
+            cpu: 100m
+            memory: 1Gi
+          requests:
+            cpu: 10m
+            memory: 12Mi
+        volumeMounts:
+        - mountPath: /etc/kubernetes/kubeconfig
+          name: kube-state-metrics-kubeconfig
+          readOnly: true
+        - mountPath: /http-prober-bin
+          name: http-prober-bin
+      imagePullSecrets:
+      - name: dockercfg
+      initContainers:
+      - command:
+        - /bin/cp
+        - /usr/local/bin/http-prober
+        - /http-prober-bin/http-prober
+        image: quay.io/kubermatic/http-prober:v0.3.1
+        name: copy-http-prober
+        resources: {}
+        volumeMounts:
+        - mountPath: /http-prober-bin
+          name: http-prober-bin
+      volumes:
+      - name: kube-state-metrics-kubeconfig
+        secret:
+          secretName: kube-state-metrics-kubeconfig
+      - emptyDir: {}
+        name: http-prober-bin
+status: {}

--- a/pkg/resources/test/fixtures/deployment-bringyourown-1.20.0-kubernetes-dashboard.yaml
+++ b/pkg/resources/test/fixtures/deployment-bringyourown-1.20.0-kubernetes-dashboard.yaml
@@ -1,0 +1,97 @@
+# This file has been generated, DO NOT EDIT.
+
+metadata:
+  creationTimestamp: null
+  labels:
+    app: kubernetes-dashboard
+  name: kubernetes-dashboard
+spec:
+  replicas: 2
+  selector:
+    matchLabels:
+      app: kubernetes-dashboard
+  strategy: {}
+  template:
+    metadata:
+      creationTimestamp: null
+      labels:
+        app: kubernetes-dashboard
+        cluster: de-test-01
+        kubernetes-dashboard-kubeconfig-secret-revision: "123456"
+    spec:
+      affinity:
+        podAntiAffinity:
+          preferredDuringSchedulingIgnoredDuringExecution:
+          - podAffinityTerm:
+              labelSelector:
+                matchLabels:
+                  app: kubernetes-dashboard
+                  cluster: de-test-01
+              topologyKey: kubernetes.io/hostname
+            weight: 100
+          - podAffinityTerm:
+              labelSelector:
+                matchLabels:
+                  app: kubernetes-dashboard
+              topologyKey: kubernetes.io/hostname
+            weight: 10
+      containers:
+      - args:
+        - -endpoint
+        - https://apiserver-external.cluster-de-test-01.svc.cluster.local./healthz
+        - -insecure
+        - -retries
+        - "100"
+        - -retry-wait
+        - "2"
+        - -timeout
+        - "1"
+        - -command
+        - '{"command":"/dashboard","args":["--kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","--namespace","kubernetes-dashboard","--enable-insecure-login"]}'
+        command:
+        - /http-prober-bin/http-prober
+        image: docker.io/kubernetesui/dashboard:v2.0.4
+        imagePullPolicy: IfNotPresent
+        name: kubernetes-dashboard
+        ports:
+        - containerPort: 9090
+          protocol: TCP
+        resources:
+          limits:
+            cpu: 250m
+            memory: 512Mi
+          requests:
+            cpu: 100m
+            memory: 256Mi
+        securityContext:
+          allowPrivilegeEscalation: false
+          readOnlyRootFilesystem: true
+          runAsUser: 1001
+        volumeMounts:
+        - mountPath: /etc/kubernetes/kubeconfig
+          name: kubernetes-dashboard-kubeconfig
+          readOnly: true
+        - mountPath: /tmp
+          name: tmp-volume
+        - mountPath: /http-prober-bin
+          name: http-prober-bin
+      initContainers:
+      - command:
+        - /bin/cp
+        - /usr/local/bin/http-prober
+        - /http-prober-bin/http-prober
+        image: quay.io/kubermatic/http-prober:v0.3.1
+        name: copy-http-prober
+        resources: {}
+        volumeMounts:
+        - mountPath: /http-prober-bin
+          name: http-prober-bin
+      volumes:
+      - name: kubernetes-dashboard-kubeconfig
+        secret:
+          secretName: kubernetes-dashboard-kubeconfig
+      - emptyDir: {}
+        name: tmp-volume
+      - emptyDir: {}
+        name: http-prober-bin
+status: {}

--- a/pkg/resources/test/fixtures/deployment-bringyourown-1.20.0-machine-controller-webhook.yaml
+++ b/pkg/resources/test/fixtures/deployment-bringyourown-1.20.0-machine-controller-webhook.yaml
@@ -1,0 +1,114 @@
+# This file has been generated, DO NOT EDIT.
+
+metadata:
+  creationTimestamp: null
+  labels:
+    app: machine-controller-webhook
+  name: machine-controller-webhook
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: machine-controller-webhook
+  strategy: {}
+  template:
+    metadata:
+      creationTimestamp: null
+      labels:
+        app: machine-controller-webhook
+        cluster: de-test-01
+        machinecontroller-kubeconfig-secret-revision: "123456"
+        machinecontroller-webhook-serving-cert-secret-revision: "123456"
+    spec:
+      containers:
+      - args:
+        - -endpoint
+        - https://apiserver-external.cluster-de-test-01.svc.cluster.local./healthz
+        - -insecure
+        - -retries
+        - "100"
+        - -retry-wait
+        - "2"
+        - -timeout
+        - "1"
+        - -command
+        - '{"command":"/usr/local/bin/webhook","args":["-kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","-logtostderr","-v","4","-listen-address","0.0.0.0:9876"]}'
+        - --crd-to-wait-for
+        - Machine,cluster.k8s.io/v1alpha1
+        command:
+        - /http-prober-bin/http-prober
+        env:
+        - name: HTTP_PROXY
+          value: http://my-corp
+        - name: HTTPS_PROXY
+          value: http://my-corp
+        - name: http_proxy
+          value: http://my-corp
+        - name: https_proxy
+          value: http://my-corp
+        - name: NO_PROXY
+          value: apiserver-external.cluster-de-test-01.svc.cluster.local.
+        - name: no_proxy
+          value: apiserver-external.cluster-de-test-01.svc.cluster.local.
+        - name: KUBECONFIG
+          value: /etc/kubernetes/kubeconfig/kubeconfig
+        image: docker.io/kubermatic/machine-controller:v1.23.1
+        livenessProbe:
+          failureThreshold: 8
+          httpGet:
+            path: /healthz
+            port: 9876
+            scheme: HTTPS
+          initialDelaySeconds: 15
+          periodSeconds: 10
+          successThreshold: 1
+          timeoutSeconds: 15
+        name: machine-controller
+        readinessProbe:
+          failureThreshold: 3
+          httpGet:
+            path: /healthz
+            port: 9876
+            scheme: HTTPS
+          periodSeconds: 10
+          successThreshold: 1
+          timeoutSeconds: 15
+        resources:
+          limits:
+            cpu: 100m
+            memory: 512Mi
+          requests:
+            cpu: 10m
+            memory: 32Mi
+        volumeMounts:
+        - mountPath: /etc/kubernetes/kubeconfig
+          name: machinecontroller-kubeconfig
+          readOnly: true
+        - mountPath: /tmp/cert
+          name: machinecontroller-webhook-serving-cert
+          readOnly: true
+        - mountPath: /http-prober-bin
+          name: http-prober-bin
+      imagePullSecrets:
+      - name: dockercfg
+      initContainers:
+      - command:
+        - /bin/cp
+        - /usr/local/bin/http-prober
+        - /http-prober-bin/http-prober
+        image: quay.io/kubermatic/http-prober:v0.3.1
+        name: copy-http-prober
+        resources: {}
+        volumeMounts:
+        - mountPath: /http-prober-bin
+          name: http-prober-bin
+      volumes:
+      - name: machinecontroller-kubeconfig
+        secret:
+          secretName: machinecontroller-kubeconfig
+      - name: machinecontroller-webhook-serving-cert
+        secret:
+          secretName: machinecontroller-webhook-serving-cert
+      - emptyDir: {}
+        name: http-prober-bin
+status: {}

--- a/pkg/resources/test/fixtures/deployment-bringyourown-1.20.0-machine-controller.yaml
+++ b/pkg/resources/test/fixtures/deployment-bringyourown-1.20.0-machine-controller.yaml
@@ -1,0 +1,102 @@
+# This file has been generated, DO NOT EDIT.
+
+metadata:
+  creationTimestamp: null
+  labels:
+    app: machine-controller
+  name: machine-controller
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: machine-controller
+  strategy: {}
+  template:
+    metadata:
+      annotations:
+        prometheus.io/path: /metrics
+        prometheus.io/port: "8080"
+        prometheus.io/scrape: "true"
+      creationTimestamp: null
+      labels:
+        app: machine-controller
+        cluster: de-test-01
+        machinecontroller-kubeconfig-secret-revision: "123456"
+    spec:
+      containers:
+      - args:
+        - -endpoint
+        - https://apiserver-external.cluster-de-test-01.svc.cluster.local./healthz
+        - -insecure
+        - -retries
+        - "100"
+        - -retry-wait
+        - "2"
+        - -timeout
+        - "1"
+        - -command
+        - '{"command":"/usr/local/bin/machine-controller","args":["-kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","-logtostderr","-v","4","-cluster-dns","169.254.20.10","-health-probe-address","0.0.0.0:8085","-metrics-address","0.0.0.0:8080"]}'
+        - --crd-to-wait-for
+        - Machine,cluster.k8s.io/v1alpha1
+        command:
+        - /http-prober-bin/http-prober
+        env:
+        - name: HTTP_PROXY
+          value: http://my-corp
+        - name: HTTPS_PROXY
+          value: http://my-corp
+        - name: http_proxy
+          value: http://my-corp
+        - name: https_proxy
+          value: http://my-corp
+        - name: NO_PROXY
+          value: apiserver-external.cluster-de-test-01.svc.cluster.local.
+        - name: no_proxy
+          value: apiserver-external.cluster-de-test-01.svc.cluster.local.
+        - name: KUBECONFIG
+          value: /etc/kubernetes/kubeconfig/kubeconfig
+        image: docker.io/kubermatic/machine-controller:v1.23.1
+        livenessProbe:
+          failureThreshold: 3
+          httpGet:
+            path: /readyz
+            port: 8085
+            scheme: HTTP
+          initialDelaySeconds: 15
+          periodSeconds: 10
+          successThreshold: 1
+          timeoutSeconds: 15
+        name: machine-controller
+        resources:
+          limits:
+            cpu: "2"
+            memory: 512Mi
+          requests:
+            cpu: 25m
+            memory: 32Mi
+        volumeMounts:
+        - mountPath: /etc/kubernetes/kubeconfig
+          name: machinecontroller-kubeconfig
+          readOnly: true
+        - mountPath: /http-prober-bin
+          name: http-prober-bin
+      imagePullSecrets:
+      - name: dockercfg
+      initContainers:
+      - command:
+        - /bin/cp
+        - /usr/local/bin/http-prober
+        - /http-prober-bin/http-prober
+        image: quay.io/kubermatic/http-prober:v0.3.1
+        name: copy-http-prober
+        resources: {}
+        volumeMounts:
+        - mountPath: /http-prober-bin
+          name: http-prober-bin
+      volumes:
+      - name: machinecontroller-kubeconfig
+        secret:
+          secretName: machinecontroller-kubeconfig
+      - emptyDir: {}
+        name: http-prober-bin
+status: {}

--- a/pkg/resources/test/fixtures/deployment-bringyourown-1.20.0-metrics-server.yaml
+++ b/pkg/resources/test/fixtures/deployment-bringyourown-1.20.0-metrics-server.yaml
@@ -1,0 +1,182 @@
+# This file has been generated, DO NOT EDIT.
+
+metadata:
+  creationTimestamp: null
+  labels:
+    app: metrics-server
+  name: metrics-server
+spec:
+  replicas: 2
+  selector:
+    matchLabels:
+      app: metrics-server
+  strategy: {}
+  template:
+    metadata:
+      creationTimestamp: null
+      labels:
+        app: metrics-server
+        cluster: de-test-01
+        kubeletdnatcontroller-kubeconfig-secret-revision: "123456"
+        metrics-server-secret-revision: "123456"
+        metrics-server-serving-cert-secret-revision: "123456"
+        openvpn-client-certificates-secret-revision: "123456"
+    spec:
+      affinity:
+        podAntiAffinity:
+          preferredDuringSchedulingIgnoredDuringExecution:
+          - podAffinityTerm:
+              labelSelector:
+                matchLabels:
+                  app: metrics-server
+                  cluster: de-test-01
+              topologyKey: kubernetes.io/hostname
+            weight: 100
+          - podAffinityTerm:
+              labelSelector:
+                matchLabels:
+                  app: metrics-server
+              topologyKey: kubernetes.io/hostname
+            weight: 10
+      containers:
+      - args:
+        - -endpoint
+        - https://apiserver-external.cluster-de-test-01.svc.cluster.local./healthz
+        - -insecure
+        - -retries
+        - "100"
+        - -retry-wait
+        - "2"
+        - -timeout
+        - "1"
+        - -command
+        - '{"command":"/metrics-server","args":["--kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","--authentication-kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","--authorization-kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","--kubelet-port","10250","--kubelet-insecure-tls","--kubelet-preferred-address-types","ExternalIP,InternalIP","--v","1","--logtostderr","--tls-cert-file","/etc/serving-cert/serving.crt","--tls-private-key-file","/etc/serving-cert/serving.key"]}'
+        command:
+        - /http-prober-bin/http-prober
+        image: k8s.gcr.io/metrics-server-amd64:v0.3.6
+        name: metrics-server
+        resources:
+          limits:
+            cpu: 150m
+            memory: 512Mi
+          requests:
+            cpu: 25m
+            memory: 32Mi
+        volumeMounts:
+        - mountPath: /etc/kubernetes/kubeconfig
+          name: metrics-server
+          readOnly: true
+        - mountPath: /etc/serving-cert
+          name: metrics-server-serving-cert
+          readOnly: true
+        - mountPath: /http-prober-bin
+          name: http-prober-bin
+      - args:
+        - --client
+        - --proto
+        - tcp
+        - --dev
+        - tun
+        - --auth-nocache
+        - --remote
+        - openvpn-server.cluster-de-test-01.svc.cluster.local.
+        - "1194"
+        - --nobind
+        - --connect-timeout
+        - "5"
+        - --connect-retry
+        - "1"
+        - --ca
+        - /etc/openvpn/pki/client/ca.crt
+        - --cert
+        - /etc/openvpn/pki/client/client.crt
+        - --key
+        - /etc/openvpn/pki/client/client.key
+        - --remote-cert-tls
+        - server
+        - --link-mtu
+        - "1432"
+        - --cipher
+        - AES-256-GCM
+        - --auth
+        - SHA1
+        - --keysize
+        - "256"
+        - --script-security
+        - "2"
+        - --status
+        - /run/openvpn-status
+        - --log
+        - /dev/stdout
+        command:
+        - /usr/sbin/openvpn
+        image: quay.io/kubermatic/openvpn:v2.4.8-r1
+        name: openvpn-client
+        resources:
+          limits:
+            cpu: 100m
+            memory: 32Mi
+          requests:
+            cpu: 5m
+            memory: 5Mi
+        securityContext:
+          privileged: true
+        volumeMounts:
+        - mountPath: /etc/openvpn/pki/client
+          name: openvpn-client-certificates
+          readOnly: true
+      - args:
+        - -kubeconfig
+        - /etc/kubernetes/kubeconfig/kubeconfig
+        - -node-access-network
+        - 192.0.2.0/24
+        command:
+        - /usr/local/bin/kubeletdnat-controller
+        image: quay.io/kubermatic/kubeletdnat-controller:v0.0.0-test
+        name: dnat-controller
+        resources:
+          limits:
+            cpu: 100m
+            memory: 512Mi
+          requests:
+            cpu: 5m
+            memory: 16Mi
+        securityContext:
+          capabilities:
+            add:
+            - NET_ADMIN
+          procMount: Default
+          runAsUser: 0
+        volumeMounts:
+        - mountPath: /etc/kubernetes/kubeconfig
+          name: kubeletdnatcontroller-kubeconfig
+          readOnly: true
+      imagePullSecrets:
+      - name: dockercfg
+      initContainers:
+      - command:
+        - /bin/cp
+        - /usr/local/bin/http-prober
+        - /http-prober-bin/http-prober
+        image: quay.io/kubermatic/http-prober:v0.3.1
+        name: copy-http-prober
+        resources: {}
+        volumeMounts:
+        - mountPath: /http-prober-bin
+          name: http-prober-bin
+      volumes:
+      - name: metrics-server
+        secret:
+          secretName: metrics-server
+      - name: openvpn-client-certificates
+        secret:
+          secretName: openvpn-client-certificates
+      - name: kubeletdnatcontroller-kubeconfig
+        secret:
+          secretName: kubeletdnatcontroller-kubeconfig
+      - name: metrics-server-serving-cert
+        secret:
+          secretName: metrics-server-serving-cert
+      - emptyDir: {}
+        name: http-prober-bin
+status: {}

--- a/pkg/resources/test/fixtures/deployment-bringyourown-1.20.0-openvpn-server.yaml
+++ b/pkg/resources/test/fixtures/deployment-bringyourown-1.20.0-openvpn-server.yaml
@@ -1,0 +1,223 @@
+# This file has been generated, DO NOT EDIT.
+
+metadata:
+  creationTimestamp: null
+  labels:
+    app: openvpn-server
+  name: openvpn-server
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: openvpn-server
+  strategy:
+    rollingUpdate:
+      maxSurge: 1
+      maxUnavailable: 1
+    type: RollingUpdate
+  template:
+    metadata:
+      annotations:
+        prometheus.io/path: /metrics
+        prometheus.io/port: "9176"
+        prometheus.io/scrape: "true"
+      creationTimestamp: null
+      labels:
+        app: openvpn-server
+        cluster: de-test-01
+        openvpn-ca-secret-revision: "123456"
+        openvpn-client-configs-configmap-revision: "123456"
+        openvpn-server-certificates-secret-revision: "123456"
+    spec:
+      containers:
+      - args:
+        - --proto
+        - tcp
+        - --dev
+        - tun
+        - --mode
+        - server
+        - --lport
+        - "1194"
+        - --server
+        - 10.20.0.0
+        - 255.255.255.0
+        - --ca
+        - /etc/kubernetes/pki/ca/ca.crt
+        - --cert
+        - /etc/openvpn/pki/server/server.crt
+        - --key
+        - /etc/openvpn/pki/server/server.key
+        - --dh
+        - none
+        - --duplicate-cn
+        - --client-config-dir
+        - /etc/openvpn/clients
+        - --status
+        - /run/openvpn/openvpn-status
+        - --status-version
+        - "3"
+        - --cipher
+        - AES-256-GCM
+        - --auth
+        - SHA1
+        - --keysize
+        - "256"
+        - --script-security
+        - "2"
+        - --ping
+        - "5"
+        - --verb
+        - "3"
+        - --log
+        - /dev/stdout
+        - --push
+        - route 172.25.0.0 255.255.0.0
+        - --route
+        - 172.25.0.0
+        - 255.255.0.0
+        - --push
+        - route 10.240.16.0 255.255.240.0
+        - --route
+        - 10.240.16.0
+        - 255.255.240.0
+        - --push
+        - route 192.0.2.0 255.255.255.0
+        - --route
+        - 192.0.2.0
+        - 255.255.255.0
+        command:
+        - /usr/sbin/openvpn
+        image: quay.io/kubermatic/openvpn:v2.4.8-r1
+        name: openvpn-server
+        ports:
+        - containerPort: 1194
+          protocol: TCP
+        readinessProbe:
+          exec:
+            command:
+            - test
+            - -s
+            - /run/openvpn/openvpn-status
+          failureThreshold: 3
+          initialDelaySeconds: 5
+          periodSeconds: 5
+          successThreshold: 1
+          timeoutSeconds: 1
+        resources:
+          limits:
+            cpu: 100m
+            memory: 20Mi
+          requests:
+            cpu: 5m
+            memory: 5Mi
+        securityContext:
+          privileged: true
+          procMount: Default
+        volumeMounts:
+        - mountPath: /etc/openvpn/pki/server
+          name: openvpn-server-certificates
+          readOnly: true
+        - mountPath: /etc/kubernetes/pki/ca
+          name: ca
+          readOnly: true
+        - mountPath: /etc/openvpn/clients
+          name: openvpn-client-configs
+          readOnly: true
+        - mountPath: /run/openvpn
+          name: openvpn-status
+      - args:
+        - -c
+        - |-
+          while true; do sysctl -w net.ipv4.ip_forward=1;
+            if ! iptables -t mangle -C INPUT -p tcp --tcp-flags SYN,RST SYN --dport 1194 -j TCPMSS --set-mss 1300 &>/dev/null; then
+             iptables -t mangle -A INPUT -p tcp --tcp-flags SYN,RST SYN --dport 1194 -j TCPMSS --set-mss 1300
+            fi
+            sleep 30;
+          done
+        command:
+        - /bin/bash
+        image: quay.io/kubermatic/openvpn:v2.4.8-r1
+        name: ip-fixup
+        resources:
+          limits:
+            cpu: 10m
+            memory: 32Mi
+          requests:
+            cpu: 5m
+            memory: 16Mi
+        securityContext:
+          privileged: true
+          procMount: Default
+      - args:
+        - -openvpn.status_paths
+        - /run/openvpn/openvpn-status
+        command:
+        - /bin/openvpn_exporter
+        image: docker.io/kumina/openvpn-exporter:v0.2.2
+        name: openvpn-exporter
+        ports:
+        - containerPort: 9176
+          protocol: TCP
+        resources:
+          limits:
+            cpu: 100m
+            memory: 20Mi
+          requests:
+            cpu: 5m
+            memory: 5Mi
+        volumeMounts:
+        - mountPath: /run/openvpn
+          name: openvpn-status
+      imagePullSecrets:
+      - name: dockercfg
+      initContainers:
+      - args:
+        - -c
+        - |
+          # do not give a 10.20.0.0/24 route to clients (nodes) but
+          # masquerade to openvpn-server's IP instead:
+          iptables -t nat -A POSTROUTING -o tun0 -s 10.20.0.0/24 -j MASQUERADE
+
+          # Only allow outbound traffic to services, pods, nodes
+          iptables -P FORWARD DROP
+          iptables -A FORWARD -m state --state ESTABLISHED,RELATED -j ACCEPT
+          iptables -A FORWARD -i tun0 -o tun0 -s 10.20.0.0/24 -d 172.25.0.0/16 -j ACCEPT
+          iptables -A FORWARD -i tun0 -o tun0 -s 10.20.0.0/24 -d 10.240.16.0/20 -j ACCEPT
+          iptables -A FORWARD -i tun0 -o tun0 -s 10.20.0.0/24 -d 192.0.2.0/24 -j ACCEPT
+
+          iptables -A INPUT -m state --state ESTABLISHED,RELATED -j ACCEPT
+          iptables -A INPUT -i tun0 -p icmp -j ACCEPT
+          iptables -A INPUT -i tun0 -j DROP
+        command:
+        - /bin/bash
+        image: quay.io/kubermatic/openvpn:v2.4.8-r1
+        name: iptables-init
+        resources:
+          limits:
+            cpu: 100m
+            memory: 20Mi
+          requests:
+            cpu: 5m
+            memory: 5Mi
+        securityContext:
+          capabilities:
+            add:
+            - NET_ADMIN
+          procMount: Default
+      volumes:
+      - name: ca
+        secret:
+          items:
+          - key: ca.crt
+            path: ca.crt
+          secretName: openvpn-ca
+      - name: openvpn-server-certificates
+        secret:
+          secretName: openvpn-server-certificates
+      - configMap:
+          name: openvpn-client-configs
+        name: openvpn-client-configs
+      - emptyDir: {}
+        name: openvpn-status
+status: {}

--- a/pkg/resources/test/fixtures/deployment-bringyourown-1.20.0-scheduler.yaml
+++ b/pkg/resources/test/fixtures/deployment-bringyourown-1.20.0-scheduler.yaml
@@ -1,0 +1,203 @@
+# This file has been generated, DO NOT EDIT.
+
+metadata:
+  creationTimestamp: null
+  labels:
+    app: scheduler
+  name: scheduler
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: scheduler
+  strategy: {}
+  template:
+    metadata:
+      annotations:
+        prometheus.io/path: /metrics
+        prometheus.io/port: "10259"
+        prometheus.io/scrape_with_kube_cert: "true"
+      creationTimestamp: null
+      labels:
+        app: scheduler
+        ca-secret-revision: "123456"
+        cluster: de-test-01
+        openvpn-client-certificates-secret-revision: "123456"
+        scheduler-kubeconfig-secret-revision: "123456"
+    spec:
+      affinity:
+        podAntiAffinity:
+          preferredDuringSchedulingIgnoredDuringExecution:
+          - podAffinityTerm:
+              labelSelector:
+                matchLabels:
+                  app: scheduler
+                  cluster: de-test-01
+              topologyKey: kubernetes.io/hostname
+            weight: 100
+          - podAffinityTerm:
+              labelSelector:
+                matchLabels:
+                  app: scheduler
+              topologyKey: kubernetes.io/hostname
+            weight: 10
+      containers:
+      - args:
+        - --client
+        - --proto
+        - tcp
+        - --dev
+        - tun
+        - --auth-nocache
+        - --remote
+        - openvpn-server.cluster-de-test-01.svc.cluster.local.
+        - "1194"
+        - --nobind
+        - --connect-timeout
+        - "5"
+        - --connect-retry
+        - "1"
+        - --ca
+        - /etc/openvpn/pki/client/ca.crt
+        - --cert
+        - /etc/openvpn/pki/client/client.crt
+        - --key
+        - /etc/openvpn/pki/client/client.key
+        - --remote-cert-tls
+        - server
+        - --link-mtu
+        - "1432"
+        - --cipher
+        - AES-256-GCM
+        - --auth
+        - SHA1
+        - --keysize
+        - "256"
+        - --script-security
+        - "2"
+        - --status
+        - /run/openvpn-status
+        - --log
+        - /dev/stdout
+        command:
+        - /usr/sbin/openvpn
+        image: quay.io/kubermatic/openvpn:v2.4.8-r1
+        name: openvpn-client
+        resources:
+          limits:
+            cpu: 100m
+            memory: 32Mi
+          requests:
+            cpu: 5m
+            memory: 5Mi
+        securityContext:
+          privileged: true
+        volumeMounts:
+        - mountPath: /etc/openvpn/pki/client
+          name: openvpn-client-certificates
+          readOnly: true
+      - args:
+        - -endpoint
+        - https://apiserver-external.cluster-de-test-01.svc.cluster.local./healthz
+        - -insecure
+        - -retries
+        - "100"
+        - -retry-wait
+        - "2"
+        - -timeout
+        - "1"
+        - -command
+        - '{"command":"/usr/local/bin/kube-scheduler","args":["--kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","--authentication-kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","--authorization-kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","--client-ca-file","/etc/kubernetes/pki/ca/ca.crt","--port","0"]}'
+        command:
+        - /http-prober-bin/http-prober
+        image: k8s.gcr.io/kube-scheduler:v1.20.0
+        livenessProbe:
+          failureThreshold: 8
+          httpGet:
+            path: /healthz
+            port: 10259
+            scheme: HTTPS
+          initialDelaySeconds: 15
+          periodSeconds: 10
+          successThreshold: 1
+          timeoutSeconds: 15
+        name: scheduler
+        readinessProbe:
+          failureThreshold: 3
+          httpGet:
+            path: /healthz
+            port: 10259
+            scheme: HTTPS
+          periodSeconds: 10
+          successThreshold: 1
+          timeoutSeconds: 15
+        resources:
+          limits:
+            cpu: "1"
+            memory: 512Mi
+          requests:
+            cpu: 20m
+            memory: 64Mi
+        volumeMounts:
+        - mountPath: /etc/kubernetes/kubeconfig
+          name: scheduler-kubeconfig
+          readOnly: true
+        - mountPath: /etc/kubernetes/pki/ca
+          name: ca
+          readOnly: true
+        - mountPath: /etc/ssl/certs
+          name: ca-certs
+          readOnly: true
+        - mountPath: /usr/share/ca-certificates
+          name: usr-share-ca-certificates
+          readOnly: true
+        - mountPath: /http-prober-bin
+          name: http-prober-bin
+      dnsConfig:
+        nameservers:
+        - 192.0.2.14
+        options:
+        - name: ndots
+          value: "5"
+        searches:
+        - kube-system.svc.cluster.local
+        - svc.cluster.local
+        - cluster.local
+      dnsPolicy: None
+      imagePullSecrets:
+      - name: dockercfg
+      initContainers:
+      - command:
+        - /bin/cp
+        - /usr/local/bin/http-prober
+        - /http-prober-bin/http-prober
+        image: quay.io/kubermatic/http-prober:v0.3.1
+        name: copy-http-prober
+        resources: {}
+        volumeMounts:
+        - mountPath: /http-prober-bin
+          name: http-prober-bin
+      volumes:
+      - name: openvpn-client-certificates
+        secret:
+          secretName: openvpn-client-certificates
+      - name: ca
+        secret:
+          items:
+          - key: ca.crt
+            path: ca.crt
+          secretName: ca
+      - name: scheduler-kubeconfig
+        secret:
+          secretName: scheduler-kubeconfig
+      - hostPath:
+          path: /etc/ssl/certs
+          type: DirectoryOrCreate
+        name: ca-certs
+      - hostPath:
+          path: /usr/share/ca-certificates
+          type: DirectoryOrCreate
+        name: usr-share-ca-certificates
+      - emptyDir: {}
+        name: http-prober-bin
+status: {}

--- a/pkg/resources/test/fixtures/deployment-bringyourown-1.20.0-usercluster-controller.yaml
+++ b/pkg/resources/test/fixtures/deployment-bringyourown-1.20.0-usercluster-controller.yaml
@@ -1,0 +1,95 @@
+# This file has been generated, DO NOT EDIT.
+
+metadata:
+  creationTimestamp: null
+  labels:
+    app: usercluster-controller
+  name: usercluster-controller
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: usercluster-controller
+  strategy:
+    rollingUpdate:
+      maxSurge: 1
+      maxUnavailable: 1
+    type: RollingUpdate
+  template:
+    metadata:
+      annotations:
+        prometheus.io/path: /metrics
+        prometheus.io/port: "8085"
+        prometheus.io/scrape: "true"
+      creationTimestamp: null
+      labels:
+        app: usercluster-controller
+        cluster: de-test-01
+        internal-admin-kubeconfig-secret-revision: "123456"
+    spec:
+      containers:
+      - args:
+        - -endpoint
+        - https://apiserver-external.cluster-de-test-01.svc.cluster.local./healthz
+        - -insecure
+        - -retries
+        - "100"
+        - -retry-wait
+        - "2"
+        - -timeout
+        - "1"
+        - -command
+        - '{"command":"/usr/local/bin/user-cluster-controller-manager","args":["-kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","-metrics-listen-address","0.0.0.0:8085","-health-listen-address","0.0.0.0:8086","-namespace","$(NAMESPACE)","-cluster-url","https://jh8j81chn.europe-west3-c.dev.kubermatic.io:30000","-dns-cluster-ip","10.240.16.10","-openvpn-server-port","30003","-overwrite-registry","","-openshift=false","-version","1.20.0","-cloud-provider-name","","-owner-email","","-opa-integration=false","--ipam-controller-network","192.168.1.1/24,192.168.1.1,8.8.8.8","-node-labels","{\"my-label\":\"my-value\"}"]}'
+        command:
+        - /http-prober-bin/http-prober
+        env:
+        - name: NAMESPACE
+          valueFrom:
+            fieldRef:
+              apiVersion: v1
+              fieldPath: metadata.namespace
+        image: quay.io/kubermatic/kubermatic:v0.0.0-test
+        name: usercluster-controller
+        readinessProbe:
+          failureThreshold: 5
+          httpGet:
+            path: /ready
+            port: 8086
+            scheme: HTTP
+          periodSeconds: 5
+          successThreshold: 1
+          timeoutSeconds: 15
+        resources:
+          limits:
+            cpu: 500m
+            memory: 512Mi
+          requests:
+            cpu: 25m
+            memory: 32Mi
+        volumeMounts:
+        - mountPath: /etc/kubernetes/kubeconfig
+          name: internal-admin-kubeconfig
+          readOnly: true
+        - mountPath: /http-prober-bin
+          name: http-prober-bin
+      imagePullSecrets:
+      - name: dockercfg
+      initContainers:
+      - command:
+        - /bin/cp
+        - /usr/local/bin/http-prober
+        - /http-prober-bin/http-prober
+        image: quay.io/kubermatic/http-prober:v0.3.1
+        name: copy-http-prober
+        resources: {}
+        volumeMounts:
+        - mountPath: /http-prober-bin
+          name: http-prober-bin
+      serviceAccountName: kubermatic-usercluster-controller-manager
+      volumes:
+      - name: internal-admin-kubeconfig
+        secret:
+          secretName: internal-admin-kubeconfig
+      - emptyDir: {}
+        name: http-prober-bin
+status: {}

--- a/pkg/resources/test/fixtures/deployment-digitalocean-1.17.0-apiserver.yaml
+++ b/pkg/resources/test/fixtures/deployment-digitalocean-1.17.0-apiserver.yaml
@@ -202,12 +202,12 @@ spec:
         - X-Remote-Group
         - --requestheader-username-headers
         - X-Remote-User
+        - --service-account-issuer
+        - https://jh8j81chn.europe-west3-c.dev.kubermatic.io:30000
         - --service-account-signing-key-file
         - /etc/kubernetes/service-account-key/sa.key
-        - --service-account-issuer
-        - kubernetes.default.svc
         - --api-audiences
-        - kubernetes.default.svc
+        - https://jh8j81chn.europe-west3-c.dev.kubermatic.io:30000
         - --kubelet-preferred-address-types
         - ExternalIP,InternalIP
         - --oidc-issuer-url

--- a/pkg/resources/test/fixtures/deployment-digitalocean-1.17.0-usercluster-controller.yaml
+++ b/pkg/resources/test/fixtures/deployment-digitalocean-1.17.0-usercluster-controller.yaml
@@ -39,7 +39,7 @@ spec:
         - -timeout
         - "1"
         - -command
-        - '{"command":"/usr/local/bin/user-cluster-controller-manager","args":["-kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","-metrics-listen-address","0.0.0.0:8085","-health-listen-address","0.0.0.0:8086","-namespace","$(NAMESPACE)","-cluster-url","","-dns-cluster-ip","10.240.16.10","-openvpn-server-port","30003","-overwrite-registry","","-openshift=false","-version","1.17.0","-cloud-provider-name","","-owner-email","","-opa-integration=false","--ipam-controller-network","192.168.1.1/24,192.168.1.1,8.8.8.8","-node-labels","{\"my-label\":\"my-value\"}"]}'
+        - '{"command":"/usr/local/bin/user-cluster-controller-manager","args":["-kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","-metrics-listen-address","0.0.0.0:8085","-health-listen-address","0.0.0.0:8086","-namespace","$(NAMESPACE)","-cluster-url","https://jh8j81chn.europe-west3-c.dev.kubermatic.io:30000","-dns-cluster-ip","10.240.16.10","-openvpn-server-port","30003","-overwrite-registry","","-openshift=false","-version","1.17.0","-cloud-provider-name","","-owner-email","","-opa-integration=false","--ipam-controller-network","192.168.1.1/24,192.168.1.1,8.8.8.8","-node-labels","{\"my-label\":\"my-value\"}"]}'
         command:
         - /http-prober-bin/http-prober
         env:

--- a/pkg/resources/test/fixtures/deployment-digitalocean-1.18.0-apiserver.yaml
+++ b/pkg/resources/test/fixtures/deployment-digitalocean-1.18.0-apiserver.yaml
@@ -202,12 +202,12 @@ spec:
         - X-Remote-Group
         - --requestheader-username-headers
         - X-Remote-User
+        - --service-account-issuer
+        - https://jh8j81chn.europe-west3-c.dev.kubermatic.io:30000
         - --service-account-signing-key-file
         - /etc/kubernetes/service-account-key/sa.key
-        - --service-account-issuer
-        - kubernetes.default.svc
         - --api-audiences
-        - kubernetes.default.svc
+        - https://jh8j81chn.europe-west3-c.dev.kubermatic.io:30000
         - --kubelet-preferred-address-types
         - ExternalIP,InternalIP
         - --oidc-issuer-url

--- a/pkg/resources/test/fixtures/deployment-digitalocean-1.18.0-usercluster-controller.yaml
+++ b/pkg/resources/test/fixtures/deployment-digitalocean-1.18.0-usercluster-controller.yaml
@@ -39,7 +39,7 @@ spec:
         - -timeout
         - "1"
         - -command
-        - '{"command":"/usr/local/bin/user-cluster-controller-manager","args":["-kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","-metrics-listen-address","0.0.0.0:8085","-health-listen-address","0.0.0.0:8086","-namespace","$(NAMESPACE)","-cluster-url","","-dns-cluster-ip","10.240.16.10","-openvpn-server-port","30003","-overwrite-registry","","-openshift=false","-version","1.18.0","-cloud-provider-name","","-owner-email","","-opa-integration=false","--ipam-controller-network","192.168.1.1/24,192.168.1.1,8.8.8.8","-node-labels","{\"my-label\":\"my-value\"}"]}'
+        - '{"command":"/usr/local/bin/user-cluster-controller-manager","args":["-kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","-metrics-listen-address","0.0.0.0:8085","-health-listen-address","0.0.0.0:8086","-namespace","$(NAMESPACE)","-cluster-url","https://jh8j81chn.europe-west3-c.dev.kubermatic.io:30000","-dns-cluster-ip","10.240.16.10","-openvpn-server-port","30003","-overwrite-registry","","-openshift=false","-version","1.18.0","-cloud-provider-name","","-owner-email","","-opa-integration=false","--ipam-controller-network","192.168.1.1/24,192.168.1.1,8.8.8.8","-node-labels","{\"my-label\":\"my-value\"}"]}'
         command:
         - /http-prober-bin/http-prober
         env:

--- a/pkg/resources/test/fixtures/deployment-digitalocean-1.19.0-apiserver.yaml
+++ b/pkg/resources/test/fixtures/deployment-digitalocean-1.19.0-apiserver.yaml
@@ -202,12 +202,12 @@ spec:
         - X-Remote-Group
         - --requestheader-username-headers
         - X-Remote-User
+        - --service-account-issuer
+        - https://jh8j81chn.europe-west3-c.dev.kubermatic.io:30000
         - --service-account-signing-key-file
         - /etc/kubernetes/service-account-key/sa.key
-        - --service-account-issuer
-        - kubernetes.default.svc
         - --api-audiences
-        - kubernetes.default.svc
+        - https://jh8j81chn.europe-west3-c.dev.kubermatic.io:30000
         - --kubelet-preferred-address-types
         - ExternalIP,InternalIP
         - --oidc-issuer-url

--- a/pkg/resources/test/fixtures/deployment-digitalocean-1.19.0-usercluster-controller.yaml
+++ b/pkg/resources/test/fixtures/deployment-digitalocean-1.19.0-usercluster-controller.yaml
@@ -39,7 +39,7 @@ spec:
         - -timeout
         - "1"
         - -command
-        - '{"command":"/usr/local/bin/user-cluster-controller-manager","args":["-kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","-metrics-listen-address","0.0.0.0:8085","-health-listen-address","0.0.0.0:8086","-namespace","$(NAMESPACE)","-cluster-url","","-dns-cluster-ip","10.240.16.10","-openvpn-server-port","30003","-overwrite-registry","","-openshift=false","-version","1.19.0","-cloud-provider-name","","-owner-email","","-opa-integration=false","--ipam-controller-network","192.168.1.1/24,192.168.1.1,8.8.8.8","-node-labels","{\"my-label\":\"my-value\"}"]}'
+        - '{"command":"/usr/local/bin/user-cluster-controller-manager","args":["-kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","-metrics-listen-address","0.0.0.0:8085","-health-listen-address","0.0.0.0:8086","-namespace","$(NAMESPACE)","-cluster-url","https://jh8j81chn.europe-west3-c.dev.kubermatic.io:30000","-dns-cluster-ip","10.240.16.10","-openvpn-server-port","30003","-overwrite-registry","","-openshift=false","-version","1.19.0","-cloud-provider-name","","-owner-email","","-opa-integration=false","--ipam-controller-network","192.168.1.1/24,192.168.1.1,8.8.8.8","-node-labels","{\"my-label\":\"my-value\"}"]}'
         command:
         - /http-prober-bin/http-prober
         env:

--- a/pkg/resources/test/fixtures/deployment-digitalocean-1.20.0-apiserver.yaml
+++ b/pkg/resources/test/fixtures/deployment-digitalocean-1.20.0-apiserver.yaml
@@ -1,0 +1,402 @@
+# This file has been generated, DO NOT EDIT.
+
+metadata:
+  creationTimestamp: null
+  labels:
+    app: apiserver
+  name: apiserver
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: apiserver
+  strategy: {}
+  template:
+    metadata:
+      annotations:
+        prometheus.io/path: /metrics
+        prometheus.io/port: "30000"
+        prometheus.io/scrape_with_kube_cert: "true"
+      creationTimestamp: null
+      labels:
+        adm-control-configmap-revision: "123456"
+        apiserver-etcd-client-certificate-secret-revision: "123456"
+        apiserver-proxy-client-certificate-secret-revision: "123456"
+        apiserver-tls-secret-revision: "123456"
+        app: apiserver
+        audit-config-configmap-revision: "123456"
+        ca-secret-revision: "123456"
+        cloud-config-configmap-revision: "123456"
+        cluster: de-test-01
+        dex-ca-secret-revision: "123456"
+        front-proxy-ca-secret-revision: "123456"
+        kubelet-client-certificates-secret-revision: "123456"
+        kubeletdnatcontroller-kubeconfig-secret-revision: "123456"
+        openvpn-client-certificates-secret-revision: "123456"
+        service-account-key-secret-revision: "123456"
+        tokens-secret-revision: "123456"
+    spec:
+      affinity:
+        podAntiAffinity:
+          preferredDuringSchedulingIgnoredDuringExecution:
+          - podAffinityTerm:
+              labelSelector:
+                matchLabels:
+                  app: apiserver
+                  cluster: de-test-01
+              topologyKey: kubernetes.io/hostname
+            weight: 100
+          - podAffinityTerm:
+              labelSelector:
+                matchLabels:
+                  app: apiserver
+              topologyKey: kubernetes.io/hostname
+            weight: 10
+      containers:
+      - args:
+        - --client
+        - --proto
+        - tcp
+        - --dev
+        - tun
+        - --auth-nocache
+        - --remote
+        - openvpn-server.cluster-de-test-01.svc.cluster.local.
+        - "1194"
+        - --nobind
+        - --connect-timeout
+        - "5"
+        - --connect-retry
+        - "1"
+        - --ca
+        - /etc/openvpn/pki/client/ca.crt
+        - --cert
+        - /etc/openvpn/pki/client/client.crt
+        - --key
+        - /etc/openvpn/pki/client/client.key
+        - --remote-cert-tls
+        - server
+        - --link-mtu
+        - "1432"
+        - --cipher
+        - AES-256-GCM
+        - --auth
+        - SHA1
+        - --keysize
+        - "256"
+        - --script-security
+        - "2"
+        - --status
+        - /run/openvpn-status
+        - --log
+        - /dev/stdout
+        command:
+        - /usr/sbin/openvpn
+        image: quay.io/kubermatic/openvpn:v2.4.8-r1
+        name: openvpn-client
+        resources:
+          limits:
+            cpu: 100m
+            memory: 32Mi
+          requests:
+            cpu: 5m
+            memory: 5Mi
+        securityContext:
+          privileged: true
+        volumeMounts:
+        - mountPath: /etc/openvpn/pki/client
+          name: openvpn-client-certificates
+          readOnly: true
+      - args:
+        - -kubeconfig
+        - /etc/kubernetes/kubeconfig/kubeconfig
+        - -node-access-network
+        - 192.0.2.0/24
+        - -master
+        - https://127.0.0.1:30000
+        command:
+        - /usr/local/bin/kubeletdnat-controller
+        image: quay.io/kubermatic/kubeletdnat-controller:v0.0.0-test
+        name: dnat-controller
+        resources:
+          limits:
+            cpu: 100m
+            memory: 512Mi
+          requests:
+            cpu: 5m
+            memory: 16Mi
+        securityContext:
+          capabilities:
+            add:
+            - NET_ADMIN
+          procMount: Default
+          runAsUser: 0
+        volumeMounts:
+        - mountPath: /etc/kubernetes/kubeconfig
+          name: kubeletdnatcontroller-kubeconfig
+          readOnly: true
+      - args:
+        - --advertise-address
+        - 35.198.93.90
+        - --secure-port
+        - "30000"
+        - --kubernetes-service-node-port
+        - "30000"
+        - --etcd-servers
+        - https://etcd-0.etcd.cluster-de-test-01.svc.cluster.local.:2379,https://etcd-1.etcd.cluster-de-test-01.svc.cluster.local.:2379,https://etcd-2.etcd.cluster-de-test-01.svc.cluster.local.:2379
+        - --etcd-cafile
+        - /etc/etcd/pki/client/ca.crt
+        - --etcd-certfile
+        - /etc/etcd/pki/client/apiserver-etcd-client.crt
+        - --etcd-keyfile
+        - /etc/etcd/pki/client/apiserver-etcd-client.key
+        - --storage-backend
+        - etcd3
+        - --enable-admission-plugins
+        - DefaultStorageClass,DefaultTolerationSeconds,LimitRanger,MutatingAdmissionWebhook,NamespaceLifecycle,Priority,ResourceQuota,ServiceAccount,ValidatingAdmissionWebhook
+        - --admission-control-config-file
+        - /etc/kubernetes/adm-control/admission-control.yaml
+        - --authorization-mode
+        - Node,RBAC
+        - --external-hostname
+        - jh8j81chn.europe-west3-c.dev.kubermatic.io
+        - --token-auth-file
+        - /etc/kubernetes/tokens/tokens.csv
+        - --enable-bootstrap-token-auth
+        - --service-account-key-file
+        - /etc/kubernetes/service-account-key/sa.key
+        - --service-cluster-ip-range
+        - 10.240.16.0/20
+        - --service-node-port-range
+        - 30000-32767
+        - --allow-privileged
+        - --audit-log-maxage
+        - "30"
+        - --audit-log-maxbackup
+        - "3"
+        - --audit-log-maxsize
+        - "100"
+        - --audit-log-path
+        - /var/log/kubernetes/audit/audit.log
+        - --tls-cert-file
+        - /etc/kubernetes/tls/apiserver-tls.crt
+        - --tls-private-key-file
+        - /etc/kubernetes/tls/apiserver-tls.key
+        - --proxy-client-cert-file
+        - /etc/kubernetes/pki/front-proxy/client/apiserver-proxy-client.crt
+        - --proxy-client-key-file
+        - /etc/kubernetes/pki/front-proxy/client/apiserver-proxy-client.key
+        - --client-ca-file
+        - /etc/kubernetes/pki/ca/ca.crt
+        - --kubelet-client-certificate
+        - /etc/kubernetes/kubelet/kubelet-client.crt
+        - --kubelet-client-key
+        - /etc/kubernetes/kubelet/kubelet-client.key
+        - --requestheader-client-ca-file
+        - /etc/kubernetes/pki/front-proxy/ca/ca.crt
+        - --requestheader-allowed-names
+        - apiserver-aggregator
+        - --requestheader-extra-headers-prefix
+        - X-Remote-Extra-
+        - --requestheader-group-headers
+        - X-Remote-Group
+        - --requestheader-username-headers
+        - X-Remote-User
+        - --service-account-issuer
+        - https://jh8j81chn.europe-west3-c.dev.kubermatic.io:30000
+        - --service-account-signing-key-file
+        - /etc/kubernetes/service-account-key/sa.key
+        - --api-audiences
+        - https://jh8j81chn.europe-west3-c.dev.kubermatic.io:30000
+        - --kubelet-preferred-address-types
+        - ExternalIP,InternalIP
+        - --oidc-issuer-url
+        - https://dev.kubermatic.io/dex
+        - --oidc-client-id
+        - kubermaticIssuer
+        - --oidc-username-claim
+        - email
+        - --oidc-groups-prefix
+        - 'oidc:'
+        - --oidc-groups-claim
+        - groups
+        - --oidc-ca-file
+        - /etc/kubernetes/dex/ca/caBundle.pem
+        command:
+        - /usr/local/bin/kube-apiserver
+        env:
+        - name: HTTP_PROXY
+          value: http://my-corp
+        - name: HTTPS_PROXY
+          value: http://my-corp
+        - name: http_proxy
+          value: http://my-corp
+        - name: https_proxy
+          value: http://my-corp
+        - name: NO_PROXY
+          value: apiserver-external.cluster-de-test-01.svc.cluster.local.
+        - name: no_proxy
+          value: apiserver-external.cluster-de-test-01.svc.cluster.local.
+        image: k8s.gcr.io/kube-apiserver:v1.20.0
+        livenessProbe:
+          failureThreshold: 8
+          httpGet:
+            path: /healthz
+            port: 30000
+            scheme: HTTPS
+          initialDelaySeconds: 15
+          periodSeconds: 10
+          successThreshold: 1
+          timeoutSeconds: 15
+        name: apiserver
+        ports:
+        - containerPort: 30000
+          protocol: TCP
+        readinessProbe:
+          failureThreshold: 3
+          httpGet:
+            path: /healthz
+            port: 30000
+            scheme: HTTPS
+          periodSeconds: 5
+          successThreshold: 1
+          timeoutSeconds: 15
+        resources:
+          limits:
+            cpu: "2"
+            memory: 4Gi
+          requests:
+            cpu: 100m
+            memory: 256Mi
+        volumeMounts:
+        - mountPath: /etc/kubernetes/tls
+          name: apiserver-tls
+          readOnly: true
+        - mountPath: /etc/kubernetes/tokens
+          name: tokens
+          readOnly: true
+        - mountPath: /etc/kubernetes/kubelet
+          name: kubelet-client-certificates
+          readOnly: true
+        - mountPath: /etc/kubernetes/pki/ca
+          name: ca
+          readOnly: true
+        - mountPath: /etc/kubernetes/service-account-key
+          name: service-account-key
+          readOnly: true
+        - mountPath: /etc/kubernetes/cloud
+          name: cloud-config
+          readOnly: true
+        - mountPath: /etc/etcd/pki/client
+          name: apiserver-etcd-client-certificate
+          readOnly: true
+        - mountPath: /etc/kubernetes/pki/front-proxy/client
+          name: apiserver-proxy-client-certificate
+          readOnly: true
+        - mountPath: /etc/kubernetes/pki/front-proxy/ca
+          name: front-proxy-ca
+          readOnly: true
+        - mountPath: /etc/kubernetes/audit
+          name: audit-config
+          readOnly: true
+        - mountPath: /var/log/kubernetes/audit
+          name: audit-log
+        - mountPath: /etc/kubernetes/adm-control
+          name: adm-control
+          readOnly: true
+        - mountPath: /etc/ssl/certs
+          name: ca-certs
+          readOnly: true
+        - mountPath: /usr/share/ca-certificates
+          name: usr-share-ca-certificates
+          readOnly: true
+        - mountPath: /etc/kubernetes/dex/ca
+          name: dex-ca
+          readOnly: true
+      dnsConfig:
+        nameservers:
+        - 192.0.2.14
+        options:
+        - name: ndots
+          value: "5"
+        searches:
+        - kube-system.svc.cluster.local
+        - svc.cluster.local
+        - cluster.local
+      dnsPolicy: None
+      imagePullSecrets:
+      - name: dockercfg
+      initContainers:
+      - command:
+        - /bin/sh
+        - -ec
+        - until ETCDCTL_API=3 /usr/local/bin/etcdctl --cacert=/etc/etcd/pki/client/ca.crt
+          --cert=/etc/etcd/pki/client/apiserver-etcd-client.crt --key=/etc/etcd/pki/client/apiserver-etcd-client.key
+          --dial-timeout=2s --endpoints='https://etcd-0.etcd.cluster-de-test-01.svc.cluster.local.:2379,https://etcd-1.etcd.cluster-de-test-01.svc.cluster.local.:2379,https://etcd-2.etcd.cluster-de-test-01.svc.cluster.local.:2379'
+          put kubermatic/quorum-check something; do echo waiting for etcd; sleep 2;
+          done;
+        image: gcr.io/etcd-development/etcd:v3.4.3
+        name: etcd-running
+        resources: {}
+        volumeMounts:
+        - mountPath: /etc/etcd/pki/client
+          name: apiserver-etcd-client-certificate
+          readOnly: true
+      volumes:
+      - name: apiserver-tls
+        secret:
+          secretName: apiserver-tls
+      - name: tokens
+        secret:
+          secretName: tokens
+      - name: openvpn-client-certificates
+        secret:
+          secretName: openvpn-client-certificates
+      - name: kubelet-client-certificates
+        secret:
+          secretName: kubelet-client-certificates
+      - name: ca
+        secret:
+          items:
+          - key: ca.crt
+            path: ca.crt
+          secretName: ca
+      - name: service-account-key
+        secret:
+          secretName: service-account-key
+      - configMap:
+          name: cloud-config
+        name: cloud-config
+      - name: apiserver-etcd-client-certificate
+        secret:
+          secretName: apiserver-etcd-client-certificate
+      - name: apiserver-proxy-client-certificate
+        secret:
+          secretName: apiserver-proxy-client-certificate
+      - name: front-proxy-ca
+        secret:
+          secretName: front-proxy-ca
+      - name: kubeletdnatcontroller-kubeconfig
+        secret:
+          secretName: kubeletdnatcontroller-kubeconfig
+      - configMap:
+          name: audit-config
+          optional: false
+        name: audit-config
+      - emptyDir: {}
+        name: audit-log
+      - configMap:
+          name: adm-control
+        name: adm-control
+      - hostPath:
+          path: /etc/ssl/certs
+          type: DirectoryOrCreate
+        name: ca-certs
+      - hostPath:
+          path: /usr/share/ca-certificates
+          type: DirectoryOrCreate
+        name: usr-share-ca-certificates
+      - name: dex-ca
+        secret:
+          secretName: dex-ca
+status: {}

--- a/pkg/resources/test/fixtures/deployment-digitalocean-1.20.0-controller-manager.yaml
+++ b/pkg/resources/test/fixtures/deployment-digitalocean-1.20.0-controller-manager.yaml
@@ -1,0 +1,227 @@
+# This file has been generated, DO NOT EDIT.
+
+metadata:
+  creationTimestamp: null
+  labels:
+    app: controller-manager
+  name: controller-manager
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: controller-manager
+  strategy: {}
+  template:
+    metadata:
+      annotations:
+        prometheus.io/path: /metrics
+        prometheus.io/port: "10257"
+        prometheus.io/scrape_with_kube_cert: "true"
+      creationTimestamp: null
+      labels:
+        app: controller-manager
+        ca-secret-revision: "123456"
+        cloud-config-configmap-revision: "123456"
+        cluster: de-test-01
+        controllermanager-kubeconfig-secret-revision: "123456"
+        openvpn-client-certificates-secret-revision: "123456"
+        service-account-key-secret-revision: "123456"
+    spec:
+      affinity:
+        podAntiAffinity:
+          preferredDuringSchedulingIgnoredDuringExecution:
+          - podAffinityTerm:
+              labelSelector:
+                matchLabels:
+                  app: controller-manager
+                  cluster: de-test-01
+              topologyKey: kubernetes.io/hostname
+            weight: 100
+          - podAffinityTerm:
+              labelSelector:
+                matchLabels:
+                  app: controller-manager
+              topologyKey: kubernetes.io/hostname
+            weight: 10
+      containers:
+      - args:
+        - --client
+        - --proto
+        - tcp
+        - --dev
+        - tun
+        - --auth-nocache
+        - --remote
+        - openvpn-server.cluster-de-test-01.svc.cluster.local.
+        - "1194"
+        - --nobind
+        - --connect-timeout
+        - "5"
+        - --connect-retry
+        - "1"
+        - --ca
+        - /etc/openvpn/pki/client/ca.crt
+        - --cert
+        - /etc/openvpn/pki/client/client.crt
+        - --key
+        - /etc/openvpn/pki/client/client.key
+        - --remote-cert-tls
+        - server
+        - --link-mtu
+        - "1432"
+        - --cipher
+        - AES-256-GCM
+        - --auth
+        - SHA1
+        - --keysize
+        - "256"
+        - --script-security
+        - "2"
+        - --status
+        - /run/openvpn-status
+        - --log
+        - /dev/stdout
+        command:
+        - /usr/sbin/openvpn
+        image: quay.io/kubermatic/openvpn:v2.4.8-r1
+        name: openvpn-client
+        resources:
+          limits:
+            cpu: 100m
+            memory: 32Mi
+          requests:
+            cpu: 5m
+            memory: 5Mi
+        securityContext:
+          privileged: true
+        volumeMounts:
+        - mountPath: /etc/openvpn/pki/client
+          name: openvpn-client-certificates
+          readOnly: true
+      - args:
+        - -endpoint
+        - https://apiserver-external.cluster-de-test-01.svc.cluster.local./healthz
+        - -insecure
+        - -retries
+        - "100"
+        - -retry-wait
+        - "2"
+        - -timeout
+        - "1"
+        - -command
+        - '{"command":"/usr/local/bin/kube-controller-manager","args":["--kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","--service-account-private-key-file","/etc/kubernetes/service-account-key/sa.key","--root-ca-file","/etc/kubernetes/pki/ca/ca.crt","--cluster-signing-cert-file","/etc/kubernetes/pki/ca/ca.crt","--cluster-signing-key-file","/etc/kubernetes/pki/ca/ca.key","--cluster-cidr","172.25.0.0/16","--allocate-node-cidrs","--controllers","*,bootstrapsigner,tokencleaner","--use-service-account-credentials","--feature-gates","RotateKubeletClientCertificate=true,RotateKubeletServerCertificate=true","--authentication-kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","--client-ca-file","/etc/kubernetes/pki/ca/ca.crt","--authentication-kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","--authorization-kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","--port","0"]}'
+        command:
+        - /http-prober-bin/http-prober
+        env:
+        - name: HTTP_PROXY
+          value: http://my-corp
+        - name: HTTPS_PROXY
+          value: http://my-corp
+        - name: http_proxy
+          value: http://my-corp
+        - name: https_proxy
+          value: http://my-corp
+        - name: NO_PROXY
+          value: apiserver-external.cluster-de-test-01.svc.cluster.local.
+        - name: no_proxy
+          value: apiserver-external.cluster-de-test-01.svc.cluster.local.
+        image: k8s.gcr.io/kube-controller-manager:v1.20.0
+        livenessProbe:
+          failureThreshold: 8
+          httpGet:
+            path: /healthz
+            port: 10257
+            scheme: HTTPS
+          initialDelaySeconds: 15
+          periodSeconds: 10
+          successThreshold: 1
+          timeoutSeconds: 15
+        name: controller-manager
+        readinessProbe:
+          failureThreshold: 3
+          httpGet:
+            path: /healthz
+            port: 10257
+            scheme: HTTPS
+          periodSeconds: 10
+          successThreshold: 1
+          timeoutSeconds: 15
+        resources:
+          limits:
+            cpu: "2"
+            memory: 2Gi
+          requests:
+            cpu: 100m
+            memory: 100Mi
+        volumeMounts:
+        - mountPath: /etc/kubernetes/pki/ca
+          name: ca
+          readOnly: true
+        - mountPath: /etc/kubernetes/service-account-key
+          name: service-account-key
+          readOnly: true
+        - mountPath: /etc/kubernetes/cloud
+          name: cloud-config
+          readOnly: true
+        - mountPath: /etc/kubernetes/kubeconfig
+          name: controllermanager-kubeconfig
+          readOnly: true
+        - mountPath: /etc/ssl/certs
+          name: ca-certs
+          readOnly: true
+        - mountPath: /usr/share/ca-certificates
+          name: usr-share-ca-certificates
+          readOnly: true
+        - mountPath: /http-prober-bin
+          name: http-prober-bin
+      dnsConfig:
+        nameservers:
+        - 192.0.2.14
+        options:
+        - name: ndots
+          value: "5"
+        searches:
+        - kube-system.svc.cluster.local
+        - svc.cluster.local
+        - cluster.local
+      dnsPolicy: None
+      imagePullSecrets:
+      - name: dockercfg
+      initContainers:
+      - command:
+        - /bin/cp
+        - /usr/local/bin/http-prober
+        - /http-prober-bin/http-prober
+        image: quay.io/kubermatic/http-prober:v0.3.1
+        name: copy-http-prober
+        resources: {}
+        volumeMounts:
+        - mountPath: /http-prober-bin
+          name: http-prober-bin
+      volumes:
+      - name: ca
+        secret:
+          secretName: ca
+      - name: service-account-key
+        secret:
+          secretName: service-account-key
+      - configMap:
+          name: cloud-config
+        name: cloud-config
+      - name: openvpn-client-certificates
+        secret:
+          secretName: openvpn-client-certificates
+      - name: controllermanager-kubeconfig
+        secret:
+          secretName: controllermanager-kubeconfig
+      - hostPath:
+          path: /etc/ssl/certs
+          type: DirectoryOrCreate
+        name: ca-certs
+      - hostPath:
+          path: /usr/share/ca-certificates
+          type: DirectoryOrCreate
+        name: usr-share-ca-certificates
+      - emptyDir: {}
+        name: http-prober-bin
+status: {}

--- a/pkg/resources/test/fixtures/deployment-digitalocean-1.20.0-dns-resolver.yaml
+++ b/pkg/resources/test/fixtures/deployment-digitalocean-1.20.0-dns-resolver.yaml
@@ -1,0 +1,140 @@
+# This file has been generated, DO NOT EDIT.
+
+metadata:
+  creationTimestamp: null
+  labels:
+    app: dns-resolver
+  name: dns-resolver
+spec:
+  replicas: 2
+  selector:
+    matchLabels:
+      app: dns-resolver
+  strategy: {}
+  template:
+    metadata:
+      annotations:
+        prometheus.io/path: /metrics
+        prometheus.io/port: "9253"
+        prometheus.io/scrape: "true"
+      creationTimestamp: null
+      labels:
+        app: dns-resolver
+        ca-secret-revision: "123456"
+        cluster: de-test-01
+        dns-resolver-configmap-revision: "123456"
+        openvpn-client-certificates-secret-revision: "123456"
+    spec:
+      affinity:
+        podAntiAffinity:
+          preferredDuringSchedulingIgnoredDuringExecution:
+          - podAffinityTerm:
+              labelSelector:
+                matchLabels:
+                  app: dns-resolver
+                  cluster: de-test-01
+              topologyKey: kubernetes.io/hostname
+            weight: 100
+          - podAffinityTerm:
+              labelSelector:
+                matchLabels:
+                  app: dns-resolver
+              topologyKey: kubernetes.io/hostname
+            weight: 10
+      containers:
+      - args:
+        - --client
+        - --proto
+        - tcp
+        - --dev
+        - tun
+        - --auth-nocache
+        - --remote
+        - openvpn-server.cluster-de-test-01.svc.cluster.local.
+        - "1194"
+        - --nobind
+        - --connect-timeout
+        - "5"
+        - --connect-retry
+        - "1"
+        - --ca
+        - /etc/openvpn/pki/client/ca.crt
+        - --cert
+        - /etc/openvpn/pki/client/client.crt
+        - --key
+        - /etc/openvpn/pki/client/client.key
+        - --remote-cert-tls
+        - server
+        - --link-mtu
+        - "1432"
+        - --cipher
+        - AES-256-GCM
+        - --auth
+        - SHA1
+        - --keysize
+        - "256"
+        - --script-security
+        - "2"
+        - --status
+        - /run/openvpn-status
+        - --log
+        - /dev/stdout
+        command:
+        - /usr/sbin/openvpn
+        image: quay.io/kubermatic/openvpn:v2.4.8-r1
+        name: openvpn-client
+        resources:
+          limits:
+            cpu: 100m
+            memory: 32Mi
+          requests:
+            cpu: 5m
+            memory: 5Mi
+        securityContext:
+          privileged: true
+        volumeMounts:
+        - mountPath: /etc/openvpn/pki/client
+          name: openvpn-client-certificates
+          readOnly: true
+      - args:
+        - -conf
+        - /etc/coredns/Corefile
+        image: k8s.gcr.io/coredns:1.3.1
+        name: dns-resolver
+        readinessProbe:
+          failureThreshold: 3
+          httpGet:
+            path: /health
+            port: 8080
+            scheme: HTTP
+          initialDelaySeconds: 2
+          periodSeconds: 10
+          successThreshold: 1
+          timeoutSeconds: 15
+        resources:
+          limits:
+            cpu: 100m
+            memory: 128Mi
+          requests:
+            cpu: 5m
+            memory: 20Mi
+        volumeMounts:
+        - mountPath: /etc/coredns
+          name: dns-resolver
+          readOnly: true
+      imagePullSecrets:
+      - name: dockercfg
+      volumes:
+      - configMap:
+          name: dns-resolver
+        name: dns-resolver
+      - name: openvpn-client-certificates
+        secret:
+          secretName: openvpn-client-certificates
+      - name: ca
+        secret:
+          items:
+          - key: ca.crt
+            path: ca.crt
+          secretName: ca
+status: {}

--- a/pkg/resources/test/fixtures/deployment-digitalocean-1.20.0-kube-state-metrics.yaml
+++ b/pkg/resources/test/fixtures/deployment-digitalocean-1.20.0-kube-state-metrics.yaml
@@ -1,0 +1,89 @@
+# This file has been generated, DO NOT EDIT.
+
+metadata:
+  creationTimestamp: null
+  labels:
+    app: kube-state-metrics
+  name: kube-state-metrics
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: kube-state-metrics
+  strategy: {}
+  template:
+    metadata:
+      annotations:
+        prometheus.io/scrape: "true"
+      creationTimestamp: null
+      labels:
+        app: kube-state-metrics
+        cluster: de-test-01
+        kube-state-metrics-kubeconfig-secret-revision: "123456"
+    spec:
+      containers:
+      - args:
+        - -endpoint
+        - https://apiserver-external.cluster-de-test-01.svc.cluster.local./healthz
+        - -insecure
+        - -retries
+        - "100"
+        - -retry-wait
+        - "2"
+        - -timeout
+        - "1"
+        - -command
+        - '{"command":"/kube-state-metrics","args":["--kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","--port","8080","--telemetry-port","8081"]}'
+        command:
+        - /http-prober-bin/http-prober
+        image: quay.io/coreos/kube-state-metrics:v1.9.7
+        name: kube-state-metrics
+        ports:
+        - containerPort: 8080
+          name: metrics
+          protocol: TCP
+        - containerPort: 8081
+          name: telemetry
+          protocol: TCP
+        readinessProbe:
+          failureThreshold: 3
+          httpGet:
+            path: /healthz
+            port: 8080
+            scheme: HTTP
+          periodSeconds: 10
+          successThreshold: 1
+          timeoutSeconds: 15
+        resources:
+          limits:
+            cpu: 100m
+            memory: 1Gi
+          requests:
+            cpu: 10m
+            memory: 12Mi
+        volumeMounts:
+        - mountPath: /etc/kubernetes/kubeconfig
+          name: kube-state-metrics-kubeconfig
+          readOnly: true
+        - mountPath: /http-prober-bin
+          name: http-prober-bin
+      imagePullSecrets:
+      - name: dockercfg
+      initContainers:
+      - command:
+        - /bin/cp
+        - /usr/local/bin/http-prober
+        - /http-prober-bin/http-prober
+        image: quay.io/kubermatic/http-prober:v0.3.1
+        name: copy-http-prober
+        resources: {}
+        volumeMounts:
+        - mountPath: /http-prober-bin
+          name: http-prober-bin
+      volumes:
+      - name: kube-state-metrics-kubeconfig
+        secret:
+          secretName: kube-state-metrics-kubeconfig
+      - emptyDir: {}
+        name: http-prober-bin
+status: {}

--- a/pkg/resources/test/fixtures/deployment-digitalocean-1.20.0-kubernetes-dashboard.yaml
+++ b/pkg/resources/test/fixtures/deployment-digitalocean-1.20.0-kubernetes-dashboard.yaml
@@ -1,0 +1,97 @@
+# This file has been generated, DO NOT EDIT.
+
+metadata:
+  creationTimestamp: null
+  labels:
+    app: kubernetes-dashboard
+  name: kubernetes-dashboard
+spec:
+  replicas: 2
+  selector:
+    matchLabels:
+      app: kubernetes-dashboard
+  strategy: {}
+  template:
+    metadata:
+      creationTimestamp: null
+      labels:
+        app: kubernetes-dashboard
+        cluster: de-test-01
+        kubernetes-dashboard-kubeconfig-secret-revision: "123456"
+    spec:
+      affinity:
+        podAntiAffinity:
+          preferredDuringSchedulingIgnoredDuringExecution:
+          - podAffinityTerm:
+              labelSelector:
+                matchLabels:
+                  app: kubernetes-dashboard
+                  cluster: de-test-01
+              topologyKey: kubernetes.io/hostname
+            weight: 100
+          - podAffinityTerm:
+              labelSelector:
+                matchLabels:
+                  app: kubernetes-dashboard
+              topologyKey: kubernetes.io/hostname
+            weight: 10
+      containers:
+      - args:
+        - -endpoint
+        - https://apiserver-external.cluster-de-test-01.svc.cluster.local./healthz
+        - -insecure
+        - -retries
+        - "100"
+        - -retry-wait
+        - "2"
+        - -timeout
+        - "1"
+        - -command
+        - '{"command":"/dashboard","args":["--kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","--namespace","kubernetes-dashboard","--enable-insecure-login"]}'
+        command:
+        - /http-prober-bin/http-prober
+        image: docker.io/kubernetesui/dashboard:v2.0.4
+        imagePullPolicy: IfNotPresent
+        name: kubernetes-dashboard
+        ports:
+        - containerPort: 9090
+          protocol: TCP
+        resources:
+          limits:
+            cpu: 250m
+            memory: 512Mi
+          requests:
+            cpu: 100m
+            memory: 256Mi
+        securityContext:
+          allowPrivilegeEscalation: false
+          readOnlyRootFilesystem: true
+          runAsUser: 1001
+        volumeMounts:
+        - mountPath: /etc/kubernetes/kubeconfig
+          name: kubernetes-dashboard-kubeconfig
+          readOnly: true
+        - mountPath: /tmp
+          name: tmp-volume
+        - mountPath: /http-prober-bin
+          name: http-prober-bin
+      initContainers:
+      - command:
+        - /bin/cp
+        - /usr/local/bin/http-prober
+        - /http-prober-bin/http-prober
+        image: quay.io/kubermatic/http-prober:v0.3.1
+        name: copy-http-prober
+        resources: {}
+        volumeMounts:
+        - mountPath: /http-prober-bin
+          name: http-prober-bin
+      volumes:
+      - name: kubernetes-dashboard-kubeconfig
+        secret:
+          secretName: kubernetes-dashboard-kubeconfig
+      - emptyDir: {}
+        name: tmp-volume
+      - emptyDir: {}
+        name: http-prober-bin
+status: {}

--- a/pkg/resources/test/fixtures/deployment-digitalocean-1.20.0-machine-controller-webhook.yaml
+++ b/pkg/resources/test/fixtures/deployment-digitalocean-1.20.0-machine-controller-webhook.yaml
@@ -1,0 +1,116 @@
+# This file has been generated, DO NOT EDIT.
+
+metadata:
+  creationTimestamp: null
+  labels:
+    app: machine-controller-webhook
+  name: machine-controller-webhook
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: machine-controller-webhook
+  strategy: {}
+  template:
+    metadata:
+      creationTimestamp: null
+      labels:
+        app: machine-controller-webhook
+        cluster: de-test-01
+        machinecontroller-kubeconfig-secret-revision: "123456"
+        machinecontroller-webhook-serving-cert-secret-revision: "123456"
+    spec:
+      containers:
+      - args:
+        - -endpoint
+        - https://apiserver-external.cluster-de-test-01.svc.cluster.local./healthz
+        - -insecure
+        - -retries
+        - "100"
+        - -retry-wait
+        - "2"
+        - -timeout
+        - "1"
+        - -command
+        - '{"command":"/usr/local/bin/webhook","args":["-kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","-logtostderr","-v","4","-listen-address","0.0.0.0:9876"]}'
+        - --crd-to-wait-for
+        - Machine,cluster.k8s.io/v1alpha1
+        command:
+        - /http-prober-bin/http-prober
+        env:
+        - name: DO_TOKEN
+          value: do-token
+        - name: HTTP_PROXY
+          value: http://my-corp
+        - name: HTTPS_PROXY
+          value: http://my-corp
+        - name: http_proxy
+          value: http://my-corp
+        - name: https_proxy
+          value: http://my-corp
+        - name: NO_PROXY
+          value: apiserver-external.cluster-de-test-01.svc.cluster.local.
+        - name: no_proxy
+          value: apiserver-external.cluster-de-test-01.svc.cluster.local.
+        - name: KUBECONFIG
+          value: /etc/kubernetes/kubeconfig/kubeconfig
+        image: docker.io/kubermatic/machine-controller:v1.23.1
+        livenessProbe:
+          failureThreshold: 8
+          httpGet:
+            path: /healthz
+            port: 9876
+            scheme: HTTPS
+          initialDelaySeconds: 15
+          periodSeconds: 10
+          successThreshold: 1
+          timeoutSeconds: 15
+        name: machine-controller
+        readinessProbe:
+          failureThreshold: 3
+          httpGet:
+            path: /healthz
+            port: 9876
+            scheme: HTTPS
+          periodSeconds: 10
+          successThreshold: 1
+          timeoutSeconds: 15
+        resources:
+          limits:
+            cpu: 100m
+            memory: 512Mi
+          requests:
+            cpu: 10m
+            memory: 32Mi
+        volumeMounts:
+        - mountPath: /etc/kubernetes/kubeconfig
+          name: machinecontroller-kubeconfig
+          readOnly: true
+        - mountPath: /tmp/cert
+          name: machinecontroller-webhook-serving-cert
+          readOnly: true
+        - mountPath: /http-prober-bin
+          name: http-prober-bin
+      imagePullSecrets:
+      - name: dockercfg
+      initContainers:
+      - command:
+        - /bin/cp
+        - /usr/local/bin/http-prober
+        - /http-prober-bin/http-prober
+        image: quay.io/kubermatic/http-prober:v0.3.1
+        name: copy-http-prober
+        resources: {}
+        volumeMounts:
+        - mountPath: /http-prober-bin
+          name: http-prober-bin
+      volumes:
+      - name: machinecontroller-kubeconfig
+        secret:
+          secretName: machinecontroller-kubeconfig
+      - name: machinecontroller-webhook-serving-cert
+        secret:
+          secretName: machinecontroller-webhook-serving-cert
+      - emptyDir: {}
+        name: http-prober-bin
+status: {}

--- a/pkg/resources/test/fixtures/deployment-digitalocean-1.20.0-machine-controller.yaml
+++ b/pkg/resources/test/fixtures/deployment-digitalocean-1.20.0-machine-controller.yaml
@@ -1,0 +1,104 @@
+# This file has been generated, DO NOT EDIT.
+
+metadata:
+  creationTimestamp: null
+  labels:
+    app: machine-controller
+  name: machine-controller
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: machine-controller
+  strategy: {}
+  template:
+    metadata:
+      annotations:
+        prometheus.io/path: /metrics
+        prometheus.io/port: "8080"
+        prometheus.io/scrape: "true"
+      creationTimestamp: null
+      labels:
+        app: machine-controller
+        cluster: de-test-01
+        machinecontroller-kubeconfig-secret-revision: "123456"
+    spec:
+      containers:
+      - args:
+        - -endpoint
+        - https://apiserver-external.cluster-de-test-01.svc.cluster.local./healthz
+        - -insecure
+        - -retries
+        - "100"
+        - -retry-wait
+        - "2"
+        - -timeout
+        - "1"
+        - -command
+        - '{"command":"/usr/local/bin/machine-controller","args":["-kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","-logtostderr","-v","4","-cluster-dns","169.254.20.10","-health-probe-address","0.0.0.0:8085","-metrics-address","0.0.0.0:8080"]}'
+        - --crd-to-wait-for
+        - Machine,cluster.k8s.io/v1alpha1
+        command:
+        - /http-prober-bin/http-prober
+        env:
+        - name: DO_TOKEN
+          value: do-token
+        - name: HTTP_PROXY
+          value: http://my-corp
+        - name: HTTPS_PROXY
+          value: http://my-corp
+        - name: http_proxy
+          value: http://my-corp
+        - name: https_proxy
+          value: http://my-corp
+        - name: NO_PROXY
+          value: apiserver-external.cluster-de-test-01.svc.cluster.local.
+        - name: no_proxy
+          value: apiserver-external.cluster-de-test-01.svc.cluster.local.
+        - name: KUBECONFIG
+          value: /etc/kubernetes/kubeconfig/kubeconfig
+        image: docker.io/kubermatic/machine-controller:v1.23.1
+        livenessProbe:
+          failureThreshold: 3
+          httpGet:
+            path: /readyz
+            port: 8085
+            scheme: HTTP
+          initialDelaySeconds: 15
+          periodSeconds: 10
+          successThreshold: 1
+          timeoutSeconds: 15
+        name: machine-controller
+        resources:
+          limits:
+            cpu: "2"
+            memory: 512Mi
+          requests:
+            cpu: 25m
+            memory: 32Mi
+        volumeMounts:
+        - mountPath: /etc/kubernetes/kubeconfig
+          name: machinecontroller-kubeconfig
+          readOnly: true
+        - mountPath: /http-prober-bin
+          name: http-prober-bin
+      imagePullSecrets:
+      - name: dockercfg
+      initContainers:
+      - command:
+        - /bin/cp
+        - /usr/local/bin/http-prober
+        - /http-prober-bin/http-prober
+        image: quay.io/kubermatic/http-prober:v0.3.1
+        name: copy-http-prober
+        resources: {}
+        volumeMounts:
+        - mountPath: /http-prober-bin
+          name: http-prober-bin
+      volumes:
+      - name: machinecontroller-kubeconfig
+        secret:
+          secretName: machinecontroller-kubeconfig
+      - emptyDir: {}
+        name: http-prober-bin
+status: {}

--- a/pkg/resources/test/fixtures/deployment-digitalocean-1.20.0-metrics-server.yaml
+++ b/pkg/resources/test/fixtures/deployment-digitalocean-1.20.0-metrics-server.yaml
@@ -1,0 +1,182 @@
+# This file has been generated, DO NOT EDIT.
+
+metadata:
+  creationTimestamp: null
+  labels:
+    app: metrics-server
+  name: metrics-server
+spec:
+  replicas: 2
+  selector:
+    matchLabels:
+      app: metrics-server
+  strategy: {}
+  template:
+    metadata:
+      creationTimestamp: null
+      labels:
+        app: metrics-server
+        cluster: de-test-01
+        kubeletdnatcontroller-kubeconfig-secret-revision: "123456"
+        metrics-server-secret-revision: "123456"
+        metrics-server-serving-cert-secret-revision: "123456"
+        openvpn-client-certificates-secret-revision: "123456"
+    spec:
+      affinity:
+        podAntiAffinity:
+          preferredDuringSchedulingIgnoredDuringExecution:
+          - podAffinityTerm:
+              labelSelector:
+                matchLabels:
+                  app: metrics-server
+                  cluster: de-test-01
+              topologyKey: kubernetes.io/hostname
+            weight: 100
+          - podAffinityTerm:
+              labelSelector:
+                matchLabels:
+                  app: metrics-server
+              topologyKey: kubernetes.io/hostname
+            weight: 10
+      containers:
+      - args:
+        - -endpoint
+        - https://apiserver-external.cluster-de-test-01.svc.cluster.local./healthz
+        - -insecure
+        - -retries
+        - "100"
+        - -retry-wait
+        - "2"
+        - -timeout
+        - "1"
+        - -command
+        - '{"command":"/metrics-server","args":["--kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","--authentication-kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","--authorization-kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","--kubelet-port","10250","--kubelet-insecure-tls","--kubelet-preferred-address-types","ExternalIP,InternalIP","--v","1","--logtostderr","--tls-cert-file","/etc/serving-cert/serving.crt","--tls-private-key-file","/etc/serving-cert/serving.key"]}'
+        command:
+        - /http-prober-bin/http-prober
+        image: k8s.gcr.io/metrics-server-amd64:v0.3.6
+        name: metrics-server
+        resources:
+          limits:
+            cpu: 150m
+            memory: 512Mi
+          requests:
+            cpu: 25m
+            memory: 32Mi
+        volumeMounts:
+        - mountPath: /etc/kubernetes/kubeconfig
+          name: metrics-server
+          readOnly: true
+        - mountPath: /etc/serving-cert
+          name: metrics-server-serving-cert
+          readOnly: true
+        - mountPath: /http-prober-bin
+          name: http-prober-bin
+      - args:
+        - --client
+        - --proto
+        - tcp
+        - --dev
+        - tun
+        - --auth-nocache
+        - --remote
+        - openvpn-server.cluster-de-test-01.svc.cluster.local.
+        - "1194"
+        - --nobind
+        - --connect-timeout
+        - "5"
+        - --connect-retry
+        - "1"
+        - --ca
+        - /etc/openvpn/pki/client/ca.crt
+        - --cert
+        - /etc/openvpn/pki/client/client.crt
+        - --key
+        - /etc/openvpn/pki/client/client.key
+        - --remote-cert-tls
+        - server
+        - --link-mtu
+        - "1432"
+        - --cipher
+        - AES-256-GCM
+        - --auth
+        - SHA1
+        - --keysize
+        - "256"
+        - --script-security
+        - "2"
+        - --status
+        - /run/openvpn-status
+        - --log
+        - /dev/stdout
+        command:
+        - /usr/sbin/openvpn
+        image: quay.io/kubermatic/openvpn:v2.4.8-r1
+        name: openvpn-client
+        resources:
+          limits:
+            cpu: 100m
+            memory: 32Mi
+          requests:
+            cpu: 5m
+            memory: 5Mi
+        securityContext:
+          privileged: true
+        volumeMounts:
+        - mountPath: /etc/openvpn/pki/client
+          name: openvpn-client-certificates
+          readOnly: true
+      - args:
+        - -kubeconfig
+        - /etc/kubernetes/kubeconfig/kubeconfig
+        - -node-access-network
+        - 192.0.2.0/24
+        command:
+        - /usr/local/bin/kubeletdnat-controller
+        image: quay.io/kubermatic/kubeletdnat-controller:v0.0.0-test
+        name: dnat-controller
+        resources:
+          limits:
+            cpu: 100m
+            memory: 512Mi
+          requests:
+            cpu: 5m
+            memory: 16Mi
+        securityContext:
+          capabilities:
+            add:
+            - NET_ADMIN
+          procMount: Default
+          runAsUser: 0
+        volumeMounts:
+        - mountPath: /etc/kubernetes/kubeconfig
+          name: kubeletdnatcontroller-kubeconfig
+          readOnly: true
+      imagePullSecrets:
+      - name: dockercfg
+      initContainers:
+      - command:
+        - /bin/cp
+        - /usr/local/bin/http-prober
+        - /http-prober-bin/http-prober
+        image: quay.io/kubermatic/http-prober:v0.3.1
+        name: copy-http-prober
+        resources: {}
+        volumeMounts:
+        - mountPath: /http-prober-bin
+          name: http-prober-bin
+      volumes:
+      - name: metrics-server
+        secret:
+          secretName: metrics-server
+      - name: openvpn-client-certificates
+        secret:
+          secretName: openvpn-client-certificates
+      - name: kubeletdnatcontroller-kubeconfig
+        secret:
+          secretName: kubeletdnatcontroller-kubeconfig
+      - name: metrics-server-serving-cert
+        secret:
+          secretName: metrics-server-serving-cert
+      - emptyDir: {}
+        name: http-prober-bin
+status: {}

--- a/pkg/resources/test/fixtures/deployment-digitalocean-1.20.0-openvpn-server.yaml
+++ b/pkg/resources/test/fixtures/deployment-digitalocean-1.20.0-openvpn-server.yaml
@@ -1,0 +1,223 @@
+# This file has been generated, DO NOT EDIT.
+
+metadata:
+  creationTimestamp: null
+  labels:
+    app: openvpn-server
+  name: openvpn-server
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: openvpn-server
+  strategy:
+    rollingUpdate:
+      maxSurge: 1
+      maxUnavailable: 1
+    type: RollingUpdate
+  template:
+    metadata:
+      annotations:
+        prometheus.io/path: /metrics
+        prometheus.io/port: "9176"
+        prometheus.io/scrape: "true"
+      creationTimestamp: null
+      labels:
+        app: openvpn-server
+        cluster: de-test-01
+        openvpn-ca-secret-revision: "123456"
+        openvpn-client-configs-configmap-revision: "123456"
+        openvpn-server-certificates-secret-revision: "123456"
+    spec:
+      containers:
+      - args:
+        - --proto
+        - tcp
+        - --dev
+        - tun
+        - --mode
+        - server
+        - --lport
+        - "1194"
+        - --server
+        - 10.20.0.0
+        - 255.255.255.0
+        - --ca
+        - /etc/kubernetes/pki/ca/ca.crt
+        - --cert
+        - /etc/openvpn/pki/server/server.crt
+        - --key
+        - /etc/openvpn/pki/server/server.key
+        - --dh
+        - none
+        - --duplicate-cn
+        - --client-config-dir
+        - /etc/openvpn/clients
+        - --status
+        - /run/openvpn/openvpn-status
+        - --status-version
+        - "3"
+        - --cipher
+        - AES-256-GCM
+        - --auth
+        - SHA1
+        - --keysize
+        - "256"
+        - --script-security
+        - "2"
+        - --ping
+        - "5"
+        - --verb
+        - "3"
+        - --log
+        - /dev/stdout
+        - --push
+        - route 172.25.0.0 255.255.0.0
+        - --route
+        - 172.25.0.0
+        - 255.255.0.0
+        - --push
+        - route 10.240.16.0 255.255.240.0
+        - --route
+        - 10.240.16.0
+        - 255.255.240.0
+        - --push
+        - route 192.0.2.0 255.255.255.0
+        - --route
+        - 192.0.2.0
+        - 255.255.255.0
+        command:
+        - /usr/sbin/openvpn
+        image: quay.io/kubermatic/openvpn:v2.4.8-r1
+        name: openvpn-server
+        ports:
+        - containerPort: 1194
+          protocol: TCP
+        readinessProbe:
+          exec:
+            command:
+            - test
+            - -s
+            - /run/openvpn/openvpn-status
+          failureThreshold: 3
+          initialDelaySeconds: 5
+          periodSeconds: 5
+          successThreshold: 1
+          timeoutSeconds: 1
+        resources:
+          limits:
+            cpu: 100m
+            memory: 20Mi
+          requests:
+            cpu: 5m
+            memory: 5Mi
+        securityContext:
+          privileged: true
+          procMount: Default
+        volumeMounts:
+        - mountPath: /etc/openvpn/pki/server
+          name: openvpn-server-certificates
+          readOnly: true
+        - mountPath: /etc/kubernetes/pki/ca
+          name: ca
+          readOnly: true
+        - mountPath: /etc/openvpn/clients
+          name: openvpn-client-configs
+          readOnly: true
+        - mountPath: /run/openvpn
+          name: openvpn-status
+      - args:
+        - -c
+        - |-
+          while true; do sysctl -w net.ipv4.ip_forward=1;
+            if ! iptables -t mangle -C INPUT -p tcp --tcp-flags SYN,RST SYN --dport 1194 -j TCPMSS --set-mss 1300 &>/dev/null; then
+             iptables -t mangle -A INPUT -p tcp --tcp-flags SYN,RST SYN --dport 1194 -j TCPMSS --set-mss 1300
+            fi
+            sleep 30;
+          done
+        command:
+        - /bin/bash
+        image: quay.io/kubermatic/openvpn:v2.4.8-r1
+        name: ip-fixup
+        resources:
+          limits:
+            cpu: 10m
+            memory: 32Mi
+          requests:
+            cpu: 5m
+            memory: 16Mi
+        securityContext:
+          privileged: true
+          procMount: Default
+      - args:
+        - -openvpn.status_paths
+        - /run/openvpn/openvpn-status
+        command:
+        - /bin/openvpn_exporter
+        image: docker.io/kumina/openvpn-exporter:v0.2.2
+        name: openvpn-exporter
+        ports:
+        - containerPort: 9176
+          protocol: TCP
+        resources:
+          limits:
+            cpu: 100m
+            memory: 20Mi
+          requests:
+            cpu: 5m
+            memory: 5Mi
+        volumeMounts:
+        - mountPath: /run/openvpn
+          name: openvpn-status
+      imagePullSecrets:
+      - name: dockercfg
+      initContainers:
+      - args:
+        - -c
+        - |
+          # do not give a 10.20.0.0/24 route to clients (nodes) but
+          # masquerade to openvpn-server's IP instead:
+          iptables -t nat -A POSTROUTING -o tun0 -s 10.20.0.0/24 -j MASQUERADE
+
+          # Only allow outbound traffic to services, pods, nodes
+          iptables -P FORWARD DROP
+          iptables -A FORWARD -m state --state ESTABLISHED,RELATED -j ACCEPT
+          iptables -A FORWARD -i tun0 -o tun0 -s 10.20.0.0/24 -d 172.25.0.0/16 -j ACCEPT
+          iptables -A FORWARD -i tun0 -o tun0 -s 10.20.0.0/24 -d 10.240.16.0/20 -j ACCEPT
+          iptables -A FORWARD -i tun0 -o tun0 -s 10.20.0.0/24 -d 192.0.2.0/24 -j ACCEPT
+
+          iptables -A INPUT -m state --state ESTABLISHED,RELATED -j ACCEPT
+          iptables -A INPUT -i tun0 -p icmp -j ACCEPT
+          iptables -A INPUT -i tun0 -j DROP
+        command:
+        - /bin/bash
+        image: quay.io/kubermatic/openvpn:v2.4.8-r1
+        name: iptables-init
+        resources:
+          limits:
+            cpu: 100m
+            memory: 20Mi
+          requests:
+            cpu: 5m
+            memory: 5Mi
+        securityContext:
+          capabilities:
+            add:
+            - NET_ADMIN
+          procMount: Default
+      volumes:
+      - name: ca
+        secret:
+          items:
+          - key: ca.crt
+            path: ca.crt
+          secretName: openvpn-ca
+      - name: openvpn-server-certificates
+        secret:
+          secretName: openvpn-server-certificates
+      - configMap:
+          name: openvpn-client-configs
+        name: openvpn-client-configs
+      - emptyDir: {}
+        name: openvpn-status
+status: {}

--- a/pkg/resources/test/fixtures/deployment-digitalocean-1.20.0-scheduler.yaml
+++ b/pkg/resources/test/fixtures/deployment-digitalocean-1.20.0-scheduler.yaml
@@ -1,0 +1,203 @@
+# This file has been generated, DO NOT EDIT.
+
+metadata:
+  creationTimestamp: null
+  labels:
+    app: scheduler
+  name: scheduler
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: scheduler
+  strategy: {}
+  template:
+    metadata:
+      annotations:
+        prometheus.io/path: /metrics
+        prometheus.io/port: "10259"
+        prometheus.io/scrape_with_kube_cert: "true"
+      creationTimestamp: null
+      labels:
+        app: scheduler
+        ca-secret-revision: "123456"
+        cluster: de-test-01
+        openvpn-client-certificates-secret-revision: "123456"
+        scheduler-kubeconfig-secret-revision: "123456"
+    spec:
+      affinity:
+        podAntiAffinity:
+          preferredDuringSchedulingIgnoredDuringExecution:
+          - podAffinityTerm:
+              labelSelector:
+                matchLabels:
+                  app: scheduler
+                  cluster: de-test-01
+              topologyKey: kubernetes.io/hostname
+            weight: 100
+          - podAffinityTerm:
+              labelSelector:
+                matchLabels:
+                  app: scheduler
+              topologyKey: kubernetes.io/hostname
+            weight: 10
+      containers:
+      - args:
+        - --client
+        - --proto
+        - tcp
+        - --dev
+        - tun
+        - --auth-nocache
+        - --remote
+        - openvpn-server.cluster-de-test-01.svc.cluster.local.
+        - "1194"
+        - --nobind
+        - --connect-timeout
+        - "5"
+        - --connect-retry
+        - "1"
+        - --ca
+        - /etc/openvpn/pki/client/ca.crt
+        - --cert
+        - /etc/openvpn/pki/client/client.crt
+        - --key
+        - /etc/openvpn/pki/client/client.key
+        - --remote-cert-tls
+        - server
+        - --link-mtu
+        - "1432"
+        - --cipher
+        - AES-256-GCM
+        - --auth
+        - SHA1
+        - --keysize
+        - "256"
+        - --script-security
+        - "2"
+        - --status
+        - /run/openvpn-status
+        - --log
+        - /dev/stdout
+        command:
+        - /usr/sbin/openvpn
+        image: quay.io/kubermatic/openvpn:v2.4.8-r1
+        name: openvpn-client
+        resources:
+          limits:
+            cpu: 100m
+            memory: 32Mi
+          requests:
+            cpu: 5m
+            memory: 5Mi
+        securityContext:
+          privileged: true
+        volumeMounts:
+        - mountPath: /etc/openvpn/pki/client
+          name: openvpn-client-certificates
+          readOnly: true
+      - args:
+        - -endpoint
+        - https://apiserver-external.cluster-de-test-01.svc.cluster.local./healthz
+        - -insecure
+        - -retries
+        - "100"
+        - -retry-wait
+        - "2"
+        - -timeout
+        - "1"
+        - -command
+        - '{"command":"/usr/local/bin/kube-scheduler","args":["--kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","--authentication-kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","--authorization-kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","--client-ca-file","/etc/kubernetes/pki/ca/ca.crt","--port","0"]}'
+        command:
+        - /http-prober-bin/http-prober
+        image: k8s.gcr.io/kube-scheduler:v1.20.0
+        livenessProbe:
+          failureThreshold: 8
+          httpGet:
+            path: /healthz
+            port: 10259
+            scheme: HTTPS
+          initialDelaySeconds: 15
+          periodSeconds: 10
+          successThreshold: 1
+          timeoutSeconds: 15
+        name: scheduler
+        readinessProbe:
+          failureThreshold: 3
+          httpGet:
+            path: /healthz
+            port: 10259
+            scheme: HTTPS
+          periodSeconds: 10
+          successThreshold: 1
+          timeoutSeconds: 15
+        resources:
+          limits:
+            cpu: "1"
+            memory: 512Mi
+          requests:
+            cpu: 20m
+            memory: 64Mi
+        volumeMounts:
+        - mountPath: /etc/kubernetes/kubeconfig
+          name: scheduler-kubeconfig
+          readOnly: true
+        - mountPath: /etc/kubernetes/pki/ca
+          name: ca
+          readOnly: true
+        - mountPath: /etc/ssl/certs
+          name: ca-certs
+          readOnly: true
+        - mountPath: /usr/share/ca-certificates
+          name: usr-share-ca-certificates
+          readOnly: true
+        - mountPath: /http-prober-bin
+          name: http-prober-bin
+      dnsConfig:
+        nameservers:
+        - 192.0.2.14
+        options:
+        - name: ndots
+          value: "5"
+        searches:
+        - kube-system.svc.cluster.local
+        - svc.cluster.local
+        - cluster.local
+      dnsPolicy: None
+      imagePullSecrets:
+      - name: dockercfg
+      initContainers:
+      - command:
+        - /bin/cp
+        - /usr/local/bin/http-prober
+        - /http-prober-bin/http-prober
+        image: quay.io/kubermatic/http-prober:v0.3.1
+        name: copy-http-prober
+        resources: {}
+        volumeMounts:
+        - mountPath: /http-prober-bin
+          name: http-prober-bin
+      volumes:
+      - name: openvpn-client-certificates
+        secret:
+          secretName: openvpn-client-certificates
+      - name: ca
+        secret:
+          items:
+          - key: ca.crt
+            path: ca.crt
+          secretName: ca
+      - name: scheduler-kubeconfig
+        secret:
+          secretName: scheduler-kubeconfig
+      - hostPath:
+          path: /etc/ssl/certs
+          type: DirectoryOrCreate
+        name: ca-certs
+      - hostPath:
+          path: /usr/share/ca-certificates
+          type: DirectoryOrCreate
+        name: usr-share-ca-certificates
+      - emptyDir: {}
+        name: http-prober-bin
+status: {}

--- a/pkg/resources/test/fixtures/deployment-digitalocean-1.20.0-usercluster-controller.yaml
+++ b/pkg/resources/test/fixtures/deployment-digitalocean-1.20.0-usercluster-controller.yaml
@@ -1,0 +1,95 @@
+# This file has been generated, DO NOT EDIT.
+
+metadata:
+  creationTimestamp: null
+  labels:
+    app: usercluster-controller
+  name: usercluster-controller
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: usercluster-controller
+  strategy:
+    rollingUpdate:
+      maxSurge: 1
+      maxUnavailable: 1
+    type: RollingUpdate
+  template:
+    metadata:
+      annotations:
+        prometheus.io/path: /metrics
+        prometheus.io/port: "8085"
+        prometheus.io/scrape: "true"
+      creationTimestamp: null
+      labels:
+        app: usercluster-controller
+        cluster: de-test-01
+        internal-admin-kubeconfig-secret-revision: "123456"
+    spec:
+      containers:
+      - args:
+        - -endpoint
+        - https://apiserver-external.cluster-de-test-01.svc.cluster.local./healthz
+        - -insecure
+        - -retries
+        - "100"
+        - -retry-wait
+        - "2"
+        - -timeout
+        - "1"
+        - -command
+        - '{"command":"/usr/local/bin/user-cluster-controller-manager","args":["-kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","-metrics-listen-address","0.0.0.0:8085","-health-listen-address","0.0.0.0:8086","-namespace","$(NAMESPACE)","-cluster-url","https://jh8j81chn.europe-west3-c.dev.kubermatic.io:30000","-dns-cluster-ip","10.240.16.10","-openvpn-server-port","30003","-overwrite-registry","","-openshift=false","-version","1.20.0","-cloud-provider-name","","-owner-email","","-opa-integration=false","--ipam-controller-network","192.168.1.1/24,192.168.1.1,8.8.8.8","-node-labels","{\"my-label\":\"my-value\"}"]}'
+        command:
+        - /http-prober-bin/http-prober
+        env:
+        - name: NAMESPACE
+          valueFrom:
+            fieldRef:
+              apiVersion: v1
+              fieldPath: metadata.namespace
+        image: quay.io/kubermatic/kubermatic:v0.0.0-test
+        name: usercluster-controller
+        readinessProbe:
+          failureThreshold: 5
+          httpGet:
+            path: /ready
+            port: 8086
+            scheme: HTTP
+          periodSeconds: 5
+          successThreshold: 1
+          timeoutSeconds: 15
+        resources:
+          limits:
+            cpu: 500m
+            memory: 512Mi
+          requests:
+            cpu: 25m
+            memory: 32Mi
+        volumeMounts:
+        - mountPath: /etc/kubernetes/kubeconfig
+          name: internal-admin-kubeconfig
+          readOnly: true
+        - mountPath: /http-prober-bin
+          name: http-prober-bin
+      imagePullSecrets:
+      - name: dockercfg
+      initContainers:
+      - command:
+        - /bin/cp
+        - /usr/local/bin/http-prober
+        - /http-prober-bin/http-prober
+        image: quay.io/kubermatic/http-prober:v0.3.1
+        name: copy-http-prober
+        resources: {}
+        volumeMounts:
+        - mountPath: /http-prober-bin
+          name: http-prober-bin
+      serviceAccountName: kubermatic-usercluster-controller-manager
+      volumes:
+      - name: internal-admin-kubeconfig
+        secret:
+          secretName: internal-admin-kubeconfig
+      - emptyDir: {}
+        name: http-prober-bin
+status: {}

--- a/pkg/resources/test/fixtures/deployment-openstack-1.17.0-apiserver.yaml
+++ b/pkg/resources/test/fixtures/deployment-openstack-1.17.0-apiserver.yaml
@@ -202,12 +202,12 @@ spec:
         - X-Remote-Group
         - --requestheader-username-headers
         - X-Remote-User
+        - --service-account-issuer
+        - https://jh8j81chn.europe-west3-c.dev.kubermatic.io:30000
         - --service-account-signing-key-file
         - /etc/kubernetes/service-account-key/sa.key
-        - --service-account-issuer
-        - kubernetes.default.svc
         - --api-audiences
-        - kubernetes.default.svc
+        - https://jh8j81chn.europe-west3-c.dev.kubermatic.io:30000
         - --kubelet-preferred-address-types
         - ExternalIP,InternalIP
         - --cloud-provider

--- a/pkg/resources/test/fixtures/deployment-openstack-1.17.0-usercluster-controller.yaml
+++ b/pkg/resources/test/fixtures/deployment-openstack-1.17.0-usercluster-controller.yaml
@@ -39,7 +39,7 @@ spec:
         - -timeout
         - "1"
         - -command
-        - '{"command":"/usr/local/bin/user-cluster-controller-manager","args":["-kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","-metrics-listen-address","0.0.0.0:8085","-health-listen-address","0.0.0.0:8086","-namespace","$(NAMESPACE)","-cluster-url","","-dns-cluster-ip","10.240.16.10","-openvpn-server-port","30003","-overwrite-registry","","-openshift=false","-version","1.17.0","-cloud-provider-name","openstack","-owner-email","","-opa-integration=false","--ipam-controller-network","192.168.1.1/24,192.168.1.1,8.8.8.8","-node-labels","{\"my-label\":\"my-value\"}"]}'
+        - '{"command":"/usr/local/bin/user-cluster-controller-manager","args":["-kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","-metrics-listen-address","0.0.0.0:8085","-health-listen-address","0.0.0.0:8086","-namespace","$(NAMESPACE)","-cluster-url","https://jh8j81chn.europe-west3-c.dev.kubermatic.io:30000","-dns-cluster-ip","10.240.16.10","-openvpn-server-port","30003","-overwrite-registry","","-openshift=false","-version","1.17.0","-cloud-provider-name","openstack","-owner-email","","-opa-integration=false","--ipam-controller-network","192.168.1.1/24,192.168.1.1,8.8.8.8","-node-labels","{\"my-label\":\"my-value\"}"]}'
         command:
         - /http-prober-bin/http-prober
         env:

--- a/pkg/resources/test/fixtures/deployment-openstack-1.18.0-apiserver.yaml
+++ b/pkg/resources/test/fixtures/deployment-openstack-1.18.0-apiserver.yaml
@@ -202,12 +202,12 @@ spec:
         - X-Remote-Group
         - --requestheader-username-headers
         - X-Remote-User
+        - --service-account-issuer
+        - https://jh8j81chn.europe-west3-c.dev.kubermatic.io:30000
         - --service-account-signing-key-file
         - /etc/kubernetes/service-account-key/sa.key
-        - --service-account-issuer
-        - kubernetes.default.svc
         - --api-audiences
-        - kubernetes.default.svc
+        - https://jh8j81chn.europe-west3-c.dev.kubermatic.io:30000
         - --kubelet-preferred-address-types
         - ExternalIP,InternalIP
         - --cloud-provider

--- a/pkg/resources/test/fixtures/deployment-openstack-1.18.0-usercluster-controller.yaml
+++ b/pkg/resources/test/fixtures/deployment-openstack-1.18.0-usercluster-controller.yaml
@@ -39,7 +39,7 @@ spec:
         - -timeout
         - "1"
         - -command
-        - '{"command":"/usr/local/bin/user-cluster-controller-manager","args":["-kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","-metrics-listen-address","0.0.0.0:8085","-health-listen-address","0.0.0.0:8086","-namespace","$(NAMESPACE)","-cluster-url","","-dns-cluster-ip","10.240.16.10","-openvpn-server-port","30003","-overwrite-registry","","-openshift=false","-version","1.18.0","-cloud-provider-name","openstack","-owner-email","","-opa-integration=false","--ipam-controller-network","192.168.1.1/24,192.168.1.1,8.8.8.8","-node-labels","{\"my-label\":\"my-value\"}"]}'
+        - '{"command":"/usr/local/bin/user-cluster-controller-manager","args":["-kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","-metrics-listen-address","0.0.0.0:8085","-health-listen-address","0.0.0.0:8086","-namespace","$(NAMESPACE)","-cluster-url","https://jh8j81chn.europe-west3-c.dev.kubermatic.io:30000","-dns-cluster-ip","10.240.16.10","-openvpn-server-port","30003","-overwrite-registry","","-openshift=false","-version","1.18.0","-cloud-provider-name","openstack","-owner-email","","-opa-integration=false","--ipam-controller-network","192.168.1.1/24,192.168.1.1,8.8.8.8","-node-labels","{\"my-label\":\"my-value\"}"]}'
         command:
         - /http-prober-bin/http-prober
         env:

--- a/pkg/resources/test/fixtures/deployment-openstack-1.19.0-apiserver.yaml
+++ b/pkg/resources/test/fixtures/deployment-openstack-1.19.0-apiserver.yaml
@@ -202,12 +202,12 @@ spec:
         - X-Remote-Group
         - --requestheader-username-headers
         - X-Remote-User
+        - --service-account-issuer
+        - https://jh8j81chn.europe-west3-c.dev.kubermatic.io:30000
         - --service-account-signing-key-file
         - /etc/kubernetes/service-account-key/sa.key
-        - --service-account-issuer
-        - kubernetes.default.svc
         - --api-audiences
-        - kubernetes.default.svc
+        - https://jh8j81chn.europe-west3-c.dev.kubermatic.io:30000
         - --kubelet-preferred-address-types
         - ExternalIP,InternalIP
         - --cloud-provider

--- a/pkg/resources/test/fixtures/deployment-openstack-1.19.0-usercluster-controller.yaml
+++ b/pkg/resources/test/fixtures/deployment-openstack-1.19.0-usercluster-controller.yaml
@@ -39,7 +39,7 @@ spec:
         - -timeout
         - "1"
         - -command
-        - '{"command":"/usr/local/bin/user-cluster-controller-manager","args":["-kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","-metrics-listen-address","0.0.0.0:8085","-health-listen-address","0.0.0.0:8086","-namespace","$(NAMESPACE)","-cluster-url","","-dns-cluster-ip","10.240.16.10","-openvpn-server-port","30003","-overwrite-registry","","-openshift=false","-version","1.19.0","-cloud-provider-name","openstack","-owner-email","","-opa-integration=false","--ipam-controller-network","192.168.1.1/24,192.168.1.1,8.8.8.8","-node-labels","{\"my-label\":\"my-value\"}"]}'
+        - '{"command":"/usr/local/bin/user-cluster-controller-manager","args":["-kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","-metrics-listen-address","0.0.0.0:8085","-health-listen-address","0.0.0.0:8086","-namespace","$(NAMESPACE)","-cluster-url","https://jh8j81chn.europe-west3-c.dev.kubermatic.io:30000","-dns-cluster-ip","10.240.16.10","-openvpn-server-port","30003","-overwrite-registry","","-openshift=false","-version","1.19.0","-cloud-provider-name","openstack","-owner-email","","-opa-integration=false","--ipam-controller-network","192.168.1.1/24,192.168.1.1,8.8.8.8","-node-labels","{\"my-label\":\"my-value\"}"]}'
         command:
         - /http-prober-bin/http-prober
         env:

--- a/pkg/resources/test/fixtures/deployment-openstack-1.20.0-apiserver.yaml
+++ b/pkg/resources/test/fixtures/deployment-openstack-1.20.0-apiserver.yaml
@@ -1,0 +1,406 @@
+# This file has been generated, DO NOT EDIT.
+
+metadata:
+  creationTimestamp: null
+  labels:
+    app: apiserver
+  name: apiserver
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: apiserver
+  strategy: {}
+  template:
+    metadata:
+      annotations:
+        prometheus.io/path: /metrics
+        prometheus.io/port: "30000"
+        prometheus.io/scrape_with_kube_cert: "true"
+      creationTimestamp: null
+      labels:
+        adm-control-configmap-revision: "123456"
+        apiserver-etcd-client-certificate-secret-revision: "123456"
+        apiserver-proxy-client-certificate-secret-revision: "123456"
+        apiserver-tls-secret-revision: "123456"
+        app: apiserver
+        audit-config-configmap-revision: "123456"
+        ca-secret-revision: "123456"
+        cloud-config-configmap-revision: "123456"
+        cluster: de-test-01
+        dex-ca-secret-revision: "123456"
+        front-proxy-ca-secret-revision: "123456"
+        kubelet-client-certificates-secret-revision: "123456"
+        kubeletdnatcontroller-kubeconfig-secret-revision: "123456"
+        openvpn-client-certificates-secret-revision: "123456"
+        service-account-key-secret-revision: "123456"
+        tokens-secret-revision: "123456"
+    spec:
+      affinity:
+        podAntiAffinity:
+          preferredDuringSchedulingIgnoredDuringExecution:
+          - podAffinityTerm:
+              labelSelector:
+                matchLabels:
+                  app: apiserver
+                  cluster: de-test-01
+              topologyKey: kubernetes.io/hostname
+            weight: 100
+          - podAffinityTerm:
+              labelSelector:
+                matchLabels:
+                  app: apiserver
+              topologyKey: kubernetes.io/hostname
+            weight: 10
+      containers:
+      - args:
+        - --client
+        - --proto
+        - tcp
+        - --dev
+        - tun
+        - --auth-nocache
+        - --remote
+        - openvpn-server.cluster-de-test-01.svc.cluster.local.
+        - "1194"
+        - --nobind
+        - --connect-timeout
+        - "5"
+        - --connect-retry
+        - "1"
+        - --ca
+        - /etc/openvpn/pki/client/ca.crt
+        - --cert
+        - /etc/openvpn/pki/client/client.crt
+        - --key
+        - /etc/openvpn/pki/client/client.key
+        - --remote-cert-tls
+        - server
+        - --link-mtu
+        - "1432"
+        - --cipher
+        - AES-256-GCM
+        - --auth
+        - SHA1
+        - --keysize
+        - "256"
+        - --script-security
+        - "2"
+        - --status
+        - /run/openvpn-status
+        - --log
+        - /dev/stdout
+        command:
+        - /usr/sbin/openvpn
+        image: quay.io/kubermatic/openvpn:v2.4.8-r1
+        name: openvpn-client
+        resources:
+          limits:
+            cpu: 100m
+            memory: 32Mi
+          requests:
+            cpu: 5m
+            memory: 5Mi
+        securityContext:
+          privileged: true
+        volumeMounts:
+        - mountPath: /etc/openvpn/pki/client
+          name: openvpn-client-certificates
+          readOnly: true
+      - args:
+        - -kubeconfig
+        - /etc/kubernetes/kubeconfig/kubeconfig
+        - -node-access-network
+        - 192.0.2.0/24
+        - -master
+        - https://127.0.0.1:30000
+        command:
+        - /usr/local/bin/kubeletdnat-controller
+        image: quay.io/kubermatic/kubeletdnat-controller:v0.0.0-test
+        name: dnat-controller
+        resources:
+          limits:
+            cpu: 100m
+            memory: 512Mi
+          requests:
+            cpu: 5m
+            memory: 16Mi
+        securityContext:
+          capabilities:
+            add:
+            - NET_ADMIN
+          procMount: Default
+          runAsUser: 0
+        volumeMounts:
+        - mountPath: /etc/kubernetes/kubeconfig
+          name: kubeletdnatcontroller-kubeconfig
+          readOnly: true
+      - args:
+        - --advertise-address
+        - 35.198.93.90
+        - --secure-port
+        - "30000"
+        - --kubernetes-service-node-port
+        - "30000"
+        - --etcd-servers
+        - https://etcd-0.etcd.cluster-de-test-01.svc.cluster.local.:2379,https://etcd-1.etcd.cluster-de-test-01.svc.cluster.local.:2379,https://etcd-2.etcd.cluster-de-test-01.svc.cluster.local.:2379
+        - --etcd-cafile
+        - /etc/etcd/pki/client/ca.crt
+        - --etcd-certfile
+        - /etc/etcd/pki/client/apiserver-etcd-client.crt
+        - --etcd-keyfile
+        - /etc/etcd/pki/client/apiserver-etcd-client.key
+        - --storage-backend
+        - etcd3
+        - --enable-admission-plugins
+        - DefaultStorageClass,DefaultTolerationSeconds,LimitRanger,MutatingAdmissionWebhook,NamespaceLifecycle,Priority,ResourceQuota,ServiceAccount,ValidatingAdmissionWebhook
+        - --admission-control-config-file
+        - /etc/kubernetes/adm-control/admission-control.yaml
+        - --authorization-mode
+        - Node,RBAC
+        - --external-hostname
+        - jh8j81chn.europe-west3-c.dev.kubermatic.io
+        - --token-auth-file
+        - /etc/kubernetes/tokens/tokens.csv
+        - --enable-bootstrap-token-auth
+        - --service-account-key-file
+        - /etc/kubernetes/service-account-key/sa.key
+        - --service-cluster-ip-range
+        - 10.240.16.0/20
+        - --service-node-port-range
+        - 30000-32767
+        - --allow-privileged
+        - --audit-log-maxage
+        - "30"
+        - --audit-log-maxbackup
+        - "3"
+        - --audit-log-maxsize
+        - "100"
+        - --audit-log-path
+        - /var/log/kubernetes/audit/audit.log
+        - --tls-cert-file
+        - /etc/kubernetes/tls/apiserver-tls.crt
+        - --tls-private-key-file
+        - /etc/kubernetes/tls/apiserver-tls.key
+        - --proxy-client-cert-file
+        - /etc/kubernetes/pki/front-proxy/client/apiserver-proxy-client.crt
+        - --proxy-client-key-file
+        - /etc/kubernetes/pki/front-proxy/client/apiserver-proxy-client.key
+        - --client-ca-file
+        - /etc/kubernetes/pki/ca/ca.crt
+        - --kubelet-client-certificate
+        - /etc/kubernetes/kubelet/kubelet-client.crt
+        - --kubelet-client-key
+        - /etc/kubernetes/kubelet/kubelet-client.key
+        - --requestheader-client-ca-file
+        - /etc/kubernetes/pki/front-proxy/ca/ca.crt
+        - --requestheader-allowed-names
+        - apiserver-aggregator
+        - --requestheader-extra-headers-prefix
+        - X-Remote-Extra-
+        - --requestheader-group-headers
+        - X-Remote-Group
+        - --requestheader-username-headers
+        - X-Remote-User
+        - --service-account-issuer
+        - https://jh8j81chn.europe-west3-c.dev.kubermatic.io:30000
+        - --service-account-signing-key-file
+        - /etc/kubernetes/service-account-key/sa.key
+        - --api-audiences
+        - https://jh8j81chn.europe-west3-c.dev.kubermatic.io:30000
+        - --kubelet-preferred-address-types
+        - ExternalIP,InternalIP
+        - --cloud-provider
+        - openstack
+        - --cloud-config
+        - /etc/kubernetes/cloud/config
+        - --oidc-issuer-url
+        - https://dev.kubermatic.io/dex
+        - --oidc-client-id
+        - kubermaticIssuer
+        - --oidc-username-claim
+        - email
+        - --oidc-groups-prefix
+        - 'oidc:'
+        - --oidc-groups-claim
+        - groups
+        - --oidc-ca-file
+        - /etc/kubernetes/dex/ca/caBundle.pem
+        command:
+        - /usr/local/bin/kube-apiserver
+        env:
+        - name: HTTP_PROXY
+          value: http://my-corp
+        - name: HTTPS_PROXY
+          value: http://my-corp
+        - name: http_proxy
+          value: http://my-corp
+        - name: https_proxy
+          value: http://my-corp
+        - name: NO_PROXY
+          value: apiserver-external.cluster-de-test-01.svc.cluster.local.
+        - name: no_proxy
+          value: apiserver-external.cluster-de-test-01.svc.cluster.local.
+        image: k8s.gcr.io/kube-apiserver:v1.20.0
+        livenessProbe:
+          failureThreshold: 8
+          httpGet:
+            path: /healthz
+            port: 30000
+            scheme: HTTPS
+          initialDelaySeconds: 15
+          periodSeconds: 10
+          successThreshold: 1
+          timeoutSeconds: 15
+        name: apiserver
+        ports:
+        - containerPort: 30000
+          protocol: TCP
+        readinessProbe:
+          failureThreshold: 3
+          httpGet:
+            path: /healthz
+            port: 30000
+            scheme: HTTPS
+          periodSeconds: 5
+          successThreshold: 1
+          timeoutSeconds: 15
+        resources:
+          limits:
+            cpu: "2"
+            memory: 4Gi
+          requests:
+            cpu: 100m
+            memory: 256Mi
+        volumeMounts:
+        - mountPath: /etc/kubernetes/tls
+          name: apiserver-tls
+          readOnly: true
+        - mountPath: /etc/kubernetes/tokens
+          name: tokens
+          readOnly: true
+        - mountPath: /etc/kubernetes/kubelet
+          name: kubelet-client-certificates
+          readOnly: true
+        - mountPath: /etc/kubernetes/pki/ca
+          name: ca
+          readOnly: true
+        - mountPath: /etc/kubernetes/service-account-key
+          name: service-account-key
+          readOnly: true
+        - mountPath: /etc/kubernetes/cloud
+          name: cloud-config
+          readOnly: true
+        - mountPath: /etc/etcd/pki/client
+          name: apiserver-etcd-client-certificate
+          readOnly: true
+        - mountPath: /etc/kubernetes/pki/front-proxy/client
+          name: apiserver-proxy-client-certificate
+          readOnly: true
+        - mountPath: /etc/kubernetes/pki/front-proxy/ca
+          name: front-proxy-ca
+          readOnly: true
+        - mountPath: /etc/kubernetes/audit
+          name: audit-config
+          readOnly: true
+        - mountPath: /var/log/kubernetes/audit
+          name: audit-log
+        - mountPath: /etc/kubernetes/adm-control
+          name: adm-control
+          readOnly: true
+        - mountPath: /etc/ssl/certs
+          name: ca-certs
+          readOnly: true
+        - mountPath: /usr/share/ca-certificates
+          name: usr-share-ca-certificates
+          readOnly: true
+        - mountPath: /etc/kubernetes/dex/ca
+          name: dex-ca
+          readOnly: true
+      dnsConfig:
+        nameservers:
+        - 192.0.2.14
+        options:
+        - name: ndots
+          value: "5"
+        searches:
+        - kube-system.svc.cluster.local
+        - svc.cluster.local
+        - cluster.local
+      dnsPolicy: None
+      imagePullSecrets:
+      - name: dockercfg
+      initContainers:
+      - command:
+        - /bin/sh
+        - -ec
+        - until ETCDCTL_API=3 /usr/local/bin/etcdctl --cacert=/etc/etcd/pki/client/ca.crt
+          --cert=/etc/etcd/pki/client/apiserver-etcd-client.crt --key=/etc/etcd/pki/client/apiserver-etcd-client.key
+          --dial-timeout=2s --endpoints='https://etcd-0.etcd.cluster-de-test-01.svc.cluster.local.:2379,https://etcd-1.etcd.cluster-de-test-01.svc.cluster.local.:2379,https://etcd-2.etcd.cluster-de-test-01.svc.cluster.local.:2379'
+          put kubermatic/quorum-check something; do echo waiting for etcd; sleep 2;
+          done;
+        image: gcr.io/etcd-development/etcd:v3.4.3
+        name: etcd-running
+        resources: {}
+        volumeMounts:
+        - mountPath: /etc/etcd/pki/client
+          name: apiserver-etcd-client-certificate
+          readOnly: true
+      volumes:
+      - name: apiserver-tls
+        secret:
+          secretName: apiserver-tls
+      - name: tokens
+        secret:
+          secretName: tokens
+      - name: openvpn-client-certificates
+        secret:
+          secretName: openvpn-client-certificates
+      - name: kubelet-client-certificates
+        secret:
+          secretName: kubelet-client-certificates
+      - name: ca
+        secret:
+          items:
+          - key: ca.crt
+            path: ca.crt
+          secretName: ca
+      - name: service-account-key
+        secret:
+          secretName: service-account-key
+      - configMap:
+          name: cloud-config
+        name: cloud-config
+      - name: apiserver-etcd-client-certificate
+        secret:
+          secretName: apiserver-etcd-client-certificate
+      - name: apiserver-proxy-client-certificate
+        secret:
+          secretName: apiserver-proxy-client-certificate
+      - name: front-proxy-ca
+        secret:
+          secretName: front-proxy-ca
+      - name: kubeletdnatcontroller-kubeconfig
+        secret:
+          secretName: kubeletdnatcontroller-kubeconfig
+      - configMap:
+          name: audit-config
+          optional: false
+        name: audit-config
+      - emptyDir: {}
+        name: audit-log
+      - configMap:
+          name: adm-control
+        name: adm-control
+      - hostPath:
+          path: /etc/ssl/certs
+          type: DirectoryOrCreate
+        name: ca-certs
+      - hostPath:
+          path: /usr/share/ca-certificates
+          type: DirectoryOrCreate
+        name: usr-share-ca-certificates
+      - name: dex-ca
+        secret:
+          secretName: dex-ca
+status: {}

--- a/pkg/resources/test/fixtures/deployment-openstack-1.20.0-controller-manager.yaml
+++ b/pkg/resources/test/fixtures/deployment-openstack-1.20.0-controller-manager.yaml
@@ -1,0 +1,227 @@
+# This file has been generated, DO NOT EDIT.
+
+metadata:
+  creationTimestamp: null
+  labels:
+    app: controller-manager
+  name: controller-manager
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: controller-manager
+  strategy: {}
+  template:
+    metadata:
+      annotations:
+        prometheus.io/path: /metrics
+        prometheus.io/port: "10257"
+        prometheus.io/scrape_with_kube_cert: "true"
+      creationTimestamp: null
+      labels:
+        app: controller-manager
+        ca-secret-revision: "123456"
+        cloud-config-configmap-revision: "123456"
+        cluster: de-test-01
+        controllermanager-kubeconfig-secret-revision: "123456"
+        openvpn-client-certificates-secret-revision: "123456"
+        service-account-key-secret-revision: "123456"
+    spec:
+      affinity:
+        podAntiAffinity:
+          preferredDuringSchedulingIgnoredDuringExecution:
+          - podAffinityTerm:
+              labelSelector:
+                matchLabels:
+                  app: controller-manager
+                  cluster: de-test-01
+              topologyKey: kubernetes.io/hostname
+            weight: 100
+          - podAffinityTerm:
+              labelSelector:
+                matchLabels:
+                  app: controller-manager
+              topologyKey: kubernetes.io/hostname
+            weight: 10
+      containers:
+      - args:
+        - --client
+        - --proto
+        - tcp
+        - --dev
+        - tun
+        - --auth-nocache
+        - --remote
+        - openvpn-server.cluster-de-test-01.svc.cluster.local.
+        - "1194"
+        - --nobind
+        - --connect-timeout
+        - "5"
+        - --connect-retry
+        - "1"
+        - --ca
+        - /etc/openvpn/pki/client/ca.crt
+        - --cert
+        - /etc/openvpn/pki/client/client.crt
+        - --key
+        - /etc/openvpn/pki/client/client.key
+        - --remote-cert-tls
+        - server
+        - --link-mtu
+        - "1432"
+        - --cipher
+        - AES-256-GCM
+        - --auth
+        - SHA1
+        - --keysize
+        - "256"
+        - --script-security
+        - "2"
+        - --status
+        - /run/openvpn-status
+        - --log
+        - /dev/stdout
+        command:
+        - /usr/sbin/openvpn
+        image: quay.io/kubermatic/openvpn:v2.4.8-r1
+        name: openvpn-client
+        resources:
+          limits:
+            cpu: 100m
+            memory: 32Mi
+          requests:
+            cpu: 5m
+            memory: 5Mi
+        securityContext:
+          privileged: true
+        volumeMounts:
+        - mountPath: /etc/openvpn/pki/client
+          name: openvpn-client-certificates
+          readOnly: true
+      - args:
+        - -endpoint
+        - https://apiserver-external.cluster-de-test-01.svc.cluster.local./healthz
+        - -insecure
+        - -retries
+        - "100"
+        - -retry-wait
+        - "2"
+        - -timeout
+        - "1"
+        - -command
+        - '{"command":"/usr/local/bin/kube-controller-manager","args":["--kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","--service-account-private-key-file","/etc/kubernetes/service-account-key/sa.key","--root-ca-file","/etc/kubernetes/pki/ca/ca.crt","--cluster-signing-cert-file","/etc/kubernetes/pki/ca/ca.crt","--cluster-signing-key-file","/etc/kubernetes/pki/ca/ca.key","--cluster-cidr","172.25.0.0/16","--allocate-node-cidrs","--controllers","*,bootstrapsigner,tokencleaner","--use-service-account-credentials","--feature-gates","RotateKubeletClientCertificate=true,RotateKubeletServerCertificate=true","--cloud-provider","openstack","--cloud-config","/etc/kubernetes/cloud/config","--configure-cloud-routes=false","--authentication-kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","--client-ca-file","/etc/kubernetes/pki/ca/ca.crt","--authentication-kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","--authorization-kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","--port","0"]}'
+        command:
+        - /http-prober-bin/http-prober
+        env:
+        - name: HTTP_PROXY
+          value: http://my-corp
+        - name: HTTPS_PROXY
+          value: http://my-corp
+        - name: http_proxy
+          value: http://my-corp
+        - name: https_proxy
+          value: http://my-corp
+        - name: NO_PROXY
+          value: apiserver-external.cluster-de-test-01.svc.cluster.local.
+        - name: no_proxy
+          value: apiserver-external.cluster-de-test-01.svc.cluster.local.
+        image: k8s.gcr.io/kube-controller-manager:v1.20.0
+        livenessProbe:
+          failureThreshold: 8
+          httpGet:
+            path: /healthz
+            port: 10257
+            scheme: HTTPS
+          initialDelaySeconds: 15
+          periodSeconds: 10
+          successThreshold: 1
+          timeoutSeconds: 15
+        name: controller-manager
+        readinessProbe:
+          failureThreshold: 3
+          httpGet:
+            path: /healthz
+            port: 10257
+            scheme: HTTPS
+          periodSeconds: 10
+          successThreshold: 1
+          timeoutSeconds: 15
+        resources:
+          limits:
+            cpu: "2"
+            memory: 2Gi
+          requests:
+            cpu: 100m
+            memory: 100Mi
+        volumeMounts:
+        - mountPath: /etc/kubernetes/pki/ca
+          name: ca
+          readOnly: true
+        - mountPath: /etc/kubernetes/service-account-key
+          name: service-account-key
+          readOnly: true
+        - mountPath: /etc/kubernetes/cloud
+          name: cloud-config
+          readOnly: true
+        - mountPath: /etc/kubernetes/kubeconfig
+          name: controllermanager-kubeconfig
+          readOnly: true
+        - mountPath: /etc/ssl/certs
+          name: ca-certs
+          readOnly: true
+        - mountPath: /usr/share/ca-certificates
+          name: usr-share-ca-certificates
+          readOnly: true
+        - mountPath: /http-prober-bin
+          name: http-prober-bin
+      dnsConfig:
+        nameservers:
+        - 192.0.2.14
+        options:
+        - name: ndots
+          value: "5"
+        searches:
+        - kube-system.svc.cluster.local
+        - svc.cluster.local
+        - cluster.local
+      dnsPolicy: None
+      imagePullSecrets:
+      - name: dockercfg
+      initContainers:
+      - command:
+        - /bin/cp
+        - /usr/local/bin/http-prober
+        - /http-prober-bin/http-prober
+        image: quay.io/kubermatic/http-prober:v0.3.1
+        name: copy-http-prober
+        resources: {}
+        volumeMounts:
+        - mountPath: /http-prober-bin
+          name: http-prober-bin
+      volumes:
+      - name: ca
+        secret:
+          secretName: ca
+      - name: service-account-key
+        secret:
+          secretName: service-account-key
+      - configMap:
+          name: cloud-config
+        name: cloud-config
+      - name: openvpn-client-certificates
+        secret:
+          secretName: openvpn-client-certificates
+      - name: controllermanager-kubeconfig
+        secret:
+          secretName: controllermanager-kubeconfig
+      - hostPath:
+          path: /etc/ssl/certs
+          type: DirectoryOrCreate
+        name: ca-certs
+      - hostPath:
+          path: /usr/share/ca-certificates
+          type: DirectoryOrCreate
+        name: usr-share-ca-certificates
+      - emptyDir: {}
+        name: http-prober-bin
+status: {}

--- a/pkg/resources/test/fixtures/deployment-openstack-1.20.0-dns-resolver.yaml
+++ b/pkg/resources/test/fixtures/deployment-openstack-1.20.0-dns-resolver.yaml
@@ -1,0 +1,140 @@
+# This file has been generated, DO NOT EDIT.
+
+metadata:
+  creationTimestamp: null
+  labels:
+    app: dns-resolver
+  name: dns-resolver
+spec:
+  replicas: 2
+  selector:
+    matchLabels:
+      app: dns-resolver
+  strategy: {}
+  template:
+    metadata:
+      annotations:
+        prometheus.io/path: /metrics
+        prometheus.io/port: "9253"
+        prometheus.io/scrape: "true"
+      creationTimestamp: null
+      labels:
+        app: dns-resolver
+        ca-secret-revision: "123456"
+        cluster: de-test-01
+        dns-resolver-configmap-revision: "123456"
+        openvpn-client-certificates-secret-revision: "123456"
+    spec:
+      affinity:
+        podAntiAffinity:
+          preferredDuringSchedulingIgnoredDuringExecution:
+          - podAffinityTerm:
+              labelSelector:
+                matchLabels:
+                  app: dns-resolver
+                  cluster: de-test-01
+              topologyKey: kubernetes.io/hostname
+            weight: 100
+          - podAffinityTerm:
+              labelSelector:
+                matchLabels:
+                  app: dns-resolver
+              topologyKey: kubernetes.io/hostname
+            weight: 10
+      containers:
+      - args:
+        - --client
+        - --proto
+        - tcp
+        - --dev
+        - tun
+        - --auth-nocache
+        - --remote
+        - openvpn-server.cluster-de-test-01.svc.cluster.local.
+        - "1194"
+        - --nobind
+        - --connect-timeout
+        - "5"
+        - --connect-retry
+        - "1"
+        - --ca
+        - /etc/openvpn/pki/client/ca.crt
+        - --cert
+        - /etc/openvpn/pki/client/client.crt
+        - --key
+        - /etc/openvpn/pki/client/client.key
+        - --remote-cert-tls
+        - server
+        - --link-mtu
+        - "1432"
+        - --cipher
+        - AES-256-GCM
+        - --auth
+        - SHA1
+        - --keysize
+        - "256"
+        - --script-security
+        - "2"
+        - --status
+        - /run/openvpn-status
+        - --log
+        - /dev/stdout
+        command:
+        - /usr/sbin/openvpn
+        image: quay.io/kubermatic/openvpn:v2.4.8-r1
+        name: openvpn-client
+        resources:
+          limits:
+            cpu: 100m
+            memory: 32Mi
+          requests:
+            cpu: 5m
+            memory: 5Mi
+        securityContext:
+          privileged: true
+        volumeMounts:
+        - mountPath: /etc/openvpn/pki/client
+          name: openvpn-client-certificates
+          readOnly: true
+      - args:
+        - -conf
+        - /etc/coredns/Corefile
+        image: k8s.gcr.io/coredns:1.3.1
+        name: dns-resolver
+        readinessProbe:
+          failureThreshold: 3
+          httpGet:
+            path: /health
+            port: 8080
+            scheme: HTTP
+          initialDelaySeconds: 2
+          periodSeconds: 10
+          successThreshold: 1
+          timeoutSeconds: 15
+        resources:
+          limits:
+            cpu: 100m
+            memory: 128Mi
+          requests:
+            cpu: 5m
+            memory: 20Mi
+        volumeMounts:
+        - mountPath: /etc/coredns
+          name: dns-resolver
+          readOnly: true
+      imagePullSecrets:
+      - name: dockercfg
+      volumes:
+      - configMap:
+          name: dns-resolver
+        name: dns-resolver
+      - name: openvpn-client-certificates
+        secret:
+          secretName: openvpn-client-certificates
+      - name: ca
+        secret:
+          items:
+          - key: ca.crt
+            path: ca.crt
+          secretName: ca
+status: {}

--- a/pkg/resources/test/fixtures/deployment-openstack-1.20.0-kube-state-metrics.yaml
+++ b/pkg/resources/test/fixtures/deployment-openstack-1.20.0-kube-state-metrics.yaml
@@ -1,0 +1,89 @@
+# This file has been generated, DO NOT EDIT.
+
+metadata:
+  creationTimestamp: null
+  labels:
+    app: kube-state-metrics
+  name: kube-state-metrics
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: kube-state-metrics
+  strategy: {}
+  template:
+    metadata:
+      annotations:
+        prometheus.io/scrape: "true"
+      creationTimestamp: null
+      labels:
+        app: kube-state-metrics
+        cluster: de-test-01
+        kube-state-metrics-kubeconfig-secret-revision: "123456"
+    spec:
+      containers:
+      - args:
+        - -endpoint
+        - https://apiserver-external.cluster-de-test-01.svc.cluster.local./healthz
+        - -insecure
+        - -retries
+        - "100"
+        - -retry-wait
+        - "2"
+        - -timeout
+        - "1"
+        - -command
+        - '{"command":"/kube-state-metrics","args":["--kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","--port","8080","--telemetry-port","8081"]}'
+        command:
+        - /http-prober-bin/http-prober
+        image: quay.io/coreos/kube-state-metrics:v1.9.7
+        name: kube-state-metrics
+        ports:
+        - containerPort: 8080
+          name: metrics
+          protocol: TCP
+        - containerPort: 8081
+          name: telemetry
+          protocol: TCP
+        readinessProbe:
+          failureThreshold: 3
+          httpGet:
+            path: /healthz
+            port: 8080
+            scheme: HTTP
+          periodSeconds: 10
+          successThreshold: 1
+          timeoutSeconds: 15
+        resources:
+          limits:
+            cpu: 100m
+            memory: 1Gi
+          requests:
+            cpu: 10m
+            memory: 12Mi
+        volumeMounts:
+        - mountPath: /etc/kubernetes/kubeconfig
+          name: kube-state-metrics-kubeconfig
+          readOnly: true
+        - mountPath: /http-prober-bin
+          name: http-prober-bin
+      imagePullSecrets:
+      - name: dockercfg
+      initContainers:
+      - command:
+        - /bin/cp
+        - /usr/local/bin/http-prober
+        - /http-prober-bin/http-prober
+        image: quay.io/kubermatic/http-prober:v0.3.1
+        name: copy-http-prober
+        resources: {}
+        volumeMounts:
+        - mountPath: /http-prober-bin
+          name: http-prober-bin
+      volumes:
+      - name: kube-state-metrics-kubeconfig
+        secret:
+          secretName: kube-state-metrics-kubeconfig
+      - emptyDir: {}
+        name: http-prober-bin
+status: {}

--- a/pkg/resources/test/fixtures/deployment-openstack-1.20.0-kubernetes-dashboard.yaml
+++ b/pkg/resources/test/fixtures/deployment-openstack-1.20.0-kubernetes-dashboard.yaml
@@ -1,0 +1,97 @@
+# This file has been generated, DO NOT EDIT.
+
+metadata:
+  creationTimestamp: null
+  labels:
+    app: kubernetes-dashboard
+  name: kubernetes-dashboard
+spec:
+  replicas: 2
+  selector:
+    matchLabels:
+      app: kubernetes-dashboard
+  strategy: {}
+  template:
+    metadata:
+      creationTimestamp: null
+      labels:
+        app: kubernetes-dashboard
+        cluster: de-test-01
+        kubernetes-dashboard-kubeconfig-secret-revision: "123456"
+    spec:
+      affinity:
+        podAntiAffinity:
+          preferredDuringSchedulingIgnoredDuringExecution:
+          - podAffinityTerm:
+              labelSelector:
+                matchLabels:
+                  app: kubernetes-dashboard
+                  cluster: de-test-01
+              topologyKey: kubernetes.io/hostname
+            weight: 100
+          - podAffinityTerm:
+              labelSelector:
+                matchLabels:
+                  app: kubernetes-dashboard
+              topologyKey: kubernetes.io/hostname
+            weight: 10
+      containers:
+      - args:
+        - -endpoint
+        - https://apiserver-external.cluster-de-test-01.svc.cluster.local./healthz
+        - -insecure
+        - -retries
+        - "100"
+        - -retry-wait
+        - "2"
+        - -timeout
+        - "1"
+        - -command
+        - '{"command":"/dashboard","args":["--kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","--namespace","kubernetes-dashboard","--enable-insecure-login"]}'
+        command:
+        - /http-prober-bin/http-prober
+        image: docker.io/kubernetesui/dashboard:v2.0.4
+        imagePullPolicy: IfNotPresent
+        name: kubernetes-dashboard
+        ports:
+        - containerPort: 9090
+          protocol: TCP
+        resources:
+          limits:
+            cpu: 250m
+            memory: 512Mi
+          requests:
+            cpu: 100m
+            memory: 256Mi
+        securityContext:
+          allowPrivilegeEscalation: false
+          readOnlyRootFilesystem: true
+          runAsUser: 1001
+        volumeMounts:
+        - mountPath: /etc/kubernetes/kubeconfig
+          name: kubernetes-dashboard-kubeconfig
+          readOnly: true
+        - mountPath: /tmp
+          name: tmp-volume
+        - mountPath: /http-prober-bin
+          name: http-prober-bin
+      initContainers:
+      - command:
+        - /bin/cp
+        - /usr/local/bin/http-prober
+        - /http-prober-bin/http-prober
+        image: quay.io/kubermatic/http-prober:v0.3.1
+        name: copy-http-prober
+        resources: {}
+        volumeMounts:
+        - mountPath: /http-prober-bin
+          name: http-prober-bin
+      volumes:
+      - name: kubernetes-dashboard-kubeconfig
+        secret:
+          secretName: kubernetes-dashboard-kubeconfig
+      - emptyDir: {}
+        name: tmp-volume
+      - emptyDir: {}
+        name: http-prober-bin
+status: {}

--- a/pkg/resources/test/fixtures/deployment-openstack-1.20.0-machine-controller-webhook.yaml
+++ b/pkg/resources/test/fixtures/deployment-openstack-1.20.0-machine-controller-webhook.yaml
@@ -1,0 +1,125 @@
+# This file has been generated, DO NOT EDIT.
+
+metadata:
+  creationTimestamp: null
+  labels:
+    app: machine-controller-webhook
+  name: machine-controller-webhook
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: machine-controller-webhook
+  strategy: {}
+  template:
+    metadata:
+      creationTimestamp: null
+      labels:
+        app: machine-controller-webhook
+        cluster: de-test-01
+        machinecontroller-kubeconfig-secret-revision: "123456"
+        machinecontroller-webhook-serving-cert-secret-revision: "123456"
+    spec:
+      containers:
+      - args:
+        - -endpoint
+        - https://apiserver-external.cluster-de-test-01.svc.cluster.local./healthz
+        - -insecure
+        - -retries
+        - "100"
+        - -retry-wait
+        - "2"
+        - -timeout
+        - "1"
+        - -command
+        - '{"command":"/usr/local/bin/webhook","args":["-kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","-logtostderr","-v","4","-listen-address","0.0.0.0:9876"]}'
+        - --crd-to-wait-for
+        - Machine,cluster.k8s.io/v1alpha1
+        command:
+        - /http-prober-bin/http-prober
+        env:
+        - name: OS_AUTH_URL
+          value: https://example.com:8000/v3
+        - name: OS_USER_NAME
+          value: openstack-username
+        - name: OS_PASSWORD
+          value: openstack-password
+        - name: OS_DOMAIN_NAME
+          value: openstack-domain
+        - name: OS_TENANT_NAME
+          value: openstack-tenant
+        - name: OS_TENANT_ID
+        - name: HTTP_PROXY
+          value: http://my-corp
+        - name: HTTPS_PROXY
+          value: http://my-corp
+        - name: http_proxy
+          value: http://my-corp
+        - name: https_proxy
+          value: http://my-corp
+        - name: NO_PROXY
+          value: apiserver-external.cluster-de-test-01.svc.cluster.local.
+        - name: no_proxy
+          value: apiserver-external.cluster-de-test-01.svc.cluster.local.
+        - name: KUBECONFIG
+          value: /etc/kubernetes/kubeconfig/kubeconfig
+        image: docker.io/kubermatic/machine-controller:v1.23.1
+        livenessProbe:
+          failureThreshold: 8
+          httpGet:
+            path: /healthz
+            port: 9876
+            scheme: HTTPS
+          initialDelaySeconds: 15
+          periodSeconds: 10
+          successThreshold: 1
+          timeoutSeconds: 15
+        name: machine-controller
+        readinessProbe:
+          failureThreshold: 3
+          httpGet:
+            path: /healthz
+            port: 9876
+            scheme: HTTPS
+          periodSeconds: 10
+          successThreshold: 1
+          timeoutSeconds: 15
+        resources:
+          limits:
+            cpu: 100m
+            memory: 512Mi
+          requests:
+            cpu: 10m
+            memory: 32Mi
+        volumeMounts:
+        - mountPath: /etc/kubernetes/kubeconfig
+          name: machinecontroller-kubeconfig
+          readOnly: true
+        - mountPath: /tmp/cert
+          name: machinecontroller-webhook-serving-cert
+          readOnly: true
+        - mountPath: /http-prober-bin
+          name: http-prober-bin
+      imagePullSecrets:
+      - name: dockercfg
+      initContainers:
+      - command:
+        - /bin/cp
+        - /usr/local/bin/http-prober
+        - /http-prober-bin/http-prober
+        image: quay.io/kubermatic/http-prober:v0.3.1
+        name: copy-http-prober
+        resources: {}
+        volumeMounts:
+        - mountPath: /http-prober-bin
+          name: http-prober-bin
+      volumes:
+      - name: machinecontroller-kubeconfig
+        secret:
+          secretName: machinecontroller-kubeconfig
+      - name: machinecontroller-webhook-serving-cert
+        secret:
+          secretName: machinecontroller-webhook-serving-cert
+      - emptyDir: {}
+        name: http-prober-bin
+status: {}

--- a/pkg/resources/test/fixtures/deployment-openstack-1.20.0-machine-controller.yaml
+++ b/pkg/resources/test/fixtures/deployment-openstack-1.20.0-machine-controller.yaml
@@ -1,0 +1,113 @@
+# This file has been generated, DO NOT EDIT.
+
+metadata:
+  creationTimestamp: null
+  labels:
+    app: machine-controller
+  name: machine-controller
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: machine-controller
+  strategy: {}
+  template:
+    metadata:
+      annotations:
+        prometheus.io/path: /metrics
+        prometheus.io/port: "8080"
+        prometheus.io/scrape: "true"
+      creationTimestamp: null
+      labels:
+        app: machine-controller
+        cluster: de-test-01
+        machinecontroller-kubeconfig-secret-revision: "123456"
+    spec:
+      containers:
+      - args:
+        - -endpoint
+        - https://apiserver-external.cluster-de-test-01.svc.cluster.local./healthz
+        - -insecure
+        - -retries
+        - "100"
+        - -retry-wait
+        - "2"
+        - -timeout
+        - "1"
+        - -command
+        - '{"command":"/usr/local/bin/machine-controller","args":["-kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","-logtostderr","-v","4","-cluster-dns","169.254.20.10","-health-probe-address","0.0.0.0:8085","-metrics-address","0.0.0.0:8080"]}'
+        - --crd-to-wait-for
+        - Machine,cluster.k8s.io/v1alpha1
+        command:
+        - /http-prober-bin/http-prober
+        env:
+        - name: OS_AUTH_URL
+          value: https://example.com:8000/v3
+        - name: OS_USER_NAME
+          value: openstack-username
+        - name: OS_PASSWORD
+          value: openstack-password
+        - name: OS_DOMAIN_NAME
+          value: openstack-domain
+        - name: OS_TENANT_NAME
+          value: openstack-tenant
+        - name: OS_TENANT_ID
+        - name: HTTP_PROXY
+          value: http://my-corp
+        - name: HTTPS_PROXY
+          value: http://my-corp
+        - name: http_proxy
+          value: http://my-corp
+        - name: https_proxy
+          value: http://my-corp
+        - name: NO_PROXY
+          value: apiserver-external.cluster-de-test-01.svc.cluster.local.
+        - name: no_proxy
+          value: apiserver-external.cluster-de-test-01.svc.cluster.local.
+        - name: KUBECONFIG
+          value: /etc/kubernetes/kubeconfig/kubeconfig
+        image: docker.io/kubermatic/machine-controller:v1.23.1
+        livenessProbe:
+          failureThreshold: 3
+          httpGet:
+            path: /readyz
+            port: 8085
+            scheme: HTTP
+          initialDelaySeconds: 15
+          periodSeconds: 10
+          successThreshold: 1
+          timeoutSeconds: 15
+        name: machine-controller
+        resources:
+          limits:
+            cpu: "2"
+            memory: 512Mi
+          requests:
+            cpu: 25m
+            memory: 32Mi
+        volumeMounts:
+        - mountPath: /etc/kubernetes/kubeconfig
+          name: machinecontroller-kubeconfig
+          readOnly: true
+        - mountPath: /http-prober-bin
+          name: http-prober-bin
+      imagePullSecrets:
+      - name: dockercfg
+      initContainers:
+      - command:
+        - /bin/cp
+        - /usr/local/bin/http-prober
+        - /http-prober-bin/http-prober
+        image: quay.io/kubermatic/http-prober:v0.3.1
+        name: copy-http-prober
+        resources: {}
+        volumeMounts:
+        - mountPath: /http-prober-bin
+          name: http-prober-bin
+      volumes:
+      - name: machinecontroller-kubeconfig
+        secret:
+          secretName: machinecontroller-kubeconfig
+      - emptyDir: {}
+        name: http-prober-bin
+status: {}

--- a/pkg/resources/test/fixtures/deployment-openstack-1.20.0-metrics-server.yaml
+++ b/pkg/resources/test/fixtures/deployment-openstack-1.20.0-metrics-server.yaml
@@ -1,0 +1,182 @@
+# This file has been generated, DO NOT EDIT.
+
+metadata:
+  creationTimestamp: null
+  labels:
+    app: metrics-server
+  name: metrics-server
+spec:
+  replicas: 2
+  selector:
+    matchLabels:
+      app: metrics-server
+  strategy: {}
+  template:
+    metadata:
+      creationTimestamp: null
+      labels:
+        app: metrics-server
+        cluster: de-test-01
+        kubeletdnatcontroller-kubeconfig-secret-revision: "123456"
+        metrics-server-secret-revision: "123456"
+        metrics-server-serving-cert-secret-revision: "123456"
+        openvpn-client-certificates-secret-revision: "123456"
+    spec:
+      affinity:
+        podAntiAffinity:
+          preferredDuringSchedulingIgnoredDuringExecution:
+          - podAffinityTerm:
+              labelSelector:
+                matchLabels:
+                  app: metrics-server
+                  cluster: de-test-01
+              topologyKey: kubernetes.io/hostname
+            weight: 100
+          - podAffinityTerm:
+              labelSelector:
+                matchLabels:
+                  app: metrics-server
+              topologyKey: kubernetes.io/hostname
+            weight: 10
+      containers:
+      - args:
+        - -endpoint
+        - https://apiserver-external.cluster-de-test-01.svc.cluster.local./healthz
+        - -insecure
+        - -retries
+        - "100"
+        - -retry-wait
+        - "2"
+        - -timeout
+        - "1"
+        - -command
+        - '{"command":"/metrics-server","args":["--kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","--authentication-kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","--authorization-kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","--kubelet-port","10250","--kubelet-insecure-tls","--kubelet-preferred-address-types","ExternalIP,InternalIP","--v","1","--logtostderr","--tls-cert-file","/etc/serving-cert/serving.crt","--tls-private-key-file","/etc/serving-cert/serving.key"]}'
+        command:
+        - /http-prober-bin/http-prober
+        image: k8s.gcr.io/metrics-server-amd64:v0.3.6
+        name: metrics-server
+        resources:
+          limits:
+            cpu: 150m
+            memory: 512Mi
+          requests:
+            cpu: 25m
+            memory: 32Mi
+        volumeMounts:
+        - mountPath: /etc/kubernetes/kubeconfig
+          name: metrics-server
+          readOnly: true
+        - mountPath: /etc/serving-cert
+          name: metrics-server-serving-cert
+          readOnly: true
+        - mountPath: /http-prober-bin
+          name: http-prober-bin
+      - args:
+        - --client
+        - --proto
+        - tcp
+        - --dev
+        - tun
+        - --auth-nocache
+        - --remote
+        - openvpn-server.cluster-de-test-01.svc.cluster.local.
+        - "1194"
+        - --nobind
+        - --connect-timeout
+        - "5"
+        - --connect-retry
+        - "1"
+        - --ca
+        - /etc/openvpn/pki/client/ca.crt
+        - --cert
+        - /etc/openvpn/pki/client/client.crt
+        - --key
+        - /etc/openvpn/pki/client/client.key
+        - --remote-cert-tls
+        - server
+        - --link-mtu
+        - "1432"
+        - --cipher
+        - AES-256-GCM
+        - --auth
+        - SHA1
+        - --keysize
+        - "256"
+        - --script-security
+        - "2"
+        - --status
+        - /run/openvpn-status
+        - --log
+        - /dev/stdout
+        command:
+        - /usr/sbin/openvpn
+        image: quay.io/kubermatic/openvpn:v2.4.8-r1
+        name: openvpn-client
+        resources:
+          limits:
+            cpu: 100m
+            memory: 32Mi
+          requests:
+            cpu: 5m
+            memory: 5Mi
+        securityContext:
+          privileged: true
+        volumeMounts:
+        - mountPath: /etc/openvpn/pki/client
+          name: openvpn-client-certificates
+          readOnly: true
+      - args:
+        - -kubeconfig
+        - /etc/kubernetes/kubeconfig/kubeconfig
+        - -node-access-network
+        - 192.0.2.0/24
+        command:
+        - /usr/local/bin/kubeletdnat-controller
+        image: quay.io/kubermatic/kubeletdnat-controller:v0.0.0-test
+        name: dnat-controller
+        resources:
+          limits:
+            cpu: 100m
+            memory: 512Mi
+          requests:
+            cpu: 5m
+            memory: 16Mi
+        securityContext:
+          capabilities:
+            add:
+            - NET_ADMIN
+          procMount: Default
+          runAsUser: 0
+        volumeMounts:
+        - mountPath: /etc/kubernetes/kubeconfig
+          name: kubeletdnatcontroller-kubeconfig
+          readOnly: true
+      imagePullSecrets:
+      - name: dockercfg
+      initContainers:
+      - command:
+        - /bin/cp
+        - /usr/local/bin/http-prober
+        - /http-prober-bin/http-prober
+        image: quay.io/kubermatic/http-prober:v0.3.1
+        name: copy-http-prober
+        resources: {}
+        volumeMounts:
+        - mountPath: /http-prober-bin
+          name: http-prober-bin
+      volumes:
+      - name: metrics-server
+        secret:
+          secretName: metrics-server
+      - name: openvpn-client-certificates
+        secret:
+          secretName: openvpn-client-certificates
+      - name: kubeletdnatcontroller-kubeconfig
+        secret:
+          secretName: kubeletdnatcontroller-kubeconfig
+      - name: metrics-server-serving-cert
+        secret:
+          secretName: metrics-server-serving-cert
+      - emptyDir: {}
+        name: http-prober-bin
+status: {}

--- a/pkg/resources/test/fixtures/deployment-openstack-1.20.0-openvpn-server.yaml
+++ b/pkg/resources/test/fixtures/deployment-openstack-1.20.0-openvpn-server.yaml
@@ -1,0 +1,223 @@
+# This file has been generated, DO NOT EDIT.
+
+metadata:
+  creationTimestamp: null
+  labels:
+    app: openvpn-server
+  name: openvpn-server
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: openvpn-server
+  strategy:
+    rollingUpdate:
+      maxSurge: 1
+      maxUnavailable: 1
+    type: RollingUpdate
+  template:
+    metadata:
+      annotations:
+        prometheus.io/path: /metrics
+        prometheus.io/port: "9176"
+        prometheus.io/scrape: "true"
+      creationTimestamp: null
+      labels:
+        app: openvpn-server
+        cluster: de-test-01
+        openvpn-ca-secret-revision: "123456"
+        openvpn-client-configs-configmap-revision: "123456"
+        openvpn-server-certificates-secret-revision: "123456"
+    spec:
+      containers:
+      - args:
+        - --proto
+        - tcp
+        - --dev
+        - tun
+        - --mode
+        - server
+        - --lport
+        - "1194"
+        - --server
+        - 10.20.0.0
+        - 255.255.255.0
+        - --ca
+        - /etc/kubernetes/pki/ca/ca.crt
+        - --cert
+        - /etc/openvpn/pki/server/server.crt
+        - --key
+        - /etc/openvpn/pki/server/server.key
+        - --dh
+        - none
+        - --duplicate-cn
+        - --client-config-dir
+        - /etc/openvpn/clients
+        - --status
+        - /run/openvpn/openvpn-status
+        - --status-version
+        - "3"
+        - --cipher
+        - AES-256-GCM
+        - --auth
+        - SHA1
+        - --keysize
+        - "256"
+        - --script-security
+        - "2"
+        - --ping
+        - "5"
+        - --verb
+        - "3"
+        - --log
+        - /dev/stdout
+        - --push
+        - route 172.25.0.0 255.255.0.0
+        - --route
+        - 172.25.0.0
+        - 255.255.0.0
+        - --push
+        - route 10.240.16.0 255.255.240.0
+        - --route
+        - 10.240.16.0
+        - 255.255.240.0
+        - --push
+        - route 192.0.2.0 255.255.255.0
+        - --route
+        - 192.0.2.0
+        - 255.255.255.0
+        command:
+        - /usr/sbin/openvpn
+        image: quay.io/kubermatic/openvpn:v2.4.8-r1
+        name: openvpn-server
+        ports:
+        - containerPort: 1194
+          protocol: TCP
+        readinessProbe:
+          exec:
+            command:
+            - test
+            - -s
+            - /run/openvpn/openvpn-status
+          failureThreshold: 3
+          initialDelaySeconds: 5
+          periodSeconds: 5
+          successThreshold: 1
+          timeoutSeconds: 1
+        resources:
+          limits:
+            cpu: 100m
+            memory: 20Mi
+          requests:
+            cpu: 5m
+            memory: 5Mi
+        securityContext:
+          privileged: true
+          procMount: Default
+        volumeMounts:
+        - mountPath: /etc/openvpn/pki/server
+          name: openvpn-server-certificates
+          readOnly: true
+        - mountPath: /etc/kubernetes/pki/ca
+          name: ca
+          readOnly: true
+        - mountPath: /etc/openvpn/clients
+          name: openvpn-client-configs
+          readOnly: true
+        - mountPath: /run/openvpn
+          name: openvpn-status
+      - args:
+        - -c
+        - |-
+          while true; do sysctl -w net.ipv4.ip_forward=1;
+            if ! iptables -t mangle -C INPUT -p tcp --tcp-flags SYN,RST SYN --dport 1194 -j TCPMSS --set-mss 1300 &>/dev/null; then
+             iptables -t mangle -A INPUT -p tcp --tcp-flags SYN,RST SYN --dport 1194 -j TCPMSS --set-mss 1300
+            fi
+            sleep 30;
+          done
+        command:
+        - /bin/bash
+        image: quay.io/kubermatic/openvpn:v2.4.8-r1
+        name: ip-fixup
+        resources:
+          limits:
+            cpu: 10m
+            memory: 32Mi
+          requests:
+            cpu: 5m
+            memory: 16Mi
+        securityContext:
+          privileged: true
+          procMount: Default
+      - args:
+        - -openvpn.status_paths
+        - /run/openvpn/openvpn-status
+        command:
+        - /bin/openvpn_exporter
+        image: docker.io/kumina/openvpn-exporter:v0.2.2
+        name: openvpn-exporter
+        ports:
+        - containerPort: 9176
+          protocol: TCP
+        resources:
+          limits:
+            cpu: 100m
+            memory: 20Mi
+          requests:
+            cpu: 5m
+            memory: 5Mi
+        volumeMounts:
+        - mountPath: /run/openvpn
+          name: openvpn-status
+      imagePullSecrets:
+      - name: dockercfg
+      initContainers:
+      - args:
+        - -c
+        - |
+          # do not give a 10.20.0.0/24 route to clients (nodes) but
+          # masquerade to openvpn-server's IP instead:
+          iptables -t nat -A POSTROUTING -o tun0 -s 10.20.0.0/24 -j MASQUERADE
+
+          # Only allow outbound traffic to services, pods, nodes
+          iptables -P FORWARD DROP
+          iptables -A FORWARD -m state --state ESTABLISHED,RELATED -j ACCEPT
+          iptables -A FORWARD -i tun0 -o tun0 -s 10.20.0.0/24 -d 172.25.0.0/16 -j ACCEPT
+          iptables -A FORWARD -i tun0 -o tun0 -s 10.20.0.0/24 -d 10.240.16.0/20 -j ACCEPT
+          iptables -A FORWARD -i tun0 -o tun0 -s 10.20.0.0/24 -d 192.0.2.0/24 -j ACCEPT
+
+          iptables -A INPUT -m state --state ESTABLISHED,RELATED -j ACCEPT
+          iptables -A INPUT -i tun0 -p icmp -j ACCEPT
+          iptables -A INPUT -i tun0 -j DROP
+        command:
+        - /bin/bash
+        image: quay.io/kubermatic/openvpn:v2.4.8-r1
+        name: iptables-init
+        resources:
+          limits:
+            cpu: 100m
+            memory: 20Mi
+          requests:
+            cpu: 5m
+            memory: 5Mi
+        securityContext:
+          capabilities:
+            add:
+            - NET_ADMIN
+          procMount: Default
+      volumes:
+      - name: ca
+        secret:
+          items:
+          - key: ca.crt
+            path: ca.crt
+          secretName: openvpn-ca
+      - name: openvpn-server-certificates
+        secret:
+          secretName: openvpn-server-certificates
+      - configMap:
+          name: openvpn-client-configs
+        name: openvpn-client-configs
+      - emptyDir: {}
+        name: openvpn-status
+status: {}

--- a/pkg/resources/test/fixtures/deployment-openstack-1.20.0-scheduler.yaml
+++ b/pkg/resources/test/fixtures/deployment-openstack-1.20.0-scheduler.yaml
@@ -1,0 +1,203 @@
+# This file has been generated, DO NOT EDIT.
+
+metadata:
+  creationTimestamp: null
+  labels:
+    app: scheduler
+  name: scheduler
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: scheduler
+  strategy: {}
+  template:
+    metadata:
+      annotations:
+        prometheus.io/path: /metrics
+        prometheus.io/port: "10259"
+        prometheus.io/scrape_with_kube_cert: "true"
+      creationTimestamp: null
+      labels:
+        app: scheduler
+        ca-secret-revision: "123456"
+        cluster: de-test-01
+        openvpn-client-certificates-secret-revision: "123456"
+        scheduler-kubeconfig-secret-revision: "123456"
+    spec:
+      affinity:
+        podAntiAffinity:
+          preferredDuringSchedulingIgnoredDuringExecution:
+          - podAffinityTerm:
+              labelSelector:
+                matchLabels:
+                  app: scheduler
+                  cluster: de-test-01
+              topologyKey: kubernetes.io/hostname
+            weight: 100
+          - podAffinityTerm:
+              labelSelector:
+                matchLabels:
+                  app: scheduler
+              topologyKey: kubernetes.io/hostname
+            weight: 10
+      containers:
+      - args:
+        - --client
+        - --proto
+        - tcp
+        - --dev
+        - tun
+        - --auth-nocache
+        - --remote
+        - openvpn-server.cluster-de-test-01.svc.cluster.local.
+        - "1194"
+        - --nobind
+        - --connect-timeout
+        - "5"
+        - --connect-retry
+        - "1"
+        - --ca
+        - /etc/openvpn/pki/client/ca.crt
+        - --cert
+        - /etc/openvpn/pki/client/client.crt
+        - --key
+        - /etc/openvpn/pki/client/client.key
+        - --remote-cert-tls
+        - server
+        - --link-mtu
+        - "1432"
+        - --cipher
+        - AES-256-GCM
+        - --auth
+        - SHA1
+        - --keysize
+        - "256"
+        - --script-security
+        - "2"
+        - --status
+        - /run/openvpn-status
+        - --log
+        - /dev/stdout
+        command:
+        - /usr/sbin/openvpn
+        image: quay.io/kubermatic/openvpn:v2.4.8-r1
+        name: openvpn-client
+        resources:
+          limits:
+            cpu: 100m
+            memory: 32Mi
+          requests:
+            cpu: 5m
+            memory: 5Mi
+        securityContext:
+          privileged: true
+        volumeMounts:
+        - mountPath: /etc/openvpn/pki/client
+          name: openvpn-client-certificates
+          readOnly: true
+      - args:
+        - -endpoint
+        - https://apiserver-external.cluster-de-test-01.svc.cluster.local./healthz
+        - -insecure
+        - -retries
+        - "100"
+        - -retry-wait
+        - "2"
+        - -timeout
+        - "1"
+        - -command
+        - '{"command":"/usr/local/bin/kube-scheduler","args":["--kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","--authentication-kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","--authorization-kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","--client-ca-file","/etc/kubernetes/pki/ca/ca.crt","--port","0"]}'
+        command:
+        - /http-prober-bin/http-prober
+        image: k8s.gcr.io/kube-scheduler:v1.20.0
+        livenessProbe:
+          failureThreshold: 8
+          httpGet:
+            path: /healthz
+            port: 10259
+            scheme: HTTPS
+          initialDelaySeconds: 15
+          periodSeconds: 10
+          successThreshold: 1
+          timeoutSeconds: 15
+        name: scheduler
+        readinessProbe:
+          failureThreshold: 3
+          httpGet:
+            path: /healthz
+            port: 10259
+            scheme: HTTPS
+          periodSeconds: 10
+          successThreshold: 1
+          timeoutSeconds: 15
+        resources:
+          limits:
+            cpu: "1"
+            memory: 512Mi
+          requests:
+            cpu: 20m
+            memory: 64Mi
+        volumeMounts:
+        - mountPath: /etc/kubernetes/kubeconfig
+          name: scheduler-kubeconfig
+          readOnly: true
+        - mountPath: /etc/kubernetes/pki/ca
+          name: ca
+          readOnly: true
+        - mountPath: /etc/ssl/certs
+          name: ca-certs
+          readOnly: true
+        - mountPath: /usr/share/ca-certificates
+          name: usr-share-ca-certificates
+          readOnly: true
+        - mountPath: /http-prober-bin
+          name: http-prober-bin
+      dnsConfig:
+        nameservers:
+        - 192.0.2.14
+        options:
+        - name: ndots
+          value: "5"
+        searches:
+        - kube-system.svc.cluster.local
+        - svc.cluster.local
+        - cluster.local
+      dnsPolicy: None
+      imagePullSecrets:
+      - name: dockercfg
+      initContainers:
+      - command:
+        - /bin/cp
+        - /usr/local/bin/http-prober
+        - /http-prober-bin/http-prober
+        image: quay.io/kubermatic/http-prober:v0.3.1
+        name: copy-http-prober
+        resources: {}
+        volumeMounts:
+        - mountPath: /http-prober-bin
+          name: http-prober-bin
+      volumes:
+      - name: openvpn-client-certificates
+        secret:
+          secretName: openvpn-client-certificates
+      - name: ca
+        secret:
+          items:
+          - key: ca.crt
+            path: ca.crt
+          secretName: ca
+      - name: scheduler-kubeconfig
+        secret:
+          secretName: scheduler-kubeconfig
+      - hostPath:
+          path: /etc/ssl/certs
+          type: DirectoryOrCreate
+        name: ca-certs
+      - hostPath:
+          path: /usr/share/ca-certificates
+          type: DirectoryOrCreate
+        name: usr-share-ca-certificates
+      - emptyDir: {}
+        name: http-prober-bin
+status: {}

--- a/pkg/resources/test/fixtures/deployment-openstack-1.20.0-usercluster-controller.yaml
+++ b/pkg/resources/test/fixtures/deployment-openstack-1.20.0-usercluster-controller.yaml
@@ -1,0 +1,95 @@
+# This file has been generated, DO NOT EDIT.
+
+metadata:
+  creationTimestamp: null
+  labels:
+    app: usercluster-controller
+  name: usercluster-controller
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: usercluster-controller
+  strategy:
+    rollingUpdate:
+      maxSurge: 1
+      maxUnavailable: 1
+    type: RollingUpdate
+  template:
+    metadata:
+      annotations:
+        prometheus.io/path: /metrics
+        prometheus.io/port: "8085"
+        prometheus.io/scrape: "true"
+      creationTimestamp: null
+      labels:
+        app: usercluster-controller
+        cluster: de-test-01
+        internal-admin-kubeconfig-secret-revision: "123456"
+    spec:
+      containers:
+      - args:
+        - -endpoint
+        - https://apiserver-external.cluster-de-test-01.svc.cluster.local./healthz
+        - -insecure
+        - -retries
+        - "100"
+        - -retry-wait
+        - "2"
+        - -timeout
+        - "1"
+        - -command
+        - '{"command":"/usr/local/bin/user-cluster-controller-manager","args":["-kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","-metrics-listen-address","0.0.0.0:8085","-health-listen-address","0.0.0.0:8086","-namespace","$(NAMESPACE)","-cluster-url","https://jh8j81chn.europe-west3-c.dev.kubermatic.io:30000","-dns-cluster-ip","10.240.16.10","-openvpn-server-port","30003","-overwrite-registry","","-openshift=false","-version","1.20.0","-cloud-provider-name","openstack","-owner-email","","-opa-integration=false","--ipam-controller-network","192.168.1.1/24,192.168.1.1,8.8.8.8","-node-labels","{\"my-label\":\"my-value\"}"]}'
+        command:
+        - /http-prober-bin/http-prober
+        env:
+        - name: NAMESPACE
+          valueFrom:
+            fieldRef:
+              apiVersion: v1
+              fieldPath: metadata.namespace
+        image: quay.io/kubermatic/kubermatic:v0.0.0-test
+        name: usercluster-controller
+        readinessProbe:
+          failureThreshold: 5
+          httpGet:
+            path: /ready
+            port: 8086
+            scheme: HTTP
+          periodSeconds: 5
+          successThreshold: 1
+          timeoutSeconds: 15
+        resources:
+          limits:
+            cpu: 500m
+            memory: 512Mi
+          requests:
+            cpu: 25m
+            memory: 32Mi
+        volumeMounts:
+        - mountPath: /etc/kubernetes/kubeconfig
+          name: internal-admin-kubeconfig
+          readOnly: true
+        - mountPath: /http-prober-bin
+          name: http-prober-bin
+      imagePullSecrets:
+      - name: dockercfg
+      initContainers:
+      - command:
+        - /bin/cp
+        - /usr/local/bin/http-prober
+        - /http-prober-bin/http-prober
+        image: quay.io/kubermatic/http-prober:v0.3.1
+        name: copy-http-prober
+        resources: {}
+        volumeMounts:
+        - mountPath: /http-prober-bin
+          name: http-prober-bin
+      serviceAccountName: kubermatic-usercluster-controller-manager
+      volumes:
+      - name: internal-admin-kubeconfig
+        secret:
+          secretName: internal-admin-kubeconfig
+      - emptyDir: {}
+        name: http-prober-bin
+status: {}

--- a/pkg/resources/test/fixtures/deployment-vsphere-1.17.0-apiserver.yaml
+++ b/pkg/resources/test/fixtures/deployment-vsphere-1.17.0-apiserver.yaml
@@ -202,12 +202,12 @@ spec:
         - X-Remote-Group
         - --requestheader-username-headers
         - X-Remote-User
+        - --service-account-issuer
+        - https://jh8j81chn.europe-west3-c.dev.kubermatic.io:30000
         - --service-account-signing-key-file
         - /etc/kubernetes/service-account-key/sa.key
-        - --service-account-issuer
-        - kubernetes.default.svc
         - --api-audiences
-        - kubernetes.default.svc
+        - https://jh8j81chn.europe-west3-c.dev.kubermatic.io:30000
         - --kubelet-preferred-address-types
         - ExternalIP,InternalIP
         - --cloud-provider

--- a/pkg/resources/test/fixtures/deployment-vsphere-1.17.0-usercluster-controller.yaml
+++ b/pkg/resources/test/fixtures/deployment-vsphere-1.17.0-usercluster-controller.yaml
@@ -39,7 +39,7 @@ spec:
         - -timeout
         - "1"
         - -command
-        - '{"command":"/usr/local/bin/user-cluster-controller-manager","args":["-kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","-metrics-listen-address","0.0.0.0:8085","-health-listen-address","0.0.0.0:8086","-namespace","$(NAMESPACE)","-cluster-url","","-dns-cluster-ip","10.240.16.10","-openvpn-server-port","30003","-overwrite-registry","","-openshift=false","-version","1.17.0","-cloud-provider-name","vsphere","-owner-email","","-opa-integration=false","--ipam-controller-network","192.168.1.1/24,192.168.1.1,8.8.8.8","-node-labels","{\"my-label\":\"my-value\"}"]}'
+        - '{"command":"/usr/local/bin/user-cluster-controller-manager","args":["-kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","-metrics-listen-address","0.0.0.0:8085","-health-listen-address","0.0.0.0:8086","-namespace","$(NAMESPACE)","-cluster-url","https://jh8j81chn.europe-west3-c.dev.kubermatic.io:30000","-dns-cluster-ip","10.240.16.10","-openvpn-server-port","30003","-overwrite-registry","","-openshift=false","-version","1.17.0","-cloud-provider-name","vsphere","-owner-email","","-opa-integration=false","--ipam-controller-network","192.168.1.1/24,192.168.1.1,8.8.8.8","-node-labels","{\"my-label\":\"my-value\"}"]}'
         command:
         - /http-prober-bin/http-prober
         env:

--- a/pkg/resources/test/fixtures/deployment-vsphere-1.18.0-apiserver.yaml
+++ b/pkg/resources/test/fixtures/deployment-vsphere-1.18.0-apiserver.yaml
@@ -202,12 +202,12 @@ spec:
         - X-Remote-Group
         - --requestheader-username-headers
         - X-Remote-User
+        - --service-account-issuer
+        - https://jh8j81chn.europe-west3-c.dev.kubermatic.io:30000
         - --service-account-signing-key-file
         - /etc/kubernetes/service-account-key/sa.key
-        - --service-account-issuer
-        - kubernetes.default.svc
         - --api-audiences
-        - kubernetes.default.svc
+        - https://jh8j81chn.europe-west3-c.dev.kubermatic.io:30000
         - --kubelet-preferred-address-types
         - ExternalIP,InternalIP
         - --cloud-provider

--- a/pkg/resources/test/fixtures/deployment-vsphere-1.18.0-usercluster-controller.yaml
+++ b/pkg/resources/test/fixtures/deployment-vsphere-1.18.0-usercluster-controller.yaml
@@ -39,7 +39,7 @@ spec:
         - -timeout
         - "1"
         - -command
-        - '{"command":"/usr/local/bin/user-cluster-controller-manager","args":["-kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","-metrics-listen-address","0.0.0.0:8085","-health-listen-address","0.0.0.0:8086","-namespace","$(NAMESPACE)","-cluster-url","","-dns-cluster-ip","10.240.16.10","-openvpn-server-port","30003","-overwrite-registry","","-openshift=false","-version","1.18.0","-cloud-provider-name","vsphere","-owner-email","","-opa-integration=false","--ipam-controller-network","192.168.1.1/24,192.168.1.1,8.8.8.8","-node-labels","{\"my-label\":\"my-value\"}"]}'
+        - '{"command":"/usr/local/bin/user-cluster-controller-manager","args":["-kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","-metrics-listen-address","0.0.0.0:8085","-health-listen-address","0.0.0.0:8086","-namespace","$(NAMESPACE)","-cluster-url","https://jh8j81chn.europe-west3-c.dev.kubermatic.io:30000","-dns-cluster-ip","10.240.16.10","-openvpn-server-port","30003","-overwrite-registry","","-openshift=false","-version","1.18.0","-cloud-provider-name","vsphere","-owner-email","","-opa-integration=false","--ipam-controller-network","192.168.1.1/24,192.168.1.1,8.8.8.8","-node-labels","{\"my-label\":\"my-value\"}"]}'
         command:
         - /http-prober-bin/http-prober
         env:

--- a/pkg/resources/test/fixtures/deployment-vsphere-1.19.0-apiserver.yaml
+++ b/pkg/resources/test/fixtures/deployment-vsphere-1.19.0-apiserver.yaml
@@ -202,12 +202,12 @@ spec:
         - X-Remote-Group
         - --requestheader-username-headers
         - X-Remote-User
+        - --service-account-issuer
+        - https://jh8j81chn.europe-west3-c.dev.kubermatic.io:30000
         - --service-account-signing-key-file
         - /etc/kubernetes/service-account-key/sa.key
-        - --service-account-issuer
-        - kubernetes.default.svc
         - --api-audiences
-        - kubernetes.default.svc
+        - https://jh8j81chn.europe-west3-c.dev.kubermatic.io:30000
         - --kubelet-preferred-address-types
         - ExternalIP,InternalIP
         - --cloud-provider

--- a/pkg/resources/test/fixtures/deployment-vsphere-1.19.0-usercluster-controller.yaml
+++ b/pkg/resources/test/fixtures/deployment-vsphere-1.19.0-usercluster-controller.yaml
@@ -39,7 +39,7 @@ spec:
         - -timeout
         - "1"
         - -command
-        - '{"command":"/usr/local/bin/user-cluster-controller-manager","args":["-kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","-metrics-listen-address","0.0.0.0:8085","-health-listen-address","0.0.0.0:8086","-namespace","$(NAMESPACE)","-cluster-url","","-dns-cluster-ip","10.240.16.10","-openvpn-server-port","30003","-overwrite-registry","","-openshift=false","-version","1.19.0","-cloud-provider-name","vsphere","-owner-email","","-opa-integration=false","--ipam-controller-network","192.168.1.1/24,192.168.1.1,8.8.8.8","-node-labels","{\"my-label\":\"my-value\"}"]}'
+        - '{"command":"/usr/local/bin/user-cluster-controller-manager","args":["-kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","-metrics-listen-address","0.0.0.0:8085","-health-listen-address","0.0.0.0:8086","-namespace","$(NAMESPACE)","-cluster-url","https://jh8j81chn.europe-west3-c.dev.kubermatic.io:30000","-dns-cluster-ip","10.240.16.10","-openvpn-server-port","30003","-overwrite-registry","","-openshift=false","-version","1.19.0","-cloud-provider-name","vsphere","-owner-email","","-opa-integration=false","--ipam-controller-network","192.168.1.1/24,192.168.1.1,8.8.8.8","-node-labels","{\"my-label\":\"my-value\"}"]}'
         command:
         - /http-prober-bin/http-prober
         env:

--- a/pkg/resources/test/fixtures/deployment-vsphere-1.20.0-apiserver.yaml
+++ b/pkg/resources/test/fixtures/deployment-vsphere-1.20.0-apiserver.yaml
@@ -1,0 +1,406 @@
+# This file has been generated, DO NOT EDIT.
+
+metadata:
+  creationTimestamp: null
+  labels:
+    app: apiserver
+  name: apiserver
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: apiserver
+  strategy: {}
+  template:
+    metadata:
+      annotations:
+        prometheus.io/path: /metrics
+        prometheus.io/port: "30000"
+        prometheus.io/scrape_with_kube_cert: "true"
+      creationTimestamp: null
+      labels:
+        adm-control-configmap-revision: "123456"
+        apiserver-etcd-client-certificate-secret-revision: "123456"
+        apiserver-proxy-client-certificate-secret-revision: "123456"
+        apiserver-tls-secret-revision: "123456"
+        app: apiserver
+        audit-config-configmap-revision: "123456"
+        ca-secret-revision: "123456"
+        cloud-config-configmap-revision: "123456"
+        cluster: de-test-01
+        dex-ca-secret-revision: "123456"
+        front-proxy-ca-secret-revision: "123456"
+        kubelet-client-certificates-secret-revision: "123456"
+        kubeletdnatcontroller-kubeconfig-secret-revision: "123456"
+        openvpn-client-certificates-secret-revision: "123456"
+        service-account-key-secret-revision: "123456"
+        tokens-secret-revision: "123456"
+    spec:
+      affinity:
+        podAntiAffinity:
+          preferredDuringSchedulingIgnoredDuringExecution:
+          - podAffinityTerm:
+              labelSelector:
+                matchLabels:
+                  app: apiserver
+                  cluster: de-test-01
+              topologyKey: kubernetes.io/hostname
+            weight: 100
+          - podAffinityTerm:
+              labelSelector:
+                matchLabels:
+                  app: apiserver
+              topologyKey: kubernetes.io/hostname
+            weight: 10
+      containers:
+      - args:
+        - --client
+        - --proto
+        - tcp
+        - --dev
+        - tun
+        - --auth-nocache
+        - --remote
+        - openvpn-server.cluster-de-test-01.svc.cluster.local.
+        - "1194"
+        - --nobind
+        - --connect-timeout
+        - "5"
+        - --connect-retry
+        - "1"
+        - --ca
+        - /etc/openvpn/pki/client/ca.crt
+        - --cert
+        - /etc/openvpn/pki/client/client.crt
+        - --key
+        - /etc/openvpn/pki/client/client.key
+        - --remote-cert-tls
+        - server
+        - --link-mtu
+        - "1432"
+        - --cipher
+        - AES-256-GCM
+        - --auth
+        - SHA1
+        - --keysize
+        - "256"
+        - --script-security
+        - "2"
+        - --status
+        - /run/openvpn-status
+        - --log
+        - /dev/stdout
+        command:
+        - /usr/sbin/openvpn
+        image: quay.io/kubermatic/openvpn:v2.4.8-r1
+        name: openvpn-client
+        resources:
+          limits:
+            cpu: 100m
+            memory: 32Mi
+          requests:
+            cpu: 5m
+            memory: 5Mi
+        securityContext:
+          privileged: true
+        volumeMounts:
+        - mountPath: /etc/openvpn/pki/client
+          name: openvpn-client-certificates
+          readOnly: true
+      - args:
+        - -kubeconfig
+        - /etc/kubernetes/kubeconfig/kubeconfig
+        - -node-access-network
+        - 192.0.2.0/24
+        - -master
+        - https://127.0.0.1:30000
+        command:
+        - /usr/local/bin/kubeletdnat-controller
+        image: quay.io/kubermatic/kubeletdnat-controller:v0.0.0-test
+        name: dnat-controller
+        resources:
+          limits:
+            cpu: 100m
+            memory: 512Mi
+          requests:
+            cpu: 5m
+            memory: 16Mi
+        securityContext:
+          capabilities:
+            add:
+            - NET_ADMIN
+          procMount: Default
+          runAsUser: 0
+        volumeMounts:
+        - mountPath: /etc/kubernetes/kubeconfig
+          name: kubeletdnatcontroller-kubeconfig
+          readOnly: true
+      - args:
+        - --advertise-address
+        - 35.198.93.90
+        - --secure-port
+        - "30000"
+        - --kubernetes-service-node-port
+        - "30000"
+        - --etcd-servers
+        - https://etcd-0.etcd.cluster-de-test-01.svc.cluster.local.:2379,https://etcd-1.etcd.cluster-de-test-01.svc.cluster.local.:2379,https://etcd-2.etcd.cluster-de-test-01.svc.cluster.local.:2379
+        - --etcd-cafile
+        - /etc/etcd/pki/client/ca.crt
+        - --etcd-certfile
+        - /etc/etcd/pki/client/apiserver-etcd-client.crt
+        - --etcd-keyfile
+        - /etc/etcd/pki/client/apiserver-etcd-client.key
+        - --storage-backend
+        - etcd3
+        - --enable-admission-plugins
+        - DefaultStorageClass,DefaultTolerationSeconds,LimitRanger,MutatingAdmissionWebhook,NamespaceLifecycle,Priority,ResourceQuota,ServiceAccount,ValidatingAdmissionWebhook
+        - --admission-control-config-file
+        - /etc/kubernetes/adm-control/admission-control.yaml
+        - --authorization-mode
+        - Node,RBAC
+        - --external-hostname
+        - jh8j81chn.europe-west3-c.dev.kubermatic.io
+        - --token-auth-file
+        - /etc/kubernetes/tokens/tokens.csv
+        - --enable-bootstrap-token-auth
+        - --service-account-key-file
+        - /etc/kubernetes/service-account-key/sa.key
+        - --service-cluster-ip-range
+        - 10.240.16.0/20
+        - --service-node-port-range
+        - 30000-32767
+        - --allow-privileged
+        - --audit-log-maxage
+        - "30"
+        - --audit-log-maxbackup
+        - "3"
+        - --audit-log-maxsize
+        - "100"
+        - --audit-log-path
+        - /var/log/kubernetes/audit/audit.log
+        - --tls-cert-file
+        - /etc/kubernetes/tls/apiserver-tls.crt
+        - --tls-private-key-file
+        - /etc/kubernetes/tls/apiserver-tls.key
+        - --proxy-client-cert-file
+        - /etc/kubernetes/pki/front-proxy/client/apiserver-proxy-client.crt
+        - --proxy-client-key-file
+        - /etc/kubernetes/pki/front-proxy/client/apiserver-proxy-client.key
+        - --client-ca-file
+        - /etc/kubernetes/pki/ca/ca.crt
+        - --kubelet-client-certificate
+        - /etc/kubernetes/kubelet/kubelet-client.crt
+        - --kubelet-client-key
+        - /etc/kubernetes/kubelet/kubelet-client.key
+        - --requestheader-client-ca-file
+        - /etc/kubernetes/pki/front-proxy/ca/ca.crt
+        - --requestheader-allowed-names
+        - apiserver-aggregator
+        - --requestheader-extra-headers-prefix
+        - X-Remote-Extra-
+        - --requestheader-group-headers
+        - X-Remote-Group
+        - --requestheader-username-headers
+        - X-Remote-User
+        - --service-account-issuer
+        - https://jh8j81chn.europe-west3-c.dev.kubermatic.io:30000
+        - --service-account-signing-key-file
+        - /etc/kubernetes/service-account-key/sa.key
+        - --api-audiences
+        - https://jh8j81chn.europe-west3-c.dev.kubermatic.io:30000
+        - --kubelet-preferred-address-types
+        - ExternalIP,InternalIP
+        - --cloud-provider
+        - vsphere
+        - --cloud-config
+        - /etc/kubernetes/cloud/config
+        - --oidc-issuer-url
+        - https://dev.kubermatic.io/dex
+        - --oidc-client-id
+        - kubermaticIssuer
+        - --oidc-username-claim
+        - email
+        - --oidc-groups-prefix
+        - 'oidc:'
+        - --oidc-groups-claim
+        - groups
+        - --oidc-ca-file
+        - /etc/kubernetes/dex/ca/caBundle.pem
+        command:
+        - /usr/local/bin/kube-apiserver
+        env:
+        - name: HTTP_PROXY
+          value: http://my-corp
+        - name: HTTPS_PROXY
+          value: http://my-corp
+        - name: http_proxy
+          value: http://my-corp
+        - name: https_proxy
+          value: http://my-corp
+        - name: NO_PROXY
+          value: apiserver-external.cluster-de-test-01.svc.cluster.local.
+        - name: no_proxy
+          value: apiserver-external.cluster-de-test-01.svc.cluster.local.
+        image: k8s.gcr.io/kube-apiserver:v1.20.0
+        livenessProbe:
+          failureThreshold: 8
+          httpGet:
+            path: /healthz
+            port: 30000
+            scheme: HTTPS
+          initialDelaySeconds: 15
+          periodSeconds: 10
+          successThreshold: 1
+          timeoutSeconds: 15
+        name: apiserver
+        ports:
+        - containerPort: 30000
+          protocol: TCP
+        readinessProbe:
+          failureThreshold: 3
+          httpGet:
+            path: /healthz
+            port: 30000
+            scheme: HTTPS
+          periodSeconds: 5
+          successThreshold: 1
+          timeoutSeconds: 15
+        resources:
+          limits:
+            cpu: "2"
+            memory: 4Gi
+          requests:
+            cpu: 100m
+            memory: 256Mi
+        volumeMounts:
+        - mountPath: /etc/kubernetes/tls
+          name: apiserver-tls
+          readOnly: true
+        - mountPath: /etc/kubernetes/tokens
+          name: tokens
+          readOnly: true
+        - mountPath: /etc/kubernetes/kubelet
+          name: kubelet-client-certificates
+          readOnly: true
+        - mountPath: /etc/kubernetes/pki/ca
+          name: ca
+          readOnly: true
+        - mountPath: /etc/kubernetes/service-account-key
+          name: service-account-key
+          readOnly: true
+        - mountPath: /etc/kubernetes/cloud
+          name: cloud-config
+          readOnly: true
+        - mountPath: /etc/etcd/pki/client
+          name: apiserver-etcd-client-certificate
+          readOnly: true
+        - mountPath: /etc/kubernetes/pki/front-proxy/client
+          name: apiserver-proxy-client-certificate
+          readOnly: true
+        - mountPath: /etc/kubernetes/pki/front-proxy/ca
+          name: front-proxy-ca
+          readOnly: true
+        - mountPath: /etc/kubernetes/audit
+          name: audit-config
+          readOnly: true
+        - mountPath: /var/log/kubernetes/audit
+          name: audit-log
+        - mountPath: /etc/kubernetes/adm-control
+          name: adm-control
+          readOnly: true
+        - mountPath: /etc/ssl/certs
+          name: ca-certs
+          readOnly: true
+        - mountPath: /usr/share/ca-certificates
+          name: usr-share-ca-certificates
+          readOnly: true
+        - mountPath: /etc/kubernetes/dex/ca
+          name: dex-ca
+          readOnly: true
+      dnsConfig:
+        nameservers:
+        - 192.0.2.14
+        options:
+        - name: ndots
+          value: "5"
+        searches:
+        - kube-system.svc.cluster.local
+        - svc.cluster.local
+        - cluster.local
+      dnsPolicy: None
+      imagePullSecrets:
+      - name: dockercfg
+      initContainers:
+      - command:
+        - /bin/sh
+        - -ec
+        - until ETCDCTL_API=3 /usr/local/bin/etcdctl --cacert=/etc/etcd/pki/client/ca.crt
+          --cert=/etc/etcd/pki/client/apiserver-etcd-client.crt --key=/etc/etcd/pki/client/apiserver-etcd-client.key
+          --dial-timeout=2s --endpoints='https://etcd-0.etcd.cluster-de-test-01.svc.cluster.local.:2379,https://etcd-1.etcd.cluster-de-test-01.svc.cluster.local.:2379,https://etcd-2.etcd.cluster-de-test-01.svc.cluster.local.:2379'
+          put kubermatic/quorum-check something; do echo waiting for etcd; sleep 2;
+          done;
+        image: gcr.io/etcd-development/etcd:v3.4.3
+        name: etcd-running
+        resources: {}
+        volumeMounts:
+        - mountPath: /etc/etcd/pki/client
+          name: apiserver-etcd-client-certificate
+          readOnly: true
+      volumes:
+      - name: apiserver-tls
+        secret:
+          secretName: apiserver-tls
+      - name: tokens
+        secret:
+          secretName: tokens
+      - name: openvpn-client-certificates
+        secret:
+          secretName: openvpn-client-certificates
+      - name: kubelet-client-certificates
+        secret:
+          secretName: kubelet-client-certificates
+      - name: ca
+        secret:
+          items:
+          - key: ca.crt
+            path: ca.crt
+          secretName: ca
+      - name: service-account-key
+        secret:
+          secretName: service-account-key
+      - configMap:
+          name: cloud-config
+        name: cloud-config
+      - name: apiserver-etcd-client-certificate
+        secret:
+          secretName: apiserver-etcd-client-certificate
+      - name: apiserver-proxy-client-certificate
+        secret:
+          secretName: apiserver-proxy-client-certificate
+      - name: front-proxy-ca
+        secret:
+          secretName: front-proxy-ca
+      - name: kubeletdnatcontroller-kubeconfig
+        secret:
+          secretName: kubeletdnatcontroller-kubeconfig
+      - configMap:
+          name: audit-config
+          optional: false
+        name: audit-config
+      - emptyDir: {}
+        name: audit-log
+      - configMap:
+          name: adm-control
+        name: adm-control
+      - hostPath:
+          path: /etc/ssl/certs
+          type: DirectoryOrCreate
+        name: ca-certs
+      - hostPath:
+          path: /usr/share/ca-certificates
+          type: DirectoryOrCreate
+        name: usr-share-ca-certificates
+      - name: dex-ca
+        secret:
+          secretName: dex-ca
+status: {}

--- a/pkg/resources/test/fixtures/deployment-vsphere-1.20.0-controller-manager.yaml
+++ b/pkg/resources/test/fixtures/deployment-vsphere-1.20.0-controller-manager.yaml
@@ -1,0 +1,231 @@
+# This file has been generated, DO NOT EDIT.
+
+metadata:
+  creationTimestamp: null
+  labels:
+    app: controller-manager
+  name: controller-manager
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: controller-manager
+  strategy: {}
+  template:
+    metadata:
+      annotations:
+        prometheus.io/path: /metrics
+        prometheus.io/port: "10257"
+        prometheus.io/scrape_with_kube_cert: "true"
+      creationTimestamp: null
+      labels:
+        app: controller-manager
+        ca-secret-revision: "123456"
+        cloud-config-configmap-revision: "123456"
+        cluster: de-test-01
+        controllermanager-kubeconfig-secret-revision: "123456"
+        openvpn-client-certificates-secret-revision: "123456"
+        service-account-key-secret-revision: "123456"
+    spec:
+      affinity:
+        podAntiAffinity:
+          preferredDuringSchedulingIgnoredDuringExecution:
+          - podAffinityTerm:
+              labelSelector:
+                matchLabels:
+                  app: controller-manager
+                  cluster: de-test-01
+              topologyKey: kubernetes.io/hostname
+            weight: 100
+          - podAffinityTerm:
+              labelSelector:
+                matchLabels:
+                  app: controller-manager
+              topologyKey: kubernetes.io/hostname
+            weight: 10
+      containers:
+      - args:
+        - --client
+        - --proto
+        - tcp
+        - --dev
+        - tun
+        - --auth-nocache
+        - --remote
+        - openvpn-server.cluster-de-test-01.svc.cluster.local.
+        - "1194"
+        - --nobind
+        - --connect-timeout
+        - "5"
+        - --connect-retry
+        - "1"
+        - --ca
+        - /etc/openvpn/pki/client/ca.crt
+        - --cert
+        - /etc/openvpn/pki/client/client.crt
+        - --key
+        - /etc/openvpn/pki/client/client.key
+        - --remote-cert-tls
+        - server
+        - --link-mtu
+        - "1432"
+        - --cipher
+        - AES-256-GCM
+        - --auth
+        - SHA1
+        - --keysize
+        - "256"
+        - --script-security
+        - "2"
+        - --status
+        - /run/openvpn-status
+        - --log
+        - /dev/stdout
+        command:
+        - /usr/sbin/openvpn
+        image: quay.io/kubermatic/openvpn:v2.4.8-r1
+        name: openvpn-client
+        resources:
+          limits:
+            cpu: 100m
+            memory: 32Mi
+          requests:
+            cpu: 5m
+            memory: 5Mi
+        securityContext:
+          privileged: true
+        volumeMounts:
+        - mountPath: /etc/openvpn/pki/client
+          name: openvpn-client-certificates
+          readOnly: true
+      - args:
+        - -endpoint
+        - https://apiserver-external.cluster-de-test-01.svc.cluster.local./healthz
+        - -insecure
+        - -retries
+        - "100"
+        - -retry-wait
+        - "2"
+        - -timeout
+        - "1"
+        - -command
+        - '{"command":"/usr/local/bin/kube-controller-manager","args":["--kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","--service-account-private-key-file","/etc/kubernetes/service-account-key/sa.key","--root-ca-file","/etc/kubernetes/pki/ca/ca.crt","--cluster-signing-cert-file","/etc/kubernetes/pki/ca/ca.crt","--cluster-signing-key-file","/etc/kubernetes/pki/ca/ca.key","--cluster-cidr","172.25.0.0/16","--allocate-node-cidrs","--controllers","*,bootstrapsigner,tokencleaner","--use-service-account-credentials","--feature-gates","RotateKubeletClientCertificate=true,RotateKubeletServerCertificate=true","--cloud-provider","vsphere","--cloud-config","/etc/kubernetes/cloud/config","--configure-cloud-routes=false","--authentication-kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","--client-ca-file","/etc/kubernetes/pki/ca/ca.crt","--authentication-kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","--authorization-kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","--port","0"]}'
+        command:
+        - /http-prober-bin/http-prober
+        env:
+        - name: HTTP_PROXY
+          value: http://my-corp
+        - name: HTTPS_PROXY
+          value: http://my-corp
+        - name: http_proxy
+          value: http://my-corp
+        - name: https_proxy
+          value: http://my-corp
+        - name: NO_PROXY
+          value: apiserver-external.cluster-de-test-01.svc.cluster.local.
+        - name: no_proxy
+          value: apiserver-external.cluster-de-test-01.svc.cluster.local.
+        image: k8s.gcr.io/kube-controller-manager:v1.20.0
+        livenessProbe:
+          failureThreshold: 8
+          httpGet:
+            path: /healthz
+            port: 10257
+            scheme: HTTPS
+          initialDelaySeconds: 15
+          periodSeconds: 10
+          successThreshold: 1
+          timeoutSeconds: 15
+        name: controller-manager
+        readinessProbe:
+          failureThreshold: 3
+          httpGet:
+            path: /healthz
+            port: 10257
+            scheme: HTTPS
+          periodSeconds: 10
+          successThreshold: 1
+          timeoutSeconds: 15
+        resources:
+          limits:
+            cpu: "2"
+            memory: 2Gi
+          requests:
+            cpu: 100m
+            memory: 100Mi
+        volumeMounts:
+        - mountPath: /etc/kubernetes/pki/ca
+          name: ca
+          readOnly: true
+        - mountPath: /etc/kubernetes/service-account-key
+          name: service-account-key
+          readOnly: true
+        - mountPath: /etc/kubernetes/cloud
+          name: cloud-config
+          readOnly: true
+        - mountPath: /etc/kubernetes/kubeconfig
+          name: controllermanager-kubeconfig
+          readOnly: true
+        - mountPath: /etc/ssl/certs
+          name: ca-certs
+          readOnly: true
+        - mountPath: /usr/share/ca-certificates
+          name: usr-share-ca-certificates
+          readOnly: true
+        - mountPath: /sys/class/dmi/id/product_serial
+          name: cloud-config
+          readOnly: true
+          subPath: fakeVmwareUUID
+        - mountPath: /http-prober-bin
+          name: http-prober-bin
+      dnsConfig:
+        nameservers:
+        - 192.0.2.14
+        options:
+        - name: ndots
+          value: "5"
+        searches:
+        - kube-system.svc.cluster.local
+        - svc.cluster.local
+        - cluster.local
+      dnsPolicy: None
+      imagePullSecrets:
+      - name: dockercfg
+      initContainers:
+      - command:
+        - /bin/cp
+        - /usr/local/bin/http-prober
+        - /http-prober-bin/http-prober
+        image: quay.io/kubermatic/http-prober:v0.3.1
+        name: copy-http-prober
+        resources: {}
+        volumeMounts:
+        - mountPath: /http-prober-bin
+          name: http-prober-bin
+      volumes:
+      - name: ca
+        secret:
+          secretName: ca
+      - name: service-account-key
+        secret:
+          secretName: service-account-key
+      - configMap:
+          name: cloud-config
+        name: cloud-config
+      - name: openvpn-client-certificates
+        secret:
+          secretName: openvpn-client-certificates
+      - name: controllermanager-kubeconfig
+        secret:
+          secretName: controllermanager-kubeconfig
+      - hostPath:
+          path: /etc/ssl/certs
+          type: DirectoryOrCreate
+        name: ca-certs
+      - hostPath:
+          path: /usr/share/ca-certificates
+          type: DirectoryOrCreate
+        name: usr-share-ca-certificates
+      - emptyDir: {}
+        name: http-prober-bin
+status: {}

--- a/pkg/resources/test/fixtures/deployment-vsphere-1.20.0-dns-resolver.yaml
+++ b/pkg/resources/test/fixtures/deployment-vsphere-1.20.0-dns-resolver.yaml
@@ -1,0 +1,140 @@
+# This file has been generated, DO NOT EDIT.
+
+metadata:
+  creationTimestamp: null
+  labels:
+    app: dns-resolver
+  name: dns-resolver
+spec:
+  replicas: 2
+  selector:
+    matchLabels:
+      app: dns-resolver
+  strategy: {}
+  template:
+    metadata:
+      annotations:
+        prometheus.io/path: /metrics
+        prometheus.io/port: "9253"
+        prometheus.io/scrape: "true"
+      creationTimestamp: null
+      labels:
+        app: dns-resolver
+        ca-secret-revision: "123456"
+        cluster: de-test-01
+        dns-resolver-configmap-revision: "123456"
+        openvpn-client-certificates-secret-revision: "123456"
+    spec:
+      affinity:
+        podAntiAffinity:
+          preferredDuringSchedulingIgnoredDuringExecution:
+          - podAffinityTerm:
+              labelSelector:
+                matchLabels:
+                  app: dns-resolver
+                  cluster: de-test-01
+              topologyKey: kubernetes.io/hostname
+            weight: 100
+          - podAffinityTerm:
+              labelSelector:
+                matchLabels:
+                  app: dns-resolver
+              topologyKey: kubernetes.io/hostname
+            weight: 10
+      containers:
+      - args:
+        - --client
+        - --proto
+        - tcp
+        - --dev
+        - tun
+        - --auth-nocache
+        - --remote
+        - openvpn-server.cluster-de-test-01.svc.cluster.local.
+        - "1194"
+        - --nobind
+        - --connect-timeout
+        - "5"
+        - --connect-retry
+        - "1"
+        - --ca
+        - /etc/openvpn/pki/client/ca.crt
+        - --cert
+        - /etc/openvpn/pki/client/client.crt
+        - --key
+        - /etc/openvpn/pki/client/client.key
+        - --remote-cert-tls
+        - server
+        - --link-mtu
+        - "1432"
+        - --cipher
+        - AES-256-GCM
+        - --auth
+        - SHA1
+        - --keysize
+        - "256"
+        - --script-security
+        - "2"
+        - --status
+        - /run/openvpn-status
+        - --log
+        - /dev/stdout
+        command:
+        - /usr/sbin/openvpn
+        image: quay.io/kubermatic/openvpn:v2.4.8-r1
+        name: openvpn-client
+        resources:
+          limits:
+            cpu: 100m
+            memory: 32Mi
+          requests:
+            cpu: 5m
+            memory: 5Mi
+        securityContext:
+          privileged: true
+        volumeMounts:
+        - mountPath: /etc/openvpn/pki/client
+          name: openvpn-client-certificates
+          readOnly: true
+      - args:
+        - -conf
+        - /etc/coredns/Corefile
+        image: k8s.gcr.io/coredns:1.3.1
+        name: dns-resolver
+        readinessProbe:
+          failureThreshold: 3
+          httpGet:
+            path: /health
+            port: 8080
+            scheme: HTTP
+          initialDelaySeconds: 2
+          periodSeconds: 10
+          successThreshold: 1
+          timeoutSeconds: 15
+        resources:
+          limits:
+            cpu: 100m
+            memory: 128Mi
+          requests:
+            cpu: 5m
+            memory: 20Mi
+        volumeMounts:
+        - mountPath: /etc/coredns
+          name: dns-resolver
+          readOnly: true
+      imagePullSecrets:
+      - name: dockercfg
+      volumes:
+      - configMap:
+          name: dns-resolver
+        name: dns-resolver
+      - name: openvpn-client-certificates
+        secret:
+          secretName: openvpn-client-certificates
+      - name: ca
+        secret:
+          items:
+          - key: ca.crt
+            path: ca.crt
+          secretName: ca
+status: {}

--- a/pkg/resources/test/fixtures/deployment-vsphere-1.20.0-kube-state-metrics.yaml
+++ b/pkg/resources/test/fixtures/deployment-vsphere-1.20.0-kube-state-metrics.yaml
@@ -1,0 +1,89 @@
+# This file has been generated, DO NOT EDIT.
+
+metadata:
+  creationTimestamp: null
+  labels:
+    app: kube-state-metrics
+  name: kube-state-metrics
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: kube-state-metrics
+  strategy: {}
+  template:
+    metadata:
+      annotations:
+        prometheus.io/scrape: "true"
+      creationTimestamp: null
+      labels:
+        app: kube-state-metrics
+        cluster: de-test-01
+        kube-state-metrics-kubeconfig-secret-revision: "123456"
+    spec:
+      containers:
+      - args:
+        - -endpoint
+        - https://apiserver-external.cluster-de-test-01.svc.cluster.local./healthz
+        - -insecure
+        - -retries
+        - "100"
+        - -retry-wait
+        - "2"
+        - -timeout
+        - "1"
+        - -command
+        - '{"command":"/kube-state-metrics","args":["--kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","--port","8080","--telemetry-port","8081"]}'
+        command:
+        - /http-prober-bin/http-prober
+        image: quay.io/coreos/kube-state-metrics:v1.9.7
+        name: kube-state-metrics
+        ports:
+        - containerPort: 8080
+          name: metrics
+          protocol: TCP
+        - containerPort: 8081
+          name: telemetry
+          protocol: TCP
+        readinessProbe:
+          failureThreshold: 3
+          httpGet:
+            path: /healthz
+            port: 8080
+            scheme: HTTP
+          periodSeconds: 10
+          successThreshold: 1
+          timeoutSeconds: 15
+        resources:
+          limits:
+            cpu: 100m
+            memory: 1Gi
+          requests:
+            cpu: 10m
+            memory: 12Mi
+        volumeMounts:
+        - mountPath: /etc/kubernetes/kubeconfig
+          name: kube-state-metrics-kubeconfig
+          readOnly: true
+        - mountPath: /http-prober-bin
+          name: http-prober-bin
+      imagePullSecrets:
+      - name: dockercfg
+      initContainers:
+      - command:
+        - /bin/cp
+        - /usr/local/bin/http-prober
+        - /http-prober-bin/http-prober
+        image: quay.io/kubermatic/http-prober:v0.3.1
+        name: copy-http-prober
+        resources: {}
+        volumeMounts:
+        - mountPath: /http-prober-bin
+          name: http-prober-bin
+      volumes:
+      - name: kube-state-metrics-kubeconfig
+        secret:
+          secretName: kube-state-metrics-kubeconfig
+      - emptyDir: {}
+        name: http-prober-bin
+status: {}

--- a/pkg/resources/test/fixtures/deployment-vsphere-1.20.0-kubernetes-dashboard.yaml
+++ b/pkg/resources/test/fixtures/deployment-vsphere-1.20.0-kubernetes-dashboard.yaml
@@ -1,0 +1,97 @@
+# This file has been generated, DO NOT EDIT.
+
+metadata:
+  creationTimestamp: null
+  labels:
+    app: kubernetes-dashboard
+  name: kubernetes-dashboard
+spec:
+  replicas: 2
+  selector:
+    matchLabels:
+      app: kubernetes-dashboard
+  strategy: {}
+  template:
+    metadata:
+      creationTimestamp: null
+      labels:
+        app: kubernetes-dashboard
+        cluster: de-test-01
+        kubernetes-dashboard-kubeconfig-secret-revision: "123456"
+    spec:
+      affinity:
+        podAntiAffinity:
+          preferredDuringSchedulingIgnoredDuringExecution:
+          - podAffinityTerm:
+              labelSelector:
+                matchLabels:
+                  app: kubernetes-dashboard
+                  cluster: de-test-01
+              topologyKey: kubernetes.io/hostname
+            weight: 100
+          - podAffinityTerm:
+              labelSelector:
+                matchLabels:
+                  app: kubernetes-dashboard
+              topologyKey: kubernetes.io/hostname
+            weight: 10
+      containers:
+      - args:
+        - -endpoint
+        - https://apiserver-external.cluster-de-test-01.svc.cluster.local./healthz
+        - -insecure
+        - -retries
+        - "100"
+        - -retry-wait
+        - "2"
+        - -timeout
+        - "1"
+        - -command
+        - '{"command":"/dashboard","args":["--kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","--namespace","kubernetes-dashboard","--enable-insecure-login"]}'
+        command:
+        - /http-prober-bin/http-prober
+        image: docker.io/kubernetesui/dashboard:v2.0.4
+        imagePullPolicy: IfNotPresent
+        name: kubernetes-dashboard
+        ports:
+        - containerPort: 9090
+          protocol: TCP
+        resources:
+          limits:
+            cpu: 250m
+            memory: 512Mi
+          requests:
+            cpu: 100m
+            memory: 256Mi
+        securityContext:
+          allowPrivilegeEscalation: false
+          readOnlyRootFilesystem: true
+          runAsUser: 1001
+        volumeMounts:
+        - mountPath: /etc/kubernetes/kubeconfig
+          name: kubernetes-dashboard-kubeconfig
+          readOnly: true
+        - mountPath: /tmp
+          name: tmp-volume
+        - mountPath: /http-prober-bin
+          name: http-prober-bin
+      initContainers:
+      - command:
+        - /bin/cp
+        - /usr/local/bin/http-prober
+        - /http-prober-bin/http-prober
+        image: quay.io/kubermatic/http-prober:v0.3.1
+        name: copy-http-prober
+        resources: {}
+        volumeMounts:
+        - mountPath: /http-prober-bin
+          name: http-prober-bin
+      volumes:
+      - name: kubernetes-dashboard-kubeconfig
+        secret:
+          secretName: kubernetes-dashboard-kubeconfig
+      - emptyDir: {}
+        name: tmp-volume
+      - emptyDir: {}
+        name: http-prober-bin
+status: {}

--- a/pkg/resources/test/fixtures/deployment-vsphere-1.20.0-machine-controller-webhook.yaml
+++ b/pkg/resources/test/fixtures/deployment-vsphere-1.20.0-machine-controller-webhook.yaml
@@ -1,0 +1,120 @@
+# This file has been generated, DO NOT EDIT.
+
+metadata:
+  creationTimestamp: null
+  labels:
+    app: machine-controller-webhook
+  name: machine-controller-webhook
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: machine-controller-webhook
+  strategy: {}
+  template:
+    metadata:
+      creationTimestamp: null
+      labels:
+        app: machine-controller-webhook
+        cluster: de-test-01
+        machinecontroller-kubeconfig-secret-revision: "123456"
+        machinecontroller-webhook-serving-cert-secret-revision: "123456"
+    spec:
+      containers:
+      - args:
+        - -endpoint
+        - https://apiserver-external.cluster-de-test-01.svc.cluster.local./healthz
+        - -insecure
+        - -retries
+        - "100"
+        - -retry-wait
+        - "2"
+        - -timeout
+        - "1"
+        - -command
+        - '{"command":"/usr/local/bin/webhook","args":["-kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","-logtostderr","-v","4","-listen-address","0.0.0.0:9876"]}'
+        - --crd-to-wait-for
+        - Machine,cluster.k8s.io/v1alpha1
+        command:
+        - /http-prober-bin/http-prober
+        env:
+        - name: VSPHERE_ADDRESS
+          value: https://vs-endpoint.io
+        - name: VSPHERE_USERNAME
+          value: vs-username
+        - name: VSPHERE_PASSWORD
+          value: vs-password
+        - name: HTTP_PROXY
+          value: http://my-corp
+        - name: HTTPS_PROXY
+          value: http://my-corp
+        - name: http_proxy
+          value: http://my-corp
+        - name: https_proxy
+          value: http://my-corp
+        - name: NO_PROXY
+          value: apiserver-external.cluster-de-test-01.svc.cluster.local.
+        - name: no_proxy
+          value: apiserver-external.cluster-de-test-01.svc.cluster.local.
+        - name: KUBECONFIG
+          value: /etc/kubernetes/kubeconfig/kubeconfig
+        image: docker.io/kubermatic/machine-controller:v1.23.1
+        livenessProbe:
+          failureThreshold: 8
+          httpGet:
+            path: /healthz
+            port: 9876
+            scheme: HTTPS
+          initialDelaySeconds: 15
+          periodSeconds: 10
+          successThreshold: 1
+          timeoutSeconds: 15
+        name: machine-controller
+        readinessProbe:
+          failureThreshold: 3
+          httpGet:
+            path: /healthz
+            port: 9876
+            scheme: HTTPS
+          periodSeconds: 10
+          successThreshold: 1
+          timeoutSeconds: 15
+        resources:
+          limits:
+            cpu: 100m
+            memory: 512Mi
+          requests:
+            cpu: 10m
+            memory: 32Mi
+        volumeMounts:
+        - mountPath: /etc/kubernetes/kubeconfig
+          name: machinecontroller-kubeconfig
+          readOnly: true
+        - mountPath: /tmp/cert
+          name: machinecontroller-webhook-serving-cert
+          readOnly: true
+        - mountPath: /http-prober-bin
+          name: http-prober-bin
+      imagePullSecrets:
+      - name: dockercfg
+      initContainers:
+      - command:
+        - /bin/cp
+        - /usr/local/bin/http-prober
+        - /http-prober-bin/http-prober
+        image: quay.io/kubermatic/http-prober:v0.3.1
+        name: copy-http-prober
+        resources: {}
+        volumeMounts:
+        - mountPath: /http-prober-bin
+          name: http-prober-bin
+      volumes:
+      - name: machinecontroller-kubeconfig
+        secret:
+          secretName: machinecontroller-kubeconfig
+      - name: machinecontroller-webhook-serving-cert
+        secret:
+          secretName: machinecontroller-webhook-serving-cert
+      - emptyDir: {}
+        name: http-prober-bin
+status: {}

--- a/pkg/resources/test/fixtures/deployment-vsphere-1.20.0-machine-controller.yaml
+++ b/pkg/resources/test/fixtures/deployment-vsphere-1.20.0-machine-controller.yaml
@@ -1,0 +1,108 @@
+# This file has been generated, DO NOT EDIT.
+
+metadata:
+  creationTimestamp: null
+  labels:
+    app: machine-controller
+  name: machine-controller
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: machine-controller
+  strategy: {}
+  template:
+    metadata:
+      annotations:
+        prometheus.io/path: /metrics
+        prometheus.io/port: "8080"
+        prometheus.io/scrape: "true"
+      creationTimestamp: null
+      labels:
+        app: machine-controller
+        cluster: de-test-01
+        machinecontroller-kubeconfig-secret-revision: "123456"
+    spec:
+      containers:
+      - args:
+        - -endpoint
+        - https://apiserver-external.cluster-de-test-01.svc.cluster.local./healthz
+        - -insecure
+        - -retries
+        - "100"
+        - -retry-wait
+        - "2"
+        - -timeout
+        - "1"
+        - -command
+        - '{"command":"/usr/local/bin/machine-controller","args":["-kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","-logtostderr","-v","4","-cluster-dns","169.254.20.10","-health-probe-address","0.0.0.0:8085","-metrics-address","0.0.0.0:8080"]}'
+        - --crd-to-wait-for
+        - Machine,cluster.k8s.io/v1alpha1
+        command:
+        - /http-prober-bin/http-prober
+        env:
+        - name: VSPHERE_ADDRESS
+          value: https://vs-endpoint.io
+        - name: VSPHERE_USERNAME
+          value: vs-username
+        - name: VSPHERE_PASSWORD
+          value: vs-password
+        - name: HTTP_PROXY
+          value: http://my-corp
+        - name: HTTPS_PROXY
+          value: http://my-corp
+        - name: http_proxy
+          value: http://my-corp
+        - name: https_proxy
+          value: http://my-corp
+        - name: NO_PROXY
+          value: apiserver-external.cluster-de-test-01.svc.cluster.local.
+        - name: no_proxy
+          value: apiserver-external.cluster-de-test-01.svc.cluster.local.
+        - name: KUBECONFIG
+          value: /etc/kubernetes/kubeconfig/kubeconfig
+        image: docker.io/kubermatic/machine-controller:v1.23.1
+        livenessProbe:
+          failureThreshold: 3
+          httpGet:
+            path: /readyz
+            port: 8085
+            scheme: HTTP
+          initialDelaySeconds: 15
+          periodSeconds: 10
+          successThreshold: 1
+          timeoutSeconds: 15
+        name: machine-controller
+        resources:
+          limits:
+            cpu: "2"
+            memory: 512Mi
+          requests:
+            cpu: 25m
+            memory: 32Mi
+        volumeMounts:
+        - mountPath: /etc/kubernetes/kubeconfig
+          name: machinecontroller-kubeconfig
+          readOnly: true
+        - mountPath: /http-prober-bin
+          name: http-prober-bin
+      imagePullSecrets:
+      - name: dockercfg
+      initContainers:
+      - command:
+        - /bin/cp
+        - /usr/local/bin/http-prober
+        - /http-prober-bin/http-prober
+        image: quay.io/kubermatic/http-prober:v0.3.1
+        name: copy-http-prober
+        resources: {}
+        volumeMounts:
+        - mountPath: /http-prober-bin
+          name: http-prober-bin
+      volumes:
+      - name: machinecontroller-kubeconfig
+        secret:
+          secretName: machinecontroller-kubeconfig
+      - emptyDir: {}
+        name: http-prober-bin
+status: {}

--- a/pkg/resources/test/fixtures/deployment-vsphere-1.20.0-metrics-server.yaml
+++ b/pkg/resources/test/fixtures/deployment-vsphere-1.20.0-metrics-server.yaml
@@ -1,0 +1,182 @@
+# This file has been generated, DO NOT EDIT.
+
+metadata:
+  creationTimestamp: null
+  labels:
+    app: metrics-server
+  name: metrics-server
+spec:
+  replicas: 2
+  selector:
+    matchLabels:
+      app: metrics-server
+  strategy: {}
+  template:
+    metadata:
+      creationTimestamp: null
+      labels:
+        app: metrics-server
+        cluster: de-test-01
+        kubeletdnatcontroller-kubeconfig-secret-revision: "123456"
+        metrics-server-secret-revision: "123456"
+        metrics-server-serving-cert-secret-revision: "123456"
+        openvpn-client-certificates-secret-revision: "123456"
+    spec:
+      affinity:
+        podAntiAffinity:
+          preferredDuringSchedulingIgnoredDuringExecution:
+          - podAffinityTerm:
+              labelSelector:
+                matchLabels:
+                  app: metrics-server
+                  cluster: de-test-01
+              topologyKey: kubernetes.io/hostname
+            weight: 100
+          - podAffinityTerm:
+              labelSelector:
+                matchLabels:
+                  app: metrics-server
+              topologyKey: kubernetes.io/hostname
+            weight: 10
+      containers:
+      - args:
+        - -endpoint
+        - https://apiserver-external.cluster-de-test-01.svc.cluster.local./healthz
+        - -insecure
+        - -retries
+        - "100"
+        - -retry-wait
+        - "2"
+        - -timeout
+        - "1"
+        - -command
+        - '{"command":"/metrics-server","args":["--kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","--authentication-kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","--authorization-kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","--kubelet-port","10250","--kubelet-insecure-tls","--kubelet-preferred-address-types","ExternalIP,InternalIP","--v","1","--logtostderr","--tls-cert-file","/etc/serving-cert/serving.crt","--tls-private-key-file","/etc/serving-cert/serving.key"]}'
+        command:
+        - /http-prober-bin/http-prober
+        image: k8s.gcr.io/metrics-server-amd64:v0.3.6
+        name: metrics-server
+        resources:
+          limits:
+            cpu: 150m
+            memory: 512Mi
+          requests:
+            cpu: 25m
+            memory: 32Mi
+        volumeMounts:
+        - mountPath: /etc/kubernetes/kubeconfig
+          name: metrics-server
+          readOnly: true
+        - mountPath: /etc/serving-cert
+          name: metrics-server-serving-cert
+          readOnly: true
+        - mountPath: /http-prober-bin
+          name: http-prober-bin
+      - args:
+        - --client
+        - --proto
+        - tcp
+        - --dev
+        - tun
+        - --auth-nocache
+        - --remote
+        - openvpn-server.cluster-de-test-01.svc.cluster.local.
+        - "1194"
+        - --nobind
+        - --connect-timeout
+        - "5"
+        - --connect-retry
+        - "1"
+        - --ca
+        - /etc/openvpn/pki/client/ca.crt
+        - --cert
+        - /etc/openvpn/pki/client/client.crt
+        - --key
+        - /etc/openvpn/pki/client/client.key
+        - --remote-cert-tls
+        - server
+        - --link-mtu
+        - "1432"
+        - --cipher
+        - AES-256-GCM
+        - --auth
+        - SHA1
+        - --keysize
+        - "256"
+        - --script-security
+        - "2"
+        - --status
+        - /run/openvpn-status
+        - --log
+        - /dev/stdout
+        command:
+        - /usr/sbin/openvpn
+        image: quay.io/kubermatic/openvpn:v2.4.8-r1
+        name: openvpn-client
+        resources:
+          limits:
+            cpu: 100m
+            memory: 32Mi
+          requests:
+            cpu: 5m
+            memory: 5Mi
+        securityContext:
+          privileged: true
+        volumeMounts:
+        - mountPath: /etc/openvpn/pki/client
+          name: openvpn-client-certificates
+          readOnly: true
+      - args:
+        - -kubeconfig
+        - /etc/kubernetes/kubeconfig/kubeconfig
+        - -node-access-network
+        - 192.0.2.0/24
+        command:
+        - /usr/local/bin/kubeletdnat-controller
+        image: quay.io/kubermatic/kubeletdnat-controller:v0.0.0-test
+        name: dnat-controller
+        resources:
+          limits:
+            cpu: 100m
+            memory: 512Mi
+          requests:
+            cpu: 5m
+            memory: 16Mi
+        securityContext:
+          capabilities:
+            add:
+            - NET_ADMIN
+          procMount: Default
+          runAsUser: 0
+        volumeMounts:
+        - mountPath: /etc/kubernetes/kubeconfig
+          name: kubeletdnatcontroller-kubeconfig
+          readOnly: true
+      imagePullSecrets:
+      - name: dockercfg
+      initContainers:
+      - command:
+        - /bin/cp
+        - /usr/local/bin/http-prober
+        - /http-prober-bin/http-prober
+        image: quay.io/kubermatic/http-prober:v0.3.1
+        name: copy-http-prober
+        resources: {}
+        volumeMounts:
+        - mountPath: /http-prober-bin
+          name: http-prober-bin
+      volumes:
+      - name: metrics-server
+        secret:
+          secretName: metrics-server
+      - name: openvpn-client-certificates
+        secret:
+          secretName: openvpn-client-certificates
+      - name: kubeletdnatcontroller-kubeconfig
+        secret:
+          secretName: kubeletdnatcontroller-kubeconfig
+      - name: metrics-server-serving-cert
+        secret:
+          secretName: metrics-server-serving-cert
+      - emptyDir: {}
+        name: http-prober-bin
+status: {}

--- a/pkg/resources/test/fixtures/deployment-vsphere-1.20.0-openvpn-server.yaml
+++ b/pkg/resources/test/fixtures/deployment-vsphere-1.20.0-openvpn-server.yaml
@@ -1,0 +1,223 @@
+# This file has been generated, DO NOT EDIT.
+
+metadata:
+  creationTimestamp: null
+  labels:
+    app: openvpn-server
+  name: openvpn-server
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: openvpn-server
+  strategy:
+    rollingUpdate:
+      maxSurge: 1
+      maxUnavailable: 1
+    type: RollingUpdate
+  template:
+    metadata:
+      annotations:
+        prometheus.io/path: /metrics
+        prometheus.io/port: "9176"
+        prometheus.io/scrape: "true"
+      creationTimestamp: null
+      labels:
+        app: openvpn-server
+        cluster: de-test-01
+        openvpn-ca-secret-revision: "123456"
+        openvpn-client-configs-configmap-revision: "123456"
+        openvpn-server-certificates-secret-revision: "123456"
+    spec:
+      containers:
+      - args:
+        - --proto
+        - tcp
+        - --dev
+        - tun
+        - --mode
+        - server
+        - --lport
+        - "1194"
+        - --server
+        - 10.20.0.0
+        - 255.255.255.0
+        - --ca
+        - /etc/kubernetes/pki/ca/ca.crt
+        - --cert
+        - /etc/openvpn/pki/server/server.crt
+        - --key
+        - /etc/openvpn/pki/server/server.key
+        - --dh
+        - none
+        - --duplicate-cn
+        - --client-config-dir
+        - /etc/openvpn/clients
+        - --status
+        - /run/openvpn/openvpn-status
+        - --status-version
+        - "3"
+        - --cipher
+        - AES-256-GCM
+        - --auth
+        - SHA1
+        - --keysize
+        - "256"
+        - --script-security
+        - "2"
+        - --ping
+        - "5"
+        - --verb
+        - "3"
+        - --log
+        - /dev/stdout
+        - --push
+        - route 172.25.0.0 255.255.0.0
+        - --route
+        - 172.25.0.0
+        - 255.255.0.0
+        - --push
+        - route 10.240.16.0 255.255.240.0
+        - --route
+        - 10.240.16.0
+        - 255.255.240.0
+        - --push
+        - route 192.0.2.0 255.255.255.0
+        - --route
+        - 192.0.2.0
+        - 255.255.255.0
+        command:
+        - /usr/sbin/openvpn
+        image: quay.io/kubermatic/openvpn:v2.4.8-r1
+        name: openvpn-server
+        ports:
+        - containerPort: 1194
+          protocol: TCP
+        readinessProbe:
+          exec:
+            command:
+            - test
+            - -s
+            - /run/openvpn/openvpn-status
+          failureThreshold: 3
+          initialDelaySeconds: 5
+          periodSeconds: 5
+          successThreshold: 1
+          timeoutSeconds: 1
+        resources:
+          limits:
+            cpu: 100m
+            memory: 20Mi
+          requests:
+            cpu: 5m
+            memory: 5Mi
+        securityContext:
+          privileged: true
+          procMount: Default
+        volumeMounts:
+        - mountPath: /etc/openvpn/pki/server
+          name: openvpn-server-certificates
+          readOnly: true
+        - mountPath: /etc/kubernetes/pki/ca
+          name: ca
+          readOnly: true
+        - mountPath: /etc/openvpn/clients
+          name: openvpn-client-configs
+          readOnly: true
+        - mountPath: /run/openvpn
+          name: openvpn-status
+      - args:
+        - -c
+        - |-
+          while true; do sysctl -w net.ipv4.ip_forward=1;
+            if ! iptables -t mangle -C INPUT -p tcp --tcp-flags SYN,RST SYN --dport 1194 -j TCPMSS --set-mss 1300 &>/dev/null; then
+             iptables -t mangle -A INPUT -p tcp --tcp-flags SYN,RST SYN --dport 1194 -j TCPMSS --set-mss 1300
+            fi
+            sleep 30;
+          done
+        command:
+        - /bin/bash
+        image: quay.io/kubermatic/openvpn:v2.4.8-r1
+        name: ip-fixup
+        resources:
+          limits:
+            cpu: 10m
+            memory: 32Mi
+          requests:
+            cpu: 5m
+            memory: 16Mi
+        securityContext:
+          privileged: true
+          procMount: Default
+      - args:
+        - -openvpn.status_paths
+        - /run/openvpn/openvpn-status
+        command:
+        - /bin/openvpn_exporter
+        image: docker.io/kumina/openvpn-exporter:v0.2.2
+        name: openvpn-exporter
+        ports:
+        - containerPort: 9176
+          protocol: TCP
+        resources:
+          limits:
+            cpu: 100m
+            memory: 20Mi
+          requests:
+            cpu: 5m
+            memory: 5Mi
+        volumeMounts:
+        - mountPath: /run/openvpn
+          name: openvpn-status
+      imagePullSecrets:
+      - name: dockercfg
+      initContainers:
+      - args:
+        - -c
+        - |
+          # do not give a 10.20.0.0/24 route to clients (nodes) but
+          # masquerade to openvpn-server's IP instead:
+          iptables -t nat -A POSTROUTING -o tun0 -s 10.20.0.0/24 -j MASQUERADE
+
+          # Only allow outbound traffic to services, pods, nodes
+          iptables -P FORWARD DROP
+          iptables -A FORWARD -m state --state ESTABLISHED,RELATED -j ACCEPT
+          iptables -A FORWARD -i tun0 -o tun0 -s 10.20.0.0/24 -d 172.25.0.0/16 -j ACCEPT
+          iptables -A FORWARD -i tun0 -o tun0 -s 10.20.0.0/24 -d 10.240.16.0/20 -j ACCEPT
+          iptables -A FORWARD -i tun0 -o tun0 -s 10.20.0.0/24 -d 192.0.2.0/24 -j ACCEPT
+
+          iptables -A INPUT -m state --state ESTABLISHED,RELATED -j ACCEPT
+          iptables -A INPUT -i tun0 -p icmp -j ACCEPT
+          iptables -A INPUT -i tun0 -j DROP
+        command:
+        - /bin/bash
+        image: quay.io/kubermatic/openvpn:v2.4.8-r1
+        name: iptables-init
+        resources:
+          limits:
+            cpu: 100m
+            memory: 20Mi
+          requests:
+            cpu: 5m
+            memory: 5Mi
+        securityContext:
+          capabilities:
+            add:
+            - NET_ADMIN
+          procMount: Default
+      volumes:
+      - name: ca
+        secret:
+          items:
+          - key: ca.crt
+            path: ca.crt
+          secretName: openvpn-ca
+      - name: openvpn-server-certificates
+        secret:
+          secretName: openvpn-server-certificates
+      - configMap:
+          name: openvpn-client-configs
+        name: openvpn-client-configs
+      - emptyDir: {}
+        name: openvpn-status
+status: {}

--- a/pkg/resources/test/fixtures/deployment-vsphere-1.20.0-scheduler.yaml
+++ b/pkg/resources/test/fixtures/deployment-vsphere-1.20.0-scheduler.yaml
@@ -1,0 +1,203 @@
+# This file has been generated, DO NOT EDIT.
+
+metadata:
+  creationTimestamp: null
+  labels:
+    app: scheduler
+  name: scheduler
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: scheduler
+  strategy: {}
+  template:
+    metadata:
+      annotations:
+        prometheus.io/path: /metrics
+        prometheus.io/port: "10259"
+        prometheus.io/scrape_with_kube_cert: "true"
+      creationTimestamp: null
+      labels:
+        app: scheduler
+        ca-secret-revision: "123456"
+        cluster: de-test-01
+        openvpn-client-certificates-secret-revision: "123456"
+        scheduler-kubeconfig-secret-revision: "123456"
+    spec:
+      affinity:
+        podAntiAffinity:
+          preferredDuringSchedulingIgnoredDuringExecution:
+          - podAffinityTerm:
+              labelSelector:
+                matchLabels:
+                  app: scheduler
+                  cluster: de-test-01
+              topologyKey: kubernetes.io/hostname
+            weight: 100
+          - podAffinityTerm:
+              labelSelector:
+                matchLabels:
+                  app: scheduler
+              topologyKey: kubernetes.io/hostname
+            weight: 10
+      containers:
+      - args:
+        - --client
+        - --proto
+        - tcp
+        - --dev
+        - tun
+        - --auth-nocache
+        - --remote
+        - openvpn-server.cluster-de-test-01.svc.cluster.local.
+        - "1194"
+        - --nobind
+        - --connect-timeout
+        - "5"
+        - --connect-retry
+        - "1"
+        - --ca
+        - /etc/openvpn/pki/client/ca.crt
+        - --cert
+        - /etc/openvpn/pki/client/client.crt
+        - --key
+        - /etc/openvpn/pki/client/client.key
+        - --remote-cert-tls
+        - server
+        - --link-mtu
+        - "1432"
+        - --cipher
+        - AES-256-GCM
+        - --auth
+        - SHA1
+        - --keysize
+        - "256"
+        - --script-security
+        - "2"
+        - --status
+        - /run/openvpn-status
+        - --log
+        - /dev/stdout
+        command:
+        - /usr/sbin/openvpn
+        image: quay.io/kubermatic/openvpn:v2.4.8-r1
+        name: openvpn-client
+        resources:
+          limits:
+            cpu: 100m
+            memory: 32Mi
+          requests:
+            cpu: 5m
+            memory: 5Mi
+        securityContext:
+          privileged: true
+        volumeMounts:
+        - mountPath: /etc/openvpn/pki/client
+          name: openvpn-client-certificates
+          readOnly: true
+      - args:
+        - -endpoint
+        - https://apiserver-external.cluster-de-test-01.svc.cluster.local./healthz
+        - -insecure
+        - -retries
+        - "100"
+        - -retry-wait
+        - "2"
+        - -timeout
+        - "1"
+        - -command
+        - '{"command":"/usr/local/bin/kube-scheduler","args":["--kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","--authentication-kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","--authorization-kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","--client-ca-file","/etc/kubernetes/pki/ca/ca.crt","--port","0"]}'
+        command:
+        - /http-prober-bin/http-prober
+        image: k8s.gcr.io/kube-scheduler:v1.20.0
+        livenessProbe:
+          failureThreshold: 8
+          httpGet:
+            path: /healthz
+            port: 10259
+            scheme: HTTPS
+          initialDelaySeconds: 15
+          periodSeconds: 10
+          successThreshold: 1
+          timeoutSeconds: 15
+        name: scheduler
+        readinessProbe:
+          failureThreshold: 3
+          httpGet:
+            path: /healthz
+            port: 10259
+            scheme: HTTPS
+          periodSeconds: 10
+          successThreshold: 1
+          timeoutSeconds: 15
+        resources:
+          limits:
+            cpu: "1"
+            memory: 512Mi
+          requests:
+            cpu: 20m
+            memory: 64Mi
+        volumeMounts:
+        - mountPath: /etc/kubernetes/kubeconfig
+          name: scheduler-kubeconfig
+          readOnly: true
+        - mountPath: /etc/kubernetes/pki/ca
+          name: ca
+          readOnly: true
+        - mountPath: /etc/ssl/certs
+          name: ca-certs
+          readOnly: true
+        - mountPath: /usr/share/ca-certificates
+          name: usr-share-ca-certificates
+          readOnly: true
+        - mountPath: /http-prober-bin
+          name: http-prober-bin
+      dnsConfig:
+        nameservers:
+        - 192.0.2.14
+        options:
+        - name: ndots
+          value: "5"
+        searches:
+        - kube-system.svc.cluster.local
+        - svc.cluster.local
+        - cluster.local
+      dnsPolicy: None
+      imagePullSecrets:
+      - name: dockercfg
+      initContainers:
+      - command:
+        - /bin/cp
+        - /usr/local/bin/http-prober
+        - /http-prober-bin/http-prober
+        image: quay.io/kubermatic/http-prober:v0.3.1
+        name: copy-http-prober
+        resources: {}
+        volumeMounts:
+        - mountPath: /http-prober-bin
+          name: http-prober-bin
+      volumes:
+      - name: openvpn-client-certificates
+        secret:
+          secretName: openvpn-client-certificates
+      - name: ca
+        secret:
+          items:
+          - key: ca.crt
+            path: ca.crt
+          secretName: ca
+      - name: scheduler-kubeconfig
+        secret:
+          secretName: scheduler-kubeconfig
+      - hostPath:
+          path: /etc/ssl/certs
+          type: DirectoryOrCreate
+        name: ca-certs
+      - hostPath:
+          path: /usr/share/ca-certificates
+          type: DirectoryOrCreate
+        name: usr-share-ca-certificates
+      - emptyDir: {}
+        name: http-prober-bin
+status: {}

--- a/pkg/resources/test/fixtures/deployment-vsphere-1.20.0-usercluster-controller.yaml
+++ b/pkg/resources/test/fixtures/deployment-vsphere-1.20.0-usercluster-controller.yaml
@@ -1,0 +1,95 @@
+# This file has been generated, DO NOT EDIT.
+
+metadata:
+  creationTimestamp: null
+  labels:
+    app: usercluster-controller
+  name: usercluster-controller
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: usercluster-controller
+  strategy:
+    rollingUpdate:
+      maxSurge: 1
+      maxUnavailable: 1
+    type: RollingUpdate
+  template:
+    metadata:
+      annotations:
+        prometheus.io/path: /metrics
+        prometheus.io/port: "8085"
+        prometheus.io/scrape: "true"
+      creationTimestamp: null
+      labels:
+        app: usercluster-controller
+        cluster: de-test-01
+        internal-admin-kubeconfig-secret-revision: "123456"
+    spec:
+      containers:
+      - args:
+        - -endpoint
+        - https://apiserver-external.cluster-de-test-01.svc.cluster.local./healthz
+        - -insecure
+        - -retries
+        - "100"
+        - -retry-wait
+        - "2"
+        - -timeout
+        - "1"
+        - -command
+        - '{"command":"/usr/local/bin/user-cluster-controller-manager","args":["-kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","-metrics-listen-address","0.0.0.0:8085","-health-listen-address","0.0.0.0:8086","-namespace","$(NAMESPACE)","-cluster-url","https://jh8j81chn.europe-west3-c.dev.kubermatic.io:30000","-dns-cluster-ip","10.240.16.10","-openvpn-server-port","30003","-overwrite-registry","","-openshift=false","-version","1.20.0","-cloud-provider-name","vsphere","-owner-email","","-opa-integration=false","--ipam-controller-network","192.168.1.1/24,192.168.1.1,8.8.8.8","-node-labels","{\"my-label\":\"my-value\"}"]}'
+        command:
+        - /http-prober-bin/http-prober
+        env:
+        - name: NAMESPACE
+          valueFrom:
+            fieldRef:
+              apiVersion: v1
+              fieldPath: metadata.namespace
+        image: quay.io/kubermatic/kubermatic:v0.0.0-test
+        name: usercluster-controller
+        readinessProbe:
+          failureThreshold: 5
+          httpGet:
+            path: /ready
+            port: 8086
+            scheme: HTTP
+          periodSeconds: 5
+          successThreshold: 1
+          timeoutSeconds: 15
+        resources:
+          limits:
+            cpu: 500m
+            memory: 512Mi
+          requests:
+            cpu: 25m
+            memory: 32Mi
+        volumeMounts:
+        - mountPath: /etc/kubernetes/kubeconfig
+          name: internal-admin-kubeconfig
+          readOnly: true
+        - mountPath: /http-prober-bin
+          name: http-prober-bin
+      imagePullSecrets:
+      - name: dockercfg
+      initContainers:
+      - command:
+        - /bin/cp
+        - /usr/local/bin/http-prober
+        - /http-prober-bin/http-prober
+        image: quay.io/kubermatic/http-prober:v0.3.1
+        name: copy-http-prober
+        resources: {}
+        volumeMounts:
+        - mountPath: /http-prober-bin
+          name: http-prober-bin
+      serviceAccountName: kubermatic-usercluster-controller-manager
+      volumes:
+      - name: internal-admin-kubeconfig
+        secret:
+          secretName: internal-admin-kubeconfig
+      - emptyDir: {}
+        name: http-prober-bin
+status: {}

--- a/pkg/resources/test/fixtures/poddisruptionbudget-aws-1.20.0-apiserver.yaml
+++ b/pkg/resources/test/fixtures/poddisruptionbudget-aws-1.20.0-apiserver.yaml
@@ -1,0 +1,14 @@
+# This file has been generated, DO NOT EDIT.
+
+metadata:
+  creationTimestamp: null
+spec:
+  maxUnavailable: 1
+  selector:
+    matchLabels:
+      app: apiserver
+status:
+  currentHealthy: 0
+  desiredHealthy: 0
+  disruptionsAllowed: 0
+  expectedPods: 0

--- a/pkg/resources/test/fixtures/poddisruptionbudget-aws-1.20.0-dns-resolver.yaml
+++ b/pkg/resources/test/fixtures/poddisruptionbudget-aws-1.20.0-dns-resolver.yaml
@@ -1,0 +1,14 @@
+# This file has been generated, DO NOT EDIT.
+
+metadata:
+  creationTimestamp: null
+spec:
+  minAvailable: 1
+  selector:
+    matchLabels:
+      app: dns-resolver
+status:
+  currentHealthy: 0
+  desiredHealthy: 0
+  disruptionsAllowed: 0
+  expectedPods: 0

--- a/pkg/resources/test/fixtures/poddisruptionbudget-aws-1.20.0-etcd.yaml
+++ b/pkg/resources/test/fixtures/poddisruptionbudget-aws-1.20.0-etcd.yaml
@@ -1,0 +1,15 @@
+# This file has been generated, DO NOT EDIT.
+
+metadata:
+  creationTimestamp: null
+spec:
+  minAvailable: 2
+  selector:
+    matchLabels:
+      app: etcd
+      cluster: de-test-01
+status:
+  currentHealthy: 0
+  desiredHealthy: 0
+  disruptionsAllowed: 0
+  expectedPods: 0

--- a/pkg/resources/test/fixtures/poddisruptionbudget-aws-1.20.0-metrics-server.yaml
+++ b/pkg/resources/test/fixtures/poddisruptionbudget-aws-1.20.0-metrics-server.yaml
@@ -1,0 +1,14 @@
+# This file has been generated, DO NOT EDIT.
+
+metadata:
+  creationTimestamp: null
+spec:
+  minAvailable: 1
+  selector:
+    matchLabels:
+      app: metrics-server
+status:
+  currentHealthy: 0
+  desiredHealthy: 0
+  disruptionsAllowed: 0
+  expectedPods: 0

--- a/pkg/resources/test/fixtures/poddisruptionbudget-azure-1.20.0-apiserver.yaml
+++ b/pkg/resources/test/fixtures/poddisruptionbudget-azure-1.20.0-apiserver.yaml
@@ -1,0 +1,14 @@
+# This file has been generated, DO NOT EDIT.
+
+metadata:
+  creationTimestamp: null
+spec:
+  maxUnavailable: 1
+  selector:
+    matchLabels:
+      app: apiserver
+status:
+  currentHealthy: 0
+  desiredHealthy: 0
+  disruptionsAllowed: 0
+  expectedPods: 0

--- a/pkg/resources/test/fixtures/poddisruptionbudget-azure-1.20.0-dns-resolver.yaml
+++ b/pkg/resources/test/fixtures/poddisruptionbudget-azure-1.20.0-dns-resolver.yaml
@@ -1,0 +1,14 @@
+# This file has been generated, DO NOT EDIT.
+
+metadata:
+  creationTimestamp: null
+spec:
+  minAvailable: 1
+  selector:
+    matchLabels:
+      app: dns-resolver
+status:
+  currentHealthy: 0
+  desiredHealthy: 0
+  disruptionsAllowed: 0
+  expectedPods: 0

--- a/pkg/resources/test/fixtures/poddisruptionbudget-azure-1.20.0-etcd.yaml
+++ b/pkg/resources/test/fixtures/poddisruptionbudget-azure-1.20.0-etcd.yaml
@@ -1,0 +1,15 @@
+# This file has been generated, DO NOT EDIT.
+
+metadata:
+  creationTimestamp: null
+spec:
+  minAvailable: 2
+  selector:
+    matchLabels:
+      app: etcd
+      cluster: de-test-01
+status:
+  currentHealthy: 0
+  desiredHealthy: 0
+  disruptionsAllowed: 0
+  expectedPods: 0

--- a/pkg/resources/test/fixtures/poddisruptionbudget-azure-1.20.0-metrics-server.yaml
+++ b/pkg/resources/test/fixtures/poddisruptionbudget-azure-1.20.0-metrics-server.yaml
@@ -1,0 +1,14 @@
+# This file has been generated, DO NOT EDIT.
+
+metadata:
+  creationTimestamp: null
+spec:
+  minAvailable: 1
+  selector:
+    matchLabels:
+      app: metrics-server
+status:
+  currentHealthy: 0
+  desiredHealthy: 0
+  disruptionsAllowed: 0
+  expectedPods: 0

--- a/pkg/resources/test/fixtures/poddisruptionbudget-bringyourown-1.20.0-apiserver.yaml
+++ b/pkg/resources/test/fixtures/poddisruptionbudget-bringyourown-1.20.0-apiserver.yaml
@@ -1,0 +1,14 @@
+# This file has been generated, DO NOT EDIT.
+
+metadata:
+  creationTimestamp: null
+spec:
+  maxUnavailable: 1
+  selector:
+    matchLabels:
+      app: apiserver
+status:
+  currentHealthy: 0
+  desiredHealthy: 0
+  disruptionsAllowed: 0
+  expectedPods: 0

--- a/pkg/resources/test/fixtures/poddisruptionbudget-bringyourown-1.20.0-dns-resolver.yaml
+++ b/pkg/resources/test/fixtures/poddisruptionbudget-bringyourown-1.20.0-dns-resolver.yaml
@@ -1,0 +1,14 @@
+# This file has been generated, DO NOT EDIT.
+
+metadata:
+  creationTimestamp: null
+spec:
+  minAvailable: 1
+  selector:
+    matchLabels:
+      app: dns-resolver
+status:
+  currentHealthy: 0
+  desiredHealthy: 0
+  disruptionsAllowed: 0
+  expectedPods: 0

--- a/pkg/resources/test/fixtures/poddisruptionbudget-bringyourown-1.20.0-etcd.yaml
+++ b/pkg/resources/test/fixtures/poddisruptionbudget-bringyourown-1.20.0-etcd.yaml
@@ -1,0 +1,15 @@
+# This file has been generated, DO NOT EDIT.
+
+metadata:
+  creationTimestamp: null
+spec:
+  minAvailable: 2
+  selector:
+    matchLabels:
+      app: etcd
+      cluster: de-test-01
+status:
+  currentHealthy: 0
+  desiredHealthy: 0
+  disruptionsAllowed: 0
+  expectedPods: 0

--- a/pkg/resources/test/fixtures/poddisruptionbudget-bringyourown-1.20.0-metrics-server.yaml
+++ b/pkg/resources/test/fixtures/poddisruptionbudget-bringyourown-1.20.0-metrics-server.yaml
@@ -1,0 +1,14 @@
+# This file has been generated, DO NOT EDIT.
+
+metadata:
+  creationTimestamp: null
+spec:
+  minAvailable: 1
+  selector:
+    matchLabels:
+      app: metrics-server
+status:
+  currentHealthy: 0
+  desiredHealthy: 0
+  disruptionsAllowed: 0
+  expectedPods: 0

--- a/pkg/resources/test/fixtures/poddisruptionbudget-digitalocean-1.20.0-apiserver.yaml
+++ b/pkg/resources/test/fixtures/poddisruptionbudget-digitalocean-1.20.0-apiserver.yaml
@@ -1,0 +1,14 @@
+# This file has been generated, DO NOT EDIT.
+
+metadata:
+  creationTimestamp: null
+spec:
+  maxUnavailable: 1
+  selector:
+    matchLabels:
+      app: apiserver
+status:
+  currentHealthy: 0
+  desiredHealthy: 0
+  disruptionsAllowed: 0
+  expectedPods: 0

--- a/pkg/resources/test/fixtures/poddisruptionbudget-digitalocean-1.20.0-dns-resolver.yaml
+++ b/pkg/resources/test/fixtures/poddisruptionbudget-digitalocean-1.20.0-dns-resolver.yaml
@@ -1,0 +1,14 @@
+# This file has been generated, DO NOT EDIT.
+
+metadata:
+  creationTimestamp: null
+spec:
+  minAvailable: 1
+  selector:
+    matchLabels:
+      app: dns-resolver
+status:
+  currentHealthy: 0
+  desiredHealthy: 0
+  disruptionsAllowed: 0
+  expectedPods: 0

--- a/pkg/resources/test/fixtures/poddisruptionbudget-digitalocean-1.20.0-etcd.yaml
+++ b/pkg/resources/test/fixtures/poddisruptionbudget-digitalocean-1.20.0-etcd.yaml
@@ -1,0 +1,15 @@
+# This file has been generated, DO NOT EDIT.
+
+metadata:
+  creationTimestamp: null
+spec:
+  minAvailable: 2
+  selector:
+    matchLabels:
+      app: etcd
+      cluster: de-test-01
+status:
+  currentHealthy: 0
+  desiredHealthy: 0
+  disruptionsAllowed: 0
+  expectedPods: 0

--- a/pkg/resources/test/fixtures/poddisruptionbudget-digitalocean-1.20.0-metrics-server.yaml
+++ b/pkg/resources/test/fixtures/poddisruptionbudget-digitalocean-1.20.0-metrics-server.yaml
@@ -1,0 +1,14 @@
+# This file has been generated, DO NOT EDIT.
+
+metadata:
+  creationTimestamp: null
+spec:
+  minAvailable: 1
+  selector:
+    matchLabels:
+      app: metrics-server
+status:
+  currentHealthy: 0
+  desiredHealthy: 0
+  disruptionsAllowed: 0
+  expectedPods: 0

--- a/pkg/resources/test/fixtures/poddisruptionbudget-openstack-1.20.0-apiserver.yaml
+++ b/pkg/resources/test/fixtures/poddisruptionbudget-openstack-1.20.0-apiserver.yaml
@@ -1,0 +1,14 @@
+# This file has been generated, DO NOT EDIT.
+
+metadata:
+  creationTimestamp: null
+spec:
+  maxUnavailable: 1
+  selector:
+    matchLabels:
+      app: apiserver
+status:
+  currentHealthy: 0
+  desiredHealthy: 0
+  disruptionsAllowed: 0
+  expectedPods: 0

--- a/pkg/resources/test/fixtures/poddisruptionbudget-openstack-1.20.0-dns-resolver.yaml
+++ b/pkg/resources/test/fixtures/poddisruptionbudget-openstack-1.20.0-dns-resolver.yaml
@@ -1,0 +1,14 @@
+# This file has been generated, DO NOT EDIT.
+
+metadata:
+  creationTimestamp: null
+spec:
+  minAvailable: 1
+  selector:
+    matchLabels:
+      app: dns-resolver
+status:
+  currentHealthy: 0
+  desiredHealthy: 0
+  disruptionsAllowed: 0
+  expectedPods: 0

--- a/pkg/resources/test/fixtures/poddisruptionbudget-openstack-1.20.0-etcd.yaml
+++ b/pkg/resources/test/fixtures/poddisruptionbudget-openstack-1.20.0-etcd.yaml
@@ -1,0 +1,15 @@
+# This file has been generated, DO NOT EDIT.
+
+metadata:
+  creationTimestamp: null
+spec:
+  minAvailable: 2
+  selector:
+    matchLabels:
+      app: etcd
+      cluster: de-test-01
+status:
+  currentHealthy: 0
+  desiredHealthy: 0
+  disruptionsAllowed: 0
+  expectedPods: 0

--- a/pkg/resources/test/fixtures/poddisruptionbudget-openstack-1.20.0-metrics-server.yaml
+++ b/pkg/resources/test/fixtures/poddisruptionbudget-openstack-1.20.0-metrics-server.yaml
@@ -1,0 +1,14 @@
+# This file has been generated, DO NOT EDIT.
+
+metadata:
+  creationTimestamp: null
+spec:
+  minAvailable: 1
+  selector:
+    matchLabels:
+      app: metrics-server
+status:
+  currentHealthy: 0
+  desiredHealthy: 0
+  disruptionsAllowed: 0
+  expectedPods: 0

--- a/pkg/resources/test/fixtures/poddisruptionbudget-vsphere-1.20.0-apiserver.yaml
+++ b/pkg/resources/test/fixtures/poddisruptionbudget-vsphere-1.20.0-apiserver.yaml
@@ -1,0 +1,14 @@
+# This file has been generated, DO NOT EDIT.
+
+metadata:
+  creationTimestamp: null
+spec:
+  maxUnavailable: 1
+  selector:
+    matchLabels:
+      app: apiserver
+status:
+  currentHealthy: 0
+  desiredHealthy: 0
+  disruptionsAllowed: 0
+  expectedPods: 0

--- a/pkg/resources/test/fixtures/poddisruptionbudget-vsphere-1.20.0-dns-resolver.yaml
+++ b/pkg/resources/test/fixtures/poddisruptionbudget-vsphere-1.20.0-dns-resolver.yaml
@@ -1,0 +1,14 @@
+# This file has been generated, DO NOT EDIT.
+
+metadata:
+  creationTimestamp: null
+spec:
+  minAvailable: 1
+  selector:
+    matchLabels:
+      app: dns-resolver
+status:
+  currentHealthy: 0
+  desiredHealthy: 0
+  disruptionsAllowed: 0
+  expectedPods: 0

--- a/pkg/resources/test/fixtures/poddisruptionbudget-vsphere-1.20.0-etcd.yaml
+++ b/pkg/resources/test/fixtures/poddisruptionbudget-vsphere-1.20.0-etcd.yaml
@@ -1,0 +1,15 @@
+# This file has been generated, DO NOT EDIT.
+
+metadata:
+  creationTimestamp: null
+spec:
+  minAvailable: 2
+  selector:
+    matchLabels:
+      app: etcd
+      cluster: de-test-01
+status:
+  currentHealthy: 0
+  desiredHealthy: 0
+  disruptionsAllowed: 0
+  expectedPods: 0

--- a/pkg/resources/test/fixtures/poddisruptionbudget-vsphere-1.20.0-metrics-server.yaml
+++ b/pkg/resources/test/fixtures/poddisruptionbudget-vsphere-1.20.0-metrics-server.yaml
@@ -1,0 +1,14 @@
+# This file has been generated, DO NOT EDIT.
+
+metadata:
+  creationTimestamp: null
+spec:
+  minAvailable: 1
+  selector:
+    matchLabels:
+      app: metrics-server
+status:
+  currentHealthy: 0
+  desiredHealthy: 0
+  disruptionsAllowed: 0
+  expectedPods: 0

--- a/pkg/resources/test/fixtures/service-aws-1.20.0-apiserver-external.yaml
+++ b/pkg/resources/test/fixtures/service-aws-1.20.0-apiserver-external.yaml
@@ -1,0 +1,17 @@
+# This file has been generated, DO NOT EDIT.
+
+metadata:
+  annotations:
+    nodeport-proxy.k8s.io/expose-namespaced: "true"
+  creationTimestamp: null
+spec:
+  ports:
+  - name: secure
+    port: 443
+    protocol: TCP
+    targetPort: 6443
+  selector:
+    app: apiserver
+  type: NodePort
+status:
+  loadBalancer: {}

--- a/pkg/resources/test/fixtures/service-aws-1.20.0-dns-resolver.yaml
+++ b/pkg/resources/test/fixtures/service-aws-1.20.0-dns-resolver.yaml
@@ -1,0 +1,15 @@
+# This file has been generated, DO NOT EDIT.
+
+metadata:
+  creationTimestamp: null
+  name: dns-resolver
+spec:
+  ports:
+  - name: dns
+    port: 53
+    protocol: UDP
+    targetPort: 53
+  selector:
+    app: dns-resolver
+status:
+  loadBalancer: {}

--- a/pkg/resources/test/fixtures/service-aws-1.20.0-etcd.yaml
+++ b/pkg/resources/test/fixtures/service-aws-1.20.0-etcd.yaml
@@ -1,0 +1,30 @@
+# This file has been generated, DO NOT EDIT.
+
+metadata:
+  annotations:
+    service.alpha.kubernetes.io/tolerate-unready-endpoints: "true"
+  creationTimestamp: null
+  name: etcd
+  ownerReferences:
+  - apiVersion: kubermatic.k8s.io/v1
+    blockOwnerDeletion: true
+    controller: true
+    kind: Cluster
+    name: de-test-01
+    uid: "1234567890"
+spec:
+  clusterIP: None
+  ports:
+  - name: client
+    port: 2379
+    protocol: TCP
+    targetPort: 2379
+  - name: peer
+    port: 2380
+    protocol: TCP
+    targetPort: 2380
+  selector:
+    app: etcd
+    cluster: de-test-01
+status:
+  loadBalancer: {}

--- a/pkg/resources/test/fixtures/service-aws-1.20.0-front-loadbalancer.yaml
+++ b/pkg/resources/test/fixtures/service-aws-1.20.0-front-loadbalancer.yaml
@@ -1,0 +1,15 @@
+# This file has been generated, DO NOT EDIT.
+
+metadata:
+  creationTimestamp: null
+spec:
+  ports:
+  - name: secure
+    port: 443
+    protocol: TCP
+    targetPort: 443
+  selector:
+    app: nodeport-proxy-envoy
+  type: LoadBalancer
+status:
+  loadBalancer: {}

--- a/pkg/resources/test/fixtures/service-aws-1.20.0-machine-controller-webhook.yaml
+++ b/pkg/resources/test/fixtures/service-aws-1.20.0-machine-controller-webhook.yaml
@@ -1,0 +1,17 @@
+# This file has been generated, DO NOT EDIT.
+
+metadata:
+  creationTimestamp: null
+  labels:
+    app: machine-controller-webhook
+  name: machine-controller-webhook
+spec:
+  ports:
+  - port: 443
+    protocol: TCP
+    targetPort: 9876
+  selector:
+    app: machine-controller-webhook
+  type: ClusterIP
+status:
+  loadBalancer: {}

--- a/pkg/resources/test/fixtures/service-aws-1.20.0-metrics-server.yaml
+++ b/pkg/resources/test/fixtures/service-aws-1.20.0-metrics-server.yaml
@@ -1,0 +1,16 @@
+# This file has been generated, DO NOT EDIT.
+
+metadata:
+  creationTimestamp: null
+  labels:
+    app: metrics-server
+  name: metrics-server
+spec:
+  ports:
+  - port: 443
+    protocol: TCP
+    targetPort: 443
+  selector:
+    app: metrics-server
+status:
+  loadBalancer: {}

--- a/pkg/resources/test/fixtures/service-aws-1.20.0-openvpn-server.yaml
+++ b/pkg/resources/test/fixtures/service-aws-1.20.0-openvpn-server.yaml
@@ -1,0 +1,20 @@
+# This file has been generated, DO NOT EDIT.
+
+metadata:
+  annotations:
+    nodeport-proxy.k8s.io/expose-namespaced: "true"
+  creationTimestamp: null
+  labels:
+    app: openvpn-server
+  name: openvpn-server
+spec:
+  ports:
+  - name: secure
+    port: 1194
+    protocol: TCP
+    targetPort: 1194
+  selector:
+    app: openvpn-server
+  type: NodePort
+status:
+  loadBalancer: {}

--- a/pkg/resources/test/fixtures/service-azure-1.20.0-apiserver-external.yaml
+++ b/pkg/resources/test/fixtures/service-azure-1.20.0-apiserver-external.yaml
@@ -1,0 +1,17 @@
+# This file has been generated, DO NOT EDIT.
+
+metadata:
+  annotations:
+    nodeport-proxy.k8s.io/expose-namespaced: "true"
+  creationTimestamp: null
+spec:
+  ports:
+  - name: secure
+    port: 443
+    protocol: TCP
+    targetPort: 6443
+  selector:
+    app: apiserver
+  type: NodePort
+status:
+  loadBalancer: {}

--- a/pkg/resources/test/fixtures/service-azure-1.20.0-dns-resolver.yaml
+++ b/pkg/resources/test/fixtures/service-azure-1.20.0-dns-resolver.yaml
@@ -1,0 +1,15 @@
+# This file has been generated, DO NOT EDIT.
+
+metadata:
+  creationTimestamp: null
+  name: dns-resolver
+spec:
+  ports:
+  - name: dns
+    port: 53
+    protocol: UDP
+    targetPort: 53
+  selector:
+    app: dns-resolver
+status:
+  loadBalancer: {}

--- a/pkg/resources/test/fixtures/service-azure-1.20.0-etcd.yaml
+++ b/pkg/resources/test/fixtures/service-azure-1.20.0-etcd.yaml
@@ -1,0 +1,30 @@
+# This file has been generated, DO NOT EDIT.
+
+metadata:
+  annotations:
+    service.alpha.kubernetes.io/tolerate-unready-endpoints: "true"
+  creationTimestamp: null
+  name: etcd
+  ownerReferences:
+  - apiVersion: kubermatic.k8s.io/v1
+    blockOwnerDeletion: true
+    controller: true
+    kind: Cluster
+    name: de-test-01
+    uid: "1234567890"
+spec:
+  clusterIP: None
+  ports:
+  - name: client
+    port: 2379
+    protocol: TCP
+    targetPort: 2379
+  - name: peer
+    port: 2380
+    protocol: TCP
+    targetPort: 2380
+  selector:
+    app: etcd
+    cluster: de-test-01
+status:
+  loadBalancer: {}

--- a/pkg/resources/test/fixtures/service-azure-1.20.0-front-loadbalancer.yaml
+++ b/pkg/resources/test/fixtures/service-azure-1.20.0-front-loadbalancer.yaml
@@ -1,0 +1,15 @@
+# This file has been generated, DO NOT EDIT.
+
+metadata:
+  creationTimestamp: null
+spec:
+  ports:
+  - name: secure
+    port: 443
+    protocol: TCP
+    targetPort: 443
+  selector:
+    app: nodeport-proxy-envoy
+  type: LoadBalancer
+status:
+  loadBalancer: {}

--- a/pkg/resources/test/fixtures/service-azure-1.20.0-machine-controller-webhook.yaml
+++ b/pkg/resources/test/fixtures/service-azure-1.20.0-machine-controller-webhook.yaml
@@ -1,0 +1,17 @@
+# This file has been generated, DO NOT EDIT.
+
+metadata:
+  creationTimestamp: null
+  labels:
+    app: machine-controller-webhook
+  name: machine-controller-webhook
+spec:
+  ports:
+  - port: 443
+    protocol: TCP
+    targetPort: 9876
+  selector:
+    app: machine-controller-webhook
+  type: ClusterIP
+status:
+  loadBalancer: {}

--- a/pkg/resources/test/fixtures/service-azure-1.20.0-metrics-server.yaml
+++ b/pkg/resources/test/fixtures/service-azure-1.20.0-metrics-server.yaml
@@ -1,0 +1,16 @@
+# This file has been generated, DO NOT EDIT.
+
+metadata:
+  creationTimestamp: null
+  labels:
+    app: metrics-server
+  name: metrics-server
+spec:
+  ports:
+  - port: 443
+    protocol: TCP
+    targetPort: 443
+  selector:
+    app: metrics-server
+status:
+  loadBalancer: {}

--- a/pkg/resources/test/fixtures/service-azure-1.20.0-openvpn-server.yaml
+++ b/pkg/resources/test/fixtures/service-azure-1.20.0-openvpn-server.yaml
@@ -1,0 +1,20 @@
+# This file has been generated, DO NOT EDIT.
+
+metadata:
+  annotations:
+    nodeport-proxy.k8s.io/expose-namespaced: "true"
+  creationTimestamp: null
+  labels:
+    app: openvpn-server
+  name: openvpn-server
+spec:
+  ports:
+  - name: secure
+    port: 1194
+    protocol: TCP
+    targetPort: 1194
+  selector:
+    app: openvpn-server
+  type: NodePort
+status:
+  loadBalancer: {}

--- a/pkg/resources/test/fixtures/service-bringyourown-1.20.0-apiserver-external.yaml
+++ b/pkg/resources/test/fixtures/service-bringyourown-1.20.0-apiserver-external.yaml
@@ -1,0 +1,17 @@
+# This file has been generated, DO NOT EDIT.
+
+metadata:
+  annotations:
+    nodeport-proxy.k8s.io/expose-namespaced: "true"
+  creationTimestamp: null
+spec:
+  ports:
+  - name: secure
+    port: 443
+    protocol: TCP
+    targetPort: 6443
+  selector:
+    app: apiserver
+  type: NodePort
+status:
+  loadBalancer: {}

--- a/pkg/resources/test/fixtures/service-bringyourown-1.20.0-dns-resolver.yaml
+++ b/pkg/resources/test/fixtures/service-bringyourown-1.20.0-dns-resolver.yaml
@@ -1,0 +1,15 @@
+# This file has been generated, DO NOT EDIT.
+
+metadata:
+  creationTimestamp: null
+  name: dns-resolver
+spec:
+  ports:
+  - name: dns
+    port: 53
+    protocol: UDP
+    targetPort: 53
+  selector:
+    app: dns-resolver
+status:
+  loadBalancer: {}

--- a/pkg/resources/test/fixtures/service-bringyourown-1.20.0-etcd.yaml
+++ b/pkg/resources/test/fixtures/service-bringyourown-1.20.0-etcd.yaml
@@ -1,0 +1,30 @@
+# This file has been generated, DO NOT EDIT.
+
+metadata:
+  annotations:
+    service.alpha.kubernetes.io/tolerate-unready-endpoints: "true"
+  creationTimestamp: null
+  name: etcd
+  ownerReferences:
+  - apiVersion: kubermatic.k8s.io/v1
+    blockOwnerDeletion: true
+    controller: true
+    kind: Cluster
+    name: de-test-01
+    uid: "1234567890"
+spec:
+  clusterIP: None
+  ports:
+  - name: client
+    port: 2379
+    protocol: TCP
+    targetPort: 2379
+  - name: peer
+    port: 2380
+    protocol: TCP
+    targetPort: 2380
+  selector:
+    app: etcd
+    cluster: de-test-01
+status:
+  loadBalancer: {}

--- a/pkg/resources/test/fixtures/service-bringyourown-1.20.0-front-loadbalancer.yaml
+++ b/pkg/resources/test/fixtures/service-bringyourown-1.20.0-front-loadbalancer.yaml
@@ -1,0 +1,15 @@
+# This file has been generated, DO NOT EDIT.
+
+metadata:
+  creationTimestamp: null
+spec:
+  ports:
+  - name: secure
+    port: 443
+    protocol: TCP
+    targetPort: 443
+  selector:
+    app: nodeport-proxy-envoy
+  type: LoadBalancer
+status:
+  loadBalancer: {}

--- a/pkg/resources/test/fixtures/service-bringyourown-1.20.0-machine-controller-webhook.yaml
+++ b/pkg/resources/test/fixtures/service-bringyourown-1.20.0-machine-controller-webhook.yaml
@@ -1,0 +1,17 @@
+# This file has been generated, DO NOT EDIT.
+
+metadata:
+  creationTimestamp: null
+  labels:
+    app: machine-controller-webhook
+  name: machine-controller-webhook
+spec:
+  ports:
+  - port: 443
+    protocol: TCP
+    targetPort: 9876
+  selector:
+    app: machine-controller-webhook
+  type: ClusterIP
+status:
+  loadBalancer: {}

--- a/pkg/resources/test/fixtures/service-bringyourown-1.20.0-metrics-server.yaml
+++ b/pkg/resources/test/fixtures/service-bringyourown-1.20.0-metrics-server.yaml
@@ -1,0 +1,16 @@
+# This file has been generated, DO NOT EDIT.
+
+metadata:
+  creationTimestamp: null
+  labels:
+    app: metrics-server
+  name: metrics-server
+spec:
+  ports:
+  - port: 443
+    protocol: TCP
+    targetPort: 443
+  selector:
+    app: metrics-server
+status:
+  loadBalancer: {}

--- a/pkg/resources/test/fixtures/service-bringyourown-1.20.0-openvpn-server.yaml
+++ b/pkg/resources/test/fixtures/service-bringyourown-1.20.0-openvpn-server.yaml
@@ -1,0 +1,20 @@
+# This file has been generated, DO NOT EDIT.
+
+metadata:
+  annotations:
+    nodeport-proxy.k8s.io/expose-namespaced: "true"
+  creationTimestamp: null
+  labels:
+    app: openvpn-server
+  name: openvpn-server
+spec:
+  ports:
+  - name: secure
+    port: 1194
+    protocol: TCP
+    targetPort: 1194
+  selector:
+    app: openvpn-server
+  type: NodePort
+status:
+  loadBalancer: {}

--- a/pkg/resources/test/fixtures/service-digitalocean-1.20.0-apiserver-external.yaml
+++ b/pkg/resources/test/fixtures/service-digitalocean-1.20.0-apiserver-external.yaml
@@ -1,0 +1,17 @@
+# This file has been generated, DO NOT EDIT.
+
+metadata:
+  annotations:
+    nodeport-proxy.k8s.io/expose-namespaced: "true"
+  creationTimestamp: null
+spec:
+  ports:
+  - name: secure
+    port: 443
+    protocol: TCP
+    targetPort: 6443
+  selector:
+    app: apiserver
+  type: NodePort
+status:
+  loadBalancer: {}

--- a/pkg/resources/test/fixtures/service-digitalocean-1.20.0-dns-resolver.yaml
+++ b/pkg/resources/test/fixtures/service-digitalocean-1.20.0-dns-resolver.yaml
@@ -1,0 +1,15 @@
+# This file has been generated, DO NOT EDIT.
+
+metadata:
+  creationTimestamp: null
+  name: dns-resolver
+spec:
+  ports:
+  - name: dns
+    port: 53
+    protocol: UDP
+    targetPort: 53
+  selector:
+    app: dns-resolver
+status:
+  loadBalancer: {}

--- a/pkg/resources/test/fixtures/service-digitalocean-1.20.0-etcd.yaml
+++ b/pkg/resources/test/fixtures/service-digitalocean-1.20.0-etcd.yaml
@@ -1,0 +1,30 @@
+# This file has been generated, DO NOT EDIT.
+
+metadata:
+  annotations:
+    service.alpha.kubernetes.io/tolerate-unready-endpoints: "true"
+  creationTimestamp: null
+  name: etcd
+  ownerReferences:
+  - apiVersion: kubermatic.k8s.io/v1
+    blockOwnerDeletion: true
+    controller: true
+    kind: Cluster
+    name: de-test-01
+    uid: "1234567890"
+spec:
+  clusterIP: None
+  ports:
+  - name: client
+    port: 2379
+    protocol: TCP
+    targetPort: 2379
+  - name: peer
+    port: 2380
+    protocol: TCP
+    targetPort: 2380
+  selector:
+    app: etcd
+    cluster: de-test-01
+status:
+  loadBalancer: {}

--- a/pkg/resources/test/fixtures/service-digitalocean-1.20.0-front-loadbalancer.yaml
+++ b/pkg/resources/test/fixtures/service-digitalocean-1.20.0-front-loadbalancer.yaml
@@ -1,0 +1,15 @@
+# This file has been generated, DO NOT EDIT.
+
+metadata:
+  creationTimestamp: null
+spec:
+  ports:
+  - name: secure
+    port: 443
+    protocol: TCP
+    targetPort: 443
+  selector:
+    app: nodeport-proxy-envoy
+  type: LoadBalancer
+status:
+  loadBalancer: {}

--- a/pkg/resources/test/fixtures/service-digitalocean-1.20.0-machine-controller-webhook.yaml
+++ b/pkg/resources/test/fixtures/service-digitalocean-1.20.0-machine-controller-webhook.yaml
@@ -1,0 +1,17 @@
+# This file has been generated, DO NOT EDIT.
+
+metadata:
+  creationTimestamp: null
+  labels:
+    app: machine-controller-webhook
+  name: machine-controller-webhook
+spec:
+  ports:
+  - port: 443
+    protocol: TCP
+    targetPort: 9876
+  selector:
+    app: machine-controller-webhook
+  type: ClusterIP
+status:
+  loadBalancer: {}

--- a/pkg/resources/test/fixtures/service-digitalocean-1.20.0-metrics-server.yaml
+++ b/pkg/resources/test/fixtures/service-digitalocean-1.20.0-metrics-server.yaml
@@ -1,0 +1,16 @@
+# This file has been generated, DO NOT EDIT.
+
+metadata:
+  creationTimestamp: null
+  labels:
+    app: metrics-server
+  name: metrics-server
+spec:
+  ports:
+  - port: 443
+    protocol: TCP
+    targetPort: 443
+  selector:
+    app: metrics-server
+status:
+  loadBalancer: {}

--- a/pkg/resources/test/fixtures/service-digitalocean-1.20.0-openvpn-server.yaml
+++ b/pkg/resources/test/fixtures/service-digitalocean-1.20.0-openvpn-server.yaml
@@ -1,0 +1,20 @@
+# This file has been generated, DO NOT EDIT.
+
+metadata:
+  annotations:
+    nodeport-proxy.k8s.io/expose-namespaced: "true"
+  creationTimestamp: null
+  labels:
+    app: openvpn-server
+  name: openvpn-server
+spec:
+  ports:
+  - name: secure
+    port: 1194
+    protocol: TCP
+    targetPort: 1194
+  selector:
+    app: openvpn-server
+  type: NodePort
+status:
+  loadBalancer: {}

--- a/pkg/resources/test/fixtures/service-openstack-1.20.0-apiserver-external.yaml
+++ b/pkg/resources/test/fixtures/service-openstack-1.20.0-apiserver-external.yaml
@@ -1,0 +1,17 @@
+# This file has been generated, DO NOT EDIT.
+
+metadata:
+  annotations:
+    nodeport-proxy.k8s.io/expose-namespaced: "true"
+  creationTimestamp: null
+spec:
+  ports:
+  - name: secure
+    port: 443
+    protocol: TCP
+    targetPort: 6443
+  selector:
+    app: apiserver
+  type: NodePort
+status:
+  loadBalancer: {}

--- a/pkg/resources/test/fixtures/service-openstack-1.20.0-dns-resolver.yaml
+++ b/pkg/resources/test/fixtures/service-openstack-1.20.0-dns-resolver.yaml
@@ -1,0 +1,15 @@
+# This file has been generated, DO NOT EDIT.
+
+metadata:
+  creationTimestamp: null
+  name: dns-resolver
+spec:
+  ports:
+  - name: dns
+    port: 53
+    protocol: UDP
+    targetPort: 53
+  selector:
+    app: dns-resolver
+status:
+  loadBalancer: {}

--- a/pkg/resources/test/fixtures/service-openstack-1.20.0-etcd.yaml
+++ b/pkg/resources/test/fixtures/service-openstack-1.20.0-etcd.yaml
@@ -1,0 +1,30 @@
+# This file has been generated, DO NOT EDIT.
+
+metadata:
+  annotations:
+    service.alpha.kubernetes.io/tolerate-unready-endpoints: "true"
+  creationTimestamp: null
+  name: etcd
+  ownerReferences:
+  - apiVersion: kubermatic.k8s.io/v1
+    blockOwnerDeletion: true
+    controller: true
+    kind: Cluster
+    name: de-test-01
+    uid: "1234567890"
+spec:
+  clusterIP: None
+  ports:
+  - name: client
+    port: 2379
+    protocol: TCP
+    targetPort: 2379
+  - name: peer
+    port: 2380
+    protocol: TCP
+    targetPort: 2380
+  selector:
+    app: etcd
+    cluster: de-test-01
+status:
+  loadBalancer: {}

--- a/pkg/resources/test/fixtures/service-openstack-1.20.0-front-loadbalancer.yaml
+++ b/pkg/resources/test/fixtures/service-openstack-1.20.0-front-loadbalancer.yaml
@@ -1,0 +1,15 @@
+# This file has been generated, DO NOT EDIT.
+
+metadata:
+  creationTimestamp: null
+spec:
+  ports:
+  - name: secure
+    port: 443
+    protocol: TCP
+    targetPort: 443
+  selector:
+    app: nodeport-proxy-envoy
+  type: LoadBalancer
+status:
+  loadBalancer: {}

--- a/pkg/resources/test/fixtures/service-openstack-1.20.0-machine-controller-webhook.yaml
+++ b/pkg/resources/test/fixtures/service-openstack-1.20.0-machine-controller-webhook.yaml
@@ -1,0 +1,17 @@
+# This file has been generated, DO NOT EDIT.
+
+metadata:
+  creationTimestamp: null
+  labels:
+    app: machine-controller-webhook
+  name: machine-controller-webhook
+spec:
+  ports:
+  - port: 443
+    protocol: TCP
+    targetPort: 9876
+  selector:
+    app: machine-controller-webhook
+  type: ClusterIP
+status:
+  loadBalancer: {}

--- a/pkg/resources/test/fixtures/service-openstack-1.20.0-metrics-server.yaml
+++ b/pkg/resources/test/fixtures/service-openstack-1.20.0-metrics-server.yaml
@@ -1,0 +1,16 @@
+# This file has been generated, DO NOT EDIT.
+
+metadata:
+  creationTimestamp: null
+  labels:
+    app: metrics-server
+  name: metrics-server
+spec:
+  ports:
+  - port: 443
+    protocol: TCP
+    targetPort: 443
+  selector:
+    app: metrics-server
+status:
+  loadBalancer: {}

--- a/pkg/resources/test/fixtures/service-openstack-1.20.0-openvpn-server.yaml
+++ b/pkg/resources/test/fixtures/service-openstack-1.20.0-openvpn-server.yaml
@@ -1,0 +1,20 @@
+# This file has been generated, DO NOT EDIT.
+
+metadata:
+  annotations:
+    nodeport-proxy.k8s.io/expose-namespaced: "true"
+  creationTimestamp: null
+  labels:
+    app: openvpn-server
+  name: openvpn-server
+spec:
+  ports:
+  - name: secure
+    port: 1194
+    protocol: TCP
+    targetPort: 1194
+  selector:
+    app: openvpn-server
+  type: NodePort
+status:
+  loadBalancer: {}

--- a/pkg/resources/test/fixtures/service-vsphere-1.20.0-apiserver-external.yaml
+++ b/pkg/resources/test/fixtures/service-vsphere-1.20.0-apiserver-external.yaml
@@ -1,0 +1,17 @@
+# This file has been generated, DO NOT EDIT.
+
+metadata:
+  annotations:
+    nodeport-proxy.k8s.io/expose-namespaced: "true"
+  creationTimestamp: null
+spec:
+  ports:
+  - name: secure
+    port: 443
+    protocol: TCP
+    targetPort: 6443
+  selector:
+    app: apiserver
+  type: NodePort
+status:
+  loadBalancer: {}

--- a/pkg/resources/test/fixtures/service-vsphere-1.20.0-dns-resolver.yaml
+++ b/pkg/resources/test/fixtures/service-vsphere-1.20.0-dns-resolver.yaml
@@ -1,0 +1,15 @@
+# This file has been generated, DO NOT EDIT.
+
+metadata:
+  creationTimestamp: null
+  name: dns-resolver
+spec:
+  ports:
+  - name: dns
+    port: 53
+    protocol: UDP
+    targetPort: 53
+  selector:
+    app: dns-resolver
+status:
+  loadBalancer: {}

--- a/pkg/resources/test/fixtures/service-vsphere-1.20.0-etcd.yaml
+++ b/pkg/resources/test/fixtures/service-vsphere-1.20.0-etcd.yaml
@@ -1,0 +1,30 @@
+# This file has been generated, DO NOT EDIT.
+
+metadata:
+  annotations:
+    service.alpha.kubernetes.io/tolerate-unready-endpoints: "true"
+  creationTimestamp: null
+  name: etcd
+  ownerReferences:
+  - apiVersion: kubermatic.k8s.io/v1
+    blockOwnerDeletion: true
+    controller: true
+    kind: Cluster
+    name: de-test-01
+    uid: "1234567890"
+spec:
+  clusterIP: None
+  ports:
+  - name: client
+    port: 2379
+    protocol: TCP
+    targetPort: 2379
+  - name: peer
+    port: 2380
+    protocol: TCP
+    targetPort: 2380
+  selector:
+    app: etcd
+    cluster: de-test-01
+status:
+  loadBalancer: {}

--- a/pkg/resources/test/fixtures/service-vsphere-1.20.0-front-loadbalancer.yaml
+++ b/pkg/resources/test/fixtures/service-vsphere-1.20.0-front-loadbalancer.yaml
@@ -1,0 +1,15 @@
+# This file has been generated, DO NOT EDIT.
+
+metadata:
+  creationTimestamp: null
+spec:
+  ports:
+  - name: secure
+    port: 443
+    protocol: TCP
+    targetPort: 443
+  selector:
+    app: nodeport-proxy-envoy
+  type: LoadBalancer
+status:
+  loadBalancer: {}

--- a/pkg/resources/test/fixtures/service-vsphere-1.20.0-machine-controller-webhook.yaml
+++ b/pkg/resources/test/fixtures/service-vsphere-1.20.0-machine-controller-webhook.yaml
@@ -1,0 +1,17 @@
+# This file has been generated, DO NOT EDIT.
+
+metadata:
+  creationTimestamp: null
+  labels:
+    app: machine-controller-webhook
+  name: machine-controller-webhook
+spec:
+  ports:
+  - port: 443
+    protocol: TCP
+    targetPort: 9876
+  selector:
+    app: machine-controller-webhook
+  type: ClusterIP
+status:
+  loadBalancer: {}

--- a/pkg/resources/test/fixtures/service-vsphere-1.20.0-metrics-server.yaml
+++ b/pkg/resources/test/fixtures/service-vsphere-1.20.0-metrics-server.yaml
@@ -1,0 +1,16 @@
+# This file has been generated, DO NOT EDIT.
+
+metadata:
+  creationTimestamp: null
+  labels:
+    app: metrics-server
+  name: metrics-server
+spec:
+  ports:
+  - port: 443
+    protocol: TCP
+    targetPort: 443
+  selector:
+    app: metrics-server
+status:
+  loadBalancer: {}

--- a/pkg/resources/test/fixtures/service-vsphere-1.20.0-openvpn-server.yaml
+++ b/pkg/resources/test/fixtures/service-vsphere-1.20.0-openvpn-server.yaml
@@ -1,0 +1,20 @@
+# This file has been generated, DO NOT EDIT.
+
+metadata:
+  annotations:
+    nodeport-proxy.k8s.io/expose-namespaced: "true"
+  creationTimestamp: null
+  labels:
+    app: openvpn-server
+  name: openvpn-server
+spec:
+  ports:
+  - name: secure
+    port: 1194
+    protocol: TCP
+    targetPort: 1194
+  selector:
+    app: openvpn-server
+  type: NodePort
+status:
+  loadBalancer: {}

--- a/pkg/resources/test/fixtures/statefulset-aws-1.20.0-etcd.yaml
+++ b/pkg/resources/test/fixtures/statefulset-aws-1.20.0-etcd.yaml
@@ -1,0 +1,192 @@
+# This file has been generated, DO NOT EDIT.
+
+metadata:
+  creationTimestamp: null
+  name: etcd
+spec:
+  podManagementPolicy: Parallel
+  replicas: 3
+  selector:
+    matchLabels:
+      app: etcd
+      cluster: de-test-01
+  serviceName: etcd
+  template:
+    metadata:
+      creationTimestamp: null
+      labels:
+        apiserver-etcd-client-certificate-secret-revision: "123456"
+        app: etcd
+        ca-secret-revision: "123456"
+        cluster: de-test-01
+        etcd-tls-certificate-secret-revision: "123456"
+      name: etcd
+    spec:
+      affinity:
+        podAntiAffinity:
+          preferredDuringSchedulingIgnoredDuringExecution:
+          - podAffinityTerm:
+              labelSelector:
+                matchLabels:
+                  app: etcd
+                  cluster: de-test-01
+              topologyKey: kubernetes.io/hostname
+            weight: 100
+          - podAffinityTerm:
+              labelSelector:
+                matchLabels:
+                  app: etcd
+              topologyKey: kubernetes.io/hostname
+            weight: 10
+      containers:
+      - command:
+        - /bin/sh
+        - -ec
+        - |
+          export MASTER_ENDPOINT="https://etcd-0.etcd.cluster-de-test-01.svc.cluster.local:2379"
+
+          export INITIAL_STATE="new"
+          export INITIAL_CLUSTER="etcd-0=http://etcd-0.etcd.cluster-de-test-01.svc.cluster.local:2380,etcd-1=http://etcd-1.etcd.cluster-de-test-01.svc.cluster.local:2380,etcd-2=http://etcd-2.etcd.cluster-de-test-01.svc.cluster.local:2380"
+
+          echo "initial-state: ${INITIAL_STATE}"
+          echo "initial-cluster: ${INITIAL_CLUSTER}"
+
+          exec /usr/local/bin/etcd \
+              --name=${POD_NAME} \
+              --data-dir="/var/run/etcd/pod_${POD_NAME}/" \
+              --initial-cluster=${INITIAL_CLUSTER} \
+              --initial-cluster-token="de-test-01" \
+              --initial-cluster-state=${INITIAL_STATE} \
+              --advertise-client-urls "https://${POD_NAME}.etcd.cluster-de-test-01.svc.cluster.local:2379,https://${POD_IP}:2379" \
+              --listen-client-urls "https://${POD_IP}:2379,https://127.0.0.1:2379" \
+              --listen-peer-urls "http://${POD_IP}:2380" \
+              --listen-metrics-urls "http://${POD_IP}:2378,http://127.0.0.1:2378" \
+              --initial-advertise-peer-urls "http://${POD_NAME}.etcd.cluster-de-test-01.svc.cluster.local:2380" \
+              --trusted-ca-file /etc/etcd/pki/ca/ca.crt \
+              --client-cert-auth \
+              --cert-file /etc/etcd/pki/tls/etcd-tls.crt \
+              --key-file /etc/etcd/pki/tls/etcd-tls.key \
+              --auto-compaction-retention=8
+        env:
+        - name: POD_NAME
+          valueFrom:
+            fieldRef:
+              apiVersion: v1
+              fieldPath: metadata.name
+        - name: POD_IP
+          valueFrom:
+            fieldRef:
+              apiVersion: v1
+              fieldPath: status.podIP
+        - name: NAMESPACE
+          valueFrom:
+            fieldRef:
+              apiVersion: v1
+              fieldPath: metadata.namespace
+        - name: TOKEN
+          value: de-test-01
+        - name: ETCD_CLUSTER_SIZE
+          value: "3"
+        - name: ENABLE_CORRUPTION_CHECK
+          value: "false"
+        - name: ETCDCTL_API
+          value: "3"
+        - name: ETCDCTL_CACERT
+          value: /etc/etcd/pki/ca/ca.crt
+        - name: ETCDCTL_CERT
+          value: /etc/etcd/pki/client/apiserver-etcd-client.crt
+        - name: ETCDCTL_KEY
+          value: /etc/etcd/pki/client/apiserver-etcd-client.key
+        image: gcr.io/etcd-development/etcd:v3.4.3
+        imagePullPolicy: IfNotPresent
+        livenessProbe:
+          failureThreshold: 3
+          httpGet:
+            path: /health
+            port: 2378
+            scheme: HTTP
+          initialDelaySeconds: 5
+          periodSeconds: 30
+          successThreshold: 1
+          timeoutSeconds: 10
+        name: etcd
+        ports:
+        - containerPort: 2379
+          name: client
+          protocol: TCP
+        - containerPort: 2380
+          name: peer
+          protocol: TCP
+        readinessProbe:
+          exec:
+            command:
+            - /usr/local/bin/etcdctl
+            - --command-timeout
+            - 10s
+            - endpoint
+            - health
+          failureThreshold: 3
+          initialDelaySeconds: 5
+          periodSeconds: 15
+          successThreshold: 1
+          timeoutSeconds: 10
+        resources:
+          limits:
+            cpu: "2"
+            memory: 2Gi
+          requests:
+            cpu: 50m
+            memory: 256Mi
+        volumeMounts:
+        - mountPath: /var/run/etcd
+          name: data
+        - mountPath: /etc/etcd/pki/tls
+          name: etcd-tls-certificate
+        - mountPath: /etc/etcd/pki/ca
+          name: ca
+        - mountPath: /etc/etcd/pki/client
+          name: apiserver-etcd-client-certificate
+          readOnly: true
+        - mountPath: /opt/bin/
+          name: launcher
+      imagePullSecrets:
+      - name: dockercfg
+      serviceAccountName: etcd-launcher
+      volumes:
+      - name: etcd-tls-certificate
+        secret:
+          secretName: etcd-tls-certificate
+      - name: ca
+        secret:
+          items:
+          - key: ca.crt
+            path: ca.crt
+          secretName: ca
+      - name: apiserver-etcd-client-certificate
+        secret:
+          secretName: apiserver-etcd-client-certificate
+      - emptyDir: {}
+        name: launcher
+  updateStrategy:
+    type: RollingUpdate
+  volumeClaimTemplates:
+  - metadata:
+      creationTimestamp: null
+      name: data
+      ownerReferences:
+      - apiVersion: kubermatic.k8s.io/v1
+        blockOwnerDeletion: true
+        controller: true
+        kind: Cluster
+        name: de-test-01
+        uid: "1234567890"
+    spec:
+      accessModes:
+      - ReadWriteOnce
+      resources:
+        requests:
+          storage: 5Gi
+      storageClassName: kubermatic-fast
+    status: {}
+status:
+  replicas: 0

--- a/pkg/resources/test/fixtures/statefulset-aws-1.20.0-prometheus.yaml
+++ b/pkg/resources/test/fixtures/statefulset-aws-1.20.0-prometheus.yaml
@@ -1,0 +1,112 @@
+# This file has been generated, DO NOT EDIT.
+
+metadata:
+  creationTimestamp: null
+  labels:
+    app: prometheus
+    cluster: de-test-01
+  name: prometheus
+  ownerReferences:
+  - apiVersion: kubermatic.k8s.io/v1
+    blockOwnerDeletion: true
+    controller: true
+    kind: Cluster
+    name: de-test-01
+    uid: "1234567890"
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: prometheus
+      cluster: de-test-01
+  serviceName: ""
+  template:
+    metadata:
+      creationTimestamp: null
+      labels:
+        apiserver-etcd-client-certificate-secret-revision: "123456"
+        app: prometheus
+        cluster: de-test-01
+        prometheus-apiserver-certificate-secret-revision: "123456"
+        prometheus-configmap-revision: "123456"
+    spec:
+      containers:
+      - args:
+        - --config.file=/etc/prometheus/config/prometheus.yaml
+        - --storage.tsdb.path=/var/prometheus/data
+        - --storage.tsdb.min-block-duration=15m
+        - --storage.tsdb.max-block-duration=30m
+        - --storage.tsdb.retention.time=1h
+        - --web.enable-lifecycle
+        - --storage.tsdb.no-lockfile
+        - --web.route-prefix=/
+        image: quay.io/prometheus/prometheus:v2.23.0
+        livenessProbe:
+          failureThreshold: 10
+          httpGet:
+            path: /-/healthy
+            port: web
+            scheme: HTTP
+          initialDelaySeconds: 30
+          periodSeconds: 5
+          successThreshold: 1
+          timeoutSeconds: 3
+        name: prometheus
+        ports:
+        - containerPort: 9090
+          name: web
+          protocol: TCP
+        readinessProbe:
+          failureThreshold: 6
+          httpGet:
+            path: /-/ready
+            port: web
+            scheme: HTTP
+          initialDelaySeconds: 5
+          periodSeconds: 5
+          successThreshold: 1
+          timeoutSeconds: 3
+        resources:
+          limits:
+            cpu: 100m
+            memory: 1Gi
+          requests:
+            cpu: 50m
+            memory: 256Mi
+        volumeMounts:
+        - mountPath: /etc/prometheus/config
+          name: config
+          readOnly: true
+        - mountPath: /var/prometheus/data
+          name: data
+        - mountPath: /etc/etcd/pki/client
+          name: apiserver-etcd-client-certificate
+          readOnly: true
+        - mountPath: /etc/kubernetes
+          name: prometheus-apiserver-certificate
+          readOnly: true
+      imagePullSecrets:
+      - name: dockercfg
+      restartPolicy: Always
+      securityContext:
+        fsGroup: 2000
+        runAsNonRoot: true
+        runAsUser: 1000
+      serviceAccountName: prometheus
+      terminationGracePeriodSeconds: 0
+      volumes:
+      - configMap:
+          name: prometheus
+        name: config
+      - emptyDir: {}
+        name: data
+      - name: apiserver-etcd-client-certificate
+        secret:
+          secretName: apiserver-etcd-client-certificate
+      - name: prometheus-apiserver-certificate
+        secret:
+          secretName: prometheus-apiserver-certificate
+  updateStrategy:
+    type: RollingUpdate
+status:
+  replicas: 0

--- a/pkg/resources/test/fixtures/statefulset-azure-1.20.0-etcd.yaml
+++ b/pkg/resources/test/fixtures/statefulset-azure-1.20.0-etcd.yaml
@@ -1,0 +1,192 @@
+# This file has been generated, DO NOT EDIT.
+
+metadata:
+  creationTimestamp: null
+  name: etcd
+spec:
+  podManagementPolicy: Parallel
+  replicas: 3
+  selector:
+    matchLabels:
+      app: etcd
+      cluster: de-test-01
+  serviceName: etcd
+  template:
+    metadata:
+      creationTimestamp: null
+      labels:
+        apiserver-etcd-client-certificate-secret-revision: "123456"
+        app: etcd
+        ca-secret-revision: "123456"
+        cluster: de-test-01
+        etcd-tls-certificate-secret-revision: "123456"
+      name: etcd
+    spec:
+      affinity:
+        podAntiAffinity:
+          preferredDuringSchedulingIgnoredDuringExecution:
+          - podAffinityTerm:
+              labelSelector:
+                matchLabels:
+                  app: etcd
+                  cluster: de-test-01
+              topologyKey: kubernetes.io/hostname
+            weight: 100
+          - podAffinityTerm:
+              labelSelector:
+                matchLabels:
+                  app: etcd
+              topologyKey: kubernetes.io/hostname
+            weight: 10
+      containers:
+      - command:
+        - /bin/sh
+        - -ec
+        - |
+          export MASTER_ENDPOINT="https://etcd-0.etcd.cluster-de-test-01.svc.cluster.local:2379"
+
+          export INITIAL_STATE="new"
+          export INITIAL_CLUSTER="etcd-0=http://etcd-0.etcd.cluster-de-test-01.svc.cluster.local:2380,etcd-1=http://etcd-1.etcd.cluster-de-test-01.svc.cluster.local:2380,etcd-2=http://etcd-2.etcd.cluster-de-test-01.svc.cluster.local:2380"
+
+          echo "initial-state: ${INITIAL_STATE}"
+          echo "initial-cluster: ${INITIAL_CLUSTER}"
+
+          exec /usr/local/bin/etcd \
+              --name=${POD_NAME} \
+              --data-dir="/var/run/etcd/pod_${POD_NAME}/" \
+              --initial-cluster=${INITIAL_CLUSTER} \
+              --initial-cluster-token="de-test-01" \
+              --initial-cluster-state=${INITIAL_STATE} \
+              --advertise-client-urls "https://${POD_NAME}.etcd.cluster-de-test-01.svc.cluster.local:2379,https://${POD_IP}:2379" \
+              --listen-client-urls "https://${POD_IP}:2379,https://127.0.0.1:2379" \
+              --listen-peer-urls "http://${POD_IP}:2380" \
+              --listen-metrics-urls "http://${POD_IP}:2378,http://127.0.0.1:2378" \
+              --initial-advertise-peer-urls "http://${POD_NAME}.etcd.cluster-de-test-01.svc.cluster.local:2380" \
+              --trusted-ca-file /etc/etcd/pki/ca/ca.crt \
+              --client-cert-auth \
+              --cert-file /etc/etcd/pki/tls/etcd-tls.crt \
+              --key-file /etc/etcd/pki/tls/etcd-tls.key \
+              --auto-compaction-retention=8
+        env:
+        - name: POD_NAME
+          valueFrom:
+            fieldRef:
+              apiVersion: v1
+              fieldPath: metadata.name
+        - name: POD_IP
+          valueFrom:
+            fieldRef:
+              apiVersion: v1
+              fieldPath: status.podIP
+        - name: NAMESPACE
+          valueFrom:
+            fieldRef:
+              apiVersion: v1
+              fieldPath: metadata.namespace
+        - name: TOKEN
+          value: de-test-01
+        - name: ETCD_CLUSTER_SIZE
+          value: "3"
+        - name: ENABLE_CORRUPTION_CHECK
+          value: "false"
+        - name: ETCDCTL_API
+          value: "3"
+        - name: ETCDCTL_CACERT
+          value: /etc/etcd/pki/ca/ca.crt
+        - name: ETCDCTL_CERT
+          value: /etc/etcd/pki/client/apiserver-etcd-client.crt
+        - name: ETCDCTL_KEY
+          value: /etc/etcd/pki/client/apiserver-etcd-client.key
+        image: gcr.io/etcd-development/etcd:v3.4.3
+        imagePullPolicy: IfNotPresent
+        livenessProbe:
+          failureThreshold: 3
+          httpGet:
+            path: /health
+            port: 2378
+            scheme: HTTP
+          initialDelaySeconds: 5
+          periodSeconds: 30
+          successThreshold: 1
+          timeoutSeconds: 10
+        name: etcd
+        ports:
+        - containerPort: 2379
+          name: client
+          protocol: TCP
+        - containerPort: 2380
+          name: peer
+          protocol: TCP
+        readinessProbe:
+          exec:
+            command:
+            - /usr/local/bin/etcdctl
+            - --command-timeout
+            - 10s
+            - endpoint
+            - health
+          failureThreshold: 3
+          initialDelaySeconds: 5
+          periodSeconds: 15
+          successThreshold: 1
+          timeoutSeconds: 10
+        resources:
+          limits:
+            cpu: "2"
+            memory: 2Gi
+          requests:
+            cpu: 50m
+            memory: 256Mi
+        volumeMounts:
+        - mountPath: /var/run/etcd
+          name: data
+        - mountPath: /etc/etcd/pki/tls
+          name: etcd-tls-certificate
+        - mountPath: /etc/etcd/pki/ca
+          name: ca
+        - mountPath: /etc/etcd/pki/client
+          name: apiserver-etcd-client-certificate
+          readOnly: true
+        - mountPath: /opt/bin/
+          name: launcher
+      imagePullSecrets:
+      - name: dockercfg
+      serviceAccountName: etcd-launcher
+      volumes:
+      - name: etcd-tls-certificate
+        secret:
+          secretName: etcd-tls-certificate
+      - name: ca
+        secret:
+          items:
+          - key: ca.crt
+            path: ca.crt
+          secretName: ca
+      - name: apiserver-etcd-client-certificate
+        secret:
+          secretName: apiserver-etcd-client-certificate
+      - emptyDir: {}
+        name: launcher
+  updateStrategy:
+    type: RollingUpdate
+  volumeClaimTemplates:
+  - metadata:
+      creationTimestamp: null
+      name: data
+      ownerReferences:
+      - apiVersion: kubermatic.k8s.io/v1
+        blockOwnerDeletion: true
+        controller: true
+        kind: Cluster
+        name: de-test-01
+        uid: "1234567890"
+    spec:
+      accessModes:
+      - ReadWriteOnce
+      resources:
+        requests:
+          storage: 5Gi
+      storageClassName: kubermatic-fast
+    status: {}
+status:
+  replicas: 0

--- a/pkg/resources/test/fixtures/statefulset-azure-1.20.0-prometheus.yaml
+++ b/pkg/resources/test/fixtures/statefulset-azure-1.20.0-prometheus.yaml
@@ -1,0 +1,112 @@
+# This file has been generated, DO NOT EDIT.
+
+metadata:
+  creationTimestamp: null
+  labels:
+    app: prometheus
+    cluster: de-test-01
+  name: prometheus
+  ownerReferences:
+  - apiVersion: kubermatic.k8s.io/v1
+    blockOwnerDeletion: true
+    controller: true
+    kind: Cluster
+    name: de-test-01
+    uid: "1234567890"
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: prometheus
+      cluster: de-test-01
+  serviceName: ""
+  template:
+    metadata:
+      creationTimestamp: null
+      labels:
+        apiserver-etcd-client-certificate-secret-revision: "123456"
+        app: prometheus
+        cluster: de-test-01
+        prometheus-apiserver-certificate-secret-revision: "123456"
+        prometheus-configmap-revision: "123456"
+    spec:
+      containers:
+      - args:
+        - --config.file=/etc/prometheus/config/prometheus.yaml
+        - --storage.tsdb.path=/var/prometheus/data
+        - --storage.tsdb.min-block-duration=15m
+        - --storage.tsdb.max-block-duration=30m
+        - --storage.tsdb.retention.time=1h
+        - --web.enable-lifecycle
+        - --storage.tsdb.no-lockfile
+        - --web.route-prefix=/
+        image: quay.io/prometheus/prometheus:v2.23.0
+        livenessProbe:
+          failureThreshold: 10
+          httpGet:
+            path: /-/healthy
+            port: web
+            scheme: HTTP
+          initialDelaySeconds: 30
+          periodSeconds: 5
+          successThreshold: 1
+          timeoutSeconds: 3
+        name: prometheus
+        ports:
+        - containerPort: 9090
+          name: web
+          protocol: TCP
+        readinessProbe:
+          failureThreshold: 6
+          httpGet:
+            path: /-/ready
+            port: web
+            scheme: HTTP
+          initialDelaySeconds: 5
+          periodSeconds: 5
+          successThreshold: 1
+          timeoutSeconds: 3
+        resources:
+          limits:
+            cpu: 100m
+            memory: 1Gi
+          requests:
+            cpu: 50m
+            memory: 256Mi
+        volumeMounts:
+        - mountPath: /etc/prometheus/config
+          name: config
+          readOnly: true
+        - mountPath: /var/prometheus/data
+          name: data
+        - mountPath: /etc/etcd/pki/client
+          name: apiserver-etcd-client-certificate
+          readOnly: true
+        - mountPath: /etc/kubernetes
+          name: prometheus-apiserver-certificate
+          readOnly: true
+      imagePullSecrets:
+      - name: dockercfg
+      restartPolicy: Always
+      securityContext:
+        fsGroup: 2000
+        runAsNonRoot: true
+        runAsUser: 1000
+      serviceAccountName: prometheus
+      terminationGracePeriodSeconds: 0
+      volumes:
+      - configMap:
+          name: prometheus
+        name: config
+      - emptyDir: {}
+        name: data
+      - name: apiserver-etcd-client-certificate
+        secret:
+          secretName: apiserver-etcd-client-certificate
+      - name: prometheus-apiserver-certificate
+        secret:
+          secretName: prometheus-apiserver-certificate
+  updateStrategy:
+    type: RollingUpdate
+status:
+  replicas: 0

--- a/pkg/resources/test/fixtures/statefulset-bringyourown-1.20.0-etcd.yaml
+++ b/pkg/resources/test/fixtures/statefulset-bringyourown-1.20.0-etcd.yaml
@@ -1,0 +1,192 @@
+# This file has been generated, DO NOT EDIT.
+
+metadata:
+  creationTimestamp: null
+  name: etcd
+spec:
+  podManagementPolicy: Parallel
+  replicas: 3
+  selector:
+    matchLabels:
+      app: etcd
+      cluster: de-test-01
+  serviceName: etcd
+  template:
+    metadata:
+      creationTimestamp: null
+      labels:
+        apiserver-etcd-client-certificate-secret-revision: "123456"
+        app: etcd
+        ca-secret-revision: "123456"
+        cluster: de-test-01
+        etcd-tls-certificate-secret-revision: "123456"
+      name: etcd
+    spec:
+      affinity:
+        podAntiAffinity:
+          preferredDuringSchedulingIgnoredDuringExecution:
+          - podAffinityTerm:
+              labelSelector:
+                matchLabels:
+                  app: etcd
+                  cluster: de-test-01
+              topologyKey: kubernetes.io/hostname
+            weight: 100
+          - podAffinityTerm:
+              labelSelector:
+                matchLabels:
+                  app: etcd
+              topologyKey: kubernetes.io/hostname
+            weight: 10
+      containers:
+      - command:
+        - /bin/sh
+        - -ec
+        - |
+          export MASTER_ENDPOINT="https://etcd-0.etcd.cluster-de-test-01.svc.cluster.local:2379"
+
+          export INITIAL_STATE="new"
+          export INITIAL_CLUSTER="etcd-0=http://etcd-0.etcd.cluster-de-test-01.svc.cluster.local:2380,etcd-1=http://etcd-1.etcd.cluster-de-test-01.svc.cluster.local:2380,etcd-2=http://etcd-2.etcd.cluster-de-test-01.svc.cluster.local:2380"
+
+          echo "initial-state: ${INITIAL_STATE}"
+          echo "initial-cluster: ${INITIAL_CLUSTER}"
+
+          exec /usr/local/bin/etcd \
+              --name=${POD_NAME} \
+              --data-dir="/var/run/etcd/pod_${POD_NAME}/" \
+              --initial-cluster=${INITIAL_CLUSTER} \
+              --initial-cluster-token="de-test-01" \
+              --initial-cluster-state=${INITIAL_STATE} \
+              --advertise-client-urls "https://${POD_NAME}.etcd.cluster-de-test-01.svc.cluster.local:2379,https://${POD_IP}:2379" \
+              --listen-client-urls "https://${POD_IP}:2379,https://127.0.0.1:2379" \
+              --listen-peer-urls "http://${POD_IP}:2380" \
+              --listen-metrics-urls "http://${POD_IP}:2378,http://127.0.0.1:2378" \
+              --initial-advertise-peer-urls "http://${POD_NAME}.etcd.cluster-de-test-01.svc.cluster.local:2380" \
+              --trusted-ca-file /etc/etcd/pki/ca/ca.crt \
+              --client-cert-auth \
+              --cert-file /etc/etcd/pki/tls/etcd-tls.crt \
+              --key-file /etc/etcd/pki/tls/etcd-tls.key \
+              --auto-compaction-retention=8
+        env:
+        - name: POD_NAME
+          valueFrom:
+            fieldRef:
+              apiVersion: v1
+              fieldPath: metadata.name
+        - name: POD_IP
+          valueFrom:
+            fieldRef:
+              apiVersion: v1
+              fieldPath: status.podIP
+        - name: NAMESPACE
+          valueFrom:
+            fieldRef:
+              apiVersion: v1
+              fieldPath: metadata.namespace
+        - name: TOKEN
+          value: de-test-01
+        - name: ETCD_CLUSTER_SIZE
+          value: "3"
+        - name: ENABLE_CORRUPTION_CHECK
+          value: "false"
+        - name: ETCDCTL_API
+          value: "3"
+        - name: ETCDCTL_CACERT
+          value: /etc/etcd/pki/ca/ca.crt
+        - name: ETCDCTL_CERT
+          value: /etc/etcd/pki/client/apiserver-etcd-client.crt
+        - name: ETCDCTL_KEY
+          value: /etc/etcd/pki/client/apiserver-etcd-client.key
+        image: gcr.io/etcd-development/etcd:v3.4.3
+        imagePullPolicy: IfNotPresent
+        livenessProbe:
+          failureThreshold: 3
+          httpGet:
+            path: /health
+            port: 2378
+            scheme: HTTP
+          initialDelaySeconds: 5
+          periodSeconds: 30
+          successThreshold: 1
+          timeoutSeconds: 10
+        name: etcd
+        ports:
+        - containerPort: 2379
+          name: client
+          protocol: TCP
+        - containerPort: 2380
+          name: peer
+          protocol: TCP
+        readinessProbe:
+          exec:
+            command:
+            - /usr/local/bin/etcdctl
+            - --command-timeout
+            - 10s
+            - endpoint
+            - health
+          failureThreshold: 3
+          initialDelaySeconds: 5
+          periodSeconds: 15
+          successThreshold: 1
+          timeoutSeconds: 10
+        resources:
+          limits:
+            cpu: "2"
+            memory: 2Gi
+          requests:
+            cpu: 50m
+            memory: 256Mi
+        volumeMounts:
+        - mountPath: /var/run/etcd
+          name: data
+        - mountPath: /etc/etcd/pki/tls
+          name: etcd-tls-certificate
+        - mountPath: /etc/etcd/pki/ca
+          name: ca
+        - mountPath: /etc/etcd/pki/client
+          name: apiserver-etcd-client-certificate
+          readOnly: true
+        - mountPath: /opt/bin/
+          name: launcher
+      imagePullSecrets:
+      - name: dockercfg
+      serviceAccountName: etcd-launcher
+      volumes:
+      - name: etcd-tls-certificate
+        secret:
+          secretName: etcd-tls-certificate
+      - name: ca
+        secret:
+          items:
+          - key: ca.crt
+            path: ca.crt
+          secretName: ca
+      - name: apiserver-etcd-client-certificate
+        secret:
+          secretName: apiserver-etcd-client-certificate
+      - emptyDir: {}
+        name: launcher
+  updateStrategy:
+    type: RollingUpdate
+  volumeClaimTemplates:
+  - metadata:
+      creationTimestamp: null
+      name: data
+      ownerReferences:
+      - apiVersion: kubermatic.k8s.io/v1
+        blockOwnerDeletion: true
+        controller: true
+        kind: Cluster
+        name: de-test-01
+        uid: "1234567890"
+    spec:
+      accessModes:
+      - ReadWriteOnce
+      resources:
+        requests:
+          storage: 5Gi
+      storageClassName: kubermatic-fast
+    status: {}
+status:
+  replicas: 0

--- a/pkg/resources/test/fixtures/statefulset-bringyourown-1.20.0-prometheus.yaml
+++ b/pkg/resources/test/fixtures/statefulset-bringyourown-1.20.0-prometheus.yaml
@@ -1,0 +1,112 @@
+# This file has been generated, DO NOT EDIT.
+
+metadata:
+  creationTimestamp: null
+  labels:
+    app: prometheus
+    cluster: de-test-01
+  name: prometheus
+  ownerReferences:
+  - apiVersion: kubermatic.k8s.io/v1
+    blockOwnerDeletion: true
+    controller: true
+    kind: Cluster
+    name: de-test-01
+    uid: "1234567890"
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: prometheus
+      cluster: de-test-01
+  serviceName: ""
+  template:
+    metadata:
+      creationTimestamp: null
+      labels:
+        apiserver-etcd-client-certificate-secret-revision: "123456"
+        app: prometheus
+        cluster: de-test-01
+        prometheus-apiserver-certificate-secret-revision: "123456"
+        prometheus-configmap-revision: "123456"
+    spec:
+      containers:
+      - args:
+        - --config.file=/etc/prometheus/config/prometheus.yaml
+        - --storage.tsdb.path=/var/prometheus/data
+        - --storage.tsdb.min-block-duration=15m
+        - --storage.tsdb.max-block-duration=30m
+        - --storage.tsdb.retention.time=1h
+        - --web.enable-lifecycle
+        - --storage.tsdb.no-lockfile
+        - --web.route-prefix=/
+        image: quay.io/prometheus/prometheus:v2.23.0
+        livenessProbe:
+          failureThreshold: 10
+          httpGet:
+            path: /-/healthy
+            port: web
+            scheme: HTTP
+          initialDelaySeconds: 30
+          periodSeconds: 5
+          successThreshold: 1
+          timeoutSeconds: 3
+        name: prometheus
+        ports:
+        - containerPort: 9090
+          name: web
+          protocol: TCP
+        readinessProbe:
+          failureThreshold: 6
+          httpGet:
+            path: /-/ready
+            port: web
+            scheme: HTTP
+          initialDelaySeconds: 5
+          periodSeconds: 5
+          successThreshold: 1
+          timeoutSeconds: 3
+        resources:
+          limits:
+            cpu: 100m
+            memory: 1Gi
+          requests:
+            cpu: 50m
+            memory: 256Mi
+        volumeMounts:
+        - mountPath: /etc/prometheus/config
+          name: config
+          readOnly: true
+        - mountPath: /var/prometheus/data
+          name: data
+        - mountPath: /etc/etcd/pki/client
+          name: apiserver-etcd-client-certificate
+          readOnly: true
+        - mountPath: /etc/kubernetes
+          name: prometheus-apiserver-certificate
+          readOnly: true
+      imagePullSecrets:
+      - name: dockercfg
+      restartPolicy: Always
+      securityContext:
+        fsGroup: 2000
+        runAsNonRoot: true
+        runAsUser: 1000
+      serviceAccountName: prometheus
+      terminationGracePeriodSeconds: 0
+      volumes:
+      - configMap:
+          name: prometheus
+        name: config
+      - emptyDir: {}
+        name: data
+      - name: apiserver-etcd-client-certificate
+        secret:
+          secretName: apiserver-etcd-client-certificate
+      - name: prometheus-apiserver-certificate
+        secret:
+          secretName: prometheus-apiserver-certificate
+  updateStrategy:
+    type: RollingUpdate
+status:
+  replicas: 0

--- a/pkg/resources/test/fixtures/statefulset-digitalocean-1.20.0-etcd.yaml
+++ b/pkg/resources/test/fixtures/statefulset-digitalocean-1.20.0-etcd.yaml
@@ -1,0 +1,192 @@
+# This file has been generated, DO NOT EDIT.
+
+metadata:
+  creationTimestamp: null
+  name: etcd
+spec:
+  podManagementPolicy: Parallel
+  replicas: 3
+  selector:
+    matchLabels:
+      app: etcd
+      cluster: de-test-01
+  serviceName: etcd
+  template:
+    metadata:
+      creationTimestamp: null
+      labels:
+        apiserver-etcd-client-certificate-secret-revision: "123456"
+        app: etcd
+        ca-secret-revision: "123456"
+        cluster: de-test-01
+        etcd-tls-certificate-secret-revision: "123456"
+      name: etcd
+    spec:
+      affinity:
+        podAntiAffinity:
+          preferredDuringSchedulingIgnoredDuringExecution:
+          - podAffinityTerm:
+              labelSelector:
+                matchLabels:
+                  app: etcd
+                  cluster: de-test-01
+              topologyKey: kubernetes.io/hostname
+            weight: 100
+          - podAffinityTerm:
+              labelSelector:
+                matchLabels:
+                  app: etcd
+              topologyKey: kubernetes.io/hostname
+            weight: 10
+      containers:
+      - command:
+        - /bin/sh
+        - -ec
+        - |
+          export MASTER_ENDPOINT="https://etcd-0.etcd.cluster-de-test-01.svc.cluster.local:2379"
+
+          export INITIAL_STATE="new"
+          export INITIAL_CLUSTER="etcd-0=http://etcd-0.etcd.cluster-de-test-01.svc.cluster.local:2380,etcd-1=http://etcd-1.etcd.cluster-de-test-01.svc.cluster.local:2380,etcd-2=http://etcd-2.etcd.cluster-de-test-01.svc.cluster.local:2380"
+
+          echo "initial-state: ${INITIAL_STATE}"
+          echo "initial-cluster: ${INITIAL_CLUSTER}"
+
+          exec /usr/local/bin/etcd \
+              --name=${POD_NAME} \
+              --data-dir="/var/run/etcd/pod_${POD_NAME}/" \
+              --initial-cluster=${INITIAL_CLUSTER} \
+              --initial-cluster-token="de-test-01" \
+              --initial-cluster-state=${INITIAL_STATE} \
+              --advertise-client-urls "https://${POD_NAME}.etcd.cluster-de-test-01.svc.cluster.local:2379,https://${POD_IP}:2379" \
+              --listen-client-urls "https://${POD_IP}:2379,https://127.0.0.1:2379" \
+              --listen-peer-urls "http://${POD_IP}:2380" \
+              --listen-metrics-urls "http://${POD_IP}:2378,http://127.0.0.1:2378" \
+              --initial-advertise-peer-urls "http://${POD_NAME}.etcd.cluster-de-test-01.svc.cluster.local:2380" \
+              --trusted-ca-file /etc/etcd/pki/ca/ca.crt \
+              --client-cert-auth \
+              --cert-file /etc/etcd/pki/tls/etcd-tls.crt \
+              --key-file /etc/etcd/pki/tls/etcd-tls.key \
+              --auto-compaction-retention=8
+        env:
+        - name: POD_NAME
+          valueFrom:
+            fieldRef:
+              apiVersion: v1
+              fieldPath: metadata.name
+        - name: POD_IP
+          valueFrom:
+            fieldRef:
+              apiVersion: v1
+              fieldPath: status.podIP
+        - name: NAMESPACE
+          valueFrom:
+            fieldRef:
+              apiVersion: v1
+              fieldPath: metadata.namespace
+        - name: TOKEN
+          value: de-test-01
+        - name: ETCD_CLUSTER_SIZE
+          value: "3"
+        - name: ENABLE_CORRUPTION_CHECK
+          value: "false"
+        - name: ETCDCTL_API
+          value: "3"
+        - name: ETCDCTL_CACERT
+          value: /etc/etcd/pki/ca/ca.crt
+        - name: ETCDCTL_CERT
+          value: /etc/etcd/pki/client/apiserver-etcd-client.crt
+        - name: ETCDCTL_KEY
+          value: /etc/etcd/pki/client/apiserver-etcd-client.key
+        image: gcr.io/etcd-development/etcd:v3.4.3
+        imagePullPolicy: IfNotPresent
+        livenessProbe:
+          failureThreshold: 3
+          httpGet:
+            path: /health
+            port: 2378
+            scheme: HTTP
+          initialDelaySeconds: 5
+          periodSeconds: 30
+          successThreshold: 1
+          timeoutSeconds: 10
+        name: etcd
+        ports:
+        - containerPort: 2379
+          name: client
+          protocol: TCP
+        - containerPort: 2380
+          name: peer
+          protocol: TCP
+        readinessProbe:
+          exec:
+            command:
+            - /usr/local/bin/etcdctl
+            - --command-timeout
+            - 10s
+            - endpoint
+            - health
+          failureThreshold: 3
+          initialDelaySeconds: 5
+          periodSeconds: 15
+          successThreshold: 1
+          timeoutSeconds: 10
+        resources:
+          limits:
+            cpu: "2"
+            memory: 2Gi
+          requests:
+            cpu: 50m
+            memory: 256Mi
+        volumeMounts:
+        - mountPath: /var/run/etcd
+          name: data
+        - mountPath: /etc/etcd/pki/tls
+          name: etcd-tls-certificate
+        - mountPath: /etc/etcd/pki/ca
+          name: ca
+        - mountPath: /etc/etcd/pki/client
+          name: apiserver-etcd-client-certificate
+          readOnly: true
+        - mountPath: /opt/bin/
+          name: launcher
+      imagePullSecrets:
+      - name: dockercfg
+      serviceAccountName: etcd-launcher
+      volumes:
+      - name: etcd-tls-certificate
+        secret:
+          secretName: etcd-tls-certificate
+      - name: ca
+        secret:
+          items:
+          - key: ca.crt
+            path: ca.crt
+          secretName: ca
+      - name: apiserver-etcd-client-certificate
+        secret:
+          secretName: apiserver-etcd-client-certificate
+      - emptyDir: {}
+        name: launcher
+  updateStrategy:
+    type: RollingUpdate
+  volumeClaimTemplates:
+  - metadata:
+      creationTimestamp: null
+      name: data
+      ownerReferences:
+      - apiVersion: kubermatic.k8s.io/v1
+        blockOwnerDeletion: true
+        controller: true
+        kind: Cluster
+        name: de-test-01
+        uid: "1234567890"
+    spec:
+      accessModes:
+      - ReadWriteOnce
+      resources:
+        requests:
+          storage: 5Gi
+      storageClassName: kubermatic-fast
+    status: {}
+status:
+  replicas: 0

--- a/pkg/resources/test/fixtures/statefulset-digitalocean-1.20.0-prometheus.yaml
+++ b/pkg/resources/test/fixtures/statefulset-digitalocean-1.20.0-prometheus.yaml
@@ -1,0 +1,112 @@
+# This file has been generated, DO NOT EDIT.
+
+metadata:
+  creationTimestamp: null
+  labels:
+    app: prometheus
+    cluster: de-test-01
+  name: prometheus
+  ownerReferences:
+  - apiVersion: kubermatic.k8s.io/v1
+    blockOwnerDeletion: true
+    controller: true
+    kind: Cluster
+    name: de-test-01
+    uid: "1234567890"
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: prometheus
+      cluster: de-test-01
+  serviceName: ""
+  template:
+    metadata:
+      creationTimestamp: null
+      labels:
+        apiserver-etcd-client-certificate-secret-revision: "123456"
+        app: prometheus
+        cluster: de-test-01
+        prometheus-apiserver-certificate-secret-revision: "123456"
+        prometheus-configmap-revision: "123456"
+    spec:
+      containers:
+      - args:
+        - --config.file=/etc/prometheus/config/prometheus.yaml
+        - --storage.tsdb.path=/var/prometheus/data
+        - --storage.tsdb.min-block-duration=15m
+        - --storage.tsdb.max-block-duration=30m
+        - --storage.tsdb.retention.time=1h
+        - --web.enable-lifecycle
+        - --storage.tsdb.no-lockfile
+        - --web.route-prefix=/
+        image: quay.io/prometheus/prometheus:v2.23.0
+        livenessProbe:
+          failureThreshold: 10
+          httpGet:
+            path: /-/healthy
+            port: web
+            scheme: HTTP
+          initialDelaySeconds: 30
+          periodSeconds: 5
+          successThreshold: 1
+          timeoutSeconds: 3
+        name: prometheus
+        ports:
+        - containerPort: 9090
+          name: web
+          protocol: TCP
+        readinessProbe:
+          failureThreshold: 6
+          httpGet:
+            path: /-/ready
+            port: web
+            scheme: HTTP
+          initialDelaySeconds: 5
+          periodSeconds: 5
+          successThreshold: 1
+          timeoutSeconds: 3
+        resources:
+          limits:
+            cpu: 100m
+            memory: 1Gi
+          requests:
+            cpu: 50m
+            memory: 256Mi
+        volumeMounts:
+        - mountPath: /etc/prometheus/config
+          name: config
+          readOnly: true
+        - mountPath: /var/prometheus/data
+          name: data
+        - mountPath: /etc/etcd/pki/client
+          name: apiserver-etcd-client-certificate
+          readOnly: true
+        - mountPath: /etc/kubernetes
+          name: prometheus-apiserver-certificate
+          readOnly: true
+      imagePullSecrets:
+      - name: dockercfg
+      restartPolicy: Always
+      securityContext:
+        fsGroup: 2000
+        runAsNonRoot: true
+        runAsUser: 1000
+      serviceAccountName: prometheus
+      terminationGracePeriodSeconds: 0
+      volumes:
+      - configMap:
+          name: prometheus
+        name: config
+      - emptyDir: {}
+        name: data
+      - name: apiserver-etcd-client-certificate
+        secret:
+          secretName: apiserver-etcd-client-certificate
+      - name: prometheus-apiserver-certificate
+        secret:
+          secretName: prometheus-apiserver-certificate
+  updateStrategy:
+    type: RollingUpdate
+status:
+  replicas: 0

--- a/pkg/resources/test/fixtures/statefulset-openstack-1.20.0-etcd.yaml
+++ b/pkg/resources/test/fixtures/statefulset-openstack-1.20.0-etcd.yaml
@@ -1,0 +1,192 @@
+# This file has been generated, DO NOT EDIT.
+
+metadata:
+  creationTimestamp: null
+  name: etcd
+spec:
+  podManagementPolicy: Parallel
+  replicas: 3
+  selector:
+    matchLabels:
+      app: etcd
+      cluster: de-test-01
+  serviceName: etcd
+  template:
+    metadata:
+      creationTimestamp: null
+      labels:
+        apiserver-etcd-client-certificate-secret-revision: "123456"
+        app: etcd
+        ca-secret-revision: "123456"
+        cluster: de-test-01
+        etcd-tls-certificate-secret-revision: "123456"
+      name: etcd
+    spec:
+      affinity:
+        podAntiAffinity:
+          preferredDuringSchedulingIgnoredDuringExecution:
+          - podAffinityTerm:
+              labelSelector:
+                matchLabels:
+                  app: etcd
+                  cluster: de-test-01
+              topologyKey: kubernetes.io/hostname
+            weight: 100
+          - podAffinityTerm:
+              labelSelector:
+                matchLabels:
+                  app: etcd
+              topologyKey: kubernetes.io/hostname
+            weight: 10
+      containers:
+      - command:
+        - /bin/sh
+        - -ec
+        - |
+          export MASTER_ENDPOINT="https://etcd-0.etcd.cluster-de-test-01.svc.cluster.local:2379"
+
+          export INITIAL_STATE="new"
+          export INITIAL_CLUSTER="etcd-0=http://etcd-0.etcd.cluster-de-test-01.svc.cluster.local:2380,etcd-1=http://etcd-1.etcd.cluster-de-test-01.svc.cluster.local:2380,etcd-2=http://etcd-2.etcd.cluster-de-test-01.svc.cluster.local:2380"
+
+          echo "initial-state: ${INITIAL_STATE}"
+          echo "initial-cluster: ${INITIAL_CLUSTER}"
+
+          exec /usr/local/bin/etcd \
+              --name=${POD_NAME} \
+              --data-dir="/var/run/etcd/pod_${POD_NAME}/" \
+              --initial-cluster=${INITIAL_CLUSTER} \
+              --initial-cluster-token="de-test-01" \
+              --initial-cluster-state=${INITIAL_STATE} \
+              --advertise-client-urls "https://${POD_NAME}.etcd.cluster-de-test-01.svc.cluster.local:2379,https://${POD_IP}:2379" \
+              --listen-client-urls "https://${POD_IP}:2379,https://127.0.0.1:2379" \
+              --listen-peer-urls "http://${POD_IP}:2380" \
+              --listen-metrics-urls "http://${POD_IP}:2378,http://127.0.0.1:2378" \
+              --initial-advertise-peer-urls "http://${POD_NAME}.etcd.cluster-de-test-01.svc.cluster.local:2380" \
+              --trusted-ca-file /etc/etcd/pki/ca/ca.crt \
+              --client-cert-auth \
+              --cert-file /etc/etcd/pki/tls/etcd-tls.crt \
+              --key-file /etc/etcd/pki/tls/etcd-tls.key \
+              --auto-compaction-retention=8
+        env:
+        - name: POD_NAME
+          valueFrom:
+            fieldRef:
+              apiVersion: v1
+              fieldPath: metadata.name
+        - name: POD_IP
+          valueFrom:
+            fieldRef:
+              apiVersion: v1
+              fieldPath: status.podIP
+        - name: NAMESPACE
+          valueFrom:
+            fieldRef:
+              apiVersion: v1
+              fieldPath: metadata.namespace
+        - name: TOKEN
+          value: de-test-01
+        - name: ETCD_CLUSTER_SIZE
+          value: "3"
+        - name: ENABLE_CORRUPTION_CHECK
+          value: "false"
+        - name: ETCDCTL_API
+          value: "3"
+        - name: ETCDCTL_CACERT
+          value: /etc/etcd/pki/ca/ca.crt
+        - name: ETCDCTL_CERT
+          value: /etc/etcd/pki/client/apiserver-etcd-client.crt
+        - name: ETCDCTL_KEY
+          value: /etc/etcd/pki/client/apiserver-etcd-client.key
+        image: gcr.io/etcd-development/etcd:v3.4.3
+        imagePullPolicy: IfNotPresent
+        livenessProbe:
+          failureThreshold: 3
+          httpGet:
+            path: /health
+            port: 2378
+            scheme: HTTP
+          initialDelaySeconds: 5
+          periodSeconds: 30
+          successThreshold: 1
+          timeoutSeconds: 10
+        name: etcd
+        ports:
+        - containerPort: 2379
+          name: client
+          protocol: TCP
+        - containerPort: 2380
+          name: peer
+          protocol: TCP
+        readinessProbe:
+          exec:
+            command:
+            - /usr/local/bin/etcdctl
+            - --command-timeout
+            - 10s
+            - endpoint
+            - health
+          failureThreshold: 3
+          initialDelaySeconds: 5
+          periodSeconds: 15
+          successThreshold: 1
+          timeoutSeconds: 10
+        resources:
+          limits:
+            cpu: "2"
+            memory: 2Gi
+          requests:
+            cpu: 50m
+            memory: 256Mi
+        volumeMounts:
+        - mountPath: /var/run/etcd
+          name: data
+        - mountPath: /etc/etcd/pki/tls
+          name: etcd-tls-certificate
+        - mountPath: /etc/etcd/pki/ca
+          name: ca
+        - mountPath: /etc/etcd/pki/client
+          name: apiserver-etcd-client-certificate
+          readOnly: true
+        - mountPath: /opt/bin/
+          name: launcher
+      imagePullSecrets:
+      - name: dockercfg
+      serviceAccountName: etcd-launcher
+      volumes:
+      - name: etcd-tls-certificate
+        secret:
+          secretName: etcd-tls-certificate
+      - name: ca
+        secret:
+          items:
+          - key: ca.crt
+            path: ca.crt
+          secretName: ca
+      - name: apiserver-etcd-client-certificate
+        secret:
+          secretName: apiserver-etcd-client-certificate
+      - emptyDir: {}
+        name: launcher
+  updateStrategy:
+    type: RollingUpdate
+  volumeClaimTemplates:
+  - metadata:
+      creationTimestamp: null
+      name: data
+      ownerReferences:
+      - apiVersion: kubermatic.k8s.io/v1
+        blockOwnerDeletion: true
+        controller: true
+        kind: Cluster
+        name: de-test-01
+        uid: "1234567890"
+    spec:
+      accessModes:
+      - ReadWriteOnce
+      resources:
+        requests:
+          storage: 5Gi
+      storageClassName: kubermatic-fast
+    status: {}
+status:
+  replicas: 0

--- a/pkg/resources/test/fixtures/statefulset-openstack-1.20.0-prometheus.yaml
+++ b/pkg/resources/test/fixtures/statefulset-openstack-1.20.0-prometheus.yaml
@@ -1,0 +1,112 @@
+# This file has been generated, DO NOT EDIT.
+
+metadata:
+  creationTimestamp: null
+  labels:
+    app: prometheus
+    cluster: de-test-01
+  name: prometheus
+  ownerReferences:
+  - apiVersion: kubermatic.k8s.io/v1
+    blockOwnerDeletion: true
+    controller: true
+    kind: Cluster
+    name: de-test-01
+    uid: "1234567890"
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: prometheus
+      cluster: de-test-01
+  serviceName: ""
+  template:
+    metadata:
+      creationTimestamp: null
+      labels:
+        apiserver-etcd-client-certificate-secret-revision: "123456"
+        app: prometheus
+        cluster: de-test-01
+        prometheus-apiserver-certificate-secret-revision: "123456"
+        prometheus-configmap-revision: "123456"
+    spec:
+      containers:
+      - args:
+        - --config.file=/etc/prometheus/config/prometheus.yaml
+        - --storage.tsdb.path=/var/prometheus/data
+        - --storage.tsdb.min-block-duration=15m
+        - --storage.tsdb.max-block-duration=30m
+        - --storage.tsdb.retention.time=1h
+        - --web.enable-lifecycle
+        - --storage.tsdb.no-lockfile
+        - --web.route-prefix=/
+        image: quay.io/prometheus/prometheus:v2.23.0
+        livenessProbe:
+          failureThreshold: 10
+          httpGet:
+            path: /-/healthy
+            port: web
+            scheme: HTTP
+          initialDelaySeconds: 30
+          periodSeconds: 5
+          successThreshold: 1
+          timeoutSeconds: 3
+        name: prometheus
+        ports:
+        - containerPort: 9090
+          name: web
+          protocol: TCP
+        readinessProbe:
+          failureThreshold: 6
+          httpGet:
+            path: /-/ready
+            port: web
+            scheme: HTTP
+          initialDelaySeconds: 5
+          periodSeconds: 5
+          successThreshold: 1
+          timeoutSeconds: 3
+        resources:
+          limits:
+            cpu: 100m
+            memory: 1Gi
+          requests:
+            cpu: 50m
+            memory: 256Mi
+        volumeMounts:
+        - mountPath: /etc/prometheus/config
+          name: config
+          readOnly: true
+        - mountPath: /var/prometheus/data
+          name: data
+        - mountPath: /etc/etcd/pki/client
+          name: apiserver-etcd-client-certificate
+          readOnly: true
+        - mountPath: /etc/kubernetes
+          name: prometheus-apiserver-certificate
+          readOnly: true
+      imagePullSecrets:
+      - name: dockercfg
+      restartPolicy: Always
+      securityContext:
+        fsGroup: 2000
+        runAsNonRoot: true
+        runAsUser: 1000
+      serviceAccountName: prometheus
+      terminationGracePeriodSeconds: 0
+      volumes:
+      - configMap:
+          name: prometheus
+        name: config
+      - emptyDir: {}
+        name: data
+      - name: apiserver-etcd-client-certificate
+        secret:
+          secretName: apiserver-etcd-client-certificate
+      - name: prometheus-apiserver-certificate
+        secret:
+          secretName: prometheus-apiserver-certificate
+  updateStrategy:
+    type: RollingUpdate
+status:
+  replicas: 0

--- a/pkg/resources/test/fixtures/statefulset-vsphere-1.20.0-etcd.yaml
+++ b/pkg/resources/test/fixtures/statefulset-vsphere-1.20.0-etcd.yaml
@@ -1,0 +1,192 @@
+# This file has been generated, DO NOT EDIT.
+
+metadata:
+  creationTimestamp: null
+  name: etcd
+spec:
+  podManagementPolicy: Parallel
+  replicas: 3
+  selector:
+    matchLabels:
+      app: etcd
+      cluster: de-test-01
+  serviceName: etcd
+  template:
+    metadata:
+      creationTimestamp: null
+      labels:
+        apiserver-etcd-client-certificate-secret-revision: "123456"
+        app: etcd
+        ca-secret-revision: "123456"
+        cluster: de-test-01
+        etcd-tls-certificate-secret-revision: "123456"
+      name: etcd
+    spec:
+      affinity:
+        podAntiAffinity:
+          preferredDuringSchedulingIgnoredDuringExecution:
+          - podAffinityTerm:
+              labelSelector:
+                matchLabels:
+                  app: etcd
+                  cluster: de-test-01
+              topologyKey: kubernetes.io/hostname
+            weight: 100
+          - podAffinityTerm:
+              labelSelector:
+                matchLabels:
+                  app: etcd
+              topologyKey: kubernetes.io/hostname
+            weight: 10
+      containers:
+      - command:
+        - /bin/sh
+        - -ec
+        - |
+          export MASTER_ENDPOINT="https://etcd-0.etcd.cluster-de-test-01.svc.cluster.local:2379"
+
+          export INITIAL_STATE="new"
+          export INITIAL_CLUSTER="etcd-0=http://etcd-0.etcd.cluster-de-test-01.svc.cluster.local:2380,etcd-1=http://etcd-1.etcd.cluster-de-test-01.svc.cluster.local:2380,etcd-2=http://etcd-2.etcd.cluster-de-test-01.svc.cluster.local:2380"
+
+          echo "initial-state: ${INITIAL_STATE}"
+          echo "initial-cluster: ${INITIAL_CLUSTER}"
+
+          exec /usr/local/bin/etcd \
+              --name=${POD_NAME} \
+              --data-dir="/var/run/etcd/pod_${POD_NAME}/" \
+              --initial-cluster=${INITIAL_CLUSTER} \
+              --initial-cluster-token="de-test-01" \
+              --initial-cluster-state=${INITIAL_STATE} \
+              --advertise-client-urls "https://${POD_NAME}.etcd.cluster-de-test-01.svc.cluster.local:2379,https://${POD_IP}:2379" \
+              --listen-client-urls "https://${POD_IP}:2379,https://127.0.0.1:2379" \
+              --listen-peer-urls "http://${POD_IP}:2380" \
+              --listen-metrics-urls "http://${POD_IP}:2378,http://127.0.0.1:2378" \
+              --initial-advertise-peer-urls "http://${POD_NAME}.etcd.cluster-de-test-01.svc.cluster.local:2380" \
+              --trusted-ca-file /etc/etcd/pki/ca/ca.crt \
+              --client-cert-auth \
+              --cert-file /etc/etcd/pki/tls/etcd-tls.crt \
+              --key-file /etc/etcd/pki/tls/etcd-tls.key \
+              --auto-compaction-retention=8
+        env:
+        - name: POD_NAME
+          valueFrom:
+            fieldRef:
+              apiVersion: v1
+              fieldPath: metadata.name
+        - name: POD_IP
+          valueFrom:
+            fieldRef:
+              apiVersion: v1
+              fieldPath: status.podIP
+        - name: NAMESPACE
+          valueFrom:
+            fieldRef:
+              apiVersion: v1
+              fieldPath: metadata.namespace
+        - name: TOKEN
+          value: de-test-01
+        - name: ETCD_CLUSTER_SIZE
+          value: "3"
+        - name: ENABLE_CORRUPTION_CHECK
+          value: "false"
+        - name: ETCDCTL_API
+          value: "3"
+        - name: ETCDCTL_CACERT
+          value: /etc/etcd/pki/ca/ca.crt
+        - name: ETCDCTL_CERT
+          value: /etc/etcd/pki/client/apiserver-etcd-client.crt
+        - name: ETCDCTL_KEY
+          value: /etc/etcd/pki/client/apiserver-etcd-client.key
+        image: gcr.io/etcd-development/etcd:v3.4.3
+        imagePullPolicy: IfNotPresent
+        livenessProbe:
+          failureThreshold: 3
+          httpGet:
+            path: /health
+            port: 2378
+            scheme: HTTP
+          initialDelaySeconds: 5
+          periodSeconds: 30
+          successThreshold: 1
+          timeoutSeconds: 10
+        name: etcd
+        ports:
+        - containerPort: 2379
+          name: client
+          protocol: TCP
+        - containerPort: 2380
+          name: peer
+          protocol: TCP
+        readinessProbe:
+          exec:
+            command:
+            - /usr/local/bin/etcdctl
+            - --command-timeout
+            - 10s
+            - endpoint
+            - health
+          failureThreshold: 3
+          initialDelaySeconds: 5
+          periodSeconds: 15
+          successThreshold: 1
+          timeoutSeconds: 10
+        resources:
+          limits:
+            cpu: "2"
+            memory: 2Gi
+          requests:
+            cpu: 50m
+            memory: 256Mi
+        volumeMounts:
+        - mountPath: /var/run/etcd
+          name: data
+        - mountPath: /etc/etcd/pki/tls
+          name: etcd-tls-certificate
+        - mountPath: /etc/etcd/pki/ca
+          name: ca
+        - mountPath: /etc/etcd/pki/client
+          name: apiserver-etcd-client-certificate
+          readOnly: true
+        - mountPath: /opt/bin/
+          name: launcher
+      imagePullSecrets:
+      - name: dockercfg
+      serviceAccountName: etcd-launcher
+      volumes:
+      - name: etcd-tls-certificate
+        secret:
+          secretName: etcd-tls-certificate
+      - name: ca
+        secret:
+          items:
+          - key: ca.crt
+            path: ca.crt
+          secretName: ca
+      - name: apiserver-etcd-client-certificate
+        secret:
+          secretName: apiserver-etcd-client-certificate
+      - emptyDir: {}
+        name: launcher
+  updateStrategy:
+    type: RollingUpdate
+  volumeClaimTemplates:
+  - metadata:
+      creationTimestamp: null
+      name: data
+      ownerReferences:
+      - apiVersion: kubermatic.k8s.io/v1
+        blockOwnerDeletion: true
+        controller: true
+        kind: Cluster
+        name: de-test-01
+        uid: "1234567890"
+    spec:
+      accessModes:
+      - ReadWriteOnce
+      resources:
+        requests:
+          storage: 5Gi
+      storageClassName: kubermatic-fast
+    status: {}
+status:
+  replicas: 0

--- a/pkg/resources/test/fixtures/statefulset-vsphere-1.20.0-prometheus.yaml
+++ b/pkg/resources/test/fixtures/statefulset-vsphere-1.20.0-prometheus.yaml
@@ -1,0 +1,112 @@
+# This file has been generated, DO NOT EDIT.
+
+metadata:
+  creationTimestamp: null
+  labels:
+    app: prometheus
+    cluster: de-test-01
+  name: prometheus
+  ownerReferences:
+  - apiVersion: kubermatic.k8s.io/v1
+    blockOwnerDeletion: true
+    controller: true
+    kind: Cluster
+    name: de-test-01
+    uid: "1234567890"
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: prometheus
+      cluster: de-test-01
+  serviceName: ""
+  template:
+    metadata:
+      creationTimestamp: null
+      labels:
+        apiserver-etcd-client-certificate-secret-revision: "123456"
+        app: prometheus
+        cluster: de-test-01
+        prometheus-apiserver-certificate-secret-revision: "123456"
+        prometheus-configmap-revision: "123456"
+    spec:
+      containers:
+      - args:
+        - --config.file=/etc/prometheus/config/prometheus.yaml
+        - --storage.tsdb.path=/var/prometheus/data
+        - --storage.tsdb.min-block-duration=15m
+        - --storage.tsdb.max-block-duration=30m
+        - --storage.tsdb.retention.time=1h
+        - --web.enable-lifecycle
+        - --storage.tsdb.no-lockfile
+        - --web.route-prefix=/
+        image: quay.io/prometheus/prometheus:v2.23.0
+        livenessProbe:
+          failureThreshold: 10
+          httpGet:
+            path: /-/healthy
+            port: web
+            scheme: HTTP
+          initialDelaySeconds: 30
+          periodSeconds: 5
+          successThreshold: 1
+          timeoutSeconds: 3
+        name: prometheus
+        ports:
+        - containerPort: 9090
+          name: web
+          protocol: TCP
+        readinessProbe:
+          failureThreshold: 6
+          httpGet:
+            path: /-/ready
+            port: web
+            scheme: HTTP
+          initialDelaySeconds: 5
+          periodSeconds: 5
+          successThreshold: 1
+          timeoutSeconds: 3
+        resources:
+          limits:
+            cpu: 100m
+            memory: 1Gi
+          requests:
+            cpu: 50m
+            memory: 256Mi
+        volumeMounts:
+        - mountPath: /etc/prometheus/config
+          name: config
+          readOnly: true
+        - mountPath: /var/prometheus/data
+          name: data
+        - mountPath: /etc/etcd/pki/client
+          name: apiserver-etcd-client-certificate
+          readOnly: true
+        - mountPath: /etc/kubernetes
+          name: prometheus-apiserver-certificate
+          readOnly: true
+      imagePullSecrets:
+      - name: dockercfg
+      restartPolicy: Always
+      securityContext:
+        fsGroup: 2000
+        runAsNonRoot: true
+        runAsUser: 1000
+      serviceAccountName: prometheus
+      terminationGracePeriodSeconds: 0
+      volumes:
+      - configMap:
+          name: prometheus
+        name: config
+      - emptyDir: {}
+        name: data
+      - name: apiserver-etcd-client-certificate
+        secret:
+          secretName: apiserver-etcd-client-certificate
+      - name: prometheus-apiserver-certificate
+        secret:
+          secretName: prometheus-apiserver-certificate
+  updateStrategy:
+    type: RollingUpdate
+status:
+  replicas: 0

--- a/pkg/resources/test/load_files_test.go
+++ b/pkg/resources/test/load_files_test.go
@@ -111,6 +111,9 @@ func TestLoadFiles(t *testing.T) {
 		{
 			Version: semver.MustParse("1.19.0"),
 		},
+		{
+			Version: semver.MustParse("1.20.0"),
+		},
 	}
 
 	clouds := map[string]kubermaticv1.CloudSpec{
@@ -251,6 +254,7 @@ func TestLoadFiles(t *testing.T) {
 						IP:           "35.198.93.90",
 						AdminToken:   "6hzr76.u8txpkk4vhgmtgdp",
 						InternalName: "apiserver-external.cluster-de-test-01.svc.cluster.local.",
+						URL:          "https://jh8j81chn.europe-west3-c.dev.kubermatic.io:30000",
 						Port:         30000,
 					},
 					Status: kubermaticv1.ClusterStatus{


### PR DESCRIPTION
**What this PR does / why we need it**:
This adds support for Kubernetes 1.20 and makes 1.19 the default for new user clusters. Our Azure tests are defunct at the moment, the test failure is (probably) unrelated to Kubernetes 1.20. Likewise, the CSI stuff for Openstack is not supported in 1.20 anymore, so the tests can't pass. Handling Openstack compat should be done in a different PR.

1.19 has not been bumped to the most recent version because of two reasons:

* 1.19.4 has bugs in the conformance test, see https://github.com/kubernetes/kubernetes/issues/96577, https://github.com/kubernetes/kubernetes/issues/86418
* poseidon is not publishing kubelet Docker images for 1.19.4+

**Does this PR introduce a user-facing change?**:
```release-note
Add Kubernetes 1.20
```
