### PR TITLE
WIP - refactor etcd-launcher tests

### DIFF
--- a/cmd/conformance-tests/etcdlauncher.go
+++ b/cmd/conformance-tests/etcdlauncher.go
@@ -19,12 +19,17 @@ package main
 import (
 	"context"
 	"fmt"
+	"io/ioutil"
 	"math/rand"
+	"path/filepath"
 	"time"
 
+	"go.etcd.io/etcd/v3/pkg/transport"
 	"go.uber.org/zap"
 
 	kubermaticv1 "k8c.io/kubermatic/v2/pkg/crd/kubermatic/v1"
+	"k8c.io/kubermatic/v2/pkg/resources"
+	"k8c.io/kubermatic/v2/pkg/resources/etcd"
 
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
@@ -37,228 +42,177 @@ import (
 const (
 	scaleUpCount       = 5
 	scaleDownCount     = 3
-	healthCheckTimeout = 10
+	healthCheckTimeout = 10 * time.Minute
 )
 
 func (r *testRunner) testEtcdLauncher(ctx context.Context, log *zap.SugaredLogger, cluster *kubermaticv1.Cluster) error {
-	// So far, the etcdlauncher is experimental. We need to enable it first
-	log.Info("Testing etcd-launcher experimental features...")
+	// So far, the etcd-launcher is experimental. We need to enable it first
+	log.Info("Testing etcd-launcher experimental features.")
+
 	log.Info("Enabling etcd-launcher...")
-	if err := r.enableEtcdlauncherForCluster(ctx, cluster); err != nil {
-		return fmt.Errorf("failed to enable etcd-launcher: %v", zap.Error(err))
+	if err := r.setClusterLauncherFeature(ctx, cluster, true); err != nil {
+		return fmt.Errorf("failed to enable etcd-launcher: %v", err)
 	}
 
-	if err := wait.Poll(30*time.Second, healthCheckTimeout*time.Minute, func() (bool, error) {
+	if err := wait.Poll(2*time.Second, healthCheckTimeout, func() (bool, error) {
 		active, err := r.isEtcdLauncherActive(ctx, cluster)
 		if err != nil {
-			log.Warnf("failed to check etcd-launcher status: %v", zap.Error(err))
+			log.Warnw("Failed to check etcd-launcher status", zap.Error(err))
 			return false, nil
 		}
 		return active, nil
 	}); err != nil {
-		return fmt.Errorf("failed to check etcd-launcher enabled status: %v", zap.Error(err))
+		return fmt.Errorf("failed to check etcd-launcher enabled status: %v", err)
 	}
-	log.Info("etcd-launcher enabled successfully...")
+	log.Info("etcd-launcher enabled successfully.")
 
-	log.Info("waiting for etcd to regain quorum...")
-	time.Sleep(2 * time.Minute)
+	// let etcd settle down
+	if err := r.waitForHealthyEtcd(ctx, log, cluster); err != nil {
+		return fmt.Errorf("etcd did not become healthy: %v", err)
+	}
 
 	// scale up to 5 nodes
-	log.Infof("Testing etcd cluster scale up: scaling etcd cluster to %d nodes...", scaleUpCount)
-	if err := r.resizeEtcd(ctx, cluster, scaleUpCount); err != nil {
-		return fmt.Errorf("failed while trying to scale up the etcd cluster: %v", zap.Error(err))
-	}
-	if err := wait.Poll(30*time.Second, healthCheckTimeout*time.Minute, func() (bool, error) {
-		healthy, err := r.isClusterEtcdHealthy(ctx, cluster)
-		if err != nil {
-			log.Warnf("failed to check cluster etcd health status: %v", zap.Error(err))
-			return false, nil
-		}
-		return healthy, nil
-	}); err != nil {
-		return fmt.Errorf("failed to check etcd cluster scale up status: %v", zap.Error(err))
-	}
-	// count the pods!
-	readyPods, err := r.getStsReadyPodsCount(ctx, cluster)
-	if err != nil {
-		return fmt.Errorf("failed to check ready pods count: %v", zap.Error(err))
-	}
-	if readyPods != scaleUpCount {
-		return fmt.Errorf("failed to scale up etcd cluster: want [%d] nodes, got [%d]", scaleUpCount, readyPods)
-	}
-	log.Info("etcd cluster scaled up successfully...")
-
-	log.Info("waiting for etcd to regain quorum...")
-	time.Sleep(2 * time.Minute)
-
-	// scale back to 3 nodes
-	log.Infof("Testing etcd cluster scale down: scaling etcd cluster to %d nodes...", scaleDownCount)
-	if err := r.resizeEtcd(ctx, cluster, scaleDownCount); err != nil {
-		return fmt.Errorf("failed while trying to scale down the etcd cluster: %v", zap.Error(err))
+	if err := r.etcdScaleTest(ctx, log, cluster, scaleUpCount); err != nil {
+		return fmt.Errorf("failed to scale up etcd cluster: %v", err)
 	}
 
-	if err := wait.Poll(30*time.Second, healthCheckTimeout*time.Minute, func() (bool, error) {
-		healthy, err := r.isClusterEtcdHealthy(ctx, cluster)
-		if err != nil {
-			log.Warnf("failed to check cluster etcd health status: %v", zap.Error(err))
-			return false, nil
-		}
-		return healthy, nil
-	}); err != nil {
-		return fmt.Errorf("failed to check etcd cluster scale down status: %v", zap.Error(err))
+	// scale down to 3 nodes
+	if err := r.etcdScaleTest(ctx, log, cluster, scaleDownCount); err != nil {
+		return fmt.Errorf("failed to scale down etcd cluster: %v", err)
 	}
-	// count the pods!
-	readyPods, err = r.getStsReadyPodsCount(ctx, cluster)
-	if err != nil {
-		return fmt.Errorf("failed to check ready pods count: %v", zap.Error(err))
-	}
-	if readyPods != scaleDownCount {
-		return fmt.Errorf("failed to scale down etcd cluster: want [%d] nodes, got [%d]", scaleDownCount, readyPods)
-	}
-	log.Info("etcd cluster scaled down successfully...")
 
-	log.Info("waiting for etcd to regain quorum...")
-	time.Sleep(2 * time.Minute)
-
-	// delete one of the etcd node PVs
-	log.Info("testing etcd node PV autotmatic recovery...")
+	// poke the anthill: delete one of the etcd node PVs
+	log.Info("Testing automatic node PV recovery...")
 	if err := r.forceDeleteEtcdPV(ctx, cluster); err != nil {
-		return fmt.Errorf("failed to delete etcd node PV: %v", zap.Error(err))
+		return fmt.Errorf("failed to delete etcd node PV: %v", err)
 	}
 
-	// auto recovery should kick in. We need to wait for it
-	if err := wait.Poll(30*time.Second, healthCheckTimeout*time.Minute, func() (bool, error) {
-		healthy, err := r.isClusterEtcdHealthy(ctx, cluster)
-		if err != nil {
-			log.Warnf("failed to check cluster etcd health status: %v", zap.Error(err))
-			return false, nil
-		}
-		return healthy, nil
-	}); err != nil {
-		return fmt.Errorf("failed to check etcd cluster health status: %v", zap.Error(err))
+	// make sure etcd notices the missing volume and does not answer requests based on caches
+	time.Sleep(5 * time.Second)
+
+	// wait for the cluster to recover automatically
+	if err := r.waitForHealthyEtcd(ctx, log, cluster); err != nil {
+		return fmt.Errorf("etcd did not become healthy: %v", err)
 	}
-	log.Info("etcd node PV recoverd successfully...")
+	log.Info("Node PV recovered successfully.")
 
-	log.Info("waiting for etcd to regain quorum...")
-	time.Sleep(2 * time.Minute)
-
-	// check if we can disable it
+	// disable etcd-launcher again
 	log.Info("Disabling etcd-launcher...")
-	if err := r.disableEtcdlauncherForCluster(ctx, cluster); err != nil {
-		return fmt.Errorf("failed to disable etcd-launcher: %v", zap.Error(err))
+	if err := r.setClusterLauncherFeature(ctx, cluster, false); err != nil {
+		return fmt.Errorf("failed to disable etcd-launcher: %v", err)
 	}
-	if err := wait.Poll(30*time.Second, 5*time.Minute, func() (bool, error) {
-		healthy, err := r.isClusterEtcdHealthy(ctx, cluster)
-		if err != nil {
-			log.Warnf("failed to check cluster etcd health status: %v", zap.Error(err))
-			return false, nil
-		}
-		return healthy, nil
-	}); err != nil {
-		return fmt.Errorf("failed to check etcd-launcher disabled status: %v", zap.Error(err))
+	if err := r.waitForHealthyEtcd(ctx, log, cluster); err != nil {
+		return fmt.Errorf("etcd did not become healthy: %v", err)
 	}
 	log.Info("etcd-launcher disabled successfully...")
-	log.Info(" Successfully tested etcd-launcher features.. ")
+
+	// woohoo, success!
+	log.Info("Successfully tested etcd-launcher features.")
+
 	return nil
 }
 
-// enable etcd launcher for the cluster
-func (r *testRunner) enableEtcdlauncherForCluster(ctx context.Context, cluster *kubermaticv1.Cluster) error {
-	return r.setClusterLauncherFeature(ctx, cluster, true)
+func (r *testRunner) waitForHealthyEtcd(ctx context.Context, log *zap.SugaredLogger, cluster *kubermaticv1.Cluster) error {
+	log.Info("Waiting for etcd to become fully healthy...")
+
+	if err := wait.Poll(2*time.Second, healthCheckTimeout, func() (bool, error) {
+		return r.isEtcdHealthy(ctx, log, cluster)
+	}); err != nil {
+		return fmt.Errorf("failed to check etcd health: %v", err)
+	}
+
+	log.Info("Cluster is fully healthy.")
+
+	return nil
 }
 
-func (r *testRunner) disableEtcdlauncherForCluster(ctx context.Context, cluster *kubermaticv1.Cluster) error {
-	return r.setClusterLauncherFeature(ctx, cluster, false)
+// etcdScaleTest rescales the etcd ring to a given size, waits for it to become
+// healthy and then checks if there are the desired number of pods.
+func (r *testRunner) etcdScaleTest(ctx context.Context, log *zap.SugaredLogger, cluster *kubermaticv1.Cluster, targetSize int) error {
+	// scale up to 5 nodes
+	log.Infof("Testing etcd cluster scaling: scaling etcd cluster to %d nodes...", targetSize)
+	if err := r.resizeEtcd(ctx, cluster, targetSize); err != nil {
+		return fmt.Errorf("failed to scale up the etcd cluster: %v", err)
+	}
+
+	if err := r.waitForHealthyEtcd(ctx, log, cluster); err != nil {
+		return fmt.Errorf("etcd did not become healthy: %v", err)
+	}
+
+	// count the pods, in case the etcd cluster is healthy but too small or too large
+	readyPods, err := r.getStsReadyPodsCount(ctx, cluster)
+	if err != nil {
+		return fmt.Errorf("failed to check ready pods count: %v", err)
+	}
+	if readyPods != targetSize {
+		return fmt.Errorf("failed to scale etcd cluster: want [%d] nodes, got [%d]", targetSize, readyPods)
+	}
+
+	return nil
 }
 
 func (r *testRunner) setClusterLauncherFeature(ctx context.Context, cluster *kubermaticv1.Cluster, flag bool) error {
-	if err := r.seedClusterClient.Get(ctx, types.NamespacedName{Name: cluster.Name}, cluster); err != nil {
-		return fmt.Errorf("failed to get cluster: %v", zap.Error(err))
-	}
+	return r.patchCluster(ctx, cluster, func(c *kubermaticv1.Cluster) (*kubermaticv1.Cluster, error) {
+		if cluster.Spec.Features == nil {
+			cluster.Spec.Features = map[string]bool{}
+		}
 
-	if cluster.Spec.Features == nil {
-		cluster.Spec.Features = map[string]bool{}
-	}
-	if cluster.Spec.Features[kubermaticv1.ClusterFeatureEtcdLauncher] == flag {
-		return nil
-	}
+		cluster.Spec.Features[kubermaticv1.ClusterFeatureEtcdLauncher] = flag
 
-	oldCluster := cluster.DeepCopy()
-
-	cluster.Spec.Features[kubermaticv1.ClusterFeatureEtcdLauncher] = flag
-	return r.seedClusterClient.Patch(ctx, cluster, ctrlruntimeclient.MergeFrom(oldCluster))
-}
-
-// check etcd health
-func (r *testRunner) isClusterEtcdHealthy(ctx context.Context, cluster *kubermaticv1.Cluster) (bool, error) {
-	if err := r.seedClusterClient.Get(ctx, types.NamespacedName{Name: cluster.Name}, cluster); err != nil {
-		return false, fmt.Errorf("failed to get cluster: %v", zap.Error(err))
-	}
-	sts := &appsv1.StatefulSet{}
-	if err := r.seedClusterClient.Get(ctx, types.NamespacedName{Name: "etcd", Namespace: fmt.Sprintf("cluster-%s", cluster.Name)}, sts); err != nil {
-		return false, fmt.Errorf("failed to get StatefulSet: %v", zap.Error(err))
-	}
-	// we are healthy if the cluster controller is happy and the sts is ready
-	return cluster.Status.ExtendedHealth.Etcd == kubermaticv1.HealthStatusUp &&
-		*sts.Spec.Replicas == sts.Status.ReadyReplicas, nil
+		return cluster, nil
+	})
 }
 
 func (r *testRunner) isEtcdLauncherActive(ctx context.Context, cluster *kubermaticv1.Cluster) (bool, error) {
-	etcdHealthy, err := r.isClusterEtcdHealthy(ctx, cluster)
+	sts, err := r.getEtcdStatefulSet(ctx, cluster)
 	if err != nil {
-		return false, fmt.Errorf("etcd health check failed: %v", zap.Error(err))
+		return false, err
 	}
 
-	sts := &appsv1.StatefulSet{}
-	if err := r.seedClusterClient.Get(ctx, types.NamespacedName{Name: "etcd", Namespace: fmt.Sprintf("cluster-%s", cluster.Name)}, sts); err != nil {
-		return false, fmt.Errorf("failed to get StatefulSet: %v", zap.Error(err))
-	}
-
-	return etcdHealthy && sts.Spec.Template.Spec.Containers[0].Command[0] == "/opt/bin/etcd-launcher", nil
+	return sts.Spec.Template.Spec.Containers[0].Command[0] == "/opt/bin/etcd-launcher", nil
 }
 
 // change cluster etcd size.
 func (r *testRunner) resizeEtcd(ctx context.Context, cluster *kubermaticv1.Cluster, size int) error {
-	if size > kubermaticv1.MaxEtcdClusterSize || size < kubermaticv1.DefaultEtcdClusterSize {
-		return fmt.Errorf("Invalid etcd cluster size: %d", size)
-	}
+	return r.patchCluster(ctx, cluster, func(c *kubermaticv1.Cluster) (*kubermaticv1.Cluster, error) {
+		if size > kubermaticv1.MaxEtcdClusterSize || size < kubermaticv1.DefaultEtcdClusterSize {
+			return nil, fmt.Errorf("Invalid etcd cluster size: %d", size)
+		}
 
-	if err := r.seedClusterClient.Get(ctx, types.NamespacedName{Name: cluster.Name}, cluster); err != nil {
-		return fmt.Errorf("failed to get cluster: %v", zap.Error(err))
-	}
-	if cluster.Spec.ComponentsOverride.Etcd.ClusterSize == size {
-		return nil
-	}
-	oldCluster := cluster.DeepCopy()
-	cluster.Spec.ComponentsOverride.Etcd.ClusterSize = size
-	return r.seedClusterClient.Patch(ctx, cluster, ctrlruntimeclient.MergeFrom(oldCluster))
+		cluster.Spec.ComponentsOverride.Etcd.ClusterSize = size
+
+		return cluster, nil
+	})
 }
 
 func (r *testRunner) forceDeleteEtcdPV(ctx context.Context, cluster *kubermaticv1.Cluster) error {
 	pvcList := &corev1.PersistentVolumeClaimList{}
 	if err := r.seedClusterClient.List(ctx, pvcList, &ctrlruntimeclient.ListOptions{Namespace: cluster.Namespace}); err != nil || len(pvcList.Items) == 0 {
-		return fmt.Errorf("failed to list PVCs or empty list in custer namespace: %v", zap.Error(err))
+		return fmt.Errorf("failed to list PVCs or empty list in cluster namespace: %v", err)
 	}
-	// pick a random PVC, get it's PV and delete it
+
+	// pick a random PVC, get its PV and delete it
 	pvc := pvcList.Items[rand.Intn(len(pvcList.Items))]
 	pvName := pvc.Spec.VolumeName
 	pv := &corev1.PersistentVolume{}
 	if err := r.seedClusterClient.Get(ctx, types.NamespacedName{Name: pvName, Namespace: cluster.Namespace}, pv); err != nil {
-		return fmt.Errorf("failed to get etcd node PV :%v", zap.Error(err))
+		return fmt.Errorf("failed to get etcd node PV: %v", err)
 	}
 	oldPv := pv.DeepCopy()
 
 	// first, we delete it
 	if err := r.seedClusterClient.Delete(ctx, pv); err != nil {
-		return fmt.Errorf("failed to delete etcd node PV: %v", zap.Error(err))
+		return fmt.Errorf("failed to delete etcd node PV: %v", err)
 	}
+
 	// now it will get stuck, we need to patch it to remove the pv finalizer
 	pv.Finalizers = nil
 	if err := r.seedClusterClient.Patch(ctx, pv, ctrlruntimeclient.MergeFrom(oldPv)); err != nil {
-		return fmt.Errorf("failed to delete the PV finalizer: %v", zap.Error(err))
+		return fmt.Errorf("failed to delete the PV finalizer: %v", err)
 	}
+
 	// make sure it's gone
-	return wait.Poll(30*time.Second, healthCheckTimeout*time.Minute, func() (bool, error) {
+	return wait.Poll(2*time.Second, healthCheckTimeout, func() (bool, error) {
 		if err := r.seedClusterClient.Get(ctx, types.NamespacedName{Name: pvName, Namespace: cluster.Namespace}, pv); kerrors.IsNotFound(err) {
 			return true, nil
 		}
@@ -266,10 +220,125 @@ func (r *testRunner) forceDeleteEtcdPV(ctx context.Context, cluster *kubermaticv
 	})
 }
 
-func (r *testRunner) getStsReadyPodsCount(ctx context.Context, cluster *kubermaticv1.Cluster) (int32, error) {
+func (r *testRunner) getStsReadyPodsCount(ctx context.Context, cluster *kubermaticv1.Cluster) (int, error) {
+	sts, err := r.getEtcdStatefulSet(ctx, cluster)
+	if err != nil {
+		return 0, err
+	}
+	return int(sts.Status.ReadyReplicas), nil
+}
+
+func (r *testRunner) getCluster(ctx context.Context, cluster *kubermaticv1.Cluster) (*kubermaticv1.Cluster, error) {
+	if err := r.seedClusterClient.Get(ctx, types.NamespacedName{Name: cluster.Name}, cluster); err != nil {
+		return nil, fmt.Errorf("failed to get cluster: %v", err)
+	}
+
+	return cluster, nil
+}
+
+func (r *testRunner) getEtcdStatefulSet(ctx context.Context, cluster *kubermaticv1.Cluster) (*appsv1.StatefulSet, error) {
+	cluster, err := r.getCluster(ctx, cluster)
+	if err != nil {
+		return nil, err
+	}
+
 	sts := &appsv1.StatefulSet{}
 	if err := r.seedClusterClient.Get(ctx, types.NamespacedName{Name: "etcd", Namespace: fmt.Sprintf("cluster-%s", cluster.Name)}, sts); err != nil {
-		return 0, fmt.Errorf("failed to get StatefulSet: %v", zap.Error(err))
+		return nil, fmt.Errorf("failed to get StatefulSet: %v", err)
 	}
-	return sts.Status.ReadyReplicas, nil
+
+	return sts, nil
+}
+
+type clusterPatch func(cluster *kubermaticv1.Cluster) (*kubermaticv1.Cluster, error)
+
+func (r *testRunner) patchCluster(ctx context.Context, cluster *kubermaticv1.Cluster, patch clusterPatch) error {
+	cluster, err := r.getCluster(ctx, cluster)
+	if err != nil {
+		return err
+	}
+
+	oldCluster := cluster.DeepCopy()
+
+	cluster, err = patch(cluster)
+	if err != nil {
+		return err
+	}
+
+	return r.seedClusterClient.Patch(ctx, cluster, ctrlruntimeclient.MergeFrom(oldCluster))
+}
+
+// getEtcdClient returns an etcd.Client setup to communicate with a usercluster's etcd ring.
+func (r *testRunner) getEtcdClient(ctx context.Context, cluster *kubermaticv1.Cluster) (*etcd.Client, error) {
+	// get TLS certificate
+	etcdSecret := &corev1.Secret{}
+	if err := r.seedClusterClient.Get(ctx, types.NamespacedName{
+		Namespace: cluster.Status.NamespaceName,
+		Name:      resources.EtcdTLSCertificateSecretName,
+	}, etcdSecret); err != nil {
+		return nil, fmt.Errorf("failed to find etcd TLS certificate: %v", err)
+	}
+
+	caSecret := &corev1.Secret{}
+	if err := r.seedClusterClient.Get(ctx, types.NamespacedName{
+		Namespace: cluster.Status.NamespaceName,
+		Name:      resources.CASecretName,
+	}, caSecret); err != nil {
+		return nil, fmt.Errorf("failed to find etcd CA certificate: %v", err)
+	}
+
+	// dump secrets to temporary files
+	tempDir, err := ioutil.TempDir("", "etcd.*")
+	if err != nil {
+		return nil, fmt.Errorf("failed to create temporary directory: %v", err)
+	}
+
+	certFile := filepath.Join(tempDir, "etcd.crt")
+	keyFile := filepath.Join(tempDir, "etcd.key")
+	caFile := filepath.Join(tempDir, "ca.crt")
+
+	if err := ioutil.WriteFile(certFile, caSecret.Data[resources.EtcdTLSCertSecretKey], 0600); err != nil {
+		return nil, fmt.Errorf("failed to write file: %v", err)
+	}
+
+	if err := ioutil.WriteFile(keyFile, caSecret.Data[resources.EtcdTLSKeySecretKey], 0600); err != nil {
+		return nil, fmt.Errorf("failed to write file: %v", err)
+	}
+
+	if err := ioutil.WriteFile(caFile, caSecret.Data[resources.CACertSecretKey], 0600); err != nil {
+		return nil, fmt.Errorf("failed to write file: %v", err)
+	}
+
+	clusterSize := cluster.Spec.ComponentsOverride.Etcd.ClusterSize
+	if clusterSize <= 0 {
+		clusterSize = kubermaticv1.DefaultEtcdClusterSize
+	}
+
+	endpoints := etcd.ClientEndpoints(clusterSize, cluster.Status.NamespaceName)
+
+	return etcd.NewClient(endpoints, &transport.TLSInfo{
+		CertFile:       certFile,
+		KeyFile:        keyFile,
+		TrustedCAFile:  caFile,
+		ClientCertAuth: true,
+	})
+}
+
+// isEtcdHealthy combines creating a client and checking the health of an etcd cluster.
+// This is useful for the various wait loops in the tests.
+func (r *testRunner) isEtcdHealthy(ctx context.Context, log *zap.SugaredLogger, cluster *kubermaticv1.Cluster) (bool, error) {
+	client, err := r.getEtcdClient(ctx, cluster)
+	if err != nil {
+		log.Warnw("Failed to create etcd client", zap.Error(err))
+		return false, nil
+	}
+	defer client.Close()
+
+	healthy, err := client.Healthy(ctx, nil)
+	if err != nil {
+		log.Warnw("Failed to check health status", zap.Error(err))
+		return false, nil
+	}
+
+	return healthy, nil
 }

--- a/cmd/etcd-launcher/main.go
+++ b/cmd/etcd-launcher/main.go
@@ -21,7 +21,6 @@ import (
 	"errors"
 	"flag"
 	"fmt"
-	"log"
 	"net/url"
 	"os"
 	"os/exec"
@@ -30,14 +29,13 @@ import (
 	"time"
 
 	"go.etcd.io/etcd/v3/clientv3"
-	"go.etcd.io/etcd/v3/etcdserver/api/v3rpc/rpctypes"
 	"go.etcd.io/etcd/v3/etcdserver/etcdserverpb"
-	"go.etcd.io/etcd/v3/pkg/transport"
 	"go.uber.org/zap"
 
 	kubermaticv1 "k8c.io/kubermatic/v2/pkg/crd/kubermatic/v1"
 	kubermaticlog "k8c.io/kubermatic/v2/pkg/log"
 	"k8c.io/kubermatic/v2/pkg/resources"
+	"k8c.io/kubermatic/v2/pkg/resources/etcd"
 
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/types"
@@ -66,21 +64,21 @@ type config struct {
 	initialState          string
 }
 
-type etcdCluster struct {
-	config *config
-}
-
 func main() {
-	// normal workflow, we don't do migrations anymore
-	e := &etcdCluster{}
-	err := e.parseConfigFlags()
+	logOpts := kubermaticlog.NewDefaultOptions()
+	logOpts.AddFlags(flag.CommandLine)
+
+	cfg := &config{}
+	err := cfg.parseConfigFlags()
+	log := kubermaticlog.New(logOpts.Debug, logOpts.Format).Sugar()
+
 	if err != nil {
-		log.Fatalf("failed to get launcher configuration: %v", err)
+		log.Fatalw("failed to get launcher configuration", zap.Error(err))
 	}
 
-	logOpts := kubermaticlog.NewDefaultOptions()
-	rawLog := kubermaticlog.New(logOpts.Debug, logOpts.Format)
-	log := rawLog.Sugar()
+	if _, err := os.Stat(etcdCommandPath); os.IsNotExist(err) {
+		log.Fatalw("can't find etcd command", "binary", etcdCommandPath, zap.Error(err))
+	}
 
 	// here we find the cluster state
 	config, err := rest.InClusterConfig()
@@ -92,191 +90,330 @@ func main() {
 		log.Fatalw("failed to create cluster client", zap.Error(err))
 	}
 
+	ctx := context.Background()
+
+	// fetch Kubermatic Cluster object
+	clusterName := strings.ReplaceAll(cfg.namespace, "cluster-", "")
 	k8cCluster := kubermaticv1.Cluster{}
-	if err := clusterClient.Get(context.Background(), types.NamespacedName{Name: strings.ReplaceAll(e.config.namespace, "cluster-", ""), Namespace: ""}, &k8cCluster); err != nil {
-		log.Fatalw("failed to get cluster", zap.Error(err))
+	if err := clusterClient.Get(ctx, types.NamespacedName{Name: clusterName}, &k8cCluster); err != nil {
+		log.Fatalw("failed to get cluster", "cluster", clusterName, zap.Error(err))
 	}
-	initialMembers := initialMemberList(e.config.clusterSize, e.config.namespace)
 
-	e.config.initialState = initialStateNew
-	// check if the etcd cluster is initialized successfully.
+	// check if the etcd cluster is initialized successfully
+	cfg.initialState = initialStateNew
 	if k8cCluster.Status.HasConditionValue(kubermaticv1.ClusterConditionEtcdClusterInitialized, corev1.ConditionTrue) {
-		e.config.initialState = initialStateExisting
+		cfg.initialState = initialStateExisting
 	}
 
-	log.Info("initializing etcd..")
-	log.Infof("initial-state: %s", e.config.initialState)
-	log.Infof("initial-cluster: %s", strings.Join(initialMembers, ","))
+	log.Infow("initializing etcd...",
+		"pod", cfg.podName,
+		"state", cfg.initialState,
+		"size", cfg.clusterSize,
+		"namespace", cfg.namespace,
+	)
 
-	if _, err := os.Stat(etcdCommandPath); os.IsNotExist(err) {
-		log.Fatalw("can't find command", "command-path", etcdCommandPath, zap.Error(err))
-	}
 	// setup and start etcd command
-	cmd := exec.Command(etcdCommandPath, etcdCmd(e.config)...)
+	cmd := exec.Command(etcdCommandPath, etcdCmd(cfg)...)
 	cmd.Env = os.Environ()
 	cmd.Stderr = os.Stderr
 	cmd.Stdout = os.Stdout
-	log.Infof("starting etcd command: %s", cmd.String())
+
+	log.Infow("starting etcd...", "cmd", cmd.String())
 	if err = cmd.Start(); err != nil {
-		log.Fatalf("failed to start etcd: %v", err)
+		log.Fatalw("failed to start etcd", zap.Error(err))
 	}
 
-	if err = wait.Poll(1*time.Second, 30*time.Second, e.isClusterHealthy); err != nil {
-		log.Fatalf("manager thread failed to connect to cluster: %v", err)
-	}
+	// wait for etcd to accept connections and become healthy
+	var etcdClient *etcd.Client
 
-	isMemeber, err := e.isClusterMember(e.config.podName)
-	if err != nil {
-		log.Fatalf("failed to check cluster membership: %v", err)
-	}
-	if isMemeber {
-		log.Infof("%s is a member", e.config.podName)
-		for {
-			// handle changes to peerURLs
-			if err := e.updatePeerURL(); err != nil {
-				log.Fatalf("failed to update peerURL: %v", err)
-			}
-			// reconcile dead members
-			containsUnwantedMembers, err := e.containsUnwantedMembers()
-			if err != nil {
-				log.Warnw("failed to list members ", zap.Error(err))
-				time.Sleep(10 * time.Second)
-				continue
-			}
-			// we only need to reconcile if we have members that we shouldn't have
-			if !containsUnwantedMembers {
-				log.Info("cluster members reconciled..")
-				break
-			}
-			// to avoide race conditions, we will run only on the cluster leader
-			leader, err := e.isLeader()
-			if err != nil || !leader {
-				log.Warnw("failed to remove member, error occurred or didn't get the current leader", zap.Error(err))
-				time.Sleep(10 * time.Second)
-				continue
-			}
-			if err := e.removeDeadMembers(log); err != nil {
-				log.Warnw("failed to remove member", zap.Error(err))
-				continue
-			}
-		}
-	} else { // new etcd member, need to join the cluster
-		log.Info("pod is not a cluster member, trying to join..")
-		// remove possibly stale member data dir..
-		log.Info("removing possibly stale data dir")
-		_ = os.RemoveAll(path.Join(e.config.dataDir, "member"))
-		// join the cluster
-		client, err := e.getClusterClient()
+	timeout := 30 * time.Second
+	endpoints := etcd.ClientEndpoints(cfg.clusterSize, cfg.namespace)
+	log.Infof("waiting up to %v for etcd to become healthy...", timeout)
+
+	if err := wait.Poll(1*time.Second, timeout, func() (bool, error) {
+		var err error
+
+		etcdClient, err = etcd.NewClient(endpoints, nil)
 		if err != nil {
-			log.Fatalf("can't find cluster client: %v", err)
+			return false, nil
 		}
-		defer client.Close()
 
-		if _, err := client.MemberAdd(context.Background(), []string{fmt.Sprintf("http://%s.etcd.%s.svc.cluster.local:2380", e.config.podName, e.config.namespace)}); err != nil {
-			log.Fatalf("failed to join cluster: %v", err)
-		}
-		log.Info("joined etcd cluster successfully.")
+		return etcdClient.Healthy(ctx, nil)
+	}); err != nil {
+		log.Fatalw("failed to connect to etcd cluster", zap.Error(err))
 	}
 
+	// determine if this pod is already an etcd member
+	isMember, err := etcdClient.IsClusterMember(ctx, cfg.podName)
+	if err != nil {
+		log.Fatalw("failed to check cluster membership", zap.Error(err))
+	}
+
+	if isMember {
+		if err := reconcileClusterMembers(ctx, log, etcdClient, cfg); err != nil {
+			log.Fatalw("failed to reconcile cluster status", zap.Error(err))
+		}
+	} else {
+		if err := joinNewMember(ctx, log, etcdClient, cfg); err != nil {
+			log.Fatalw("failed to join cluster", zap.Error(err))
+		}
+	}
+
+	// we do not need this connection anymore
+	if err := etcdClient.Close(); err != nil {
+		log.Warnw("failed to close unused management connection", zap.Error(err))
+	}
+
+	// wait and sit until etcd exits
+	log.Info("startup complete, regular operation from here on")
 	if err = cmd.Wait(); err != nil {
 		log.Fatal(err)
 	}
+
+	log.Info("etcd exited")
 }
 
-func (e *etcdCluster) updatePeerURL() error {
-	members, err := e.listMembers()
-	if err != nil {
-		return err
+func joinNewMember(ctx context.Context, log *zap.SugaredLogger, etcdClient *etcd.Client, cfg *config) error {
+	log.Info("pod is not a cluster member, trying to join...")
+
+	// remove possibly stale member data dir
+	log.Info("removing possibly stale data dir...")
+	if err := os.RemoveAll(path.Join(cfg.dataDir, "member")); err != nil {
+		log.Warnw("failed to remove directory", zap.Error(err))
+		// do not exit here
 	}
-	for _, member := range members {
-		peerURL, err := url.Parse(member.PeerURLs[0])
-		if err != nil {
-			return err
-		}
-		if member.Name == e.config.podName && peerURL.Scheme == "https" {
-			client, err := e.getClusterClient()
-			if err != nil {
-				return err
-			}
-			defer client.Close()
-			peerURL.Scheme = "http"
-			_, err = client.MemberUpdate(context.Background(), member.ID, []string{peerURL.String()})
-			if err != nil {
-				return err
-			}
-			break
-		}
+
+	// join the cluster
+	peerURL := fmt.Sprintf("http://%s.etcd.%s.svc.cluster.local:%d", cfg.podName, cfg.namespace, etcd.PeersPort)
+	if err := etcdClient.MemberAdd(ctx, []string{peerURL}); err != nil {
+		return fmt.Errorf("failed to join cluster: %v", err)
 	}
+
+	log.Info("joined etcd cluster successfully")
 	return nil
 }
 
-func initialMemberList(n int, namespace string) []string {
-	members := []string{}
-	for i := 0; i < n; i++ {
-		members = append(members, fmt.Sprintf("etcd-%d=http://etcd-%d.etcd.%s.svc.cluster.local:2380", i, i, namespace))
+func reconcileClusterMembers(ctx context.Context, log *zap.SugaredLogger, etcdClient *etcd.Client, cfg *config) error {
+	log.Infof("%s is already a member", cfg.podName)
+
+	for {
+		// handle changes to peerURLs
+		if err := updatePeerURL(ctx, etcdClient, cfg); err != nil {
+			return fmt.Errorf("failed to update peerURL: %v", err)
+		}
+
+		// determine dead members
+		unwantedMembers, err := hasUnwantedMembers(ctx, etcdClient, cfg)
+		if err != nil {
+			log.Warnw("failed to determine member status", zap.Error(err))
+			time.Sleep(3 * time.Second)
+			continue
+		}
+
+		// we only need to reconcile if we have members that we shouldn't have
+		if !unwantedMembers {
+			break
+		}
+
+		// to avoid race conditions, we will run only on the cluster leader
+		leader, err := podIsLeader(ctx, log, cfg)
+		if err != nil {
+			log.Warnw("failed to determine leader status", zap.Error(err))
+			time.Sleep(3 * time.Second)
+			continue
+		}
+
+		if !leader {
+			// There are unwanted members, but we are not the leader. This means
+			// we need to wait for someone else to do the cleanup or for us to
+			// become the leader. In any way, we should wait a short moment.
+			time.Sleep(3 * time.Second)
+			continue
+		}
+
+		if err := removeDeadMembers(ctx, log, etcdClient, cfg); err != nil {
+			log.Warnw("failed to remove member", zap.Error(err))
+		}
 	}
-	return members
+
+	log.Info("cluster members reconciled successfully")
+
+	return nil
 }
 
-func peerURLsList(n int, namespace string) []string {
-	urls := []string{}
-	for i := 0; i < n; i++ {
-		urls = append(urls, fmt.Sprintf("etcd-%d.etcd.%s.svc.cluster.local:2380", i, namespace))
+func updatePeerURL(ctx context.Context, etcdClient *etcd.Client, cfg *config) error {
+	self, err := getOwnMember(ctx, etcdClient, cfg.podName)
+	if err != nil {
+		return fmt.Errorf("failed to determine own member: %v", err)
 	}
-	return urls
-}
 
-func clientEndpoints(n int, namespace string) []string {
-	endpoints := []string{}
-	for i := 0; i < n; i++ {
-		endpoints = append(endpoints, fmt.Sprintf("https://etcd-%d.etcd.%s.svc.cluster.local:2379", i, namespace))
+	peerURL, err := url.Parse(self.PeerURLs[0])
+	if err != nil {
+		return fmt.Errorf("failed to parse peer URL %q: %v", self.PeerURLs[0], err)
 	}
-	return endpoints
+
+	// ensure a non-HTTPS url
+	if peerURL.Scheme == "https" {
+		peerURL.Scheme = "http"
+		if err := etcdClient.MemberUpdate(ctx, self.ID, []string{peerURL.String()}); err != nil {
+			return fmt.Errorf("failed to update etcd member: %v", err)
+		}
+	}
+
+	return nil
 }
 
-func (e *etcdCluster) endpoint() string {
-	return "https://127.0.0.1:2379"
+func hasUnwantedMembers(ctx context.Context, etcdClient *etcd.Client, cfg *config) (bool, error) {
+	members, err := etcdClient.MemberList(ctx)
+	if err != nil {
+		return false, fmt.Errorf("failed to list members: %v", err)
+	}
+
+	expectedPeers := etcd.PeerURLs(cfg.clusterSize, cfg.namespace)
+
+	for _, member := range members {
+		// we only want members with a single peer URL
+		if len(member.PeerURLs) != 1 {
+			return true, nil
+		}
+
+		peerURL, err := url.Parse(member.PeerURLs[0])
+		if err != nil {
+			return false, fmt.Errorf("failed to parse peer URL %q: %v", member.PeerURLs[0], err)
+		}
+
+		isExpected := false
+		for _, expectedPeer := range expectedPeers {
+			if expectedPeer == peerURL.Host {
+				isExpected = true
+				break
+			}
+		}
+
+		if !isExpected {
+			return true, nil
+		}
+	}
+
+	return false, nil
 }
 
-func (e *etcdCluster) parseConfigFlags() error {
-	config := &config{}
+func removeDeadMembers(ctx context.Context, log *zap.SugaredLogger, etcdClient *etcd.Client, cfg *config) error {
+	members, err := etcdClient.MemberList(ctx)
+	if err != nil {
+		return fmt.Errorf("failed to list members: %v", err)
+	}
 
-	flag.StringVar(&config.namespace, "namespace", "", "namespace of the user cluster")
-	flag.IntVar(&config.clusterSize, "etcd-cluster-size", defaultClusterSize, "number of replicas in the etcd cluster")
-	flag.StringVar(&config.podName, "pod-name", "", "name of this etcd pod")
-	flag.StringVar(&config.podIP, "pod-ip", "", "IP address of this etcd pod")
-	flag.StringVar(&config.etcdctlAPIVersion, "api-version", defaultEtcdctlAPIVersion, "etcdctl API version")
-	flag.StringVar(&config.token, "token", "", "etcd database token")
-	flag.BoolVar(&config.enableCorruptionCheck, "enable-corruption-check", false, "enable etcd experimental corruption check")
+	log.Warnw("finding and removing dead members...")
+
+	for _, member := range members {
+		// ignore the leader (as we only do this removal when we are the leader, this means we
+		// ignore ourselves)
+		if member.Name == cfg.podName {
+			continue
+		}
+
+		if err = wait.PollImmediate(1*time.Second, 30*time.Second, func() (bool, error) {
+			// We use the cluster FQDN endpoint url here (internally in Healthy()).
+			// Using the IP endpoint will fail because the certificates don't include Pod IP addresses.
+			return etcdClient.Healthy(ctx, member)
+		}); err != nil {
+			log.Warnw("member is not responding, removing from cluster...", "member", member.Name)
+			if err := etcdClient.MemberRemove(ctx, member.ID); err != nil {
+				return fmt.Errorf("failed to remove member: %v", err)
+			}
+		}
+
+		log.Warnw("member is alive", "member", member.Name)
+	}
+
+	return nil
+}
+
+func podIsLeader(ctx context.Context, log *zap.SugaredLogger, cfg *config) (bool, error) {
+	localhost := etcd.LocalEndpoint()
+
+	var status *clientv3.StatusResponse
+	if err := wait.PollImmediate(1*time.Second, 1*time.Minute, func() (bool, error) {
+		localClient, err := etcd.NewClient([]string{localhost}, nil)
+		if err != nil {
+			log.Warnw(fmt.Sprintf("failed to create etcd client for %q", localhost), zap.Error(err))
+			return false, nil
+		}
+		defer localClient.Close()
+
+		status, err = localClient.Status(ctx, localhost)
+		if err != nil {
+			log.Warnw("failed to determine endpoint status", zap.Error(err))
+			return false, nil
+		}
+
+		// member does not know about any leaders
+		if status.Leader == 0 {
+			return false, nil
+		}
+
+		return true, nil
+	}); err != nil {
+		return false, fmt.Errorf("failed to determine leader status: %v", err)
+	}
+
+	return status.Header.MemberId == status.Leader, nil
+}
+
+// getOwnMember finds the etcd member that is running in this pod; returns
+// nil when no such member could be found
+func getOwnMember(ctx context.Context, etcdClient *etcd.Client, podName string) (*etcdserverpb.Member, error) {
+	members, err := etcdClient.MemberList(ctx)
+	if err != nil {
+		return nil, fmt.Errorf("failed to list members: %v", err)
+	}
+
+	for i, member := range members {
+		if member.Name == podName {
+			return members[i], nil
+		}
+	}
+
+	return nil, nil
+}
+
+func (cfg *config) parseConfigFlags() error {
+	flag.StringVar(&cfg.namespace, "namespace", "", "namespace of the user cluster")
+	flag.IntVar(&cfg.clusterSize, "etcd-cluster-size", defaultClusterSize, "number of replicas in the etcd cluster")
+	flag.StringVar(&cfg.podName, "pod-name", "", "name of this etcd pod")
+	flag.StringVar(&cfg.podIP, "pod-ip", "", "IP address of this etcd pod")
+	flag.StringVar(&cfg.etcdctlAPIVersion, "api-version", defaultEtcdctlAPIVersion, "etcdctl API version")
+	flag.StringVar(&cfg.token, "token", "", "etcd database token")
+	flag.BoolVar(&cfg.enableCorruptionCheck, "enable-corruption-check", false, "enable etcd experimental corruption check")
 	flag.Parse()
 
-	if config.namespace == "" {
+	if cfg.namespace == "" {
 		return errors.New("-namespace is not set")
 	}
 
-	if config.clusterSize < defaultClusterSize {
+	if cfg.clusterSize < defaultClusterSize {
 		return fmt.Errorf("-etcd-cluster-size is smaller than %d", defaultClusterSize)
 	}
 
-	if config.podName == "" {
+	if cfg.podName == "" {
 		return errors.New("-pod-name is not set")
 	}
 
-	if config.podIP == "" {
+	if cfg.podIP == "" {
 		return errors.New("-pod-ip is not set")
 	}
 
-	if config.etcdctlAPIVersion != "2" && config.etcdctlAPIVersion != "3" {
-		return errors.New("-api-version is either 2 or 3")
+	if cfg.etcdctlAPIVersion != "2" && cfg.etcdctlAPIVersion != "3" {
+		return errors.New("-api-version must be either 2 or 3")
 	}
 
-	if config.token == "" {
+	if cfg.token == "" {
 		return errors.New("-token is not set")
 	}
 
-	config.dataDir = fmt.Sprintf("/var/run/etcd/pod_%s/", config.podName)
+	cfg.dataDir = fmt.Sprintf("/var/run/etcd/pod_%s/", cfg.podName)
 
-	e.config = config
 	return nil
 }
 
@@ -284,14 +421,14 @@ func etcdCmd(config *config) []string {
 	cmd := []string{
 		fmt.Sprintf("--name=%s", config.podName),
 		fmt.Sprintf("--data-dir=%s", config.dataDir),
-		fmt.Sprintf("--initial-cluster=%s", strings.Join(initialMemberList(config.clusterSize, config.namespace), ",")),
+		fmt.Sprintf("--initial-cluster=%s", strings.Join(etcd.MembersList(config.clusterSize, config.namespace), ",")),
 		fmt.Sprintf("--initial-cluster-token=%s", config.token),
 		fmt.Sprintf("--initial-cluster-state=%s", config.initialState),
-		fmt.Sprintf("--advertise-client-urls=https://%s.etcd.%s.svc.cluster.local:2379,https://%s:2379", config.podName, config.namespace, config.podIP),
-		fmt.Sprintf("--listen-client-urls=https://%s:2379,https://127.0.0.1:2379", config.podIP),
-		fmt.Sprintf("--listen-metrics-urls=http://%s:2378,http://127.0.0.1:2378", config.podIP),
-		fmt.Sprintf("--listen-peer-urls=http://%s:2380", config.podIP),
-		fmt.Sprintf("--initial-advertise-peer-urls=http://%s.etcd.%s.svc.cluster.local:2380", config.podName, config.namespace),
+		fmt.Sprintf("--advertise-client-urls=https://%s.etcd.%s.svc.cluster.local:%d,https://%s:%d", config.podName, config.namespace, etcd.ClientPort, config.podIP, etcd.ClientPort),
+		fmt.Sprintf("--listen-client-urls=https://%s:%d,https://127.0.0.1:%d", config.podIP, etcd.ClientPort, etcd.ClientPort),
+		fmt.Sprintf("--listen-metrics-urls=http://%s:%d,http://127.0.0.1:%d", config.podIP, etcd.MetricsPort, etcd.MetricsPort),
+		fmt.Sprintf("--listen-peer-urls=http://%s:%d", config.podIP, etcd.PeersPort),
+		fmt.Sprintf("--initial-advertise-peer-urls=http://%s.etcd.%s.svc.cluster.local:%d", config.podName, config.namespace, etcd.PeersPort),
 		"--client-cert-auth",
 		fmt.Sprintf("--trusted-ca-file=%s", resources.EtcdTrustedCAFile),
 		fmt.Sprintf("--cert-file=%s", resources.EtcdCertFile),
@@ -305,170 +442,6 @@ func etcdCmd(config *config) []string {
 			"--experimental-corrupt-check-time=10m",
 		}...)
 	}
+
 	return cmd
-}
-
-func (e *etcdCluster) getClusterClient() (*clientv3.Client, error) {
-	endpoints := clientEndpoints(e.config.clusterSize, e.config.namespace)
-	return e.getClientWithEndpoints(endpoints)
-}
-
-func (e *etcdCluster) getLocalClient() (*clientv3.Client, error) {
-	return e.getClientWithEndpoints([]string{e.endpoint()})
-}
-
-func (e *etcdCluster) getClientWithEndpoints(eps []string) (*clientv3.Client, error) {
-	var err error
-	tlsInfo := transport.TLSInfo{
-		CertFile:       resources.EtcdClientCertFile,
-		KeyFile:        resources.EtcdClientKeyFile,
-		TrustedCAFile:  resources.EtcdTrustedCAFile,
-		ClientCertAuth: true,
-	}
-	tlsConfig, err := tlsInfo.ClientConfig()
-	if err != nil {
-		return nil, fmt.Errorf("failed to generate client TLS config: %v", err)
-	}
-	for i := 0; i < 5; i++ {
-		cli, err := clientv3.New(clientv3.Config{
-			Endpoints:   eps,
-			DialTimeout: 2 * time.Second,
-			TLS:         tlsConfig,
-		})
-		if err == nil && cli != nil {
-			return cli, nil
-		}
-		time.Sleep(5 * time.Second)
-	}
-	return nil, fmt.Errorf("failed to establish client connection: %v", err)
-
-}
-
-func (e *etcdCluster) listMembers() ([]*etcdserverpb.Member, error) {
-	client, err := e.getClientWithEndpoints(clientEndpoints(e.config.clusterSize, e.config.namespace))
-	if err != nil {
-		return nil, fmt.Errorf("can't find cluster client: %v", err)
-	}
-	defer client.Close()
-
-	resp, err := client.MemberList(context.Background())
-	if err != nil {
-		return nil, err
-	}
-	return resp.Members, err
-}
-
-func (e *etcdCluster) isClusterMember(name string) (bool, error) {
-	members, err := e.listMembers()
-	if err != nil {
-		return false, err
-	}
-	if len(members) == 0 {
-		return false, nil
-	}
-	for _, member := range members {
-		url, err := url.Parse(member.PeerURLs[0])
-		if err != nil {
-			return false, err
-		}
-		// if the member is not started yet, its name would be empty, in that case, we match for peerURL host.
-		if member.Name == name || url.Host == fmt.Sprintf("%s.etcd.%s.svc.cluster.local:2380", e.config.podName, e.config.namespace) {
-			return true, nil
-		}
-	}
-	return false, nil
-}
-
-func (e *etcdCluster) containsUnwantedMembers() (bool, error) {
-	members, err := e.listMembers()
-	if err != nil {
-		return false, err
-	}
-	expectedMembers := peerURLsList(e.config.clusterSize, e.config.namespace)
-membersLoop:
-	for _, member := range members {
-		for _, expectedMember := range expectedMembers {
-			if len(member.GetPeerURLs()) == 1 {
-				peerURL, err := url.Parse(member.PeerURLs[0])
-				if err != nil {
-					return false, err
-				}
-				if expectedMember == peerURL.Host {
-					continue membersLoop
-				}
-			}
-		}
-		return true, nil
-	}
-	return false, nil
-}
-
-func (e *etcdCluster) isClusterHealthy() (bool, error) {
-	return e.isHealthyWithEndpoints(clientEndpoints(e.config.clusterSize, e.config.namespace))
-}
-
-func (e *etcdCluster) isHealthyWithEndpoints(endpoints []string) (bool, error) {
-	client, err := e.getClientWithEndpoints(endpoints)
-	if err != nil {
-		return false, err
-	}
-	defer client.Close()
-	// just get a key from etcd, this is how `etcdctl endpoint health` works!
-	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
-	_, err = client.Get(ctx, "healthy")
-	defer cancel()
-	if err != nil && err != rpctypes.ErrPermissionDenied {
-		// silently swallow/drop transient errors
-		return false, nil
-	}
-	return true, nil
-}
-
-func (e *etcdCluster) isLeader() (bool, error) {
-	localClient, err := e.getLocalClient()
-	if err != nil {
-		return false, err
-	}
-	defer localClient.Close()
-
-	for i := 0; i < 10; i++ {
-		resp, err := localClient.Status(context.Background(), e.endpoint())
-		if err != nil || resp.Leader == 0 {
-			time.Sleep(2 * time.Second)
-			continue
-		}
-		if resp.Header.MemberId == resp.Leader {
-			return true, nil
-		}
-	}
-	return false, nil
-}
-
-func (e *etcdCluster) removeDeadMembers(log *zap.SugaredLogger) error {
-	members, err := e.listMembers()
-	if err != nil {
-		return err
-	}
-
-	client, err := e.getClusterClient()
-	if err != nil {
-		return fmt.Errorf("can't find cluster client: %v", err)
-	}
-	defer client.Close()
-
-	for _, member := range members {
-		if member.Name == e.config.podName {
-			continue
-		}
-		if err = wait.Poll(1*time.Second, 30*time.Second, func() (bool, error) {
-			// we use the cluster FQDN endpoint url here. Using the IP endpoint will
-			// fail because the certificates don't include Pod IP addresses.
-			return e.isHealthyWithEndpoints(member.ClientURLs[len(member.ClientURLs)-1:])
-		}); err != nil {
-			log.Infow("member is not responding, removing from cluster", "member-name", member.Name)
-			_, err = client.MemberRemove(context.Background(), member.ID)
-			return err
-		}
-	}
-	return nil
 }

--- a/pkg/resources/etcd/cluster.go
+++ b/pkg/resources/etcd/cluster.go
@@ -1,0 +1,194 @@
+/*
+Copyright 2020 The Kubermatic Kubernetes Platform contributors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package etcd
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"net/url"
+	"time"
+
+	"go.etcd.io/etcd/v3/clientv3"
+	"go.etcd.io/etcd/v3/etcdserver/api/v3rpc/rpctypes"
+	"go.etcd.io/etcd/v3/etcdserver/etcdserverpb"
+	"go.etcd.io/etcd/v3/pkg/transport"
+
+	"k8c.io/kubermatic/v2/pkg/resources"
+)
+
+const (
+	MetricsPort = 2378
+	ClientPort  = 2379
+	PeersPort   = 2380
+)
+
+func hostname(n int, namespace string, port int) string {
+	return fmt.Sprintf("etcd-%d.etcd.%s.svc.cluster.local:%d", n, namespace, port)
+}
+
+func LocalEndpoint() string {
+	return fmt.Sprintf("https://127.0.0.1:%d", ClientPort)
+}
+
+func ClientEndpoints(members int, namespace string) []string {
+	endpoints := []string{}
+	for i := 0; i < members; i++ {
+		endpoints = append(endpoints, fmt.Sprintf("https://%s", hostname(i, namespace, ClientPort)))
+	}
+	return endpoints
+}
+
+func PeerURLs(members int, namespace string) []string {
+	urls := []string{}
+	for i := 0; i < members; i++ {
+		urls = append(urls, hostname(i, namespace, PeersPort))
+	}
+	return urls
+}
+
+func MembersList(members int, namespace string) []string {
+	list := PeerURLs(members, namespace)
+	for i, member := range list {
+		list[i] = fmt.Sprintf("etcd-%d=%s", i, member)
+	}
+	return list
+}
+
+type Client struct {
+	client  *clientv3.Client
+	tlsInfo *transport.TLSInfo
+}
+
+func NewLocalClient(tlsInfo *transport.TLSInfo) (*Client, error) {
+	return NewClient([]string{LocalEndpoint()}, tlsInfo)
+}
+
+func NewClient(endpoints []string, tlsInfo *transport.TLSInfo) (*Client, error) {
+	if tlsInfo == nil {
+		tlsInfo = &transport.TLSInfo{
+			CertFile:       resources.EtcdClientCertFile,
+			KeyFile:        resources.EtcdClientKeyFile,
+			TrustedCAFile:  resources.EtcdTrustedCAFile,
+			ClientCertAuth: true,
+		}
+	}
+
+	tlsConfig, err := tlsInfo.ClientConfig()
+	if err != nil {
+		return nil, fmt.Errorf("failed to generate TLS client config: %v", err)
+	}
+
+	client, err := clientv3.New(clientv3.Config{
+		Endpoints:   endpoints,
+		DialTimeout: 2 * time.Second,
+		TLS:         tlsConfig,
+	})
+	if err != nil {
+		return nil, fmt.Errorf("failed to build etcd client: %v", err)
+	}
+
+	return &Client{
+		client:  client,
+		tlsInfo: tlsInfo,
+	}, nil
+}
+
+func (c *Client) MemberList(ctx context.Context) ([]*etcdserverpb.Member, error) {
+	resp, err := c.client.MemberList(ctx)
+	if err != nil {
+		return nil, err
+	}
+	return resp.Members, err
+}
+
+func (c *Client) Close() error {
+	return c.client.Close()
+}
+
+// Healthy checks if the cluster is healthy. If a member is given, only this member's
+// health is checked.
+func (c *Client) Healthy(ctx context.Context, member *etcdserverpb.Member) (bool, error) {
+	client := c.client
+
+	if member != nil {
+		clientURLs := member.ClientURLs
+		if len(clientURLs) == 0 {
+			return false, errors.New("member has no client URLs; was it started already?")
+		}
+
+		cluster, err := NewClient(clientURLs[len(clientURLs)-1:], c.tlsInfo)
+		if err != nil {
+			// swallow any connection error at this point
+			return false, nil
+		}
+
+		client = cluster.client
+		defer client.Close()
+	}
+
+	// just get a key from etcd, this is how `etcdctl endpoint health` works!
+	_, err := client.Get(ctx, "healthy")
+
+	// silently swallow/drop transient errors
+	return err == nil || err == rpctypes.ErrPermissionDenied, nil
+}
+
+func (c *Client) IsClusterMember(ctx context.Context, name string) (bool, error) {
+	members, err := c.MemberList(ctx)
+	if err != nil {
+		return false, fmt.Errorf("failed to list cluster members: %v", err)
+	}
+
+	for i, member := range members {
+		if member.Name == name {
+			return true, nil
+		}
+
+		// if the member is not started yet, its name would be empty,
+		// in that case, we match for peerURL host.
+		url, err := url.Parse(member.PeerURLs[0])
+		if err != nil {
+			return false, fmt.Errorf("failed to parse member %d peer URL: %v", i, err)
+		}
+
+		if url.Host == name {
+			return true, nil
+		}
+	}
+
+	return false, nil
+}
+
+func (c *Client) MemberAdd(ctx context.Context, peerURLs []string) error {
+	_, err := c.client.MemberAdd(ctx, peerURLs)
+	return err
+}
+
+func (c *Client) MemberUpdate(ctx context.Context, memberID uint64, peerURLs []string) error {
+	_, err := c.client.MemberUpdate(ctx, memberID, peerURLs)
+	return err
+}
+
+func (c *Client) MemberRemove(ctx context.Context, memberID uint64) error {
+	_, err := c.client.MemberRemove(ctx, memberID)
+	return err
+}
+
+func (c *Client) Status(ctx context.Context, endpoint string) (*clientv3.StatusResponse, error) {
+	return c.client.Status(ctx, endpoint)
+}


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR improves the reliability of speed of our etcd-launcher e2e tests. Previously, there were a lot of "just wait a few minutes" spots, which dramatically increased the test runtime (e.g. from 45min to 60min).

This PR moves some of the etcd cluster health code from the etcd-launcher/main.go into pkg/resources/etcd and makes it reusable. This reusable code is then used in the e2e tests to have a smarter health detection.

**Does this PR introduce a user-facing change?**:
```release-note
NONE
```
