### PR TITLE
User cluster CoreDNS fixes and extensions

### DIFF
--- a/pkg/controller/seed-controller-manager/openshift/testdata/Kubermatic_API_image_is_overwritten-usercluster-controller.golden.yaml
+++ b/pkg/controller/seed-controller-manager/openshift/testdata/Kubermatic_API_image_is_overwritten-usercluster-controller.golden.yaml
@@ -42,7 +42,7 @@ spec:
         - -timeout
         - "1"
         - -command
-        - '{"command":"/usr/local/bin/user-cluster-controller-manager","args":["-kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","-metrics-listen-address","0.0.0.0:8085","-health-listen-address","0.0.0.0:8086","-namespace","$(NAMESPACE)","-cluster-url","https://test-cluster.alias-europe-west3-c.dev.kubermatic.io:0","-dns-cluster-ip","10.240.16.10","-openvpn-server-port","0","-overwrite-registry","","-openshift=true","-version","4.1.9","-cloud-provider-name","","-owner-email","","-enable-ssh-key-agent=false","-opa-integration=false","-openshift-console-callback-uri","https://dev.kubermatic.io/api/v1/projects//dc/alias-europe-west3-c/clusters/test-cluster/openshift/console/proxy/auth/callback"]}'
+        - '{"command":"/usr/local/bin/user-cluster-controller-manager","args":["-kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","-metrics-listen-address","0.0.0.0:8085","-health-listen-address","0.0.0.0:8086","-namespace","$(NAMESPACE)","-cluster-url","https://test-cluster.alias-europe-west3-c.dev.kubermatic.io:0","-dns-cluster-ip","10.240.16.10","-openvpn-server-port","0","-overwrite-registry","","-openshift=true","-version","4.1.9","-cloud-provider-name","","-owner-email","","-enable-ssh-key-agent=false","-opa-integration=false","-cluster-dns-domain","cluster.local","-openshift-console-callback-uri","https://dev.kubermatic.io/api/v1/projects//dc/alias-europe-west3-c/clusters/test-cluster/openshift/console/proxy/auth/callback"]}'
         command:
         - /http-prober-bin/http-prober
         env:

