### PR TITLE
remove Procfile

### DIFF
--- a/Procfile
+++ b/Procfile
@@ -1,3 +1,0 @@
-controller: ./hack/run-controller.sh
-api: ./hack/run-api.sh
-master-controller-manager: ./hack/run-master-controller-manager.sh


### PR DESCRIPTION
**What this PR does / why we need it**:
The file was added many moons ago in #2919, but today doesn't prove to be very useful. For example, both master and seed ctrlmgrs want to open a port for pprof, but they can't both be listening on the same port, so one of them needs `PPROF_PORT` to be altered. Likewise, `run-controller.sh` doesn't even exist, which I take as prove that nobody used this in a looooong time.

**Does this PR introduce a user-facing change?**:
```release-note
NONE
```
