### PR TITLE
Add externalTrafficPolicy variable to nginx-ingress-controller chart

### DIFF
--- a/charts/nginx-ingress-controller/Chart.yaml
+++ b/charts/nginx-ingress-controller/Chart.yaml
@@ -14,7 +14,7 @@
 
 apiVersion: v1
 name: nginx-ingress-controller
-version: 1.1.7
+version: 1.1.8
 appVersion: 0.34.1
 description: nginx-ingress-controller
 keywords:

--- a/charts/nginx-ingress-controller/templates/service.yaml
+++ b/charts/nginx-ingress-controller/templates/service.yaml
@@ -37,4 +37,5 @@ spec:
     protocol: TCP
   selector:
     app: ingress-nginx
+  externalTrafficPolicy: '{{ .Values.nginx.service.externalTrafficPolicy }}'
 {{ end }}

--- a/charts/nginx-ingress-controller/values.yaml
+++ b/charts/nginx-ingress-controller/values.yaml
@@ -57,3 +57,8 @@ nginx:
   # By default, while using host network, name resolution uses the host's DNS. If you wish nginx-controller
   # to keep resolving names inside the k8s network, use ClusterFirstWithHostNet.
   dnsPolicy: ClusterFirst
+  service:
+    # externalTrafficPolicy denotes if this Service desires to route external traffic to node-local or
+    # cluster-wide endpoints. Available values: "Local" and "Cluster".
+    # "Local" preserves the client source IP, and "Cluster" doesn't.
+    externalTrafficPolicy: ""


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR makes the `externalTrafficPolicy` of nginx-ingress-controller service configurable.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Documentation**:
<!-- Add links to the related documentation changes related to this pull request. E.g. the link to the kubermatic/docs pull request. -->

**Does this PR introduce a user-facing change?**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If  no release note is required, just write "NONE".
-->
```release-note
NONE
```
