### PR TITLE
Extend retry parameters in http framework for e2e tests

### DIFF
--- a/pkg/test/e2e/api/credentials_test.go
+++ b/pkg/test/e2e/api/credentials_test.go
@@ -141,10 +141,14 @@ func TestProviderEndpointsWithCredentials(t *testing.T) {
 				req.Header.Set("Location", tc.location)
 			}
 
-			// should be able to perform at least 4 calls in case request
-			// timeout is hit all the times
-			client := utils.NewHTTPClientWithRetries(t, 10*time.Second, 1*time.Second, 50*time.Second)
-
+			// with those settings the cumulative sleep duration is ~ 8s
+			// when all attempts are made.
+			client := &http.Client{
+				Transport: utils.NewRoundTripperWithRetries(t, 15*time.Second, utils.Backoff{
+					Steps:    4,
+					Duration: 1 * time.Second,
+					Factor:   1.5}),
+			}
 			resp, err := client.Do(req)
 			if err != nil {
 				t.Fatalf("error reading response: %v", err)

--- a/pkg/test/e2e/api/runner.go
+++ b/pkg/test/e2e/api/runner.go
@@ -1133,7 +1133,11 @@ func (r *runner) UpdateDC(seed, dcToUpdate string, dc *models.Datacenter) (*mode
 		DCToUpdate: dcToUpdate,
 		Seed:       seed,
 	}
-	utils.SetupParams(r.test, params, 1*time.Second, 3*time.Minute, http.StatusBadRequest)
+	utils.SetupRetryParams(r.test, params, utils.Backoff{
+		Duration: 1 * time.Second,
+		Steps:    4,
+		Factor:   1.5,
+	}, http.StatusBadRequest)
 
 	updatedDC, err := r.client.Datacenter.UpdateDC(params, r.bearerToken)
 	if err != nil {


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR makes the HTTP retry parameters for the HTTP framework used in e2e tests more generic, allowing to specifying the exact number of retries and configure an exponential backoff.

 

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Documentation**:
<!-- Add links to the related documentation changes related to this pull request. E.g. the link to the kubermatic/docs pull request. -->

**Does this PR introduce a user-facing change?**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If  no release note is required, just write "NONE".
-->
```release-note
NONE
```
