### PR TITLE
Relax memory limit for openvpn container

### DIFF
--- a/pkg/resources/openvpn/deployment.go
+++ b/pkg/resources/openvpn/deployment.go
@@ -39,7 +39,7 @@ var (
 			corev1.ResourceCPU:    resource.MustParse("5m"),
 		},
 		Limits: corev1.ResourceList{
-			corev1.ResourceMemory: resource.MustParse("20Mi"),
+			corev1.ResourceMemory: resource.MustParse("50Mi"),
 			corev1.ResourceCPU:    resource.MustParse("100m"),
 		},
 	}

--- a/pkg/resources/test/fixtures/deployment-aws-1.17.0-openvpn-server.yaml
+++ b/pkg/resources/test/fixtures/deployment-aws-1.17.0-openvpn-server.yaml
@@ -107,7 +107,7 @@ spec:
         resources:
           limits:
             cpu: 100m
-            memory: 20Mi
+            memory: 50Mi
           requests:
             cpu: 5m
             memory: 5Mi
@@ -162,7 +162,7 @@ spec:
         resources:
           limits:
             cpu: 100m
-            memory: 20Mi
+            memory: 50Mi
           requests:
             cpu: 5m
             memory: 5Mi
@@ -196,7 +196,7 @@ spec:
         resources:
           limits:
             cpu: 100m
-            memory: 20Mi
+            memory: 50Mi
           requests:
             cpu: 5m
             memory: 5Mi

--- a/pkg/resources/test/fixtures/deployment-aws-1.18.0-openvpn-server.yaml
+++ b/pkg/resources/test/fixtures/deployment-aws-1.18.0-openvpn-server.yaml
@@ -107,7 +107,7 @@ spec:
         resources:
           limits:
             cpu: 100m
-            memory: 20Mi
+            memory: 50Mi
           requests:
             cpu: 5m
             memory: 5Mi
@@ -162,7 +162,7 @@ spec:
         resources:
           limits:
             cpu: 100m
-            memory: 20Mi
+            memory: 50Mi
           requests:
             cpu: 5m
             memory: 5Mi
@@ -196,7 +196,7 @@ spec:
         resources:
           limits:
             cpu: 100m
-            memory: 20Mi
+            memory: 50Mi
           requests:
             cpu: 5m
             memory: 5Mi

--- a/pkg/resources/test/fixtures/deployment-aws-1.19.0-openvpn-server.yaml
+++ b/pkg/resources/test/fixtures/deployment-aws-1.19.0-openvpn-server.yaml
@@ -107,7 +107,7 @@ spec:
         resources:
           limits:
             cpu: 100m
-            memory: 20Mi
+            memory: 50Mi
           requests:
             cpu: 5m
             memory: 5Mi
@@ -162,7 +162,7 @@ spec:
         resources:
           limits:
             cpu: 100m
-            memory: 20Mi
+            memory: 50Mi
           requests:
             cpu: 5m
             memory: 5Mi
@@ -196,7 +196,7 @@ spec:
         resources:
           limits:
             cpu: 100m
-            memory: 20Mi
+            memory: 50Mi
           requests:
             cpu: 5m
             memory: 5Mi

--- a/pkg/resources/test/fixtures/deployment-aws-1.20.0-openvpn-server.yaml
+++ b/pkg/resources/test/fixtures/deployment-aws-1.20.0-openvpn-server.yaml
@@ -107,7 +107,7 @@ spec:
         resources:
           limits:
             cpu: 100m
-            memory: 20Mi
+            memory: 50Mi
           requests:
             cpu: 5m
             memory: 5Mi
@@ -162,7 +162,7 @@ spec:
         resources:
           limits:
             cpu: 100m
-            memory: 20Mi
+            memory: 50Mi
           requests:
             cpu: 5m
             memory: 5Mi
@@ -196,7 +196,7 @@ spec:
         resources:
           limits:
             cpu: 100m
-            memory: 20Mi
+            memory: 50Mi
           requests:
             cpu: 5m
             memory: 5Mi

--- a/pkg/resources/test/fixtures/deployment-azure-1.17.0-openvpn-server.yaml
+++ b/pkg/resources/test/fixtures/deployment-azure-1.17.0-openvpn-server.yaml
@@ -107,7 +107,7 @@ spec:
         resources:
           limits:
             cpu: 100m
