### PR TITLE
fix installer not being able to test certificates

### DIFF
--- a/cmd/kubermatic-installer/cmd_deploy.go
+++ b/cmd/kubermatic-installer/cmd_deploy.go
@@ -35,6 +35,7 @@ import (
 	"k8c.io/kubermatic/v2/pkg/resources"
 	"k8c.io/kubermatic/v2/pkg/util/edition"
 
+	certmanagerv1alpha2 "github.com/jetstack/cert-manager/pkg/apis/certmanager/v1alpha2"
 	apiextensionsv1beta1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1beta1"
 	"k8s.io/apimachinery/pkg/util/wait"
 	ctrlruntimeconfig "sigs.k8s.io/controller-runtime/pkg/client/config"
@@ -216,6 +217,10 @@ func DeployAction(logger *logrus.Logger) cli.ActionFunc {
 		}
 
 		if err := operatorv1alpha1.AddToScheme(mgr.GetScheme()); err != nil {
+			return fmt.Errorf("failed to add scheme: %v", err)
+		}
+
+		if err := certmanagerv1alpha2.AddToScheme(mgr.GetScheme()); err != nil {
 			return fmt.Errorf("failed to add scheme: %v", err)
 		}
 


### PR DESCRIPTION
**What this PR does / why we need it**:
When making the cert-manager optional, we accidentally broke the test cert *if* the user installs cert-manager. This PR fixes that mistake.

**Does this PR introduce a user-facing change?**:
```release-note
Fix installer not being able to probe for Certificate support
```
