### PR TITLE
Update the default value of service account token issuer to the URL of apiserver

### DIFF
--- a/cmd/kubermatic-api/swagger.json
+++ b/cmd/kubermatic-api/swagger.json
@@ -18202,7 +18202,7 @@
           "x-go-name": "APIAudiences"
         },
         "issuer": {
-          "description": "Issuer is the identifier of the service account token issuer\nIf this is not specified, it will be set to the default value kubernetes.default.svc",
+          "description": "Issuer is the identifier of the service account token issuer\nIf this is not specified, it will be set to the URL of apiserver by default",
           "type": "string",
           "x-go-name": "Issuer"
         },

--- a/pkg/crd/kubermatic/v1/cluster.go
+++ b/pkg/crd/kubermatic/v1/cluster.go
@@ -329,7 +329,7 @@ type OPAIntegrationSettings struct {
 type ServiceAccountSettings struct {
 	TokenVolumeProjectionEnabled bool `json:"tokenVolumeProjectionEnabled,omitempty"`
 	// Issuer is the identifier of the service account token issuer
-	// If this is not specified, it will be set to the default value kubernetes.default.svc
+	// If this is not specified, it will be set to the URL of apiserver by default
 	Issuer string `json:"issuer,omitempty"`
 	// APIAudiences are the Identifiers of the API
 	// If this is not specified, it will be set to a single element list containing the issuer URL

--- a/pkg/test/e2e/utils/apiclient/models/service_account_settings.go
+++ b/pkg/test/e2e/utils/apiclient/models/service_account_settings.go
@@ -20,7 +20,7 @@ type ServiceAccountSettings struct {
 	APIAudiences []string `json:"apiAudiences"`
 
 	// Issuer is the identifier of the service account token issuer
-	// If this is not specified, it will be set to the default value kubernetes.default.svc
+	// If this is not specified, it will be set to the URL of apiserver by default
 	Issuer string `json:"issuer,omitempty"`
 
 	// token volume projection enabled


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR updates the default value of service account token issuer to the URL of apiserver. It was default to `kubernetes.cluster.svc` and this is changed in 
https://github.com/kubermatic/kubermatic/pull/6122/files#diff-fad1e08c5bd97e226c2401126d17acbb787178668742e8a0182dc52b3b4e9ab1R334
**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Documentation**:
<!-- Add links to the related documentation changes related to this pull request. E.g. the link to the kubermatic/docs pull request. -->

**Does this PR introduce a user-facing change?**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If  no release note is required, just write "NONE".
-->
```release-note
NONE
```