-            memory: 20Mi
+            memory: 50Mi
           requests:
             cpu: 5m
             memory: 5Mi
@@ -162,7 +162,7 @@ spec:
         resources:
           limits:
             cpu: 100m
-            memory: 20Mi
+            memory: 50Mi
           requests:
             cpu: 5m
             memory: 5Mi
@@ -196,7 +196,7 @@ spec:
         resources:
           limits:
             cpu: 100m
-            memory: 20Mi
+            memory: 50Mi
           requests:
             cpu: 5m
             memory: 5Mi

--- a/pkg/resources/test/fixtures/deployment-azure-1.18.0-openvpn-server.yaml
+++ b/pkg/resources/test/fixtures/deployment-azure-1.18.0-openvpn-server.yaml
@@ -107,7 +107,7 @@ spec:
         resources:
           limits:
             cpu: 100m
-            memory: 20Mi
+            memory: 50Mi
           requests:
             cpu: 5m
             memory: 5Mi
@@ -162,7 +162,7 @@ spec:
         resources:
           limits:
             cpu: 100m
-            memory: 20Mi
+            memory: 50Mi
           requests:
             cpu: 5m
             memory: 5Mi
@@ -196,7 +196,7 @@ spec:
         resources:
           limits:
             cpu: 100m
-            memory: 20Mi
+            memory: 50Mi
           requests:
             cpu: 5m
             memory: 5Mi

--- a/pkg/resources/test/fixtures/deployment-azure-1.19.0-openvpn-server.yaml
+++ b/pkg/resources/test/fixtures/deployment-azure-1.19.0-openvpn-server.yaml
@@ -107,7 +107,7 @@ spec:
         resources:
           limits:
             cpu: 100m
-            memory: 20Mi
+            memory: 50Mi
           requests:
             cpu: 5m
             memory: 5Mi
@@ -162,7 +162,7 @@ spec:
         resources:
           limits:
             cpu: 100m
-            memory: 20Mi
+            memory: 50Mi
           requests:
             cpu: 5m
             memory: 5Mi
@@ -196,7 +196,7 @@ spec:
         resources:
           limits:
             cpu: 100m
-            memory: 20Mi
+            memory: 50Mi
           requests:
             cpu: 5m
             memory: 5Mi

--- a/pkg/resources/test/fixtures/deployment-azure-1.20.0-openvpn-server.yaml
+++ b/pkg/resources/test/fixtures/deployment-azure-1.20.0-openvpn-server.yaml
@@ -107,7 +107,7 @@ spec:
         resources:
           limits:
             cpu: 100m
-            memory: 20Mi
+            memory: 50Mi
           requests:
             cpu: 5m
             memory: 5Mi
@@ -162,7 +162,7 @@ spec:
         resources:
           limits:
             cpu: 100m
-            memory: 20Mi
+            memory: 50Mi
           requests:
             cpu: 5m
             memory: 5Mi
@@ -196,7 +196,7 @@ spec:
         resources:
           limits:
             cpu: 100m
-            memory: 20Mi
+            memory: 50Mi
           requests:
             cpu: 5m
             memory: 5Mi

--- a/pkg/resources/test/fixtures/deployment-bringyourown-1.17.0-openvpn-server.yaml
+++ b/pkg/resources/test/fixtures/deployment-bringyourown-1.17.0-openvpn-server.yaml
@@ -107,7 +107,7 @@ spec:
         resources:
           limits:
             cpu: 100m
-            memory: 20Mi
+            memory: 50Mi
           requests:
             cpu: 5m
             memory: 5Mi
@@ -162,7 +162,7 @@ spec:
         resources:
           limits:
             cpu: 100m
-            memory: 20Mi
+            memory: 50Mi
           requests:
             cpu: 5m
             memory: 5Mi
@@ -196,7 +196,7 @@ spec:
         resources:
           limits:
             cpu: 100m
-            memory: 20Mi
+            memory: 50Mi
           requests:
             cpu: 5m
             memory: 5Mi

--- a/pkg/resources/test/fixtures/deployment-bringyourown-1.18.0-openvpn-server.yaml
+++ b/pkg/resources/test/fixtures/deployment-bringyourown-1.18.0-openvpn-server.yaml
@@ -107,7 +107,7 @@ spec:
         resources:
           limits:
             cpu: 100m
-            memory: 20Mi
+            memory: 50Mi
           requests:
             cpu: 5m
             memory: 5Mi
