### PR TITLE
Remove the CCM/CSI Migration annotations in favor of feature flags

### DIFF
--- a/pkg/controller/seed-controller-manager/kubernetes/resources.go
+++ b/pkg/controller/seed-controller-manager/kubernetes/resources.go
@@ -269,8 +269,7 @@ func GetDeploymentCreators(data *resources.TemplateData, enableAPIserverOIDCAuth
 	// moment in which cloud controllers or the full in-tree cloud provider
 	// have been deactivated.
 	if data.Cluster().Spec.Features[kubermaticv1.ClusterFeatureExternalCloudProvider] &&
-		(!metav1.HasAnnotation(data.Cluster().ObjectMeta, kubermaticv1.CCMMigrationNeededAnnotation) ||
-			data.KCMCloudControllersDeactivated()) {
+		data.KCMCloudControllersDeactivated(false) {
 		deployments = append(deployments, cloudcontroller.DeploymentCreator(data))
 	}
 	if data.Cluster().Spec.OPAIntegration != nil && data.Cluster().Spec.OPAIntegration.Enabled {

--- a/pkg/controller/seed-controller-manager/kubernetes/resources.go
+++ b/pkg/controller/seed-controller-manager/kubernetes/resources.go
@@ -269,7 +269,7 @@ func GetDeploymentCreators(data *resources.TemplateData, enableAPIserverOIDCAuth
 	// moment in which cloud controllers or the full in-tree cloud provider
 	// have been deactivated.
 	if data.Cluster().Spec.Features[kubermaticv1.ClusterFeatureExternalCloudProvider] &&
-		data.KCMCloudControllersDeactivated(false) {
+		data.KCMCloudControllersDeactivated() {
 		deployments = append(deployments, cloudcontroller.DeploymentCreator(data))
 	}
 	if data.Cluster().Spec.OPAIntegration != nil && data.Cluster().Spec.OPAIntegration.Enabled {

--- a/pkg/controller/seed-controller-manager/kubernetes/resources_test.go
+++ b/pkg/controller/seed-controller-manager/kubernetes/resources_test.go
@@ -201,35 +201,6 @@ func TestCloudControllerManagerDeployment(t *testing.T) {
 			wantCCMCreator: false,
 		},
 		{
-			name: "No CCM migration ongoing",
-			cluster: &kubermaticv1.Cluster{
-				ObjectMeta: metav1.ObjectMeta{
-					Name: "cluster-a",
-				},
-				Spec: kubermaticv1.ClusterSpec{
-					Features: map[string]bool{
-						kubermaticv1.ClusterFeatureExternalCloudProvider: true,
-					},
-				},
-				Status: kubermaticv1.ClusterStatus{
-					NamespaceName: "test",
-				},
-			},
-			kcmDeploymentConfig: KCMDeploymentConfig{
-				Flags: []string{},
-				Status: appsv1.DeploymentStatus{
-					ObservedGeneration: 1,
-					Replicas:           2,
-					AvailableReplicas:  1,
-					UpdatedReplicas:    1,
-				},
-				Generation: 1,
-				Replicas:   2,
-				Namespace:  "test",
-			},
-			wantCCMCreator: true,
-		},
-		{
 			name: "No external cloud-provider",
 			cluster: &kubermaticv1.Cluster{
 				ObjectMeta: metav1.ObjectMeta{

--- a/pkg/controller/seed-controller-manager/kubernetes/resources_test.go
+++ b/pkg/controller/seed-controller-manager/kubernetes/resources_test.go
@@ -52,14 +52,11 @@ func TestCloudControllerManagerDeployment(t *testing.T) {
 			cluster: &kubermaticv1.Cluster{
 				ObjectMeta: metav1.ObjectMeta{
 					Name: "cluster-a",
-					Annotations: map[string]string{
-						kubermaticv1.CCMMigrationNeededAnnotation: "",
-						kubermaticv1.CSIMigrationNeededAnnotation: "",
-					},
 				},
 				Spec: kubermaticv1.ClusterSpec{
 					Features: map[string]bool{
 						kubermaticv1.ClusterFeatureExternalCloudProvider: true,
+						kubermaticv1.ClusterFeatureCSIMigration:          true,
 					},
 				},
 				Status: kubermaticv1.ClusterStatus{
@@ -85,14 +82,11 @@ func TestCloudControllerManagerDeployment(t *testing.T) {
 			cluster: &kubermaticv1.Cluster{
 				ObjectMeta: metav1.ObjectMeta{
 					Name: "cluster-a",
-					Annotations: map[string]string{
-						kubermaticv1.CCMMigrationNeededAnnotation: "",
-						kubermaticv1.CSIMigrationNeededAnnotation: "",
-					},
 				},
 				Spec: kubermaticv1.ClusterSpec{
 					Features: map[string]bool{
 						kubermaticv1.ClusterFeatureExternalCloudProvider: true,
+						kubermaticv1.ClusterFeatureCSIMigration:          true,
 					},
 				},
 				Status: kubermaticv1.ClusterStatus{
@@ -118,14 +112,11 @@ func TestCloudControllerManagerDeployment(t *testing.T) {
 			cluster: &kubermaticv1.Cluster{
 				ObjectMeta: metav1.ObjectMeta{
 					Name: "cluster-a",
-					Annotations: map[string]string{
-						kubermaticv1.CCMMigrationNeededAnnotation: "",
-						kubermaticv1.CSIMigrationNeededAnnotation: "",
-					},
 				},
 				Spec: kubermaticv1.ClusterSpec{
 					Features: map[string]bool{
 						kubermaticv1.ClusterFeatureExternalCloudProvider: true,
+						kubermaticv1.ClusterFeatureCSIMigration:          true,
 					},
 				},
 				Status: kubermaticv1.ClusterStatus{
@@ -154,14 +145,11 @@ func TestCloudControllerManagerDeployment(t *testing.T) {
 			cluster: &kubermaticv1.Cluster{
 				ObjectMeta: metav1.ObjectMeta{
 					Name: "cluster-a",
-					Annotations: map[string]string{
-						kubermaticv1.CCMMigrationNeededAnnotation: "",
-						kubermaticv1.CSIMigrationNeededAnnotation: "",
-					},
 				},
 				Spec: kubermaticv1.ClusterSpec{
 					Features: map[string]bool{
 						kubermaticv1.ClusterFeatureExternalCloudProvider: true,
+						kubermaticv1.ClusterFeatureCSIMigration:          true,
 					},
 				},
 				Status: kubermaticv1.ClusterStatus{
@@ -187,14 +175,11 @@ func TestCloudControllerManagerDeployment(t *testing.T) {
 			cluster: &kubermaticv1.Cluster{
 				ObjectMeta: metav1.ObjectMeta{
 					Name: "cluster-a",
-					Annotations: map[string]string{
-						kubermaticv1.CCMMigrationNeededAnnotation: "",
-						kubermaticv1.CSIMigrationNeededAnnotation: "",
-					},
 				},
 				Spec: kubermaticv1.ClusterSpec{
 					Features: map[string]bool{
 						kubermaticv1.ClusterFeatureExternalCloudProvider: true,
+						kubermaticv1.ClusterFeatureCSIMigration:          true,
 					},
 				},
 				Status: kubermaticv1.ClusterStatus{

--- a/pkg/controller/seed-controller-manager/openshift/data.go
+++ b/pkg/controller/seed-controller-manager/openshift/data.go
@@ -332,7 +332,8 @@ func (od *openshiftData) BackupSchedule() time.Duration {
 
 func (od *openshiftData) GetKubernetesCloudProviderName() string {
 	return kubernetesresources.GetKubernetesCloudProviderName(od.Cluster(),
-		od.Cluster().Spec.Features[kubermaticv1.ClusterFeatureExternalCloudProvider])
+		od.Cluster().Spec.Features[kubermaticv1.ClusterFeatureExternalCloudProvider],
+		false)
 }
 
 func (od *openshiftData) CloudCredentialSecretTemplate() ([]byte, error) {

--- a/pkg/crd/kubermatic/v1/cluster.go
+++ b/pkg/crd/kubermatic/v1/cluster.go
@@ -47,11 +47,6 @@ const (
 )
 
 const (
-	CCMMigrationNeededAnnotation = "ccm-migration.k8c.io/migration-needed"
-	CSIMigrationNeededAnnotation = "csi-migration.k8c.io/migration-needed"
-)
-
-const (
 	WorkerNameLabelKey   = "worker-name"
 	ProjectIDLabelKey    = "project-id"
 	UpdatedByVPALabelKey = "updated-by-vpa"
@@ -165,6 +160,13 @@ const (
 	// only supported on a limited set of providers for a specific set of Kube versions. It must
 	// not be set if its not supported.
 	ClusterFeatureExternalCloudProvider = "externalCloudProvider"
+
+	// ClusterFeatureCSIMigration describes the CSIMigration feature. This feature enables
+	// the CSIMigration feature gates on API server, controller-manager, and kubelets, which are
+	// responsible for translating and redirecting calls from the in-tree volumes APIs to the
+	// CSI plugins. This feautre is only supported on a limited set of providers for a specific
+	// set of Kube versions. It must not be set if its not supported.
+	ClusterFeatureCSIMigration = "csiMigration"
 
 	// ClusterFeatureRancherIntegration enables the rancher server integration feature.
 	// It will deploy a Rancher Server Managegment plane on the seed cluster and import the user cluster into it.

--- a/pkg/resources/apiserver/deployment.go
+++ b/pkg/resources/apiserver/deployment.go
@@ -375,7 +375,9 @@ func getApiserverFlags(data *resources.TemplateData, etcdEndpoints []string, ena
 		flags = append(flags, "--kubelet-preferred-address-types", "ExternalIP,InternalIP")
 	}
 
-	cloudProviderName := resources.GetKubernetesCloudProviderName(data.Cluster(), resources.ExternalCloudProviderEnabled(data.Cluster()))
+	cloudProviderName := resources.GetKubernetesCloudProviderName(data.Cluster(),
+		resources.ExternalCloudProviderEnabled(data.Cluster()),
+		data.KCMInTreeCloudProviderDisabled())
 	if cloudProviderName != "" && cloudProviderName != "external" {
 		flags = append(flags, "--cloud-provider", cloudProviderName)
 		flags = append(flags, "--cloud-config", "/etc/kubernetes/cloud/config")

--- a/pkg/resources/controllermanager/deployment.go
+++ b/pkg/resources/controllermanager/deployment.go
@@ -205,7 +205,7 @@ func getFlags(data *resources.TemplateData) ([]string, error) {
 	controllers := []string{"*", "bootstrapsigner", "tokencleaner"}
 	// If CCM migration is enabled and all kubeletes have not been migrated yet
 	// disable the cloud controllers.
-	// If in-tree cloud providers are deactivated (KCMCloudControllersDeactivated is true),
+	// If in-tree cloud providers are deactivated (KCMInTreeCloudProviderDisabled is true),
 	// we don't want to disable any controllers, because those clusters are already using
 	// the external CCM (newly-created OpenStack clusters).
 	if data.Cluster().Spec.Features[kubermaticv1.ClusterFeatureExternalCloudProvider] &&

--- a/pkg/resources/controllermanager/deployment.go
+++ b/pkg/resources/controllermanager/deployment.go
@@ -210,7 +210,7 @@ func getFlags(data *resources.TemplateData) ([]string, error) {
 	// the external CCM (newly-created OpenStack clusters).
 	if data.Cluster().Spec.Features[kubermaticv1.ClusterFeatureExternalCloudProvider] &&
 		!kubermaticv1helper.ClusterConditionHasStatus(data.Cluster(), kubermaticv1.ClusterConditionCSIKubeletMigrationCompleted, corev1.ConditionTrue) &&
-		!data.KCMCloudControllersDeactivated(true) {
+		!data.KCMInTreeCloudProviderDisabled() {
 		controllers = append(controllers, "-cloud-node-lifecycle", "-route", "-service")
 	}
 	flags := []string{
@@ -233,7 +233,8 @@ func getFlags(data *resources.TemplateData) ([]string, error) {
 	flags = append(flags, strings.Join(featureGates, ","))
 
 	cloudProviderName := resources.GetKubernetesCloudProviderName(data.Cluster(),
-		resources.ExternalCloudProviderEnabled(data.Cluster()))
+		resources.ExternalCloudProviderEnabled(data.Cluster()),
+		data.KCMInTreeCloudProviderDisabled())
 	if cloudProviderName != "" && cloudProviderName != "external" {
 		flags = append(flags, "--cloud-provider", cloudProviderName)
 		flags = append(flags, "--cloud-config", "/etc/kubernetes/cloud/config")

--- a/pkg/resources/data_test.go
+++ b/pkg/resources/data_test.go
@@ -40,8 +40,33 @@ func TestGetCSIMigrationFeatureGates(t *testing.T) {
 					Annotations: map[string]string{},
 				},
 				Spec: kubermaticv1.ClusterSpec{
+					Cloud: kubermaticv1.CloudSpec{
+						Openstack: &kubermaticv1.OpenstackCloudSpec{},
+					},
 					Features: map[string]bool{
 						kubermaticv1.ClusterFeatureExternalCloudProvider: true,
+					},
+				},
+				Status: kubermaticv1.ClusterStatus{
+					NamespaceName: "test",
+				},
+			},
+			wantFeatureGates: sets.String{},
+		},
+		{
+			name: "CSI migration feature disabled",
+			cluster: &kubermaticv1.Cluster{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:        "cluster-a",
+					Annotations: map[string]string{},
+				},
+				Spec: kubermaticv1.ClusterSpec{
+					Cloud: kubermaticv1.CloudSpec{
+						Openstack: &kubermaticv1.OpenstackCloudSpec{},
+					},
+					Features: map[string]bool{
+						kubermaticv1.ClusterFeatureExternalCloudProvider: true,
+						kubermaticv1.ClusterFeatureCSIMigration:          false,
 					},
 				},
 				Status: kubermaticv1.ClusterStatus{
@@ -55,13 +80,14 @@ func TestGetCSIMigrationFeatureGates(t *testing.T) {
 			cluster: &kubermaticv1.Cluster{
 				ObjectMeta: metav1.ObjectMeta{
 					Name: "cluster-a",
-					Annotations: map[string]string{
-						kubermaticv1.CSIMigrationNeededAnnotation: "",
-					},
 				},
 				Spec: kubermaticv1.ClusterSpec{
+					Cloud: kubermaticv1.CloudSpec{
+						Openstack: &kubermaticv1.OpenstackCloudSpec{},
+					},
 					Features: map[string]bool{
 						kubermaticv1.ClusterFeatureExternalCloudProvider: true,
+						kubermaticv1.ClusterFeatureCSIMigration:          true,
 					},
 				},
 				Status: kubermaticv1.ClusterStatus{
@@ -75,13 +101,14 @@ func TestGetCSIMigrationFeatureGates(t *testing.T) {
 			cluster: &kubermaticv1.Cluster{
 				ObjectMeta: metav1.ObjectMeta{
 					Name: "cluster-a",
-					Annotations: map[string]string{
-						kubermaticv1.CSIMigrationNeededAnnotation: "",
-					},
 				},
 				Spec: kubermaticv1.ClusterSpec{
+					Cloud: kubermaticv1.CloudSpec{
+						Openstack: &kubermaticv1.OpenstackCloudSpec{},
+					},
 					Features: map[string]bool{
 						kubermaticv1.ClusterFeatureExternalCloudProvider: true,
+						kubermaticv1.ClusterFeatureCSIMigration:          true,
 					},
 				},
 				Status: kubermaticv1.ClusterStatus{
@@ -95,6 +122,27 @@ func TestGetCSIMigrationFeatureGates(t *testing.T) {
 				},
 			},
 			wantFeatureGates: sets.NewString("CSIMigration=true", "CSIMigrationOpenStack=true", "ExpandCSIVolumes=true", "CSIMigrationOpenStackComplete=true"),
+		},
+		{
+			name: "CSI migration on non-OpenStack provider",
+			cluster: &kubermaticv1.Cluster{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "cluster-a",
+				},
+				Spec: kubermaticv1.ClusterSpec{
+					Cloud: kubermaticv1.CloudSpec{
+						AWS: &kubermaticv1.AWSCloudSpec{},
+					},
+					Features: map[string]bool{
+						kubermaticv1.ClusterFeatureExternalCloudProvider: true,
+						kubermaticv1.ClusterFeatureCSIMigration:          true,
+					},
+				},
+				Status: kubermaticv1.ClusterStatus{
+					NamespaceName: "test",
+				},
+			},
+			wantFeatureGates: sets.String{},
 		},
 	}
 


### PR DESCRIPTION
**What this PR does / why we need it**:

We've introduced the CCM/CSI Migration logic based on two annotations (`ccm-migration.k8c.io/migration-needed` and `csi-migration.k8c.io/migration-needed`) in #6535.

This PR refactors the logic to drop those two annotations in favor of two feature flags:

* `externalCloudProvider` (this feature flag has been existing before)
* `csiMigration` (this is a new feature flag)

This PR uses the following workflow:

* New OpenStack clusters are created with the `externalCloudProvider` feature flag by default
  * New OpenStack clusters will have in-tree cloud provider enabled, but CCM controllers will be disabled, and the external CCM will be deployed
    * This is different from what we were doing before (we were deploying clusters will in-tree cloud provider disabled)
  * In a follow-up, we should also enable the `csiMigration` feature flag by default, and disable the in-tree provider
* Existing OpenStack clusters with the external CCM
  * Those clusters will remain with the in-tree cloud provider disabled (i.e. no changes will be done to those clusters)
  * The CSI migration can be triggered by enabling the `csiMigration` feature flag
* Existing OpenStack clusters without the external CCM
  * The CCM migration is triggered by enabling the `externalCloudProvider` feature flag
  * The CSI migration is triggered by enabling the `csiMigration` feature flag

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #5799

**Does this PR introduce a user-facing change?**:
```release-note
NONE
```

/assign @kron4eg @moadqassem 