### PR TITLE
fix kube-rbac-proxy

### DIFF
--- a/charts/monitoring/node-exporter/Chart.yaml
+++ b/charts/monitoring/node-exporter/Chart.yaml
@@ -14,7 +14,7 @@
 
 apiVersion: v1
 name: node-exporter
-version: 1.2.0
+version: 1.2.1
 appVersion: v1.1.2
 description: Prometheus Node Exporter for Kubermatic
 keywords:

--- a/charts/monitoring/node-exporter/templates/daemonset.yaml
+++ b/charts/monitoring/node-exporter/templates/daemonset.yaml
@@ -90,7 +90,8 @@ spec:
           path: /
       securityContext:
         runAsNonRoot: true
-        runAsUser: 65534
+        runAsUser: 65532
+        runAsGroup: 65534
       nodeSelector:
 {{ toYaml .Values.nodeExporter.nodeSelector | indent 8 }}
       affinity:


### PR DESCRIPTION
**What this PR does / why we need it**:
This fixes

>     State:          Waiting
>      Reason:       CrashLoopBackOff
>    Last State:     Terminated
>      Reason:       ContainerCannotRun
>      Message:      OCI runtime create failed: container_linux.go:346: starting container process caused "chdir to cwd (\"/home/nonroot\") set in config.json failed: permission denied": unknown
>      Exit Code:    126

Thanks to https://github.com/brancz/kube-rbac-proxy/issues/101

**Does this PR introduce a user-facing change?**:
```release-note
NONE
```
