### PR TITLE
handle dockerizing spellchecker like any other tool

### DIFF
--- a/.prow.yaml
+++ b/.prow.yaml
@@ -14,22 +14,6 @@
 
 presubmits:
 
-  - name: pre-kubermatic-spellcheck
-    always_run: true
-    decorate: true
-    clone_uri: "ssh://git@github.com/kubermatic/kubermatic.git"
-    spec:
-      containers:
-      - image: quay.io/kubermatic/codespell:1.17.1
-        command:
-        - make
-        args:
-        - spellcheck
-        resources:
-          requests:
-            memory: 512Mi
-            cpu: 0.5
-
   #########################################################
   # unit tests
   #########################################################
@@ -185,6 +169,22 @@ presubmits:
         env:
         - name: KUBERMATIC_EDITION
           value: ee
+
+  - name: pre-kubermatic-spellcheck
+    always_run: true
+    decorate: true
+    clone_uri: "ssh://git@github.com/kubermatic/kubermatic.git"
+    spec:
+      containers:
+      - image: quay.io/kubermatic/codespell:1.17.1
+        command:
+        - make
+        args:
+        - spellcheck
+        resources:
+          requests:
+            memory: 512Mi
+            cpu: 0.5
 
   - name: pre-kubermatic-dependencies
     run_if_changed: "^(cmd|codegen|hack|pkg|go.mod|go.sum)/"

--- a/Makefile
+++ b/Makefile
@@ -37,8 +37,6 @@ LDFLAGS_EXTRA=-w
 BUILD_DEST ?= _build
 GOTOOLFLAGS ?= $(GOBUILDFLAGS) -ldflags '$(LDFLAGS_EXTRA) $(LDFLAGS)' $(GOTOOLFLAGS_EXTRA)
 GOBUILDIMAGE ?= golang:1.15.1
-CODESPELL_IMAGE ?= quay.io/kubermatic/codespell:1.17.1
-CODESPELL_BIN := $(shell which codespell)
 DOCKER_BIN := $(shell which docker)
 
 default: all
@@ -126,16 +124,7 @@ ifndef DOCKER_BIN
 endif
 
 spellcheck:
-ifndef CODESPELL_BIN
-	$(error "codespell not available in your environment, use spellcheck-in-docker if you have Docker installed.")
-endif
-	$(CODESPELL_BIN) -S *.png,*.po,.git,*.jpg,*.mod,*.sum,*.woff,*.woff2,swagger.json,*/_build/*,*/_dist/*,./vendor/* -I .codespell.exclude -f
-
-spellcheck-in-docker:
-ifndef DOCKER_BIN
-	$(error "Docker not available in your environment, please install it and retry.")
-endif
-	$(DOCKER_BIN) run -it -v ${PWD}:/kubermatic -w /kubermatic $(CODESPELL_IMAGE) make spellcheck
+	./hack/verify-spelling.sh
 
 cover:
 	./hack/cover.sh --html

--- a/hack/lib.sh
+++ b/hack/lib.sh
@@ -292,14 +292,14 @@ check_all_deployments_ready() {
   local deployments
   deployments=$(kubectl -n $namespace get deployments -o json)
 
-  if [ $(jq '.items | length' <<< $deployments) -eq 0 ]; then
+  if [ $(echo "$deployments" | jq '.items | length') -eq 0 ]; then
     echodate "No Deployments created yet."
     return 1
   fi
 
   # check that all Deployments are ready
   local unready
-  unready=$(jq -r '[.items[] | select(.spec.replicas > 0) | select (.status.availableReplicas < .spec.replicas) | .metadata.name] | @tsv' <<< $deployments)
+  unready=$(echo "$deployments" | jq -r '[.items[] | select(.spec.replicas > 0) | select (.status.availableReplicas < .spec.replicas) | .metadata.name] | @tsv')
   if [ -n "$unready" ]; then
     echodate "Not all Deployments have finished rolling out, namely: $unready"
     return 1
@@ -308,7 +308,7 @@ check_all_deployments_ready() {
   return 0
 }
 
-function cleanup_kubermatic_clusters_in_kind {
+cleanup_kubermatic_clusters_in_kind() {
   # Tolerate errors and just continue
   set +e
   # Clean up clusters

--- a/hack/verify-spelling.sh
+++ b/hack/verify-spelling.sh
@@ -1,0 +1,32 @@
+#!/usr/bin/env sh
+
+# Copyright 2020 The Kubermatic Kubernetes Platform contributors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+set -e
+
+cd $(dirname $0)/..
+. hack/lib.sh
+
+CONTAINERIZE_IMAGE=quay.io/kubermatic/codespell:1.17.1 containerize ./hack/verify-spelling.sh
+
+echodate "Running codespell..."
+
+codespell \
+  --skip .git,_build,_dist,vendor,go.mod,go.sum,swagger.json,*.png,*.woff,*.woff2 \
+  --ignore-words .codespell.exclude \
+  --check-filenames \
+  --check-hidden
+
+echodate "No problems detected."

--- a/pkg/controller/user-cluster-controller-manager/openshift-master-node-labeler/openshiftmasternodelabeler_test.go
+++ b/pkg/controller/user-cluster-controller-manager/openshift-master-node-labeler/openshiftmasternodelabeler_test.go
@@ -142,7 +142,7 @@ func TestReconciliation(t *testing.T) {
 					return fmt.Errorf("expected err to be nil, was %v", err)
 				}
 				if r == nil {
-					return errors.New("expcted to get reconcile.Result, but was nil")
+					return errors.New("expected to get reconcile.Result, but was nil")
 				}
 				if r.RequeueAfter != time.Minute {
 					return fmt.Errorf("expected RequeueAfter to be 1 Minute, was %v", r.RequeueAfter)

--- a/pkg/provider/cloud/openstack/helper.go
+++ b/pkg/provider/cloud/openstack/helper.go
@@ -154,7 +154,7 @@ func createKubermaticSecurityGroup(netClient *gophercloud.ServiceClient, cluster
 	secGroupName := resourceNamePrefix + clusterName
 	secGroups, err := getSecurityGroups(netClient, ossecuritygroups.ListOpts{Name: secGroupName})
 	if err != nil {
-		return "", fmt.Errorf("failed to get securiy groups: %v", err)
+		return "", fmt.Errorf("failed to get security groups: %v", err)
 	}
 
 	var securityGroupID string


### PR DESCRIPTION
**What this PR does / why we need it**:
This removes the `spellcheck-in-docker` Make target and instead uses the same approach as we use for all other tools: Have a script and this script calls itself in Docker when necessary. And as the codespell image does not have bash, the PR also makes the lib.sh POSIX compatible again.

**Does this PR introduce a user-facing change?**:
```release-note
NONE
```
