### PR TITLE
Compute CoreDNS version based on Kubernetes version

### DIFF
--- a/cmd/etcd-launcher/Dockerfile
+++ b/cmd/etcd-launcher/Dockerfile
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-FROM busybox
+FROM busybox:1.32.1
 LABEL maintainer="support@kubermatic.com"
 
 COPY ./_build/etcd-launcher /

--- a/pkg/controller/user-cluster-controller-manager/resources/controller.go
+++ b/pkg/controller/user-cluster-controller-manager/resources/controller.go
@@ -25,6 +25,7 @@ import (
 	"sync"
 	"time"
 
+	"github.com/Masterminds/semver/v3"
 	"github.com/heptiolabs/healthcheck"
 	"go.uber.org/zap"
 
@@ -96,6 +97,11 @@ func Add(
 		opaIntegration:                opaIntegration,
 		userSSHKeyAgent:               userSSHKeyAgent,
 		versions:                      versions,
+	}
+
+	var err error
+	if r.clusterSemVer, err = semver.NewVersion(r.version); err != nil {
+		return err
 	}
 
 	if r.openshift {
@@ -228,6 +234,7 @@ type reconciler struct {
 	seedClient                    client.Client
 	openshift                     bool
 	version                       string
+	clusterSemVer                 *semver.Version
 	cache                         cache.Cache
 	namespace                     string
 	clusterURL                    *url.URL

--- a/pkg/controller/user-cluster-controller-manager/resources/reconciler.go
+++ b/pkg/controller/user-cluster-controller-manager/resources/reconciler.go
@@ -689,7 +689,7 @@ func (r *reconciler) reconcileDeployments(ctx context.Context) error {
 	}
 
 	kubeSystemCreators := []reconciling.NamedDeploymentCreatorGetter{
-		coredns.DeploymentCreator(),
+		coredns.DeploymentCreator(r.clusterSemVer),
 	}
 
 	if err := reconciling.ReconcileDeployments(ctx, kubeSystemCreators, metav1.NamespaceSystem, r.Client); err != nil {

--- a/pkg/controller/user-cluster-controller-manager/resources/resources/core-dns/configmap.go
+++ b/pkg/controller/user-cluster-controller-manager/resources/resources/core-dns/configmap.go
@@ -37,11 +37,10 @@ func ConfigMapCreator() reconciling.NamedConfigMapCreatorGetter {
           health
           kubernetes cluster.local in-addr.arpa ip6.arpa {
              pods insecure
-             upstream
              fallthrough in-addr.arpa ip6.arpa
           }
           prometheus :9153
-          proxy . /etc/resolv.conf
+          forward . /etc/resolv.conf
           cache 30
           loop
           reload

--- a/pkg/resources/test/fixtures/deployment-aws-1.17.0-dns-resolver.yaml
+++ b/pkg/resources/test/fixtures/deployment-aws-1.17.0-dns-resolver.yaml
@@ -99,7 +99,7 @@ spec:
       - args:
         - -conf
         - /etc/coredns/Corefile
-        image: k8s.gcr.io/coredns:1.3.1
+        image: k8s.gcr.io/coredns:1.6.5
         name: dns-resolver
         readinessProbe:
           failureThreshold: 3

--- a/pkg/resources/test/fixtures/deployment-aws-1.18.0-dns-resolver.yaml
+++ b/pkg/resources/test/fixtures/deployment-aws-1.18.0-dns-resolver.yaml
@@ -99,7 +99,7 @@ spec:
       - args:
         - -conf
         - /etc/coredns/Corefile
-        image: k8s.gcr.io/coredns:1.3.1
+        image: k8s.gcr.io/coredns:1.6.7
         name: dns-resolver
         readinessProbe:
           failureThreshold: 3

--- a/pkg/resources/test/fixtures/deployment-aws-1.19.0-dns-resolver.yaml
+++ b/pkg/resources/test/fixtures/deployment-aws-1.19.0-dns-resolver.yaml
@@ -99,7 +99,7 @@ spec:
       - args:
         - -conf
         - /etc/coredns/Corefile
-        image: k8s.gcr.io/coredns:1.3.1
+        image: k8s.gcr.io/coredns:1.7.0
         name: dns-resolver
         readinessProbe:
           failureThreshold: 3

--- a/pkg/resources/test/fixtures/deployment-aws-1.20.0-dns-resolver.yaml
+++ b/pkg/resources/test/fixtures/deployment-aws-1.20.0-dns-resolver.yaml
@@ -99,7 +99,7 @@ spec:
       - args:
         - -conf
         - /etc/coredns/Corefile
-        image: k8s.gcr.io/coredns:1.3.1
+        image: k8s.gcr.io/coredns:1.7.0
         name: dns-resolver
         readinessProbe:
           failureThreshold: 3

--- a/pkg/resources/test/fixtures/deployment-azure-1.17.0-dns-resolver.yaml
+++ b/pkg/resources/test/fixtures/deployment-azure-1.17.0-dns-resolver.yaml
@@ -99,7 +99,7 @@ spec:
       - args:
         - -conf
         - /etc/coredns/Corefile
-        image: k8s.gcr.io/coredns:1.3.1
+        image: k8s.gcr.io/coredns:1.6.5
         name: dns-resolver
         readinessProbe:
           failureThreshold: 3

--- a/pkg/resources/test/fixtures/deployment-azure-1.18.0-dns-resolver.yaml
+++ b/pkg/resources/test/fixtures/deployment-azure-1.18.0-dns-resolver.yaml
@@ -99,7 +99,7 @@ spec:
       - args:
         - -conf
         - /etc/coredns/Corefile
-        image: k8s.gcr.io/coredns:1.3.1
+        image: k8s.gcr.io/coredns:1.6.7
         name: dns-resolver
         readinessProbe:
           failureThreshold: 3

--- a/pkg/resources/test/fixtures/deployment-azure-1.19.0-dns-resolver.yaml
+++ b/pkg/resources/test/fixtures/deployment-azure-1.19.0-dns-resolver.yaml
@@ -99,7 +99,7 @@ spec:
       - args:
         - -conf
         - /etc/coredns/Corefile
-        image: k8s.gcr.io/coredns:1.3.1
+        image: k8s.gcr.io/coredns:1.7.0
         name: dns-resolver
         readinessProbe:
           failureThreshold: 3

--- a/pkg/resources/test/fixtures/deployment-azure-1.20.0-dns-resolver.yaml
+++ b/pkg/resources/test/fixtures/deployment-azure-1.20.0-dns-resolver.yaml
@@ -99,7 +99,7 @@ spec:
       - args:
         - -conf
         - /etc/coredns/Corefile
-        image: k8s.gcr.io/coredns:1.3.1
+        image: k8s.gcr.io/coredns:1.7.0
         name: dns-resolver
         readinessProbe:
           failureThreshold: 3

--- a/pkg/resources/test/fixtures/deployment-bringyourown-1.17.0-dns-resolver.yaml
+++ b/pkg/resources/test/fixtures/deployment-bringyourown-1.17.0-dns-resolver.yaml
@@ -99,7 +99,7 @@ spec:
       - args:
         - -conf
         - /etc/coredns/Corefile
-        image: k8s.gcr.io/coredns:1.3.1
+        image: k8s.gcr.io/coredns:1.6.5
         name: dns-resolver
         readinessProbe:
           failureThreshold: 3

--- a/pkg/resources/test/fixtures/deployment-bringyourown-1.18.0-dns-resolver.yaml
+++ b/pkg/resources/test/fixtures/deployment-bringyourown-1.18.0-dns-resolver.yaml
@@ -99,7 +99,7 @@ spec:
       - args:
         - -conf
         - /etc/coredns/Corefile
-        image: k8s.gcr.io/coredns:1.3.1
+        image: k8s.gcr.io/coredns:1.6.7
         name: dns-resolver
         readinessProbe:
           failureThreshold: 3

--- a/pkg/resources/test/fixtures/deployment-bringyourown-1.19.0-dns-resolver.yaml
+++ b/pkg/resources/test/fixtures/deployment-bringyourown-1.19.0-dns-resolver.yaml
@@ -99,7 +99,7 @@ spec:
       - args:
         - -conf
         - /etc/coredns/Corefile
-        image: k8s.gcr.io/coredns:1.3.1
+        image: k8s.gcr.io/coredns:1.7.0
         name: dns-resolver
         readinessProbe:
           failureThreshold: 3

--- a/pkg/resources/test/fixtures/deployment-bringyourown-1.20.0-dns-resolver.yaml
+++ b/pkg/resources/test/fixtures/deployment-bringyourown-1.20.0-dns-resolver.yaml
@@ -99,7 +99,7 @@ spec:
       - args:
         - -conf
         - /etc/coredns/Corefile
-        image: k8s.gcr.io/coredns:1.3.1
+        image: k8s.gcr.io/coredns:1.7.0
         name: dns-resolver
         readinessProbe:
           failureThreshold: 3

--- a/pkg/resources/test/fixtures/deployment-digitalocean-1.17.0-dns-resolver.yaml
+++ b/pkg/resources/test/fixtures/deployment-digitalocean-1.17.0-dns-resolver.yaml
@@ -99,7 +99,7 @@ spec:
       - args:
         - -conf
         - /etc/coredns/Corefile
-        image: k8s.gcr.io/coredns:1.3.1
+        image: k8s.gcr.io/coredns:1.6.5
         name: dns-resolver
         readinessProbe:
           failureThreshold: 3

--- a/pkg/resources/test/fixtures/deployment-digitalocean-1.18.0-dns-resolver.yaml
+++ b/pkg/resources/test/fixtures/deployment-digitalocean-1.18.0-dns-resolver.yaml
@@ -99,7 +99,7 @@ spec:
       - args:
         - -conf
         - /etc/coredns/Corefile
-        image: k8s.gcr.io/coredns:1.3.1
+        image: k8s.gcr.io/coredns:1.6.7
         name: dns-resolver
         readinessProbe:
           failureThreshold: 3

--- a/pkg/resources/test/fixtures/deployment-digitalocean-1.19.0-dns-resolver.yaml
+++ b/pkg/resources/test/fixtures/deployment-digitalocean-1.19.0-dns-resolver.yaml
@@ -99,7 +99,7 @@ spec:
       - args:
         - -conf
         - /etc/coredns/Corefile
-        image: k8s.gcr.io/coredns:1.3.1
+        image: k8s.gcr.io/coredns:1.7.0
         name: dns-resolver
         readinessProbe:
           failureThreshold: 3

--- a/pkg/resources/test/fixtures/deployment-digitalocean-1.20.0-dns-resolver.yaml
+++ b/pkg/resources/test/fixtures/deployment-digitalocean-1.20.0-dns-resolver.yaml
@@ -99,7 +99,7 @@ spec:
       - args:
         - -conf
         - /etc/coredns/Corefile
-        image: k8s.gcr.io/coredns:1.3.1
+        image: k8s.gcr.io/coredns:1.7.0
         name: dns-resolver
         readinessProbe:
           failureThreshold: 3

--- a/pkg/resources/test/fixtures/deployment-openstack-1.17.0-dns-resolver.yaml
+++ b/pkg/resources/test/fixtures/deployment-openstack-1.17.0-dns-resolver.yaml
@@ -99,7 +99,7 @@ spec:
       - args:
         - -conf
         - /etc/coredns/Corefile
-        image: k8s.gcr.io/coredns:1.3.1
+        image: k8s.gcr.io/coredns:1.6.5
         name: dns-resolver
         readinessProbe:
           failureThreshold: 3

--- a/pkg/resources/test/fixtures/deployment-openstack-1.18.0-dns-resolver.yaml
+++ b/pkg/resources/test/fixtures/deployment-openstack-1.18.0-dns-resolver.yaml
@@ -99,7 +99,7 @@ spec:
       - args:
         - -conf
         - /etc/coredns/Corefile
-        image: k8s.gcr.io/coredns:1.3.1
+        image: k8s.gcr.io/coredns:1.6.7
         name: dns-resolver
         readinessProbe:
           failureThreshold: 3

--- a/pkg/resources/test/fixtures/deployment-openstack-1.19.0-dns-resolver.yaml
+++ b/pkg/resources/test/fixtures/deployment-openstack-1.19.0-dns-resolver.yaml
@@ -99,7 +99,7 @@ spec:
       - args:
         - -conf
         - /etc/coredns/Corefile
-        image: k8s.gcr.io/coredns:1.3.1
+        image: k8s.gcr.io/coredns:1.7.0
         name: dns-resolver
         readinessProbe:
           failureThreshold: 3

--- a/pkg/resources/test/fixtures/deployment-openstack-1.20.0-dns-resolver.yaml
+++ b/pkg/resources/test/fixtures/deployment-openstack-1.20.0-dns-resolver.yaml
@@ -99,7 +99,7 @@ spec:
       - args:
         - -conf
         - /etc/coredns/Corefile
-        image: k8s.gcr.io/coredns:1.3.1
+        image: k8s.gcr.io/coredns:1.7.0
         name: dns-resolver
         readinessProbe:
           failureThreshold: 3

--- a/pkg/resources/test/fixtures/deployment-vsphere-1.17.0-dns-resolver.yaml
+++ b/pkg/resources/test/fixtures/deployment-vsphere-1.17.0-dns-resolver.yaml
@@ -99,7 +99,7 @@ spec:
       - args:
         - -conf
         - /etc/coredns/Corefile
-        image: k8s.gcr.io/coredns:1.3.1
+        image: k8s.gcr.io/coredns:1.6.5
         name: dns-resolver
         readinessProbe:
           failureThreshold: 3

--- a/pkg/resources/test/fixtures/deployment-vsphere-1.18.0-dns-resolver.yaml
+++ b/pkg/resources/test/fixtures/deployment-vsphere-1.18.0-dns-resolver.yaml
@@ -99,7 +99,7 @@ spec:
       - args:
         - -conf
         - /etc/coredns/Corefile
-        image: k8s.gcr.io/coredns:1.3.1
+        image: k8s.gcr.io/coredns:1.6.7
         name: dns-resolver
         readinessProbe:
           failureThreshold: 3

--- a/pkg/resources/test/fixtures/deployment-vsphere-1.19.0-dns-resolver.yaml
+++ b/pkg/resources/test/fixtures/deployment-vsphere-1.19.0-dns-resolver.yaml
@@ -99,7 +99,7 @@ spec:
       - args:
         - -conf
         - /etc/coredns/Corefile
-        image: k8s.gcr.io/coredns:1.3.1
+        image: k8s.gcr.io/coredns:1.7.0
         name: dns-resolver
         readinessProbe:
           failureThreshold: 3

--- a/pkg/resources/test/fixtures/deployment-vsphere-1.20.0-dns-resolver.yaml
+++ b/pkg/resources/test/fixtures/deployment-vsphere-1.20.0-dns-resolver.yaml
@@ -99,7 +99,7 @@ spec:
       - args:
         - -conf
         - /etc/coredns/Corefile
-        image: k8s.gcr.io/coredns:1.3.1
+        image: k8s.gcr.io/coredns:1.7.0
         name: dns-resolver
         readinessProbe:
           failureThreshold: 3


### PR DESCRIPTION
And result to deploy both, in-seed and in-user-cluster CoreDNS

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #6023 

**Does this PR introduce a user-facing change?**:
```release-note
CoreDNS version now based on Kubernetes version
```
