### PR TITLE
Envoy Clusters / Listeners for New expose strategy

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -78,6 +78,7 @@ require (
 	gomodules.xyz/jsonpatch/v2 v2.1.0 // indirect
 	google.golang.org/api v0.15.0
 	google.golang.org/grpc v1.27.1
+	google.golang.org/protobuf v1.25.0
 	gopkg.in/fsnotify.v1 v1.4.7
 	gopkg.in/square/go-jose.v2 v2.5.1
 	gopkg.in/yaml.v2 v2.3.0

--- a/go.mod
+++ b/go.mod
@@ -78,7 +78,6 @@ require (
 	gomodules.xyz/jsonpatch/v2 v2.1.0 // indirect
 	google.golang.org/api v0.15.0
 	google.golang.org/grpc v1.27.1
-	google.golang.org/protobuf v1.25.0
 	gopkg.in/fsnotify.v1 v1.4.7
 	gopkg.in/square/go-jose.v2 v2.5.1
 	gopkg.in/yaml.v2 v2.3.0

--- a/pkg/controller/nodeport-proxy/envoymanager/controller.go
+++ b/pkg/controller/nodeport-proxy/envoymanager/controller.go
@@ -151,7 +151,8 @@ func (r *Reconciler) sync() error {
 			serviceLog.Debug("skipping service: it has no running pods")
 			continue
 		}
-		l, c := r.makeListenersAndClustersForService(&service, &eps)
+		l := r.makeListenersForNodePortService(&service)
+		c := r.makeClusters(&service, &eps)
 		listeners = append(listeners, l...)
 		clusters = append(clusters, c...)
 

--- a/pkg/controller/nodeport-proxy/envoymanager/controller_test.go
+++ b/pkg/controller/nodeport-proxy/envoymanager/controller_test.go
@@ -117,15 +117,15 @@ func TestSync(t *testing.T) {
 				},
 			},
 			expectedClusters: map[string]*envoyclusterv3.Cluster{
-				"test/my-nodeport-32000": {
-					Name:           "test/my-nodeport-32000",
+				"test/my-nodeport-https": {
+					Name:           "test/my-nodeport-https",
 					ConnectTimeout: ptypes.DurationProto(clusterConnectTimeout),
 					ClusterDiscoveryType: &envoyclusterv3.Cluster_Type{
 						Type: envoyclusterv3.Cluster_STATIC,
 					},
 					LbPolicy: envoyclusterv3.Cluster_ROUND_ROBIN,
 					LoadAssignment: &envoyendpointv3.ClusterLoadAssignment{
-						ClusterName: "test/my-nodeport-32000",
+						ClusterName: "test/my-nodeport-https",
 						Endpoints: []*envoyendpointv3.LocalityLbEndpoints{
 							{
 								LbEndpoints: []*envoyendpointv3.LbEndpoint{
@@ -168,15 +168,15 @@ func TestSync(t *testing.T) {
 						},
 					},
 				},
-				"test/my-nodeport-32001": {
-					Name:           "test/my-nodeport-32001",
+				"test/my-nodeport-http": {
+					Name:           "test/my-nodeport-http",
 					ConnectTimeout: ptypes.DurationProto(clusterConnectTimeout),
 					ClusterDiscoveryType: &envoyclusterv3.Cluster_Type{
 						Type: envoyclusterv3.Cluster_STATIC,
 					},
 					LbPolicy: envoyclusterv3.Cluster_ROUND_ROBIN,
 					LoadAssignment: &envoyendpointv3.ClusterLoadAssignment{
-						ClusterName: "test/my-nodeport-32001",
+						ClusterName: "test/my-nodeport-http",
 						Endpoints: []*envoyendpointv3.LocalityLbEndpoints{
 							{
 								LbEndpoints: []*envoyendpointv3.LbEndpoint{
@@ -221,8 +221,8 @@ func TestSync(t *testing.T) {
 				},
 			},
 			expectedListener: map[string]*envoylistenerv3.Listener{
-				"test/my-nodeport-32000": {
-					Name: "test/my-nodeport-32000",
+				"test/my-nodeport-https": {
+					Name: "test/my-nodeport-https",
 					Address: &envoycorev3.Address{
 						Address: &envoycorev3.Address_SocketAddress{
 							SocketAddress: &envoycorev3.SocketAddress{
@@ -243,7 +243,7 @@ func TestSync(t *testing.T) {
 										TypedConfig: marshalMessage(t, &envoytcpfilterv3.TcpProxy{
 											StatPrefix: "ingress_tcp",
 											ClusterSpecifier: &envoytcpfilterv3.TcpProxy_Cluster{
-												Cluster: "test/my-nodeport-32000",
+												Cluster: "test/my-nodeport-https",
 											},
 										}),
 									},
@@ -252,8 +252,8 @@ func TestSync(t *testing.T) {
 						},
 					},
 				},
-				"test/my-nodeport-32001": {
-					Name: "test/my-nodeport-32001",
+				"test/my-nodeport-http": {
+					Name: "test/my-nodeport-http",
 					Address: &envoycorev3.Address{
 						Address: &envoycorev3.Address_SocketAddress{
 							SocketAddress: &envoycorev3.SocketAddress{
@@ -274,7 +274,7 @@ func TestSync(t *testing.T) {
 										TypedConfig: marshalMessage(t, &envoytcpfilterv3.TcpProxy{
 											StatPrefix: "ingress_tcp",
 											ClusterSpecifier: &envoytcpfilterv3.TcpProxy_Cluster{
-												Cluster: "test/my-nodeport-32001",
+												Cluster: "test/my-nodeport-http",
 											},
 										}),
 									},
@@ -337,15 +337,15 @@ func TestSync(t *testing.T) {
 				},
 			},
 			expectedClusters: map[string]*envoyclusterv3.Cluster{
-				"test/my-nodeport-32001": {
-					Name:           "test/my-nodeport-32001",
+				"test/my-nodeport-http": {
+					Name:           "test/my-nodeport-http",
 					ConnectTimeout: ptypes.DurationProto(clusterConnectTimeout),
 					ClusterDiscoveryType: &envoyclusterv3.Cluster_Type{
 						Type: envoyclusterv3.Cluster_STATIC,
 					},
 					LbPolicy: envoyclusterv3.Cluster_ROUND_ROBIN,
 					LoadAssignment: &envoyendpointv3.ClusterLoadAssignment{
-						ClusterName: "test/my-nodeport-32001",
+						ClusterName: "test/my-nodeport-http",
 						Endpoints: []*envoyendpointv3.LocalityLbEndpoints{
 							{
 								LbEndpoints: []*envoyendpointv3.LbEndpoint{
@@ -373,8 +373,8 @@ func TestSync(t *testing.T) {
 				},
 			},
 			expectedListener: map[string]*envoylistenerv3.Listener{
-				"test/my-nodeport-32001": {
-					Name: "test/my-nodeport-32001",
+				"test/my-nodeport-http": {
+					Name: "test/my-nodeport-http",
 					Address: &envoycorev3.Address{
 						Address: &envoycorev3.Address_SocketAddress{
 							SocketAddress: &envoycorev3.SocketAddress{
@@ -395,7 +395,7 @@ func TestSync(t *testing.T) {
 										TypedConfig: marshalMessage(t, &envoytcpfilterv3.TcpProxy{
 											StatPrefix: "ingress_tcp",
 											ClusterSpecifier: &envoytcpfilterv3.TcpProxy_Cluster{
-												Cluster: "test/my-nodeport-32001",
+												Cluster: "test/my-nodeport-http",
 											},
 										}),
 									},

--- a/pkg/controller/nodeport-proxy/envoymanager/resources.go
+++ b/pkg/controller/nodeport-proxy/envoymanager/resources.go
@@ -77,7 +77,7 @@ func makeAccessLog() []*envoyaccesslogv3.AccessLog {
 }
 
 // This will be used when the new expose strategy will be fully implemented
-//nolint:unused
+//nolint:unused,deadcode
 func makeSNIFilterChain(service *corev1.Service, p portHostMapping) []*envoylistenerv3.FilterChain {
 	var sniFilterChains []*envoylistenerv3.FilterChain
 
@@ -139,7 +139,7 @@ func (r *Reconciler) makeSNIListener() *envoylistenerv3.Listener {
 }
 
 // This will be used when the new expose strategy will be fully implemented
-//nolint:unused
+//nolint:unused,deadcode
 func makeTunnelingVirtualHosts(service *corev1.Service) []*envoyroutev3.VirtualHost {
 	var virtualhosts []*envoyroutev3.VirtualHost
 	serviceKey := ServiceKey(service)
@@ -208,8 +208,7 @@ func (r *Reconciler) makeTunnelingListener() *envoylistenerv3.Listener {
 
 	HTTPManagerConfigMarshalled, err := ptypes.MarshalAny(httpmanager)
 	if err != nil {
-		errors.Wrap(err, "failed to marshal HTTP Connection Manager")
-		panic(err)
+		panic(errors.Wrap(err, "failed to marshal HTTP Connection Manager"))
 	}
 
 	r.log.Debugf("Using a listener on port %d", r.EnvoyHTTP2ConnectListenerPort)

--- a/pkg/controller/nodeport-proxy/envoymanager/utils.go
+++ b/pkg/controller/nodeport-proxy/envoymanager/utils.go
@@ -76,6 +76,14 @@ func ServiceKey(service *corev1.Service) string {
 	return fmt.Sprintf("%s/%s", service.Namespace, service.Name)
 }
 
+// ServicePortKey returns a string used to identify the given ServicePort.
+func ServicePortKey(serviceKey string, servicePort *corev1.ServicePort) string {
+	if servicePort.Name == "" {
+		return serviceKey
+	}
+	return fmt.Sprintf("%s-%s", serviceKey, servicePort.Name)
+}
+
 func isExposed(obj metav1.Object, exposeAnnotationKey string) bool {
 	return len(extractExposeTypes(obj, exposeAnnotationKey)) > 0
 }


### PR DESCRIPTION
**What this PR does / why we need it**:
Introduces functions to the "nodeport-proxy" to create Envoy's clusters and listeners for the new expose strategy.

**Does this PR introduce a user-facing change?**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If  no release note is required, just write "NONE".
-->
```release-note
NONE
```
