### PR TITLE
update ec2-instances-info to 2020-11-10

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -15,7 +15,7 @@ require (
 	github.com/aws/aws-sdk-go v1.27.4
 	github.com/coreos/go-oidc v2.2.1+incompatible
 	github.com/coreos/locksmith v0.6.2
-	github.com/cristim/ec2-instances-info v0.0.0-20190708120723-b53a9860c46d
+	github.com/cristim/ec2-instances-info v0.0.0-20201110114654-2dfcc09f67d4
 	github.com/digitalocean/godo v1.54.0
 	github.com/docker/distribution v2.7.1+incompatible
 	github.com/docker/spdystream v0.0.0-20181023171402-6480d4af844c // indirect

--- a/go.sum
+++ b/go.sum
@@ -242,8 +242,8 @@ github.com/cpuguy83/go-md2man/v2 v2.0.0 h1:EoUDS0afbrsXAZ9YQ9jdu/mZ2sXgT1/2yyNng
 github.com/cpuguy83/go-md2man/v2 v2.0.0/go.mod h1:maD7wRr/U5Z6m/iR4s+kqSMx2CaBsrgA7czyZG/E6dU=
 github.com/creack/pty v1.1.7/go.mod h1:lj5s0c3V2DBrqTV7llrYr5NG6My20zk30Fl46Y7DoTY=
 github.com/creack/pty v1.1.9/go.mod h1:oKZEueFk5CKHvIhNR5MUki03XCEU+Q6VDXinZuGJ33E=
-github.com/cristim/ec2-instances-info v0.0.0-20190708120723-b53a9860c46d h1:PhYh47NpQu3168rU60fDKuPwp+tSznxBX4+TKU2R32M=
-github.com/cristim/ec2-instances-info v0.0.0-20190708120723-b53a9860c46d/go.mod h1:SCEMkkczeDuTdxcoqyNMEtwPiofRFxliCtf2wNUZEzk=
+github.com/cristim/ec2-instances-info v0.0.0-20201110114654-2dfcc09f67d4 h1:uPdJfcX6oBDV/n7KYnXipTvZr0Mll06CnH0FYsY5vYY=
+github.com/cristim/ec2-instances-info v0.0.0-20201110114654-2dfcc09f67d4/go.mod h1:0yCjO4zBzlwWSGh/zGfW2Zq1NX605qCYVBHD1fPXKNs=
 github.com/davecgh/go-spew v0.0.0-20151105211317-5215b55f46b2/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=


### PR DESCRIPTION
**What this PR does / why we need it**:
EC2 instances have changed since July 2019...

**Does this PR introduce a user-facing change?**:
```release-note
NONE
```
