### PR TITLE
Implement the MutatingWebhook for the Cluster objects

### DIFF
--- a/cmd/seed-controller-manager/main.go
+++ b/cmd/seed-controller-manager/main.go
@@ -38,7 +38,7 @@ import (
 	"k8c.io/kubermatic/v2/pkg/pprof"
 	"k8c.io/kubermatic/v2/pkg/util/cli"
 	"k8c.io/kubermatic/v2/pkg/version/kubermatic"
-	clustervalidation "k8c.io/kubermatic/v2/pkg/webhook/cluster"
+	clustervalidation "k8c.io/kubermatic/v2/pkg/webhook/cluster/validation"
 
 	"k8s.io/apimachinery/pkg/api/meta"
 	autoscalingv1beta2 "k8s.io/autoscaler/vertical-pod-autoscaler/pkg/apis/autoscaling.k8s.io/v1beta2"

--- a/pkg/webhook/cluster/mutation/mutation.go
+++ b/pkg/webhook/cluster/mutation/mutation.go
@@ -1,0 +1,115 @@
+/*
+Copyright 2020 The Kubermatic Kubernetes Platform contributors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package mutation
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+
+	"github.com/go-logr/logr"
+
+	kubermaticv1 "k8c.io/kubermatic/v2/pkg/crd/kubermatic/v1"
+
+	admissionv1 "k8s.io/api/admission/v1"
+	"k8s.io/utils/pointer"
+	ctrlruntime "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/webhook"
+	"sigs.k8s.io/controller-runtime/pkg/webhook/admission"
+)
+
+// AdmissionHandler for mutating Kubermatic Cluster CRD.
+type AdmissionHandler struct {
+	log     logr.Logger
+	decoder *admission.Decoder
+}
+
+// NewAdmissionHandler returns a new cluster mutation AdmissionHandler.
+func NewAdmissionHandler() *AdmissionHandler {
+	return &AdmissionHandler{}
+}
+
+func (h *AdmissionHandler) InjectLogger(l logr.Logger) error {
+	h.log = l.WithName("cluster-mutation-handler")
+	return nil
+}
+
+func (h *AdmissionHandler) InjectDecoder(d *admission.Decoder) error {
+	h.decoder = d
+	return nil
+}
+
+func (h *AdmissionHandler) Handle(ctx context.Context, req webhook.AdmissionRequest) webhook.AdmissionResponse {
+	cluster := &kubermaticv1.Cluster{}
+	oldCluster := &kubermaticv1.Cluster{}
+
+	switch req.Operation {
+	case admissionv1.Create:
+		// NOP
+	case admissionv1.Update:
+		if err := h.decoder.Decode(req, cluster); err != nil {
+			return admission.Errored(http.StatusBadRequest, err)
+		}
+		if err := h.decoder.DecodeRaw(req.OldObject, oldCluster); err != nil {
+			return admission.Errored(http.StatusBadRequest, err)
+		}
+
+		if err := h.mutateUpdate(ctx, oldCluster, cluster); err != nil {
+			h.log.Info("cluster mutation failed", "error", err)
+			return webhook.Errored(http.StatusInternalServerError, fmt.Errorf("cluster mutation request %s failed: %v", req.UID, err))
+		}
+
+		mutatedCluster, err := json.Marshal(cluster)
+		if err != nil {
+			return webhook.Errored(http.StatusInternalServerError, fmt.Errorf("marshaling cluster object failed: %v", err))
+		}
+
+		return admission.PatchResponseFromRaw(req.Object.Raw, mutatedCluster)
+	case admissionv1.Delete:
+		// NOP
+	default:
+		return admission.Errored(http.StatusBadRequest, fmt.Errorf("%s not supported on cluster resources", req.Operation))
+	}
+	return webhook.Allowed(fmt.Sprintf("no mutation done for request %s", req.UID))
+}
+
+func (h *AdmissionHandler) mutateUpdate(ctx context.Context, oldCluster, newCluster *kubermaticv1.Cluster) error {
+	// This part of the code handles the CCM/CSI migration. It currently works
+	// only for OpenStack clusters, in the following way:
+	//   * Add the CCM/CSI migration annotations
+	//   * Enable the UseOctaiva flag
+	switch {
+	case newCluster.Spec.Cloud.Openstack != nil:
+		if v, oldV := newCluster.Spec.Features[kubermaticv1.ClusterFeatureExternalCloudProvider],
+			oldCluster.Spec.Features[kubermaticv1.ClusterFeatureExternalCloudProvider]; v && !oldV {
+			if newCluster.ObjectMeta.Annotations == nil {
+				newCluster.ObjectMeta.Annotations = map[string]string{}
+			}
+
+			newCluster.ObjectMeta.Annotations[kubermaticv1.CCMMigrationNeededAnnotation] = ""
+			newCluster.ObjectMeta.Annotations[kubermaticv1.CSIMigrationNeededAnnotation] = ""
+			newCluster.Spec.Cloud.Openstack.UseOctavia = pointer.BoolPtr(true)
+		}
+	}
+
+	return nil
+}
+
+func (h *AdmissionHandler) SetupWebhookWithManager(mgr ctrlruntime.Manager) {
+	mgr.GetWebhookServer().Register("/mutate-kubermatic-k8s-io-cluster", &webhook.Admission{Handler: h})
+}

--- a/pkg/webhook/cluster/mutation/mutation_test.go
+++ b/pkg/webhook/cluster/mutation/mutation_test.go
@@ -1,0 +1,239 @@
+/*
+Copyright 2020 The Kubermatic Kubernetes Platform contributors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package mutation
+
+import (
+	"bytes"
+	"context"
+	"testing"
+	"text/template"
+
+	logrtesting "github.com/go-logr/logr/testing"
+
+	kubermaticv1 "k8c.io/kubermatic/v2/pkg/crd/kubermatic/v1"
+
+	admissionv1 "k8s.io/api/admission/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"sigs.k8s.io/controller-runtime/pkg/webhook"
+	"sigs.k8s.io/controller-runtime/pkg/webhook/admission"
+)
+
+var (
+	testScheme = runtime.NewScheme()
+)
+
+func init() {
+	_ = kubermaticv1.AddToScheme(testScheme)
+}
+
+func TestHandle(t *testing.T) {
+	tests := []struct {
+		name            string
+		req             webhook.AdmissionRequest
+		wantAllowed     bool
+		wantAnnotations bool
+		wantUseOctavia  bool
+	}{
+		{
+			name: "Create cluster success",
+			req: webhook.AdmissionRequest{
+				AdmissionRequest: admissionv1.AdmissionRequest{
+					Operation: admissionv1.Create,
+					RequestKind: &metav1.GroupVersionKind{
+						Group:   kubermaticv1.GroupName,
+						Version: kubermaticv1.GroupVersion,
+						Kind:    "Cluster",
+					},
+					Name: "foo",
+					Object: runtime.RawExtension{
+						Raw: rawClusterGen{Name: "foo", CloudProvider: "openstack", ExternalCloudProvider: true}.Do(),
+					},
+				},
+			},
+			wantAllowed: true,
+		},
+		{
+			name: "Delete cluster success",
+			req: webhook.AdmissionRequest{
+				AdmissionRequest: admissionv1.AdmissionRequest{
+					Operation: admissionv1.Delete,
+					RequestKind: &metav1.GroupVersionKind{
+						Group:   kubermaticv1.GroupName,
+						Version: kubermaticv1.GroupVersion,
+						Kind:    "Cluster",
+					},
+					Name: "foo",
+					Object: runtime.RawExtension{
+						Raw: rawClusterGen{Name: "foo", CloudProvider: "openstack", ExternalCloudProvider: true}.Do(),
+					},
+				},
+			},
+			wantAllowed: true,
+		},
+		{
+			name: "Update OpenStack cluster to enable the CCM/CSI migration",
+			req: webhook.AdmissionRequest{
+				AdmissionRequest: admissionv1.AdmissionRequest{
+					Operation: admissionv1.Update,
+					RequestKind: &metav1.GroupVersionKind{
+						Group:   kubermaticv1.GroupName,
+						Version: kubermaticv1.GroupVersion,
+						Kind:    "Cluster",
+					},
+					Name: "foo",
+					Object: runtime.RawExtension{
+						Raw: rawClusterGen{Name: "foo", CloudProvider: "openstack", ExternalCloudProvider: true}.Do(),
+					},
+					OldObject: runtime.RawExtension{
+						Raw: rawClusterGen{Name: "foo", CloudProvider: "openstack", ExternalCloudProvider: false}.Do(),
+					},
+				},
+			},
+			wantAllowed:     true,
+			wantAnnotations: true,
+			wantUseOctavia:  true,
+		},
+		{
+			name: "Update OpenStack cluster with enabled CCM/CSI migration",
+			req: webhook.AdmissionRequest{
+				AdmissionRequest: admissionv1.AdmissionRequest{
+					Operation: admissionv1.Update,
+					RequestKind: &metav1.GroupVersionKind{
+						Group:   kubermaticv1.GroupName,
+						Version: kubermaticv1.GroupVersion,
+						Kind:    "Cluster",
+					},
+					Name: "foo",
+					Object: runtime.RawExtension{
+						Raw: rawClusterGen{Name: "foo", CloudProvider: "openstack", ExternalCloudProvider: true}.Do(),
+					},
+					OldObject: runtime.RawExtension{
+						Raw: rawClusterGen{Name: "foo", CloudProvider: "openstack", ExternalCloudProvider: true}.Do(),
+					},
+				},
+			},
+			wantAllowed:     true,
+			wantAnnotations: false,
+			wantUseOctavia:  false,
+		},
+		{
+			name: "Update non-OpenStack cluster to enable CCM/CSI migration",
+			req: webhook.AdmissionRequest{
+				AdmissionRequest: admissionv1.AdmissionRequest{
+					Operation: admissionv1.Update,
+					RequestKind: &metav1.GroupVersionKind{
+						Group:   kubermaticv1.GroupName,
+						Version: kubermaticv1.GroupVersion,
+						Kind:    "Cluster",
+					},
+					Name: "foo",
+					Object: runtime.RawExtension{
+						Raw: rawClusterGen{Name: "foo", CloudProvider: "hetzner", ExternalCloudProvider: true}.Do(),
+					},
+					OldObject: runtime.RawExtension{
+						Raw: rawClusterGen{Name: "foo", CloudProvider: "hetzner", ExternalCloudProvider: false}.Do(),
+					},
+				},
+			},
+			wantAllowed:     true,
+			wantAnnotations: false,
+			wantUseOctavia:  false,
+		},
+	}
+	for _, tt := range tests {
+		d, err := admission.NewDecoder(testScheme)
+		if err != nil {
+			t.Fatalf("error occurred while creating decoder: %v", err)
+		}
+		handler := AdmissionHandler{
+			log:     &logrtesting.NullLogger{},
+			decoder: d,
+		}
+		t.Run(tt.name, func(t *testing.T) {
+			res := handler.Handle(context.TODO(), tt.req)
+			if res.Allowed != tt.wantAllowed {
+				t.Logf("Response: %v", res)
+				t.Fatalf("Allowed %t, but wanted %t", res.Allowed, tt.wantAllowed)
+			}
+
+			foundPatchCCMAnnotation := false
+			foundPatchCSIAnnotation := false
+			foundPatchUseOctavia := false
+
+			for _, patch := range res.Patches {
+				switch {
+				case patch.Operation == "add" && patch.Path == "/metadata/annotations" && patch.Value != nil:
+					if m, ok := patch.Value.(map[string]interface{}); ok {
+						for k := range m {
+							if k == kubermaticv1.CCMMigrationNeededAnnotation {
+								foundPatchCCMAnnotation = true
+							}
+							if k == kubermaticv1.CSIMigrationNeededAnnotation {
+								foundPatchCSIAnnotation = true
+							}
+						}
+					}
+				case patch.Operation == "add" && patch.Path == "/spec/cloud/openstack/useOctavia":
+					if v, ok := patch.Value.(bool); ok {
+						if v {
+							foundPatchUseOctavia = true
+						}
+					}
+				}
+			}
+
+			if tt.wantAnnotations != foundPatchCCMAnnotation {
+				t.Errorf("ccm-migration.k8c.io/migration-needed: expected: %v, found: %v", tt.wantAnnotations, foundPatchCCMAnnotation)
+			}
+			if tt.wantAnnotations != foundPatchCSIAnnotation {
+				t.Errorf("csi-migration.k8c.io/migration-needed: expected: %v, found: %v", tt.wantAnnotations, foundPatchCSIAnnotation)
+			}
+			if tt.wantUseOctavia != foundPatchUseOctavia {
+				t.Errorf(".spec.Cloud.openstack.UseOctavia: expected: %v, found: %v", tt.wantAnnotations, foundPatchUseOctavia)
+			}
+		})
+	}
+}
+
+type rawClusterGen struct {
+	Name                  string
+	CloudProvider         string
+	ExternalCloudProvider bool
+}
+
+func (r rawClusterGen) Do() []byte {
+	tmpl, _ := template.New("cluster").Parse(`
+	{
+	"apiVersion": "kubermatic.k8s.io/v1",
+	"kind": "Cluster",
+	"metadata": {
+	  "name": "{{ .Name }}"
+	},
+	"spec": {
+	  "features": {
+		"externalCloudProvider": {{ .ExternalCloudProvider }}
+	  },
+      "cloud": {
+        "{{ .CloudProvider }}": {}
+      }
+	}
+}`)
+	sb := bytes.Buffer{}
+	_ = tmpl.Execute(&sb, r)
+	return sb.Bytes()
+}

--- a/pkg/webhook/cluster/validation/validation.go
+++ b/pkg/webhook/cluster/validation/validation.go
@@ -14,7 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package cluster
+package validation
 
 import (
 	"context"
@@ -36,7 +36,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/webhook/admission"
 )
 
-// AdmissionHandler for Kubermatic Cluster CRD.
+// AdmissionHandler for validating Kubermatic Cluster CRD.
 type AdmissionHandler struct {
 	log      logr.Logger
 	decoder  *admission.Decoder
@@ -44,7 +44,7 @@ type AdmissionHandler struct {
 	client   ctrlruntimeclient.Client
 }
 
-// NewAdmissionHandler returns a new cluster.AdmissionHandler.
+// NewAdmissionHandler returns a new cluster validation AdmissionHandler.
 func NewAdmissionHandler(client ctrlruntimeclient.Client, features features.FeatureGate) *AdmissionHandler {
 	return &AdmissionHandler{
 		features: features,

--- a/pkg/webhook/cluster/validation/validation_test.go
+++ b/pkg/webhook/cluster/validation/validation_test.go
@@ -14,7 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package cluster
+package validation
 
 import (
 	"bytes"
@@ -25,8 +25,8 @@ import (
 	logrtesting "github.com/go-logr/logr/testing"
 
 	kubermaticv1 "k8c.io/kubermatic/v2/pkg/crd/kubermatic/v1"
-
 	"k8c.io/kubermatic/v2/pkg/features"
+
 	admissionv1 "k8s.io/api/admission/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"


### PR DESCRIPTION
**What this PR does / why we need it**:

This PR is the second stage of #6555. It implements the mutating webhook for the Cluster objects to apply the CCM and CSI migration-needed annotations. Currently, the mutating webhook affects only OpenStack clusters, in the following way:

* If the Cluster is updated to enable the `externalCloudProvider` feature gate, apply the annotations and enable the `UseOctavia` feature

The webhook is currently not wired with the other components, which will be done in the next stage. This way we can more easily revert it if something goes wrong.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
xref #6555

**Does this PR introduce a user-facing change?**:

```release-note
NONE
```

/assign @irozzo-1A @xrstf 