### PR TITLE
fix Dex image repository

### DIFF
--- a/charts/oauth/Chart.yaml
+++ b/charts/oauth/Chart.yaml
@@ -14,7 +14,7 @@
 
 apiVersion: v1
 name: oauth
-version: 1.5.2
+version: 1.5.3
 appVersion: v2.27.0
 description: Dex
 keywords:

--- a/charts/oauth/values.yaml
+++ b/charts/oauth/values.yaml
@@ -14,7 +14,7 @@
 
 dex:
   image:
-    repository: "quay.io/dexidp/dex"
+    repository: "docker.io/dexidp/dex"
     tag: "v2.27.0"
   replicas: 2
   # this options allows setting custom envvars in the dex container


### PR DESCRIPTION
**What this PR does / why we need it**:
Dex either forgot to tag the 2.27 on quay or is moving away from quay entirely.

**Does this PR introduce a user-facing change?**:
```release-note
NONE
```
