### PR TITLE
Add support for use-octavia in openstack-providerspecs

### DIFF
--- a/cmd/example-yaml-generator/main.go
+++ b/cmd/example-yaml-generator/main.go
@@ -136,6 +136,7 @@ func createExampleSeed() *kubermaticv1.Seed {
 						Openstack: &kubermaticv1.DatacenterSpecOpenstack{
 							Images:               imageList,
 							ManageSecurityGroups: pointer.BoolPtr(true),
+							UseOctavia:           pointer.BoolPtr(true),
 							DNSServers:           []string{},
 							TrustDevicePath:      pointer.BoolPtr(false),
 						},

--- a/cmd/kubermatic-api/swagger.json
+++ b/cmd/kubermatic-api/swagger.json
@@ -15085,11 +15085,6 @@
           "type": "boolean",
           "x-go-name": "ManageSecurityGroups"
         },
-        "use_octavia": {
-          "description": "Optional: Gets mapped to the \"use-octavia\" setting in the cloud config.\nThis setting defaults to true.",
-          "type": "boolean",
-          "x-go-name": "UseOctavia"
-        },
         "node_size_requirements": {
           "$ref": "#/definitions/OpenstackNodeSizeRequirements"
         },
@@ -15101,6 +15096,11 @@
           "description": "Optional: Gets mapped to the \"trust-device-path\" setting in the cloud config.\nSee https://kubernetes.io/docs/concepts/cluster-administration/cloud-providers/#block-storage\nThis setting defaults to false.",
           "type": "boolean",
           "x-go-name": "TrustDevicePath"
+        },
+        "use_octavia": {
+          "description": "Optional: Gets mapped to the \"use-octavia\" setting in the cloud config.\nSee https://kubernetes.io/docs/concepts/cluster-administration/cloud-providers/#load-balancer\nThis setting defaults to true.",
+          "type": "boolean",
+          "x-go-name": "UseOctavia"
         }
       },
       "x-go-package": "k8c.io/kubermatic/v2/pkg/crd/kubermatic/v1"

--- a/cmd/kubermatic-api/swagger.json
+++ b/cmd/kubermatic-api/swagger.json
@@ -15098,7 +15098,7 @@
           "x-go-name": "TrustDevicePath"
         },
         "use_octavia": {
-          "description": "Optional: Gets mapped to the \"use-octavia\" setting in the cloud config.\nuse-octavia is enabled by default in CCM since v1.17.0, and disabled by\ndefault with the in-tree cloud provider. This setting defaults to true.",
+          "description": "Optional: Gets mapped to the \"use-octavia\" setting in the cloud config.\nuse-octavia is enabled by default in CCM since v1.17.0, and disabled by\ndefault with the in-tree cloud provider.",
           "type": "boolean",
           "x-go-name": "UseOctavia"
         }

--- a/cmd/kubermatic-api/swagger.json
+++ b/cmd/kubermatic-api/swagger.json
@@ -15085,6 +15085,11 @@
           "type": "boolean",
           "x-go-name": "ManageSecurityGroups"
         },
+        "use_octavia": {
+          "description": "Optional: Gets mapped to the \"use-octavia\" setting in the cloud config.\nThis setting defaults to true.",
+          "type": "boolean",
+          "x-go-name": "UseOctavia"
+        },
         "node_size_requirements": {
           "$ref": "#/definitions/OpenstackNodeSizeRequirements"
         },

--- a/cmd/kubermatic-api/swagger.json
+++ b/cmd/kubermatic-api/swagger.json
@@ -15098,7 +15098,7 @@
           "x-go-name": "TrustDevicePath"
         },
         "use_octavia": {
-          "description": "Optional: Gets mapped to the \"use-octavia\" setting in the cloud config.\nSee https://kubernetes.io/docs/concepts/cluster-administration/cloud-providers/#load-balancer\nThis setting defaults to true.",
+          "description": "Optional: Gets mapped to the \"use-octavia\" setting in the cloud config.\nuse-octavia is enabled by default in CCM since v1.17.0, and disabled by\ndefault with the in-tree cloud provider. This setting defaults to true.",
           "type": "boolean",
           "x-go-name": "UseOctavia"
         }

