### PR TITLE
WIP - migrate to v1 for our CRDs

### DIFF
--- a/charts/kubermatic/Chart.yaml
+++ b/charts/kubermatic/Chart.yaml
@@ -14,7 +14,7 @@
 
 apiVersion: v1
 name: kubermatic
-version: 1.1.26
+version: 1.1.30
 appVersion: '__KUBERMATIC_TAG__'
 description: Kubermatic chart for master and/or seed clusters.
 keywords:

--- a/charts/kubermatic/crd/crd-addon-configs.yaml
+++ b/charts/kubermatic/crd/crd-addon-configs.yaml
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-apiVersion: apiextensions.k8s.io/v1beta1
+apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   name: addonconfigs.kubermatic.k8s.io
@@ -24,4 +24,7 @@ spec:
     plural: addonconfigs
     singular: addonconfig
   scope: Cluster
-  version: v1
+  versions:
+  - name: v1
+    served: true
+    storage: true

--- a/charts/kubermatic/crd/crd-addons.yaml
+++ b/charts/kubermatic/crd/crd-addons.yaml
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-apiVersion: apiextensions.k8s.io/v1beta1
+apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   name: addons.kubermatic.k8s.io
@@ -24,4 +24,7 @@ spec:
     plural: addons
     singular: addon
   scope: Namespaced
-  version: v1
+  versions:
+  - name: v1
+    served: true
+    storage: true

--- a/charts/kubermatic/crd/crd-admission-plugins.yaml
+++ b/charts/kubermatic/crd/crd-admission-plugins.yaml
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-apiVersion: apiextensions.k8s.io/v1beta1
+apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   name: admissionplugins.kubermatic.k8s.io
@@ -24,4 +24,7 @@ spec:
     plural: admissionplugins
     singular: admissionplugin
   scope: Cluster
-  version: v1
+  versions:
+  - name: v1
+    served: true
+    storage: true

--- a/charts/kubermatic/crd/crd-clusters.yaml
+++ b/charts/kubermatic/crd/crd-clusters.yaml
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-apiVersion: apiextensions.k8s.io/v1beta1
+apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   name: clusters.kubermatic.k8s.io
@@ -26,7 +26,10 @@ spec:
     shortNames:
       - cl
   scope: Cluster
-  version: v1
+  versions:
+  - name: v1
+    served: true
+    storage: true
   additionalPrinterColumns:
   - JSONPath: .metadata.creationTimestamp
     description: |-

--- a/charts/kubermatic/crd/crd-constraint-templates.yaml
+++ b/charts/kubermatic/crd/crd-constraint-templates.yaml
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-apiVersion: apiextensions.k8s.io/v1beta1
+apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   name: constrainttemplates.kubermatic.k8s.io
@@ -24,4 +24,7 @@ spec:
     plural: constrainttemplates
     singular: constrainttemplate
   scope: Cluster
-  version: v1
+  versions:
+  - name: v1
+    served: true
+    storage: true

--- a/charts/kubermatic/crd/crd-constraints.yaml
+++ b/charts/kubermatic/crd/crd-constraints.yaml
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-apiVersion: apiextensions.k8s.io/v1beta1
+apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   name: constraints.kubermatic.k8s.io
@@ -24,4 +24,7 @@ spec:
     plural: constraints
     singular: constraint
   scope: Namespaced
-  version: v1
+  versions:
+  - name: v1
+    served: true
+    storage: true

--- a/charts/kubermatic/crd/crd-datacenter.yaml
+++ b/charts/kubermatic/crd/crd-datacenter.yaml
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-apiVersion: apiextensions.k8s.io/v1beta1
+apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   name: seeds.kubermatic.k8s.io
@@ -24,4 +24,7 @@ spec:
     plural: seeds
     singular: seed
   scope: Namespaced
-  version: v1
+  versions:
+  - name: v1
+    served: true
+    storage: true

--- a/charts/kubermatic/crd/crd-external-clusters.yaml
+++ b/charts/kubermatic/crd/crd-external-clusters.yaml
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-apiVersion: apiextensions.k8s.io/v1beta1
+apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   name: externalclusters.kubermatic.k8s.io
@@ -26,7 +26,10 @@ spec:
     shortNames:
       - ecl
   scope: Cluster
-  version: v1
+  versions:
+  - name: v1
+    served: true
+    storage: true
   additionalPrinterColumns:
     - JSONPath: .metadata.creationTimestamp
       description: |-

--- a/charts/kubermatic/crd/crd-kubermatic-configuration.yaml
+++ b/charts/kubermatic/crd/crd-kubermatic-configuration.yaml
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-apiVersion: apiextensions.k8s.io/v1beta1
+apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   name: kubermaticconfigurations.operator.kubermatic.io
@@ -24,4 +24,7 @@ spec:
     plural: kubermaticconfigurations
     singular: kubermaticconfiguration
   scope: Namespaced
-  version: v1alpha1
+  versions:
+  - name: v1alpha1
+    served: true
+    storage: true

