### PR TITLE
Fix typo in HCloud CSI driver

### DIFF
--- a/addons/csi/hetzner/hcloud-csi.yaml
+++ b/addons/csi/hetzner/hcloud-csi.yaml
@@ -207,7 +207,7 @@ spec:
             allowPrivilegeEscalation: true
         - name: liveness-probe
           imagePullPolicy: Always
-          image: '{{ Registry "docker.io" }}/k8scsi/livenessprobe:v1.1.0'
+          image: '{{ Registry "quay.io" }}/k8scsi/livenessprobe:v1.1.0'
           args:
             - --csi-address=/var/lib/csi/sockets/pluginproxy/csi.sock
           volumeMounts:


### PR DESCRIPTION
**What this PR does / why we need it**:
This fixes the registry and makes sure the pods can become healthy. This fix is already included in the 2.16 backport (#6620).

/test pre-kubermatic-e2e-hetzner-ubuntu-1.20

**Does this PR introduce a user-facing change?**:
```release-note
NONE
```
