### PR TITLE
user cluster coredns pdb label fix

### DIFF
--- a/pkg/controller/user-cluster-controller-manager/resources/resources/core-dns/deployment.go
+++ b/pkg/controller/user-cluster-controller-manager/resources/resources/core-dns/deployment.go
@@ -107,7 +107,7 @@ func PodDisruptionBudgetCreator() reconciling.NamedPodDisruptionBudgetCreatorGet
 			iptr := intstr.FromInt(1)
 			pdb.Spec.MinAvailable = &iptr
 			pdb.Spec.Selector = &metav1.LabelSelector{
-				MatchLabels: resources.BaseAppLabels(resources.CoreDNSServiceName, nil),
+				MatchLabels: resources.BaseAppLabels(resources.CoreDNSDeploymentName, nil),
 			}
 
 			return pdb, nil


### PR DESCRIPTION
Signed-off-by: Olaf Klischat <olaf.klischat@gmail.com>

**What this PR does / why we need it**:

The kube-system/coredns PodDisruptionBudget (rolled out by user-cluster-controller-manager) has matchLabels that no longer match the coredns pods in 2.15, which means there's effectively no PDB for the user cluster coredns. This PR fixes that.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Documentation**:
<!-- Add links to the related documentation changes related to this pull request. E.g. the link to the kubermatic/docs pull request. -->

**Does this PR introduce a user-facing change?**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If  no release note is required, just write "NONE".
-->
```release-note
Fix kube-system/coredns PodDisruptionBudget matchLabels in user clusters
```
