### PR TITLE
kubelet-configmap addon ensured to update in old clusters

### DIFF
--- a/charts/kubermatic/static/master/kubernetes-addons.yaml
+++ b/charts/kubermatic/static/master/kubernetes-addons.yaml
@@ -37,6 +37,8 @@ items:
   kind: Addon
   metadata:
     name: kubelet-configmap
+    labels:
+      addons.kubermatic.io/ensure: true
 - apiVersion: kubermatic.k8s.io/v1
   kind: Addon
   metadata:

--- a/docs/zz_generated.kubermaticConfiguration.yaml
+++ b/docs/zz_generated.kubermaticConfiguration.yaml
@@ -286,6 +286,8 @@ spec:
             kind: Addon
             metadata:
               name: kubelet-configmap
+          	labels:
+          	  addons.kubermatic.io/ensure: true
           - apiVersion: kubermatic.k8s.io/v1
             kind: Addon
             metadata:

--- a/pkg/controller/operator/common/defaults.go
+++ b/pkg/controller/operator/common/defaults.go
@@ -753,6 +753,8 @@ items:
   kind: Addon
   metadata:
     name: kubelet-configmap
+	labels:
+	  addons.kubermatic.io/ensure: true
 - apiVersion: kubermatic.k8s.io/v1
   kind: Addon
   metadata:


### PR DESCRIPTION
Signed-off-by: furkhat <vailodf@gmail.com>

**What this PR does / why we need it**:

If manifest of kubelet-configmap addon is updated, for example configmap for new version of k8s was added, old clusters should reconcile the addon.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Documentation**:
<!-- Add links to the related documentation changes related to this pull request. E.g. the link to the kubermatic/docs pull request. -->

**Does this PR introduce a user-facing change?**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If  no release note is required, just write "NONE".
-->
```release-note ensure kubelet-configmap addon
```
