### PR TITLE
fixed issue with kubermatic constraints delete failing when user cluster constraint is missing

### DIFF
--- a/pkg/controller/user-cluster-controller-manager/constraint-syncer/controller.go
+++ b/pkg/controller/user-cluster-controller-manager/constraint-syncer/controller.go
@@ -118,7 +118,7 @@ func (r *reconciler) reconcile(ctx context.Context, constraint *kubermaticv1.Con
 		})
 		toDelete.SetName(constraint.Name)
 
-		if err := r.userClient.Delete(ctx, toDelete); err != nil {
+		if err := r.userClient.Delete(ctx, toDelete); err != nil && !kerrors.IsNotFound(err) {
 			return fmt.Errorf("failed to delete constraint: %v", err)
 		}
 

--- a/pkg/controller/user-cluster-controller-manager/constraint-syncer/controller_test.go
+++ b/pkg/controller/user-cluster-controller-manager/constraint-syncer/controller_test.go
@@ -106,6 +106,29 @@ func TestReconcile(t *testing.T) {
 				}).
 				Build(),
 		},
+		{
+			name: "scenario 3: delete kubermatic constraint on seed cluster when the corresponding constraint on user cluster is missing",
+			namespacedName: types.NamespacedName{
+				Namespace: "namespace",
+				Name:      constraintName,
+			},
+			expectedGetErrStatus: metav1.StatusReasonNotFound,
+			seedClient: fakectrlruntimeclient.
+				NewClientBuilder().
+				WithScheme(scheme.Scheme).
+				WithObjects(func() *v1.Constraint {
+					c := test.GenConstraint(constraintName, "namespace", kind)
+					deleteTime := metav1.NewTime(time.Now())
+					c.DeletionTimestamp = &deleteTime
+					c.Finalizers = []string{kubermaticapiv1.GatekeeperConstraintCleanupFinalizer}
+					return c
+				}()).
+				Build(),
+			userClient: fakectrlruntimeclient.
+				NewClientBuilder().
+				WithScheme(scheme.Scheme).
+				Build(),
+		},
 	}
 
 	for _, tc := range testCases {


### PR DESCRIPTION
**What this PR does / why we need it**:
Fixes an issue with kubermatic constraints delete failing when user cluster constraint is missing. It was causing such clusters to hang when being deleted because of the finalizers on the constraints.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #6597 

**Does this PR introduce a user-facing change?**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If  no release note is required, just write "NONE".
-->
```release-note
Fixed a bug with kubermatic constraints delete getting stuck when corresponding user cluster constraint is missing
```
