### PR TITLE
remove anexia from the kube-controller-manager cloud providers

### DIFF
--- a/pkg/resources/data.go
+++ b/pkg/resources/data.go
@@ -347,8 +347,6 @@ func GetKubernetesCloudProviderName(cluster *kubermaticv1.Cluster) string {
 			return "external"
 		}
 		return "openstack"
-	case cluster.Spec.Cloud.Anexia != nil:
-		return "anexia"
 	default:
 		return ""
 	}


### PR DESCRIPTION
**What this PR does / why we need it**:
Removing anexia from the cloud providers list the kube-controller-manager fails. Anexia is not supported as a legacy cloud provider: https://github.com/kubernetes/kubernetes/tree/ac996a37f65a8f11640808a883e9522832ed364f/staging/src/k8s.io/legacy-cloud-providers

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:
Make sure that the controller manager for anexia user clusters is running and not crashing.

```release-note
Support Anexia cloud provider in KKP
```