--- a/pkg/controller/user-cluster-controller-manager/resources/controller.go
+++ b/pkg/controller/user-cluster-controller-manager/resources/controller.go
@@ -73,6 +73,7 @@ func Add(
 	openvpnServerPort uint32,
 	kasSecurePort uint32,
 	tunnelingAgentIP net.IP,
+	clusterDNSDomain string,
 	registerReconciledCheck func(name string, check healthz.Checker) error,
 	cloudCredentialSecretTemplate *corev1.Secret,
 	openshiftConsoleCallbackURI string,
@@ -87,6 +88,7 @@ func Add(
 		rLock:                         &sync.Mutex{},
 		namespace:                     namespace,
 		clusterURL:                    clusterURL,
+		clusterDNSDomain:              clusterDNSDomain,
 		openvpnServerPort:             openvpnServerPort,
 		kasSecurePort:                 kasSecurePort,
 		tunnelingAgentIP:              tunnelingAgentIP,
@@ -243,6 +245,7 @@ type reconciler struct {
 	openvpnServerPort             uint32
 	kasSecurePort                 uint32
 	tunnelingAgentIP              net.IP
+	clusterDNSDomain              string
 	platform                      string
 	cloudCredentialSecretTemplate *corev1.Secret
 	openshiftConsoleCallbackURI   string

--- a/pkg/controller/user-cluster-controller-manager/resources/reconciler.go
+++ b/pkg/controller/user-cluster-controller-manager/resources/reconciler.go
@@ -29,6 +29,7 @@ import (
 	dnatcontroller "k8c.io/kubermatic/v2/pkg/controller/user-cluster-controller-manager/resources/resources/dnat-controller"
 	envoyagent "k8c.io/kubermatic/v2/pkg/controller/user-cluster-controller-manager/resources/resources/envoy-agent"
 	"k8c.io/kubermatic/v2/pkg/controller/user-cluster-controller-manager/resources/resources/gatekeeper"
+	dnsautoscaler "k8c.io/kubermatic/v2/pkg/controller/user-cluster-controller-manager/resources/resources/dns-autoscaler"
 	kubestatemetrics "k8c.io/kubermatic/v2/pkg/controller/user-cluster-controller-manager/resources/resources/kube-state-metrics"
 	kubernetesdashboard "k8c.io/kubermatic/v2/pkg/controller/user-cluster-controller-manager/resources/resources/kubernetes-dashboard"
 	machinecontroller "k8c.io/kubermatic/v2/pkg/controller/user-cluster-controller-manager/resources/resources/machine-controller"
@@ -208,6 +209,7 @@ func (r *reconciler) reconcileServiceAcconts(ctx context.Context) error {
 		}
 		creators = []reconciling.NamedServiceAccountCreatorGetter{
 			coredns.ServiceAccountCreator(),
+			dnsautoscaler.ServiceAccountCreator(),
 			nodelocaldns.ServiceAccountCreator(),
 		}
 		if err := reconciling.ReconcileServiceAccounts(ctx, creators, metav1.NamespaceSystem, r.Client); err != nil {
@@ -368,6 +370,7 @@ func (r *reconciler) reconcileClusterRoles(ctx context.Context) error {
 			[]reconciling.NamedClusterRoleCreatorGetter{
 				kubernetesdashboard.ClusterRoleCreator(),
 				coredns.ClusterRoleCreator(),
+				dnsautoscaler.ClusterRolereator(),
 			}...)
 	}
 
@@ -402,6 +405,7 @@ func (r *reconciler) reconcileClusterRoleBindings(ctx context.Context) error {
 			[]reconciling.NamedClusterRoleBindingCreatorGetter{
 				kubernetesdashboard.ClusterRoleBindingCreator(),
 				coredns.ClusterRoleBindingCreator(),
+				dnsautoscaler.ClusterRoleBindingCreator(),
 			}...)
 	}
 
@@ -533,6 +537,7 @@ func (r *reconciler) reconcileConfigMaps(ctx context.Context, data reconcileData
 	} else {
 		creators = append(creators,
 			coredns.ConfigMapCreator(r.clusterDNSDomain),
+			dnsautoscaler.ConfigMapCreator(),
 			nodelocaldns.ConfigMapCreator(r.dnsClusterIP),
 		)
 	}
@@ -705,6 +710,7 @@ func (r *reconciler) reconcileDeployments(ctx context.Context) error {
 
 	kubeSystemCreators := []reconciling.NamedDeploymentCreatorGetter{
 		coredns.DeploymentCreator(r.clusterSemVer),
+		dnsautoscaler.DeploymentCreator(),
 	}
 
 	if err := reconciling.ReconcileDeployments(ctx, kubeSystemCreators, metav1.NamespaceSystem, r.Client); err != nil {

--- a/pkg/controller/user-cluster-controller-manager/resources/reconciler.go
+++ b/pkg/controller/user-cluster-controller-manager/resources/reconciler.go
@@ -532,7 +532,7 @@ func (r *reconciler) reconcileConfigMaps(ctx context.Context, data reconcileData
 		creators = append(creators, openshift.ControlplaneConfigCreator(r.platform))
 	} else {
 		creators = append(creators,
-			coredns.ConfigMapCreator(),
+			coredns.ConfigMapCreator(r.clusterDNSDomain),
 			nodelocaldns.ConfigMapCreator(r.dnsClusterIP),
 		)
 	}

--- a/pkg/controller/user-cluster-controller-manager/resources/resources/core-dns/configmap.go
+++ b/pkg/controller/user-cluster-controller-manager/resources/resources/core-dns/configmap.go
@@ -33,6 +33,7 @@ func ConfigMapCreator(clusterDNSDomain string) reconciling.NamedConfigMapCreator
 			}
 			cm.Labels = resources.BaseAppLabels(resources.CoreDNSServiceName, nil)
 			cm.Data["Corefile"] = fmt.Sprintf(`
+      import %s
       .:53 {
           errors
           health
@@ -47,7 +48,7 @@ func ConfigMapCreator(clusterDNSDomain string) reconciling.NamedConfigMapCreator
           reload
           loadbalance
       }
-      `, clusterDNSDomain)
+      `, ExtraConfigImportPath, clusterDNSDomain)
 
 			return cm, nil
 		}

--- a/pkg/controller/user-cluster-controller-manager/resources/resources/core-dns/deployment.go
+++ b/pkg/controller/user-cluster-controller-manager/resources/resources/core-dns/deployment.go
@@ -67,7 +67,7 @@ func DeploymentCreator(kubernetesVersion *semver.Version) reconciling.NamedDeplo
 			dep.Namespace = metav1.NamespaceSystem
 			dep.Labels = resources.BaseAppLabels(resources.CoreDNSDeploymentName, nil)
 
-			dep.Spec.Replicas = resources.Int32(1)
+			dep.Spec.Replicas = resources.Int32(2)
 			// The Selector is immutable, so we don't change it if it's set. This happens in upgrade cases
 			// where coredns is switched from a manifest based addon to a user-cluster-controller-manager resource
 			if dep.Spec.Selector == nil {

--- a/pkg/controller/user-cluster-controller-manager/resources/resources/dns-autoscaler/clusterrole.go
+++ b/pkg/controller/user-cluster-controller-manager/resources/resources/dns-autoscaler/clusterrole.go
@@ -1,0 +1,34 @@
+package dnsautoscaler
+
+import (
+	"k8c.io/kubermatic/v2/pkg/resources"
+	"k8c.io/kubermatic/v2/pkg/resources/reconciling"
+
+	rbacv1 "k8s.io/api/rbac/v1"
+)
+
+// ClusterRolereator returns the func to create/update the ClusterRole for dns autoscaler.
+func ClusterRolereator() reconciling.NamedClusterRoleCreatorGetter {
+	return func() (string, reconciling.ClusterRoleCreator) {
+		return resources.DNSAutoscalerClusterRoleName, func(cr *rbacv1.ClusterRole) (*rbacv1.ClusterRole, error) {
+			cr.Rules = []rbacv1.PolicyRule{
+				{
+					APIGroups: []string{""},
+					Resources: []string{"nodes"},
+					Verbs:     []string{"watch", "list"},
+				},
+				{
+					APIGroups: []string{""},
+					Resources: []string{"configmaps"},
+					Verbs:     []string{"get", "create"},
+				},
+				{
+					APIGroups: []string{"extensions", "apps"},
+					Resources: []string{"deployments/scale"},
+					Verbs:     []string{"get", "update"},
+				},
+			}
+			return cr, nil
+		}
+	}
+}

--- a/pkg/controller/user-cluster-controller-manager/resources/resources/dns-autoscaler/clusterrolebinding.go
+++ b/pkg/controller/user-cluster-controller-manager/resources/resources/dns-autoscaler/clusterrolebinding.go
@@ -1,0 +1,31 @@
+package dnsautoscaler
+
+import (
+	"k8c.io/kubermatic/v2/pkg/resources"
+	"k8c.io/kubermatic/v2/pkg/resources/reconciling"
+
+	rbacv1 "k8s.io/api/rbac/v1"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+// ClusterRoleBindingCreator returns the func to create/update the ClusterRoleBinding for dns autoscaler.
+func ClusterRoleBindingCreator() reconciling.NamedClusterRoleBindingCreatorGetter {
+	return func() (string, reconciling.ClusterRoleBindingCreator) {
+		return resources.DNSAutoscalerClusterRoleBindingName, func(crb *rbacv1.ClusterRoleBinding) (*rbacv1.ClusterRoleBinding, error) {
+			crb.RoleRef = rbacv1.RoleRef{
+				Name:     resources.DNSAutoscalerClusterRoleName,
+				Kind:     "ClusterRole",
+				APIGroup: rbacv1.GroupName,
+			}
+			crb.Subjects = []rbacv1.Subject{
+				{
+					Kind:      rbacv1.ServiceAccountKind,
+					Name:      resources.DNSAutoscalerServicaAccountName,
+					Namespace: metav1.NamespaceSystem,
+				},
+			}
+			return crb, nil
+		}
+	}
+}

--- a/pkg/controller/user-cluster-controller-manager/resources/resources/dns-autoscaler/configmap.go
+++ b/pkg/controller/user-cluster-controller-manager/resources/resources/dns-autoscaler/configmap.go
@@ -1,0 +1,31 @@
+package dnsautoscaler
+
+import (
+	"k8c.io/kubermatic/v2/pkg/resources"
+	"k8c.io/kubermatic/v2/pkg/resources/reconciling"
+
+	corev1 "k8s.io/api/core/v1"
+)
+
+// ConfigMapCreator returns a ConfigMap containing the config for the dns autoscaler.
+func ConfigMapCreator() reconciling.NamedConfigMapCreatorGetter {
+	return func() (string, reconciling.ConfigMapCreator) {
+		return resources.DNSAutoscalerConfigMapName, func(cm *corev1.ConfigMap) (*corev1.ConfigMap, error) {
+			if cm.Data == nil {
+				cm.Data = map[string]string{}
+			}
+			cm.Labels = resources.BaseAppLabels(resources.DNSAutoscalerDeploymentName, nil)
+			cm.Data["linear"] = `
+			{
+				"min": 2,
+				"coresPerReplica": 32,
+				"nodesPerReplica": 4,
+				"preventSinglePointFailure": true,
+				"includeUnschedulableNodes": true
+			}
+      `
+
+			return cm, nil
+		}
+	}
+}

--- a/pkg/controller/user-cluster-controller-manager/resources/resources/dns-autoscaler/deployment.go
+++ b/pkg/controller/user-cluster-controller-manager/resources/resources/dns-autoscaler/deployment.go
@@ -1,0 +1,75 @@
+package dnsautoscaler
+
+import (
+	"fmt"
+
+	"k8c.io/kubermatic/v2/pkg/resources"
+	"k8c.io/kubermatic/v2/pkg/resources/reconciling"
+
+	appsv1 "k8s.io/api/apps/v1"
+	corev1 "k8s.io/api/core/v1"
+
+	"k8s.io/apimachinery/pkg/api/resource"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+var (
+	defaultResourceRequirements = map[string]*corev1.ResourceRequirements{
+		resources.CoreDNSDeploymentName: {
+			Requests: corev1.ResourceList{
+				corev1.ResourceMemory: resource.MustParse("10Mi"),
+				corev1.ResourceCPU:    resource.MustParse("20m"),
+			},
+			Limits: corev1.ResourceList{
+				corev1.ResourceMemory: resource.MustParse("100Mi"),
+				corev1.ResourceCPU:    resource.MustParse("100m"),
+			},
+		},
+	}
+)
+
+// DeploymentCreator returns the function to create and update the dns autoscaler deployment.
+func DeploymentCreator() reconciling.NamedDeploymentCreatorGetter {
+	return func() (string, reconciling.DeploymentCreator) {
+		return resources.DNSAutoscalerDeploymentName, func(dep *appsv1.Deployment) (*appsv1.Deployment, error) {
+			dep.Name = resources.DNSAutoscalerDeploymentName
+			dep.Namespace = metav1.NamespaceSystem
+			dep.Labels = resources.BaseAppLabels(resources.DNSAutoscalerDeploymentName, nil)
+
+			dep.Spec.Replicas = resources.Int32(1)
+			// The Selector is immutable, so we don't change it if it's set. This happens in upgrade cases
+			// where dns autoscaler is switched from a manifest based addon to a user-cluster-controller-manager resource
+			if dep.Spec.Selector == nil {
+				dep.Spec.Selector = &metav1.LabelSelector{
+					MatchLabels: resources.BaseAppLabels(resources.DNSAutoscalerDeploymentName,
+						map[string]string{"app.kubernetes.io/name": "dns-autoscaler"}),
+				}
+			}
+
+			// has to be the same as the selector
+			if dep.Spec.Template.ObjectMeta.Labels == nil {
+				dep.Spec.Template.ObjectMeta = metav1.ObjectMeta{
+					Labels: resources.BaseAppLabels(resources.DNSAutoscalerDeploymentName,
+						map[string]string{"app.kubernetes.io/name": "dns-autoscaler"}),
+				}
+			}
+
+			dep.Spec.Template.Spec.Containers = []corev1.Container{
+				{
+					Name:    "autoscaler",
+					Image:   fmt.Sprintf("%s/cluster-proportional-autoscaler-amd64:1.6.0", resources.RegistryK8SGCR),
+					Command: []string{"/cluster-proportional-autoscaler", "--namespace=kube-system", "--configmap=dns-autoscaler", "--target=deployment/coredns", "--logtostderr=true", "--v=2"},
+				},
+			}
+
+			err := resources.SetResourceRequirements(dep.Spec.Template.Spec.Containers, defaultResourceRequirements, nil, dep.Annotations)
+			if err != nil {
+				return nil, fmt.Errorf("failed to set resource requirements: %v", err)
+			}
+
+			dep.Spec.Template.Spec.ServiceAccountName = resources.DNSAutoscalerServicaAccountName
+
+			return dep, nil
+		}
+	}
+}

--- a/pkg/controller/user-cluster-controller-manager/resources/resources/dns-autoscaler/servicaaccount.go
+++ b/pkg/controller/user-cluster-controller-manager/resources/resources/dns-autoscaler/servicaaccount.go
@@ -1,0 +1,17 @@
+package dnsautoscaler
+
+import (
+	"k8c.io/kubermatic/v2/pkg/resources"
+	"k8c.io/kubermatic/v2/pkg/resources/reconciling"
+
+	corev1 "k8s.io/api/core/v1"
+)
+
+// ServiceAccountCreator creates the service account for dns autoscaler.
+func ServiceAccountCreator() reconciling.NamedServiceAccountCreatorGetter {
+	return func() (string, reconciling.ServiceAccountCreator) {
+		return resources.DNSAutoscalerServicaAccountName, func(sa *corev1.ServiceAccount) (*corev1.ServiceAccount, error) {
+			return sa, nil
+		}
+	}
+}

--- a/pkg/controller/user-cluster-controller-manager/resources/resources/node-local-dns/configmap.go
+++ b/pkg/controller/user-cluster-controller-manager/resources/resources/node-local-dns/configmap.go
@@ -18,6 +18,7 @@ package nodelocaldns
 
 import (
 	"bytes"
+	"fmt"
 	"html/template"
 
 	"k8c.io/kubermatic/v2/pkg/resources"
@@ -59,8 +60,9 @@ func ConfigMapCreator(dnsClusterIP string) reconciling.NamedConfigMapCreatorGett
 	}
 }
 
-const (
-	configTemplate = `
+var (
+	configTemplate = fmt.Sprintf(`
+import %s
 cluster.local:53 {
     errors
     cache {
@@ -109,5 +111,5 @@ ip6.arpa:53 {
     }
     prometheus :9253
     }
-  `
+  `, extraConfigImportPath)
 )

--- a/pkg/resources/resources.go
+++ b/pkg/resources/resources.go
@@ -518,6 +518,21 @@ const (
 	CoreDNSConfigMapName           = "coredns"
 	CoreDNSDeploymentName          = "coredns"
 	CoreDNSPodDisruptionBudgetName = "coredns"
+
+	// CoreDNSExtraConfigMapName is a configmap where user can place extra configururation for core dns.
+	CoreDNSExtraConfigMapName = "coredns-extra-configs"
+
+	// NodeLocalDNSExtraConfigMapName is a configmap where user can place extra configururation for node local dns.
+	NodeLocalDNSExtraConfigMapName = "node-local-dns-extra-configs"
+)
+
+// Resource names and constants for dns autoscaler.
+const (
+	DNSAutoscalerServicaAccountName     = "dns-autoscaler"
+	DNSAutoscalerClusterRoleName        = "dns-autoscaler"
+	DNSAutoscalerClusterRoleBindingName = "dns-autoscaler"
+	DNSAutoscalerConfigMapName          = "dns-autoscaler"
+	DNSAutoscalerDeploymentName         = "dns-autoscaler"
 )
 
 const (

--- a/pkg/resources/test/fixtures/deployment-aws-1.17.0-usercluster-controller.yaml
+++ b/pkg/resources/test/fixtures/deployment-aws-1.17.0-usercluster-controller.yaml
@@ -39,7 +39,7 @@ spec:
         - -timeout
         - "1"
         - -command
-        - '{"command":"/usr/local/bin/user-cluster-controller-manager","args":["-kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","-metrics-listen-address","0.0.0.0:8085","-health-listen-address","0.0.0.0:8086","-namespace","$(NAMESPACE)","-cluster-url","https://jh8j81chn.europe-west3-c.dev.kubermatic.io:30000","-dns-cluster-ip","10.240.16.10","-openvpn-server-port","30003","-overwrite-registry","","-openshift=false","-version","1.17.0","-cloud-provider-name","aws","-owner-email","","-enable-ssh-key-agent=false","-opa-integration=false","--ipam-controller-network","192.168.1.1/24,192.168.1.1,8.8.8.8","-node-labels","{\"my-label\":\"my-value\"}"]}'
+        - '{"command":"/usr/local/bin/user-cluster-controller-manager","args":["-kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","-metrics-listen-address","0.0.0.0:8085","-health-listen-address","0.0.0.0:8086","-namespace","$(NAMESPACE)","-cluster-url","https://jh8j81chn.europe-west3-c.dev.kubermatic.io:30000","-dns-cluster-ip","10.240.16.10","-openvpn-server-port","30003","-overwrite-registry","","-openshift=false","-version","1.17.0","-cloud-provider-name","aws","-owner-email","","-enable-ssh-key-agent=false","-opa-integration=false","--ipam-controller-network","192.168.1.1/24,192.168.1.1,8.8.8.8","-cluster-dns-domain","cluster.local","-node-labels","{\"my-label\":\"my-value\"}"]}'
         command:
         - /http-prober-bin/http-prober
         env:

--- a/pkg/resources/test/fixtures/deployment-aws-1.18.0-usercluster-controller.yaml
+++ b/pkg/resources/test/fixtures/deployment-aws-1.18.0-usercluster-controller.yaml
@@ -39,7 +39,7 @@ spec:
         - -timeout
         - "1"
         - -command
-        - '{"command":"/usr/local/bin/user-cluster-controller-manager","args":["-kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","-metrics-listen-address","0.0.0.0:8085","-health-listen-address","0.0.0.0:8086","-namespace","$(NAMESPACE)","-cluster-url","https://jh8j81chn.europe-west3-c.dev.kubermatic.io:30000","-dns-cluster-ip","10.240.16.10","-openvpn-server-port","30003","-overwrite-registry","","-openshift=false","-version","1.18.0","-cloud-provider-name","aws","-owner-email","","-enable-ssh-key-agent=false","-opa-integration=false","--ipam-controller-network","192.168.1.1/24,192.168.1.1,8.8.8.8","-node-labels","{\"my-label\":\"my-value\"}"]}'
+        - '{"command":"/usr/local/bin/user-cluster-controller-manager","args":["-kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","-metrics-listen-address","0.0.0.0:8085","-health-listen-address","0.0.0.0:8086","-namespace","$(NAMESPACE)","-cluster-url","https://jh8j81chn.europe-west3-c.dev.kubermatic.io:30000","-dns-cluster-ip","10.240.16.10","-openvpn-server-port","30003","-overwrite-registry","","-openshift=false","-version","1.18.0","-cloud-provider-name","aws","-owner-email","","-enable-ssh-key-agent=false","-opa-integration=false","--ipam-controller-network","192.168.1.1/24,192.168.1.1,8.8.8.8","-cluster-dns-domain","cluster.local","-node-labels","{\"my-label\":\"my-value\"}"]}'
         command:
         - /http-prober-bin/http-prober
         env:

--- a/pkg/resources/test/fixtures/deployment-aws-1.19.0-usercluster-controller.yaml
+++ b/pkg/resources/test/fixtures/deployment-aws-1.19.0-usercluster-controller.yaml
@@ -39,7 +39,7 @@ spec:
         - -timeout
         - "1"
         - -command
-        - '{"command":"/usr/local/bin/user-cluster-controller-manager","args":["-kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","-metrics-listen-address","0.0.0.0:8085","-health-listen-address","0.0.0.0:8086","-namespace","$(NAMESPACE)","-cluster-url","https://jh8j81chn.europe-west3-c.dev.kubermatic.io:30000","-dns-cluster-ip","10.240.16.10","-openvpn-server-port","30003","-overwrite-registry","","-openshift=false","-version","1.19.0","-cloud-provider-name","aws","-owner-email","","-enable-ssh-key-agent=false","-opa-integration=false","--ipam-controller-network","192.168.1.1/24,192.168.1.1,8.8.8.8","-node-labels","{\"my-label\":\"my-value\"}"]}'
+        - '{"command":"/usr/local/bin/user-cluster-controller-manager","args":["-kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","-metrics-listen-address","0.0.0.0:8085","-health-listen-address","0.0.0.0:8086","-namespace","$(NAMESPACE)","-cluster-url","https://jh8j81chn.europe-west3-c.dev.kubermatic.io:30000","-dns-cluster-ip","10.240.16.10","-openvpn-server-port","30003","-overwrite-registry","","-openshift=false","-version","1.19.0","-cloud-provider-name","aws","-owner-email","","-enable-ssh-key-agent=false","-opa-integration=false","--ipam-controller-network","192.168.1.1/24,192.168.1.1,8.8.8.8","-cluster-dns-domain","cluster.local","-node-labels","{\"my-label\":\"my-value\"}"]}'
         command:
         - /http-prober-bin/http-prober
         env:

--- a/pkg/resources/test/fixtures/deployment-aws-1.20.0-usercluster-controller.yaml
+++ b/pkg/resources/test/fixtures/deployment-aws-1.20.0-usercluster-controller.yaml
@@ -39,7 +39,7 @@ spec:
         - -timeout
         - "1"
         - -command
-        - '{"command":"/usr/local/bin/user-cluster-controller-manager","args":["-kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","-metrics-listen-address","0.0.0.0:8085","-health-listen-address","0.0.0.0:8086","-namespace","$(NAMESPACE)","-cluster-url","https://jh8j81chn.europe-west3-c.dev.kubermatic.io:30000","-dns-cluster-ip","10.240.16.10","-openvpn-server-port","30003","-overwrite-registry","","-openshift=false","-version","1.20.0","-cloud-provider-name","aws","-owner-email","","-enable-ssh-key-agent=false","-opa-integration=false","--ipam-controller-network","192.168.1.1/24,192.168.1.1,8.8.8.8","-node-labels","{\"my-label\":\"my-value\"}"]}'
+        - '{"command":"/usr/local/bin/user-cluster-controller-manager","args":["-kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","-metrics-listen-address","0.0.0.0:8085","-health-listen-address","0.0.0.0:8086","-namespace","$(NAMESPACE)","-cluster-url","https://jh8j81chn.europe-west3-c.dev.kubermatic.io:30000","-dns-cluster-ip","10.240.16.10","-openvpn-server-port","30003","-overwrite-registry","","-openshift=false","-version","1.20.0","-cloud-provider-name","aws","-owner-email","","-enable-ssh-key-agent=false","-opa-integration=false","--ipam-controller-network","192.168.1.1/24,192.168.1.1,8.8.8.8","-cluster-dns-domain","cluster.local","-node-labels","{\"my-label\":\"my-value\"}"]}'
         command:
         - /http-prober-bin/http-prober
         env:

--- a/pkg/resources/test/fixtures/deployment-azure-1.17.0-usercluster-controller.yaml
+++ b/pkg/resources/test/fixtures/deployment-azure-1.17.0-usercluster-controller.yaml
@@ -39,7 +39,7 @@ spec:
         - -timeout
         - "1"
         - -command
-        - '{"command":"/usr/local/bin/user-cluster-controller-manager","args":["-kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","-metrics-listen-address","0.0.0.0:8085","-health-listen-address","0.0.0.0:8086","-namespace","$(NAMESPACE)","-cluster-url","https://jh8j81chn.europe-west3-c.dev.kubermatic.io:30000","-dns-cluster-ip","10.240.16.10","-openvpn-server-port","30003","-overwrite-registry","","-openshift=false","-version","1.17.0","-cloud-provider-name","azure","-owner-email","","-enable-ssh-key-agent=false","-opa-integration=false","--ipam-controller-network","192.168.1.1/24,192.168.1.1,8.8.8.8","-node-labels","{\"my-label\":\"my-value\"}"]}'
+        - '{"command":"/usr/local/bin/user-cluster-controller-manager","args":["-kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","-metrics-listen-address","0.0.0.0:8085","-health-listen-address","0.0.0.0:8086","-namespace","$(NAMESPACE)","-cluster-url","https://jh8j81chn.europe-west3-c.dev.kubermatic.io:30000","-dns-cluster-ip","10.240.16.10","-openvpn-server-port","30003","-overwrite-registry","","-openshift=false","-version","1.17.0","-cloud-provider-name","azure","-owner-email","","-enable-ssh-key-agent=false","-opa-integration=false","--ipam-controller-network","192.168.1.1/24,192.168.1.1,8.8.8.8","-cluster-dns-domain","cluster.local","-node-labels","{\"my-label\":\"my-value\"}"]}'
         command:
         - /http-prober-bin/http-prober
         env:

--- a/pkg/resources/test/fixtures/deployment-azure-1.18.0-usercluster-controller.yaml
+++ b/pkg/resources/test/fixtures/deployment-azure-1.18.0-usercluster-controller.yaml
@@ -39,7 +39,7 @@ spec:
         - -timeout
         - "1"
         - -command
-        - '{"command":"/usr/local/bin/user-cluster-controller-manager","args":["-kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","-metrics-listen-address","0.0.0.0:8085","-health-listen-address","0.0.0.0:8086","-namespace","$(NAMESPACE)","-cluster-url","https://jh8j81chn.europe-west3-c.dev.kubermatic.io:30000","-dns-cluster-ip","10.240.16.10","-openvpn-server-port","30003","-overwrite-registry","","-openshift=false","-version","1.18.0","-cloud-provider-name","azure","-owner-email","","-enable-ssh-key-agent=false","-opa-integration=false","--ipam-controller-network","192.168.1.1/24,192.168.1.1,8.8.8.8","-node-labels","{\"my-label\":\"my-value\"}"]}'
+        - '{"command":"/usr/local/bin/user-cluster-controller-manager","args":["-kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","-metrics-listen-address","0.0.0.0:8085","-health-listen-address","0.0.0.0:8086","-namespace","$(NAMESPACE)","-cluster-url","https://jh8j81chn.europe-west3-c.dev.kubermatic.io:30000","-dns-cluster-ip","10.240.16.10","-openvpn-server-port","30003","-overwrite-registry","","-openshift=false","-version","1.18.0","-cloud-provider-name","azure","-owner-email","","-enable-ssh-key-agent=false","-opa-integration=false","--ipam-controller-network","192.168.1.1/24,192.168.1.1,8.8.8.8","-cluster-dns-domain","cluster.local","-node-labels","{\"my-label\":\"my-value\"}"]}'
         command:
         - /http-prober-bin/http-prober
         env:

--- a/pkg/resources/test/fixtures/deployment-azure-1.19.0-usercluster-controller.yaml
+++ b/pkg/resources/test/fixtures/deployment-azure-1.19.0-usercluster-controller.yaml
@@ -39,7 +39,7 @@ spec:
         - -timeout
         - "1"
         - -command
-        - '{"command":"/usr/local/bin/user-cluster-controller-manager","args":["-kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","-metrics-listen-address","0.0.0.0:8085","-health-listen-address","0.0.0.0:8086","-namespace","$(NAMESPACE)","-cluster-url","https://jh8j81chn.europe-west3-c.dev.kubermatic.io:30000","-dns-cluster-ip","10.240.16.10","-openvpn-server-port","30003","-overwrite-registry","","-openshift=false","-version","1.19.0","-cloud-provider-name","azure","-owner-email","","-enable-ssh-key-agent=false","-opa-integration=false","--ipam-controller-network","192.168.1.1/24,192.168.1.1,8.8.8.8","-node-labels","{\"my-label\":\"my-value\"}"]}'
+        - '{"command":"/usr/local/bin/user-cluster-controller-manager","args":["-kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","-metrics-listen-address","0.0.0.0:8085","-health-listen-address","0.0.0.0:8086","-namespace","$(NAMESPACE)","-cluster-url","https://jh8j81chn.europe-west3-c.dev.kubermatic.io:30000","-dns-cluster-ip","10.240.16.10","-openvpn-server-port","30003","-overwrite-registry","","-openshift=false","-version","1.19.0","-cloud-provider-name","azure","-owner-email","","-enable-ssh-key-agent=false","-opa-integration=false","--ipam-controller-network","192.168.1.1/24,192.168.1.1,8.8.8.8","-cluster-dns-domain","cluster.local","-node-labels","{\"my-label\":\"my-value\"}"]}'
         command:
         - /http-prober-bin/http-prober
         env:

--- a/pkg/resources/test/fixtures/deployment-azure-1.20.0-usercluster-controller.yaml
+++ b/pkg/resources/test/fixtures/deployment-azure-1.20.0-usercluster-controller.yaml
@@ -39,7 +39,7 @@ spec:
         - -timeout
         - "1"
         - -command
-        - '{"command":"/usr/local/bin/user-cluster-controller-manager","args":["-kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","-metrics-listen-address","0.0.0.0:8085","-health-listen-address","0.0.0.0:8086","-namespace","$(NAMESPACE)","-cluster-url","https://jh8j81chn.europe-west3-c.dev.kubermatic.io:30000","-dns-cluster-ip","10.240.16.10","-openvpn-server-port","30003","-overwrite-registry","","-openshift=false","-version","1.20.0","-cloud-provider-name","azure","-owner-email","","-enable-ssh-key-agent=false","-opa-integration=false","--ipam-controller-network","192.168.1.1/24,192.168.1.1,8.8.8.8","-node-labels","{\"my-label\":\"my-value\"}"]}'
+        - '{"command":"/usr/local/bin/user-cluster-controller-manager","args":["-kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","-metrics-listen-address","0.0.0.0:8085","-health-listen-address","0.0.0.0:8086","-namespace","$(NAMESPACE)","-cluster-url","https://jh8j81chn.europe-west3-c.dev.kubermatic.io:30000","-dns-cluster-ip","10.240.16.10","-openvpn-server-port","30003","-overwrite-registry","","-openshift=false","-version","1.20.0","-cloud-provider-name","azure","-owner-email","","-enable-ssh-key-agent=false","-opa-integration=false","--ipam-controller-network","192.168.1.1/24,192.168.1.1,8.8.8.8","-cluster-dns-domain","cluster.local","-node-labels","{\"my-label\":\"my-value\"}"]}'
         command:
         - /http-prober-bin/http-prober
         env:

--- a/pkg/resources/test/fixtures/deployment-bringyourown-1.17.0-usercluster-controller.yaml
+++ b/pkg/resources/test/fixtures/deployment-bringyourown-1.17.0-usercluster-controller.yaml
@@ -39,7 +39,7 @@ spec:
         - -timeout
         - "1"
         - -command
-        - '{"command":"/usr/local/bin/user-cluster-controller-manager","args":["-kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","-metrics-listen-address","0.0.0.0:8085","-health-listen-address","0.0.0.0:8086","-namespace","$(NAMESPACE)","-cluster-url","https://jh8j81chn.europe-west3-c.dev.kubermatic.io:30000","-dns-cluster-ip","10.240.16.10","-openvpn-server-port","30003","-overwrite-registry","","-openshift=false","-version","1.17.0","-cloud-provider-name","","-owner-email","","-enable-ssh-key-agent=false","-opa-integration=false","--ipam-controller-network","192.168.1.1/24,192.168.1.1,8.8.8.8","-node-labels","{\"my-label\":\"my-value\"}"]}'
+        - '{"command":"/usr/local/bin/user-cluster-controller-manager","args":["-kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","-metrics-listen-address","0.0.0.0:8085","-health-listen-address","0.0.0.0:8086","-namespace","$(NAMESPACE)","-cluster-url","https://jh8j81chn.europe-west3-c.dev.kubermatic.io:30000","-dns-cluster-ip","10.240.16.10","-openvpn-server-port","30003","-overwrite-registry","","-openshift=false","-version","1.17.0","-cloud-provider-name","","-owner-email","","-enable-ssh-key-agent=false","-opa-integration=false","--ipam-controller-network","192.168.1.1/24,192.168.1.1,8.8.8.8","-cluster-dns-domain","cluster.local","-node-labels","{\"my-label\":\"my-value\"}"]}'
         command:
         - /http-prober-bin/http-prober
         env:

--- a/pkg/resources/test/fixtures/deployment-bringyourown-1.18.0-usercluster-controller.yaml
+++ b/pkg/resources/test/fixtures/deployment-bringyourown-1.18.0-usercluster-controller.yaml
@@ -39,7 +39,7 @@ spec:
         - -timeout
         - "1"
         - -command
-        - '{"command":"/usr/local/bin/user-cluster-controller-manager","args":["-kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","-metrics-listen-address","0.0.0.0:8085","-health-listen-address","0.0.0.0:8086","-namespace","$(NAMESPACE)","-cluster-url","https://jh8j81chn.europe-west3-c.dev.kubermatic.io:30000","-dns-cluster-ip","10.240.16.10","-openvpn-server-port","30003","-overwrite-registry","","-openshift=false","-version","1.18.0","-cloud-provider-name","","-owner-email","","-enable-ssh-key-agent=false","-opa-integration=false","--ipam-controller-network","192.168.1.1/24,192.168.1.1,8.8.8.8","-node-labels","{\"my-label\":\"my-value\"}"]}'
+        - '{"command":"/usr/local/bin/user-cluster-controller-manager","args":["-kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","-metrics-listen-address","0.0.0.0:8085","-health-listen-address","0.0.0.0:8086","-namespace","$(NAMESPACE)","-cluster-url","https://jh8j81chn.europe-west3-c.dev.kubermatic.io:30000","-dns-cluster-ip","10.240.16.10","-openvpn-server-port","30003","-overwrite-registry","","-openshift=false","-version","1.18.0","-cloud-provider-name","","-owner-email","","-enable-ssh-key-agent=false","-opa-integration=false","--ipam-controller-network","192.168.1.1/24,192.168.1.1,8.8.8.8","-cluster-dns-domain","cluster.local","-node-labels","{\"my-label\":\"my-value\"}"]}'
         command:
         - /http-prober-bin/http-prober
         env:

--- a/pkg/resources/test/fixtures/deployment-bringyourown-1.19.0-usercluster-controller.yaml
+++ b/pkg/resources/test/fixtures/deployment-bringyourown-1.19.0-usercluster-controller.yaml
@@ -39,7 +39,7 @@ spec:
         - -timeout
         - "1"
         - -command
-        - '{"command":"/usr/local/bin/user-cluster-controller-manager","args":["-kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","-metrics-listen-address","0.0.0.0:8085","-health-listen-address","0.0.0.0:8086","-namespace","$(NAMESPACE)","-cluster-url","https://jh8j81chn.europe-west3-c.dev.kubermatic.io:30000","-dns-cluster-ip","10.240.16.10","-openvpn-server-port","30003","-overwrite-registry","","-openshift=false","-version","1.19.0","-cloud-provider-name","","-owner-email","","-enable-ssh-key-agent=false","-opa-integration=false","--ipam-controller-network","192.168.1.1/24,192.168.1.1,8.8.8.8","-node-labels","{\"my-label\":\"my-value\"}"]}'
+        - '{"command":"/usr/local/bin/user-cluster-controller-manager","args":["-kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","-metrics-listen-address","0.0.0.0:8085","-health-listen-address","0.0.0.0:8086","-namespace","$(NAMESPACE)","-cluster-url","https://jh8j81chn.europe-west3-c.dev.kubermatic.io:30000","-dns-cluster-ip","10.240.16.10","-openvpn-server-port","30003","-overwrite-registry","","-openshift=false","-version","1.19.0","-cloud-provider-name","","-owner-email","","-enable-ssh-key-agent=false","-opa-integration=false","--ipam-controller-network","192.168.1.1/24,192.168.1.1,8.8.8.8","-cluster-dns-domain","cluster.local","-node-labels","{\"my-label\":\"my-value\"}"]}'
         command:
         - /http-prober-bin/http-prober
         env:

--- a/pkg/resources/test/fixtures/deployment-bringyourown-1.20.0-usercluster-controller.yaml
+++ b/pkg/resources/test/fixtures/deployment-bringyourown-1.20.0-usercluster-controller.yaml
@@ -39,7 +39,7 @@ spec:
         - -timeout
         - "1"
         - -command
-        - '{"command":"/usr/local/bin/user-cluster-controller-manager","args":["-kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","-metrics-listen-address","0.0.0.0:8085","-health-listen-address","0.0.0.0:8086","-namespace","$(NAMESPACE)","-cluster-url","https://jh8j81chn.europe-west3-c.dev.kubermatic.io:30000","-dns-cluster-ip","10.240.16.10","-openvpn-server-port","30003","-overwrite-registry","","-openshift=false","-version","1.20.0","-cloud-provider-name","","-owner-email","","-enable-ssh-key-agent=false","-opa-integration=false","--ipam-controller-network","192.168.1.1/24,192.168.1.1,8.8.8.8","-node-labels","{\"my-label\":\"my-value\"}"]}'
+        - '{"command":"/usr/local/bin/user-cluster-controller-manager","args":["-kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","-metrics-listen-address","0.0.0.0:8085","-health-listen-address","0.0.0.0:8086","-namespace","$(NAMESPACE)","-cluster-url","https://jh8j81chn.europe-west3-c.dev.kubermatic.io:30000","-dns-cluster-ip","10.240.16.10","-openvpn-server-port","30003","-overwrite-registry","","-openshift=false","-version","1.20.0","-cloud-provider-name","","-owner-email","","-enable-ssh-key-agent=false","-opa-integration=false","--ipam-controller-network","192.168.1.1/24,192.168.1.1,8.8.8.8","-cluster-dns-domain","cluster.local","-node-labels","{\"my-label\":\"my-value\"}"]}'
         command:
         - /http-prober-bin/http-prober
         env:

--- a/pkg/resources/test/fixtures/deployment-digitalocean-1.17.0-usercluster-controller.yaml
+++ b/pkg/resources/test/fixtures/deployment-digitalocean-1.17.0-usercluster-controller.yaml
@@ -39,7 +39,7 @@ spec:
         - -timeout
         - "1"
         - -command
-        - '{"command":"/usr/local/bin/user-cluster-controller-manager","args":["-kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","-metrics-listen-address","0.0.0.0:8085","-health-listen-address","0.0.0.0:8086","-namespace","$(NAMESPACE)","-cluster-url","https://jh8j81chn.europe-west3-c.dev.kubermatic.io:30000","-dns-cluster-ip","10.240.16.10","-openvpn-server-port","30003","-overwrite-registry","","-openshift=false","-version","1.17.0","-cloud-provider-name","","-owner-email","","-enable-ssh-key-agent=false","-opa-integration=false","--ipam-controller-network","192.168.1.1/24,192.168.1.1,8.8.8.8","-node-labels","{\"my-label\":\"my-value\"}"]}'
+        - '{"command":"/usr/local/bin/user-cluster-controller-manager","args":["-kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","-metrics-listen-address","0.0.0.0:8085","-health-listen-address","0.0.0.0:8086","-namespace","$(NAMESPACE)","-cluster-url","https://jh8j81chn.europe-west3-c.dev.kubermatic.io:30000","-dns-cluster-ip","10.240.16.10","-openvpn-server-port","30003","-overwrite-registry","","-openshift=false","-version","1.17.0","-cloud-provider-name","","-owner-email","","-enable-ssh-key-agent=false","-opa-integration=false","--ipam-controller-network","192.168.1.1/24,192.168.1.1,8.8.8.8","-cluster-dns-domain","cluster.local","-node-labels","{\"my-label\":\"my-value\"}"]}'
         command:
         - /http-prober-bin/http-prober
         env:

--- a/pkg/resources/test/fixtures/deployment-digitalocean-1.18.0-usercluster-controller.yaml
+++ b/pkg/resources/test/fixtures/deployment-digitalocean-1.18.0-usercluster-controller.yaml
@@ -39,7 +39,7 @@ spec:
         - -timeout
         - "1"
         - -command
-        - '{"command":"/usr/local/bin/user-cluster-controller-manager","args":["-kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","-metrics-listen-address","0.0.0.0:8085","-health-listen-address","0.0.0.0:8086","-namespace","$(NAMESPACE)","-cluster-url","https://jh8j81chn.europe-west3-c.dev.kubermatic.io:30000","-dns-cluster-ip","10.240.16.10","-openvpn-server-port","30003","-overwrite-registry","","-openshift=false","-version","1.18.0","-cloud-provider-name","","-owner-email","","-enable-ssh-key-agent=false","-opa-integration=false","--ipam-controller-network","192.168.1.1/24,192.168.1.1,8.8.8.8","-node-labels","{\"my-label\":\"my-value\"}"]}'
+        - '{"command":"/usr/local/bin/user-cluster-controller-manager","args":["-kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","-metrics-listen-address","0.0.0.0:8085","-health-listen-address","0.0.0.0:8086","-namespace","$(NAMESPACE)","-cluster-url","https://jh8j81chn.europe-west3-c.dev.kubermatic.io:30000","-dns-cluster-ip","10.240.16.10","-openvpn-server-port","30003","-overwrite-registry","","-openshift=false","-version","1.18.0","-cloud-provider-name","","-owner-email","","-enable-ssh-key-agent=false","-opa-integration=false","--ipam-controller-network","192.168.1.1/24,192.168.1.1,8.8.8.8","-cluster-dns-domain","cluster.local","-node-labels","{\"my-label\":\"my-value\"}"]}'
         command:
         - /http-prober-bin/http-prober
         env:

--- a/pkg/resources/test/fixtures/deployment-digitalocean-1.19.0-usercluster-controller.yaml
+++ b/pkg/resources/test/fixtures/deployment-digitalocean-1.19.0-usercluster-controller.yaml
@@ -39,7 +39,7 @@ spec:
         - -timeout
         - "1"
         - -command
-        - '{"command":"/usr/local/bin/user-cluster-controller-manager","args":["-kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","-metrics-listen-address","0.0.0.0:8085","-health-listen-address","0.0.0.0:8086","-namespace","$(NAMESPACE)","-cluster-url","https://jh8j81chn.europe-west3-c.dev.kubermatic.io:30000","-dns-cluster-ip","10.240.16.10","-openvpn-server-port","30003","-overwrite-registry","","-openshift=false","-version","1.19.0","-cloud-provider-name","","-owner-email","","-enable-ssh-key-agent=false","-opa-integration=false","--ipam-controller-network","192.168.1.1/24,192.168.1.1,8.8.8.8","-node-labels","{\"my-label\":\"my-value\"}"]}'
+        - '{"command":"/usr/local/bin/user-cluster-controller-manager","args":["-kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","-metrics-listen-address","0.0.0.0:8085","-health-listen-address","0.0.0.0:8086","-namespace","$(NAMESPACE)","-cluster-url","https://jh8j81chn.europe-west3-c.dev.kubermatic.io:30000","-dns-cluster-ip","10.240.16.10","-openvpn-server-port","30003","-overwrite-registry","","-openshift=false","-version","1.19.0","-cloud-provider-name","","-owner-email","","-enable-ssh-key-agent=false","-opa-integration=false","--ipam-controller-network","192.168.1.1/24,192.168.1.1,8.8.8.8","-cluster-dns-domain","cluster.local","-node-labels","{\"my-label\":\"my-value\"}"]}'
         command:
         - /http-prober-bin/http-prober
         env:

--- a/pkg/resources/test/fixtures/deployment-digitalocean-1.20.0-usercluster-controller.yaml
+++ b/pkg/resources/test/fixtures/deployment-digitalocean-1.20.0-usercluster-controller.yaml
@@ -39,7 +39,7 @@ spec:
         - -timeout
         - "1"
         - -command
-        - '{"command":"/usr/local/bin/user-cluster-controller-manager","args":["-kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","-metrics-listen-address","0.0.0.0:8085","-health-listen-address","0.0.0.0:8086","-namespace","$(NAMESPACE)","-cluster-url","https://jh8j81chn.europe-west3-c.dev.kubermatic.io:30000","-dns-cluster-ip","10.240.16.10","-openvpn-server-port","30003","-overwrite-registry","","-openshift=false","-version","1.20.0","-cloud-provider-name","","-owner-email","","-enable-ssh-key-agent=false","-opa-integration=false","--ipam-controller-network","192.168.1.1/24,192.168.1.1,8.8.8.8","-node-labels","{\"my-label\":\"my-value\"}"]}'
+        - '{"command":"/usr/local/bin/user-cluster-controller-manager","args":["-kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","-metrics-listen-address","0.0.0.0:8085","-health-listen-address","0.0.0.0:8086","-namespace","$(NAMESPACE)","-cluster-url","https://jh8j81chn.europe-west3-c.dev.kubermatic.io:30000","-dns-cluster-ip","10.240.16.10","-openvpn-server-port","30003","-overwrite-registry","","-openshift=false","-version","1.20.0","-cloud-provider-name","","-owner-email","","-enable-ssh-key-agent=false","-opa-integration=false","--ipam-controller-network","192.168.1.1/24,192.168.1.1,8.8.8.8","-cluster-dns-domain","cluster.local","-node-labels","{\"my-label\":\"my-value\"}"]}'
         command:
         - /http-prober-bin/http-prober
         env:

--- a/pkg/resources/test/fixtures/deployment-openstack-1.17.0-usercluster-controller.yaml
+++ b/pkg/resources/test/fixtures/deployment-openstack-1.17.0-usercluster-controller.yaml
@@ -39,7 +39,7 @@ spec:
         - -timeout
         - "1"
         - -command
-        - '{"command":"/usr/local/bin/user-cluster-controller-manager","args":["-kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","-metrics-listen-address","0.0.0.0:8085","-health-listen-address","0.0.0.0:8086","-namespace","$(NAMESPACE)","-cluster-url","https://jh8j81chn.europe-west3-c.dev.kubermatic.io:30000","-dns-cluster-ip","10.240.16.10","-openvpn-server-port","30003","-overwrite-registry","","-openshift=false","-version","1.17.0","-cloud-provider-name","openstack","-owner-email","","-enable-ssh-key-agent=false","-opa-integration=false","--ipam-controller-network","192.168.1.1/24,192.168.1.1,8.8.8.8","-node-labels","{\"my-label\":\"my-value\"}"]}'
+        - '{"command":"/usr/local/bin/user-cluster-controller-manager","args":["-kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","-metrics-listen-address","0.0.0.0:8085","-health-listen-address","0.0.0.0:8086","-namespace","$(NAMESPACE)","-cluster-url","https://jh8j81chn.europe-west3-c.dev.kubermatic.io:30000","-dns-cluster-ip","10.240.16.10","-openvpn-server-port","30003","-overwrite-registry","","-openshift=false","-version","1.17.0","-cloud-provider-name","openstack","-owner-email","","-enable-ssh-key-agent=false","-opa-integration=false","--ipam-controller-network","192.168.1.1/24,192.168.1.1,8.8.8.8","-cluster-dns-domain","cluster.local","-node-labels","{\"my-label\":\"my-value\"}"]}'
         command:
         - /http-prober-bin/http-prober
         env:

--- a/pkg/resources/test/fixtures/deployment-openstack-1.18.0-usercluster-controller.yaml
+++ b/pkg/resources/test/fixtures/deployment-openstack-1.18.0-usercluster-controller.yaml
@@ -39,7 +39,7 @@ spec:
         - -timeout
         - "1"
         - -command
-        - '{"command":"/usr/local/bin/user-cluster-controller-manager","args":["-kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","-metrics-listen-address","0.0.0.0:8085","-health-listen-address","0.0.0.0:8086","-namespace","$(NAMESPACE)","-cluster-url","https://jh8j81chn.europe-west3-c.dev.kubermatic.io:30000","-dns-cluster-ip","10.240.16.10","-openvpn-server-port","30003","-overwrite-registry","","-openshift=false","-version","1.18.0","-cloud-provider-name","openstack","-owner-email","","-enable-ssh-key-agent=false","-opa-integration=false","--ipam-controller-network","192.168.1.1/24,192.168.1.1,8.8.8.8","-node-labels","{\"my-label\":\"my-value\"}"]}'
+        - '{"command":"/usr/local/bin/user-cluster-controller-manager","args":["-kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","-metrics-listen-address","0.0.0.0:8085","-health-listen-address","0.0.0.0:8086","-namespace","$(NAMESPACE)","-cluster-url","https://jh8j81chn.europe-west3-c.dev.kubermatic.io:30000","-dns-cluster-ip","10.240.16.10","-openvpn-server-port","30003","-overwrite-registry","","-openshift=false","-version","1.18.0","-cloud-provider-name","openstack","-owner-email","","-enable-ssh-key-agent=false","-opa-integration=false","--ipam-controller-network","192.168.1.1/24,192.168.1.1,8.8.8.8","-cluster-dns-domain","cluster.local","-node-labels","{\"my-label\":\"my-value\"}"]}'
         command:
         - /http-prober-bin/http-prober
         env:

--- a/pkg/resources/test/fixtures/deployment-openstack-1.19.0-usercluster-controller.yaml
+++ b/pkg/resources/test/fixtures/deployment-openstack-1.19.0-usercluster-controller.yaml
@@ -39,7 +39,7 @@ spec:
         - -timeout
         - "1"
         - -command
-        - '{"command":"/usr/local/bin/user-cluster-controller-manager","args":["-kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","-metrics-listen-address","0.0.0.0:8085","-health-listen-address","0.0.0.0:8086","-namespace","$(NAMESPACE)","-cluster-url","https://jh8j81chn.europe-west3-c.dev.kubermatic.io:30000","-dns-cluster-ip","10.240.16.10","-openvpn-server-port","30003","-overwrite-registry","","-openshift=false","-version","1.19.0","-cloud-provider-name","openstack","-owner-email","","-enable-ssh-key-agent=false","-opa-integration=false","--ipam-controller-network","192.168.1.1/24,192.168.1.1,8.8.8.8","-node-labels","{\"my-label\":\"my-value\"}"]}'
+        - '{"command":"/usr/local/bin/user-cluster-controller-manager","args":["-kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","-metrics-listen-address","0.0.0.0:8085","-health-listen-address","0.0.0.0:8086","-namespace","$(NAMESPACE)","-cluster-url","https://jh8j81chn.europe-west3-c.dev.kubermatic.io:30000","-dns-cluster-ip","10.240.16.10","-openvpn-server-port","30003","-overwrite-registry","","-openshift=false","-version","1.19.0","-cloud-provider-name","openstack","-owner-email","","-enable-ssh-key-agent=false","-opa-integration=false","--ipam-controller-network","192.168.1.1/24,192.168.1.1,8.8.8.8","-cluster-dns-domain","cluster.local","-node-labels","{\"my-label\":\"my-value\"}"]}'
         command:
         - /http-prober-bin/http-prober
         env:

--- a/pkg/resources/test/fixtures/deployment-openstack-1.20.0-usercluster-controller.yaml
+++ b/pkg/resources/test/fixtures/deployment-openstack-1.20.0-usercluster-controller.yaml
@@ -39,7 +39,7 @@ spec:
         - -timeout
         - "1"
         - -command
-        - '{"command":"/usr/local/bin/user-cluster-controller-manager","args":["-kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","-metrics-listen-address","0.0.0.0:8085","-health-listen-address","0.0.0.0:8086","-namespace","$(NAMESPACE)","-cluster-url","https://jh8j81chn.europe-west3-c.dev.kubermatic.io:30000","-dns-cluster-ip","10.240.16.10","-openvpn-server-port","30003","-overwrite-registry","","-openshift=false","-version","1.20.0","-cloud-provider-name","openstack","-owner-email","","-enable-ssh-key-agent=false","-opa-integration=false","--ipam-controller-network","192.168.1.1/24,192.168.1.1,8.8.8.8","-node-labels","{\"my-label\":\"my-value\"}"]}'
+        - '{"command":"/usr/local/bin/user-cluster-controller-manager","args":["-kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","-metrics-listen-address","0.0.0.0:8085","-health-listen-address","0.0.0.0:8086","-namespace","$(NAMESPACE)","-cluster-url","https://jh8j81chn.europe-west3-c.dev.kubermatic.io:30000","-dns-cluster-ip","10.240.16.10","-openvpn-server-port","30003","-overwrite-registry","","-openshift=false","-version","1.20.0","-cloud-provider-name","openstack","-owner-email","","-enable-ssh-key-agent=false","-opa-integration=false","--ipam-controller-network","192.168.1.1/24,192.168.1.1,8.8.8.8","-cluster-dns-domain","cluster.local","-node-labels","{\"my-label\":\"my-value\"}"]}'
         command:
         - /http-prober-bin/http-prober
         env:

--- a/pkg/resources/test/fixtures/deployment-vsphere-1.17.0-usercluster-controller.yaml
+++ b/pkg/resources/test/fixtures/deployment-vsphere-1.17.0-usercluster-controller.yaml
@@ -39,7 +39,7 @@ spec:
         - -timeout
         - "1"
         - -command
-        - '{"command":"/usr/local/bin/user-cluster-controller-manager","args":["-kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","-metrics-listen-address","0.0.0.0:8085","-health-listen-address","0.0.0.0:8086","-namespace","$(NAMESPACE)","-cluster-url","https://jh8j81chn.europe-west3-c.dev.kubermatic.io:30000","-dns-cluster-ip","10.240.16.10","-openvpn-server-port","30003","-overwrite-registry","","-openshift=false","-version","1.17.0","-cloud-provider-name","vsphere","-owner-email","","-enable-ssh-key-agent=false","-opa-integration=false","--ipam-controller-network","192.168.1.1/24,192.168.1.1,8.8.8.8","-node-labels","{\"my-label\":\"my-value\"}"]}'
+        - '{"command":"/usr/local/bin/user-cluster-controller-manager","args":["-kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","-metrics-listen-address","0.0.0.0:8085","-health-listen-address","0.0.0.0:8086","-namespace","$(NAMESPACE)","-cluster-url","https://jh8j81chn.europe-west3-c.dev.kubermatic.io:30000","-dns-cluster-ip","10.240.16.10","-openvpn-server-port","30003","-overwrite-registry","","-openshift=false","-version","1.17.0","-cloud-provider-name","vsphere","-owner-email","","-enable-ssh-key-agent=false","-opa-integration=false","--ipam-controller-network","192.168.1.1/24,192.168.1.1,8.8.8.8","-cluster-dns-domain","cluster.local","-node-labels","{\"my-label\":\"my-value\"}"]}'
         command:
         - /http-prober-bin/http-prober
         env:

--- a/pkg/resources/test/fixtures/deployment-vsphere-1.18.0-usercluster-controller.yaml
+++ b/pkg/resources/test/fixtures/deployment-vsphere-1.18.0-usercluster-controller.yaml
@@ -39,7 +39,7 @@ spec:
         - -timeout
         - "1"
         - -command
-        - '{"command":"/usr/local/bin/user-cluster-controller-manager","args":["-kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","-metrics-listen-address","0.0.0.0:8085","-health-listen-address","0.0.0.0:8086","-namespace","$(NAMESPACE)","-cluster-url","https://jh8j81chn.europe-west3-c.dev.kubermatic.io:30000","-dns-cluster-ip","10.240.16.10","-openvpn-server-port","30003","-overwrite-registry","","-openshift=false","-version","1.18.0","-cloud-provider-name","vsphere","-owner-email","","-enable-ssh-key-agent=false","-opa-integration=false","--ipam-controller-network","192.168.1.1/24,192.168.1.1,8.8.8.8","-node-labels","{\"my-label\":\"my-value\"}"]}'
+        - '{"command":"/usr/local/bin/user-cluster-controller-manager","args":["-kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","-metrics-listen-address","0.0.0.0:8085","-health-listen-address","0.0.0.0:8086","-namespace","$(NAMESPACE)","-cluster-url","https://jh8j81chn.europe-west3-c.dev.kubermatic.io:30000","-dns-cluster-ip","10.240.16.10","-openvpn-server-port","30003","-overwrite-registry","","-openshift=false","-version","1.18.0","-cloud-provider-name","vsphere","-owner-email","","-enable-ssh-key-agent=false","-opa-integration=false","--ipam-controller-network","192.168.1.1/24,192.168.1.1,8.8.8.8","-cluster-dns-domain","cluster.local","-node-labels","{\"my-label\":\"my-value\"}"]}'
         command:
         - /http-prober-bin/http-prober
         env:

--- a/pkg/resources/test/fixtures/deployment-vsphere-1.19.0-usercluster-controller.yaml
+++ b/pkg/resources/test/fixtures/deployment-vsphere-1.19.0-usercluster-controller.yaml
@@ -39,7 +39,7 @@ spec:
         - -timeout
         - "1"
         - -command
-        - '{"command":"/usr/local/bin/user-cluster-controller-manager","args":["-kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","-metrics-listen-address","0.0.0.0:8085","-health-listen-address","0.0.0.0:8086","-namespace","$(NAMESPACE)","-cluster-url","https://jh8j81chn.europe-west3-c.dev.kubermatic.io:30000","-dns-cluster-ip","10.240.16.10","-openvpn-server-port","30003","-overwrite-registry","","-openshift=false","-version","1.19.0","-cloud-provider-name","vsphere","-owner-email","","-enable-ssh-key-agent=false","-opa-integration=false","--ipam-controller-network","192.168.1.1/24,192.168.1.1,8.8.8.8","-node-labels","{\"my-label\":\"my-value\"}"]}'
+        - '{"command":"/usr/local/bin/user-cluster-controller-manager","args":["-kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","-metrics-listen-address","0.0.0.0:8085","-health-listen-address","0.0.0.0:8086","-namespace","$(NAMESPACE)","-cluster-url","https://jh8j81chn.europe-west3-c.dev.kubermatic.io:30000","-dns-cluster-ip","10.240.16.10","-openvpn-server-port","30003","-overwrite-registry","","-openshift=false","-version","1.19.0","-cloud-provider-name","vsphere","-owner-email","","-enable-ssh-key-agent=false","-opa-integration=false","--ipam-controller-network","192.168.1.1/24,192.168.1.1,8.8.8.8","-cluster-dns-domain","cluster.local","-node-labels","{\"my-label\":\"my-value\"}"]}'
         command:
         - /http-prober-bin/http-prober
         env:

--- a/pkg/resources/test/fixtures/deployment-vsphere-1.20.0-usercluster-controller.yaml
+++ b/pkg/resources/test/fixtures/deployment-vsphere-1.20.0-usercluster-controller.yaml
@@ -39,7 +39,7 @@ spec:
         - -timeout
         - "1"
         - -command
-        - '{"command":"/usr/local/bin/user-cluster-controller-manager","args":["-kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","-metrics-listen-address","0.0.0.0:8085","-health-listen-address","0.0.0.0:8086","-namespace","$(NAMESPACE)","-cluster-url","https://jh8j81chn.europe-west3-c.dev.kubermatic.io:30000","-dns-cluster-ip","10.240.16.10","-openvpn-server-port","30003","-overwrite-registry","","-openshift=false","-version","1.20.0","-cloud-provider-name","vsphere","-owner-email","","-enable-ssh-key-agent=false","-opa-integration=false","--ipam-controller-network","192.168.1.1/24,192.168.1.1,8.8.8.8","-node-labels","{\"my-label\":\"my-value\"}"]}'
+        - '{"command":"/usr/local/bin/user-cluster-controller-manager","args":["-kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","-metrics-listen-address","0.0.0.0:8085","-health-listen-address","0.0.0.0:8086","-namespace","$(NAMESPACE)","-cluster-url","https://jh8j81chn.europe-west3-c.dev.kubermatic.io:30000","-dns-cluster-ip","10.240.16.10","-openvpn-server-port","30003","-overwrite-registry","","-openshift=false","-version","1.20.0","-cloud-provider-name","vsphere","-owner-email","","-enable-ssh-key-agent=false","-opa-integration=false","--ipam-controller-network","192.168.1.1/24,192.168.1.1,8.8.8.8","-cluster-dns-domain","cluster.local","-node-labels","{\"my-label\":\"my-value\"}"]}'
         command:
         - /http-prober-bin/http-prober
         env:

--- a/pkg/resources/usercluster/deployment.go
+++ b/pkg/resources/usercluster/deployment.go
@@ -135,6 +135,10 @@ func DeploymentCreator(data userclusterControllerData, openshift bool) reconcili
 				fmt.Sprintf("-opa-integration=%t", data.Cluster().Spec.OPAIntegration != nil && data.Cluster().Spec.OPAIntegration.Enabled),
 			}, getNetworkArgs(data)...)
 
+			if data.Cluster().Spec.ClusterNetwork.DNSDomain != "" {
+				args = append(args, "-cluster-dns-domain", data.Cluster().Spec.ClusterNetwork.DNSDomain)
+			}
+
 			if data.Cluster().Spec.ExposeStrategy == kubermaticv1.ExposeStrategyTunneling {
 				args = append(args, "-tunneling-agent-ip", data.Cluster().Address.IP)
 				args = append(args, "-kas-secure-port", fmt.Sprint(data.Cluster().Address.Port))


### PR DESCRIPTION
**What this PR does / why we need it**:

This brings features that the former dns addon had back into the CoreDNS that's now deployed into the user cluster by the usercluster-controller-manager. It also adds some new things to it. Specifically:

- if `.spec.clusterNetwork.dnsDomain` is overridden on the cluster resource, it gets copied into the dns configuration (`Corefile`) in the user cluster as the domain name for which records are looked up in the K8s api. We implement this by passing the overridden dnsDomain to the user-cluster-controller via an optional command line argument (TODO would it be better if user-cluster-controller grabbed this from the cluster resource directly?)

- we've added a dns-autoscaler deployment

- there's also an extension mechanism that allows the user to provide additional CoreDNS configuration by creating an optional configmap that contains corefiles which will then be used by the main Corefile. This will be used by the normal coredns (kubedns) as well as by the node-local-dns deployment. This may solve https://github.com/kubermatic/kubermatic/issues/6195.

The PR contains 3 commits for easier review -- the dnsDomain transfer is done by the first commit and the other two points by the last two. We can also maybe split this into more than one PR if you want.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Documentation**:
<!-- Add links to the related documentation changes related to this pull request. E.g. the link to the kubermatic/docs pull request. -->

**Does this PR introduce a user-facing change?**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If  no release note is required, just write "NONE".
-->
```release-note
kube-dns supports custom cluster DNS domains as well as optional user-provided additional configuration
```