--- a/docs/zz_generated.seed.yaml
+++ b/docs/zz_generated.seed.yaml
@@ -139,8 +139,6 @@ spec:
           # See https://kubernetes.io/docs/concepts/cluster-administration/cloud-providers/#load-balancer
           # This setting defaults to true.
           manage_security_groups: true
-          # Optional: Gets mapped to "use-octavia" setting in the cloud config. This setting defaults to true.
-          use_octavia: true
           node_size_requirements:
             # MinimumMemory is the minimum required amount of memory, measured in MB
             minimum_memory: 0
@@ -151,6 +149,10 @@ spec:
           # See https://kubernetes.io/docs/concepts/cluster-administration/cloud-providers/#block-storage
           # This setting defaults to false.
           trust_device_path: false
+          # Optional: Gets mapped to the "use-octavia" setting in the cloud config.
+          # See https://kubernetes.io/docs/concepts/cluster-administration/cloud-providers/#load-balancer
+          # This setting defaults to true.
+          use_octavia: true
         packet:
           # The list of enabled facilities, for example "ams1", for a full list of available
           # facilities see https://support.packet.com/kb/articles/data-centers

--- a/docs/zz_generated.seed.yaml
+++ b/docs/zz_generated.seed.yaml
@@ -139,6 +139,8 @@ spec:
           # See https://kubernetes.io/docs/concepts/cluster-administration/cloud-providers/#load-balancer
           # This setting defaults to true.
           manage_security_groups: true
+          # Optional: Gets mapped to "use-octavia" setting in the cloud config. This setting defaults to true.
+          use_octavia: true
           node_size_requirements:
             # MinimumMemory is the minimum required amount of memory, measured in MB
             minimum_memory: 0

--- a/docs/zz_generated.seed.yaml
+++ b/docs/zz_generated.seed.yaml
@@ -150,8 +150,8 @@ spec:
           # This setting defaults to false.
           trust_device_path: false
           # Optional: Gets mapped to the "use-octavia" setting in the cloud config.
-          # See https://kubernetes.io/docs/concepts/cluster-administration/cloud-providers/#load-balancer
-          # This setting defaults to true.
+          # use-octavia is enabled by default in CCM since v1.17.0, and disabled by
+          # default with the in-tree cloud provider.
           use_octavia: true
         packet:
           # The list of enabled facilities, for example "ams1", for a full list of available

