### PR TITLE
Enforce TunnelingExposeStrategy feature gate

### DIFF
--- a/cmd/kubermatic-api/options.go
+++ b/cmd/kubermatic-api/options.go
@@ -71,9 +71,8 @@ type serverRunOptions struct {
 }
 
 func newServerRunOptions() (serverRunOptions, error) {
-	s := serverRunOptions{}
+	s := serverRunOptions{featureGates: features.FeatureGate{}}
 	var (
-		rawFeatureGates     string
 		rawExposeStrategy   string
 		rawAccessibleAddons string
 		oidcCAFile          string
@@ -102,7 +101,7 @@ func newServerRunOptions() (serverRunOptions, error) {
 	flag.StringVar(&s.oidcIssuerCookieHashKey, "oidc-issuer-cookie-hash-key", "", "Hash key authenticates the cookie value using HMAC. It is recommended to use a key with 32 or 64 bytes.")
 	flag.BoolVar(&s.oidcIssuerCookieSecureMode, "oidc-issuer-cookie-secure-mode", true, "When true cookie received only with HTTPS. Set false for local deployment with HTTP")
 	flag.BoolVar(&s.oidcIssuerOfflineAccessAsScope, "oidc-issuer-offline-access-as-scope", true, "Set it to false if OIDC provider requires to set \"access_type=offline\" query param when accessing the refresh token")
-	flag.StringVar(&rawFeatureGates, "feature-gates", "", "A set of key=value pairs that describe feature gates for various features.")
+	flag.Var(&s.featureGates, "feature-gates", "A set of key=value pairs that describe feature gates for various features.")
 	flag.StringVar(&s.domain, "domain", "localhost", "A domain name on which the server is deployed")
 	flag.StringVar(&s.serviceAccountSigningKey, "service-account-signing-key", "", "Signing key authenticates the service account's token value using HMAC. It is recommended to use a key with 32 bytes or longer.")
 	flag.StringVar(&rawExposeStrategy, "expose-strategy", "NodePort", "The strategy to expose the controlplane with, either \"NodePort\" which creates NodePorts with a \"nodeport-proxy.k8s.io/expose: true\" annotation or \"LoadBalancer\", which creates a LoadBalancer")
@@ -110,12 +109,6 @@ func newServerRunOptions() (serverRunOptions, error) {
 	flag.StringVar(&s.namespace, "namespace", "kubermatic", "The namespace kubermatic runs in, uses to determine where to look for datacenter custom resources")
 	addFlags(flag.CommandLine)
 	flag.Parse()
-
-	featureGates, err := features.NewFeatures(rawFeatureGates)
-	if err != nil {
-		return s, err
-	}
-	s.featureGates = featureGates
 
 	var validExposeStrategy bool
 	s.exposeStrategy, validExposeStrategy = kubermaticv1.ExposeStrategyFromString(rawExposeStrategy)

--- a/cmd/master-controller-manager/main.go
+++ b/cmd/master-controller-manager/main.go
@@ -24,6 +24,7 @@ import (
 	"github.com/prometheus/client_golang/prometheus"
 	"go.uber.org/zap"
 
+	"k8c.io/kubermatic/v2/pkg/features"
 	kubermaticlog "k8c.io/kubermatic/v2/pkg/log"
 	"k8c.io/kubermatic/v2/pkg/metrics"
 	metricserver "k8c.io/kubermatic/v2/pkg/metrics/server"
@@ -52,6 +53,7 @@ type controllerRunOptions struct {
 	seedvalidationHook      validation.WebhookOpts
 	enableLeaderElection    bool
 	leaderElectionNamespace string
+	featureGates            features.FeatureGate
 
 	workerName string
 	namespace  string
@@ -73,7 +75,7 @@ type controllerContext struct {
 
 func main() {
 	ctrlCtx := &controllerContext{}
-	runOpts := controllerRunOptions{}
+	runOpts := controllerRunOptions{featureGates: features.FeatureGate{}}
 	klog.InitFlags(nil)
 	pprofOpts := &pprof.Opts{}
 	pprofOpts.AddFlags(flag.CommandLine)
@@ -87,6 +89,7 @@ func main() {
 	flag.BoolVar(&runOpts.enableLeaderElection, "enable-leader-election", true, "Enable leader election for controller manager. "+
 		"Enabling this will ensure there is only one active controller manager.")
 	flag.StringVar(&runOpts.leaderElectionNamespace, "leader-election-namespace", "", "Leader election namespace. In-cluster discovery will be attempted in such case.")
+	flag.Var(&runOpts.featureGates, "feature-gates", "A set of key=value pairs that describe feature gates for various features.")
 	addFlags(flag.CommandLine)
 	flag.Parse()
 

--- a/cmd/master-controller-manager/main.go
+++ b/cmd/master-controller-manager/main.go
@@ -33,6 +33,7 @@ import (
 	"k8c.io/kubermatic/v2/pkg/util/cli"
 	"k8c.io/kubermatic/v2/pkg/util/workerlabel"
 	"k8c.io/kubermatic/v2/pkg/validation"
+	clustervalidation "k8c.io/kubermatic/v2/pkg/validation/cluster"
 
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"
@@ -170,7 +171,7 @@ func main() {
 			log.Fatalw("failed to build Seed validation handler", zap.Error(err))
 		}
 		h.SetupWebhookWithManager(mgr)
-
+		clustervalidation.NewAdmissionHandler(runOpts.featureGates).SetupWebhookWithManager(mgr)
 	} else {
 		log.Info("the validatingAdmissionWebhook server can not be started because seed-admissionwebhook-cert-file and seed-admissionwebhook-key-file are empty")
 	}

--- a/cmd/master-controller-manager/wrappers_ce.go
+++ b/cmd/master-controller-manager/wrappers_ce.go
@@ -45,5 +45,6 @@ func seedValidationHandler(ctx context.Context, client ctrlruntimeclient.Client,
 		Client(client).
 		WorkerName(options.workerName).
 		AllowedSeed(options.namespace, provider.DefaultSeedName).
+		FeatureGates(options.featureGates).
 		Build(ctx)
 }

--- a/cmd/master-controller-manager/wrappers_ee.go
+++ b/cmd/master-controller-manager/wrappers_ee.go
@@ -45,5 +45,6 @@ func seedValidationHandler(ctx context.Context, client ctrlruntimeclient.Client,
 	return (&seedvalidation.ValidationHandlerBuilder{}).
 		Client(client).
 		WorkerName(options.workerName).
+		FeatureGates(options.featureGates).
 		Build(ctx)
 }

--- a/cmd/seed-controller-manager/main.go
+++ b/cmd/seed-controller-manager/main.go
@@ -37,6 +37,7 @@ import (
 	metricserver "k8c.io/kubermatic/v2/pkg/metrics/server"
 	"k8c.io/kubermatic/v2/pkg/pprof"
 	"k8c.io/kubermatic/v2/pkg/util/cli"
+	clustervalidation "k8c.io/kubermatic/v2/pkg/validation/cluster"
 	"k8c.io/kubermatic/v2/pkg/version/kubermatic"
 	ctrl "sigs.k8s.io/controller-runtime"
 
@@ -166,7 +167,11 @@ Please install the VerticalPodAutoscaler according to the documentation: https:/
 		if err != nil {
 			log.Fatalw("Failed to build Seed validation handler", zap.Error(err))
 		}
+
+		// Setup the admission handler for kubermatic Seed CRDs
 		h.SetupWebhookWithManager(mgr)
+		// Setup the admission handler for kubermatic Cluster CRDs
+		clustervalidation.NewAdmissionHandler(options.featureGates).SetupWebhookWithManager(mgr)
 	}
 
 	ctrlCtx := &controllerContext{

--- a/cmd/seed-controller-manager/options.go
+++ b/cmd/seed-controller-manager/options.go
@@ -97,8 +97,7 @@ type controllerRunOptions struct {
 }
 
 func newControllerRunOptions() (controllerRunOptions, error) {
-	c := controllerRunOptions{}
-	var rawFeatureGates string
+	c := controllerRunOptions{featureGates: features.FeatureGate{}}
 	var rawEtcdDiskSize string
 	var defaultKubernetesAddonsList string
 	var defaultKubernetesAddonsFile string
@@ -135,7 +134,7 @@ func newControllerRunOptions() (controllerRunOptions, error) {
 	flag.BoolVar(&c.inClusterPrometheusDisableDefaultScrapingConfigs, "in-cluster-prometheus-disable-default-scraping-configs", false, "A flag indicating whether the default scraping configs for the prometheus running in the cluster-foo namespaces should be deployed.")
 	flag.StringVar(&c.inClusterPrometheusScrapingConfigsFile, "in-cluster-prometheus-scraping-configs-file", "", "The file containing the custom scraping configs for the prometheus running in the cluster-foo namespaces.")
 	flag.StringVar(&c.monitoringScrapeAnnotationPrefix, "monitoring-scrape-annotation-prefix", "monitoring.kubermatic.io", "The prefix for monitoring annotations in the user cluster. Default: monitoring.kubermatic.io -> monitoring.kubermatic.io/port, monitoring.kubermatic.io/path")
-	flag.StringVar(&rawFeatureGates, "feature-gates", "", "A set of key=value pairs that describe feature gates for various features.")
+	flag.Var(&c.featureGates, "feature-gates", "A set of key=value pairs that describe feature gates for various features.")
 	flag.StringVar(&c.oidcCAFile, "oidc-ca-file", "", "The path to the certificate for the CA that signed your identity provider’s web certificate.")
 	flag.StringVar(&c.oidcIssuerURL, "oidc-issuer-url", "", "URL of the OpenID token issuer. Example: http://auth.int.kubermatic.io")
 	flag.StringVar(&c.oidcIssuerClientID, "oidc-issuer-client-id", "", "Issuer client ID")
@@ -153,12 +152,6 @@ func newControllerRunOptions() (controllerRunOptions, error) {
 	c.validationWebhook.AddFlags(flag.CommandLine, true)
 	addFlags(flag.CommandLine)
 	flag.Parse()
-
-	featureGates, err := features.NewFeatures(rawFeatureGates)
-	if err != nil {
-		return c, err
-	}
-	c.featureGates = featureGates
 
 	etcdDiskSize, err := resource.ParseQuantity(rawEtcdDiskSize)
 	if err != nil {

--- a/cmd/seed-controller-manager/wrappers_ce.go
+++ b/cmd/seed-controller-manager/wrappers_ce.go
@@ -42,5 +42,6 @@ func seedValidationHandler(ctx context.Context, client ctrlruntimeclient.Client,
 		SeedName(options.dc).
 		WorkerName(options.workerName).
 		AllowedSeed(options.namespace, provider.DefaultSeedName).
+		FeatureGates(options.featureGates).
 		Build(ctx)
 }

--- a/cmd/seed-controller-manager/wrappers_ee.go
+++ b/cmd/seed-controller-manager/wrappers_ee.go
@@ -42,5 +42,6 @@ func seedValidationHandler(ctx context.Context, client ctrlruntimeclient.Client,
 		Client(client).
 		SeedName(options.dc).
 		WorkerName(options.workerName).
+		FeatureGates(options.featureGates).
 		Build(ctx)
 }

--- a/pkg/controller/operator/master/reconciler.go
+++ b/pkg/controller/operator/master/reconciler.go
@@ -299,7 +299,7 @@ func (r *Reconciler) reconcileServices(config *operatorv1alpha1.KubermaticConfig
 	creators := []reconciling.NamedServiceCreatorGetter{
 		kubermatic.APIServiceCreator(config),
 		kubermatic.UIServiceCreator(config),
-		common.SeedAdmissionServiceCreator(config, r.Client),
+		common.AdmissionServiceCreator(config, r.Client),
 	}
 
 	if err := reconciling.ReconcileServices(r.ctx, creators, config.Namespace, r.Client, common.OwnershipModifierFactory(config, r.scheme)); err != nil {

--- a/pkg/controller/operator/master/resources/kubermatic/master-controller-manager.go
+++ b/pkg/controller/operator/master/resources/kubermatic/master-controller-manager.go
@@ -74,6 +74,7 @@ func MasterControllerManagerDeploymentCreator(cfg *operatorv1alpha1.KubermaticCo
 				fmt.Sprintf("-pprof-listen-address=%s", *cfg.Spec.MasterController.PProfEndpoint),
 				fmt.Sprintf("-seed-admissionwebhook-cert-file=/opt/seed-webhook-serving-cert/%s", resources.ServingCertSecretKey),
 				fmt.Sprintf("-seed-admissionwebhook-key-file=/opt/seed-webhook-serving-cert/%s", resources.ServingCertKeySecretKey),
+				fmt.Sprintf("-feature-gates=%s", common.StringifyFeatureGates(cfg)),
 			}
 
 			// Only EE does support dynamic-datacenters

--- a/pkg/crd/kubermatic/v1/utils.go
+++ b/pkg/crd/kubermatic/v1/utils.go
@@ -22,9 +22,7 @@ import (
 )
 
 // AllExposeStrategies is a set containing all the ExposeStrategy.
-// TODO(irozzo) ExposeStrategyTunneling is not exposed yet as it is not fully
-// implemented.
-var AllExposeStrategies = NewExposeStrategiesSet(ExposeStrategyNodePort, ExposeStrategyLoadBalancer)
+var AllExposeStrategies = NewExposeStrategiesSet(ExposeStrategyNodePort, ExposeStrategyLoadBalancer, ExposeStrategyTunneling)
 
 // ExposeStrategyFromString returns the expose strategy which String
 // representation corresponds to the input string, and a bool saying whether a

--- a/pkg/features/features.go
+++ b/pkg/features/features.go
@@ -59,14 +59,28 @@ type FeatureGate map[string]bool
 // and returns a FeatureGate.
 func NewFeatures(rawFeatures string) (FeatureGate, error) {
 	fGate := FeatureGate{}
-	for _, s := range strings.Split(rawFeatures, ",") {
+	return fGate, fGate.Set(rawFeatures)
+}
+
+func (f FeatureGate) String() string {
+	activeFeatures := make([]string, 0, len(f))
+	for f, isActive := range f {
+		if isActive {
+			activeFeatures = append(activeFeatures, f)
+		}
+	}
+	return strings.Join(activeFeatures, ", ")
+}
+
+func (f FeatureGate) Set(s string) error {
+	for _, s := range strings.Split(s, ",") {
 		if len(s) == 0 {
 			continue
 		}
 
 		arr := strings.SplitN(s, "=", 2)
 		if len(arr) != 2 {
-			return nil, fmt.Errorf("missing bool value for feature gate key = %s", s)
+			return fmt.Errorf("missing bool value for feature gate key = %s", s)
 		}
 
 		k := strings.TrimSpace(arr[0])
@@ -74,12 +88,11 @@ func NewFeatures(rawFeatures string) (FeatureGate, error) {
 
 		boolValue, err := strconv.ParseBool(v)
 		if err != nil {
-			return nil, fmt.Errorf("invalid value %v for feature gate key = %s, use true|false instead", v, k)
+			return fmt.Errorf("invalid value %v for feature gate key = %s, use true|false instead", v, k)
 		}
-		fGate[k] = boolValue
+		f[k] = boolValue
 	}
-
-	return fGate, nil
+	return nil
 }
 
 // Enabled returns true if the feature gate value of a particular feature is true.

--- a/pkg/validation/cluster/handler.go
+++ b/pkg/validation/cluster/handler.go
@@ -87,7 +87,7 @@ func (h *AdmissionHandler) validateCreateOrUpdate(c *kubermaticv1.Cluster) error
 	}
 	if c.Spec.ExposeStrategy == kubermaticv1.ExposeStrategyTunneling &&
 		!h.features.Enabled(features.TunnelingExposeStrategy) {
-		return errors.New("cannot create cluster with Tunneling expose strategy, TunnelingExposeStrategy feature gate is not enabled.")
+		return errors.New("cannot create cluster with Tunneling expose strategy, the TunnelingExposeStrategy feature gate is not enabled")
 	}
 	return nil
 }

--- a/pkg/validation/cluster/handler.go
+++ b/pkg/validation/cluster/handler.go
@@ -1,0 +1,97 @@
+/*
+Copyright 2020 The Kubermatic Kubernetes Platform contributors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package cluster
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"net/http"
+
+	"github.com/go-logr/logr"
+
+	kubermaticv1 "k8c.io/kubermatic/v2/pkg/crd/kubermatic/v1"
+	"k8c.io/kubermatic/v2/pkg/features"
+
+	admissionv1beta1 "k8s.io/api/admission/v1beta1"
+	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/webhook"
+	"sigs.k8s.io/controller-runtime/pkg/webhook/admission"
+)
+
+// AdmissionHandler for Kubermatic Cluster CRD.
+type AdmissionHandler struct {
+	log      logr.Logger
+	decoder  *admission.Decoder
+	features features.FeatureGate
+}
+
+// NewAdmissionHandler returns a new cluster.AdmissionHandler.
+func NewAdmissionHandler(features features.FeatureGate) *AdmissionHandler {
+	return &AdmissionHandler{
+		features: features,
+	}
+}
+
+func (h *AdmissionHandler) InjectLogger(l logr.Logger) error {
+	h.log = l.WithName("seed-validation-handler")
+	return nil
+}
+
+func (h *AdmissionHandler) InjectDecoder(d *admission.Decoder) error {
+	h.decoder = d
+	return nil
+}
+
+func (h *AdmissionHandler) Handle(_ context.Context, req webhook.AdmissionRequest) webhook.AdmissionResponse {
+	cluster := &kubermaticv1.Cluster{}
+
+	switch req.Operation {
+	case admissionv1beta1.Create:
+		fallthrough
+	case admissionv1beta1.Update:
+		err := h.decoder.Decode(req, cluster)
+		if err != nil {
+			return admission.Errored(http.StatusBadRequest, err)
+		}
+		validationErr := h.validateCreateOrUpdate(cluster)
+		if validationErr != nil {
+			h.log.Info("seed admission failed", "error", validationErr)
+			return webhook.Denied(fmt.Sprintf("seed validation request %s rejected: %v", req.UID, validationErr))
+		}
+	case admissionv1beta1.Delete:
+		// NOP we always allow delete operarions at the moment
+	default:
+		return admission.Errored(http.StatusBadRequest, fmt.Errorf("%s not supported on seed resources", req.Operation))
+	}
+	return webhook.Allowed(fmt.Sprintf("seed validation request %s allowed", req.UID))
+}
+
+func (h *AdmissionHandler) validateCreateOrUpdate(c *kubermaticv1.Cluster) error {
+	if !kubermaticv1.AllExposeStrategies.Has(c.Spec.ExposeStrategy) {
+		return fmt.Errorf("unknown expose strategy %q, use one between: %s", c.Spec.ExposeStrategy, kubermaticv1.AllExposeStrategies)
+	}
+	if c.Spec.ExposeStrategy == kubermaticv1.ExposeStrategyTunneling &&
+		!h.features.Enabled(features.TunnelingExposeStrategy) {
+		return errors.New("cannot create cluster with Tunneling expose strategy, TunnelingExposeStrategy feature gate is not enabled.")
+	}
+	return nil
+}
+
+func (h *AdmissionHandler) SetupWebhookWithManager(mgr ctrl.Manager) {
+	mgr.GetWebhookServer().Register("/validate-kubermatic-k8s-io-cluster", &webhook.Admission{Handler: h})
+}

--- a/pkg/validation/cluster/handler.go
+++ b/pkg/validation/cluster/handler.go
@@ -48,7 +48,7 @@ func NewAdmissionHandler(features features.FeatureGate) *AdmissionHandler {
 }
 
 func (h *AdmissionHandler) InjectLogger(l logr.Logger) error {
-	h.log = l.WithName("seed-validation-handler")
+	h.log = l.WithName("cluster-validation-handler")
 	return nil
 }
 
@@ -70,15 +70,15 @@ func (h *AdmissionHandler) Handle(_ context.Context, req webhook.AdmissionReques
 		}
 		validationErr := h.validateCreateOrUpdate(cluster)
 		if validationErr != nil {
-			h.log.Info("seed admission failed", "error", validationErr)
-			return webhook.Denied(fmt.Sprintf("seed validation request %s rejected: %v", req.UID, validationErr))
+			h.log.Info("cluster admission failed", "error", validationErr)
+			return webhook.Denied(fmt.Sprintf("cluster validation request %s rejected: %v", req.UID, validationErr))
 		}
 	case admissionv1beta1.Delete:
 		// NOP we always allow delete operarions at the moment
 	default:
-		return admission.Errored(http.StatusBadRequest, fmt.Errorf("%s not supported on seed resources", req.Operation))
+		return admission.Errored(http.StatusBadRequest, fmt.Errorf("%s not supported on cluster resources", req.Operation))
 	}
-	return webhook.Allowed(fmt.Sprintf("seed validation request %s allowed", req.UID))
+	return webhook.Allowed(fmt.Sprintf("cluster validation request %s allowed", req.UID))
 }
 
 func (h *AdmissionHandler) validateCreateOrUpdate(c *kubermaticv1.Cluster) error {

--- a/pkg/validation/cluster/handler_test.go
+++ b/pkg/validation/cluster/handler_test.go
@@ -1,0 +1,186 @@
+/*
+Copyright 2020 The Kubermatic Kubernetes Platform contributors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package cluster
+
+import (
+	"bytes"
+	"context"
+	"testing"
+	"text/template"
+
+	logrtesting "github.com/go-logr/logr/testing"
+	admissionv1beta1 "k8s.io/api/admission/v1beta1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"sigs.k8s.io/controller-runtime/pkg/webhook"
+	"sigs.k8s.io/controller-runtime/pkg/webhook/admission"
+
+	kubermaticv1 "k8c.io/kubermatic/v2/pkg/crd/kubermatic/v1"
+	"k8c.io/kubermatic/v2/pkg/features"
+)
+
+var (
+	testScheme = runtime.NewScheme()
+)
+
+func init() {
+	_ = kubermaticv1.AddToScheme(testScheme)
+}
+
+func TestHandle(t *testing.T) {
+	tests := []struct {
+		name        string
+		req         webhook.AdmissionRequest
+		wantAllowed bool
+		features    features.FeatureGate
+	}{
+		{
+			name: "delete cluster succeess",
+			req: webhook.AdmissionRequest{
+				AdmissionRequest: admissionv1beta1.AdmissionRequest{
+					Operation: admissionv1beta1.Delete,
+					RequestKind: &metav1.GroupVersionKind{
+						Group:   kubermaticv1.GroupName,
+						Version: kubermaticv1.GroupVersion,
+						Kind:    "Cluster",
+					},
+					Name:      "cluster",
+					Namespace: "kubermatic",
+				},
+			},
+			wantAllowed: true,
+		},
+		{
+			name: "Create cluster with Tunneling expose strategy succeeds when the FeatureGate is enabled",
+			req: webhook.AdmissionRequest{
+				AdmissionRequest: admissionv1beta1.AdmissionRequest{
+					Operation: admissionv1beta1.Create,
+					RequestKind: &metav1.GroupVersionKind{
+						Group:   kubermaticv1.GroupName,
+						Version: kubermaticv1.GroupVersion,
+						Kind:    "Cluster",
+					},
+					Name:      "foo",
+					Namespace: "kubermatic",
+					Object: runtime.RawExtension{
+						Raw: rawClusterGen{Name: "foo", Namespace: "kubermatic", ExposeStrategy: "Tunneling"}.Do(),
+					},
+				},
+			},
+			wantAllowed: true,
+			features:    features.FeatureGate{features.TunnelingExposeStrategy: true},
+		},
+		{
+			name: "Create cluster with Tunneling expose strategy fails when the FeatureGate is not enabled",
+			req: webhook.AdmissionRequest{
+				AdmissionRequest: admissionv1beta1.AdmissionRequest{
+					Operation: admissionv1beta1.Create,
+					RequestKind: &metav1.GroupVersionKind{
+						Group:   kubermaticv1.GroupName,
+						Version: kubermaticv1.GroupVersion,
+						Kind:    "Cluster",
+					},
+					Name:      "foo",
+					Namespace: "kubermatic",
+					Object: runtime.RawExtension{
+						Raw: rawClusterGen{Name: "foo", Namespace: "kubermatic", ExposeStrategy: "Tunneling"}.Do(),
+					},
+				},
+			},
+			wantAllowed: false,
+			features:    features.FeatureGate{features.TunnelingExposeStrategy: false},
+		},
+		{
+			name: "Create cluster expose strategy different from Tunneling should succeed",
+			req: webhook.AdmissionRequest{
+				AdmissionRequest: admissionv1beta1.AdmissionRequest{
+					Operation: admissionv1beta1.Create,
+					RequestKind: &metav1.GroupVersionKind{
+						Group:   kubermaticv1.GroupName,
+						Version: kubermaticv1.GroupVersion,
+						Kind:    "Cluster",
+					},
+					Name:      "foo",
+					Namespace: "kubermatic",
+					Object: runtime.RawExtension{
+						Raw: rawClusterGen{Name: "foo", Namespace: "kubermatic", ExposeStrategy: "NodePort"}.Do(),
+					},
+				},
+			},
+			wantAllowed: true,
+		},
+		{
+			name: "Unknown expose strategy",
+			req: webhook.AdmissionRequest{
+				AdmissionRequest: admissionv1beta1.AdmissionRequest{
+					Operation: admissionv1beta1.Create,
+					RequestKind: &metav1.GroupVersionKind{
+						Group:   kubermaticv1.GroupName,
+						Version: kubermaticv1.GroupVersion,
+						Kind:    "Cluster",
+					},
+					Name:      "foo",
+					Namespace: "kubermatic",
+					Object: runtime.RawExtension{
+						Raw: rawClusterGen{Name: "foo", Namespace: "kubermatic", ExposeStrategy: "ciao"}.Do(),
+					},
+				},
+			},
+			wantAllowed: false,
+		},
+	}
+	for _, tt := range tests {
+		d, err := admission.NewDecoder(testScheme)
+		if err != nil {
+			t.Fatalf("error occurred while creating decoder: %v", err)
+		}
+		handler := AdmissionHandler{
+			log:      &logrtesting.NullLogger{},
+			decoder:  d,
+			features: tt.features,
+		}
+		t.Run(tt.name, func(t *testing.T) {
+			if res := handler.Handle(context.TODO(), tt.req); res.Allowed != tt.wantAllowed {
+				t.Errorf("Allowed %t, but wanted %t", res.Allowed, tt.wantAllowed)
+				t.Logf("Response: %v", res)
+			}
+		})
+	}
+}
+
+type rawClusterGen struct {
+	Name           string
+	Namespace      string
+	ExposeStrategy string
+}
+
+func (r rawClusterGen) Do() []byte {
+	tmpl, _ := template.New("cluster").Parse(`{
+  "apiVersion": "kubermatic.k8s.io/v1",
+  "kind": "Cluster",
+  "metadata": {
+	"name": "{{ .Name }}",
+	"namespace": "{{ .Namespace}}"
+  },
+  "spec": {
+	"exposeStrategy": "{{ .ExposeStrategy }}"
+  }
+}`)
+	sb := bytes.Buffer{}
+	_ = tmpl.Execute(&sb, r)
+	return sb.Bytes()
+}

--- a/pkg/validation/seed/builder.go
+++ b/pkg/validation/seed/builder.go
@@ -24,6 +24,7 @@ import (
 	ctrlruntimeclient "sigs.k8s.io/controller-runtime/pkg/client"
 
 	kubermaticv1 "k8c.io/kubermatic/v2/pkg/crd/kubermatic/v1"
+	"k8c.io/kubermatic/v2/pkg/features"
 	"k8c.io/kubermatic/v2/pkg/provider"
 )
 
@@ -32,12 +33,19 @@ type ValidationHandlerBuilder struct {
 	workerName          string
 	seedName            string
 	singleSeedValidator *ensureSingleSeedValidatorWrapper
+	features            features.FeatureGate
 }
 
 // Client sets the client to get API resources on the cluster the handler is
 // used for.
 func (v *ValidationHandlerBuilder) Client(client ctrlruntimeclient.Client) *ValidationHandlerBuilder {
 	v.client = client
+	return v
+}
+
+// FeatureGates sets the feature gates.
+func (v *ValidationHandlerBuilder) FeatureGates(features features.FeatureGate) *ValidationHandlerBuilder {
+	v.features = features
 	return v
 }
 
@@ -84,6 +92,7 @@ func (v *ValidationHandlerBuilder) Build(ctx context.Context) (AdmissionHandler,
 		v.workerName,
 		v.client,
 		seedClientGetter,
+		v.features,
 	)
 	if err != nil {
 		return nil, fmt.Errorf("error occurred while creating seed validator: %v", err)

--- a/pkg/validation/seed/validator.go
+++ b/pkg/validation/seed/validator.go
@@ -106,9 +106,9 @@ func (v *validator) Validate(ctx context.Context, seed *kubermaticv1.Seed, op ad
 }
 
 func (v *validator) validate(ctx context.Context, subject *kubermaticv1.Seed, seedClient ctrlruntimeclient.Client, existingSeeds map[string]*kubermaticv1.Seed, isDelete bool) error {
-	// check wether the expose strategy is allowed or not.
+	// check whether the expose strategy is allowed or not.
 	if subject.Spec.ExposeStrategy == kubermaticv1.ExposeStrategyTunneling && !v.features.Enabled(features.TunnelingExposeStrategy) {
-		return errors.New("cannot create seed using Tunneling as a default expose strategy, the TunnelingExposeStrategy feature gate is not enabled.")
+		return errors.New("cannot create seed using Tunneling as a default expose strategy, the TunnelingExposeStrategy feature gate is not enabled")
 	}
 
 	// this can be nil on new seed clusters


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR enforces the `TunnelingExposeStrategy` feature gate. If TunnelingExposeStrategy feature gate is not enabled on the following operations won't be allowed:

- `Seed`s with Tunneling expose strategy as default cannot be created.
- `Cluster`s with Tunneling expose strategy cannot be created.

xref: #4942 

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:
Installations performed without the Kubermatic operator are out of scope.

**Documentation**:
<!-- Add links to the related documentation changes related to this pull request. E.g. the link to the kubermatic/docs pull request. -->

**Does this PR introduce a user-facing change?**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If  no release note is required, just write "NONE".
-->
```release-note
NONE
```
