### PR TITLE
update Loki to 2.1, use boltdb-shipper starting June 1st

### DIFF
--- a/charts/logging/loki/Chart.yaml
+++ b/charts/logging/loki/Chart.yaml
@@ -14,8 +14,8 @@
 
 apiVersion: "v1"
 name: loki
-version: 0.0.10
-appVersion: v1.6.1
+version: 0.1.0
+appVersion: v2.1.0
 description: "Loki: like Prometheus, but for logs."
 keywords:
 - kubermatic

--- a/charts/logging/loki/values.yaml
+++ b/charts/logging/loki/values.yaml
@@ -39,7 +39,6 @@ loki:
           kvstore:
             store: inmemory
           replication_factor: 1
-
     limits_config:
       enforce_metric_name: false
       reject_old_samples: true
@@ -53,6 +52,13 @@ loki:
         index:
           prefix: index_
           period: 144h
+      - from: 2021-07-01
+        store: boltdb-shipper
+        object_store: filesystem
+        schema: v11
+        index:
+          prefix: index_
+          period: 24h
     server:
       http_listen_port: 3100
     storage_config:
@@ -68,7 +74,7 @@ loki:
 
   image:
     repository: docker.io/grafana/loki
-    tag: 1.6.1
+    tag: 2.1.0
     pullPolicy: IfNotPresent
 
   ## The app name of loki clients

--- a/charts/logging/promtail/Chart.yaml
+++ b/charts/logging/promtail/Chart.yaml
@@ -14,8 +14,8 @@
 
 apiVersion: "v1"
 name: promtail
-version: 0.1.6
-appVersion: v1.6.1
+version: 0.2.0
+appVersion: v2.1.0
 description: "Responsible for gathering logs and sending them to Loki"
 keywords:
 - kubermatic

--- a/charts/logging/promtail/values.yaml
+++ b/charts/logging/promtail/values.yaml
@@ -17,7 +17,7 @@ promtail:
 
   image:
     repository: docker.io/grafana/promtail
-    tag: 1.6.1
+    tag: 2.1.0
     pullPolicy: IfNotPresent
 
   loki:


### PR DESCRIPTION
**What this PR does / why we need it**:
What it says on the tin.

**Does this PR introduce a user-facing change?**:
```release-note
update Loki to 2.1, use boltdb-shipper starting June 1st
```
