### PR TITLE
Use cloud init for flatcar on aws

### DIFF
--- a/pkg/resources/machine/common.go
+++ b/pkg/resources/machine/common.go
@@ -520,8 +520,9 @@ func getFlatcarOperatingSystemSpec(nodeSpec apiv1.NodeSpec) (*runtime.RawExtensi
 
 		ProvisioningUtility: flatcar.Ignition,
 	}
-	// set cloud init only for anexia provider
-	if nodeSpec.Cloud.Anexia != nil {
+	// set cloud init only for anexia and aws(due to the userdata size limit on aws, ignition increases the size drastically).
+	// This should be temporary until the new operating system manager is added to KKP.
+	if nodeSpec.Cloud.Anexia != nil || nodeSpec.Cloud.AWS != nil {
 		config.ProvisioningUtility = flatcar.CloudInit
 	}
 


### PR DESCRIPTION
**What this PR does / why we need it**:
Flatcar support on aws stopped working due to an increase of the userdata. While using ignition, userdata size hits the limit on aws, however when coreos-cloud-config is used, then the userdata size will be accepted.

**Which issue(s) this PR fixes** 
Fixes #

**Special notes for your reviewer**:
This is a temporary fix until the new operating system manager is finished and integrated with KKP, as we would like to keep using ignition as the default cloud-init for flatcar.
**Documentation**:
<!-- Add links to the related documentation changes related to this pull request. E.g. the link to the kubermatic/docs pull request. -->

**Does this PR introduce a user-facing change?**:
```release-note
Use Coreos-Cloud-Config for flatcar machines on aws 
```
