### PR TITLE
[release/v2.15] Fix Prometheus alerts using oldstyle label selector (#6167)

### DIFF
--- a/charts/kubermatic/Chart.yaml
+++ b/charts/kubermatic/Chart.yaml
@@ -14,7 +14,7 @@
 
 apiVersion: v1
 name: kubermatic
-version: 1.1.20
+version: 1.1.25
 appVersion: '__KUBERMATIC_TAG__'
 description: Kubermatic chart for master and/or seed clusters.
 keywords:

--- a/charts/kubermatic/templates/kubermatic-api-dep.yaml
+++ b/charts/kubermatic/templates/kubermatic-api-dep.yaml
@@ -28,6 +28,7 @@ spec:
       labels:
         role: kubermatic-api
         version: v1
+        app.kubernetes.io/name: kubermatic-api
       annotations:
         prometheus.io/scrape: 'true'
         prometheus.io/port: '8085'

--- a/charts/kubermatic/templates/kubermatic-controller-manager-dep.yaml
+++ b/charts/kubermatic/templates/kubermatic-controller-manager-dep.yaml
@@ -27,6 +27,7 @@ spec:
       labels:
         role: controller-manager
         version: v1
+        app.kubernetes.io/name: kubermatic-seed-controller-manager
       annotations:
         prometheus.io/scrape: 'true'
         prometheus.io/port: '8085'

--- a/charts/kubermatic/templates/kubermatic-ui-dep.yaml
+++ b/charts/kubermatic/templates/kubermatic-ui-dep.yaml
@@ -31,6 +31,7 @@ spec:
       labels:
         role: kubermatic-dashboard
         version: v1
+        app.kubernetes.io/name: kubermatic-dashboard
     spec:
       containers:
       - name: webserver

--- a/charts/kubermatic/templates/master-controller-manager-dep.yaml
+++ b/charts/kubermatic/templates/master-controller-manager-dep.yaml
@@ -28,6 +28,7 @@ spec:
     metadata:
       labels:
         app: master-controller
+        app.kubernetes.io/name: kubermatic-master-controller-manager
       annotations:
         prometheus.io/scrape: 'true'
         prometheus.io/port: '8085'

--- a/charts/monitoring/prometheus/Chart.yaml
+++ b/charts/monitoring/prometheus/Chart.yaml
@@ -14,7 +14,7 @@
 
 apiVersion: v1
 name: prometheus
-version: 2.2.30
+version: 2.2.33
 appVersion: v2.20.1
 description: Prometheus Monitoring for Kubernetes
 keywords:

--- a/charts/monitoring/prometheus/rules/kubermatic-master-kubermatic.yaml
+++ b/charts/monitoring/prometheus/rules/kubermatic-master-kubermatic.yaml
@@ -21,7 +21,7 @@ groups:
         annotations:
           message: KubermaticAPI has disappeared from Prometheus target discovery.
           runbook_url: https://docs.kubermatic.com/kubermatic/master/monitoring/runbook/#alert-kubermaticapidown
-        expr: absent(up{job="pods",namespace="kubermatic",role="kubermatic-api"} == 1)
+        expr: absent(up{job="pods",namespace="kubermatic",app_kubernetes_io_name="kubermatic-api"} == 1)
         for: 15m
         labels:
           severity: critical
@@ -29,7 +29,7 @@ groups:
         annotations:
           message: Kubermatic API is returning a high rate of HTTP 5xx responses.
           runbook_url: https://docs.kubermatic.com/kubermatic/master/monitoring/runbook/#alert-kubermaticapitoomanyerrors
-        expr: sum(rate(http_requests_total{role="kubermatic-api",code=~"5.."}[5m])) > 0.1
+        expr: sum(rate(http_requests_total{app_kubernetes_io_name="kubermatic-api",code=~"5.."}[5m])) > 0.1
         for: 15m
         labels:
           severity: warning
@@ -40,3 +40,11 @@ groups:
         for: 15m
         labels:
           severity: warning
+      - alert: KubermaticMasterControllerManagerDown
+        annotations:
+          message: Kubermatic Master Controller Manager has disappeared from Prometheus target discovery.
+          runbook_url: https://docs.kubermatic.com/kubermatic/master/monitoring/runbook/#alert-kubermaticmastercontrollermanagerdown
+        expr: absent(up{job="pods",namespace="kubermatic",app_kubernetes_io_name="kubermatic-master-controller-manager"} == 1)
+        for: 15m
+        labels:
+          severity: critical

--- a/charts/monitoring/prometheus/rules/kubermatic-seed-kubermatic.yaml
+++ b/charts/monitoring/prometheus/rules/kubermatic-seed-kubermatic.yaml
@@ -49,11 +49,11 @@ groups:
         for: 30m
         labels:
           severity: warning
-      - alert: KubermaticControllerManagerDown
+      - alert: KubermaticSeedControllerManagerDown
         annotations:
-          message: KubermaticControllerManager has disappeared from Prometheus target discovery.
-          runbook_url: https://docs.kubermatic.com/kubermatic/master/monitoring/runbook/#alert-kubermaticcontrollermanagerdown
-        expr: absent(up{job="pods",namespace="kubermatic",role="controller-manager"} == 1)
+          message: Kubermatic Seed Controller Manager has disappeared from Prometheus target discovery.
+          runbook_url: https://docs.kubermatic.com/kubermatic/master/monitoring/runbook/#alert-kubermaticseedcontrollermanagerdown
+        expr: absent(up{job="pods",namespace="kubermatic",app_kubernetes_io_name="kubermatic-seed-controller-manager"} == 1)
         for: 15m
         labels:
           severity: critical

--- a/charts/monitoring/prometheus/rules/src/kubermatic-master/kubermatic.yaml
+++ b/charts/monitoring/prometheus/rules/src/kubermatic-master/kubermatic.yaml
@@ -19,7 +19,7 @@ groups:
     annotations:
       message: KubermaticAPI has disappeared from Prometheus target discovery.
       runbook_url: https://docs.kubermatic.com/kubermatic/master/monitoring/runbook/#alert-kubermaticapidown
-    expr: absent(up{job="pods",namespace="kubermatic",role="kubermatic-api"} == 1)
+    expr: absent(up{job="pods",namespace="kubermatic",app_kubernetes_io_name="kubermatic-api"} == 1)
     for: 15m
     labels:
       severity: critical
@@ -32,7 +32,7 @@ groups:
     annotations:
       message: Kubermatic API is returning a high rate of HTTP 5xx responses.
       runbook_url: https://docs.kubermatic.com/kubermatic/master/monitoring/runbook/#alert-kubermaticapitoomanyerrors
-    expr: sum(rate(http_requests_total{role="kubermatic-api",code=~"5.."}[5m])) > 0.1
+    expr: sum(rate(http_requests_total{app_kubernetes_io_name="kubermatic-api",code=~"5.."}[5m])) > 0.1
     for: 15m
     labels:
       severity: warning
@@ -47,3 +47,16 @@ groups:
     for: 15m
     labels:
       severity: warning
+
+  - alert: KubermaticMasterControllerManagerDown
+    annotations:
+      message: Kubermatic Master Controller Manager has disappeared from Prometheus target discovery.
+      runbook_url: https://docs.kubermatic.com/kubermatic/master/monitoring/runbook/#alert-kubermaticmastercontrollermanagerdown
+    expr: absent(up{job="pods",namespace="kubermatic",app_kubernetes_io_name="kubermatic-master-controller-manager"} == 1)
+    for: 15m
+    labels:
+      severity: critical
+    runbook:
+      steps:
+      - Check the Prometheus Service Discovery page to find out why the target is unreachable.
+      - Ensure that the master-controller-manager pod's logs and that it is not crashlooping.

--- a/charts/monitoring/prometheus/rules/src/kubermatic-seed/kubermatic.yaml
+++ b/charts/monitoring/prometheus/rules/src/kubermatic-seed/kubermatic.yaml
@@ -53,7 +53,7 @@ groups:
       severity: warning
     runbook:
       steps:
-        - Check the kubermatic controller-manager's logs via `kubectl -n kubermatic logs -l 'role=controller-manager'` for errors related to deletion of the addon.
+        - Check the kubermatic controller-manager's logs via `kubectl -n kubermatic logs -l 'app.kubernetes.io/name=kubermatic-seed-controller-manager'` for errors related to deletion of the addon.
           Manually deleted resources inside of the user cluster is a common reason for failing deletions.
         - If all resources of the addon inside the user cluster have been cleaned up, remove the blocking finalizer (e.g. `cleanup-manifests`) from the addon resource.
 
@@ -70,20 +70,20 @@ groups:
       severity: warning
     runbook:
       steps:
-        - Check the kubermatic controller-manager's logs via `kubectl -n kubermatic logs -l 'role=controller-manager'` for errors related to reconciliation of the addon.
+        - Check the kubermatic seed controller-manager's logs via `kubectl -n kubermatic logs -l 'app.kubernetes.io/name=kubermatic-seed-controller-manager'` for errors related to reconciliation of the addon.
 
-  - alert: KubermaticControllerManagerDown
+  - alert: KubermaticSeedControllerManagerDown
     annotations:
-      message: KubermaticControllerManager has disappeared from Prometheus target discovery.
-      runbook_url: https://docs.kubermatic.com/kubermatic/master/monitoring/runbook/#alert-kubermaticcontrollermanagerdown
-    expr: absent(up{job="pods",namespace="kubermatic",role="controller-manager"} == 1)
+      message: Kubermatic Seed Controller Manager has disappeared from Prometheus target discovery.
+      runbook_url: https://docs.kubermatic.com/kubermatic/master/monitoring/runbook/#alert-kubermaticseedcontrollermanagerdown
+    expr: absent(up{job="pods",namespace="kubermatic",app_kubernetes_io_name="kubermatic-seed-controller-manager"} == 1)
     for: 15m
     labels:
       severity: critical
     runbook:
       steps:
       - Check the Prometheus Service Discovery page to find out why the target is unreachable.
-      - Ensure that the controller-manager pod's logs and that it is not crashlooping.
+      - Ensure that the seed-controller-manager pod's logs and that it is not crashlooping.
 
   - alert: OpenVPNServerDown
     annotations:


### PR DESCRIPTION
**What this PR does / why we need it**:
Backports #6167 into the 2.15 release branch.

**Does this PR introduce a user-facing change?**:
```release-note
Fix Prometheus alerts misfiring about absent KKP components
```
