### PR TITLE
only enable password-logins in Dex if passwords are configured

### DIFF
--- a/charts/oauth/Chart.yaml
+++ b/charts/oauth/Chart.yaml
@@ -14,7 +14,7 @@
 
 apiVersion: v1
 name: oauth
-version: 1.4.0
+version: 1.5.0
 appVersion: v2.24.0
 description: Dex
 keywords:

--- a/charts/oauth/templates/configmap.yaml
+++ b/charts/oauth/templates/configmap.yaml
@@ -12,13 +12,13 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-kind: ConfigMap
 apiVersion: v1
+kind: ConfigMap
 metadata:
   name: dex
 data:
   config.yaml: |
-    issuer: {{ .Values.dex.ingress.scheme }}://{{ .Values.dex.ingress.host }}{{ .Values.dex.ingress.path }}
+    issuer: "{{ .Values.dex.ingress.scheme }}://{{ .Values.dex.ingress.host }}{{ .Values.dex.ingress.path }}"
     oauth2:
       skipApprovalScreen: true
       responseTypes:
@@ -35,8 +35,6 @@ data:
       logoURL: theme/logo.svg
     telemetry:
       http: 0.0.0.0:5558
-    # this is a requirement for static passwords, so we just enable it by default
-    enablePasswordDB: true
 {{ if .Values.dex.expiry }}
     expiry:
 {{ toYaml .Values.dex.expiry | indent 6 }}
@@ -53,12 +51,8 @@ data:
     staticClients:
 {{ toYaml .Values.dex.clients | indent 6 }}
 {{- end }}
-{{ if or .Values.dex.staticPasswords .Values.dex.staticPasswordLogins }}
+{{ if .Values.dex.staticPasswords }}
+    enablePasswordDB: true
     staticPasswords:
-{{- if .Values.dex.staticPasswords }}
 {{ toYaml .Values.dex.staticPasswords | indent 6 }}
-{{- end }}
-{{- if .Values.dex.staticPasswordLogins }}
-{{ toYaml .Values.dex.staticPasswordLogins | indent 6 }}
-{{- end }}
 {{- end }}

--- a/charts/oauth/templates/secrets.yaml
+++ b/charts/oauth/templates/secrets.yaml
@@ -24,8 +24,8 @@ data: {{ if .Values.dex.grpc }}
 {{- end }}
 
 ---
-kind: Secret
 apiVersion: v1
+kind: Secret
 metadata:
   name: themes
 data:


### PR DESCRIPTION
**What this PR does / why we need it**:
This makes it easier to use Dex for OIDC logins, as the whole login can happen completely automatically. Currently the user would have to make a single click: the click on the login provider they want to use.

With this patch, if you only have 1 connector, the user will automatically be redirected to that connector.

This PR also removes the deprecated `staticPasswordLogins` field, which has long been replaced by `staticPasswords`. The old spelling was deprecated since KKP 2.13.

**Does this PR introduce a user-facing change?**:
```release-note
Dex configuration does not support `staticPasswordLogins` anymore, use `staticPasswords` instead.
```
