### PR TITLE
changed gatekeeper webhook admission version to v1beta1

### DIFF
--- a/pkg/controller/user-cluster-controller-manager/resources/resources/gatekeeper/webhook.go
+++ b/pkg/controller/user-cluster-controller-manager/resources/resources/gatekeeper/webhook.go
@@ -25,6 +25,7 @@ import (
 	"k8c.io/kubermatic/v2/pkg/resources/reconciling"
 
 	admissionregistrationv1 "k8s.io/api/admissionregistration/v1"
+	admissionregistrationv1beta1 "k8s.io/api/admissionregistration/v1beta1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/utils/pointer"
 )
@@ -42,7 +43,7 @@ func ValidatingWebhookConfigurationCreator(caCert *x509.Certificate, namespace s
 			validatingWebhookConfigurationWebhookConfiguration.Webhooks = []admissionregistrationv1.ValidatingWebhook{
 				{
 					Name:                    "validation.gatekeeper.sh",
-					AdmissionReviewVersions: []string{admissionregistrationv1.SchemeGroupVersion.Version},
+					AdmissionReviewVersions: []string{admissionregistrationv1beta1.SchemeGroupVersion.Version},
 					FailurePolicy:           &failurePolicyIgnore,
 					SideEffects:             &sideEffectsNone,
 					TimeoutSeconds:          pointer.Int32Ptr(2),
@@ -82,7 +83,7 @@ func ValidatingWebhookConfigurationCreator(caCert *x509.Certificate, namespace s
 				},
 				{
 					Name:                    "check-ignore-label.gatekeeper.sh",
-					AdmissionReviewVersions: []string{admissionregistrationv1.SchemeGroupVersion.Version},
+					AdmissionReviewVersions: []string{admissionregistrationv1beta1.SchemeGroupVersion.Version},
 					FailurePolicy:           &failurePolicyIgnore,
 					SideEffects:             &sideEffectsNone,
 					TimeoutSeconds:          pointer.Int32Ptr(2),


### PR DESCRIPTION
**What this PR does / why we need it**:
Fix issue with gatekeeper not recognizing the AdmissionReview v1 version by changing the webhook to use v1beta1

**Does this PR introduce a user-facing change?**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If  no release note is required, just write "NONE".
-->
```release-note
Fix issue with gatekeeper not recognizing the AdmissionReview v1 version by changing the webhook to use v1beta1
```
