### PR TITLE
[release/v2.15] allow to disable creation of certificates for IAP deployments (#6119) 

### DIFF
--- a/charts/iap/Chart.yaml
+++ b/charts/iap/Chart.yaml
@@ -14,8 +14,8 @@
 
 apiVersion: v1
 name: iap
-version: 2.0.1
-appVersion: v6.0.0
+version: 3.1.0
+appVersion: v6.1.1
 description: A Helm chart to install OAuth2-Proxy as an identity-aware proxy.
 keywords:
 - kubermatic

--- a/charts/iap/templates/certificates.yaml
+++ b/charts/iap/templates/certificates.yaml
@@ -12,6 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+{{ if .Values.iap.certIssuer.name }}
 {{ range .Values.iap.deployments }}
 ---
 apiVersion: cert-manager.io/v1alpha2
@@ -25,4 +26,5 @@ spec:
     kind: {{ $.Values.iap.certIssuer.kind }}
   dnsNames:
   - {{ .ingress.host | trim }}
+{{ end -}}
 {{ end -}}

--- a/charts/iap/templates/deployments.yaml
+++ b/charts/iap/templates/deployments.yaml
@@ -42,6 +42,9 @@ spec:
         imagePullPolicy: {{ $.Values.iap.image.pullPolicy }}
         args:
         - --provider=oidc
+        {{- if $.Values.iap.customProviderCA }}
+        - --provider-ca-file=/etc/ssl/certs/{{ $.Values.iap.customProviderCA.secretKey }}
+        {{- end }}
         - --oidc-issuer-url={{ $.Values.iap.oidc_issuer_url }}
         - --http-address=0.0.0.0:{{ $.Values.iap.port }}
         - --upstream=http://{{ .upstream_service }}:{{ .upstream_port }}
@@ -76,6 +79,10 @@ spec:
         volumeMounts:
         - name: config
           mountPath: /config
+        {{- if $.Values.iap.customProviderCA }}
+        - name: ca
+          mountPath: /etc/ssl/certs
+        {{- end }}
       volumes:
       - name: config
         configMap:
@@ -83,6 +90,14 @@ spec:
           items:
           - key: config.yaml
             path: config.yaml
+      {{- if $.Values.iap.customProviderCA }}
+      - name: ca
+        secret:
+          secretName: {{ $.Values.iap.customProviderCA.secretName }}
+          items:
+          - key: {{ $.Values.iap.customProviderCA.secretKey }}
+            path: {{ $.Values.iap.customProviderCA.secretKey }}
+      {{- end }}
       securityContext:
         fsGroup: 65534
         runAsNonRoot: true

--- a/charts/iap/values.yaml
+++ b/charts/iap/values.yaml
@@ -15,7 +15,7 @@
 iap:
   image:
     repository: quay.io/oauth2-proxy/oauth2-proxy
-    tag: v6.0.0
+    tag: v6.1.1
     pullPolicy: IfNotPresent
 
   oidc_issuer_url: https://kubermatic.tld/dex
@@ -106,10 +106,19 @@ iap:
     #     annotations:
     #       ingress.kubernetes.io/upstream-hash-by: "ip_hash" ## needed for prometheus federations
 
-  # the cert-manager Issuer (or ClusterIssuer) responsible for managing the certificates
+  # the cert-manager Issuer (or ClusterIssuer) responsible for managing the certificates;
+  # set this to an empty value to disable creating Certificate resources; in this case you need
+  # to manually provide the appropriate certificates
   certIssuer:
     name: letsencrypt-prod
     kind: ClusterIssuer
+
+  # provides secret name at iap namespace for secret for a ca.crt file; this is required if
+  # the OIDC provider (by default: Dex) uses a custom CA, because the oauth-proxy needs to
+  # validate the user tokens with the OIDC provider.
+  #customProviderCA:
+  #    secretName: ca-cert
+  #    secretKey: ca.crt
 
   resources:
     requests:


### PR DESCRIPTION
**What this PR does / why we need it**:
This backports the last remaining piece for the custom CA handling in the KKP stack.

**Does this PR introduce a user-facing change?**:
```release-note
Allow to disable creation of certificates for IAP deployments
```
