### PR TITLE
Fix operator failing to reconcile admission configs

### DIFF
--- a/pkg/controller/operator/seed/resources/kubermatic/admission.go
+++ b/pkg/controller/operator/seed/resources/kubermatic/admission.go
@@ -67,7 +67,8 @@ func ClusterValidatingWebhookConfigurationCreator(cfg *operatorv1alpha1.Kubermat
 							Port:      pointer.Int32Ptr(443),
 						},
 					},
-					ObjectSelector: &metav1.LabelSelector{},
+					ObjectSelector:    &metav1.LabelSelector{},
+					NamespaceSelector: &metav1.LabelSelector{},
 					Rules: []admissionregistrationv1.RuleWithOperations{
 						{
 							Rule: admissionregistrationv1.Rule{
@@ -120,7 +121,8 @@ func ClusterMutatingWebhookConfigurationCreator(cfg *operatorv1alpha1.Kubermatic
 							Port:      pointer.Int32Ptr(443),
 						},
 					},
-					ObjectSelector: &metav1.LabelSelector{},
+					ObjectSelector:    &metav1.LabelSelector{},
+					NamespaceSelector: &metav1.LabelSelector{},
 					Rules: []admissionregistrationv1.RuleWithOperations{
 						{
 							Rule: admissionregistrationv1.Rule{


### PR DESCRIPTION
**What this PR does / why we need it**:

The operator is currently stuck in a loop trying to reconcile the `kubermatic-clusters` ValidatingWebhookConfiguration. This seems to be caused by a mismatch between the expected and the defaulted object.

```
{"level":"debug","time":"2021-03-04T19:24:23.346Z","caller":"reconciling/compare.go:60","msg":"Object differs from generated one","type":"*v1.ValidatingWebhookConfiguration","namespace":"","name":"kubermatic-clusters","diff":["Webhooks.slice[0].NamespaceSelector: <nil pointer> != v1.LabelSelector"]}
```

After that, the operator fails to update the ValidatingWebhookConfiguration for some reason. This PR might improve the situation or even fix the problem.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
xref #6555

**Special notes for your reviewer**:

This PR **is not tested**.

**Does this PR introduce a user-facing change?**:
```release-note
Fix the operator failing to reconcile the ValidatingWebhookConfiguration object for the cluster validation webhook
```

/assign @xrstf 