### PR TITLE
Add support for openstack instance check period/timeout variables

### DIFF
--- a/cmd/kubermatic-api/swagger.json
+++ b/cmd/kubermatic-api/swagger.json
@@ -10116,7 +10116,7 @@
           "x-go-name": "AssignPublicIP"
         },
         "availabilityZone": {
-          "description": "Availiability zone in which to place the node. It is coupled with the subnet to which the node will belong.",
+          "description": "Availability zone in which to place the node. It is coupled with the subnet to which the node will belong.",
           "type": "string",
           "x-go-name": "AvailabilityZone"
         },
@@ -13810,6 +13810,16 @@
           "description": "image to use",
           "type": "string",
           "x-go-name": "Image"
+        },
+        "instanceReadyCheckPeriod": {
+          "description": "Period of time to check for instance ready status",
+          "type": "string",
+          "x-go-name": "InstanceReadyCheckPeriod"
+        },
+        "instanceReadyCheckTimeout": {
+          "description": "Max time to wait for the instance to be ready",
+          "type": "string",
+          "x-go-name": "InstanceReadyCheckTimeout"
         },
         "tags": {
           "description": "Additional metadata to set",

--- a/pkg/api/v1/types.go
+++ b/pkg/api/v1/types.go
@@ -1177,7 +1177,7 @@ type OpenstackNodeSpec struct {
 	AvailabilityZone string `json:"availabilityZone"`
 	// Period of time to check for instance ready status
 	// required: false
-	InstanceReadyCheckPeriod  string `json:"instanceReadyCheckPeriod"`
+	InstanceReadyCheckPeriod string `json:"instanceReadyCheckPeriod"`
 	// Max time to wait for the instance to be ready
 	// required: false
 	InstanceReadyCheckTimeout string `json:"instanceReadyCheckTimeout"`

--- a/pkg/api/v1/types.go
+++ b/pkg/api/v1/types.go
@@ -23,7 +23,6 @@ import (
 
 	"github.com/kubermatic/machine-controller/pkg/apis/cluster/v1alpha1"
 	"github.com/kubermatic/machine-controller/pkg/userdata/flatcar"
-
 	"k8c.io/kubermatic/v2/pkg/controller/master-controller-manager/rbac"
 	kubermaticv1 "k8c.io/kubermatic/v2/pkg/crd/kubermatic/v1"
 	ksemver "k8c.io/kubermatic/v2/pkg/semver"

--- a/pkg/api/v1/types.go
+++ b/pkg/api/v1/types.go
@@ -23,6 +23,7 @@ import (
 
 	"github.com/kubermatic/machine-controller/pkg/apis/cluster/v1alpha1"
 	"github.com/kubermatic/machine-controller/pkg/userdata/flatcar"
+
 	"k8c.io/kubermatic/v2/pkg/controller/master-controller-manager/rbac"
 	kubermaticv1 "k8c.io/kubermatic/v2/pkg/crd/kubermatic/v1"
 	ksemver "k8c.io/kubermatic/v2/pkg/semver"
@@ -1174,6 +1175,12 @@ type OpenstackNodeSpec struct {
 	// if not set, the default AZ from the Datacenter spec will be used
 	// required: false
 	AvailabilityZone string `json:"availabilityZone"`
+	// Period of time to check for instance ready status
+	// required: false
+	InstanceReadyCheckPeriod  string `json:"instanceReadyCheckPeriod"`
+	// Max time to wait for the instance to be ready
+	// required: false
+	InstanceReadyCheckTimeout string `json:"instanceReadyCheckTimeout"`
 }
 
 // AWSNodeSpec aws specific node settings
@@ -1192,7 +1199,7 @@ type AWSNodeSpec struct {
 	AMI string `json:"ami"`
 	// additional instance tags
 	Tags map[string]string `json:"tags"`
-	// Availiability zone in which to place the node. It is coupled with the subnet to which the node will belong.
+	// Availability zone in which to place the node. It is coupled with the subnet to which the node will belong.
 	AvailabilityZone string `json:"availabilityZone"`
 	// The VPC subnet to which the node shall be connected.
 	SubnetID string `json:"subnetID"`

--- a/pkg/machine/convert.go
+++ b/pkg/machine/convert.go
@@ -38,7 +38,6 @@ import (
 	"github.com/kubermatic/machine-controller/pkg/userdata/rhel"
 	"github.com/kubermatic/machine-controller/pkg/userdata/sles"
 	"github.com/kubermatic/machine-controller/pkg/userdata/ubuntu"
-
 	apiv1 "k8c.io/kubermatic/v2/pkg/api/v1"
 
 	"k8s.io/apimachinery/pkg/util/json"

--- a/pkg/machine/convert.go
+++ b/pkg/machine/convert.go
@@ -38,6 +38,7 @@ import (
 	"github.com/kubermatic/machine-controller/pkg/userdata/rhel"
 	"github.com/kubermatic/machine-controller/pkg/userdata/sles"
 	"github.com/kubermatic/machine-controller/pkg/userdata/ubuntu"
+
 	apiv1 "k8c.io/kubermatic/v2/pkg/api/v1"
 
 	"k8s.io/apimachinery/pkg/util/json"
@@ -177,11 +178,11 @@ func GetAPIV2NodeCloudSpec(machineSpec clusterv1alpha1.MachineSpec) (*apiv1.Node
 			return nil, fmt.Errorf("failed to parse openstack config: %v", err)
 		}
 		cloudSpec.Openstack = &apiv1.OpenstackNodeSpec{
-			Flavor:           config.Flavor.Value,
-			Image:            config.Image.Value,
-			Tags:             config.Tags,
-			AvailabilityZone: config.AvailabilityZone.Value,
-			InstanceReadyCheckPeriod: config.InstanceReadyCheckPeriod.Value,
+			Flavor:                    config.Flavor.Value,
+			Image:                     config.Image.Value,
+			Tags:                      config.Tags,
+			AvailabilityZone:          config.AvailabilityZone.Value,
+			InstanceReadyCheckPeriod:  config.InstanceReadyCheckPeriod.Value,
 			InstanceReadyCheckTimeout: config.InstanceReadyCheckTimeout.Value,
 		}
 		cloudSpec.Openstack.UseFloatingIP = config.FloatingIPPool.Value != ""

--- a/pkg/machine/convert.go
+++ b/pkg/machine/convert.go
@@ -181,6 +181,8 @@ func GetAPIV2NodeCloudSpec(machineSpec clusterv1alpha1.MachineSpec) (*apiv1.Node
 			Image:            config.Image.Value,
 			Tags:             config.Tags,
 			AvailabilityZone: config.AvailabilityZone.Value,
+			InstanceReadyCheckPeriod: config.InstanceReadyCheckPeriod.Value,
+			InstanceReadyCheckTimeout: config.InstanceReadyCheckTimeout.Value,
 		}
 		cloudSpec.Openstack.UseFloatingIP = config.FloatingIPPool.Value != ""
 		if config.RootDiskSizeGB != nil && *config.RootDiskSizeGB > 0 {

--- a/pkg/resources/machine/common.go
+++ b/pkg/resources/machine/common.go
@@ -40,6 +40,7 @@ import (
 	"github.com/kubermatic/machine-controller/pkg/userdata/rhel"
 	"github.com/kubermatic/machine-controller/pkg/userdata/sles"
 	"github.com/kubermatic/machine-controller/pkg/userdata/ubuntu"
+
 	apiv1 "k8c.io/kubermatic/v2/pkg/api/v1"
 	kubermaticv1 "k8c.io/kubermatic/v2/pkg/crd/kubermatic/v1"
 
@@ -195,15 +196,15 @@ func getVSphereProviderSpec(c *kubermaticv1.Cluster, nodeSpec apiv1.NodeSpec, dc
 
 func getOpenstackProviderSpec(c *kubermaticv1.Cluster, nodeSpec apiv1.NodeSpec, dc *kubermaticv1.Datacenter) (*runtime.RawExtension, error) {
 	config := openstack.RawConfig{
-		Image:            providerconfig.ConfigVarString{Value: nodeSpec.Cloud.Openstack.Image},
-		Flavor:           providerconfig.ConfigVarString{Value: nodeSpec.Cloud.Openstack.Flavor},
-		AvailabilityZone: providerconfig.ConfigVarString{Value: dc.Spec.Openstack.AvailabilityZone},
-		Region:           providerconfig.ConfigVarString{Value: dc.Spec.Openstack.Region},
-		IdentityEndpoint: providerconfig.ConfigVarString{Value: dc.Spec.Openstack.AuthURL},
-		Network:          providerconfig.ConfigVarString{Value: c.Spec.Cloud.Openstack.Network},
-		Subnet:           providerconfig.ConfigVarString{Value: c.Spec.Cloud.Openstack.SubnetID},
-		SecurityGroups:   []providerconfig.ConfigVarString{{Value: c.Spec.Cloud.Openstack.SecurityGroups}},
-		InstanceReadyCheckPeriod: providerconfig.ConfigVarString{Value: nodeSpec.Cloud.Openstack.InstanceReadyCheckPeriod},
+		Image:                     providerconfig.ConfigVarString{Value: nodeSpec.Cloud.Openstack.Image},
+		Flavor:                    providerconfig.ConfigVarString{Value: nodeSpec.Cloud.Openstack.Flavor},
+		AvailabilityZone:          providerconfig.ConfigVarString{Value: dc.Spec.Openstack.AvailabilityZone},
+		Region:                    providerconfig.ConfigVarString{Value: dc.Spec.Openstack.Region},
+		IdentityEndpoint:          providerconfig.ConfigVarString{Value: dc.Spec.Openstack.AuthURL},
+		Network:                   providerconfig.ConfigVarString{Value: c.Spec.Cloud.Openstack.Network},
+		Subnet:                    providerconfig.ConfigVarString{Value: c.Spec.Cloud.Openstack.SubnetID},
+		SecurityGroups:            []providerconfig.ConfigVarString{{Value: c.Spec.Cloud.Openstack.SecurityGroups}},
+		InstanceReadyCheckPeriod:  providerconfig.ConfigVarString{Value: nodeSpec.Cloud.Openstack.InstanceReadyCheckPeriod},
 		InstanceReadyCheckTimeout: providerconfig.ConfigVarString{Value: nodeSpec.Cloud.Openstack.InstanceReadyCheckTimeout},
 	}
 

--- a/pkg/resources/machine/common.go
+++ b/pkg/resources/machine/common.go
@@ -203,6 +203,8 @@ func getOpenstackProviderSpec(c *kubermaticv1.Cluster, nodeSpec apiv1.NodeSpec, 
 		Network:          providerconfig.ConfigVarString{Value: c.Spec.Cloud.Openstack.Network},
 		Subnet:           providerconfig.ConfigVarString{Value: c.Spec.Cloud.Openstack.SubnetID},
 		SecurityGroups:   []providerconfig.ConfigVarString{{Value: c.Spec.Cloud.Openstack.SecurityGroups}},
+		InstanceReadyCheckPeriod: providerconfig.ConfigVarString{Value: nodeSpec.Cloud.Openstack.InstanceReadyCheckPeriod},
+		InstanceReadyCheckTimeout: providerconfig.ConfigVarString{Value: nodeSpec.Cloud.Openstack.InstanceReadyCheckTimeout},
 	}
 
 	if nodeSpec.Cloud.Openstack.UseFloatingIP || dc.Spec.Openstack.EnforceFloatingIP {

--- a/pkg/test/e2e/api/utils/apiclient/models/a_w_s_node_spec.go
+++ b/pkg/test/e2e/api/utils/apiclient/models/a_w_s_node_spec.go
@@ -24,7 +24,7 @@ type AWSNodeSpec struct {
 	// assigned during launch overriding a possible setting in the used AWS subnet.
 	AssignPublicIP bool `json:"assignPublicIP,omitempty"`
 
-	// Availiability zone in which to place the node. It is coupled with the subnet to which the node will belong.
+	// Availability zone in which to place the node. It is coupled with the subnet to which the node will belong.
 	AvailabilityZone string `json:"availabilityZone,omitempty"`
 
 	// instance type

--- a/pkg/test/e2e/api/utils/apiclient/models/openstack_node_spec.go
+++ b/pkg/test/e2e/api/utils/apiclient/models/openstack_node_spec.go
@@ -28,6 +28,12 @@ type OpenstackNodeSpec struct {
 	// Required: true
 	Image *string `json:"image"`
 
+	// Period of time to check for instance ready status
+	InstanceReadyCheckPeriod string `json:"instanceReadyCheckPeriod,omitempty"`
+
+	// Max time to wait for the instance to be ready
+	InstanceReadyCheckTimeout string `json:"instanceReadyCheckTimeout,omitempty"`
+
 	// if set, the rootDisk will be a volume. If not, the rootDisk will be on ephemeral storage and its size will be derived from the flavor
 	RootDiskSizeGB int64 `json:"diskSize,omitempty"`
 


### PR DESCRIPTION
**What this PR does / why we need it**:
Add support for 2 new variables to the OpenStack provider.

**Which issue(s) this PR fixes**:
Fixes #6113

**Does this PR introduce a user-facing change?**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If  no release note is required, just write "NONE".
-->
```release-note
Add support for 'InstanceReadyCheckPeriod' and 'InstanceReadyCheckTimeout' to Openstack provider.
```
