### PR TITLE
Fix nodeport proxy bugs introduced during refactoring

### DIFF
--- a/pkg/controller/nodeport-proxy/envoymanager/resources.go
+++ b/pkg/controller/nodeport-proxy/envoymanager/resources.go
@@ -327,7 +327,7 @@ func (r *Reconciler) getEndpoints(s *corev1.Service, port *corev1.ServicePort, p
 
 func newSnapshot(version string, clusters, listeners []envoycachetype.Resource) envoycachev3.Snapshot {
 	return envoycachev3.NewSnapshot(
-		"v0.0.0",
+		version,
 		nil,       // endpoints
 		clusters,  // clusters
 		nil,       // routes

--- a/pkg/controller/nodeport-proxy/envoymanager/resources.go
+++ b/pkg/controller/nodeport-proxy/envoymanager/resources.go
@@ -39,7 +39,6 @@ import (
 	envoytcpfilterv3 "github.com/envoyproxy/go-control-plane/envoy/extensions/filters/network/tcp_proxy/v3"
 	envoycachetype "github.com/envoyproxy/go-control-plane/pkg/cache/types"
 	envoycachev3 "github.com/envoyproxy/go-control-plane/pkg/cache/v3"
-	envoylog "github.com/envoyproxy/go-control-plane/pkg/log"
 	envoywellknown "github.com/envoyproxy/go-control-plane/pkg/wellknown"
 )
 
@@ -87,7 +86,7 @@ func (r *Reconciler) makeListenersAndClustersForService(service *corev1.Service,
 			panic(errors.Wrap(err, "failed to marshal tcpProxyConfig"))
 		}
 
-		r.Log.Debugf("Using a listener on port %d", servicePort.NodePort)
+		r.log.Debugf("Using a listener on port %d", servicePort.NodePort)
 
 		listener := &envoylistenerv3.Listener{
 			Name: serviceNodePortName,
@@ -271,7 +270,7 @@ func (r *Reconciler) getEndpoints(s *corev1.Service, port *corev1.ServicePort, p
 	processedUpstreamServers := make(map[string]struct{})
 
 	svcKey := ServiceKey(s)
-	serviceLog := r.Log.With("service", svcKey)
+	serviceLog := r.log.With("service", svcKey)
 
 	for _, ss := range eps.Subsets {
 		for _, epPort := range ss.Ports {
@@ -335,9 +334,4 @@ func newSnapshot(version string, clusters, listeners []envoycachetype.Resource) 
 		nil,       // runtimes
 		nil,       // secrets
 	)
-}
-
-// NewSnapshotCache returns a new envoy snapshot cache.
-func NewSnapshotCache(log envoylog.Logger) envoycachev3.SnapshotCache {
-	return envoycachev3.NewSnapshotCache(true, envoycachev3.IDHash{}, log)
 }


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR fixes a few bugs introduced with #6154:
* The envoy configuration is not set in the snapshot cache until the first reconcile request arrives, this causes the liveness probe to fail if no exposed services are present.
* Method creating the snapshot does not take into account the version provided in input.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Documentation**:
<!-- Add links to the related documentation changes related to this pull request. E.g. the link to the kubermatic/docs pull request. -->

**Does this PR introduce a user-facing change?**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If  no release note is required, just write "NONE".
-->
```release-note
NONE
```