@@ -162,7 +162,7 @@ spec:
         resources:
           limits:
             cpu: 100m
-            memory: 20Mi
+            memory: 50Mi
           requests:
             cpu: 5m
             memory: 5Mi
@@ -196,7 +196,7 @@ spec:
         resources:
           limits:
             cpu: 100m
-            memory: 20Mi
+            memory: 50Mi
           requests:
             cpu: 5m
             memory: 5Mi

--- a/pkg/resources/test/fixtures/deployment-bringyourown-1.19.0-openvpn-server.yaml
+++ b/pkg/resources/test/fixtures/deployment-bringyourown-1.19.0-openvpn-server.yaml
@@ -107,7 +107,7 @@ spec:
         resources:
           limits:
             cpu: 100m
-            memory: 20Mi
+            memory: 50Mi
           requests:
             cpu: 5m
             memory: 5Mi
@@ -162,7 +162,7 @@ spec:
         resources:
           limits:
             cpu: 100m
-            memory: 20Mi
+            memory: 50Mi
           requests:
             cpu: 5m
             memory: 5Mi
@@ -196,7 +196,7 @@ spec:
         resources:
           limits:
             cpu: 100m
-            memory: 20Mi
+            memory: 50Mi
           requests:
             cpu: 5m
             memory: 5Mi

--- a/pkg/resources/test/fixtures/deployment-bringyourown-1.20.0-openvpn-server.yaml
+++ b/pkg/resources/test/fixtures/deployment-bringyourown-1.20.0-openvpn-server.yaml
@@ -107,7 +107,7 @@ spec:
         resources:
           limits:
             cpu: 100m
-            memory: 20Mi
+            memory: 50Mi
           requests:
             cpu: 5m
             memory: 5Mi
@@ -162,7 +162,7 @@ spec:
         resources:
           limits:
             cpu: 100m
-            memory: 20Mi
+            memory: 50Mi
           requests:
             cpu: 5m
             memory: 5Mi
@@ -196,7 +196,7 @@ spec:
         resources:
           limits:
             cpu: 100m
-            memory: 20Mi
+            memory: 50Mi
           requests:
             cpu: 5m
             memory: 5Mi

--- a/pkg/resources/test/fixtures/deployment-digitalocean-1.17.0-openvpn-server.yaml
+++ b/pkg/resources/test/fixtures/deployment-digitalocean-1.17.0-openvpn-server.yaml
@@ -107,7 +107,7 @@ spec:
         resources:
           limits:
             cpu: 100m
-            memory: 20Mi
+            memory: 50Mi
           requests:
             cpu: 5m
             memory: 5Mi
@@ -162,7 +162,7 @@ spec:
         resources:
           limits:
             cpu: 100m
-            memory: 20Mi
+            memory: 50Mi
           requests:
             cpu: 5m
             memory: 5Mi
@@ -196,7 +196,7 @@ spec:
         resources:
           limits:
             cpu: 100m
-            memory: 20Mi
+            memory: 50Mi
           requests:
             cpu: 5m
             memory: 5Mi

--- a/pkg/resources/test/fixtures/deployment-digitalocean-1.18.0-openvpn-server.yaml
+++ b/pkg/resources/test/fixtures/deployment-digitalocean-1.18.0-openvpn-server.yaml
@@ -107,7 +107,7 @@ spec:
         resources:
           limits:
             cpu: 100m
-            memory: 20Mi
+            memory: 50Mi
           requests:
             cpu: 5m
             memory: 5Mi
@@ -162,7 +162,7 @@ spec:
         resources:
           limits:
             cpu: 100m
-            memory: 20Mi
+            memory: 50Mi
           requests:
             cpu: 5m
             memory: 5Mi
@@ -196,7 +196,7 @@ spec:
         resources:
           limits:
             cpu: 100m
-            memory: 20Mi
+            memory: 50Mi
           requests:
             cpu: 5m
             memory: 5Mi

--- a/pkg/resources/test/fixtures/deployment-digitalocean-1.19.0-openvpn-server.yaml
+++ b/pkg/resources/test/fixtures/deployment-digitalocean-1.19.0-openvpn-server.yaml
@@ -107,7 +107,7 @@ spec:
         resources:
           limits:
             cpu: 100m
-            memory: 20Mi
+            memory: 50Mi
           requests:
             cpu: 5m
             memory: 5Mi
