### PR TITLE
[release/v2.15] fix CA's not being properly mounted on CentOS

### DIFF
--- a/pkg/resources/resources.go
+++ b/pkg/resources/resources.go
@@ -209,6 +209,8 @@ const (
 
 	// HostCACertVolumeName is the name for the /etc/ssl/certs host mount volume
 	HostCACertVolumeName = "ca-certs"
+	// HostPKIVolumeName is the name for the /etc/ssl/certs host mount volume
+	HostPKIVolumeName = "pki"
 	// HostUsrShareCACertVolumeName is the anme for the /usr/share/ca-certificates host mount volume
 	HostUsrShareCACertVolumeName = "usr-share-ca-certificates"
 
@@ -1052,7 +1054,16 @@ func GetHostCACertVolumes() []corev1.Volume {
 			Name: HostCACertVolumeName,
 			VolumeSource: corev1.VolumeSource{
 				HostPath: &corev1.HostPathVolumeSource{
-					Path: "/etc/ssl/certs",
+					Path: "/etc/ssl",
+					Type: &doc,
+				},
+			},
+		},
+		{
+			Name: HostPKIVolumeName,
+			VolumeSource: corev1.VolumeSource{
+				HostPath: &corev1.HostPathVolumeSource{
+					Path: "/etc/pki",
 					Type: &doc,
 				},
 			},
@@ -1069,12 +1080,20 @@ func GetHostCACertVolumes() []corev1.Volume {
 	}
 }
 
-// GetHostCACertVolumeMounts returns a list of v1 volumeMounts such that pod could mount from the host OS root CA-certs
+// GetHostCACertVolumeMounts returns a list of v1 volumeMounts
+// such that pod could mount from the host OS root CA-certs.
+// Note that on some OS /etc/ssl only contains symlinks to
+// /etc/pki, which is why we mount both.
 func GetHostCACertVolumeMounts() []corev1.VolumeMount {
 	return []corev1.VolumeMount{
 		{
 			Name:      HostCACertVolumeName,
-			MountPath: "/etc/ssl/certs",
+			MountPath: "/etc/ssl",
+			ReadOnly:  true,
+		},
+		{
+			Name:      HostPKIVolumeName,
+			MountPath: "/etc/pki",
 			ReadOnly:  true,
 		},
 		{

--- a/pkg/resources/test/fixtures/deployment-aws-1.17.0-apiserver.yaml
+++ b/pkg/resources/test/fixtures/deployment-aws-1.17.0-apiserver.yaml
@@ -308,8 +308,11 @@ spec:
         - mountPath: /etc/kubernetes/adm-control
           name: adm-control
           readOnly: true
-        - mountPath: /etc/ssl/certs
+        - mountPath: /etc/ssl
           name: ca-certs
+          readOnly: true
+        - mountPath: /etc/pki
+          name: pki
           readOnly: true
         - mountPath: /usr/share/ca-certificates
           name: usr-share-ca-certificates
@@ -389,9 +392,13 @@ spec:
           name: adm-control
         name: adm-control
       - hostPath:
-          path: /etc/ssl/certs
+          path: /etc/ssl
           type: DirectoryOrCreate
         name: ca-certs
+      - hostPath:
+          path: /etc/pki
+          type: DirectoryOrCreate
+        name: pki
       - hostPath:
           path: /usr/share/ca-certificates
           type: DirectoryOrCreate

--- a/pkg/resources/test/fixtures/deployment-aws-1.17.0-controller-manager.yaml
+++ b/pkg/resources/test/fixtures/deployment-aws-1.17.0-controller-manager.yaml
@@ -172,8 +172,11 @@ spec:
         - mountPath: /etc/kubernetes/kubeconfig
           name: controllermanager-kubeconfig
           readOnly: true
-        - mountPath: /etc/ssl/certs
+        - mountPath: /etc/ssl
           name: ca-certs
+          readOnly: true
+        - mountPath: /etc/pki
+          name: pki
           readOnly: true
         - mountPath: /usr/share/ca-certificates
           name: usr-share-ca-certificates
@@ -221,9 +224,13 @@ spec:
         secret:
           secretName: controllermanager-kubeconfig
       - hostPath:
-          path: /etc/ssl/certs
+          path: /etc/ssl
           type: DirectoryOrCreate
         name: ca-certs
+      - hostPath:
+          path: /etc/pki
+          type: DirectoryOrCreate
+        name: pki
       - hostPath:
           path: /usr/share/ca-certificates
           type: DirectoryOrCreate

--- a/pkg/resources/test/fixtures/deployment-aws-1.17.0-scheduler.yaml
+++ b/pkg/resources/test/fixtures/deployment-aws-1.17.0-scheduler.yaml
@@ -145,8 +145,11 @@ spec:
         - mountPath: /etc/kubernetes/pki/ca
           name: ca
           readOnly: true
-        - mountPath: /etc/ssl/certs
+        - mountPath: /etc/ssl
           name: ca-certs
+          readOnly: true
+        - mountPath: /etc/pki
+          name: pki
           readOnly: true
         - mountPath: /usr/share/ca-certificates
           name: usr-share-ca-certificates
@@ -191,9 +194,13 @@ spec:
         secret:
           secretName: scheduler-kubeconfig
       - hostPath:
-          path: /etc/ssl/certs
+          path: /etc/ssl
           type: DirectoryOrCreate
         name: ca-certs
+      - hostPath:
+          path: /etc/pki
+          type: DirectoryOrCreate
+        name: pki
       - hostPath:
           path: /usr/share/ca-certificates
           type: DirectoryOrCreate

--- a/pkg/resources/test/fixtures/deployment-aws-1.18.0-apiserver.yaml
+++ b/pkg/resources/test/fixtures/deployment-aws-1.18.0-apiserver.yaml
@@ -308,8 +308,11 @@ spec:
         - mountPath: /etc/kubernetes/adm-control
           name: adm-control
           readOnly: true
-        - mountPath: /etc/ssl/certs
+        - mountPath: /etc/ssl
           name: ca-certs
+          readOnly: true
+        - mountPath: /etc/pki
+          name: pki
           readOnly: true
         - mountPath: /usr/share/ca-certificates
           name: usr-share-ca-certificates
@@ -389,9 +392,13 @@ spec:
           name: adm-control
         name: adm-control
       - hostPath:
-          path: /etc/ssl/certs
+          path: /etc/ssl
           type: DirectoryOrCreate
         name: ca-certs
+      - hostPath:
+          path: /etc/pki
+          type: DirectoryOrCreate
+        name: pki
       - hostPath:
           path: /usr/share/ca-certificates
           type: DirectoryOrCreate

--- a/pkg/resources/test/fixtures/deployment-aws-1.18.0-controller-manager.yaml
+++ b/pkg/resources/test/fixtures/deployment-aws-1.18.0-controller-manager.yaml
@@ -172,8 +172,11 @@ spec:
         - mountPath: /etc/kubernetes/kubeconfig
           name: controllermanager-kubeconfig
           readOnly: true
-        - mountPath: /etc/ssl/certs
+        - mountPath: /etc/ssl
           name: ca-certs
+          readOnly: true
+        - mountPath: /etc/pki
+          name: pki
           readOnly: true
         - mountPath: /usr/share/ca-certificates
           name: usr-share-ca-certificates
@@ -221,9 +224,13 @@ spec:
         secret:
           secretName: controllermanager-kubeconfig
       - hostPath:
-          path: /etc/ssl/certs
+          path: /etc/ssl
           type: DirectoryOrCreate
         name: ca-certs
+      - hostPath:
+          path: /etc/pki
+          type: DirectoryOrCreate
+        name: pki
       - hostPath:
           path: /usr/share/ca-certificates
           type: DirectoryOrCreate

--- a/pkg/resources/test/fixtures/deployment-aws-1.18.0-scheduler.yaml
+++ b/pkg/resources/test/fixtures/deployment-aws-1.18.0-scheduler.yaml
@@ -145,8 +145,11 @@ spec:
         - mountPath: /etc/kubernetes/pki/ca
           name: ca
           readOnly: true
-        - mountPath: /etc/ssl/certs
+        - mountPath: /etc/ssl
           name: ca-certs
+          readOnly: true
+        - mountPath: /etc/pki
+          name: pki
           readOnly: true
         - mountPath: /usr/share/ca-certificates
           name: usr-share-ca-certificates
@@ -191,9 +194,13 @@ spec:
         secret:
           secretName: scheduler-kubeconfig
       - hostPath:
-          path: /etc/ssl/certs
+          path: /etc/ssl
           type: DirectoryOrCreate
         name: ca-certs
+      - hostPath:
+          path: /etc/pki
+          type: DirectoryOrCreate
+        name: pki
       - hostPath:
           path: /usr/share/ca-certificates
           type: DirectoryOrCreate

--- a/pkg/resources/test/fixtures/deployment-aws-1.19.0-apiserver.yaml
+++ b/pkg/resources/test/fixtures/deployment-aws-1.19.0-apiserver.yaml
@@ -308,8 +308,11 @@ spec:
         - mountPath: /etc/kubernetes/adm-control
           name: adm-control
           readOnly: true
-        - mountPath: /etc/ssl/certs
+        - mountPath: /etc/ssl
           name: ca-certs
+          readOnly: true
+        - mountPath: /etc/pki
+          name: pki
           readOnly: true
         - mountPath: /usr/share/ca-certificates
           name: usr-share-ca-certificates
@@ -389,9 +392,13 @@ spec:
           name: adm-control
         name: adm-control
       - hostPath:
-          path: /etc/ssl/certs
+          path: /etc/ssl
           type: DirectoryOrCreate
         name: ca-certs
+      - hostPath:
+          path: /etc/pki
+          type: DirectoryOrCreate
+        name: pki
       - hostPath:
           path: /usr/share/ca-certificates
           type: DirectoryOrCreate

--- a/pkg/resources/test/fixtures/deployment-aws-1.19.0-controller-manager.yaml
+++ b/pkg/resources/test/fixtures/deployment-aws-1.19.0-controller-manager.yaml
@@ -172,8 +172,11 @@ spec:
         - mountPath: /etc/kubernetes/kubeconfig
           name: controllermanager-kubeconfig
           readOnly: true
-        - mountPath: /etc/ssl/certs
+        - mountPath: /etc/ssl
           name: ca-certs
+          readOnly: true
+        - mountPath: /etc/pki
+          name: pki
           readOnly: true
         - mountPath: /usr/share/ca-certificates
           name: usr-share-ca-certificates
@@ -221,9 +224,13 @@ spec:
         secret:
           secretName: controllermanager-kubeconfig
       - hostPath:
-          path: /etc/ssl/certs
+          path: /etc/ssl
           type: DirectoryOrCreate
         name: ca-certs
+      - hostPath:
+          path: /etc/pki
+          type: DirectoryOrCreate
+        name: pki
       - hostPath:
           path: /usr/share/ca-certificates
           type: DirectoryOrCreate

--- a/pkg/resources/test/fixtures/deployment-aws-1.19.0-scheduler.yaml
+++ b/pkg/resources/test/fixtures/deployment-aws-1.19.0-scheduler.yaml
@@ -145,8 +145,11 @@ spec:
         - mountPath: /etc/kubernetes/pki/ca
           name: ca
           readOnly: true
-        - mountPath: /etc/ssl/certs
+        - mountPath: /etc/ssl
           name: ca-certs
+          readOnly: true
+        - mountPath: /etc/pki
+          name: pki
           readOnly: true
         - mountPath: /usr/share/ca-certificates
           name: usr-share-ca-certificates
@@ -191,9 +194,13 @@ spec:
         secret:
           secretName: scheduler-kubeconfig
       - hostPath:
-          path: /etc/ssl/certs
+          path: /etc/ssl
           type: DirectoryOrCreate
         name: ca-certs
+      - hostPath:
+          path: /etc/pki
+          type: DirectoryOrCreate
+        name: pki
       - hostPath:
           path: /usr/share/ca-certificates
           type: DirectoryOrCreate

--- a/pkg/resources/test/fixtures/deployment-azure-1.17.0-apiserver.yaml
+++ b/pkg/resources/test/fixtures/deployment-azure-1.17.0-apiserver.yaml
@@ -302,8 +302,11 @@ spec:
         - mountPath: /etc/kubernetes/adm-control
           name: adm-control
           readOnly: true
-        - mountPath: /etc/ssl/certs
+        - mountPath: /etc/ssl
           name: ca-certs
+          readOnly: true
+        - mountPath: /etc/pki
+          name: pki
           readOnly: true
         - mountPath: /usr/share/ca-certificates
           name: usr-share-ca-certificates
@@ -383,9 +386,13 @@ spec:
           name: adm-control
         name: adm-control
       - hostPath:
-          path: /etc/ssl/certs
+          path: /etc/ssl
           type: DirectoryOrCreate
         name: ca-certs
+      - hostPath:
+          path: /etc/pki
+          type: DirectoryOrCreate
+        name: pki
       - hostPath:
           path: /usr/share/ca-certificates
           type: DirectoryOrCreate

--- a/pkg/resources/test/fixtures/deployment-azure-1.17.0-controller-manager.yaml
+++ b/pkg/resources/test/fixtures/deployment-azure-1.17.0-controller-manager.yaml
@@ -166,8 +166,11 @@ spec:
         - mountPath: /etc/kubernetes/kubeconfig
           name: controllermanager-kubeconfig
           readOnly: true
-        - mountPath: /etc/ssl/certs
+        - mountPath: /etc/ssl
           name: ca-certs
+          readOnly: true
+        - mountPath: /etc/pki
+          name: pki
           readOnly: true
         - mountPath: /usr/share/ca-certificates
           name: usr-share-ca-certificates
@@ -215,9 +218,13 @@ spec:
         secret:
           secretName: controllermanager-kubeconfig
       - hostPath:
-          path: /etc/ssl/certs
+          path: /etc/ssl
           type: DirectoryOrCreate
         name: ca-certs
+      - hostPath:
+          path: /etc/pki
+          type: DirectoryOrCreate
+        name: pki
       - hostPath:
           path: /usr/share/ca-certificates
           type: DirectoryOrCreate

--- a/pkg/resources/test/fixtures/deployment-azure-1.17.0-scheduler.yaml
+++ b/pkg/resources/test/fixtures/deployment-azure-1.17.0-scheduler.yaml
@@ -145,8 +145,11 @@ spec:
         - mountPath: /etc/kubernetes/pki/ca
           name: ca
           readOnly: true
-        - mountPath: /etc/ssl/certs
+        - mountPath: /etc/ssl
           name: ca-certs
+          readOnly: true
+        - mountPath: /etc/pki
+          name: pki
           readOnly: true
         - mountPath: /usr/share/ca-certificates
           name: usr-share-ca-certificates
@@ -191,9 +194,13 @@ spec:
         secret:
           secretName: scheduler-kubeconfig
       - hostPath:
-          path: /etc/ssl/certs
+          path: /etc/ssl
           type: DirectoryOrCreate
         name: ca-certs
+      - hostPath:
+          path: /etc/pki
+          type: DirectoryOrCreate
+        name: pki
       - hostPath:
           path: /usr/share/ca-certificates
           type: DirectoryOrCreate

--- a/pkg/resources/test/fixtures/deployment-azure-1.18.0-apiserver.yaml
+++ b/pkg/resources/test/fixtures/deployment-azure-1.18.0-apiserver.yaml
@@ -302,8 +302,11 @@ spec:
         - mountPath: /etc/kubernetes/adm-control
           name: adm-control
           readOnly: true
-        - mountPath: /etc/ssl/certs
+        - mountPath: /etc/ssl
           name: ca-certs
+          readOnly: true
+        - mountPath: /etc/pki
+          name: pki
           readOnly: true
         - mountPath: /usr/share/ca-certificates
           name: usr-share-ca-certificates
@@ -383,9 +386,13 @@ spec:
           name: adm-control
         name: adm-control
       - hostPath:
-          path: /etc/ssl/certs
+          path: /etc/ssl
           type: DirectoryOrCreate
         name: ca-certs
+      - hostPath:
+          path: /etc/pki
+          type: DirectoryOrCreate
+        name: pki
       - hostPath:
           path: /usr/share/ca-certificates
           type: DirectoryOrCreate

--- a/pkg/resources/test/fixtures/deployment-azure-1.18.0-controller-manager.yaml
+++ b/pkg/resources/test/fixtures/deployment-azure-1.18.0-controller-manager.yaml
@@ -166,8 +166,11 @@ spec:
         - mountPath: /etc/kubernetes/kubeconfig
           name: controllermanager-kubeconfig
           readOnly: true
-        - mountPath: /etc/ssl/certs
+        - mountPath: /etc/ssl
           name: ca-certs
+          readOnly: true
+        - mountPath: /etc/pki
+          name: pki
           readOnly: true
         - mountPath: /usr/share/ca-certificates
           name: usr-share-ca-certificates
@@ -215,9 +218,13 @@ spec:
         secret:
           secretName: controllermanager-kubeconfig
       - hostPath:
-          path: /etc/ssl/certs
+          path: /etc/ssl
           type: DirectoryOrCreate
         name: ca-certs
+      - hostPath:
+          path: /etc/pki
+          type: DirectoryOrCreate
+        name: pki
       - hostPath:
           path: /usr/share/ca-certificates
           type: DirectoryOrCreate

--- a/pkg/resources/test/fixtures/deployment-azure-1.18.0-scheduler.yaml
+++ b/pkg/resources/test/fixtures/deployment-azure-1.18.0-scheduler.yaml
@@ -145,8 +145,11 @@ spec:
         - mountPath: /etc/kubernetes/pki/ca
           name: ca
           readOnly: true
-        - mountPath: /etc/ssl/certs
+        - mountPath: /etc/ssl
           name: ca-certs
+          readOnly: true
+        - mountPath: /etc/pki
+          name: pki
           readOnly: true
         - mountPath: /usr/share/ca-certificates
           name: usr-share-ca-certificates
@@ -191,9 +194,13 @@ spec:
         secret:
           secretName: scheduler-kubeconfig
       - hostPath:
-          path: /etc/ssl/certs
+          path: /etc/ssl
           type: DirectoryOrCreate
         name: ca-certs
+      - hostPath:
+          path: /etc/pki
+          type: DirectoryOrCreate
+        name: pki
       - hostPath:
           path: /usr/share/ca-certificates
           type: DirectoryOrCreate

--- a/pkg/resources/test/fixtures/deployment-azure-1.19.0-apiserver.yaml
+++ b/pkg/resources/test/fixtures/deployment-azure-1.19.0-apiserver.yaml
@@ -302,8 +302,11 @@ spec:
         - mountPath: /etc/kubernetes/adm-control
           name: adm-control
           readOnly: true
-        - mountPath: /etc/ssl/certs
+        - mountPath: /etc/ssl
           name: ca-certs
+          readOnly: true
+        - mountPath: /etc/pki
+          name: pki
           readOnly: true
         - mountPath: /usr/share/ca-certificates
           name: usr-share-ca-certificates
@@ -383,9 +386,13 @@ spec:
           name: adm-control
         name: adm-control
       - hostPath:
-          path: /etc/ssl/certs
+          path: /etc/ssl
           type: DirectoryOrCreate
         name: ca-certs
+      - hostPath:
+          path: /etc/pki
+          type: DirectoryOrCreate
+        name: pki
       - hostPath:
           path: /usr/share/ca-certificates
           type: DirectoryOrCreate

--- a/pkg/resources/test/fixtures/deployment-azure-1.19.0-controller-manager.yaml
+++ b/pkg/resources/test/fixtures/deployment-azure-1.19.0-controller-manager.yaml
@@ -166,8 +166,11 @@ spec:
         - mountPath: /etc/kubernetes/kubeconfig
           name: controllermanager-kubeconfig
           readOnly: true
-        - mountPath: /etc/ssl/certs
+        - mountPath: /etc/ssl
           name: ca-certs
+          readOnly: true
+        - mountPath: /etc/pki
+          name: pki
           readOnly: true
         - mountPath: /usr/share/ca-certificates
           name: usr-share-ca-certificates
@@ -215,9 +218,13 @@ spec:
         secret:
           secretName: controllermanager-kubeconfig
       - hostPath:
-          path: /etc/ssl/certs
+          path: /etc/ssl
           type: DirectoryOrCreate
         name: ca-certs
+      - hostPath:
+          path: /etc/pki
+          type: DirectoryOrCreate
+        name: pki
       - hostPath:
           path: /usr/share/ca-certificates
           type: DirectoryOrCreate

--- a/pkg/resources/test/fixtures/deployment-azure-1.19.0-scheduler.yaml
+++ b/pkg/resources/test/fixtures/deployment-azure-1.19.0-scheduler.yaml
@@ -145,8 +145,11 @@ spec:
         - mountPath: /etc/kubernetes/pki/ca
           name: ca
           readOnly: true
-        - mountPath: /etc/ssl/certs
+        - mountPath: /etc/ssl
           name: ca-certs
+          readOnly: true
+        - mountPath: /etc/pki
+          name: pki
           readOnly: true
         - mountPath: /usr/share/ca-certificates
           name: usr-share-ca-certificates
@@ -191,9 +194,13 @@ spec:
         secret:
           secretName: scheduler-kubeconfig
       - hostPath:
-          path: /etc/ssl/certs
+          path: /etc/ssl
           type: DirectoryOrCreate
         name: ca-certs
+      - hostPath:
+          path: /etc/pki
+          type: DirectoryOrCreate
+        name: pki
       - hostPath:
           path: /usr/share/ca-certificates
           type: DirectoryOrCreate

--- a/pkg/resources/test/fixtures/deployment-bringyourown-1.17.0-apiserver.yaml
+++ b/pkg/resources/test/fixtures/deployment-bringyourown-1.17.0-apiserver.yaml
@@ -298,8 +298,11 @@ spec:
         - mountPath: /etc/kubernetes/adm-control
           name: adm-control
           readOnly: true
-        - mountPath: /etc/ssl/certs
+        - mountPath: /etc/ssl
           name: ca-certs
+          readOnly: true
+        - mountPath: /etc/pki
+          name: pki
           readOnly: true
         - mountPath: /usr/share/ca-certificates
           name: usr-share-ca-certificates
@@ -379,9 +382,13 @@ spec:
           name: adm-control
         name: adm-control
       - hostPath:
-          path: /etc/ssl/certs
+          path: /etc/ssl
           type: DirectoryOrCreate
         name: ca-certs
+      - hostPath:
+          path: /etc/pki
+          type: DirectoryOrCreate
+        name: pki
       - hostPath:
           path: /usr/share/ca-certificates
           type: DirectoryOrCreate

--- a/pkg/resources/test/fixtures/deployment-bringyourown-1.17.0-controller-manager.yaml
+++ b/pkg/resources/test/fixtures/deployment-bringyourown-1.17.0-controller-manager.yaml
@@ -166,8 +166,11 @@ spec:
         - mountPath: /etc/kubernetes/kubeconfig
           name: controllermanager-kubeconfig
           readOnly: true
-        - mountPath: /etc/ssl/certs
+        - mountPath: /etc/ssl
           name: ca-certs
+          readOnly: true
+        - mountPath: /etc/pki
+          name: pki
           readOnly: true
         - mountPath: /usr/share/ca-certificates
           name: usr-share-ca-certificates
@@ -215,9 +218,13 @@ spec:
         secret:
           secretName: controllermanager-kubeconfig
       - hostPath:
-          path: /etc/ssl/certs
+          path: /etc/ssl
           type: DirectoryOrCreate
         name: ca-certs
+      - hostPath:
+          path: /etc/pki
+          type: DirectoryOrCreate
+        name: pki
       - hostPath:
           path: /usr/share/ca-certificates
           type: DirectoryOrCreate

--- a/pkg/resources/test/fixtures/deployment-bringyourown-1.17.0-scheduler.yaml
+++ b/pkg/resources/test/fixtures/deployment-bringyourown-1.17.0-scheduler.yaml
@@ -145,8 +145,11 @@ spec:
         - mountPath: /etc/kubernetes/pki/ca
           name: ca
           readOnly: true
-        - mountPath: /etc/ssl/certs
+        - mountPath: /etc/ssl
           name: ca-certs
+          readOnly: true
+        - mountPath: /etc/pki
+          name: pki
           readOnly: true
         - mountPath: /usr/share/ca-certificates
           name: usr-share-ca-certificates
@@ -191,9 +194,13 @@ spec:
         secret:
           secretName: scheduler-kubeconfig
       - hostPath:
-          path: /etc/ssl/certs
+          path: /etc/ssl
           type: DirectoryOrCreate
         name: ca-certs
+      - hostPath:
+          path: /etc/pki
+          type: DirectoryOrCreate
+        name: pki
       - hostPath:
           path: /usr/share/ca-certificates
           type: DirectoryOrCreate

--- a/pkg/resources/test/fixtures/deployment-bringyourown-1.18.0-apiserver.yaml
+++ b/pkg/resources/test/fixtures/deployment-bringyourown-1.18.0-apiserver.yaml
@@ -298,8 +298,11 @@ spec:
         - mountPath: /etc/kubernetes/adm-control
           name: adm-control
           readOnly: true
-        - mountPath: /etc/ssl/certs
+        - mountPath: /etc/ssl
           name: ca-certs
+          readOnly: true
+        - mountPath: /etc/pki
+          name: pki
           readOnly: true
         - mountPath: /usr/share/ca-certificates
           name: usr-share-ca-certificates
@@ -379,9 +382,13 @@ spec:
           name: adm-control
         name: adm-control
       - hostPath:
-          path: /etc/ssl/certs
+          path: /etc/ssl
           type: DirectoryOrCreate
         name: ca-certs
+      - hostPath:
+          path: /etc/pki
+          type: DirectoryOrCreate
+        name: pki
       - hostPath:
           path: /usr/share/ca-certificates
           type: DirectoryOrCreate

--- a/pkg/resources/test/fixtures/deployment-bringyourown-1.18.0-controller-manager.yaml
+++ b/pkg/resources/test/fixtures/deployment-bringyourown-1.18.0-controller-manager.yaml
@@ -166,8 +166,11 @@ spec:
         - mountPath: /etc/kubernetes/kubeconfig
           name: controllermanager-kubeconfig
           readOnly: true
-        - mountPath: /etc/ssl/certs
+        - mountPath: /etc/ssl
           name: ca-certs
+          readOnly: true
+        - mountPath: /etc/pki
+          name: pki
           readOnly: true
         - mountPath: /usr/share/ca-certificates
           name: usr-share-ca-certificates
@@ -215,9 +218,13 @@ spec:
         secret:
           secretName: controllermanager-kubeconfig
       - hostPath:
-          path: /etc/ssl/certs
+          path: /etc/ssl
           type: DirectoryOrCreate
         name: ca-certs
+      - hostPath:
+          path: /etc/pki
+          type: DirectoryOrCreate
+        name: pki
       - hostPath:
           path: /usr/share/ca-certificates
           type: DirectoryOrCreate

--- a/pkg/resources/test/fixtures/deployment-bringyourown-1.18.0-scheduler.yaml
+++ b/pkg/resources/test/fixtures/deployment-bringyourown-1.18.0-scheduler.yaml
@@ -145,8 +145,11 @@ spec:
         - mountPath: /etc/kubernetes/pki/ca
           name: ca
           readOnly: true
-        - mountPath: /etc/ssl/certs
+        - mountPath: /etc/ssl
           name: ca-certs
+          readOnly: true
+        - mountPath: /etc/pki
+          name: pki
           readOnly: true
         - mountPath: /usr/share/ca-certificates
           name: usr-share-ca-certificates
@@ -191,9 +194,13 @@ spec:
         secret:
           secretName: scheduler-kubeconfig
       - hostPath:
-          path: /etc/ssl/certs
+          path: /etc/ssl
           type: DirectoryOrCreate
         name: ca-certs
+      - hostPath:
+          path: /etc/pki
+          type: DirectoryOrCreate
+        name: pki
       - hostPath:
           path: /usr/share/ca-certificates
           type: DirectoryOrCreate

--- a/pkg/resources/test/fixtures/deployment-bringyourown-1.19.0-apiserver.yaml
+++ b/pkg/resources/test/fixtures/deployment-bringyourown-1.19.0-apiserver.yaml
@@ -298,8 +298,11 @@ spec:
         - mountPath: /etc/kubernetes/adm-control
           name: adm-control
           readOnly: true
-        - mountPath: /etc/ssl/certs
+        - mountPath: /etc/ssl
           name: ca-certs
+          readOnly: true
+        - mountPath: /etc/pki
+          name: pki
           readOnly: true
         - mountPath: /usr/share/ca-certificates
           name: usr-share-ca-certificates
@@ -379,9 +382,13 @@ spec:
           name: adm-control
         name: adm-control
       - hostPath:
-          path: /etc/ssl/certs
+          path: /etc/ssl
           type: DirectoryOrCreate
         name: ca-certs
+      - hostPath:
+          path: /etc/pki
+          type: DirectoryOrCreate
+        name: pki
       - hostPath:
           path: /usr/share/ca-certificates
           type: DirectoryOrCreate

--- a/pkg/resources/test/fixtures/deployment-bringyourown-1.19.0-controller-manager.yaml
+++ b/pkg/resources/test/fixtures/deployment-bringyourown-1.19.0-controller-manager.yaml
@@ -166,8 +166,11 @@ spec:
         - mountPath: /etc/kubernetes/kubeconfig
           name: controllermanager-kubeconfig
           readOnly: true
-        - mountPath: /etc/ssl/certs
+        - mountPath: /etc/ssl
           name: ca-certs
+          readOnly: true
+        - mountPath: /etc/pki
+          name: pki
           readOnly: true
         - mountPath: /usr/share/ca-certificates
           name: usr-share-ca-certificates
@@ -215,9 +218,13 @@ spec:
         secret:
           secretName: controllermanager-kubeconfig
       - hostPath:
-          path: /etc/ssl/certs
+          path: /etc/ssl
           type: DirectoryOrCreate
         name: ca-certs
+      - hostPath:
+          path: /etc/pki
+          type: DirectoryOrCreate
+        name: pki
       - hostPath:
           path: /usr/share/ca-certificates
           type: DirectoryOrCreate

--- a/pkg/resources/test/fixtures/deployment-bringyourown-1.19.0-scheduler.yaml
+++ b/pkg/resources/test/fixtures/deployment-bringyourown-1.19.0-scheduler.yaml
@@ -145,8 +145,11 @@ spec:
         - mountPath: /etc/kubernetes/pki/ca
           name: ca
           readOnly: true
-        - mountPath: /etc/ssl/certs
+        - mountPath: /etc/ssl
           name: ca-certs
+          readOnly: true
+        - mountPath: /etc/pki
+          name: pki
           readOnly: true
         - mountPath: /usr/share/ca-certificates
           name: usr-share-ca-certificates
@@ -191,9 +194,13 @@ spec:
         secret:
           secretName: scheduler-kubeconfig
       - hostPath:
-          path: /etc/ssl/certs
+          path: /etc/ssl
           type: DirectoryOrCreate
         name: ca-certs
+      - hostPath:
+          path: /etc/pki
+          type: DirectoryOrCreate
+        name: pki
       - hostPath:
           path: /usr/share/ca-certificates
           type: DirectoryOrCreate

--- a/pkg/resources/test/fixtures/deployment-digitalocean-1.17.0-apiserver.yaml
+++ b/pkg/resources/test/fixtures/deployment-digitalocean-1.17.0-apiserver.yaml
@@ -298,8 +298,11 @@ spec:
         - mountPath: /etc/kubernetes/adm-control
           name: adm-control
           readOnly: true
-        - mountPath: /etc/ssl/certs
+        - mountPath: /etc/ssl
           name: ca-certs
+          readOnly: true
+        - mountPath: /etc/pki
+          name: pki
           readOnly: true
         - mountPath: /usr/share/ca-certificates
           name: usr-share-ca-certificates
@@ -379,9 +382,13 @@ spec:
           name: adm-control
         name: adm-control
       - hostPath:
-          path: /etc/ssl/certs
+          path: /etc/ssl
           type: DirectoryOrCreate
         name: ca-certs
+      - hostPath:
+          path: /etc/pki
+          type: DirectoryOrCreate
+        name: pki
       - hostPath:
           path: /usr/share/ca-certificates
           type: DirectoryOrCreate

--- a/pkg/resources/test/fixtures/deployment-digitalocean-1.17.0-controller-manager.yaml
+++ b/pkg/resources/test/fixtures/deployment-digitalocean-1.17.0-controller-manager.yaml
@@ -166,8 +166,11 @@ spec:
         - mountPath: /etc/kubernetes/kubeconfig
           name: controllermanager-kubeconfig
           readOnly: true
-        - mountPath: /etc/ssl/certs
+        - mountPath: /etc/ssl
           name: ca-certs
+          readOnly: true
+        - mountPath: /etc/pki
+          name: pki
           readOnly: true
         - mountPath: /usr/share/ca-certificates
           name: usr-share-ca-certificates
@@ -215,9 +218,13 @@ spec:
         secret:
           secretName: controllermanager-kubeconfig
       - hostPath:
-          path: /etc/ssl/certs
+          path: /etc/ssl
           type: DirectoryOrCreate
         name: ca-certs
+      - hostPath:
+          path: /etc/pki
+          type: DirectoryOrCreate
+        name: pki
       - hostPath:
           path: /usr/share/ca-certificates
           type: DirectoryOrCreate

--- a/pkg/resources/test/fixtures/deployment-digitalocean-1.17.0-scheduler.yaml
+++ b/pkg/resources/test/fixtures/deployment-digitalocean-1.17.0-scheduler.yaml
@@ -145,8 +145,11 @@ spec:
         - mountPath: /etc/kubernetes/pki/ca
           name: ca
           readOnly: true
-        - mountPath: /etc/ssl/certs
+        - mountPath: /etc/ssl
           name: ca-certs
+          readOnly: true
+        - mountPath: /etc/pki
+          name: pki
           readOnly: true
         - mountPath: /usr/share/ca-certificates
           name: usr-share-ca-certificates
@@ -191,9 +194,13 @@ spec:
         secret:
           secretName: scheduler-kubeconfig
       - hostPath:
-          path: /etc/ssl/certs
+          path: /etc/ssl
           type: DirectoryOrCreate
         name: ca-certs
+      - hostPath:
+          path: /etc/pki
+          type: DirectoryOrCreate
+        name: pki
       - hostPath:
           path: /usr/share/ca-certificates
           type: DirectoryOrCreate

--- a/pkg/resources/test/fixtures/deployment-digitalocean-1.18.0-apiserver.yaml
+++ b/pkg/resources/test/fixtures/deployment-digitalocean-1.18.0-apiserver.yaml
@@ -298,8 +298,11 @@ spec:
         - mountPath: /etc/kubernetes/adm-control
           name: adm-control
           readOnly: true
-        - mountPath: /etc/ssl/certs
+        - mountPath: /etc/ssl
           name: ca-certs
+          readOnly: true
+        - mountPath: /etc/pki
+          name: pki
           readOnly: true
         - mountPath: /usr/share/ca-certificates
           name: usr-share-ca-certificates
@@ -379,9 +382,13 @@ spec:
           name: adm-control
         name: adm-control
       - hostPath:
-          path: /etc/ssl/certs
+          path: /etc/ssl
           type: DirectoryOrCreate
         name: ca-certs
+      - hostPath:
+          path: /etc/pki
+          type: DirectoryOrCreate
+        name: pki
       - hostPath:
           path: /usr/share/ca-certificates
           type: DirectoryOrCreate

--- a/pkg/resources/test/fixtures/deployment-digitalocean-1.18.0-controller-manager.yaml
+++ b/pkg/resources/test/fixtures/deployment-digitalocean-1.18.0-controller-manager.yaml
@@ -166,8 +166,11 @@ spec:
         - mountPath: /etc/kubernetes/kubeconfig
           name: controllermanager-kubeconfig
           readOnly: true
-        - mountPath: /etc/ssl/certs
+        - mountPath: /etc/ssl
           name: ca-certs
+          readOnly: true
+        - mountPath: /etc/pki
+          name: pki
           readOnly: true
         - mountPath: /usr/share/ca-certificates
           name: usr-share-ca-certificates
@@ -215,9 +218,13 @@ spec:
         secret:
           secretName: controllermanager-kubeconfig
       - hostPath:
-          path: /etc/ssl/certs
+          path: /etc/ssl
           type: DirectoryOrCreate
         name: ca-certs
+      - hostPath:
+          path: /etc/pki
+          type: DirectoryOrCreate
+        name: pki
       - hostPath:
           path: /usr/share/ca-certificates
           type: DirectoryOrCreate

--- a/pkg/resources/test/fixtures/deployment-digitalocean-1.18.0-scheduler.yaml
+++ b/pkg/resources/test/fixtures/deployment-digitalocean-1.18.0-scheduler.yaml
@@ -145,8 +145,11 @@ spec:
         - mountPath: /etc/kubernetes/pki/ca
           name: ca
           readOnly: true
-        - mountPath: /etc/ssl/certs
+        - mountPath: /etc/ssl
           name: ca-certs
+          readOnly: true
+        - mountPath: /etc/pki
+          name: pki
           readOnly: true
         - mountPath: /usr/share/ca-certificates
           name: usr-share-ca-certificates
@@ -191,9 +194,13 @@ spec:
         secret:
           secretName: scheduler-kubeconfig
       - hostPath:
-          path: /etc/ssl/certs
+          path: /etc/ssl
           type: DirectoryOrCreate
         name: ca-certs
+      - hostPath:
+          path: /etc/pki
+          type: DirectoryOrCreate
+        name: pki
       - hostPath:
           path: /usr/share/ca-certificates
           type: DirectoryOrCreate

--- a/pkg/resources/test/fixtures/deployment-digitalocean-1.19.0-apiserver.yaml
+++ b/pkg/resources/test/fixtures/deployment-digitalocean-1.19.0-apiserver.yaml
@@ -298,8 +298,11 @@ spec:
         - mountPath: /etc/kubernetes/adm-control
           name: adm-control
           readOnly: true
-        - mountPath: /etc/ssl/certs
+        - mountPath: /etc/ssl
           name: ca-certs
+          readOnly: true
+        - mountPath: /etc/pki
+          name: pki
           readOnly: true
         - mountPath: /usr/share/ca-certificates
           name: usr-share-ca-certificates
@@ -379,9 +382,13 @@ spec:
           name: adm-control
         name: adm-control
       - hostPath:
-          path: /etc/ssl/certs
+          path: /etc/ssl
           type: DirectoryOrCreate
         name: ca-certs
+      - hostPath:
+          path: /etc/pki
+          type: DirectoryOrCreate
+        name: pki
       - hostPath:
           path: /usr/share/ca-certificates
           type: DirectoryOrCreate

--- a/pkg/resources/test/fixtures/deployment-digitalocean-1.19.0-controller-manager.yaml
+++ b/pkg/resources/test/fixtures/deployment-digitalocean-1.19.0-controller-manager.yaml
@@ -166,8 +166,11 @@ spec:
         - mountPath: /etc/kubernetes/kubeconfig
           name: controllermanager-kubeconfig
           readOnly: true
-        - mountPath: /etc/ssl/certs
+        - mountPath: /etc/ssl
           name: ca-certs
+          readOnly: true
+        - mountPath: /etc/pki
+          name: pki
           readOnly: true
         - mountPath: /usr/share/ca-certificates
           name: usr-share-ca-certificates
@@ -215,9 +218,13 @@ spec:
         secret:
           secretName: controllermanager-kubeconfig
       - hostPath:
-          path: /etc/ssl/certs
+          path: /etc/ssl
           type: DirectoryOrCreate
         name: ca-certs
+      - hostPath:
+          path: /etc/pki
+          type: DirectoryOrCreate
+        name: pki
       - hostPath:
           path: /usr/share/ca-certificates
           type: DirectoryOrCreate

--- a/pkg/resources/test/fixtures/deployment-digitalocean-1.19.0-scheduler.yaml
+++ b/pkg/resources/test/fixtures/deployment-digitalocean-1.19.0-scheduler.yaml
@@ -145,8 +145,11 @@ spec:
         - mountPath: /etc/kubernetes/pki/ca
           name: ca
           readOnly: true
-        - mountPath: /etc/ssl/certs
+        - mountPath: /etc/ssl
           name: ca-certs
+          readOnly: true
+        - mountPath: /etc/pki
+          name: pki
           readOnly: true
         - mountPath: /usr/share/ca-certificates
           name: usr-share-ca-certificates
@@ -191,9 +194,13 @@ spec:
         secret:
           secretName: scheduler-kubeconfig
       - hostPath:
-          path: /etc/ssl/certs
+          path: /etc/ssl
           type: DirectoryOrCreate
         name: ca-certs
+      - hostPath:
+          path: /etc/pki
+          type: DirectoryOrCreate
+        name: pki
       - hostPath:
           path: /usr/share/ca-certificates
           type: DirectoryOrCreate

--- a/pkg/resources/test/fixtures/deployment-openstack-1.17.0-apiserver.yaml
+++ b/pkg/resources/test/fixtures/deployment-openstack-1.17.0-apiserver.yaml
@@ -302,8 +302,11 @@ spec:
         - mountPath: /etc/kubernetes/adm-control
           name: adm-control
           readOnly: true
-        - mountPath: /etc/ssl/certs
+        - mountPath: /etc/ssl
           name: ca-certs
+          readOnly: true
+        - mountPath: /etc/pki
+          name: pki
           readOnly: true
         - mountPath: /usr/share/ca-certificates
           name: usr-share-ca-certificates
@@ -383,9 +386,13 @@ spec:
           name: adm-control
         name: adm-control
       - hostPath:
-          path: /etc/ssl/certs
+          path: /etc/ssl
           type: DirectoryOrCreate
         name: ca-certs
+      - hostPath:
+          path: /etc/pki
+          type: DirectoryOrCreate
+        name: pki
       - hostPath:
           path: /usr/share/ca-certificates
           type: DirectoryOrCreate

--- a/pkg/resources/test/fixtures/deployment-openstack-1.17.0-controller-manager.yaml
+++ b/pkg/resources/test/fixtures/deployment-openstack-1.17.0-controller-manager.yaml
@@ -166,8 +166,11 @@ spec:
         - mountPath: /etc/kubernetes/kubeconfig
           name: controllermanager-kubeconfig
           readOnly: true
-        - mountPath: /etc/ssl/certs
+        - mountPath: /etc/ssl
           name: ca-certs
+          readOnly: true
+        - mountPath: /etc/pki
+          name: pki
           readOnly: true
         - mountPath: /usr/share/ca-certificates
           name: usr-share-ca-certificates
@@ -215,9 +218,13 @@ spec:
         secret:
           secretName: controllermanager-kubeconfig
       - hostPath:
-          path: /etc/ssl/certs
+          path: /etc/ssl
           type: DirectoryOrCreate
         name: ca-certs
+      - hostPath:
+          path: /etc/pki
+          type: DirectoryOrCreate
+        name: pki
       - hostPath:
           path: /usr/share/ca-certificates
           type: DirectoryOrCreate

--- a/pkg/resources/test/fixtures/deployment-openstack-1.17.0-scheduler.yaml
+++ b/pkg/resources/test/fixtures/deployment-openstack-1.17.0-scheduler.yaml
@@ -145,8 +145,11 @@ spec:
         - mountPath: /etc/kubernetes/pki/ca
           name: ca
           readOnly: true
-        - mountPath: /etc/ssl/certs
+        - mountPath: /etc/ssl
           name: ca-certs
+          readOnly: true
+        - mountPath: /etc/pki
+          name: pki
           readOnly: true
         - mountPath: /usr/share/ca-certificates
           name: usr-share-ca-certificates
@@ -191,9 +194,13 @@ spec:
         secret:
           secretName: scheduler-kubeconfig
       - hostPath:
-          path: /etc/ssl/certs
+          path: /etc/ssl
           type: DirectoryOrCreate
         name: ca-certs
+      - hostPath:
+          path: /etc/pki
+          type: DirectoryOrCreate
+        name: pki
       - hostPath:
           path: /usr/share/ca-certificates
           type: DirectoryOrCreate

--- a/pkg/resources/test/fixtures/deployment-openstack-1.18.0-apiserver.yaml
+++ b/pkg/resources/test/fixtures/deployment-openstack-1.18.0-apiserver.yaml
@@ -302,8 +302,11 @@ spec:
         - mountPath: /etc/kubernetes/adm-control
           name: adm-control
           readOnly: true
-        - mountPath: /etc/ssl/certs
+        - mountPath: /etc/ssl
           name: ca-certs
+          readOnly: true
+        - mountPath: /etc/pki
+          name: pki
           readOnly: true
         - mountPath: /usr/share/ca-certificates
           name: usr-share-ca-certificates
@@ -383,9 +386,13 @@ spec:
           name: adm-control
         name: adm-control
       - hostPath:
-          path: /etc/ssl/certs
+          path: /etc/ssl
           type: DirectoryOrCreate
         name: ca-certs
+      - hostPath:
+          path: /etc/pki
+          type: DirectoryOrCreate
+        name: pki
       - hostPath:
           path: /usr/share/ca-certificates
           type: DirectoryOrCreate

--- a/pkg/resources/test/fixtures/deployment-openstack-1.18.0-controller-manager.yaml
+++ b/pkg/resources/test/fixtures/deployment-openstack-1.18.0-controller-manager.yaml
@@ -166,8 +166,11 @@ spec:
         - mountPath: /etc/kubernetes/kubeconfig
           name: controllermanager-kubeconfig
           readOnly: true
-        - mountPath: /etc/ssl/certs
+        - mountPath: /etc/ssl
           name: ca-certs
+          readOnly: true
+        - mountPath: /etc/pki
+          name: pki
           readOnly: true
         - mountPath: /usr/share/ca-certificates
           name: usr-share-ca-certificates
@@ -215,9 +218,13 @@ spec:
         secret:
           secretName: controllermanager-kubeconfig
       - hostPath:
-          path: /etc/ssl/certs
+          path: /etc/ssl
           type: DirectoryOrCreate
         name: ca-certs
+      - hostPath:
+          path: /etc/pki
+          type: DirectoryOrCreate
+        name: pki
       - hostPath:
           path: /usr/share/ca-certificates
           type: DirectoryOrCreate

--- a/pkg/resources/test/fixtures/deployment-openstack-1.18.0-scheduler.yaml
+++ b/pkg/resources/test/fixtures/deployment-openstack-1.18.0-scheduler.yaml
@@ -145,8 +145,11 @@ spec:
         - mountPath: /etc/kubernetes/pki/ca
           name: ca
           readOnly: true
-        - mountPath: /etc/ssl/certs
+        - mountPath: /etc/ssl
           name: ca-certs
+          readOnly: true
+        - mountPath: /etc/pki
+          name: pki
           readOnly: true
         - mountPath: /usr/share/ca-certificates
           name: usr-share-ca-certificates
@@ -191,9 +194,13 @@ spec:
         secret:
           secretName: scheduler-kubeconfig
       - hostPath:
-          path: /etc/ssl/certs
+          path: /etc/ssl
           type: DirectoryOrCreate
         name: ca-certs
+      - hostPath:
+          path: /etc/pki
+          type: DirectoryOrCreate
+        name: pki
       - hostPath:
           path: /usr/share/ca-certificates
           type: DirectoryOrCreate

--- a/pkg/resources/test/fixtures/deployment-openstack-1.19.0-apiserver.yaml
+++ b/pkg/resources/test/fixtures/deployment-openstack-1.19.0-apiserver.yaml
@@ -302,8 +302,11 @@ spec:
         - mountPath: /etc/kubernetes/adm-control
           name: adm-control
           readOnly: true
-        - mountPath: /etc/ssl/certs
+        - mountPath: /etc/ssl
           name: ca-certs
+          readOnly: true
+        - mountPath: /etc/pki
+          name: pki
           readOnly: true
         - mountPath: /usr/share/ca-certificates
           name: usr-share-ca-certificates
@@ -383,9 +386,13 @@ spec:
           name: adm-control
         name: adm-control
       - hostPath:
-          path: /etc/ssl/certs
+          path: /etc/ssl
           type: DirectoryOrCreate
         name: ca-certs
+      - hostPath:
+          path: /etc/pki
+          type: DirectoryOrCreate
+        name: pki
       - hostPath:
           path: /usr/share/ca-certificates
           type: DirectoryOrCreate

--- a/pkg/resources/test/fixtures/deployment-openstack-1.19.0-controller-manager.yaml
+++ b/pkg/resources/test/fixtures/deployment-openstack-1.19.0-controller-manager.yaml
@@ -166,8 +166,11 @@ spec:
         - mountPath: /etc/kubernetes/kubeconfig
           name: controllermanager-kubeconfig
           readOnly: true
-        - mountPath: /etc/ssl/certs
+        - mountPath: /etc/ssl
           name: ca-certs
+          readOnly: true
+        - mountPath: /etc/pki
+          name: pki
           readOnly: true
         - mountPath: /usr/share/ca-certificates
           name: usr-share-ca-certificates
@@ -215,9 +218,13 @@ spec:
         secret:
           secretName: controllermanager-kubeconfig
       - hostPath:
-          path: /etc/ssl/certs
+          path: /etc/ssl
           type: DirectoryOrCreate
         name: ca-certs
+      - hostPath:
+          path: /etc/pki
+          type: DirectoryOrCreate
+        name: pki
       - hostPath:
           path: /usr/share/ca-certificates
           type: DirectoryOrCreate

--- a/pkg/resources/test/fixtures/deployment-openstack-1.19.0-scheduler.yaml
+++ b/pkg/resources/test/fixtures/deployment-openstack-1.19.0-scheduler.yaml
@@ -145,8 +145,11 @@ spec:
         - mountPath: /etc/kubernetes/pki/ca
           name: ca
           readOnly: true
-        - mountPath: /etc/ssl/certs
+        - mountPath: /etc/ssl
           name: ca-certs
+          readOnly: true
+        - mountPath: /etc/pki
+          name: pki
           readOnly: true
         - mountPath: /usr/share/ca-certificates
           name: usr-share-ca-certificates
@@ -191,9 +194,13 @@ spec:
         secret:
           secretName: scheduler-kubeconfig
       - hostPath:
-          path: /etc/ssl/certs
+          path: /etc/ssl
           type: DirectoryOrCreate
         name: ca-certs
+      - hostPath:
+          path: /etc/pki
+          type: DirectoryOrCreate
+        name: pki
       - hostPath:
           path: /usr/share/ca-certificates
           type: DirectoryOrCreate

--- a/pkg/resources/test/fixtures/deployment-vsphere-1.17.0-apiserver.yaml
+++ b/pkg/resources/test/fixtures/deployment-vsphere-1.17.0-apiserver.yaml
@@ -302,8 +302,11 @@ spec:
         - mountPath: /etc/kubernetes/adm-control
           name: adm-control
           readOnly: true
-        - mountPath: /etc/ssl/certs
+        - mountPath: /etc/ssl
           name: ca-certs
+          readOnly: true
+        - mountPath: /etc/pki
+          name: pki
           readOnly: true
         - mountPath: /usr/share/ca-certificates
           name: usr-share-ca-certificates
@@ -383,9 +386,13 @@ spec:
           name: adm-control
         name: adm-control
       - hostPath:
-          path: /etc/ssl/certs
+          path: /etc/ssl
           type: DirectoryOrCreate
         name: ca-certs
+      - hostPath:
+          path: /etc/pki
+          type: DirectoryOrCreate
+        name: pki
       - hostPath:
           path: /usr/share/ca-certificates
           type: DirectoryOrCreate

--- a/pkg/resources/test/fixtures/deployment-vsphere-1.17.0-controller-manager.yaml
+++ b/pkg/resources/test/fixtures/deployment-vsphere-1.17.0-controller-manager.yaml
@@ -166,8 +166,11 @@ spec:
         - mountPath: /etc/kubernetes/kubeconfig
           name: controllermanager-kubeconfig
           readOnly: true
-        - mountPath: /etc/ssl/certs
+        - mountPath: /etc/ssl
           name: ca-certs
+          readOnly: true
+        - mountPath: /etc/pki
+          name: pki
           readOnly: true
         - mountPath: /usr/share/ca-certificates
           name: usr-share-ca-certificates
@@ -219,9 +222,13 @@ spec:
         secret:
           secretName: controllermanager-kubeconfig
       - hostPath:
-          path: /etc/ssl/certs
+          path: /etc/ssl
           type: DirectoryOrCreate
         name: ca-certs
+      - hostPath:
+          path: /etc/pki
+          type: DirectoryOrCreate
+        name: pki
       - hostPath:
           path: /usr/share/ca-certificates
           type: DirectoryOrCreate

--- a/pkg/resources/test/fixtures/deployment-vsphere-1.17.0-scheduler.yaml
+++ b/pkg/resources/test/fixtures/deployment-vsphere-1.17.0-scheduler.yaml
@@ -145,8 +145,11 @@ spec:
         - mountPath: /etc/kubernetes/pki/ca
           name: ca
           readOnly: true
-        - mountPath: /etc/ssl/certs
+        - mountPath: /etc/ssl
           name: ca-certs
+          readOnly: true
+        - mountPath: /etc/pki
+          name: pki
           readOnly: true
         - mountPath: /usr/share/ca-certificates
           name: usr-share-ca-certificates
@@ -191,9 +194,13 @@ spec:
         secret:
           secretName: scheduler-kubeconfig
       - hostPath:
-          path: /etc/ssl/certs
+          path: /etc/ssl
           type: DirectoryOrCreate
         name: ca-certs
+      - hostPath:
+          path: /etc/pki
+          type: DirectoryOrCreate
+        name: pki
       - hostPath:
           path: /usr/share/ca-certificates
           type: DirectoryOrCreate

--- a/pkg/resources/test/fixtures/deployment-vsphere-1.18.0-apiserver.yaml
+++ b/pkg/resources/test/fixtures/deployment-vsphere-1.18.0-apiserver.yaml
@@ -302,8 +302,11 @@ spec:
         - mountPath: /etc/kubernetes/adm-control
           name: adm-control
           readOnly: true
-        - mountPath: /etc/ssl/certs
+        - mountPath: /etc/ssl
           name: ca-certs
+          readOnly: true
+        - mountPath: /etc/pki
+          name: pki
           readOnly: true
         - mountPath: /usr/share/ca-certificates
           name: usr-share-ca-certificates
@@ -383,9 +386,13 @@ spec:
           name: adm-control
         name: adm-control
       - hostPath:
-          path: /etc/ssl/certs
+          path: /etc/ssl
           type: DirectoryOrCreate
         name: ca-certs
+      - hostPath:
+          path: /etc/pki
+          type: DirectoryOrCreate
+        name: pki
       - hostPath:
           path: /usr/share/ca-certificates
           type: DirectoryOrCreate

--- a/pkg/resources/test/fixtures/deployment-vsphere-1.18.0-controller-manager.yaml
+++ b/pkg/resources/test/fixtures/deployment-vsphere-1.18.0-controller-manager.yaml
@@ -166,8 +166,11 @@ spec:
         - mountPath: /etc/kubernetes/kubeconfig
           name: controllermanager-kubeconfig
           readOnly: true
-        - mountPath: /etc/ssl/certs
+        - mountPath: /etc/ssl
           name: ca-certs
+          readOnly: true
+        - mountPath: /etc/pki
+          name: pki
           readOnly: true
         - mountPath: /usr/share/ca-certificates
           name: usr-share-ca-certificates
@@ -219,9 +222,13 @@ spec:
         secret:
           secretName: controllermanager-kubeconfig
       - hostPath:
-          path: /etc/ssl/certs
+          path: /etc/ssl
           type: DirectoryOrCreate
         name: ca-certs
+      - hostPath:
+          path: /etc/pki
+          type: DirectoryOrCreate
+        name: pki
       - hostPath:
           path: /usr/share/ca-certificates
           type: DirectoryOrCreate

--- a/pkg/resources/test/fixtures/deployment-vsphere-1.18.0-scheduler.yaml
+++ b/pkg/resources/test/fixtures/deployment-vsphere-1.18.0-scheduler.yaml
@@ -145,8 +145,11 @@ spec:
         - mountPath: /etc/kubernetes/pki/ca
           name: ca
           readOnly: true
-        - mountPath: /etc/ssl/certs
+        - mountPath: /etc/ssl
           name: ca-certs
+          readOnly: true
+        - mountPath: /etc/pki
+          name: pki
           readOnly: true
         - mountPath: /usr/share/ca-certificates
           name: usr-share-ca-certificates
@@ -191,9 +194,13 @@ spec:
         secret:
           secretName: scheduler-kubeconfig
       - hostPath:
-          path: /etc/ssl/certs
+          path: /etc/ssl
           type: DirectoryOrCreate
         name: ca-certs
+      - hostPath:
+          path: /etc/pki
+          type: DirectoryOrCreate
+        name: pki
       - hostPath:
           path: /usr/share/ca-certificates
           type: DirectoryOrCreate

--- a/pkg/resources/test/fixtures/deployment-vsphere-1.19.0-apiserver.yaml
+++ b/pkg/resources/test/fixtures/deployment-vsphere-1.19.0-apiserver.yaml
@@ -302,8 +302,11 @@ spec:
         - mountPath: /etc/kubernetes/adm-control
           name: adm-control
           readOnly: true
-        - mountPath: /etc/ssl/certs
+        - mountPath: /etc/ssl
           name: ca-certs
+          readOnly: true
+        - mountPath: /etc/pki
+          name: pki
           readOnly: true
         - mountPath: /usr/share/ca-certificates
           name: usr-share-ca-certificates
@@ -383,9 +386,13 @@ spec:
           name: adm-control
         name: adm-control
       - hostPath:
-          path: /etc/ssl/certs
+          path: /etc/ssl
           type: DirectoryOrCreate
         name: ca-certs
+      - hostPath:
+          path: /etc/pki
+          type: DirectoryOrCreate
+        name: pki
       - hostPath:
           path: /usr/share/ca-certificates
           type: DirectoryOrCreate

--- a/pkg/resources/test/fixtures/deployment-vsphere-1.19.0-controller-manager.yaml
+++ b/pkg/resources/test/fixtures/deployment-vsphere-1.19.0-controller-manager.yaml
@@ -166,8 +166,11 @@ spec:
         - mountPath: /etc/kubernetes/kubeconfig
           name: controllermanager-kubeconfig
           readOnly: true
-        - mountPath: /etc/ssl/certs
+        - mountPath: /etc/ssl
           name: ca-certs
+          readOnly: true
+        - mountPath: /etc/pki
+          name: pki
           readOnly: true
         - mountPath: /usr/share/ca-certificates
           name: usr-share-ca-certificates
@@ -219,9 +222,13 @@ spec:
         secret:
           secretName: controllermanager-kubeconfig
       - hostPath:
-          path: /etc/ssl/certs
+          path: /etc/ssl
           type: DirectoryOrCreate
         name: ca-certs
+      - hostPath:
+          path: /etc/pki
+          type: DirectoryOrCreate
+        name: pki
       - hostPath:
           path: /usr/share/ca-certificates
           type: DirectoryOrCreate

--- a/pkg/resources/test/fixtures/deployment-vsphere-1.19.0-scheduler.yaml
+++ b/pkg/resources/test/fixtures/deployment-vsphere-1.19.0-scheduler.yaml
@@ -145,8 +145,11 @@ spec:
         - mountPath: /etc/kubernetes/pki/ca
           name: ca
           readOnly: true
-        - mountPath: /etc/ssl/certs
+        - mountPath: /etc/ssl
           name: ca-certs
+          readOnly: true
+        - mountPath: /etc/pki
+          name: pki
           readOnly: true
         - mountPath: /usr/share/ca-certificates
           name: usr-share-ca-certificates
@@ -191,9 +194,13 @@ spec:
         secret:
           secretName: scheduler-kubeconfig
       - hostPath:
-          path: /etc/ssl/certs
+          path: /etc/ssl
           type: DirectoryOrCreate
         name: ca-certs
+      - hostPath:
+          path: /etc/pki
+          type: DirectoryOrCreate
+        name: pki
       - hostPath:
           path: /usr/share/ca-certificates
           type: DirectoryOrCreate


### PR DESCRIPTION
**What this PR does / why we need it**:
This is a temporary fix for 2.15 to allow customers to upgrade, as 2.16+ ships with the new CA handling (#6538).
The root cause is Fedora/CentOS storing their trust anchors as

```
[root@xrstf-ssl-mount-test certs]# pwd && ls -lah
/etc/ssl/certs
total 8.0K
drwxr-xr-x. 2 root root 4.0K Feb 14 05:41 .
drwxr-xr-x. 5 root root 4.0K Feb 14 05:41 ..
lrwxrwxrwx. 1 root root   49 Aug 12  2020 ca-bundle.crt -> /etc/pki/ca-trust/extracted/pem/tls-ca-bundle.pem
lrwxrwxrwx. 1 root root   55 Aug 12  2020 ca-bundle.trust.crt -> /etc/pki/ca-trust/extracted/openssl/ca-bundle.trust.crt
```

**Which issue(s) this PR fixes**:
Fixes #6469

**Does this PR introduce a user-facing change?**:
```release-note
Fix CA certificates not being mounted on Seed clusters using CentOS/Fedora.
```
