### PR TITLE
enable PVC conformance test for hetzner clusters

### DIFF
--- a/cmd/conformance-tests/runner.go
+++ b/cmd/conformance-tests/runner.go
@@ -1337,10 +1337,8 @@ func supportsStorage(cluster *kubermaticv1.Cluster) bool {
 		cluster.Spec.Cloud.Azure != nil ||
 		cluster.Spec.Cloud.AWS != nil ||
 		cluster.Spec.Cloud.VSphere != nil ||
-		cluster.Spec.Cloud.GCP != nil
-
-	// Currently broken, see https://github.com/kubermatic/kubermatic/issues/3312
-	//cluster.Spec.Cloud.Hetzner != nil
+		cluster.Spec.Cloud.GCP != nil ||
+		cluster.Spec.Cloud.Hetzner != nil
 }
 
 func supportsLBs(cluster *kubermaticv1.Cluster) bool {


### PR DESCRIPTION
**What this PR does / why we need it**:
Storage works fine on Hetzner, so let's make sure it stays this way.

/test pre-kubermatic-e2e-hetzner-ubuntu-1.20

**Does this PR introduce a user-facing change?**:
```release-note
Improve CSI on Hetzner
```
