### PR TITLE
[release/v2.16] CT controller queue and deletion fix backport

### DIFF
--- a/pkg/controller/seed-controller-manager/constraint-template-controller/controller_test.go
+++ b/pkg/controller/seed-controller-manager/constraint-template-controller/controller_test.go
@@ -144,6 +144,47 @@ func TestReconcile(t *testing.T) {
 	}
 }
 
+func TestDeleteWhenCTOnUserClusterIsMissing(t *testing.T) {
+	sch, err := v1beta1.SchemeBuilder.Build()
+	if err != nil {
+		t.Fatalf("building gatekeeper scheme failed: %v", err)
+	}
+
+	workerSelector, err := workerlabel.LabelSelector("")
+	if err != nil {
+		t.Fatalf("failed to build worker-name selector: %v", err)
+	}
+
+	seedClient := fakectrlruntimeclient.NewFakeClientWithScheme(
+		scheme.Scheme,
+		genConstraintTemplate(ctName, true),
+		genCluster("cluster", true))
+	userClient := fakectrlruntimeclient.NewFakeClientWithScheme(sch)
+
+	ctx := context.Background()
+	r := &reconciler{
+		log:                       kubermaticlog.Logger,
+		workerNameLabelSelector:   workerSelector,
+		recorder:                  &record.FakeRecorder{},
+		seedClient:                seedClient,
+		userClusterClientProvider: newFakeClientProvider(userClient),
+		userClusterClients:        map[string]ctrlruntimeclient.Client{},
+	}
+
+	request := reconcile.Request{NamespacedName: types.NamespacedName{Name: ctName}}
+	if _, err := r.Reconcile(request); err != nil {
+		t.Fatalf("reconciling failed: %v", err)
+	}
+
+	err = userClient.Get(ctx, request.NamespacedName, &v1beta1.ConstraintTemplate{})
+	if err == nil {
+		t.Fatalf("expected error")
+	}
+	if errors.ReasonForError(err) != metav1.StatusReasonNotFound {
+		t.Fatalf("expected err: %v, got %v", metav1.StatusReasonNotFound, errors.ReasonForError(err))
+	}
+}
+
 func genConstraintTemplate(name string, delete bool) *kubermaticv1.ConstraintTemplate {
 	ct := &kubermaticv1.ConstraintTemplate{}
 	ct.Name = name


### PR DESCRIPTION
**What this PR does / why we need it**:
Fixes issues discovered on Constraint Template seed controller. One is that CT deletes got stuck if they were already deleted on user cluster, second is that when clusters were created with OPA integration already enabled, the CT controller enqueue was not recognizing properly that they had OPA integration enabled.

Cherrypick of https://github.com/kubermatic/kubermatic/pull/6580

**Does this PR introduce a user-facing change?**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If  no release note is required, just write "NONE".
-->
```release-note
Fixed a bug in OPA-integration where deleting a Constraint Template in the seed cluster, when the user cluster Constraint Template is already deleted, caused the deletion to get stuck.
Fixed a bug in OPA-integration where creating a cluster with OPA-integration enabled didnt trigger the Constraint Template reconcile loop.
```