@@ -162,7 +162,7 @@ spec:
         resources:
           limits:
             cpu: 100m
-            memory: 20Mi
+            memory: 50Mi
           requests:
             cpu: 5m
             memory: 5Mi
@@ -196,7 +196,7 @@ spec:
         resources:
           limits:
             cpu: 100m
-            memory: 20Mi
+            memory: 50Mi
           requests:
             cpu: 5m
             memory: 5Mi

--- a/pkg/resources/test/fixtures/deployment-digitalocean-1.20.0-openvpn-server.yaml
+++ b/pkg/resources/test/fixtures/deployment-digitalocean-1.20.0-openvpn-server.yaml
@@ -107,7 +107,7 @@ spec:
         resources:
           limits:
             cpu: 100m
-            memory: 20Mi
+            memory: 50Mi
           requests:
             cpu: 5m
             memory: 5Mi
@@ -162,7 +162,7 @@ spec:
         resources:
           limits:
             cpu: 100m
-            memory: 20Mi
+            memory: 50Mi
           requests:
             cpu: 5m
             memory: 5Mi
@@ -196,7 +196,7 @@ spec:
         resources:
           limits:
             cpu: 100m
-            memory: 20Mi
+            memory: 50Mi
           requests:
             cpu: 5m
             memory: 5Mi

--- a/pkg/resources/test/fixtures/deployment-openstack-1.17.0-openvpn-server.yaml
+++ b/pkg/resources/test/fixtures/deployment-openstack-1.17.0-openvpn-server.yaml
@@ -107,7 +107,7 @@ spec:
         resources:
           limits:
             cpu: 100m
-            memory: 20Mi
+            memory: 50Mi
           requests:
             cpu: 5m
             memory: 5Mi
@@ -162,7 +162,7 @@ spec:
         resources:
           limits:
             cpu: 100m
-            memory: 20Mi
+            memory: 50Mi
           requests:
             cpu: 5m
             memory: 5Mi
@@ -196,7 +196,7 @@ spec:
         resources:
           limits:
             cpu: 100m
-            memory: 20Mi
+            memory: 50Mi
           requests:
             cpu: 5m
             memory: 5Mi

--- a/pkg/resources/test/fixtures/deployment-openstack-1.18.0-openvpn-server.yaml
+++ b/pkg/resources/test/fixtures/deployment-openstack-1.18.0-openvpn-server.yaml
@@ -107,7 +107,7 @@ spec:
         resources:
           limits:
             cpu: 100m
-            memory: 20Mi
+            memory: 50Mi
           requests:
             cpu: 5m
             memory: 5Mi
@@ -162,7 +162,7 @@ spec:
         resources:
           limits:
             cpu: 100m
-            memory: 20Mi
+            memory: 50Mi
           requests:
             cpu: 5m
             memory: 5Mi
@@ -196,7 +196,7 @@ spec:
         resources:
           limits:
             cpu: 100m
-            memory: 20Mi
+            memory: 50Mi
           requests:
             cpu: 5m
             memory: 5Mi

--- a/pkg/resources/test/fixtures/deployment-openstack-1.19.0-openvpn-server.yaml
+++ b/pkg/resources/test/fixtures/deployment-openstack-1.19.0-openvpn-server.yaml
@@ -107,7 +107,7 @@ spec:
         resources:
           limits:
             cpu: 100m
-            memory: 20Mi
+            memory: 50Mi
           requests:
             cpu: 5m
             memory: 5Mi
@@ -162,7 +162,7 @@ spec:
         resources:
           limits:
             cpu: 100m
-            memory: 20Mi
+            memory: 50Mi
           requests:
             cpu: 5m
             memory: 5Mi
@@ -196,7 +196,7 @@ spec:
         resources:
           limits:
             cpu: 100m
-            memory: 20Mi
+            memory: 50Mi
           requests:
             cpu: 5m
             memory: 5Mi

--- a/pkg/resources/test/fixtures/deployment-openstack-1.20.0-openvpn-server.yaml
+++ b/pkg/resources/test/fixtures/deployment-openstack-1.20.0-openvpn-server.yaml
@@ -107,7 +107,7 @@ spec:
         resources:
           limits:
             cpu: 100m
-            memory: 20Mi
+            memory: 50Mi
           requests:
             cpu: 5m
             memory: 5Mi
@@ -162,7 +162,7 @@ spec:
         resources:
           limits:
             cpu: 100m
