### PR TITLE
Prevent container orphans when using apiserver.IsRunningWrapper

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -57,7 +57,6 @@ install:
 showenv:
 	@go env
 
-.PHONY: download-gocache
 download-gocache:
 	@./hack/ci/download-gocache.sh
 	@# Prevent this from getting executed multiple times

--- a/pkg/controller/seed-controller-manager/openshift/resources/cloud_credential_operator.go
+++ b/pkg/controller/seed-controller-manager/openshift/resources/cloud_credential_operator.go
@@ -37,7 +37,6 @@ const (
 func CloudCredentialOperator(data openshiftData) reconciling.NamedDeploymentCreatorGetter {
 	return func() (string, reconciling.DeploymentCreator) {
 		return cloudCredentialOperatorDeploymentName, func(d *appsv1.Deployment) (*appsv1.Deployment, error) {
-
 			image, err := cloudCredentialOperatorImage(data.Cluster().Spec.Version.String(), data.ImageRegistry(""))
 			if err != nil {
 				return nil, err
@@ -50,6 +49,7 @@ func CloudCredentialOperator(data openshiftData) reconciling.NamedDeploymentCrea
 				{Name: openshiftImagePullSecretName},
 			}
 			d.Spec.Template.Spec.AutomountServiceAccountToken = utilpointer.BoolPtr(false)
+			d.Spec.Template.Spec.InitContainers = []corev1.Container{}
 			d.Spec.Template.Spec.Containers = []corev1.Container{{
 				Name:    cloudCredentialOperatorDeploymentName,
 				Command: []string{"/root/manager", "--log-level", "debug"},
@@ -83,7 +83,7 @@ func CloudCredentialOperator(data openshiftData) reconciling.NamedDeploymentCrea
 
 			d.Spec.Template.Labels, err = data.GetPodTemplateLabels(cloudCredentialOperatorDeploymentName, d.Spec.Template.Spec.Volumes, nil)
 			if err != nil {
-				return nil, err
+				return nil, fmt.Errorf("failed to add template labels: %v", err)
 			}
 			wrappedPodSpec, err := apiserver.IsRunningWrapper(data, d.Spec.Template.Spec, sets.NewString(cloudCredentialOperatorDeploymentName), "CredentialsRequest,cloudcredential.openshift.io/v1")
 			if err != nil {

--- a/pkg/controller/seed-controller-manager/openshift/resources/console.go
+++ b/pkg/controller/seed-controller-manager/openshift/resources/console.go
@@ -86,6 +86,7 @@ func ConsoleDeployment(data openshiftData) reconciling.NamedDeploymentCreatorGet
 				return nil, err
 			}
 
+			d.Spec.Template.Spec.InitContainers = []corev1.Container{}
 			d.Spec.Template.Spec.Containers = []corev1.Container{{
 				Name:  "console",
 				Image: image,
@@ -177,7 +178,7 @@ func ConsoleDeployment(data openshiftData) reconciling.NamedDeploymentCreatorGet
 
 			podLabels, err := data.GetPodTemplateLabels(consoleDeploymentName, d.Spec.Template.Spec.Volumes, nil)
 			if err != nil {
-				return nil, err
+				return nil, fmt.Errorf("failed to add template labels: %v", err)
 			}
 			d.Spec.Template.Labels = podLabels
 

--- a/pkg/controller/seed-controller-manager/openshift/resources/dns_operator.go
+++ b/pkg/controller/seed-controller-manager/openshift/resources/dns_operator.go
@@ -82,6 +82,7 @@ func OpenshiftDNSOperatorFactory(data openshiftData) reconciling.NamedDeployment
 				return nil, err
 			}
 
+			d.Spec.Template.Spec.InitContainers = []corev1.Container{}
 			d.Spec.Template.Spec.Containers = []corev1.Container{{
 				Name:  openshiftDNSOperatorContainerName,
 				Image: image,
@@ -113,7 +114,7 @@ func OpenshiftDNSOperatorFactory(data openshiftData) reconciling.NamedDeployment
 
 			d.Spec.Template.Labels, err = data.GetPodTemplateLabels(openshiftDNSOperatorDeploymentName, d.Spec.Template.Spec.Volumes, nil)
 			if err != nil {
-				return nil, err
+				return nil, fmt.Errorf("failed to add template labels: %v", err)
 			}
 
 			wrappedPodSpec, err := apiserver.IsRunningWrapper(data, d.Spec.Template.Spec, sets.NewString(openshiftDNSOperatorContainerName), "DNS,operator.openshift.io/v1", "Network,config.openshift.io/v1")

--- a/pkg/controller/seed-controller-manager/openshift/resources/kube_controller_manager.go
+++ b/pkg/controller/seed-controller-manager/openshift/resources/kube_controller_manager.go
@@ -278,6 +278,7 @@ func KubeControllerManagerDeploymentCreatorFactory(data kubeControllerManagerDat
 				}
 				kubeControllerManagerContainerName := "kube-controller-manager"
 
+				dep.Spec.Template.Spec.InitContainers = []corev1.Container{}
 				dep.Spec.Template.Spec.Containers = []corev1.Container{
 					*openvpnSidecar,
 					{
@@ -317,7 +318,7 @@ func KubeControllerManagerDeploymentCreatorFactory(data kubeControllerManagerDat
 				}
 				podLabels, err := data.GetPodTemplateLabels(resources.ControllerManagerDeploymentName, dep.Spec.Template.Spec.Volumes, nil)
 				if err != nil {
-					return nil, err
+					return nil, fmt.Errorf("failed to add template labels: %v", err)
 				}
 				dep.Spec.Template.Labels = podLabels
 				wrappedPodSpec, err := apiserver.IsRunningWrapper(data, dep.Spec.Template.Spec, sets.NewString(resources.ControllerManagerDeploymentName))

--- a/pkg/controller/seed-controller-manager/openshift/resources/kube_scheduler.go
+++ b/pkg/controller/seed-controller-manager/openshift/resources/kube_scheduler.go
@@ -135,6 +135,7 @@ func KubeSchedulerDeploymentCreator(data openshiftData) reconciling.NamedDeploym
 
 			dep.Spec.Template.Spec.ImagePullSecrets = []corev1.LocalObjectReference{{Name: openshiftImagePullSecretName}}
 
+			dep.Spec.Template.Spec.InitContainers = []corev1.Container{}
 			dep.Spec.Template.Spec.Containers = []corev1.Container{
 				*openvpnSidecar,
 				{

--- a/pkg/controller/seed-controller-manager/openshift/resources/oauth.go
+++ b/pkg/controller/seed-controller-manager/openshift/resources/oauth.go
@@ -374,6 +374,7 @@ func OauthDeploymentCreator(data openshiftData) reconciling.NamedDeploymentCreat
 				},
 			}
 
+			dep.Spec.Template.Spec.InitContainers = []corev1.Container{}
 			dep.Spec.Template.Spec.Containers = []corev1.Container{{
 				Name:  OauthName,
 				Image: image,
@@ -445,7 +446,7 @@ func OauthDeploymentCreator(data openshiftData) reconciling.NamedDeploymentCreat
 			dep.Spec.Template.Spec.Affinity = resources.HostnameAntiAffinity(OpenshiftAPIServerDeploymentName, data.Cluster().Name)
 			podLabels, err := data.GetPodTemplateLabels(OauthName, dep.Spec.Template.Spec.Volumes, nil)
 			if err != nil {
-				return nil, err
+				return nil, fmt.Errorf("failed to add template labels: %v", err)
 			}
 			dep.Spec.Template.Labels = podLabels
 

--- a/pkg/controller/seed-controller-manager/openshift/resources/openshift_apiserver_deployment.go
+++ b/pkg/controller/seed-controller-manager/openshift/resources/openshift_apiserver_deployment.go
@@ -195,6 +195,7 @@ func OpenshiftAPIServerDeploymentCreator(ctx context.Context, data openshiftData
 				return nil, err
 			}
 
+			dep.Spec.Template.Spec.InitContainers = []corev1.Container{}
 			dep.Spec.Template.Spec.Containers = []corev1.Container{
 				*openvpnSidecar,
 				*dnatControllerSidecar,
@@ -285,7 +286,7 @@ func OpenshiftAPIServerDeploymentCreator(ctx context.Context, data openshiftData
 			dep.Spec.Template.Spec.Affinity = resources.HostnameAntiAffinity(OpenshiftAPIServerDeploymentName, data.Cluster().Name)
 			podLabels, err := data.GetPodTemplateLabels(OpenshiftAPIServerDeploymentName, dep.Spec.Template.Spec.Volumes, nil)
 			if err != nil {
-				return nil, err
+				return nil, fmt.Errorf("failed to add template labels: %v", err)
 			}
 			dep.Spec.Template.Labels = podLabels
 

--- a/pkg/controller/seed-controller-manager/openshift/resources/openshift_controller_manager.go
+++ b/pkg/controller/seed-controller-manager/openshift/resources/openshift_controller_manager.go
@@ -172,6 +172,7 @@ func OpenshiftControllerManagerDeploymentCreator(ctx context.Context, data opens
 				return nil, fmt.Errorf("failed to get openvpn sidecar: %v", err)
 			}
 
+			dep.Spec.Template.Spec.InitContainers = []corev1.Container{}
 			dep.Spec.Template.Spec.Containers = []corev1.Container{
 				*openvpnSidecar,
 				{

--- a/pkg/controller/seed-controller-manager/openshift/resources/openshift_network_operator.go
+++ b/pkg/controller/seed-controller-manager/openshift/resources/openshift_network_operator.go
@@ -84,6 +84,7 @@ func OpenshiftNetworkOperatorCreatorFactory(data openshiftData) reconciling.Name
 				return nil, err
 			}
 
+			d.Spec.Template.Spec.InitContainers = []corev1.Container{}
 			d.Spec.Template.Spec.Containers = []corev1.Container{{
 				Name:  "network-operator",
 				Image: image,
@@ -117,7 +118,7 @@ func OpenshiftNetworkOperatorCreatorFactory(data openshiftData) reconciling.Name
 
 			d.Spec.Template.Labels, err = data.GetPodTemplateLabels(openshiftNetworkOperatorDeploymentName, d.Spec.Template.Spec.Volumes, nil)
 			if err != nil {
-				return nil, err
+				return nil, fmt.Errorf("failed to add template labels: %v", err)
 			}
 
 			wrappedPodSpec, err := apiserver.IsRunningWrapper(data, d.Spec.Template.Spec, sets.NewString("network-operator"), "Network,operator.openshift.io/v1")

--- a/pkg/controller/seed-controller-manager/openshift/resources/registry_operator.go
+++ b/pkg/controller/seed-controller-manager/openshift/resources/registry_operator.go
@@ -63,6 +63,7 @@ func RegistryOperatorFactory(data openshiftData) reconciling.NamedDeploymentCrea
 			if err != nil {
 				return nil, err
 			}
+			d.Spec.Template.Spec.InitContainers = []corev1.Container{}
 			d.Spec.Template.Spec.Containers = []corev1.Container{{
 				Name:    openshiftRegistryOperatorName,
 				Image:   image,
@@ -86,7 +87,7 @@ func RegistryOperatorFactory(data openshiftData) reconciling.NamedDeploymentCrea
 			}
 			d.Spec.Template.Labels, err = data.GetPodTemplateLabels(openshiftRegistryOperatorName, d.Spec.Template.Spec.Volumes, nil)
 			if err != nil {
-				return nil, err
+				return nil, fmt.Errorf("failed to add template labels: %v", err)
 			}
 			wrappedPodSpec, err := apiserver.IsRunningWrapper(data, d.Spec.Template.Spec, sets.NewString(openshiftRegistryOperatorName), "Config,imageregistry.operator.openshift.io/v1")
 			if err != nil {

--- a/pkg/resources/clusterautoscaler/clusterautoscaler.go
+++ b/pkg/resources/clusterautoscaler/clusterautoscaler.go
@@ -97,6 +97,7 @@ func DeploymentCreator(data clusterautoscalerData) reconciling.NamedDeploymentCr
 
 			dep.Spec.Template.Spec.Volumes = volumes
 
+			dep.Spec.Template.Spec.InitContainers = []corev1.Container{}
 			dep.Spec.Template.Spec.Containers = []corev1.Container{
 				{
 					Name:    resources.ClusterAutoscalerDeploymentName,

--- a/pkg/resources/controllermanager/deployment.go
+++ b/pkg/resources/controllermanager/deployment.go
@@ -147,6 +147,7 @@ func DeploymentCreator(data *resources.TemplateData) reconciling.NamedDeployment
 				Port:   intstr.FromInt(10257),
 			}
 
+			dep.Spec.Template.Spec.InitContainers = []corev1.Container{}
 			dep.Spec.Template.Spec.Containers = []corev1.Container{
 				*openvpnSidecar,
 				{

--- a/pkg/resources/gatekeeper/deployment.go
+++ b/pkg/resources/gatekeeper/deployment.go
@@ -120,6 +120,7 @@ func ControllerDeploymentCreator(data gatekeeperData) reconciling.NamedDeploymen
 			dep.Spec.Template.Spec.ServiceAccountName = serviceAccountName
 
 			dep.Spec.Template.Spec.Volumes = volumes
+			dep.Spec.Template.Spec.InitContainers = []corev1.Container{}
 			dep.Spec.Template.Spec.Containers = getControllerContainers(data, dep.Spec.Template.Spec.Containers)
 			err = resources.SetResourceRequirements(dep.Spec.Template.Spec.Containers, defaultResourceRequirements, nil, dep.Annotations)
 			if err != nil {
@@ -167,6 +168,7 @@ func AuditDeploymentCreator(data gatekeeperData) reconciling.NamedDeploymentCrea
 			dep.Spec.Template.Spec.ServiceAccountName = serviceAccountName
 
 			dep.Spec.Template.Spec.Volumes = volumes
+			dep.Spec.Template.Spec.InitContainers = []corev1.Container{}
 			dep.Spec.Template.Spec.Containers = getAuditContainers(data, dep.Spec.Template.Spec.Containers)
 			err = resources.SetResourceRequirements(dep.Spec.Template.Spec.Containers, defaultResourceRequirements, nil, dep.Annotations)
 			if err != nil {

--- a/pkg/resources/kubernetes-dashboard/deployment.go
+++ b/pkg/resources/kubernetes-dashboard/deployment.go
@@ -87,6 +87,7 @@ func DeploymentCreator(data kubernetesDashboardData) reconciling.NamedDeployment
 			}
 
 			dep.Spec.Template.Spec.Volumes = volumes
+			dep.Spec.Template.Spec.InitContainers = []corev1.Container{}
 			dep.Spec.Template.Spec.Containers = getContainers(data, dep.Spec.Template.Spec.Containers)
 			err = resources.SetResourceRequirements(dep.Spec.Template.Spec.Containers, defaultResourceRequirements, nil, dep.Annotations)
 			if err != nil {

--- a/pkg/resources/kubestatemetrics/deployment.go
+++ b/pkg/resources/kubestatemetrics/deployment.go
@@ -81,6 +81,7 @@ func DeploymentCreator(data *resources.TemplateData) reconciling.NamedDeployment
 
 			dep.Spec.Template.Spec.Volumes = volumes
 
+			dep.Spec.Template.Spec.InitContainers = []corev1.Container{}
 			dep.Spec.Template.Spec.Containers = []corev1.Container{
 				{
 					Name:    name,

--- a/pkg/resources/machinecontroller/deployment.go
+++ b/pkg/resources/machinecontroller/deployment.go
@@ -135,6 +135,7 @@ func DeploymentCreatorWithoutInitWrapper(data machinecontrollerData) reconciling
 
 			externalCloudProvider := data.Cluster().Spec.Features[kubermaticv1.ClusterFeatureExternalCloudProvider]
 
+			dep.Spec.Template.Spec.InitContainers = []corev1.Container{}
 			dep.Spec.Template.Spec.Containers = []corev1.Container{
 				{
 					Name:    Name,

--- a/pkg/resources/machinecontroller/webhook.go
+++ b/pkg/resources/machinecontroller/webhook.go
@@ -74,6 +74,7 @@ func WebhookDeploymentCreator(data machinecontrollerData) reconciling.NamedDeplo
 			}
 			dep.Spec.Template.ObjectMeta = metav1.ObjectMeta{Labels: podLabels}
 
+			dep.Spec.Template.Spec.InitContainers = []corev1.Container{}
 			dep.Spec.Template.Spec.Containers = []corev1.Container{
 				{
 					Name:    Name,

--- a/pkg/resources/metrics-server/deployment.go
+++ b/pkg/resources/metrics-server/deployment.go
@@ -116,6 +116,7 @@ func DeploymentCreator(data metricsServerData) reconciling.NamedDeploymentCreato
 				return nil, fmt.Errorf("failed to get dnat-controller sidecar: %v", err)
 			}
 
+			dep.Spec.Template.Spec.InitContainers = []corev1.Container{}
 			dep.Spec.Template.Spec.Containers = []corev1.Container{
 				{
 					Name:    name,

--- a/pkg/resources/scheduler/deployment.go
+++ b/pkg/resources/scheduler/deployment.go
@@ -115,6 +115,7 @@ func DeploymentCreator(data *resources.TemplateData) reconciling.NamedDeployment
 				Port:   intstr.FromInt(10259),
 			}
 
+			dep.Spec.Template.Spec.InitContainers = []corev1.Container{}
 			dep.Spec.Template.Spec.Containers = []corev1.Container{
 				*openvpnSidecar,
 				{

--- a/pkg/resources/usercluster/deployment.go
+++ b/pkg/resources/usercluster/deployment.go
@@ -158,6 +158,7 @@ func DeploymentCreator(data userclusterControllerData, openshift bool) reconcili
 				args = append(args, "-cloud-credential-secret-template", string(cloudCredentialSecretTemplate))
 			}
 
+			dep.Spec.Template.Spec.InitContainers = []corev1.Container{}
 			dep.Spec.Template.Spec.Containers = []corev1.Container{
 				{
 					Name:    name,


### PR DESCRIPTION
**What this PR does / why we need it**:
When the IsRunningWrapper() function is fiddling with initContainers, we must make sure we only accept and deal with a known state. Otherwise it can happen that old init containers are left behind or copies are never cleaned up.

**Which issue(s) this PR fixes**:
Fixes #6328

**Does this PR introduce a user-facing change?**:
```release-note
[ATTN] Fix orphaned apiserver-is-running initContainers in usercluster controlplane. This can cause a short reconciliation burst to bring older usercluster resources in all Seed clusters up to date. Tune the maxReconcileLimit if needed.
```
