### PR TITLE
stop syncing ssh keys if there was no keys attached to the user cluster

### DIFF
--- a/pkg/controller/usersshkeysagent/usersshkeys_controller.go
+++ b/pkg/controller/usersshkeysagent/usersshkeys_controller.go
@@ -112,6 +112,12 @@ func (r *Reconciler) Reconcile(request reconcile.Request) (reconcile.Result, err
 		return reconcile.Result{}, fmt.Errorf("failed to fetch user ssh keys: %v", err)
 	}
 
+	// if there was no user ssh keys attached to the user cluster, the agent won't carry out any updates,
+	// however, if any ssh keys were attached to the cluster, then those newly attached keys will override any pre-existent ones
+	if len(secret.Data) == 0 {
+		return reconcile.Result{}, nil
+	}
+
 	if err := r.updateAuthorizedKeys(secret.Data); err != nil {
 		r.log.Errorw("Failed reconciling user ssh key secret", zap.Error(err))
 		return reconcile.Result{}, fmt.Errorf("failed to reconcile user ssh keys: %v", err)


### PR DESCRIPTION
**What this PR does / why we need it**:
Disable the user-ssh-key-agent when there was no user ssh keys attached to the user cluster. Whatever ssh keys the cluster user would add to machines will remain there until a new user ssh key was attached to the cluster. In that case the ssh keys that were added manually will be overwritten by the ones which were attached.
   
**Which issue(s) this PR fixes**
Fixes #6381

**Documentation**:
Documentation for the user ssh keys agent will be added in a different PR

**Does this PR introduce a user-facing change?**:
No

```release-note
Disable user ssh key sync when no user ssh keys are added.
```
