### PR TITLE
remove CE binaries before building EE binaries, or else Make does nothing

### DIFF
--- a/hack/ci/github-release.sh
+++ b/hack/ci/github-release.sh
@@ -136,14 +136,14 @@ function tar_to_zip() {
 }
 
 function build_installer() {
-  make kubermatic-installer
+  make clean kubermatic-installer
   if [ "$GOOS" == "windows" ]; then
     mv _build/kubermatic-installer _build/kubermatic-installer.exe
   fi
 }
 
 function build_tools() {
-  make image-loader
+  make clean image-loader
   if [ "$GOOS" == "windows" ]; then
     mv _build/image-loader _build/image-loader.exe
   fi


### PR DESCRIPTION
**What this PR does / why we need it**:
I just noticed this during the GitHub release:

```
[2021-03-09T15:39:10+00:00] Creating CE archive...
[2021-03-09T15:39:12+00:00] Upload darwin-amd64 archive...
[2021-03-09T15:39:14+00:00] Compiling EE installer (darwin-amd64)...
make: Nothing to be done for 'kubermatic-installer'.
[2021-03-09T15:39:14+00:00] Creating EE archive...
[2021-03-09T15:39:16+00:00] Upload darwin-amd64 archive...
```

This means that for now we have always accidentally put the CE installer into the EE archives.

/test pre-kubermatic-simulate-github-release

**Does this PR introduce a user-facing change?**:
```release-note
Fix CE installer binary in EE downloads
```
