### PR TITLE
Fix the nodeport-proxy role to have permissions on endpoints

### DIFF
--- a/pkg/resources/nodeportproxy/nodeportproxy.go
+++ b/pkg/resources/nodeportproxy/nodeportproxy.go
@@ -206,7 +206,7 @@ func role() reconciling.NamedRoleCreatorGetter {
 			r.Rules = []rbacv1.PolicyRule{
 				{
 					APIGroups: []string{""},
-					Resources: []string{"services", "pods"},
+					Resources: []string{"endpoints", "services"},
 					Verbs:     []string{"list", "get", "watch"},
 				},
 				{


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR fixes the role that is used by the nodeport-proxy when `LoadBalancer` expose strategy is used.
Before #6154 the nodeport proxy was watching `pods` and not `endpoints` to configure the backends. The cluster role used by nodeport-proxy when `nodeport` and `tunneling` strategy are used is updated accordingly, but when `LoadBalancer` strategy is used nodeport-proxy is deployed by the `seed-controller-manager` in each namespace and a `Role` is used instead.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #6645 

**Special notes for your reviewer**:

**Documentation**:
<!-- Add links to the related documentation changes related to this pull request. E.g. the link to the kubermatic/docs pull request. -->

**Does this PR introduce a user-facing change?**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If  no release note is required, just write "NONE".
-->
```release-note
Fix nodeport-proxy role used with LoadBalancer expose strategy.
```
