### PR TITLE
Add Kubernetes 1.19.8

### DIFF
--- a/.prow.yaml
+++ b/.prow.yaml
@@ -442,12 +442,12 @@ presubmits:
       preset-goproxy: "true"
     spec:
       containers:
-      - image: quay.io/kubermatic/e2e-kind:with-conformance-tests-v1.0.22
+      - image: quay.io/kubermatic/e2e-kind:with-conformance-tests-v1.0.24
         env:
         - name: KUBERMATIC_EDITION
           value: ee
         - name: VERSIONS_TO_TEST
-          value: "v1.19.3"
+          value: "v1.19.8"
         - name: DISTRIBUTIONS
           value: ubuntu
         - name: SERVICE_ACCOUNT_KEY

--- a/charts/kubermatic/Chart.yaml
+++ b/charts/kubermatic/Chart.yaml
@@ -14,7 +14,7 @@
 
 apiVersion: v1
 name: kubermatic
-version: 1.1.33
+version: 1.1.34
 appVersion: '__KUBERMATIC_TAG__'
 description: Kubermatic chart for master and/or seed clusters.
 keywords:

--- a/charts/kubermatic/static/master/versions.yaml
+++ b/charts/kubermatic/static/master/versions.yaml
@@ -23,8 +23,10 @@ versions:
   version: 1.19.0
 - type: kubernetes
   version: 1.19.2
+- type: kubernetes
+  version: 1.19.3
 - default: true
   type: kubernetes
-  version: 1.19.3
+  version: 1.19.8
 - type: kubernetes
   version: 1.20.2

--- a/docs/zz_generated.kubermaticConfiguration.yaml
+++ b/docs/zz_generated.kubermaticConfiguration.yaml
@@ -396,7 +396,7 @@ spec:
     # Kubernetes configures the Kubernetes versions and updates.
     kubernetes:
       # Default is the default version to offer users.
-      default: 1.19.3
+      default: 1.19.8
       # Updates is a list of available and automatic upgrades.
       # All 'to' versions must be configured in the version list for this orchestrator.
       # Each update may optionally be configured to be 'automatic: true', in which case the
@@ -458,6 +458,7 @@ spec:
         - 1.19.0
         - 1.19.2
         - 1.19.3
+        - 1.19.8
         - 1.20.2
   # VerticalPodAutoscaler configures the Kubernetes VPA integration.
   verticalPodAutoscaler:

--- a/hack/ci/setup-kubermatic-in-kind.sh
+++ b/hack/ci/setup-kubermatic-in-kind.sh
@@ -133,11 +133,13 @@ echodate "Successfully built and loaded all images"
 # prepare to run kubermatic-installer
 KUBERMATIC_CONFIG="$(mktemp)"
 IMAGE_PULL_SECRET_INLINE="$(echo "$IMAGE_PULL_SECRET_DATA" | base64 --decode | jq --compact-output --monochrome-output '.')"
+KUBERMATIC_DOMAIN="${KUBERMATIC_DOMAIN:-ci.kubermatic.io}"
 
 cp hack/ci/testdata/kubermatic.yaml $KUBERMATIC_CONFIG
 
 sed -i "s;__SERVICE_ACCOUNT_KEY__;$SERVICE_ACCOUNT_KEY;g" $KUBERMATIC_CONFIG
 sed -i "s;__IMAGE_PULL_SECRET__;$IMAGE_PULL_SECRET_INLINE;g" $KUBERMATIC_CONFIG
+sed -i "s;__KUBERMATIC_DOMAIN__;$KUBERMATIC_DOMAIN;g" $KUBERMATIC_CONFIG
 
 HELM_VALUES_FILE="$(mktemp)"
 cat << EOF > $HELM_VALUES_FILE

--- a/hack/ci/testdata/kubermatic.yaml
+++ b/hack/ci/testdata/kubermatic.yaml
@@ -19,7 +19,7 @@ metadata:
   namespace: kubermatic
 spec:
   ingress:
-    domain: ci.kubermatic.io
+    domain: '__KUBERMATIC_DOMAIN__'
     disable: true
   imagePullSecret: '__IMAGE_PULL_SECRET__'
   userCluster:

--- a/hack/lib.sh
+++ b/hack/lib.sh
@@ -252,10 +252,14 @@ pushMetric() {
   local labels="${3:-}"
   local kind="${4:-gauge}"
   local help="${5:-}"
-  local pushgateway="pushgateway.monitoring.svc.cluster.local.:9091"
+  local pushgateway="${PUSHGATEWAY_URL:-}"
   local job="ci"
   local instance="$PROW_JOB_ID"
   local prowjob="$JOB_NAME"
+
+  if [ -z "$pushgateway" ]; then
+    return
+  fi
 
   local payload="# TYPE $metric $kind"
 
@@ -269,7 +273,7 @@ pushMetric() {
 
   payload="$payload\n$metric{prowjob=\"$prowjob\"$labels} $value\n"
 
-  echo -e "$payload" | curl --data-binary @- -s "http://$pushgateway/metrics/job/$job/instance/$instance"
+  echo -e "$payload" | curl --data-binary @- -s "$pushgateway/metrics/job/$job/instance/$instance"
 }
 
 pushElapsed() {

--- a/pkg/controller/operator/common/defaults.go
+++ b/pkg/controller/operator/common/defaults.go
@@ -190,7 +190,7 @@ var (
 	}
 
 	DefaultKubernetesVersioning = operatorv1alpha1.KubermaticVersioningConfiguration{
-		Default: semver.MustParse("v1.19.3"),
+		Default: semver.MustParse("v1.19.8"),
 		Versions: []*semver.Version{
 			// Kubernetes 1.17
 			semver.MustParse("v1.17.9"),
@@ -207,6 +207,7 @@ var (
 			semver.MustParse("v1.19.0"),
 			semver.MustParse("v1.19.2"),
 			semver.MustParse("v1.19.3"),
+			semver.MustParse("v1.19.8"),
 			// Kubernetes 1.20
 			semver.MustParse("v1.20.2"),
 		},


### PR DESCRIPTION
**What this PR does / why we need it**:
This adds support for Kubernetes 1.19.8. Funny enough, when updating to Go 1.16, I forgot to update the 1.19 tests, which was lucky, because 1.19.3 would have failed the conformance-tests. As #6122 noted, there were upstream bugs in the tests. This made it necessary to update both the kube-test binaries and the usercluster version.

This PR started out as a test PR for a new CI cluster, so a few nifty improvements to make jobs a bit less dependent on ci.kubermatic.io also made their way into here.

**Does this PR introduce a user-facing change?**:
```release-note
Add Kubernetes 1.19.8
```
