### PR TITLE
Add openstack flavor restriction

### DIFF
--- a/cmd/example-yaml-generator/main.go
+++ b/cmd/example-yaml-generator/main.go
@@ -139,6 +139,7 @@ func createExampleSeed() *kubermaticv1.Seed {
 							UseOctavia:           pointer.BoolPtr(true),
 							DNSServers:           []string{},
 							TrustDevicePath:      pointer.BoolPtr(false),
+							EnabledFlavors:       []string{},
 						},
 						Packet: &kubermaticv1.DatacenterSpecPacket{
 							Facilities: []string{},

--- a/cmd/kubermatic-api/swagger.json
+++ b/cmd/kubermatic-api/swagger.json
@@ -15090,6 +15090,14 @@
           },
           "x-go-name": "DNSServers"
         },
+        "enabled_flavors": {
+          "description": "Optional: List of enabled flavors for the given datacenter",
+          "type": "array",
+          "items": {
+            "type": "string"
+          },
+          "x-go-name": "EnabledFlavors"
+        },
         "enforce_floating_ip": {
           "description": "Optional",
           "type": "boolean",

--- a/docs/zz_generated.seed.yaml
+++ b/docs/zz_generated.seed.yaml
@@ -124,7 +124,7 @@ spec:
           # Used for automatic network creation
           dns_servers: []
           # Optional: List of enabled flavors for the given datacenter
-          enabled_flavors: null
+          enabled_flavors: []
           # Optional
           enforce_floating_ip: false
           # Optional

--- a/docs/zz_generated.seed.yaml
+++ b/docs/zz_generated.seed.yaml
@@ -123,6 +123,8 @@ spec:
           availability_zone: ""
           # Used for automatic network creation
           dns_servers: []
+          # Optional: List of enabled flavors for the given datacenter
+          enabled_flavors: null
           # Optional
           enforce_floating_ip: false
           # Optional

--- a/pkg/crd/kubermatic/v1/datacenter.go
+++ b/pkg/crd/kubermatic/v1/datacenter.go
@@ -215,6 +215,8 @@ type DatacenterSpecOpenstack struct {
 	// This setting defaults to false.
 	TrustDevicePath      *bool                         `json:"trust_device_path"`
 	NodeSizeRequirements OpenstackNodeSizeRequirements `json:"node_size_requirements"`
+	// Optional: List of enabled flavors for the given datacenter
+	EnabledFlavors []string `json:"enabled_flavors"`
 }
 
 type OpenstackNodeSizeRequirements struct {

--- a/pkg/crd/kubermatic/v1/zz_generated.deepcopy.go
+++ b/pkg/crd/kubermatic/v1/zz_generated.deepcopy.go
@@ -1480,6 +1480,11 @@ func (in *DatacenterSpecOpenstack) DeepCopyInto(out *DatacenterSpecOpenstack) {
 		**out = **in
 	}
 	out.NodeSizeRequirements = in.NodeSizeRequirements
+	if in.EnabledFlavors != nil {
+		in, out := &in.EnabledFlavors, &out.EnabledFlavors
+		*out = make([]string, len(*in))
+		copy(*out, *in)
+	}
 	return
 }
 

--- a/pkg/handler/common/provider/openstack.go
+++ b/pkg/handler/common/provider/openstack.go
@@ -277,7 +277,9 @@ func GetOpenstackSizes(username, password, tenant, tenantID, domain, datacenterN
 			IsPublic: flavor.IsPublic,
 		}
 		if MeetsOpenstackNodeSizeRequirement(apiSize, datacenter.Spec.Openstack.NodeSizeRequirements) {
-			apiSizes = append(apiSizes, apiSize)
+			if IsFlavorEnabled(apiSize, datacenter.Spec.Openstack.EnabledFlavors) {
+				apiSizes = append(apiSizes, apiSize)
+			}
 		}
 	}
 
@@ -315,6 +317,19 @@ func MeetsOpenstackNodeSizeRequirement(apiSize apiv1.OpenstackSize, requirements
 		return false
 	}
 	return true
