### PR TITLE
Add new annotations to control the way envoy-manager exposes the services

### DIFF
--- a/pkg/controller/nodeport-proxy/envoymanager/controller.go
+++ b/pkg/controller/nodeport-proxy/envoymanager/controller.go
@@ -57,6 +57,16 @@ type Options struct {
 	EnvoyAdminPort int
 	// EnvoyStatsPort is the port used to expose Envoy stats.
 	EnvoyStatsPort int
+
+	// EnvoySNIListenerPort is the port used by the SNI Listener.
+	// When the value is less or equal than 0 the SNI Listener is disabled and
+	// won't be configured in Envoy.
+	EnvoySNIListenerPort int
+	// EnvoyHTTP2ConnectListenerPort is the port used to listen for HTTP/2
+	// CONNECT requests.
+	// When the value is less or equal than 0 the HTTP/2 CONNECT Listener is
+	// disabled and won't be configured in Envoy.
+	EnvoyHTTP2ConnectListenerPort int
 }
 
 // NewReconciler returns a new Reconciler or an error if something goes wrong

--- a/pkg/controller/nodeport-proxy/envoymanager/helper.go
+++ b/pkg/controller/nodeport-proxy/envoymanager/helper.go
@@ -17,19 +17,135 @@ limitations under the License.
 package envoymanager
 
 import (
+	"encoding/json"
 	"fmt"
+	"strings"
+
+	"github.com/pkg/errors"
 
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/util/sets"
+)
+
+// ExposeType defines the strategy used to expose the service.
+type ExposeType string
+
+func ExposeTypeFromString(s string) (ExposeType, bool) {
+	switch ExposeType(s) {
+	case NodePortType:
+		return NodePortType, true
+	case SNIType:
+		return SNIType, true
+	case HTTP2ConnectType:
+		return HTTP2ConnectType, true
+	default:
+		return NodePortType, false
+	}
+}
+
+const (
+	// NodePortType is the default ExposeType which creates a listener for each
+	// NodePort.
+	NodePortType ExposeType = "NodePort"
+	// SNIType configures Envoy to route TLS streams based on SNI
+	// without terminating them.
+	SNIType = "SNI"
+	// HTTP2ConnectType configures Envoy to terminate HTTP/2 Connect requests.
+	HTTP2ConnectType = "HTTP2Connect"
+)
+
+const (
+	DefaultExposeAnnotationKey = "nodeport-proxy.k8s.io/expose"
+	// PortHostMappingAnnotationKey contains the mapping between the port to be
+	// exposed and the hostname, this is only used when the ExposeType is
+	// SNIType.
+	PortHostMappingAnnotationKey = "nodeport-proxy.k8s.io/port-mapping"
 )
 
 func ServiceKey(service *corev1.Service) string {
 	return fmt.Sprintf("%s/%s", service.Namespace, service.Name)
 }
 
