### PR TITLE
Introduce task runner

### DIFF
--- a/codegen/reconcile/main.go
+++ b/codegen/reconcile/main.go
@@ -283,7 +283,9 @@ func {{ .APIVersionPrefix }}{{ .ResourceName }}ObjectWrapper(create {{ .APIVersi
 func Reconcile{{ .APIVersionPrefix }}{{ .ResourceNamePlural }}(ctx context.Context, namedGetters []Named{{ .APIVersionPrefix }}{{ .ResourceName }}CreatorGetter, namespace string, client ctrlruntimeclient.Client, objectModifiers ...ObjectModifier) error {
 	for _, get := range namedGetters {
 		name, create := get()
-		return Reconcile{{ .APIVersionPrefix }}{{ .ResourceName }}TaskFn(create, name, namespace, objectModifiers...)(ctx, client)
+		if err := Reconcile{{ .APIVersionPrefix }}{{ .ResourceName }}TaskFn(create, name, namespace, objectModifiers...)(ctx, client); err != nil {
+			return err
+		}
 	}
 
 	return nil

--- a/pkg/resources/reconciling/tasks_runner.go
+++ b/pkg/resources/reconciling/tasks_runner.go
@@ -107,7 +107,7 @@ func (tr *TasksGraphBuilder) AddTask(id TaskID, task TaskFn, dependencies ...Tas
 
 // Build creates a nes TaskGraph based on the TaskFn added so far.
 // It returns a non-nil error if some invariants are violated.
-// * All dependencies shoud be present.
+// * All dependencies should be present.
 // * No cycles between tasks.
 func (tr *TasksGraphBuilder) Build() (TasksGraph, error) {
 	tr.mark = make(map[*taskNode]struct{})
@@ -167,7 +167,7 @@ func (tr *TasksGraphBuilder) visitRec(n *taskNode) error {
 				return err
 			}
 		} else {
-			return fmt.Errorf("depenency of node %s was not found: %s", n.id, c)
+			return fmt.Errorf("dependency of node %s was not found: %s", n.id, c)
 		}
 	}
 

--- a/pkg/resources/reconciling/tasks_runner.go
+++ b/pkg/resources/reconciling/tasks_runner.go
@@ -1,0 +1,255 @@
+/*
+Copyright 2020 The Kubermatic Kubernetes Platform contributors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package reconciling
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	ctrlruntimeclient "sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+// TaskID represents the task identifier.
+type TaskID string
+
+// TaskIDSet is a set of TaskIDs
+type TaskIDSet map[TaskID]struct{}
+
+// Has returns true if and only if item is contained in the set.
+func (s TaskIDSet) Has(item TaskID) bool {
+	_, contained := s[item]
+	return contained
+}
+
+// TaskFn represents a reconciliation task.
+type TaskFn func(context.Context, ctrlruntimeclient.Client) error
+
+// taskNode represents a node of the taskGraph.
+type taskNode struct {
+	id   TaskID
+	task TaskFn
+	// Only populated after graph is built.
+	dependencies []*taskNode
+}
+
+func (tn *taskNode) String() string {
+	var deps []string
+	for _, d := range tn.dependencies {
+		deps = append(deps, string(d.id))
+	}
+	return fmt.Sprintf("ID: %s out edges: %v", tn.id, deps)
+}
+
+// TasksGraph is a DAG where each node represent a task. Task nodes are sorted
+// with topological ordering.
+//
+// This is useful to represent state-machines. e.g. migration tasks, updates.
+type TasksGraph []*taskNode
+
+// TasksGraphBuilder allows to create a TaskGraph.
+// It is not thread-safe.
+type TasksGraphBuilder struct {
+	// tasksMap maps a task id with the corresponding taskNode.
+	tasksMap map[TaskID]*taskNode
+	// dependenciesMap keeps track of dependencies to be able to build the graph.
+	// TODO(irozzo) Forbid forward references would make this unnecessary.
+	dependenciesMap map[TaskID][]TaskID
+
+	topologicalOrder []*taskNode
+	mark             map[*taskNode]struct{}
+	tempMark         map[*taskNode]struct{}
+}
+
+// TaskEventHandler can handle notifications for events that occur to a task.
+type TaskEventHandler interface {
+	// OnStarted is called when the task starts running.
+	OnStarted(TaskID)
+	// OnCompleted is called when the task completes.
+	OnSuccess(TaskID)
+	// OnSkipped is called when the task is skipped.
+	OnSkipped(TaskID)
+	// OnError is called when the task terminates with an error.
+	OnError(TaskID, error)
+}
+
+// NewTasksGraphBuilder creates a new TaskRunner.
+func NewTasksGraphBuilder() *TasksGraphBuilder {
+	return &TasksGraphBuilder{
+		tasksMap:        map[TaskID]*taskNode{},
+		dependenciesMap: map[TaskID][]TaskID{},
+	}
+}
+
+// AddTask adds a TaskFn to the TasksGraphBuilder with the given ID and
+// optional dependencies.
+func (tr *TasksGraphBuilder) AddTask(id TaskID, task TaskFn, dependencies ...TaskID) *TasksGraphBuilder {
+	n := &taskNode{id: id, task: task}
+	// TODO(irozzo): We should maybe check if node with such ID is already present?
+	tr.tasksMap[id] = n
+	tr.dependenciesMap[n.id] = dependencies
+	return tr
+}
+
+// Build creates a nes TaskGraph based on the TaskFn added so far.
+// It returns a non-nil error if some invariants are violated.
+// * All dependencies shoud be present.
+// * No cycles between tasks.
+func (tr *TasksGraphBuilder) Build() (TasksGraph, error) {
+	tr.mark = make(map[*taskNode]struct{})
+	tr.tempMark = make(map[*taskNode]struct{})
+	tr.topologicalOrder = make([]*taskNode, 0, len(tr.tasksMap))
+	for _, n := range tr.tasksMap {
+		if _, ok := tr.mark[n]; !ok {
+			if err := tr.visitRec(n); err != nil {
+				return nil, err
+			}
+		}
+	}
+	return TasksGraph(tr.topologicalOrder), nil
+}
+
+type cycleFoundError struct {
+	cycle []*taskNode
+}
+
+func (e *cycleFoundError) addNode(n *taskNode) {
+	e.cycle = append(e.cycle, n)
+}
+
+func (e *cycleFoundError) Error() string {
+	var b strings.Builder
+	b.WriteString("cycle was found in task graph: ")
+	for i := len(e.cycle) - 1; i >= 0; i-- {
+		b.WriteString(string(e.cycle[i].id))
+		if i > 0 {
+			b.WriteString(" -> ")
+		}
+	}
+	return b.String()
+}
+
+func (tr *TasksGraphBuilder) visitRec(n *taskNode) error {
+	if _, ok := tr.mark[n]; ok {
+		return nil
+	}
+	if _, ok := tr.tempMark[n]; ok {
+		return &cycleFoundError{[]*taskNode{n}}
+	}
+
+	// temporary mark the node.
+	tr.tempMark[n] = struct{}{}
+
+	n.dependencies = nil
+	for _, c := range tr.dependenciesMap[n.id] {
+		// re-initialize in case it is run multiple times.
+		if t, ok := tr.tasksMap[c]; ok {
+			n.dependencies = append(n.dependencies, t)
+			if err := tr.visitRec(t); err != nil {
+				// Construct the cycle path
+				if cerr, ok := err.(*cycleFoundError); ok {
+					cerr.addNode(n)
+				}
+				return err
+			}
+		} else {
+			return fmt.Errorf("depenency of node %s was not found: %s", n.id, c)
+		}
+	}
+
+	delete(tr.tempMark, n)
+	tr.mark[n] = struct{}{}
+	tr.topologicalOrder = append(tr.topologicalOrder, n)
+	return nil
+}
+
+// RunTasks executes the provided task graph.
+func RunTasks(ctx context.Context, client ctrlruntimeclient.Client, tasks TasksGraph, handlers ...TaskEventHandler) RunStatus {
+	runner := tasksRunner{ctx: ctx, client: client, eventHandlers: handlers}
+	return runner.run(tasks)
+}
+
+// RunStatus contains the results of the TaskGraph execution.
+type RunStatus struct {
+	SuccessTasks TaskIDSet
+	SkippedTasks TaskIDSet
+	FailedTasks  map[TaskID]error
+}
+
+// Error returns the error returned by the task execution or nil if it did not
+// return an error.
+func (s RunStatus) Error(id TaskID) error {
+	return s.FailedTasks[id]
+}
+
+// Failed returns the IDs of the tasks that failed during the execution.
+func (s RunStatus) Failed() []TaskID {
+	ids := make([]TaskID, len(s.FailedTasks), 0)
+	for id := range s.FailedTasks {
+		ids = append(ids, id)
+	}
+	return ids
+}
+
+// tasksRunner runs the tasks of the given TaskGraph.
+type tasksRunner struct {
+	RunStatus
+	ctx           context.Context
+	client        ctrlruntimeclient.Client
+	eventHandlers []TaskEventHandler
+}
+
+func (r *tasksRunner) run(g TasksGraph) RunStatus {
+	r.SuccessTasks = TaskIDSet{}
+	r.SkippedTasks = TaskIDSet{}
+	r.FailedTasks = map[TaskID]error{}
+
+OUTER:
+	for _, t := range g {
+		for _, d := range t.dependencies {
+			// Skip the task if any of the dependencies was not run or skipped.
+			if r.Error(d.id) != nil || r.SkippedTasks.Has(d.id) {
+				for _, h := range r.eventHandlers {
+					h.OnSkipped(t.id)
+				}
+				r.SkippedTasks[t.id] = struct{}{}
+				continue OUTER
+			}
+			if _, ok := r.SuccessTasks[d.id]; !ok {
+				// TODO(irozzo): We assume that task nodes in TaskGraph are sorted
+				// by topological ordering. Verify before running.
+				panic(fmt.Sprintf("task %s cannot be run as it depends on task %s that did not complete", t.id, d.id))
+			}
+		}
+		for _, h := range r.eventHandlers {
+			h.OnStarted(t.id)
+		}
+		if err := t.task(r.ctx, r.client); err != nil {
+			for _, h := range r.eventHandlers {
+				h.OnError(t.id, err)
+			}
+			r.FailedTasks[t.id] = err
+		} else {
+			for _, h := range r.eventHandlers {
+				h.OnSuccess(t.id)
+			}
+			r.SuccessTasks[t.id] = struct{}{}
+		}
+	}
+
+	return r.RunStatus
+}

--- a/pkg/resources/reconciling/tasks_runner.go
+++ b/pkg/resources/reconciling/tasks_runner.go
@@ -198,7 +198,7 @@ func (s RunStatus) Error(id TaskID) error {
 
 // Failed returns the IDs of the tasks that failed during the execution.
 func (s RunStatus) Failed() []TaskID {
-	ids := make([]TaskID, len(s.FailedTasks), 0)
+	ids := make([]TaskID, 0, len(s.FailedTasks))
 	for id := range s.FailedTasks {
 		ids = append(ids, id)
 	}

--- a/pkg/resources/reconciling/tasks_runner_test.go
+++ b/pkg/resources/reconciling/tasks_runner_test.go
@@ -1,0 +1,284 @@
+/*
+Copyright 2020 The Kubermatic Kubernetes Platform contributors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package reconciling
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"math/rand"
+	"testing"
+
+	"github.com/go-test/deep"
+	ctrlruntimeclient "sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+)
+
+func TestBuildTaskGraph(t *testing.T) {
+	tests := []struct {
+		name         string
+		graphBuilder *TasksGraphBuilder
+		expLength    int
+		expError     bool
+	}{
+		{
+			name: "Linear sequence",
+			graphBuilder: NewTasksGraphBuilder().
+				AddTask("task1", nopTaskFn).
+				AddTask("task2", nopTaskFn, "task1").
+				AddTask("task3", nopTaskFn, "task2"),
+			expLength: 3,
+		},
+		{
+			name: "Multiple dependencies",
+			graphBuilder: NewTasksGraphBuilder().
+				AddTask("task4", nopTaskFn, "task1", "task2", "task3").
+				AddTask("task1", nopTaskFn).
+				AddTask("task2", nopTaskFn).
+				AddTask("task3", nopTaskFn),
+			expLength: 4,
+		},
+		{
+			name: "Twisted",
+			graphBuilder: NewTasksGraphBuilder().
+				AddTask("task1", nopTaskFn).
+				AddTask("task2", nopTaskFn, "task1", "task3").
+				AddTask("task3", nopTaskFn, "task5").
+				AddTask("task4", nopTaskFn, "task2").
+				AddTask("task5", nopTaskFn, "task1"),
+			expLength: 5,
+		},
+		{
+			name: "Cycle",
+			graphBuilder: NewTasksGraphBuilder().
+				AddTask("task1", nopTaskFn, "task3").
+				AddTask("task2", nopTaskFn, "task1").
+				AddTask("task3", nopTaskFn, "task2"),
+			expError: true,
+		},
+		{
+			name: "Self cycle",
+			graphBuilder: NewTasksGraphBuilder().
+				AddTask("task1", nopTaskFn, "task1"),
+			expError: true,
+		},
+		{
+			name:         "Random DAG sparse",
+			graphBuilder: generateRandomDAG(1000, 0.1),
+			expError:     false,
+			expLength:    1000,
+		},
+		{
+			name:         "Random DAG tree",
+			graphBuilder: generateRandomDAG(1000, 0.9),
+			expError:     false,
+			expLength:    1000,
+		},
+		{
+			name:         "Random DAG tree complete",
+			graphBuilder: generateRandomDAG(1000, 1.0),
+			expError:     false,
+			expLength:    1000,
+		},
+		{
+			name:         "Random DAG tree no edges",
+			graphBuilder: generateRandomDAG(1000, 0.0),
+			expError:     false,
+			expLength:    1000,
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			g, err := test.graphBuilder.Build()
+			t.Logf("Graph: %v", g)
+			if (err != nil) != test.expError {
+				t.Errorf("error expected=%t, but got: %v", test.expError, err)
+			}
+			// if an error was expected the other tests are not relevant
+			if test.expError {
+				return
+			}
+			if e, a := test.expLength, len(g); e != a {
+				t.Errorf("expected %d nodes, but got: %d", e, a)
+			}
+			visited := map[*taskNode]struct{}{}
+			for _, n := range g {
+				if _, ok := visited[n]; ok {
+					t.Errorf("nodes should not be duplicated: %v", n)
+				}
+				for _, d := range n.dependencies {
+					if _, ok := visited[d]; !ok {
+						t.Errorf("task node %s should be placed after their dependencies: %s", n, d)
+					}
+				}
+				visited[n] = struct{}{}
+			}
+		})
+	}
+}
+
+func TestRunTaskGraph(t *testing.T) {
+	tests := []struct {
+		name      string
+		graph     TasksGraph
+		expStatus RunStatus
+	}{
+		{
+			name: "Base case",
+			graph: buildTaskGraphForTest(t, NewTasksGraphBuilder().
+				AddTask("task1", nopTaskFn).
+				AddTask("task2", nopTaskFn, "task1").
+				AddTask("task3", nopTaskFn, "task2")),
+			expStatus: RunStatus{
+				FailedTasks:  map[TaskID]error{},
+				SkippedTasks: map[TaskID]struct{}{},
+				SuccessTasks: map[TaskID]struct{}{
+					"task1": struct{}{},
+					"task2": struct{}{},
+					"task3": struct{}{},
+				},
+			},
+		},
+		{
+			name: "Skipped tasks",
+			graph: buildTaskGraphForTest(t, NewTasksGraphBuilder().
+				AddTask("task1", nopTaskFn).
+				AddTask("task2", nopTaskFn, "task1").
+				AddTask("task3", nopTaskFn, "task2").
+				AddTask("task4", failedTaskFn(errors.New("task 4 failed")), "task3").
+				AddTask("task5", nopTaskFn, "task4").
+				AddTask("task6", nopTaskFn, "task5")),
+			expStatus: RunStatus{
+				FailedTasks: map[TaskID]error{
+					"task4": errors.New("task 4 failed"),
+				},
+				SkippedTasks: map[TaskID]struct{}{
+					"task5": struct{}{},
+					"task6": struct{}{},
+				},
+				SuccessTasks: map[TaskID]struct{}{
+					"task1": struct{}{},
+					"task2": struct{}{},
+					"task3": struct{}{},
+				},
+			},
+		},
+		{
+			name: "No dependencies",
+			graph: buildTaskGraphForTest(t, NewTasksGraphBuilder().
+				AddTask("task1", nopTaskFn).
+				AddTask("task2", nopTaskFn).
+				AddTask("task3", nopTaskFn).
+				AddTask("task4", failedTaskFn(errors.New("task 4 failed"))).
+				AddTask("task5", nopTaskFn).
+				AddTask("task6", failedTaskFn(errors.New("task 6 failed")))),
+			expStatus: RunStatus{
+				FailedTasks: map[TaskID]error{
+					"task4": errors.New("task 4 failed"),
+					"task6": errors.New("task 6 failed"),
+				},
+				SkippedTasks: map[TaskID]struct{}{},
+				SuccessTasks: map[TaskID]struct{}{
+					"task1": struct{}{},
+					"task2": struct{}{},
+					"task3": struct{}{},
+					"task5": struct{}{},
+				},
+			},
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			rh := recordingHandler{}
+			res := RunTasks(context.TODO(), fake.NewFakeClient(), test.graph, &rh)
+			if diff := deep.Equal(res, test.expStatus); diff != nil {
+				t.Errorf("unexpected run status: %v", diff)
+			}
+			var expRunOrder []TaskID
+			// as tasks are run sequentially in the same gorouting so far we
+			// can expect that the completion order and the start order match.
+			// This login has to be changed if we parallelize tasks in future.
+			for i, _ := range test.graph {
+				expRunOrder = append(expRunOrder, test.graph[i].id)
+			}
+			if diff := deep.Equal(rh.runOrder, expRunOrder); diff != nil {
+				t.Errorf("unexpected completion order: %v", diff)
+			}
+		})
+	}
+}
+
+type recordingHandler struct {
+	runOrder []TaskID
+}
+
+func (h *recordingHandler) OnStarted(id TaskID) {
+	//NOP
+}
+func (h *recordingHandler) OnSuccess(id TaskID) {
+	h.runOrder = append(h.runOrder, id)
+}
+func (h *recordingHandler) OnSkipped(id TaskID) {
+	h.runOrder = append(h.runOrder, id)
+}
+func (h *recordingHandler) OnError(id TaskID, _ error) {
+	h.runOrder = append(h.runOrder, id)
+}
+
+func buildTaskGraphForTest(t *testing.T, b *TasksGraphBuilder) TasksGraph {
+	tg, err := b.Build()
+	if err != nil {
+		t.Fatalf("error occurred while building the TasksGraph: %v", err)
+		return TasksGraph{}
+	}
+	return tg
+}
+
+type dummyTask struct {
+	called bool
+	err    error
+}
+
+func (n *dummyTask) run(ctx context.Context, cli ctrlruntimeclient.Client) error {
+	n.called = true
+	return n.err
+}
+
+func failedTaskFn(err error) TaskFn {
+	return (&dummyTask{err: err}).run
+}
+
+func nopTaskFn(ctx context.Context, cli ctrlruntimeclient.Client) error {
+	return nil
+}
+
+func generateRandomDAG(numNodes int, edgeThreashold float64) *TasksGraphBuilder {
+	var t = NewTasksGraphBuilder()
+	var r = rand.New(rand.NewSource(123123))
+	for i := 0; i < numNodes; i++ {
+		var deps []TaskID
+		for j := 0; j < i; j++ {
+			if r.Float64() < edgeThreashold {
+				deps = append(deps, TaskID(fmt.Sprintf("task-%d", j)))
+			}
+		}
+		t.AddTask(TaskID(fmt.Sprintf("task-%d", i)), nopTaskFn, deps...)
+	}
+	return t
+}

--- a/pkg/resources/reconciling/tasks_runner_test.go
+++ b/pkg/resources/reconciling/tasks_runner_test.go
@@ -148,9 +148,9 @@ func TestRunTaskGraph(t *testing.T) {
 				FailedTasks:  map[TaskID]error{},
 				SkippedTasks: map[TaskID]struct{}{},
 				SuccessTasks: map[TaskID]struct{}{
-					"task1": struct{}{},
-					"task2": struct{}{},
-					"task3": struct{}{},
+					"task1": {},
+					"task2": {},
+					"task3": {},
 				},
 			},
 		},
@@ -168,13 +168,13 @@ func TestRunTaskGraph(t *testing.T) {
 					"task4": errors.New("task 4 failed"),
 				},
 				SkippedTasks: map[TaskID]struct{}{
-					"task5": struct{}{},
-					"task6": struct{}{},
+					"task5": {},
+					"task6": {},
 				},
 				SuccessTasks: map[TaskID]struct{}{
-					"task1": struct{}{},
-					"task2": struct{}{},
-					"task3": struct{}{},
+					"task1": {},
+					"task2": {},
+					"task3": {},
 				},
 			},
 		},
@@ -194,10 +194,10 @@ func TestRunTaskGraph(t *testing.T) {
 				},
 				SkippedTasks: map[TaskID]struct{}{},
 				SuccessTasks: map[TaskID]struct{}{
-					"task1": struct{}{},
-					"task2": struct{}{},
-					"task3": struct{}{},
-					"task5": struct{}{},
+					"task1": {},
+					"task2": {},
+					"task3": {},
+					"task5": {},
 				},
 			},
 		},
@@ -214,7 +214,7 @@ func TestRunTaskGraph(t *testing.T) {
 			// as tasks are run sequentially in the same gorouting so far we
 			// can expect that the completion order and the start order match.
 			// This login has to be changed if we parallelize tasks in future.
-			for i, _ := range test.graph {
+			for i := range test.graph {
 				expRunOrder = append(expRunOrder, test.graph[i].id)
 			}
 			if diff := deep.Equal(rh.runOrder, expRunOrder); diff != nil {

--- a/pkg/resources/reconciling/zz_generated_reconcile.go
+++ b/pkg/resources/reconciling/zz_generated_reconcile.go
@@ -45,7 +45,9 @@ func NamespaceObjectWrapper(create NamespaceCreator) ObjectCreator {
 func ReconcileNamespaces(ctx context.Context, namedGetters []NamedNamespaceCreatorGetter, namespace string, client ctrlruntimeclient.Client, objectModifiers ...ObjectModifier) error {
 	for _, get := range namedGetters {
 		name, create := get()
-		return ReconcileNamespaceTaskFn(create, name, namespace, objectModifiers...)(ctx, client)
+		if err := ReconcileNamespaceTaskFn(create, name, namespace, objectModifiers...)(ctx, client); err != nil {
+			return err
+		}
 	}
 
 	return nil
@@ -92,7 +94,9 @@ func ServiceObjectWrapper(create ServiceCreator) ObjectCreator {
 func ReconcileServices(ctx context.Context, namedGetters []NamedServiceCreatorGetter, namespace string, client ctrlruntimeclient.Client, objectModifiers ...ObjectModifier) error {
 	for _, get := range namedGetters {
 		name, create := get()
-		return ReconcileServiceTaskFn(create, name, namespace, objectModifiers...)(ctx, client)
+		if err := ReconcileServiceTaskFn(create, name, namespace, objectModifiers...)(ctx, client); err != nil {
+			return err
+		}
 	}
 
 	return nil
@@ -139,7 +143,9 @@ func SecretObjectWrapper(create SecretCreator) ObjectCreator {
 func ReconcileSecrets(ctx context.Context, namedGetters []NamedSecretCreatorGetter, namespace string, client ctrlruntimeclient.Client, objectModifiers ...ObjectModifier) error {
 	for _, get := range namedGetters {
 		name, create := get()
-		return ReconcileSecretTaskFn(create, name, namespace, objectModifiers...)(ctx, client)
+		if err := ReconcileSecretTaskFn(create, name, namespace, objectModifiers...)(ctx, client); err != nil {
+			return err
+		}
 	}
 
 	return nil
@@ -186,7 +192,9 @@ func ConfigMapObjectWrapper(create ConfigMapCreator) ObjectCreator {
 func ReconcileConfigMaps(ctx context.Context, namedGetters []NamedConfigMapCreatorGetter, namespace string, client ctrlruntimeclient.Client, objectModifiers ...ObjectModifier) error {
 	for _, get := range namedGetters {
 		name, create := get()
-		return ReconcileConfigMapTaskFn(create, name, namespace, objectModifiers...)(ctx, client)
+		if err := ReconcileConfigMapTaskFn(create, name, namespace, objectModifiers...)(ctx, client); err != nil {
+			return err
+		}
 	}
 
 	return nil
@@ -233,7 +241,9 @@ func ServiceAccountObjectWrapper(create ServiceAccountCreator) ObjectCreator {
 func ReconcileServiceAccounts(ctx context.Context, namedGetters []NamedServiceAccountCreatorGetter, namespace string, client ctrlruntimeclient.Client, objectModifiers ...ObjectModifier) error {
 	for _, get := range namedGetters {
 		name, create := get()
-		return ReconcileServiceAccountTaskFn(create, name, namespace, objectModifiers...)(ctx, client)
+		if err := ReconcileServiceAccountTaskFn(create, name, namespace, objectModifiers...)(ctx, client); err != nil {
+			return err
+		}
 	}
 
 	return nil
@@ -280,7 +290,9 @@ func StatefulSetObjectWrapper(create StatefulSetCreator) ObjectCreator {
 func ReconcileStatefulSets(ctx context.Context, namedGetters []NamedStatefulSetCreatorGetter, namespace string, client ctrlruntimeclient.Client, objectModifiers ...ObjectModifier) error {
 	for _, get := range namedGetters {
 		name, create := get()
-		return ReconcileStatefulSetTaskFn(create, name, namespace, objectModifiers...)(ctx, client)
+		if err := ReconcileStatefulSetTaskFn(create, name, namespace, objectModifiers...)(ctx, client); err != nil {
+			return err
+		}
 	}
 
 	return nil
@@ -328,7 +340,9 @@ func DeploymentObjectWrapper(create DeploymentCreator) ObjectCreator {
 func ReconcileDeployments(ctx context.Context, namedGetters []NamedDeploymentCreatorGetter, namespace string, client ctrlruntimeclient.Client, objectModifiers ...ObjectModifier) error {
 	for _, get := range namedGetters {
 		name, create := get()
-		return ReconcileDeploymentTaskFn(create, name, namespace, objectModifiers...)(ctx, client)
+		if err := ReconcileDeploymentTaskFn(create, name, namespace, objectModifiers...)(ctx, client); err != nil {
+			return err
+		}
 	}
 
 	return nil
@@ -376,7 +390,9 @@ func DaemonSetObjectWrapper(create DaemonSetCreator) ObjectCreator {
 func ReconcileDaemonSets(ctx context.Context, namedGetters []NamedDaemonSetCreatorGetter, namespace string, client ctrlruntimeclient.Client, objectModifiers ...ObjectModifier) error {
 	for _, get := range namedGetters {
 		name, create := get()
-		return ReconcileDaemonSetTaskFn(create, name, namespace, objectModifiers...)(ctx, client)
+		if err := ReconcileDaemonSetTaskFn(create, name, namespace, objectModifiers...)(ctx, client); err != nil {
+			return err
+		}
 	}
 
 	return nil
@@ -424,7 +440,9 @@ func PodDisruptionBudgetObjectWrapper(create PodDisruptionBudgetCreator) ObjectC
 func ReconcilePodDisruptionBudgets(ctx context.Context, namedGetters []NamedPodDisruptionBudgetCreatorGetter, namespace string, client ctrlruntimeclient.Client, objectModifiers ...ObjectModifier) error {
 	for _, get := range namedGetters {
 		name, create := get()
-		return ReconcilePodDisruptionBudgetTaskFn(create, name, namespace, objectModifiers...)(ctx, client)
+		if err := ReconcilePodDisruptionBudgetTaskFn(create, name, namespace, objectModifiers...)(ctx, client); err != nil {
+			return err
+		}
 	}
 
 	return nil
@@ -471,7 +489,9 @@ func VerticalPodAutoscalerObjectWrapper(create VerticalPodAutoscalerCreator) Obj
 func ReconcileVerticalPodAutoscalers(ctx context.Context, namedGetters []NamedVerticalPodAutoscalerCreatorGetter, namespace string, client ctrlruntimeclient.Client, objectModifiers ...ObjectModifier) error {
 	for _, get := range namedGetters {
 		name, create := get()
-		return ReconcileVerticalPodAutoscalerTaskFn(create, name, namespace, objectModifiers...)(ctx, client)
+		if err := ReconcileVerticalPodAutoscalerTaskFn(create, name, namespace, objectModifiers...)(ctx, client); err != nil {
+			return err
+		}
 	}
 
 	return nil
@@ -518,7 +538,9 @@ func ClusterRoleBindingObjectWrapper(create ClusterRoleBindingCreator) ObjectCre
 func ReconcileClusterRoleBindings(ctx context.Context, namedGetters []NamedClusterRoleBindingCreatorGetter, namespace string, client ctrlruntimeclient.Client, objectModifiers ...ObjectModifier) error {
 	for _, get := range namedGetters {
 		name, create := get()
-		return ReconcileClusterRoleBindingTaskFn(create, name, namespace, objectModifiers...)(ctx, client)
+		if err := ReconcileClusterRoleBindingTaskFn(create, name, namespace, objectModifiers...)(ctx, client); err != nil {
+			return err
+		}
 	}
 
 	return nil
@@ -565,7 +587,9 @@ func ClusterRoleObjectWrapper(create ClusterRoleCreator) ObjectCreator {
 func ReconcileClusterRoles(ctx context.Context, namedGetters []NamedClusterRoleCreatorGetter, namespace string, client ctrlruntimeclient.Client, objectModifiers ...ObjectModifier) error {
 	for _, get := range namedGetters {
 		name, create := get()
-		return ReconcileClusterRoleTaskFn(create, name, namespace, objectModifiers...)(ctx, client)
+		if err := ReconcileClusterRoleTaskFn(create, name, namespace, objectModifiers...)(ctx, client); err != nil {
+			return err
+		}
 	}
 
 	return nil
@@ -612,7 +636,9 @@ func RoleObjectWrapper(create RoleCreator) ObjectCreator {
 func ReconcileRoles(ctx context.Context, namedGetters []NamedRoleCreatorGetter, namespace string, client ctrlruntimeclient.Client, objectModifiers ...ObjectModifier) error {
 	for _, get := range namedGetters {
 		name, create := get()
-		return ReconcileRoleTaskFn(create, name, namespace, objectModifiers...)(ctx, client)
+		if err := ReconcileRoleTaskFn(create, name, namespace, objectModifiers...)(ctx, client); err != nil {
+			return err
+		}
 	}
 
 	return nil
@@ -659,7 +685,9 @@ func RoleBindingObjectWrapper(create RoleBindingCreator) ObjectCreator {
 func ReconcileRoleBindings(ctx context.Context, namedGetters []NamedRoleBindingCreatorGetter, namespace string, client ctrlruntimeclient.Client, objectModifiers ...ObjectModifier) error {
 	for _, get := range namedGetters {
 		name, create := get()
-		return ReconcileRoleBindingTaskFn(create, name, namespace, objectModifiers...)(ctx, client)
+		if err := ReconcileRoleBindingTaskFn(create, name, namespace, objectModifiers...)(ctx, client); err != nil {
+			return err
+		}
 	}
 
 	return nil
@@ -706,7 +734,9 @@ func CustomResourceDefinitionObjectWrapper(create CustomResourceDefinitionCreato
 func ReconcileCustomResourceDefinitions(ctx context.Context, namedGetters []NamedCustomResourceDefinitionCreatorGetter, namespace string, client ctrlruntimeclient.Client, objectModifiers ...ObjectModifier) error {
 	for _, get := range namedGetters {
 		name, create := get()
-		return ReconcileCustomResourceDefinitionTaskFn(create, name, namespace, objectModifiers...)(ctx, client)
+		if err := ReconcileCustomResourceDefinitionTaskFn(create, name, namespace, objectModifiers...)(ctx, client); err != nil {
+			return err
+		}
 	}
 
 	return nil
@@ -753,7 +783,9 @@ func CronJobObjectWrapper(create CronJobCreator) ObjectCreator {
 func ReconcileCronJobs(ctx context.Context, namedGetters []NamedCronJobCreatorGetter, namespace string, client ctrlruntimeclient.Client, objectModifiers ...ObjectModifier) error {
 	for _, get := range namedGetters {
 		name, create := get()
-		return ReconcileCronJobTaskFn(create, name, namespace, objectModifiers...)(ctx, client)
+		if err := ReconcileCronJobTaskFn(create, name, namespace, objectModifiers...)(ctx, client); err != nil {
+			return err
+		}
 	}
 
 	return nil
@@ -801,7 +833,9 @@ func MutatingWebhookConfigurationObjectWrapper(create MutatingWebhookConfigurati
 func ReconcileMutatingWebhookConfigurations(ctx context.Context, namedGetters []NamedMutatingWebhookConfigurationCreatorGetter, namespace string, client ctrlruntimeclient.Client, objectModifiers ...ObjectModifier) error {
 	for _, get := range namedGetters {
 		name, create := get()
-		return ReconcileMutatingWebhookConfigurationTaskFn(create, name, namespace, objectModifiers...)(ctx, client)
+		if err := ReconcileMutatingWebhookConfigurationTaskFn(create, name, namespace, objectModifiers...)(ctx, client); err != nil {
+			return err
+		}
 	}
 
 	return nil
@@ -848,7 +882,9 @@ func ValidatingWebhookConfigurationObjectWrapper(create ValidatingWebhookConfigu
 func ReconcileValidatingWebhookConfigurations(ctx context.Context, namedGetters []NamedValidatingWebhookConfigurationCreatorGetter, namespace string, client ctrlruntimeclient.Client, objectModifiers ...ObjectModifier) error {
 	for _, get := range namedGetters {
 		name, create := get()
-		return ReconcileValidatingWebhookConfigurationTaskFn(create, name, namespace, objectModifiers...)(ctx, client)
+		if err := ReconcileValidatingWebhookConfigurationTaskFn(create, name, namespace, objectModifiers...)(ctx, client); err != nil {
+			return err
+		}
 	}
 
 	return nil
@@ -895,7 +931,9 @@ func APIServiceObjectWrapper(create APIServiceCreator) ObjectCreator {
 func ReconcileAPIServices(ctx context.Context, namedGetters []NamedAPIServiceCreatorGetter, namespace string, client ctrlruntimeclient.Client, objectModifiers ...ObjectModifier) error {
 	for _, get := range namedGetters {
 		name, create := get()
-		return ReconcileAPIServiceTaskFn(create, name, namespace, objectModifiers...)(ctx, client)
+		if err := ReconcileAPIServiceTaskFn(create, name, namespace, objectModifiers...)(ctx, client); err != nil {
+			return err
+		}
 	}
 
 	return nil
@@ -942,7 +980,9 @@ func IngressObjectWrapper(create IngressCreator) ObjectCreator {
 func ReconcileIngresses(ctx context.Context, namedGetters []NamedIngressCreatorGetter, namespace string, client ctrlruntimeclient.Client, objectModifiers ...ObjectModifier) error {
 	for _, get := range namedGetters {
 		name, create := get()
-		return ReconcileIngressTaskFn(create, name, namespace, objectModifiers...)(ctx, client)
+		if err := ReconcileIngressTaskFn(create, name, namespace, objectModifiers...)(ctx, client); err != nil {
+			return err
+		}
 	}
 
 	return nil
@@ -989,7 +1029,9 @@ func SeedObjectWrapper(create SeedCreator) ObjectCreator {
 func ReconcileSeeds(ctx context.Context, namedGetters []NamedSeedCreatorGetter, namespace string, client ctrlruntimeclient.Client, objectModifiers ...ObjectModifier) error {
 	for _, get := range namedGetters {
 		name, create := get()
-		return ReconcileSeedTaskFn(create, name, namespace, objectModifiers...)(ctx, client)
+		if err := ReconcileSeedTaskFn(create, name, namespace, objectModifiers...)(ctx, client); err != nil {
+			return err
+		}
 	}
 
 	return nil
@@ -1036,7 +1078,9 @@ func CertificateObjectWrapper(create CertificateCreator) ObjectCreator {
 func ReconcileCertificates(ctx context.Context, namedGetters []NamedCertificateCreatorGetter, namespace string, client ctrlruntimeclient.Client, objectModifiers ...ObjectModifier) error {
 	for _, get := range namedGetters {
 		name, create := get()
-		return ReconcileCertificateTaskFn(create, name, namespace, objectModifiers...)(ctx, client)
+		if err := ReconcileCertificateTaskFn(create, name, namespace, objectModifiers...)(ctx, client); err != nil {
+			return err
+		}
 	}
 
 	return nil
@@ -1083,7 +1127,9 @@ func ConstraintTemplateObjectWrapper(create ConstraintTemplateCreator) ObjectCre
 func ReconcileConstraintTemplates(ctx context.Context, namedGetters []NamedConstraintTemplateCreatorGetter, namespace string, client ctrlruntimeclient.Client, objectModifiers ...ObjectModifier) error {
 	for _, get := range namedGetters {
 		name, create := get()
-		return ReconcileConstraintTemplateTaskFn(create, name, namespace, objectModifiers...)(ctx, client)
+		if err := ReconcileConstraintTemplateTaskFn(create, name, namespace, objectModifiers...)(ctx, client); err != nil {
+			return err
+		}
 	}
 
 	return nil
@@ -1130,7 +1176,9 @@ func KubermaticV1ConstraintTemplateObjectWrapper(create KubermaticV1ConstraintTe
 func ReconcileKubermaticV1ConstraintTemplates(ctx context.Context, namedGetters []NamedKubermaticV1ConstraintTemplateCreatorGetter, namespace string, client ctrlruntimeclient.Client, objectModifiers ...ObjectModifier) error {
 	for _, get := range namedGetters {
 		name, create := get()
-		return ReconcileKubermaticV1ConstraintTemplateTaskFn(create, name, namespace, objectModifiers...)(ctx, client)
+		if err := ReconcileKubermaticV1ConstraintTemplateTaskFn(create, name, namespace, objectModifiers...)(ctx, client); err != nil {
+			return err
+		}
 	}
 
 	return nil

--- a/pkg/resources/reconciling/zz_generated_reconcile.go
+++ b/pkg/resources/reconciling/zz_generated_reconcile.go
@@ -45,6 +45,16 @@ func NamespaceObjectWrapper(create NamespaceCreator) ObjectCreator {
 func ReconcileNamespaces(ctx context.Context, namedGetters []NamedNamespaceCreatorGetter, namespace string, client ctrlruntimeclient.Client, objectModifiers ...ObjectModifier) error {
 	for _, get := range namedGetters {
 		name, create := get()
+		return ReconcileNamespaceTaskFn(create, name, namespace, objectModifiers...)(ctx, client)
+	}
+
+	return nil
+}
+
+// ReconcileNamespaceTaskFn will return a TaskFn to create or update
+// the Namespace coming from the passed NamespaceCreator.
+func ReconcileNamespaceTaskFn(create NamespaceCreator, name, namespace string, objectModifiers ...ObjectModifier) TaskFn {
+	return func(ctx context.Context, client ctrlruntimeclient.Client) error {
 		createObject := NamespaceObjectWrapper(create)
 		createObject = createWithNamespace(createObject, namespace)
 		createObject = createWithName(createObject, name)
@@ -56,9 +66,9 @@ func ReconcileNamespaces(ctx context.Context, namedGetters []NamedNamespaceCreat
 		if err := EnsureNamedObject(ctx, types.NamespacedName{Namespace: namespace, Name: name}, createObject, client, &corev1.Namespace{}, false); err != nil {
 			return fmt.Errorf("failed to ensure Namespace %s/%s: %v", namespace, name, err)
 		}
-	}
 
-	return nil
+		return nil
+	}
 }
 
 // ServiceCreator defines an interface to create/update Services
@@ -82,6 +92,16 @@ func ServiceObjectWrapper(create ServiceCreator) ObjectCreator {
 func ReconcileServices(ctx context.Context, namedGetters []NamedServiceCreatorGetter, namespace string, client ctrlruntimeclient.Client, objectModifiers ...ObjectModifier) error {
 	for _, get := range namedGetters {
 		name, create := get()
+		return ReconcileServiceTaskFn(create, name, namespace, objectModifiers...)(ctx, client)
+	}
+
+	return nil
+}
+
+// ReconcileServiceTaskFn will return a TaskFn to create or update
+// the Service coming from the passed ServiceCreator.
+func ReconcileServiceTaskFn(create ServiceCreator, name, namespace string, objectModifiers ...ObjectModifier) TaskFn {
+	return func(ctx context.Context, client ctrlruntimeclient.Client) error {
 		createObject := ServiceObjectWrapper(create)
 		createObject = createWithNamespace(createObject, namespace)
 		createObject = createWithName(createObject, name)
@@ -93,9 +113,9 @@ func ReconcileServices(ctx context.Context, namedGetters []NamedServiceCreatorGe
 		if err := EnsureNamedObject(ctx, types.NamespacedName{Namespace: namespace, Name: name}, createObject, client, &corev1.Service{}, false); err != nil {
 			return fmt.Errorf("failed to ensure Service %s/%s: %v", namespace, name, err)
 		}
-	}
 
-	return nil
+		return nil
+	}
 }
 
 // SecretCreator defines an interface to create/update Secrets
@@ -119,6 +139,16 @@ func SecretObjectWrapper(create SecretCreator) ObjectCreator {
 func ReconcileSecrets(ctx context.Context, namedGetters []NamedSecretCreatorGetter, namespace string, client ctrlruntimeclient.Client, objectModifiers ...ObjectModifier) error {
 	for _, get := range namedGetters {
 		name, create := get()
+		return ReconcileSecretTaskFn(create, name, namespace, objectModifiers...)(ctx, client)
+	}
+
+	return nil
+}
+
+// ReconcileSecretTaskFn will return a TaskFn to create or update
+// the Secret coming from the passed SecretCreator.
+func ReconcileSecretTaskFn(create SecretCreator, name, namespace string, objectModifiers ...ObjectModifier) TaskFn {
+	return func(ctx context.Context, client ctrlruntimeclient.Client) error {
 		createObject := SecretObjectWrapper(create)
 		createObject = createWithNamespace(createObject, namespace)
 		createObject = createWithName(createObject, name)
@@ -130,9 +160,9 @@ func ReconcileSecrets(ctx context.Context, namedGetters []NamedSecretCreatorGett
 		if err := EnsureNamedObject(ctx, types.NamespacedName{Namespace: namespace, Name: name}, createObject, client, &corev1.Secret{}, false); err != nil {
 			return fmt.Errorf("failed to ensure Secret %s/%s: %v", namespace, name, err)
 		}
-	}
 
-	return nil
+		return nil
+	}
 }
 
 // ConfigMapCreator defines an interface to create/update ConfigMaps
@@ -156,6 +186,16 @@ func ConfigMapObjectWrapper(create ConfigMapCreator) ObjectCreator {
 func ReconcileConfigMaps(ctx context.Context, namedGetters []NamedConfigMapCreatorGetter, namespace string, client ctrlruntimeclient.Client, objectModifiers ...ObjectModifier) error {
 	for _, get := range namedGetters {
 		name, create := get()
+		return ReconcileConfigMapTaskFn(create, name, namespace, objectModifiers...)(ctx, client)
+	}
+
+	return nil
+}
+
+// ReconcileConfigMapTaskFn will return a TaskFn to create or update
+// the ConfigMap coming from the passed ConfigMapCreator.
+func ReconcileConfigMapTaskFn(create ConfigMapCreator, name, namespace string, objectModifiers ...ObjectModifier) TaskFn {
+	return func(ctx context.Context, client ctrlruntimeclient.Client) error {
 		createObject := ConfigMapObjectWrapper(create)
 		createObject = createWithNamespace(createObject, namespace)
 		createObject = createWithName(createObject, name)
@@ -167,9 +207,9 @@ func ReconcileConfigMaps(ctx context.Context, namedGetters []NamedConfigMapCreat
 		if err := EnsureNamedObject(ctx, types.NamespacedName{Namespace: namespace, Name: name}, createObject, client, &corev1.ConfigMap{}, false); err != nil {
 			return fmt.Errorf("failed to ensure ConfigMap %s/%s: %v", namespace, name, err)
 		}
-	}
 
-	return nil
+		return nil
+	}
 }
 
 // ServiceAccountCreator defines an interface to create/update ServiceAccounts
@@ -193,6 +233,16 @@ func ServiceAccountObjectWrapper(create ServiceAccountCreator) ObjectCreator {
 func ReconcileServiceAccounts(ctx context.Context, namedGetters []NamedServiceAccountCreatorGetter, namespace string, client ctrlruntimeclient.Client, objectModifiers ...ObjectModifier) error {
 	for _, get := range namedGetters {
 		name, create := get()
+		return ReconcileServiceAccountTaskFn(create, name, namespace, objectModifiers...)(ctx, client)
+	}
+
+	return nil
+}
+
+// ReconcileServiceAccountTaskFn will return a TaskFn to create or update
+// the ServiceAccount coming from the passed ServiceAccountCreator.
+func ReconcileServiceAccountTaskFn(create ServiceAccountCreator, name, namespace string, objectModifiers ...ObjectModifier) TaskFn {
+	return func(ctx context.Context, client ctrlruntimeclient.Client) error {
 		createObject := ServiceAccountObjectWrapper(create)
 		createObject = createWithNamespace(createObject, namespace)
 		createObject = createWithName(createObject, name)
@@ -204,9 +254,9 @@ func ReconcileServiceAccounts(ctx context.Context, namedGetters []NamedServiceAc
 		if err := EnsureNamedObject(ctx, types.NamespacedName{Namespace: namespace, Name: name}, createObject, client, &corev1.ServiceAccount{}, false); err != nil {
 			return fmt.Errorf("failed to ensure ServiceAccount %s/%s: %v", namespace, name, err)
 		}
-	}
 
-	return nil
+		return nil
+	}
 }
 
 // StatefulSetCreator defines an interface to create/update StatefulSets
@@ -230,6 +280,16 @@ func StatefulSetObjectWrapper(create StatefulSetCreator) ObjectCreator {
 func ReconcileStatefulSets(ctx context.Context, namedGetters []NamedStatefulSetCreatorGetter, namespace string, client ctrlruntimeclient.Client, objectModifiers ...ObjectModifier) error {
 	for _, get := range namedGetters {
 		name, create := get()
+		return ReconcileStatefulSetTaskFn(create, name, namespace, objectModifiers...)(ctx, client)
+	}
+
+	return nil
+}
+
+// ReconcileStatefulSetTaskFn will return a TaskFn to create or update
+// the StatefulSet coming from the passed StatefulSetCreator.
+func ReconcileStatefulSetTaskFn(create StatefulSetCreator, name, namespace string, objectModifiers ...ObjectModifier) TaskFn {
+	return func(ctx context.Context, client ctrlruntimeclient.Client) error {
 		create = DefaultStatefulSet(create)
 		createObject := StatefulSetObjectWrapper(create)
 		createObject = createWithNamespace(createObject, namespace)
@@ -242,9 +302,9 @@ func ReconcileStatefulSets(ctx context.Context, namedGetters []NamedStatefulSetC
 		if err := EnsureNamedObject(ctx, types.NamespacedName{Namespace: namespace, Name: name}, createObject, client, &appsv1.StatefulSet{}, false); err != nil {
 			return fmt.Errorf("failed to ensure StatefulSet %s/%s: %v", namespace, name, err)
 		}
-	}
 
-	return nil
+		return nil
+	}
 }
 
 // DeploymentCreator defines an interface to create/update Deployments
@@ -268,6 +328,16 @@ func DeploymentObjectWrapper(create DeploymentCreator) ObjectCreator {
 func ReconcileDeployments(ctx context.Context, namedGetters []NamedDeploymentCreatorGetter, namespace string, client ctrlruntimeclient.Client, objectModifiers ...ObjectModifier) error {
 	for _, get := range namedGetters {
 		name, create := get()
+		return ReconcileDeploymentTaskFn(create, name, namespace, objectModifiers...)(ctx, client)
+	}
+
+	return nil
+}
+
+// ReconcileDeploymentTaskFn will return a TaskFn to create or update
+// the Deployment coming from the passed DeploymentCreator.
+func ReconcileDeploymentTaskFn(create DeploymentCreator, name, namespace string, objectModifiers ...ObjectModifier) TaskFn {
+	return func(ctx context.Context, client ctrlruntimeclient.Client) error {
 		create = DefaultDeployment(create)
 		createObject := DeploymentObjectWrapper(create)
 		createObject = createWithNamespace(createObject, namespace)
@@ -280,9 +350,9 @@ func ReconcileDeployments(ctx context.Context, namedGetters []NamedDeploymentCre
 		if err := EnsureNamedObject(ctx, types.NamespacedName{Namespace: namespace, Name: name}, createObject, client, &appsv1.Deployment{}, false); err != nil {
 			return fmt.Errorf("failed to ensure Deployment %s/%s: %v", namespace, name, err)
 		}
-	}
 
-	return nil
+		return nil
+	}
 }
 
 // DaemonSetCreator defines an interface to create/update DaemonSets
@@ -306,6 +376,16 @@ func DaemonSetObjectWrapper(create DaemonSetCreator) ObjectCreator {
 func ReconcileDaemonSets(ctx context.Context, namedGetters []NamedDaemonSetCreatorGetter, namespace string, client ctrlruntimeclient.Client, objectModifiers ...ObjectModifier) error {
 	for _, get := range namedGetters {
 		name, create := get()
+		return ReconcileDaemonSetTaskFn(create, name, namespace, objectModifiers...)(ctx, client)
+	}
+
+	return nil
+}
+
+// ReconcileDaemonSetTaskFn will return a TaskFn to create or update
+// the DaemonSet coming from the passed DaemonSetCreator.
+func ReconcileDaemonSetTaskFn(create DaemonSetCreator, name, namespace string, objectModifiers ...ObjectModifier) TaskFn {
+	return func(ctx context.Context, client ctrlruntimeclient.Client) error {
 		create = DefaultDaemonSet(create)
 		createObject := DaemonSetObjectWrapper(create)
 		createObject = createWithNamespace(createObject, namespace)
@@ -318,9 +398,9 @@ func ReconcileDaemonSets(ctx context.Context, namedGetters []NamedDaemonSetCreat
 		if err := EnsureNamedObject(ctx, types.NamespacedName{Namespace: namespace, Name: name}, createObject, client, &appsv1.DaemonSet{}, false); err != nil {
 			return fmt.Errorf("failed to ensure DaemonSet %s/%s: %v", namespace, name, err)
 		}
-	}
 
-	return nil
+		return nil
+	}
 }
 
 // PodDisruptionBudgetCreator defines an interface to create/update PodDisruptionBudgets
@@ -344,6 +424,16 @@ func PodDisruptionBudgetObjectWrapper(create PodDisruptionBudgetCreator) ObjectC
 func ReconcilePodDisruptionBudgets(ctx context.Context, namedGetters []NamedPodDisruptionBudgetCreatorGetter, namespace string, client ctrlruntimeclient.Client, objectModifiers ...ObjectModifier) error {
 	for _, get := range namedGetters {
 		name, create := get()
+		return ReconcilePodDisruptionBudgetTaskFn(create, name, namespace, objectModifiers...)(ctx, client)
+	}
+
+	return nil
+}
+
+// ReconcilePodDisruptionBudgetTaskFn will return a TaskFn to create or update
+// the PodDisruptionBudget coming from the passed PodDisruptionBudgetCreator.
+func ReconcilePodDisruptionBudgetTaskFn(create PodDisruptionBudgetCreator, name, namespace string, objectModifiers ...ObjectModifier) TaskFn {
+	return func(ctx context.Context, client ctrlruntimeclient.Client) error {
 		createObject := PodDisruptionBudgetObjectWrapper(create)
 		createObject = createWithNamespace(createObject, namespace)
 		createObject = createWithName(createObject, name)
@@ -355,9 +445,9 @@ func ReconcilePodDisruptionBudgets(ctx context.Context, namedGetters []NamedPodD
 		if err := EnsureNamedObject(ctx, types.NamespacedName{Namespace: namespace, Name: name}, createObject, client, &policyv1beta1.PodDisruptionBudget{}, true); err != nil {
 			return fmt.Errorf("failed to ensure PodDisruptionBudget %s/%s: %v", namespace, name, err)
 		}
-	}
 
-	return nil
+		return nil
+	}
 }
 
 // VerticalPodAutoscalerCreator defines an interface to create/update VerticalPodAutoscalers
@@ -381,6 +471,16 @@ func VerticalPodAutoscalerObjectWrapper(create VerticalPodAutoscalerCreator) Obj
 func ReconcileVerticalPodAutoscalers(ctx context.Context, namedGetters []NamedVerticalPodAutoscalerCreatorGetter, namespace string, client ctrlruntimeclient.Client, objectModifiers ...ObjectModifier) error {
 	for _, get := range namedGetters {
 		name, create := get()
+		return ReconcileVerticalPodAutoscalerTaskFn(create, name, namespace, objectModifiers...)(ctx, client)
+	}
+
+	return nil
+}
+
+// ReconcileVerticalPodAutoscalerTaskFn will return a TaskFn to create or update
+// the VerticalPodAutoscaler coming from the passed VerticalPodAutoscalerCreator.
+func ReconcileVerticalPodAutoscalerTaskFn(create VerticalPodAutoscalerCreator, name, namespace string, objectModifiers ...ObjectModifier) TaskFn {
+	return func(ctx context.Context, client ctrlruntimeclient.Client) error {
 		createObject := VerticalPodAutoscalerObjectWrapper(create)
 		createObject = createWithNamespace(createObject, namespace)
 		createObject = createWithName(createObject, name)
@@ -392,9 +492,9 @@ func ReconcileVerticalPodAutoscalers(ctx context.Context, namedGetters []NamedVe
 		if err := EnsureNamedObject(ctx, types.NamespacedName{Namespace: namespace, Name: name}, createObject, client, &autoscalingv1beta2.VerticalPodAutoscaler{}, false); err != nil {
 			return fmt.Errorf("failed to ensure VerticalPodAutoscaler %s/%s: %v", namespace, name, err)
 		}
-	}
 
-	return nil
+		return nil
+	}
 }
 
 // ClusterRoleBindingCreator defines an interface to create/update ClusterRoleBindings
@@ -418,6 +518,16 @@ func ClusterRoleBindingObjectWrapper(create ClusterRoleBindingCreator) ObjectCre
 func ReconcileClusterRoleBindings(ctx context.Context, namedGetters []NamedClusterRoleBindingCreatorGetter, namespace string, client ctrlruntimeclient.Client, objectModifiers ...ObjectModifier) error {
 	for _, get := range namedGetters {
 		name, create := get()
+		return ReconcileClusterRoleBindingTaskFn(create, name, namespace, objectModifiers...)(ctx, client)
+	}
+
+	return nil
+}
+
+// ReconcileClusterRoleBindingTaskFn will return a TaskFn to create or update
+// the ClusterRoleBinding coming from the passed ClusterRoleBindingCreator.
+func ReconcileClusterRoleBindingTaskFn(create ClusterRoleBindingCreator, name, namespace string, objectModifiers ...ObjectModifier) TaskFn {
+	return func(ctx context.Context, client ctrlruntimeclient.Client) error {
 		createObject := ClusterRoleBindingObjectWrapper(create)
 		createObject = createWithNamespace(createObject, namespace)
 		createObject = createWithName(createObject, name)
@@ -429,9 +539,9 @@ func ReconcileClusterRoleBindings(ctx context.Context, namedGetters []NamedClust
 		if err := EnsureNamedObject(ctx, types.NamespacedName{Namespace: namespace, Name: name}, createObject, client, &rbacv1.ClusterRoleBinding{}, false); err != nil {
 			return fmt.Errorf("failed to ensure ClusterRoleBinding %s/%s: %v", namespace, name, err)
 		}
-	}
 
-	return nil
+		return nil
+	}
 }
 
 // ClusterRoleCreator defines an interface to create/update ClusterRoles
@@ -455,6 +565,16 @@ func ClusterRoleObjectWrapper(create ClusterRoleCreator) ObjectCreator {
 func ReconcileClusterRoles(ctx context.Context, namedGetters []NamedClusterRoleCreatorGetter, namespace string, client ctrlruntimeclient.Client, objectModifiers ...ObjectModifier) error {
 	for _, get := range namedGetters {
 		name, create := get()
+		return ReconcileClusterRoleTaskFn(create, name, namespace, objectModifiers...)(ctx, client)
+	}
+
+	return nil
+}
+
+// ReconcileClusterRoleTaskFn will return a TaskFn to create or update
+// the ClusterRole coming from the passed ClusterRoleCreator.
+func ReconcileClusterRoleTaskFn(create ClusterRoleCreator, name, namespace string, objectModifiers ...ObjectModifier) TaskFn {
+	return func(ctx context.Context, client ctrlruntimeclient.Client) error {
 		createObject := ClusterRoleObjectWrapper(create)
 		createObject = createWithNamespace(createObject, namespace)
 		createObject = createWithName(createObject, name)
@@ -466,9 +586,9 @@ func ReconcileClusterRoles(ctx context.Context, namedGetters []NamedClusterRoleC
 		if err := EnsureNamedObject(ctx, types.NamespacedName{Namespace: namespace, Name: name}, createObject, client, &rbacv1.ClusterRole{}, false); err != nil {
 			return fmt.Errorf("failed to ensure ClusterRole %s/%s: %v", namespace, name, err)
 		}
-	}
 
-	return nil
+		return nil
+	}
 }
 
 // RoleCreator defines an interface to create/update Roles
@@ -492,6 +612,16 @@ func RoleObjectWrapper(create RoleCreator) ObjectCreator {
 func ReconcileRoles(ctx context.Context, namedGetters []NamedRoleCreatorGetter, namespace string, client ctrlruntimeclient.Client, objectModifiers ...ObjectModifier) error {
 	for _, get := range namedGetters {
 		name, create := get()
+		return ReconcileRoleTaskFn(create, name, namespace, objectModifiers...)(ctx, client)
+	}
+
+	return nil
+}
+
+// ReconcileRoleTaskFn will return a TaskFn to create or update
+// the Role coming from the passed RoleCreator.
+func ReconcileRoleTaskFn(create RoleCreator, name, namespace string, objectModifiers ...ObjectModifier) TaskFn {
+	return func(ctx context.Context, client ctrlruntimeclient.Client) error {
 		createObject := RoleObjectWrapper(create)
 		createObject = createWithNamespace(createObject, namespace)
 		createObject = createWithName(createObject, name)
@@ -503,9 +633,9 @@ func ReconcileRoles(ctx context.Context, namedGetters []NamedRoleCreatorGetter, 
 		if err := EnsureNamedObject(ctx, types.NamespacedName{Namespace: namespace, Name: name}, createObject, client, &rbacv1.Role{}, false); err != nil {
 			return fmt.Errorf("failed to ensure Role %s/%s: %v", namespace, name, err)
 		}
-	}
 
-	return nil
+		return nil
+	}
 }
 
 // RoleBindingCreator defines an interface to create/update RoleBindings
@@ -529,6 +659,16 @@ func RoleBindingObjectWrapper(create RoleBindingCreator) ObjectCreator {
 func ReconcileRoleBindings(ctx context.Context, namedGetters []NamedRoleBindingCreatorGetter, namespace string, client ctrlruntimeclient.Client, objectModifiers ...ObjectModifier) error {
 	for _, get := range namedGetters {
 		name, create := get()
+		return ReconcileRoleBindingTaskFn(create, name, namespace, objectModifiers...)(ctx, client)
+	}
+
+	return nil
+}
+
+// ReconcileRoleBindingTaskFn will return a TaskFn to create or update
+// the RoleBinding coming from the passed RoleBindingCreator.
+func ReconcileRoleBindingTaskFn(create RoleBindingCreator, name, namespace string, objectModifiers ...ObjectModifier) TaskFn {
+	return func(ctx context.Context, client ctrlruntimeclient.Client) error {
 		createObject := RoleBindingObjectWrapper(create)
 		createObject = createWithNamespace(createObject, namespace)
 		createObject = createWithName(createObject, name)
@@ -540,9 +680,9 @@ func ReconcileRoleBindings(ctx context.Context, namedGetters []NamedRoleBindingC
 		if err := EnsureNamedObject(ctx, types.NamespacedName{Namespace: namespace, Name: name}, createObject, client, &rbacv1.RoleBinding{}, false); err != nil {
 			return fmt.Errorf("failed to ensure RoleBinding %s/%s: %v", namespace, name, err)
 		}
-	}
 
-	return nil
+		return nil
+	}
 }
 
 // CustomResourceDefinitionCreator defines an interface to create/update CustomResourceDefinitions
@@ -566,6 +706,16 @@ func CustomResourceDefinitionObjectWrapper(create CustomResourceDefinitionCreato
 func ReconcileCustomResourceDefinitions(ctx context.Context, namedGetters []NamedCustomResourceDefinitionCreatorGetter, namespace string, client ctrlruntimeclient.Client, objectModifiers ...ObjectModifier) error {
 	for _, get := range namedGetters {
 		name, create := get()
+		return ReconcileCustomResourceDefinitionTaskFn(create, name, namespace, objectModifiers...)(ctx, client)
+	}
+
+	return nil
+}
+
+// ReconcileCustomResourceDefinitionTaskFn will return a TaskFn to create or update
+// the CustomResourceDefinition coming from the passed CustomResourceDefinitionCreator.
+func ReconcileCustomResourceDefinitionTaskFn(create CustomResourceDefinitionCreator, name, namespace string, objectModifiers ...ObjectModifier) TaskFn {
+	return func(ctx context.Context, client ctrlruntimeclient.Client) error {
 		createObject := CustomResourceDefinitionObjectWrapper(create)
 		createObject = createWithNamespace(createObject, namespace)
 		createObject = createWithName(createObject, name)
@@ -577,9 +727,9 @@ func ReconcileCustomResourceDefinitions(ctx context.Context, namedGetters []Name
 		if err := EnsureNamedObject(ctx, types.NamespacedName{Namespace: namespace, Name: name}, createObject, client, &apiextensionsv1beta1.CustomResourceDefinition{}, false); err != nil {
 			return fmt.Errorf("failed to ensure CustomResourceDefinition %s/%s: %v", namespace, name, err)
 		}
-	}
 
-	return nil
+		return nil
+	}
 }
 
 // CronJobCreator defines an interface to create/update CronJobs
@@ -603,6 +753,16 @@ func CronJobObjectWrapper(create CronJobCreator) ObjectCreator {
 func ReconcileCronJobs(ctx context.Context, namedGetters []NamedCronJobCreatorGetter, namespace string, client ctrlruntimeclient.Client, objectModifiers ...ObjectModifier) error {
 	for _, get := range namedGetters {
 		name, create := get()
+		return ReconcileCronJobTaskFn(create, name, namespace, objectModifiers...)(ctx, client)
+	}
+
+	return nil
+}
+
+// ReconcileCronJobTaskFn will return a TaskFn to create or update
+// the CronJob coming from the passed CronJobCreator.
+func ReconcileCronJobTaskFn(create CronJobCreator, name, namespace string, objectModifiers ...ObjectModifier) TaskFn {
+	return func(ctx context.Context, client ctrlruntimeclient.Client) error {
 		create = DefaultCronJob(create)
 		createObject := CronJobObjectWrapper(create)
 		createObject = createWithNamespace(createObject, namespace)
@@ -615,9 +775,9 @@ func ReconcileCronJobs(ctx context.Context, namedGetters []NamedCronJobCreatorGe
 		if err := EnsureNamedObject(ctx, types.NamespacedName{Namespace: namespace, Name: name}, createObject, client, &batchv1beta1.CronJob{}, false); err != nil {
 			return fmt.Errorf("failed to ensure CronJob %s/%s: %v", namespace, name, err)
 		}
-	}
 
-	return nil
+		return nil
+	}
 }
 
 // MutatingWebhookConfigurationCreator defines an interface to create/update MutatingWebhookConfigurations
@@ -641,6 +801,16 @@ func MutatingWebhookConfigurationObjectWrapper(create MutatingWebhookConfigurati
 func ReconcileMutatingWebhookConfigurations(ctx context.Context, namedGetters []NamedMutatingWebhookConfigurationCreatorGetter, namespace string, client ctrlruntimeclient.Client, objectModifiers ...ObjectModifier) error {
 	for _, get := range namedGetters {
 		name, create := get()
+		return ReconcileMutatingWebhookConfigurationTaskFn(create, name, namespace, objectModifiers...)(ctx, client)
+	}
+
+	return nil
+}
+
+// ReconcileMutatingWebhookConfigurationTaskFn will return a TaskFn to create or update
+// the MutatingWebhookConfiguration coming from the passed MutatingWebhookConfigurationCreator.
+func ReconcileMutatingWebhookConfigurationTaskFn(create MutatingWebhookConfigurationCreator, name, namespace string, objectModifiers ...ObjectModifier) TaskFn {
+	return func(ctx context.Context, client ctrlruntimeclient.Client) error {
 		createObject := MutatingWebhookConfigurationObjectWrapper(create)
 		createObject = createWithNamespace(createObject, namespace)
 		createObject = createWithName(createObject, name)
@@ -652,9 +822,9 @@ func ReconcileMutatingWebhookConfigurations(ctx context.Context, namedGetters []
 		if err := EnsureNamedObject(ctx, types.NamespacedName{Namespace: namespace, Name: name}, createObject, client, &admissionregistrationv1.MutatingWebhookConfiguration{}, false); err != nil {
 			return fmt.Errorf("failed to ensure MutatingWebhookConfiguration %s/%s: %v", namespace, name, err)
 		}
-	}
 
-	return nil
+		return nil
+	}
 }
 
 // ValidatingWebhookConfigurationCreator defines an interface to create/update ValidatingWebhookConfigurations
@@ -678,6 +848,16 @@ func ValidatingWebhookConfigurationObjectWrapper(create ValidatingWebhookConfigu
 func ReconcileValidatingWebhookConfigurations(ctx context.Context, namedGetters []NamedValidatingWebhookConfigurationCreatorGetter, namespace string, client ctrlruntimeclient.Client, objectModifiers ...ObjectModifier) error {
 	for _, get := range namedGetters {
 		name, create := get()
+		return ReconcileValidatingWebhookConfigurationTaskFn(create, name, namespace, objectModifiers...)(ctx, client)
+	}
+
+	return nil
+}
+
+// ReconcileValidatingWebhookConfigurationTaskFn will return a TaskFn to create or update
+// the ValidatingWebhookConfiguration coming from the passed ValidatingWebhookConfigurationCreator.
+func ReconcileValidatingWebhookConfigurationTaskFn(create ValidatingWebhookConfigurationCreator, name, namespace string, objectModifiers ...ObjectModifier) TaskFn {
+	return func(ctx context.Context, client ctrlruntimeclient.Client) error {
 		createObject := ValidatingWebhookConfigurationObjectWrapper(create)
 		createObject = createWithNamespace(createObject, namespace)
 		createObject = createWithName(createObject, name)
@@ -689,9 +869,9 @@ func ReconcileValidatingWebhookConfigurations(ctx context.Context, namedGetters 
 		if err := EnsureNamedObject(ctx, types.NamespacedName{Namespace: namespace, Name: name}, createObject, client, &admissionregistrationv1.ValidatingWebhookConfiguration{}, false); err != nil {
 			return fmt.Errorf("failed to ensure ValidatingWebhookConfiguration %s/%s: %v", namespace, name, err)
 		}
-	}
 
-	return nil
+		return nil
+	}
 }
 
 // APIServiceCreator defines an interface to create/update APIServices
@@ -715,6 +895,16 @@ func APIServiceObjectWrapper(create APIServiceCreator) ObjectCreator {
 func ReconcileAPIServices(ctx context.Context, namedGetters []NamedAPIServiceCreatorGetter, namespace string, client ctrlruntimeclient.Client, objectModifiers ...ObjectModifier) error {
 	for _, get := range namedGetters {
 		name, create := get()
+		return ReconcileAPIServiceTaskFn(create, name, namespace, objectModifiers...)(ctx, client)
+	}
+
+	return nil
+}
+
+// ReconcileAPIServiceTaskFn will return a TaskFn to create or update
+// the APIService coming from the passed APIServiceCreator.
+func ReconcileAPIServiceTaskFn(create APIServiceCreator, name, namespace string, objectModifiers ...ObjectModifier) TaskFn {
+	return func(ctx context.Context, client ctrlruntimeclient.Client) error {
 		createObject := APIServiceObjectWrapper(create)
 		createObject = createWithNamespace(createObject, namespace)
 		createObject = createWithName(createObject, name)
@@ -726,9 +916,9 @@ func ReconcileAPIServices(ctx context.Context, namedGetters []NamedAPIServiceCre
 		if err := EnsureNamedObject(ctx, types.NamespacedName{Namespace: namespace, Name: name}, createObject, client, &apiregistrationv1beta1.APIService{}, false); err != nil {
 			return fmt.Errorf("failed to ensure APIService %s/%s: %v", namespace, name, err)
 		}
-	}
 
-	return nil
+		return nil
+	}
 }
 
 // IngressCreator defines an interface to create/update Ingresss
@@ -752,6 +942,16 @@ func IngressObjectWrapper(create IngressCreator) ObjectCreator {
 func ReconcileIngresses(ctx context.Context, namedGetters []NamedIngressCreatorGetter, namespace string, client ctrlruntimeclient.Client, objectModifiers ...ObjectModifier) error {
 	for _, get := range namedGetters {
 		name, create := get()
+		return ReconcileIngressTaskFn(create, name, namespace, objectModifiers...)(ctx, client)
+	}
+
+	return nil
+}
+
+// ReconcileIngressTaskFn will return a TaskFn to create or update
+// the Ingress coming from the passed IngressCreator.
+func ReconcileIngressTaskFn(create IngressCreator, name, namespace string, objectModifiers ...ObjectModifier) TaskFn {
+	return func(ctx context.Context, client ctrlruntimeclient.Client) error {
 		createObject := IngressObjectWrapper(create)
 		createObject = createWithNamespace(createObject, namespace)
 		createObject = createWithName(createObject, name)
@@ -763,9 +963,9 @@ func ReconcileIngresses(ctx context.Context, namedGetters []NamedIngressCreatorG
 		if err := EnsureNamedObject(ctx, types.NamespacedName{Namespace: namespace, Name: name}, createObject, client, &networkingv1beta1.Ingress{}, false); err != nil {
 			return fmt.Errorf("failed to ensure Ingress %s/%s: %v", namespace, name, err)
 		}
-	}
 
-	return nil
+		return nil
+	}
 }
 
 // SeedCreator defines an interface to create/update Seeds
@@ -789,6 +989,16 @@ func SeedObjectWrapper(create SeedCreator) ObjectCreator {
 func ReconcileSeeds(ctx context.Context, namedGetters []NamedSeedCreatorGetter, namespace string, client ctrlruntimeclient.Client, objectModifiers ...ObjectModifier) error {
 	for _, get := range namedGetters {
 		name, create := get()
+		return ReconcileSeedTaskFn(create, name, namespace, objectModifiers...)(ctx, client)
+	}
+
+	return nil
+}
+
+// ReconcileSeedTaskFn will return a TaskFn to create or update
+// the Seed coming from the passed SeedCreator.
+func ReconcileSeedTaskFn(create SeedCreator, name, namespace string, objectModifiers ...ObjectModifier) TaskFn {
+	return func(ctx context.Context, client ctrlruntimeclient.Client) error {
 		createObject := SeedObjectWrapper(create)
 		createObject = createWithNamespace(createObject, namespace)
 		createObject = createWithName(createObject, name)
@@ -800,9 +1010,9 @@ func ReconcileSeeds(ctx context.Context, namedGetters []NamedSeedCreatorGetter, 
 		if err := EnsureNamedObject(ctx, types.NamespacedName{Namespace: namespace, Name: name}, createObject, client, &kubermaticv1.Seed{}, false); err != nil {
 			return fmt.Errorf("failed to ensure Seed %s/%s: %v", namespace, name, err)
 		}
-	}
 
-	return nil
+		return nil
+	}
 }
 
 // CertificateCreator defines an interface to create/update Certificates
@@ -826,6 +1036,16 @@ func CertificateObjectWrapper(create CertificateCreator) ObjectCreator {
 func ReconcileCertificates(ctx context.Context, namedGetters []NamedCertificateCreatorGetter, namespace string, client ctrlruntimeclient.Client, objectModifiers ...ObjectModifier) error {
 	for _, get := range namedGetters {
 		name, create := get()
+		return ReconcileCertificateTaskFn(create, name, namespace, objectModifiers...)(ctx, client)
+	}
+
+	return nil
+}
+
+// ReconcileCertificateTaskFn will return a TaskFn to create or update
+// the Certificate coming from the passed CertificateCreator.
+func ReconcileCertificateTaskFn(create CertificateCreator, name, namespace string, objectModifiers ...ObjectModifier) TaskFn {
+	return func(ctx context.Context, client ctrlruntimeclient.Client) error {
 		createObject := CertificateObjectWrapper(create)
 		createObject = createWithNamespace(createObject, namespace)
 		createObject = createWithName(createObject, name)
@@ -837,9 +1057,9 @@ func ReconcileCertificates(ctx context.Context, namedGetters []NamedCertificateC
 		if err := EnsureNamedObject(ctx, types.NamespacedName{Namespace: namespace, Name: name}, createObject, client, &certmanagerv1alpha2.Certificate{}, false); err != nil {
 			return fmt.Errorf("failed to ensure Certificate %s/%s: %v", namespace, name, err)
 		}
-	}
 
-	return nil
+		return nil
+	}
 }
 
 // ConstraintTemplateCreator defines an interface to create/update ConstraintTemplates
@@ -863,6 +1083,16 @@ func ConstraintTemplateObjectWrapper(create ConstraintTemplateCreator) ObjectCre
 func ReconcileConstraintTemplates(ctx context.Context, namedGetters []NamedConstraintTemplateCreatorGetter, namespace string, client ctrlruntimeclient.Client, objectModifiers ...ObjectModifier) error {
 	for _, get := range namedGetters {
 		name, create := get()
+		return ReconcileConstraintTemplateTaskFn(create, name, namespace, objectModifiers...)(ctx, client)
+	}
+
+	return nil
+}
+
+// ReconcileConstraintTemplateTaskFn will return a TaskFn to create or update
+// the ConstraintTemplate coming from the passed ConstraintTemplateCreator.
+func ReconcileConstraintTemplateTaskFn(create ConstraintTemplateCreator, name, namespace string, objectModifiers ...ObjectModifier) TaskFn {
+	return func(ctx context.Context, client ctrlruntimeclient.Client) error {
 		createObject := ConstraintTemplateObjectWrapper(create)
 		createObject = createWithNamespace(createObject, namespace)
 		createObject = createWithName(createObject, name)
@@ -874,9 +1104,9 @@ func ReconcileConstraintTemplates(ctx context.Context, namedGetters []NamedConst
 		if err := EnsureNamedObject(ctx, types.NamespacedName{Namespace: namespace, Name: name}, createObject, client, &gatekeeperv1beta1.ConstraintTemplate{}, false); err != nil {
 			return fmt.Errorf("failed to ensure ConstraintTemplate %s/%s: %v", namespace, name, err)
 		}
-	}
 
-	return nil
+		return nil
+	}
 }
 
 // KubermaticV1ConstraintTemplateCreator defines an interface to create/update ConstraintTemplates
@@ -900,6 +1130,16 @@ func KubermaticV1ConstraintTemplateObjectWrapper(create KubermaticV1ConstraintTe
 func ReconcileKubermaticV1ConstraintTemplates(ctx context.Context, namedGetters []NamedKubermaticV1ConstraintTemplateCreatorGetter, namespace string, client ctrlruntimeclient.Client, objectModifiers ...ObjectModifier) error {
 	for _, get := range namedGetters {
 		name, create := get()
+		return ReconcileKubermaticV1ConstraintTemplateTaskFn(create, name, namespace, objectModifiers...)(ctx, client)
+	}
+
+	return nil
+}
+
+// ReconcileKubermaticV1ConstraintTemplateTaskFn will return a TaskFn to create or update
+// the ConstraintTemplate coming from the passed ConstraintTemplateCreator.
+func ReconcileKubermaticV1ConstraintTemplateTaskFn(create KubermaticV1ConstraintTemplateCreator, name, namespace string, objectModifiers ...ObjectModifier) TaskFn {
+	return func(ctx context.Context, client ctrlruntimeclient.Client) error {
 		createObject := KubermaticV1ConstraintTemplateObjectWrapper(create)
 		createObject = createWithNamespace(createObject, namespace)
 		createObject = createWithName(createObject, name)
@@ -909,9 +1149,9 @@ func ReconcileKubermaticV1ConstraintTemplates(ctx context.Context, namedGetters 
 		}
 
 		if err := EnsureNamedObject(ctx, types.NamespacedName{Namespace: namespace, Name: name}, createObject, client, &kubermaticv1.ConstraintTemplate{}, false); err != nil {
-			return fmt.Errorf("failed to ensure ConstraintTemplate %s/%s: %v", namespace, name, err)
+			return fmt.Errorf("failed to ensure KubermaticV1ConstraintTemplate %s/%s: %v", namespace, name, err)
 		}
-	}
 
-	return nil
+		return nil
+	}
 }


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR introduces in the `reconciling` package a utility that can be used to define a graph of tasks and to run it respecting the dependencies.
This will be used for migrations (e.g. #6225) and upgrades (#5949) where the need for defining a state-machine naturally arises.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:
At the moment the tasks are executed in a single goroutine, but this can evolve in the future to allow some parallelization.

**Documentation**:
<!-- Add links to the related documentation changes related to this pull request. E.g. the link to the kubermatic/docs pull request. -->

**Does this PR introduce a user-facing change?**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If  no release note is required, just write "NONE".
-->
```release-note
NONE
```
