### PR TITLE
Add components override field to set nodeportrange for apiserver

### DIFF
--- a/pkg/crd/kubermatic/v1/cluster.go
+++ b/pkg/crd/kubermatic/v1/cluster.go
@@ -347,7 +347,8 @@ type ComponentSettings struct {
 type APIServerSettings struct {
 	DeploymentSettings `json:",inline"`
 
-	EndpointReconcilingDisabled *bool `json:"endpointReconcilingDisabled,omitempty"`
+	EndpointReconcilingDisabled *bool  `json:"endpointReconcilingDisabled,omitempty"`
+	NodePortRange               string `json:"nodePortRange,omitempty"`
 }
 
 type DeploymentSettings struct {

--- a/pkg/resources/apiserver/deployment.go
+++ b/pkg/resources/apiserver/deployment.go
@@ -18,6 +18,7 @@ package apiserver
 
 import (
 	"fmt"
+	"k8s.io/apimachinery/pkg/util/net"
 	"path/filepath"
 	"strings"
 
@@ -247,6 +248,13 @@ func DeploymentCreator(data *resources.TemplateData, enableOIDCAuthentication bo
 
 func getApiserverFlags(data *resources.TemplateData, etcdEndpoints []string, enableOIDCAuthentication, auditLogEnabled, endpointReconcilingDisabled bool) ([]string, error) {
 	nodePortRange := data.NodePortRange()
+	overrideNodePortRange := data.Cluster().Spec.ComponentsOverride.Apiserver.NodePortRange
+	if overrideNodePortRange != "" {
+		if _, err := net.ParsePortRange(overrideNodePortRange); err == nil {
+			nodePortRange = overrideNodePortRange
+		}
+	}
+
 	if nodePortRange == "" {
 		nodePortRange = defaultNodePortRange
 	}

--- a/pkg/resources/apiserver/deployment.go
+++ b/pkg/resources/apiserver/deployment.go
@@ -18,7 +18,6 @@ package apiserver
 
 import (
 	"fmt"
-	"k8s.io/apimachinery/pkg/util/net"
 	"path/filepath"
 	"strings"
 
@@ -34,6 +33,7 @@ import (
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/intstr"
+	"k8s.io/apimachinery/pkg/util/net"
 	"k8s.io/apimachinery/pkg/util/sets"
 )
 


### PR DESCRIPTION
**What this PR does / why we need it**:
Allows overriding the nodeportrange for the apiserver in
componentsOverride.
If field is left empty nodeport will be set the same way as before.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #6530

**Special notes for your reviewer**:

**Documentation**:
<!-- Add links to the related documentation changes related to this pull request. E.g. the link to the kubermatic/docs pull request. -->

**Does this PR introduce a user-facing change?**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If  no release note is required, just write "NONE".
-->
```release-note
Add components override field to set nodeportrange for apiserver
```