-func isExposed(obj metav1.Object, annotation string) bool {
+func isExposed(obj metav1.Object, exposeAnnotationKey string) bool {
+	return len(extractExposeTypes(obj, exposeAnnotationKey)) > 0
+}
+
+func (e ExposeType) String() string {
+	return string(e)
+}
+
+func extractExposeTypes(obj metav1.Object, exposeAnnotationKey string) []ExposeType {
+	var types []ExposeType
 	if obj.GetAnnotations() == nil {
-		return false
+		return types
 	}
-	return obj.GetAnnotations()[annotation] == "true"
+	// When legacy value 'true' is encountered NodePortType is returned for
+	// backward compatibility.
+	val := obj.GetAnnotations()[exposeAnnotationKey]
+	if val == "true" {
+		return append(types, NodePortType)
+	}
+	// Parse the comma separated list and return the list of ExposeType
+	ts := strings.Split(val, ",")
+	for i := range ts {
+		ts[i] = strings.TrimSpace(ts[i])
+	}
+	for _, t := range sets.NewString(ts...).List() {
+		e, ok := ExposeTypeFromString(t)
+		if !ok {
+			return nil
+		}
+		types = append(types, e)
+	}
+	return types
+}
+
+// portNamesSet returns the set of port names extracted from the given Service.
+func portNamesSet(svc *corev1.Service) sets.String {
+	portNames := sets.NewString()
+	for _, p := range svc.Spec.Ports {
+		if p.Protocol == corev1.ProtocolTCP {
+			portNames.Insert(p.Name)
+		}
+	}
+	return portNames
+}
+
+type portHostMapping map[string]string
+
+func portHostMappingFromService(svc *corev1.Service) (portHostMapping, error) {
+	m := portHostMapping{}
+	a := svc.GetAnnotations()
+	if a == nil {
+		return m, fmt.Errorf("service %s/%s does not contain port mapping annotation", svc.Namespace, svc.Name)
+	}
+	val := a[PortHostMappingAnnotationKey]
+	err := json.Unmarshal([]byte(val), m)
+	if err != nil {
+		return m, errors.Wrap(err, "failed to unmarshal port host mapping for service")
+	}
+	return m, nil
+}
+
+func (p portHostMapping) validate(svc *corev1.Service) error {
+	portNames, hosts := p.portHostSets()
+	if len(p) > hosts.Len() {
+		return fmt.Errorf("duplicated hostname in port host mapping of service: %v", hosts.List())
+	}
+	actualPortNames := portNamesSet(svc)
+	if diff := portNames.Difference(actualPortNames); len(diff) > 0 {
+		return fmt.Errorf("ports declared in port host mapping not found in service: %v", diff.List())
+	}
+	return nil
+}
+
+func (p portHostMapping) portHostSets() (sets.String, sets.String) {
+	hosts := sets.NewString()
+	portNames := sets.NewString()
+	for portName, host := range p {
+		hosts.Insert(host)
+		portNames.Insert(portName)
+	}
+	return portNames, hosts
 }

--- a/pkg/controller/nodeport-proxy/envoymanager/resources.go
+++ b/pkg/controller/nodeport-proxy/envoymanager/resources.go
@@ -42,6 +42,8 @@ import (
 	envoywellknown "github.com/envoyproxy/go-control-plane/pkg/wellknown"
 )
 
+const clusterConnectTimeout = 1 * time.Second
+
 func (r *Reconciler) makeListenersAndClustersForService(service *corev1.Service, endpoints *corev1.Endpoints) (listeners []envoycachetype.Resource, clusters []envoycachetype.Resource) {
 	serviceKey := ServiceKey(service)
 	for _, servicePort := range service.Spec.Ports {

--- a/pkg/controller/nodeport-proxy/envoymanager/utils_test.go
+++ b/pkg/controller/nodeport-proxy/envoymanager/utils_test.go
@@ -92,8 +92,8 @@ func TestExtractPortHostMappingFromService(t *testing.T) {
 		},
 		{
 			name:        "Multiple port mappings",
-			service:     makeService(`{"port-a": "host.com", "port-b": "another-host.com"}`, ""),
-			wantMapping: portHostMapping{"port-a": "host.com", "port-b": "another-host.com"},
+			service:     makeService(`{"port-a": "admin.host.com", "port-b": "host.com"}`, ""),
+			wantMapping: portHostMapping{"port-a": "admin.host.com", "port-b": "host.com"},
 		},
 		{
 			name:        "Missing annotations",
@@ -149,7 +149,7 @@ func TestPortHostMappingValidate(t *testing.T) {
 				corev1.ServicePort{Name: "port-a", Protocol: corev1.ProtocolTCP},
 				corev1.ServicePort{Name: "port-b", Protocol: corev1.ProtocolTCP},
 				corev1.ServicePort{Name: "port-c", Protocol: corev1.ProtocolTCP}),
-			mapping: portHostMapping{"port-a": "host-a.com", "port-b": "host-b.com"},
+			mapping: portHostMapping{"port-a": "admin.host.com", "port-b": "host.com"},
 		},
 		{
 			name: "Duplicated ports",
@@ -157,7 +157,14 @@ func TestPortHostMappingValidate(t *testing.T) {
 				corev1.ServicePort{Name: "port-a", Protocol: corev1.ProtocolTCP},
 				corev1.ServicePort{Name: "port-b", Protocol: corev1.ProtocolTCP},
 				corev1.ServicePort{Name: "port-c", Protocol: corev1.ProtocolTCP}),
-			mapping: portHostMapping{"port-a": "host-a.com", "port-b": "host-b.com", "port-c": "host-b.com"},
+			mapping: portHostMapping{"port-a": "admin.host.com", "port-b": "host.com", "port-c": "host.com"},
+			wantErr: true,
+		},
+		{
+			name: "Mapping reference missing ports",
+			svc: makeService("", "",
+				corev1.ServicePort{Name: "port-a", Protocol: corev1.ProtocolTCP}),
+			mapping: portHostMapping{"port-a": "admin.host.com", "port-b": "host.com"},
 			wantErr: true,
 		},
 	}

--- a/pkg/controller/nodeport-proxy/envoymanager/utils_test.go
+++ b/pkg/controller/nodeport-proxy/envoymanager/utils_test.go
@@ -1,0 +1,186 @@
+/*
+Copyright 2020 The Kubermatic Kubernetes Platform contributors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package envoymanager
+
+import (
+	"testing"
+
+	"github.com/go-test/deep"
+
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+func TestExtractExposeType(t *testing.T) {
+	var testcases = []struct {
+		name            string
+		svc             *corev1.Service
+		wantExposeTypes []ExposeType
+	}{
+		{
+			name:            "Legacy value",
+			svc:             makeService("", "true"),
+			wantExposeTypes: []ExposeType{NodePortType},
+		},
+		{
+			name:            "New value",
+			svc:             makeService("", "NodePort"),
+			wantExposeTypes: []ExposeType{NodePortType},
+		},
+		{
+			name:            "No value",
+			svc:             makeService("", ""),
+			wantExposeTypes: nil,
+		},
+		{
+			name:            "Both HTTP2 Connet and SNI",
+			svc:             makeService("", "HTTP2Connect, SNI"),
+			wantExposeTypes: []ExposeType{HTTP2ConnectType, SNIType},
+		},
+		{
+			name:            "Both HTTP2 Connet and SNI #2",
+			svc:             makeService("", "HTTP2Connect,SNI"),
+			wantExposeTypes: []ExposeType{HTTP2ConnectType, SNIType},
+		},
+		{
+			name:            "Malformed value",
+			svc:             makeService("", "HTTP2Connect SNI"),
+			wantExposeTypes: nil,
+		},
+		{
+			name:            "Malformed value #2",
+			svc:             makeService("", "True"),
+			wantExposeTypes: nil,
+		},
+	}
+	for _, tt := range testcases {
+		t.Run(tt.name, func(t *testing.T) {
+			e := extractExposeTypes(tt.svc, DefaultExposeAnnotationKey)
+
+			if diff := deep.Equal(tt.wantExposeTypes, e); diff != nil {
+				t.Errorf("Got export types. Diff to expected: %v", diff)
+			}
+		})
+	}
+}
+
+func TestExtractPortHostMappingFromService(t *testing.T) {
+	var testcases = []struct {
+		name        string
+		service     *corev1.Service
+		wantMapping portHostMapping
+		wantErr     bool
+	}{
+		{
+			name:        "Default port only",
+			service:     makeService(`{"": "host.com"}`, ""),
+			wantMapping: portHostMapping{"": "host.com"},
+		},
+		{
+			name:        "Multiple port mappings",
+			service:     makeService(`{"port-a": "host.com", "port-b": "another-host.com"}`, ""),
+			wantMapping: portHostMapping{"port-a": "host.com", "port-b": "another-host.com"},
+		},
+		{
+			name:        "Missing annotations",
+			service:     &corev1.Service{},
+			wantMapping: portHostMapping{},
+		},
+		{
+			name: "Missing port host mapping annotation",
+			service: &corev1.Service{
+				ObjectMeta: metav1.ObjectMeta{
+					Annotations: map[string]string{},
+				},
+			},
+			wantMapping: portHostMapping{},
+		},
+		{
+			name:        "Annotation contains malformed json",
+			service:     makeService("{sdf: a}", ""),
+			wantErr:     true,
+			wantMapping: portHostMapping{},
+		},
+	}
+	for _, tt := range testcases {
+		t.Run(tt.name, func(t *testing.T) {
+			p, err := portHostMappingFromService(tt.service)
+			if (err != nil) != tt.wantErr {
+				t.Fatalf("wantErr: %t, got %v", tt.wantErr, err)
+			}
+
+			if diff := deep.Equal(tt.wantMapping, p); diff != nil {
+				t.Errorf("Got unexpected host port mapping. Diff to expected: %v", diff)
+			}
+		})
+	}
+}
+
+func TestPortHostMappingValidate(t *testing.T) {
+	var testcases = []struct {
+		name    string
+		svc     *corev1.Service
+		mapping portHostMapping
+		wantErr bool
+	}{
+		{
+			name: "Default port",
+			svc: makeService("", "",
+				corev1.ServicePort{Name: "", Protocol: corev1.ProtocolTCP}),
+			mapping: portHostMapping{"": "host.com"},
+		},
+		{
+			name: "Multiple ports",
+			svc: makeService("", "",
+				corev1.ServicePort{Name: "port-a", Protocol: corev1.ProtocolTCP},
+				corev1.ServicePort{Name: "port-b", Protocol: corev1.ProtocolTCP},
+				corev1.ServicePort{Name: "port-c", Protocol: corev1.ProtocolTCP}),
+			mapping: portHostMapping{"port-a": "host-a.com", "port-b": "host-b.com"},
+		},
+		{
+			name: "Duplicated ports",
+			svc: makeService("", "",
+				corev1.ServicePort{Name: "port-a", Protocol: corev1.ProtocolTCP},
+				corev1.ServicePort{Name: "port-b", Protocol: corev1.ProtocolTCP},
+				corev1.ServicePort{Name: "port-c", Protocol: corev1.ProtocolTCP}),
+			mapping: portHostMapping{"port-a": "host-a.com", "port-b": "host-b.com", "port-c": "host-b.com"},
+			wantErr: true,
+		},
+	}
+	for _, tt := range testcases {
+		t.Run(tt.name, func(t *testing.T) {
+			if err := tt.mapping.validate(tt.svc); (err != nil) != tt.wantErr {
+				t.Fatalf("wantErr: %t, got: %v", tt.wantErr, err)
+			}
+		})
+	}
+}
+
+func makeService(portHostMappingVal string, exposeTypeVal string, ports ...corev1.ServicePort) *corev1.Service {
+	return &corev1.Service{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "foo",
+			Annotations: map[string]string{
+				PortHostMappingAnnotationKey: portHostMappingVal,
+				DefaultExposeAnnotationKey:   exposeTypeVal,
+			},
+		},
+		Spec: corev1.ServiceSpec{
+			Ports: ports,
+		},
+	}
+}


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR introduces new annotations that are processed by the `envoy-manager` to expose services with SNI and HTTP2 connect strategy. #5805

Before this  PR the only allowed "exposing" annotation (i.e. `"nodeport-proxy.k8s.io/expose"` by default) value was `true`. Now it is possible to add a comma-separated list of `ExposeType`s that don't just define if the service is exposed, but also how. Allowed values are `NodePort`, `SNI` and `HTTP2Connect`. The value `true` is still valid for backward compatibility and it is equivalent to `NodePort`.

Another annotation has been introduced specifically for the `SNI` expose type, `nodeport-proxy.k8s.io/port-mapping`, which contains a JSON encoded mapping between service port names and the FQDNs that will be used for the service.

This PR does not implement the new expose types, the implementation is deferred to a follow-up PR.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:
This PR does not fully implement the new expose types.

**Documentation**:
<!-- Add links to the related documentation changes related to this pull request. E.g. the link to the kubermatic/docs pull request. -->

**Does this PR introduce a user-facing change?**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If  no release note is required, just write "NONE".
-->
```release-note
NONE
```
