### PR TITLE
Add min/max replicas fields to node/machine deployment API

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,6 +7,7 @@
 .env
 .idea
 .kubeconfig
+.kube
 /client-gen
 /codecgen_binary
 /deepcopy-gen

--- a/cmd/kubermatic-api/swagger.json
+++ b/cmd/kubermatic-api/swagger.json
@@ -16680,6 +16680,16 @@
           "type": "boolean",
           "x-go-name": "DynamicConfig"
         },
+        "maxReplicas": {
+          "type": "integer",
+          "format": "int32",
+          "x-go-name": "MaxReplicas"
+        },
+        "minReplicas": {
+          "type": "integer",
+          "format": "int32",
+          "x-go-name": "MinReplicas"
+        },
         "paused": {
           "type": "boolean",
           "x-go-name": "Paused"

--- a/pkg/api/v1/types.go
+++ b/pkg/api/v1/types.go
@@ -2128,6 +2128,6 @@ func ToInternalClusterType(externalClusterType string) kubermaticv1.ClusterType 
 
 const (
 	InitialMachineDeploymentRequestAnnotation = "kubermatic.io/initial-machinedeployment-request"
-	AutoscalerMinSizeAnnotation = "cluster.x-k8s.io/cluster-api-autoscaler-node-group-min-size"
-	AutoscalerMaxSizeAnnotation = "cluster.x-k8s.io/cluster-api-autoscaler-node-group-max-size"
+	AutoscalerMinSizeAnnotation = "cluster.k8s.io/cluster-api-autoscaler-node-group-min-size"
+	AutoscalerMaxSizeAnnotation = "cluster.k8s.io/cluster-api-autoscaler-node-group-max-size"
 )

--- a/pkg/api/v1/types.go
+++ b/pkg/api/v1/types.go
@@ -1883,9 +1883,9 @@ type NodeDeploymentSpec struct {
 	// required: false
 	DynamicConfig *bool `json:"dynamicConfig,omitempty"`
 	// required: false
-	MinReplicas   int32 `json:"minReplicas,omitempty"`
+	MinReplicas int32 `json:"minReplicas,omitempty"`
 	// required: false
-	MaxReplicas   int32 `json:"maxReplicas,omitempty"`
+	MaxReplicas int32 `json:"maxReplicas,omitempty"`
 }
 
 // Event is a report of an event somewhere in the cluster.
@@ -2128,6 +2128,6 @@ func ToInternalClusterType(externalClusterType string) kubermaticv1.ClusterType 
 
 const (
 	InitialMachineDeploymentRequestAnnotation = "kubermatic.io/initial-machinedeployment-request"
-	AutoscalerMinSizeAnnotation = "cluster.k8s.io/cluster-api-autoscaler-node-group-min-size"
-	AutoscalerMaxSizeAnnotation = "cluster.k8s.io/cluster-api-autoscaler-node-group-max-size"
+	AutoscalerMinSizeAnnotation               = "cluster.k8s.io/cluster-api-autoscaler-node-group-min-size"
+	AutoscalerMaxSizeAnnotation               = "cluster.k8s.io/cluster-api-autoscaler-node-group-max-size"
 )

--- a/pkg/api/v1/types.go
+++ b/pkg/api/v1/types.go
@@ -1882,6 +1882,10 @@ type NodeDeploymentSpec struct {
 	Paused *bool `json:"paused,omitempty"`
 	// required: false
 	DynamicConfig *bool `json:"dynamicConfig,omitempty"`
+	// required: false
+	MinReplicas   int32 `json:"minReplicas,omitempty"`
+	// required: false
+	MaxReplicas   int32 `json:"maxReplicas,omitempty"`
 }
 
 // Event is a report of an event somewhere in the cluster.
@@ -2124,4 +2128,6 @@ func ToInternalClusterType(externalClusterType string) kubermaticv1.ClusterType 
 
 const (
 	InitialMachineDeploymentRequestAnnotation = "kubermatic.io/initial-machinedeployment-request"
+	AutoscalerMinSizeAnnotation = "cluster.x-k8s.io/cluster-api-autoscaler-node-group-min-size"
+	AutoscalerMaxSizeAnnotation = "cluster.x-k8s.io/cluster-api-autoscaler-node-group-max-size"
 )

--- a/pkg/handler/common/machine.go
+++ b/pkg/handler/common/machine.go
@@ -172,7 +172,7 @@ func outputMachineDeployment(md *clusterv1alpha1.MachineDeployment) (*apiv1.Node
 			CreationTimestamp: apiv1.NewTime(md.CreationTimestamp.Time),
 		},
 		Spec: apiv1.NodeDeploymentSpec{
-			Replicas: *md.Spec.Replicas,
+			Replicas:    *md.Spec.Replicas,
 			MinReplicas: minReplicas,
 			MaxReplicas: maxReplicas,
 			Template: apiv1.NodeSpec{

--- a/pkg/handler/common/machine.go
+++ b/pkg/handler/common/machine.go
@@ -538,6 +538,7 @@ func PatchMachineDeployment(ctx context.Context, userInfoGetter provider.UserInf
 
 	// Only the fields from NodeDeploymentSpec will be updated by a patch.
 	// It ensures that the name and resource version are set and the selector stays the same.
+	machineDeployment.Annotations = patchedMachineDeployment.Annotations
 	machineDeployment.Spec.Template.Spec = patchedMachineDeployment.Spec.Template.Spec
 	machineDeployment.Spec.Replicas = patchedMachineDeployment.Spec.Replicas
 	machineDeployment.Spec.Paused = patchedMachineDeployment.Spec.Paused

--- a/pkg/resources/machine/machinedeployment.go
+++ b/pkg/resources/machine/machinedeployment.go
@@ -90,13 +90,6 @@ func Deployment(c *kubermaticv1.Cluster, nd *apiv1.NodeDeployment, dc *kubermati
 		}
 		md.Annotations[apiv1.AutoscalerMinSizeAnnotation] = strconv.Itoa(int(nd.Spec.MinReplicas))
 		md.Annotations[apiv1.AutoscalerMaxSizeAnnotation] = strconv.Itoa(int(nd.Spec.MaxReplicas))
-	} else if md.Annotations != nil {
-		if _, ok := md.Annotations[apiv1.AutoscalerMinSizeAnnotation]; ok {
-			delete(md.Annotations, apiv1.AutoscalerMinSizeAnnotation)
-		}
-		if _, ok := md.Annotations[apiv1.AutoscalerMaxSizeAnnotation]; ok {
-			delete(md.Annotations, apiv1.AutoscalerMaxSizeAnnotation)
-		}
 	}
 
 	md.Spec.Template.Spec.Versions.Kubelet = nd.Spec.Template.Versions.Kubelet

--- a/pkg/test/e2e/utils/apiclient/models/node_deployment_spec.go
+++ b/pkg/test/e2e/utils/apiclient/models/node_deployment_spec.go
@@ -20,6 +20,12 @@ type NodeDeploymentSpec struct {
 	// dynamic config
 	DynamicConfig bool `json:"dynamicConfig,omitempty"`
 
+	// max replicas
+	MaxReplicas int32 `json:"maxReplicas,omitempty"`
+
+	// min replicas
+	MinReplicas int32 `json:"minReplicas,omitempty"`
+
 	// paused
 	Paused bool `json:"paused,omitempty"`
 


### PR DESCRIPTION
**What this PR does / why we need it**:

This PR adds the fields `minReplicas` and `maxReplicas` to the [NodeDeploymentSpec](https://github.com/kubermatic/kubermatic/blob/fcfdea9cfbc210bd3817c0c85dc00fea49e90095/cmd/kubermatic-api/swagger.json#L16671) of the Kubermatic API.

When the `maxReplicas` is present and has a value > `0`, the corresponding annotations for the cluster autoscaler are applied to the respective machinedeployment.

**Which issue(s) this PR fixes** 
This PR contributes to #6507 

**Does this PR introduce a user-facing change?**:
```release-note
1. Support setting cluster autoscaler annotations from the Kubermatic API
```
