### PR TITLE
Increase proxy buffer size for nginx by default

### DIFF
--- a/charts/nginx-ingress-controller/values.yaml
+++ b/charts/nginx-ingress-controller/values.yaml
@@ -19,7 +19,8 @@ nginx:
   image:
     repository: k8s.gcr.io/ingress-nginx/controller
     tag: v0.44.0
-  config: {}
+  config: 
+    proxy-buffer-size: "16k"
 #   load-balance: "least_conn"
   extraArgs: []
   resources:


### PR DESCRIPTION

**What this PR does / why we need it**:
Update proxy-buffer-size to prevent a 502 error when using Keycloak. This happens every time the header is too big in size e.g. after logging out from Kubermatic without closing the Keycloak session.

Idea is from https://www.ibm.com/support/pages/502-error-ingress-keycloak-response
nginx docs: http://nginx.org/en/docs/http/ngx_http_proxy_module.html#proxy_buffer_size


**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Documentation**:
<!-- Add links to the related documentation changes related to this pull request. E.g. the link to the kubermatic/docs pull request. -->

**Does this PR introduce a user-facing change?**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If  no release note is required, just write "NONE".
-->
```release-note
NONE
```
