### PR TITLE
Fix KAS service port in tunneling agent config

### DIFF
--- a/pkg/controller/user-cluster-controller-manager/resources/reconciler.go
+++ b/pkg/controller/user-cluster-controller-manager/resources/reconciler.go
@@ -517,7 +517,7 @@ func (r *reconciler) reconcileConfigMaps(ctx context.Context, data reconcileData
 					{
 						BindAddress: r.tunnelingAgentIP.String(),
 						BindPort:    r.kasSecurePort,
-						Authority:   net.JoinHostPort(fmt.Sprintf("apiserver-external.%s.svc.cluster.local", r.namespace), "6443"),
+						Authority:   net.JoinHostPort(fmt.Sprintf("apiserver-external.%s.svc.cluster.local", r.namespace), "443"),
 					},
 				},
 			}),


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR provides a fix for the `Tunneling` expose strategy, at the moment the configuration provided to the agents do not match the proxy server configuration.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Documentation**:
<!-- Add links to the related documentation changes related to this pull request. E.g. the link to the kubermatic/docs pull request. -->

**Does this PR introduce a user-facing change?**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If  no release note is required, just write "NONE".
-->
```release-note
Fix KAS service port in Tunneling agent configuration.
```
