### PR TITLE
add admission control configuration for the user cluster API deployment

### DIFF
--- a/cmd/image-loader/main.go
+++ b/cmd/image-loader/main.go
@@ -370,8 +370,14 @@ func getTemplateData(clusterVersion *kubermaticversion.Version, kubermaticVersio
 			Namespace: mockNamespaceName,
 		},
 	}
+	admissionControlConfigMapName := corev1.ConfigMap{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      resources.AdmissionControlConfigMapName,
+			Namespace: mockNamespaceName,
+		},
+	}
 	configMapList := &corev1.ConfigMapList{
-		Items: []corev1.ConfigMap{cloudConfigConfigMap, prometheusConfigMap, dnsResolverConfigMap, openvpnClientConfigsConfigMap, auditConfigMap},
+		Items: []corev1.ConfigMap{cloudConfigConfigMap, prometheusConfigMap, dnsResolverConfigMap, openvpnClientConfigsConfigMap, auditConfigMap, admissionControlConfigMapName},
 	}
 	apiServerService := corev1.Service{
 		ObjectMeta: metav1.ObjectMeta{

--- a/cmd/kubermatic-api/swagger.json
+++ b/cmd/kubermatic-api/swagger.json
@@ -13769,6 +13769,14 @@
         "openshift": {
           "$ref": "#/definitions/Openshift"
         },
+        "podNodeSelectorAdmissionPluginConfig": {
+          "description": "PodNodeSelectorAdmissionPluginConfig provides the configuration for the PodNodeSelector.\nIt's used by the backend to create a configuration file for this plugin.\nThe key:value from the map is converted to the namespace:\u003cnode-selectors-labels\u003e in the file.\nThe format in a file:\npodNodeSelectorPluginConfig:\nclusterDefaultNodeSelector: \u003cnode-selectors-labels\u003e\nnamespace1: \u003cnode-selectors-labels\u003e\nnamespace2: \u003cnode-selectors-labels\u003e",
+          "type": "object",
+          "additionalProperties": {
+            "type": "string"
+          },
+          "x-go-name": "PodNodeSelectorAdmissionPluginConfig"
+        },
         "updateWindow": {
           "$ref": "#/definitions/UpdateWindow"
         },

--- a/pkg/api/v1/types.go
+++ b/pkg/api/v1/types.go
@@ -687,6 +687,16 @@ type ClusterSpec struct {
 	// If active the PodNodeSelector admission plugin is configured at the apiserver
 	UsePodNodeSelectorAdmissionPlugin bool `json:"usePodNodeSelectorAdmissionPlugin,omitempty"`
 
+	// PodNodeSelectorAdmissionPluginConfig provides the configuration for the PodNodeSelector.
+	// It's used by the backend to create a configuration file for this plugin.
+	// The key:value from the map is converted to the namespace:<node-selectors-labels> in the file.
+	// The format in a file:
+	// podNodeSelectorPluginConfig:
+	//  clusterDefaultNodeSelector: <node-selectors-labels>
+	//  namespace1: <node-selectors-labels>
+	//  namespace2: <node-selectors-labels>
+	PodNodeSelectorAdmissionPluginConfig map[string]string `json:"podNodeSelectorAdmissionPluginConfig,omitempty"`
+
 	// Additional Admission Controller plugins
 	AdmissionPlugins []string `json:"admissionPlugins,omitempty"`
 
@@ -706,15 +716,16 @@ type ClusterSpec struct {
 // that will be returned in the API responses (see: PublicCloudSpec struct).
 func (cs *ClusterSpec) MarshalJSON() ([]byte, error) {
 	ret, err := json.Marshal(struct {
-		Cloud                               PublicCloudSpec                        `json:"cloud"`
-		MachineNetworks                     []kubermaticv1.MachineNetworkingConfig `json:"machineNetworks,omitempty"`
-		Version                             ksemver.Semver                         `json:"version"`
-		OIDC                                kubermaticv1.OIDCSettings              `json:"oidc"`
-		UpdateWindow                        *kubermaticv1.UpdateWindow             `json:"updateWindow,omitempty"`
-		UsePodSecurityPolicyAdmissionPlugin bool                                   `json:"usePodSecurityPolicyAdmissionPlugin,omitempty"`
-		UsePodNodeSelectorAdmissionPlugin   bool                                   `json:"usePodNodeSelectorAdmissionPlugin,omitempty"`
-		AuditLogging                        *kubermaticv1.AuditLoggingSettings     `json:"auditLogging,omitempty"`
-		AdmissionPlugins                    []string                               `json:"admissionPlugins,omitempty"`
+		Cloud                                PublicCloudSpec                        `json:"cloud"`
+		MachineNetworks                      []kubermaticv1.MachineNetworkingConfig `json:"machineNetworks,omitempty"`
+		Version                              ksemver.Semver                         `json:"version"`
+		OIDC                                 kubermaticv1.OIDCSettings              `json:"oidc"`
+		UpdateWindow                         *kubermaticv1.UpdateWindow             `json:"updateWindow,omitempty"`
+		UsePodSecurityPolicyAdmissionPlugin  bool                                   `json:"usePodSecurityPolicyAdmissionPlugin,omitempty"`
+		UsePodNodeSelectorAdmissionPlugin    bool                                   `json:"usePodNodeSelectorAdmissionPlugin,omitempty"`
+		AuditLogging                         *kubermaticv1.AuditLoggingSettings     `json:"auditLogging,omitempty"`
+		AdmissionPlugins                     []string                               `json:"admissionPlugins,omitempty"`
+		PodNodeSelectorAdmissionPluginConfig map[string]string                      `json:"podNodeSelectorAdmissionPluginConfig,omitempty"`
 	}{
 		Cloud: PublicCloudSpec{
 			DatacenterName: cs.Cloud.DatacenterName,
@@ -732,14 +743,15 @@ func (cs *ClusterSpec) MarshalJSON() ([]byte, error) {
 			Alibaba:        newPublicAlibabaCloudSpec(cs.Cloud.Alibaba),
 			Anexia:         newPublicAnexiaCloudSpec(cs.Cloud.Anexia),
 		},
-		Version:                             cs.Version,
-		MachineNetworks:                     cs.MachineNetworks,
-		OIDC:                                cs.OIDC,
-		UpdateWindow:                        cs.UpdateWindow,
-		UsePodSecurityPolicyAdmissionPlugin: cs.UsePodSecurityPolicyAdmissionPlugin,
-		UsePodNodeSelectorAdmissionPlugin:   cs.UsePodNodeSelectorAdmissionPlugin,
-		AuditLogging:                        cs.AuditLogging,
-		AdmissionPlugins:                    cs.AdmissionPlugins,
+		Version:                              cs.Version,
+		MachineNetworks:                      cs.MachineNetworks,
+		OIDC:                                 cs.OIDC,
+		UpdateWindow:                         cs.UpdateWindow,
+		UsePodSecurityPolicyAdmissionPlugin:  cs.UsePodSecurityPolicyAdmissionPlugin,
+		UsePodNodeSelectorAdmissionPlugin:    cs.UsePodNodeSelectorAdmissionPlugin,
+		AuditLogging:                         cs.AuditLogging,
+		AdmissionPlugins:                     cs.AdmissionPlugins,
+		PodNodeSelectorAdmissionPluginConfig: cs.PodNodeSelectorAdmissionPluginConfig,
 	})
 
 	return ret, err

--- a/pkg/controller/seed-controller-manager/kubernetes/resources.go
+++ b/pkg/controller/seed-controller-manager/kubernetes/resources.go
@@ -396,6 +396,7 @@ func GetConfigMapCreators(data *resources.TemplateData) []reconciling.NamedConfi
 		openvpn.ServerClientConfigsConfigMapCreator(data),
 		dns.ConfigMapCreator(data),
 		apiserver.AuditConfigMapCreator(),
+		apiserver.AdmissionControlCreator(data),
 	}
 }
 

--- a/pkg/resources/apiserver/admission-control.go
+++ b/pkg/resources/apiserver/admission-control.go
@@ -1,0 +1,114 @@
+/*
+Copyright 2020 The Kubermatic Kubernetes Platform contributors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package apiserver
+
+import (
+	"fmt"
+
+	"gopkg.in/yaml.v2"
+
+	"k8c.io/kubermatic/v2/pkg/resources"
+	"k8c.io/kubermatic/v2/pkg/resources/reconciling"
+
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/util/sets"
+)
+
+const podNodeSelectorFileName = "podnodeselector.yaml"
+
+// AdmissionConfiguration provides versioned configuration for admission controllers.
+type AdmissionConfiguration struct {
+	Kind string `yaml:"kind,omitempty"`
+
+	APIVersion string `yaml:"apiVersion,omitempty"`
+
+	// Plugins allows specifying a configuration per admission control plugin.
+	Plugins []AdmissionPluginConfiguration `yaml:"plugins,omitempty"`
+}
+
+// AdmissionPluginConfiguration provides the configuration for a single plug-in.
+type AdmissionPluginConfiguration struct {
+	// Name is the name of the admission controller.
+	// It must match the registered admission plugin name.
+	Name string `yaml:"name"`
+
+	// Path is the path to a configuration file that contains the plugin's
+	// configuration
+	Path string `yaml:"path"`
+}
+
+func AdmissionControlCreator(data *resources.TemplateData) reconciling.NamedConfigMapCreatorGetter {
+	return func() (string, reconciling.ConfigMapCreator) {
+		return resources.AdmissionControlConfigMapName, func(cm *corev1.ConfigMap) (*corev1.ConfigMap, error) {
+			if cm.Data == nil {
+				cm.Data = map[string]string{}
+			}
+
+			admissionConfiguration := AdmissionConfiguration{
+				APIVersion: "apiserver.config.k8s.io/v1",
+				Kind:       "AdmissionConfiguration",
+				Plugins:    []AdmissionPluginConfiguration{},
+			}
+			if usePodNodeSelectorAdmissionPlugin(data) {
+				podNodeSelector := AdmissionPluginConfiguration{
+					Name: resources.PodNodeSelectorAdmissionPlugin,
+					Path: fmt.Sprintf("/etc/kubernetes/adm-control/%s", podNodeSelectorFileName),
+				}
+				admissionConfiguration.Plugins = append(admissionConfiguration.Plugins, podNodeSelector)
+
+				podNodeConfig, err := getPodNodeSelectorAdmissionPluginConfig(data)
+				if err != nil {
+					return nil, err
+				}
+				cm.Data[podNodeSelectorFileName] = podNodeConfig
+			}
+
+			rawAdmissionConfiguration, err := yaml.Marshal(admissionConfiguration)
+			if err != nil {
+				return nil, err
+			}
+
+			cm.Data["admission-control.yaml"] = string(rawAdmissionConfiguration)
+
+			return cm, nil
+		}
+	}
+}
+
+func usePodNodeSelectorAdmissionPlugin(data *resources.TemplateData) bool {
+	admissionPlugins := sets.NewString(data.Cluster().Spec.AdmissionPlugins...)
+	return data.Cluster().Spec.UsePodNodeSelectorAdmissionPlugin || admissionPlugins.Has(resources.PodNodeSelectorAdmissionPlugin)
+}
+
+func getPodNodeSelectorAdmissionPluginConfig(data *resources.TemplateData) (string, error) {
+	var pluginConfig struct {
+		PodNodeSelectorPluginConfig map[string]string `yaml:"podNodeSelectorPluginConfig,omitempty"`
+	}
+
+	if data.Cluster().Spec.PodNodeSelectorAdmissionPluginConfig == nil {
+		data.Cluster().Spec.PodNodeSelectorAdmissionPluginConfig = map[string]string{}
+	}
+
+	pluginConfig.PodNodeSelectorPluginConfig = data.Cluster().Spec.PodNodeSelectorAdmissionPluginConfig
+
+	rawPodNodeConfig, err := yaml.Marshal(pluginConfig)
+	if err != nil {
+		return "", err
+	}
+
+	return string(rawPodNodeConfig), nil
+}

--- a/pkg/resources/cluster/cluster.go
+++ b/pkg/resources/cluster/cluster.go
@@ -31,18 +31,19 @@ import (
 // Spec builds ClusterSpec kubermatic Custom Resource from API Cluster
 func Spec(apiCluster apiv1.Cluster, dc *kubermaticv1.Datacenter, secretKeyGetter provider.SecretKeySelectorValueFunc) (*kubermaticv1.ClusterSpec, error) {
 	spec := &kubermaticv1.ClusterSpec{
-		HumanReadableName:                   apiCluster.Name,
-		Cloud:                               apiCluster.Spec.Cloud,
-		MachineNetworks:                     apiCluster.Spec.MachineNetworks,
-		OIDC:                                apiCluster.Spec.OIDC,
-		UpdateWindow:                        apiCluster.Spec.UpdateWindow,
-		Version:                             apiCluster.Spec.Version,
-		UsePodSecurityPolicyAdmissionPlugin: apiCluster.Spec.UsePodSecurityPolicyAdmissionPlugin,
-		UsePodNodeSelectorAdmissionPlugin:   apiCluster.Spec.UsePodNodeSelectorAdmissionPlugin,
-		AuditLogging:                        apiCluster.Spec.AuditLogging,
-		Openshift:                           apiCluster.Spec.Openshift,
-		AdmissionPlugins:                    apiCluster.Spec.AdmissionPlugins,
-		OPAIntegration:                      apiCluster.Spec.OPAIntegration,
+		HumanReadableName:                    apiCluster.Name,
+		Cloud:                                apiCluster.Spec.Cloud,
+		MachineNetworks:                      apiCluster.Spec.MachineNetworks,
+		OIDC:                                 apiCluster.Spec.OIDC,
+		UpdateWindow:                         apiCluster.Spec.UpdateWindow,
+		Version:                              apiCluster.Spec.Version,
+		UsePodSecurityPolicyAdmissionPlugin:  apiCluster.Spec.UsePodSecurityPolicyAdmissionPlugin,
+		UsePodNodeSelectorAdmissionPlugin:    apiCluster.Spec.UsePodNodeSelectorAdmissionPlugin,
+		AuditLogging:                         apiCluster.Spec.AuditLogging,
+		Openshift:                            apiCluster.Spec.Openshift,
+		AdmissionPlugins:                     apiCluster.Spec.AdmissionPlugins,
+		OPAIntegration:                       apiCluster.Spec.OPAIntegration,
+		PodNodeSelectorAdmissionPluginConfig: apiCluster.Spec.PodNodeSelectorAdmissionPluginConfig,
 	}
 
 	providerName, err := provider.ClusterCloudProviderName(spec.Cloud)

--- a/pkg/resources/resources.go
+++ b/pkg/resources/resources.go
@@ -228,6 +228,8 @@ const (
 	PrometheusConfigConfigMapName = "prometheus"
 	//AuditConfigMapName is the name for the configmap that contains the content of the file that will be passed to the apiserver with the flag "--audit-policy-file".
 	AuditConfigMapName = "audit-config"
+	//AdmissionControlConfigMapName is the name for the configmap that contains the Admission Controller config file
+	AdmissionControlConfigMapName = "adm-control"
 
 	//PrometheusServiceAccountName is the name for the Prometheus serviceaccount
 	PrometheusServiceAccountName = "prometheus"
@@ -379,6 +381,9 @@ const (
 	IPVSProxyMode = "ipvs"
 	// IPTablesProxyMode defines the iptables kube-proxy mode.
 	IPTablesProxyMode = "iptables"
+
+	// PodNodeSelectorAdmissionPlugin defines PodNodeSelector admission plugin
+	PodNodeSelectorAdmissionPlugin = "PodNodeSelector"
 )
 
 const (

--- a/pkg/resources/test/fixtures/configmap-aws-1.17.0-adm-control.yaml
+++ b/pkg/resources/test/fixtures/configmap-aws-1.17.0-adm-control.yaml
@@ -1,0 +1,8 @@
+# This file has been generated, DO NOT EDIT.
+
+data:
+  admission-control.yaml: |
+    kind: AdmissionConfiguration
+    apiVersion: apiserver.config.k8s.io/v1
+metadata:
+  creationTimestamp: null

--- a/pkg/resources/test/fixtures/configmap-aws-1.18.0-adm-control.yaml
+++ b/pkg/resources/test/fixtures/configmap-aws-1.18.0-adm-control.yaml
@@ -1,0 +1,8 @@
+# This file has been generated, DO NOT EDIT.
+
+data:
+  admission-control.yaml: |
+    kind: AdmissionConfiguration
+    apiVersion: apiserver.config.k8s.io/v1
+metadata:
+  creationTimestamp: null

--- a/pkg/resources/test/fixtures/configmap-aws-1.19.0-adm-control.yaml
+++ b/pkg/resources/test/fixtures/configmap-aws-1.19.0-adm-control.yaml
@@ -1,0 +1,8 @@
+# This file has been generated, DO NOT EDIT.
+
+data:
+  admission-control.yaml: |
+    kind: AdmissionConfiguration
+    apiVersion: apiserver.config.k8s.io/v1
+metadata:
+  creationTimestamp: null

--- a/pkg/resources/test/fixtures/configmap-azure-1.17.0-adm-control.yaml
+++ b/pkg/resources/test/fixtures/configmap-azure-1.17.0-adm-control.yaml
@@ -1,0 +1,8 @@
+# This file has been generated, DO NOT EDIT.
+
+data:
+  admission-control.yaml: |
+    kind: AdmissionConfiguration
+    apiVersion: apiserver.config.k8s.io/v1
+metadata:
+  creationTimestamp: null

--- a/pkg/resources/test/fixtures/configmap-azure-1.18.0-adm-control.yaml
+++ b/pkg/resources/test/fixtures/configmap-azure-1.18.0-adm-control.yaml
@@ -1,0 +1,8 @@
+# This file has been generated, DO NOT EDIT.
+
+data:
+  admission-control.yaml: |
+    kind: AdmissionConfiguration
+    apiVersion: apiserver.config.k8s.io/v1
+metadata:
+  creationTimestamp: null

--- a/pkg/resources/test/fixtures/configmap-azure-1.19.0-adm-control.yaml
+++ b/pkg/resources/test/fixtures/configmap-azure-1.19.0-adm-control.yaml
@@ -1,0 +1,8 @@
+# This file has been generated, DO NOT EDIT.
+
+data:
+  admission-control.yaml: |
+    kind: AdmissionConfiguration
+    apiVersion: apiserver.config.k8s.io/v1
+metadata:
+  creationTimestamp: null

--- a/pkg/resources/test/fixtures/configmap-bringyourown-1.17.0-adm-control.yaml
+++ b/pkg/resources/test/fixtures/configmap-bringyourown-1.17.0-adm-control.yaml
@@ -1,0 +1,8 @@
+# This file has been generated, DO NOT EDIT.
+
+data:
+  admission-control.yaml: |
+    kind: AdmissionConfiguration
+    apiVersion: apiserver.config.k8s.io/v1
+metadata:
+  creationTimestamp: null

--- a/pkg/resources/test/fixtures/configmap-bringyourown-1.18.0-adm-control.yaml
+++ b/pkg/resources/test/fixtures/configmap-bringyourown-1.18.0-adm-control.yaml
@@ -1,0 +1,8 @@
+# This file has been generated, DO NOT EDIT.
+
+data:
+  admission-control.yaml: |
+    kind: AdmissionConfiguration
+    apiVersion: apiserver.config.k8s.io/v1
+metadata:
+  creationTimestamp: null

--- a/pkg/resources/test/fixtures/configmap-bringyourown-1.19.0-adm-control.yaml
+++ b/pkg/resources/test/fixtures/configmap-bringyourown-1.19.0-adm-control.yaml
@@ -1,0 +1,8 @@
+# This file has been generated, DO NOT EDIT.
+
+data:
+  admission-control.yaml: |
+    kind: AdmissionConfiguration
+    apiVersion: apiserver.config.k8s.io/v1
+metadata:
+  creationTimestamp: null

--- a/pkg/resources/test/fixtures/configmap-digitalocean-1.17.0-adm-control.yaml
+++ b/pkg/resources/test/fixtures/configmap-digitalocean-1.17.0-adm-control.yaml
@@ -1,0 +1,8 @@
+# This file has been generated, DO NOT EDIT.
+
+data:
+  admission-control.yaml: |
+    kind: AdmissionConfiguration
+    apiVersion: apiserver.config.k8s.io/v1
+metadata:
+  creationTimestamp: null

--- a/pkg/resources/test/fixtures/configmap-digitalocean-1.18.0-adm-control.yaml
+++ b/pkg/resources/test/fixtures/configmap-digitalocean-1.18.0-adm-control.yaml
@@ -1,0 +1,8 @@
+# This file has been generated, DO NOT EDIT.
+
+data:
+  admission-control.yaml: |
+    kind: AdmissionConfiguration
+    apiVersion: apiserver.config.k8s.io/v1
+metadata:
+  creationTimestamp: null

--- a/pkg/resources/test/fixtures/configmap-digitalocean-1.19.0-adm-control.yaml
+++ b/pkg/resources/test/fixtures/configmap-digitalocean-1.19.0-adm-control.yaml
@@ -1,0 +1,8 @@
+# This file has been generated, DO NOT EDIT.
+
+data:
+  admission-control.yaml: |
+    kind: AdmissionConfiguration
+    apiVersion: apiserver.config.k8s.io/v1
+metadata:
+  creationTimestamp: null

--- a/pkg/resources/test/fixtures/configmap-openstack-1.17.0-adm-control.yaml
+++ b/pkg/resources/test/fixtures/configmap-openstack-1.17.0-adm-control.yaml
@@ -1,0 +1,8 @@
+# This file has been generated, DO NOT EDIT.
+
+data:
+  admission-control.yaml: |
+    kind: AdmissionConfiguration
+    apiVersion: apiserver.config.k8s.io/v1
+metadata:
+  creationTimestamp: null

--- a/pkg/resources/test/fixtures/configmap-openstack-1.18.0-adm-control.yaml
+++ b/pkg/resources/test/fixtures/configmap-openstack-1.18.0-adm-control.yaml
@@ -1,0 +1,8 @@
+# This file has been generated, DO NOT EDIT.
+
+data:
+  admission-control.yaml: |
+    kind: AdmissionConfiguration
+    apiVersion: apiserver.config.k8s.io/v1
+metadata:
+  creationTimestamp: null

--- a/pkg/resources/test/fixtures/configmap-openstack-1.19.0-adm-control.yaml
+++ b/pkg/resources/test/fixtures/configmap-openstack-1.19.0-adm-control.yaml
@@ -1,0 +1,8 @@
+# This file has been generated, DO NOT EDIT.
+
+data:
+  admission-control.yaml: |
+    kind: AdmissionConfiguration
+    apiVersion: apiserver.config.k8s.io/v1
+metadata:
+  creationTimestamp: null

--- a/pkg/resources/test/fixtures/configmap-vsphere-1.17.0-adm-control.yaml
+++ b/pkg/resources/test/fixtures/configmap-vsphere-1.17.0-adm-control.yaml
@@ -1,0 +1,8 @@
+# This file has been generated, DO NOT EDIT.
+
+data:
+  admission-control.yaml: |
+    kind: AdmissionConfiguration
+    apiVersion: apiserver.config.k8s.io/v1
+metadata:
+  creationTimestamp: null

--- a/pkg/resources/test/fixtures/configmap-vsphere-1.18.0-adm-control.yaml
+++ b/pkg/resources/test/fixtures/configmap-vsphere-1.18.0-adm-control.yaml
@@ -1,0 +1,8 @@
+# This file has been generated, DO NOT EDIT.
+
+data:
+  admission-control.yaml: |
+    kind: AdmissionConfiguration
+    apiVersion: apiserver.config.k8s.io/v1
+metadata:
+  creationTimestamp: null

--- a/pkg/resources/test/fixtures/configmap-vsphere-1.19.0-adm-control.yaml
+++ b/pkg/resources/test/fixtures/configmap-vsphere-1.19.0-adm-control.yaml
@@ -1,0 +1,8 @@
+# This file has been generated, DO NOT EDIT.
+
+data:
+  admission-control.yaml: |
+    kind: AdmissionConfiguration
+    apiVersion: apiserver.config.k8s.io/v1
+metadata:
+  creationTimestamp: null

--- a/pkg/resources/test/fixtures/deployment-aws-1.17.0-apiserver.yaml
+++ b/pkg/resources/test/fixtures/deployment-aws-1.17.0-apiserver.yaml
@@ -19,6 +19,7 @@ spec:
         prometheus.io/scrape_with_kube_cert: "true"
       creationTimestamp: null
       labels:
+        adm-control-configmap-revision: "123456"
         apiserver-etcd-client-certificate-secret-revision: "123456"
         apiserver-proxy-client-certificate-secret-revision: "123456"
         apiserver-tls-secret-revision: "123456"
@@ -153,6 +154,8 @@ spec:
         - etcd3
         - --enable-admission-plugins
         - DefaultStorageClass,DefaultTolerationSeconds,LimitRanger,MutatingAdmissionWebhook,NamespaceLifecycle,Priority,ResourceQuota,ServiceAccount,ValidatingAdmissionWebhook
+        - --admission-control-config-file
+        - /etc/kubernetes/adm-control/admission-control.yaml
         - --authorization-mode
         - Node,RBAC
         - --external-hostname
@@ -302,6 +305,9 @@ spec:
           readOnly: true
         - mountPath: /var/log/kubernetes/audit
           name: audit-log
+        - mountPath: /etc/kubernetes/adm-control
+          name: adm-control
+          readOnly: true
         - mountPath: /etc/ssl/certs
           name: ca-certs
           readOnly: true
@@ -383,6 +389,9 @@ spec:
         name: audit-config
       - emptyDir: {}
         name: audit-log
+      - configMap:
+          name: adm-control
+        name: adm-control
       - hostPath:
           path: /etc/ssl/certs
           type: DirectoryOrCreate

--- a/pkg/resources/test/fixtures/deployment-aws-1.18.0-apiserver.yaml
+++ b/pkg/resources/test/fixtures/deployment-aws-1.18.0-apiserver.yaml
@@ -19,6 +19,7 @@ spec:
         prometheus.io/scrape_with_kube_cert: "true"
       creationTimestamp: null
       labels:
+        adm-control-configmap-revision: "123456"
         apiserver-etcd-client-certificate-secret-revision: "123456"
         apiserver-proxy-client-certificate-secret-revision: "123456"
         apiserver-tls-secret-revision: "123456"
@@ -153,6 +154,8 @@ spec:
         - etcd3
         - --enable-admission-plugins
         - DefaultStorageClass,DefaultTolerationSeconds,LimitRanger,MutatingAdmissionWebhook,NamespaceLifecycle,Priority,ResourceQuota,ServiceAccount,ValidatingAdmissionWebhook
+        - --admission-control-config-file
+        - /etc/kubernetes/adm-control/admission-control.yaml
         - --authorization-mode
         - Node,RBAC
         - --external-hostname
@@ -302,6 +305,9 @@ spec:
           readOnly: true
         - mountPath: /var/log/kubernetes/audit
           name: audit-log
+        - mountPath: /etc/kubernetes/adm-control
+          name: adm-control
+          readOnly: true
         - mountPath: /etc/ssl/certs
           name: ca-certs
           readOnly: true
@@ -383,6 +389,9 @@ spec:
         name: audit-config
       - emptyDir: {}
         name: audit-log
+      - configMap:
+          name: adm-control
+        name: adm-control
       - hostPath:
           path: /etc/ssl/certs
           type: DirectoryOrCreate

--- a/pkg/resources/test/fixtures/deployment-aws-1.19.0-apiserver.yaml
+++ b/pkg/resources/test/fixtures/deployment-aws-1.19.0-apiserver.yaml
@@ -19,6 +19,7 @@ spec:
         prometheus.io/scrape_with_kube_cert: "true"
       creationTimestamp: null
       labels:
+        adm-control-configmap-revision: "123456"
         apiserver-etcd-client-certificate-secret-revision: "123456"
         apiserver-proxy-client-certificate-secret-revision: "123456"
         apiserver-tls-secret-revision: "123456"
@@ -153,6 +154,8 @@ spec:
         - etcd3
         - --enable-admission-plugins
         - DefaultStorageClass,DefaultTolerationSeconds,LimitRanger,MutatingAdmissionWebhook,NamespaceLifecycle,Priority,ResourceQuota,ServiceAccount,ValidatingAdmissionWebhook
+        - --admission-control-config-file
+        - /etc/kubernetes/adm-control/admission-control.yaml
         - --authorization-mode
         - Node,RBAC
         - --external-hostname
@@ -302,6 +305,9 @@ spec:
           readOnly: true
         - mountPath: /var/log/kubernetes/audit
           name: audit-log
+        - mountPath: /etc/kubernetes/adm-control
+          name: adm-control
+          readOnly: true
         - mountPath: /etc/ssl/certs
           name: ca-certs
           readOnly: true
@@ -383,6 +389,9 @@ spec:
         name: audit-config
       - emptyDir: {}
         name: audit-log
+      - configMap:
+          name: adm-control
+        name: adm-control
       - hostPath:
           path: /etc/ssl/certs
           type: DirectoryOrCreate

--- a/pkg/resources/test/fixtures/deployment-azure-1.17.0-apiserver.yaml
+++ b/pkg/resources/test/fixtures/deployment-azure-1.17.0-apiserver.yaml
@@ -19,6 +19,7 @@ spec:
         prometheus.io/scrape_with_kube_cert: "true"
       creationTimestamp: null
       labels:
+        adm-control-configmap-revision: "123456"
         apiserver-etcd-client-certificate-secret-revision: "123456"
         apiserver-proxy-client-certificate-secret-revision: "123456"
         apiserver-tls-secret-revision: "123456"
@@ -153,6 +154,8 @@ spec:
         - etcd3
         - --enable-admission-plugins
         - DefaultStorageClass,DefaultTolerationSeconds,LimitRanger,MutatingAdmissionWebhook,NamespaceLifecycle,Priority,ResourceQuota,ServiceAccount,ValidatingAdmissionWebhook
+        - --admission-control-config-file
+        - /etc/kubernetes/adm-control/admission-control.yaml
         - --authorization-mode
         - Node,RBAC
         - --external-hostname
@@ -296,6 +299,9 @@ spec:
           readOnly: true
         - mountPath: /var/log/kubernetes/audit
           name: audit-log
+        - mountPath: /etc/kubernetes/adm-control
+          name: adm-control
+          readOnly: true
         - mountPath: /etc/ssl/certs
           name: ca-certs
           readOnly: true
@@ -377,6 +383,9 @@ spec:
         name: audit-config
       - emptyDir: {}
         name: audit-log
+      - configMap:
+          name: adm-control
+        name: adm-control
       - hostPath:
           path: /etc/ssl/certs
           type: DirectoryOrCreate

--- a/pkg/resources/test/fixtures/deployment-azure-1.18.0-apiserver.yaml
+++ b/pkg/resources/test/fixtures/deployment-azure-1.18.0-apiserver.yaml
@@ -19,6 +19,7 @@ spec:
         prometheus.io/scrape_with_kube_cert: "true"
       creationTimestamp: null
       labels:
+        adm-control-configmap-revision: "123456"
         apiserver-etcd-client-certificate-secret-revision: "123456"
         apiserver-proxy-client-certificate-secret-revision: "123456"
         apiserver-tls-secret-revision: "123456"
@@ -153,6 +154,8 @@ spec:
         - etcd3
         - --enable-admission-plugins
         - DefaultStorageClass,DefaultTolerationSeconds,LimitRanger,MutatingAdmissionWebhook,NamespaceLifecycle,Priority,ResourceQuota,ServiceAccount,ValidatingAdmissionWebhook
+        - --admission-control-config-file
+        - /etc/kubernetes/adm-control/admission-control.yaml
         - --authorization-mode
         - Node,RBAC
         - --external-hostname
@@ -296,6 +299,9 @@ spec:
           readOnly: true
         - mountPath: /var/log/kubernetes/audit
           name: audit-log
+        - mountPath: /etc/kubernetes/adm-control
+          name: adm-control
+          readOnly: true
         - mountPath: /etc/ssl/certs
           name: ca-certs
           readOnly: true
@@ -377,6 +383,9 @@ spec:
         name: audit-config
       - emptyDir: {}
         name: audit-log
+      - configMap:
+          name: adm-control
+        name: adm-control
       - hostPath:
           path: /etc/ssl/certs
           type: DirectoryOrCreate

--- a/pkg/resources/test/fixtures/deployment-azure-1.19.0-apiserver.yaml
+++ b/pkg/resources/test/fixtures/deployment-azure-1.19.0-apiserver.yaml
@@ -19,6 +19,7 @@ spec:
         prometheus.io/scrape_with_kube_cert: "true"
       creationTimestamp: null
       labels:
+        adm-control-configmap-revision: "123456"
         apiserver-etcd-client-certificate-secret-revision: "123456"
         apiserver-proxy-client-certificate-secret-revision: "123456"
         apiserver-tls-secret-revision: "123456"
@@ -153,6 +154,8 @@ spec:
         - etcd3
         - --enable-admission-plugins
         - DefaultStorageClass,DefaultTolerationSeconds,LimitRanger,MutatingAdmissionWebhook,NamespaceLifecycle,Priority,ResourceQuota,ServiceAccount,ValidatingAdmissionWebhook
+        - --admission-control-config-file
+        - /etc/kubernetes/adm-control/admission-control.yaml
         - --authorization-mode
         - Node,RBAC
         - --external-hostname
@@ -296,6 +299,9 @@ spec:
           readOnly: true
         - mountPath: /var/log/kubernetes/audit
           name: audit-log
+        - mountPath: /etc/kubernetes/adm-control
+          name: adm-control
+          readOnly: true
         - mountPath: /etc/ssl/certs
           name: ca-certs
           readOnly: true
@@ -377,6 +383,9 @@ spec:
         name: audit-config
       - emptyDir: {}
         name: audit-log
+      - configMap:
+          name: adm-control
+        name: adm-control
       - hostPath:
           path: /etc/ssl/certs
           type: DirectoryOrCreate

--- a/pkg/resources/test/fixtures/deployment-bringyourown-1.17.0-apiserver.yaml
+++ b/pkg/resources/test/fixtures/deployment-bringyourown-1.17.0-apiserver.yaml
@@ -19,6 +19,7 @@ spec:
         prometheus.io/scrape_with_kube_cert: "true"
       creationTimestamp: null
       labels:
+        adm-control-configmap-revision: "123456"
         apiserver-etcd-client-certificate-secret-revision: "123456"
         apiserver-proxy-client-certificate-secret-revision: "123456"
         apiserver-tls-secret-revision: "123456"
@@ -153,6 +154,8 @@ spec:
         - etcd3
         - --enable-admission-plugins
         - DefaultStorageClass,DefaultTolerationSeconds,LimitRanger,MutatingAdmissionWebhook,NamespaceLifecycle,Priority,ResourceQuota,ServiceAccount,ValidatingAdmissionWebhook
+        - --admission-control-config-file
+        - /etc/kubernetes/adm-control/admission-control.yaml
         - --authorization-mode
         - Node,RBAC
         - --external-hostname
@@ -292,6 +295,9 @@ spec:
           readOnly: true
         - mountPath: /var/log/kubernetes/audit
           name: audit-log
+        - mountPath: /etc/kubernetes/adm-control
+          name: adm-control
+          readOnly: true
         - mountPath: /etc/ssl/certs
           name: ca-certs
           readOnly: true
@@ -373,6 +379,9 @@ spec:
         name: audit-config
       - emptyDir: {}
         name: audit-log
+      - configMap:
+          name: adm-control
+        name: adm-control
       - hostPath:
           path: /etc/ssl/certs
           type: DirectoryOrCreate

--- a/pkg/resources/test/fixtures/deployment-bringyourown-1.18.0-apiserver.yaml
+++ b/pkg/resources/test/fixtures/deployment-bringyourown-1.18.0-apiserver.yaml
@@ -19,6 +19,7 @@ spec:
         prometheus.io/scrape_with_kube_cert: "true"
       creationTimestamp: null
       labels:
+        adm-control-configmap-revision: "123456"
         apiserver-etcd-client-certificate-secret-revision: "123456"
         apiserver-proxy-client-certificate-secret-revision: "123456"
         apiserver-tls-secret-revision: "123456"
@@ -153,6 +154,8 @@ spec:
         - etcd3
         - --enable-admission-plugins
         - DefaultStorageClass,DefaultTolerationSeconds,LimitRanger,MutatingAdmissionWebhook,NamespaceLifecycle,Priority,ResourceQuota,ServiceAccount,ValidatingAdmissionWebhook
+        - --admission-control-config-file
+        - /etc/kubernetes/adm-control/admission-control.yaml
         - --authorization-mode
         - Node,RBAC
         - --external-hostname
@@ -292,6 +295,9 @@ spec:
           readOnly: true
         - mountPath: /var/log/kubernetes/audit
           name: audit-log
+        - mountPath: /etc/kubernetes/adm-control
+          name: adm-control
+          readOnly: true
         - mountPath: /etc/ssl/certs
           name: ca-certs
           readOnly: true
@@ -373,6 +379,9 @@ spec:
         name: audit-config
       - emptyDir: {}
         name: audit-log
+      - configMap:
+          name: adm-control
+        name: adm-control
       - hostPath:
           path: /etc/ssl/certs
           type: DirectoryOrCreate

--- a/pkg/resources/test/fixtures/deployment-bringyourown-1.19.0-apiserver.yaml
+++ b/pkg/resources/test/fixtures/deployment-bringyourown-1.19.0-apiserver.yaml
@@ -19,6 +19,7 @@ spec:
         prometheus.io/scrape_with_kube_cert: "true"
       creationTimestamp: null
       labels:
+        adm-control-configmap-revision: "123456"
         apiserver-etcd-client-certificate-secret-revision: "123456"
         apiserver-proxy-client-certificate-secret-revision: "123456"
         apiserver-tls-secret-revision: "123456"
@@ -153,6 +154,8 @@ spec:
         - etcd3
         - --enable-admission-plugins
         - DefaultStorageClass,DefaultTolerationSeconds,LimitRanger,MutatingAdmissionWebhook,NamespaceLifecycle,Priority,ResourceQuota,ServiceAccount,ValidatingAdmissionWebhook
+        - --admission-control-config-file
+        - /etc/kubernetes/adm-control/admission-control.yaml
         - --authorization-mode
         - Node,RBAC
         - --external-hostname
@@ -292,6 +295,9 @@ spec:
           readOnly: true
         - mountPath: /var/log/kubernetes/audit
           name: audit-log
+        - mountPath: /etc/kubernetes/adm-control
+          name: adm-control
+          readOnly: true
         - mountPath: /etc/ssl/certs
           name: ca-certs
           readOnly: true
@@ -373,6 +379,9 @@ spec:
         name: audit-config
       - emptyDir: {}
         name: audit-log
+      - configMap:
+          name: adm-control
+        name: adm-control
       - hostPath:
           path: /etc/ssl/certs
           type: DirectoryOrCreate

--- a/pkg/resources/test/fixtures/deployment-digitalocean-1.17.0-apiserver.yaml
+++ b/pkg/resources/test/fixtures/deployment-digitalocean-1.17.0-apiserver.yaml
@@ -19,6 +19,7 @@ spec:
         prometheus.io/scrape_with_kube_cert: "true"
       creationTimestamp: null
       labels:
+        adm-control-configmap-revision: "123456"
         apiserver-etcd-client-certificate-secret-revision: "123456"
         apiserver-proxy-client-certificate-secret-revision: "123456"
         apiserver-tls-secret-revision: "123456"
@@ -153,6 +154,8 @@ spec:
         - etcd3
         - --enable-admission-plugins
         - DefaultStorageClass,DefaultTolerationSeconds,LimitRanger,MutatingAdmissionWebhook,NamespaceLifecycle,Priority,ResourceQuota,ServiceAccount,ValidatingAdmissionWebhook
+        - --admission-control-config-file
+        - /etc/kubernetes/adm-control/admission-control.yaml
         - --authorization-mode
         - Node,RBAC
         - --external-hostname
@@ -292,6 +295,9 @@ spec:
           readOnly: true
         - mountPath: /var/log/kubernetes/audit
           name: audit-log
+        - mountPath: /etc/kubernetes/adm-control
+          name: adm-control
+          readOnly: true
         - mountPath: /etc/ssl/certs
           name: ca-certs
           readOnly: true
@@ -373,6 +379,9 @@ spec:
         name: audit-config
       - emptyDir: {}
         name: audit-log
+      - configMap:
+          name: adm-control
+        name: adm-control
       - hostPath:
           path: /etc/ssl/certs
           type: DirectoryOrCreate

--- a/pkg/resources/test/fixtures/deployment-digitalocean-1.18.0-apiserver.yaml
+++ b/pkg/resources/test/fixtures/deployment-digitalocean-1.18.0-apiserver.yaml
@@ -19,6 +19,7 @@ spec:
         prometheus.io/scrape_with_kube_cert: "true"
       creationTimestamp: null
       labels:
+        adm-control-configmap-revision: "123456"
         apiserver-etcd-client-certificate-secret-revision: "123456"
         apiserver-proxy-client-certificate-secret-revision: "123456"
         apiserver-tls-secret-revision: "123456"
@@ -153,6 +154,8 @@ spec:
         - etcd3
         - --enable-admission-plugins
         - DefaultStorageClass,DefaultTolerationSeconds,LimitRanger,MutatingAdmissionWebhook,NamespaceLifecycle,Priority,ResourceQuota,ServiceAccount,ValidatingAdmissionWebhook
+        - --admission-control-config-file
+        - /etc/kubernetes/adm-control/admission-control.yaml
         - --authorization-mode
         - Node,RBAC
         - --external-hostname
@@ -292,6 +295,9 @@ spec:
           readOnly: true
         - mountPath: /var/log/kubernetes/audit
           name: audit-log
+        - mountPath: /etc/kubernetes/adm-control
+          name: adm-control
+          readOnly: true
         - mountPath: /etc/ssl/certs
           name: ca-certs
           readOnly: true
@@ -373,6 +379,9 @@ spec:
         name: audit-config
       - emptyDir: {}
         name: audit-log
+      - configMap:
+          name: adm-control
+        name: adm-control
       - hostPath:
           path: /etc/ssl/certs
           type: DirectoryOrCreate

--- a/pkg/resources/test/fixtures/deployment-digitalocean-1.19.0-apiserver.yaml
+++ b/pkg/resources/test/fixtures/deployment-digitalocean-1.19.0-apiserver.yaml
@@ -19,6 +19,7 @@ spec:
         prometheus.io/scrape_with_kube_cert: "true"
       creationTimestamp: null
       labels:
+        adm-control-configmap-revision: "123456"
         apiserver-etcd-client-certificate-secret-revision: "123456"
         apiserver-proxy-client-certificate-secret-revision: "123456"
         apiserver-tls-secret-revision: "123456"
@@ -153,6 +154,8 @@ spec:
         - etcd3
         - --enable-admission-plugins
         - DefaultStorageClass,DefaultTolerationSeconds,LimitRanger,MutatingAdmissionWebhook,NamespaceLifecycle,Priority,ResourceQuota,ServiceAccount,ValidatingAdmissionWebhook
+        - --admission-control-config-file
+        - /etc/kubernetes/adm-control/admission-control.yaml
         - --authorization-mode
         - Node,RBAC
         - --external-hostname
@@ -292,6 +295,9 @@ spec:
           readOnly: true
         - mountPath: /var/log/kubernetes/audit
           name: audit-log
+        - mountPath: /etc/kubernetes/adm-control
+          name: adm-control
+          readOnly: true
         - mountPath: /etc/ssl/certs
           name: ca-certs
           readOnly: true
@@ -373,6 +379,9 @@ spec:
         name: audit-config
       - emptyDir: {}
         name: audit-log
+      - configMap:
+          name: adm-control
+        name: adm-control
       - hostPath:
           path: /etc/ssl/certs
           type: DirectoryOrCreate

--- a/pkg/resources/test/fixtures/deployment-openstack-1.17.0-apiserver.yaml
+++ b/pkg/resources/test/fixtures/deployment-openstack-1.17.0-apiserver.yaml
@@ -19,6 +19,7 @@ spec:
         prometheus.io/scrape_with_kube_cert: "true"
       creationTimestamp: null
       labels:
+        adm-control-configmap-revision: "123456"
         apiserver-etcd-client-certificate-secret-revision: "123456"
         apiserver-proxy-client-certificate-secret-revision: "123456"
         apiserver-tls-secret-revision: "123456"
@@ -153,6 +154,8 @@ spec:
         - etcd3
         - --enable-admission-plugins
         - DefaultStorageClass,DefaultTolerationSeconds,LimitRanger,MutatingAdmissionWebhook,NamespaceLifecycle,Priority,ResourceQuota,ServiceAccount,ValidatingAdmissionWebhook
+        - --admission-control-config-file
+        - /etc/kubernetes/adm-control/admission-control.yaml
         - --authorization-mode
         - Node,RBAC
         - --external-hostname
@@ -296,6 +299,9 @@ spec:
           readOnly: true
         - mountPath: /var/log/kubernetes/audit
           name: audit-log
+        - mountPath: /etc/kubernetes/adm-control
+          name: adm-control
+          readOnly: true
         - mountPath: /etc/ssl/certs
           name: ca-certs
           readOnly: true
@@ -377,6 +383,9 @@ spec:
         name: audit-config
       - emptyDir: {}
         name: audit-log
+      - configMap:
+          name: adm-control
+        name: adm-control
       - hostPath:
           path: /etc/ssl/certs
           type: DirectoryOrCreate

--- a/pkg/resources/test/fixtures/deployment-openstack-1.18.0-apiserver.yaml
+++ b/pkg/resources/test/fixtures/deployment-openstack-1.18.0-apiserver.yaml
@@ -19,6 +19,7 @@ spec:
         prometheus.io/scrape_with_kube_cert: "true"
       creationTimestamp: null
       labels:
+        adm-control-configmap-revision: "123456"
         apiserver-etcd-client-certificate-secret-revision: "123456"
         apiserver-proxy-client-certificate-secret-revision: "123456"
         apiserver-tls-secret-revision: "123456"
@@ -153,6 +154,8 @@ spec:
         - etcd3
         - --enable-admission-plugins
         - DefaultStorageClass,DefaultTolerationSeconds,LimitRanger,MutatingAdmissionWebhook,NamespaceLifecycle,Priority,ResourceQuota,ServiceAccount,ValidatingAdmissionWebhook
+        - --admission-control-config-file
+        - /etc/kubernetes/adm-control/admission-control.yaml
         - --authorization-mode
         - Node,RBAC
         - --external-hostname
@@ -296,6 +299,9 @@ spec:
           readOnly: true
         - mountPath: /var/log/kubernetes/audit
           name: audit-log
+        - mountPath: /etc/kubernetes/adm-control
+          name: adm-control
+          readOnly: true
         - mountPath: /etc/ssl/certs
           name: ca-certs
           readOnly: true
@@ -377,6 +383,9 @@ spec:
         name: audit-config
       - emptyDir: {}
         name: audit-log
+      - configMap:
+          name: adm-control
+        name: adm-control
       - hostPath:
           path: /etc/ssl/certs
           type: DirectoryOrCreate

--- a/pkg/resources/test/fixtures/deployment-openstack-1.19.0-apiserver.yaml
+++ b/pkg/resources/test/fixtures/deployment-openstack-1.19.0-apiserver.yaml
@@ -19,6 +19,7 @@ spec:
         prometheus.io/scrape_with_kube_cert: "true"
       creationTimestamp: null
       labels:
+        adm-control-configmap-revision: "123456"
         apiserver-etcd-client-certificate-secret-revision: "123456"
         apiserver-proxy-client-certificate-secret-revision: "123456"
         apiserver-tls-secret-revision: "123456"
@@ -153,6 +154,8 @@ spec:
         - etcd3
         - --enable-admission-plugins
         - DefaultStorageClass,DefaultTolerationSeconds,LimitRanger,MutatingAdmissionWebhook,NamespaceLifecycle,Priority,ResourceQuota,ServiceAccount,ValidatingAdmissionWebhook
+        - --admission-control-config-file
+        - /etc/kubernetes/adm-control/admission-control.yaml
         - --authorization-mode
         - Node,RBAC
         - --external-hostname
@@ -296,6 +299,9 @@ spec:
           readOnly: true
         - mountPath: /var/log/kubernetes/audit
           name: audit-log
+        - mountPath: /etc/kubernetes/adm-control
+          name: adm-control
+          readOnly: true
         - mountPath: /etc/ssl/certs
           name: ca-certs
           readOnly: true
@@ -377,6 +383,9 @@ spec:
         name: audit-config
       - emptyDir: {}
         name: audit-log
+      - configMap:
+          name: adm-control
+        name: adm-control
       - hostPath:
           path: /etc/ssl/certs
           type: DirectoryOrCreate

--- a/pkg/resources/test/fixtures/deployment-vsphere-1.17.0-apiserver.yaml
+++ b/pkg/resources/test/fixtures/deployment-vsphere-1.17.0-apiserver.yaml
@@ -19,6 +19,7 @@ spec:
         prometheus.io/scrape_with_kube_cert: "true"
       creationTimestamp: null
       labels:
+        adm-control-configmap-revision: "123456"
         apiserver-etcd-client-certificate-secret-revision: "123456"
         apiserver-proxy-client-certificate-secret-revision: "123456"
         apiserver-tls-secret-revision: "123456"
@@ -153,6 +154,8 @@ spec:
         - etcd3
         - --enable-admission-plugins
         - DefaultStorageClass,DefaultTolerationSeconds,LimitRanger,MutatingAdmissionWebhook,NamespaceLifecycle,Priority,ResourceQuota,ServiceAccount,ValidatingAdmissionWebhook
+        - --admission-control-config-file
+        - /etc/kubernetes/adm-control/admission-control.yaml
         - --authorization-mode
         - Node,RBAC
         - --external-hostname
@@ -296,6 +299,9 @@ spec:
           readOnly: true
         - mountPath: /var/log/kubernetes/audit
           name: audit-log
+        - mountPath: /etc/kubernetes/adm-control
+          name: adm-control
+          readOnly: true
         - mountPath: /etc/ssl/certs
           name: ca-certs
           readOnly: true
@@ -377,6 +383,9 @@ spec:
         name: audit-config
       - emptyDir: {}
         name: audit-log
+      - configMap:
+          name: adm-control
+        name: adm-control
       - hostPath:
           path: /etc/ssl/certs
           type: DirectoryOrCreate

--- a/pkg/resources/test/fixtures/deployment-vsphere-1.18.0-apiserver.yaml
+++ b/pkg/resources/test/fixtures/deployment-vsphere-1.18.0-apiserver.yaml
@@ -19,6 +19,7 @@ spec:
         prometheus.io/scrape_with_kube_cert: "true"
       creationTimestamp: null
       labels:
+        adm-control-configmap-revision: "123456"
         apiserver-etcd-client-certificate-secret-revision: "123456"
         apiserver-proxy-client-certificate-secret-revision: "123456"
         apiserver-tls-secret-revision: "123456"
@@ -153,6 +154,8 @@ spec:
         - etcd3
         - --enable-admission-plugins
         - DefaultStorageClass,DefaultTolerationSeconds,LimitRanger,MutatingAdmissionWebhook,NamespaceLifecycle,Priority,ResourceQuota,ServiceAccount,ValidatingAdmissionWebhook
+        - --admission-control-config-file
+        - /etc/kubernetes/adm-control/admission-control.yaml
         - --authorization-mode
         - Node,RBAC
         - --external-hostname
@@ -296,6 +299,9 @@ spec:
           readOnly: true
         - mountPath: /var/log/kubernetes/audit
           name: audit-log
+        - mountPath: /etc/kubernetes/adm-control
+          name: adm-control
+          readOnly: true
         - mountPath: /etc/ssl/certs
           name: ca-certs
           readOnly: true
@@ -377,6 +383,9 @@ spec:
         name: audit-config
       - emptyDir: {}
         name: audit-log
+      - configMap:
+          name: adm-control
+        name: adm-control
       - hostPath:
           path: /etc/ssl/certs
           type: DirectoryOrCreate

--- a/pkg/resources/test/fixtures/deployment-vsphere-1.19.0-apiserver.yaml
+++ b/pkg/resources/test/fixtures/deployment-vsphere-1.19.0-apiserver.yaml
@@ -19,6 +19,7 @@ spec:
         prometheus.io/scrape_with_kube_cert: "true"
       creationTimestamp: null
       labels:
+        adm-control-configmap-revision: "123456"
         apiserver-etcd-client-certificate-secret-revision: "123456"
         apiserver-proxy-client-certificate-secret-revision: "123456"
         apiserver-tls-secret-revision: "123456"
@@ -153,6 +154,8 @@ spec:
         - etcd3
         - --enable-admission-plugins
         - DefaultStorageClass,DefaultTolerationSeconds,LimitRanger,MutatingAdmissionWebhook,NamespaceLifecycle,Priority,ResourceQuota,ServiceAccount,ValidatingAdmissionWebhook
+        - --admission-control-config-file
+        - /etc/kubernetes/adm-control/admission-control.yaml
         - --authorization-mode
         - Node,RBAC
         - --external-hostname
@@ -296,6 +299,9 @@ spec:
           readOnly: true
         - mountPath: /var/log/kubernetes/audit
           name: audit-log
+        - mountPath: /etc/kubernetes/adm-control
+          name: adm-control
+          readOnly: true
         - mountPath: /etc/ssl/certs
           name: ca-certs
           readOnly: true
@@ -377,6 +383,9 @@ spec:
         name: audit-config
       - emptyDir: {}
         name: audit-log
+      - configMap:
+          name: adm-control
+        name: adm-control
       - hostPath:
           path: /etc/ssl/certs
           type: DirectoryOrCreate

--- a/pkg/resources/test/load_files_test.go
+++ b/pkg/resources/test/load_files_test.go
@@ -480,6 +480,13 @@ func TestLoadFiles(t *testing.T) {
 							Namespace:       cluster.Status.NamespaceName,
 						},
 					},
+					&corev1.ConfigMap{
+						ObjectMeta: metav1.ObjectMeta{
+							ResourceVersion: "123456",
+							Name:            resources.AdmissionControlConfigMapName,
+							Namespace:       cluster.Status.NamespaceName,
+						},
+					},
 					&corev1.Service{
 						ObjectMeta: metav1.ObjectMeta{
 							Name:      resources.ApiserverServiceName,

--- a/pkg/test/e2e/api/utils/apiclient/models/cluster_spec.go
+++ b/pkg/test/e2e/api/utils/apiclient/models/cluster_spec.go
@@ -24,6 +24,16 @@ type ClusterSpec struct {
 	// MachineNetworks optionally specifies the parameters for IPAM.
 	MachineNetworks []*MachineNetworkingConfig `json:"machineNetworks"`
 
+	// PodNodeSelectorAdmissionPluginConfig provides the configuration for the PodNodeSelector.
+	// It's used by the backend to create a configuration file for this plugin.
+	// The key:value from the map is converted to the namespace:<node-selectors-labels> in the file.
+	// The format in a file:
+	// podNodeSelectorPluginConfig:
+	// clusterDefaultNodeSelector: <node-selectors-labels>
+	// namespace1: <node-selectors-labels>
+	// namespace2: <node-selectors-labels>
+	PodNodeSelectorAdmissionPluginConfig map[string]string `json:"podNodeSelectorAdmissionPluginConfig,omitempty"`
+
 	// If active the PodNodeSelector admission plugin is configured at the apiserver
 	UsePodNodeSelectorAdmissionPlugin bool `json:"usePodNodeSelectorAdmissionPlugin,omitempty"`
 


### PR DESCRIPTION
**What this PR does / why we need it**: add admission control configuration for the user cluster API deployment

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #6307


```release-note
add admission control configuration for the user cluster API deployment
```
