### PR TITLE
migrate to networking.k8s.io/v1beta1 for Ingresses

### DIFF
--- a/charts/certs/Chart.yaml
+++ b/charts/certs/Chart.yaml
@@ -14,7 +14,7 @@
 
 apiVersion: v1
 name: certs
-version: 1.1.3
+version: 1.1.4
 description: Chart for creating the required certificates for Kubermatic master clusters.
 keywords:
 - kubermatic

--- a/charts/certs/templates/acme-challenge-ingress.yaml
+++ b/charts/certs/templates/acme-challenge-ingress.yaml
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-apiVersion: extensions/v1beta1
+apiVersion: networking.k8s.io/v1beta1
 kind: Ingress
 metadata:
   annotations:

--- a/charts/iap/Chart.yaml
+++ b/charts/iap/Chart.yaml
@@ -14,7 +14,7 @@
 
 apiVersion: v1
 name: iap
-version: 3.1.1
+version: 3.1.2
 appVersion: v6.1.1
 description: A Helm chart to install OAuth2-Proxy as an identity-aware proxy.
 keywords:

--- a/charts/iap/templates/ingresses.yaml
+++ b/charts/iap/templates/ingresses.yaml
@@ -14,7 +14,7 @@
 
 {{ range .Values.iap.deployments }}
 ---
-apiVersion: extensions/v1beta1
+apiVersion: networking.k8s.io/v1beta1
 kind: Ingress
 metadata:
   name: {{ .name }}-iap

--- a/charts/kubermatic/Chart.yaml
+++ b/charts/kubermatic/Chart.yaml
@@ -14,7 +14,7 @@
 
 apiVersion: v1
 name: kubermatic
-version: 1.1.26
+version: 1.1.27
 appVersion: '__KUBERMATIC_TAG__'
 description: Kubermatic chart for master and/or seed clusters.
 keywords:

--- a/charts/kubermatic/templates/ingress.yaml
+++ b/charts/kubermatic/templates/ingress.yaml
@@ -13,7 +13,7 @@
 # limitations under the License.
 
 {{ if .Values.kubermatic.isMaster }}
-apiVersion: extensions/v1beta1
+apiVersion: networking.k8s.io/v1beta1
 kind: Ingress
 metadata:
   name: api

--- a/charts/oauth/Chart.yaml
+++ b/charts/oauth/Chart.yaml
@@ -14,7 +14,7 @@
 
 apiVersion: v1
 name: oauth
-version: 1.5.0
+version: 1.5.1
 appVersion: v2.24.0
 description: Dex
 keywords:

--- a/charts/oauth/templates/ingress.yaml
+++ b/charts/oauth/templates/ingress.yaml
@@ -13,7 +13,7 @@
 # limitations under the License.
 
 {{ if ne .Values.dex.ingress.class "non-existent" }}
-apiVersion: extensions/v1beta1
+apiVersion: networking.k8s.io/v1beta1
 kind: Ingress
 metadata:
   name: dex

