### PR TITLE
fixed gatekeeper deployment annotations being overwritten

### DIFF
--- a/pkg/resources/gatekeeper/deployment.go
+++ b/pkg/resources/gatekeeper/deployment.go
@@ -98,7 +98,10 @@ func ControllerDeploymentCreator(data gatekeeperData) reconciling.NamedDeploymen
 			dep.Name = controllerName
 			dep.Labels = resources.BaseAppLabels(controllerName, gatekeeperControllerLabels)
 
-			dep.Annotations = map[string]string{"container.seccomp.security.alpha.kubernetes.io/manager": "runtime/default"}
+			if dep.Annotations == nil {
+				dep.Annotations = make(map[string]string)
+			}
+			dep.Annotations["container.seccomp.security.alpha.kubernetes.io/manager"] = "runtime/default"
 
 			dep.Spec.Replicas = resources.Int32(1)
 			dep.Spec.Selector = &metav1.LabelSelector{
@@ -146,7 +149,10 @@ func AuditDeploymentCreator(data gatekeeperData) reconciling.NamedDeploymentCrea
 			dep.Name = auditName
 			dep.Labels = resources.BaseAppLabels(auditName, gatekeeperAuditLabels)
 
-			dep.Annotations = map[string]string{"container.seccomp.security.alpha.kubernetes.io/manager": "runtime/default"}
+			if dep.Annotations == nil {
+				dep.Annotations = make(map[string]string)
+			}
+			dep.Annotations["container.seccomp.security.alpha.kubernetes.io/manager"] = "runtime/default"
 
 			dep.Spec.Replicas = resources.Int32(1)
 			dep.Spec.Selector = &metav1.LabelSelector{


### PR DESCRIPTION
**What this PR does / why we need it**:
Fixes the reconcile loop that happens because gatekeeper deployment keeps overwriting its annotations.

**Does this PR introduce a user-facing change?**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If  no release note is required, just write "NONE".
-->
```release-note
NONE
```
