### PR TITLE
fix license check, update to wwhrd 0.4

### DIFF
--- a/.prow.yaml
+++ b/.prow.yaml
@@ -266,7 +266,7 @@ presubmits:
       preset-goproxy: "true"
     spec:
       containers:
-      - image: quay.io/kubermatic/util:1.4.1
+      - image: quay.io/kubermatic/wwhrd:0.4.0-0
         command:
         - ./hack/verify-licenses.sh
         resources:

--- a/.wwhrd.yml
+++ b/.wwhrd.yml
@@ -12,11 +12,11 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-blacklist:
+denylist:
   - GPL-2.0
   - LGPL-3.0
 
-whitelist:
+allowlist:
   - Apache-2.0
   - MIT
   - BSD-2-Clause
@@ -25,32 +25,21 @@ whitelist:
   - ISC
 
 exceptions:
-  - code.cloudfoundry.org/go-pubsub # Apache 2.0 - Cannot detect the license for some reason.
-  - code.cloudfoundry.org/go-pubsub/internal/node # Apache 2.0 - Cannot detect the license for some reason.
   - github.com/cristim/ec2-instances-info # Public domain: https://github.com/cristim/ec2-instances-info/blob/master/LICENSE.
   - github.com/cristim/ec2-instances-info/data # MIT: https://github.com/powdahound/ec2instances.info/blob/master/LICENSE.
-  - github.com/davecgh/go-spew/spew # ISC - Cannot detect the license for some reason.
-  - github.com/docker/spdystream # Apache 2.0 - Detector picks up on the CC-BY-4.0 license that is only for the documentation.
-  - github.com/docker/spdystream/spdy # Apache 2.0 - Detector picks up on the CC-BY-4.0 license that is only for the documentation.
-  - github.com/ghodss/yaml # BSD-3-Clause and MIT
-  - github.com/go-openapi/inflect # MIT - Cannot detect the license for some reason.
-  - github.com/gogo/protobuf/proto # BSD-3-Clause, as is the entire repository
-  - github.com/gogo/protobuf/sortkeys # BSD-3-Clause, as is the entire repository
-  - github.com/gogo/protobuf/gogoproto # BSD-3-Clause, as is the entire repository
-  - github.com/gogo/protobuf/protoc-gen-gogo/descriptor # BSD-3-Clause, as is the entire repository
-  - github.com/hashicorp/golang-lru # MPL-2.0 - used in transient vendor projects
-  - github.com/hashicorp/golang-lru/simplelru # MPL-2.0 - used in transient vendor projects
-  - github.com/hashicorp/hcl # MPL-2.0 - used in transient vendor projects
-  - github.com/hashicorp/hcl/hcl/ast # MPL-2.0 - used in transient vendor projects
-  - github.com/hashicorp/hcl/hcl/parser # MPL-2.0 - used in transient vendor projects
-  - github.com/hashicorp/hcl/hcl/printer # MPL-2.0 - used in transient vendor projects
-  - github.com/hashicorp/hcl/hcl/scanner # MPL-2.0 - used in transient vendor projects
-  - github.com/hashicorp/hcl/hcl/strconv # MPL-2.0 - used in transient vendor projects
-  - github.com/hashicorp/hcl/hcl/token # MPL-2.0 - used in transient vendor projects
-  - github.com/hashicorp/hcl/json/parser # MPL-2.0 - used in transient vendor projects
-  - github.com/hashicorp/hcl/json/scanner # MPL-2.0 - used in transient vendor projects
-  - github.com/hashicorp/hcl/json/token # MPL-2.0 - used in transient vendor projects
-  - github.com/kr/logfmt # MIT - No separate license file included.
-  - github.com/opencontainers/go-digest # Apache 2.0 - Cannot detect the license for some reason.
-  - github.com/spf13/cobra # Apache 2.0 - Cannot detect the license for some reason.
-  - sigs.k8s.io/yaml # MIT - Cannot detect the license for some reason.
+  - github.com/hashicorp/errwrap # MPL-2.0
+  - github.com/hashicorp/go-cleanhttp # MPL-2.0
+  - github.com/hashicorp/go-multierror # MPL-2.0
+  - github.com/hashicorp/go-retryablehttp # MPL-2.0
+  - github.com/hashicorp/golang-lru # MPL-2.0
+  - github.com/hashicorp/golang-lru/simplelru # MPL-2.0
+  - github.com/hashicorp/hcl # MPL-2.0
+  - github.com/hashicorp/hcl/hcl/ast # MPL-2.0
+  - github.com/hashicorp/hcl/hcl/parser # MPL-2.0
+  - github.com/hashicorp/hcl/hcl/printer # MPL-2.0
+  - github.com/hashicorp/hcl/hcl/scanner # MPL-2.0
+  - github.com/hashicorp/hcl/hcl/strconv # MPL-2.0
+  - github.com/hashicorp/hcl/hcl/token # MPL-2.0
+  - github.com/hashicorp/hcl/json/parser # MPL-2.0
+  - github.com/hashicorp/hcl/json/scanner # MPL-2.0
+  - github.com/hashicorp/hcl/json/token # MPL-2.0

