### PR TITLE
Fix OpenStack CCM supported version validation

### DIFF
--- a/pkg/resources/cloudcontroller/openstack.go
+++ b/pkg/resources/cloudcontroller/openstack.go
@@ -171,7 +171,7 @@ func getOSFlags(data *resources.TemplateData) []string {
 }
 
 func getOSVersion(version semver.Semver) (string, error) {
-	if version.Major() < 17 {
+	if version.Minor() < 17 {
 		return "", fmt.Errorf("Kubernetes version %s is not supported", version.String())
 	}
 


### PR DESCRIPTION
**What this PR does / why we need it**:

Fix OpenStack CCM supported version validation. I've checked the major version instead of the minor version, so CCM doesn't get deployed at all.

**Does this PR introduce a user-facing change?**:
```release-note
NONE
```