### PR TITLE
Fix operator failing to reconcile MutatingWebhookConfiguration

### DIFF
--- a/pkg/controller/operator/seed/resources/kubermatic/admission.go
+++ b/pkg/controller/operator/seed/resources/kubermatic/admission.go
@@ -96,6 +96,7 @@ func ClusterMutatingWebhookConfigurationCreator(cfg *operatorv1alpha1.Kubermatic
 		return ClusterAdmissionWebhookName, func(hook *admissionregistrationv1.MutatingWebhookConfiguration) (*admissionregistrationv1.MutatingWebhookConfiguration, error) {
 			matchPolicy := admissionregistrationv1.Exact
 			failurePolicy := admissionregistrationv1.Fail
+			reinvocationPolicy := admissionregistrationv1.NeverReinvocationPolicy
 			sideEffects := admissionregistrationv1.SideEffectClassNone
 			scope := admissionregistrationv1.ClusterScope
 
@@ -110,6 +111,7 @@ func ClusterMutatingWebhookConfigurationCreator(cfg *operatorv1alpha1.Kubermatic
 					AdmissionReviewVersions: []string{"v1beta1"},
 					MatchPolicy:             &matchPolicy,
 					FailurePolicy:           &failurePolicy,
+					ReinvocationPolicy:      &reinvocationPolicy,
 					SideEffects:             &sideEffects,
 					TimeoutSeconds:          pointer.Int32Ptr(30),
 					ClientConfig: admissionregistrationv1.WebhookClientConfig{


### PR DESCRIPTION
**What this PR does / why we need it**:

This PR is similar to #6639, but it fixes the problem for the MutatingWebhookConfiguration added in #6638.

The operator shows the following error:

```
{"level":"debug","time":"2021-03-04T20:40:09.442Z","caller":"reconciling/compare.go:60","msg":"Object differs from generated one","type":"*v1.MutatingWebhookConfiguration","namespace":"","name":"kubermatic-clusters","diff":["Webhooks.slice[0].ReinvocationPolicy: <nil pointer> != v1.ReinvocationPolicyType"]}
```

The operator successfully creates the MutatingWebhookConfiguration initially, but subsequent reconciliations are failing with the error showed above.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
xref #6555

**Does this PR introduce a user-facing change?**:
```release-note
NONE
```

/assign @xrstf 