### PR TITLE
Fix nodeport proxy e2e tests

### DIFF
--- a/OWNERS_ALIASES
+++ b/OWNERS_ALIASES
@@ -16,10 +16,12 @@ aliases:
 
   sig-cluster-management:
     - kron4eg
+    - irozzo-1A
     - moadqassem
     - moelsayed
     - xmudrii
     - xrstf
+    - youssefazrak
 
   sig-networking:
     - irozzo-1A

--- a/cmd/nodeport-proxy/OWNERS
+++ b/cmd/nodeport-proxy/OWNERS
@@ -1,0 +1,7 @@
+# See the OWNERS docs: https://git.k8s.io/community/contributors/guide/owners.md
+
+approvers:
+  - sig-networking
+
+reviewers:
+  - sig-networking

--- a/pkg/controller/nodeport-proxy/OWNERS
+++ b/pkg/controller/nodeport-proxy/OWNERS
@@ -1,0 +1,7 @@
+# See the OWNERS docs: https://git.k8s.io/community/contributors/guide/owners.md
+
+approvers:
+  - sig-networking
+
+reviewers:
+  - sig-networking

--- a/pkg/test/e2e/nodeport-proxy/network.go
+++ b/pkg/test/e2e/nodeport-proxy/network.go
@@ -149,6 +149,7 @@ func (n *NetworkingTestConfig) DialFromNode(targetIP string, targetPort, maxTrie
 			n.Log.Infof("Failed to execute %q: %v, stdout: %q, stderr: %q", filterCmd, err, stdout, stderr)
 		} else {
 			trimmed := strings.TrimSpace(stdout)
+			n.Log.Debugf("Got response: %q", trimmed)
 			if trimmed != "" {
 				eps.Insert(trimmed)
 			}

--- a/pkg/test/e2e/nodeport-proxy/services.go
+++ b/pkg/test/e2e/nodeport-proxy/services.go
@@ -89,7 +89,9 @@ func (n *ServiceJig) CreateNodePortService(name string, nodePort int32, numPods 
 	if n.ServicePods == nil {
 		n.ServicePods = map[string][]string{}
 	}
+	n.Services = append(n.Services, svc)
 	n.ServicePods[svc.Name] = pods
+
 	return svc, err
 }
 


### PR DESCRIPTION
**What this PR does / why we need it**:
Fixes the e2e tests for the nodeport-proxy, that were not running correctly due to a bug on `ServiceJig` that was not updating the slice containing the service created.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Documentation**:
<!-- Add links to the related documentation changes related to this pull request. E.g. the link to the kubermatic/docs pull request. -->

**Does this PR introduce a user-facing change?**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If  no release note is required, just write "NONE".
-->
```release-note
NONE
```
