### PR TITLE
add PodNodeSelector admission plugin configuration to the cluster CRD

### DIFF
--- a/pkg/crd/kubermatic/v1/cluster.go
+++ b/pkg/crd/kubermatic/v1/cluster.go
@@ -122,9 +122,18 @@ type ClusterSpec struct {
 	// Openshift holds all openshift-specific settings
 	Openshift *Openshift `json:"openshift,omitempty"`
 
-	UsePodSecurityPolicyAdmissionPlugin bool     `json:"usePodSecurityPolicyAdmissionPlugin,omitempty"`
-	UsePodNodeSelectorAdmissionPlugin   bool     `json:"usePodNodeSelectorAdmissionPlugin,omitempty"`
-	AdmissionPlugins                    []string `json:"admissionPlugins,omitempty"`
+	UsePodSecurityPolicyAdmissionPlugin bool `json:"usePodSecurityPolicyAdmissionPlugin,omitempty"`
+	UsePodNodeSelectorAdmissionPlugin   bool `json:"usePodNodeSelectorAdmissionPlugin,omitempty"`
+	// PodNodeSelectorAdmissionPluginConfig provides the configuration for the PodNodeSelector.
+	// It's used by the backend to create a configuration file for this plugin.
+	// The key:value from the map is converted to the namespace:<node-selectors-labels> in the file.
+	// The format in a file:
+	// podNodeSelectorPluginConfig:
+	//  clusterDefaultNodeSelector: <node-selectors-labels>
+	//  namespace1: <node-selectors-labels>
+	//  namespace2: <node-selectors-labels>
+	PodNodeSelectorAdmissionPluginConfig map[string]string `json:"podNodeSelectorAdmissionPluginConfig,omitempty"`
+	AdmissionPlugins                     []string          `json:"admissionPlugins,omitempty"`
 
 	AuditLogging *AuditLoggingSettings `json:"auditLogging,omitempty"`
 

--- a/pkg/crd/kubermatic/v1/zz_generated.deepcopy.go
+++ b/pkg/crd/kubermatic/v1/zz_generated.deepcopy.go
@@ -779,6 +779,13 @@ func (in *ClusterSpec) DeepCopyInto(out *ClusterSpec) {
 		*out = new(Openshift)
 		**out = **in
 	}
+	if in.PodNodeSelectorAdmissionPluginConfig != nil {
+		in, out := &in.PodNodeSelectorAdmissionPluginConfig, &out.PodNodeSelectorAdmissionPluginConfig
+		*out = make(map[string]string, len(*in))
+		for key, val := range *in {
+			(*out)[key] = val
+		}
+	}
 	if in.AdmissionPlugins != nil {
 		in, out := &in.AdmissionPlugins, &out.AdmissionPlugins
 		*out = make([]string, len(*in))


### PR DESCRIPTION
**What this PR does / why we need it**: add PodNodeSelector admission plugin configuration to the cluster CRD. Currently, the user can not set the configuration for the PodNodeSelector plugin according to the documentation: https://kubernetes.io/docs/reference/access-authn-authz/admission-controllers/#podnodeselector

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #6304


```release-note
Extend Cluster CRD for PodNodeSelectorAdmissionPluginConfig
```
