### PR TITLE
Add support for tunneling expose strategy in control plane components

### DIFF
--- a/cmd/nodeport-proxy/envoy-manager/main.go
+++ b/cmd/nodeport-proxy/envoy-manager/main.go
@@ -25,6 +25,7 @@ import (
 
 	"k8c.io/kubermatic/v2/pkg/controller/nodeport-proxy/envoymanager"
 	kubermaticlog "k8c.io/kubermatic/v2/pkg/log"
+	"k8c.io/kubermatic/v2/pkg/resources/nodeportproxy"
 	"k8c.io/kubermatic/v2/pkg/util/cli"
 
 	ctrlruntimeconfig "sigs.k8s.io/controller-runtime/pkg/client/config"
@@ -45,7 +46,7 @@ func main() {
 	flag.IntVar(&ctrlOpts.EnvoySNIListenerPort, "envoy-sni-port", 0, "Port used for SNI entry point.")
 	flag.IntVar(&ctrlOpts.EnvoyTunnelingListenerPort, "envoy-tunneling-port", 0, "Port used for HTTP/2 CONNECT termination.")
 	flag.StringVar(&ctrlOpts.Namespace, "namespace", "", "The namespace we should use for pods and services. Leave empty for all namespaces.")
-	flag.StringVar(&ctrlOpts.ExposeAnnotationKey, "expose-annotation-key", envoymanager.DefaultExposeAnnotationKey, "The annotation key used to determine if a service should be exposed")
+	flag.StringVar(&ctrlOpts.ExposeAnnotationKey, "expose-annotation-key", nodeportproxy.DefaultExposeAnnotationKey, "The annotation key used to determine if a service should be exposed")
 	flag.Parse()
 
 	// setup signal handler

--- a/cmd/nodeport-proxy/lb-updater/main.go
+++ b/cmd/nodeport-proxy/lb-updater/main.go
@@ -29,6 +29,7 @@ import (
 	"k8c.io/kubermatic/v2/pkg/controller/nodeport-proxy/envoymanager"
 	controllerutil "k8c.io/kubermatic/v2/pkg/controller/util"
 	kubermaticlog "k8c.io/kubermatic/v2/pkg/log"
+	"k8c.io/kubermatic/v2/pkg/resources/nodeportproxy"
 	"k8c.io/kubermatic/v2/pkg/util/cli"
 
 	corev1 "k8s.io/api/core/v1"
@@ -62,7 +63,7 @@ func main() {
 	flag.StringVar(&lbName, "lb-name", "nodeport-lb", "name of the LoadBalancer service to manage.")
 	flag.StringVar(&lbNamespace, "lb-namespace", "nodeport-proxy", "namespace of the LoadBalancer service to manage. Needs to exist")
 	flag.BoolVar(&namespaced, "namespaced", false, "Whether this controller should only watch services in the lbNamespace")
-	flag.StringVar(&opts.ExposeAnnotationKey, "expose-annotation-key", envoymanager.DefaultExposeAnnotationKey, "The annotation key used to determine if a Service should be exposed")
+	flag.StringVar(&opts.ExposeAnnotationKey, "expose-annotation-key", nodeportproxy.DefaultExposeAnnotationKey, "The annotation key used to determine if a Service should be exposed")
 	flag.IntVar(&opts.EnvoySNIListenerPort, "envoy-sni-port", 0, "Port used for SNI entry point.")
 	flag.IntVar(&opts.EnvoyTunnelingListenerPort, "envoy-tunneling-port", 0, "Port used for HTTP/2 CONNECT termination.")
 	flag.Parse()

--- a/cmd/nodeport-proxy/lb-updater/main.go
+++ b/cmd/nodeport-proxy/lb-updater/main.go
@@ -181,8 +181,8 @@ func (u *LBUpdater) syncLB(s string) error {
 	for _, service := range services.Items {
 		serviceLog := u.log.With("namespace", service.Namespace).With("name", service.Name)
 
-		if service.Annotations[u.opts.ExposeAnnotationKey] != "true" {
-			serviceLog.Debugw("Skipping service as the annotation is not set to 'true'", "annotation", u.opts.ExposeAnnotationKey)
+		if e := service.Annotations[u.opts.ExposeAnnotationKey]; e != "true" && e != nodeportproxy.NodePortType.String() {
+			serviceLog.Debugw("Skipping service as the annotation is not set to 'true' or NodePort", "annotation", u.opts.ExposeAnnotationKey)
 			continue
 		}
 

--- a/cmd/nodeport-proxy/lb-updater/main_test.go
+++ b/cmd/nodeport-proxy/lb-updater/main_test.go
@@ -33,6 +33,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 
 	"k8c.io/kubermatic/v2/pkg/controller/nodeport-proxy/envoymanager"
+	"k8c.io/kubermatic/v2/pkg/resources/nodeportproxy"
 )
 
 func TestReconciliation(t *testing.T) {
@@ -704,7 +705,7 @@ func TestReconciliation(t *testing.T) {
 				client:      client,
 				log:         zap.NewNop().Sugar(),
 				opts: envoymanager.Options{
-					ExposeAnnotationKey:        envoymanager.DefaultExposeAnnotationKey,
+					ExposeAnnotationKey:        nodeportproxy.DefaultExposeAnnotationKey,
 					EnvoySNIListenerPort:       tc.sniListenerPort,
 					EnvoyTunnelingListenerPort: tc.tunnelingListenerPort,
 				},

--- a/pkg/controller/nodeport-proxy/envoymanager/controller_test.go
+++ b/pkg/controller/nodeport-proxy/envoymanager/controller_test.go
@@ -47,6 +47,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/event"
 	"sigs.k8s.io/controller-runtime/pkg/handler"
 
+	"k8c.io/kubermatic/v2/pkg/resources/nodeportproxy"
 	"k8c.io/kubermatic/v2/pkg/test"
 )
 
@@ -66,7 +67,7 @@ func TestSync(t *testing.T) {
 			resources: []runtime.Object{
 				test.NewServiceBuilder(test.NamespacedName{Name: "my-nodeport", Namespace: "test"}).
 					WithServiceType(corev1.ServiceTypeNodePort).
-					WithAnnotation(DefaultExposeAnnotationKey, "true").
+					WithAnnotation(nodeportproxy.DefaultExposeAnnotationKey, "true").
 					WithServicePort("https", 443, 32000, intstr.FromString("https"), corev1.ProtocolTCP).
 					WithServicePort("http", 80, 32001, intstr.FromString("http"), corev1.ProtocolTCP).
 					Build(),
@@ -91,7 +92,7 @@ func TestSync(t *testing.T) {
 			name: "1-port-2-pods-one-unhealthy",
 			resources: []runtime.Object{
 				test.NewServiceBuilder(test.NamespacedName{Name: "my-nodeport", Namespace: "test"}).
-					WithAnnotation(DefaultExposeAnnotationKey, "NodePort").
+					WithAnnotation(nodeportproxy.DefaultExposeAnnotationKey, "NodePort").
 					WithServiceType(corev1.ServiceTypeNodePort).
 					WithServicePort("http", 80, 32001, intstr.FromString("http"), corev1.ProtocolTCP).
 					Build(),
@@ -126,7 +127,7 @@ func TestSync(t *testing.T) {
 			name: "1-port-service-without-pods",
 			resources: []runtime.Object{
 				test.NewServiceBuilder(test.NamespacedName{Name: "my-nodeport", Namespace: "test"}).
-					WithAnnotation(DefaultExposeAnnotationKey, "NodePort").
+					WithAnnotation(nodeportproxy.DefaultExposeAnnotationKey, "NodePort").
 					WithServiceType(corev1.ServiceTypeNodePort).
 					WithServicePort("http", 80, 32001, intstr.FromString("http"), corev1.ProtocolTCP).
 					Build(),
@@ -140,8 +141,8 @@ func TestSync(t *testing.T) {
 			name: "1-sni-service-with-1-exposed-port",
 			resources: []runtime.Object{
 				test.NewServiceBuilder(test.NamespacedName{Name: "my-cluster-ip", Namespace: "test"}).
-					WithAnnotation(DefaultExposeAnnotationKey, "SNI").
-					WithAnnotation(PortHostMappingAnnotationKey, `{"https": "host.com"}`).
+					WithAnnotation(nodeportproxy.DefaultExposeAnnotationKey, "SNI").
+					WithAnnotation(nodeportproxy.PortHostMappingAnnotationKey, `{"https": "host.com"}`).
 					WithServicePort("http", 80, 0, intstr.FromString("http"), corev1.ProtocolTCP).
 					WithServicePort("https", 8080, 0, intstr.FromString("https"), corev1.ProtocolTCP).
 					Build(),
@@ -165,8 +166,8 @@ func TestSync(t *testing.T) {
 			name: "1-sni-service-with-2-exposed-ports",
 			resources: []runtime.Object{
 				test.NewServiceBuilder(test.NamespacedName{Name: "my-cluster-ip", Namespace: "test"}).
-					WithAnnotation(DefaultExposeAnnotationKey, "SNI").
-					WithAnnotation(PortHostMappingAnnotationKey, `{"https": "host.com", "admin": "admin.host.com"}`).
+					WithAnnotation(nodeportproxy.DefaultExposeAnnotationKey, "SNI").
+					WithAnnotation(nodeportproxy.PortHostMappingAnnotationKey, `{"https": "host.com", "admin": "admin.host.com"}`).
 					WithServicePort("http", 80, 0, intstr.FromString("http"), corev1.ProtocolTCP).
 					WithServicePort("https", 8080, 0, intstr.FromString("https"), corev1.ProtocolTCP).
 					WithServicePort("admin", 6443, 0, intstr.FromString("https"), corev1.ProtocolTCP).
@@ -195,8 +196,8 @@ func TestSync(t *testing.T) {
 			name: "sni-listener-not-enabled",
 			resources: []runtime.Object{
 				test.NewServiceBuilder(test.NamespacedName{Name: "my-cluster-ip", Namespace: "test"}).
-					WithAnnotation(DefaultExposeAnnotationKey, "SNI").
-					WithAnnotation(PortHostMappingAnnotationKey, `{"https": "host.com"}`).
+					WithAnnotation(nodeportproxy.DefaultExposeAnnotationKey, "SNI").
+					WithAnnotation(nodeportproxy.PortHostMappingAnnotationKey, `{"https": "host.com"}`).
 					WithServicePort("https", 8080, 0, intstr.FromString("https"), corev1.ProtocolTCP).
 					Build(),
 				test.NewEndpointsBuilder(test.NamespacedName{Name: "my-cluster-ip", Namespace: "test"}).
@@ -215,8 +216,8 @@ func TestSync(t *testing.T) {
 			resources: []runtime.Object{
 				test.NewServiceBuilder(test.NamespacedName{Name: "newer-service", Namespace: "test"}).
 					WithCreationTimestamp(timeRef.Add(1*time.Hour)).
-					WithAnnotation(DefaultExposeAnnotationKey, "SNI").
-					WithAnnotation(PortHostMappingAnnotationKey, `{"https": "host.com"}`).
+					WithAnnotation(nodeportproxy.DefaultExposeAnnotationKey, "SNI").
+					WithAnnotation(nodeportproxy.PortHostMappingAnnotationKey, `{"https": "host.com"}`).
 					WithServicePort("https", 443, 0, intstr.FromString("https"), corev1.ProtocolTCP).
 					Build(),
 				test.NewEndpointsBuilder(test.NamespacedName{Name: "newer-service", Namespace: "test"}).
@@ -226,8 +227,8 @@ func TestSync(t *testing.T) {
 					DoneWithEndpointSubset().Build(),
 				test.NewServiceBuilder(test.NamespacedName{Name: "older-service", Namespace: "test"}).
 					WithCreationTimestamp(timeRef).
-					WithAnnotation(DefaultExposeAnnotationKey, "SNI").
-					WithAnnotation(PortHostMappingAnnotationKey, `{"https": "host.com"}`).
+					WithAnnotation(nodeportproxy.DefaultExposeAnnotationKey, "SNI").
+					WithAnnotation(nodeportproxy.PortHostMappingAnnotationKey, `{"https": "host.com"}`).
 					WithServicePort("https", 443, 0, intstr.FromString("https"), corev1.ProtocolTCP).
 					Build(),
 				test.NewEndpointsBuilder(test.NamespacedName{Name: "older-service", Namespace: "test"}).
@@ -250,8 +251,8 @@ func TestSync(t *testing.T) {
 			resources: []runtime.Object{
 				test.NewServiceBuilder(test.NamespacedName{Name: "udp-service", Namespace: "test"}).
 					WithCreationTimestamp(timeRef.Add(1*time.Hour)).
-					WithAnnotation(DefaultExposeAnnotationKey, "SNI").
-					WithAnnotation(PortHostMappingAnnotationKey, `{"": "host.com"}`).
+					WithAnnotation(nodeportproxy.DefaultExposeAnnotationKey, "SNI").
+					WithAnnotation(nodeportproxy.PortHostMappingAnnotationKey, `{"": "host.com"}`).
 					WithServicePort("", 1025, 0, intstr.FromString(""), corev1.ProtocolUDP).
 					Build(),
 				test.NewEndpointsBuilder(test.NamespacedName{Name: "udp-service", Namespace: "test"}).
@@ -269,7 +270,7 @@ func TestSync(t *testing.T) {
 			resources: []runtime.Object{
 				test.NewServiceBuilder(test.NamespacedName{Name: "my-service", Namespace: "test"}).
 					WithCreationTimestamp(timeRef.Add(1*time.Hour)).
-					WithAnnotation(DefaultExposeAnnotationKey, "Tunneling").
+					WithAnnotation(nodeportproxy.DefaultExposeAnnotationKey, "Tunneling").
 					WithServicePort("https", 443, 0, intstr.FromString("https"), corev1.ProtocolTCP).
 					Build(),
 				test.NewEndpointsBuilder(test.NamespacedName{Name: "my-service", Namespace: "test"}).
@@ -291,8 +292,8 @@ func TestSync(t *testing.T) {
 			resources: []runtime.Object{
 				test.NewServiceBuilder(test.NamespacedName{Name: "my-service", Namespace: "test"}).
 					WithCreationTimestamp(timeRef.Add(1*time.Hour)).
-					WithAnnotation(DefaultExposeAnnotationKey, "SNI,Tunneling").
-					WithAnnotation(PortHostMappingAnnotationKey, `{"https": "host.com"}`).
+					WithAnnotation(nodeportproxy.DefaultExposeAnnotationKey, "SNI,Tunneling").
+					WithAnnotation(nodeportproxy.PortHostMappingAnnotationKey, `{"https": "host.com"}`).
 					WithServicePort("https", 443, 0, intstr.FromString("https"), corev1.ProtocolTCP).
 					Build(),
 				test.NewEndpointsBuilder(test.NamespacedName{Name: "my-service", Namespace: "test"}).
@@ -316,8 +317,8 @@ func TestSync(t *testing.T) {
 			resources: []runtime.Object{
 				test.NewServiceBuilder(test.NamespacedName{Name: "my-service", Namespace: "test"}).
 					WithCreationTimestamp(timeRef.Add(1*time.Hour)).
-					WithAnnotation(DefaultExposeAnnotationKey, "SNI,Tunneling").
-					WithAnnotation(PortHostMappingAnnotationKey, `{"http": "host.com"}`). // port http does not exist
+					WithAnnotation(nodeportproxy.DefaultExposeAnnotationKey, "SNI,Tunneling").
+					WithAnnotation(nodeportproxy.PortHostMappingAnnotationKey, `{"http": "host.com"}`). // port http does not exist
 					WithServicePort("https", 443, 0, intstr.FromString("https"), corev1.ProtocolTCP).
 					Build(),
 				test.NewEndpointsBuilder(test.NamespacedName{Name: "my-service", Namespace: "test"}).
@@ -347,7 +348,7 @@ func TestSync(t *testing.T) {
 				client,
 				Options{
 					EnvoyNodeName:              "node-name",
-					ExposeAnnotationKey:        DefaultExposeAnnotationKey,
+					ExposeAnnotationKey:        nodeportproxy.DefaultExposeAnnotationKey,
 					EnvoySNIListenerPort:       test.sniListenerPort,
 					EnvoyTunnelingListenerPort: test.tunnelingListenerPort,
 				},
@@ -565,7 +566,7 @@ func TestEndpointToService(t *testing.T) {
 					ObjectMeta: metav1.ObjectMeta{
 						Namespace:   "foo",
 						Name:        "bar",
-						Annotations: map[string]string{DefaultExposeAnnotationKey: "true"},
+						Annotations: map[string]string{nodeportproxy.DefaultExposeAnnotationKey: "true"},
 					},
 				},
 			},
@@ -579,7 +580,7 @@ func TestEndpointToService(t *testing.T) {
 			log := zaptest.NewLogger(t).Sugar()
 			client := fakectrlruntimeclient.NewFakeClient(tt.resources...)
 			res := (&Reconciler{
-				Options: Options{ExposeAnnotationKey: DefaultExposeAnnotationKey},
+				Options: Options{ExposeAnnotationKey: nodeportproxy.DefaultExposeAnnotationKey},
 				Client:  client,
 				ctx:     context.TODO(),
 				log:     log,
@@ -602,7 +603,7 @@ func TestExposeAnnotationPredicate(t *testing.T) {
 			name: "Should be accepted when annotation has the good value",
 			obj: &corev1.Service{
 				ObjectMeta: metav1.ObjectMeta{
-					Annotations: map[string]string{DefaultExposeAnnotationKey: "true"},
+					Annotations: map[string]string{nodeportproxy.DefaultExposeAnnotationKey: "true"},
 				},
 			},
 			expectAccept: true,
@@ -616,7 +617,7 @@ func TestExposeAnnotationPredicate(t *testing.T) {
 			name: "Should be rejected when annotation value is wrong",
 			obj: &corev1.Service{
 				ObjectMeta: metav1.ObjectMeta{
-					Annotations: map[string]string{DefaultExposeAnnotationKey: "tru"},
+					Annotations: map[string]string{nodeportproxy.DefaultExposeAnnotationKey: "tru"},
 				},
 			},
 			expectAccept: false,
@@ -625,7 +626,7 @@ func TestExposeAnnotationPredicate(t *testing.T) {
 			name: "Should be rejected when annotation value has wrong case",
 			obj: &corev1.Service{
 				ObjectMeta: metav1.ObjectMeta{
-					Annotations: map[string]string{DefaultExposeAnnotationKey: "True"},
+					Annotations: map[string]string{nodeportproxy.DefaultExposeAnnotationKey: "True"},
 				},
 			},
 			expectAccept: false,
@@ -644,7 +645,7 @@ func TestExposeAnnotationPredicate(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			if tt.annotationKey == "" {
-				tt.annotationKey = DefaultExposeAnnotationKey
+				tt.annotationKey = nodeportproxy.DefaultExposeAnnotationKey
 			}
 			p := exposeAnnotationPredicate{annotation: tt.annotationKey, log: zaptest.NewLogger(t).Sugar()}
 			if got, exp := p.Create(event.CreateEvent{Meta: tt.obj, Object: tt.obj}), tt.expectAccept; got != exp {

--- a/pkg/controller/seed-controller-manager/kubernetes/resources.go
+++ b/pkg/controller/seed-controller-manager/kubernetes/resources.go
@@ -212,7 +212,7 @@ func (r *Reconciler) ensureNamespaceExists(ctx context.Context, cluster *kuberma
 // GetServiceCreators returns all service creators that are currently in use
 func GetServiceCreators(data *resources.TemplateData) []reconciling.NamedServiceCreatorGetter {
 	creators := []reconciling.NamedServiceCreatorGetter{
-		apiserver.ServiceCreator(data.Cluster().Spec.ExposeStrategy),
+		apiserver.ServiceCreator(data.Cluster().Spec.ExposeStrategy, data.Cluster().Address.InternalName),
 		openvpn.ServiceCreator(data.Cluster().Spec.ExposeStrategy),
 		etcd.ServiceCreator(data),
 		dns.ServiceCreator(),

--- a/pkg/controller/seed-controller-manager/openshift/openshift_controller.go
+++ b/pkg/controller/seed-controller-manager/openshift/openshift_controller.go
@@ -653,7 +653,7 @@ func (r *Reconciler) networkDefaults(ctx context.Context, cluster *kubermaticv1.
 // GetServiceCreators returns all service creators that are currently in use
 func getAllServiceCreators(osData *openshiftData) []reconciling.NamedServiceCreatorGetter {
 	creators := []reconciling.NamedServiceCreatorGetter{
-		apiserver.ServiceCreator(osData.Cluster().Spec.ExposeStrategy),
+		apiserver.ServiceCreator(osData.Cluster().Spec.ExposeStrategy, osData.Cluster().Address.InternalName),
 		openshiftresources.OpenshiftAPIServiceCreator,
 		openvpn.ServiceCreator(osData.Cluster().Spec.ExposeStrategy),
 		etcd.ServiceCreator(osData),

--- a/pkg/resources/address/address.go
+++ b/pkg/resources/address/address.go
@@ -165,7 +165,14 @@ func (m *ModifiersBuilder) Build(ctx context.Context) ([]func(*kubermaticv1.Clus
 
 	// Port
 	port := service.Spec.Ports[0].NodePort
-	if m.cluster.Address.Port != port {
+
+	// Use the nodeport value for KAS secure port when strategy is NodePort or
+	// LoadBalancer. This is because the same service will be accessed both
+	// locally and passing from nodeport proxy.
+	if (m.cluster.Spec.ExposeStrategy == kubermaticv1.ExposeStrategyNodePort ||
+		m.cluster.Spec.ExposeStrategy == kubermaticv1.ExposeStrategyLoadBalancer) &&
+		m.cluster.Address.Port != port {
+
 		modifiers = append(modifiers, func(c *kubermaticv1.Cluster) {
 			c.Address.Port = port
 		})

--- a/pkg/resources/apiserver/service.go
+++ b/pkg/resources/apiserver/service.go
@@ -22,7 +22,6 @@ import (
 
 	kubermaticv1 "k8c.io/kubermatic/v2/pkg/crd/kubermatic/v1"
 
-	"k8c.io/kubermatic/v2/pkg/controller/nodeport-proxy/envoymanager"
 	"k8c.io/kubermatic/v2/pkg/resources"
 	"k8c.io/kubermatic/v2/pkg/resources/nodeportproxy"
 	"k8c.io/kubermatic/v2/pkg/resources/reconciling"
@@ -42,7 +41,7 @@ func ServiceCreator(exposeStrategy kubermaticv1.ExposeStrategy, internalName str
 			switch exposeStrategy {
 			case kubermaticv1.ExposeStrategyNodePort:
 				se.Spec.Type = corev1.ServiceTypeNodePort
-				se.Annotations[envoymanager.DefaultExposeAnnotationKey] = envoymanager.NodePortType.String()
+				se.Annotations[nodeportproxy.DefaultExposeAnnotationKey] = nodeportproxy.NodePortType.String()
 				delete(se.Annotations, nodeportproxy.NodePortProxyExposeNamespacedAnnotationKey)
 			case kubermaticv1.ExposeStrategyLoadBalancer:
 				// Even when using exposeStrategy==LoadBalancer, we create
@@ -52,14 +51,14 @@ func ServiceCreator(exposeStrategy kubermaticv1.ExposeStrategy, internalName str
 				// for a unique port
 				se.Spec.Type = corev1.ServiceTypeNodePort
 				se.Annotations[nodeportproxy.NodePortProxyExposeNamespacedAnnotationKey] = "true"
-				delete(se.Annotations, envoymanager.DefaultExposeAnnotationKey)
+				delete(se.Annotations, nodeportproxy.DefaultExposeAnnotationKey)
 			case kubermaticv1.ExposeStrategyTunneling:
 				se.Spec.Type = corev1.ServiceTypeClusterIP
 				// When using exposeStrategy==Tunneling we need to expose
 				// the APIServer both with the SNI and the Tunneling listeners.
-				se.Annotations[envoymanager.DefaultExposeAnnotationKey] = strings.Join([]string{envoymanager.SNIType.String(), envoymanager.TunnelingType.String()}, ",")
+				se.Annotations[nodeportproxy.DefaultExposeAnnotationKey] = strings.Join([]string{nodeportproxy.SNIType.String(), nodeportproxy.TunnelingType.String()}, ",")
 				// We map the secure port to the internal name for SNI routing.
-				se.Annotations[envoymanager.PortHostMappingAnnotationKey] = fmt.Sprintf(`{"secure": %q}`, internalName)
+				se.Annotations[nodeportproxy.PortHostMappingAnnotationKey] = fmt.Sprintf(`{"secure": %q}`, internalName)
 				delete(se.Annotations, nodeportproxy.NodePortProxyExposeNamespacedAnnotationKey)
 			default:
 				return nil, fmt.Errorf("unsupported expose strategy: %q", exposeStrategy)

--- a/pkg/resources/nodeportproxy/nodeportproxy_test.go
+++ b/pkg/resources/nodeportproxy/nodeportproxy_test.go
@@ -1,1 +1,0 @@
-package nodeportproxy

--- a/pkg/resources/nodeportproxy/nodeportproxy_test.go
+++ b/pkg/resources/nodeportproxy/nodeportproxy_test.go
@@ -1,0 +1,1 @@
+package nodeportproxy

--- a/pkg/resources/openvpn/service.go
+++ b/pkg/resources/openvpn/service.go
@@ -19,7 +19,6 @@ package openvpn
 import (
 	"fmt"
 
-	"k8c.io/kubermatic/v2/pkg/controller/nodeport-proxy/envoymanager"
 	kubermaticv1 "k8c.io/kubermatic/v2/pkg/crd/kubermatic/v1"
 	"k8c.io/kubermatic/v2/pkg/resources"
 	"k8c.io/kubermatic/v2/pkg/resources/nodeportproxy"
@@ -42,15 +41,15 @@ func ServiceCreator(exposeStrategy kubermaticv1.ExposeStrategy) reconciling.Name
 			switch exposeStrategy {
 			case kubermaticv1.ExposeStrategyNodePort:
 				se.Spec.Type = corev1.ServiceTypeNodePort
-				se.Annotations[envoymanager.DefaultExposeAnnotationKey] = "true"
+				se.Annotations[nodeportproxy.DefaultExposeAnnotationKey] = "true"
 				delete(se.Annotations, nodeportproxy.NodePortProxyExposeNamespacedAnnotationKey)
 			case kubermaticv1.ExposeStrategyLoadBalancer:
 				se.Spec.Type = corev1.ServiceTypeNodePort
 				se.Annotations[nodeportproxy.NodePortProxyExposeNamespacedAnnotationKey] = "true"
-				delete(se.Annotations, envoymanager.DefaultExposeAnnotationKey)
+				delete(se.Annotations, nodeportproxy.DefaultExposeAnnotationKey)
 			case kubermaticv1.ExposeStrategyTunneling:
 				se.Spec.Type = corev1.ServiceTypeClusterIP
-				se.Annotations[envoymanager.DefaultExposeAnnotationKey] = envoymanager.TunnelingType.String()
+				se.Annotations[nodeportproxy.DefaultExposeAnnotationKey] = nodeportproxy.TunnelingType.String()
 				delete(se.Annotations, nodeportproxy.NodePortProxyExposeNamespacedAnnotationKey)
 			default:
 				return nil, fmt.Errorf("unsupported expose strategy: %q", exposeStrategy)

--- a/pkg/resources/openvpn/service.go
+++ b/pkg/resources/openvpn/service.go
@@ -17,6 +17,9 @@ limitations under the License.
 package openvpn
 
 import (
+	"fmt"
+
+	"k8c.io/kubermatic/v2/pkg/controller/nodeport-proxy/envoymanager"
 	kubermaticv1 "k8c.io/kubermatic/v2/pkg/crd/kubermatic/v1"
 	"k8c.io/kubermatic/v2/pkg/resources"
 	"k8c.io/kubermatic/v2/pkg/resources/nodeportproxy"
@@ -36,17 +39,25 @@ func ServiceCreator(exposeStrategy kubermaticv1.ExposeStrategy) reconciling.Name
 			if se.Annotations == nil {
 				se.Annotations = map[string]string{}
 			}
-			if exposeStrategy == kubermaticv1.ExposeStrategyNodePort {
-				se.Annotations["nodeport-proxy.k8s.io/expose"] = "true"
+			switch exposeStrategy {
+			case kubermaticv1.ExposeStrategyNodePort:
+				se.Spec.Type = corev1.ServiceTypeNodePort
+				se.Annotations[envoymanager.DefaultExposeAnnotationKey] = "true"
 				delete(se.Annotations, nodeportproxy.NodePortProxyExposeNamespacedAnnotationKey)
-			} else {
+			case kubermaticv1.ExposeStrategyLoadBalancer:
+				se.Spec.Type = corev1.ServiceTypeNodePort
 				se.Annotations[nodeportproxy.NodePortProxyExposeNamespacedAnnotationKey] = "true"
-				delete(se.Annotations, "nodeport-proxy.k8s.io/expose")
+				delete(se.Annotations, envoymanager.DefaultExposeAnnotationKey)
+			case kubermaticv1.ExposeStrategyTunneling:
+				se.Spec.Type = corev1.ServiceTypeClusterIP
+				se.Annotations[envoymanager.DefaultExposeAnnotationKey] = envoymanager.TunnelingType.String()
+				delete(se.Annotations, nodeportproxy.NodePortProxyExposeNamespacedAnnotationKey)
+			default:
+				return nil, fmt.Errorf("unsupported expose strategy: %q", exposeStrategy)
 			}
 			se.Spec.Selector = map[string]string{
 				resources.AppLabelKey: name,
 			}
-			se.Spec.Type = corev1.ServiceTypeNodePort
 			if len(se.Spec.Ports) == 0 {
 				se.Spec.Ports = make([]corev1.ServicePort, 1)
 			}

--- a/pkg/test/e2e/nodeport-proxy/nodeport_proxy_test.go
+++ b/pkg/test/e2e/nodeport-proxy/nodeport_proxy_test.go
@@ -28,7 +28,7 @@ import (
 	"k8s.io/apimachinery/pkg/util/intstr"
 	"k8s.io/apimachinery/pkg/util/sets"
 
-	"k8c.io/kubermatic/v2/pkg/controller/nodeport-proxy/envoymanager"
+	"k8c.io/kubermatic/v2/pkg/resources/nodeportproxy"
 	"k8c.io/kubermatic/v2/pkg/test"
 )
 
@@ -52,7 +52,7 @@ var _ = ginkgo.Describe("NodeportProxy", func() {
 				// nodePort set to 0 so that it gets allocated dynamically.
 				gomega.Expect(svcJig.CreateServiceWithPods(
 					test.NewServiceBuilder(test.NamespacedName{Name: "service-a"}).
-						WithAnnotation(envoymanager.DefaultExposeAnnotationKey, "true").
+						WithAnnotation(nodeportproxy.DefaultExposeAnnotationKey, "true").
 						WithSelector(map[string]string{"apps": "app-a"}).
 						WithServiceType(corev1.ServiceTypeNodePort).
 						WithServicePort("http", 80, 0, intstr.FromInt(8080), corev1.ProtocolTCP).
@@ -60,7 +60,7 @@ var _ = ginkgo.Describe("NodeportProxy", func() {
 					NotTo(gomega.BeNil(), "NodePort service creation failed")
 				gomega.Expect(svcJig.CreateServiceWithPods(
 					test.NewServiceBuilder(test.NamespacedName{Name: "service-b"}).
-						WithAnnotation(envoymanager.DefaultExposeAnnotationKey, "true").
+						WithAnnotation(nodeportproxy.DefaultExposeAnnotationKey, "true").
 						WithSelector(map[string]string{"apps": "app-b"}).
 						WithServiceType(corev1.ServiceTypeNodePort).
 						WithServicePort("http", 80, 0, intstr.FromInt(8080), corev1.ProtocolTCP).
@@ -98,8 +98,8 @@ var _ = ginkgo.Describe("NodeportProxy", func() {
 			ginkgo.BeforeEach(func() {
 				gomega.Expect(svcJig.CreateServiceWithPods(
 					test.NewServiceBuilder(test.NamespacedName{Name: "service-a"}).
-						WithAnnotation(envoymanager.DefaultExposeAnnotationKey, envoymanager.SNIType.String()).
-						WithAnnotation(envoymanager.PortHostMappingAnnotationKey, `{"https":"service-a.example.com"}`).
+						WithAnnotation(nodeportproxy.DefaultExposeAnnotationKey, nodeportproxy.SNIType.String()).
+						WithAnnotation(nodeportproxy.PortHostMappingAnnotationKey, `{"https":"service-a.example.com"}`).
 						WithSelector(map[string]string{"apps": "app-a"}).
 						WithServiceType(corev1.ServiceTypeClusterIP).
 						WithServicePort("https", 6443, 0, intstr.FromInt(6443), corev1.ProtocolTCP).
@@ -107,8 +107,8 @@ var _ = ginkgo.Describe("NodeportProxy", func() {
 					NotTo(gomega.BeNil(), "ClusterIP service creation failed")
 				gomega.Expect(svcJig.CreateServiceWithPods(
 					test.NewServiceBuilder(test.NamespacedName{Name: "service-b"}).
-						WithAnnotation(envoymanager.DefaultExposeAnnotationKey, envoymanager.SNIType.String()).
-						WithAnnotation(envoymanager.PortHostMappingAnnotationKey, `{"https":"service-b.example.com"}`).
+						WithAnnotation(nodeportproxy.DefaultExposeAnnotationKey, nodeportproxy.SNIType.String()).
+						WithAnnotation(nodeportproxy.PortHostMappingAnnotationKey, `{"https":"service-b.example.com"}`).
 						WithSelector(map[string]string{"apps": "app-b"}).
 						WithServiceType(corev1.ServiceTypeClusterIP).
 						WithServicePort("https", 6443, 0, intstr.FromInt(6443), corev1.ProtocolTCP).
@@ -131,7 +131,7 @@ var _ = ginkgo.Describe("NodeportProxy", func() {
 			ginkgo.BeforeEach(func() {
 				gomega.Expect(svcJig.CreateServiceWithPods(
 					test.NewServiceBuilder(test.NamespacedName{Name: "service-a"}).
-						WithAnnotation(envoymanager.DefaultExposeAnnotationKey, envoymanager.TunnelingType.String()).
+						WithAnnotation(nodeportproxy.DefaultExposeAnnotationKey, nodeportproxy.TunnelingType.String()).
 						WithSelector(map[string]string{"apps": "app-a"}).
 						WithServiceType(corev1.ServiceTypeClusterIP).
 						WithServicePort("https", 8080, 0, intstr.FromInt(8088), corev1.ProtocolTCP).
@@ -139,7 +139,7 @@ var _ = ginkgo.Describe("NodeportProxy", func() {
 					NotTo(gomega.BeNil(), "ClusterIP service creation failed")
 				gomega.Expect(svcJig.CreateServiceWithPods(
 					test.NewServiceBuilder(test.NamespacedName{Name: "service-b"}).
-						WithAnnotation(envoymanager.DefaultExposeAnnotationKey, envoymanager.TunnelingType.String()).
+						WithAnnotation(nodeportproxy.DefaultExposeAnnotationKey, nodeportproxy.TunnelingType.String()).
 						WithSelector(map[string]string{"apps": "app-b"}).
 						WithServiceType(corev1.ServiceTypeClusterIP).
 						WithServicePort("https", 8080, 0, intstr.FromInt(8088), corev1.ProtocolTCP).
@@ -170,7 +170,7 @@ var _ = ginkgo.Describe("NodeportProxy", func() {
 					NotTo(gomega.BeNil(), "NodePort service creation failed")
 				gomega.Expect(svcJig.CreateServiceWithPods(
 					test.NewServiceBuilder(test.NamespacedName{Name: "service-b"}).
-						WithAnnotation(envoymanager.DefaultExposeAnnotationKey, "false").
+						WithAnnotation(nodeportproxy.DefaultExposeAnnotationKey, "false").
 						WithSelector(map[string]string{"apps": "app-b"}).
 						WithServiceType(corev1.ServiceTypeNodePort).
 						WithServicePort("http", 80, 0, intstr.FromInt(8080), corev1.ProtocolTCP).

--- a/pkg/test/e2e/nodeport-proxy/nodeport_proxy_test.go
+++ b/pkg/test/e2e/nodeport-proxy/nodeport_proxy_test.go
@@ -52,7 +52,7 @@ var _ = ginkgo.Describe("NodeportProxy", func() {
 				// nodePort set to 0 so that it gets allocated dynamically.
 				gomega.Expect(svcJig.CreateServiceWithPods(
 					test.NewServiceBuilder(test.NamespacedName{Name: "service-a"}).
-						WithAnnotation(nodeportproxy.DefaultExposeAnnotationKey, "true").
+						WithAnnotation(nodeportproxy.DefaultExposeAnnotationKey, nodeportproxy.NodePortType.String()).
 						WithSelector(map[string]string{"apps": "app-a"}).
 						WithServiceType(corev1.ServiceTypeNodePort).
 						WithServicePort("http", 80, 0, intstr.FromInt(8080), corev1.ProtocolTCP).


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR makes sure that the control plane components manifests are configured properly when the Tunneling expose strategy is used:
- The KAS uses standard port `6443`.
- KAS and OpenVPN services are properly annotated.

xref: #4942

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #5812 

**Special notes for your reviewer**:

**Documentation**:
<!-- Add links to the related documentation changes related to this pull request. E.g. the link to the kubermatic/docs pull request. -->

**Does this PR introduce a user-facing change?**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If  no release note is required, just write "NONE".
-->
```release-note
NONE
```