-            memory: 20Mi
+            memory: 50Mi
           requests:
             cpu: 5m
             memory: 5Mi
@@ -196,7 +196,7 @@ spec:
         resources:
           limits:
             cpu: 100m
-            memory: 20Mi
+            memory: 50Mi
           requests:
             cpu: 5m
             memory: 5Mi

--- a/pkg/resources/test/fixtures/deployment-vsphere-1.17.0-openvpn-server.yaml
+++ b/pkg/resources/test/fixtures/deployment-vsphere-1.17.0-openvpn-server.yaml
@@ -107,7 +107,7 @@ spec:
         resources:
           limits:
             cpu: 100m
-            memory: 20Mi
+            memory: 50Mi
           requests:
             cpu: 5m
             memory: 5Mi
@@ -162,7 +162,7 @@ spec:
         resources:
           limits:
             cpu: 100m
-            memory: 20Mi
+            memory: 50Mi
           requests:
             cpu: 5m
             memory: 5Mi
@@ -196,7 +196,7 @@ spec:
         resources:
           limits:
             cpu: 100m
-            memory: 20Mi
+            memory: 50Mi
           requests:
             cpu: 5m
             memory: 5Mi

--- a/pkg/resources/test/fixtures/deployment-vsphere-1.18.0-openvpn-server.yaml
+++ b/pkg/resources/test/fixtures/deployment-vsphere-1.18.0-openvpn-server.yaml
@@ -107,7 +107,7 @@ spec:
         resources:
           limits:
             cpu: 100m
-            memory: 20Mi
+            memory: 50Mi
           requests:
             cpu: 5m
             memory: 5Mi
@@ -162,7 +162,7 @@ spec:
         resources:
           limits:
             cpu: 100m
-            memory: 20Mi
+            memory: 50Mi
           requests:
             cpu: 5m
             memory: 5Mi
@@ -196,7 +196,7 @@ spec:
         resources:
           limits:
             cpu: 100m
-            memory: 20Mi
+            memory: 50Mi
           requests:
             cpu: 5m
             memory: 5Mi

--- a/pkg/resources/test/fixtures/deployment-vsphere-1.19.0-openvpn-server.yaml
+++ b/pkg/resources/test/fixtures/deployment-vsphere-1.19.0-openvpn-server.yaml
@@ -107,7 +107,7 @@ spec:
         resources:
           limits:
             cpu: 100m
-            memory: 20Mi
+            memory: 50Mi
           requests:
             cpu: 5m
             memory: 5Mi
@@ -162,7 +162,7 @@ spec:
         resources:
           limits:
             cpu: 100m
-            memory: 20Mi
+            memory: 50Mi
           requests:
             cpu: 5m
             memory: 5Mi
@@ -196,7 +196,7 @@ spec:
         resources:
           limits:
             cpu: 100m
-            memory: 20Mi
+            memory: 50Mi
           requests:
             cpu: 5m
             memory: 5Mi

--- a/pkg/resources/test/fixtures/deployment-vsphere-1.20.0-openvpn-server.yaml
+++ b/pkg/resources/test/fixtures/deployment-vsphere-1.20.0-openvpn-server.yaml
@@ -107,7 +107,7 @@ spec:
         resources:
           limits:
             cpu: 100m
-            memory: 20Mi
+            memory: 50Mi
           requests:
             cpu: 5m
             memory: 5Mi
@@ -162,7 +162,7 @@ spec:
         resources:
           limits:
             cpu: 100m
-            memory: 20Mi
+            memory: 50Mi
           requests:
             cpu: 5m
             memory: 5Mi
@@ -196,7 +196,7 @@ spec:
         resources:
           limits:
             cpu: 100m
-            memory: 20Mi
+            memory: 50Mi
           requests:
             cpu: 5m
             memory: 5Mi


### PR DESCRIPTION
**What this PR does / why we need it**:
Some of our customers run into the issue with openvpn container that described in the following post 
https://www.cloudfoundry.org/blog/the-garden-team-and-the-strange-case-of-a-connection-being-reset/

This PS is an attempt to fix the issue, but given the race-condition nature of the issue it may fail too.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Documentation**:
<!-- Add links to the related documentation changes related to this pull request. E.g. the link to the kubermatic/docs pull request. -->

**Does this PR introduce a user-facing change?**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If  no release note is required, just write "NONE".
-->
```release-note
Relax memory limit for openvpn container
```
