### PR TITLE
Open NodePorts for openstack

### DIFF
--- a/cmd/conformance-tests/runner.go
+++ b/cmd/conformance-tests/runner.go
@@ -1190,7 +1190,7 @@ func (r *testRunner) getGinkgoRuns(
 			ginkgoFocus:   `\[Serial\].*\[Conformance\]`,
 			ginkgoSkip:    `should not cause race condition when used for configmap`,
 			parallelTests: 1,
-			timeout:       30 * time.Minute,
+			timeout:       60 * time.Minute,
 		},
 	}
 	versionRoot := path.Join(repoRoot, MajorMinor)

--- a/pkg/provider/cloud/openstack/helper.go
+++ b/pkg/provider/cloud/openstack/helper.go
@@ -37,6 +37,7 @@ import (
 	osports "github.com/gophercloud/gophercloud/openstack/networking/v2/ports"
 	ossubnets "github.com/gophercloud/gophercloud/openstack/networking/v2/subnets"
 	"github.com/gophercloud/gophercloud/pagination"
+
 	"k8c.io/kubermatic/v2/pkg/provider"
 )
 
@@ -201,6 +202,15 @@ func createKubermaticSecurityGroup(netClient *gophercloud.ServiceClient, cluster
 			SecGroupID:   securityGroupID,
 			PortRangeMin: provider.DefaultSSHPort,
 			PortRangeMax: provider.DefaultSSHPort,
+			Protocol:     osecuritygrouprules.ProtocolTCP,
+		},
+		{
+			// Allows NodePort range
+			Direction:    osecuritygrouprules.DirIngress,
+			EtherType:    osecuritygrouprules.EtherType4,
+			SecGroupID:   securityGroupID,
+			PortRangeMin: 30000,
+			PortRangeMax: 32000,
 			Protocol:     osecuritygrouprules.ProtocolTCP,
 		},
 		{


### PR DESCRIPTION
In case when SecurityGroup is managed by us, open NodePorts for openstack.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #6283

**Special notes for your reviewer**:

**Documentation**:
<!-- Add links to the related documentation changes related to this pull request. E.g. the link to the kubermatic/docs pull request. -->

**Does this PR introduce a user-facing change?**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If  no release note is required, just write "NONE".
-->
```release-note
Open NodePorts for openstack
```
