### PR TITLE
Fix cluster_info type label

### DIFF
--- a/pkg/collectors/cluster.go
+++ b/pkg/collectors/cluster.go
@@ -139,7 +139,7 @@ func (cc *ClusterCollector) clusterLabels(cluster *kubermaticv1.Cluster) ([]stri
 	}
 
 	clusterType := "kubernetes"
-	if cluster.Spec.Openshift != nil {
+	if cluster.IsOpenshift() {
 		clusterType = "openshift"
 	}
 


### PR DESCRIPTION
**What this PR does / why we need it**:
All clusters were seemingly Openshift clusters.

**Which issue(s) this PR fixes**:
Fixes #6120

**Does this PR introduce a user-facing change?**:
```release-note
Fix Prometheus cluster_info metric having the wrong `type` label
```
