### PR TITLE
[release/v2.15] Prevent container orphans when using apiserver.IsRunningWrapper

### DIFF
--- a/pkg/controller/seed-controller-manager/openshift/resources/cloud_credential_operator.go
+++ b/pkg/controller/seed-controller-manager/openshift/resources/cloud_credential_operator.go
@@ -50,6 +50,7 @@ func CloudCredentialOperator(data openshiftData) reconciling.NamedDeploymentCrea
 				{Name: openshiftImagePullSecretName},
 			}
 			d.Spec.Template.Spec.AutomountServiceAccountToken = utilpointer.BoolPtr(false)
+			d.Spec.Template.Spec.InitContainers = []corev1.Container{}
 			d.Spec.Template.Spec.Containers = []corev1.Container{{
 				Name:    cloudCredentialOperatorDeploymentName,
 				Command: []string{"/root/manager", "--log-level", "debug"},

--- a/pkg/controller/seed-controller-manager/openshift/resources/console.go
+++ b/pkg/controller/seed-controller-manager/openshift/resources/console.go
@@ -86,6 +86,7 @@ func ConsoleDeployment(data openshiftData) reconciling.NamedDeploymentCreatorGet
 				return nil, err
 			}
 
+			d.Spec.Template.Spec.InitContainers = []corev1.Container{}
 			d.Spec.Template.Spec.Containers = []corev1.Container{{
 				Name:  "console",
 				Image: image,

--- a/pkg/controller/seed-controller-manager/openshift/resources/dns_operator.go
+++ b/pkg/controller/seed-controller-manager/openshift/resources/dns_operator.go
@@ -82,6 +82,7 @@ func OpenshiftDNSOperatorFactory(data openshiftData) reconciling.NamedDeployment
 				return nil, err
 			}
 
+			d.Spec.Template.Spec.InitContainers = []corev1.Container{}
 			d.Spec.Template.Spec.Containers = []corev1.Container{{
 				Name:  openshiftDNSOperatorContainerName,
 				Image: image,

--- a/pkg/controller/seed-controller-manager/openshift/resources/kube_controller_manager.go
+++ b/pkg/controller/seed-controller-manager/openshift/resources/kube_controller_manager.go
@@ -278,6 +278,7 @@ func KubeControllerManagerDeploymentCreatorFactory(data kubeControllerManagerDat
 				}
 				kubeControllerManagerContainerName := "kube-controller-manager"
 
+				dep.Spec.Template.Spec.InitContainers = []corev1.Container{}
 				dep.Spec.Template.Spec.Containers = []corev1.Container{
 					*openvpnSidecar,
 					{

--- a/pkg/controller/seed-controller-manager/openshift/resources/oauth.go
+++ b/pkg/controller/seed-controller-manager/openshift/resources/oauth.go
@@ -373,6 +373,7 @@ func OauthDeploymentCreator(data openshiftData) reconciling.NamedDeploymentCreat
 				},
 			}
 
+			dep.Spec.Template.Spec.InitContainers = []corev1.Container{}
 			dep.Spec.Template.Spec.Containers = []corev1.Container{{
 				Name:  OauthName,
 				Image: image,

--- a/pkg/controller/seed-controller-manager/openshift/resources/openshift_apiserver_deployment.go
+++ b/pkg/controller/seed-controller-manager/openshift/resources/openshift_apiserver_deployment.go
@@ -195,6 +195,7 @@ func OpenshiftAPIServerDeploymentCreator(ctx context.Context, data openshiftData
 				return nil, err
 			}
 
+			dep.Spec.Template.Spec.InitContainers = []corev1.Container{}
 			dep.Spec.Template.Spec.Containers = []corev1.Container{
 				*openvpnSidecar,
 				*dnatControllerSidecar,

--- a/pkg/controller/seed-controller-manager/openshift/resources/openshift_controller_manager.go
+++ b/pkg/controller/seed-controller-manager/openshift/resources/openshift_controller_manager.go
@@ -172,6 +172,7 @@ func OpenshiftControllerManagerDeploymentCreator(ctx context.Context, data opens
 				return nil, fmt.Errorf("failed to get openvpn sidecar: %v", err)
 			}
 
+			dep.Spec.Template.Spec.InitContainers = []corev1.Container{}
 			dep.Spec.Template.Spec.Containers = []corev1.Container{
 				*openvpnSidecar,
 				{

--- a/pkg/controller/seed-controller-manager/openshift/resources/openshift_network_operator.go
+++ b/pkg/controller/seed-controller-manager/openshift/resources/openshift_network_operator.go
@@ -84,6 +84,7 @@ func OpenshiftNetworkOperatorCreatorFactory(data openshiftData) reconciling.Name
 				return nil, err
 			}
 
+			d.Spec.Template.Spec.InitContainers = []corev1.Container{}
 			d.Spec.Template.Spec.Containers = []corev1.Container{{
 				Name:  "network-operator",
 				Image: image,

--- a/pkg/controller/seed-controller-manager/openshift/resources/registry_operator.go
+++ b/pkg/controller/seed-controller-manager/openshift/resources/registry_operator.go
@@ -63,6 +63,7 @@ func RegistryOperatorFactory(data openshiftData) reconciling.NamedDeploymentCrea
 			if err != nil {
 				return nil, err
 			}
+			d.Spec.Template.Spec.InitContainers = []corev1.Container{}
 			d.Spec.Template.Spec.Containers = []corev1.Container{{
 				Name:    openshiftRegistryOperatorName,
 				Image:   image,

--- a/pkg/resources/clusterautoscaler/clusterautoscaler.go
+++ b/pkg/resources/clusterautoscaler/clusterautoscaler.go
@@ -97,6 +97,7 @@ func DeploymentCreator(data clusterautoscalerData) reconciling.NamedDeploymentCr
 
 			dep.Spec.Template.Spec.Volumes = volumes
 
+			dep.Spec.Template.Spec.InitContainers = []corev1.Container{}
 			dep.Spec.Template.Spec.Containers = []corev1.Container{
 				{
 					Name:    resources.ClusterAutoscalerDeploymentName,

--- a/pkg/resources/controllermanager/deployment.go
+++ b/pkg/resources/controllermanager/deployment.go
@@ -147,6 +147,7 @@ func DeploymentCreator(data *resources.TemplateData) reconciling.NamedDeployment
 				Port:   intstr.FromInt(10257),
 			}
 
+			dep.Spec.Template.Spec.InitContainers = []corev1.Container{}
 			dep.Spec.Template.Spec.Containers = []corev1.Container{
 				*openvpnSidecar,
 				{

--- a/pkg/resources/kubernetes-dashboard/deployment.go
+++ b/pkg/resources/kubernetes-dashboard/deployment.go
@@ -87,6 +87,7 @@ func DeploymentCreator(data kubernetesDashboardData) reconciling.NamedDeployment
 			}
 
 			dep.Spec.Template.Spec.Volumes = volumes
+			dep.Spec.Template.Spec.InitContainers = []corev1.Container{}
 			dep.Spec.Template.Spec.Containers = getContainers(data, dep.Spec.Template.Spec.Containers)
 			err = resources.SetResourceRequirements(dep.Spec.Template.Spec.Containers, defaultResourceRequirements, nil, dep.Annotations)
 			if err != nil {

--- a/pkg/resources/kubestatemetrics/deployment.go
+++ b/pkg/resources/kubestatemetrics/deployment.go
@@ -81,6 +81,7 @@ func DeploymentCreator(data *resources.TemplateData) reconciling.NamedDeployment
 
 			dep.Spec.Template.Spec.Volumes = volumes
 
+			dep.Spec.Template.Spec.InitContainers = []corev1.Container{}
 			dep.Spec.Template.Spec.Containers = []corev1.Container{
 				{
 					Name:    name,

--- a/pkg/resources/machinecontroller/deployment.go
+++ b/pkg/resources/machinecontroller/deployment.go
@@ -135,6 +135,7 @@ func DeploymentCreatorWithoutInitWrapper(data machinecontrollerData) reconciling
 
 			externalCloudProvider := data.Cluster().Spec.Features[kubermaticv1.ClusterFeatureExternalCloudProvider]
 
+			dep.Spec.Template.Spec.InitContainers = []corev1.Container{}
 			dep.Spec.Template.Spec.Containers = []corev1.Container{
 				{
 					Name:    Name,

--- a/pkg/resources/machinecontroller/webhook.go
+++ b/pkg/resources/machinecontroller/webhook.go
@@ -74,6 +74,7 @@ func WebhookDeploymentCreator(data machinecontrollerData) reconciling.NamedDeplo
 			}
 			dep.Spec.Template.ObjectMeta = metav1.ObjectMeta{Labels: podLabels}
 
+			dep.Spec.Template.Spec.InitContainers = []corev1.Container{}
 			dep.Spec.Template.Spec.Containers = []corev1.Container{
 				{
 					Name:    Name,

--- a/pkg/resources/metrics-server/deployment.go
+++ b/pkg/resources/metrics-server/deployment.go
@@ -115,6 +115,7 @@ func DeploymentCreator(data metricsServerData) reconciling.NamedDeploymentCreato
 				return nil, fmt.Errorf("failed to get dnat-controller sidecar: %v", err)
 			}
 
+			dep.Spec.Template.Spec.InitContainers = []corev1.Container{}
 			dep.Spec.Template.Spec.Containers = []corev1.Container{
 				{
 					Name:    name,

--- a/pkg/resources/scheduler/deployment.go
+++ b/pkg/resources/scheduler/deployment.go
@@ -115,6 +115,7 @@ func DeploymentCreator(data *resources.TemplateData) reconciling.NamedDeployment
 				Port:   intstr.FromInt(10259),
 			}
 
+			dep.Spec.Template.Spec.InitContainers = []corev1.Container{}
 			dep.Spec.Template.Spec.Containers = []corev1.Container{
 				*openvpnSidecar,
 				{

--- a/pkg/resources/usercluster/deployment.go
+++ b/pkg/resources/usercluster/deployment.go
@@ -156,6 +156,7 @@ func DeploymentCreator(data userclusterControllerData, openshift bool) reconcili
 				args = append(args, "-cloud-credential-secret-template", string(cloudCredentialSecretTemplate))
 			}
 
+			dep.Spec.Template.Spec.InitContainers = []corev1.Container{}
 			dep.Spec.Template.Spec.Containers = []corev1.Container{
 				{
 					Name:    name,


### PR DESCRIPTION
**What this PR does / why we need it**:
Backport #6329 into 2.14.x.

**Does this PR introduce a user-facing change?**:
```release-note
[ATTN] Fix orphaned apiserver-is-running initContainers in usercluster controlplane. This can cause a short reconciliation burst to bring older usercluster resources in all Seed clusters up to date. Tune the maxReconcileLimit if needed.
```
