### PR TITLE
Update envoy static configuration to use xds v3

### DIFF
--- a/charts/nodeport-proxy/Chart.yaml
+++ b/charts/nodeport-proxy/Chart.yaml
@@ -14,7 +14,7 @@
 
 apiVersion: v1
 name: nodeport-proxy
-version: 1.5.6
+version: 1.6.0
 appVersion: __KUBERMATIC_TAG__
 description: Kubermatic nodeport-proxy
 keywords:

--- a/charts/nodeport-proxy/values.yaml
+++ b/charts/nodeport-proxy/values.yaml
@@ -20,7 +20,7 @@ nodePortProxy:
   envoy:
     image:
       repository: "docker.io/envoyproxy/envoy-alpine"
-      tag: v1.13.0
+      tag: v1.16.0
 
   nodeSelector: {}
   affinity:

--- a/cmd/nodeport-proxy/envoy.yaml
+++ b/cmd/nodeport-proxy/envoy.yaml
@@ -13,18 +13,24 @@
 # limitations under the License.
 
 dynamic_resources:
-  lds_config:
-    api_config_source:
-      api_type: GRPC
-      grpc_services:
-      - envoy_grpc:
-          cluster_name: xds_cluster
   cds_config:
+    resource_api_version: V3
     api_config_source:
       api_type: GRPC
+      transport_api_version: V3
       grpc_services:
       - envoy_grpc:
           cluster_name: xds_cluster
+      set_node_on_first_message_only: true
+  lds_config:
+    resource_api_version: V3
+    api_config_source:
+      api_type: GRPC
+      transport_api_version: V3
+      grpc_services:
+      - envoy_grpc:
+          cluster_name: xds_cluster
+      set_node_on_first_message_only: true
 static_resources:
   clusters:
   - name: xds_cluster

--- a/pkg/controller/operator/common/versions.go
+++ b/pkg/controller/operator/common/versions.go
@@ -43,7 +43,7 @@ func NewDefaultVersions() Versions {
 		Kubermatic:        KUBERMATICDOCKERTAG,
 		UI:                UIDOCKERTAG,
 		VPA:               "0.5.0",
-		Envoy:             "v1.13.0",
+		Envoy:             "v1.16.0",
 		KubermaticEdition: edition.KubermaticEdition,
 	}
 }

--- a/pkg/resources/nodeportproxy/nodeportproxy.go
+++ b/pkg/resources/nodeportproxy/nodeportproxy.go
@@ -223,7 +223,7 @@ func deploymentEnvoy(image string, data nodePortProxyData) reconciling.NamedDepl
 				}},
 			}, {
 				Name:  "envoy",
-				Image: data.ImageRegistry("docker.io") + "/envoyproxy/envoy-alpine:v1.13.0",
+				Image: data.ImageRegistry("docker.io") + "/envoyproxy/envoy-alpine:v1.16.0",
 				Command: []string{
 					"/usr/local/bin/envoy",
 					"-c",


### PR DESCRIPTION
Signed-off-by: Iacopo Rozzo <iacopo@kubermatic.com>

**What this PR does / why we need it**:
This PR is to fix node-port proxy after that the control plane xds protocol moved to v3 #6137 

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Documentation**:
<!-- Add links to the related documentation changes related to this pull request. E.g. the link to the kubermatic/docs pull request. -->

**Does this PR introduce a user-facing change?**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If  no release note is required, just write "NONE".
-->
```release-note
NONE
```
