### PR TITLE
Stabilize Flatcar conformance tests

### DIFF
--- a/cmd/conformance-tests/runner.go
+++ b/cmd/conformance-tests/runner.go
@@ -1086,9 +1086,9 @@ func (r *testRunner) waitForControlPlane(log *zap.SugaredLogger, clusterName str
 // between scheduler and kubelet.
 // see: https://github.com/kubernetes/kubernetes/issues/93338
 func (r *testRunner) podFailedKubeletAdmissionDueToNodeAffinityPredicate(p *corev1.Pod) bool {
-	failedAdmission := p.Status.Phase == "Failed" && p.Status.Reason == "NodeAffinity" && p.Spec.NodeName != ""
+	failedAdmission := p.Status.Phase == "Failed" && p.Status.Reason == "NodeAffinity"
 	if failedAdmission {
-		r.log.Debugw(
+		r.log.Infow(
 			"pod failed kubelet admission due to NodeAffinity predicate",
 			"pod", *p,
 		)

--- a/cmd/conformance-tests/runner.go
+++ b/cmd/conformance-tests/runner.go
@@ -1081,13 +1081,19 @@ func (r *testRunner) waitForControlPlane(log *zap.SugaredLogger, clusterName str
 	return cluster, nil
 }
 
-// This is a workaround for: https://github.com/kubermatic/kubermatic/issues/6185
+// podFailedKubeletAdmissionDueToNodeAffinityPredicate detects a condition in
+// which a pod is scheduled but fails kubelet admission due to a race condition
+// between scheduler and kubelet.
+// see: https://github.com/kubernetes/kubernetes/issues/93338
 func (r *testRunner) podFailedKubeletAdmissionDueToNodeAffinityPredicate(p *corev1.Pod) bool {
-	r.log.Debugw(
-		"found pod that was scheduled successfully, but failed kubelet admission due to NodeAffinity predicate",
-		"pod", *p,
-	)
-	return p.Status.Phase == "Failed" && p.Status.Reason == "NodeAffinity"
+	failedAdmission := p.Status.Phase == "Failed" && p.Status.Reason == "NodeAffinity"
+	if failedAdmission {
+		r.log.Debugw(
+			"pod but failed kubelet admission due to NodeAffinity predicate",
+			"pod", *p,
+		)
+	}
+	return failedAdmission
 }
 
 func (r *testRunner) waitUntilAllPodsAreReady(log *zap.SugaredLogger, userClusterClient ctrlruntimeclient.Client, timeout time.Duration) error {
@@ -1102,6 +1108,7 @@ func (r *testRunner) waitUntilAllPodsAreReady(log *zap.SugaredLogger, userCluste
 		}
 
 		for _, pod := range podList.Items {
+			// Ignore pods failing kubelet admission #6185
 			if !podIsReady(&pod) && !r.podFailedKubeletAdmissionDueToNodeAffinityPredicate(&pod) {
 				return false, nil
 			}

--- a/cmd/conformance-tests/runner.go
+++ b/cmd/conformance-tests/runner.go
@@ -1064,7 +1064,7 @@ func (r *testRunner) waitForControlPlane(log *zap.SugaredLogger, clusterName str
 			return false, fmt.Errorf("failed to list controlplane pods: %v", err)
 		}
 		for _, pod := range controlPlanePods.Items {
-			if !podIsReady(&pod) && !podFailedKubeletAdmissionDueToNodeAffinityPredicate(&pod) {
+			if !podIsReady(&pod) {
 				return false, nil
 			}
 		}
@@ -1098,7 +1098,7 @@ func (r *testRunner) waitUntilAllPodsAreReady(log *zap.SugaredLogger, userCluste
 		}
 
 		for _, pod := range podList.Items {
-			if !podIsReady(&pod) {
+			if !podIsReady(&pod) && !podFailedKubeletAdmissionDueToNodeAffinityPredicate(&pod) {
 				return false, nil
 			}
 		}

--- a/cmd/conformance-tests/runner.go
+++ b/cmd/conformance-tests/runner.go
@@ -1086,10 +1086,10 @@ func (r *testRunner) waitForControlPlane(log *zap.SugaredLogger, clusterName str
 // between scheduler and kubelet.
 // see: https://github.com/kubernetes/kubernetes/issues/93338
 func (r *testRunner) podFailedKubeletAdmissionDueToNodeAffinityPredicate(p *corev1.Pod) bool {
-	failedAdmission := p.Status.Phase == "Failed" && p.Status.Reason == "NodeAffinity"
+	failedAdmission := p.Status.Phase == "Failed" && p.Status.Reason == "NodeAffinity" && p.Spec.NodeName != ""
 	if failedAdmission {
 		r.log.Debugw(
-			"pod but failed kubelet admission due to NodeAffinity predicate",
+			"pod failed kubelet admission due to NodeAffinity predicate",
 			"pod", *p,
 		)
 	}


### PR DESCRIPTION
**What this PR does / why we need it**:
The Flatcar conformance tests are often failing due to a race between scheduler and kubelet (see #6185). This PR provides a workaround that aims at improving the situation.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Documentation**:
<!-- Add links to the related documentation changes related to this pull request. E.g. the link to the kubermatic/docs pull request. -->

**Does this PR introduce a user-facing change?**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If  no release note is required, just write "NONE".
-->
```release-note
NONE
```
