### PR TITLE
[Installer] Support setting up seed clusters

### DIFF
--- a/cmd/kubermatic-installer/cmd_deploy.go
+++ b/cmd/kubermatic-installer/cmd_deploy.go
@@ -29,7 +29,7 @@ import (
 
 	operatorv1alpha1 "k8c.io/kubermatic/v2/pkg/crd/operator/v1alpha1"
 	"k8c.io/kubermatic/v2/pkg/install/helm"
-	"k8c.io/kubermatic/v2/pkg/install/stack/kubermatic"
+	kubermaticmaster "k8c.io/kubermatic/v2/pkg/install/stack/kubermatic-master"
 	"k8c.io/kubermatic/v2/pkg/log"
 	"k8c.io/kubermatic/v2/pkg/util/edition"
 	"k8c.io/kubermatic/v2/pkg/util/yamled"
@@ -84,7 +84,7 @@ var (
 	}
 	deployStorageClassFlag = cli.StringFlag{
 		Name:  "storageclass",
-		Usage: fmt.Sprintf("Type of StorageClass to create (one of %v)", kubermatic.SupportedStorageClassProviders().List()),
+		Usage: fmt.Sprintf("Type of StorageClass to create (one of %v)", kubermaticmaster.SupportedStorageClassProviders().List()),
 	}
 )
 
@@ -175,7 +175,7 @@ func DeployAction(logger *logrus.Logger, versions kubermaticversion.Versions) cl
 
 		subLogger := log.Prefix(logrus.NewEntry(logger), "   ")
 
