### PR TITLE
increase resources for go mod verify

### DIFF
--- a/.prow.yaml
+++ b/.prow.yaml
@@ -202,10 +202,7 @@ presubmits:
         resources:
           requests:
             memory: 256Mi
-            cpu: 250m
-          limits:
-            memory: 256Mi
-            cpu: 250m
+            cpu: 1
         env:
         - name: KUBERMATIC_EDITION
           value: ee


### PR DESCRIPTION
**What this PR does / why we need it**:
On my computer, `go mod verify` takes roughly 5-10 seconds. On CI, it takes upwards of 10 (ten) minutes. For no reason.

**Does this PR introduce a user-facing change?**:
```release-note
NONE
```
