### PR TITLE
bump gatekeeper to 3.1.0

### DIFF
--- a/pkg/resources/gatekeeper/deployment.go
+++ b/pkg/resources/gatekeeper/deployment.go
@@ -39,7 +39,7 @@ const (
 	controllerName = resources.GatekeeperControllerDeploymentName
 	auditName      = resources.GatekeeperAuditDeploymentName
 	imageName      = "open-policy-agent/gatekeeper"
-	tag            = "v3.1.0-beta.9"
+	tag            = "v3.1.0"
 	// Namespace used by Dashboard to find required resources.
 	webhookServerPort  = 8443
 	metricsPort        = 8888


### PR DESCRIPTION
**What this PR does / why we need it**:
Bumps gatekeeper from the `3.1.0-beta.9` to a stable `3.1.0`

**Does this PR introduce a user-facing change?**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If  no release note is required, just write "NONE".
-->
```release-note
NONE
```