--- a/charts/kubermatic/crd/crd-kubermatic-settings.yaml
+++ b/charts/kubermatic/crd/crd-kubermatic-settings.yaml
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-apiVersion: apiextensions.k8s.io/v1beta1
+apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   name: kubermaticsettings.kubermatic.k8s.io
@@ -24,4 +24,7 @@ spec:
     plural: kubermaticsettings
     singular: kubermaticsetting
   scope: Cluster
-  version: v1
+  versions:
+  - name: v1
+    served: true
+    storage: true

--- a/charts/kubermatic/crd/crd-presets.yaml
+++ b/charts/kubermatic/crd/crd-presets.yaml
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-apiVersion: apiextensions.k8s.io/v1beta1
+apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   name: presets.kubermatic.k8s.io
@@ -24,4 +24,7 @@ spec:
     plural: presets
     singular: preset
   scope: Cluster
-  version: v1
+  versions:
+  - name: v1
+    served: true
+    storage: true

--- a/charts/kubermatic/crd/crd-projects.yaml
+++ b/charts/kubermatic/crd/crd-projects.yaml
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-apiVersion: apiextensions.k8s.io/v1beta1
+apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   name: projects.kubermatic.k8s.io
@@ -24,7 +24,10 @@ spec:
     plural: projects
     singular: project
   scope: Cluster
-  version: v1
+  versions:
+  - name: v1
+    served: true
+    storage: true
   additionalPrinterColumns:
     - JSONPath: .metadata.creationTimestamp
       description: |-

--- a/charts/kubermatic/crd/crd-ssh-keys.yaml
+++ b/charts/kubermatic/crd/crd-ssh-keys.yaml
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-apiVersion: apiextensions.k8s.io/v1beta1
+apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   name: usersshkeies.kubermatic.k8s.io
@@ -24,7 +24,10 @@ spec:
     plural: usersshkeies
     singular: usersshkey
   scope: Cluster
-  version: v1
+  versions:
+  - name: v1
+    served: true
+    storage: true
   additionalPrinterColumns:
     - JSONPath: .metadata.creationTimestamp
       description: |-

--- a/charts/kubermatic/crd/crd-user-project-binding.yaml
+++ b/charts/kubermatic/crd/crd-user-project-binding.yaml
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-apiVersion: apiextensions.k8s.io/v1beta1
+apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   name: userprojectbindings.kubermatic.k8s.io
@@ -24,7 +24,10 @@ spec:
     plural: userprojectbindings
     singular: userprojectbinding
   scope: Cluster
-  version: v1
+  versions:
+  - name: v1
+    served: true
+    storage: true
   additionalPrinterColumns:
     - JSONPath: .metadata.creationTimestamp
       description: |-

--- a/charts/kubermatic/crd/crd-users.yaml
+++ b/charts/kubermatic/crd/crd-users.yaml
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-apiVersion: apiextensions.k8s.io/v1beta1
+apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   name: users.kubermatic.k8s.io
@@ -24,7 +24,10 @@ spec:
     plural: users
     singular: user
   scope: Cluster
-  version: v1
+  versions:
+  - name: v1
+    served: true
+    storage: true
   additionalPrinterColumns:
   - JSONPath: .metadata.creationTimestamp
     description: |-

--- a/charts/kubermatic/crd/crd-vpa.yaml
+++ b/charts/kubermatic/crd/crd-vpa.yaml
@@ -12,20 +12,19 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-apiVersion: apiextensions.k8s.io/v1beta1
+apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   name: verticalpodautoscalers.autoscaling.k8s.io
 spec:
   group: autoscaling.k8s.io
-  scope: Namespaced
   names:
     plural: verticalpodautoscalers
     singular: verticalpodautoscaler
     kind: VerticalPodAutoscaler
     shortNames:
     - vpa
-  version: v1beta1
+  scope: Namespaced
   versions:
   - name: v1beta1
     served: true
@@ -50,21 +49,21 @@ spec:
               properties:
                 containerPolicies:
                   type: array
+
 ---
-apiVersion: apiextensions.k8s.io/v1beta1
+apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   name: verticalpodautoscalercheckpoints.autoscaling.k8s.io
 spec:
   group: autoscaling.k8s.io
-  scope: Namespaced
   names:
     plural: verticalpodautoscalercheckpoints
     singular: verticalpodautoscalercheckpoint
     kind: VerticalPodAutoscalerCheckpoint
     shortNames:
     - vpacheckpoint
-  version: v1beta1
+  scope: Namespaced
   versions:
   - name: v1beta1
     served: true


### PR DESCRIPTION
**What this PR does / why we need it**:
v1beta1 has been deprecated (see https://github.com/kubernetes/kubernetes/issues/82022) and v1 has been available since Kubernetes 1.16.

Velero upstream is still using v1beta1 for compatibility reasons, cert-manager CRDs for v1.0 are using v1, but updating them is a bit more work.

**Does this PR introduce a user-facing change?**:
```release-note
Kubermatic CRDs are now using apiextensions/v1.
```
