### PR TITLE
Add UseOctavia flag in Cluster cloud spec

### DIFF
--- a/cmd/kubermatic-api/swagger.json
+++ b/cmd/kubermatic-api/swagger.json
@@ -17152,6 +17152,11 @@
           "type": "string",
           "x-go-name": "TenantID"
         },
+        "useOctavia": {
+          "description": "Whether or not to use Octavia for LoadBalancer type of Service\nimplementation instead of using Neutron-LBaaS.\nAttention:Openstack CCM use Octavia as default load balancer\nimplementation since v1.17.0\n\nTakes precedence over the 'use_octavia' flag provided at datacenter\nlevel if both are specified.",
+          "type": "boolean",
+          "x-go-name": "UseOctavia"
+        },
         "username": {
           "type": "string",
           "x-go-name": "Username"

--- a/cmd/kubermatic-api/swagger.json
+++ b/cmd/kubermatic-api/swagger.json
@@ -17153,7 +17153,7 @@
           "x-go-name": "TenantID"
         },
         "useOctavia": {
-          "description": "Whether or not to use Octavia for LoadBalancer type of Service\nimplementation instead of using Neutron-LBaaS.\nAttention:Openstack CCM use Octavia as default load balancer\nimplementation since v1.17.0\n\nTakes precedence over the 'use_octavia' flag provided at datacenter\nlevel if both are specified.",
+          "description": "Whether or not to use Octavia for LoadBalancer type of Service\nimplementation instead of using Neutron-LBaaS.\nAttention:Openstack CCM use Octavia as default load balancer\nimplementation since v1.17.0\n\nTakes precedence over the 'use_octavia' flag provided at datacenter\nlevel if both are specified.\n+optional",
           "type": "boolean",
           "x-go-name": "UseOctavia"
         },

--- a/go.mod
+++ b/go.mod
@@ -74,6 +74,7 @@ require (
 	google.golang.org/api v0.36.0
 	google.golang.org/grpc v1.33.2
 	gopkg.in/fsnotify.v1 v1.4.7
+	gopkg.in/gcfg.v1 v1.2.3
 	gopkg.in/square/go-jose.v2 v2.5.1
 	gopkg.in/yaml.v2 v2.4.0
 	gopkg.in/yaml.v3 v3.0.0-20200615113413-eeeca48fe776

--- a/pkg/crd/kubermatic/v1/cluster.go
+++ b/pkg/crd/kubermatic/v1/cluster.go
@@ -582,7 +582,8 @@ type OpenstackCloudSpec struct {
 	//
 	// Takes precedence over the 'use_octavia' flag provided at datacenter
 	// level if both are specified.
-	UseOctavia *bool `json:"useOctavia"`
+	// +optional
+	UseOctavia *bool `json:"useOctavia,omitempty"`
 }
 
 // PacketCloudSpec specifies access data to a Packet cloud.

--- a/pkg/crd/kubermatic/v1/cluster.go
+++ b/pkg/crd/kubermatic/v1/cluster.go
@@ -575,6 +575,14 @@ type OpenstackCloudSpec struct {
 	FloatingIPPool string `json:"floatingIpPool"`
 	RouterID       string `json:"routerID"`
 	SubnetID       string `json:"subnetID"`
+	// Whether or not to use Octavia for LoadBalancer type of Service
+	// implementation instead of using Neutron-LBaaS.
+	// Attention:Openstack CCM use Octavia as default load balancer
+	// implementation since v1.17.0
+	//
+	// Takes precedence over the 'use_octavia' flag provided at datacenter
+	// level if both are specified.
+	UseOctavia *bool `json:"useOctavia"`
 }
 
 // PacketCloudSpec specifies access data to a Packet cloud.

--- a/pkg/crd/kubermatic/v1/zz_generated.deepcopy.go
+++ b/pkg/crd/kubermatic/v1/zz_generated.deepcopy.go
@@ -2511,6 +2511,11 @@ func (in *OpenstackCloudSpec) DeepCopyInto(out *OpenstackCloudSpec) {
 		*out = new(types.GlobalSecretKeySelector)
 		**out = **in
 	}
+	if in.UseOctavia != nil {
+		in, out := &in.UseOctavia, &out.UseOctavia
+		*out = new(bool)
+		**out = **in
+	}
 	return
 }
 

--- a/pkg/resources/cloudconfig/configmap.go
+++ b/pkg/resources/cloudconfig/configmap.go
@@ -127,6 +127,10 @@ func CloudConfig(
 	case cloud.Openstack != nil:
 		manageSecurityGroups := dc.Spec.Openstack.ManageSecurityGroups
 		trustDevicePath := dc.Spec.Openstack.TrustDevicePath
+		useOctavia := dc.Spec.Openstack.UseOctavia
+		if cluster.Spec.Cloud.Openstack.UseOctavia != nil {
+			useOctavia = cluster.Spec.Cloud.Openstack.UseOctavia
+		}
 		openstackCloudConfig := &openstack.CloudConfig{
 			Global: openstack.GlobalOpts{
 				AuthURL:    dc.Spec.Openstack.AuthURL,
@@ -144,7 +148,7 @@ func CloudConfig(
 			},
 			LoadBalancer: openstack.LoadBalancerOpts{
 				ManageSecurityGroups: manageSecurityGroups == nil || *manageSecurityGroups,
-				UseOctavia:           dc.Spec.Openstack.UseOctavia,
+				UseOctavia:           useOctavia,
 			},
 			Version: cluster.Spec.Version.String(),
 		}

--- a/pkg/test/e2e/utils/apiclient/models/openstack_cloud_spec.go
+++ b/pkg/test/e2e/utils/apiclient/models/openstack_cloud_spec.go
@@ -52,6 +52,15 @@ type OpenstackCloudSpec struct {
 	// tenant ID
 	TenantID string `json:"tenantID,omitempty"`
 
+	// Whether or not to use Octavia for LoadBalancer type of Service
+	// implementation instead of using Neutron-LBaaS.
+	// Attention:Openstack CCM use Octavia as default load balancer
+	// implementation since v1.17.0
+	//
+	// Takes precedence over the 'use_octavia' flag provided at datacenter
+	// level if both are specified.
+	UseOctavia bool `json:"useOctavia,omitempty"`
+
 	// username
 	Username string `json:"username,omitempty"`
 

--- a/pkg/test/e2e/utils/apiclient/models/openstack_cloud_spec.go
+++ b/pkg/test/e2e/utils/apiclient/models/openstack_cloud_spec.go
@@ -59,6 +59,7 @@ type OpenstackCloudSpec struct {
 	//
 	// Takes precedence over the 'use_octavia' flag provided at datacenter
 	// level if both are specified.
+	// +optional
 	UseOctavia bool `json:"useOctavia,omitempty"`
 
 	// username


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR completes the implementation of #6309 the allowing to set `use-octavia` cloud-config flag at `Cluster` level.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #6553

**Special notes for your reviewer**:

**Documentation**:
<!-- Add links to the related documentation changes related to this pull request. E.g. the link to the kubermatic/docs pull request. -->

**Does this PR introduce a user-facing change?**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If  no release note is required, just write "NONE".
-->
```release-note
OpenStack: Add support for "use-octavia" setting in Cluster Openstack cloud specs.
```