-		kubermaticConfig, helmValues, validationErrors := kubermatic.ValidateConfiguration(kubermaticConfig, helmValues, subLogger)
+		kubermaticConfig, helmValues, validationErrors := kubermaticmaster.ValidateConfiguration(kubermaticConfig, helmValues, subLogger)
 		if len(validationErrors) > 0 {
 			logger.Error("⛔ The provided configuration files are invalid:")
 
@@ -257,7 +257,7 @@ func DeployAction(logger *logrus.Logger, versions kubermaticversion.Versions) cl
 }
 
 func installKubermaticMasterStack(ctx context.Context, logger logrus.FieldLogger, opt *deployOptions) error {
-	supportedProviders := kubermatic.SupportedStorageClassProviders()
+	supportedProviders := kubermaticmaster.SupportedStorageClassProviders()
 	chosenProvider := opt.cli.String(deployStorageClassFlag.Name)
 	if chosenProvider != "" && !supportedProviders.Has(chosenProvider) {
 		return fmt.Errorf("invalid storage class provider %q given (--%s)", chosenProvider, deployStorageClassFlag.Name)
@@ -265,7 +265,7 @@ func installKubermaticMasterStack(ctx context.Context, logger logrus.FieldLogger
 
 	logger.Info("🧩 Deploying KKP master stack…")
 
-	options := kubermatic.Options{
+	options := kubermaticmaster.Options{
 		HelmValues:                 opt.helmValues,
 		KubermaticConfiguration:    opt.kubermaticConfig,
 		RawKubermaticConfiguration: opt.rawKubermaticConfig,
@@ -274,7 +274,7 @@ func installKubermaticMasterStack(ctx context.Context, logger logrus.FieldLogger
 		StorageClassProvider:       chosenProvider,
 	}
 
-	return kubermatic.Deploy(ctx, opt.subLogger, opt.kubeClient, opt.helmClient, options)
+	return kubermaticmaster.Deploy(ctx, opt.subLogger, opt.kubeClient, opt.helmClient, options)
 }
 
 func greeting() string {

--- a/cmd/kubermatic-installer/cmd_deploy.go
+++ b/cmd/kubermatic-installer/cmd_deploy.go
@@ -36,14 +36,11 @@ import (
 	kubermaticseed "k8c.io/kubermatic/v2/pkg/install/stack/kubermatic-seed"
 	"k8c.io/kubermatic/v2/pkg/log"
 	"k8c.io/kubermatic/v2/pkg/util/edition"
-	"k8c.io/kubermatic/v2/pkg/util/yamled"
 	kubermaticversion "k8c.io/kubermatic/v2/pkg/version/kubermatic"
 
 	certmanagerv1alpha2 "github.com/jetstack/cert-manager/pkg/apis/certmanager/v1alpha2"
 	apiextensionsv1beta1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1beta1"
-	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/util/wait"
-	ctrlruntimeclient "sigs.k8s.io/controller-runtime/pkg/client"
 	ctrlruntimeconfig "sigs.k8s.io/controller-runtime/pkg/client/config"
 	"sigs.k8s.io/controller-runtime/pkg/manager"
 )
@@ -109,16 +106,6 @@ func DeployCommand(logger *logrus.Logger, versions kubermaticversion.Versions) c
 			deployStorageClassFlag,
 		},
 	}
-}
-
-type deployOptions struct {
-	cli                 *cli.Context
-	subLogger           *logrus.Entry
-	helmClient          helm.Client
-	kubeClient          ctrlruntimeclient.Client
-	helmValues          *yamled.Document
-	kubermaticConfig    *operatorv1alpha1.KubermaticConfiguration
-	rawKubermaticConfig *unstructured.Unstructured
 }
 
 func DeployAction(logger *logrus.Logger, versions kubermaticversion.Versions) cli.ActionFunc {
@@ -266,7 +253,7 @@ func DeployAction(logger *logrus.Logger, versions kubermaticversion.Versions) cl
 			ChartsDirectory:            ctx.GlobalString(chartsDirectoryFlag.Name),
 		}
 
-		logger.Info("🧩 Deploying %s…", kubermaticStack.Name())
+		logger.Infof("🧩 Deploying %s…", kubermaticStack.Name())
 
 		if err := kubermaticStack.Deploy(appContext, opt); err != nil {
 			return err

--- a/cmd/kubermatic-installer/cmd_deploy.go
+++ b/cmd/kubermatic-installer/cmd_deploy.go
@@ -153,11 +153,10 @@ func DeployAction(logger *logrus.Logger, versions kubermaticversion.Versions) cl
 		case "kubermatic-master":
 			fallthrough
 
-		default:
+		case "":
 			kubermaticStack = kubermaticmaster.NewStack()
-		}
 
-		if kubermaticStack == nil {
+		default:
 			return fmt.Errorf("unknown stack %q specified", stackName)
 		}
 

--- a/pkg/install/stack/common/storageclass.go
+++ b/pkg/install/stack/common/storageclass.go
@@ -14,7 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package kubermaticmaster
+package common
 
 import (
 	"context"
@@ -26,6 +26,10 @@ import (
 	"k8s.io/apimachinery/pkg/util/sets"
 	"k8s.io/utils/pointer"
 	ctrlruntimeclient "sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+const (
+	StorageClassName = "kubermatic-fast"
 )
 
 type storageClassFactory func(context.Context, *logrus.Entry, ctrlruntimeclient.Client, string) (storagev1.StorageClass, error)
@@ -113,6 +117,15 @@ var (
 		},
 	}
 )
+
+func StorageClassCreator(provider string) (storageClassFactory, error) {
+	factory, ok := storageClassFactories[provider]
+	if !ok {
+		return nil, fmt.Errorf("unknown StorageClass provider %q", provider)
+	}
+
+	return factory, nil
+}
 
 func SupportedStorageClassProviders() sets.String {
 	return sets.StringKeySet(storageClassFactories)

--- a/pkg/install/stack/common/storageclass.go
+++ b/pkg/install/stack/common/storageclass.go
@@ -32,10 +32,10 @@ const (
 	StorageClassName = "kubermatic-fast"
 )
 
-type storageClassFactory func(context.Context, *logrus.Entry, ctrlruntimeclient.Client, string) (storagev1.StorageClass, error)
+type StorageClassFactory func(context.Context, *logrus.Entry, ctrlruntimeclient.Client, string) (storagev1.StorageClass, error)
 
 var (
-	storageClassFactories = map[string]storageClassFactory{
+	storageClassFactories = map[string]StorageClassFactory{
 		"copy-default": func(ctx context.Context, logger *logrus.Entry, kubeClient ctrlruntimeclient.Client, name string) (storagev1.StorageClass, error) {
 			s := &storagev1.StorageClass{
 				Parameters: map[string]string{},
@@ -118,7 +118,7 @@ var (
 	}
 )
 
-func StorageClassCreator(provider string) (storageClassFactory, error) {
+func StorageClassCreator(provider string) (StorageClassFactory, error) {
 	factory, ok := storageClassFactories[provider]
 	if !ok {
 		return nil, fmt.Errorf("unknown StorageClass provider %q", provider)

--- a/pkg/install/stack/common/validation.go
+++ b/pkg/install/stack/common/validation.go
@@ -1,0 +1,48 @@
+/*
+Copyright 2020 The Kubermatic Kubernetes Platform contributors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package common
+
+import (
+	"crypto/rand"
+	"encoding/base64"
+	"fmt"
+)
+
+func ValidateRandomSecret(value string, path string) error {
+	if value == "" {
+		secret, err := randomString()
+		if err == nil {
+			return fmt.Errorf("%s must be a non-empty secret, for example: %s", path, secret)
+		}
+
+		return fmt.Errorf("%s must be a non-empty secret", path)
+	}
+
+	return nil
+}
+
+func randomString() (string, error) {
+	c := 32
+	b := make([]byte, c)
+
+	_, err := rand.Read(b)
+	if err != nil {
+		return "", err
+	}
+
+	return base64.RawURLEncoding.EncodeToString(b), nil
+}

--- a/pkg/install/stack/kubermatic-master/certmanager.go
+++ b/pkg/install/stack/kubermatic-master/certmanager.go
@@ -14,7 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package kubermatic
+package kubermaticmaster
 
 import (
 	"context"

--- a/pkg/install/stack/kubermatic-master/stack.go
+++ b/pkg/install/stack/kubermatic-master/stack.go
@@ -69,11 +69,11 @@ func NewStack() stack.Stack {
 	return &MasterStack{}
 }
 
-func (_ *MasterStack) Name() string {
+func (*MasterStack) Name() string {
 	return "KKP master stack"
 }
 
-func (_ *MasterStack) Deploy(ctx context.Context, opt stack.DeployOptions) error {
+func (*MasterStack) Deploy(ctx context.Context, opt stack.DeployOptions) error {
 	if err := deployStorageClass(ctx, opt.Logger, opt.KubeClient, opt); err != nil {
 		return fmt.Errorf("failed to deploy StorageClass: %v", err)
 	}

--- a/pkg/install/stack/kubermatic-master/stack.go
+++ b/pkg/install/stack/kubermatic-master/stack.go
@@ -14,7 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package kubermatic
+package kubermaticmaster
 
 import (
 	"context"

--- a/pkg/install/stack/kubermatic-master/storageclass.go
+++ b/pkg/install/stack/kubermatic-master/storageclass.go
@@ -14,7 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package kubermatic
+package kubermaticmaster
 
 import (
 	"context"

--- a/pkg/install/stack/kubermatic-master/validation.go
+++ b/pkg/install/stack/kubermatic-master/validation.go
@@ -33,7 +33,7 @@ import (
 	"k8c.io/kubermatic/v2/pkg/util/yamled"
 )
 
-func ValidateConfiguration(config *operatorv1alpha1.KubermaticConfiguration, helmValues *yamled.Document, logger logrus.FieldLogger) (*operatorv1alpha1.KubermaticConfiguration, *yamled.Document, []error) {
+func (_ *MasterStack) ValidateConfiguration(config *operatorv1alpha1.KubermaticConfiguration, helmValues *yamled.Document, logger logrus.FieldLogger) (*operatorv1alpha1.KubermaticConfiguration, *yamled.Document, []error) {
 	kubermaticFailures := validateKubermaticConfiguration(config)
 	for idx, e := range kubermaticFailures {
 		kubermaticFailures[idx] = prefixError("KubermaticConfiguration: ", e)

--- a/pkg/install/stack/kubermatic-master/validation.go
+++ b/pkg/install/stack/kubermatic-master/validation.go
@@ -33,7 +33,7 @@ import (
 	"k8c.io/kubermatic/v2/pkg/util/yamled"
 )
 
-func (_ *MasterStack) ValidateConfiguration(config *operatorv1alpha1.KubermaticConfiguration, helmValues *yamled.Document, logger logrus.FieldLogger) (*operatorv1alpha1.KubermaticConfiguration, *yamled.Document, []error) {
+func (*MasterStack) ValidateConfiguration(config *operatorv1alpha1.KubermaticConfiguration, helmValues *yamled.Document, logger logrus.FieldLogger) (*operatorv1alpha1.KubermaticConfiguration, *yamled.Document, []error) {
 	kubermaticFailures := validateKubermaticConfiguration(config)
 	for idx, e := range kubermaticFailures {
 		kubermaticFailures[idx] = prefixError("KubermaticConfiguration: ", e)

--- a/pkg/install/stack/kubermatic-master/validation.go
+++ b/pkg/install/stack/kubermatic-master/validation.go
@@ -14,7 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package kubermatic
+package kubermaticmaster
 
 import (
 	"crypto/rand"

--- a/pkg/install/stack/kubermatic-seed/stack.go
+++ b/pkg/install/stack/kubermatic-seed/stack.go
@@ -56,11 +56,11 @@ func NewStack() stack.Stack {
 	return &SeedStack{}
 }
 
-func (_ *SeedStack) Name() string {
+func (*SeedStack) Name() string {
 	return "KKP seed stack"
 }
 
-func (_ *SeedStack) Deploy(ctx context.Context, opt stack.DeployOptions) error {
+func (*SeedStack) Deploy(ctx context.Context, opt stack.DeployOptions) error {
 	if err := deployStorageClass(ctx, opt.Logger, opt.KubeClient, opt); err != nil {
 		return fmt.Errorf("failed to deploy StorageClass: %v", err)
 	}
@@ -186,7 +186,7 @@ func deployS3Exporter(ctx context.Context, logger *logrus.Entry, kubeClient ctrl
 // showDNSSettings attempts to inform the user about required DNS settings
 // to be made. If errors happen, only warnings are printed, but the installation
 // can still succeed.
-func showDNSSettings(ctx context.Context, logger *logrus.Entry, kubeClient ctrlruntimeclient.Client, opt stack.DeployOptions) {
+func showDNSSettings(ctx context.Context, logger *logrus.Entry, kubeClient ctrlruntimeclient.Reader, opt stack.DeployOptions) {
 	logger.Info("📡 Determining DNS settings…")
 
 	logger = log.Prefix(logger, "   ")

--- a/pkg/install/stack/kubermatic-seed/stack.go
+++ b/pkg/install/stack/kubermatic-seed/stack.go
@@ -1,0 +1,256 @@
+/*
+Copyright 2020 The Kubermatic Kubernetes Platform contributors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package kubermaticseed
+
+import (
+	"context"
+	"fmt"
+	"path/filepath"
+	"time"
+
+	"github.com/sirupsen/logrus"
+
+	kubermaticv1 "k8c.io/kubermatic/v2/pkg/crd/kubermatic/v1"
+	operatorv1alpha1 "k8c.io/kubermatic/v2/pkg/crd/operator/v1alpha1"
+	"k8c.io/kubermatic/v2/pkg/install/helm"
+	"k8c.io/kubermatic/v2/pkg/install/stack/common"
+	kubermaticmaster "k8c.io/kubermatic/v2/pkg/install/stack/kubermatic-master"
+	"k8c.io/kubermatic/v2/pkg/install/util"
+	"k8c.io/kubermatic/v2/pkg/log"
+	"k8c.io/kubermatic/v2/pkg/util/yamled"
+
+	v1 "k8s.io/api/core/v1"
+	storagev1 "k8s.io/api/storage/v1"
+	kerrors "k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/apimachinery/pkg/util/wait"
+	ctrlruntimeclient "sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+const (
+	MinioChartName   = "minio"
+	MinioReleaseName = MinioChartName
+	MinioNamespace   = MinioChartName
+
+	S3ExporterChartName   = "kube-system"
+	S3ExporterReleaseName = S3ExporterChartName
+	S3ExporterNamespace   = S3ExporterChartName
+)
+
+type Options struct {
+	StorageClassProvider       string
+	HelmValues                 *yamled.Document
+	KubermaticConfiguration    *operatorv1alpha1.KubermaticConfiguration
+	RawKubermaticConfiguration *unstructured.Unstructured
+	ForceHelmReleaseUpgrade    bool
+	ChartsDirectory            string
+}
+
+func Deploy(ctx context.Context, logger *logrus.Entry, kubeClient ctrlruntimeclient.Client, helmClient helm.Client, opt Options) error {
+	if err := deployStorageClass(ctx, logger, kubeClient, opt); err != nil {
+		return fmt.Errorf("failed to deploy StorageClass: %v", err)
+	}
+
+	if err := deployMinio(ctx, logger, kubeClient, helmClient, opt); err != nil {
+		return fmt.Errorf("failed to deploy Minio: %v", err)
+	}
+
+	if err := deployS3Exporter(ctx, logger, kubeClient, helmClient, opt); err != nil {
+		return fmt.Errorf("failed to deploy S3 Exporter: %v", err)
+	}
+
+	showDNSSettings(ctx, logger, kubeClient, opt)
+
+	return nil
+}
+
+func deployStorageClass(ctx context.Context, logger *logrus.Entry, kubeClient ctrlruntimeclient.Client, opt Options) error {
+	logger.Infof("💾 Deploying %s StorageClass…", common.StorageClassName)
+	sublogger := log.Prefix(logger, "   ")
+
+	cls := storagev1.StorageClass{}
+	key := types.NamespacedName{Name: common.StorageClassName}
+
+	err := kubeClient.Get(ctx, key, &cls)
+
+	// storage class exists already
+	if err == nil {
+		logger.Info("✅ StorageClass exists, nothing to do.")
+		return nil
+	}
+
+	if !kerrors.IsNotFound(err) {
+		return fmt.Errorf("failed to check for StorageClass %s: %v", common.StorageClassName, err)
+	}
+
+	if opt.StorageClassProvider == "" {
+		sublogger.Warnf("The %s StorageClass does not exist yet. Depending on your environment,", common.StorageClassName)
+		sublogger.Warn("the installer can auto-create a class for you, see the --storageclass CLI flag.")
+		sublogger.Warn("Alternatively, please manually create a StorageClass and then re-run the installer to continue.")
+
+		return fmt.Errorf("no %s StorageClass found", common.StorageClassName)
+	}
+
+	factory, err := common.StorageClassCreator(opt.StorageClassProvider)
+	if err != nil {
+		return fmt.Errorf("invalid StorageClass provider: %v", err)
+	}
+
+	sc, err := factory(ctx, sublogger, kubeClient, common.StorageClassName)
+	if err != nil {
+		return fmt.Errorf("failed to define StorageClass: %v", err)
+	}
+
+	if err := kubeClient.Create(ctx, &sc); err != nil {
+		return fmt.Errorf("failed to create StorageClass: %v", err)
+	}
+
+	logger.Info("✅ Success.")
+
+	return nil
+}
+
+func deployMinio(ctx context.Context, logger *logrus.Entry, kubeClient ctrlruntimeclient.Client, helmClient helm.Client, opt Options) error {
+	logger.Info("📦 Deploying Minio…")
+	sublogger := log.Prefix(logger, "   ")
+
+	chart, err := helm.LoadChart(filepath.Join(opt.ChartsDirectory, "minio"))
+	if err != nil {
+		return fmt.Errorf("failed to load Helm chart: %v", err)
+	}
+
+	if err := util.EnsureNamespace(ctx, sublogger, kubeClient, MinioNamespace); err != nil {
+		return fmt.Errorf("failed to create namespace: %v", err)
+	}
+
+	release, err := util.CheckHelmRelease(ctx, sublogger, helmClient, MinioNamespace, MinioReleaseName)
+	if err != nil {
+		return fmt.Errorf("failed to check to Helm release: %v", err)
+	}
+
+	if err := util.DeployHelmChart(ctx, sublogger, helmClient, chart, MinioNamespace, MinioReleaseName, opt.HelmValues, true, opt.ForceHelmReleaseUpgrade, release); err != nil {
+		return fmt.Errorf("failed to deploy Helm release: %v", err)
+	}
+
+	logger.Info("✅ Success.")
+
+	return nil
+}
+
+func deployS3Exporter(ctx context.Context, logger *logrus.Entry, kubeClient ctrlruntimeclient.Client, helmClient helm.Client, opt Options) error {
+	logger.Info("📦 Deploying S3 Exporter…")
+	sublogger := log.Prefix(logger, "   ")
+
+	chart, err := helm.LoadChart(filepath.Join(opt.ChartsDirectory, "s3-exporter"))
+	if err != nil {
+		return fmt.Errorf("failed to load Helm chart: %v", err)
+	}
+
+	if err := util.EnsureNamespace(ctx, sublogger, kubeClient, S3ExporterNamespace); err != nil {
+		return fmt.Errorf("failed to create namespace: %v", err)
+	}
+
+	release, err := util.CheckHelmRelease(ctx, sublogger, helmClient, S3ExporterNamespace, S3ExporterReleaseName)
+	if err != nil {
+		return fmt.Errorf("failed to check to Helm release: %v", err)
+	}
+
+	if err := util.DeployHelmChart(ctx, sublogger, helmClient, chart, S3ExporterNamespace, S3ExporterReleaseName, opt.HelmValues, true, opt.ForceHelmReleaseUpgrade, release); err != nil {
+		return fmt.Errorf("failed to deploy Helm release: %v", err)
+	}
+
+	logger.Info("✅ Success.")
+
+	return nil
+}
+
+// showDNSSettings attempts to inform the user about required DNS settings
+// to be made. If errors happen, only warnings are printed, but the installation
+// can still succeed.
+func showDNSSettings(ctx context.Context, logger *logrus.Entry, kubeClient ctrlruntimeclient.Client, opt Options) {
+	logger.Info("📡 Determining DNS settings…")
+
+	logger = log.Prefix(logger, "   ")
+	ns := kubermaticmaster.KubermaticOperatorNamespace
+
+	// step 1: to ensure that a Seed has been created on the master, we check
+	// if the Seed's copy has already been created in this cluster (by the KKP
+	// seed-sync controller). Besides checking its existence, we also need to
+	// know the Seed's name to construct the FQDN for the DNS settings.
+	seedList := kubermaticv1.SeedList{}
+	err := kubeClient.List(ctx, &seedList, &ctrlruntimeclient.ListOptions{Namespace: ns})
+	if err != nil || len(seedList.Items) == 0 {
+		logger.Warnf("No Seed resource was found in the %s namespace.", ns)
+		logger.Warn("Make sure to create the Seed resource on the *master* cluster, from where KKP")
+		logger.Warn("will automatically synchronize it to the seed cluster. Once this is done, re-run")
+		logger.Warn("the installer to determine the DNS settings automatically.")
+		logger.Warn("If you already created the Seed resource and its copy is not present on the")
+		logger.Warn("seed cluster, check the KKP Master Controller's logs.")
+		return
+	}
+
+	// step 2: find the nodeport-proxy Service
+	svcName := types.NamespacedName{
+		Namespace: ns,
+		Name:      kubermaticmaster.NodePortProxyService,
+	}
+
+	logger.Debugf("Waiting for %q to be ready…", svcName)
+
+	var ingresses []v1.LoadBalancerIngress
+	err = wait.PollImmediate(5*time.Second, 3*time.Minute, func() (bool, error) {
+		svc := v1.Service{}
+		if err := kubeClient.Get(ctx, svcName, &svc); err != nil {
+			return false, err
+		}
+
+		ingresses = svc.Status.LoadBalancer.Ingress
+
+		return len(ingresses) > 0, nil
+	})
+	if err != nil {
+		logger.Warnf("Timed out waiting for the LoadBalancer service %q to become ready.", svcName)
+		logger.Warn("Note that the LoadBalancer is created by the KKP Operator after the Seed")
+		logger.Warn("resource is created on the *master* cluster. If the Seed is installed and")
+		logger.Warn("no LoadBalancer is provisioned, check the KKP Operator's logs.")
+		return
+	}
+
+	logger.Info("The main LoadBalancer is ready.")
+	logger.Info("")
+	logger.Infof("  Service             : %s / %s", svcName.Namespace, svcName.Name)
+
+	seed := seedList.Items[0]
+	domain := opt.KubermaticConfiguration.Spec.Ingress.Domain
+
+	if hostname := ingresses[0].Hostname; hostname != "" {
+		logger.Infof("  Ingress via hostname: %s", hostname)
+		logger.Info("")
+		logger.Infof("Please ensure your DNS settings for %q includes the following record:", domain)
+		logger.Info("")
+		logger.Infof("   *.%s.%s.  IN  CNAME  %s.", seed.Name, domain, hostname)
+	} else if ip := ingresses[0].IP; ip != "" {
+		logger.Infof("  Ingress via IP      : %s", ip)
+		logger.Info("")
+		logger.Infof("Please ensure your DNS settings for %q includes the following record:", domain)
+		logger.Info("")
+		logger.Infof("   *.%s.%s.  IN  A  %s", seed.Name, domain, ip)
+	}
+
+	logger.Info("")
+}

--- a/pkg/install/stack/kubermatic-seed/stack.go
+++ b/pkg/install/stack/kubermatic-seed/stack.go
@@ -45,9 +45,9 @@ const (
 	MinioReleaseName = MinioChartName
 	MinioNamespace   = MinioChartName
 
-	S3ExporterChartName   = "kube-system"
+	S3ExporterChartName   = "s3-exporter"
 	S3ExporterReleaseName = S3ExporterChartName
-	S3ExporterNamespace   = S3ExporterChartName
+	S3ExporterNamespace   = "kube-system"
 )
 
 type SeedStack struct{}

--- a/pkg/install/stack/kubermatic-seed/validation.go
+++ b/pkg/install/stack/kubermatic-seed/validation.go
@@ -1,0 +1,58 @@
+/*
+Copyright 2020 The Kubermatic Kubernetes Platform contributors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package kubermaticseed
+
+import (
+	"fmt"
+
+	"github.com/sirupsen/logrus"
+
+	operatorv1alpha1 "k8c.io/kubermatic/v2/pkg/crd/operator/v1alpha1"
+	"k8c.io/kubermatic/v2/pkg/install/stack/common"
+	"k8c.io/kubermatic/v2/pkg/util/yamled"
+)
+
+func ValidateConfiguration(config *operatorv1alpha1.KubermaticConfiguration, helmValues *yamled.Document, logger logrus.FieldLogger) (*operatorv1alpha1.KubermaticConfiguration, *yamled.Document, []error) {
+	helmFailures := validateHelmValues(helmValues)
+	for idx, e := range helmFailures {
+		helmFailures[idx] = prefixError("Helm values: ", e)
+	}
+
+	return config, helmValues, helmFailures
+}
+
+func validateHelmValues(helmValues *yamled.Document) []error {
+	failures := []error{}
+
+	path := yamled.Path{"minio", "credentials", "accessKey"}
+	accessKey, _ := helmValues.GetString(path)
+	if err := common.ValidateRandomSecret(accessKey, path.String()); err != nil {
+		failures = append(failures, err)
+	}
+
+	path = yamled.Path{"minio", "credentials", "secretKey"}
+	secretKey, _ := helmValues.GetString(path)
+	if err := common.ValidateRandomSecret(secretKey, path.String()); err != nil {
+		failures = append(failures, err)
+	}
+
+	return failures
+}
+
+func prefixError(prefix string, e error) error {
+	return fmt.Errorf("%s%v", prefix, e)
+}

--- a/pkg/install/stack/kubermatic-seed/validation.go
+++ b/pkg/install/stack/kubermatic-seed/validation.go
@@ -26,7 +26,7 @@ import (
 	"k8c.io/kubermatic/v2/pkg/util/yamled"
 )
 
-func ValidateConfiguration(config *operatorv1alpha1.KubermaticConfiguration, helmValues *yamled.Document, logger logrus.FieldLogger) (*operatorv1alpha1.KubermaticConfiguration, *yamled.Document, []error) {
+func (_ *SeedStack) ValidateConfiguration(config *operatorv1alpha1.KubermaticConfiguration, helmValues *yamled.Document, logger logrus.FieldLogger) (*operatorv1alpha1.KubermaticConfiguration, *yamled.Document, []error) {
 	helmFailures := validateHelmValues(helmValues)
 	for idx, e := range helmFailures {
 		helmFailures[idx] = prefixError("Helm values: ", e)

--- a/pkg/install/stack/kubermatic-seed/validation.go
+++ b/pkg/install/stack/kubermatic-seed/validation.go
@@ -26,7 +26,7 @@ import (
 	"k8c.io/kubermatic/v2/pkg/util/yamled"
 )
 
-func (_ *SeedStack) ValidateConfiguration(config *operatorv1alpha1.KubermaticConfiguration, helmValues *yamled.Document, logger logrus.FieldLogger) (*operatorv1alpha1.KubermaticConfiguration, *yamled.Document, []error) {
+func (*SeedStack) ValidateConfiguration(config *operatorv1alpha1.KubermaticConfiguration, helmValues *yamled.Document, logger logrus.FieldLogger) (*operatorv1alpha1.KubermaticConfiguration, *yamled.Document, []error) {
 	helmFailures := validateHelmValues(helmValues)
 	for idx, e := range helmFailures {
 		helmFailures[idx] = prefixError("Helm values: ", e)

--- a/pkg/install/stack/types.go
+++ b/pkg/install/stack/types.go
@@ -1,0 +1,32 @@
+package stack
+
+import (
+	"context"
+
+	"github.com/sirupsen/logrus"
+
+	operatorv1alpha1 "k8c.io/kubermatic/v2/pkg/crd/operator/v1alpha1"
+	"k8c.io/kubermatic/v2/pkg/install/helm"
+	"k8c.io/kubermatic/v2/pkg/util/yamled"
+
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	ctrlruntimeclient "sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+type DeployOptions struct {
+	HelmClient                 helm.Client
+	HelmValues                 *yamled.Document
+	KubeClient                 ctrlruntimeclient.Client
+	StorageClassProvider       string
+	KubermaticConfiguration    *operatorv1alpha1.KubermaticConfiguration
+	RawKubermaticConfiguration *unstructured.Unstructured
+	ForceHelmReleaseUpgrade    bool
+	ChartsDirectory            string
+	Logger                     *logrus.Entry
+}
+
+type Stack interface {
+	Name() string
+	ValidateConfiguration(config *operatorv1alpha1.KubermaticConfiguration, helmValues *yamled.Document, logger logrus.FieldLogger) (*operatorv1alpha1.KubermaticConfiguration, *yamled.Document, []error)
+	Deploy(ctx context.Context, opt DeployOptions) error
+}

--- a/pkg/install/stack/types.go
+++ b/pkg/install/stack/types.go
@@ -1,3 +1,19 @@
+/*
+Copyright 2020 The Kubermatic Kubernetes Platform contributors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
 package stack
 
 import (


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR extends the KKP installer to be able to provision seed clusters. While the KKP operator does most of the heavy lifting for KKP, the installer is still needed for Minio, S3-Exporter etc.

**Which issue(s) this PR fixes**:
Fixes #5870

**Does this PR introduce a user-facing change?**:
```release-note
Add `kubermatic-seed` stack target to the Installer
```
