### PR TITLE
Create RBAC role to allow kubeadm to get nodes

### DIFF
--- a/addons/rbac/allow-kubeadm-get-nodes.yaml
+++ b/addons/rbac/allow-kubeadm-get-nodes.yaml
@@ -1,0 +1,38 @@
+# Copyright 2020 The Kubermatic Kubernetes Platform contributors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: kubeadm:get-nodes
+rules:
+- apiGroups:
+  - ""
+  resources:
+  - nodes
+  verbs:
+  - get
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: kubeadm:get-nodes
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: kubeadm:get-nodes
+subjects:
+- apiGroup: rbac.authorization.k8s.io
+  kind: Group
+  name: system:bootstrappers:kubeadm:default-node-token


### PR DESCRIPTION
**What this PR does / why we need it**:

As of Kubernetes 1.18+, kubeadm verifies that there is no node with the same name before joining a new node to a cluster.

This PR adds a new manifest to the RBAC addon to grant kubeadm permissions to get nodes. Without this PR, nodes can't join kubeadm clusters running Kubernetes 1.18+

This manifest has been copied from the Kubernetes documentation and tested manually.

Reference: https://kubernetes.io/docs/setup/production-environment/tools/kubeadm/troubleshooting-kubeadm/#not-possible-to-join-a-v1-18-node-to-a-v1-17-cluster-due-to-missing-rbac

This PR should be cherry-picked to branches with Kubernetes 1.18+ support.

**Does this PR introduce a user-facing change?**:
```release-note
Create an RBAC role to allow kubeadm to get nodes. This fixes nodes failing to join kubeadm clusters running Kubernetes 1.18+
```

/assign @aborilov 