### PR TITLE
Nodeport-proxy e2e extensions for the new expose strategy.

### DIFF
--- a/pkg/controller/nodeport-proxy/envoymanager/resources.go
+++ b/pkg/controller/nodeport-proxy/envoymanager/resources.go
@@ -309,7 +309,7 @@ func (sb *snapshotBuilder) makeTunnelingVirtualHosts(service *corev1.Service) (v
 
 func (sb *snapshotBuilder) makeTunnelingListener(vhs ...*envoyroutev3.VirtualHost) *envoylistenerv3.Listener {
 	hcm := &envoyhttpconnectionmanagerv3.HttpConnectionManager{
-		CodecType:  envoyhttpconnectionmanagerv3.HttpConnectionManager_HTTP2,
+		CodecType:  envoyhttpconnectionmanagerv3.HttpConnectionManager_AUTO,
 		StatPrefix: "ingress_http",
 		RouteSpecifier: &envoyhttpconnectionmanagerv3.HttpConnectionManager_RouteConfig{
 			RouteConfig: &envoyroutev3.RouteConfiguration{

--- a/pkg/controller/operator/seed/resources/nodeportproxy/deployments.go
+++ b/pkg/controller/operator/seed/resources/nodeportproxy/deployments.go
@@ -41,7 +41,7 @@ const (
 	UpdaterDeploymentName = "nodeport-proxy-updater"
 	EnvoyPort             = 8002
 	EnvoySNIPort          = 6443
-	EnvoyTunnelingPort    = 8080
+	EnvoyTunnelingPort    = 8088
 )
 
 func EnvoyDeploymentCreator(cfg *operatorv1alpha1.KubermaticConfiguration, seed *kubermaticv1.Seed, versions kubermatic.Versions) reconciling.NamedDeploymentCreatorGetter {

--- a/pkg/test/builder.go
+++ b/pkg/test/builder.go
@@ -56,6 +56,7 @@ type ServiceBuilder struct {
 
 	serviceType  corev1.ServiceType
 	servicePorts []corev1.ServicePort
+	selector     map[string]string
 }
 
 // NewServiceBuilder returns a ServiceBuilder to be used to build a v1.Service
@@ -70,6 +71,11 @@ func NewServiceBuilder(nn NamespacedName) *ServiceBuilder {
 	}
 }
 
+func (b *ServiceBuilder) WithLabel(key, value string) *ServiceBuilder {
+	_ = b.ObjectBuilder.WithLabel(key, value)
+	return b
+}
+
 func (b *ServiceBuilder) WithAnnotation(key, value string) *ServiceBuilder {
 	_ = b.ObjectBuilder.WithAnnotation(key, value)
 	return b
@@ -82,6 +88,11 @@ func (b *ServiceBuilder) WithCreationTimestamp(time time.Time) *ServiceBuilder {
 
 func (b *ServiceBuilder) WithServiceType(serviceType corev1.ServiceType) *ServiceBuilder {
 	b.serviceType = serviceType
+	return b
+}
+
+func (b *ServiceBuilder) WithSelector(selector map[string]string) *ServiceBuilder {
+	b.selector = selector
 	return b
 }
 
@@ -109,8 +120,9 @@ func (b ServiceBuilder) Build() *corev1.Service {
 	return &corev1.Service{
 		ObjectMeta: metav1.ObjectMeta(b.ObjectBuilder),
 		Spec: corev1.ServiceSpec{
-			Type:  b.serviceType,
-			Ports: b.servicePorts,
+			Type:     b.serviceType,
+			Ports:    b.servicePorts,
+			Selector: b.selector,
 		},
 	}
 }

--- a/pkg/test/e2e/nodeport-proxy/deployer.go
+++ b/pkg/test/e2e/nodeport-proxy/deployer.go
@@ -28,6 +28,7 @@ import (
 	"k8c.io/kubermatic/v2/pkg/controller/operator/seed/resources/nodeportproxy"
 	kubermaticv1 "k8c.io/kubermatic/v2/pkg/crd/kubermatic/v1"
 	operatorv1alpha1 "k8c.io/kubermatic/v2/pkg/crd/operator/v1alpha1"
+	features "k8c.io/kubermatic/v2/pkg/features"
 	"k8c.io/kubermatic/v2/pkg/resources/reconciling"
 	"k8c.io/kubermatic/v2/pkg/version/kubermatic"
 
@@ -36,6 +37,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/apimachinery/pkg/util/sets"
 	ctrlclient "sigs.k8s.io/controller-runtime/pkg/client"
 )
 
@@ -76,6 +78,9 @@ func (d *Deployer) SetUp() error {
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      "kubermatic",
 			Namespace: d.Namespace,
+		},
+		Spec: operatorv1alpha1.KubermaticConfigurationSpec{
+			FeatureGates: sets.NewString(features.TunnelingExposeStrategy),
 		},
 	}
 

--- a/pkg/test/e2e/nodeport-proxy/nodeport_proxy_test.go
+++ b/pkg/test/e2e/nodeport-proxy/nodeport_proxy_test.go
@@ -19,16 +19,21 @@ limitations under the License.
 package nodeportproxy
 
 import (
+	"fmt"
+
 	"github.com/onsi/ginkgo"
 	"github.com/onsi/gomega"
 
-	"k8c.io/kubermatic/v2/pkg/controller/nodeport-proxy/envoymanager"
-
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/util/intstr"
 	"k8s.io/apimachinery/pkg/util/sets"
+
+	"k8c.io/kubermatic/v2/pkg/controller/nodeport-proxy/envoymanager"
+	"k8c.io/kubermatic/v2/pkg/test"
 )
 
 var _ = ginkgo.Describe("NodeportProxy", func() {
-	ginkgo.Describe("services of type node port", func() {
+	ginkgo.Describe("all services", func() {
 		var svcJig *ServiceJig
 		ginkgo.BeforeEach(func() {
 			k8scli, _, _ := GetClientsOrDie()
@@ -42,13 +47,24 @@ var _ = ginkgo.Describe("NodeportProxy", func() {
 				gomega.Expect(svcJig.CleanUp()).NotTo(gomega.HaveOccurred())
 			}
 		})
-		ginkgo.Context("with the proper annotation", func() {
+		ginkgo.Context("of type NodePort, having the NodePort expose annotation", func() {
 			ginkgo.BeforeEach(func() {
 				// nodePort set to 0 so that it gets allocated dynamically.
-				gomega.Expect(svcJig.CreateNodePortService("service-a", 0, 1, map[string]string{envoymanager.DefaultExposeAnnotationKey: "true"})).
+				gomega.Expect(svcJig.CreateServiceWithPods(
+					test.NewServiceBuilder(test.NamespacedName{Name: "service-a"}).
+						WithAnnotation(envoymanager.DefaultExposeAnnotationKey, "true").
+						WithSelector(map[string]string{"apps": "app-a"}).
+						WithServiceType(corev1.ServiceTypeNodePort).
+						WithServicePort("http", 80, 0, intstr.FromInt(8080), corev1.ProtocolTCP).
+						Build(), 1, false)).
 					NotTo(gomega.BeNil(), "NodePort service creation failed")
-				// nodePort set to 0 so that it gets allocated dynamically.
-				gomega.Expect(svcJig.CreateNodePortService("service-b", 0, 2, map[string]string{envoymanager.DefaultExposeAnnotationKey: "true"})).
+				gomega.Expect(svcJig.CreateServiceWithPods(
+					test.NewServiceBuilder(test.NamespacedName{Name: "service-b"}).
+						WithAnnotation(envoymanager.DefaultExposeAnnotationKey, "true").
+						WithSelector(map[string]string{"apps": "app-b"}).
+						WithServiceType(corev1.ServiceTypeNodePort).
+						WithServicePort("http", 80, 0, intstr.FromInt(8080), corev1.ProtocolTCP).
+						Build(), 2, false)).
 					NotTo(gomega.BeNil(), "NodePort service creation failed")
 			})
 
@@ -66,24 +82,99 @@ var _ = ginkgo.Describe("NodeportProxy", func() {
 					lbSvc := deployer.GetLbService()
 					gomega.Expect(lbSvc).ShouldNot(gomega.BeNil())
 					return portsToBeExposed.Difference(ExtractPorts(lbSvc))
-				}, "10m", "1s").Should(gomega.HaveLen(0), "All exposed service ports should be reflected in the lb service")
+				}, "2m", "1s").Should(gomega.HaveLen(0), "All exposed service ports should be reflected in the lb service")
 
-				ginkgo.By("load-balancing on available endpoints")
+				ginkgo.By("by load-balancing on available endpoints")
 				for _, svc := range svcJig.Services {
 					lbSvc := deployer.GetLbService()
 					targetNp := FindExposingNodePort(lbSvc, svc.Spec.Ports[0].NodePort)
 					logger.Debugw("found target nodeport in lb service", "service", svc, "port", targetNp)
-					gomega.Expect(networkingTest.DialFromNode("127.0.0.1", int(targetNp), 5, 1, sets.NewString(svcJig.ServicePods[svc.Name]...))).Should(gomega.HaveLen(0), "All exposed endpoints should be hit")
+					gomega.Expect(networkingTest.DialFromNode("127.0.0.1", int(targetNp), 5, 1, sets.NewString(svcJig.ServicePods[svc.Name]...), false)).Should(gomega.HaveLen(0), "All exposed endpoints should be hit")
 				}
 			})
 		})
 
-		ginkgo.Context("without the proper annotation", func() {
+		ginkgo.Context("of type ClusterIP, having the SNI expose annotation", func() {
+			ginkgo.BeforeEach(func() {
+				gomega.Expect(svcJig.CreateServiceWithPods(
+					test.NewServiceBuilder(test.NamespacedName{Name: "service-a"}).
+						WithAnnotation(envoymanager.DefaultExposeAnnotationKey, envoymanager.SNIType.String()).
+						WithAnnotation(envoymanager.PortHostMappingAnnotationKey, `{"https":"service-a.example.com"}`).
+						WithSelector(map[string]string{"apps": "app-a"}).
+						WithServiceType(corev1.ServiceTypeClusterIP).
+						WithServicePort("https", 6443, 0, intstr.FromInt(6443), corev1.ProtocolTCP).
+						Build(), 1, true)).
+					NotTo(gomega.BeNil(), "ClusterIP service creation failed")
+				gomega.Expect(svcJig.CreateServiceWithPods(
+					test.NewServiceBuilder(test.NamespacedName{Name: "service-b"}).
+						WithAnnotation(envoymanager.DefaultExposeAnnotationKey, envoymanager.SNIType.String()).
+						WithAnnotation(envoymanager.PortHostMappingAnnotationKey, `{"https":"service-b.example.com"}`).
+						WithSelector(map[string]string{"apps": "app-b"}).
+						WithServiceType(corev1.ServiceTypeClusterIP).
+						WithServicePort("https", 6443, 0, intstr.FromInt(6443), corev1.ProtocolTCP).
+						Build(), 2, true)).
+					NotTo(gomega.BeNil(), "ClusterIP service creation failed")
+			})
+
+			ginkgo.It("should be exposed", func() {
+				ginkgo.By("load-balancing on available endpoints")
+				for _, svc := range svcJig.Services {
+					lbSvc := deployer.GetLbService()
+					targetNp := FindExposingNodePort(lbSvc, 6443)
+					logger.Debugw("found target nodeport in lb service", "service", svc, "port", targetNp)
+					gomega.Expect(networkingTest.DialFromNode(fmt.Sprintf("%s.example.com", svc.Name), int(targetNp), 5, 1, sets.NewString(svcJig.ServicePods[svc.Name]...), true, "-k", "--resolve", fmt.Sprintf("%s.example.com:%d:127.0.0.1", svc.Name, targetNp))).Should(gomega.HaveLen(0), "All exposed endpoints should be hit")
+				}
+			})
+		})
+
+		ginkgo.Context("of type ClusterIP, having the Tunneling expose annotation", func() {
+			ginkgo.BeforeEach(func() {
+				gomega.Expect(svcJig.CreateServiceWithPods(
+					test.NewServiceBuilder(test.NamespacedName{Name: "service-a"}).
+						WithAnnotation(envoymanager.DefaultExposeAnnotationKey, envoymanager.TunnelingType.String()).
+						WithSelector(map[string]string{"apps": "app-a"}).
+						WithServiceType(corev1.ServiceTypeClusterIP).
+						WithServicePort("https", 8080, 0, intstr.FromInt(8088), corev1.ProtocolTCP).
+						Build(), 1, true)).
+					NotTo(gomega.BeNil(), "ClusterIP service creation failed")
+				gomega.Expect(svcJig.CreateServiceWithPods(
+					test.NewServiceBuilder(test.NamespacedName{Name: "service-b"}).
+						WithAnnotation(envoymanager.DefaultExposeAnnotationKey, envoymanager.TunnelingType.String()).
+						WithSelector(map[string]string{"apps": "app-b"}).
+						WithServiceType(corev1.ServiceTypeClusterIP).
+						WithServicePort("https", 8080, 0, intstr.FromInt(8088), corev1.ProtocolTCP).
+						Build(), 2, true)).
+					NotTo(gomega.BeNil(), "ClusterIP service creation failed")
+			})
+
+			ginkgo.It("should be exposed", func() {
+				ginkgo.By("load-balancing on available endpoints")
+				for _, svc := range svcJig.Services {
+					lbSvc := deployer.GetLbService()
+					targetNp := FindExposingNodePort(lbSvc, 8088)
+					logger.Debugw("found target nodeport in lb service", "service", svc, "port", targetNp)
+					gomega.Expect(networkingTest.DialFromNode(fmt.Sprintf("%s.%s.svc.cluster.local", svc.Name, svc.Namespace), 8080, 15, 1, sets.NewString(svcJig.ServicePods[svc.Name]...), true, "--proxy", fmt.Sprintf("127.0.0.1:%d", targetNp))).Should(gomega.HaveLen(0), "All exposed endpoints should be hit")
+				}
+			})
+		})
+
+		ginkgo.Context("not having the proper annotation", func() {
 			ginkgo.BeforeEach(func() {
 				// nodePort set to 0 so that it gets allocated dynamically.
-				gomega.Expect(svcJig.CreateNodePortService("service-a", 0, 1, map[string]string{})).
+				gomega.Expect(svcJig.CreateServiceWithPods(
+					test.NewServiceBuilder(test.NamespacedName{Name: "service-a"}).
+						WithSelector(map[string]string{"apps": "app-a"}).
+						WithServiceType(corev1.ServiceTypeNodePort).
+						WithServicePort("http", 80, 0, intstr.FromInt(8080), corev1.ProtocolTCP).
+						Build(), 1, false)).
 					NotTo(gomega.BeNil(), "NodePort service creation failed")
-				gomega.Expect(svcJig.CreateNodePortService("service-b", 0, 1, map[string]string{envoymanager.DefaultExposeAnnotationKey: "false"})).
+				gomega.Expect(svcJig.CreateServiceWithPods(
+					test.NewServiceBuilder(test.NamespacedName{Name: "service-b"}).
+						WithAnnotation(envoymanager.DefaultExposeAnnotationKey, "false").
+						WithSelector(map[string]string{"apps": "app-b"}).
+						WithServiceType(corev1.ServiceTypeNodePort).
+						WithServicePort("http", 80, 0, intstr.FromInt(8080), corev1.ProtocolTCP).
+						Build(), 1, false)).
 					NotTo(gomega.BeNil(), "NodePort service creation failed")
 			})
 


### PR DESCRIPTION
**What this PR does / why we need it:**

This PR extends the e2e tests for the NodePort-proxy to the new expose strategy by introducing tests to both the SNI listener and the Tunneling listener.

xref: #4942 

**Does this PR introduce a user-facing change?**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If  no release note is required, just write "NONE".
-->
```release-note
NONE
```
