### PR TITLE
Make operator deploy the MutatingWebhookConfig for Clusters

### DIFF
--- a/cmd/seed-controller-manager/main.go
+++ b/cmd/seed-controller-manager/main.go
@@ -38,6 +38,7 @@ import (
 	"k8c.io/kubermatic/v2/pkg/pprof"
 	"k8c.io/kubermatic/v2/pkg/util/cli"
 	"k8c.io/kubermatic/v2/pkg/version/kubermatic"
+	clustermutation "k8c.io/kubermatic/v2/pkg/webhook/cluster/mutation"
 	clustervalidation "k8c.io/kubermatic/v2/pkg/webhook/cluster/validation"
 
 	"k8s.io/apimachinery/pkg/api/meta"
@@ -170,8 +171,10 @@ Please install the VerticalPodAutoscaler according to the documentation: https:/
 
 		// Setup the admission handler for kubermatic Seed CRDs
 		h.SetupWebhookWithManager(mgr)
-		// Setup the admission handler for kubermatic Cluster CRDs
+		// Setup the validation admission handler for kubermatic Cluster CRDs
 		clustervalidation.NewAdmissionHandler(mgr.GetClient(), options.featureGates).SetupWebhookWithManager(mgr)
+		// Setup the mutation admission handler for kubermatic Cluster CRDs
+		clustermutation.NewAdmissionHandler().SetupWebhookWithManager(mgr)
 	}
 
 	ctrlCtx := &controllerContext{


### PR DESCRIPTION
**What this PR does / why we need it**:

This PR is the final phase of #6555. It modifies the operator to deploy the MutatingWebhookConfiguration for the webhook and modifies the seed-controller-manager to register the webhook.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
xref #6555
The issue will be closed once we're sure that the webhook works properly.

**Special notes for your reviewer**:

The webhook **is not tested**. This is because testing mutating webhook locally is complicated. We should get the first signal from the E2E tests and then we can do more detailed tests on the dev environment.

In the case something goes wrong, it's enough to just revert this PR and remove the MutatingWebhookConfiguration from the cluster.

**Does this PR introduce a user-facing change?**:
```release-note
NONE
```

/assign @irozzo-1A @xrstf 