### PR TITLE
Validating ssh key agent deployment

### DIFF
--- a/cmd/seed-controller-manager/main.go
+++ b/cmd/seed-controller-manager/main.go
@@ -171,7 +171,7 @@ Please install the VerticalPodAutoscaler according to the documentation: https:/
 		// Setup the admission handler for kubermatic Seed CRDs
 		h.SetupWebhookWithManager(mgr)
 		// Setup the admission handler for kubermatic Cluster CRDs
-		clustervalidation.NewAdmissionHandler(options.featureGates).SetupWebhookWithManager(mgr)
+		clustervalidation.NewAdmissionHandler(mgr.GetClient(), options.featureGates).SetupWebhookWithManager(mgr)
 	}
 
 	ctrlCtx := &controllerContext{

--- a/pkg/validation/cluster/handler.go
+++ b/pkg/validation/cluster/handler.go
@@ -28,7 +28,10 @@ import (
 	"k8c.io/kubermatic/v2/pkg/features"
 
 	admissionv1beta1 "k8s.io/api/admission/v1beta1"
+	kerrors "k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/types"
 	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/webhook"
 	"sigs.k8s.io/controller-runtime/pkg/webhook/admission"
 )
@@ -38,12 +41,14 @@ type AdmissionHandler struct {
 	log      logr.Logger
 	decoder  *admission.Decoder
 	features features.FeatureGate
+	client   client.Client
 }
 
 // NewAdmissionHandler returns a new cluster.AdmissionHandler.
-func NewAdmissionHandler(features features.FeatureGate) *AdmissionHandler {
+func NewAdmissionHandler(client client.Client, features features.FeatureGate) *AdmissionHandler {
 	return &AdmissionHandler{
 		features: features,
+		client:   client,
 	}
 }
 
@@ -57,7 +62,7 @@ func (h *AdmissionHandler) InjectDecoder(d *admission.Decoder) error {
 	return nil
 }
 
-func (h *AdmissionHandler) Handle(_ context.Context, req webhook.AdmissionRequest) webhook.AdmissionResponse {
+func (h *AdmissionHandler) Handle(ctx context.Context, req webhook.AdmissionRequest) webhook.AdmissionResponse {
 	cluster := &kubermaticv1.Cluster{}
 
 	switch req.Operation {
@@ -68,11 +73,18 @@ func (h *AdmissionHandler) Handle(_ context.Context, req webhook.AdmissionReques
 		if err != nil {
 			return admission.Errored(http.StatusBadRequest, err)
 		}
+
 		validationErr := h.validateCreateOrUpdate(cluster)
 		if validationErr != nil {
 			h.log.Info("cluster admission failed", "error", validationErr)
 			return webhook.Denied(fmt.Sprintf("cluster validation request %s rejected: %v", req.UID, validationErr))
 		}
+
+		if err := h.rejectEnableUserSSHKeyAgentUpdate(ctx, cluster); err != nil {
+			h.log.Info("cluster admission failed", "error", err)
+			return webhook.Denied(fmt.Sprintf("cluster validation request %s rejected: %v", req.UID, err))
+		}
+
 	case admissionv1beta1.Delete:
 		// NOP we always allow delete operarions at the moment
 	default:
@@ -94,4 +106,27 @@ func (h *AdmissionHandler) validateCreateOrUpdate(c *kubermaticv1.Cluster) error
 
 func (h *AdmissionHandler) SetupWebhookWithManager(mgr ctrl.Manager) {
 	mgr.GetWebhookServer().Register("/validate-kubermatic-k8s-io-cluster", &webhook.Admission{Handler: h})
+}
+
+func (h *AdmissionHandler) rejectEnableUserSSHKeyAgentUpdate(ctx context.Context, cluster *kubermaticv1.Cluster) error {
+	var (
+		oldCluster = &kubermaticv1.Cluster{}
+		nName      = types.NamespacedName{Name: cluster.Name}
+	)
+
+	if h.client != nil {
+		if err := h.client.Get(ctx, nName, oldCluster); err != nil {
+			if kerrors.IsNotFound(err) {
+				return nil
+			}
+
+			return fmt.Errorf("failed to fetch cluster name=%s: %v", cluster.Name, err)
+		}
+
+		if oldCluster.Spec.EnableUserSSHKeyAgent != cluster.Spec.EnableUserSSHKeyAgent {
+			return errors.New("enableUserSSHKeyAgent field cannot be updated after cluster creation")
+		}
+	}
+
+	return nil
 }

--- a/pkg/validation/cluster/handler.go
+++ b/pkg/validation/cluster/handler.go
@@ -111,7 +111,7 @@ func (h *AdmissionHandler) SetupWebhookWithManager(mgr ctrl.Manager) {
 func (h *AdmissionHandler) rejectEnableUserSSHKeyAgentUpdate(ctx context.Context, cluster *kubermaticv1.Cluster) error {
 	var (
 		oldCluster = &kubermaticv1.Cluster{}
-		nName      = types.NamespacedName{Name: cluster.Name}
+		nName      = types.NamespacedName{Name: cluster.Name, Namespace: cluster.Namespace}
 	)
 
 	if h.client != nil {

--- a/pkg/validation/cluster/handler_test.go
+++ b/pkg/validation/cluster/handler_test.go
@@ -52,7 +52,7 @@ func TestHandle(t *testing.T) {
 		client      client.Client
 	}{
 		{
-			name: "Delete cluster succeess",
+			name: "Delete cluster success",
 			req: webhook.AdmissionRequest{
 				AdmissionRequest: admissionv1beta1.AdmissionRequest{
 					Operation: admissionv1beta1.Delete,
@@ -61,8 +61,7 @@ func TestHandle(t *testing.T) {
 						Version: kubermaticv1.GroupVersion,
 						Kind:    "Cluster",
 					},
-					Name:      "cluster",
-					Namespace: "kubermatic",
+					Name: "cluster",
 				},
 			},
 			wantAllowed: true,
@@ -77,8 +76,7 @@ func TestHandle(t *testing.T) {
 						Version: kubermaticv1.GroupVersion,
 						Kind:    "Cluster",
 					},
-					Name:      "foo",
-					Namespace: "kubermatic",
+					Name: "foo",
 					Object: runtime.RawExtension{
 						Raw: rawClusterGen{Name: "foo", Namespace: "kubermatic", ExposeStrategy: "Tunneling"}.Do(),
 					},
@@ -97,8 +95,7 @@ func TestHandle(t *testing.T) {
 						Version: kubermaticv1.GroupVersion,
 						Kind:    "Cluster",
 					},
-					Name:      "foo",
-					Namespace: "kubermatic",
+					Name: "foo",
 					Object: runtime.RawExtension{
 						Raw: rawClusterGen{Name: "foo", Namespace: "kubermatic", ExposeStrategy: "Tunneling"}.Do(),
 					},
@@ -117,8 +114,7 @@ func TestHandle(t *testing.T) {
 						Version: kubermaticv1.GroupVersion,
 						Kind:    "Cluster",
 					},
-					Name:      "foo",
-					Namespace: "kubermatic",
+					Name: "foo",
 					Object: runtime.RawExtension{
 						Raw: rawClusterGen{Name: "foo", Namespace: "kubermatic", ExposeStrategy: "NodePort"}.Do(),
 					},
@@ -136,8 +132,7 @@ func TestHandle(t *testing.T) {
 						Version: kubermaticv1.GroupVersion,
 						Kind:    "Cluster",
 					},
-					Name:      "foo",
-					Namespace: "kubermatic",
+					Name: "foo",
 					Object: runtime.RawExtension{
 						Raw: rawClusterGen{Name: "foo", Namespace: "kubermatic", ExposeStrategy: "ciao"}.Do(),
 					},
@@ -155,8 +150,7 @@ func TestHandle(t *testing.T) {
 						Version: kubermaticv1.GroupVersion,
 						Kind:    "Cluster",
 					},
-					Name:      "foo",
-					Namespace: "kubermatic",
+					Name: "foo",
 					Object: runtime.RawExtension{
 						Raw: rawClusterGen{Name: "foo", Namespace: "kubermatic", ExposeStrategy: "NodePort", EnableUserSSHKey: true}.Do(),
 					},
@@ -166,8 +160,7 @@ func TestHandle(t *testing.T) {
 			client: fake.NewFakeClient(
 				&kubermaticv1.Cluster{
 					ObjectMeta: metav1.ObjectMeta{
-						Name:      "foo",
-						Namespace: "kubermatic",
+						Name: "foo",
 					},
 					Spec: kubermaticv1.ClusterSpec{
 						EnableUserSSHKeyAgent: true,
@@ -184,8 +177,7 @@ func TestHandle(t *testing.T) {
 						Version: kubermaticv1.GroupVersion,
 						Kind:    "Cluster",
 					},
-					Name:      "foo",
-					Namespace: "kubermatic",
+					Name: "foo",
 					Object: runtime.RawExtension{
 						Raw: rawClusterGen{Name: "foo", Namespace: "kubermatic", ExposeStrategy: "NodePort", EnableUserSSHKey: false}.Do(),
 					},
@@ -195,8 +187,7 @@ func TestHandle(t *testing.T) {
 			client: fake.NewFakeClient(
 				&kubermaticv1.Cluster{
 					ObjectMeta: metav1.ObjectMeta{
-						Name:      "foo",
-						Namespace: "kubermatic",
+						Name: "foo",
 					},
 					Spec: kubermaticv1.ClusterSpec{
 						EnableUserSSHKeyAgent: false,


### PR DESCRIPTION
**What this PR does / why we need it**:
Adding validation for user ssh key agent enabling. The user ssh key agent can be enabled/disabled only during the creation of the user cluster, once the cluster is created, the agent status cannot be changed.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes kubermatic/kubermatic#6429

**Does this PR introduce a user-facing change?**:
```release-note
Disabling/Enabling User SSH Key agent 
```