+}
+
+func IsFlavorEnabled(apiSize apiv1.OpenstackSize, enabledFlavors []string) bool {
+	if len(enabledFlavors) == 0 {
+		// Flavors are enabled if no restrictions were made.
+		return true
+	}
+	for _, flavor := range enabledFlavors {
+		if flavor == apiSize.Slug {
+			return true
+		}
+	}
+	return false
 }
 
 func GetOpenstackSecurityGroups(userInfo *provider.UserInfo, seedsGetter provider.SeedsGetter, username, password, tenant, tenantID, domain, datacenterName string) ([]apiv1.OpenstackSecurityGroup, error) {

--- a/pkg/handler/v1/provider/openstack_test.go
+++ b/pkg/handler/v1/provider/openstack_test.go
@@ -409,6 +409,55 @@ func TestMeetsOpentackNodeSizeRequirement(t *testing.T) {
 	}
 }
 
+func TestFilterEnabledFlavors(t *testing.T) {
+	tests := []struct {
+		name           string
+		apiSize        apiv1.OpenstackSize
+		enabledFlavors []string
+		enabledFlavor  bool
+	}{
+		{
+			name: "enabled specific flavor",
+			apiSize: apiv1.OpenstackSize{
+				Slug: "m1.small",
+			},
+			enabledFlavors: []string{"m1.small"},
+			enabledFlavor:  true,
+		},
+		{
+			name: "filtered flavor",
+			apiSize: apiv1.OpenstackSize{
+				Slug: "m1.small",
+			},
+			enabledFlavors: []string{"m1.medium"},
+			enabledFlavor:  false,
+		},
+		{
+			name: "enable multiple flavors",
+			apiSize: apiv1.OpenstackSize{
+				Slug: "m1.small",
+			},
+			enabledFlavors: []string{"m1.small", "m1.medium"},
+			enabledFlavor:  true,
+		},
+		{
+			name: "empty enabledFlavors",
+			apiSize: apiv1.OpenstackSize{
+				Slug: "m1.small",
+			},
+			enabledFlavors: []string{},
+			enabledFlavor:  true,
+		},
+	}
+	for _, testToRun := range tests {
+		t.Run(testToRun.name, func(t *testing.T) {
+			if providercommon.IsFlavorEnabled(testToRun.apiSize, testToRun.enabledFlavors) != testToRun.enabledFlavor {
+				t.Errorf("expected result to be %v, but got %v", testToRun.enabledFlavor, !testToRun.enabledFlavor)
+			}
+		})
+	}
+}
+
 func compareJSON(t *testing.T, res *httptest.ResponseRecorder, expectedResponseString string) {
 	t.Helper()
 	var actualResponse interface{}

--- a/pkg/test/e2e/utils/apiclient/models/datacenter_spec_openstack.go
+++ b/pkg/test/e2e/utils/apiclient/models/datacenter_spec_openstack.go
@@ -25,6 +25,9 @@ type DatacenterSpecOpenstack struct {
 	// Used for automatic network creation
 	DNSServers []string `json:"dns_servers"`
 
+	// Optional: List of enabled flavors for the given datacenter
+	EnabledFlavors []string `json:"enabled_flavors"`
+
 	// Optional
 	EnforceFloatingIP bool `json:"enforce_floating_ip,omitempty"`
 


### PR DESCRIPTION
Signed-off-by: Happy2C0de <46957159+Happy2C0de@users.noreply.github.com>

**What this PR does / why we need it**:
Enables certain flavors for Openstack Datacenters instead of showing all flavors of a given Openstack project (there might be flavors that are not ideal for Machine Deployments) Admins should be able to control what kind of flavors a user can use within its clusters.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #6611

**Special notes for your reviewer**:
Added a new Test in openstack_test.go to check that the filtering works as expected. If no flavors are specified, we should go with the default -> show all flavors of a project.

**Documentation**:
<!-- Add links to the related documentation changes related to this pull request. E.g. the link to the kubermatic/docs pull request. -->

**Does this PR introduce a user-facing change?**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If  no release note is required, just write "NONE".
-->
```release-note
- Add support in Openstack datacenters to explicitly enable certain flavor types.
```
