### PR TITLE
Fix envoymanager flag

### DIFF
--- a/cmd/nodeport-proxy/envoy-manager/main.go
+++ b/cmd/nodeport-proxy/envoy-manager/main.go
@@ -43,7 +43,7 @@ func main() {
 	flag.IntVar(&ctrlOpts.EnvoyAdminPort, "envoy-admin-port", 9001, "Envoys admin port")
 	flag.IntVar(&ctrlOpts.EnvoyStatsPort, "envoy-stats-port", 8002, "Limited port which should be opened on envoy to expose metrics and the health check. Endpoints are: /healthz & /stats")
 	flag.IntVar(&ctrlOpts.EnvoySNIListenerPort, "envoy-sni-port", 0, "Port used for SNI entry point.")
-	flag.IntVar(&ctrlOpts.EnvoyTunnelingListenerPort, "envoy-tunneling-connect-port", 0, "Port used for HTTP/2 CONNECT termination.")
+	flag.IntVar(&ctrlOpts.EnvoyTunnelingListenerPort, "envoy-tunneling-port", 0, "Port used for HTTP/2 CONNECT termination.")
 	flag.StringVar(&ctrlOpts.Namespace, "namespace", "", "The namespace we should use for pods and services. Leave empty for all namespaces.")
 	flag.StringVar(&ctrlOpts.ExposeAnnotationKey, "expose-annotation-key", envoymanager.DefaultExposeAnnotationKey, "The annotation key used to determine if a service should be exposed")
 	flag.Parse()

--- a/hack/run-nodeport-proxy-e2e-test-in-kind.sh
+++ b/hack/run-nodeport-proxy-e2e-test-in-kind.sh
@@ -75,7 +75,7 @@ else
         --ginkgo.failOnPending \
         --ginkgo.trace \
         --ginkgo.progress \
-        -- --kubeconfig "${HOME}/.kube/config" \
+        --kubeconfig "${HOME}/.kube/config" \
         --kubermatic-tag "${TAG}" \
         --debug-log
 fi

--- a/pkg/controller/operator/seed/resources/nodeportproxy/deployments.go
+++ b/pkg/controller/operator/seed/resources/nodeportproxy/deployments.go
@@ -98,7 +98,7 @@ func EnvoyDeploymentCreator(cfg *operatorv1alpha1.KubermaticConfiguration, seed 
 			if cfg.Spec.FeatureGates.Has(features.TunnelingExposeStrategy) {
 				args = append(args,
 					fmt.Sprintf("-envoy-sni-port=%d", EnvoySNIPort),
-					fmt.Sprintf("-envoy-tunneling-connect-port=%d", EnvoyTunnelingPort))
+					fmt.Sprintf("-envoy-tunneling-port=%d", EnvoyTunnelingPort))
 			}
 			d.Spec.Template.Spec.Containers = []corev1.Container{
 				{
@@ -226,7 +226,7 @@ func UpdaterDeploymentCreator(cfg *operatorv1alpha1.KubermaticConfiguration, see
 			if cfg.Spec.FeatureGates.Has(features.TunnelingExposeStrategy) {
 				args = append(args,
 					fmt.Sprintf("-envoy-sni-port=%d", EnvoySNIPort),
-					fmt.Sprintf("-envoy-tunneling-connect-port=%d", EnvoyTunnelingPort))
+					fmt.Sprintf("-envoy-tunneling-port=%d", EnvoyTunnelingPort))
 			}
 			d.Spec.Template.Spec.Containers = []corev1.Container{
 				{

--- a/pkg/test/e2e/nodeport-proxy/deployer.go
+++ b/pkg/test/e2e/nodeport-proxy/deployer.go
@@ -152,6 +152,7 @@ func (d *Deployer) SetUp() error {
 			}
 		}
 	}
+	d.Log.Debugw("deployed nodeport-proxy", "version", d.Versions.Kubermatic)
 	return nil
 }
 


### PR DESCRIPTION
**What this PR does / why we need it**:
- Fixes a flag typo in envoy-manager 
- Fixes the node-port proxy e2e script to use the right image when `go test` is used instead of `ginkgo`

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Documentation**:
<!-- Add links to the related documentation changes related to this pull request. E.g. the link to the kubermatic/docs pull request. -->

**Does this PR introduce a user-facing change?**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If  no release note is required, just write "NONE".
-->
```release-note
NONE
```