--- a/codegen/reconcile/main.go
+++ b/codegen/reconcile/main.go
@@ -138,8 +138,8 @@ func main() {
 			{
 				ResourceName:       "Ingress",
 				ResourceNamePlural: "Ingresses",
-				ImportAlias:        "extensionsv1beta1",
-				ResourceImportPath: "k8s.io/api/extensions/v1beta1",
+				ImportAlias:        "networkingv1beta1",
+				ResourceImportPath: "k8s.io/api/networking/v1beta1",
 			},
 			{
 				ResourceName:       "Seed",

--- a/pkg/controller/operator/master/controller.go
+++ b/pkg/controller/operator/master/controller.go
@@ -30,7 +30,7 @@ import (
 	admissionregistrationv1beta1 "k8s.io/api/admissionregistration/v1beta1"
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
-	extensionsv1beta1 "k8s.io/api/extensions/v1beta1"
+	networkingv1beta1 "k8s.io/api/networking/v1beta1"
 	policyv1beta1 "k8s.io/api/policy/v1beta1"
 	rbacv1 "k8s.io/api/rbac/v1"
 	"k8s.io/apimachinery/pkg/runtime"
@@ -127,7 +127,7 @@ func Add(
 		&corev1.Secret{},
 		&corev1.Service{},
 		&corev1.ServiceAccount{},
-		&extensionsv1beta1.Ingress{},
+		&networkingv1beta1.Ingress{},
 		&policyv1beta1.PodDisruptionBudget{},
 	}
 

--- a/pkg/controller/operator/master/resources/kubermatic/common.go
+++ b/pkg/controller/operator/master/resources/kubermatic/common.go
@@ -24,7 +24,7 @@ import (
 
 	certmanagerv1alpha2 "github.com/jetstack/cert-manager/pkg/apis/certmanager/v1alpha2"
 	corev1 "k8s.io/api/core/v1"
-	extensionsv1beta1 "k8s.io/api/extensions/v1beta1"
+	networkingv1beta1 "k8s.io/api/networking/v1beta1"
 	rbacv1 "k8s.io/api/rbac/v1"
 	"k8s.io/apimachinery/pkg/util/intstr"
 )
@@ -92,7 +92,7 @@ func ClusterRoleBindingCreator(cfg *operatorv1alpha1.KubermaticConfiguration) re
 
 func IngressCreator(cfg *operatorv1alpha1.KubermaticConfiguration) reconciling.NamedIngressCreatorGetter {
 	return func() (string, reconciling.IngressCreator) {
-		return ingressName, func(i *extensionsv1beta1.Ingress) (*extensionsv1beta1.Ingress, error) {
+		return ingressName, func(i *networkingv1beta1.Ingress) (*networkingv1beta1.Ingress, error) {
 			if i.Annotations == nil {
 				i.Annotations = make(map[string]string)
 			}
@@ -115,7 +115,7 @@ func IngressCreator(cfg *operatorv1alpha1.KubermaticConfiguration) reconciling.N
 					return nil, fmt.Errorf("unknown Certificate Issuer Kind %q configured", issuer.Kind)
 				}
 
-				i.Spec.TLS = []extensionsv1beta1.IngressTLS{
+				i.Spec.TLS = []networkingv1beta1.IngressTLS{
 					{
 						Hosts:      []string{cfg.Spec.Ingress.Domain},
 						SecretName: certificateSecretName,
@@ -123,7 +123,7 @@ func IngressCreator(cfg *operatorv1alpha1.KubermaticConfiguration) reconciling.N
 				}
 			}
 
-			i.Spec.Backend = &extensionsv1beta1.IngressBackend{
+			i.Spec.Backend = &networkingv1beta1.IngressBackend{
 				ServiceName: uiServiceName,
 				ServicePort: intstr.FromInt(80),
 			}
@@ -132,7 +132,7 @@ func IngressCreator(cfg *operatorv1alpha1.KubermaticConfiguration) reconciling.N
 			// "ImplementationSpecific". To prevent reconcile loops in previous
 			// Kubernetes versions, this code is carefully written to not
 			// overwrite a PathType that has been defaulted by the apiserver.
-			var pathType *extensionsv1beta1.PathType
+			var pathType *networkingv1beta1.PathType
 
 			// As we control the entire rule set anyway, it's enough to find
 			// the first pathType -- they will all be identical eventually.
@@ -145,16 +145,16 @@ func IngressCreator(cfg *operatorv1alpha1.KubermaticConfiguration) reconciling.N
 				}
 			}
 
-			i.Spec.Rules = []extensionsv1beta1.IngressRule{
+			i.Spec.Rules = []networkingv1beta1.IngressRule{
 				{
 					Host: cfg.Spec.Ingress.Domain,
-					IngressRuleValue: extensionsv1beta1.IngressRuleValue{
-						HTTP: &extensionsv1beta1.HTTPIngressRuleValue{
-							Paths: []extensionsv1beta1.HTTPIngressPath{
+					IngressRuleValue: networkingv1beta1.IngressRuleValue{
+						HTTP: &networkingv1beta1.HTTPIngressRuleValue{
+							Paths: []networkingv1beta1.HTTPIngressPath{
 								{
 									Path:     "/api",
 									PathType: pathType,
-									Backend: extensionsv1beta1.IngressBackend{
+									Backend: networkingv1beta1.IngressBackend{
 										ServiceName: apiServiceName,
 										ServicePort: intstr.FromInt(80),
 									},

--- a/pkg/controller/operator/master/resources/kubermatic/common_test.go
+++ b/pkg/controller/operator/master/resources/kubermatic/common_test.go
@@ -21,7 +21,7 @@ import (
 
 	operatorv1alpha1 "k8c.io/kubermatic/v2/pkg/crd/operator/v1alpha1"
 
-	extensionsv1beta1 "k8s.io/api/extensions/v1beta1"
+	networkingv1beta1 "k8s.io/api/networking/v1beta1"
 	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
@@ -29,30 +29,30 @@ func TestIngressCreatorKeepsPathType(t *testing.T) {
 	cfg := &operatorv1alpha1.KubermaticConfiguration{}
 	creatorGetter := IngressCreator(cfg)
 	_, creator := creatorGetter()
-	defaultPathType := extensionsv1beta1.PathTypeImplementationSpecific
+	defaultPathType := networkingv1beta1.PathTypeImplementationSpecific
 
 	testcases := []struct {
 		name              string
-		ingress           *extensionsv1beta1.Ingress
-		expectedPathTypes map[string]*extensionsv1beta1.PathType
+		ingress           *networkingv1beta1.Ingress
+		expectedPathTypes map[string]*networkingv1beta1.PathType
 	}{
 		{
 			name:    "vanilla case",
-			ingress: &extensionsv1beta1.Ingress{},
-			expectedPathTypes: map[string]*extensionsv1beta1.PathType{
+			ingress: &networkingv1beta1.Ingress{},
+			expectedPathTypes: map[string]*networkingv1beta1.PathType{
 				"/":    nil,
 				"/api": nil,
 			},
 		},
 		{
 			name: "keep 1.18+ apiserver defaults",
-			ingress: &extensionsv1beta1.Ingress{
-				Spec: extensionsv1beta1.IngressSpec{
-					Rules: []extensionsv1beta1.IngressRule{
+			ingress: &networkingv1beta1.Ingress{
+				Spec: networkingv1beta1.IngressSpec{
+					Rules: []networkingv1beta1.IngressRule{
 						{
-							IngressRuleValue: extensionsv1beta1.IngressRuleValue{
-								HTTP: &extensionsv1beta1.HTTPIngressRuleValue{
-									Paths: []extensionsv1beta1.HTTPIngressPath{
+							IngressRuleValue: networkingv1beta1.IngressRuleValue{
+								HTTP: &networkingv1beta1.HTTPIngressRuleValue{
+									Paths: []networkingv1beta1.HTTPIngressPath{
 										{
 											Path:     "/",
 											PathType: &defaultPathType,
@@ -68,7 +68,7 @@ func TestIngressCreatorKeepsPathType(t *testing.T) {
 					},
 				},
 			},
-			expectedPathTypes: map[string]*extensionsv1beta1.PathType{
+			expectedPathTypes: map[string]*networkingv1beta1.PathType{
 				"/":    &defaultPathType,
 				"/api": &defaultPathType,
 			},
@@ -106,15 +106,15 @@ func TestIngressCreatorKeepsAnnotations(t *testing.T) {
 
 	testcases := []struct {
 		name    string
-		ingress *extensionsv1beta1.Ingress
+		ingress *networkingv1beta1.Ingress
 	}{
 		{
 			name:    "do not fail on nil map",
-			ingress: &extensionsv1beta1.Ingress{},
+			ingress: &networkingv1beta1.Ingress{},
 		},
 		{
 			name: "keep existing annotations",
-			ingress: &extensionsv1beta1.Ingress{
+			ingress: &networkingv1beta1.Ingress{
 				ObjectMeta: v1.ObjectMeta{
 					Annotations: map[string]string{
 						"test": "value",

--- a/pkg/controller/user-cluster-controller-manager/rbac/mapper.go
+++ b/pkg/controller/user-cluster-controller-manager/rbac/mapper.go
@@ -28,6 +28,7 @@ import (
 	autoscaling "k8s.io/api/autoscaling/v1"
 	batch "k8s.io/api/batch/v1"
 	extensions "k8s.io/api/extensions/v1beta1"
+	networking "k8s.io/api/networking/v1beta1"
 	rbacv1 "k8s.io/api/rbac/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
@@ -80,7 +81,8 @@ func GenerateRBACClusterRole(resourceName string) (*rbacv1.ClusterRole, error) {
 			},
 			{
 				APIGroups: []string{""},
-				Resources: []string{"configmaps",
+				Resources: []string{
+					"configmaps",
 					"endpoints",
 					"persistentvolumeclaims",
 					"pods",
@@ -95,7 +97,8 @@ func GenerateRBACClusterRole(resourceName string) (*rbacv1.ClusterRole, error) {
 			},
 			{
 				APIGroups: []string{""},
-				Resources: []string{"bindings",
+				Resources: []string{
+					"bindings",
 					"events",
 					"limitranges",
 					"namespaces/status",
@@ -109,7 +112,8 @@ func GenerateRBACClusterRole(resourceName string) (*rbacv1.ClusterRole, error) {
 			},
 			{
 				APIGroups: []string{apps.GroupName},
-				Resources: []string{"controllerrevisions",
+				Resources: []string{
+					"controllerrevisions",
 					"daemonsets",
 					"deployments",
 					"deployments/scale",
@@ -132,7 +136,8 @@ func GenerateRBACClusterRole(resourceName string) (*rbacv1.ClusterRole, error) {
 			},
 			{
 				APIGroups: []string{extensions.GroupName},
-				Resources: []string{"daemonsets",
+				Resources: []string{
+					"daemonsets",
 					"deployments",
 					"deployments/scale",
 					"ingresses",
@@ -144,7 +149,7 @@ func GenerateRBACClusterRole(resourceName string) (*rbacv1.ClusterRole, error) {
 				Verbs: verbs,
 			},
 			{
-				APIGroups: []string{"networking.k8s.io"},
+				APIGroups: []string{networking.GroupName},
 				Resources: []string{"ingresses", "networkpolicies"},
 				Verbs:     verbs,
 			},

--- a/pkg/resources/reconciling/zz_generated_reconcile.go
+++ b/pkg/resources/reconciling/zz_generated_reconcile.go
@@ -16,7 +16,7 @@ import (
 	appsv1 "k8s.io/api/apps/v1"
 	batchv1beta1 "k8s.io/api/batch/v1beta1"
 	corev1 "k8s.io/api/core/v1"
-	extensionsv1beta1 "k8s.io/api/extensions/v1beta1"
+	networkingv1beta1 "k8s.io/api/networking/v1beta1"
 	policyv1beta1 "k8s.io/api/policy/v1beta1"
 	rbacv1 "k8s.io/api/rbac/v1"
 	apiextensionsv1beta1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1beta1"
@@ -732,7 +732,7 @@ func ReconcileAPIServices(ctx context.Context, namedGetters []NamedAPIServiceCre
 }
 
 // IngressCreator defines an interface to create/update Ingresss
-type IngressCreator = func(existing *extensionsv1beta1.Ingress) (*extensionsv1beta1.Ingress, error)
+type IngressCreator = func(existing *networkingv1beta1.Ingress) (*networkingv1beta1.Ingress, error)
 
 // NamedIngressCreatorGetter returns the name of the resource and the corresponding creator function
 type NamedIngressCreatorGetter = func() (name string, create IngressCreator)
@@ -742,9 +742,9 @@ type NamedIngressCreatorGetter = func() (name string, create IngressCreator)
 func IngressObjectWrapper(create IngressCreator) ObjectCreator {
 	return func(existing runtime.Object) (runtime.Object, error) {
 		if existing != nil {
-			return create(existing.(*extensionsv1beta1.Ingress))
+			return create(existing.(*networkingv1beta1.Ingress))
 		}
-		return create(&extensionsv1beta1.Ingress{})
+		return create(&networkingv1beta1.Ingress{})
 	}
 }
 
@@ -760,7 +760,7 @@ func ReconcileIngresses(ctx context.Context, namedGetters []NamedIngressCreatorG
 			createObject = objectModifier(createObject)
 		}
 
-		if err := EnsureNamedObject(ctx, types.NamespacedName{Namespace: namespace, Name: name}, createObject, client, &extensionsv1beta1.Ingress{}, false); err != nil {
+		if err := EnsureNamedObject(ctx, types.NamespacedName{Namespace: namespace, Name: name}, createObject, client, &networkingv1beta1.Ingress{}, false); err != nil {
 			return fmt.Errorf("failed to ensure Ingress %s/%s: %v", namespace, name, err)
 		}
 	}


### PR DESCRIPTION
**What this PR does / why we need it**:
`extensions/v1beta1` has been deprecated for Ingresses for quite some time.

**Does this PR introduce a user-facing change?**:
```release-note
Update to networking.k8s.io/v1beta1 for managing Ingresses.
```
