### PR TITLE
added proper gatekeeper namespace

### DIFF
--- a/pkg/controller/user-cluster-controller-manager/resources/reconciler.go
+++ b/pkg/controller/user-cluster-controller-manager/resources/reconciler.go
@@ -555,6 +555,9 @@ func (r *reconciler) reconcileNamespaces(ctx context.Context) error {
 		creators := []reconciling.NamedNamespaceCreatorGetter{
 			kubernetesdashboard.NamespaceCreator,
 		}
+		if r.opaIntegration {
+			creators = append(creators, gatekeeper.NamespaceCreator)
+		}
 		if err := reconciling.ReconcileNamespaces(ctx, creators, "", r.Client); err != nil {
 			return fmt.Errorf("failed to reconcile namespaces: %v", err)
 		}

--- a/pkg/controller/user-cluster-controller-manager/resources/resources/gatekeeper/namespace.go
+++ b/pkg/controller/user-cluster-controller-manager/resources/resources/gatekeeper/namespace.go
@@ -23,7 +23,7 @@ import (
 	corev1 "k8s.io/api/core/v1"
 )
 
-// NamespaceCreator creates the namespace for the Kubernetes Dashboard
+// NamespaceCreator creates the namespace for Gatekeeper
 func NamespaceCreator() (string, reconciling.NamespaceCreator) {
 	return resources.GatekeeperNamespace, func(ns *corev1.Namespace) (*corev1.Namespace, error) {
 		return ns, nil

--- a/pkg/controller/user-cluster-controller-manager/resources/resources/gatekeeper/namespace.go
+++ b/pkg/controller/user-cluster-controller-manager/resources/resources/gatekeeper/namespace.go
@@ -1,0 +1,31 @@
+/*
+Copyright 2020 The Kubermatic Kubernetes Platform contributors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package gatekeeper
+
+import (
+	"k8c.io/kubermatic/v2/pkg/resources"
+	"k8c.io/kubermatic/v2/pkg/resources/reconciling"
+
+	corev1 "k8s.io/api/core/v1"
+)
+
+// NamespaceCreator creates the namespace for the Kubernetes Dashboard
+func NamespaceCreator() (string, reconciling.NamespaceCreator) {
+	return resources.GatekeeperNamespace, func(ns *corev1.Namespace) (*corev1.Namespace, error) {
+		return ns, nil
+	}
+}

--- a/pkg/resources/gatekeeper/deployment.go
+++ b/pkg/resources/gatekeeper/deployment.go
@@ -228,12 +228,7 @@ func getControllerContainers(data gatekeeperData, existingContainers []corev1.Co
 		},
 		Env: []corev1.EnvVar{
 			{Name: "POD_NAMESPACE",
-				ValueFrom: &corev1.EnvVarSource{
-					FieldRef: &corev1.ObjectFieldSelector{
-						APIVersion: "v1",
-						FieldPath:  "metadata.namespace",
-					},
-				}},
+				Value: resources.GatekeeperNamespace},
 			{Name: "POD_NAME",
 				ValueFrom: &corev1.EnvVarSource{
 					FieldRef: &corev1.ObjectFieldSelector{
@@ -314,12 +309,7 @@ func getAuditContainers(data gatekeeperData, existingContainers []corev1.Contain
 		},
 		Env: []corev1.EnvVar{
 			{Name: "POD_NAMESPACE",
-				ValueFrom: &corev1.EnvVarSource{
-					FieldRef: &corev1.ObjectFieldSelector{
-						APIVersion: "v1",
-						FieldPath:  "metadata.namespace",
-					},
-				}},
+				Value: resources.GatekeeperNamespace},
 			{Name: "POD_NAME",
 				ValueFrom: &corev1.EnvVarSource{
 					FieldRef: &corev1.ObjectFieldSelector{

--- a/pkg/resources/resources.go
+++ b/pkg/resources/resources.go
@@ -317,6 +317,8 @@ const (
 
 	// KubermaticNamespace is the main kubermatic namespace
 	KubermaticNamespace = "kubermatic"
+	// GatekeeperNamespace is the main gatkeeper namespace where the gatekeeper config is stored
+	GatekeeperNamespace = "gatekeeper-system"
 
 	// DefaultOwnerReadOnlyMode represents file mode with read permission for owner only
 	DefaultOwnerReadOnlyMode = 0400


### PR DESCRIPTION
**What this PR does / why we need it**:
To find the gatkeeper config, gatkeeper audit check the given namespace and hardcoded "config" name (https://github.com/open-policy-agent/gatekeeper/blob/master/pkg/controller/config/config_controller.go#L196-L198).
So this PR creates the `gatekeeper-system` namespace on the user cluster as a place where to hold the gatekeeper config CR and whatever gatekeeper will need in the future.

**Does this PR introduce a user-facing change?**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If  no release note is required, just write "NONE".
-->
```release-note
NONE
```
