### PR TITLE
Deploy envoy-agent for tunneling expose strategy

### DIFF
--- a/cmd/seed-controller-manager/controllers.go
+++ b/cmd/seed-controller-manager/controllers.go
@@ -177,6 +177,7 @@ func createKubernetesController(ctrlCtx *controllerContext) error {
 		ctrlCtx.runOptions.kubermaticImage,
 		ctrlCtx.runOptions.etcdLauncherImage,
 		ctrlCtx.runOptions.dnatControllerImage,
+		ctrlCtx.runOptions.tunnelingAgentIP.String(),
 		kubernetescontroller.Features{
 			VPA:                          ctrlCtx.runOptions.featureGates.Enabled(features.VerticalPodAutoscaler),
 			EtcdDataCorruptionChecks:     ctrlCtx.runOptions.featureGates.Enabled(features.EtcdDataCorruptionChecks),

--- a/cmd/user-cluster-controller-manager/main.go
+++ b/cmd/user-cluster-controller-manager/main.go
@@ -52,6 +52,7 @@ import (
 	"k8c.io/kubermatic/v2/pkg/pprof"
 	"k8c.io/kubermatic/v2/pkg/resources/reconciling"
 	"k8c.io/kubermatic/v2/pkg/util/cli"
+	"k8c.io/kubermatic/v2/pkg/util/flagopts"
 	"k8c.io/kubermatic/v2/pkg/version/kubermatic"
 
 	corev1 "k8s.io/api/core/v1"
@@ -76,6 +77,8 @@ type controllerRunOptions struct {
 	namespace                     string
 	clusterURL                    string
 	openvpnServerPort             int
+	kasSecurePort                 int
+	tunnelingAgentIP              flagopts.IPValue
 	overwriteRegistry             string
 	cloudProviderName             string
 	cloudCredentialSecretTemplate string
@@ -107,6 +110,8 @@ func main() {
 	flag.StringVar(&runOp.clusterURL, "cluster-url", "", "Cluster URL")
 	flag.StringVar(&runOp.dnsClusterIP, "dns-cluster-ip", "", "KubeDNS service IP for the cluster")
 	flag.IntVar(&runOp.openvpnServerPort, "openvpn-server-port", 0, "OpenVPN server port")
+	flag.IntVar(&runOp.kasSecurePort, "kas-secure-port", 6443, "Secure KAS port")
+	flag.Var(&runOp.tunnelingAgentIP, "tunneling-agent-ip", "If specified the tunneling agent will bind to this IP address, otherwise it will not be deployed.")
 	flag.StringVar(&runOp.overwriteRegistry, "overwrite-registry", "", "registry to use for all images")
 	flag.StringVar(&runOp.cloudProviderName, "cloud-provider-name", "", "Name of the cloudprovider")
 	flag.StringVar(&runOp.cloudCredentialSecretTemplate, "cloud-credential-secret-template", "", "A serialized Kubernetes secret whose Name and Data fields will be used to create a secret for the openshift cloud credentials operator.")
@@ -230,7 +235,9 @@ func main() {
 		runOp.namespace,
 		runOp.cloudProviderName,
 		clusterURL,
-		runOp.openvpnServerPort,
+		uint32(runOp.openvpnServerPort),
+		uint32(runOp.kasSecurePort),
+		runOp.tunnelingAgentIP.IP,
 		healthHandler.AddReadinessCheck,
 		cloudCredentialSecretTemplate,
 		runOp.openshiftConsoleCallbackURI,

--- a/pkg/controller/seed-controller-manager/kubernetes/address.go
+++ b/pkg/controller/seed-controller-manager/kubernetes/address.go
@@ -41,7 +41,12 @@ func (r *Reconciler) syncAddress(ctx context.Context, log *zap.SugaredLogger, cl
 		r.log.Infow("Created admin token for cluster", "cluster", cluster.Name)
 	}
 
-	modifiers, err := address.NewModifiersBuilder(log).
+	b := address.NewModifiersBuilder(log)
+	// we only need providing the agentIP if the Tunneling strategy is used.
+	if cluster.Spec.ExposeStrategy == kubermaticv1.ExposeStrategyTunneling {
+		b.TunnelingAgentIP(r.tunnelingAgentIP)
+	}
+	modifiers, err := b.
 		Cluster(cluster).
 		Client(r.Client).
 		ExternalURL(r.externalURL).

--- a/pkg/controller/seed-controller-manager/kubernetes/cluster_controller.go
+++ b/pkg/controller/seed-controller-manager/kubernetes/cluster_controller.go
@@ -101,6 +101,8 @@ type Reconciler struct {
 
 	features Features
 	versions kubermatic.Versions
+
+	tunnelingAgentIP string
 }
 
 // NewController creates a cluster controller.
@@ -131,6 +133,9 @@ func Add(
 	kubermaticImage string,
 	etcdLauncherImage string,
 	dnatControllerImage string,
+
+	tunnelingAgentIP string,
+
 	features Features,
 	versions kubermatic.Versions) error {
 
@@ -165,8 +170,9 @@ func Add(
 		oidcIssuerURL:      oidcIssuerURL,
 		oidcIssuerClientID: oidcIssuerClientID,
 
-		features: features,
-		versions: versions,
+		tunnelingAgentIP: tunnelingAgentIP,
+		features:         features,
+		versions:         versions,
 	}
 
 	c, err := controller.New(ControllerName, mgr, controller.Options{Reconciler: reconciler, MaxConcurrentReconciles: numWorkers})

--- a/pkg/controller/seed-controller-manager/kubernetes/resources.go
+++ b/pkg/controller/seed-controller-manager/kubernetes/resources.go
@@ -67,8 +67,10 @@ func (r *Reconciler) ensureResourcesAreDeployed(ctx context.Context, cluster *ku
 		return fmt.Errorf("failed to sync address: %v", err)
 	}
 
-	// We should not proceed without having an IP address. Its required for all Kubeconfigs & triggers errors otherwise.
-	if cluster.Address.IP == "" {
+	// We should not proceed without having an IP address unless tunneling
+	// strategy is used. Its required for all Kubeconfigs & triggers errors
+	// otherwise.
+	if cluster.Address.IP == "" && cluster.Spec.ExposeStrategy != kubermaticv1.ExposeStrategyTunneling {
 		return nil
 	}
 
@@ -212,7 +214,7 @@ func (r *Reconciler) ensureNamespaceExists(ctx context.Context, cluster *kuberma
 // GetServiceCreators returns all service creators that are currently in use
 func GetServiceCreators(data *resources.TemplateData) []reconciling.NamedServiceCreatorGetter {
 	creators := []reconciling.NamedServiceCreatorGetter{
-		apiserver.ServiceCreator(data.Cluster().Spec.ExposeStrategy, data.Cluster().Address.InternalName),
+		apiserver.ServiceCreator(data.Cluster().Spec.ExposeStrategy, data.Cluster().Address.ExternalName),
 		openvpn.ServiceCreator(data.Cluster().Spec.ExposeStrategy),
 		etcd.ServiceCreator(data),
 		dns.ServiceCreator(),

--- a/pkg/controller/user-cluster-controller-manager/resources/controller.go
+++ b/pkg/controller/user-cluster-controller-manager/resources/controller.go
@@ -20,6 +20,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"net"
 	"net/url"
 	"sync"
 	"time"
@@ -67,7 +68,9 @@ func Add(
 	namespace string,
 	cloudProviderName string,
 	clusterURL *url.URL,
-	openvpnServerPort int,
+	openvpnServerPort uint32,
+	kasSecurePort uint32,
+	tunnelingAgentIP net.IP,
 	registerReconciledCheck func(name string, check healthcheck.Check),
 	cloudCredentialSecretTemplate *corev1.Secret,
 	openshiftConsoleCallbackURI string,
@@ -83,6 +86,8 @@ func Add(
 		namespace:                     namespace,
 		clusterURL:                    clusterURL,
 		openvpnServerPort:             openvpnServerPort,
+		kasSecurePort:                 kasSecurePort,
+		tunnelingAgentIP:              tunnelingAgentIP,
 		cloudCredentialSecretTemplate: cloudCredentialSecretTemplate,
 		log:                           log,
 		platform:                      cloudProviderName,
@@ -226,7 +231,9 @@ type reconciler struct {
 	cache                         cache.Cache
 	namespace                     string
 	clusterURL                    *url.URL
-	openvpnServerPort             int
+	openvpnServerPort             uint32
+	kasSecurePort                 uint32
+	tunnelingAgentIP              net.IP
 	platform                      string
 	cloudCredentialSecretTemplate *corev1.Secret
 	openshiftConsoleCallbackURI   string

--- a/pkg/controller/user-cluster-controller-manager/resources/resources/envoy-agent/configmap.go
+++ b/pkg/controller/user-cluster-controller-manager/resources/resources/envoy-agent/configmap.go
@@ -1,0 +1,107 @@
+/*
+Copyright 2020 The Kubermatic Kubernetes Platform contributors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package envoyagent
+
+import (
+	"strings"
+	"text/template"
+
+	"k8c.io/kubermatic/v2/pkg/resources"
+	"k8c.io/kubermatic/v2/pkg/resources/reconciling"
+
+	corev1 "k8s.io/api/core/v1"
+)
+
+var envoyConfigTemplate = `admin:
+  access_log_path: /dev/stdout
+  address:
+    socket_address:
+      protocol: TCP
+      address: 127.0.0.1
+      port_value: {{.AdminPort}}
+static_resources:
+  listeners: {{if not .Listeners -}}[]{{- end}}
+{{- range $i, $l := .Listeners}}
+  - name: listener_{{$i}}
+    address:
+      socket_address:
+        protocol: TCP
+        address: {{$l.BindAddress}}
+        port_value: {{$l.BindPort}}
+    filter_chains:
+    - filters:
+      - name: tcp
+        typed_config:
+          "@type": type.googleapis.com/envoy.extensions.filters.network.tcp_proxy.v3.TcpProxy
+          stat_prefix: tcp_stats
+          cluster: "proxy_cluster"
+          tunneling_config:
+            hostname: {{$l.Authority}}
+{{- end}}
+  clusters:
+    - name: proxy_cluster
+      connect_timeout: 5s
+      type: LOGICAL_DNS
+      # This ensures HTTP/2 CONNECT is used for establishing the tunnel.
+      typed_extension_protocol_options:
+        envoy.extensions.upstreams.http.v3.HttpProtocolOptions:
+          "@type": type.googleapis.com/envoy.extensions.upstreams.http.v3.HttpProtocolOptions
+          explicit_http_config:
+            http2_protocol_options: {}
+      load_assignment:
+        cluster_name: proxy_cluster
+        endpoints:
+          - lb_endpoints:
+              - endpoint:
+                  address:
+                    socket_address:
+                      address: {{.ProxyHost}}
+                      port_value: {{.ProxyPort}}
+`
+
+type Config struct {
+	AdminPort uint32
+	ProxyHost string
+	ProxyPort uint32
+	Listeners []Listener
+}
+
+type Listener struct {
+	BindAddress string
+	BindPort    uint32
+	Authority   string
+}
+
+// ConfigMapCreator returns a ConfigMap containing the config for the Envoy agent
+func ConfigMapCreator(cfg Config) reconciling.NamedConfigMapCreatorGetter {
+	return func() (string, reconciling.ConfigMapCreator) {
+		return resources.EnvoyAgentConfigMapName, func(cm *corev1.ConfigMap) (*corev1.ConfigMap, error) {
+			if cm.Data == nil {
+				cm.Data = map[string]string{}
+			}
+			cm.Labels = resources.BaseAppLabels(resources.EnvoyAgentConfigMapName, nil)
+			var b strings.Builder
+			err := template.Must(template.New("envoy-config").Parse(envoyConfigTemplate)).Execute(&b, cfg)
+			if err != nil {
+				return nil, err
+			}
+			cm.Data["envoy.yaml"] = b.String()
+
+			return cm, nil
+		}
+	}
+}

--- a/pkg/controller/user-cluster-controller-manager/resources/resources/envoy-agent/daemonset.go
+++ b/pkg/controller/user-cluster-controller-manager/resources/resources/envoy-agent/daemonset.go
@@ -1,0 +1,184 @@
+/*
+Copyright 2020 The Kubermatic Kubernetes Platform contributors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package envoyagent
+
+import (
+	"fmt"
+	"net"
+
+	"k8c.io/kubermatic/v2/pkg/resources"
+	"k8c.io/kubermatic/v2/pkg/resources/reconciling"
+	"k8c.io/kubermatic/v2/pkg/version/kubermatic"
+
+	appsv1 "k8s.io/api/apps/v1"
+	corev1 "k8s.io/api/core/v1"
+	utilpointer "k8s.io/utils/pointer"
+
+	"k8s.io/apimachinery/pkg/api/resource"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+var (
+	defaultResourceRequirements = map[string]*corev1.ResourceRequirements{
+		resources.EnvoyAgentDaemonSetName: {
+			Requests: corev1.ResourceList{
+				corev1.ResourceMemory: resource.MustParse("32Mi"),
+				corev1.ResourceCPU:    resource.MustParse("50m"),
+			},
+			Limits: corev1.ResourceList{
+				corev1.ResourceMemory: resource.MustParse("64Mi"),
+				corev1.ResourceCPU:    resource.MustParse("100m"),
+			},
+		},
+	}
+)
+
+const (
+	envoyImageName = "envoyproxy/envoy"
+	envoyImageTag  = "v1.17.0"
+)
+
+// DaemonSetCreator returns the function to create and update the Envoy DaemonSet
+func DaemonSetCreator(agentIP net.IP, versions kubermatic.Versions) reconciling.NamedDaemonSetCreatorGetter {
+	return func() (string, reconciling.DaemonSetCreator) {
+		return resources.EnvoyAgentDaemonSetName, func(ds *appsv1.DaemonSet) (*appsv1.DaemonSet, error) {
+			ds.Name = resources.EnvoyAgentDaemonSetName
+			ds.Namespace = metav1.NamespaceSystem
+			ds.Labels = resources.BaseAppLabels(resources.EnvoyAgentDaemonSetName, nil)
+
+			ds.Spec.Selector = &metav1.LabelSelector{
+				MatchLabels: resources.BaseAppLabels(resources.EnvoyAgentDaemonSetName,
+					map[string]string{"app.kubernetes.io/name": "envoy-agent"}),
+			}
+
+			// has to be the same as the selector
+			ds.Spec.Template.ObjectMeta = metav1.ObjectMeta{
+				Labels: resources.BaseAppLabels(resources.EnvoyAgentDaemonSetName,
+					map[string]string{"app.kubernetes.io/name": "envoy-agent"}),
+			}
+
+			//TODO(youssefazrak) needed?
+			ds.Spec.Template.Spec.PriorityClassName = "system-cluster-critical"
+			ds.Spec.Template.Spec.DNSPolicy = corev1.DNSClusterFirst
+
+			ds.Spec.Template.Spec.HostNetwork = true
+
+			volumes := getVolumes()
+			ds.Spec.Template.Spec.Volumes = volumes
+
+			ds.Spec.Template.Spec.InitContainers = getInitContainers(agentIP, versions)
+			ds.Spec.Template.Spec.Containers = getContainers()
+			err := resources.SetResourceRequirements(ds.Spec.Template.Spec.Containers, defaultResourceRequirements, nil, ds.Annotations)
+			if err != nil {
+				return nil, fmt.Errorf("failed to set resource requirements: %v", err)
+			}
+
+			return ds, nil
+		}
+	}
+}
+
+func getInitContainers(ip net.IP, v kubermatic.Versions) []corev1.Container {
+	// TODO(irozzo): we are creating and configuring the a dummy interface
+	// using init containers. This approach is good enough for the tech preview
+	// but it is definitely not production ready. This should be replaced with
+	// a binary that properly handles error conditions and reconciles the
+	// interface in a loop.
+	return []corev1.Container{
+		{
+			Name: resources.EnvoyAgentCreateInterfaceInitContainerName,
+			// TODO(irozzo): the registry should be overridable.
+			Image:   fmt.Sprintf("%s/%s:%s", resources.RegistryQuay, resources.EnvoyAgentDeviceSetupImage, v.Kubermatic),
+			Command: []string{"sh", "-c", "ip link add envoyagent type dummy || true"},
+			SecurityContext: &corev1.SecurityContext{
+				Capabilities: &corev1.Capabilities{
+					Add: []corev1.Capability{
+						"NET_ADMIN",
+					},
+					Drop: []corev1.Capability{
+						"all",
+					},
+				},
+			},
+		},
+		{
+			Name:    resources.EnvoyAgentAssignAddressInitContainerName,
+			Image:   fmt.Sprintf("%s/%s:%s", resources.RegistryQuay, resources.EnvoyAgentDeviceSetupImage, v.Kubermatic),
+			Command: []string{"sh", "-c", fmt.Sprintf("ip addr add %s/32 dev envoyagent scope host || true", ip.String())},
+			SecurityContext: &corev1.SecurityContext{
+				Capabilities: &corev1.Capabilities{
+					Add: []corev1.Capability{
+						"NET_ADMIN",
+					},
+					Drop: []corev1.Capability{
+						"all",
+					},
+				},
+			},
+		},
+	}
+}
+
+func getContainers() []corev1.Container {
+	return []corev1.Container{
+		{
+			Name:            resources.EnvoyAgentDaemonSetName,
+			Image:           fmt.Sprintf("%s/%s:%s", resources.RegistryDocker, envoyImageName, envoyImageTag),
+			ImagePullPolicy: corev1.PullIfNotPresent,
+
+			// This amount of logs will be kept for the Tech Preview of
+			// the new expose strategy
+			Args: []string{"--config-path", "etc/envoy/envoy.yaml", "--component-log-level", "upstream:trace,connection:trace,http:trace,router:trace,filter:trace"},
+			VolumeMounts: []corev1.VolumeMount{
+				{
+					Name:      "config-volume",
+					MountPath: "/etc/envoy/envoy.yaml",
+					SubPath:   "envoy.yaml",
+				},
+			},
+			SecurityContext: &corev1.SecurityContext{
+				Capabilities: &corev1.Capabilities{
+					Add: []corev1.Capability{
+						"CAP_CHOWN",
+						"CAP_SETGID",
+						"CAP_SETUID",
+						"NET_BIND_SERVICE",
+					},
+					Drop: []corev1.Capability{
+						"all",
+					},
+				},
+			},
+		},
+	}
+}
+
+func getVolumes() []corev1.Volume {
+	return []corev1.Volume{
+		{
+			Name: "config-volume",
+			VolumeSource: corev1.VolumeSource{
+				ConfigMap: &corev1.ConfigMapVolumeSource{
+					DefaultMode: utilpointer.Int32Ptr(corev1.ConfigMapVolumeSourceDefaultMode),
+					LocalObjectReference: corev1.LocalObjectReference{
+						Name: resources.EnvoyAgentConfigMapName,
+					},
+				},
+			},
+		},
+	}
+}

--- a/pkg/controller/user-cluster-controller-manager/resources/resources/openvpn/configmap.go
+++ b/pkg/controller/user-cluster-controller-manager/resources/resources/openvpn/configmap.go
@@ -30,7 +30,7 @@ const (
 )
 
 // ClientConfigConfigMapCreator returns a ConfigMap containing the config for the OpenVPN client. It lives inside the user-cluster
-func ClientConfigConfigMapCreator(hostname string, serverPort int) reconciling.NamedConfigMapCreatorGetter {
+func ClientConfigConfigMapCreator(hostname string, serverPort uint32) reconciling.NamedConfigMapCreatorGetter {
 	return func() (string, reconciling.ConfigMapCreator) {
 		return resources.OpenVPNClientConfigConfigMapName, func(cm *v1.ConfigMap) (*v1.ConfigMap, error) {
 			if cm.Data == nil {

--- a/pkg/resources/apiserver/service.go
+++ b/pkg/resources/apiserver/service.go
@@ -31,7 +31,7 @@ import (
 )
 
 // ServiceCreator returns the function to reconcile the external API server service
-func ServiceCreator(exposeStrategy kubermaticv1.ExposeStrategy, internalName string) reconciling.NamedServiceCreatorGetter {
+func ServiceCreator(exposeStrategy kubermaticv1.ExposeStrategy, externalURL string) reconciling.NamedServiceCreatorGetter {
 	return func() (string, reconciling.ServiceCreator) {
 		return resources.ApiserverServiceName, func(se *corev1.Service) (*corev1.Service, error) {
 			if se.Annotations == nil {
@@ -58,7 +58,7 @@ func ServiceCreator(exposeStrategy kubermaticv1.ExposeStrategy, internalName str
 				// the APIServer both with the SNI and the Tunneling listeners.
 				se.Annotations[nodeportproxy.DefaultExposeAnnotationKey] = strings.Join([]string{nodeportproxy.SNIType.String(), nodeportproxy.TunnelingType.String()}, ",")
 				// We map the secure port to the internal name for SNI routing.
-				se.Annotations[nodeportproxy.PortHostMappingAnnotationKey] = fmt.Sprintf(`{"secure": %q}`, internalName)
+				se.Annotations[nodeportproxy.PortHostMappingAnnotationKey] = fmt.Sprintf(`{"secure": %q}`, externalURL)
 				delete(se.Annotations, nodeportproxy.NodePortProxyExposeNamespacedAnnotationKey)
 			default:
 				return nil, fmt.Errorf("unsupported expose strategy: %q", exposeStrategy)

--- a/pkg/resources/data.go
+++ b/pkg/resources/data.go
@@ -292,6 +292,10 @@ func (d *TemplateData) GetPodTemplateLabels(appName string, volumes []corev1.Vol
 
 // GetApiserverExternalNodePort returns the nodeport of the external apiserver service
 func (d *TemplateData) GetOpenVPNServerPort() (int32, error) {
+	// When using tunneling expose strategy the port is fixed
+	if d.Cluster().Spec.ExposeStrategy == kubermaticv1.ExposeStrategyTunneling {
+		return 1194, nil
+	}
 	service := &corev1.Service{}
 	key := types.NamespacedName{Namespace: d.cluster.Status.NamespaceName, Name: OpenVPNServerServiceName}
 	if err := d.client.Get(d.ctx, key, service); err != nil {

--- a/pkg/resources/resources.go
+++ b/pkg/resources/resources.go
@@ -514,6 +514,14 @@ const (
 )
 
 const (
+	EnvoyAgentConfigMapName                    = "envoy-agent"
+	EnvoyAgentDaemonSetName                    = "envoy-agent"
+	EnvoyAgentCreateInterfaceInitContainerName = "create-dummy-interface"
+	EnvoyAgentAssignAddressInitContainerName   = "assign-address"
+	EnvoyAgentDeviceSetupImage                 = "kubermatic/kubeletdnat-controller"
+)
+
+const (
 	NodeLocalDNSServiceAccountName = "node-local-dns"
 	NodeLocalDNSConfigMapName      = "node-local-dns"
 	NodeLocalDNSDaemonSetName      = "node-local-dns"

--- a/pkg/resources/usercluster/deployment.go
+++ b/pkg/resources/usercluster/deployment.go
@@ -135,6 +135,11 @@ func DeploymentCreator(data userclusterControllerData, openshift bool) reconcili
 				fmt.Sprintf("-opa-integration=%t", data.Cluster().Spec.OPAIntegration != nil && data.Cluster().Spec.OPAIntegration.Enabled),
 			}, getNetworkArgs(data)...)
 
+			if data.Cluster().Spec.ExposeStrategy == kubermaticv1.ExposeStrategyTunneling {
+				args = append(args, "-tunneling-agent-ip", data.Cluster().Address.IP)
+				args = append(args, "-kas-secure-port", fmt.Sprint(data.Cluster().Address.Port))
+			}
+
 			if openshiftConsoleCallbackURI := data.Cluster().Address.OpenshiftConsoleCallBack; openshiftConsoleCallbackURI != "" {
 				args = append(args, "-openshift-console-callback-uri", openshiftConsoleCallbackURI)
 			}

--- a/pkg/util/flagopts/ip_flag.go
+++ b/pkg/util/flagopts/ip_flag.go
@@ -1,0 +1,39 @@
+/*
+Copyright 2020 The Kubermatic Kubernetes Platform contributors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package flagopts
+
+import (
+	"fmt"
+	"net"
+)
+
+type IPValue struct {
+	IP net.IP
+}
+
+func (i *IPValue) String() string {
+	return i.IP.String()
+}
+
+func (i *IPValue) Set(s string) error {
+	ip := net.ParseIP(s)
+	if ip == nil {
+		return fmt.Errorf("%q is not valid ip address", s)
+	}
+	i.IP = ip
+	return nil
+}


### PR DESCRIPTION
This PR introduces the deployment of the tunneling agent when tunneling expose strategy is used.

* Each agent is creating a dummy interface and assigning the IP chosen by the user with `host` scope through init containers.
* Envoy agent is deployed and configured to bind to such IP.

**What this PR does / why we need it**:

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #6392, #6445

**Special notes for your reviewer**:
This is not intended to be prod ready.

**Documentation**:
<!-- Add links to the related documentation changes related to this pull request. E.g. the link to the kubermatic/docs pull request. -->

**Does this PR introduce a user-facing change?**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If  no release note is required, just write "NONE".
-->
```release-note
Add Tunneling expose strategy (tech preview).
```
