### PR TITLE
Implement new expose types in EnvoyManager

### DIFF
--- a/pkg/controller/nodeport-proxy/envoymanager/controller_test.go
+++ b/pkg/controller/nodeport-proxy/envoymanager/controller_test.go
@@ -264,7 +264,7 @@ func TestSync(t *testing.T) {
 				"test/my-service-https": makeCluster(t, "test/my-service-https", 8443, "172.16.0.1"),
 			},
 			expectedListener: map[string]*envoylistenerv3.Listener{
-				"http2connect_listener": makeHttp2ConnectListener(t, 443, hostClusterName{Cluster: "test/my-service-https", Hostname: "my-service.test.svc.cluster.local:443"}),
+				"http2connect_listener": makeHTTP2ConnectListener(t, 443, hostClusterName{Cluster: "test/my-service-https", Hostname: "my-service.test.svc.cluster.local:443"}),
 			},
 		},
 		{
@@ -411,7 +411,7 @@ func makeSNIListener(t *testing.T, portValue uint32, hostClusterNames ...hostClu
 	return sb.makeSNIListener(fcs...)
 }
 
-func makeHttp2ConnectListener(t *testing.T, portValue int, hostClusterNames ...hostClusterName) *envoylistenerv3.Listener {
+func makeHTTP2ConnectListener(t *testing.T, portValue int, hostClusterNames ...hostClusterName) *envoylistenerv3.Listener {
 	var vhs []*envoyroutev3.VirtualHost
 	for _, hostClusterName := range hostClusterNames {
 		vhs = append(vhs, &envoyroutev3.VirtualHost{

--- a/pkg/controller/nodeport-proxy/envoymanager/controller_test.go
+++ b/pkg/controller/nodeport-proxy/envoymanager/controller_test.go
@@ -20,7 +20,7 @@ import (
 	"context"
 	"testing"
 
-	"go.uber.org/zap"
+	"go.uber.org/zap/zaptest"
 
 	"github.com/go-test/deep"
 	"github.com/gogo/protobuf/proto"
@@ -501,7 +501,7 @@ func TestSync(t *testing.T) {
 
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
-			log := zap.NewNop().Sugar()
+			log := zaptest.NewLogger(t).Sugar()
 			client := fakectrlruntimeclient.NewFakeClient(test.resources...)
 			c, _, _ := NewReconciler(
 				context.TODO(),
@@ -584,7 +584,7 @@ func TestEndpointToService(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			log := zap.NewNop().Sugar()
+			log := zaptest.NewLogger(t).Sugar()
 			client := fakectrlruntimeclient.NewFakeClient(tt.resources...)
 			res := (&Reconciler{
 				Options: Options{ExposeAnnotationKey: DefaultExposeAnnotationKey},
@@ -654,7 +654,7 @@ func TestExposeAnnotationPredicate(t *testing.T) {
 			if tt.annotationKey == "" {
 				tt.annotationKey = DefaultExposeAnnotationKey
 			}
-			p := exposeAnnotationPredicate{annotation: tt.annotationKey, log: zap.NewNop().Sugar()}
+			p := exposeAnnotationPredicate{annotation: tt.annotationKey, log: zaptest.NewLogger(t).Sugar()}
 			if got, exp := p.Create(event.CreateEvent{Meta: tt.obj, Object: tt.obj}), tt.expectAccept; got != exp {
 				t.Errorf("expect create accepted %t, but got %t for object: %+v", exp, got, *tt.obj)
 			}

--- a/pkg/controller/nodeport-proxy/envoymanager/utils.go
+++ b/pkg/controller/nodeport-proxy/envoymanager/utils.go
@@ -206,7 +206,7 @@ func (p portHostMapping) validate(svc *corev1.Service) error {
 	}
 	tcpPortNames := portNamesSet(svc, func(p corev1.ServicePort) bool { return p.Protocol == corev1.ProtocolTCP })
 	if diff := portNames.Difference(tcpPortNames); len(diff) > 0 {
-		return fmt.Errorf("port name(s) not found in TCP servie ports: %v", diff.List())
+		return fmt.Errorf("port name(s) not found in TCP service ports: %v", diff.List())
 	}
 	return nil
 }

--- a/pkg/controller/nodeport-proxy/envoymanager/utils_test.go
+++ b/pkg/controller/nodeport-proxy/envoymanager/utils_test.go
@@ -23,48 +23,49 @@ import (
 
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/util/sets"
 )
 
 func TestExtractExposeType(t *testing.T) {
 	var testcases = []struct {
 		name            string
 		svc             *corev1.Service
-		wantExposeTypes []ExposeType
+		wantExposeTypes sets.String
 	}{
 		{
 			name:            "Legacy value",
 			svc:             makeService("", "true"),
-			wantExposeTypes: []ExposeType{NodePortType},
+			wantExposeTypes: sets.NewString(NodePortType.String()),
 		},
 		{
 			name:            "New value",
 			svc:             makeService("", "NodePort"),
-			wantExposeTypes: []ExposeType{NodePortType},
+			wantExposeTypes: sets.NewString(NodePortType.String()),
 		},
 		{
 			name:            "No value",
 			svc:             makeService("", ""),
-			wantExposeTypes: nil,
+			wantExposeTypes: sets.NewString(),
 		},
 		{
 			name:            "Both HTTP2 Connet and SNI",
 			svc:             makeService("", "HTTP2Connect, SNI"),
-			wantExposeTypes: []ExposeType{HTTP2ConnectType, SNIType},
+			wantExposeTypes: sets.NewString(HTTP2ConnectType.String(), SNIType.String()),
 		},
 		{
 			name:            "Both HTTP2 Connet and SNI #2",
 			svc:             makeService("", "HTTP2Connect,SNI"),
-			wantExposeTypes: []ExposeType{HTTP2ConnectType, SNIType},
+			wantExposeTypes: sets.NewString(HTTP2ConnectType.String(), SNIType.String()),
 		},
 		{
 			name:            "Malformed value",
 			svc:             makeService("", "HTTP2Connect SNI"),
-			wantExposeTypes: nil,
+			wantExposeTypes: sets.NewString(),
 		},
 		{
 			name:            "Malformed value #2",
 			svc:             makeService("", "True"),
-			wantExposeTypes: nil,
+			wantExposeTypes: sets.NewString(),
 		},
 	}
 	for _, tt := range testcases {

--- a/pkg/controller/nodeport-proxy/envoymanager/utils_test.go
+++ b/pkg/controller/nodeport-proxy/envoymanager/utils_test.go
@@ -23,49 +23,48 @@ import (
 
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/apimachinery/pkg/util/sets"
 )
 
 func TestExtractExposeType(t *testing.T) {
 	var testcases = []struct {
 		name            string
 		svc             *corev1.Service
-		wantExposeTypes sets.String
+		wantExposeTypes ExposeTypes
 	}{
 		{
 			name:            "Legacy value",
 			svc:             makeService("", "true"),
-			wantExposeTypes: sets.NewString(NodePortType.String()),
+			wantExposeTypes: NewExposeTypes(NodePortType),
 		},
 		{
 			name:            "New value",
 			svc:             makeService("", "NodePort"),
-			wantExposeTypes: sets.NewString(NodePortType.String()),
+			wantExposeTypes: NewExposeTypes(NodePortType),
 		},
 		{
 			name:            "No value",
 			svc:             makeService("", ""),
-			wantExposeTypes: sets.NewString(),
+			wantExposeTypes: NewExposeTypes(),
 		},
 		{
 			name:            "Both HTTP2 Connet and SNI",
 			svc:             makeService("", "HTTP2Connect, SNI"),
-			wantExposeTypes: sets.NewString(HTTP2ConnectType.String(), SNIType.String()),
+			wantExposeTypes: NewExposeTypes(HTTP2ConnectType, SNIType),
 		},
 		{
 			name:            "Both HTTP2 Connet and SNI #2",
 			svc:             makeService("", "HTTP2Connect,SNI"),
-			wantExposeTypes: sets.NewString(HTTP2ConnectType.String(), SNIType.String()),
+			wantExposeTypes: NewExposeTypes(HTTP2ConnectType, SNIType),
 		},
 		{
 			name:            "Malformed value",
 			svc:             makeService("", "HTTP2Connect SNI"),
-			wantExposeTypes: sets.NewString(),
+			wantExposeTypes: NewExposeTypes(),
 		},
 		{
 			name:            "Malformed value #2",
 			svc:             makeService("", "True"),
-			wantExposeTypes: sets.NewString(),
+			wantExposeTypes: NewExposeTypes(),
 		},
 	}
 	for _, tt := range testcases {
@@ -119,7 +118,7 @@ func TestExtractPortHostMappingFromService(t *testing.T) {
 	}
 	for _, tt := range testcases {
 		t.Run(tt.name, func(t *testing.T) {
-			p, err := portHostMappingFromService(tt.service)
+			p, err := portHostMappingFromAnnotation(tt.service)
 			if (err != nil) != tt.wantErr {
 				t.Fatalf("wantErr: %t, got %v", tt.wantErr, err)
 			}

--- a/pkg/test/builder.go
+++ b/pkg/test/builder.go
@@ -1,0 +1,197 @@
+/*
+Copyright 2020 The Kubermatic Kubernetes Platform contributors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package test
+
+import (
+	"time"
+
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/apimachinery/pkg/util/intstr"
+)
+
+type NamespacedName types.NamespacedName
+
+type ObjectBuilder metav1.ObjectMeta
+
+func (b *ObjectBuilder) WithLabel(key, value string) *ObjectBuilder {
+	if b.Labels == nil {
+		b.Labels = map[string]string{}
+	}
+	b.Labels[key] = value
+	return b
+}
+
+func (b *ObjectBuilder) WithAnnotation(key, value string) *ObjectBuilder {
+	if b.Annotations == nil {
+		b.Annotations = map[string]string{}
+	}
+	b.Annotations[key] = value
+	return b
+}
+
+func (b *ObjectBuilder) WithCreationTimestamp(time time.Time) *ObjectBuilder {
+	b.CreationTimestamp = metav1.NewTime(time)
+	return b
+}
+
+// ServiceBuilder is a builder for v1.Service.
+type ServiceBuilder struct {
+	ObjectBuilder
+
+	serviceType  corev1.ServiceType
+	servicePorts []corev1.ServicePort
+}
+
+// NewServiceBuilder returns a ServiceBuilder to be used to build a v1.Service
+// with name and namespace given in input.
+func NewServiceBuilder(nn NamespacedName) *ServiceBuilder {
+	return &ServiceBuilder{
+		ObjectBuilder: ObjectBuilder{
+			Name:      nn.Name,
+			Namespace: nn.Namespace,
+		},
+		serviceType: corev1.ServiceTypeClusterIP,
+	}
+}
+
+func (b *ServiceBuilder) WithAnnotation(key, value string) *ServiceBuilder {
+	_ = b.ObjectBuilder.WithAnnotation(key, value)
+	return b
+}
+
+func (b *ServiceBuilder) WithCreationTimestamp(time time.Time) *ServiceBuilder {
+	_ = b.ObjectBuilder.WithCreationTimestamp(time)
+	return b
+}
+
+func (b *ServiceBuilder) WithServiceType(serviceType corev1.ServiceType) *ServiceBuilder {
+	b.serviceType = serviceType
+	return b
+}
+
+func (b *ServiceBuilder) WithServicePorts(sp ...corev1.ServicePort) *ServiceBuilder {
+	b.servicePorts = append(b.servicePorts, sp...)
+	return b
+}
+
+func (b *ServiceBuilder) WithServicePort(
+	name string,
+	port int32,
+	nodePort int32,
+	targetPort intstr.IntOrString,
+	protocol corev1.Protocol) *ServiceBuilder {
+	return b.WithServicePorts(corev1.ServicePort{
+		Name:       name,
+		NodePort:   nodePort,
+		Port:       port,
+		TargetPort: targetPort,
+		Protocol:   protocol,
+	})
+}
+
+func (b ServiceBuilder) Build() *corev1.Service {
+	return &corev1.Service{
+		ObjectMeta: metav1.ObjectMeta(b.ObjectBuilder),
+		Spec: corev1.ServiceSpec{
+			Type:  b.serviceType,
+			Ports: b.servicePorts,
+		},
+	}
+}
+
+// EndpointsBuilder is a builder for v1.Endpoints.
+type EndpointsBuilder struct {
+	ObjectBuilder
+
+	epsSubsets []corev1.EndpointSubset
+}
+
+// NewServiceBuilder returns a ServiceBuilder to be used to build a
+// v1.Endpoints with name and namespace given in input.
+func NewEndpointsBuilder(nn NamespacedName) *EndpointsBuilder {
+	return &EndpointsBuilder{
+		ObjectBuilder: ObjectBuilder{
+			Name:      nn.Name,
+			Namespace: nn.Namespace,
+		},
+	}
+}
+
+func (b *EndpointsBuilder) WithEndpointsSubset() *epsSubsetBuilder {
+	return &epsSubsetBuilder{eb: b}
+}
+
+func (b *EndpointsBuilder) Build() *corev1.Endpoints {
+	return &corev1.Endpoints{
+		ObjectMeta: metav1.ObjectMeta(b.ObjectBuilder),
+		Subsets:    b.epsSubsets,
+	}
+}
+
+type epsSubsetBuilder struct {
+	// Used to come back to main builder
+	eb *EndpointsBuilder
+
+	epsAddresses         []corev1.EndpointAddress
+	epsNotReadyAddresses []corev1.EndpointAddress
+	epsPorts             []corev1.EndpointPort
+}
+
+func (b *epsSubsetBuilder) WithReadyAddressIP(ip string) *epsSubsetBuilder {
+	return b.WithReadyAddresses(corev1.EndpointAddress{IP: ip})
+}
+
+func (b *epsSubsetBuilder) WithNotReadyAddressIP(ip string) *epsSubsetBuilder {
+	return b.WithNotReadyAddresses(corev1.EndpointAddress{IP: ip})
+}
+
+func (b *epsSubsetBuilder) WithReadyAddresses(eas ...corev1.EndpointAddress) *epsSubsetBuilder {
+	b.epsAddresses = append(b.epsAddresses, eas...)
+	return b
+}
+
+func (b *epsSubsetBuilder) WithNotReadyAddresses(eas ...corev1.EndpointAddress) *epsSubsetBuilder {
+	b.epsNotReadyAddresses = append(b.epsNotReadyAddresses, eas...)
+	return b
+}
+
+func (b *epsSubsetBuilder) WithEndpointPorts(eps ...corev1.EndpointPort) *epsSubsetBuilder {
+	b.epsPorts = append(b.epsPorts, eps...)
+	return b
+}
+
+func (b *epsSubsetBuilder) WithEndpointPort(
+	name string,
+	port int32,
+	protocol corev1.Protocol) *epsSubsetBuilder {
+	return b.WithEndpointPorts(corev1.EndpointPort{
+		Name:     name,
+		Port:     port,
+		Protocol: protocol,
+	})
+}
+
+func (b *epsSubsetBuilder) DoneWithEndpointSubset(eps ...corev1.EndpointPort) *EndpointsBuilder {
+	b.epsPorts = append(b.epsPorts, eps...)
+	b.eb.epsSubsets = append(b.eb.epsSubsets, corev1.EndpointSubset{
+		Addresses: b.epsAddresses,
+		Ports:     b.epsPorts,
+	})
+	return b.eb
+}

--- a/pkg/test/builder.go
+++ b/pkg/test/builder.go
@@ -50,7 +50,7 @@ func (b *ObjectBuilder) WithCreationTimestamp(time time.Time) *ObjectBuilder {
 	return b
 }
 
-// ServiceBuilder is a builder for v1.Service.
+// ServiceBuilder is a builder providing a fluent API for v1.Service creation.
 type ServiceBuilder struct {
 	ObjectBuilder
 
@@ -115,7 +115,8 @@ func (b ServiceBuilder) Build() *corev1.Service {
 	}
 }
 
-// EndpointsBuilder is a builder for v1.Endpoints.
+// EndpointsBuilder is a builder providing a fluent API for v1.Endpoints
+// creation.
 type EndpointsBuilder struct {
 	ObjectBuilder
 
@@ -133,6 +134,10 @@ func NewEndpointsBuilder(nn NamespacedName) *EndpointsBuilder {
 	}
 }
 
+// WithEndpointsSubset starts the creation of an Endpoints Subset, the creation
+// must me terminated with a call to DoneWithEndpointSubset, after ports and
+// addresses are added.
+// nolint:golint
 func (b *EndpointsBuilder) WithEndpointsSubset() *epsSubsetBuilder {
 	return &epsSubsetBuilder{eb: b}
 }
@@ -187,6 +192,9 @@ func (b *epsSubsetBuilder) WithEndpointPort(
 	})
 }
 
+// DoneWithEndpointSubset concludes the creation of the Subset and returns the
+// EndpointsBuilder to start the creation of a new Subset or create the
+// Endpoints with Build method.
 func (b *epsSubsetBuilder) DoneWithEndpointSubset(eps ...corev1.EndpointPort) *EndpointsBuilder {
 	b.epsPorts = append(b.epsPorts, eps...)
 	b.eb.epsSubsets = append(b.eb.epsSubsets, corev1.EndpointSubset{


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR implements the new expose types in EnvoyManager (#5805), which will be used for the new expose strategy (#4942).

This will allow configuring two new entry point in Envoy:

- SNI entry point will allow routing the TLS traffic based on SNI. Services will be exposed by this entrypoint when the expose annotation (i.e. `nodeport-proxy.k8s.io/expose` by default) value includes the keyword "SNI". The mapping between FQDN and service ports will be made by mean of `nodeport-proxy.k8s.io/port-mapping` annotation, which contains a JSON object (e.g. for exposing a single port named `https` use `{"https": "https.host.com"}`).
- HTTP2 Connect entry point will allow terminating HTTP2 CONNECT requests, and forwarding the traffic to the proper service endpoints. Services will be exposed by this entrypoint when the expose annotation (i.e. `nodeport-proxy.k8s.io/expose` by default) value includes the keyword "HTTP2Connect".

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Documentation**:
<!-- Add links to the related documentation changes related to this pull request. E.g. the link to the kubermatic/docs pull request. -->

**Does this PR introduce a user-facing change?**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If  no release note is required, just write "NONE".
-->
```release-note
NONE
```
