### PR TITLE
Default to the latest available OpenStack CCM version

### DIFF
--- a/docs/adding-kubernetes-versions.md
+++ b/docs/adding-kubernetes-versions.md
@@ -38,6 +38,10 @@ Once new Docker images are ready, KKP can be updated as well.
   minor (just copy an existing job and adjust accordingly). Make sure to change the Docker
   image tag for the e2e images to use the new tag you just created with the new test binaries.
 - Update the CSI addon manifests (`addon/csi/*.yaml`) to include the new minor version.
+- Update the OpenStack CCM manifest (`pkg/resources/cloudcontroller/openstack.go`) to
+  include the new minor version.
+  - The latest OpenStack CCM version can be found in the 
+  [`kubernetes/cloud-provider-openstack` repository](https://github.com/kubernetes/cloud-provider-openstack).
 - Ensure a kubelet ConfigMap for the new minor exists in `addons/kubelet-configmap/kubelet-configmap.yaml`.
 - Update `addons/rbac/allow-kubeadm-join-configmap.yaml` to include the new ConfigMap.
 - The conformance-tests runner (`cmd/conformance-tests/runner.go`) has a list of

--- a/pkg/resources/cloudcontroller/openstack.go
+++ b/pkg/resources/cloudcontroller/openstack.go
@@ -171,13 +171,19 @@ func getOSFlags(data *resources.TemplateData) []string {
 }
 
 func getOSVersion(version semver.Semver) (string, error) {
+	if version.Major() < 17 {
+		return "", fmt.Errorf("Kubernetes version %s is not supported", version.String())
+	}
+
 	switch version.Minor() {
 	case 17:
 		return "1.17.0", nil
 	case 18:
 		return "1.18.0", nil
+	case 19:
+		return "1.19.2", nil
 	default:
-		return "", fmt.Errorf("Kubernetes version %s is not supported", version.String())
+		return "1.19.2", nil
 	}
 }
 


### PR DESCRIPTION
**What this PR does / why we need it**:

Currently, we determine the OpenStack CCM version based on the Kubernetes version. In the case when we don't specify the OpenStack CCM version for a Kubernetes version, in-tree CCM would be used as a fall-back.

In this concrete case, we didn't specify the OpenStack CCM version for Kubernetes 1.19, so all newly-created 1.19 OpenStack clusters are using the in-tree cloud provider instead of the external CCM. This should be considered as a breaking change because we have deployed the external CCM for all 1.17 and 1.18 OpenStack clusters.

OpenStack clusters upgraded from 1.18 to 1.19 are not affected. Seed-controller-manager will log errors regarding that Kubernetes version is not supported, but the cluster will still use external CCM deployed for 1.18.

* The 1.19 OpenStack clusters that were created before this change will continue using the in-tree cloud provider instead of the external CCM
* Those clusters will have to use the CCM migration mechanism to migrate to the external CCM. This mechanism is still **not implemented**
* All newly-created 1.19+ OpenStack clusters created after this change will use the external CCM

In the case when OpenStack CCM is not available for the latest Kubernetes versions, the latest available OpenStack CCM version will be used.

The documentation on adding new Kubernetes versions support has been extended with guidelines for adding a new OpenStack CCM version for that Kubernetes version.

**Does this PR introduce a user-facing change?**:
```release-note
Default to the latest available OpenStack CCM version. This fixes a bug where newly-created OpenStack clusters running Kubernetes 1.19 were using the in-tree cloud provider instead of the external CCM. Those clusters will remain to use the in-tree cloud provider until the CCM migration mechanism is not implemented. The OpenStack clusters running Kubernetes 1.19+ and created with KKP 2.15.6+ will use the external CCM.
```

/assign @irozzo-1A 