--- a/pkg/crd/kubermatic/v1/datacenter.go
+++ b/pkg/crd/kubermatic/v1/datacenter.go
@@ -206,6 +206,10 @@ type DatacenterSpecOpenstack struct {
 	// See https://kubernetes.io/docs/concepts/cluster-administration/cloud-providers/#load-balancer
 	// This setting defaults to true.
 	ManageSecurityGroups *bool `json:"manage_security_groups"`
+	// Optional: Gets mapped to the "use-octavia" setting in the cloud config.
+	// See https://kubernetes.io/docs/concepts/cluster-administration/cloud-providers/#load-balancer
+	// This setting defaults to true.
+	UseOctavia *bool `json:"use_octavia"`
 	// Optional: Gets mapped to the "trust-device-path" setting in the cloud config.
 	// See https://kubernetes.io/docs/concepts/cluster-administration/cloud-providers/#block-storage
 	// This setting defaults to false.

--- a/pkg/crd/kubermatic/v1/datacenter.go
+++ b/pkg/crd/kubermatic/v1/datacenter.go
@@ -208,7 +208,7 @@ type DatacenterSpecOpenstack struct {
 	ManageSecurityGroups *bool `json:"manage_security_groups"`
 	// Optional: Gets mapped to the "use-octavia" setting in the cloud config.
 	// use-octavia is enabled by default in CCM since v1.17.0, and disabled by
-	// default with the in-tree cloud provider. This setting defaults to true.
+	// default with the in-tree cloud provider.
 	UseOctavia *bool `json:"use_octavia"`
 	// Optional: Gets mapped to the "trust-device-path" setting in the cloud config.
 	// See https://kubernetes.io/docs/concepts/cluster-administration/cloud-providers/#block-storage

--- a/pkg/crd/kubermatic/v1/datacenter.go
+++ b/pkg/crd/kubermatic/v1/datacenter.go
@@ -207,8 +207,8 @@ type DatacenterSpecOpenstack struct {
 	// This setting defaults to true.
 	ManageSecurityGroups *bool `json:"manage_security_groups"`
 	// Optional: Gets mapped to the "use-octavia" setting in the cloud config.
-	// See https://kubernetes.io/docs/concepts/cluster-administration/cloud-providers/#load-balancer
-	// This setting defaults to true.
+	// use-octavia is enabled by default in CCM since v1.17.0, and disabled by
+	// default with the in-tree cloud provider. This setting defaults to true.
 	UseOctavia *bool `json:"use_octavia"`
 	// Optional: Gets mapped to the "trust-device-path" setting in the cloud config.
 	// See https://kubernetes.io/docs/concepts/cluster-administration/cloud-providers/#block-storage

--- a/pkg/crd/kubermatic/v1/zz_generated.deepcopy.go
+++ b/pkg/crd/kubermatic/v1/zz_generated.deepcopy.go
@@ -1415,6 +1415,11 @@ func (in *DatacenterSpecOpenstack) DeepCopyInto(out *DatacenterSpecOpenstack) {
 		*out = new(bool)
 		**out = **in
 	}
+	if in.UseOctavia != nil {
+		in, out := &in.UseOctavia, &out.UseOctavia
+		*out = new(bool)
+		**out = **in
+	}
 	if in.TrustDevicePath != nil {
 		in, out := &in.TrustDevicePath, &out.TrustDevicePath
 		*out = new(bool)

--- a/pkg/resources/cloudconfig/configmap.go
+++ b/pkg/resources/cloudconfig/configmap.go
@@ -126,6 +126,7 @@ func CloudConfig(
 
 	case cloud.Openstack != nil:
 		manageSecurityGroups := dc.Spec.Openstack.ManageSecurityGroups
+		useOctavia := dc.Spec.Openstack.UseOctavia
 		trustDevicePath := dc.Spec.Openstack.TrustDevicePath
 		openstackCloudConfig := &openstack.CloudConfig{
 			Global: openstack.GlobalOpts{
@@ -144,6 +145,7 @@ func CloudConfig(
 			},
 			LoadBalancer: openstack.LoadBalancerOpts{
 				ManageSecurityGroups: manageSecurityGroups == nil || *manageSecurityGroups,
+				UseOctavia: useOctavia == nil || *useOctavia,
 			},
 			Version: cluster.Spec.Version.String(),
 		}

--- a/pkg/resources/cloudconfig/configmap.go
+++ b/pkg/resources/cloudconfig/configmap.go
@@ -144,7 +144,7 @@ func CloudConfig(
 			},
 			LoadBalancer: openstack.LoadBalancerOpts{
 				ManageSecurityGroups: manageSecurityGroups == nil || *manageSecurityGroups,
-				UseOctavia: dc.Spec.Openstack.UseOctavia,
+				UseOctavia:           dc.Spec.Openstack.UseOctavia,
 			},
 			Version: cluster.Spec.Version.String(),
 		}

--- a/pkg/resources/cloudconfig/configmap.go
+++ b/pkg/resources/cloudconfig/configmap.go
@@ -126,7 +126,6 @@ func CloudConfig(
 
 	case cloud.Openstack != nil:
 		manageSecurityGroups := dc.Spec.Openstack.ManageSecurityGroups
-		useOctavia := dc.Spec.Openstack.UseOctavia
 		trustDevicePath := dc.Spec.Openstack.TrustDevicePath
 		openstackCloudConfig := &openstack.CloudConfig{
 			Global: openstack.GlobalOpts{
@@ -145,7 +144,7 @@ func CloudConfig(
 			},
 			LoadBalancer: openstack.LoadBalancerOpts{
 				ManageSecurityGroups: manageSecurityGroups == nil || *manageSecurityGroups,
-				UseOctavia: useOctavia == nil || *useOctavia,
+				UseOctavia: dc.Spec.Openstack.UseOctavia,
 			},
 			Version: cluster.Spec.Version.String(),
 		}

--- a/pkg/test/e2e/utils/apiclient/models/datacenter_spec_openstack.go
+++ b/pkg/test/e2e/utils/apiclient/models/datacenter_spec_openstack.go
@@ -45,8 +45,8 @@ type DatacenterSpecOpenstack struct {
 	TrustDevicePath bool `json:"trust_device_path,omitempty"`
 
 	// Optional: Gets mapped to the "use-octavia" setting in the cloud config.
-	// See https://kubernetes.io/docs/concepts/cluster-administration/cloud-providers/#load-balancer
-	// This setting defaults to true.
+	// use-octavia is enabled by default in CCM since v1.17.0, and disabled by
+	// default with the in-tree cloud provider. This setting defaults to true.
 	UseOctavia bool `json:"use_octavia,omitempty"`
 
 	// images

--- a/pkg/test/e2e/utils/apiclient/models/datacenter_spec_openstack.go
+++ b/pkg/test/e2e/utils/apiclient/models/datacenter_spec_openstack.go
@@ -46,7 +46,7 @@ type DatacenterSpecOpenstack struct {
 
 	// Optional: Gets mapped to the "use-octavia" setting in the cloud config.
 	// use-octavia is enabled by default in CCM since v1.17.0, and disabled by
-	// default with the in-tree cloud provider. This setting defaults to true.
+	// default with the in-tree cloud provider.
 	UseOctavia bool `json:"use_octavia,omitempty"`
 
 	// images

--- a/pkg/test/e2e/utils/apiclient/models/datacenter_spec_openstack.go
+++ b/pkg/test/e2e/utils/apiclient/models/datacenter_spec_openstack.go
@@ -36,10 +36,6 @@ type DatacenterSpecOpenstack struct {
 	// This setting defaults to true.
 	ManageSecurityGroups bool `json:"manage_security_groups,omitempty"`
 
-	// Optional: Gets mapped to the "use-octavia" setting in the cloud config.
-	// This setting defaults to true.
-	UseOctavia bool `json:"use_octavia,omitempty"`
-
 	// region
 	Region string `json:"region,omitempty"`
 
@@ -47,6 +43,11 @@ type DatacenterSpecOpenstack struct {
 	// See https://kubernetes.io/docs/concepts/cluster-administration/cloud-providers/#block-storage
 	// This setting defaults to false.
 	TrustDevicePath bool `json:"trust_device_path,omitempty"`
+
+	// Optional: Gets mapped to the "use-octavia" setting in the cloud config.
+	// See https://kubernetes.io/docs/concepts/cluster-administration/cloud-providers/#load-balancer
+	// This setting defaults to true.
+	UseOctavia bool `json:"use_octavia,omitempty"`
 
 	// images
 	Images ImageList `json:"images,omitempty"`

--- a/pkg/test/e2e/utils/apiclient/models/datacenter_spec_openstack.go
+++ b/pkg/test/e2e/utils/apiclient/models/datacenter_spec_openstack.go
@@ -36,6 +36,10 @@ type DatacenterSpecOpenstack struct {
 	// This setting defaults to true.
 	ManageSecurityGroups bool `json:"manage_security_groups,omitempty"`
 
+	// Optional: Gets mapped to the "use-octavia" setting in the cloud config.
+	// This setting defaults to true.
+	UseOctavia bool `json:"use_octavia,omitempty"`
+
 	// region
 	Region string `json:"region,omitempty"`
 


### PR DESCRIPTION
Signed-off-by: Happy2C0de <46957159+Happy2C0de@users.noreply.github.com>

**What this PR does / why we need it**:
Add support for the UseOctavia setting in Openstack provider specs in a given datacenter.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Is related to https://github.com/kubermatic/kubermatic/issues/6309

**Special notes for your reviewer**:
Please review the given PR and run it against your test infra.

**Documentation**:
<!-- Add links to the related documentation changes related to this pull request. E.g. the link to the kubermatic/docs pull request. -->
Special docs for Kubermatic are pending.
Cloud-provider-openstack docs can be found in the official docs:
https://github.com/kubernetes/cloud-provider-openstack/blob/master/docs/openstack-cloud-controller-manager/using-openstack-cloud-controller-manager.md#load-balancer

**Does this PR introduce a user-facing change?**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If  no release note is required, just write "NONE".
-->
```release-note
Add support for "use-octavia" setting in Openstack provider specs. It defaults to "true" but leaves the possibility to set it to "false" if your provider doesn't support Octavia yet but Neutron LBaaSv2
```
