### PR TITLE
[release/v2.15] Default to the latest available OpenStack CCM version

### DIFF
--- a/docs/adding-kubernetes-versions.md
+++ b/docs/adding-kubernetes-versions.md
@@ -38,6 +38,10 @@ Once new Docker images are ready, KKP can be updated as well.
   minor (just copy an existing job and adjust accordingly). Make sure to change the Docker
   image tag for the e2e images to use the new tag you just created with the new test binaries.
 - Update the CSI addon manifests (`addon/csi/*.yaml`) to include the new minor version.
+- Update the OpenStack CCM manifest (`pkg/resources/cloudcontroller/openstack.go`) to
+  include the new minor version.
+  - The latest OpenStack CCM version can be found in the 
+  [`kubernetes/cloud-provider-openstack` repository](https://github.com/kubernetes/cloud-provider-openstack).
 - Ensure a kubelet ConfigMap for the new minor exists in `addons/kubelet-configmap/kubelet-configmap.yaml`.
 - Update `addons/rbac/allow-kubeadm-join-configmap.yaml` to include the new ConfigMap.
 - The conformance-tests runner (`cmd/conformance-tests/runner.go`) has a list of

--- a/pkg/resources/cloudcontroller/openstack.go
+++ b/pkg/resources/cloudcontroller/openstack.go
@@ -171,13 +171,19 @@ func getOSFlags(data *resources.TemplateData) []string {
 }
 
 func getOSVersion(version semver.Semver) (string, error) {
+	if version.Minor() < 17 {
+		return "", fmt.Errorf("Kubernetes version %s is not supported", version.String())
+	}
+
 	switch version.Minor() {
 	case 17:
 		return "1.17.0", nil
 	case 18:
 		return "1.18.0", nil
+	case 19:
+		return "1.19.2", nil
 	default:
-		return "", fmt.Errorf("Kubernetes version %s is not supported", version.String())
+		return "1.19.2", nil
 	}
 }
 


### PR DESCRIPTION
**What this PR does / why we need it**:

Combined cherry-pick of #6272 and #6273 to the `release/v2.15` branch.

**Does this PR introduce a user-facing change?**:
```release-note
Default to the latest available OpenStack CCM version. This fixes a bug where newly-created OpenStack clusters running Kubernetes 1.19 were using the in-tree cloud provider instead of the external CCM. Those clusters will remain to use the in-tree cloud provider until the CCM migration mechanism is not implemented. The OpenStack clusters running Kubernetes 1.19+ and created with KKP 2.15.6+ will use the external CCM.
```

/assign @irozzo-1A @xrstf 