### PR TITLE
[release/v2.14] add admission control configuration for the user cluster API deployment

### DIFF
--- a/api/cmd/image-loader/main.go
+++ b/api/cmd/image-loader/main.go
@@ -370,8 +370,14 @@ func getTemplateData(version *kubermaticversion.Version) (*resources.TemplateDat
 			Namespace: mockNamespaceName,
 		},
 	}
+	admissionControlConfigMapName := corev1.ConfigMap{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      resources.AdmissionControlConfigMapName,
+			Namespace: mockNamespaceName,
+		},
+	}
 	configMapList := &corev1.ConfigMapList{
-		Items: []corev1.ConfigMap{cloudConfigConfigMap, prometheusConfigMap, dnsResolverConfigMap, openvpnClientConfigsConfigMap, auditConfigMap},
+		Items: []corev1.ConfigMap{cloudConfigConfigMap, prometheusConfigMap, dnsResolverConfigMap, openvpnClientConfigsConfigMap, auditConfigMap, admissionControlConfigMapName},
 	}
 	apiServerExternalService := corev1.Service{
 		ObjectMeta: metav1.ObjectMeta{

--- a/api/cmd/kubermatic-api/swagger.json
+++ b/api/cmd/kubermatic-api/swagger.json
@@ -8874,6 +8874,14 @@
         "openshift": {
           "$ref": "#/definitions/Openshift"
         },
+        "podNodeSelectorAdmissionPluginConfig": {
+          "description": "PodNodeSelectorAdmissionPluginConfig provides the configuration for the PodNodeSelector.\nIt's used by the backend to create a configuration file for this plugin.\nThe key:value from the map is converted to the namespace:\u003cnode-selectors-labels\u003e in the file.\nThe format in a file:\npodNodeSelectorPluginConfig:\nclusterDefaultNodeSelector: \u003cnode-selectors-labels\u003e\nnamespace1: \u003cnode-selectors-labels\u003e\nnamespace2: \u003cnode-selectors-labels\u003e",
+          "type": "object",
+          "additionalProperties": {
+            "type": "string"
+          },
+          "x-go-name": "PodNodeSelectorAdmissionPluginConfig"
+        },
         "updateWindow": {
           "$ref": "#/definitions/UpdateWindow"
         },

--- a/api/pkg/api/v1/types.go
+++ b/api/pkg/api/v1/types.go
@@ -699,6 +699,16 @@ type ClusterSpec struct {
 	// If active the PodNodeSelector admission plugin is configured at the apiserver
 	UsePodNodeSelectorAdmissionPlugin bool `json:"usePodNodeSelectorAdmissionPlugin,omitempty"`
 
+	// PodNodeSelectorAdmissionPluginConfig provides the configuration for the PodNodeSelector.
+	// It's used by the backend to create a configuration file for this plugin.
+	// The key:value from the map is converted to the namespace:<node-selectors-labels> in the file.
+	// The format in a file:
+	// podNodeSelectorPluginConfig:
+	//  clusterDefaultNodeSelector: <node-selectors-labels>
+	//  namespace1: <node-selectors-labels>
+	//  namespace2: <node-selectors-labels>
+	PodNodeSelectorAdmissionPluginConfig map[string]string `json:"podNodeSelectorAdmissionPluginConfig,omitempty"`
+
 	// Additional Admission Controller plugins
 	AdmissionPlugins []string `json:"admissionPlugins,omitempty"`
 
@@ -713,15 +723,16 @@ type ClusterSpec struct {
 // that will be returned in the API responses (see: PublicCloudSpec struct).
 func (cs *ClusterSpec) MarshalJSON() ([]byte, error) {
 	ret, err := json.Marshal(struct {
-		Cloud                               PublicCloudSpec                        `json:"cloud"`
-		MachineNetworks                     []kubermaticv1.MachineNetworkingConfig `json:"machineNetworks,omitempty"`
-		Version                             ksemver.Semver                         `json:"version"`
-		OIDC                                kubermaticv1.OIDCSettings              `json:"oidc"`
-		UpdateWindow                        *kubermaticv1.UpdateWindow             `json:"updateWindow,omitempty"`
-		UsePodSecurityPolicyAdmissionPlugin bool                                   `json:"usePodSecurityPolicyAdmissionPlugin,omitempty"`
-		UsePodNodeSelectorAdmissionPlugin   bool                                   `json:"usePodNodeSelectorAdmissionPlugin,omitempty"`
-		AuditLogging                        *kubermaticv1.AuditLoggingSettings     `json:"auditLogging,omitempty"`
-		AdmissionPlugins                    []string                               `json:"admissionPlugins,omitempty"`
+		Cloud                                PublicCloudSpec                        `json:"cloud"`
+		MachineNetworks                      []kubermaticv1.MachineNetworkingConfig `json:"machineNetworks,omitempty"`
+		Version                              ksemver.Semver                         `json:"version"`
+		OIDC                                 kubermaticv1.OIDCSettings              `json:"oidc"`
+		UpdateWindow                         *kubermaticv1.UpdateWindow             `json:"updateWindow,omitempty"`
+		UsePodSecurityPolicyAdmissionPlugin  bool                                   `json:"usePodSecurityPolicyAdmissionPlugin,omitempty"`
+		UsePodNodeSelectorAdmissionPlugin    bool                                   `json:"usePodNodeSelectorAdmissionPlugin,omitempty"`
+		AuditLogging                         *kubermaticv1.AuditLoggingSettings     `json:"auditLogging,omitempty"`
+		AdmissionPlugins                     []string                               `json:"admissionPlugins,omitempty"`
+		PodNodeSelectorAdmissionPluginConfig map[string]string                      `json:"podNodeSelectorAdmissionPluginConfig,omitempty"`
 	}{
 		Cloud: PublicCloudSpec{
 			DatacenterName: cs.Cloud.DatacenterName,
@@ -738,14 +749,15 @@ func (cs *ClusterSpec) MarshalJSON() ([]byte, error) {
 			Kubevirt:       newPublicKubevirtCloudSpec(cs.Cloud.Kubevirt),
 			Alibaba:        newPublicAlibabaCloudSpec(cs.Cloud.Alibaba),
 		},
-		Version:                             cs.Version,
-		MachineNetworks:                     cs.MachineNetworks,
-		OIDC:                                cs.OIDC,
-		UpdateWindow:                        cs.UpdateWindow,
-		UsePodSecurityPolicyAdmissionPlugin: cs.UsePodSecurityPolicyAdmissionPlugin,
-		UsePodNodeSelectorAdmissionPlugin:   cs.UsePodNodeSelectorAdmissionPlugin,
-		AuditLogging:                        cs.AuditLogging,
-		AdmissionPlugins:                    cs.AdmissionPlugins,
+		Version:                              cs.Version,
+		MachineNetworks:                      cs.MachineNetworks,
+		OIDC:                                 cs.OIDC,
+		UpdateWindow:                         cs.UpdateWindow,
+		UsePodSecurityPolicyAdmissionPlugin:  cs.UsePodSecurityPolicyAdmissionPlugin,
+		UsePodNodeSelectorAdmissionPlugin:    cs.UsePodNodeSelectorAdmissionPlugin,
+		AuditLogging:                         cs.AuditLogging,
+		AdmissionPlugins:                     cs.AdmissionPlugins,
+		PodNodeSelectorAdmissionPluginConfig: cs.PodNodeSelectorAdmissionPluginConfig,
 	})
 
 	return ret, err

--- a/api/pkg/controller/seed-controller-manager/kubernetes/resources.go
+++ b/api/pkg/controller/seed-controller-manager/kubernetes/resources.go
@@ -357,6 +357,7 @@ func GetConfigMapCreators(data *resources.TemplateData) []reconciling.NamedConfi
 		openvpn.ServerClientConfigsConfigMapCreator(data),
 		dns.ConfigMapCreator(data),
 		apiserver.AuditConfigMapCreator(),
+		apiserver.AdmissionControlCreator(data),
 	}
 }
 

--- a/api/pkg/handler/v1/cluster/cluster.go
+++ b/api/pkg/handler/v1/cluster/cluster.go
@@ -457,6 +457,7 @@ func PatchEndpoint(projectProvider provider.ProjectProvider, privilegedProjectPr
 		newInternalCluster.Spec.AuditLogging = patchedCluster.Spec.AuditLogging
 		newInternalCluster.Spec.Openshift = patchedCluster.Spec.Openshift
 		newInternalCluster.Spec.UpdateWindow = patchedCluster.Spec.UpdateWindow
+		newInternalCluster.Spec.PodNodeSelectorAdmissionPluginConfig = patchedCluster.Spec.PodNodeSelectorAdmissionPluginConfig
 
 		incompatibleKubelets, err := common.CheckClusterVersionSkew(ctx, userInfoGetter, clusterProvider, newInternalCluster, req.ProjectID)
 		if err != nil {
@@ -851,15 +852,16 @@ func convertInternalClusterToExternal(internalCluster *kubermaticv1.Cluster, fil
 		Labels:          internalCluster.Labels,
 		InheritedLabels: internalCluster.Status.InheritedLabels,
 		Spec: apiv1.ClusterSpec{
-			Cloud:                               internalCluster.Spec.Cloud,
-			Version:                             internalCluster.Spec.Version,
-			MachineNetworks:                     internalCluster.Spec.MachineNetworks,
-			OIDC:                                internalCluster.Spec.OIDC,
-			UpdateWindow:                        internalCluster.Spec.UpdateWindow,
-			AuditLogging:                        internalCluster.Spec.AuditLogging,
-			UsePodSecurityPolicyAdmissionPlugin: internalCluster.Spec.UsePodSecurityPolicyAdmissionPlugin,
-			UsePodNodeSelectorAdmissionPlugin:   internalCluster.Spec.UsePodNodeSelectorAdmissionPlugin,
-			AdmissionPlugins:                    internalCluster.Spec.AdmissionPlugins,
+			Cloud:                                internalCluster.Spec.Cloud,
+			Version:                              internalCluster.Spec.Version,
+			MachineNetworks:                      internalCluster.Spec.MachineNetworks,
+			OIDC:                                 internalCluster.Spec.OIDC,
+			UpdateWindow:                         internalCluster.Spec.UpdateWindow,
+			AuditLogging:                         internalCluster.Spec.AuditLogging,
+			UsePodSecurityPolicyAdmissionPlugin:  internalCluster.Spec.UsePodSecurityPolicyAdmissionPlugin,
+			UsePodNodeSelectorAdmissionPlugin:    internalCluster.Spec.UsePodNodeSelectorAdmissionPlugin,
+			AdmissionPlugins:                     internalCluster.Spec.AdmissionPlugins,
+			PodNodeSelectorAdmissionPluginConfig: internalCluster.Spec.PodNodeSelectorAdmissionPluginConfig,
 		},
 		Status: apiv1.ClusterStatus{
 			Version: internalCluster.Spec.Version,

--- a/api/pkg/resources/apiserver/admission-control.go
+++ b/api/pkg/resources/apiserver/admission-control.go
@@ -1,0 +1,124 @@
+/*
+Copyright 2020 The Kubermatic Kubernetes Platform contributors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package apiserver
+
+import (
+	"fmt"
+
+	"gopkg.in/yaml.v2"
+
+	"github.com/kubermatic/kubermatic/api/pkg/resources"
+	"github.com/kubermatic/kubermatic/api/pkg/resources/reconciling"
+	"github.com/kubermatic/kubermatic/api/pkg/semver"
+
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/util/sets"
+)
+
+const podNodeSelectorFileName = "podnodeselector.yaml"
+
+// AdmissionConfiguration provides versioned configuration for admission controllers.
+type AdmissionConfiguration struct {
+	Kind string `yaml:"kind,omitempty"`
+
+	APIVersion string `yaml:"apiVersion,omitempty"`
+
+	// Plugins allows specifying a configuration per admission control plugin.
+	Plugins []AdmissionPluginConfiguration `yaml:"plugins,omitempty"`
+}
+
+// AdmissionPluginConfiguration provides the configuration for a single plug-in.
+type AdmissionPluginConfiguration struct {
+	// Name is the name of the admission controller.
+	// It must match the registered admission plugin name.
+	Name string `yaml:"name"`
+
+	// Path is the path to a configuration file that contains the plugin's
+	// configuration
+	Path string `yaml:"path"`
+}
+
+func AdmissionControlCreator(data *resources.TemplateData) reconciling.NamedConfigMapCreatorGetter {
+	return func() (string, reconciling.ConfigMapCreator) {
+		return resources.AdmissionControlConfigMapName, func(cm *corev1.ConfigMap) (*corev1.ConfigMap, error) {
+			if cm.Data == nil {
+				cm.Data = map[string]string{}
+			}
+
+			admissionConfiguration := AdmissionConfiguration{
+				APIVersion: "apiserver.config.k8s.io/v1",
+				Kind:       "AdmissionConfiguration",
+				Plugins:    []AdmissionPluginConfiguration{},
+			}
+			deprecatedVersion, err := semver.NewSemver("1.17")
+			if err != nil {
+				return nil, err
+			}
+
+			// Deprecated in v1.17 in favor of apiserver.config.k8s.io/v1
+			if data.Cluster().Spec.Version.LessThan(deprecatedVersion.Version) {
+				admissionConfiguration.APIVersion = "apiserver.k8s.io/v1alpha1"
+			}
+			if usePodNodeSelectorAdmissionPlugin(data) {
+				podNodeSelector := AdmissionPluginConfiguration{
+					Name: resources.PodNodeSelectorAdmissionPlugin,
+					Path: fmt.Sprintf("/etc/kubernetes/adm-control/%s", podNodeSelectorFileName),
+				}
+				admissionConfiguration.Plugins = append(admissionConfiguration.Plugins, podNodeSelector)
+
+				podNodeConfig, err := getPodNodeSelectorAdmissionPluginConfig(data)
+				if err != nil {
+					return nil, err
+				}
+				cm.Data[podNodeSelectorFileName] = podNodeConfig
+			}
+
+			rawAdmissionConfiguration, err := yaml.Marshal(admissionConfiguration)
+			if err != nil {
+				return nil, err
+			}
+
+			cm.Data["admission-control.yaml"] = string(rawAdmissionConfiguration)
+
+			return cm, nil
+		}
+	}
+}
+
+func usePodNodeSelectorAdmissionPlugin(data *resources.TemplateData) bool {
+	admissionPlugins := sets.NewString(data.Cluster().Spec.AdmissionPlugins...)
+	return data.Cluster().Spec.UsePodNodeSelectorAdmissionPlugin || admissionPlugins.Has(resources.PodNodeSelectorAdmissionPlugin)
+}
+
+func getPodNodeSelectorAdmissionPluginConfig(data *resources.TemplateData) (string, error) {
+	var pluginConfig struct {
+		PodNodeSelectorPluginConfig map[string]string `yaml:"podNodeSelectorPluginConfig,omitempty"`
+	}
+
+	if data.Cluster().Spec.PodNodeSelectorAdmissionPluginConfig == nil {
+		data.Cluster().Spec.PodNodeSelectorAdmissionPluginConfig = map[string]string{}
+	}
+
+	pluginConfig.PodNodeSelectorPluginConfig = data.Cluster().Spec.PodNodeSelectorAdmissionPluginConfig
+
+	rawPodNodeConfig, err := yaml.Marshal(pluginConfig)
+	if err != nil {
+		return "", err
+	}
+
+	return string(rawPodNodeConfig), nil
+}

--- a/api/pkg/resources/apiserver/deployment.go
+++ b/api/pkg/resources/apiserver/deployment.go
@@ -265,7 +265,7 @@ func getApiserverFlags(data *resources.TemplateData, etcdEndpoints []string, ena
 		admissionPlugins.Insert("PodSecurityPolicy")
 	}
 	if data.Cluster().Spec.UsePodNodeSelectorAdmissionPlugin {
-		admissionPlugins.Insert("PodNodeSelector")
+		admissionPlugins.Insert(resources.PodNodeSelectorAdmissionPlugin)
 	}
 
 	admissionPlugins.Insert(data.Cluster().Spec.AdmissionPlugins...)
@@ -280,6 +280,7 @@ func getApiserverFlags(data *resources.TemplateData, etcdEndpoints []string, ena
 		"--etcd-keyfile", "/etc/etcd/pki/client/apiserver-etcd-client.key",
 		"--storage-backend", "etcd3",
 		"--enable-admission-plugins", strings.Join(admissionPlugins.List(), ","),
+		"--admission-control-config-file", "/etc/kubernetes/adm-control/admission-control.yaml",
 		"--authorization-mode", "Node,RBAC",
 		"--external-hostname", data.Cluster().Address.ExternalName,
 		"--token-auth-file", "/etc/kubernetes/tokens/tokens.csv",
@@ -412,6 +413,11 @@ func getVolumeMounts() []corev1.VolumeMount {
 			MountPath: "/var/log/kubernetes/audit",
 			ReadOnly:  false,
 		},
+		{
+			Name:      resources.AdmissionControlConfigMapName,
+			MountPath: "/etc/kubernetes/adm-control",
+			ReadOnly:  true,
+		},
 	}
 }
 
@@ -528,6 +534,16 @@ func getVolumes() []corev1.Volume {
 			Name: resources.AuditLogVolumeName,
 			VolumeSource: corev1.VolumeSource{
 				EmptyDir: &corev1.EmptyDirVolumeSource{},
+			},
+		},
+		{
+			Name: resources.AdmissionControlConfigMapName,
+			VolumeSource: corev1.VolumeSource{
+				ConfigMap: &corev1.ConfigMapVolumeSource{
+					LocalObjectReference: corev1.LocalObjectReference{
+						Name: resources.AdmissionControlConfigMapName,
+					},
+				},
 			},
 		},
 	}

--- a/api/pkg/resources/cluster/cluster.go
+++ b/api/pkg/resources/cluster/cluster.go
@@ -31,17 +31,18 @@ import (
 // Spec builds ClusterSpec kubermatic Custom Resource from API Cluster
 func Spec(apiCluster apiv1.Cluster, dc *kubermaticv1.Datacenter, secretKeyGetter provider.SecretKeySelectorValueFunc) (*kubermaticv1.ClusterSpec, error) {
 	spec := &kubermaticv1.ClusterSpec{
-		HumanReadableName:                   apiCluster.Name,
-		Cloud:                               apiCluster.Spec.Cloud,
-		MachineNetworks:                     apiCluster.Spec.MachineNetworks,
-		OIDC:                                apiCluster.Spec.OIDC,
-		UpdateWindow:                        apiCluster.Spec.UpdateWindow,
-		Version:                             apiCluster.Spec.Version,
-		UsePodSecurityPolicyAdmissionPlugin: apiCluster.Spec.UsePodSecurityPolicyAdmissionPlugin,
-		UsePodNodeSelectorAdmissionPlugin:   apiCluster.Spec.UsePodNodeSelectorAdmissionPlugin,
-		AuditLogging:                        apiCluster.Spec.AuditLogging,
-		Openshift:                           apiCluster.Spec.Openshift,
-		AdmissionPlugins:                    apiCluster.Spec.AdmissionPlugins,
+		HumanReadableName:                    apiCluster.Name,
+		Cloud:                                apiCluster.Spec.Cloud,
+		MachineNetworks:                      apiCluster.Spec.MachineNetworks,
+		OIDC:                                 apiCluster.Spec.OIDC,
+		UpdateWindow:                         apiCluster.Spec.UpdateWindow,
+		Version:                              apiCluster.Spec.Version,
+		UsePodSecurityPolicyAdmissionPlugin:  apiCluster.Spec.UsePodSecurityPolicyAdmissionPlugin,
+		UsePodNodeSelectorAdmissionPlugin:    apiCluster.Spec.UsePodNodeSelectorAdmissionPlugin,
+		AuditLogging:                         apiCluster.Spec.AuditLogging,
+		Openshift:                            apiCluster.Spec.Openshift,
+		AdmissionPlugins:                     apiCluster.Spec.AdmissionPlugins,
+		PodNodeSelectorAdmissionPluginConfig: apiCluster.Spec.PodNodeSelectorAdmissionPluginConfig,
 	}
 
 	providerName, err := provider.ClusterCloudProviderName(spec.Cloud)

--- a/api/pkg/resources/resources.go
+++ b/api/pkg/resources/resources.go
@@ -220,6 +220,8 @@ const (
 	PrometheusConfigConfigMapName = "prometheus"
 	//AuditConfigMapName is the name for the configmap that contains the content of the file that will be passed to the apiserver with the flag "--audit-policy-file".
 	AuditConfigMapName = "audit-config"
+	//AdmissionControlConfigMapName is the name for the configmap that contains the Admission Controller config file
+	AdmissionControlConfigMapName = "adm-control"
 
 	//PrometheusServiceAccountName is the name for the Prometheus serviceaccount
 	PrometheusServiceAccountName = "prometheus"
@@ -361,6 +363,9 @@ const (
 	IPVSProxyMode = "ipvs"
 	// IPTablesProxyMode defines the iptables kube-proxy mode.
 	IPTablesProxyMode = "iptables"
+
+	// PodNodeSelectorAdmissionPlugin defines PodNodeSelector admission plugin
+	PodNodeSelectorAdmissionPlugin = "PodNodeSelector"
 )
 
 const (

--- a/api/pkg/resources/test/fixtures/configmap-aws-1.15.0-adm-control.yaml
+++ b/api/pkg/resources/test/fixtures/configmap-aws-1.15.0-adm-control.yaml
@@ -1,0 +1,6 @@
+data:
+  admission-control.yaml: |
+    kind: AdmissionConfiguration
+    apiVersion: apiserver.k8s.io/v1alpha1
+metadata:
+  creationTimestamp: null

--- a/api/pkg/resources/test/fixtures/configmap-aws-1.16.0-adm-control.yaml
+++ b/api/pkg/resources/test/fixtures/configmap-aws-1.16.0-adm-control.yaml
@@ -1,0 +1,6 @@
+data:
+  admission-control.yaml: |
+    kind: AdmissionConfiguration
+    apiVersion: apiserver.k8s.io/v1alpha1
+metadata:
+  creationTimestamp: null

--- a/api/pkg/resources/test/fixtures/configmap-aws-1.17.0-adm-control.yaml
+++ b/api/pkg/resources/test/fixtures/configmap-aws-1.17.0-adm-control.yaml
@@ -1,0 +1,6 @@
+data:
+  admission-control.yaml: |
+    kind: AdmissionConfiguration
+    apiVersion: apiserver.config.k8s.io/v1
+metadata:
+  creationTimestamp: null

--- a/api/pkg/resources/test/fixtures/configmap-aws-1.18.0-adm-control.yaml
+++ b/api/pkg/resources/test/fixtures/configmap-aws-1.18.0-adm-control.yaml
@@ -1,0 +1,6 @@
+data:
+  admission-control.yaml: |
+    kind: AdmissionConfiguration
+    apiVersion: apiserver.config.k8s.io/v1
+metadata:
+  creationTimestamp: null

--- a/api/pkg/resources/test/fixtures/configmap-azure-1.15.0-adm-control.yaml
+++ b/api/pkg/resources/test/fixtures/configmap-azure-1.15.0-adm-control.yaml
@@ -1,0 +1,6 @@
+data:
+  admission-control.yaml: |
+    kind: AdmissionConfiguration
+    apiVersion: apiserver.k8s.io/v1alpha1
+metadata:
+  creationTimestamp: null

--- a/api/pkg/resources/test/fixtures/configmap-azure-1.16.0-adm-control.yaml
+++ b/api/pkg/resources/test/fixtures/configmap-azure-1.16.0-adm-control.yaml
@@ -1,0 +1,6 @@
+data:
+  admission-control.yaml: |
+    kind: AdmissionConfiguration
+    apiVersion: apiserver.k8s.io/v1alpha1
+metadata:
+  creationTimestamp: null

--- a/api/pkg/resources/test/fixtures/configmap-azure-1.17.0-adm-control.yaml
+++ b/api/pkg/resources/test/fixtures/configmap-azure-1.17.0-adm-control.yaml
@@ -1,0 +1,6 @@
+data:
+  admission-control.yaml: |
+    kind: AdmissionConfiguration
+    apiVersion: apiserver.config.k8s.io/v1
+metadata:
+  creationTimestamp: null

--- a/api/pkg/resources/test/fixtures/configmap-azure-1.18.0-adm-control.yaml
+++ b/api/pkg/resources/test/fixtures/configmap-azure-1.18.0-adm-control.yaml
@@ -1,0 +1,6 @@
+data:
+  admission-control.yaml: |
+    kind: AdmissionConfiguration
+    apiVersion: apiserver.config.k8s.io/v1
+metadata:
+  creationTimestamp: null

--- a/api/pkg/resources/test/fixtures/configmap-bringyourown-1.15.0-adm-control.yaml
+++ b/api/pkg/resources/test/fixtures/configmap-bringyourown-1.15.0-adm-control.yaml
@@ -1,0 +1,6 @@
+data:
+  admission-control.yaml: |
+    kind: AdmissionConfiguration
+    apiVersion: apiserver.k8s.io/v1alpha1
+metadata:
+  creationTimestamp: null

--- a/api/pkg/resources/test/fixtures/configmap-bringyourown-1.16.0-adm-control.yaml
+++ b/api/pkg/resources/test/fixtures/configmap-bringyourown-1.16.0-adm-control.yaml
@@ -1,0 +1,6 @@
+data:
+  admission-control.yaml: |
+    kind: AdmissionConfiguration
+    apiVersion: apiserver.k8s.io/v1alpha1
+metadata:
+  creationTimestamp: null

--- a/api/pkg/resources/test/fixtures/configmap-bringyourown-1.17.0-adm-control.yaml
+++ b/api/pkg/resources/test/fixtures/configmap-bringyourown-1.17.0-adm-control.yaml
@@ -1,0 +1,6 @@
+data:
+  admission-control.yaml: |
+    kind: AdmissionConfiguration
+    apiVersion: apiserver.config.k8s.io/v1
+metadata:
+  creationTimestamp: null

--- a/api/pkg/resources/test/fixtures/configmap-bringyourown-1.18.0-adm-control.yaml
+++ b/api/pkg/resources/test/fixtures/configmap-bringyourown-1.18.0-adm-control.yaml
@@ -1,0 +1,6 @@
+data:
+  admission-control.yaml: |
+    kind: AdmissionConfiguration
+    apiVersion: apiserver.config.k8s.io/v1
+metadata:
+  creationTimestamp: null

--- a/api/pkg/resources/test/fixtures/configmap-digitalocean-1.15.0-adm-control.yaml
+++ b/api/pkg/resources/test/fixtures/configmap-digitalocean-1.15.0-adm-control.yaml
@@ -1,0 +1,6 @@
+data:
+  admission-control.yaml: |
+    kind: AdmissionConfiguration
+    apiVersion: apiserver.k8s.io/v1alpha1
+metadata:
+  creationTimestamp: null

--- a/api/pkg/resources/test/fixtures/configmap-digitalocean-1.16.0-adm-control.yaml
+++ b/api/pkg/resources/test/fixtures/configmap-digitalocean-1.16.0-adm-control.yaml
@@ -1,0 +1,6 @@
+data:
+  admission-control.yaml: |
+    kind: AdmissionConfiguration
+    apiVersion: apiserver.k8s.io/v1alpha1
+metadata:
+  creationTimestamp: null

--- a/api/pkg/resources/test/fixtures/configmap-digitalocean-1.17.0-adm-control.yaml
+++ b/api/pkg/resources/test/fixtures/configmap-digitalocean-1.17.0-adm-control.yaml
@@ -1,0 +1,6 @@
+data:
+  admission-control.yaml: |
+    kind: AdmissionConfiguration
+    apiVersion: apiserver.config.k8s.io/v1
+metadata:
+  creationTimestamp: null

--- a/api/pkg/resources/test/fixtures/configmap-digitalocean-1.18.0-adm-control.yaml
+++ b/api/pkg/resources/test/fixtures/configmap-digitalocean-1.18.0-adm-control.yaml
@@ -1,0 +1,6 @@
+data:
+  admission-control.yaml: |
+    kind: AdmissionConfiguration
+    apiVersion: apiserver.config.k8s.io/v1
+metadata:
+  creationTimestamp: null

--- a/api/pkg/resources/test/fixtures/configmap-openstack-1.15.0-adm-control.yaml
+++ b/api/pkg/resources/test/fixtures/configmap-openstack-1.15.0-adm-control.yaml
@@ -1,0 +1,6 @@
+data:
+  admission-control.yaml: |
+    kind: AdmissionConfiguration
+    apiVersion: apiserver.k8s.io/v1alpha1
+metadata:
+  creationTimestamp: null

--- a/api/pkg/resources/test/fixtures/configmap-openstack-1.16.0-adm-control.yaml
+++ b/api/pkg/resources/test/fixtures/configmap-openstack-1.16.0-adm-control.yaml
@@ -1,0 +1,6 @@
+data:
+  admission-control.yaml: |
+    kind: AdmissionConfiguration
+    apiVersion: apiserver.k8s.io/v1alpha1
+metadata:
+  creationTimestamp: null

--- a/api/pkg/resources/test/fixtures/configmap-openstack-1.17.0-adm-control.yaml
+++ b/api/pkg/resources/test/fixtures/configmap-openstack-1.17.0-adm-control.yaml
@@ -1,0 +1,6 @@
+data:
+  admission-control.yaml: |
+    kind: AdmissionConfiguration
+    apiVersion: apiserver.config.k8s.io/v1
+metadata:
+  creationTimestamp: null

--- a/api/pkg/resources/test/fixtures/configmap-openstack-1.18.0-adm-control.yaml
+++ b/api/pkg/resources/test/fixtures/configmap-openstack-1.18.0-adm-control.yaml
@@ -1,0 +1,6 @@
+data:
+  admission-control.yaml: |
+    kind: AdmissionConfiguration
+    apiVersion: apiserver.config.k8s.io/v1
+metadata:
+  creationTimestamp: null

--- a/api/pkg/resources/test/fixtures/configmap-vsphere-1.15.0-adm-control.yaml
+++ b/api/pkg/resources/test/fixtures/configmap-vsphere-1.15.0-adm-control.yaml
@@ -1,0 +1,6 @@
+data:
+  admission-control.yaml: |
+    kind: AdmissionConfiguration
+    apiVersion: apiserver.k8s.io/v1alpha1
+metadata:
+  creationTimestamp: null

--- a/api/pkg/resources/test/fixtures/configmap-vsphere-1.16.0-adm-control.yaml
+++ b/api/pkg/resources/test/fixtures/configmap-vsphere-1.16.0-adm-control.yaml
@@ -1,0 +1,6 @@
+data:
+  admission-control.yaml: |
+    kind: AdmissionConfiguration
+    apiVersion: apiserver.k8s.io/v1alpha1
+metadata:
+  creationTimestamp: null

--- a/api/pkg/resources/test/fixtures/configmap-vsphere-1.17.0-adm-control.yaml
+++ b/api/pkg/resources/test/fixtures/configmap-vsphere-1.17.0-adm-control.yaml
@@ -1,0 +1,6 @@
+data:
+  admission-control.yaml: |
+    kind: AdmissionConfiguration
+    apiVersion: apiserver.config.k8s.io/v1
+metadata:
+  creationTimestamp: null

--- a/api/pkg/resources/test/fixtures/configmap-vsphere-1.18.0-adm-control.yaml
+++ b/api/pkg/resources/test/fixtures/configmap-vsphere-1.18.0-adm-control.yaml
@@ -1,0 +1,6 @@
+data:
+  admission-control.yaml: |
+    kind: AdmissionConfiguration
+    apiVersion: apiserver.config.k8s.io/v1
+metadata:
+  creationTimestamp: null

--- a/api/pkg/resources/test/fixtures/deployment-aws-1.15.0-apiserver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-aws-1.15.0-apiserver.yaml
@@ -17,6 +17,7 @@ spec:
         prometheus.io/scrape_with_kube_cert: "true"
       creationTimestamp: null
       labels:
+        adm-control-configmap-revision: "123456"
         apiserver-etcd-client-certificate-secret-revision: "123456"
         apiserver-proxy-client-certificate-secret-revision: "123456"
         apiserver-tls-secret-revision: "123456"
@@ -151,6 +152,8 @@ spec:
         - etcd3
         - --enable-admission-plugins
         - DefaultStorageClass,DefaultTolerationSeconds,LimitRanger,MutatingAdmissionWebhook,NamespaceLifecycle,Priority,ResourceQuota,ServiceAccount,ValidatingAdmissionWebhook
+        - --admission-control-config-file
+        - /etc/kubernetes/adm-control/admission-control.yaml
         - --authorization-mode
         - Node,RBAC
         - --external-hostname
@@ -302,6 +305,9 @@ spec:
           readOnly: true
         - mountPath: /var/log/kubernetes/audit
           name: audit-log
+        - mountPath: /etc/kubernetes/adm-control
+          name: adm-control
+          readOnly: true
         - mountPath: /etc/kubernetes/dex/ca
           name: dex-ca
           readOnly: true
@@ -377,6 +383,9 @@ spec:
         name: audit-config
       - emptyDir: {}
         name: audit-log
+      - configMap:
+          name: adm-control
+        name: adm-control
       - name: dex-ca
         secret:
           secretName: dex-ca

--- a/api/pkg/resources/test/fixtures/deployment-aws-1.16.0-apiserver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-aws-1.16.0-apiserver.yaml
@@ -17,6 +17,7 @@ spec:
         prometheus.io/scrape_with_kube_cert: "true"
       creationTimestamp: null
       labels:
+        adm-control-configmap-revision: "123456"
         apiserver-etcd-client-certificate-secret-revision: "123456"
         apiserver-proxy-client-certificate-secret-revision: "123456"
         apiserver-tls-secret-revision: "123456"
@@ -151,6 +152,8 @@ spec:
         - etcd3
         - --enable-admission-plugins
         - DefaultStorageClass,DefaultTolerationSeconds,LimitRanger,MutatingAdmissionWebhook,NamespaceLifecycle,Priority,ResourceQuota,ServiceAccount,ValidatingAdmissionWebhook
+        - --admission-control-config-file
+        - /etc/kubernetes/adm-control/admission-control.yaml
         - --authorization-mode
         - Node,RBAC
         - --external-hostname
@@ -302,6 +305,9 @@ spec:
           readOnly: true
         - mountPath: /var/log/kubernetes/audit
           name: audit-log
+        - mountPath: /etc/kubernetes/adm-control
+          name: adm-control
+          readOnly: true
         - mountPath: /etc/kubernetes/dex/ca
           name: dex-ca
           readOnly: true
@@ -377,6 +383,9 @@ spec:
         name: audit-config
       - emptyDir: {}
         name: audit-log
+      - configMap:
+          name: adm-control
+        name: adm-control
       - name: dex-ca
         secret:
           secretName: dex-ca

--- a/api/pkg/resources/test/fixtures/deployment-aws-1.17.0-apiserver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-aws-1.17.0-apiserver.yaml
@@ -17,6 +17,7 @@ spec:
         prometheus.io/scrape_with_kube_cert: "true"
       creationTimestamp: null
       labels:
+        adm-control-configmap-revision: "123456"
         apiserver-etcd-client-certificate-secret-revision: "123456"
         apiserver-proxy-client-certificate-secret-revision: "123456"
         apiserver-tls-secret-revision: "123456"
@@ -151,6 +152,8 @@ spec:
         - etcd3
         - --enable-admission-plugins
         - DefaultStorageClass,DefaultTolerationSeconds,LimitRanger,MutatingAdmissionWebhook,NamespaceLifecycle,Priority,ResourceQuota,ServiceAccount,ValidatingAdmissionWebhook
+        - --admission-control-config-file
+        - /etc/kubernetes/adm-control/admission-control.yaml
         - --authorization-mode
         - Node,RBAC
         - --external-hostname
@@ -302,6 +305,9 @@ spec:
           readOnly: true
         - mountPath: /var/log/kubernetes/audit
           name: audit-log
+        - mountPath: /etc/kubernetes/adm-control
+          name: adm-control
+          readOnly: true
         - mountPath: /etc/kubernetes/dex/ca
           name: dex-ca
           readOnly: true
@@ -377,6 +383,9 @@ spec:
         name: audit-config
       - emptyDir: {}
         name: audit-log
+      - configMap:
+          name: adm-control
+        name: adm-control
       - name: dex-ca
         secret:
           secretName: dex-ca

--- a/api/pkg/resources/test/fixtures/deployment-aws-1.18.0-apiserver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-aws-1.18.0-apiserver.yaml
@@ -17,6 +17,7 @@ spec:
         prometheus.io/scrape_with_kube_cert: "true"
       creationTimestamp: null
       labels:
+        adm-control-configmap-revision: "123456"
         apiserver-etcd-client-certificate-secret-revision: "123456"
         apiserver-proxy-client-certificate-secret-revision: "123456"
         apiserver-tls-secret-revision: "123456"
@@ -151,6 +152,8 @@ spec:
         - etcd3
         - --enable-admission-plugins
         - DefaultStorageClass,DefaultTolerationSeconds,LimitRanger,MutatingAdmissionWebhook,NamespaceLifecycle,Priority,ResourceQuota,ServiceAccount,ValidatingAdmissionWebhook
+        - --admission-control-config-file
+        - /etc/kubernetes/adm-control/admission-control.yaml
         - --authorization-mode
         - Node,RBAC
         - --external-hostname
@@ -302,6 +305,9 @@ spec:
           readOnly: true
         - mountPath: /var/log/kubernetes/audit
           name: audit-log
+        - mountPath: /etc/kubernetes/adm-control
+          name: adm-control
+          readOnly: true
         - mountPath: /etc/kubernetes/dex/ca
           name: dex-ca
           readOnly: true
@@ -377,6 +383,9 @@ spec:
         name: audit-config
       - emptyDir: {}
         name: audit-log
+      - configMap:
+          name: adm-control
+        name: adm-control
       - name: dex-ca
         secret:
           secretName: dex-ca

--- a/api/pkg/resources/test/fixtures/deployment-azure-1.15.0-apiserver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-azure-1.15.0-apiserver.yaml
@@ -17,6 +17,7 @@ spec:
         prometheus.io/scrape_with_kube_cert: "true"
       creationTimestamp: null
       labels:
+        adm-control-configmap-revision: "123456"
         apiserver-etcd-client-certificate-secret-revision: "123456"
         apiserver-proxy-client-certificate-secret-revision: "123456"
         apiserver-tls-secret-revision: "123456"
@@ -151,6 +152,8 @@ spec:
         - etcd3
         - --enable-admission-plugins
         - DefaultStorageClass,DefaultTolerationSeconds,LimitRanger,MutatingAdmissionWebhook,NamespaceLifecycle,Priority,ResourceQuota,ServiceAccount,ValidatingAdmissionWebhook
+        - --admission-control-config-file
+        - /etc/kubernetes/adm-control/admission-control.yaml
         - --authorization-mode
         - Node,RBAC
         - --external-hostname
@@ -296,6 +299,9 @@ spec:
           readOnly: true
         - mountPath: /var/log/kubernetes/audit
           name: audit-log
+        - mountPath: /etc/kubernetes/adm-control
+          name: adm-control
+          readOnly: true
         - mountPath: /etc/kubernetes/dex/ca
           name: dex-ca
           readOnly: true
@@ -371,6 +377,9 @@ spec:
         name: audit-config
       - emptyDir: {}
         name: audit-log
+      - configMap:
+          name: adm-control
+        name: adm-control
       - name: dex-ca
         secret:
           secretName: dex-ca

--- a/api/pkg/resources/test/fixtures/deployment-azure-1.16.0-apiserver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-azure-1.16.0-apiserver.yaml
@@ -17,6 +17,7 @@ spec:
         prometheus.io/scrape_with_kube_cert: "true"
       creationTimestamp: null
       labels:
+        adm-control-configmap-revision: "123456"
         apiserver-etcd-client-certificate-secret-revision: "123456"
         apiserver-proxy-client-certificate-secret-revision: "123456"
         apiserver-tls-secret-revision: "123456"
@@ -151,6 +152,8 @@ spec:
         - etcd3
         - --enable-admission-plugins
         - DefaultStorageClass,DefaultTolerationSeconds,LimitRanger,MutatingAdmissionWebhook,NamespaceLifecycle,Priority,ResourceQuota,ServiceAccount,ValidatingAdmissionWebhook
+        - --admission-control-config-file
+        - /etc/kubernetes/adm-control/admission-control.yaml
         - --authorization-mode
         - Node,RBAC
         - --external-hostname
@@ -296,6 +299,9 @@ spec:
           readOnly: true
         - mountPath: /var/log/kubernetes/audit
           name: audit-log
+        - mountPath: /etc/kubernetes/adm-control
+          name: adm-control
+          readOnly: true
         - mountPath: /etc/kubernetes/dex/ca
           name: dex-ca
           readOnly: true
@@ -371,6 +377,9 @@ spec:
         name: audit-config
       - emptyDir: {}
         name: audit-log
+      - configMap:
+          name: adm-control
+        name: adm-control
       - name: dex-ca
         secret:
           secretName: dex-ca

--- a/api/pkg/resources/test/fixtures/deployment-azure-1.17.0-apiserver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-azure-1.17.0-apiserver.yaml
@@ -17,6 +17,7 @@ spec:
         prometheus.io/scrape_with_kube_cert: "true"
       creationTimestamp: null
       labels:
+        adm-control-configmap-revision: "123456"
         apiserver-etcd-client-certificate-secret-revision: "123456"
         apiserver-proxy-client-certificate-secret-revision: "123456"
         apiserver-tls-secret-revision: "123456"
@@ -151,6 +152,8 @@ spec:
         - etcd3
         - --enable-admission-plugins
         - DefaultStorageClass,DefaultTolerationSeconds,LimitRanger,MutatingAdmissionWebhook,NamespaceLifecycle,Priority,ResourceQuota,ServiceAccount,ValidatingAdmissionWebhook
+        - --admission-control-config-file
+        - /etc/kubernetes/adm-control/admission-control.yaml
         - --authorization-mode
         - Node,RBAC
         - --external-hostname
@@ -296,6 +299,9 @@ spec:
           readOnly: true
         - mountPath: /var/log/kubernetes/audit
           name: audit-log
+        - mountPath: /etc/kubernetes/adm-control
+          name: adm-control
+          readOnly: true
         - mountPath: /etc/kubernetes/dex/ca
           name: dex-ca
           readOnly: true
@@ -371,6 +377,9 @@ spec:
         name: audit-config
       - emptyDir: {}
         name: audit-log
+      - configMap:
+          name: adm-control
+        name: adm-control
       - name: dex-ca
         secret:
           secretName: dex-ca

--- a/api/pkg/resources/test/fixtures/deployment-azure-1.18.0-apiserver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-azure-1.18.0-apiserver.yaml
@@ -17,6 +17,7 @@ spec:
         prometheus.io/scrape_with_kube_cert: "true"
       creationTimestamp: null
       labels:
+        adm-control-configmap-revision: "123456"
         apiserver-etcd-client-certificate-secret-revision: "123456"
         apiserver-proxy-client-certificate-secret-revision: "123456"
         apiserver-tls-secret-revision: "123456"
@@ -151,6 +152,8 @@ spec:
         - etcd3
         - --enable-admission-plugins
         - DefaultStorageClass,DefaultTolerationSeconds,LimitRanger,MutatingAdmissionWebhook,NamespaceLifecycle,Priority,ResourceQuota,ServiceAccount,ValidatingAdmissionWebhook
+        - --admission-control-config-file
+        - /etc/kubernetes/adm-control/admission-control.yaml
         - --authorization-mode
         - Node,RBAC
         - --external-hostname
@@ -296,6 +299,9 @@ spec:
           readOnly: true
         - mountPath: /var/log/kubernetes/audit
           name: audit-log
+        - mountPath: /etc/kubernetes/adm-control
+          name: adm-control
+          readOnly: true
         - mountPath: /etc/kubernetes/dex/ca
           name: dex-ca
           readOnly: true
@@ -371,6 +377,9 @@ spec:
         name: audit-config
       - emptyDir: {}
         name: audit-log
+      - configMap:
+          name: adm-control
+        name: adm-control
       - name: dex-ca
         secret:
           secretName: dex-ca

--- a/api/pkg/resources/test/fixtures/deployment-bringyourown-1.15.0-apiserver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-bringyourown-1.15.0-apiserver.yaml
@@ -17,6 +17,7 @@ spec:
         prometheus.io/scrape_with_kube_cert: "true"
       creationTimestamp: null
       labels:
+        adm-control-configmap-revision: "123456"
         apiserver-etcd-client-certificate-secret-revision: "123456"
         apiserver-proxy-client-certificate-secret-revision: "123456"
         apiserver-tls-secret-revision: "123456"
@@ -151,6 +152,8 @@ spec:
         - etcd3
         - --enable-admission-plugins
         - DefaultStorageClass,DefaultTolerationSeconds,LimitRanger,MutatingAdmissionWebhook,NamespaceLifecycle,Priority,ResourceQuota,ServiceAccount,ValidatingAdmissionWebhook
+        - --admission-control-config-file
+        - /etc/kubernetes/adm-control/admission-control.yaml
         - --authorization-mode
         - Node,RBAC
         - --external-hostname
@@ -292,6 +295,9 @@ spec:
           readOnly: true
         - mountPath: /var/log/kubernetes/audit
           name: audit-log
+        - mountPath: /etc/kubernetes/adm-control
+          name: adm-control
+          readOnly: true
         - mountPath: /etc/kubernetes/dex/ca
           name: dex-ca
           readOnly: true
@@ -367,6 +373,9 @@ spec:
         name: audit-config
       - emptyDir: {}
         name: audit-log
+      - configMap:
+          name: adm-control
+        name: adm-control
       - name: dex-ca
         secret:
           secretName: dex-ca

--- a/api/pkg/resources/test/fixtures/deployment-bringyourown-1.16.0-apiserver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-bringyourown-1.16.0-apiserver.yaml
@@ -17,6 +17,7 @@ spec:
         prometheus.io/scrape_with_kube_cert: "true"
       creationTimestamp: null
       labels:
+        adm-control-configmap-revision: "123456"
         apiserver-etcd-client-certificate-secret-revision: "123456"
         apiserver-proxy-client-certificate-secret-revision: "123456"
         apiserver-tls-secret-revision: "123456"
@@ -151,6 +152,8 @@ spec:
         - etcd3
         - --enable-admission-plugins
         - DefaultStorageClass,DefaultTolerationSeconds,LimitRanger,MutatingAdmissionWebhook,NamespaceLifecycle,Priority,ResourceQuota,ServiceAccount,ValidatingAdmissionWebhook
+        - --admission-control-config-file
+        - /etc/kubernetes/adm-control/admission-control.yaml
         - --authorization-mode
         - Node,RBAC
         - --external-hostname
@@ -292,6 +295,9 @@ spec:
           readOnly: true
         - mountPath: /var/log/kubernetes/audit
           name: audit-log
+        - mountPath: /etc/kubernetes/adm-control
+          name: adm-control
+          readOnly: true
         - mountPath: /etc/kubernetes/dex/ca
           name: dex-ca
           readOnly: true
@@ -367,6 +373,9 @@ spec:
         name: audit-config
       - emptyDir: {}
         name: audit-log
+      - configMap:
+          name: adm-control
+        name: adm-control
       - name: dex-ca
         secret:
           secretName: dex-ca

--- a/api/pkg/resources/test/fixtures/deployment-bringyourown-1.17.0-apiserver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-bringyourown-1.17.0-apiserver.yaml
@@ -17,6 +17,7 @@ spec:
         prometheus.io/scrape_with_kube_cert: "true"
       creationTimestamp: null
       labels:
+        adm-control-configmap-revision: "123456"
         apiserver-etcd-client-certificate-secret-revision: "123456"
         apiserver-proxy-client-certificate-secret-revision: "123456"
         apiserver-tls-secret-revision: "123456"
@@ -151,6 +152,8 @@ spec:
         - etcd3
         - --enable-admission-plugins
         - DefaultStorageClass,DefaultTolerationSeconds,LimitRanger,MutatingAdmissionWebhook,NamespaceLifecycle,Priority,ResourceQuota,ServiceAccount,ValidatingAdmissionWebhook
+        - --admission-control-config-file
+        - /etc/kubernetes/adm-control/admission-control.yaml
         - --authorization-mode
         - Node,RBAC
         - --external-hostname
@@ -292,6 +295,9 @@ spec:
           readOnly: true
         - mountPath: /var/log/kubernetes/audit
           name: audit-log
+        - mountPath: /etc/kubernetes/adm-control
+          name: adm-control
+          readOnly: true
         - mountPath: /etc/kubernetes/dex/ca
           name: dex-ca
           readOnly: true
@@ -367,6 +373,9 @@ spec:
         name: audit-config
       - emptyDir: {}
         name: audit-log
+      - configMap:
+          name: adm-control
+        name: adm-control
       - name: dex-ca
         secret:
           secretName: dex-ca

--- a/api/pkg/resources/test/fixtures/deployment-bringyourown-1.18.0-apiserver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-bringyourown-1.18.0-apiserver.yaml
@@ -17,6 +17,7 @@ spec:
         prometheus.io/scrape_with_kube_cert: "true"
       creationTimestamp: null
       labels:
+        adm-control-configmap-revision: "123456"
         apiserver-etcd-client-certificate-secret-revision: "123456"
         apiserver-proxy-client-certificate-secret-revision: "123456"
         apiserver-tls-secret-revision: "123456"
@@ -151,6 +152,8 @@ spec:
         - etcd3
         - --enable-admission-plugins
         - DefaultStorageClass,DefaultTolerationSeconds,LimitRanger,MutatingAdmissionWebhook,NamespaceLifecycle,Priority,ResourceQuota,ServiceAccount,ValidatingAdmissionWebhook
+        - --admission-control-config-file
+        - /etc/kubernetes/adm-control/admission-control.yaml
         - --authorization-mode
         - Node,RBAC
         - --external-hostname
@@ -292,6 +295,9 @@ spec:
           readOnly: true
         - mountPath: /var/log/kubernetes/audit
           name: audit-log
+        - mountPath: /etc/kubernetes/adm-control
+          name: adm-control
+          readOnly: true
         - mountPath: /etc/kubernetes/dex/ca
           name: dex-ca
           readOnly: true
@@ -367,6 +373,9 @@ spec:
         name: audit-config
       - emptyDir: {}
         name: audit-log
+      - configMap:
+          name: adm-control
+        name: adm-control
       - name: dex-ca
         secret:
           secretName: dex-ca

--- a/api/pkg/resources/test/fixtures/deployment-digitalocean-1.15.0-apiserver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-digitalocean-1.15.0-apiserver.yaml
@@ -17,6 +17,7 @@ spec:
         prometheus.io/scrape_with_kube_cert: "true"
       creationTimestamp: null
       labels:
+        adm-control-configmap-revision: "123456"
         apiserver-etcd-client-certificate-secret-revision: "123456"
         apiserver-proxy-client-certificate-secret-revision: "123456"
         apiserver-tls-secret-revision: "123456"
@@ -151,6 +152,8 @@ spec:
         - etcd3
         - --enable-admission-plugins
         - DefaultStorageClass,DefaultTolerationSeconds,LimitRanger,MutatingAdmissionWebhook,NamespaceLifecycle,Priority,ResourceQuota,ServiceAccount,ValidatingAdmissionWebhook
+        - --admission-control-config-file
+        - /etc/kubernetes/adm-control/admission-control.yaml
         - --authorization-mode
         - Node,RBAC
         - --external-hostname
@@ -292,6 +295,9 @@ spec:
           readOnly: true
         - mountPath: /var/log/kubernetes/audit
           name: audit-log
+        - mountPath: /etc/kubernetes/adm-control
+          name: adm-control
+          readOnly: true
         - mountPath: /etc/kubernetes/dex/ca
           name: dex-ca
           readOnly: true
@@ -367,6 +373,9 @@ spec:
         name: audit-config
       - emptyDir: {}
         name: audit-log
+      - configMap:
+          name: adm-control
+        name: adm-control
       - name: dex-ca
         secret:
           secretName: dex-ca

--- a/api/pkg/resources/test/fixtures/deployment-digitalocean-1.16.0-apiserver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-digitalocean-1.16.0-apiserver.yaml
@@ -17,6 +17,7 @@ spec:
         prometheus.io/scrape_with_kube_cert: "true"
       creationTimestamp: null
       labels:
+        adm-control-configmap-revision: "123456"
         apiserver-etcd-client-certificate-secret-revision: "123456"
         apiserver-proxy-client-certificate-secret-revision: "123456"
         apiserver-tls-secret-revision: "123456"
@@ -151,6 +152,8 @@ spec:
         - etcd3
         - --enable-admission-plugins
         - DefaultStorageClass,DefaultTolerationSeconds,LimitRanger,MutatingAdmissionWebhook,NamespaceLifecycle,Priority,ResourceQuota,ServiceAccount,ValidatingAdmissionWebhook
+        - --admission-control-config-file
+        - /etc/kubernetes/adm-control/admission-control.yaml
         - --authorization-mode
         - Node,RBAC
         - --external-hostname
@@ -292,6 +295,9 @@ spec:
           readOnly: true
         - mountPath: /var/log/kubernetes/audit
           name: audit-log
+        - mountPath: /etc/kubernetes/adm-control
+          name: adm-control
+          readOnly: true
         - mountPath: /etc/kubernetes/dex/ca
           name: dex-ca
           readOnly: true
@@ -367,6 +373,9 @@ spec:
         name: audit-config
       - emptyDir: {}
         name: audit-log
+      - configMap:
+          name: adm-control
+        name: adm-control
       - name: dex-ca
         secret:
           secretName: dex-ca

--- a/api/pkg/resources/test/fixtures/deployment-digitalocean-1.17.0-apiserver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-digitalocean-1.17.0-apiserver.yaml
@@ -17,6 +17,7 @@ spec:
         prometheus.io/scrape_with_kube_cert: "true"
       creationTimestamp: null
       labels:
+        adm-control-configmap-revision: "123456"
         apiserver-etcd-client-certificate-secret-revision: "123456"
         apiserver-proxy-client-certificate-secret-revision: "123456"
         apiserver-tls-secret-revision: "123456"
@@ -151,6 +152,8 @@ spec:
         - etcd3
         - --enable-admission-plugins
         - DefaultStorageClass,DefaultTolerationSeconds,LimitRanger,MutatingAdmissionWebhook,NamespaceLifecycle,Priority,ResourceQuota,ServiceAccount,ValidatingAdmissionWebhook
+        - --admission-control-config-file
+        - /etc/kubernetes/adm-control/admission-control.yaml
         - --authorization-mode
         - Node,RBAC
         - --external-hostname
@@ -292,6 +295,9 @@ spec:
           readOnly: true
         - mountPath: /var/log/kubernetes/audit
           name: audit-log
+        - mountPath: /etc/kubernetes/adm-control
+          name: adm-control
+          readOnly: true
         - mountPath: /etc/kubernetes/dex/ca
           name: dex-ca
           readOnly: true
@@ -367,6 +373,9 @@ spec:
         name: audit-config
       - emptyDir: {}
         name: audit-log
+      - configMap:
+          name: adm-control
+        name: adm-control
       - name: dex-ca
         secret:
           secretName: dex-ca

--- a/api/pkg/resources/test/fixtures/deployment-digitalocean-1.18.0-apiserver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-digitalocean-1.18.0-apiserver.yaml
@@ -17,6 +17,7 @@ spec:
         prometheus.io/scrape_with_kube_cert: "true"
       creationTimestamp: null
       labels:
+        adm-control-configmap-revision: "123456"
         apiserver-etcd-client-certificate-secret-revision: "123456"
         apiserver-proxy-client-certificate-secret-revision: "123456"
         apiserver-tls-secret-revision: "123456"
@@ -151,6 +152,8 @@ spec:
         - etcd3
         - --enable-admission-plugins
         - DefaultStorageClass,DefaultTolerationSeconds,LimitRanger,MutatingAdmissionWebhook,NamespaceLifecycle,Priority,ResourceQuota,ServiceAccount,ValidatingAdmissionWebhook
+        - --admission-control-config-file
+        - /etc/kubernetes/adm-control/admission-control.yaml
         - --authorization-mode
         - Node,RBAC
         - --external-hostname
@@ -292,6 +295,9 @@ spec:
           readOnly: true
         - mountPath: /var/log/kubernetes/audit
           name: audit-log
+        - mountPath: /etc/kubernetes/adm-control
+          name: adm-control
+          readOnly: true
         - mountPath: /etc/kubernetes/dex/ca
           name: dex-ca
           readOnly: true
@@ -367,6 +373,9 @@ spec:
         name: audit-config
       - emptyDir: {}
         name: audit-log
+      - configMap:
+          name: adm-control
+        name: adm-control
       - name: dex-ca
         secret:
           secretName: dex-ca

--- a/api/pkg/resources/test/fixtures/deployment-openstack-1.15.0-apiserver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-openstack-1.15.0-apiserver.yaml
@@ -17,6 +17,7 @@ spec:
         prometheus.io/scrape_with_kube_cert: "true"
       creationTimestamp: null
       labels:
+        adm-control-configmap-revision: "123456"
         apiserver-etcd-client-certificate-secret-revision: "123456"
         apiserver-proxy-client-certificate-secret-revision: "123456"
         apiserver-tls-secret-revision: "123456"
@@ -151,6 +152,8 @@ spec:
         - etcd3
         - --enable-admission-plugins
         - DefaultStorageClass,DefaultTolerationSeconds,LimitRanger,MutatingAdmissionWebhook,NamespaceLifecycle,Priority,ResourceQuota,ServiceAccount,ValidatingAdmissionWebhook
+        - --admission-control-config-file
+        - /etc/kubernetes/adm-control/admission-control.yaml
         - --authorization-mode
         - Node,RBAC
         - --external-hostname
@@ -296,6 +299,9 @@ spec:
           readOnly: true
         - mountPath: /var/log/kubernetes/audit
           name: audit-log
+        - mountPath: /etc/kubernetes/adm-control
+          name: adm-control
+          readOnly: true
         - mountPath: /etc/kubernetes/dex/ca
           name: dex-ca
           readOnly: true
@@ -371,6 +377,9 @@ spec:
         name: audit-config
       - emptyDir: {}
         name: audit-log
+      - configMap:
+          name: adm-control
+        name: adm-control
       - name: dex-ca
         secret:
           secretName: dex-ca

--- a/api/pkg/resources/test/fixtures/deployment-openstack-1.16.0-apiserver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-openstack-1.16.0-apiserver.yaml
@@ -17,6 +17,7 @@ spec:
         prometheus.io/scrape_with_kube_cert: "true"
       creationTimestamp: null
       labels:
+        adm-control-configmap-revision: "123456"
         apiserver-etcd-client-certificate-secret-revision: "123456"
         apiserver-proxy-client-certificate-secret-revision: "123456"
         apiserver-tls-secret-revision: "123456"
@@ -151,6 +152,8 @@ spec:
         - etcd3
         - --enable-admission-plugins
         - DefaultStorageClass,DefaultTolerationSeconds,LimitRanger,MutatingAdmissionWebhook,NamespaceLifecycle,Priority,ResourceQuota,ServiceAccount,ValidatingAdmissionWebhook
+        - --admission-control-config-file
+        - /etc/kubernetes/adm-control/admission-control.yaml
         - --authorization-mode
         - Node,RBAC
         - --external-hostname
@@ -296,6 +299,9 @@ spec:
           readOnly: true
         - mountPath: /var/log/kubernetes/audit
           name: audit-log
+        - mountPath: /etc/kubernetes/adm-control
+          name: adm-control
+          readOnly: true
         - mountPath: /etc/kubernetes/dex/ca
           name: dex-ca
           readOnly: true
@@ -371,6 +377,9 @@ spec:
         name: audit-config
       - emptyDir: {}
         name: audit-log
+      - configMap:
+          name: adm-control
+        name: adm-control
       - name: dex-ca
         secret:
           secretName: dex-ca

--- a/api/pkg/resources/test/fixtures/deployment-openstack-1.17.0-apiserver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-openstack-1.17.0-apiserver.yaml
@@ -17,6 +17,7 @@ spec:
         prometheus.io/scrape_with_kube_cert: "true"
       creationTimestamp: null
       labels:
+        adm-control-configmap-revision: "123456"
         apiserver-etcd-client-certificate-secret-revision: "123456"
         apiserver-proxy-client-certificate-secret-revision: "123456"
         apiserver-tls-secret-revision: "123456"
@@ -151,6 +152,8 @@ spec:
         - etcd3
         - --enable-admission-plugins
         - DefaultStorageClass,DefaultTolerationSeconds,LimitRanger,MutatingAdmissionWebhook,NamespaceLifecycle,Priority,ResourceQuota,ServiceAccount,ValidatingAdmissionWebhook
+        - --admission-control-config-file
+        - /etc/kubernetes/adm-control/admission-control.yaml
         - --authorization-mode
         - Node,RBAC
         - --external-hostname
@@ -296,6 +299,9 @@ spec:
           readOnly: true
         - mountPath: /var/log/kubernetes/audit
           name: audit-log
+        - mountPath: /etc/kubernetes/adm-control
+          name: adm-control
+          readOnly: true
         - mountPath: /etc/kubernetes/dex/ca
           name: dex-ca
           readOnly: true
@@ -371,6 +377,9 @@ spec:
         name: audit-config
       - emptyDir: {}
         name: audit-log
+      - configMap:
+          name: adm-control
+        name: adm-control
       - name: dex-ca
         secret:
           secretName: dex-ca

--- a/api/pkg/resources/test/fixtures/deployment-openstack-1.18.0-apiserver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-openstack-1.18.0-apiserver.yaml
@@ -17,6 +17,7 @@ spec:
         prometheus.io/scrape_with_kube_cert: "true"
       creationTimestamp: null
       labels:
+        adm-control-configmap-revision: "123456"
         apiserver-etcd-client-certificate-secret-revision: "123456"
         apiserver-proxy-client-certificate-secret-revision: "123456"
         apiserver-tls-secret-revision: "123456"
@@ -151,6 +152,8 @@ spec:
         - etcd3
         - --enable-admission-plugins
         - DefaultStorageClass,DefaultTolerationSeconds,LimitRanger,MutatingAdmissionWebhook,NamespaceLifecycle,Priority,ResourceQuota,ServiceAccount,ValidatingAdmissionWebhook
+        - --admission-control-config-file
+        - /etc/kubernetes/adm-control/admission-control.yaml
         - --authorization-mode
         - Node,RBAC
         - --external-hostname
@@ -296,6 +299,9 @@ spec:
           readOnly: true
         - mountPath: /var/log/kubernetes/audit
           name: audit-log
+        - mountPath: /etc/kubernetes/adm-control
+          name: adm-control
+          readOnly: true
         - mountPath: /etc/kubernetes/dex/ca
           name: dex-ca
           readOnly: true
@@ -371,6 +377,9 @@ spec:
         name: audit-config
       - emptyDir: {}
         name: audit-log
+      - configMap:
+          name: adm-control
+        name: adm-control
       - name: dex-ca
         secret:
           secretName: dex-ca

--- a/api/pkg/resources/test/fixtures/deployment-vsphere-1.15.0-apiserver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-vsphere-1.15.0-apiserver.yaml
@@ -17,6 +17,7 @@ spec:
         prometheus.io/scrape_with_kube_cert: "true"
       creationTimestamp: null
       labels:
+        adm-control-configmap-revision: "123456"
         apiserver-etcd-client-certificate-secret-revision: "123456"
         apiserver-proxy-client-certificate-secret-revision: "123456"
         apiserver-tls-secret-revision: "123456"
@@ -151,6 +152,8 @@ spec:
         - etcd3
         - --enable-admission-plugins
         - DefaultStorageClass,DefaultTolerationSeconds,LimitRanger,MutatingAdmissionWebhook,NamespaceLifecycle,Priority,ResourceQuota,ServiceAccount,ValidatingAdmissionWebhook
+        - --admission-control-config-file
+        - /etc/kubernetes/adm-control/admission-control.yaml
         - --authorization-mode
         - Node,RBAC
         - --external-hostname
@@ -296,6 +299,9 @@ spec:
           readOnly: true
         - mountPath: /var/log/kubernetes/audit
           name: audit-log
+        - mountPath: /etc/kubernetes/adm-control
+          name: adm-control
+          readOnly: true
         - mountPath: /etc/kubernetes/dex/ca
           name: dex-ca
           readOnly: true
@@ -371,6 +377,9 @@ spec:
         name: audit-config
       - emptyDir: {}
         name: audit-log
+      - configMap:
+          name: adm-control
+        name: adm-control
       - name: dex-ca
         secret:
           secretName: dex-ca

--- a/api/pkg/resources/test/fixtures/deployment-vsphere-1.16.0-apiserver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-vsphere-1.16.0-apiserver.yaml
@@ -17,6 +17,7 @@ spec:
         prometheus.io/scrape_with_kube_cert: "true"
       creationTimestamp: null
       labels:
+        adm-control-configmap-revision: "123456"
         apiserver-etcd-client-certificate-secret-revision: "123456"
         apiserver-proxy-client-certificate-secret-revision: "123456"
         apiserver-tls-secret-revision: "123456"
@@ -151,6 +152,8 @@ spec:
         - etcd3
         - --enable-admission-plugins
         - DefaultStorageClass,DefaultTolerationSeconds,LimitRanger,MutatingAdmissionWebhook,NamespaceLifecycle,Priority,ResourceQuota,ServiceAccount,ValidatingAdmissionWebhook
+        - --admission-control-config-file
+        - /etc/kubernetes/adm-control/admission-control.yaml
         - --authorization-mode
         - Node,RBAC
         - --external-hostname
@@ -296,6 +299,9 @@ spec:
           readOnly: true
         - mountPath: /var/log/kubernetes/audit
           name: audit-log
+        - mountPath: /etc/kubernetes/adm-control
+          name: adm-control
+          readOnly: true
         - mountPath: /etc/kubernetes/dex/ca
           name: dex-ca
           readOnly: true
@@ -371,6 +377,9 @@ spec:
         name: audit-config
       - emptyDir: {}
         name: audit-log
+      - configMap:
+          name: adm-control
+        name: adm-control
       - name: dex-ca
         secret:
           secretName: dex-ca

--- a/api/pkg/resources/test/fixtures/deployment-vsphere-1.17.0-apiserver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-vsphere-1.17.0-apiserver.yaml
@@ -17,6 +17,7 @@ spec:
         prometheus.io/scrape_with_kube_cert: "true"
       creationTimestamp: null
       labels:
+        adm-control-configmap-revision: "123456"
         apiserver-etcd-client-certificate-secret-revision: "123456"
         apiserver-proxy-client-certificate-secret-revision: "123456"
         apiserver-tls-secret-revision: "123456"
@@ -151,6 +152,8 @@ spec:
         - etcd3
         - --enable-admission-plugins
         - DefaultStorageClass,DefaultTolerationSeconds,LimitRanger,MutatingAdmissionWebhook,NamespaceLifecycle,Priority,ResourceQuota,ServiceAccount,ValidatingAdmissionWebhook
+        - --admission-control-config-file
+        - /etc/kubernetes/adm-control/admission-control.yaml
         - --authorization-mode
         - Node,RBAC
         - --external-hostname
@@ -296,6 +299,9 @@ spec:
           readOnly: true
         - mountPath: /var/log/kubernetes/audit
           name: audit-log
+        - mountPath: /etc/kubernetes/adm-control
+          name: adm-control
+          readOnly: true
         - mountPath: /etc/kubernetes/dex/ca
           name: dex-ca
           readOnly: true
@@ -371,6 +377,9 @@ spec:
         name: audit-config
       - emptyDir: {}
         name: audit-log
+      - configMap:
+          name: adm-control
+        name: adm-control
       - name: dex-ca
         secret:
           secretName: dex-ca

--- a/api/pkg/resources/test/fixtures/deployment-vsphere-1.18.0-apiserver.yaml
+++ b/api/pkg/resources/test/fixtures/deployment-vsphere-1.18.0-apiserver.yaml
@@ -17,6 +17,7 @@ spec:
         prometheus.io/scrape_with_kube_cert: "true"
       creationTimestamp: null
       labels:
+        adm-control-configmap-revision: "123456"
         apiserver-etcd-client-certificate-secret-revision: "123456"
         apiserver-proxy-client-certificate-secret-revision: "123456"
         apiserver-tls-secret-revision: "123456"
@@ -151,6 +152,8 @@ spec:
         - etcd3
         - --enable-admission-plugins
         - DefaultStorageClass,DefaultTolerationSeconds,LimitRanger,MutatingAdmissionWebhook,NamespaceLifecycle,Priority,ResourceQuota,ServiceAccount,ValidatingAdmissionWebhook
+        - --admission-control-config-file
+        - /etc/kubernetes/adm-control/admission-control.yaml
         - --authorization-mode
         - Node,RBAC
         - --external-hostname
@@ -296,6 +299,9 @@ spec:
           readOnly: true
         - mountPath: /var/log/kubernetes/audit
           name: audit-log
+        - mountPath: /etc/kubernetes/adm-control
+          name: adm-control
+          readOnly: true
         - mountPath: /etc/kubernetes/dex/ca
           name: dex-ca
           readOnly: true
@@ -371,6 +377,9 @@ spec:
         name: audit-config
       - emptyDir: {}
         name: audit-log
+      - configMap:
+          name: adm-control
+        name: adm-control
       - name: dex-ca
         secret:
           secretName: dex-ca

--- a/api/pkg/resources/test/load_files_test.go
+++ b/api/pkg/resources/test/load_files_test.go
@@ -464,6 +464,13 @@ func TestLoadFiles(t *testing.T) {
 							Namespace:       cluster.Status.NamespaceName,
 						},
 					},
+					&corev1.ConfigMap{
+						ObjectMeta: metav1.ObjectMeta{
+							ResourceVersion: "123456",
+							Name:            resources.AdmissionControlConfigMapName,
+							Namespace:       cluster.Status.NamespaceName,
+						},
+					},
 					&corev1.Service{
 						ObjectMeta: metav1.ObjectMeta{
 							Name:      resources.ApiserverExternalServiceName,

--- a/api/pkg/test/e2e/api/utils/apiclient/models/cluster_spec.go
+++ b/api/pkg/test/e2e/api/utils/apiclient/models/cluster_spec.go
@@ -24,6 +24,16 @@ type ClusterSpec struct {
 	// MachineNetworks optionally specifies the parameters for IPAM.
 	MachineNetworks []*MachineNetworkingConfig `json:"machineNetworks"`
 
+	// PodNodeSelectorAdmissionPluginConfig provides the configuration for the PodNodeSelector.
+	// It's used by the backend to create a configuration file for this plugin.
+	// The key:value from the map is converted to the namespace:<node-selectors-labels> in the file.
+	// The format in a file:
+	// podNodeSelectorPluginConfig:
+	// clusterDefaultNodeSelector: <node-selectors-labels>
+	// namespace1: <node-selectors-labels>
+	// namespace2: <node-selectors-labels>
+	PodNodeSelectorAdmissionPluginConfig map[string]string `json:"podNodeSelectorAdmissionPluginConfig,omitempty"`
+
 	// If active the PodNodeSelector admission plugin is configured at the apiserver
 	UsePodNodeSelectorAdmissionPlugin bool `json:"usePodNodeSelectorAdmissionPlugin,omitempty"`
 


### PR DESCRIPTION
**What this PR does / why we need it**: [backport] add admission control configuration for the user cluster API deployment

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #6307


```release-note
add admission control configuration for the user cluster API deployment
```
