### PR TITLE
Add support for Openstack Application Credentials

### DIFF
--- a/cmd/conformance-tests/main.go
+++ b/cmd/conformance-tests/main.go
@@ -128,10 +128,12 @@ type secrets struct {
 		Token string
 	}
 	OpenStack struct {
-		Domain   string
-		Tenant   string
-		Username string
-		Password string
+		Domain                      string
+		Tenant                      string
+		Username                    string
+		Password                    string
+		ApplicationCredentialID     string
+		ApplicationCredentialSecret string
 	}
 	VSphere struct {
 		Username string
@@ -230,6 +232,8 @@ func main() {
 	flag.StringVar(&opts.secrets.OpenStack.Tenant, "openstack-tenant", "", "OpenStack: Tenant")
 	flag.StringVar(&opts.secrets.OpenStack.Username, "openstack-username", "", "OpenStack: Username")
 	flag.StringVar(&opts.secrets.OpenStack.Password, "openstack-password", "", "OpenStack: Password")
+	flag.StringVar(&opts.secrets.OpenStack.ApplicationCredentialID, "openstack-application-credential-id", "", "OpenStack: ApplicationCredentialID")
+	flag.StringVar(&opts.secrets.OpenStack.ApplicationCredentialSecret, "openstack-application-credential-secret", "", "OpenStack: ApplicationCredentialSecret")
 	flag.StringVar(&opts.secrets.VSphere.Username, "vsphere-username", "", "vSphere: Username")
 	flag.StringVar(&opts.secrets.VSphere.Password, "vsphere-password", "", "vSphere: Password")
 	flag.StringVar(&opts.secrets.Azure.ClientID, "azure-client-id", "", "Azure: ClientID")

--- a/cmd/kubermatic-api/swagger.json
+++ b/cmd/kubermatic-api/swagger.json
@@ -7073,6 +7073,16 @@
           },
           {
             "type": "string",
+            "name": "ApplicationCredentialID",
+            "in": "header"
+          },
+          {
+            "type": "string",
+            "name": "ApplicationCredentialSecret",
+            "in": "header"
+          },
+          {
+            "type": "string",
             "name": "DatacenterName",
             "in": "header"
           },
@@ -7135,6 +7145,16 @@
           {
             "type": "string",
             "name": "TenantID",
+            "in": "header"
+          },
+          {
+            "type": "string",
+            "name": "ApplicationCredentialID",
+            "in": "header"
+          },
+          {
+            "type": "string",
+            "name": "ApplicationCredentialSecret",
             "in": "header"
           },
           {
@@ -7205,6 +7225,16 @@
           },
           {
             "type": "string",
+            "name": "ApplicationCredentialID",
+            "in": "header"
+          },
+          {
+            "type": "string",
+            "name": "ApplicationCredentialSecret",
+            "in": "header"
+          },
+          {
+            "type": "string",
             "name": "DatacenterName",
             "in": "header"
           },
@@ -7267,6 +7297,16 @@
           {
             "type": "string",
             "name": "TenantID",
+            "in": "header"
+          },
+          {
+            "type": "string",
+            "name": "ApplicationCredentialID",
+            "in": "header"
+          },
+          {
+            "type": "string",
+            "name": "ApplicationCredentialSecret",
             "in": "header"
           },
           {
@@ -7337,6 +7377,16 @@
           },
           {
             "type": "string",
+            "name": "ApplicationCredentialID",
+            "in": "header"
+          },
+          {
+            "type": "string",
+            "name": "ApplicationCredentialSecret",
+            "in": "header"
+          },
+          {
+            "type": "string",
             "name": "DatacenterName",
             "in": "header"
           },
@@ -7395,6 +7445,16 @@
           {
             "type": "string",
             "name": "Domain",
+            "in": "header"
+          },
+          {
+            "type": "string",
+            "name": "ApplicationCredentialID",
+            "in": "header"
+          },
+          {
+            "type": "string",
+            "name": "ApplicationCredentialSecret",
             "in": "header"
           },
           {
@@ -17319,6 +17379,14 @@
       "type": "object",
       "title": "OpenstackCloudSpec specifies access data to an OpenStack cloud.",
       "properties": {
+        "applicationCredentialID": {
+          "type": "string",
+          "x-go-name": "ApplicationCredentialID"
+        },
+        "applicationCredentialSecret": {
+          "type": "string",
+          "x-go-name": "ApplicationCredentialSecret"
+        },
         "credentialsReference": {
           "$ref": "#/definitions/GlobalSecretKeySelector"
         },

--- a/docs/zz_generated.addondata.go.txt
+++ b/docs/zz_generated.addondata.go.txt
@@ -104,11 +104,13 @@ type HetznerCredentials struct {
 }
 
 type OpenstackCredentials struct {
-	Username string
-	Password string
-	Tenant   string
-	TenantID string
-	Domain   string
+	Username                    string
+	Password                    string
+	Tenant                      string
+	TenantID                    string
+	Domain                      string
+	ApplicationCredentialID     string
+	ApplicationCredentialSecret string
 }
 
 type PacketCredentials struct {

--- a/hack/ci/run-conformance-tests.sh
+++ b/hack/ci/run-conformance-tests.sh
@@ -62,7 +62,9 @@ elif [[ $provider == "openstack" ]]; then
   EXTRA_ARGS="-openstack-domain=${OS_DOMAIN}
     -openstack-tenant=${OS_TENANT_NAME}
     -openstack-username=${OS_USERNAME}
-    -openstack-password=${OS_PASSWORD}"
+    -openstack-password=${OS_PASSWORD}
+    -openstack-application-credential-id=${OS_APPLICATION_CREDENTIAL_ID}
+    -openstack-application-credential-secret=${OS_APPLICATION_CREDENTIAL_SECRET}"
 elif [[ $provider == "vsphere" ]]; then
   EXTRA_ARGS="-vsphere-username=${VSPHERE_E2E_USERNAME}
     -vsphere-password=${VSPHERE_E2E_PASSWORD}"

--- a/hack/run-conformance-tests.sh
+++ b/hack/run-conformance-tests.sh
@@ -104,10 +104,14 @@ openstack)
   OS_TENANT_NAME="${OS_TENANT_NAME:-$(vault kv get -field=OS_TENANT_NAME dev/syseleven-openstack)}"
   OS_USERNAME="${OS_USERNAME:-$(vault kv get -field=username dev/syseleven-openstack)}"
   OS_PASSWORD="${OS_PASSWORD:-$(vault kv get -field=password dev/syseleven-openstack)}"
+  OS_APPLICATION_CREDENTIAL_ID="${OS_APPLICATION_CREDENTIAL_ID:-$(vault kv get -field=application-credential-id dev/syseleven-openstack)}"
+  OS_APPLICATION_CREDENTIAL_SECRET="${OS_APPLICATION_CREDENTIAL_SECRET:-$(vault kv get -field=application-credential-secret dev/syseleven-openstack)}"
   extraArgs="-openstack-domain=$OS_DOMAIN
       -openstack-tenant=$OS_TENANT_NAME
       -openstack-username=$OS_USERNAME
-      -openstack-password=$OS_PASSWORD"
+      -openstack-password=$OS_PASSWORD
+      -openstack-application-credential-id=$OS_APPLICATION_CREDENTIAL_ID
+      -openstack-application-credential-secret=$OS_APPLICATION_CREDENTIAL_SECRET"
   ;;
 
 packet)

--- a/pkg/crd/kubermatic/v1/cluster.go
+++ b/pkg/crd/kubermatic/v1/cluster.go
@@ -587,11 +587,13 @@ type AWSCloudSpec struct {
 type OpenstackCloudSpec struct {
 	CredentialsReference *providerconfig.GlobalSecretKeySelector `json:"credentialsReference,omitempty"`
 
-	Username string `json:"username,omitempty"`
-	Password string `json:"password,omitempty"`
-	Tenant   string `json:"tenant,omitempty"`
-	TenantID string `json:"tenantID,omitempty"`
-	Domain   string `json:"domain,omitempty"`
+	Username                    string `json:"username,omitempty"`
+	Password                    string `json:"password,omitempty"`
+	Tenant                      string `json:"tenant,omitempty"`
+	TenantID                    string `json:"tenantID,omitempty"`
+	Domain                      string `json:"domain,omitempty"`
+	ApplicationCredentialID     string `json:"applicationCredentialID,omitempty"`
+	ApplicationCredentialSecret string `json:"applicationCredentialSecret,omitempty"`
 	// Network holds the name of the internal network
 	// When specified, all worker nodes will be attached to this network. If not specified, a network, subnet & router will be created
 	//

--- a/pkg/crd/kubermatic/v1/preset.go
+++ b/pkg/crd/kubermatic/v1/preset.go
@@ -300,11 +300,13 @@ func (s AWS) IsValid() bool {
 type Openstack struct {
 	PresetProvider `json:",inline"`
 
-	Username string `json:"username"`
-	Password string `json:"password"`
-	Tenant   string `json:"tenant"`
-	TenantID string `json:"tenantID"`
-	Domain   string `json:"domain"`
+	Username                    string `json:"username,omitempty"`
+	Password                    string `json:"password,omitempty"`
+	Tenant                      string `json:"tenant,omitempty"`
+	TenantID                    string `json:"tenantID,omitempty"`
+	Domain                      string `json:"domain"`
+	ApplicationCredentialID     string `json:"applicationCredentialID,omitempty"`
+	ApplicationCredentialSecret string `json:"applicationCredentialSecret,omitempty"`
 
 	Network        string `json:"network,omitempty"`
 	SecurityGroups string `json:"securityGroups,omitempty"`
@@ -314,9 +316,13 @@ type Openstack struct {
 }
 
 func (s Openstack) IsValid() bool {
-	return len(s.Username) > 0 &&
-		len(s.Password) > 0 &&
-		(len(s.Tenant) > 0 || len(s.TenantID) > 0) &&
+	// It's valid if either ApplicationCredentialID/Secret are specified or
+	// Username/Password and Tenant(ID)
+	return ((len(s.ApplicationCredentialID) > 0 &&
+		len(s.ApplicationCredentialSecret) > 0) ||
+		(len(s.Username) > 0 &&
+			len(s.Password) > 0 &&
+			(len(s.Tenant) > 0 || len(s.TenantID) > 0))) &&
 		len(s.Domain) > 0
 }
 

--- a/pkg/handler/common/provider/openstack.go
+++ b/pkg/handler/common/provider/openstack.go
@@ -61,7 +61,7 @@ func OpenstackSizeWithClusterCredentialsEndpoint(ctx context.Context, userInfoGe
 		return nil, common.KubernetesErrorToHTTPError(err)
 	}
 
-	return GetOpenstackSizes(creds.Username, creds.Password, creds.Tenant, creds.TenantID, creds.Domain, datacenterName, datacenter, settings.Spec.MachineDeploymentVMResourceQuota)
+	return GetOpenstackSizes(creds, datacenterName, datacenter, settings.Spec.MachineDeploymentVMResourceQuota)
 }
 
 func OpenstackTenantWithClusterCredentialsEndpoint(ctx context.Context, userInfoGetter provider.UserInfoGetter, projectProvider provider.ProjectProvider, privilegedProjectProvider provider.PrivilegedProjectProvider, seedsGetter provider.SeedsGetter, projectID, clusterID string) (interface{}, error) {
@@ -81,7 +81,7 @@ func OpenstackTenantWithClusterCredentialsEndpoint(ctx context.Context, userInfo
 	if err != nil {
 		return nil, err
 	}
-	return GetOpenstackTenants(userInfo, seedsGetter, creds.Username, creds.Password, creds.Domain, creds.Tenant, creds.TenantID, datacenterName)
+	return GetOpenstackTenants(userInfo, seedsGetter, creds, datacenterName)
 }
 
 func OpenstackNetworkWithClusterCredentialsEndpoint(ctx context.Context, userInfoGetter provider.UserInfoGetter, projectProvider provider.ProjectProvider, privilegedProjectProvider provider.PrivilegedProjectProvider, seedsGetter provider.SeedsGetter, projectID, clusterID string) (interface{}, error) {
@@ -101,7 +101,7 @@ func OpenstackNetworkWithClusterCredentialsEndpoint(ctx context.Context, userInf
 	if err != nil {
 		return nil, err
 	}
-	return GetOpenstackNetworks(userInfo, seedsGetter, creds.Username, creds.Password, creds.Tenant, creds.TenantID, creds.Domain, datacenterName)
+	return GetOpenstackNetworks(userInfo, seedsGetter, creds, datacenterName)
 }
 
 func OpenstackSecurityGroupWithClusterCredentialsEndpoint(ctx context.Context, userInfoGetter provider.UserInfoGetter, projectProvider provider.ProjectProvider, privilegedProjectProvider provider.PrivilegedProjectProvider, seedsGetter provider.SeedsGetter, projectID, clusterID string) (interface{}, error) {
@@ -122,7 +122,7 @@ func OpenstackSecurityGroupWithClusterCredentialsEndpoint(ctx context.Context, u
 		return nil, err
 	}
 
-	return GetOpenstackSecurityGroups(userInfo, seedsGetter, creds.Username, creds.Password, creds.Tenant, creds.TenantID, creds.Domain, datacenterName)
+	return GetOpenstackSecurityGroups(userInfo, seedsGetter, creds, datacenterName)
 }
 
 func OpenstackSubnetsWithClusterCredentialsEndpoint(ctx context.Context, userInfoGetter provider.UserInfoGetter, projectProvider provider.ProjectProvider, privilegedProjectProvider provider.PrivilegedProjectProvider, seedsGetter provider.SeedsGetter, projectID, clusterID, networkID string) (interface{}, error) {
@@ -143,7 +143,7 @@ func OpenstackSubnetsWithClusterCredentialsEndpoint(ctx context.Context, userInf
 		return nil, err
 	}
 
-	return GetOpenstackSubnets(userInfo, seedsGetter, creds.Username, creds.Password, creds.Domain, creds.Tenant, creds.TenantID, networkID, datacenterName)
+	return GetOpenstackSubnets(userInfo, seedsGetter, creds, networkID, datacenterName)
 }
 
 func OpenstackAvailabilityZoneWithClusterCredentialsEndpoint(ctx context.Context, userInfoGetter provider.UserInfoGetter, projectProvider provider.ProjectProvider, privilegedProjectProvider provider.PrivilegedProjectProvider, seedsGetter provider.SeedsGetter, projectID, clusterID string) (interface{}, error) {
@@ -169,11 +169,11 @@ func OpenstackAvailabilityZoneWithClusterCredentialsEndpoint(ctx context.Context
 		return nil, err
 	}
 
-	return GetOpenstackAvailabilityZones(creds.Username, creds.Password, creds.Tenant, creds.TenantID, creds.Domain, datacenterName, datacenter)
+	return GetOpenstackAvailabilityZones(creds, datacenterName, datacenter)
 }
 
-func GetOpenstackAvailabilityZones(username, password, tenant, tenantID, domain, datacenterName string, datacenter *kubermaticv1.Datacenter) ([]apiv1.OpenstackAvailabilityZone, error) {
-	availabilityZones, err := openstack.GetAvailabilityZones(username, password, domain, tenant, tenantID, datacenter.Spec.Openstack.AuthURL, datacenter.Spec.Openstack.Region)
+func GetOpenstackAvailabilityZones(creds *resources.OpenstackCredentials, datacenterName string, datacenter *kubermaticv1.Datacenter) ([]apiv1.OpenstackAvailabilityZone, error) {
+	availabilityZones, err := openstack.GetAvailabilityZones(creds, datacenter.Spec.Openstack.AuthURL, datacenter.Spec.Openstack.Region)
 	if err != nil {
 		return nil, err
 	}
@@ -188,13 +188,13 @@ func GetOpenstackAvailabilityZones(username, password, tenant, tenantID, domain,
 	return apiAvailabilityZones, nil
 }
 
-func GetOpenstackSubnets(userInfo *provider.UserInfo, seedsGetter provider.SeedsGetter, username, password, domain, tenant, tenantID, networkID, datacenterName string) ([]apiv1.OpenstackSubnet, error) {
+func GetOpenstackSubnets(userInfo *provider.UserInfo, seedsGetter provider.SeedsGetter, creds *resources.OpenstackCredentials, networkID, datacenterName string) ([]apiv1.OpenstackSubnet, error) {
 	authURL, region, err := getOpenstackAuthURLAndRegion(userInfo, seedsGetter, datacenterName)
 	if err != nil {
 		return nil, err
 	}
 
-	subnets, err := openstack.GetSubnets(username, password, domain, tenant, tenantID, networkID, authURL, region)
+	subnets, err := openstack.GetSubnets(creds, networkID, authURL, region)
 	if err != nil {
 		return nil, err
 	}
@@ -210,13 +210,13 @@ func GetOpenstackSubnets(userInfo *provider.UserInfo, seedsGetter provider.Seeds
 	return apiSubnetIDs, nil
 }
 
-func GetOpenstackNetworks(userInfo *provider.UserInfo, seedsGetter provider.SeedsGetter, username, password, tenant, tenantID, domain, datacenterName string) ([]apiv1.OpenstackNetwork, error) {
+func GetOpenstackNetworks(userInfo *provider.UserInfo, seedsGetter provider.SeedsGetter, creds *resources.OpenstackCredentials, datacenterName string) ([]apiv1.OpenstackNetwork, error) {
 	authURL, region, err := getOpenstackAuthURLAndRegion(userInfo, seedsGetter, datacenterName)
 	if err != nil {
 		return nil, err
 	}
 
-	networks, err := openstack.GetNetworks(username, password, domain, tenant, tenantID, authURL, region)
+	networks, err := openstack.GetNetworks(creds, authURL, region)
 	if err != nil {
 		return nil, err
 	}
@@ -235,13 +235,13 @@ func GetOpenstackNetworks(userInfo *provider.UserInfo, seedsGetter provider.Seed
 	return apiNetworks, nil
 }
 
-func GetOpenstackTenants(userInfo *provider.UserInfo, seedsGetter provider.SeedsGetter, username, password, domain, tenant, tenantID, datacenterName string) ([]apiv1.OpenstackTenant, error) {
+func GetOpenstackTenants(userInfo *provider.UserInfo, seedsGetter provider.SeedsGetter, creds *resources.OpenstackCredentials, datacenterName string) ([]apiv1.OpenstackTenant, error) {
 	authURL, region, err := getOpenstackAuthURLAndRegion(userInfo, seedsGetter, datacenterName)
 	if err != nil {
 		return nil, err
 	}
 
-	tenants, err := openstack.GetTenants(username, password, domain, tenant, tenantID, authURL, region)
+	tenants, err := openstack.GetTenants(creds, authURL, region)
 	if err != nil {
 		return nil, fmt.Errorf("couldn't get tenants: %v", err)
 	}
@@ -259,8 +259,8 @@ func GetOpenstackTenants(userInfo *provider.UserInfo, seedsGetter provider.Seeds
 	return apiTenants, nil
 }
 
-func GetOpenstackSizes(username, password, tenant, tenantID, domain, datacenterName string, datacenter *kubermaticv1.Datacenter, quota kubermaticv1.MachineDeploymentVMResourceQuota) ([]apiv1.OpenstackSize, error) {
-	flavors, err := openstack.GetFlavors(username, password, domain, tenant, tenantID, datacenter.Spec.Openstack.AuthURL, datacenter.Spec.Openstack.Region)
+func GetOpenstackSizes(creds *resources.OpenstackCredentials, datacenterName string, datacenter *kubermaticv1.Datacenter, quota kubermaticv1.MachineDeploymentVMResourceQuota) ([]apiv1.OpenstackSize, error) {
+	flavors, err := openstack.GetFlavors(creds, datacenter.Spec.Openstack.AuthURL, datacenter.Spec.Openstack.Region)
 	if err != nil {
 		return nil, err
 	}
@@ -332,13 +332,13 @@ func IsFlavorEnabled(apiSize apiv1.OpenstackSize, enabledFlavors []string) bool 
 	return false
 }
 
-func GetOpenstackSecurityGroups(userInfo *provider.UserInfo, seedsGetter provider.SeedsGetter, username, password, tenant, tenantID, domain, datacenterName string) ([]apiv1.OpenstackSecurityGroup, error) {
+func GetOpenstackSecurityGroups(userInfo *provider.UserInfo, seedsGetter provider.SeedsGetter, creds *resources.OpenstackCredentials, datacenterName string) ([]apiv1.OpenstackSecurityGroup, error) {
 	authURL, region, err := getOpenstackAuthURLAndRegion(userInfo, seedsGetter, datacenterName)
 	if err != nil {
 		return nil, err
 	}
 
-	securityGroups, err := openstack.GetSecurityGroups(username, password, domain, tenant, tenantID, authURL, region)
+	securityGroups, err := openstack.GetSecurityGroups(creds, authURL, region)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/handler/v1/provider/openstack.go
+++ b/pkg/handler/v1/provider/openstack.go
@@ -26,6 +26,7 @@ import (
 	providercommon "k8c.io/kubermatic/v2/pkg/handler/common/provider"
 	"k8c.io/kubermatic/v2/pkg/handler/v1/common"
 	"k8c.io/kubermatic/v2/pkg/provider"
+	"k8c.io/kubermatic/v2/pkg/resources"
 )
 
 func OpenstackSizeEndpoint(seedsGetter provider.SeedsGetter, presetsProvider provider.PresetProvider, userInfoGetter provider.UserInfoGetter, settingsProvider provider.SettingsProvider) endpoint.Endpoint {
@@ -45,7 +46,7 @@ func OpenstackSizeEndpoint(seedsGetter provider.SeedsGetter, presetsProvider pro
 			return nil, fmt.Errorf("error getting dc: %v", err)
 		}
 
-		username, password, domain, tenant, tenantID, err := getOpenstackCredentials(userInfo, req.Credential, req.Username, req.Password, req.Domain, req.Tenant, req.TenantID, presetsProvider)
+		creds, err := getOpenstackCredentials(userInfo, req.Credential, req.Username, req.Password, req.Domain, req.Tenant, req.TenantID, req.ApplicationCredentialID, req.ApplicationCredentialSecret, presetsProvider)
 		if err != nil {
 			return nil, fmt.Errorf("error getting OpenStack credentials: %v", err)
 		}
@@ -55,7 +56,7 @@ func OpenstackSizeEndpoint(seedsGetter provider.SeedsGetter, presetsProvider pro
 			return nil, common.KubernetesErrorToHTTPError(err)
 		}
 
-		return providercommon.GetOpenstackSizes(username, password, tenant, tenantID, domain, datacenterName, datacenter, settings.Spec.MachineDeploymentVMResourceQuota)
+		return providercommon.GetOpenstackSizes(creds, datacenterName, datacenter, settings.Spec.MachineDeploymentVMResourceQuota)
 	}
 }
 
@@ -76,11 +77,11 @@ func OpenstackTenantEndpoint(seedsGetter provider.SeedsGetter, presetsProvider p
 		if err != nil {
 			return nil, common.KubernetesErrorToHTTPError(err)
 		}
-		username, password, domain, _, _, err := getOpenstackCredentials(userInfo, req.Credential, req.Username, req.Password, req.Domain, "", "", presetsProvider)
+		creds, err := getOpenstackCredentials(userInfo, req.Credential, req.Username, req.Password, req.Domain, "", "", req.ApplicationCredentialID, req.ApplicationCredentialSecret, presetsProvider)
 		if err != nil {
 			return nil, fmt.Errorf("error getting OpenStack credentials: %v", err)
 		}
-		return providercommon.GetOpenstackTenants(userInfo, seedsGetter, username, password, domain, "", "", req.DatacenterName)
+		return providercommon.GetOpenstackTenants(userInfo, seedsGetter, creds, req.DatacenterName)
 	}
 }
 
@@ -101,11 +102,11 @@ func OpenstackNetworkEndpoint(seedsGetter provider.SeedsGetter, presetsProvider 
 		if err != nil {
 			return nil, common.KubernetesErrorToHTTPError(err)
 		}
-		username, password, domain, tenant, tenantID, err := getOpenstackCredentials(userInfo, req.Credential, req.Username, req.Password, req.Domain, req.Tenant, req.TenantID, presetsProvider)
+		creds, err := getOpenstackCredentials(userInfo, req.Credential, req.Username, req.Password, req.Domain, req.Tenant, req.TenantID, req.ApplicationCredentialID, req.ApplicationCredentialSecret, presetsProvider)
 		if err != nil {
 			return nil, fmt.Errorf("error getting OpenStack credentials: %v", err)
 		}
-		return providercommon.GetOpenstackNetworks(userInfo, seedsGetter, username, password, tenant, tenantID, domain, req.DatacenterName)
+		return providercommon.GetOpenstackNetworks(userInfo, seedsGetter, creds, req.DatacenterName)
 	}
 }
 
@@ -126,11 +127,11 @@ func OpenstackSecurityGroupEndpoint(seedsGetter provider.SeedsGetter, presetsPro
 		if err != nil {
 			return nil, common.KubernetesErrorToHTTPError(err)
 		}
-		username, password, domain, tenant, tenantID, err := getOpenstackCredentials(userInfo, req.Credential, req.Username, req.Password, req.Domain, req.Tenant, req.TenantID, presetsProvider)
+		creds, err := getOpenstackCredentials(userInfo, req.Credential, req.Username, req.Password, req.Domain, req.Tenant, req.TenantID, req.ApplicationCredentialID, req.ApplicationCredentialSecret, presetsProvider)
 		if err != nil {
 			return nil, fmt.Errorf("error getting OpenStack credentials: %v", err)
 		}
-		return providercommon.GetOpenstackSecurityGroups(userInfo, seedsGetter, username, password, tenant, tenantID, domain, req.DatacenterName)
+		return providercommon.GetOpenstackSecurityGroups(userInfo, seedsGetter, creds, req.DatacenterName)
 	}
 }
 
@@ -151,11 +152,11 @@ func OpenstackSubnetsEndpoint(seedsGetter provider.SeedsGetter, presetsProvider 
 		if err != nil {
 			return nil, common.KubernetesErrorToHTTPError(err)
 		}
-		username, password, domain, tenant, tenantID, err := getOpenstackCredentials(userInfo, req.Credential, req.Username, req.Password, req.Domain, req.Tenant, req.TenantID, presetsProvider)
+		creds, err := getOpenstackCredentials(userInfo, req.Credential, req.Username, req.Password, req.Domain, req.Tenant, req.TenantID, req.ApplicationCredentialID, req.ApplicationCredentialSecret, presetsProvider)
 		if err != nil {
 			return nil, fmt.Errorf("error getting OpenStack credentials: %v", err)
 		}
-		return providercommon.GetOpenstackSubnets(userInfo, seedsGetter, username, password, domain, tenant, tenantID, req.NetworkID, req.DatacenterName)
+		return providercommon.GetOpenstackSubnets(userInfo, seedsGetter, creds, req.NetworkID, req.DatacenterName)
 	}
 }
 
@@ -183,11 +184,11 @@ func OpenstackAvailabilityZoneEndpoint(seedsGetter provider.SeedsGetter, presets
 			return nil, fmt.Errorf("error getting dc: %v", err)
 		}
 
-		username, password, domain, tenant, tenantID, err := getOpenstackCredentials(userInfo, req.Credential, req.Username, req.Password, req.Domain, req.Tenant, req.TenantID, presetsProvider)
+		creds, err := getOpenstackCredentials(userInfo, req.Credential, req.Username, req.Password, req.Domain, req.Tenant, req.TenantID, req.ApplicationCredentialID, req.ApplicationCredentialSecret, presetsProvider)
 		if err != nil {
 			return nil, fmt.Errorf("error getting OpenStack credentials: %v", err)
 		}
-		return providercommon.GetOpenstackAvailabilityZones(username, password, tenant, tenantID, domain, datacenterName, datacenter)
+		return providercommon.GetOpenstackAvailabilityZones(creds, datacenterName, datacenter)
 	}
 }
 
@@ -217,6 +218,12 @@ type OpenstackReq struct {
 	// TenantID OpenStack tenant ID
 	TenantID string
 	// in: header
+	// ApplicationCredentialID OpenStack application credential ID
+	ApplicationCredentialID string
+	// in: header
+	// ApplicationCredentialSecret OpenStack application credential secret
+	ApplicationCredentialSecret string
+	// in: header
 	// DatacenterName Openstack datacenter name
 	DatacenterName string
 	// in: header
@@ -232,6 +239,8 @@ func DecodeOpenstackReq(_ context.Context, r *http.Request) (interface{}, error)
 	req.Tenant = r.Header.Get("Tenant")
 	req.TenantID = r.Header.Get("TenantID")
 	req.Domain = r.Header.Get("Domain")
+	req.ApplicationCredentialID = r.Header.Get("ApplicationCredentialID")
+	req.ApplicationCredentialSecret = r.Header.Get("ApplicationCredentialSecret")
 	req.DatacenterName = r.Header.Get("DatacenterName")
 	req.Credential = r.Header.Get("Credential")
 	return req, nil
@@ -269,6 +278,8 @@ func DecodeOpenstackSubnetReq(_ context.Context, r *http.Request) (interface{}, 
 	req.Password = r.Header.Get("Password")
 	req.Domain = r.Header.Get("Domain")
 	req.Tenant = r.Header.Get("Tenant")
+	req.ApplicationCredentialID = r.Header.Get("ApplicationCredentialID")
+	req.ApplicationCredentialSecret = r.Header.Get("ApplicationCredentialSecret")
 	req.DatacenterName = r.Header.Get("DatacenterName")
 	req.NetworkID = r.URL.Query().Get("network_id")
 	if req.NetworkID == "" {
@@ -315,6 +326,12 @@ type OpenstackTenantReq struct {
 	// Domain OpenStack domain name
 	Domain string
 	// in: header
+	// ApplicationCredentialID OpenStack application credential ID
+	ApplicationCredentialID string
+	// in: header
+	// ApplicationCredentialSecret OpenStack application credential secret
+	ApplicationCredentialSecret string
+	// in: header
 	// DatacenterName Openstack datacenter na
 	DatacenterName string
 	// in: header
@@ -328,17 +345,19 @@ func DecodeOpenstackTenantReq(_ context.Context, r *http.Request) (interface{}, 
 	req.Username = r.Header.Get("Username")
 	req.Password = r.Header.Get("Password")
 	req.Domain = r.Header.Get("Domain")
+	req.ApplicationCredentialID = r.Header.Get("ApplicationCredentialID")
+	req.ApplicationCredentialSecret = r.Header.Get("ApplicationCredentialSecret")
 	req.DatacenterName = r.Header.Get("DatacenterName")
 	req.Credential = r.Header.Get("Credential")
 
 	return req, nil
 }
 
-func getOpenstackCredentials(userInfo *provider.UserInfo, credentialName, username, password, domain, tenant, tenantID string, presetProvider provider.PresetProvider) (string, string, string, string, string, error) {
+func getOpenstackCredentials(userInfo *provider.UserInfo, credentialName, username, password, domain, tenant, tenantID, applicationCredentialID, applicationCredentialSecret string, presetProvider provider.PresetProvider) (*resources.OpenstackCredentials, error) {
 	if len(credentialName) > 0 {
 		preset, err := presetProvider.GetPreset(userInfo, credentialName)
 		if err != nil {
-			return "", "", "", "", "", fmt.Errorf("can not get preset %s for the user %s", credentialName, userInfo.Email)
+			return nil, fmt.Errorf("can not get preset %s for the user %s", credentialName, userInfo.Email)
 		}
 		if credentials := preset.Spec.Openstack; credentials != nil {
 			username = credentials.Username
@@ -346,7 +365,18 @@ func getOpenstackCredentials(userInfo *provider.UserInfo, credentialName, userna
 			tenant = credentials.Tenant
 			tenantID = credentials.TenantID
 			domain = credentials.Domain
+			applicationCredentialID = credentials.ApplicationCredentialID
+			applicationCredentialSecret = credentials.ApplicationCredentialSecret
 		}
 	}
-	return username, password, domain, tenant, tenantID, nil
+	creds := resources.OpenstackCredentials{
+		Username:                    username,
+		Password:                    password,
+		Tenant:                      tenant,
+		TenantID:                    tenantID,
+		Domain:                      domain,
+		ApplicationCredentialID:     applicationCredentialID,
+		ApplicationCredentialSecret: applicationCredentialSecret,
+	}
+	return &creds, nil
 }

--- a/pkg/handler/v2/preset/preset_test.go
+++ b/pkg/handler/v2/preset/preset_test.go
@@ -975,7 +975,59 @@ func TestUpdatePreset(t *testing.T) {
 
 		// scenario 4
 		{
-			Name:       "scenario 4: block user from updating multiple providers at once",
+			Name:       "scenario 4: replace username/password with application credentials",
+			PresetName: "openstack-preset",
+			Provider:   v2.PresetProvider{Name: kubermaticv1.ProviderOpenstack, Enabled: true},
+			Body: `{
+						"metadata": {
+						"name": "openstack-preset"
+						},
+						"spec": {
+						"openstack": {
+							"applicationCredentialID": "updated",
+							"applicationCredentialSecret": "updated",
+							"domain": "updated"
+						}
+						}
+			}`,
+			ExistingPreset: &kubermaticv1.Preset{
+				ObjectMeta: v1.ObjectMeta{Name: "openstack-preset"},
+				TypeMeta:   v1.TypeMeta{Kind: "Preset", APIVersion: "kubermatic.k8s.io/v1"},
+				Spec: kubermaticv1.PresetSpec{
+					Digitalocean: &kubermaticv1.Digitalocean{
+						Token: "test",
+					},
+					Openstack: &kubermaticv1.Openstack{
+						Username:       "test",
+						Password:       "test",
+						TenantID:       "test",
+						Domain:         "test",
+						FloatingIPPool: "test",
+						RouterID:       "test",
+					},
+				},
+			},
+			ExpectedPreset: &kubermaticv1.Preset{
+				ObjectMeta: v1.ObjectMeta{Name: "openstack-preset", ResourceVersion: "1"},
+				TypeMeta:   v1.TypeMeta{Kind: "Preset", APIVersion: "kubermatic.k8s.io/v1"},
+				Spec: kubermaticv1.PresetSpec{
+					Digitalocean: &kubermaticv1.Digitalocean{
+						Token: "test",
+					},
+					Openstack: &kubermaticv1.Openstack{
+						ApplicationCredentialID:     "updated",
+						ApplicationCredentialSecret: "updated",
+						Domain:                      "updated",
+					},
+				},
+			},
+			HTTPStatus:      http.StatusOK,
+			ExistingAPIUser: test.GenDefaultAdminAPIUser(),
+		},
+
+		// scenario 5
+		{
+			Name:       "scenario 5: block user from updating multiple providers at once",
 			PresetName: "openstack-preset",
 			Provider:   v2.PresetProvider{Name: kubermaticv1.ProviderOpenstack, Enabled: true},
 			Body: `{
@@ -1012,9 +1064,9 @@ func TestUpdatePreset(t *testing.T) {
 			ExistingAPIUser: test.GenDefaultAdminAPIUser(),
 		},
 
-		// scenario 5
+		// scenario 6
 		{
-			Name:     "scenario 5: block preset update for regular user",
+			Name:     "scenario 6: block preset update for regular user",
 			Provider: v2.PresetProvider{Name: kubermaticv1.ProviderFake, Enabled: true},
 			Body: `{
 					 "metadata": {

--- a/pkg/provider/kubernetes/credentials.go
+++ b/pkg/provider/kubernetes/credentials.go
@@ -269,7 +269,7 @@ func createOrUpdateOpenstackSecret(ctx context.Context, seedClient ctrlruntimecl
 	spec := cluster.Spec.Cloud.Openstack
 
 	// already migrated
-	if spec.Username == "" && spec.Password == "" && spec.Tenant == "" && spec.TenantID == "" && spec.Domain == "" {
+	if spec.Username == "" && spec.Password == "" && spec.Tenant == "" && spec.TenantID == "" && spec.Domain == "" && spec.ApplicationCredentialID == "" && spec.ApplicationCredentialSecret == "" {
 		return nil
 	}
 
@@ -287,14 +287,22 @@ func createOrUpdateOpenstackSecret(ctx context.Context, seedClient ctrlruntimecl
 	if spec.Domain == "" {
 		spec.Domain = oldCred.Domain
 	}
+	if spec.ApplicationCredentialID == "" {
+		spec.ApplicationCredentialID = oldCred.ApplicationCredentialID
+	}
+	if spec.ApplicationCredentialSecret == "" {
+		spec.ApplicationCredentialSecret = oldCred.ApplicationCredentialSecret
+	}
 
 	// move credentials into dedicated Secret
 	credentialRef, err := ensureCredentialSecret(ctx, seedClient, cluster, map[string][]byte{
-		resources.OpenstackUsername: []byte(spec.Username),
-		resources.OpenstackPassword: []byte(spec.Password),
-		resources.OpenstackTenant:   []byte(spec.Tenant),
-		resources.OpenstackTenantID: []byte(spec.TenantID),
-		resources.OpenstackDomain:   []byte(spec.Domain),
+		resources.OpenstackUsername:                    []byte(spec.Username),
+		resources.OpenstackPassword:                    []byte(spec.Password),
+		resources.OpenstackTenant:                      []byte(spec.Tenant),
+		resources.OpenstackTenantID:                    []byte(spec.TenantID),
+		resources.OpenstackDomain:                      []byte(spec.Domain),
+		resources.OpenstackApplicationCredentialID:     []byte(spec.ApplicationCredentialID),
+		resources.OpenstackApplicationCredentialSecret: []byte(spec.ApplicationCredentialSecret),
 	})
 	if err != nil {
 		return err
@@ -309,6 +317,8 @@ func createOrUpdateOpenstackSecret(ctx context.Context, seedClient ctrlruntimecl
 	cluster.Spec.Cloud.Openstack.Tenant = ""
 	cluster.Spec.Cloud.Openstack.TenantID = ""
 	cluster.Spec.Cloud.Openstack.Domain = ""
+	cluster.Spec.Cloud.Openstack.ApplicationCredentialID = ""
+	cluster.Spec.Cloud.Openstack.ApplicationCredentialSecret = ""
 
 	return nil
 }

--- a/pkg/provider/kubernetes/preset.go
+++ b/pkg/provider/kubernetes/preset.go
@@ -414,6 +414,8 @@ func (m *PresetsProvider) setOpenStackCredentials(userInfo *provider.UserInfo, p
 	cloud.Openstack.Domain = credentials.Domain
 	cloud.Openstack.Tenant = credentials.Tenant
 	cloud.Openstack.TenantID = credentials.TenantID
+	cloud.Openstack.ApplicationCredentialID = credentials.ApplicationCredentialID
+	cloud.Openstack.ApplicationCredentialSecret = credentials.ApplicationCredentialSecret
 
 	cloud.Openstack.SubnetID = credentials.SubnetID
 	cloud.Openstack.Network = credentials.Network

--- a/pkg/provider/kubernetes/preset_test.go
+++ b/pkg/provider/kubernetes/preset_test.go
@@ -546,7 +546,28 @@ func TestCredentialEndpoint(t *testing.T) {
 			expectedCloudSpec: &kubermaticv1.CloudSpec{Openstack: &kubermaticv1.OpenstackCloudSpec{Tenant: "a", Domain: "b", Password: "c", Username: "d"}},
 		},
 		{
-			name:       "test 8: set credentials for Vsphere provider",
+			name:       "test 8: set application credentials for OpenStack provider",
+			presetName: "test",
+			userInfo:   provider.UserInfo{Email: "test@example.com"},
+			presets: []ctrlruntimeclient.Object{
+				&kubermaticv1.Preset{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "test",
+					},
+					Spec: kubermaticv1.PresetSpec{
+						RequiredEmailDomain: "example.com",
+						Openstack: &kubermaticv1.Openstack{
+							ApplicationCredentialID: "a", ApplicationCredentialSecret: "b", Domain: "c",
+						},
+					},
+				},
+			},
+			dc:                &kubermaticv1.Datacenter{Spec: kubermaticv1.DatacenterSpec{Openstack: &kubermaticv1.DatacenterSpecOpenstack{EnforceFloatingIP: false}}},
+			cloudSpec:         kubermaticv1.CloudSpec{Openstack: &kubermaticv1.OpenstackCloudSpec{}},
+			expectedCloudSpec: &kubermaticv1.CloudSpec{Openstack: &kubermaticv1.OpenstackCloudSpec{ApplicationCredentialID: "a", ApplicationCredentialSecret: "b", Domain: "c"}},
+		},
+		{
+			name:       "test 9: set credentials for Vsphere provider",
 			presetName: "test",
 			userInfo:   provider.UserInfo{Email: "test@example.com"},
 			presets: []ctrlruntimeclient.Object{
@@ -566,7 +587,7 @@ func TestCredentialEndpoint(t *testing.T) {
 			expectedCloudSpec: &kubermaticv1.CloudSpec{VSphere: &kubermaticv1.VSphereCloudSpec{Password: "secret", Username: "bob"}},
 		},
 		{
-			name:       "test 9: set credentials for Azure provider",
+			name:       "test 10: set credentials for Azure provider",
 			presetName: "test",
 			userInfo:   provider.UserInfo{Email: "test@example.com"},
 			presets: []ctrlruntimeclient.Object{
@@ -586,7 +607,7 @@ func TestCredentialEndpoint(t *testing.T) {
 			expectedCloudSpec: &kubermaticv1.CloudSpec{Azure: &kubermaticv1.AzureCloudSpec{SubscriptionID: "a", ClientID: "b", ClientSecret: "c", TenantID: "d"}},
 		},
 		{
-			name:       "test 10: no credentials for Azure provider",
+			name:       "test 11: no credentials for Azure provider",
 			presetName: "test",
 			userInfo:   provider.UserInfo{Email: "test@example.com"},
 			presets: []ctrlruntimeclient.Object{
@@ -603,7 +624,7 @@ func TestCredentialEndpoint(t *testing.T) {
 			expectedError: "the preset test doesn't contain credential for Azure provider",
 		},
 		{
-			name:       "test 11: cloud provider spec is empty",
+			name:       "test 12: cloud provider spec is empty",
 			presetName: "test",
 			userInfo:   provider.UserInfo{Email: "test@example.com"},
 			presets: []ctrlruntimeclient.Object{
@@ -623,7 +644,7 @@ func TestCredentialEndpoint(t *testing.T) {
 			expectedError: "can not find provider to set credentials",
 		},
 		{
-			name:       "test 12: set credentials for Kubevirt provider",
+			name:       "test 13: set credentials for Kubevirt provider",
 			presetName: "test",
 			userInfo:   provider.UserInfo{Email: "test@example.com"},
 			presets: []ctrlruntimeclient.Object{
@@ -643,7 +664,7 @@ func TestCredentialEndpoint(t *testing.T) {
 			expectedCloudSpec: &kubermaticv1.CloudSpec{Kubevirt: &kubermaticv1.KubevirtCloudSpec{Kubeconfig: "test"}},
 		},
 		{
-			name:       "test 13: credential with wrong email domain returns error",
+			name:       "test 14: credential with wrong email domain returns error",
 			presetName: "test",
 			userInfo:   provider.UserInfo{Email: "test@example.com"},
 			presets: []ctrlruntimeclient.Object{
@@ -664,7 +685,7 @@ func TestCredentialEndpoint(t *testing.T) {
 			expectedError: "preset.kubermatic.k8s.io \"test\" not found",
 		},
 		{
-			name:       "test 14: set credentials for Alibaba provider",
+			name:       "test 15: set credentials for Alibaba provider",
 			presetName: "test",
 			userInfo:   provider.UserInfo{Email: "test@example.com"},
 			presets: []ctrlruntimeclient.Object{

--- a/pkg/resources/cloudconfig/configmap.go
+++ b/pkg/resources/cloudconfig/configmap.go
@@ -133,13 +133,15 @@ func CloudConfig(
 		}
 		openstackCloudConfig := &openstack.CloudConfig{
 			Global: openstack.GlobalOpts{
-				AuthURL:    dc.Spec.Openstack.AuthURL,
-				Username:   credentials.Openstack.Username,
-				Password:   credentials.Openstack.Password,
-				DomainName: credentials.Openstack.Domain,
-				TenantName: credentials.Openstack.Tenant,
-				TenantID:   credentials.Openstack.TenantID,
-				Region:     dc.Spec.Openstack.Region,
+				AuthURL:                     dc.Spec.Openstack.AuthURL,
+				Username:                    credentials.Openstack.Username,
+				Password:                    credentials.Openstack.Password,
+				ApplicationCredentialID:     credentials.Openstack.ApplicationCredentialID,
+				ApplicationCredentialSecret: credentials.Openstack.ApplicationCredentialSecret,
+				DomainName:                  credentials.Openstack.Domain,
+				TenantName:                  credentials.Openstack.Tenant,
+				TenantID:                    credentials.Openstack.TenantID,
+				Region:                      dc.Spec.Openstack.Region,
 			},
 			BlockStorage: openstack.BlockStorageOpts{
 				BSVersion:       "auto",

--- a/pkg/resources/credentials.go
+++ b/pkg/resources/credentials.go
@@ -281,21 +281,22 @@ func GetHetznerCredentials(data CredentialsData) (HetznerCredentials, error) {
 
 func GetOpenstackCredentials(data CredentialsData) (OpenstackCredentials, error) {
 	spec := data.Cluster().Spec.Cloud.Openstack
-	openstackCredentials := OpenstackCredentials{}
+	openstackCredentials := OpenstackCredentials{
+		ApplicationCredentialID:     spec.ApplicationCredentialID,
+		ApplicationCredentialSecret: spec.ApplicationCredentialSecret,
+	}
+
 	var err error
 
-	if spec.ApplicationCredentialID != "" {
-		openstackCredentials.ApplicationCredentialID = spec.ApplicationCredentialID
-	} else {
+	if openstackCredentials.ApplicationCredentialID == "" {
 		openstackCredentials.ApplicationCredentialID, _ = data.GetGlobalSecretKeySelectorValue(spec.CredentialsReference, OpenstackApplicationCredentialID)
 	}
-	if spec.ApplicationCredentialSecret != "" {
-		openstackCredentials.ApplicationCredentialSecret = spec.ApplicationCredentialSecret
-	} else {
+
+	if spec.ApplicationCredentialSecret == "" {
 		openstackCredentials.ApplicationCredentialSecret, _ = data.GetGlobalSecretKeySelectorValue(spec.CredentialsReference, OpenstackApplicationCredentialSecret)
 	}
 
-	if openstackCredentials.ApplicationCredentialID == "" || openstackCredentials.ApplicationCredentialSecret == "" {
+	if openstackCredentials.ApplicationCredentialID == "" && openstackCredentials.ApplicationCredentialSecret == "" {
 		if spec.Username != "" {
 			openstackCredentials.Username = spec.Username
 		} else if openstackCredentials.Username, err = data.GetGlobalSecretKeySelectorValue(spec.CredentialsReference, OpenstackUsername); err != nil {

--- a/pkg/resources/credentials.go
+++ b/pkg/resources/credentials.go
@@ -65,11 +65,13 @@ type HetznerCredentials struct {
 }
 
 type OpenstackCredentials struct {
-	Username string
-	Password string
-	Tenant   string
-	TenantID string
-	Domain   string
+	Username                    string
+	Password                    string
+	Tenant                      string
+	TenantID                    string
+	Domain                      string
+	ApplicationCredentialID     string
+	ApplicationCredentialSecret string
 }
 
 type PacketCredentials struct {
@@ -282,31 +284,44 @@ func GetOpenstackCredentials(data CredentialsData) (OpenstackCredentials, error)
 	openstackCredentials := OpenstackCredentials{}
 	var err error
 
-	if spec.Username != "" {
-		openstackCredentials.Username = spec.Username
-	} else if openstackCredentials.Username, err = data.GetGlobalSecretKeySelectorValue(spec.CredentialsReference, OpenstackUsername); err != nil {
-		return OpenstackCredentials{}, err
+	if spec.ApplicationCredentialID != "" {
+		openstackCredentials.ApplicationCredentialID = spec.ApplicationCredentialID
+	} else {
+		openstackCredentials.ApplicationCredentialID, _ = data.GetGlobalSecretKeySelectorValue(spec.CredentialsReference, OpenstackApplicationCredentialID)
+	}
+	if spec.ApplicationCredentialSecret != "" {
+		openstackCredentials.ApplicationCredentialSecret = spec.ApplicationCredentialSecret
+	} else {
+		openstackCredentials.ApplicationCredentialSecret, _ = data.GetGlobalSecretKeySelectorValue(spec.CredentialsReference, OpenstackApplicationCredentialSecret)
 	}
 
-	if spec.Password != "" {
-		openstackCredentials.Password = spec.Password
-	} else if openstackCredentials.Password, err = data.GetGlobalSecretKeySelectorValue(spec.CredentialsReference, OpenstackPassword); err != nil {
-		return OpenstackCredentials{}, err
-	}
-
-	if spec.Tenant != "" {
-		openstackCredentials.Tenant = spec.Tenant
-	} else if spec.CredentialsReference != nil && spec.CredentialsReference.Name != "" {
-		if openstackCredentials.Tenant, err = data.GetGlobalSecretKeySelectorValue(spec.CredentialsReference, OpenstackTenant); err != nil {
+	if openstackCredentials.ApplicationCredentialID == "" || openstackCredentials.ApplicationCredentialSecret == "" {
+		if spec.Username != "" {
+			openstackCredentials.Username = spec.Username
+		} else if openstackCredentials.Username, err = data.GetGlobalSecretKeySelectorValue(spec.CredentialsReference, OpenstackUsername); err != nil {
 			return OpenstackCredentials{}, err
 		}
-	}
 
-	if spec.TenantID != "" {
-		openstackCredentials.TenantID = spec.TenantID
-	} else if spec.CredentialsReference != nil && spec.CredentialsReference.Name != "" {
-		if openstackCredentials.TenantID, err = data.GetGlobalSecretKeySelectorValue(spec.CredentialsReference, OpenstackTenantID); err != nil {
+		if spec.Password != "" {
+			openstackCredentials.Password = spec.Password
+		} else if openstackCredentials.Password, err = data.GetGlobalSecretKeySelectorValue(spec.CredentialsReference, OpenstackPassword); err != nil {
 			return OpenstackCredentials{}, err
+		}
+
+		if spec.Tenant != "" {
+			openstackCredentials.Tenant = spec.Tenant
+		} else if spec.CredentialsReference != nil && spec.CredentialsReference.Name != "" {
+			if openstackCredentials.Tenant, err = data.GetGlobalSecretKeySelectorValue(spec.CredentialsReference, OpenstackTenant); err != nil {
+				return OpenstackCredentials{}, err
+			}
+		}
+
+		if spec.TenantID != "" {
+			openstackCredentials.TenantID = spec.TenantID
+		} else if spec.CredentialsReference != nil && spec.CredentialsReference.Name != "" {
+			if openstackCredentials.TenantID, err = data.GetGlobalSecretKeySelectorValue(spec.CredentialsReference, OpenstackTenantID); err != nil {
+				return OpenstackCredentials{}, err
+			}
 		}
 	}
 

--- a/pkg/resources/machinecontroller/deployment.go
+++ b/pkg/resources/machinecontroller/deployment.go
@@ -203,6 +203,8 @@ func getEnvVars(data machinecontrollerData) ([]corev1.EnvVar, error) {
 		vars = append(vars, corev1.EnvVar{Name: "OS_AUTH_URL", Value: data.DC().Spec.Openstack.AuthURL})
 		vars = append(vars, corev1.EnvVar{Name: "OS_USER_NAME", Value: credentials.Openstack.Username})
 		vars = append(vars, corev1.EnvVar{Name: "OS_PASSWORD", Value: credentials.Openstack.Password})
+		vars = append(vars, corev1.EnvVar{Name: "OS_APPLICATION_CREDENTIAL_ID", Value: credentials.Openstack.ApplicationCredentialID})
+		vars = append(vars, corev1.EnvVar{Name: "OS_APPLICATION_CREDENTIAL_ID", Value: credentials.Openstack.ApplicationCredentialSecret})
 		vars = append(vars, corev1.EnvVar{Name: "OS_DOMAIN_NAME", Value: credentials.Openstack.Domain})
 		vars = append(vars, corev1.EnvVar{Name: "OS_TENANT_NAME", Value: credentials.Openstack.Tenant})
 		vars = append(vars, corev1.EnvVar{Name: "OS_TENANT_ID", Value: credentials.Openstack.TenantID})

--- a/pkg/resources/machinecontroller/deployment.go
+++ b/pkg/resources/machinecontroller/deployment.go
@@ -204,7 +204,7 @@ func getEnvVars(data machinecontrollerData) ([]corev1.EnvVar, error) {
 		vars = append(vars, corev1.EnvVar{Name: "OS_USER_NAME", Value: credentials.Openstack.Username})
 		vars = append(vars, corev1.EnvVar{Name: "OS_PASSWORD", Value: credentials.Openstack.Password})
 		vars = append(vars, corev1.EnvVar{Name: "OS_APPLICATION_CREDENTIAL_ID", Value: credentials.Openstack.ApplicationCredentialID})
-		vars = append(vars, corev1.EnvVar{Name: "OS_APPLICATION_CREDENTIAL_ID", Value: credentials.Openstack.ApplicationCredentialSecret})
+		vars = append(vars, corev1.EnvVar{Name: "OS_APPLICATION_CREDENTIAL_SECRET", Value: credentials.Openstack.ApplicationCredentialSecret})
 		vars = append(vars, corev1.EnvVar{Name: "OS_DOMAIN_NAME", Value: credentials.Openstack.Domain})
 		vars = append(vars, corev1.EnvVar{Name: "OS_TENANT_NAME", Value: credentials.Openstack.Tenant})
 		vars = append(vars, corev1.EnvVar{Name: "OS_TENANT_ID", Value: credentials.Openstack.TenantID})

--- a/pkg/resources/resources.go
+++ b/pkg/resources/resources.go
@@ -500,11 +500,13 @@ const (
 
 	HetznerToken = "token"
 
-	OpenstackUsername = "username"
-	OpenstackPassword = "password"
-	OpenstackTenant   = "tenant"
-	OpenstackTenantID = "tenantID"
-	OpenstackDomain   = "domain"
+	OpenstackUsername                    = "username"
+	OpenstackPassword                    = "password"
+	OpenstackTenant                      = "tenant"
+	OpenstackTenantID                    = "tenantID"
+	OpenstackDomain                      = "domain"
+	OpenstackApplicationCredentialID     = "applicationcredentialID"
+	OpenstackApplicationCredentialSecret = "applicationcredentialSecret"
 
 	PacketAPIKey    = "apiKey"
 	PacketProjectID = "projectID"

--- a/pkg/resources/test/fixtures/deployment-openstack-1.17.0-machine-controller-webhook.yaml
+++ b/pkg/resources/test/fixtures/deployment-openstack-1.17.0-machine-controller-webhook.yaml
@@ -45,6 +45,8 @@ spec:
           value: openstack-username
         - name: OS_PASSWORD
           value: openstack-password
+        - name: OS_APPLICATION_CREDENTIAL_ID
+        - name: OS_APPLICATION_CREDENTIAL_ID
         - name: OS_DOMAIN_NAME
           value: openstack-domain
         - name: OS_TENANT_NAME

--- a/pkg/resources/test/fixtures/deployment-openstack-1.17.0-machine-controller-webhook.yaml
+++ b/pkg/resources/test/fixtures/deployment-openstack-1.17.0-machine-controller-webhook.yaml
@@ -46,7 +46,7 @@ spec:
         - name: OS_PASSWORD
           value: openstack-password
         - name: OS_APPLICATION_CREDENTIAL_ID
-        - name: OS_APPLICATION_CREDENTIAL_ID
+        - name: OS_APPLICATION_CREDENTIAL_SECRET
         - name: OS_DOMAIN_NAME
           value: openstack-domain
         - name: OS_TENANT_NAME

--- a/pkg/resources/test/fixtures/deployment-openstack-1.17.0-machine-controller.yaml
+++ b/pkg/resources/test/fixtures/deployment-openstack-1.17.0-machine-controller.yaml
@@ -48,6 +48,8 @@ spec:
           value: openstack-username
         - name: OS_PASSWORD
           value: openstack-password
+        - name: OS_APPLICATION_CREDENTIAL_ID
+        - name: OS_APPLICATION_CREDENTIAL_ID
         - name: OS_DOMAIN_NAME
           value: openstack-domain
         - name: OS_TENANT_NAME

--- a/pkg/resources/test/fixtures/deployment-openstack-1.17.0-machine-controller.yaml
+++ b/pkg/resources/test/fixtures/deployment-openstack-1.17.0-machine-controller.yaml
@@ -49,7 +49,7 @@ spec:
         - name: OS_PASSWORD
           value: openstack-password
         - name: OS_APPLICATION_CREDENTIAL_ID
-        - name: OS_APPLICATION_CREDENTIAL_ID
+        - name: OS_APPLICATION_CREDENTIAL_SECRET
         - name: OS_DOMAIN_NAME
           value: openstack-domain
         - name: OS_TENANT_NAME

--- a/pkg/resources/test/fixtures/deployment-openstack-1.18.0-machine-controller-webhook.yaml
+++ b/pkg/resources/test/fixtures/deployment-openstack-1.18.0-machine-controller-webhook.yaml
@@ -45,6 +45,8 @@ spec:
           value: openstack-username
         - name: OS_PASSWORD
           value: openstack-password
+        - name: OS_APPLICATION_CREDENTIAL_ID
+        - name: OS_APPLICATION_CREDENTIAL_ID
         - name: OS_DOMAIN_NAME
           value: openstack-domain
         - name: OS_TENANT_NAME

--- a/pkg/resources/test/fixtures/deployment-openstack-1.18.0-machine-controller-webhook.yaml
+++ b/pkg/resources/test/fixtures/deployment-openstack-1.18.0-machine-controller-webhook.yaml
@@ -46,7 +46,7 @@ spec:
         - name: OS_PASSWORD
           value: openstack-password
         - name: OS_APPLICATION_CREDENTIAL_ID
-        - name: OS_APPLICATION_CREDENTIAL_ID
+        - name: OS_APPLICATION_CREDENTIAL_SECRET
         - name: OS_DOMAIN_NAME
           value: openstack-domain
         - name: OS_TENANT_NAME

--- a/pkg/resources/test/fixtures/deployment-openstack-1.18.0-machine-controller.yaml
+++ b/pkg/resources/test/fixtures/deployment-openstack-1.18.0-machine-controller.yaml
@@ -48,6 +48,8 @@ spec:
           value: openstack-username
         - name: OS_PASSWORD
           value: openstack-password
+        - name: OS_APPLICATION_CREDENTIAL_ID
+        - name: OS_APPLICATION_CREDENTIAL_ID
         - name: OS_DOMAIN_NAME
           value: openstack-domain
         - name: OS_TENANT_NAME

--- a/pkg/resources/test/fixtures/deployment-openstack-1.18.0-machine-controller.yaml
+++ b/pkg/resources/test/fixtures/deployment-openstack-1.18.0-machine-controller.yaml
@@ -49,7 +49,7 @@ spec:
         - name: OS_PASSWORD
           value: openstack-password
         - name: OS_APPLICATION_CREDENTIAL_ID
-        - name: OS_APPLICATION_CREDENTIAL_ID
+        - name: OS_APPLICATION_CREDENTIAL_SECRET
         - name: OS_DOMAIN_NAME
           value: openstack-domain
         - name: OS_TENANT_NAME

--- a/pkg/resources/test/fixtures/deployment-openstack-1.19.0-machine-controller-webhook.yaml
+++ b/pkg/resources/test/fixtures/deployment-openstack-1.19.0-machine-controller-webhook.yaml
@@ -45,6 +45,8 @@ spec:
           value: openstack-username
         - name: OS_PASSWORD
           value: openstack-password
+        - name: OS_APPLICATION_CREDENTIAL_ID
+        - name: OS_APPLICATION_CREDENTIAL_ID
         - name: OS_DOMAIN_NAME
           value: openstack-domain
         - name: OS_TENANT_NAME

--- a/pkg/resources/test/fixtures/deployment-openstack-1.19.0-machine-controller-webhook.yaml
+++ b/pkg/resources/test/fixtures/deployment-openstack-1.19.0-machine-controller-webhook.yaml
@@ -46,7 +46,7 @@ spec:
         - name: OS_PASSWORD
           value: openstack-password
         - name: OS_APPLICATION_CREDENTIAL_ID
-        - name: OS_APPLICATION_CREDENTIAL_ID
+        - name: OS_APPLICATION_CREDENTIAL_SECRET
         - name: OS_DOMAIN_NAME
           value: openstack-domain
         - name: OS_TENANT_NAME

--- a/pkg/resources/test/fixtures/deployment-openstack-1.19.0-machine-controller.yaml
+++ b/pkg/resources/test/fixtures/deployment-openstack-1.19.0-machine-controller.yaml
@@ -48,6 +48,8 @@ spec:
           value: openstack-username
         - name: OS_PASSWORD
           value: openstack-password
+        - name: OS_APPLICATION_CREDENTIAL_ID
+        - name: OS_APPLICATION_CREDENTIAL_ID
         - name: OS_DOMAIN_NAME
           value: openstack-domain
         - name: OS_TENANT_NAME

--- a/pkg/resources/test/fixtures/deployment-openstack-1.19.0-machine-controller.yaml
+++ b/pkg/resources/test/fixtures/deployment-openstack-1.19.0-machine-controller.yaml
@@ -49,7 +49,7 @@ spec:
         - name: OS_PASSWORD
           value: openstack-password
         - name: OS_APPLICATION_CREDENTIAL_ID
-        - name: OS_APPLICATION_CREDENTIAL_ID
+        - name: OS_APPLICATION_CREDENTIAL_SECRET
         - name: OS_DOMAIN_NAME
           value: openstack-domain
         - name: OS_TENANT_NAME

--- a/pkg/resources/test/fixtures/deployment-openstack-1.20.0-machine-controller-webhook.yaml
+++ b/pkg/resources/test/fixtures/deployment-openstack-1.20.0-machine-controller-webhook.yaml
@@ -45,6 +45,8 @@ spec:
           value: openstack-username
         - name: OS_PASSWORD
           value: openstack-password
+        - name: OS_APPLICATION_CREDENTIAL_ID
+        - name: OS_APPLICATION_CREDENTIAL_ID
         - name: OS_DOMAIN_NAME
           value: openstack-domain
         - name: OS_TENANT_NAME

--- a/pkg/resources/test/fixtures/deployment-openstack-1.20.0-machine-controller-webhook.yaml
+++ b/pkg/resources/test/fixtures/deployment-openstack-1.20.0-machine-controller-webhook.yaml
@@ -46,7 +46,7 @@ spec:
         - name: OS_PASSWORD
           value: openstack-password
         - name: OS_APPLICATION_CREDENTIAL_ID
-        - name: OS_APPLICATION_CREDENTIAL_ID
+        - name: OS_APPLICATION_CREDENTIAL_SECRET
         - name: OS_DOMAIN_NAME
           value: openstack-domain
         - name: OS_TENANT_NAME

--- a/pkg/resources/test/fixtures/deployment-openstack-1.20.0-machine-controller.yaml
+++ b/pkg/resources/test/fixtures/deployment-openstack-1.20.0-machine-controller.yaml
@@ -48,6 +48,8 @@ spec:
           value: openstack-username
         - name: OS_PASSWORD
           value: openstack-password
+        - name: OS_APPLICATION_CREDENTIAL_ID
+        - name: OS_APPLICATION_CREDENTIAL_ID
         - name: OS_DOMAIN_NAME
           value: openstack-domain
         - name: OS_TENANT_NAME

--- a/pkg/resources/test/fixtures/deployment-openstack-1.20.0-machine-controller.yaml
+++ b/pkg/resources/test/fixtures/deployment-openstack-1.20.0-machine-controller.yaml
@@ -49,7 +49,7 @@ spec:
         - name: OS_PASSWORD
           value: openstack-password
         - name: OS_APPLICATION_CREDENTIAL_ID
-        - name: OS_APPLICATION_CREDENTIAL_ID
+        - name: OS_APPLICATION_CREDENTIAL_SECRET
         - name: OS_DOMAIN_NAME
           value: openstack-domain
         - name: OS_TENANT_NAME

--- a/pkg/test/e2e/utils/apiclient/client/openstack/list_openstack_availability_zones_parameters.go
+++ b/pkg/test/e2e/utils/apiclient/client/openstack/list_openstack_availability_zones_parameters.go
@@ -60,6 +60,10 @@ for the list openstack availability zones operation typically these are written 
 */
 type ListOpenstackAvailabilityZonesParams struct {
 
+	/*ApplicationCredentialID*/
+	ApplicationCredentialID *string
+	/*ApplicationCredentialSecret*/
+	ApplicationCredentialSecret *string
 	/*Credential*/
 	Credential *string
 	/*DatacenterName*/
@@ -111,6 +115,28 @@ func (o *ListOpenstackAvailabilityZonesParams) WithHTTPClient(client *http.Clien
 // SetHTTPClient adds the HTTPClient to the list openstack availability zones params
 func (o *ListOpenstackAvailabilityZonesParams) SetHTTPClient(client *http.Client) {
 	o.HTTPClient = client
+}
+
+// WithApplicationCredentialID adds the applicationCredentialID to the list openstack availability zones params
+func (o *ListOpenstackAvailabilityZonesParams) WithApplicationCredentialID(applicationCredentialID *string) *ListOpenstackAvailabilityZonesParams {
+	o.SetApplicationCredentialID(applicationCredentialID)
+	return o
+}
+
+// SetApplicationCredentialID adds the applicationCredentialId to the list openstack availability zones params
+func (o *ListOpenstackAvailabilityZonesParams) SetApplicationCredentialID(applicationCredentialID *string) {
+	o.ApplicationCredentialID = applicationCredentialID
+}
+
+// WithApplicationCredentialSecret adds the applicationCredentialSecret to the list openstack availability zones params
+func (o *ListOpenstackAvailabilityZonesParams) WithApplicationCredentialSecret(applicationCredentialSecret *string) *ListOpenstackAvailabilityZonesParams {
+	o.SetApplicationCredentialSecret(applicationCredentialSecret)
+	return o
+}
+
+// SetApplicationCredentialSecret adds the applicationCredentialSecret to the list openstack availability zones params
+func (o *ListOpenstackAvailabilityZonesParams) SetApplicationCredentialSecret(applicationCredentialSecret *string) {
+	o.ApplicationCredentialSecret = applicationCredentialSecret
 }
 
 // WithCredential adds the credential to the list openstack availability zones params
@@ -197,6 +223,24 @@ func (o *ListOpenstackAvailabilityZonesParams) WriteToRequest(r runtime.ClientRe
 		return err
 	}
 	var res []error
+
+	if o.ApplicationCredentialID != nil {
+
+		// header param ApplicationCredentialID
+		if err := r.SetHeaderParam("ApplicationCredentialID", *o.ApplicationCredentialID); err != nil {
+			return err
+		}
+
+	}
+
+	if o.ApplicationCredentialSecret != nil {
+
+		// header param ApplicationCredentialSecret
+		if err := r.SetHeaderParam("ApplicationCredentialSecret", *o.ApplicationCredentialSecret); err != nil {
+			return err
+		}
+
+	}
 
 	if o.Credential != nil {
 

--- a/pkg/test/e2e/utils/apiclient/client/openstack/list_openstack_networks_parameters.go
+++ b/pkg/test/e2e/utils/apiclient/client/openstack/list_openstack_networks_parameters.go
@@ -60,6 +60,10 @@ for the list openstack networks operation typically these are written to a http.
 */
 type ListOpenstackNetworksParams struct {
 
+	/*ApplicationCredentialID*/
+	ApplicationCredentialID *string
+	/*ApplicationCredentialSecret*/
+	ApplicationCredentialSecret *string
 	/*Credential*/
 	Credential *string
 	/*DatacenterName*/
@@ -111,6 +115,28 @@ func (o *ListOpenstackNetworksParams) WithHTTPClient(client *http.Client) *ListO
 // SetHTTPClient adds the HTTPClient to the list openstack networks params
 func (o *ListOpenstackNetworksParams) SetHTTPClient(client *http.Client) {
 	o.HTTPClient = client
+}
+
+// WithApplicationCredentialID adds the applicationCredentialID to the list openstack networks params
+func (o *ListOpenstackNetworksParams) WithApplicationCredentialID(applicationCredentialID *string) *ListOpenstackNetworksParams {
+	o.SetApplicationCredentialID(applicationCredentialID)
+	return o
+}
+
+// SetApplicationCredentialID adds the applicationCredentialId to the list openstack networks params
+func (o *ListOpenstackNetworksParams) SetApplicationCredentialID(applicationCredentialID *string) {
+	o.ApplicationCredentialID = applicationCredentialID
+}
+
+// WithApplicationCredentialSecret adds the applicationCredentialSecret to the list openstack networks params
+func (o *ListOpenstackNetworksParams) WithApplicationCredentialSecret(applicationCredentialSecret *string) *ListOpenstackNetworksParams {
+	o.SetApplicationCredentialSecret(applicationCredentialSecret)
+	return o
+}
+
+// SetApplicationCredentialSecret adds the applicationCredentialSecret to the list openstack networks params
+func (o *ListOpenstackNetworksParams) SetApplicationCredentialSecret(applicationCredentialSecret *string) {
+	o.ApplicationCredentialSecret = applicationCredentialSecret
 }
 
 // WithCredential adds the credential to the list openstack networks params
@@ -197,6 +223,24 @@ func (o *ListOpenstackNetworksParams) WriteToRequest(r runtime.ClientRequest, re
 		return err
 	}
 	var res []error
+
+	if o.ApplicationCredentialID != nil {
+
+		// header param ApplicationCredentialID
+		if err := r.SetHeaderParam("ApplicationCredentialID", *o.ApplicationCredentialID); err != nil {
+			return err
+		}
+
+	}
+
+	if o.ApplicationCredentialSecret != nil {
+
+		// header param ApplicationCredentialSecret
+		if err := r.SetHeaderParam("ApplicationCredentialSecret", *o.ApplicationCredentialSecret); err != nil {
+			return err
+		}
+
+	}
 
 	if o.Credential != nil {
 

--- a/pkg/test/e2e/utils/apiclient/client/openstack/list_openstack_security_groups_parameters.go
+++ b/pkg/test/e2e/utils/apiclient/client/openstack/list_openstack_security_groups_parameters.go
@@ -60,6 +60,10 @@ for the list openstack security groups operation typically these are written to 
 */
 type ListOpenstackSecurityGroupsParams struct {
 
+	/*ApplicationCredentialID*/
+	ApplicationCredentialID *string
+	/*ApplicationCredentialSecret*/
+	ApplicationCredentialSecret *string
 	/*Credential*/
 	Credential *string
 	/*DatacenterName*/
@@ -111,6 +115,28 @@ func (o *ListOpenstackSecurityGroupsParams) WithHTTPClient(client *http.Client) 
 // SetHTTPClient adds the HTTPClient to the list openstack security groups params
 func (o *ListOpenstackSecurityGroupsParams) SetHTTPClient(client *http.Client) {
 	o.HTTPClient = client
+}
+
+// WithApplicationCredentialID adds the applicationCredentialID to the list openstack security groups params
+func (o *ListOpenstackSecurityGroupsParams) WithApplicationCredentialID(applicationCredentialID *string) *ListOpenstackSecurityGroupsParams {
+	o.SetApplicationCredentialID(applicationCredentialID)
+	return o
+}
+
+// SetApplicationCredentialID adds the applicationCredentialId to the list openstack security groups params
+func (o *ListOpenstackSecurityGroupsParams) SetApplicationCredentialID(applicationCredentialID *string) {
+	o.ApplicationCredentialID = applicationCredentialID
+}
+
+// WithApplicationCredentialSecret adds the applicationCredentialSecret to the list openstack security groups params
+func (o *ListOpenstackSecurityGroupsParams) WithApplicationCredentialSecret(applicationCredentialSecret *string) *ListOpenstackSecurityGroupsParams {
+	o.SetApplicationCredentialSecret(applicationCredentialSecret)
+	return o
+}
+
+// SetApplicationCredentialSecret adds the applicationCredentialSecret to the list openstack security groups params
+func (o *ListOpenstackSecurityGroupsParams) SetApplicationCredentialSecret(applicationCredentialSecret *string) {
+	o.ApplicationCredentialSecret = applicationCredentialSecret
 }
 
 // WithCredential adds the credential to the list openstack security groups params
@@ -197,6 +223,24 @@ func (o *ListOpenstackSecurityGroupsParams) WriteToRequest(r runtime.ClientReque
 		return err
 	}
 	var res []error
+
+	if o.ApplicationCredentialID != nil {
+
+		// header param ApplicationCredentialID
+		if err := r.SetHeaderParam("ApplicationCredentialID", *o.ApplicationCredentialID); err != nil {
+			return err
+		}
+
+	}
+
+	if o.ApplicationCredentialSecret != nil {
+
+		// header param ApplicationCredentialSecret
+		if err := r.SetHeaderParam("ApplicationCredentialSecret", *o.ApplicationCredentialSecret); err != nil {
+			return err
+		}
+
+	}
 
 	if o.Credential != nil {
 

--- a/pkg/test/e2e/utils/apiclient/client/openstack/list_openstack_sizes_parameters.go
+++ b/pkg/test/e2e/utils/apiclient/client/openstack/list_openstack_sizes_parameters.go
@@ -60,6 +60,10 @@ for the list openstack sizes operation typically these are written to a http.Req
 */
 type ListOpenstackSizesParams struct {
 
+	/*ApplicationCredentialID*/
+	ApplicationCredentialID *string
+	/*ApplicationCredentialSecret*/
+	ApplicationCredentialSecret *string
 	/*Credential*/
 	Credential *string
 	/*DatacenterName*/
@@ -111,6 +115,28 @@ func (o *ListOpenstackSizesParams) WithHTTPClient(client *http.Client) *ListOpen
 // SetHTTPClient adds the HTTPClient to the list openstack sizes params
 func (o *ListOpenstackSizesParams) SetHTTPClient(client *http.Client) {
 	o.HTTPClient = client
+}
+
+// WithApplicationCredentialID adds the applicationCredentialID to the list openstack sizes params
+func (o *ListOpenstackSizesParams) WithApplicationCredentialID(applicationCredentialID *string) *ListOpenstackSizesParams {
+	o.SetApplicationCredentialID(applicationCredentialID)
+	return o
+}
+
+// SetApplicationCredentialID adds the applicationCredentialId to the list openstack sizes params
+func (o *ListOpenstackSizesParams) SetApplicationCredentialID(applicationCredentialID *string) {
+	o.ApplicationCredentialID = applicationCredentialID
+}
+
+// WithApplicationCredentialSecret adds the applicationCredentialSecret to the list openstack sizes params
+func (o *ListOpenstackSizesParams) WithApplicationCredentialSecret(applicationCredentialSecret *string) *ListOpenstackSizesParams {
+	o.SetApplicationCredentialSecret(applicationCredentialSecret)
+	return o
+}
+
+// SetApplicationCredentialSecret adds the applicationCredentialSecret to the list openstack sizes params
+func (o *ListOpenstackSizesParams) SetApplicationCredentialSecret(applicationCredentialSecret *string) {
+	o.ApplicationCredentialSecret = applicationCredentialSecret
 }
 
 // WithCredential adds the credential to the list openstack sizes params
@@ -197,6 +223,24 @@ func (o *ListOpenstackSizesParams) WriteToRequest(r runtime.ClientRequest, reg s
 		return err
 	}
 	var res []error
+
+	if o.ApplicationCredentialID != nil {
+
+		// header param ApplicationCredentialID
+		if err := r.SetHeaderParam("ApplicationCredentialID", *o.ApplicationCredentialID); err != nil {
+			return err
+		}
+
+	}
+
+	if o.ApplicationCredentialSecret != nil {
+
+		// header param ApplicationCredentialSecret
+		if err := r.SetHeaderParam("ApplicationCredentialSecret", *o.ApplicationCredentialSecret); err != nil {
+			return err
+		}
+
+	}
 
 	if o.Credential != nil {
 

--- a/pkg/test/e2e/utils/apiclient/client/openstack/list_openstack_subnets_parameters.go
+++ b/pkg/test/e2e/utils/apiclient/client/openstack/list_openstack_subnets_parameters.go
@@ -60,6 +60,10 @@ for the list openstack subnets operation typically these are written to a http.R
 */
 type ListOpenstackSubnetsParams struct {
 
+	/*ApplicationCredentialID*/
+	ApplicationCredentialID *string
+	/*ApplicationCredentialSecret*/
+	ApplicationCredentialSecret *string
 	/*Credential*/
 	Credential *string
 	/*DatacenterName*/
@@ -113,6 +117,28 @@ func (o *ListOpenstackSubnetsParams) WithHTTPClient(client *http.Client) *ListOp
 // SetHTTPClient adds the HTTPClient to the list openstack subnets params
 func (o *ListOpenstackSubnetsParams) SetHTTPClient(client *http.Client) {
 	o.HTTPClient = client
+}
+
+// WithApplicationCredentialID adds the applicationCredentialID to the list openstack subnets params
+func (o *ListOpenstackSubnetsParams) WithApplicationCredentialID(applicationCredentialID *string) *ListOpenstackSubnetsParams {
+	o.SetApplicationCredentialID(applicationCredentialID)
+	return o
+}
+
+// SetApplicationCredentialID adds the applicationCredentialId to the list openstack subnets params
+func (o *ListOpenstackSubnetsParams) SetApplicationCredentialID(applicationCredentialID *string) {
+	o.ApplicationCredentialID = applicationCredentialID
+}
+
+// WithApplicationCredentialSecret adds the applicationCredentialSecret to the list openstack subnets params
+func (o *ListOpenstackSubnetsParams) WithApplicationCredentialSecret(applicationCredentialSecret *string) *ListOpenstackSubnetsParams {
+	o.SetApplicationCredentialSecret(applicationCredentialSecret)
+	return o
+}
+
+// SetApplicationCredentialSecret adds the applicationCredentialSecret to the list openstack subnets params
+func (o *ListOpenstackSubnetsParams) SetApplicationCredentialSecret(applicationCredentialSecret *string) {
+	o.ApplicationCredentialSecret = applicationCredentialSecret
 }
 
 // WithCredential adds the credential to the list openstack subnets params
@@ -210,6 +236,24 @@ func (o *ListOpenstackSubnetsParams) WriteToRequest(r runtime.ClientRequest, reg
 		return err
 	}
 	var res []error
+
+	if o.ApplicationCredentialID != nil {
+
+		// header param ApplicationCredentialID
+		if err := r.SetHeaderParam("ApplicationCredentialID", *o.ApplicationCredentialID); err != nil {
+			return err
+		}
+
+	}
+
+	if o.ApplicationCredentialSecret != nil {
+
+		// header param ApplicationCredentialSecret
+		if err := r.SetHeaderParam("ApplicationCredentialSecret", *o.ApplicationCredentialSecret); err != nil {
+			return err
+		}
+
+	}
 
 	if o.Credential != nil {
 

--- a/pkg/test/e2e/utils/apiclient/client/openstack/list_openstack_tenants_parameters.go
+++ b/pkg/test/e2e/utils/apiclient/client/openstack/list_openstack_tenants_parameters.go
@@ -60,6 +60,10 @@ for the list openstack tenants operation typically these are written to a http.R
 */
 type ListOpenstackTenantsParams struct {
 
+	/*ApplicationCredentialID*/
+	ApplicationCredentialID *string
+	/*ApplicationCredentialSecret*/
+	ApplicationCredentialSecret *string
 	/*Credential*/
 	Credential *string
 	/*DatacenterName*/
@@ -107,6 +111,28 @@ func (o *ListOpenstackTenantsParams) WithHTTPClient(client *http.Client) *ListOp
 // SetHTTPClient adds the HTTPClient to the list openstack tenants params
 func (o *ListOpenstackTenantsParams) SetHTTPClient(client *http.Client) {
 	o.HTTPClient = client
+}
+
+// WithApplicationCredentialID adds the applicationCredentialID to the list openstack tenants params
+func (o *ListOpenstackTenantsParams) WithApplicationCredentialID(applicationCredentialID *string) *ListOpenstackTenantsParams {
+	o.SetApplicationCredentialID(applicationCredentialID)
+	return o
+}
+
+// SetApplicationCredentialID adds the applicationCredentialId to the list openstack tenants params
+func (o *ListOpenstackTenantsParams) SetApplicationCredentialID(applicationCredentialID *string) {
+	o.ApplicationCredentialID = applicationCredentialID
+}
+
+// WithApplicationCredentialSecret adds the applicationCredentialSecret to the list openstack tenants params
+func (o *ListOpenstackTenantsParams) WithApplicationCredentialSecret(applicationCredentialSecret *string) *ListOpenstackTenantsParams {
+	o.SetApplicationCredentialSecret(applicationCredentialSecret)
+	return o
+}
+
+// SetApplicationCredentialSecret adds the applicationCredentialSecret to the list openstack tenants params
+func (o *ListOpenstackTenantsParams) SetApplicationCredentialSecret(applicationCredentialSecret *string) {
+	o.ApplicationCredentialSecret = applicationCredentialSecret
 }
 
 // WithCredential adds the credential to the list openstack tenants params
@@ -171,6 +197,24 @@ func (o *ListOpenstackTenantsParams) WriteToRequest(r runtime.ClientRequest, reg
 		return err
 	}
 	var res []error
+
+	if o.ApplicationCredentialID != nil {
+
+		// header param ApplicationCredentialID
+		if err := r.SetHeaderParam("ApplicationCredentialID", *o.ApplicationCredentialID); err != nil {
+			return err
+		}
+
+	}
+
+	if o.ApplicationCredentialSecret != nil {
+
+		// header param ApplicationCredentialSecret
+		if err := r.SetHeaderParam("ApplicationCredentialSecret", *o.ApplicationCredentialSecret); err != nil {
+			return err
+		}
+
+	}
 
 	if o.Credential != nil {
 

--- a/pkg/test/e2e/utils/apiclient/models/openstack_cloud_spec.go
+++ b/pkg/test/e2e/utils/apiclient/models/openstack_cloud_spec.go
@@ -16,6 +16,12 @@ import (
 // swagger:model OpenstackCloudSpec
 type OpenstackCloudSpec struct {
 
+	// application credential ID
+	ApplicationCredentialID string `json:"applicationCredentialID,omitempty"`
+
+	// application credential secret
+	ApplicationCredentialSecret string `json:"applicationCredentialSecret,omitempty"`
+
 	// domain
 	Domain string `json:"domain,omitempty"`
 

--- a/pkg/validation/cluster.go
+++ b/pkg/validation/cluster.go
@@ -302,26 +302,27 @@ func validateOpenStackCloudSpec(spec *kubermaticv1.OpenstackCloudSpec, dc *kuber
 			return err
 		}
 	}
-	if spec.Username == "" {
-		if err := kuberneteshelper.ValidateSecretKeySelector(spec.CredentialsReference, resources.OpenstackUsername); err != nil {
-			return err
+	if spec.ApplicationCredentialID == "" || spec.ApplicationCredentialSecret == "" {
+		if spec.Username == "" {
+			if err := kuberneteshelper.ValidateSecretKeySelector(spec.CredentialsReference, resources.OpenstackUsername); err != nil {
+				return err
+			}
 		}
-	}
-	if spec.Password == "" {
-		if err := kuberneteshelper.ValidateSecretKeySelector(spec.CredentialsReference, resources.OpenstackPassword); err != nil {
-			return err
+		if spec.Password == "" {
+			if err := kuberneteshelper.ValidateSecretKeySelector(spec.CredentialsReference, resources.OpenstackPassword); err != nil {
+				return err
+			}
 		}
-	}
-
-	var errs []error
-	if spec.Tenant == "" && spec.CredentialsReference != nil && spec.CredentialsReference.Name != "" {
-		errs = append(errs, kuberneteshelper.ValidateSecretKeySelector(spec.CredentialsReference, resources.OpenstackTenant))
-	}
-	if spec.TenantID == "" && spec.CredentialsReference != nil && spec.CredentialsReference.Name != "" {
-		errs = append(errs, kuberneteshelper.ValidateSecretKeySelector(spec.CredentialsReference, resources.OpenstackTenantID))
-	}
-	if utilerror.NewAggregate(errs) != nil {
-		return errors.New("no tenant name or ID specified")
+		var errs []error
+		if spec.Tenant == "" && spec.CredentialsReference != nil && spec.CredentialsReference.Name != "" {
+			errs = append(errs, kuberneteshelper.ValidateSecretKeySelector(spec.CredentialsReference, resources.OpenstackTenant))
+		}
+		if spec.TenantID == "" && spec.CredentialsReference != nil && spec.CredentialsReference.Name != "" {
+			errs = append(errs, kuberneteshelper.ValidateSecretKeySelector(spec.CredentialsReference, resources.OpenstackTenantID))
+		}
+		if utilerror.NewAggregate(errs) != nil {
+			return errors.New("no tenant name or ID specified")
+		}
 	}
 
 	if spec.FloatingIPPool == "" && dc.Spec.Openstack != nil && dc.Spec.Openstack.EnforceFloatingIP {


### PR DESCRIPTION
Signed-off-by: Happy2C0de <46957159+Happy2C0de@users.noreply.github.com>

**What this PR does / why we need it**:
Adds support for application credentials for the Openstack provider.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #6527 

**Special notes for your reviewer**:
This requires an adjustment of the e2e such that OS_APPLICATION_CREDENTIAL_ID/SECRET get sourced and that one tries to implement specific e2e with app creds.

Furthermore, there is a need for an adjustment in the WebUI. Mainly, when one adds an authentication one should have like a drop down option where one should be able to select: "username/password" or "application credentials" authentication. ATM, only username/password is supported and is requires (or selecting a given preset).

This has some security implications for Openstack too. Username/Passwords are not limited to one project but a given user could be member of more than one project. Because the cloud-config secret in the user cluster is readable by the user this could lead to project breakout. For some use cases, this is no problem but there are others that would like to limit the permissions more granularly. Furthermore, username/password is generally a bad idea for application deployments on Openstack because it's a highly personalized info.

Note: Here, I need help and support from your engineers. Pls, report changes directly or create a new PR copying my changes. I think, this PR is a very good basis that requires some design decisions.
Note: https://github.com/kubermatic/kubermatic/blob/24376f2209aca78f52be35d7814ca7d7494c3b23/pkg/resources/test/load_files_test.go#L159
I guess, for proper e2e tests one requires new fixtures. (I learnt that the hard way, docs are missing!)

**Documentation**:
<!-- Add links to the related documentation changes related to this pull request. E.g. the link to the kubermatic/docs pull request. -->
- Requires: https://github.com/kubermatic/machine-controller/releases/tag/v1.27.0
- https://github.com/kubernetes/cloud-provider-openstack/blob/master/docs/openstack-cloud-controller-manager/using-openstack-cloud-controller-manager.md#global (application-credential-id/secret)

**Does this PR introduce a user-facing change?**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If  no release note is required, just write "NONE".
-->
```release-note
Add support for Openstack Application Credentials
```