--- a/hack/images/util/Dockerfile
+++ b/hack/images/util/Dockerfile
@@ -19,7 +19,7 @@ ENV MC_VERSION=RELEASE.2020-09-03T00-08-28Z \
     HELM_VERSION=v2.16.9 \
     VAULT_VERSION=1.5.1 \
     YQ_VERSION=3.3.4 \
-    WWHRD_VERSION=0.3.0
+    WWHRD_VERSION=0.4.0
 
 RUN apk add --no-cache -U \
     bash \

--- a/hack/images/wwhrd/Dockerfile
+++ b/hack/images/wwhrd/Dockerfile
@@ -16,10 +16,10 @@ FROM alpine:3.12 AS builder
 
 RUN apk update
 RUN apk add curl
-RUN cd tmp && curl -L --fail https://github.com/frapposelli/wwhrd/releases/download/v0.3.0/wwhrd_0.3.0_linux_amd64.tar.gz | tar -xvz
+RUN cd tmp && curl -L --fail https://github.com/frapposelli/wwhrd/releases/download/v0.4.0/wwhrd_0.4.0_linux_amd64.tar.gz | tar -xvz
 RUN /tmp/wwhrd -v
 
-FROM alpine:3.12
+FROM golang:1.15.1
 
 COPY --from=builder /tmp/wwhrd /usr/local/bin/
 ENTRYPOINT ["wwhrd"]

--- a/hack/images/wwhrd/release.sh
+++ b/hack/images/wwhrd/release.sh
@@ -19,7 +19,7 @@ set -euo pipefail
 cd $(dirname $0)
 
 REPOSITORY=quay.io/kubermatic/wwhrd
-VERSION=0.3.0
+VERSION=0.4.0
 NUMBER=0
 
 docker build --no-cache --pull -t "${REPOSITORY}:${VERSION}-${NUMBER}" .

--- a/hack/lib.sh
+++ b/hack/lib.sh
@@ -104,9 +104,10 @@ containerize() {
       -w /go/src/k8c.io/kubermatic \
       -e "GOCACHE=$gocache" \
       -u "$(id -u):$(id -g)" \
+      --entrypoint="$cmd" \
       --rm \
       -it \
-      $image $cmd $@
+      $image $@
 
     exit $?
   fi

--- a/hack/verify-licenses.sh
+++ b/hack/verify-licenses.sh
@@ -19,6 +19,10 @@ set -euo pipefail
 cd $(dirname $0)/..
 source hack/lib.sh
 
+CONTAINERIZE_IMAGE=quay.io/kubermatic/wwhrd:0.4.0-0 containerize ./hack/verify-licenses.sh
+
+go mod vendor
+
 echodate "Checking licenses..."
 wwhrd check -q
 echodate "Check successful."


### PR DESCRIPTION
**What this PR does / why we need it**:
Without a vendor folder, wwhrd never did anything for us. This PR fixes that.

Weirdly enough, wwhhrd still does not recognize any of the hashicorp licenses.

**Does this PR introduce a user-facing change?**:
```release-note
NONE
```
