### PR TITLE
remove canary-ci-deployment job

### DIFF
--- a/.prow.yaml
+++ b/.prow.yaml
@@ -1302,43 +1302,6 @@ presubmits:
             memory: 4Gi
             cpu: 2
 
-  - name: pre-kubermatic-canary-deployment-ci-kubermatic-io
-    max_concurrency: 1
-    decorate: true
-    # * hack: Contains all the deployment scripting
-    # * charts/kubermatic: Contains the chart
-    # * pkg/crd/kubermatic/v1: Contains the Seed and Datacenter types, if
-    #   this gets out of sync with what's in the secrets repo, we fail because we use
-    #   yaml.UnmarshalStrict
-    run_if_changed: "(hack|charts/kubermatic|pkg/crd/kubermatic/v1)"
-    clone_uri: "ssh://git@github.com/kubermatic/kubermatic.git"
-    branches:
-    - ^master$
-    labels:
-      preset-docker-push: "true"
-      preset-vault: "true"
-      preset-repo-ssh: "true"
-      preset-goproxy: "true"
-    spec:
-      containers:
-      - image: quay.io/kubermatic/go-docker:15.1-1903-1
-        command:
-        - ./hack/ci/deploy-ci-kubermatic-io.sh
-        env:
-        - name: KUBERMATIC_EDITION
-          value: ee
-        - name: CANARY_DEPLOYMENT
-          value: "true"
-        # docker-in-docker needs privileged mode
-        securityContext:
-          privileged: true
-        resources:
-          requests:
-            cpu: 1
-            memory: 1Gi
-          limits:
-            memory: 3Gi
-
   - name: pre-kubermatic-test-integration
     run_if_changed: "^(cmd|codegen|hack|pkg)/"
     decorate: true

--- a/hack/ci/deploy.sh
+++ b/hack/ci/deploy.sh
@@ -93,12 +93,6 @@ function deploy {
   echodate "Upgrading ${name}..."
   retry 5 helm --tiller-namespace ${TILLER_NAMESPACE} upgrade --install --force --atomic --timeout $timeout ${MASTER_FLAG} ${HELM_EXTRA_ARGS} --values ${VALUES_FILE} --namespace ${namespace} ${name} ${path}
 
-  if [ "${CANARY_DEPLOYMENT:-}" = "true" ]; then
-    TEST_NAME="[Helm] Rollback chart ${name}"
-    echodate "Rolling back ${name} to revision ${inital_revision} as this was only a canary deployment"
-    retry 5 helm --tiller-namespace ${TILLER_NAMESPACE} rollback --wait --timeout $timeout ${name} ${inital_revision}
-  fi
-
   unset TEST_NAME
 }
 

--- a/hack/ci/push-images.sh
+++ b/hack/ci/push-images.sh
@@ -28,9 +28,8 @@ GIT_HEAD_TAG="$(git tag -l "$PULL_BASE_REF")"
 GIT_BRANCH="$(git rev-parse --abbrev-ref HEAD)"
 TAGS="$GIT_HEAD_HASH $GIT_HEAD_TAG"
 
-# we only want to create the "latest" tag if we're building
-# the master branch and it's not a canary deployment
-if [ -z "${CANARY_DEPLOYMENT:-}" ] && [ "$GIT_BRANCH" == "master" ]; then
+# we only want to create the "latest" tag if we're building the master branch
+if [ "$GIT_BRANCH" == "master" ]; then
   TAGS="$TAGS latest"
 fi
 


### PR DESCRIPTION
**What this PR does / why we need it**:
The old Helm chart is going to be deleted in this release cycle (i.e. for 2.17), so soon we will not be able to use it for canary deployments anymore. Given that the chart was deprecated, the value in updating our CI cluster was minimal to begin with.

In the future, we should replace this with a kind-based job that uses the KKP Operator / installer instead.

**Does this PR introduce a user-facing change?**:
```release-note
NONE
```
