### PR TITLE
raise cert-manager resource limits to prevent OOMKills

### DIFF
--- a/charts/cert-manager/Chart.yaml
+++ b/charts/cert-manager/Chart.yaml
@@ -14,7 +14,7 @@
 
 apiVersion: v1
 name: cert-manager
-version: 1.4.0
+version: 1.4.1
 appVersion: v0.16.1
 description: A Helm chart for cert-manager
 keywords:

--- a/charts/cert-manager/values.yaml
+++ b/charts/cert-manager/values.yaml
@@ -31,10 +31,9 @@ certManager:
     resources:
       requests:
         cpu: 100m
-        memory: 30Mi
+        memory: 64Mi
       limits:
-        cpu: 300m
-        memory: 50Mi
+        memory: 128Mi
 
     affinity: {}
     nodeSelector: {}
@@ -63,8 +62,7 @@ certManager:
         cpu: 100m
         memory: 30Mi
       limits:
-        cpu: 250m
-        memory: 30Mi
+        memory: 128Mi
 
     affinity: {}
     nodeSelector: {}


### PR DESCRIPTION
**What this PR does / why we need it**:
The 30MB limit for cert-manager is too restrictive, it began to crashloop even just managing 5 certificates in my cluster.

**Does this PR introduce a user-facing change?**:
```release-note
Raise cert-manager resource limits to prevent OOMKills
```
