### PR TITLE
add PodNodeSelectorAdmissionPluginConfig for cluster patch endpoint

### DIFF
--- a/pkg/handler/common/cluster.go
+++ b/pkg/handler/common/cluster.go
@@ -351,6 +351,7 @@ func PatchEndpoint(ctx context.Context, userInfoGetter provider.UserInfoGetter, 
 	newInternalCluster.Spec.Openshift = patchedCluster.Spec.Openshift
 	newInternalCluster.Spec.UpdateWindow = patchedCluster.Spec.UpdateWindow
 	newInternalCluster.Spec.OPAIntegration = patchedCluster.Spec.OPAIntegration
+	newInternalCluster.Spec.PodNodeSelectorAdmissionPluginConfig = patchedCluster.Spec.PodNodeSelectorAdmissionPluginConfig
 
 	incompatibleKubelets, err := common.CheckClusterVersionSkew(ctx, userInfoGetter, clusterProvider, newInternalCluster, projectID)
 	if err != nil {
@@ -821,16 +822,17 @@ func convertInternalClusterToExternal(internalCluster *kubermaticv1.Cluster, fil
 		Labels:          internalCluster.Labels,
 		InheritedLabels: internalCluster.Status.InheritedLabels,
 		Spec: apiv1.ClusterSpec{
-			Cloud:                               internalCluster.Spec.Cloud,
-			Version:                             internalCluster.Spec.Version,
-			MachineNetworks:                     internalCluster.Spec.MachineNetworks,
-			OIDC:                                internalCluster.Spec.OIDC,
-			UpdateWindow:                        internalCluster.Spec.UpdateWindow,
-			AuditLogging:                        internalCluster.Spec.AuditLogging,
-			UsePodSecurityPolicyAdmissionPlugin: internalCluster.Spec.UsePodSecurityPolicyAdmissionPlugin,
-			UsePodNodeSelectorAdmissionPlugin:   internalCluster.Spec.UsePodNodeSelectorAdmissionPlugin,
-			AdmissionPlugins:                    internalCluster.Spec.AdmissionPlugins,
-			OPAIntegration:                      internalCluster.Spec.OPAIntegration,
+			Cloud:                                internalCluster.Spec.Cloud,
+			Version:                              internalCluster.Spec.Version,
+			MachineNetworks:                      internalCluster.Spec.MachineNetworks,
+			OIDC:                                 internalCluster.Spec.OIDC,
+			UpdateWindow:                         internalCluster.Spec.UpdateWindow,
+			AuditLogging:                         internalCluster.Spec.AuditLogging,
+			UsePodSecurityPolicyAdmissionPlugin:  internalCluster.Spec.UsePodSecurityPolicyAdmissionPlugin,
+			UsePodNodeSelectorAdmissionPlugin:    internalCluster.Spec.UsePodNodeSelectorAdmissionPlugin,
+			AdmissionPlugins:                     internalCluster.Spec.AdmissionPlugins,
+			OPAIntegration:                       internalCluster.Spec.OPAIntegration,
+			PodNodeSelectorAdmissionPluginConfig: internalCluster.Spec.PodNodeSelectorAdmissionPluginConfig,
 		},
 		Status: apiv1.ClusterStatus{
 			Version: internalCluster.Spec.Version,

--- a/pkg/handler/v2/cluster/cluster_test.go
+++ b/pkg/handler/v2/cluster/cluster_test.go
@@ -875,6 +875,22 @@ func TestPatchCluster(t *testing.T) {
 					return cluster
 				}(), genUser("John", "john@acme.com", false)),
 		},
+		// scenario 8
+		{
+			Name:             "scenario 8: update the pod node selector admission plugin config",
+			Body:             `{"spec":{"version":"1.2.3","podNodeSelectorAdmissionPluginConfig":{"clusterDefaultNodeSelector":"env=development"}}}`,
+			ExpectedResponse: `{"id":"keen-snyder","name":"clusterAbc","creationTimestamp":"2013-02-03T19:54:00Z","type":"kubernetes","spec":{"cloud":{"dc":"fake-dc","fake":{}},"version":"1.2.3","oidc":{},"podNodeSelectorAdmissionPluginConfig":{"clusterDefaultNodeSelector":"env=development"}},"status":{"version":"1.2.3","url":"https://w225mx4z66.asia-east1-a-1.cloud.kubermatic.io:31885"}}`,
+			cluster:          "keen-snyder",
+			HTTPStatus:       http.StatusOK,
+			project:          test.GenDefaultProject().Name,
+			ExistingAPIUser:  test.GenDefaultAPIUser(),
+			ExistingKubermaticObjects: test.GenDefaultKubermaticObjects(
+				func() *kubermaticv1.Cluster {
+					cluster := test.GenCluster("keen-snyder", "clusterAbc", test.GenDefaultProject().Name, time.Date(2013, 02, 03, 19, 54, 0, 0, time.UTC))
+					cluster.Spec.Cloud.DatacenterName = fakeDC
+					return cluster
+				}()),
+		},
 	}
 
 	for _, tc := range testcases {


### PR DESCRIPTION
**What this PR does / why we need it**: add PodNodeSelectorAdmissionPluginConfig for cluster patch endpoint

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #6318

```release-note
NONE
```
